### PR TITLE
Disables FP8 when using CPU initialization when loading a megatron model (e.g., during export)

### DIFF
--- a/src/megatron/bridge/training/model_load_save.py
+++ b/src/megatron/bridge/training/model_load_save.py
@@ -377,6 +377,9 @@ def load_megatron_model(
     model_cfg.perform_initialization = False
     model_cfg.virtual_pipeline_model_parallel_size = None
     model_cfg.hierarchical_context_parallel_sizes = None
+    if use_cpu_init:
+        model_cfg.fp8 = None
+        model_cfg.fp8_param = False
 
     # Apply model-parallel overrides if provided
     if mp_overrides:


### PR DESCRIPTION
# What does this PR do ?

Disables FP8 when using CPU initialization  when loading a megatron model (e.g., during export). 

# Changelog

- Disables FP8 when using CPU initialization  when loading a megatron model (e.g., during export). 

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [v] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

This is following the same convention done in NeMo: 

https://github.com/NVIDIA/NeMo/blob/main/nemo/lightning/io/connector.py#L241-L242

I encountered this when trying to export the checkpoint from a training run, and the container froze and I had to reboot the machine:

```bash
python examples/conversion/convert_checkpoints.py export  --hf-model $HF_MODEL_ID  --megatron-path /path/to/trained/checkpoint --hf-path /path/to/save
```