### PR TITLE
fix: Moonlight/Kimi (DeepSeek V3 MoE) supports exporting to model.layers.*.self_attn.rotary_emb.inv_freq

### DIFF
--- a/src/megatron/bridge/models/conversion/model_bridge.py
+++ b/src/megatron/bridge/models/conversion/model_bridge.py
@@ -687,15 +687,19 @@ class MegatronModelBridge(Generic[HFPreTrained, ModelProviderTarget, MegatronMod
         return hf_weights
 
     def maybe_modify_converted_hf_weight(
-        self, task: WeightConversionTask, converted_weights_dict: Dict[str, torch.Tensor]
+        self,
+        task: WeightConversionTask,
+        converted_weights_dict: Dict[str, torch.Tensor],
+        hf_state_dict: Mapping[str, torch.Tensor],
     ) -> Dict[str, torch.Tensor]:
         """Modify the converted weights after conversion. By default, no modification is done.
         This function can be overridden by subclasses to postprocess the converted weights, such as merging the
         weights of multiple experts or quantizing the weights.
 
         Args:
-            task: The WeightConversionTask object
+            task: The WeightConversionTask object.
             converted_weights_dict: The converted weights dictionary.
+            hf_state_dict: The HuggingFace state dict accessor for expected-key checks.
 
         Returns:
             The modified weights dictionary.
@@ -947,10 +951,15 @@ class MegatronModelBridge(Generic[HFPreTrained, ModelProviderTarget, MegatronMod
         unwrapped_model = unwrap_model(megatron_model)[0]
         model_config = unwrapped_model.config
         embeddings_are_tied = self._share_embeddings_and_output_weights(model_config, unwrapped_model)
+
+        hf_state_dict: Mapping[str, torch.Tensor] = hf_pretrained.state if hasattr(hf_pretrained, "state") else {}
+
         for task in self._with_progress_tracking(megatron_to_hf_tasks, "Converting to HuggingFace", show_progress):
             converted_weights_dict = task.mapping.megatron_to_hf(task.param_weight, task.megatron_module)
             converted_weights_dict = self.maybe_modify_converted_hf_weight(
-                task, converted_weights_dict
+                task,
+                converted_weights_dict,
+                hf_state_dict,
             )  # dict will be none except for one expert;
             # All ranks get the full tensor
 

--- a/src/megatron/bridge/models/gpt_oss/gpt_oss_bridge.py
+++ b/src/megatron/bridge/models/gpt_oss/gpt_oss_bridge.py
@@ -109,7 +109,10 @@ class GPTOSSBridge(MegatronModelBridge):
         return hf_weights
 
     def maybe_modify_converted_hf_weight(
-        self, task: WeightConversionTask, converted_weights_dict: Dict[str, torch.Tensor]
+        self,
+        task: WeightConversionTask,
+        converted_weights_dict: Dict[str, torch.Tensor],
+        hf_state_dict: Mapping[str, torch.Tensor],
     ) -> Dict[str, torch.Tensor]:
         num_experts = self.hf_config.num_local_experts
         ep_size = parallel_state.get_expert_model_parallel_world_size()


### PR DESCRIPTION
# What does this PR do ?

Add support for exporting `model.layers.*.self_attn.rotary_emb.inv_freq` to fix the following errors when save as hf model format.

```log
 Warning: The following files could not be saved because the generator did not yield all of their tensors:
   - model-19-of-27.safetensors: missing 1 tensors:
     - model.layers.18.self_attn.rotary_emb.inv_freq
   - model-27-of-27.safetensors: missing 1 tensors:
     - model.layers.26.self_attn.rotary_emb.inv_freq
 …
 Warning: 5317 tensors were yielded but not saved because their corresponding file shards were incomplete.
 ```

# Changelog

- Override `maybe_modify_converted_hf_weight` for DeepSeek V3 and add DeepSeek rotary embedding inverse frequency parameter if not present.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [X] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [X] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
