### PR TITLE
build: Set transformers to be < 5.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ classifiers = [
     "Topic :: Utilities",
 ]
 dependencies = [
-    "transformers>=4.51.3,<5.0.0",
+    "transformers<5.0.0",
     "datasets",
     "accelerate",
     "omegaconf>=2.3.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2396,7 +2396,7 @@ requires-dist = [
     { name = "timm" },
     { name = "tqdm", specifier = ">=4.67.1" },
     { name = "transformer-engine", extras = ["pytorch"], git = "https://github.com/NVIDIA/TransformerEngine.git?rev=release_v2.11" },
-    { name = "transformers", specifier = ">=4.51.3,<5.0.0" },
+    { name = "transformers", specifier = "<5.0.0" },
     { name = "typing-extensions" },
     { name = "wandb", specifier = ">=0.19.10" },
 ]


### PR DESCRIPTION
# What does this PR do ?

Set transformers to be < 5.0.0

We previously pinned transformers to 4.57.1 because the other patch versions until 4.57.5 would not load models from local HF cache correctly. However, 4.57.5 should fix that.  Additionally, set the transformers range to just be < 5.0.0.  A tighter range prevents MBridge from being installed with Export-Deploy when using trt-llm, which has very explicit transformers version pinned.

# Changelog

- Set transformers to be < 5.0.0

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
