### PR TITLE
ci: Skip unit test timeout on Azure runners

### DIFF
--- a/.github/actions/test-template/action.yml
+++ b/.github/actions/test-template/action.yml
@@ -132,6 +132,7 @@ runs:
           --runtime=nvidia --gpus all \
           --shm-size=64g \
           --cpus=40 \
+          --env GHA_RUNNER=${{ inputs.runner }} \
           --env HYDRA_FULL_ERROR=1 \
           --env HF_HOME=/home/TestData/HF_HOME \
           --env NEMO_HOME=/home/TestData/nemo_home \

--- a/tests/unit_tests/Launch_Unit_Tests.sh
+++ b/tests/unit_tests/Launch_Unit_Tests.sh
@@ -25,8 +25,14 @@ if [ -f "/opt/Megatron-Bridge/.mcore_commit_sha" ]; then
 fi
 echo ""
 
+# Skip timeout on Azure runners because the machines are slower
+TIMEOUT_ARG="--timeout=2"
+if [[ "${GHA_RUNNER:-}" == *"azure"* ]]; then
+    TIMEOUT_ARG=""
+fi
+
 CUDA_VISIBLE_DEVICES="0,1" uv run coverage run -a --data-file=/opt/Megatron-Bridge/.coverage --source=/opt/Megatron-Bridge/ -m pytest \
-    --timeout=2 \
+    $TIMEOUT_ARG \
     -o log_cli=true \
     -o log_cli_level=INFO \
     --disable-warnings \


### PR DESCRIPTION
# What does this PR do ?

ci: Skip unit test timeout on Azure runners

The Azure runners are currently used for external contributors for now. But their test time can be worse compared to our other runners.

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated unit test timeout handling to conditionally disable timeouts for specific runner environments, improving test reliability.

* **Chores**
  * Enhanced CI/CD configuration to better support different test execution environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->