### PR TITLE
[sync][training] fix: log loss values of exactly 0.0 in training_log()

### DIFF
--- a/src/megatron/bridge/training/utils/train_utils.py
+++ b/src/megatron/bridge/training/utils/train_utils.py
@@ -715,7 +715,7 @@ def training_log(
         for key in total_loss_dict:
             if key not in [advanced_iters_key, skipped_iters_key, nan_iters_key]:
                 avg = total_loss_dict[key].item() / float(max(1, total_loss_dict[advanced_iters_key]))
-                if avg > 0.0:
+                if avg >= 0.0:
                     log_string += " {}: {:.6E} |".format(key, avg)
                 total_loss_dict[key] = torch.tensor([0.0], dtype=torch.float, device="cuda")
         log_string += f" loss scale: {loss_scale:.1f} |"


### PR DESCRIPTION
## Summary

Mirrors MCore fix from [NVIDIA/Megatron-LM#1555](https://github.com/NVIDIA/Megatron-LM/pull/1555) (commit `b09ee64`).

The condition `avg > 0.0` in `training_log()` silently drops loss values that are exactly `0.0` from the training log output. Changing to `avg >= 0.0` ensures zero losses are always logged.

## Changes

- `src/megatron/bridge/training/utils/train_utils.py`: `avg > 0.0` → `avg >= 0.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Training loss logging now correctly includes metrics with zero average loss values, ensuring comprehensive tracking and visibility of all loss entries during training operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->