### PR TITLE
[test] fix: temporarily disable qwen2.5 omni unit tests

### DIFF
--- a/tests/unit_tests/models/qwen_omni/modeling_qwen25_omni/test_omni_model.py
+++ b/tests/unit_tests/models/qwen_omni/modeling_qwen25_omni/test_omni_model.py
@@ -67,6 +67,7 @@ def random_audio():
     return np.random.randint(-1, 32767, size=(800), dtype=np.int16)
 
 
+@pytest.mark.pleasefixme  # TODO: replace full-size HF vision/audio encoders with dummy stubs to avoid timeout
 class TestQwen25OmniModel:
     """Test suite for Qwen2.5 Omni Model."""
 


### PR DESCRIPTION
## What does this PR do?

Temporarily disables the `TestQwen25OmniModel` test class with `@pytest.mark.pleasefixme` to unblock CI.

## Why?

The tests introduced in #2634 instantiate full-size HF vision and audio encoders (`Qwen2_5OmniVisionEncoder`, `Qwen2_5OmniAudioEncoder`) at real Qwen2.5-Omni-7B dimensions. `test_shared_embedding_or_output_weight` constructs **two** such models in a single test with a 50s timeout, which is causing CI timeouts on other PRs (e.g. #2004).

## Follow-up needed

Replace the full-size HF encoders with lightweight dummy stubs so the tests run fast and can be re-enabled. cc @yuekaizhang

## Changelog

- Mark `TestQwen25OmniModel` with `@pytest.mark.pleasefixme` to skip in CI


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test annotations to track pending improvements for enhanced reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->