### PR TITLE
Revert "Revert Qwen3 235B GB300 MXFP8 large scale mapping (#2338)"

### DIFF
--- a/scripts/performance/configs/qwen/qwen3_workload_base_configs.py
+++ b/scripts/performance/configs/qwen/qwen3_workload_base_configs.py
@@ -279,9 +279,6 @@ QWEN3_235B_A22B_PRETRAIN_CONFIG_H100_FP8_CS_V2 = replace(
 
 QWEN3_235B_A22B_PRETRAIN_CONFIG_GB300_FP8_MX_LARGE_SCALE = replace(
     QWEN3_235B_A22B_PRETRAIN_CONFIG_GB300_FP8_MX_V2,
-    virtual_pipeline_model_parallel_size=12,
-    expert_model_parallel_size=16,
-    cuda_graph_scope=["moe_router", "moe_preprocess"],
     global_batch_size=512,
 )
 


### PR DESCRIPTION
This reverts commit d3d8030fac4ea69cc228151353c9288acbf2fe6f.

# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined large-scale workload configuration by removing explicit parallelism and CUDA graph scope parameters, simplifying performance tuning settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->