### PR TITLE
[r0.2.0] Fix functional conftest to handle optional `nvdlfw-inspect` dependency

### DIFF
--- a/tests/functional_tests/conftest.py
+++ b/tests/functional_tests/conftest.py
@@ -152,8 +152,15 @@ def reset_env_vars():
 @pytest.fixture(autouse=True)
 def reset_te_debug_state():
     """Ensure Transformer Engine debug state is reset after each test."""
-    from transformer_engine.debug.pytorch.debug_state import TEDebugState
+    try:
+        from transformer_engine.debug.pytorch.debug_state import TEDebugState
+    except (ImportError, ModuleNotFoundError):
+        yield
+        return
 
     yield
 
-    TEDebugState._reset()
+    try:
+        TEDebugState._reset()
+    except (ImportError, ModuleNotFoundError):
+        pass


### PR DESCRIPTION
# What does this PR do ?

fix reported issue for conversion functional tests on the release container

```
____________ ERROR at teardown of TestQwen3NextConversion.test_toy_model_creation _____________

    @pytest.fixture(autouse=True)
    def reset_te_debug_state():
        """Ensure Transformer Engine debug state is reset after each test."""
        from transformer_engine.debug.pytorch.debug_state import TEDebugState
    
        yield
    
>       TEDebugState._reset()

    
    """
    Utils for the debug features.
    """
    
    import torch
>   import nvdlfw_inspect.api as debug_api
E   ModuleNotFoundError: No module named 'nvdlfw_inspect'
```

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
