### PR TITLE
qwen gbs 2x

### DIFF
--- a/scripts/performance/configs/qwen/qwen3_workload_base_configs.py
+++ b/scripts/performance/configs/qwen/qwen3_workload_base_configs.py
@@ -414,6 +414,7 @@ QWEN3_30B_A3B_PRETRAIN_CONFIG_H100_BF16_V1 = replace(
     moe_a2a_overlap=True,
     cuda_graph_impl="transformer_engine",
     cuda_graph_scope=["moe_router", "moe_preprocess"],
+    moe_flex_dispatcher_backend="deepep",
 )
 
 
@@ -424,6 +425,7 @@ QWEN3_30B_A3B_PRETRAIN_CONFIG_H100_FP8_CS_V1 = replace(
     pipeline_model_parallel_size=2,
     virtual_pipeline_model_parallel_size=12,
     moe_a2a_overlap=True,
+    moe_flex_dispatcher_backend="deepep",
 )
 
 


### PR DESCRIPTION
# What does this PR do ?

Updated GBS for Qwen3 30B_a3B H100 

# Changelog

```
global_batch_size=1024,
```

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated batch size configuration for QWEN 30B model training on H100 GPUs to enhance computational efficiency across BF16 and FP8 precision modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->