### PR TITLE
correct_parallelism_perf_plugin

### DIFF
--- a/scripts/performance/perf_plugins.py
+++ b/scripts/performance/perf_plugins.py
@@ -192,10 +192,10 @@ class PerfEnvPlugin(Plugin):
     enable_vboost: bool = False
     enable_manual_gc: bool = True
     manual_gc_interval: int = 100
-    tp_size: int = 1
-    cp_size: int = 1
-    pp_size: int = 1
-    ep_size: int = 1
+    tp_size: int | None = None
+    cp_size: int | None = None
+    pp_size: int | None = None
+    ep_size: int | None = None
     script_args_converter_fn: Optional[Callable[[PerfEnvPluginScriptArgs], List[str]]] = None
     moe_a2a_overlap: bool = False
     model_family_name: str
@@ -374,7 +374,7 @@ class PerfEnvPlugin(Plugin):
         tp_size = self.tp_size if self.tp_size is not None else workload_base_config.tensor_model_parallel_size
         pp_size = self.pp_size if self.pp_size is not None else workload_base_config.pipeline_model_parallel_size
         cp_size = self.cp_size if self.cp_size is not None else workload_base_config.context_parallel_size
-        ep_size = self.ep_size if self.ep_size is not None else workload_base_config.ep_size
+        ep_size = self.ep_size if self.ep_size is not None else workload_base_config.expert_model_parallel_size
 
         # Force program order kernel launch for TP, CP overlap
         moe_flex_dispatcher_backend = getattr(workload_base_config, "moe_flex_dispatcher_backend", None)


### PR DESCRIPTION
# What does this PR do ?
Correct setting for parallelism sizes and arg name

- The default values for parallelism sizes is 1. 
- But, we check for `None` causing regression and failure due to incorrect setting for `CUDA_DEVICE_MAX_CONNECTIONS` and `NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN`.

# Changelog

```
    tp_size: int | None = None
    cp_size: int | None = None
    pp_size: int | None = None
    ep_size: int | None = None
```

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
