### PR TITLE
Set create_attention_mask = False for pretrain

### DIFF
--- a/scripts/performance/run_script.py
+++ b/scripts/performance/run_script.py
@@ -45,7 +45,7 @@ def main():
     )
 
     recipe = set_cli_overrides(recipe, cli_overrides)
-    recipe = set_user_overrides(recipe, args)
+    recipe = set_user_overrides(recipe, args, args.task)
     recipe = set_post_overrides(
         recipe,
         args.model_family_name,

--- a/scripts/performance/utils/overrides.py
+++ b/scripts/performance/utils/overrides.py
@@ -248,7 +248,7 @@ def set_cli_overrides(recipe: ConfigContainer, cli_overrides: List[str]) -> Conf
     return recipe
 
 
-def set_user_overrides(recipe: ConfigContainer, args: argparse.Namespace) -> ConfigContainer:
+def set_user_overrides(recipe: ConfigContainer, args: argparse.Namespace, task: str) -> ConfigContainer:
     """Set the user overrides."""
     _set_megatron_fsdp_overrides(recipe, use_megatron_fsdp=args.use_megatron_fsdp, nccl_ub=args.nccl_ub)
     _set_cuda_graph_overrides(
@@ -361,6 +361,9 @@ def set_user_overrides(recipe: ConfigContainer, args: argparse.Namespace) -> Con
         recipe.dataset.dataset_kwargs = {"pad_to_max_length": True}
     else:
         raise ValueError(f"Unknown dataset type: {args.data}")
+    if task == "pretrain":
+        recipe.dataset.create_attention_mask = False
+
     if args.hidden_size is not None:
         recipe.model.hidden_size = args.hidden_size
     if args.num_layers is not None or args.first_k_dense_replace is not None:


### PR DESCRIPTION
# What does this PR do ?

The option is True by default in MLM. During pretrain we don't need to be generated. Because the casual mask is autogenerated in the model

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced configuration override system to support task-specific settings, improving pretraining configuration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->