### PR TITLE
[ckpt] feat: use explicit checkpoint format

### DIFF
--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -1711,7 +1711,7 @@ def _load_checkpoint_from_path(
         update_num_microbatches(consumed_samples=state.train_state.consumed_train_samples, verbose=True)
 
     # Load model weights
-    if not skip_load_to_model_and_opt:
+    if not skip_load_to_model_and_opt and ckpt_type != CheckpointType.FSDP_DTENSOR:
         # Handle PEFT resume for strict loading
         load_strict = strict
         is_peft_resume = (

--- a/tests/unit_tests/training/test_checkpointing.py
+++ b/tests/unit_tests/training/test_checkpointing.py
@@ -1732,6 +1732,7 @@ class TestMegatronLMCompatibility:
         mock_cfg.non_persistent_ckpt_type = None
         mock_cfg.exit_on_missing_checkpoint = False
         mock_cfg.ckpt_step = None
+        mock_cfg.ckpt_format = "torch_dist"
 
         # Create mock pg_collection
         mock_pg_collection = Mock()


### PR DESCRIPTION
# What does this PR do ?

Currently, checkpoint loading logic ignores the `ckpt_format` specified by the user and silently tries to infer the format. This leads to counter-intuitive failure in loading. I mistakenly had metadata.json in FSDP folder, but a user-specified ckpt_format should still take precedence.

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for explicitly specifying checkpoint format during base checkpoint loading. When a format is provided, automatic format inference from the checkpoint path is bypassed, giving users greater control over checkpoint loading behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->