### PR TITLE
ci: Run install check on self-hosted cpu runners

### DIFF
--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -33,13 +33,12 @@ jobs:
     if: |
       !(needs.pre-flight.outputs.docs_only == 'true'
       || needs.pre-flight.outputs.is_deployment_workflow == 'true')
-    runs-on: ${{ matrix.arch }}
-    name: Pip - Python${{ matrix.python-version }} - ${{ matrix.arch == 'ubuntu-latest' && 'AMD64/Linux' || 'ARM64/Darwin' }} - Bare Metal
+    runs-on: linux-amd64-cpu16
+    name: Pip - Python${{ matrix.python-version }} - AMD64/Linux - Bare Metal
     container: ubuntu:24.04
     strategy:
       fail-fast: false
       matrix:
-        arch: ["ubuntu-latest"]
         python-version: ["3.10", "3.11", "3.12"]
     steps:
       - name: Checkout repository

--- a/docker/common/install.sh
+++ b/docker/common/install.sh
@@ -51,6 +51,17 @@ main() {
         chmod 600 ~/.netrc
     fi
 
+    # Remove unnecessary packages and files on Ubuntu
+    apt-get clean
+    rm -rf /usr/local/lib/android || true
+    rm -rf /opt/ghc || true
+    rm -rf /usr/local/.ghcup || true
+    rm -rf /usr/share/dotnet || true
+    rm -rf /opt/az || true
+    # Clear pip and npm caches
+    pip cache purge || true
+    npm cache clean --force || true
+
     # Install dependencies
     export DEBIAN_FRONTEND=noninteractive
 

--- a/docker/common/install.sh
+++ b/docker/common/install.sh
@@ -51,17 +51,6 @@ main() {
         chmod 600 ~/.netrc
     fi
 
-    # Remove unnecessary packages and files on Ubuntu
-    apt-get clean
-    rm -rf /usr/local/lib/android || true
-    rm -rf /opt/ghc || true
-    rm -rf /usr/local/.ghcup || true
-    rm -rf /usr/share/dotnet || true
-    rm -rf /opt/az || true
-    # Clear pip and npm caches
-    pip cache purge || true
-    npm cache clean --force || true
-
     # Install dependencies
     export DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
Install tests are failing in MBridge similar to what we experienced in NeMo with disk space problems.  Tried clearing some of that space but it didn't seem to work.  Now trying to just run the install checks on self-hosted cpu runners instead.

https://github.com/NVIDIA-NeMo/Megatron-Bridge/pull/542
