### PR TITLE
support profiling with nvtx ranges in megatron core

### DIFF
--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -763,6 +763,10 @@ class ProfilingConfig:
     record_shapes: bool = False
     """Record shapes of tensors."""
 
+    nvtx_ranges: bool = False
+    """Enable NVTX range annotations for profiling. When enabled, inserts NVTX markers
+    to categorize execution in profiler output."""
+
     def finalize(self) -> None:
         """Validate profiling configuration."""
         assert not (self.use_pytorch_profiler and self.use_nsys_profiler), (

--- a/src/megatron/bridge/training/initialize.py
+++ b/src/megatron/bridge/training/initialize.py
@@ -28,7 +28,7 @@ from megatron.core.num_microbatches_calculator import (
     init_num_microbatches_calculator,
 )
 from megatron.core.transformer.moe.router import MoEAuxLossAutoScaler
-from megatron.core.utils import get_te_version, is_te_min_version, is_torch_min_version
+from megatron.core.utils import configure_nvtx_profiling, get_te_version, is_te_min_version, is_torch_min_version
 
 from megatron.bridge.models import GPTModelProvider, T5ModelProvider
 from megatron.bridge.training.config import ConfigContainer, DistributedInitConfig, RerunStateMachineConfig, RNGConfig
@@ -71,6 +71,10 @@ def initialize_megatron(
     rerun_state_machine_config = cfg.rerun_state_machine
     train_config = cfg.train
     use_inprocess_restart = cfg.inprocess_restart is not None and cfg.inprocess_restart.enabled
+
+    # Configure NVTX profiling if requested
+    if cfg.profiling is not None and cfg.profiling.nvtx_ranges:
+        configure_nvtx_profiling(enabled=True)
 
     # Prep for checkpoint conversion.
     # if args.ckpt_convert_format is not None:


### PR DESCRIPTION
parity for nsys profiling options in nemo: https://github.com/NVIDIA-NeMo/NeMo/blob/da1b0150990b455a74329d722997f8f8801a2f58/nemo/lightning/pytorch/callbacks/nsys.py#L72-L90