### PR TITLE
chore(🤖): Bump dependencies (2025-06-30)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ override-dependencies = [
 
 [tool.uv.sources]
 nemo-toolkit = { git = "https://github.com/NVIDIA/NeMo.git", rev = "5e63ca3c1631bb156187705f9c4cf643a67f9c05" }
-megatron-core = { git = "https://github.com/NVIDIA/Megatron-LM.git", rev = "c40f31f307221a8458c0775658d19da89303c26b" }
+megatron-core = { git = "https://github.com/NVIDIA/Megatron-LM.git", rev = "03f7793114aa49af8ad7ac5eb70affe56f5f28ea" }
 
 [build-system]
 requires = ["setuptools>=64", "wheel"]


### PR DESCRIPTION
🚀 PR to bump `NVIDIA/Megatron-LM` in `pyproject.toml` to `03f7793114aa49af8ad7ac5eb70affe56f5f28ea`.  

📝 Please remember the following to-do's before merge: 
- [ ] Verify the presubmit CI  

🙏 Please merge this PR only if the CI workflow completed successfully.