### PR TITLE
config_filepath arg parse location update

### DIFF
--- a/scripts/performance/README.md
+++ b/scripts/performance/README.md
@@ -88,7 +88,6 @@ The following line shows an example of how you can launch a pre-training benchma
 - `--load_dir`: Directory to load checkpoints.
 - `--save_interval`: Number of iterations between checkpoint saves.
 - `--most_recent_k`: Number of latest checkpoints to keep.
-- `--save_config_filepath`: Path to save the task configuration file.
 
 #### Data arguments
 
@@ -170,6 +169,7 @@ The following line shows an example of how you can launch a pre-training benchma
 - `-wde/--wandb_entity_name`: Weights & Biases entity name.
 - `-wdj/--wandb_experiment_name`: Weights & Biases experiment/run name.
 - `-wds/--wandb_save_dir`: Weights & Biases save directory.
+- - `--save_config_filepath`: Path to save the task configuration file.
 
 #### Testing arguments
 

--- a/scripts/performance/argument_parser.py
+++ b/scripts/performance/argument_parser.py
@@ -245,9 +245,6 @@ def parse_cli_args():
     checkpointing_args.add_argument("--load_dir", type=str, help="Directory to load checkpoints")
     checkpointing_args.add_argument("--save_interval", type=int, help="Number of iterations between checkpoint saves")
     checkpointing_args.add_argument("--most_recent_k", type=int, help="Number of latest checkpoints to keep")
-    checkpointing_args.add_argument(
-        "--save_config_filepath", type=str, help="Path to save the task configuration file"
-    )
 
     # Data
     data_args = parser.add_argument_group("Data arguments")
@@ -631,6 +628,7 @@ def parse_cli_args():
         required=False,
         default=None,
     )
+    logging_args.add_argument("--save_config_filepath", type=str, help="Path to save the task configuration file")
 
     # Config variant selection
     config_variant_args = parser.add_argument_group("Config variant arguments")


### PR DESCRIPTION
# What does this PR do ?

Change location of `config_filepath` from checkpointing args to logging args in argument_parser.py and README

# Changelog

```
logging_args.add_argument("--save_config_filepath", type=str, help="Path to save the task configuration file")
```

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
