### PR TITLE
Change pytest fixture to not autouse

### DIFF
--- a/tests/unit_tests/data/datasets/test_sft.py
+++ b/tests/unit_tests/data/datasets/test_sft.py
@@ -12,16 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import datetime
 import json
-import os
 from unittest.mock import MagicMock
 
-import megatron.core.parallel_state as parallel_state
 import numpy as np
-import pytest
-import torch
-import torch.distributed as dist
 
 from megatron.bridge.data.datasets.sft import GPTSFTChatDataset, GPTSFTDataset, GPTSFTPackedDataset
 
@@ -50,7 +44,8 @@ def get_gpt_sft(tmp_path, dataset_type="sft"):
     path = str(datasets_dir / "sft.jsonl")
     line = {"input": "hi how are you?", "output": "I'm fine, thanks."}
 
-    num_samples = 100
+    # Enough rows for index checks (e.g. [11] and [-11]); keep small for fast IO and mapping.
+    num_samples = 24
     with open(path, "w") as f:
         for i in range(num_samples):
             f.write(json.dumps(line) + "\n")
@@ -65,6 +60,7 @@ def get_gpt_sft(tmp_path, dataset_type="sft"):
             max_num_samples=num_samples,
             prompt_template="{input}\n\n### Response:\n{output}",
             truncation_field="output",
+            memmap_workers=1,
         )
     elif dataset_type == "packed":
         # Create a mock packed dataset file
@@ -87,6 +83,7 @@ def get_gpt_sft(tmp_path, dataset_type="sft"):
             label_key="output",
             prompt_template="{input}\n\n### Response:\n{output}",
             truncation_field="output",
+            memmap_workers=1,
         )
     else:
         dataset = GPTSFTChatDataset(
@@ -95,74 +92,13 @@ def get_gpt_sft(tmp_path, dataset_type="sft"):
             label_key="output",
             prompt_template="{input}\n\n### Response:\n{output}",
             truncation_field="output",
+            memmap_workers=1,
         )
 
     return dataset, num_samples
 
 
 class TestDataGPTSFTDataset:
-    @pytest.fixture()
-    def setup_and_teardown_parallel_state(self):
-        """Setup and teardown parallel state for Megatron tests."""
-
-        if not dist.is_initialized():
-            os.environ["MASTER_ADDR"] = "127.0.0.1"
-            os.environ["MASTER_PORT"] = "29500"
-            os.environ["RANK"] = "0"
-            os.environ["LOCAL_RANK"] = "0"
-            os.environ["WORLD_SIZE"] = "1"
-
-            device_count = torch.cuda.device_count()
-            if device_count > 0:
-                torch.cuda.set_device(0)
-
-            init_process_group_kwargs = {
-                "backend": "nccl" if device_count > 0 else "gloo",
-                "world_size": 1,
-                "rank": 0,
-                "timeout": datetime.timedelta(minutes=30),
-            }
-
-            dist.init_process_group(**init_process_group_kwargs)
-
-        assert dist.is_initialized(), "Distributed backend not initialized"
-        if not parallel_state.model_parallel_is_initialized():
-            parallel_state.initialize_model_parallel(
-                tensor_model_parallel_size=1,
-                pipeline_model_parallel_size=1,
-                virtual_pipeline_model_parallel_size=None,
-                context_parallel_size=1,
-            )
-
-        assert parallel_state.model_parallel_is_initialized(), "Model parallel not initialized"
-        from megatron.core.process_groups_config import ProcessGroupCollection
-
-        from megatron.bridge.training.initialize import _set_random_seed
-
-        # Create pg_collection from initialized mpu
-        pg_collection = ProcessGroupCollection.use_mpu_process_groups()
-
-        _set_random_seed(
-            seed_=1234,
-            data_parallel_random_init=False,
-            te_rng_tracker=True,
-            inference_rng_tracker=False,
-            pg_collection=pg_collection,
-        )
-
-        yield
-
-        try:
-            if parallel_state.model_parallel_is_initialized():
-                parallel_state.destroy_model_parallel()
-            if dist.is_initialized():
-                dist.destroy_process_group()
-                # Clean up environment variables
-                for key in ["MASTER_ADDR", "MASTER_PORT", "RANK", "LOCAL_RANK", "WORLD_SIZE"]:
-                    os.environ.pop(key, None)
-        except (NameError, AttributeError, RuntimeError):
-            pass
-
     def test_build_samples_mapping(self, tmp_path):
         dataset, _ = get_gpt_sft(tmp_path)
         dataset._build_samples_mapping()


### PR DESCRIPTION
  - Remove `autouse=True` from `setup_and_teardown_parallel_state` fixture in `TestDataGPTSFTDataset`
  - None of the 6 tests in this class need distributed process groups, model parallel state, or random seed init — they test pure string parsing, list manipulation, and local tensor ops

  ## Performance

  `test_separate_template` call time: **2.41s → 0.38s (~6x faster)**. Same speedup applies to all 6 tests in the class since the
  fixture added ~2s of overhead per test (dist.init_process_group + parallel_state.initialize_model_parallel + teardown).

  Total class runtime dropped from ~17s to ~2.5s.

# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test fixture configuration to execute only when explicitly requested rather than automatically for all tests in the suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->