### PR TITLE
[Fix] gptoss yarn parameter

### DIFF
--- a/src/megatron/bridge/models/gpt_oss/gpt_oss_provider.py
+++ b/src/megatron/bridge/models/gpt_oss/gpt_oss_provider.py
@@ -63,8 +63,8 @@ class GPTOSSProvider(GPTModelProvider):
     yarn_beta_fast: float = 32.0
     yarn_beta_slow: float = 1.0
     yarn_correction_range_round_to_int: bool = False
-    yarn_mscale: Optional[float] = None
-    yarn_mscale_all_dim: Optional[float] = None
+    yarn_mscale: Optional[float] = 1.0 # NOTE (yiakwy) : None
+    yarn_mscale_all_dim: Optional[float] = 1.0 # NOTE(yiakwy) : None
 
     moe_router_topk: int = 4
     moe_router_pre_softmax: bool = False

--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -153,7 +153,7 @@ class DistributedInitConfig:
     Make sure EP and CP aren't used with this option enabled.
     """
 
-    use_gloo_process_groups: bool = True
+    use_gloo_process_groups: bool = False # True NOTE (yiakwy)
     """If set, create Gloo process groups for communications."""
 
     use_sharp: bool = False


### PR DESCRIPTION
# What does this PR do ?

Fix gptoss GptOSS yarn default parameters when passing them to mcore where mcore does not accept None as  valid vlaues.

# Changelog

- Fix GptOss Yarn default parameters : mcore cannot read none values

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to https://github.com/NVIDIA/Megatron-LM/pull/2383
