### PR TITLE
cp: `Fix Qwen2.5-VL huggingface conversion issue (#2107) (2156)` into `r0.3.0`

### DIFF
--- a/src/megatron/bridge/inference/vlm/base.py
+++ b/src/megatron/bridge/inference/vlm/base.py
@@ -112,6 +112,17 @@ def setup_model_and_tokenizer(
     return inference_wrapped_model, processor
 
 
+def _expose_decoder_from_language_model(model):
+    """Recursively get language_model from model and expose decoder, handling wrapped modules."""
+    current = model
+    while hasattr(current, "module"):
+        current = current.module
+
+    if hasattr(current, "language_model"):
+        language_model = current.language_model
+        current.decoder = language_model.decoder
+
+
 def setup_inference_wrapper(
     model,
     tokenizer,
@@ -131,6 +142,8 @@ def setup_inference_wrapper(
         wrapper_cls = QwenVLInferenceWrapper
         if isinstance(config, Qwen25VLModelProvider):
             hidden_size = config.hidden_size
+            # Expose decoder for MCore Infernce Engine compatibility (used by get_mamba_inference_state_config_from_model)
+            _expose_decoder_from_language_model(mcore_model)
         else:
             hidden_size = config.language_transformer_config.hidden_size
     else:

--- a/src/megatron/bridge/models/qwen_vl/modeling_qwen25_vl.py
+++ b/src/megatron/bridge/models/qwen_vl/modeling_qwen25_vl.py
@@ -111,9 +111,6 @@ class Qwen25VLModel(MegatronModule):
         self.share_embeddings_and_output_weights = config.share_embeddings_and_output_weights
         self.shared_embedding_or_output_weight = self.language_model.shared_embedding_or_output_weight
 
-        # Expose decoder for MCore Infernce Engine compatibility (used by get_mamba_inference_state_config_from_model)
-        self.decoder = self.language_model.decoder
-
         # Bind methods from HF's Qwen2_5_VLModel to this instance
         # get_placeholder_mask is only available in transformers 4.55+
         if is_transformers_min_version("4.55.0"):


### PR DESCRIPTION
beep boop [🤖]: Hi @meatybobby 👋,

    we've cherry picked #2156 into  for you! 🚀

    Please review and approve this cherry pick by your convenience!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved handling of nested model structures for MCore Inference Engine compatibility with Qwen25 VLM inference.

* **Tests**
  * Enhanced test coverage to validate proper exposure of model components across various nested model configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->