### PR TITLE
Remove `__call__` from AutoBridge

### DIFF
--- a/src/megatron/bridge/models/conversion/auto_bridge.py
+++ b/src/megatron/bridge/models/conversion/auto_bridge.py
@@ -261,14 +261,6 @@ class AutoBridge(Generic[MegatronModelT]):
         except Exception:
             return False
 
-    def __call__(
-        self,
-        model: list[MegatronModelT],
-        cpu: bool = False,
-        show_progress: bool = True,
-    ) -> Iterable["HFWeightTuple"]:
-        return self.export_hf_weights(model=model, cpu=cpu, show_progress=show_progress)
-
     def load_hf_weights(self, model: list[MegatronModelT], hf_path: str | Path | None = None) -> None:
         """
         Load HuggingFace weights into a Megatron model.


### PR DESCRIPTION
this API is carryover from merging the CausalLM bridge into the AutoBridge. however, it's not obvious at all that `__call__` should export to HF weights, so I'm removing this API to avoid confusion for users.