### PR TITLE
docs: Update 0.3.0 docs version picker to include nightly

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           repository: NVIDIA-NeMo/FW-CI-templates
-          ref: v0.72.0
+          ref: v0.74.0
           path: FW-CI-templates
 
       - uses: ./FW-CI-templates/.github/actions/publish-docs

--- a/docs/versions1.json
+++ b/docs/versions1.json
@@ -1,12 +1,13 @@
 [
   {
-    "preferred": true,
-    "version": "latest",
-    "url": "https://docs.nvidia.com/nemo/megatron-bridge/latest/"
+    "version": "nightly",
+    "url": "https://docs.nvidia.com/nemo/export-deploy/nightly/"
   },
   {
-    "version": "0.3.0",
-    "url": "https://docs.nvidia.com/nemo/megatron-bridge/0.3.0/"
+      "name": "0.3.0 (latest)",
+      "version": "0.3.0",
+      "url": "https://docs.nvidia.com/nemo/export-deploy/latest/",
+      "preferred": true
   },
   {
     "version": "0.2.0",


### PR DESCRIPTION
# What does this PR do ?

docs: Update 0.3.0 docs version picker to include nightly

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated documentation version management configuration to provide clearer separation between stable releases (0.3.0) and nightly development builds, enhancing user access to the appropriate documentation version.

* **Chores**
  * Updated continuous integration and deployment workflow dependencies to the latest compatible version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->