### PR TITLE
Specify setup.py codeowner at root

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,6 +2,6 @@
 docker/ @ko3n1g @chtruong814 @thomasdhc @pablo-garay
 .pylintrc.* @ko3n1g @chtruong814 @thomasdhc @pablo-garay
 .flake8.* @ko3n1g @chtruong814 @thomasdhc @pablo-garay
-setup.py @ko3n1g @chtruong814 @thomasdhc @pablo-garay
+/setup.py @ko3n1g @chtruong814 @thomasdhc @pablo-garay
 pyproject.toml @ko3n1g @chtruong814 @thomasdhc @pablo-garay
 requirements/ @ko3n1g @chtruong814 @thomasdhc @pablo-garay


### PR DESCRIPTION
Specify the codeowners for setup.py to be one at the root directory.  There's other similarly named files now in nemo_lm directory that are unrelated to the package definition.