### PR TITLE
fix(fp16): fix HF-Megatron dtype mismatch

### DIFF
--- a/src/megatron/bridge/models/conversion/param_mapping.py
+++ b/src/megatron/bridge/models/conversion/param_mapping.py
@@ -903,6 +903,13 @@ class RowParallelMapping(MegatronParamMapping[torch.Tensor]):
         if self.tp_rank == 0:
             if hf_weights is None:
                 raise ValueError("hf_weights should not be None on rank 0")
+            if hf_weights.dtype != target_param.dtype:
+                logger.warning(
+                    f"WARNING: Dtype mismatch between HuggingFace weights and Megatron module. "
+                    f"HF dtype: {hf_weights.dtype}. Megatron dtype: {target_param.dtype}. "
+                    f"Casting HF weights to Megatron dtype. THIS MAY RESULT IN A LOSS OF PRECISION. "
+                )
+                hf_weights = hf_weights.to(target_param.dtype)
 
             # bias (1D) is replicated across tp ranks
             # For weight (2D), we split along dim 1


### PR DESCRIPTION
# What does this PR do ?

Fix HuggingFace to Megatron dtype mismatch when using fp16.

When converting models using fp16 (float16) precision, the following mismatch occurs between HuggingFace weights and Megatron modules:
 
<img width="2218" height="722" alt="image" src="https://github.com/user-attachments/assets/0d38680f-0203-4a6d-b6c5-b73bdb41ff71" />


# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced data type compatibility handling during model weight conversion. Automatic dtype conversion with warning notifications is now applied when mismatches are detected to ensure proper alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->