### PR TITLE
1F1B EP A2A overlap integration

### DIFF
--- a/src/megatron/bridge/training/comm_overlap.py
+++ b/src/megatron/bridge/training/comm_overlap.py
@@ -500,7 +500,6 @@ class CommOverlapConfig:
             )
 
         if self.user_comm_overlap_cfg.delay_wgrad_compute is True:
-            assert HAVE_TE, "TE is required for delay_wgrad_compute"
             assert is_te_min_version("2.7.0"), (
                 f"TE version >= 2.7.0 is required for delay_wgrad_compute, \
                 current TE version: {get_te_version()}"

--- a/src/megatron/bridge/training/comm_overlap.py
+++ b/src/megatron/bridge/training/comm_overlap.py
@@ -504,9 +504,10 @@ class CommOverlapConfig:
                 f"TE version >= 2.7.0 is required for delay_wgrad_compute, \
                 current TE version: {get_te_version()}"
             )
-            assert model_cfg.overlap_moe_expert_parallel_comm, (
-                "overlap_moe_expert_parallel_comm is required for delay_wgrad_compute"
-            )
+            assert (
+                model_cfg.overlap_moe_expert_parallel_comm
+                or self.user_comm_overlap_cfg.overlap_moe_expert_parallel_comm
+            ), "overlap_moe_expert_parallel_comm is required for delay_wgrad_compute"
             assert not model_cfg.moe_use_legacy_grouped_gemm, (
                 "delay_wgrad_compute is not supported with legacy groupedgemm implementation"
             )

--- a/src/megatron/bridge/training/comm_overlap.py
+++ b/src/megatron/bridge/training/comm_overlap.py
@@ -477,6 +477,10 @@ class CommOverlapConfig:
             assert model_cfg.bf16 or model_cfg.fp16, (
                 "overlap_moe_expert_parallel_comm is only supported when using bf16 or fp16 models"
             )
+            assert model_cfg.pipeline_model_parallel_size == 1 or model_cfg.virtual_pipeline_model_parallel_size > 1, (
+                "overlap_moe_expert_parallel_comm is only supported when pipeline_model_parallel_size == 1 or \
+                    virtual_pipeline_model_parallel_size > 1"
+            )
 
         if self.user_comm_overlap_cfg.delay_wgrad_compute is True:
             assert HAVE_TE, "TE is required for delay_wgrad_compute"

--- a/src/megatron/bridge/training/comm_overlap.py
+++ b/src/megatron/bridge/training/comm_overlap.py
@@ -458,28 +458,36 @@ class CommOverlapConfig:
             comm_overlap_cfg.batch_p2p_comm = False
 
         # MOE expert parallel comm overlap
-        assert hasattr(model_cfg, "overlap_moe_expert_parallel_comm"), \
+        assert hasattr(model_cfg, "overlap_moe_expert_parallel_comm"), (
             f"model_cfg: {model_cfg} does not have overlap_moe_expert_parallel_comm"
+        )
 
         if self.user_comm_overlap_cfg.overlap_moe_expert_parallel_comm is True:
-            assert model_cfg.expert_model_parallel_size > 1, \
-                f"overlap_moe_expert_parallel_comm is only supported when expert_model_parallel_size > 1"
-            assert model_cfg.num_moe_experts > 1, \
+            assert model_cfg.expert_model_parallel_size > 1, (
+                "overlap_moe_expert_parallel_comm is only supported when expert_model_parallel_size > 1"
+            )
+            assert model_cfg.num_moe_experts > 1, (
                 f"overlap_moe_expert_parallel_comm is only supported when num_moe_experts > 1, \
                     but got {model_cfg.num_moe_experts}"
-            assert model_cfg.moe_token_dispatcher_type == "alltoall", \
-                f"overlap_moe_expert_parallel_comm is only supported when moe_token_dispatcher_type == 'alltoall',\
+            )
+            assert model_cfg.moe_token_dispatcher_type in ["alltoall", "flex"], (
+                f"overlap_moe_expert_parallel_comm is only supported when moe_token_dispatcher_type == 'alltoall' or 'flex',\
                       but got {model_cfg.moe_token_dispatcher_type}"
-            assert model_cfg.bf16 or model_cfg.fp16, \
-                f"overlap_moe_expert_parallel_comm is only supported when using bf16 or fp16 models"
+            )
+            assert model_cfg.bf16 or model_cfg.fp16, (
+                "overlap_moe_expert_parallel_comm is only supported when using bf16 or fp16 models"
+            )
 
         if self.user_comm_overlap_cfg.delay_wgrad_compute is True:
             assert HAVE_TE, "TE is required for delay_wgrad_compute"
-            assert is_te_min_version("2.7.0"), f"TE version >= 2.7.0 is required for delay_wgrad_compute, \
+            assert is_te_min_version("2.7.0"), (
+                f"TE version >= 2.7.0 is required for delay_wgrad_compute, \
                 current TE version: {get_te_version()}"
-            
-            assert model_cfg.overlap_moe_expert_parallel_comm, \
+            )
+
+            assert model_cfg.overlap_moe_expert_parallel_comm, (
                 "overlap_moe_expert_parallel_comm is required for delay_wgrad_compute"
+            )
 
         comm_overlap_cfg = self._override_user_cfgs(comm_overlap_cfg)
         return comm_overlap_cfg

--- a/src/megatron/bridge/training/gpt_step.py
+++ b/src/megatron/bridge/training/gpt_step.py
@@ -286,13 +286,14 @@ def get_batch(
     )
 
 
-def forward_step(state: GlobalState, data_iterator: Iterable, model: GPTModel) -> tuple[torch.Tensor, partial]:
+def forward_step(state: GlobalState, data_iterator: Iterable, model: GPTModel, return_schedule_plan: bool = False) -> tuple[torch.Tensor, partial]:
     """Forward training step.
 
     Args:
         state: Global state for the run
         data_iterator: Input data iterator
         model: The GPT Model
+        return_schedule_plan (bool): Whether to return the schedule plan instead of the output tensor
 
     Returns:
         tuple containing the output tensor and the loss function
@@ -327,6 +328,14 @@ def forward_step(state: GlobalState, data_iterator: Iterable, model: GPTModel) -
         forward_args["packed_seq_params"] = get_packed_seq_params(packed_seq_params)
 
     with straggler_timer:
-        output_tensor = model(**forward_args)
+        if return_schedule_plan:
+            assert config.overlap_moe_expert_parallel_comm, \
+                "overlap_moe_expert_parallel_comm must be enabled to return the schedule plan"
+            schedule_plan = model.build_schedule_plan(
+                tokens, position_ids, attention_mask, labels=labels, loss_mask=loss_mask
+            )
+            return schedule_plan, partial(masked_next_token_loss, loss_mask)
+        else:
+            output_tensor = model(**forward_args)
 
     return output_tensor, partial(masked_next_token_loss, loss_mask)

--- a/src/megatron/bridge/training/gpt_step.py
+++ b/src/megatron/bridge/training/gpt_step.py
@@ -286,7 +286,9 @@ def get_batch(
     )
 
 
-def forward_step(state: GlobalState, data_iterator: Iterable, model: GPTModel, return_schedule_plan: bool = False) -> tuple[torch.Tensor, partial]:
+def forward_step(
+    state: GlobalState, data_iterator: Iterable, model: GPTModel, return_schedule_plan: bool = False
+) -> tuple[torch.Tensor, partial]:
     """Forward training step.
 
     Args:
@@ -329,8 +331,9 @@ def forward_step(state: GlobalState, data_iterator: Iterable, model: GPTModel, r
 
     with straggler_timer:
         if return_schedule_plan:
-            assert config.overlap_moe_expert_parallel_comm, \
+            assert config.overlap_moe_expert_parallel_comm, (
                 "overlap_moe_expert_parallel_comm must be enabled to return the schedule plan"
+            )
             schedule_plan = model.build_schedule_plan(
                 tokens, position_ids, attention_mask, labels=labels, loss_mask=loss_mask
             )

--- a/src/megatron/bridge/training/utils/train_utils.py
+++ b/src/megatron/bridge/training/utils/train_utils.py
@@ -572,7 +572,7 @@ def maybe_inject_state(forward_step_func: Callable, state: GlobalState, num_fw_a
     """
     if not num_fw_args:
         num_fw_args = len(inspect.signature(forward_step_func).parameters)
-    if num_fw_args == 3:
+    if num_fw_args == 4: # megatron bridge gpt_step.py forward_step has 4 args
         # inject global_state
         return partial(forward_step_func, state)
     else:
@@ -582,9 +582,9 @@ def maybe_inject_state(forward_step_func: Callable, state: GlobalState, num_fw_a
 def check_forward_step_func_num_args(forward_step_func: Callable) -> int:
     """Check if the forward step function has a supported number of arguments.
 
-    Currently supports 2 or 3 arguments:
+    Currently supports 2 or 4 arguments:
     - func(data_iterator, model)
-    - func(state, data_iterator, model)
+    - func(state, data_iterator, model, return_schedule_plan: bool = False)
 
     Args:
         forward_step_func: The function to check.
@@ -593,14 +593,14 @@ def check_forward_step_func_num_args(forward_step_func: Callable) -> int:
         The number of arguments the function takes.
 
     Raises:
-        AssertionError: If the function does not have 2 or 3 arguments.
+        AssertionError: If the function does not have 2 or 4 arguments.
     """
     num_fw_args = len(inspect.signature(forward_step_func).parameters)
     fail_msg = f"""
     forward_step_func has {num_fw_args} arguments. Only the following signatures are supported:
         2 args: forward_step_func(data_iterator: Iterable, model: GPTModel)
-        3 args: forward_step_func(state: GlobalState, data_iterator: Iterable, model: GPTModel)
+        4 args: forward_step_func(state: GlobalState, data_iterator: Iterable, model: GPTModel, return_schedule_plan: bool = False)
     """
-    assert num_fw_args in (2, 3), fail_msg
+    assert num_fw_args in (2, 4), fail_msg
 
     return num_fw_args

--- a/src/megatron/bridge/training/utils/train_utils.py
+++ b/src/megatron/bridge/training/utils/train_utils.py
@@ -572,7 +572,7 @@ def maybe_inject_state(forward_step_func: Callable, state: GlobalState, num_fw_a
     """
     if not num_fw_args:
         num_fw_args = len(inspect.signature(forward_step_func).parameters)
-    if num_fw_args == 4: # megatron bridge gpt_step.py forward_step has 4 args
+    if num_fw_args == 4:  # megatron bridge gpt_step.py forward_step has 4 args
         # inject global_state
         return partial(forward_step_func, state)
     else:

--- a/tests/functional_tests/training/test_nvrx_straggler.py
+++ b/tests/functional_tests/training/test_nvrx_straggler.py
@@ -185,12 +185,12 @@ def create_timed_forward_step_func(sleep_time: float = 1.0):
         A forward step function compatible with megatron training
     """
 
-    def timed_forward_step_func(state: GlobalState, data_iterator, model):
+    def timed_forward_step_func(state: GlobalState, data_iterator, model, return_schedule_plan: bool = False):
         if torch.distributed.is_initialized() and torch.distributed.get_rank() == 0:
             time.sleep(sleep_time)
             print(f"Rank {torch.distributed.get_rank()}: Simulated slow forward step (slept {sleep_time}s)")
 
-        return forward_step(state, data_iterator, model)
+        return forward_step(state, data_iterator, model, return_schedule_plan=return_schedule_plan)
 
     return timed_forward_step_func
 

--- a/tests/unit_tests/training/test_comm_overlap.py
+++ b/tests/unit_tests/training/test_comm_overlap.py
@@ -483,7 +483,6 @@ class TestMegatronCommOverlapConfig:
         assert model_cfg.tp_comm_overlap_cfg is None
         assert model_cfg.tp_comm_bootstrap_backend is None
 
-    @patch("megatron.bridge.training.comm_overlap.HAVE_TE", True)
     def test_tp_overlap_config_filters_none_values(self):
         """Test that None values are filtered from tp_comm_overlap_cfg dict."""
         from dataclasses import dataclass
@@ -551,6 +550,7 @@ class TestMegatronCommOverlapConfig:
             moe_shared_expert_overlap=False,
             mtp_num_layers=None,
             moe_use_legacy_grouped_gemm=False,
+            add_bias_linear=False,
         )
 
         with patch("megatron.bridge.training.comm_overlap.is_torch_min_version", return_value=True):
@@ -558,7 +558,6 @@ class TestMegatronCommOverlapConfig:
 
         assert result.overlap_moe_expert_parallel_comm is True
 
-    @patch("megatron.bridge.training.comm_overlap.HAVE_TE", True)
     def test_delay_wgrad_config_validation(self):
         """delay_wgrad_compute passes when TE and EP overlap conditions are met."""
         comm_cfg = CommOverlapConfig(
@@ -578,13 +577,13 @@ class TestMegatronCommOverlapConfig:
             moe_token_dispatcher_type="alltoall",
             bf16=True,
             moe_use_legacy_grouped_gemm=False,
+            add_bias_linear=False,
         )
 
         with patch("megatron.bridge.training.comm_overlap.is_te_min_version", return_value=True):
             result = comm_cfg._get_model_comm_overlap_cfgs(model_cfg)
             assert result.delay_wgrad_compute is True
 
-    @patch("megatron.bridge.training.comm_overlap.HAVE_TE", True)
     def test_delay_wgrad_requires_ep_overlap(self):
         """delay_wgrad_compute requires EP overlap to be enabled."""
         comm_cfg = CommOverlapConfig(
@@ -604,6 +603,7 @@ class TestMegatronCommOverlapConfig:
             moe_token_dispatcher_type="alltoall",
             bf16=True,
             moe_use_legacy_grouped_gemm=False,
+            add_bias_linear=False,
         )
 
         with patch("megatron.bridge.training.comm_overlap.is_te_min_version", return_value=True):

--- a/tests/unit_tests/training/test_comm_overlap.py
+++ b/tests/unit_tests/training/test_comm_overlap.py
@@ -526,3 +526,89 @@ class TestMegatronCommOverlapConfig:
         # Check that None value keys are filtered out
         for key in filtered_keys:
             assert key not in model_cfg.tp_comm_overlap_cfg
+
+    def test_moe_ep_overlap_config_validation(self):
+        comm_cfg = CommOverlapConfig(
+            tp_comm_overlap=False,
+            data_parallel_size=1,
+            overlap_moe_expert_parallel_comm=True,
+        )
+
+        # Minimal valid config to pass MOE EP overlap assertions
+        model_cfg = create_gpt_config(
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=1,
+            virtual_pipeline_model_parallel_size=None,
+            sequence_parallel=False,
+            expert_model_parallel_size=2,
+            num_moe_experts=2,
+            moe_token_dispatcher_type="alltoall",
+            bf16=True,
+            fp16=False,
+            recompute_granularity=None,
+            recompute_method=None,
+            recompute_num_layers=None,
+            moe_shared_expert_overlap=False,
+            mtp_num_layers=None,
+            moe_use_legacy_grouped_gemm=False,
+        )
+
+        with patch("megatron.bridge.training.comm_overlap.is_torch_min_version", return_value=True):
+            result = comm_cfg._get_model_comm_overlap_cfgs(model_cfg)
+
+        assert result.overlap_moe_expert_parallel_comm is True
+
+    @patch("megatron.bridge.training.comm_overlap.HAVE_TE", True)
+    def test_delay_wgrad_config_validation(self):
+        """delay_wgrad_compute passes when TE and EP overlap conditions are met."""
+        comm_cfg = CommOverlapConfig(
+            tp_comm_overlap=False,
+            data_parallel_size=1,
+            delay_wgrad_compute=True,
+            overlap_moe_expert_parallel_comm=True,
+        )
+
+        model_cfg = create_gpt_config(
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=1,
+            virtual_pipeline_model_parallel_size=None,
+            sequence_parallel=False,
+            expert_model_parallel_size=2,
+            num_moe_experts=2,
+            moe_token_dispatcher_type="alltoall",
+            bf16=True,
+            moe_use_legacy_grouped_gemm=False,
+        )
+
+        with patch("megatron.bridge.training.comm_overlap.is_te_min_version", return_value=True):
+            result = comm_cfg._get_model_comm_overlap_cfgs(model_cfg)
+            assert result.delay_wgrad_compute is True
+
+    @patch("megatron.bridge.training.comm_overlap.HAVE_TE", True)
+    def test_delay_wgrad_requires_ep_overlap(self):
+        """delay_wgrad_compute requires EP overlap to be enabled."""
+        comm_cfg = CommOverlapConfig(
+            tp_comm_overlap=False,
+            data_parallel_size=1,
+            delay_wgrad_compute=True,
+            overlap_moe_expert_parallel_comm=False,
+        )
+
+        model_cfg = create_gpt_config(
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=1,
+            virtual_pipeline_model_parallel_size=None,
+            sequence_parallel=False,
+            expert_model_parallel_size=2,
+            num_moe_experts=2,
+            moe_token_dispatcher_type="alltoall",
+            bf16=True,
+            moe_use_legacy_grouped_gemm=False,
+        )
+
+        with patch("megatron.bridge.training.comm_overlap.is_te_min_version", return_value=True):
+            try:
+                comm_cfg._get_model_comm_overlap_cfgs(model_cfg)
+                assert False, "Expected AssertionError when EP overlap is not enabled"
+            except AssertionError:
+                pass


### PR DESCRIPTION
This PR creates an interface to use the 1F1B-based EP comm overlap. 

## How to enable this feature
`comm_overlap.overlap_moe_expert_parallel_comm=True`

_If you have TE >= v2.7.0 also use_
`comm_overlap.delay_wgrad_compute=True`

## Requirements
1. MCore ToT
2. EP > 1
3. moe_token_dispatcher_type == 'alltoall' or 'flex'
4. PP==1 or ( PP>1 and VPP > 1)

## Related Mcore MRs:
* https://gitlab-master.nvidia.com/ADLR/megatron-lm/-/merge_requests/3217
* https://gitlab-master.nvidia.com/ADLR/megatron-lm/-/merge_requests/3470
* https://gitlab-master.nvidia.com/ADLR/megatron-lm/-/merge_requests/3074
