### PR TITLE
kimi-k2 optimizer type

### DIFF
--- a/docs/performance-summary.md
+++ b/docs/performance-summary.md
@@ -122,7 +122,7 @@ The performance data includes:
 |--------|--------|-----------|-----|-----|-----------------|------|----|----|----|----|----|-----------------------|-------------------------|
 | DGX-GB300 | 256 | MXFP8 | 4096 | 2 | 4096 | 0 | 1 | 4 | 1 | 4 | 64 | 5072 | 1037 |
 
-    -  Muon optimizer was used for pre-training Kimi-K2.
+-  Muon optimizer was used for pre-training Kimi-K2.
 
 - In MoE training benchmarks, we force-balance the token distribution among experts and all benchmarks are token-dropless.
 


### PR DESCRIPTION
# What does this PR do ?

Add note for muon optimizer used for kimi-k2 to summary docs

# Changelog

```
-  Muon optimizer was used for pre-training Kimi-K2.
```

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated pre-training documentation for Kimi_K2 results to include optimizer information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->