### PR TITLE
qwen x86 flex backend

### DIFF
--- a/scripts/performance/configs/qwen/qwen3_workload_base_configs.py
+++ b/scripts/performance/configs/qwen/qwen3_workload_base_configs.py
@@ -31,6 +31,7 @@ from utils.utils import WorkloadBaseConfig
 
 BASE_QWEN3_235B_A22B_CONFIG = WorkloadBaseConfig(
     expert_tensor_parallel_size=1,
+    moe_flex_dispatcher_backend="deepep",
 )
 
 
@@ -38,6 +39,7 @@ BASE_QWEN3_30B_A3B_CONFIG = WorkloadBaseConfig(
     expert_model_parallel_size=8,
     expert_tensor_parallel_size=1,
     global_batch_size=512,
+    moe_flex_dispatcher_backend="deepep",
 )
 
 BASE_QWEN3_NEXT_80B_A3B_CONFIG = WorkloadBaseConfig(


### PR DESCRIPTION
# What does this PR do ?

Valid flex dispatcher backend for H100, B200, B300 for Qwen3 30B_a3B and 235B_a22B

- Before refactor- default was `deepep`
- After refactor- default is `None`

This PR changes back the default for specific systems to `deepep` in perf scripts.

# Changelog

```
moe_flex_dispatcher_backend="deepep",
```

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new dispatcher backend configuration for Qwen3 large language models, enabling enhanced inference optimization and improved model dispatch flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->