### PR TITLE
don't hardcode val dataloader type for finetuning/external dataloaders

### DIFF
--- a/src/megatron/bridge/data/loaders.py
+++ b/src/megatron/bridge/data/loaders.py
@@ -22,7 +22,7 @@ from megatron.core.rerun_state_machine import RerunDataIterator
 from torch.utils.data import DataLoader
 
 from megatron.bridge.data.samplers import build_pretraining_data_loader
-from megatron.bridge.training.config import ConfigContainer
+from megatron.bridge.training.config import ConfigContainer, GPTDatasetConfig
 from megatron.bridge.training.state import TrainState
 from megatron.bridge.training.utils.sig_utils import DistributedSignalHandler
 from megatron.bridge.utils.common_utils import print_rank_0
@@ -223,10 +223,11 @@ def build_train_valid_test_data_loaders(
             global_batch_size=cfg.train.global_batch_size,
         )
     elif cfg.train.eval_iters > 0:
+        val_dataloader_type = "cyclic" if isinstance(cfg.dataset, GPTDatasetConfig) else cfg.dataset.dataloader_type
         valid_dataloader = build_pretraining_data_loader(
             valid_ds,
             train_state.consumed_valid_samples,
-            "cyclic",
+            val_dataloader_type,
             cfg.train.micro_batch_size,
             cfg.dataset.num_workers,
             cfg.dataset.data_sharding,


### PR DESCRIPTION
`build_pretraining_data_loader` may attach a sampler based on the dataloader type: https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/8e440bb767f16a2b4c52628d673921ceee4b8fd9/src/megatron/bridge/data/samplers.py#L65-L91

for running evaluation during training, the "cyclic" dataloader type is currently hardcoded, which is unexpected - part of https://github.com/NVIDIA-NeMo/Megatron-Bridge/issues/894

this PR passes the dataloader type through unless a pretraining dataset config is used, which continues to default to "cyclic" 