### PR TITLE
chore(🤖): Bump dependencies (2025-07-07)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ override-dependencies = [
 
 [tool.uv.sources]
 nemo-toolkit = { git = "https://github.com/NVIDIA/NeMo.git", rev = "5e63ca3c1631bb156187705f9c4cf643a67f9c05" }
-megatron-core = { git = "https://github.com/NVIDIA/Megatron-LM.git", rev = "f53f689e4af1a03b105ceae7eab261d89e4cd223" }
+megatron-core = { git = "https://github.com/NVIDIA/Megatron-LM.git", rev = "c7ee1bf06023ca189cb531c26ed85717d13429db" }
 
 [build-system]
 requires = ["setuptools>=64", "wheel"]


### PR DESCRIPTION
🚀 PR to bump `NVIDIA/Megatron-LM` in `pyproject.toml` to `c7ee1bf06023ca189cb531c26ed85717d13429db`.  

📝 Please remember the following to-do's before merge: 
- [ ] Verify the presubmit CI  

🙏 Please merge this PR only if the CI workflow completed successfully.