### PR TITLE
Reverse param mappings dict in bridges

### DIFF
--- a/src/megatron/bridge/models/llama/llama_bridge.py
+++ b/src/megatron/bridge/models/llama/llama_bridge.py
@@ -93,25 +93,25 @@ class LlamaBridge(MegatronModelBridge):
         }
 
         mapping_list = []
-        # Convert each dictionary entry to AutoMapping(hf_param, megatron_param)
+        # Convert each dictionary entry to AutoMapping(megatron_param, hf_param)
         for megatron_param, hf_param in param_mappings.items():
-            mapping_list.append(AutoMapping(hf_param=hf_param, megatron_param=megatron_param))
+            mapping_list.append(AutoMapping(megatron_param=megatron_param, hf_param=hf_param))
 
         # Add special mappings that require parameter concatenation/transformation
         mapping_list.extend(
             [
                 # QKV: Combine separate Q, K, V matrices into single QKV matrix
                 QKVMapping(
+                    megatron_param="decoder.layers.*.self_attention.linear_qkv.weight",
                     q="model.layers.*.self_attn.q_proj.weight",
                     k="model.layers.*.self_attn.k_proj.weight",
                     v="model.layers.*.self_attn.v_proj.weight",
-                    megatron_param="decoder.layers.*.self_attention.linear_qkv.weight",
                 ),
                 # Gated MLP: Combine gate and up projection matrices into single FC1 matrix
                 GatedMLPMapping(
+                    megatron_param="decoder.layers.*.mlp.linear_fc1.weight",
                     gate="model.layers.*.mlp.gate_proj.weight",
                     up="model.layers.*.mlp.up_proj.weight",
-                    megatron_param="decoder.layers.*.mlp.linear_fc1.weight",
                 ),
             ]
         )

--- a/src/megatron/bridge/models/llama/llama_bridge.py
+++ b/src/megatron/bridge/models/llama/llama_bridge.py
@@ -83,18 +83,18 @@ class LlamaBridge(MegatronModelBridge):
         # Dictionary maps HF parameter names -> Megatron parameter names
         # Supports wildcard (*) patterns for layer-specific parameters
         param_mappings = {
-            "model.embed_tokens.weight": "embedding.word_embeddings.weight",
-            "lm_head.weight": "output_layer.weight",
-            "model.norm.weight": "decoder.final_layernorm.weight",
-            "model.layers.*.input_layernorm.weight": "decoder.layers.*.self_attention.linear_qkv.layer_norm_weight",
-            "model.layers.*.post_attention_layernorm.weight": "decoder.layers.*.mlp.linear_fc1.layer_norm_weight",
-            "model.layers.*.self_attn.o_proj.weight": "decoder.layers.*.self_attention.linear_proj.weight",
-            "model.layers.*.mlp.down_proj.weight": "decoder.layers.*.mlp.linear_fc2.weight",
+            "embedding.word_embeddings.weight": "model.embed_tokens.weight",
+            "output_layer.weight": "lm_head.weight",
+            "decoder.final_layernorm.weight": "model.norm.weight",
+            "decoder.layers.*.self_attention.linear_qkv.layer_norm_weight": "model.layers.*.input_layernorm.weight",
+            "decoder.layers.*.mlp.linear_fc1.layer_norm_weight": "model.layers.*.post_attention_layernorm.weight",
+            "decoder.layers.*.self_attention.linear_proj.weight": "model.layers.*.self_attn.o_proj.weight",
+            "decoder.layers.*.mlp.linear_fc2.weight": "model.layers.*.mlp.down_proj.weight",
         }
 
         mapping_list = []
         # Convert each dictionary entry to AutoMapping(hf_param, megatron_param)
-        for hf_param, megatron_param in param_mappings.items():
+        for megatron_param, hf_param in param_mappings.items():
             mapping_list.append(AutoMapping(hf_param=hf_param, megatron_param=megatron_param))
 
         # Add special mappings that require parameter concatenation/transformation

--- a/src/megatron/bridge/models/llama/llama_bridge.py
+++ b/src/megatron/bridge/models/llama/llama_bridge.py
@@ -77,10 +77,10 @@ class LlamaBridge(MegatronModelBridge):
         return provider
 
     def mapping_registry(self) -> MegatronMappingRegistry:
-        # Return MegatronMappingRegistry containing parameter mappings from HF to Megatron format
+        # Return MegatronMappingRegistry containing parameter mappings from Megatron to HF format
         # First create simple 1:1 parameter mappings using a dictionary for readability
 
-        # Dictionary maps HF parameter names -> Megatron parameter names
+        # Dictionary maps Megatron parameter names -> HF parameter names
         # Supports wildcard (*) patterns for layer-specific parameters
         param_mappings = {
             "embedding.word_embeddings.weight": "model.embed_tokens.weight",

--- a/src/megatron/bridge/models/qwen/qwen2_bridge.py
+++ b/src/megatron/bridge/models/qwen/qwen2_bridge.py
@@ -75,18 +75,18 @@ class Qwen2Bridge(MegatronModelBridge):
         # Dictionary maps HF parameter names -> Megatron parameter names
         # Supports wildcard (*) patterns for layer-specific parameters
         param_mappings = {
-            "model.embed_tokens.weight": "embedding.word_embeddings.weight",
-            "lm_head.weight": "output_layer.weight",
-            "model.norm.weight": "decoder.final_layernorm.weight",
-            "model.layers.*.input_layernorm.weight": "decoder.layers.*.self_attention.linear_qkv.layer_norm_weight",
-            "model.layers.*.post_attention_layernorm.weight": "decoder.layers.*.mlp.linear_fc1.layer_norm_weight",
-            "model.layers.*.self_attn.o_proj.weight": "decoder.layers.*.self_attention.linear_proj.weight",
-            "model.layers.*.mlp.down_proj.weight": "decoder.layers.*.mlp.linear_fc2.weight",
+            "embedding.word_embeddings.weight": "model.embed_tokens.weight",
+            "output_layer.weight": "lm_head.weight",
+            "decoder.final_layernorm.weight": "model.norm.weight",
+            "decoder.layers.*.self_attention.linear_qkv.layer_norm_weight": "model.layers.*.input_layernorm.weight",
+            "decoder.layers.*.mlp.linear_fc1.layer_norm_weight": "model.layers.*.post_attention_layernorm.weight",
+            "decoder.layers.*.self_attention.linear_proj.weight": "model.layers.*.self_attn.o_proj.weight",
+            "decoder.layers.*.mlp.linear_fc2.weight": "model.layers.*.mlp.down_proj.weight",
         }
 
         mapping_list = []
         # Convert each dictionary entry to AutoMapping(hf_param, megatron_param)
-        for hf_param, megatron_param in param_mappings.items():
+        for megatron_param, hf_param in param_mappings.items():
             mapping_list.append(AutoMapping(hf_param=hf_param, megatron_param=megatron_param))
 
         # Add special mappings that require parameter concatenation/transformation

--- a/src/megatron/bridge/models/qwen/qwen2_bridge.py
+++ b/src/megatron/bridge/models/qwen/qwen2_bridge.py
@@ -85,32 +85,32 @@ class Qwen2Bridge(MegatronModelBridge):
         }
 
         mapping_list = []
-        # Convert each dictionary entry to AutoMapping(hf_param, megatron_param)
+        # Convert each dictionary entry to AutoMapping(megatron_param, hf_param)
         for megatron_param, hf_param in param_mappings.items():
-            mapping_list.append(AutoMapping(hf_param=hf_param, megatron_param=megatron_param))
+            mapping_list.append(AutoMapping(megatron_param=megatron_param, hf_param=hf_param))
 
         # Add special mappings that require parameter concatenation/transformation
         mapping_list.extend(
             [
                 # QKV: Combine separate Q, K, V matrices into single QKV matrix
                 QKVMapping(
+                    megatron_param="decoder.layers.*.self_attention.linear_qkv.weight",
                     q="model.layers.*.self_attn.q_proj.weight",
                     k="model.layers.*.self_attn.k_proj.weight",
                     v="model.layers.*.self_attn.v_proj.weight",
-                    megatron_param="decoder.layers.*.self_attention.linear_qkv.weight",
                 ),
                 # QKV bias: Combine separate Q, K, V biases into single QKV bias (Qwen2 specific)
                 QKVMapping(
+                    megatron_param="decoder.layers.*.self_attention.linear_qkv.bias",
                     q="model.layers.*.self_attn.q_proj.bias",
                     k="model.layers.*.self_attn.k_proj.bias",
                     v="model.layers.*.self_attn.v_proj.bias",
-                    megatron_param="decoder.layers.*.self_attention.linear_qkv.bias",
                 ),
                 # Gated MLP: Combine gate and up projection matrices into single FC1 matrix
                 GatedMLPMapping(
+                    megatron_param="decoder.layers.*.mlp.linear_fc1.weight",
                     gate="model.layers.*.mlp.gate_proj.weight",
                     up="model.layers.*.mlp.up_proj.weight",
-                    megatron_param="decoder.layers.*.mlp.linear_fc1.weight",
                 ),
             ]
         )

--- a/src/megatron/bridge/models/qwen/qwen2_bridge.py
+++ b/src/megatron/bridge/models/qwen/qwen2_bridge.py
@@ -69,10 +69,10 @@ class Qwen2Bridge(MegatronModelBridge):
         return provider
 
     def mapping_registry(self) -> MegatronMappingRegistry:
-        # Return MegatronMappingRegistry containing parameter mappings from HF to Megatron format
+        # Return MegatronMappingRegistry containing parameter mappings from Megatron to HF format
         # First create simple 1:1 parameter mappings using a dictionary for readability
 
-        # Dictionary maps HF parameter names -> Megatron parameter names
+        # Dictionary maps Megatron parameter names -> HF parameter names
         # Supports wildcard (*) patterns for layer-specific parameters
         param_mappings = {
             "embedding.word_embeddings.weight": "model.embed_tokens.weight",

--- a/src/megatron/bridge/models/qwen/qwen3_bridge.py
+++ b/src/megatron/bridge/models/qwen/qwen3_bridge.py
@@ -75,20 +75,20 @@ class Qwen3Bridge(MegatronModelBridge):
         # Dictionary maps HF parameter names -> Megatron parameter names
         # Supports wildcard (*) patterns for layer-specific parameters
         param_mappings = {
-            "model.embed_tokens.weight": "embedding.word_embeddings.weight",
-            "lm_head.weight": "output_layer.weight",
-            "model.norm.weight": "decoder.final_layernorm.weight",
-            "model.layers.*.input_layernorm.weight": "decoder.layers.*.self_attention.linear_qkv.layer_norm_weight",
-            "model.layers.*.post_attention_layernorm.weight": "decoder.layers.*.mlp.linear_fc1.layer_norm_weight",
-            "model.layers.*.self_attn.q_norm.weight": "decoder.layers.*.self_attention.q_layernorm.weight",  # Qwen3 specific
-            "model.layers.*.self_attn.k_norm.weight": "decoder.layers.*.self_attention.k_layernorm.weight",  # Qwen3 specific
-            "model.layers.*.self_attn.o_proj.weight": "decoder.layers.*.self_attention.linear_proj.weight",
-            "model.layers.*.mlp.down_proj.weight": "decoder.layers.*.mlp.linear_fc2.weight",
+            "embedding.word_embeddings.weight": "model.embed_tokens.weight",
+            "output_layer.weight": "lm_head.weight",
+            "decoder.final_layernorm.weight": "model.norm.weight",
+            "decoder.layers.*.self_attention.linear_qkv.layer_norm_weight": "model.layers.*.input_layernorm.weight",
+            "decoder.layers.*.mlp.linear_fc1.layer_norm_weight": "model.layers.*.post_attention_layernorm.weight",
+            "decoder.layers.*.self_attention.q_layernorm.weight": "model.layers.*.self_attn.q_norm.weight",  # Qwen3 specific
+            "decoder.layers.*.self_attention.k_layernorm.weight": "model.layers.*.self_attn.k_norm.weight",  # Qwen3 specific
+            "decoder.layers.*.self_attention.linear_proj.weight": "model.layers.*.self_attn.o_proj.weight",
+            "decoder.layers.*.mlp.linear_fc2.weight": "model.layers.*.mlp.down_proj.weight",
         }
 
         mapping_list = []
         # Convert each dictionary entry to AutoMapping(hf_param, megatron_param)
-        for hf_param, megatron_param in param_mappings.items():
+        for megatron_param, hf_param in param_mappings.items():
             mapping_list.append(AutoMapping(hf_param=hf_param, megatron_param=megatron_param))
 
         # Add special mappings that require parameter concatenation/transformation

--- a/src/megatron/bridge/models/qwen/qwen3_bridge.py
+++ b/src/megatron/bridge/models/qwen/qwen3_bridge.py
@@ -87,9 +87,9 @@ class Qwen3Bridge(MegatronModelBridge):
         }
 
         mapping_list = []
-        # Convert each dictionary entry to AutoMapping(hf_param, megatron_param)
+        # Convert each dictionary entry to AutoMapping(megatron_param, hf_param)
         for megatron_param, hf_param in param_mappings.items():
-            mapping_list.append(AutoMapping(hf_param=hf_param, megatron_param=megatron_param))
+            mapping_list.append(AutoMapping(megatron_param=megatron_param, hf_param=hf_param))
 
         # Add special mappings that require parameter concatenation/transformation
         mapping_list.extend(
@@ -97,16 +97,16 @@ class Qwen3Bridge(MegatronModelBridge):
                 # QKV: Combine separate Q, K, V matrices into single QKV matrix
                 # Note: Qwen3 does NOT have bias in QKV projections (unlike Qwen2)
                 QKVMapping(
+                    megatron_param="decoder.layers.*.self_attention.linear_qkv.weight",
                     q="model.layers.*.self_attn.q_proj.weight",
                     k="model.layers.*.self_attn.k_proj.weight",
                     v="model.layers.*.self_attn.v_proj.weight",
-                    megatron_param="decoder.layers.*.self_attention.linear_qkv.weight",
                 ),
                 # Gated MLP: Combine gate and up projection matrices into single FC1 matrix
                 GatedMLPMapping(
+                    megatron_param="decoder.layers.*.mlp.linear_fc1.weight",
                     gate="model.layers.*.mlp.gate_proj.weight",
                     up="model.layers.*.mlp.up_proj.weight",
-                    megatron_param="decoder.layers.*.mlp.linear_fc1.weight",
                 ),
             ]
         )

--- a/src/megatron/bridge/models/qwen/qwen3_bridge.py
+++ b/src/megatron/bridge/models/qwen/qwen3_bridge.py
@@ -69,10 +69,10 @@ class Qwen3Bridge(MegatronModelBridge):
         return provider
 
     def mapping_registry(self) -> MegatronMappingRegistry:
-        # Return MegatronMappingRegistry containing parameter mappings from HF to Megatron format
+        # Return MegatronMappingRegistry containing parameter mappings from Megatron to HF format
         # First create simple 1:1 parameter mappings using a dictionary for readability
 
-        # Dictionary maps HF parameter names -> Megatron parameter names
+        # Dictionary maps Megatron parameter names -> HF parameter names
         # Supports wildcard (*) patterns for layer-specific parameters
         param_mappings = {
             "embedding.word_embeddings.weight": "model.embed_tokens.weight",

--- a/src/megatron/bridge/models/qwen/qwen3_moe_bridge.py
+++ b/src/megatron/bridge/models/qwen/qwen3_moe_bridge.py
@@ -79,20 +79,20 @@ class Qwen3MoEBridge(MegatronModelBridge):
         # Dictionary maps HF parameter names -> Megatron parameter names
         # Supports wildcard (*) patterns for layer-specific parameters
         param_mappings = {
-            "model.embed_tokens.weight": "embedding.word_embeddings.weight",
-            "lm_head.weight": "output_layer.weight",
-            "model.norm.weight": "decoder.final_layernorm.weight",
-            "model.layers.*.input_layernorm.weight": "decoder.layers.*.self_attention.linear_qkv.layer_norm_weight",
-            "model.layers.*.mlp.gate.weight": "decoder.layers.*.mlp.router.weight",
-            "model.layers.*.post_attention_layernorm.weight": "decoder.layers.*.pre_mlp_layernorm.weight",
-            "model.layers.*.self_attn.q_norm.weight": "decoder.layers.*.self_attention.q_layernorm.weight",
-            "model.layers.*.self_attn.k_norm.weight": "decoder.layers.*.self_attention.k_layernorm.weight",
-            "model.layers.*.self_attn.o_proj.weight": "decoder.layers.*.self_attention.linear_proj.weight",
+            "embedding.word_embeddings.weight": "model.embed_tokens.weight",
+            "output_layer.weight": "lm_head.weight",
+            "decoder.final_layernorm.weight": "model.norm.weight",
+            "decoder.layers.*.self_attention.linear_qkv.layer_norm_weight": "model.layers.*.input_layernorm.weight",
+            "decoder.layers.*.mlp.router.weight": "model.layers.*.mlp.gate.weight",
+            "decoder.layers.*.pre_mlp_layernorm.weight": "model.layers.*.post_attention_layernorm.weight",
+            "decoder.layers.*.self_attention.q_layernorm.weight": "model.layers.*.self_attn.q_norm.weight",
+            "decoder.layers.*.self_attention.k_layernorm.weight": "model.layers.*.self_attn.k_norm.weight",
+            "decoder.layers.*.self_attention.linear_proj.weight": "model.layers.*.self_attn.o_proj.weight",
         }
 
         mapping_list = []
         # Convert each dictionary entry to AutoMapping(hf_param, megatron_param)
-        for hf_param, megatron_param in param_mappings.items():
+        for megatron_param, hf_param in param_mappings.items():
             mapping_list.append(AutoMapping(hf_param=hf_param, megatron_param=megatron_param))
 
         # Add special mappings that require parameter concatenation/transformation

--- a/src/megatron/bridge/models/qwen/qwen3_moe_bridge.py
+++ b/src/megatron/bridge/models/qwen/qwen3_moe_bridge.py
@@ -91,9 +91,9 @@ class Qwen3MoEBridge(MegatronModelBridge):
         }
 
         mapping_list = []
-        # Convert each dictionary entry to AutoMapping(hf_param, megatron_param)
+        # Convert each dictionary entry to AutoMapping(megatron_param, hf_param)
         for megatron_param, hf_param in param_mappings.items():
-            mapping_list.append(AutoMapping(hf_param=hf_param, megatron_param=megatron_param))
+            mapping_list.append(AutoMapping(megatron_param=megatron_param, hf_param=hf_param))
 
         # Add special mappings that require parameter concatenation/transformation
         mapping_list.extend(
@@ -101,19 +101,19 @@ class Qwen3MoEBridge(MegatronModelBridge):
                 # QKV: Combine separate Q, K, V matrices into single QKV matrix
                 # Note: Qwen3 MoE does NOT have bias in QKV projections
                 QKVMapping(
+                    megatron_param="decoder.layers.*.self_attention.linear_qkv.weight",
                     q="model.layers.*.self_attn.q_proj.weight",
                     k="model.layers.*.self_attn.k_proj.weight",
                     v="model.layers.*.self_attn.v_proj.weight",
-                    megatron_param="decoder.layers.*.self_attention.linear_qkv.weight",
                 ),
                 GatedMLPMapping(
+                    megatron_param="decoder.layers.*.mlp.experts.linear_fc1.weight*",
                     gate="model.layers.*.mlp.experts.*.gate_proj.weight",
                     up="model.layers.*.mlp.experts.*.up_proj.weight",
-                    megatron_param="decoder.layers.*.mlp.experts.linear_fc1.weight*",
                 ),
                 AutoMapping(
-                    hf_param="model.layers.*.mlp.experts.*.down_proj.weight",
                     megatron_param="decoder.layers.*.mlp.experts.linear_fc2.weight*",
+                    hf_param="model.layers.*.mlp.experts.*.down_proj.weight",
                 ),
             ]
         )

--- a/src/megatron/bridge/models/qwen/qwen3_moe_bridge.py
+++ b/src/megatron/bridge/models/qwen/qwen3_moe_bridge.py
@@ -73,10 +73,10 @@ class Qwen3MoEBridge(MegatronModelBridge):
         return provider
 
     def mapping_registry(self) -> MegatronMappingRegistry:
-        # Return MegatronMappingRegistry containing parameter mappings from HF to Megatron format
+        # Return MegatronMappingRegistry containing parameter mappings from Megatron to HF format
         # First create simple 1:1 parameter mappings using a dictionary for readability
 
-        # Dictionary maps HF parameter names -> Megatron parameter names
+        # Dictionary maps Megatron parameter names -> HF parameter names
         # Supports wildcard (*) patterns for layer-specific parameters
         param_mappings = {
             "embedding.word_embeddings.weight": "model.embed_tokens.weight",


### PR DESCRIPTION
In Bridge, we use megatron_param as the central reference for parameter lookup, and then use it to find the corresponding Hugging Face (HF) parameter. Given this flow, it makes more sense to define param_mapping from Megatron parameters to HF parameters.