### PR TITLE
[sync] mxfp8 reuse grad buf for param all gather sync

### DIFF
--- a/src/megatron/bridge/training/mixed_precision.py
+++ b/src/megatron/bridge/training/mixed_precision.py
@@ -78,6 +78,13 @@ class MixedPrecisionConfig:
         if self.fp8_param is None:
             self.fp8_param = self.fp8_param_gather
 
+        # Validate that mxfp8 recipe requires reuse_grad_buf_for_mxfp8_param_ag=True when fp8_param_gather=True
+        if self.fp8_param_gather and self.fp8_recipe == "mxfp8":
+            assert self.reuse_grad_buf_for_mxfp8_param_ag, (
+                "When fp8_param_gather=True and fp8_recipe='mxfp8', "
+                "reuse_grad_buf_for_mxfp8_param_ag must be set to True"
+            )
+
     def setup(
         self,
         model_config: GPTModelProvider | T5ModelProvider,

--- a/src/megatron/bridge/training/mixed_precision.py
+++ b/src/megatron/bridge/training/mixed_precision.py
@@ -59,6 +59,7 @@ class MixedPrecisionConfig:
     hysteresis: int = 2
     num_layers_at_start_in_bf16: int = 0
     num_layers_at_end_in_bf16: int = 0
+    reuse_grad_buf_for_mxfp8_param_ag: bool = False
 
     def __setattr__(self, name: str, value) -> None:
         # Use object.__setattr__ to avoid recursion
@@ -217,7 +218,8 @@ def bf16_with_mxfp8_mixed() -> MixedPrecisionConfig:
     cfg = bf16_mixed()
     cfg.fp8 = "hybrid"
     cfg.fp8_recipe = "mxfp8"
-    cfg.fp8_param_gather = False
+    cfg.fp8_param_gather = True
+    cfg.reuse_grad_buf_for_mxfp8_param_ag = True
     return cfg
 
 
@@ -231,7 +233,8 @@ def fp16_with_mxfp8_mixed() -> MixedPrecisionConfig:
     cfg = fp16_mixed()
     cfg.fp8 = "hybrid"
     cfg.fp8_recipe = "mxfp8"
-    cfg.fp8_param_gather = False
+    cfg.fp8_param_gather = True
+    cfg.reuse_grad_buf_for_mxfp8_param_ag = True
     return cfg
 
 

--- a/src/megatron/bridge/training/train.py
+++ b/src/megatron/bridge/training/train.py
@@ -489,13 +489,11 @@ def train_step(
         # Optionally inject state into forward step
         wrapped_forward_step = maybe_inject_state(forward_step_func, global_state, num_fw_args=num_fw_args)
 
-        # For the mxfp8_param with reuse_grad_buf_for_mxfp8_param_ag and dp_ag_overlap,
-        # we need to call the _copy_main_params_to_param_buffer() after the grad buffer
-        # is zeroed by zero_grad_buffer() because param and grad buffer are shared.
-        if cfg.optimizer.reuse_grad_buf_for_mxfp8_param_ag and cfg.ddp.overlap_param_gather:
-            for optim_instance in optimizer.chained_optimizers:
-                if isinstance(optim_instance, DistributedOptimizer):
-                    optim_instance._copy_main_params_to_param_buffer()
+        _handle_mxfp8_param_buffer_copy(
+            optimizer=optimizer,
+            reuse_grad_buf_for_mxfp8_param_ag=cfg.optimizer.reuse_grad_buf_for_mxfp8_param_ag,
+            overlap_param_gather=cfg.ddp.overlap_param_gather,
+        )
 
         # Forward pass.
         forward_backward_func = get_forward_backward_func()
@@ -977,3 +975,23 @@ def _finish_train(global_state: GlobalState):
         global_state.wandb_logger.finish()
 
     destroy_global_state()
+
+
+def _handle_mxfp8_param_buffer_copy(
+    optimizer: MegatronOptimizer, reuse_grad_buf_for_mxfp8_param_ag: bool, overlap_param_gather: bool
+) -> None:
+    """Copy main params to param buffer for mxfp8 with grad buffer reuse.
+
+    For mxfp8_param with reuse_grad_buf_for_mxfp8_param_ag and dp_ag_overlap,
+    we need to call _copy_main_params_to_param_buffer() after the grad buffer
+    is zeroed because param and grad buffer are shared.
+
+    Args:
+        optimizer: The MegatronOptimizer instance
+        reuse_grad_buf_for_mxfp8_param_ag: Config flag for grad buffer reuse
+        overlap_param_gather: Config flag for overlapping param gathering
+    """
+    if reuse_grad_buf_for_mxfp8_param_ag and overlap_param_gather:
+        for optim_instance in optimizer.chained_optimizers:
+            if isinstance(optim_instance, DistributedOptimizer):
+                optim_instance._copy_main_params_to_param_buffer()

--- a/tests/unit_tests/training/test_mixed_precision.py
+++ b/tests/unit_tests/training/test_mixed_precision.py
@@ -564,7 +564,7 @@ class TestMixedPrecisionRecipes:
         assert config.fp8_param_gather is True
         assert config.reuse_grad_buf_for_mxfp8_param_ag is True
         # Verify fp8_param is initialized from fp8_param_gather
-        assert config.fp8_param is False
+        assert config.fp8_param is True
 
     def test_fp16_with_mxfp8_mixed(self):
         config = fp16_with_mxfp8_mixed()
@@ -579,7 +579,7 @@ class TestMixedPrecisionRecipes:
         assert config.fp8_param_gather is True
         assert config.reuse_grad_buf_for_mxfp8_param_ag is True
         # Verify fp8_param is initialized from fp8_param_gather
-        assert config.fp8_param is False
+        assert config.fp8_param is True
 
     def test_bf16_with_fp8_current_scaling_mixed(self):
         config = bf16_with_fp8_current_scaling_mixed()

--- a/tests/unit_tests/training/test_mixed_precision.py
+++ b/tests/unit_tests/training/test_mixed_precision.py
@@ -113,6 +113,56 @@ class TestMegatronMixedPrecisionConfig:
         assert config3.fp8_param is True
         assert config3.fp8_param_gather is True
 
+    def test_mxfp8_param_gather_validation(self):
+        """Test that mxfp8 recipe with fp8_param_gather=True requires reuse_grad_buf_for_mxfp8_param_ag=True."""
+        # Valid configuration: fp8_param_gather=True, fp8_recipe="mxfp8", reuse_grad_buf_for_mxfp8_param_ag=True
+        config_valid = MixedPrecisionConfig(
+            fp8_param_gather=True, fp8_recipe="mxfp8", reuse_grad_buf_for_mxfp8_param_ag=True
+        )
+        # Should not raise any assertion error
+        assert config_valid.fp8_param_gather is True
+        assert config_valid.fp8_recipe == "mxfp8"
+        assert config_valid.reuse_grad_buf_for_mxfp8_param_ag is True
+
+        # Invalid configuration: fp8_param_gather=True, fp8_recipe="mxfp8", reuse_grad_buf_for_mxfp8_param_ag=False
+        with pytest.raises(AssertionError, match="When fp8_param_gather=True and fp8_recipe='mxfp8'"):
+            MixedPrecisionConfig(fp8_param_gather=True, fp8_recipe="mxfp8", reuse_grad_buf_for_mxfp8_param_ag=False)
+
+        # Valid configuration: fp8_param_gather=False with mxfp8 recipe (assertion doesn't apply)
+        config_param_gather_false = MixedPrecisionConfig(
+            fp8_param_gather=False, fp8_recipe="mxfp8", reuse_grad_buf_for_mxfp8_param_ag=False
+        )
+        assert config_param_gather_false.fp8_param_gather is False
+        assert config_param_gather_false.fp8_recipe == "mxfp8"
+        assert config_param_gather_false.reuse_grad_buf_for_mxfp8_param_ag is False
+
+        # Valid configuration: fp8_param_gather=True with non-mxfp8 recipe (assertion doesn't apply)
+        config_other_recipe = MixedPrecisionConfig(
+            fp8_param_gather=True, fp8_recipe="delayed", reuse_grad_buf_for_mxfp8_param_ag=False
+        )
+        assert config_other_recipe.fp8_param_gather is True
+        assert config_other_recipe.fp8_recipe == "delayed"
+        assert config_other_recipe.reuse_grad_buf_for_mxfp8_param_ag is False
+
+    def test_mxfp8_validation_after_field_modification(self):
+        """Test that the mxfp8 validation works after modifying fields and re-running __post_init__."""
+        # Start with a valid configuration
+        config = MixedPrecisionConfig(
+            fp8_param_gather=True, fp8_recipe="delayed", reuse_grad_buf_for_mxfp8_param_ag=False
+        )
+
+        # Modify to make it invalid (mxfp8 with reuse_grad_buf_for_mxfp8_param_ag=False)
+        config.fp8_recipe = "mxfp8"
+
+        # Re-running __post_init__ should trigger the assertion
+        with pytest.raises(AssertionError, match="When fp8_param_gather=True and fp8_recipe='mxfp8'"):
+            config.__post_init__()
+
+        # Fix the configuration
+        config.reuse_grad_buf_for_mxfp8_param_ag = True
+        # This should not raise any error
+        config.__post_init__()
+
     def test_fp8_param_matching_fp8_param_gather(self):
         """Test that matching values for fp8_param and fp8_param_gather work correctly."""
         # Both True

--- a/tests/unit_tests/training/test_mixed_precision.py
+++ b/tests/unit_tests/training/test_mixed_precision.py
@@ -511,7 +511,8 @@ class TestMixedPrecisionRecipes:
         # MXFP8 specific settings
         assert config.fp8 == "hybrid"
         assert config.fp8_recipe == "mxfp8"
-        assert config.fp8_param_gather is False
+        assert config.fp8_param_gather is True
+        assert config.reuse_grad_buf_for_mxfp8_param_ag is True
         # Verify fp8_param is initialized from fp8_param_gather
         assert config.fp8_param is False
 
@@ -525,7 +526,8 @@ class TestMixedPrecisionRecipes:
         # MXFP8 specific settings
         assert config.fp8 == "hybrid"
         assert config.fp8_recipe == "mxfp8"
-        assert config.fp8_param_gather is False
+        assert config.fp8_param_gather is True
+        assert config.reuse_grad_buf_for_mxfp8_param_ag is True
         # Verify fp8_param is initialized from fp8_param_gather
         assert config.fp8_param is False
 

--- a/tests/unit_tests/training/test_train.py
+++ b/tests/unit_tests/training/test_train.py
@@ -1,0 +1,128 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for train module utility functions."""
+
+from unittest.mock import Mock
+
+from megatron.core.optimizer.distrib_optimizer import DistributedOptimizer
+
+from megatron.bridge.training.train import _handle_mxfp8_param_buffer_copy
+
+
+class TestMxfp8ParamBufferCopy:
+    """Unit tests for mxfp8 parameter buffer copying functionality."""
+
+    def test_copy_main_params_called_when_both_flags_true(self):
+        """Test that _copy_main_params_to_param_buffer is called when both config flags are True."""
+        mock_distributed_optimizer = Mock(spec=DistributedOptimizer)
+        mock_other_optimizer = Mock()
+
+        mock_megatron_optimizer = Mock()
+        mock_megatron_optimizer.chained_optimizers = [
+            mock_other_optimizer,
+            mock_distributed_optimizer,
+        ]
+
+        _handle_mxfp8_param_buffer_copy(
+            optimizer=mock_megatron_optimizer, reuse_grad_buf_for_mxfp8_param_ag=True, overlap_param_gather=True
+        )
+
+        mock_distributed_optimizer._copy_main_params_to_param_buffer.assert_called_once()
+        assert (
+            not hasattr(mock_other_optimizer, "_copy_main_params_to_param_buffer")
+            or not mock_other_optimizer._copy_main_params_to_param_buffer.called
+        )
+
+    def test_no_copy_when_reuse_grad_buf_false(self):
+        """Test that no copying occurs when reuse_grad_buf_for_mxfp8_param_ag is False."""
+        mock_distributed_optimizer = Mock(spec=DistributedOptimizer)
+        mock_megatron_optimizer = Mock()
+        mock_megatron_optimizer.chained_optimizers = [mock_distributed_optimizer]
+
+        _handle_mxfp8_param_buffer_copy(
+            optimizer=mock_megatron_optimizer, reuse_grad_buf_for_mxfp8_param_ag=False, overlap_param_gather=True
+        )
+        mock_distributed_optimizer._copy_main_params_to_param_buffer.assert_not_called()
+
+    def test_no_copy_when_overlap_param_gather_false(self):
+        """Test that no copying occurs when overlap_param_gather is False."""
+        mock_distributed_optimizer = Mock(spec=DistributedOptimizer)
+        mock_megatron_optimizer = Mock()
+        mock_megatron_optimizer.chained_optimizers = [mock_distributed_optimizer]
+        _handle_mxfp8_param_buffer_copy(
+            optimizer=mock_megatron_optimizer, reuse_grad_buf_for_mxfp8_param_ag=True, overlap_param_gather=False
+        )
+
+        mock_distributed_optimizer._copy_main_params_to_param_buffer.assert_not_called()
+
+    def test_no_copy_when_both_flags_false(self):
+        """Test that no copying occurs when both flags are False."""
+        mock_distributed_optimizer = Mock(spec=DistributedOptimizer)
+        mock_megatron_optimizer = Mock()
+        mock_megatron_optimizer.chained_optimizers = [mock_distributed_optimizer]
+
+        _handle_mxfp8_param_buffer_copy(
+            optimizer=mock_megatron_optimizer, reuse_grad_buf_for_mxfp8_param_ag=False, overlap_param_gather=False
+        )
+
+        mock_distributed_optimizer._copy_main_params_to_param_buffer.assert_not_called()
+
+    def test_handles_multiple_distributed_optimizers(self):
+        """Test that function calls copy on multiple DistributedOptimizers."""
+        mock_distributed_optimizer_1 = Mock(spec=DistributedOptimizer)
+        mock_distributed_optimizer_2 = Mock(spec=DistributedOptimizer)
+        mock_other_optimizer = Mock()
+
+        mock_megatron_optimizer = Mock()
+        mock_megatron_optimizer.chained_optimizers = [
+            mock_other_optimizer,
+            mock_distributed_optimizer_1,
+            mock_distributed_optimizer_2,
+        ]
+
+        _handle_mxfp8_param_buffer_copy(
+            optimizer=mock_megatron_optimizer, reuse_grad_buf_for_mxfp8_param_ag=True, overlap_param_gather=True
+        )
+
+        mock_distributed_optimizer_1._copy_main_params_to_param_buffer.assert_called_once()
+        mock_distributed_optimizer_2._copy_main_params_to_param_buffer.assert_called_once()
+
+    def test_only_calls_on_distributed_optimizers(self):
+        """Test that only DistributedOptimizer instances get the copy call."""
+        mock_distributed_optimizer = Mock(spec=DistributedOptimizer)
+        mock_regular_optimizer = Mock()  # Regular optimizer without _copy_main_params_to_param_buffer
+        mock_different_optimizer = Mock()
+
+        # Add the method to one non-DistributedOptimizer to ensure it's not called
+        mock_different_optimizer._copy_main_params_to_param_buffer = Mock()
+
+        mock_megatron_optimizer = Mock()
+        mock_megatron_optimizer.chained_optimizers = [
+            mock_regular_optimizer,
+            mock_different_optimizer,
+            mock_distributed_optimizer,
+        ]
+
+        _handle_mxfp8_param_buffer_copy(
+            optimizer=mock_megatron_optimizer, reuse_grad_buf_for_mxfp8_param_ag=True, overlap_param_gather=True
+        )
+
+        mock_distributed_optimizer._copy_main_params_to_param_buffer.assert_called_once()
+        mock_different_optimizer._copy_main_params_to_param_buffer.assert_not_called()
+
+        assert (
+            not hasattr(mock_regular_optimizer, "_copy_main_params_to_param_buffer")
+            or not mock_regular_optimizer._copy_main_params_to_param_buffer.called
+        )


### PR DESCRIPTION
Bring changes in from:
- https://github.com/NVIDIA/NeMo/pull/14445
- https://github.com/NVIDIA/Megatron-LM/commit/13fd57a2feb1b29c0083a70b5b7f5ccb53dd19df

the mixed precision `__post_init__` will be called here before training starts:
- https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/fed237de248543d1e206904b89feca5a071d1964/src/megatron/bridge/training/setup.py#L112
- https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/fed237de248543d1e206904b89feca5a071d1964/src/megatron/bridge/training/config.py#L752-L762
