### PR TITLE
[ci] feat: split unit tests into core and diffusion buckets

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -315,7 +315,7 @@ jobs:
             echo "needs_more_tests=false" >> $GITHUB_OUTPUT
           fi
 
-  cicd-unit-tests:
+  cicd-unit-tests-core:
     if: |
       (
         success()
@@ -326,7 +326,7 @@ jobs:
       && (github.event.inputs.test_suite == '' || github.event.inputs.test_suite == 'all' || github.event.inputs.test_suite == 'unit-only')
     needs: [pre-flight, cicd-wait-in-queue, cicd-container-build]
     runs-on: ${{ needs.pre-flight.outputs.runner_prefix }}-gpu-x2
-    name: Launch_Unit_Tests
+    name: Launch_Unit_Tests_Core
     environment: nemo-ci
     env:
       TRANSFORMERS_OFFLINE: "1"
@@ -364,7 +364,68 @@ jobs:
       - name: main
         uses: ./.github/actions/test-template
         with:
-          script: Launch_Unit_Tests
+          script: Launch_Unit_Tests_Core
+          timeout: 18
+          is_unit_test: "true"
+          has-azure-credentials: "true"
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          PAT: ${{ secrets.PAT }}
+          container-image: ${{ env.container-registry }}/megatron-bridge:${{ github.sha }}
+          test-data-path: ${{ needs.pre-flight.outputs.test_data_path }}
+          runner: ${{ needs.pre-flight.outputs.runner_prefix }}-gpu-x2
+
+  cicd-unit-tests-diffusion:
+    if: |
+      (
+        success()
+        || needs.pre-flight.outputs.is_ci_workload == 'true'
+        || needs.pre-flight.outputs.force_run_all == 'true'
+      )
+      && !cancelled()
+      && (github.event.inputs.test_suite == '' || github.event.inputs.test_suite == 'all' || github.event.inputs.test_suite == 'unit-only')
+    needs: [pre-flight, cicd-wait-in-queue, cicd-container-build]
+    runs-on: ${{ needs.pre-flight.outputs.runner_prefix }}-gpu-x2
+    name: Launch_Unit_Tests_Diffusion
+    environment: nemo-ci
+    env:
+      TRANSFORMERS_OFFLINE: "1"
+      HF_HUB_OFFLINE: "1"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Update MCore submodule (if triggered from MCore)
+        if: ${{ github.event.inputs.mcore_ref != '' }}
+        run: |
+          echo "🔄 Updating MCore submodule for unit tests..."
+          cd 3rdparty/Megatron-LM
+          git fetch ${{ github.event.inputs.mcore_repo || 'origin' }} ${{ github.event.inputs.mcore_ref }}
+          git checkout ${{ github.event.inputs.mcore_ref }}
+
+          ACTUAL_COMMIT=$(git rev-parse HEAD)
+          EXPECTED_COMMIT="${{ github.event.inputs.mcore_ref }}"
+
+          echo "🧪 UNIT TESTS - MCore verification:"
+          echo "Expected: ${EXPECTED_COMMIT}"
+          echo "Actual:   ${ACTUAL_COMMIT}"
+
+          if [ "${ACTUAL_COMMIT}" != "${EXPECTED_COMMIT}" ]; then
+            echo "❌ ERROR: MCore commit mismatch!"
+            exit 1
+          fi
+
+          echo "✅ MCore commit verified"
+          echo "📦 Container: ${{ env.container-registry }}/megatron-bridge:${{ github.sha }}"
+          git log -1 --oneline
+
+      - name: main
+        uses: ./.github/actions/test-template
+        with:
+          script: Launch_Unit_Tests_Diffusion
           timeout: 18
           is_unit_test: "true"
           has-azure-credentials: "true"
@@ -391,7 +452,7 @@ jobs:
           - script: L0_Launch_models_qwen3
           - script: L0_Launch_recipes_llama_1b
           - script: L0_Launch_utils
-    needs: [pre-flight, cicd-unit-tests]
+    needs: [pre-flight, cicd-unit-tests-core, cicd-unit-tests-diffusion]
     runs-on: ${{ needs.pre-flight.outputs.runner_prefix }}-gpu-x2
     if: |
       (
@@ -480,7 +541,7 @@ jobs:
           - script: L1_Launch_recipes_ministral3
           - script: L1_Launch_recipes_nemotronh
           - script: L1_Launch_recipes_qwen
-    needs: [pre-flight, cicd-unit-tests, check-labels]
+    needs: [pre-flight, cicd-unit-tests-core, cicd-unit-tests-diffusion, check-labels]
     runs-on: ${{ needs.pre-flight.outputs.runner_prefix }}-gpu-x2
     if: |
       (
@@ -569,7 +630,7 @@ jobs:
           - script: L2_Launch_recipes_qwen_vl
           - script: L2_Launch_models_flux
           - script: L2_Launch_models_wan
-    needs: [pre-flight, cicd-unit-tests]
+    needs: [pre-flight, cicd-unit-tests-core, cicd-unit-tests-diffusion]
     runs-on: ${{ needs.pre-flight.outputs.runner_prefix }}-gpu-x2
     if: |
       (
@@ -635,7 +696,8 @@ jobs:
     needs:
       - pre-flight
       - check-labels
-      - cicd-unit-tests
+      - cicd-unit-tests-core
+      - cicd-unit-tests-diffusion
       - cicd-functional-tests-l0
       - cicd-functional-tests-l1
       - cicd-functional-tests-l2

--- a/tests/unit_tests/Launch_Unit_Tests_Core.sh
+++ b/tests/unit_tests/Launch_Unit_Tests_Core.sh
@@ -16,7 +16,7 @@
 set -xeuo pipefail # Exit immediately if a command exits with a non-zero status
 
 echo "=================================================="
-echo "🧪 UNIT TESTS"
+echo "🧪 UNIT TESTS (core)"
 echo "=================================================="
 
 # Display MCore commit SHA if triggered from MCore CI
@@ -36,4 +36,6 @@ CUDA_VISIBLE_DEVICES="0,1" uv run coverage run -a --data-file=/opt/Megatron-Brid
     -o log_cli=true \
     -o log_cli_level=INFO \
     --disable-warnings \
-    -vs tests/unit_tests -m "not pleasefixme"
+    -vs tests/unit_tests \
+    --ignore=tests/unit_tests/diffusion \
+    -m "not pleasefixme"

--- a/tests/unit_tests/Launch_Unit_Tests_Diffusion.sh
+++ b/tests/unit_tests/Launch_Unit_Tests_Diffusion.sh
@@ -1,0 +1,39 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/bin/bash
+set -xeuo pipefail # Exit immediately if a command exits with a non-zero status
+
+echo "=================================================="
+echo "🧪 UNIT TESTS (diffusion)"
+echo "=================================================="
+
+# Display MCore commit SHA if triggered from MCore CI
+if [ -f "/opt/Megatron-Bridge/.mcore_commit_sha" ]; then
+    echo "📦 MCore commit: $(cat /opt/Megatron-Bridge/.mcore_commit_sha)"
+fi
+echo ""
+
+# Skip timeout on Azure runners because the machines are slower
+TIMEOUT_ARG="--timeout=2"
+if [[ "${GHA_RUNNER:-}" == *"azure"* ]]; then
+    TIMEOUT_ARG=""
+fi
+
+CUDA_VISIBLE_DEVICES="0,1" uv run coverage run -a --data-file=/opt/Megatron-Bridge/.coverage --source=/opt/Megatron-Bridge/ -m pytest \
+    $TIMEOUT_ARG \
+    -o log_cli=true \
+    -o log_cli_level=INFO \
+    --disable-warnings \
+    -vs tests/unit_tests/diffusion -m "not pleasefixme"


### PR DESCRIPTION
## Summary

- Splits the single `Launch_Unit_Tests` CI job into two parallel jobs: `Launch_Unit_Tests_Core` and `Launch_Unit_Tests_Diffusion`
- `diffusion/` tests dominate runtime (`test_wan_recipe.py` alone = ~8.3 min, 76% of total); running them in parallel removes them from the critical path
- Core job uses `--ignore=tests/unit_tests/diffusion` so new test directories are picked up automatically

## Expected impact

| | Before | After |
|---|---|---|
| Wall-clock time | ~15 min (sequential) | ~9 min (parallel) |
| Timeout headroom | tight (18 min limit) | comfortable |

## Test plan
- [ ] Verify `Launch_Unit_Tests_Core` job passes
- [ ] Verify `Launch_Unit_Tests_Diffusion` job passes
- [ ] Confirm downstream jobs (`cicd-functional-tests`, `Nemo_CICD_Test`) still trigger correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restructured CI/CD pipeline to split unit tests into parallel core and diffusion test paths, enabling faster test execution and feedback
  * Introduced separate test scripts for core and diffusion unit test suites with independent configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->