### PR TITLE
Update import checks for nvrx straggler detection

### DIFF
--- a/src/megatron/bridge/training/nvrx_straggler.py
+++ b/src/megatron/bridge/training/nvrx_straggler.py
@@ -23,11 +23,18 @@ from megatron.bridge.utils.import_utils import MISSING_NVRX_MSG
 
 
 try:
-    import nvidia_resiliency_ext.straggler as straggler
+    # Try the newer version first (nvidia-resiliency-ext >= 0.4)
+    import nvidia_resiliency_ext.attribution.straggler as straggler
 
     HAVE_NVRX = True
 except (ImportError, ModuleNotFoundError):
-    HAVE_NVRX = False
+    try:
+        # Fall back to the older version (nvidia-resiliency-ext < 0.4)
+        import nvidia_resiliency_ext.straggler as straggler
+
+        HAVE_NVRX = True
+    except (ImportError, ModuleNotFoundError):
+        HAVE_NVRX = False
 
 
 class NVRxStragglerDetectionManager:

--- a/tests/unit_tests/training/test_nvrx_straggler.py
+++ b/tests/unit_tests/training/test_nvrx_straggler.py
@@ -32,7 +32,12 @@ def mock_nvidia_resiliency_ext():
     """
     # Store original state
     original_modules = {}
-    modules_to_mock = ["nvidia_resiliency_ext", "nvidia_resiliency_ext.straggler"]
+    modules_to_mock = [
+        "nvidia_resiliency_ext",
+        "nvidia_resiliency_ext.attribution",
+        "nvidia_resiliency_ext.attribution.straggler",
+        "nvidia_resiliency_ext.straggler",
+    ]
 
     for module in modules_to_mock:
         if module in sys.modules:
@@ -40,10 +45,17 @@ def mock_nvidia_resiliency_ext():
 
     # Mock the modules
     mock_module = MagicMock()
+    mock_attribution = MagicMock()
     mock_straggler = MagicMock()
+
+    # Set up the hierarchy: nvidia_resiliency_ext -> attribution -> straggler
+    mock_attribution.straggler = mock_straggler
+    mock_module.attribution = mock_attribution
     mock_module.straggler = mock_straggler
 
     sys.modules["nvidia_resiliency_ext"] = mock_module
+    sys.modules["nvidia_resiliency_ext.attribution"] = mock_attribution
+    sys.modules["nvidia_resiliency_ext.attribution.straggler"] = mock_straggler
     sys.modules["nvidia_resiliency_ext.straggler"] = mock_straggler
 
     yield mock_module


### PR DESCRIPTION
Straggler was moved here: https://github.com/NVIDIA/nvidia-resiliency-ext/tree/main/src/nvidia_resiliency_ext/attribution
