### PR TITLE
perf: add KubeflowExecutor support to scripts/performance

### DIFF
--- a/scripts/performance/argument_parser.py
+++ b/scripts/performance/argument_parser.py
@@ -528,6 +528,35 @@ def parse_cli_args():
         required=False,
     )
 
+    # Kubeflow
+    kubeflow_args = parser.add_argument_group("Kubeflow arguments")
+    kubeflow_args.add_argument(
+        "--kubeflow_namespace",
+        type=str,
+        help="Kubernetes namespace for Kubeflow TrainJob. When set, uses the Kubeflow executor instead of Slurm.",
+        required=False,
+    )
+    kubeflow_args.add_argument(
+        "--kubeflow_workdir_pvc",
+        type=str,
+        help="PVC name for syncing job workdir (launch scripts, packaged code) to the cluster before launch.",
+        required=False,
+    )
+    kubeflow_args.add_argument(
+        "--kubeflow_workdir_pvc_path",
+        type=str,
+        help="Mount path for the workdir PVC inside the training pod. Defaults to '/nemo_run'.",
+        default="/nemo_run",
+        required=False,
+    )
+    kubeflow_args.add_argument(
+        "--kubeflow_image_pull_secrets",
+        type=list_of_strings,
+        help="Comma-separated list of Kubernetes image pull secret names.",
+        required=False,
+        default=[],
+    )
+
     # For performance
     performance_args = parser.add_argument_group("Performance arguments")
     performance_args.add_argument(

--- a/scripts/performance/setup_experiment.py
+++ b/scripts/performance/setup_experiment.py
@@ -30,12 +30,12 @@ from nemo_run.config import get_nemorun_home
 try:
     from argument_parser import NUM_GPUS_PER_NODE_MAP, parse_cli_args
     from utils.evaluate import calc_convergence_and_performance
-    from utils.executors import dgxc_executor, slurm_executor
+    from utils.executors import dgxc_executor, kubeflow_executor, slurm_executor
     from utils.utils import get_exp_name_config, select_config_variant_interactive
 except (ImportError, ModuleNotFoundError):
     from .argument_parser import NUM_GPUS_PER_NODE_MAP, parse_cli_args
     from .utils.evaluate import calc_convergence_and_performance
-    from .utils.executors import dgxc_executor, slurm_executor
+    from .utils.executors import dgxc_executor, kubeflow_executor, slurm_executor
     from .utils.utils import get_exp_name_config, select_config_variant_interactive
 
 try:
@@ -240,6 +240,10 @@ def main(
     dgxc_project_name: str,
     dgxc_pvc_claim_name: str,
     dgxc_pvc_mount_path: str,
+    kubeflow_namespace: str,
+    kubeflow_workdir_pvc: str,
+    kubeflow_workdir_pvc_path: str,
+    kubeflow_image_pull_secrets: List[str],
     config_variant: str = "v1",
     gres: Optional[str] = None,
 ):
@@ -310,7 +314,37 @@ def main(
     if nccl_ub:
         custom_env_vars.update({"NCCL_NVLS_ENABLE": "1", "NCCL_CTA_POLICY": "1"})
 
-    if not dgxc_cluster:
+    if kubeflow_namespace:
+        executor = kubeflow_executor(
+            namespace=kubeflow_namespace,
+            nodes=-(num_gpus // -gpus_per_node),
+            num_gpus_per_node=gpus_per_node,
+            container_image=container_image,
+            workdir_pvc=kubeflow_workdir_pvc,
+            workdir_pvc_path=kubeflow_workdir_pvc_path,
+            image_pull_secrets=kubeflow_image_pull_secrets,
+            custom_env_vars=custom_env_vars,
+            wandb_key=wandb_key,
+            hf_token=hf_token,
+        )
+    elif dgxc_cluster:
+        executor = dgxc_executor(
+            dgxc_base_url=dgxc_base_url,
+            dgxc_cluster=dgxc_cluster,
+            dgxc_kube_apiserver_url=dgxc_kube_apiserver_url,
+            dgxc_app_id=dgxc_app_id,
+            dgxc_app_secret=dgxc_app_secret,
+            dgxc_project_name=dgxc_project_name,
+            dgxc_pvc_claim_name=dgxc_pvc_claim_name,
+            dgxc_pvc_mount_path=dgxc_pvc_mount_path,
+            custom_env_vars=custom_env_vars,
+            nodes=-(num_gpus // -gpus_per_node),
+            num_gpus_per_node=gpus_per_node,
+            container_image=container_image,
+            wandb_key=wandb_key,
+            hf_token=hf_token,
+        )
+    else:
         executor = slurm_executor(
             gpu=gpu,
             account=account,
@@ -329,23 +363,6 @@ def main(
             nemo_home=nemo_home,
             additional_slurm_params=additional_slurm_params,
             wandb_key=wandb_key,
-        )
-    else:
-        executor = dgxc_executor(
-            dgxc_base_url=dgxc_base_url,
-            dgxc_cluster=dgxc_cluster,
-            dgxc_kube_apiserver_url=dgxc_kube_apiserver_url,
-            dgxc_app_id=dgxc_app_id,
-            dgxc_app_secret=dgxc_app_secret,
-            dgxc_project_name=dgxc_project_name,
-            dgxc_pvc_claim_name=dgxc_pvc_claim_name,
-            dgxc_pvc_mount_path=dgxc_pvc_mount_path,
-            custom_env_vars=custom_env_vars,
-            nodes=-(num_gpus // -gpus_per_node),
-            num_gpus_per_node=gpus_per_node,
-            container_image=container_image,
-            wandb_key=wandb_key,
-            hf_token=hf_token,
         )
 
     plugins = []
@@ -420,7 +437,7 @@ def main(
     error_msg = None
     n_attempts = 0
     exp_name = (
-        exp_name[:33] if dgxc_cluster is not None else exp_name
+        exp_name[:33] if (dgxc_cluster is not None or kubeflow_namespace is not None) else exp_name
     )  # Some k8s clusters have a limit on the length of the experiment name.
     wandb_run_id = None
     while n_attempts <= max_retries:
@@ -666,6 +683,10 @@ if __name__ == "__main__":
         dgxc_project_name=args.dgxc_project_name,
         dgxc_pvc_claim_name=args.dgxc_pvc_claim_name,
         dgxc_pvc_mount_path=args.dgxc_pvc_mount_path,
+        kubeflow_namespace=args.kubeflow_namespace,
+        kubeflow_workdir_pvc=args.kubeflow_workdir_pvc,
+        kubeflow_workdir_pvc_path=args.kubeflow_workdir_pvc_path,
+        kubeflow_image_pull_secrets=args.kubeflow_image_pull_secrets,
         config_variant=config_variant,
         gres=args.gres,
     )

--- a/scripts/performance/utils/executors.py
+++ b/scripts/performance/utils/executors.py
@@ -158,6 +158,48 @@ def slurm_executor(
     return executor
 
 
+def kubeflow_executor(
+    namespace: str,
+    nodes: int,
+    num_gpus_per_node: int,
+    container_image: str = "nvcr.io/nvidia/nemo:dev",
+    volumes: List[Dict[str, Any]] = None,
+    volume_mounts: List[Dict[str, Any]] = None,
+    workdir_pvc: Optional[str] = None,
+    workdir_pvc_path: str = "/nemo_run",
+    image_pull_secrets: List[str] = None,
+    wandb_key: str = None,
+    hf_token: str = None,
+    custom_env_vars: Dict[str, str] = None,
+) -> run.KubeflowExecutor:
+    """
+    Kubeflow Training Operator executor definition with appropriate cluster params and NeMo container
+    params needed for pre-training and fine-tuning experiments on Kubernetes.
+    """
+    env_vars = dict(PERF_ENV_VARS)
+    if wandb_key is not None:
+        env_vars["WANDB_API_KEY"] = wandb_key
+    if hf_token is not None:
+        env_vars.update({"HF_TOKEN": hf_token, "TRANSFORMERS_OFFLINE": "0"})
+    if custom_env_vars:
+        env_vars.update(custom_env_vars)
+
+    executor = run.KubeflowExecutor(
+        namespace=namespace,
+        image=container_image,
+        num_nodes=nodes,
+        gpus_per_node=num_gpus_per_node,
+        volumes=volumes or [],
+        volume_mounts=volume_mounts or [],
+        workdir_pvc=workdir_pvc,
+        workdir_pvc_path=workdir_pvc_path,
+        image_pull_secrets=image_pull_secrets or [],
+        env_vars=env_vars,
+        packager=run.GitArchivePackager(include_submodules=False),
+    )
+    return executor
+
+
 def dgxc_executor(
     dgxc_base_url: str,
     dgxc_cluster: str,


### PR DESCRIPTION
## Summary

- Adds `kubeflow_executor()` to `scripts/performance/utils/executors.py`, wrapping `run.KubeflowExecutor` with the standard `PERF_ENV_VARS` baseline and the same HF/WandB token handling used by the Slurm and DGXCloud executors.
- Wires the new executor into `setup_experiment.py` with a clear three-way selection: **Kubeflow** (`--kubeflow_namespace` set) → **DGXCloud** (`--dgxc_cluster` set) → **Slurm** (default).
- Adds a "Kubeflow arguments" group to `argument_parser.py` with four new flags:
  - `--kubeflow_namespace` — Kubernetes namespace; presence triggers the Kubeflow path
  - `--kubeflow_workdir_pvc` — PVC used to sync launch scripts / packaged code before launch
  - `--kubeflow_workdir_pvc_path` — mount path inside the training pod (default `/nemo_run`)
  - `--kubeflow_image_pull_secrets` — comma-separated pull-secret names for private registries
- Applies the existing k8s experiment-name truncation (33 chars) to Kubeflow jobs as well.

Depends on: NVIDIA/NeMo-Run@9b12f25 (`KubeflowExecutor` added to `nemo-run`).

## Test plan

- [ ] Dry-run smoke test: `python setup_experiment.py ... --kubeflow_namespace default --dryrun` — verify executor is constructed without errors and the correct TrainJob manifest is printed.
- [ ] Live run on a Kubeflow Training Operator v2 cluster with `--kubeflow_workdir_pvc <pvc>` and confirm launch script is synced to the PVC and the TrainJob reaches `RUNNING`.
- [ ] Existing Slurm path unaffected: run without any `--kubeflow_*` or `--dgxc_*` flags and confirm `SlurmExecutor` is selected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)