### PR TITLE
[resiliency] feat: Support configurable spiky loss threshold for re-run state machine

### DIFF
--- a/docs/training/resiliency.md
+++ b/docs/training/resiliency.md
@@ -441,6 +441,7 @@ config.rerun_state_machine = RerunStateMachineConfig(
     rerun_mode="validate_results",  # or "report_determinism_stats" or "disabled"
     check_for_nan_in_loss=True,
     check_for_spiky_loss=False,
+    spiky_loss_factor=10.0,  # Adjust for your model architecture
     error_injection_rate=0,  # For testing only
     error_injection_type="transient_error",
 )
@@ -453,6 +454,7 @@ config.rerun_state_machine = RerunStateMachineConfig(
 | `rerun_mode` | `str` | `"disabled"` | Operating mode: `"disabled"`, `"validate_results"`, or `"report_determinism_stats"` |
 | `check_for_nan_in_loss` | `bool` | `True` | Check for NaN values in loss |
 | `check_for_spiky_loss` | `bool` | `False` | Check for unexpectedly large loss values |
+| `spiky_loss_factor` | `float` | `10.0` | Factor for spiky loss detection. Loss is flagged if it exceeds this multiple of max observed loss. Larger models may need higher values (e.g., 15-20 for 70B+). |
 | `error_injection_rate` | `int` | `0` | Rate for injecting test errors (testing only) |
 | `error_injection_type` | `str` | `"transient_error"` | Type of error to inject for testing |
 

--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -223,6 +223,10 @@ class RerunStateMachineConfig:
     check_for_spiky_loss: bool = False
     """Check for spiky loss."""
 
+    spiky_loss_factor: float = 10.0
+    """Factor for detecting spiky loss. A loss is considered spiky if it exceeds
+    this multiple of the max observed loss over the sample window."""
+
 
 @dataclass(kw_only=True)
 class DataloaderConfig:

--- a/src/megatron/bridge/training/initialize.py
+++ b/src/megatron/bridge/training/initialize.py
@@ -222,6 +222,7 @@ def init_rerun_state(rerun_state_machine_config: RerunStateMachineConfig) -> Non
         RerunDiagnostic,
         RerunErrorInjector,
         RerunMode,
+        get_rerun_state_machine,
         initialize_rerun_state_machine,
     )
 
@@ -241,6 +242,10 @@ def init_rerun_state(rerun_state_machine_config: RerunStateMachineConfig) -> Non
             error_injection_type=RerunDiagnostic(rerun_state_machine_config.error_injection_type),
         ),
     )
+
+    # Store config on the singleton for use in loss validation
+    rsm = get_rerun_state_machine()
+    rsm.spiky_loss_factor = rerun_state_machine_config.spiky_loss_factor
 
 
 def set_jit_fusion_options(model_config: GPTModelProvider | T5ModelProvider, micro_batch_size: int) -> None:

--- a/src/megatron/bridge/training/losses.py
+++ b/src/megatron/bridge/training/losses.py
@@ -19,7 +19,7 @@ import torch
 from megatron.core.rerun_state_machine import get_rerun_state_machine
 
 
-SPIKY_LOSS_FACTOR: int = 10
+_DEFAULT_SPIKY_LOSS_FACTOR: float = 10.0
 
 
 def create_masked_next_token_loss_function(
@@ -86,11 +86,12 @@ def masked_next_token_loss(
         )
     # Check for spiky loss
     if check_for_spiky_loss:
+        spiky_loss_factor = getattr(rerun_state_machine, "spiky_loss_factor", _DEFAULT_SPIKY_LOSS_FACTOR)
         rerun_state_machine.validate_result(
             result=loss,
             rejection_func=partial(
                 rerun_state_machine.is_unexpectedly_large,
-                threshold=SPIKY_LOSS_FACTOR,
+                threshold=spiky_loss_factor,
                 context="loss",
             ),
             message="Spiky loss",

--- a/tests/unit_tests/training/test_losses.py
+++ b/tests/unit_tests/training/test_losses.py
@@ -20,7 +20,7 @@ from unittest.mock import MagicMock, patch
 import torch
 
 from megatron.bridge.training.losses import (
-    SPIKY_LOSS_FACTOR,
+    _DEFAULT_SPIKY_LOSS_FACTOR,
     create_masked_next_token_loss_function,
     masked_next_token_loss,
 )
@@ -312,7 +312,7 @@ class TestCreateMaskedNextTokenLossFunction:
 class TestConstants:
     """Test module constants."""
 
-    def test_spiky_loss_factor(self):
-        """Test that SPIKY_LOSS_FACTOR has expected value."""
-        assert SPIKY_LOSS_FACTOR == 10, "SPIKY_LOSS_FACTOR should be 10"
-        assert isinstance(SPIKY_LOSS_FACTOR, int), "SPIKY_LOSS_FACTOR should be an integer"
+    def test_default_spiky_loss_factor(self):
+        """Test that _DEFAULT_SPIKY_LOSS_FACTOR has expected value."""
+        assert _DEFAULT_SPIKY_LOSS_FACTOR == 10.0, "_DEFAULT_SPIKY_LOSS_FACTOR should be 10.0"
+        assert isinstance(_DEFAULT_SPIKY_LOSS_FACTOR, float), "_DEFAULT_SPIKY_LOSS_FACTOR should be a float"


### PR DESCRIPTION
# What does this PR do ?

Fixes https://github.com/NVIDIA-NeMo/Megatron-Bridge/issues/620

This change allows users to tune the threshold factor via the config rather than patching the code to change the hardcoded default. To avoid deeper mcore changes, this attaches the spiky loss factor to the re-run state machine singleton, and the configured value is read from there during loss calculation. If no threshold is set, we fallback to the default value to provide backwards compatibility.

# Changelog

- Support configurable spiky loss threshold for re-run state machine

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to #620 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable spiky loss detection threshold parameter to training configuration, allowing users to adjust sensitivity for identifying anomalous loss patterns during training runs. Default value is 10.0.

* **Documentation**
  * Updated training configuration documentation to include the new spiky loss threshold parameter and its behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->