### PR TITLE
Disable persist layer norm

### DIFF
--- a/src/megatron/hub/models/gpt_provider.py
+++ b/src/megatron/hub/models/gpt_provider.py
@@ -154,7 +154,7 @@ class GPTModelProvider(TransformerConfig, ModelProviderMixin[MCoreGPTModel]):
     cross_entropy_loss_fusion: bool = True  # Generally beneficial, no specific dependencies
     gradient_accumulation_fusion: bool = field(default_factory=fusions.can_enable_gradient_accumulation_fusion)
     bias_activation_fusion: bool = False  # Disabled by default as it can interfere with certain architectures
-    persist_layer_norm: bool = False
+    persist_layer_norm: bool = field(default=False, init=False)
     bias_dropout_fusion: bool = field(default_factory=fusions.can_enable_bias_dropout_fusion)
     apply_rope_fusion: bool = field(default_factory=fusions.can_enable_apply_rope_fusion)
 

--- a/src/megatron/hub/models/llama/llama_provider.py
+++ b/src/megatron/hub/models/llama/llama_provider.py
@@ -52,7 +52,6 @@ class LlamaModelProvider(GPTModelProvider):
     # Fusions
     bias_activation_fusion: bool = True
     masked_softmax_fusion: bool = field(default_factory=fusions.can_enable_masked_softmax_fusion)
-    persist_layer_norm: bool = True
     bias_dropout_fusion: bool = field(default_factory=fusions.can_enable_bias_dropout_fusion)
     apply_rope_fusion: bool = field(default_factory=fusions.can_enable_apply_rope_fusion)
     use_transformer_engine_op_fuser: Optional[bool] = None
@@ -124,7 +123,6 @@ class Llama3ModelProvider(LlamaModelProvider):
     # Fusions
     bias_activation_fusion: bool = True
     masked_softmax_fusion: bool = field(default_factory=fusions.can_enable_masked_softmax_fusion)
-    persist_layer_norm: bool = True
     bias_dropout_fusion: bool = field(default_factory=fusions.can_enable_bias_dropout_fusion)
     apply_rope_fusion: bool = field(default_factory=fusions.can_enable_apply_rope_fusion)
     share_embeddings_and_output_weights: bool = False

--- a/tests/unit_tests/models/llama/test_llama_provider.py
+++ b/tests/unit_tests/models/llama/test_llama_provider.py
@@ -56,7 +56,7 @@ class TestLlamaModelProvider:
         assert provider.normalization == "RMSNorm"
         assert provider.add_bias_linear is False
         assert provider.share_embeddings_and_output_weights is False
-        assert provider.persist_layer_norm is True
+        assert provider.persist_layer_norm is False
 
     def test_llama_model_provider_with_custom_rope(self):
         """Test LlamaModelProvider with custom RoPE configuration."""


### PR DESCRIPTION
`persist_layer_norm` is only a relevant flag for Apex fused layernorm implementations. It must be false for MCore's local implementation, and does not affect the TE implementation. Since we are not supporting Apex, we should disallow setting this option.