### PR TITLE
Remove deprecated NCCL_NET_GDR_LEVEL and NCCL_NET_GDR_C2C environment variables

### DIFF
--- a/docs/performance-guide.md
+++ b/docs/performance-guide.md
@@ -330,12 +330,7 @@ Additionally, because CP shards activations, it also partitions optimizer states
    >    > 2. `TransformerConfig.cpu_offloading_weights=False`
    >    > 3. `TransformerConfig.cpu_offloading_num_layers= <int:≤activation_offload_layers>`
    >
-   > 3. Environment variable settings to avoid resource conflict between CPU memory offloading and network communication
-   >
-   >    > 1. `NCCL_NET_GDR_LEVEL=PHB # NCCL <=2.25`
-   >    > 2. `NCCL_NET_GDR_C2C=1     # NCCL >=2.26`
-   >
-   > 4. Optimization tips
+   > 3. Optimization tips
    >
    >    > 1. Given the ratio between activation volume and computational operations, offloading all layer activations naively can become a performance bottleneck. Optimizing performance requires tuning the number of layers to offload while balancing it with recomputation.
 
@@ -451,8 +446,6 @@ Additionally, because CP shards activations, it also partitions optimizer states
 - `TrainingConfig.manual_gc_interval`
 - `MixedPrecisionConfig.fp8_param`
 - `ProfilingConfig`
-- `NCCL_NET_GDR_C2C`
-- `NCCL_NET_GDR_LEVEL`
 - `NCCL_NVLS_ENABLE`
 - `NVTE_BWD_LAYERNORM_SM_MARGIN=<#SM for DP collectives`
 - `TransformerConfig.attention_backend`

--- a/scripts/performance/utils/executors.py
+++ b/scripts/performance/utils/executors.py
@@ -97,9 +97,7 @@ def slurm_executor(
     if wandb_key is not None:
         PERF_ENV_VARS["WANDB_API_KEY"] = wandb_key
 
-    if gpu.lower() == "gb200":
-        PERF_ENV_VARS["NCCL_NET_GDR_LEVEL"] = "PHB"  # For NCCL 2.25
-        PERF_ENV_VARS["NCCL_NET_GDR_C2C"] = "1"  # For NCCL 2.26
+
 
     if nemo_home != DEFAULT_NEMO_CACHE_HOME:  # DO NOT change this to 'DEFAULT_NEMO_HOME'/'NEMO_HOME'
         PERF_ENV_VARS["NEMO_HOME"] = nemo_home


### PR DESCRIPTION
These variables were a workaround for NCCL versions older than 2.27.x and are no longer needed, with NeMo containers having 2.27x since 25.07.
- Removed setting of these variables in .
- Updated  to remove references to these variables from the 'Activation offloading to host memory' section and the 'Index - List of Tuning Knobs'.

Additionally since we aren't checking the NCCL version and blanket applying, should be removed.