### PR TITLE
ci: Add cache prune args for uv

### DIFF
--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -63,6 +63,7 @@ FROM mbridge_base as mbridge_final
 WORKDIR /opt/Megatron-Bridge
 # Build arg to skip --locked when testing with different MCore versions
 ARG MCORE_TRIGGERED_TESTING=false
+ARG UV_CACHE_PRUNE_ARGS
 
 COPY --from=mbridge_mcore /tmp/Megatron-LM /opt/Megatron-Bridge/3rdparty/Megatron-LM
 
@@ -77,7 +78,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         uv sync --locked --only-group build && \
         uv sync --link-mode copy --locked --all-extras --all-groups; \
     fi && \
-    uv cache prune
+    uv cache prune ${UV_CACHE_PRUNE_ARGS}
 
 COPY . /opt/Megatron-Bridge
 COPY --from=mbridge_mcore /src/Megatron-LM* /opt/Megatron-Bridge/3rdparty


### PR DESCRIPTION
# What does this PR do ?

Allow additional args to be passed to uv cache prune

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
