### PR TITLE
Match fp16 loss scaling defaults with NeMo2

### DIFF
--- a/src/megatron/bridge/training/mixed_precision.py
+++ b/src/megatron/bridge/training/mixed_precision.py
@@ -53,10 +53,10 @@ class MixedPrecisionConfig:
     fp8_param_gather: bool = False
     # FP16 Loss scaling
     loss_scale: Optional[float] = None
-    initial_loss_scale: Optional[float] = None
-    min_loss_scale: Optional[float] = None
-    loss_scale_window: Optional[float] = None
-    hysteresis: Optional[float] = None
+    initial_loss_scale: Optional[float] = 4294967296  # 2^32
+    min_loss_scale: float = 1.0
+    loss_scale_window: float = 1000
+    hysteresis: int = 2
     num_layers_at_start_in_bf16: int = 0
     num_layers_at_end_in_bf16: int = 0
 


### PR DESCRIPTION
found while investigating https://github.com/NVIDIA-NeMo/Megatron-Bridge/issues/353

current defaults don't match:
https://github.com/NVIDIA/NeMo/blob/379b87679df2fb44509687b18be842ace70f0718/nemo/lightning/pytorch/plugins/mixed_precision.py#L119-L122

https://github.com/NVIDIA/Megatron-LM/blob/75e2efd10fd324819a29c5ce581fdf0f3c37b29f/megatron/core/optimizer/optimizer_config.py#L81-L99