### PR TITLE
Add global barrier after checkpoint save to ensure synchronization across ranks

### DIFF
--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -610,6 +610,18 @@ def save_checkpoint(
         else:
             train_state_finalize_fn()
 
+    # Ensure all ranks see a fully written checkpoint (e.g., run_config.yaml) before W&B scans.
+    def _post_save_global_barrier() -> None:
+        if torch.distributed.is_initialized():
+            torch.distributed.barrier()
+
+    if ckpt_cfg.async_save:
+        assert async_save_request is not None
+        async_save_request.add_finalize_fn(_post_save_global_barrier)
+    else:
+        _post_save_global_barrier()
+
+
     # Additional callback for wandb (last rank)
     if not torch.distributed.is_initialized() or is_last_rank():
 
@@ -630,10 +642,6 @@ def save_checkpoint(
     if ckpt_cfg.async_save:
         schedule_async_save(state, async_save_request)
         print_rank_0(f"  scheduled an async checkpoint save at iteration {train_state.step:7d} to {save_dir}")
-
-    # Wait so everyone is done (not necessary)
-    if torch.distributed.is_initialized():
-        torch.distributed.barrier()
 
     end_misc = time()
     logger.debug(f"rank: {rank}, takes {end_misc - start_misc} to finalize ckpt save ")

--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -621,7 +621,6 @@ def save_checkpoint(
     else:
         _post_save_global_barrier()
 
-
     # Additional callback for wandb (last rank)
     if not torch.distributed.is_initialized() or is_last_rank():
 


### PR DESCRIPTION
Lack of synchronisation results in a race condition which in-turn results in a crash while reporting wandb artifact.
When saving the config in rank 0 using ```cfg.to_yaml(config_filename)```, a tmp file is created.
During this process, in the last rank (which runs the wandb reporter), walks the checkpoint directory, containing the above tmp file.
Then, when reporting of each file occurs, the tmp file is no longer present which causes a FileNotFound exception.