### PR TITLE
Adding baichuan causal-bridge + model-providers

### DIFF
--- a/examples/models/2_way_hf_binding.py
+++ b/examples/models/2_way_hf_binding.py
@@ -49,7 +49,15 @@ def main(hf_model_id: str = HF_MODEL_ID, output_dir: str = None) -> None:
     else:
         save_path = model_name
 
-    bridge = CausalLMBridge.from_hf_pretrained(hf_model_id)
+    # Special handling for Baichuan models that require trust_remote_code
+    if "baichuan" in hf_model_id.lower():
+        from megatron.bridge.models.baichuan import BaichuanCausalBridge
+
+        bridge = CausalLMBridge.from_hf_pretrained(
+            hf_model_id, bridge_class=BaichuanCausalBridge, trust_remote_code=True
+        )
+    else:
+        bridge = CausalLMBridge.from_hf_pretrained(hf_model_id)
     megatron_model = bridge.to_megatron_model(wrap_with_ddp=False)
     console.print(weights_verification_table(bridge, megatron_model))
 

--- a/src/megatron/bridge/models/__init__.py
+++ b/src/megatron/bridge/models/__init__.py
@@ -14,6 +14,11 @@
 
 # Import model providers for easy access
 from megatron.bridge.models.auto_bridge import AutoBridge
+from megatron.bridge.models.baichuan import (
+    Baichuan2ModelProvider7B,
+    Baichuan2ModelProvider13B,
+    BaichuanModelProvider,
+)
 from megatron.bridge.models.causal_bridge import CausalLMBridge
 from megatron.bridge.models.gpt_provider import GPTModelProvider
 from megatron.bridge.models.llama import (
@@ -87,4 +92,7 @@ __all__ = [
     "Llama4ModelProvider",
     "Llama4Experts16ModelProvider",
     "Llama4Experts128ModelProvider",
+    "BaichuanModelProvider",
+    "Baichuan2ModelProvider7B",
+    "Baichuan2ModelProvider13B",
 ]

--- a/src/megatron/bridge/models/baichuan/__init__.py
+++ b/src/megatron/bridge/models/baichuan/__init__.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from megatron.bridge.models.baichuan.baichuan_causal_bridge import BaichuanCausalBridge  # noqa: F401
+from megatron.bridge.models.baichuan.baichuan_provider import (
+    Baichuan2ModelProvider7B,
+    Baichuan2ModelProvider13B,
+    BaichuanModelProvider,
+)
+
+
+__all__ = [
+    "BaichuanModelProvider",
+    "Baichuan2ModelProvider7B",
+    "Baichuan2ModelProvider13B",
+]

--- a/src/megatron/bridge/models/baichuan/baichuan_causal_bridge.py
+++ b/src/megatron/bridge/models/baichuan/baichuan_causal_bridge.py
@@ -1,0 +1,138 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+from megatron.core.models.gpt.gpt_model import GPTModel
+from transformers import AutoModelForCausalLM
+
+from megatron.bridge.models.baichuan.baichuan_mapping import BaichuanQKVMapping
+from megatron.bridge.models.baichuan.baichuan_provider import BaichuanModelProvider
+from megatron.bridge.models.hf_pretrained.causal_lm import PreTrainedCausalLM
+from megatron.bridge.models.mapping_registry import MegatronMappingRegistry
+from megatron.bridge.models.model_bridge import MegatronModelBridge
+from megatron.bridge.models.param_mapping import (
+    GatedMLPMapping,
+    TPAwareMapping,
+)
+
+
+@MegatronModelBridge.register_bridge(source=AutoModelForCausalLM, target=GPTModel)
+class BaichuanCausalBridge(MegatronModelBridge):
+    """
+    Megatron Hub Bridge for Baichuan Causal LM.
+
+    This bridge handles the conversion between HuggingFace Baichuan models
+    and Megatron-Core GPTModel formats. Baichuan models have a unique
+    packed QKV format (W_pack) that requires special handling.
+
+    Note: Baichuan models require trust_remote_code=True when loading from HuggingFace.
+    Since they use custom model classes, you need to specify this bridge manually:
+
+    Example:
+        >>> from megatron.bridge import CausalLMBridge
+        >>> from megatron.bridge.models.baichuan import BaichuanCausalBridge
+        >>>
+        >>> bridge = CausalLMBridge.from_hf_pretrained(
+        ...     "baichuan-inc/Baichuan2-7B-Base",
+        ...     bridge_class=BaichuanCausalBridge,
+        ...     trust_remote_code=True
+        ... )
+        >>> provider = bridge.to_megatron_provider()
+    """
+
+    def provider_bridge(self, hf_pretrained: PreTrainedCausalLM) -> BaichuanModelProvider:
+        hf_config = hf_pretrained.config
+
+        # Determine position embedding type based on model size
+        # 7B uses RoPE, 13B uses ALiBi
+        position_embedding_type = "rope" if hf_config.num_hidden_layers == 32 else "alibi"
+
+        provider = BaichuanModelProvider(
+            num_layers=hf_config.num_hidden_layers,
+            hidden_size=hf_config.hidden_size,
+            ffn_hidden_size=hf_config.intermediate_size,
+            num_attention_heads=hf_config.num_attention_heads,
+            num_query_groups=hf_config.num_attention_heads,  # Baichuan doesn't use GQA
+            init_method_std=hf_config.initializer_range,
+            layernorm_epsilon=hf_config.rms_norm_eps,
+            gated_linear_unit=True,
+            make_vocab_size_divisible_by=self.make_vocab_size_divisible_by(hf_config.vocab_size),
+            rotary_base=10000.0,  # Default RoPE base
+            share_embeddings_and_output_weights=False,
+            vocab_size=hf_config.vocab_size,
+            seq_length=hf_config.max_position_embeddings,
+            position_embedding_type=position_embedding_type,
+            fp16=(self.dtype_from_hf(hf_config, default=torch.float32) == torch.float16),
+            bf16=(self.dtype_from_hf(hf_config, default=torch.float32) == torch.bfloat16),
+            params_dtype=self.dtype_from_hf(hf_config, default=torch.float32),
+            generation_config=hf_pretrained.generation_config,
+        )
+
+        provider.gradient_accumulation_fusion = False
+        provider.variable_seq_lengths = True
+
+        return provider
+
+    def mapping_registry(self) -> MegatronMappingRegistry:
+        return MegatronMappingRegistry(
+            # ------------------------------------------------------------------
+            # Embedding & output projection – column-parallel
+            # ------------------------------------------------------------------
+            TPAwareMapping(
+                megatron_param="embedding.word_embeddings.weight",
+                hf_param="model.embed_tokens.weight",
+            ),
+            TPAwareMapping(
+                megatron_param="output_layer.weight",
+                hf_param="lm_head.weight",
+            ),
+            # ------------------------------------------------------------------
+            # LayerNorm (replicated across TP ranks)
+            # ------------------------------------------------------------------
+            TPAwareMapping(
+                megatron_param="decoder.final_layernorm.weight",
+                hf_param="model.norm.weight",
+            ),
+            TPAwareMapping(
+                megatron_param="decoder.layers.*.self_attention.linear_qkv.layer_norm_weight",
+                hf_param="model.layers.*.input_layernorm.weight",
+            ),
+            TPAwareMapping(
+                megatron_param="decoder.layers.*.mlp.linear_fc1.layer_norm_weight",
+                hf_param="model.layers.*.post_attention_layernorm.weight",
+            ),
+            # ------------------------------------------------------------------
+            # Attention – Baichuan uses packed W_pack format
+            # ------------------------------------------------------------------
+            BaichuanQKVMapping(
+                megatron_param="decoder.layers.*.self_attention.linear_qkv.weight",
+                hf_param="model.layers.*.self_attn.W_pack.weight",
+            ),
+            TPAwareMapping(
+                megatron_param="decoder.layers.*.self_attention.linear_proj.weight",
+                hf_param="model.layers.*.self_attn.o_proj.weight",
+            ),
+            # ------------------------------------------------------------------
+            # MLP – Gated MLP with gate_proj and up_proj
+            # ------------------------------------------------------------------
+            GatedMLPMapping(
+                megatron_param="decoder.layers.*.mlp.linear_fc1.weight",
+                gate="model.layers.*.mlp.gate_proj.weight",
+                up="model.layers.*.mlp.up_proj.weight",
+            ),
+            TPAwareMapping(
+                megatron_param="decoder.layers.*.mlp.linear_fc2.weight",
+                hf_param="model.layers.*.mlp.down_proj.weight",
+            ),
+        )

--- a/src/megatron/bridge/models/baichuan/baichuan_mapping.py
+++ b/src/megatron/bridge/models/baichuan/baichuan_mapping.py
@@ -1,0 +1,175 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Dict, Optional
+
+import torch
+import torch.nn as nn
+
+from megatron.bridge.models.param_mapping import MegatronParamMapping
+
+
+class BaichuanQKVMapping(MegatronParamMapping[torch.Tensor]):
+    """
+    Custom mapping for Baichuan's W_pack QKV format.
+
+    Baichuan uses a unique packing format where Q, K, V are concatenated
+    along dimension 0 in a specific order, different from the standard
+    Megatron QKV interleaving.
+
+    HF format (W_pack):
+        - Shape: [3 * hidden_size, hidden_size]
+        - Layout: [Q_full, K_full, V_full] concatenated
+
+    Megatron format:
+        - Interleaved per head group for GQA efficiency
+        - Layout: [q1...qn, k1, v1, q1...qn, k2, v2, ...]
+    """
+
+    def hf_to_megatron(
+        self,
+        hf_weights: torch.Tensor,
+        megatron_module: nn.Module,
+    ) -> torch.Tensor:
+        """Convert Baichuan W_pack format to Megatron interleaved QKV format."""
+        # Get dimensions from the module's config
+        config = megatron_module.config
+        head_num = config.num_attention_heads
+        num_query_groups = config.num_query_groups
+        heads_per_group = head_num // num_query_groups
+        hidden_size = config.hidden_size
+        head_size = config.kv_channels
+
+        # Unpack the W_pack tensor
+        # W_pack shape: [3 * hidden_size, hidden_size]
+        qkv_weights = hf_weights.unflatten(0, (3, hidden_size))
+
+        # Extract Q, K, V
+        # Each has shape [hidden_size, hidden_size]
+        q_weight = qkv_weights[0]  # [hidden_size, hidden_size]
+        k_weight = qkv_weights[1]  # [hidden_size, hidden_size]
+        v_weight = qkv_weights[2]  # [hidden_size, hidden_size]
+
+        # Reshape to separate heads
+        # Q: [hidden_size, hidden_size] -> [num_heads, head_size, hidden_size]
+        q_weight = q_weight.view(head_num, head_size, hidden_size)
+        # K, V: [hidden_size, hidden_size] -> [num_query_groups, head_size, hidden_size]
+        k_weight = k_weight.view(num_query_groups, head_size, hidden_size)
+        v_weight = v_weight.view(num_query_groups, head_size, hidden_size)
+
+        # Interleave according to Megatron format
+        qkv_interleaved = []
+        for i in range(num_query_groups):
+            # Add Q heads for this group
+            start_idx = i * heads_per_group
+            end_idx = (i + 1) * heads_per_group
+            qkv_interleaved.append(q_weight[start_idx:end_idx])
+            # Add K for this group
+            qkv_interleaved.append(k_weight[i : i + 1])
+            # Add V for this group
+            qkv_interleaved.append(v_weight[i : i + 1])
+
+        # Concatenate all interleaved weights
+        qkv_weight = torch.cat(qkv_interleaved, dim=0)
+        # Reshape to final format
+        qkv_weight = qkv_weight.reshape(head_size * (head_num + 2 * num_query_groups), hidden_size)
+
+        # Handle tensor parallel if needed
+        if self.tp_size > 1:
+            # Distribute across TP ranks
+            return self._distribute_qkv_tp(qkv_weight, megatron_module)
+
+        return qkv_weight
+
+    def megatron_to_hf(
+        self,
+        megatron_weights: Optional[torch.Tensor],
+        megatron_module: Optional[nn.Module],
+    ) -> Dict[str, torch.Tensor]:
+        """Convert Megatron interleaved QKV format to Baichuan W_pack format."""
+        # Handle cross-PP broadcast
+        megatron_weights = self.broadcast_from_pp_rank(megatron_weights)
+
+        if megatron_weights is None:
+            return {}
+
+        # Get dimensions
+        config = megatron_module.config if megatron_module else None
+        if config is None:
+            return {}
+
+        head_num = config.num_attention_heads
+        num_query_groups = config.num_query_groups
+        heads_per_group = head_num // num_query_groups
+        hidden_size = config.hidden_size
+        head_size = config.kv_channels
+        qkv_total_dim = head_num + 2 * num_query_groups
+
+        # Gather from TP ranks if needed
+        if self.tp_size > 1:
+            megatron_weights = self._gather_qkv_tp(megatron_weights)
+            if self.tp_rank != 0:
+                return {}
+
+        # Reshape to separate heads
+        # [qkv_total_dim * head_size, hidden_size] -> [qkv_total_dim, head_size, hidden_size]
+        qkv_weight = megatron_weights.reshape(qkv_total_dim, head_size, hidden_size)
+
+        # Extract Q, K, V from interleaved format
+        q_weights = []
+        k_weights = []
+        v_weights = []
+
+        idx = 0
+        for i in range(num_query_groups):
+            # Extract Q heads for this group
+            q_weights.append(qkv_weight[idx : idx + heads_per_group])
+            idx += heads_per_group
+            # Extract K for this group
+            k_weights.append(qkv_weight[idx : idx + 1])
+            idx += 1
+            # Extract V for this group
+            v_weights.append(qkv_weight[idx : idx + 1])
+            idx += 1
+
+        # Concatenate Q, K, V separately
+        q_weight = torch.cat(q_weights, dim=0).reshape(hidden_size, hidden_size)
+        k_weight = torch.cat(k_weights, dim=0).reshape(hidden_size, hidden_size)
+        v_weight = torch.cat(v_weights, dim=0).reshape(hidden_size, hidden_size)
+
+        # Pack into W_pack format [3 * hidden_size, hidden_size]
+        w_pack = torch.cat([q_weight, k_weight, v_weight], dim=0)
+
+        return {str(self.hf_param): w_pack}
+
+    def _distribute_qkv_tp(self, qkv_weight: torch.Tensor, module: nn.Module) -> torch.Tensor:
+        """Distribute QKV weights across tensor parallel ranks."""
+        # For column parallel, we split along dim 0
+        if self.tp_rank == 0:
+            splits = torch.chunk(qkv_weight, self.tp_size, dim=0)
+        else:
+            splits = None
+
+        output_shape = module.weight.shape
+        return self.scatter_to_tp_ranks(
+            splits,
+            output_shape,
+            module.weight.dtype,
+            module.weight.device,
+        )
+
+    def _gather_qkv_tp(self, local_weight: torch.Tensor) -> torch.Tensor:
+        """Gather QKV weights from all tensor parallel ranks."""
+        gathered = self.gather_from_tp_ranks(local_weight)
+        return torch.cat(gathered, dim=0)

--- a/src/megatron/bridge/models/baichuan/baichuan_provider.py
+++ b/src/megatron/bridge/models/baichuan/baichuan_provider.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from dataclasses import dataclass
+
+import torch.nn.functional as F
+
+from megatron.bridge.models.gpt_provider import GPTModelProvider
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class BaichuanModelProvider(GPTModelProvider):
+    """Base model provider for Baichuan Models."""
+
+    normalization: str = "RMSNorm"
+    activation_func = F.silu
+    gated_linear_unit: bool = True
+    add_bias_linear: bool = False
+    seq_length: int = 4096
+    init_method_std: float = 0.02
+    hidden_dropout: float = 0.0
+    attention_dropout: float = 0.0
+    share_embeddings_and_output_weights: bool = False
+    layernorm_epsilon: float = 1e-6
+    position_embedding_type: str = "rope"
+    rotary_base: float = 10000.0
+
+
+@dataclass
+class Baichuan2ModelProvider7B(BaichuanModelProvider):
+    """
+    Config for Baichuan2 7B: https://huggingface.co/baichuan-inc/Baichuan2-7B-Base
+    """
+
+    num_layers: int = 32
+    hidden_size: int = 4096
+    ffn_hidden_size: int = 11008
+    num_attention_heads: int = 32
+    num_query_groups: int = 32  # No GQA in 7B model
+    vocab_size: int = 125696
+
+
+@dataclass
+class Baichuan2ModelProvider13B(BaichuanModelProvider):
+    """
+    Config for Baichuan2 13B: https://huggingface.co/baichuan-inc/Baichuan2-13B-Base
+
+    Note: 13B model uses ALiBi position embeddings instead of RoPE
+    """
+
+    num_layers: int = 40
+    hidden_size: int = 5120
+    ffn_hidden_size: int = 13696
+    num_attention_heads: int = 40
+    num_query_groups: int = 40  # No GQA
+    vocab_size: int = 125696
+    position_embedding_type: str = "alibi"  # 13B uses ALiBi


### PR DESCRIPTION
This PR contains some extra changes to support the model:
  - Added `PyTorchStateSource` class for lazy loading of .bin/.pt checkpoint files, matching SafeTensorsStateSource functionality
  - Enhanced `CausalLMBridge` with optional `bridge_class` parameter for models requiring `trust_remote_code=True`
  - Improved automatic checkpoint format detection in `PreTrainedBase` with fallback logic for both local and HuggingFace Hub models
  - Updated export functionality to handle manual bridges correctly when model architecture classes aren't in standard transformers

  These changes are fully backward compatible and extend bridge support to legacy PyTorch checkpoints and custom model architectures.