### PR TITLE
fix: correctly handle rope_scaling dicts for MLA providers

### DIFF
--- a/src/megatron/bridge/models/conversion/model_bridge.py
+++ b/src/megatron/bridge/models/conversion/model_bridge.py
@@ -379,33 +379,41 @@ class MegatronModelBridge(MegatronPeftBridge, Generic[HFPreTrained, ModelProvide
         is_mla_provider = self.PROVIDER_CLASS is not None and issubclass(self.PROVIDER_CLASS, MLAModelProvider)
         rope_scaling = getattr(hf_config, "rope_scaling", None)
 
-        if rope_scaling is not None and isinstance(rope_scaling, dict):
+        rope_type = None
+        if rope_scaling is not None and isinstance(rope_scaling, dict) and rope_scaling != {}:
             rope_type = rope_scaling.get("type") or rope_scaling.get("rope_type")
-            if rope_type == "yarn":
-                # Check if this is an MLA provider (uses direct field names)
-                # or a GPT provider (uses yarn_ prefixed field names)
-                if is_mla_provider:
-                    # MLA models: use direct field names (mscale, rotary_scaling_factor, etc.)
-                    mla_params = {}
-                    for hf_key, megatron_key in self.MLA_ROPE_SCALING_MAPPING:
-                        value = rope_scaling.get(hf_key)
-                        if value is not None:
-                            mla_params[megatron_key] = value
-                    if mla_params:
-                        provider_kwargs["_mla_rope_params"] = mla_params
-                else:
-                    # GPT models: use yarn_ prefixed field names (dataclass fields on GPTModelProvider)
-                    provider_kwargs["position_embedding_type"] = "yarn"
-                    for hf_key, megatron_key in self.YARN_ROPE_SCALING_MAPPING:
-                        value = rope_scaling.get(hf_key)
-                        if value is not None:
-                            provider_kwargs[megatron_key] = value
-                    if "truncate" in rope_scaling:
-                        provider_kwargs["yarn_correction_range_round_to_int"] = rope_scaling["truncate"]
+
+        if rope_type == "yarn":
+            # Check if this is an MLA provider (uses direct field names)
+            # or a GPT provider (uses yarn_ prefixed field names)
+            if is_mla_provider:
+                # MLA models: use direct field names (mscale, rotary_scaling_factor, etc.)
+                mla_params = {}
+                for hf_key, megatron_key in self.MLA_ROPE_SCALING_MAPPING:
+                    value = rope_scaling.get(hf_key)
+                    if value is not None:
+                        mla_params[megatron_key] = value
+                if mla_params:
+                    provider_kwargs["_mla_rope_params"] = mla_params
+            else:
+                # GPT models: use yarn_ prefixed field names (dataclass fields on GPTModelProvider)
+                provider_kwargs["position_embedding_type"] = "yarn"
+                for hf_key, megatron_key in self.YARN_ROPE_SCALING_MAPPING:
+                    value = rope_scaling.get(hf_key)
+                    if value is not None:
+                        provider_kwargs[megatron_key] = value
+                if "truncate" in rope_scaling:
+                    provider_kwargs["yarn_correction_range_round_to_int"] = rope_scaling["truncate"]
         elif is_mla_provider:
-            # MLA provider without rope_scaling in HF config:
-            # Override rotary_scaling_factor to 1.0 (no scaling) instead of
-            # using MLATransformerConfig default of 40
+            if rope_type not in (None, "default"):
+                logger.warning(
+                    f"Unsupported {rope_type=} for MLA model; "
+                    "defaulting to no scaling (rotary_scaling_factor=1.0, mscale_all_dim=1.0). "
+                    "Add explicit handling for this rope_type if the model requires it."
+                )
+            # Fill in 1.0 for any missing keys to avoid Megatron's MLATransformerConfig defaults
+            # (rotary_scaling_factor=40, mscale_all_dim=0.0), which are hardcoded for DeepSeek-V3's
+            # YaRN config and are wrong for models without yarn scaling.
             provider_kwargs["_mla_rope_params"] = {"rotary_scaling_factor": 1.0, "mscale_all_dim": 1.0}
 
         # Handle vocab_size_divisible_by


### PR DESCRIPTION
## Summary
- Restructure `rope_scaling` handling in `MegatronModelBridge` so that yarn-specific logic is gated on `rope_type == 'yarn'` only
- All other cases (no `rope_scaling`, empty dict, `rope_type='default'`, or any unknown type) fall into a single `elif is_mla_provider` branch that overrides `rotary_scaling_factor=1.0` / `mscale_all_dim=1.0`
- Fixes logprob mismatches between vLLM and Megatron for models like Moonlight/Moonshot whose HF config has `rope_scaling={'rope_theta': ..., 'rope_type': 'default'}` — previously this non-empty dict with a non-yarn type silently fell through all branches, leaving `MLATransformerConfig`'s default `rotary_scaling_factor=40` in place

## Test plan
- [x] Run GRPO with Moonlight 16BA3B and verify `gen_kl_error` is within expected range: https://wandb.ai/nvidia/nemo-rl/runs/vohhc8s3/logs

Made with [Cursor](https://cursor.com)