### PR TITLE
Initialize persistent async workers only if saving checkpoints

### DIFF
--- a/src/megatron/hub/training/checkpointing.py
+++ b/src/megatron/hub/training/checkpointing.py
@@ -1195,7 +1195,13 @@ def init_async_checkpoint_worker(global_state: GlobalState) -> None:
     """
     from megatron.hub.core.utils.common_utils import print_rank_0
 
-    if global_state.cfg.checkpoint.async_save and global_state.cfg.checkpoint.use_persistent_ckpt_worker:
+    checkpoint_config = global_state.cfg.checkpoint
+
+    if (
+        checkpoint_config.save is not None
+        and checkpoint_config.async_save
+        and checkpoint_config.use_persistent_ckpt_worker
+    ):
         # Access the async_calls_queue property to trigger lazy initialization
         # This creates the persistent worker immediately during setup
         _ = global_state.async_calls_queue


### PR DESCRIPTION
Users might have `async_save=True, use_persistent_ckpt_worker=True` but if not actually saving checkpoints , there's no need to initialize these worker processes. this is gated by the `save` field in the checkpoint config not being None

https://github.com/NVIDIA-NeMo/Megatron-Hub/blob/c7f081bd841bd689cb5a5f46b72f4e98df9ceccd/src/megatron/hub/training/train.py#L809-L910