### PR TITLE
Cherry pick `fix: re-computed mlm padded vocab size for load (469)` into `r0.1.0`

### DIFF
--- a/tests/functional_tests/training/test_load_model.py
+++ b/tests/functional_tests/training/test_load_model.py
@@ -38,8 +38,7 @@ class TestModelLoad:
         "ckpt_path",
         [
             "/home/TestData/megatron_bridge/checkpoints/llama3_145m-mbridge_saved-distckpt",
-            #  TODO: Add back in once vocab size is properly set
-            # "/home/TestData/megatron_bridge/checkpoints/llama3_145m-mlm_saved-distckpt",
+            "/home/TestData/megatron_bridge/checkpoints/llama3_145m-mlm_saved-distckpt",
         ],
     )
     def test_model_load_and_forward(self, ckpt_path: str):


### PR DESCRIPTION
beep boop [🤖]: Hi @ananthsub 👋,
    
    we've cherry picked #469 into  for you! 🚀
    
    Please review and approve this cherry pick by your convenience!