### PR TITLE
add unit test coverage for dumping config to file before training

### DIFF
--- a/src/megatron/bridge/training/setup.py
+++ b/src/megatron/bridge/training/setup.py
@@ -293,16 +293,7 @@ def setup(
     # Print setup timing.
     print_rank_0("done with setup ...")
     timers.log(["model-and-optimizer-setup", "train/valid/test-data-iterators-setup"], barrier=True)
-    if get_rank_safe() == 0:
-        if cfg.logger.save_config_filepath is not None:
-            try:
-                cfg.to_yaml(cfg.logger.save_config_filepath)
-            except Exception as e:
-                print_rank_0(f"Error saving config to file {cfg.logger.save_config_filepath}: {e}")
-        # Print final resolved/updated/overridden configs
-        print("------- Task Configuration -------")
-        cfg.print_yaml()
-        print("----------------------------------")
+    maybe_log_and_save_config(cfg)
 
     return SetupOutput(
         state,
@@ -478,3 +469,20 @@ def _validate_and_set_vocab_size(model_vocab_size: Optional[int], tokenizer_voca
                 f" {model_vocab_size - tokenizer_vocab_size}."
             )
         return model_vocab_size, False
+
+
+def maybe_log_and_save_config(cfg: ConfigContainer) -> None:
+    """Save configuration to disk and log it on rank 0."""
+
+    if get_rank_safe() != 0:
+        return
+
+    if cfg.logger.save_config_filepath is not None:
+        try:
+            cfg.to_yaml(cfg.logger.save_config_filepath)
+        except Exception as e:
+            print_rank_0(f"Error saving config to file {cfg.logger.save_config_filepath}: {e}")
+
+    print("------- Task Configuration -------")
+    cfg.print_yaml()
+    print("----------------------------------")


### PR DESCRIPTION
# What does this PR do ?

Follow up to https://github.com/NVIDIA-NeMo/Megatron-Bridge/pull/1190
Adds unit test coverage by splitting out saving/printing as its own function

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
