### PR TITLE
Fix Megatron->HF export when PP>1 for Qwen3.5 VL MoE models with MTP enabled

### DIFF
--- a/src/megatron/bridge/models/conversion/model_bridge.py
+++ b/src/megatron/bridge/models/conversion/model_bridge.py
@@ -1060,7 +1060,13 @@ class MegatronModelBridge(MegatronPeftBridge, Generic[HFPreTrained, ModelProvide
         _grouped_buffers: Dict[str, Dict[int, torch.Tensor]] = {}
 
         for task in self._with_progress_tracking(megatron_to_hf_tasks, "Converting to HuggingFace", show_progress):
-            converted_weights_dict = task.mapping.megatron_to_hf(task.param_weight, task.megatron_module)
+            megatron_weights = task.param_weight
+            megatron_module = task.megatron_module
+            if self._should_skip_mtp_duplicate_embedding_export(task, megatron_model):
+                megatron_weights = None
+                megatron_module = None
+
+            converted_weights_dict = task.mapping.megatron_to_hf(megatron_weights, megatron_module)
 
             # --- Grouped export path: accumulate per-expert weights, yield when complete ---
             if getattr(task.mapping, "is_grouped_export", False):
@@ -1288,6 +1294,29 @@ class MegatronModelBridge(MegatronPeftBridge, Generic[HFPreTrained, ModelProvide
                 torch.distributed.broadcast(embd_weights, src=embd_group_ranks[0], group=embd_group)
                 if hasattr(unwrapped_model, "output_layer"):
                     unwrapped_model.output_layer.weight.data.copy_(embd_weights)
+
+    def _should_skip_mtp_duplicate_embedding_export(
+        self,
+        task: WeightConversionTask,
+        megatron_model: List[MegatronModel],
+    ) -> bool:
+        """Treat duplicate MTP embedding copies as PP receivers during export."""
+        if task.vp_stage is None or not 0 <= task.vp_stage < len(megatron_model):
+            return False
+
+        if not task.global_param_name.endswith("embedding.word_embeddings.weight"):
+            return False
+
+        model_chunk = unwrap_model(megatron_model[task.vp_stage])
+        model_config = getattr(model_chunk, "config", None)
+        if getattr(model_config, "pipeline_model_parallel_size", 1) <= 1:
+            return False
+
+        if getattr(model_chunk, "pre_process", False):
+            return False
+
+        inner_model = getattr(model_chunk, "language_model", model_chunk)
+        return bool(getattr(inner_model, "mtp_process", False))
 
     def build_conversion_tasks(
         self,

--- a/tests/unit_tests/models/qwen_vl/test_qwen35_vl_bridge.py
+++ b/tests/unit_tests/models/qwen_vl/test_qwen35_vl_bridge.py
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import pytest
 import torch
 
 from megatron.bridge.models.conversion.mapping_registry import MegatronMappingRegistry
+from megatron.bridge.models.conversion.model_bridge import WeightConversionTask
 from megatron.bridge.models.hf_pretrained.vlm import PreTrainedVLM
 from megatron.bridge.models.qwen_vl.qwen35_vl_bridge import Qwen35VLBridge, Qwen35VLMoEBridge
 from megatron.bridge.models.qwen_vl.qwen35_vl_provider import (
@@ -107,6 +109,7 @@ def _make_vision_config():
 
 
 def _make_mock_pretrained(text_config, vision_config, tie_word_embeddings=False):
+    """Create a minimal VLM pretrained wrapper for provider tests."""
     pretrained = Mock(spec=PreTrainedVLM)
     config = Mock()
     config.text_config = text_config
@@ -375,3 +378,218 @@ class TestQwen35VLMoEBridgeMappingRegistry:
     def test_mapping_registry_has_vision_params(self, bridge):
         names = self._get_mapping_names(bridge.mapping_registry())
         assert any("visual" in n or "vision_model" in n for n in names)
+
+
+@pytest.mark.unit
+@pytest.mark.skipif(not _TRANSFORMERS_HAS_QWEN3_5_MOE, reason="transformers does not have qwen3_5_moe support")
+class TestQwen35VLMoEBridgeExport:
+    def test_maybe_modify_converted_hf_weight_keeps_explicit_mtp_expert_keys(self, monkeypatch):
+        """Preserve already-expanded MTP expert keys without extra regrouping."""
+        bridge = Qwen35VLMoEBridge()
+        bridge.hf_config = Mock()
+        bridge.hf_config.text_config = Mock()
+        bridge.hf_config.text_config.num_experts = 256
+
+        monkeypatch.setattr(
+            "megatron.bridge.models.conversion.model_bridge.parallel_state.get_expert_model_parallel_world_size",
+            lambda: 8,
+        )
+
+        task = Mock()
+        task.param_name = "language_model.mtp.layers.0.mtp_model_layer.mlp.experts.linear_fc1.weight0"
+        converted = {
+            "mtp.layers.0.mlp.experts.0.gate_proj.weight": torch.ones(2, 2),
+            "mtp.layers.0.mlp.experts.32.gate_proj.weight": 2 * torch.ones(2, 2),
+            "mtp.layers.0.mlp.experts.0.up_proj.weight": 3 * torch.ones(2, 2),
+            "mtp.layers.0.mlp.experts.32.up_proj.weight": 4 * torch.ones(2, 2),
+        }
+
+        result = bridge.maybe_modify_converted_hf_weight(task, dict(converted), {})
+
+        assert result.keys() == converted.keys()
+        for key in converted:
+            torch.testing.assert_close(result[key], converted[key])
+
+    def test_stream_weights_megatron_to_hf_skips_mtp_duplicate_embedding_export(self, monkeypatch):
+        """Skip the last-stage MTP embedding copy when exporting shared vocab weights."""
+        bridge = Qwen35VLMoEBridge()
+        calls = []
+
+        class DummyMapping:
+            def megatron_to_hf(self, weight, module):
+                calls.append((weight, module))
+                return {}
+
+        config = SimpleNamespace(share_embeddings_and_output_weights=False, pipeline_model_parallel_size=2)
+        stage0 = SimpleNamespace(pre_process=True, config=config)
+        wrapped_stage1 = SimpleNamespace(
+            module=SimpleNamespace(
+                pre_process=False,
+                config=config,
+                language_model=SimpleNamespace(mtp_process=True),
+            )
+        )
+        duplicate_module = Mock()
+        task = WeightConversionTask(
+            param_name="language_model.embedding.word_embeddings.weight",
+            global_param_name="language_model.embedding.word_embeddings.weight",
+            mapping=DummyMapping(),
+            pp_rank=1,
+            vp_stage=1,
+            megatron_module=duplicate_module,
+            param_weight=torch.ones(1),
+        )
+
+        monkeypatch.setattr(
+            Qwen35VLMoEBridge,
+            "_with_progress_tracking",
+            lambda self, tasks, *_args, **_kwargs: tasks,
+        )
+        monkeypatch.setattr(
+            Qwen35VLMoEBridge,
+            "maybe_modify_converted_hf_weight",
+            lambda self, *_args, **_kwargs: _args[1],
+        )
+        monkeypatch.setattr(
+            "megatron.bridge.models.conversion.model_bridge.unwrap_model",
+            lambda model, *_args, **_kwargs: [model[0]]
+            if isinstance(model, list)
+            else getattr(model, "module", model),
+        )
+
+        weights = list(
+            bridge.stream_weights_megatron_to_hf(
+                [stage0, wrapped_stage1],
+                SimpleNamespace(),
+                cpu=False,
+                show_progress=False,
+                conversion_tasks=[task],
+                merge_adapter_weights=False,
+            )
+        )
+
+        assert weights == []
+        assert len(calls) == 1
+        assert calls[0] == (None, None)
+
+    def test_stream_weights_megatron_to_hf_keeps_pre_process_embedding_owner(self, monkeypatch):
+        """Keep the first-stage embedding owner active during export."""
+        bridge = Qwen35VLMoEBridge()
+        calls = []
+        embedding_weight = torch.ones(1)
+        embedding_module = Mock()
+
+        class DummyMapping:
+            def megatron_to_hf(self, weight, module):
+                calls.append((weight, module))
+                return {"hf.weight": weight}
+
+        stage0 = SimpleNamespace(
+            pre_process=True,
+            config=SimpleNamespace(share_embeddings_and_output_weights=False, pipeline_model_parallel_size=2),
+            language_model=SimpleNamespace(mtp_process=False),
+        )
+        task = WeightConversionTask(
+            param_name="language_model.embedding.word_embeddings.weight",
+            global_param_name="language_model.embedding.word_embeddings.weight",
+            mapping=DummyMapping(),
+            pp_rank=0,
+            vp_stage=0,
+            megatron_module=embedding_module,
+            param_weight=embedding_weight,
+        )
+
+        monkeypatch.setattr(
+            Qwen35VLMoEBridge,
+            "_with_progress_tracking",
+            lambda self, tasks, *_args, **_kwargs: tasks,
+        )
+        monkeypatch.setattr(
+            Qwen35VLMoEBridge,
+            "maybe_modify_converted_hf_weight",
+            lambda self, *_args, **_kwargs: _args[1],
+        )
+        monkeypatch.setattr(
+            "megatron.bridge.models.conversion.model_bridge.unwrap_model",
+            lambda model, *_args, **_kwargs: [model[0]]
+            if isinstance(model, list)
+            else getattr(model, "module", model),
+        )
+
+        weights = list(
+            bridge.stream_weights_megatron_to_hf(
+                [stage0],
+                SimpleNamespace(),
+                cpu=False,
+                show_progress=False,
+                conversion_tasks=[task],
+                merge_adapter_weights=False,
+            )
+        )
+
+        assert len(weights) == 1
+        assert weights[0].param_name == "hf.weight"
+        assert len(calls) == 1
+        assert calls[0][0] is embedding_weight
+        assert calls[0][1] is embedding_module
+
+    def test_stream_weights_megatron_to_hf_does_not_skip_mtp_embedding_without_pp(self, monkeypatch):
+        """Do not suppress the only owner when pipeline parallelism is disabled."""
+        bridge = Qwen35VLMoEBridge()
+        calls = []
+        embedding_weight = torch.ones(1)
+        embedding_module = Mock()
+
+        class DummyMapping:
+            def megatron_to_hf(self, weight, module):
+                calls.append((weight, module))
+                return {"hf.weight": weight}
+
+        stage0 = SimpleNamespace(
+            pre_process=False,
+            config=SimpleNamespace(share_embeddings_and_output_weights=False, pipeline_model_parallel_size=1),
+            language_model=SimpleNamespace(mtp_process=True),
+        )
+        task = WeightConversionTask(
+            param_name="language_model.embedding.word_embeddings.weight",
+            global_param_name="language_model.embedding.word_embeddings.weight",
+            mapping=DummyMapping(),
+            pp_rank=0,
+            vp_stage=0,
+            megatron_module=embedding_module,
+            param_weight=embedding_weight,
+        )
+
+        monkeypatch.setattr(
+            Qwen35VLMoEBridge,
+            "_with_progress_tracking",
+            lambda self, tasks, *_args, **_kwargs: tasks,
+        )
+        monkeypatch.setattr(
+            Qwen35VLMoEBridge,
+            "maybe_modify_converted_hf_weight",
+            lambda self, *_args, **_kwargs: _args[1],
+        )
+        monkeypatch.setattr(
+            "megatron.bridge.models.conversion.model_bridge.unwrap_model",
+            lambda model, *_args, **_kwargs: [model[0]]
+            if isinstance(model, list)
+            else getattr(model, "module", model),
+        )
+
+        weights = list(
+            bridge.stream_weights_megatron_to_hf(
+                [stage0],
+                SimpleNamespace(),
+                cpu=False,
+                show_progress=False,
+                conversion_tasks=[task],
+                merge_adapter_weights=False,
+            )
+        )
+
+        assert len(weights) == 1
+        assert weights[0].param_name == "hf.weight"
+        assert len(calls) == 1
+        assert calls[0][0] is embedding_weight
+        assert calls[0][1] is embedding_module


### PR DESCRIPTION
# What does this PR do ?

The export path could treat the MTP-stage duplicate embedding as a second PP owner for `embedding.word_embeddings.weight`, which caused `broadcast_from_pp_rank()` to fail with:

```text
ValueError: Tensor exists on more than one PP rank. Found on ranks 0 and 1.
```

This change makes the export path treat that duplicate MTP embedding copy as a PP receiver, while keeping the first-stage embedding as the canonical owner.

# Changelog

- makes the export path treat that duplicate MTP embedding copy as a PP receiver

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [X] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [X] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved model export process to optimize embedding weight handling during Megatron to HuggingFace conversion, reducing redundant weight exports.

* **Tests**
  * Added comprehensive tests for Qwen35VL model export functionality, validating weight conversion and streaming behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->