### PR TITLE
disable precision_aware_optimizer for FSDP

### DIFF
--- a/scripts/performance/utils/overrides.py
+++ b/scripts/performance/utils/overrides.py
@@ -342,7 +342,7 @@ def set_post_overrides(
         model_family_name, model_recipe_name, gpu, compute_dtype, task, config_variant
     )
 
-    if compute_dtype == "bf16":
+    if compute_dtype == "bf16" and not recipe.ddp.use_megatron_fsdp:
         recipe.optimizer.use_precision_aware_optimizer = True
 
     tp = recipe.model.tensor_model_parallel_size


### PR DESCRIPTION
# What does this PR do ?

Disable precision aware optimizer when used with FSDP

# Changelog

```
if compute_dtype == "bf16" and not recipe.ddp.use_megatron_fsdp:
        recipe.optimizer.use_precision_aware_optimizer = True
```

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
