### PR TITLE
fix: exit profiler context

### DIFF
--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -768,6 +768,11 @@ class ProfilingConfig:
         assert not (self.use_pytorch_profiler and self.use_nsys_profiler), (
             "Exactly one of pytorch or nsys profiler should be enabled, not both, when ProfilingConfig is active."
         )
+        assert self.profile_step_start >= 0, f"profile_step_start must be >= 0, got {self.profile_step_start}"
+        assert self.profile_step_end >= 0, f"profile_step_end must be >= 0, got {self.profile_step_end}"
+        assert self.profile_step_end >= self.profile_step_start, (
+            f"profile_step_end ({self.profile_step_end}) must be >= profile_step_start ({self.profile_step_start})"
+        )
 
 
 @dataclass

--- a/src/megatron/bridge/training/profiling.py
+++ b/src/megatron/bridge/training/profiling.py
@@ -1,0 +1,135 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Profiling utilities for training loop."""
+
+from typing import Optional
+
+import torch
+import torch.profiler
+
+from megatron.bridge.training.config import ProfilingConfig
+
+
+def should_profile_rank(config: Optional[ProfilingConfig], rank: int) -> bool:
+    """Check if current rank should be profiled.
+
+    Args:
+        config: Profiling configuration
+        rank: Current process rank
+
+    Returns:
+        True if this rank should be profiled
+    """
+    if config is None:
+        return False
+    return rank in config.profile_ranks
+
+
+def initialize_pytorch_profiler(
+    config: ProfilingConfig,
+    tensorboard_dir: str,
+) -> torch.profiler.profile:
+    """Initialize PyTorch profiler with config settings.
+
+    Args:
+        config: Profiling configuration
+        tensorboard_dir: Directory for tensorboard outputs
+
+    Returns:
+        Initialized (but not started) PyTorch profiler
+    """
+    prof = torch.profiler.profile(
+        schedule=torch.profiler.schedule(
+            wait=max(config.profile_step_start - 1, 0),
+            warmup=1 if config.profile_step_start > 0 else 0,
+            active=config.profile_step_end - config.profile_step_start,
+            repeat=1,
+        ),
+        on_trace_ready=torch.profiler.tensorboard_trace_handler(tensorboard_dir),
+        record_shapes=config.record_shapes,
+        with_stack=True,
+    )
+    return prof
+
+
+def start_nsys_profiler(config: ProfilingConfig) -> None:
+    """Start CUDA profiler for nsys profiling.
+
+    Args:
+        config: Profiling configuration
+    """
+    torch.cuda.check_error(torch.cuda.cudart().cudaProfilerStart())
+    if config.record_shapes:
+        torch.autograd.profiler.emit_nvtx(record_shapes=True).__enter__()
+    else:
+        torch.autograd.profiler.emit_nvtx().__enter__()
+
+
+def stop_nsys_profiler() -> None:
+    """Stop CUDA profiler for nsys profiling."""
+    torch.cuda.check_error(torch.cuda.cudart().cudaProfilerStop())
+    torch.autograd.profiler.emit_nvtx().__exit__(None, None, None)
+
+
+def handle_profiling_step(
+    config: Optional[ProfilingConfig],
+    iteration: int,
+    rank: int,
+    pytorch_prof: Optional[torch.profiler.profile],
+) -> None:
+    """Handle profiling logic for a single training step.
+
+    Args:
+        config: Profiling configuration
+        iteration: Current training iteration
+        rank: Current process rank
+        pytorch_prof: PyTorch profiler instance (if using PyTorch profiler)
+    """
+    if not should_profile_rank(config, rank):
+        return
+
+    if config.use_pytorch_profiler and pytorch_prof is not None:
+        pytorch_prof.step()
+
+    if config.use_nsys_profiler:
+        if iteration == config.profile_step_start:
+            start_nsys_profiler(config)
+
+
+def handle_profiling_stop(
+    config: Optional[ProfilingConfig],
+    iteration: int,
+    rank: int,
+    pytorch_prof: Optional[torch.profiler.profile],
+) -> None:
+    """Handle profiling cleanup at designated stop iteration.
+
+    Args:
+        config: Profiling configuration
+        iteration: Current training iteration
+        rank: Current process rank
+        pytorch_prof: PyTorch profiler instance (if using PyTorch profiler)
+    """
+    if not should_profile_rank(config, rank):
+        return
+
+    if iteration != config.profile_step_end:
+        return
+
+    if config.use_pytorch_profiler and pytorch_prof is not None:
+        pytorch_prof.stop()
+
+    if config.use_nsys_profiler:
+        stop_nsys_profiler()

--- a/src/megatron/bridge/training/train.py
+++ b/src/megatron/bridge/training/train.py
@@ -47,6 +47,12 @@ from megatron.bridge.training.nvrx_straggler import (
     check_nvrx_straggler_detection,
     safe_shutdown_nvrx_straggler_manager,
 )
+from megatron.bridge.training.profiling import (
+    handle_profiling_step,
+    handle_profiling_stop,
+    initialize_pytorch_profiler,
+    should_profile_rank,
+)
 from megatron.bridge.training.state import GlobalState
 from megatron.bridge.training.utils import flop_utils
 from megatron.bridge.training.utils.log_utils import append_to_progress_log, barrier_and_log
@@ -171,19 +177,10 @@ def train(
 
     prof = None
     prof_config = config.profiling
-    if prof_config and torch.distributed.get_rank() in prof_config.profile_ranks and prof_config.use_pytorch_profiler:
-        prof = torch.profiler.profile(
-            schedule=torch.profiler.schedule(
-                wait=max(prof_config.profile_step_start - 1, 0),
-                warmup=1 if prof_config.profile_step_start > 0 else 0,
-                active=prof_config.profile_step_end - prof_config.profile_step_start,
-                repeat=1,
-            ),
-            on_trace_ready=torch.profiler.tensorboard_trace_handler(config.logger.tensorboard_dir),
-            record_shapes=prof_config.record_shapes,
-            with_stack=True,
-        )
-        prof.start()
+    if prof_config and should_profile_rank(prof_config, torch.distributed.get_rank()):
+        if prof_config.use_pytorch_profiler:
+            prof = initialize_pytorch_profiler(prof_config, config.logger.tensorboard_dir)
+            prof.start()
 
     start_iteration = global_state.train_state.step
     # Megatron FSDP and FSDP2 does not have this hook
@@ -223,16 +220,13 @@ def train(
 
     # Run training iterations till done.
     while global_state.train_state.step < train_config.train_iters:
-        if prof_config and torch.distributed.get_rank() in prof_config.profile_ranks:
-            if prof_config.use_pytorch_profiler:
-                prof.step()
-            if prof_config.use_nsys_profiler:
-                if global_state.train_state.step == prof_config.profile_step_start:
-                    torch.cuda.check_error(torch.cuda.cudart().cudaProfilerStart())
-                    if prof_config.record_shapes:
-                        torch.autograd.profiler.emit_nvtx(record_shapes=True).__enter__()
-                    else:
-                        torch.autograd.profiler.emit_nvtx().__enter__()
+        # Handle profiling for this step
+        handle_profiling_step(
+            prof_config,
+            global_state.train_state.step,
+            torch.distributed.get_rank(),
+            prof,
+        )
 
         fault_tolerance.on_checkpointing_start(global_state)
         maybe_finalize_async_save(global_state=global_state, ckpt_cfg=config.checkpoint, blocking=False)
@@ -647,17 +641,12 @@ def post_training_step_callbacks(
             enable_forward_pre_hook(model)
 
     # Profiling.
-    if (
-        config.profiling
-        and iteration == config.profiling.profile_step_end
-        and torch.distributed.get_rank() in config.profiling.profile_ranks
-    ):
-        if config.profiling.use_pytorch_profiler:
-            assert prof is not None
-            prof.stop()
-        if config.profiling.use_nsys_profiler:
-            torch.cuda.check_error(torch.cuda.cudart().cudaProfilerStop())
-            torch.autograd.profiler.emit_nvtx().__exit__(None, None, None)
+    handle_profiling_stop(
+        config.profiling,
+        iteration,
+        torch.distributed.get_rank(),
+        prof,
+    )
 
     # Manual garbage collection.
     if train_config.manual_gc:

--- a/src/megatron/bridge/training/utils/flop_utils.py
+++ b/src/megatron/bridge/training/utils/flop_utils.py
@@ -278,6 +278,7 @@ def num_floating_point_operations(cfg: ConfigContainer, batch_size: int = 1):
             cfg.model.vocab_size,
             cfg.model.make_vocab_size_divisible_by,
             cfg.model.tensor_model_parallel_size,
+            logging_enabled=False,
         )
 
         total_floating_point_operations = (

--- a/tests/unit_tests/training/test_profiling.py
+++ b/tests/unit_tests/training/test_profiling.py
@@ -1,0 +1,506 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for profiling utility functions."""
+
+from unittest.mock import MagicMock, Mock, patch
+
+from megatron.bridge.training.config import ProfilingConfig
+from megatron.bridge.training.profiling import (
+    handle_profiling_step,
+    handle_profiling_stop,
+    initialize_pytorch_profiler,
+    should_profile_rank,
+    start_nsys_profiler,
+    stop_nsys_profiler,
+)
+
+
+class TestShouldProfileRank:
+    """Tests for should_profile_rank function."""
+
+    def test_should_profile_rank_with_no_config(self):
+        """Test that profiling is disabled when config is None."""
+        assert should_profile_rank(None, 0) is False
+        assert should_profile_rank(None, 1) is False
+
+    def test_should_profile_rank_with_matching_rank(self):
+        """Test that profiling is enabled for ranks in profile_ranks."""
+        config = ProfilingConfig(use_pytorch_profiler=True, profile_ranks=[0, 2])
+        assert should_profile_rank(config, 0) is True
+        assert should_profile_rank(config, 2) is True
+
+    def test_should_profile_rank_with_non_matching_rank(self):
+        """Test that profiling is disabled for ranks not in profile_ranks."""
+        config = ProfilingConfig(use_pytorch_profiler=True, profile_ranks=[0, 2])
+        assert should_profile_rank(config, 1) is False
+        assert should_profile_rank(config, 3) is False
+
+    def test_should_profile_rank_empty_list(self):
+        """Test that profiling is disabled when profile_ranks is empty."""
+        config = ProfilingConfig(use_pytorch_profiler=True, profile_ranks=[])
+        assert should_profile_rank(config, 0) is False
+
+
+class TestInitializePytorchProfiler:
+    """Tests for initialize_pytorch_profiler function."""
+
+    @patch("torch.profiler.profile")
+    @patch("torch.profiler.tensorboard_trace_handler")
+    @patch("torch.profiler.schedule")
+    def test_initialize_pytorch_profiler_basic(self, mock_schedule, mock_handler, mock_profile):
+        """Test PyTorch profiler initialization with basic parameters."""
+        config = ProfilingConfig(
+            use_pytorch_profiler=True,
+            profile_step_start=5,
+            profile_step_end=10,
+            record_shapes=False,
+        )
+
+        mock_schedule_instance = Mock()
+        mock_schedule.return_value = mock_schedule_instance
+        mock_handler_instance = Mock()
+        mock_handler.return_value = mock_handler_instance
+        mock_profiler = Mock()
+        mock_profile.return_value = mock_profiler
+
+        prof = initialize_pytorch_profiler(config, "/tmp/tensorboard")
+
+        # Verify schedule was created with correct parameters
+        mock_schedule.assert_called_once_with(
+            wait=4,  # max(5-1, 0)
+            warmup=1,  # 1 if start > 0
+            active=5,  # end - start
+            repeat=1,
+        )
+
+        # Verify handler was called with correct directory
+        mock_handler.assert_called_once_with("/tmp/tensorboard")
+
+        # Verify profiler was created with correct kwargs
+        mock_profile.assert_called_once()
+        call_kwargs = mock_profile.call_args.kwargs
+        assert call_kwargs["schedule"] == mock_schedule_instance
+        assert call_kwargs["on_trace_ready"] == mock_handler_instance
+        assert call_kwargs["record_shapes"] is False
+        assert call_kwargs["with_stack"] is True
+
+        # Verify returned profiler
+        assert prof == mock_profiler
+
+    @patch("torch.profiler.profile")
+    @patch("torch.profiler.tensorboard_trace_handler")
+    @patch("torch.profiler.schedule")
+    def test_initialize_pytorch_profiler_with_shapes(self, mock_schedule, mock_handler, mock_profile):
+        """Test profiler initialization with shape recording enabled."""
+        config = ProfilingConfig(
+            use_pytorch_profiler=True,
+            profile_step_start=3,
+            profile_step_end=8,
+            record_shapes=True,
+        )
+
+        initialize_pytorch_profiler(config, "/tmp/tb")
+
+        # Verify record_shapes is True
+        call_kwargs = mock_profile.call_args.kwargs
+        assert call_kwargs["record_shapes"] is True
+
+    @patch("torch.profiler.profile")
+    @patch("torch.profiler.tensorboard_trace_handler")
+    @patch("torch.profiler.schedule")
+    def test_initialize_pytorch_profiler_start_at_zero(self, mock_schedule, mock_handler, mock_profile):
+        """Test profiler initialization when starting at iteration 0."""
+        config = ProfilingConfig(
+            use_pytorch_profiler=True,
+            profile_step_start=0,
+            profile_step_end=3,
+        )
+
+        initialize_pytorch_profiler(config, "/tmp/tb")
+
+        # When start=0, wait should be 0 and warmup should be 0
+        mock_schedule.assert_called_once_with(
+            wait=0,  # max(0-1, 0) = 0
+            warmup=0,  # 0 if start == 0
+            active=3,
+            repeat=1,
+        )
+
+    @patch("torch.profiler.profile")
+    @patch("torch.profiler.tensorboard_trace_handler")
+    @patch("torch.profiler.schedule")
+    def test_initialize_pytorch_profiler_start_at_one(self, mock_schedule, mock_handler, mock_profile):
+        """Test profiler initialization when starting at iteration 1."""
+        config = ProfilingConfig(
+            use_pytorch_profiler=True,
+            profile_step_start=1,
+            profile_step_end=4,
+        )
+
+        initialize_pytorch_profiler(config, "/tmp/tb")
+
+        # When start=1, wait should be 0, warmup should be 1
+        mock_schedule.assert_called_once_with(
+            wait=0,  # max(1-1, 0) = 0
+            warmup=1,  # 1 if start > 0
+            active=3,
+            repeat=1,
+        )
+
+
+class TestStartNsysProfiler:
+    """Tests for start_nsys_profiler function."""
+
+    @patch("torch.cuda.cudart")
+    @patch("torch.autograd.profiler.emit_nvtx")
+    @patch("torch.cuda.check_error")
+    def test_start_nsys_profiler_without_shapes(self, mock_check_error, mock_nvtx, mock_cudart):
+        """Test nsys profiler start without shape recording."""
+        mock_cudart_instance = Mock()
+        mock_cudart_instance.cudaProfilerStart.return_value = (0,)
+        mock_cudart.return_value = mock_cudart_instance
+
+        mock_nvtx_context = MagicMock()
+        mock_nvtx.return_value = mock_nvtx_context
+
+        config = ProfilingConfig(
+            use_nsys_profiler=True,
+            record_shapes=False,
+        )
+
+        start_nsys_profiler(config)
+
+        # Verify CUDA profiler was started
+        mock_cudart_instance.cudaProfilerStart.assert_called_once()
+        mock_check_error.assert_called_once_with((0,))
+
+        # Verify NVTX was called without record_shapes
+        mock_nvtx.assert_called_once_with()
+        mock_nvtx_context.__enter__.assert_called_once()
+
+    @patch("torch.cuda.cudart")
+    @patch("torch.autograd.profiler.emit_nvtx")
+    @patch("torch.cuda.check_error")
+    def test_start_nsys_profiler_with_shapes(self, mock_check_error, mock_nvtx, mock_cudart):
+        """Test nsys profiler start with shape recording."""
+        mock_cudart_instance = Mock()
+        mock_cudart_instance.cudaProfilerStart.return_value = (0,)
+        mock_cudart.return_value = mock_cudart_instance
+
+        mock_nvtx_context = MagicMock()
+        mock_nvtx.return_value = mock_nvtx_context
+
+        config = ProfilingConfig(
+            use_nsys_profiler=True,
+            record_shapes=True,
+        )
+
+        start_nsys_profiler(config)
+
+        # Verify NVTX was called WITH record_shapes
+        mock_nvtx.assert_called_once_with(record_shapes=True)
+        mock_nvtx_context.__enter__.assert_called_once()
+
+
+class TestStopNsysProfiler:
+    """Tests for stop_nsys_profiler function."""
+
+    @patch("torch.cuda.cudart")
+    @patch("torch.autograd.profiler.emit_nvtx")
+    @patch("torch.cuda.check_error")
+    def test_stop_nsys_profiler(self, mock_check_error, mock_nvtx, mock_cudart):
+        """Test nsys profiler stop."""
+        mock_cudart_instance = Mock()
+        mock_cudart_instance.cudaProfilerStop.return_value = (0,)
+        mock_cudart.return_value = mock_cudart_instance
+
+        mock_nvtx_context = MagicMock()
+        mock_nvtx.return_value = mock_nvtx_context
+
+        stop_nsys_profiler()
+
+        # Verify CUDA profiler was stopped
+        mock_cudart_instance.cudaProfilerStop.assert_called_once()
+        mock_check_error.assert_called_once_with((0,))
+
+        # Verify NVTX context was exited
+        mock_nvtx.return_value.__exit__.assert_called_once_with(None, None, None)
+
+
+class TestHandleProfilingStep:
+    """Tests for handle_profiling_step function."""
+
+    def test_handle_profiling_step_with_no_config(self):
+        """Test that profiling step does nothing when config is None."""
+        mock_prof = Mock()
+
+        handle_profiling_step(None, iteration=5, rank=0, pytorch_prof=mock_prof)
+
+        # Profiler should not be called
+        mock_prof.step.assert_not_called()
+
+    def test_handle_profiling_step_skips_non_profiled_rank(self):
+        """Test that profiling step is skipped for non-profiled ranks."""
+        config = ProfilingConfig(
+            use_pytorch_profiler=True,
+            profile_ranks=[0],
+        )
+        mock_prof = Mock()
+
+        # Rank 1 should not profile
+        handle_profiling_step(config, iteration=5, rank=1, pytorch_prof=mock_prof)
+
+        # PyTorch profiler step should NOT be called
+        mock_prof.step.assert_not_called()
+
+    def test_handle_profiling_step_pytorch_profiler(self):
+        """Test profiling step calls PyTorch profiler.step()."""
+        config = ProfilingConfig(
+            use_pytorch_profiler=True,
+            profile_ranks=[0],
+        )
+        mock_prof = Mock()
+
+        handle_profiling_step(config, iteration=5, rank=0, pytorch_prof=mock_prof)
+
+        # PyTorch profiler step should be called
+        mock_prof.step.assert_called_once()
+
+    def test_handle_profiling_step_pytorch_profiler_none(self):
+        """Test profiling step handles None profiler gracefully."""
+        config = ProfilingConfig(
+            use_pytorch_profiler=True,
+            profile_ranks=[0],
+        )
+
+        # Should not raise exception
+        handle_profiling_step(config, iteration=5, rank=0, pytorch_prof=None)
+
+    @patch("megatron.bridge.training.profiling.start_nsys_profiler")
+    def test_handle_profiling_step_nsys_before_start(self, mock_start_nsys):
+        """Test nsys profiler does not start before profile_step_start."""
+        config = ProfilingConfig(
+            use_nsys_profiler=True,
+            profile_step_start=10,
+            profile_step_end=15,
+            profile_ranks=[0],
+        )
+
+        # Before start iteration - should not start
+        handle_profiling_step(config, iteration=9, rank=0, pytorch_prof=None)
+        mock_start_nsys.assert_not_called()
+
+    @patch("megatron.bridge.training.profiling.start_nsys_profiler")
+    def test_handle_profiling_step_nsys_at_start_iteration(self, mock_start_nsys):
+        """Test nsys profiler starts at profile_step_start."""
+        config = ProfilingConfig(
+            use_nsys_profiler=True,
+            profile_step_start=10,
+            profile_step_end=15,
+            profile_ranks=[0],
+        )
+
+        # At start iteration - should start
+        handle_profiling_step(config, iteration=10, rank=0, pytorch_prof=None)
+        mock_start_nsys.assert_called_once_with(config)
+
+    @patch("megatron.bridge.training.profiling.start_nsys_profiler")
+    def test_handle_profiling_step_nsys_after_start(self, mock_start_nsys):
+        """Test nsys profiler does not restart after profile_step_start."""
+        config = ProfilingConfig(
+            use_nsys_profiler=True,
+            profile_step_start=10,
+            profile_step_end=15,
+            profile_ranks=[0],
+        )
+
+        # After start iteration - should not start again
+        handle_profiling_step(config, iteration=11, rank=0, pytorch_prof=None)
+        mock_start_nsys.assert_not_called()
+
+    @patch("megatron.bridge.training.profiling.start_nsys_profiler")
+    def test_handle_profiling_step_nsys_rank_filtering(self, mock_start_nsys):
+        """Test nsys profiler respects rank filtering."""
+        config = ProfilingConfig(
+            use_nsys_profiler=True,
+            profile_step_start=10,
+            profile_step_end=15,
+            profile_ranks=[0, 2],
+        )
+
+        # Rank 1 should not start profiler
+        handle_profiling_step(config, iteration=10, rank=1, pytorch_prof=None)
+        mock_start_nsys.assert_not_called()
+
+        # Rank 0 should start profiler
+        handle_profiling_step(config, iteration=10, rank=0, pytorch_prof=None)
+        mock_start_nsys.assert_called_once_with(config)
+
+
+class TestHandleProfilingStop:
+    """Tests for handle_profiling_stop function."""
+
+    def test_handle_profiling_stop_with_no_config(self):
+        """Test that profiling stop does nothing when config is None."""
+        mock_prof = Mock()
+
+        handle_profiling_stop(None, iteration=10, rank=0, pytorch_prof=mock_prof)
+
+        # Profiler should not be stopped
+        mock_prof.stop.assert_not_called()
+
+    def test_handle_profiling_stop_skips_non_profiled_rank(self):
+        """Test that profiling stop is skipped for non-profiled ranks."""
+        config = ProfilingConfig(
+            use_pytorch_profiler=True,
+            profile_step_end=10,
+            profile_ranks=[0],
+        )
+        mock_prof = Mock()
+
+        # Rank 1 should not stop profiler
+        handle_profiling_stop(config, iteration=10, rank=1, pytorch_prof=mock_prof)
+
+        # PyTorch profiler stop should NOT be called
+        mock_prof.stop.assert_not_called()
+
+    def test_handle_profiling_stop_skips_wrong_iteration(self):
+        """Test that profiling stop is skipped for iterations other than profile_step_end."""
+        config = ProfilingConfig(
+            use_pytorch_profiler=True,
+            profile_step_end=10,
+            profile_ranks=[0],
+        )
+        mock_prof = Mock()
+
+        # Wrong iteration - should not stop
+        handle_profiling_stop(config, iteration=9, rank=0, pytorch_prof=mock_prof)
+        mock_prof.stop.assert_not_called()
+
+        # Also test after end iteration
+        handle_profiling_stop(config, iteration=11, rank=0, pytorch_prof=mock_prof)
+        mock_prof.stop.assert_not_called()
+
+    def test_handle_profiling_stop_pytorch_profiler(self):
+        """Test profiling stop calls PyTorch profiler.stop()."""
+        config = ProfilingConfig(
+            use_pytorch_profiler=True,
+            profile_step_end=10,
+            profile_ranks=[0],
+        )
+        mock_prof = Mock()
+
+        handle_profiling_stop(config, iteration=10, rank=0, pytorch_prof=mock_prof)
+
+        # PyTorch profiler stop should be called
+        mock_prof.stop.assert_called_once()
+
+    def test_handle_profiling_stop_pytorch_profiler_none(self):
+        """Test profiling stop handles None profiler gracefully."""
+        config = ProfilingConfig(
+            use_pytorch_profiler=True,
+            profile_step_end=10,
+            profile_ranks=[0],
+        )
+
+        # Should not raise exception
+        handle_profiling_stop(config, iteration=10, rank=0, pytorch_prof=None)
+
+    @patch("megatron.bridge.training.profiling.stop_nsys_profiler")
+    def test_handle_profiling_stop_nsys_at_end_iteration(self, mock_stop_nsys):
+        """Test nsys profiler stops at profile_step_end."""
+        config = ProfilingConfig(
+            use_nsys_profiler=True,
+            profile_step_end=10,
+            profile_ranks=[0],
+        )
+
+        handle_profiling_stop(config, iteration=10, rank=0, pytorch_prof=None)
+
+        # Nsys stop should be called
+        mock_stop_nsys.assert_called_once()
+
+    @patch("megatron.bridge.training.profiling.stop_nsys_profiler")
+    def test_handle_profiling_stop_nsys_wrong_iteration(self, mock_stop_nsys):
+        """Test nsys profiler does not stop at wrong iteration."""
+        config = ProfilingConfig(
+            use_nsys_profiler=True,
+            profile_step_end=10,
+            profile_ranks=[0],
+        )
+
+        # Wrong iteration - should not stop
+        handle_profiling_stop(config, iteration=9, rank=0, pytorch_prof=None)
+        mock_stop_nsys.assert_not_called()
+
+    @patch("megatron.bridge.training.profiling.stop_nsys_profiler")
+    def test_handle_profiling_stop_nsys_rank_filtering(self, mock_stop_nsys):
+        """Test nsys profiler stop respects rank filtering."""
+        config = ProfilingConfig(
+            use_nsys_profiler=True,
+            profile_step_end=10,
+            profile_ranks=[0, 2],
+        )
+
+        # Rank 1 should not stop profiler
+        handle_profiling_stop(config, iteration=10, rank=1, pytorch_prof=None)
+        mock_stop_nsys.assert_not_called()
+
+        # Rank 0 should stop profiler
+        handle_profiling_stop(config, iteration=10, rank=0, pytorch_prof=None)
+        mock_stop_nsys.assert_called_once()
+
+
+class TestProfilingEdgeCases:
+    """Tests for edge cases and combinations."""
+
+    def test_handle_profiling_step_both_profilers_disabled(self):
+        """Test that nothing happens when both profilers are disabled."""
+        config = ProfilingConfig(
+            use_pytorch_profiler=False,
+            use_nsys_profiler=False,
+            profile_ranks=[0],
+        )
+        mock_prof = Mock()
+
+        handle_profiling_step(config, iteration=5, rank=0, pytorch_prof=mock_prof)
+
+        # Nothing should be called
+        mock_prof.step.assert_not_called()
+
+    def test_multiple_ranks_profiling(self):
+        """Test that multiple ranks can be profiled."""
+        config = ProfilingConfig(
+            use_pytorch_profiler=True,
+            profile_ranks=[0, 1, 3],
+        )
+
+        assert should_profile_rank(config, 0) is True
+        assert should_profile_rank(config, 1) is True
+        assert should_profile_rank(config, 2) is False
+        assert should_profile_rank(config, 3) is True
+
+    @patch("megatron.bridge.training.profiling.start_nsys_profiler")
+    def test_handle_profiling_step_nsys_at_iteration_zero(self, mock_start_nsys):
+        """Test nsys profiler can start at iteration 0."""
+        config = ProfilingConfig(
+            use_nsys_profiler=True,
+            profile_step_start=0,
+            profile_step_end=5,
+            profile_ranks=[0],
+        )
+
+        handle_profiling_step(config, iteration=0, rank=0, pytorch_prof=None)
+        mock_start_nsys.assert_called_once_with(config)


### PR DESCRIPTION
- exit context once steps are completed
- refactor profiling calls into functions for better testability
- add extra assertions for profiling config

```
 [2025-10-02 22:52:07] iteration       10/      50 | consumed samples:         5120 |
elapsed time per iteration (ms): 13212.7 | learning rate: 3.000000E-04 | global batch
size:   512 | lm loss: 4.474437E+00 | loss scale: 1.0 | grad norm: 0.704 | number of s
kipped iterations:   0 | number of nan iterations:   0 |
[Rank 0] (after 10 iterations) memory (MB) | allocated: 11908.05029296875 | max alloca
ted: 12712.43603515625 | reserved: 12954.0 | max reserved: 12954.0
Step Time : 14.26s GPU utilization: 58.2TFLOP/s/GPU
 [2025-10-02 22:54:30] iteration       20/      50 | consumed samples:        10240 |
elapsed time per iteration (ms): 14260.3 | learning rate: 2.604594E-04 | global batch
size:   512 | lm loss: 8.797448E-02 | loss scale: 1.0 | grad norm: 0.170 | number of s
kipped iterations:   0 | number of nan iterations:   0 |
Capture range started in the application.
Capture range ended in the application.
Generating '/tmp/nsys-report-3660.qdstrm'
[1/1] [0%                          ] profiling_validation.nsys-repProcessing events...
[1/1] [========================100%] profiling_validation.nsys-rep
Generated:
    profiling_validation.nsys-rep
Step Time : 16.85s GPU utilization: 49.3TFLOP/s/GPU
 [2025-10-02 22:57:18] iteration       30/      50 | consumed samples:        15360 |
elapsed time per iteration (ms): 16849.1 | learning rate: 1.650000E-04 | global batch
size:   512 | lm loss: 2.124715E-02 | loss scale: 1.0 | grad norm: 0.082 | number of s
kipped iterations:   0 | number of nan iterations:   0 |
Step Time : 14.47s GPU utilization: 57.4TFLOP/s/GPU
 [2025-10-02 22:59:43] iteration       40/      50 | consumed samples:        20480 |
elapsed time per iteration (ms): 14472.4 | learning rate: 6.954058E-05 | global batch
size:   512 | lm loss: 1.176494E-02 | loss scale: 1.0 | grad norm: 0.065 | number of s
kipped iterations:   0 | number of nan iterations:   0 |
Step Time : 14.30s GPU utilization: 58.0TFLOP/s/GPU
 [2025-10-02 23:02:06] iteration       50/      50 | consumed samples:        25600 |
elapsed time per iteration (ms): 14298.7 | learning rate: 3.000000E-05 | global batch
size:   512 | lm loss: 9.120504E-03 | loss scale: 1.0 | grad norm: 0.059 | number of s
kipped iterations:   0 | number of nan iterations:   0 |
```