### PR TITLE
cg_scope valid list and default none

### DIFF
--- a/scripts/performance/argument_parser.py
+++ b/scripts/performance/argument_parser.py
@@ -55,7 +55,7 @@ def is_cuda_graph_impl_valid(arg):
 
 def is_cuda_graph_scope_valid(arg):
     """Validate the CUDA graph scope argument."""
-    choices = ["full_iteration", "full", "attn"]
+    choices = ["full_iteration", "full", "attn", None]
     if arg.lower() in choices:
         if arg.lower() == "full_iteration":
             logger.warning("Make sure cuda_graph_impl is `local`. You can set it using `--cuda_graph_impl local`")
@@ -295,7 +295,7 @@ def parse_cli_args():
         type=is_cuda_graph_scope_valid,
         choices=["full_iteration", "full", "attn"],
         required=False,
-        default="full",
+        default=None,
     )
     parser.add_argument(
         "-tp",

--- a/scripts/performance/argument_parser.py
+++ b/scripts/performance/argument_parser.py
@@ -55,13 +55,12 @@ def is_cuda_graph_impl_valid(arg):
 def is_cuda_graph_scope_valid(arg):
     """Validate the CUDA graph scope argument."""
     args = arg.split(",")
-    args = [a.lower() for a in args]
     if all(a in VALID_CUDA_GRAPH_SCOPES for a in args):
         return args
     else:
         raise ValueError(
             f"Invalid value for cuda_graph_scope: {arg}. Valid options are: {VALID_CUDA_GRAPH_SCOPES}. "
-            "If you want to disable CUDA graphs, set `--cuda_graph_impl none`"
+            "Comma separated list of scopes is allowed."
         )
 
 
@@ -291,8 +290,7 @@ def parse_cli_args():
     )
     parser.add_argument(
         "--cuda_graph_scope",
-        help=f"Cuda graph scope. Options- {VALID_CUDA_GRAPH_SCOPES}. "
-        "If you want to disable CUDA graphs, set `--cuda_graph_impl none`",
+        help=f"Cuda graph scope. Options- {VALID_CUDA_GRAPH_SCOPES}. Comma separated list of scopes is allowed.",
         type=is_cuda_graph_scope_valid,
         required=False,
         default=None,

--- a/scripts/performance/argument_parser.py
+++ b/scripts/performance/argument_parser.py
@@ -25,6 +25,9 @@ logger: logging.Logger = logging.getLogger(__name__)
 DEFAULT_NEMO_CACHE_HOME = Path.home() / ".cache" / "nemo"
 DEFAULT_NEMO_HOME = os.getenv("NEMO_HOME", DEFAULT_NEMO_CACHE_HOME)
 
+VALID_CUDA_GRAPH_IMPLS = ["none", "local", "transformer_engine"]
+VALID_CUDA_GRAPH_SCOPES = ["full_iteration", "attn", "mlp", "moe", "moe_router", "moe_preprocess", "mamba"]
+
 
 def bool_arg(arg):
     """Convert a string CLI value to a boolean."""
@@ -43,25 +46,23 @@ def list_of_strings(arg):
 
 def is_cuda_graph_impl_valid(arg):
     """Validate and normalize the CUDA graph implementation argument."""
-    choices = ["none", "None", "local", "te", "TE", "transformer_engine"]
-    if arg.lower() in choices:
-        arg = arg.lower()
-        if arg == "te":
-            arg = "transformer_engine"
+    if arg in VALID_CUDA_GRAPH_IMPLS:
         return arg
     else:
-        raise ValueError(f"Invalid value for cuda_graph_impl: {arg}. Valid options are: {choices}")
+        raise ValueError(f"Invalid value for cuda_graph_impl: {arg}. Valid options are: {VALID_CUDA_GRAPH_IMPLS}")
 
 
 def is_cuda_graph_scope_valid(arg):
     """Validate the CUDA graph scope argument."""
-    choices = ["full_iteration", "full", "attn", None]
-    if arg.lower() in choices:
-        if arg.lower() == "full_iteration":
-            logger.warning("Make sure cuda_graph_impl is `local`. You can set it using `--cuda_graph_impl local`")
-        return arg
+    args = arg.split(",")
+    args = [a.lower() for a in args]
+    if all(a in VALID_CUDA_GRAPH_SCOPES for a in args):
+        return args
     else:
-        raise ValueError(f"Invalid value for cuda_graph_scope: {arg}. Valid options are: {choices}")
+        raise ValueError(
+            f"Invalid value for cuda_graph_scope: {arg}. Valid options are: {VALID_CUDA_GRAPH_SCOPES}. "
+            "If you want to disable CUDA graphs, set `--cuda_graph_impl none`"
+        )
 
 
 def lower_str(arg):
@@ -283,17 +284,16 @@ def parse_cli_args():
     )
     parser.add_argument(
         "--cuda_graph_impl",
-        help="Cuda graph implementation. Options- 'local', 'te', 'TE', 'transformer_engine'.",
+        help=f"Cuda graph implementation. Options- {', '.join(VALID_CUDA_GRAPH_IMPLS)}.",
         type=is_cuda_graph_impl_valid,
-        choices=["none", "None", "local", "te", "TE", "transformer_engine"],
         required=False,
         default=None,
     )
     parser.add_argument(
         "--cuda_graph_scope",
-        help="Cuda graph scope. Options- 'full_iteration', 'full', 'attn'.",
+        help=f"Cuda graph scope. Options- {VALID_CUDA_GRAPH_SCOPES}. "
+        "If you want to disable CUDA graphs, set `--cuda_graph_impl none`",
         type=is_cuda_graph_scope_valid,
-        choices=["full_iteration", "full", "attn"],
         required=False,
         default=None,
     )

--- a/scripts/performance/configs/llama3/llama3_llm_pretrain.py
+++ b/scripts/performance/configs/llama3/llama3_llm_pretrain.py
@@ -232,5 +232,6 @@ def llama3_8b_h100_config(precision: str = "bf16", fp8_recipe: str = "cs") -> Co
     if cfg.ddp.use_megatron_fsdp:
         cfg.ddp.nccl_ub = True
         cfg.model.gradient_accumulation_fusion = False  # Disabled to avoid functional errors
+        cfg.ddp.keep_fp8_transpose_cache = True
 
     return cfg

--- a/scripts/performance/utils/helpers.py
+++ b/scripts/performance/utils/helpers.py
@@ -66,9 +66,11 @@ def set_workload_base_configs(cfg: ConfigContainer, settings: WorkloadBaseConfig
 
     if settings.use_megatron_fsdp:
         set_megatron_fsdp_overrides(cfg)
-    if settings.cuda_graph_impl is not None:
+    if settings.cuda_graph_impl is not None or settings.cuda_graph_scope is not None:
         set_cuda_graph_overrides(
-            cfg, cuda_graph_impl=settings.cuda_graph_impl, cuda_graph_scope=settings.cuda_graph_scope
+            cfg,
+            cuda_graph_impl=settings.cuda_graph_impl,
+            cuda_graph_scope=settings.cuda_graph_scope,
         )
     set_recompute_overrides(
         cfg,
@@ -137,12 +139,13 @@ def set_cuda_graph_overrides(
         else:  # this condition ensures we unset in case of user override to "none" from default
             recipe.rng.te_rng_tracker = recipe.model.use_te_rng_tracker = False
 
-    if cuda_graph_impl == "transformer_engine":
-        assert cuda_graph_scope in ["full", "attn"], (
-            f"Invalid cuda graph scope: {cuda_graph_scope}. Valid options are: full, attn"
-        )
+        if cuda_graph_impl == "transformer_engine":
+            assert cuda_graph_scope in ["full", "attn"], (
+                f"Invalid cuda graph scope: {cuda_graph_scope}. Valid options are: full, attn"
+            )
 
-    recipe.model.cuda_graph_scope = cuda_graph_scope
+    if cuda_graph_scope is not None:
+        recipe.model.cuda_graph_scope = cuda_graph_scope
 
 
 def set_recompute_overrides(
@@ -187,7 +190,12 @@ def set_user_overrides(recipe: ConfigContainer, kwargs: Dict[str, Any]) -> None:
 
     cuda_graph_impl = kwargs.get("cuda_graph_impl")
     cuda_graph_scope = kwargs.get("cuda_graph_scope")
-    set_cuda_graph_overrides(recipe, cuda_graph_impl=cuda_graph_impl, cuda_graph_scope=cuda_graph_scope)
+    if cuda_graph_impl is not None or cuda_graph_scope is not None:
+        set_cuda_graph_overrides(
+            recipe,
+            cuda_graph_impl=cuda_graph_impl,
+            cuda_graph_scope=cuda_graph_scope,
+        )
 
     recompute_num_layers = kwargs.get("recompute_num_layers")
     cpu_offloading_num_layers = kwargs.get("activation_offload_layers")

--- a/scripts/performance/utils/helpers.py
+++ b/scripts/performance/utils/helpers.py
@@ -141,7 +141,7 @@ def set_cuda_graph_overrides(
 
         if cuda_graph_impl == "transformer_engine":
             valid_te_scopes = ["attn", "mlp", "moe", "moe_router", "moe_preprocess", "mamba"]
-            assert cuda_graph_scope in valid_te_scopes, (
+            assert all(scope in valid_te_scopes for scope in cuda_graph_scope), (
                 f"Invalid cuda graph scope: {cuda_graph_scope}. Valid options are: {valid_te_scopes}"
             )
 

--- a/scripts/performance/utils/helpers.py
+++ b/scripts/performance/utils/helpers.py
@@ -140,8 +140,9 @@ def set_cuda_graph_overrides(
             recipe.rng.te_rng_tracker = recipe.model.use_te_rng_tracker = False
 
         if cuda_graph_impl == "transformer_engine":
-            assert cuda_graph_scope in ["full", "attn"], (
-                f"Invalid cuda graph scope: {cuda_graph_scope}. Valid options are: full, attn"
+            valid_te_scopes = ["attn", "mlp", "moe", "moe_router", "moe_preprocess", "mamba"]
+            assert cuda_graph_scope in valid_te_scopes, (
+                f"Invalid cuda graph scope: {cuda_graph_scope}. Valid options are: {valid_te_scopes}"
             )
 
     if cuda_graph_scope is not None:

--- a/scripts/performance/utils/utils.py
+++ b/scripts/performance/utils/utils.py
@@ -46,7 +46,7 @@ class WorkloadBaseConfig:
 
     use_megatron_fsdp: Optional[bool] = None
     cuda_graph_impl: Optional[str] = None
-    cuda_graph_scope: str = "full"
+    cuda_graph_scope: Optional[str] = None
     cpu_offloading_num_layers: Optional[int] = None
     recompute_num_layers: Optional[int] = None
     recompute_modules: Optional[List[str]] = None


### PR DESCRIPTION
# What does this PR do ?

- `cuda_graph_scope` has default value of `None`
- `cuda_graph_scope` can be a list of strings based on the [dev branch in Megatron-LM](https://github.com/NVIDIA/Megatron-LM/blob/dev/megatron/core/transformer/transformer_config.py#L693) 
    - changed from `str` validity 

# Changelog

```
VALID_CUDA_GRAPH_SCOPES = ["full_iteration", "attn", "mlp", "moe", "moe_router", "moe_preprocess", "mamba"]

parser.add_argument(
        "--cuda_graph_scope",
        help=f"Cuda graph scope. Options- {VALID_CUDA_GRAPH_SCOPES}. Comma separated list of scopes is allowed.",
        type=is_cuda_graph_scope_valid,
        required=False,
        default=None,
)
```

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
