### PR TITLE
Fix Mamba and NemotronH recipes

### DIFF
--- a/src/megatron/bridge/models/mamba/mamba_provider.py
+++ b/src/megatron/bridge/models/mamba/mamba_provider.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Callable, Literal, Optional, Union
 
 import torch
@@ -70,9 +70,7 @@ class MambaProvider(TransformerConfig, ModelProviderMixin[MCoreMambaModel]):
     deallocate_pipeline_outputs: bool = True
     bias_dropout_fusion: bool = True
     cross_entropy_loss_fusion: bool = True
-    mamba_stack_spec: Union[ModuleSpec, Callable[[], ModuleSpec]] = field(
-        default_factory=lambda: default_mamba_stack_spec
-    )
+    mamba_stack_spec: Union[ModuleSpec, Callable[[], ModuleSpec]] = lambda: default_mamba_stack_spec
     vocab_size: Optional[int] = None
     should_pad_vocab: bool = False
 

--- a/src/megatron/bridge/recipes/mamba/mamba2_130m.py
+++ b/src/megatron/bridge/recipes/mamba/mamba2_130m.py
@@ -85,7 +85,7 @@ def pretrain_config(
     context_parallelism: int = 1,
     sequence_parallelism: bool = False,
     # Training hyperparameters
-    train_iters: int = 100,
+    train_iters: int = 1_168_251,
     global_batch_size: int = 8,
     micro_batch_size: int = 1,
     seq_length: int = 4096,

--- a/src/megatron/bridge/recipes/mamba/mamba2_130m.py
+++ b/src/megatron/bridge/recipes/mamba/mamba2_130m.py
@@ -174,6 +174,7 @@ def pretrain_config(
             grad_reduce_in_fp32=True,
             overlap_grad_reduce=True,
             overlap_param_gather=True,
+            use_distributed_optimizer=True,
         ),
         dataset=GPTDatasetConfig(
             random_seed=1234,

--- a/src/megatron/bridge/recipes/mamba/mamba2_1_3b.py
+++ b/src/megatron/bridge/recipes/mamba/mamba2_1_3b.py
@@ -85,7 +85,7 @@ def pretrain_config(
     context_parallelism: int = 1,
     sequence_parallelism: bool = False,
     # Training hyperparameters
-    train_iters: int = 100,
+    train_iters: int = 1_168_251,
     global_batch_size: int = 8,
     micro_batch_size: int = 1,
     seq_length: int = 4096,

--- a/src/megatron/bridge/recipes/mamba/mamba2_1_3b.py
+++ b/src/megatron/bridge/recipes/mamba/mamba2_1_3b.py
@@ -174,6 +174,7 @@ def pretrain_config(
             grad_reduce_in_fp32=True,
             overlap_grad_reduce=True,
             overlap_param_gather=True,
+            use_distributed_optimizer=True,
         ),
         dataset=GPTDatasetConfig(
             random_seed=1234,

--- a/src/megatron/bridge/recipes/mamba/mamba2_2_7b.py
+++ b/src/megatron/bridge/recipes/mamba/mamba2_2_7b.py
@@ -85,7 +85,7 @@ def pretrain_config(
     context_parallelism: int = 1,
     sequence_parallelism: bool = False,
     # Training hyperparameters
-    train_iters: int = 100,
+    train_iters: int = 1_168_251,
     global_batch_size: int = 8,
     micro_batch_size: int = 1,
     seq_length: int = 4096,

--- a/src/megatron/bridge/recipes/mamba/mamba2_2_7b.py
+++ b/src/megatron/bridge/recipes/mamba/mamba2_2_7b.py
@@ -174,6 +174,7 @@ def pretrain_config(
             grad_reduce_in_fp32=True,
             overlap_grad_reduce=True,
             overlap_param_gather=True,
+            use_distributed_optimizer=True,
         ),
         dataset=GPTDatasetConfig(
             random_seed=1234,

--- a/src/megatron/bridge/recipes/mamba/mamba2_370m.py
+++ b/src/megatron/bridge/recipes/mamba/mamba2_370m.py
@@ -85,7 +85,7 @@ def pretrain_config(
     context_parallelism: int = 1,
     sequence_parallelism: bool = False,
     # Training hyperparameters
-    train_iters: int = 100,
+    train_iters: int = 1_168_251,
     global_batch_size: int = 8,
     micro_batch_size: int = 1,
     seq_length: int = 4096,

--- a/src/megatron/bridge/recipes/mamba/mamba2_370m.py
+++ b/src/megatron/bridge/recipes/mamba/mamba2_370m.py
@@ -174,6 +174,7 @@ def pretrain_config(
             grad_reduce_in_fp32=True,
             overlap_grad_reduce=True,
             overlap_param_gather=True,
+            use_distributed_optimizer=True,
         ),
         dataset=GPTDatasetConfig(
             random_seed=1234,

--- a/src/megatron/bridge/recipes/mamba/mamba2_780m.py
+++ b/src/megatron/bridge/recipes/mamba/mamba2_780m.py
@@ -85,7 +85,7 @@ def pretrain_config(
     context_parallelism: int = 1,
     sequence_parallelism: bool = False,
     # Training hyperparameters
-    train_iters: int = 100,
+    train_iters: int = 1_168_251,
     global_batch_size: int = 8,
     micro_batch_size: int = 1,
     seq_length: int = 4096,

--- a/src/megatron/bridge/recipes/mamba/mamba2_780m.py
+++ b/src/megatron/bridge/recipes/mamba/mamba2_780m.py
@@ -174,6 +174,7 @@ def pretrain_config(
             grad_reduce_in_fp32=True,
             overlap_grad_reduce=True,
             overlap_param_gather=True,
+            use_distributed_optimizer=True,
         ),
         dataset=GPTDatasetConfig(
             random_seed=1234,

--- a/src/megatron/bridge/recipes/mamba/mamba2_8b.py
+++ b/src/megatron/bridge/recipes/mamba/mamba2_8b.py
@@ -175,6 +175,7 @@ def pretrain_config(
             grad_reduce_in_fp32=True,
             overlap_grad_reduce=True,
             overlap_param_gather=True,
+            use_distributed_optimizer=True,
         ),
         dataset=GPTDatasetConfig(
             random_seed=1234,

--- a/src/megatron/bridge/recipes/mamba/mamba2_8b.py
+++ b/src/megatron/bridge/recipes/mamba/mamba2_8b.py
@@ -86,7 +86,7 @@ def pretrain_config(
     context_parallelism: int = 1,
     sequence_parallelism: bool = False,
     # Training hyperparameters
-    train_iters: int = 100,
+    train_iters: int = 1_168_251,
     global_batch_size: int = 8,
     micro_batch_size: int = 1,
     seq_length: int = 4096,

--- a/src/megatron/bridge/recipes/mamba/mamba2_hybrid_8b.py
+++ b/src/megatron/bridge/recipes/mamba/mamba2_hybrid_8b.py
@@ -175,6 +175,7 @@ def pretrain_config(
             grad_reduce_in_fp32=True,
             overlap_grad_reduce=True,
             overlap_param_gather=True,
+            use_distributed_optimizer=True,
         ),
         dataset=GPTDatasetConfig(
             random_seed=1234,

--- a/src/megatron/bridge/recipes/mamba/mamba2_hybrid_8b.py
+++ b/src/megatron/bridge/recipes/mamba/mamba2_hybrid_8b.py
@@ -86,7 +86,7 @@ def pretrain_config(
     context_parallelism: int = 1,
     sequence_parallelism: bool = False,
     # Training hyperparameters
-    train_iters: int = 100,
+    train_iters: int = 1_168_251,
     global_batch_size: int = 8,
     micro_batch_size: int = 1,
     seq_length: int = 4096,

--- a/src/megatron/bridge/recipes/mamba/nemotron_nano_12b_v2.py
+++ b/src/megatron/bridge/recipes/mamba/nemotron_nano_12b_v2.py
@@ -174,6 +174,7 @@ def pretrain_config(
             grad_reduce_in_fp32=True,
             overlap_grad_reduce=True,
             overlap_param_gather=False,
+            use_distributed_optimizer=True,
         ),
         dataset=GPTDatasetConfig(
             random_seed=1234,

--- a/src/megatron/bridge/recipes/mamba/nemotron_nano_12b_v2.py
+++ b/src/megatron/bridge/recipes/mamba/nemotron_nano_12b_v2.py
@@ -85,7 +85,7 @@ def pretrain_config(
     context_parallelism: int = 1,
     sequence_parallelism: bool = True,
     # Training hyperparameters
-    train_iters: int = 10,
+    train_iters: int = 1_168_251,
     global_batch_size: int = 768,
     micro_batch_size: int = 1,
     seq_length: int = 8192,

--- a/src/megatron/bridge/recipes/mamba/nemotron_nano_9b_v2.py
+++ b/src/megatron/bridge/recipes/mamba/nemotron_nano_9b_v2.py
@@ -174,6 +174,7 @@ def pretrain_config(
             grad_reduce_in_fp32=True,
             overlap_grad_reduce=True,
             overlap_param_gather=False,
+            use_distributed_optimizer=True,
         ),
         dataset=GPTDatasetConfig(
             random_seed=1234,

--- a/src/megatron/bridge/recipes/mamba/nemotron_nano_9b_v2.py
+++ b/src/megatron/bridge/recipes/mamba/nemotron_nano_9b_v2.py
@@ -85,7 +85,7 @@ def pretrain_config(
     context_parallelism: int = 1,
     sequence_parallelism: bool = True,
     # Training hyperparameters
-    train_iters: int = 10,
+    train_iters: int = 1_168_251,
     global_batch_size: int = 768,
     micro_batch_size: int = 1,
     seq_length: int = 8192,

--- a/src/megatron/bridge/recipes/mamba/nemotronh_47b.py
+++ b/src/megatron/bridge/recipes/mamba/nemotronh_47b.py
@@ -174,6 +174,7 @@ def pretrain_config(
             grad_reduce_in_fp32=True,
             overlap_grad_reduce=True,
             overlap_param_gather=False,
+            use_distributed_optimizer=True,
         ),
         dataset=GPTDatasetConfig(
             random_seed=1234,

--- a/src/megatron/bridge/recipes/mamba/nemotronh_47b.py
+++ b/src/megatron/bridge/recipes/mamba/nemotronh_47b.py
@@ -85,7 +85,7 @@ def pretrain_config(
     context_parallelism: int = 1,
     sequence_parallelism: bool = True,
     # Training hyperparameters
-    train_iters: int = 10,
+    train_iters: int = 1_168_251,
     global_batch_size: int = 768,
     micro_batch_size: int = 1,
     seq_length: int = 8192,

--- a/src/megatron/bridge/recipes/mamba/nemotronh_4b.py
+++ b/src/megatron/bridge/recipes/mamba/nemotronh_4b.py
@@ -174,6 +174,7 @@ def pretrain_config(
             grad_reduce_in_fp32=True,
             overlap_grad_reduce=True,
             overlap_param_gather=False,
+            use_distributed_optimizer=True,
         ),
         dataset=GPTDatasetConfig(
             random_seed=1234,

--- a/src/megatron/bridge/recipes/mamba/nemotronh_4b.py
+++ b/src/megatron/bridge/recipes/mamba/nemotronh_4b.py
@@ -85,7 +85,7 @@ def pretrain_config(
     context_parallelism: int = 1,
     sequence_parallelism: bool = False,
     # Training hyperparameters
-    train_iters: int = 10,
+    train_iters: int = 1_168_251,
     global_batch_size: int = 768,
     micro_batch_size: int = 1,
     seq_length: int = 8192,

--- a/src/megatron/bridge/recipes/mamba/nemotronh_56b.py
+++ b/src/megatron/bridge/recipes/mamba/nemotronh_56b.py
@@ -174,6 +174,7 @@ def pretrain_config(
             grad_reduce_in_fp32=True,
             overlap_grad_reduce=True,
             overlap_param_gather=False,
+            use_distributed_optimizer=True,
         ),
         dataset=GPTDatasetConfig(
             random_seed=1234,

--- a/src/megatron/bridge/recipes/mamba/nemotronh_56b.py
+++ b/src/megatron/bridge/recipes/mamba/nemotronh_56b.py
@@ -85,7 +85,7 @@ def pretrain_config(
     context_parallelism: int = 1,
     sequence_parallelism: bool = True,
     # Training hyperparameters
-    train_iters: int = 10,
+    train_iters: int = 1_168_251,
     global_batch_size: int = 768,
     micro_batch_size: int = 1,
     seq_length: int = 8192,

--- a/src/megatron/bridge/recipes/mamba/nemotronh_8b.py
+++ b/src/megatron/bridge/recipes/mamba/nemotronh_8b.py
@@ -174,6 +174,7 @@ def pretrain_config(
             grad_reduce_in_fp32=True,
             overlap_grad_reduce=True,
             overlap_param_gather=False,
+            use_distributed_optimizer=True,
         ),
         dataset=GPTDatasetConfig(
             random_seed=1234,

--- a/src/megatron/bridge/recipes/mamba/nemotronh_8b.py
+++ b/src/megatron/bridge/recipes/mamba/nemotronh_8b.py
@@ -85,7 +85,7 @@ def pretrain_config(
     context_parallelism: int = 1,
     sequence_parallelism: bool = True,
     # Training hyperparameters
-    train_iters: int = 10,
+    train_iters: int = 1_168_251,
     global_batch_size: int = 768,
     micro_batch_size: int = 1,
     seq_length: int = 8192,

--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -906,3 +906,7 @@ class ConfigContainer(Container):
 
         # Validate DeepEP is supported for the current GPU architecture
         validate_deepep(self.model)
+
+        assert self.ddp.use_distributed_optimizer == self.optimizer.use_distributed_optimizer, (
+            "Please ensure 'use_distributed_optimizer' setting in DistributedDataParallelConfig and OptimizerConfig matches."
+        )

--- a/tests/unit_tests/recipes/mamba/test_mamba2_130m.py
+++ b/tests/unit_tests/recipes/mamba/test_mamba2_130m.py
@@ -238,6 +238,7 @@ class TestPretrainConfig:
         assert config.ddp.grad_reduce_in_fp32 is True
         assert config.ddp.overlap_grad_reduce is True
         assert config.ddp.overlap_param_gather is True
+        assert config.ddp.use_distributed_optimizer is True
 
     def test_pretrain_config_default_comm_overlap(self):
         """Test default CommOverlapConfig setup."""

--- a/tests/unit_tests/recipes/mamba/test_mamba2_130m.py
+++ b/tests/unit_tests/recipes/mamba/test_mamba2_130m.py
@@ -97,7 +97,7 @@ class TestPretrainConfig:
         assert isinstance(config.model, MambaProvider130M)
 
         # Check training configuration
-        assert config.train.train_iters == 100
+        assert config.train.train_iters == 1_168_251
         assert config.train.global_batch_size == 8
         assert config.train.micro_batch_size == 1
         assert config.train.eval_interval == 100

--- a/tests/unit_tests/recipes/mamba/test_mamba2_1_3b.py
+++ b/tests/unit_tests/recipes/mamba/test_mamba2_1_3b.py
@@ -244,6 +244,7 @@ class TestPretrainConfig:
         assert config.ddp.grad_reduce_in_fp32 is True
         assert config.ddp.overlap_grad_reduce is True
         assert config.ddp.overlap_param_gather is True
+        assert config.ddp.use_distributed_optimizer is True
 
     def test_pretrain_config_default_comm_overlap(self):
         """Test default CommOverlapConfig setup."""

--- a/tests/unit_tests/recipes/mamba/test_mamba2_1_3b.py
+++ b/tests/unit_tests/recipes/mamba/test_mamba2_1_3b.py
@@ -99,7 +99,7 @@ class TestPretrainConfig:
         assert isinstance(config.model, MambaProvider1_3B)
 
         # Check training configuration
-        assert config.train.train_iters == 100
+        assert config.train.train_iters == 1_168_251
         assert config.train.global_batch_size == 8
         assert config.train.micro_batch_size == 1
         assert config.train.eval_interval == 100

--- a/tests/unit_tests/recipes/mamba/test_mamba2_2_7b.py
+++ b/tests/unit_tests/recipes/mamba/test_mamba2_2_7b.py
@@ -244,6 +244,7 @@ class TestPretrainConfig:
         assert config.ddp.grad_reduce_in_fp32 is True
         assert config.ddp.overlap_grad_reduce is True
         assert config.ddp.overlap_param_gather is True
+        assert config.ddp.use_distributed_optimizer is True
 
     def test_pretrain_config_default_comm_overlap(self):
         """Test default CommOverlapConfig setup."""

--- a/tests/unit_tests/recipes/mamba/test_mamba2_2_7b.py
+++ b/tests/unit_tests/recipes/mamba/test_mamba2_2_7b.py
@@ -99,7 +99,7 @@ class TestPretrainConfig:
         assert isinstance(config.model, MambaProvider2_7B)
 
         # Check training configuration
-        assert config.train.train_iters == 100
+        assert config.train.train_iters == 1_168_251
         assert config.train.global_batch_size == 8
         assert config.train.micro_batch_size == 1
         assert config.train.eval_interval == 100

--- a/tests/unit_tests/recipes/mamba/test_mamba2_370m.py
+++ b/tests/unit_tests/recipes/mamba/test_mamba2_370m.py
@@ -242,6 +242,7 @@ class TestPretrainConfig:
         assert config.ddp.grad_reduce_in_fp32 is True
         assert config.ddp.overlap_grad_reduce is True
         assert config.ddp.overlap_param_gather is True
+        assert config.ddp.use_distributed_optimizer is True
 
     def test_pretrain_config_default_comm_overlap(self):
         """Test default CommOverlapConfig setup."""

--- a/tests/unit_tests/recipes/mamba/test_mamba2_370m.py
+++ b/tests/unit_tests/recipes/mamba/test_mamba2_370m.py
@@ -99,7 +99,7 @@ class TestPretrainConfig:
         assert isinstance(config.model, MambaProvider370M)
 
         # Check training configuration
-        assert config.train.train_iters == 100
+        assert config.train.train_iters == 1_168_251
         assert config.train.global_batch_size == 8
         assert config.train.micro_batch_size == 1
         assert config.train.eval_interval == 100

--- a/tests/unit_tests/recipes/mamba/test_mamba2_780m.py
+++ b/tests/unit_tests/recipes/mamba/test_mamba2_780m.py
@@ -99,7 +99,7 @@ class TestPretrainConfig:
         assert isinstance(config.model, MambaProvider780M)
 
         # Check training configuration
-        assert config.train.train_iters == 100
+        assert config.train.train_iters == 1_168_251
         assert config.train.global_batch_size == 8
         assert config.train.micro_batch_size == 1
         assert config.train.eval_interval == 100

--- a/tests/unit_tests/recipes/mamba/test_mamba2_780m.py
+++ b/tests/unit_tests/recipes/mamba/test_mamba2_780m.py
@@ -244,6 +244,7 @@ class TestPretrainConfig:
         assert config.ddp.grad_reduce_in_fp32 is True
         assert config.ddp.overlap_grad_reduce is True
         assert config.ddp.overlap_param_gather is True
+        assert config.ddp.use_distributed_optimizer is True
 
     def test_pretrain_config_default_comm_overlap(self):
         """Test default CommOverlapConfig setup."""

--- a/tests/unit_tests/recipes/mamba/test_mamba2_8b.py
+++ b/tests/unit_tests/recipes/mamba/test_mamba2_8b.py
@@ -259,6 +259,7 @@ class TestPretrainConfig:
         assert config.ddp.grad_reduce_in_fp32 is True
         assert config.ddp.overlap_grad_reduce is True
         assert config.ddp.overlap_param_gather is True
+        assert config.ddp.use_distributed_optimizer is True
 
     def test_pretrain_config_default_comm_overlap(self):
         """Test default CommOverlapConfig setup."""

--- a/tests/unit_tests/recipes/mamba/test_mamba2_8b.py
+++ b/tests/unit_tests/recipes/mamba/test_mamba2_8b.py
@@ -114,7 +114,7 @@ class TestPretrainConfig:
         assert isinstance(config.model, NVIDIAMambaProvider8B)
 
         # Check training configuration
-        assert config.train.train_iters == 100
+        assert config.train.train_iters == 1_168_251
         assert config.train.global_batch_size == 8
         assert config.train.micro_batch_size == 1
         assert config.train.eval_interval == 100

--- a/tests/unit_tests/recipes/mamba/test_mamba2_hybrid_8b.py
+++ b/tests/unit_tests/recipes/mamba/test_mamba2_hybrid_8b.py
@@ -114,7 +114,7 @@ class TestPretrainConfig:
         assert isinstance(config.model, NVIDIAMambaHybridProvider8B)
 
         # Check training configuration
-        assert config.train.train_iters == 100
+        assert config.train.train_iters == 1_168_251
         assert config.train.global_batch_size == 8
         assert config.train.micro_batch_size == 1
         assert config.train.eval_interval == 100

--- a/tests/unit_tests/recipes/mamba/test_mamba2_hybrid_8b.py
+++ b/tests/unit_tests/recipes/mamba/test_mamba2_hybrid_8b.py
@@ -259,6 +259,7 @@ class TestPretrainConfig:
         assert config.ddp.grad_reduce_in_fp32 is True
         assert config.ddp.overlap_grad_reduce is True
         assert config.ddp.overlap_param_gather is True
+        assert config.ddp.use_distributed_optimizer is True
 
     def test_pretrain_config_default_comm_overlap(self):
         """Test default CommOverlapConfig setup."""

--- a/tests/unit_tests/recipes/mamba/test_nemotron_nano_12b_v2.py
+++ b/tests/unit_tests/recipes/mamba/test_nemotron_nano_12b_v2.py
@@ -119,7 +119,7 @@ class TestPretrainConfig:
         assert isinstance(config.model, NemotronNano12Bv2Provider)
 
         # Check training configuration
-        assert config.train.train_iters == 10
+        assert config.train.train_iters == 1_168_251
         assert config.train.global_batch_size == 768
         assert config.train.micro_batch_size == 1
         assert config.train.eval_interval == 10

--- a/tests/unit_tests/recipes/mamba/test_nemotron_nano_12b_v2.py
+++ b/tests/unit_tests/recipes/mamba/test_nemotron_nano_12b_v2.py
@@ -264,6 +264,7 @@ class TestPretrainConfig:
         assert config.ddp.grad_reduce_in_fp32 is True
         assert config.ddp.overlap_grad_reduce is True
         assert config.ddp.overlap_param_gather is False
+        assert config.ddp.use_distributed_optimizer is True
 
     def test_pretrain_config_default_comm_overlap(self):
         """Test default CommOverlapConfig setup."""

--- a/tests/unit_tests/recipes/mamba/test_nemotron_nano_9b_v2.py
+++ b/tests/unit_tests/recipes/mamba/test_nemotron_nano_9b_v2.py
@@ -119,7 +119,7 @@ class TestPretrainConfig:
         assert isinstance(config.model, NemotronNano9Bv2Provider)
 
         # Check training configuration
-        assert config.train.train_iters == 10
+        assert config.train.train_iters == 1_168_251
         assert config.train.global_batch_size == 768
         assert config.train.micro_batch_size == 1
         assert config.train.eval_interval == 10

--- a/tests/unit_tests/recipes/mamba/test_nemotron_nano_9b_v2.py
+++ b/tests/unit_tests/recipes/mamba/test_nemotron_nano_9b_v2.py
@@ -264,6 +264,7 @@ class TestPretrainConfig:
         assert config.ddp.grad_reduce_in_fp32 is True
         assert config.ddp.overlap_grad_reduce is True
         assert config.ddp.overlap_param_gather is False
+        assert config.ddp.use_distributed_optimizer is True
 
     def test_pretrain_config_default_comm_overlap(self):
         """Test default CommOverlapConfig setup."""

--- a/tests/unit_tests/recipes/mamba/test_nemotronh_47b.py
+++ b/tests/unit_tests/recipes/mamba/test_nemotronh_47b.py
@@ -264,6 +264,7 @@ class TestPretrainConfig:
         assert config.ddp.grad_reduce_in_fp32 is True
         assert config.ddp.overlap_grad_reduce is True
         assert config.ddp.overlap_param_gather is False  # Different from other models
+        assert config.ddp.use_distributed_optimizer is True
 
     def test_pretrain_config_default_comm_overlap(self):
         """Test default CommOverlapConfig setup."""

--- a/tests/unit_tests/recipes/mamba/test_nemotronh_47b.py
+++ b/tests/unit_tests/recipes/mamba/test_nemotronh_47b.py
@@ -119,7 +119,7 @@ class TestPretrainConfig:
         assert isinstance(config.model, NemotronHModel47BProvider)
 
         # Check training configuration
-        assert config.train.train_iters == 10
+        assert config.train.train_iters == 1_168_251
         assert config.train.global_batch_size == 768
         assert config.train.micro_batch_size == 1
         assert config.train.eval_interval == 10

--- a/tests/unit_tests/recipes/mamba/test_nemotronh_4b.py
+++ b/tests/unit_tests/recipes/mamba/test_nemotronh_4b.py
@@ -119,7 +119,7 @@ class TestPretrainConfig:
         assert isinstance(config.model, NemotronHModel4BProvider)
 
         # Check training configuration
-        assert config.train.train_iters == 10
+        assert config.train.train_iters == 1_168_251
         assert config.train.global_batch_size == 768
         assert config.train.micro_batch_size == 1
         assert config.train.eval_interval == 10

--- a/tests/unit_tests/recipes/mamba/test_nemotronh_4b.py
+++ b/tests/unit_tests/recipes/mamba/test_nemotronh_4b.py
@@ -264,6 +264,7 @@ class TestPretrainConfig:
         assert config.ddp.grad_reduce_in_fp32 is True
         assert config.ddp.overlap_grad_reduce is True
         assert config.ddp.overlap_param_gather is False  # Different from other models
+        assert config.ddp.use_distributed_optimizer is True
 
     def test_pretrain_config_default_comm_overlap(self):
         """Test default CommOverlapConfig setup."""

--- a/tests/unit_tests/recipes/mamba/test_nemotronh_56b.py
+++ b/tests/unit_tests/recipes/mamba/test_nemotronh_56b.py
@@ -119,7 +119,7 @@ class TestPretrainConfig:
         assert isinstance(config.model, NemotronHModel56BProvider)
 
         # Check training configuration
-        assert config.train.train_iters == 10
+        assert config.train.train_iters == 1_168_251
         assert config.train.global_batch_size == 768
         assert config.train.micro_batch_size == 1
         assert config.train.eval_interval == 10

--- a/tests/unit_tests/recipes/mamba/test_nemotronh_56b.py
+++ b/tests/unit_tests/recipes/mamba/test_nemotronh_56b.py
@@ -264,6 +264,7 @@ class TestPretrainConfig:
         assert config.ddp.grad_reduce_in_fp32 is True
         assert config.ddp.overlap_grad_reduce is True
         assert config.ddp.overlap_param_gather is False  # Different from other models
+        assert config.ddp.use_distributed_optimizer is True
 
     def test_pretrain_config_default_comm_overlap(self):
         """Test default CommOverlapConfig setup."""

--- a/tests/unit_tests/recipes/mamba/test_nemotronh_8b.py
+++ b/tests/unit_tests/recipes/mamba/test_nemotronh_8b.py
@@ -119,7 +119,7 @@ class TestPretrainConfig:
         assert isinstance(config.model, NemotronHModel8BProvider)
 
         # Check training configuration
-        assert config.train.train_iters == 10
+        assert config.train.train_iters == 1_168_251
         assert config.train.global_batch_size == 768
         assert config.train.micro_batch_size == 1
         assert config.train.eval_interval == 10

--- a/tests/unit_tests/recipes/mamba/test_nemotronh_8b.py
+++ b/tests/unit_tests/recipes/mamba/test_nemotronh_8b.py
@@ -264,6 +264,7 @@ class TestPretrainConfig:
         assert config.ddp.grad_reduce_in_fp32 is True
         assert config.ddp.overlap_grad_reduce is True
         assert config.ddp.overlap_param_gather is False  # Different from other models
+        assert config.ddp.use_distributed_optimizer is True
 
     def test_pretrain_config_default_comm_overlap(self):
         """Test default CommOverlapConfig setup."""

--- a/tests/unit_tests/training/test_config.py
+++ b/tests/unit_tests/training/test_config.py
@@ -17,6 +17,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
+from megatron.core.distributed import DistributedDataParallelConfig
 from megatron.core.optimizer import OptimizerConfig
 
 from megatron.bridge.models.gpt_provider import GPTModelProvider
@@ -157,6 +158,11 @@ def create_test_distributed_init_config(**kwargs: Any) -> DistributedInitConfig:
     return DistributedInitConfig(**defaults)
 
 
+def create_test_ddp_config(**kwargs: Any) -> DistributedDataParallelConfig:
+    """Creates an instance of DistributedDataParallelConfig with defaults for testing."""
+    return DistributedDataParallelConfig(**kwargs)
+
+
 def create_test_profiling_config(**kwargs: Any) -> ProfilingConfig:
     """Creates an instance of ProfilingConfig with defaults for testing."""
     defaults = {
@@ -189,6 +195,7 @@ def create_test_config_container(
     checkpoint_config: Optional[CheckpointConfig] = None,
     dist_config: Optional[DistributedInitConfig] = None,
     profiling_config: Optional[ProfilingConfig] = None,
+    ddp_config: Optional[DistributedDataParallelConfig] = None,
 ):
     """
     Helper to create a ConfigContainer with specified or default test configurations.
@@ -221,8 +228,6 @@ def create_test_config_container(
     else:
         raise ValueError(f"Unsupported model_config type for default dataset_config: {type(model_config)}")
 
-    from megatron.core.distributed import DistributedDataParallelConfig
-
     container = ConfigContainer(
         train=train_config or create_test_training_config(),
         model=model_config,
@@ -233,7 +238,7 @@ def create_test_config_container(
         tokenizer=tokenizer_config or create_test_tokenizer_config(),
         checkpoint=checkpoint_config or create_test_checkpoint_config(),
         dist=dist_config or create_test_distributed_init_config(),
-        ddp=DistributedDataParallelConfig(),
+        ddp=ddp_config or create_test_ddp_config(),
         rng=RNGConfig(),
         rerun_state_machine=RerunStateMachineConfig(),
         profiling=profiling_config,
@@ -469,6 +474,7 @@ class TestConfigContainerValidation:
         dist_cfg = create_test_distributed_init_config(use_gloo_process_groups=False)
         opt_cfg = create_test_optimizer_config(use_distributed_optimizer=True)
         chkpt_cfg = create_test_checkpoint_config(ckpt_format="torch_dist")
+        ddp_cfg = create_test_ddp_config(use_distributed_optimizer=True)
 
         container, og_ws, cfg_mod = create_test_config_container(
             world_size_override=4,
@@ -476,6 +482,7 @@ class TestConfigContainerValidation:
             dist_config=dist_cfg,
             optimizer_config=opt_cfg,
             checkpoint_config=chkpt_cfg,
+            ddp_config=ddp_cfg,
         )
         try:
             container.validate()
@@ -1201,6 +1208,7 @@ class TestCheckpointConfig:
         optim_cfg.use_distributed_optimizer = True  # Required for precision aware optimizer
 
         dist_cfg = create_test_distributed_init_config(use_megatron_fsdp=True)
+        ddp_cfg = create_test_ddp_config(use_distributed_optimizer=True)
 
         container, og_ws, cfg_mod = create_test_config_container(
             world_size_override=1,
@@ -1209,6 +1217,7 @@ class TestCheckpointConfig:
             scheduler_config=sched_cfg,
             optimizer_config=optim_cfg,
             dist_config=dist_cfg,
+            ddp_config=ddp_cfg,
         )
         try:
             container.validate()
@@ -1231,6 +1240,7 @@ class TestCheckpointConfig:
         optim_cfg.use_distributed_optimizer = True  # Enable distributed optimizer for consistency
 
         dist_cfg = create_test_distributed_init_config(use_megatron_fsdp=True)
+        ddp_cfg = create_test_ddp_config(use_distributed_optimizer=True)
 
         container, og_ws, cfg_mod = create_test_config_container(
             world_size_override=1,
@@ -1239,6 +1249,7 @@ class TestCheckpointConfig:
             scheduler_config=sched_cfg,
             optimizer_config=optim_cfg,
             dist_config=dist_cfg,
+            ddp_config=ddp_cfg,
         )
         try:
             container.validate()


### PR DESCRIPTION
Set  `ddp_config.use_distributed_optimizer` in Mamba and NemotronH recipes.
Also various other fixes to avoid assertion errors.