### PR TITLE
Propagate PERF_ENV_VARS and overrides to SlurmExecutor container_env

### DIFF
--- a/scripts/performance/setup_experiment.py
+++ b/scripts/performance/setup_experiment.py
@@ -159,6 +159,10 @@ if __name__ == "__main__":
     if args.model_name in ["deepseek"] and args.model_size == "v3" and args.gpu.lower() in ["gb200"] and args.num_gpus == 128:
         executor.env_vars["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
 
+    # Ensure all environment variables (including those added above) are propagated to the container
+    current_container_env = set(executor.container_env) if executor.container_env else set()
+    executor.container_env = list(current_container_env | set(executor.env_vars))
+
     target_script_args = [
         "--config_file",
         str(config_filepath),

--- a/scripts/performance/utils/executors.py
+++ b/scripts/performance/utils/executors.py
@@ -57,6 +57,7 @@ def slurm_executor(
     time_limit: str = "00:30:00",
     container_image: str = "nvcr.io/nvidia/nemo:dev",
     custom_mounts: List[str] = [],
+    container_env: List[str] = [],
     custom_env_vars: Dict[str, str] = {},
     custom_srun_args: List[str] = [],
     hf_token: str = None,
@@ -134,6 +135,8 @@ def slurm_executor(
         template_vars={"pre_cmds": " ; ".join(custom_bash_cmds)},
     )
 
+    all_container_env = list(set(PERF_ENV_VARS) | set(container_env))
+
     executor = run.SlurmExecutor(
         account=account,
         partition=partition,
@@ -142,6 +145,7 @@ def slurm_executor(
         ntasks_per_node=num_gpus_per_node,
         container_image=container_image,
         container_mounts=mounts,
+        container_env=all_container_env,
         env_vars=PERF_ENV_VARS,
         srun_args=srun_args,
         time=time_limit,


### PR DESCRIPTION
Expose the container_env parameter of SlurmExecutor, explicitly set container_env for any environment variable being set. If you're setting performance variables for your run you expect them to be set in the container.

The pyxis/enroot defaults are to set all variables in the user environment in the container environment, except when that variable already exists in the container. Then it won't overwrite it unless '--container-env=VAR' is set.
