### PR TITLE
[misc] fix: Use double quotes for lint consistency

### DIFF
--- a/src/megatron/bridge/package_info.py
+++ b/src/megatron/bridge/package_info.py
@@ -16,7 +16,7 @@
 MAJOR = 0
 MINOR = 4
 PATCH = 0
-PRE_RELEASE = 'rc0'
+PRE_RELEASE = "rc0"
 
 # Use the following formatting: (major, minor, patch, pre-release)
 VERSION = (MAJOR, MINOR, PATCH, PRE_RELEASE)


### PR DESCRIPTION
This PR fixes a lint issue by changing single quotes to double quotes in `package_info.py` for consistency with the project's style guidelines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Applied formatting consistency update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->