### PR TITLE
[bridge] Skip allocating to device if cpu initialization is enabled

### DIFF
--- a/src/megatron/bridge/models/model_provider.py
+++ b/src/megatron/bridge/models/model_provider.py
@@ -524,7 +524,11 @@ def get_model(
     # GPU allocation.
     # For FSDP2, we don't allocate GPU memory here. We allocate GPU memory
     # in the fully_shard function of FSDP2 instead.
-    if not (use_torch_fsdp2 and model_config.use_cpu_initialization) and not model_config.init_model_with_meta_device:
+    if (
+        not use_torch_fsdp2
+        and not model_config.use_cpu_initialization
+        and not model_config.init_model_with_meta_device
+    ):
         for model_module in model:
             model_module.cuda(torch.cuda.current_device())
 


### PR DESCRIPTION
From https://github.com/NVIDIA-NeMo/Megatron-Bridge/pull/677

This is to ensure that when AutoBridge.import_ckpt is called, the conversion happens fully on CPU. Otherwise, larger models will OOM at this step when trying to move the parameters to the device