### PR TITLE
fix HF saving for `tied_word_embeddings`

### DIFF
--- a/src/megatron/bridge/models/conversion/model_bridge.py
+++ b/src/megatron/bridge/models/conversion/model_bridge.py
@@ -598,7 +598,8 @@ class MegatronModelBridge(Generic[HFPreTrained, ModelProviderTarget, MegatronMod
                     if hasattr(hf_pretrained, "state") and hasattr(hf_pretrained.state, "source"):
                         expected_keys = hf_pretrained.state.source.get_all_keys()
                         if "lm_head.weight" in expected_keys:
-                            yield HFWeightTuple("lm_head.weight", final_tensor)
+                            # Clone the tensor to avoid shared memory issues with safetensors
+                            yield HFWeightTuple("lm_head.weight", final_tensor.clone())
                 elif embeddings_are_tied and hf_name == "lm_head.weight":
                     # This should not happen when embeddings are tied - assert error
                     raise ValueError(


### PR DESCRIPTION
fix #919 

in the tied embeddings case, we yield the same tensor object twice with different names, which causes safetensors to detect shared memory. cloning the tensor resolves the issue

script now works:
```
from megatron.bridge import AutoBridge

if __name__ == "__main__":
    bridge = AutoBridge.from_hf_pretrained("Qwen/Qwen3-0.6B", trust_remote_code=True)

    provider = bridge.to_megatron_provider()
    provider.tensor_model_parallel_size = 1
    provider.pipeline_model_parallel_size = 1
    provider.finalize()
    model = provider.provide_distributed_model(wrap_with_ddp=False)

    bridge.save_hf_weights(model, "./hf_exports/qwen3_0.6b")
```