### PR TITLE
[example, doc] fix: Fix RLHF script bugs and tutorial tokenization path

### DIFF
--- a/tutorials/training/reduced_precision_training.ipynb
+++ b/tutorials/training/reduced_precision_training.ipynb
@@ -119,7 +119,7 @@
     "# - train_text_document.bin (document/sequence data)\n",
     "# - train_text_document.idx (document/sequence metadata)\n",
     "\n",
-    "MEGATRON_LM_PATH=/opt/megatron-lm/\n",
+    "MEGATRON_LM_PATH=/opt/Megatron-Bridge/3rdparty/Megatron-LM/\n",
     "\n",
     "echo \"Tokenizing training data...\"\n",
     "python3 $MEGATRON_LM_PATH/tools/preprocess_data.py \\\n",


### PR DESCRIPTION
## Summary
This PR fixes two bugs in the RLHF example script and one path issue in the tutorial notebook.

## Changes

### Bug 1: Missing trust_remote_code field in Args dataclass
- Added `trust_remote_code: bool = False` to the Args dataclass
- Added `trust_remote_code=ns.trust_remote_code,` to Args constructor
- Fixes AttributeError when accessing args.trust_remote_code

### Bug 2: Missing pg_collection argument in get_model() call
- Added import: `from megatron.core.process_groups_config import ProcessGroupCollection`
- Added `pg_collection = ProcessGroupCollection.use_mpu_process_groups()` after initialize_megatron()
- Added `pg_collection=pg_collection,` to get_model() call
- Fixes TypeError: get_model() missing required keyword-only argument 'pg_collection'

### Bug 3: Incorrect path in tutorial notebook
- Changed `MEGATRON_LM_PATH=/opt/megatron-lm/` to `MEGATRON_LM_PATH=/opt/Megatron-Bridge/3rdparty/Megatron-LM/`
- Fixes FileNotFoundError when running tokenization cell in NeMo container

## Testing
- Fixed issues reported in the bug descriptions
- All changes follow existing code patterns and API requirements