### PR TITLE
fix: set default value for `cuda_graph_impl`

### DIFF
--- a/src/megatron/bridge/models/gpt_provider.py
+++ b/src/megatron/bridge/models/gpt_provider.py
@@ -167,6 +167,7 @@ class GPTModelProvider(TransformerConfig, ModelProviderMixin[MCoreGPTModel]):
 
     # Additional parameters that might be needed
     init_model_with_meta_device: bool = False
+    cuda_graph_impl: Literal["none", "local", "te", "transformer_engine"] = "none"
     use_te_rng_tracker: bool = False
     virtual_pipeline_model_parallel_size: Optional[int] = None
     account_for_embedding_in_pipeline_split: bool = False


### PR DESCRIPTION
# What does this PR do ?

Set default value for `cuda_graph_impl` according to https://github.com/NVIDIA/Megatron-LM/blob/1f6cde85d23ff0c307a47bbdd8bfd778b95a161f/megatron/core/transformer/transformer_config.py#L646, as this is needed in:

https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/b94ef9c73a95de8655da8347b999413183d423eb/src/megatron/bridge/models/gpt_provider.py#L199

So that users don't need to pass it manually to the provider everytime if they don't want to set it


```log
  File "megatron/bridge/models/model_provider.py", line 179, in provide_distributed_model
    model = get_model(
            ^^^^^^^^^^
  File "megatron/bridge/models/model_provider.py", line 524, in get_model
    model = _create_model(model_provider, model_type)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "megatron/bridge/models/model_provider.py", line 630, in _create_model
    model = model_provider.provide(
            ^^^^^^^^^^^^^^^^^^^^^^^
  File "megatron/bridge/models/gpt_provider.py", line 199, in provide
    if self.cuda_graph_impl != "none":
       ^^^^^^^^^^^^^^^^^^^^
AttributeError: 'Qwen2ModelProvider' object has no attribute 'cuda_graph_impl'. Did you mean: 'cuda_graph_scope'?. Did you mean: '_return_value'?
```

# Changelog

- Set default value for `cuda_graph_impl` to be `none`

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [X] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
