### PR TITLE
feat: in process restart integration

### DIFF
--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -1273,28 +1273,6 @@ def _load_checkpoint_from_path(
     return state.train_state.step, state.train_state.floating_point_operations_so_far
 
 
-def init_async_checkpoint_worker(global_state: GlobalState) -> None:
-    """Initialize the async checkpoint worker if enabled.
-
-    Creates a persistent background worker for handling asynchronous checkpoint saves
-    when both async_save and use_persistent_ckpt_worker are enabled in the configuration.
-
-    Args:
-        global_state: The GlobalState instance containing the configuration and async queue.
-    """
-    from megatron.bridge.utils.common_utils import print_rank_0
-
-    checkpoint_config = global_state.cfg.checkpoint
-
-    if (
-        checkpoint_config.save is not None
-        and checkpoint_config.async_save
-        and checkpoint_config.use_persistent_ckpt_worker
-    ):
-        global_state.initialize_async_checkpoint_worker()
-        print_rank_0("Initialized persistent async checkpoint worker")
-
-
 def init_checkpointing_context(checkpoint_config: CheckpointConfig) -> dict[str, Any]:
     """Initialize the checkpointing context, primarily for local checkpointing support.
 

--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -1291,9 +1291,7 @@ def init_async_checkpoint_worker(global_state: GlobalState) -> None:
         and checkpoint_config.async_save
         and checkpoint_config.use_persistent_ckpt_worker
     ):
-        # Access the async_calls_queue property to trigger lazy initialization
-        # This creates the persistent worker immediately during setup
-        _ = global_state.async_calls_queue
+        global_state.initialize_async_checkpoint_worker()
         print_rank_0("Initialized persistent async checkpoint worker")
 
 

--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -29,7 +29,6 @@ from megatron.bridge.models.mamba.mamba_provider import MambaProvider
 from megatron.bridge.peft.base import PEFT
 from megatron.bridge.training.comm_overlap import CommOverlapConfig
 from megatron.bridge.training.deepep import validate_deepep
-from megatron.bridge.training.inprocess_restart import InProcessRestartConfig
 from megatron.bridge.training.mixed_precision import MixedPrecisionConfig
 from megatron.bridge.training.tokenizers.config import TokenizerConfig
 from megatron.bridge.training.utils.config_utils import _ConfigContainerBase as Container
@@ -710,6 +709,61 @@ class NVRxStragglerDetectionConfig:
                 raise ValueError("gpu_relative_perf_threshold must be between 0.0 and 1.0.")
             if not (0.0 <= self.gpu_individual_perf_threshold <= 1.0):
                 raise ValueError("gpu_individual_perf_threshold must be between 0.0 and 1.0.")
+
+
+@dataclass
+class InProcessRestartConfig:
+    """Configuration settings for NVIDIA Resiliency Extension in-process restart functionality."""
+
+    enabled: bool = False
+    """Enable in-process restart mechanism from nvidia-resiliency-ext."""
+
+    max_iterations: Optional[int] = None
+    """Maximum number of in-process restart iterations."""
+
+    monitor_thread_interval: float = 1.0
+    """Monitoring interval (in seconds) for the monitoring thread."""
+
+    monitor_process_interval: float = 1.0
+    """Monitoring interval (in seconds) for the monitoring process."""
+
+    progress_watchdog_interval: float = 1.0
+    """Interval (in seconds) for automatic progress watchdog timestamp updates."""
+
+    heartbeat_interval: float = 30.0
+    """Monitoring interval (in seconds) for detecting unresponsive ranks."""
+
+    soft_timeout: float = 60.0
+    """Soft progress timeout (in seconds)."""
+
+    hard_timeout: float = 90.0
+    """Hard progress timeout (in seconds)."""
+
+    heartbeat_timeout: float = 60.0
+    """Timeout (in seconds) for a missing rank detection heartbeat."""
+
+    barrier_timeout: float = 120.0
+    """Timeout (in seconds) for internal distributed barrier."""
+
+    completion_timeout: float = 120.0
+    """Timeout (in seconds) for barrier on completion on all ranks."""
+
+    last_call_wait: float = 1.0
+    """Time interval (in seconds) for other ranks to report concurrent terminal failures."""
+
+    termination_grace_time: float = 1.0
+    """Interval (in seconds) between SIGTERM and SIGKILL issued on hard timeout."""
+
+    granularity: Literal["node", "rank"] = "node"
+    """Granularity for in-process restart."""
+
+    active_world_size: Optional[int] = None
+    """The number of ranks initially executing the workload.
+    The remaining ranks from the allocation are set aside as warm reserve.
+    If None, defaults to WORLD_SIZE environment variable."""
+
+    empty_cuda_cache: bool = True
+    """Empty CUDA cache during restart finalization."""
 
 
 # ---------------- Container config (standalone top-level config) ----------------

--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -29,6 +29,7 @@ from megatron.bridge.models.mamba.mamba_provider import MambaProvider
 from megatron.bridge.peft.base import PEFT
 from megatron.bridge.training.comm_overlap import CommOverlapConfig
 from megatron.bridge.training.deepep import validate_deepep
+from megatron.bridge.training.inprocess_restart import InProcessRestartConfig
 from megatron.bridge.training.mixed_precision import MixedPrecisionConfig
 from megatron.bridge.training.tokenizers.config import TokenizerConfig
 from megatron.bridge.training.utils.config_utils import _ConfigContainerBase as Container
@@ -735,6 +736,7 @@ class ConfigContainer(Container):
     peft: Optional[PEFT] = None
     comm_overlap: Optional[CommOverlapConfig] = None
     mixed_precision: Optional[Union[MixedPrecisionConfig, str]] = None
+    inprocess_restart: Optional[InProcessRestartConfig] = None
 
     def get_data_parallel_size(self, world_size: int) -> int:
         """Calculate the data parallel size based on the model configuration."""

--- a/src/megatron/bridge/training/initialize.py
+++ b/src/megatron/bridge/training/initialize.py
@@ -363,7 +363,7 @@ def _initialize_distributed(
 
         # Force NCCL backend initialization if using in-process restart
         if use_inprocess_restart:
-            maybe_force_nccl_backend_init(torch.cuda.current_device())
+            force_nccl_backend_init(torch.cuda.current_device())
 
         if dist_config.external_gpu_device_mapping:
             torch.distributed.barrier(device_ids=[0])
@@ -503,7 +503,7 @@ def _warmup_jit_function(model_config: GPTModelProvider | T5ModelProvider, micro
     torch.cuda.empty_cache()
 
 
-def maybe_force_nccl_backend_init(device_id) -> None:
+def force_nccl_backend_init(device_id: torch.device) -> None:
     """Force NCCL backend initialization for in-process restart compatibility.
 
     The nvidia-resiliency-ext in-process restart uses destroy_process_group to

--- a/src/megatron/bridge/training/initialize.py
+++ b/src/megatron/bridge/training/initialize.py
@@ -41,6 +41,7 @@ def initialize_megatron(
     skip_mpu_initialization: bool = False,
     get_embedding_ranks: Optional[Callable[[list[int], Optional[int]], list[int]]] = None,
     get_position_embedding_ranks: Optional[Callable[[list[int], Optional[int]], list[int]]] = None,
+    restart_store: Optional[torch.distributed.Store] = None,
 ) -> Optional[Callable[[], None]]:
     """Initialize Megatron core components and distributed setup.
 
@@ -53,6 +54,7 @@ def initialize_megatron(
         skip_mpu_initialization: If True, skips MPU initialization (for external managers).
         get_embedding_ranks: Optional function to determine embedding layer ranks.
         get_position_embedding_ranks: Optional function to determine position embedding ranks.
+        restart_store: Optional store for in-process restart.
 
     Returns:
         An optional callable to finish MPU initialization if lazy_mpu_init is True,
@@ -68,6 +70,7 @@ def initialize_megatron(
     rng_config = cfg.rng
     rerun_state_machine_config = cfg.rerun_state_machine
     train_config = cfg.train
+    use_inprocess_restart = cfg.inprocess_restart is not None and cfg.inprocess_restart.enabled
 
     # Prep for checkpoint conversion.
     # if args.ckpt_convert_format is not None:
@@ -102,6 +105,8 @@ def initialize_megatron(
         get_embedding_ranks=get_embedding_ranks,
         get_position_embedding_ranks=get_position_embedding_ranks,
         skip_mpu_initialization=skip_mpu_initialization,
+        restart_store=restart_store,
+        use_inprocess_restart=use_inprocess_restart,
     )
 
 
@@ -114,6 +119,8 @@ def torch_dist_init(
     get_embedding_ranks: Optional[Callable[[list[int], Optional[int]], list[int]]],
     get_position_embedding_ranks: Optional[Callable[[list[int], Optional[int]], list[int]]],
     skip_mpu_initialization: bool,
+    restart_store: Optional[torch.distributed.Store] = None,
+    use_inprocess_restart: bool = False,
 ) -> Optional[Callable[[], None]]:
     """Initialize torch.distributed and dependent components.
 
@@ -144,6 +151,8 @@ def torch_dist_init(
             num_distributed_optimizer_instances=num_distributed_optimizer_instances,
             get_embedding_ranks=get_embedding_ranks,
             get_position_embedding_ranks=get_position_embedding_ranks,
+            restart_store=restart_store,
+            use_inprocess_restart=use_inprocess_restart,
         )
 
         # Random seeds for reproducibility.
@@ -317,6 +326,8 @@ def _initialize_distributed(
     num_distributed_optimizer_instances: int,
     get_embedding_ranks: Optional[Callable[[list[int], Optional[int]], list[int]]],
     get_position_embedding_ranks: Optional[Callable[[list[int], Optional[int]], list[int]]],
+    restart_store: Optional[torch.distributed.Store] = None,
+    use_inprocess_restart: bool = False,
 ) -> None:
     """Initialize torch.distributed and core model parallel."""
 
@@ -344,10 +355,16 @@ def _initialize_distributed(
             "backend": dist_config.distributed_backend,
             "world_size": get_world_size_safe(),
             "rank": get_rank_safe(),
+            "store": restart_store,
             "timeout": datetime.timedelta(minutes=dist_config.distributed_timeout_minutes),
         }
 
         torch.distributed.init_process_group(**init_process_group_kwargs)
+
+        # Force NCCL backend initialization if using in-process restart
+        if use_inprocess_restart:
+            maybe_force_nccl_backend_init(torch.cuda.current_device())
+
         if dist_config.external_gpu_device_mapping:
             torch.distributed.barrier(device_ids=[0])
         else:
@@ -484,3 +501,21 @@ def _warmup_jit_function(model_config: GPTModelProvider | T5ModelProvider, micro
             output = bias_dropout_add_fused_train([input, bias], residual, dropout_rate)
     del bias, input, residual, output
     torch.cuda.empty_cache()
+
+
+def maybe_force_nccl_backend_init(device_id) -> None:
+    """Force NCCL backend initialization for in-process restart compatibility.
+
+    The nvidia-resiliency-ext in-process restart uses destroy_process_group to
+    terminate the NCCL backend, which does not terminate NCCL kernels if the NCCL
+    backend wasn't fully initialized before additional distributed subgroups are created.
+
+    This function forces full initialization of the NCCL backend by performing
+    a simple all_reduce operation.
+
+    Args:
+        device_id: CUDA device ID to use for the dummy tensor operation
+    """
+    tensor = torch.ones(128, device=device_id)
+    torch.distributed.all_reduce(tensor)
+    torch.cuda.synchronize()

--- a/src/megatron/bridge/training/inprocess_restart.py
+++ b/src/megatron/bridge/training/inprocess_restart.py
@@ -1,0 +1,208 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+
+import os
+import socket
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Callable, Literal, Optional
+
+
+try:
+    import nvidia_resiliency_ext.inprocess as inprocess
+except ImportError:
+    inprocess = None
+
+import warnings
+
+import torch
+
+from megatron.bridge.training.initialize import destroy_global_state
+
+
+@dataclass
+class InProcessRestartConfig:
+    """Configuration settings for NVIDIA Resiliency Extension in-process restart functionality."""
+
+    enabled: bool = False
+    """Enable in-process restart mechanism from nvidia-resiliency-ext."""
+
+    max_iterations: Optional[int] = None
+    """Maximum number of in-process restart iterations."""
+
+    monitor_thread_interval: float = 1.0
+    """Monitoring interval (in seconds) for the monitoring thread."""
+
+    monitor_process_interval: float = 1.0
+    """Monitoring interval (in seconds) for the monitoring process."""
+
+    progress_watchdog_interval: float = 1.0
+    """Interval (in seconds) for automatic progress watchdog timestamp updates."""
+
+    heartbeat_interval: float = 30.0
+    """Monitoring interval (in seconds) for detecting unresponsive ranks."""
+
+    soft_timeout: float = 60.0
+    """Soft progress timeout (in seconds)."""
+
+    hard_timeout: float = 90.0
+    """Hard progress timeout (in seconds)."""
+
+    heartbeat_timeout: float = 60.0
+    """Timeout (in seconds) for a missing rank detection heartbeat."""
+
+    barrier_timeout: float = 120.0
+    """Timeout (in seconds) for internal distributed barrier."""
+
+    completion_timeout: float = 120.0
+    """Timeout (in seconds) for barrier on completion on all ranks."""
+
+    last_call_wait: float = 1.0
+    """Time interval (in seconds) for other ranks to report concurrent terminal failures."""
+
+    termination_grace_time: float = 1.0
+    """Interval (in seconds) between SIGTERM and SIGKILL issued on hard timeout."""
+
+    granularity: Literal["node", "rank"] = "node"
+    """Granularity for in-process restart."""
+
+    active_world_size: Optional[int] = None
+    """The number of ranks initially executing the workload.
+    The remaining ranks from the allocation are set aside as warm reserve.
+    If None, defaults to WORLD_SIZE environment variable."""
+
+    empty_cuda_cache: bool = True
+    """Empty CUDA cache during restart finalization."""
+
+
+def inprocess_restart(train_fn, config: InProcessRestartConfig, *, state=None) -> Callable:
+    """
+    Wraps the train_fn with in-process restart functionality.
+
+    Args:
+        train_fn: The training function to wrap.
+        config: Configuration settings for in-process restart.
+        state: Optional state object for the training function.
+
+    Returns:
+        The wrapped training function.
+    """
+
+    if "TORCH_CPP_LOG_LEVEL" not in os.environ or os.environ["TORCH_CPP_LOG_LEVEL"] not in (
+        "error",
+        "fatal",
+    ):
+        warnings.warn("Set TORCH_CPP_LOG_LEVEL=error to suppress c10d waitForInput timeout warning messages")
+
+    # Layers represents a configuration for a layer of branches at a certain
+    # depth in a topology tree constructed by inprocess.rank_assignment.Tree.
+    # First layer contains all ranks and it's the root of the topology tree,
+    # the second optional layer groups ranks by nodes.
+    layers = [
+        inprocess.rank_assignment.Layer(
+            min_ranks=config.active_world_size,
+            max_ranks=config.active_world_size,
+            flag=inprocess.rank_assignment.LayerFlag.RESERVE,
+        )
+    ]
+    if config.granularity == "node":
+        device_count = torch.cuda.device_count()
+
+        layers.append(
+            inprocess.rank_assignment.Layer(
+                min_ranks=device_count,
+                max_ranks=device_count,
+                key_or_fn=lambda _: socket.gethostname(),
+                flag=inprocess.rank_assignment.LayerFlag.RESERVE,
+            )
+        )
+
+    finalize = [inprocess.finalize.ThreadedFinalize(timeout=timedelta(seconds=10), fn=destroy_global_state)]
+
+    if config.empty_cuda_cache:
+        finalize.append(inprocess.finalize.ThreadedFinalize(timeout=timedelta(seconds=10), fn=torch.cuda.empty_cache))
+
+    initialize = inprocess.Compose(
+        inprocess.initialize.RetryController(min_world_size=config.active_world_size),
+        inprocess.nested_restarter.NestedRestarterHandlingCompleted(),
+    )
+
+    class AbortCheckpoint(inprocess.abort.Abort):
+        def __call__(self, frozen_state: inprocess.state.FrozenState) -> inprocess.state.FrozenState:
+            # Abort persistent async worker processes if present
+            try:
+                if state is not None and getattr(state, "async_calls_queue", None) is not None:
+                    queue = state.async_calls_queue
+                    if queue is not None:
+                        queue.close(abort=True)
+                # Attempt to shutdown filesystem async results queue manager if present
+                try:
+                    from megatron.core.dist_checkpointing.strategies.filesystem_async import _results_queue
+
+                    if _results_queue is not None:
+                        _results_queue._manager.shutdown()
+                except Exception:
+                    pass
+            except Exception:
+                pass
+            return frozen_state
+
+    abort = inprocess.Compose(
+        inprocess.abort.AbortTransformerEngine(),
+        inprocess.abort.AbortTorchDistributed(),
+        AbortCheckpoint(),
+        inprocess.nested_restarter.NestedRestarterHandlingStarting(),
+    )
+    completion = inprocess.nested_restarter.NestedRestarterFinalized()
+    terminate = inprocess.nested_restarter.NestedRestarterAborted()
+
+    new_train_fn = inprocess.Wrapper(
+        store_kwargs={
+            "timeout": timedelta(seconds=300),
+            "port": int(os.environ["MASTER_PORT"]) + 2,
+        },
+        initialize=initialize,
+        abort=abort,
+        completion=completion,
+        terminate=terminate,
+        health_check=inprocess.health_check.CudaHealthCheck(timeout=timedelta(seconds=10)),
+        rank_assignment=inprocess.rank_assignment.Tree(layers=layers),
+        finalize=inprocess.Compose(*finalize),
+        heartbeat_interval=timedelta(seconds=config.heartbeat_interval),
+        heartbeat_timeout=timedelta(seconds=config.heartbeat_timeout),
+        barrier_timeout=timedelta(seconds=config.barrier_timeout),
+        completion_timeout=timedelta(seconds=config.completion_timeout),
+        monitor_process_interval=timedelta(seconds=config.monitor_process_interval),
+        monitor_thread_interval=timedelta(seconds=config.monitor_thread_interval),
+        last_call_wait=timedelta(seconds=config.last_call_wait),
+        soft_timeout=timedelta(seconds=config.soft_timeout),
+        hard_timeout=timedelta(seconds=config.hard_timeout),
+        termination_grace_time=timedelta(seconds=config.termination_grace_time),
+        enabled=True,
+    )(train_fn)
+
+    return new_train_fn
+
+
+def maybe_wrap_for_inprocess_restart(
+    train_fn, config: InProcessRestartConfig, state=None
+) -> tuple[Callable, Optional[torch.distributed.Store]]:
+    """Conditionally wrap function for in-process restart."""
+
+    if not config.enabled:
+        return train_fn, None
+
+    # Apply inprocess restart wrapper
+    wrapped_train_fn = inprocess_restart(train_fn, config, state=state)
+
+    # Create the TCPStore
+    store = torch.distributed.TCPStore(
+        host_name=os.environ["MASTER_ADDR"],
+        port=int(os.environ["MASTER_PORT"]) + 1,
+        world_size=int(os.getenv("WORLD_SIZE", "1")),
+        is_master=(int(os.getenv("RANK", "0")) == 0),
+        timeout=timedelta(seconds=300),
+        wait_for_workers=True,
+        use_libuv=True,
+    )
+
+    return wrapped_train_fn, store

--- a/src/megatron/bridge/training/pretrain.py
+++ b/src/megatron/bridge/training/pretrain.py
@@ -95,8 +95,8 @@ def _pretrain(
         iteration = inprocess_call_wrapper.iteration
         store = dist.PrefixStore(str(iteration), store)
 
-    cfg = state.cfg
-    dataset_provider = get_dataset_provider(cfg.dataset)
+    config = state.cfg
+    dataset_provider = get_dataset_provider(config.dataset)
     setup_output = setup(state, dataset_provider, restart_store=store)
     state = setup_output.state
     model = setup_output.model
@@ -108,9 +108,9 @@ def _pretrain(
     ckpt_context = setup_output.checkpointing_context
 
     # TRAINING
-    if not cfg.train.skip_train:
+    if not config.train.skip_train:
         print_rank_0("Training ...")
-        if state.train_state.do_train and cfg.train.train_iters > 0:
+        if state.train_state.do_train and config.train.train_iters > 0:
             train(
                 forward_step_func,
                 model,
@@ -123,7 +123,7 @@ def _pretrain(
             )
 
         barrier_and_log("after training is done")
-        ckpt_config = cfg.checkpoint
+        ckpt_config = config.checkpoint
         if ckpt_config.save and state.train_state.step != 0 and ckpt_config.save_interval != 0:
             save_checkpoint(
                 state,
@@ -149,9 +149,9 @@ def _pretrain(
             forward_step_func,
             valid_data_iterator,
             model,
-            cfg.model,
+            config.model,
             verbose=True,
-            write_to_tensorboard=not cfg.train.skip_train,
+            write_to_tensorboard=not config.train.skip_train,
         )
     if state.train_state.do_test:
         prefix = f"iteration {iteration} on test set"
@@ -161,9 +161,9 @@ def _pretrain(
             forward_step_func,
             test_data_iterator,
             model,
-            cfg.model,
+            config.model,
             verbose=True,
-            write_to_tensorboard=not cfg.train.skip_train,
+            write_to_tensorboard=not config.train.skip_train,
         )
 
     _finish_train(state)

--- a/src/megatron/bridge/training/setup.py
+++ b/src/megatron/bridge/training/setup.py
@@ -34,7 +34,6 @@ from megatron.bridge.training.checkpointing import (
     checkpoint_exists,
     init_checkpointing_context,
     load_checkpoint,
-    init_async_checkpoint_worker,
 )
 from megatron.bridge.training.config import ConfigContainer
 from megatron.bridge.training.initialize import initialize_megatron, set_jit_fusion_options
@@ -115,7 +114,7 @@ def setup(
     set_experimental_flag(cfg.dist.enable_megatron_core_experimental)
 
     # Initialize async checkpoint worker if enabled (idempotent if already initialized)
-    init_async_checkpoint_worker(state)
+    state.initialize_async_checkpoint_worker()
 
     setup_logging(
         logging_level=cfg.logger.logging_level,

--- a/src/megatron/bridge/training/setup.py
+++ b/src/megatron/bridge/training/setup.py
@@ -81,54 +81,40 @@ class SetupOutput(NamedTuple):
 
 
 def setup(
-    cfg: ConfigContainer,
+    state: GlobalState,
     train_valid_test_datasets_provider: Callable[..., tuple[Optional[Any], Optional[Any], Optional[Any]]],
     get_embedding_ranks: Optional[Callable[[list[int], Optional[int]], list[int]]] = None,
     get_position_embedding_ranks: Optional[Callable[[list[int], Optional[int]], list[int]]] = None,
+    restart_store: Optional[torch.distributed.Store] = None,
 ) -> SetupOutput:
-    """Initializes the training/evaluation environment.
+    """Initialize the training/evaluation environment using an existing GlobalState.
 
-    Sets up logging, initializes Megatron core components (distributed,
-    timers), builds the tokenizer, creates the model, optimizer, and scheduler,
-    loads checkpoints if specified, and prepares data iterators.
+    Performs all runtime setup using the provided `state` and its attached config (`state.cfg`).
+    This includes:
+      - enabling Megatron-Core experimental features
+      - initializing async checkpoint workers (if enabled)
+      - logging setup
+      - torch.distributed and model-parallel initialization (via initialize_megatron)
+      - tokenizer/model/optimizer/scheduler construction
+      - optional checkpoint load
+      - dataloader setup
 
     Args:
-        cfg: The main configuration container holding all sub-configurations
-             (model, training, optimizer, etc.).
-        train_valid_test_datasets_provider: A callable function that takes
-            configuration and potentially a tokenizer, and returns tuples
-            representing the training, validation, and test datasets.
-        get_embedding_ranks: Optional callable to determine ranks for embedding layers,
-                             used during Megatron initialization.
-        get_position_embedding_ranks: Optional callable to determine ranks for
-                                      position embedding layers, used during Megatron
-                                      initialization.
+        state: The GlobalState instance to populate and use throughout setup.
+        train_valid_test_datasets_provider: Callable returning the train/valid/test datasets or iterators.
+        get_embedding_ranks: Optional function to determine embedding layer ranks for model-parallel init.
+        get_position_embedding_ranks: Optional function to determine positional embedding ranks.
+        restart_store: Optional torch.distributed Store used when in-process restart is enabled.
 
     Returns:
-        A SetupOutput named tuple containing the initialized state, model,
-        optimizer, scheduler, data iterators, and checkpointing context.
+        SetupOutput containing the populated state, model, optimizer, scheduler, dataloaders, and ckpt context.
     """
-    # TODO: Freeze state.cfg
-
-    cfg.validate()
-
-    # Apply mixed precision configuration if provided
-    if cfg.mixed_precision is not None:
-        if isinstance(cfg.mixed_precision, str):
-            cfg.mixed_precision = get_mixed_precision_config(cfg.mixed_precision)
-        cfg.mixed_precision.setup(cfg.model, cfg.optimizer, cfg.ddp)
-
-    # Apply communication overlap configuration if provided at the very beginning
-    if cfg.comm_overlap is not None:
-        cfg.comm_overlap.setup(cfg.model, cfg.optimizer, cfg.ddp)
-
-    state = GlobalState()
-    state.cfg = cfg
+    cfg = state.cfg
 
     # Conditionally enable experimental features for Megatron Core
     set_experimental_flag(cfg.dist.enable_megatron_core_experimental)
 
-    # Initialize async checkpoint worker if enabled
+    # Initialize async checkpoint worker if enabled (idempotent if already initialized)
     init_async_checkpoint_worker(state)
 
     setup_logging(
@@ -142,6 +128,7 @@ def setup(
         cfg=cfg,
         get_embedding_ranks=get_embedding_ranks,
         get_position_embedding_ranks=get_position_embedding_ranks,
+        restart_store=restart_store,
     )
 
     timers = state.timers

--- a/src/megatron/bridge/training/state.py
+++ b/src/megatron/bridge/training/state.py
@@ -261,16 +261,14 @@ class GlobalState:
             self._straggler_timer = StragglerDetector()
         return self._straggler_timer
 
+    def initialize_async_checkpoint_worker(self) -> None:
+        """Initializes the async checkpoint worker."""
+        if self._async_calls_queue is None and self.cfg and self.cfg.checkpoint.async_save:
+            self._async_calls_queue = AsyncCallsQueue(persistent=self.cfg.checkpoint.use_persistent_ckpt_worker)
+
     @property
     def async_calls_queue(self) -> Optional[AsyncCallsQueue]:
-        """The AsyncCallsQueue instance for handling asynchronous checkpoint saves.
-
-        Creates a persistent AsyncCallsQueue when async_save is enabled in the checkpoint config.
-        Returns None if async_save is disabled.
-        """
-        if self._async_calls_queue is None and self.cfg and self.cfg.checkpoint.async_save:
-            # Create persistent queue by default when async_save is enabled
-            self._async_calls_queue = AsyncCallsQueue(persistent=self.cfg.checkpoint.use_persistent_ckpt_worker)
+        """The AsyncCallsQueue instance for handling asynchronous checkpoint saves."""
         return self._async_calls_queue
 
     @property

--- a/src/megatron/bridge/training/state.py
+++ b/src/megatron/bridge/training/state.py
@@ -263,7 +263,12 @@ class GlobalState:
 
     def initialize_async_checkpoint_worker(self) -> None:
         """Initializes the async checkpoint worker."""
-        if self._async_calls_queue is None and self.cfg and self.cfg.checkpoint.async_save:
+        if (
+            self._async_calls_queue is None
+            and self.cfg
+            and self.cfg.checkpoint.save is not None
+            and self.cfg.checkpoint.async_save
+        ):
             self._async_calls_queue = AsyncCallsQueue(persistent=self.cfg.checkpoint.use_persistent_ckpt_worker)
 
     @property


### PR DESCRIPTION
https://nvidia.github.io/nvidia-resiliency-ext/inprocess/index.html

enable low-overhead restarts inside the same process for distributed PyTorch workloads. This PR adds dedicated configuration for in-process restart, internal wrapping of the training entrypoint, explicit lifecycle hooks for persistent async checkpoint workers, and proper distributed init interactions.

Internally, pretrain conditionally wraps a new private `_pretrain` function when config.inprocess_restart.enabled is true, passing state, the NVRx wrapper, and a restart Store. the state is needed in order to have a reference to explicitly abort the persistent async workers as part of the termination sequence.

as part of this, the pretrain/setup API is refactored:
the config validation + runtime overrides are applied at the beginning of pretrain, instead of setup. this is so that we can initialize the global state object and pass it for when the new private function is wrapped.

the persistent async worker initialization is also slightly refactored: we add an explicit method to the global state class for initializing these workers rather than lazily creating the calls queue on its first access. this allows us to remove the init_async_checkpoint_worker function from checkpointing.py



