### PR TITLE
Add end to end test script for CI

### DIFF
--- a/tests/end_to_end_tests/__init__.py
+++ b/tests/end_to_end_tests/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/end_to_end_tests/train_from_recipe.py
+++ b/tests/end_to_end_tests/train_from_recipe.py
@@ -1,0 +1,449 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Training script for Megatron-Bridge recipes.
+
+This script is designed to be run by CI systems and external launchers inside containers.
+It dynamically imports recipe configurations from the megatron.bridge.recipes directory
+and executes training with support for both explicit CLI arguments and Hydra-style
+dot notation overrides.
+
+Key Features:
+- Dynamic recipe loading from megatron.bridge.recipes.{model_family}.{recipe_name}
+- Support for both pretraining (--pretrain) and finetuning (--finetune) modes
+- CLI arguments for common training parameters (batch sizes, learning rates, etc.)
+- Configuration overrides via dot notation (e.g., model.seq_length=4096)
+- Multiple dataset types: mock, rp2, squad, squad_packed
+- Multiple tokenizer types: NullTokenizer, HuggingFaceTokenizer, SentencePieceTokenizer
+- Built-in profiling support (nsys, memory profiling)
+- WandB integration for experiment tracking
+- Convergence mode for testing with optimized logging/checkpointing
+
+Usage Examples:
+    # Basic pretraining with mock data
+    python train_from_recipe.py --model-family llama --recipe-name llama3_8b \\
+        --exp-name test_run --pretrain --max-steps 100
+
+    # Finetuning with custom parameters and overrides
+    python train_from_recipe.py --model-family llama --recipe-name llama3_8b \\
+        --exp-name finetune_run --finetune --data squad --dataset-root /data/squad \\
+        --lr 1e-5 model.seq_length=4096 train.eval_interval=50
+
+    # Advanced training with profiling
+    python train_from_recipe.py --model-family llama --recipe-name llama3_8b \\
+        --exp-name profile_run --pretrain --nsys --convergence \\
+        --tensor-parallel-size 2 optimizer.lr=3e-4
+
+Expected Recipe Structure:
+- Recipe modules must be located at: megatron.bridge.recipes.{model_family}.{recipe_name}
+- For pretraining: recipe must have pretrain_config(dir, name, **kwargs) function
+- For finetuning: recipe must have finetune_config(dir, name, **kwargs) function
+- Both functions should return a ConfigContainer instance
+"""
+
+import argparse
+import importlib
+import logging
+from typing import Optional
+
+import torch
+
+from megatron.bridge.data.builders.hf_dataset import HFDatasetConfig
+from megatron.bridge.data.datasets.packed_sequence import PackedSequenceSpecs
+from megatron.bridge.data.hf_processors import process_squad_example
+from megatron.bridge.peft.dora import DoRA
+from megatron.bridge.peft.lora import LoRA
+from megatron.bridge.recipes.utils.dataset_utils import get_blend_fields_from_data_paths
+from megatron.bridge.training.config import (
+    ConfigContainer,
+    GPTDatasetConfig,
+    MockGPTDatasetConfig,
+    ProfilingConfig,
+    TokenizerConfig,
+)
+from megatron.bridge.training.finetune import finetune
+from megatron.bridge.training.gpt_step import forward_step
+from megatron.bridge.training.pretrain import pretrain
+from megatron.bridge.training.utils.omegaconf_utils import (
+    apply_overrides,
+    create_omegaconf_dict_config,
+    parse_hydra_overrides,
+)
+
+
+def parse_plugin_config_overrides(unknown_args: list[str]) -> list[str]:
+    """Parse unknown arguments as config overrides from plugins.
+
+    Args:
+        unknown_args: List of unknown command line arguments
+
+    Returns:
+        List of config override strings in format "section.field=value"
+    """
+    config_overrides = []
+    for arg in unknown_args:
+        if "=" in arg:
+            # Handle dotted config format: section.field=value
+            config_overrides.append(arg)
+        else:
+            logging.warning(f"Unknown argument ignored (expected format section.field=value): {arg}")
+
+    if config_overrides:
+        logging.info(f"Found {len(config_overrides)} config overrides from plugins: {config_overrides}")
+
+    return config_overrides
+
+
+def create_mock_dataset_config(seq_length: int) -> MockGPTDatasetConfig:
+    """Create mock dataset configuration for Megatron-Bridge."""
+    # Create mock dataset using MockGPTDatasetConfig which enforces blend=None, blend_per_split=None
+    return MockGPTDatasetConfig(
+        random_seed=1234,
+        reset_attention_mask=False,
+        reset_position_ids=False,
+        eod_mask_loss=False,
+        sequence_length=seq_length,
+        num_dataset_builder_threads=1,
+        split="99990,8,2",  # Standard train/val/test split
+        # Dataloader config parameters
+        data_sharding=True,
+        dataloader_type="single",
+        num_workers=1,
+    )
+
+
+def create_rp2_dataset_config(
+    dataset_paths: list[str], seq_length: int, index_mapping_dir: Optional[str] = None
+) -> GPTDatasetConfig:
+    """Create RedPajama2 dataset configuration for Megatron-Bridge."""
+    # Get blend configuration for rp2 data paths
+    blend, blend_per_split, split = get_blend_fields_from_data_paths(data_paths=dataset_paths, mock=False)
+
+    return GPTDatasetConfig(
+        random_seed=1234,
+        reset_attention_mask=False,
+        reset_position_ids=False,
+        eod_mask_loss=False,
+        sequence_length=seq_length,
+        num_dataset_builder_threads=1,
+        blend=blend,
+        blend_per_split=blend_per_split,
+        split=split or "99990,8,2",
+        path_to_cache=index_mapping_dir,
+        # Dataloader config parameters
+        data_sharding=True,
+        dataloader_type="single",
+        num_workers=1,
+        persistent_workers=True,
+    )
+
+
+def create_squad_dataset_config(dataset_root: str, seq_length: int, packed: bool = False) -> HFDatasetConfig:
+    """Create SQuAD dataset configuration for Megatron-Bridge using HF dataset."""
+    # Create packed sequence specs if needed
+    packed_sequence_specs = None
+    if packed:
+        packed_sequence_specs = PackedSequenceSpecs(packed_sequence_size=seq_length)
+
+    return HFDatasetConfig(
+        dataset_name="squad",  # Hugging Face dataset name
+        process_example_fn=process_squad_example,  # Processing function
+        dataset_root=dataset_root,  # Local cache/processed files location
+        seq_length=seq_length,
+        seed=1234,
+        memmap_workers=1,
+        # Dataloader config parameters
+        dataloader_type="single",
+        num_workers=2,
+        data_sharding=True,
+        pin_memory=True,
+        persistent_workers=False,
+        packed_sequence_specs=packed_sequence_specs,
+        # HF-specific parameters
+        rewrite=False,  # Rewrite existing processed files
+        delete_raw=False,  # Keep raw HF dataset cache
+    )
+
+
+def apply_args_to_config(config: ConfigContainer, args: argparse.Namespace) -> ConfigContainer:
+    """Apply CLI arguments to ConfigContainer fields."""
+
+    # Training configuration
+    if args.max_steps:
+        config.train.train_iters = args.max_steps
+    if args.gbs:
+        config.train.global_batch_size = args.gbs
+    if args.mbs:
+        config.train.micro_batch_size = args.mbs
+
+    # Model configuration
+    if args.seq_length:
+        config.model.seq_length = args.seq_length
+    if args.tensor_parallel_size:
+        config.model.tensor_model_parallel_size = args.tensor_parallel_size
+    if args.pipeline_parallel_size:
+        config.model.pipeline_model_parallel_size = args.pipeline_parallel_size
+    if args.context_parallel_size:
+        config.model.context_parallel_size = args.context_parallel_size
+
+    # Optimizer configuration
+    if args.lr:
+        config.optimizer.lr = args.lr
+    if args.min_lr:
+        config.optimizer.min_lr = args.min_lr
+
+    # Scheduler configuration
+    if args.warmup_iters:
+        config.scheduler.lr_warmup_iters = args.warmup_iters
+
+    # PEFT configuration
+    if args.finetune:
+        if args.peft_scheme == "lora":
+            config.peft = LoRA()
+        elif args.peft_scheme == "dora":
+            config.peft = DoRA()
+        else:
+            raise ValueError(f"Unknown PEFT scheme: {args.peft_scheme}")
+
+    # Checkpoint configuration
+    if args.pretrained_checkpoint:
+        config.checkpoint.pretrained_checkpoint = args.pretrained_checkpoint
+    if args.save_dir:
+        config.checkpoint.save = args.save_dir
+    if args.save_interval:
+        config.checkpoint.save_interval = args.save_interval
+
+    # Dataset configuration
+    logging.info(f"Configuring dataset: type={args.data}")
+
+    # Create dataset configuration based on type
+    if args.data == "mock":
+        config.dataset = create_mock_dataset_config(seq_length=args.seq_length or 8192)
+    elif args.data == "rp2":
+        if not args.dataset_paths or not args.index_mapping_dir:
+            raise ValueError("--dataset-paths and --index-mapping-dir are required for rp2 dataset")
+        config.dataset = create_rp2_dataset_config(
+            dataset_paths=args.dataset_paths,
+            seq_length=args.seq_length or 8192,
+            index_mapping_dir=args.index_mapping_dir,
+        )
+    elif args.data == "squad":
+        if not args.dataset_root:
+            raise ValueError("--dataset-root is required for squad dataset")
+        config.dataset = create_squad_dataset_config(
+            dataset_root=args.dataset_root, seq_length=args.seq_length or 8192, packed=False
+        )
+    elif args.data == "squad_packed":
+        if not args.dataset_root:
+            raise ValueError("--dataset-root is required for squad_packed dataset")
+        config.dataset = create_squad_dataset_config(
+            dataset_root=args.dataset_root, seq_length=args.seq_length or 8192, packed=True
+        )
+    else:
+        raise ValueError(f"Unknown dataset type: {args.data}")
+
+    # Apply training batch sizes
+    config.train.global_batch_size = args.gbs
+    config.train.micro_batch_size = args.mbs
+
+    # Tokenizer configuration
+    if args.tokenizer_type == "NullTokenizer":
+        config.tokenizer = TokenizerConfig(tokenizer_type="NullTokenizer", vocab_size=args.vocab_size)
+    elif args.tokenizer_type == "HuggingFaceTokenizer":
+        if not args.tokenizer_model:
+            raise ValueError("--tokenizer-model is required when using HuggingFaceTokenizer")
+        tokenizer_model = args.tokenizer_model
+        config.tokenizer = TokenizerConfig(tokenizer_type="HuggingFaceTokenizer", tokenizer_model=tokenizer_model)
+    elif args.tokenizer_type == "SentencePieceTokenizer":
+        if not args.tokenizer_model:
+            raise ValueError("--tokenizer-model is required for SentencePieceTokenizer")
+        config.tokenizer = TokenizerConfig(
+            tokenizer_type="SentencePieceTokenizer", tokenizer_model=args.tokenizer_model
+        )
+
+    config.logger.timing_log_level = 1
+    config.logger.log_timers_to_tensorboard = True
+
+    # WandB configuration
+    if args.wandb_project:
+        config.logger.wandb_project = args.wandb_project
+    if args.wandb_entity:
+        config.logger.wandb_entity = args.wandb_entity
+    if args.wandb_exp_name:
+        config.logger.wandb_exp_name = args.wandb_exp_name
+    if args.wandb_save_dir:
+        config.logger.wandb_save_dir = args.wandb_save_dir
+
+    # Handle convergence mode configuration
+    if args.convergence:
+        config.logger.log_interval = 1
+
+        # Checkpoint configuration for convergence
+        if args.max_steps <= 100:
+            # Short convergence runs - save at the end
+            config.checkpoint.save_interval = args.max_steps
+        else:
+            # Long convergence runs - save every 1000 steps
+            config.checkpoint.save_interval = 1000
+
+        # Validation configuration for convergence
+        if args.max_steps <= 100:
+            config.train.eval_interval = args.max_steps
+        else:
+            config.train.eval_interval = 800
+
+        # Scheduler warmup for convergence
+        config.scheduler.lr_warmup_iters = int(0.01 * args.max_steps)
+
+    # Profiling configuration
+    if args.nsys or args.mem:
+        config.profiling = ProfilingConfig(
+            use_nsys_profiler=args.nsys,
+            record_memory_history=args.mem,
+            profile_step_start=10,
+            profile_step_end=min(12, args.max_steps),
+        )
+
+    return config
+
+
+def main():
+    """Main entry point for the training script."""
+    parser = argparse.ArgumentParser(description="Megatron-Bridge Recipe Training Script")
+
+    # Model specification
+    parser.add_argument("--model-family", required=True, help="Model family (e.g., llama)")
+    parser.add_argument("--recipe-name", required=True, help="Recipe name (e.g., pretrain_llama3_8b)")
+    parser.add_argument("--exp-name", required=True, help="Experiment name for logging and checkpoints")
+
+    # Training modes
+    parser.add_argument("--pretrain", action="store_true", help="Run pretraining")
+    parser.add_argument("--finetune", action="store_true", help="Run finetuning")
+
+    # Training configuration
+    parser.add_argument("--max-steps", type=int, default=100, help="Number of training steps")
+    parser.add_argument("--gbs", type=int, default=8, help="Global batch size")
+    parser.add_argument("--mbs", type=int, default=1, help="Micro batch size")
+    parser.add_argument("--seq-length", type=int, help="Sequence length")
+
+    # PEFT configuration
+    parser.add_argument("--peft-scheme", type=str, default="lora", help="PEFT scheme")
+
+    # Parallelism
+    parser.add_argument("--tensor-parallel-size", type=int, default=1, help="Tensor parallel size")
+    parser.add_argument("--pipeline-parallel-size", type=int, default=1, help="Pipeline parallel size")
+    parser.add_argument("--context-parallel-size", type=int, default=1, help="Context parallel size")
+
+    # Optimization
+    parser.add_argument("--lr", type=float, help="Learning rate")
+    parser.add_argument("--min-lr", type=float, help="Minimum learning rate")
+    parser.add_argument("--warmup-iters", type=int, help="Warmup iterations")
+
+    # Checkpointing
+    parser.add_argument("--pretrained-checkpoint", type=str, help="Path to pretrained checkpoint")
+    parser.add_argument("--save-dir", type=str, help="Directory to save checkpoints")
+    parser.add_argument("--save-interval", type=int, help="Number of iterations between checkpoint saves")
+
+    # Data
+    parser.add_argument(
+        "--data",
+        type=str,
+        default="mock",
+        choices=["mock", "rp2", "squad", "squad_packed"],
+        help="Dataset type to use",
+    )
+    parser.add_argument("--dataset-paths", nargs="*", help="Dataset paths (for rp2 dataset)")
+    parser.add_argument("--dataset-root", type=str, help="Dataset root directory (for squad datasets)")
+    parser.add_argument("--index-mapping-dir", type=str, help="Index mapping directory (for rp2 dataset)")
+    parser.add_argument("--dataset-name", type=str, help="Dataset name (deprecated)")
+    parser.add_argument("--packed-sequence", action="store_true", help="Use packed sequences")
+    parser.add_argument("--head-only", action="store_true", help="Use only head data (for rp2 dataset)")
+
+    # Tokenizer configuration
+    parser.add_argument(
+        "--tokenizer-type",
+        type=str,
+        default="SentencePieceTokenizer",
+        choices=["NullTokenizer", "HuggingFaceTokenizer", "SentencePieceTokenizer"],
+        help="Type of tokenizer to use",
+    )
+    parser.add_argument(
+        "--tokenizer-model", type=str, help="Path to tokenizer model (automatically provided by launcher)"
+    )
+    parser.add_argument("--vocab-size", type=int, default=32000, help="Vocabulary size for NullTokenizer")
+
+    # Debugging and profiling
+    parser.add_argument("--convergence", action="store_true", help="Enable convergence run", default=False)
+    parser.add_argument("--nsys", action="store_true", help="Enable nsys profiling", default=False)
+    parser.add_argument("--mem", action="store_true", help="Enable torch memory profiling", default=False)
+
+    # WandB configuration
+    parser.add_argument("--wandb-project", type=str, help="WandB project name")
+    parser.add_argument("--wandb-entity", type=str, help="WandB entity name")
+    parser.add_argument("--wandb-exp-name", type=str, help="WandB experiment name")
+    parser.add_argument("--wandb-save-dir", type=str, help="Directory to save WandB logs locally")
+
+    # Parse known args and capture unknown ones for config overrides
+    args, unknown_args = parser.parse_known_args()
+
+    # Parse plugin config overrides from unknown arguments
+    plugin_config_overrides = parse_plugin_config_overrides(unknown_args)
+
+    # Import recipe dynamically
+    recipe_module_path = f"megatron.bridge.recipes.{args.model_family}.{args.recipe_name}"
+    logging.info(f"Loading recipe module path: {recipe_module_path}")
+    recipe_module = importlib.import_module(recipe_module_path)
+
+    # Get base configuration from recipe based on training mode
+    if args.pretrain:
+        if not hasattr(recipe_module, "pretrain_config"):
+            raise ValueError(f"Recipe {recipe_module_path} must have 'pretrain_config' function for pretraining")
+        base_config = recipe_module.pretrain_config(dir="/nemo_run/", name=args.exp_name)
+    elif args.finetune:
+        if not hasattr(recipe_module, "finetune_config"):
+            raise ValueError(f"Recipe {recipe_module_path} must have 'finetune_config' function for finetuning")
+        base_config = recipe_module.finetune_config(dir="/nemo_run/", name=args.exp_name)
+    else:
+        raise ValueError("Must specify either --pretrain or --finetune")
+
+    # Apply plugin config overrides first (lower priority)
+    if plugin_config_overrides:
+        omega_conf, excluded_fields = create_omegaconf_dict_config(base_config)
+        updated_conf = parse_hydra_overrides(omega_conf, plugin_config_overrides)
+        apply_overrides(base_config, updated_conf, excluded_fields)
+
+    # Apply CLI arguments to config (higher priority - overrides plugin settings)
+    final_config = apply_args_to_config(base_config, args)
+
+    # Log final configuration
+    logging.info("Final configuration:")
+    final_config.to_yaml()
+
+    if args.pretrain:
+        logging.info("Starting pretraining")
+        pretrain(config=final_config, forward_step_func=forward_step)
+    elif args.finetune:
+        logging.info("Starting finetuning")
+        finetune(config=final_config, forward_step_func=forward_step)
+    else:
+        raise ValueError("Must specify either --pretrain or --finetune")
+
+    if torch.distributed.is_initialized():
+        torch.distributed.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/end_to_end_tests/train_from_recipe.py
+++ b/tests/end_to_end_tests/train_from_recipe.py
@@ -1,4 +1,17 @@
 #!/usr/bin/env python3
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """
 Training script for Megatron-Bridge recipes.
 This script runs inside the container and handles the actual training execution.


### PR DESCRIPTION
Provide a generic script for training, intended to be used by internal CI systems. Including this in the repo means it will be part of the container build by default. otherwise, the CI system would need to mount this script or build a separate dev container to include the testing script. 

This is not intended to be a generic API for external users to call, which is why it's under the `tests/` directory and not `examples/`