### PR TITLE
[sync] Fix bug of reuse_grad_buf_for_mxfp8_param_ag

### DIFF
--- a/src/megatron/bridge/training/train.py
+++ b/src/megatron/bridge/training/train.py
@@ -628,6 +628,7 @@ def train_step(
 
         _handle_mxfp8_param_buffer_copy(
             optimizer=optimizer,
+            model=model,
             reuse_grad_buf_for_mxfp8_param_ag=cfg.optimizer.reuse_grad_buf_for_mxfp8_param_ag,
             overlap_param_gather=cfg.ddp.overlap_param_gather,
         )
@@ -1291,7 +1292,10 @@ def _dummy_train_step(
 
 
 def _handle_mxfp8_param_buffer_copy(
-    optimizer: MegatronOptimizer, reuse_grad_buf_for_mxfp8_param_ag: bool, overlap_param_gather: bool
+    optimizer: MegatronOptimizer,
+    model: list[MegatronModule],
+    reuse_grad_buf_for_mxfp8_param_ag: bool,
+    overlap_param_gather: bool,
 ) -> None:
     """Copy main params to param buffer for mxfp8 with grad buffer reuse.
 
@@ -1299,15 +1303,25 @@ def _handle_mxfp8_param_buffer_copy(
     we need to call _copy_main_params_to_param_buffer() after the grad buffer
     is zeroed because param and grad buffer are shared.
 
+    However, we should skip this on the first iteration when forward_pre_hook is disabled,
+    because:
+    1. The first iteration's params are already in param.data (from init or checkpoint).
+    2. Without forward_pre_hook, finish_param_sync() won't be called to zero the grad buffer,
+       so the main grads will be polluted by the main params.
+
     Args:
         optimizer: The MegatronOptimizer instance
+        model: List of model chunks (MegatronModule instances)
         reuse_grad_buf_for_mxfp8_param_ag: Config flag for grad buffer reuse
         overlap_param_gather: Config flag for overlapping param gathering
     """
     if reuse_grad_buf_for_mxfp8_param_ag and overlap_param_gather:
-        for optim_instance in optimizer.chained_optimizers:
-            if isinstance(optim_instance, DistributedOptimizer):
-                optim_instance._copy_main_params_to_param_buffer()
+        # Check if forward_pre_hook is enabled by checking if hooks are registered.
+        forward_pre_hook_enabled = len(model[0].remove_forward_pre_hook_handles) > 0
+        if forward_pre_hook_enabled:
+            for optim_instance in optimizer.chained_optimizers:
+                if isinstance(optim_instance, DistributedOptimizer):
+                    optim_instance._copy_main_params_to_param_buffer()
 
 
 def _delete_cuda_graphs(cuda_graph_helper: TECudaGraphHelper):

--- a/tests/unit_tests/training/test_train.py
+++ b/tests/unit_tests/training/test_train.py
@@ -198,8 +198,18 @@ class TestPostTrainingStepHelpers:
 class TestMxfp8ParamBufferCopy:
     """Unit tests for mxfp8 parameter buffer copying functionality."""
 
-    def test_copy_main_params_called_when_both_flags_true(self):
-        """Test that _copy_main_params_to_param_buffer is called when both config flags are True."""
+    def _create_mock_model(self, forward_pre_hook_enabled: bool = True):
+        """Helper to create a mock model with forward_pre_hook configuration."""
+        mock_model_chunk = Mock()
+        # Simulate forward_pre_hook enabled/disabled via remove_forward_pre_hook_handles
+        if forward_pre_hook_enabled:
+            mock_model_chunk.remove_forward_pre_hook_handles = [Mock()]  # Non-empty list
+        else:
+            mock_model_chunk.remove_forward_pre_hook_handles = []  # Empty list
+        return [mock_model_chunk]
+
+    def test_copy_main_params_called_when_both_flags_true_and_hook_enabled(self):
+        """Test that _copy_main_params_to_param_buffer is called when both config flags are True and hook is enabled."""
         mock_distributed_optimizer = Mock(spec=DistributedOptimizer)
         mock_other_optimizer = Mock()
 
@@ -209,8 +219,13 @@ class TestMxfp8ParamBufferCopy:
             mock_distributed_optimizer,
         ]
 
+        model = self._create_mock_model(forward_pre_hook_enabled=True)
+
         _handle_mxfp8_param_buffer_copy(
-            optimizer=mock_megatron_optimizer, reuse_grad_buf_for_mxfp8_param_ag=True, overlap_param_gather=True
+            optimizer=mock_megatron_optimizer,
+            model=model,
+            reuse_grad_buf_for_mxfp8_param_ag=True,
+            overlap_param_gather=True,
         )
 
         mock_distributed_optimizer._copy_main_params_to_param_buffer.assert_called_once()
@@ -219,14 +234,36 @@ class TestMxfp8ParamBufferCopy:
             or not mock_other_optimizer._copy_main_params_to_param_buffer.called
         )
 
+    def test_no_copy_when_forward_pre_hook_disabled(self):
+        """Test that no copying occurs when forward_pre_hook is disabled (first iteration)."""
+        mock_distributed_optimizer = Mock(spec=DistributedOptimizer)
+        mock_megatron_optimizer = Mock()
+        mock_megatron_optimizer.chained_optimizers = [mock_distributed_optimizer]
+
+        model = self._create_mock_model(forward_pre_hook_enabled=False)
+
+        _handle_mxfp8_param_buffer_copy(
+            optimizer=mock_megatron_optimizer,
+            model=model,
+            reuse_grad_buf_for_mxfp8_param_ag=True,
+            overlap_param_gather=True,
+        )
+
+        mock_distributed_optimizer._copy_main_params_to_param_buffer.assert_not_called()
+
     def test_no_copy_when_reuse_grad_buf_false(self):
         """Test that no copying occurs when reuse_grad_buf_for_mxfp8_param_ag is False."""
         mock_distributed_optimizer = Mock(spec=DistributedOptimizer)
         mock_megatron_optimizer = Mock()
         mock_megatron_optimizer.chained_optimizers = [mock_distributed_optimizer]
 
+        model = self._create_mock_model(forward_pre_hook_enabled=True)
+
         _handle_mxfp8_param_buffer_copy(
-            optimizer=mock_megatron_optimizer, reuse_grad_buf_for_mxfp8_param_ag=False, overlap_param_gather=True
+            optimizer=mock_megatron_optimizer,
+            model=model,
+            reuse_grad_buf_for_mxfp8_param_ag=False,
+            overlap_param_gather=True,
         )
         mock_distributed_optimizer._copy_main_params_to_param_buffer.assert_not_called()
 
@@ -235,8 +272,14 @@ class TestMxfp8ParamBufferCopy:
         mock_distributed_optimizer = Mock(spec=DistributedOptimizer)
         mock_megatron_optimizer = Mock()
         mock_megatron_optimizer.chained_optimizers = [mock_distributed_optimizer]
+
+        model = self._create_mock_model(forward_pre_hook_enabled=True)
+
         _handle_mxfp8_param_buffer_copy(
-            optimizer=mock_megatron_optimizer, reuse_grad_buf_for_mxfp8_param_ag=True, overlap_param_gather=False
+            optimizer=mock_megatron_optimizer,
+            model=model,
+            reuse_grad_buf_for_mxfp8_param_ag=True,
+            overlap_param_gather=False,
         )
 
         mock_distributed_optimizer._copy_main_params_to_param_buffer.assert_not_called()
@@ -247,8 +290,13 @@ class TestMxfp8ParamBufferCopy:
         mock_megatron_optimizer = Mock()
         mock_megatron_optimizer.chained_optimizers = [mock_distributed_optimizer]
 
+        model = self._create_mock_model(forward_pre_hook_enabled=True)
+
         _handle_mxfp8_param_buffer_copy(
-            optimizer=mock_megatron_optimizer, reuse_grad_buf_for_mxfp8_param_ag=False, overlap_param_gather=False
+            optimizer=mock_megatron_optimizer,
+            model=model,
+            reuse_grad_buf_for_mxfp8_param_ag=False,
+            overlap_param_gather=False,
         )
 
         mock_distributed_optimizer._copy_main_params_to_param_buffer.assert_not_called()
@@ -266,8 +314,13 @@ class TestMxfp8ParamBufferCopy:
             mock_distributed_optimizer_2,
         ]
 
+        model = self._create_mock_model(forward_pre_hook_enabled=True)
+
         _handle_mxfp8_param_buffer_copy(
-            optimizer=mock_megatron_optimizer, reuse_grad_buf_for_mxfp8_param_ag=True, overlap_param_gather=True
+            optimizer=mock_megatron_optimizer,
+            model=model,
+            reuse_grad_buf_for_mxfp8_param_ag=True,
+            overlap_param_gather=True,
         )
 
         mock_distributed_optimizer_1._copy_main_params_to_param_buffer.assert_called_once()
@@ -289,8 +342,13 @@ class TestMxfp8ParamBufferCopy:
             mock_distributed_optimizer,
         ]
 
+        model = self._create_mock_model(forward_pre_hook_enabled=True)
+
         _handle_mxfp8_param_buffer_copy(
-            optimizer=mock_megatron_optimizer, reuse_grad_buf_for_mxfp8_param_ag=True, overlap_param_gather=True
+            optimizer=mock_megatron_optimizer,
+            model=model,
+            reuse_grad_buf_for_mxfp8_param_ag=True,
+            overlap_param_gather=True,
         )
 
         mock_distributed_optimizer._copy_main_params_to_param_buffer.assert_called_once()
@@ -300,6 +358,31 @@ class TestMxfp8ParamBufferCopy:
             not hasattr(mock_regular_optimizer, "_copy_main_params_to_param_buffer")
             or not mock_regular_optimizer._copy_main_params_to_param_buffer.called
         )
+
+    def test_no_copy_when_hook_disabled_despite_all_flags_true(self):
+        """Test that no copying occurs on first iteration (hook disabled) even when all flags are True."""
+        mock_distributed_optimizer_1 = Mock(spec=DistributedOptimizer)
+        mock_distributed_optimizer_2 = Mock(spec=DistributedOptimizer)
+
+        mock_megatron_optimizer = Mock()
+        mock_megatron_optimizer.chained_optimizers = [
+            mock_distributed_optimizer_1,
+            mock_distributed_optimizer_2,
+        ]
+
+        # Simulate first iteration where forward_pre_hook is disabled
+        model = self._create_mock_model(forward_pre_hook_enabled=False)
+
+        _handle_mxfp8_param_buffer_copy(
+            optimizer=mock_megatron_optimizer,
+            model=model,
+            reuse_grad_buf_for_mxfp8_param_ag=True,
+            overlap_param_gather=True,
+        )
+
+        # Neither optimizer should have copy called
+        mock_distributed_optimizer_1._copy_main_params_to_param_buffer.assert_not_called()
+        mock_distributed_optimizer_2._copy_main_params_to_param_buffer.assert_not_called()
 
 
 class TestShouldDisableForwardPreHook:


### PR DESCRIPTION
# What does this PR do ?

Sync changes from https://github.com/NVIDIA/Megatron-LM/pull/2802

# Changelog

- Fix bug of reuse_grad_buf_for_mxfp8_param_ag

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parameter buffer management during training by making buffer copying conditional on forward pre-hook availability, optimizing resource handling and preventing unnecessary operations on iterations where forward pre-hooks are inactive.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->