### PR TITLE
NVFP4 memory spike fix compared to M-LM

### DIFF
--- a/src/megatron/bridge/training/mixed_precision.py
+++ b/src/megatron/bridge/training/mixed_precision.py
@@ -400,6 +400,7 @@ def bf16_with_nvfp4_mixed() -> MixedPrecisionConfig:
     cfg.fp4 = "e2m1"
     cfg.fp4_recipe = "nvfp4"
     cfg.fp8_param_gather = False
+    cfg.fp8_recipe = None
     return cfg
 
 


### PR DESCRIPTION
Sets the default fp8_recipe to None for FP4 training recipes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected mixed precision training configuration to ensure proper handling of FP8 precision modes when using NVFP4 alongside BF16.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->