### PR TITLE
Add deprecation warnings for mamba2

### DIFF
--- a/src/megatron/bridge/models/mamba/mamba_provider.py
+++ b/src/megatron/bridge/models/mamba/mamba_provider.py
@@ -141,7 +141,11 @@ class MambaModelProvider(TransformerConfig, ModelProviderMixin[MCoreMambaModel])
 
 @dataclass
 class MambaModelProvider130M(MambaModelProvider):
-    """Configuration for a 130M parameter Mamba model."""
+    """Configuration for a 130M parameter Mamba model.
+
+    Deprecated:
+        This class is deprecated and will be removed in a future release.
+    """
 
     hybrid_override_pattern: str = "M" * 24
     num_layers: int = 24
@@ -151,10 +155,18 @@ class MambaModelProvider130M(MambaModelProvider):
     ffn_hidden_size: int = 768
     make_vocab_size_divisible_by: int = 16
 
+    def finalize(self) -> None:
+        super().finalize()
+        _warn_class_deprecated("MambaModelProvider130M")
+
 
 @dataclass
 class MambaModelProvider370M(MambaModelProvider):
-    """Configuration for a 370M parameter Mamba model."""
+    """Configuration for a 370M parameter Mamba model.
+
+    Deprecated:
+        This class is deprecated and will be removed in a future release.
+    """
 
     hybrid_override_pattern: str = "M" * 48
     num_layers: int = 48
@@ -164,10 +176,18 @@ class MambaModelProvider370M(MambaModelProvider):
     ffn_hidden_size: int = 1024
     make_vocab_size_divisible_by: int = 16
 
+    def finalize(self) -> None:
+        super().finalize()
+        _warn_class_deprecated("MambaModelProvider370M")
+
 
 @dataclass
 class MambaModelProvider780M(MambaModelProvider):
-    """Configuration for a 780M parameter Mamba model."""
+    """Configuration for a 780M parameter Mamba model.
+
+    Deprecated:
+        This class is deprecated and will be removed in a future release.
+    """
 
     hybrid_override_pattern: str = "M" * 48
     num_layers: int = 48
@@ -177,10 +197,18 @@ class MambaModelProvider780M(MambaModelProvider):
     ffn_hidden_size: int = 1536
     make_vocab_size_divisible_by: int = 16
 
+    def finalize(self) -> None:
+        super().finalize()
+        _warn_class_deprecated("MambaModelProvider780M")
+
 
 @dataclass
 class MambaModelProvider1P3B(MambaModelProvider):
-    """Configuration for a 1.3B parameter Mamba model."""
+    """Configuration for a 1.3B parameter Mamba model.
+
+    Deprecated:
+        This class is deprecated and will be removed in a future release.
+    """
 
     hybrid_override_pattern: str = "M" * 48
     num_layers: int = 48
@@ -190,10 +218,18 @@ class MambaModelProvider1P3B(MambaModelProvider):
     ffn_hidden_size: int = 2048
     make_vocab_size_divisible_by: int = 16
 
+    def finalize(self) -> None:
+        super().finalize()
+        _warn_class_deprecated("MambaModelProvider1P3B")
+
 
 @dataclass
 class MambaModelProvider2P7B(MambaModelProvider):
-    """Configuration for a 2.7B parameter Mamba model."""
+    """Configuration for a 2.7B parameter Mamba model.
+
+    Deprecated:
+        This class is deprecated and will be removed in a future release.
+    """
 
     hybrid_override_pattern: str = "M" * 64
     num_layers: int = 64
@@ -203,10 +239,18 @@ class MambaModelProvider2P7B(MambaModelProvider):
     ffn_hidden_size: int = 2560
     make_vocab_size_divisible_by: int = 16
 
+    def finalize(self) -> None:
+        super().finalize()
+        _warn_class_deprecated("MambaModelProvider2P7B")
+
 
 @dataclass
 class NVIDIAMambaModelProvider8B(MambaModelProvider):
-    """Configuration for a 8B parameter Mamba model used in NVIDIA research."""
+    """Configuration for a 8B parameter Mamba model used in NVIDIA research.
+
+    Deprecated:
+        This class is deprecated and will be removed in a future release.
+    """
 
     hybrid_override_pattern: str = "M" * 56
     num_attention_heads: int = 32
@@ -217,10 +261,18 @@ class NVIDIAMambaModelProvider8B(MambaModelProvider):
     ffn_hidden_size: int = 4096
     make_vocab_size_divisible_by: int = 128
 
+    def finalize(self) -> None:
+        super().finalize()
+        _warn_class_deprecated("NVIDIAMambaModelProvider8B")
+
 
 @dataclass
 class NVIDIAMambaHybridModelProvider8B(MambaModelProvider):
-    """Configuration for a 8B parameter hybrid Mamba model used in NVIDIA research."""
+    """Configuration for a 8B parameter hybrid Mamba model used in NVIDIA research.
+
+    Deprecated:
+        This class is deprecated and will be removed in a future release.
+    """
 
     hybrid_override_pattern: str = "M-M-M--M-M*-M-M-M-M--M*-M-M-M-M-M*--M-M-M-M-M*-M--M-M-M-"
     num_layers: int = 56
@@ -231,6 +283,10 @@ class NVIDIAMambaHybridModelProvider8B(MambaModelProvider):
     num_attention_heads: int = 32
     num_query_groups: int = 8
     make_vocab_size_divisible_by: int = 128
+
+    def finalize(self) -> None:
+        super().finalize()
+        _warn_class_deprecated("NVIDIAMambaHybridModelProvider8B")
 
 
 # -----------------------------------------------------------------------------
@@ -244,6 +300,20 @@ def _warn_deprecated(old_cls: str, new_cls: str) -> None:
             f"{old_cls} is deprecated and will be removed in a future release. Use {new_cls} instead.",
             DeprecationWarning,
             stacklevel=2,
+        )
+
+
+def _warn_class_deprecated(cls_name: str) -> None:
+    """Log a deprecation warning for a class.
+
+    Args:
+        cls_name: The name of the deprecated class.
+    """
+    if get_rank_safe() == 0:
+        warnings.warn(
+            f"{cls_name} is deprecated and will be removed in a future release.",
+            DeprecationWarning,
+            stacklevel=4,
         )
 
 

--- a/src/megatron/bridge/recipes/mamba/mamba2.py
+++ b/src/megatron/bridge/recipes/mamba/mamba2.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import warnings
 
 import torch
 from typing_extensions import TypedDict, Unpack
@@ -91,7 +92,16 @@ class Mamba2CommonKwargs(TypedDict, total=False):
 
 
 def mamba2_130m_pretrain_config(**user_kwargs: Unpack[Mamba2CommonKwargs]) -> ConfigContainer:
-    """Return a pre-training config for Mamba2 130M."""
+    """Return a pre-training config for Mamba2 130M.
+
+    Deprecated:
+        This recipe is deprecated and will be removed in a future release.
+    """
+    warnings.warn(
+        "mamba2_130m_pretrain_config is deprecated and will be removed in a future release.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     recommended: Mamba2CommonKwargs = {
         "model_provider": MambaModelProvider130M,
         "tensor_model_parallel_size": 1,
@@ -105,7 +115,16 @@ def mamba2_130m_pretrain_config(**user_kwargs: Unpack[Mamba2CommonKwargs]) -> Co
 
 
 def mamba2_370m_pretrain_config(**user_kwargs: Unpack[Mamba2CommonKwargs]) -> ConfigContainer:
-    """Return a pre-training config for Mamba2 370M."""
+    """Return a pre-training config for Mamba2 370M.
+
+    Deprecated:
+        This recipe is deprecated and will be removed in a future release.
+    """
+    warnings.warn(
+        "mamba2_370m_pretrain_config is deprecated and will be removed in a future release.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     recommended: Mamba2CommonKwargs = {
         "model_provider": MambaModelProvider370M,
         "tensor_model_parallel_size": 1,
@@ -119,7 +138,16 @@ def mamba2_370m_pretrain_config(**user_kwargs: Unpack[Mamba2CommonKwargs]) -> Co
 
 
 def mamba2_780m_pretrain_config(**user_kwargs: Unpack[Mamba2CommonKwargs]) -> ConfigContainer:
-    """Return a pre-training config for Mamba2 780M."""
+    """Return a pre-training config for Mamba2 780M.
+
+    Deprecated:
+        This recipe is deprecated and will be removed in a future release.
+    """
+    warnings.warn(
+        "mamba2_780m_pretrain_config is deprecated and will be removed in a future release.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     recommended: Mamba2CommonKwargs = {
         "model_provider": MambaModelProvider780M,
         "tensor_model_parallel_size": 1,
@@ -133,7 +161,16 @@ def mamba2_780m_pretrain_config(**user_kwargs: Unpack[Mamba2CommonKwargs]) -> Co
 
 
 def mamba2_1p3b_pretrain_config(**user_kwargs: Unpack[Mamba2CommonKwargs]) -> ConfigContainer:
-    """Return a pre-training config for Mamba2 1.3B."""
+    """Return a pre-training config for Mamba2 1.3B.
+
+    Deprecated:
+        This recipe is deprecated and will be removed in a future release.
+    """
+    warnings.warn(
+        "mamba2_1p3b_pretrain_config is deprecated and will be removed in a future release.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     recommended: Mamba2CommonKwargs = {
         "model_provider": MambaModelProvider1P3B,
         "tensor_model_parallel_size": 1,
@@ -147,7 +184,16 @@ def mamba2_1p3b_pretrain_config(**user_kwargs: Unpack[Mamba2CommonKwargs]) -> Co
 
 
 def mamba2_2p7b_pretrain_config(**user_kwargs: Unpack[Mamba2CommonKwargs]) -> ConfigContainer:
-    """Return a pre-training config for Mamba2 2.7B."""
+    """Return a pre-training config for Mamba2 2.7B.
+
+    Deprecated:
+        This recipe is deprecated and will be removed in a future release.
+    """
+    warnings.warn(
+        "mamba2_2p7b_pretrain_config is deprecated and will be removed in a future release.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     recommended: Mamba2CommonKwargs = {
         "model_provider": MambaModelProvider2P7B,
         "tensor_model_parallel_size": 1,
@@ -161,7 +207,16 @@ def mamba2_2p7b_pretrain_config(**user_kwargs: Unpack[Mamba2CommonKwargs]) -> Co
 
 
 def mamba2_8b_pretrain_config(**user_kwargs: Unpack[Mamba2CommonKwargs]) -> ConfigContainer:
-    """Return a pre-training config for Mamba2 8B."""
+    """Return a pre-training config for Mamba2 8B.
+
+    Deprecated:
+        This recipe is deprecated and will be removed in a future release.
+    """
+    warnings.warn(
+        "mamba2_8b_pretrain_config is deprecated and will be removed in a future release.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     recommended: Mamba2CommonKwargs = {
         "model_provider": NVIDIAMambaModelProvider8B,
         "tensor_model_parallel_size": 8,
@@ -175,7 +230,16 @@ def mamba2_8b_pretrain_config(**user_kwargs: Unpack[Mamba2CommonKwargs]) -> Conf
 
 
 def mamba2_hybrid_8b_pretrain_config(**user_kwargs: Unpack[Mamba2CommonKwargs]) -> ConfigContainer:
-    """Return a pre-training config for Mamba2 Hybrid 8B."""
+    """Return a pre-training config for Mamba2 Hybrid 8B.
+
+    Deprecated:
+        This recipe is deprecated and will be removed in a future release.
+    """
+    warnings.warn(
+        "mamba2_hybrid_8b_pretrain_config is deprecated and will be removed in a future release.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     recommended: Mamba2CommonKwargs = {
         "model_provider": NVIDIAMambaHybridProvider8B,
         "tensor_model_parallel_size": 8,


### PR DESCRIPTION
# What does this PR do ?

These models have been superseded by newer hybrid model variants. This PR adds a deprecation warning for users that these model providers & recipes will be removed in the following release
# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
