### PR TITLE
fix(qwen3-vl): get_rope_index bug if input_ids is packed

### DIFF
--- a/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/utils.py
+++ b/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/utils.py
@@ -93,7 +93,7 @@ def get_rope_index(
         # Build an attention mask from packed sequence metadata when one is not provided.
         # cu_seqlens_q entries are cumulative lengths; their diffs give per-sample lengths.
         cu_seqlens = packed_seq_params.cu_seqlens_q
-        if cu_seqlens is not None and cu_seqlens.numel() >= 2:
+        if cu_seqlens is not None and cu_seqlens.numel() >= 2 and input_ids.shape[0] >= 2:
             seq_lens = cu_seqlens[1:] - cu_seqlens[:-1]
             attention_mask = torch.zeros_like(input_ids, dtype=input_ids.dtype)
             max_len = attention_mask.shape[1]


### PR DESCRIPTION
# What does this PR do ?

Fix a rope index calculation bug introduced in PR #1868. The issue occurred because we were unnecessarily recovering a padded attention mask when input_ids are already packed (i.e., pre-processed without padding). This redundant step corrupted the rope index alignment for packed sequences.

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
