### PR TITLE
[model] feat: add get_model/load_weights/save_weights facade on AutoBridge

### DIFF
--- a/src/megatron/bridge/models/conversion/auto_bridge.py
+++ b/src/megatron/bridge/models/conversion/auto_bridge.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import dataclasses
+import warnings
 from functools import cached_property, partial
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Generic, Iterable, List, Optional, Type, TypeVar, Union
@@ -96,7 +97,7 @@ class AutoBridge(Generic[MegatronModelT]):
         >>> megatron_model = provider.provide_distributed_model(wrap_with_ddp=False)
 
         >>> # Export a Megatron model back to HuggingFace format
-        >>> bridge.save_hf_pretrained(megatron_model, "./exported_model")
+        >>> bridge.save_weights(megatron_model, "./exported_model")
 
         >>> # Convert weights with custom settings
         >>> for name, weight in bridge.export_hf_weights(
@@ -293,55 +294,219 @@ class AutoBridge(Generic[MegatronModelT]):
         model: list[MegatronModelT],
         hf_path: str | Path | None = None,
         allowed_mismatched_params: list[str] | None = None,
-    ) -> None:
-        """
-        Load HuggingFace weights into a Megatron model.
+    ) -> list[MegatronModelT]:
+        """Load HuggingFace weights into a Megatron model.
 
-        This method handles the conversion and distribution of weights from
-        HuggingFace format to Megatron's distributed format, including proper
-        tensor parallel and pipeline parallel distribution.
+        .. deprecated::
+            Use :meth:`load_weights` instead. ``load_hf_weights`` will be
+            removed in a future release.
 
         Args:
-            model: List of Megatron model instances (one per virtual pipeline stage)
+            model: List of Megatron model instances (one per virtual pipeline stage).
             hf_path: Optional path to load weights from. If None, uses weights
-                from the bridge's hf_pretrained instance
+                from the bridge's ``hf_pretrained`` instance.
             allowed_mismatched_params: Optional list of parameter names or patterns
-                to allow mismatch (skip instead of raise error).
+                to allow mismatch (skipped instead of raising an error).
 
         Returns:
-            The input model with loaded weights
+            The input model with loaded weights.
+        """
+        warnings.warn(
+            "load_hf_weights() is deprecated and will be removed in a future release. Use load_weights() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.load_weights(model, path=hf_path, allowed_mismatched_params=allowed_mismatched_params)
 
-        Raises:
-            ValueError: If hf_path is None and bridge was created without weights
+    def get_model(
+        self,
+        tp: int = 1,
+        pp: int = 1,
+        cp: int = 1,
+        ep: int = 1,
+        load_weights: bool = True,
+        hf_path: str | Path | None = None,
+    ) -> list[MegatronModelT]:
+        """Create a distributed Megatron model from the HuggingFace checkpoint.
+
+        This is the primary entry point for users who want to get a ready-to-use
+        Megatron model without interacting with the provider API directly. It
+        combines provider creation, parallelism configuration, and weight loading
+        into a single call.
+
+        Args:
+            tp: Tensor model parallel size (default: 1).
+            pp: Pipeline model parallel size (default: 1).
+            cp: Context parallel size (default: 1).
+            ep: Expert model parallel size for MoE models (default: 1).
+            load_weights: Whether to load HuggingFace weights into the model.
+                Set to False for random initialization. (default: True)
+            hf_path: Optional path to load weights from. If None, uses weights
+                from the bridge's ``hf_pretrained`` instance.
+
+        Returns:
+            List of Megatron model instances (one per virtual pipeline stage).
 
         Example:
-            >>> # Load weights from bridge's pretrained model
-            >>> bridge = AutoBridge.from_hf_pretrained("gpt2")
-            >>> megatron_model = create_megatron_model()  # Your model creation
-            >>> bridge.load_hf_weights(megatron_model)
+            >>> # Single-GPU inference
+            >>> bridge = AutoBridge.from_hf_pretrained("meta-llama/Llama-3.2-1B")
+            >>> model = bridge.get_model()
 
-            >>> # Load weights from a different checkpoint
-            >>> bridge.load_hf_weights(megatron_model, "./finetuned_model")
+            >>> # Tensor parallel across 8 GPUs
+            >>> bridge = AutoBridge.from_hf_pretrained("meta-llama/Llama-3.2-1B")
+            >>> model = bridge.get_model(tp=8)
 
-            >>> # Load weights with allowed mismatched parameters
-            >>> bridge.load_hf_weights(
-            ...     megatron_model,
-            ...     allowed_mismatched_params=["*.bias", "decoder.layers.0.*"]
-            ... )
+            >>> # Separate weight loading
+            >>> bridge = AutoBridge.from_hf_pretrained("meta-llama/Llama-3.2-1B")
+            >>> model = bridge.get_model(tp=4, load_weights=False)
+            >>> bridge.load_weights(model)
+
+        See Also:
+            to_megatron_provider: Access the provider directly for advanced configuration.
+            load_weights: Load weights into an existing model.
+            save_weights: Export model weights back to HuggingFace format.
         """
-        if hf_path is None:
+        provider = self.to_megatron_provider(load_weights=load_weights, hf_path=hf_path)
+        if tp != 1:
+            provider.tensor_model_parallel_size = tp
+        if pp != 1:
+            provider.pipeline_model_parallel_size = pp
+        if cp != 1:
+            provider.context_parallel_size = cp
+        if ep != 1:
+            provider.expert_model_parallel_size = ep
+        if hasattr(provider, "finalize"):
+            provider.finalize()
+        return provider.provide_distributed_model(wrap_with_ddp=False)
+
+    def load_weights(
+        self,
+        model: list[MegatronModelT],
+        path: str | Path | None = None,
+        allowed_mismatched_params: list[str] | None = None,
+    ) -> list[MegatronModelT]:
+        """Load HuggingFace weights into a Megatron model.
+
+        Handles the conversion and distribution of weights from HuggingFace format
+        to Megatron's distributed format, including tensor parallel and pipeline
+        parallel distribution.
+
+        Args:
+            model: List of Megatron model instances (one per virtual pipeline stage).
+            path: Optional path to load weights from. If None, uses weights
+                from the bridge's ``hf_pretrained`` instance.
+            allowed_mismatched_params: Optional list of parameter name patterns
+                to allow mismatch (skipped instead of raising an error).
+
+        Returns:
+            The input model list with loaded weights.
+
+        Raises:
+            ValueError: If ``path`` is None and the bridge was created without weights
+                (i.e., via :meth:`from_hf_config`).
+
+        Example:
+            >>> bridge = AutoBridge.from_hf_pretrained("meta-llama/Llama-3.2-1B")
+            >>> model = bridge.get_model(load_weights=False)
+            >>> bridge.load_weights(model)
+
+            >>> # Load from a different checkpoint
+            >>> bridge.load_weights(model, path="./finetuned_model")
+
+            >>> # Allow certain params to be missing
+            >>> bridge.load_weights(model, allowed_mismatched_params=["*.bias"])
+        """
+        if path is None:
             if not isinstance(self.hf_pretrained, PreTrainedCausalLM):
-                raise ValueError("hf_path is required when hf_pretrained is not a PreTrainedCausalLM instance")
+                raise ValueError("path is required when the bridge was created without weights (from_hf_config)")
             pre_trained = self.hf_pretrained
         else:
-            # Preserve trust_remote_code setting from the original bridge instance
             trust_remote_code = getattr(self.hf_pretrained, "trust_remote_code", False)
-            pre_trained = PreTrainedCausalLM.from_pretrained(hf_path, trust_remote_code=trust_remote_code)
+            pre_trained = PreTrainedCausalLM.from_pretrained(path, trust_remote_code=trust_remote_code)
         self._model_bridge.load_weights_hf_to_megatron(
             pre_trained, model, allowed_mismatched_params=allowed_mismatched_params
         )
-
         return model
+
+    def save_weights(
+        self,
+        model: list[MegatronModelT],
+        path: str | Path,
+        show_progress: bool = True,
+        source_path: Optional[Union[str, Path]] = None,
+        strict: bool = True,
+        merge_adapter_weights: bool = True,
+        distributed_save: bool = False,
+        save_every_n_ranks: int = 1,
+    ) -> None:
+        """Save a Megatron model in HuggingFace format.
+
+        Exports the complete model — configuration, tokenizer, and weights — to
+        a directory loadable with HuggingFace's ``from_pretrained`` methods.
+
+        If the model contains LoRA adapters they are automatically merged into
+        the base weights before saving. If the original model was loaded with
+        ``trust_remote_code=True``, any custom modeling files are preserved.
+
+        Args:
+            model: Megatron model instance or list of instances.
+            path: Directory path to save the model.
+            show_progress: Display a progress bar during weight export.
+            source_path: Path containing custom modeling files to preserve.
+                Inferred from the HuggingFace config when not specified.
+            strict: Whether to perform strict validation during weight export.
+            merge_adapter_weights: Merge LoRA adapter weights into base tensors
+                before export.
+            distributed_save: Each rank saves part of the weights independently.
+                When ``False`` (default), only rank 0 saves after gathering.
+            save_every_n_ranks: In distributed-save mode, only ranks
+                ``0, n, 2n, …`` write files. Ignored when
+                ``distributed_save=False``.
+
+        Example:
+            >>> bridge = AutoBridge.from_hf_pretrained("meta-llama/Llama-3.2-1B")
+            >>> model = bridge.get_model()
+            >>> # ... training ...
+            >>> bridge.save_weights(model, "./my_finetuned_model")
+
+            >>> # Load back with HuggingFace
+            >>> from transformers import AutoModelForCausalLM
+            >>> hf_model = AutoModelForCausalLM.from_pretrained("./my_finetuned_model")
+
+        Note:
+            This method is collective — all ranks must call it. Only rank 0
+            saves configuration files; weight saving is coordinated across ranks.
+        """
+        if not isinstance(self.hf_pretrained, PreTrainedCausalLM):
+            raise ValueError(
+                "save_weights requires a pretrained HuggingFace model. "
+                "AutoBridge.from_hf_config() creates a config-only bridge; "
+                "use AutoBridge.from_hf_pretrained(...) instead."
+            )
+
+        additional_files = None
+        if hasattr(self._model_bridge, "ADDITIONAL_FILE_PATTERNS") and self._model_bridge.ADDITIONAL_FILE_PATTERNS:
+            additional_files = self._model_bridge.ADDITIONAL_FILE_PATTERNS
+
+        if dist.is_available() and dist.is_initialized():
+            if dist.get_rank() == 0:
+                self.hf_pretrained.save_artifacts(
+                    path, original_source_path=source_path, additional_files=additional_files
+                )
+        else:
+            self.hf_pretrained.save_artifacts(
+                path, original_source_path=source_path, additional_files=additional_files
+            )
+
+        self.save_hf_weights(
+            model,
+            path,
+            show_progress,
+            strict,
+            merge_adapter_weights=merge_adapter_weights,
+            distributed_save=distributed_save,
+            save_every_n_ranks=save_every_n_ranks,
+        )
 
     def export_hf_weights(
         self,
@@ -577,35 +742,17 @@ class AutoBridge(Generic[MegatronModelT]):
             saves the configuration files, while weight saving is coordinated
             across all ranks.
         """
-        if not isinstance(self.hf_pretrained, PreTrainedCausalLM):
-            raise ValueError(
-                "save_hf_pretrained requires a pretrained HuggingFace model. "
-                "AutoBridge.from_hf_config() creates a config-only bridge; "
-                "use AutoBridge.from_hf_pretrained(...) instead."
-            )
-
-        # Get bridge-level ADDITIONAL_FILE_PATTERNS if configured
-        additional_files = None
-        if hasattr(self._model_bridge, "ADDITIONAL_FILE_PATTERNS") and self._model_bridge.ADDITIONAL_FILE_PATTERNS:
-            additional_files = self._model_bridge.ADDITIONAL_FILE_PATTERNS
-
-        if dist.is_available() and dist.is_initialized():
-            # Distributed training, only rank 0 saves artifacts
-            if dist.get_rank() == 0:
-                self.hf_pretrained.save_artifacts(
-                    path, original_source_path=source_path, additional_files=additional_files
-                )
-        else:
-            # No distributed training, save artifacts
-            self.hf_pretrained.save_artifacts(
-                path, original_source_path=source_path, additional_files=additional_files
-            )
-
-        self.save_hf_weights(
+        warnings.warn(
+            "save_hf_pretrained() is deprecated and will be removed in a future release. Use save_weights() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.save_weights(
             model,
             path,
-            show_progress,
-            strict,
+            show_progress=show_progress,
+            source_path=source_path,
+            strict=strict,
             merge_adapter_weights=merge_adapter_weights,
             distributed_save=distributed_save,
             save_every_n_ranks=save_every_n_ranks,
@@ -970,7 +1117,7 @@ class AutoBridge(Generic[MegatronModelT]):
             megatron_model = self.load_megatron_model(megatron_path, wrap_with_ddp=False)
 
             # Save in HuggingFace format
-            self.save_hf_pretrained(
+            self.save_weights(
                 megatron_model,
                 hf_path,
                 show_progress=show_progress,

--- a/src/megatron/bridge/models/conversion/auto_bridge.py
+++ b/src/megatron/bridge/models/conversion/auto_bridge.py
@@ -324,25 +324,37 @@ class AutoBridge(Generic[MegatronModelT]):
         pp: int = 1,
         cp: int = 1,
         ep: int = 1,
+        etp: int | None = None,
+        vp: int | None = None,
         load_weights: bool = True,
         hf_path: str | Path | None = None,
+        **overrides: Any,
     ) -> list[MegatronModelT]:
         """Create a distributed Megatron model from the HuggingFace checkpoint.
 
-        This is the primary entry point for users who want to get a ready-to-use
+        This is the primary entry point for users who want a ready-to-use
         Megatron model without interacting with the provider API directly. It
-        combines provider creation, parallelism configuration, and weight loading
-        into a single call.
+        combines provider creation, parallelism configuration, and weight
+        loading into a single call.
+
+        For use cases that require pre-wrap hooks (e.g. PEFT, custom value
+        heads), use :meth:`get_provider` instead, which returns a configured
+        provider before ``finalize()`` is called.
 
         Args:
             tp: Tensor model parallel size (default: 1).
             pp: Pipeline model parallel size (default: 1).
             cp: Context parallel size (default: 1).
             ep: Expert model parallel size for MoE models (default: 1).
+            etp: Expert tensor parallel size (default: None, inherits ``tp``).
+            vp: Virtual pipeline model parallel size (default: None).
             load_weights: Whether to load HuggingFace weights into the model.
                 Set to False for random initialization. (default: True)
             hf_path: Optional path to load weights from. If None, uses weights
                 from the bridge's ``hf_pretrained`` instance.
+            **overrides: Additional provider attribute overrides applied before
+                ``finalize()`` (e.g. ``sequence_parallel=True``,
+                ``params_dtype=torch.bfloat16``).
 
         Returns:
             List of Megatron model instances (one per virtual pipeline stage).
@@ -353,18 +365,105 @@ class AutoBridge(Generic[MegatronModelT]):
             >>> model = bridge.get_model()
 
             >>> # Tensor parallel across 8 GPUs
-            >>> bridge = AutoBridge.from_hf_pretrained("meta-llama/Llama-3.2-1B")
             >>> model = bridge.get_model(tp=8)
 
             >>> # Separate weight loading
-            >>> bridge = AutoBridge.from_hf_pretrained("meta-llama/Llama-3.2-1B")
             >>> model = bridge.get_model(tp=4, load_weights=False)
             >>> bridge.load_weights(model)
 
         See Also:
-            to_megatron_provider: Access the provider directly for advanced configuration.
+            get_provider: Get the provider for advanced use (hooks, PEFT).
             load_weights: Load weights into an existing model.
             save_weights: Export model weights back to HuggingFace format.
+        """
+        provider = self.get_provider(
+            tp=tp,
+            pp=pp,
+            cp=cp,
+            ep=ep,
+            etp=etp,
+            vp=vp,
+            load_weights=load_weights,
+            hf_path=hf_path,
+            **overrides,
+        )
+        if hasattr(provider, "finalize"):
+            provider.finalize()
+        return provider.provide_distributed_model(wrap_with_ddp=False)
+
+    def get_provider(
+        self,
+        tp: int = 1,
+        pp: int = 1,
+        cp: int = 1,
+        ep: int = 1,
+        etp: int | None = None,
+        vp: int | None = None,
+        load_weights: bool = False,
+        hf_path: str | Path | None = None,
+        **overrides: Any,
+    ) -> GPTModelProvider:
+        """Return a configured provider ready for hook registration and model creation.
+
+        This is the recommended entry point for downstream frameworks (e.g. veRL,
+        NeMo-RL) that need to:
+
+        - Register pre-wrap hooks (PEFT, custom value heads, MoE router freezing)
+        - Apply custom attribute overrides before ``finalize()``
+        - Control DDP wrapping and optimizer configuration
+
+        Unlike :meth:`get_model`, this method does **not** call ``finalize()``
+        or ``provide_distributed_model()``, giving callers full control over the
+        provider lifecycle.
+
+        Args:
+            tp: Tensor model parallel size (default: 1).
+            pp: Pipeline model parallel size (default: 1).
+            cp: Context parallel size (default: 1).
+            ep: Expert model parallel size for MoE models (default: 1).
+            etp: Expert tensor parallel size (default: None).
+            vp: Virtual pipeline model parallel size (default: None).
+            load_weights: Pre-register an HF weight-loading hook that runs
+                inside ``provide_distributed_model()``. Set to ``True`` when
+                you want weights loaded automatically during model creation.
+                Default is ``False`` (load weights explicitly afterwards via
+                :meth:`load_weights`).
+            hf_path: Path to load weights from when ``load_weights=True``.
+                Defaults to the bridge's ``hf_pretrained`` source.
+            **overrides: Any additional provider attribute to set before
+                returning. Common examples::
+
+                    params_dtype=torch.bfloat16,
+                    sequence_parallel=True,
+                    variable_seq_lengths=True,
+                    attention_backend=AttnBackend.flash,
+                    moe_token_dispatcher_type="alltoall",
+
+        Returns:
+            GPTModelProvider configured with the requested parallelism and
+            overrides. Call ``provider.finalize()`` followed by
+            ``provider.provide_distributed_model(...)`` when ready.
+
+        Example:
+            >>> # veRL-style training setup with PEFT and custom overrides
+            >>> bridge = AutoBridge.from_hf_pretrained("meta-llama/Llama-3.2-1B")
+            >>> provider = bridge.get_provider(
+            ...     tp=4, pp=2, ep=1, vp=2,
+            ...     params_dtype=torch.bfloat16,
+            ...     sequence_parallel=True,
+            ...     variable_seq_lengths=True,
+            ...     moe_token_dispatcher_type="alltoall",
+            ... )
+            >>> provider.register_pre_wrap_hook(my_peft_hook)
+            >>> provider.finalize()
+            >>> model = provider.provide_distributed_model(
+            ...     wrap_with_ddp=True, ddp_config=ddp_cfg
+            ... )
+
+        See Also:
+            get_model: Simpler one-call API when no hooks are needed.
+            to_megatron_provider: Lower-level accessor that returns the raw
+                provider without any parallelism or override application.
         """
         provider = self.to_megatron_provider(load_weights=load_weights, hf_path=hf_path)
         if tp != 1:
@@ -375,9 +474,13 @@ class AutoBridge(Generic[MegatronModelT]):
             provider.context_parallel_size = cp
         if ep != 1:
             provider.expert_model_parallel_size = ep
-        if hasattr(provider, "finalize"):
-            provider.finalize()
-        return provider.provide_distributed_model(wrap_with_ddp=False)
+        if etp is not None:
+            provider.expert_tensor_parallel_size = etp
+        if vp is not None:
+            provider.virtual_pipeline_model_parallel_size = vp
+        for key, value in overrides.items():
+            setattr(provider, key, value)
+        return provider
 
     def load_weights(
         self,

--- a/tests/unit_tests/models/test_auto_bridge.py
+++ b/tests/unit_tests/models/test_auto_bridge.py
@@ -1477,3 +1477,156 @@ class TestSimpleFacade:
             distributed_save=False,
             save_every_n_ranks=1,
         )
+
+
+class TestGetProvider:
+    """Tests for get_provider() — the hook-friendly provider facade."""
+
+    @pytest.fixture
+    def bridge(self):
+        mock_pretrained = create_mock_pretrained_causal_lm()
+        return AutoBridge(mock_pretrained)
+
+    def _make_provider(self):
+        mock_provider = Mock()
+        mock_provider.provide_distributed_model.return_value = ["model"]
+        return mock_provider
+
+    def test_get_provider_returns_provider_without_finalizing(self, bridge):
+        """get_provider() returns the provider but does NOT call finalize()."""
+        mock_provider = self._make_provider()
+
+        with patch.object(bridge, "to_megatron_provider", return_value=mock_provider):
+            result = bridge.get_provider()
+
+        assert result is mock_provider
+        mock_provider.finalize.assert_not_called()
+        mock_provider.provide_distributed_model.assert_not_called()
+
+    def test_get_provider_load_weights_false_by_default(self, bridge):
+        """get_provider() defaults to load_weights=False (training use-case)."""
+        mock_provider = self._make_provider()
+
+        with patch.object(bridge, "to_megatron_provider", return_value=mock_provider) as mock_fn:
+            bridge.get_provider()
+
+        mock_fn.assert_called_once_with(load_weights=False, hf_path=None)
+
+    def test_get_provider_sets_tp_pp_cp_ep(self, bridge):
+        """get_provider(tp, pp, cp, ep) sets the parallelism attributes."""
+        mock_provider = self._make_provider()
+
+        with patch.object(bridge, "to_megatron_provider", return_value=mock_provider):
+            bridge.get_provider(tp=4, pp=2, cp=2, ep=4)
+
+        assert mock_provider.tensor_model_parallel_size == 4
+        assert mock_provider.pipeline_model_parallel_size == 2
+        assert mock_provider.context_parallel_size == 2
+        assert mock_provider.expert_model_parallel_size == 4
+
+    def test_get_provider_sets_etp(self, bridge):
+        """get_provider(etp=2) sets expert_tensor_parallel_size."""
+        mock_provider = self._make_provider()
+
+        with patch.object(bridge, "to_megatron_provider", return_value=mock_provider):
+            bridge.get_provider(etp=2)
+
+        assert mock_provider.expert_tensor_parallel_size == 2
+
+    def test_get_provider_sets_vp(self, bridge):
+        """get_provider(vp=4) sets virtual_pipeline_model_parallel_size."""
+        mock_provider = self._make_provider()
+
+        with patch.object(bridge, "to_megatron_provider", return_value=mock_provider):
+            bridge.get_provider(vp=4)
+
+        assert mock_provider.virtual_pipeline_model_parallel_size == 4
+
+    def test_get_provider_etp_none_not_set(self, bridge):
+        """etp=None (default) does not set expert_tensor_parallel_size."""
+        mock_provider = self._make_provider()
+
+        with patch.object(bridge, "to_megatron_provider", return_value=mock_provider):
+            bridge.get_provider()
+
+        calls = [str(c) for c in mock_provider.mock_calls]
+        assert not any("expert_tensor_parallel_size" in c for c in calls)
+
+    def test_get_provider_vp_none_not_set(self, bridge):
+        """vp=None (default) does not set virtual_pipeline_model_parallel_size."""
+        mock_provider = self._make_provider()
+
+        with patch.object(bridge, "to_megatron_provider", return_value=mock_provider):
+            bridge.get_provider()
+
+        calls = [str(c) for c in mock_provider.mock_calls]
+        assert not any("virtual_pipeline_model_parallel_size" in c for c in calls)
+
+    def test_get_provider_applies_overrides(self, bridge):
+        """**overrides are applied via setattr on the provider."""
+        mock_provider = self._make_provider()
+
+        with patch.object(bridge, "to_megatron_provider", return_value=mock_provider):
+            bridge.get_provider(
+                sequence_parallel=True,
+                variable_seq_lengths=True,
+                moe_token_dispatcher_type="alltoall",
+                moe_router_load_balancing_type="none",
+            )
+
+        assert mock_provider.sequence_parallel is True
+        assert mock_provider.variable_seq_lengths is True
+        assert mock_provider.moe_token_dispatcher_type == "alltoall"
+        assert mock_provider.moe_router_load_balancing_type == "none"
+
+    def test_get_provider_full_verl_pattern(self, bridge):
+        """Simulates the complete veRL provider setup in a single call."""
+        import torch
+
+        mock_provider = self._make_provider()
+
+        with patch.object(bridge, "to_megatron_provider", return_value=mock_provider):
+            provider = bridge.get_provider(
+                tp=4,
+                pp=2,
+                ep=1,
+                vp=2,
+                params_dtype=torch.bfloat16,
+                fp16=False,
+                bf16=True,
+                sequence_parallel=True,
+                variable_seq_lengths=True,
+                moe_token_dispatcher_type="alltoall",
+                moe_router_load_balancing_type="none",
+            )
+
+        # No finalize or model creation yet — hooks can still be registered
+        mock_provider.finalize.assert_not_called()
+        mock_provider.provide_distributed_model.assert_not_called()
+
+        # All attributes set
+        assert provider.tensor_model_parallel_size == 4
+        assert provider.pipeline_model_parallel_size == 2
+        assert provider.virtual_pipeline_model_parallel_size == 2
+        assert provider.params_dtype == torch.bfloat16
+        assert provider.bf16 is True
+        assert provider.sequence_parallel is True
+
+    def test_get_model_delegates_through_get_provider(self, bridge):
+        """get_model() now delegates to get_provider() internally."""
+        mock_provider = self._make_provider()
+
+        with patch.object(bridge, "get_provider", return_value=mock_provider) as mock_gp:
+            bridge.get_model(tp=8, sequence_parallel=True)
+
+        mock_gp.assert_called_once_with(
+            tp=8,
+            pp=1,
+            cp=1,
+            ep=1,
+            etp=None,
+            vp=None,
+            load_weights=True,
+            hf_path=None,
+            sequence_parallel=True,
+        )

--- a/tests/unit_tests/models/test_auto_bridge.py
+++ b/tests/unit_tests/models/test_auto_bridge.py
@@ -1285,3 +1285,195 @@ class TestAutoBridge:
             bridge.save_hf_weights(mock_megatron_model, "/tmp/output")
 
             mock_torch_save.assert_not_called()
+
+
+class TestSimpleFacade:
+    """Tests for the simplified get_model / load_weights / save_weights facade."""
+
+    @pytest.fixture
+    def bridge(self):
+        mock_pretrained = create_mock_pretrained_causal_lm()
+        return AutoBridge(mock_pretrained)
+
+    def test_get_model_delegates_to_provider(self, bridge):
+        """get_model() calls to_megatron_provider and provide_distributed_model."""
+        mock_provider = Mock()
+        mock_provider.provide_distributed_model.return_value = ["model"]
+
+        with patch.object(bridge, "to_megatron_provider", return_value=mock_provider) as mock_provider_fn:
+            result = bridge.get_model()
+
+        mock_provider_fn.assert_called_once_with(load_weights=True, hf_path=None)
+        mock_provider.finalize.assert_called_once()
+        mock_provider.provide_distributed_model.assert_called_once_with(wrap_with_ddp=False)
+        assert result == ["model"]
+
+    def test_get_model_sets_tp(self, bridge):
+        """get_model(tp=8) sets tensor_model_parallel_size on the provider."""
+        mock_provider = Mock()
+        mock_provider.provide_distributed_model.return_value = ["model"]
+
+        with patch.object(bridge, "to_megatron_provider", return_value=mock_provider):
+            bridge.get_model(tp=8)
+
+        assert mock_provider.tensor_model_parallel_size == 8
+
+    def test_get_model_sets_pp(self, bridge):
+        """get_model(pp=4) sets pipeline_model_parallel_size on the provider."""
+        mock_provider = Mock()
+        mock_provider.provide_distributed_model.return_value = ["model"]
+
+        with patch.object(bridge, "to_megatron_provider", return_value=mock_provider):
+            bridge.get_model(pp=4)
+
+        assert mock_provider.pipeline_model_parallel_size == 4
+
+    def test_get_model_sets_cp(self, bridge):
+        """get_model(cp=2) sets context_parallel_size on the provider."""
+        mock_provider = Mock()
+        mock_provider.provide_distributed_model.return_value = ["model"]
+
+        with patch.object(bridge, "to_megatron_provider", return_value=mock_provider):
+            bridge.get_model(cp=2)
+
+        assert mock_provider.context_parallel_size == 2
+
+    def test_get_model_sets_ep(self, bridge):
+        """get_model(ep=4) sets expert_model_parallel_size on the provider."""
+        mock_provider = Mock()
+        mock_provider.provide_distributed_model.return_value = ["model"]
+
+        with patch.object(bridge, "to_megatron_provider", return_value=mock_provider):
+            bridge.get_model(ep=4)
+
+        assert mock_provider.expert_model_parallel_size == 4
+
+    def test_get_model_default_parallelism_not_set(self, bridge):
+        """Default tp=1/pp=1/cp=1/ep=1 does not mutate provider attributes."""
+        mock_provider = Mock(spec=[])  # no attributes → setattr would create them
+        mock_provider = Mock()
+        mock_provider.provide_distributed_model.return_value = ["model"]
+
+        with patch.object(bridge, "to_megatron_provider", return_value=mock_provider):
+            bridge.get_model()
+
+        # The parallelism attributes must NOT have been set (defaults stay as-is on provider)
+        assert mock_provider.tensor_model_parallel_size != 1 or True  # only checks via call counts
+        # A simpler assertion: no explicit assignment should have happened for default values
+        # We verify this by checking the provider's attribute wasn't touched
+        calls = [str(c) for c in mock_provider.mock_calls]
+        assert not any("tensor_model_parallel_size" in c for c in calls)
+        assert not any("pipeline_model_parallel_size" in c for c in calls)
+
+    def test_get_model_load_weights_false(self, bridge):
+        """get_model(load_weights=False) passes through to provider."""
+        mock_provider = Mock()
+        mock_provider.provide_distributed_model.return_value = ["model"]
+
+        with patch.object(bridge, "to_megatron_provider", return_value=mock_provider) as mock_fn:
+            bridge.get_model(load_weights=False)
+
+        mock_fn.assert_called_once_with(load_weights=False, hf_path=None)
+
+    def test_get_model_with_hf_path(self, bridge):
+        """get_model(hf_path=...) passes through to provider."""
+        mock_provider = Mock()
+        mock_provider.provide_distributed_model.return_value = ["model"]
+
+        with patch.object(bridge, "to_megatron_provider", return_value=mock_provider) as mock_fn:
+            bridge.get_model(hf_path="/tmp/weights")
+
+        mock_fn.assert_called_once_with(load_weights=True, hf_path="/tmp/weights")
+
+    def test_load_weights_is_primary(self, bridge):
+        """load_weights() holds the real implementation (not a delegation chain)."""
+        mock_model = [Mock()]
+        mock_pretrained = create_mock_pretrained_causal_lm()
+        bridge.hf_pretrained = mock_pretrained
+
+        with (
+            patch.object(bridge, "_model_bridge") as mock_mb,
+            patch(
+                "megatron.bridge.models.conversion.auto_bridge.PreTrainedCausalLM.from_pretrained",
+                return_value=mock_pretrained,
+            ),
+        ):
+            bridge.load_weights(mock_model, path="/tmp/weights")
+
+        mock_mb.load_weights_hf_to_megatron.assert_called_once()
+
+    def test_load_weights_without_path_uses_hf_pretrained(self, bridge):
+        """load_weights() with no path uses bridge.hf_pretrained directly."""
+        mock_model = [Mock()]
+        mock_pretrained = create_mock_pretrained_causal_lm()
+        bridge.hf_pretrained = mock_pretrained
+
+        with patch.object(bridge, "_model_bridge") as mock_mb:
+            bridge.load_weights(mock_model)
+
+        mock_mb.load_weights_hf_to_megatron.assert_called_once_with(
+            mock_pretrained, mock_model, allowed_mismatched_params=None
+        )
+
+    def test_load_weights_with_allowed_mismatched_params(self, bridge):
+        """load_weights() forwards allowed_mismatched_params to the bridge."""
+        mock_model = [Mock()]
+        mock_pretrained = create_mock_pretrained_causal_lm()
+        bridge.hf_pretrained = mock_pretrained
+        patterns = ["*.bias"]
+
+        with patch.object(bridge, "_model_bridge") as mock_mb:
+            bridge.load_weights(mock_model, allowed_mismatched_params=patterns)
+
+        mock_mb.load_weights_hf_to_megatron.assert_called_once_with(
+            mock_pretrained, mock_model, allowed_mismatched_params=patterns
+        )
+
+    def test_load_hf_weights_deprecated(self, bridge):
+        """load_hf_weights() emits DeprecationWarning and delegates to load_weights."""
+        mock_model = [Mock()]
+
+        with (
+            patch.object(bridge, "load_weights", return_value=mock_model) as mock_fn,
+            pytest.warns(DeprecationWarning, match="load_hf_weights.*deprecated.*load_weights"),
+        ):
+            result = bridge.load_hf_weights(mock_model, hf_path="/tmp/weights")
+
+        mock_fn.assert_called_once_with(mock_model, path="/tmp/weights", allowed_mismatched_params=None)
+        assert result is mock_model
+
+    def test_save_weights_calls_save_hf_weights(self, bridge):
+        """save_weights() calls save_hf_weights() for the actual weight serialisation."""
+        mock_model = [Mock()]
+        mock_pretrained = create_mock_pretrained_causal_lm()
+        bridge.hf_pretrained = mock_pretrained
+
+        with (
+            patch.object(bridge, "_model_bridge", Mock()),
+            patch.object(bridge.hf_pretrained, "save_artifacts", Mock()),
+            patch.object(bridge, "save_hf_weights") as mock_shw,
+        ):
+            bridge.save_weights(mock_model, "/tmp/output")
+
+        mock_shw.assert_called_once()
+
+    def test_save_hf_pretrained_deprecated(self, bridge):
+        """save_hf_pretrained() emits DeprecationWarning and delegates to save_weights."""
+        mock_model = [Mock()]
+
+        with (
+            patch.object(bridge, "save_weights") as mock_fn,
+            pytest.warns(DeprecationWarning, match="save_hf_pretrained.*deprecated.*save_weights"),
+        ):
+            bridge.save_hf_pretrained(mock_model, "/tmp/output", show_progress=False)
+
+        mock_fn.assert_called_once_with(
+            mock_model,
+            "/tmp/output",
+            show_progress=False,
+            source_path=None,
+            strict=True,
+            merge_adapter_weights=True,
+            distributed_save=False,
+            save_every_n_ranks=1,
+        )


### PR DESCRIPTION
## Summary

The current user flow for loading a HuggingFace model into Megatron requires knowing about two separate objects (`AutoBridge` + `ModelProvider`) and remembering to call `finalize()`:

```python
bridge = AutoBridge.from_hf_pretrained("meta-llama/Llama-3.2-1B")
provider = bridge.to_megatron_provider()
provider.tensor_model_parallel_size = 8
provider.finalize()
model = provider.provide_distributed_model(wrap_with_ddp=False)
bridge.save_hf_pretrained(model, "./output")
```

This PR introduces a simpler facade that mirrors the [mbridge](https://github.com/ISEEKYAN/mbridge) convention:

```python
bridge = AutoBridge.from_hf_pretrained("meta-llama/Llama-3.2-1B")
model = bridge.get_model(tp=8)
bridge.save_weights(model, "./output")
```

## Changes

### New methods on `AutoBridge`

| Method | Description |
|---|---|
| `get_model(tp, pp, cp, ep, load_weights, hf_path)` | One-call model creation with parallelism config. Hides provider lifecycle and `wrap_with_ddp=False` default. |
| `load_weights(model, path, ...)` | Primary replacement for `load_hf_weights`. Cleaner name, positional `path`. |
| `save_weights(model, path, ...)` | Primary replacement for `save_hf_pretrained`. Cleaner name, same full signature. |

### Deprecated methods (kept for backwards compat)

- `load_hf_weights()` → emits `DeprecationWarning`, delegates to `load_weights()`
- `save_hf_pretrained()` → emits `DeprecationWarning`, delegates to `save_weights()`
- Internal `export_ckpt` call updated to use `save_weights()` directly (no spurious warning)

## Usage examples

```python
# Single-GPU: simplest case
bridge = AutoBridge.from_hf_pretrained("meta-llama/Llama-3.2-1B")
model = bridge.get_model()
bridge.save_weights(model, "./output")

# 8-way tensor parallel
model = bridge.get_model(tp=8)

# MoE with expert parallelism
bridge = AutoBridge.from_hf_pretrained("Qwen/Qwen3-30B-A3B")
model = bridge.get_model(tp=4, ep=2)

# Separate weight loading
model = bridge.get_model(tp=4, load_weights=False)
bridge.load_weights(model)
bridge.save_weights(model, "./output")
```

## Test plan

- [x] `TestSimpleFacade` added to `test_auto_bridge.py` (13 tests)
  - `get_model` delegates to provider, sets `tp`/`pp`/`cp`/`ep`, respects `load_weights=False` and `hf_path`
  - `load_weights` owns the implementation, correctly passes `path` and `allowed_mismatched_params`
  - `save_weights` calls `save_hf_weights` for the actual serialisation
  - `load_hf_weights` emits `DeprecationWarning` and delegates to `load_weights`
  - `save_hf_pretrained` emits `DeprecationWarning` and delegates to `save_weights`
- [x] Pre-commit (ruff format + lint) passes
- [ ] CI unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)