### PR TITLE
[sync] Enforce absolute path for wandb add artifact

### DIFF
--- a/src/megatron/bridge/training/utils/wandb_utils.py
+++ b/src/megatron/bridge/training/utils/wandb_utils.py
@@ -41,6 +41,8 @@ def on_save_checkpoint_success(
         metadata = {"iteration": iteration}
         artifact_name, artifact_version = _get_artifact_name_and_version(Path(save_dir), Path(checkpoint_path))
         artifact = wandb_writer.Artifact(artifact_name, type="model", metadata=metadata)
+        # wandb's artifact.add_reference requires absolute paths
+        checkpoint_path = str(Path(checkpoint_path).resolve())
         artifact.add_reference(f"file://{checkpoint_path}", checksum=False)
         wandb_writer.run.log_artifact(artifact, aliases=[artifact_version])
         wandb_tracker_filename = _get_wandb_artifact_tracker_filename(save_dir)


### PR DESCRIPTION
Sync with MLM: https://github.com/NVIDIA/Megatron-LM/commit/afb755f548b48151a4408b0e9caf674b8349b589