### PR TITLE
Add config options to control checking nan/spiky loss in rerun state machine

### DIFF
--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -140,6 +140,12 @@ class RerunStateMachineConfig:
     """Use re-run engine to validate results (default) or to emit stats
     on variability of computations due to non-deterministic algorithms."""
 
+    check_for_nan_in_loss: bool = True
+    """Check for NaN in the loss."""
+
+    check_for_spiky_loss: bool = False
+    """Check for spiky loss."""
+
 
 @dataclass(kw_only=True)
 class DataloaderConfig:


### PR DESCRIPTION
currently these are not configurable: https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/57382a58357f951bf00e2c4a0d5df96d6202b9ca/src/megatron/bridge/training/losses.py#L27-L28

https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/57382a58357f951bf00e2c4a0d5df96d6202b9ca/src/megatron/bridge/training/gpt_step.py#L340-L344

for performance tests, we want to be able to toggle these checks. we enable this by adding these flags to the rerun state machine config. these flags would then be read when the global state is injected