### PR TITLE
Safely import TELinearAdapter

### DIFF
--- a/src/megatron/hub/peft/lora.py
+++ b/src/megatron/hub/peft/lora.py
@@ -20,7 +20,7 @@ import torch
 import torch.nn as nn
 
 from megatron.hub.peft.base import PEFT
-from megatron.hub.peft.lora_layers import LinearAdapter, LoRALinear, TELinearAdapter, patch_linear_module
+from megatron.hub.peft.lora_layers import LinearAdapter, LoRALinear, patch_linear_module
 from megatron.hub.peft.module_matcher import ModuleMatcher
 from megatron.hub.peft.utils import ParallelLinearAdapter, get_adapter_attributes_from_linear, is_expert_linear
 from megatron.hub.utils.import_utils import safe_import
@@ -30,10 +30,12 @@ logger = logging.getLogger(__name__)
 
 try:
     import transformer_engine.pytorch as te
+    from megatron.hub.peft.lora_layers import TELinearAdapter
 
     HAVE_TE = True
 except ImportError:
     te = None
+    TELinearAdapter = None
     HAVE_TE = False
 
 if torch.cuda.is_available():

--- a/src/megatron/hub/peft/lora.py
+++ b/src/megatron/hub/peft/lora.py
@@ -30,6 +30,7 @@ logger = logging.getLogger(__name__)
 
 try:
     import transformer_engine.pytorch as te
+
     from megatron.hub.peft.lora_layers import TELinearAdapter
 
     HAVE_TE = True


### PR DESCRIPTION
## Problem

The file `src/megatron/hub/peft/lora.py` was importing `TELinearAdapter` directly in the import statements:

```python
from megatron.hub.peft.lora_layers import LinearAdapter, LoRALinear, TELinearAdapter, patch_linear_module
```

This causes an `ImportError` when transformer-engine is not installed, even though the code properly handles the optional dependency elsewhere in the file.

## Solution

Move the `TELinearAdapter` import to the try-except block where transformer-engine is imported:

```python
# Before
from megatron.hub.peft.lora_layers import LinearAdapter, LoRALinear, TELinearAdapter, patch_linear_module

# After
from megatron.hub.peft.lora_layers import LinearAdapter, LoRALinear, patch_linear_module

# Later in the file
try:
    import transformer_engine.pytorch as te
    from megatron.hub.peft.lora_layers import TELinearAdapter
    
    HAVE_TE = True
except ImportError:
    te = None
    TELinearAdapter = None
    HAVE_TE = False
```