### PR TITLE
Update `check_for_nan_in_loss` and `skip_getting_attention_mask_from_dataset` setting

### DIFF
--- a/scripts/performance/llm/configs/deepseek_v3_pretrain_overrides.yaml
+++ b/scripts/performance/llm/configs/deepseek_v3_pretrain_overrides.yaml
@@ -38,6 +38,9 @@ train:
   train_iters: 25
   eval_iters: 0
 
+rerun_state_machine:
+  check_for_nan_in_loss: false
+
 dist:
   enable_megatron_core_experimental: true
 

--- a/scripts/performance/llm/configs/llama31_405b_pretrain_overrides.yaml
+++ b/scripts/performance/llm/configs/llama31_405b_pretrain_overrides.yaml
@@ -30,6 +30,9 @@ model:
 rng:
   te_rng_tracker: false
 
+rerun_state_machine:
+  check_for_nan_in_loss: false
+
 train:
   global_batch_size: 64
   micro_batch_size: 1

--- a/scripts/performance/llm/configs/llama3_70b_pretrain_overrides.yaml
+++ b/scripts/performance/llm/configs/llama3_70b_pretrain_overrides.yaml
@@ -34,6 +34,9 @@ train:
   train_iters: 25
   eval_iters: 0
 
+rerun_state_machine:
+  check_for_nan_in_loss: false
+
 checkpoint:
   # Directory to save to. If null, no checkpoint will be saved.
   save: null

--- a/scripts/performance/llm/configs/llama3_8b_pretrain_overrides.yaml
+++ b/scripts/performance/llm/configs/llama3_8b_pretrain_overrides.yaml
@@ -31,6 +31,9 @@ train:
   train_iters: 25
   eval_iters: 0
 
+rerun_state_machine:
+  check_for_nan_in_loss: false
+
 checkpoint:
   # Directory to save to. If null, no checkpoint will be saved.
   save: null

--- a/src/megatron/bridge/recipes/deepseek/deepseek_v2.py
+++ b/src/megatron/bridge/recipes/deepseek/deepseek_v2.py
@@ -219,6 +219,7 @@ def pretrain_config(
             data_sharding=True,
             dataloader_type="single",
             num_workers=8,
+            skip_getting_attention_mask_from_dataset=True,
         ),
         logger=LoggerConfig(log_interval=10, tensorboard_dir=tensorboard_dir, log_timers_to_tensorboard=True),
         tokenizer=TokenizerConfig(tokenizer_type="NullTokenizer", vocab_size=DEFAULT_NULL_TOKENIZER_VOCAB_SIZE),

--- a/src/megatron/bridge/recipes/deepseek/deepseek_v2_lite.py
+++ b/src/megatron/bridge/recipes/deepseek/deepseek_v2_lite.py
@@ -219,6 +219,7 @@ def pretrain_config(
             data_sharding=True,
             dataloader_type="single",
             num_workers=8,
+            skip_getting_attention_mask_from_dataset=True,
         ),
         logger=LoggerConfig(log_interval=10, tensorboard_dir=tensorboard_dir, log_timers_to_tensorboard=True),
         tokenizer=TokenizerConfig(tokenizer_type="NullTokenizer", vocab_size=DEFAULT_NULL_TOKENIZER_VOCAB_SIZE),

--- a/src/megatron/bridge/recipes/deepseek/deepseek_v3.py
+++ b/src/megatron/bridge/recipes/deepseek/deepseek_v3.py
@@ -273,6 +273,7 @@ def pretrain_config(
             data_sharding=True,
             dataloader_type="single",
             num_workers=8,
+            skip_getting_attention_mask_from_dataset=True,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/gpt/gpt3_175b.py
+++ b/src/megatron/bridge/recipes/gpt/gpt3_175b.py
@@ -206,6 +206,7 @@ def pretrain_config(
             data_sharding=True,
             dataloader_type="single",
             num_workers=8,
+            skip_getting_attention_mask_from_dataset=True,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/llama/llama2_7b.py
+++ b/src/megatron/bridge/recipes/llama/llama2_7b.py
@@ -195,6 +195,7 @@ def pretrain_config(
             data_sharding=True,
             dataloader_type="single",
             num_workers=8,
+            skip_getting_attention_mask_from_dataset=True,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/llama/llama31_405b.py
+++ b/src/megatron/bridge/recipes/llama/llama31_405b.py
@@ -207,6 +207,7 @@ def pretrain_config(
             data_sharding=True,
             dataloader_type="single",
             num_workers=8,
+            skip_getting_attention_mask_from_dataset=True,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/llama/llama31_70b.py
+++ b/src/megatron/bridge/recipes/llama/llama31_70b.py
@@ -195,6 +195,7 @@ def pretrain_config(
             data_sharding=True,
             dataloader_type="single",
             num_workers=8,
+            skip_getting_attention_mask_from_dataset=True,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/llama/llama31_8b.py
+++ b/src/megatron/bridge/recipes/llama/llama31_8b.py
@@ -195,6 +195,7 @@ def pretrain_config(
             data_sharding=True,
             dataloader_type="single",
             num_workers=8,
+            skip_getting_attention_mask_from_dataset=True,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/llama/llama32_1b.py
+++ b/src/megatron/bridge/recipes/llama/llama32_1b.py
@@ -194,6 +194,7 @@ def pretrain_config(
             data_sharding=True,
             dataloader_type="single",
             num_workers=8,
+            skip_getting_attention_mask_from_dataset=True,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/llama/llama32_3b.py
+++ b/src/megatron/bridge/recipes/llama/llama32_3b.py
@@ -194,6 +194,7 @@ def pretrain_config(
             data_sharding=True,
             dataloader_type="single",
             num_workers=8,
+            skip_getting_attention_mask_from_dataset=True,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/llama/llama3_70b.py
+++ b/src/megatron/bridge/recipes/llama/llama3_70b.py
@@ -191,6 +191,7 @@ def pretrain_config(
             data_sharding=True,
             dataloader_type="single",
             num_workers=8,
+            skip_getting_attention_mask_from_dataset=True,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/llama/llama3_8b.py
+++ b/src/megatron/bridge/recipes/llama/llama3_8b.py
@@ -194,6 +194,7 @@ def pretrain_config(
             data_sharding=True,
             dataloader_type="single",
             num_workers=8,
+            skip_getting_attention_mask_from_dataset=True,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/llama/llama4_e128.py
+++ b/src/megatron/bridge/recipes/llama/llama4_e128.py
@@ -198,6 +198,7 @@ def pretrain_config(
             data_sharding=True,
             dataloader_type="single",
             num_workers=8,
+            skip_getting_attention_mask_from_dataset=True,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/llama/llama4_e16.py
+++ b/src/megatron/bridge/recipes/llama/llama4_e16.py
@@ -198,6 +198,7 @@ def pretrain_config(
             data_sharding=True,
             dataloader_type="single",
             num_workers=8,
+            skip_getting_attention_mask_from_dataset=True,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/mamba/mamba2_130m.py
+++ b/src/megatron/bridge/recipes/mamba/mamba2_130m.py
@@ -189,6 +189,7 @@ def pretrain_config(
             data_sharding=True,
             dataloader_type="single",
             num_workers=8,
+            skip_getting_attention_mask_from_dataset=True,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/mamba/mamba2_1_3b.py
+++ b/src/megatron/bridge/recipes/mamba/mamba2_1_3b.py
@@ -189,6 +189,7 @@ def pretrain_config(
             data_sharding=True,
             dataloader_type="single",
             num_workers=8,
+            skip_getting_attention_mask_from_dataset=True,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/mamba/mamba2_2_7b.py
+++ b/src/megatron/bridge/recipes/mamba/mamba2_2_7b.py
@@ -189,6 +189,7 @@ def pretrain_config(
             data_sharding=True,
             dataloader_type="single",
             num_workers=8,
+            skip_getting_attention_mask_from_dataset=True,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/mamba/mamba2_370m.py
+++ b/src/megatron/bridge/recipes/mamba/mamba2_370m.py
@@ -189,6 +189,7 @@ def pretrain_config(
             data_sharding=True,
             dataloader_type="single",
             num_workers=8,
+            skip_getting_attention_mask_from_dataset=True,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/mamba/mamba2_780m.py
+++ b/src/megatron/bridge/recipes/mamba/mamba2_780m.py
@@ -189,6 +189,7 @@ def pretrain_config(
             data_sharding=True,
             dataloader_type="single",
             num_workers=8,
+            skip_getting_attention_mask_from_dataset=True,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/mamba/mamba2_8b.py
+++ b/src/megatron/bridge/recipes/mamba/mamba2_8b.py
@@ -190,6 +190,7 @@ def pretrain_config(
             data_sharding=True,
             dataloader_type="single",
             num_workers=8,
+            skip_getting_attention_mask_from_dataset=True,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/mamba/mamba2_hybrid_8b.py
+++ b/src/megatron/bridge/recipes/mamba/mamba2_hybrid_8b.py
@@ -190,6 +190,7 @@ def pretrain_config(
             data_sharding=True,
             dataloader_type="single",
             num_workers=8,
+            skip_getting_attention_mask_from_dataset=True,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/mamba/nemotron_nano_12b_v2.py
+++ b/src/megatron/bridge/recipes/mamba/nemotron_nano_12b_v2.py
@@ -189,6 +189,7 @@ def pretrain_config(
             data_sharding=True,
             dataloader_type="single",
             num_workers=8,
+            skip_getting_attention_mask_from_dataset=True,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/mamba/nemotron_nano_9b_v2.py
+++ b/src/megatron/bridge/recipes/mamba/nemotron_nano_9b_v2.py
@@ -189,6 +189,7 @@ def pretrain_config(
             data_sharding=True,
             dataloader_type="single",
             num_workers=8,
+            skip_getting_attention_mask_from_dataset=True,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/mamba/nemotronh_47b.py
+++ b/src/megatron/bridge/recipes/mamba/nemotronh_47b.py
@@ -189,6 +189,7 @@ def pretrain_config(
             data_sharding=True,
             dataloader_type="single",
             num_workers=8,
+            skip_getting_attention_mask_from_dataset=True,
         ),
         logger=LoggerConfig(
             log_interval=1,

--- a/src/megatron/bridge/recipes/mamba/nemotronh_4b.py
+++ b/src/megatron/bridge/recipes/mamba/nemotronh_4b.py
@@ -189,6 +189,7 @@ def pretrain_config(
             data_sharding=True,
             dataloader_type="single",
             num_workers=8,
+            skip_getting_attention_mask_from_dataset=True,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/mamba/nemotronh_56b.py
+++ b/src/megatron/bridge/recipes/mamba/nemotronh_56b.py
@@ -189,6 +189,7 @@ def pretrain_config(
             data_sharding=True,
             dataloader_type="single",
             num_workers=8,
+            skip_getting_attention_mask_from_dataset=True,
         ),
         logger=LoggerConfig(
             log_interval=1,

--- a/src/megatron/bridge/recipes/mamba/nemotronh_8b.py
+++ b/src/megatron/bridge/recipes/mamba/nemotronh_8b.py
@@ -189,6 +189,7 @@ def pretrain_config(
             data_sharding=True,
             dataloader_type="single",
             num_workers=8,
+            skip_getting_attention_mask_from_dataset=True,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/qwen/qwen25_14b.py
+++ b/src/megatron/bridge/recipes/qwen/qwen25_14b.py
@@ -183,6 +183,7 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
+            skip_getting_attention_mask_from_dataset=True,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/qwen/qwen25_1p5b.py
+++ b/src/megatron/bridge/recipes/qwen/qwen25_1p5b.py
@@ -183,6 +183,7 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
+            skip_getting_attention_mask_from_dataset=True,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/qwen/qwen25_32b.py
+++ b/src/megatron/bridge/recipes/qwen/qwen25_32b.py
@@ -183,6 +183,7 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
+            skip_getting_attention_mask_from_dataset=True,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/qwen/qwen25_500m.py
+++ b/src/megatron/bridge/recipes/qwen/qwen25_500m.py
@@ -183,6 +183,7 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
+            skip_getting_attention_mask_from_dataset=True,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/qwen/qwen25_72b.py
+++ b/src/megatron/bridge/recipes/qwen/qwen25_72b.py
@@ -183,6 +183,7 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
+            skip_getting_attention_mask_from_dataset=True,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/qwen/qwen25_7b.py
+++ b/src/megatron/bridge/recipes/qwen/qwen25_7b.py
@@ -183,6 +183,7 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
+            skip_getting_attention_mask_from_dataset=True,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/qwen/qwen2_1p5b.py
+++ b/src/megatron/bridge/recipes/qwen/qwen2_1p5b.py
@@ -183,6 +183,7 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
+            skip_getting_attention_mask_from_dataset=True,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/qwen/qwen2_500m.py
+++ b/src/megatron/bridge/recipes/qwen/qwen2_500m.py
@@ -183,6 +183,7 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
+            skip_getting_attention_mask_from_dataset=True,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/qwen/qwen2_72b.py
+++ b/src/megatron/bridge/recipes/qwen/qwen2_72b.py
@@ -183,6 +183,7 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
+            skip_getting_attention_mask_from_dataset=True,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/qwen/qwen2_7b.py
+++ b/src/megatron/bridge/recipes/qwen/qwen2_7b.py
@@ -183,6 +183,7 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
+            skip_getting_attention_mask_from_dataset=True,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/qwen/qwen3_14b.py
+++ b/src/megatron/bridge/recipes/qwen/qwen3_14b.py
@@ -190,6 +190,7 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
+            skip_getting_attention_mask_from_dataset=True,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/qwen/qwen3_1p7b.py
+++ b/src/megatron/bridge/recipes/qwen/qwen3_1p7b.py
@@ -190,6 +190,7 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
+            skip_getting_attention_mask_from_dataset=True,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/qwen/qwen3_235b_a22b.py
+++ b/src/megatron/bridge/recipes/qwen/qwen3_235b_a22b.py
@@ -201,6 +201,7 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
+            skip_getting_attention_mask_from_dataset=True,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/qwen/qwen3_30b_a3b.py
+++ b/src/megatron/bridge/recipes/qwen/qwen3_30b_a3b.py
@@ -204,6 +204,7 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
+            skip_getting_attention_mask_from_dataset=True,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/qwen/qwen3_32b.py
+++ b/src/megatron/bridge/recipes/qwen/qwen3_32b.py
@@ -197,6 +197,7 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
+            skip_getting_attention_mask_from_dataset=True,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/qwen/qwen3_4b.py
+++ b/src/megatron/bridge/recipes/qwen/qwen3_4b.py
@@ -190,6 +190,7 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
+            skip_getting_attention_mask_from_dataset=True,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/qwen/qwen3_600m.py
+++ b/src/megatron/bridge/recipes/qwen/qwen3_600m.py
@@ -191,6 +191,7 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
+            skip_getting_attention_mask_from_dataset=True,
         ),
         logger=LoggerConfig(
             log_interval=10,

--- a/src/megatron/bridge/recipes/qwen/qwen3_8b.py
+++ b/src/megatron/bridge/recipes/qwen/qwen3_8b.py
@@ -190,6 +190,7 @@ def pretrain_config(
             # Dataloader config parameters
             data_sharding=True,
             dataloader_type="single",
+            skip_getting_attention_mask_from_dataset=True,
         ),
         logger=LoggerConfig(
             log_interval=10,


### PR DESCRIPTION
- Default disable `check_for_nan_in_loss` in performance scripts.
- Set `skip_getting_attention_mask_from_dataset=True` in all LLM benchmarks