### PR TITLE
[sync] Refactor cuda_graph_scope to use enums

### DIFF
--- a/src/megatron/bridge/models/gpt_full_te_layer_autocast_spec.py
+++ b/src/megatron/bridge/models/gpt_full_te_layer_autocast_spec.py
@@ -20,6 +20,7 @@ import torch
 from megatron.core import tensor_parallel
 from megatron.core.fusions.fused_layer_norm import FusedLayerNorm
 from megatron.core.transformer.cuda_graphs import CudaGraphManager
+from megatron.core.transformer.enums import CudaGraphScope
 from megatron.core.transformer.module import MegatronModule
 from megatron.core.transformer.spec_utils import ModuleSpec
 from megatron.core.transformer.transformer_block import TransformerBlockSubmodules, get_num_layers_to_build
@@ -228,7 +229,7 @@ class TETransformerLayerAutocast(MegatronModule, BaseTransformerLayer):  # type:
         if (
             self.config.cuda_graph_impl == "local"
             and self.training
-            and "full_iteration" not in self.config.cuda_graph_scope
+            and CudaGraphScope.full_iteration not in self.config.cuda_graph_scope
         ):
             assert not config.cpu_offloading and config.recompute_granularity is None, "Cudagraphs not supported"
             self.add_module("cudagraph_manager", CudaGraphManager(config))

--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -28,7 +28,7 @@ from megatron.core.optimizer import (
     ParamGroupOverride,
     ParamKey,
 )
-from megatron.core.transformer.enums import AttnBackend
+from megatron.core.transformer.enums import AttnBackend, CudaGraphScope
 from megatron.core.transformer.module import MegatronModule
 
 from megatron.bridge.data.datasets.packed_sequence import PackedSequenceSpecs
@@ -1405,6 +1405,13 @@ class ConfigContainer(Container):
         # Run validations
         _validate_and_sync_distributed_optimizer_settings(self)
         _validate_mixed_precision_consistency(self)
+
+        # CUDA graph scope validation: check_for_nan_in_loss must be disabled with full_iteration graph
+        if self.model.cuda_graph_impl == "local" and CudaGraphScope.full_iteration in self.model.cuda_graph_scope:
+            assert not self.rerun_state_machine.check_for_nan_in_loss, (
+                "check_for_nan_in_loss must be disabled when using full_iteration CUDA graph. "
+                "Set rerun_state_machine.check_for_nan_in_loss=False."
+            )
 
         if self.dist.use_megatron_fsdp and self.dist.use_torch_fsdp2:
             raise ValueError("Using use_megatron_fsdp and use_torch_fsdp2 at the same time is not supported.")

--- a/src/megatron/bridge/training/eval.py
+++ b/src/megatron/bridge/training/eval.py
@@ -24,6 +24,7 @@ from megatron.core.pipeline_parallel.p2p_communication import P2PCommunicator
 from megatron.core.pipeline_parallel.utils import is_pp_last_stage
 from megatron.core.rerun_state_machine import RerunDataIterator, RerunMode, get_rerun_state_machine
 from megatron.core.transformer import MegatronModule
+from megatron.core.transformer.enums import CudaGraphScope
 from megatron.core.utils import get_model_config
 
 from megatron.bridge.data.finetuning import prepare_finetuning_batch
@@ -95,7 +96,10 @@ def evaluate(
         if verbose:
             print_rank_0(f"Evaluating on {state.cfg.train.eval_iters * eval_batch_size} samples")
 
-        if state.cfg.model.cuda_graph_impl == "local" and "full_iteration" in state.cfg.model.cuda_graph_scope:
+        if (
+            state.cfg.model.cuda_graph_impl == "local"
+            and CudaGraphScope.full_iteration in state.cfg.model.cuda_graph_scope
+        ):
             forward_backward_func = FullCudaGraphWrapper(
                 get_forward_backward_func(
                     pp_size=pg_collection.pp.size(),

--- a/src/megatron/bridge/training/train.py
+++ b/src/megatron/bridge/training/train.py
@@ -46,6 +46,7 @@ from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.rerun_state_machine import RerunDataIterator, get_rerun_state_machine
 from megatron.core.transformer import MegatronModule
 from megatron.core.transformer.cuda_graphs import TECudaGraphHelper
+from megatron.core.transformer.enums import CudaGraphScope
 from megatron.core.utils import check_param_hashes_across_dp_replicas, get_model_config
 from modelopt.torch.distill.plugins.megatron import get_tensor_shapes_adjust_fn_for_distillation
 
@@ -254,7 +255,7 @@ def train(
         pp_size=pg_collection.pp.size(),
         vp_size=config.model.virtual_pipeline_model_parallel_size,
     )
-    if config.model.cuda_graph_impl == "local" and "full_iteration" in config.model.cuda_graph_scope:
+    if config.model.cuda_graph_impl == "local" and CudaGraphScope.full_iteration in config.model.cuda_graph_scope:
         forward_backward_func = FullCudaGraphWrapper(
             forward_backward_func, cuda_graph_warmup_steps=config.model.cuda_graph_warmup_steps
         )

--- a/tests/unit_tests/training/test_config.py
+++ b/tests/unit_tests/training/test_config.py
@@ -17,6 +17,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
+from megatron.core.transformer.enums import CudaGraphScope
 
 from megatron.bridge.models.deepseek.deepseek_provider import DeepSeekModelProvider
 from megatron.bridge.models.gpt_provider import GPTModelProvider
@@ -1082,6 +1083,60 @@ class TestConfigContainerValidation:
         try:
             with pytest.raises(AssertionError):
                 container.validate()
+        finally:
+            restore_get_world_size_safe(og_ws, cfg_mod)
+
+    def test_cuda_graph_full_iteration_requires_check_for_nan_disabled(self, monkeypatch):
+        """Test that full_iteration CUDA graph requires check_for_nan_in_loss=False."""
+        # Create config with cuda_graph_impl="local" and TE RNG tracker (required for cuda graphs)
+        gpt_model_cfg = create_test_gpt_config(
+            cuda_graph_impl="local",
+            use_te_rng_tracker=True,
+        )
+
+        container, og_ws, cfg_mod = create_test_config_container(
+            world_size_override=1,
+            model_config=gpt_model_cfg,
+        )
+
+        try:
+            # Set cuda_graph_scope to include full_iteration after model creation
+            # (MCore's __post_init__ converts strings to enums during finalize)
+            container.model.cuda_graph_scope = [CudaGraphScope.full_iteration]
+
+            # Default check_for_nan_in_loss is True - should fail validation
+            assert container.rerun_state_machine.check_for_nan_in_loss is True
+            with pytest.raises(
+                AssertionError,
+                match="check_for_nan_in_loss must be disabled when using full_iteration CUDA graph",
+            ):
+                container.validate()
+
+            # Setting check_for_nan_in_loss=False should pass validation
+            container.rerun_state_machine.check_for_nan_in_loss = False
+            container.validate()  # Should pass without error
+        finally:
+            restore_get_world_size_safe(og_ws, cfg_mod)
+
+    def test_cuda_graph_non_full_iteration_allows_check_for_nan(self, monkeypatch):
+        """Test that non-full_iteration CUDA graph allows check_for_nan_in_loss=True."""
+        gpt_model_cfg = create_test_gpt_config(
+            cuda_graph_impl="local",
+            use_te_rng_tracker=True,
+        )
+
+        container, og_ws, cfg_mod = create_test_config_container(
+            world_size_override=1,
+            model_config=gpt_model_cfg,
+        )
+
+        try:
+            # Set cuda_graph_scope to NOT include full_iteration
+            container.model.cuda_graph_scope = [CudaGraphScope.attn, CudaGraphScope.mlp]
+
+            # check_for_nan_in_loss=True should be allowed
+            assert container.rerun_state_machine.check_for_nan_in_loss is True
+            container.validate()  # Should pass without error
         finally:
             restore_get_world_size_safe(og_ws, cfg_mod)
 


### PR DESCRIPTION
# What does this PR do ?

Sync with changes from https://github.com/NVIDIA/Megatron-LM/pull/1920/

Use the enums in place of strings and add assertion for re-run state machine compatibility

# Changelog

- Use CudaGraphScope enum values 

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
