### PR TITLE
[peft] align adapter output shape with wrapped module output shape 

### DIFF
--- a/src/megatron/hub/peft/lora_layers.py
+++ b/src/megatron/hub/peft/lora_layers.py
@@ -61,6 +61,7 @@ class LoRALinear(AdapterWrapper):
         # pylint: disable=C0115,C0116
         linear_output, bias, layernorm_output = self.base_linear_forward(x, *args, **kwargs)
         adapter_output = self.adapter(layernorm_output.contiguous())
+        adapter_output = adapter_output.reshape(linear_output.shape)
         return linear_output + adapter_output, bias
 
 


### PR DESCRIPTION
Keep in sync with https://github.com/NVIDIA/NeMo/commit/76918a9db0b66c9d6e51825a55b7c72086b9ecc6