### PR TITLE
[peft] Port module matcher over from NeMo

### DIFF
--- a/src/megatron/hub/peft/module_matcher.py
+++ b/src/megatron/hub/peft/module_matcher.py
@@ -1,0 +1,165 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Set, Tuple
+
+import torch.nn as nn
+from megatron.core.tensor_parallel import ColumnParallelLinear, RowParallelLinear
+
+from megatron.hub.peft.utils import wildcard_match
+from megatron.hub.utils.import_utils import safe_import_from
+
+
+TEColumnParallelLinear, HAVE_TE_COL_LINEAR = safe_import_from(
+    "megatron.core.extensions.transformer_engine", "TEColumnParallelLinear"
+)
+TELayerNormColumnParallelLinear, HAVE_TE_LN_COL_LINEAR = safe_import_from(
+    "megatron.core.extensions.transformer_engine",
+    "TELayerNormColumnParallelLinear",
+)
+TERowParallelLinear, HAVE_TE_ROW_LINEAR = safe_import_from(
+    "megatron.core.extensions.transformer_engine", "TERowParallelLinear"
+)
+HAVE_TE = all((HAVE_TE_COL_LINEAR, HAVE_TE_LN_COL_LINEAR, HAVE_TE_ROW_LINEAR))
+
+
+@dataclass
+class ModuleMatcher:
+    """Module matcher for parameter-efficient fine-tuning (PEFT) applications.
+
+    This class facilitates the identification and selection of modules within a model
+    architecture for applying PEFT techniques like LoRA (Low-Rank Adaptation). It provides
+    flexible matching patterns including wildcards, exact module names, and type-based
+    selection.
+
+    The matcher supports three modes of operation:
+    1. Canonical mapping: Uses predefined mappings to match modules
+    2. Target modules: Matches against a list of target module names/patterns
+    3. Exclude modules: Matches all linear layers except those explicitly excluded
+
+    Args:
+        target_modules (List[str], optional): A list of module names to apply PEFT to.
+            Defaults to all linear layers ['linear_qkv', 'linear_proj', 'linear_fc1', 'linear_fc2'].
+                - 'linear_qkv': Apply to the fused linear layer used for query, key, and value projections
+                                in self-attention.
+                - 'linear_proj': Apply to the linear layer used for projecting the output of self-attention.
+                - 'linear_fc1': Apply to the first fully-connected layer in MLP.
+                - 'linear_fc2': Apply to the second fully-connected layer in MLP.
+            Target modules can also contain wildcards. For example, you can specify
+                target_modules=['*.layers.0.*.linear_qkv', '*.layers.1.*.linear_qkv'] to add adapters to
+                only linear_qkv on the first two layers.
+        exclude_modules (List[str], optional): A list of module names to exclude from matching.
+            Only used when neither canonical_mapping nor target_modules are specified.
+        canonical_mapping (Dict[str, Set], optional): A mapping from pattern names to sets of
+            module types. Used for more complex matching scenarios.
+
+    Example:
+        >>> # Match specific modules by name
+        >>> matcher = ModuleMatcher(target_modules=['linear_qkv', 'linear_proj'])
+        >>>
+        >>> # Match with wildcards
+        >>> matcher = ModuleMatcher(target_modules=['*.layers.*.linear_qkv'])
+        >>>
+        >>> # Exclude specific modules (matches all linear layers except excluded ones)
+        >>> matcher = ModuleMatcher(exclude_modules=['linear_fc1'])
+    """
+
+    target_modules: List[str] = field(
+        default_factory=lambda: ["linear_qkv", "linear_proj", "linear_fc1", "linear_fc2"]
+    )
+    exclude_modules: List[str] = field(default_factory=list)
+    canonical_mapping: Dict[str, Set] = field(default_factory=lambda: defaultdict(set))
+
+    def match(
+        self, m: nn.Module, name: Optional[str] = None, prefix: Optional[str] = None
+    ) -> Optional[Tuple[str, str]]:
+        """Determine whether a given module matches specified target patterns.
+
+        This function checks if the provided module `m` should be included based on predefined
+        mapping rules (`canonical_mapping`, `target_modules`, and `exclude_modules`). It returns
+        the matching pattern and full name if a match is found; otherwise, it returns `None`.
+
+        Args:
+            m (nn.Module): The module being checked.
+            name (str, optional): The module's name. Defaults to None.
+            prefix (str, optional): A prefix to be used in constructing `full_name`. Defaults to None.
+
+        Returns:
+            Optional[Tuple[str, str]]: A tuple containing (matching_pattern, full_name) if a match
+                is found; otherwise, `None`.
+
+        Matching Logic:
+            1) If `canonical_mapping` is defined, it checks:
+                - Whether `name` exactly matches a pattern.
+                - Whether `full_name` matches any wildcard pattern in `canonical_mapping`.
+            2) If `target_modules` is defined, it follows the same logic as `canonical_mapping`.
+            3) If neither `canonical_mapping` nor `target_modules` are defined, it ensures:
+                - `name` is not in `exclude_modules`.
+                - `full_name` does not match any `exclude_modules` patterns.
+                - `m` is an instance of a supported linear layer type.
+
+        Notes:
+            - `exclude_modules` should only be non-empty if neither `canonical_mapping` nor
+              `target_modules` are set.
+            - The function asserts that `exclude_modules` is empty when using `canonical_mapping`
+              or `target_modules`.
+
+        Example:
+            >>> matcher = ModuleMatcher(target_modules=['*.linear_qkv'])
+            >>> result = matcher.match(module, 'linear_qkv', 'model.layers.0.self_attention')
+            >>> if result:
+            ...     pattern, full_name = result
+            ...     print(f"Matched {full_name} with pattern {pattern}")
+        """
+        full_name = f"{prefix}.{name}" if prefix else name
+
+        if len(self.canonical_mapping or []) > 0:
+            """
+            Find the element in canonical_mapping which
+            1) matches the current `name` exactly, OR
+            2) matches the current `full_name` with wildcard
+            match is None if current module name doesn't match the specified targets.
+            """
+            assert len(self.exclude_modules) == 0, "exclude_modules should be empty when using canonical_mapping"
+            for pattern in self.canonical_mapping:
+                if name == pattern or wildcard_match(pattern, full_name):
+                    return (pattern, full_name)
+
+        elif len(self.target_modules or []) > 0:
+            assert len(self.exclude_modules) == 0, "exclude_modules should be empty when using target_modules"
+            for pattern in self.target_modules:
+                if name == pattern or wildcard_match(pattern, full_name):
+                    return (pattern, full_name)
+
+        else:
+            # Default mode: match all linear layers except excluded ones
+            linear_types = [ColumnParallelLinear, RowParallelLinear, nn.Linear]
+            if HAVE_TE_COL_LINEAR:
+                linear_types.append(TEColumnParallelLinear)
+            if HAVE_TE_LN_COL_LINEAR:
+                linear_types.append(TELayerNormColumnParallelLinear)
+            if HAVE_TE_ROW_LINEAR:
+                linear_types.append(TERowParallelLinear)
+            linear_types = tuple(linear_types)
+
+            if (
+                name not in self.exclude_modules
+                and not any(wildcard_match(pattern, full_name) for pattern in self.exclude_modules)
+                and isinstance(m, linear_types)
+            ):
+                return (name, full_name)
+
+        return None

--- a/tests/unit_tests/peft/test_module_matcher.py
+++ b/tests/unit_tests/peft/test_module_matcher.py
@@ -1,0 +1,400 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections import defaultdict
+from unittest.mock import patch
+
+import pytest
+import torch
+import torch.nn as nn
+
+from megatron.hub.peft.module_matcher import ModuleMatcher
+
+
+class MockColumnParallelLinear(nn.Module):
+    """Mock ColumnParallelLinear for testing."""
+
+    def __init__(self, in_features: int = 128, out_features: int = 256):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.weight = nn.Parameter(torch.randn(out_features, in_features))
+
+    def forward(self, x):
+        return x
+
+
+class MockRowParallelLinear(nn.Module):
+    """Mock RowParallelLinear for testing."""
+
+    def __init__(self, in_features: int = 128, out_features: int = 256):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.weight = nn.Parameter(torch.randn(out_features, in_features))
+
+    def forward(self, x):
+        return x
+
+
+class MockTELinear(nn.Module):
+    """Mock Transformer Engine Linear for testing."""
+
+    def __init__(self, in_features: int = 128, out_features: int = 256):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.weight = nn.Parameter(torch.randn(out_features, in_features))
+
+    def forward(self, x):
+        return x
+
+
+class TestModuleMatcher:
+    """Test suite for ModuleMatcher class."""
+
+    def test_default_initialization(self):
+        """Test ModuleMatcher with default parameters."""
+        matcher = ModuleMatcher()
+        assert matcher.target_modules == ["linear_qkv", "linear_proj", "linear_fc1", "linear_fc2"]
+        assert matcher.exclude_modules == []
+        assert len(matcher.canonical_mapping) == 0
+
+    def test_custom_target_modules(self):
+        """Test ModuleMatcher with custom target modules."""
+        target_modules = ["linear_qkv", "linear_proj"]
+        matcher = ModuleMatcher(target_modules=target_modules)
+        assert matcher.target_modules == target_modules
+
+    def test_custom_exclude_modules(self):
+        """Test ModuleMatcher with custom exclude modules."""
+        exclude_modules = ["linear_fc1", "linear_fc2"]
+        matcher = ModuleMatcher(exclude_modules=exclude_modules)
+        assert matcher.exclude_modules == exclude_modules
+
+    def test_custom_canonical_mapping(self):
+        """Test ModuleMatcher with custom canonical mapping."""
+        canonical_mapping = defaultdict(set)
+        canonical_mapping["test_pattern"] = {"TestModule"}
+        matcher = ModuleMatcher(canonical_mapping=canonical_mapping)
+        assert "test_pattern" in matcher.canonical_mapping
+
+    @pytest.mark.parametrize(
+        "module_type,expected_match",
+        [
+            (nn.Linear, True),
+            (nn.Conv2d, True),  # Should match because name matches, regardless of module type
+            (nn.BatchNorm1d, True),  # Should match because name matches, regardless of module type
+        ],
+    )
+    def test_target_modules_exact_match(self, module_type, expected_match):
+        """Test exact matching with target modules."""
+        matcher = ModuleMatcher(target_modules=["linear_qkv"])
+
+        # Create modules with proper parameters for each type
+        if module_type == nn.Linear:
+            module = module_type(128, 256)
+        elif module_type == nn.Conv2d:
+            module = module_type(in_channels=3, out_channels=64, kernel_size=3)
+        elif module_type == nn.BatchNorm1d:
+            module = module_type(128)
+        else:
+            module = module_type(128)
+
+        result = matcher.match(module, name="linear_qkv")
+        if expected_match:
+            assert result is not None
+            pattern, full_name = result
+            assert pattern == "linear_qkv"
+            assert full_name == "linear_qkv"
+        else:
+            assert result is None
+
+    def test_target_modules_no_match(self):
+        """Test no match with target modules."""
+        matcher = ModuleMatcher(target_modules=["linear_qkv"])
+        module = nn.Linear(128, 256)
+
+        result = matcher.match(module, name="linear_proj")
+        assert result is None
+
+    def test_target_vs_exclude_mode_difference(self):
+        """Test the difference between target_modules (name-based) and exclude mode (type-based)."""
+        # In target_modules mode, matching is based on name patterns only
+        target_matcher = ModuleMatcher(target_modules=["linear_qkv"])
+        conv_module = nn.Conv2d(in_channels=3, out_channels=64, kernel_size=3)
+
+        # Should match because name matches, regardless of module type
+        result = target_matcher.match(conv_module, name="linear_qkv")
+        assert result is not None
+
+        # In exclude mode, matching is based on both name and module type
+        with (
+            patch("megatron.hub.peft.module_matcher.ColumnParallelLinear", MockColumnParallelLinear),
+            patch("megatron.hub.peft.module_matcher.RowParallelLinear", MockRowParallelLinear),
+        ):
+            exclude_matcher = ModuleMatcher(target_modules=[], exclude_modules=[])
+
+            # Should NOT match because it's not a linear layer type
+            result = exclude_matcher.match(conv_module, name="linear_qkv")
+            assert result is None
+
+            # Should match because it IS a linear layer type
+            linear_module = nn.Linear(128, 256)
+            result = exclude_matcher.match(linear_module, name="linear_qkv")
+            assert result is not None
+
+    def test_target_modules_wildcard_match(self):
+        """Test wildcard matching with target modules."""
+        matcher = ModuleMatcher(target_modules=["*.layers.0.*.linear_qkv"])
+        module = nn.Linear(128, 256)
+
+        result = matcher.match(module, name="linear_qkv", prefix="model.layers.0.self_attention")
+        assert result is not None
+        pattern, full_name = result
+        assert pattern == "*.layers.0.*.linear_qkv"
+        assert full_name == "model.layers.0.self_attention.linear_qkv"
+
+    def test_target_modules_wildcard_no_match(self):
+        """Test wildcard pattern that doesn't match."""
+        matcher = ModuleMatcher(target_modules=["*.layers.0.*.linear_qkv"])
+        module = nn.Linear(128, 256)
+
+        result = matcher.match(module, name="linear_qkv", prefix="model.layers.1.self_attention")
+        assert result is None
+
+    def test_canonical_mapping_exact_match(self):
+        """Test exact matching with canonical mapping."""
+        canonical_mapping = defaultdict(set)
+        canonical_mapping["linear_qkv"] = {nn.Linear}
+        matcher = ModuleMatcher(canonical_mapping=canonical_mapping)
+        module = nn.Linear(128, 256)
+
+        result = matcher.match(module, name="linear_qkv")
+        assert result is not None
+        pattern, full_name = result
+        assert pattern == "linear_qkv"
+        assert full_name == "linear_qkv"
+
+    def test_canonical_mapping_wildcard_match(self):
+        """Test wildcard matching with canonical mapping."""
+        canonical_mapping = defaultdict(set)
+        canonical_mapping["*.linear_qkv"] = {nn.Linear}
+        matcher = ModuleMatcher(canonical_mapping=canonical_mapping)
+        module = nn.Linear(128, 256)
+
+        result = matcher.match(module, name="linear_qkv", prefix="model.layers.0.self_attention")
+        assert result is not None
+        pattern, full_name = result
+        assert pattern == "*.linear_qkv"
+        assert full_name == "model.layers.0.self_attention.linear_qkv"
+
+    @patch("megatron.hub.peft.module_matcher.ColumnParallelLinear", MockColumnParallelLinear)
+    @patch("megatron.hub.peft.module_matcher.RowParallelLinear", MockRowParallelLinear)
+    def test_exclude_modules_mode_match(self):
+        """Test exclude modules mode with matching linear layer."""
+        matcher = ModuleMatcher(target_modules=[], exclude_modules=["linear_fc1"])
+        module = nn.Linear(128, 256)
+
+        result = matcher.match(module, name="linear_qkv")
+        assert result is not None
+        pattern, full_name = result
+        assert pattern == "linear_qkv"
+        assert full_name == "linear_qkv"
+
+    @patch("megatron.hub.peft.module_matcher.ColumnParallelLinear", MockColumnParallelLinear)
+    @patch("megatron.hub.peft.module_matcher.RowParallelLinear", MockRowParallelLinear)
+    def test_exclude_modules_mode_exclude(self):
+        """Test exclude modules mode with excluded module."""
+        matcher = ModuleMatcher(target_modules=[], exclude_modules=["linear_fc1"])
+        module = nn.Linear(128, 256)
+
+        result = matcher.match(module, name="linear_fc1")
+        assert result is None
+
+    @patch("megatron.hub.peft.module_matcher.ColumnParallelLinear", MockColumnParallelLinear)
+    @patch("megatron.hub.peft.module_matcher.RowParallelLinear", MockRowParallelLinear)
+    def test_exclude_modules_wildcard_exclude(self):
+        """Test exclude modules mode with wildcard exclusion."""
+        matcher = ModuleMatcher(target_modules=[], exclude_modules=["*.linear_fc*"])
+        module = nn.Linear(128, 256)
+
+        result = matcher.match(module, name="linear_fc1", prefix="model.layers.0")
+        assert result is None
+
+    @patch("megatron.hub.peft.module_matcher.ColumnParallelLinear", MockColumnParallelLinear)
+    @patch("megatron.hub.peft.module_matcher.RowParallelLinear", MockRowParallelLinear)
+    def test_exclude_modules_non_linear_no_match(self):
+        """Test exclude modules mode with non-linear module."""
+        matcher = ModuleMatcher(target_modules=[], exclude_modules=[])
+        module = nn.Conv2d(3, 64, 3)
+
+        result = matcher.match(module, name="conv1")
+        assert result is None
+
+    @patch("megatron.hub.peft.module_matcher.ColumnParallelLinear", MockColumnParallelLinear)
+    @patch("megatron.hub.peft.module_matcher.RowParallelLinear", MockRowParallelLinear)
+    def test_parallel_linear_types(self):
+        """Test matching with parallel linear types."""
+        matcher = ModuleMatcher(target_modules=[], exclude_modules=[])
+
+        # Test ColumnParallelLinear
+        col_module = MockColumnParallelLinear()
+        result = matcher.match(col_module, name="linear_qkv")
+        assert result is not None
+
+        # Test RowParallelLinear
+        row_module = MockRowParallelLinear()
+        result = matcher.match(row_module, name="linear_proj")
+        assert result is not None
+
+    @patch("megatron.hub.peft.module_matcher.HAVE_TE_COL_LINEAR", True)
+    @patch("megatron.hub.peft.module_matcher.TEColumnParallelLinear", MockTELinear)
+    def test_transformer_engine_support(self):
+        """Test matching with Transformer Engine modules when available."""
+        matcher = ModuleMatcher(target_modules=[], exclude_modules=[])
+        te_module = MockTELinear()
+
+        result = matcher.match(te_module, name="linear_qkv")
+        assert result is not None
+
+    def test_full_name_construction(self):
+        """Test proper construction of full names with prefixes."""
+        matcher = ModuleMatcher(target_modules=["linear_qkv"])
+        module = nn.Linear(128, 256)
+
+        # Test with prefix
+        result = matcher.match(module, name="linear_qkv", prefix="model.layers.0.self_attention")
+        assert result is not None
+        pattern, full_name = result
+        assert full_name == "model.layers.0.self_attention.linear_qkv"
+
+        # Test without prefix
+        result = matcher.match(module, name="linear_qkv")
+        assert result is not None
+        pattern, full_name = result
+        assert full_name == "linear_qkv"
+
+    def test_assertion_exclude_modules_with_canonical_mapping(self):
+        """Test assertion when exclude_modules is used with canonical_mapping."""
+        canonical_mapping = defaultdict(set)
+        canonical_mapping["linear_qkv"] = {nn.Linear}
+        matcher = ModuleMatcher(canonical_mapping=canonical_mapping, exclude_modules=["linear_fc1"])
+        module = nn.Linear(128, 256)
+
+        with pytest.raises(AssertionError, match="exclude_modules should be empty when using canonical_mapping"):
+            matcher.match(module, name="linear_qkv")
+
+    def test_assertion_exclude_modules_with_target_modules(self):
+        """Test assertion when exclude_modules is used with target_modules."""
+        matcher = ModuleMatcher(target_modules=["linear_qkv"], exclude_modules=["linear_fc1"])
+        module = nn.Linear(128, 256)
+
+        with pytest.raises(AssertionError, match="exclude_modules should be empty when using target_modules"):
+            matcher.match(module, name="linear_qkv")
+
+    def test_none_name_handling(self):
+        """Test handling of None name parameter."""
+        matcher = ModuleMatcher(target_modules=["linear_qkv"])
+        module = nn.Linear(128, 256)
+
+        result = matcher.match(module, name=None)
+        assert result is None
+
+    def test_none_prefix_handling(self):
+        """Test handling of None prefix parameter."""
+        matcher = ModuleMatcher(target_modules=["linear_qkv"])
+        module = nn.Linear(128, 256)
+
+        result = matcher.match(module, name="linear_qkv", prefix=None)
+        assert result is not None
+        pattern, full_name = result
+        assert full_name == "linear_qkv"
+
+    def test_empty_target_modules_with_exclude(self):
+        """Test behavior with empty target_modules and exclude_modules."""
+        matcher = ModuleMatcher(target_modules=[], exclude_modules=[])
+        module = nn.Linear(128, 256)
+
+        # Should fall back to exclude mode
+        with (
+            patch("megatron.hub.peft.module_matcher.ColumnParallelLinear", MockColumnParallelLinear),
+            patch("megatron.hub.peft.module_matcher.RowParallelLinear", MockRowParallelLinear),
+        ):
+            result = matcher.match(module, name="linear_qkv")
+            assert result is not None
+
+    def test_complex_wildcard_patterns(self):
+        """Test complex wildcard patterns."""
+        matcher = ModuleMatcher(target_modules=["model.layers.*.self_attention.linear_*"])
+        module = nn.Linear(128, 256)
+
+        # Should match
+        result = matcher.match(module, name="linear_qkv", prefix="model.layers.5.self_attention")
+        assert result is not None
+
+        # Should not match - wrong layer structure
+        result = matcher.match(module, name="linear_qkv", prefix="model.decoder.layers.5.self_attention")
+        assert result is None
+
+    def test_multiple_target_patterns(self):
+        """Test matching with multiple target patterns."""
+        matcher = ModuleMatcher(target_modules=["linear_qkv", "*.linear_proj", "model.*.linear_fc1"])
+        module = nn.Linear(128, 256)
+
+        # Test exact match
+        result = matcher.match(module, name="linear_qkv")
+        assert result is not None
+        assert result[0] == "linear_qkv"
+
+        # Test wildcard match 1
+        result = matcher.match(module, name="linear_proj", prefix="model.layers.0")
+        assert result is not None
+        assert result[0] == "*.linear_proj"
+
+        # Test wildcard match 2
+        result = matcher.match(module, name="linear_fc1", prefix="model.layers.0")
+        assert result is not None
+        assert result[0] == "model.*.linear_fc1"
+
+    def test_edge_case_empty_strings(self):
+        """Test edge cases with empty strings."""
+        matcher = ModuleMatcher(target_modules=[""])
+        module = nn.Linear(128, 256)
+
+        result = matcher.match(module, name="", prefix="")
+        assert result is not None
+        pattern, full_name = result
+        assert pattern == ""
+        assert full_name == ""
+
+    @pytest.mark.parametrize(
+        "target_modules,canonical_mapping,exclude_modules",
+        [
+            (["linear_qkv"], None, []),
+            ([], {"pattern": {nn.Linear}}, []),
+            ([], None, ["linear_fc1"]),
+        ],
+    )
+    def test_different_mode_configurations(self, target_modules, canonical_mapping, exclude_modules):
+        """Test different valid configurations of the matcher."""
+        if canonical_mapping is None:
+            canonical_mapping = defaultdict(set)
+
+        matcher = ModuleMatcher(
+            target_modules=target_modules, canonical_mapping=canonical_mapping, exclude_modules=exclude_modules
+        )
+
+        # Should not raise any exceptions during initialization
+        assert isinstance(matcher, ModuleMatcher)


### PR DESCRIPTION
This logic is kept as-is based on the NeMo reference: https://github.com/NVIDIA/NeMo/blob/main/nemo/collections/llm/peft/module_matcher.py



