### PR TITLE
Remove Bia specific pinning.

### DIFF
--- a/scripts/performance/utils/executors.py
+++ b/scripts/performance/utils/executors.py
@@ -131,8 +131,6 @@ def slurm_executor(
 
     numa_divisor = 2 if gpu.lower() in ["gb200", "gb300"] else 4
     numa_cmd = f"numactl --cpunodebind=$((SLURM_LOCALID/{numa_divisor})) --membind=$((SLURM_LOCALID/{numa_divisor}))"
-    if gpu.lower() in ["b300"]:
-        numa_cmd += " -C $((SLURM_LOCALID * 16)),$((SLURM_LOCALID * 16 + 1))"
     custom_bash_cmds.append(numa_cmd)
 
     launcher = SlurmTemplate(


### PR DESCRIPTION
It causes issues for any system that doesn't match Bia's proc.

For LLMB 26.02 workloads small to no perf impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CPU binding configuration for B300 GPU systems in performance testing utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->