### PR TITLE
followup to add tests for tokenizer changes in #969

### DIFF
--- a/tests/unit_tests/training/test_tokenizer.py
+++ b/tests/unit_tests/training/test_tokenizer.py
@@ -12,10 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
+import sys
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from megatron.bridge.training.tokenizers.config import TokenizerConfig
-from megatron.bridge.training.tokenizers.tokenizer import build_tokenizer
+from megatron.bridge.training.tokenizers.tokenizer import CustomTikTokenizer, build_tokenizer
 
 
 class TestTokenizerConfig:
@@ -231,3 +236,247 @@ class TestHuggingFaceTokenizerIntegration:
         mock_hf_tokenizer_class.assert_called_once_with("gpt2")
         assert tokenizer is not None
         assert hasattr(tokenizer, "vocab_size")
+
+
+@pytest.fixture()
+def mock_transformers(monkeypatch):
+    class _MockHFTokenizer:
+        def __init__(self, eos_token_id=2, bos_token_id=1, mask_token_id=None):
+            self.eos_token_id = eos_token_id
+            self.bos_token_id = bos_token_id
+            self.mask_token_id = mask_token_id
+            self.chat_template = None
+
+        def get_vocab(self):
+            return {"</s>": self.eos_token_id}
+
+        def decode(self, ids, **kwargs):
+            return ""
+
+        def __call__(self, text, **kwargs):
+            return SimpleNamespace(input_ids=[1, 2])
+
+    class _MockAutoTokenizer:
+        def from_pretrained(self, *args, **kwargs):
+            eos_id = kwargs.pop("_eos_token_id", 2)
+            return _MockHFTokenizer(eos_token_id=eos_id)
+
+    mock_module = type("_T", (), {"AutoTokenizer": _MockAutoTokenizer()})
+    monkeypatch.setattr("megatron.bridge.training.tokenizers.tokenizer.transformers", mock_module, raising=False)
+    return mock_module
+
+
+@pytest.fixture()
+def mock_sentencepiece(monkeypatch):
+    class _MockSP:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __len__(self):
+            return 10
+
+        def vocab_size(self):
+            return 10
+
+        def get_piece_size(self):
+            return 10
+
+        def id_to_piece(self, i):
+            mapping = {0: "<PAD>", 1: "<BOS>", 2: "<EOS>"}
+            return mapping.get(i, f"_{i}")
+
+        def pad_id(self):
+            return 0
+
+        def bos_id(self):
+            return 1
+
+        def eos_id(self):
+            return 2
+
+        def encode_as_ids(self, s):
+            return [1, 2]
+
+        def decode_ids(self, ids):
+            return ""
+
+        def encode(self, s):
+            return [1, 2]
+
+        def decode_ids_as_immutable_proto(self, ids):
+            class _Piece:
+                def __init__(self, begin):
+                    self.begin = begin
+
+            class _Proto:
+                def __init__(self):
+                    self.pieces = [_Piece(0)]
+
+            return _Proto()
+
+    mock_module = type("_S", (), {"SentencePieceProcessor": _MockSP})
+    monkeypatch.setitem(sys.modules, "sentencepiece", mock_module)
+    return mock_module
+
+
+@patch("megatron.bridge.training.tokenizers.tokenizer._HuggingFaceTokenizer")
+@patch("megatron.bridge.training.tokenizers.tokenizer.get_rank_safe", return_value=0)
+def test_hf_tokenizer_eos_property(mock_get_rank, mock_hf_cls):
+    inst = MagicMock()
+    type(inst).eos = 7
+    type(inst).eos_id = 7
+    mock_hf_cls.return_value = inst
+
+    cfg = TokenizerConfig(
+        tokenizer_type="HuggingFaceTokenizer",
+        tokenizer_model="dummy-model",
+        hf_tokenizer_kwargs={"_eos_token_id": 7},
+    )
+    tok = build_tokenizer(cfg)
+    assert tok.eos == 7
+    assert tok.eos_id == 7
+
+
+@patch("megatron.bridge.training.tokenizers.tokenizer._HuggingFaceTokenizer")
+@patch("megatron.bridge.training.tokenizers.tokenizer.get_rank_safe", return_value=0)
+def test_hf_tokenizer_none_eos_property(mock_get_rank, mock_hf_cls):
+    inst = MagicMock()
+    type(inst).eos = None
+    type(inst).eos_id = None
+    mock_hf_cls.return_value = inst
+
+    cfg = TokenizerConfig(tokenizer_type="HuggingFaceTokenizer", tokenizer_model="dummy")
+    tok = build_tokenizer(cfg)
+    assert tok.eos is None
+    assert tok.eos_id is None
+
+
+def test_sentencepiece_tokenizer_eos_property(mock_sentencepiece):
+    cfg = TokenizerConfig(tokenizer_type="SentencePieceTokenizer", tokenizer_model="sp.model")
+    tok = build_tokenizer(cfg)
+    assert tok.eos == 2
+    assert tok.eos_id == 2
+
+
+def test_gpt_sentencepiece_tokenizer_eos_property(mock_sentencepiece):
+    cfg = TokenizerConfig(tokenizer_type="GPTSentencePieceTokenizer", tokenizer_model="sp.model")
+    tok = build_tokenizer(cfg)
+    assert tok.eos == 2
+    assert tok.eos_id == 2
+    assert tok.eod == 2
+
+
+@patch("megatron.bridge.training.tokenizers.tokenizer._Llama2Tokenizer")
+@patch("megatron.bridge.training.tokenizers.tokenizer.get_rank_safe", return_value=0)
+def test_llama2_tokenizer_eos_property(mock_get_rank, mock_llama2_cls, mock_sentencepiece):
+    inst = MagicMock()
+    type(inst).eos = 2
+    type(inst).eos_id = 2
+    type(inst).eod = 2
+    mock_llama2_cls.return_value = inst
+
+    cfg = TokenizerConfig(tokenizer_type="Llama2Tokenizer", tokenizer_model="sp.model")
+    tok = build_tokenizer(cfg)
+    assert tok.eos == 2
+    assert tok.eos_id == 2
+    assert tok.eod == 2
+
+
+@patch("megatron.bridge.training.tokenizers.tokenizer._GPT2BPETokenizer")
+@patch("megatron.bridge.training.tokenizers.tokenizer.get_rank_safe", return_value=0)
+def test_gpt2_bpe_tokenizer_eos_property(mock_get_rank, mock_gpt2_cls):
+    inst = MagicMock()
+    type(inst).eos = 50256
+    type(inst).eos_id = 50256
+    type(inst).eod = 50256
+    mock_gpt2_cls.return_value = inst
+
+    cfg = TokenizerConfig(tokenizer_type="GPT2BPETokenizer", vocab_file="vocab.json", merge_file="merges.txt")
+    tok = build_tokenizer(cfg)
+    assert tok.eos == 50256
+    assert tok.eos_id == 50256
+    assert tok.eod == 50256
+
+
+def test_null_tokenizer_eos_property():
+    cfg = TokenizerConfig(tokenizer_type="NullTokenizer", vocab_size=10)
+    tok = build_tokenizer(cfg)
+    assert tok.eos == 9
+    assert tok.eos_id == 9
+    assert tok.eod == 9
+
+
+@pytest.mark.skipif(not hasattr(CustomTikTokenizer, "__init__"), reason="CustomTikTokenizer not available")
+def test_tiktokenizer_eos_property(tmp_path):
+    try:
+        import tiktoken  # noqa: F401
+    except Exception:
+        pytest.skip("tiktoken not installed")
+
+    vocab = [
+        {"rank": 0, "token_bytes": "AA==", "token_str": "\u0000"},
+        {"rank": 1, "token_bytes": "AQ==", "token_str": "\u0001"},
+    ]
+    p = tmp_path / "tiny_vocab.json"
+    p.write_text(json.dumps(vocab), encoding="utf-8")
+
+    # Minimal consistent vocab_size = special_tokens(3) + mergeable_ranks(len(vocab)=2) = 5
+    cfg = TokenizerConfig(
+        tokenizer_type="TikTokenizer",
+        tokenizer_model=str(p),
+        vocab_size=5,
+        tiktoken_pattern="v2",
+        tiktoken_num_special_tokens=3,
+        tiktoken_special_tokens=["<unk>", "<s>", "</s>"],
+    )
+    tok = build_tokenizer(cfg)
+    # Validate consistency and mapping
+    assert tok.eos_id == tok.eos
+    assert tok.vocab["</s>"] == tok.eos
+
+
+def test_null_multimodal_tokenizer_basic_properties():
+    cfg = TokenizerConfig(tokenizer_type="NullMultimodalTokenizer", vocab_size=127)
+    tok = build_tokenizer(cfg)
+
+    assert tok.vocab_size == 127
+    assert tok.eod == 126
+    assert tok.eos == 126
+
+
+def test_null_multimodal_tokenizer_tokenize_detokenize_offsets():
+    cfg = TokenizerConfig(tokenizer_type="NullMultimodalTokenizer", vocab_size=100)
+    tok = build_tokenizer(cfg)
+
+    s = "1 23 456"
+    ids = tok.tokenize(s)
+    assert ids == [1, 23, 456]
+    text = tok.detokenize(ids)
+    assert text == s
+
+    offs = tok.offsets(ids, s)
+    assert offs == [0, 2, 5]
+
+
+def test_null_multimodal_tokenizer_image_token_default():
+    cfg = TokenizerConfig(tokenizer_type="NullMultimodalTokenizer", vocab_size=100)
+    tok = build_tokenizer(cfg)
+
+    tokens = "1  " + tok._image_token + "  2"
+    ids = tok.convert_tokens_to_ids(tokens)
+    assert isinstance(ids, list)
+    assert len(ids) == 3
+    assert ids[0] == 1 and ids[-1] == 2
+    assert ids[1] == tok._image_token_id
+
+
+def test_null_multimodal_tokenizer_image_token_override():
+    cfg = TokenizerConfig(tokenizer_type="NullMultimodalTokenizer", vocab_size=100)
+    tok = build_tokenizer(cfg)
+
+    tok._image_token = "<<img>>"
+    tok._image_token_id = 77
+
+    tokens = "3  <<img>>  4"
+    ids = tok.convert_tokens_to_ids(tokens)
+    assert ids == [3, 77, 4]


### PR DESCRIPTION
improve test coverage for eos property + null multimodal tokenizer introduced in sync #969 