### PR TITLE
fix: Remove `top_k`

### DIFF
--- a/examples/evaluation/eval.sh
+++ b/examples/evaluation/eval.sh
@@ -58,7 +58,6 @@ eval_params = ConfigParams(
     request_timeout=request_timeout,
     temperature=temperature,
     top_p=top_p,
-    top_k=top_k,
 )
 eval_cfg = EvaluationConfig(
     type=eval_task,


### PR DESCRIPTION
# What does this PR do ?

This was maybe never a valid config item and with Pydantic its now enforced: https://github.com/NVIDIA-NeMo/Evaluator/commit/359b97db7d2c7194643f8c84fd60ed5bfcc8a1b2

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Changes**
  * Removed a configuration parameter from evaluation settings. Configurations that include this parameter will require manual updates to remain compatible with this version. Please review your evaluation configuration files and remove any references to this parameter. This change may affect existing evaluation workflows, so please test your setups accordingly after updating.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->