### PR TITLE
fix hf model loading : TBD

### DIFF
--- a/src/megatron/bridge/models/hf_pretrained/state.py
+++ b/src/megatron/bridge/models/hf_pretrained/state.py
@@ -795,9 +795,9 @@ class SafeTensorsStateSource(StateSource):
             )
 
         # Final check on whether all original tensors were written.
-        unsaved_keys = all_expected_keys - all_saved_keys
+        unsaved_keys = all_expected_keys.intersection(all_saved_keys)
         if not unsaved_keys:
-            extra_keys = all_yielded_keys - all_expected_keys
+            extra_keys = all_yielded_keys.intersection(all_expected_keys)
             if extra_keys:
                 print(
                     f"\nSuccess: All tensors from the original checkpoint were written. "


### PR DESCRIPTION
# What does this PR do ?

# Add a one line overview of what this PR aims to accomplish.
HF loading broken. 

Reason : set intersection is not unified

## Test

```
from megatron.bridge import AutoBridge
from megatron.bridge.training.model_load_save import load_megatron_model, load_tokenizer

from megatron.core import parallel_state
from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed

import torch
from transformers import AutoModelForCausalLM, AutoTokenizer

# model info
MODEL="Llama-2-7b-hf"
MODEL_TYPE="llama2-7B"

# create soft links to /workspace/models
MODEL_DIR="/workspace/models"

HF_MODEL_DIR=f"{MODEL_DIR}/{MODEL}"

# Specify model partitions
TP=1
PP=1

SAVER="mcore_bridge"

def export():
    # fp8 recipe
    dtype="fp8"

    # using Megatron Bridge provider API
    bridge = AutoBridge.from_hf_pretrained(f"{HF_MODEL_DIR}", trust_remote_code=True)

    provider = bridge.to_megatron_provider()

    provider.tensor_model_parallel_size = TP
    provider.pipeline_model_parallel_size = PP

    provider.finalize()

    model = provider.provide_distributed_model(wrap_with_ddp=False)

    # output info
    OUTPUT=f"{MODEL_DIR}/MODEL-to-{SAVER}-tp{TP}-pp{PP}-{dtype}"

    bridge.save_hf_pretrained(model, f"{OUTPUT}")

    return model
    
 model = export() 
```

## Snapshot
<img width="890" height="96" alt="截屏2025-11-21 15 41 42" src="https://github.com/user-attachments/assets/cff30d0e-316d-49eb-a681-e9c6d8989a42" />

# Changelog

- unifying set operation

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
