### PR TITLE
[docs] update contributing doc for how to run github CI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,3 +157,35 @@ Quality documentation is essential for both the usability of Megatron-Bridge and
       maintained indefinitely and may be redistributed consistent with
       this project or the open source license(s) involved.
   ```
+
+## 🚀 Running GitHub CI
+
+There are two ways to trigger CI tests on your pull request:
+
+### Automatic CI Triggering
+
+If your GitHub user is configured to use [signed commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification), CI tests will run automatically when you push commits to your pull request.
+
+> **Note**: Signed commits are different from signing-off on commits (which uses the `-s` flag mentioned in the [Signing Your Work](#signing-your-work) section).
+
+### Manual CI Triggering
+
+If you don't have signed commits set up, you can still trigger CI tests manually by commenting on your pull request:
+
+```
+/ok to test <commit-SHA>
+```
+
+For example:
+```
+/ok to test a1b2c3d4e5f6
+```
+
+**Important**: You'll need to add this comment for each new commit you push to ensure CI tests run on the latest changes.
+
+#### Finding Your Commit SHA
+
+You can find the commit SHA in several ways:
+- View your pull request's commit history on GitHub
+- Run `git log --oneline -1` in your local repository
+- Check the commit details in your Git client


### PR DESCRIPTION
Include instructions for how to run CI either manually with `/ok to test` or using the verified commits