### PR TITLE
Drop `megatron_` prefix from pretrain function

### DIFF
--- a/examples/llm/llama3_8b/pretrain_llama3_8b.py
+++ b/examples/llm/llama3_8b/pretrain_llama3_8b.py
@@ -60,7 +60,7 @@ from omegaconf import OmegaConf
 from megatron.hub.models.utils import forward_step
 from megatron.hub.recipes.llm.llama3_8b import pretrain_config
 from megatron.hub.training.config import ConfigContainer
-from megatron.hub.training.pretrain import megatron_pretrain
+from megatron.hub.training.pretrain import pretrain
 from megatron.hub.utils.omegaconf_utils import apply_overrides, create_omegaconf_dict_config, parse_hydra_overrides
 
 
@@ -161,8 +161,8 @@ def main() -> None:
     logger.info("----------------------------------")
 
     # Start training
-    logger.debug("Starting Megatron pretraining...")
-    megatron_pretrain(config=cfg, forward_step_func=forward_step)
+    logger.debug("Starting pretraining...")
+    pretrain(config=cfg, forward_step_func=forward_step)
 
 
 if __name__ == "__main__":

--- a/examples/llm/llama3_8b/pretrain_llama3_8b_nemo_run_partial.py
+++ b/examples/llm/llama3_8b/pretrain_llama3_8b_nemo_run_partial.py
@@ -22,7 +22,7 @@ from megatron.hub.models.utils import forward_step
 from megatron.hub.recipes.llm.llama3_8b import pretrain_config
 from megatron.hub.recipes.utils.nemo_run_utils import get_partial_fn
 from megatron.hub.training.config import ConfigContainer, ProfilingConfig
-from megatron.hub.training.pretrain import megatron_pretrain
+from megatron.hub.training.pretrain import pretrain
 
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -48,7 +48,7 @@ def main(args: argparse.Namespace) -> None:
     cfg.profiling.record_shapes = True
 
     # Create a run.Partial object for the pretrain function
-    fn = get_partial_fn(megatron_pretrain, cfg, forward_step)
+    fn = get_partial_fn(pretrain, cfg, forward_step)
 
     logger.info(f"Launching locally with TorchRun with nproc_per_node={args.nproc_per_node}")
     executor = run.LocalExecutor(ntasks_per_node=args.nproc_per_node, launcher="torchrun")

--- a/src/megatron/hub/recipes/utils/nemo_run_utils.py
+++ b/src/megatron/hub/recipes/utils/nemo_run_utils.py
@@ -42,7 +42,7 @@ def get_partial_fn(
     and forward_step_func.
 
     Args:
-        target_fn: The target function to be wrapped in run.Partial (e.g., megatron_pretrain).
+        target_fn: The target function to be wrapped in run.Partial (e.g., pretrain).
         config: The ConfigContainer dataclass instance.
         forward_step_func: The forward step function to use for training.
 

--- a/src/megatron/hub/training/pretrain.py
+++ b/src/megatron/hub/training/pretrain.py
@@ -26,7 +26,7 @@ from megatron.hub.utils.log_utils import barrier_and_log
 
 
 @experimental_fn
-def megatron_pretrain(
+def pretrain(
     config: ConfigContainer,
     forward_step_func: Callable,
 ) -> None:

--- a/tests/functional_tests/test_nvrx_straggler.py
+++ b/tests/functional_tests/test_nvrx_straggler.py
@@ -2,7 +2,7 @@
 """
 End-to-end functional test for NVRx straggler detection with megatron/hub training.
 
-This test runs the actual megatron_pretrain function with NVRx straggler detection
+This test runs the actual pretrain function with NVRx straggler detection
 enabled, using mock data and a tiny model configuration for fast testing.
 """
 
@@ -30,7 +30,7 @@ from megatron.hub.training.config import (
     TokenizerConfig,
     TrainingConfig,
 )
-from megatron.hub.training.pretrain import megatron_pretrain
+from megatron.hub.training.pretrain import pretrain
 from megatron.hub.training.state import GlobalState
 from megatron.hub.utils.common_utils import get_rank_safe, print_rank_0
 
@@ -226,7 +226,7 @@ def test_nvrx_straggler_detection_end_to_end(sleep_time: float = 1.0):
     This test:
     1. Sets up a complete megatron training configuration
     2. Uses mock data and small model for fast execution
-    3. Runs the actual megatron_pretrain function
+    3. Runs the actual pretrain function
     4. Verifies NVRx straggler detection is working by checking logs
     """
     rank = get_rank_safe()
@@ -244,7 +244,7 @@ def test_nvrx_straggler_detection_end_to_end(sleep_time: float = 1.0):
             forward_step_func = create_timed_forward_step_func(sleep_time=sleep_time)
 
             try:
-                megatron_pretrain(
+                pretrain(
                     config=config,
                     forward_step_func=forward_step_func,
                 )

--- a/tests/functional_tests/test_pretrain.py
+++ b/tests/functional_tests/test_pretrain.py
@@ -32,7 +32,7 @@ from megatron.hub.training.config import (
     TokenizerConfig,
     TrainingConfig,
 )
-from megatron.hub.training.pretrain import megatron_pretrain
+from megatron.hub.training.pretrain import pretrain
 
 
 class TestPretrain:
@@ -138,7 +138,7 @@ class TestPretrain:
             )
 
             # Run training
-            megatron_pretrain(cfg, forward_step)
+            pretrain(cfg, forward_step)
 
             # Check for the latest checkpoint tracker file
             if torch.distributed.get_rank() == 0:


### PR DESCRIPTION
The `megatron_` prefix is redundant considering it's inside megatron hub