### PR TITLE
[perf] feat: support Hydra-style CLI config overrides in run_recipe.py

### DIFF
--- a/scripts/performance/run_recipe.py
+++ b/scripts/performance/run_recipe.py
@@ -31,6 +31,7 @@ from utils.datasets import (
 from utils.utils import get_library_recipe
 
 from megatron.bridge.recipes.utils.determinism_utils import apply_determinism_overrides
+from megatron.bridge.training.utils.omegaconf_utils import process_config_with_overrides
 from megatron.bridge.utils.common_utils import get_rank_safe
 
 
@@ -207,9 +208,10 @@ def set_user_overrides(config, args):
 def main():
     """Main entry point for the training script."""
 
-    # Parse known args and capture unknown ones for config overrides
+    # Parse known args and capture unknown ones for Hydra-style config overrides
+    # (e.g. model.hidden_size=15360 model.num_moe_experts=8)
     parser = parse_cli_args()
-    args, _ = parser.parse_known_args()
+    args, cli_overrides = parser.parse_known_args()
 
     recipe = get_library_recipe(
         model_family_name=args.model_family_name,
@@ -219,6 +221,10 @@ def main():
     )
 
     recipe = set_user_overrides(recipe, args)
+
+    if cli_overrides:
+        logging.info("Applying %d CLI config override(s)", len(cli_overrides))
+        recipe = process_config_with_overrides(recipe, cli_overrides=cli_overrides)
 
     if args.dryrun:
         save_path = args.save_config_filepath or "ConfigContainer.yaml"


### PR DESCRIPTION
## Summary
- `scripts/performance/run_recipe.py` (`--use_recipes` mode) now captures unknown CLI args from `parse_known_args()` and applies them via `process_config_with_overrides()`, enabling Hydra-style dotted overrides (e.g. `model.hidden_size=15360`, `model.num_moe_experts=8`).
- This matches the existing pattern in `scripts/training/run_recipe.py` and unblocks running custom MoE proxy benchmarks via `--use_recipes` without needing a pre-built performance config.
- Only 2 lines of logic changed (+ 1 import): capture `cli_overrides` instead of discarding them, then call `process_config_with_overrides` after `set_user_overrides`.

## Motivation
The GPT MoE proxy benchmark model uses `--use_recipes` with `model_family_name=gpt, model_recipe_name=gpt3_175b`, then overrides model architecture fields (hidden_size, num_layers, num_moe_experts, moe_router_topk, etc.) to create a custom MoE proxy. Previously `set_user_overrides()` only handled parallelism and batch sizes — model architecture overrides were silently dropped because `parse_known_args()` discarded unknown args.

## Usage
```bash
python run_recipe.py \
    --use_recipes -m gpt -mr gpt3_175b --task pretrain \
    model.hidden_size=15360 \
    model.num_layers=30 \
    model.num_attention_heads=96 \
    model.ffn_hidden_size=49152 \
    model.num_moe_experts=8 \
    model.moe_router_topk=2 \
    model.moe_aux_loss_coeff=0.001 \
    model.moe_token_dispatcher_type=alltoall \
    model.add_bias_linear=False \
    model.moe_pad_expert_input_to_capacity=True \
    model.moe_expert_capacity_factor=1.0
```

## Test plan
- [ ] Verify `run_recipe.py` with `--use_recipes` + Hydra-style model overrides produces correct `ConfigContainer` (check `print_yaml()` output)
- [ ] Verify existing argparse-based overrides (TP/PP/EP/GBS/MBS) still work unchanged
- [ ] Verify unknown args without `=` (typos) produce a clear Hydra parse error, not silent failure


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now pass Hydra-style configuration overrides directly via the command line when executing recipes, providing more granular control over runtime parameters without modifying configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->