### PR TITLE
Revert strong-scaling support for DeepSeek-V3

### DIFF
--- a/scripts/performance/argument_parser.py
+++ b/scripts/performance/argument_parser.py
@@ -271,14 +271,6 @@ def parse_cli_args():
         default=None,
     )
     parser.add_argument(
-        "--moe_flex_dispatcher_backend",
-        type=str,
-        choices=["deepep", "hybridep"],
-        help="MoE flex dispatcher backend to use. Defaults to None",
-        required=False,
-        default=None,
-    )
-    parser.add_argument(
         "--use_megatron_fsdp",
         help="Use Megatron FSDP. Disabled by default.",
         type=bool_arg,
@@ -326,10 +318,10 @@ def parse_cli_args():
     parser.add_argument(
         "-vp",
         "--virtual_pipeline_model_parallel_size",
-        type=lambda x: None if x == "None" else int(x),
+        type=int,
         help="Number of virtual blocks per pipeline model parallel rank is the virtual model parallel size.",
         required=False,
-        default=-1,
+        default=None,
     )
     parser.add_argument(
         "-ep",

--- a/scripts/performance/perf_plugins.py
+++ b/scripts/performance/perf_plugins.py
@@ -197,7 +197,6 @@ class PerfEnvPlugin(Plugin):
     pp_size: int = 1
     script_args_converter_fn: Optional[Callable[[PerfEnvPluginScriptArgs], List[str]]] = None
     moe_a2a_overlap: bool = False
-    moe_flex_dispatcher_backend: str
     model_name: str
     model_size: str
     gpu: str
@@ -369,11 +368,7 @@ class PerfEnvPlugin(Plugin):
         cp_size = self.cp_size if self.cp_size is not None else workload_base_config.context_parallel_size
 
         # Force program order kernel launch for TP, CP overlap
-        moe_flex_dispatcher_backend = (
-            self.moe_flex_dispatcher_backend
-            if self.moe_flex_dispatcher_backend is not None
-            else getattr(workload_base_config, "moe_flex_dispatcher_backend", None)
-        )
+        moe_flex_dispatcher_backend = getattr(workload_base_config, "moe_flex_dispatcher_backend", None)
         moe_a2a_overlap = (
             self.moe_a2a_overlap
             if self.moe_a2a_overlap is not None

--- a/scripts/performance/setup_experiment.py
+++ b/scripts/performance/setup_experiment.py
@@ -58,7 +58,6 @@ def main(
     enable_nsys: bool,
     use_tokendrop: bool,
     moe_a2a_overlap: bool,
-    moe_flex_dispatcher_backend: str,
     tp_size: Optional[int],
     pp_size: Optional[int],
     cp_size: Optional[int],
@@ -92,7 +91,6 @@ def main(
         PerfEnvPlugin(
             enable_vboost=enable_vboost,
             moe_a2a_overlap=moe_a2a_overlap,
-            moe_flex_dispatcher_backend=moe_flex_dispatcher_backend,
             tp_size=tp_size,
             pp_size=pp_size,
             cp_size=cp_size,
@@ -183,7 +181,6 @@ if __name__ == "__main__":
         enable_nsys=args.enable_nsys,
         use_tokendrop=args.use_tokendrop,
         moe_a2a_overlap=args.moe_a2a_overlap,
-        moe_flex_dispatcher_backend=args.moe_flex_dispatcher_backend,
         tp_size=args.tensor_model_parallel_size,
         pp_size=args.pipeline_model_parallel_size,
         cp_size=args.context_parallel_size,

--- a/scripts/performance/utils/helpers.py
+++ b/scripts/performance/utils/helpers.py
@@ -240,7 +240,7 @@ def set_user_overrides(recipe: ConfigContainer, kwargs: Dict[str, Any]) -> None:
         recipe.model.pipeline_model_parallel_size = kwargs.get("pipeline_model_parallel_size")
     if kwargs.get("context_parallel_size") is not None:
         recipe.model.context_parallel_size = kwargs.get("context_parallel_size")
-    if kwargs.get("virtual_pipeline_model_parallel_size") != -1:
+    if kwargs.get("virtual_pipeline_model_parallel_size") is not None:
         recipe.model.virtual_pipeline_model_parallel_size = kwargs.get("virtual_pipeline_model_parallel_size")
     if kwargs.get("expert_model_parallel_size") is not None:
         recipe.model.expert_model_parallel_size = kwargs.get("expert_model_parallel_size")
@@ -270,25 +270,6 @@ def set_user_overrides(recipe: ConfigContainer, kwargs: Dict[str, Any]) -> None:
             recipe.comm_overlap.overlap_param_gather_with_optimizer_step = True
 
 
-def set_deepseek_v3_layout(recipe: ConfigContainer) -> None:
-    """Set the DeepSeek V3 layout."""
-    pp = recipe.model.pipeline_model_parallel_size
-    vp = recipe.model.virtual_pipeline_model_parallel_size or 1
-    mtp_layers = getattr(recipe.model, "mtp_num_layers", 1) or 0
-    last_layer = ["mtp"] * mtp_layers + ["loss"]
-
-    layout_map = {
-        (1, 1): None,
-        (4, 1): [["embedding"] + ["decoder"] * 16, ["decoder"] * 16, ["decoder"] * 16, ["decoder"] * 13 + last_layer],
-        (8, 1): [["embedding"] + ["decoder"] * 8] + [["decoder"] * 8] * 6 + [["decoder"] * 5 + last_layer],
-        (4, 2): [["embedding"] + ["decoder"] * 8] + [["decoder"] * 8] * 6 + [["decoder"] * 5 + last_layer],
-        (16, 1): [["embedding"] + ["decoder"] * 4] + [["decoder"] * 4] * 14 + [["decoder"] + last_layer],
-        (8, 2): [["embedding"] + ["decoder"] * 4] + [["decoder"] * 4] * 14 + [["decoder"] + last_layer],
-        (4, 4): [["embedding"] + ["decoder"] * 4] + [["decoder"] * 4] * 14 + [["decoder"] + last_layer],
-    }
-    recipe.model.pipeline_model_parallel_layout = layout_map[(pp, vp)]
-
-
 def get_model_recipe_with_user_overrides(**kwargs) -> ConfigContainer:
     """Get the model recipe with user overrides."""
     model_name = kwargs.get("model_name")
@@ -303,8 +284,6 @@ def get_model_recipe_with_user_overrides(**kwargs) -> ConfigContainer:
     recipe = get_model_recipe(model_name, model_size, gpu, compute_dtype, domain, task)
     set_common_perf_overrides(recipe)
     set_user_overrides(recipe, kwargs)
-    if model_name == "deepseek" and model_size == "v3":
-        set_deepseek_v3_layout(recipe)
 
     # Scale global batch size based on the number of GPUs IF GBS is not specified by the use 0 r
     workload_base_config = get_workload_base_config(model_name, model_size, gpu, compute_dtype, domain, task)


### PR DESCRIPTION
This PR
- reverts strong-scaling support for DeepSeek-V3.
- removes `moe_flex_dispatcher_backend` from arguments.