### PR TITLE
[recipe] fix: pass trust_remote_code=True for Kimi-K2 HF config loading

### DIFF
--- a/src/megatron/bridge/recipes/kimi/kimi_k2.py
+++ b/src/megatron/bridge/recipes/kimi/kimi_k2.py
@@ -61,7 +61,9 @@ def kimi_k2_pretrain_config(optimizer_type: str = "muon") -> ConfigContainer:
     cfg = _pretrain_common()
 
     # Model config via AutoBridge (dispatches to KimiK2Bridge)
-    cfg.model = AutoBridge.from_hf_pretrained("moonshotai/Kimi-K2-Instruct").to_megatron_provider(load_weights=False)
+    cfg.model = AutoBridge.from_hf_pretrained(
+        "moonshotai/Kimi-K2-Instruct", trust_remote_code=True
+    ).to_megatron_provider(load_weights=False)
 
     # Parallelism
     cfg.model.tensor_model_parallel_size = 2


### PR DESCRIPTION
## Summary
- The `moonshotai/Kimi-K2-Instruct` HuggingFace repository contains custom modeling code, which requires `trust_remote_code=True` to load the config.
- The Kimi-K2 pretrain recipe calls `AutoBridge.from_hf_pretrained("moonshotai/Kimi-K2-Instruct")` without passing `trust_remote_code=True`, causing `safe_load_config_with_retry` to fail with a `ValueError` after 4 retry attempts.
- This one-line fix passes `trust_remote_code=True` to unblock CI (e.g. the 256-GPU Kimi-K2 perf job).

## Test plan
- [ ] Verify CI perf job `kimi_kimi_k2_pretrain_config_256gpus_gb300_slurm_fp8_mx_v1_perf` no longer hits the `trust_remote_code` error.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Model loading now supports remote code execution, enabling access to a broader range of models from Hugging Face Hub.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->