### PR TITLE
fix: remove unused config

### DIFF
--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -191,42 +191,6 @@ class DistributedInitConfig:
     disable_jit_fuser: bool = False
     """Disable the JIT fuser."""
 
-    nccl_ub: bool = False
-    """If true, allocate and register NCCL userbuffer for param and grad buffer.
-      This flag enables SM efficient nccl algorithm that could improve the performance
-      of FSDP and DP with comm_overlap. This flag will be much more effective when used
-      together with sharp.
-    """
-
-    fsdp_double_buffer: bool = False
-    """If true, use persistently allocated double buffers for the
-      temporary memory needed in the Megatron FSDP communications.
-      This option will cause additional memory overhead, however, it is necessary for
-      to register user buffer (nccl_ub=True) for the Megatron FSDP.
-      This option will be automatically set to True when nccl_ub=True.
-    """
-
-    outer_dp_sharding_strategy: str = "no_shard"
-    """
-    Sharding strategy for outer data parallel group in Hybrid Sharded Data Parallel (HSDP) mode.
-    Valid values are 'no_shard', 'optim', 'optim_grads', 'optim_grads_params'.
-    This option is only effective when Hybrid FSDP is enabled.
-    """
-
-    disable_symmetric_registration: bool = False
-    """If true, disable symmetric (window) registration for NCCL userbuffer registration.
-      This option will force to use conventional (local) userbuffer registration
-      when nccl_ub is set.
-    """
-
-    fsdp_manual_registration: bool = False
-    """If true, manually register the FSDP communication buffers to NCCL user buffer.
-      This option is only effective when use_megatron_fsdp and nccl_ub is set.
-      For symmetric registration with large models, the registration itself can take
-      a significant amount of time. This option minimizes the number of registration calls
-      to minimize the registration time.
-    """
-
 
 @dataclass
 class RerunStateMachineConfig:


### PR DESCRIPTION
# What does this PR do ?

Removing unused config that was wrongly inserted from 
#1828 (https://github.com/NVIDIA-NeMo/Megatron-Bridge/pull/1828/files#diff-40277e879c4a8826db6a81b7911cff35e78aa1dfb49da2d6d9987d8fb84bac7eR194).

These configs are part of the DDP config, which was inserted here by me by mistake. These configs are not used by the `DistributedInitConfig` class. So, trying to remove it to reduce confusion. 

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
