### PR TITLE
[sync] Various quality-of-life improvements in training loop

### DIFF
--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -1455,6 +1455,7 @@ class ConfigContainer(Container):
                 "check_for_nan_in_loss must be disabled when using full_iteration CUDA graph. "
                 "Set rerun_state_machine.check_for_nan_in_loss=False."
             )
+        _validate_skip_train_settings(self)
 
         if self.dist.use_megatron_fsdp and self.dist.use_torch_fsdp2:
             raise ValueError("Using use_megatron_fsdp and use_torch_fsdp2 at the same time is not supported.")
@@ -1754,6 +1755,7 @@ def _validate_mixed_precision_consistency(config: ConfigContainer) -> None:
             )
 
 
+<<<<<<< HEAD
 def _validate_fine_grained_activation_offloading(config: ConfigContainer) -> None:
     """Validate fine-grained activation offloading configuration.
 
@@ -1788,3 +1790,18 @@ def _validate_fine_grained_activation_offloading(config: ConfigContainer) -> Non
                 "For fine-grained activation offloading with TE >= 2.10.0, "
                 "NVTE_CPU_OFFLOAD_V1 environment variable should be set to 1 to avoid offloading weights."
             )
+=======
+def _validate_skip_train_settings(config: ConfigContainer) -> None:
+    """Validate and apply skip_train settings.
+
+    When skip_train is enabled:
+    1. Automatically disable loading optimizer state from checkpoint to save memory
+    2. Log a warning if load_optim was explicitly set to True
+
+    Args:
+        config: The configuration container to validate and potentially modify.
+    """
+    if config.train.skip_train and config.checkpoint.load_optim:
+        config.checkpoint.load_optim = False
+        print_rank_0("Warning: enabling load_optim=False when skipping training (skip_train=True).")
+>>>>>>> 4c8a752a ([sync] Various quality-of-life improvements in training loop)

--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -1755,7 +1755,6 @@ def _validate_mixed_precision_consistency(config: ConfigContainer) -> None:
             )
 
 
-<<<<<<< HEAD
 def _validate_fine_grained_activation_offloading(config: ConfigContainer) -> None:
     """Validate fine-grained activation offloading configuration.
 
@@ -1790,7 +1789,8 @@ def _validate_fine_grained_activation_offloading(config: ConfigContainer) -> Non
                 "For fine-grained activation offloading with TE >= 2.10.0, "
                 "NVTE_CPU_OFFLOAD_V1 environment variable should be set to 1 to avoid offloading weights."
             )
-=======
+
+
 def _validate_skip_train_settings(config: ConfigContainer) -> None:
     """Validate and apply skip_train settings.
 
@@ -1804,4 +1804,3 @@ def _validate_skip_train_settings(config: ConfigContainer) -> None:
     if config.train.skip_train and config.checkpoint.load_optim:
         config.checkpoint.load_optim = False
         print_rank_0("Warning: enabling load_optim=False when skipping training (skip_train=True).")
->>>>>>> 4c8a752a ([sync] Various quality-of-life improvements in training loop)


### PR DESCRIPTION
# What does this PR do ?

Sync with https://github.com/NVIDIA/Megatron-LM/pull/2580
- Skip optimizer creation + checkpoint loading when skipping training
- Skip train dataloader creation if skipping training

One difference in this PR and MLM is that bridge continues to wrap the model with DDP/FSDP even if `skip_train` is specified in order to handle megatron FSDP checkpoint formats on load

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added skip training mode that omits training dataloader construction to conserve memory while preserving evaluation iterations.
  * Automatically adjusts checkpoint settings when skip training is enabled.

* **Tests**
  * Added comprehensive test coverage for skip training functionality including data loader construction and configuration validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->