### PR TITLE
API docs setup

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,10 @@
 ```{include} ../README.md
 :relative-docs: docs/
 ```
+
+```{toctree}
+:caption: Development
+:hidden:
+
+apidocs/index.rst
+```


### PR DESCRIPTION
`sphinx-build` is already configured to build API docs (see `conf.py`). Just need to include them in a toctree.

Test with:
```
uv run --only-group docs sphinx-autobuild docs docs/_build/html
```

Note, `:hidden:` is needed so the index/landing page does not include the entire API docs tree.