### PR TITLE
Adding mistral causal-bridge + model-providers

### DIFF
--- a/src/megatron/bridge/models/__init__.py
+++ b/src/megatron/bridge/models/__init__.py
@@ -39,6 +39,13 @@ from megatron.bridge.models.llama import (
     LlamaModelProvider,
 )
 from megatron.bridge.models.mapping_registry import MegatronMappingRegistry
+from megatron.bridge.models.mistral import (
+    MistralLargeModelProvider,
+    MistralModelProvider,
+    MistralModelProvider7B,
+    MistralModelProvider7BInstruct,
+    MistralNemoModelProvider,
+)
 from megatron.bridge.models.model_bridge import MegatronModelBridge, WeightDistributionMode
 from megatron.bridge.models.param_mapping import (
     ColumnParallelMapping,
@@ -87,4 +94,9 @@ __all__ = [
     "Llama4ModelProvider",
     "Llama4Experts16ModelProvider",
     "Llama4Experts128ModelProvider",
+    "MistralModelProvider",
+    "MistralModelProvider7B",
+    "MistralModelProvider7BInstruct",
+    "MistralNemoModelProvider",
+    "MistralLargeModelProvider",
 ]

--- a/src/megatron/bridge/models/mistral/__init__.py
+++ b/src/megatron/bridge/models/mistral/__init__.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from megatron.bridge.models.mistral.mistral_causal_bridge import MistralCausalBridge  # noqa: F401
+from megatron.bridge.models.mistral.mistral_provider import (
+    MistralLargeModelProvider,
+    MistralModelProvider,
+    MistralModelProvider7B,
+    MistralModelProvider7BInstruct,
+    MistralNemoModelProvider,
+)
+
+
+__all__ = [
+    "MistralModelProvider",
+    "MistralModelProvider7B",
+    "MistralModelProvider7BInstruct",
+    "MistralNemoModelProvider",
+    "MistralLargeModelProvider",
+]

--- a/src/megatron/bridge/models/mistral/mistral_causal_bridge.py
+++ b/src/megatron/bridge/models/mistral/mistral_causal_bridge.py
@@ -1,0 +1,134 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+from megatron.core.models.gpt.gpt_model import GPTModel
+from transformers import MistralForCausalLM
+
+from megatron.bridge.models.hf_pretrained.causal_lm import PreTrainedCausalLM
+from megatron.bridge.models.mapping_registry import MegatronMappingRegistry
+from megatron.bridge.models.mistral.mistral_provider import MistralModelProvider
+from megatron.bridge.models.model_bridge import MegatronModelBridge
+from megatron.bridge.models.param_mapping import (
+    GatedMLPMapping,
+    QKVMapping,
+    TPAwareMapping,
+)
+
+
+@MegatronModelBridge.register_bridge(source=MistralForCausalLM, target=GPTModel)
+class MistralCausalBridge(MegatronModelBridge):
+    """
+    Megatron Hub Bridge for Mistral Causal LM.
+
+    This bridge handles the conversion between HuggingFace MistralForCausalLM
+    and Megatron-Core GPTModel formats. Mistral models feature sliding window
+    attention (for some variants) and grouped query attention (GQA).
+
+    Example:
+        >>> from megatron.bridge import AutoBridge
+        >>> bridge = AutoBridge.from_hf_pretrained("mistralai/Mistral-7B-v0.1")
+        >>> provider = bridge.to_megatron_provider()
+    """
+
+    def provider_bridge(self, hf_pretrained: PreTrainedCausalLM) -> MistralModelProvider:
+        hf_config = hf_pretrained.config
+
+        # Handle sliding window - convert to tuple format if it exists
+        sliding_window = getattr(hf_config, "sliding_window", None)
+        window_size = None
+        if sliding_window is not None:
+            window_size = (sliding_window, 0)  # Format: (window_size, backward)
+
+        provider = MistralModelProvider(
+            num_layers=hf_config.num_hidden_layers,
+            hidden_size=hf_config.hidden_size,
+            ffn_hidden_size=hf_config.intermediate_size,
+            num_attention_heads=hf_config.num_attention_heads,
+            num_query_groups=hf_config.num_key_value_heads,
+            init_method_std=hf_config.initializer_range,
+            layernorm_epsilon=hf_config.rms_norm_eps,
+            gated_linear_unit=True,
+            make_vocab_size_divisible_by=self.make_vocab_size_divisible_by(hf_config.vocab_size),
+            rotary_base=hf_config.rope_theta,
+            share_embeddings_and_output_weights=getattr(hf_config, "tie_word_embeddings", False),
+            vocab_size=hf_config.vocab_size,
+            seq_length=hf_config.max_position_embeddings,
+            window_size=window_size,
+            kv_channels=getattr(hf_config, "head_dim", None),
+            fp16=(self.dtype_from_hf(hf_config, default=torch.float32) == torch.float16),
+            bf16=(self.dtype_from_hf(hf_config, default=torch.float32) == torch.bfloat16),
+            params_dtype=self.dtype_from_hf(hf_config, default=torch.float32),
+            generation_config=hf_pretrained.generation_config,
+        )
+
+        provider.gradient_accumulation_fusion = False
+        provider.variable_seq_lengths = True
+
+        return provider
+
+    def mapping_registry(self) -> MegatronMappingRegistry:
+        return MegatronMappingRegistry(
+            # ------------------------------------------------------------------
+            # Embedding & output projection – column-parallel
+            # ------------------------------------------------------------------
+            TPAwareMapping(
+                megatron_param="embedding.word_embeddings.weight",
+                hf_param="model.embed_tokens.weight",
+            ),
+            TPAwareMapping(
+                megatron_param="output_layer.weight",
+                hf_param="lm_head.weight",
+            ),
+            # ------------------------------------------------------------------
+            # LayerNorm (replicated across TP ranks)
+            # ------------------------------------------------------------------
+            TPAwareMapping(
+                megatron_param="decoder.final_layernorm.weight",
+                hf_param="model.norm.weight",
+            ),
+            TPAwareMapping(
+                megatron_param="decoder.layers.*.self_attention.linear_qkv.layer_norm_weight",
+                hf_param="model.layers.*.input_layernorm.weight",
+            ),
+            TPAwareMapping(
+                megatron_param="decoder.layers.*.mlp.linear_fc1.layer_norm_weight",
+                hf_param="model.layers.*.post_attention_layernorm.weight",
+            ),
+            # ------------------------------------------------------------------
+            # Attention – QKV split in HF, combined in Megatron
+            # ------------------------------------------------------------------
+            QKVMapping(
+                megatron_param="decoder.layers.*.self_attention.linear_qkv.weight",
+                q="model.layers.*.self_attn.q_proj.weight",
+                k="model.layers.*.self_attn.k_proj.weight",
+                v="model.layers.*.self_attn.v_proj.weight",
+            ),
+            TPAwareMapping(
+                megatron_param="decoder.layers.*.self_attention.linear_proj.weight",
+                hf_param="model.layers.*.self_attn.o_proj.weight",
+            ),
+            # ------------------------------------------------------------------
+            # MLP – Gated MLP with gate_proj and up_proj
+            # ------------------------------------------------------------------
+            GatedMLPMapping(
+                megatron_param="decoder.layers.*.mlp.linear_fc1.weight",
+                gate="model.layers.*.mlp.gate_proj.weight",
+                up="model.layers.*.mlp.up_proj.weight",
+            ),
+            TPAwareMapping(
+                megatron_param="decoder.layers.*.mlp.linear_fc2.weight",
+                hf_param="model.layers.*.mlp.down_proj.weight",
+            ),
+        )

--- a/src/megatron/bridge/models/mistral/mistral_provider.py
+++ b/src/megatron/bridge/models/mistral/mistral_provider.py
@@ -1,0 +1,105 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+import torch.nn.functional as F
+
+from megatron.bridge.models.gpt_provider import GPTModelProvider
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class MistralModelProvider(GPTModelProvider):
+    """Base model provider for Mistral Models."""
+
+    normalization: str = "RMSNorm"
+    activation_func = F.silu
+    gated_linear_unit: bool = True
+    add_bias_linear: bool = False
+    seq_length: int = 32768
+    init_method_std: float = 0.02
+    hidden_dropout: float = 0.0
+    attention_dropout: float = 0.0
+    share_embeddings_and_output_weights: bool = False
+    layernorm_epsilon: float = 1e-5
+    rotary_base: float = 10000.0
+    position_embedding_type: str = "rope"
+
+
+@dataclass
+class MistralModelProvider7B(MistralModelProvider):
+    """
+    Config for Mistral 7B: https://huggingface.co/mistralai/Mistral-7B-v0.1
+    """
+
+    num_layers: int = 32
+    hidden_size: int = 4096
+    ffn_hidden_size: int = 14336
+    num_attention_heads: int = 32
+    num_query_groups: int = 8  # GQA
+    vocab_size: int = 32000
+    # Sliding window attention
+    window_size: Optional[Tuple[int, int]] = (4096, 0)
+
+
+@dataclass
+class MistralModelProvider7BInstruct(MistralModelProvider7B):
+    """
+    Config for Mistral 7B Instruct: https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2
+    """
+
+    seq_length: int = 32768
+
+
+@dataclass
+class MistralNemoModelProvider(MistralModelProvider):
+    """
+    Config for Mistral Nemo (12B): https://huggingface.co/mistralai/Mistral-Nemo-Base-2407
+    """
+
+    num_layers: int = 40
+    hidden_size: int = 5120
+    ffn_hidden_size: int = 14336
+    num_attention_heads: int = 32
+    num_query_groups: int = 8  # GQA
+    kv_channels: int = 128
+    vocab_size: int = 131072  # Larger vocab
+    seq_length: int = 128000  # Very long context
+    rotary_base: float = 1000000.0  # Different rope theta
+    # No sliding window for Nemo
+    window_size: Optional[Tuple[int, int]] = None
+
+
+@dataclass
+class MistralLargeModelProvider(MistralModelProvider):
+    """
+    Config for Mistral Large (123B): https://huggingface.co/mistralai/Mistral-Large-Instruct-2407
+    """
+
+    num_layers: int = 88
+    hidden_size: int = 12288
+    ffn_hidden_size: int = 28672
+    num_attention_heads: int = 96
+    num_query_groups: int = 8  # GQA
+    kv_channels: int = 128
+    vocab_size: int = 32768
+    seq_length: int = 131072
+    rotary_base: float = 1000000.0
+    # No sliding window for Large
+    window_size: Optional[Tuple[int, int]] = None


### PR DESCRIPTION
Validated manually that it works:

```
>>> uv run python examples/models/2_way_hf_binding.py --hf-model-id mistralai/Mistral-7B-v0.1 --output-dir /tmp
/home/marc/src/Megatron-Bridge/.venv/lib/python3.11/site-packages/megatron/core/models/backends.py:21: UserWarning: Apex is not installed. Falling back to Torch Norm
  warnings.warn("Apex is not installed. Falling back to Torch Norm")
/home/marc/src/Megatron-Bridge/.venv/lib/python3.11/site-packages/megatron/core/models/gpt/gpt_layer_specs.py:63: UserWarning: Apex is not installed. Falling back to Torch Norm
  warnings.warn("Apex is not installed. Falling back to Torch Norm")
gradient_accumulation_fusion requires FusedLayerNorm from megatron.core.fusions but it is not available. Fusion disabled.
masked_softmax_fusion requires CUDA kernels (scaled_masked_softmax_cuda) but they are not available. This typically happens when Megatron-Core is not built with CUDA extensions. Fusion disabled.
Model parallel not initialized, initializing...
/home/marc/src/Megatron-Bridge/.venv/lib/python3.11/site-packages/megatron/core/models/gpt/gpt_layer_specs.py:98: UserWarning: The fp8 argument in "get_gpt_layer_with_transformer_engine_spec" has been deprecated and will be removed soon. Please update your code accordingly.
  warnings.warn(
/home/marc/src/Megatron-Bridge/.venv/lib/python3.11/site-packages/transformer_engine/pytorch/cpu_offload.py:595: DeprecationWarning: Offloading weights is deprecated. Using offload_weights=True does not have any effect.
  warnings.warn(
model.safetensors.index.json: 100%|██████████████████████████████████████████████████████████████████████████████████| 25.1k/25.1k [00:00<00:00, 58.6MB/s]
model-00002-of-00002.safetensors: 100%|██████████████████████████████████████████████████████████████████████████████| 4.54G/4.54G [09:38<00:00, 7.85MB/s]
model-00001-of-00002.safetensors: 100%|██████████████████████████████████████████████████████████████████████████████| 9.94G/9.94G [17:59<00:00, 9.21MB/s]
Fetching 3 files: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [18:00<00:00, 360.11s/it]
Loading from mistralai/Mistral-7B-v0.1 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 (195/195) MistralCausalBridge
 > number of parameters on (tensor, pipeline) model parallel rank (0, 0): 7241732096
Converting to HuggingFace ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 (195/195) MistralCausalBridge
                                    Hugging Face Weights Verification                                     
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━┓
┃ Weight Name                                     ┃ Shape         ┃ DType    ┃ Device ┃ Matches Original ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━━━━┩
│ model.embed_tokens.weight                       │ (32000, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.0.self_attn.o_proj.weight          │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.0.input_layernorm.weight           │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.0.self_attn.q_proj.weight          │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.0.self_attn.k_proj.weight          │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.0.self_attn.v_proj.weight          │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.0.post_attention_layernorm.weight  │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.0.mlp.gate_proj.weight             │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.0.mlp.up_proj.weight               │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.0.mlp.down_proj.weight             │ (4096, 14336) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.1.self_attn.o_proj.weight          │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.1.input_layernorm.weight           │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.1.self_attn.q_proj.weight          │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.1.self_attn.k_proj.weight          │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.1.self_attn.v_proj.weight          │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.1.post_attention_layernorm.weight  │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.1.mlp.gate_proj.weight             │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.1.mlp.up_proj.weight               │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.1.mlp.down_proj.weight             │ (4096, 14336) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.2.self_attn.o_proj.weight          │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.2.input_layernorm.weight           │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.2.self_attn.q_proj.weight          │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.2.self_attn.k_proj.weight          │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.2.self_attn.v_proj.weight          │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.2.post_attention_layernorm.weight  │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.2.mlp.gate_proj.weight             │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.2.mlp.up_proj.weight               │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.2.mlp.down_proj.weight             │ (4096, 14336) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.3.self_attn.o_proj.weight          │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.3.input_layernorm.weight           │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.3.self_attn.q_proj.weight          │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.3.self_attn.k_proj.weight          │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.3.self_attn.v_proj.weight          │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.3.post_attention_layernorm.weight  │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.3.mlp.gate_proj.weight             │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.3.mlp.up_proj.weight               │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.3.mlp.down_proj.weight             │ (4096, 14336) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.4.self_attn.o_proj.weight          │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.4.input_layernorm.weight           │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.4.self_attn.q_proj.weight          │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.4.self_attn.k_proj.weight          │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.4.self_attn.v_proj.weight          │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.4.post_attention_layernorm.weight  │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.4.mlp.gate_proj.weight             │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.4.mlp.up_proj.weight               │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.4.mlp.down_proj.weight             │ (4096, 14336) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.5.self_attn.o_proj.weight          │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.5.input_layernorm.weight           │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.5.self_attn.q_proj.weight          │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.5.self_attn.k_proj.weight          │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.5.self_attn.v_proj.weight          │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.5.post_attention_layernorm.weight  │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.5.mlp.gate_proj.weight             │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.5.mlp.up_proj.weight               │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.5.mlp.down_proj.weight             │ (4096, 14336) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.6.self_attn.o_proj.weight          │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.6.input_layernorm.weight           │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.6.self_attn.q_proj.weight          │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.6.self_attn.k_proj.weight          │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.6.self_attn.v_proj.weight          │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.6.post_attention_layernorm.weight  │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.6.mlp.gate_proj.weight             │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.6.mlp.up_proj.weight               │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.6.mlp.down_proj.weight             │ (4096, 14336) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.7.self_attn.o_proj.weight          │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.7.input_layernorm.weight           │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.7.self_attn.q_proj.weight          │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.7.self_attn.k_proj.weight          │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.7.self_attn.v_proj.weight          │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.7.post_attention_layernorm.weight  │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.7.mlp.gate_proj.weight             │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.7.mlp.up_proj.weight               │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.7.mlp.down_proj.weight             │ (4096, 14336) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.8.self_attn.o_proj.weight          │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.8.input_layernorm.weight           │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.8.self_attn.q_proj.weight          │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.8.self_attn.k_proj.weight          │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.8.self_attn.v_proj.weight          │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.8.post_attention_layernorm.weight  │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.8.mlp.gate_proj.weight             │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.8.mlp.up_proj.weight               │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.8.mlp.down_proj.weight             │ (4096, 14336) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.9.self_attn.o_proj.weight          │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.9.input_layernorm.weight           │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.9.self_attn.q_proj.weight          │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.9.self_attn.k_proj.weight          │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.9.self_attn.v_proj.weight          │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.9.post_attention_layernorm.weight  │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.9.mlp.gate_proj.weight             │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.9.mlp.up_proj.weight               │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.9.mlp.down_proj.weight             │ (4096, 14336) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.10.self_attn.o_proj.weight         │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.10.input_layernorm.weight          │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.10.self_attn.q_proj.weight         │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.10.self_attn.k_proj.weight         │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.10.self_attn.v_proj.weight         │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.10.post_attention_layernorm.weight │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.10.mlp.gate_proj.weight            │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.10.mlp.up_proj.weight              │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.10.mlp.down_proj.weight            │ (4096, 14336) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.11.self_attn.o_proj.weight         │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.11.input_layernorm.weight          │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.11.self_attn.q_proj.weight         │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.11.self_attn.k_proj.weight         │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.11.self_attn.v_proj.weight         │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.11.post_attention_layernorm.weight │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.11.mlp.gate_proj.weight            │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.11.mlp.up_proj.weight              │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.11.mlp.down_proj.weight            │ (4096, 14336) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.12.self_attn.o_proj.weight         │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.12.input_layernorm.weight          │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.12.self_attn.q_proj.weight         │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.12.self_attn.k_proj.weight         │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.12.self_attn.v_proj.weight         │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.12.post_attention_layernorm.weight │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.12.mlp.gate_proj.weight            │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.12.mlp.up_proj.weight              │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.12.mlp.down_proj.weight            │ (4096, 14336) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.13.self_attn.o_proj.weight         │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.13.input_layernorm.weight          │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.13.self_attn.q_proj.weight         │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.13.self_attn.k_proj.weight         │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.13.self_attn.v_proj.weight         │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.13.post_attention_layernorm.weight │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.13.mlp.gate_proj.weight            │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.13.mlp.up_proj.weight              │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.13.mlp.down_proj.weight            │ (4096, 14336) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.14.self_attn.o_proj.weight         │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.14.input_layernorm.weight          │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.14.self_attn.q_proj.weight         │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.14.self_attn.k_proj.weight         │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.14.self_attn.v_proj.weight         │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.14.post_attention_layernorm.weight │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.14.mlp.gate_proj.weight            │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.14.mlp.up_proj.weight              │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.14.mlp.down_proj.weight            │ (4096, 14336) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.15.self_attn.o_proj.weight         │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.15.input_layernorm.weight          │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.15.self_attn.q_proj.weight         │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.15.self_attn.k_proj.weight         │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.15.self_attn.v_proj.weight         │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.15.post_attention_layernorm.weight │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.15.mlp.gate_proj.weight            │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.15.mlp.up_proj.weight              │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.15.mlp.down_proj.weight            │ (4096, 14336) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.16.self_attn.o_proj.weight         │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.16.input_layernorm.weight          │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.16.self_attn.q_proj.weight         │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.16.self_attn.k_proj.weight         │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.16.self_attn.v_proj.weight         │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.16.post_attention_layernorm.weight │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.16.mlp.gate_proj.weight            │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.16.mlp.up_proj.weight              │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.16.mlp.down_proj.weight            │ (4096, 14336) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.17.self_attn.o_proj.weight         │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.17.input_layernorm.weight          │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.17.self_attn.q_proj.weight         │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.17.self_attn.k_proj.weight         │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.17.self_attn.v_proj.weight         │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.17.post_attention_layernorm.weight │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.17.mlp.gate_proj.weight            │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.17.mlp.up_proj.weight              │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.17.mlp.down_proj.weight            │ (4096, 14336) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.18.self_attn.o_proj.weight         │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.18.input_layernorm.weight          │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.18.self_attn.q_proj.weight         │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.18.self_attn.k_proj.weight         │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.18.self_attn.v_proj.weight         │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.18.post_attention_layernorm.weight │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.18.mlp.gate_proj.weight            │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.18.mlp.up_proj.weight              │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.18.mlp.down_proj.weight            │ (4096, 14336) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.19.self_attn.o_proj.weight         │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.19.input_layernorm.weight          │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.19.self_attn.q_proj.weight         │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.19.self_attn.k_proj.weight         │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.19.self_attn.v_proj.weight         │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.19.post_attention_layernorm.weight │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.19.mlp.gate_proj.weight            │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.19.mlp.up_proj.weight              │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.19.mlp.down_proj.weight            │ (4096, 14336) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.20.self_attn.o_proj.weight         │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.20.input_layernorm.weight          │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.20.self_attn.q_proj.weight         │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.20.self_attn.k_proj.weight         │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.20.self_attn.v_proj.weight         │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.20.post_attention_layernorm.weight │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.20.mlp.gate_proj.weight            │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.20.mlp.up_proj.weight              │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.20.mlp.down_proj.weight            │ (4096, 14336) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.21.self_attn.o_proj.weight         │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.21.input_layernorm.weight          │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.21.self_attn.q_proj.weight         │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.21.self_attn.k_proj.weight         │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.21.self_attn.v_proj.weight         │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.21.post_attention_layernorm.weight │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.21.mlp.gate_proj.weight            │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.21.mlp.up_proj.weight              │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.21.mlp.down_proj.weight            │ (4096, 14336) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.22.self_attn.o_proj.weight         │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.22.input_layernorm.weight          │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.22.self_attn.q_proj.weight         │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.22.self_attn.k_proj.weight         │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.22.self_attn.v_proj.weight         │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.22.post_attention_layernorm.weight │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.22.mlp.gate_proj.weight            │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.22.mlp.up_proj.weight              │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.22.mlp.down_proj.weight            │ (4096, 14336) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.23.self_attn.o_proj.weight         │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.23.input_layernorm.weight          │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.23.self_attn.q_proj.weight         │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.23.self_attn.k_proj.weight         │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.23.self_attn.v_proj.weight         │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.23.post_attention_layernorm.weight │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.23.mlp.gate_proj.weight            │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.23.mlp.up_proj.weight              │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.23.mlp.down_proj.weight            │ (4096, 14336) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.24.self_attn.o_proj.weight         │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.24.input_layernorm.weight          │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.24.self_attn.q_proj.weight         │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.24.self_attn.k_proj.weight         │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.24.self_attn.v_proj.weight         │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.24.post_attention_layernorm.weight │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.24.mlp.gate_proj.weight            │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.24.mlp.up_proj.weight              │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.24.mlp.down_proj.weight            │ (4096, 14336) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.25.self_attn.o_proj.weight         │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.25.input_layernorm.weight          │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.25.self_attn.q_proj.weight         │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.25.self_attn.k_proj.weight         │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.25.self_attn.v_proj.weight         │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.25.post_attention_layernorm.weight │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.25.mlp.gate_proj.weight            │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.25.mlp.up_proj.weight              │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.25.mlp.down_proj.weight            │ (4096, 14336) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.26.self_attn.o_proj.weight         │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.26.input_layernorm.weight          │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.26.self_attn.q_proj.weight         │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.26.self_attn.k_proj.weight         │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.26.self_attn.v_proj.weight         │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.26.post_attention_layernorm.weight │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.26.mlp.gate_proj.weight            │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.26.mlp.up_proj.weight              │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.26.mlp.down_proj.weight            │ (4096, 14336) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.27.self_attn.o_proj.weight         │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.27.input_layernorm.weight          │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.27.self_attn.q_proj.weight         │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.27.self_attn.k_proj.weight         │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.27.self_attn.v_proj.weight         │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.27.post_attention_layernorm.weight │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.27.mlp.gate_proj.weight            │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.27.mlp.up_proj.weight              │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.27.mlp.down_proj.weight            │ (4096, 14336) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.28.self_attn.o_proj.weight         │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.28.input_layernorm.weight          │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.28.self_attn.q_proj.weight         │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.28.self_attn.k_proj.weight         │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.28.self_attn.v_proj.weight         │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.28.post_attention_layernorm.weight │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.28.mlp.gate_proj.weight            │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.28.mlp.up_proj.weight              │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.28.mlp.down_proj.weight            │ (4096, 14336) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.29.self_attn.o_proj.weight         │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.29.input_layernorm.weight          │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.29.self_attn.q_proj.weight         │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.29.self_attn.k_proj.weight         │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.29.self_attn.v_proj.weight         │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.29.post_attention_layernorm.weight │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.29.mlp.gate_proj.weight            │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.29.mlp.up_proj.weight              │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.29.mlp.down_proj.weight            │ (4096, 14336) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.30.self_attn.o_proj.weight         │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.30.input_layernorm.weight          │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.30.self_attn.q_proj.weight         │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.30.self_attn.k_proj.weight         │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.30.self_attn.v_proj.weight         │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.30.post_attention_layernorm.weight │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.30.mlp.gate_proj.weight            │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.30.mlp.up_proj.weight              │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.30.mlp.down_proj.weight            │ (4096, 14336) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.31.self_attn.o_proj.weight         │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.31.input_layernorm.weight          │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.31.self_attn.q_proj.weight         │ (4096, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.31.self_attn.k_proj.weight         │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.31.self_attn.v_proj.weight         │ (1024, 4096)  │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.31.post_attention_layernorm.weight │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.31.mlp.gate_proj.weight            │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.31.mlp.up_proj.weight              │ (14336, 4096) │ bfloat16 │ cuda:0 │        ✅        │
│ model.layers.31.mlp.down_proj.weight            │ (4096, 14336) │ bfloat16 │ cuda:0 │        ✅        │
│ model.norm.weight                               │ (4096,)       │ bfloat16 │ cuda:0 │        ✅        │
│ lm_head.weight                                  │ (32000, 4096) │ bfloat16 │ cuda:0 │        ✅        │
└─────────────────────────────────────────────────┴───────────────┴──────────┴────────┴──────────────────┘
Saving HF-ckpt in /tmp/Mistral-7B-v0.1...
/home/marc/src/Megatron-Bridge/.venv/lib/python3.11/site-packages/torch/distributed/distributed_c10d.py:4631: UserWarning: No device id is provided via `init_process_group` or `barrier `. Using the current device set by the user. 
  warnings.warn(  # warn only once
[rank0]:[W718 13:54:05.992947244 ProcessGroupNCCL.cpp:4718] [PG ID 0 PG GUID 0 Rank 0]  using GPU 0 as device used by this process is currently unknown. This can potentially cause a hang if this rank to GPU mapping is incorrect. You can pecify device_id in init_process_group() to force use of a particular device.
Converting to HuggingFace ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 (195/195) MistralCausalBridge

Success: All tensors from the original checkpoint were written.
[rank0]:[W718 13:54:21.338548149 ProcessGroupNCCL.cpp:1479] Warning: WARNING: destroy_process_group() was not called before program exit, which can leak resources. For more info, please see https://pytorch.org/docs/stable/distributed.html#shutdown (function operator())
```