### PR TITLE
405b fp4 gb300 no cg

### DIFF
--- a/scripts/performance/configs/llama/llama31_workload_base_configs.py
+++ b/scripts/performance/configs/llama/llama31_workload_base_configs.py
@@ -246,6 +246,7 @@ LLAMA31_405B_PRETRAIN_CONFIG_GB300_NVFP4_V2 = replace(
     LLAMA31_405B_PRETRAIN_CONFIG_GB300_NVFP4_V1,
     num_gpus=256,
     global_batch_size=1536,
+    cuda_graph_impl="none",
 )
 
 


### PR DESCRIPTION
# What does this PR do ?

Disable cuda graphs for Llama3.1 405B + NVFP4 + GB300 to resolve Hang

# Changelog

```
cuda_graph_impl="none"
```

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pretraining configuration settings for optimized model performance on specific hardware platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->