### PR TITLE
Revert to pass-through Packager.

### DIFF
--- a/scripts/performance/utils/executors.py
+++ b/scripts/performance/utils/executors.py
@@ -140,7 +140,7 @@ def slurm_executor(
         time=time_limit,
         mem="0",
         exclusive=True,
-        packager=run.GitArchivePackager(),
+        packager=run.Packager(),
         segment=segment,
         network=network,
         launcher=launcher,


### PR DESCRIPTION
GitArchiver adds unnecessary time copying the source for each job. 10+ seconds depending on the filesystem.