### PR TITLE
docs: Correct nvrx in docs to 0.4.1

### DIFF
--- a/docs/releases/software-versions.md
+++ b/docs/releases/software-versions.md
@@ -14,7 +14,7 @@
 | NeMo | 2.7.0 |
 | NeMo Run | 0.8.0 |
 | Nvidia-ModelOpt | 0.41.0 |
-| NVRX | 0.5.0 |
+| NVRX | 0.4.1 |
 | CUDA | 13.0.2 |
 | cuDNN | 9.18.0.50 |
 | TRT-LLM | 1.1.0 |


### PR DESCRIPTION
# What does this PR do ?

docs: Correct nvrx in docs to 0.4.1

We'll ensure it is 0.5.0 in an upcoming patch release.

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated NVRX version information in NeMo Framework 26.02 release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->