### PR TITLE
cp: `LLAMA3 70B: LoRa enabled in all modules instead of only LinearQKV (2181)` into `r0.3.0`

### DIFF
--- a/scripts/performance/configs/llama/llama3_llm_finetune.py
+++ b/scripts/performance/configs/llama/llama3_llm_finetune.py
@@ -210,6 +210,9 @@ def llama3_70b_lora_config_gb300(precision: str = "bf16", config_variant: str = 
     set_llama3_common_peft_configs(cfg)
     set_workload_base_configs(cfg, base_cfg)
 
+    # Override target_modules to only apply LoRA to QKV
+    cfg.peft.target_modules = ["linear_qkv"]
+
     # Enable pad_cu_seqlens for CUDA graphs compatibility with packed sequences.
     # This ensures consistent cu_seqlens tensor shapes across batches, which is required
     # for CUDA graphs and avoids NaN issues in attention kernels.
@@ -240,6 +243,9 @@ def llama3_70b_lora_config_gb200(precision: str = "bf16", config_variant: str = 
     set_llama3_common_peft_configs(cfg)
     set_workload_base_configs(cfg, base_cfg)
 
+    # Override target_modules to only apply LoRA to QKV
+    cfg.peft.target_modules = ["linear_qkv"]
+
     return cfg
 
 
@@ -263,5 +269,8 @@ def llama3_70b_lora_config_h100(precision: str = "bf16", config_variant: str = "
     )
     set_llama3_common_peft_configs(cfg)
     set_workload_base_configs(cfg, base_cfg)
+
+    # Override target_modules to only apply LoRA to QKV
+    cfg.peft.target_modules = ["linear_qkv"]
 
     return cfg


### PR DESCRIPTION
beep boop [🤖]: Hi @rhmukundan 👋,

    we've cherry picked #2181 into  for you! 🚀

    Please review and approve this cherry pick by your convenience!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted LoRA configuration settings for model fine-tuning to target specific linear module types instead of all available modules across multiple GPU architecture configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->