### PR TITLE
[Canonical LoRA] feat: Support more flexible target_modules

### DIFF
--- a/src/megatron/bridge/peft/canonical_lora.py
+++ b/src/megatron/bridge/peft/canonical_lora.py
@@ -188,15 +188,15 @@ class CanonicalLoRA(PEFT, ModuleMatcher):
                 "use ['linear_fc1_up', 'linear_fc1_gate'] with Canonical LoRA"
             )
 
-            if "linear_q" in target:
+            if target.endswith("linear_q"):
                 self.canonical_mapping[target.replace("linear_q", "linear_qkv")].add("linear_q")
-            elif "linear_k" in target:
+            elif target.endswith("linear_k"):
                 self.canonical_mapping[target.replace("linear_k", "linear_qkv")].add("linear_k")
-            elif "linear_v" in target:
+            elif target.endswith("linear_v"):
                 self.canonical_mapping[target.replace("linear_v", "linear_qkv")].add("linear_v")
-            elif "linear_fc1_up" in target:
+            elif target.endswith("linear_fc1_up"):
                 self.canonical_mapping[target.replace("linear_fc1_up", "linear_fc1")].add("linear_fc1_up")
-            elif "linear_fc1_gate" in target:
+            elif target.endswith("linear_fc1_gate"):
                 self.canonical_mapping[target.replace("linear_fc1_gate", "linear_fc1")].add("linear_fc1_gate")
             else:
                 self.canonical_mapping[target].add(target)
@@ -247,10 +247,6 @@ class CanonicalLoRA(PEFT, ModuleMatcher):
                 disable_sequence_parallel_comm=disable_sp_comm,
                 base_linear_is_parallel=base_linear_is_parallel,
             )
-            if name in ["linear_proj", "linear_fc2"]:
-                adapter = ParallelLinearAdapter(in_features, out_features, **adapter_kwargs)
-                logger.info(f"Adding lora to: {full_name}")
-                return LoRALinear(m, adapter)
 
             canonical_submodules = self.canonical_mapping[match]
             logger.info(f"Adding lora to: {full_name} ({canonical_submodules})")
@@ -275,5 +271,9 @@ class CanonicalLoRA(PEFT, ModuleMatcher):
                     adapter_gate = ParallelLinearAdapter(in_features, out_features // 2, **adapter_kwargs)
                 adapters = ModuleDict({"adapter_up": adapter_up, "adapter_gate": adapter_gate})
                 return LoRALinearSplitFC1UpGate(m, adapters)
+
+            adapter = ParallelLinearAdapter(in_features, out_features, **adapter_kwargs)
+            logger.info(f"Adding lora to: {full_name}")
+            return LoRALinear(m, adapter)
 
         return m


### PR DESCRIPTION
# What does this PR do ?

e.g., for MLA (DeepSeek V3 arch models), we should also be able to support all linear layers LoRA via setting `target_modules` as: ["linear_kv_down_proj","linear_kv_up_proj","linear_q_down_proj","linear_q_up_proj","linear_q_proj","linear_proj","linear_fc1_up","linear_fc1_gate","linear_fc2"]

# Changelog

- Not hard coding the possible supported `target_modules` and using `endswith` to matching target module names instead. 

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [X] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)

<sub>✨ Presented to you with <a href="https://macaron.im/mindlab">Mind Lab</a> - A Lab for Experiential Intelligence.</sub>
