### PR TITLE
align perf naming w/ base recipe

### DIFF
--- a/scripts/performance/configs/deepseek/deepseek_llm_pretrain.py
+++ b/scripts/performance/configs/deepseek/deepseek_llm_pretrain.py
@@ -58,8 +58,8 @@ def deepseek_v3_gb300_256gpus_config(precision: str = "bf16", fp8_recipe: str = 
     cfg = pretrain_config(
         mock=True,
         precision_config=precision_config,
-        pipeline_parallelism=base_cfg.pipeline_model_parallel_size,
-        virtual_pipeline_parallelism=base_cfg.virtual_pipeline_model_parallel_size,
+        pipeline_model_parallel_size=base_cfg.pipeline_model_parallel_size,
+        virtual_pipeline_model_parallel_size=base_cfg.virtual_pipeline_model_parallel_size,
         enable_deepep=False,
         layout=None,
     )
@@ -90,8 +90,8 @@ def deepseek_v3_gb200_256gpus_config(precision: str = "bf16", fp8_recipe: str = 
     cfg = pretrain_config(
         mock=True,
         precision_config=precision_config,
-        pipeline_parallelism=base_cfg.pipeline_model_parallel_size,
-        virtual_pipeline_parallelism=base_cfg.virtual_pipeline_model_parallel_size,
+        pipeline_model_parallel_size=base_cfg.pipeline_model_parallel_size,
+        virtual_pipeline_model_parallel_size=base_cfg.virtual_pipeline_model_parallel_size,
         enable_deepep=False,
         layout=None,
     )
@@ -122,8 +122,8 @@ def deepseek_v3_b200_256gpus_config(precision: str = "bf16", fp8_recipe: str = "
     cfg = pretrain_config(
         mock=True,
         precision_config=precision_config,
-        pipeline_parallelism=base_cfg.pipeline_model_parallel_size,
-        virtual_pipeline_parallelism=base_cfg.virtual_pipeline_model_parallel_size,
+        pipeline_model_parallel_size=base_cfg.pipeline_model_parallel_size,
+        virtual_pipeline_model_parallel_size=base_cfg.virtual_pipeline_model_parallel_size,
         enable_deepep=False,
         layout=None,
     )
@@ -149,8 +149,8 @@ def deepseek_v3_h100_1024gpus_config(precision: str = "bf16", fp8_recipe: str = 
     cfg = pretrain_config(
         mock=True,
         precision_config=precision_config,
-        pipeline_parallelism=base_cfg.pipeline_model_parallel_size,
-        virtual_pipeline_parallelism=base_cfg.virtual_pipeline_model_parallel_size,
+        pipeline_model_parallel_size=base_cfg.pipeline_model_parallel_size,
+        virtual_pipeline_model_parallel_size=base_cfg.virtual_pipeline_model_parallel_size,
         enable_deepep=True,
         layout="Et|(tt|)*30mL",
     )


### PR DESCRIPTION
# What does this PR do ?

Change arg names in perf script to align the name changes in base recipe for DeepSeekV3

# Changelog

- `pipeline_parallelism` -> `pipeline_model_parallel_size`
- `virtual_pipeline_parallelism` -> `virtual_pipeline_model_parallel_size`

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to https://github.com/NVIDIA-NeMo/Megatron-Bridge/pull/1199
