### PR TITLE
default to using 8 workers for dataloading

### DIFF
--- a/src/megatron/bridge/recipes/deepseek/deepseek_v2.py
+++ b/src/megatron/bridge/recipes/deepseek/deepseek_v2.py
@@ -218,6 +218,7 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
+            num_workers=8,
         ),
         logger=LoggerConfig(log_interval=10, tensorboard_dir=tensorboard_dir, log_timers_to_tensorboard=True),
         tokenizer=TokenizerConfig(tokenizer_type="NullTokenizer", vocab_size=DEFAULT_NULL_TOKENIZER_VOCAB_SIZE),

--- a/src/megatron/bridge/recipes/deepseek/deepseek_v2.py
+++ b/src/megatron/bridge/recipes/deepseek/deepseek_v2.py
@@ -218,7 +218,6 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
-            num_workers=1,
         ),
         logger=LoggerConfig(log_interval=10, tensorboard_dir=tensorboard_dir, log_timers_to_tensorboard=True),
         tokenizer=TokenizerConfig(tokenizer_type="NullTokenizer", vocab_size=DEFAULT_NULL_TOKENIZER_VOCAB_SIZE),

--- a/src/megatron/bridge/recipes/deepseek/deepseek_v2_lite.py
+++ b/src/megatron/bridge/recipes/deepseek/deepseek_v2_lite.py
@@ -218,6 +218,7 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
+            num_workers=8,
         ),
         logger=LoggerConfig(log_interval=10, tensorboard_dir=tensorboard_dir, log_timers_to_tensorboard=True),
         tokenizer=TokenizerConfig(tokenizer_type="NullTokenizer", vocab_size=DEFAULT_NULL_TOKENIZER_VOCAB_SIZE),

--- a/src/megatron/bridge/recipes/deepseek/deepseek_v2_lite.py
+++ b/src/megatron/bridge/recipes/deepseek/deepseek_v2_lite.py
@@ -218,7 +218,6 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
-            num_workers=1,
         ),
         logger=LoggerConfig(log_interval=10, tensorboard_dir=tensorboard_dir, log_timers_to_tensorboard=True),
         tokenizer=TokenizerConfig(tokenizer_type="NullTokenizer", vocab_size=DEFAULT_NULL_TOKENIZER_VOCAB_SIZE),

--- a/src/megatron/bridge/recipes/deepseek/deepseek_v3.py
+++ b/src/megatron/bridge/recipes/deepseek/deepseek_v3.py
@@ -267,6 +267,7 @@ def pretrain_config(
             split=split,
             data_sharding=True,
             dataloader_type="single",
+            num_workers=8,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/deepseek/deepseek_v3.py
+++ b/src/megatron/bridge/recipes/deepseek/deepseek_v3.py
@@ -267,7 +267,6 @@ def pretrain_config(
             split=split,
             data_sharding=True,
             dataloader_type="single",
-            num_workers=1,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/gpt/gpt3_175b.py
+++ b/src/megatron/bridge/recipes/gpt/gpt3_175b.py
@@ -205,6 +205,7 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
+            num_workers=8,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/gpt/gpt3_175b.py
+++ b/src/megatron/bridge/recipes/gpt/gpt3_175b.py
@@ -205,7 +205,6 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
-            num_workers=1,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/llama/llama2_7b.py
+++ b/src/megatron/bridge/recipes/llama/llama2_7b.py
@@ -194,7 +194,6 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
-            num_workers=1,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/llama/llama2_7b.py
+++ b/src/megatron/bridge/recipes/llama/llama2_7b.py
@@ -194,6 +194,7 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
+            num_workers=8,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/llama/llama31_405b.py
+++ b/src/megatron/bridge/recipes/llama/llama31_405b.py
@@ -206,6 +206,7 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
+            num_workers=8,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/llama/llama31_405b.py
+++ b/src/megatron/bridge/recipes/llama/llama31_405b.py
@@ -206,7 +206,6 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
-            num_workers=1,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/llama/llama31_70b.py
+++ b/src/megatron/bridge/recipes/llama/llama31_70b.py
@@ -194,7 +194,6 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
-            num_workers=1,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/llama/llama31_70b.py
+++ b/src/megatron/bridge/recipes/llama/llama31_70b.py
@@ -194,6 +194,7 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
+            num_workers=8,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/llama/llama31_8b.py
+++ b/src/megatron/bridge/recipes/llama/llama31_8b.py
@@ -194,7 +194,6 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
-            num_workers=1,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/llama/llama31_8b.py
+++ b/src/megatron/bridge/recipes/llama/llama31_8b.py
@@ -194,6 +194,7 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
+            num_workers=8,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/llama/llama32_1b.py
+++ b/src/megatron/bridge/recipes/llama/llama32_1b.py
@@ -193,6 +193,7 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
+            num_workers=8,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/llama/llama32_1b.py
+++ b/src/megatron/bridge/recipes/llama/llama32_1b.py
@@ -193,7 +193,6 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
-            num_workers=1,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/llama/llama32_3b.py
+++ b/src/megatron/bridge/recipes/llama/llama32_3b.py
@@ -193,6 +193,7 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
+            num_workers=8,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/llama/llama32_3b.py
+++ b/src/megatron/bridge/recipes/llama/llama32_3b.py
@@ -193,7 +193,6 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
-            num_workers=1,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/llama/llama3_70b.py
+++ b/src/megatron/bridge/recipes/llama/llama3_70b.py
@@ -190,7 +190,6 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
-            num_workers=1,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/llama/llama3_70b.py
+++ b/src/megatron/bridge/recipes/llama/llama3_70b.py
@@ -190,6 +190,7 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
+            num_workers=8,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/llama/llama3_8b.py
+++ b/src/megatron/bridge/recipes/llama/llama3_8b.py
@@ -193,6 +193,7 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
+            num_workers=8,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/llama/llama3_8b.py
+++ b/src/megatron/bridge/recipes/llama/llama3_8b.py
@@ -193,7 +193,6 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
-            num_workers=1,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/llama/llama4_e128.py
+++ b/src/megatron/bridge/recipes/llama/llama4_e128.py
@@ -197,7 +197,6 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
-            num_workers=1,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/llama/llama4_e128.py
+++ b/src/megatron/bridge/recipes/llama/llama4_e128.py
@@ -197,6 +197,7 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
+            num_workers=8,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/llama/llama4_e16.py
+++ b/src/megatron/bridge/recipes/llama/llama4_e16.py
@@ -197,7 +197,6 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
-            num_workers=1,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/llama/llama4_e16.py
+++ b/src/megatron/bridge/recipes/llama/llama4_e16.py
@@ -197,6 +197,7 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
+            num_workers=8,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/mamba/mamba2_130m.py
+++ b/src/megatron/bridge/recipes/mamba/mamba2_130m.py
@@ -188,6 +188,7 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
+            num_workers=8,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/mamba/mamba2_130m.py
+++ b/src/megatron/bridge/recipes/mamba/mamba2_130m.py
@@ -188,7 +188,6 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
-            num_workers=1,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/mamba/mamba2_1_3b.py
+++ b/src/megatron/bridge/recipes/mamba/mamba2_1_3b.py
@@ -188,6 +188,7 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
+            num_workers=8,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/mamba/mamba2_1_3b.py
+++ b/src/megatron/bridge/recipes/mamba/mamba2_1_3b.py
@@ -188,7 +188,6 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
-            num_workers=1,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/mamba/mamba2_2_7b.py
+++ b/src/megatron/bridge/recipes/mamba/mamba2_2_7b.py
@@ -188,6 +188,7 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
+            num_workers=8,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/mamba/mamba2_2_7b.py
+++ b/src/megatron/bridge/recipes/mamba/mamba2_2_7b.py
@@ -188,7 +188,6 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
-            num_workers=1,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/mamba/mamba2_370m.py
+++ b/src/megatron/bridge/recipes/mamba/mamba2_370m.py
@@ -188,6 +188,7 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
+            num_workers=8,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/mamba/mamba2_370m.py
+++ b/src/megatron/bridge/recipes/mamba/mamba2_370m.py
@@ -188,7 +188,6 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
-            num_workers=1,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/mamba/mamba2_780m.py
+++ b/src/megatron/bridge/recipes/mamba/mamba2_780m.py
@@ -188,6 +188,7 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
+            num_workers=8,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/mamba/mamba2_780m.py
+++ b/src/megatron/bridge/recipes/mamba/mamba2_780m.py
@@ -188,7 +188,6 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
-            num_workers=1,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/mamba/mamba2_8b.py
+++ b/src/megatron/bridge/recipes/mamba/mamba2_8b.py
@@ -189,6 +189,7 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
+            num_workers=8,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/mamba/mamba2_8b.py
+++ b/src/megatron/bridge/recipes/mamba/mamba2_8b.py
@@ -189,7 +189,6 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
-            num_workers=1,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/mamba/mamba2_hybrid_8b.py
+++ b/src/megatron/bridge/recipes/mamba/mamba2_hybrid_8b.py
@@ -189,6 +189,7 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
+            num_workers=8,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/mamba/mamba2_hybrid_8b.py
+++ b/src/megatron/bridge/recipes/mamba/mamba2_hybrid_8b.py
@@ -189,7 +189,6 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
-            num_workers=1,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/mamba/nemotron_nano_12b_v2.py
+++ b/src/megatron/bridge/recipes/mamba/nemotron_nano_12b_v2.py
@@ -188,6 +188,7 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
+            num_workers=8,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/mamba/nemotron_nano_12b_v2.py
+++ b/src/megatron/bridge/recipes/mamba/nemotron_nano_12b_v2.py
@@ -188,7 +188,6 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
-            num_workers=1,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/mamba/nemotron_nano_9b_v2.py
+++ b/src/megatron/bridge/recipes/mamba/nemotron_nano_9b_v2.py
@@ -188,6 +188,7 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
+            num_workers=8,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/mamba/nemotron_nano_9b_v2.py
+++ b/src/megatron/bridge/recipes/mamba/nemotron_nano_9b_v2.py
@@ -188,7 +188,6 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
-            num_workers=1,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/mamba/nemotronh_47b.py
+++ b/src/megatron/bridge/recipes/mamba/nemotronh_47b.py
@@ -188,7 +188,6 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
-            num_workers=1,
         ),
         logger=LoggerConfig(
             log_interval=1,

--- a/src/megatron/bridge/recipes/mamba/nemotronh_47b.py
+++ b/src/megatron/bridge/recipes/mamba/nemotronh_47b.py
@@ -188,6 +188,7 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
+            num_workers=8,
         ),
         logger=LoggerConfig(
             log_interval=1,

--- a/src/megatron/bridge/recipes/mamba/nemotronh_4b.py
+++ b/src/megatron/bridge/recipes/mamba/nemotronh_4b.py
@@ -188,6 +188,7 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
+            num_workers=8,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/mamba/nemotronh_4b.py
+++ b/src/megatron/bridge/recipes/mamba/nemotronh_4b.py
@@ -188,7 +188,6 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
-            num_workers=1,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/mamba/nemotronh_56b.py
+++ b/src/megatron/bridge/recipes/mamba/nemotronh_56b.py
@@ -188,7 +188,6 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
-            num_workers=1,
         ),
         logger=LoggerConfig(
             log_interval=1,

--- a/src/megatron/bridge/recipes/mamba/nemotronh_56b.py
+++ b/src/megatron/bridge/recipes/mamba/nemotronh_56b.py
@@ -188,6 +188,7 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
+            num_workers=8,
         ),
         logger=LoggerConfig(
             log_interval=1,

--- a/src/megatron/bridge/recipes/mamba/nemotronh_8b.py
+++ b/src/megatron/bridge/recipes/mamba/nemotronh_8b.py
@@ -188,6 +188,7 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
+            num_workers=8,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/mamba/nemotronh_8b.py
+++ b/src/megatron/bridge/recipes/mamba/nemotronh_8b.py
@@ -188,7 +188,6 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
-            num_workers=1,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/tests/unit_tests/recipes/gpt/test_gpt3_175b.py
+++ b/tests/unit_tests/recipes/gpt/test_gpt3_175b.py
@@ -213,7 +213,7 @@ class TestPretrainConfig:
         assert config.dataset.num_dataset_builder_threads == 1
         assert config.dataset.data_sharding is True
         assert config.dataset.dataloader_type == "single"
-        assert config.dataset.num_workers == 1
+        assert config.dataset.num_workers == 8
 
     def test_pretrain_config_logger_configuration(self):
         """Test logger configuration."""

--- a/tests/unit_tests/recipes/llama/test_llama2_7b.py
+++ b/tests/unit_tests/recipes/llama/test_llama2_7b.py
@@ -329,7 +329,7 @@ class TestPretrainConfig:
         assert config.dataset.num_dataset_builder_threads == 1
         assert config.dataset.data_sharding is True
         assert config.dataset.dataloader_type == "single"
-        assert config.dataset.num_workers == 1
+        assert config.dataset.num_workers == 8
 
     def test_pretrain_config_logger_configuration(self):
         """Test logger configuration."""

--- a/tests/unit_tests/recipes/llama/test_llama31_405b.py
+++ b/tests/unit_tests/recipes/llama/test_llama31_405b.py
@@ -372,7 +372,7 @@ class TestPretrainConfig:
         assert config.dataset.num_dataset_builder_threads == 1
         assert config.dataset.data_sharding is True
         assert config.dataset.dataloader_type == "single"
-        assert config.dataset.num_workers == 1
+        assert config.dataset.num_workers == 8
 
     def test_pretrain_config_logger_configuration(self):
         """Test logger configuration."""

--- a/tests/unit_tests/recipes/llama/test_llama31_70b.py
+++ b/tests/unit_tests/recipes/llama/test_llama31_70b.py
@@ -350,7 +350,7 @@ class TestPretrainConfig:
         assert config.dataset.num_dataset_builder_threads == 1
         assert config.dataset.data_sharding is True
         assert config.dataset.dataloader_type == "single"
-        assert config.dataset.num_workers == 1
+        assert config.dataset.num_workers == 8
 
     def test_pretrain_config_logger_configuration(self):
         """Test logger configuration."""

--- a/tests/unit_tests/recipes/llama/test_llama31_8b.py
+++ b/tests/unit_tests/recipes/llama/test_llama31_8b.py
@@ -363,7 +363,7 @@ class TestPretrainConfig:
         assert config.dataset.num_dataset_builder_threads == 1
         assert config.dataset.data_sharding is True
         assert config.dataset.dataloader_type == "single"
-        assert config.dataset.num_workers == 1
+        assert config.dataset.num_workers == 8
 
     def test_pretrain_config_logger_configuration(self):
         """Test logger configuration."""

--- a/tests/unit_tests/recipes/llama/test_llama32_1b.py
+++ b/tests/unit_tests/recipes/llama/test_llama32_1b.py
@@ -303,7 +303,7 @@ class TestPretrainConfig:
         assert config.dataset.num_dataset_builder_threads == 1
         assert config.dataset.data_sharding is True
         assert config.dataset.dataloader_type == "single"
-        assert config.dataset.num_workers == 1
+        assert config.dataset.num_workers == 8
 
     def test_pretrain_config_logger_configuration(self):
         """Test logger configuration."""

--- a/tests/unit_tests/recipes/llama/test_llama32_3b.py
+++ b/tests/unit_tests/recipes/llama/test_llama32_3b.py
@@ -303,7 +303,7 @@ class TestPretrainConfig:
         assert config.dataset.num_dataset_builder_threads == 1
         assert config.dataset.data_sharding is True
         assert config.dataset.dataloader_type == "single"
-        assert config.dataset.num_workers == 1
+        assert config.dataset.num_workers == 8
 
     def test_pretrain_config_logger_configuration(self):
         """Test logger configuration."""

--- a/tests/unit_tests/recipes/llama/test_llama3_70b.py
+++ b/tests/unit_tests/recipes/llama/test_llama3_70b.py
@@ -343,7 +343,7 @@ class TestPretrainConfig:
         assert config.dataset.num_dataset_builder_threads == 1
         assert config.dataset.data_sharding is True
         assert config.dataset.dataloader_type == "single"
-        assert config.dataset.num_workers == 1
+        assert config.dataset.num_workers == 8
 
     def test_pretrain_config_logger_configuration(self):
         """Test logger configuration."""

--- a/tests/unit_tests/recipes/llama/test_llama3_70b_16k.py
+++ b/tests/unit_tests/recipes/llama/test_llama3_70b_16k.py
@@ -276,7 +276,7 @@ class TestPretrainConfig:
         assert config.dataset.num_dataset_builder_threads == 1
         assert config.dataset.data_sharding is True
         assert config.dataset.dataloader_type == "single"
-        assert config.dataset.num_workers == 1
+        assert config.dataset.num_workers == 8
 
     def test_pretrain_config_logger_configuration(self):
         """Test logger configuration."""

--- a/tests/unit_tests/recipes/llama/test_llama3_70b_64k.py
+++ b/tests/unit_tests/recipes/llama/test_llama3_70b_64k.py
@@ -282,7 +282,7 @@ class TestPretrainConfig:
         assert config.dataset.num_dataset_builder_threads == 1
         assert config.dataset.data_sharding is True
         assert config.dataset.dataloader_type == "single"
-        assert config.dataset.num_workers == 1
+        assert config.dataset.num_workers == 8
 
     def test_pretrain_config_logger_configuration(self):
         """Test logger configuration."""

--- a/tests/unit_tests/recipes/llama/test_llama3_8b.py
+++ b/tests/unit_tests/recipes/llama/test_llama3_8b.py
@@ -329,7 +329,7 @@ class TestPretrainConfig:
         assert config.dataset.num_dataset_builder_threads == 1
         assert config.dataset.data_sharding is True
         assert config.dataset.dataloader_type == "single"
-        assert config.dataset.num_workers == 1
+        assert config.dataset.num_workers == 8
 
     def test_pretrain_config_logger_configuration(self):
         """Test logger configuration."""

--- a/tests/unit_tests/recipes/llama/test_llama3_8b_16k.py
+++ b/tests/unit_tests/recipes/llama/test_llama3_8b_16k.py
@@ -301,7 +301,7 @@ class TestPretrainConfig:
         assert config.dataset.num_dataset_builder_threads == 1
         assert config.dataset.data_sharding is True
         assert config.dataset.dataloader_type == "single"
-        assert config.dataset.num_workers == 1
+        assert config.dataset.num_workers == 8
 
     def test_pretrain_config_logger_configuration(self):
         """Test logger configuration."""

--- a/tests/unit_tests/recipes/mamba/test_mamba2_130m.py
+++ b/tests/unit_tests/recipes/mamba/test_mamba2_130m.py
@@ -297,7 +297,7 @@ class TestPretrainConfig:
         assert config.dataset.num_dataset_builder_threads == 1
         assert config.dataset.data_sharding is True
         assert config.dataset.dataloader_type == "single"
-        assert config.dataset.num_workers == 1
+        assert config.dataset.num_workers == 8
 
     def test_pretrain_config_logger_configuration(self):
         """Test logger configuration."""

--- a/tests/unit_tests/recipes/mamba/test_mamba2_1_3b.py
+++ b/tests/unit_tests/recipes/mamba/test_mamba2_1_3b.py
@@ -302,7 +302,7 @@ class TestPretrainConfig:
         assert config.dataset.num_dataset_builder_threads == 1
         assert config.dataset.data_sharding is True
         assert config.dataset.dataloader_type == "single"
-        assert config.dataset.num_workers == 1
+        assert config.dataset.num_workers == 8
 
     def test_pretrain_config_logger_configuration(self):
         """Test logger configuration."""

--- a/tests/unit_tests/recipes/mamba/test_mamba2_2_7b.py
+++ b/tests/unit_tests/recipes/mamba/test_mamba2_2_7b.py
@@ -302,7 +302,7 @@ class TestPretrainConfig:
         assert config.dataset.num_dataset_builder_threads == 1
         assert config.dataset.data_sharding is True
         assert config.dataset.dataloader_type == "single"
-        assert config.dataset.num_workers == 1
+        assert config.dataset.num_workers == 8
 
     def test_pretrain_config_logger_configuration(self):
         """Test logger configuration."""

--- a/tests/unit_tests/recipes/mamba/test_mamba2_370m.py
+++ b/tests/unit_tests/recipes/mamba/test_mamba2_370m.py
@@ -301,7 +301,7 @@ class TestPretrainConfig:
         assert config.dataset.num_dataset_builder_threads == 1
         assert config.dataset.data_sharding is True
         assert config.dataset.dataloader_type == "single"
-        assert config.dataset.num_workers == 1
+        assert config.dataset.num_workers == 8
 
     def test_pretrain_config_logger_configuration(self):
         """Test logger configuration."""

--- a/tests/unit_tests/recipes/mamba/test_mamba2_780m.py
+++ b/tests/unit_tests/recipes/mamba/test_mamba2_780m.py
@@ -302,7 +302,7 @@ class TestPretrainConfig:
         assert config.dataset.num_dataset_builder_threads == 1
         assert config.dataset.data_sharding is True
         assert config.dataset.dataloader_type == "single"
-        assert config.dataset.num_workers == 1
+        assert config.dataset.num_workers == 8
 
     def test_pretrain_config_logger_configuration(self):
         """Test logger configuration."""

--- a/tests/unit_tests/recipes/mamba/test_mamba2_8b.py
+++ b/tests/unit_tests/recipes/mamba/test_mamba2_8b.py
@@ -317,7 +317,7 @@ class TestPretrainConfig:
         assert config.dataset.num_dataset_builder_threads == 1
         assert config.dataset.data_sharding is True
         assert config.dataset.dataloader_type == "single"
-        assert config.dataset.num_workers == 1
+        assert config.dataset.num_workers == 8
 
     def test_pretrain_config_logger_configuration(self):
         """Test logger configuration."""

--- a/tests/unit_tests/recipes/mamba/test_mamba2_hybrid_8b.py
+++ b/tests/unit_tests/recipes/mamba/test_mamba2_hybrid_8b.py
@@ -317,7 +317,7 @@ class TestPretrainConfig:
         assert config.dataset.num_dataset_builder_threads == 1
         assert config.dataset.data_sharding is True
         assert config.dataset.dataloader_type == "single"
-        assert config.dataset.num_workers == 1
+        assert config.dataset.num_workers == 8
 
     def test_pretrain_config_logger_configuration(self):
         """Test logger configuration."""

--- a/tests/unit_tests/recipes/mamba/test_nemotron_nano_12b_v2.py
+++ b/tests/unit_tests/recipes/mamba/test_nemotron_nano_12b_v2.py
@@ -323,7 +323,7 @@ class TestPretrainConfig:
         assert config.dataset.num_dataset_builder_threads == 1
         assert config.dataset.data_sharding is True
         assert config.dataset.dataloader_type == "single"
-        assert config.dataset.num_workers == 1
+        assert config.dataset.num_workers == 8
 
     def test_pretrain_config_logger_configuration(self):
         """Test logger configuration."""

--- a/tests/unit_tests/recipes/mamba/test_nemotron_nano_9b_v2.py
+++ b/tests/unit_tests/recipes/mamba/test_nemotron_nano_9b_v2.py
@@ -324,7 +324,7 @@ class TestPretrainConfig:
         assert config.dataset.num_dataset_builder_threads == 1
         assert config.dataset.data_sharding is True
         assert config.dataset.dataloader_type == "single"
-        assert config.dataset.num_workers == 1
+        assert config.dataset.num_workers == 8
 
     def test_pretrain_config_logger_configuration(self):
         """Test logger configuration."""

--- a/tests/unit_tests/recipes/mamba/test_nemotronh_47b.py
+++ b/tests/unit_tests/recipes/mamba/test_nemotronh_47b.py
@@ -324,7 +324,7 @@ class TestPretrainConfig:
         assert config.dataset.num_dataset_builder_threads == 1
         assert config.dataset.data_sharding is True
         assert config.dataset.dataloader_type == "single"
-        assert config.dataset.num_workers == 1
+        assert config.dataset.num_workers == 8
 
     def test_pretrain_config_logger_configuration(self):
         """Test logger configuration."""

--- a/tests/unit_tests/recipes/mamba/test_nemotronh_4b.py
+++ b/tests/unit_tests/recipes/mamba/test_nemotronh_4b.py
@@ -324,7 +324,7 @@ class TestPretrainConfig:
         assert config.dataset.num_dataset_builder_threads == 1
         assert config.dataset.data_sharding is True
         assert config.dataset.dataloader_type == "single"
-        assert config.dataset.num_workers == 1
+        assert config.dataset.num_workers == 8
 
     def test_pretrain_config_logger_configuration(self):
         """Test logger configuration."""

--- a/tests/unit_tests/recipes/mamba/test_nemotronh_56b.py
+++ b/tests/unit_tests/recipes/mamba/test_nemotronh_56b.py
@@ -324,7 +324,7 @@ class TestPretrainConfig:
         assert config.dataset.num_dataset_builder_threads == 1
         assert config.dataset.data_sharding is True
         assert config.dataset.dataloader_type == "single"
-        assert config.dataset.num_workers == 1
+        assert config.dataset.num_workers == 8
 
     def test_pretrain_config_logger_configuration(self):
         """Test logger configuration."""

--- a/tests/unit_tests/recipes/mamba/test_nemotronh_8b.py
+++ b/tests/unit_tests/recipes/mamba/test_nemotronh_8b.py
@@ -324,7 +324,7 @@ class TestPretrainConfig:
         assert config.dataset.num_dataset_builder_threads == 1
         assert config.dataset.data_sharding is True
         assert config.dataset.dataloader_type == "single"
-        assert config.dataset.num_workers == 1
+        assert config.dataset.num_workers == 8
 
     def test_pretrain_config_logger_configuration(self):
         """Test logger configuration."""


### PR DESCRIPTION
the default for the dataloading config is to use 8 workers: https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/eb25f11bd8a479a104a8eea8f82db059e9cfe31f/src/megatron/bridge/training/config.py#L151-L153

to match default workers used for mock data/recipes in nemo2: https://github.com/NVIDIA/NeMo/blob/449b7df1b88f7e6cbd8eb62a3300b60c8f565645/nemo/collections/llm/gpt/data/mock.py#L64

so we should remove the override set in these recipes