### PR TITLE
[fix] fix example scripts

### DIFF
--- a/examples/conversion/hf_to_megatron_generate_nemotron_vlm.py
+++ b/examples/conversion/hf_to_megatron_generate_nemotron_vlm.py
@@ -307,6 +307,7 @@ def main(args) -> None:
         model_provider.expert_tensor_parallel_size = etp
         model_provider.pipeline_dtype = torch.bfloat16
         model_provider.initialize_model_parallel(seed=0)
+        model_provider.finalize()
         model = model_provider.provide_distributed_model(wrap_with_ddp=False)
 
     model = [m.cuda() for m in model]


### PR DESCRIPTION
# What does this PR do?

Fix example conversion scripts: normalize precision-sensitive parameters to float32 during weight comparison, and add missing `finalize()` call in VLM conversion.

Cherry-pick of #2862 (targeting `r0.3.0`) to `main`.

# Changelog

- Fix `hf_megatron_roundtrip_multi_gpu.py`: cast known precision-sensitive params (`e_score_correction_bias`, `A_log`, `linear_attn.norm.weight`) to float32 before comparison to avoid false mismatches between Megatron and HF dtypes
- Fix `hf_to_megatron_generate_nemotron_vlm.py`: add missing `model_provider.finalize()` call before `provide_distributed_model`

# GitHub Actions CI

See the CI section in the Contributing doc for how to trigger the CI.
A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

Pre checks:
- [x] Make sure you read and followed Contributor guidelines
- [ ] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

Cherry-pick of #2862 (`r0.3.0`) to `main`.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed initialization sequence in the HuggingFace-to-Megatron conversion example to ensure proper model provider setup before distributed model creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->