### PR TITLE
[ckpt] fix: Log warning when HuggingFace Hub download fails silently

### DIFF
--- a/src/megatron/bridge/models/hf_pretrained/state.py
+++ b/src/megatron/bridge/models/hf_pretrained/state.py
@@ -14,6 +14,7 @@
 
 import fnmatch
 import json
+import logging
 import re
 from abc import ABC, abstractmethod
 from collections import defaultdict
@@ -33,6 +34,9 @@ from typing import (
 )
 
 import torch
+
+
+logger = logging.getLogger(__name__)
 
 
 class StateDict(Mapping[str, torch.Tensor]):
@@ -545,10 +549,11 @@ class SafeTensorsStateSource(StateSource):
                     ignore_patterns=["*.bin", "*.pt", "*.pth"],
                 )
             )
-        except (ImportError, HfHubHTTPError, ValueError):
-            # If huggingface_hub is not installed, or if it's not a
-            # valid model ID, we return the original path and let the
-            # subsequent logic handle the file not found error.
+        except (ImportError, HfHubHTTPError, ValueError) as e:
+            logger.warning(
+                f"Failed to download '{model_name_or_path}' from HuggingFace Hub: {e}. "
+                f"Falling back to treating it as a local path."
+            )
             return local_path
 
     def get_all_keys(self) -> List[str]:


### PR DESCRIPTION
## Summary
- When `snapshot_download` from HuggingFace Hub fails (auth, network, rate-limit, etc.), the exception is silently caught and the code falls back to treating the model ID as a local path. This results in a misleading `FileNotFoundError: No .safetensors files or index found in <model_id>`.
- Added a `logger.warning` to surface the actual download failure reason, making it much easier for users to diagnose the issue.

## Test plan
- [x] Pre-commit hooks pass (ruff, formatting, trailing whitespace)
- Manually verify that when `snapshot_download` raises (e.g. no network, bad auth), the warning message is printed before the `FileNotFoundError`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Implemented explicit warning messages when model downloads from HuggingFace Hub fail, improving visibility of download errors that previously fell back to local paths without notification.
- System maintains functionality by automatically switching to local path handling when download issues occur, enabling better transparency into model loading processes and error conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->