### PR TITLE
cp: `DSv3 EP=8 for B200, PP8-VP2 for B300 BF16, Lm3.1 405B TP4-CP1 GB300 FP8-CS (2175)` into `r0.3.0`

### DIFF
--- a/scripts/performance/configs/deepseek/deepseek_workload_base_configs.py
+++ b/scripts/performance/configs/deepseek/deepseek_workload_base_configs.py
@@ -103,7 +103,7 @@ DEEPSEEK_V3_PRETRAIN_CONFIG_B200_V1 = replace(
     BASE_DEEPSEEK_V3_CONFIG,
     num_gpus=256,
     pipeline_model_parallel_size=16,
-    expert_model_parallel_size=16,
+    expert_model_parallel_size=8,
     global_batch_size=2048,
     recompute_modules=["mla_up_proj"],
     moe_flex_dispatcher_backend="hybridep",
@@ -161,7 +161,11 @@ DEEPSEEK_V3_PRETRAIN_CONFIG_B300_V2 = replace(
     DEEPSEEK_V3_PRETRAIN_CONFIG_B300_V1,
     global_batch_size=4096,
 )
-DEEPSEEK_V3_PRETRAIN_CONFIG_B300_BF16_V2 = DEEPSEEK_V3_PRETRAIN_CONFIG_B300_V2
+DEEPSEEK_V3_PRETRAIN_CONFIG_B300_BF16_V2 = replace(
+    DEEPSEEK_V3_PRETRAIN_CONFIG_B300_V2,
+    pipeline_model_parallel_size=8,
+    virtual_pipeline_model_parallel_size=2,
+)
 DEEPSEEK_V3_PRETRAIN_CONFIG_B300_FP8_CS_V2 = DEEPSEEK_V3_PRETRAIN_CONFIG_B300_V2
 DEEPSEEK_V3_PRETRAIN_CONFIG_B300_FP8_MX_V2 = DEEPSEEK_V3_PRETRAIN_CONFIG_B300_FP8_CS_V2
 

--- a/scripts/performance/configs/llama/llama31_workload_base_configs.py
+++ b/scripts/performance/configs/llama/llama31_workload_base_configs.py
@@ -224,9 +224,9 @@ LLAMA31_405B_PRETRAIN_CONFIG_GB300_BF16_V2 = replace(
 
 LLAMA31_405B_PRETRAIN_CONFIG_GB300_FP8_CS_V2 = replace(
     LLAMA31_405B_PRETRAIN_CONFIG_GB300_FP8_CS_V1,
-    tensor_model_parallel_size=2,
+    tensor_model_parallel_size=4,
     pipeline_model_parallel_size=8,
-    context_parallel_size=2,
+    context_parallel_size=1,
     virtual_pipeline_model_parallel_size=4,
     num_gpus=256,
     global_batch_size=1536,


### PR DESCRIPTION
beep boop [🤖]: Hi @malay-nagda 👋,

    we've cherry picked #2175 into  for you! 🚀

    Please review and approve this cherry pick by your convenience!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized DeepSeek V3 pretraining configuration for GB300 hardware by adjusting expert and pipeline parallelism parameters.
  * Updated LLaMA 3.1 pretraining configuration to refine tensor and context parallelism settings for improved training efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->