### PR TITLE
Update Deepseek V3 B200 recipe

### DIFF
--- a/scripts/performance/configs/deepseek/deepseek_workload_base_configs.py
+++ b/scripts/performance/configs/deepseek/deepseek_workload_base_configs.py
@@ -65,9 +65,10 @@ DEEPSEEK_V3_PRETRAIN_CONFIG_B200 = replace(
     BASE_DEEPSEEK_V3_CONFIG,
     num_gpus=256,
     pipeline_model_parallel_size=16,
-    expert_model_parallel_size=8,
+    expert_model_parallel_size=16,
     global_batch_size=2048,
     recompute_modules=["mla_up_proj"],
+    moe_flex_dispatcher_backend="deepep",
     moe_a2a_overlap=False,
 )
 DEEPSEEK_V3_PRETRAIN_CONFIG_B200_BF16 = DEEPSEEK_V3_PRETRAIN_CONFIG_B200


### PR DESCRIPTION
# What does this PR do ?
This PR update Deepseek V3 B200 performance recipe for better performance.

25.11 tracker has 532 and 557 TFLOPs for BF16 and MXFP8 respectively. The updated config has 575 and 635 TFLOPs for BF16 and MXFP8 respectively.
