### PR TITLE
save tokenizer metadata when importing checkpoint via auto bridge

### DIFF
--- a/src/megatron/bridge/training/model_load_save.py
+++ b/src/megatron/bridge/training/model_load_save.py
@@ -333,7 +333,12 @@ def load_megatron_model(
     )
 
 
-def save_megatron_model(model: list[MegatronModule], path: Union[str, Path], ckpt_format: str = "torch_dist") -> None:
+def save_megatron_model(
+    model: list[MegatronModule],
+    path: Union[str, Path],
+    ckpt_format: str = "torch_dist",
+    hf_tokenizer_path: Optional[Union[str, Path]] = None,
+) -> None:
     """Save a Megatron model in native Megatron checkpoint format without optimizer state.
 
     This method saves the model in Megatron's native checkpoint format, which
@@ -345,16 +350,35 @@ def save_megatron_model(model: list[MegatronModule], path: Union[str, Path], ckp
         model: Megatron model instance or list of instances.
         path: Directory path where the checkpoint will be saved.
         ckpt_format: Checkpoint format to use ("torch_dist" or other supported formats).
+        hf_tokenizer_path: Optional HuggingFace model ID or path for tokenizer metadata.
+            If provided, the tokenizer metadata will be included in the checkpoint.
 
     Example:
         >>> # Save model checkpoint
         >>> save_megatron_model(megatron_model, "./megatron_checkpoint")
+
+        >>> # Save model checkpoint with tokenizer metadata
+        >>> save_megatron_model(
+        ...     megatron_model,
+        ...     "./megatron_checkpoint",
+        ...     hf_tokenizer_path="meta-llama/Llama-3-8B"
+        ... )
 
     Note:
         - This method is collective and must be called by all ranks
         - The saved checkpoint can be loaded with Megatron's checkpoint loading utilities
         - The checkpoint format follows Megatron's standard structure for compatibility
     """
+    # Create tokenizer config if tokenizer path is provided
+    tokenizer_config = None
+    if hf_tokenizer_path is not None:
+        from megatron.bridge.training.tokenizers.config import TokenizerConfig
+
+        tokenizer_config = TokenizerConfig(
+            tokenizer_type="HuggingFaceTokenizer",
+            tokenizer_model=str(hf_tokenizer_path),
+        )
+
     # Get model config from the first model instance
     model_config = get_model_config(model[0])
 
@@ -377,7 +401,7 @@ def save_megatron_model(model: list[MegatronModule], path: Union[str, Path], ckp
         scheduler=None,
         dataset=None,
         logger=LoggerConfig(),
-        tokenizer=None,
+        tokenizer=tokenizer_config,
         checkpoint=CheckpointConfig(
             async_save=False,
             save=str(path),

--- a/tests/unit_tests/models/test_auto_bridge.py
+++ b/tests/unit_tests/models/test_auto_bridge.py
@@ -674,7 +674,9 @@ class TestAutoBridge:
         # Assertions
         mock_from_hf_pretrained.assert_called_once_with("meta-llama/Llama-3-8B")
         mock_bridge.to_megatron_model.assert_called_once_with(wrap_with_ddp=False, use_cpu_initialization=True)
-        mock_bridge.save_megatron_model.assert_called_once_with(mock_megatron_model, "./megatron_checkpoint")
+        mock_bridge.save_megatron_model.assert_called_once_with(
+            mock_megatron_model, "./megatron_checkpoint", hf_tokenizer_path="meta-llama/Llama-3-8B"
+        )
 
     @patch.object(AutoBridge, "save_megatron_model")
     @patch.object(AutoBridge, "to_megatron_model")
@@ -695,7 +697,9 @@ class TestAutoBridge:
         # Assertions
         mock_from_hf_pretrained.assert_called_once_with("./local_model", torch_dtype=torch.float16, device_map="auto")
         mock_bridge.to_megatron_model.assert_called_once_with(wrap_with_ddp=False, use_cpu_initialization=True)
-        mock_bridge.save_megatron_model.assert_called_once_with(mock_megatron_model, "./megatron_checkpoint")
+        mock_bridge.save_megatron_model.assert_called_once_with(
+            mock_megatron_model, "./megatron_checkpoint", hf_tokenizer_path="./local_model"
+        )
 
     def test_export_ckpt_basic(self):
         """Test basic export_ckpt functionality."""
@@ -762,7 +766,30 @@ class TestAutoBridge:
         with patch("megatron.bridge.training.model_load_save.save_megatron_model") as mock_save_megatron_model:
             bridge.save_megatron_model(mock_megatron_model, "./checkpoint_path")
 
-            mock_save_megatron_model.assert_called_once_with(mock_megatron_model, "./checkpoint_path")
+            mock_save_megatron_model.assert_called_once_with(
+                mock_megatron_model, "./checkpoint_path", hf_tokenizer_path=None
+            )
+
+    def test_save_megatron_model_with_tokenizer(self):
+        """Test save_megatron_model method with tokenizer path."""
+        mock_hf_model = Mock(spec=PreTrainedCausalLM)
+        mock_config = Mock(spec=PretrainedConfig)
+        mock_config.architectures = ["LlamaForCausalLM"]
+        mock_hf_model.config = mock_config
+
+        mock_megatron_model = [Mock()]
+
+        bridge = AutoBridge.__new__(AutoBridge)
+        bridge.hf_pretrained = mock_hf_model
+
+        with patch("megatron.bridge.training.model_load_save.save_megatron_model") as mock_save_megatron_model:
+            bridge.save_megatron_model(
+                mock_megatron_model, "./checkpoint_path", hf_tokenizer_path="meta-llama/Llama-3-8B"
+            )
+
+            mock_save_megatron_model.assert_called_once_with(
+                mock_megatron_model, "./checkpoint_path", hf_tokenizer_path="meta-llama/Llama-3-8B"
+            )
 
     def test_save_megatron_model_import_error(self):
         """Test save_megatron_model import error handling."""


### PR DESCRIPTION
fixes #645 