### PR TITLE
Remove custom dataset provider callable from pretrain entry point

### DIFF
--- a/nemo_lm/training/pretrain.py
+++ b/nemo_lm/training/pretrain.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Callable, Optional
+from typing import Callable
 
 from nemo_lm.data.utils import get_dataset_provider
 from nemo_lm.training.checkpointing import save_checkpoint


### PR DESCRIPTION
Going from the dataset config to dataset/dataloaders is assumed to be covered by the factories here: https://github.com/NVIDIA-NeMo/NeMo-LM/blob/117a22a24d4a5fbe72ee014c4d9deea5319ce03c/nemo_lm/data/utils.py#L144-L148