### PR TITLE
add lora rank normalization for expert layers

### DIFF
--- a/src/megatron/bridge/peft/canonical_lora.py
+++ b/src/megatron/bridge/peft/canonical_lora.py
@@ -198,6 +198,9 @@ class CanonicalLoRA(PEFT, ModuleMatcher):
             Can be 'pre' (before the low-rank projection) or 'post' (after). Defaults to 'pre'.
         lora_A_init_method (str): Initialization method for LoRA A matrix. Defaults to "xavier".
         lora_B_init_method (str): Initialization method for LoRA B matrix. Defaults to "zero".
+        normalize_moe_lora (bool): When True, expert linear layers use dim // moe_router_topk as the LoRA rank
+            while non-expert layers keep the full dim. This normalizes the total adapter capacity for MoE models
+            so it is comparable to a dense model. Defaults to False.
     """
 
     target_modules: List[str] = field(
@@ -217,6 +220,21 @@ class CanonicalLoRA(PEFT, ModuleMatcher):
     dropout_position: Literal["pre", "post"] = "pre"
     lora_A_init_method: str = "xavier"
     lora_B_init_method: str = "zero"
+    normalize_moe_lora: bool = False
+
+    def _get_effective_dim(self, m: nn.Module, is_expert: bool) -> int:
+        """Return the LoRA rank to use, reduced for expert layers when normalize_moe_lora is enabled."""
+        if not self.normalize_moe_lora or not is_expert:
+            return self.dim
+        topk = getattr(getattr(m, "config", None), "moe_router_topk", None)
+        if topk is None or topk <= 0:
+            return self.dim
+        if self.dim % topk != 0:
+            raise ValueError(
+                f"LoRA dim={self.dim} must be divisible by moe_router_topk={topk} "
+                f"when normalize_moe_lora is enabled"
+            )
+        return self.dim // topk
 
     def __post_init__(self) -> None:
         """
@@ -289,8 +307,10 @@ class CanonicalLoRA(PEFT, ModuleMatcher):
             is_expert = is_expert_linear(full_name)
             attrs = get_adapter_attributes_from_linear(m, is_expert=is_expert)
 
+            dim = self._get_effective_dim(m, is_expert)
+
             adapter_kwargs = dict(
-                dim=self.dim,
+                dim=dim,
                 base_linear_name=full_name,
                 activation="identity",
                 norm_type=None,

--- a/src/megatron/bridge/peft/lora.py
+++ b/src/megatron/bridge/peft/lora.py
@@ -78,6 +78,9 @@ class LoRA(PEFT, ModuleMatcher):
         lora_A_init_method (str): Initialization method for the low-rank matrix A. Defaults to "xavier".
         lora_B_init_method (str): Initialization method for the low-rank matrix B. Defaults to "zero".
         lora_dtype (torch.dtype): Parameter data type for LoRA weights. Default None (will use model's dtype).
+        normalize_moe_lora (bool): When True, expert linear layers use dim // moe_router_topk as the LoRA rank
+            while non-expert layers keep the full dim. This normalizes the total adapter capacity for MoE models
+            so it is comparable to a dense model. Defaults to False.
     """
 
     target_modules: List[str] = field(
@@ -91,6 +94,21 @@ class LoRA(PEFT, ModuleMatcher):
     lora_B_init_method: str = "zero"
     a2a_experimental: bool = False
     lora_dtype: torch.dtype = None
+    normalize_moe_lora: bool = False
+
+    def _get_effective_dim(self, module: nn.Module, is_expert: bool) -> int:
+        """Return the LoRA rank to use, reduced for expert layers when normalize_moe_lora is enabled."""
+        if not self.normalize_moe_lora or not is_expert:
+            return self.dim
+        topk = getattr(getattr(module, "config", None), "moe_router_topk", None)
+        if topk is None or topk <= 0:
+            return self.dim
+        if self.dim % topk != 0:
+            raise ValueError(
+                f"LoRA dim={self.dim} must be divisible by moe_router_topk={topk} "
+                f"when normalize_moe_lora is enabled"
+            )
+        return self.dim // topk
 
     def transform(self, module: nn.Module, name: Optional[str] = None, prefix: Optional[str] = None) -> nn.Module:
         """
@@ -140,6 +158,8 @@ class LoRA(PEFT, ModuleMatcher):
             is_expert = is_expert_linear(full_name)
             attrs = get_adapter_attributes_from_linear(module, is_expert=is_expert)
 
+            dim = self._get_effective_dim(module, is_expert)
+
             enable_op_fuser = (
                 hasattr(module, "config")
                 and getattr(module.config, "use_transformer_engine_op_fuser", False)
@@ -151,7 +171,7 @@ class LoRA(PEFT, ModuleMatcher):
             adapter = ParallelLinearAdapter(
                 attrs.in_features,
                 attrs.out_features,
-                self.dim,
+                dim,
                 base_linear_name=full_name,
                 activation="identity",
                 norm_type=None,

--- a/tests/unit_tests/peft/test_canonical_lora.py
+++ b/tests/unit_tests/peft/test_canonical_lora.py
@@ -51,24 +51,24 @@ class SimpleModel(nn.Module):
 class MockMegatronLinear(nn.Module):
     """Mock Megatron linear layer that's not nn.Linear to trigger parallel adapter path."""
 
-    def __init__(self, in_features, out_features, kv_channels=None, num_query_groups=None):
+    def __init__(self, in_features, out_features, kv_channels=None, num_query_groups=None, moe_router_topk=None):
         super().__init__()
         self.linear = nn.Linear(in_features, out_features)
         self.in_features = in_features
         self.out_features = out_features
 
-        # Mock config
         class MockConfig:
             def __init__(self):
                 self.kv_channels = kv_channels or 64
                 self.num_query_groups = num_query_groups or 8
                 self.num_attention_heads = self.num_query_groups
                 self.sequence_parallel = False
+                self.moe_router_topk = moe_router_topk
 
         self.config = MockConfig()
 
     def forward(self, x):
-        return self.linear(x), None  # Return tuple like Megatron layers
+        return self.linear(x), None
 
 
 class MegatronStyleModel(nn.Module):
@@ -100,7 +100,7 @@ class VisionLanguageMegatronStyleModel(nn.Module):
 class MoEMegatronStyleModel(nn.Module):
     """Model with dense, expert, and shared-expert linear_fc1 modules."""
 
-    def __init__(self):
+    def __init__(self, moe_router_topk=None):
         super().__init__()
         self.language_model = nn.Module()
         self.language_model.decoder = nn.Module()
@@ -108,11 +108,11 @@ class MoEMegatronStyleModel(nn.Module):
 
         layer = self.language_model.decoder.layers[0]
         layer.mlp = nn.Module()
-        layer.mlp.linear_fc1 = MockMegatronLinear(512, 2048)
+        layer.mlp.linear_fc1 = MockMegatronLinear(512, 2048, moe_router_topk=moe_router_topk)
         layer.mlp.experts = nn.Module()
-        layer.mlp.experts.linear_fc1 = MockMegatronLinear(512, 2048)
+        layer.mlp.experts.linear_fc1 = MockMegatronLinear(512, 2048, moe_router_topk=moe_router_topk)
         layer.mlp.shared_experts = nn.Module()
-        layer.mlp.shared_experts.linear_fc1 = MockMegatronLinear(512, 2048)
+        layer.mlp.shared_experts.linear_fc1 = MockMegatronLinear(512, 2048, moe_router_topk=moe_router_topk)
 
 
 class NestedModel(nn.Module):
@@ -359,6 +359,79 @@ class TestCanonicalLoRA:
         assert isinstance(layer.mlp.experts.linear_fc1, LoRALinear)
         assert not isinstance(layer.mlp.experts.linear_fc1, LoRALinearSplitFC1UpGate)
         assert isinstance(layer.mlp.shared_experts.linear_fc1, LoRALinearSplitFC1UpGate)
+
+    def test_canonical_lora_normalize_moe_lora_reduces_expert_dim(self):
+        """Expert linear_fc1 should get reduced dim when normalize_moe_lora is enabled."""
+        model = MoEMegatronStyleModel(moe_router_topk=2)
+        lora = CanonicalLoRA(
+            target_modules=["linear_fc1_up", "linear_fc1_gate"],
+            dim=32,
+            normalize_moe_lora=True,
+        )
+
+        def mock_get_attrs(module, is_expert=False):
+            return AdapterAttributes(
+                input_is_parallel=False,
+                in_features=module.in_features,
+                out_features=module.out_features,
+                disable_tensor_parallel_comm=False,
+                disable_sequence_parallel_comm=True,
+                base_linear_is_parallel=True,
+            )
+
+        with patch(
+            "megatron.bridge.peft.canonical_lora.get_adapter_attributes_from_linear", side_effect=mock_get_attrs
+        ):
+            with patch("megatron.bridge.peft.canonical_lora.ParallelLinearAdapter") as mock_adapter:
+                mock_adapter.return_value = nn.Linear(1, 1)
+                lora(model, training=True)
+
+        expert_calls = {}
+        non_expert_calls = {}
+        for call in mock_adapter.call_args_list:
+            kwargs = call.kwargs
+            name = kwargs.get("base_linear_name", "")
+            dim_used = kwargs.get("dim")
+            if ".mlp.experts." in name and ".shared_experts." not in name:
+                expert_calls[name] = dim_used
+            else:
+                non_expert_calls[name] = dim_used
+
+        assert len(expert_calls) > 0, "Should have expert adapter calls"
+        assert len(non_expert_calls) > 0, "Should have non-expert adapter calls"
+
+        for name, dim_used in expert_calls.items():
+            assert dim_used == 16, f"Expert {name} should get dim=16 (32 // 2), got {dim_used}"
+
+        for name, dim_used in non_expert_calls.items():
+            assert dim_used == 32, f"Non-expert {name} should get full dim=32, got {dim_used}"
+
+    def test_canonical_lora_normalize_moe_lora_indivisible_raises(self):
+        """Should raise ValueError when dim is not divisible by moe_router_topk."""
+        model = MoEMegatronStyleModel(moe_router_topk=3)
+        lora = CanonicalLoRA(
+            target_modules=["linear_fc1_up", "linear_fc1_gate"],
+            dim=32,
+            normalize_moe_lora=True,
+        )
+
+        def mock_get_attrs(module, is_expert=False):
+            return AdapterAttributes(
+                input_is_parallel=False,
+                in_features=module.in_features,
+                out_features=module.out_features,
+                disable_tensor_parallel_comm=False,
+                disable_sequence_parallel_comm=True,
+                base_linear_is_parallel=True,
+            )
+
+        with patch(
+            "megatron.bridge.peft.canonical_lora.get_adapter_attributes_from_linear", side_effect=mock_get_attrs
+        ):
+            with patch("megatron.bridge.peft.canonical_lora.ParallelLinearAdapter") as mock_adapter:
+                mock_adapter.return_value = nn.Linear(1, 1)
+                with pytest.raises(ValueError, match="must be divisible by moe_router_topk"):
+                    lora(model, training=True)
 
     def test_canonical_lora_transform_nested_model(self):
         """Test CanonicalLoRA transformation on nested model structures."""

--- a/tests/unit_tests/peft/test_lora.py
+++ b/tests/unit_tests/peft/test_lora.py
@@ -26,6 +26,7 @@ from megatron.core.transformer.module import MegatronModule
 from megatron.bridge.models.gpt_provider import GPTModelProvider
 from megatron.bridge.peft.lora import LoRA, LoRAMerge, VLMLoRA
 from megatron.bridge.peft.lora_layers import LinearAdapter, LoRALinear
+from megatron.bridge.peft.utils import AdapterAttributes
 
 
 class SimpleModel(nn.Module):
@@ -68,6 +69,47 @@ class NestedModel(nn.Module):
                 for _ in range(2)
             ]
         )
+
+
+class MockMegatronLinear(nn.Module):
+    """Mock Megatron linear layer that's not nn.Linear to trigger parallel adapter path."""
+
+    def __init__(self, in_features, out_features, moe_router_topk=None):
+        super().__init__()
+        self.linear = nn.Linear(in_features, out_features)
+        self.in_features = in_features
+        self.out_features = out_features
+
+        class MockConfig:
+            def __init__(self):
+                self.sequence_parallel = False
+                self.moe_router_topk = moe_router_topk
+
+        self.config = MockConfig()
+
+    def forward(self, x):
+        return self.linear(x), None
+
+
+class MoEModel(nn.Module):
+    """Model with dense and expert linear layers for testing normalize_moe_lora."""
+
+    def __init__(self, moe_router_topk=2):
+        super().__init__()
+        self.decoder = nn.Module()
+        self.decoder.layers = nn.ModuleList([nn.Module()])
+
+        layer = self.decoder.layers[0]
+        layer.self_attention = nn.Module()
+        layer.self_attention.linear_proj = MockMegatronLinear(512, 512, moe_router_topk=moe_router_topk)
+        layer.mlp = nn.Module()
+        layer.mlp.linear_fc1 = MockMegatronLinear(512, 2048, moe_router_topk=moe_router_topk)
+        layer.mlp.linear_fc2 = MockMegatronLinear(2048, 512, moe_router_topk=moe_router_topk)
+        layer.mlp.experts = nn.Module()
+        layer.mlp.experts.linear_fc1 = MockMegatronLinear(512, 2048, moe_router_topk=moe_router_topk)
+        layer.mlp.experts.linear_fc2 = MockMegatronLinear(2048, 512, moe_router_topk=moe_router_topk)
+        layer.mlp.shared_experts = nn.Module()
+        layer.mlp.shared_experts.linear_fc1 = MockMegatronLinear(512, 2048, moe_router_topk=moe_router_topk)
 
 
 class TestLoRA:
@@ -332,6 +374,132 @@ class TestLoRA:
             assert isinstance(chunk.linear_proj, LinearAdapter)
             assert isinstance(chunk.linear_fc1, LinearAdapter)
             assert isinstance(chunk.linear_fc2, LinearAdapter)
+
+
+class TestLoRANormalizeMoE:
+    """Tests for LoRA normalize_moe_lora feature."""
+
+    def test_normalize_moe_lora_reduces_expert_dim(self):
+        """Expert layers should get dim // moe_router_topk when normalize_moe_lora is enabled."""
+        model = MoEModel(moe_router_topk=2)
+        lora = LoRA(target_modules=["linear_fc1", "linear_fc2", "linear_proj"], dim=32, normalize_moe_lora=True)
+
+        def mock_get_attrs(module, is_expert=False):
+            return AdapterAttributes(
+                input_is_parallel=False,
+                in_features=module.in_features,
+                out_features=module.out_features,
+                disable_tensor_parallel_comm=False,
+                disable_sequence_parallel_comm=True,
+                base_linear_is_parallel=True,
+            )
+
+        with patch("megatron.bridge.peft.lora.get_adapter_attributes_from_linear", side_effect=mock_get_attrs):
+            with patch("megatron.bridge.peft.lora.ParallelLinearAdapter") as mock_adapter:
+                mock_adapter.return_value = nn.Linear(1, 1)
+                lora(model, training=True)
+
+        expert_calls = {}
+        non_expert_calls = {}
+        for call in mock_adapter.call_args_list:
+            name = call.kwargs.get("base_linear_name", "")
+            dim_used = call.args[2] if len(call.args) > 2 else call.kwargs.get("dim")
+            if ".mlp.experts." in name and ".shared_experts." not in name:
+                expert_calls[name] = dim_used
+            else:
+                non_expert_calls[name] = dim_used
+
+        assert len(expert_calls) > 0, "Should have expert adapter calls"
+        assert len(non_expert_calls) > 0, "Should have non-expert adapter calls"
+
+        for name, dim_used in expert_calls.items():
+            assert dim_used == 16, f"Expert layer {name} should get dim=16 (32 // 2), got {dim_used}"
+
+        for name, dim_used in non_expert_calls.items():
+            assert dim_used == 32, f"Non-expert layer {name} should get full dim=32, got {dim_used}"
+
+    def test_normalize_moe_lora_disabled_uses_full_dim(self):
+        """All layers should get full dim when normalize_moe_lora is False (default)."""
+        model = MoEModel(moe_router_topk=2)
+        lora = LoRA(target_modules=["linear_fc1", "linear_fc2"], dim=32, normalize_moe_lora=False)
+
+        def mock_get_attrs(module, is_expert=False):
+            return AdapterAttributes(
+                input_is_parallel=False,
+                in_features=module.in_features,
+                out_features=module.out_features,
+                disable_tensor_parallel_comm=False,
+                disable_sequence_parallel_comm=True,
+                base_linear_is_parallel=True,
+            )
+
+        with patch("megatron.bridge.peft.lora.get_adapter_attributes_from_linear", side_effect=mock_get_attrs):
+            with patch("megatron.bridge.peft.lora.ParallelLinearAdapter") as mock_adapter:
+                mock_adapter.return_value = nn.Linear(1, 1)
+                lora(model, training=True)
+
+        for call in mock_adapter.call_args_list:
+            dim_used = call.args[2] if len(call.args) > 2 else call.kwargs.get("dim")
+            assert dim_used == 32, f"All layers should get full dim=32 when normalize_moe_lora=False, got {dim_used}"
+
+    def test_normalize_moe_lora_indivisible_dim_raises(self):
+        """Should raise ValueError when dim is not divisible by moe_router_topk."""
+        model = MoEModel(moe_router_topk=3)
+        lora = LoRA(target_modules=["linear_fc1"], dim=32, normalize_moe_lora=True)
+
+        def mock_get_attrs(module, is_expert=False):
+            return AdapterAttributes(
+                input_is_parallel=False,
+                in_features=module.in_features,
+                out_features=module.out_features,
+                disable_tensor_parallel_comm=False,
+                disable_sequence_parallel_comm=True,
+                base_linear_is_parallel=True,
+            )
+
+        with patch("megatron.bridge.peft.lora.get_adapter_attributes_from_linear", side_effect=mock_get_attrs):
+            with patch("megatron.bridge.peft.lora.ParallelLinearAdapter") as mock_adapter:
+                mock_adapter.return_value = nn.Linear(1, 1)
+                with pytest.raises(ValueError, match="must be divisible by moe_router_topk"):
+                    lora(model, training=True)
+
+    def test_normalize_moe_lora_shared_experts_get_full_dim(self):
+        """Shared expert layers should get full dim (they are excluded by is_expert_linear)."""
+        model = MoEModel(moe_router_topk=2)
+        lora = LoRA(target_modules=["linear_fc1"], dim=32, normalize_moe_lora=True)
+
+        def mock_get_attrs(module, is_expert=False):
+            return AdapterAttributes(
+                input_is_parallel=False,
+                in_features=module.in_features,
+                out_features=module.out_features,
+                disable_tensor_parallel_comm=False,
+                disable_sequence_parallel_comm=True,
+                base_linear_is_parallel=True,
+            )
+
+        with patch("megatron.bridge.peft.lora.get_adapter_attributes_from_linear", side_effect=mock_get_attrs):
+            with patch("megatron.bridge.peft.lora.ParallelLinearAdapter") as mock_adapter:
+                mock_adapter.return_value = nn.Linear(1, 1)
+                lora(model, training=True)
+
+        for call in mock_adapter.call_args_list:
+            name = call.kwargs.get("base_linear_name", "")
+            dim_used = call.args[2] if len(call.args) > 2 else call.kwargs.get("dim")
+            if ".shared_experts." in name:
+                assert dim_used == 32, f"Shared expert {name} should get full dim=32, got {dim_used}"
+
+    def test_normalize_moe_lora_no_op_on_dense_model(self):
+        """normalize_moe_lora=True with a non-MoE model should be a no-op (full dim everywhere)."""
+        model = SimpleModel()
+        lora = LoRA(target_modules=["linear_fc1", "linear_fc2"], dim=32, normalize_moe_lora=True)
+
+        transformed_model = lora(model, training=True)
+
+        assert isinstance(transformed_model.linear_fc1, LinearAdapter)
+        assert isinstance(transformed_model.linear_fc2, LinearAdapter)
+        assert transformed_model.linear_fc1.dim == 32
+        assert transformed_model.linear_fc2.dim == 32
 
 
 class TestLoRAMerge:


### PR DESCRIPTION
# What does this PR do ?

Adds a `normalize_moe_lora` flag to `LoRA` and `CanonicalLoRA` that automatically reduces the LoRA rank for expert linear layers by dividing by `moe_router_topk`, so that the total adapter capacity for MoE models is comparable to a dense model.

# Changelog

- Add `normalize_moe_lora: bool = False` field to `LoRA` and `CanonicalLoRA` dataclasses.
- Add `_get_effective_dim()` helper that returns `dim // moe_router_topk` for expert layers when the flag is enabled, with validation that `dim` is evenly divisible.
- Non-expert layers (attention projections, dense MLP, shared experts) are unaffected and always use the full `dim`.
- Add 5 unit tests in `test_lora.py` and 2 in `test_canonical_lora.py` covering: reduced expert dim, full dim when disabled, indivisible dim error, shared expert exclusion, and no-op on dense models.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

# Additional Information

- Related to #2964

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Mixture-of-Experts (MoE) normalization support to LoRA configuration, enabling expert-specific adapter rank reduction in MoE models.
  * Introduced validation to ensure adapter dimensions are properly divisible by MoE router topology settings.

* **Tests**
  * Added comprehensive test coverage for MoE normalization behavior across LoRA modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->