### PR TITLE
cp: `Fix typo in dataclass from `callable` => `typing.Callable` in `nemotron_h_provider.py` (1442)` into `r0.2.0`

### DIFF
--- a/src/megatron/bridge/models/nemotronh/nemotron_h_provider.py
+++ b/src/megatron/bridge/models/nemotronh/nemotron_h_provider.py
@@ -15,6 +15,7 @@
 import logging
 import warnings
 from dataclasses import dataclass
+from typing import Callable
 
 from megatron.core.activations import squared_relu
 
@@ -34,7 +35,7 @@ class NemotronHModelProvider(MambaModelProvider):
     mamba_head_dim: int = 64
     num_query_groups: int = 8
     make_vocab_size_divisible_by: int = 128
-    activation_func: callable = squared_relu
+    activation_func: Callable = squared_relu
     masked_softmax_fusion: bool = True
     apply_query_key_layer_scaling: bool = False
     persist_layer_norm: bool = True


### PR DESCRIPTION
beep boop [🤖]: Hi @shaltielshmid 👋,

    we've cherry picked #1442 into  for you! 🚀

    Please review and approve this cherry pick by your convenience!