### PR TITLE
fix: sequence_parallelism argname change

### DIFF
--- a/src/megatron/bridge/recipes/gpt_oss/gpt_oss.py
+++ b/src/megatron/bridge/recipes/gpt_oss/gpt_oss.py
@@ -103,7 +103,7 @@ class GPTOSSFinetuneKwargs(TypedDict, total=False):
     virtual_pipeline_model_parallel_size: Optional[int]
     context_parallel_size: int
     expert_model_parallel_size: Optional[int]
-    sequence_parallelism: bool
+    sequence_parallel: bool
     use_megatron_fsdp: bool
     # Finetuning specifics
     pretrained_checkpoint: Optional[str]
@@ -136,7 +136,7 @@ def gpt_oss_20b_pretrain_config(**user_kwargs: Unpack[GPTOSSCommonKwargs]) -> Co
         "tensor_model_parallel_size": 1,
         "pipeline_model_parallel_size": 4,
         "expert_model_parallel_size": 2,
-        "sequence_parallelism": False,
+        "sequence_parallel": False,
         "use_null_tokenizer": True,
     }
     kwargs: GPTOSSCommonKwargs = {**recommended, **user_kwargs}
@@ -150,7 +150,7 @@ def gpt_oss_120b_pretrain_config(**user_kwargs: Unpack[GPTOSSCommonKwargs]) -> C
         "tensor_model_parallel_size": 1,
         "pipeline_model_parallel_size": 4,
         "expert_model_parallel_size": 8,
-        "sequence_parallelism": False,
+        "sequence_parallel": False,
         "use_null_tokenizer": True,
     }
     kwargs: GPTOSSCommonKwargs = {**recommended, **user_kwargs}
@@ -372,7 +372,7 @@ def _gpt_oss_finetune_common(
     virtual_pipeline_model_parallel_size: Optional[int] = None,
     context_parallel_size: int = 1,
     expert_model_parallel_size: int = 1,
-    sequence_parallelism: bool = False,
+    sequence_parallel: bool = False,
     use_megatron_fsdp: bool = False,
     # Finetuning-specific params
     pretrained_checkpoint: Optional[str] = None,
@@ -417,7 +417,7 @@ def _gpt_oss_finetune_common(
     model_cfg.virtual_pipeline_model_parallel_size = virtual_pipeline_model_parallel_size
     model_cfg.context_parallel_size = context_parallel_size
     model_cfg.expert_model_parallel_size = expert_model_parallel_size
-    model_cfg.sequence_parallel = sequence_parallelism
+    model_cfg.sequence_parallel = sequence_parallel
     model_cfg.seq_length = seq_length
 
     # Optimizer and LR scheduler


### PR DESCRIPTION
# What does this PR do ?

```
ain_fp8_mx/0   File "/opt/Megatron-Bridge/src/megatron/bridge/recipes/gpt_oss/gpt_oss.py", line 157, in gpt_oss_120b_pretrain_config
ain_fp8_mx/0 ^^^^^^^
ain_fp8_mx/0     return _gpt_oss_common(**kwargs)
ain_fp8_mx/0     recipe = get_model_recipe(model_name, model_size, gpu, compute_dtype)
ain_fp8_mx/0  ^^^^^^^^^^
ain_fp8_mx/0 TypeError: _gpt_oss_common() got an unexpected keyword argument 'sequence_parallelism'
ain_fp8_mx/0 TypeError: _gpt_oss_common() got an unexpected keyword argument 'sequence_parallelism'
ain_fp8_mx/0                   ^^^^^^    ^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ain_fp8_mx/0 TypeError^^^^^^
```

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
