### PR TITLE
Increase unit test timeout to 2s

### DIFF
--- a/tests/unit_tests/Launch_Unit_Tests.sh
+++ b/tests/unit_tests/Launch_Unit_Tests.sh
@@ -26,7 +26,7 @@ fi
 echo ""
 
 CUDA_VISIBLE_DEVICES="0,1" uv run coverage run -a --data-file=/opt/Megatron-Bridge/.coverage --source=/opt/Megatron-Bridge/ -m pytest \
-    --timeout=1 \
+    --timeout=2 \
     -o log_cli=true \
     -o log_cli_level=INFO \
     --disable-warnings \


### PR DESCRIPTION
# What does this PR do ?

Increase unit test timeout to 2s

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Adjusted test timeout threshold to allow extended execution duration for test cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->