### PR TITLE
[training] fix: Add missing dataset and validation configs to summary logging

### DIFF
--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -1741,7 +1741,9 @@ class ConfigContainer(Container):
         # Non-Mcore configs - log all values
         non_mcore_configs = [
             ("train", self.train),
+            ("validation", self.validation),
             ("scheduler", self.scheduler),
+            ("dataset", self.dataset),
             ("checkpoint", self.checkpoint),
             ("logger", self.logger),
             ("tokenizer", self.tokenizer),


### PR DESCRIPTION
## Summary
- Add `dataset` and `validation` configs to the `non_mcore_configs` list in `ConfigContainer.log_non_default_values()`, so they appear in the configuration summary log at startup.

## Test plan
- [ ] Run a training job and verify `[dataset]` and `[validation]` sections appear in the configuration summary output.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal logging for configuration validation and dataset handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->