### PR TITLE
fix: force os._exit in pytest_sessionfinish to avoid PyTorch teardown crash

### DIFF
--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -124,3 +124,10 @@ def sample_config_data():
 def sample_train_state_data():
     """Provide sample train state data for testing."""
     return {"iteration": 5000, "epoch": 10, "step": 50000, "learning_rate": 0.0001, "loss": 2.34}
+
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """Force immediate exit to bypass PyTorch/CUDA C++ destructor crashes during teardown."""
+    import os
+    os._exit(int(exitstatus))


### PR DESCRIPTION
## Problem

The `Launch_Unit_Tests` CI job [67161568658](https://github.com/NVIDIA-NeMo/Megatron-Bridge/actions/runs/23123145467/job/67161568658) was failing with exit code 134 (SIGABRT) even though all 4575 tests passed. The crash occurred ~3 seconds after pytest finished, during Python interpreter shutdown:

```
4575 passed, 2 skipped, 3 deselected in 220.76s
terminate called without an active exception
##[error]Process completed with exit code 134.
```

This is a known class of issue where PyTorch's CUDA C++ destructors (global/static objects) are invoked in an unsafe order during interpreter teardown, causing `std::terminate()` → `abort()` → SIGABRT. The test suite itself is fully healthy.

## Fix

Add a `pytest_sessionfinish` hook to `tests/unit_tests/conftest.py` that calls `os._exit(int(exitstatus))` immediately after the test session ends. This bypasses the Python/C++ interpreter shutdown sequence entirely, exiting with the correct pytest exit code:

- `0` → all tests passed
- `1` → tests failed
- `2` → interrupted
- etc.

Coverage data is already flushed to disk before `pytest_sessionfinish` is called, so the `coverage combine` step in CI is unaffected.

## Test plan

- [ ] Verify `Launch_Unit_Tests` CI job passes without exit code 134
- [ ] Verify coverage reporting still works correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test teardown stability by implementing enhanced session cleanup handling to prevent crashes that could occur during the test suite completion phase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->