### PR TITLE
Rename quantization spec to modelopt spec

### DIFF
--- a/examples/quantization/quantize.py
+++ b/examples/quantization/quantize.py
@@ -45,9 +45,9 @@ from tqdm import tqdm
 
 from megatron.bridge import AutoBridge
 from megatron.bridge.models.decorators import torchrun_main
-from megatron.bridge.models.gpt_provider import quantization_layer_spec
+from megatron.bridge.models.gpt_provider import modelopt_transformer_layer_spec
 from megatron.bridge.models.hf_pretrained.utils import is_safe_repo
-from megatron.bridge.models.mamba.mamba_provider import MambaModelProvider, quantization_mamba_stack_spec
+from megatron.bridge.models.mamba.mamba_provider import MambaModelProvider, modelopt_mamba_stack_spec
 
 
 warnings.filterwarnings("ignore")
@@ -177,17 +177,17 @@ def main(
     model_provider.expert_model_parallel_size = ep
     model_provider.expert_tensor_parallel_size = etp
     model_provider.pipeline_dtype = torch.bfloat16
-    # Disable MoE permute fusion for SequentialMLP (used by quantization_layer_spec)
+    # Disable MoE permute fusion for SequentialMLP (used by modelopt_transformer_layer_spec)
     # The fused kernels are optimized for TEGroupedMLP and cause issues with SequentialMLP
     model_provider.moe_permute_fusion = False
 
     # Set the correct layer spec for quantization based on model type
     if isinstance(model_provider, MambaModelProvider):
-        # For Mamba/Nemotron-H models: use quantization_mamba_stack_spec
-        model_provider.mamba_stack_spec = quantization_mamba_stack_spec
+        # For Mamba/Nemotron-H models: use modelopt_mamba_stack_spec
+        model_provider.mamba_stack_spec = modelopt_mamba_stack_spec
     else:
         # For GPT/Llama models: use the standard quantization layer spec
-        model_provider.transformer_layer_spec = quantization_layer_spec
+        model_provider.transformer_layer_spec = modelopt_transformer_layer_spec
 
     # Once all overrides are set, finalize the model provider to ensure the post initialization logic is run
     model_provider.finalize()

--- a/src/megatron/bridge/models/gpt_provider.py
+++ b/src/megatron/bridge/models/gpt_provider.py
@@ -99,7 +99,7 @@ def local_layer_spec(config: "GPTModelProvider") -> ModuleSpec:
     )
 
 
-def quantization_layer_spec(config: "GPTModelProvider") -> ModuleSpec:
+def modelopt_transformer_layer_spec(config: "GPTModelProvider") -> ModuleSpec:
     """Layer specification for quantization with ModelOpt."""
     # arbitrary attention mask is used for speculative decoding training
     # When context parallel > 1, only causal mask type is supported
@@ -122,7 +122,7 @@ def quantization_layer_spec(config: "GPTModelProvider") -> ModuleSpec:
 def default_layer_spec(config: "GPTModelProvider") -> ModuleSpec:
     """Determine the most appropriate layer specification based on availability."""
     if config.restore_modelopt_state:
-        return quantization_layer_spec(config)
+        return modelopt_transformer_layer_spec(config)
     elif config.use_transformer_engine_full_layer_spec:
         return transformer_engine_full_layer_spec(config)
     else:

--- a/src/megatron/bridge/models/mamba/mamba_provider.py
+++ b/src/megatron/bridge/models/mamba/mamba_provider.py
@@ -48,7 +48,7 @@ def transformer_engine_mamba_stack_spec() -> ModuleSpec:
     return default_mamba_stack_spec
 
 
-def quantization_mamba_stack_spec(config: "MambaModelProvider") -> ModuleSpec:
+def modelopt_mamba_stack_spec(config: "MambaModelProvider") -> ModuleSpec:
     """Mamba stack specification for quantization with ModelOpt.
 
     Uses Norm instead of TENorm and ColumnParallelLinear/RowParallelLinear
@@ -76,7 +76,7 @@ def get_default_mamba_stack_spec(config: "MambaModelProvider") -> ModuleSpec:
         ModuleSpec: Appropriate module specification based on config
     """
     if config.restore_modelopt_state:
-        return quantization_mamba_stack_spec(config)
+        return modelopt_mamba_stack_spec(config)
     else:
         return transformer_engine_mamba_stack_spec()
 

--- a/tests/unit_tests/models/test_gpt_provider.py
+++ b/tests/unit_tests/models/test_gpt_provider.py
@@ -285,9 +285,9 @@ class TestGPTModelProvider:
 
     @patch("megatron.core.parallel_state")
     @patch("megatron.bridge.models.gpt_provider.get_gpt_modelopt_spec")
-    def test_quantization_layer_spec(self, mock_get_gpt_modelopt_spec, mock_parallel_state):
-        """Test quantization_layer_spec function."""
-        from megatron.bridge.models.gpt_provider import quantization_layer_spec
+    def test_modelopt_transformer_layer_spec(self, mock_get_gpt_modelopt_spec, mock_parallel_state):
+        """Test modelopt_transformer_layer_spec function."""
+        from megatron.bridge.models.gpt_provider import modelopt_transformer_layer_spec
 
         # Mock context parallel world size to return 1 (use_arbitrary_attention_mask will be True)
         mock_parallel_state.get_context_parallel_world_size.return_value = 1
@@ -304,7 +304,7 @@ class TestGPTModelProvider:
         mock_get_gpt_modelopt_spec.return_value = mock_spec
 
         # Call the function
-        result = quantization_layer_spec(provider)
+        result = modelopt_transformer_layer_spec(provider)
 
         # Verify the mock was called with correct parameters
         mock_get_gpt_modelopt_spec.assert_called_once_with(
@@ -318,7 +318,7 @@ class TestGPTModelProvider:
         # Verify the result
         assert result is mock_spec
 
-    @patch("megatron.bridge.models.gpt_provider.quantization_layer_spec")
+    @patch("megatron.bridge.models.gpt_provider.modelopt_transformer_layer_spec")
     @patch("megatron.bridge.models.gpt_provider.transformer_engine_layer_spec")
     @patch("megatron.bridge.models.gpt_provider.transformer_engine_full_layer_spec")
     def test_default_layer_spec_with_restore_modelopt_state(self, mock_te_full_spec, mock_te_spec, mock_quant_spec):
@@ -347,7 +347,7 @@ class TestGPTModelProvider:
         mock_te_spec.assert_not_called()
         assert result == "quantization_spec"
 
-    @patch("megatron.bridge.models.gpt_provider.quantization_layer_spec")
+    @patch("megatron.bridge.models.gpt_provider.modelopt_transformer_layer_spec")
     @patch("megatron.bridge.models.gpt_provider.transformer_engine_layer_spec")
     @patch("megatron.bridge.models.gpt_provider.transformer_engine_full_layer_spec")
     def test_default_layer_spec_with_te_full_layer_spec(self, mock_te_full_spec, mock_te_spec, mock_quant_spec):
@@ -377,7 +377,7 @@ class TestGPTModelProvider:
         mock_te_spec.assert_not_called()
         assert result == "te_full_spec"
 
-    @patch("megatron.bridge.models.gpt_provider.quantization_layer_spec")
+    @patch("megatron.bridge.models.gpt_provider.modelopt_transformer_layer_spec")
     @patch("megatron.bridge.models.gpt_provider.transformer_engine_layer_spec")
     @patch("megatron.bridge.models.gpt_provider.transformer_engine_full_layer_spec")
     def test_default_layer_spec_default_case(self, mock_te_full_spec, mock_te_spec, mock_quant_spec):


### PR DESCRIPTION
# What does this PR do ?

- Previous name of quantization spec was not meaningful as we use this spec for other modelopt optimizations (e.g. pruning) as well

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
