### PR TITLE
update get mixed precision config helper

### DIFF
--- a/src/megatron/bridge/training/mixed_precision.py
+++ b/src/megatron/bridge/training/mixed_precision.py
@@ -367,15 +367,17 @@ def fp16_with_fp8_subchannel_scaling_mixed() -> MixedPrecisionConfig:
     return cfg
 
 
-def get_mixed_precision_config(name: str) -> MixedPrecisionConfig:
+def get_mixed_precision_config(name: str | MixedPrecisionConfig) -> MixedPrecisionConfig:
     """Return a :class:`MixedPrecisionConfig` for *name*.
 
     Args:
-        name: Key of the recipe in :pydata:`MIXED_PRECISION_RECIPES`.
+        name: Key of the recipe in :pydata:`MIXED_PRECISION_RECIPES` or a :class:`MixedPrecisionConfig` instance.
 
     Raises:
         ValueError: If *name* is not a known recipe.
     """
+    if isinstance(name, MixedPrecisionConfig):
+        return name
     try:
         return MIXED_PRECISION_RECIPES[name]()
     except KeyError as err:

--- a/src/megatron/bridge/training/mixed_precision.py
+++ b/src/megatron/bridge/training/mixed_precision.py
@@ -142,8 +142,19 @@ MIXED_PRECISION_RECIPES: dict[str, Callable[[], "MixedPrecisionConfig"]] = {}
 
 
 def register(func: Callable[[], "MixedPrecisionConfig"]):
-    """Decorator that registers a mixed-precision recipe factory by its function name."""
-    MIXED_PRECISION_RECIPES[func.__name__] = func
+    """Decorator that registers a mixed-precision recipe factory by its function name.
+
+    Automatically registers both underscore and hyphen versions (e.g., 'bf16_mixed' and 'bf16-mixed')
+    to simplify migrating from NeMo2.
+    """
+    name = func.__name__
+    MIXED_PRECISION_RECIPES[name] = func
+
+    # Also register hyphen version if the name contains underscores
+    if "_" in name:
+        hyphen_name = name.replace("_", "-")
+        MIXED_PRECISION_RECIPES[hyphen_name] = func
+
     return func
 
 

--- a/tests/unit_tests/training/test_mixed_precision.py
+++ b/tests/unit_tests/training/test_mixed_precision.py
@@ -754,3 +754,11 @@ class TestRegisterAndGetMixedPrecisionConfig:
             get_mixed_precision_config("does_not_exist")
 
         assert "Unknown mixed-precision recipe" in str(exc_info.value)
+
+    def test_get_mixed_precision_config_passthrough(self):
+        """Ensure an existing MixedPrecisionConfig instance is passed through unchanged."""
+        config = MixedPrecisionConfig(fp16=True)
+        result = get_mixed_precision_config(config)
+
+        assert result is config
+        assert result.fp16 is True


### PR DESCRIPTION
1. add a small convenience to accept either a str or MixedPrecisionConfig so users / recipes don't have to keep adding checks like this:

```
if isinstance(mixed_precision_config, str):
    mixed_precision_config = get_mixed_precision_config(mixed_precision_config)

# apply overrides to config
```

2. register hyphenated names along with underscores to support nemo2 conventions like "bf16-mixed" alongside "bf16_mixed"