### PR TITLE
added logic for specific checkpointing directory. Affecting llama31 a…

### DIFF
--- a/scripts/performance/setup_experiment.py
+++ b/scripts/performance/setup_experiment.py
@@ -271,6 +271,17 @@ def main(
     if pretrained_checkpoint is not None:
         custom_mounts.append(f"{pretrained_checkpoint}:{pretrained_checkpoint}")
 
+    if (
+        not dgxc_cluster
+        and getattr(args, "save_dir", None) is not None
+        and args.save_dir
+    ):
+        save_dir_parent = str(Path(args.save_dir).resolve().parent)
+        save_dir_mount = f"{save_dir_parent}:{save_dir_parent}"
+        if save_dir_mount not in custom_mounts:
+            custom_mounts.append(save_dir_mount)
+            logger.info(f"Added checkpoint save directory mount for container: {save_dir_mount}")
+
     run_script_path = SCRIPT_DIR / script_name
     logger.info(f"Run script path: {run_script_path}")
     if not run_script_path.is_file():


### PR DESCRIPTION
added logic for specifying checkpointing directory. Affecting llama31 and gpt-oss. Joy was seeing issue here:https://nvbugspro.nvidia.com/bug/5971374 where she was seeing an issue with specifying a specific checkpointing directory, she was seeing that issue because: the checkpoint save_dir must be mounted so writes persist to the host. At the moment it was writing to its local filesystem and the directory disappears when the job ends.

This PR resolves this issue. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced checkpoint directory handling for non-DGXC environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->