### PR TITLE
fix: explicitly configure qwen3 moe recipes to set ETP=1

### DIFF
--- a/src/megatron/bridge/recipes/qwen/qwen3_235b_a22b.py
+++ b/src/megatron/bridge/recipes/qwen/qwen3_235b_a22b.py
@@ -65,6 +65,7 @@ def model_config(
         virtual_pipeline_model_parallel_size=virtual_pipeline_parallelism,
         context_parallel_size=context_parallelism,
         expert_model_parallel_size=expert_parallelism,
+        expert_tensor_parallel_size=1,
         sequence_parallel=sequence_parallelism,
         account_for_embedding_in_pipeline_split=True,
         account_for_loss_in_pipeline_split=True,

--- a/src/megatron/bridge/recipes/qwen/qwen3_30b_a3b.py
+++ b/src/megatron/bridge/recipes/qwen/qwen3_30b_a3b.py
@@ -65,6 +65,7 @@ def model_config(
         virtual_pipeline_model_parallel_size=virtual_pipeline_parallelism,
         context_parallel_size=context_parallelism,
         expert_model_parallel_size=expert_parallelism,
+        expert_tensor_parallel_size=1,
         sequence_parallel=sequence_parallelism,
     )
 


### PR DESCRIPTION
match nemo2 default: https://github.com/NVIDIA/NeMo/blob/ddcb75fb0237d0384f5cfbb50414da609662cb07/nemo/collections/llm/recipes/qwen3.py#L133