### PR TITLE
Dump the env for rank0 for slurm based runs.

### DIFF
--- a/scripts/performance/argument_parser.py
+++ b/scripts/performance/argument_parser.py
@@ -730,6 +730,12 @@ def parse_cli_args():
         default=None,
     )
     logging_args.add_argument("--save_config_filepath", type=str, help="Path to save the task configuration file")
+    logging_args.add_argument(
+        "--dump_env",
+        action="store_true",
+        help="Write environment variables to /nemo_run/env_<SLURM_JOB_ID>.log on rank 0. "
+        "Useful for post-run debugging of NCCL, CUDA, and SLURM settings.",
+    )
 
     # Config variant selection
     config_variant_args = parser.add_argument_group("Config variant arguments")

--- a/scripts/performance/run_script.py
+++ b/scripts/performance/run_script.py
@@ -62,12 +62,13 @@ def _dump_env_rank0() -> None:
 
 def main():
     """Main function to run the pretraining/finetuning script."""
-    _dump_env_rank0()
-
     # Parse known args and treat any unknown args as Hydra-style config overrides.
     # `argparse.parse_known_args()` returns the unknown args as a `list[str]`.
     parser = parse_cli_args()
     args, cli_overrides = parser.parse_known_args()
+
+    if args.dump_env:
+        _dump_env_rank0()
 
     recipe = get_perf_optimized_recipe(
         model_family_name=args.model_family_name,


### PR DESCRIPTION
Dumps the 'env' on job start for the first slurm rank, with some mild redactions.

Many params or cluster specifics end up in env vars, being able to quickly see what was set after the fact is very useful for debugging. Compared to the current process of manually editing the sbatch or adding 'env' to the pre_cmds for a specific job.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Environment variables are now automatically logged at script startup with sensitive credentials (tokens, API keys, passwords) automatically redacted to ensure security.

* **Chores**
  * Enhanced debugging capabilities with automatic environment state snapshots. Logging errors are handled gracefully without interrupting execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->