### PR TITLE
26.02 perf summary

### DIFF
--- a/docs/performance-summary.md
+++ b/docs/performance-summary.md
@@ -37,7 +37,7 @@ Below are performance benchmarks for various large language models organized by 
 The performance data includes:
 
 - **Pre-training Performance**: Throughput metrics for various model sizes and architectures
-- **System Configurations**: Results across different GPU systems (DGX-GB200, DGX-B200, DGX-H100)
+- **System Configurations**: Results across different GPU systems (DGX-GB300, DGX-GB200, DGX-B300, DGX-B200, DGX-H100)
 - **Precision Options**: Performance comparisons between different precision modes (BF16, FP8, MXFP8)
 
 ---


### PR DESCRIPTION
# What does this PR do ?

Adds performance summary for 26.02 NeMo container for GB300, GB200, B300, B200, H100 systems.

# Changelog

```
## 26.02 NeMo Container

### Pre-Training Performance

...
```

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added 26.02 NeMo Container Performance Summary section with Pre-Training Performance tables across multiple hardware systems.
  * Included detailed performance metrics and configurations for additional models.
  * Added clarification on MoE training benchmarks using token-dropless approaches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->