### PR TITLE
Fix Docker building instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,14 @@ You can either follow the steps below to set up the environment from scratch, or
 
 **Build and run the Docker container**:
 
+First, set up the third-party modules of this repository so they can be copied into the container:
+
+```bash
+git submodule update --init --recursive
+```
+
+Build the container:
+
 ```bash
 docker build \
     -f docker/Dockerfile.ci \


### PR DESCRIPTION
# What does this PR do ?

It's never mentioned that the Megatron-LM submodule has to be initialized, even though it's used in the Dockerfile. So these instructions are added.

# Changelog

- Add submodule initialization to Docker build instructions.

# Additional Information

- Related to #1168

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guide with setup instructions for third-party submodules.
  * Added clarified Docker build command instructions for contributors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->