### PR TITLE
fix: prioritize dataclass recursion in config conversion

### DIFF
--- a/src/megatron/bridge/training/utils/omegaconf_utils.py
+++ b/src/megatron/bridge/training/utils/omegaconf_utils.py
@@ -355,12 +355,12 @@ def _track_excluded_fields(obj: Any, path: str = "") -> Dict[str, Any]:
             field_path = f"{path}.{field_name}" if path else field_name
             field_value = getattr(obj, field_name)
 
-            if _is_omegaconf_problematic(field_value):
-                excluded_fields[field_path] = field_value
-                logger.debug(f"Tracking excluded callable: {field_path}")
-            elif dataclasses.is_dataclass(field_value):
+            if dataclasses.is_dataclass(field_value):
                 nested_excluded = _track_excluded_fields(field_value, field_path)
                 excluded_fields.update(nested_excluded)
+            elif _is_omegaconf_problematic(field_value):
+                excluded_fields[field_path] = field_value
+                logger.debug(f"Tracking excluded callable: {field_path}")
             elif isinstance(field_value, dict):
                 for key, value in field_value.items():
                     if _is_omegaconf_problematic(value):


### PR DESCRIPTION
# fix: prioritize dataclass recursion in config conversion

Reorder _track_excluded_fields checks to recurse into dataclasses before checking for problematic fields. This ensures only leaf-level callables (like defaultdict) are excluded, not their parent dataclass containers.

Fixes YAML override issue where 'peft: dora' was ignored because the entire LoRA dataclass was incorrectly excluded.

# What does this PR do?

Fixes config override logic to ensure dataclass fields (like `peft`) can be properly overridden by YAML configs, while still excluding problematic nested fields.

# Changelog

- Reorder if-elif checks in `_track_excluded_fields` to prioritize `dataclasses.is_dataclass()` before `_is_omegaconf_problematic()`
- Ensures dataclass containers are recursively processed instead of being excluded entirely
- Only leaf-level problematic fields (e.g., callables, defaultdict) are now excluded
- Enables YAML overrides like `peft: 'dora'` to work correctly

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

# Additional Information

## Root Cause
When overriding configs via YAML, `mixed_precision` could be overridden successfully, but `peft` silently failed. Investigation revealed that `_track_excluded_fields` was checking `_is_omegaconf_problematic()` before recursing into dataclasses. With the incorrect check order, the entire `peft` (LoRA dataclass) was being excluded, preventing any YAML overrides from taking effect.

## Why mixed_precision worked but peft didn't
- `MixedPrecisionConfig`: Contains only safe primitive types → never triggered problematic check → overrides worked
- `LoRA`: Likely contains problematic fields (callables or complex types) → entire object excluded with wrong check order → overrides failed

## Solution
By checking `dataclasses.is_dataclass()` first, we now recursively process dataclass containers and only exclude their problematic leaf fields, allowing the parent dataclass to remain in OmegaConf for override capability.
