### PR TITLE
feat: Add whitelist support for mismatched params in load_hf_weights

### DIFF
--- a/src/megatron/bridge/models/conversion/auto_bridge.py
+++ b/src/megatron/bridge/models/conversion/auto_bridge.py
@@ -274,7 +274,7 @@ class AutoBridge(Generic[MegatronModelT]):
         self,
         model: list[MegatronModelT],
         hf_path: str | Path | None = None,
-        mismatch_params_whitelist: list[str] | None = None,
+        allowed_mismatched_params: list[str] | None = None,
     ) -> None:
         """
         Load HuggingFace weights into a Megatron model.
@@ -287,7 +287,7 @@ class AutoBridge(Generic[MegatronModelT]):
             model: List of Megatron model instances (one per virtual pipeline stage)
             hf_path: Optional path to load weights from. If None, uses weights
                 from the bridge's hf_pretrained instance
-            mismatch_params_whitelist: Optional list of parameter names or patterns
+            allowed_mismatched_params: Optional list of parameter names or patterns
                 to allow mismatch (skip instead of raise error).
 
         Returns:
@@ -304,6 +304,12 @@ class AutoBridge(Generic[MegatronModelT]):
 
             >>> # Load weights from a different checkpoint
             >>> bridge.load_hf_weights(megatron_model, "./finetuned_model")
+
+            >>> # Load weights with allowed mismatched parameters
+            >>> bridge.load_hf_weights(
+            ...     megatron_model,
+            ...     allowed_mismatched_params=["*.bias", "decoder.layers.0.*"]
+            ... )
         """
         if hf_path is None:
             if not isinstance(self.hf_pretrained, PreTrainedCausalLM):
@@ -314,7 +320,7 @@ class AutoBridge(Generic[MegatronModelT]):
             trust_remote_code = getattr(self.hf_pretrained, "trust_remote_code", False)
             pre_trained = PreTrainedCausalLM.from_pretrained(hf_path, trust_remote_code=trust_remote_code)
         self._model_bridge.load_weights_hf_to_megatron(
-            pre_trained, model, mismatch_params_whitelist=mismatch_params_whitelist
+            pre_trained, model, allowed_mismatched_params=allowed_mismatched_params
         )
 
         return model

--- a/src/megatron/bridge/models/conversion/model_bridge.py
+++ b/src/megatron/bridge/models/conversion/model_bridge.py
@@ -419,7 +419,7 @@ class MegatronModelBridge(Generic[HFPreTrained, ModelProviderTarget, MegatronMod
         self,
         hf_pretrained: HFPreTrained,
         megatron_model: Union[MegatronModel, List[MegatronModel]],
-        mismatch_params_whitelist: Optional[List[str]] = None,
+        allowed_mismatched_params: Optional[List[str]] = None,
     ) -> List[MegatronModel]:
         """Load HuggingFace weights into Megatron models.
 
@@ -435,7 +435,7 @@ class MegatronModelBridge(Generic[HFPreTrained, ModelProviderTarget, MegatronMod
                 weights to load.
             megatron_model (Union[MegatronModel, List[MegatronModel]]): Megatron model instance
                 or list of model instances (one per virtual pipeline stage).
-            mismatch_params_whitelist (Optional[List[str]]): List of parameter names or patterns
+            allowed_mismatched_params (Optional[List[str]]): List of parameter names or patterns
                 to allow mismatch (skip instead of raise error).
 
         Returns:
@@ -490,8 +490,8 @@ class MegatronModelBridge(Generic[HFPreTrained, ModelProviderTarget, MegatronMod
                 if converted_weights.shape != task.param_weight.shape:
                     # Check whitelist
                     is_whitelisted = False
-                    if mismatch_params_whitelist:
-                        for pattern in mismatch_params_whitelist:
+                    if allowed_mismatched_params:
+                        for pattern in allowed_mismatched_params:
                             if fnmatch.fnmatch(task.mapping.megatron_param, pattern) or fnmatch.fnmatch(
                                 task.param_name, pattern
                             ):

--- a/tests/unit_tests/models/test_auto_bridge.py
+++ b/tests/unit_tests/models/test_auto_bridge.py
@@ -456,11 +456,11 @@ class TestAutoBridge:
             bridge.load_hf_weights(mock_megatron_model)
 
             mock_model_bridge.load_weights_hf_to_megatron.assert_called_once_with(
-                mock_hf_model, mock_megatron_model, mismatch_params_whitelist=None
+                mock_hf_model, mock_megatron_model, allowed_mismatched_params=None
             )
 
-    def test_load_hf_weights_with_whitelist(self):
-        """Test loading weights with mismatch_params_whitelist."""
+    def test_load_hf_weights_with_allowed_mismatched_params(self):
+        """Test loading weights with allowed_mismatched_params."""
         # Setup mocks
         mock_hf_model = Mock(spec=PreTrainedCausalLM)
         mock_config = Mock(spec=PretrainedConfig)
@@ -474,10 +474,10 @@ class TestAutoBridge:
         with patch.object(AutoBridge, "_model_bridge", mock_model_bridge):
             bridge = AutoBridge(mock_hf_model)
             whitelist = ["*.bias", "layer.1.weight"]
-            bridge.load_hf_weights(mock_megatron_model, mismatch_params_whitelist=whitelist)
+            bridge.load_hf_weights(mock_megatron_model, allowed_mismatched_params=whitelist)
 
             mock_model_bridge.load_weights_hf_to_megatron.assert_called_once_with(
-                mock_hf_model, mock_megatron_model, mismatch_params_whitelist=whitelist
+                mock_hf_model, mock_megatron_model, allowed_mismatched_params=whitelist
             )
 
     def test_load_hf_weights_from_path(self):
@@ -509,7 +509,7 @@ class TestAutoBridge:
                 mock_model_bridge.load_weights_hf_to_megatron.assert_called_once_with(
                     mock_loaded_model,
                     mock_megatron_model,
-                    mismatch_params_whitelist=None,
+                    allowed_mismatched_params=None,
                 )
 
     def test_load_hf_weights_no_path_config_only(self):


### PR DESCRIPTION
This PR introduces a whitelist mechanism for `load_hf_weights` to allow skipping specific parameters that have shape mismatches during HuggingFace to Megatron conversion. This is particularly useful when dealing with models that have known structural differences or when intentionally ignoring certain weights (e.g., specific biases or auxiliary heads) that would otherwise cause the loading process to fail with a `ValueError`.

### Key Changes
*   **Core Logic**: Modified `load_weights_hf_to_megatron` in `MegatronModelBridge` (both in `models/model_bridge.py` and `models/conversion/model_bridge.py`) to accept a `mismatch_params_whitelist` argument.
*   **Pattern Matching**: Implemented `fnmatch`-based matching, allowing users to specify exact parameter names or glob patterns (e.g., `"*.bias"`, `"layers.0.*"`) in the whitelist.
*   **AutoBridge Integration**: Exposed `mismatch_params_whitelist` argument in `AutoBridge.load_hf_weights` to pass it down to the underlying model bridge.
*   **Behavior**: Mismatched parameters found in the whitelist are skipped with a warning log (on rank 0) instead of raising a `ValueError`.

### Testing
*   Added a new unit test `test_load_hf_weights_with_whitelist` in `tests/unit_tests/models/test_auto_bridge.py` to verify that the whitelist is correctly passed and handled.
*   Updated existing tests in `test_auto_bridge.py` to align with the updated method signature.

### Usage Example
```python
# Load weights, skipping specific mismatched parameters
bridge.load_hf_weights(
    megatron_model,
    mismatch_params_whitelist=[
        "decoder.layers.0.self_attention.linear_qkv.weight", 
        "*.bias"