### PR TITLE
Provide megatron param name in addition to hf param name

### DIFF
--- a/src/megatron/bridge/models/conversion/model_bridge.py
+++ b/src/megatron/bridge/models/conversion/model_bridge.py
@@ -76,6 +76,7 @@ class HFWeightTuple(NamedTuple):
 
     param_name: str
     weight: torch.Tensor
+    megatron_param_name: str
 
 
 @dataclass(frozen=True)
@@ -643,13 +644,13 @@ class MegatronModelBridge(Generic[HFPreTrained, ModelProviderTarget, MegatronMod
                 # TODO(yuya): fix this hard coded naming
                 if embeddings_are_tied and hf_name == "model.embed_tokens.weight":
                     # Yield the embedding weight
-                    yield HFWeightTuple(hf_name, final_tensor)
+                    yield HFWeightTuple(hf_name, final_tensor, task.param_name)
 
                     # Also yield as lm_head.weight if it's expected
                     if hasattr(hf_pretrained, "state") and hasattr(hf_pretrained.state, "source"):
                         expected_keys = hf_pretrained.state.source.get_all_keys()
                         if "lm_head.weight" in expected_keys:
-                            yield HFWeightTuple("lm_head.weight", final_tensor.clone().detach())
+                            yield HFWeightTuple("lm_head.weight", final_tensor.clone().detach(), task.param_name)
                 elif embeddings_are_tied and hf_name == "lm_head.weight":
                     # This should not happen when embeddings are tied - assert error
                     raise ValueError(
@@ -657,7 +658,7 @@ class MegatronModelBridge(Generic[HFPreTrained, ModelProviderTarget, MegatronMod
                     )
                 else:
                     # Regular case - yield the tensor normally
-                    yield HFWeightTuple(hf_name, final_tensor)
+                    yield HFWeightTuple(hf_name, final_tensor, task.param_name)
 
     def _merge_lora_adapter_weights(
         self,


### PR DESCRIPTION
# What does this PR do ?

useful in https://github.com/radixark/miles / https://github.com/THUDM/slime integration, since some code needs the megatron param name for postprocessing the weights.
This is a tentative PR to know what do you think about it. If it looks good, I will polish the PR.

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
