### PR TITLE
fix: fixing fsdp_manual_registration logic in perf script

### DIFF
--- a/scripts/performance/utils/overrides.py
+++ b/scripts/performance/utils/overrides.py
@@ -251,7 +251,7 @@ def _set_nccl_ub_overrides(recipe: ConfigContainer, nccl_ub: bool = False) -> Co
         # To enable symmetric kernels, average_in_collective must be disabled.
         recipe.ddp.average_in_collective = False
 
-    if recipe.ddp.use_megatron_fsdp:
+    if recipe.ddp.use_megatron_fsdp and recipe.ddp.nccl_ub:
         recipe.ddp.fsdp_manual_registration = True
 
     return recipe


### PR DESCRIPTION
# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a performance configuration logic issue where a setting was being applied in unintended scenarios. The setting now correctly applies only when both required conditions are met.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->