### PR TITLE
add checkpoint swizzling for gemm+swiglu fused cute dsl kernel

### DIFF
--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -21,7 +21,7 @@ import random
 import shutil
 import sys
 import threading
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from enum import Enum, auto
 from logging import getLogger
 from pathlib import Path
@@ -32,7 +32,7 @@ import numpy as np
 import torch
 import torch.nn.functional as F
 from megatron.core import dist_checkpointing, tensor_parallel
-from megatron.core.dist_checkpointing.mapping import ShardedObject, ShardedStateDict
+from megatron.core.dist_checkpointing.mapping import ShardedObject, ShardedStateDict, ShardedTensor
 from megatron.core.dist_checkpointing.serialization import (
     StateDict,
     get_default_load_sharded_strategy,
@@ -907,6 +907,35 @@ def save_checkpoint(
             pg_collection=pg_collection,
         )
 
+    # De-interleave GLU weights/biases if model has interleaved weights in memory
+    # Checkpoints are always saved in contiguous format
+    from megatron.core.utils import get_model_config
+
+    model_interleave_size = None
+    try:
+        if len(model) > 0:
+            model_config = get_model_config(model[0])
+            model_interleave_size = getattr(model_config, "moe_mlp_glu_interleave_size", None)
+    except Exception:
+        model_interleave_size = getattr(cfg.model, "moe_mlp_glu_interleave_size", None)
+
+    model_is_interleaved = model_interleave_size is not None
+    if model_is_interleaved and ckpt_cfg.ckpt_format != "fsdp_dtensor":
+        print_rank_0(
+            f"[GLU Interleaving] De-interleaving GLU weights on save: model has interleaved weights (size={model_interleave_size}), converting to contiguous format for checkpoint"
+        )
+        if len(model) == 1:
+            state_dict["model"] = _process_state_dict_for_glu_interleaving(
+                state_dict["model"], model_interleave_size, interleave=False
+            )
+        else:
+            for i in range(len(model)):
+                model_key = "model%d" % i
+                if model_key in state_dict:
+                    state_dict[model_key] = _process_state_dict_for_glu_interleaving(
+                        state_dict[model_key], model_interleave_size, interleave=False
+                    )
+
     # Apply PEFT filtering to save adapter-only checkpoints
     if cfg.peft is not None:
         state_dict = apply_peft_adapter_filter_to_state_dict(state_dict, cfg.peft)
@@ -1727,6 +1756,123 @@ def load_checkpoint(
     )
 
 
+def _deinterleave_glu_tensor(tensor: torch.Tensor, interleave_size: int) -> torch.Tensor:
+    """De-interleave SwiGLU fc1 tensor along dim 0: block-interleaved -> contiguous [W_all, V_all].
+
+    Same layout for ``linear_fc1.weight`` (dim 0 + remaining dims) and ``linear_fc1.bias`` (dim 0 only).
+    Interleaved format (dim 0): [W0:k, V0:k, Wk:2k, Vk:2k, ...] with ``k = interleave_size``.
+    """
+    shape = tensor.shape
+    x = tensor.reshape(
+        shape[0] // (2 * interleave_size),
+        2,
+        interleave_size,
+        *shape[1:],
+    )
+    x = x.transpose(0, 1).contiguous()
+    return x.reshape(shape)
+
+
+def _interleave_glu_tensor(tensor: torch.Tensor, interleave_size: int) -> torch.Tensor:
+    """Interleave SwiGLU fc1 tensor along dim 0: contiguous [W_all, V_all] -> block-interleaved."""
+    shape = tensor.shape
+    x = tensor.reshape(
+        2,
+        shape[0] // (2 * interleave_size),
+        interleave_size,
+        *shape[1:],
+    )
+    x = x.transpose(0, 1).contiguous()
+    return x.reshape(shape)
+
+
+def _is_swiglu_fc1_checkpoint_key(key: str) -> bool:
+    """True for MoE local-expert SwiGLU linear_fc1 weights/biases (not shared_experts).
+
+    Dense ``mlp.linear_fc1`` is included only when ``USE_ACT_FUSION_FOR_DENSE=1`` (same block layout
+    as fused experts); otherwise dense weights stay contiguous and must not be permuted.
+    """
+    is_swiglu_fc1_dense = (
+        os.environ.get("USE_ACT_FUSION_FOR_DENSE", "0") == "1"
+        and "experts" not in key
+        and "mlp" in key
+        and ("linear_fc1.weight" in key or "linear_fc1.bias" in key)
+    )
+    is_swiglu_fc1_moe = (
+        "shared_experts" not in key and "experts" in key and ("linear_fc1.weight" in key or "linear_fc1.bias" in key)
+    )
+    return is_swiglu_fc1_dense or is_swiglu_fc1_moe
+
+
+def _apply_glu_interleave_to_tensor_data(tensor: torch.Tensor, interleave_size: int, interleave: bool) -> torch.Tensor:
+    """Run interleave or de-interleave on fc1 weight or bias (identical dim-0 layout)."""
+    return (
+        _interleave_glu_tensor(tensor, interleave_size)
+        if interleave
+        else _deinterleave_glu_tensor(tensor, interleave_size)
+    )
+
+
+def _process_state_dict_for_glu_interleaving(
+    model_state_dict: dict[str, Any],
+    interleave_size: int,
+    interleave: bool = True,
+) -> dict[str, Any]:
+    """Process GLU weights and biases in state dict for interleaving or de-interleaving.
+
+    Args:
+        model_state_dict: The state dict to process
+        interleave_size: The interleave size to use
+        interleave: If True, interleave from contiguous to interleaved (for loading).
+                   If False, de-interleave from interleaved to contiguous (for saving).
+    """
+    if not isinstance(model_state_dict, dict):
+        return model_state_dict
+
+    processed_state_dict: dict[str, Any] = {}
+    num_keys_processed = 0
+    operation = "interleaved" if interleave else "de-interleaved"
+
+    for key, value in model_state_dict.items():
+        if not _is_swiglu_fc1_checkpoint_key(key):
+            processed_state_dict[key] = value
+            continue
+
+        if isinstance(value, ShardedTensor):
+            if value.data is None:
+                processed_state_dict[key] = value
+                continue
+            new_data = _apply_glu_interleave_to_tensor_data(value.data, interleave_size, interleave)
+            # Interleaving permutes elements; local shape unchanged. Preserve global sharding metadata.
+            processed_state_dict[key] = replace(value, data=new_data, local_shape=new_data.shape)
+            num_keys_processed += 1
+            continue
+
+        if isinstance(value, ShardedObject):
+            if not isinstance(value.data, torch.Tensor):
+                processed_state_dict[key] = value
+                continue
+            new_data = _apply_glu_interleave_to_tensor_data(value.data, interleave_size, interleave)
+            processed_state_dict[key] = replace(value, data=new_data)
+            num_keys_processed += 1
+            continue
+
+        if isinstance(value, torch.Tensor):
+            processed_state_dict[key] = _apply_glu_interleave_to_tensor_data(value, interleave_size, interleave)
+            num_keys_processed += 1
+            continue
+
+        processed_state_dict[key] = value
+
+    if num_keys_processed > 0:
+        print_rank_0(
+            f"[GLU Interleaving] Processed {num_keys_processed} SwiGLU fc1 keys "
+            f"(weights and biases): {operation} with interleave_size={interleave_size}"
+        )
+
+    return processed_state_dict
+
+
 def _load_model_state_dict(module: torch.nn.Module, state_dict: dict[str, Any], strict: bool):
     """Helper function to load state dict with fallback for missing extra states."""
     if HAVE_MEGATRON_FSDP and isinstance(module, MegatronFSDP):
@@ -1810,6 +1956,7 @@ def _load_checkpoint_from_path(
     load_kwargs = {}
     ignore_rng_state = False
     ignore_rerun_state = True
+    run_config = None  # Initialize for later use
 
     # Step 3: Format-specific preparation
     if ckpt_format == "torch_dist":
@@ -2096,6 +2243,38 @@ def _load_checkpoint_from_path(
 
     # Load model weights
     if not skip_load_to_model_and_opt:
+        # Process state dict for GLU interleaving if needed
+        # Assumption: checkpoints are always in contiguous (non-interleaved) format
+        from megatron.core.utils import get_model_config
+
+        # Check if model expects interleaved weights - get from model config
+        model_interleave_size = None
+        try:
+            if len(model) > 0:
+                model_config = get_model_config(model[0])
+                model_interleave_size = getattr(model_config, "moe_mlp_glu_interleave_size", None)
+        except Exception:
+            # Fallback to cfg if model config not available
+            model_interleave_size = getattr(cfg.model, "moe_mlp_glu_interleave_size", None)
+        model_expects_interleaving = model_interleave_size is not None
+
+        # Interleave if model expects interleaved weights (checkpoints are always contiguous)
+        if model_expects_interleaving and ckpt_format != "fsdp_dtensor":
+            print_rank_0(
+                f"[GLU Interleaving] Interleaving GLU weights on load: model expects interleaving (size={model_interleave_size}), converting checkpoint from contiguous to interleaved format"
+            )
+            if len(model) == 1:
+                state_dict["model"] = _process_state_dict_for_glu_interleaving(
+                    state_dict["model"], model_interleave_size
+                )
+            else:
+                for i in range(len(model)):
+                    model_key = "model%d" % i
+                    if model_key in state_dict:
+                        state_dict[model_key] = _process_state_dict_for_glu_interleaving(
+                            state_dict[model_key], model_interleave_size
+                        )
+
         # Handle PEFT resume for strict loading
         load_strict = strict
         is_peft_resume = (

--- a/tests/unit_tests/training/test_glu_fc1_checkpoint_round_trip.py
+++ b/tests/unit_tests/training/test_glu_fc1_checkpoint_round_trip.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""SwiGLU fc1 checkpoint layout: contiguous -> load (interleave) -> save (de-interleave) -> contiguous."""
+
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from megatron.bridge.training.checkpointing import _process_state_dict_for_glu_interleaving
+
+
+MOE_FC1_KEY = "decoder.layers.0.mlp.experts.local_experts.0.linear_fc1.weight"
+MOE_FC1_BIAS_KEY = "decoder.layers.0.mlp.experts.local_experts.0.linear_fc1.bias"
+DENSE_FC1_KEY = "decoder.layers.0.mlp.linear_fc1.weight"
+DENSE_FC1_BIAS_KEY = "decoder.layers.0.mlp.linear_fc1.bias"
+
+
+@pytest.fixture
+def patch_print_rank_0():
+    with patch("megatron.bridge.training.checkpointing.print_rank_0"):
+        yield
+
+
+class TestCheckpointLoadSaveRoundTrip:
+    """Contiguous checkpoint layout -> load (interleave) -> save (de-interleave) matches original tensors."""
+
+    @pytest.mark.parametrize("interleave_size", [4, 8])
+    def test_moe_state_dict_round_trip_recover_contiguous(self, interleave_size, patch_print_rank_0):
+        """MoE fc1 weight + bias + unrelated tensor: full round-trip recovers originals."""
+        w = torch.randn(2 * interleave_size * 4, 16)
+        b = torch.randn(2 * interleave_size * 2)
+        passthrough = torch.randn(3, 7)
+        original = {
+            MOE_FC1_KEY: w.clone(),
+            MOE_FC1_BIAS_KEY: b.clone(),
+            "decoder.layers.0.mlp.linear_fc2.weight": passthrough.clone(),
+        }
+        after_load = _process_state_dict_for_glu_interleaving(
+            {k: v.clone() for k, v in original.items()}, interleave_size, interleave=True
+        )
+        after_save = _process_state_dict_for_glu_interleaving(after_load, interleave_size, interleave=False)
+        assert torch.equal(after_save[MOE_FC1_KEY], original[MOE_FC1_KEY])
+        assert torch.equal(after_save[MOE_FC1_BIAS_KEY], original[MOE_FC1_BIAS_KEY])
+        assert torch.equal(
+            after_save["decoder.layers.0.mlp.linear_fc2.weight"],
+            original["decoder.layers.0.mlp.linear_fc2.weight"],
+        )
+
+    @pytest.mark.parametrize("interleave_size", [4, 8])
+    def test_dense_state_dict_round_trip_with_fusion_env(self, interleave_size, monkeypatch, patch_print_rank_0):
+        """Dense fc1 participates only with USE_ACT_FUSION_FOR_DENSE=1; round-trip recovers contiguous tensors."""
+        monkeypatch.setenv("USE_ACT_FUSION_FOR_DENSE", "1")
+        w = torch.randn(2 * interleave_size * 3, 8)
+        b = torch.randn(2 * interleave_size * 5)
+        original = {
+            DENSE_FC1_KEY: w.clone(),
+            DENSE_FC1_BIAS_KEY: b.clone(),
+        }
+        after_load = _process_state_dict_for_glu_interleaving(
+            {k: v.clone() for k, v in original.items()}, interleave_size, interleave=True
+        )
+        after_save = _process_state_dict_for_glu_interleaving(after_load, interleave_size, interleave=False)
+        assert torch.equal(after_save[DENSE_FC1_KEY], original[DENSE_FC1_KEY])
+        assert torch.equal(after_save[DENSE_FC1_BIAS_KEY], original[DENSE_FC1_BIAS_KEY])


### PR DESCRIPTION
# What does this PR do ?

This packs the weights from the input and gate in blocks of 32 to enable the Gemm+Siwiglu fusion kernel.

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved checkpoint save/load compatibility for SwiGLU models with optimized weight and bias handling.
  * Enhanced checkpoint loading flexibility with relaxed validation constraints for broader compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->