### PR TITLE
fix: disable MoE overlap and delayed wgrad during model load

### DIFF
--- a/src/megatron/bridge/training/model_load_save.py
+++ b/src/megatron/bridge/training/model_load_save.py
@@ -386,6 +386,8 @@ def load_megatron_model(
     model_cfg.perform_initialization = False
     model_cfg.virtual_pipeline_model_parallel_size = None
     model_cfg.hierarchical_context_parallel_sizes = None
+    model_cfg.overlap_moe_expert_parallel_comm = False # Required with EP=1
+    model_cfg.delay_wgrad_compute = False # Required with overlap=False
     if use_cpu_init:
         model_cfg.fp8 = None
         model_cfg.fp8_param = False

--- a/src/megatron/bridge/training/model_load_save.py
+++ b/src/megatron/bridge/training/model_load_save.py
@@ -386,8 +386,8 @@ def load_megatron_model(
     model_cfg.perform_initialization = False
     model_cfg.virtual_pipeline_model_parallel_size = None
     model_cfg.hierarchical_context_parallel_sizes = None
-    model_cfg.overlap_moe_expert_parallel_comm = False # Required with EP=1
-    model_cfg.delay_wgrad_compute = False # Required with overlap=False
+    model_cfg.overlap_moe_expert_parallel_comm = False  # Required with EP=1
+    model_cfg.delay_wgrad_compute = False  # Required with overlap=False
     if use_cpu_init:
         model_cfg.fp8 = None
         model_cfg.fp8_param = False


### PR DESCRIPTION
# What does this PR do ?

Disabled MoE overlap & delayed wgrad when loading model for export. This is because the export overrides the config setting EP=1, which requires MoE to be False (https://github.com/NVIDIA/Megatron-LM/blob/main/megatron/core/transformer/transformer_config.py#L2049-L2050), which in turn requires delayed wgrad to be False (https://github.com/NVIDIA/Megatron-LM/blob/main/megatron/core/transformer/transformer_config.py#L2096-L2097). 

# Changelog

- Disabled MoE overlap & delayed wgrad when loading model for export.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [v] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated model loading configuration to establish proper defaults for expert parallel communication and gradient computation behavior, ensuring stable and consistent model initialization across deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->