### PR TITLE
Re-enable FSDP checkpoint test

### DIFF
--- a/tests/functional_tests/training/test_megatron_fsdp.py
+++ b/tests/functional_tests/training/test_megatron_fsdp.py
@@ -276,7 +276,6 @@ class TestMegatronFSDP:
         finally:
             clear_directories(tmp_path)
 
-    @pytest.mark.pleasefixme
     @pytest.mark.run_only_on("GPU")
     def test_fsdp_pretrain_with_checkpoint(self, tmp_path):
         """


### PR DESCRIPTION
# What does this PR do ?

Not able to reproduce this test with a recent RC. The issue might be fixed in 25.12. Trying to re-enable.
Will resolve #1866

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test decorators for training validation tests, removing temporary fix markers to reflect improved test stability status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->