### PR TITLE
Fix `gemma3_1b_pretrain_config` with correct `hf_path`

### DIFF
--- a/src/megatron/bridge/recipes/gemma/gemma3.py
+++ b/src/megatron/bridge/recipes/gemma/gemma3.py
@@ -133,7 +133,7 @@ def gemma3_1b_pretrain_config(**user_kwargs: Unpack[Gemma3CommonKwargs]) -> Conf
     """
     recommended_kwargs: Gemma3CommonKwargs = {
         "provider_class": Gemma3ModelProvider1B,
-        "hf_path": "google/gemma-3-1b",
+        "hf_path": "google/gemma-3-1b-pt",
         "tensor_model_parallel_size": 1,
         "pipeline_model_parallel_size": 1,
         "context_parallel_size": 1,
@@ -188,7 +188,7 @@ def _gemma3_common(
 
     Args:
         provider_class (type): Gemma3 model provider class (e.g., Gemma3ModelProvider1B).
-        hf_path (str | None): HuggingFace model path (e.g., "google/gemma-3-1b").
+        hf_path (str | None): HuggingFace model path (e.g., "google/gemma-3-1b-pt").
         dir (str | None): Base directory for saving logs and checkpoints.
         name (str): Name of the pre-training run.
         data_paths (list[str] | None): List of paths to dataset files. If None, mock data will be used.


### PR DESCRIPTION
# What does this PR do ?

Resolves #1591
Fix `gemma3_1b_pretrain_config` with correct `hf_path`, which in https://huggingface.co/google/gemma-3-1b-pt

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to #1591
