### PR TITLE
Remove sequence length validation check for custom dataset providers

### DIFF
--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -1238,17 +1238,20 @@ class ConfigContainer(Container):
             assert self.checkpoint.pretrained_checkpoint is not None, "PEFT requires a pretrained checkpoint path"
 
         if self.dataset is not None:
-            data_seq_length = (
-                self.dataset.seq_length
-                if isinstance(self.dataset, FinetuningDatasetConfig)
-                else self.dataset.sequence_length
-            )
+            # Only validate sequence length for GPTDatasetConfig or FinetuningDatasetConfig
+            # DatasetProvider instances may not have sequence_length attributes
+            if isinstance(self.dataset, (GPTDatasetConfig, FinetuningDatasetConfig)):
+                data_seq_length = (
+                    self.dataset.seq_length
+                    if isinstance(self.dataset, FinetuningDatasetConfig)
+                    else self.dataset.sequence_length
+                )
 
-            assert self.model.seq_length == data_seq_length, (
-                f"Please ensure sequence length configuration in model config and "
-                f"dataset config match.\nSequence length in model config: {self.model.seq_length}, "
-                f"Sequence length in dataset config: {data_seq_length}"
-            )
+                assert self.model.seq_length == data_seq_length, (
+                    f"Please ensure sequence length configuration in model config and "
+                    f"dataset config match.\nSequence length in model config: {self.model.seq_length}, "
+                    f"Sequence length in dataset config: {data_seq_length}"
+                )
 
         # Validate DeepEP is supported for the current GPU architecture
         validate_deepep(self.model)


### PR DESCRIPTION
only if users provide a `GPTDatasetConfig` or `FinetuningDatasetConfig` should we validate that the configured sequence length matches with what the model provider contains.

part of https://github.com/NVIDIA-NeMo/Megatron-Bridge/issues/894