### PR TITLE
Fix comm overlap handling if tp overlap config not set

### DIFF
--- a/src/megatron/bridge/training/comm_overlap.py
+++ b/src/megatron/bridge/training/comm_overlap.py
@@ -553,7 +553,12 @@ class CommOverlapConfig:
                 )
                 model_config.tp_comm_overlap_cfg = None
             else:
+                # ub_cfgs is a dataclass, however TE needs a dict, so convert here
                 model_config.tp_comm_overlap_cfg = asdict(comm_overlap_cfg.tp_comm_overlap_cfg)
+                # remove keys with None values from dictionary to match TE's expectations
+                model_config.tp_comm_overlap_cfg = {
+                    key: value for key, value in model_config.tp_comm_overlap_cfg.items() if value is not None
+                }
             model_config.tp_comm_bootstrap_backend = comm_overlap_cfg.tp_comm_bootstrap_backend
 
         # Data parallel overlap is only available with the Megatron DDP and Distributed optimizer

--- a/tests/unit_tests/training/test_comm_overlap.py
+++ b/tests/unit_tests/training/test_comm_overlap.py
@@ -448,6 +448,10 @@ class TestMegatronCommOverlapConfig:
         assert "qkv_dgrad" in model_cfg.tp_comm_overlap_cfg
         assert "proj_fprop" in model_cfg.tp_comm_overlap_cfg
 
+        # Check that None values were filtered out (TE expectation)
+        for key, value in model_cfg.tp_comm_overlap_cfg.items():
+            assert value is not None, f"Found None value for key '{key}' - should have been filtered out"
+
     @patch("megatron.bridge.training.comm_overlap.HAVE_TE", True)
     def test_tp_overlap_with_no_config_provided(self):
         """Test that TP overlap handles the case when no tp_comm_overlap_cfg is provided."""
@@ -478,3 +482,47 @@ class TestMegatronCommOverlapConfig:
         assert model_cfg.tp_comm_overlap is True
         assert model_cfg.tp_comm_overlap_cfg is None
         assert model_cfg.tp_comm_bootstrap_backend is None
+
+    @patch("megatron.bridge.training.comm_overlap.HAVE_TE", True)
+    def test_tp_overlap_config_filters_none_values(self):
+        """Test that None values are filtered from tp_comm_overlap_cfg dict."""
+        from dataclasses import dataclass
+
+        # Create a mock config with some None values
+        @dataclass
+        class MockTPOverlapCfg:
+            qkv_dgrad: str = "qkv_dgrad"
+            proj_fprop: str = "proj_fprop"
+            none_field1: str = None
+            valid_field: str = "valid"
+            none_field2: int = None
+
+        mock_tp_cfg = MockTPOverlapCfg()
+        comm_cfg = CommOverlapConfig(tp_comm_overlap=True, tp_comm_overlap_cfg=mock_tp_cfg, data_parallel_size=1)
+
+        model_cfg = create_gpt_config(
+            tensor_model_parallel_size=4,
+            pipeline_model_parallel_size=1,
+            sequence_parallel=True,
+            num_attention_heads=16,
+        )
+
+        optimizer_cfg = OptimizerConfig()
+        ddp_cfg = DistributedDataParallelConfig(use_distributed_optimizer=False)
+
+        with patch("torch.cuda.get_device_capability", return_value=(9, 0)):
+            comm_cfg.setup(model_cfg, optimizer_cfg, ddp_cfg)
+
+        # Check that config was converted to dict and None values filtered
+        assert isinstance(model_cfg.tp_comm_overlap_cfg, dict)
+        expected_keys = {"qkv_dgrad", "proj_fprop", "valid_field"}
+        filtered_keys = {"none_field1", "none_field2"}
+
+        # Check that valid keys are present
+        for key in expected_keys:
+            assert key in model_cfg.tp_comm_overlap_cfg
+            assert model_cfg.tp_comm_overlap_cfg[key] is not None
+
+        # Check that None value keys are filtered out
+        for key in filtered_keys:
+            assert key not in model_cfg.tp_comm_overlap_cfg


### PR DESCRIPTION
Found when testing nemotronh 8b recipes: https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/678ff84e288c1a883f73bd4178034c9d27ea9a21/src/megatron/bridge/recipes/mamba/nemotronh_8b.py#L213-L216

though the config is replicated from [nemo2](https://github.com/NVIDIA/NeMo/blob/dcd27ffbaa2ba60e93b8e682e8b033e2382c07c1/nemo/collections/llm/recipes/nemotronh_8b.py#L153-L157), the mbridge run fails with this error:
```
 Traceback (most recent call last):
   File "/opt/Megatron-Bridge/src/megatron/bridge/training/setup.py", line 121, in setup
     cfg.comm_overlap.setup(cfg.model, cfg.optimizer, cfg.ddp)
   File "/opt/Megatron-Bridge/src/megatron/bridge/training/comm_overlap.py", line 549, in setup
     model_config.tp_comm_overlap_cfg = asdict(comm_overlap_cfg.tp_comm_overlap_cfg)
                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   File "/usr/lib/python3.12/dataclasses.py", line 1321, in asdict
     raise TypeError("asdict() should be called on dataclass instances")
 TypeError: asdict() should be called on dataclass instances
```

we were missing the fallback logic here: https://github.com/NVIDIA/NeMo/blob/dcd27ffbaa2ba60e93b8e682e8b033e2382c07c1/nemo/lightning/pytorch/callbacks/megatron_comm_overlap.py#L293-L304