### PR TITLE
Update DeepSeek-V3 B300 config

### DIFF
--- a/scripts/performance/configs/deepseek/deepseek_workload_base_configs.py
+++ b/scripts/performance/configs/deepseek/deepseek_workload_base_configs.py
@@ -168,8 +168,8 @@ DEEPSEEK_V3_PRETRAIN_CONFIG_B300_V2 = replace(
 DEEPSEEK_V3_PRETRAIN_CONFIG_B300_BF16_V2 = replace(
     DEEPSEEK_V3_PRETRAIN_CONFIG_B300_V2,
     pipeline_model_parallel_size=8,
-    virtual_pipeline_model_parallel_size=2,
-    recompute_modules=["mla_up_proj", "moe_act", "layernorm"],
+    virtual_pipeline_model_parallel_size=None,
+    recompute_modules=["mla_up_proj"],
 )
 DEEPSEEK_V3_PRETRAIN_CONFIG_B300_FP8_CS_V2 = DEEPSEEK_V3_PRETRAIN_CONFIG_B300_V2
 DEEPSEEK_V3_PRETRAIN_CONFIG_B300_FP8_MX_V2 = DEEPSEEK_V3_PRETRAIN_CONFIG_B300_FP8_CS_V2


### PR DESCRIPTION
The `PP8VP2` configuration shows performance fluctuations across iterations. This PR, which changes the configuration to `PP8VPNone`, seems to fix the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimized DeepSeek V3 B300 BF16 pretraining configuration for improved training performance and resource efficiency. Updated model parallelism parameters and refined memory management strategy to enhance how computational resources are distributed and memory is utilized during model training. These changes improve overall training efficiency, reduce resource overhead, and optimize hardware utilization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->