### PR TITLE
[ci] ci: remove nemotronh 4b L2 ckpt jobs until hybrid pattern fixed (PR #2628)

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -384,8 +384,9 @@ jobs:
           - script: L2_Launch_ckpts_mlm_to_mbridge_llama32_1b
           - script: L2_Launch_ckpts_mbridge_to_mlm_qwen3_4b
           - script: L2_Launch_ckpts_mlm_to_mbridge_qwen3_4b
-          - script: L2_Launch_ckpts_mbridge_to_mlm_nemotronh_4b
-          - script: L2_Launch_ckpts_mlm_to_mbridge_nemotronh_4b
+          # NemotronH 4B ckpt L2 jobs skipped until hybrid_override_pattern -> hybrid_layer_pattern (PR #2628)
+          # - script: L2_Launch_ckpts_mbridge_to_mlm_nemotronh_4b
+          # - script: L2_Launch_ckpts_mlm_to_mbridge_nemotronh_4b
     needs: [pre-flight, cicd-unit-tests]
     runs-on: ${{ needs.pre-flight.outputs.runner_prefix }}-gpu-x2
     if: |


### PR DESCRIPTION
Comment out `L2_Launch_ckpts_mbridge_to_mlm_nemotronh_4b` and `L2_Launch_ckpts_mlm_to_mbridge_nemotronh_4b` in the functional test matrix.

**Why:** The previous skip via `@pytest.mark.pleasefixme` on the test class caused pytest to collect 0 tests (all deselected by `-m "not pleasefixme"`), so pytest exited with code 5 and the L2 jobs still failed. Removing the jobs from the matrix is the reliable fix until hybrid_override_pattern → hybrid_layer_pattern is resolved in PR #2628.

Made with [Cursor](https://cursor.com)