### PR TITLE
Add container-writable flag to slurm executor

### DIFF
--- a/scripts/performance/utils/executors.py
+++ b/scripts/performance/utils/executors.py
@@ -85,6 +85,7 @@ def slurm_executor(
     srun_args = custom_srun_args.copy() + [
         "--mpi=pmix",
         "--no-container-mount-home",
+        "--container-writable",
     ]
 
     if log_dir != get_nemorun_home():


### PR DESCRIPTION
Many of the performance recipes require the container environment to be writable, the enroot default config is disabled.
 
Prevent errors out of box.
