### PR TITLE
Cherry pick qwen2.5 VL nemo-rl changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,8 @@ dependencies = [
     "datasets",
     "omegaconf>=2.3.0",
     "tensorboard>=2.19.0",
+    "torch",
+    "transformers>=4.55.0",
     "typing-extensions",
     "rich",
     "wandb>=0.19.10",
@@ -96,7 +98,7 @@ no-build-isolation-package = [
 ]
 prerelease = "allow"
 
-# uv.sources allows us to override dependencies with VCS commits. 
+# uv.sources allows us to override dependencies with VCS commits.
 # Lets use this only for debugging purposes, but not for production (main).
 [tool.uv.sources]
 transformer-engine = { git = "https://github.com/NVIDIA/TransformerEngine.git", rev = "0289e76380088358a584d809faf69effab1a7cda" } # on `release_v2.7

--- a/src/megatron/bridge/models/qwen_vl/modeling_qwen25_vl.py
+++ b/src/megatron/bridge/models/qwen_vl/modeling_qwen25_vl.py
@@ -188,9 +188,12 @@ class Qwen25VLModel(MegatronModule):
             image_grid_thw,
             video_grid_thw,
             second_per_grid_ts=second_per_grid_ts,
-            attention_mask=attention_mask,
+            # The "attention_mask" HF expects is a padding mask
+            # We pass in None here because we do not have padding in the input
+            attention_mask=None,
         )
 
+        # TODO(yifu): packed_seq_params
         outputs = self.language_model.forward(
             input_ids=None,
             position_ids=position_ids,

--- a/src/megatron/bridge/models/qwen_vl/modeling_qwen25_vl.py
+++ b/src/megatron/bridge/models/qwen_vl/modeling_qwen25_vl.py
@@ -193,7 +193,6 @@ class Qwen25VLModel(MegatronModule):
             attention_mask=None,
         )
 
-        # TODO(yifu): packed_seq_params
         outputs = self.language_model.forward(
             input_ids=None,
             position_ids=position_ids,
@@ -202,6 +201,7 @@ class Qwen25VLModel(MegatronModule):
             labels=labels,
             loss_mask=loss_mask,
             runtime_gather_output=runtime_gather_output,
+            packed_seq_params=packed_seq_params,
         )
         return outputs
 


### PR DESCRIPTION
These changes were added to support qwen2.5 vl for nemo-rl and previously were only on the nemo-rl branch. This PR cherry picks them into main. The transformers bump is necessary because the Qwen25VLModel assumes 4.55 version of transformers (we already have a guard for this).