### PR TITLE
Cherry-pick PR 2315: fix broken doc links and skip flaky HF dataset tests

### DIFF
--- a/tests/functional_tests/data/builders/test_hf_dataset.py
+++ b/tests/functional_tests/data/builders/test_hf_dataset.py
@@ -65,6 +65,7 @@ def disable_hf_cache():
 
 
 class TestDataHFDataset:
+    @pytest.mark.skip(reason="Requires HF network access; hits 429 rate limit")
     def test_preprocess_and_split_data_split_val_from_train(self, ensure_test_data):
         path = f"{ensure_test_data}/datasets/hf"
         os.makedirs(path, exist_ok=True)
@@ -85,6 +86,7 @@ class TestDataHFDataset:
         assert os.path.exists(path / "validation.jsonl")
         assert os.path.exists(path / "test.jsonl")
 
+    @pytest.mark.skip(reason="Requires HF network access; hits 429 rate limit")
     def test_preprocess_and_split_data(self, ensure_test_data):
         path = f"{ensure_test_data}/datasets/hf"
         os.makedirs(path, exist_ok=True)
@@ -107,6 +109,7 @@ class TestDataHFDataset:
         assert os.path.exists(path / "validation.jsonl")
         assert os.path.exists(path / "test.jsonl")
 
+    @pytest.mark.skip(reason="Requires HF network access; hits 429 rate limit")
     def test_hf_dataset_builder(self, ensure_test_data):
         path = f"{ensure_test_data}/datasets/hf"
         os.makedirs(path, exist_ok=True)
@@ -142,6 +145,7 @@ class TestDataHFDataset:
         with pytest.raises(ValueError):
             builder.prepare_data()
 
+    @pytest.mark.skip(reason="Requires HF network access; hits 429 rate limit")
     def test_hf_dataset_builder_with_dict(self, ensure_test_data):
         path = f"{ensure_test_data}/datasets/hf"
         os.makedirs(path, exist_ok=True)


### PR DESCRIPTION
Cherry-picked PR #2315 from NVIDIA-NeMo/Megatron-Bridge to r0.3.0 branch.

Original PR: https://github.com/NVIDIA-NeMo/Megatron-Bridge/pull/2315

This PR fixes:
- Update broken doc links in parallelisms.md
- Skip flaky HF dataset tests that hit 429 rate limits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Skipped network-dependent tests that were causing rate limit failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->