### PR TITLE
[test] fix: Speed up test_collate_fn_respects_pad_seq_length_to_mult

### DIFF
--- a/tests/unit_tests/data/datasets/test_sft.py
+++ b/tests/unit_tests/data/datasets/test_sft.py
@@ -331,7 +331,7 @@ class TestDataGPTSFTChatDataset:
         path = str(datasets_dir / "sft.jsonl")
         line = {"input": "hi how are you?", "output": "I'm fine, thanks."}
         with open(path, "w") as f:
-            for _ in range(10):
+            for _ in range(2):
                 f.write(json.dumps(line) + "\n")
 
         tokenizer = create_mock_tokenizer()
@@ -342,6 +342,7 @@ class TestDataGPTSFTChatDataset:
             prompt_template="{input}\n\n### Response:\n{output}",
             truncation_field="output",
             pad_seq_length_to_mult=32,
+            memmap_workers=1,
         )
         batch = [
             {


### PR DESCRIPTION
# What does this PR do?

Speed up `test_collate_fn_respects_pad_seq_length_to_mult` by eliminating unnecessary multiprocessing overhead in the test setup.

GPTSFTChatDataset(...) init takes ~530ms, with 99.9% spent in _load_dataset() → _JSONLMemMapDataset → build_index_files() →
  safe_map(). The safe_map function spawns 64 fork processes (os.cpu_count() // 2 on this 128-core machine) to index a 10-line JSONL file. The
  multiprocessing fork overhead dominates completely.

  Fix applied: Added memmap_workers=1 to the GPTSFTChatDataset constructor in test_collate_fn_respects_pad_seq_length_to_mult. This reduces init
  time from ~530ms → ~30ms (~20x faster).

# Changelog

- Set `memmap_workers=1` to avoid spawning `cpu_count/2` worker processes for a tiny test dataset
- Reduce JSONL sample count from 10 to 2 (the batch is manually constructed, so extra samples are unused)

# GitHub Actions CI

See the CI section in the Contributing doc for how to trigger the CI.
A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

Pre checks:
- [x] Make sure you read and followed Contributor guidelines
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized test dataset configuration to reduce test execution overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->