### PR TITLE
build: make mamba and nv-grouped-gemm optional dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,57 @@ docker run --rm -it -w /workdir -v $(pwd):/opt/Megatron-Bridge \
   megatron-bridge
 ```
 
+### Local Workstation
+
+For local development without containers, install Megatron Bridge using [uv](https://docs.astral.sh/uv/):
+
+#### Prerequisites
+
+```bash
+# Install Python development headers (required for building C++ extensions)
+sudo apt-get update && sudo apt-get install -y python3-dev
+
+# Install uv if not already installed
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+#### Basic Installation
+
+```bash
+# Clone the repository
+git clone https://github.com/NVIDIA-NeMo/Megatron-Bridge.git
+cd Megatron-Bridge
+
+# Install with uv (recommended)
+uv pip install -e .
+```
+
+#### Optional Dependencies
+
+Install additional features as needed:
+
+```bash
+# For Mamba model architectures (requires building from source, ~30 minutes)
+uv pip install -e ".[mamba]"
+
+# For NeMo Run recipes
+uv pip install -e ".[recipes]"
+
+# For development tools (note: nv-grouped-gemm may fail to build, see known issues)
+uv pip install -e ".[dev]"
+```
+
+#### Known Installation Issues
+
+**nv-grouped-gemm build failure:**
+- The `nv-grouped-gemm` package (included in `[dev]` extras) may fail to build due to missing CUTLASS headers
+- This package is optional and only needed for specific optimizations
+- Issue tracker: https://github.com/fanshiqing/grouped_gemm
+
+**Long build times:**
+- Packages like `transformer-engine`, `mamba-ssm`, and `causal-conv1d` build from source
+- Expected build times: 8-15 minutes per package on systems with 16 vCPUs
+
 ## 📝 Writing tests
 
 We use [pytest](https://docs.pytest.org/en/stable/) for writing both unit and functional tests.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,38 @@ docker run --rm -it -w /workdir -v $(pwd):/workdir \
   nvcr.io/nvidia/nemo:${TAG}
 ```
 
-For development installation and additional details, please refer to our [Contribution guide](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md).
+### 📦 Local Installation with UV
+
+Install from PyPI using [uv](https://docs.astral.sh/uv/):
+
+```bash
+# Install uv if not already installed
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Install Megatron Bridge
+uv pip install megatron-bridge
+```
+
+**Optional dependencies:**
+```bash
+# For Mamba model architectures
+uv pip install "megatron-bridge[mamba]"
+
+# For NeMo Run recipes
+uv pip install "megatron-bridge[recipes]"
+```
+
+**Development installation:**
+```bash
+# Clone and install in editable mode
+git clone https://github.com/NVIDIA-NeMo/Megatron-Bridge.git
+cd Megatron-Bridge
+uv pip install -e .
+```
+
+> **Note:** Installation requires Python development headers (`sudo apt-get install python3-dev`). The base installation includes `transformer-engine` which takes ~10 minutes to build from source. Installing `[mamba]` extras adds `mamba-ssm` and `causal-conv1d` which take an additional ~27 minutes to build.
+
+For additional details, please refer to our [Contribution guide](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md).
 
 ## ⚡ Quickstart
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,12 +79,10 @@ dependencies = [
     "pyyaml>=6.0.2",
     "tqdm>=4.67.1",
     "hydra-core>1.3,<=1.3.2",
-    "megatron-core[dev,mlm]>=0.15.0a0,<0.17.0",
+    "megatron-core[mlm]>=0.15.0a0,<0.17.0",
     "qwen-vl-utils",
     "transformer-engine[pytorch]>=2.9.0a0,<2.10.0",
-    "mamba-ssm",
     "nvidia-resiliency-ext",
-    "causal-conv1d",
     "flash-linear-attention",
     "timm",
     "open-clip-torch>=3.2.0",
@@ -128,6 +126,13 @@ recipes = [
 ]
 tensor-inspect = [
     "nvdlfw-inspect==0.2.1",
+]
+mamba = [
+    "mamba-ssm",
+    "causal-conv1d",
+]
+dev = [
+    "nv-grouped-gemm",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
# What does this PR do ?

Makes mamba-ssm, causal-conv1d, and nv-grouped-gemm optional dependencies and adds uv installation documentation.

# Changelog

 - Moved `mamba-ssm` and `causal-conv1d` from core dependencies to optional `[mamba]` extra
 - Moved `nv-grouped-gemm` to optional `[dev]` extra
 - Changed `megatron-core[dev,mlm]` to `megatron-core[mlm]` to avoid requiring nv-grouped-gemm by default
 - Added uv installation section to README.md 
 - Documented expected build times (~10 min for TE, ~27 min for mamba extras)
 - Documented known installation issues (nv-grouped-gemm build failures due to missing CUTLASS headers)

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to https://github.com/NVIDIA-NeMo/Megatron-Bridge/issues/1168 and https://github.com/NVIDIA/Megatron-LM/issues/2541
