### PR TITLE
chore: bump TransformerEngine to release_v2.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,7 @@ override-dependencies = [
     "torch; sys_platform == 'never'",
     "torchvision; sys_platform == 'never'",
     "triton; sys_platform == 'never'",
-    "transformer-engine @ git+https://github.com/NVIDIA/TransformerEngine.git@287770466f0f4433052260a765db5ff7b8be1320",
+    "transformer-engine @ git+https://github.com/NVIDIA/TransformerEngine.git@release_v2.14",
     "mlflow>=3.5.0",
     "cryptography>=43.0.0,<47",
     "nvidia-modelopt>=0.42.0a0",


### PR DESCRIPTION
Automated dependency bump of `TransformerEngine` to `release_v2.14`.

Updates the `override-dependencies` entry in `pyproject.toml` from the previous pinned SHA (`287770466f0f4433052260a765db5ff7b8be1320`) to the `release_v2.14` branch ref.

> **Note:** The `uv.lock` file must be regenerated inside a `megatron-bridge` container after this change is reviewed. Run `docker run --rm -v $(pwd):/workdir/ -w /workdir/ megatron-bridge uv lock` and commit the updated lockfile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated transformer-engine dependency to the latest release branch version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->