### PR TITLE
Improving Qwen3-235B-A22B B200 performance.

### DIFF
--- a/scripts/performance/configs/qwen/qwen3_workload_base_configs.py
+++ b/scripts/performance/configs/qwen/qwen3_workload_base_configs.py
@@ -102,7 +102,7 @@ QWEN3_235B_A22B_PRETRAIN_CONFIG_B200_BF16 = replace(
     virtual_pipeline_model_parallel_size=4,
     expert_model_parallel_size=8,
     global_batch_size=1024,
-    moe_a2a_overlap=True,
+    moe_a2a_overlap=False,
 )
 
 
@@ -110,10 +110,9 @@ QWEN3_235B_A22B_PRETRAIN_CONFIG_B200_FP8_CS = replace(
     BASE_QWEN3_235B_A22B_CONFIG,
     num_gpus=64,
     pipeline_model_parallel_size=8,
-    virtual_pipeline_model_parallel_size=4,
     expert_model_parallel_size=8,
     global_batch_size=1024,
-    moe_a2a_overlap=True,
+    moe_a2a_overlap=False,
 )
 
 


### PR DESCRIPTION
Update Qwen3 235B A22B B200 performance recipe to address performance regression from 25.09. MXFP8 step time improved from 20.1s to 16.9s. BF16 step time improved from 17.2s to 16s.

Disable `moe_a2a_overlap` due to CPU overhead for BF16 and MXFP8. Disable VP for mxfp8.
