### PR TITLE
fix(models): fire language model of qwen3vlmoe by default

### DIFF
--- a/src/megatron/bridge/models/qwen_vl/qwen3_vl_provider.py
+++ b/src/megatron/bridge/models/qwen_vl/qwen3_vl_provider.py
@@ -236,9 +236,9 @@ class Qwen3VLMoEModelProvider(Qwen3MoEModelProvider):
 
     # Freeze options for fine-tuning scenarios
     # Whether to freeze language model weights
-    freeze_language_model: bool = True
+    freeze_language_model: bool = False
     # Whether to freeze vision encoder weights
-    freeze_vision_model: bool = True
+    freeze_vision_model: bool = False
     # Whether to freeze vision-to-language projection weights
     freeze_vision_projection: bool = False
     language_max_sequence_length: int = 2048


### PR DESCRIPTION
# What does this PR do ?

as per title

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Updated default fine-tuning configuration for Qwen3VL and Qwen3VLMoE models. Language and vision model components are now trainable by default rather than frozen.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->