### PR TITLE
chore: bump TransformerEngine to release_v2.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,7 @@ override-dependencies = [
     "torch; sys_platform == 'never'",
     "torchvision; sys_platform == 'never'",
     "triton; sys_platform == 'never'",
-    "transformer-engine @ git+https://github.com/NVIDIA/TransformerEngine.git@287770466f0f4433052260a765db5ff7b8be1320",
+    "transformer-engine @ git+https://github.com/NVIDIA/TransformerEngine.git@da8f7d6fd81848a26eea62281f8676e51b5c240e",
     "mlflow>=3.5.0",
     "cryptography>=43.0.0,<47",
     "nvidia-modelopt>=0.42.0a0",


### PR DESCRIPTION
Automated dependency bump of `TransformerEngine` to `release_v2.14` (SHA: `da8f7d6fd81848a26eea62281f8676e51b5c240e`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->