### PR TITLE
[script] fix: recognize 'sft' and 'peft' keywords in train mode inference

### DIFF
--- a/scripts/training/run_recipe.py
+++ b/scripts/training/run_recipe.py
@@ -84,7 +84,8 @@ TRAIN_MODES = {
 ERR_UNKNOWN_STEP = "Unknown step type: {step_type}. Choose from: {choices}"
 ERR_INFER_MODE_FAILED = (
     "Unable to infer training mode from recipe name. "
-    "Please include 'pretrain' or 'finetune' in the recipe name or pass --mode explicitly."
+    "Please include 'pretrain' or 'finetune' (or 'sft'/'peft') in the recipe name, "
+    "or pass --mode explicitly."
 )
 
 


### PR DESCRIPTION
The infer_train_mode function only checked for 'finetune' in recipe names. Recipes named with 'sft' or 'peft' were not recognized as finetune mode, causing a ValueError. Add these keywords to the has_finetune check.


Made-with: Cursor

# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced training mode detection to correctly recognize recipes with "sft" or "peft" naming conventions as fine-tuning operations, in addition to recipes with "finetune" in the name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->