### PR TITLE
add zero_rank_only func

### DIFF
--- a/src/megatron/bridge/training/utils/config_utils.py
+++ b/src/megatron/bridge/training/utils/config_utils.py
@@ -22,6 +22,7 @@ import yaml
 from megatron.core.msc_utils import MultiStorageClientFeature
 from omegaconf import OmegaConf
 
+from megatron.bridge.utils.common_utils import rank_zero_only
 from megatron.bridge.utils.instantiate_utils import InstantiationMode, instantiate
 from megatron.bridge.utils.yaml_utils import safe_yaml_representers
 
@@ -181,6 +182,7 @@ class _ConfigContainerBase:
         else:
             return value
 
+    @rank_zero_only
     def to_yaml(self, yaml_path: Optional[str] = None) -> None:
         """
         Save the config container to a YAML file.

--- a/src/megatron/bridge/utils/common_utils.py
+++ b/src/megatron/bridge/utils/common_utils.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 import os
-from typing import Type, Union
+from functools import wraps
+from typing import Type, Union, Callable, Any, Optional
 
 import torch
 import torch.distributed
@@ -143,3 +144,15 @@ def use_dist_ckpt(ckpt_format: str) -> bool:
         True if the format is not "torch", False otherwise.
     """
     return ckpt_format != "torch"
+
+
+def rank_zero_only(fn: Callable) -> Callable:
+    """Decorator to enable a function being called only on global rank 0."""
+
+    @wraps(fn)
+    def wrapped_fn(*args: Any, **kwargs: Any) -> Optional[Any]:
+        if get_rank_safe() == 0:
+            return fn(*args, **kwargs)
+        return None
+
+    return wrapped_fn


### PR DESCRIPTION
Adding a decorator `rank_zero_only` to enable a func being called only on rank 0.

It fixes the issue that `cfg.to_yaml(yaml_path=xxx)` not compatible with MultiStorageClientFeature when multi-gpu is used. Calling this func from all ranks will crash if msc is enabled.
```
if MultiStorageClientFeature.is_enabled():
    msc = MultiStorageClientFeature.import_package()
    with msc.open(yaml_path, "w") as f:
        yaml.safe_dump(config_dict, f, default_flow_style=False)
```

`rank_zero_only` should also be useful for other functions intended to be called only on rank 0.