### PR TITLE
Utilize B300 cluster PCT cores

### DIFF
--- a/scripts/performance/utils/executors.py
+++ b/scripts/performance/utils/executors.py
@@ -125,6 +125,8 @@ def slurm_executor(
 
     numa_divisor = 2 if gpu.lower() in ["gb200", "gb300"] else 4
     numa_cmd = f"numactl --cpunodebind=$((SLURM_LOCALID/{numa_divisor})) --membind=$((SLURM_LOCALID/{numa_divisor}))"
+    if gpu.lower() in ["b300"]:
+        numa_cmd += " -C $((SLURM_LOCALID * 16)),$((SLURM_LOCALID * 16 + 1))"
     custom_bash_cmds.append(numa_cmd)
 
     launcher = SlurmTemplate(


### PR DESCRIPTION
Binding Priority Core Turbo (PCT) cores on Bia cluster (B300) that improves CPU latency. This recovers 60% performance regression compared to Prenyx (B200).