### PR TITLE
[docs] Add training & customization setting for configs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,17 @@ performance-guide.md
 ```
 
 ```{toctree}
+:caption: Training and Customization
+:hidden:
+
+training/config-container-overview.md
+training/training-config.md
+training/optimizer-scheduler-config.md
+training/checkpointing-config.md
+training/peft-config.md
+```
+
+```{toctree}
 :caption: Development
 :hidden:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,7 @@ training/training-config.md
 training/optimizer-scheduler-config.md
 training/checkpointing-config.md
 training/peft-config.md
+training/resiliency.md
 ```
 
 ```{toctree}

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,7 @@ performance-guide.md
 :hidden:
 
 training/config-container-overview.md
+training/entry-points.md
 training/training-config.md
 training/optimizer-scheduler-config.md
 training/checkpointing-config.md

--- a/docs/training/checkpointing-config.md
+++ b/docs/training/checkpointing-config.md
@@ -52,7 +52,6 @@ Parameters to control how checkpoints are saved.
 ## Asynchronous Saving
 
 Asynchronous saving allows training to continue while checkpoint data is persisted to disk in the background, reducing the impact of checkpointing on training throughput.
-Parameter for asynchronous checkpoint saving.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
@@ -103,7 +102,6 @@ Parameter for selecting the checkpoint format.
 | `ckpt_format` | `Literal["torch_dist"]` | `"torch_dist"` | Checkpoint format (PyTorch distributed checkpoint format) |
 
 ## Performance Optimizations
-Parameters to optimize checkpoint save and load performance.
 Parameters to optimize checkpoint save and load performance.
 
 | Parameter | Type | Default | Description |
@@ -162,7 +160,6 @@ Local checkpointing leverages the [NVIDIA Resiliency Extension](https://nvidia.g
 
 ### Non-Persistent Checkpointing Configuration
 Parameters for non-persistent checkpointing.
-Parameters for non-persistent checkpointing.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
@@ -173,7 +170,6 @@ Parameters for non-persistent checkpointing.
 | `non_persistent_local_ckpt_algo` | `Literal["fully_parallel", "atomic"]` | `"fully_parallel"` | Algorithm for local non-persistent checkpointing |
 
 ### Replication and Fault Tolerance
-Parameters for replication and fault tolerance of local checkpoints.
 Parameters for replication and fault tolerance of local checkpoints.
 
 | Parameter | Type | Default | Description |

--- a/docs/training/checkpointing-config.md
+++ b/docs/training/checkpointing-config.md
@@ -1,46 +1,28 @@
-# Checkpointing Configuration
+# Checkpointing
 
-The `CheckpointConfig` controls model checkpointing behavior, including saving and loading checkpoints, checkpoint formats, and various optimization features.
+The {py:class}`bridge.training.config.CheckpointConfig` controls model checkpointing behavior, including saving and loading checkpoints, checkpoint formats, and various optimization features.
 
 ## Overview
 
-Megatron Bridge uses Megatron Core's distributed checkpointing system, which is designed for large-scale training across multiple GPUs and nodes. The distributed checkpoint approach saves the state of a distributed training job by sharding checkpoint data across multiple files, reducing memory overhead and improving GPU utilization during save and load operations.
+Megatron Bridge uses Megatron Core's distributed checkpointing system, which is designed for large-scale training across multiple GPUs and nodes. The distributed checkpoint approach saves the state of a distributed training job by sharding checkpoint data across multiple files, reducing memory overhead and improving GPU utilization during save/load operations.
 
-## Distributed Checkpointing Benefits
+### Distributed Checkpointing Benefits
 
-Distributed checkpointing introduces a robust and scalable approach to model training, offering key advantages in memory efficiency, parallelism flexibility, and performance optimization across diverse hardware configurations.
+**Memory Efficiency**: Instead of gathering all model parameters and optimizer states on a single rank, distributed checkpointing saves data directly from each rank, significantly reducing memory requirements during checkpointing.
 
-### Memory Efficiency
-Distributed checkpointing avoids centralizing all model parameters and optimizer states on a single rank. Instead, each rank saves its own data, significantly reducing memory requirements during checkpointing.
+**Parallelism Flexibility**: The system provides flexibility to resume training using different parallelism strategies. You can change tensor parallelism, pipeline parallelism, or data parallelism sizes between checkpoint save and load operations.
 
-### Parallelism Flexibility
-Training can be resumed with different parallelism strategies. You can adjust:
-- Tensor Parallelism
-- Pipeline Parallelism
-- Data Parallelism
+**Scalability**: Handles all types of parallelism including:
+- **Data Parallelism (DP)**: Replicates the model across multiple GPUs with different data batches
+- **Tensor Parallelism (TP)**: Distributes individual layer parameters across GPUs  
+- **Pipeline Parallelism (PP)**: Assigns consecutive layers to different GPUs
+- **Context Parallelism (CP)**: Shards tensors along the sequence dimension for long sequences
+- **Expert Parallelism (EP)**: Distributes MoE expert weights across GPUs
 
-This flexibility allows seamless transitions between checkpoint save and load operations.
-
-### Scalability
-Distributed checkpointing supports a wide range of parallelism types:
-
-| Parallelism Type       | Description                                                                 |
-|------------------------|-----------------------------------------------------------------------------|
-| Data Parallelism (DP)     | Replicates the model across multiple GPUs with different data batches       |
-| Tensor Parallelism (TP)   | Distributes individual layer parameters across GPUs                         |
-| Pipeline Parallelism (PP) | Assigns consecutive layers to different GPUs                                |
-| Context Parallelism (CP)  | Shards tensors along the sequence dimension for long sequences              |
-| Expert Parallelism (EP)   | Distributes Mixture-of-Experts (MoE) weights across GPUs                    |
-
-### Performance
-The distributed optimizer shards both optimizer states and master parameters across data-parallel ranks. This approach:
-- Reduces memory usage
-- Minimizes communication overhead
-- Enhances training efficiency
+**Performance**: The distributed optimizer shards optimizer states and master parameters across data-parallel ranks instead of replicating them, reducing memory usage and communication overhead.
 
 
 ## Save Configuration
-Parameters to control how checkpoints are saved.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
@@ -49,7 +31,7 @@ Parameters to control how checkpoints are saved.
 | `save_optim` | `bool` | `True` | Whether to save optimizer state |
 | `save_rng` | `bool` | `True` | Whether to save random number generator state |
 
-## Asynchronous Saving
+### Asynchronous Saving
 
 Asynchronous saving allows training to continue while checkpoint data is persisted to disk in the background, reducing the impact of checkpointing on training throughput.
 
@@ -58,7 +40,6 @@ Asynchronous saving allows training to continue while checkpoint data is persist
 | `async_save` | `bool` | `False` | Enable asynchronous checkpoint saving (requires `torch_dist` format) |
 
 ## Load Configuration
-Parameters to control how checkpoints are loaded.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
@@ -70,39 +51,32 @@ Parameters to control how checkpoints are loaded.
 | `exit_on_missing_checkpoint` | `bool` | `False` | Exit if specified checkpoint is not found instead of random initialization |
 | `dist_ckpt_strictness` | `Literal[...]` | `"assume_ok_unexpected"` | Handling of key mismatches during distributed checkpoint load |
 
-## Checkpoint Loading Strictness
+### Checkpoint Loading Strictness
 
-When loading distributed checkpoints, key mismatches can occur between the saved checkpoint and the current model. These discrepancies often arise when resuming training with different parallelism settings, model architectures, or software versions. The `dist_ckpt_strictness` parameter determines how strictly these mismatches are handled.
+When loading distributed checkpoints, there may be mismatches between the keys in the saved checkpoint and what the current model expects. This can happen when resuming training with different parallelism settings, model configurations, or software versions. The `dist_ckpt_strictness` parameter controls how these mismatches are handled:
 
+- **`assume_ok_unexpected`**: Assume unexpected keys are acceptable (default, most permissive)
+- **`log_unexpected`**: Log unexpected keys but continue loading
+- **`log_all`**: Log all key mismatches for debugging
+- **`raise_unexpected`**: Raise error on unexpected keys (stricter validation)
+- **`raise_all`**: Raise error on any key mismatch (strictest validation)
+- **`return_unexpected`**: Return information about unexpected keys
+- **`return_all`**: Return information about all key mismatches
+- **`ignore_all`**: Ignore all key mismatches completely
 
-| Parameter              | Description                                                       |
-|------------------------|-------------------------------------------------------------------|
-| `assume_ok_unexpected` | Assume unexpected keys are acceptable (default, most permissive)  |
-| `log_unexpected`       | Log unexpected keys but continue loading                          |
-| `log_all`              | Log all key mismatches for debugging                              |
-| `raise_unexpected`     | Raise error on unexpected keys (stricter validation)              |
-| `raise_all`            | Raise error on any key mismatch (strictest validation)            |
-| `return_unexpected`    | Return information about unexpected keys                          |
-| `return_all`           | Return information about all key mismatches                       |
-| `ignore_all`           | Ignore all key mismatches completely                              |
-
-
-## Fine-Tuning Configuration
-Parameter for fine-tuning from a pretrained checkpoint.
+## Fine-tuning Configuration
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `pretrained_checkpoint` | `Optional[str]` | `None` | Directory containing pretrained model checkpoint for fine-tuning |
 
 ## Checkpoint Format
-Parameter for selecting the checkpoint format.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `ckpt_format` | `Literal["torch_dist"]` | `"torch_dist"` | Checkpoint format (PyTorch distributed checkpoint format) |
 
 ## Performance Optimizations
-Parameters to optimize checkpoint save and load performance.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
@@ -111,9 +85,16 @@ Parameters to optimize checkpoint save and load performance.
 | `ckpt_assume_constant_structure` | `bool` | `False` | Assume constant model/optimizer structure over successive checkpoint saves for performance optimizations |
 
 
-## Checkpoint Format on Disk
+## Checkpoint Contents
 
-When using the `torch_dist` checkpoint format, Megatron Bridge creates checkpoints with the following directory structure:
+The checkpoint includes the following components when using the `torch_dist` checkpoint format:
+- **Model parameters and optimizer states**: Stored across `.distcp` files to support distributed training.
+- **Training state**: Captures the current iteration count, number of consumed samples, and the state of the learning rate scheduler.
+- **Configuration**: Serialized as a YAML file (`run_config.yaml`) containing the complete `ConfigContainer`.
+- **Dataloader states**: Ensures deterministic resumption of data iteration.
+- **Metadata**: Used for validating and correctly loading the checkpoint.
+
+Megatron Bridge creates checkpoints with the following directory structure:
 
 ```
 checkpoint_dir/
@@ -136,16 +117,6 @@ checkpoint_dir/
 │   │   └── ...                              # One file per DP rank
 ```
 
-## Checkpoint Contents
-
-The checkpoint includes the following components:
-
-- **Model parameters and optimizer states**: Stored across `.distcp` files to support distributed training.
-- **Training state**: Captures the current iteration count, number of consumed samples, and the state of the learning rate scheduler.
-- **Configuration**: Serialized as a YAML file (`run_config.yaml`) containing the complete `ConfigContainer`.
-- **Dataloader states**: Ensures deterministic resumption of data iteration.
-- **Metadata**: Used for validating and correctly loading the checkpoint.
-
 ## Local Checkpointing
 
 Local checkpointing saves model checkpoints directly to storage on each node (e.g., local SSDs or RAM disks), instead of relying solely on a shared network filesystem. This approach can significantly speed up the saving process and reduce the load on shared storage infrastructure.
@@ -157,9 +128,7 @@ Local checkpointing leverages the [NVIDIA Resiliency Extension](https://nvidia.g
 - **Automatic Cleanup**: Handles the removal of outdated or incomplete local checkpoints automatically.
 - **Optional Replication**: For multi-node jobs, checkpoints are replicated to other nodes to allow recovery even if a node fails after saving. Single-node jobs do not use replication.
 - **Automated Loading**: When resuming, the framework automatically finds the latest valid checkpoint, comparing local and global checkpoints, and retrieves any needed parts across nodes.
-
 ### Non-Persistent Checkpointing Configuration
-Parameters for non-persistent checkpointing.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
@@ -170,7 +139,6 @@ Parameters for non-persistent checkpointing.
 | `non_persistent_local_ckpt_algo` | `Literal["fully_parallel", "atomic"]` | `"fully_parallel"` | Algorithm for local non-persistent checkpointing |
 
 ### Replication and Fault Tolerance
-Parameters for replication and fault tolerance of local checkpoints.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|

--- a/docs/training/checkpointing-config.md
+++ b/docs/training/checkpointing-config.md
@@ -104,6 +104,7 @@ Parameter for selecting the checkpoint format.
 
 ## Performance Optimizations
 Parameters to optimize checkpoint save and load performance.
+Parameters to optimize checkpoint save and load performance.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
@@ -161,6 +162,7 @@ Local checkpointing leverages the [NVIDIA Resiliency Extension](https://nvidia.g
 
 ### Non-Persistent Checkpointing Configuration
 Parameters for non-persistent checkpointing.
+Parameters for non-persistent checkpointing.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
@@ -171,6 +173,7 @@ Parameters for non-persistent checkpointing.
 | `non_persistent_local_ckpt_algo` | `Literal["fully_parallel", "atomic"]` | `"fully_parallel"` | Algorithm for local non-persistent checkpointing |
 
 ### Replication and Fault Tolerance
+Parameters for replication and fault tolerance of local checkpoints.
 Parameters for replication and fault tolerance of local checkpoints.
 
 | Parameter | Type | Default | Description |

--- a/docs/training/checkpointing-config.md
+++ b/docs/training/checkpointing-config.md
@@ -1,0 +1,153 @@
+# Checkpointing
+
+The `CheckpointConfig` controls model checkpointing behavior, including saving and loading checkpoints, checkpoint formats, and various optimization features.
+
+## Overview
+
+Megatron-Bridge uses Megatron Core's distributed checkpointing system, which is designed for large-scale training across multiple GPUs and nodes. The distributed checkpoint approach saves the state of a distributed training job by sharding checkpoint data across multiple files, reducing memory overhead and improving GPU utilization during save/load operations.
+
+### Distributed Checkpointing Benefits
+
+**Memory Efficiency**: Instead of gathering all model parameters and optimizer states on a single rank, distributed checkpointing saves data directly from each rank, significantly reducing memory requirements during checkpointing.
+
+**Parallelism Flexibility**: The system provides flexibility to resume training using different parallelism strategies. You can change tensor parallelism, pipeline parallelism, or data parallelism sizes between checkpoint save and load operations.
+
+**Scalability**: Handles all types of parallelism including:
+- **Data Parallelism (DP)**: Replicates the model across multiple GPUs with different data batches
+- **Tensor Parallelism (TP)**: Distributes individual layer parameters across GPUs  
+- **Pipeline Parallelism (PP)**: Assigns consecutive layers to different GPUs
+- **Context Parallelism (CP)**: Shards tensors along the sequence dimension for long sequences
+- **Expert Parallelism (EP)**: Distributes MoE expert weights across GPUs
+
+**Performance**: The distributed optimizer shards optimizer states and master parameters across data-parallel ranks instead of replicating them, reducing memory usage and communication overhead.
+
+
+## Save Configuration
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `save` | `Optional[str]` | `None` | Output directory to save checkpoints to |
+| `save_interval` | `Optional[int]` | `None` | Number of iterations between persistent checkpoint saves |
+| `save_optim` | `bool` | `True` | Whether to save optimizer state |
+| `save_rng` | `bool` | `True` | Whether to save random number generator state |
+
+### Asynchronous Saving
+
+Asynchronous saving allows training to continue while checkpoint data is persisted to disk in the background, reducing the impact of checkpointing on training throughput.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `async_save` | `bool` | `False` | Enable asynchronous checkpoint saving (requires `torch_dist` format) |
+
+## Load Configuration
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `load` | `Optional[str]` | `None` | Directory containing a model checkpoint to load |
+| `load_optim` | `bool` | `True` | Whether to load optimizer state from checkpoint |
+| `load_rng` | `bool` | `True` | Whether to load random number generator state from checkpoint |
+| `load_main_params_from_ckpt` | `bool` | `False` | Load main parameters from checkpoint (use with `load_optim=False`) |
+| `ckpt_step` | `Optional[int]` | `None` | Specific checkpoint step to load from |
+| `exit_on_missing_checkpoint` | `bool` | `False` | Exit if specified checkpoint is not found instead of random initialization |
+| `dist_ckpt_strictness` | `Literal[...]` | `"assume_ok_unexpected"` | Handling of key mismatches during distributed checkpoint load |
+
+### Checkpoint Loading Strictness
+
+When loading distributed checkpoints, there may be mismatches between the keys in the saved checkpoint and what the current model expects. This can happen when resuming training with different parallelism settings, model configurations, or software versions. The `dist_ckpt_strictness` parameter controls how these mismatches are handled:
+
+- **`assume_ok_unexpected`**: Assume unexpected keys are acceptable (default, most permissive)
+- **`log_unexpected`**: Log unexpected keys but continue loading
+- **`log_all`**: Log all key mismatches for debugging
+- **`raise_unexpected`**: Raise error on unexpected keys (stricter validation)
+- **`raise_all`**: Raise error on any key mismatch (strictest validation)
+- **`return_unexpected`**: Return information about unexpected keys
+- **`return_all`**: Return information about all key mismatches
+- **`ignore_all`**: Ignore all key mismatches completely
+
+## Fine-tuning Configuration
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `pretrained_checkpoint` | `Optional[str]` | `None` | Directory containing pretrained model checkpoint for fine-tuning |
+
+## Checkpoint Format
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `ckpt_format` | `Literal["torch_dist"]` | `"torch_dist"` | Checkpoint format (PyTorch distributed checkpoint format) |
+
+## Performance Optimizations
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `fully_parallel_save` | `bool` | `True` | Apply full save parallelization across data parallel ranks |
+| `fully_parallel_load` | `bool` | `False` | Apply full load parallelization across data parallel ranks |
+| `ckpt_assume_constant_structure` | `bool` | `False` | Assume constant model/optimizer structure over successive checkpoint saves for performance optimizations |
+
+
+## Checkpoint Format on Disk
+
+When using the `torch_dist` checkpoint format, Megatron-Bridge creates checkpoints with the following directory structure:
+
+```
+checkpoint_dir/
+├── latest_train_state.pt                      # Latest training state (top-level)
+├── iter_N/                                    # Checkpoint at iteration N
+│   ├── __0_0.distcp                          # Distributed checkpoint shards: maps to PyTorch DCP weights format
+│   ├── __0_1.distcp                          # Contains model parameters, optimizer states
+│   ├── __1_0.distcp
+│   ├── __1_1.distcp
+│   ├── ...
+│   ├── .metadata                             # PyTorch DCP checkpoint metadata
+│   ├── common.pt                             # MCore dist ckpt states saved from rank 0
+│   ├── metadata.json                         # MCore dist ckpt metadata
+│   ├── run_config.yaml                       # Serialized ConfigContainer
+│   ├── train_state.pt                        # Number of steps, consumed samples, etc
+│   ├── dataloader_state/                     # Data iterator states
+│   │   ├── train_dataloader_dprank000.pt    # DP rank 0 dataloader state
+│   │   ├── train_dataloader_dprank001.pt    # DP rank 1 dataloader state
+│   │   ├── train_dataloader_dprank002.pt    # DP rank 2 dataloader state
+│   │   └── ...                              # One file per DP rank
+```
+
+The checkpoint includes:
+- **Model parameters and optimizer states** distributed across `.distcp` files
+- **Training state** with iteration count, consumed samples, learning rate scheduler state
+- **Configuration** as a serialized YAML file (`run_config.yaml`) containing the complete `ConfigContainer`
+- **Dataloader states** to ensure deterministic data iteration resumption
+- **Metadata** for checkpoint validation and loading
+
+## Local Checkpointing
+
+Local checkpointing saves model checkpoints directly to storage on each node (e.g., local SSDs or RAM disks), instead of relying solely on a shared network filesystem. This approach can significantly speed up the saving process and reduce the load on shared storage infrastructure.
+
+Local checkpointing leverages the [NVIDIA Resiliency Extension](https://nvidia.github.io/nvidia-resiliency-ext/checkpointing/local/index.html) and provides several key features:
+
+**Local Saving**: Each node saves its part of the checkpoint locally, reducing network I/O and improving save performance.
+
+**Synchronous and Asynchronous Support**: Saving can happen synchronously or asynchronously, mirroring the configuration used for global checkpoints.
+
+**Automatic Cleanup**: Handles the removal of outdated or incomplete local checkpoints automatically.
+
+**Optional Replication**: For multi-node jobs, checkpoints are replicated to other nodes to allow recovery even if a node fails after saving. Single-node jobs do not use replication.
+
+**Automated Loading**: When resuming, the framework automatically finds the latest valid checkpoint, comparing local and global checkpoints, and retrieves any needed parts across nodes.
+
+### Non-Persistent Checkpointing Configuration
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `non_persistent_save_interval` | `Optional[int]` | `None` | Iterations between non-persistent saves |
+| `non_persistent_ckpt_type` | `Optional[Literal["global", "local", "in_memory", "None"]]` | `None` | Type of non-persistent checkpointing |
+| `non_persistent_global_ckpt_dir` | `Optional[str]` | `None` | Directory for global non-persistent checkpoints |
+| `non_persistent_local_ckpt_dir` | `Optional[str]` | `None` | Directory for local non-persistent checkpoints |
+| `non_persistent_local_ckpt_algo` | `Literal["fully_parallel", "atomic"]` | `"fully_parallel"` | Algorithm for local non-persistent checkpointing |
+
+### Replication & Fault Tolerance
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `replication` | `bool` | `False` | Enable replication of local checkpoints across ranks |
+| `replication_jump` | `Optional[int]` | `None` | Spacing between ranks storing replicas |
+| `replication_factor` | `int` | `2` | Number of machines storing replica of each rank's data |
+

--- a/docs/training/checkpointing-config.md
+++ b/docs/training/checkpointing-config.md
@@ -1,28 +1,46 @@
-# Checkpointing
+# Checkpointing Configuration
 
 The `CheckpointConfig` controls model checkpointing behavior, including saving and loading checkpoints, checkpoint formats, and various optimization features.
 
 ## Overview
 
-Megatron-Bridge uses Megatron Core's distributed checkpointing system, which is designed for large-scale training across multiple GPUs and nodes. The distributed checkpoint approach saves the state of a distributed training job by sharding checkpoint data across multiple files, reducing memory overhead and improving GPU utilization during save/load operations.
+Megatron Bridge uses Megatron Core's distributed checkpointing system, which is designed for large-scale training across multiple GPUs and nodes. The distributed checkpoint approach saves the state of a distributed training job by sharding checkpoint data across multiple files, reducing memory overhead and improving GPU utilization during save and load operations.
 
-### Distributed Checkpointing Benefits
+## Distributed Checkpointing Benefits
 
-**Memory Efficiency**: Instead of gathering all model parameters and optimizer states on a single rank, distributed checkpointing saves data directly from each rank, significantly reducing memory requirements during checkpointing.
+Distributed checkpointing introduces a robust and scalable approach to model training, offering key advantages in memory efficiency, parallelism flexibility, and performance optimization across diverse hardware configurations.
 
-**Parallelism Flexibility**: The system provides flexibility to resume training using different parallelism strategies. You can change tensor parallelism, pipeline parallelism, or data parallelism sizes between checkpoint save and load operations.
+### Memory Efficiency
+Distributed checkpointing avoids centralizing all model parameters and optimizer states on a single rank. Instead, each rank saves its own data, significantly reducing memory requirements during checkpointing.
 
-**Scalability**: Handles all types of parallelism including:
-- **Data Parallelism (DP)**: Replicates the model across multiple GPUs with different data batches
-- **Tensor Parallelism (TP)**: Distributes individual layer parameters across GPUs  
-- **Pipeline Parallelism (PP)**: Assigns consecutive layers to different GPUs
-- **Context Parallelism (CP)**: Shards tensors along the sequence dimension for long sequences
-- **Expert Parallelism (EP)**: Distributes MoE expert weights across GPUs
+### Parallelism Flexibility
+Training can be resumed with different parallelism strategies. You can adjust:
+- Tensor Parallelism
+- Pipeline Parallelism
+- Data Parallelism
 
-**Performance**: The distributed optimizer shards optimizer states and master parameters across data-parallel ranks instead of replicating them, reducing memory usage and communication overhead.
+This flexibility allows seamless transitions between checkpoint save and load operations.
+
+### Scalability
+Distributed checkpointing supports a wide range of parallelism types:
+
+| Parallelism Type       | Description                                                                 |
+|------------------------|-----------------------------------------------------------------------------|
+| Data Parallelism (DP)     | Replicates the model across multiple GPUs with different data batches       |
+| Tensor Parallelism (TP)   | Distributes individual layer parameters across GPUs                         |
+| Pipeline Parallelism (PP) | Assigns consecutive layers to different GPUs                                |
+| Context Parallelism (CP)  | Shards tensors along the sequence dimension for long sequences              |
+| Expert Parallelism (EP)   | Distributes Mixture-of-Experts (MoE) weights across GPUs                    |
+
+### Performance
+The distributed optimizer shards both optimizer states and master parameters across data-parallel ranks. This approach:
+- Reduces memory usage
+- Minimizes communication overhead
+- Enhances training efficiency
 
 
 ## Save Configuration
+Parameters to control how checkpoints are saved.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
@@ -31,15 +49,17 @@ Megatron-Bridge uses Megatron Core's distributed checkpointing system, which is 
 | `save_optim` | `bool` | `True` | Whether to save optimizer state |
 | `save_rng` | `bool` | `True` | Whether to save random number generator state |
 
-### Asynchronous Saving
+## Asynchronous Saving
 
 Asynchronous saving allows training to continue while checkpoint data is persisted to disk in the background, reducing the impact of checkpointing on training throughput.
+Parameter for asynchronous checkpoint saving.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `async_save` | `bool` | `False` | Enable asynchronous checkpoint saving (requires `torch_dist` format) |
 
 ## Load Configuration
+Parameters to control how checkpoints are loaded.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
@@ -51,32 +71,39 @@ Asynchronous saving allows training to continue while checkpoint data is persist
 | `exit_on_missing_checkpoint` | `bool` | `False` | Exit if specified checkpoint is not found instead of random initialization |
 | `dist_ckpt_strictness` | `Literal[...]` | `"assume_ok_unexpected"` | Handling of key mismatches during distributed checkpoint load |
 
-### Checkpoint Loading Strictness
+## Checkpoint Loading Strictness
 
-When loading distributed checkpoints, there may be mismatches between the keys in the saved checkpoint and what the current model expects. This can happen when resuming training with different parallelism settings, model configurations, or software versions. The `dist_ckpt_strictness` parameter controls how these mismatches are handled:
+When loading distributed checkpoints, key mismatches can occur between the saved checkpoint and the current model. These discrepancies often arise when resuming training with different parallelism settings, model architectures, or software versions. The `dist_ckpt_strictness` parameter determines how strictly these mismatches are handled.
 
-- **`assume_ok_unexpected`**: Assume unexpected keys are acceptable (default, most permissive)
-- **`log_unexpected`**: Log unexpected keys but continue loading
-- **`log_all`**: Log all key mismatches for debugging
-- **`raise_unexpected`**: Raise error on unexpected keys (stricter validation)
-- **`raise_all`**: Raise error on any key mismatch (strictest validation)
-- **`return_unexpected`**: Return information about unexpected keys
-- **`return_all`**: Return information about all key mismatches
-- **`ignore_all`**: Ignore all key mismatches completely
 
-## Fine-tuning Configuration
+| Parameter              | Description                                                       |
+|------------------------|-------------------------------------------------------------------|
+| `assume_ok_unexpected` | Assume unexpected keys are acceptable (default, most permissive)  |
+| `log_unexpected`       | Log unexpected keys but continue loading                          |
+| `log_all`              | Log all key mismatches for debugging                              |
+| `raise_unexpected`     | Raise error on unexpected keys (stricter validation)              |
+| `raise_all`            | Raise error on any key mismatch (strictest validation)            |
+| `return_unexpected`    | Return information about unexpected keys                          |
+| `return_all`           | Return information about all key mismatches                       |
+| `ignore_all`           | Ignore all key mismatches completely                              |
+
+
+## Fine-Tuning Configuration
+Parameter for fine-tuning from a pretrained checkpoint.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `pretrained_checkpoint` | `Optional[str]` | `None` | Directory containing pretrained model checkpoint for fine-tuning |
 
 ## Checkpoint Format
+Parameter for selecting the checkpoint format.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `ckpt_format` | `Literal["torch_dist"]` | `"torch_dist"` | Checkpoint format (PyTorch distributed checkpoint format) |
 
 ## Performance Optimizations
+Parameters to optimize checkpoint save and load performance.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
@@ -87,7 +114,7 @@ When loading distributed checkpoints, there may be mismatches between the keys i
 
 ## Checkpoint Format on Disk
 
-When using the `torch_dist` checkpoint format, Megatron-Bridge creates checkpoints with the following directory structure:
+When using the `torch_dist` checkpoint format, Megatron Bridge creates checkpoints with the following directory structure:
 
 ```
 checkpoint_dir/
@@ -110,12 +137,15 @@ checkpoint_dir/
 │   │   └── ...                              # One file per DP rank
 ```
 
-The checkpoint includes:
-- **Model parameters and optimizer states** distributed across `.distcp` files
-- **Training state** with iteration count, consumed samples, learning rate scheduler state
-- **Configuration** as a serialized YAML file (`run_config.yaml`) containing the complete `ConfigContainer`
-- **Dataloader states** to ensure deterministic data iteration resumption
-- **Metadata** for checkpoint validation and loading
+## Checkpoint Contents
+
+The checkpoint includes the following components:
+
+- **Model parameters and optimizer states**: Stored across `.distcp` files to support distributed training.
+- **Training state**: Captures the current iteration count, number of consumed samples, and the state of the learning rate scheduler.
+- **Configuration**: Serialized as a YAML file (`run_config.yaml`) containing the complete `ConfigContainer`.
+- **Dataloader states**: Ensures deterministic resumption of data iteration.
+- **Metadata**: Used for validating and correctly loading the checkpoint.
 
 ## Local Checkpointing
 
@@ -123,17 +153,14 @@ Local checkpointing saves model checkpoints directly to storage on each node (e.
 
 Local checkpointing leverages the [NVIDIA Resiliency Extension](https://nvidia.github.io/nvidia-resiliency-ext/checkpointing/local/index.html) and provides several key features:
 
-**Local Saving**: Each node saves its part of the checkpoint locally, reducing network I/O and improving save performance.
-
-**Synchronous and Asynchronous Support**: Saving can happen synchronously or asynchronously, mirroring the configuration used for global checkpoints.
-
-**Automatic Cleanup**: Handles the removal of outdated or incomplete local checkpoints automatically.
-
-**Optional Replication**: For multi-node jobs, checkpoints are replicated to other nodes to allow recovery even if a node fails after saving. Single-node jobs do not use replication.
-
-**Automated Loading**: When resuming, the framework automatically finds the latest valid checkpoint, comparing local and global checkpoints, and retrieves any needed parts across nodes.
+- **Local Saving**: Each node saves its part of the checkpoint locally, reducing network I/O and improving save performance.
+- **Synchronous and Asynchronous Support**: Saving can happen synchronously or asynchronously, mirroring the configuration used for global checkpoints.
+- **Automatic Cleanup**: Handles the removal of outdated or incomplete local checkpoints automatically.
+- **Optional Replication**: For multi-node jobs, checkpoints are replicated to other nodes to allow recovery even if a node fails after saving. Single-node jobs do not use replication.
+- **Automated Loading**: When resuming, the framework automatically finds the latest valid checkpoint, comparing local and global checkpoints, and retrieves any needed parts across nodes.
 
 ### Non-Persistent Checkpointing Configuration
+Parameters for non-persistent checkpointing.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
@@ -143,7 +170,8 @@ Local checkpointing leverages the [NVIDIA Resiliency Extension](https://nvidia.g
 | `non_persistent_local_ckpt_dir` | `Optional[str]` | `None` | Directory for local non-persistent checkpoints |
 | `non_persistent_local_ckpt_algo` | `Literal["fully_parallel", "atomic"]` | `"fully_parallel"` | Algorithm for local non-persistent checkpointing |
 
-### Replication & Fault Tolerance
+### Replication and Fault Tolerance
+Parameters for replication and fault tolerance of local checkpoints.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|

--- a/docs/training/config-container-overview.md
+++ b/docs/training/config-container-overview.md
@@ -1,4 +1,4 @@
-# ConfigContainer Overview
+# Configuration Overview
 
 The `ConfigContainer` is the central configuration object in Megatron Bridge that orchestrates all aspects of training. It acts as a single source of truth that brings together model architecture, training parameters, data loading, optimization, checkpointing, logging, and distributed training settings.
 
@@ -36,7 +36,7 @@ The `ConfigContainer` organizes training settings into three categories—**requ
 
 ### Required Attributes
 
-The following configuration attributes must be provided when creating a `ConfigContainer`:
+The following configuration attributes must be provided when creating a `ConfigContainer` for training:
 
 | Attribute | Purpose |
 |-----------|---------|
@@ -52,7 +52,6 @@ The following configuration attributes must be provided when creating a `ConfigC
 ### Default Attributes
 
 These attributes have predefined defaults, but can be customized to suit specific training needs:
-
 
 | Attribute | Purpose |
 |-----------|---------|
@@ -84,8 +83,6 @@ Several configuration components in `ConfigContainer` are directly derived from 
 | `optimizer`   | Uses `OptimizerConfig` from Megatron Core for optimization settings |
 | `ddp`         | Uses `DistributedDataParallelConfig` from Megatron Core for data parallel configuration |
 
-
-
 These configurations provide seamless integration with the Megatron Core library.
 
 ## Automatic Configuration Processing
@@ -99,8 +96,6 @@ At the start of training, Megatron Bridge automatically validates, adjusts, and 
 You do not need to manually validate configurations - this process occurs automatically at the start of training.
 
 ## Configuration Export and Import
-The `ConfigContainer` supports serialization to and from YAML, allowing configurations to be saved, shared, and reloaded across training sessions.
-The `ConfigContainer` supports serialization to and from YAML, allowing configurations to be saved, shared, and reloaded across training sessions.
 
 ### Export to YAML
 ```python

--- a/docs/training/config-container-overview.md
+++ b/docs/training/config-container-overview.md
@@ -1,8 +1,8 @@
-# Configuration Overview
+# ConfigContainer Overview
 
-The `ConfigContainer` is the central configuration object in Megatron-Bridge that orchestrates all aspects of training. It acts as a single source of truth that brings together model architecture, training parameters, data loading, optimization, checkpointing, logging, and distributed training settings.
+The `ConfigContainer` is the central configuration object in Megatron Bridge that orchestrates all aspects of training. It acts as a single source of truth that brings together model architecture, training parameters, data loading, optimization, checkpointing, logging, and distributed training settings.
 
-## What is ConfigContainer?
+## What is ConfigContainer
 
 `ConfigContainer` is a dataclass that holds all the configuration objects needed for training:
 
@@ -32,11 +32,11 @@ config = ConfigContainer(
 
 ## Configuration Attributes
 
-The `ConfigContainer` contains the following configuration attributes:
+The `ConfigContainer` organizes training settings into three categories—**required**, **default**, and **optional** each controlling a specific aspect of model setup, execution, and advanced features.
 
 ### Required Attributes
 
-These configuration attributes must be provided when creating a `ConfigContainer`:
+The following configuration attributes must be provided when creating a `ConfigContainer`:
 
 | Attribute | Purpose |
 |-----------|---------|
@@ -51,7 +51,8 @@ These configuration attributes must be provided when creating a `ConfigContainer
 
 ### Default Attributes
 
-These configuration attributes have sensible defaults but can be customized:
+These attributes have predefined defaults, but can be customized to suit specific training needs:
+
 
 | Attribute | Purpose |
 |-----------|---------|
@@ -62,7 +63,7 @@ These configuration attributes have sensible defaults but can be customized:
 
 ### Optional Attributes
 
-These configuration attributes are `None` by default and enable specific features when set:
+These configuration attributes are set to `None` by default and enable specific features when configured:
 
 | Attribute | Purpose |
 |-----------|---------|
@@ -76,24 +77,29 @@ These configuration attributes are `None` by default and enable specific feature
 
 ## Megatron Core Integration
 
-Several configuration objects come directly from Megatron Core:
+Several configuration components in `ConfigContainer` are directly derived from Megatron Core, ensuring compatibility with its optimization and data parallel frameworks:
 
-- **`optimizer`**: Uses `OptimizerConfig` from Megatron Core for optimization settings
-- **`ddp`**: Uses `DistributedDataParallelConfig` from Megatron Core for data parallel configuration
+| Configuration | Purpose |
+|---------------|---------|
+| `optimizer`   | Uses `OptimizerConfig` from Megatron Core for optimization settings |
+| `ddp`         | Uses `DistributedDataParallelConfig` from Megatron Core for data parallel configuration |
+
+
 
 These configurations provide seamless integration with the Megatron Core library.
 
 ## Automatic Configuration Processing
 
-When training begins, the framework automatically handles configuration processing:
+At the start of training, Megatron Bridge automatically validates, adjusts, and resolves configuration settings to ensure consistency and optimal runtime behavior:
 
-1. **Validation**: All configurations are validated for consistency and compatibility
-2. **Runtime Overrides**: Mixed precision and communication overlap configs apply runtime overrides based on environment variables and device-specific checks
-3. **Dependency Resolution**: Dependent values (like data parallel size, scheduler steps) are calculated automatically
+1. **Validation**: All configurations are validated for consistency and compatibility.
+2. **Runtime Overrides**: Mixed precision and communication overlap configurations apply runtime overrides based on environment variables and device-specific checks.
+3. **Dependency Resolution**: Dependent values (like data parallel size and scheduler steps) are calculated automatically.
 
-Users do not need to manually validate configurations - this happens automatically at the start of training.
+You do not need to manually validate configurations - this process occurs automatically at the start of training.
 
 ## Configuration Export and Import
+The `ConfigContainer` supports serialization to and from YAML, allowing configurations to be saved, shared, and reloaded across training sessions.
 
 ### Export to YAML
 ```python

--- a/docs/training/config-container-overview.md
+++ b/docs/training/config-container-overview.md
@@ -100,6 +100,7 @@ You do not need to manually validate configurations - this process occurs automa
 
 ## Configuration Export and Import
 The `ConfigContainer` supports serialization to and from YAML, allowing configurations to be saved, shared, and reloaded across training sessions.
+The `ConfigContainer` supports serialization to and from YAML, allowing configurations to be saved, shared, and reloaded across training sessions.
 
 ### Export to YAML
 ```python

--- a/docs/training/config-container-overview.md
+++ b/docs/training/config-container-overview.md
@@ -1,0 +1,111 @@
+# Configuration Overview
+
+The `ConfigContainer` is the central configuration object in Megatron-Bridge that orchestrates all aspects of training. It acts as a single source of truth that brings together model architecture, training parameters, data loading, optimization, checkpointing, logging, and distributed training settings.
+
+## What is ConfigContainer?
+
+`ConfigContainer` is a dataclass that holds all the configuration objects needed for training:
+
+```python
+from megatron.bridge.training.config import ConfigContainer
+
+# ConfigContainer brings together all training configurations
+config = ConfigContainer(
+    model=model_provider,             # Model architecture and parallelism
+    train=training_config,            # Training loop parameters  
+    optimizer=optimizer_config,       # Megatron Optimization settings
+    scheduler=scheduler_config,       # Learning rate scheduling
+    dataset=dataset_config,           # Data loading configuration
+    logger=logger_config,             # Logging and monitoring
+    tokenizer=tokenizer_config,       # Tokenization settings
+    checkpoint=checkpoint_config,     # Checkpointing and resuming
+    dist=distributed_config,          # Distributed training setup
+    ddp=ddp_config,                   # Megatron Distributed Data Parallel settings
+    # Optional configurations
+    peft=peft_config,                 # Parameter-efficient fine-tuning
+    profiling=profiling_config,       # Performance profiling
+    mixed_precision=mp_config,        # Mixed precision training
+    comm_overlap=comm_overlap_config, # Communication overlap settings
+    # ... and more
+)
+```
+
+## Configuration Attributes
+
+The `ConfigContainer` contains the following configuration attributes:
+
+### Required Attributes
+
+These configuration attributes must be provided when creating a `ConfigContainer`:
+
+| Attribute | Purpose |
+|-----------|---------|
+| `model` | Model architecture and parallelism strategy (from model providers) |
+| `train` | Training loop parameters (batch sizes, iterations, validation) |
+| `optimizer` | Optimizer type and hyperparameters (from Megatron Core) |
+| `scheduler` | Learning rate and weight decay scheduling |
+| `dataset` | Data loading and preprocessing configuration |
+| `logger` | Logging, TensorBoard, and WandB configuration |
+| `tokenizer` | Tokenizer settings and vocabulary |
+| `checkpoint` | Checkpointing, saving, and loading |
+
+### Default Attributes
+
+These configuration attributes have sensible defaults but can be customized:
+
+| Attribute | Purpose |
+|-----------|---------|
+| `dist` | Distributed training initialization |
+| `ddp` | Data parallel configuration (from Megatron Core) |
+| `rng` | Random number generation settings |
+| `rerun_state_machine` | Result validation and error injection |
+
+### Optional Attributes
+
+These configuration attributes are `None` by default and enable specific features when set:
+
+| Attribute | Purpose |
+|-----------|---------|
+| `peft` | Parameter-efficient fine-tuning (LoRA, DoRA, etc.) |
+| `profiling` | Performance profiling with nsys or PyTorch profiler |
+| `mixed_precision` | Mixed precision training settings |
+| `comm_overlap` | Communication overlap optimizations |
+| `ft` | Fault tolerance and automatic recovery |
+| `straggler` | GPU straggler detection |
+| `nvrx_straggler` | NVIDIA Resiliency Extension straggler detection |
+
+## Megatron Core Integration
+
+Several configuration objects come directly from Megatron Core:
+
+- **`optimizer`**: Uses `OptimizerConfig` from Megatron Core for optimization settings
+- **`ddp`**: Uses `DistributedDataParallelConfig` from Megatron Core for data parallel configuration
+
+These configurations provide seamless integration with the Megatron Core library.
+
+## Automatic Configuration Processing
+
+When training begins, the framework automatically handles configuration processing:
+
+1. **Validation**: All configurations are validated for consistency and compatibility
+2. **Runtime Overrides**: Mixed precision and communication overlap configs apply runtime overrides based on environment variables and device-specific checks
+3. **Dependency Resolution**: Dependent values (like data parallel size, scheduler steps) are calculated automatically
+
+Users do not need to manually validate configurations - this happens automatically at the start of training.
+
+## Configuration Export and Import
+
+### Export to YAML
+```python
+# Print yaml configuration to console
+config.print_yaml()
+
+# Save to file
+config.to_yaml("config.yaml")
+```
+
+### Load from YAML
+```python
+# Load configuration from YAML file
+config = ConfigContainer.from_yaml("config.yaml")
+```

--- a/docs/training/entry-points.md
+++ b/docs/training/entry-points.md
@@ -4,7 +4,7 @@ Megatron Bridge provides unified training entry points for pretraining, Supervis
 
 ## Main Entry Points
 
-The [`pretrain`](../apidocs/bridge/bridge.training.pretrain.md) and [`finetune`](../apidocs/bridge/bridge.training.finetune.md) functions are the primary entry points for pretraining models—either from scratch or through fine-tuning. Each function accepts a [`ConfigContainer`](../apidocs/bridge/bridge.training.config.md) along with a `forward_step_func` that defines how the training loop should be run.
+The {py:func}`bridge.training.pretrain.pretrain` and {py:func}`bridge.training.finetune.finetune` functions are the primary entry points for pretraining models—either from scratch or through fine-tuning. Each function accepts a {py:class}`bridge.training.config.ConfigContainer` along with a `forward_step_func` that defines how the training loop should be run.
 
 
 ## Forward Step Function
@@ -43,7 +43,7 @@ The forward step function has three main responsibilities:
 
 ### State Access
 
-Megatron Bridge automatically provides the [`GlobalState`](../apidocs/bridge/bridge.training.state.md) object containing:
+Megatron Bridge automatically provides the {py:class}`bridge.training.state.GlobalState` object containing:
 - **Configuration**: Complete training configuration (`global_state.cfg`).
 - **Timers**: Performance monitoring utilities (`global_state.timers`).
 - **Training Progress**: Current step, consumed samples (`global_state.train_state`).
@@ -51,7 +51,7 @@ Megatron Bridge automatically provides the [`GlobalState`](../apidocs/bridge/bri
 
 All configuration and state information are accessible through the injected `state` object.
 
-For complete implementation examples, see [`gpt_step.forward_step`](../apidocs/bridge/bridge.training.gpt_step.md).
+For complete implementation examples, see {py:func}`bridge.training.gpt_step.forward_step`.
 
 ## Loss Calculation and Reduction
 
@@ -82,7 +82,7 @@ The training loop automatically handles:
 - **Pipeline Coordination**: Only the last pipeline stage computes and reduces losses.
 - **Logging Integration**: Automatically logs loss components to TensorBoard/WandB.
 
-For implementation details, see [`train.train_step`](../apidocs/bridge/bridge.training.train.md) and [`losses`](../apidocs/bridge/bridge.training.losses.md).
+For implementation details, see {py:func}`bridge.training.train.train_step` and {py:func}`bridge.training.losses.masked_token_loss`, as an example.
 
 ## Customization
 

--- a/docs/training/entry-points.md
+++ b/docs/training/entry-points.md
@@ -1,10 +1,10 @@
 # Training Entry Points
 
-Megatron-Bridge provides unified training entry points for pretraining, supervised fine-tuning (SFT), and parameter-efficient fine-tuning (PEFT). All training modes share the same underlying training loop architecture, differing primarily in their data handling and model configuration.
+Megatron Bridge provides unified training entry points for pretraining, Supervised Fine-Tuning (SFT), and Parameter-Efficient Fine-Tuning (PEFT). All training modes share the same underlying training loop architecture, differing primarily in their data handling and model configuration.
 
 ## Main Entry Points
 
-The [`pretrain`](../apidocs/bridge/bridge.training.pretrain.md) and [`finetune`](../apidocs/bridge/bridge.training.finetune.md) functions are the primary entry points for pretraining from scratch and finetuning models, respectively. Each accept the [`ConfigContainer`](../apidocs/bridge/bridge.training.config.md) along with a `forward_step_func` to specify how the training loop should be run.
+The [`pretrain`](../apidocs/bridge/bridge.training.pretrain.md) and [`finetune`](../apidocs/bridge/bridge.training.finetune.md) functions are the primary entry points for pretraining models—either from scratch or through fine-tuning. Each function accepts a [`ConfigContainer`](../apidocs/bridge/bridge.training.config.md) along with a `forward_step_func` that defines how the training loop should be run.
 
 
 ## Forward Step Function
@@ -37,19 +37,19 @@ def forward_step_func(
 
 The forward step function has three main responsibilities:
 
-1. **Get a Batch**: Retrieve and process the next batch from the data iterator
-2. **Run Forward Pass**: Execute the model's forward pass on the batch  
-3. **Return Loss Function**: Provide a function to compute loss from the output
+1. **Get a Batch**: Retrieve and process the next batch from the data iterator.
+2. **Run Forward Pass**: Execute the model's forward pass on the batch.
+3. **Return Loss Function**: Provide a function to compute loss from the output.
 
 ### State Access
 
-Megatron-Bridge automatically provides the [`GlobalState`](../apidocs/bridge/bridge.training.state.md) object containing:
-- **Configuration**: Complete training configuration (`global_state.cfg`)
-- **Timers**: Performance monitoring utilities (`global_state.timers`)
-- **Training Progress**: Current step, consumed samples (`global_state.train_state`)
-- **Loggers**: TensorBoard and WandB loggers for metrics tracking
+Megatron Bridge automatically provides the [`GlobalState`](../apidocs/bridge/bridge.training.state.md) object containing:
+- **Configuration**: Complete training configuration (`global_state.cfg`).
+- **Timers**: Performance monitoring utilities (`global_state.timers`).
+- **Training Progress**: Current step, consumed samples (`global_state.train_state`).
+- **Loggers**: TensorBoard and WandB loggers for metrics tracking.
 
-All configuration and state is accessible through the injected state object.
+All configuration and state information are accessible through the injected `state` object.
 
 For complete implementation examples, see [`gpt_step.forward_step`](../apidocs/bridge/bridge.training.gpt_step.md).
 
@@ -77,10 +77,10 @@ The loss function returned by the forward step can follow different patterns bas
 ### Automatic Loss Processing
 
 The training loop automatically handles:
-- **Microbatch Reduction**: Aggregates losses across all microbatches in the global batch
-- **Distributed Reduction**: Performs all-reduce operations across data parallel ranks
-- **Pipeline Coordination**: Only the last pipeline stage computes and reduces losses
-- **Logging Integration**: Automatically logs loss components to TensorBoard/WandB
+- **Microbatch Reduction**: Aggregates losses across all microbatches in the global batch.
+- **Distributed Reduction**: Performs all-reduce operations across data parallel ranks.
+- **Pipeline Coordination**: Only the last pipeline stage computes and reduces losses.
+- **Logging Integration**: Automatically logs loss components to TensorBoard/WandB.
 
 For implementation details, see [`train.train_step`](../apidocs/bridge/bridge.training.train.md) and [`losses`](../apidocs/bridge/bridge.training.losses.md).
 
@@ -90,8 +90,8 @@ For implementation details, see [`train.train_step`](../apidocs/bridge/bridge.tr
 
 You can customize the forward step function when you need:
 
-- **Custom Loss Functions**: Beyond standard language modeling loss (e.g., adding regularization, multi-objective training)
-- **Multi-task Learning**: Training models on multiple tasks simultaneously with different loss components
-- **Custom Data Processing**: Specialized batch preprocessing for domain-specific data formats
-- **Additional Metrics**: Computing extra evaluation metrics during training
-- **Model-specific Logic**: Special handling for custom model architectures or training procedures
+- **Custom Loss Functions**: Beyond standard language modeling loss (e.g., adding regularization, multi-objective training).
+- **Multi-task Learning**: Training models on multiple tasks simultaneously with different loss components.
+- **Custom Data Processing**: Specialized batch preprocessing for domain-specific data formats.
+- **Additional Metrics**: Computing extra evaluation metrics during training.
+- **Model-specific Logic**: Special handling for custom model architectures or training procedures.

--- a/docs/training/entry-points.md
+++ b/docs/training/entry-points.md
@@ -1,0 +1,97 @@
+# Training Entry Points
+
+Megatron-Bridge provides unified training entry points for pretraining, supervised fine-tuning (SFT), and parameter-efficient fine-tuning (PEFT). All training modes share the same underlying training loop architecture, differing primarily in their data handling and model configuration.
+
+## Main Entry Points
+
+The [`pretrain`](../apidocs/bridge/bridge.training.pretrain.md) and [`finetune`](../apidocs/bridge/bridge.training.finetune.md) functions are the primary entry points for pretraining from scratch and finetuning models, respectively. Each accept the [`ConfigContainer`](../apidocs/bridge/bridge.training.config.md) along with a `forward_step_func` to specify how the training loop should be run.
+
+
+## Forward Step Function
+
+The `forward_step_func` defines how each training step is executed. It should follow this signature:
+
+```python
+def forward_step_func(
+    global_state: GlobalState,
+    data_iterator: Iterable,
+    model: MegatronModule,
+    return_schedule_plan: bool = False,
+) -> tuple[Any, Callable]:
+    """Forward step function.
+    
+    Args:
+        global_state: Training state object containing configuration and utilities
+        data_iterator: Iterator over training/evaluation data
+        model: The model to perform forward step on
+        return_schedule_plan: Whether to return schedule plan (for MoE overlap)
+        
+    Returns:
+        tuple containing:
+        - output: Forward pass output (tensor or collection of tensors)
+        - loss_func: Function to compute loss from the output
+    """
+```
+
+### Responsibilities
+
+The forward step function has three main responsibilities:
+
+1. **Get a Batch**: Retrieve and process the next batch from the data iterator
+2. **Run Forward Pass**: Execute the model's forward pass on the batch  
+3. **Return Loss Function**: Provide a function to compute loss from the output
+
+### State Access
+
+Megatron-Bridge automatically provides the [`GlobalState`](../apidocs/bridge/bridge.training.state.md) object containing:
+- **Configuration**: Complete training configuration (`global_state.cfg`)
+- **Timers**: Performance monitoring utilities (`global_state.timers`)
+- **Training Progress**: Current step, consumed samples (`global_state.train_state`)
+- **Loggers**: TensorBoard and WandB loggers for metrics tracking
+
+All configuration and state is accessible through the injected state object.
+
+For complete implementation examples, see [`gpt_step.forward_step`](../apidocs/bridge/bridge.training.gpt_step.md).
+
+## Loss Calculation and Reduction
+
+The loss function returned by the forward step can follow different patterns based on your needs:
+
+### Loss Function Patterns
+
+1. **Standard Pattern**: Return `(loss, metadata_dict)`
+   - The loss is automatically averaged across microbatches
+   - Metadata dict contains named loss components for logging
+   - Most common pattern for standard training
+
+2. **Token-aware Pattern**: Return `(loss, num_tokens, metadata_dict)`
+   - Loss is averaged across both microbatches and tokens
+   - Useful when you want per-token loss averaging
+   - Recommended for variable-length sequences
+
+3. **Inference Pattern**: Return arbitrary data structures
+   - Used with `collect_non_loss_data=True` and `forward_only=True`
+   - Suitable for inference, evaluation metrics, or custom data collection
+   - No automatic loss processing applied
+
+### Automatic Loss Processing
+
+The training loop automatically handles:
+- **Microbatch Reduction**: Aggregates losses across all microbatches in the global batch
+- **Distributed Reduction**: Performs all-reduce operations across data parallel ranks
+- **Pipeline Coordination**: Only the last pipeline stage computes and reduces losses
+- **Logging Integration**: Automatically logs loss components to TensorBoard/WandB
+
+For implementation details, see [`train.train_step`](../apidocs/bridge/bridge.training.train.md) and [`losses`](../apidocs/bridge/bridge.training.losses.md).
+
+## Customization
+
+### When to Customize
+
+You can customize the forward step function when you need:
+
+- **Custom Loss Functions**: Beyond standard language modeling loss (e.g., adding regularization, multi-objective training)
+- **Multi-task Learning**: Training models on multiple tasks simultaneously with different loss components
+- **Custom Data Processing**: Specialized batch preprocessing for domain-specific data formats
+- **Additional Metrics**: Computing extra evaluation metrics during training
+- **Model-specific Logic**: Special handling for custom model architectures or training procedures

--- a/docs/training/optimizer-scheduler-config.md
+++ b/docs/training/optimizer-scheduler-config.md
@@ -27,7 +27,6 @@ The `OptimizerConfig` contains all parameters for the optimization algorithm and
 The `SchedulerConfig` controls learning rate scheduling and weight decay progression throughout training.
 
 ### Learning Rate Scheduling
-Parameters for controlling the learning rate schedule, including decay strategy, warmup behavior, and iteration-based adjustments:
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
@@ -38,7 +37,6 @@ Parameters for controlling the learning rate schedule, including decay strategy,
 | `lr_warmup_init` | `float` | `0.0` | Initial learning rate for warmup phase |
 
 ### WSD (Warmup-Stable-Decay) Scheduling
-Parameters for configuring the annealing phase of the WSD schedule, including decay style and iteration count:
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
@@ -46,7 +44,9 @@ Parameters for configuring the annealing phase of the WSD schedule, including de
 | `lr_wsd_decay_iters` | `Optional[int]` | `None` | Iterations for WSD annealing phase |
 
 ### Weight Decay Scheduling
+
 Parameters for controlling the progression of weight decay during training, including start and end values and the scheduling strategy:
+
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `start_weight_decay` | `Optional[float]` | `None` | Initial weight decay coefficient |
@@ -54,7 +54,9 @@ Parameters for controlling the progression of weight decay during training, incl
 | `weight_decay_incr_style` | `Literal["constant", "linear", "cosine"]` | `"constant"` | Weight decay progression style |
 
 ### Checkpoint Integration
+
 Parameters for managing how scheduler settings are applied during checkpoint loading, allowing control over whether to prioritize config values or restore from saved state:
+
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `override_opt_param_scheduler` | `bool` | `False` | Reset scheduler values from config, ignoring checkpoint |
@@ -64,7 +66,6 @@ Parameters for managing how scheduler settings are applied during checkpoint loa
 
 These fields are automatically calculated during configuration validation and help align training schedules with the configured batch size and iteration counts:
 
-
 | Field | Description |
 |-------|-------------|
 | `lr_warmup_steps` | Total steps for warmup (calculated from iterations and batch size) |
@@ -73,8 +74,8 @@ These fields are automatically calculated during configuration validation and he
 | `wsd_decay_steps` | Total steps for WSD annealing phase |
 
 ## Learning Rate Schedules
-The following scheduling strategies define how the learning rate evolves during training, each suited to different convergence behaviors and model types:
 
+The following scheduling strategies define how the learning rate evolves during training, each suited to different convergence behaviors and model types:
 | Schedule Type           | Description                                                                 |
 |-------------------------|-----------------------------------------------------------------------------|
 | **Constant**            | Learning rate remains fixed throughout training.                            |
@@ -82,24 +83,19 @@ The following scheduling strategies define how the learning rate evolves during 
 | **Cosine**              | Learning rate follows a cosine decay curve from base LR to minimum LR.      |
 | **Inverse Square Root** | Learning rate decays proportionally to the inverse square root of the step. |
 
-
 ## WSD (Warmup-Stable-Decay)
-
 The WSD schedule divides learning rate progression into three distinct phases, offering fine-grained control over early ramp-up, mid-training stability, and final decay:
-
 | Phase     | Description                                              |
 |-----------|----------------------------------------------------------|
 | **Warmup** | Learning rate increases linearly from initial value to base LR. |
 | **Stable** | Learning rate remains constant at base LR.              |
 | **Decay**  | Learning rate decays to minimum LR using a specified style (e.g., exponential, linear, cosine). |
 
-
 ## Weight Decay Scheduling
-These scheduling options control how the weight decay coefficient changes over time, allowing for regularization strategies that adapt to different training phases:
 
+These scheduling options control how the weight decay coefficient changes over time, allowing for regularization strategies that adapt to different training phases:
 | Schedule Type | Description                                                                 |
 |---------------|-----------------------------------------------------------------------------|
 | **Constant**  | Fixed weight decay throughout training.                                     |
 | **Linear**    | Linear progression from start to end weight decay.                          |
 | **Cosine**    | Cosine progression from start to end weight decay.                          |
-

--- a/docs/training/optimizer-scheduler-config.md
+++ b/docs/training/optimizer-scheduler-config.md
@@ -28,7 +28,6 @@ The `SchedulerConfig` controls learning rate scheduling and weight decay progres
 
 ### Learning Rate Scheduling
 Parameters for controlling the learning rate schedule, including decay strategy, warmup behavior, and iteration-based adjustments:
-Parameters for controlling the learning rate schedule, including decay strategy, warmup behavior, and iteration-based adjustments:
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
@@ -39,7 +38,6 @@ Parameters for controlling the learning rate schedule, including decay strategy,
 | `lr_warmup_init` | `float` | `0.0` | Initial learning rate for warmup phase |
 
 ### WSD (Warmup-Stable-Decay) Scheduling
-Parameters for configuring the annealing phase of the WSD schedule, including decay style and iteration count:
 Parameters for configuring the annealing phase of the WSD schedule, including decay style and iteration count:
 
 | Parameter | Type | Default | Description |

--- a/docs/training/optimizer-scheduler-config.md
+++ b/docs/training/optimizer-scheduler-config.md
@@ -1,4 +1,4 @@
-# Optimizer & Scheduler Configuration
+# Optimizer and Scheduler Configuration
 
 The optimizer and scheduler configurations control optimization algorithms, learning rate schedules, and weight decay strategies.
 
@@ -27,6 +27,7 @@ The `OptimizerConfig` contains all parameters for the optimization algorithm and
 The `SchedulerConfig` controls learning rate scheduling and weight decay progression throughout training.
 
 ### Learning Rate Scheduling
+Parameters for controlling the learning rate schedule, including decay strategy, warmup behavior, and iteration-based adjustments:
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
@@ -37,6 +38,7 @@ The `SchedulerConfig` controls learning rate scheduling and weight decay progres
 | `lr_warmup_init` | `float` | `0.0` | Initial learning rate for warmup phase |
 
 ### WSD (Warmup-Stable-Decay) Scheduling
+Parameters for configuring the annealing phase of the WSD schedule, including decay style and iteration count:
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
@@ -44,7 +46,7 @@ The `SchedulerConfig` controls learning rate scheduling and weight decay progres
 | `lr_wsd_decay_iters` | `Optional[int]` | `None` | Iterations for WSD annealing phase |
 
 ### Weight Decay Scheduling
-
+Parameters for controlling the progression of weight decay during training, including start and end values and the scheduling strategy:
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `start_weight_decay` | `Optional[float]` | `None` | Initial weight decay coefficient |
@@ -52,7 +54,7 @@ The `SchedulerConfig` controls learning rate scheduling and weight decay progres
 | `weight_decay_incr_style` | `Literal["constant", "linear", "cosine"]` | `"constant"` | Weight decay progression style |
 
 ### Checkpoint Integration
-
+Parameters for managing how scheduler settings are applied during checkpoint loading, allowing control over whether to prioritize config values or restore from saved state:
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `override_opt_param_scheduler` | `bool` | `False` | Reset scheduler values from config, ignoring checkpoint |
@@ -60,7 +62,8 @@ The `SchedulerConfig` controls learning rate scheduling and weight decay progres
 
 ### Computed Fields
 
-These fields are automatically calculated during configuration validation:
+These fields are automatically calculated during configuration validation and help align training schedules with the configured batch size and iteration counts:
+
 
 | Field | Description |
 |-------|-------------|
@@ -70,29 +73,33 @@ These fields are automatically calculated during configuration validation:
 | `wsd_decay_steps` | Total steps for WSD annealing phase |
 
 ## Learning Rate Schedules
+The following scheduling strategies define how the learning rate evolves during training, each suited to different convergence behaviors and model types:
 
-### Constant
-Learning rate remains fixed throughout training.
+| Schedule Type           | Description                                                                 |
+|-------------------------|-----------------------------------------------------------------------------|
+| **Constant**            | Learning rate remains fixed throughout training.                            |
+| **Linear**              | Learning rate decreases linearly from the base LR to the minimum LR.        |
+| **Cosine**              | Learning rate follows a cosine decay curve from base LR to minimum LR.      |
+| **Inverse Square Root** | Learning rate decays proportionally to the inverse square root of the step. |
 
-### Linear
-Learning rate decreases linearly from the base LR to minimum LR over the decay period.
 
-### Cosine
-Learning rate follows a cosine decay curve from base LR to minimum LR.
+## WSD (Warmup-Stable-Decay)
 
-### Inverse Square Root
-Learning rate decays proportionally to the inverse square root of the step number.
+The WSD schedule divides learning rate progression into three distinct phases, offering fine-grained control over early ramp-up, mid-training stability, and final decay:
 
-### WSD (Warmup-Stable-Decay)
-Three-phase schedule:
-1. **Warmup**: Linear increase to base LR
-2. **Stable**: Constant at base LR  
-3. **Decay**: Decay using specified style to minimum LR
+| Phase     | Description                                              |
+|-----------|----------------------------------------------------------|
+| **Warmup** | Learning rate increases linearly from initial value to base LR. |
+| **Stable** | Learning rate remains constant at base LR.              |
+| **Decay**  | Learning rate decays to minimum LR using a specified style (e.g., exponential, linear, cosine). |
+
 
 ## Weight Decay Scheduling
+These scheduling options control how the weight decay coefficient changes over time, allowing for regularization strategies that adapt to different training phases:
 
-Weight decay can be scheduled to change over training:
+| Schedule Type | Description                                                                 |
+|---------------|-----------------------------------------------------------------------------|
+| **Constant**  | Fixed weight decay throughout training.                                     |
+| **Linear**    | Linear progression from start to end weight decay.                          |
+| **Cosine**    | Cosine progression from start to end weight decay.                          |
 
-- **Constant**: Fixed weight decay throughout training
-- **Linear**: Linear progression from start to end weight decay
-- **Cosine**: Cosine progression from start to end weight decay

--- a/docs/training/optimizer-scheduler-config.md
+++ b/docs/training/optimizer-scheduler-config.md
@@ -1,0 +1,98 @@
+# Optimizer & Scheduler Configuration
+
+The optimizer and scheduler configurations control optimization algorithms, learning rate schedules, and weight decay strategies.
+
+## OptimizerConfig (from Megatron Core)
+
+The `OptimizerConfig` contains all parameters for the optimization algorithm and comes directly from Megatron Core. Key parameters include:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `optimizer` | `str` | Optimizer type ("adam", "sgd", etc.) |
+| `lr` | `float` | Base learning rate |
+| `min_lr` | `float` | Minimum learning rate for decay schedules |
+| `weight_decay` | `float` | L2 regularization coefficient |
+| `adam_beta1` | `float` | Adam optimizer beta1 parameter |
+| `adam_beta2` | `float` | Adam optimizer beta2 parameter |
+| `adam_eps` | `float` | Adam optimizer epsilon parameter |
+| `clip_grad` | `float` | Gradient clipping threshold |
+| `use_distributed_optimizer` | `bool` | Enable distributed optimizer for memory efficiency |
+| `overlap_grad_reduce` | `bool` | Overlap gradient reduction with computation |
+| `overlap_param_gather` | `bool` | Overlap parameter gathering with computation |
+| `bf16` | `bool` | Use BF16 precision for training |
+| `fp16` | `bool` | Use FP16 precision for training |
+
+## SchedulerConfig
+
+The `SchedulerConfig` controls learning rate scheduling and weight decay progression throughout training.
+
+### Learning Rate Scheduling
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `lr_decay_style` | `Literal["constant", "linear", "cosine", "inverse-square-root", "WSD"]` | `"linear"` | Learning rate decay function |
+| `lr_decay_iters` | `Optional[int]` | `None` | Iterations to decay LR over (defaults to `train_iters`) |
+| `lr_warmup_iters` | `int` | `0` | Iterations to linearly warmup learning rate |
+| `lr_warmup_fraction` | `Optional[float]` | `None` | Fraction of decay iterations to use for warmup |
+| `lr_warmup_init` | `float` | `0.0` | Initial learning rate for warmup phase |
+
+### WSD (Warmup-Stable-Decay) Scheduling
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `lr_wsd_decay_style` | `Literal["exponential", "linear", "cosine"]` | `"exponential"` | Decay style for WSD annealing phase |
+| `lr_wsd_decay_iters` | `Optional[int]` | `None` | Iterations for WSD annealing phase |
+
+### Weight Decay Scheduling
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `start_weight_decay` | `Optional[float]` | `None` | Initial weight decay coefficient |
+| `end_weight_decay` | `Optional[float]` | `None` | Final weight decay coefficient |
+| `weight_decay_incr_style` | `Literal["constant", "linear", "cosine"]` | `"constant"` | Weight decay progression style |
+
+### Checkpoint Integration
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `override_opt_param_scheduler` | `bool` | `False` | Reset scheduler values from config, ignoring checkpoint |
+| `use_checkpoint_opt_param_scheduler` | `bool` | `False` | Use scheduler values from checkpoint, ignoring config |
+
+### Computed Fields
+
+These fields are automatically calculated during configuration validation:
+
+| Field | Description |
+|-------|-------------|
+| `lr_warmup_steps` | Total steps for warmup (calculated from iterations and batch size) |
+| `lr_decay_steps` | Total steps for decay (calculated from iterations and batch size) |
+| `wd_incr_steps` | Total steps for weight decay progression |
+| `wsd_decay_steps` | Total steps for WSD annealing phase |
+
+## Learning Rate Schedules
+
+### Constant
+Learning rate remains fixed throughout training.
+
+### Linear
+Learning rate decreases linearly from the base LR to minimum LR over the decay period.
+
+### Cosine
+Learning rate follows a cosine decay curve from base LR to minimum LR.
+
+### Inverse Square Root
+Learning rate decays proportionally to the inverse square root of the step number.
+
+### WSD (Warmup-Stable-Decay)
+Three-phase schedule:
+1. **Warmup**: Linear increase to base LR
+2. **Stable**: Constant at base LR  
+3. **Decay**: Decay using specified style to minimum LR
+
+## Weight Decay Scheduling
+
+Weight decay can be scheduled to change over training:
+
+- **Constant**: Fixed weight decay throughout training
+- **Linear**: Linear progression from start to end weight decay
+- **Cosine**: Cosine progression from start to end weight decay

--- a/docs/training/optimizer-scheduler-config.md
+++ b/docs/training/optimizer-scheduler-config.md
@@ -28,6 +28,7 @@ The `SchedulerConfig` controls learning rate scheduling and weight decay progres
 
 ### Learning Rate Scheduling
 Parameters for controlling the learning rate schedule, including decay strategy, warmup behavior, and iteration-based adjustments:
+Parameters for controlling the learning rate schedule, including decay strategy, warmup behavior, and iteration-based adjustments:
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
@@ -38,6 +39,7 @@ Parameters for controlling the learning rate schedule, including decay strategy,
 | `lr_warmup_init` | `float` | `0.0` | Initial learning rate for warmup phase |
 
 ### WSD (Warmup-Stable-Decay) Scheduling
+Parameters for configuring the annealing phase of the WSD schedule, including decay style and iteration count:
 Parameters for configuring the annealing phase of the WSD schedule, including decay style and iteration count:
 
 | Parameter | Type | Default | Description |

--- a/docs/training/peft-config.md
+++ b/docs/training/peft-config.md
@@ -45,7 +45,6 @@ config = ConfigContainer(
 
 ## Supported PEFT Methods
 Megatron Bridge supports two efficient fine-tuning techniques—LoRA and DoRA—that adapt large language models with minimal overhead. These methods update only a small set of parameters, preserving the original weights and avoiding changes to model architecture or inference speed. Below is a quick guide to configuring and applying them.
-Megatron Bridge supports two efficient fine-tuning techniques—LoRA and DoRA—that adapt large language models with minimal overhead. These methods update only a small set of parameters, preserving the original weights and avoiding changes to model architecture or inference speed. Below is a quick guide to configuring and applying them.
 
 ### [LoRA: Low-Rank Adaptation of Large Language Models](https://arxiv.org/abs/2106.09685)
 
@@ -140,7 +139,6 @@ The following table lists key hyperparameters for configuring DoRA, which contro
 
 ## Full Configuration Example
 The following example demonstrates a complete setup for PEFT fine-tuning using LoRA within the Megatron framework.
-The following example demonstrates a complete setup for PEFT fine-tuning using LoRA within the Megatron framework.
 
 ```python
 from megatron.bridge.training.config import (
@@ -196,7 +194,6 @@ config = ConfigContainer(
 
 This section describes the internal design and architecture for how PEFT is integrated into Megatron Bridge.
 
-### Architecture Overview
 ### Architecture Overview
 
 The PEFT framework introduces a modular design for integrating adapters into large-scale models. Its architecture consists of the following components:

--- a/docs/training/peft-config.md
+++ b/docs/training/peft-config.md
@@ -1,0 +1,192 @@
+# Parameter-Efficient Fine-Tuning (PEFT)
+
+Customizing models enables you to adapt a general pre-trained models to a specific use case or domain. This process results in a fine-tuned model that benefits from the extensive pretraining data, while also yielding more accurate outputs for the specific downstream task. Model customization is achieved through supervised fine-tuning and falls into two popular categories:
+
+- Full-Parameter Fine-Tuning, which is referred to as Supervised Fine-Tuning (SFT)
+
+- Parameter-Efficient Fine-Tuning (PEFT)
+
+In SFT, all of the model parameters are updated to produce outputs that are adapted to the task.
+
+PEFT, on the other hand, tunes a much smaller number of parameters which are inserted into the base model at strategic locations. When fine-tuning with PEFT, the base model weights remain frozen, and only the adapter modules are trained. As a result, the number of trainable parameters is significantly reduced, often to less than 1%.
+
+While SFT often yields the best possible results, PEFT methods can often achieve nearly the same degree of accuracy, while significantly reducing the computational cost. As language models continue to grow in size, PEFT is gaining popularity due to its lightweight requirements on training hardware.
+
+
+## Configuration
+
+PEFT is configured as an optional attribute in `ConfigContainer`:
+
+```python
+from megatron.bridge.training.config import ConfigContainer
+from megatron.bridge.peft.lora import LoRA
+
+config = ConfigContainer(
+    # ... other required configurations
+    peft=LoRA(
+        target_modules=["linear_qkv", "linear_proj", "linear_fc1", "linear_fc2"],
+        dim=16,
+        alpha=32,
+        dropout=0.1,
+    ),
+    checkpoint=CheckpointConfig(
+        pretrained_checkpoint="/path/to/pretrained/checkpoint",  # Required for PEFT
+        save="/path/to/peft/checkpoints",
+    ),
+)
+```
+
+```{note}
+**Requirements**: PEFT requires `checkpoint.pretrained_checkpoint` to be set to load the base model weights.
+```
+
+## Supported PEFT Methods
+
+### [LoRA: Low-Rank Adaptation of Large Language Models](https://arxiv.org/abs/2106.09685)
+
+LoRA makes fine-tuning efficient by representing weight updates with two low rank decomposition matrices. The original model weights remain frozen, while the low-rank decomposition matrices are updated to adapt to the new data, keeping the number of trainable parameters low. In contrast with adapters, the original model weights and adapted weights can be combined during inference, avoiding any architectural change or additional latency in the model at inference time.
+
+In Megatron-Bridge, you can customize the adapter bottleneck dimension and the target modules to apply LoRA. LoRA can be applied to any linear layer. In a transformer model, this includes 1) Q, K, V attention projections, 2) attention output projection layer, and 3) either or both of the two transformer MLP layers. For QKV, Megatron-Bridge's attention implementation fuses QKV into a single projection, so our LoRA implementation learns a single low-rank projection for QKV combined.
+
+```python
+from megatron.bridge.peft.lora import LoRA
+
+lora_config = LoRA(
+    target_modules=["linear_qkv", "linear_proj", "linear_fc1", "linear_fc2"],
+    dim=16,                    # Rank of adaptation
+    alpha=32,                  # Scaling parameter  
+    dropout=0.1,               # Dropout rate
+    network_alpha=None,        # Network alpha for scaling
+)
+```
+
+**Key Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `target_modules` | `List[str]` | All linear layers | Modules to apply LoRA to |
+| `dim` | `int` | `32` | Rank of the low-rank adaptation |
+| `alpha` | `float` | `16` | Scaling parameter for LoRA |
+| `dropout` | `float` | `0.0` | Dropout rate for LoRA layers |
+| `network_alpha` | `Optional[float]` | `None` | Network-wide alpha scaling |
+
+**Target Modules:**
+- `linear_qkv`: Query, key, value projections in attention
+- `linear_proj`: Attention output projection  
+- `linear_fc1`: First MLP layer
+- `linear_fc2`: Second MLP layer
+
+### Wildcard Target Modules
+For more granular targeting, individual layers can be targeted for the adapters.
+```python
+# Target specific layers only
+lora_config = LoRA(
+    target_modules=[
+        "*.layers.0.*.linear_qkv",   # First layer only
+        "*.layers.1.*.linear_qkv",   # Second layer only
+    ]
+)
+```
+
+### [DoRA: Weight-Decomposed Low-Rank Adaptation](https://arxiv.org/abs/2402.09353)
+
+DoRA decomposes the pre-trained weight into magnitude and direction. It learns a separate magnitude parameter while employing LoRA for directional updates, efficiently minimizing the number of trainable parameters. DoRA enhances both the learning capacity and training stability of LoRA while avoiding any additional inference overhead. DoRA has been shown to consistently outperform LoRA on various downstream tasks.
+
+In Megatron-Bridge, DoRA leverages the same adapter structure as LoRA. Megatron-Bridge adds support for Tensor Parallelism and Pipeline Parallelism for DoRA, enabling DoRA to be scaled to larger model variants.
+
+```python
+from megatron.bridge.peft.dora import DoRA
+
+dora_config = DoRA(
+    target_modules=["linear_qkv", "linear_proj", "linear_fc1", "linear_fc2"],
+    dim=16,                    # Rank of adaptation
+    alpha=32,                  # Scaling parameter
+    dropout=0.1,               # Dropout rate
+)
+```
+
+**Key Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `target_modules` | `List[str]` | All linear layers | Modules to apply DoRA to |
+| `dim` | `int` | `32` | Rank of the low-rank adaptation |
+| `alpha` | `float` | `16` | Scaling parameter for DoRA |
+| `dropout` | `float` | `0.0` | Dropout rate for DoRA layers |
+
+## Full Configuration Example
+
+```python
+from megatron.bridge.training.config import (
+    ConfigContainer, TrainingConfig, CheckpointConfig
+)
+from megatron.bridge.data.builders.hf_dataset import HFDatasetConfig
+from megatron.bridge.data.hf_processors.squad import process_squad_example
+from megatron.bridge.peft.lora import LoRA
+from megatron.core.optimizer import OptimizerConfig
+
+# Configure PEFT fine-tuning
+config = ConfigContainer(
+    model=model_provider,
+    train=TrainingConfig(
+        train_iters=1000,
+        global_batch_size=64,
+        micro_batch_size=1,  # Required for packed sequences if used
+        eval_interval=100,
+    ),
+    optimizer=OptimizerConfig(
+        optimizer="adam",
+        lr=1e-4,  # Lower learning rate for fine-tuning
+        weight_decay=0.01,
+        bf16=True,
+        use_distributed_optimizer=True,
+    ),
+    scheduler=SchedulerConfig(
+        lr_decay_style="cosine",
+        lr_warmup_iters=100,
+        lr_decay_iters=1000,
+    ),
+    dataset=HFDatasetConfig(
+        dataset_name="squad",
+        process_example_fn=process_squad_example,
+        seq_length=512,
+    ),
+    checkpoint=CheckpointConfig(
+        pretrained_checkpoint="/path/to/pretrained/model",  # Required
+        save="/path/to/peft/checkpoints",
+        save_interval=200,
+    ),
+    peft=LoRA(
+        target_modules=["linear_qkv", "linear_proj", "linear_fc1", "linear_fc2"],
+        dim=16,
+        alpha=32,
+        dropout=0.1,
+    ),
+    # ... other configurations
+)
+```
+
+## PEFT Design in Megatron-Bridge
+
+This section describes the internal design and architecture for how PEFT is integrated into Megatron-Bridge.
+
+### Architecture Overview
+
+1. **Base PEFT Class**: All PEFT methods inherit from the abstract `PEFT` base class, which defines the core transformation interface.
+2. **Module Transformation**: PEFT methods transform individual modules by walking through the model structure.
+3. **Adapter Integration**: Adapters are injected into target modules using a pre-wrap hook during model initialization.
+4. **Checkpoint Integration**: Only adapter parameters are saved/loaded, while base model weights remain frozen.
+
+### PEFT Workflow in Training
+
+1. **Model Loading**: The Base model is loaded from the specified pretrained checkpoint during setup.
+2. **PEFT Application**: The PEFT transformation is applied after the Megatron Core model initialization but before distributed wrapping.
+3. **Parameter Freezing**: Base model parameters are frozen, only adapter parameters remain trainable.
+4. **Adapter Weight Loading**: If resuming training, adapter weights are restored from the checkpoint.
+5. **Checkpoint Saving**: Only adapter states are saved, significantly reducing checkpoint size.
+
+### Key Benefits
+
+- **Reduced Checkpoint Size**: Checkpoints are orders of magnitude smaller than full model checkpoints.
+- **Memory Efficiency**: Base model weights don't require gradients, only adapters do.
+- **Resume Support**: Can resume PEFT training from adapter-only checkpoints.

--- a/docs/training/peft-config.md
+++ b/docs/training/peft-config.md
@@ -45,6 +45,7 @@ config = ConfigContainer(
 
 ## Supported PEFT Methods
 Megatron Bridge supports two efficient fine-tuning techniques—LoRA and DoRA—that adapt large language models with minimal overhead. These methods update only a small set of parameters, preserving the original weights and avoiding changes to model architecture or inference speed. Below is a quick guide to configuring and applying them.
+Megatron Bridge supports two efficient fine-tuning techniques—LoRA and DoRA—that adapt large language models with minimal overhead. These methods update only a small set of parameters, preserving the original weights and avoiding changes to model architecture or inference speed. Below is a quick guide to configuring and applying them.
 
 ### [LoRA: Low-Rank Adaptation of Large Language Models](https://arxiv.org/abs/2106.09685)
 
@@ -138,6 +139,7 @@ The following table lists key hyperparameters for configuring DoRA, which contro
 | `dropout` | `float` | `0.0` | Dropout rate for DoRA layers |
 
 ## Full Configuration Example
+The following example demonstrates a complete setup for PEFT fine-tuning using LoRA within the Megatron framework.
 The following example demonstrates a complete setup for PEFT fine-tuning using LoRA within the Megatron framework.
 
 ```python

--- a/docs/training/resiliency.md
+++ b/docs/training/resiliency.md
@@ -2,7 +2,7 @@
 
 Megatron Bridge incorporates resilient training features from the [NVIDIA Resiliency Extension](https://github.com/NVIDIA/nvidia-resiliency-ext). This extension provides fault-tolerant capabilities that help minimize downtime due to failures and interruptions during training.
 
-## Fault Tolerance
+## Fault Tolerance: In Job Restart
 
 The fault tolerance feature can detect hangs during training and automatically restart a workload due to a hang or error. This is particularly useful when training on unreliable hardware, at very large scale, or when transient faults are common.
 
@@ -27,9 +27,9 @@ Before using fault tolerance features, ensure the following:
 
 Megatron Bridge provides two ways to enable fault tolerance:
 
-#### Option 1: NeMo Run Plugin (Recommended)
+#### Option 1: NeMo Run Plugin
 
-If you're using NeMo Run, the `FaultTolerancePlugin` provides the simplest integration:
+If you're using NeMo Run, the {py:class}`bridge.recipes.run_plugins.FaultTolerancePlugin` provides the simplest integration:
 
 ```python
 from megatron.bridge.recipes.run_plugins import FaultTolerancePlugin
@@ -54,9 +54,9 @@ run_plugins = [
 run.run(task, plugins=run_plugins, executor=executor)
 ```
 
-#### Option 2: Direct Configuration (Advanced)
+#### Option 2: Direct Configuration
 
-If you’re an advanced user and want more control, you can configure fault tolerance manually:
+If you’re a user who wants more direct control, you can configure fault tolerance manually:
 
 ```python
 from megatron.bridge.training.config import FaultToleranceConfig
@@ -84,7 +84,7 @@ ft_launcher \
 
 ### Configuration Options
 
-The fault tolerance system can be configured through `FaultToleranceConfig`:
+The fault tolerance system can be configured through {py:class}`bridge.training.config.FaultToleranceConfig`:
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
@@ -97,7 +97,7 @@ The fault tolerance system can be configured through `FaultToleranceConfig`:
 
 ### Plugin Configuration Options
 
-When using the `FaultTolerancePlugin`, additional options are available:
+When using the {py:class}`bridge.recipes.run_plugins.FaultTolerancePlugin`, additional options are available:
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
@@ -163,7 +163,7 @@ The straggler detection feature identifies slow-performing ranks and can optiona
 
 ### Configuration
 
-Enable straggler detection through the `NVRxStragglerDetectionConfig`:
+Enable straggler detection through the {py:class}`bridge.training.config.NVRxStragglerDetectionConfig`:
 
 ```python
 from megatron.bridge.training.config import NVRxStragglerDetectionConfig
@@ -275,7 +275,7 @@ The straggler detection system:
 
 The straggler detection integrates directly with the training loop:
 
-- Automatically initializes when `NVRxStragglerDetectionManager` is configured.
+- Automatically initializes when {py:class}`bridge.training.resiliency.NVRxStragglerDetectionManager` is configured.
 - Monitors training steps without affecting the training logic.
 - Provides exit conditions that the training loop respects.
 - Safely shuts down when training completes.
@@ -301,7 +301,7 @@ Megatron Bridge provides two ways to enable preemption handling:
 
 > **Warning**: This plugin is currently only supported on Slurm-based clusters.
 
-If you're using NeMo Run, the `PreemptionPlugin` provides the simplest integration:
+If you're using NeMo Run, the {py:class}`bridge.recipes.run_plugins.PreemptionPlugin` provides the simplest integration:
 
 ```python
 from megatron.bridge.recipes.run_plugins import PreemptionPlugin
@@ -378,7 +378,7 @@ The system will:
 
 The preemption system operates through several components:
 
-1. **Signal Handler Installation**: Sets up a distributed signal handler using `DistributedSignalHandler`.
+1. **Signal Handler Installation**: Sets up a distributed signal handler using {py:class}`bridge.training.resiliency.DistributedSignalHandler`.
 2. **Signal Detection**: Checks for received signals at the end of each training step.
 3. **Distributed Coordination**: Uses all-gather to ensure all ranks are aware of the signal.
 4. **Checkpoint Saving**: Automatically saves a checkpoint before exiting.
@@ -431,7 +431,7 @@ The re-run state machine operates through several stages:
 
 ### Configuration
 
-Configure the re-run state machine through `RerunStateMachineConfig`:
+Configure the re-run state machine through {py:class}`bridge.training.config.RerunStateMachineConfig`:
 
 ```python
 from megatron.bridge.training.config import RerunStateMachineConfig

--- a/docs/training/resiliency.md
+++ b/docs/training/resiliency.md
@@ -1,6 +1,6 @@
 # Resiliency
 
-Megatron-Bridge incorporates resilient training features from the [NVIDIA Resiliency Extension](https://github.com/NVIDIA/nvidia-resiliency-ext). This extension provides fault-tolerant capabilities that help minimize downtime due to failures and interruptions during training.
+Megatron Bridge incorporates resilient training features from the [NVIDIA Resiliency Extension](https://github.com/NVIDIA/nvidia-resiliency-ext). This extension provides fault-tolerant capabilities that help minimize downtime due to failures and interruptions during training.
 
 ## Fault Tolerance
 
@@ -8,11 +8,11 @@ The fault tolerance feature can detect hangs during training and automatically r
 
 ### Key Features
 
-- **Hang Detection**: Monitors training progress and detects when ranks become unresponsive
-- **Automatic Restart**: Automatically restarts training from the last checkpoint when faults are detected
-- **Section-based Monitoring**: Uses different timeout thresholds for setup, training steps, and checkpointing operations
-- **Timeout Calculation**: Can automatically calculate optimal timeouts based on observed training behavior
-- **Multi-level Restart Logic**: Supports both in-job restarts and new job launches on failure
+- **Hang Detection**: Monitors training progress and detects when ranks become unresponsive.
+- **Automatic Restart**: Automatically restarts training from the last checkpoint when faults are detected.
+- **Section-based Monitoring**: Uses different timeout thresholds for setup, training steps, and checkpointing operations.
+- **Timeout Calculation**: Can automatically calculate optimal timeouts based on observed training behavior.
+- **Multi-level Restart Logic**: Supports both in-job restarts and new job launches on failure.
 
 ### Prerequisites
 
@@ -20,16 +20,16 @@ The fault tolerance feature can detect hangs during training and automatically r
 
 Before using fault tolerance features, ensure the following:
 
-1. **Slurm Environment**: Run on a Slurm-based cluster
-2. **Checkpoint Configuration**: A valid checkpoint save directory must be configured
+1. **Slurm Environment**: The system must be running on a Slurm-based cluster.
+2. **Checkpoint Configuration**: A valid directory for saving checkpoints must be properly configured.
 
 ### Usage Options
 
-Megatron-Bridge provides two ways to enable fault tolerance:
+Megatron Bridge provides two ways to enable fault tolerance:
 
-#### Option 1: NeMo-Run Plugin (Recommended)
+#### Option 1: NeMo Run Plugin (Recommended)
 
-For users using NeMo-Run, the `FaultTolerancePlugin` provides the simplest integration:
+If you're using NeMo Run, the `FaultTolerancePlugin` provides the simplest integration:
 
 ```python
 from megatron.bridge.recipes.run_plugins import FaultTolerancePlugin
@@ -56,7 +56,7 @@ run.run(task, plugins=run_plugins, executor=executor)
 
 #### Option 2: Direct Configuration (Advanced)
 
-For advanced users who need more control, configure fault tolerance directly:
+If you’re an advanced user and want more control, you can configure fault tolerance manually:
 
 ```python
 from megatron.bridge.training.config import FaultToleranceConfig
@@ -121,33 +121,33 @@ The system will then automatically restart training from the most recent checkpo
 
 ### How It Works
 
-The fault tolerance system integrates with Megatron-Bridge's training pipeline through several key points:
+The fault tolerance system integrates with Megatron Bridge's training pipeline through several key points:
 
-1. **Setup Phase**: Initializes fault tolerance monitoring before training begins
-2. **Training Steps**: Wraps each training iteration with timeout monitoring
-3. **Evaluation Steps**: Monitors evaluation iterations separately
-4. **Checkpointing**: Tracks checkpoint saving operations with dedicated timeouts
-5. **State Persistence**: Saves timeout calculations to `ft_state.json` for future runs
+1. **Setup Phase**: Initializes fault tolerance monitoring before training begins.
+2. **Training Steps**: Wraps each training iteration with timeout monitoring.
+3. **Evaluation Steps**: Monitors evaluation iterations separately.
+4. **Checkpointing**: Tracks checkpoint saving operations with dedicated timeouts.
+5. **State Persistence**: Saves timeout calculations to `ft_state.json` for future runs.
 
 The system uses a section-based approach with different timeout thresholds:
-- **Setup Section**: Covers initialization and checkpoint loading
-- **Step Section**: Monitors individual training/evaluation iterations
-- **Checkpointing Section**: Tracks checkpoint saving operations
-- **Out-of-Section**: Handles time between sections
+- **Setup Section**: Covers initialization and checkpoint loading.
+- **Step Section**: Monitors individual training/evaluation iterations.
+- **Checkpointing Section**: Tracks checkpoint saving operations.
+- **Out-of-Section**: Handles time between sections.
 
 ### Best Practices
 
-1. **Enable Automatic Timeout Calculation**: Set `calc_ft_timeouts=True` to let the system learn optimal timeouts from your workload
-2. **Conservative Restart Limits**: Use reasonable limits for `num_in_job_restarts` and `num_job_retries_on_failure` to avoid infinite restart loops
-3. **Monitor Logs**: Watch for fault tolerance messages to understand when and why restarts occur
-4. **Test with Simulation**: Use the fault simulation features to test your fault tolerance setup before production runs
-5. **Checkpoint Frequency**: Ensure regular checkpointing to minimize lost work during restarts
+1. **Enable Automatic Timeout Calculation**: Set `calc_ft_timeouts=True` to let the system learn optimal timeouts from your workload.
+2. **Conservative Restart Limits**: Use reasonable limits for `num_in_job_restarts` and `num_job_retries_on_failure` to avoid infinite restart loops.
+3. **Monitor Logs**: Watch for fault tolerance messages to understand when and why restarts occur.
+4. **Test with Simulation**: Use the fault simulation features to test your fault tolerance setup before production runs.
+5. **Checkpoint Frequency**: Ensure regular checkpointing to minimize lost work during restarts.
 
 ### Limitations
 
-- Currently only supported on Slurm-based clusters
-- Not compatible with NSys profiling (the plugin will automatically disable nsys if enabled)
-- Checkpoint save directory must be configured and accessible
+- Currently only supported on Slurm-based clusters.
+- Not compatible with NSys profiling (the plugin will automatically disable nsys if enabled).
+- Checkpoint save directory must be configured and accessible.
 
 ## Straggler Detection
 
@@ -155,11 +155,11 @@ The straggler detection feature identifies slow-performing ranks and can optiona
 
 ### Key Features
 
-- **Performance Monitoring**: Tracks individual and relative GPU performance scores
-- **Automatic Detection**: Identifies stragglers based on configurable thresholds
-- **Detailed Reporting**: Provides comprehensive performance reports with best/worst performing ranks
-- **Optional Termination**: Can automatically stop training when stragglers are detected
-- **Flexible Configuration**: Supports various reporting intervals and threshold settings
+- **Performance Monitoring**: Tracks individual and relative GPU performance scores.
+- **Automatic Detection**: Identifies stragglers based on configurable thresholds.
+- **Detailed Reporting**: Provides comprehensive performance reports with best/worst performing ranks.
+- **Optional Termination**: Can automatically stop training when stragglers are detected.
+- **Flexible Configuration**: Supports various reporting intervals and threshold settings.
 
 ### Configuration
 
@@ -245,8 +245,8 @@ STRAGGLER DETECTION WARNING: Some GPUs performance dropped. Affected ranks: [162
 
 The system calculates two types of performance scores:
 
-1. **Relative Performance**: Compares each rank's performance relative to other ranks in the same training run
-2. **Individual Performance**: Tracks each rank's performance over time to detect degradation
+1. **Relative Performance**: Compares each rank's performance relative to other ranks in the same training run.
+2. **Individual Performance**: Tracks each rank's performance over time to detect degradation.
 
 Scores range from 0.0 to 1.0, where:
 - **1.0**: Best possible performance
@@ -257,51 +257,51 @@ Scores range from 0.0 to 1.0, where:
 
 The straggler detection system:
 
-1. **Initialization**: Sets up the NVRx detector during training setup
-2. **Monitoring**: Wraps the training step function to monitor execution time
-3. **Periodic Reporting**: Generates performance reports at specified intervals
-4. **Straggler Identification**: Compares performance scores against thresholds
-5. **Action**: Optionally saves a checkpoint and terminates training if stragglers are detected
+1. **Initialization**: Sets up the NVRx detector during training setup.
+2. **Monitoring**: Wraps the training step function to monitor execution time.
+3. **Periodic Reporting**: Generates performance reports at specified intervals.
+4. **Straggler Identification**: Compares performance scores against thresholds.
+5. **Action**: Optionally saves a checkpoint and terminates training if stragglers are detected.
 
 ### Best Practices
 
-1. **Appropriate Intervals**: Set `report_time_interval` based on your training characteristics
-2. **Threshold Tuning**: Adjust thresholds based on your hardware and expected performance variability
-3. **Gradual Rollout**: Start with `stop_if_detected=False` to observe performance patterns before enabling automatic termination
-4. **Monitor Logs**: Regularly check straggler reports to identify persistent hardware issues
-5. **Performance Impact**: The overhead is minimal, but you can adjust `profiling_interval` if needed
+1. **Appropriate Intervals**: Set `report_time_interval` based on your training characteristics.
+2. **Threshold Tuning**: Adjust thresholds based on your hardware and expected performance variability.
+3. **Gradual Rollout**: Start with `stop_if_detected=False` to observe performance patterns before enabling automatic termination.
+4. **Monitor Logs**: Regularly check straggler reports to identify persistent hardware issues.
+5. **Performance Impact**: The overhead is minimal, but you can adjust `profiling_interval` if needed.
 
 ### Integration with Training
 
 The straggler detection integrates directly with the training loop:
 
-- Automatically initializes when `NVRxStragglerDetectionManager` is configured
-- Monitors training steps without affecting the training logic
-- Provides exit conditions that the training loop respects
-- Safely shuts down when training completes
+- Automatically initializes when `NVRxStragglerDetectionManager` is configured.
+- Monitors training steps without affecting the training logic.
+- Provides exit conditions that the training loop respects.
+- Safely shuts down when training completes.
 
 ## Preemption
 
 Training foundation models can take several hours or even days to complete. In some cases, training jobs must be halted preemptively due to cluster time limits, higher priority jobs, or other reasons.
 
-Megatron-Bridge provides functionality to gracefully perform preemptive shutdown of training. This feature listens for user-specified signals and saves a checkpoint before exiting when the signal is received.
+Megatron Bridge provides functionality to gracefully perform preemptive shutdown of training. This feature listens for user-specified signals and saves a checkpoint before exiting when the signal is received.
 
 ### Key Features
 
-- **Signal-based Shutdown**: Listens for signals (default: SIGTERM) during training
-- **Graceful Exit**: Saves checkpoint before terminating to preserve training progress
-- **Distributed Coordination**: Ensures all ranks receive and handle the signal properly
-- **Flexible Configuration**: Supports different signals and timing configurations
+- **Signal-based Shutdown**: Listens for signals (default: SIGTERM) during training.
+- **Graceful Exit**: Saves checkpoint before terminating to preserve training progress.
+- **Distributed Coordination**: Ensures all ranks receive and handle the signal properly.
+- **Flexible Configuration**: Supports different signals and timing configurations.
 
 ### Usage Options
 
-Megatron-Bridge provides two ways to enable preemption handling:
+Megatron Bridge provides two ways to enable preemption handling:
 
-#### Option 1: NeMo-Run Plugin (Recommended)
+#### Option 1: NeMo Run Plugin (Recommended)
 
 > **Warning**: This plugin is currently only supported on Slurm-based clusters.
 
-For users using NeMo-Run, the `PreemptionPlugin` provides the simplest integration:
+If you're using NeMo Run, the `PreemptionPlugin` provides the simplest integration:
 
 ```python
 from megatron.bridge.recipes.run_plugins import PreemptionPlugin
@@ -369,42 +369,42 @@ exiting program after receiving SIGTERM.
 ```
 
 The system will:
-1. **Detect the signal** at the end of the current training step
-2. **Save a checkpoint** to preserve training progress
-3. **Log the shutdown reason** for debugging purposes
-4. **Exit gracefully** with proper cleanup
+1. **Detect the signal** at the end of the current training step.
+2. **Save a checkpoint** to preserve training progress.
+3. **Log the shutdown reason** for debugging purposes.
+4. **Exit gracefully** with proper cleanup.
 
 ### How It Works
 
 The preemption system operates through several components:
 
-1. **Signal Handler Installation**: Sets up a distributed signal handler using `DistributedSignalHandler`
-2. **Signal Detection**: Checks for received signals at the end of each training step
-3. **Distributed Coordination**: Uses all-gather to ensure all ranks are aware of the signal
-4. **Checkpoint Saving**: Automatically saves a checkpoint before exiting
-5. **Graceful Shutdown**: Properly cleans up resources and exits
+1. **Signal Handler Installation**: Sets up a distributed signal handler using `DistributedSignalHandler`.
+2. **Signal Detection**: Checks for received signals at the end of each training step.
+3. **Distributed Coordination**: Uses all-gather to ensure all ranks are aware of the signal.
+4. **Checkpoint Saving**: Automatically saves a checkpoint before exiting.
+5. **Graceful Shutdown**: Properly cleans up resources and exits.
 
 ### Signal Handling Details
 
 The `DistributedSignalHandler` class provides:
-- **Cross-rank coordination**: Ensures all ranks handle the signal consistently
-- **Original handler preservation**: Restores original signal handlers on exit
-- **Flexible signal support**: Can handle different signal types (SIGTERM, SIGINT, etc.)
+- **Cross-rank coordination**: Ensures all ranks handle the signal consistently.
+- **Original handler preservation**: Restores original signal handlers on exit.
+- **Flexible signal support**: Can handle different signal types (SIGTERM, SIGINT, etc.).
 
 ### Integration with Slurm
 
 When using Slurm, the system automatically:
-- **Receives SIGTERM** when approaching job time limits
-- **Coordinates across nodes** to ensure consistent shutdown
-- **Saves progress** before the job is forcibly terminated
+- **Receives SIGTERM** when approaching job time limits.
+- **Coordinates across nodes** to ensure consistent shutdown.
+- **Saves progress** before the job is forcibly terminated.
 
 ### Best Practices
 
-1. **Use Appropriate Timing**: Set `preempt_time` to allow sufficient time for checkpoint saving
-2. **Monitor Logs**: Watch for preemption messages to understand shutdown patterns
-3. **Test Signal Handling**: Verify preemption works correctly in your environment
-4. **Regular Checkpointing**: Ensure regular checkpoint intervals to minimize potential data loss
-5. **Resource Cleanup**: The system handles cleanup automatically, but monitor for any resource leaks
+1. **Use Appropriate Timing**: Set `preempt_time` to allow sufficient time for checkpoint saving.
+2. **Monitor Logs**: Watch for preemption messages to understand shutdown patterns.
+3. **Test Signal Handling**: Verify preemption works correctly in your environment.
+4. **Regular Checkpointing**: Ensure regular checkpoint intervals to minimize potential data loss.
+5. **Resource Cleanup**: The system handles cleanup automatically, but monitor for any resource leaks.
 
 ## Re-run State Machine
 
@@ -414,20 +414,20 @@ The re-run state machine is an experimental feature that helps with attribution 
 
 ### Key Features
 
-- **Automatic Re-run Logic**: Detects unexpected results and automatically re-runs computations to verify reproducibility
-- **Error Attribution**: Classifies issues as transient errors, persistent errors, or correct results
-- **Multi-stage Validation**: Uses in-place re-runs and checkpoint-based re-runs on different hardware
-- **Determinism Tracking**: Can report statistics on computational non-determinism
-- **State Management**: Handles RNG state and data iterator state for reproducible re-runs
+- **Automatic Re-run Logic**: Detects unexpected results and automatically re-runs computations to verify reproducibility.
+- **Error Attribution**: Classifies issues as transient errors, persistent errors, or correct results.
+- **Multi-stage Validation**: Uses in-place re-runs and checkpoint-based re-runs on different hardware.
+- **Determinism Tracking**: Can report statistics on computational non-determinism.
+- **State Management**: Handles RNG state and data iterator state for reproducible re-runs.
 
 ### How It Works
 
 The re-run state machine operates through several stages:
 
-1. **Initial Run**: Executes the training step normally, validating results
-2. **First Re-run (In-place)**: If validation fails, re-runs on the same GPU to check reproducibility
-3. **Second Re-run (Different GPU)**: If the issue is reproducible, saves checkpoint and re-runs on different hardware
-4. **Attribution**: Determines if the issue is a transient error, persistent error, or correct result
+1. **Initial Run**: Executes the training step normally, validating results.
+2. **First Re-run (In-place)**: If validation fails, re-runs on the same GPU to check reproducibility.
+3. **Second Re-run (Different GPU)**: If the issue is reproducible, saves checkpoint and re-runs on different hardware.
+4. **Attribution**: Determines if the issue is a transient error, persistent error, or correct result.
 
 ### Configuration
 
@@ -459,19 +459,19 @@ config.rerun_state_machine = RerunStateMachineConfig(
 ### Operating Modes
 
 #### 1. Disabled Mode (`disabled`)
-- **Purpose**: No result validation or re-run logic
-- **Behavior**: Training proceeds normally without any result checking
-- **Use Case**: When re-run overhead is not acceptable or validation is not needed
+- **Purpose**: No result validation or re-run logic.
+- **Behavior**: Training proceeds normally without any result checking.
+- **Use Case**: When re-run overhead is not acceptable or validation is not needed.
 
 #### 2. Report Stats Mode (`report_stats`)  
-- **Purpose**: Collect statistics on computational determinism
-- **Behavior**: Re-runs every step once to measure variability
-- **Output**: Reports on computational non-determinism without stopping training
+- **Purpose**: Collect statistics on computational determinism.
+- **Behavior**: Re-runs every step once to measure variability.
+- **Output**: Reports on computational non-determinism without stopping training.
 
 #### 3. Validate Results Mode (`validate_results`)
-- **Purpose**: Full validation with re-runs and hardware fault attribution
-- **Behavior**: Re-runs computations when unexpected results are detected
-- **Exit Conditions**: May exit with specific codes for checkpointing or validation failure
+- **Purpose**: Full validation with re-runs and hardware fault attribution.
+- **Behavior**: Re-runs computations when unexpected results are detected.
+- **Exit Conditions**: May exit with specific codes for checkpointing or validation failure.
 
 ### Integration with Training
 
@@ -498,8 +498,8 @@ if should_exit:
 
 The re-run state machine uses specific exit codes to control job behavior:
 
-- **Exit Code 16** (`EXIT_CODE_RESUME_TO_DISAMBIGUATE`): Job should be restarted from checkpoint to re-run on different hardware
-- **Exit Code 17** (`EXIT_CODE_FAILED_ON_RESULT_VALIDATION`): Job failed validation and should not continue
+- **Exit Code 16** (`EXIT_CODE_RESUME_TO_DISAMBIGUATE`): Job should be restarted from checkpoint to re-run on different hardware.
+- **Exit Code 17** (`EXIT_CODE_FAILED_ON_RESULT_VALIDATION`): Job failed validation and should not continue.
 
 ### Expected Behavior
 
@@ -529,13 +529,13 @@ Correct result (but possible Application error)
 
 ### Result Attribution Categories
 
-1. **Transient Error**: Result not reproducible on same GPU - likely temporary hardware glitch
-2. **Persistent Error**: Result reproducible on same GPU but different on other GPU - likely hardware fault
-3. **Correct Result**: Result reproducible across different GPUs - likely correct but unexpected
+1. **Transient Error**: Result not reproducible on same GPU - likely temporary hardware glitch.
+2. **Persistent Error**: Result reproducible on same GPU but different on other GPU - likely hardware fault.
+3. **Correct Result**: Result reproducible across different GPUs - likely correct but unexpected.
 
 ### Data Iterator Integration
 
 The system uses `RerunDataIterator` to handle data replay:
-- **State Saving**: Captures data iterator state for reproducible re-runs
-- **Replay Capability**: Can rewind and replay the same data batches
-- **Checkpoint Support**: Saves/restores iterator state across job restarts
+- **State Saving**: Captures data iterator state for reproducible re-runs.
+- **Replay Capability**: Can rewind and replay the same data batches.
+- **Checkpoint Support**: Saves/restores iterator state across job restarts.

--- a/docs/training/resiliency.md
+++ b/docs/training/resiliency.md
@@ -1,0 +1,407 @@
+# Resiliency
+
+Megatron-Bridge incorporates resilient training features from the [NVIDIA Resiliency Extension](https://github.com/NVIDIA/nvidia-resiliency-ext). This extension provides fault-tolerant capabilities that help minimize downtime due to failures and interruptions during training.
+
+## Fault Tolerance
+
+The fault tolerance feature can detect hangs during training and automatically restart a workload due to a hang or error. This is particularly useful when training on unreliable hardware, at very large scale, or when transient faults are common.
+
+### Key Features
+
+- **Hang Detection**: Monitors training progress and detects when ranks become unresponsive
+- **Automatic Restart**: Automatically restarts training from the last checkpoint when faults are detected
+- **Section-based Monitoring**: Uses different timeout thresholds for setup, training steps, and checkpointing operations
+- **Timeout Calculation**: Can automatically calculate optimal timeouts based on observed training behavior
+- **Multi-level Restart Logic**: Supports both in-job restarts and new job launches on failure
+
+### Prerequisites
+
+> **Warning**: This feature is currently only supported on Slurm-based clusters.
+
+Before using fault tolerance features, ensure the following:
+
+1. **Slurm Environment**: Run on a Slurm-based cluster
+2. **Checkpoint Configuration**: A valid checkpoint save directory must be configured
+
+### Usage Options
+
+Megatron-Bridge provides two ways to enable fault tolerance:
+
+#### Option 1: NeMo-Run Plugin (Recommended)
+
+For users using NeMo-Run, the `FaultTolerancePlugin` provides the simplest integration:
+
+```python
+from megatron.bridge.recipes.run_plugins import FaultTolerancePlugin
+import nemo_run as run
+
+# Configure your task
+task = run.Script(...)
+
+# Add fault tolerance plugin
+run_plugins = [
+    FaultTolerancePlugin(
+        enable_ft_package=True,
+        calc_ft_timeouts=True,
+        num_in_job_restarts=3,
+        num_job_retries_on_failure=2,
+        initial_rank_heartbeat_timeout=1800,
+        rank_heartbeat_timeout=300,
+    )
+]
+
+# Run with fault tolerance
+run.run(task, plugins=run_plugins, executor=executor)
+```
+
+#### Option 2: Direct Configuration (Advanced)
+
+For advanced users who need more control, configure fault tolerance directly:
+
+```python
+from megatron.bridge.training.config import FaultToleranceConfig
+
+# Configure fault tolerance in your config
+config.ft = FaultToleranceConfig(
+    enable_ft_package=True,
+    calc_ft_timeouts=True,
+    # Optional: simulate faults for testing
+    simulate_fault=False,
+    simulated_fault_type="random",
+)
+```
+
+When directly using the configuration, you must launch your training script using the `ft_launcher` tool:
+
+```bash
+ft_launcher \
+    --rdzv_backend=c10d --rdzv_endpoint=${MASTER_ADDR}:${MASTER_PORT} \
+    --nnodes=${NUM_NODES} --nproc-per-node=${NUM_GPUS_PER_NODE} \
+    --ft-param-rank_section_timeouts=setup:600,step:180,checkpointing:420 \
+    --ft-param-rank_out_of_section_timeout=300 \
+    your_training_script.py
+```
+
+### Configuration Options
+
+The fault tolerance system can be configured through `FaultToleranceConfig`:
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `enable_ft_package` | `bool` | `False` | Enable the fault tolerance package |
+| `calc_ft_timeouts` | `bool` | `False` | Automatically compute optimal timeouts |
+| `simulate_fault` | `bool` | `False` | Enable fault simulation for testing |
+| `simulated_fault_type` | `str` | `"random"` | Type of fault to simulate: `"rank_hung"`, `"rank_killed"`, or `"random"` |
+| `simulated_fault_rank` | `int` | `None` | Specific rank to simulate fault on (random if not specified) |
+| `simulated_fault_base_delay` | `int` | `0` | Base delay before simulating fault |
+
+### Plugin Configuration Options
+
+When using the `FaultTolerancePlugin`, additional options are available:
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `num_in_job_restarts` | `int` | `3` | Maximum number of restarts within the same job |
+| `num_job_retries_on_failure` | `int` | `2` | Maximum number of new job launches on failure |
+| `initial_rank_heartbeat_timeout` | `int` | `1800` | Timeout for initial heartbeat (seconds) |
+| `rank_heartbeat_timeout` | `int` | `300` | Timeout for subsequent heartbeats (seconds) |
+
+### What to Expect
+
+When fault tolerance is enabled and a hang or fault is detected, you should see log messages similar to:
+
+```
+[WARNING] [RankMonitorServer:34] Did not get subsequent heartbeat. Waited 171.92 seconds.
+[WARNING] [RankMonitorServer:58] Did not get subsequent heartbeat. Waited 171.92 seconds.
+FT: Simulating fault: rank_killed; rank to fail: 2
+torch.distributed.elastic.multiprocessing.api: [WARNING] Sending process 453152 closing signal SIGTERM
+```
+
+The system will then automatically restart training from the most recent checkpoint.
+
+### How It Works
+
+The fault tolerance system integrates with Megatron-Bridge's training pipeline through several key points:
+
+1. **Setup Phase**: Initializes fault tolerance monitoring before training begins
+2. **Training Steps**: Wraps each training iteration with timeout monitoring
+3. **Evaluation Steps**: Monitors evaluation iterations separately
+4. **Checkpointing**: Tracks checkpoint saving operations with dedicated timeouts
+5. **State Persistence**: Saves timeout calculations to `ft_state.json` for future runs
+
+The system uses a section-based approach with different timeout thresholds:
+- **Setup Section**: Covers initialization and checkpoint loading
+- **Step Section**: Monitors individual training/evaluation iterations
+- **Checkpointing Section**: Tracks checkpoint saving operations
+- **Out-of-Section**: Handles time between sections
+
+### Best Practices
+
+1. **Enable Automatic Timeout Calculation**: Set `calc_ft_timeouts=True` to let the system learn optimal timeouts from your workload
+2. **Conservative Restart Limits**: Use reasonable limits for `num_in_job_restarts` and `num_job_retries_on_failure` to avoid infinite restart loops
+3. **Monitor Logs**: Watch for fault tolerance messages to understand when and why restarts occur
+4. **Test with Simulation**: Use the fault simulation features to test your fault tolerance setup before production runs
+5. **Checkpoint Frequency**: Ensure regular checkpointing to minimize lost work during restarts
+
+### Limitations
+
+- Currently only supported on Slurm-based clusters
+- Not compatible with NSys profiling (the plugin will automatically disable nsys if enabled)
+- Checkpoint save directory must be configured and accessible
+
+## Straggler Detection
+
+The straggler detection feature identifies slow-performing ranks and can optionally terminate training if performance falls below specified thresholds. This helps ensure efficient training by detecting and mitigating the impact of underperforming nodes.
+
+### Key Features
+
+- **Performance Monitoring**: Tracks individual and relative GPU performance scores
+- **Automatic Detection**: Identifies stragglers based on configurable thresholds
+- **Detailed Reporting**: Provides comprehensive performance reports with best/worst performing ranks
+- **Optional Termination**: Can automatically stop training when stragglers are detected
+- **Flexible Configuration**: Supports various reporting intervals and threshold settings
+
+### Configuration
+
+Enable straggler detection through the `NVRxStragglerDetectionConfig`:
+
+```python
+from megatron.bridge.training.config import NVRxStragglerDetectionConfig
+
+# Configure straggler detection in your config
+config.nvrx_straggler = NVRxStragglerDetectionConfig(
+    enabled=True,
+    report_time_interval=300.0,  # Report every 5 minutes
+    calc_relative_gpu_perf=True,
+    calc_individual_gpu_perf=True,
+    num_gpu_perf_scores_to_print=5,
+    gpu_relative_perf_threshold=0.7,
+    gpu_individual_perf_threshold=0.7,
+    stop_if_detected=False,  # Set to True to stop training on detection
+    enable_logging=True,
+)
+```
+
+### Configuration Options
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `enabled` | `bool` | `False` | Enable NVRx straggler detection |
+| `report_time_interval` | `float` | `300.0` | Interval in seconds between straggler checks |
+| `calc_relative_gpu_perf` | `bool` | `True` | Calculate relative GPU performance scores |
+| `calc_individual_gpu_perf` | `bool` | `True` | Calculate individual GPU performance scores |
+| `num_gpu_perf_scores_to_print` | `int` | `5` | Number of best/worst scores to print (0 disables periodic printing) |
+| `gpu_relative_perf_threshold` | `float` | `0.7` | Threshold for relative performance (0.0-1.0) |
+| `gpu_individual_perf_threshold` | `float` | `0.7` | Threshold for individual performance (0.0-1.0) |
+| `stop_if_detected` | `bool` | `False` | Terminate training if stragglers are detected (saves checkpoint before exiting) |
+| `enable_logging` | `bool` | `True` | Log GPU performance scores as structured data |
+| `profiling_interval` | `int` | `1` | Profiling interval for the detector |
+| `logger_name` | `str` | `"megatron.bridge.NVRxStragglerDetection"` | Logger name for messages |
+
+### Expected Output
+
+When straggler detection is enabled, you'll see performance reports in the training logs similar to:
+
+```
+GPU relative performance:
+ Worst performing 5/512 ranks:
+  Rank=76 Node=h100-001-253-012 Score=0.94
+  Rank=13 Node=h100-001-010-003 Score=0.94
+  Rank=45 Node=h100-001-172-026 Score=0.94
+  Rank=433 Node=h100-004-141-026 Score=0.95
+  Rank=308 Node=h100-003-263-012 Score=0.95
+ Best performing 5/512 ranks:
+  Rank=432 Node=h100-004-141-026 Score=0.99
+  Rank=376 Node=h100-004-005-003 Score=0.98
+  Rank=487 Node=h100-004-255-026 Score=0.98
+  Rank=369 Node=h100-004-004-033 Score=0.98
+  Rank=361 Node=h100-004-004-023 Score=0.98
+
+GPU individual performance:
+ Worst performing 5/512 ranks:
+  Rank=76 Node=h100-001-253-012 Score=0.98
+  Rank=162 Node=h100-002-042-026 Score=0.98
+  Rank=79 Node=h100-001-253-012 Score=0.98
+  Rank=357 Node=h100-004-004-013 Score=0.98
+  Rank=85 Node=h100-001-253-026 Score=0.98
+ Best performing 5/512 ranks:
+  Rank=297 Node=h100-003-095-026 Score=1.00
+  Rank=123 Node=h100-001-273-026 Score=1.00
+  Rank=21 Node=h100-001-010-013 Score=1.00
+  Rank=389 Node=h100-004-074-012 Score=1.00
+  Rank=489 Node=h100-004-269-026 Score=1.00
+
+ Straggler report processing time: 0.042 sec.
+```
+
+If stragglers are detected and thresholds are exceeded, you'll see warnings like:
+
+```
+STRAGGLER DETECTION WARNING: Some GPUs have worse relative performance. Affected ranks: [76, 13, 45]
+STRAGGLER DETECTION WARNING: Some GPUs performance dropped. Affected ranks: [162, 79, 357]
+```
+
+### Performance Scores
+
+The system calculates two types of performance scores:
+
+1. **Relative Performance**: Compares each rank's performance relative to other ranks in the same training run
+2. **Individual Performance**: Tracks each rank's performance over time to detect degradation
+
+Scores range from 0.0 to 1.0, where:
+- **1.0**: Best possible performance
+- **0.7** (default threshold): Below this indicates a potential straggler
+- **Lower values**: Indicate worse performance
+
+### How It Works
+
+The straggler detection system:
+
+1. **Initialization**: Sets up the NVRx detector during training setup
+2. **Monitoring**: Wraps the training step function to monitor execution time
+3. **Periodic Reporting**: Generates performance reports at specified intervals
+4. **Straggler Identification**: Compares performance scores against thresholds
+5. **Action**: Optionally saves a checkpoint and terminates training if stragglers are detected
+
+### Best Practices
+
+1. **Appropriate Intervals**: Set `report_time_interval` based on your training characteristics
+2. **Threshold Tuning**: Adjust thresholds based on your hardware and expected performance variability
+3. **Gradual Rollout**: Start with `stop_if_detected=False` to observe performance patterns before enabling automatic termination
+4. **Monitor Logs**: Regularly check straggler reports to identify persistent hardware issues
+5. **Performance Impact**: The overhead is minimal, but you can adjust `profiling_interval` if needed
+
+### Integration with Training
+
+The straggler detection integrates directly with the training loop:
+
+- Automatically initializes when `NVRxStragglerDetectionManager` is configured
+- Monitors training steps without affecting the training logic
+- Provides exit conditions that the training loop respects
+- Safely shuts down when training completes
+
+## Preemption
+
+Training foundation models can take several hours or even days to complete. In some cases, training jobs must be halted preemptively due to cluster time limits, higher priority jobs, or other reasons.
+
+Megatron-Bridge provides functionality to gracefully perform preemptive shutdown of training. This feature listens for user-specified signals and saves a checkpoint before exiting when the signal is received.
+
+### Key Features
+
+- **Signal-based Shutdown**: Listens for signals (default: SIGTERM) during training
+- **Graceful Exit**: Saves checkpoint before terminating to preserve training progress
+- **Distributed Coordination**: Ensures all ranks receive and handle the signal properly
+- **Flexible Configuration**: Supports different signals and timing configurations
+
+### Usage Options
+
+Megatron-Bridge provides two ways to enable preemption handling:
+
+#### Option 1: NeMo-Run Plugin (Recommended)
+
+> **Warning**: This plugin is currently only supported on Slurm-based clusters.
+
+For users using NeMo-Run, the `PreemptionPlugin` provides the simplest integration:
+
+```python
+from megatron.bridge.recipes.run_plugins import PreemptionPlugin
+import nemo_run as run
+
+# Configure your task
+task = run.Script(...)
+
+# Add preemption plugin
+run_plugins = [
+    PreemptionPlugin(
+        preempt_time=60,  # Send signal 60 seconds before time limit
+        enable_exit_handler=True,
+        enable_exit_handler_for_data_loader=False,
+    )
+]
+
+# Run with preemption support
+run.run(task, plugins=run_plugins, executor=executor)
+```
+
+#### Option 2: Direct Configuration
+
+Configure preemption handling directly in your training configuration:
+
+```python
+from megatron.bridge.training.config import TrainingConfig
+import signal
+
+# Configure preemption in training config
+config.train = TrainingConfig(
+    exit_signal_handler=True,
+    exit_signal=signal.SIGTERM,  # Signal to listen for
+    exit_signal_handler_for_dataloader=False,
+    # ... other training config options
+)
+```
+
+### Configuration Options
+
+#### PreemptionPlugin Options
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `preempt_time` | `int` | `60` | Time in seconds before job limit to send preemption signal |
+| `enable_exit_handler` | `bool` | `True` | Enable the exit signal handler in training |
+| `enable_exit_handler_for_data_loader` | `bool` | `False` | Enable signal handler for dataloader workers |
+
+#### Training Configuration Options
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `exit_signal_handler` | `bool` | `False` | Enable signal handler for graceful shutdown |
+| `exit_signal` | `int` | `signal.SIGTERM` | Signal to listen for (default: SIGTERM) |
+| `exit_signal_handler_for_dataloader` | `bool` | `False` | Enable signal handler for dataloader workers |
+
+### Expected Behavior
+
+When a preemption signal is received, you'll see log messages similar to:
+
+```
+Received signal 15, initiating graceful stop
+Signal handler installed for 15
+exiting program after receiving SIGTERM.
+```
+
+The system will:
+1. **Detect the signal** at the end of the current training step
+2. **Save a checkpoint** to preserve training progress
+3. **Log the shutdown reason** for debugging purposes
+4. **Exit gracefully** with proper cleanup
+
+### How It Works
+
+The preemption system operates through several components:
+
+1. **Signal Handler Installation**: Sets up a distributed signal handler using `DistributedSignalHandler`
+2. **Signal Detection**: Checks for received signals at the end of each training step
+3. **Distributed Coordination**: Uses all-gather to ensure all ranks are aware of the signal
+4. **Checkpoint Saving**: Automatically saves a checkpoint before exiting
+5. **Graceful Shutdown**: Properly cleans up resources and exits
+
+### Signal Handling Details
+
+The `DistributedSignalHandler` class provides:
+- **Cross-rank coordination**: Ensures all ranks handle the signal consistently
+- **Original handler preservation**: Restores original signal handlers on exit
+- **Flexible signal support**: Can handle different signal types (SIGTERM, SIGINT, etc.)
+
+### Integration with Slurm
+
+When using Slurm, the system automatically:
+- **Receives SIGTERM** when approaching job time limits
+- **Coordinates across nodes** to ensure consistent shutdown
+- **Saves progress** before the job is forcibly terminated
+
+### Best Practices
+
+1. **Use Appropriate Timing**: Set `preempt_time` to allow sufficient time for checkpoint saving
+2. **Monitor Logs**: Watch for preemption messages to understand shutdown patterns
+3. **Test Signal Handling**: Verify preemption works correctly in your environment
+4. **Regular Checkpointing**: Ensure regular checkpoint intervals to minimize potential data loss
+5. **Resource Cleanup**: The system handles cleanup automatically, but monitor for any resource leaks

--- a/docs/training/training-config.md
+++ b/docs/training/training-config.md
@@ -6,7 +6,6 @@ The `TrainingConfig` contains settings related to the training loop bounds, exit
 Configure these parameters to control core training behavior, resource utilization, and monitoring across distributed setups.
 ### Batch Configuration
 Define how data is batched and distributed across devices during training.
-Define how data is batched and distributed across devices during training.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
@@ -22,7 +21,6 @@ The relationship between batch sizes:
 ### Training Duration
 
 Control when training stops using iteration counts or time-based limits.
-Control when training stops using iteration counts or time-based limits.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `train_iters` | `Optional[int]` | `None` | Total number of iterations to train |
@@ -30,7 +28,6 @@ Control when training stops using iteration counts or time-based limits.
 | `exit_duration_in_mins` | `Optional[int]` | `None` | Exit after this many minutes |
 
 ### Validation
-Configure validation frequency, duration, and evaluation-only modes.
 Configure validation frequency, duration, and evaluation-only modes.
 
 | Parameter | Type | Default | Description |
@@ -45,7 +42,6 @@ Configure validation frequency, duration, and evaluation-only modes.
 
 ### Memory Management
 Control GPU memory cleanup and garbage collection to prevent memory issues during training.
-Control GPU memory cleanup and garbage collection to prevent memory issues during training.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
@@ -56,7 +52,6 @@ Control GPU memory cleanup and garbage collection to prevent memory issues durin
 
 ### Signal Handling and Exit Conditions
 Set up automatic checkpoint saving and clean exit procedures for signal-based interruptions.
-Set up automatic checkpoint saving and clean exit procedures for signal-based interruptions.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
@@ -65,7 +60,6 @@ Set up automatic checkpoint saving and clean exit procedures for signal-based in
 | `exit_signal_handler_for_dataloader` | `bool` | `False` | Use signal handler for dataloader workers |
 
 ### Performance Monitoring
-Monitor training consistency and synchronization across distributed processes.
 Monitor training consistency and synchronization across distributed processes.
 
 | Parameter | Type | Default | Description |

--- a/docs/training/training-config.md
+++ b/docs/training/training-config.md
@@ -1,9 +1,11 @@
 # Training Loop Configuration
 
-The `TrainingConfig` contains settings related to the training loop bounds, exit conditions, validation, batch sizing, and memory management.
+The {py:class}`bridge.training.config.TrainingConfig` contains settings related to the training loop bounds, exit conditions, validation, batch sizing, and memory management.
 
 ## Key Parameters
+
 Configure these parameters to control core training behavior, resource utilization, and monitoring across distributed setups.
+
 ### Batch Configuration
 Define how data is batched and distributed across devices during training.
 

--- a/docs/training/training-config.md
+++ b/docs/training/training-config.md
@@ -6,6 +6,7 @@ The `TrainingConfig` contains settings related to the training loop bounds, exit
 Configure these parameters to control core training behavior, resource utilization, and monitoring across distributed setups.
 ### Batch Configuration
 Define how data is batched and distributed across devices during training.
+Define how data is batched and distributed across devices during training.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
@@ -21,6 +22,7 @@ The relationship between batch sizes:
 ### Training Duration
 
 Control when training stops using iteration counts or time-based limits.
+Control when training stops using iteration counts or time-based limits.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `train_iters` | `Optional[int]` | `None` | Total number of iterations to train |
@@ -28,6 +30,7 @@ Control when training stops using iteration counts or time-based limits.
 | `exit_duration_in_mins` | `Optional[int]` | `None` | Exit after this many minutes |
 
 ### Validation
+Configure validation frequency, duration, and evaluation-only modes.
 Configure validation frequency, duration, and evaluation-only modes.
 
 | Parameter | Type | Default | Description |
@@ -42,6 +45,7 @@ Configure validation frequency, duration, and evaluation-only modes.
 
 ### Memory Management
 Control GPU memory cleanup and garbage collection to prevent memory issues during training.
+Control GPU memory cleanup and garbage collection to prevent memory issues during training.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
@@ -52,6 +56,7 @@ Control GPU memory cleanup and garbage collection to prevent memory issues durin
 
 ### Signal Handling and Exit Conditions
 Set up automatic checkpoint saving and clean exit procedures for signal-based interruptions.
+Set up automatic checkpoint saving and clean exit procedures for signal-based interruptions.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
@@ -60,6 +65,7 @@ Set up automatic checkpoint saving and clean exit procedures for signal-based in
 | `exit_signal_handler_for_dataloader` | `bool` | `False` | Use signal handler for dataloader workers |
 
 ### Performance Monitoring
+Monitor training consistency and synchronization across distributed processes.
 Monitor training consistency and synchronization across distributed processes.
 
 | Parameter | Type | Default | Description |

--- a/docs/training/training-config.md
+++ b/docs/training/training-config.md
@@ -3,8 +3,9 @@
 The `TrainingConfig` contains settings related to the training loop bounds, exit conditions, validation, batch sizing, and memory management.
 
 ## Key Parameters
-
+Configure these parameters to control core training behavior, resource utilization, and monitoring across distributed setups.
 ### Batch Configuration
+Define how data is batched and distributed across devices during training.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
@@ -19,6 +20,7 @@ The relationship between batch sizes:
 
 ### Training Duration
 
+Control when training stops using iteration counts or time-based limits.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `train_iters` | `Optional[int]` | `None` | Total number of iterations to train |
@@ -26,6 +28,7 @@ The relationship between batch sizes:
 | `exit_duration_in_mins` | `Optional[int]` | `None` | Exit after this many minutes |
 
 ### Validation
+Configure validation frequency, duration, and evaluation-only modes.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
@@ -38,6 +41,7 @@ The relationship between batch sizes:
 - Set `eval_interval` to `None` to skip validation during training, but still run validation after training completes.
 
 ### Memory Management
+Control GPU memory cleanup and garbage collection to prevent memory issues during training.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
@@ -46,7 +50,8 @@ The relationship between batch sizes:
 | `manual_gc_interval` | `int` | `0` | Training step interval for manual garbage collection (0=disabled) |
 | `manual_gc_eval` | `bool` | `True` | Enable garbage collection during evaluation when using manual GC |
 
-### Signal Handling & Exit Conditions
+### Signal Handling and Exit Conditions
+Set up automatic checkpoint saving and clean exit procedures for signal-based interruptions.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
@@ -55,6 +60,7 @@ The relationship between batch sizes:
 | `exit_signal_handler_for_dataloader` | `bool` | `False` | Use signal handler for dataloader workers |
 
 ### Performance Monitoring
+Monitor training consistency and synchronization across distributed processes.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|

--- a/docs/training/training-config.md
+++ b/docs/training/training-config.md
@@ -33,6 +33,10 @@ The relationship between batch sizes:
 | `eval_interval` | `Optional[int]` | `1000` | Interval between validation runs |
 | `skip_train` | `bool` | `False` | Skip training, only do evaluation and exit |
 
+**Note:** To control validation behavior:
+- Set `eval_iters` to `0` to disable validation entirely (both during and after training).
+- Set `eval_interval` to `None` to skip validation during training, but still run validation after training completes.
+
 ### Memory Management
 
 | Parameter | Type | Default | Description |

--- a/docs/training/training-config.md
+++ b/docs/training/training-config.md
@@ -1,0 +1,59 @@
+# Training Loop Configuration
+
+The `TrainingConfig` contains settings related to the training loop bounds, exit conditions, validation, batch sizing, and memory management.
+
+## Key Parameters
+
+### Batch Configuration
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `micro_batch_size` | `Optional[int]` | `None` | Batch size per model instance (local batch size) |
+| `global_batch_size` | `Optional[int]` | `None` | Training batch size across all devices |
+| `rampup_batch_size` | `Optional[list[int]]` | `None` | Batch size ramp up: `[start_size, increment, ramp_samples]` |
+| `decrease_batch_size_if_needed` | `bool` | `False` | Automatically decrease batch size if needed for fault tolerance |
+
+The relationship between batch sizes:
+- **Global batch size** = `micro_batch_size` × `data_parallel_size` × `gradient_accumulation_steps`
+- If `global_batch_size` is not set, it defaults to `micro_batch_size` × `data_parallel_size`
+
+### Training Duration
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `train_iters` | `Optional[int]` | `None` | Total number of iterations to train |
+| `exit_interval` | `Optional[int]` | `None` | Exit after iteration divisible by this value |
+| `exit_duration_in_mins` | `Optional[int]` | `None` | Exit after this many minutes |
+
+### Validation
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `eval_iters` | `int` | `100` | Number of iterations for validation/test evaluation |
+| `eval_interval` | `Optional[int]` | `1000` | Interval between validation runs |
+| `skip_train` | `bool` | `False` | Skip training, only do evaluation and exit |
+
+### Memory Management
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `empty_unused_memory_level` | `Literal[0, 1, 2]` | `0` | Call `torch.cuda.empty_cache()` each iteration (0=off, 1=moderate, 2=aggressive) |
+| `manual_gc` | `bool` | `False` | Synchronize Python garbage collection across ranks to avoid stragglers |
+| `manual_gc_interval` | `int` | `0` | Training step interval for manual garbage collection (0=disabled) |
+| `manual_gc_eval` | `bool` | `True` | Enable garbage collection during evaluation when using manual GC |
+
+### Signal Handling & Exit Conditions
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `exit_signal_handler` | `bool` | `False` | Save checkpoint and shutdown gracefully on signal detection |
+| `exit_signal` | `int` | `signal.SIGTERM` | Signal to handle for graceful shutdown |
+| `exit_signal_handler_for_dataloader` | `bool` | `False` | Use signal handler for dataloader workers |
+
+### Performance Monitoring
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `check_weight_hash_across_dp_replicas_interval` | `Optional[int]` | `None` | Check weight hash consistency across data parallel replicas |
+| `train_sync_interval` | `Optional[int]` | `None` | CPU-GPU synchronization interval to prevent CPU running ahead |
+

--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -705,7 +705,7 @@ class NVRxStragglerDetectionConfig:
     profiling_interval: int = 1
     """Profiling interval passed to straggler.Detector.initialize."""
 
-    logger_name: str = "megatron_hub.NVRxStragglerDetection"
+    logger_name: str = "megatron.bridge.NVRxStragglerDetection"
     """Logger name for straggler detection messages."""
 
     def __post_init__(self) -> None:

--- a/src/megatron/bridge/training/fault_tolerance.py
+++ b/src/megatron/bridge/training/fault_tolerance.py
@@ -13,15 +13,15 @@
 # limitations under the License.
 
 """
-Fault Tolerance (FT) package integration for Megatron-Hub, using the FT section-based API.
+Fault Tolerance (FT) package integration for Megatron-Bridge, using the FT section-based API.
 
 The FT package is included in "nvidia-resiliency-ext"
 (https://github.com/NVIDIA/nvidia-resiliency-ext).
 
 NOTE: The workload must be run using the `ft_launcher` tool provided by `nvidia-resiliency-ext.`
 NOTE: Calls to the public API of this module are no-ops if FT is not initialized
-(`ft_integration.setup` was not called).
-NOTE: Default distributed process group should be initialized before calling `ft_integration.setup`
+(`fault_tolerance.setup` was not called).
+NOTE: Default distributed process group should be initialized before calling `fault_tolerance.setup`
 
 The "setup" FT section is opened during FT initialization and closed before the first training or
 eval iteration. Training and evaluation steps are wrapped in the "step" section, but only after a

--- a/tests/unit_tests/training/test_nvrx_straggler.py
+++ b/tests/unit_tests/training/test_nvrx_straggler.py
@@ -123,7 +123,7 @@ class TestNVRxStragglerDetectionConfig:
         assert config.stop_if_detected is False
         assert config.enable_logging is True
         assert config.profiling_interval == 1
-        assert config.logger_name == "megatron_hub.NVRxStragglerDetection"
+        assert config.logger_name == "megatron.bridge.NVRxStragglerDetection"
 
     def test_custom_config(self):
         """Test custom configuration values."""


### PR DESCRIPTION
This adds a dedicated Training & Customization section to the docs site. This covers
1. An overview of the configuration via `ConfigContainer`
2. Entry points `pretrain`, `finetune` with details for the passed in `forward_step_func`
3. Training loop settings controlled by `TrainingConfig`
4. Optimizer/LR Scheduler settings controlled by their corresponding configs
5. Checkpointing & configuration: global & local checkpointing
6. PEFT: overview, how to configure, and how its integrated into megatron bridge
7. Resiliency: fault tolerance launcher, straggler detection, preemption support, re-run state machine


Fixes https://github.com/NVIDIA-NeMo/Megatron-Bridge/issues/176
part of https://github.com/NVIDIA-NeMo/Megatron-Bridge/issues/445