### PR TITLE
[doc] fix: remove `network_alpha` args that doesn't exist in the codebase

### DIFF
--- a/docs/training/peft.md
+++ b/docs/training/peft.md
@@ -62,7 +62,6 @@ lora_config = LoRA(
     dim=16,                    # Rank of adaptation
     alpha=32,                  # Scaling parameter  
     dropout=0.1,               # Dropout rate
-    network_alpha=None,        # Network alpha for scaling
 )
 ```
 


### PR DESCRIPTION
# What does this PR do ?

Remove `network_alpha` args as it never exists in the codebase

# Changelog

- Remove `network_alpha` args when initialize `LoRA` in the documents

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [X] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [X] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
