### PR TITLE
Bug in MXFP8 Recipe

### DIFF
--- a/src/megatron/bridge/training/mixed_precision.py
+++ b/src/megatron/bridge/training/mixed_precision.py
@@ -225,7 +225,7 @@ def bf16_with_mxfp8_mixed() -> MixedPrecisionConfig:
         MixedPrecisionConfig: Configuration for BF16 with MXFP8 mixed precision training
     """
     cfg = bf16_mixed()
-    cfg.fp8 = "hybrid"
+    cfg.fp8 = "e4m3"
     cfg.fp8_recipe = "mxfp8"
     cfg.fp8_param_gather = True
     cfg.reuse_grad_buf_for_mxfp8_param_ag = True
@@ -240,7 +240,7 @@ def fp16_with_mxfp8_mixed() -> MixedPrecisionConfig:
         MixedPrecisionConfig: Configuration for FP16 with MXFP8 mixed precision training
     """
     cfg = fp16_mixed()
-    cfg.fp8 = "hybrid"
+    cfg.fp8 = "e4m3"
     cfg.fp8_recipe = "mxfp8"
     cfg.fp8_param_gather = True
     cfg.reuse_grad_buf_for_mxfp8_param_ag = True

--- a/tests/unit_tests/training/test_mixed_precision.py
+++ b/tests/unit_tests/training/test_mixed_precision.py
@@ -559,7 +559,7 @@ class TestMixedPrecisionRecipes:
         assert config.params_dtype == torch.bfloat16
 
         # MXFP8 specific settings
-        assert config.fp8 == "hybrid"
+        assert config.fp8 == "e4m3"
         assert config.fp8_recipe == "mxfp8"
         assert config.fp8_param_gather is True
         assert config.reuse_grad_buf_for_mxfp8_param_ag is True
@@ -574,7 +574,7 @@ class TestMixedPrecisionRecipes:
         assert config.params_dtype == torch.half
 
         # MXFP8 specific settings
-        assert config.fp8 == "hybrid"
+        assert config.fp8 == "e4m3"
         assert config.fp8_recipe == "mxfp8"
         assert config.fp8_param_gather is True
         assert config.reuse_grad_buf_for_mxfp8_param_ag is True


### PR DESCRIPTION
MXFP8 recipe must only use E4M3 data format for both fprop and bprop. Using E5M2 for gradients causes the training curve to diverge and also affects downstream accuracy on MMLU. Plots for reference using a Nemotron5-8B Dense model architecture (trained using NeMo5-15T-Phase1 dataset) can be found below:
<img width="925" height="425" alt="image" src="https://github.com/user-attachments/assets/1d2a49e5-4242-488c-973b-d53c65cec51d" />
