### PR TITLE
ci: Cleanup up remote triggering

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -24,12 +24,8 @@ on:
   # Allow MCore to trigger this workflow remotely for compatibility testing
   workflow_dispatch:
     inputs:
-      mcore_commit:
+      mcore_ref:
         description: "MCore commit SHA to test against"
-        required: false
-        type: string
-      mcore_branch:
-        description: "MCore branch name (for reference)"
         required: false
         type: string
       mcore_repo:
@@ -94,35 +90,18 @@ jobs:
           submodules: "recursive"
 
       - name: Update MCore submodule (if triggered from MCore)
-        if: ${{ github.event.inputs.mcore_commit != '' }}
+        if: ${{ github.event.inputs.mcore_ref != '' }}
         run: |
-          echo "🔄 Updating MCore submodule to commit: ${{ github.event.inputs.mcore_commit }}"
-          echo "📌 MCore branch: ${{ github.event.inputs.mcore_branch || 'unknown' }}"
+          echo "🔄 Updating MCore submodule to commit: ${{ github.event.inputs.mcore_ref }}"
           echo "📍 MCore repo: ${{ github.event.inputs.mcore_repo || 'https://github.com/NVIDIA/Megatron-LM.git' }}"
           echo "🎯 Triggered by: ${{ github.event.inputs.triggered_by }}"
 
           cd 3rdparty/Megatron-LM
-          git fetch ${{ github.event.inputs.mcore_repo || 'origin' }} ${{ github.event.inputs.mcore_commit }}
-          git checkout ${{ github.event.inputs.mcore_commit }}
-
-          # Verify the checkout was successful
-          ACTUAL_COMMIT=$(git rev-parse HEAD)
-          EXPECTED_COMMIT="${{ github.event.inputs.mcore_commit }}"
-
-          echo "✅ MCore submodule updated successfully"
-          echo "Expected: ${EXPECTED_COMMIT}"
-          echo "Actual:   ${ACTUAL_COMMIT}"
-
-          if [ "${ACTUAL_COMMIT}" != "${EXPECTED_COMMIT}" ]; then
-            echo "❌ ERROR: MCore commit mismatch!"
-            exit 1
-          fi
-
-          git log -1 --oneline
-          cd ../..
+          git fetch ${{ github.event.inputs.mcore_repo || 'origin' }} ${{ github.event.inputs.mcore_ref }}
+          git checkout ${{ github.event.inputs.mcore_ref }}
 
       - name: Set environment for MCore testing
-        if: ${{ github.event.inputs.mcore_commit != '' }}
+        if: ${{ github.event.inputs.mcore_ref != '' }}
         run: |
           echo "MCORE_TRIGGERED_TESTING=true" | tee -a "$GITHUB_ENV"
           echo "⚙️ MCore testing mode: skipping --locked flag because lockfile was generated with different MCore version"
@@ -164,20 +143,20 @@ jobs:
           submodules: recursive
 
       - name: Update MCore submodule (if triggered from MCore)
-        if: ${{ github.event.inputs.mcore_commit != '' }}
+        if: ${{ github.event.inputs.mcore_ref != '' }}
         run: |
-          echo "🔄 Updating MCore submodule to commit: ${{ github.event.inputs.mcore_commit }}"
+          echo "🔄 Updating MCore submodule to commit: ${{ github.event.inputs.mcore_ref }}"
           echo "📌 MCore branch: ${{ github.event.inputs.mcore_branch || 'unknown' }}"
           echo "📍 MCore repo: ${{ github.event.inputs.mcore_repo || 'https://github.com/NVIDIA/Megatron-LM.git' }}"
           echo "🎯 Triggered by: ${{ github.event.inputs.triggered_by }}"
 
           cd 3rdparty/Megatron-LM
-          git fetch ${{ github.event.inputs.mcore_repo || 'origin' }} ${{ github.event.inputs.mcore_commit }}
-          git checkout ${{ github.event.inputs.mcore_commit }}
+          git fetch ${{ github.event.inputs.mcore_repo || 'origin' }} ${{ github.event.inputs.mcore_ref }}
+          git checkout ${{ github.event.inputs.mcore_ref }}
 
           # Verify the checkout was successful
           ACTUAL_COMMIT=$(git rev-parse HEAD)
-          EXPECTED_COMMIT="${{ github.event.inputs.mcore_commit }}"
+          EXPECTED_COMMIT="${{ github.event.inputs.mcore_ref }}"
 
           echo "✅ MCore submodule updated successfully"
           echo "Expected: ${EXPECTED_COMMIT}"
@@ -195,7 +174,7 @@ jobs:
           echo "MCORE_COMMIT_SHA=${EXPECTED_COMMIT}" | tee -a "$GITHUB_ENV"
 
       - name: Set environment for MCore testing
-        if: ${{ github.event.inputs.mcore_commit != '' }}
+        if: ${{ github.event.inputs.mcore_ref != '' }}
         run: |
           echo "MCORE_TRIGGERED_TESTING=true" | tee -a "$GITHUB_ENV"
           echo "⚙️ MCore testing mode: skipping --locked flag because lockfile was generated with different MCore version"
@@ -284,32 +263,6 @@ jobs:
           secrets: |
             GH_TOKEN=${{ secrets.PAT }}
 
-      - name: Verify MCore commit in Docker image
-        if: ${{ github.event.inputs.mcore_commit != '' }}
-        run: |
-          echo "🔍 Verifying MCore commit inside Docker image..."
-          EXPECTED="${{ env.MCORE_COMMIT_SHA }}"
-
-          # Get last line first (the SHA), then trim whitespace
-          ACTUAL=$(docker run --rm ${{ env.container-registry }}/megatron-bridge:${{ github.sha }} \
-            cat /opt/Megatron-Bridge/.mcore_commit_sha 2>&1 | tail -1)
-          ACTUAL=$(echo "${ACTUAL}" | tr -d '\n\r ')
-
-          # Trim whitespace from expected value too
-          EXPECTED=$(echo "${EXPECTED}" | tr -d '\n\r ')
-
-          echo "Expected MCore commit: ${EXPECTED}"
-          echo "Actual MCore commit:   ${ACTUAL}"
-
-          if [ "${ACTUAL}" = "${EXPECTED}" ]; then
-            echo "✅ MCore commit verified in Docker image!"
-          else
-            echo "❌ ERROR: MCore commit mismatch in Docker image! The build did not use the correct MCore version."
-            echo "Expected length: ${#EXPECTED}"
-            echo "Actual length:   ${#ACTUAL}"
-            exit 1
-          fi
-
   cicd-unit-tests:
     if: |
       (
@@ -333,15 +286,15 @@ jobs:
           submodules: recursive
 
       - name: Update MCore submodule (if triggered from MCore)
-        if: ${{ github.event.inputs.mcore_commit != '' }}
+        if: ${{ github.event.inputs.mcore_ref != '' }}
         run: |
           echo "🔄 Updating MCore submodule for unit tests..."
           cd 3rdparty/Megatron-LM
-          git fetch ${{ github.event.inputs.mcore_repo || 'origin' }} ${{ github.event.inputs.mcore_commit }}
-          git checkout ${{ github.event.inputs.mcore_commit }}
+          git fetch ${{ github.event.inputs.mcore_repo || 'origin' }} ${{ github.event.inputs.mcore_ref }}
+          git checkout ${{ github.event.inputs.mcore_ref }}
 
           ACTUAL_COMMIT=$(git rev-parse HEAD)
-          EXPECTED_COMMIT="${{ github.event.inputs.mcore_commit }}"
+          EXPECTED_COMMIT="${{ github.event.inputs.mcore_ref }}"
 
           echo "🧪 UNIT TESTS - MCore verification:"
           echo "Expected: ${EXPECTED_COMMIT}"
@@ -431,15 +384,15 @@ jobs:
           submodules: recursive
 
       - name: Update MCore submodule (if triggered from MCore)
-        if: ${{ github.event.inputs.mcore_commit != '' }}
+        if: ${{ github.event.inputs.mcore_ref != '' }}
         run: |
           echo "🔄 Updating MCore submodule for functional tests..."
           cd 3rdparty/Megatron-LM
-          git fetch ${{ github.event.inputs.mcore_repo || 'origin' }} ${{ github.event.inputs.mcore_commit }}
-          git checkout ${{ github.event.inputs.mcore_commit }}
+          git fetch ${{ github.event.inputs.mcore_repo || 'origin' }} ${{ github.event.inputs.mcore_ref }}
+          git checkout ${{ github.event.inputs.mcore_ref }}
 
           ACTUAL_COMMIT=$(git rev-parse HEAD)
-          EXPECTED_COMMIT="${{ github.event.inputs.mcore_commit }}"
+          EXPECTED_COMMIT="${{ github.event.inputs.mcore_ref }}"
 
           echo "🧪 FUNCTIONAL TESTS - MCore verification:"
           echo "Expected: ${EXPECTED_COMMIT}"


### PR DESCRIPTION
# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified CI/CD workflow by consolidating MCore reference handling and streamlining git operations in the build pipeline.
  * Removed redundant verification checks to improve workflow efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->