### PR TITLE
expose option to dump config to file during end to end tests

### DIFF
--- a/tests/end_to_end_tests/train_from_recipe.py
+++ b/tests/end_to_end_tests/train_from_recipe.py
@@ -244,6 +244,8 @@ def apply_args_to_config(config, args):
 
     # Logging configuration
     config.logger.log_timers_to_tensorboard = args.tensorboard is True
+    if args.save_config_filepath:
+        config.logger.save_config_filepath = args.save_config_filepath
 
     # WandB configuration
     if args.wandb_project:
@@ -342,6 +344,7 @@ def setup_argument_parser():
     parser.add_argument("--save-interval", type=int, help="Number of iterations between checkpoint saves")
     parser.add_argument("--async-save", action="store_true", help="Enable async checkpoint saving", default=False)
     parser.add_argument("--most-recent-k", type=int, help="Number of latest checkpoints to keep")
+    parser.add_argument("--save-config-filepath", type=str, help="Path to save the task configuration file")
 
     # Data
     parser.add_argument(


### PR DESCRIPTION
# What does this PR do ?

Currently the config as a yaml is printed to stdout before the training loop begins, but this can be lost in the logs.

This PR exposes an option to save the config to disk before training begins, primarily to aid in debugging in case of test failures or poor performance.

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
