### PR TITLE
Revert "Fix small error in README"

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ if __name__ == "__main__":
     cfg.model = model_provider
     cfg.train.train_iters = 10
 
-    cfg.dataset.seq_length = cfg.model.seq_length
+    cfg.dataset.sequence_length = cfg.model.seq_length
     cfg.tokenizer.vocab_size = cfg.model.vocab_size
 
     pretrain(cfg, forward_step)


### PR DESCRIPTION
Reverts NVIDIA-NeMo/Megatron-Bridge#711

Based on what I've learned/described in https://github.com/NVIDIA-NeMo/Megatron-Bridge/issues/717 modifying  `cfg.dataset.seq_length` is not the same as modifying `cfg.dataset.sequence_length`, so the readme example should have its old version