### PR TITLE
chore(beep boop 🤖): Bump `uv.lock` (r0.2.0) (2025-11-19)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1254,7 +1254,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.121.2"
+version = "0.121.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -1262,9 +1262,9 @@ dependencies = [
     { name = "starlette" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fb/48/f08f264da34cf160db82c62ffb335e838b1fc16cbcc905f474c7d4c815db/fastapi-0.121.2.tar.gz", hash = "sha256:ca8e932b2b823ec1721c641e3669472c855ad9564a2854c9899d904c2848b8b9", size = 342944, upload-time = "2025-11-13T17:05:54.692Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/80/f0/086c442c6516195786131b8ca70488c6ef11d2f2e33c9a893576b2b0d3f7/fastapi-0.121.3.tar.gz", hash = "sha256:0055bc24fe53e56a40e9e0ad1ae2baa81622c406e548e501e717634e2dfbc40b", size = 344501, upload-time = "2025-11-19T16:53:39.243Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/23/dfb161e91db7c92727db505dc72a384ee79681fe0603f706f9f9f52c2901/fastapi-0.121.2-py3-none-any.whl", hash = "sha256:f2d80b49a86a846b70cc3a03eb5ea6ad2939298bf6a7fe377aa9cd3dd079d358", size = 109201, upload-time = "2025-11-13T17:05:52.718Z" },
+    { url = "https://files.pythonhosted.org/packages/98/b6/4f620d7720fc0a754c8c1b7501d73777f6ba43b57c8ab99671f4d7441eb8/fastapi-0.121.3-py3-none-any.whl", hash = "sha256:0c78fc87587fcd910ca1bbf5bc8ba37b80e119b388a7206b39f0ecc95ebf53e9", size = 109801, upload-time = "2025-11-19T16:53:37.918Z" },
 ]
 
 [[package]]
@@ -4811,28 +4811,28 @@ wheels = [
 
 [[package]]
 name = "safetensors"
-version = "0.7.0rc1"
+version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c0/ed/fcd8c0c2a1bc0bbc135c33a39c34007fb5bd766d42d576c0e583ae202fde/safetensors-0.7.0rc1.tar.gz", hash = "sha256:bf7094bc7f85b80e05027eca25d3db277087f78ec52b35c98952dcf43600574c", size = 200999, upload-time = "2025-11-17T19:11:18.13Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/9c/6e74567782559a63bd040a236edca26fd71bc7ba88de2ef35d75df3bca5e/safetensors-0.7.0.tar.gz", hash = "sha256:07663963b67e8bd9f0b8ad15bb9163606cd27cc5a1b96235a50d8369803b96b0", size = 200878, upload-time = "2025-11-19T15:18:43.199Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/75/f7/ce3aa5453920e0fdb02a1a8f877b4dff0458d1d543ad70db3cedc86152d8/safetensors-0.7.0rc1-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:2f5b75a3dd0542940a20c60f17ce2eff57423923fcdd33cad9205f8122f3190a", size = 467997, upload-time = "2025-11-17T19:11:13.03Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/90/d33d589f8ad0ea2c9cd0f5fc67e779392472fe16c6d1a3c6c544c5af0aa5/safetensors-0.7.0rc1-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:3753bb55b53c352367d68c0123bed81b7fd8508d28d6f099e3724c871e4935b6", size = 446955, upload-time = "2025-11-17T19:11:11.681Z" },
-    { url = "https://files.pythonhosted.org/packages/41/1f/d871f124ccc0d6066bc6e4ed1a65d9790f9ee2aee26a6c4f54265aa42c4d/safetensors-0.7.0rc1-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:19c9bdb50b287fbe14bc75dd2e363248ef80b725eb834a1ce6d7695e8356bb22", size = 491868, upload-time = "2025-11-17T19:10:54.424Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/0d/6f35af001ba7efeed80e0649c34207c41970cfbad44ab4dc8292a9b92860/safetensors-0.7.0rc1-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8f7ea8e41befe1480262c9da2c0fa016d57fae9c2b6cd77724acce79574f9a2e", size = 503623, upload-time = "2025-11-17T19:10:58.306Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/dd/7aee82dced2df67690c4304ecb93ef3734dd5ee6675435e6728449c3b6be/safetensors-0.7.0rc1-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9ac36b953dc59c5fa25d063479de13315407fb65a26ffdc77b0741b96f1e2298", size = 623414, upload-time = "2025-11-17T19:11:02.404Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/48/94d0367a5c41bf9226cab240290226a0ab7505fbc02c64555c22dd6f60bc/safetensors-0.7.0rc1-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6adef145e51b593456ae73c38071a2c8f6be3aebcd4c74436fcdb4b0565b3dc7", size = 532766, upload-time = "2025-11-17T19:11:05.712Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/ff/7107c5b2b3547cbb3c567249762c543a670665990e53bee66d417afa0c9b/safetensors-0.7.0rc1-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:318bf950ed393bea27d220c72b9582f38e544a05d3b27872b5c21ad9a7dfacd9", size = 507095, upload-time = "2025-11-17T19:11:10.212Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/96/062d90d224659f62b018049f7dfbcb15c396b854d57178253fd2def6c106/safetensors-0.7.0rc1-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5fdca0c7199136738e2b63d9631eebdd2498fa02674bcd8687e111588f4d3ea2", size = 541715, upload-time = "2025-11-17T19:11:08.802Z" },
-    { url = "https://files.pythonhosted.org/packages/60/65/ee3207cd7ec43610609bc0ba20d8c09e50bb3d32774714c4a7bcb9f95296/safetensors-0.7.0rc1-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:19300115a6ae0f2369ec57945557b7a995988e4a4e09bd6c56c5d6268e355bbb", size = 673791, upload-time = "2025-11-17T19:11:14.072Z" },
-    { url = "https://files.pythonhosted.org/packages/98/33/cade8685e55da8c81809471e82baa87a0cd1b8b1257f72cdff5c234268dc/safetensors-0.7.0rc1-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:71b8b1718503e2327fe3cc3bc623ba2b9f58151311cd4fbd08ad80f43b68d605", size = 771730, upload-time = "2025-11-17T19:11:15.091Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/83/c6b24ddb4ed2dc28b59579b9554dc836d91c9a6622284160fdc0437e307f/safetensors-0.7.0rc1-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:fa324daea6436bd0136409a95a349eee56c5218395c41ba804c7960666992b39", size = 714062, upload-time = "2025-11-17T19:11:16.122Z" },
-    { url = "https://files.pythonhosted.org/packages/83/c0/2c417c661837efdae528e85d12a3725d0fd498c687b05685771fa0f71088/safetensors-0.7.0rc1-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b385625f97b8bb561f9a3eaa0e67059dfb3f9571045bdcd2a1a3090d06706fcc", size = 677301, upload-time = "2025-11-17T19:11:17.134Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/f7/588970ce5fbb0868162495dfb2450ae2266c975f257eac176e9c8074c8f7/safetensors-0.7.0rc1-cp38-abi3-win32.whl", hash = "sha256:7c94e67a7c7fdf04f6cf63a240c3594c2cb3683ade2363cb001e1eb5b8e0ac1a", size = 326541, upload-time = "2025-11-17T19:11:20.453Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/c8/5c36e5e923a50b49f4755cd2c58d7d8eb126bbf3210e5baa85ec15691309/safetensors-0.7.0rc1-cp38-abi3-win_amd64.whl", hash = "sha256:878a93a69b20bcd1ab96fcba4daf2c34c73e2cb5c3bebda766563280a2559b57", size = 341487, upload-time = "2025-11-17T19:11:18.967Z" },
-    { url = "https://files.pythonhosted.org/packages/48/90/c7b8a69653c2f7267ef7faff42fced853a1b359e18e29c51a86ffd4379d4/safetensors-0.7.0rc1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:16877576d924cb32697a69bd1d2e6bdda5ca8987bbf6cf48808531b8278ecbb8", size = 492478, upload-time = "2025-11-17T19:10:56.268Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/1e/15c0d96fdaf9033858da02b0cf2a1b6b4207b304eb68a1c4fa34c306235f/safetensors-0.7.0rc1-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e8bd6354a970adec44634d1251224ac4d8260df22a81a42bbcacee4d34c2042e", size = 503969, upload-time = "2025-11-17T19:10:59.749Z" },
-    { url = "https://files.pythonhosted.org/packages/23/62/aff71a22b7e73e287f8be352d96f2dc95f86cf25a83efb693b56a8c39ab2/safetensors-0.7.0rc1-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f7d27ef9ba9c17e1c128ca37c6d394e616c80b3c96815bd917d5b29f61100816", size = 623750, upload-time = "2025-11-17T19:11:03.485Z" },
-    { url = "https://files.pythonhosted.org/packages/27/a4/c499a46512ddb4688651703f06638db3188dccb470818fb6db694aa93665/safetensors-0.7.0rc1-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:777b683a8b1fbb724353ba74ad5f2663545893c938c786f290ef3a245194f257", size = 531883, upload-time = "2025-11-17T19:11:06.748Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/47/aef6c06649039accf914afef490268e1067ed82be62bcfa5b7e886ad15e8/safetensors-0.7.0-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c82f4d474cf725255d9e6acf17252991c3c8aac038d6ef363a4bf8be2f6db517", size = 467781, upload-time = "2025-11-19T15:18:35.84Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/00/374c0c068e30cd31f1e1b46b4b5738168ec79e7689ca82ee93ddfea05109/safetensors-0.7.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:94fd4858284736bb67a897a41608b5b0c2496c9bdb3bf2af1fa3409127f20d57", size = 447058, upload-time = "2025-11-19T15:18:34.416Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/06/578ffed52c2296f93d7fd2d844cabfa92be51a587c38c8afbb8ae449ca89/safetensors-0.7.0-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e07d91d0c92a31200f25351f4acb2bc6aff7f48094e13ebb1d0fb995b54b6542", size = 491748, upload-time = "2025-11-19T15:18:09.79Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/33/1debbbb70e4791dde185edb9413d1fe01619255abb64b300157d7f15dddd/safetensors-0.7.0-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8469155f4cb518bafb4acf4865e8bb9d6804110d2d9bdcaa78564b9fd841e104", size = 503881, upload-time = "2025-11-19T15:18:16.145Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/1c/40c2ca924d60792c3be509833df711b553c60effbd91da6f5284a83f7122/safetensors-0.7.0-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:54bef08bf00a2bff599982f6b08e8770e09cc012d7bba00783fc7ea38f1fb37d", size = 623463, upload-time = "2025-11-19T15:18:21.11Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/3a/13784a9364bd43b0d61eef4bea2845039bc2030458b16594a1bd787ae26e/safetensors-0.7.0-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:42cb091236206bb2016d245c377ed383aa7f78691748f3bb6ee1bfa51ae2ce6a", size = 532855, upload-time = "2025-11-19T15:18:25.719Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/60/429e9b1cb3fc651937727befe258ea24122d9663e4d5709a48c9cbfceecb/safetensors-0.7.0-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dac7252938f0696ddea46f5e855dd3138444e82236e3be475f54929f0c510d48", size = 507152, upload-time = "2025-11-19T15:18:33.023Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a8/4b45e4e059270d17af60359713ffd83f97900d45a6afa73aaa0d737d48b6/safetensors-0.7.0-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1d060c70284127fa805085d8f10fbd0962792aed71879d00864acda69dbab981", size = 541856, upload-time = "2025-11-19T15:18:31.075Z" },
+    { url = "https://files.pythonhosted.org/packages/06/87/d26d8407c44175d8ae164a95b5a62707fcc445f3c0c56108e37d98070a3d/safetensors-0.7.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:cdab83a366799fa730f90a4ebb563e494f28e9e92c4819e556152ad55e43591b", size = 674060, upload-time = "2025-11-19T15:18:37.211Z" },
+    { url = "https://files.pythonhosted.org/packages/11/f5/57644a2ff08dc6325816ba7217e5095f17269dada2554b658442c66aed51/safetensors-0.7.0-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:672132907fcad9f2aedcb705b2d7b3b93354a2aec1b2f706c4db852abe338f85", size = 771715, upload-time = "2025-11-19T15:18:38.689Z" },
+    { url = "https://files.pythonhosted.org/packages/86/31/17883e13a814bd278ae6e266b13282a01049b0c81341da7fd0e3e71a80a3/safetensors-0.7.0-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:5d72abdb8a4d56d4020713724ba81dac065fedb7f3667151c4a637f1d3fb26c0", size = 714377, upload-time = "2025-11-19T15:18:40.162Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d8/0c8a7dc9b41dcac53c4cbf9df2b9c83e0e0097203de8b37a712b345c0be5/safetensors-0.7.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b0f6d66c1c538d5a94a73aa9ddca8ccc4227e6c9ff555322ea40bdd142391dd4", size = 677368, upload-time = "2025-11-19T15:18:41.627Z" },
+    { url = "https://files.pythonhosted.org/packages/05/e5/cb4b713c8a93469e3c5be7c3f8d77d307e65fe89673e731f5c2bfd0a9237/safetensors-0.7.0-cp38-abi3-win32.whl", hash = "sha256:c74af94bf3ac15ac4d0f2a7c7b4663a15f8c2ab15ed0fc7531ca61d0835eccba", size = 326423, upload-time = "2025-11-19T15:18:45.74Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/e6/ec8471c8072382cb91233ba7267fd931219753bb43814cbc71757bfd4dab/safetensors-0.7.0-cp38-abi3-win_amd64.whl", hash = "sha256:d1239932053f56f3456f32eb9625590cc7582e905021f94636202a864d470755", size = 341380, upload-time = "2025-11-19T15:18:44.427Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/6a/4d08d89a6fcbe905c5ae68b8b34f0791850882fc19782d0d02c65abbdf3b/safetensors-0.7.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f4729811a6640d019a4b7ba8638ee2fd21fa5ca8c7e7bdf0fed62068fcaac737", size = 492430, upload-time = "2025-11-19T15:18:11.884Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/29/59ed8152b30f72c42d00d241e58eaca558ae9dbfa5695206e2e0f54c7063/safetensors-0.7.0-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:12f49080303fa6bb424b362149a12949dfbbf1e06811a88f2307276b0c131afd", size = 503977, upload-time = "2025-11-19T15:18:17.523Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/0b/4811bfec67fa260e791369b16dab105e4bae82686120554cc484064e22b4/safetensors-0.7.0-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0071bffba4150c2f46cae1432d31995d77acfd9f8db598b5d1a2ce67e8440ad2", size = 623890, upload-time = "2025-11-19T15:18:22.666Z" },
+    { url = "https://files.pythonhosted.org/packages/58/5b/632a58724221ef03d78ab65062e82a1010e1bef8e8e0b9d7c6d7b8044841/safetensors-0.7.0-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:473b32699f4200e69801bf5abf93f1a4ecd432a70984df164fc22ccf39c4a6f3", size = 531885, upload-time = "2025-11-19T15:18:27.146Z" },
 ]
 
 [[package]]
@@ -5360,15 +5360,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.49.3"
+version = "0.50.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/1a/608df0b10b53b0beb96a37854ee05864d182ddd4b1156a22f1ad3860425a/starlette-0.49.3.tar.gz", hash = "sha256:1c14546f299b5901a1ea0e34410575bc33bbd741377a10484a54445588d00284", size = 2655031, upload-time = "2025-11-01T15:12:26.13Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/b8/73a0e6a6e079a9d9cfa64113d771e421640b6f679a52eeb9b32f72d871a1/starlette-0.50.0.tar.gz", hash = "sha256:a2a17b22203254bcbc2e1f926d2d55f3f9497f769416b3190768befe598fa3ca", size = 2646985, upload-time = "2025-11-01T15:25:27.516Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/e0/021c772d6a662f43b63044ab481dc6ac7592447605b5b35a957785363122/starlette-0.49.3-py3-none-any.whl", hash = "sha256:b579b99715fdc2980cf88c8ec96d3bf1ce16f5a8051a7c2b84ef9b1cdecaea2f", size = 74340, upload-time = "2025-11-01T15:12:24.387Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/52/1064f510b141bd54025f9b55105e26d1fa970b9be67ad766380a3c9b74b0/starlette-0.50.0-py3-none-any.whl", hash = "sha256:9e5391843ec9b6e472eed1365a78c8098cfceb7a74bfd4d6b1c0c0095efb3bca", size = 74033, upload-time = "2025-11-01T15:25:25.461Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
🚀 PR to bump `uv.lock` in `r0.2.0`.

📝 This PR will be automatically merged if all CI checks pass successfully.
If any CI checks fail, the PR will remain open for manual review.

🤖 **Auto-merge enabled** - No manual action required if CI passes.