### PR TITLE
ci: upgrade GitHub Actions for Node.js 24 compatibility

### DIFF
--- a/.github/actions/test-template/action.yml
+++ b/.github/actions/test-template/action.yml
@@ -64,7 +64,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v6
       with:
         path: ${{ github.workspace }}/Megatron-Bridge
         submodules: recursive
@@ -254,7 +254,7 @@ runs:
         echo "::endgroup::"
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       if: ${{ steps.check.outputs.coverage_report != 'none' }}
       with:
         name: ${{ steps.check.outputs.coverage_report }}

--- a/.github/workflows/_update_dependencies.yml
+++ b/.github/workflows/_update_dependencies.yml
@@ -43,7 +43,7 @@ jobs:
       TARGET_BRANCH: ${{ inputs.target-branch }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ env.TARGET_BRANCH }}
           token: ${{ secrets.PAT }}
@@ -63,7 +63,7 @@ jobs:
           fi
 
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ env.SOURCE_BRANCH }}
           token: ${{ secrets.PAT }}

--- a/.github/workflows/cache-hf-model.yml
+++ b/.github/workflows/cache-hf-model.yml
@@ -30,12 +30,12 @@ jobs:
       HF_HOME: /mnt/datadrive/TestData/HF_HOME
     steps:
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/changelog-build.yml
+++ b/.github/workflows/changelog-build.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 0
@@ -80,7 +80,7 @@ jobs:
         run: cat CHANGELOG.md
 
       - name: Create or update label
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         with:
           script: |
             const labelName = '${{ inputs.release-branch }}';

--- a/.github/workflows/cicd-approve-test-queue.yml
+++ b/.github/workflows/cicd-approve-test-queue.yml
@@ -30,10 +30,10 @@ jobs:
         contributor_type: [internal, external]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -86,7 +86,7 @@ jobs:
       )
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: "recursive"
 
@@ -157,7 +157,7 @@ jobs:
           echo "main=${SHA}" | tee -a "$GITHUB_OUTPUT"
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
           ref: ${{ steps.sha.outputs.main }}
@@ -200,7 +200,7 @@ jobs:
           echo "⚙️ MCore testing mode: skipping --locked flag because lockfile was generated with different MCore version"
 
       - name: Setup python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.12
 
@@ -341,7 +341,7 @@ jobs:
       HF_HUB_OFFLINE: "1"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -402,7 +402,7 @@ jobs:
       HF_HUB_OFFLINE: "1"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -454,7 +454,7 @@ jobs:
       matrix_l2: ${{ steps.scan.outputs.matrix_l2 }}
       matrix_flaky: ${{ steps.scan.outputs.matrix_flaky }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - id: scan
         shell: bash
         run: |
@@ -507,7 +507,7 @@ jobs:
       HF_HUB_OFFLINE: "1"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -575,7 +575,7 @@ jobs:
       HF_HUB_OFFLINE: "1"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -643,7 +643,7 @@ jobs:
       HF_HUB_OFFLINE: "1"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -702,7 +702,7 @@ jobs:
       HF_HUB_OFFLINE: "1"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -767,7 +767,7 @@ jobs:
     permissions: write-all
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Get workflow result
         id: result
@@ -827,7 +827,7 @@ jobs:
       )
     steps:
       - name: Generate fake coverage report
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.PAT }}
           script: |
@@ -856,10 +856,10 @@ jobs:
           - e2e
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download coverage reports of current branch
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: coverage-${{ matrix.flag }}-*
 
@@ -884,7 +884,7 @@ jobs:
           flags: ${{ matrix.flag }}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: coverage-${{ matrix.flag }}-aggregated
           path: |

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -89,7 +89,7 @@ jobs:
   #         apt-get install -y git
 
   #     - name: Checkout repository
-  #       uses: actions/checkout@v4
+  #       uses: actions/checkout@v6
   #       with:
   #         submodules: recursive
 
@@ -107,7 +107,7 @@ jobs:
   #       run: bash docker/common/install.sh --base-image pytorch --python-version ${{ matrix.python-version }}
 
   #     - name: Checkout check-imports
-  #       uses: actions/checkout@v4
+  #       uses: actions/checkout@v6
   #       with:
   #         repository: NVIDIA-NeMo/FW-CI-templates
   #         ref: v0.39.0
@@ -140,7 +140,7 @@ jobs:
           apt-get install -y git
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 

--- a/.github/workflows/release-freeze.yml
+++ b/.github/workflows/release-freeze.yml
@@ -56,7 +56,7 @@ jobs:
       DRY_RUN: ${{ inputs.dry-run }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
           token: ${{ secrets.PAT }}


### PR DESCRIPTION
## Summary

Upgrades all GitHub Actions to versions compatible with the Node.js 24 runtime, which GitHub is rolling out as the new runner default.

**Action upgrades:**
- `actions/checkout`: any version → `v6`
- `actions/upload-artifact`: any version → `v6`
- `actions/download-artifact`: any version → `v7`
- `actions/github-script`: any version → `v8`
- `actions/setup-python`: any version → `v6`

Mirrors: https://github.com/NVIDIA/Megatron-LM/commit/1d5e68b0749f0fc075250fae4e36081d972379a8

## Test plan
- [ ] Verify CI pipelines pass after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow dependencies to newer major versions across multiple CI/CD configuration files. Upgrades include checkout, Python setup, GitHub script functionality, and artifact handling actions to ensure compatibility and maintain security standards in build and deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->