### PR TITLE
[model] fix: restore position_embedding_type and gradient_accumulation_fusion for MLA models

### DIFF
--- a/src/megatron/bridge/models/conversion/model_bridge.py
+++ b/src/megatron/bridge/models/conversion/model_bridge.py
@@ -448,6 +448,7 @@ class MegatronModelBridge(MegatronPeftBridge, Generic[HFPreTrained, ModelProvide
             ModelProviderTarget: A configured model provider instance
         """
         from megatron.bridge.models.gpt_provider import GPTModelProvider
+        from megatron.bridge.models.mla_provider import MLAModelProvider
 
         hf_config = hf_pretrained.config
 
@@ -458,22 +459,25 @@ class MegatronModelBridge(MegatronPeftBridge, Generic[HFPreTrained, ModelProvide
 
         # Use specified provider class, defaulting to GPTModelProvider
         provider_class = self.PROVIDER_CLASS if self.PROVIDER_CLASS is not None else GPTModelProvider
+        is_mla_provider = issubclass(provider_class, MLAModelProvider)
         # Filter kwargs to only fields the provider dataclass accepts, so that MLA-only None
         # values (q_lora_rank, kv_lora_rank, …) are silently dropped for non-MLA providers
         # while still being passed through for MLA providers that declare them as fields.
         valid_fields = provider_class.__dataclass_fields__
         provider = provider_class(**{k: v for k, v in provider_kwargs.items() if k in valid_fields})
 
-        # All models that flow through the base provider_bridge use RoPE.
-        # YARN is already handled above (hf_config_to_provider_kwargs sets
-        # position_embedding_type="yarn"), so we only need to guard against
-        # overwriting it here.  Every other rope_type value (None, "default",
-        # "llama3", "longrope", …) means plain RoPE.
+        # Determine position_embedding_type from HF rope_scaling.
+        # For GPT providers: rope_type=="yarn" → "yarn"; everything else → "rope".
+        # For MLA providers: always "rope" — YaRN scaling parameters are applied
+        # separately via mla_rope_params (rotary_scaling_factor, mscale, etc.) and
+        # position_embedding_type="yarn" is not a valid MLA config value.
         hf_rope_scaling = getattr(hf_config, "rope_scaling", None)
         rope_type = None
         if hf_rope_scaling:
             rope_type = hf_rope_scaling.get("type") or hf_rope_scaling.get("rope_type")
-        if rope_type != "yarn":
+        if rope_type == "yarn" and not is_mla_provider:
+            provider.position_embedding_type = "yarn"
+        else:
             provider.position_embedding_type = "rope"
 
         # Apply MLA rope params via setattr (for MLA models like DeepSeek, Kimi)

--- a/src/megatron/bridge/models/deepseek/deepseek_v2_bridge.py
+++ b/src/megatron/bridge/models/deepseek/deepseek_v2_bridge.py
@@ -62,6 +62,7 @@ class DeepSeekV2Bridge(MegatronModelBridge):
         provider.moe_permute_fusion = True
 
         provider.apply_rope_fusion = False
+        provider.gradient_accumulation_fusion = True
         provider.bias_activation_fusion = True
         provider.bias_dropout_fusion = True
         provider.cross_entropy_fusion_impl = "te"

--- a/src/megatron/bridge/models/deepseek/deepseek_v3_bridge.py
+++ b/src/megatron/bridge/models/deepseek/deepseek_v3_bridge.py
@@ -69,6 +69,7 @@ class DeepSeekV3Bridge(MegatronModelBridge):
         provider.moe_aux_loss_coeff = 0.0001
 
         provider.apply_rope_fusion = False
+        provider.gradient_accumulation_fusion = True
         provider.bias_activation_fusion = True
         provider.bias_dropout_fusion = True
         provider.cross_entropy_fusion_impl = "te"


### PR DESCRIPTION
## Problem

Two regressions caused a ~30% perf drop on DSV3 GB300 MXFP8 (1292 → 914 TFLOPs, March 14 → March 18), both introduced by PRs #2599 and #2739:

1. `position_embedding_type` changed from `rope` to `learned_absolute`
2. `gradient_accumulation_fusion` changed from `True` to `False`

## Root Causes & Fixes

### Fix 1: `position_embedding_type` for MLA providers (`model_bridge.py`)

PR #2599 deleted `deepseek_provider.py` which had `position_embedding_type: str = "rope"` as a class field on `DeepSeekModelProvider`. After switching to raw `MLAModelProvider`, this default was lost.

The base `provider_bridge()` only set `"rope"` when `rope_type != "yarn"` — but DSV3's HF config has `rope_scaling.type = "yarn"`, so the guard tripped and `position_embedding_type` fell through to `GPTModelProvider`'s default `"learned_absolute"`.

**Fix:** For MLA providers, `position_embedding_type` must always be `"rope"` — YaRN scaling is handled separately via `mla_rope_params` (not via `position_embedding_type`). Added `is_mla_provider` check in `provider_bridge()` to handle this correctly.

### Fix 2: `gradient_accumulation_fusion` for DeepSeek V2/V3 (`deepseek_v2/v3_bridge.py`)

PR #2739 removed the hardcoded `provider.gradient_accumulation_fusion = True` from the DeepSeek bridges to use the dynamic `can_enable_gradient_accumulation_fusion()` check. That check returns `False` if the `fused_weight_gradient_mlp_cuda` CUDA extension (from APEX) is not importable, silently disabling the fusion with no error.

**Fix:** Restore explicit `gradient_accumulation_fusion = True` in `DeepSeekV2Bridge` and `DeepSeekV3Bridge`.

## Test Plan

- [ ] DSV3 GB300 MXFP8 perf run to verify TFLOPs recover to ~1292
- [ ] Confirm config diff shows `position_embedding_type=rope` and `gradient_accumulation_fusion=True`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced position embedding handling with improved support for MLA model variants
  * Enabled gradient accumulation fusion optimization for DeepSeek V2 and V3 models to improve training performance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->