### PR TITLE
Override moe_token_dispatcher_type to "alltoall" when export megatron…

### DIFF
--- a/src/megatron/bridge/models/conversion/auto_bridge.py
+++ b/src/megatron/bridge/models/conversion/auto_bridge.py
@@ -835,7 +835,12 @@ class AutoBridge(Generic[MegatronModelT]):
         # Export ckpt performs on CPU
         with temporary_distributed_context(backend="gloo"):
             # Load the Megatron model
-            megatron_model = self.load_megatron_model(megatron_path, wrap_with_ddp=False)
+            # 'flex' dispatcher requires TPxEP > 1; fall back to 'alltoall'
+            megatron_model = self.load_megatron_model(
+                megatron_path,
+                wrap_with_ddp=False,
+                mp_overrides={"moe_token_dispatcher_type": "alltoall"},
+            )
 
             # Save in HuggingFace format
             self.save_hf_pretrained(

--- a/src/megatron/bridge/models/conversion/auto_bridge.py
+++ b/src/megatron/bridge/models/conversion/auto_bridge.py
@@ -835,12 +835,12 @@ class AutoBridge(Generic[MegatronModelT]):
         # Export ckpt performs on CPU
         with temporary_distributed_context(backend="gloo"):
             # Load the Megatron model
-            # 'flex' dispatcher requires TPxEP > 1; fall back to 'alltoall'
-            megatron_model = self.load_megatron_model(
-                megatron_path,
-                wrap_with_ddp=False,
-                mp_overrides={"moe_token_dispatcher_type": "alltoall"},
+            mp_overrides = (
+                {"moe_token_dispatcher_type": "alltoall"}
+                if getattr(self.transformer_config, "num_moe_experts", 0) > 0
+                else None
             )
+            megatron_model = self.load_megatron_model(megatron_path, wrap_with_ddp=False, mp_overrides=mp_overrides)
 
             # Save in HuggingFace format
             self.save_hf_pretrained(


### PR DESCRIPTION
# What does this PR do ?

When exporting a Megatron checkpoint to HF format, an error `AssertionError: Flex token dispatcher requires TPxEP > 1` occurs if `moe_token_dispatcher_type` is set to `flex`.

This PR overrides `moe_token_dispatcher_type` during the export process and temporarily switches `flex` to `alltoall` only for export. This avoids the assertion without affecting the original configuration.

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to https://github.com/NVIDIA-NeMo/Megatron-Bridge/issues/2655


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modified model checkpoint export and loading mechanisms to adjust the initialization sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->