### PR TITLE
Cleanup ci test import fallback

### DIFF
--- a/tests/end_to_end_tests/train_from_recipe.py
+++ b/tests/end_to_end_tests/train_from_recipe.py
@@ -414,7 +414,6 @@ def main():
     try:
         family_pkg = importlib.import_module(family_pkg_path)
         config_builder = getattr(family_pkg, recipe_attr)
-        logging.info(f"Successfully loaded recipe function: {family_pkg_path}.{recipe_attr}")
     except (ImportError, AttributeError) as e:
         raise ValueError(
             f"Unable to import recipe '{recipe_attr}' from '{family_pkg_path}'. "


### PR DESCRIPTION
Depends on https://github.com/NVIDIA-NeMo/Megatron-Bridge/pull/1038 and #1007 

now that the recipe imports are all updated to use the same style, we can remove the fallback support in `train_from_recipe` for testing