### PR TITLE
ci: Fix lora test with AdapterAttributes

### DIFF
--- a/tests/unit_tests/peft/test_lora_layers.py
+++ b/tests/unit_tests/peft/test_lora_layers.py
@@ -808,14 +808,13 @@ class TestLoRATopKRouterAdapters:
         )
 
         attrs = peft_utils.get_adapter_attributes_from_linear(router)
-        input_is_parallel, in_features, out_features, disable_tp_comm, disable_sp_comm, base_linear_is_parallel = attrs
 
-        assert input_is_parallel is False
-        assert in_features == router.weight.shape[1]
-        assert out_features == router.weight.shape[0]
-        assert disable_tp_comm is False
-        assert disable_sp_comm is True
-        assert base_linear_is_parallel is False
+        assert attrs.input_is_parallel is False
+        assert attrs.in_features == router.weight.shape[1]
+        assert attrs.out_features == router.weight.shape[0]
+        assert attrs.disable_tensor_parallel_comm is False
+        assert attrs.disable_sequence_parallel_comm is True
+        assert attrs.base_linear_is_parallel is False
 
 
 class TestCanonicalLoRATopKRouter:


### PR DESCRIPTION
# What does this PR do ?

Fix lora test with AdapterAttributes

I think two PRs merged close together and there's a breaking test on main.  On a separate unrelated PR, I had some unit tests failing.  
https://github.com/NVIDIA-NeMo/Megatron-Bridge/actions/runs/20941216942/job/60176460561?pr=1618

I think it was these two PRs:
* https://github.com/NVIDIA-NeMo/Megatron-Bridge/pull/1766
* https://github.com/NVIDIA-NeMo/Megatron-Bridge/pull/1834

# Changelog

- Fix lora test with AdapterAttributes

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
