### PR TITLE
Fix for RL for mtp_num_layers

### DIFF
--- a/src/megatron/bridge/models/mamba/mamba_provider.py
+++ b/src/megatron/bridge/models/mamba/mamba_provider.py
@@ -172,13 +172,11 @@ class MambaModelProvider(TransformerConfig, ModelProviderMixin[MCoreMambaModel])
                 mamba_stack_spec = mamba_stack_spec()
 
         sep = Symbols.MTP_SEPARATOR
-        if self.mtp_hybrid_override_pattern is not None and self.mtp_num_layers > 0 and (self.hybrid_override_pattern is None or sep not in self.hybrid_override_pattern):
-            main_pattern = self.hybrid_override_pattern or ""
-            mtp_pattern = self.mtp_hybrid_override_pattern
-            hybrid_override_pattern = main_pattern + sep + sep.join([mtp_pattern] * self.mtp_num_layers)
-            print(f"Converted legacy MTP pattern to unified: {hybrid_override_pattern}")
-            self.hybrid_override_pattern = hybrid_override_pattern
-            self.mtp_hybrid_override_pattern = None
+        # Derive the hybrid override pattern from the saved hybrid_override_pattern, 
+        # mtp_hybrid_override_pattern, and mtp_num_layers.
+        # This allows us to use a different mtp_num_layers than the one saved in the checkpoint.
+        main_pattern = self.hybrid_override_pattern.split(sep)[0]
+        self.hybrid_override_pattern = main_pattern + sep + sep.join([self.mtp_hybrid_override_pattern] * self.mtp_num_layers)
 
         if self.hybrid_override_pattern and sep in self.hybrid_override_pattern:
             parsed = parse_hybrid_pattern(self.hybrid_override_pattern)


### PR DESCRIPTION
# What does this PR do ?

This change allows us to continue training for a setting of `mtp_num_layers` that differs from the checkpoint.

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
