### PR TITLE
ci: Remove keyword from secret detector

### DIFF
--- a/.github/workflows/config/.secrets.baseline
+++ b/.github/workflows/config/.secrets.baseline
@@ -46,10 +46,6 @@
       "name": "JwtTokenDetector"
     },
     {
-      "name": "KeywordDetector",
-      "keyword_exclude": ""
-    },
-    {
       "name": "MailchimpDetector"
     },
     {
@@ -91,10 +87,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".github/workflows/config/.secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -133,43 +125,13 @@
     }
   ],
   "results": {
-    ".github/workflows/cicd-main.yml": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/cicd-main.yml",
-        "hashed_secret": "0de7d8c7d76191fdcb236d3c62be9adf20424ca2",
-        "is_verified": false,
-        "line_number": 284
-      }
-    ],
-    "CONTRIBUTING.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": "CONTRIBUTING.md",
-        "hashed_secret": "999d493295471df21f917fdc49321086466edf87",
-        "is_verified": false,
-        "line_number": 58,
-        "is_secret": false
-      }
-    ],
     "docker/manifest.json": [
       {
         "type": "Hex High Entropy String",
         "filename": "docker/manifest.json",
         "hashed_secret": "7ae58d0f08b842ce4d8de7c9ae79feca070eb79e",
         "is_verified": false,
-        "line_number": 5,
-        "is_secret": false
-      }
-    ],
-    "scripts/training/launch_with_sbatch.sh": [
-      {
-        "type": "Secret Keyword",
-        "filename": "scripts/training/launch_with_sbatch.sh",
-        "hashed_secret": "5d961f73a9b6f9dc9884e659e013d76631e13dbf",
-        "is_verified": false,
-        "line_number": 87,
-        "is_secret": false
+        "line_number": 5
       }
     ],
     "tests/functional_tests/training/test_load_model.py": [
@@ -178,26 +140,7 @@
         "filename": "tests/functional_tests/training/test_load_model.py",
         "hashed_secret": "906b706cb02260b7de67df2a36315ae2fb2ab27d",
         "is_verified": false,
-        "line_number": 41,
-        "is_secret": false
-      }
-    ],
-    "tests/unit_tests/recipes/test_run_plugins.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/unit_tests/recipes/test_run_plugins.py",
-        "hashed_secret": "767ef7376d44bb6e52b390ddcd12c1cb1b3902a4",
-        "is_verified": false,
-        "line_number": 521,
-        "is_secret": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/unit_tests/recipes/test_run_plugins.py",
-        "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
-        "is_verified": false,
-        "line_number": 882,
-        "is_secret": false
+        "line_number": 41
       }
     ],
     "tutorials/data/dclm/data_pipeline.ipynb": [
@@ -206,24 +149,21 @@
         "filename": "tutorials/data/dclm/data_pipeline.ipynb",
         "hashed_secret": "518f01d26deb33a16a9750232754e8950c8fc698",
         "is_verified": false,
-        "line_number": 69,
-        "is_secret": false
+        "line_number": 69
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "tutorials/data/dclm/data_pipeline.ipynb",
         "hashed_secret": "a307fa66e51942700c4023ae0a4745654e768735",
         "is_verified": false,
-        "line_number": 129,
-        "is_secret": false
+        "line_number": 129
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "tutorials/data/dclm/data_pipeline.ipynb",
         "hashed_secret": "8bc0e0ae33dd981ff58e4a06e0392c87d1bda9e5",
         "is_verified": false,
-        "line_number": 136,
-        "is_secret": false
+        "line_number": 136
       }
     ],
     "tutorials/training/reduced_precision_training.ipynb": [
@@ -232,10 +172,9 @@
         "filename": "tutorials/training/reduced_precision_training.ipynb",
         "hashed_secret": "9e399440a1f7957a428b39d3a61d249f64401780",
         "is_verified": false,
-        "line_number": 122,
-        "is_secret": false
+        "line_number": 122
       }
     ]
   },
-  "generated_at": "2026-01-29T20:01:40Z"
+  "generated_at": "2026-02-04T04:20:29Z"
 }


### PR DESCRIPTION
# What does this PR do ?

The keyword plugin for the secret detector can have several false positives.  Just mentioning "password" or "api key" will flag the change.

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security scanning configuration and removed outdated detection entries from the baseline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->