### PR TITLE
[misc] fix: Fix CLI_OVERRIDES quoting in slurm scripts and use uv wrapper

### DIFF
--- a/examples/models/nemotron_3/slurm_peft.sh
+++ b/examples/models/nemotron_3/slurm_peft.sh
@@ -132,7 +132,7 @@ for CONFIG in "${PARALLELISM_CONFIGS[@]}"; do
     echo "======================================"
 
     # Build CLI overrides for this config
-    CLI_OVERRIDES=" \
+    CLI_OVERRIDES="\
         checkpoint.pretrained_checkpoint=$PRETRAINED_CHECKPOINT \
         train.train_iters=$TRAIN_ITERS \
         train.global_batch_size=$GLOBAL_BATCH_SIZE \
@@ -153,14 +153,12 @@ for CONFIG in "${PARALLELISM_CONFIGS[@]}"; do
         dataset.packed_sequence_specs.pad_seq_to_mult=$((CP * 2)) \
         dataset.packed_sequence_specs.packed_sequence_size=$SEQ_LENGTH \
         dataset.seq_length=$SEQ_LENGTH \
-        model.seq_length=$SEQ_LENGTH
-    "
+        model.seq_length=$SEQ_LENGTH"
 
-    CMD="python /opt/Megatron-Bridge/scripts/training/run_recipe.py"
+    CMD="uv run --no-sync python scripts/training/run_recipe.py"
     CMD="$CMD --recipe ${MODEL_NAME}_finetune_config"
     CMD="$CMD --peft_scheme lora"
-    # Collapse newlines so bash -c receives a single command
-    CMD="$CMD $(echo "$CLI_OVERRIDES" | tr '\n' ' ' | sed 's/  \+/ /g')"
+    CMD="$CMD $CLI_OVERRIDES"
 
     echo "Executing command..."
     echo $CMD

--- a/examples/models/nemotron_3/slurm_pretrain.sh
+++ b/examples/models/nemotron_3/slurm_pretrain.sh
@@ -128,7 +128,7 @@ for CONFIG in "${PARALLELISM_CONFIGS[@]}"; do
     echo "======================================"
 
     # Build CLI overrides for this config
-    CLI_OVERRIDES=" \
+    CLI_OVERRIDES="\
         model.seq_length=$SEQ_LENGTH \
         train.train_iters=$TRAIN_ITERS \
         train.global_batch_size=$GLOBAL_BATCH_SIZE \
@@ -144,10 +144,9 @@ for CONFIG in "${PARALLELISM_CONFIGS[@]}"; do
         model.pipeline_model_parallel_size=$PP \
         model.expert_model_parallel_size=$EP \
         model.sequence_parallel=$SP \
-        model.context_parallel_size=$CP
-    "
+        model.context_parallel_size=$CP"
 
-    CMD="python /opt/Megatron-Bridge/scripts/training/run_recipe.py"
+    CMD="uv run --no-sync python scripts/training/run_recipe.py"
     CMD="$CMD --recipe ${MODEL_NAME}_pretrain_config"
     CMD="$CMD $CLI_OVERRIDES"
 

--- a/examples/models/nemotron_3/slurm_sft.sh
+++ b/examples/models/nemotron_3/slurm_sft.sh
@@ -130,7 +130,7 @@ for CONFIG in "${PARALLELISM_CONFIGS[@]}"; do
     echo "======================================"
 
     # Build CLI overrides for this config
-    CLI_OVERRIDES=" \
+    CLI_OVERRIDES="\
         checkpoint.pretrained_checkpoint=$PRETRAINED_CHECKPOINT \
         train.train_iters=$TRAIN_ITERS \
         train.global_batch_size=$GLOBAL_BATCH_SIZE \
@@ -151,13 +151,11 @@ for CONFIG in "${PARALLELISM_CONFIGS[@]}"; do
         dataset.packed_sequence_specs.pad_seq_to_mult=$((CP * 2)) \
         dataset.packed_sequence_specs.packed_sequence_size=$SEQ_LENGTH \
         dataset.seq_length=$SEQ_LENGTH \
-        model.seq_length=$SEQ_LENGTH
-    "
+        model.seq_length=$SEQ_LENGTH"
 
-    CMD="python /opt/Megatron-Bridge/scripts/training/run_recipe.py"
+    CMD="uv run --no-sync python scripts/training/run_recipe.py"
     CMD="$CMD --recipe ${MODEL_NAME}_finetune_config"
-    # Collapse newlines so bash -c receives a single command
-    CMD="$CMD $(echo "$CLI_OVERRIDES" | tr '\n' ' ' | sed 's/  \+/ /g')"
+    CMD="$CMD $CLI_OVERRIDES"
 
     echo "Executing command..."
     echo $CMD

--- a/examples/models/vlm/glm_45v/slurm_peft.sh
+++ b/examples/models/vlm/glm_45v/slurm_peft.sh
@@ -112,7 +112,7 @@ echo "======================================"
 mkdir -p logs
 
 # Build CLI overrides
-CLI_OVERRIDES="
+CLI_OVERRIDES="\
     checkpoint.pretrained_checkpoint=$PRETRAINED_CHECKPOINT \
     model.seq_length=$SEQ_LENGTH \
     train.train_iters=$TRAIN_ITERS \
@@ -130,13 +130,12 @@ CLI_OVERRIDES="
     dataset.seq_length=$SEQ_LENGTH \
     model.tensor_model_parallel_size=$TP \
     model.pipeline_model_parallel_size=$PP \
-    model.expert_model_parallel_size=$EP
-"
+    model.expert_model_parallel_size=$EP"
 
 # Build command
-# Only local rank 0 on each node runs uv sync, then all ranks run with --no-sync
-CMD="if [ \"\$SLURM_LOCALID\" -eq 0 ]; then uv sync; else sleep 2; fi && "
-CMD="$CMD uv run --no-sync python scripts/training/run_recipe.py"
+# If mounting a workspace that requires re-syncing dependencies, uncomment the uv sync line:
+# CMD="if [ \"\$SLURM_LOCALID\" -eq 0 ]; then uv sync; else sleep 2; fi && "
+CMD="uv run --no-sync python scripts/training/run_recipe.py"
 CMD="$CMD --recipe ${MODEL_NAME}_finetune_config"
 CMD="$CMD --step_func vlm_step"
 CMD="$CMD --peft_scheme lora"

--- a/examples/models/vlm/glm_45v/slurm_sft.sh
+++ b/examples/models/vlm/glm_45v/slurm_sft.sh
@@ -111,7 +111,7 @@ echo "======================================"
 mkdir -p logs
 
 # Build CLI overrides
-CLI_OVERRIDES="
+CLI_OVERRIDES="\
     checkpoint.pretrained_checkpoint=$PRETRAINED_CHECKPOINT \
     model.seq_length=$SEQ_LENGTH \
     train.train_iters=$TRAIN_ITERS \
@@ -129,13 +129,12 @@ CLI_OVERRIDES="
     dataset.seq_length=$SEQ_LENGTH \
     model.tensor_model_parallel_size=$TP \
     model.pipeline_model_parallel_size=$PP \
-    model.expert_model_parallel_size=$EP
-"
+    model.expert_model_parallel_size=$EP"
 
 # Build command
-# Only local rank 0 on each node runs uv sync, then all ranks run with --no-sync
-CMD="if [ \"\$SLURM_LOCALID\" -eq 0 ]; then uv sync; else sleep 2; fi && "
-CMD="$CMD uv run --no-sync python scripts/training/run_recipe.py"
+# If mounting a workspace that requires re-syncing dependencies, uncomment the uv sync line:
+# CMD="if [ \"\$SLURM_LOCALID\" -eq 0 ]; then uv sync; else sleep 2; fi && "
+CMD="uv run --no-sync python scripts/training/run_recipe.py"
 CMD="$CMD --recipe ${MODEL_NAME}_finetune_config"
 CMD="$CMD --step_func vlm_step"
 CMD="$CMD $CLI_OVERRIDES"


### PR DESCRIPTION
## Summary
- Fix newline quoting bug in `CLI_OVERRIDES` across all slurm example scripts. The double-quoted string contained leading/trailing newlines that caused `bash -c` to split overrides into separate commands, resulting in "No such file or directory" errors.
- Replace hardcoded `python /opt/Megatron-Bridge/...` path with `uv run --no-sync` wrapper in nemotron_3 slurm scripts for consistency with GLM-4.5V scripts.
- Comment out `uv sync` pre-step in GLM-4.5V scripts since the container already has synced dependencies; added comment explaining when to re-enable.
- Remove `tr`/`sed` workarounds in nemotron_3 slurm_sft and slurm_peft that were papering over the quoting bug.

## Test plan
- [ ] Verify slurm scripts parse correctly with `bash -n` (syntax check)
- [ ] Confirm CLI overrides expand as a single line when passed to `bash -c`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated training scripts to use an improved execution wrapper for model training across multiple configurations (Nemotron 3 and GLM-4V).
* Refactored command construction and execution paths for consistency across SLURM training environments.
* Simplified script paths and configuration parameter handling for streamlined training workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->