### PR TITLE
[megatron FSDP] Support `fsdp_dtensor` checkpoint format 

### DIFF
--- a/src/megatron/bridge/models/conversion/model_bridge.py
+++ b/src/megatron/bridge/models/conversion/model_bridge.py
@@ -36,6 +36,7 @@ from megatron.core.transformer.module import MegatronModule
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.utils import (
     get_pg_size,
+    unwrap_model,
 )
 from rich.progress import BarColumn, Progress, TextColumn, TimeRemainingColumn
 from transformers.modeling_utils import PreTrainedModel
@@ -49,7 +50,7 @@ from megatron.bridge.models.conversion.utils import (
 )
 from megatron.bridge.models.decorators.dispatch import dispatch
 from megatron.bridge.models.model_provider import ModelProviderMixin
-from megatron.bridge.utils.common_utils import print_rank_0, unwrap_model
+from megatron.bridge.utils.common_utils import print_rank_0
 
 
 logger = logging.getLogger(__name__)

--- a/src/megatron/bridge/models/conversion/utils.py
+++ b/src/megatron/bridge/models/conversion/utils.py
@@ -20,10 +20,9 @@ from typing import Iterable, List, Optional, Tuple
 
 import torch
 from megatron.core.transformer.module import MegatronModule
+from megatron.core.utils import unwrap_model
 from rich.table import Table
 from transformers.configuration_utils import PretrainedConfig
-
-from megatron.bridge.utils.common_utils import unwrap_model
 
 
 def weights_verification_table(bridge, megatron_model) -> Table:

--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -69,7 +69,6 @@ from megatron.bridge.utils.common_utils import (
     get_rank_safe,
     is_last_rank,
     print_rank_0,
-    # unwrap_model,
 )
 from megatron.bridge.utils.import_utils import safe_import
 

--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -136,6 +136,34 @@ def get_checkpoint_version() -> Optional[float]:
     return _CHECKPOINT_VERSION
 
 
+def _get_checkpoint_format(checkpoint_path: str) -> str:
+    """Determine the checkpoint format by examining the checkpoint directory.
+
+    Args:
+        checkpoint_path: Path to the checkpoint directory.
+
+    Returns:
+        The checkpoint format string.
+    """
+    # Check for Megatron Core distributed checkpoint first
+    if dist_checkpointing.check_is_distributed_checkpoint(checkpoint_path):
+        return "torch_dist"
+
+    # Check for PyTorch DCP format (.metadata file exists)
+    if MultiStorageClientFeature.is_enabled():
+        msc = MultiStorageClientFeature.import_package()
+        checkpoint_dir = msc.Path(checkpoint_path)
+        is_torch_dcp = checkpoint_dir.joinpath(".metadata").exists()
+    else:
+        is_torch_dcp = os.path.exists(os.path.join(checkpoint_path, ".metadata"))
+
+    if is_torch_dcp:
+        # Assume fsdp_dtensor for PyTorch DCP format
+        return "fsdp_dtensor"
+    else:
+        raise NotImplementedError(f"Unknown checkpoint format in {checkpoint_path}")
+
+
 def find_checkpoint_rank_0(checkpoints_path: str, iteration: int, release: bool = False) -> Optional[str]:
     """Find the checkpoint directory for a given iteration, assuming distributed checkpoints.
 
@@ -313,13 +341,15 @@ def get_rng_state(data_parallel_random_init: bool, ckpt_format: str = "torch_dis
 
     Collects states from random, numpy, torch, cuda, and the Megatron RNG tracker.
     Optionally gathers states across data parallel ranks.
-    Always wraps the result in a ShardedObject for distributed checkpointing.
+    Returns format depends on checkpoint format.
 
     Args:
         data_parallel_random_init: If True, gathers RNG states across data parallel ranks.
+        ckpt_format: The checkpoint format being used.
 
     Returns:
-        A ShardedObject containing the RNG states.
+        For torch_dist: A ShardedObject containing the RNG states.
+        For fsdp_dtensor: A dict mapping (pp_rank, tp_rank) to RNG state lists.
     """
     rng_state = {
         "random_rng_state": random.getstate(),
@@ -361,6 +391,7 @@ class CheckpointType(Enum):
 
     LOCAL = auto()
     GLOBAL = auto()
+    FSDP_DTENSOR = auto()
 
 
 def save_checkpoint(
@@ -498,7 +529,7 @@ def save_checkpoint(
             ensure_directory_exists(checkpoint_name, check_parent=False)
 
         if ckpt_cfg.ckpt_format == "fsdp_dtensor":
-            # FSDP DTensor checkpoint save path
+            # FSDP DTensor checkpoint save path using PyTorch Distributed Checkpointing
             fs_storage_writer = torch.distributed.checkpoint.FileSystemWriter(checkpoint_name)
             torch.distributed.checkpoint.save(
                 state_dict=state_dict,
@@ -545,10 +576,9 @@ def save_checkpoint(
                 preprocess_common_before_consistancy_check=preprocess_common_state_dict_fn,
                 content_metadata=sharded_sd_metadata,
             )
-
-        # [ModelOpt]: save sharded modelopt_state
-        if has_nvidia_modelopt:
-            save_sharded_modelopt_state(model, checkpoint_name, (ckpt_cfg.ckpt_format, 1))
+            # [ModelOpt]: save sharded modelopt_state
+            if has_nvidia_modelopt:
+                save_sharded_modelopt_state(model, checkpoint_name, (ckpt_cfg.ckpt_format, 1))
     else:
         # [ModelOpt]: Inject modelopt_state into state_dict
         if has_nvidia_modelopt:
@@ -859,7 +889,8 @@ def generate_state_dict(
         if len(model) != 1:
             raise RuntimeError("FSDP DTensor checkpoints are not supported for multiple models.")
 
-        # Apply FSDP-specific preprocessing
+        # Apply FSDP-specific preprocessing - mirror Megatron-LM approach
+        # Only call SWiGLU handler if we have an explicit swiglu flag (like Megatron-LM)
         from megatron.core.utils import get_model_config
 
         model_config = get_model_config(model[0])
@@ -1034,223 +1065,267 @@ def _load_checkpoint_from_path(
         - num_floating_point_operations_so_far: The total FLOPs computed so far.
     """
     cfg = state.cfg
-
     model = unwrap_model(model)
+    ckpt_format = cfg.checkpoint.ckpt_format
 
+    # Step 1: Load base checkpoint with rank0=True (torch_dist only)
+    if ckpt_format == "torch_dist":
+        state_dict, checkpoint_name, release, ckpt_type = _load_base_checkpoint(
+            load_dir, cfg.checkpoint, rank0=True, checkpointing_context=checkpointing_context
+        )
+
+    # Step 2: Initialize scaffolding
     load_kwargs = {}
-    state_dict, checkpoint_name, release, ckpt_type = _load_base_checkpoint(
-        load_dir,
-        cfg.checkpoint,
-        rank0=True,
-        checkpointing_context=checkpointing_context,
-    )
+    ignore_rng_state = False
+    ignore_rerun_state = True
 
-    # Checkpoint not loaded.
-    if state_dict is None:
-        # Iteration and num_floating_point_operations_so_far default to 0.
-        return 0, 0
+    # Step 3: Format-specific preparation
+    if ckpt_format == "torch_dist":
+        if state_dict is None:
+            return 0, 0
 
-    # Try to read run_config.yaml first
-    # If that fails, we are loading from a Megatron-LM checkpoint, so extract the corresponding values
-    # from args in the state_dict
-    run_config_filename = get_checkpoint_run_config_filename(checkpoint_name)
-
-    if file_exists(run_config_filename):
-        run_config = read_run_config(run_config_filename)
-    else:
-        # Fallback to legacy Megatron-LM args extraction
-        print_rank_0("run_config.yaml not found, extracting config from legacy Megatron-LM checkpoint")
-        run_config = _extract_megatron_lm_args_from_state_dict(state_dict)
-
-    # TODO: Make read_run_config() return a ConfigContainer object
-    ckpt_tp_pp = (
-        run_config["model"]["tensor_model_parallel_size"],
-        run_config["model"]["pipeline_model_parallel_size"],
-    )
-    run_tp_pp = (
-        cfg.model.tensor_model_parallel_size,
-        cfg.model.pipeline_model_parallel_size,
-    )
-    mismatch_msg = "(TP, PP, encoder TP, encoder PP) mismatch after resume ({} vs {} from checkpoint)".format(
-        run_tp_pp, ckpt_tp_pp
-    )
-    # Determine if RNG state will be loaded
-    if (
-        ckpt_tp_pp == run_tp_pp
-        and not release
-        and not cfg.checkpoint.finetune
-        and cfg.checkpoint.load_rng
-        and run_config["checkpoint"]["save_rng"]
-    ):
-        # we can load the rng state
-        ckpt_format = "fsdp_dtensor" if file_exists(os.path.join(checkpoint_name, ".metadata")) else "torch_dist"
-        gen_sd_rng_state = get_rng_state(
-            data_parallel_random_init=cfg.rng.data_parallel_random_init, ckpt_format=ckpt_format
-        )
-    else:
-        gen_sd_rng_state = None
-        if ckpt_tp_pp != run_tp_pp:
-            print_rank_0("{}: RNG state will be ignored".format(mismatch_msg))
-
-    # Handle metadata loading for different checkpoint types
-    if ckpt_type == CheckpointType.GLOBAL and file_exists(os.path.join(checkpoint_name, ".metadata")):
-        # FSDP DTensor checkpoint - build metadata from config
-        sharded_sd_metadata = _build_sharded_state_dict_metadata(
-            cfg.optimizer.use_distributed_optimizer, cfg.checkpoint.fully_parallel_save, "fsdp_dtensor"
-        )
-    else:
-        # torch_dist checkpoint - load metadata from checkpoint
-        sharded_sd_metadata = dist_checkpointing.load_content_metadata(preloaded_state_dict=state_dict)
-    print_rank_0(f"sharded_state_dict metadata loaded from the checkpoint: {sharded_sd_metadata}")
-    # Determine if optimizer state will be loaded
-    if (
-        not release
-        and not cfg.checkpoint.finetune
-        and cfg.checkpoint.load_optim
-        and run_config["checkpoint"]["save_optim"]
-    ):
-        gen_sd_optim = optimizer
-        gen_sd_opt_param_scheduler = opt_param_scheduler
-
-        if cfg.optimizer.use_distributed_optimizer:
-            if sharded_sd_metadata is None:
-                # Backward-compatibility with old checkpoints which don't have content versioning
-                # Can be removed after ending support for optimizer checkpoints with MCore < v0.13
-                # (for MCore v0.13+ checkpoints `sharded_sd_metadata is not None`)
-                sharded_sd_metadata = {
-                    "distrib_optim_sharding_type": (
-                        "fully_sharded_model_space"
-                        if run_config["checkpoint"]["fully_parallel_save"]
-                        else "dp_zero_gather_scatter"
-                    ),
-                }
-            if (
-                ckpt_tp_pp != run_tp_pp
-                and sharded_sd_metadata["distrib_optim_sharding_type"] != "fully_sharded_model_space"
-            ):
-                raise RuntimeError(
-                    f"{mismatch_msg}: not supported for DistributedOptimizer with sharding type"
-                    f" {sharded_sd_metadata['distrib_optim_sharding_type']}."
-                    f" Please use `checkpoint_config.fully_parallel_save=True` for checkpoint saving."
-                )
-
-    else:
-        gen_sd_optim = None
-        gen_sd_opt_param_scheduler = None
-
-    optim_sd_kwargs = dict(metadata=sharded_sd_metadata, is_loading=True)
-    model_sd_kwargs = dict(metadata=sharded_sd_metadata)
-
-    # Determine if rerun state will be loaded
-    if ckpt_tp_pp == run_tp_pp and not release and not cfg.checkpoint.finetune and "rerun_state_machine" in state_dict:
-        rerun_state_machine = get_rerun_state_machine()
-        gen_sd_rerun_state = rerun_state_machine.state_dict(data_iterator=None, ckpt_format="torch_dist")
-    else:
-        gen_sd_rerun_state = None
-        if ckpt_tp_pp != run_tp_pp:
-            print_rank_0("{}: Rerun state will be ignored".format(mismatch_msg))
-
-    # [ModelOpt]: IMPORTANT! Restoring modelopt_state (sharded or not) must be performed
-    # after the model instance has been created and before _load_base_checkpoint is called.
-    if has_nvidia_modelopt:
-        if ckpt_type == CheckpointType.LOCAL:
-            print_rank_0("WARNING: Local checkpointing does not support nvidia_modelopt.")
-        elif ckpt_type == CheckpointType.GLOBAL:
-            restore_modelopt_state(model, state_dict)
+        # Read run_config for TP/PP compatibility checks
+        run_config_filename = get_checkpoint_run_config_filename(checkpoint_name)
+        if file_exists(run_config_filename):
+            run_config = read_run_config(run_config_filename)
         else:
-            restore_sharded_modelopt_state(model, checkpoint_name)
+            print_rank_0("run_config.yaml not found, extracting config from legacy Megatron-LM checkpoint")
+            run_config = _extract_megatron_lm_args_from_state_dict(state_dict)
 
-    # [ModelOpt]: Initial loading from non-resume sharded checkpoint to a Distillation Model
-    # will result in key mismatch with loss modules potentially containing parameters, since
-    # it requires generating a state_dict before loading. Here we hide those modules if present.
-    with contextlib.ExitStack() as stack:  # Allows multiple context managers for each model shard
-        if cfg.checkpoint.finetune and hasattr(model[0], "hide_loss_modules"):
-            for m in model:
-                stack.enter_context(m.hide_loss_modules())
+        ckpt_tp_pp = (
+            run_config["model"]["tensor_model_parallel_size"],
+            run_config["model"]["pipeline_model_parallel_size"],
+        )
+        run_tp_pp = (
+            cfg.model.tensor_model_parallel_size,
+            cfg.model.pipeline_model_parallel_size,
+        )
+        mismatch_msg = "(TP, PP) mismatch after resume ({} vs {} from checkpoint)".format(run_tp_pp, ckpt_tp_pp)
+
+        # Determine if RNG state will be loaded
+        if (
+            ckpt_tp_pp == run_tp_pp
+            and not release
+            and not cfg.checkpoint.finetune
+            and cfg.checkpoint.load_rng
+            and run_config["checkpoint"]["save_rng"]
+        ):
+            gen_sd_rng_state = get_rng_state(cfg.rng.data_parallel_random_init, ckpt_format)
+        else:
+            ignore_rng_state = True
+            gen_sd_rng_state = None
+            if ckpt_tp_pp != run_tp_pp:
+                print_rank_0("{}: RNG state will be ignored".format(mismatch_msg))
+
+        sharded_sd_metadata = dist_checkpointing.load_content_metadata(preloaded_state_dict=state_dict)
+        print_rank_0(f"sharded_state_dict metadata loaded from the checkpoint: {sharded_sd_metadata}")
+
+        # Determine if optimizer state will be loaded
+        if (
+            not release
+            and not cfg.checkpoint.finetune
+            and cfg.checkpoint.load_optim
+            and run_config["checkpoint"]["save_optim"]
+        ):
+            gen_sd_optim = optimizer
+            gen_sd_opt_param_scheduler = opt_param_scheduler
+
+            if cfg.optimizer.use_distributed_optimizer:
+                if sharded_sd_metadata is None:
+                    sharded_sd_metadata = {
+                        "distrib_optim_sharding_type": (
+                            "fully_sharded_model_space"
+                            if run_config["checkpoint"]["fully_parallel_save"]
+                            else "dp_zero_gather_scatter"
+                        ),
+                    }
+                if (
+                    ckpt_tp_pp != run_tp_pp
+                    and sharded_sd_metadata["distrib_optim_sharding_type"] != "fully_sharded_model_space"
+                ):
+                    raise RuntimeError(
+                        f"{mismatch_msg}: not supported for DistributedOptimizer with sharding type"
+                        f" {sharded_sd_metadata['distrib_optim_sharding_type']}."
+                        f" Please use `checkpoint_config.fully_parallel_save=True` for checkpoint saving."
+                    )
+        else:
+            gen_sd_optim = None
+            gen_sd_opt_param_scheduler = None
+
+        # Determine if rerun state will be loaded
+        if (
+            ckpt_tp_pp == run_tp_pp
+            and not release
+            and not cfg.checkpoint.finetune
+            and "rerun_state_machine" in state_dict
+        ):
+            rerun_state_machine = get_rerun_state_machine()
+            gen_sd_rerun_state = rerun_state_machine.state_dict(
+                data_iterator=None, ckpt_format=ckpt_format, force=True
+            )
+            ignore_rerun_state = False
+        else:
+            gen_sd_rerun_state = None
+            if ckpt_tp_pp != run_tp_pp:
+                print_rank_0("{}: Rerun state will be ignored".format(mismatch_msg))
+
+        optim_sd_kwargs = dict(metadata=sharded_sd_metadata, is_loading=True)
+        model_sd_kwargs = dict(metadata=sharded_sd_metadata)
+
+        # ModelOpt restoration
+        if has_nvidia_modelopt:
+            if ckpt_type == CheckpointType.LOCAL:
+                print_rank_0("WARNING: Local checkpointing does not support nvidia_modelopt.")
+            elif ckpt_type == CheckpointType.GLOBAL:
+                restore_modelopt_state(model, state_dict)
+            else:
+                restore_sharded_modelopt_state(model, checkpoint_name)
+
+        # Build sharded state dict for loading
+        with contextlib.ExitStack() as stack:
+            if cfg.checkpoint.finetune and hasattr(model[0], "hide_loss_modules"):
+                for m in model:
+                    stack.enter_context(m.hide_loss_modules())
+            load_kwargs["sharded_state_dict"] = generate_state_dict(
+                cfg.checkpoint,
+                model,
+                gen_sd_optim,
+                gen_sd_opt_param_scheduler,
+                gen_sd_rng_state,
+                optim_sd_kwargs=optim_sd_kwargs,
+                model_sd_kwargs=model_sd_kwargs,
+                rerun_state=gen_sd_rerun_state,
+            )
+
+        # PEFT resume filtering
+        is_peft_resume = (
+            cfg.peft is not None
+            and cfg.checkpoint.load is not None
+            and load_dir == cfg.checkpoint.load
+            and load_dir != cfg.checkpoint.pretrained_checkpoint
+            and not cfg.checkpoint.finetune
+        )
+        if is_peft_resume:
+            load_kwargs["sharded_state_dict"] = apply_peft_adapter_filter_to_state_dict(
+                load_kwargs["sharded_state_dict"], cfg.peft
+            )
+
+    elif ckpt_format == "fsdp_dtensor":
+        # Handle fsdp_dtensor format
+        from torch.distributed.checkpoint import FileSystemReader
+
+        # Get checkpoint path using Bridge's utilities
+        tracker_filename = get_checkpoint_train_state_filename(load_dir, prefix=TRACKER_PREFIX)
+        if file_exists(tracker_filename):
+            train_state = read_train_state(tracker_filename)
+            iteration = train_state.step
+            release = False
+        else:
+            # Fallback to legacy Megatron-LM tracker
+            legacy_tracker_filename = get_checkpoint_tracker_filename(load_dir)
+            if file_exists(legacy_tracker_filename):
+                iteration, release = read_metadata(legacy_tracker_filename)
+            else:
+                print_rank_0(f"WARNING: could not find metadata file in {load_dir}")
+                return 0, 0
+
+        checkpoint_name = get_checkpoint_name(load_dir, iteration, release)
+        reader = FileSystemReader(checkpoint_name)
+        try:
+            state_dict_metadata = reader.read_metadata().state_dict_metadata
+        except FileNotFoundError:
+            state_dict_metadata = {}
+
+        # Decide what sections to load based on metadata and config
+        gen_sd_rerun_state = None
+        gen_sd_opt_param_scheduler = None
+        gen_sd_rng_state = None
+        gen_sd_optim = None
+        if not cfg.checkpoint.finetune:
+            if "rerun_state_machine" in state_dict_metadata:
+                gen_sd_rerun_state = get_rerun_state_machine().state_dict(
+                    data_iterator=None, ckpt_format=ckpt_format, force=True
+                )
+            if cfg.checkpoint.load_rng:
+                gen_sd_rng_state = get_rng_state(cfg.rng.data_parallel_random_init, ckpt_format)
+            if cfg.checkpoint.load_optim:
+                gen_sd_optim = optimizer
+                gen_sd_opt_param_scheduler = opt_param_scheduler
+
+        optim_sd_kwargs = dict(
+            metadata=_build_sharded_state_dict_metadata(
+                cfg.optimizer.use_distributed_optimizer, cfg.checkpoint.fully_parallel_save, ckpt_format
+            ),
+            is_loading=True,
+        )
+
         load_kwargs["sharded_state_dict"] = generate_state_dict(
             cfg.checkpoint,
-            model,
-            gen_sd_optim,
-            gen_sd_opt_param_scheduler,
-            gen_sd_rng_state,
+            model=model,
+            optimizer=gen_sd_optim,
+            opt_param_scheduler=gen_sd_opt_param_scheduler,
+            rng_state=gen_sd_rng_state,
             optim_sd_kwargs=optim_sd_kwargs,
-            model_sd_kwargs=model_sd_kwargs,
             rerun_state=gen_sd_rerun_state,
+            iteration=1,
         )
 
-    # For PEFT, check if resuming from a checkpoint saved during training, which contains only the PEFT adapter states
-    # This situation occurs when:
-    # 1. The PEFT config is set
-    # 2. Loading from a checkpoint saved during training (not loading from a pretrained checkpoint)
-    # 3. Not in finetune mode
-    is_peft_resume = (
-        cfg.peft is not None
-        and cfg.checkpoint.load is not None
-        and load_dir == cfg.checkpoint.load
-        and load_dir != cfg.checkpoint.pretrained_checkpoint
-        and not cfg.checkpoint.finetune
-    )
-
-    if is_peft_resume:
-        load_kwargs["sharded_state_dict"] = apply_peft_adapter_filter_to_state_dict(
-            load_kwargs["sharded_state_dict"], cfg.peft
-        )
-
+    # Step 4: Load the checkpoint
     state_dict, checkpoint_name, release, ckpt_type = _load_base_checkpoint(
         load_dir, cfg.checkpoint, rank0=False, checkpointing_context=checkpointing_context, **load_kwargs
     )
 
-    # Set checkpoint version.
+    # Checkpoint not loaded
+    if state_dict is None:
+        return 0, 0
+
+    # Step 5: Common finalization
     set_checkpoint_version(state_dict.get("checkpoint_version", 0))
 
-    # Check arguments.
-    assert state.train_state.consumed_train_samples == 0
-    assert state.train_state.skipped_train_samples == 0
-    assert state.train_state.consumed_valid_samples == 0
-
+    # Handle train state
     if not cfg.checkpoint.finetune:
-        # Try to read train_state.pt from checkpoint directory
-        # If it doesn't exist (checkpoint generated by Megatron-LM), create from available information
         train_state_filename = get_checkpoint_train_state_filename(checkpoint_name)
-
         if file_exists(train_state_filename):
             state.train_state = read_train_state(train_state_filename)
         else:
-            # Legacy Megatron-LM checkpoint - create TrainState from checkpoint iteration
             print_rank_0(f"{train_state_filename} not found, creating TrainState from checkpoint state dict")
             state.train_state = _get_train_state_from_state_dict(state_dict)
 
-    # Set iteration.
     if cfg.checkpoint.finetune or release:
         state.train_state.step = 0
 
     if not cfg.checkpoint.finetune:
-        # check_checkpoint_args(checkpoint_args)
         update_num_microbatches(consumed_samples=state.train_state.consumed_train_samples, verbose=True)
 
-    # Model.
+    # Load model weights
     if not skip_load_to_model_and_opt:
-        load_strict = False if is_peft_resume else strict
+        # Handle PEFT resume for strict loading (torch_dist only)
+        load_strict = strict
+        if ckpt_format == "torch_dist":
+            is_peft_resume = (
+                cfg.peft is not None
+                and cfg.checkpoint.load is not None
+                and load_dir == cfg.checkpoint.load
+                and load_dir != cfg.checkpoint.pretrained_checkpoint
+                and not cfg.checkpoint.finetune
+            )
+            load_strict = False if is_peft_resume else strict
+
         if len(model) == 1:
             _load_model_state_dict(model[0], state_dict["model"], load_strict)
         else:
             for i in range(len(model)):
-                # If there is no corresponding model in the state_dict, it will be ignored.
-                # It means that this is an empty stage.
                 model_key = "model%d" % i
                 if model_key not in state_dict:
                     continue
                 _load_model_state_dict(model[i], state_dict[model_key], load_strict)
 
-    # Fix up query/key/value matrix ordering if needed.
     checkpoint_version = get_checkpoint_version()
     print_rank_0(f" checkpoint version {checkpoint_version}")
-    # fix_query_key_value_ordering(model, checkpoint_version) # Assuming this is not needed if only v3.0 is supported
 
-    # Optimizer.
+    # Load optimizer and scheduler
     if not release and not cfg.checkpoint.finetune and cfg.checkpoint.load_optim:
         try:
-            # Load state dict.
             if (
                 not skip_load_to_model_and_opt
                 and optimizer is not None
@@ -1258,33 +1333,16 @@ def _load_checkpoint_from_path(
             ):
                 optimizer.load_state_dict(state_dict["optimizer"])
 
-            # Load distributed optimizer's custom parameter state.
-            # For distributed checkpoint it's already loaded in load_state_dict above
-            # if cfg.optimizer.use_distributed_optimizer and not is_dist_ckpt:
-            #     # NOTE: this is a manual read of the tracker file.
-            #     # This code should not be reached when reading from a non_persistent checkpoint
-            #     assert not is_dist_ckpt
-            #     tracker_filename = get_checkpoint_train_state_filename(load_dir, prefix="latest")
-            #     iteration, release = read_train_state(tracker_filename)
-            #     model_checkpoint_name = get_checkpoint_name(load_dir, iteration, release)
-            #     optim_checkpoint_name = get_distributed_optimizer_checkpoint_name(model_checkpoint_name)
-            #     optimizer.load_parameter_state(
-            #         optim_checkpoint_name,
-            #         update_legacy_format=cfg.checkpoint.ckpt_convert_update_legacy_dist_opt_format,
-            #     )
-
-            # Load scheduler.
             if opt_param_scheduler is not None:
-                if "lr_scheduler" in state_dict:  # backward compatibility
+                if "lr_scheduler" in state_dict:
                     opt_param_scheduler.load_state_dict(state_dict["lr_scheduler"])
                 else:
                     opt_param_scheduler.load_state_dict(state_dict["opt_param_scheduler"])
         except KeyError as e:
             print_rank_0(
                 "Unable to load optimizer from checkpoint {}. "
-                "Specify --no-load-optim or --finetune to prevent "
-                "attempting to load the optimizer state, "
-                "exiting ...".format(checkpoint_name)
+                "Specify load_optim=False or finetune=True to prevent "
+                "attempting to load the optimizer state.".format(checkpoint_name)
             )
             raise e
     else:
@@ -1293,22 +1351,21 @@ def _load_checkpoint_from_path(
                 optimizer.reload_model_params(state_dict=state_dict)
             else:
                 optimizer.reload_model_params()
-    # rerun state
-    try:
-        if "rerun_state_machine" in state_dict:
-            get_rerun_state_machine().load_state_dict(state_dict["rerun_state_machine"])
-    except Exception as e:
-        print(f"Unable to restore RerunMachine from checkpoint: {e}")
-        sys.exit()
 
-    # rng states.
-    if not release and not cfg.checkpoint.finetune and cfg.checkpoint.load_rng:
+    # Load rerun state
+    if not ignore_rerun_state:
+        try:
+            if "rerun_state_machine" in state_dict:
+                get_rerun_state_machine().load_state_dict(state_dict["rerun_state_machine"])
+        except Exception as e:
+            print(f"Unable to restore RerunMachine from checkpoint: {e}. Skipping.")
+            sys.exit()
+
+    # Load RNG states
+    if not release and not cfg.checkpoint.finetune and cfg.checkpoint.load_rng and not ignore_rng_state:
         try:
             if "rng_state" in state_dict:
-                # Handle different RNG state formats
-                if isinstance(state_dict["rng_state"], dict) and any(
-                    key.startswith("(") for key in state_dict["rng_state"]
-                ):
+                if ckpt_format == "fsdp_dtensor":
                     # FSDP DTensor format: {(pp_rank, tp_rank): rng_state_list}
                     tp_rank = mpu.get_tensor_model_parallel_rank()
                     pp_rank = mpu.get_pipeline_model_parallel_rank()
@@ -1316,26 +1373,25 @@ def _load_checkpoint_from_path(
                     if key in state_dict["rng_state"]:
                         rng_state_list = state_dict["rng_state"][key]
                     else:
-                        print_rank_0(f"WARNING: RNG state not found for TP/PP rank ({tp_rank}, {pp_rank})")
+                        print_rank_0("WARNING: RNG state not found for current TP/PP rank")
                         rng_state_list = next(iter(state_dict["rng_state"].values()))
-                    # access rng_state for data parallel rank
-                    if cfg.rng.data_parallel_random_init:
-                        rng_state = rng_state_list[mpu.get_data_parallel_rank()]
-                    else:
-                        rng_state = rng_state_list[0]
+                    rng_state = (
+                        rng_state_list[mpu.get_data_parallel_rank()]
+                        if cfg.rng.data_parallel_random_init
+                        else rng_state_list[0]
+                    )
                 else:
-                    # torch_dist format: ShardedObject or list
-                    # access rng_state for data parallel rank
-                    if cfg.rng.data_parallel_random_init:
-                        rng_state = state_dict["rng_state"][mpu.get_data_parallel_rank()]
-                    else:
-                        rng_state = state_dict["rng_state"][0]
+                    # torch_dist format: ShardedObject
+                    rng_state = (
+                        state_dict["rng_state"][mpu.get_data_parallel_rank()]
+                        if cfg.rng.data_parallel_random_init
+                        else state_dict["rng_state"][0]
+                    )
 
                 random.setstate(rng_state["random_rng_state"])
                 np.random.set_state(rng_state["np_rng_state"])
                 torch.set_rng_state(rng_state["torch_rng_state"])
                 torch.cuda.set_rng_state(rng_state["cuda_rng_state"])
-                # Check for empty states array
                 if not rng_state["rng_tracker_states"]:
                     raise KeyError
                 tensor_parallel.get_cuda_rng_tracker().set_states(rng_state["rng_tracker_states"])
@@ -1344,20 +1400,18 @@ def _load_checkpoint_from_path(
                 np.random.set_state(state_dict["np_rng_state"])
                 torch.set_rng_state(state_dict["torch_rng_state"])
                 torch.cuda.set_rng_state(state_dict["cuda_rng_state"])
-                # Check for empty states array
                 if not state_dict["rng_tracker_states"]:
                     raise KeyError
                 tensor_parallel.get_cuda_rng_tracker().set_states(state_dict["rng_tracker_states"])
         except KeyError:
             print_rank_0(
                 "Unable to load rng state from checkpoint {}. "
-                "Specify --no-load-rng or --finetune to prevent "
-                "attempting to load the rng state, "
-                "exiting ...".format(checkpoint_name)
+                "Specify load_rng=False or finetune=True to prevent "
+                "attempting to load the rng state.".format(checkpoint_name)
             )
             sys.exit()
 
-    # Some utilities want to load a checkpoint without distributed being initialized
+    # Final synchronization and logging
     if torch.distributed.is_initialized():
         torch.distributed.barrier()
 
@@ -1368,14 +1422,12 @@ def _load_checkpoint_from_path(
         f"at iteration {state.train_state.step}"
     )
 
-    # Additional callback for wandb (last rank)
     if not torch.distributed.is_initialized() or is_last_rank():
         wandb_utils.on_load_checkpoint_success(checkpoint_name, load_dir, state.wandb_logger)
 
     torch.cuda.empty_cache()
 
     if state.train_state.step > 0:
-        # Notify FT that a checkpoint was loaded.
         is_local_chkpt = ckpt_type == CheckpointType.LOCAL
         fault_tolerance.on_checkpoint_loaded(is_local_chkpt=is_local_chkpt, global_state=state)
 
@@ -1701,32 +1753,19 @@ def _load_base_checkpoint(
 
         return None, "", False, None
 
-    # Determine the type of the checkpoint
-    checkpoint_name_dir = get_checkpoint_name(load_dir, iteration, release)
-    is_dist_ckpt = dist_checkpointing.check_is_distributed_checkpoint(checkpoint_name_dir)
-
-    # Check for FSDP DTensor format (torch.distributed.checkpoint format)
-    is_fsdp_dtensor_ckpt = False
-    if not is_dist_ckpt:
-        # Check if this is an FSDP DTensor checkpoint
-        metadata_file = os.path.join(checkpoint_name_dir, ".metadata")
-        if file_exists(metadata_file):
-            is_fsdp_dtensor_ckpt = True
+    # Determine the checkpoint format
+    checkpoint_path = get_checkpoint_name(load_dir, iteration, release)
+    ckpt_format = _get_checkpoint_format(checkpoint_path)
 
     if not rank0:
-        if is_fsdp_dtensor_ckpt:
-            dist_infix = "FSDP DTensor "
-        elif is_dist_ckpt:
-            dist_infix = "distributed "
-        else:
-            dist_infix = ""
+        dist_infix = "distributed " if ckpt_format == "torch_dist" else ""
         if release:
             print_rank_0(f" loading release {dist_infix}checkpoint from {load_dir}")
         else:
             print_rank_0(f" loading {dist_infix}checkpoint from {load_dir} at iteration {iteration}")
 
     # Handle different checkpoint formats
-    if is_dist_ckpt:
+    if ckpt_format == "torch_dist":
         return _load_global_dist_base_checkpoint(
             load_dir,
             ckpt_cfg,
@@ -1736,7 +1775,7 @@ def _load_base_checkpoint(
             release,
             checkpointing_context=checkpointing_context,
         )
-    elif is_fsdp_dtensor_ckpt:
+    elif ckpt_format == "fsdp_dtensor":
         return _load_fsdp_dtensor_base_checkpoint(
             load_dir,
             ckpt_cfg,
@@ -1747,11 +1786,7 @@ def _load_base_checkpoint(
             checkpointing_context=checkpointing_context,
         )
     else:
-        # This path implies a non-distributed checkpoint, which is no longer supported.
-        # All checkpoints should now be distributed (either GLOBAL or LOCAL types).
-        raise RuntimeError(
-            "Loading non-distributed checkpoints is no longer supported. Please use distributed checkpointing formats."
-        )
+        raise NotImplementedError(f"Checkpoint format {ckpt_format} not supported")
 
 
 def _load_fsdp_dtensor_base_checkpoint(
@@ -1765,8 +1800,8 @@ def _load_fsdp_dtensor_base_checkpoint(
 ) -> tuple[dict[str, Any], str, bool, CheckpointType]:
     """Load the base state_dict from an FSDP DTensor checkpoint."""
     if rank0:
-        # For rank 0, just return metadata
-        return {}, get_checkpoint_name(load_dir, iteration, release), release, CheckpointType.GLOBAL
+        # For rank 0, return empty state dict (no common metadata for fsdp_dtensor)
+        return {}, get_checkpoint_name(load_dir, iteration, release), release, CheckpointType.FSDP_DTENSOR
 
     if not HAVE_MEGATRON_FSDP:
         raise RuntimeError("Megatron FSDP is required but not available for loading FSDP DTensor checkpoints.")
@@ -1778,28 +1813,23 @@ def _load_fsdp_dtensor_base_checkpoint(
     fs_storage_reader = torch.distributed.checkpoint.FileSystemReader(checkpoint_name)
 
     # Configure partial loading based on strict_fsdp_dtensor_load setting
-    allow_partial_load = not ckpt_cfg.strict_fsdp_dtensor_load
+    allow_partial_load = not getattr(ckpt_cfg, "strict_fsdp_dtensor_load", False)
     if allow_partial_load:
-        try:
-            state_dict_metadata = fs_storage_reader.read_metadata().state_dict_metadata
-            rank = torch.distributed.get_rank()
-            import time as _time
+        state_dict_metadata = fs_storage_reader.read_metadata().state_dict_metadata
+        rank = torch.distributed.get_rank()
+        import time as _time
 
-            _time.sleep(rank * 0.001)  # Prevent log overlap across ranks
-            print_diff_in_state_dicts(state_dict_metadata, sharded_state_dict)
-        except Exception as e:
-            print_rank_0(f"Warning: Could not read metadata for partial loading: {e}")
+        _time.sleep(rank * 0.001)  # Prevent log overlap across ranks
+        print_diff_in_state_dicts(state_dict_metadata, sharded_state_dict)
 
-    from torch.distributed.checkpoint import default_planner
-
-    planner = default_planner.DefaultLoadPlanner(allow_partial_load=allow_partial_load)
+    planner = torch.distributed.checkpoint.default_planner.DefaultLoadPlanner(allow_partial_load=allow_partial_load)
     torch.distributed.checkpoint.load_state_dict(
         state_dict=sharded_state_dict,
         storage_reader=fs_storage_reader,
         planner=planner,
     )
 
-    return sharded_state_dict, checkpoint_name, release, CheckpointType.GLOBAL
+    return sharded_state_dict, checkpoint_name, release, CheckpointType.FSDP_DTENSOR
 
 
 def _build_sharded_state_dict_metadata(
@@ -1855,1734 +1885,3 @@ def _get_train_state_from_state_dict(state_dict: dict[str, Any]) -> TrainState:
     legacy_train_state.do_valid = False
     legacy_train_state.do_test = False
     return legacy_train_state
-
-
-"""
-
-import contextlib
-import os
-import random
-import shutil
-import sys
-import threading
-from argparse import Namespace
-from enum import Enum, auto
-from logging import getLogger
-from pathlib import Path
-
-import numpy as np
-from time import time
-
-import torch
-from torch.distributed.checkpoint import default_planner, FileSystemReader
-
-from megatron.core import mpu, tensor_parallel, dist_checkpointing
-from megatron.core.dist_checkpointing.mapping import ShardedObject
-from megatron.core.dist_checkpointing.serialization import get_default_load_sharded_strategy
-from megatron.core.dist_checkpointing.strategies.fully_parallel import \
-    FullyParallelSaveStrategyWrapper, FullyParallelLoadStrategyWrapper
-from megatron.core.num_microbatches_calculator import update_num_microbatches
-from megatron.core.fp8_utils import is_float8tensor, dequantize_fp8_tensor
-from megatron.core.rerun_state_machine import get_rerun_state_machine
-from .async_utils import schedule_async_save, is_empty_async_queue
-from .global_vars import get_args
-from .utils import unwrap_model, print_rank_0, append_to_progress_log, is_last_rank
-from ..core.dist_checkpointing.serialization import \
-    get_default_save_sharded_strategy
-from .one_logger_utils import on_save_checkpoint_start, on_save_checkpoint_success
-from . import wandb_utils
-
-from . import ft_integration
-
-from megatron.core.msc_utils import MultiStorageClientFeature, open_file
-
-try:
-    from megatron.core.distributed.fsdp.src.megatron_fsdp.uneven_dtensor import preprocess_state_dict_for_uneven_dtensor
-    from megatron.core.transformer.fsdp_dtensor_checkpoint import (
-        handle_swiglu_in_state_dict,
-        handle_fp8_extra_state_case,
-        print_diff_in_state_dicts,
-    )
-    HAVE_MEGATRON_FSDP = True
-except ImportError:
-    HAVE_MEGATRON_FSDP = False
-
-
-# [ModelOpt]: Import
-try:
-    from modelopt.torch.opt.plugins import (
-        save_modelopt_state,
-        save_sharded_modelopt_state,
-        restore_modelopt_state,
-        restore_sharded_modelopt_state,
-    )
-    has_nvidia_modelopt = True
-except Exception:
-    has_nvidia_modelopt = False
-
-_CHECKPOINT_VERSION = None
-
-logger = getLogger(__name__)
-_NON_PERSISTENT_CKPT_SUBDIR = 'non_persistent'
-
-def set_checkpoint_version(value):
-    global _CHECKPOINT_VERSION
-    if _CHECKPOINT_VERSION is not None:
-        assert _CHECKPOINT_VERSION == value, \
-            "checkpoint versions do not match"
-    _CHECKPOINT_VERSION = value
-
-
-def get_checkpoint_version():
-    global _CHECKPOINT_VERSION
-    return _CHECKPOINT_VERSION
-
-
-def check_checkpoint_args(checkpoint_args):
-    args = get_args()
-
-    def _compare(arg_name, old_arg_name=None, default=None):
-        if old_arg_name is not None:
-            ckpt_arg_name = old_arg_name
-        else:
-            ckpt_arg_name = arg_name
-        if default is not None:
-            checkpoint_value = getattr(checkpoint_args, ckpt_arg_name, default)
-        else:
-            checkpoint_value = getattr(checkpoint_args, ckpt_arg_name)
-        args_value = getattr(args, arg_name)
-        error_message = '{} value from checkpoint ({}) is not equal to the ' \
-                        'input argument value ({}).'.format(
-                            arg_name, checkpoint_value, args_value)
-        assert checkpoint_value == args_value, error_message
-
-    _compare('num_layers')
-    _compare('hidden_size')
-    _compare('num_attention_heads')
-    _compare('add_position_embedding', default=True)
-    if args.vocab_file:
-        _compare('max_position_embeddings')
-        _compare('make_vocab_size_divisible_by')
-        if not args.use_dist_ckpt:
-            _compare('padded_vocab_size')
-        _compare('tokenizer_type')
-    if args.data_parallel_random_init:
-        _compare('data_parallel_random_init')
-    if get_checkpoint_version() < 3.0:
-        _compare('tensor_model_parallel_size',
-                 old_arg_name='model_parallel_size')
-    if get_checkpoint_version() >= 3.0 and not args.use_dist_ckpt:
-        _compare('tensor_model_parallel_size')
-        _compare('pipeline_model_parallel_size')
-
-
-def isfile(filename) -> bool:
-    if MultiStorageClientFeature.is_enabled():
-        msc = MultiStorageClientFeature.import_package()
-        return msc.os.path.isfile(filename)
-    else:
-        return os.path.isfile(filename)
-
-
-def ensure_directory_exists(filename, check_parent=True):
-    dirname = os.path.dirname(filename) if check_parent else filename
-    if MultiStorageClientFeature.is_enabled():
-        msc = MultiStorageClientFeature.import_package()
-        msc.os.makedirs(dirname, exist_ok=True)
-    else:
-        os.makedirs(dirname, exist_ok=True)
-
-
-def get_checkpoint_name(checkpoints_path, iteration, release=False,
-                        pipeline_parallel=None,
-                        tensor_rank=None, pipeline_rank=None,
-                        expert_parallel=None, expert_rank=None,
-                        return_base_dir=False, basename="model_optim_rng.pt"):
-    if release:
-        directory = 'release'
-    else:
-        directory = 'iter_{:07d}'.format(iteration)
-    if return_base_dir:
-        common_path = os.path.join(checkpoints_path, directory)
-        return common_path
-
-    # Use both the tensor and pipeline MP rank.
-    if pipeline_parallel is None:
-        pipeline_parallel = (mpu.get_pipeline_model_parallel_world_size() > 1)
-    if tensor_rank is None:
-        tensor_rank = mpu.get_tensor_model_parallel_rank()
-    if pipeline_rank is None:
-        pipeline_rank = mpu.get_pipeline_model_parallel_rank()
-    if expert_parallel is None:
-        expert_parallel = (mpu.get_expert_model_parallel_world_size() > 1)
-    if expert_rank is None:
-        expert_rank = mpu.get_expert_model_parallel_rank()
-
-    # Use both the tensor and pipeline MP rank. If using the distributed
-    # optimizer, then the optimizer's path must additionally include the
-    # data parallel rank.
-    if not pipeline_parallel:
-        common_path = os.path.join(checkpoints_path, directory,
-                            f'mp_rank_{tensor_rank:02d}')
-    else:
-        common_path = os.path.join(checkpoints_path, directory,
-                f'mp_rank_{tensor_rank:02d}_{pipeline_rank:03d}')
-
-    if expert_parallel:
-        common_path = common_path + f'_{expert_rank:03d}'
-
-    return os.path.join(common_path, basename)
-
-
-def get_load_checkpoint_path_by_args(args, load_arg="load"):
-    load_dir = getattr(args, load_arg)
-    iteration, release = -1, False
-    tracker_filename = 'because load directory is not defined'
-    if load_dir is not None:
-        tracker_filename = get_checkpoint_tracker_filename(load_dir)
-        if isfile(tracker_filename):
-            iteration, release = read_metadata(tracker_filename)
-
-    # Allow user to specify the loaded iteration.
-    if getattr(args, "ckpt_step", None):
-        iteration = args.ckpt_step
-
-    return get_checkpoint_name(load_dir, iteration, release, return_base_dir=True)
-
-
-def get_distributed_optimizer_checkpoint_name(model_checkpoint_name):
-    return os.path.join(os.path.dirname(model_checkpoint_name),
-                        "distrib_optim.pt")
-
-
-def find_checkpoint_rank_0(checkpoints_path, iteration, release=False):
-
-    # Look for checkpoint with no pipelining and no expert parallelism
-    filename = get_checkpoint_name(checkpoints_path, iteration, release,
-                                   pipeline_parallel=False,
-                                   tensor_rank=0, pipeline_rank=0,
-                                   expert_parallel=False, expert_rank=0)
-    if isfile(filename):
-        return filename
-
-    # Look for checkpoint with no pipelining and expert parallelism
-    filename = get_checkpoint_name(checkpoints_path, iteration, release,
-                                   pipeline_parallel=False,
-                                   tensor_rank=0, pipeline_rank=0,
-                                   expert_parallel=True, expert_rank=0)
-    if isfile(filename):
-        return filename
-
-    # Look for checkpoint with pipelining and no expert parallelism
-    filename = get_checkpoint_name(checkpoints_path, iteration, release,
-                                   pipeline_parallel=True,
-                                   tensor_rank=0, pipeline_rank=0,
-                                   expert_parallel=False, expert_rank=0)
-    if isfile(filename):
-        return filename
-
-    # Look for checkpoint with pipelining and expert parallelism
-    filename = get_checkpoint_name(checkpoints_path, iteration, release,
-                                   pipeline_parallel=True,
-                                   tensor_rank=0, pipeline_rank=0,
-                                   expert_parallel=True, expert_rank=0)
-    if isfile(filename):
-        return filename
-
-    # Look for a distributed checkpoint
-    filename = get_checkpoint_name(checkpoints_path, iteration, release,
-                                   pipeline_parallel=True,
-                                   return_base_dir=True)
-    if dist_checkpointing.check_is_distributed_checkpoint(filename):
-        return filename
-
-    return None
-
-
-def get_checkpoint_tracker_filename(checkpoints_path):
-    return os.path.join(checkpoints_path, 'latest_checkpointed_iteration.txt')
-
-
-def checkpoint_exists(checkpoints_path):
-    if checkpoints_path is None:
-        return False
-    path = get_checkpoint_tracker_filename(checkpoints_path)
-    return isfile(path)
-
-
-def read_metadata(tracker_filename):
-    # Read the tracker file and either set the iteration or
-    # mark it as a release checkpoint.
-    iteration = 0
-    release = False
-
-    with open_file(tracker_filename, 'r') as f:
-        metastring = f.read().strip()
-        try:
-            iteration = int(metastring)
-        except ValueError:
-            release = metastring == 'release'
-            if not release:
-                print_rank_0('ERROR: Invalid metadata file {}. Exiting'.format(
-                    tracker_filename))
-                sys.exit()
-    assert iteration > 0 or release, 'error parsing metadata file {}'.format(
-        tracker_filename)
-
-    # Get the max iteration retrieved across the ranks.
-    if torch.distributed.is_initialized():
-        iters_cuda = torch.tensor([iteration], dtype=torch.long, device='cuda')
-        torch.distributed.all_reduce(iters_cuda, op=torch.distributed.ReduceOp.MAX)
-        max_iter = iters_cuda[0].item()
-
-        # We should now have all the same iteration.
-        # If not, print a warning and chose the maximum
-        # iteration across all ranks.
-        if iteration != max_iter:
-            rank = torch.distributed.get_rank()
-            print('WARNING: on rank {} found iteration {} in the '
-                  'metadata while max iteration across the ranks '
-                  'is {}, replacing it with max iteration.'.format(
-                      rank, iteration, max_iter), flush=True)
-    else:
-        # When loading a checkpoint outside of training (for example,
-        # when editing it), we might not have torch distributed
-        # initialized, in this case, just assume we have the latest
-        max_iter = iteration
-    return max_iter, release
-
-
-def get_rng_state(ckpt_format: str):
-    args = get_args()
-    rng_state = {
-        'random_rng_state': random.getstate(),
-        'np_rng_state': np.random.get_state(),
-        'torch_rng_state': torch.get_rng_state(),
-        'cuda_rng_state': torch.cuda.get_rng_state(),
-        'rng_tracker_states': tensor_parallel.get_cuda_rng_tracker().get_states()}
-
-    rng_state_list = None
-    if args.data_parallel_random_init and torch.distributed.is_initialized() and \
-            mpu.get_data_parallel_world_size() > 1:
-        rng_state_list = \
-            [None for i in range(mpu.get_data_parallel_world_size())]
-        torch.distributed.all_gather_object(
-            rng_state_list,
-            rng_state,
-            group=mpu.get_data_parallel_group())
-    else:
-        rng_state_list = [rng_state]
-
-    if ckpt_format == "torch_dist":
-        pp_rank = mpu.get_pipeline_model_parallel_rank()
-        pp_size = mpu.get_pipeline_model_parallel_world_size()
-        tp_rank = mpu.get_tensor_model_parallel_rank()
-        tp_size = mpu.get_tensor_model_parallel_world_size()
-        rng_state_list = ShardedObject('rng_state', rng_state_list, (pp_size, tp_size), (pp_rank, tp_rank),
-                                       replica_id=mpu.get_data_parallel_rank(with_context_parallel=True))
-    elif ckpt_format == "fsdp_dtensor":
-        pp_rank = mpu.get_pipeline_model_parallel_rank()
-        tp_rank = mpu.get_tensor_model_parallel_rank()
-        rng_state_list = {
-            f"({pp_rank}, {tp_rank})": rng_state_list
-        }
-
-    return rng_state_list
-
-class CheckpointType(Enum):
-    LEGACY = auto()
-    LOCAL = auto()
-    GLOBAL = auto()
-    TORCH_DCP = auto()
-    FSDP_DTENSOR = auto()
-
-def _build_sharded_state_dict_metadata(args: Namespace) -> dict:
-    metadata = {}
-    if args.use_distributed_optimizer:
-        if args.ckpt_format == "fsdp_dtensor":
-            metadata['distrib_optim_sharding_type'] = 'fsdp_dtensor'
-        elif args.ckpt_fully_parallel_save:
-            metadata['distrib_optim_sharding_type'] = 'fully_sharded_model_space'
-        else:
-            metadata['distrib_optim_sharding_type'] = 'dp_zero_gather_scatter'
-
-        # TODO (v0.14): this is the intended metadata logic after fully switching to simplistic
-        #  format. For now it's disabled, will be enabled after completing the ckpt refactor
-        if args.ckpt_pre_mcore_014:
-            metadata['singleton_local_shards'] = False
-            metadata['unpadded_embeddings'] = False
-            if args.use_distributed_optimizer:
-                if args.ckpt_fully_parallel_save:
-                    metadata['distrib_optim_sharding_type'] = 'fully_sharded_model_space'
-                else:
-                    metadata['distrib_optim_sharding_type'] = 'dp_zero_gather_scatter'
-        else:
-            metadata['singleton_local_shards'] = True
-            metadata['unpadded_embeddings'] = True
-            if args.use_distributed_optimizer:
-                if args.ckpt_optim_fully_reshardable:
-                    metadata['distrib_optim_sharding_type'] = 'fully_reshardable'
-                    # TODO: add a separate flag and based on this flag raise if gloo groups
-                    # are not created in arguments.py
-                    metadata['distrib_optim_fully_reshardable_mem_efficient'] = False
-                else:
-                    metadata['distrib_optim_sharding_type'] = 'dp_reshardable'
-    metadata['chained_optim_avoid_prefix'] = True
-    metadata['singleton_local_shards'] = False
-    return metadata
-
-def save_checkpoint(iteration, model, optimizer, opt_param_scheduler, num_floating_point_operations_so_far,
-                    checkpointing_context=None, pipeline_rank=None, expert_rank=None, tensor_rank=None, pipeline_parallel=None, expert_parallel=None, non_persistent_ckpt=False,
-                    train_data_iterator=None, preprocess_common_state_dict_fn = None):
-    start_ckpt = time()
-    args = get_args()
-
-    if args.async_save and not is_empty_async_queue():
-        print_rank_0('WARNING: Starting a checkpoint save before previous has finished. Consider increasing the checkpoint interval.')
-
-    # Prepare E2E metrics at start of save checkpoint
-    productive_metrics = on_save_checkpoint_start(args.async_save)
-
-    # Monitor for the checkpointing timeout (no-op if FT is not enabled)
-    ft_integration.on_checkpointing_start()
-
-    # Only rank zero of the data parallel writes to the disk.
-    model = unwrap_model(model)
-
-    # Handle non_persistent_ckpt flag. Besides overwriting `args.save` and
-    # `args.use_dist_ckpt`, non-persistent global ckpt requires no additional logic
-    ckpt_type = CheckpointType.GLOBAL if args.use_dist_ckpt else CheckpointType.LEGACY
-    save_dir = args.save
-    if non_persistent_ckpt:
-        if args.non_persistent_ckpt_type == 'global':
-            ckpt_type = CheckpointType.GLOBAL
-            save_dir = (
-                args.non_persistent_global_ckpt_dir
-                if args.non_persistent_global_ckpt_dir
-                else os.path.join(save_dir, _NON_PERSISTENT_CKPT_SUBDIR)
-            )
-            # TODO Can we ensure the previous checkpoint is saved? We don't want to allow two saves in parallel.
-            cleanup_old_non_persistent_checkpoint(
-                save_dir, leave_ckpt_num=1, do_async=args.async_save
-            )
-        elif args.non_persistent_ckpt_type == 'local':
-            ckpt_type = CheckpointType.LOCAL
-            save_dir = checkpointing_context['local_checkpoint_manager'].local_ckpt_dir
-        else:
-            raise NotImplementedError(f"Please use local or global non-persistent checkpoints (got: {args.non_persistent_ckpt_type})")
-
-    ckpt_format = args.ckpt_format if ckpt_type == CheckpointType.GLOBAL else 'torch'
-    print_rank_0('saving checkpoint at iteration {:7d} to {} in {} format'.format(
-        iteration, save_dir, ckpt_format))
-
-    # Collect rng state across data parallel ranks.
-    rng_state = get_rng_state(args.ckpt_format)
-
-    # Collect rerun state across all ranks
-    rerun_state_machine = get_rerun_state_machine()
-    rerun_state = rerun_state_machine.state_dict(
-        data_iterator=train_data_iterator, ckpt_format=args.ckpt_format,
-    )
-
-    # Checkpoint name.
-    return_base_dir = (ckpt_type != CheckpointType.LEGACY)
-    checkpoint_name = get_checkpoint_name(save_dir, iteration, release=False, pipeline_parallel=pipeline_parallel,
-        tensor_rank=tensor_rank, pipeline_rank=pipeline_rank, expert_parallel=expert_parallel, expert_rank=expert_rank, return_base_dir=return_base_dir)
-
-    # Save dataloader state if the dataloader supports it (currently only Megatron Energon).
-    maybe_save_dataloader_state(train_data_iterator, iteration, getattr(args, "dataloader_save", None))
-
-    # Save distributed optimizer's custom parameter state.
-    if (
-        args.use_distributed_optimizer
-        and not args.no_save_optim
-        and optimizer is not None
-        and ckpt_type == CheckpointType.LEGACY
-    ):
-        optim_checkpoint_name = \
-            get_distributed_optimizer_checkpoint_name(checkpoint_name)
-        ensure_directory_exists(optim_checkpoint_name)
-        if not optimizer.is_stub_optimizer:
-            optimizer.save_parameter_state(optim_checkpoint_name)
-
-    async_save_request = None
-    if args.async_save:
-        if ckpt_type == CheckpointType.LEGACY:
-            raise NotImplementedError('Async checkpoint save not implemented for legacy checkpoints')
-        elif ckpt_type == CheckpointType.GLOBAL and args.ckpt_format != 'torch_dist':
-            raise NotImplementedError(f'Async checkpoint save not implemented for {args.ckpt_format} distributed checkpoint format')
-
-    rank = torch.distributed.get_rank() if torch.distributed.is_initialized() else 0
-
-    # Collect args, model, RNG.
-    if not torch.distributed.is_initialized() \
-            or mpu.get_expert_data_parallel_rank() == 0 \
-            or ckpt_type != CheckpointType.LEGACY:
-        if ckpt_type != CheckpointType.LEGACY:
-            sharded_sd_metadata = _build_sharded_state_dict_metadata(args)
-            if args.use_distributed_optimizer:
-                print_rank_0(f'Storing distributed optimizer sharded state of type'
-                             f' {sharded_sd_metadata["distrib_optim_sharding_type"]}')
-        else:
-            sharded_sd_metadata = None
-        state_dict = generate_state_dict(
-            args,
-            model,
-            optimizer,
-            opt_param_scheduler,
-            rng_state,
-            iteration=iteration,
-            optim_sd_kwargs=dict(metadata=sharded_sd_metadata),
-            model_sd_kwargs=dict(metadata=sharded_sd_metadata),
-            rerun_state=rerun_state,
-        )
-
-        state_dict['num_floating_point_operations_so_far'] = num_floating_point_operations_so_far
-        if ckpt_type == CheckpointType.GLOBAL and ckpt_format == "torch_dist":
-            if not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0:
-                # TODO Handle non-empty directories (e.g., after a crash during saving).
-                ensure_directory_exists(checkpoint_name, check_parent=False)
-            if checkpointing_context is not None and 'save_strategy' in checkpointing_context:
-                save_strategy = checkpointing_context['save_strategy']
-                # Already saved once before - don't need to rerun sharding validation
-                validate_sharding_integrity = not args.ckpt_assume_constant_structure
-            else:
-                validate_sharding_integrity = True
-                save_strategy = get_default_save_sharded_strategy(args.ckpt_format)
-                if args.ckpt_assume_constant_structure and args.ckpt_format == 'torch_dist':
-                    save_strategy.use_cached_ckpt_structure = args.ckpt_assume_constant_structure
-                    if checkpointing_context is not None and 'load_strategy' in checkpointing_context:
-                        cached_global_metadata = getattr(checkpointing_context['load_strategy'], 'cached_global_metadata', None)
-                        if cached_global_metadata is not None:
-                            logger.debug("Plugging in the read metadata from the load strategy...")
-                            save_strategy.cached_global_metadata = cached_global_metadata
-                        else:
-                            logger.debug("Failed to plug in the read metadata from the load strategy...")
-
-                if args.ckpt_fully_parallel_save:
-                    save_strategy = FullyParallelSaveStrategyWrapper(save_strategy, mpu.get_data_parallel_group(with_context_parallel=True),
-                                                                     args.ckpt_assume_constant_structure)
-            # Store save strategy for future checkpoint saves
-            if checkpointing_context is not None:
-                checkpointing_context['save_strategy'] = save_strategy
-            end_ckpt = time()
-            logger.debug(f"rank: {rank}, takes {end_ckpt - start_ckpt} to prepare state dict for ckpt ")
-            async_save_request = dist_checkpointing.save(state_dict, checkpoint_name, save_strategy,
-                                                         async_sharded_save=args.async_save,
-                                                         validate_access_integrity=validate_sharding_integrity,
-                                                         preprocess_common_before_consistancy_check=preprocess_common_state_dict_fn,
-                                                         content_metadata=sharded_sd_metadata)
-            # [ModelOpt]: save sharded modelopt_state
-            if has_nvidia_modelopt:
-                save_sharded_modelopt_state(model, checkpoint_name, (args.ckpt_format, 1))
-        elif ckpt_type == CheckpointType.GLOBAL and ckpt_format in ["torch_dcp", "fsdp_dtensor"]:
-            if not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0:
-                # TODO Handle non-empty directories (e.g., after a crash during saving).
-                ensure_directory_exists(checkpoint_name, check_parent=False)
-
-            fs_storage_writer = torch.distributed.checkpoint.FileSystemWriter(checkpoint_name)
-            torch.distributed.checkpoint.save(
-                state_dict=state_dict,
-                storage_writer=fs_storage_writer,
-            )
-        else:
-            # [ModelOpt]: Inject modelopt_state into state_dict
-            if has_nvidia_modelopt:
-                if ckpt_type == CheckpointType.LOCAL:
-                    print_rank_0('WARNING: Local checkpointing does not support nvidia_modelopt.')
-                else:
-                    save_modelopt_state(model, state_dict)
-
-            end_ckpt = time()
-            logger.debug(f"rank: {rank}, takes {end_ckpt - start_ckpt} to prepare state dict for ckpt ")
-            if ckpt_type == CheckpointType.LOCAL:
-                try:
-                    from megatron.core.dist_checkpointing.tensor_aware_state_dict import MCoreTensorAwareStateDict
-                except ModuleNotFoundError:
-                    raise RuntimeError("The 'nvidia_resiliency_ext' module is required for local "
-                                       "checkpointing but was not found. Please ensure it is installed.")
-                if (sharded_sd_metadata or {}).get('distrib_optim_sharding_type') in ['fully_reshardable', 'dp_zero_gather_scatter']:
-                    # Note: Currently full reshardabilty is not supported when local checkpoints are used.
-                    raise RuntimeError(
-                        f"Local checkpointing does not support optimizer sharding type '{sharded_sd_metadata['distrib_optim_sharding_type']}'. "
-                        "Use '--ckpt-fully-parallel-save' when saving local checkpoints."
-                    )
-                algo = args.non_persistent_local_ckpt_algo
-                cached_metadata = None
-                if args.ckpt_assume_constant_structure and 'local_checkpoint_cache' in checkpointing_context:
-                    cached_metadata = checkpointing_context['local_checkpoint_cache']
-                state_dict_for_save, cacheable_metadata = MCoreTensorAwareStateDict.from_state_dict(
-                    state_dict, algo=algo, cached_metadata=cached_metadata,
-                    parallelization_group=mpu.get_data_parallel_group(with_context_parallel=True)
-                )
-                async_save_request = checkpointing_context['local_checkpoint_manager'].save(
-                    state_dict_for_save, iteration, is_async=bool(args.async_save)
-                )
-                checkpointing_context['local_checkpoint_cache'] = cacheable_metadata
-            else:
-                assert ckpt_type == CheckpointType.LEGACY
-                # Save.
-                ensure_directory_exists(checkpoint_name)
-                torch.save(state_dict, checkpoint_name)
-    start_misc = time()
-    if ckpt_type != CheckpointType.LOCAL:
-        if not args.async_save:
-            assert async_save_request is None
-            # Wait so everyone is done (necessary)
-            if torch.distributed.is_initialized():
-                torch.distributed.barrier()
-
-    # And update the latest iteration
-    if not torch.distributed.is_initialized() \
-            or torch.distributed.get_rank() == 0:
-        tracker_filename = get_checkpoint_tracker_filename(save_dir)
-
-        if ckpt_type == CheckpointType.LOCAL:
-            def iter_finalize_fn():
-                print_rank_0('  successfully saved local checkpoint from iteration {:7d}'
-                             .format(iteration))
-                if args.log_progress and args.async_save:
-                    append_to_progress_log(f'Saved async local checkpoint\tIteration: {iteration}',
-                                           barrier=False)
-        else:
-            def iter_finalize_fn():
-                prev_iteration = 0
-                save_retain_interval = getattr(args, 'save_retain_interval', None)  # For backwards compatibility of tests.
-                if save_retain_interval is not None:
-                    if os.path.exists(tracker_filename):  # TODO: Make this work with MSC remote paths?
-                        with open_file(tracker_filename, 'r') as f:
-                            prev_iteration = int(f.read().strip())
-                with open_file(tracker_filename, 'w') as f:
-                    f.write(str(iteration))
-                tensor_rank_to_print = (tensor_rank if tensor_rank is not None else mpu.get_tensor_model_parallel_rank()) + 1
-                pipeline_rank_to_print = (pipeline_rank if pipeline_rank is not None else mpu.get_pipeline_model_parallel_rank()) + 1
-                print_rank_0(f'  successfully saved checkpoint from iteration {int(iteration):7d} to {args.save} '
-                             f'[ t {tensor_rank_to_print}/{mpu.get_tensor_model_parallel_world_size()}, '
-                             f'p {pipeline_rank_to_print}/{mpu.get_pipeline_model_parallel_world_size()} ]')
-                if args.log_progress and args.async_save:
-                    append_to_progress_log(f'Saved async checkpoint\tIteration: {iteration}',
-                                           barrier=False)
-
-                def delete_checkpoint(args, iteration_to_delete):
-                    checkpoint_name = get_checkpoint_name(args.save, iteration=iteration_to_delete,
-                                                          return_base_dir=True)
-                    try:
-                        shutil.rmtree(checkpoint_name)  # TODO: Make this work with MSC remote paths?
-                        print_rank_0(f'  successfully deleted checkpoint from iteration {iteration_to_delete:7d} '
-                                     f'at {args.save}')
-                        if args.log_progress:
-                            append_to_progress_log(f'Deleted checkpoint\tIteration: {iteration_to_delete}', barrier=False)
-                    except Exception as e:
-                        print_rank_0(f'  encountered exception "{e}" when trying to delete checkpoint from '
-                                     f'iteration {iteration_to_delete:7d} at {args.save}')
-                        # Any exception encountered in checkpoint deletion can be ignored and is not fatal.
-                        pass
-
-                if save_retain_interval is not None:
-                    if prev_iteration > 0 and prev_iteration != iteration and prev_iteration % save_retain_interval != 0:
-                        checkpoint_name = get_checkpoint_name(args.save, iteration=prev_iteration,
-                                                              return_base_dir=True)
-                        # Don't delete if `checkpoint_name` is a symbolic link.
-                        if os.path.islink(checkpoint_name):  # TODO: Make this work with MSC remote paths?
-                            print_rank_0(f'  skipping deleting checkpoint from iteration {prev_iteration:7d} '
-                                         f'at {args.save} since it is a symbolic link')
-                        else:
-                            # Asynchronous version of delete_checkpoint(args, iteration_to_delete=prev_iteration).
-                            threading.Thread(target=delete_checkpoint, args=(args, prev_iteration,)).start()
-
-        if args.async_save:
-            assert async_save_request is not None
-            async_save_request.add_finalize_fn(iter_finalize_fn)
-        else:
-            iter_finalize_fn()
-
-    # Additional callback for one_logger (last rank)
-    if not torch.distributed.is_initialized() \
-       or is_last_rank():
-        def onelogger_finalize_fn():
-            on_save_checkpoint_success(productive_metrics, args.async_save)
-        if args.async_save:
-            assert async_save_request is not None
-            async_save_request.add_finalize_fn(onelogger_finalize_fn)
-        else:
-            onelogger_finalize_fn()
-
-    # Additional callback for wandb (last rank)
-    if not torch.distributed.is_initialized() \
-       or is_last_rank():
-        def wandb_finalize_fn():
-            wandb_utils.on_save_checkpoint_success(checkpoint_name, get_checkpoint_tracker_filename(save_dir), save_dir, iteration)
-        if args.async_save:
-            assert async_save_request is not None
-            async_save_request.add_finalize_fn(wandb_finalize_fn)
-        else:
-            wandb_finalize_fn()
-
-    if args.async_save:
-        schedule_async_save(async_save_request)
-        print_rank_0('  scheduled an async checkpoint save at iteration {:7d} to {}' \
-                     .format(iteration, save_dir))
-
-    # Wait so everyone is done (not necessary)
-    if torch.distributed.is_initialized():
-        torch.distributed.barrier()
-
-    end_misc = time()
-    logger.debug(f"rank: {rank}, takes {end_misc - start_misc} to finalize ckpt save ")
-
-    ft_integration.on_checkpointing_end(is_async_finalization=False)
-
-def cleanup_old_non_persistent_checkpoint(save_dir, leave_ckpt_num=1, do_async=False):
-    if torch.distributed.is_initialized() and torch.distributed.get_rank() != 0:
-        return
-    save_dir = Path(save_dir)
-
-    iter_prefix = "iter_"
-    iter_ckpts = save_dir.rglob(f'{iter_prefix}*')
-    sorted_iter_ckpts = sorted(iter_ckpts, key=lambda ckpt_name: int(ckpt_name.name[len(iter_prefix):]))
-    if not sorted_iter_ckpts:
-        return
-    rm_iter_ckpts = sorted_iter_ckpts[:-leave_ckpt_num]
-    print_rank_0(f'Non-persistent checkpoints scheduled for removal: {rm_iter_ckpts}')
-    print_rank_0(f'Non-persistent checkpoints to be kept: {sorted_iter_ckpts[-leave_ckpt_num:]}')
-
-    def remove_iter_ckpts(_iter_ckpts):
-        for ckpt in _iter_ckpts:
-            shutil.rmtree(ckpt)
-    if do_async:
-        threading.Thread(target=remove_iter_ckpts, args=(rm_iter_ckpts,)).start()
-    else:
-        remove_iter_ckpts(rm_iter_ckpts)
-
-
-def maybe_save_dataloader_state(train_iterator, iteration, dataloader_save_path):
-    # If no dataloader or saving path is provided, exit early, otherwise, raise an error.
-    if train_iterator is None or dataloader_save_path is None or dataloader_save_path == "":
-        return
-
-    # If dataloader doesn't support saving state, raise an error.
-    if not hasattr(train_iterator.iterable, "save_state"):
-        raise RuntimeError(f"Could not find a save_state for the train_iterator of type {type(train_iterator)}")
-
-    # Save dataloader state for each data parallel rank only once.
-    first_rank = mpu.is_pipeline_first_stage(ignore_virtual=True) and mpu.get_tensor_model_parallel_rank() == 0
-    if not first_rank:
-        return
-
-    dp_rank = mpu.get_data_parallel_rank()
-    print(f"saving dataloader checkpoint at iteration {iteration} to {dataloader_save_path}")
-    train_dataloader_state_dict = train_iterator.iterable.save_state()
-    data_state_save_path = get_checkpoint_name(
-        dataloader_save_path, iteration,
-        basename=f'train_dataloader_dprank{dp_rank:03d}.pt'
-    )
-
-    torch.distributed.barrier(group=mpu.get_data_parallel_group())
-
-    if mpu.get_data_parallel_rank() == 0:
-        ensure_directory_exists(data_state_save_path)
-
-    torch.distributed.barrier(group=mpu.get_data_parallel_group())
-
-    dataloader_save_dict = {}
-    dataloader_save_dict['dataloader_state_dict'] = train_dataloader_state_dict
-    torch.save(dataloader_save_dict, data_state_save_path)
-
-
-def generate_state_dict(args, model, optimizer, opt_param_scheduler,
-                        rng_state, iteration=None,
-                        optim_sd_kwargs=None, model_sd_kwargs=None, rerun_state=None):
-
-    # Arguments, iteration, and model.
-    state_dict = {}
-    state_dict['args'] = args
-    state_dict['checkpoint_version'] = 3.0
-    if iteration is not None:
-        state_dict['iteration'] = iteration
-
-    for i in range(len(model)):
-        key = "model"
-        if len(model) > 1:
-            key = f"model{i}"
-
-        if args.ckpt_format == "torch_dist":
-            model_sd = model[i].sharded_state_dict(**(model_sd_kwargs or {}))
-        else:   # torch, torch_dcp, fsdp_dtensor
-            model_sd = model[i].state_dict_for_save_checkpoint()
-
-        state_dict[key] = model_sd
-
-    # Optimizer stuff.
-    if not args.no_save_optim:
-        if optimizer is not None and not optimizer.is_stub_optimizer:
-            optimizer_sd = None
-
-            if args.ckpt_format == "torch_dist":
-                optimizer_sd = optimizer.sharded_state_dict(state_dict, **(optim_sd_kwargs or {}))
-            elif args.ckpt_format == "fsdp_dtensor":
-                if optim_sd_kwargs is None:
-                    optim_sd_kwargs = {}
-                if "metadata" not in optim_sd_kwargs:
-                    optim_sd_kwargs["metadata"] = {}
-                optim_sd_kwargs['metadata'].update(_build_sharded_state_dict_metadata(args))
-                optimizer_sd = optimizer.sharded_state_dict(state_dict, **optim_sd_kwargs)
-            else:
-                optimizer_sd = optimizer.state_dict()
-
-            state_dict['optimizer'] = optimizer_sd
-
-        if opt_param_scheduler is not None:
-            state_dict['opt_param_scheduler'] = \
-                opt_param_scheduler.state_dict()
-
-    # Rerun state
-    if rerun_state:
-        state_dict['rerun_state_machine'] = rerun_state
-
-    # RNG states.
-    if not args.no_save_rng and rng_state:
-        state_dict["rng_state"] = rng_state
-
-    # fsdp_dtensor ckpt specific state dict preprocessing
-    if args.ckpt_format == "fsdp_dtensor":
-        assert HAVE_MEGATRON_FSDP, "Megatron FSDP is enabled but Megatron-FSDP is not available."
-        assert len(model) == 1, "FSDP DTensor checkpoints are not supported for multiple models."
-        if args.swiglu:
-            state_dict = state_dict.copy()
-            handle_swiglu_in_state_dict(
-                model[0], state_dict["model"], state_dict["optimizer"])
-        handle_fp8_extra_state_case(state_dict["model"])
-        preprocess_state_dict_for_uneven_dtensor(state_dict)
-
-    return state_dict
-
-
-def _transpose_first_dim(t, num_splits, num_splits_first, model):
-    input_shape = t.size()
-    # We use a self_attention module but the values extracted aren't
-    # specific to self attention so should work for cross attention as well
-    while hasattr(model, 'module'):
-        model = model.module
-    attention_module = model.language_model.encoder.layers[0].self_attention
-    hidden_size_per_attention_head = attention_module.hidden_size_per_attention_head
-    num_attention_heads_per_partition = attention_module.num_attention_heads_per_partition
-    if num_splits_first:
-        intermediate_shape = \
-            (num_splits, num_attention_heads_per_partition,
-             hidden_size_per_attention_head) + input_shape[1:]
-
-        t = t.view(*intermediate_shape)
-        t = t.transpose(0, 1).contiguous()
-    else:
-        intermediate_shape = \
-            (num_attention_heads_per_partition,
-             hidden_size_per_attention_head, num_splits) +\
-             input_shape[1:]
-
-        t = t.view(*intermediate_shape)
-        t = t.transpose(1, 2).contiguous()
-    t = t.view(*input_shape)
-
-    return t
-
-
-def fix_query_key_value_ordering(model, checkpoint_version):
-    if checkpoint_version < 2.0:
-        if isinstance(model, list):
-            assert len(model)==1
-            model = model[0]
-        for name, param in model.named_parameters():
-            if name.endswith(('.query_key_value.weight', '.query_key_value.bias')):
-                if checkpoint_version == 0:
-                    fixed_param = _transpose_first_dim(param.data, 3, True, model)
-                elif checkpoint_version == 1.0:
-                    fixed_param = _transpose_first_dim(param.data, 3, False, model)
-                else:
-                    print_rank_0(f"Invalid checkpoint version {checkpoint_version}.")
-                    sys.exit()
-                param.data.copy_(fixed_param)
-            if name.endswith(('.key_value.weight', '.key_value.bias')):
-                if checkpoint_version == 0:
-                    fixed_param = _transpose_first_dim(param.data, 2, True, model)
-                elif checkpoint_version == 1.0:
-                    fixed_param = _transpose_first_dim(param.data, 2, False, model)
-                else:
-                    print_rank_0(f"Invalid checkpoint version {checkpoint_version}.")
-                    sys.exit()
-                param.data.copy_(fixed_param)
-        print_rank_0(" successfully fixed query-key-values ordering for"
-                     " checkpoint version {}".format(checkpoint_version))
-
-
-def _get_non_persistent_iteration(non_persistent_global_dir, args, checkpointing_context=None):
-    if args.non_persistent_ckpt_type is None:
-        return -1
-    elif args.non_persistent_ckpt_type == "global":
-        tracker_filename = get_checkpoint_tracker_filename(non_persistent_global_dir)
-        if isfile(tracker_filename):
-            iteration, release = read_metadata(tracker_filename)
-            if release:
-                raise RuntimeError('Non-persistent checkpoint can\'t be a release checkpoint')
-        else:
-            iteration = -1
-            print_rank_0('WARNING: could not find the metadata file {}'.format(tracker_filename))
-            print_rank_0('    will not load any non-persistent checkpoint')
-        return iteration
-    elif args.non_persistent_ckpt_type == "local":
-        return checkpointing_context['local_checkpoint_manager'].find_latest()
-    else:
-        assert False, 'Please use local or global non-persistent checkpoints' \
-            f'(got: {args.non_persistent_ckpt_type})'
-
-
-def _load_non_persistent_base_checkpoint(
-    non_persistent_global_dir,
-    args,
-    rank0,
-    sharded_state_dict,
-    non_persistent_iteration,
-    checkpointing_context=None,
-):
-    assert args.non_persistent_ckpt_type is not None
-    if args.non_persistent_ckpt_type == "global":
-        if not rank0:
-            print_rank_0(
-                f'Loading from a non-persistent checkpoint (non-persistent iter {non_persistent_iteration})'
-            )
-        return _load_global_dist_base_checkpoint(
-            non_persistent_global_dir, args, rank0, sharded_state_dict, non_persistent_iteration, False,
-            checkpointing_context=checkpointing_context
-        )
-    elif args.non_persistent_ckpt_type == "local":
-        intermediate_state_dict, checkpoint_name = checkpointing_context[
-            'local_checkpoint_manager'
-        ].load()
-        state_dict = intermediate_state_dict.to_state_dict(
-            sharded_state_dict,
-            algo=args.non_persistent_local_ckpt_algo,
-            parallelization_group = mpu.get_data_parallel_group(with_context_parallel=True)
-        )
-        return state_dict, checkpoint_name, False, CheckpointType.LOCAL
-    else:
-        raise NotImplementedError(f"Please use local or global non-persistent checkpoints (got: {args.non_persistent_ckpt_type})")
-
-
-def _load_global_dist_base_checkpoint(
-    load_dir, args, rank0, sharded_state_dict, iteration, release, checkpointing_context=None
-):
-    if rank0:
-        checkpoint_name = find_checkpoint_rank_0(load_dir, iteration, release)
-        state_dict = dist_checkpointing.load_common_state_dict(checkpoint_name)
-        return state_dict, checkpoint_name, release, CheckpointType.GLOBAL
-
-    if sharded_state_dict is None:
-        assert not args.auto_detect_ckpt_format and not args.use_dist_ckpt, (
-            args.auto_detect_ckpt_format,
-            args.use_dist_ckpt,
-        )
-        raise RuntimeError(
-            'Detected load from a distributed checkpoint, but neither --use-dist-ckpt nor --auto-detect-ckpt-format is set.'
-        )
-
-    checkpoint_name = get_checkpoint_name(load_dir, iteration, release, return_base_dir=True)
-    load_strategy = get_default_load_sharded_strategy(checkpoint_name)
-    # NOTE: `args.ckpt_fully_parallel_load` applies to both persistent and non-persistent checkpoints.
-    if args.ckpt_fully_parallel_load:
-        load_strategy = FullyParallelLoadStrategyWrapper(
-            load_strategy, mpu.get_data_parallel_group(with_context_parallel=True)
-        )
-    if checkpointing_context is not None:
-        checkpointing_context["load_strategy"] = load_strategy
-    state_dict = dist_checkpointing.load(sharded_state_dict, checkpoint_name, load_strategy, strict=args.dist_ckpt_strictness)
-    return state_dict, checkpoint_name, release, CheckpointType.GLOBAL
-
-
-def _get_checkpoint_format(checkpoint_name, args):
-    if MultiStorageClientFeature.is_enabled():
-        msc = MultiStorageClientFeature.import_package()
-        checkpoint_dir = msc.Path(checkpoint_name)
-        is_torch_ckpt = any([f.name.startswith("mp_rank_0") for f in checkpoint_dir.iterdir()])
-        is_torch_dcp = checkpoint_dir.joinpath(".metadata").exists()
-    else:
-        is_torch_ckpt = any([f.startswith("mp_rank_0") for f in os.listdir(checkpoint_name)])
-        is_torch_dcp = os.path.exists(os.path.join(checkpoint_name, ".metadata"))
-
-    ckpt_format = None
-    if dist_checkpointing.check_is_distributed_checkpoint(checkpoint_name):
-        ckpt_format = "torch_dist"
-    elif is_torch_ckpt:
-        ckpt_format = "torch"
-    elif is_torch_dcp:
-        ckpt_format = "torch_dcp"
-        if getattr(args, "use_megatron_fsdp", False):
-            ckpt_format = "fsdp_dtensor"
-    else:
-        raise NotImplementedError(f"unknown checkpoint format in {checkpoint_name}")
-
-    return ckpt_format
-
-
-def _load_base_checkpoint(
-    load_dir,
-    args,
-    rank0=False,
-    sharded_state_dict=None,
-    checkpointing_context=None,
-):
-    # Try to load non-persistent checkpoint first
-    non_persistent_global_dir = (
-        args.non_persistent_global_ckpt_dir
-        if args.non_persistent_global_ckpt_dir or load_dir is None
-        else os.path.join(load_dir, _NON_PERSISTENT_CKPT_SUBDIR)
-    )
-    non_persistent_iteration = _get_non_persistent_iteration(
-        non_persistent_global_dir, args, checkpointing_context
-    )
-    iteration, release = -1, False
-    tracker_filename = 'because load directory is not defined'
-    if load_dir is not None:
-        tracker_filename = get_checkpoint_tracker_filename(load_dir)
-        if isfile(tracker_filename):
-            iteration, release = read_metadata(tracker_filename)
-
-    # Allow user to specify the loaded iteration.
-    if getattr(args, "ckpt_step", None):
-        iteration = args.ckpt_step
-
-    if non_persistent_iteration != -1:  # there is a non-persistent checkpoint
-        if non_persistent_iteration >= iteration:
-            return _load_non_persistent_base_checkpoint(
-                non_persistent_global_dir,
-                args,
-                rank0,
-                sharded_state_dict,
-                non_persistent_iteration,
-                checkpointing_context,
-            )
-        else:
-            print_rank_0('WARNING: non-persistent checkpoints are older than persistent checkpoint')
-
-    # Otherwise we are dealing with global checkpoints
-    # If no tracker file, return nothing
-    if iteration == -1:
-        if not rank0:
-            print_rank_0('WARNING: could not find the metadata file {}'.format(tracker_filename))
-            print_rank_0('    will not load any checkpoints and will start from random')
-        # Conditionally exit if checkpoint not found.
-        if args.exit_on_missing_checkpoint:
-            print_rank_0(">> '--exit-on-missing-checkpoint' set ... exiting. <<")
-            if torch.distributed.is_initialized():
-                torch.distributed.barrier()
-            sys.exit()
-
-        return None, "", False, None
-
-    # Determine the type of the checkpoint on disk.
-    checkpoint_name = get_checkpoint_name(load_dir, iteration, release, return_base_dir=True)
-    ckpt_format = _get_checkpoint_format(checkpoint_name, args)
-
-    if not rank0:
-        dist_infix = "distributed " if ckpt_format == "torch_dist" else ""
-        if release:
-            print_rank_0(f' loading release {dist_infix}checkpoint from {load_dir}')
-        else:
-            print_rank_0(
-                f' loading {dist_infix}checkpoint from {load_dir} at iteration {iteration}'
-            )
-
-    ckpt_type = None
-
-    # Handle global distributed checkpoint
-    if ckpt_format == "torch_dist":
-        return _load_global_dist_base_checkpoint(
-            load_dir, args, rank0, sharded_state_dict, iteration, release, checkpointing_context=checkpointing_context
-        )
-    elif ckpt_format == "torch":
-        ckpt_type = CheckpointType.LEGACY
-        # Handle global legacy checkpoint
-        if rank0:
-            checkpoint_name = find_checkpoint_rank_0(load_dir, iteration, release)
-        else:
-            checkpoint_name = get_checkpoint_name(load_dir, iteration, release, return_base_dir=False)
-        try:
-            state_dict = torch.load(checkpoint_name, map_location='cpu')
-        except ModuleNotFoundError:
-            from megatron.legacy.fp16_deprecated import loss_scaler
-
-            # For backward compatibility.
-            if not rank0:
-                print_rank_0(' > deserializing using the old code structure ...')
-            sys.modules['fp16.loss_scaler'] = sys.modules['megatron.legacy.fp16_deprecated.loss_scaler']
-            sys.modules['megatron.fp16.loss_scaler'] = sys.modules[
-                'megatron.legacy.fp16_deprecated.loss_scaler'
-            ]
-            sys.modules['megatron.model'] = sys.modules['megatron.legacy.model']
-            state_dict = torch.load(checkpoint_name, map_location='cpu')
-            sys.modules.pop('fp16.loss_scaler', None)
-            sys.modules.pop('megatron.fp16.loss_scaler', None)
-            sys.modules.pop('megatron.model', None)
-        except Exception as e:
-            print('could not load the checkpoint')
-            print(e)
-            sys.exit()
-    elif ckpt_format == "torch_dcp":
-        ckpt_type = CheckpointType.TORCH_DCP
-
-        if rank0:
-            # _load_base_checkpoint is called from load_args_from_checkpoint. torch.distributed is not initialized.
-            # Load only metadata.
-            state_dict = {"args": None, "iteration": None}
-            torch.distributed.checkpoint.load(
-                state_dict=state_dict,
-                checkpoint_id=checkpoint_name,
-            )
-        else:
-            # _load_base_checkpoint is called from load_checkpoint with a proper state dict.
-            state_dict = sharded_state_dict
-
-            fs_storage_reader = torch.distributed.checkpoint.FileSystemReader(checkpoint_name)
-
-            torch.distributed.checkpoint.load_state_dict(
-                state_dict=state_dict,
-                storage_reader=fs_storage_reader,
-            )
-    elif ckpt_format == "fsdp_dtensor":
-        assert HAVE_MEGATRON_FSDP, "Should not be called if Megatron-FSDP is not available."
-        if rank0:
-            return {}, checkpoint_name, release, CheckpointType.FSDP_DTENSOR
-
-        ckpt_type = CheckpointType.FSDP_DTENSOR
-        fs_storage_reader = torch.distributed.checkpoint.FileSystemReader(checkpoint_name)
-        allow_partial_load = not getattr(args, 'strict_fsdp_dtensor_load', False)
-        if allow_partial_load:
-            state_dict_metadata = fs_storage_reader.read_metadata().state_dict_metadata
-            rank = torch.distributed.get_rank()
-            import time as _time
-            _time.sleep(rank * 0.001)  # Make that logs of different ranks do not overlap
-            print_diff_in_state_dicts(state_dict_metadata, sharded_state_dict)
-
-        planner = default_planner.DefaultLoadPlanner(allow_partial_load=allow_partial_load)
-        torch.distributed.checkpoint.load_state_dict(
-            state_dict=sharded_state_dict,
-            storage_reader=fs_storage_reader,
-            planner=planner,
-        )
-        state_dict = sharded_state_dict
-    else:
-        raise NotImplementedError(f"checkpoint format {ckpt_format} not supported")
-
-    return state_dict, checkpoint_name, release, ckpt_type
-
-
-def load_args_from_checkpoint(
-    args, load_arg='load', checkpointing_context=None
-):
-    load_dir = getattr(args, load_arg)
-
-    if load_dir is None:
-        print_rank_0('No load directory specified, using provided arguments.')
-        return args
-
-    state_dict, checkpoint_name, release, ckpt_type = _load_base_checkpoint(
-        load_dir,
-        args,
-        rank0=True,
-        checkpointing_context=checkpointing_context,
-    )
-
-    # Args.
-    if not state_dict:
-        print_rank_0('Checkpoint not found to provide arguments, using provided arguments.')
-        return args
-
-    if 'args' not in state_dict:
-        print_rank_0('Checkpoint provided does not have arguments saved, using provided arguments.')
-        return args
-
-    checkpoint_args = state_dict['args']
-    checkpoint_version = state_dict.get('checkpoint_version', 0)
-    args.iteration = state_dict['iteration']
-
-    # One-off conversion for foundation models
-    if hasattr(checkpoint_args, 'disable_bias_linear'):
-        setattr(
-            checkpoint_args, 'add_bias_linear', not getattr(checkpoint_args, 'disable_bias_linear')
-        )
-
-    def _set_arg(arg_name, old_arg_name=None, force=False):
-        if not force and getattr(args, arg_name, None) is not None:
-            return
-
-        if old_arg_name is not None:
-            checkpoint_value = getattr(checkpoint_args, old_arg_name, None)
-        else:
-            checkpoint_value = getattr(checkpoint_args, arg_name, None)
-
-        if checkpoint_value is not None:
-            print_rank_0(f"Setting {arg_name} to {checkpoint_value} from checkpoint")
-            setattr(args, arg_name, checkpoint_value)
-        else:
-            print_rank_0(f"Checkpoint did not provide arguments {arg_name}")
-
-    # Model args.
-    _set_arg('num_layers')
-    _set_arg('hidden_size')
-    _set_arg('ffn_hidden_size')
-    _set_arg('seq_length')
-    _set_arg('num_attention_heads')
-    _set_arg('num_query_groups', force=True)
-    _set_arg('group_query_attention', force=True)
-    _set_arg('kv_channels')
-    _set_arg('max_position_embeddings')
-    _set_arg('position_embedding_type', force=True)
-    _set_arg('add_position_embedding', force=True)
-    _set_arg('use_rotary_position_embeddings', force=True)
-    _set_arg('rotary_base', force=True)
-    _set_arg('rotary_percent', force=True)
-    _set_arg('rotary_interleaved', force=True)
-    _set_arg('add_bias_linear', force=True)
-    _set_arg('add_qkv_bias', force=True)
-    _set_arg('squared_relu', force=True)
-    _set_arg('swiglu', force=True)
-    _set_arg('untie_embeddings_and_output_weights', force=True)
-    _set_arg('apply_layernorm_1p', force=True)
-    _set_arg('normalization', force=True)
-    _set_arg('apply_query_key_layer_scaling', force=True)
-    _set_arg('attention_dropout', force=True)
-    _set_arg('hidden_dropout', force=True)
-
-    _set_arg('hybrid_override_pattern', force=True)
-    _set_arg('spec', force=True)
-    _set_arg('hybrid_attention_ratio', force=True)
-    _set_arg('hybrid_mlp_ratio', force=True)
-
-    _set_arg('num_experts', force=True)
-    _set_arg('moe_layer_freq', force=True)
-    if getattr(checkpoint_args, 'num_experts', None) is not None:
-        _set_arg('moe_ffn_hidden_size', force=True)
-    else:
-        setattr(args, 'moe_ffn_hidden_size', None)
-    _set_arg('moe_router_topk', force=True)
-    _set_arg('moe_token_dispatcher_type', force=True)
-    _set_arg('moe_router_pre_softmax', force=True)
-    _set_arg('moe_grouped_gemm', force=True)
-    _set_arg('moe_shared_expert_intermediate_size', force=True)
-
-    # Mamba args.
-    _set_arg('mamba_state_dim', force=True)
-    _set_arg('mamba_head_dim', force=True)
-    _set_arg('mamba_num_groups', force=True)
-    _set_arg('mamba_num_heads', force=True)
-    _set_arg('is_hybrid_model', force=True)
-
-    # Heterogeneous args.
-    _set_arg('heterogeneous_layers_config_path', force=True)
-    _set_arg('heterogeneous_layers_config_encoded_json', force=True)
-
-    # Tokenizer args.
-    _set_arg('tokenizer_type', force=True)
-    # Using checkpoint version might not always be safe (e.g., if running on different cluster).
-    if args.use_tokenizer_model_from_checkpoint_args:
-        _set_arg('tokenizer_model', force=True)
-    _set_arg('tiktoken_pattern', force=True)
-    _set_arg('padded_vocab_size')
-
-    # Checkpoint args.
-    _set_arg('ckpt_format')
-
-    # Model parallelism args.
-    if args.use_mp_args_from_checkpoint_args:
-        if checkpoint_version < 3.0:
-            _set_arg('tensor_model_parallel_size', 'model_parallel_size')
-        else:
-            _set_arg('tensor_model_parallel_size', force=True)
-            _set_arg('pipeline_model_parallel_size', force=True)
-            _set_arg('virtual_pipeline_model_parallel_size', force=True)
-            _set_arg('num_layers_per_virtual_pipeline_stage')
-            _set_arg('expert_model_parallel_size', force=True)
-
-    return args, checkpoint_args
-
-
-def load_checkpoint(ddp_model, optimizer, opt_param_scheduler, load_arg='load', strict=True,
-                    checkpointing_context=None, skip_load_to_model_and_opt=False):
-    args = get_args()
-    load_dir = getattr(args, load_arg)
-
-    # Check for model-opt format loading
-    if hasattr(args, 'load_model_opt_format') and args.load_model_opt_format:
-        print_rank_0(f'Loading checkpoint using ModelOpt format from {load_dir}')
-        from megatron.post_training.checkpointing import load_modelopt_checkpoint
-
-        # Call the ModelOpt checkpoint loading function
-        load_modelopt_checkpoint(
-            ddp_model,
-            optimizer=optimizer,
-            opt_param_scheduler=opt_param_scheduler,
-            strict=strict,
-            load_arg=load_arg
-        )
-
-        # Since load_modelopt_checkpoint doesn't return iteration count, we need to get it
-        if torch.distributed.is_initialized():
-            tracker_filename = get_checkpoint_tracker_filename(load_dir)
-            if os.path.isfile(tracker_filename):
-                iteration, release = read_metadata(tracker_filename)
-                if release:
-                    iteration = 0
-            else:
-                iteration = 0
-        else:
-            iteration = 0
-
-        # We don't have a reliable way to get num_floating_point_operations_so_far from ModelOpt format
-        return iteration, 0
-
-    # Finetuning directories
-    pretrained_dir = getattr(args, 'pretrained_checkpoint', None)
-    if pretrained_dir is not None and not checkpoint_exists(load_dir):
-        print_rank_0(
-            f'Checkpoint file not found in load directory {load_dir} attempting to finetune with checkpoint in {pretrained_dir}'
-        )
-        load_dir = pretrained_dir
-        if not checkpoint_exists(load_dir):
-            raise FileNotFoundError("No checkpoint found in load directory or pretrained directory")
-        args.finetune = True
-
-    model = unwrap_model(ddp_model)
-
-    ckpt_format = args.ckpt_format
-    if args.auto_detect_ckpt_format or ckpt_format == "torch_dist":
-        state_dict, checkpoint_name, release, ckpt_type = _load_base_checkpoint(
-            load_dir,
-            args,
-            rank0=True,
-            checkpointing_context=checkpointing_context,
-        )
-
-        ckpt_format = None
-        if ckpt_type == CheckpointType.TORCH_DCP:
-            ckpt_format = "torch_dcp"
-        elif ckpt_type == CheckpointType.FSDP_DTENSOR:
-            ckpt_format = "fsdp_dtensor"
-        elif ckpt_type == CheckpointType.LEGACY:
-            ckpt_format = "torch"
-        elif ckpt_type in [CheckpointType.LOCAL, CheckpointType.GLOBAL]:
-            ckpt_format = "torch_dist"
-        elif ckpt_type == None:
-            pass    # Not loaded.
-        else:
-            raise NotImplementedError(f"checkpoint format {ckpt_format} not supported")
-
-    load_kwargs = {}
-    ignore_rng_state = False
-    ignore_rerun_state = True
-    if ckpt_format == "torch_dist":
-        ckpt_tp_pp = (
-            state_dict['args'].tensor_model_parallel_size,
-            state_dict['args'].pipeline_model_parallel_size,
-        )
-        run_tp_pp = (
-            args.tensor_model_parallel_size,
-            args.pipeline_model_parallel_size,
-        )
-
-        ckpt_world_size = getattr(state_dict['args'], 'world_size', 0)
-        run_world_size = getattr(args, 'world_size', 0)
-        ckpt_dp = getattr(state_dict['args'], 'data_parallel_size', 0)
-        run_dp = getattr(args, 'data_parallel_size', 0)
-        mismatch_msg = "(TP, PP) mismatch after resume ({} vs {} from checkpoint)".format(
-            run_tp_pp, ckpt_tp_pp
-        )
-
-        # Determine if RNG state will be loaded
-        if (ckpt_tp_pp == run_tp_pp and not release and not args.finetune and not args.no_load_rng
-                and not getattr(state_dict['args'], 'no_save_rng', False)):
-            gen_sd_rng_state = get_rng_state(args.ckpt_format)  # we can load the rng state
-        else:
-            ignore_rng_state = True
-            gen_sd_rng_state = None
-            if ckpt_tp_pp != run_tp_pp:
-                print_rank_0("{}: RNG state will be ignored".format(mismatch_msg))
-
-        if ckpt_type == CheckpointType.LOCAL:
-            sharded_sd_metadata = _build_sharded_state_dict_metadata(args)
-        else:
-            sharded_sd_metadata = dist_checkpointing.load_content_metadata(preloaded_state_dict=state_dict)
-        print_rank_0(f'sharded_state_dict metadata loaded from the checkpoint: {sharded_sd_metadata}')
-        # Determine if optimizer state will be loaded
-        if (not release and not args.finetune and not args.no_load_optim
-                and not getattr(state_dict['args'], 'no_save_optim', False)):
-            gen_sd_optim = optimizer
-            gen_sd_opt_param_scheduler = opt_param_scheduler
-
-            if args.use_distributed_optimizer:
-                if sharded_sd_metadata is None:
-                    # Backward-compatibility with old checkpoints which don't have content versioning
-                    # Can be removed after ending support for MLM optimizer checkpoints with MCore < v0.13
-                    # (for MCore v0.13+ checkpoints `sharded_sd_metadata is not None`)
-                    sharded_sd_metadata = {
-                        'distrib_optim_sharding_type': ('fully_sharded_model_space'
-                                                        if getattr(state_dict['args'], 'ckpt_fully_parallel_save', False)
-                                                        else 'dp_zero_gather_scatter'),
-                    }
-                if ckpt_tp_pp != run_tp_pp and sharded_sd_metadata['distrib_optim_sharding_type'] != 'fully_sharded_model_space':
-                    raise RuntimeError(f"{mismatch_msg}: not supported for DistributedOptimizer with sharding type"
-                                       f" {sharded_sd_metadata['distrib_optim_sharding_type']}."
-                                       f" Please use `--ckpt-fully-parallel-save` flag during checkpoint saving.")
-
-                # Check if fully parallel load is compatible with sharding type
-                if args.ckpt_fully_parallel_load and sharded_sd_metadata['distrib_optim_sharding_type'] == 'dp_zero_gather_scatter':
-                    raise RuntimeError("Fully parallel load is not supported for dp_zero_gather_scatter checkpoints. "
-                                       "Please remove --ckpt-fully-parallel-load flag")
-        else:
-            gen_sd_optim = None
-            gen_sd_opt_param_scheduler = None
-
-        optim_sd_kwargs = dict(metadata=sharded_sd_metadata, is_loading=True)
-        model_sd_kwargs = dict(metadata=sharded_sd_metadata)
-
-        # Determine if rerun state will be loaded
-        gen_sd_rerun_state = None
-        if (
-            ckpt_world_size == run_world_size
-            and ckpt_tp_pp == run_tp_pp
-            and ckpt_dp == run_dp
-            and not release
-            and not args.finetune
-            and 'rerun_state_machine' in state_dict
-        ):
-            rerun_state_machine = get_rerun_state_machine()
-            if rerun_state_machine.validate_state_dict(state_dict['rerun_state_machine']):
-                gen_sd_rerun_state = rerun_state_machine.state_dict(
-                    data_iterator=None, ckpt_format=ckpt_format, force=True,
-                )
-                ignore_rerun_state = False
-        if (
-            ckpt_world_size != run_world_size
-            or ckpt_tp_pp != run_tp_pp
-            or ckpt_dp != run_dp
-        ):
-            print_rank_0("Job sharding has changed: Rerun state will be ignored")
-
-        # [ModelOpt]: IMPORTANT! Restoring modelopt_state (sharded or not) must be performed
-        # after the model instance has been created and before _load_base_checkpoint is called.
-        if has_nvidia_modelopt:
-            if ckpt_type == CheckpointType.LOCAL:
-                print_rank_0('WARNING: Local checkpointing does not support nvidia_modelopt.')
-            elif ckpt_type == CheckpointType.GLOBAL:
-                restore_modelopt_state(model, state_dict)
-            else:
-                restore_sharded_modelopt_state(model, checkpoint_name)
-
-        # [ModelOpt]: Initial loading from non-resume sharded checkpoint to a Distillation Model
-        # will result in key mismatch with loss modules potentially containing parameters, since
-        # it requires generating a state_dict before loading. Here we hide those modules if present.
-        with contextlib.ExitStack() as stack:  # Allows multiple context managers for each model shard
-            if args.finetune and hasattr(model[0], "hide_loss_modules"):
-                for m in model:
-                    stack.enter_context(m.hide_loss_modules())
-            load_kwargs['sharded_state_dict'] = generate_state_dict(
-                args, model, gen_sd_optim, gen_sd_opt_param_scheduler, gen_sd_rng_state,
-                optim_sd_kwargs=optim_sd_kwargs, model_sd_kwargs=model_sd_kwargs,
-                rerun_state=gen_sd_rerun_state
-            )
-    elif args.ckpt_format == "torch_dcp":
-        model_sd = model[0].state_dict()
-        optimizer_sd = optimizer.state_dict(is_loading=True)
-        sharded_state_dict = {
-            "model": model_sd,
-            "optimizer": optimizer_sd,
-            "args": None,
-            "iteration": 1,
-            "rng_state": get_rng_state(args.ckpt_format),
-            "checkpoint_version": None,
-            "opt_param_scheduler": opt_param_scheduler.state_dict(),
-            "num_floating_point_operations_so_far": 0,
-        }
-        load_kwargs["sharded_state_dict"] = sharded_state_dict
-    elif args.ckpt_format == "fsdp_dtensor":
-        reader = FileSystemReader(get_load_checkpoint_path_by_args(args))
-        try:
-            state_dict_metadata = reader.read_metadata().state_dict_metadata
-        except FileNotFoundError:
-            state_dict_metadata = {}
-
-        gen_sd_rerun_state = None
-        gen_sd_opt_param_scheduler = None
-        gen_sd_rng_state = None
-        gen_sd_optim = None
-        if not args.finetune:
-            if "rerun_state_machine" in state_dict_metadata:
-                gen_sd_rerun_state = get_rerun_state_machine().state_dict(
-                    data_iterator=None, ckpt_format=ckpt_format, force=True,
-                )
-            if not args.no_load_rng:
-                gen_sd_rng_state = get_rng_state(args.ckpt_format)
-            if not args.no_load_optim:
-                gen_sd_optim = optimizer
-                gen_sd_opt_param_scheduler = opt_param_scheduler
-
-        optim_sd_kwargs = dict(metadata=_build_sharded_state_dict_metadata(args), is_loading=True)
-
-        load_kwargs["sharded_state_dict"] = generate_state_dict(
-            args,
-            model=model,
-            optimizer=gen_sd_optim,
-            opt_param_scheduler=gen_sd_opt_param_scheduler,
-            rng_state=gen_sd_rng_state,
-            optim_sd_kwargs=optim_sd_kwargs,
-            rerun_state=gen_sd_rerun_state,
-            iteration=1,
-        )
-
-    state_dict, checkpoint_name, release, ckpt_type = _load_base_checkpoint(
-        load_dir, args, rank0=False, checkpointing_context=checkpointing_context,
-        **load_kwargs
-    )
-
-    # Checkpoint not loaded.
-    if state_dict is None:
-        # Iteration and num_floating_point_operations_so_far default to 0.
-        return 0, 0
-
-    # Set checkpoint version.
-    set_checkpoint_version(state_dict.get('checkpoint_version', 0))
-
-    # Convert to regular torch tensor to DTensor.
-    if ckpt_type == CheckpointType.LEGACY and args.ckpt_format == "torch_dcp":
-        dtensor_state_dict = _to_dtensor(ddp_model, state_dict["model"])
-        state_dict["model"] = dtensor_state_dict
-
-    # Set iteration.
-    if args.finetune or release:
-        iteration = 0
-    else:
-        try:
-            iteration = state_dict['iteration']
-        except KeyError:
-            try:  # Backward compatible with older checkpoints
-                iteration = state_dict['total_iters']
-            except KeyError:
-                print_rank_0('A metadata file exists but unable to load '
-                             'iteration from checkpoint {}, exiting'.format(checkpoint_name))
-                sys.exit()
-    num_floating_point_operations_so_far = state_dict.get('num_floating_point_operations_so_far', 0)
-
-    # Check arguments.
-    assert args.consumed_train_samples == 0
-    assert args.skipped_train_samples == 0
-    assert args.consumed_valid_samples == 0
-    if 'args' in state_dict and not args.finetune:
-        checkpoint_args = state_dict['args']
-        check_checkpoint_args(checkpoint_args)
-        args.consumed_train_samples = getattr(checkpoint_args,
-                                              'consumed_train_samples', 0)
-        args.skipped_train_samples = getattr(checkpoint_args,
-                                             'skipped_train_samples', 0)
-        update_num_microbatches(consumed_samples=args.consumed_train_samples, verbose=True)
-        args.consumed_valid_samples = getattr(checkpoint_args,
-                                              'consumed_valid_samples', 0)
-    else:
-        print_rank_0('could not find arguments in the checkpoint ...')
-
-    def load_model_state_dict(module, state_dict, strict: bool):
-        try:
-            module.load_state_dict(state_dict, strict=strict)
-        except Exception as e:
-            if strict:
-                # Fallback support for backward compatibility breaking changes in TransformerEngine
-                load_return = module.load_state_dict(state_dict, strict=False)
-                print(f"load_return: {load_return}")
-    # Model.
-    strict = False if args.retro_add_retriever else strict
-    if not skip_load_to_model_and_opt:
-        if len(ddp_model) == 1:
-            load_model_state_dict(ddp_model[0], state_dict['model'], strict)
-        else:
-            for i in range(len(ddp_model)):
-                # If there is no corresponding model in the state_dict, it will be ignored.
-                # It means that this is an empty stage.
-                if 'model%d' % i not in state_dict:
-                    continue
-                load_model_state_dict(ddp_model[i], state_dict['model%d' % i], strict)
-    # Fix up query/key/value matrix ordering if needed.
-    checkpoint_version = get_checkpoint_version()
-    print_rank_0(f' checkpoint version {checkpoint_version}')
-    fix_query_key_value_ordering(model, checkpoint_version)
-
-    # Optimizer.
-    if not release and not args.finetune and not args.no_load_optim:
-        try:
-            # Load state dict.
-            if not skip_load_to_model_and_opt and optimizer is not None and not optimizer.is_stub_optimizer:
-                optimizer.load_state_dict(state_dict['optimizer'])
-
-            # Load distributed optimizer's custom parameter state.
-            # For distributed checkpoint it's already loaded in load_state_dict above
-            is_torch_dist = ckpt_format == "torch_dist"
-            if args.use_distributed_optimizer and not is_torch_dist and ckpt_format not in ["torch_dcp", "fsdp_dtensor"]:
-                # NOTE: this is a manual read of the tracker file.
-                # This code should not be reached when reading from a non_persistent checkpoint
-                assert not is_torch_dist
-                tracker_filename = get_checkpoint_tracker_filename(load_dir)
-                iteration, release = read_metadata(tracker_filename)
-                model_checkpoint_name = \
-                    get_checkpoint_name(load_dir, iteration, release)
-                optim_checkpoint_name = \
-                    get_distributed_optimizer_checkpoint_name(
-                        model_checkpoint_name)
-                optimizer.load_parameter_state(optim_checkpoint_name,
-                                               update_legacy_format=args.ckpt_convert_update_legacy_dist_opt_format)
-
-            # Load scheduler.
-            if opt_param_scheduler is not None:
-                if 'lr_scheduler' in state_dict: # backward compatbility
-                    opt_param_scheduler.load_state_dict(state_dict['lr_scheduler'])
-                else:
-                    opt_param_scheduler.load_state_dict(state_dict['opt_param_scheduler'])
-        except KeyError as e:
-            print_rank_0('Unable to load optimizer from checkpoint {}. '
-                         'Specify --no-load-optim or --finetune to prevent '
-                         'attempting to load the optimizer state, '
-                         'exiting ...'.format(checkpoint_name))
-            raise e
-    else:
-        if (args.fp16 or args.bf16) and optimizer is not None:
-            if args.load_main_params_from_ckpt:
-                optimizer.reload_model_params(state_dict=state_dict)
-            else:
-                optimizer.reload_model_params()
-
-    # rerun state
-    if not ignore_rerun_state:
-        try:
-            if 'rerun_state_machine' in state_dict:
-                get_rerun_state_machine().load_state_dict(state_dict['rerun_state_machine'])
-        except Exception as e:
-            print(f"Unable to restore RerunMachine from checkpoint: {e}. Skipping.")
-
-    # rng states.
-    if not release and not args.finetune and not args.no_load_rng and not ignore_rng_state:
-        try:
-            if 'rng_state' in state_dict:
-                if args.ckpt_format == "fsdp_dtensor":
-                    # FSDP DTensor checkpoints store rng_state in a different format.
-                    tp_rank = mpu.get_tensor_model_parallel_rank()
-                    pp_rank = mpu.get_pipeline_model_parallel_rank()
-                    if f"({pp_rank}, {tp_rank})" in state_dict['rng_state']:
-                        rng_state = state_dict['rng_state'][f"({pp_rank}, {tp_rank})"]
-                    else:
-                        print("WARNING: RNG state not found for current TP/PP rank")
-                        rng_state = next(iter(state_dict['rng_state'].values()))
-                else:
-                    rng_state = state_dict['rng_state']
-
-                # access rng_state for data parallel rank
-                if args.data_parallel_random_init:
-                    rng_state = rng_state[mpu.get_data_parallel_rank()]
-                else:
-                    rng_state = rng_state[0]
-                random.setstate(rng_state['random_rng_state'])
-                np.random.set_state(rng_state['np_rng_state'])
-                torch.set_rng_state(rng_state['torch_rng_state'])
-                torch.cuda.set_rng_state(rng_state['cuda_rng_state'])
-                # Check for empty states array
-                if not rng_state['rng_tracker_states']:
-                    raise KeyError
-                tensor_parallel.get_cuda_rng_tracker().set_states(
-                    rng_state['rng_tracker_states'])
-            else:  # backward compatability
-                random.setstate(state_dict['random_rng_state'])
-                np.random.set_state(state_dict['np_rng_state'])
-                torch.set_rng_state(state_dict['torch_rng_state'])
-                torch.cuda.set_rng_state(state_dict['cuda_rng_state'])
-                # Check for empty states array
-                if not state_dict['rng_tracker_states']:
-                    raise KeyError
-                tensor_parallel.get_cuda_rng_tracker().set_states(
-                    state_dict['rng_tracker_states'])
-        except KeyError:
-            print_rank_0('Unable to load rng state from checkpoint {}. '
-                         'Specify --no-load-rng or --finetune to prevent '
-                         'attempting to load the rng state, '
-                         'exiting ...'.format(checkpoint_name))
-            sys.exit()
-
-    # Some utilities want to load a checkpoint without distributed being initialized
-    if torch.distributed.is_initialized():
-        torch.distributed.barrier()
-
-    print_rank_0(f'  successfully loaded checkpoint from {load_dir} '
-                 f'[ t {mpu.get_tensor_model_parallel_rank() + 1}/{mpu.get_tensor_model_parallel_world_size()}, '
-                 f'p {mpu.get_pipeline_model_parallel_rank() + 1}/{mpu.get_pipeline_model_parallel_world_size()} ] '
-                 f'at iteration {iteration}')
-
-    # Additional callback for wandb (last rank)
-    if not torch.distributed.is_initialized() \
-       or is_last_rank():
-        wandb_utils.on_load_checkpoint_success(checkpoint_name, load_dir)
-
-    torch.cuda.empty_cache()
-
-    if iteration > 0:
-        # Notify FT that a checkpoint was loaded.
-        is_local_chkpt = (ckpt_type == CheckpointType.LOCAL)
-        ft_integration.on_checkpoint_loaded(is_local_chkpt=is_local_chkpt)
-
-    return iteration, num_floating_point_operations_so_far
-
-
-def _to_dtensor(wrapped_model, model_state_dict):
-    device_mesh = wrapped_model[0].device_mesh
-
-    new_model_sd = dict()
-    for k, v in model_state_dict.items():
-        # FP8 extra state cannot be converted to dtensor yet.
-        if "_extra_state" in k:
-            new_model_sd[k] = v
-        else:
-            new_model_sd[k] = torch.distributed.tensor.distribute_tensor(v, device_mesh)
-
-    return new_model_sd
-
-
-def load_biencoder_checkpoint(model, only_query_model=False,
-                              only_context_model=False, custom_load_path=None):
-
-    args = get_args()
-
-    model = unwrap_model(model)
-
-    load_path = custom_load_path if custom_load_path is not None else args.load
-
-    tracker_filename = get_checkpoint_tracker_filename(load_path)
-
-    with open_file(tracker_filename, 'r') as f:
-        iteration = int(f.read().strip())
-
-    checkpoint_name = get_checkpoint_name(load_path, iteration,
-                                          args.use_distributed_optimizer,
-                                          release=False)
-
-    if mpu.get_data_parallel_rank() == 0:
-        print('global rank {} is loading checkpoint {}'.format(
-            torch.distributed.get_rank(), checkpoint_name))
-
-    state_dict = torch.load(checkpoint_name, map_location='cpu')
-    ret_state_dict = state_dict['model']
-
-    if only_query_model:
-        ret_state_dict.pop('context_model')
-    if only_context_model:
-        ret_state_dict.pop('query_model')
-
-    assert len(model) == 1
-    model[0].load_state_dict(ret_state_dict)
-    torch.distributed.barrier()
-
-    if mpu.get_data_parallel_rank() == 0:
-        print(' successfully loaded {}'.format(checkpoint_name))
-
-    return model
-"""

--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -876,7 +876,8 @@ def generate_state_dict(
             state_dict["opt_param_scheduler"] = opt_param_scheduler.state_dict()
 
     # Rerun state
-    state_dict["rerun_state_machine"] = rerun_state
+    if rerun_state is not None:
+        state_dict["rerun_state_machine"] = rerun_state
 
     # RNG states.
     if ckpt_cfg.save_rng:

--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -74,6 +74,21 @@ from megatron.bridge.utils.import_utils import safe_import
 
 _, HAVE_RESIL = safe_import("nvidia_resiliency_ext.checkpointing")
 
+try:
+    from megatron.core.distributed.fsdp.src.megatron_fsdp.uneven_dtensor import (
+        preprocess_state_dict_for_uneven_dtensor,
+    )
+    from megatron.core.transformer.fsdp_dtensor_checkpoint import (
+        handle_fp8_extra_state_case,
+        handle_swiglu_in_state_dict,
+        print_diff_in_state_dicts,
+    )
+
+    HAVE_MEGATRON_FSDP = True
+except ImportError:
+    HAVE_MEGATRON_FSDP = False
+
+
 # [ModelOpt]: Import
 try:
     from modelopt.torch.opt.plugins import (
@@ -293,7 +308,7 @@ def is_empty_async_queue(global_state: GlobalState) -> bool:
     return async_queue.get_num_unfinalized_calls() == 0
 
 
-def get_rng_state(data_parallel_random_init: bool) -> ShardedObject:
+def get_rng_state(data_parallel_random_init: bool, ckpt_format: str = "torch_dist") -> Union[ShardedObject, dict]:
     """Get the random number generator states for all necessary libraries.
 
     Collects states from random, numpy, torch, cuda, and the Megatron RNG tracker.
@@ -321,17 +336,22 @@ def get_rng_state(data_parallel_random_init: bool) -> ShardedObject:
     else:
         rng_state_list = [rng_state]
 
-    pp_rank = mpu.get_pipeline_model_parallel_rank()
-    pp_size = mpu.get_pipeline_model_parallel_world_size()
-    tp_rank = mpu.get_tensor_model_parallel_rank()
-    tp_size = mpu.get_tensor_model_parallel_world_size()
-    rng_state_list = ShardedObject(
-        "rng_state",
-        rng_state_list,
-        (pp_size, tp_size),
-        (pp_rank, tp_rank),
-        replica_id=mpu.get_data_parallel_rank(with_context_parallel=True),
-    )
+    if ckpt_format == "torch_dist":
+        pp_rank = mpu.get_pipeline_model_parallel_rank()
+        pp_size = mpu.get_pipeline_model_parallel_world_size()
+        tp_rank = mpu.get_tensor_model_parallel_rank()
+        tp_size = mpu.get_tensor_model_parallel_world_size()
+        rng_state_list = ShardedObject(
+            "rng_state",
+            rng_state_list,
+            (pp_size, tp_size),
+            (pp_rank, tp_rank),
+            replica_id=mpu.get_data_parallel_rank(with_context_parallel=True),
+        )
+    elif ckpt_format == "fsdp_dtensor":
+        pp_rank = mpu.get_pipeline_model_parallel_rank()
+        tp_rank = mpu.get_tensor_model_parallel_rank()
+        rng_state_list = {f"({pp_rank}, {tp_rank})": rng_state_list}
 
     return rng_state_list
 
@@ -421,7 +441,9 @@ def save_checkpoint(
     print_rank_0(f"saving checkpoint at iteration {train_state.step:7d} to {save_dir} in {ckpt_format} format")
 
     # Collect rng state across data parallel ranks.
-    rng_state = get_rng_state(data_parallel_random_init=cfg.rng.data_parallel_random_init)
+    rng_state = get_rng_state(
+        data_parallel_random_init=cfg.rng.data_parallel_random_init, ckpt_format=ckpt_cfg.ckpt_format
+    )
 
     # Collect rerun state across all ranks
     rerun_state_machine = get_rerun_state_machine()
@@ -447,7 +469,7 @@ def save_checkpoint(
 
     # Collect cfg, model, RNG.
     sharded_sd_metadata = _build_sharded_state_dict_metadata(
-        cfg.optimizer.use_distributed_optimizer, ckpt_cfg.fully_parallel_save
+        cfg.optimizer.use_distributed_optimizer, ckpt_cfg.fully_parallel_save, ckpt_cfg.ckpt_format
     )
     if cfg.optimizer.use_distributed_optimizer:
         print_rank_0(
@@ -474,45 +496,56 @@ def save_checkpoint(
         if not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0:
             # TODO Handle non-empty directories (e.g., after a crash during saving).
             ensure_directory_exists(checkpoint_name, check_parent=False)
-        if checkpointing_context is not None and "save_strategy" in checkpointing_context:
-            save_strategy = checkpointing_context["save_strategy"]
-            # Already saved once before - don't need to rerun sharding validation
-            validate_sharding_integrity = not ckpt_cfg.ckpt_assume_constant_structure
-        else:
-            validate_sharding_integrity = True
-            save_strategy = get_default_save_sharded_strategy(ckpt_cfg.ckpt_format)
-            if ckpt_cfg.ckpt_assume_constant_structure and ckpt_cfg.ckpt_format == "torch_dist":
-                save_strategy.use_cached_ckpt_structure = ckpt_cfg.ckpt_assume_constant_structure
-                if checkpointing_context is not None and "load_strategy" in checkpointing_context:
-                    cached_global_metadata = getattr(
-                        checkpointing_context["load_strategy"], "cached_global_metadata", None
-                    )
-                    if cached_global_metadata is not None:
-                        logger.debug("Plugging in the read metadata from the load strategy...")
-                        save_strategy.cached_global_metadata = cached_global_metadata
-                    else:
-                        logger.debug("Failed to plug in the read metadata from the load strategy...")
 
-            if ckpt_cfg.fully_parallel_save:
-                save_strategy = FullyParallelSaveStrategyWrapper(
-                    save_strategy,
-                    mpu.get_data_parallel_group(with_context_parallel=True),
-                    ckpt_cfg.ckpt_assume_constant_structure,
-                )
-        # Store save strategy for future checkpoint saves
-        if checkpointing_context is not None:
-            checkpointing_context["save_strategy"] = save_strategy
-        end_ckpt = time()
-        logger.debug(f"rank: {rank}, takes {end_ckpt - start_ckpt} to prepare state dict for ckpt ")
-        async_save_request = dist_checkpointing.save(
-            state_dict,
-            checkpoint_name,
-            save_strategy,
-            async_sharded_save=ckpt_cfg.async_save,
-            validate_access_integrity=validate_sharding_integrity,
-            preprocess_common_before_consistancy_check=preprocess_common_state_dict_fn,
-            content_metadata=sharded_sd_metadata,
-        )
+        if ckpt_cfg.ckpt_format == "fsdp_dtensor":
+            # FSDP DTensor checkpoint save path
+            fs_storage_writer = torch.distributed.checkpoint.FileSystemWriter(checkpoint_name)
+            torch.distributed.checkpoint.save(
+                state_dict=state_dict,
+                storage_writer=fs_storage_writer,
+            )
+        else:
+            # torch_dist and other formats using MCore distributed checkpointing
+            if checkpointing_context is not None and "save_strategy" in checkpointing_context:
+                save_strategy = checkpointing_context["save_strategy"]
+                # Already saved once before - don't need to rerun sharding validation
+                validate_sharding_integrity = not ckpt_cfg.ckpt_assume_constant_structure
+            else:
+                validate_sharding_integrity = True
+                save_strategy = get_default_save_sharded_strategy(ckpt_cfg.ckpt_format)
+                if ckpt_cfg.ckpt_assume_constant_structure and ckpt_cfg.ckpt_format == "torch_dist":
+                    save_strategy.use_cached_ckpt_structure = ckpt_cfg.ckpt_assume_constant_structure
+                    if checkpointing_context is not None and "load_strategy" in checkpointing_context:
+                        cached_global_metadata = getattr(
+                            checkpointing_context["load_strategy"], "cached_global_metadata", None
+                        )
+                        if cached_global_metadata is not None:
+                            logger.debug("Plugging in the read metadata from the load strategy...")
+                            save_strategy.cached_global_metadata = cached_global_metadata
+                        else:
+                            logger.debug("Failed to plug in the read metadata from the load strategy...")
+
+                if ckpt_cfg.fully_parallel_save:
+                    save_strategy = FullyParallelSaveStrategyWrapper(
+                        save_strategy,
+                        mpu.get_data_parallel_group(with_context_parallel=True),
+                        ckpt_cfg.ckpt_assume_constant_structure,
+                    )
+            # Store save strategy for future checkpoint saves
+            if checkpointing_context is not None:
+                checkpointing_context["save_strategy"] = save_strategy
+            end_ckpt = time()
+            logger.debug(f"rank: {rank}, takes {end_ckpt - start_ckpt} to prepare state dict for ckpt ")
+            async_save_request = dist_checkpointing.save(
+                state_dict,
+                checkpoint_name,
+                save_strategy,
+                async_sharded_save=ckpt_cfg.async_save,
+                validate_access_integrity=validate_sharding_integrity,
+                preprocess_common_before_consistancy_check=preprocess_common_state_dict_fn,
+                content_metadata=sharded_sd_metadata,
+            )
+
         # [ModelOpt]: save sharded modelopt_state
         if has_nvidia_modelopt:
             save_sharded_modelopt_state(model, checkpoint_name, (ckpt_cfg.ckpt_format, 1))
@@ -728,6 +761,7 @@ def maybe_save_dataloader_state(train_iterator: Any, iteration: int, dataloader_
 def _generate_model_state_dict(
     model: list[MegatronModule],
     model_sd_kwargs: Optional[dict[str, Any]] = None,
+    ckpt_format: str = "torch_dist",
 ) -> dict[str, ShardedStateDict]:
     """Generate the model subset of the state dictionary to be saved in a checkpoint.
 
@@ -736,6 +770,7 @@ def _generate_model_state_dict(
     Args:
         model: The model module(s).
         model_sd_kwargs: Metadata for model state dict generation.
+        ckpt_format: The checkpoint format being used.
 
     Returns:
         A dictionary containing the model state to be saved.
@@ -743,10 +778,16 @@ def _generate_model_state_dict(
     state_dict = {}
 
     if len(model) == 1:
-        state_dict["model"] = model[0].sharded_state_dict(**(model_sd_kwargs or {}))
+        if ckpt_format == "torch_dist":
+            state_dict["model"] = model[0].sharded_state_dict(**(model_sd_kwargs or {}))
+        else:  # fsdp_dtensor and other formats
+            state_dict["model"] = model[0].state_dict_for_save_checkpoint()
     else:
         for i in range(len(model)):
-            state_dict["model%d" % i] = model[i].sharded_state_dict(**(model_sd_kwargs or {}))
+            if ckpt_format == "torch_dist":
+                state_dict["model%d" % i] = model[i].sharded_state_dict(**(model_sd_kwargs or {}))
+            else:  # fsdp_dtensor and other formats
+                state_dict["model%d" % i] = model[i].state_dict_for_save_checkpoint()
 
     return state_dict
 
@@ -784,21 +825,50 @@ def generate_state_dict(
     if iteration is not None:
         state_dict["iteration"] = iteration
 
-    state_dict.update(_generate_model_state_dict(model, model_sd_kwargs))
+    state_dict.update(_generate_model_state_dict(model, model_sd_kwargs, ckpt_cfg.ckpt_format))
 
     # Optimizer stuff.
     if ckpt_cfg.save_optim:
         if optimizer is not None and not getattr(optimizer, "is_stub_optimizer", False):
-            state_dict["optimizer"] = optimizer.sharded_state_dict(state_dict, **(optim_sd_kwargs or {}))
+            if ckpt_cfg.ckpt_format == "torch_dist":
+                state_dict["optimizer"] = optimizer.sharded_state_dict(state_dict, **(optim_sd_kwargs or {}))
+            elif ckpt_cfg.ckpt_format == "fsdp_dtensor":
+                if optim_sd_kwargs is None:
+                    optim_sd_kwargs = {}
+                if "metadata" not in optim_sd_kwargs:
+                    optim_sd_kwargs["metadata"] = {}
+                # Use the metadata that was passed in (should include FSDP-specific metadata)
+                state_dict["optimizer"] = optimizer.sharded_state_dict(state_dict, **optim_sd_kwargs)
+            else:
+                state_dict["optimizer"] = optimizer.state_dict()
         if opt_param_scheduler is not None:
             state_dict["opt_param_scheduler"] = opt_param_scheduler.state_dict()
 
     # Rerun state
-    state_dict["rerun_state_machine"] = rerun_state
+    if rerun_state:
+        state_dict["rerun_state_machine"] = rerun_state
 
     # RNG states.
     if ckpt_cfg.save_rng:
         state_dict["rng_state"] = rng_state
+
+    # FSDP DTensor checkpoint specific state dict preprocessing
+    if ckpt_cfg.ckpt_format == "fsdp_dtensor":
+        if not HAVE_MEGATRON_FSDP:
+            raise RuntimeError("Megatron FSDP is enabled but Megatron-FSDP is not available.")
+        if len(model) != 1:
+            raise RuntimeError("FSDP DTensor checkpoints are not supported for multiple models.")
+
+        # Apply FSDP-specific preprocessing
+        from megatron.core.utils import get_model_config
+
+        model_config = get_model_config(model[0])
+        if getattr(model_config, "swiglu", False):
+            state_dict = state_dict.copy()
+            handle_swiglu_in_state_dict(model[0], state_dict["model"], state_dict.get("optimizer"))
+        handle_fp8_extra_state_case(state_dict["model"])
+        preprocess_state_dict_for_uneven_dtensor(state_dict)
+
     return state_dict
 
 
@@ -1013,13 +1083,24 @@ def _load_checkpoint_from_path(
         and run_config["checkpoint"]["save_rng"]
     ):
         # we can load the rng state
-        gen_sd_rng_state = get_rng_state(data_parallel_random_init=cfg.rng.data_parallel_random_init)
+        ckpt_format = "fsdp_dtensor" if file_exists(os.path.join(checkpoint_name, ".metadata")) else "torch_dist"
+        gen_sd_rng_state = get_rng_state(
+            data_parallel_random_init=cfg.rng.data_parallel_random_init, ckpt_format=ckpt_format
+        )
     else:
         gen_sd_rng_state = None
         if ckpt_tp_pp != run_tp_pp:
             print_rank_0("{}: RNG state will be ignored".format(mismatch_msg))
 
-    sharded_sd_metadata = dist_checkpointing.load_content_metadata(preloaded_state_dict=state_dict)
+    # Handle metadata loading for different checkpoint types
+    if ckpt_type == CheckpointType.GLOBAL and file_exists(os.path.join(checkpoint_name, ".metadata")):
+        # FSDP DTensor checkpoint - build metadata from config
+        sharded_sd_metadata = _build_sharded_state_dict_metadata(
+            cfg.optimizer.use_distributed_optimizer, cfg.checkpoint.fully_parallel_save, "fsdp_dtensor"
+        )
+    else:
+        # torch_dist checkpoint - load metadata from checkpoint
+        sharded_sd_metadata = dist_checkpointing.load_content_metadata(preloaded_state_dict=state_dict)
     print_rank_0(f"sharded_state_dict metadata loaded from the checkpoint: {sharded_sd_metadata}")
     # Determine if optimizer state will be loaded
     if (
@@ -1224,11 +1305,32 @@ def _load_checkpoint_from_path(
     if not release and not cfg.checkpoint.finetune and cfg.checkpoint.load_rng:
         try:
             if "rng_state" in state_dict:
-                # access rng_state for data parallel rank
-                if cfg.rng.data_parallel_random_init:
-                    rng_state = state_dict["rng_state"][mpu.get_data_parallel_rank()]
+                # Handle different RNG state formats
+                if isinstance(state_dict["rng_state"], dict) and any(
+                    key.startswith("(") for key in state_dict["rng_state"]
+                ):
+                    # FSDP DTensor format: {(pp_rank, tp_rank): rng_state_list}
+                    tp_rank = mpu.get_tensor_model_parallel_rank()
+                    pp_rank = mpu.get_pipeline_model_parallel_rank()
+                    key = f"({pp_rank}, {tp_rank})"
+                    if key in state_dict["rng_state"]:
+                        rng_state_list = state_dict["rng_state"][key]
+                    else:
+                        print_rank_0(f"WARNING: RNG state not found for TP/PP rank ({tp_rank}, {pp_rank})")
+                        rng_state_list = next(iter(state_dict["rng_state"].values()))
+                    # access rng_state for data parallel rank
+                    if cfg.rng.data_parallel_random_init:
+                        rng_state = rng_state_list[mpu.get_data_parallel_rank()]
+                    else:
+                        rng_state = rng_state_list[0]
                 else:
-                    rng_state = state_dict["rng_state"][0]
+                    # torch_dist format: ShardedObject or list
+                    # access rng_state for data parallel rank
+                    if cfg.rng.data_parallel_random_init:
+                        rng_state = state_dict["rng_state"][mpu.get_data_parallel_rank()]
+                    else:
+                        rng_state = state_dict["rng_state"][0]
+
                 random.setstate(rng_state["random_rng_state"])
                 np.random.set_state(rng_state["np_rng_state"])
                 torch.set_rng_state(rng_state["torch_rng_state"])
@@ -1602,16 +1704,40 @@ def _load_base_checkpoint(
     # Determine the type of the checkpoint
     checkpoint_name_dir = get_checkpoint_name(load_dir, iteration, release)
     is_dist_ckpt = dist_checkpointing.check_is_distributed_checkpoint(checkpoint_name_dir)
+
+    # Check for FSDP DTensor format (torch.distributed.checkpoint format)
+    is_fsdp_dtensor_ckpt = False
+    if not is_dist_ckpt:
+        # Check if this is an FSDP DTensor checkpoint
+        metadata_file = os.path.join(checkpoint_name_dir, ".metadata")
+        if file_exists(metadata_file):
+            is_fsdp_dtensor_ckpt = True
+
     if not rank0:
-        dist_infix = "distributed " if is_dist_ckpt else ""
+        if is_fsdp_dtensor_ckpt:
+            dist_infix = "FSDP DTensor "
+        elif is_dist_ckpt:
+            dist_infix = "distributed "
+        else:
+            dist_infix = ""
         if release:
             print_rank_0(f" loading release {dist_infix}checkpoint from {load_dir}")
         else:
             print_rank_0(f" loading {dist_infix}checkpoint from {load_dir} at iteration {iteration}")
 
-    # Handle global distributed checkpoint
+    # Handle different checkpoint formats
     if is_dist_ckpt:
         return _load_global_dist_base_checkpoint(
+            load_dir,
+            ckpt_cfg,
+            rank0,
+            sharded_state_dict,
+            iteration,
+            release,
+            checkpointing_context=checkpointing_context,
+        )
+    elif is_fsdp_dtensor_ckpt:
+        return _load_fsdp_dtensor_base_checkpoint(
             load_dir,
             ckpt_cfg,
             rank0,
@@ -1628,7 +1754,57 @@ def _load_base_checkpoint(
         )
 
 
-def _build_sharded_state_dict_metadata(use_distributed_optimizer: bool, ckpt_fully_parallel_save: bool) -> dict:
+def _load_fsdp_dtensor_base_checkpoint(
+    load_dir: str,
+    ckpt_cfg: CheckpointConfig,
+    rank0: bool,
+    sharded_state_dict: Optional[dict[str, Any]],
+    iteration: int,
+    release: bool,
+    checkpointing_context: Optional[dict[str, Any]] = None,
+) -> tuple[dict[str, Any], str, bool, CheckpointType]:
+    """Load the base state_dict from an FSDP DTensor checkpoint."""
+    if rank0:
+        # For rank 0, just return metadata
+        return {}, get_checkpoint_name(load_dir, iteration, release), release, CheckpointType.GLOBAL
+
+    if not HAVE_MEGATRON_FSDP:
+        raise RuntimeError("Megatron FSDP is required but not available for loading FSDP DTensor checkpoints.")
+
+    if sharded_state_dict is None:
+        raise RuntimeError("sharded_state_dict is required for FSDP DTensor checkpoint loading.")
+
+    checkpoint_name = get_checkpoint_name(load_dir, iteration, release)
+    fs_storage_reader = torch.distributed.checkpoint.FileSystemReader(checkpoint_name)
+
+    # Configure partial loading based on strict_fsdp_dtensor_load setting
+    allow_partial_load = not ckpt_cfg.strict_fsdp_dtensor_load
+    if allow_partial_load:
+        try:
+            state_dict_metadata = fs_storage_reader.read_metadata().state_dict_metadata
+            rank = torch.distributed.get_rank()
+            import time as _time
+
+            _time.sleep(rank * 0.001)  # Prevent log overlap across ranks
+            print_diff_in_state_dicts(state_dict_metadata, sharded_state_dict)
+        except Exception as e:
+            print_rank_0(f"Warning: Could not read metadata for partial loading: {e}")
+
+    from torch.distributed.checkpoint import default_planner
+
+    planner = default_planner.DefaultLoadPlanner(allow_partial_load=allow_partial_load)
+    torch.distributed.checkpoint.load_state_dict(
+        state_dict=sharded_state_dict,
+        storage_reader=fs_storage_reader,
+        planner=planner,
+    )
+
+    return sharded_state_dict, checkpoint_name, release, CheckpointType.GLOBAL
+
+
+def _build_sharded_state_dict_metadata(
+    use_distributed_optimizer: bool, ckpt_fully_parallel_save: bool, ckpt_format: str = "torch_dist"
+) -> dict:
     """Builds metadata used for sharded_state_dict versioning.
 
     The whole content metadata is passed to ``shared_state_dict`` model and optimizer methods
@@ -1645,7 +1821,9 @@ def _build_sharded_state_dict_metadata(use_distributed_optimizer: bool, ckpt_ful
     """
     metadata = {}
     if use_distributed_optimizer:
-        if ckpt_fully_parallel_save:
+        if ckpt_format == "fsdp_dtensor":
+            metadata["distrib_optim_sharding_type"] = "fsdp_dtensor"
+        elif ckpt_fully_parallel_save:
             metadata["distrib_optim_sharding_type"] = "fully_sharded_model_space"
         else:
             metadata["distrib_optim_sharding_type"] = "dp_zero_gather_scatter"
@@ -1677,3 +1855,1734 @@ def _get_train_state_from_state_dict(state_dict: dict[str, Any]) -> TrainState:
     legacy_train_state.do_valid = False
     legacy_train_state.do_test = False
     return legacy_train_state
+
+
+"""
+
+import contextlib
+import os
+import random
+import shutil
+import sys
+import threading
+from argparse import Namespace
+from enum import Enum, auto
+from logging import getLogger
+from pathlib import Path
+
+import numpy as np
+from time import time
+
+import torch
+from torch.distributed.checkpoint import default_planner, FileSystemReader
+
+from megatron.core import mpu, tensor_parallel, dist_checkpointing
+from megatron.core.dist_checkpointing.mapping import ShardedObject
+from megatron.core.dist_checkpointing.serialization import get_default_load_sharded_strategy
+from megatron.core.dist_checkpointing.strategies.fully_parallel import \
+    FullyParallelSaveStrategyWrapper, FullyParallelLoadStrategyWrapper
+from megatron.core.num_microbatches_calculator import update_num_microbatches
+from megatron.core.fp8_utils import is_float8tensor, dequantize_fp8_tensor
+from megatron.core.rerun_state_machine import get_rerun_state_machine
+from .async_utils import schedule_async_save, is_empty_async_queue
+from .global_vars import get_args
+from .utils import unwrap_model, print_rank_0, append_to_progress_log, is_last_rank
+from ..core.dist_checkpointing.serialization import \
+    get_default_save_sharded_strategy
+from .one_logger_utils import on_save_checkpoint_start, on_save_checkpoint_success
+from . import wandb_utils
+
+from . import ft_integration
+
+from megatron.core.msc_utils import MultiStorageClientFeature, open_file
+
+try:
+    from megatron.core.distributed.fsdp.src.megatron_fsdp.uneven_dtensor import preprocess_state_dict_for_uneven_dtensor
+    from megatron.core.transformer.fsdp_dtensor_checkpoint import (
+        handle_swiglu_in_state_dict,
+        handle_fp8_extra_state_case,
+        print_diff_in_state_dicts,
+    )
+    HAVE_MEGATRON_FSDP = True
+except ImportError:
+    HAVE_MEGATRON_FSDP = False
+
+
+# [ModelOpt]: Import
+try:
+    from modelopt.torch.opt.plugins import (
+        save_modelopt_state,
+        save_sharded_modelopt_state,
+        restore_modelopt_state,
+        restore_sharded_modelopt_state,
+    )
+    has_nvidia_modelopt = True
+except Exception:
+    has_nvidia_modelopt = False
+
+_CHECKPOINT_VERSION = None
+
+logger = getLogger(__name__)
+_NON_PERSISTENT_CKPT_SUBDIR = 'non_persistent'
+
+def set_checkpoint_version(value):
+    global _CHECKPOINT_VERSION
+    if _CHECKPOINT_VERSION is not None:
+        assert _CHECKPOINT_VERSION == value, \
+            "checkpoint versions do not match"
+    _CHECKPOINT_VERSION = value
+
+
+def get_checkpoint_version():
+    global _CHECKPOINT_VERSION
+    return _CHECKPOINT_VERSION
+
+
+def check_checkpoint_args(checkpoint_args):
+    args = get_args()
+
+    def _compare(arg_name, old_arg_name=None, default=None):
+        if old_arg_name is not None:
+            ckpt_arg_name = old_arg_name
+        else:
+            ckpt_arg_name = arg_name
+        if default is not None:
+            checkpoint_value = getattr(checkpoint_args, ckpt_arg_name, default)
+        else:
+            checkpoint_value = getattr(checkpoint_args, ckpt_arg_name)
+        args_value = getattr(args, arg_name)
+        error_message = '{} value from checkpoint ({}) is not equal to the ' \
+                        'input argument value ({}).'.format(
+                            arg_name, checkpoint_value, args_value)
+        assert checkpoint_value == args_value, error_message
+
+    _compare('num_layers')
+    _compare('hidden_size')
+    _compare('num_attention_heads')
+    _compare('add_position_embedding', default=True)
+    if args.vocab_file:
+        _compare('max_position_embeddings')
+        _compare('make_vocab_size_divisible_by')
+        if not args.use_dist_ckpt:
+            _compare('padded_vocab_size')
+        _compare('tokenizer_type')
+    if args.data_parallel_random_init:
+        _compare('data_parallel_random_init')
+    if get_checkpoint_version() < 3.0:
+        _compare('tensor_model_parallel_size',
+                 old_arg_name='model_parallel_size')
+    if get_checkpoint_version() >= 3.0 and not args.use_dist_ckpt:
+        _compare('tensor_model_parallel_size')
+        _compare('pipeline_model_parallel_size')
+
+
+def isfile(filename) -> bool:
+    if MultiStorageClientFeature.is_enabled():
+        msc = MultiStorageClientFeature.import_package()
+        return msc.os.path.isfile(filename)
+    else:
+        return os.path.isfile(filename)
+
+
+def ensure_directory_exists(filename, check_parent=True):
+    dirname = os.path.dirname(filename) if check_parent else filename
+    if MultiStorageClientFeature.is_enabled():
+        msc = MultiStorageClientFeature.import_package()
+        msc.os.makedirs(dirname, exist_ok=True)
+    else:
+        os.makedirs(dirname, exist_ok=True)
+
+
+def get_checkpoint_name(checkpoints_path, iteration, release=False,
+                        pipeline_parallel=None,
+                        tensor_rank=None, pipeline_rank=None,
+                        expert_parallel=None, expert_rank=None,
+                        return_base_dir=False, basename="model_optim_rng.pt"):
+    if release:
+        directory = 'release'
+    else:
+        directory = 'iter_{:07d}'.format(iteration)
+    if return_base_dir:
+        common_path = os.path.join(checkpoints_path, directory)
+        return common_path
+
+    # Use both the tensor and pipeline MP rank.
+    if pipeline_parallel is None:
+        pipeline_parallel = (mpu.get_pipeline_model_parallel_world_size() > 1)
+    if tensor_rank is None:
+        tensor_rank = mpu.get_tensor_model_parallel_rank()
+    if pipeline_rank is None:
+        pipeline_rank = mpu.get_pipeline_model_parallel_rank()
+    if expert_parallel is None:
+        expert_parallel = (mpu.get_expert_model_parallel_world_size() > 1)
+    if expert_rank is None:
+        expert_rank = mpu.get_expert_model_parallel_rank()
+
+    # Use both the tensor and pipeline MP rank. If using the distributed
+    # optimizer, then the optimizer's path must additionally include the
+    # data parallel rank.
+    if not pipeline_parallel:
+        common_path = os.path.join(checkpoints_path, directory,
+                            f'mp_rank_{tensor_rank:02d}')
+    else:
+        common_path = os.path.join(checkpoints_path, directory,
+                f'mp_rank_{tensor_rank:02d}_{pipeline_rank:03d}')
+
+    if expert_parallel:
+        common_path = common_path + f'_{expert_rank:03d}'
+
+    return os.path.join(common_path, basename)
+
+
+def get_load_checkpoint_path_by_args(args, load_arg="load"):
+    load_dir = getattr(args, load_arg)
+    iteration, release = -1, False
+    tracker_filename = 'because load directory is not defined'
+    if load_dir is not None:
+        tracker_filename = get_checkpoint_tracker_filename(load_dir)
+        if isfile(tracker_filename):
+            iteration, release = read_metadata(tracker_filename)
+
+    # Allow user to specify the loaded iteration.
+    if getattr(args, "ckpt_step", None):
+        iteration = args.ckpt_step
+
+    return get_checkpoint_name(load_dir, iteration, release, return_base_dir=True)
+
+
+def get_distributed_optimizer_checkpoint_name(model_checkpoint_name):
+    return os.path.join(os.path.dirname(model_checkpoint_name),
+                        "distrib_optim.pt")
+
+
+def find_checkpoint_rank_0(checkpoints_path, iteration, release=False):
+
+    # Look for checkpoint with no pipelining and no expert parallelism
+    filename = get_checkpoint_name(checkpoints_path, iteration, release,
+                                   pipeline_parallel=False,
+                                   tensor_rank=0, pipeline_rank=0,
+                                   expert_parallel=False, expert_rank=0)
+    if isfile(filename):
+        return filename
+
+    # Look for checkpoint with no pipelining and expert parallelism
+    filename = get_checkpoint_name(checkpoints_path, iteration, release,
+                                   pipeline_parallel=False,
+                                   tensor_rank=0, pipeline_rank=0,
+                                   expert_parallel=True, expert_rank=0)
+    if isfile(filename):
+        return filename
+
+    # Look for checkpoint with pipelining and no expert parallelism
+    filename = get_checkpoint_name(checkpoints_path, iteration, release,
+                                   pipeline_parallel=True,
+                                   tensor_rank=0, pipeline_rank=0,
+                                   expert_parallel=False, expert_rank=0)
+    if isfile(filename):
+        return filename
+
+    # Look for checkpoint with pipelining and expert parallelism
+    filename = get_checkpoint_name(checkpoints_path, iteration, release,
+                                   pipeline_parallel=True,
+                                   tensor_rank=0, pipeline_rank=0,
+                                   expert_parallel=True, expert_rank=0)
+    if isfile(filename):
+        return filename
+
+    # Look for a distributed checkpoint
+    filename = get_checkpoint_name(checkpoints_path, iteration, release,
+                                   pipeline_parallel=True,
+                                   return_base_dir=True)
+    if dist_checkpointing.check_is_distributed_checkpoint(filename):
+        return filename
+
+    return None
+
+
+def get_checkpoint_tracker_filename(checkpoints_path):
+    return os.path.join(checkpoints_path, 'latest_checkpointed_iteration.txt')
+
+
+def checkpoint_exists(checkpoints_path):
+    if checkpoints_path is None:
+        return False
+    path = get_checkpoint_tracker_filename(checkpoints_path)
+    return isfile(path)
+
+
+def read_metadata(tracker_filename):
+    # Read the tracker file and either set the iteration or
+    # mark it as a release checkpoint.
+    iteration = 0
+    release = False
+
+    with open_file(tracker_filename, 'r') as f:
+        metastring = f.read().strip()
+        try:
+            iteration = int(metastring)
+        except ValueError:
+            release = metastring == 'release'
+            if not release:
+                print_rank_0('ERROR: Invalid metadata file {}. Exiting'.format(
+                    tracker_filename))
+                sys.exit()
+    assert iteration > 0 or release, 'error parsing metadata file {}'.format(
+        tracker_filename)
+
+    # Get the max iteration retrieved across the ranks.
+    if torch.distributed.is_initialized():
+        iters_cuda = torch.tensor([iteration], dtype=torch.long, device='cuda')
+        torch.distributed.all_reduce(iters_cuda, op=torch.distributed.ReduceOp.MAX)
+        max_iter = iters_cuda[0].item()
+
+        # We should now have all the same iteration.
+        # If not, print a warning and chose the maximum
+        # iteration across all ranks.
+        if iteration != max_iter:
+            rank = torch.distributed.get_rank()
+            print('WARNING: on rank {} found iteration {} in the '
+                  'metadata while max iteration across the ranks '
+                  'is {}, replacing it with max iteration.'.format(
+                      rank, iteration, max_iter), flush=True)
+    else:
+        # When loading a checkpoint outside of training (for example,
+        # when editing it), we might not have torch distributed
+        # initialized, in this case, just assume we have the latest
+        max_iter = iteration
+    return max_iter, release
+
+
+def get_rng_state(ckpt_format: str):
+    args = get_args()
+    rng_state = {
+        'random_rng_state': random.getstate(),
+        'np_rng_state': np.random.get_state(),
+        'torch_rng_state': torch.get_rng_state(),
+        'cuda_rng_state': torch.cuda.get_rng_state(),
+        'rng_tracker_states': tensor_parallel.get_cuda_rng_tracker().get_states()}
+
+    rng_state_list = None
+    if args.data_parallel_random_init and torch.distributed.is_initialized() and \
+            mpu.get_data_parallel_world_size() > 1:
+        rng_state_list = \
+            [None for i in range(mpu.get_data_parallel_world_size())]
+        torch.distributed.all_gather_object(
+            rng_state_list,
+            rng_state,
+            group=mpu.get_data_parallel_group())
+    else:
+        rng_state_list = [rng_state]
+
+    if ckpt_format == "torch_dist":
+        pp_rank = mpu.get_pipeline_model_parallel_rank()
+        pp_size = mpu.get_pipeline_model_parallel_world_size()
+        tp_rank = mpu.get_tensor_model_parallel_rank()
+        tp_size = mpu.get_tensor_model_parallel_world_size()
+        rng_state_list = ShardedObject('rng_state', rng_state_list, (pp_size, tp_size), (pp_rank, tp_rank),
+                                       replica_id=mpu.get_data_parallel_rank(with_context_parallel=True))
+    elif ckpt_format == "fsdp_dtensor":
+        pp_rank = mpu.get_pipeline_model_parallel_rank()
+        tp_rank = mpu.get_tensor_model_parallel_rank()
+        rng_state_list = {
+            f"({pp_rank}, {tp_rank})": rng_state_list
+        }
+
+    return rng_state_list
+
+class CheckpointType(Enum):
+    LEGACY = auto()
+    LOCAL = auto()
+    GLOBAL = auto()
+    TORCH_DCP = auto()
+    FSDP_DTENSOR = auto()
+
+def _build_sharded_state_dict_metadata(args: Namespace) -> dict:
+    metadata = {}
+    if args.use_distributed_optimizer:
+        if args.ckpt_format == "fsdp_dtensor":
+            metadata['distrib_optim_sharding_type'] = 'fsdp_dtensor'
+        elif args.ckpt_fully_parallel_save:
+            metadata['distrib_optim_sharding_type'] = 'fully_sharded_model_space'
+        else:
+            metadata['distrib_optim_sharding_type'] = 'dp_zero_gather_scatter'
+
+        # TODO (v0.14): this is the intended metadata logic after fully switching to simplistic
+        #  format. For now it's disabled, will be enabled after completing the ckpt refactor
+        if args.ckpt_pre_mcore_014:
+            metadata['singleton_local_shards'] = False
+            metadata['unpadded_embeddings'] = False
+            if args.use_distributed_optimizer:
+                if args.ckpt_fully_parallel_save:
+                    metadata['distrib_optim_sharding_type'] = 'fully_sharded_model_space'
+                else:
+                    metadata['distrib_optim_sharding_type'] = 'dp_zero_gather_scatter'
+        else:
+            metadata['singleton_local_shards'] = True
+            metadata['unpadded_embeddings'] = True
+            if args.use_distributed_optimizer:
+                if args.ckpt_optim_fully_reshardable:
+                    metadata['distrib_optim_sharding_type'] = 'fully_reshardable'
+                    # TODO: add a separate flag and based on this flag raise if gloo groups
+                    # are not created in arguments.py
+                    metadata['distrib_optim_fully_reshardable_mem_efficient'] = False
+                else:
+                    metadata['distrib_optim_sharding_type'] = 'dp_reshardable'
+    metadata['chained_optim_avoid_prefix'] = True
+    metadata['singleton_local_shards'] = False
+    return metadata
+
+def save_checkpoint(iteration, model, optimizer, opt_param_scheduler, num_floating_point_operations_so_far,
+                    checkpointing_context=None, pipeline_rank=None, expert_rank=None, tensor_rank=None, pipeline_parallel=None, expert_parallel=None, non_persistent_ckpt=False,
+                    train_data_iterator=None, preprocess_common_state_dict_fn = None):
+    start_ckpt = time()
+    args = get_args()
+
+    if args.async_save and not is_empty_async_queue():
+        print_rank_0('WARNING: Starting a checkpoint save before previous has finished. Consider increasing the checkpoint interval.')
+
+    # Prepare E2E metrics at start of save checkpoint
+    productive_metrics = on_save_checkpoint_start(args.async_save)
+
+    # Monitor for the checkpointing timeout (no-op if FT is not enabled)
+    ft_integration.on_checkpointing_start()
+
+    # Only rank zero of the data parallel writes to the disk.
+    model = unwrap_model(model)
+
+    # Handle non_persistent_ckpt flag. Besides overwriting `args.save` and
+    # `args.use_dist_ckpt`, non-persistent global ckpt requires no additional logic
+    ckpt_type = CheckpointType.GLOBAL if args.use_dist_ckpt else CheckpointType.LEGACY
+    save_dir = args.save
+    if non_persistent_ckpt:
+        if args.non_persistent_ckpt_type == 'global':
+            ckpt_type = CheckpointType.GLOBAL
+            save_dir = (
+                args.non_persistent_global_ckpt_dir
+                if args.non_persistent_global_ckpt_dir
+                else os.path.join(save_dir, _NON_PERSISTENT_CKPT_SUBDIR)
+            )
+            # TODO Can we ensure the previous checkpoint is saved? We don't want to allow two saves in parallel.
+            cleanup_old_non_persistent_checkpoint(
+                save_dir, leave_ckpt_num=1, do_async=args.async_save
+            )
+        elif args.non_persistent_ckpt_type == 'local':
+            ckpt_type = CheckpointType.LOCAL
+            save_dir = checkpointing_context['local_checkpoint_manager'].local_ckpt_dir
+        else:
+            raise NotImplementedError(f"Please use local or global non-persistent checkpoints (got: {args.non_persistent_ckpt_type})")
+
+    ckpt_format = args.ckpt_format if ckpt_type == CheckpointType.GLOBAL else 'torch'
+    print_rank_0('saving checkpoint at iteration {:7d} to {} in {} format'.format(
+        iteration, save_dir, ckpt_format))
+
+    # Collect rng state across data parallel ranks.
+    rng_state = get_rng_state(args.ckpt_format)
+
+    # Collect rerun state across all ranks
+    rerun_state_machine = get_rerun_state_machine()
+    rerun_state = rerun_state_machine.state_dict(
+        data_iterator=train_data_iterator, ckpt_format=args.ckpt_format,
+    )
+
+    # Checkpoint name.
+    return_base_dir = (ckpt_type != CheckpointType.LEGACY)
+    checkpoint_name = get_checkpoint_name(save_dir, iteration, release=False, pipeline_parallel=pipeline_parallel,
+        tensor_rank=tensor_rank, pipeline_rank=pipeline_rank, expert_parallel=expert_parallel, expert_rank=expert_rank, return_base_dir=return_base_dir)
+
+    # Save dataloader state if the dataloader supports it (currently only Megatron Energon).
+    maybe_save_dataloader_state(train_data_iterator, iteration, getattr(args, "dataloader_save", None))
+
+    # Save distributed optimizer's custom parameter state.
+    if (
+        args.use_distributed_optimizer
+        and not args.no_save_optim
+        and optimizer is not None
+        and ckpt_type == CheckpointType.LEGACY
+    ):
+        optim_checkpoint_name = \
+            get_distributed_optimizer_checkpoint_name(checkpoint_name)
+        ensure_directory_exists(optim_checkpoint_name)
+        if not optimizer.is_stub_optimizer:
+            optimizer.save_parameter_state(optim_checkpoint_name)
+
+    async_save_request = None
+    if args.async_save:
+        if ckpt_type == CheckpointType.LEGACY:
+            raise NotImplementedError('Async checkpoint save not implemented for legacy checkpoints')
+        elif ckpt_type == CheckpointType.GLOBAL and args.ckpt_format != 'torch_dist':
+            raise NotImplementedError(f'Async checkpoint save not implemented for {args.ckpt_format} distributed checkpoint format')
+
+    rank = torch.distributed.get_rank() if torch.distributed.is_initialized() else 0
+
+    # Collect args, model, RNG.
+    if not torch.distributed.is_initialized() \
+            or mpu.get_expert_data_parallel_rank() == 0 \
+            or ckpt_type != CheckpointType.LEGACY:
+        if ckpt_type != CheckpointType.LEGACY:
+            sharded_sd_metadata = _build_sharded_state_dict_metadata(args)
+            if args.use_distributed_optimizer:
+                print_rank_0(f'Storing distributed optimizer sharded state of type'
+                             f' {sharded_sd_metadata["distrib_optim_sharding_type"]}')
+        else:
+            sharded_sd_metadata = None
+        state_dict = generate_state_dict(
+            args,
+            model,
+            optimizer,
+            opt_param_scheduler,
+            rng_state,
+            iteration=iteration,
+            optim_sd_kwargs=dict(metadata=sharded_sd_metadata),
+            model_sd_kwargs=dict(metadata=sharded_sd_metadata),
+            rerun_state=rerun_state,
+        )
+
+        state_dict['num_floating_point_operations_so_far'] = num_floating_point_operations_so_far
+        if ckpt_type == CheckpointType.GLOBAL and ckpt_format == "torch_dist":
+            if not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0:
+                # TODO Handle non-empty directories (e.g., after a crash during saving).
+                ensure_directory_exists(checkpoint_name, check_parent=False)
+            if checkpointing_context is not None and 'save_strategy' in checkpointing_context:
+                save_strategy = checkpointing_context['save_strategy']
+                # Already saved once before - don't need to rerun sharding validation
+                validate_sharding_integrity = not args.ckpt_assume_constant_structure
+            else:
+                validate_sharding_integrity = True
+                save_strategy = get_default_save_sharded_strategy(args.ckpt_format)
+                if args.ckpt_assume_constant_structure and args.ckpt_format == 'torch_dist':
+                    save_strategy.use_cached_ckpt_structure = args.ckpt_assume_constant_structure
+                    if checkpointing_context is not None and 'load_strategy' in checkpointing_context:
+                        cached_global_metadata = getattr(checkpointing_context['load_strategy'], 'cached_global_metadata', None)
+                        if cached_global_metadata is not None:
+                            logger.debug("Plugging in the read metadata from the load strategy...")
+                            save_strategy.cached_global_metadata = cached_global_metadata
+                        else:
+                            logger.debug("Failed to plug in the read metadata from the load strategy...")
+
+                if args.ckpt_fully_parallel_save:
+                    save_strategy = FullyParallelSaveStrategyWrapper(save_strategy, mpu.get_data_parallel_group(with_context_parallel=True),
+                                                                     args.ckpt_assume_constant_structure)
+            # Store save strategy for future checkpoint saves
+            if checkpointing_context is not None:
+                checkpointing_context['save_strategy'] = save_strategy
+            end_ckpt = time()
+            logger.debug(f"rank: {rank}, takes {end_ckpt - start_ckpt} to prepare state dict for ckpt ")
+            async_save_request = dist_checkpointing.save(state_dict, checkpoint_name, save_strategy,
+                                                         async_sharded_save=args.async_save,
+                                                         validate_access_integrity=validate_sharding_integrity,
+                                                         preprocess_common_before_consistancy_check=preprocess_common_state_dict_fn,
+                                                         content_metadata=sharded_sd_metadata)
+            # [ModelOpt]: save sharded modelopt_state
+            if has_nvidia_modelopt:
+                save_sharded_modelopt_state(model, checkpoint_name, (args.ckpt_format, 1))
+        elif ckpt_type == CheckpointType.GLOBAL and ckpt_format in ["torch_dcp", "fsdp_dtensor"]:
+            if not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0:
+                # TODO Handle non-empty directories (e.g., after a crash during saving).
+                ensure_directory_exists(checkpoint_name, check_parent=False)
+
+            fs_storage_writer = torch.distributed.checkpoint.FileSystemWriter(checkpoint_name)
+            torch.distributed.checkpoint.save(
+                state_dict=state_dict,
+                storage_writer=fs_storage_writer,
+            )
+        else:
+            # [ModelOpt]: Inject modelopt_state into state_dict
+            if has_nvidia_modelopt:
+                if ckpt_type == CheckpointType.LOCAL:
+                    print_rank_0('WARNING: Local checkpointing does not support nvidia_modelopt.')
+                else:
+                    save_modelopt_state(model, state_dict)
+
+            end_ckpt = time()
+            logger.debug(f"rank: {rank}, takes {end_ckpt - start_ckpt} to prepare state dict for ckpt ")
+            if ckpt_type == CheckpointType.LOCAL:
+                try:
+                    from megatron.core.dist_checkpointing.tensor_aware_state_dict import MCoreTensorAwareStateDict
+                except ModuleNotFoundError:
+                    raise RuntimeError("The 'nvidia_resiliency_ext' module is required for local "
+                                       "checkpointing but was not found. Please ensure it is installed.")
+                if (sharded_sd_metadata or {}).get('distrib_optim_sharding_type') in ['fully_reshardable', 'dp_zero_gather_scatter']:
+                    # Note: Currently full reshardabilty is not supported when local checkpoints are used.
+                    raise RuntimeError(
+                        f"Local checkpointing does not support optimizer sharding type '{sharded_sd_metadata['distrib_optim_sharding_type']}'. "
+                        "Use '--ckpt-fully-parallel-save' when saving local checkpoints."
+                    )
+                algo = args.non_persistent_local_ckpt_algo
+                cached_metadata = None
+                if args.ckpt_assume_constant_structure and 'local_checkpoint_cache' in checkpointing_context:
+                    cached_metadata = checkpointing_context['local_checkpoint_cache']
+                state_dict_for_save, cacheable_metadata = MCoreTensorAwareStateDict.from_state_dict(
+                    state_dict, algo=algo, cached_metadata=cached_metadata,
+                    parallelization_group=mpu.get_data_parallel_group(with_context_parallel=True)
+                )
+                async_save_request = checkpointing_context['local_checkpoint_manager'].save(
+                    state_dict_for_save, iteration, is_async=bool(args.async_save)
+                )
+                checkpointing_context['local_checkpoint_cache'] = cacheable_metadata
+            else:
+                assert ckpt_type == CheckpointType.LEGACY
+                # Save.
+                ensure_directory_exists(checkpoint_name)
+                torch.save(state_dict, checkpoint_name)
+    start_misc = time()
+    if ckpt_type != CheckpointType.LOCAL:
+        if not args.async_save:
+            assert async_save_request is None
+            # Wait so everyone is done (necessary)
+            if torch.distributed.is_initialized():
+                torch.distributed.barrier()
+
+    # And update the latest iteration
+    if not torch.distributed.is_initialized() \
+            or torch.distributed.get_rank() == 0:
+        tracker_filename = get_checkpoint_tracker_filename(save_dir)
+
+        if ckpt_type == CheckpointType.LOCAL:
+            def iter_finalize_fn():
+                print_rank_0('  successfully saved local checkpoint from iteration {:7d}'
+                             .format(iteration))
+                if args.log_progress and args.async_save:
+                    append_to_progress_log(f'Saved async local checkpoint\tIteration: {iteration}',
+                                           barrier=False)
+        else:
+            def iter_finalize_fn():
+                prev_iteration = 0
+                save_retain_interval = getattr(args, 'save_retain_interval', None)  # For backwards compatibility of tests.
+                if save_retain_interval is not None:
+                    if os.path.exists(tracker_filename):  # TODO: Make this work with MSC remote paths?
+                        with open_file(tracker_filename, 'r') as f:
+                            prev_iteration = int(f.read().strip())
+                with open_file(tracker_filename, 'w') as f:
+                    f.write(str(iteration))
+                tensor_rank_to_print = (tensor_rank if tensor_rank is not None else mpu.get_tensor_model_parallel_rank()) + 1
+                pipeline_rank_to_print = (pipeline_rank if pipeline_rank is not None else mpu.get_pipeline_model_parallel_rank()) + 1
+                print_rank_0(f'  successfully saved checkpoint from iteration {int(iteration):7d} to {args.save} '
+                             f'[ t {tensor_rank_to_print}/{mpu.get_tensor_model_parallel_world_size()}, '
+                             f'p {pipeline_rank_to_print}/{mpu.get_pipeline_model_parallel_world_size()} ]')
+                if args.log_progress and args.async_save:
+                    append_to_progress_log(f'Saved async checkpoint\tIteration: {iteration}',
+                                           barrier=False)
+
+                def delete_checkpoint(args, iteration_to_delete):
+                    checkpoint_name = get_checkpoint_name(args.save, iteration=iteration_to_delete,
+                                                          return_base_dir=True)
+                    try:
+                        shutil.rmtree(checkpoint_name)  # TODO: Make this work with MSC remote paths?
+                        print_rank_0(f'  successfully deleted checkpoint from iteration {iteration_to_delete:7d} '
+                                     f'at {args.save}')
+                        if args.log_progress:
+                            append_to_progress_log(f'Deleted checkpoint\tIteration: {iteration_to_delete}', barrier=False)
+                    except Exception as e:
+                        print_rank_0(f'  encountered exception "{e}" when trying to delete checkpoint from '
+                                     f'iteration {iteration_to_delete:7d} at {args.save}')
+                        # Any exception encountered in checkpoint deletion can be ignored and is not fatal.
+                        pass
+
+                if save_retain_interval is not None:
+                    if prev_iteration > 0 and prev_iteration != iteration and prev_iteration % save_retain_interval != 0:
+                        checkpoint_name = get_checkpoint_name(args.save, iteration=prev_iteration,
+                                                              return_base_dir=True)
+                        # Don't delete if `checkpoint_name` is a symbolic link.
+                        if os.path.islink(checkpoint_name):  # TODO: Make this work with MSC remote paths?
+                            print_rank_0(f'  skipping deleting checkpoint from iteration {prev_iteration:7d} '
+                                         f'at {args.save} since it is a symbolic link')
+                        else:
+                            # Asynchronous version of delete_checkpoint(args, iteration_to_delete=prev_iteration).
+                            threading.Thread(target=delete_checkpoint, args=(args, prev_iteration,)).start()
+
+        if args.async_save:
+            assert async_save_request is not None
+            async_save_request.add_finalize_fn(iter_finalize_fn)
+        else:
+            iter_finalize_fn()
+
+    # Additional callback for one_logger (last rank)
+    if not torch.distributed.is_initialized() \
+       or is_last_rank():
+        def onelogger_finalize_fn():
+            on_save_checkpoint_success(productive_metrics, args.async_save)
+        if args.async_save:
+            assert async_save_request is not None
+            async_save_request.add_finalize_fn(onelogger_finalize_fn)
+        else:
+            onelogger_finalize_fn()
+
+    # Additional callback for wandb (last rank)
+    if not torch.distributed.is_initialized() \
+       or is_last_rank():
+        def wandb_finalize_fn():
+            wandb_utils.on_save_checkpoint_success(checkpoint_name, get_checkpoint_tracker_filename(save_dir), save_dir, iteration)
+        if args.async_save:
+            assert async_save_request is not None
+            async_save_request.add_finalize_fn(wandb_finalize_fn)
+        else:
+            wandb_finalize_fn()
+
+    if args.async_save:
+        schedule_async_save(async_save_request)
+        print_rank_0('  scheduled an async checkpoint save at iteration {:7d} to {}' \
+                     .format(iteration, save_dir))
+
+    # Wait so everyone is done (not necessary)
+    if torch.distributed.is_initialized():
+        torch.distributed.barrier()
+
+    end_misc = time()
+    logger.debug(f"rank: {rank}, takes {end_misc - start_misc} to finalize ckpt save ")
+
+    ft_integration.on_checkpointing_end(is_async_finalization=False)
+
+def cleanup_old_non_persistent_checkpoint(save_dir, leave_ckpt_num=1, do_async=False):
+    if torch.distributed.is_initialized() and torch.distributed.get_rank() != 0:
+        return
+    save_dir = Path(save_dir)
+
+    iter_prefix = "iter_"
+    iter_ckpts = save_dir.rglob(f'{iter_prefix}*')
+    sorted_iter_ckpts = sorted(iter_ckpts, key=lambda ckpt_name: int(ckpt_name.name[len(iter_prefix):]))
+    if not sorted_iter_ckpts:
+        return
+    rm_iter_ckpts = sorted_iter_ckpts[:-leave_ckpt_num]
+    print_rank_0(f'Non-persistent checkpoints scheduled for removal: {rm_iter_ckpts}')
+    print_rank_0(f'Non-persistent checkpoints to be kept: {sorted_iter_ckpts[-leave_ckpt_num:]}')
+
+    def remove_iter_ckpts(_iter_ckpts):
+        for ckpt in _iter_ckpts:
+            shutil.rmtree(ckpt)
+    if do_async:
+        threading.Thread(target=remove_iter_ckpts, args=(rm_iter_ckpts,)).start()
+    else:
+        remove_iter_ckpts(rm_iter_ckpts)
+
+
+def maybe_save_dataloader_state(train_iterator, iteration, dataloader_save_path):
+    # If no dataloader or saving path is provided, exit early, otherwise, raise an error.
+    if train_iterator is None or dataloader_save_path is None or dataloader_save_path == "":
+        return
+
+    # If dataloader doesn't support saving state, raise an error.
+    if not hasattr(train_iterator.iterable, "save_state"):
+        raise RuntimeError(f"Could not find a save_state for the train_iterator of type {type(train_iterator)}")
+
+    # Save dataloader state for each data parallel rank only once.
+    first_rank = mpu.is_pipeline_first_stage(ignore_virtual=True) and mpu.get_tensor_model_parallel_rank() == 0
+    if not first_rank:
+        return
+
+    dp_rank = mpu.get_data_parallel_rank()
+    print(f"saving dataloader checkpoint at iteration {iteration} to {dataloader_save_path}")
+    train_dataloader_state_dict = train_iterator.iterable.save_state()
+    data_state_save_path = get_checkpoint_name(
+        dataloader_save_path, iteration,
+        basename=f'train_dataloader_dprank{dp_rank:03d}.pt'
+    )
+
+    torch.distributed.barrier(group=mpu.get_data_parallel_group())
+
+    if mpu.get_data_parallel_rank() == 0:
+        ensure_directory_exists(data_state_save_path)
+
+    torch.distributed.barrier(group=mpu.get_data_parallel_group())
+
+    dataloader_save_dict = {}
+    dataloader_save_dict['dataloader_state_dict'] = train_dataloader_state_dict
+    torch.save(dataloader_save_dict, data_state_save_path)
+
+
+def generate_state_dict(args, model, optimizer, opt_param_scheduler,
+                        rng_state, iteration=None,
+                        optim_sd_kwargs=None, model_sd_kwargs=None, rerun_state=None):
+
+    # Arguments, iteration, and model.
+    state_dict = {}
+    state_dict['args'] = args
+    state_dict['checkpoint_version'] = 3.0
+    if iteration is not None:
+        state_dict['iteration'] = iteration
+
+    for i in range(len(model)):
+        key = "model"
+        if len(model) > 1:
+            key = f"model{i}"
+
+        if args.ckpt_format == "torch_dist":
+            model_sd = model[i].sharded_state_dict(**(model_sd_kwargs or {}))
+        else:   # torch, torch_dcp, fsdp_dtensor
+            model_sd = model[i].state_dict_for_save_checkpoint()
+
+        state_dict[key] = model_sd
+
+    # Optimizer stuff.
+    if not args.no_save_optim:
+        if optimizer is not None and not optimizer.is_stub_optimizer:
+            optimizer_sd = None
+
+            if args.ckpt_format == "torch_dist":
+                optimizer_sd = optimizer.sharded_state_dict(state_dict, **(optim_sd_kwargs or {}))
+            elif args.ckpt_format == "fsdp_dtensor":
+                if optim_sd_kwargs is None:
+                    optim_sd_kwargs = {}
+                if "metadata" not in optim_sd_kwargs:
+                    optim_sd_kwargs["metadata"] = {}
+                optim_sd_kwargs['metadata'].update(_build_sharded_state_dict_metadata(args))
+                optimizer_sd = optimizer.sharded_state_dict(state_dict, **optim_sd_kwargs)
+            else:
+                optimizer_sd = optimizer.state_dict()
+
+            state_dict['optimizer'] = optimizer_sd
+
+        if opt_param_scheduler is not None:
+            state_dict['opt_param_scheduler'] = \
+                opt_param_scheduler.state_dict()
+
+    # Rerun state
+    if rerun_state:
+        state_dict['rerun_state_machine'] = rerun_state
+
+    # RNG states.
+    if not args.no_save_rng and rng_state:
+        state_dict["rng_state"] = rng_state
+
+    # fsdp_dtensor ckpt specific state dict preprocessing
+    if args.ckpt_format == "fsdp_dtensor":
+        assert HAVE_MEGATRON_FSDP, "Megatron FSDP is enabled but Megatron-FSDP is not available."
+        assert len(model) == 1, "FSDP DTensor checkpoints are not supported for multiple models."
+        if args.swiglu:
+            state_dict = state_dict.copy()
+            handle_swiglu_in_state_dict(
+                model[0], state_dict["model"], state_dict["optimizer"])
+        handle_fp8_extra_state_case(state_dict["model"])
+        preprocess_state_dict_for_uneven_dtensor(state_dict)
+
+    return state_dict
+
+
+def _transpose_first_dim(t, num_splits, num_splits_first, model):
+    input_shape = t.size()
+    # We use a self_attention module but the values extracted aren't
+    # specific to self attention so should work for cross attention as well
+    while hasattr(model, 'module'):
+        model = model.module
+    attention_module = model.language_model.encoder.layers[0].self_attention
+    hidden_size_per_attention_head = attention_module.hidden_size_per_attention_head
+    num_attention_heads_per_partition = attention_module.num_attention_heads_per_partition
+    if num_splits_first:
+        intermediate_shape = \
+            (num_splits, num_attention_heads_per_partition,
+             hidden_size_per_attention_head) + input_shape[1:]
+
+        t = t.view(*intermediate_shape)
+        t = t.transpose(0, 1).contiguous()
+    else:
+        intermediate_shape = \
+            (num_attention_heads_per_partition,
+             hidden_size_per_attention_head, num_splits) +\
+             input_shape[1:]
+
+        t = t.view(*intermediate_shape)
+        t = t.transpose(1, 2).contiguous()
+    t = t.view(*input_shape)
+
+    return t
+
+
+def fix_query_key_value_ordering(model, checkpoint_version):
+    if checkpoint_version < 2.0:
+        if isinstance(model, list):
+            assert len(model)==1
+            model = model[0]
+        for name, param in model.named_parameters():
+            if name.endswith(('.query_key_value.weight', '.query_key_value.bias')):
+                if checkpoint_version == 0:
+                    fixed_param = _transpose_first_dim(param.data, 3, True, model)
+                elif checkpoint_version == 1.0:
+                    fixed_param = _transpose_first_dim(param.data, 3, False, model)
+                else:
+                    print_rank_0(f"Invalid checkpoint version {checkpoint_version}.")
+                    sys.exit()
+                param.data.copy_(fixed_param)
+            if name.endswith(('.key_value.weight', '.key_value.bias')):
+                if checkpoint_version == 0:
+                    fixed_param = _transpose_first_dim(param.data, 2, True, model)
+                elif checkpoint_version == 1.0:
+                    fixed_param = _transpose_first_dim(param.data, 2, False, model)
+                else:
+                    print_rank_0(f"Invalid checkpoint version {checkpoint_version}.")
+                    sys.exit()
+                param.data.copy_(fixed_param)
+        print_rank_0(" successfully fixed query-key-values ordering for"
+                     " checkpoint version {}".format(checkpoint_version))
+
+
+def _get_non_persistent_iteration(non_persistent_global_dir, args, checkpointing_context=None):
+    if args.non_persistent_ckpt_type is None:
+        return -1
+    elif args.non_persistent_ckpt_type == "global":
+        tracker_filename = get_checkpoint_tracker_filename(non_persistent_global_dir)
+        if isfile(tracker_filename):
+            iteration, release = read_metadata(tracker_filename)
+            if release:
+                raise RuntimeError('Non-persistent checkpoint can\'t be a release checkpoint')
+        else:
+            iteration = -1
+            print_rank_0('WARNING: could not find the metadata file {}'.format(tracker_filename))
+            print_rank_0('    will not load any non-persistent checkpoint')
+        return iteration
+    elif args.non_persistent_ckpt_type == "local":
+        return checkpointing_context['local_checkpoint_manager'].find_latest()
+    else:
+        assert False, 'Please use local or global non-persistent checkpoints' \
+            f'(got: {args.non_persistent_ckpt_type})'
+
+
+def _load_non_persistent_base_checkpoint(
+    non_persistent_global_dir,
+    args,
+    rank0,
+    sharded_state_dict,
+    non_persistent_iteration,
+    checkpointing_context=None,
+):
+    assert args.non_persistent_ckpt_type is not None
+    if args.non_persistent_ckpt_type == "global":
+        if not rank0:
+            print_rank_0(
+                f'Loading from a non-persistent checkpoint (non-persistent iter {non_persistent_iteration})'
+            )
+        return _load_global_dist_base_checkpoint(
+            non_persistent_global_dir, args, rank0, sharded_state_dict, non_persistent_iteration, False,
+            checkpointing_context=checkpointing_context
+        )
+    elif args.non_persistent_ckpt_type == "local":
+        intermediate_state_dict, checkpoint_name = checkpointing_context[
+            'local_checkpoint_manager'
+        ].load()
+        state_dict = intermediate_state_dict.to_state_dict(
+            sharded_state_dict,
+            algo=args.non_persistent_local_ckpt_algo,
+            parallelization_group = mpu.get_data_parallel_group(with_context_parallel=True)
+        )
+        return state_dict, checkpoint_name, False, CheckpointType.LOCAL
+    else:
+        raise NotImplementedError(f"Please use local or global non-persistent checkpoints (got: {args.non_persistent_ckpt_type})")
+
+
+def _load_global_dist_base_checkpoint(
+    load_dir, args, rank0, sharded_state_dict, iteration, release, checkpointing_context=None
+):
+    if rank0:
+        checkpoint_name = find_checkpoint_rank_0(load_dir, iteration, release)
+        state_dict = dist_checkpointing.load_common_state_dict(checkpoint_name)
+        return state_dict, checkpoint_name, release, CheckpointType.GLOBAL
+
+    if sharded_state_dict is None:
+        assert not args.auto_detect_ckpt_format and not args.use_dist_ckpt, (
+            args.auto_detect_ckpt_format,
+            args.use_dist_ckpt,
+        )
+        raise RuntimeError(
+            'Detected load from a distributed checkpoint, but neither --use-dist-ckpt nor --auto-detect-ckpt-format is set.'
+        )
+
+    checkpoint_name = get_checkpoint_name(load_dir, iteration, release, return_base_dir=True)
+    load_strategy = get_default_load_sharded_strategy(checkpoint_name)
+    # NOTE: `args.ckpt_fully_parallel_load` applies to both persistent and non-persistent checkpoints.
+    if args.ckpt_fully_parallel_load:
+        load_strategy = FullyParallelLoadStrategyWrapper(
+            load_strategy, mpu.get_data_parallel_group(with_context_parallel=True)
+        )
+    if checkpointing_context is not None:
+        checkpointing_context["load_strategy"] = load_strategy
+    state_dict = dist_checkpointing.load(sharded_state_dict, checkpoint_name, load_strategy, strict=args.dist_ckpt_strictness)
+    return state_dict, checkpoint_name, release, CheckpointType.GLOBAL
+
+
+def _get_checkpoint_format(checkpoint_name, args):
+    if MultiStorageClientFeature.is_enabled():
+        msc = MultiStorageClientFeature.import_package()
+        checkpoint_dir = msc.Path(checkpoint_name)
+        is_torch_ckpt = any([f.name.startswith("mp_rank_0") for f in checkpoint_dir.iterdir()])
+        is_torch_dcp = checkpoint_dir.joinpath(".metadata").exists()
+    else:
+        is_torch_ckpt = any([f.startswith("mp_rank_0") for f in os.listdir(checkpoint_name)])
+        is_torch_dcp = os.path.exists(os.path.join(checkpoint_name, ".metadata"))
+
+    ckpt_format = None
+    if dist_checkpointing.check_is_distributed_checkpoint(checkpoint_name):
+        ckpt_format = "torch_dist"
+    elif is_torch_ckpt:
+        ckpt_format = "torch"
+    elif is_torch_dcp:
+        ckpt_format = "torch_dcp"
+        if getattr(args, "use_megatron_fsdp", False):
+            ckpt_format = "fsdp_dtensor"
+    else:
+        raise NotImplementedError(f"unknown checkpoint format in {checkpoint_name}")
+
+    return ckpt_format
+
+
+def _load_base_checkpoint(
+    load_dir,
+    args,
+    rank0=False,
+    sharded_state_dict=None,
+    checkpointing_context=None,
+):
+    # Try to load non-persistent checkpoint first
+    non_persistent_global_dir = (
+        args.non_persistent_global_ckpt_dir
+        if args.non_persistent_global_ckpt_dir or load_dir is None
+        else os.path.join(load_dir, _NON_PERSISTENT_CKPT_SUBDIR)
+    )
+    non_persistent_iteration = _get_non_persistent_iteration(
+        non_persistent_global_dir, args, checkpointing_context
+    )
+    iteration, release = -1, False
+    tracker_filename = 'because load directory is not defined'
+    if load_dir is not None:
+        tracker_filename = get_checkpoint_tracker_filename(load_dir)
+        if isfile(tracker_filename):
+            iteration, release = read_metadata(tracker_filename)
+
+    # Allow user to specify the loaded iteration.
+    if getattr(args, "ckpt_step", None):
+        iteration = args.ckpt_step
+
+    if non_persistent_iteration != -1:  # there is a non-persistent checkpoint
+        if non_persistent_iteration >= iteration:
+            return _load_non_persistent_base_checkpoint(
+                non_persistent_global_dir,
+                args,
+                rank0,
+                sharded_state_dict,
+                non_persistent_iteration,
+                checkpointing_context,
+            )
+        else:
+            print_rank_0('WARNING: non-persistent checkpoints are older than persistent checkpoint')
+
+    # Otherwise we are dealing with global checkpoints
+    # If no tracker file, return nothing
+    if iteration == -1:
+        if not rank0:
+            print_rank_0('WARNING: could not find the metadata file {}'.format(tracker_filename))
+            print_rank_0('    will not load any checkpoints and will start from random')
+        # Conditionally exit if checkpoint not found.
+        if args.exit_on_missing_checkpoint:
+            print_rank_0(">> '--exit-on-missing-checkpoint' set ... exiting. <<")
+            if torch.distributed.is_initialized():
+                torch.distributed.barrier()
+            sys.exit()
+
+        return None, "", False, None
+
+    # Determine the type of the checkpoint on disk.
+    checkpoint_name = get_checkpoint_name(load_dir, iteration, release, return_base_dir=True)
+    ckpt_format = _get_checkpoint_format(checkpoint_name, args)
+
+    if not rank0:
+        dist_infix = "distributed " if ckpt_format == "torch_dist" else ""
+        if release:
+            print_rank_0(f' loading release {dist_infix}checkpoint from {load_dir}')
+        else:
+            print_rank_0(
+                f' loading {dist_infix}checkpoint from {load_dir} at iteration {iteration}'
+            )
+
+    ckpt_type = None
+
+    # Handle global distributed checkpoint
+    if ckpt_format == "torch_dist":
+        return _load_global_dist_base_checkpoint(
+            load_dir, args, rank0, sharded_state_dict, iteration, release, checkpointing_context=checkpointing_context
+        )
+    elif ckpt_format == "torch":
+        ckpt_type = CheckpointType.LEGACY
+        # Handle global legacy checkpoint
+        if rank0:
+            checkpoint_name = find_checkpoint_rank_0(load_dir, iteration, release)
+        else:
+            checkpoint_name = get_checkpoint_name(load_dir, iteration, release, return_base_dir=False)
+        try:
+            state_dict = torch.load(checkpoint_name, map_location='cpu')
+        except ModuleNotFoundError:
+            from megatron.legacy.fp16_deprecated import loss_scaler
+
+            # For backward compatibility.
+            if not rank0:
+                print_rank_0(' > deserializing using the old code structure ...')
+            sys.modules['fp16.loss_scaler'] = sys.modules['megatron.legacy.fp16_deprecated.loss_scaler']
+            sys.modules['megatron.fp16.loss_scaler'] = sys.modules[
+                'megatron.legacy.fp16_deprecated.loss_scaler'
+            ]
+            sys.modules['megatron.model'] = sys.modules['megatron.legacy.model']
+            state_dict = torch.load(checkpoint_name, map_location='cpu')
+            sys.modules.pop('fp16.loss_scaler', None)
+            sys.modules.pop('megatron.fp16.loss_scaler', None)
+            sys.modules.pop('megatron.model', None)
+        except Exception as e:
+            print('could not load the checkpoint')
+            print(e)
+            sys.exit()
+    elif ckpt_format == "torch_dcp":
+        ckpt_type = CheckpointType.TORCH_DCP
+
+        if rank0:
+            # _load_base_checkpoint is called from load_args_from_checkpoint. torch.distributed is not initialized.
+            # Load only metadata.
+            state_dict = {"args": None, "iteration": None}
+            torch.distributed.checkpoint.load(
+                state_dict=state_dict,
+                checkpoint_id=checkpoint_name,
+            )
+        else:
+            # _load_base_checkpoint is called from load_checkpoint with a proper state dict.
+            state_dict = sharded_state_dict
+
+            fs_storage_reader = torch.distributed.checkpoint.FileSystemReader(checkpoint_name)
+
+            torch.distributed.checkpoint.load_state_dict(
+                state_dict=state_dict,
+                storage_reader=fs_storage_reader,
+            )
+    elif ckpt_format == "fsdp_dtensor":
+        assert HAVE_MEGATRON_FSDP, "Should not be called if Megatron-FSDP is not available."
+        if rank0:
+            return {}, checkpoint_name, release, CheckpointType.FSDP_DTENSOR
+
+        ckpt_type = CheckpointType.FSDP_DTENSOR
+        fs_storage_reader = torch.distributed.checkpoint.FileSystemReader(checkpoint_name)
+        allow_partial_load = not getattr(args, 'strict_fsdp_dtensor_load', False)
+        if allow_partial_load:
+            state_dict_metadata = fs_storage_reader.read_metadata().state_dict_metadata
+            rank = torch.distributed.get_rank()
+            import time as _time
+            _time.sleep(rank * 0.001)  # Make that logs of different ranks do not overlap
+            print_diff_in_state_dicts(state_dict_metadata, sharded_state_dict)
+
+        planner = default_planner.DefaultLoadPlanner(allow_partial_load=allow_partial_load)
+        torch.distributed.checkpoint.load_state_dict(
+            state_dict=sharded_state_dict,
+            storage_reader=fs_storage_reader,
+            planner=planner,
+        )
+        state_dict = sharded_state_dict
+    else:
+        raise NotImplementedError(f"checkpoint format {ckpt_format} not supported")
+
+    return state_dict, checkpoint_name, release, ckpt_type
+
+
+def load_args_from_checkpoint(
+    args, load_arg='load', checkpointing_context=None
+):
+    load_dir = getattr(args, load_arg)
+
+    if load_dir is None:
+        print_rank_0('No load directory specified, using provided arguments.')
+        return args
+
+    state_dict, checkpoint_name, release, ckpt_type = _load_base_checkpoint(
+        load_dir,
+        args,
+        rank0=True,
+        checkpointing_context=checkpointing_context,
+    )
+
+    # Args.
+    if not state_dict:
+        print_rank_0('Checkpoint not found to provide arguments, using provided arguments.')
+        return args
+
+    if 'args' not in state_dict:
+        print_rank_0('Checkpoint provided does not have arguments saved, using provided arguments.')
+        return args
+
+    checkpoint_args = state_dict['args']
+    checkpoint_version = state_dict.get('checkpoint_version', 0)
+    args.iteration = state_dict['iteration']
+
+    # One-off conversion for foundation models
+    if hasattr(checkpoint_args, 'disable_bias_linear'):
+        setattr(
+            checkpoint_args, 'add_bias_linear', not getattr(checkpoint_args, 'disable_bias_linear')
+        )
+
+    def _set_arg(arg_name, old_arg_name=None, force=False):
+        if not force and getattr(args, arg_name, None) is not None:
+            return
+
+        if old_arg_name is not None:
+            checkpoint_value = getattr(checkpoint_args, old_arg_name, None)
+        else:
+            checkpoint_value = getattr(checkpoint_args, arg_name, None)
+
+        if checkpoint_value is not None:
+            print_rank_0(f"Setting {arg_name} to {checkpoint_value} from checkpoint")
+            setattr(args, arg_name, checkpoint_value)
+        else:
+            print_rank_0(f"Checkpoint did not provide arguments {arg_name}")
+
+    # Model args.
+    _set_arg('num_layers')
+    _set_arg('hidden_size')
+    _set_arg('ffn_hidden_size')
+    _set_arg('seq_length')
+    _set_arg('num_attention_heads')
+    _set_arg('num_query_groups', force=True)
+    _set_arg('group_query_attention', force=True)
+    _set_arg('kv_channels')
+    _set_arg('max_position_embeddings')
+    _set_arg('position_embedding_type', force=True)
+    _set_arg('add_position_embedding', force=True)
+    _set_arg('use_rotary_position_embeddings', force=True)
+    _set_arg('rotary_base', force=True)
+    _set_arg('rotary_percent', force=True)
+    _set_arg('rotary_interleaved', force=True)
+    _set_arg('add_bias_linear', force=True)
+    _set_arg('add_qkv_bias', force=True)
+    _set_arg('squared_relu', force=True)
+    _set_arg('swiglu', force=True)
+    _set_arg('untie_embeddings_and_output_weights', force=True)
+    _set_arg('apply_layernorm_1p', force=True)
+    _set_arg('normalization', force=True)
+    _set_arg('apply_query_key_layer_scaling', force=True)
+    _set_arg('attention_dropout', force=True)
+    _set_arg('hidden_dropout', force=True)
+
+    _set_arg('hybrid_override_pattern', force=True)
+    _set_arg('spec', force=True)
+    _set_arg('hybrid_attention_ratio', force=True)
+    _set_arg('hybrid_mlp_ratio', force=True)
+
+    _set_arg('num_experts', force=True)
+    _set_arg('moe_layer_freq', force=True)
+    if getattr(checkpoint_args, 'num_experts', None) is not None:
+        _set_arg('moe_ffn_hidden_size', force=True)
+    else:
+        setattr(args, 'moe_ffn_hidden_size', None)
+    _set_arg('moe_router_topk', force=True)
+    _set_arg('moe_token_dispatcher_type', force=True)
+    _set_arg('moe_router_pre_softmax', force=True)
+    _set_arg('moe_grouped_gemm', force=True)
+    _set_arg('moe_shared_expert_intermediate_size', force=True)
+
+    # Mamba args.
+    _set_arg('mamba_state_dim', force=True)
+    _set_arg('mamba_head_dim', force=True)
+    _set_arg('mamba_num_groups', force=True)
+    _set_arg('mamba_num_heads', force=True)
+    _set_arg('is_hybrid_model', force=True)
+
+    # Heterogeneous args.
+    _set_arg('heterogeneous_layers_config_path', force=True)
+    _set_arg('heterogeneous_layers_config_encoded_json', force=True)
+
+    # Tokenizer args.
+    _set_arg('tokenizer_type', force=True)
+    # Using checkpoint version might not always be safe (e.g., if running on different cluster).
+    if args.use_tokenizer_model_from_checkpoint_args:
+        _set_arg('tokenizer_model', force=True)
+    _set_arg('tiktoken_pattern', force=True)
+    _set_arg('padded_vocab_size')
+
+    # Checkpoint args.
+    _set_arg('ckpt_format')
+
+    # Model parallelism args.
+    if args.use_mp_args_from_checkpoint_args:
+        if checkpoint_version < 3.0:
+            _set_arg('tensor_model_parallel_size', 'model_parallel_size')
+        else:
+            _set_arg('tensor_model_parallel_size', force=True)
+            _set_arg('pipeline_model_parallel_size', force=True)
+            _set_arg('virtual_pipeline_model_parallel_size', force=True)
+            _set_arg('num_layers_per_virtual_pipeline_stage')
+            _set_arg('expert_model_parallel_size', force=True)
+
+    return args, checkpoint_args
+
+
+def load_checkpoint(ddp_model, optimizer, opt_param_scheduler, load_arg='load', strict=True,
+                    checkpointing_context=None, skip_load_to_model_and_opt=False):
+    args = get_args()
+    load_dir = getattr(args, load_arg)
+
+    # Check for model-opt format loading
+    if hasattr(args, 'load_model_opt_format') and args.load_model_opt_format:
+        print_rank_0(f'Loading checkpoint using ModelOpt format from {load_dir}')
+        from megatron.post_training.checkpointing import load_modelopt_checkpoint
+
+        # Call the ModelOpt checkpoint loading function
+        load_modelopt_checkpoint(
+            ddp_model,
+            optimizer=optimizer,
+            opt_param_scheduler=opt_param_scheduler,
+            strict=strict,
+            load_arg=load_arg
+        )
+
+        # Since load_modelopt_checkpoint doesn't return iteration count, we need to get it
+        if torch.distributed.is_initialized():
+            tracker_filename = get_checkpoint_tracker_filename(load_dir)
+            if os.path.isfile(tracker_filename):
+                iteration, release = read_metadata(tracker_filename)
+                if release:
+                    iteration = 0
+            else:
+                iteration = 0
+        else:
+            iteration = 0
+
+        # We don't have a reliable way to get num_floating_point_operations_so_far from ModelOpt format
+        return iteration, 0
+
+    # Finetuning directories
+    pretrained_dir = getattr(args, 'pretrained_checkpoint', None)
+    if pretrained_dir is not None and not checkpoint_exists(load_dir):
+        print_rank_0(
+            f'Checkpoint file not found in load directory {load_dir} attempting to finetune with checkpoint in {pretrained_dir}'
+        )
+        load_dir = pretrained_dir
+        if not checkpoint_exists(load_dir):
+            raise FileNotFoundError("No checkpoint found in load directory or pretrained directory")
+        args.finetune = True
+
+    model = unwrap_model(ddp_model)
+
+    ckpt_format = args.ckpt_format
+    if args.auto_detect_ckpt_format or ckpt_format == "torch_dist":
+        state_dict, checkpoint_name, release, ckpt_type = _load_base_checkpoint(
+            load_dir,
+            args,
+            rank0=True,
+            checkpointing_context=checkpointing_context,
+        )
+
+        ckpt_format = None
+        if ckpt_type == CheckpointType.TORCH_DCP:
+            ckpt_format = "torch_dcp"
+        elif ckpt_type == CheckpointType.FSDP_DTENSOR:
+            ckpt_format = "fsdp_dtensor"
+        elif ckpt_type == CheckpointType.LEGACY:
+            ckpt_format = "torch"
+        elif ckpt_type in [CheckpointType.LOCAL, CheckpointType.GLOBAL]:
+            ckpt_format = "torch_dist"
+        elif ckpt_type == None:
+            pass    # Not loaded.
+        else:
+            raise NotImplementedError(f"checkpoint format {ckpt_format} not supported")
+
+    load_kwargs = {}
+    ignore_rng_state = False
+    ignore_rerun_state = True
+    if ckpt_format == "torch_dist":
+        ckpt_tp_pp = (
+            state_dict['args'].tensor_model_parallel_size,
+            state_dict['args'].pipeline_model_parallel_size,
+        )
+        run_tp_pp = (
+            args.tensor_model_parallel_size,
+            args.pipeline_model_parallel_size,
+        )
+
+        ckpt_world_size = getattr(state_dict['args'], 'world_size', 0)
+        run_world_size = getattr(args, 'world_size', 0)
+        ckpt_dp = getattr(state_dict['args'], 'data_parallel_size', 0)
+        run_dp = getattr(args, 'data_parallel_size', 0)
+        mismatch_msg = "(TP, PP) mismatch after resume ({} vs {} from checkpoint)".format(
+            run_tp_pp, ckpt_tp_pp
+        )
+
+        # Determine if RNG state will be loaded
+        if (ckpt_tp_pp == run_tp_pp and not release and not args.finetune and not args.no_load_rng
+                and not getattr(state_dict['args'], 'no_save_rng', False)):
+            gen_sd_rng_state = get_rng_state(args.ckpt_format)  # we can load the rng state
+        else:
+            ignore_rng_state = True
+            gen_sd_rng_state = None
+            if ckpt_tp_pp != run_tp_pp:
+                print_rank_0("{}: RNG state will be ignored".format(mismatch_msg))
+
+        if ckpt_type == CheckpointType.LOCAL:
+            sharded_sd_metadata = _build_sharded_state_dict_metadata(args)
+        else:
+            sharded_sd_metadata = dist_checkpointing.load_content_metadata(preloaded_state_dict=state_dict)
+        print_rank_0(f'sharded_state_dict metadata loaded from the checkpoint: {sharded_sd_metadata}')
+        # Determine if optimizer state will be loaded
+        if (not release and not args.finetune and not args.no_load_optim
+                and not getattr(state_dict['args'], 'no_save_optim', False)):
+            gen_sd_optim = optimizer
+            gen_sd_opt_param_scheduler = opt_param_scheduler
+
+            if args.use_distributed_optimizer:
+                if sharded_sd_metadata is None:
+                    # Backward-compatibility with old checkpoints which don't have content versioning
+                    # Can be removed after ending support for MLM optimizer checkpoints with MCore < v0.13
+                    # (for MCore v0.13+ checkpoints `sharded_sd_metadata is not None`)
+                    sharded_sd_metadata = {
+                        'distrib_optim_sharding_type': ('fully_sharded_model_space'
+                                                        if getattr(state_dict['args'], 'ckpt_fully_parallel_save', False)
+                                                        else 'dp_zero_gather_scatter'),
+                    }
+                if ckpt_tp_pp != run_tp_pp and sharded_sd_metadata['distrib_optim_sharding_type'] != 'fully_sharded_model_space':
+                    raise RuntimeError(f"{mismatch_msg}: not supported for DistributedOptimizer with sharding type"
+                                       f" {sharded_sd_metadata['distrib_optim_sharding_type']}."
+                                       f" Please use `--ckpt-fully-parallel-save` flag during checkpoint saving.")
+
+                # Check if fully parallel load is compatible with sharding type
+                if args.ckpt_fully_parallel_load and sharded_sd_metadata['distrib_optim_sharding_type'] == 'dp_zero_gather_scatter':
+                    raise RuntimeError("Fully parallel load is not supported for dp_zero_gather_scatter checkpoints. "
+                                       "Please remove --ckpt-fully-parallel-load flag")
+        else:
+            gen_sd_optim = None
+            gen_sd_opt_param_scheduler = None
+
+        optim_sd_kwargs = dict(metadata=sharded_sd_metadata, is_loading=True)
+        model_sd_kwargs = dict(metadata=sharded_sd_metadata)
+
+        # Determine if rerun state will be loaded
+        gen_sd_rerun_state = None
+        if (
+            ckpt_world_size == run_world_size
+            and ckpt_tp_pp == run_tp_pp
+            and ckpt_dp == run_dp
+            and not release
+            and not args.finetune
+            and 'rerun_state_machine' in state_dict
+        ):
+            rerun_state_machine = get_rerun_state_machine()
+            if rerun_state_machine.validate_state_dict(state_dict['rerun_state_machine']):
+                gen_sd_rerun_state = rerun_state_machine.state_dict(
+                    data_iterator=None, ckpt_format=ckpt_format, force=True,
+                )
+                ignore_rerun_state = False
+        if (
+            ckpt_world_size != run_world_size
+            or ckpt_tp_pp != run_tp_pp
+            or ckpt_dp != run_dp
+        ):
+            print_rank_0("Job sharding has changed: Rerun state will be ignored")
+
+        # [ModelOpt]: IMPORTANT! Restoring modelopt_state (sharded or not) must be performed
+        # after the model instance has been created and before _load_base_checkpoint is called.
+        if has_nvidia_modelopt:
+            if ckpt_type == CheckpointType.LOCAL:
+                print_rank_0('WARNING: Local checkpointing does not support nvidia_modelopt.')
+            elif ckpt_type == CheckpointType.GLOBAL:
+                restore_modelopt_state(model, state_dict)
+            else:
+                restore_sharded_modelopt_state(model, checkpoint_name)
+
+        # [ModelOpt]: Initial loading from non-resume sharded checkpoint to a Distillation Model
+        # will result in key mismatch with loss modules potentially containing parameters, since
+        # it requires generating a state_dict before loading. Here we hide those modules if present.
+        with contextlib.ExitStack() as stack:  # Allows multiple context managers for each model shard
+            if args.finetune and hasattr(model[0], "hide_loss_modules"):
+                for m in model:
+                    stack.enter_context(m.hide_loss_modules())
+            load_kwargs['sharded_state_dict'] = generate_state_dict(
+                args, model, gen_sd_optim, gen_sd_opt_param_scheduler, gen_sd_rng_state,
+                optim_sd_kwargs=optim_sd_kwargs, model_sd_kwargs=model_sd_kwargs,
+                rerun_state=gen_sd_rerun_state
+            )
+    elif args.ckpt_format == "torch_dcp":
+        model_sd = model[0].state_dict()
+        optimizer_sd = optimizer.state_dict(is_loading=True)
+        sharded_state_dict = {
+            "model": model_sd,
+            "optimizer": optimizer_sd,
+            "args": None,
+            "iteration": 1,
+            "rng_state": get_rng_state(args.ckpt_format),
+            "checkpoint_version": None,
+            "opt_param_scheduler": opt_param_scheduler.state_dict(),
+            "num_floating_point_operations_so_far": 0,
+        }
+        load_kwargs["sharded_state_dict"] = sharded_state_dict
+    elif args.ckpt_format == "fsdp_dtensor":
+        reader = FileSystemReader(get_load_checkpoint_path_by_args(args))
+        try:
+            state_dict_metadata = reader.read_metadata().state_dict_metadata
+        except FileNotFoundError:
+            state_dict_metadata = {}
+
+        gen_sd_rerun_state = None
+        gen_sd_opt_param_scheduler = None
+        gen_sd_rng_state = None
+        gen_sd_optim = None
+        if not args.finetune:
+            if "rerun_state_machine" in state_dict_metadata:
+                gen_sd_rerun_state = get_rerun_state_machine().state_dict(
+                    data_iterator=None, ckpt_format=ckpt_format, force=True,
+                )
+            if not args.no_load_rng:
+                gen_sd_rng_state = get_rng_state(args.ckpt_format)
+            if not args.no_load_optim:
+                gen_sd_optim = optimizer
+                gen_sd_opt_param_scheduler = opt_param_scheduler
+
+        optim_sd_kwargs = dict(metadata=_build_sharded_state_dict_metadata(args), is_loading=True)
+
+        load_kwargs["sharded_state_dict"] = generate_state_dict(
+            args,
+            model=model,
+            optimizer=gen_sd_optim,
+            opt_param_scheduler=gen_sd_opt_param_scheduler,
+            rng_state=gen_sd_rng_state,
+            optim_sd_kwargs=optim_sd_kwargs,
+            rerun_state=gen_sd_rerun_state,
+            iteration=1,
+        )
+
+    state_dict, checkpoint_name, release, ckpt_type = _load_base_checkpoint(
+        load_dir, args, rank0=False, checkpointing_context=checkpointing_context,
+        **load_kwargs
+    )
+
+    # Checkpoint not loaded.
+    if state_dict is None:
+        # Iteration and num_floating_point_operations_so_far default to 0.
+        return 0, 0
+
+    # Set checkpoint version.
+    set_checkpoint_version(state_dict.get('checkpoint_version', 0))
+
+    # Convert to regular torch tensor to DTensor.
+    if ckpt_type == CheckpointType.LEGACY and args.ckpt_format == "torch_dcp":
+        dtensor_state_dict = _to_dtensor(ddp_model, state_dict["model"])
+        state_dict["model"] = dtensor_state_dict
+
+    # Set iteration.
+    if args.finetune or release:
+        iteration = 0
+    else:
+        try:
+            iteration = state_dict['iteration']
+        except KeyError:
+            try:  # Backward compatible with older checkpoints
+                iteration = state_dict['total_iters']
+            except KeyError:
+                print_rank_0('A metadata file exists but unable to load '
+                             'iteration from checkpoint {}, exiting'.format(checkpoint_name))
+                sys.exit()
+    num_floating_point_operations_so_far = state_dict.get('num_floating_point_operations_so_far', 0)
+
+    # Check arguments.
+    assert args.consumed_train_samples == 0
+    assert args.skipped_train_samples == 0
+    assert args.consumed_valid_samples == 0
+    if 'args' in state_dict and not args.finetune:
+        checkpoint_args = state_dict['args']
+        check_checkpoint_args(checkpoint_args)
+        args.consumed_train_samples = getattr(checkpoint_args,
+                                              'consumed_train_samples', 0)
+        args.skipped_train_samples = getattr(checkpoint_args,
+                                             'skipped_train_samples', 0)
+        update_num_microbatches(consumed_samples=args.consumed_train_samples, verbose=True)
+        args.consumed_valid_samples = getattr(checkpoint_args,
+                                              'consumed_valid_samples', 0)
+    else:
+        print_rank_0('could not find arguments in the checkpoint ...')
+
+    def load_model_state_dict(module, state_dict, strict: bool):
+        try:
+            module.load_state_dict(state_dict, strict=strict)
+        except Exception as e:
+            if strict:
+                # Fallback support for backward compatibility breaking changes in TransformerEngine
+                load_return = module.load_state_dict(state_dict, strict=False)
+                print(f"load_return: {load_return}")
+    # Model.
+    strict = False if args.retro_add_retriever else strict
+    if not skip_load_to_model_and_opt:
+        if len(ddp_model) == 1:
+            load_model_state_dict(ddp_model[0], state_dict['model'], strict)
+        else:
+            for i in range(len(ddp_model)):
+                # If there is no corresponding model in the state_dict, it will be ignored.
+                # It means that this is an empty stage.
+                if 'model%d' % i not in state_dict:
+                    continue
+                load_model_state_dict(ddp_model[i], state_dict['model%d' % i], strict)
+    # Fix up query/key/value matrix ordering if needed.
+    checkpoint_version = get_checkpoint_version()
+    print_rank_0(f' checkpoint version {checkpoint_version}')
+    fix_query_key_value_ordering(model, checkpoint_version)
+
+    # Optimizer.
+    if not release and not args.finetune and not args.no_load_optim:
+        try:
+            # Load state dict.
+            if not skip_load_to_model_and_opt and optimizer is not None and not optimizer.is_stub_optimizer:
+                optimizer.load_state_dict(state_dict['optimizer'])
+
+            # Load distributed optimizer's custom parameter state.
+            # For distributed checkpoint it's already loaded in load_state_dict above
+            is_torch_dist = ckpt_format == "torch_dist"
+            if args.use_distributed_optimizer and not is_torch_dist and ckpt_format not in ["torch_dcp", "fsdp_dtensor"]:
+                # NOTE: this is a manual read of the tracker file.
+                # This code should not be reached when reading from a non_persistent checkpoint
+                assert not is_torch_dist
+                tracker_filename = get_checkpoint_tracker_filename(load_dir)
+                iteration, release = read_metadata(tracker_filename)
+                model_checkpoint_name = \
+                    get_checkpoint_name(load_dir, iteration, release)
+                optim_checkpoint_name = \
+                    get_distributed_optimizer_checkpoint_name(
+                        model_checkpoint_name)
+                optimizer.load_parameter_state(optim_checkpoint_name,
+                                               update_legacy_format=args.ckpt_convert_update_legacy_dist_opt_format)
+
+            # Load scheduler.
+            if opt_param_scheduler is not None:
+                if 'lr_scheduler' in state_dict: # backward compatbility
+                    opt_param_scheduler.load_state_dict(state_dict['lr_scheduler'])
+                else:
+                    opt_param_scheduler.load_state_dict(state_dict['opt_param_scheduler'])
+        except KeyError as e:
+            print_rank_0('Unable to load optimizer from checkpoint {}. '
+                         'Specify --no-load-optim or --finetune to prevent '
+                         'attempting to load the optimizer state, '
+                         'exiting ...'.format(checkpoint_name))
+            raise e
+    else:
+        if (args.fp16 or args.bf16) and optimizer is not None:
+            if args.load_main_params_from_ckpt:
+                optimizer.reload_model_params(state_dict=state_dict)
+            else:
+                optimizer.reload_model_params()
+
+    # rerun state
+    if not ignore_rerun_state:
+        try:
+            if 'rerun_state_machine' in state_dict:
+                get_rerun_state_machine().load_state_dict(state_dict['rerun_state_machine'])
+        except Exception as e:
+            print(f"Unable to restore RerunMachine from checkpoint: {e}. Skipping.")
+
+    # rng states.
+    if not release and not args.finetune and not args.no_load_rng and not ignore_rng_state:
+        try:
+            if 'rng_state' in state_dict:
+                if args.ckpt_format == "fsdp_dtensor":
+                    # FSDP DTensor checkpoints store rng_state in a different format.
+                    tp_rank = mpu.get_tensor_model_parallel_rank()
+                    pp_rank = mpu.get_pipeline_model_parallel_rank()
+                    if f"({pp_rank}, {tp_rank})" in state_dict['rng_state']:
+                        rng_state = state_dict['rng_state'][f"({pp_rank}, {tp_rank})"]
+                    else:
+                        print("WARNING: RNG state not found for current TP/PP rank")
+                        rng_state = next(iter(state_dict['rng_state'].values()))
+                else:
+                    rng_state = state_dict['rng_state']
+
+                # access rng_state for data parallel rank
+                if args.data_parallel_random_init:
+                    rng_state = rng_state[mpu.get_data_parallel_rank()]
+                else:
+                    rng_state = rng_state[0]
+                random.setstate(rng_state['random_rng_state'])
+                np.random.set_state(rng_state['np_rng_state'])
+                torch.set_rng_state(rng_state['torch_rng_state'])
+                torch.cuda.set_rng_state(rng_state['cuda_rng_state'])
+                # Check for empty states array
+                if not rng_state['rng_tracker_states']:
+                    raise KeyError
+                tensor_parallel.get_cuda_rng_tracker().set_states(
+                    rng_state['rng_tracker_states'])
+            else:  # backward compatability
+                random.setstate(state_dict['random_rng_state'])
+                np.random.set_state(state_dict['np_rng_state'])
+                torch.set_rng_state(state_dict['torch_rng_state'])
+                torch.cuda.set_rng_state(state_dict['cuda_rng_state'])
+                # Check for empty states array
+                if not state_dict['rng_tracker_states']:
+                    raise KeyError
+                tensor_parallel.get_cuda_rng_tracker().set_states(
+                    state_dict['rng_tracker_states'])
+        except KeyError:
+            print_rank_0('Unable to load rng state from checkpoint {}. '
+                         'Specify --no-load-rng or --finetune to prevent '
+                         'attempting to load the rng state, '
+                         'exiting ...'.format(checkpoint_name))
+            sys.exit()
+
+    # Some utilities want to load a checkpoint without distributed being initialized
+    if torch.distributed.is_initialized():
+        torch.distributed.barrier()
+
+    print_rank_0(f'  successfully loaded checkpoint from {load_dir} '
+                 f'[ t {mpu.get_tensor_model_parallel_rank() + 1}/{mpu.get_tensor_model_parallel_world_size()}, '
+                 f'p {mpu.get_pipeline_model_parallel_rank() + 1}/{mpu.get_pipeline_model_parallel_world_size()} ] '
+                 f'at iteration {iteration}')
+
+    # Additional callback for wandb (last rank)
+    if not torch.distributed.is_initialized() \
+       or is_last_rank():
+        wandb_utils.on_load_checkpoint_success(checkpoint_name, load_dir)
+
+    torch.cuda.empty_cache()
+
+    if iteration > 0:
+        # Notify FT that a checkpoint was loaded.
+        is_local_chkpt = (ckpt_type == CheckpointType.LOCAL)
+        ft_integration.on_checkpoint_loaded(is_local_chkpt=is_local_chkpt)
+
+    return iteration, num_floating_point_operations_so_far
+
+
+def _to_dtensor(wrapped_model, model_state_dict):
+    device_mesh = wrapped_model[0].device_mesh
+
+    new_model_sd = dict()
+    for k, v in model_state_dict.items():
+        # FP8 extra state cannot be converted to dtensor yet.
+        if "_extra_state" in k:
+            new_model_sd[k] = v
+        else:
+            new_model_sd[k] = torch.distributed.tensor.distribute_tensor(v, device_mesh)
+
+    return new_model_sd
+
+
+def load_biencoder_checkpoint(model, only_query_model=False,
+                              only_context_model=False, custom_load_path=None):
+
+    args = get_args()
+
+    model = unwrap_model(model)
+
+    load_path = custom_load_path if custom_load_path is not None else args.load
+
+    tracker_filename = get_checkpoint_tracker_filename(load_path)
+
+    with open_file(tracker_filename, 'r') as f:
+        iteration = int(f.read().strip())
+
+    checkpoint_name = get_checkpoint_name(load_path, iteration,
+                                          args.use_distributed_optimizer,
+                                          release=False)
+
+    if mpu.get_data_parallel_rank() == 0:
+        print('global rank {} is loading checkpoint {}'.format(
+            torch.distributed.get_rank(), checkpoint_name))
+
+    state_dict = torch.load(checkpoint_name, map_location='cpu')
+    ret_state_dict = state_dict['model']
+
+    if only_query_model:
+        ret_state_dict.pop('context_model')
+    if only_context_model:
+        ret_state_dict.pop('query_model')
+
+    assert len(model) == 1
+    model[0].load_state_dict(ret_state_dict)
+    torch.distributed.barrier()
+
+    if mpu.get_data_parallel_rank() == 0:
+        print(' successfully loaded {}'.format(checkpoint_name))
+
+    return model
+"""

--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -431,7 +431,7 @@ class CheckpointConfig:
     exit_on_missing_checkpoint: bool = False
     """If 'load' is set, but checkpoint is not found (e.g., path typo), then exit instead of random initialization."""
 
-    ckpt_format: Literal["torch_dist", "zarr"] = "torch_dist"
+    ckpt_format: Literal["torch_dist", "zarr", "fsdp_dtensor"] = "torch_dist"
     """Checkpoint format to use."""
 
     ckpt_convert_format: Optional[Literal["torch", "torch_dist", "zarr"]] = None
@@ -457,8 +457,10 @@ class CheckpointConfig:
     """Apply full load parallelization across DP for distributed checkpoints."""
 
     ckpt_assume_constant_structure: bool = False
-    """If the model and optimizer state dict structure is constant throughout a *single training job,
-    it allows for different checkpointing performance optimizations."""
+    """Assume the checkpoint structure is constant across saves to enable optimizations."""
+
+    strict_fsdp_dtensor_load: bool = False
+    """Whether to enforce strict loading for FSDP DTensor checkpoints. When False, allows partial loading."""
 
     dist_ckpt_strictness: Literal[
         "assume_ok_unexpected",

--- a/src/megatron/bridge/training/setup.py
+++ b/src/megatron/bridge/training/setup.py
@@ -21,6 +21,7 @@ from typing import Any, Callable, NamedTuple, Optional
 import torch
 from megatron.core.config import set_experimental_flag
 from megatron.core.distributed import DistributedDataParallel, DistributedDataParallelConfig, finalize_model_grads
+from megatron.core.distributed.fsdp.mcore_fsdp_adapter import FullyShardedDataParallel as megatron_FSDP
 from megatron.core.optimizer import MegatronOptimizer
 from megatron.core.optimizer_param_scheduler import OptimizerParamScheduler
 from megatron.core.rerun_state_machine import RerunDataIterator
@@ -283,18 +284,18 @@ def _update_model_config_funcs(
     align_grad_reduce: bool = True,
 ) -> None:
     """Update model config sync funcs based on initialized model."""
-    if isinstance(model[0], DistributedDataParallel) and ddp_config.overlap_grad_reduce:
+    if isinstance(model[0], (DistributedDataParallel, megatron_FSDP)) and ddp_config.overlap_grad_reduce:
         assert model_config.no_sync_func is None, (
             "When overlap_grad_reduce is True, config.no_sync_func must be None; "
             "a custom no_sync_func is not supported when overlapping grad-reduce"
         )
-    model_config.no_sync_func = [model_chunk.no_sync for model_chunk in model]
-    if len(model) == 1:
-        model_config.no_sync_func = model_config.no_sync_func[0]
-    if align_grad_reduce:
-        model_config.grad_sync_func = [model_chunk.start_grad_sync for model_chunk in model]
+        model_config.no_sync_func = [model_chunk.no_sync for model_chunk in model]
         if len(model) == 1:
-            model_config.grad_sync_func = model_config.grad_sync_func[0]
+            model_config.no_sync_func = model_config.no_sync_func[0]
+        if align_grad_reduce:
+            model_config.grad_sync_func = [model_chunk.start_grad_sync for model_chunk in model]
+            if len(model) == 1:
+                model_config.grad_sync_func = model_config.grad_sync_func[0]
     if ddp_config.overlap_param_gather and ddp_config.align_param_gather:
         model_config.param_sync_func = [model_chunk.start_param_sync for model_chunk in model]
         if len(model) == 1:

--- a/src/megatron/bridge/utils/common_utils.py
+++ b/src/megatron/bridge/utils/common_utils.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import os
-from typing import Type, Union
 
 import torch
 import torch.distributed
@@ -104,42 +103,3 @@ def print_rank_last(message: str) -> None:
             print(message, flush=True)
     else:
         print(message, flush=True)
-
-
-def unwrap_model(
-    model: Union[torch.nn.Module, list[torch.nn.Module]],
-    module_instances: tuple[Type[torch.nn.Module], ...] = ALL_MODULE_WRAPPER_CLASSNAMES,
-) -> Union[torch.nn.Module, list[torch.nn.Module]]:
-    """Recursively unwraps a model or list of models from common wrapper modules.
-
-    Args:
-        model: The model or list of models to unwrap.
-        module_instances: A tuple of wrapper module types to remove (e.g., DDP, Float16Module).
-
-    Returns:
-        The unwrapped model or list of models.
-    """
-    return_list = True
-    if not isinstance(model, list):
-        model = [model]
-        return_list = False
-    unwrapped_model = []
-    for model_module in model:
-        while isinstance(model_module, module_instances):
-            model_module = model_module.module
-        unwrapped_model.append(model_module)
-    if not return_list:
-        return unwrapped_model[0]
-    return unwrapped_model
-
-
-def use_dist_ckpt(ckpt_format: str) -> bool:
-    """Check if the checkpoint format indicates a distributed checkpoint.
-
-    Args:
-        ckpt_format: The checkpoint format string (e.g., "torch", "torch_dist").
-
-    Returns:
-        True if the format is not "torch", False otherwise.
-    """
-    return ckpt_format != "torch"

--- a/tests/functional_tests/training/test_megatron_fsdp.py
+++ b/tests/functional_tests/training/test_megatron_fsdp.py
@@ -1,0 +1,484 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from dataclasses import dataclass
+
+import pytest
+import torch
+from megatron.core.distributed import DistributedDataParallelConfig
+from megatron.core.optimizer import OptimizerConfig
+
+from megatron.bridge.models.llama import Llama3ModelProvider
+from megatron.bridge.training.config import (
+    CheckpointConfig,
+    ConfigContainer,
+    DistributedInitConfig,
+    LoggerConfig,
+    MockGPTDatasetConfig,
+    RNGConfig,
+    SchedulerConfig,
+    TokenizerConfig,
+    TrainingConfig,
+)
+from megatron.bridge.training.gpt_step import forward_step
+from megatron.bridge.training.pretrain import pretrain
+from tests.functional_tests.utils import (
+    broadcast_path,
+    clear_directories,
+    initialize_distributed,
+    verify_checkpoint_files,
+)
+
+
+@dataclass
+class Llama3ModelProviderFSDP145M(Llama3ModelProvider):
+    """Small Llama3 model configuration for FSDP testing."""
+
+    rotary_base: int = 500_000
+    seq_length: int = 8192
+    num_layers: int = 2
+    hidden_size: int = 768
+    ffn_hidden_size: int = 2688
+    num_attention_heads: int = 16
+    vocab_size: int | None = None
+    # Disable gradient accumulation fusion for FSDP
+    gradient_accumulation_fusion: bool = False
+
+
+class TestMegatronFSDP:
+    """
+    Test end to end training with Megatron FSDP and fsdp_dtensor checkpoint functionality.
+    """
+
+    @pytest.mark.run_only_on("GPU")
+    def test_fsdp_pretrain_basic(self, tmp_path):
+        """
+        Test basic FSDP training without checkpointing.
+        """
+        initialize_distributed()
+
+        torch.distributed.barrier()
+
+        try:
+            global_batch_size = 8
+            micro_batch_size = 1
+            seq_length = 512
+            total_iters = 10
+
+            model_cfg = Llama3ModelProviderFSDP145M(
+                seq_length=seq_length,
+                tensor_model_parallel_size=1,
+                pipeline_model_parallel_size=1,
+                context_parallel_size=1,
+                sequence_parallel=False,
+                attention_softmax_in_fp32=True,
+                pipeline_dtype=torch.bfloat16,
+                bf16=True,
+                make_vocab_size_divisible_by=128,
+                vocab_size=None,
+            )
+
+            # Config Container with Megatron FSDP enabled
+            cfg = ConfigContainer(
+                model=model_cfg,
+                dist=DistributedInitConfig(
+                    use_megatron_fsdp=True,
+                ),
+                train=TrainingConfig(
+                    train_iters=total_iters,
+                    eval_interval=5,
+                    eval_iters=2,
+                    global_batch_size=global_batch_size,
+                    micro_batch_size=micro_batch_size,
+                    exit_signal_handler=True,
+                ),
+                optimizer=OptimizerConfig(
+                    optimizer="adam",
+                    bf16=True,
+                    fp16=False,
+                    adam_beta1=0.9,
+                    adam_beta2=0.95,
+                    adam_eps=1e-5,
+                    use_distributed_optimizer=True,
+                    clip_grad=1.0,
+                    lr=3e-3,
+                    weight_decay=0.01,
+                    min_lr=1e-6,
+                ),
+                scheduler=SchedulerConfig(
+                    start_weight_decay=0.033,
+                    end_weight_decay=0.033,
+                    weight_decay_incr_style="constant",
+                    lr_decay_style="cosine",
+                    lr_warmup_iters=2,
+                    lr_warmup_init=0.0,
+                    lr_decay_iters=total_iters,
+                    override_opt_param_scheduler=True,
+                ),
+                ddp=DistributedDataParallelConfig(
+                    check_for_nan_in_grad=True,
+                    grad_reduce_in_fp32=True,
+                    overlap_grad_reduce=True,
+                    overlap_param_gather=True,
+                    average_in_collective=False,  # Required for FSDP
+                    use_distributed_optimizer=True,
+                ),
+                dataset=MockGPTDatasetConfig(
+                    random_seed=1234,
+                    reset_attention_mask=False,
+                    reset_position_ids=False,
+                    eod_mask_loss=False,
+                    sequence_length=seq_length,
+                    num_dataset_builder_threads=1,
+                    data_sharding=True,
+                    dataloader_type="single",
+                    num_workers=1,
+                ),
+                logger=LoggerConfig(
+                    log_interval=5,
+                    log_params_norm=True,
+                ),
+                tokenizer=TokenizerConfig(
+                    tokenizer_type="NullTokenizer",
+                    vocab_size=10000,
+                ),
+                rng=RNGConfig(seed=1234),
+                checkpoint=CheckpointConfig(
+                    ckpt_format="fsdp_dtensor",  # Use FSDP DTensor format
+                ),
+            )
+
+            # Run training
+            pretrain(cfg, forward_step)
+
+            torch.distributed.barrier()
+
+        finally:
+            clear_directories(tmp_path)
+
+    @pytest.mark.run_only_on("GPU")
+    def test_fsdp_pretrain_with_checkpoint(self, tmp_path):
+        """
+        Test FSDP training with checkpoint saving using fsdp_dtensor format.
+        """
+        initialize_distributed()
+        shared_base_dir = broadcast_path(tmp_path)
+
+        checkpoint_dir = os.path.join(shared_base_dir, "checkpoints")
+        tensorboard_dir = os.path.join(shared_base_dir, "tensorboard")
+
+        if torch.distributed.get_rank() == 0:
+            os.makedirs(checkpoint_dir, exist_ok=True)
+            os.makedirs(tensorboard_dir, exist_ok=True)
+
+        torch.distributed.barrier()
+
+        try:
+            global_batch_size = 8
+            micro_batch_size = 1
+            seq_length = 512
+            total_iters = 20
+
+            model_cfg = Llama3ModelProviderFSDP145M(
+                seq_length=seq_length,
+                tensor_model_parallel_size=1,
+                pipeline_model_parallel_size=1,
+                context_parallel_size=1,
+                sequence_parallel=False,
+                attention_softmax_in_fp32=True,
+                pipeline_dtype=torch.bfloat16,
+                bf16=True,
+                make_vocab_size_divisible_by=128,
+                vocab_size=None,
+            )
+
+            # Config Container with FSDP and checkpointing
+            cfg = ConfigContainer(
+                model=model_cfg,
+                dist=DistributedInitConfig(
+                    use_megatron_fsdp=True,
+                ),
+                train=TrainingConfig(
+                    train_iters=total_iters,
+                    eval_interval=10,
+                    eval_iters=2,
+                    global_batch_size=global_batch_size,
+                    micro_batch_size=micro_batch_size,
+                    exit_signal_handler=True,
+                ),
+                optimizer=OptimizerConfig(
+                    optimizer="adam",
+                    bf16=True,
+                    fp16=False,
+                    adam_beta1=0.9,
+                    adam_beta2=0.95,
+                    adam_eps=1e-5,
+                    use_distributed_optimizer=True,
+                    clip_grad=1.0,
+                    lr=3e-3,
+                    weight_decay=0.01,
+                    min_lr=1e-6,
+                ),
+                scheduler=SchedulerConfig(
+                    start_weight_decay=0.033,
+                    end_weight_decay=0.033,
+                    weight_decay_incr_style="constant",
+                    lr_decay_style="cosine",
+                    lr_warmup_iters=2,
+                    lr_warmup_init=0.0,
+                    lr_decay_iters=total_iters,
+                    override_opt_param_scheduler=True,
+                ),
+                ddp=DistributedDataParallelConfig(
+                    check_for_nan_in_grad=True,
+                    grad_reduce_in_fp32=True,
+                    overlap_grad_reduce=True,
+                    overlap_param_gather=True,
+                    average_in_collective=False,  # Required for FSDP
+                    use_distributed_optimizer=True,
+                ),
+                dataset=MockGPTDatasetConfig(
+                    random_seed=1234,
+                    reset_attention_mask=False,
+                    reset_position_ids=False,
+                    eod_mask_loss=False,
+                    sequence_length=seq_length,
+                    num_dataset_builder_threads=1,
+                    data_sharding=True,
+                    dataloader_type="single",
+                    num_workers=1,
+                ),
+                logger=LoggerConfig(
+                    log_interval=5,
+                    tensorboard_dir=tensorboard_dir,
+                    log_params_norm=True,
+                ),
+                tokenizer=TokenizerConfig(
+                    tokenizer_type="NullTokenizer",
+                    vocab_size=10000,
+                ),
+                checkpoint=CheckpointConfig(
+                    save_interval=10,
+                    save=checkpoint_dir,
+                    ckpt_format="fsdp_dtensor",  # Use FSDP DTensor format
+                    fully_parallel_save=True,
+                    async_save=False,  # Disable async save for testing
+                ),
+                rng=RNGConfig(seed=1234),
+            )
+
+            # Run training
+            pretrain(cfg, forward_step)
+
+            # Verify checkpoint files
+            torch.distributed.barrier()
+            verify_checkpoint_files(checkpoint_dir, total_iters)
+
+        finally:
+            clear_directories(tmp_path)
+
+    @pytest.mark.run_only_on("GPU")
+    def test_fsdp_pretrain_save_resume(self, tmp_path):
+        """
+        Test FSDP training with checkpoint saving and resuming using fsdp_dtensor format.
+        """
+        initialize_distributed()
+        shared_base_dir = broadcast_path(tmp_path)
+
+        checkpoint_dir = os.path.join(shared_base_dir, "checkpoints")
+        tensorboard_dir = os.path.join(shared_base_dir, "tensorboard")
+
+        if torch.distributed.get_rank() == 0:
+            os.makedirs(checkpoint_dir, exist_ok=True)
+            os.makedirs(tensorboard_dir, exist_ok=True)
+
+        torch.distributed.barrier()
+
+        try:
+            global_batch_size = 8
+            micro_batch_size = 1
+            seq_length = 512
+            total_iters = 20
+            checkpoint_iters = 10
+
+            # First training run - train for 10 iterations and save checkpoint
+            cfg_first = ConfigContainer(
+                model=Llama3ModelProviderFSDP145M(seq_length=seq_length),
+                dist=DistributedInitConfig(
+                    use_megatron_fsdp=True,
+                ),
+                train=TrainingConfig(
+                    train_iters=checkpoint_iters,
+                    eval_interval=5,
+                    eval_iters=2,
+                    global_batch_size=global_batch_size,
+                    micro_batch_size=micro_batch_size,
+                    exit_signal_handler=True,
+                ),
+                optimizer=OptimizerConfig(
+                    optimizer="adam",
+                    bf16=True,
+                    fp16=False,
+                    adam_beta1=0.9,
+                    adam_beta2=0.95,
+                    adam_eps=1e-5,
+                    use_distributed_optimizer=True,
+                    clip_grad=1.0,
+                    lr=3e-3,
+                    weight_decay=0.01,
+                    min_lr=1e-6,
+                ),
+                scheduler=SchedulerConfig(
+                    start_weight_decay=0.033,
+                    end_weight_decay=0.033,
+                    weight_decay_incr_style="constant",
+                    lr_decay_style="cosine",
+                    lr_warmup_iters=2,
+                    lr_warmup_init=0.0,
+                    lr_decay_iters=total_iters,
+                    override_opt_param_scheduler=True,
+                ),
+                ddp=DistributedDataParallelConfig(
+                    check_for_nan_in_grad=True,
+                    grad_reduce_in_fp32=True,
+                    overlap_grad_reduce=True,
+                    overlap_param_gather=True,
+                    average_in_collective=False,  # Required for FSDP
+                    use_distributed_optimizer=True,
+                ),
+                dataset=MockGPTDatasetConfig(
+                    random_seed=1234,
+                    reset_attention_mask=False,
+                    reset_position_ids=False,
+                    eod_mask_loss=False,
+                    sequence_length=seq_length,
+                    num_dataset_builder_threads=1,
+                    data_sharding=True,
+                    dataloader_type="single",
+                    num_workers=1,
+                ),
+                logger=LoggerConfig(
+                    log_interval=5,
+                    tensorboard_dir=tensorboard_dir,
+                ),
+                tokenizer=TokenizerConfig(
+                    tokenizer_type="NullTokenizer",
+                    vocab_size=10000,
+                ),
+                checkpoint=CheckpointConfig(
+                    save_interval=checkpoint_iters,
+                    save=checkpoint_dir,
+                    ckpt_format="fsdp_dtensor",  # Use FSDP DTensor format
+                    fully_parallel_save=True,
+                    async_save=False,  # Disable async save for testing
+                ),
+                rng=RNGConfig(seed=1234),
+            )
+
+            # Run first training job
+            pretrain(cfg_first, forward_step)
+
+            torch.distributed.barrier()
+
+            # Verify checkpoint files from first run
+            verify_checkpoint_files(checkpoint_dir, checkpoint_iters)
+
+            torch.distributed.barrier()
+
+            # Second training run - resume from checkpoint and train for remaining 10 iterations
+            cfg_second = ConfigContainer(
+                model=Llama3ModelProviderFSDP145M(seq_length=seq_length),
+                dist=DistributedInitConfig(
+                    use_megatron_fsdp=True,
+                ),
+                train=TrainingConfig(
+                    train_iters=total_iters,
+                    eval_interval=5,
+                    eval_iters=2,
+                    global_batch_size=global_batch_size,
+                    micro_batch_size=micro_batch_size,
+                    exit_signal_handler=True,
+                ),
+                optimizer=OptimizerConfig(
+                    optimizer="adam",
+                    bf16=True,
+                    fp16=False,
+                    adam_beta1=0.9,
+                    adam_beta2=0.95,
+                    adam_eps=1e-5,
+                    use_distributed_optimizer=True,
+                    clip_grad=1.0,
+                    lr=3e-3,
+                    weight_decay=0.01,
+                    min_lr=1e-6,
+                ),
+                scheduler=SchedulerConfig(
+                    start_weight_decay=0.033,
+                    end_weight_decay=0.033,
+                    weight_decay_incr_style="constant",
+                    lr_decay_style="cosine",
+                    lr_warmup_iters=2,
+                    lr_warmup_init=0.0,
+                    lr_decay_iters=total_iters,
+                    override_opt_param_scheduler=True,
+                ),
+                ddp=DistributedDataParallelConfig(
+                    check_for_nan_in_grad=True,
+                    grad_reduce_in_fp32=True,
+                    overlap_grad_reduce=True,
+                    overlap_param_gather=True,
+                    average_in_collective=False,  # Required for FSDP
+                    use_distributed_optimizer=True,
+                ),
+                dataset=MockGPTDatasetConfig(
+                    random_seed=1234,
+                    reset_attention_mask=False,
+                    reset_position_ids=False,
+                    eod_mask_loss=False,
+                    sequence_length=seq_length,
+                    num_dataset_builder_threads=1,
+                    data_sharding=True,
+                    dataloader_type="single",
+                    num_workers=1,
+                ),
+                logger=LoggerConfig(
+                    log_interval=5,
+                    tensorboard_dir=tensorboard_dir,
+                ),
+                tokenizer=TokenizerConfig(
+                    tokenizer_type="NullTokenizer",
+                    vocab_size=10000,
+                ),
+                checkpoint=CheckpointConfig(
+                    save_interval=checkpoint_iters,
+                    save=checkpoint_dir,
+                    load=checkpoint_dir,  # Resume from checkpoint
+                    ckpt_format="fsdp_dtensor",  # Use FSDP DTensor format
+                    fully_parallel_save=True,
+                    async_save=False,  # Disable async save for testing
+                ),
+                rng=RNGConfig(seed=1234),
+            )
+
+            # Run second training job (resume from checkpoint)
+            pretrain(cfg_second, forward_step)
+
+            torch.distributed.barrier()
+
+            # Verify checkpoint files from second run
+            verify_checkpoint_files(checkpoint_dir, total_iters)
+
+        finally:
+            clear_directories(shared_base_dir)

--- a/tests/functional_tests/training/test_pretrain.py
+++ b/tests/functional_tests/training/test_pretrain.py
@@ -23,7 +23,6 @@ from megatron.bridge.models.llama import Llama32ModelProvider1B
 from megatron.bridge.training.config import (
     CheckpointConfig,
     ConfigContainer,
-    DistributedInitConfig,
     LoggerConfig,
     MockGPTDatasetConfig,
     RNGConfig,
@@ -298,120 +297,6 @@ class TestPretrain:
             # Verify checkpoint files
             torch.distributed.barrier()
             verify_checkpoint_files(checkpoint_dir, total_iters)
-
-        finally:
-            # pytest's tmp_path fixture doesn't clean up immediately.
-            # Clean up manually.
-            clear_directories(tmp_path)
-
-
-class TestPretrainMegatronFSDP:
-    """
-    Test end to end training with checkpoint functionality for Megatron FSDP.
-    """
-
-    @pytest.mark.run_only_on("GPU")
-    def test_pretrain_without_checkpoint(self, tmp_path):
-        """
-        Test end to end training with checkpoint functionality.
-        """
-        initialize_distributed()
-
-        torch.distributed.barrier()
-
-        try:
-            global_batch_size = 8
-            micro_batch_size = 1
-            seq_length = 512
-            total_iters = 100
-
-            model_cfg = Llama32ModelProvider1B(
-                tensor_model_parallel_size=1,
-                pipeline_model_parallel_size=1,
-                context_parallel_size=1,
-                sequence_parallel=False,
-                attention_softmax_in_fp32=True,
-                pipeline_dtype=torch.bfloat16,
-                bf16=True,
-                seq_length=seq_length,
-                make_vocab_size_divisible_by=128,
-                vocab_size=None,
-                gradient_accumulation_fusion=False,
-            )
-
-            # Config Container
-            cfg = ConfigContainer(
-                model=model_cfg,
-                dist=DistributedInitConfig(
-                    use_megatron_fsdp=True,
-                ),
-                train=TrainingConfig(
-                    train_iters=total_iters,
-                    eval_interval=50,
-                    eval_iters=2,
-                    global_batch_size=global_batch_size,
-                    micro_batch_size=micro_batch_size,
-                    exit_signal_handler=True,
-                ),
-                optimizer=OptimizerConfig(
-                    optimizer="adam",
-                    bf16=True,
-                    fp16=False,
-                    adam_beta1=0.9,
-                    adam_beta2=0.95,
-                    adam_eps=1e-5,
-                    use_distributed_optimizer=True,
-                    clip_grad=1.0,
-                    lr=3e-3,
-                    weight_decay=0.01,
-                    min_lr=1e-6,
-                ),
-                scheduler=SchedulerConfig(
-                    start_weight_decay=0.033,
-                    end_weight_decay=0.033,
-                    weight_decay_incr_style="constant",
-                    lr_decay_style="cosine",
-                    lr_warmup_iters=2,
-                    lr_warmup_init=0.0,
-                    lr_decay_iters=total_iters,
-                    override_opt_param_scheduler=True,
-                ),
-                ddp=DistributedDataParallelConfig(
-                    check_for_nan_in_grad=True,
-                    grad_reduce_in_fp32=True,
-                    overlap_grad_reduce=True,
-                    overlap_param_gather=True,
-                    average_in_collective=False,
-                    use_distributed_optimizer=True,
-                ),
-                dataset=MockGPTDatasetConfig(
-                    random_seed=1234,
-                    reset_attention_mask=False,
-                    reset_position_ids=False,
-                    eod_mask_loss=False,
-                    sequence_length=seq_length,
-                    num_dataset_builder_threads=1,
-                    data_sharding=True,
-                    dataloader_type="single",
-                    num_workers=1,
-                ),
-                logger=LoggerConfig(
-                    log_interval=5,
-                    log_params_norm=True,
-                ),
-                tokenizer=TokenizerConfig(
-                    tokenizer_type="NullTokenizer",
-                    vocab_size=10000,
-                ),
-                rng=RNGConfig(seed=1234),
-                checkpoint=CheckpointConfig(),
-            )
-
-            # Run training
-            pretrain(cfg, forward_step)
-
-            # Verify checkpoint files
-            torch.distributed.barrier()
 
         finally:
             # pytest's tmp_path fixture doesn't clean up immediately.

--- a/tests/functional_tests/utils.py
+++ b/tests/functional_tests/utils.py
@@ -95,8 +95,14 @@ def clear_directories(path: str) -> None:
         torch.distributed.barrier()
 
 
-def verify_checkpoint_files(checkpoint_dir: str, iteration_count: int) -> None:
-    """Verify that checkpoint files were created correctly."""
+def verify_checkpoint_files(checkpoint_dir: str, iteration_count: int, ckpt_format: str = "torch_dist") -> None:
+    """Verify that checkpoint files were created correctly for different checkpoint formats.
+
+    Args:
+        checkpoint_dir: Directory containing checkpoints
+        iteration_count: Expected iteration number for the checkpoint
+        ckpt_format: Checkpoint format ("torch_dist", "fsdp_dtensor", etc.)
+    """
     if torch.distributed.is_initialized():
         torch.distributed.barrier()
 
@@ -110,10 +116,19 @@ def verify_checkpoint_files(checkpoint_dir: str, iteration_count: int) -> None:
         metadata_file = os.path.join(final_iter_dir, ".metadata")
         assert os.path.exists(metadata_file), "Checkpoint metadata file not found"
 
+        # Both formats use torch.distributed.checkpoint but may create different numbers of .distcp files
         distcp_files = [f for f in os.listdir(final_iter_dir) if f.endswith(".distcp")]
-        num_expected_files = 2 * torch.distributed.get_world_size()
+
+        if ckpt_format == "torch_dist":
+            num_expected_files = 2 * torch.distributed.get_world_size()
+        elif ckpt_format == "fsdp_dtensor":
+            # fsdp_dtensor format creates .distcp files (one per rank)
+            num_expected_files = torch.distributed.get_world_size()
+        else:
+            raise ValueError(f"Unsupported checkpoint format for verification: {ckpt_format}")
+
         assert len(distcp_files) == num_expected_files, (
-            f"Expected {num_expected_files} .distcp files, found {len(distcp_files)}: {distcp_files}"
+            f"Expected {num_expected_files} .distcp files for fsdp_dtensor, found {len(distcp_files)}: {distcp_files}"
         )
 
 

--- a/tests/unit_tests/training/test_checkpointing.py
+++ b/tests/unit_tests/training/test_checkpointing.py
@@ -25,6 +25,7 @@ from megatron.core.msc_utils import MultiStorageClientFeature
 from megatron.bridge.training.checkpointing import (
     CheckpointType,
     _extract_megatron_lm_args_from_state_dict,
+    _get_checkpoint_format,
     _get_non_persistent_iteration,
     _load_base_checkpoint,
     checkpoint_exists,
@@ -213,9 +214,10 @@ class TestCheckpointTypes:
 
     def test_checkpoint_type_enum(self):
         """Test CheckpointType enum values."""
-        assert len(CheckpointType) == 2
+        assert len(CheckpointType) == 3
         assert CheckpointType.LOCAL in CheckpointType
         assert CheckpointType.GLOBAL in CheckpointType
+        assert CheckpointType.FSDP_DTENSOR in CheckpointType
 
 
 class TestRNGState:
@@ -809,24 +811,27 @@ class TestLoadBaseCheckpoint:
     @patch("megatron.bridge.training.checkpointing._get_non_persistent_iteration")
     @patch("megatron.bridge.training.checkpointing.read_train_state")
     @patch("megatron.bridge.training.checkpointing.dist_checkpointing")
+    @patch("megatron.bridge.training.checkpointing.file_exists")
     @patch("os.path.exists")
     def test_load_base_checkpoint_non_distributed_error(
-        self, mock_isfile, mock_dist_ckpt, mock_read_state, mock_get_np_iter, base_config
+        self, mock_os_exists, mock_file_exists, mock_dist_ckpt, mock_read_state, mock_get_np_iter, base_config
     ):
         """Test error when trying to load non-distributed checkpoint."""
         mock_get_np_iter.return_value = -1
-        mock_isfile.return_value = True
+        mock_file_exists.return_value = True  # train_state file exists
 
         mock_train_state = Mock()
         mock_train_state.step = 1000
         mock_read_state.return_value = mock_train_state
 
         mock_dist_ckpt.check_is_distributed_checkpoint.return_value = False
+        # Mock that .metadata file does NOT exist (so it's not fsdp_dtensor)
+        mock_os_exists.return_value = False
 
         with pytest.raises(RuntimeError) as exc_info:
             _load_base_checkpoint("/fake/dir", base_config)
 
-        assert "non-distributed checkpoints is no longer supported" in str(exc_info.value)
+        assert "Unknown checkpoint format" in str(exc_info.value)
 
 
 class TestLoadModelWeightsFromCheckpoint:
@@ -1647,3 +1652,256 @@ class TestGetTrainStateFromStateDict:
         assert result.do_train is False
         assert result.do_valid is False
         assert result.do_test is False
+
+
+class TestFSDPDTensorFunctionality:
+    """Test new FSDP DTensor checkpointing functionality."""
+
+    @patch("megatron.core.dist_checkpointing.check_is_distributed_checkpoint")
+    @patch("os.path.exists")
+    def test_get_checkpoint_format_torch_dist(self, mock_exists, mock_check_dist_ckpt):
+        """Test _get_checkpoint_format detects torch_dist format."""
+        mock_check_dist_ckpt.return_value = True
+        mock_exists.return_value = False
+
+        result = _get_checkpoint_format("/path/to/checkpoint")
+
+        assert result == "torch_dist"
+        mock_check_dist_ckpt.assert_called_once_with("/path/to/checkpoint")
+
+    @patch("megatron.core.dist_checkpointing.check_is_distributed_checkpoint")
+    @patch("os.path.exists")
+    def test_get_checkpoint_format_fsdp_dtensor(self, mock_exists, mock_check_dist_ckpt):
+        """Test _get_checkpoint_format detects fsdp_dtensor format."""
+        mock_check_dist_ckpt.return_value = False
+        mock_exists.return_value = True  # .metadata file exists
+
+        result = _get_checkpoint_format("/path/to/checkpoint")
+
+        assert result == "fsdp_dtensor"
+        mock_check_dist_ckpt.assert_called_once_with("/path/to/checkpoint")
+        mock_exists.assert_called_once_with("/path/to/checkpoint/.metadata")
+
+    @patch("megatron.core.dist_checkpointing.check_is_distributed_checkpoint")
+    @patch("os.path.exists")
+    def test_get_checkpoint_format_unknown(self, mock_exists, mock_check_dist_ckpt):
+        """Test _get_checkpoint_format raises error for unknown format."""
+        mock_check_dist_ckpt.return_value = False
+        mock_exists.return_value = False  # No .metadata file
+
+        with pytest.raises(NotImplementedError, match="Unknown checkpoint format"):
+            _get_checkpoint_format("/path/to/checkpoint")
+
+    @patch("megatron.core.mpu.get_pipeline_model_parallel_rank")
+    @patch("megatron.core.mpu.get_tensor_model_parallel_rank")
+    @patch("megatron.core.mpu.get_data_parallel_world_size")
+    @patch("torch.distributed.is_initialized")
+    def test_get_rng_state_fsdp_dtensor_format(self, mock_dist_init, mock_dp_world_size, mock_tp_rank, mock_pp_rank):
+        """Test get_rng_state returns correct format for fsdp_dtensor."""
+        mock_dist_init.return_value = False  # Simplify
+        mock_dp_world_size.return_value = 1
+        mock_tp_rank.return_value = 0
+        mock_pp_rank.return_value = 0
+
+        with (
+            patch("random.getstate"),
+            patch("numpy.random.get_state"),
+            patch("torch.get_rng_state"),
+            patch("torch.cuda.get_rng_state"),
+            patch("megatron.core.tensor_parallel.get_cuda_rng_tracker"),
+        ):
+            result = get_rng_state(data_parallel_random_init=False, ckpt_format="fsdp_dtensor")
+
+        # Should return dict format for fsdp_dtensor
+        assert isinstance(result, dict)
+        assert "(0, 0)" in result
+
+    @patch("megatron.core.mpu.get_pipeline_model_parallel_rank")
+    @patch("megatron.core.mpu.get_pipeline_model_parallel_world_size")
+    @patch("megatron.core.mpu.get_tensor_model_parallel_rank")
+    @patch("megatron.core.mpu.get_tensor_model_parallel_world_size")
+    @patch("megatron.core.mpu.get_data_parallel_rank")
+    @patch("megatron.core.mpu.get_data_parallel_world_size")
+    @patch("torch.distributed.is_initialized")
+    def test_get_rng_state_torch_dist_format(
+        self,
+        mock_dist_init,
+        mock_dp_world_size,
+        mock_dp_rank,
+        mock_tp_world_size,
+        mock_tp_rank,
+        mock_pp_world_size,
+        mock_pp_rank,
+    ):
+        """Test get_rng_state returns ShardedObject for torch_dist."""
+        # The ShardedObject is only created for torch_dist format regardless of distributed state
+        mock_dp_world_size.return_value = 1
+        mock_dp_rank.return_value = 0
+        mock_tp_rank.return_value = 0
+        mock_tp_world_size.return_value = 1
+        mock_pp_rank.return_value = 0
+        mock_pp_world_size.return_value = 1
+        mock_dist_init.return_value = False
+
+        with (
+            patch("random.getstate"),
+            patch("numpy.random.get_state"),
+            patch("torch.get_rng_state"),
+            patch("torch.cuda.get_rng_state"),
+            patch("megatron.core.tensor_parallel.get_cuda_rng_tracker"),
+            patch("megatron.bridge.training.checkpointing.ShardedObject") as mock_sharded_obj,
+        ):
+            _ = get_rng_state(data_parallel_random_init=False, ckpt_format="torch_dist")
+
+        # Should create ShardedObject for torch_dist format
+        # The exact arguments depend on the RNG state, but we just verify it was called
+        mock_sharded_obj.assert_called_once()
+
+    def test_build_sharded_state_dict_metadata_fsdp_dtensor(self):
+        """Test _build_sharded_state_dict_metadata for fsdp_dtensor format."""
+        from megatron.bridge.training.checkpointing import _build_sharded_state_dict_metadata
+
+        result = _build_sharded_state_dict_metadata(
+            use_distributed_optimizer=True, ckpt_fully_parallel_save=False, ckpt_format="fsdp_dtensor"
+        )
+
+        assert result["distrib_optim_sharding_type"] == "fsdp_dtensor"
+        assert result["chained_optim_avoid_prefix"] is True
+        assert result["singleton_local_shards"] is False
+
+    def test_build_sharded_state_dict_metadata_torch_dist_fully_parallel(self):
+        """Test _build_sharded_state_dict_metadata for torch_dist with fully parallel save."""
+        from megatron.bridge.training.checkpointing import _build_sharded_state_dict_metadata
+
+        result = _build_sharded_state_dict_metadata(
+            use_distributed_optimizer=True, ckpt_fully_parallel_save=True, ckpt_format="torch_dist"
+        )
+
+        assert result["distrib_optim_sharding_type"] == "fully_sharded_model_space"
+
+    def test_build_sharded_state_dict_metadata_torch_dist_dp_zero(self):
+        """Test _build_sharded_state_dict_metadata for torch_dist with dp_zero_gather_scatter."""
+        from megatron.bridge.training.checkpointing import _build_sharded_state_dict_metadata
+
+        result = _build_sharded_state_dict_metadata(
+            use_distributed_optimizer=True, ckpt_fully_parallel_save=False, ckpt_format="torch_dist"
+        )
+
+        assert result["distrib_optim_sharding_type"] == "dp_zero_gather_scatter"
+
+    @patch("megatron.bridge.training.checkpointing.HAVE_MEGATRON_FSDP", True)
+    @patch("torch.distributed.checkpoint.FileSystemReader")
+    @patch("torch.distributed.checkpoint.load_state_dict")
+    @patch("torch.distributed.checkpoint.default_planner.DefaultLoadPlanner")
+    def test_load_fsdp_dtensor_base_checkpoint_rank0(self, mock_planner, mock_load_state_dict, mock_reader):
+        """Test _load_fsdp_dtensor_base_checkpoint for rank0."""
+        from megatron.bridge.training.checkpointing import _load_fsdp_dtensor_base_checkpoint
+        from megatron.bridge.training.config import CheckpointConfig
+
+        ckpt_cfg = CheckpointConfig()
+
+        state_dict, checkpoint_name, release, ckpt_type = _load_fsdp_dtensor_base_checkpoint(
+            load_dir="/test/dir",
+            ckpt_cfg=ckpt_cfg,
+            rank0=True,
+            sharded_state_dict=None,
+            iteration=1000,
+            release=False,
+        )
+
+        # For rank0, should return empty state dict
+        assert state_dict == {}
+        assert ckpt_type == CheckpointType.FSDP_DTENSOR
+        assert release is False
+        # Should not call any loading functions for rank0
+        mock_reader.assert_not_called()
+        mock_load_state_dict.assert_not_called()
+
+    @patch("megatron.bridge.training.checkpointing.HAVE_MEGATRON_FSDP", False)
+    def test_load_fsdp_dtensor_base_checkpoint_no_fsdp(self):
+        """Test _load_fsdp_dtensor_base_checkpoint raises error when FSDP not available."""
+        from megatron.bridge.training.checkpointing import _load_fsdp_dtensor_base_checkpoint
+        from megatron.bridge.training.config import CheckpointConfig
+
+        ckpt_cfg = CheckpointConfig()
+
+        with pytest.raises(RuntimeError, match="Megatron FSDP is required but not available"):
+            _load_fsdp_dtensor_base_checkpoint(
+                load_dir="/test/dir",
+                ckpt_cfg=ckpt_cfg,
+                rank0=False,
+                sharded_state_dict={},
+                iteration=1000,
+                release=False,
+            )
+
+    @patch("megatron.bridge.training.checkpointing.HAVE_MEGATRON_FSDP", True)
+    def test_generate_state_dict_fsdp_dtensor_preprocessing(self):
+        """Test generate_state_dict applies FSDP DTensor preprocessing."""
+        from unittest.mock import Mock
+
+        from megatron.bridge.training.checkpointing import generate_state_dict
+        from megatron.bridge.training.config import CheckpointConfig
+
+        # Create mock model with no swiglu flag (to avoid SWiGLU handler)
+        mock_model = Mock()
+        mock_model.state_dict_for_save_checkpoint.return_value = {"test_param": torch.tensor([1.0])}
+
+        # Mock get_model_config to return config without swiglu
+        with patch("megatron.core.utils.get_model_config") as mock_get_config:
+            mock_config = Mock()
+            mock_config.swiglu = False  # No swiglu flag
+            mock_get_config.return_value = mock_config
+
+            with (
+                patch("megatron.bridge.training.checkpointing.handle_fp8_extra_state_case") as mock_fp8,
+                patch(
+                    "megatron.bridge.training.checkpointing.preprocess_state_dict_for_uneven_dtensor"
+                ) as mock_uneven,
+            ):
+                ckpt_cfg = CheckpointConfig(ckpt_format="fsdp_dtensor", save_rng=False)
+                result = generate_state_dict(
+                    ckpt_cfg=ckpt_cfg,
+                    model=[mock_model],
+                    optimizer=None,
+                    opt_param_scheduler=None,
+                    rng_state=None,
+                )
+
+                # Should call FSDP preprocessing functions
+                mock_fp8.assert_called_once()
+                mock_uneven.assert_called_once()
+                # Should use state_dict_for_save_checkpoint for fsdp_dtensor
+                mock_model.state_dict_for_save_checkpoint.assert_called_once()
+                assert "model" in result
+                assert result["checkpoint_version"] == 3.0
+
+    def test_generate_state_dict_torch_dist_no_preprocessing(self):
+        """Test generate_state_dict skips FSDP preprocessing for torch_dist."""
+        from unittest.mock import Mock
+
+        from megatron.bridge.training.checkpointing import generate_state_dict
+        from megatron.bridge.training.config import CheckpointConfig
+
+        mock_model = Mock()
+        mock_model.sharded_state_dict.return_value = {"test_param": torch.tensor([1.0])}
+
+        with (
+            patch("megatron.bridge.training.checkpointing.handle_fp8_extra_state_case") as mock_fp8,
+            patch("megatron.bridge.training.checkpointing.preprocess_state_dict_for_uneven_dtensor") as mock_uneven,
+        ):
+            ckpt_cfg = CheckpointConfig(ckpt_format="torch_dist", save_rng=False)
+            result = generate_state_dict(
+                ckpt_cfg=ckpt_cfg,
+                model=[mock_model],
+                optimizer=None,
+                opt_param_scheduler=None,
+                rng_state=None,
+            )
+
+            # Should NOT call FSDP preprocessing functions for torch_dist
+            mock_fp8.assert_not_called()
+            mock_uneven.assert_not_called()
+            # Should use sharded_state_dict for torch_dist
+            mock_model.sharded_state_dict.assert_called_once()
+            assert "model" in result

--- a/tests/unit_tests/training/test_config.py
+++ b/tests/unit_tests/training/test_config.py
@@ -1092,3 +1092,159 @@ class TestCheckpointConfig:
         create_test_checkpoint_config(
             async_save=True, save="/tmp/test_checkpoint_config", use_persistent_ckpt_worker=True
         )
+
+    def test_async_save_format_validation_torch_dist(self, monkeypatch):
+        """Test that async_save works with torch_dist format."""
+        gpt_model_cfg = create_test_gpt_config()
+        train_cfg = create_test_training_config(train_iters=500, global_batch_size=16)
+        sched_cfg = create_test_scheduler_config()
+        ckpt_cfg = create_test_checkpoint_config(
+            async_save=True, save="/tmp/test_checkpoint", ckpt_format="torch_dist"
+        )
+
+        container, og_ws, cfg_mod = create_test_config_container(
+            world_size_override=1,
+            model_config=gpt_model_cfg,
+            train_config=train_cfg,
+            scheduler_config=sched_cfg,
+            checkpoint_config=ckpt_cfg,
+        )
+        try:
+            # Should not raise error - async_save with torch_dist is allowed
+            container.validate()
+        finally:
+            restore_get_world_size_safe(og_ws, cfg_mod)
+
+    def test_async_save_format_validation_fsdp_dtensor_fails(self, monkeypatch):
+        """Test that async_save fails with fsdp_dtensor format."""
+        gpt_model_cfg = create_test_gpt_config()
+        train_cfg = create_test_training_config(train_iters=500, global_batch_size=16)
+        sched_cfg = create_test_scheduler_config()
+        ckpt_cfg = create_test_checkpoint_config(
+            async_save=True, save="/tmp/test_checkpoint", ckpt_format="fsdp_dtensor"
+        )
+        # Enable Megatron FSDP so the format validation passes and we reach the async_save check
+        dist_cfg = create_test_distributed_init_config(use_megatron_fsdp=True)
+
+        container, og_ws, cfg_mod = create_test_config_container(
+            world_size_override=1,
+            model_config=gpt_model_cfg,
+            train_config=train_cfg,
+            scheduler_config=sched_cfg,
+            checkpoint_config=ckpt_cfg,
+            dist_config=dist_cfg,
+        )
+        try:
+            # Should raise error - async_save with fsdp_dtensor is not allowed
+            with pytest.raises(AssertionError, match="async_save is only supported with ckpt_format='torch_dist'"):
+                container.validate()
+        finally:
+            restore_get_world_size_safe(og_ws, cfg_mod)
+
+    def test_fsdp_dtensor_format_validation_with_megatron_fsdp(self, monkeypatch):
+        """Test that fsdp_dtensor format requires Megatron FSDP."""
+        gpt_model_cfg = create_test_gpt_config()
+        train_cfg = create_test_training_config(train_iters=500, global_batch_size=16)
+        sched_cfg = create_test_scheduler_config()
+        ckpt_cfg = create_test_checkpoint_config(save="/tmp/test_checkpoint", ckpt_format="fsdp_dtensor")
+        dist_cfg = create_test_distributed_init_config(use_megatron_fsdp=True)
+
+        container, og_ws, cfg_mod = create_test_config_container(
+            world_size_override=1,
+            model_config=gpt_model_cfg,
+            train_config=train_cfg,
+            scheduler_config=sched_cfg,
+            checkpoint_config=ckpt_cfg,
+            dist_config=dist_cfg,
+        )
+        try:
+            # Should not raise error - fsdp_dtensor with Megatron FSDP is allowed
+            container.validate()
+            assert container.checkpoint.ckpt_format == "fsdp_dtensor"
+            assert container.dist.use_megatron_fsdp is True
+            assert container.ddp.use_megatron_fsdp is True
+        finally:
+            restore_get_world_size_safe(og_ws, cfg_mod)
+
+    def test_fsdp_dtensor_format_validation_without_megatron_fsdp_fails(self, monkeypatch):
+        """Test that fsdp_dtensor format fails without Megatron FSDP."""
+        gpt_model_cfg = create_test_gpt_config()
+        train_cfg = create_test_training_config(train_iters=500, global_batch_size=16)
+        sched_cfg = create_test_scheduler_config()
+        ckpt_cfg = create_test_checkpoint_config(save="/tmp/test_checkpoint", ckpt_format="fsdp_dtensor")
+        dist_cfg = create_test_distributed_init_config(use_megatron_fsdp=False)
+
+        container, og_ws, cfg_mod = create_test_config_container(
+            world_size_override=1,
+            model_config=gpt_model_cfg,
+            train_config=train_cfg,
+            scheduler_config=sched_cfg,
+            checkpoint_config=ckpt_cfg,
+            dist_config=dist_cfg,
+        )
+        try:
+            # Should raise error - fsdp_dtensor without Megatron FSDP is not allowed
+            with pytest.raises(AssertionError, match="fsdp_dtensor checkpoint format only supports Megatron FSDP"):
+                container.validate()
+        finally:
+            restore_get_world_size_safe(og_ws, cfg_mod)
+
+    def test_megatron_fsdp_with_precision_aware_optimizer(self, monkeypatch):
+        """Test that Megatron FSDP with precision aware optimizer sets preserve_fp32_weights=False."""
+        gpt_model_cfg = create_test_gpt_config()
+        train_cfg = create_test_training_config(train_iters=500, global_batch_size=16)
+        sched_cfg = create_test_scheduler_config()
+
+        # Create optimizer config with precision aware optimizer enabled
+        optim_cfg = create_test_optimizer_config()
+        optim_cfg.use_precision_aware_optimizer = True
+        optim_cfg.use_distributed_optimizer = True  # Required for precision aware optimizer
+
+        dist_cfg = create_test_distributed_init_config(use_megatron_fsdp=True)
+
+        container, og_ws, cfg_mod = create_test_config_container(
+            world_size_override=1,
+            model_config=gpt_model_cfg,
+            train_config=train_cfg,
+            scheduler_config=sched_cfg,
+            optimizer_config=optim_cfg,
+            dist_config=dist_cfg,
+        )
+        try:
+            container.validate()
+            # Should automatically set preserve_fp32_weights=False when using precision aware optimizer with FSDP
+            assert container.ddp.preserve_fp32_weights is False
+            assert container.optimizer.use_precision_aware_optimizer is True
+            assert container.dist.use_megatron_fsdp is True
+        finally:
+            restore_get_world_size_safe(og_ws, cfg_mod)
+
+    def test_megatron_fsdp_without_precision_aware_optimizer(self, monkeypatch):
+        """Test that Megatron FSDP without precision aware optimizer doesn't modify preserve_fp32_weights."""
+        gpt_model_cfg = create_test_gpt_config()
+        train_cfg = create_test_training_config(train_iters=500, global_batch_size=16)
+        sched_cfg = create_test_scheduler_config()
+
+        # Create optimizer config with precision aware optimizer disabled
+        optim_cfg = create_test_optimizer_config()
+        optim_cfg.use_precision_aware_optimizer = False
+        optim_cfg.use_distributed_optimizer = True  # Enable distributed optimizer for consistency
+
+        dist_cfg = create_test_distributed_init_config(use_megatron_fsdp=True)
+
+        container, og_ws, cfg_mod = create_test_config_container(
+            world_size_override=1,
+            model_config=gpt_model_cfg,
+            train_config=train_cfg,
+            scheduler_config=sched_cfg,
+            optimizer_config=optim_cfg,
+            dist_config=dist_cfg,
+        )
+        try:
+            container.validate()
+            # preserve_fp32_weights should keep its default value when precision aware optimizer is disabled
+            assert container.optimizer.use_precision_aware_optimizer is False
+            assert container.dist.use_megatron_fsdp is True
+            # preserve_fp32_weights should remain at its default
+        finally:
+            restore_get_world_size_safe(og_ws, cfg_mod)


### PR DESCRIPTION
fixes #54 

Megatron FSDP relies on DTensor support, which needs special handling in megatron bridge checkpointing. This PR introduces a few changes to support this:

1. Use `unwrap_model` from megatron core

As this is already in core, there's no need to redefine it in the common utils. All callsites are updated to use the core utility and the copy in megatron bridge is removed.

2. Checkpointing:

A new checkpoint format `fsdp_dtensor` was introduced to distinguish handling for Megatron FSDP vs. megatron core dist checkpointing paths. This directly calls PyTorch DCP instead of going through MCore Dist Ckpt APIs. There are differences in:
- RNG state generation
- model state dict generation
- sharded state dict metadata
- the actual save/load paths

MLM reference: https://github.com/NVIDIA/Megatron-LM/commit/af28b5a559ace0782ad53957267f36e2b36ae011

3. This PR includes a few other fixes synchronizing changes from MLM:
- model config function handling
- adding a dedicated function to force parameter syncing before checkpoint saving / switching to eval
- precision aware optimizer + megatron fsdp should update the ddp config's `preserve_fp32_weights`

4. Testing
- Unit testing for configs/train utils
- Integration testing for checkpointing functions
- Functional testing for end to end training with megatron FSDP enabled + checkpoint saving & resuming