### PR TITLE
removed dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ dependencies = [
     "pyyaml>=6.0.2",
     "tqdm>=4.67.1",
     "hydra-core>1.3,<=1.3.2",
-    "megatron-core[dev,mlm]>=0.14.0a0,<0.16.0",
+    "megatron-core>=0.14.0a0,<0.16.0",
     "nvidia-modelopt[torch]>=0.33.0a0,<0.34.0; sys_platform != 'darwin'",
     "nvidia-resiliency-ext>=0.4.0a0,<0.5.0; sys_platform != 'darwin'",
 #    "transformer-engine[pytorch]>=2.6.0a0,<2.8.0; sys_platform != 'darwin'"


### PR DESCRIPTION
When run from a login node, using megatron-core[dev,mlm] would pull in many unnecessary packages that needed GPU libraries to be installed which would be unnaccessible from a login node