### PR TITLE
Update async save default for recipes

### DIFF
--- a/src/megatron/bridge/recipes/llama/llama2_7b.py
+++ b/src/megatron/bridge/recipes/llama/llama2_7b.py
@@ -206,7 +206,6 @@ def pretrain_config(
             save=checkpoint_dir,
             ckpt_format="torch_dist",
             fully_parallel_save=True,
-            async_save=True,
         ),
         rng=RNGConfig(seed=1234),
         comm_overlap=comm_overlap_config,

--- a/src/megatron/bridge/recipes/llama/llama31_405b.py
+++ b/src/megatron/bridge/recipes/llama/llama31_405b.py
@@ -218,7 +218,6 @@ def pretrain_config(
             save=checkpoint_dir,
             ckpt_format="torch_dist",
             fully_parallel_save=True,
-            async_save=True,
         ),
         rng=RNGConfig(seed=1234),
         comm_overlap=comm_overlap_config,

--- a/src/megatron/bridge/recipes/llama/llama31_70b.py
+++ b/src/megatron/bridge/recipes/llama/llama31_70b.py
@@ -206,7 +206,6 @@ def pretrain_config(
             save=checkpoint_dir,
             ckpt_format="torch_dist",
             fully_parallel_save=True,
-            async_save=True,
         ),
         rng=RNGConfig(seed=1234),
         comm_overlap=comm_overlap_config,

--- a/src/megatron/bridge/recipes/llama/llama31_8b.py
+++ b/src/megatron/bridge/recipes/llama/llama31_8b.py
@@ -203,7 +203,6 @@ def pretrain_config(
             save=checkpoint_dir,
             ckpt_format="torch_dist",
             fully_parallel_save=True,
-            async_save=True,
         ),
         rng=RNGConfig(seed=1234),
         comm_overlap=comm_overlap_config,

--- a/src/megatron/bridge/recipes/llama/llama32_1b.py
+++ b/src/megatron/bridge/recipes/llama/llama32_1b.py
@@ -205,7 +205,6 @@ def pretrain_config(
             save=checkpoint_dir,
             ckpt_format="torch_dist",
             fully_parallel_save=True,
-            async_save=True,
         ),
         rng=RNGConfig(seed=1234),
         comm_overlap=comm_overlap_config,

--- a/src/megatron/bridge/recipes/llama/llama32_3b.py
+++ b/src/megatron/bridge/recipes/llama/llama32_3b.py
@@ -205,7 +205,6 @@ def pretrain_config(
             save=checkpoint_dir,
             ckpt_format="torch_dist",
             fully_parallel_save=True,
-            async_save=True,
         ),
         rng=RNGConfig(seed=1234),
         comm_overlap=comm_overlap_config,

--- a/src/megatron/bridge/recipes/llama/llama3_70b.py
+++ b/src/megatron/bridge/recipes/llama/llama3_70b.py
@@ -202,7 +202,6 @@ def pretrain_config(
             save=checkpoint_dir,
             ckpt_format="torch_dist",
             fully_parallel_save=True,
-            async_save=True,
         ),
         rng=RNGConfig(seed=1234),
         comm_overlap=comm_overlap_config,

--- a/src/megatron/bridge/recipes/llama/llama3_8b.py
+++ b/src/megatron/bridge/recipes/llama/llama3_8b.py
@@ -205,7 +205,6 @@ def pretrain_config(
             save=checkpoint_dir,
             ckpt_format="torch_dist",
             fully_parallel_save=True,
-            async_save=True,
         ),
         rng=RNGConfig(seed=1234),
         comm_overlap=comm_overlap_config,

--- a/src/megatron/bridge/recipes/llama/llama4_e128.py
+++ b/src/megatron/bridge/recipes/llama/llama4_e128.py
@@ -209,7 +209,6 @@ def pretrain_config(
             save=checkpoint_dir,
             ckpt_format="torch_dist",
             fully_parallel_save=True,
-            async_save=True,
         ),
         rng=RNGConfig(seed=1234),
         mixed_precision=precision_config,

--- a/src/megatron/bridge/recipes/llama/llama4_e16.py
+++ b/src/megatron/bridge/recipes/llama/llama4_e16.py
@@ -209,7 +209,6 @@ def pretrain_config(
             save=checkpoint_dir,
             ckpt_format="torch_dist",
             fully_parallel_save=True,
-            async_save=True,
         ),
         rng=RNGConfig(seed=1234),
         mixed_precision=precision_config,

--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -470,6 +470,7 @@ class CheckpointConfig:
 
         if self.async_save:
             assert self.save is not None, "async_save is enabled, but save is not set. Set save to a valid path."
+            assert self.use_persistent_ckpt_worker, "async_save requires use_persistent_ckpt_worker=True."
 
 
 @dataclass(kw_only=True)

--- a/tests/unit_tests/recipes/llama/test_llama2_7b.py
+++ b/tests/unit_tests/recipes/llama/test_llama2_7b.py
@@ -250,7 +250,7 @@ class TestPretrainConfig:
         assert config.checkpoint.save_interval == 2000
         assert config.checkpoint.ckpt_format == "torch_dist"
         assert config.checkpoint.fully_parallel_save is True
-        assert config.checkpoint.async_save is True
+        assert config.checkpoint.async_save is False
 
     def test_pretrain_config_ddp_configuration(self):
         """Test distributed data parallel configuration."""

--- a/tests/unit_tests/recipes/llama/test_llama31_405b.py
+++ b/tests/unit_tests/recipes/llama/test_llama31_405b.py
@@ -274,7 +274,7 @@ class TestPretrainConfig:
         assert config.checkpoint.save_interval == 2000
         assert config.checkpoint.ckpt_format == "torch_dist"
         assert config.checkpoint.fully_parallel_save is True
-        assert config.checkpoint.async_save is True
+        assert config.checkpoint.async_save is False
 
     def test_pretrain_config_ddp_configuration(self):
         """Test distributed data parallel configuration."""

--- a/tests/unit_tests/recipes/llama/test_llama31_70b.py
+++ b/tests/unit_tests/recipes/llama/test_llama31_70b.py
@@ -251,7 +251,7 @@ class TestPretrainConfig:
         assert config.checkpoint.save_interval == 2000
         assert config.checkpoint.ckpt_format == "torch_dist"
         assert config.checkpoint.fully_parallel_save is True
-        assert config.checkpoint.async_save is True
+        assert config.checkpoint.async_save is False
 
     def test_pretrain_config_ddp_configuration(self):
         """Test distributed data parallel configuration."""

--- a/tests/unit_tests/recipes/llama/test_llama31_8b.py
+++ b/tests/unit_tests/recipes/llama/test_llama31_8b.py
@@ -251,7 +251,7 @@ class TestPretrainConfig:
         assert config.checkpoint.save_interval == 2000
         assert config.checkpoint.ckpt_format == "torch_dist"
         assert config.checkpoint.fully_parallel_save is True
-        assert config.checkpoint.async_save is True
+        assert config.checkpoint.async_save is False
 
     def test_pretrain_config_ddp_configuration(self):
         """Test distributed data parallel configuration."""

--- a/tests/unit_tests/recipes/llama/test_llama32_1b.py
+++ b/tests/unit_tests/recipes/llama/test_llama32_1b.py
@@ -253,7 +253,7 @@ class TestPretrainConfig:
         assert config.checkpoint.save_interval == 2000
         assert config.checkpoint.ckpt_format == "torch_dist"
         assert config.checkpoint.fully_parallel_save is True
-        assert config.checkpoint.async_save is True
+        assert config.checkpoint.async_save is False
 
     def test_pretrain_config_ddp_configuration(self):
         """Test distributed data parallel configuration."""

--- a/tests/unit_tests/recipes/llama/test_llama32_3b.py
+++ b/tests/unit_tests/recipes/llama/test_llama32_3b.py
@@ -253,7 +253,7 @@ class TestPretrainConfig:
         assert config.checkpoint.save_interval == 2000
         assert config.checkpoint.ckpt_format == "torch_dist"
         assert config.checkpoint.fully_parallel_save is True
-        assert config.checkpoint.async_save is True
+        assert config.checkpoint.async_save is False
 
     def test_pretrain_config_ddp_configuration(self):
         """Test distributed data parallel configuration."""

--- a/tests/unit_tests/recipes/llama/test_llama3_70b.py
+++ b/tests/unit_tests/recipes/llama/test_llama3_70b.py
@@ -252,7 +252,7 @@ class TestPretrainConfig:
         assert config.checkpoint.save_interval == 2000
         assert config.checkpoint.ckpt_format == "torch_dist"
         assert config.checkpoint.fully_parallel_save is True
-        assert config.checkpoint.async_save is True
+        assert config.checkpoint.async_save is False
 
     def test_pretrain_config_ddp_configuration(self):
         """Test distributed data parallel configuration."""

--- a/tests/unit_tests/recipes/llama/test_llama3_70b_16k.py
+++ b/tests/unit_tests/recipes/llama/test_llama3_70b_16k.py
@@ -224,7 +224,7 @@ class TestPretrainConfig:
         assert config.checkpoint.save_interval == 2000
         assert config.checkpoint.ckpt_format == "torch_dist"
         assert config.checkpoint.fully_parallel_save is True
-        assert config.checkpoint.async_save is True
+        assert config.checkpoint.async_save is False
 
     def test_pretrain_config_ddp_configuration(self):
         """Test distributed data parallel configuration."""

--- a/tests/unit_tests/recipes/llama/test_llama3_70b_64k.py
+++ b/tests/unit_tests/recipes/llama/test_llama3_70b_64k.py
@@ -230,7 +230,7 @@ class TestPretrainConfig:
         assert config.checkpoint.save_interval == 2000
         assert config.checkpoint.ckpt_format == "torch_dist"
         assert config.checkpoint.fully_parallel_save is True
-        assert config.checkpoint.async_save is True
+        assert config.checkpoint.async_save is False
 
     def test_pretrain_config_ddp_configuration(self):
         """Test distributed data parallel configuration."""

--- a/tests/unit_tests/recipes/llama/test_llama3_8b.py
+++ b/tests/unit_tests/recipes/llama/test_llama3_8b.py
@@ -250,7 +250,7 @@ class TestPretrainConfig:
         assert config.checkpoint.save_interval == 2000
         assert config.checkpoint.ckpt_format == "torch_dist"
         assert config.checkpoint.fully_parallel_save is True
-        assert config.checkpoint.async_save is True
+        assert config.checkpoint.async_save is False
 
     def test_pretrain_config_ddp_configuration(self):
         """Test distributed data parallel configuration."""

--- a/tests/unit_tests/recipes/llama/test_llama3_8b_16k.py
+++ b/tests/unit_tests/recipes/llama/test_llama3_8b_16k.py
@@ -249,7 +249,7 @@ class TestPretrainConfig:
         assert config.checkpoint.save_interval == 2000
         assert config.checkpoint.ckpt_format == "torch_dist"
         assert config.checkpoint.fully_parallel_save is True
-        assert config.checkpoint.async_save is True
+        assert config.checkpoint.async_save is False
 
     def test_pretrain_config_ddp_configuration(self):
         """Test distributed data parallel configuration."""

--- a/tests/unit_tests/training/test_config.py
+++ b/tests/unit_tests/training/test_config.py
@@ -870,11 +870,20 @@ class TestCheckpointConfig:
             create_test_checkpoint_config(load_main_params_from_ckpt=load_main_params_from_ckpt, load_optim=load_optim)
 
     def test_async_save_validation_error(self):
-        """Test that async_save is not allowed without a save path."""
+        """Test that async_save requires both a save path and use_persistent_ckpt_worker=True."""
+        # Test that async_save requires a save path
         with pytest.raises(
             AssertionError, match="async_save is enabled, but save is not set. Set save to a valid path."
         ):
             create_test_checkpoint_config(async_save=True, save=None)
 
-        # should not raise an error
-        create_test_checkpoint_config(async_save=True, save="/tmp/test_checkpoint_config")
+        # Test that async_save requires use_persistent_ckpt_worker=True
+        with pytest.raises(AssertionError, match="async_save requires use_persistent_ckpt_worker=True."):
+            create_test_checkpoint_config(
+                async_save=True, save="/tmp/test_checkpoint_config", use_persistent_ckpt_worker=False
+            )
+
+        # should not raise an error when both conditions are met
+        create_test_checkpoint_config(
+            async_save=True, save="/tmp/test_checkpoint_config", use_persistent_ckpt_worker=True
+        )


### PR DESCRIPTION
- async save with persistent workers is consuming more memory, causing OOMs. update the default for recipes to use synchronous saving
- add assertions to checkpoint config that async save must be used with persistent workers 

Fixes https://github.com/NVIDIA-NeMo/Megatron-Bridge/issues/353