### PR TITLE
Move toggle after the callback as the callback could see an optimizer

### DIFF
--- a/src/megatron/bridge/training/train.py
+++ b/src/megatron/bridge/training/train.py
@@ -271,9 +271,7 @@ def train(
                 scheduler=scheduler,
             ),
         )
-    is_any_logging_enabled = any(
-        [config.logger.tensorboard_dir, global_state.wandb_logger, global_state.mlflow_logger]
-    )
+    is_any_logging_enabled = config.logger is not None
     # Disable forward pre-hook to start training to ensure that errors in checkpoint loading
     # or random initialization don't propagate to all ranks in first all-gather (which is a
     # no-op if things work correctly).


### PR DESCRIPTION
Move toggle after the callback as the callback could see an optimizer as the callback could see an optimizer forward pre_hook disabled

If callback does a few iterations to warmup, this would fail. Hence, moving the disable forward pre-hook after the callback.

# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal code organization and timing logic during training initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->