### PR TITLE
Add Qwen3 480B-A35B model provider and pretraining recipe

### DIFF
--- a/src/megatron/bridge/models/qwen/__init__.py
+++ b/src/megatron/bridge/models/qwen/__init__.py
@@ -31,6 +31,7 @@ from megatron.bridge.models.qwen.qwen_provider import (
     Qwen3MoEModelProvider,
     Qwen3MoEModelProvider30B_A3B,
     Qwen3MoEModelProvider235B_A22B,
+    Qwen3MoEModelProvider480B_A35B,
     Qwen25ModelProvider1P5B,
     Qwen25ModelProvider3B,
     Qwen25ModelProvider7B,
@@ -64,4 +65,5 @@ __all__ = [
     "Qwen3MoEModelProvider",
     "Qwen3MoEModelProvider30B_A3B",
     "Qwen3MoEModelProvider235B_A22B",
+    "Qwen3MoEModelProvider480B_A35B",
 ]

--- a/src/megatron/bridge/models/qwen/qwen_provider.py
+++ b/src/megatron/bridge/models/qwen/qwen_provider.py
@@ -401,3 +401,18 @@ class Qwen3MoEModelProvider235B_A22B(Qwen3MoEModelProvider):
     num_query_groups: int = 4
     ffn_hidden_size: int = 12288
     moe_ffn_hidden_size: int = 1536
+
+
+@dataclass
+class Qwen3MoEModelProvider480B_A35B(Qwen3MoEModelProvider):
+    """
+    Provider for Qwen 3 480B-A35B: https://huggingface.co/Qwen/Qwen3-480B-A35B-Instruct
+    """
+
+    num_layers: int = 62
+    hidden_size: int = 6144
+    num_attention_heads: int = 96
+    num_query_groups: int = 8
+    ffn_hidden_size: int = 8192
+    moe_ffn_hidden_size: int = 2560
+    num_moe_experts: int = 160

--- a/src/megatron/bridge/models/qwen/qwen_provider.py
+++ b/src/megatron/bridge/models/qwen/qwen_provider.py
@@ -406,7 +406,7 @@ class Qwen3MoEModelProvider235B_A22B(Qwen3MoEModelProvider):
 @dataclass
 class Qwen3MoEModelProvider480B_A35B(Qwen3MoEModelProvider):
     """
-    Provider for Qwen 3 480B-A35B: https://huggingface.co/Qwen/Qwen3-480B-A35B-Instruct
+    Provider for Qwen 3 480B-A35B: https://huggingface.co/Qwen/Qwen3-Coder-480B-A35B-Instruct
     """
 
     num_layers: int = 62

--- a/src/megatron/bridge/recipes/qwen/qwen3_480b_a35b.py
+++ b/src/megatron/bridge/recipes/qwen/qwen3_480b_a35b.py
@@ -1,0 +1,222 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from typing import List, Optional, Union
+
+import torch
+from megatron.core.distributed import DistributedDataParallelConfig
+
+from megatron.bridge.models.qwen import Qwen3MoEModelProvider480B_A35B
+from megatron.bridge.recipes.utils.dataset_utils import get_blend_fields_from_data_paths
+from megatron.bridge.recipes.utils.optimizer_utils import distributed_fused_adam_with_cosine_annealing
+from megatron.bridge.training.comm_overlap import CommOverlapConfig
+from megatron.bridge.training.config import (
+    CheckpointConfig,
+    ConfigContainer,
+    GPTDatasetConfig,
+    LoggerConfig,
+    RNGConfig,
+    TokenizerConfig,
+    TrainingConfig,
+)
+from megatron.bridge.training.mixed_precision import MixedPrecisionConfig
+
+
+def model_config(
+    tensor_parallelism: int = 4,
+    pipeline_parallelism: int = 32,
+    pipeline_parallelism_dtype: Optional[torch.dtype] = torch.bfloat16,
+    virtual_pipeline_parallelism: Optional[int] = None,
+    context_parallelism: int = 2,
+    expert_parallelism: Optional[int] = 8,
+    sequence_parallelism: bool = True,
+) -> Qwen3MoEModelProvider480B_A35B:
+    """
+    Configure the Qwen3 480B-A35B MoE model.
+
+    Args:
+        tensor_parallelism (int): Degree of tensor model parallelism.
+        pipeline_parallelism (int): Degree of pipeline model parallelism.
+        pipeline_parallelism_dtype (Optional[torch.dtype]): Data type for pipeline parallelism.
+        virtual_pipeline_parallelism (Optional[int]): Size of virtual pipeline parallelism.
+        context_parallelism (int): Degree of context parallelism.
+        expert_parallelism (Optional[int]): Degree of expert parallelism for MoE.
+        sequence_parallelism (bool): Whether to use sequence parallelism.
+
+    Returns:
+        Qwen3MoEModelProvider235B_A22B: Configuration for the Qwen3 235B-A22B MoE model.
+    """
+    model_cfg = Qwen3MoEModelProvider480B_A35B(
+        tensor_model_parallel_size=tensor_parallelism,
+        pipeline_model_parallel_size=pipeline_parallelism,
+        pipeline_dtype=pipeline_parallelism_dtype,
+        virtual_pipeline_model_parallel_size=virtual_pipeline_parallelism,
+        context_parallel_size=context_parallelism,
+        expert_model_parallel_size=expert_parallelism,
+        sequence_parallel=sequence_parallelism,
+        account_for_embedding_in_pipeline_split=True,
+        account_for_loss_in_pipeline_split=True,
+    )
+
+    return model_cfg
+
+
+def pretrain_config(
+    dir: Optional[str] = None,
+    name: str = "default",
+    # Dataset configuration
+    data_paths: Optional[List[str]] = None,
+    data_args_path: Optional[str] = None,
+    train_data_path: Optional[List[str]] = None,
+    valid_data_path: Optional[List[str]] = None,
+    test_data_path: Optional[List[str]] = None,
+    per_split_data_args_path: Optional[str] = None,
+    mock: bool = False,
+    # Model configuration
+    tensor_parallelism: int = 4,
+    pipeline_parallelism: int = 32,
+    pipeline_parallelism_dtype: Optional[torch.dtype] = torch.bfloat16,
+    virtual_pipeline_parallelism: Optional[int] = None,
+    context_parallelism: int = 2,
+    expert_parallelism: Optional[int] = 8,
+    sequence_parallelism: bool = True,
+    # Training hyperparameters
+    train_iters: int = 300000,
+    global_batch_size: int = 32,
+    micro_batch_size: int = 1,  # Reduced for very large model
+    seq_length: int = 4096,
+    lr: float = 3e-4,
+    min_lr: float = 3e-5,
+    lr_warmup_iters: int = 500,
+    # Precision recipe
+    precision_config: Optional[Union[MixedPrecisionConfig, str]] = "bf16_mixed",
+    comm_overlap_config: Optional[CommOverlapConfig] = None,
+) -> ConfigContainer:
+    """
+    Create a pre-training configuration for Qwen3 235B-A22B MoE model. The default configuration is for 16 nodes with 8 GPUs per node.
+
+    Args:
+        dir (Optional[str]): Base directory for saving logs and checkpoints.
+        name (str): Name of the pre-training run.
+        data_paths (Optional[List[str]]): List of paths to dataset files. If None, mock data will be used.
+        data_args_path (Optional[str]): Path to file containing data arguments.
+        train_data_path (Optional[List[str]]): List of training data paths.
+        valid_data_path (Optional[List[str]]): List of validation data paths.
+        test_data_path (Optional[List[str]]): List of test data paths.
+        per_split_data_args_path (Optional[str]): Path to JSON file with per-split data configuration.
+        mock (bool): Whether to use mock data. If True, ignores data_paths.
+        tensor_parallelism (int): Degree of tensor model parallelism.
+        pipeline_parallelism (int): Degree of pipeline model parallelism.
+        pipeline_parallelism_dtype (Optional[torch.dtype]): Data type for pipeline parallelism.
+        virtual_pipeline_parallelism (Optional[int]): Size of virtual pipeline parallelism.
+        context_parallelism (int): Degree of context parallelism to be passed to model_config.
+        expert_parallelism (Optional[int]): Degree of expert parallelism for MoE.
+        sequence_parallelism (bool): Whether to use sequence parallelism.
+        train_iters (int): Total number of training iterations.
+        global_batch_size (int): Global batch size for training.
+        micro_batch_size (int): Micro batch size for training.
+        seq_length (int): Sequence length for training data.
+        lr (float): Learning rate.
+        min_lr (float): Minimum learning rate for cosine decay.
+        lr_warmup_iters (int): Number of warmup iterations for the learning rate.
+        precision_config (Optional[Union[MixedPrecisionConfig, str]]): Precision configuration for the model.
+
+    Returns:
+        ConfigContainer: Configuration for pre-training.
+    """
+    base_output_dir = dir if dir is not None else os.path.join(os.getcwd(), "nemo_experiments")
+    run_output_dir = os.path.join(base_output_dir, name)
+    checkpoint_dir = os.path.join(run_output_dir, "checkpoints")
+    tensorboard_dir = os.path.join(run_output_dir, "tb_logs")
+
+    blend, blend_per_split, split = get_blend_fields_from_data_paths(
+        data_paths, data_args_path, train_data_path, valid_data_path, test_data_path, per_split_data_args_path, mock
+    )
+
+    model_cfg = model_config(
+        tensor_parallelism=tensor_parallelism,
+        pipeline_parallelism=pipeline_parallelism,
+        pipeline_parallelism_dtype=pipeline_parallelism_dtype,
+        virtual_pipeline_parallelism=virtual_pipeline_parallelism,
+        context_parallelism=context_parallelism,
+        expert_parallelism=expert_parallelism,
+        sequence_parallelism=sequence_parallelism,
+    )
+    model_cfg.seq_length = seq_length
+
+    opt_config, scheduler = distributed_fused_adam_with_cosine_annealing(
+        lr_warmup_iters=lr_warmup_iters,
+        lr_decay_iters=train_iters,
+        max_lr=lr,
+        min_lr=min_lr,
+    )
+
+    # Config Container
+    cfg = ConfigContainer(
+        model=model_cfg,
+        train=TrainingConfig(
+            train_iters=train_iters,
+            eval_interval=500,
+            eval_iters=32,
+            global_batch_size=global_batch_size,
+            micro_batch_size=micro_batch_size,
+            manual_gc=True,
+            manual_gc_interval=100,
+            manual_gc_eval=100,
+        ),
+        optimizer=opt_config,
+        scheduler=scheduler,
+        ddp=DistributedDataParallelConfig(
+            check_for_nan_in_grad=True,
+            grad_reduce_in_fp32=True,
+            overlap_grad_reduce=True,
+            overlap_param_gather=True,
+            average_in_collective=True,  # Not supported for custom FSDP for now, need to be set to False if using FSDP
+            data_parallel_sharding_strategy="optim_grads_params",  # For custom FSDP only
+            use_distributed_optimizer=True,
+        ),
+        dataset=GPTDatasetConfig(
+            random_seed=1234,
+            reset_attention_mask=False,
+            reset_position_ids=False,
+            eod_mask_loss=False,
+            sequence_length=seq_length,
+            num_dataset_builder_threads=1,
+            blend=blend,
+            blend_per_split=blend_per_split,
+            split=split,
+            # Dataloader config parameters
+            data_sharding=True,
+            dataloader_type="single",
+        ),
+        logger=LoggerConfig(
+            log_interval=10,
+            tensorboard_dir=tensorboard_dir,
+            log_timers_to_tensorboard=True,
+        ),
+        tokenizer=TokenizerConfig(tokenizer_type="HuggingFaceTokenizer", tokenizer_model="Qwen/Qwen3-235B-A22B"),
+        checkpoint=CheckpointConfig(
+            save_interval=500,
+            save=checkpoint_dir,
+            load=checkpoint_dir,
+            ckpt_format="torch_dist",
+            fully_parallel_save=True,
+        ),
+        rng=RNGConfig(seed=1234),
+        comm_overlap=comm_overlap_config,
+        mixed_precision=precision_config,
+    )
+
+    return cfg


### PR DESCRIPTION
- Introduced Qwen3MoEModelProvider480B_A35B class for the new model.
- Updated __init__.py to include the new model provider in the exports.
- Created a new pretraining recipe for Qwen3 480B-A35B, including configuration for training parameters and dataset handling.