### PR TITLE
[M4] feat: Add M4 end2end qwen3_vl example

### DIFF
--- a/examples/recipes/decentralized_pg/pretrain_qwen3_vl_simple.py
+++ b/examples/recipes/decentralized_pg/pretrain_qwen3_vl_simple.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+==============================================================================
+Example: Qwen3_VL Pretraining with Decentralized Process Groups (Simple)
+==============================================================================
+
+This example demonstrates the simplest way to enable decentralized process groups:
+just use an existing recipe and set `cfg.dist.use_decentralized_pg = True`.
+
+The setup() function inside pretrain() will automatically create the
+ProcessGroupCollection using HyperCommGrid based on the parallelism settings.
+
+How to Run
+----------
+# 8 GPUs: EP8
+uv run python -m torch.distributed.run --nproc_per_node=8 examples/recipes/decentralized_pg/pretrain_qwen3_vl_simple.py
+"""
+
+import torch
+
+from megatron.bridge.recipes.qwen_vl.qwen3_vl import qwen3_vl_30b_a3b_pretrain_config
+from megatron.bridge.training.pretrain import pretrain
+from megatron.bridge.training.vlm_step import forward_step
+
+
+def main() -> None:
+    """Run Qwen3 pretraining with decentralized process groups enabled."""
+    # Get the standard Qwen3 4B pretrain config with overrides
+    cfg = qwen3_vl_30b_a3b_pretrain_config(
+        # Use mock data for demo
+        mock=True,
+        # Parallelism
+        expert_model_parallel_size=8,
+        # Training settings (small for demo)
+        train_iters=100,
+        seq_length=1024,
+        global_batch_size=32,
+        micro_batch_size=1,
+        # LR schedule (must fit within train_iters)
+        lr_warmup_iters=10,
+        lr_decay_iters=100,
+    )
+    # known issue with share_embeddings_and_output_weights
+    cfg.model.share_embeddings_and_output_weights = False
+
+    # =========================================================================
+    # KEY: Enable decentralized process groups
+    # =========================================================================
+    cfg.dist.use_decentralized_pg = True
+    cfg.dist.use_gloo_process_groups = False  # Gloo not supported with decentralized PG
+
+    pretrain(config=cfg, forward_step_func=forward_step)
+
+    # Cleanup
+    if torch.distributed.is_initialized():
+        torch.distributed.barrier()
+        torch.distributed.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/text_model.py
+++ b/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/text_model.py
@@ -24,6 +24,7 @@ import torch
 from megatron.core.inference.contexts import BaseInferenceContext
 from megatron.core.models.gpt.gpt_model import GPTModel
 from megatron.core.packed_seq_params import PackedSeqParams
+from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.transformer.spec_utils import ModuleSpec
 from megatron.core.utils import deprecate_inference_params
 from torch import Tensor
@@ -59,6 +60,7 @@ class Qwen3VLGPTModel(GPTModel):
         seq_len_interpolation_factor: Optional[float] = None,
         mtp_block_spec: Optional[ModuleSpec] = None,
         vp_stage: Optional[int] = None,
+        pg_collection: ProcessGroupCollection = None,
     ) -> None:
         super().__init__(
             config=config,
@@ -79,6 +81,7 @@ class Qwen3VLGPTModel(GPTModel):
             seq_len_interpolation_factor=seq_len_interpolation_factor,
             mtp_block_spec=mtp_block_spec,
             vp_stage=vp_stage,
+            pg_collection=pg_collection,
         )
 
         is_moe = (
@@ -102,6 +105,7 @@ class Qwen3VLGPTModel(GPTModel):
             pre_process=self.pre_process,
             post_process=self.post_process,
             vp_stage=vp_stage,
+            pg_collection=pg_collection,
         )
 
     def forward(

--- a/src/megatron/bridge/models/qwen_vl/qwen3_vl_provider.py
+++ b/src/megatron/bridge/models/qwen_vl/qwen3_vl_provider.py
@@ -128,6 +128,7 @@ class Qwen3VLModelProvider(Qwen3ModelProvider):
             vision_transformer_config=hf_vision_config,
             pre_process=pre_process,
             post_process=post_process,
+            pg_collection=self._pg_collection,
         )
 
         # Apply freeze options if any are enabled for fine-tuning
@@ -285,6 +286,7 @@ class Qwen3VLMoEModelProvider(Qwen3MoEModelProvider):
             vision_transformer_config=hf_config,
             pre_process=pre_process,
             post_process=post_process,
+            pg_collection=self._pg_collection,
         )
 
         # Apply freeze options if any are enabled for fine-tuning

--- a/src/megatron/bridge/training/utils/train_utils.py
+++ b/src/megatron/bridge/training/utils/train_utils.py
@@ -580,6 +580,7 @@ def training_log(
             num_layers=layers,
             moe_layer_freq=config.model.moe_layer_freq,
             mtp_num_layers=config.model.mtp_num_layers,
+            pg_collection=pg_collection,
         )
     if config.model.mtp_num_layers is not None:
         mtp_loss_scale = 1 / get_num_microbatches()

--- a/tests/unit_tests/models/qwen_vl/modelling_qwen3_vl/test_model.py
+++ b/tests/unit_tests/models/qwen_vl/modelling_qwen3_vl/test_model.py
@@ -255,6 +255,11 @@ class TestQwen3VLModel:
         """Test model freeze API."""
         self._setup_parallel_state(tp_size=1, ep_size=1, pp_size=1)
         pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+        assert pg_collection is not None
+        assert pg_collection.tp is not None
+        assert pg_collection.pp is not None
+        assert pg_collection.cp is not None
+        assert pg_collection.embd is not None
 
         vision_transformer_config = self.get_vision_transformer_config(hf_config)
         language_transformer_config = self.get_language_transformer_config(hf_config)
@@ -289,6 +294,11 @@ class TestQwen3VLModel:
         """Test shared_embedding_or_output_weight method."""
         self._setup_parallel_state(tp_size=1, ep_size=1, pp_size=1)  # Create pg_collection from initialized mpu
         pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+        assert pg_collection is not None
+        assert pg_collection.tp is not None
+        assert pg_collection.pp is not None
+        assert pg_collection.cp is not None
+        assert pg_collection.embd is not None
 
         vision_transformer_config = self.get_vision_transformer_config(hf_config)
         language_transformer_config = self.get_language_transformer_config(hf_config)
@@ -320,6 +330,7 @@ class TestQwen3VLModel:
             post_process=True,
             add_encoder=True,
             add_decoder=False,
+            pg_collection=pg_collection,
         )
 
         weight_no_decoder = model_no_decoder.shared_embedding_or_output_weight()
@@ -330,6 +341,11 @@ class TestQwen3VLModel:
         """Test set_input_tensor method."""
         self._setup_parallel_state(tp_size=1, ep_size=1, pp_size=1)
         pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+        assert pg_collection is not None
+        assert pg_collection.tp is not None
+        assert pg_collection.pp is not None
+        assert pg_collection.cp is not None
+        assert pg_collection.embd is not None
 
         vision_transformer_config = self.get_vision_transformer_config(hf_config)
         language_transformer_config = self.get_language_transformer_config(hf_config)
@@ -372,6 +388,7 @@ class TestQwen3VLModel:
             post_process=True,
             add_encoder=True,
             add_decoder=True,
+            pg_collection=pg_collection,
         )
 
         if torch.cuda.is_available():

--- a/tests/unit_tests/models/qwen_vl/modelling_qwen3_vl/test_model.py
+++ b/tests/unit_tests/models/qwen_vl/modelling_qwen3_vl/test_model.py
@@ -29,6 +29,7 @@ import torch.distributed as dist
 import torch.nn.functional as F
 from megatron.core import parallel_state
 from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_with_transformer_engine_spec
+from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from PIL import Image
 from transformers import AutoProcessor, Qwen3VLMoeConfig
@@ -253,6 +254,7 @@ class TestQwen3VLModel:
     def test_model_freeze_api(self, freeze_all, hf_config):
         """Test model freeze API."""
         self._setup_parallel_state(tp_size=1, ep_size=1, pp_size=1)
+        pg_collection = ProcessGroupCollection.use_mpu_process_groups()
 
         vision_transformer_config = self.get_vision_transformer_config(hf_config)
         language_transformer_config = self.get_language_transformer_config(hf_config)
@@ -267,6 +269,7 @@ class TestQwen3VLModel:
             post_process=True,
             add_encoder=True,
             add_decoder=True,
+            pg_collection=pg_collection,
         )
 
         if torch.cuda.is_available():
@@ -284,7 +287,8 @@ class TestQwen3VLModel:
     @pytest.mark.timeout(50)
     def test_shared_embedding_or_output_weight(self, hf_config):
         """Test shared_embedding_or_output_weight method."""
-        self._setup_parallel_state(tp_size=1, ep_size=1, pp_size=1)
+        self._setup_parallel_state(tp_size=1, ep_size=1, pp_size=1)  # Create pg_collection from initialized mpu
+        pg_collection = ProcessGroupCollection.use_mpu_process_groups()
 
         vision_transformer_config = self.get_vision_transformer_config(hf_config)
         language_transformer_config = self.get_language_transformer_config(hf_config)
@@ -300,6 +304,7 @@ class TestQwen3VLModel:
             post_process=True,
             add_encoder=True,
             add_decoder=True,
+            pg_collection=pg_collection,
         )
 
         weight = model.shared_embedding_or_output_weight()
@@ -324,6 +329,7 @@ class TestQwen3VLModel:
     def test_set_input_tensor(self, hf_config):
         """Test set_input_tensor method."""
         self._setup_parallel_state(tp_size=1, ep_size=1, pp_size=1)
+        pg_collection = ProcessGroupCollection.use_mpu_process_groups()
 
         vision_transformer_config = self.get_vision_transformer_config(hf_config)
         language_transformer_config = self.get_language_transformer_config(hf_config)
@@ -339,6 +345,7 @@ class TestQwen3VLModel:
             post_process=True,
             add_encoder=True,
             add_decoder=True,
+            pg_collection=pg_collection,
         )
 
         if torch.cuda.is_available():


### PR DESCRIPTION
# What does this PR do ?

### Add M4 end2end qwen3vl example
1. Pass pg_collection from Qwen3VLMoEModelProvider(or Qwen3VLModelProvider) to Qwen3VLModel.
2. pass pg_collection to track_moe_metrics for moe model, in train_utils.py.

### How to Run

```
# 8 GPUs: EP8
uv run python -m torch.distributed.run --nproc_per_node=8 examples/recipes/decentralized_pg/pretrain_qwen3_vl_simple.py
```

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
