### PR TITLE
fix: Guard missing kubernetes deps

### DIFF
--- a/examples/evaluation/utils/executors.py
+++ b/examples/evaluation/utils/executors.py
@@ -17,7 +17,16 @@ from typing import Dict, List
 
 import nemo_run as run
 from nemo_run.config import get_nemorun_home
-from nemo_run.core.execution.kuberay import KubeRayExecutor, KubeRayWorkerGroup
+
+
+try:
+    from nemo_run.core.execution.kuberay import KubeRayExecutor, KubeRayWorkerGroup
+
+    HAVE_KUBERNETES = True
+except ImportError:
+    KubeRayExecutor = None
+    KubeRayWorkerGroup = None
+    HAVE_KUBERNETES = False
 
 
 def slurm_executor(
@@ -82,6 +91,10 @@ def kuberay_executor(
     Kuberay cluster definition with appropriate cluster params and NeMo container params needed for pre-training
     and fine-tuning experiments
     """
+    if not HAVE_KUBERNETES:
+        raise ImportError(
+            "KubeRayExecutor is not available. Please install nemo-run with Kubernetes support: pip install nemo-run[ray]"
+        )
 
     env_vars = {
         "TORCH_HOME": "/nemo-workspace/.cache",


### PR DESCRIPTION
# What does this PR do ?

KubeRay requires Kubernetes, which we don't install by default. Instead of adding Kubernetes, I'll guard against missing dep.

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced compatibility for environments without Kubernetes support with clearer error messages guiding users to install required dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->