### PR TITLE
Remove redundant barrier in checkpoint flow

### DIFF
--- a/src/megatron/hub/training/train.py
+++ b/src/megatron/hub/training/train.py
@@ -889,7 +889,6 @@ def checkpoint_and_decide_exit(
                 checkpointing_context,
                 train_data_iterator=train_data_iterator,
             )
-        torch.distributed.barrier()
         barrier_and_log(f"exiting program at iteration {state.train_state.step}")
 
         return True


### PR DESCRIPTION
`barrier_and_log` will call a barrier immediately afterward: https://github.com/NVIDIA-NeMo/Megatron-Hub/blob/c7f081bd841bd689cb5a5f46b72f4e98df9ceccd/src/megatron/hub/training/utils/log_utils.py#L147-L156