### PR TITLE
ci: Run L0+L1 tests on dependency bump PRs

### DIFF
--- a/.github/workflows/_update_dependencies.yml
+++ b/.github/workflows/_update_dependencies.yml
@@ -115,6 +115,7 @@ jobs:
           commit-message: ${{ env.title }}
           signoff: true
           committer: "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
+          labels: needs-more-tests
 
       - name: Post /ok to test comment
         env:


### PR DESCRIPTION
## Summary

- Adds `labels: needs-more-tests` to the `peter-evans/create-pull-request` step in `_update_dependencies.yml`

## Why

The `cicd-main.yml` L1 tests only run on `main` push, scheduled runs, `workflow_dispatch`, or PRs labeled `needs-more-tests`. Dependency bump PRs created by `_update_dependencies.yml` had none of these, so L1 tests were silently skipped — only L0 ran.

Adding this label ensures both L0 and L1 tests run on every bump PR before it is auto-merged.

## Test plan
- [ ] Trigger `_update_dependencies.yml` and verify the created bump PR has `needs-more-tests` label
- [ ] Confirm L1 jobs appear in the CI run for that PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated dependency update workflow to automatically label pull requests with "needs-more-tests" for improved testing visibility and review coordination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->