### PR TITLE
[sync] Fix distckpt optimizer state loading with PP>1 to ensure bit-wise match after saving and loading.

### DIFF
--- a/src/megatron/bridge/training/train.py
+++ b/src/megatron/bridge/training/train.py
@@ -315,6 +315,8 @@ def train(
         learning_rate = None
         decoupled_learning_rate = None
         for param_group in optimizer.param_groups:
+            if len(param_group) == 0:
+                continue
             if param_group["is_decoupled_lr"]:
                 decoupled_learning_rate = param_group["lr"]
             else:


### PR DESCRIPTION
Sync with MLM: https://github.com/NVIDIA/Megatron-LM/commit/eb5ff48f8613bf7df2f731c8708364ed9ad60790