### PR TITLE
fix: Update llama 3.18b default model sequence length

### DIFF
--- a/src/megatron/bridge/recipes/llama/llama31_8b.py
+++ b/src/megatron/bridge/recipes/llama/llama31_8b.py
@@ -90,6 +90,7 @@ def pretrain_config(
     sequence_parallelism: bool = False,
     # Training hyperparameters
     train_iters: int = 1_168_251,
+    seq_length: int = 8192,
     global_batch_size: int = 512,
     micro_batch_size: int = 1,
     lr: float = 3e-4,
@@ -119,6 +120,7 @@ def pretrain_config(
         context_parallelism (int): Degree of context parallelism to be passed to model_config.
         sequence_parallelism (bool): Whether to use sequence parallelism.
         train_iters (int): Total number of training iterations.
+        seq_length (int): Sequence length for training.
         global_batch_size (int): Global batch size for training.
         micro_batch_size (int): Micro batch size for training.
         lr (float): Learning rate.
@@ -147,6 +149,7 @@ def pretrain_config(
         context_parallelism=context_parallelism,
         sequence_parallelism=sequence_parallelism,
     )
+    model_cfg.seq_length = seq_length
 
     opt_config, scheduler = distributed_fused_adam_with_cosine_annealing(
         lr_warmup_iters=lr_warmup_iters,
@@ -183,7 +186,7 @@ def pretrain_config(
             reset_attention_mask=False,
             reset_position_ids=False,
             eod_mask_loss=False,
-            sequence_length=8192,
+            sequence_length=seq_length,
             num_dataset_builder_threads=1,
             blend=blend,
             blend_per_split=blend_per_split,

--- a/tests/unit_tests/recipes/llama/test_llama31_8b.py
+++ b/tests/unit_tests/recipes/llama/test_llama31_8b.py
@@ -130,6 +130,7 @@ class TestPretrainConfig:
 
         # Check dataset configuration (should be in mock mode)
         assert config.dataset.sequence_length == 8192
+        assert config.model.seq_length == 8192
         assert config.dataset.split == "1,1,1"
         assert config.dataset.blend is None
         assert config.dataset.blend_per_split is None


### PR DESCRIPTION
- add seq_length as argument to pretrain config and default to 8192
- ensure model + mock dataset config use the same seq length