### PR TITLE
[ci] fix: clean up stale artifacts before each functional test

### DIFF
--- a/tests/functional_tests/L2_Launch_ckpts_mbridge_to_mlm_llama32_1b.sh
+++ b/tests/functional_tests/L2_Launch_ckpts_mbridge_to_mlm_llama32_1b.sh
@@ -16,6 +16,9 @@
 set -xeuo pipefail # Exit immediately if a command exits with a non-zero status
 
 export CUDA_VISIBLE_DEVICES="0,1"
+# Clean up stale artifacts from previous runs (CI uses fresh containers, cluster does not)
+rm -rf nemo_experiments 2>/dev/null || true
+rm -f .coverage* 2>/dev/null || true
 
 # Run recipe functional tests on 2 GPUs
 # This script tests recipe configurations with their default settings to ensure

--- a/tests/functional_tests/L2_Launch_ckpts_mbridge_to_mlm_nemotronh_4b.sh
+++ b/tests/functional_tests/L2_Launch_ckpts_mbridge_to_mlm_nemotronh_4b.sh
@@ -16,6 +16,9 @@
 set -xeuo pipefail # Exit immediately if a command exits with a non-zero status
 
 export CUDA_VISIBLE_DEVICES="0,1"
+# Clean up stale artifacts from previous runs (CI uses fresh containers, cluster does not)
+rm -rf nemo_experiments 2>/dev/null || true
+rm -f .coverage* 2>/dev/null || true
 
 # Run recipe functional tests on 2 GPUs
 # This script tests recipe configurations with their default settings to ensure

--- a/tests/functional_tests/L2_Launch_ckpts_mbridge_to_mlm_qwen3_4b.sh
+++ b/tests/functional_tests/L2_Launch_ckpts_mbridge_to_mlm_qwen3_4b.sh
@@ -16,6 +16,9 @@
 set -xeuo pipefail # Exit immediately if a command exits with a non-zero status
 
 export CUDA_VISIBLE_DEVICES="0,1"
+# Clean up stale artifacts from previous runs (CI uses fresh containers, cluster does not)
+rm -rf nemo_experiments 2>/dev/null || true
+rm -f .coverage* 2>/dev/null || true
 
 # Run recipe functional tests on 2 GPUs
 # This script tests recipe configurations with their default settings to ensure

--- a/tests/functional_tests/L2_Launch_ckpts_mlm_to_mbridge_llama32_1b.sh
+++ b/tests/functional_tests/L2_Launch_ckpts_mlm_to_mbridge_llama32_1b.sh
@@ -16,6 +16,9 @@
 set -xeuo pipefail # Exit immediately if a command exits with a non-zero status
 
 export CUDA_VISIBLE_DEVICES="0,1"
+# Clean up stale artifacts from previous runs (CI uses fresh containers, cluster does not)
+rm -rf nemo_experiments 2>/dev/null || true
+rm -f .coverage* 2>/dev/null || true
 
 # Run recipe functional tests on 2 GPUs
 # This script tests recipe configurations with their default settings to ensure

--- a/tests/functional_tests/L2_Launch_ckpts_mlm_to_mbridge_nemotronh_4b.sh
+++ b/tests/functional_tests/L2_Launch_ckpts_mlm_to_mbridge_nemotronh_4b.sh
@@ -16,6 +16,9 @@
 set -xeuo pipefail # Exit immediately if a command exits with a non-zero status
 
 export CUDA_VISIBLE_DEVICES="0,1"
+# Clean up stale artifacts from previous runs (CI uses fresh containers, cluster does not)
+rm -rf nemo_experiments 2>/dev/null || true
+rm -f .coverage* 2>/dev/null || true
 
 # Run recipe functional tests on 2 GPUs
 # This script tests recipe configurations with their default settings to ensure

--- a/tests/functional_tests/L2_Launch_ckpts_mlm_to_mbridge_qwen3_4b.sh
+++ b/tests/functional_tests/L2_Launch_ckpts_mlm_to_mbridge_qwen3_4b.sh
@@ -16,6 +16,9 @@
 set -xeuo pipefail # Exit immediately if a command exits with a non-zero status
 
 export CUDA_VISIBLE_DEVICES="0,1"
+# Clean up stale artifacts from previous runs (CI uses fresh containers, cluster does not)
+rm -rf nemo_experiments 2>/dev/null || true
+rm -f .coverage* 2>/dev/null || true
 
 # Run recipe functional tests on 2 GPUs
 # This script tests recipe configurations with their default settings to ensure

--- a/tests/functional_tests/L2_Launch_converter.sh
+++ b/tests/functional_tests/L2_Launch_converter.sh
@@ -16,6 +16,9 @@
 set -xeuo pipefail # Exit immediately if a command exits with a non-zero status
 
 export CUDA_VISIBLE_DEVICES="0,1"
+# Clean up stale artifacts from previous runs (CI uses fresh containers, cluster does not)
+rm -rf nemo_experiments 2>/dev/null || true
+rm -f .coverage* 2>/dev/null || true
 
 uv run coverage run --data-file=/opt/Megatron-Bridge/.coverage --source=/opt/Megatron-Bridge/ --parallel-mode -m pytest \
   -o log_cli=true -o log_cli_level=INFO -v -s -x -m "not pleasefixme" --tb=short -rA \

--- a/tests/functional_tests/L2_Launch_data.sh
+++ b/tests/functional_tests/L2_Launch_data.sh
@@ -15,6 +15,10 @@
 #!/bin/bash
 set -xeuo pipefail # Exit immediately if a command exits with a non-zero status
 
+# Clean up stale artifacts from previous runs (CI uses fresh containers, cluster does not)
+rm -rf nemo_experiments 2>/dev/null || true
+rm -f .coverage* 2>/dev/null || true
+
 CUDA_VISIBLE_DEVICES="0,1" uv run coverage run -a --data-file=/opt/Megatron-Bridge/.coverage --source=/opt/Megatron-Bridge/ -m pytest \
     -o log_cli=true \
     -o log_cli_level=INFO \

--- a/tests/functional_tests/L2_Launch_models_deepseek.sh
+++ b/tests/functional_tests/L2_Launch_models_deepseek.sh
@@ -16,6 +16,9 @@
 set -xeuo pipefail # Exit immediately if a command exits with a non-zero status
 
 export CUDA_VISIBLE_DEVICES="0,1"
+# Clean up stale artifacts from previous runs (CI uses fresh containers, cluster does not)
+rm -rf nemo_experiments 2>/dev/null || true
+rm -f .coverage* 2>/dev/null || true
 
 uv run coverage run --data-file=/opt/Megatron-Bridge/.coverage --source=/opt/Megatron-Bridge/ --parallel-mode -m pytest \
   -o log_cli=true -o log_cli_level=INFO -v -s -x -m "not pleasefixme" --tb=short -rA \

--- a/tests/functional_tests/L2_Launch_models_gemma.sh
+++ b/tests/functional_tests/L2_Launch_models_gemma.sh
@@ -16,6 +16,9 @@
 set -xeuo pipefail # Exit immediately if a command exits with a non-zero status
 
 export CUDA_VISIBLE_DEVICES="0,1"
+# Clean up stale artifacts from previous runs (CI uses fresh containers, cluster does not)
+rm -rf nemo_experiments 2>/dev/null || true
+rm -f .coverage* 2>/dev/null || true
 
 uv run coverage run --data-file=/opt/Megatron-Bridge/.coverage --source=/opt/Megatron-Bridge/ --parallel-mode -m pytest \
   -o log_cli=true -o log_cli_level=INFO -v -s -x -m "not pleasefixme" --tb=short -rA \

--- a/tests/functional_tests/L2_Launch_models_gemma_vl.sh
+++ b/tests/functional_tests/L2_Launch_models_gemma_vl.sh
@@ -16,6 +16,9 @@
 set -xeuo pipefail # Exit immediately if a command exits with a non-zero status
 
 export CUDA_VISIBLE_DEVICES="0,1"
+# Clean up stale artifacts from previous runs (CI uses fresh containers, cluster does not)
+rm -rf nemo_experiments 2>/dev/null || true
+rm -f .coverage* 2>/dev/null || true
 
 uv run coverage run --data-file=/opt/Megatron-Bridge/.coverage --source=/opt/Megatron-Bridge/ --parallel-mode -m pytest \
   -o log_cli=true -o log_cli_level=INFO -v -s -x -m "not pleasefixme" --tb=short -rA \

--- a/tests/functional_tests/L2_Launch_models_glm.sh
+++ b/tests/functional_tests/L2_Launch_models_glm.sh
@@ -16,6 +16,9 @@
 set -xeuo pipefail # Exit immediately if a command exits with a non-zero status
 
 export CUDA_VISIBLE_DEVICES="0,1"
+# Clean up stale artifacts from previous runs (CI uses fresh containers, cluster does not)
+rm -rf nemo_experiments 2>/dev/null || true
+rm -f .coverage* 2>/dev/null || true
 
 uv run coverage run --data-file=/opt/Megatron-Bridge/.coverage --source=/opt/Megatron-Bridge/ --parallel-mode -m pytest \
   -o log_cli=true -o log_cli_level=INFO -v -s -x -m "not pleasefixme" --tb=short -rA \

--- a/tests/functional_tests/L2_Launch_models_gpt_oss.sh
+++ b/tests/functional_tests/L2_Launch_models_gpt_oss.sh
@@ -16,6 +16,9 @@
 set -xeuo pipefail # Exit immediately if a command exits with a non-zero status
 
 export CUDA_VISIBLE_DEVICES="0,1"
+# Clean up stale artifacts from previous runs (CI uses fresh containers, cluster does not)
+rm -rf nemo_experiments 2>/dev/null || true
+rm -f .coverage* 2>/dev/null || true
 
 uv run coverage run --data-file=/opt/Megatron-Bridge/.coverage --source=/opt/Megatron-Bridge/ --parallel-mode -m pytest \
   -o log_cli=true -o log_cli_level=INFO -v -s -x -m "not pleasefixme" --tb=short -rA \

--- a/tests/functional_tests/L2_Launch_models_llama_nemotron.sh
+++ b/tests/functional_tests/L2_Launch_models_llama_nemotron.sh
@@ -16,6 +16,9 @@
 set -xeuo pipefail # Exit immediately if a command exits with a non-zero status
 
 export CUDA_VISIBLE_DEVICES="0,1"
+# Clean up stale artifacts from previous runs (CI uses fresh containers, cluster does not)
+rm -rf nemo_experiments 2>/dev/null || true
+rm -f .coverage* 2>/dev/null || true
 
 uv run coverage run --data-file=/opt/Megatron-Bridge/.coverage --source=/opt/Megatron-Bridge/ --parallel-mode -m pytest \
   -o log_cli=true -o log_cli_level=INFO -v -s -x -m "not pleasefixme" --tb=short -rA \

--- a/tests/functional_tests/L2_Launch_models_ministral3.sh
+++ b/tests/functional_tests/L2_Launch_models_ministral3.sh
@@ -16,6 +16,9 @@
 set -xeuo pipefail # Exit immediately if a command exits with a non-zero status
 
 export CUDA_VISIBLE_DEVICES="0,1"
+# Clean up stale artifacts from previous runs (CI uses fresh containers, cluster does not)
+rm -rf nemo_experiments 2>/dev/null || true
+rm -f .coverage* 2>/dev/null || true
 
 uv run coverage run --data-file=/opt/Megatron-Bridge/.coverage --source=/opt/Megatron-Bridge/ --parallel-mode -m pytest \
   -o log_cli=true -o log_cli_level=INFO -v -s -x -m "not pleasefixme" --tb=short -rA \

--- a/tests/functional_tests/L2_Launch_models_mistral.sh
+++ b/tests/functional_tests/L2_Launch_models_mistral.sh
@@ -16,6 +16,9 @@
 set -xeuo pipefail # Exit immediately if a command exits with a non-zero status
 
 export CUDA_VISIBLE_DEVICES="0,1"
+# Clean up stale artifacts from previous runs (CI uses fresh containers, cluster does not)
+rm -rf nemo_experiments 2>/dev/null || true
+rm -f .coverage* 2>/dev/null || true
 
 uv run coverage run --data-file=/opt/Megatron-Bridge/.coverage --source=/opt/Megatron-Bridge/ --parallel-mode -m pytest \
   -o log_cli=true -o log_cli_level=INFO -v -s -x -m "not pleasefixme" --tb=short -rA \

--- a/tests/functional_tests/L2_Launch_models_nemotron.sh
+++ b/tests/functional_tests/L2_Launch_models_nemotron.sh
@@ -16,6 +16,9 @@
 set -xeuo pipefail # Exit immediately if a command exits with a non-zero status
 
 export CUDA_VISIBLE_DEVICES="0,1"
+# Clean up stale artifacts from previous runs (CI uses fresh containers, cluster does not)
+rm -rf nemo_experiments 2>/dev/null || true
+rm -f .coverage* 2>/dev/null || true
 
 uv run coverage run --data-file=/opt/Megatron-Bridge/.coverage --source=/opt/Megatron-Bridge/ --parallel-mode -m pytest \
   -o log_cli=true -o log_cli_level=INFO -v -s -x -m "not pleasefixme" --tb=short -rA \

--- a/tests/functional_tests/L2_Launch_models_nemotron_vl.sh
+++ b/tests/functional_tests/L2_Launch_models_nemotron_vl.sh
@@ -16,6 +16,9 @@
 set -xeuo pipefail # Exit immediately if a command exits with a non-zero status
 
 export CUDA_VISIBLE_DEVICES="0,1"
+# Clean up stale artifacts from previous runs (CI uses fresh containers, cluster does not)
+rm -rf nemo_experiments 2>/dev/null || true
+rm -f .coverage* 2>/dev/null || true
 
 uv run coverage run --data-file=/opt/Megatron-Bridge/.coverage --source=/opt/Megatron-Bridge/ --parallel-mode -m pytest \
   -o log_cli=true -o log_cli_level=INFO -v -s -x -m "not pleasefixme" --tb=short -rA \

--- a/tests/functional_tests/L2_Launch_models_nemotronh.sh
+++ b/tests/functional_tests/L2_Launch_models_nemotronh.sh
@@ -16,6 +16,9 @@
 set -xeuo pipefail # Exit immediately if a command exits with a non-zero status
 
 export CUDA_VISIBLE_DEVICES="0,1"
+# Clean up stale artifacts from previous runs (CI uses fresh containers, cluster does not)
+rm -rf nemo_experiments 2>/dev/null || true
+rm -f .coverage* 2>/dev/null || true
 
 uv run coverage run --data-file=/opt/Megatron-Bridge/.coverage --source=/opt/Megatron-Bridge/ --parallel-mode -m pytest \
   -o log_cli=true -o log_cli_level=INFO -v -s -x -m "not pleasefixme" --tb=short -rA \

--- a/tests/functional_tests/L2_Launch_models_nemotronh_quantization.sh
+++ b/tests/functional_tests/L2_Launch_models_nemotronh_quantization.sh
@@ -16,6 +16,9 @@
 set -xeuo pipefail # Exit immediately if a command exits with a non-zero status
 
 export CUDA_VISIBLE_DEVICES="0,1"
+# Clean up stale artifacts from previous runs (CI uses fresh containers, cluster does not)
+rm -rf nemo_experiments 2>/dev/null || true
+rm -f .coverage* 2>/dev/null || true
 
 uv run coverage run --data-file=/opt/Megatron-Bridge/.coverage --source=/opt/Megatron-Bridge/ --parallel-mode -m pytest \
   -o log_cli=true -o log_cli_level=INFO -v -s -x -m "not pleasefixme" --tb=short -rA \

--- a/tests/functional_tests/L2_Launch_models_olmoe.sh
+++ b/tests/functional_tests/L2_Launch_models_olmoe.sh
@@ -16,6 +16,9 @@
 set -xeuo pipefail # Exit immediately if a command exits with a non-zero status
 
 export CUDA_VISIBLE_DEVICES="0,1"
+# Clean up stale artifacts from previous runs (CI uses fresh containers, cluster does not)
+rm -rf nemo_experiments 2>/dev/null || true
+rm -f .coverage* 2>/dev/null || true
 
 uv run coverage run --data-file=/opt/Megatron-Bridge/.coverage --source=/opt/Megatron-Bridge/ --parallel-mode -m pytest \
   -o log_cli=true -o log_cli_level=INFO -v -s -x -m "not pleasefixme" --tb=short -rA \

--- a/tests/functional_tests/L2_Launch_models_qwen.sh
+++ b/tests/functional_tests/L2_Launch_models_qwen.sh
@@ -16,6 +16,9 @@
 set -xeuo pipefail # Exit immediately if a command exits with a non-zero status
 
 export CUDA_VISIBLE_DEVICES="0,1"
+# Clean up stale artifacts from previous runs (CI uses fresh containers, cluster does not)
+rm -rf nemo_experiments 2>/dev/null || true
+rm -f .coverage* 2>/dev/null || true
 
 uv run coverage run --data-file=/opt/Megatron-Bridge/.coverage --source=/opt/Megatron-Bridge/ --parallel-mode -m pytest \
   -o log_cli=true -o log_cli_level=INFO -v -s -x -m "not pleasefixme" --tb=short -rA \

--- a/tests/functional_tests/L2_Launch_models_qwen35_vl.sh
+++ b/tests/functional_tests/L2_Launch_models_qwen35_vl.sh
@@ -16,6 +16,9 @@
 set -xeuo pipefail
 
 export CUDA_VISIBLE_DEVICES="0,1"
+# Clean up stale artifacts from previous runs (CI uses fresh containers, cluster does not)
+rm -rf nemo_experiments 2>/dev/null || true
+rm -f .coverage* 2>/dev/null || true
 
 uv run coverage run --data-file=/opt/Megatron-Bridge/.coverage --source=/opt/Megatron-Bridge/ --parallel-mode -m pytest \
   -o log_cli=true -o log_cli_level=INFO -v -s -x -m "not pleasefixme" --tb=short -rA \

--- a/tests/functional_tests/L2_Launch_models_qwen_quantization.sh
+++ b/tests/functional_tests/L2_Launch_models_qwen_quantization.sh
@@ -16,6 +16,9 @@
 set -xeuo pipefail # Exit immediately if a command exits with a non-zero status
 
 export CUDA_VISIBLE_DEVICES="0,1"
+# Clean up stale artifacts from previous runs (CI uses fresh containers, cluster does not)
+rm -rf nemo_experiments 2>/dev/null || true
+rm -f .coverage* 2>/dev/null || true
 
 uv run coverage run --data-file=/opt/Megatron-Bridge/.coverage --source=/opt/Megatron-Bridge/ --parallel-mode -m pytest \
   -o log_cli=true -o log_cli_level=INFO -v -s -x -m "not pleasefixme" --tb=short -rA \

--- a/tests/functional_tests/L2_Launch_models_qwen_vl.sh
+++ b/tests/functional_tests/L2_Launch_models_qwen_vl.sh
@@ -16,6 +16,9 @@
 set -xeuo pipefail # Exit immediately if a command exits with a non-zero status
 
 export CUDA_VISIBLE_DEVICES="0,1"
+# Clean up stale artifacts from previous runs (CI uses fresh containers, cluster does not)
+rm -rf nemo_experiments 2>/dev/null || true
+rm -f .coverage* 2>/dev/null || true
 
 uv run coverage run --data-file=/opt/Megatron-Bridge/.coverage --source=/opt/Megatron-Bridge/ --parallel-mode -m pytest \
   -o log_cli=true -o log_cli_level=INFO -v -s -x -m "not pleasefixme" --tb=short -rA \

--- a/tests/functional_tests/L2_Launch_models_qwen_vl_quantization.sh
+++ b/tests/functional_tests/L2_Launch_models_qwen_vl_quantization.sh
@@ -16,6 +16,9 @@
 set -xeuo pipefail # Exit immediately if a command exits with a non-zero status
 
 export CUDA_VISIBLE_DEVICES="0,1"
+# Clean up stale artifacts from previous runs (CI uses fresh containers, cluster does not)
+rm -rf nemo_experiments 2>/dev/null || true
+rm -f .coverage* 2>/dev/null || true
 
 uv run coverage run --data-file=/opt/Megatron-Bridge/.coverage --source=/opt/Megatron-Bridge/ --parallel-mode -m pytest \
   -o log_cli=true -o log_cli_level=INFO -v -s -x -m "not pleasefixme" --tb=short -rA \

--- a/tests/functional_tests/L2_Launch_post_training_quantization.sh
+++ b/tests/functional_tests/L2_Launch_post_training_quantization.sh
@@ -19,6 +19,9 @@ set -xeuo pipefail # Exit immediately if a command exits with a non-zero status
 pip install -q datasets
 
 export CUDA_VISIBLE_DEVICES="0,1"
+# Clean up stale artifacts from previous runs (CI uses fresh containers, cluster does not)
+rm -rf nemo_experiments 2>/dev/null || true
+rm -f .coverage* 2>/dev/null || true
 
 uv run coverage run --data-file=/opt/Megatron-Bridge/.coverage --source=/opt/Megatron-Bridge/ --parallel-mode -m pytest \
   -o log_cli=true -o log_cli_level=INFO -v -s -x -m "not pleasefixme" --tb=short -rA \

--- a/tests/functional_tests/L2_Launch_quantization_aware_training.sh
+++ b/tests/functional_tests/L2_Launch_quantization_aware_training.sh
@@ -19,6 +19,9 @@ set -xeuo pipefail # Exit immediately if a command exits with a non-zero status
 pip install -q datasets
 
 export CUDA_VISIBLE_DEVICES="0,1"
+# Clean up stale artifacts from previous runs (CI uses fresh containers, cluster does not)
+rm -rf nemo_experiments 2>/dev/null || true
+rm -f .coverage* 2>/dev/null || true
 
 uv run coverage run --data-file=/opt/Megatron-Bridge/.coverage --source=/opt/Megatron-Bridge/ --parallel-mode -m pytest \
   -o log_cli=true -o log_cli_level=INFO -v -s -x -m "not pleasefixme" --tb=short -rA \

--- a/tests/functional_tests/L2_Launch_quantization_export.sh
+++ b/tests/functional_tests/L2_Launch_quantization_export.sh
@@ -19,6 +19,9 @@ set -xeuo pipefail # Exit immediately if a command exits with a non-zero status
 pip install -q datasets
 
 export CUDA_VISIBLE_DEVICES="0,1"
+# Clean up stale artifacts from previous runs (CI uses fresh containers, cluster does not)
+rm -rf nemo_experiments 2>/dev/null || true
+rm -f .coverage* 2>/dev/null || true
 
 uv run coverage run --data-file=/opt/Megatron-Bridge/.coverage --source=/opt/Megatron-Bridge/ --parallel-mode -m pytest \
   -o log_cli=true -o log_cli_level=INFO -v -s -x -m "not pleasefixme" --tb=short -rA \

--- a/tests/functional_tests/L2_Launch_recipes_gemma_vl.sh
+++ b/tests/functional_tests/L2_Launch_recipes_gemma_vl.sh
@@ -16,6 +16,9 @@
 set -xeuo pipefail # Exit immediately if a command exits with a non-zero status
 
 export CUDA_VISIBLE_DEVICES="0,1"
+# Clean up stale artifacts from previous runs (CI uses fresh containers, cluster does not)
+rm -rf nemo_experiments 2>/dev/null || true
+rm -f .coverage* 2>/dev/null || true
 
 # Run Gemma3-VL recipe functional tests on 2 GPUs
 # This script tests Gemma3-VL finetune recipe configurations with their default

--- a/tests/functional_tests/L2_Launch_recipes_gpt_oss.sh
+++ b/tests/functional_tests/L2_Launch_recipes_gpt_oss.sh
@@ -16,6 +16,9 @@
 set -xeuo pipefail # Exit immediately if a command exits with a non-zero status
 
 export CUDA_VISIBLE_DEVICES="0,1"
+# Clean up stale artifacts from previous runs (CI uses fresh containers, cluster does not)
+rm -rf nemo_experiments 2>/dev/null || true
+rm -f .coverage* 2>/dev/null || true
 
 # Run GPT-OSS recipe functional tests on 2 GPUs
 # This script tests recipe configurations with their default settings to ensure

--- a/tests/functional_tests/L2_Launch_recipes_llama_1b.sh
+++ b/tests/functional_tests/L2_Launch_recipes_llama_1b.sh
@@ -16,6 +16,9 @@
 set -xeuo pipefail # Exit immediately if a command exits with a non-zero status
 
 export CUDA_VISIBLE_DEVICES="0,1"
+# Clean up stale artifacts from previous runs (CI uses fresh containers, cluster does not)
+rm -rf nemo_experiments 2>/dev/null || true
+rm -f .coverage* 2>/dev/null || true
 
 # Run recipe functional tests on 2 GPUs
 # This script tests recipe configurations with their default settings to ensure

--- a/tests/functional_tests/L2_Launch_recipes_llama_3b.sh
+++ b/tests/functional_tests/L2_Launch_recipes_llama_3b.sh
@@ -16,6 +16,9 @@
 set -xeuo pipefail # Exit immediately if a command exits with a non-zero status
 
 export CUDA_VISIBLE_DEVICES="0,1"
+# Clean up stale artifacts from previous runs (CI uses fresh containers, cluster does not)
+rm -rf nemo_experiments 2>/dev/null || true
+rm -f .coverage* 2>/dev/null || true
 
 # Run recipe functional tests on 2 GPUs
 # This script tests recipe configurations with their default settings to ensure

--- a/tests/functional_tests/L2_Launch_recipes_llama_cuda_graphs.sh
+++ b/tests/functional_tests/L2_Launch_recipes_llama_cuda_graphs.sh
@@ -16,6 +16,9 @@
 set -xeuo pipefail # Exit immediately if a command exits with a non-zero status
 
 export CUDA_VISIBLE_DEVICES="0,1"
+# Clean up stale artifacts from previous runs (CI uses fresh containers, cluster does not)
+rm -rf nemo_experiments 2>/dev/null || true
+rm -f .coverage* 2>/dev/null || true
 
 # Run recipe functional tests on 2 GPUs
 # This script tests recipe configurations with their default settings to ensure

--- a/tests/functional_tests/L2_Launch_recipes_llama_distill.sh
+++ b/tests/functional_tests/L2_Launch_recipes_llama_distill.sh
@@ -16,6 +16,9 @@
 set -xeuo pipefail # Exit immediately if a command exits with a non-zero status
 
 export CUDA_VISIBLE_DEVICES="0,1"
+# Clean up stale artifacts from previous runs (CI uses fresh containers, cluster does not)
+rm -rf nemo_experiments 2>/dev/null || true
+rm -f .coverage* 2>/dev/null || true
 
 # Run distillation recipe functional tests on 2 GPUs
 # This script tests distillation recipe configurations with their default settings to ensure

--- a/tests/functional_tests/L2_Launch_recipes_ministral3.sh
+++ b/tests/functional_tests/L2_Launch_recipes_ministral3.sh
@@ -16,6 +16,9 @@
 set -xeuo pipefail # Exit immediately if a command exits with a non-zero status
 
 export CUDA_VISIBLE_DEVICES="0,1"
+# Clean up stale artifacts from previous runs (CI uses fresh containers, cluster does not)
+rm -rf nemo_experiments 2>/dev/null || true
+rm -f .coverage* 2>/dev/null || true
 
 # Run Ministral 3 recipe functional tests on 2 GPUs
 # This script tests recipe configurations with their default settings to ensure

--- a/tests/functional_tests/L2_Launch_recipes_nemotronh.sh
+++ b/tests/functional_tests/L2_Launch_recipes_nemotronh.sh
@@ -16,6 +16,9 @@
 set -xeuo pipefail # Exit immediately if a command exits with a non-zero status
 
 export CUDA_VISIBLE_DEVICES="0,1"
+# Clean up stale artifacts from previous runs (CI uses fresh containers, cluster does not)
+rm -rf nemo_experiments 2>/dev/null || true
+rm -f .coverage* 2>/dev/null || true
 
 export UB_SKIPMC=""
 if [[ "${GHA_RUNNER:-}" == *"azure"* ]]; then

--- a/tests/functional_tests/L2_Launch_recipes_qwen.sh
+++ b/tests/functional_tests/L2_Launch_recipes_qwen.sh
@@ -16,6 +16,9 @@
 set -xeuo pipefail # Exit immediately if a command exits with a non-zero status
 
 export CUDA_VISIBLE_DEVICES="0,1"
+# Clean up stale artifacts from previous runs (CI uses fresh containers, cluster does not)
+rm -rf nemo_experiments 2>/dev/null || true
+rm -f .coverage* 2>/dev/null || true
 
 # Run recipe functional tests on 2 GPUs
 # This script tests recipe configurations with their default settings to ensure

--- a/tests/functional_tests/L2_Launch_recipes_qwen_vl.sh
+++ b/tests/functional_tests/L2_Launch_recipes_qwen_vl.sh
@@ -16,6 +16,9 @@
 set -xeuo pipefail # Exit immediately if a command exits with a non-zero status
 
 export CUDA_VISIBLE_DEVICES="0,1"
+# Clean up stale artifacts from previous runs (CI uses fresh containers, cluster does not)
+rm -rf nemo_experiments 2>/dev/null || true
+rm -f .coverage* 2>/dev/null || true
 
 # Run Qwen VL recipe functional tests on 2 GPUs
 # This script tests Qwen2.5-VL and Qwen3-VL recipe configurations with their default

--- a/tests/functional_tests/L2_Launch_training.sh
+++ b/tests/functional_tests/L2_Launch_training.sh
@@ -16,6 +16,9 @@
 set -xeuo pipefail # Exit immediately if a command exits with a non-zero status
 
 export CUDA_VISIBLE_DEVICES="0,1"
+# Clean up stale artifacts from previous runs (CI uses fresh containers, cluster does not)
+rm -rf nemo_experiments 2>/dev/null || true
+rm -f .coverage* 2>/dev/null || true
 
 # Run standard tests first (excluding inprocess restart tests)
 uv run python -m torch.distributed.run --nproc_per_node=2 --nnodes=1 -m coverage run --data-file=/opt/Megatron-Bridge/.coverage --source=/opt/Megatron-Bridge/ --parallel-mode -m pytest -o log_cli=true -o log_cli_level=INFO -v -s -x -m "not pleasefixme" --tb=short -rA tests/functional_tests/training -k "not test_inprocess_restart"

--- a/tests/functional_tests/L2_Launch_utils.sh
+++ b/tests/functional_tests/L2_Launch_utils.sh
@@ -16,6 +16,9 @@
 set -xeuo pipefail # Exit immediately if a command exits with a non-zero status
 
 export CUDA_VISIBLE_DEVICES="0,1"
+# Clean up stale artifacts from previous runs (CI uses fresh containers, cluster does not)
+rm -rf nemo_experiments 2>/dev/null || true
+rm -f .coverage* 2>/dev/null || true
 
 uv run coverage run --data-file=/opt/Megatron-Bridge/.coverage --source=/opt/Megatron-Bridge/ --parallel-mode -m pytest \
   -o log_cli=true -o log_cli_level=INFO -v -s -x -m "not pleasefixme" --tb=short -rA \


### PR DESCRIPTION
Add `rm -rf nemo_experiments` and `rm -f .coverage*` at the top of all 41 functional-test launcher scripts.  CI runs in fresh containers so these files never accumulate there, but cluster runs reuse the same workspace and stale artifacts from a previous job can corrupt subsequent test results.

# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added pre-test cleanup steps across all functional test scripts to remove stale artifacts and coverage files. This ensures a clean test environment for each run and reduces test failures potentially caused by residual data from prior executions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->