### PR TITLE
Integrate ModelConfig & ModelBuilder interface into conversion

### DIFF
--- a/src/megatron/bridge/models/conversion/auto_bridge.py
+++ b/src/megatron/bridge/models/conversion/auto_bridge.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import dataclasses
+import os
 from functools import cached_property, partial
 from pathlib import Path
 from typing import Any, Generic, Iterable, List, Optional, Type, TypeVar, Union
@@ -38,6 +39,7 @@ from megatron.bridge.models.hf_pretrained.causal_lm import PreTrainedCausalLM, _
 from megatron.bridge.models.hf_pretrained.safe_config_loader import safe_load_config_with_retry
 from megatron.bridge.models.hf_pretrained.state import SafeTensorsStateSource
 from megatron.bridge.models.model_provider import GetModelKwargs, ModelParallelKwargs, ModelProviderMixin
+from src.megatron.bridge.models.common import ModelConfig
 
 
 MegatronModelT = TypeVar("MegatronModelT", bound=MegatronModule)
@@ -878,13 +880,63 @@ class AutoBridge(Generic[MegatronModelT]):
         hf_path: str | Path | None = None,
         **kwargs: Unpack[GetModelKwargs],
     ) -> list[MegatronModelT]:
-        provider = self.to_megatron_provider(load_weights, hf_path)
+        from megatron.core.process_groups_config import ProcessGroupCollection
 
-        # Finalize the provider before creating models
-        if hasattr(provider, "finalize"):
-            provider.finalize()
+        config = self.to_megatron_config(load_weights, hf_path)
 
-        return provider.provide_distributed_model(**kwargs)
+        if hasattr(config, "finalize"):
+            config.finalize()
+
+        pg_collection = kwargs.pop("pg_collection", None)
+        if pg_collection is None:
+            _initialize_torch_distributed()
+            _initialize_parallel_state(config, seed=0)
+            pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+
+        builder = config.get_builder_cls()(config)
+        return builder.build_distributed_models(
+            pg_collection=pg_collection,
+            **kwargs,
+        )
+
+    def to_megatron_config(self, load_weights: bool = True, hf_path: str | Path | None = None) -> ModelConfig:
+        provider_input = self._provider_bridge_input
+        model_config: ModelConfig = self._model_bridge.config_bridge(provider_input)
+
+        if load_weights:
+            if hf_path is None and not isinstance(self.hf_pretrained, PreTrainedCausalLM):
+                raise ValueError(
+                    "AutoBridge.from_hf_config() does not include weights. "
+                    "Pass load_weights=False for random initialization or provide hf_path to load weights."
+                )
+            # Skip weights initialization since we are going to load weights
+            setattr(model_config, "perform_initialization", False)
+            if hf_path is None:
+                model_config.pre_wrap_hooks.append(
+                    partial(self._model_bridge.load_weights_hf_to_megatron, self.hf_pretrained)
+                )
+            else:
+                # Load from specified path
+                trust_remote_code = getattr(self.hf_pretrained, "trust_remote_code", False)
+                pre_trained = PreTrainedCausalLM.from_pretrained(hf_path, trust_remote_code=trust_remote_code)
+                model_config.pre_wrap_hooks.append(
+                    partial(self._model_bridge.load_weights_hf_to_megatron, pre_trained)
+                )
+
+        hf_identifier: str | None = None
+        if hf_path is not None:
+            hf_identifier = str(hf_path)
+        else:
+            hf_name_or_path = getattr(self.hf_pretrained, "model_name_or_path", None)
+            if hf_name_or_path is None and isinstance(self.hf_pretrained, PretrainedConfig):
+                hf_name_or_path = getattr(self.hf_pretrained, "name_or_path", None)
+            if hf_name_or_path:
+                hf_identifier = str(hf_name_or_path)
+
+        if hf_identifier:
+            model_config.hf_model_id = hf_identifier
+
+        return model_config
 
     def to_megatron_provider(self, load_weights: bool = True, hf_path: str | Path | None = None) -> GPTModelProvider:
         """
@@ -1270,3 +1322,37 @@ class AutoBridge(Generic[MegatronModelT]):
             lines_for_build.append("  (model_bridge): ")  # Fallback for empty repr
 
         return f"{class_name}(\n" + "\n".join(lines_for_build) + "\n)"
+
+
+def _initialize_torch_distributed():
+    from megatron.bridge.utils.common_utils import get_local_rank_preinit
+
+    if not torch.distributed.is_initialized():
+        os.environ["RANK"] = os.environ.get("RANK", "0")
+        os.environ["WORLD_SIZE"] = os.environ.get("WORLD_SIZE", "1")
+        os.environ["MASTER_ADDR"] = os.environ.get("MASTER_ADDR", "localhost")
+        os.environ["MASTER_PORT"] = os.environ.get("MASTER_PORT", "12355")
+        torch.cuda.set_device(get_local_rank_preinit())
+        torch.distributed.init_process_group("nccl")
+
+
+def _initialize_parallel_state(
+    config, seed: int | None = None, seed_kwargs: dict | None = None, **model_parallel_kwargs
+):
+    from megatron.core import parallel_state
+    from megatron.core.tensor_parallel import model_parallel_cuda_manual_seed
+
+    if not parallel_state.is_initialized():
+        print("Model parallel not initialized, initializing...")
+        parallel_state.initialize_model_parallel(
+            tensor_model_parallel_size=getattr(config, "tensor_model_parallel_size", 1),
+            pipeline_model_parallel_size=getattr(config, "pipeline_model_parallel_size", 1),
+            virtual_pipeline_model_parallel_size=getattr(config, "virtual_pipeline_model_parallel_size", None),
+            context_parallel_size=getattr(config, "context_parallel_size", 1) or 1,
+            expert_model_parallel_size=getattr(config, "expert_model_parallel_size", 1) or 1,
+            expert_tensor_parallel_size=getattr(config, "expert_tensor_parallel_size", None),
+            **model_parallel_kwargs,
+        )
+
+        if seed is not None:
+            model_parallel_cuda_manual_seed(seed, **(seed_kwargs or {}))

--- a/src/megatron/bridge/models/conversion/auto_bridge.py
+++ b/src/megatron/bridge/models/conversion/auto_bridge.py
@@ -615,6 +615,7 @@ class AutoBridge(Generic[MegatronModelT]):
         path: str | Path,
         hf_tokenizer_path: Optional[str | Path] = None,
         low_memory_save: bool = False,
+        model_config: ModelProviderMixin | ModelConfig | None = None,
         hf_tokenizer_kwargs: Optional[dict] = None,
     ) -> None:
         """
@@ -674,6 +675,7 @@ class AutoBridge(Generic[MegatronModelT]):
             hf_tokenizer_path=hf_tokenizer_path,
             low_memory_save=low_memory_save,
             hf_tokenizer_kwargs=hf_tokenizer_kwargs,
+            model_config=model_config,
         )
 
     def load_megatron_model(
@@ -790,6 +792,7 @@ class AutoBridge(Generic[MegatronModelT]):
         megatron_model = bridge.to_megatron_model(wrap_with_ddp=False, use_cpu_initialization=True)
 
         # Save as Megatron checkpoint
+        config = bridge.to_megatron_config(load_weights=False)
         hf_tokenizer_kwargs = None
         if hasattr(bridge._model_bridge, "get_hf_tokenizer_kwargs"):
             hf_tokenizer_kwargs = bridge._model_bridge.get_hf_tokenizer_kwargs()
@@ -799,6 +802,7 @@ class AutoBridge(Generic[MegatronModelT]):
             hf_tokenizer_path=hf_model_id,
             hf_tokenizer_kwargs=hf_tokenizer_kwargs,
             low_memory_save=True,
+            model_config=config,
         )
 
     def export_ckpt(

--- a/src/megatron/bridge/models/conversion/auto_bridge.py
+++ b/src/megatron/bridge/models/conversion/auto_bridge.py
@@ -27,6 +27,7 @@ from modelopt.torch.quantization.utils import is_quantized
 from transformers.configuration_utils import PretrainedConfig
 from typing_extensions import Unpack
 
+from megatron.bridge.models.common import ModelConfig
 from megatron.bridge.models.conversion import model_bridge
 from megatron.bridge.models.conversion.model_bridge import (
     HFWeightTuple,
@@ -39,7 +40,6 @@ from megatron.bridge.models.hf_pretrained.causal_lm import PreTrainedCausalLM, _
 from megatron.bridge.models.hf_pretrained.safe_config_loader import safe_load_config_with_retry
 from megatron.bridge.models.hf_pretrained.state import SafeTensorsStateSource
 from megatron.bridge.models.model_provider import GetModelKwargs, ModelParallelKwargs, ModelProviderMixin
-from src.megatron.bridge.models.common import ModelConfig
 
 
 MegatronModelT = TypeVar("MegatronModelT", bound=MegatronModule)

--- a/src/megatron/bridge/models/conversion/model_bridge.py
+++ b/src/megatron/bridge/models/conversion/model_bridge.py
@@ -18,7 +18,7 @@ import fnmatch
 import itertools
 import logging
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from typing import (
     Callable,
     Dict,
@@ -46,6 +46,7 @@ from megatron.core.utils import (
 from rich.progress import BarColumn, Progress, TextColumn, TimeRemainingColumn
 from transformers.modeling_utils import PreTrainedModel
 
+from megatron.bridge.models.common import ModelConfig
 from megatron.bridge.models.conversion.mapping_registry import MegatronMappingRegistry
 from megatron.bridge.models.conversion.param_mapping import (
     MegatronParamMapping,
@@ -69,6 +70,7 @@ logger = logging.getLogger(__name__)
 MappingT = TypeVar("MappingT", bound=MegatronParamMapping)
 HFPreTrained = TypeVar("HFPreTrained")
 ModelProviderTarget = TypeVar("ModelProviderTarget", bound=ModelProviderMixin)
+ModelConfigTarget = TypeVar("ModelConfigTarget", bound=ModelConfig)
 MegatronModel = TypeVar("MegatronModel", bound=MegatronModule)
 _BridgeImplClass = TypeVar("_BridgeImplClass", bound="MegatronModelBridge")
 
@@ -241,6 +243,8 @@ class MegatronModelBridge(MegatronPeftBridge, Generic[HFPreTrained, ModelProvide
     # Provider class to instantiate in provider_bridge (set via @register_bridge decorator)
     # For MLA models, use DeepSeekModelProvider or similar; for standard GPT, use GPTModelProvider
     PROVIDER_CLASS = None  # Set by @register_bridge(provider=...) or defaults to GPTModelProvider
+    MODEL_CONFIG_CLASS = None
+    TRANSFORMER_CONFIG_CLASS = None
 
     # Additional file patterns to automatically copy during HF export (e.g., ["*reasoning_parser.py"])
     # Set this in bridge subclasses to include model-specific files beyond standard artifacts
@@ -482,6 +486,123 @@ class MegatronModelBridge(MegatronPeftBridge, Generic[HFPreTrained, ModelProvide
                 setattr(provider, key, value)
 
         return provider
+
+    def hf_config_to_model_config_kwargs(self, hf_config) -> tuple[dict, dict]:
+        transformer_cfg_kwargs = {}
+        model_cfg_kwargs = {}
+
+        for hf_name, megatron_name in self.CONFIG_MAPPING:
+            has_value = False
+            value = None
+            if "." in hf_name:
+                # Nested dict access: "parent.child" -> getattr(config, parent).get(child)
+                parts = hf_name.split(".", 1)
+                parent = getattr(hf_config, parts[0], None)
+                if parent is not None and isinstance(parent, dict):
+                    if parts[1] in parent:
+                        value = parent[parts[1]]
+                        has_value = True
+            else:
+                value = getattr(hf_config, hf_name, None)
+                has_value = hasattr(hf_config, hf_name)
+            if has_value:
+                # Adds `name=value` to appropriate kwargs list based on whether `name` is in TransformerConfig.
+                if hasattr(TransformerConfig, megatron_name):
+                    transformer_cfg_kwargs[megatron_name] = value
+                else:
+                    model_cfg_kwargs[megatron_name] = value
+
+        if "rotary_base" not in transformer_cfg_kwargs:
+            try:
+                transformer_cfg_kwargs["rotary_base"] = rope_theta_from_hf(hf_config)
+            except ValueError:
+                pass
+
+        # Handle rope scaling: extract params from rope_scaling dict
+        # HF configs use either "type" or "rope_type" key for the scaling type
+        from megatron.bridge.models.mla_provider import MLATransformerConfig
+
+        is_mla_config = self.TRANSFORMER_CONFIG_CLASS is not None and issubclass(
+            self.TRANSFORMER_CONFIG_CLASS, MLATransformerConfig
+        )
+        rope_scaling = getattr(hf_config, "rope_scaling", None)
+
+        if rope_scaling is not None and isinstance(rope_scaling, dict):
+            rope_type = rope_scaling.get("type") or rope_scaling.get("rope_type")
+            if rope_type == "yarn":
+                if is_mla_config:
+                    # MLA models: use direct field names (mscale, rotary_scaling_factor, etc.)
+                    mla_params = {}
+                    for hf_key, megatron_key in self.MLA_ROPE_SCALING_MAPPING:
+                        value = rope_scaling.get(hf_key)
+                        if value is not None:
+                            mla_params[megatron_key] = value
+                    if mla_params:
+                        transformer_cfg_kwargs["_mla_rope_params"] = mla_params
+                else:
+                    # GPT models: use yarn_ prefixed field names
+                    yarn_params = {"position_embedding_type": "yarn"}
+                    for hf_key, megatron_key in self.YARN_ROPE_SCALING_MAPPING:
+                        yarn_params[megatron_key] = rope_scaling.get(hf_key)
+                    if "truncate" in rope_scaling:
+                        yarn_params["yarn_correction_range_round_to_int"] = rope_scaling["truncate"]
+                    if yarn_params:
+                        transformer_cfg_kwargs["_yarn_params"] = yarn_params
+        elif is_mla_config:
+            # MLA provider without rope_scaling in HF config:
+            # Override rotary_scaling_factor to 1.0 (no scaling) instead of
+            # using MLATransformerConfig default of 40
+            transformer_cfg_kwargs["_mla_rope_params"] = {"rotary_scaling_factor": 1.0, "mscale_all_dim": 1.0}
+
+        # Handle vocab_size_divisible_by
+        vocab_size = model_cfg_kwargs.get("vocab_size")
+        if vocab_size is not None:
+            model_cfg_kwargs["make_vocab_size_divisible_by"] = self.make_vocab_size_divisible_by(vocab_size)
+
+        # Determine dtype
+        params_dtype = self.dtype_from_hf(hf_config, default=torch.float32)
+        transformer_cfg_kwargs["fp16"] = params_dtype == torch.float16
+        transformer_cfg_kwargs["bf16"] = params_dtype == torch.bfloat16
+        transformer_cfg_kwargs["params_dtype"] = params_dtype
+
+        # Convert activation function (some models use hidden_act, others use hidden_activation)
+        hidden_act = getattr(hf_config, "hidden_act", None) or getattr(hf_config, "hidden_activation", "silu")
+        transformer_cfg_kwargs["activation_func"] = self.hf_to_megatron_activation(hidden_act)
+
+        return transformer_cfg_kwargs, model_cfg_kwargs
+
+    def config_bridge(self, hf_pretrained: HFPreTrained) -> ModelConfigTarget:
+        from megatron.bridge.models.gpt.gpt_builder import GPTModelConfig
+
+        hf_config = hf_pretrained.config
+
+        transformer_cfg_kwargs, model_cfg_kwargs = self.hf_config_to_model_config_kwargs(hf_config)
+
+        yarn_params = transformer_cfg_kwargs.pop("_yarn_params", None)
+        mla_rope_params = transformer_cfg_kwargs.pop("_mla_rope_params", None)
+
+        transformer_cfg_cls = (
+            self.TRANSFORMER_CONFIG_CLASS if self.TRANSFORMER_CONFIG_CLASS is not None else TransformerConfig
+        )
+        model_cfg_cls = self.MODEL_CONFIG_CLASS if self.MODEL_CONFIG_CLASS is not None else GPTModelConfig
+
+        has_transformer_cfg = "transformer" in [f.name for f in fields(model_cfg_cls)]
+        if has_transformer_cfg:
+            transformer_cfg = transformer_cfg_cls(**transformer_cfg_kwargs)
+            model_cfg = model_cfg_cls(transformer=transformer_cfg, **model_cfg_kwargs)
+        else:
+            model_cfg = model_cfg_cls(**model_cfg_kwargs)
+
+        if yarn_params and has_transformer_cfg:
+            for key, value in yarn_params.items():
+                setattr(model_cfg.transformer, key, value)
+
+        # Apply MLA rope params via setattr (for MLA models like DeepSeek, Kimi)
+        if mla_rope_params and has_transformer_cfg:
+            for key, value in mla_rope_params.items():
+                setattr(model_cfg.transformer, key, value)
+
+        return model_cfg
 
     @classmethod
     def megatron_to_hf_config(cls, provider) -> dict:

--- a/src/megatron/bridge/training/model_load_save.py
+++ b/src/megatron/bridge/training/model_load_save.py
@@ -27,6 +27,7 @@ from megatron.core.optimizer import OptimizerConfig
 from megatron.core.transformer import MegatronModule, TransformerConfig
 from megatron.core.utils import get_model_config
 
+from megatron.bridge.models.common import ModelConfig
 from megatron.bridge.models.model_provider import ModelParallelKwargs, ModelProviderMixin
 from megatron.bridge.training.checkpointing import save_checkpoint
 from megatron.bridge.training.config import CheckpointConfig, ConfigContainer, LoggerConfig
@@ -407,6 +408,7 @@ def save_megatron_model(
     ckpt_format: str = "torch_dist",
     hf_tokenizer_path: Optional[Union[str, Path]] = None,
     low_memory_save: bool = False,
+    model_config: ModelProviderMixin | ModelConfig | None = None,
     hf_tokenizer_kwargs: Optional[dict] = None,
 ) -> None:
     """Save a Megatron model in native Megatron checkpoint format without optimizer state.
@@ -471,14 +473,15 @@ def save_megatron_model(
         )
 
     # Get model config from the first model instance
-    model_config = get_model_config(model[0])
+    if model_config is None:
+        model_config = get_model_config(model[0])
 
     # Validate that the model config is a model provider
-    if not isinstance(model_config, ModelProviderMixin):
+    if not isinstance(model_config, (ModelProviderMixin, ModelConfig)):
         raise TypeError(
-            f"Expected model config to be an instance of ModelProviderMixin, "
+            f"Expected model config to be an instance of ModelProviderMixin or ModelConfig, "
             f"but got {type(model_config).__name__}. "
-            f"Model configs must inherit from ModelProviderMixin to ensure proper "
+            f"Model configs must inherit from ModelProviderMixin or ModelConfig to ensure proper "
             f"model instantiation and configuration handling."
         )
 


### PR DESCRIPTION
# What does this PR do ?
A possible implementation of integrating ModelConfig and ModelBuilder into the Bridge APIs. This PR is incomplete, mainly just for reference on what changes are needed.

# Key Changes

- Add `to_megatron_config()` to `AutoBridge`. Eventually deprecate `to_megatron_provider()`. This requires a `config_bridge()` API in `ModelBridge` which may need to be overriden for specific models' bridges.
- When importing HF checkpoint to Megatron format, initializing parallel state (if not already initialized) is moved to `AutoBridge` from the mixin, since `ModelBuilder` should not perform this logic
- Since `build_model()` now only passes `TransformerConfig` to the MCore model, (old `provide()` interface passed the entire provider to MCore model), need to keep track of the full ModelConfig when saving a megatron checkpoint through the bridge

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
