### PR TITLE
Lm3 70B GB200 FP8_CS SFT cfg update

### DIFF
--- a/scripts/performance/perf_plugins.py
+++ b/scripts/performance/perf_plugins.py
@@ -313,10 +313,6 @@ class PerfEnvPlugin(Plugin):
             if "NVTE_NORM_BWD_USE_CUDNN" in executor.env_vars:
                 executor.env_vars.pop("NVTE_NORM_BWD_USE_CUDNN")
 
-        if gpu == "gb300" and model_recipe_name == "llama3_70b" and train_task == "lora":
-            executor.env_vars["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
-            executor.env_vars["NCCL_GRAPH_REGISTER"] = "0"
-
     def _set_layernorm_sm_margin(
         self,
         task: Union["run.Partial", "run.Script"],


### PR DESCRIPTION
# What does this PR do ?

Increase PP size to avoid OOM caused due to upgrading PyT to 26.02.

# Changelog

```
- pipeline_model_parallel_size=4,
+ pipeline_model_parallel_size=8,
```

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated model performance configuration settings for LLAMA3_70B on GB200 systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->