### PR TITLE
feat: Dependabot automerge if successful

### DIFF
--- a/.github/workflows/_update_dependencies.yml
+++ b/.github/workflows/_update_dependencies.yml
@@ -107,7 +107,7 @@ jobs:
           git_user_signingkey: true
           git_commit_gpgsign: true
 
-      - name: Create Bump PR: Commit and push changes
+      - name: Create Bump PR Commit and push changes
         env:
           GH_TOKEN: ${{ secrets.PAT }}
         run: |


### PR DESCRIPTION
Dependabot : automerge PR if checks all complete successful 


Workflow tested worked successfully here:
https://github.com/NVIDIA-NeMo/Megatron-Bridge/actions/runs/18758427697/job/54498962342

it did not merge PR only because of PR merge conflicts at the very end of the workflow
