### PR TITLE
[sync] Enable phase transition iterations

### DIFF
--- a/tests/unit_tests/training/test_config.py
+++ b/tests/unit_tests/training/test_config.py
@@ -2438,6 +2438,56 @@ class TestSampleBasedTraining:
             sched_cfg.finalize()
 
 
+class TestPhaseTransitionIterations:
+    """Tests for phase_transition_iterations configuration in TrainingConfig."""
+
+    def test_phase_transition_iterations_sorted_after_finalize(self):
+        """Test that phase_transition_iterations are sorted after finalize."""
+        train_cfg = create_test_training_config(
+            phase_transition_iterations=[500, 100, 300],  # Unsorted
+        )
+        train_cfg.finalize()
+
+        assert train_cfg.phase_transition_iterations == [100, 300, 500]  # Should be sorted
+
+    def test_phase_transition_iterations_with_rampup_batch_size_fails(self):
+        """Test that phase_transition_iterations with rampup_batch_size fails validation."""
+        train_cfg = create_test_training_config(
+            phase_transition_iterations=[100, 200],
+            rampup_batch_size=[16, 8, 300000],  # Incompatible with phase transitions
+        )
+
+        with pytest.raises(AssertionError, match="phase_transition_iterations is incompatible with rampup_batch_size"):
+            train_cfg.finalize()
+
+    def test_phase_transition_iterations_none_passes(self):
+        """Test that None phase_transition_iterations passes validation."""
+        train_cfg = create_test_training_config(
+            phase_transition_iterations=None,
+        )
+        train_cfg.finalize()  # Should pass without error
+
+        assert train_cfg.phase_transition_iterations is None
+
+    def test_phase_transition_iterations_empty_list_passes(self):
+        """Test that empty list phase_transition_iterations passes validation."""
+        train_cfg = create_test_training_config(
+            phase_transition_iterations=[],
+        )
+        train_cfg.finalize()  # Should pass without error
+
+        assert train_cfg.phase_transition_iterations == []
+
+    def test_phase_transition_iterations_single_value(self):
+        """Test that single phase transition iteration works."""
+        train_cfg = create_test_training_config(
+            phase_transition_iterations=[500],
+        )
+        train_cfg.finalize()
+
+        assert train_cfg.phase_transition_iterations == [500]
+
+
 class TestDatasetSequenceLengthValidation:
     """Tests for dataset sequence length validation with different dataset types."""
 


### PR DESCRIPTION
# What does this PR do ?

Sync changes from https://github.com/NVIDIA/Megatron-LM/pull/2938

phase transitions apply only to GPTDatasetConfig for pretraining. COnsumed samples in the current phase are calculated dynamically.

# Changelog

- Enable phase transition iterations for dataloader rebuilding

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
