### PR TITLE
[WIP] padded_vocab_size support

### DIFF
--- a/src/megatron/bridge/models/conversion/auto_bridge.py
+++ b/src/megatron/bridge/models/conversion/auto_bridge.py
@@ -907,7 +907,11 @@ class AutoBridge(Generic[MegatronModelT]):
 
     @property
     def _model_bridge(self) -> "MegatronModelBridge":
-        return model_bridge.get_model_bridge(self._causal_lm_architecture)
+        if isinstance(self.hf_pretrained, PreTrainedCausalLM):
+            config = self.hf_pretrained.config
+        else:
+            config = self.hf_pretrained
+        return model_bridge.get_model_bridge(self._causal_lm_architecture, hf_config=config)
 
     @property
     def _provider_bridge_input(self) -> PreTrainedCausalLM | _ConfigOnlyPretrainedShim:

--- a/src/megatron/bridge/models/conversion/model_bridge.py
+++ b/src/megatron/bridge/models/conversion/model_bridge.py
@@ -1477,7 +1477,7 @@ def is_tensor_parallel(param) -> bool:
 
 # Core dispatch functions
 @dispatch
-def get_model_bridge(hf_architecture) -> "MegatronModelBridge":
+def get_model_bridge(hf_architecture, hf_config = None) -> "MegatronModelBridge":
     """Get the appropriate model bridge for a given HuggingFace architecture."""
     ...
 
@@ -1513,8 +1513,10 @@ def register_bridge_implementation(
     bridge_class_name = bridge_class.__name__
 
     @get_model_bridge.impl(source)
-    def _get_model_bridge_impl(_) -> "MegatronModelBridge":
+    def _get_model_bridge_impl(_, hf_config) -> "MegatronModelBridge":
         bridge = bridge_class()
+        # allow bridge to access model config
+        bridge.hf_config = hf_config
         return bridge
 
     @stream_weights_megatron_to_hf.impl((source, target))

--- a/src/megatron/bridge/models/conversion/param_mapping.py
+++ b/src/megatron/bridge/models/conversion/param_mapping.py
@@ -14,7 +14,6 @@
 
 import json
 import re
-from collections import defaultdict
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Generic, List, Optional, Tuple, TypeVar, Union
 

--- a/src/megatron/bridge/models/conversion/param_mapping.py
+++ b/src/megatron/bridge/models/conversion/param_mapping.py
@@ -14,12 +14,15 @@
 
 import json
 import re
+from collections import defaultdict
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Generic, List, Optional, Tuple, TypeVar, Union
 
 import torch
 import torch.distributed
 import torch.nn as nn
+from torch.nn import functional as F
+
 from megatron.core import mpu
 from megatron.core.fp8_utils import FP8_TENSOR_CLASS, HAVE_TE_FP8_TENSOR_CLASS
 from megatron.core.transformer.module import MegatronModule
@@ -862,6 +865,36 @@ class ColumnParallelMapping(MegatronParamMapping[torch.Tensor]):
 
         return {str(self.hf_param): full_weights}
 
+
+class WordEmbeddingMapping(ColumnParallelMapping):
+    """Mapping for word embdding / lm head"""
+
+    def __init__(self, megatron_param, hf_param, hf_vocab_size: int = None):
+        super().__init__(megatron_param, hf_param)
+        self.vocab_size = hf_vocab_size
+
+    def hf_to_megatron(self, hf_weights: torch.Tensor, megatron_module: nn.Module) -> torch.Tensor:
+        """Padding if needed during conversion"""
+        if self.vocab_size is None:
+            self.vocab_size = hf_weights.shape[0]
+        if hf_weights.shape[0] != self.vocab_size:
+            raise ValueError(f"The expect vocab size is {self.vocab_size}, but the shape of loaded weight is {hf_weights.shape}")
+        full_size = megatron_module.weight.shape[0] * self.tp_size
+        if full_size != hf_weights.shape[0]:
+            if full_size < self.vocab_size:
+                raise ValueError("The vocab size of mcore model should be larger than HF ckpt!")
+            hf_weights = F.pad(hf_weights, (0, 0, 0, full_size - hf_weights.shape[0]), mode='constant', value=0)
+        return super().hf_to_megatron(hf_weights, megatron_module)
+
+    def megatron_to_hf(self, megatron_weights: torch.Tensor, megatron_module: nn.Module) -> Dict[str, torch.Tensor]:
+        assert self.vocab_size is not None, "hf vocab size must be provided when converting megatron weight to hf!"
+        weight_dict = super().megatron_to_hf(megatron_weights, megatron_module)
+        for k, v in weight_dict.items():
+            full_size = v.shape[0]
+            if full_size < self.vocab_size:
+                raise ValueError("The vocab size of mcore model should be larger than HF ckpt!")
+            weight_dict[k] = v[:self.vocab_size]
+        return weight_dict
 
 class RowParallelMapping(MegatronParamMapping[torch.Tensor]):
     """Mapping for **row-parallel** linear weights.

--- a/src/megatron/bridge/models/gpt_provider.py
+++ b/src/megatron/bridge/models/gpt_provider.py
@@ -158,6 +158,7 @@ class GPTModelProvider(TransformerConfig, ModelProviderMixin[MCoreGPTModel]):
     # This represents the unpadded vocab size
     # The padded vocab size is automatically calculated in the provide() method.
     vocab_size: Optional[int] = None
+    padded_vocab_size: Optional[int] = None
     # Set if the tokenizer provides the vocab size. In this case, the vocab size will be padded
     # Controls whether vocab size should be padded for tensor parallelism
     should_pad_vocab: bool = False
@@ -240,7 +241,10 @@ class GPTModelProvider(TransformerConfig, ModelProviderMixin[MCoreGPTModel]):
                 transformer_layer_spec = transformer_layer_spec(self)
 
         assert self.vocab_size is not None, "vocab_size must be configured before calling provide()"
-        if self.should_pad_vocab:
+        if self.padded_vocab_size is not None:
+            assert self.padded_vocab_size >= self.vocab_size, "The provided padded vocab size should be no less than base vocab size"
+            padded_vocab_size = self.padded_vocab_size
+        elif self.should_pad_vocab:
             padded_vocab_size = calculate_padded_vocab_size(
                 self.vocab_size, self.make_vocab_size_divisible_by, self.tensor_model_parallel_size
             )


### PR DESCRIPTION
# What does this PR do ?

This draft PR is for some missing logics of `padded_vocab_size`. Please refer to #1853 .

# Changelog

- Implement `WordEmbeddingMapping` for auto padding/unpadding support
- pass hf_config to MegatronModelBridge

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

 - [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
 - [ ] Did you write any new necessary tests?
 - [x] Did you add or update any necessary documentation?
 - [x] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
 - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to  #1853 
