### PR TITLE
fix: packed sequence support for cp > 1

### DIFF
--- a/src/megatron/bridge/data/datasets/sft.py
+++ b/src/megatron/bridge/data/datasets/sft.py
@@ -887,19 +887,6 @@ class GPTSFTPackedDataset(GPTSFTDataset):
             # target length (2048, 4096, 8192), so there is very minimal padding
             max_length = max(len(length) for length in input_ids)
             max_length = min(self.max_seq_length, self._ceil_to_nearest(max_length, self.pad_seq_length_to_mult))
-
-        # For Context Parallel > 1, ensure max_length is divisible by 2 * cp_size
-        # This is required by get_batch_on_this_cp_rank which splits sequences across CP ranks
-        from megatron.core import parallel_state
-
-        if parallel_state.is_initialized():
-            cp_size = parallel_state.get_context_parallel_world_size()
-            if cp_size > 1:
-                cp_divisor = 2 * cp_size
-                if max_length % cp_divisor != 0:
-                    max_length = ((max_length + cp_divisor - 1) // cp_divisor) * cp_divisor
-                    max_length = min(max_length, self.max_seq_length)
-
         assert max_length <= self.max_seq_length
 
         position_ids: list[list[int]] = []

--- a/src/megatron/bridge/training/gpt_step.py
+++ b/src/megatron/bridge/training/gpt_step.py
@@ -108,9 +108,12 @@ def get_batch(
         use_mtp,
         getattr(cfg.dataset, "skip_getting_attention_mask_from_dataset", True),
     )
+    packed_seq_metadata_keys = {"cu_seqlens", "cu_seqlens_argmin", "max_seqlen"}
+    packed_metadata = {k: batch.pop(k) for k in packed_seq_metadata_keys if k in batch}
 
-    # slice batch along sequence dimension for context parallelism
     batch = get_batch_on_this_cp_rank(batch)
+
+    batch.update(packed_metadata)
 
     return (
         batch["tokens"],


### PR DESCRIPTION
# What does this PR do ?

Fixes https://github.com/NVIDIA-NeMo/Megatron-Bridge/issues/1292

This excludes packed sequence metadata keys like `cu_seqlens` from being passed to `get_batch_on_this_cp_rank` 

To test: 
- Re-ran example provided in #1292 to confirm training works as expected
- #861 will add more functional testing for packed sequences

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.
