### PR TITLE
[MCore-sync] Change TE version to 2.8 when enabling --overlap-grad-reduce and --delay-wgrad-compute at the same time

### DIFF
--- a/src/megatron/bridge/training/comm_overlap.py
+++ b/src/megatron/bridge/training/comm_overlap.py
@@ -500,8 +500,8 @@ class CommOverlapConfig:
             )
 
         if self.user_comm_overlap_cfg.delay_wgrad_compute is True:
-            assert is_te_min_version("2.7.0"), (
-                f"TE version >= 2.7.0 is required for delay_wgrad_compute, \
+            assert is_te_min_version("2.8.0"), (
+                f"TE version >= 2.8.0 is required for delay_wgrad_compute, \
                 current TE version: {get_te_version()}"
             )
             assert (


### PR DESCRIPTION
Related MCore MR: https://gitlab-master.nvidia.com/ADLR/megatron-lm/-/merge_requests/3941