### PR TITLE
[example] fix: use AutoBridge directly in distill_llama32_3b-1b to load HF weights

### DIFF
--- a/examples/distillation/llama/distill_llama32_3b-1b.py
+++ b/examples/distillation/llama/distill_llama32_3b-1b.py
@@ -63,6 +63,7 @@ from typing import Tuple
 import torch
 from omegaconf import OmegaConf
 
+from megatron.bridge import AutoBridge
 from megatron.bridge.models.distillation_provider import convert_to_distillation_provider
 from megatron.bridge.recipes.llama import llama32_1b_pretrain_config, llama32_3b_pretrain_config
 from megatron.bridge.training.config import ConfigContainer
@@ -145,9 +146,15 @@ def main() -> None:
     logger.info("Megatron-Bridge Llama3.2 3B-1B Distillation Script with YAML & CLI Overrides")
     logger.info("------------------------------------------------------------------")
 
-    # Load base configurations as recipes and wrap provider for distillation mode
-    cfg: ConfigContainer = llama32_1b_pretrain_config(load_weights=True)
-    teacher_cfg = llama32_3b_pretrain_config(load_weights=True)
+    # Load base configurations as recipes and wrap provider for distillation mode.
+    # The recipe functions do not accept a load_weights argument; use AutoBridge
+    # directly to create providers that load HuggingFace weights.
+    cfg: ConfigContainer = llama32_1b_pretrain_config()
+    cfg.model = AutoBridge.from_hf_pretrained("meta-llama/Llama-3.2-1B").to_megatron_provider(load_weights=True)
+    teacher_cfg = llama32_3b_pretrain_config()
+    teacher_cfg.model = AutoBridge.from_hf_pretrained("meta-llama/Llama-3.2-3B").to_megatron_provider(
+        load_weights=True
+    )
     kd_config = ModelOptDistillConfig()
     cfg.model = convert_to_distillation_provider(cfg.model, teacher_cfg.model, kd_config)
     logger.info("Loaded base student and teacher configurations")


### PR DESCRIPTION
## Problem

`distill_llama32_3b-1b.py` called `llama32_1b_pretrain_config(load_weights=True)` and `llama32_3b_pretrain_config(load_weights=True)`, but these recipe functions do not accept a `load_weights` argument, causing:

```
TypeError: llama32_1b_pretrain_config() got an unexpected keyword argument 'load_weights'
```

This broke the E2E distillation test `test_distillation_llama_3b_1b_e2e` when run against the container.

## Fix (Option B — example-only change)

- Call the recipe functions without arguments (for train/tokenizer/dataset config).
- Immediately override `cfg.model` / `teacher_cfg.model` using the supported public API:
  `AutoBridge.from_hf_pretrained(...).to_megatron_provider(load_weights=True)`
- Add `AutoBridge` import.

## Notes

The recipe's `cfg.model` post-creation settings (parallelism defaults, `seq_length=8192`, etc.) are reset by the override. These can be controlled via the existing YAML / CLI override mechanism. The architecture settings (hidden size, num layers, etc.) are correctly derived from the HF model config by `to_megatron_provider`.

Cherry-pick of #2859 onto r0.3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the Llama model distillation example to use AutoBridge for loading pre-trained models, replacing the previous recipe-based approach.
  * Simplified configuration by removing the `load_weights` parameter from configuration functions.
  * Distillation setup now converts student and teacher models using the updated provider configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->