### PR TITLE
Adding explainers to PyPi version switch

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,7 @@ import sys
 project = "Megatron Bridge"
 copyright = "2025, NVIDIA Corporation"
 author = "NVIDIA Corporation"
-release = "0.1.0"
+release = "latest"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
@@ -54,6 +54,7 @@ myst_enable_extensions = [
     "deflist",  # Supports definition lists with term: definition format
     "fieldlist",  # Enables field lists for metadata like :author: Name
     "tasklist",  # Adds support for GitHub-style task lists with [ ] and [x]
+    "attrs_block",  # Enables setting attributes on block elements using {#id .class key=val}
 ]
 myst_heading_anchors = 5  # Generates anchor links for headings up to level 5
 

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -66,9 +66,79 @@ uv run --only-group docs sphinx-build -b doctest . _build/doctest
 
 ## Documentation Version
 
-The three files below control the version switcher. Before you attempt to publish a new version of the documentation, update these files to match the latest version numbers.
+The three files below control the version switcher. Before you attempt to publish a new version of the documentation, update these files in the docs/ folder to match the latest version numbers.
 
-* docs/versions1.json
-* docs/project.json
-* docs/conf.py
 
+The ``version`` and ``release`` variables with your GitHub releases when publishing new versions of documentation.
+
+
+```{danger}
+Latest should only be ``version`` and ``release`` variables in the main branch.
+```
+
+### versions1.json
+
+This JSON file defines the versions displayed in the switcher drop down. When adding a new version to the JSON, please make sure the ``version`` and ``url`` contain same version as your release.
+
+Example:
+
+
+```{code-block} json
+:caption: Example: versions1.json 
+:emphasize-lines: 9,10
+
+[
+    {
+        "preferred": true,
+        "version": "latest",
+        "url": "https://docs.nvidia.com/nemo/megatron-bridge/latest/"
+    },
+    {
+
+        "version": "#.#.#",
+        "url": "https://docs.nvidia.com/nemo/megatron-bridge/#.#.#/"
+    },
+    {
+
+        "version": "0.1.0",
+        "url": "https://docs.nvidia.com/nemo/megatron-bridge/0.1.0/"
+    }
+]
+```
+
+```{tip}
+Use absolute URLs for the ``url`` variable.
+```
+
+## project.json
+
+This JSON file tells the version switcher that documentation matches the selected version in the switcher. The ``version`` should contain same version as your release.
+
+```{code-block} json
+:caption: Example: project.json 
+:emphasize-lines: 3
+
+{
+    "name": "megatron-bridge",
+    "version": "#.#.#"
+}
+```
+
+
+
+## conf.py
+
+The conf.py ``release`` should contain same version as your release.
+
+```{code-block} python
+:caption: Example: conf.py 
+:emphasize-lines: 7
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = "Megatron Bridge"
+copyright = "2025, NVIDIA Corporation"
+author = "NVIDIA Corporation"
+release = "#.#.#"
+```

--- a/docs/project.json
+++ b/docs/project.json
@@ -1,4 +1,4 @@
 {
     "name": "megatron-bridge",
-    "version": "0.1.0"
+    "version": "latest"
 }

--- a/docs/versions1.json
+++ b/docs/versions1.json
@@ -1,7 +1,12 @@
 [
     {
         "preferred": true,
+        "version": "latest",
+        "url": "https://docs.nvidia.com/nemo/megatron-bridge/latest/"
+    },
+    {
+
         "version": "0.1.0",
-        "url": "../0.1.0"
+        "url": "https://docs.nvidia.com/nemo/megatron-bridge/0.1.0/"
     }
 ]


### PR DESCRIPTION
- Adds explainers to versions1.json, conf.py, and project.json for PyPi version switcher.
- Sets the latest in the main branch to support the "Latest" drop-down in the version switcher.
- Sets absolute URL in version switcher.

Part of #749 