### PR TITLE
[training] fix: preserve explicit FSDP dtype overrides in MixedPrecisionConfig.finalize()

### DIFF
--- a/src/megatron/bridge/training/mixed_precision.py
+++ b/src/megatron/bridge/training/mixed_precision.py
@@ -137,12 +137,14 @@ class MixedPrecisionConfig:
         if self.fp4 and not is_te_min_version("2.7.0.dev0"):
             raise ValueError("fp4 requires Transformer Engine >= 2.7.0.dev0 for NVFP4BlockScaling support.")
 
+        # grad_reduce_in_fp32 only fills in None fields — explicit values take precedence.
+        # This allows callers to set grad_reduce_in_fp32=True for fp32 gradient accumulation
+        # while independently customising grad_comm_dtype (e.g. bf16 for MLPerf FP8 runs).
         if self.grad_reduce_in_fp32:
-            self.megatron_fsdp_main_grads_dtype = torch.float32
-            self.megatron_fsdp_grad_comm_dtype = torch.float32
-        else:
-            self.megatron_fsdp_main_grads_dtype = None
-            self.megatron_fsdp_grad_comm_dtype = None
+            if self.megatron_fsdp_main_grads_dtype is None:
+                self.megatron_fsdp_main_grads_dtype = torch.float32
+            if self.megatron_fsdp_grad_comm_dtype is None:
+                self.megatron_fsdp_grad_comm_dtype = torch.float32
         for mfsdp_mp_arg in (
             self.megatron_fsdp_main_params_dtype,
             self.megatron_fsdp_main_grads_dtype,

--- a/tests/unit_tests/training/test_mixed_precision.py
+++ b/tests/unit_tests/training/test_mixed_precision.py
@@ -785,8 +785,8 @@ class TestGradReduceInFp32AffectsFsdpDtypes:
         assert config.megatron_fsdp_main_grads_dtype is None
         assert config.megatron_fsdp_grad_comm_dtype is None
 
-    def test_finalize_enforces_grad_reduce_in_fp32_false(self):
-        """finalize() overrides custom fsdp grad dtypes to None when grad_reduce_in_fp32=False."""
+    def test_finalize_preserves_explicit_fsdp_dtypes_when_grad_reduce_in_fp32_false(self):
+        """finalize() preserves explicitly-set FSDP dtype values when grad_reduce_in_fp32=False."""
         config = MixedPrecisionConfig(
             grad_reduce_in_fp32=False,
             megatron_fsdp_main_grads_dtype=torch.bfloat16,
@@ -797,8 +797,30 @@ class TestGradReduceInFp32AffectsFsdpDtypes:
 
         config.finalize()
 
-        assert config.megatron_fsdp_main_grads_dtype is None
-        assert config.megatron_fsdp_grad_comm_dtype is None
+        assert config.megatron_fsdp_main_grads_dtype == torch.bfloat16
+        assert config.megatron_fsdp_grad_comm_dtype == torch.bfloat16
+
+    def test_finalize_preserves_grad_comm_dtype_when_grad_reduce_in_fp32_true(self):
+        """finalize() respects explicit grad_comm_dtype even when grad_reduce_in_fp32=True.
+
+        This enables the MLPerf use case: fp32 gradient accumulation (main_grads_dtype=fp32)
+        combined with bf16 gradient communication (grad_comm_dtype=bf16).
+        """
+        config = MixedPrecisionConfig(
+            grad_reduce_in_fp32=True,
+            megatron_fsdp_grad_comm_dtype=torch.bfloat16,
+        )
+        config.finalize()
+        assert config.megatron_fsdp_main_grads_dtype == torch.float32
+        assert config.megatron_fsdp_grad_comm_dtype == torch.bfloat16
+
+    def test_finalize_preserves_grad_comm_dtype_override_on_recipe(self):
+        """User can override grad_comm_dtype on a recipe and have it survive finalize()."""
+        config = bf16_mixed()
+        config.megatron_fsdp_grad_comm_dtype = torch.bfloat16
+        config.finalize()
+        assert config.megatron_fsdp_main_grads_dtype == torch.float32
+        assert config.megatron_fsdp_grad_comm_dtype == torch.bfloat16
 
     def test_grad_reduce_in_fp32_toggle_round_trip(self):
         """Toggling grad_reduce_in_fp32 True->False->True updates fsdp dtypes correctly."""


### PR DESCRIPTION
## Summary

Fixes #2763.

`MixedPrecisionConfig.finalize()` was unconditionally overwriting `megatron_fsdp_main_grads_dtype` and `megatron_fsdp_grad_comm_dtype` based on the legacy `grad_reduce_in_fp32` flag, silently discarding any explicit overrides the caller had set.

This blocked the MLPerf use case of combining fp32 gradient accumulation (`grad_reduce_in_fp32=True` → `main_grads_dtype=fp32`) with bf16 gradient communication (`grad_comm_dtype=bf16`) — the key config needed for correctness with FP8 + gradient accumulation fusion on DSv3.

### Root cause

`finalize()` lines 140-145:

```python
# before — unconditional override
if self.grad_reduce_in_fp32:
    self.megatron_fsdp_main_grads_dtype = torch.float32   # clobbers explicit bf16
    self.megatron_fsdp_grad_comm_dtype = torch.float32    # clobbers explicit bf16
else:
    self.megatron_fsdp_main_grads_dtype = None
    self.megatron_fsdp_grad_comm_dtype = None
```

### Fix

Change to "fill-in-None" semantics — explicit values win:

```python
# after — only fill None fields
if self.grad_reduce_in_fp32:
    if self.megatron_fsdp_main_grads_dtype is None:
        self.megatron_fsdp_main_grads_dtype = torch.float32
    if self.megatron_fsdp_grad_comm_dtype is None:
        self.megatron_fsdp_grad_comm_dtype = torch.float32
```

The existing `__post_init__` already used this "only if None" pattern correctly; `finalize()` now matches it.

### Behavior preserved

- `grad_reduce_in_fp32=True` still defaults both FSDP grad dtype fields to fp32 (via `__post_init__` and `__setattr__`).
- Setting `grad_reduce_in_fp32` via attribute assignment still resets the dtype fields (via `__setattr__`) — callers that want to override should set the dtype fields *after* setting `grad_reduce_in_fp32`.
- All existing tests pass; one test that documented the (incorrect) clobbering behavior is updated to reflect the correct semantics.

### New test coverage

- `test_finalize_preserves_grad_comm_dtype_when_grad_reduce_in_fp32_true` — the primary MLPerf use case
- `test_finalize_preserves_grad_comm_dtype_override_on_recipe` — override on a standard recipe (`bf16_mixed()`)
- `test_finalize_preserves_explicit_fsdp_dtypes_when_grad_reduce_in_fp32_false` — explicit values survive when `grad_reduce_in_fp32=False`

## Test plan

- [ ] `tests/unit_tests/training/test_mixed_precision.py::TestGradReduceInFp32AffectsFsdpDtypes` — all 12 tests pass
- [ ] `tests/unit_tests/training/test_mixed_precision.py::TestFsdpDtypeStringConversion` — all tests pass
- [ ] Full unit test suite (`Launch_Unit_Tests_Core.sh`) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Mixed precision training now respects user-specified precision data type configurations during finalization. Previously, explicitly-set values were overwritten; they are now preserved to give users greater control.

* **Tests**
  * Enhanced test coverage to verify explicit precision settings are properly preserved across different training configurations and recipe-level overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->