### PR TITLE
[ci] feat: Add Claude Code Review workflow and disable CodeRabbit

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -23,6 +23,8 @@ language: "en-US"
 # Settings related to reviews.
 # Default: {}
 reviews:
+  # Disable CodeRabbit reviews — using Claude Code Review instead.
+  enabled: false
   # Set the profile for reviews. Assertive profile yields more feedback, that may be considered nitpicky.
   # Options: chill, assertive
   # Default: "chill"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,86 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Claude Code Review
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  review-on-comment:
+    name: Claude Review (comment trigger)
+    if: |
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '/claude review')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPO: ${{ github.repository }}
+      PR_NUMBER: ${{ github.event.issue.number }}
+    steps:
+      - name: Get PR head commit
+        id: get-pr-head-commit
+        run: |
+          echo "sha=$(gh pr view $PR_NUMBER --repo $REPO --json headRefOid -q .headRefOid)" | tee -a $GITHUB_OUTPUT
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          ref: ${{ steps.get-pr-head-commit.outputs.sha }}
+
+      - name: Run Claude Code Review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          trigger_phrase: "/claude review"
+          show_full_output: true
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*)"
+            --model "claude-opus-4-6"
+          prompt: |
+            REPO: ${{ env.REPO }}
+            PR NUMBER: ${{ env.PR_NUMBER }}
+
+            You are doing a light code review for Megatron Bridge, an open-source library that
+            bridges HuggingFace model weights and configs to Megatron-Core for distributed training.
+            The codebase is Python-based with model bridges, config converters, parameter mappings,
+            recipes, and training utilities.
+
+            Keep it concise and actionable.
+
+            Focus ONLY on:
+            - Critical bugs or logic errors
+            - Typos in code, comments, or strings
+            - Missing or insufficient test coverage for changed code
+            - Outdated or inaccurate documentation affected by the changes
+
+            Do NOT comment on:
+            - Style preferences or formatting
+            - Minor naming suggestions
+            - Architectural opinions or refactoring ideas
+            - Performance unless there is a clear, measurable issue
+
+            Provide feedback using inline comments for specific code suggestions.
+            Use top-level comments for general observations.
+
+            It's perfectly acceptable to not have anything to comment on.
+            If you do not have anything to comment on, post "LGTM".

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,22 +155,21 @@ If you have write access to the repository (NVIDIA contributors):
 Format your commit messages and PR titles as:
 
 ```text
-[{modules}] {type}: {description}
+[{areas}] {type}: {description}
 ```
 
-**Modules** (use the most relevant ones, separate multiple with `,`):
-- `model` - Model implementations and bridges
-- `recipe` - Training recipes
-- `training` - Training loop and utilities
-- `data` - Data loading and processing
-- `ckpt` - Checkpoint conversion and saving
-- `peft` - Parameter-efficient fine-tuning (LoRA, etc.)
-- `perf` - Performance optimizations
-- `ci` - CI/CD configuration
-- `doc` - Documentation
-- `test` - Tests
-- `build` - Build system and dependencies
-- `misc` - Other changes
+**Areas** (use the most relevant ones, separate multiple with `,`):
+- `model` - Model implementations and HF bridge logic
+- `recipe` - Training recipes and launch configs
+- `training` - Training loop, callbacks, and runtime integration
+- `data` - Dataset builders, preprocessing, and samplers
+- `ckpt` - Checkpoint conversion, loading, export, and save paths
+- `peft` - PEFT methods (LoRA, adapters) and adapter export
+- `perf` - Performance optimizations and throughput improvements
+- `ci` - CI, automation, and workflow infrastructure
+- `docs` - Documentation, examples, and contributor guidance
+- `build` - Dependencies, packaging, and environment setup
+- `misc` - Cross-cutting utilities and other changes
 
 **Types**:
 - `feat` - New feature
@@ -184,11 +183,132 @@ Format your commit messages and PR titles as:
 **Examples**:
 ```text
 [model] feat: Add Qwen3 model bridge
-[recipe, doc] feat: Add Llama 3.1 70B recipe with documentation
+[recipe, docs] feat: Add Llama 3.1 70B recipe with documentation
 [ckpt] fix: Handle missing keys in HF checkpoint conversion
 [BREAKING][training] refactor: Change optimizer config structure
 [ci, build] chore: Update ruff version
 ```
+
+## 🏷️ Repository Labels and Triage
+
+Megatron Bridge uses a small governance taxonomy so maintainers, oncall, and automation can reason about issues and PRs consistently:
+
+- New issues should start with `needs-triage` and leave triage with one `type` label plus one `area` label.
+- PRs should use one primary `area:*` value in the PR template. State labels such as `needs-author`, `blocked`, and `ready-to-merge` are for routing active work, not for replacing review status or CI details.
+- Release labels such as `r0.3.0`, community labels, and `needs-follow-up` are still valid, but they are orthogonal to the main governance taxonomy.
+
+### Type Labels
+
+Use exactly one type label per issue or PR after triage:
+
+| Label | Use for |
+| --- | --- |
+| `bug` | Incorrect behavior, regressions, or broken workflows |
+| `feature` | New capabilities, enhancements, or enablement work |
+| `support` | Questions, help requests, or user guidance gaps |
+| `docs` | Documentation-only updates or documentation debt |
+| `ci` | CI, automation, test queue, or workflow infrastructure work |
+
+### State Labels
+
+Use at most one state label from this set at a time:
+
+| Label | Meaning |
+| --- | --- |
+| `needs-triage` | New item needs classification and ownership |
+| `needs-review` | PR is ready for code review and waiting on a reviewer |
+| `needs-author` | Author action is required before review or merge can continue |
+| `needs-follow-up` | Issue or PR has finished initial triage/review and needs further follow-up |
+| `blocked` | Work cannot move forward until an external dependency is cleared |
+| `ready-to-merge` | PR is approved, current, and only waiting for CI to pass before merge |
+
+### Risk Labels
+
+Apply only when risk affects review or merge behavior:
+
+| Label | Meaning |
+| --- | --- |
+| `breaking-change` | Public behavior or API compatibility changes |
+| `high-complexity` | Harder to merge: prone to conflicts and needs additional test coverage |
+| `needs-more-tests` | Requires additional test coverage; triggers both L0 and L1 CI test tiers |
+
+### Area Labels
+
+Use one primary area label after triage:
+
+| Label | Scope |
+| --- | --- |
+| `area:model` | Model implementations and HF bridge logic |
+| `area:recipe` | Training recipes and launch configs |
+| `area:training` | Training loop, callbacks, and runtime integration |
+| `area:data` | Dataset builders, preprocessing, and samplers |
+| `area:ckpt` | Checkpoint conversion, loading, export, and save paths |
+| `area:peft` | PEFT methods (LoRA, adapters) and adapter export |
+| `area:perf` | Performance optimizations, kernel integration, and throughput improvements |
+| `area:build` | Dependencies, packaging, images, and environment setup |
+| `area:misc` | Cross-cutting utilities, logging, helpers, and other changes that do not fit a primary domain |
+
+### Orthogonal Labels
+
+This taxonomy does not replace every existing label:
+
+- Keep release labels such as `r0.3.0` as independent scheduling signals.
+- Keep `community-request` and other community-related labels as independent intake signals.
+- Use `needs-follow-up` when an issue or PR should stay explicitly visible to the oncaller across handoffs.
+- Avoid creating new status synonyms when an existing label in this taxonomy already fits.
+
+### Label Application Rules
+
+- New issues should start with `needs-triage`.
+- Issues should leave triage with one `type` label and one `area` label.
+- An issue keeps `needs-triage` until a maintainer has responded or assigned it. Adding type and area labels is classification; the issue leaves `needs-triage` only when a maintainer engages (responds, assigns, or explicitly routes it).
+- After a maintainer engages, transition to `needs-follow-up` (deferred work oncall should track), `needs-author` (waiting on reporter for more info), `blocked` (external dependency), or no state label (actively being worked on).
+- PRs should not use `needs-triage`. Use `needs-author`, `blocked`, or `ready-to-merge` only when they help route work.
+- `high-complexity` starts as a manual maintainer label, not an automated heuristic.
+- `needs-follow-up` should usually point to a linked issue instead of staying on a merged PR.
+- `needs-follow-up` is the visibility label for deferred work that should stay on the oncall radar.
+- `needs-follow-up` can be combined with `blocked` when the oncaller should keep watching a blocked item.
+- If a PR is marked `breaking-change`, do not treat it as auto-mergeable even if CI is green.
+
+### Daily Views
+
+These four views are the core daily queues maintainers and oncall should watch.
+
+#### Needs Triage
+
+- Scope: open issues labeled `needs-triage`
+- Goal: assign one `type` and one `area`
+- Suggested query: `is:issue is:open label:"needs-triage" sort:updated-asc`
+
+#### Ready To Merge
+
+- Scope: open PRs labeled `ready-to-merge`
+- Goal: surface PRs that should merge without rereading every CI detail
+- Suggested query: `is:pr is:open label:"ready-to-merge" draft:false sort:updated-asc`
+
+#### Blocked Or Needs Follow-Up
+
+- Scope: open issues and PRs labeled `blocked` or `needs-follow-up`
+- Goal: make blockers and deferred work visible across handoffs
+- Suggested query: `is:open (label:"blocked" OR label:"needs-follow-up") sort:updated-asc`
+
+#### High Complexity
+
+- Scope: open PRs labeled `high-complexity`
+- Goal: proactively review, rebase, and ensure adequate test coverage before conflicts waste CI and reviewer time
+- Suggested query: `is:pr is:open label:"high-complexity" sort:updated-asc`
+
+#### Recommended Columns
+
+If you mirror these queues into a GitHub Project, keep the columns and sort keys small:
+
+- item title
+- primary area
+- owner or assignee
+- age
+- last updated time
+- release label
+- current state
 
 ## 📝 Writing Tests
 
@@ -359,6 +479,31 @@ You can find the commit SHA in several ways:
 - View your pull request's commit history on GitHub
 - Run `git log --oneline -1` in your local repository
 - Check the commit details in your Git client
+
+## 🔍 AI Code Review
+
+Megatron Bridge uses [Claude Code Review](https://github.com/anthropics/claude-code-action) for on-demand AI-assisted code review on pull requests.
+
+### Requesting a Review
+
+Comment on any open PR:
+
+```
+/claude review
+```
+
+Claude will review the diff and provide feedback via inline comments and a top-level summary. The review focuses on critical bugs, logic errors, typos, missing tests, and outdated documentation. It does not comment on style, naming, or architecture.
+
+### How It Works
+
+The review is powered by the `.github/workflows/claude-review.yml` workflow, which:
+
+1. Triggers on issue comments containing `/claude review`
+2. Checks out the PR's head commit
+3. Runs Claude (Opus 4.6) with access to the diff and PR context
+4. Posts inline comments for specific suggestions and a top-level comment for general observations
+
+If everything looks good, Claude posts "LGTM".
 
 ## 🤖 Contributing Models
 


### PR DESCRIPTION
## Summary

- Add `.github/workflows/claude-review.yml` — on-demand AI code review triggered by `/claude review` comment on PRs, using `anthropics/claude-code-action@v1` with Opus 4.6
- Disable CodeRabbit reviews in `.coderabbit.yaml` (`enabled: false`)
- Document the Claude review workflow in `CONTRIBUTING.md` under a new "AI Code Review" section

Adapted from NVIDIA/Megatron-LM PRs #3679, #3685, #3704, #3707, #3709, #3727, #3745, #3756, #3760.

## Prerequisites

Before the workflow is functional:
1. Install the [Claude GitHub App](https://github.com/apps/claude/) on this repository
2. Set `ANTHROPIC_API_KEY` in repository secrets (from "Shared-nemo-ci" LastPass vault, "Inference Claude Key")

## Test plan

- [ ] Verify Claude GitHub App is installed and approved
- [ ] Verify `ANTHROPIC_API_KEY` secret is set
- [ ] Comment `/claude review` on a test PR and confirm Claude responds with a review

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Claude Code Review integration for pull requests—comment "/claude review" to request inline code analysis.

* **Documentation**
  * Updated contributing guidelines with repository labels, test organization guidance, and AI code review workflow documentation.

* **Chores**
  * Disabled CodeRabbit reviews in favor of Claude Code Review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->