### PR TITLE
Update default null tokenizer size

### DIFF
--- a/src/megatron/bridge/recipes/utils/tokenizer_utils.py
+++ b/src/megatron/bridge/recipes/utils/tokenizer_utils.py
@@ -12,4 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-DEFAULT_NULL_TOKENIZER_VOCAB_SIZE: int = 32000
+# nvidia/megatron-gpt-345m vocab size
+DEFAULT_NULL_TOKENIZER_VOCAB_SIZE: int = 52027


### PR DESCRIPTION
Match vocab size for nemo2 for benchmark testing convenience.

https://github.com/NVIDIA/NeMo/blob/ddcb75fb0237d0384f5cfbb50414da609662cb07/nemo/collections/llm/gpt/data/mock.py#L86-L88

https://github.com/NVIDIA/NeMo/blob/ddcb75fb0237d0384f5cfbb50414da609662cb07/nemo/collections/nlp/modules/common/tokenizer_utils.py#L28