### PR TITLE
[PEFT] fix: allow args and kwargs for LoRATopKRouter forward

### DIFF
--- a/src/megatron/bridge/peft/lora_layers.py
+++ b/src/megatron/bridge/peft/lora_layers.py
@@ -65,7 +65,7 @@ class LoRALinear(AdapterWrapper):
 class LoRATopKRouter(AdapterWrapper):
     """Adapter wrapper that applies LoRA to router gating logits."""
 
-    def forward(self, x: torch.Tensor):
+    def forward(self, x: torch.Tensor, *args: Any, **kwargs: Any):
         """Forward pass that adds LoRA delta to router logits before routing."""
         self.to_wrap._maintain_float32_expert_bias()
         jittered_input = self.to_wrap.apply_input_jitter(x)
@@ -75,7 +75,7 @@ class LoRATopKRouter(AdapterWrapper):
             logits = logits + adapter_output.to(dtype=logits.dtype)
         if self.to_wrap.config.moe_router_force_load_balancing:
             logits = apply_random_logits(logits)
-        return self.to_wrap.routing(logits)
+        return self.to_wrap.routing(logits, *args, **kwargs)
 
 
 class TELinearAdapter(te.Linear):


### PR DESCRIPTION
# What does this PR do ?

https://github.com/NVIDIA/Megatron-LM/commit/71c49b56da0c9d2d4fa32a2ac11bde5bd01261c9 introduces an additional `padding_mask` argument, this PR address the issue by allowing args and kwargs for LoRATopKRouter forward and pass them to `routing`.

# Changelog

- allow kwargs for LoRATopKRouter forward

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [X] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced LoRA routing mechanism to support flexible argument passing for improved extensibility and compatibility with various routing configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->