### PR TITLE
[LoRA] fix: shared_experts with moe_shared_expert_overlap

### DIFF
--- a/src/megatron/bridge/models/conversion/model_bridge.py
+++ b/src/megatron/bridge/models/conversion/model_bridge.py
@@ -446,7 +446,7 @@ class MegatronModelBridge(Generic[HFPreTrained, ModelProviderTarget, MegatronMod
                 if isinstance(adapter, ModuleDict):
                     adapter_name = local_param_name.removeprefix(local_base_prefix + ".adapter.").split(".")[0]
                     adapter = adapter[adapter_name]
-                input_is_parallel, _, _, _, base_linear_is_parallel = get_adapter_attributes_from_linear(to_wrap)
+                input_is_parallel, _, _, _, _, base_linear_is_parallel = get_adapter_attributes_from_linear(to_wrap)
                 global_param_objects.append(
                     (
                         global_base_name,

--- a/src/megatron/bridge/peft/canonical_lora.py
+++ b/src/megatron/bridge/peft/canonical_lora.py
@@ -226,7 +226,7 @@ class CanonicalLoRA(PEFT, ModuleMatcher):
                 )
 
             is_expert = is_expert_linear(full_name)
-            input_is_parallel, in_features, out_features, disable_sp_comm, base_linear_is_parallel = (
+            input_is_parallel, in_features, out_features, disable_tp_comm, disable_sp_comm, base_linear_is_parallel = (
                 get_adapter_attributes_from_linear(m, is_expert=is_expert)
             )
 
@@ -244,6 +244,7 @@ class CanonicalLoRA(PEFT, ModuleMatcher):
                 model_parallel_config=getattr(m, "config", None),
                 alpha=self.alpha,
                 is_expert=is_expert,
+                disable_tensor_parallel_comm=disable_tp_comm,
                 disable_sequence_parallel_comm=disable_sp_comm,
                 base_linear_is_parallel=base_linear_is_parallel,
             )

--- a/src/megatron/bridge/peft/dora.py
+++ b/src/megatron/bridge/peft/dora.py
@@ -90,7 +90,7 @@ class DoRA(PEFT, ModuleMatcher):
 
         if (ans := self.match(m, name, prefix)) is not None:
             (match, full_name) = ans
-            input_is_parallel, in_features, out_features, disable_sp_comm, base_linear_is_parallel = (
+            input_is_parallel, in_features, out_features, disable_tp_comm, disable_sp_comm, base_linear_is_parallel = (
                 get_adapter_attributes_from_linear(m)
             )
             logger.info(f"Adding DoRA to: {full_name}")
@@ -109,6 +109,7 @@ class DoRA(PEFT, ModuleMatcher):
                 dropout_position=self.dropout_position,
                 model_parallel_config=getattr(m, "config", None),
                 alpha=self.alpha,
+                disable_tensor_parallel_comm=disable_tp_comm,
                 disable_sequence_parallel_comm=disable_sp_comm,
                 base_linear_is_parallel=base_linear_is_parallel,
             )

--- a/src/megatron/bridge/peft/lora.py
+++ b/src/megatron/bridge/peft/lora.py
@@ -135,7 +135,7 @@ class LoRA(PEFT, ModuleMatcher):
                 )
 
             is_expert = is_expert_linear(full_name)
-            input_is_parallel, in_features, out_features, disable_sp_comm, base_linear_is_parallel = (
+            input_is_parallel, in_features, out_features, disable_tp_comm, disable_sp_comm, base_linear_is_parallel = (
                 get_adapter_attributes_from_linear(module, is_expert=is_expert)
             )
 
@@ -164,6 +164,7 @@ class LoRA(PEFT, ModuleMatcher):
                 alpha=self.alpha,
                 is_expert=is_expert,
                 a2a_experimental=self.a2a_experimental,
+                disable_tensor_parallel_comm=disable_tp_comm,
                 disable_sequence_parallel_comm=disable_sp_comm,
                 base_linear_is_parallel=base_linear_is_parallel,
             )

--- a/tests/unit_tests/models/test_model_bridge_lora.py
+++ b/tests/unit_tests/models/test_model_bridge_lora.py
@@ -257,7 +257,7 @@ def test_megatron_global_adapters_info_all_pp_ranks(monkeypatch):
     )
     monkeypatch.setattr(
         "megatron.bridge.models.conversion.model_bridge.get_adapter_attributes_from_linear",
-        lambda *_args, **_kwargs: (True, None, None, None, False),
+        lambda *_args, **_kwargs: (True, None, None, None, None, False),
     )
     monkeypatch.setattr(
         "torch.distributed.all_gather_object",

--- a/tests/unit_tests/peft/test_canonical_lora.py
+++ b/tests/unit_tests/peft/test_canonical_lora.py
@@ -221,10 +221,10 @@ class TestCanonicalLoRA:
         def mock_get_attrs(module, is_expert=False):
             if hasattr(module, "out_features"):
                 if module.out_features == 1536:  # linear_qkv
-                    return (False, 512, 1536, False, True)
+                    return (False, 512, 1536, False, True, True)
                 elif module.out_features == 2048:  # linear_fc1
-                    return (False, 512, 2048, False, True)
-            return (False, 512, 512, False, True)  # default
+                    return (False, 512, 2048, False, True, True)
+            return (False, 512, 512, False, True, True)  # default
 
         with patch(
             "megatron.bridge.peft.canonical_lora.get_adapter_attributes_from_linear", side_effect=mock_get_attrs
@@ -487,7 +487,7 @@ class TestCanonicalLoRA:
 
         # Mock the get_adapter_attributes_from_linear function
         with patch("megatron.bridge.peft.canonical_lora.get_adapter_attributes_from_linear") as mock_get_attrs:
-            mock_get_attrs.return_value = (False, 512, 1536, False, True)
+            mock_get_attrs.return_value = (False, 512, 1536, False, True, True)
 
             # Mock ParallelLinearAdapter
             with patch("megatron.bridge.peft.canonical_lora.ParallelLinearAdapter") as mock_adapter:
@@ -525,7 +525,7 @@ class TestCanonicalLoRAMegatronLayers:
 
         # Mock the get_adapter_attributes_from_linear function
         with patch("megatron.bridge.peft.canonical_lora.get_adapter_attributes_from_linear") as mock_get_attrs:
-            mock_get_attrs.return_value = (False, 512, 1536, False, True)
+            mock_get_attrs.return_value = (False, 512, 1536, False, True, True)
 
             # Mock ParallelLinearAdapter
             with patch("megatron.bridge.peft.canonical_lora.ParallelLinearAdapter") as mock_adapter:
@@ -547,7 +547,7 @@ class TestCanonicalLoRAMegatronLayers:
 
         # Mock the get_adapter_attributes_from_linear function
         with patch("megatron.bridge.peft.canonical_lora.get_adapter_attributes_from_linear") as mock_get_attrs:
-            mock_get_attrs.return_value = (False, 512, 2048, False, True)
+            mock_get_attrs.return_value = (False, 512, 2048, False, True, True)
 
             # Mock ParallelLinearAdapter
             with patch("megatron.bridge.peft.canonical_lora.ParallelLinearAdapter") as mock_adapter:

--- a/tests/unit_tests/peft/test_utils.py
+++ b/tests/unit_tests/peft/test_utils.py
@@ -276,13 +276,19 @@ class TestGetAdapterAttributes:
         mock_parallel_state.get_tensor_model_parallel_world_size.return_value = 1
         linear = MockColumnParallelLinear(input_size=100, output_size=50)
 
-        input_is_parallel, in_features, out_features, disable_sp_comm, base_linear_is_parallel = (
-            get_adapter_attributes_from_linear(linear)
-        )
+        (
+            input_is_parallel,
+            in_features,
+            out_features,
+            disable_tp_comm,
+            disable_sp_comm,
+            base_linear_is_parallel,
+        ) = get_adapter_attributes_from_linear(linear)
 
         assert not input_is_parallel
         assert in_features == 100
         assert out_features == 50
+        assert not disable_tp_comm
         assert disable_sp_comm  # Should be True when sequence_parallel is False
         assert base_linear_is_parallel  # Should be True for parallel linear layers
 
@@ -292,13 +298,19 @@ class TestGetAdapterAttributes:
         mock_parallel_state.get_tensor_model_parallel_world_size.return_value = 1
         linear = MockRowParallelLinear(input_size=100, output_size=50)
 
-        input_is_parallel, in_features, out_features, disable_sp_comm, base_linear_is_parallel = (
-            get_adapter_attributes_from_linear(linear)
-        )
+        (
+            input_is_parallel,
+            in_features,
+            out_features,
+            disable_tp_comm,
+            disable_sp_comm,
+            base_linear_is_parallel,
+        ) = get_adapter_attributes_from_linear(linear)
 
         assert input_is_parallel
         assert in_features == 100
         assert out_features == 50
+        assert not disable_tp_comm
         assert disable_sp_comm
         assert base_linear_is_parallel  # Should be True for parallel linear layers
 
@@ -309,10 +321,16 @@ class TestGetAdapterAttributes:
         linear = MockColumnParallelLinear(input_size=100, output_size=50)
         linear.config.sequence_parallel = True
 
-        input_is_parallel, in_features, out_features, disable_sp_comm, base_linear_is_parallel = (
-            get_adapter_attributes_from_linear(linear)
-        )
+        (
+            input_is_parallel,
+            in_features,
+            out_features,
+            disable_tp_comm,
+            disable_sp_comm,
+            base_linear_is_parallel,
+        ) = get_adapter_attributes_from_linear(linear)
 
+        assert not disable_tp_comm
         assert not disable_sp_comm  # Should be False when sequence_parallel is True
         assert base_linear_is_parallel  # Should be True for parallel linear layers
 
@@ -332,12 +350,12 @@ class TestGetAdapterAttributes:
         mock_parallel_state.get_tensor_model_parallel_world_size.return_value = 1
         # Test with ColumnParallelLinear - should return True for base_linear_is_parallel
         column_linear = MockColumnParallelLinear(input_size=100, output_size=50)
-        _, _, _, _, base_linear_is_parallel = get_adapter_attributes_from_linear(column_linear)
+        _, _, _, _, _, base_linear_is_parallel = get_adapter_attributes_from_linear(column_linear)
         assert base_linear_is_parallel  # Should be True for parallel linear layers
 
         # Test with RowParallelLinear - should return True for base_linear_is_parallel
         row_linear = MockRowParallelLinear(input_size=100, output_size=50)
-        _, _, _, _, base_linear_is_parallel = get_adapter_attributes_from_linear(row_linear)
+        _, _, _, _, _, base_linear_is_parallel = get_adapter_attributes_from_linear(row_linear)
         assert base_linear_is_parallel  # Should be True for parallel linear layers
 
 


### PR DESCRIPTION
# What does this PR do ?

fix `shared_experts` layers when `moe_shared_expert_overlap` is enabled 

# Changelog

- `shared_experts` are not actually sharded using ETP, so we should get it excluded from `is_expert_linear`.
- In some modules (notably MoE shared_experts when moe_shared_expert_overlap is enabled), Megatron disables TP-related communications on the base linear layer by setting `parallel_mode=None` (TE) or `explicit_expert_comm=True` (legacy). https://github.com/NVIDIA/Megatron-LM/blob/5b1ef0703184299fbf71f6131bf2f9a5331e7238/megatron/core/transformer/moe/shared_experts.py#L95-L104 This will need some special handling on lin_out_gather_output to keep shape matches.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [X] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [X] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)

<sub>✨ Presented to you with <a href="https://macaron.im/mindlab">Mind Lab</a> - A Lab for Experiential Intelligence.</sub>