### PR TITLE
Gemma3SelfAttention.forward() got an unexpected keyword argument 'rotary_pos_cos_sin' fix

### DIFF
--- a/src/megatron/bridge/models/gemma/gemma3_provider.py
+++ b/src/megatron/bridge/models/gemma/gemma3_provider.py
@@ -252,6 +252,7 @@ class Gemma3SelfAttention(SelfAttention):
         rotary_pos_emb: Optional[Union[Tensor, Tuple[Tensor, Tensor]]] = None,
         rotary_pos_cos: Optional[Tensor] = None,
         rotary_pos_sin: Optional[Tensor] = None,
+        rotary_pos_cos_sin: Optional[Tensor] = None,
         attention_bias: Optional[Tensor] = None,
         packed_seq_params: Optional[PackedSeqParams] = None,
         sequence_len_offset: Optional[int] = None,
@@ -260,7 +261,7 @@ class Gemma3SelfAttention(SelfAttention):
     ) -> Tuple[Tensor, Tensor]:
         """Switch to either local or global rope embedding before forward"""
         assert isinstance(rotary_pos_emb, tuple)
-        assert rotary_pos_cos is None and rotary_pos_sin is None
+        assert rotary_pos_cos is None and rotary_pos_sin is None and rotary_pos_cos_sin is None
 
         if _is_local_attn_layer(self.layer_number, self.config.interleaved_attn_pattern):
             final_rotary_pos_emb = rotary_pos_emb[0]


### PR DESCRIPTION
# What does this PR do ?

This PR fixed an error `Gemma 3 VL SFT fails with TypeError: Gemma3SelfAttention.forward() got an unexpected keyword argument 'rotary_pos_cos_sin'` encountered when running a finetuning script adapted from https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/examples/recipes/qwen_vl/finetune_qwen25_vl.py. A call to self-attention in Megatron Core expects the module to accept this argument.

Modified test script and required override config are in attachments.

# Changelog

- Modifies `Gemma3SelfAttention`'s `forward` method to accept `rotary_pos_cos_sin` argument.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
[gemma3_vl_pretrain_override_example.yaml](https://github.com/user-attachments/files/23422241/gemma3_vl_pretrain_override_example.yaml)
[finetune_gemma3_vl.py](https://github.com/user-attachments/files/23422243/finetune_gemma3_vl.py)
