### PR TITLE
Add AG/RS overlap distributed init support

### DIFF
--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -206,6 +206,13 @@ class DistributedInitConfig:
     global parallel state (mpu) variables. When True, parallel groups are obtained from
     the pg_collection object rather than the global megatron.core.parallel_state module."""
 
+    create_all_gather_group: bool = False
+    """Create separate all-gather process groups for AG/RS overlap optimization.
+    When True, creates separate process groups for all-gather operations, enabling
+    overlap between all-gather (forward pass) and reduce-scatter (backward pass)
+    communications in FSDP training. This improves training performance by hiding
+    communication latency."""
+
 
 @dataclass
 class RerunStateMachineConfig:

--- a/src/megatron/bridge/training/initialize.py
+++ b/src/megatron/bridge/training/initialize.py
@@ -509,7 +509,7 @@ def _create_pg_collection(
         dp_cp_rank_lists = grid._gen_rank_enum(["dp", "cp"])
         if dp_cp_rank_lists:
             dp_cp_ag_pg, _ = torch.distributed.new_subgroups_by_enumeration(dp_cp_rank_lists, backend="nccl")
-        
+
         # Create expert DP all-gather group if expert parallelism is enabled
         if ep_size > 1:
             # Use expert grid to enumerate ranks for expert dp groups
@@ -540,13 +540,13 @@ def _create_pg_collection(
         inter_dist_opt=inter_dist_opt_pg,
         intra_dist_opt=intra_dist_opt_pg,
     )
-    
+
     # Add AG groups to ProcessGroupCollection if created
     if create_all_gather_group:
         pg_collection.dp_cp_ag = dp_cp_ag_pg
         if expt_dp_ag_pg is not None:
             pg_collection.expt_dp_ag = expt_dp_ag_pg
-    
+
     return pg_collection
 
 
@@ -670,12 +670,10 @@ def _initialize_distributed(
                     f"> initialized pipeline model parallel with size "
                     f"{parallel_state.get_pipeline_model_parallel_world_size()}"
                 )
-        
+
         # Create AG groups if requested
         if dist_config.create_all_gather_group:
-            for_expert_parallelism = (
-                getattr(model_config, "expert_model_parallel_size", 1) or 1
-            ) > 1
+            for_expert_parallelism = (getattr(model_config, "expert_model_parallel_size", 1) or 1) > 1
             dp_cp_ag, expt_dp_ag = parallel_state.create_all_gather_groups(
                 for_expert_parallelism=for_expert_parallelism,
                 timeout=datetime.timedelta(minutes=dist_config.distributed_timeout_minutes),
@@ -687,7 +685,7 @@ def _initialize_distributed(
             if expt_dp_ag is not None:
                 pg_collection.expt_dp_ag = expt_dp_ag
             return pg_collection
-        
+
         # Return a ProcessGroupCollection using mpu process groups
         return ProcessGroupCollection.use_mpu_process_groups()
 


### PR DESCRIPTION
# What does this PR do ?

Enable AG/RS overlap process-group plumbing in Megatron-Bridge distributed initialization by adding support for `create_all_gather_group`, including expert-parallel all-gather groups when `EP > 1`, and wiring these groups into `ProcessGroupCollection`.

# Changelog

- Add `create_all_gather_group: bool = False` to `DistributedInitConfig` in `src/megatron/bridge/training/config.py`.
- Update `src/megatron/bridge/training/initialize.py` to thread `create_all_gather_group` through distributed init.
- In the decentralized (`HyperCommGrid`) path, create and attach:
  - `dp_cp_ag` (DP+CP all-gather group)
  - `expt_dp_ag` (expert-DP all-gather group when EP is enabled)
- In the centralized path, call `parallel_state.create_all_gather_groups(...)` after model-parallel init and attach returned AG groups to `ProcessGroupCollection`.
- Keep default behavior unchanged when `create_all_gather_group=False` (no AG group creation, existing behavior preserved).
- No intended packaging/build-system changes are part of this PR (`pyproject.toml` local testing override is excluded).

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install? **No**
  - [x] Reviewer: Does the PR have correct import guards for all optional libraries? **N/A**

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to [#<issue-number>](https://github.com/NVIDIA/Megatron-LM/pull/3249)
- Supposed to replace this PR : https://github.com/NVIDIA-NeMo/NeMo/pull/15253
- Manual validation status:
  - PR behavior tested end-to-end and training works.
  - Nsight Systems shows AG/RS overlap in tested runs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to enable optimized process groups for improved distributed training performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->