### PR TITLE
fix references to exit_duration_in_mins and start_time

### DIFF
--- a/src/megatron/bridge/training/eval.py
+++ b/src/megatron/bridge/training/eval.py
@@ -132,7 +132,7 @@ def evaluate(
             state.train_state.consumed_valid_samples += eval_batch_size
 
             if state.cfg.train.exit_duration_in_mins:
-                train_time = (time.time() - state.train_state.start_time) / 60.0
+                train_time = (time.time() - state.start_time) / 60.0
                 done_cuda = torch.tensor(
                     [train_time > state.cfg.train.exit_duration_in_mins], dtype=torch.int, device="cuda"
                 )

--- a/src/megatron/bridge/training/train.py
+++ b/src/megatron/bridge/training/train.py
@@ -910,9 +910,9 @@ def checkpoint_and_decide_exit(
 
     # Exit based on duration.
     if state.cfg.train.exit_duration_in_mins:
-        train_time = (time.time() - state.train_state.start_time) / 60.0
+        train_time = (time.time() - state.start_time) / 60.0
         done_cuda = torch.tensor(
-            [train_time > state.cfg.checkpoint.exit_duration_in_mins], dtype=torch.int, device="cuda"
+            [train_time > state.cfg.train.exit_duration_in_mins], dtype=torch.int, device="cuda"
         )
         torch.distributed.all_reduce(done_cuda, op=torch.distributed.ReduceOp.MAX)
         done = done_cuda.item()


### PR DESCRIPTION
currently using `exit_duration_in_mins` causes crashed due to invalid references. This fixes the issues