### PR TITLE
GPTModelProvider Make use_arbitrary_attention_mask configurable

### DIFF
--- a/src/megatron/bridge/models/gpt_provider.py
+++ b/src/megatron/bridge/models/gpt_provider.py
@@ -95,9 +95,13 @@ def local_layer_spec(config: "GPTModelProvider") -> ModuleSpec:
 
 def quantization_layer_spec(config: "GPTModelProvider") -> ModuleSpec:
     """Layer specification for quantization with ModelOpt."""
-    use_arbitrary_attention_mask = parallel_state.get_context_parallel_world_size() == 1
     # arbitrary attention mask is used for speculative decoding training
     # When context parallel > 1, only causal mask type is supported
+    use_arbitrary_attention_mask = (
+        config.use_arbitrary_attention_mask
+        if config.use_arbitrary_attention_mask is not None
+        else parallel_state.get_context_parallel_world_size() == 1
+    )
     return get_gpt_modelopt_spec(
         config=config,
         local_core_attention=False,
@@ -183,6 +187,11 @@ class GPTModelProvider(TransformerConfig, ModelProviderMixin[MCoreGPTModel]):
     # If True, restore the modelopt_state that contains quantization, sparsity, speculative decoding transformation state.
     # When resuming modelopt_state, we also change the transformer_layer_spec to `megatron.core.post_training.modelopt.gpt.model_specs` which is a combination of local spec + TEDotProductAttention.
     restore_modelopt_state: bool = False
+
+    # Whether to use AttnMaskType.arbitrary in the ModelOpt spec.
+    # If None, it will be determined by the default behavior (arbitrary only when context_parallel==1).
+    # Set to False when using packed/remove-padding (THD) data format.
+    use_arbitrary_attention_mask: Optional[bool] = None
 
     def provide(self, pre_process=None, post_process=None, vp_stage=None) -> MCoreGPTModel:
         """Configure and instantiate a Megatron Core GPT model based on this configuration.


### PR DESCRIPTION
# What does this PR do ?

So that downstream project can have more control over this.

If None, it will be determined by the default behavior (arbitrary only when context_parallel==1). We will need to set to False when using packed/remove-padding (THD) data format.

# Changelog

- Add `use_arbitrary_attention_mask` config to `GPTModelProvider`.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [X] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
