### PR TITLE
Fix: save_hf_weights is broken when tie_word_embeddings is true

### DIFF
--- a/src/megatron/bridge/models/conversion/model_bridge.py
+++ b/src/megatron/bridge/models/conversion/model_bridge.py
@@ -598,7 +598,7 @@ class MegatronModelBridge(Generic[HFPreTrained, ModelProviderTarget, MegatronMod
                     if hasattr(hf_pretrained, "state") and hasattr(hf_pretrained.state, "source"):
                         expected_keys = hf_pretrained.state.source.get_all_keys()
                         if "lm_head.weight" in expected_keys:
-                            yield HFWeightTuple("lm_head.weight", final_tensor)
+                            yield HFWeightTuple("lm_head.weight", final_tensor.clone().detach())
                 elif embeddings_are_tied and hf_name == "lm_head.weight":
                     # This should not happen when embeddings are tied - assert error
                     raise ValueError(


### PR DESCRIPTION
fixes https://github.com/NVIDIA-NeMo/Megatron-Bridge/issues/919

clone tied tensor to avoid 
Some tensors share memory, this will lead to duplicate memory on disk and potential differences when loading them
again: [{'model.embed_tokens.weight', 'lm_head.weight'}]