### PR TITLE
Outputing models in 2_way_hf_binding to model-dir in root

### DIFF
--- a/examples/models/2_way_hf_binding.py
+++ b/examples/models/2_way_hf_binding.py
@@ -29,9 +29,9 @@ The process is as follows:
 """
 
 import argparse
+from pathlib import Path
 
 from rich.console import Console
-from pathlib import Path
 
 from megatron.bridge import CausalLMBridge
 from megatron.bridge.models.utils import weights_verification_table


### PR DESCRIPTION
model-dir is in .gitignore