### PR TITLE
fix(ci): properly revert Megatron-LM submodule for dev bumps

### DIFF
--- a/.github/workflows/_update_dependencies.yml
+++ b/.github/workflows/_update_dependencies.yml
@@ -201,7 +201,9 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git fetch origin ${{ env.TARGET_BRANCH }}
-          git restore --source=origin/${{ env.TARGET_BRANCH }} -- 3rdparty/Megatron-LM uv.lock
+          TARGET_MLM_COMMIT=$(git ls-tree origin/${{ env.TARGET_BRANCH }} -- 3rdparty/Megatron-LM | awk '{print $3}')
+          git -C 3rdparty/Megatron-LM checkout "$TARGET_MLM_COMMIT"
+          git restore --source=origin/${{ env.TARGET_BRANCH }} -- uv.lock
           git add 3rdparty/Megatron-LM uv.lock
           git commit -m "Revert submodule bump for dev branch"
           git push origin ${{ env.SOURCE_BRANCH }}


### PR DESCRIPTION
## Summary

- `git add <submodule>` always stages the submodule's **current working-tree HEAD**, so the previous `git restore --source=origin/TARGET_BRANCH -- 3rdparty/Megatron-LM` had no lasting effect — the subsequent `git add` immediately re-staged the dev branch commit
- Fix: use `git ls-tree` to get the exact submodule commit TARGET_BRANCH uses, check it out explicitly, then add

## Test plan

- [ ] Trigger a dev bump and verify `3rdparty/Megatron-LM` pointer in the squash-merge commit matches `main`'s pointer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency management workflow to improve handling of submodule and lock file synchronization across branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->