### PR TITLE
Make TransformerConfig an attribute in MambaProvider

### DIFF
--- a/src/megatron/bridge/models/mamba/mamba_provider.py
+++ b/src/megatron/bridge/models/mamba/mamba_provider.py
@@ -260,13 +260,30 @@ class MambaModelProvider130M(MambaModelProvider):
         This class is deprecated and will be removed in a future release.
     """
 
-    hybrid_override_pattern: str = "M" * 24
-    num_layers: int = 24
-    seq_length: int = 2048
-    hidden_size: int = 768
-    mamba_num_groups: int = 1
-    ffn_hidden_size: int = 768
-    make_vocab_size_divisible_by: int = 16
+    def __init__(
+        self,
+        hybrid_override_pattern: str = "M" * 24,
+        seq_length: int = 2048,
+        make_vocab_size_divisible_by: int = 16,
+        *args,
+        **kwargs,
+    ):
+        super().__init__(
+            hybrid_override_pattern=hybrid_override_pattern,
+            make_vocab_size_divisible_by=make_vocab_size_divisible_by,
+            *args,
+            **kwargs,
+        )
+
+    @override
+    def _default_transformer_cfg(self):
+        cfg = super()._default_transformer_cfg()
+        cfg.num_layers = 24
+        cfg.hidden_size = 768
+        cfg.mamba_num_groups = 1
+        cfg.ffn_hidden_size = 768
+
+        return cfg
 
     def finalize(self) -> None:
         self.transformer_cfg.finalize()

--- a/src/megatron/bridge/models/mamba/mamba_provider.py
+++ b/src/megatron/bridge/models/mamba/mamba_provider.py
@@ -269,7 +269,7 @@ class MambaModelProvider130M(MambaModelProvider):
     make_vocab_size_divisible_by: int = 16
 
     def finalize(self) -> None:
-        super().finalize()
+        self.transformer_cfg.finalize()
         _warn_class_deprecated("MambaModelProvider130M")
 
 
@@ -290,7 +290,7 @@ class MambaModelProvider370M(MambaModelProvider):
     make_vocab_size_divisible_by: int = 16
 
     def finalize(self) -> None:
-        super().finalize()
+        self.transformer_cfg.finalize()
         _warn_class_deprecated("MambaModelProvider370M")
 
 
@@ -311,7 +311,7 @@ class MambaModelProvider780M(MambaModelProvider):
     make_vocab_size_divisible_by: int = 16
 
     def finalize(self) -> None:
-        super().finalize()
+        self.transformer_cfg.finalize()
         _warn_class_deprecated("MambaModelProvider780M")
 
 
@@ -332,7 +332,7 @@ class MambaModelProvider1P3B(MambaModelProvider):
     make_vocab_size_divisible_by: int = 16
 
     def finalize(self) -> None:
-        super().finalize()
+        self.transformer_cfg.finalize()
         _warn_class_deprecated("MambaModelProvider1P3B")
 
 
@@ -353,7 +353,7 @@ class MambaModelProvider2P7B(MambaModelProvider):
     make_vocab_size_divisible_by: int = 16
 
     def finalize(self) -> None:
-        super().finalize()
+        self.transformer_cfg.finalize()
         _warn_class_deprecated("MambaModelProvider2P7B")
 
 
@@ -375,7 +375,7 @@ class NVIDIAMambaModelProvider8B(MambaModelProvider):
     make_vocab_size_divisible_by: int = 128
 
     def finalize(self) -> None:
-        super().finalize()
+        self.transformer_cfg.finalize()
         _warn_class_deprecated("NVIDIAMambaModelProvider8B")
 
 
@@ -398,7 +398,7 @@ class NVIDIAMambaHybridModelProvider8B(MambaModelProvider):
     make_vocab_size_divisible_by: int = 128
 
     def finalize(self) -> None:
-        super().finalize()
+        self.transformer_cfg.finalize()
         _warn_class_deprecated("NVIDIAMambaHybridModelProvider8B")
 
 
@@ -441,7 +441,7 @@ class MambaProvider(MambaModelProvider):
 
     def __post_init__(self) -> None:
         _warn_deprecated("MambaProvider", "MambaModelProvider")
-        super().__post_init__()
+        self.transformer_cfg.__post_init__()
 
 
 @dataclass
@@ -455,7 +455,7 @@ class MambaProvider130M(MambaModelProvider130M):
 
     def __post_init__(self) -> None:
         _warn_deprecated("MambaProvider130M", "MambaModelProvider130M")
-        super().__post_init__()
+        self.transformer_cfg.__post_init__()
 
 
 @dataclass
@@ -469,7 +469,7 @@ class MambaProvider370M(MambaModelProvider370M):
 
     def __post_init__(self) -> None:
         _warn_deprecated("MambaProvider370M", "MambaModelProvider370M")
-        super().__post_init__()
+        self.transformer_cfg.__post_init__()
 
 
 @dataclass
@@ -483,7 +483,7 @@ class MambaProvider780M(MambaModelProvider780M):
 
     def __post_init__(self) -> None:
         _warn_deprecated("MambaProvider780M", "MambaModelProvider780M")
-        super().__post_init__()
+        self.transformer_cfg.__post_init__()
 
 
 @dataclass
@@ -497,7 +497,7 @@ class MambaProvider1_3B(MambaModelProvider1P3B):
 
     def __post_init__(self) -> None:
         _warn_deprecated("MambaProvider1_3B", "MambaModelProvider1P3B")
-        super().__post_init__()
+        self.transformer_cfg.__post_init__()
 
 
 @dataclass
@@ -511,7 +511,7 @@ class MambaProvider2_7B(MambaModelProvider2P7B):
 
     def __post_init__(self) -> None:
         _warn_deprecated("MambaProvider2_7B", "MambaModelProvider2P7B")
-        super().__post_init__()
+        self.transformer_cfg.__post_init__()
 
 
 @dataclass
@@ -525,7 +525,7 @@ class NVIDIAMambaProvider8B(NVIDIAMambaModelProvider8B):
 
     def __post_init__(self) -> None:
         _warn_deprecated("NVIDIAMambaProvider8B", "NVIDIAMambaModelProvider8B")
-        super().__post_init__()
+        self.transformer_cfg.__post_init__()
 
 
 @dataclass
@@ -539,4 +539,4 @@ class NVIDIAMambaHybridProvider8B(NVIDIAMambaHybridModelProvider8B):
 
     def __post_init__(self) -> None:
         _warn_deprecated("NVIDIAMambaHybridProvider8B", "NVIDIAMambaHybridModelProvider8B")
-        super().__post_init__()
+        self.transformer_cfg.__post_init__()


### PR DESCRIPTION
# What does this PR do ?

Refactor MambaModelProvider to take TransformerConfig as attribute instead of inheriting.

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
