### PR TITLE
fix:  multi-gpu distributed fallback for model provider

### DIFF
--- a/examples/models/list_supported_bridges.py
+++ b/examples/models/list_supported_bridges.py
@@ -42,7 +42,7 @@ def main() -> None:
     print()
     print("🔍 Model Bridge Details:")
     print("   Each model has specific implementation details and configurations.")
-    print("   Check the src/megatron/hub/models/ directory for:")
+    print("   Check the src/megatron/bridge/models/ directory for:")
     print("   • Model-specific bridge implementations")
     print("   • Configuration examples and README files")
     print("   • Weight mapping details")

--- a/src/megatron/bridge/models/model_provider.py
+++ b/src/megatron/bridge/models/model_provider.py
@@ -44,6 +44,7 @@ from megatron.core.transformer.module import Float16Module, MegatronModule
 from megatron.core.utils import get_model_config
 
 from megatron.bridge.models.config import from_hf_pretrained, save_hf_pretrained
+from megatron.bridge.utils.common_utils import get_local_rank_preinit
 from megatron.bridge.utils.instantiate_utils import InstantiationMode
 
 
@@ -143,10 +144,11 @@ class ModelProviderMixin(abc.ABC, Generic[ModelT]):
             raise ValueError("ddp_config is required when wrap_with_ddp is True")
 
         if not torch.distributed.is_initialized():
-            os.environ["RANK"] = "0"
-            os.environ["WORLD_SIZE"] = "1"
-            os.environ["MASTER_ADDR"] = "localhost"
-            os.environ["MASTER_PORT"] = "12355"
+            os.environ["RANK"] = os.environ.get("RANK", "0")
+            os.environ["WORLD_SIZE"] = os.environ.get("WORLD_SIZE", "1")
+            os.environ["MASTER_ADDR"] = os.environ.get("MASTER_ADDR", "localhost")
+            os.environ["MASTER_PORT"] = os.environ.get("MASTER_PORT", "12355")
+            torch.cuda.set_device(get_local_rank_preinit())
             torch.distributed.init_process_group("nccl")
 
         if not parallel_state.is_initialized():
@@ -202,8 +204,8 @@ class ModelProviderMixin(abc.ABC, Generic[ModelT]):
             **model_parallel_kwargs: Additional arguments for `parallel_state.initialize_model_parallel`.
         """
         if not torch.distributed.is_initialized():
-            torch.distributed.init_process_group("nccl")
             torch.cuda.set_device(torch.distributed.get_rank())
+            torch.distributed.init_process_group("nccl")
 
         parallel_state.initialize_model_parallel(
             tensor_model_parallel_size=getattr(self, "tensor_model_parallel_size", 1),

--- a/src/megatron/bridge/models/model_provider.py
+++ b/src/megatron/bridge/models/model_provider.py
@@ -204,7 +204,7 @@ class ModelProviderMixin(abc.ABC, Generic[ModelT]):
             **model_parallel_kwargs: Additional arguments for `parallel_state.initialize_model_parallel`.
         """
         if not torch.distributed.is_initialized():
-            torch.cuda.set_device(torch.distributed.get_rank())
+            torch.cuda.set_device(get_local_rank_preinit())
             torch.distributed.init_process_group("nccl")
 
         parallel_state.initialize_model_parallel(


### PR DESCRIPTION
the bridge/model provider code currently assumes single-device execution if the global process group is not already initialized before creating the model and wrapping the model. the current fallback leads to hangs for the following types of use cases

part of https://github.com/NVIDIA-NeMo/Megatron-Bridge/issues/449

test script:
```
from megatron.bridge import AutoBridge
import torch

def main() -> None:
    bridge = AutoBridge.from_hf_pretrained("meta-llama/Llama-3.1-8B")

    provider = bridge.to_megatron_provider()

    provider.tensor_model_parallel_size = 2
    provider.pipeline_model_parallel_size = 1

    model = provider.provide_distributed_model(wrap_with_ddp=False)
    if torch.distributed.is_initialized():
        torch.distributed.destroy_process_group()


if __name__ == "__main__":
    main()

```

launched with
```
 python -m torch.distributed.run --nproc-per-node 2 debug_conversion.py
```

before: hang
after: model is created
