### PR TITLE
perf: Update GPT-OSS 120B B300 defaults to PP=4, EP=8, MBS=1

### DIFF
--- a/scripts/performance/configs/gpt_oss/gpt_oss_workload_base_configs.py
+++ b/scripts/performance/configs/gpt_oss/gpt_oss_workload_base_configs.py
@@ -61,8 +61,7 @@ GPT_OSS_120B_PRETRAIN_CONFIG_GB200_BF16_V1 = replace(
 
 GPT_OSS_120B_PRETRAIN_CONFIG_B300_BF16_V1 = replace(
     BASE_GPT_OSS_120B_CONFIG,
-    expert_model_parallel_size=64,
-    micro_batch_size=4,
+    pipeline_model_parallel_size=4,
     cuda_graph_impl="transformer_engine",
     cuda_graph_scope=["attn", "moe_router", "moe_preprocess"],
 )


### PR DESCRIPTION
Change the default parallelism config for GPT-OSS 120B pretraining on B300 GPUs from EP=64/MBS=4 to PP=4/EP=8/MBS=1.

# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated model training configuration parameters for optimized resource allocation settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->