### PR TITLE
Revert DSV3 GB300 BF16 and large scale proxy recipe

### DIFF
--- a/scripts/performance/configs/deepseek/deepseek_workload_base_configs.py
+++ b/scripts/performance/configs/deepseek/deepseek_workload_base_configs.py
@@ -38,7 +38,20 @@ BASE_DEEPSEEK_V3_CONFIG = WorkloadBaseConfig(
 # DeepSeek V3 Pretrain - V1 (original GBS settings)
 # =============================================================================
 
-DEEPSEEK_V3_PRETRAIN_CONFIG_GB300_V1 = replace(
+DEEPSEEK_V3_PRETRAIN_CONFIG_GB300_BF16_V1 = replace(
+    BASE_DEEPSEEK_V3_CONFIG,
+    num_gpus=256,
+    global_batch_size=2048,
+    pipeline_model_parallel_size=4,
+    virtual_pipeline_model_parallel_size=4,
+    expert_model_parallel_size=64,
+    moe_flex_dispatcher_backend="hybridep",
+    moe_a2a_overlap=False,
+    cuda_graph_impl="transformer_engine",
+    cuda_graph_scope=["attn", "moe_router", "moe_preprocess"],
+    recompute_modules=["moe_act"],
+)
+DEEPSEEK_V3_PRETRAIN_CONFIG_GB300_FP8_CS_V1 = replace(
     BASE_DEEPSEEK_V3_CONFIG,
     num_gpus=256,
     global_batch_size=2048,
@@ -52,10 +65,8 @@ DEEPSEEK_V3_PRETRAIN_CONFIG_GB300_V1 = replace(
     cuda_graph_scope=[],
     recompute_modules=["mla_up_proj"],
 )
-DEEPSEEK_V3_PRETRAIN_CONFIG_GB300_BF16_V1 = DEEPSEEK_V3_PRETRAIN_CONFIG_GB300_V1
-DEEPSEEK_V3_PRETRAIN_CONFIG_GB300_FP8_CS_V1 = DEEPSEEK_V3_PRETRAIN_CONFIG_GB300_V1
-DEEPSEEK_V3_PRETRAIN_CONFIG_GB300_FP8_MX_V1 = DEEPSEEK_V3_PRETRAIN_CONFIG_GB300_V1
-DEEPSEEK_V3_PRETRAIN_CONFIG_GB300_NVFP4_V1 = DEEPSEEK_V3_PRETRAIN_CONFIG_GB300_V1
+DEEPSEEK_V3_PRETRAIN_CONFIG_GB300_FP8_MX_V1 = DEEPSEEK_V3_PRETRAIN_CONFIG_GB300_FP8_CS_V1
+DEEPSEEK_V3_PRETRAIN_CONFIG_GB300_NVFP4_V1 = DEEPSEEK_V3_PRETRAIN_CONFIG_GB300_FP8_CS_V1
 
 
 DEEPSEEK_V3_PRETRAIN_CONFIG_GB200_V1 = replace(
@@ -127,14 +138,16 @@ DEEPSEEK_V3_PRETRAIN_CONFIG_H100_FP8_SC_V1 = DEEPSEEK_V3_PRETRAIN_CONFIG_H100_FP
 # DeepSeek V3 Pretrain - V2 (GBS=4096 for Blackwell, GBS=16384 for H100)
 # =============================================================================
 
-DEEPSEEK_V3_PRETRAIN_CONFIG_GB300_V2 = replace(
-    DEEPSEEK_V3_PRETRAIN_CONFIG_GB300_V1,
+DEEPSEEK_V3_PRETRAIN_CONFIG_GB300_BF16_V2 = replace(
+    DEEPSEEK_V3_PRETRAIN_CONFIG_GB300_BF16_V1,
     global_batch_size=4096,
 )
-DEEPSEEK_V3_PRETRAIN_CONFIG_GB300_BF16_V2 = DEEPSEEK_V3_PRETRAIN_CONFIG_GB300_V2
-DEEPSEEK_V3_PRETRAIN_CONFIG_GB300_FP8_CS_V2 = DEEPSEEK_V3_PRETRAIN_CONFIG_GB300_V2
-DEEPSEEK_V3_PRETRAIN_CONFIG_GB300_FP8_MX_V2 = DEEPSEEK_V3_PRETRAIN_CONFIG_GB300_V2
-DEEPSEEK_V3_PRETRAIN_CONFIG_GB300_NVFP4_V2 = DEEPSEEK_V3_PRETRAIN_CONFIG_GB300_V2
+DEEPSEEK_V3_PRETRAIN_CONFIG_GB300_FP8_CS_V2 = replace(
+    DEEPSEEK_V3_PRETRAIN_CONFIG_GB300_FP8_CS_V1,
+    global_batch_size=4096,
+)
+DEEPSEEK_V3_PRETRAIN_CONFIG_GB300_FP8_MX_V2 = DEEPSEEK_V3_PRETRAIN_CONFIG_GB300_FP8_CS_V2
+DEEPSEEK_V3_PRETRAIN_CONFIG_GB300_NVFP4_V2 = DEEPSEEK_V3_PRETRAIN_CONFIG_GB300_FP8_CS_V2
 
 
 DEEPSEEK_V3_PRETRAIN_CONFIG_GB200_V2 = replace(
@@ -182,8 +195,11 @@ DEEPSEEK_V3_PRETRAIN_CONFIG_H100_FP8_SC_V2 = DEEPSEEK_V3_PRETRAIN_CONFIG_H100_FP
 # DeepSeek V3 Pretrain - Large Scale Proxy
 # =============================================================================
 
+# GB300 FP8 MX large scale: inherit from BF16_V1 (not FP8_MX_V1) for MBS=1 mapping so
+# num_microbatches >= PP and the interleaved pipeline schedule constraint is satisfied.
+# Precision/recipe remain FP8 MX from the recipe builder; only GBS and MBS layout are used here.
 DEEPSEEK_V3_PRETRAIN_CONFIG_GB300_FP8_MX_LARGE_SCALE = replace(
-    DEEPSEEK_V3_PRETRAIN_CONFIG_GB300_FP8_MX_V1,
+    DEEPSEEK_V3_PRETRAIN_CONFIG_GB300_BF16_V1,
     global_batch_size=256,
 )
 


### PR DESCRIPTION
# What does this PR do ?

Use MBS1+CG mapping in 
- BF16 for NCCL hang
- large scale proxy as no enough GBS for MBS2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new pretrain configurations for GB300 hardware, including BF16 and FP8_CS variants.
  * Introduced new large-scale proxy configuration option for GB300.

* **Chores**
  * Restructured and consolidated performance configuration aliases for GB300 variants, improving configuration management and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->