### PR TITLE
fix: default to `nccl` comm overlap bootstrap backend

### DIFF
--- a/src/megatron/bridge/training/comm_overlap.py
+++ b/src/megatron/bridge/training/comm_overlap.py
@@ -380,7 +380,7 @@ class CommOverlapConfig:
 
     tp_comm_overlap: bool
     tp_comm_overlap_cfg: Optional[TransformerLayerTPOverlapCfg] = None
-    tp_comm_bootstrap_backend: Optional[str] = None
+    tp_comm_bootstrap_backend: Optional[str] = "nccl"
     overlap_p2p_comm: Optional[bool] = None
     batch_p2p_comm: Optional[bool] = None
     overlap_grad_reduce: Optional[bool] = None
@@ -415,8 +415,6 @@ class CommOverlapConfig:
             overlap_moe_expert_parallel_comm=self.overlap_moe_expert_parallel_comm,
             delay_wgrad_compute=self.delay_wgrad_compute,
         )
-        self.tp_comm_overlap_cfg = None
-        self.tp_comm_bootstrap_backend = None
 
     def _get_model_comm_overlap_cfgs(
         self,
@@ -432,7 +430,6 @@ class CommOverlapConfig:
         # Optimizations disabled by default, can be overriden by user
         comm_overlap_cfg.tp_comm_overlap = False
         comm_overlap_cfg.tp_comm_overlap_cfg = None
-        comm_overlap_cfg.tp_comm_bootstrap_backend = None
         comm_overlap_cfg.defer_embedding_wgrad_compute = False
         comm_overlap_cfg.wgrad_deferral_limit = -1
         comm_overlap_cfg.overlap_moe_expert_parallel_comm = False

--- a/tests/unit_tests/training/test_comm_overlap.py
+++ b/tests/unit_tests/training/test_comm_overlap.py
@@ -79,8 +79,6 @@ class TestMegatronCommOverlapConfig:
         cfg.finalize()
 
         assert cfg.tp_comm_overlap is True
-        assert cfg.tp_comm_overlap_cfg is None  # Should be reset to None in finalize()
-        assert cfg.tp_comm_bootstrap_backend is None  # Should be reset to None in finalize()
         assert cfg.user_comm_overlap_cfg.tp_comm_overlap is True
         assert isinstance(cfg.user_comm_overlap_cfg.tp_comm_overlap_cfg, TransformerLayerTPOverlapCfg)
 
@@ -440,7 +438,7 @@ class TestMegatronCommOverlapConfig:
         # Check that model config was updated correctly
         assert model_cfg.tp_comm_overlap is True
         assert model_cfg.tp_comm_overlap_cfg is None
-        assert model_cfg.tp_comm_bootstrap_backend is None
+        assert model_cfg.tp_comm_bootstrap_backend == "nccl"
 
     def test_tp_overlap_config_filters_none_values(self):
         """Test that None values are filtered from tp_comm_overlap_cfg dict."""


### PR DESCRIPTION
# What does this PR do ?

This PR updates the default for the `tp_comm_overlap_bootstrap_backend`.

Previously: `CommOverlapConfig.tp_comm_overlap_bootstrap_backend` defaulted to `None`. 

If users didn't explicitly specify this, then `user_comm_overlap_cfg.tp_comm_bootstrap_backend = None` and `_get_model_comm_overlap_cfgs()` set `comm_overlap_cfg.tp_comm_bootstrap_backend = None`

which ultimately led to `_apply_cfgs()` unconditionally copying `None` to `model_config.tp_comm_bootstrap_backend`

As a result, `model_config.tp_comm_overlap_bootstrap_backend` here was None: https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/742c10465d6570eb6c25cf6c64d23ea27acb52ea/src/megatron/bridge/training/initialize.py#L322-L328

From the TE docs: https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/api/pytorch.html#transformer_engine.pytorch.initialize_ub - 
TE prefers `mpi` first, then `gloo`, then `nccl` backend for initialization.

This change keeps the default in sync with megatron core: https://github.com/NVIDIA/Megatron-LM/blob/3df200905e13afa41b84900a9275717e17cb9a81/megatron/core/model_parallel_config.py#L236-L238

This PR also removes the reset of fields after `finalize` is called, which can appear misleading in logs/checkpoints as the settings are transferred to the model/optimizer/ddp settings.

# Changelog

- Update default for `tp_comm_overlap_bootstrap_backend` to `nccl`

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
