### PR TITLE
405b nvfp4 CP=1 cfgs

### DIFF
--- a/scripts/performance/configs/llama/llama31_workload_base_configs.py
+++ b/scripts/performance/configs/llama/llama31_workload_base_configs.py
@@ -66,7 +66,7 @@ LLAMA31_405B_PRETRAIN_CONFIG_GB300_NVFP4_V1 = replace(
     num_gpus=128,
     tensor_model_parallel_size=4,
     pipeline_model_parallel_size=8,
-    context_parallel_size=2,
+    context_parallel_size=1,
     virtual_pipeline_model_parallel_size=4,
     global_batch_size=64,
     cuda_graph_impl="local",
@@ -109,12 +109,13 @@ LLAMA31_405B_PRETRAIN_CONFIG_GB200_NVFP4_V1 = replace(
     BASE_LLAMA31_405B_CONFIG,
     num_gpus=128,
     tensor_model_parallel_size=4,
-    pipeline_model_parallel_size=8,
-    context_parallel_size=2,
-    virtual_pipeline_model_parallel_size=4,
+    pipeline_model_parallel_size=16,
+    context_parallel_size=1,
+    virtual_pipeline_model_parallel_size=8,
     global_batch_size=64,
-    cuda_graph_impl="local",
+    cuda_graph_impl="none",
     cuda_graph_scope="full_iteration",
+    recompute_num_layers=1,
 )
 
 
@@ -181,10 +182,11 @@ LLAMA31_405B_PRETRAIN_CONFIG_B200_NVFP4_V1 = replace(
     BASE_LLAMA31_405B_CONFIG,
     num_gpus=128,
     tensor_model_parallel_size=4,
-    pipeline_model_parallel_size=8,
-    context_parallel_size=2,
-    virtual_pipeline_model_parallel_size=4,
+    pipeline_model_parallel_size=16,
+    context_parallel_size=1,
+    virtual_pipeline_model_parallel_size=8,
     global_batch_size=64,
+    recompute_num_layers=1,
 )
 
 LLAMA31_405B_PRETRAIN_CONFIG_H100_BF16_V1 = replace(
@@ -242,7 +244,6 @@ LLAMA31_405B_PRETRAIN_CONFIG_GB300_FP8_MX_V2 = replace(
 
 LLAMA31_405B_PRETRAIN_CONFIG_GB300_NVFP4_V2 = replace(
     LLAMA31_405B_PRETRAIN_CONFIG_GB300_NVFP4_V1,
-    tensor_model_parallel_size=2,
     num_gpus=256,
     global_batch_size=1536,
 )
@@ -281,9 +282,8 @@ LLAMA31_405B_PRETRAIN_CONFIG_GB200_FP8_MX_V2 = replace(
 LLAMA31_405B_PRETRAIN_CONFIG_GB200_NVFP4_V2 = replace(
     LLAMA31_405B_PRETRAIN_CONFIG_GB200_NVFP4_V1,
     num_gpus=256,
-    pipeline_model_parallel_size=16,
-    context_parallel_size=1,
     global_batch_size=1536,
+    recompute_num_layers=None,
 )
 
 


### PR DESCRIPTION
# What does this PR do ?

Update configs for NVFP4 precision for Llama3.1 405B for all Blackwell GPUs to avoid NaN grad norm.

Basically, we need to set CP=1 to avoid NaN grad norm. But, other configs need to be updated too to fit reduced CP size and avoid OOM.

# Changelog

```
CP=1
```

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Llama 3.1 pretraining performance configurations for GB200 and GB300 hardware platforms. Adjusted distributed training parallelism, context management, and memory optimization settings across multiple V1 and V2 configuration profiles. Configuration changes modify how the model utilizes computational and memory resources during pretraining on specified hardware.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->