### PR TITLE
[QWen3VL] Adding CUDA Graph Support for LLM Sub-module and Vision Encoder Sub-module

### DIFF
--- a/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/model.py
+++ b/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/model.py
@@ -204,6 +204,30 @@ class Qwen3VLModel(MegatronModule):
                 "Qwen3-VL model only supports context parallelism with calculate_per_token_loss enabled"
             )
 
+        self._expose_language_model_for_cuda_graph_helper()
+
+    def _expose_language_model_for_cuda_graph_helper(self) -> None:
+        """Expose LM fields on the VLM root for the CUDA graph helper when cuda_graph_impl is enabled.
+
+        The CUDA graph helper expects ``position_embedding_type``, ``rotary_pos_emb``, and ``decoder`` on
+        the model, but in Qwen3-VL these live on ``language_model``. Assigning ``decoder`` here shadows
+        the :meth:`decoder` property for this instance only when graphs are used.
+        """
+        llm_cuda_graph_enabled = (
+            self.language_model is not None
+            and getattr(self.language_model.config, "cuda_graph_impl", "none") != "none"
+        )
+        if not llm_cuda_graph_enabled:
+            return
+        assert not self.language_model.config.variable_seq_lengths, (
+            "Qwen3-VL MoE with CUDA graph requires fixed sequence lengths (variable_seq_lengths=False). "
+            "Disable variable-length / packed pipelines (e.g. in-batch packing with PP, or other modes "
+            "that set variable_seq_lengths) or turn off CUDA graph."
+        )
+        self.position_embedding_type = self.language_model.position_embedding_type
+        self.rotary_pos_emb = self.language_model.rotary_pos_emb
+        self.decoder = self.language_model.decoder
+
     def shared_embedding_or_output_weight(self):
         """This is a convenience method to surface the language model's word embeddings, which is
         necessary for `finalize_model_grads._allreduce_word_embedding_grads`."""

--- a/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/transformer_block.py
+++ b/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/transformer_block.py
@@ -121,6 +121,18 @@ class Qwen3VLVisionTransformerBlock(TransformerBlock):
                         if use_inner_fp8_context
                         else nullcontext()
                     )
+                    # Check if layer will use TE CUDA graph replay - if so, don't pass
+                    # packed_seq_params since CUDA graph only accepts tensor inputs.
+                    # Use layer.config (not self.config) because the layer's config is what
+                    # determines if _should_call_te_cudagraph returns True.
+                    layer_uses_te_cudagraph = (
+                        hasattr(layer, "cuda_graphs")
+                        and layer.cuda_graphs
+                        and layer.training
+                        and hasattr(layer, "config")
+                        and getattr(layer.config, "cuda_graph_impl", "none") == "transformer_engine"
+                    )
+                    layer_packed_seq_params = None if layer_uses_te_cudagraph else packed_seq_params
                     with inner_fp8_context:
                         hidden_states, context = layer(
                             hidden_states=hidden_states,
@@ -130,7 +142,7 @@ class Qwen3VLVisionTransformerBlock(TransformerBlock):
                             rotary_pos_emb=rotary_pos_emb,
                             attention_bias=attention_bias,
                             inference_context=None,
-                            packed_seq_params=packed_seq_params,
+                            packed_seq_params=layer_packed_seq_params,
                         )
 
                         l_no = layer.layer_number - 1
@@ -323,6 +335,18 @@ class Qwen3VLVisionTransformerBlock(TransformerBlock):
                     )
                     assert l_no == layer.layer_number - 1
                     with self.offload_context, inner_fp8_context:
+                        # Check if layer will use TE CUDA graph replay - if so, don't pass
+                        # packed_seq_params since CUDA graph only accepts tensor inputs.
+                        # Use layer.config (not self.config) because the layer's config is what
+                        # determines if _should_call_te_cudagraph returns True.
+                        layer_uses_te_cudagraph = (
+                            hasattr(layer, "cuda_graphs")
+                            and layer.cuda_graphs
+                            and layer.training
+                            and hasattr(layer, "config")
+                            and getattr(layer.config, "cuda_graph_impl", "none") == "transformer_engine"
+                        )
+                        layer_packed_seq_params = None if layer_uses_te_cudagraph else packed_seq_params
                         hidden_states, context = layer(
                             hidden_states=hidden_states,
                             attention_mask=attention_mask,
@@ -333,7 +357,7 @@ class Qwen3VLVisionTransformerBlock(TransformerBlock):
                             rotary_pos_sin=rotary_pos_sin,
                             attention_bias=attention_bias,
                             inference_context=inference_context,
-                            packed_seq_params=packed_seq_params,
+                            packed_seq_params=layer_packed_seq_params,
                             sequence_len_offset=sequence_len_offset,
                         )
 

--- a/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/transformer_config.py
+++ b/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/transformer_config.py
@@ -52,6 +52,8 @@ class Qwen3VLTransformerConfig(TransformerConfig):
     hf_text_config: Optional[Qwen3VLTextConfig] = None
     vision_dp_when_cp: bool = False
     use_hf_vision_model: bool = False
+    # Maximum sequence length for vision encoder CUDA graphs.
+    max_vision_cuda_graph_seq_length: Optional[int] = None
 
 
 def get_vision_model_config(hf_config, megatron_config=None):
@@ -120,4 +122,32 @@ def get_vision_model_config(hf_config, megatron_config=None):
     config.pipeline_model_parallel_layout = None
     config.account_for_embedding_in_pipeline_split = None
     config.account_for_loss_in_pipeline_split = None
+
+    # Vision encoder CUDA graph settings
+    # Check megatron_config (the provider / language config) for vision-specific CUDA graph
+    # settings. The provider stores these as vision_cuda_graph_impl / vision_cuda_graph_scope.
+    # If present, use them; otherwise default to "none" for backward compatibility.
+    if (
+        megatron_config is not None
+        and hasattr(megatron_config, "vision_cuda_graph_impl")
+        and megatron_config.vision_cuda_graph_impl != "none"
+    ):
+        config.cuda_graph_impl = megatron_config.vision_cuda_graph_impl
+        if hasattr(megatron_config, "vision_cuda_graph_scope") and megatron_config.vision_cuda_graph_scope:
+            # Convert string scope list to CudaGraphScope enums if needed
+            from megatron.core.transformer.cuda_graphs import CudaGraphScope
+
+            scope_list = megatron_config.vision_cuda_graph_scope
+            if scope_list and isinstance(scope_list[0], str):
+                config.cuda_graph_scope = [CudaGraphScope[scope] for scope in scope_list]
+            else:
+                config.cuda_graph_scope = scope_list
+        else:
+            config.cuda_graph_scope = []
+    else:
+        config.cuda_graph_impl = "none"
+        config.cuda_graph_scope = []
+    # Propagate max vision CUDA graph sequence length from provider
+    if megatron_config is not None and hasattr(megatron_config, "max_vision_cuda_graph_seq_length"):
+        config.max_vision_cuda_graph_seq_length = megatron_config.max_vision_cuda_graph_seq_length
     return config

--- a/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/vision_model.py
+++ b/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/vision_model.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections.abc import Callable
 from typing import Optional
 
 import torch
@@ -31,6 +32,81 @@ from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.utils import (
     Qwen3VLVisionPatchMerger,
     Qwen3VLVisionRotaryEmbedding,
 )
+
+
+def _maybe_pad_vision_sequence_for_cuda_graph(
+    hidden_states: torch.Tensor,
+    rotary_pos_emb: torch.Tensor,
+    seq_len: int,
+    max_seq_len: int,
+) -> tuple[torch.Tensor, torch.Tensor, int]:
+    """Pad vision token tensors to ``max_seq_len`` for fixed-shape CUDA graphs.
+
+    Args:
+        hidden_states: ``[seq_len, hidden_size]``.
+        rotary_pos_emb: ``[seq_len, 1, 1, dim]`` (same layout as after ``reshape``/``repeat`` in :meth:`Qwen3VLVisionModel.forward`).
+        seq_len: Current sequence length (must match tensor leading size).
+        max_seq_len: Target length for CUDA graph capture.
+
+    Returns:
+        Tuple of (padded hidden_states, padded rotary_pos_emb, new seq_len).
+
+    Raises:
+        ValueError: If ``seq_len`` exceeds ``max_seq_len``.
+    """
+    if seq_len > max_seq_len:
+        raise ValueError(
+            f"Vision input sequence length ({seq_len}) exceeds max_vision_cuda_graph_seq_length ({max_seq_len}). "
+            f"Increase max_vision_cuda_graph_seq_length in config or disable vision CUDA graphs."
+        )
+    if seq_len < max_seq_len:
+        pad_len = max_seq_len - seq_len
+        hidden_states = F.pad(hidden_states, (0, 0, 0, pad_len), value=0.0)
+        rotary_pos_emb = F.pad(rotary_pos_emb, (0, 0, 0, 0, 0, 0, 0, pad_len), value=0.0)
+        seq_len = max_seq_len
+    return hidden_states, rotary_pos_emb, seq_len
+
+
+def _vision_forward_packed_attention_setup(
+    use_cuda_graph_padding: bool,
+    hidden_states: torch.Tensor,
+    original_seq_len: int,
+    seq_len: int,
+    grid_thw: torch.Tensor,
+    build_packed_seq_params: Callable[[torch.Tensor], PackedSeqParams],
+) -> tuple[Optional[PackedSeqParams], Optional[torch.Tensor]]:
+    """Return ``(packed_seq_params, attention_mask)`` for vision encoder forward.
+
+    When using CUDA graphs, packed sequence metadata (non-tensors) cannot be passed; use full
+    attention on a fixed-length padded sequence and optionally an additive mask to ignore padding.
+
+    Args:
+        use_cuda_graph_padding: Whether vision CUDA graph padding path is active.
+        hidden_states: Vision hidden states after adding the batch dimension, shape ``[S, 1, H]``.
+        original_seq_len: Sequence length before padding.
+        seq_len: Sequence length after optional padding (equals ``hidden_states`` leading size).
+        grid_thw: Grid sizes per image/frame (used only when not using CUDA graph padding).
+        build_packed_seq_params: Callback to build :class:`PackedSeqParams` from ``grid_thw``.
+
+    Returns:
+        ``packed_seq_params`` (``None`` when using CUDA graph padding) and ``attention_mask``
+        (additive mask for padded CUDA graph runs, else ``None``).
+    """
+    if use_cuda_graph_padding:
+        packed_seq_params = None
+        if original_seq_len < seq_len:
+            attention_mask = torch.ones(
+                (1, 1, seq_len, seq_len), dtype=hidden_states.dtype, device=hidden_states.device
+            )
+            attention_mask[:, :, :, original_seq_len:] = 0
+            attention_mask[:, :, original_seq_len:, :] = 0
+            attention_mask = (1.0 - attention_mask) * torch.finfo(hidden_states.dtype).min
+        else:
+            attention_mask = None
+        return packed_seq_params, attention_mask
+
+    packed_seq_params = build_packed_seq_params(grid_thw)
+    return packed_seq_params, None
 
 
 class Qwen3VLVisionModel(VisionModule):
@@ -210,6 +286,21 @@ class Qwen3VLVisionModel(VisionModule):
         patch_pos_embeds = torch.cat(patch_pos_embeds_permute)
         return patch_pos_embeds
 
+    def _get_max_vision_seq_length(self) -> int:
+        """Get the maximum sequence length for vision encoder CUDA graphs."""
+        if hasattr(self.config, "max_vision_cuda_graph_seq_length") and self.config.max_vision_cuda_graph_seq_length:
+            return self.config.max_vision_cuda_graph_seq_length
+        # Default: calculate from num_position_embeddings
+        return self.config.num_position_embeddings // (self.config.spatial_merge_size**2)
+
+    def _uses_vision_cuda_graph(self) -> bool:
+        """Check if vision encoder CUDA graphs are enabled."""
+        return (
+            hasattr(self.config, "cuda_graph_impl")
+            and self.config.cuda_graph_impl == "transformer_engine"
+            and self.training
+        )
+
     def forward(
         self,
         hidden_states: Optional[torch.Tensor],
@@ -241,17 +332,39 @@ class Qwen3VLVisionModel(VisionModule):
 
         rotary_pos_emb = self.rot_pos_emb(grid_thw)
         rotary_pos_emb = rotary_pos_emb.reshape(seq_len, 1, 1, -1).repeat(1, 1, 1, 2)
-        hidden_states = hidden_states[:, None]
 
+        # Check if we need to pad for CUDA graphs
+        use_cuda_graph_padding = self._uses_vision_cuda_graph()
+        original_seq_len = seq_len
+        if use_cuda_graph_padding:
+            max_seq_len = self._get_max_vision_seq_length()
+            hidden_states, rotary_pos_emb, seq_len = _maybe_pad_vision_sequence_for_cuda_graph(
+                hidden_states, rotary_pos_emb, seq_len, max_seq_len
+            )
+        hidden_states = hidden_states[:, None]
+        packed_seq_params, attention_mask = _vision_forward_packed_attention_setup(
+            use_cuda_graph_padding=use_cuda_graph_padding,
+            hidden_states=hidden_states,
+            original_seq_len=original_seq_len,
+            seq_len=seq_len,
+            grid_thw=grid_thw,
+            build_packed_seq_params=self.build_packed_seq_params,
+        )
         hidden_states, deepstack_feature_lists = self.decoder(
             hidden_states=hidden_states,
-            attention_mask=None,
+            attention_mask=attention_mask,
             inference_params=inference_params,
             rotary_pos_emb=rotary_pos_emb,
-            packed_seq_params=self.build_packed_seq_params(grid_thw),
+            packed_seq_params=packed_seq_params,
             **(extra_block_kwargs or {}),
         )
-
+        # Remove padding if we added it
+        if use_cuda_graph_padding and original_seq_len < seq_len:
+            hidden_states = hidden_states[:original_seq_len]
+            # Unpad deepstack features - they go through a merger that reduces by spatial_merge_size^2
+            # So their length is seq_len // (spatial_merge_size^2)
+            original_merged_seq_len = original_seq_len // (self.spatial_merge_size**2)
+            deepstack_feature_lists = [feat[:original_merged_seq_len] for feat in deepstack_feature_lists]
         hidden_states = self.merger(hidden_states)
 
         # Encodes images into continuous embeddings that can be forwarded to the language model.

--- a/src/megatron/bridge/models/qwen_vl/qwen3_vl_provider.py
+++ b/src/megatron/bridge/models/qwen_vl/qwen3_vl_provider.py
@@ -125,6 +125,15 @@ class Qwen3VLModelProvider(GPTModelProvider):
     add_encoder: bool = True
     add_decoder: bool = True
 
+    # Vision encoder CUDA graph settings
+    # Set to "transformer_engine" to enable TE CUDA graph for vision encoder
+    vision_cuda_graph_impl: str = "none"
+    # CUDA graph scope for vision encoder (e.g., ["attn"] for attention only)
+    vision_cuda_graph_scope: List[str] = field(default_factory=list)
+    # Maximum sequence length for vision encoder CUDA graphs (must accommodate largest input)
+    # If None, calculated from num_position_embeddings / spatial_merge_size^2
+    max_vision_cuda_graph_seq_length: Optional[int] = None
+
     def provide(self, pre_process=None, post_process=None, vp_stage=None) -> Qwen3VLModel:
         """Provide a Qwen3 VL model instance with vision and language components."""
         language_transformer_config = self
@@ -276,6 +285,14 @@ class Qwen3VLMoEModelProvider(GPTModelProvider):
     dist_train: DistTrainConfig = field(default_factory=DistTrainConfig)
     add_encoder: bool = True
     add_decoder: bool = True
+
+    # Vision encoder CUDA graph settings
+    # Set to "transformer_engine" to enable TE CUDA graph for vision encoder
+    vision_cuda_graph_impl: str = "none"
+    # CUDA graph scope for vision encoder (e.g., ["attn"] for attention only)
+    vision_cuda_graph_scope: List[str] = field(default_factory=list)
+    # Maximum sequence length for vision encoder CUDA graphs (must accommodate largest input)
+    max_vision_cuda_graph_seq_length: Optional[int] = None
 
     def finalize(self) -> None:
         if self.tensor_model_parallel_size > 1:

--- a/src/megatron/bridge/training/train.py
+++ b/src/megatron/bridge/training/train.py
@@ -48,9 +48,17 @@ from megatron.core.pipeline_parallel.utils import (
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.rerun_state_machine import RerunDataIterator, get_rerun_state_machine
 from megatron.core.transformer import MegatronModule
-from megatron.core.transformer.cuda_graphs import TECudaGraphHelper
+from megatron.core.transformer.cuda_graphs import (
+    TECudaGraphHelper,
+    VisionTECudaGraphHelper,
+    get_vision_cuda_graph_seq_length,
+)
 from megatron.core.transformer.enums import CudaGraphScope
-from megatron.core.utils import check_param_hashes_across_dp_replicas, get_model_config
+from megatron.core.utils import (
+    check_param_hashes_across_dp_replicas,
+    get_attr_wrapped_model,
+    get_model_config,
+)
 from modelopt.torch.distill.plugins.megatron import get_tensor_shapes_adjust_fn_for_distillation
 
 from megatron.bridge.data.iterator_utils import make_data_iterator_list
@@ -244,7 +252,27 @@ def train(
             micro_batch_size=config.train.micro_batch_size,
             optimizers=[optimizer],
         )
-
+    # Capture Vision Encoder CUDA Graphs (separate from language model).
+    # Check if vision encoder has CUDA graph enabled
+    vision_cuda_graph_helper = None
+    vision_config = getattr(config.model, "vision_cuda_graph_impl", None)
+    if vision_config == "transformer_engine":
+        # Try to get vision config from the model
+        for model_chunk in model:
+            unwrapped = get_attr_wrapped_model(model_chunk, "vision_model", allow_none=True, return_model_obj=True)
+            if unwrapped is not None and hasattr(unwrapped, "vision_model") and unwrapped.vision_model is not None:
+                vision_model_config = unwrapped.vision_model.config
+                if vision_model_config.cuda_graph_impl == "transformer_engine":
+                    vision_seq_length = get_vision_cuda_graph_seq_length(vision_model_config)
+                    vision_cuda_graph_helper = VisionTECudaGraphHelper(
+                        model=model,
+                        vision_config=vision_model_config,
+                        vision_seq_length=vision_seq_length,
+                        micro_batch_size=config.train.micro_batch_size,
+                        num_microbatches=get_num_microbatches(),  # pg_collection=pg_collection,
+                    )
+                    print_rank_0(f"Vision encoder CUDA graph enabled with seq_length={vision_seq_length}")
+                break
     # Track train step elapsed time for throughput logging
     history_wct = None
     if config.logger.log_throughput_to_tensorboard:
@@ -358,6 +386,14 @@ def train(
             if model_config.cuda_graph_warmup_steps > 0 and should_toggle_forward_pre_hook:
                 enable_forward_pre_hook(model)
                 cuda_graph_helper.cuda_graph_set_manual_hooks()
+        # Capture Vision Encoder CUDA Graphs after warmup (separate from language model).
+        if (
+            vision_cuda_graph_helper is not None
+            and not vision_cuda_graph_helper.graphs_created()
+            and global_state.train_state.step - start_iteration == model_config.cuda_graph_warmup_steps
+        ):
+            vision_cuda_graph_helper.create_cudagraphs()
+            vision_cuda_graph_helper.cuda_graph_set_manual_hooks()
 
         # Run training step.
         fault_tolerance.on_training_step_start(global_state)
@@ -457,7 +493,13 @@ def train(
                     ):
                         assert cuda_graph_helper.graphs_created(), "CUDA Graphs should have been created."
                         cuda_graph_helper.cuda_graph_set_manual_hooks()
-
+                    # Also set manual hooks for vision encoder CUDA graphs if enabled
+                    if (
+                        vision_cuda_graph_helper is not None
+                        and model_config.cuda_graph_warmup_steps == 0
+                        and vision_cuda_graph_helper.graphs_created()
+                    ):
+                        vision_cuda_graph_helper.cuda_graph_set_manual_hooks()
         global_state.train_state.step += 1
 
         # If fsdp_manual_registration is enabled, manually register FSDP communication buffers after one training step.

--- a/tests/unit_tests/models/qwen_vl/modelling_qwen3_vl/test_model.py
+++ b/tests/unit_tests/models/qwen_vl/modelling_qwen3_vl/test_model.py
@@ -21,6 +21,7 @@ Or for single GPU: uv run pytest tests/unit_tests/models/qwen_vl/modelling_qwen3
 
 import datetime
 import os
+from dataclasses import replace
 
 import numpy as np
 import pytest
@@ -566,3 +567,63 @@ class TestQwen3VLModel:
 
         assert isinstance(out, torch.Tensor)
         assert out.dim() >= 2
+
+    @pytest.mark.timeout(50)
+    def test_cuda_graph_helper_not_exposed_when_llm_cuda_graph_disabled(self, hf_config):
+        """CUDA graph helper fields stay on language_model when cuda_graph_impl is none."""
+        self._setup_parallel_state(tp_size=1, ep_size=1, pp_size=1)
+        pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+
+        language_transformer_config = replace(
+            self.get_language_transformer_config(hf_config),
+            cuda_graph_impl="none",
+        )
+        assert getattr(language_transformer_config, "cuda_graph_impl", None) == "none"
+
+        model = Qwen3VLModel(
+            vision_transformer_config=self.get_vision_transformer_config(hf_config),
+            language_transformer_config=language_transformer_config,
+            language_transformer_layer_spec=self.get_language_model_layer_spec(),
+            parallel_output=True,
+            pre_process=True,
+            post_process=True,
+            add_encoder=True,
+            add_decoder=True,
+            pg_collection=pg_collection,
+        )
+
+        assert "decoder" not in model.__dict__
+        assert not hasattr(model, "rotary_pos_emb")
+        assert getattr(model.language_model.config, "cuda_graph_impl", None) == "none"
+
+    @pytest.mark.timeout(50)
+    def test_cuda_graph_helper_exposed_when_llm_cuda_graph_enabled(self, hf_config):
+        """Root VLM mirrors LM decoder / RoPE for CUDA graph helper when cuda_graph_impl is enabled."""
+        self._setup_parallel_state(tp_size=1, ep_size=1, pp_size=1)
+        pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+
+        language_transformer_config = replace(
+            self.get_language_transformer_config(hf_config),
+            cuda_graph_impl="transformer_engine",
+            variable_seq_lengths=False,
+            use_te_rng_tracker=True,
+        )
+
+        model = Qwen3VLModel(
+            vision_transformer_config=self.get_vision_transformer_config(hf_config),
+            language_transformer_config=language_transformer_config,
+            language_transformer_layer_spec=self.get_language_model_layer_spec(),
+            parallel_output=True,
+            pre_process=True,
+            post_process=True,
+            add_encoder=True,
+            add_decoder=True,
+            pg_collection=pg_collection,
+        )
+
+        assert getattr(language_transformer_config, "cuda_graph_impl", None) == "transformer_engine"
+        assert model.language_model.config.variable_seq_lengths is False
+        assert hasattr(model, "decoder")
+        assert model.decoder is model.language_model.decoder
+        assert model.rotary_pos_emb is model.language_model.rotary_pos_emb
+        assert model.position_embedding_type == model.language_model.position_embedding_type

--- a/tests/unit_tests/models/qwen_vl/modelling_qwen3_vl/test_qwen3_vl_transformer_config.py
+++ b/tests/unit_tests/models/qwen_vl/modelling_qwen3_vl/test_qwen3_vl_transformer_config.py
@@ -1,0 +1,133 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for Qwen3-VL vision transformer_config (get_vision_model_config)."""
+
+from types import SimpleNamespace
+
+import pytest
+from megatron.core.transformer.cuda_graphs import CudaGraphScope
+
+from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.transformer_config import get_vision_model_config
+
+
+def _hf_config():
+    return SimpleNamespace(
+        depth=2,
+        hidden_size=64,
+        num_heads=4,
+        intermediate_size=128,
+        patch_size=16,
+        temporal_patch_size=2,
+        in_channels=3,
+        spatial_merge_size=2,
+        num_position_embeddings=256,
+        out_hidden_size=64,
+        deepstack_visual_indexes=[1],
+    )
+
+
+def _megatron_base(**overrides):
+    """Minimal megatron_config for get_vision_model_config (shared fields + overrides)."""
+    base = dict(
+        recompute_granularity=None,
+        recompute_method=None,
+        recompute_num_layers=None,
+        tensor_model_parallel_size=1,
+        enable_cuda_graph=False,
+        cuda_graph_use_single_mempool=False,
+        cuda_graph_retain_backward_graph=False,
+        cuda_graph_warmup_steps=0,
+        external_cuda_graph=False,
+        cuda_graph_impl="none",
+        cuda_graph_scope=[],
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+class TestGetVisionModelConfigVisionCudaGraph:
+    """Vision encoder CUDA graph propagation from megatron_config (provider)."""
+
+    def test_vision_cuda_graph_defaults_when_impl_none(self):
+        megatron = _megatron_base(
+            vision_cuda_graph_impl="none",
+            cuda_graph_impl="local_transformer_engine",
+            cuda_graph_scope=[CudaGraphScope.attn],
+        )
+        cfg = get_vision_model_config(_hf_config(), megatron)
+        assert cfg.cuda_graph_impl == "none"
+        assert cfg.cuda_graph_scope == []
+
+    def test_vision_cuda_graph_defaults_when_attr_missing(self):
+        megatron = _megatron_base(
+            cuda_graph_impl="local_transformer_engine",
+            cuda_graph_scope=[CudaGraphScope.attn],
+        )
+        cfg = get_vision_model_config(_hf_config(), megatron)
+        assert cfg.cuda_graph_impl == "none"
+        assert cfg.cuda_graph_scope == []
+
+    def test_vision_cuda_graph_impl_propagated_scope_empty_without_scope_attr(self):
+        megatron = _megatron_base(vision_cuda_graph_impl="local_transformer_engine")
+        cfg = get_vision_model_config(_hf_config(), megatron)
+        assert cfg.cuda_graph_impl == "local_transformer_engine"
+        assert cfg.cuda_graph_scope == []
+
+    def test_vision_cuda_graph_scope_string_list_converted_to_enum(self):
+        megatron = _megatron_base(
+            vision_cuda_graph_impl="local_transformer_engine",
+            vision_cuda_graph_scope=["attn", "mlp"],
+        )
+        cfg = get_vision_model_config(_hf_config(), megatron)
+        assert cfg.cuda_graph_impl == "local_transformer_engine"
+        assert cfg.cuda_graph_scope == [CudaGraphScope.attn, CudaGraphScope.mlp]
+
+    def test_vision_cuda_graph_scope_enum_list_passed_through(self):
+        scopes = [CudaGraphScope.attn]
+        megatron = _megatron_base(
+            vision_cuda_graph_impl="local_transformer_engine",
+            vision_cuda_graph_scope=scopes,
+        )
+        cfg = get_vision_model_config(_hf_config(), megatron)
+        assert cfg.cuda_graph_scope is scopes
+
+    def test_vision_cuda_graph_scope_empty_list_clears_scope(self):
+        megatron = _megatron_base(
+            vision_cuda_graph_impl="local_transformer_engine",
+            vision_cuda_graph_scope=[],
+        )
+        cfg = get_vision_model_config(_hf_config(), megatron)
+        assert cfg.cuda_graph_scope == []
+
+    def test_max_vision_cuda_graph_seq_length_propagated(self):
+        megatron = _megatron_base(
+            vision_cuda_graph_impl="none",
+            max_vision_cuda_graph_seq_length=4096,
+        )
+        cfg = get_vision_model_config(_hf_config(), megatron)
+        assert cfg.max_vision_cuda_graph_seq_length == 4096
+
+    def test_max_vision_cuda_graph_seq_length_unchanged_when_attr_missing(self):
+        megatron = _megatron_base(vision_cuda_graph_impl="none")
+        cfg = get_vision_model_config(_hf_config(), megatron)
+        assert cfg.max_vision_cuda_graph_seq_length is None
+
+    def test_invalid_scope_string_raises_keyerror(self):
+        megatron = _megatron_base(
+            vision_cuda_graph_impl="local_transformer_engine",
+            vision_cuda_graph_scope=["not_a_valid_cuda_graph_scope_member"],
+        )
+        with pytest.raises(KeyError):
+            get_vision_model_config(_hf_config(), megatron)

--- a/tests/unit_tests/models/qwen_vl/modelling_qwen3_vl/test_vision_model.py
+++ b/tests/unit_tests/models/qwen_vl/modelling_qwen3_vl/test_vision_model.py
@@ -1,0 +1,203 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for Qwen3-VL vision model (CUDA graph sequence padding and helpers)."""
+
+import pytest
+import torch
+import torch.nn as nn
+
+from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.transformer_config import Qwen3VLTransformerConfig
+from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.vision_model import (
+    Qwen3VLVisionModel,
+    _maybe_pad_vision_sequence_for_cuda_graph,
+    _vision_forward_packed_attention_setup,
+)
+
+
+def _minimal_vision_config(**kwargs):
+    base = dict(
+        num_layers=1,
+        hidden_size=64,
+        num_attention_heads=4,
+        num_query_groups=4,
+        kv_channels=16,
+        ffn_hidden_size=128,
+        vocab_size=100,
+        language_max_sequence_length=128,
+        num_position_embeddings=64,
+        spatial_merge_size=2,
+        patch_size=16,
+        out_hidden_size=64,
+    )
+    base.update(kwargs)
+    return Qwen3VLTransformerConfig(**base)
+
+
+def _vision_model_shell(config: Qwen3VLTransformerConfig) -> Qwen3VLVisionModel:
+    """Build a :class:`Qwen3VLVisionModel` instance without running ``__init__`` (for helper tests)."""
+    m = Qwen3VLVisionModel.__new__(Qwen3VLVisionModel)
+    nn.Module.__init__(m)
+    m.config = config
+    return m
+
+
+class TestMaybePadVisionSequenceForCudaGraph:
+    """Tests for ``_maybe_pad_vision_sequence_for_cuda_graph`` (vision CUDA graph fixed length)."""
+
+    def test_no_pad_when_seq_equals_max(self):
+        seq_len, hidden, rot_d = 8, 32, 16
+        hidden_states = torch.randn(seq_len, hidden)
+        rotary_pos_emb = torch.randn(seq_len, 1, 1, rot_d)
+        out_h, out_r, out_len = _maybe_pad_vision_sequence_for_cuda_graph(
+            hidden_states, rotary_pos_emb, seq_len, max_seq_len=8
+        )
+        assert out_len == 8
+        assert out_h.shape == (8, hidden)
+        assert out_r.shape == (8, 1, 1, rot_d)
+        assert torch.equal(out_h, hidden_states)
+        assert torch.equal(out_r, rotary_pos_emb)
+
+    def test_pad_to_max_appends_zeros(self):
+        seq_len, max_seq_len, hidden, rot_d = 3, 8, 4, 6
+        hidden_states = torch.arange(seq_len * hidden, dtype=torch.float32).reshape(seq_len, hidden)
+        rotary_pos_emb = torch.ones(seq_len, 1, 1, rot_d)
+        out_h, out_r, out_len = _maybe_pad_vision_sequence_for_cuda_graph(
+            hidden_states, rotary_pos_emb, seq_len, max_seq_len=max_seq_len
+        )
+        assert out_len == max_seq_len
+        assert out_h.shape == (max_seq_len, hidden)
+        assert out_r.shape == (max_seq_len, 1, 1, rot_d)
+        assert torch.equal(out_h[:seq_len], hidden_states)
+        assert torch.equal(out_h[seq_len:], torch.zeros(max_seq_len - seq_len, hidden))
+        assert torch.equal(out_r[:seq_len], rotary_pos_emb)
+        assert torch.equal(out_r[seq_len:], torch.zeros(max_seq_len - seq_len, 1, 1, rot_d))
+
+    def test_raises_when_seq_exceeds_max(self):
+        seq_len, max_seq_len = 10, 4
+        hidden_states = torch.randn(seq_len, 8)
+        rotary_pos_emb = torch.randn(seq_len, 1, 1, 4)
+        with pytest.raises(ValueError, match="exceeds max_vision_cuda_graph_seq_length"):
+            _maybe_pad_vision_sequence_for_cuda_graph(hidden_states, rotary_pos_emb, seq_len, max_seq_len)
+
+
+class TestVisionForwardPackedAttentionSetup:
+    """Tests for ``_vision_forward_packed_attention_setup``."""
+
+    def test_non_cuda_graph_path_calls_builder_and_no_mask(self):
+        grid = torch.tensor([[1, 4, 4]], dtype=torch.long)
+        hidden = torch.zeros(5, 1, 8, dtype=torch.float32)
+        sentinel = object()
+
+        def _builder(_g):
+            assert torch.equal(_g, grid)
+            return sentinel
+
+        packed, mask = _vision_forward_packed_attention_setup(
+            use_cuda_graph_padding=False,
+            hidden_states=hidden,
+            original_seq_len=5,
+            seq_len=5,
+            grid_thw=grid,
+            build_packed_seq_params=_builder,
+        )
+        assert packed is sentinel
+        assert mask is None
+
+    def test_cuda_graph_no_padding_no_mask(self):
+        grid = torch.tensor([[1, 2, 2]], dtype=torch.long)
+        hidden = torch.randn(8, 1, 16, dtype=torch.float32)
+        packed, mask = _vision_forward_packed_attention_setup(
+            use_cuda_graph_padding=True,
+            hidden_states=hidden,
+            original_seq_len=8,
+            seq_len=8,
+            grid_thw=grid,
+            build_packed_seq_params=lambda _: pytest.fail("should not call build_packed_seq_params"),
+        )
+        assert packed is None
+        assert mask is None
+
+    def test_cuda_graph_with_padding_additive_mask(self):
+        original_seq_len, seq_len, hidden = 2, 5, 4
+        hidden_states = torch.randn(seq_len, 1, hidden, dtype=torch.float32)
+        grid = torch.tensor([[1, 2, 2]], dtype=torch.long)
+
+        packed, mask = _vision_forward_packed_attention_setup(
+            use_cuda_graph_padding=True,
+            hidden_states=hidden_states,
+            original_seq_len=original_seq_len,
+            seq_len=seq_len,
+            grid_thw=grid,
+            build_packed_seq_params=lambda _: pytest.fail("should not call build_packed_seq_params"),
+        )
+        assert packed is None
+        assert mask is not None
+        assert mask.shape == (1, 1, seq_len, seq_len)
+        assert mask.dtype == hidden_states.dtype
+        assert mask.device == hidden_states.device
+
+        min_val = torch.finfo(hidden_states.dtype).min
+        # Real token block: no additive masking
+        assert torch.all(mask[:, :, :original_seq_len, :original_seq_len] == 0)
+        # Padding keys: columns >= original_seq_len
+        assert torch.all(mask[:, :, :original_seq_len, original_seq_len:] == min_val)
+        # Padding queries: rows >= original_seq_len
+        assert torch.all(mask[:, :, original_seq_len:, :] == min_val)
+
+
+class TestQwen3VLVisionModelCudaGraphHelpers:
+    """Tests for ``_get_max_vision_seq_length`` and ``_uses_vision_cuda_graph``."""
+
+    def test_get_max_vision_seq_length_uses_config_override(self):
+        cfg = _minimal_vision_config(max_vision_cuda_graph_seq_length=512)
+        m = _vision_model_shell(cfg)
+        assert m._get_max_vision_seq_length() == 512
+
+    def test_get_max_vision_seq_length_default_from_num_position_embeddings(self):
+        cfg = _minimal_vision_config(
+            num_position_embeddings=64,
+            spatial_merge_size=2,
+            max_vision_cuda_graph_seq_length=None,
+        )
+        m = _vision_model_shell(cfg)
+        assert m._get_max_vision_seq_length() == 64 // (2**2)
+
+    def test_get_max_vision_seq_length_zero_override_falls_back_to_default(self):
+        """``0`` is falsy in ``if max_vision_cuda_graph_seq_length``; use derived default."""
+        cfg = _minimal_vision_config(
+            num_position_embeddings=64,
+            spatial_merge_size=2,
+            max_vision_cuda_graph_seq_length=0,
+        )
+        m = _vision_model_shell(cfg)
+        assert m._get_max_vision_seq_length() == 16
+
+    def test_uses_vision_cuda_graph_true_in_training_with_te_impl(self):
+        cfg = _minimal_vision_config(cuda_graph_impl="transformer_engine")
+        m = _vision_model_shell(cfg)
+        m.train()
+        assert m._uses_vision_cuda_graph() is True
+
+    def test_uses_vision_cuda_graph_false_in_eval(self):
+        cfg = _minimal_vision_config(cuda_graph_impl="transformer_engine")
+        m = _vision_model_shell(cfg)
+        m.eval()
+        assert m._uses_vision_cuda_graph() is False
+
+    def test_uses_vision_cuda_graph_false_when_impl_not_te(self):
+        cfg = _minimal_vision_config(cuda_graph_impl="none")
+        m = _vision_model_shell(cfg)
+        m.train()
+        assert m._uses_vision_cuda_graph() is False


### PR DESCRIPTION
# What does this PR do ?

This PR adds CUDA Graph support for vision encoder. 
Previous PR: https://github.com/NVIDIA-NeMo/Megatron-Bridge/pull/2274 was deprecated.

Related Mcore PR:https://github.com/NVIDIA/Megatron-LM/pull/3293, https://github.com/NVIDIA/Megatron-LM/pull/3294
Related TE PR:https://github.com/NVIDIA/TransformerEngine/pull/2657

Example run command:

```
uv run python -m torch.distributed.run --nproc_per_node=8 ${MEGATRON_BRIDGE_PATH}/scripts/training/run_recipe.py \
  --recipe qwen3_vl_8b_pretrain_mock_config \
  --step_func qwen3_vl_step \
  dataset.seq_length=8192 \
  dataset.num_images=1 \
  dataset.image_size=[768,768] \
  dataset.dataloader_type="cyclic" \
  optimizer.clip_grad=0 \
  model.seq_length=8192 \
  model.num_layers=8 \
  model.freeze_language_model=False \
  model.freeze_vision_model=False \
  model.freeze_vision_projection=False \
  model.pipeline_model_parallel_size=2 \
  model.tensor_model_parallel_size=1 \
  model.expert_model_parallel_size=1 \
  model.cuda_graph_impl="transformer_engine" \
  model.cuda_graph_scope=[attn,mlp] \
  model.vision_cuda_graph_impl=transformer_engine \
  model.vision_cuda_graph_scope=[attn,mlp] \
  model.max_vision_cuda_graph_seq_length=4608 \
  model.use_te_rng_tracker=True \
  model.apply_rope_fusion=False \
  train.micro_batch_size=2 \
  train.global_batch_size=32 \
  train.train_iters=20 \
  train.eval_iters=0 \
  train.manual_gc=true \
  train.manual_gc_interval=100 \
```

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added vision encoder CUDA graph support for improved training performance.
  * Added configurable vision CUDA graph settings including implementation scope and maximum sequence length limits.

* **Improvements**
  * Enhanced vision model with automatic sequence padding for CUDA graph compatibility.

* **Updates**
  * Updated Megatron-LM submodule to latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->