### PR TITLE
restore container writable and clarify HF offline behavior

### DIFF
--- a/scripts/performance/README.md
+++ b/scripts/performance/README.md
@@ -136,6 +136,41 @@ python scripts/performance/setup_experiment.py
 - `-hf/--hf_token`: HuggingFace token for accessing tokenizers and checkpoints.
   - User can generate a token from- huggingface.co/settings/tokens (click on "Create new token" button)
   - For a "Fine-grained" token, only "User permissions" are needed. Under "User permissions", make selections for "Repositories", "Webhooks" and "Collections".
+- `--offline`: Set `HF_HUB_OFFLINE=1` (Slurm launcher path).
+  - Cannot be used together with `--hf_token`.
+
+##### HuggingFace connectivity and cache behavior (Slurm launcher)
+
+This launcher uses split defaults:
+
+- `TRANSFORMERS_OFFLINE=1`
+- `HF_HUB_OFFLINE=0`
+
+What each variable controls in this workflow:
+
+- `TRANSFORMERS_OFFLINE`: Transformers calls (for example `AutoTokenizer`) stay offline unless `--hf_token` is provided.
+- `HF_HUB_OFFLINE`: HuggingFace Hub calls (for example Hub-backed config/model resolution such as `AutoConfig`) stay online unless `--offline` is provided.
+
+Why this split exists:
+
+- Most benchmark recipes use `NullTokenizer`, so `TRANSFORMERS_OFFLINE=1` avoids unnecessary network traffic.
+- Most performance model families (`llama`, `qwen`, `qwen_vl`, `deepseek`, `gpt_oss`) use HF-backed config/model lookup paths.
+
+Flag mapping:
+
+- `--hf_token` sets `HF_TOKEN` and `TRANSFORMERS_OFFLINE=0`.
+- `--offline` sets `HF_HUB_OFFLINE=1`.
+- `--hf_token` and `--offline` are mutually exclusive.
+
+Practical guidance:
+
+1. Prefetch required model/tokenizer/config files into a local HF cache.
+2. Mount that cache into the container with `-cm/--custom_mounts`.
+3. Set `HF_HOME` to that mounted cache path before launch (Slurm exports env vars by default), for example `export HF_HOME=/path/to/hf_cache`.
+4. If needed, explicitly override `HF_HOME` with `-ce/--custom_env_vars`.
+5. Pass `--offline` to block Hub network checks.
+
+Note: with `HF_HUB_OFFLINE=0`, jobs may still contact HuggingFace even when files are mounted, which can trigger rate limits.
 
 ##### Parallelism arguments
 
@@ -152,6 +187,7 @@ python scripts/performance/setup_experiment.py
 - `-p/--partition`: Slurm partition to use for experiment.
 - `-t/--time_limit`: Maximum time limit before the Slurm job is cancelled. Format `HH:MM:SS`. Default `00:30:00`.
 - `-gn/--gpus_per_node`: GPUs per node. Default `8`.
+- Launcher behavior: `--container-writable` is always added to `srun` for benchmark compatibility on clusters where containers are read-only by default.
 - `-cm/--custom_mounts`: Comma-separated list of host mounts to expose inside the container.
 - `-ce/--custom_env_vars`: Comma-separated string of environment variables (format: `key1=value1,key2=value2`).
 - `-cs/--custom_srun_args`: Comma-separated string of srun arguments.

--- a/scripts/performance/argument_parser.py
+++ b/scripts/performance/argument_parser.py
@@ -314,6 +314,11 @@ def parse_cli_args():
         type=str,
         help="HuggingFace token. Defaults to None. Required for accessing tokenizers and checkpoints.",
     )
+    tokenizer_args.add_argument(
+        "--offline",
+        action="store_true",
+        help="Enable offline HuggingFace Hub mode by setting HF_HUB_OFFLINE=1.",
+    )
 
     # Parallelism
     parallelism_args = parser.add_argument_group("Parallelism arguments")

--- a/scripts/performance/setup_experiment.py
+++ b/scripts/performance/setup_experiment.py
@@ -181,6 +181,7 @@ def main(
     compute_dtype: str,
     gpu: str,
     hf_token: str,
+    offline: bool,
     detach: bool,
     dryrun: bool,
     enable_vboost: bool,
@@ -234,6 +235,9 @@ def main(
     config_variant: str = "v1",
 ):
     """Sets up the experiment and runs it."""
+    if hf_token and offline:
+        raise ValueError("--hf_token and --offline cannot be used together.")
+
     if (
         model_family_name in ["qwen3"]
         and model_recipe_name
@@ -243,7 +247,10 @@ def main(
         ]
         and task == "pretrain"
     ):
-        assert hf_token is not None, "HF token is required for Qwen3 tokenizer. NullTokenizer to be used soon."
+        assert hf_token is not None or offline, (
+            "Qwen3 tokenizer requires --hf_token or --offline. If using --offline, pre-download the tokenizer into "
+            "the local HuggingFace cache. NullTokenizer to be used soon."
+        )
 
     if wandb_key is not None:
         assert wandb_project_name is not None and wandb_experiment_name is not None, (
@@ -304,6 +311,7 @@ def main(
             custom_bash_cmds=custom_bash_cmds,
             gres=args.gres,
             hf_token=hf_token,
+            offline=offline,
             nemo_home=nemo_home,
             additional_slurm_params=additional_slurm_params,
             wandb_key=wandb_key,
@@ -540,6 +548,7 @@ if __name__ == "__main__":
         compute_dtype=args.compute_dtype,
         gpu=args.gpu,
         hf_token=args.hf_token,
+        offline=args.offline,
         detach=args.detach,
         dryrun=args.dryrun,
         enable_vboost=args.enable_vboost,

--- a/scripts/performance/utils/executors.py
+++ b/scripts/performance/utils/executors.py
@@ -38,13 +38,13 @@ bash -c '{{ pre_cmds }} {{ command }}'
 
 PERF_ENV_VARS = {
     "TORCH_NCCL_AVOID_RECORD_STREAMS": "1",  # Disable caching NCCL communication buffer memory
-    "TRANSFORMERS_OFFLINE": "1",  # Disable online downloads from HuggingFace
+    "TRANSFORMERS_OFFLINE": "1",  # Default for benchmark runs that mostly use NullTokenizer.
     "TOKENIZERS_PARALLELISM": "False",  # Restrict warning message prints
     "NCCL_NVLS_ENABLE": "0",  # Disable NVLink SHARP to save memory
     "NVTE_NORM_FWD_USE_CUDNN": "1",
     "NVTE_NORM_BWD_USE_CUDNN": "1",
     "TORCH_NCCL_HIGH_PRIORITY": "1",
-    "HF_HUB_OFFLINE": "0",
+    "HF_HUB_OFFLINE": "0",  # Keep Hub online by default; --offline flips this to 1.
 }
 
 
@@ -61,6 +61,7 @@ def slurm_executor(
     custom_env_vars: Dict[str, str] = {},
     custom_srun_args: List[str] = [],
     hf_token: str = None,
+    offline: bool = False,
     nemo_home: str = DEFAULT_NEMO_HOME,
     wandb_key: str = None,
     network: str = None,
@@ -86,6 +87,7 @@ def slurm_executor(
     srun_args = custom_srun_args.copy() + [
         "--mpi=pmix",
         "--no-container-mount-home",
+        "--container-writable",  # Required for benchmark compatibility on read-only-by-default container setups.
     ]
 
     if log_dir is not None:
@@ -107,7 +109,11 @@ def slurm_executor(
         PERF_ENV_VARS["NEMO_HOME"] = nemo_home
         mounts.extend([f"{nemo_home}:{nemo_home}"])
     if hf_token is not None:
+        # Enable authenticated online access for tokenizer/config paths.
         PERF_ENV_VARS.update({"HF_TOKEN": hf_token, "TRANSFORMERS_OFFLINE": "0"})
+    if offline:
+        # Disable HF Hub network calls. Requires a populated local HF cache.
+        PERF_ENV_VARS["HF_HUB_OFFLINE"] = "1"
 
     PERF_ENV_VARS.update(custom_env_vars)
     mounts.extend(custom_mounts)


### PR DESCRIPTION
- add `--offline` (Slurm launcher) to set `HF_HUB_OFFLINE=1`
- keep default split: `TRANSFORMERS_OFFLINE=1`, `HF_HUB_OFFLINE=0`
- keep `--hf_token` behavior (`HF_TOKEN` + `TRANSFORMERS_OFFLINE=0`)
- make `--hf_token` and `--offline` mutually exclusive
- update Qwen3 pretrain validation to require `hf_token or offline` and explicitly state offline mode requires pre-downloaded tokenizer cache
- always pass `--container-writable` in Slurm `srun` args (with rationale comment)
- expand performance README with clear, actionable HF cache/offline guidance

Removed in: #2112 , Originally added in #2086 #2084 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--offline` flag to enable offline HuggingFace Hub mode.
  * Added `--container-writable` flag support for benchmark-compatible container execution.

* **Documentation**
  * Added comprehensive guidance on offline mode configuration, including mutual exclusivity with `--hf_token` and environment variable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->