### PR TITLE
Port VPP Fix to Megatron Hub

### DIFF
--- a/src/megatron/hub/common/model_provider_mixin.py
+++ b/src/megatron/hub/common/model_provider_mixin.py
@@ -64,7 +64,7 @@ class ModelProviderMixin(abc.ABC, Generic[ModelT]):
     DEFAULT_CONFIG_FORMAT = "json"
 
     @abc.abstractmethod
-    def provide(self, pre_process=None, post_process=None) -> ModelT:
+    def provide(self, pre_process=None, post_process=None, vp_stage=None) -> ModelT:
         """Abstract method to provide the model instance.
 
         Subclasses must implement this method to return the specific Megatron model
@@ -74,6 +74,7 @@ class ModelProviderMixin(abc.ABC, Generic[ModelT]):
         Args:
             pre_process (callable, optional): A function to be called before model instantiation.
             post_process (callable, optional): A function to be called after model instantiation.
+            vp_stage (int, optional): The virtual pipeline stage of the model.
 
         Returns:
             ModelT: The Megatron model instance.

--- a/src/megatron/hub/data/loaders.py
+++ b/src/megatron/hub/data/loaders.py
@@ -353,7 +353,6 @@ def setup_data_iterators(
         valid_data_iterator = []
         test_data_iterator = []
         for i in range(model_length):
-            mpu.set_virtual_pipeline_model_parallel_rank(i)
             iterators = build_train_valid_test_data_iterators(
                 cfg=cfg,
                 train_state=train_state,

--- a/src/megatron/hub/models/gpt_provider.py
+++ b/src/megatron/hub/models/gpt_provider.py
@@ -158,12 +158,13 @@ class GPTModelProvider(TransformerConfig, ModelProviderMixin[MCoreGPTModel]):
     bias_dropout_fusion: bool = field(default_factory=fusions.can_enable_bias_dropout_fusion)
     apply_rope_fusion: bool = field(default_factory=fusions.can_enable_apply_rope_fusion)
 
-    def provide(self, pre_process=None, post_process=None, tokenizer=None) -> MCoreGPTModel:
+    def provide(self, pre_process=None, post_process=None, vp_stage=None, tokenizer=None) -> MCoreGPTModel:
         """Configure and instantiate a Megatron Core GPT model based on this configuration.
 
         Args:
             pre_process: Whether to include pre-processing in the model, defaults to first pipeline stage
             post_process: Whether to include post-processing in the model, defaults to last pipeline stage
+            vp_stage: Virtual pipeline stage
             tokenizer: Tokenizer used with the model
 
         Returns:
@@ -227,9 +228,12 @@ class GPTModelProvider(TransformerConfig, ModelProviderMixin[MCoreGPTModel]):
                 rotary_percent=self.rotary_percent,
                 rotary_base=self.rotary_base,
                 seq_len_interpolation_factor=self.seq_len_interpolation_factor,
-                pre_process=pre_process or parallel_state.is_pipeline_first_stage(),
-                post_process=post_process or parallel_state.is_pipeline_last_stage(),
+                pre_process=pre_process
+                or parallel_state.is_pipeline_first_stage(ignore_virtual=False, vp_stage=vp_stage),
+                post_process=post_process
+                or parallel_state.is_pipeline_last_stage(ignore_virtual=False, vp_stage=vp_stage),
                 scatter_embedding_sequence_parallel=self.scatter_embedding_sequence_parallel,
+                vp_stage=vp_stage,
                 **kwargs,
             )
 

--- a/src/megatron/hub/models/llama/llama_provider.py
+++ b/src/megatron/hub/models/llama/llama_provider.py
@@ -124,20 +124,23 @@ class Llama31ModelProvider(LlamaModelProvider):
     old_context_len: int = 8192
     init_method_std: float = 0.02
 
-    def provide(self, tokenizer=None, pre_process=None, post_process=None) -> "MCoreGPTModel":
+    def provide(self, pre_process=None, post_process=None, vp_stage=None, tokenizer=None) -> "MCoreGPTModel":
         """Configure and instantiate a Megatron Core Llama 3.1 model.
 
         Extends the base configuration with Llama 3.1 specific RoPE scaling.
 
         Args:
-            tokenizer: Tokenizer used with the model
             pre_process: Whether to include pre-processing in the model
             post_process: Whether to include post-processing in the model
+            vp_stage: Virtual pipeline stage
+            tokenizer: Tokenizer used with the model
 
         Returns:
             MCoreGPTModel: Configured Megatron Core GPT model instance
         """
-        model = super().provide(pre_process=pre_process, post_process=post_process, tokenizer=tokenizer)
+        model = super().provide(
+            pre_process=pre_process, post_process=post_process, vp_stage=vp_stage, tokenizer=tokenizer
+        )
         # Apply rope scaling for Llama3.1 model
         model.rotary_pos_emb.inv_freq = apply_rope_scaling(
             model.rotary_pos_emb.inv_freq,

--- a/src/megatron/hub/models/t5_provider.py
+++ b/src/megatron/hub/models/t5_provider.py
@@ -102,8 +102,13 @@ class T5ModelProvider(TransformerConfig, ModelProviderMixin[MCoreT5Model]):
     vocab_size: Optional[int] = None
     tp_comm_overlap_cfg: Optional[Union[str, dict[str, Any]]] = None
 
-    def provide(self, pre_process=None, post_process=None, tokenizer=None) -> MCoreT5Model:
+    def provide(self, pre_process=None, post_process=None, vp_stage=None, tokenizer=None) -> MCoreT5Model:
         """Setup the T5 Model based on config definition."""
+
+        assert self.virtual_pipeline_model_parallel_size is None and vp_stage is None, (
+            "Virtual pipeline model parallelism is temporarily unsupported in T5 "
+            "due to upstream MCore T5Model API dependency"
+        )
 
         vp_size = self.virtual_pipeline_model_parallel_size
         if vp_size:

--- a/src/megatron/hub/training/eval.py
+++ b/src/megatron/hub/training/eval.py
@@ -109,7 +109,7 @@ def evaluate(
             if state.cfg.train.empty_unused_memory_level >= 1:
                 torch.cuda.empty_cache()
 
-            if mpu.is_pipeline_last_stage(ignore_virtual=True):
+            if mpu.is_pipeline_last_stage():
                 # Reduce across processes.
                 for loss_dict in loss_dicts:
                     for key in loss_dict:

--- a/src/megatron/hub/training/train.py
+++ b/src/megatron/hub/training/train.py
@@ -514,7 +514,7 @@ def train_step(
     if train_config.empty_unused_memory_level >= 2:
         torch.cuda.empty_cache()
 
-    if parallel_state.is_pipeline_last_stage(ignore_virtual=True):
+    if parallel_state.is_pipeline_last_stage():
         # Average loss across microbatches.
         loss_reduced = {}
         for key in losses_reduced[0].keys():

--- a/src/megatron/hub/training/utils/train_utils.py
+++ b/src/megatron/hub/training/utils/train_utils.py
@@ -466,8 +466,7 @@ def training_log(
         # Decoupled_learning_rate should be not None only on first and last pipeline stage.
         log_string += f" learning rate: {learning_rate:.6E} |"
         if config.optimizer.decoupled_lr is not None and (
-            parallel_state.is_pipeline_first_stage(ignore_virtual=True)
-            or parallel_state.is_pipeline_last_stage(ignore_virtual=True)
+            parallel_state.is_pipeline_first_stage() or parallel_state.is_pipeline_last_stage()
         ):
             assert decoupled_learning_rate is not None
             log_string += f" decoupled learning rate: {decoupled_learning_rate:.6E} |"

--- a/tests/functional_tests/training/test_pretrain.py
+++ b/tests/functional_tests/training/test_pretrain.py
@@ -40,6 +40,27 @@ class TestPretrain:
     Test end to end training with checkpoint functionality.
     """
 
+    def clear_directories(self, tmp_path):
+        """Teardown method called after each test method."""
+        if torch.distributed.is_initialized():
+            torch.distributed.barrier()
+            if torch.distributed.get_rank() == 0:
+                if os.path.exists(tmp_path):
+                    shutil.rmtree(tmp_path)
+            torch.distributed.barrier()
+
+    def _verify_checkpoint_files(self, checkpoint_dir, total_iters):
+        """Verify that checkpoint files were created correctly."""
+        if torch.distributed.get_rank() == 0:
+            latest_tracker_file = os.path.join(checkpoint_dir, "latest_train_state.pt")
+            assert os.path.exists(latest_tracker_file), "Latest checkpoint tracker file not found"
+
+            final_iter_dir = os.path.join(checkpoint_dir, f"iter_{total_iters:07d}")
+            assert os.path.exists(final_iter_dir), f"Final checkpoint directory not found at {final_iter_dir}"
+
+            metadata_file = os.path.join(final_iter_dir, ".metadata")
+            assert os.path.exists(metadata_file), "Checkpoint metadata file not found"
+
     @pytest.mark.run_only_on("GPU")
     def test_pretrain_with_checkpoint(self, tmp_path):
         """
@@ -140,28 +161,135 @@ class TestPretrain:
             # Run training
             pretrain(cfg, forward_step)
 
-            # Check for the latest checkpoint tracker file
-            if torch.distributed.get_rank() == 0:
-                latest_tracker_file = os.path.join(checkpoint_dir, "latest_train_state.pt")
-                assert os.path.exists(latest_tracker_file), "Latest checkpoint tracker file not found"
-
-                # Check for the final checkpoint directory (should be iter_0000020)
-                final_iter_dir = os.path.join(checkpoint_dir, f"iter_{total_iters:07d}")
-                assert os.path.exists(final_iter_dir), f"Final checkpoint directory not found at {final_iter_dir}"
-
-                # For distributed checkpoints, check for the metadata file
-                metadata_file = os.path.join(final_iter_dir, ".metadata")
-                assert os.path.exists(metadata_file), "Checkpoint metadata file not found"
+            # Verify checkpoint files
+            self._verify_checkpoint_files(checkpoint_dir, total_iters)
 
         finally:
             # pytest's tmp_path fixture doesn't clean up immediately.
             # Clean up manually.
-            if torch.distributed.is_initialized():
-                torch.distributed.barrier()
-                if torch.distributed.get_rank() == 0:
-                    if os.path.exists(checkpoint_dir):
-                        shutil.rmtree(checkpoint_dir)
-                    if os.path.exists(tensorboard_dir):
-                        shutil.rmtree(tensorboard_dir)
-                torch.distributed.barrier()
-                torch.distributed.destroy_process_group()
+            self.clear_directories(tmp_path)
+
+    @pytest.mark.run_only_on("GPU")
+    def test_pretrain_vpp(self, tmp_path):
+        """
+        Test end to end training with virtual pipeline parallelism.
+        """
+
+        checkpoint_dir = str(tmp_path / "checkpoints")
+        tensorboard_dir = str(tmp_path / "tensorboard")
+
+        try:
+            global_batch_size = 8
+            micro_batch_size = 1
+            seq_length = 512
+            total_iters = 100
+
+            # Create model config with VPP
+            model_cfg = Llama32ModelProvider1B(
+                tensor_model_parallel_size=1,
+                pipeline_model_parallel_size=2,
+                virtual_pipeline_model_parallel_size=2,
+                context_parallel_size=1,
+                sequence_parallel=False,
+                attention_softmax_in_fp32=True,
+                pipeline_dtype=torch.bfloat16,
+                bf16=True,
+                seq_length=seq_length,
+                make_vocab_size_divisible_by=128,
+            )
+
+            # Create other configurations
+            optimizer_cfg = OptimizerConfig(
+                optimizer="adam",
+                bf16=True,
+                fp16=False,
+                adam_beta1=0.9,
+                adam_beta2=0.95,
+                adam_eps=1e-5,
+                use_distributed_optimizer=True,
+                clip_grad=1.0,
+                lr=3e-3,
+                weight_decay=0.01,
+                min_lr=1e-6,
+            )
+
+            ddp_cfg = DistributedDataParallelConfig(
+                check_for_nan_in_grad=True,
+                grad_reduce_in_fp32=True,
+                overlap_grad_reduce=True,
+                overlap_param_gather=True,
+                average_in_collective=True,
+                use_distributed_optimizer=True,
+            )
+
+            # Setup communication overlap for VPP
+            from megatron.hub.training.comm_overlap import CommOverlapConfig
+
+            comm_overlap = CommOverlapConfig(
+                data_parallel_size=1,
+                tp_comm_overlap=False,
+            )
+
+            comm_overlap.setup(
+                model_config=model_cfg,
+                optimizer_config=optimizer_cfg,
+                ddp_config=ddp_cfg,
+            )
+
+            # Create config container
+            cfg = ConfigContainer(
+                model=model_cfg,
+                train=TrainingConfig(
+                    train_iters=total_iters,
+                    eval_interval=50,
+                    eval_iters=2,
+                    global_batch_size=global_batch_size,
+                    micro_batch_size=micro_batch_size,
+                    exit_signal_handler=True,
+                ),
+                optimizer=optimizer_cfg,
+                scheduler=SchedulerConfig(
+                    start_weight_decay=0.033,
+                    end_weight_decay=0.033,
+                    weight_decay_incr_style="constant",
+                    lr_decay_style="cosine",
+                    lr_warmup_iters=2,
+                    lr_warmup_init=0.0,
+                    lr_decay_iters=total_iters,
+                    override_opt_param_scheduler=True,
+                ),
+                ddp=ddp_cfg,
+                dataset=MockGPTDatasetConfig(
+                    random_seed=1234,
+                    reset_attention_mask=False,
+                    reset_position_ids=False,
+                    eod_mask_loss=False,
+                    sequence_length=seq_length,
+                    num_dataset_builder_threads=1,
+                    data_sharding=True,
+                    dataloader_type="single",
+                    num_workers=1,
+                ),
+                logger=LoggerConfig(
+                    log_interval=5,
+                    tensorboard_dir=tensorboard_dir,
+                ),
+                tokenizer=TokenizerConfig(
+                    tokenizer_type="NullTokenizer",
+                    vocab_size=10000,
+                ),
+                checkpoint=CheckpointConfig(
+                    save=checkpoint_dir,
+                    ckpt_format="torch_dist",
+                    fully_parallel_save=True,
+                    async_save=True,
+                ),
+                rng=RNGConfig(seed=1234),
+            )
+
+            # Run training
+            pretrain(cfg, forward_step)
+        finally:
+            # pytest's tmp_path fixture doesn't clean up immediately.
+            # Clean up manually.
+            self.clear_directories(tmp_path)

--- a/tests/unit_tests/core/models/test_model_provider.py
+++ b/tests/unit_tests/core/models/test_model_provider.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from unittest.mock import Mock, call, patch
+from unittest.mock import Mock, patch
 
 import pytest
 import torch
@@ -105,7 +105,6 @@ class TestCreateModel:
         assert len(result) == 2
         assert all(model.model_type == ModelType.encoder_or_decoder for model in result)
         assert model_provider.call_count == 2
-        mock_parallel_state.set_virtual_pipeline_model_parallel_rank.assert_has_calls([call(0), call(1)])
 
     @patch("megatron.hub.core.models.model_provider.parallel_state")
     @patch("megatron.hub.core.models.model_provider.tensor_parallel")

--- a/tests/unit_tests/training/test_checkpointing.py
+++ b/tests/unit_tests/training/test_checkpointing.py
@@ -515,7 +515,6 @@ class TestLoadCheckpoint:
         mock_mpu.get_pipeline_model_parallel_rank.return_value = 0
         mock_mpu.get_pipeline_model_parallel_world_size.return_value = 1
         mock_mpu.get_data_parallel_rank.return_value = 0
-        mock_mpu.set_virtual_pipeline_model_parallel_rank = Mock()
 
         # Mock rerun state machine
         mock_rerun_machine.return_value.load_state_dict = Mock()


### PR DESCRIPTION
Fixes https://github.com/NVIDIA-NeMo/Megatron-Hub/issues/110
Follow the vpp refactoring in mcore, where change vp_stage (virtual pipeline stage/rank) from global state to local model/module attribute.

* pass vp stage to `MCoreGPTModel`
* use `is_pipeline_(first|last)_stage(ignore_virtual=False, vp_stage=i)` only in virtual pipeline parallelism
* Bump up to the same mcore commit as that in NeMo