### PR TITLE
Propagate PERF_ENV_VARS to SlurmExecutor container_env

### DIFF
--- a/scripts/performance/utils/executors.py
+++ b/scripts/performance/utils/executors.py
@@ -56,6 +56,7 @@ def slurm_executor(
     time_limit: str = "00:30:00",
     container_image: str = "nvcr.io/nvidia/nemo:dev",
     custom_mounts: List[str] = [],
+    container_env: List[str] = [],
     custom_env_vars: Dict[str, str] = {},
     custom_srun_args: List[str] = [],
     hf_token: str = None,
@@ -121,6 +122,8 @@ def slurm_executor(
         template_vars={"pre_cmds": " ; ".join(custom_bash_cmds)},
     )
 
+    all_container_env = sorted(set(PERF_ENV_VARS) | set(container_env))
+
     executor = run.SlurmExecutor(
         account=account,
         partition=partition,
@@ -129,6 +132,7 @@ def slurm_executor(
         ntasks_per_node=num_gpus_per_node,
         container_image=container_image,
         container_mounts=mounts,
+        container_env=all_container_env,
         env_vars=PERF_ENV_VARS,
         srun_args=srun_args,
         time=time_limit,


### PR DESCRIPTION
Expose the container_env parameter of SlurmExecutor, explicitly set container_env for any environment variable being set. If you're setting performance variables for your run you expect them to be set in the container.

The pyxis/enroot defaults are to set all variables in the user environment in the container environment, except when that variable already exists in the container. Then it won't overwrite it unless '--container-env=VAR' is set.
