### PR TITLE
[OMNIML-3495] Add barrier and save-first ordering for multi-node PTQ support

### DIFF
--- a/examples/quantization/quantize.py
+++ b/examples/quantization/quantize.py
@@ -190,17 +190,12 @@ def main(
 
             console.print(table)
 
-    # Test quantized model with custom prompts
-    if is_rank_0:
-        console.print("[green]Testing quantized model with custom prompts...[/green]")
-
-    _custom_prompt_forward_loop_func(unwrapped_model, prompts, bridge.hf_pretrained.tokenizer, is_rank_0)
+    torch.distributed.barrier()
 
     # Save quantized model in Megatron format
     if megatron_save_path:
         save_path = megatron_save_path
     else:
-        # Create default save path using model name and quantization config
         model_name = hf_model_id.split("/")[-1]
         save_path = f"{model_name}_quantized_{export_quant_cfg}"
         if is_rank_0:
@@ -209,6 +204,15 @@ def main(
     if is_rank_0:
         console.print(f"Saving quantized Megatron checkpoint in {save_path}...")
     bridge.save_megatron_model(megatron_model, save_path)
+
+    torch.distributed.barrier()
+
+    # Test quantized model with custom prompts
+    if export_quant_cfg in QUANT_CFG_CHOICES:
+        if is_rank_0:
+            console.print("[green]Testing quantized model with custom prompts...[/green]")
+
+        _custom_prompt_forward_loop_func(unwrapped_model, prompts, bridge.hf_pretrained.tokenizer, is_rank_0)
 
 
 if __name__ == "__main__":

--- a/examples/quantization/quantize_utils.py
+++ b/examples/quantization/quantize_utils.py
@@ -38,6 +38,10 @@ QUANT_CFG_CHOICES = {
     "int4_awq": mtq.INT4_AWQ_CFG,
     "w4a8_awq": mtq.W4A8_AWQ_BETA_CFG,
     "nvfp4": mtq.NVFP4_DEFAULT_CFG,
+    "mamba_moe_fp8_aggressive": mtq.MAMBA_MOE_FP8_AGGRESSIVE_CFG,
+    "mamba_moe_fp8_conservative": mtq.MAMBA_MOE_FP8_CONSERVATIVE_CFG,
+    "mamba_moe_nvfp4_aggressive": mtq.MAMBA_MOE_NVFP4_AGGRESSIVE_CFG,
+    "mamba_moe_nvfp4_conservative": mtq.MAMBA_MOE_NVFP4_CONSERVATIVE_CFG,
 }
 
 


### PR DESCRIPTION
# What does this PR do ?

Add distributed barriers and reorder save/test-generation in `quantize.py` to prevent rank desync during multi-node PTQ

# Changelog

- Add `torch.distributed.barrier()` after quantization stats printing to sync all ranks before saving (rank 0 is delayed by the `if is_rank_0:` stats printing block while other ranks skip ahead).
- Reorder checkpoint saving before test generation, following MCore's `quantize.py` convention — ensures the quantized checkpoint is persisted even if test generation fails.
- Add `torch.distributed.barrier()` after saving to sync all ranks before test generation.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the quantization example script to reorganize the testing sequence and add synchronization improvements for model validation during the save process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->