### PR TITLE
fix: re-computed mlm padded vocab size for load

### DIFF
--- a/tests/functional_tests/training/test_load_model.py
+++ b/tests/functional_tests/training/test_load_model.py
@@ -38,8 +38,7 @@ class TestModelLoad:
         "ckpt_path",
         [
             "/home/TestData/megatron_bridge/checkpoints/llama3_145m-mbridge_saved-distckpt",
-            #  TODO: Add back in once vocab size is properly set
-            # "/home/TestData/megatron_bridge/checkpoints/llama3_145m-mlm_saved-distckpt",
+            "/home/TestData/megatron_bridge/checkpoints/llama3_145m-mlm_saved-distckpt",
         ],
     )
     def test_model_load_and_forward(self, ckpt_path: str):


### PR DESCRIPTION
vocab size may not be persisted in the args in the MLM checkpoint (unless the NullTokenizer is used). for other cases, the vocab size is calculated after building the tokenizer for training. the padded vocab size is set on the args, which means it's included in the checkpoint.

for compatibility with potential TP overrides, we build the tokenizer from the checkpoint to get the original unpadded vocab size, then calculate the padding based on the new TP setting

re-enable test:
```
python -m torch.distributed.run --nproc-per-node 2 -m pytest tests/functional_tests/training/test_load_model.py  -v
```