### PR TITLE
fix: reduce padded vocab size logspam

### DIFF
--- a/src/megatron/bridge/training/utils/flop_utils.py
+++ b/src/megatron/bridge/training/utils/flop_utils.py
@@ -96,7 +96,10 @@ def _get_vocab_size(model_cfg) -> int:
     """
     if model_cfg.should_pad_vocab:
         return calculate_padded_vocab_size(
-            model_cfg.vocab_size, model_cfg.make_vocab_size_divisible_by, model_cfg.tensor_model_parallel_size
+            model_cfg.vocab_size,
+            model_cfg.make_vocab_size_divisible_by,
+            model_cfg.tensor_model_parallel_size,
+            logging_enabled=False,
         )
     else:
         return model_cfg.vocab_size

--- a/src/megatron/bridge/training/utils/theoretical_memory_utils.py
+++ b/src/megatron/bridge/training/utils/theoretical_memory_utils.py
@@ -259,7 +259,10 @@ def _get_vocab_size(model_cfg) -> int:
     """
     if model_cfg.should_pad_vocab:
         return calculate_padded_vocab_size(
-            model_cfg.vocab_size, model_cfg.make_vocab_size_divisible_by, model_cfg.tensor_model_parallel_size
+            model_cfg.vocab_size,
+            model_cfg.make_vocab_size_divisible_by,
+            model_cfg.tensor_model_parallel_size,
+            logging_enabled=False,
         )
     else:
         return model_cfg.vocab_size

--- a/src/megatron/bridge/utils/vocab_utils.py
+++ b/src/megatron/bridge/utils/vocab_utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import math
+from functools import lru_cache
 
 from megatron.bridge.utils.common_utils import print_rank_0
 
@@ -32,10 +33,33 @@ def calculate_padded_vocab_size(
         vocab_size: The original (unpadded) vocabulary size
         make_vocab_size_divisible_by: Base divisibility requirement (e.g., 128)
         tensor_model_parallel_size: Number of tensor parallel ranks
+        logging_enabled: Whether to log the padding information
 
     Returns:
         int: The padded vocabulary size
     """
+    padded_size = _calculate_padded_vocab_size_cached(
+        vocab_size, make_vocab_size_divisible_by, tensor_model_parallel_size
+    )
+
+    # Handle logging separately to avoid affecting cache behavior
+    if logging_enabled:
+        print_rank_0(
+            " > padded vocab (size: {}) with {} dummy tokens (new size: {})".format(
+                vocab_size, padded_size - vocab_size, padded_size
+            )
+        )
+
+    return padded_size
+
+
+@lru_cache(maxsize=128)
+def _calculate_padded_vocab_size_cached(
+    vocab_size: int,
+    make_vocab_size_divisible_by: int,
+    tensor_model_parallel_size: int,
+) -> int:
+    """Cached computation of padded vocab size."""
     if vocab_size <= 0:
         raise ValueError(f"vocab_size must be positive, got {vocab_size}")
     if make_vocab_size_divisible_by <= 0:
@@ -43,13 +67,5 @@ def calculate_padded_vocab_size(
     if tensor_model_parallel_size <= 0:
         raise ValueError(f"tensor_model_parallel_size must be positive, got {tensor_model_parallel_size}")
 
-    after = vocab_size
     multiple = make_vocab_size_divisible_by * tensor_model_parallel_size
-    after = int(math.ceil(after / multiple) * multiple)
-    if logging_enabled:
-        print_rank_0(
-            " > padded vocab (size: {}) with {} dummy tokens (new size: {})".format(
-                vocab_size, after - vocab_size, after
-            )
-        )
-    return after
+    return int(math.ceil(vocab_size / multiple) * multiple)


### PR DESCRIPTION
without `logging_enabled=False` lines like these repeatedly show up in during training:
```
elapsed time per iteration (ms): 626.2 | learning rate: 4.326855E-05 | global batch si
ze:     8 | lm loss: 3.446180E-01 | loss scale: 1.0 | grad norm: 0.192 | number of skipped iterations:   0 | number of nan iterations:   0 |
 > padded vocab (size: 10000) with 112 dummy tokens (new size: 10112)
 > padded vocab (size: 10000) with 112 dummy tokens (new size: 10112)
 > padded vocab (size: 10000) with 112 dummy tokens (new size: 10112)
 > padded vocab (size: 10000) with 112 dummy tokens (new size: 10112)
 > padded vocab (size: 10000) with 112 dummy tokens (new size: 10112)
 [2025-09-03 04:50:23] iteration      190/     200 | consumed samples:         1520 |
elapsed time per iteration (ms): 623.4 | learning rate: 1.983539E-05 | global batch si
ze:     8 | lm loss: 3.583552E-01 | loss scale: 1.0 | grad norm: 0.334 | number of ski
pped iterations:   0 | number of nan iterations:   0 |                                 > padded vocab (size: 10000) with 112 dummy tokens (new size: 10112)
 > padded vocab (size: 10000) with 112 dummy tokens (new size: 10112)
 > padded vocab (size: 10000) with 112 dummy tokens (new size: 10112)
 > padded vocab (size: 10000) with 112 dummy tokens (new size: 10112)
 > padded vocab (size: 10000) with 112 dummy tokens (new size: 10112)
 [2025-09-03 04:50:26] iteration      195/     200 | consumed samples:         1560 |
elapsed time per iteration (ms): 623.3 | learning rate: 5.716263E-06 | global batch si
ze:     8 | lm loss: 4.167347E-01 | loss scale: 1.0 | grad norm: 0.246 | number of ski
pped iterations:   0 | number of nan iterations:   0 |
 > padded vocab (size: 10000) with 112 dummy tokens (new size: 10112)                  > padded vocab (size: 10000) with 112 dummy tokens (new size: 10112)
 > padded vocab (size: 10000) with 112 dummy tokens (new size: 10112)
 > padded vocab (size: 10000) with 112 dummy tokens (new size: 10112)
 > padded vocab (size: 10000) with 112 dummy tokens (new size: 10112)
 [2025-09-03 04:50:29] iteration      200/     200 | consumed samples:         1600 |
elapsed time per iteration (ms): 622.1 | learning rate: 1.000000E-06 | global batch si
ze:     8 | lm loss: 2.532506E-01 | loss scale: 1.0 | grad norm: 0.238 | number of ski
pped iterations:   0 | number of nan iterations:   0 |
```
