### PR TITLE
Revert Qwen3 235B GB300 MXFP8 large scale mapping

### DIFF
--- a/scripts/performance/configs/qwen/qwen3_workload_base_configs.py
+++ b/scripts/performance/configs/qwen/qwen3_workload_base_configs.py
@@ -277,6 +277,9 @@ QWEN3_235B_A22B_PRETRAIN_CONFIG_H100_FP8_CS_V2 = replace(
 
 QWEN3_235B_A22B_PRETRAIN_CONFIG_GB300_FP8_MX_LARGE_SCALE = replace(
     QWEN3_235B_A22B_PRETRAIN_CONFIG_GB300_FP8_MX_V2,
+    virtual_pipeline_model_parallel_size=12,
+    expert_model_parallel_size=16,
+    cuda_graph_scope=["moe_router", "moe_preprocess"],
     global_batch_size=512,
 )
 


### PR DESCRIPTION
# What does this PR do ?

Revert mapping for perf regression.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new large-scale configuration variant with optimized parallelism layout and enhanced CUDA graph scoping for performance workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->