### PR TITLE
profiling_trace_fix- all precisions

### DIFF
--- a/scripts/performance/setup_experiment.py
+++ b/scripts/performance/setup_experiment.py
@@ -369,10 +369,10 @@ def main(
         )
 
     if enable_nsys:
-        if compute_dtype == "fp8_mx" and nsys_trace is None:
-            logger.warning("Using `cuda-sw` trace mode for MXFP8 profiling")
-            logger.warning("MXFP8 profiling results might not be accurate due to software tracing limitations.")
-            # TODO: Remove this once the functional issues associated with PyT 26.02 are resolved.
+        if nsys_trace is None:
+            logger.warning("Using `cuda-sw` trace mode for profiling")
+            logger.warning("Profiling results might not be accurate due to software tracing limitations.")
+            # TODO: Remove this once the associated functional issues are resolved.
             nsys_trace = ["cuda-sw", "nvtx"]
         plugins.append(
             NsysPlugin(


### PR DESCRIPTION
# What does this PR do ?

Expand the fix for profiling to all precisions as job hangs after profiling.

# Changelog

```
if nsys_trace is None:
    logger.warning("Using `cuda-sw` trace mode for profiling")
    logger.warning("Profiling results might not be accurate due to software tracing limitations.")
    # TODO: Remove this once the associated functional issues are resolved.
    nsys_trace = ["cuda-sw", "nvtx"]
```

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
