### PR TITLE
Handle variable sequence lengths in sampler + train step explicitly

### DIFF
--- a/src/megatron/bridge/data/finetuning.py
+++ b/src/megatron/bridge/data/finetuning.py
@@ -1,0 +1,140 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Finetuning-specific data handling utilities."""
+
+from typing import Any, Iterator
+
+import torch
+
+
+def split_batch_into_microbatches(
+    batch: dict[str, Any], num_microbatches: int, enforce_divisible: bool = True
+) -> list[dict[str, Any]]:
+    """Split a batch dictionary into microbatches.
+
+    Takes a global batch (e.g., [16, 240] for tokens) and splits it into
+    num_microbatches smaller batches (e.g., 4 batches of [4, 240]).
+
+    Args:
+        batch: Dictionary containing tensors with batch_size = num_microbatches * micro_batch_size
+        num_microbatches: Number of microbatches to split into
+        enforce_divisible: Whether to enforce batch_size % num_microbatches == 0
+
+    Returns:
+        List of microbatch dictionaries, each containing the same keys as the input batch
+
+    Example:
+        >>> batch = {'tokens': torch.rand(16, 240), 'labels': torch.rand(16, 240)}
+        >>> microbatches = split_batch_into_microbatches(batch, num_microbatches=4)
+        >>> len(microbatches)  # 4
+        >>> microbatches[0]['tokens'].shape  # torch.Size([4, 240])
+    """
+    # Identify tensor items vs other items (like metadata)
+    tensor_items = {k: v for k, v in batch.items() if isinstance(v, torch.Tensor)}
+    other_items = {k: v for k, v in batch.items() if not isinstance(v, torch.Tensor)}
+
+    if len(tensor_items) == 0:
+        raise ValueError("Batch must contain at least one tensor")
+
+    # Get batch size from first tensor
+    first_key = next(iter(tensor_items.keys()))
+    batch_size = tensor_items[first_key].shape[0]
+
+    if enforce_divisible and batch_size % num_microbatches != 0:
+        raise ValueError(
+            f"Batch size {batch_size} is not divisible by num_microbatches {num_microbatches}. "
+            f"Cannot split evenly into microbatches."
+        )
+
+    # Split all tensors along batch dimension (dim=0)
+    split_tensors = {}
+    for key, tensor in tensor_items.items():
+        split_tensors[key] = torch.tensor_split(tensor, num_microbatches, dim=0)
+
+    # Create microbatch dictionaries
+    microbatches = []
+    for i in range(num_microbatches):
+        microbatch = {}
+
+        # Add split tensors
+        for key, splits in split_tensors.items():
+            microbatch[key] = splits[i]
+
+        # Handle non-tensor items (metadata, etc.)
+        for key, value in other_items.items():
+            if isinstance(value, list) and len(value) == batch_size:
+                # If it's a list with length matching batch size, split it too
+                micro_batch_size = batch_size // num_microbatches
+                start_idx = i * micro_batch_size
+                end_idx = start_idx + micro_batch_size
+                microbatch[key] = value[start_idx:end_idx]
+            else:
+                # Otherwise copy as-is (e.g., global metadata)
+                microbatch[key] = value
+
+        microbatches.append(microbatch)
+
+    return microbatches
+
+
+def prepare_finetuning_batch(
+    data_iterator: Iterator,
+    num_microbatches: int,
+    default_seq_length: int,
+    seq_key: str = "tokens",
+) -> tuple[Iterator, int]:
+    """Prepare a finetuning batch by getting global batch and splitting into microbatches.
+
+    This function handles the finetuning-specific data flow:
+    1. Gets the full global batch from the iterator
+    2. Extracts the dynamic sequence length from the batch
+    3. Splits the batch into microbatches with consistent sequence length
+    4. Returns an iterator over microbatches and the extracted sequence length
+
+    Args:
+        data_iterator: Iterator that yields global batches (e.g., from DataLoader with batch sampler)
+        num_microbatches: Number of microbatches to split each global batch into
+        default_seq_length: Fallback sequence length if it cannot be extracted from batch
+        seq_key: Key in batch dict containing the sequence tensor (default: 'tokens')
+
+    Returns:
+        Tuple of:
+        - Iterator over microbatches (each microbatch is a dict with same keys as global batch)
+        - Sequence length extracted from the global batch (or default_seq_length if not found)
+
+    Example:
+        >>> # DataLoader yields global batch of shape [16, 240]
+        >>> microbatch_iter, seq_len = prepare_finetuning_batch(
+        ...     data_iterator=iter(dataloader),
+        ...     num_microbatches=4,
+        ...     default_seq_length=2048
+        ... )
+        >>> seq_len  # 240 (extracted from batch)
+        >>> batch1 = next(microbatch_iter)
+        >>> batch1['tokens'].shape  # torch.Size([4, 240])
+    """
+    # Get full global batch from dataloader
+    global_batch = next(data_iterator)
+
+    # Extract dynamic seq_length from the full batch
+    seq_length = default_seq_length
+    if seq_key in global_batch and isinstance(global_batch[seq_key], torch.Tensor):
+        seq_length = global_batch[seq_key].size(1)
+
+    # Split into microbatches
+    microbatches = split_batch_into_microbatches(global_batch, num_microbatches)
+
+    # Return iterator over microbatches and the extracted seq_length
+    return iter(microbatches), seq_length

--- a/tests/functional_tests/data/test_samplers.py
+++ b/tests/functional_tests/data/test_samplers.py
@@ -187,15 +187,13 @@ class TestMegatronPretrainingBatchSampler:
     def test_batch_sampler_length(self):
         """Test length calculation for batch sampler.
 
-        After the fix, batch sampler yields microbatches one at a time,
-        so length = num_global_batches × num_micro_batches.
+        Batch sampler now yields full global batches, not individual microbatches.
+        Length = number of global batches.
         """
         from megatron.bridge.data.samplers import MegatronPretrainingBatchSampler
 
         # With drop_last=True
         # num_global_batches = 100 // 16 = 6
-        # num_micro_batches = 16 // (4 * 2) = 2
-        # total yields = 6 * 2 = 12
         sampler = MegatronPretrainingBatchSampler(
             total_samples=100,
             consumed_samples=0,
@@ -205,11 +203,10 @@ class TestMegatronPretrainingBatchSampler:
             data_parallel_size=2,
             drop_last=True,
         )
-        assert len(sampler) == 12  # 6 global batches × 2 microbatches each
+        assert len(sampler) == 6  # 6 global batches
 
         # With drop_last=False
         # num_global_batches = ceil(100 / 16) = 7
-        # total yields = 7 * 2 = 14
         sampler = MegatronPretrainingBatchSampler(
             total_samples=100,
             consumed_samples=0,
@@ -219,15 +216,14 @@ class TestMegatronPretrainingBatchSampler:
             data_parallel_size=2,
             drop_last=False,
         )
-        assert len(sampler) == 14  # 7 global batches × 2 microbatches each
+        assert len(sampler) == 7  # 7 global batches
 
     def test_batch_sampler_interleaved_distribution(self):
         """Test that indices are distributed in interleaved fashion across ranks.
 
-        With the fix, batch sampler yields microbatches one at a time. Since:
+        Batch sampler now yields full global batches. With:
         - global_batch_size=8, micro_batch_size=4, dp_size=2
-        - num_micro_batches = 8 // (4*2) = 1 per rank per global batch
-        Each global batch yields 1 microbatch per rank.
+        - Each rank gets global_batch_size // dp_size = 4 samples per yield
         """
         from megatron.bridge.data.samplers import MegatronPretrainingBatchSampler
 
@@ -257,15 +253,15 @@ class TestMegatronPretrainingBatchSampler:
         rank0_batches = list(sampler_rank0)
         rank1_batches = list(sampler_rank1)
 
-        # 2 global batches (16 / 8) × 1 microbatch each = 2 yields per rank
+        # 2 global batches (16 / 8), each yields full batch portion
         assert len(rank0_batches) == 2
         assert len(rank1_batches) == 2
 
-        # First microbatch: rank 0 gets [0, 2, 4, 6], rank 1 gets [1, 3, 5, 7]
+        # First global batch: rank 0 gets [0, 2, 4, 6], rank 1 gets [1, 3, 5, 7]
         assert rank0_batches[0] == [0, 2, 4, 6]
         assert rank1_batches[0] == [1, 3, 5, 7]
 
-        # Second microbatch: rank 0 gets [8, 10, 12, 14], rank 1 gets [9, 11, 13, 15]
+        # Second global batch: rank 0 gets [8, 10, 12, 14], rank 1 gets [9, 11, 13, 15]
         assert rank0_batches[1] == [8, 10, 12, 14]
         assert rank1_batches[1] == [9, 11, 13, 15]
 
@@ -290,8 +286,8 @@ class TestMegatronPretrainingBatchSampler:
     def test_batch_sampler_incomplete_batch_drop_last_true(self):
         """Test that incomplete batch is dropped when drop_last=True.
 
-        With microbatch-by-microbatch yielding:
-        - 1 global batch (16 samples) yields 2 microbatches of 4 samples each
+        Batch sampler yields full global batches:
+        - 1 global batch (16 samples) yields once with 8 samples (for rank 0, dp_size=2)
         - Last 4 samples dropped
         """
         from megatron.bridge.data.samplers import MegatronPretrainingBatchSampler
@@ -307,18 +303,17 @@ class TestMegatronPretrainingBatchSampler:
         )
 
         batches = list(sampler)
-        # 1 global batch × 2 microbatches = 2 yields, each with 4 samples
-        assert len(batches) == 2
-        assert len(batches[0]) == 4
-        assert len(batches[1]) == 4
+        # 1 global batch, yields 8 samples for this rank
+        assert len(batches) == 1
+        assert len(batches[0]) == 8
 
     def test_batch_sampler_incomplete_batch_drop_last_false(self):
         """Test that incomplete batch is kept when drop_last=False.
 
-        With microbatch-by-microbatch yielding:
-        - First global batch (16 samples) → 2 microbatches of 4 samples each
-        - Second global batch (4 samples) → 1 microbatch (partial)
-        Total: 3 yields
+        Batch sampler yields full global batches:
+        - First global batch (16 samples) → yields 8 samples for this rank
+        - Second global batch (4 samples) → yields 2 samples for this rank (partial)
+        Total: 2 yields
         """
         from megatron.bridge.data.samplers import MegatronPretrainingBatchSampler
 
@@ -334,19 +329,18 @@ class TestMegatronPretrainingBatchSampler:
         )
 
         batches = list(sampler)
-        # First global batch yields 2 microbatches, second yields 1 partial = 3 total
-        assert len(batches) == 3
-        assert batches[0] == [0, 2, 4, 6]  # First microbatch
-        assert batches[1] == [8, 10, 12, 14]  # Second microbatch
-        assert batches[2] == [16, 18]  # Partial microbatch from second global batch
+        # 2 global batches
+        assert len(batches) == 2
+        assert batches[0] == [0, 2, 4, 6, 8, 10, 12, 14]  # Full global batch for this rank
+        assert batches[1] == [16, 18]  # Partial batch for this rank
 
     def test_batch_sampler_incomplete_batch_with_padding(self):
         """Test that incomplete batch is padded when pad_samples_to_global_batch_size=True.
 
-        With padding and microbatch-by-microbatch yielding:
-        - First global batch (16 samples) → 2 microbatches
-        - Second global batch (4 samples, padded to 16) → 2 microbatches (with padding)
-        Total: 4 yields
+        Batch sampler yields full global batches:
+        - First global batch (16 samples) → yields 8 samples for this rank
+        - Second global batch (4 samples, padded to 8 for this rank) → yields 8 with padding
+        Total: 2 yields
         """
         from megatron.bridge.data.samplers import MegatronPretrainingBatchSampler
 
@@ -362,14 +356,12 @@ class TestMegatronPretrainingBatchSampler:
         )
 
         batches = list(sampler)
-        # First global batch: 2 microbatches, second global batch (padded): 2 microbatches = 4 total
-        assert len(batches) == 4
-        # First global batch microbatches
-        assert batches[0] == [0, 2, 4, 6]
-        assert batches[1] == [8, 10, 12, 14]
-        # Second global batch microbatches (with padding)
-        assert batches[2] == [16, 18, -1, -1]
-        assert batches[3] == [-1, -1, -1, -1]
+        # 2 global batches
+        assert len(batches) == 2
+        # First global batch: full 8 samples for this rank
+        assert batches[0] == [0, 2, 4, 6, 8, 10, 12, 14]
+        # Second global batch: 2 real + 6 padded samples
+        assert batches[1] == [16, 18, -1, -1, -1, -1, -1, -1]
 
     def test_batch_sampler_global_batch_size_validation(self):
         """Test that invalid global_batch_size raises error."""
@@ -392,8 +384,9 @@ class TestMegatronPretrainingBatchSampler:
     def test_batch_sampler_multiple_data_parallel_ranks(self):
         """Test with multiple data parallel ranks.
 
-        With microbatch-by-microbatch yielding, each rank gets multiple yields,
-        but all indices should still appear exactly once across all ranks.
+        Batch sampler yields full global batches.
+        Each rank gets global_batch_size // dp_size samples per yield.
+        All indices should appear exactly once across all ranks.
         """
         from megatron.bridge.data.samplers import MegatronPretrainingBatchSampler
 
@@ -402,8 +395,8 @@ class TestMegatronPretrainingBatchSampler:
         samplers = []
 
         # Create samplers for all ranks
-        # num_micro_batches = 16 // (4*4) = 1
-        # 2 global batches × 1 microbatch = 2 yields per rank
+        # Each rank gets 16 // 4 = 4 samples per global batch
+        # 2 global batches (32 / 16) = 2 yields per rank
         for rank in range(dp_size):
             sampler = MegatronPretrainingBatchSampler(
                 total_samples=32,
@@ -425,6 +418,135 @@ class TestMegatronPretrainingBatchSampler:
         # Verify all indices from 0-31 are present exactly once
         all_indices_sorted = sorted(all_indices)
         assert all_indices_sorted == list(range(32))
+
+
+class TestFinetuningUtilities:
+    """Tests for finetuning data handling utilities."""
+
+    def test_split_batch_into_microbatches_basic(self):
+        """Test basic batch splitting functionality."""
+        import torch
+
+        from megatron.bridge.data.finetuning import split_batch_into_microbatches
+
+        batch = {
+            "tokens": torch.randint(0, 1000, (16, 240)),
+            "labels": torch.randint(0, 1000, (16, 240)),
+            "loss_mask": torch.ones(16, 240),
+        }
+
+        microbatches = split_batch_into_microbatches(batch, num_microbatches=4)
+
+        assert len(microbatches) == 4
+        for i, mb in enumerate(microbatches):
+            assert mb["tokens"].shape == (4, 240), f"MB{i} tokens shape mismatch"
+            assert mb["labels"].shape == (4, 240), f"MB{i} labels shape mismatch"
+            assert mb["loss_mask"].shape == (4, 240), f"MB{i} loss_mask shape mismatch"
+
+    def test_split_batch_preserves_data(self):
+        """Test that splitting preserves data integrity."""
+        import torch
+
+        from megatron.bridge.data.finetuning import split_batch_into_microbatches
+
+        batch = {
+            "tokens": torch.arange(16 * 10).reshape(16, 10),
+            "labels": torch.arange(16 * 10, 32 * 10).reshape(16, 10),
+        }
+
+        microbatches = split_batch_into_microbatches(batch, num_microbatches=4)
+
+        # Reconstruct original batch
+        reconstructed_tokens = torch.cat([mb["tokens"] for mb in microbatches], dim=0)
+        reconstructed_labels = torch.cat([mb["labels"] for mb in microbatches], dim=0)
+
+        assert torch.equal(reconstructed_tokens, batch["tokens"])
+        assert torch.equal(reconstructed_labels, batch["labels"])
+
+    def test_split_batch_with_metadata(self):
+        """Test splitting with mixed tensor and non-tensor items."""
+        import torch
+
+        from megatron.bridge.data.finetuning import split_batch_into_microbatches
+
+        batch = {
+            "tokens": torch.randint(0, 1000, (16, 240)),
+            "labels": torch.randint(0, 1000, (16, 240)),
+            "metadata": ["sample_" + str(i) for i in range(16)],
+            "global_meta": {"dataset": "test"},
+        }
+
+        microbatches = split_batch_into_microbatches(batch, num_microbatches=4)
+
+        # Check metadata splitting
+        for i, mb in enumerate(microbatches):
+            assert len(mb["metadata"]) == 4
+            assert mb["metadata"][0] == f"sample_{i * 4}"
+            assert mb["global_meta"] == {"dataset": "test"}  # Should be copied
+
+    def test_prepare_finetuning_batch(self):
+        """Test prepare_finetuning_batch function."""
+        import torch
+
+        from megatron.bridge.data.finetuning import prepare_finetuning_batch
+
+        # Create mock dataloader that yields global batches
+        def mock_dataloader():
+            for seq_len in [240, 256, 224]:
+                yield {
+                    "tokens": torch.randint(0, 1000, (16, seq_len)),
+                    "labels": torch.randint(0, 1000, (16, seq_len)),
+                }
+
+        iterator = iter(mock_dataloader())
+
+        # First global batch (seq_len=240)
+        microbatch_iter, seq_length = prepare_finetuning_batch(
+            data_iterator=iterator,
+            num_microbatches=4,
+            default_seq_length=2048,
+        )
+
+        assert seq_length == 240, f"Expected seq_length=240, got {seq_length}"
+
+        # Get all microbatches
+        mb1 = next(microbatch_iter)
+        assert mb1["tokens"].shape == (4, 240)
+
+        mb2 = next(microbatch_iter)
+        assert mb2["tokens"].shape == (4, 240)
+
+        # All microbatches should have same seq_length
+        for _ in range(2):  # Get remaining microbatches
+            mb = next(microbatch_iter)
+            assert mb["tokens"].shape[1] == 240
+
+    def test_prepare_finetuning_batch_variable_lengths(self):
+        """Test with different seq_lengths across global batches."""
+        import torch
+
+        from megatron.bridge.data.finetuning import prepare_finetuning_batch
+
+        # Mock dataloader with variable seq_lengths
+        def mock_dataloader():
+            for seq_len in [240, 256, 224]:
+                yield {
+                    "tokens": torch.randint(0, 1000, (16, seq_len)),
+                    "labels": torch.randint(0, 1000, (16, seq_len)),
+                }
+
+        # First global batch (seq_len=240)
+        iterator = iter(mock_dataloader())
+        microbatch_iter, seq_length = prepare_finetuning_batch(iterator, 4, 2048)
+        assert seq_length == 240
+
+        # Second global batch (seq_len=256)
+        microbatch_iter, seq_length = prepare_finetuning_batch(iterator, 4, 2048)
+        assert seq_length == 256
+
+        # Third global batch (seq_len=224)
+        microbatch_iter, seq_length = prepare_finetuning_batch(iterator, 4, 2048)
+        assert seq_length == 224
 
 
 class TestBatchDataloaderIntegration:


### PR DESCRIPTION
This is more efficient than what was implemented in https://github.com/NVIDIA-NeMo/Megatron-Bridge/pull/974
and more closely follows NeMo's assumptions for SFT datasets/ handling in Megatron Parallel