### PR TITLE
fix: Allow building trt-llm 1.2.0

### DIFF
--- a/docker/Dockerfile.fw_base
+++ b/docker/Dockerfile.fw_base
@@ -59,6 +59,7 @@ RUN git clone https://github.com/vllm-project/vllm.git . && \
 FROM base AS trtllm_repo
 
 ARG TRT_LLM_COMMIT
+ARG CUDA_VER
 ARG NVRTC_VER
 ARG TRT_VER
 
@@ -75,6 +76,7 @@ RUN git clone https://github.com/NVIDIA/TensorRT-LLM . && \
     git submodule update --init --recursive && \
     git lfs install && git lfs pull && \
     sed -i "s/NVRTC_VER=\"[^\"]*\"/NVRTC_VER=\"${NVRTC_VER}\"/g" /src/tensorrt_llm/docker/common/install_tensorrt.sh && \
+    sed -i "s/TRT_CUDA_VERSION=\"[^\"]*\"/TRT_CUDA_VERSION=\"${CUDA_VER}\"/g" /src/tensorrt_llm/docker/common/install_tensorrt.sh && \
     sed -i "s/CUDA_RUNTIME==\"[^\"]*\"/CUDA_RUNTIME==\"${NVRTC_VER}\"/g" /src/tensorrt_llm/docker/common/install_tensorrt.sh && \
     sed -i "/triton/d" requirements.txt && \
     sed -i "s/tensorrt~=[0-9.]*/tensorrt~=${TRT_VER}/g" requirements.txt && \
@@ -250,7 +252,7 @@ RUN export LD_LIBRARY_PATH=/opt/amazon/efa/lib:/opt/amazon/openmpi/lib:${LD_LIBR
     && cd .. \
     && rm -rf aws-ofi-nccl-${AWS_OFI_NCCL_VERSION//v} \
     && rm aws-ofi-nccl-${AWS_OFI_NCCL_VERSION//v}.tar.gz
-    
+
 ##############################################################################
 ##
 ## Reinstall CUDA toolkit packages


### PR DESCRIPTION
# What does this PR do ?

fix: Allow building trt-llm 1.2.0

We need to correct the trt-llm 1.2.0 install script to allow setting the correct TRT_CUDA_VERSION.

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced Docker build configuration to support configurable CUDA versions, enabling customization during image builds.
  * Improved consistency of CUDA version parameters across the TensorRT-LLM build pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->