### PR TITLE
ci: Add Azure H100 runners as non-default runners

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -63,9 +63,9 @@ jobs:
   pre-flight:
     uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_cicd_preflight.yml@v0.73.2
     with:
-      default_runner_prefix: nemo-ci-azure-h100
-      non_nvidia_runner_prefix: nemo-ci-azure-h100
-      default_test_data_path: ${{ vars.NON_NVIDIA_TEST_DATA_PATH }}
+      default_runner_prefix: ${{ vars.DEFAULT_RUNNER_PREFIX }}
+      non_nvidia_runner_prefix: ${{ vars.NON_NVIDIA_RUNNER_PREFIX }}
+      default_test_data_path: ${{ vars.DEFAULT_TEST_DATA_PATH }}
       non_nvidia_test_data_path: ${{ vars.NON_NVIDIA_TEST_DATA_PATH }}
     secrets:
       NVIDIA_MANAGEMENT_ORG_PAT: ${{ secrets.NVIDIA_MANAGEMENT_ORG_PAT }}


### PR DESCRIPTION
# What does this PR do ?

ci: Add Azure H100 runners as non-default runners

The A100 Azure runners do not work for MBridge. Some tests assume H100. So CI fails for external contributors when it falls back to the A100 runners.

* Brought over a H100 runner from NeMo and had another one available to include in the pool. Will move one A100 machine to the NeMo repo
* Passing CI with only the Azure H100 machines after uploading updated test data and adjusting a test to set an env var.  It seems that the Azure H100 machines still are not able to handle some tests as-is.

https://github.com/NVIDIA-NeMo/Megatron-Bridge/actions/runs/22383671853/job/64790534973?pr=2519

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline configuration to optimize test execution infrastructure and data path handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->