### PR TITLE
[model] fix: add SP scatter to Ministral3 VLM forward path

### DIFF
--- a/src/megatron/bridge/models/ministral3/modeling_ministral3.py
+++ b/src/megatron/bridge/models/ministral3/modeling_ministral3.py
@@ -262,6 +262,12 @@ class Ministral3Model(MegatronModule):
             pg_collection=self.config._pg_collection,
         )
 
+        # Apply SP scatter after CP slice
+        if self.config.sequence_parallel and inputs_embeds is not None:
+            from megatron.core.tensor_parallel.mappings import scatter_to_sequence_parallel_region
+
+            inputs_embeds = scatter_to_sequence_parallel_region(inputs_embeds)
+
         # Forward through Megatron language model
         outputs = self.language_model.forward(
             input_ids=None,


### PR DESCRIPTION
# What does this PR do?

Add the missing `scatter_to_sequence_parallel_region` call to `Ministral3Model.forward()` so that sequence parallelism works correctly.

# Changelog

- Add SP scatter after combining text + vision embeddings in Ministral3, matching the pattern used in all other VLMs (Qwen2.5-VL, Qwen3-VL, GLM-4.5V, Gemma3-VL, MCore LLaVA)

# GitHub Actions CI

See the CI section in the Contributing doc for how to trigger the CI.
A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

Pre checks:
- [x] Make sure you read and followed Contributor guidelines
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

Without this fix, Ministral3 VLM training with `sequence_parallel=True` would fail because the combined embeddings were not scattered across TP ranks before entering the transformer block.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Added sequence parallelism support to Ministral3 model, enabling improved performance and scalability in distributed computing environments when enabled through configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->