### PR TITLE
chore(🤖): Bump dependencies (2025-07-07)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ override-dependencies = [
 
 [tool.uv.sources]
 nemo-toolkit = { git = "https://github.com/NVIDIA/NeMo.git", rev = "5e63ca3c1631bb156187705f9c4cf643a67f9c05" }
-megatron-core = { git = "https://github.com/NVIDIA/Megatron-LM.git", rev = "6b708890cb385ea6515706d7d474f77d433890a6" }
+megatron-core = { git = "https://github.com/NVIDIA/Megatron-LM.git", rev = "3450806c96efb6267c8b5ab7af247ba544b46a0d" }
 
 [build-system]
 requires = ["setuptools>=64", "wheel"]


### PR DESCRIPTION
🚀 PR to bump `NVIDIA/Megatron-LM` in `pyproject.toml` to `3450806c96efb6267c8b5ab7af247ba544b46a0d`.  

📝 Please remember the following to-do's before merge: 
- [ ] Verify the presubmit CI  

🙏 Please merge this PR only if the CI workflow completed successfully.