### PR TITLE
Explicitly pass `expert_tensor_parallel_size` to `initialize_model_parallel`

### DIFF
--- a/src/megatron/bridge/models/model_provider.py
+++ b/src/megatron/bridge/models/model_provider.py
@@ -215,7 +215,7 @@ class ModelProviderMixin(abc.ABC, Generic[ModelT]):
             virtual_pipeline_model_parallel_size=getattr(self, "virtual_pipeline_model_parallel_size", None),
             context_parallel_size=getattr(self, "context_parallel_size", 1) or 1,
             expert_model_parallel_size=getattr(self, "expert_model_parallel_size", 1) or 1,
-            expert_tensor_parallel_size=getattr(self, "tensor_model_parallel_size", None),
+            expert_tensor_parallel_size=getattr(self, "expert_tensor_parallel_size", None),
             **model_parallel_kwargs,
         )
         if seed is not None:

--- a/src/megatron/bridge/models/model_provider.py
+++ b/src/megatron/bridge/models/model_provider.py
@@ -215,6 +215,7 @@ class ModelProviderMixin(abc.ABC, Generic[ModelT]):
             virtual_pipeline_model_parallel_size=getattr(self, "virtual_pipeline_model_parallel_size", None),
             context_parallel_size=getattr(self, "context_parallel_size", 1) or 1,
             expert_model_parallel_size=getattr(self, "expert_model_parallel_size", 1) or 1,
+            expert_tensor_parallel_size=getattr(self, "tensor_model_parallel_size", None),
             **model_parallel_kwargs,
         )
         if seed is not None:


### PR DESCRIPTION
Due to the [default handling in MCore](https://github.com/NVIDIA/Megatron-LM/blob/e0b9fbb254663b3441375deb4a734d936be2f67f/megatron/core/parallel_state.py#L697), if this isn't passed, `expert_tensor_parallel_size` is forced to `tensor_model_parallel_size`. With this PR, we first check whether the parameter is passed, and if not, fall back to the default behaviour with None.

Not extensively tested, but came across the issue and the fix seems straightforward.

(Hopefully) fixes https://github.com/NVIDIA-NeMo/Megatron-Bridge/issues/546