### PR TITLE
Support External Cuda graph

### DIFF
--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -864,8 +864,10 @@ class ConfigContainer(Container):
             assert not self.model.enable_cuda_graph or not self.model.external_cuda_graph, (
                 "enable_cuda_graph and external_cuda_graph cannot be enabled at the same time."
             )
-            if self.model.transformer_impl == "transformer_engine" and not self.model.use_te_rng_tracker:
-                self.model.use_te_rng_tracker = True
+            if self.model.transformer_impl == "transformer_engine" and not (
+                self.rng.te_rng_tracker or self.model.use_te_rng_tracker
+            ):
+                self.rng.te_rng_tracker = self.model.use_te_rng_tracker = True
                 warn_rank_0("te_rng_tracker is not enabled, enabling it for CUDA graphs.")
 
         if self.model.external_cuda_graph:

--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -35,7 +35,6 @@ from megatron.bridge.training.utils.config_utils import _ConfigContainerBase as 
 from megatron.bridge.utils.common_utils import (
     get_world_size_safe,
     print_rank_0,
-    get_rank_safe,
     warn_rank_0,
 )
 
@@ -862,10 +861,10 @@ class ConfigContainer(Container):
         
         # Validate external_cg
         if self.model.enable_cuda_graph or self.model.external_cuda_graph:
-            assert (
-                not self.model.enable_cuda_graph or not self.model.external_cuda_graph
-            ), "enable_cuda_graph and external_cuda_graph cannot be enabled at the same time."
-            if self.model.transformer_impl == 'transformer_engine' and not self.model.use_te_rng_tracker:
+            assert not self.model.enable_cuda_graph or not self.model.external_cuda_graph, (
+            "enable_cuda_graph and external_cuda_graph cannot be enabled at the same time."
+            )
+            if self.model.transformer_impl == "transformer_engine" and not self.model.use_te_rng_tracker:
                 self.model.use_te_rng_tracker = True
                 warn_rank_0("te_rng_tracker is not enabled, enabling it for CUDA graphs.")
 
@@ -874,9 +873,9 @@ class ConfigContainer(Container):
                 "expandable_segments:True may not be safe when using CUDA Graphs with some specific parallel settings. "
                 "The training may crash with illegal memory access."
             )
-            assert (
-                self.model.recompute_granularity != 'full'
-            ), 'recompute_granularity must not be full when CUDA Graphs are enabled.'
+            assert self.model.recompute_granularity != "full", (
+                "recompute_granularity must not be full when CUDA Graphs are enabled."
+            )
 
     def validate(self) -> None:
         """Performs validation checks on the combined configuration.

--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -555,7 +555,7 @@ class CheckpointConfig:
 
     replication_jump: Optional[int] = None
     """Specifies `J`, the spacing between ranks storing replicas of a given rank's data. Replicas
-    for rank `n` may be on ranks `nJ`, `n2J`, ..., or `n-J`, `n-2J`, etc. This flag has an
+    for rank `n` may be on ranks `n+J`, `n+2J`, ..., or `n-J`, `n-2J`, etc. This flag has an
     effect only if --replication is used. and must be consistent across all ranks."""
 
     replication_factor: int = 2

--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -858,11 +858,11 @@ class ConfigContainer(Container):
         # Sync config. If TE RNG tracker is set in either ways, set them in both places.
         if self.rng.te_rng_tracker or self.model.use_te_rng_tracker:
             self.model.use_te_rng_tracker = self.rng.te_rng_tracker = True
-        
+
         # Validate external_cg
         if self.model.enable_cuda_graph or self.model.external_cuda_graph:
             assert not self.model.enable_cuda_graph or not self.model.external_cuda_graph, (
-            "enable_cuda_graph and external_cuda_graph cannot be enabled at the same time."
+                "enable_cuda_graph and external_cuda_graph cannot be enabled at the same time."
             )
             if self.model.transformer_impl == "transformer_engine" and not self.model.use_te_rng_tracker:
                 self.model.use_te_rng_tracker = True

--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -32,7 +32,12 @@ from megatron.bridge.training.deepep import validate_deepep
 from megatron.bridge.training.mixed_precision import MixedPrecisionConfig, get_mixed_precision_config
 from megatron.bridge.training.tokenizers.config import TokenizerConfig
 from megatron.bridge.training.utils.config_utils import _ConfigContainerBase as Container
-from megatron.bridge.utils.common_utils import get_world_size_safe, print_rank_0
+from megatron.bridge.utils.common_utils import (
+    get_world_size_safe,
+    print_rank_0,
+    get_rank_safe,
+    warn_rank_0,
+)
 
 
 @dataclass
@@ -550,7 +555,7 @@ class CheckpointConfig:
 
     replication_jump: Optional[int] = None
     """Specifies `J`, the spacing between ranks storing replicas of a given rank's data. Replicas
-    for rank `n` may be on ranks `n+J`, `n+2J`, ..., or `n-J`, `n-2J`, etc. This flag has an
+    for rank `n` may be on ranks `nJ`, `n2J`, ..., or `n-J`, `n-2J`, etc. This flag has an
     effect only if --replication is used. and must be consistent across all ranks."""
 
     replication_factor: int = 2
@@ -848,6 +853,31 @@ class ConfigContainer(Container):
         if self.comm_overlap is not None:
             self.comm_overlap.data_parallel_size = self.data_parallel_size
 
+    def _sync_and_validate_external_cuda_graph(self) -> None:
+        """Sync necessary configs for external CUDA Graphs and and validates it."""
+
+        # Sync config. If TE RNG tracker is set in either ways, set them in both places.
+        if self.rng.te_rng_tracker or self.model.use_te_rng_tracker:
+            self.model.use_te_rng_tracker = self.rng.te_rng_tracker = True
+        
+        # Validate external_cg
+        if self.model.enable_cuda_graph or self.model.external_cuda_graph:
+            assert (
+                not self.model.enable_cuda_graph or not self.model.external_cuda_graph
+            ), "enable_cuda_graph and external_cuda_graph cannot be enabled at the same time."
+            if self.model.transformer_impl == 'transformer_engine' and not self.model.use_te_rng_tracker:
+                self.model.use_te_rng_tracker = True
+                warn_rank_0("te_rng_tracker is not enabled, enabling it for CUDA graphs.")
+
+        if self.model.external_cuda_graph:
+            assert "expandable_segments:True" not in os.getenv("PYTORCH_CUDA_ALLOC_CONF", ""), (
+                "expandable_segments:True may not be safe when using CUDA Graphs with some specific parallel settings. "
+                "The training may crash with illegal memory access."
+            )
+            assert (
+                self.model.recompute_granularity != 'full'
+            ), 'recompute_granularity must not be full when CUDA Graphs are enabled.'
+
     def validate(self) -> None:
         """Performs validation checks on the combined configuration.
 
@@ -1006,6 +1036,8 @@ class ConfigContainer(Container):
         assert self.ddp.use_distributed_optimizer == self.optimizer.use_distributed_optimizer, (
             "Please ensure 'use_distributed_optimizer' setting in DistributedDataParallelConfig and OptimizerConfig matches."
         )
+
+        self._sync_and_validate_external_cuda_graph()
 
 
 def runtime_config_update(cfg: ConfigContainer) -> None:

--- a/src/megatron/bridge/training/train.py
+++ b/src/megatron/bridge/training/train.py
@@ -35,6 +35,7 @@ from megatron.core.optimizer_param_scheduler import OptimizerParamScheduler
 from megatron.core.pipeline_parallel import get_forward_backward_func
 from megatron.core.rerun_state_machine import RerunDataIterator, get_rerun_state_machine
 from megatron.core.transformer import MegatronModule
+from megatron.core.transformer.cuda_graphs import TECudaGraphHelper
 from megatron.core.utils import check_param_hashes_across_dp_replicas, get_model_config
 
 from megatron.bridge.training import fault_tolerance
@@ -209,6 +210,17 @@ def train(
         torch.distributed.barrier()
         print_rank_0(f">>> Weight hashes match after {global_state.train_state.step} iterations...")
 
+    # Capture CUDA Graphs.
+    if model_config.external_cuda_graph:
+        cuda_graph_helper = TECudaGraphHelper(
+            model=model,
+            config=model_config,
+            seq_length=config.model.seq_length,
+            micro_batch_size=config.train.micro_batch_size,
+            optimizers=[optimizer],
+        )
+        cuda_graph_helper.create_cudagraphs()
+
     # Run training iterations till done.
     while global_state.train_state.step < train_config.train_iters:
         if prof_config and torch.distributed.get_rank() in prof_config.profile_ranks:
@@ -297,6 +309,9 @@ def train(
                     enable_forward_pre_hook(model)
                     model_config.param_sync_func = param_sync_func
                     pre_hook_enabled = True
+                    # Set the manual hooks when CUDA Graphs are used.
+                    if model_config.external_cuda_graph:
+                        cuda_graph_helper.cuda_graph_set_manual_hooks()
 
         global_state.train_state.step += 1
         batch_size = (

--- a/src/megatron/bridge/utils/common_utils.py
+++ b/src/megatron/bridge/utils/common_utils.py
@@ -83,6 +83,7 @@ def print_rank_0(message: str) -> None:
     if rank == 0:
         print(message, flush=True)
 
+
 def warn_rank_0(message):
     """Warn only on rank 0."""
     rank = get_rank_safe()

--- a/src/megatron/bridge/utils/common_utils.py
+++ b/src/megatron/bridge/utils/common_utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import warnings
 
 import torch
 import torch.distributed
@@ -81,6 +82,12 @@ def print_rank_0(message: str) -> None:
     rank = get_rank_safe()
     if rank == 0:
         print(message, flush=True)
+
+def warn_rank_0(message):
+    """Warn only on rank 0."""
+    rank = get_rank_safe()
+    if rank == 0:
+        warnings.warn(message)
 
 
 def is_last_rank() -> bool:

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -51,6 +51,7 @@ def ensure_test_data(tmp_path_factory):
         try:
             # Download assets to data_path
             from tests.unit_tests.download_unit_tests_dataset import get_oldest_release_and_assets
+
             get_oldest_release_and_assets(assets_dir=str(data_path))
 
             logger.info("Test data downloaded successfully.")

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -20,6 +20,7 @@ from unittest.mock import patch
 import pytest
 from megatron.core.msc_utils import MultiStorageClientFeature
 
+
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -20,8 +20,6 @@ from unittest.mock import patch
 import pytest
 from megatron.core.msc_utils import MultiStorageClientFeature
 
-from tests.unit_tests.download_unit_tests_dataset import get_oldest_release_and_assets
-
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -20,7 +20,6 @@ from unittest.mock import patch
 import pytest
 from megatron.core.msc_utils import MultiStorageClientFeature
 
-
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
@@ -51,6 +50,7 @@ def ensure_test_data(tmp_path_factory):
 
         try:
             # Download assets to data_path
+            from tests.unit_tests.download_unit_tests_dataset import get_oldest_release_and_assets
             get_oldest_release_and_assets(assets_dir=str(data_path))
 
             logger.info("Test data downloaded successfully.")

--- a/tests/unit_tests/training/test_config.py
+++ b/tests/unit_tests/training/test_config.py
@@ -39,6 +39,7 @@ from megatron.bridge.training.config import (
     TokenizerConfig,
     TrainingConfig,
 )
+from megatron.bridge.utils.common_utils import get_rank_safe
 
 
 def mock_get_world_size_safe(world_size_to_return: int):
@@ -1472,3 +1473,174 @@ class TestRuntimeConfigUpdate:
 
         finally:
             restore_get_world_size_safe(og_ws, cfg_mod)
+
+class TestSyncAndValidateExternalCudaGraph:
+    """Tests for the `_sync_and_validate_external_cuda_graph` method of the `ConfigContainer` class."""
+
+    def test_rng_config_sync_to_model(self):
+        """Test that rng.te_rng_tracker syncs to model.use_te_rng_tracker."""
+        gpt_model_cfg = create_test_gpt_config(use_te_rng_tracker=False)
+        rng_cfg = RNGConfig(te_rng_tracker=True)
+
+        container, _, _ = create_test_config_container(
+            world_size_override=1, model_config=gpt_model_cfg
+        )
+        container.rng = rng_cfg
+
+        container._sync_and_validate_external_cuda_graph()
+        # RNG config should sync to model config
+        assert container.model.use_te_rng_tracker is True
+
+    def test_rng_config_sync_preserves_model_override(self):
+        """Test that model.use_te_rng_tracker is preserved when already True."""
+        gpt_model_cfg = create_test_gpt_config(use_te_rng_tracker=True)
+        rng_cfg = RNGConfig(te_rng_tracker=False)
+
+        container, _, _ = create_test_config_container(
+            world_size_override=1, model_config=gpt_model_cfg
+        )
+        container.rng = rng_cfg
+
+        container._sync_and_validate_external_cuda_graph()
+        # Model config should sync to RNG config
+        assert container.rng.te_rng_tracker is True
+
+    def test_cuda_graph_mutual_exclusivity_error(self):
+        """Test that enable_cuda_graph and external_cuda_graph cannot both be True."""
+        gpt_model_cfg = create_test_gpt_config(
+            enable_cuda_graph=True, external_cuda_graph=True
+        )
+
+        container, _, _ = create_test_config_container(
+            world_size_override=1, model_config=gpt_model_cfg
+        )
+
+        with pytest.raises(
+            AssertionError,
+            match="enable_cuda_graph and external_cuda_graph cannot be enabled at the same time",
+        ):
+            container._sync_and_validate_external_cuda_graph()
+
+    @patch("megatron.bridge.training.config.warn_rank_0")
+    def test_te_rng_tracker_auto_enable_with_enable_cuda_graph(self, mock_warn_rank_0):
+        """Test that te_rng_tracker is auto-enabled when using transformer_engine with CUDA graphs."""
+        gpt_model_cfg = create_test_gpt_config(
+            transformer_impl="transformer_engine",
+            use_te_rng_tracker=False,
+            enable_cuda_graph=True,
+        )
+
+        container, _, _ = create_test_config_container(
+            world_size_override=1, model_config=gpt_model_cfg
+        )
+
+        container._sync_and_validate_external_cuda_graph()
+        # Should auto-enable te_rng_tracker and warn
+        assert container.model.use_te_rng_tracker is True
+        mock_warn_rank_0.assert_called_once_with(
+            "te_rng_tracker is not enabled, enabling it for CUDA graphs."
+        )
+
+    @patch("megatron.bridge.training.config.warn_rank_0")
+    def test_te_rng_tracker_auto_enable_with_external_cuda_graph(
+        self, mock_warn_rank_0
+    ):
+        """Test that te_rng_tracker is auto-enabled when using transformer_engine with external CUDA graphs."""
+        gpt_model_cfg = create_test_gpt_config(
+            transformer_impl="transformer_engine",
+            use_te_rng_tracker=False,
+            external_cuda_graph=True,
+        )
+
+        container, og_ws, cfg_mod = create_test_config_container(
+            world_size_override=1, model_config=gpt_model_cfg
+        )
+
+        container._sync_and_validate_external_cuda_graph()
+        # Should auto-enable te_rng_tracker and warn
+        assert container.model.use_te_rng_tracker is True
+        mock_warn_rank_0.assert_called_once_with(
+            "te_rng_tracker is not enabled, enabling it for CUDA graphs."
+        )
+
+    @patch("megatron.bridge.training.config.warn_rank_0")
+    def test_te_rng_tracker_no_warn_when_already_enabled(self, mock_warn_rank_0):
+        """Test that no warning is issued when te_rng_tracker is already enabled."""
+        gpt_model_cfg = create_test_gpt_config(
+            transformer_impl="transformer_engine",
+            use_te_rng_tracker=True,
+            enable_cuda_graph=True,
+        )
+
+        container, og_ws, cfg_mod = create_test_config_container(
+            world_size_override=1, model_config=gpt_model_cfg
+        )
+        container._sync_and_validate_external_cuda_graph()
+        # Should not warn since te_rng_tracker is already enabled
+        mock_warn_rank_0.assert_not_called()
+
+    @patch("os.getenv")
+    def test_expandable_segments_validation_error(self, mock_getenv):
+        """Test that expandable_segments:True in PYTORCH_CUDA_ALLOC_CONF raises error with external CUDA graphs."""
+        mock_getenv.side_effect = ["0", "0", "expandable_segments:True"]
+
+        gpt_model_cfg = create_test_gpt_config(external_cuda_graph=True)
+
+        container, _, _ = create_test_config_container(
+            world_size_override=1, model_config=gpt_model_cfg
+        )
+
+        with pytest.raises(
+            AssertionError,
+            match="expandable_segments:True may not be safe when using CUDA Graphs",
+        ):
+            container._sync_and_validate_external_cuda_graph()
+
+    @patch("os.getenv")
+    def test_expandable_segments_validation_pass(self, mock_getenv):
+        """Test that expandable_segments validation passes when not set or set to False."""
+        # Test with expandable_segments:False
+        mock_getenv.side_effect = ["0", "0", ""]
+
+        gpt_model_cfg = create_test_gpt_config(external_cuda_graph=True)
+
+        container, _, _ = create_test_config_container(
+            world_size_override=1, model_config=gpt_model_cfg
+        )
+
+        container._sync_and_validate_external_cuda_graph()  # Should pass
+
+    def test_no_cuda_graph_features_enabled(self):
+        """Test normal case where no CUDA graph features are enabled."""
+        gpt_model_cfg = create_test_gpt_config(
+            enable_cuda_graph=False,
+            external_cuda_graph=False,
+            transformer_impl="local",
+            use_te_rng_tracker=False,
+        )
+
+        container, _, _ = create_test_config_container(
+            world_size_override=1, model_config=gpt_model_cfg
+        )
+
+        container._sync_and_validate_external_cuda_graph()  # Should pass without any changes
+        assert container.model.use_te_rng_tracker is False
+
+    def test_all_validations_combined(self):
+        """Test a valid configuration with external CUDA graphs that passes all validations."""
+        gpt_model_cfg = create_test_gpt_config(
+            external_cuda_graph=True,
+            transformer_impl="transformer_engine",
+            use_te_rng_tracker=True,
+            recompute_granularity="selective",
+        )
+
+        rng_cfg = RNGConfig(te_rng_tracker=True)
+
+        container, _, _ = create_test_config_container(
+            world_size_override=1, model_config=gpt_model_cfg
+        )
+        container.rng = rng_cfg
+
+        container._sync_and_validate_external_cuda_graph()
+        assert container.model.use_te_rng_tracker is True

--- a/tests/unit_tests/training/test_config.py
+++ b/tests/unit_tests/training/test_config.py
@@ -1473,6 +1473,7 @@ class TestRuntimeConfigUpdate:
         finally:
             restore_get_world_size_safe(og_ws, cfg_mod)
 
+
 class TestSyncAndValidateExternalCudaGraph:
     """Tests for the `_sync_and_validate_external_cuda_graph` method of the `ConfigContainer` class."""
 
@@ -1504,9 +1505,7 @@ class TestSyncAndValidateExternalCudaGraph:
 
     def test_cuda_graph_mutual_exclusivity_error(self):
         """Test that enable_cuda_graph and external_cuda_graph cannot both be True."""
-        gpt_model_cfg = create_test_gpt_config(
-            enable_cuda_graph=True, external_cuda_graph=True
-        )
+        gpt_model_cfg = create_test_gpt_config(enable_cuda_graph=True, external_cuda_graph=True)
 
         container, _, _ = create_test_config_container(world_size_override=1, model_config=gpt_model_cfg)
 
@@ -1533,9 +1532,7 @@ class TestSyncAndValidateExternalCudaGraph:
         mock_warn_rank_0.assert_called_once_with("te_rng_tracker is not enabled, enabling it for CUDA graphs.")
 
     @patch("megatron.bridge.training.config.warn_rank_0")
-    def test_te_rng_tracker_auto_enable_with_external_cuda_graph(
-        self, mock_warn_rank_0
-    ):
+    def test_te_rng_tracker_auto_enable_with_external_cuda_graph(self, mock_warn_rank_0):
         """Test that te_rng_tracker is auto-enabled when using transformer_engine with external CUDA graphs."""
         gpt_model_cfg = create_test_gpt_config(
             transformer_impl="transformer_engine",

--- a/tests/unit_tests/training/test_config.py
+++ b/tests/unit_tests/training/test_config.py
@@ -39,7 +39,6 @@ from megatron.bridge.training.config import (
     TokenizerConfig,
     TrainingConfig,
 )
-from megatron.bridge.utils.common_utils import get_rank_safe
 
 
 def mock_get_world_size_safe(world_size_to_return: int):
@@ -1482,9 +1481,8 @@ class TestSyncAndValidateExternalCudaGraph:
         gpt_model_cfg = create_test_gpt_config(use_te_rng_tracker=False)
         rng_cfg = RNGConfig(te_rng_tracker=True)
 
-        container, _, _ = create_test_config_container(
-            world_size_override=1, model_config=gpt_model_cfg
-        )
+        container, _, _ = create_test_config_container(world_size_override=1, model_config=gpt_model_cfg)
+
         container.rng = rng_cfg
 
         container._sync_and_validate_external_cuda_graph()
@@ -1496,9 +1494,8 @@ class TestSyncAndValidateExternalCudaGraph:
         gpt_model_cfg = create_test_gpt_config(use_te_rng_tracker=True)
         rng_cfg = RNGConfig(te_rng_tracker=False)
 
-        container, _, _ = create_test_config_container(
-            world_size_override=1, model_config=gpt_model_cfg
-        )
+        container, _, _ = create_test_config_container(world_size_override=1, model_config=gpt_model_cfg)
+
         container.rng = rng_cfg
 
         container._sync_and_validate_external_cuda_graph()
@@ -1511,9 +1508,7 @@ class TestSyncAndValidateExternalCudaGraph:
             enable_cuda_graph=True, external_cuda_graph=True
         )
 
-        container, _, _ = create_test_config_container(
-            world_size_override=1, model_config=gpt_model_cfg
-        )
+        container, _, _ = create_test_config_container(world_size_override=1, model_config=gpt_model_cfg)
 
         with pytest.raises(
             AssertionError,
@@ -1530,16 +1525,12 @@ class TestSyncAndValidateExternalCudaGraph:
             enable_cuda_graph=True,
         )
 
-        container, _, _ = create_test_config_container(
-            world_size_override=1, model_config=gpt_model_cfg
-        )
+        container, _, _ = create_test_config_container(world_size_override=1, model_config=gpt_model_cfg)
 
         container._sync_and_validate_external_cuda_graph()
         # Should auto-enable te_rng_tracker and warn
         assert container.model.use_te_rng_tracker is True
-        mock_warn_rank_0.assert_called_once_with(
-            "te_rng_tracker is not enabled, enabling it for CUDA graphs."
-        )
+        mock_warn_rank_0.assert_called_once_with("te_rng_tracker is not enabled, enabling it for CUDA graphs.")
 
     @patch("megatron.bridge.training.config.warn_rank_0")
     def test_te_rng_tracker_auto_enable_with_external_cuda_graph(
@@ -1552,16 +1543,12 @@ class TestSyncAndValidateExternalCudaGraph:
             external_cuda_graph=True,
         )
 
-        container, og_ws, cfg_mod = create_test_config_container(
-            world_size_override=1, model_config=gpt_model_cfg
-        )
+        container, _, _ = create_test_config_container(world_size_override=1, model_config=gpt_model_cfg)
 
         container._sync_and_validate_external_cuda_graph()
         # Should auto-enable te_rng_tracker and warn
         assert container.model.use_te_rng_tracker is True
-        mock_warn_rank_0.assert_called_once_with(
-            "te_rng_tracker is not enabled, enabling it for CUDA graphs."
-        )
+        mock_warn_rank_0.assert_called_once_with("te_rng_tracker is not enabled, enabling it for CUDA graphs.")
 
     @patch("megatron.bridge.training.config.warn_rank_0")
     def test_te_rng_tracker_no_warn_when_already_enabled(self, mock_warn_rank_0):
@@ -1572,9 +1559,8 @@ class TestSyncAndValidateExternalCudaGraph:
             enable_cuda_graph=True,
         )
 
-        container, og_ws, cfg_mod = create_test_config_container(
-            world_size_override=1, model_config=gpt_model_cfg
-        )
+        container, _, _ = create_test_config_container(world_size_override=1, model_config=gpt_model_cfg)
+
         container._sync_and_validate_external_cuda_graph()
         # Should not warn since te_rng_tracker is already enabled
         mock_warn_rank_0.assert_not_called()
@@ -1586,9 +1572,7 @@ class TestSyncAndValidateExternalCudaGraph:
 
         gpt_model_cfg = create_test_gpt_config(external_cuda_graph=True)
 
-        container, _, _ = create_test_config_container(
-            world_size_override=1, model_config=gpt_model_cfg
-        )
+        container, _, _ = create_test_config_container(world_size_override=1, model_config=gpt_model_cfg)
 
         with pytest.raises(
             AssertionError,
@@ -1604,9 +1588,7 @@ class TestSyncAndValidateExternalCudaGraph:
 
         gpt_model_cfg = create_test_gpt_config(external_cuda_graph=True)
 
-        container, _, _ = create_test_config_container(
-            world_size_override=1, model_config=gpt_model_cfg
-        )
+        container, _, _ = create_test_config_container(world_size_override=1, model_config=gpt_model_cfg)
 
         container._sync_and_validate_external_cuda_graph()  # Should pass
 
@@ -1619,9 +1601,7 @@ class TestSyncAndValidateExternalCudaGraph:
             use_te_rng_tracker=False,
         )
 
-        container, _, _ = create_test_config_container(
-            world_size_override=1, model_config=gpt_model_cfg
-        )
+        container, _, _ = create_test_config_container(world_size_override=1, model_config=gpt_model_cfg)
 
         container._sync_and_validate_external_cuda_graph()  # Should pass without any changes
         assert container.model.use_te_rng_tracker is False
@@ -1637,9 +1617,7 @@ class TestSyncAndValidateExternalCudaGraph:
 
         rng_cfg = RNGConfig(te_rng_tracker=True)
 
-        container, _, _ = create_test_config_container(
-            world_size_override=1, model_config=gpt_model_cfg
-        )
+        container, _, _ = create_test_config_container(world_size_override=1, model_config=gpt_model_cfg)
         container.rng = rng_cfg
 
         container._sync_and_validate_external_cuda_graph()


### PR DESCRIPTION
Adding interface to capture external cuda graph.

Test:
Local testing with perf scripts using https://github.com/NVIDIA-NeMo/Megatron-Bridge/commit/0fd7e4f1884dbe75210a8e5e6f17335ad31ba130

```
torchrun --nproc-per-node=8 run_script.py -m llama3 -s 8b --config_file configs/llama3/llama3_8b_llm_pretrain.yaml  --gpu h100 -a a -p p -ng 8

INFO:megatron.core.transformer.cuda_graphs:Time spent in CUDA Graphs capture on rank 0: 57.97806215286255s
NCCL version 2.27.3+cuda12.9
> setting tensorboard ...
Number of parameters in transformer layers in billions:  6.98 [2025-09-17 22:26:24] iteration        1/      25 | consumed samples:            8 | elapsed time per iterati
on (ms): 69179.8 | learning rate: 1.500000E-07 | global batch size:     8 | lm loss: 1.196929E+01 | loss scale: 1.0 | grad norm: 19.643 | number of skipped iterations:   0
 | number of nan iterations:   0 |

Number of parameters in embedding layers in billions: 1.05
Total number of parameters in billions: 8.03
Number of parameters in most loaded shard in billions: 2.2703
Number of parameters in other shards in billions: 1.7450
Theoretical memory footprints: weight and optimizer=38972.29 MB
[Rank 4] (after 1 iterations) memory (MB) | allocated: 21540.77294921875 | max allocated: 21540.7734375 | reserved: 31336.0 | max reserved: 31336.0
[Rank 3] (after 1 iterations) memory (MB) | allocated: 22052.77294921875 | max allocated: 25327.17138671875 | reserved: 36252.0 | max reserved: 36252.0[Rank 7] (after 1 it
erations) memory (MB) | allocated: 28106.87548828125 | max allocated: 28106.87939453125 | reserved: 33510.0 | max reserved: 33510.0
                                                                                                                                                                           [Rank 6] (after 1 iterations) memory (MB) | allocated: 28106.82080078125 | max allocated: 28106.82470703125 | reserved: 33366.0 | max reserved: 33366.0
[Rank 1] (after 1 iterations) memory (MB) | allocated: 28544.77294921875 | max allocated: 33201.42919921875 | reserved: 47024.0 | max reserved: 47024.0[Rank 0] (after 1 it
erations) memory (MB) | allocated: 28544.86669921875 | max allocated: 33201.42919921875 | reserved: 47230.0 | max reserved: 47230.0

[Rank 2] (after 1 iterations) memory (MB) | allocated: 22052.77294921875 | max allocated: 25327.17138671875 | reserved: 36236.0 | max reserved: 36236.0
[Rank 5] (after 1 iterations) memory (MB) | allocated: 21540.77294921875 | max allocated: 21540.7734375 | reserved: 31352.0 | max reserved: 31352.0
 [2025-09-17 22:26:25] iteration        2/      25 | consumed samples:           16 | elapsed time per iteration (ms): 1171.8 | learning rate: 3.000000E-07 | global batch
size:     8 | lm loss: 1.196604E+01 | loss scale: 1.0 | grad norm: 18.958 | number of skipped iterations:   0 | number of nan iterations:   0 |
 [2025-09-17 22:26:26] iteration        3/      25 | consumed samples:           24 | elapsed time per iteration (ms): 1178.1 | learning rate: 4.500000E-07 | global batch
size:     8 | lm loss: 1.196216E+01 | loss scale: 1.0 | grad norm: 20.286 | number of skipped iterations:   0 | number of nan iterations:   0 |
 [2025-09-17 22:26:28] iteration        4/      25 | consumed samples:           32 | elapsed time per iteration (ms): 1175.2 | learning rate: 6.000000E-07 | global batch
size:     8 | lm loss: 1.195645E+01 | loss scale: 1.0 | grad norm: 19.783 | number of skipped iterations:   0 | number of nan iterations:   0 |
 [2025-09-17 22:26:29] iteration        5/      25 | consumed samples:           40 | elapsed time per iteration (ms): 1167.1 | learning rate: 7.500000E-07 | global
```