### PR TITLE
fix: Use `track_moe_metrics` from mcore

### DIFF
--- a/src/megatron/bridge/training/utils/train_utils.py
+++ b/src/megatron/bridge/training/utils/train_utils.py
@@ -23,6 +23,7 @@ from megatron.core import parallel_state
 from megatron.core.num_microbatches_calculator import get_num_microbatches
 from megatron.core.tensor_parallel import param_is_not_tensor_parallel_duplicate
 from megatron.core.transformer.module import MegatronModule
+from megatron.core.transformer.moe.moe_utils import track_moe_metrics
 from megatron.core.transformer.multi_token_prediction import MTPLossLoggingHelper
 from megatron.core.utils import get_data_parallel_group_if_dtensor, to_local_if_dtensor
 
@@ -277,8 +278,9 @@ def training_log(
     """
     timers = global_state.timers
     train_state = global_state.train_state
-    tb_logger = global_state.tensorboard_logger
-    wandb_logger = global_state.wandb_logger
+    iteration = train_state.step
+    writer = global_state.tensorboard_logger
+    wandb_writer = global_state.wandb_logger
     energy_monitor = global_state.energy_monitor
     logger_config = config.logger
     train_config = config.train
@@ -344,15 +346,13 @@ def training_log(
     learning_rate = reduce_max_stat_across_model_parallel_group(learning_rate)
     # Tensorboard values.
     # Timer requires all the ranks to call.
-    if logger_config.log_timers_to_tensorboard and (train_state.step % logger_config.tensorboard_log_interval == 0):
+    if logger_config.log_timers_to_tensorboard and (iteration % logger_config.tensorboard_log_interval == 0):
         reset_in_tb = False if hasattr(timers, "write_to_wandb") else True
-        timers.write(timers_to_log, tb_logger, train_state.step, normalizer=total_iterations, reset=reset_in_tb)
+        timers.write(timers_to_log, writer, iteration, normalizer=total_iterations, reset=reset_in_tb)
         if hasattr(timers, "write_to_wandb"):
-            timers.write_to_wandb(
-                timers_to_log, wandb_logger, train_state.step, normalizer=total_iterations, reset=True
-            )
+            timers.write_to_wandb(timers_to_log, wandb_writer, iteration, normalizer=total_iterations, reset=True)
 
-    if tb_logger and (train_state.step % logger_config.tensorboard_log_interval == 0):
+    if writer and (iteration % logger_config.tensorboard_log_interval == 0):
         if config.profiling:
             if config.profiling.record_memory_history and is_last_rank():
                 snapshot = torch.cuda.memory._snapshot()
@@ -361,85 +361,77 @@ def training_log(
                 with open(config.profiling.memory_snapshot_path, "wb") as f:
                     dump(snapshot, f)
 
-        if wandb_logger:
-            wandb_logger.log({"samples vs steps": global_state.train_state.consumed_train_samples}, train_state.step)
-        tb_logger.add_scalar("learning-rate", learning_rate, train_state.step)
-        tb_logger.add_scalar(
-            "learning-rate vs samples", learning_rate, global_state.train_state.consumed_train_samples
-        )
-        if wandb_logger:
-            wandb_logger.log({"learning-rate": learning_rate}, train_state.step)
+        if wandb_writer:
+            wandb_writer.log({"samples vs steps": global_state.train_state.consumed_train_samples}, iteration)
+        writer.add_scalar("learning-rate", learning_rate, iteration)
+        writer.add_scalar("learning-rate vs samples", learning_rate, global_state.train_state.consumed_train_samples)
+        if wandb_writer:
+            wandb_writer.log({"learning-rate": learning_rate}, iteration)
         if config.optimizer.decoupled_lr is not None:
-            tb_logger.add_scalar("decoupled-learning-rate", decoupled_learning_rate, train_state.step)
+            writer.add_scalar("decoupled-learning-rate", decoupled_learning_rate, iteration)
         if global_state.train_state.skipped_train_samples > 0:
-            tb_logger.add_scalar(
-                "skipped-train-samples", global_state.train_state.skipped_train_samples, train_state.step
-            )
-            if wandb_logger:
-                wandb_logger.log(
-                    {"skipped-train-samples": global_state.train_state.skipped_train_samples}, train_state.step
-                )
-        tb_logger.add_scalar("batch-size", batch_size, train_state.step)
-        tb_logger.add_scalar("batch-size vs samples", batch_size, global_state.train_state.consumed_train_samples)
-        if wandb_logger:
-            wandb_logger.log({"batch-size": batch_size}, train_state.step)
+            writer.add_scalar("skipped-train-samples", global_state.train_state.skipped_train_samples, iteration)
+            if wandb_writer:
+                wandb_writer.log({"skipped-train-samples": global_state.train_state.skipped_train_samples}, iteration)
+        writer.add_scalar("batch-size", batch_size, iteration)
+        writer.add_scalar("batch-size vs samples", batch_size, global_state.train_state.consumed_train_samples)
+        if wandb_writer:
+            wandb_writer.log({"batch-size": batch_size}, iteration)
         for key in loss_dict:
-            tb_logger.add_scalar(key, loss_dict[key], train_state.step)
-            tb_logger.add_scalar(key + " vs samples", loss_dict[key], global_state.train_state.consumed_train_samples)
-            if wandb_logger:
-                wandb_logger.log({key: loss_dict[key]}, train_state.step)
+            writer.add_scalar(key, loss_dict[key], iteration)
+            writer.add_scalar(key + " vs samples", loss_dict[key], global_state.train_state.consumed_train_samples)
+            if wandb_writer:
+                wandb_writer.log({key: loss_dict[key]}, iteration)
         if logger_config.log_loss_scale_to_tensorboard:
-            tb_logger.add_scalar("loss-scale", loss_scale, train_state.step)
-            tb_logger.add_scalar("loss-scale vs samples", loss_scale, global_state.train_state.consumed_train_samples)
-            if wandb_logger:
-                wandb_logger.log({"loss-scale": loss_scale}, train_state.step)
+            writer.add_scalar("loss-scale", loss_scale, iteration)
+            writer.add_scalar("loss-scale vs samples", loss_scale, global_state.train_state.consumed_train_samples)
+            if wandb_writer:
+                wandb_writer.log({"loss-scale": loss_scale}, iteration)
         if logger_config.log_world_size_to_tensorboard:
-            tb_logger.add_scalar("world-size", get_world_size_safe(), train_state.step)
-            tb_logger.add_scalar(
+            writer.add_scalar("world-size", get_world_size_safe(), iteration)
+            writer.add_scalar(
                 "world-size vs samples", get_world_size_safe(), global_state.train_state.consumed_train_samples
             )
-            if wandb_logger:
-                wandb_logger.log({"world-size": get_world_size_safe()}, train_state.step)
+            if wandb_writer:
+                wandb_writer.log({"world-size": get_world_size_safe()}, iteration)
         if grad_norm is not None:
-            tb_logger.add_scalar("grad-norm", grad_norm, train_state.step)
-            tb_logger.add_scalar("grad-norm vs samples", grad_norm, global_state.train_state.consumed_train_samples)
-            if wandb_logger:
-                wandb_logger.log({"grad-norm": grad_norm}, train_state.step)
+            writer.add_scalar("grad-norm", grad_norm, iteration)
+            writer.add_scalar("grad-norm vs samples", grad_norm, global_state.train_state.consumed_train_samples)
+            if wandb_writer:
+                wandb_writer.log({"grad-norm": grad_norm}, iteration)
         if num_zeros_in_grad is not None:
-            tb_logger.add_scalar("num-zeros", num_zeros_in_grad, train_state.step)
-            tb_logger.add_scalar(
+            writer.add_scalar("num-zeros", num_zeros_in_grad, iteration)
+            writer.add_scalar(
                 "num-zeros vs samples", num_zeros_in_grad, global_state.train_state.consumed_train_samples
             )
-            if wandb_logger:
-                wandb_logger.log({"num-zeros": num_zeros_in_grad}, train_state.step)
+            if wandb_writer:
+                wandb_writer.log({"num-zeros": num_zeros_in_grad}, iteration)
         if params_norm is not None:
-            tb_logger.add_scalar("params-norm", params_norm, train_state.step)
-            tb_logger.add_scalar(
-                "params-norm vs samples", params_norm, global_state.train_state.consumed_train_samples
-            )
-            if wandb_logger:
-                wandb_logger.log({"params-norm": params_norm}, train_state.step)
+            writer.add_scalar("params-norm", params_norm, iteration)
+            writer.add_scalar("params-norm vs samples", params_norm, global_state.train_state.consumed_train_samples)
+            if wandb_writer:
+                wandb_writer.log({"params-norm": params_norm}, iteration)
         if logger_config.log_memory_to_tensorboard:
             mem_stats = torch.cuda.memory_stats()
-            tb_logger.add_scalar(
+            writer.add_scalar(
                 "mem-reserved-bytes",
                 mem_stats["reserved_bytes.all.current"],
-                train_state.step,
+                iteration,
             )
-            tb_logger.add_scalar(
+            writer.add_scalar(
                 "mem-allocated-bytes",
                 mem_stats["allocated_bytes.all.current"],
-                train_state.step,
+                iteration,
             )
-            tb_logger.add_scalar(
+            writer.add_scalar(
                 "mem-max-allocated-bytes",
                 mem_stats["allocated_bytes.all.peak"],
-                train_state.step,
+                iteration,
             )
-            tb_logger.add_scalar(
+            writer.add_scalar(
                 "mem-allocated-count",
                 mem_stats["allocation.all.current"],
-                train_state.step,
+                iteration,
             )
     if config.model.num_moe_experts is not None:
         moe_loss_scale = 1 / get_num_microbatches()
@@ -450,9 +442,9 @@ def training_log(
             track_names.append("z_loss")
         track_moe_metrics(
             loss_scale=moe_loss_scale,
-            iteration=train_state.step,
-            tb_logger=tb_logger,
-            wandb_writer=wandb_logger,
+            iteration=iteration,
+            writer=writer,
+            wandb_writer=wandb_writer,
             total_loss_dict=total_loss_dict,
             per_layer_logging=config.model.moe_per_layer_logging,
             force_initialize=True,
@@ -463,11 +455,9 @@ def training_log(
         )
     if config.model.mtp_num_layers is not None:
         mtp_loss_scale = 1 / get_num_microbatches()
-        MTPLossLoggingHelper.track_mtp_metrics(
-            mtp_loss_scale, train_state.step, tb_logger, wandb_logger, total_loss_dict
-        )
+        MTPLossLoggingHelper.track_mtp_metrics(mtp_loss_scale, iteration, writer, wandb_writer, total_loss_dict)
 
-    if train_state.step % logger_config.log_interval == 0:
+    if iteration % logger_config.log_interval == 0:
         elapsed_time = timers("interval-time").elapsed(barrier=True)
         elapsed_time_per_iteration = elapsed_time / total_iterations
 
@@ -475,12 +465,12 @@ def training_log(
         #     elapsed_time_per_iteration * 10**12 * get_world_size_safe())  # TODO: implement
 
         if logger_config.log_timers_to_tensorboard:
-            if tb_logger:
-                tb_logger.add_scalar("iteration-time", elapsed_time_per_iteration, train_state.step)
-            if wandb_logger:
-                wandb_logger.log({"iteration-time": elapsed_time_per_iteration}, train_state.step)
+            if writer:
+                writer.add_scalar("iteration-time", elapsed_time_per_iteration, iteration)
+            if wandb_writer:
+                wandb_writer.log({"iteration-time": elapsed_time_per_iteration}, iteration)
         log_string = f" [{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}]"
-        log_string += " iteration {:8d}/{:8d} |".format(train_state.step, train_config.train_iters)
+        log_string += " iteration {:8d}/{:8d} |".format(iteration, train_config.train_iters)
         log_string += " consumed samples: {:12d} |".format(global_state.train_state.consumed_train_samples)
         if global_state.train_state.skipped_train_samples > 0:
             log_string += " skipped samples: {:12d} |".format(global_state.train_state.skipped_train_samples)
@@ -490,22 +480,22 @@ def training_log(
         # if logger_config.log_throughput:
         #     log_string += f' throughput per GPU (TFLOP/s/GPU): {throughput:.1f} |'
         #     if logger_config.log_timers_to_tensorboard:
-        #         if tb_logger:
-        #             tb_logger.add_scalar('throughput', throughput, train_state.step)
-        #         if wandb_logger:
-        #             wandb_logger.log({'throughput': throughput}, train_state.step)
+        #         if writer:
+        #             writer.add_scalar('throughput', throughput, iteration)
+        #         if wandb_writer:
+        #             wandb_writer.log({'throughput': throughput}, iteration)
 
         if energy_monitor is not None:
             energy = (energy_monitor.lap() / total_iterations) / get_world_size_safe()
             power = energy / elapsed_time_per_iteration
             log_string += f" energy per GPU (J/iter/GPU): {energy:.1f} |"
             log_string += f" power per GPU (W/GPU): {power:.1f} |"
-            if tb_logger:
-                tb_logger.add_scalar("iter-energy/gpu", energy, train_state.step)
-                tb_logger.add_scalar("power/gpu", power, train_state.step)
-            if wandb_logger:
-                wandb_logger.log({"iter-energy/gpu": energy}, train_state.step)
-                wandb_logger.log({"power/gpu": power}, train_state.step)
+            if writer:
+                writer.add_scalar("iter-energy/gpu", energy, iteration)
+                writer.add_scalar("power/gpu", power, iteration)
+            if wandb_writer:
+                wandb_writer.log({"iter-energy/gpu": energy}, iteration)
+                wandb_writer.log({"power/gpu": power}, iteration)
 
         # Decoupled_learning_rate should be not None only on first and last pipeline stage.
         log_string += f" learning rate: {learning_rate:.6E} |"
@@ -541,7 +531,7 @@ def training_log(
             if torch.distributed.get_rank() == 0:
                 num_microbatches = get_num_microbatches()
                 report_theoretical_memory(config, num_microbatches=num_microbatches, verbose=True)
-            report_memory(f"(after {train_state.step} iterations)")
+            report_memory(f"(after {iteration} iterations)")
             report_memory_flag = False
         timers.log(timers_to_log, normalizer=logger_config.log_interval)
 
@@ -562,83 +552,6 @@ def report_memory(name: str) -> None:
     string += " | max reserved: {}".format(torch.cuda.max_memory_reserved() / mega_bytes)
     if parallel_state.get_data_parallel_rank() == 0:
         print("[Rank {}] {}".format(torch.distributed.get_rank(), string), flush=True)
-
-
-def track_moe_metrics(
-    loss_scale: float,
-    iteration: int,
-    tb_logger: Any,
-    wandb_logger: Optional[Any] = None,
-    total_loss_dict: Optional[dict] = None,
-    per_layer_logging: bool = False,
-) -> None:
-    """Track and log Mixture of Experts (MoE) specific metrics.
-
-    Reduces auxiliary losses across ranks and logs them to TensorBoard and WandB.
-
-    Args:
-        loss_scale (float): The current loss scale.
-        iteration (int): The current training iteration.
-        tb_logger: The TensorBoard logger instance.
-        wandb_logger: The WandB logger instance (optional).
-        total_loss_dict (Optional[dict]): Dictionary to accumulate total losses (optional).
-        per_layer_logging (bool): If True, logs metrics for each MoE layer individually.
-    """
-    # Aux loss logging
-    reduce_aux_losses_tracker_across_ranks()
-    tracker = parallel_state.get_moe_layer_wise_logging_tracker()
-    if tb_logger is not None:
-        aux_losses = {k: v["values"].float() * loss_scale for k, v in tracker.items()}
-        for name, loss_list in aux_losses.items():
-            if total_loss_dict is not None:
-                if name not in total_loss_dict:
-                    total_loss_dict[name] = loss_list.mean()
-                else:
-                    total_loss_dict[name] += loss_list.mean()
-
-            # currently when using add_scalars,
-            # torch.utils.add_scalars makes each timer its own run, which
-            # polutes the runs list, so we just add each as a scalar
-            tb_logger.add_scalar(name, loss_list.mean(), iteration)
-            if per_layer_logging:
-                for i, loss in enumerate(loss_list.tolist()):
-                    tb_logger.add_scalar(f"moe/{name}_layer_{i}", loss, iteration)
-
-            # W&B logging lacks support for logging multiple scalars simultaneously.
-            # As a workaround, we log each scalar individually first, then we can create
-            # a custom panel to manually group them to a single plot.
-            if wandb_logger:
-                wandb_logger.log({f"{name}": loss_list.mean()}, iteration)
-                if per_layer_logging:
-                    wandb_logger.log(
-                        {f"moe/{name}_layer_{i}": loss for i, loss in enumerate(loss_list.tolist())},
-                        iteration,
-                    )
-
-    clear_aux_losses_tracker()
-
-
-def clear_aux_losses_tracker():
-    """Clear the MoE auxiliary loss tracker in the parallel state."""
-    tracker = parallel_state.get_moe_layer_wise_logging_tracker()
-    for name in tracker:
-        tracker[name]["values"].zero_()
-        tracker[name]["reduce_group"] = None
-        tracker[name]["avg_group"] = None
-
-
-def reduce_aux_losses_tracker_across_ranks():
-    """Reduce the MoE auxiliary losses across pipeline and specified reduction groups."""
-    tracker = parallel_state.get_moe_layer_wise_logging_tracker()
-    for name in tracker:
-        values = tracker[name]["values"]
-        # Collect aux losses across PP.
-        torch.distributed.all_reduce(values, group=parallel_state.get_pipeline_model_parallel_group())
-        # Reduce aux losses across ranks.
-        if tracker[name].get("reduce_group") is not None:
-            torch.distributed.all_reduce(values, group=tracker[name].get("reduce_group"))
-        if tracker[name].get("avg_group") is not None:
-            torch.distributed.all_reduce(values, group=tracker[name]["avg_group"], op=torch.distributed.ReduceOp.AVG)
 
 
 def maybe_inject_state(forward_step_func: Callable, state: GlobalState, num_fw_args: Optional[int] = None) -> Callable:

--- a/src/megatron/bridge/training/utils/train_utils.py
+++ b/src/megatron/bridge/training/utils/train_utils.py
@@ -449,9 +449,9 @@ def training_log(
         if config.model.moe_z_loss_coeff is not None:
             track_names.append("z_loss")
         track_moe_metrics(
-            moe_loss_scale,
-            train_state.step,
-            tb_logger,
+            loss_scale=moe_loss_scale,
+            iteration=train_state.step,
+            tb_logger=tb_logger,
             wandb_writer=wandb_logger,
             total_loss_dict=total_loss_dict,
             per_layer_logging=config.model.moe_per_layer_logging,

--- a/src/megatron/bridge/training/utils/train_utils.py
+++ b/src/megatron/bridge/training/utils/train_utils.py
@@ -449,9 +449,9 @@ def training_log(
         if config.model.moe_z_loss_coeff is not None:
             track_names.append("z_loss")
         track_moe_metrics(
-            loss_scale=moe_loss_scale,
-            iteration=train_state.step,
-            writer=tb_logger,
+            moe_loss_scale,
+            train_state.step,
+            tb_logger,
             wandb_writer=wandb_logger,
             total_loss_dict=total_loss_dict,
             per_layer_logging=config.model.moe_per_layer_logging,

--- a/tests/unit_tests/training/utils/test_train_utils.py
+++ b/tests/unit_tests/training/utils/test_train_utils.py
@@ -1,0 +1,845 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest.mock as mock
+
+import pytest
+import torch
+
+from megatron.bridge.training.utils.train_utils import training_log
+
+
+class TestTrainingLog:
+    """Test suite for the training_log function."""
+
+    @pytest.fixture(scope="function")
+    def mock_config(self):
+        """Create a mock configuration object."""
+        config = mock.MagicMock()
+        # Logger config
+        config.logger.log_timers_to_tensorboard = True
+        config.logger.tensorboard_log_interval = 10
+        config.logger.log_interval = 5
+        config.logger.log_loss_scale_to_tensorboard = True
+        config.logger.log_world_size_to_tensorboard = True
+        config.logger.log_memory_to_tensorboard = False
+        config.logger.log_throughput = False
+
+        # Training config
+        config.train.micro_batch_size = 2
+        config.train.train_iters = 1000
+
+        # Model config
+        config.model.num_moe_experts = None
+        config.model.mtp_num_layers = None
+
+        # Optimizer config
+        config.optimizer.decoupled_lr = None
+
+        # Data parallel size
+        config.data_parallel_size = 4
+
+        # Profiling config
+        config.profiling = None
+
+        return config
+
+    @pytest.fixture(scope="function")
+    def mock_global_state(self):
+        """Create a mock global state object."""
+        global_state = mock.MagicMock()
+
+        # Mock train state
+        global_state.train_state.step = 100
+        global_state.train_state.consumed_train_samples = 12800
+        global_state.train_state.skipped_train_samples = 0
+
+        # Mock timers
+        mock_timers = mock.MagicMock()
+        mock_timers.return_value.elapsed.return_value = 0.5  # 500ms per iteration
+        global_state.timers = mock_timers
+
+        # Mock loggers
+        global_state.tensorboard_logger = mock.MagicMock()
+        global_state.wandb_logger = mock.MagicMock()
+        global_state.energy_monitor = None
+
+        return global_state
+
+    @pytest.fixture(scope="function")
+    def loss_dict(self):
+        """Create a sample loss dictionary."""
+        return {
+            "lm_loss": torch.tensor([2.5], device="cuda", dtype=torch.float32),
+            "total_loss": torch.tensor([2.5], device="cuda", dtype=torch.float32),
+        }
+
+    def get_fresh_total_loss_dict(self):
+        """Create a fresh empty total loss dictionary for accumulation."""
+        return {}
+
+    @mock.patch("megatron.bridge.training.utils.train_utils.get_num_microbatches")
+    @mock.patch("megatron.bridge.training.utils.train_utils.reduce_max_stat_across_model_parallel_group")
+    @mock.patch("megatron.bridge.training.utils.train_utils.get_world_size_safe")
+    @mock.patch("megatron.bridge.training.utils.train_utils.is_last_rank")
+    @mock.patch("megatron.bridge.training.utils.train_utils.print_rank_last")
+    def test_basic_logging_without_skip(
+        self,
+        mock_print_rank_last,
+        mock_is_last_rank,
+        mock_get_world_size,
+        mock_reduce_lr,
+        mock_get_microbatches,
+        mock_config,
+        mock_global_state,
+        loss_dict,
+    ):
+        """Test basic logging functionality without skipped iterations."""
+        # Get fresh total_loss_dict for this test
+        total_loss_dict = self.get_fresh_total_loss_dict()
+
+        # Setup mocks
+        mock_get_microbatches.return_value = 8
+        mock_reduce_lr.return_value = 1e-4
+        mock_get_world_size.return_value = 32
+        mock_is_last_rank.return_value = True
+
+        # Override iteration to avoid log interval reset (101 % 5 != 0)
+        mock_global_state.train_state.step = 101
+
+        # Call the function
+        result = training_log(
+            loss_dict=loss_dict,
+            total_loss_dict=total_loss_dict,
+            learning_rate=1e-4,
+            decoupled_learning_rate=None,
+            loss_scale=1024.0,
+            report_memory_flag=False,
+            skipped_iter=0,
+            grad_norm=2.5,
+            params_norm=15.2,
+            num_zeros_in_grad=0,
+            config=mock_config,
+            global_state=mock_global_state,
+        )
+
+        # Assertions
+        assert result is False  # report_memory_flag should remain False
+
+        # Check that losses were accumulated correctly
+        assert "advanced iterations" in total_loss_dict
+        assert total_loss_dict["advanced iterations"] == 1
+        assert "skipped iterations" in total_loss_dict
+        assert total_loss_dict["skipped iterations"] == 0
+        assert "nan iterations" in total_loss_dict
+        assert total_loss_dict["nan iterations"] == 0
+
+        # Check that losses were added to total_loss_dict
+        for key in loss_dict:
+            assert key in total_loss_dict
+            torch.testing.assert_close(total_loss_dict[key], loss_dict[key])
+
+    @mock.patch("megatron.bridge.training.utils.train_utils.get_num_microbatches")
+    @mock.patch("megatron.bridge.training.utils.train_utils.reduce_max_stat_across_model_parallel_group")
+    @mock.patch("megatron.bridge.training.utils.train_utils.get_world_size_safe")
+    @mock.patch("megatron.bridge.training.utils.train_utils.is_last_rank")
+    @mock.patch("megatron.bridge.training.utils.train_utils.print_rank_last")
+    def test_skipped_iterations(
+        self,
+        mock_print_rank_last,
+        mock_is_last_rank,
+        mock_get_world_size,
+        mock_reduce_lr,
+        mock_get_microbatches,
+        mock_config,
+        mock_global_state,
+        loss_dict,
+    ):
+        """Test logging behavior with skipped iterations."""
+        # Get fresh total_loss_dict for this test
+        total_loss_dict = self.get_fresh_total_loss_dict()
+
+        # Setup mocks
+        mock_get_microbatches.return_value = 8
+        mock_reduce_lr.return_value = 1e-4
+        mock_get_world_size.return_value = 32
+        mock_is_last_rank.return_value = True
+
+        # Override iteration to avoid log interval reset (101 % 5 != 0)
+        mock_global_state.train_state.step = 101
+
+        # Call the function with skipped iteration
+        result = training_log(
+            loss_dict=loss_dict,
+            total_loss_dict=total_loss_dict,
+            learning_rate=1e-4,
+            decoupled_learning_rate=None,
+            loss_scale=1024.0,
+            report_memory_flag=False,
+            skipped_iter=1,
+            grad_norm=None,
+            params_norm=None,
+            num_zeros_in_grad=None,
+            config=mock_config,
+            global_state=mock_global_state,
+        )
+
+        # Assertions
+        assert result is False
+
+        # Check iteration counters
+        assert total_loss_dict["advanced iterations"] == 0  # No advanced iterations
+        assert total_loss_dict["skipped iterations"] == 1
+
+        # When skipped, losses should not be accumulated in the usual way
+        for key in loss_dict:
+            assert key not in total_loss_dict or total_loss_dict[key] == torch.tensor(
+                [0.0], dtype=torch.float, device="cuda"
+            )
+
+    @mock.patch("megatron.bridge.training.utils.train_utils.get_num_microbatches")
+    @mock.patch("megatron.bridge.training.utils.train_utils.reduce_max_stat_across_model_parallel_group")
+    @mock.patch("megatron.bridge.training.utils.train_utils.get_world_size_safe")
+    @mock.patch("megatron.bridge.training.utils.train_utils.is_last_rank")
+    @mock.patch("megatron.bridge.training.utils.train_utils.print_rank_last")
+    def test_nan_detection(
+        self,
+        mock_print_rank_last,
+        mock_is_last_rank,
+        mock_get_world_size,
+        mock_reduce_lr,
+        mock_get_microbatches,
+        mock_config,
+        mock_global_state,
+    ):
+        """Test NaN detection in loss values."""
+        # Get fresh total_loss_dict for this test
+        total_loss_dict = self.get_fresh_total_loss_dict()
+
+        # Setup mocks
+        mock_get_microbatches.return_value = 8
+        mock_reduce_lr.return_value = 1e-4
+        mock_get_world_size.return_value = 32
+        mock_is_last_rank.return_value = True
+
+        # Override iteration to avoid log interval reset (101 % 5 != 0)
+        mock_global_state.train_state.step = 101
+
+        # Create loss dict with NaN values
+        nan_loss_dict = {
+            "lm_loss": torch.tensor([float("nan")], device="cuda", dtype=torch.float32),
+            "total_loss": torch.tensor([2.5], device="cuda", dtype=torch.float32),
+        }
+
+        training_log(
+            loss_dict=nan_loss_dict,
+            total_loss_dict=total_loss_dict,
+            learning_rate=1e-4,
+            decoupled_learning_rate=None,
+            loss_scale=1024.0,
+            report_memory_flag=False,
+            skipped_iter=1,  # Must be skipped for NaN detection
+            grad_norm=None,
+            params_norm=None,
+            num_zeros_in_grad=None,
+            config=mock_config,
+            global_state=mock_global_state,
+        )
+
+        # Assertions
+        assert total_loss_dict["nan iterations"] == 1
+
+    @mock.patch("megatron.bridge.training.utils.train_utils.get_num_microbatches")
+    @mock.patch("megatron.bridge.training.utils.train_utils.reduce_max_stat_across_model_parallel_group")
+    @mock.patch("megatron.bridge.training.utils.train_utils.get_world_size_safe")
+    @mock.patch("megatron.bridge.training.utils.train_utils.is_last_rank")
+    @mock.patch("megatron.bridge.training.utils.train_utils.print_rank_last")
+    def test_tensorboard_logging_interval(
+        self,
+        mock_print_rank_last,
+        mock_is_last_rank,
+        mock_get_world_size,
+        mock_reduce_lr,
+        mock_get_microbatches,
+        mock_config,
+        mock_global_state,
+        loss_dict,
+    ):
+        """Test tensorboard logging at specified intervals."""
+        # Get fresh total_loss_dict for this test
+        total_loss_dict = self.get_fresh_total_loss_dict()
+
+        # Setup mocks
+        mock_get_microbatches.return_value = 8
+        mock_reduce_lr.return_value = 1e-4
+        mock_get_world_size.return_value = 32
+        mock_is_last_rank.return_value = True
+
+        # Set iteration to match tensorboard logging interval
+        mock_global_state.train_state.step = 100  # Should trigger tensorboard logging (100 % 10 == 0)
+        mock_config.logger.tensorboard_log_interval = 10
+
+        training_log(
+            loss_dict=loss_dict,
+            total_loss_dict=total_loss_dict,
+            learning_rate=1e-4,
+            decoupled_learning_rate=None,
+            loss_scale=1024.0,
+            report_memory_flag=False,
+            skipped_iter=0,
+            grad_norm=2.5,
+            params_norm=15.2,
+            num_zeros_in_grad=0,
+            config=mock_config,
+            global_state=mock_global_state,
+        )
+
+        # Verify tensorboard logging was called
+        mock_global_state.tensorboard_logger.add_scalar.assert_called()
+        mock_global_state.timers.write.assert_called()
+
+    @mock.patch("megatron.bridge.training.utils.train_utils.get_num_microbatches")
+    @mock.patch("megatron.bridge.training.utils.train_utils.reduce_max_stat_across_model_parallel_group")
+    @mock.patch("megatron.bridge.training.utils.train_utils.get_world_size_safe")
+    @mock.patch("megatron.bridge.training.utils.train_utils.is_last_rank")
+    @mock.patch("megatron.bridge.training.utils.train_utils.print_rank_last")
+    @mock.patch("megatron.bridge.training.utils.train_utils.report_memory")
+    @mock.patch("megatron.bridge.training.utils.train_utils.report_theoretical_memory")
+    @mock.patch("torch.distributed.get_rank")
+    def test_memory_reporting(
+        self,
+        mock_get_rank,
+        mock_report_theoretical,
+        mock_report_memory,
+        mock_print_rank_last,
+        mock_is_last_rank,
+        mock_get_world_size,
+        mock_reduce_lr,
+        mock_get_microbatches,
+        mock_config,
+        mock_global_state,
+        loss_dict,
+    ):
+        """Test memory reporting functionality."""
+        # Get fresh total_loss_dict for this test
+        total_loss_dict = self.get_fresh_total_loss_dict()
+
+        # Setup mocks
+        mock_get_microbatches.return_value = 8
+        mock_reduce_lr.return_value = 1e-4
+        mock_get_world_size.return_value = 32
+        mock_is_last_rank.return_value = True
+        mock_get_rank.return_value = 0
+
+        # Set iteration to match log interval for memory reporting
+        mock_global_state.train_state.step = 5
+        mock_config.logger.log_interval = 5
+
+        # Call the function with memory reporting enabled
+        result = training_log(
+            loss_dict=loss_dict,
+            total_loss_dict=total_loss_dict,
+            learning_rate=1e-4,
+            decoupled_learning_rate=None,
+            loss_scale=1024.0,
+            report_memory_flag=True,  # Enable memory reporting
+            skipped_iter=0,
+            grad_norm=2.5,
+            params_norm=15.2,
+            num_zeros_in_grad=0,
+            config=mock_config,
+            global_state=mock_global_state,
+        )
+
+        # Memory reporting should disable the flag
+        assert result is False
+
+        # Verify memory reporting functions were called
+        mock_report_theoretical.assert_called_once()
+        mock_report_memory.assert_called_once()
+
+    @mock.patch("megatron.bridge.training.utils.train_utils.get_num_microbatches")
+    @mock.patch("megatron.bridge.training.utils.train_utils.reduce_max_stat_across_model_parallel_group")
+    @mock.patch("megatron.bridge.training.utils.train_utils.get_world_size_safe")
+    @mock.patch("megatron.bridge.training.utils.train_utils.is_last_rank")
+    @mock.patch("megatron.bridge.training.utils.train_utils.print_rank_last")
+    @mock.patch("megatron.bridge.training.utils.train_utils.track_moe_metrics")
+    def test_moe_logging(
+        self,
+        mock_track_moe,
+        mock_print_rank_last,
+        mock_is_last_rank,
+        mock_get_world_size,
+        mock_reduce_lr,
+        mock_get_microbatches,
+        mock_config,
+        mock_global_state,
+        loss_dict,
+    ):
+        """Test MoE (Mixture of Experts) logging when enabled."""
+        # Get fresh total_loss_dict for this test
+        total_loss_dict = self.get_fresh_total_loss_dict()
+
+        # Setup mocks
+        mock_get_microbatches.return_value = 8
+        mock_reduce_lr.return_value = 1e-4
+        mock_get_world_size.return_value = 32
+        mock_is_last_rank.return_value = True
+
+        # Enable MoE configuration
+        mock_config.model.num_moe_experts = 8
+        mock_config.model.moe_router_load_balancing_type = "aux_loss"
+        mock_config.model.moe_z_loss_coeff = 0.1
+        mock_config.model.moe_per_layer_logging = True
+        mock_config.model.num_layers = 12
+        mock_config.model.moe_layer_freq = 2
+        mock_config.model.mtp_num_layers = None
+
+        training_log(
+            loss_dict=loss_dict,
+            total_loss_dict=total_loss_dict,
+            learning_rate=1e-4,
+            decoupled_learning_rate=None,
+            loss_scale=1024.0,
+            report_memory_flag=False,
+            skipped_iter=0,
+            grad_norm=2.5,
+            params_norm=15.2,
+            num_zeros_in_grad=0,
+            config=mock_config,
+            global_state=mock_global_state,
+        )
+
+        # Verify MoE tracking was called
+        mock_track_moe.assert_called_once()
+        call_args = mock_track_moe.call_args
+        assert "load_balancing_loss" in call_args.kwargs["track_names"]
+        assert "z_loss" in call_args.kwargs["track_names"]
+
+    @mock.patch("megatron.bridge.training.utils.train_utils.get_num_microbatches")
+    @mock.patch("megatron.bridge.training.utils.train_utils.reduce_max_stat_across_model_parallel_group")
+    @mock.patch("megatron.bridge.training.utils.train_utils.get_world_size_safe")
+    @mock.patch("megatron.bridge.training.utils.train_utils.is_last_rank")
+    @mock.patch("megatron.bridge.training.utils.train_utils.print_rank_last")
+    @mock.patch("megatron.bridge.training.utils.train_utils.MTPLossLoggingHelper")
+    def test_mtp_logging(
+        self,
+        mock_mtp_helper,
+        mock_print_rank_last,
+        mock_is_last_rank,
+        mock_get_world_size,
+        mock_reduce_lr,
+        mock_get_microbatches,
+        mock_config,
+        mock_global_state,
+        loss_dict,
+    ):
+        """Test MTP (Multi-Token Prediction) logging when enabled."""
+        # Get fresh total_loss_dict for this test
+        total_loss_dict = self.get_fresh_total_loss_dict()
+
+        # Setup mocks
+        mock_get_microbatches.return_value = 8
+        mock_reduce_lr.return_value = 1e-4
+        mock_get_world_size.return_value = 32
+        mock_is_last_rank.return_value = True
+
+        # Enable MTP configuration
+        mock_config.model.mtp_num_layers = 4
+        mock_config.model.num_moe_experts = None
+
+        training_log(
+            loss_dict=loss_dict,
+            total_loss_dict=total_loss_dict,
+            learning_rate=1e-4,
+            decoupled_learning_rate=None,
+            loss_scale=1024.0,
+            report_memory_flag=False,
+            skipped_iter=0,
+            grad_norm=2.5,
+            params_norm=15.2,
+            num_zeros_in_grad=0,
+            config=mock_config,
+            global_state=mock_global_state,
+        )
+
+        # Verify MTP tracking was called
+        mock_mtp_helper.track_mtp_metrics.assert_called_once()
+
+    @mock.patch("megatron.bridge.training.utils.train_utils.get_num_microbatches")
+    @mock.patch("megatron.bridge.training.utils.train_utils.reduce_max_stat_across_model_parallel_group")
+    @mock.patch("megatron.bridge.training.utils.train_utils.get_world_size_safe")
+    @mock.patch("megatron.bridge.training.utils.train_utils.is_last_rank")
+    @mock.patch("megatron.bridge.training.utils.train_utils.print_rank_last")
+    @mock.patch("megatron.core.parallel_state.is_pipeline_first_stage")
+    @mock.patch("megatron.core.parallel_state.is_pipeline_last_stage")
+    def test_decoupled_learning_rate(
+        self,
+        mock_is_pipeline_last,
+        mock_is_pipeline_first,
+        mock_print_rank_last,
+        mock_is_last_rank,
+        mock_get_world_size,
+        mock_reduce_lr,
+        mock_get_microbatches,
+        mock_config,
+        mock_global_state,
+        loss_dict,
+    ):
+        """Test decoupled learning rate logging."""
+        # Get fresh total_loss_dict for this test
+        total_loss_dict = self.get_fresh_total_loss_dict()
+
+        # Setup mocks
+        mock_get_microbatches.return_value = 8
+        mock_reduce_lr.return_value = 1e-4
+        mock_get_world_size.return_value = 32
+        mock_is_last_rank.return_value = True
+        mock_is_pipeline_first.return_value = True
+        mock_is_pipeline_last.return_value = False
+
+        # Enable decoupled learning rate
+        mock_config.optimizer.decoupled_lr = 0.01
+
+        # Set iteration to match log interval
+        mock_global_state.train_state.step = 5
+        mock_config.logger.log_interval = 5
+
+        training_log(
+            loss_dict=loss_dict,
+            total_loss_dict=total_loss_dict,
+            learning_rate=1e-4,
+            decoupled_learning_rate=2e-5,  # Different from regular LR
+            loss_scale=1024.0,
+            report_memory_flag=False,
+            skipped_iter=0,
+            grad_norm=2.5,
+            params_norm=15.2,
+            num_zeros_in_grad=0,
+            config=mock_config,
+            global_state=mock_global_state,
+        )
+
+        # Check that the log string includes decoupled learning rate
+        mock_print_rank_last.assert_called()
+        log_call_args = mock_print_rank_last.call_args[0][0]
+        assert "decoupled learning rate" in log_call_args
+
+    @mock.patch("megatron.bridge.training.utils.train_utils.get_num_microbatches")
+    @mock.patch("megatron.bridge.training.utils.train_utils.reduce_max_stat_across_model_parallel_group")
+    @mock.patch("megatron.bridge.training.utils.train_utils.get_world_size_safe")
+    @mock.patch("megatron.bridge.training.utils.train_utils.is_last_rank")
+    @mock.patch("megatron.bridge.training.utils.train_utils.print_rank_last")
+    def test_energy_monitoring(
+        self,
+        mock_print_rank_last,
+        mock_is_last_rank,
+        mock_get_world_size,
+        mock_reduce_lr,
+        mock_get_microbatches,
+        mock_config,
+        mock_global_state,
+        loss_dict,
+    ):
+        """Test energy monitoring functionality."""
+        # Get fresh total_loss_dict for this test
+        total_loss_dict = self.get_fresh_total_loss_dict()
+
+        # Setup mocks
+        mock_get_microbatches.return_value = 8
+        mock_reduce_lr.return_value = 1e-4
+        mock_get_world_size.return_value = 32
+        mock_is_last_rank.return_value = True
+
+        # Enable energy monitoring
+        mock_energy_monitor = mock.MagicMock()
+        mock_energy_monitor.lap.return_value = 100.0  # 100 Joules
+        mock_global_state.energy_monitor = mock_energy_monitor
+
+        # Set iteration to match log interval
+        mock_global_state.train_state.step = 5
+        mock_config.logger.log_interval = 5
+
+        training_log(
+            loss_dict=loss_dict,
+            total_loss_dict=total_loss_dict,
+            learning_rate=1e-4,
+            decoupled_learning_rate=None,
+            loss_scale=1024.0,
+            report_memory_flag=False,
+            skipped_iter=0,
+            grad_norm=2.5,
+            params_norm=15.2,
+            num_zeros_in_grad=0,
+            config=mock_config,
+            global_state=mock_global_state,
+        )
+
+        # Verify energy monitoring was called
+        mock_energy_monitor.lap.assert_called_once()
+
+        # Check that energy metrics appear in the log string
+        mock_print_rank_last.assert_called()
+        log_call_args = mock_print_rank_last.call_args[0][0]
+        assert "energy per GPU" in log_call_args
+        assert "power per GPU" in log_call_args
+
+        # Verify tensorboard logging for energy metrics
+        mock_global_state.tensorboard_logger.add_scalar.assert_any_call(
+            "iter-energy/gpu", mock.ANY, mock_global_state.train_state.step
+        )
+        mock_global_state.tensorboard_logger.add_scalar.assert_any_call(
+            "power/gpu", mock.ANY, mock_global_state.train_state.step
+        )
+
+    @mock.patch("megatron.bridge.training.utils.train_utils.get_num_microbatches")
+    @mock.patch("megatron.bridge.training.utils.train_utils.reduce_max_stat_across_model_parallel_group")
+    @mock.patch("megatron.bridge.training.utils.train_utils.get_world_size_safe")
+    @mock.patch("megatron.bridge.training.utils.train_utils.is_last_rank")
+    @mock.patch("megatron.bridge.training.utils.train_utils.print_rank_last")
+    @mock.patch("torch.cuda.memory._snapshot")
+    @mock.patch("builtins.open")
+    @mock.patch("pickle.dump")
+    def test_profiling_memory_snapshot(
+        self,
+        mock_pickle_dump,
+        mock_open,
+        mock_memory_snapshot,
+        mock_print_rank_last,
+        mock_is_last_rank,
+        mock_get_world_size,
+        mock_reduce_lr,
+        mock_get_microbatches,
+        mock_config,
+        mock_global_state,
+        loss_dict,
+    ):
+        """Test memory snapshot functionality when profiling is enabled."""
+        # Get fresh total_loss_dict for this test
+        total_loss_dict = self.get_fresh_total_loss_dict()
+
+        # Setup mocks
+        mock_get_microbatches.return_value = 8
+        mock_reduce_lr.return_value = 1e-4
+        mock_get_world_size.return_value = 32
+        mock_is_last_rank.return_value = True
+        mock_memory_snapshot.return_value = {"mock": "snapshot"}
+        mock_file_handle = mock.MagicMock()
+        mock_open.return_value.__enter__.return_value = mock_file_handle
+
+        # Enable profiling with memory history
+        mock_profiling_config = mock.MagicMock()
+        mock_profiling_config.record_memory_history = True
+        mock_profiling_config.memory_snapshot_path = "/tmp/memory_snapshot.pkl"
+        mock_config.profiling = mock_profiling_config
+
+        # Set iteration to match tensorboard logging interval
+        mock_global_state.train_state.step = 10
+        mock_config.logger.tensorboard_log_interval = 10
+
+        training_log(
+            loss_dict=loss_dict,
+            total_loss_dict=total_loss_dict,
+            learning_rate=1e-4,
+            decoupled_learning_rate=None,
+            loss_scale=1024.0,
+            report_memory_flag=False,
+            skipped_iter=0,
+            grad_norm=2.5,
+            params_norm=15.2,
+            num_zeros_in_grad=0,
+            config=mock_config,
+            global_state=mock_global_state,
+        )
+
+        # Verify memory snapshot was taken and saved
+        mock_memory_snapshot.assert_called_once()
+        mock_open.assert_called_once_with("/tmp/memory_snapshot.pkl", "wb")
+        mock_pickle_dump.assert_called_once_with({"mock": "snapshot"}, mock_file_handle)
+
+    @mock.patch("megatron.bridge.training.utils.train_utils.get_num_microbatches")
+    @mock.patch("megatron.bridge.training.utils.train_utils.reduce_max_stat_across_model_parallel_group")
+    @mock.patch("megatron.bridge.training.utils.train_utils.get_world_size_safe")
+    @mock.patch("megatron.bridge.training.utils.train_utils.is_last_rank")
+    @mock.patch("megatron.bridge.training.utils.train_utils.print_rank_last")
+    def test_wandb_specific_logging(
+        self,
+        mock_print_rank_last,
+        mock_is_last_rank,
+        mock_get_world_size,
+        mock_reduce_lr,
+        mock_get_microbatches,
+        mock_config,
+        mock_global_state,
+        loss_dict,
+    ):
+        """Test WandB-specific logging functionality."""
+        # Get fresh total_loss_dict for this test
+        total_loss_dict = self.get_fresh_total_loss_dict()
+
+        # Setup mocks
+        mock_get_microbatches.return_value = 8
+        mock_reduce_lr.return_value = 1e-4
+        mock_get_world_size.return_value = 32
+        mock_is_last_rank.return_value = True
+
+        # Set iteration to match tensorboard logging interval
+        mock_global_state.train_state.step = 10
+        mock_config.logger.tensorboard_log_interval = 10
+
+        training_log(
+            loss_dict=loss_dict,
+            total_loss_dict=total_loss_dict,
+            learning_rate=1e-4,
+            decoupled_learning_rate=None,
+            loss_scale=1024.0,
+            report_memory_flag=False,
+            skipped_iter=0,
+            grad_norm=2.5,
+            params_norm=15.2,
+            num_zeros_in_grad=0,
+            config=mock_config,
+            global_state=mock_global_state,
+        )
+
+        # Verify WandB logging was called for various metrics
+        wandb_writer = mock_global_state.wandb_logger
+        wandb_writer.log.assert_any_call(
+            {"samples vs steps": mock_global_state.train_state.consumed_train_samples}, 10
+        )
+        wandb_writer.log.assert_any_call({"learning-rate": 1e-4}, 10)
+        wandb_writer.log.assert_any_call({"batch-size": mock.ANY}, 10)
+
+        # Check loss logging to WandB
+        for key in loss_dict:
+            wandb_writer.log.assert_any_call({key: loss_dict[key]}, 10)
+
+    @mock.patch("megatron.bridge.training.utils.train_utils.get_num_microbatches")
+    @mock.patch("megatron.bridge.training.utils.train_utils.reduce_max_stat_across_model_parallel_group")
+    @mock.patch("megatron.bridge.training.utils.train_utils.get_world_size_safe")
+    @mock.patch("megatron.bridge.training.utils.train_utils.is_last_rank")
+    @mock.patch("megatron.bridge.training.utils.train_utils.print_rank_last")
+    def test_no_loggers_present(
+        self,
+        mock_print_rank_last,
+        mock_is_last_rank,
+        mock_get_world_size,
+        mock_reduce_lr,
+        mock_get_microbatches,
+        mock_config,
+        mock_global_state,
+        loss_dict,
+    ):
+        """Test behavior when no loggers are present."""
+        # Get fresh total_loss_dict for this test
+        total_loss_dict = self.get_fresh_total_loss_dict()
+
+        # Setup mocks
+        mock_get_microbatches.return_value = 8
+        mock_reduce_lr.return_value = 1e-4
+        mock_get_world_size.return_value = 32
+        mock_is_last_rank.return_value = True
+
+        # Remove loggers
+        mock_global_state.tensorboard_logger = None
+        mock_global_state.wandb_logger = None
+
+        # Set iteration to match logging intervals
+        mock_global_state.train_state.step = 10
+        mock_config.logger.tensorboard_log_interval = 10
+        mock_config.logger.log_interval = 5
+
+        result = training_log(
+            loss_dict=loss_dict,
+            total_loss_dict=total_loss_dict,
+            learning_rate=1e-4,
+            decoupled_learning_rate=None,
+            loss_scale=1024.0,
+            report_memory_flag=False,
+            skipped_iter=0,
+            grad_norm=2.5,
+            params_norm=15.2,
+            num_zeros_in_grad=0,
+            config=mock_config,
+            global_state=mock_global_state,
+        )
+
+        assert result is False
+
+        # Should still print log string even without loggers
+        mock_print_rank_last.assert_called()
+
+    @mock.patch("megatron.bridge.training.utils.train_utils.get_num_microbatches")
+    @mock.patch("megatron.bridge.training.utils.train_utils.reduce_max_stat_across_model_parallel_group")
+    @mock.patch("megatron.bridge.training.utils.train_utils.get_world_size_safe")
+    @mock.patch("megatron.bridge.training.utils.train_utils.is_last_rank")
+    @mock.patch("megatron.bridge.training.utils.train_utils.print_rank_last")
+    @mock.patch("torch.cuda.memory_stats")
+    def test_memory_tensorboard_logging(
+        self,
+        mock_memory_stats,
+        mock_print_rank_last,
+        mock_is_last_rank,
+        mock_get_world_size,
+        mock_reduce_lr,
+        mock_get_microbatches,
+        mock_config,
+        mock_global_state,
+        loss_dict,
+    ):
+        """Test CUDA memory logging to tensorboard."""
+        # Get fresh total_loss_dict for this test
+        total_loss_dict = self.get_fresh_total_loss_dict()
+
+        # Setup mocks
+        mock_get_microbatches.return_value = 8
+        mock_reduce_lr.return_value = 1e-4
+        mock_get_world_size.return_value = 32
+        mock_is_last_rank.return_value = True
+
+        mock_memory_stats.return_value = {
+            "reserved_bytes.all.current": 2048000000,
+            "allocated_bytes.all.current": 1536000000,
+            "allocated_bytes.all.peak": 1792000000,
+            "allocation.all.current": 5000,
+        }
+
+        # Enable memory logging
+        mock_config.logger.log_memory_to_tensorboard = True
+
+        # Set iteration to match tensorboard logging interval
+        mock_global_state.train_state.step = 10
+        mock_config.logger.tensorboard_log_interval = 10
+
+        training_log(
+            loss_dict=loss_dict,
+            total_loss_dict=total_loss_dict,
+            learning_rate=1e-4,
+            decoupled_learning_rate=None,
+            loss_scale=1024.0,
+            report_memory_flag=False,
+            skipped_iter=0,
+            grad_norm=2.5,
+            params_norm=15.2,
+            num_zeros_in_grad=0,
+            config=mock_config,
+            global_state=mock_global_state,
+        )
+
+        # Verify memory stats were logged to tensorboard
+        writer = mock_global_state.tensorboard_logger
+        writer.add_scalar.assert_any_call("mem-reserved-bytes", 2048000000, 10)
+        writer.add_scalar.assert_any_call("mem-allocated-bytes", 1536000000, 10)
+        writer.add_scalar.assert_any_call("mem-max-allocated-bytes", 1792000000, 10)
+        writer.add_scalar.assert_any_call("mem-allocated-count", 5000, 10)


### PR DESCRIPTION
- use `track_moe_metrics` now that it's available in mcore
- rename variables within `training_log()` for easier comparison with MLM:
`tb_logger` -> `writer`
`wandb_logger` -> `wandb_writer`
`train_state.step` -> `iteration`
