### PR TITLE
[misc] fix: preserve multi-value cuda-graph-scope in Bridge→MLM translation

### DIFF
--- a/scripts/translate_mlm_to_bridge.py
+++ b/scripts/translate_mlm_to_bridge.py
@@ -1463,8 +1463,8 @@ def translate_bridge_to_mlm(overrides: dict[str, Any]) -> ReverseTranslationResu
         for k in list(overrides):
             if k.startswith("model.cuda_graph_scope."):
                 consumed.add(k)
-        scope_names = [overrides[k] for k in scope_name_keys]
-        result.add_arg("cuda-graph-scope", " ".join(scope_names))
+        scope_names = [str(overrides[k]) for k in scope_name_keys]
+        result.add_arg("cuda-graph-scope", scope_names)
         impl = cuda_impl or "transformer_engine"
         result.add_arg("cuda-graph-impl", impl)
         if cuda_impl is not None:
@@ -1475,13 +1475,13 @@ def translate_bridge_to_mlm(overrides: dict[str, Any]) -> ReverseTranslationResu
         # or a plain string/list of strings (from a simple CLI override).
         if isinstance(cuda_scope, (list, tuple)) and cuda_scope and isinstance(cuda_scope[0], dict):
             # Extract _name_ from each enum-dict entry (Hydra serialised CudaGraphScope)
-            names = [item["_name_"] for item in cuda_scope if "_name_" in item]
-            scope_str = " ".join(names)
+            scope_vals = [str(item["_name_"]) for item in cuda_scope if "_name_" in item]
         elif isinstance(cuda_scope, (list, tuple)):
-            scope_str = " ".join(str(s) for s in cuda_scope)
+            scope_vals = [str(s) for s in cuda_scope]
         else:
-            scope_str = str(cuda_scope)
-        result.add_arg("cuda-graph-scope", scope_str)
+            # Accept either a single token or a space-separated string.
+            scope_vals = shlex.split(str(cuda_scope))
+        result.add_arg("cuda-graph-scope", scope_vals)
         impl = cuda_impl or "transformer_engine"
         result.add_arg("cuda-graph-impl", impl)
         if cuda_impl is not None:


### PR DESCRIPTION
# What does this PR do ?

Fix Bridge→MLM reverse translation for `cuda_graph_scope` so multi-scope values are emitted as separate CLI tokens (compatible with Megatron-LM `--cuda-graph-scope` with `nargs='+'`), preventing reverse-translation failures.


# Changelog

- Update `scripts/translate_mlm_to_bridge.py` reverse path to normalize `model.cuda_graph_scope` into tokenized values instead of one space-joined string.
- Handle all incoming `cuda_graph_scope` forms consistently:
  - Hydra enum-dict list (extract `_name_`)
  - plain `list`/`tuple`
  - single string / space-separated string (split with `shlex.split`)
- Emit `cuda-graph-scope` as a list via `result.add_arg(...)` so final MLM args are generated as:
  - `--cuda-graph-scope attn mamba moe_router moe_preprocess`
  - (instead of one invalid token string)
- Keep existing behavior for `cuda-graph-impl` defaulting (`transformer_engine` when not explicitly set).
- Validate with Nemotron-3 Super reverse translation flow.
Example command used (Nemotron-3 Super):
```bash
uv run --no-sync python scripts/translate_mlm_to_bridge.py --reverse --recipe nemotron_3_super_pretrain_config --output /work/code/nemo-sa/sft/mbridge/llm/nemotron_3_super_pretrain_mlm.sh
Without this fix, the above flow can fail with:

KeyError: 'attn mamba moe_router moe_preprocess'
(raised from Megatron-LM argparse enum conversion for --cuda-graph-scope)
```

- Error log
```bash
# Loaded recipe 'nemotron_3_super_pretrain_config': 588 fields
Traceback (most recent call last):
  File "/work/code/nemo-sa/sft/mbridge/Megatron-Bridge/scripts/translate_mlm_to_bridge.py", line 1813, in <module>
    main()
  File "/work/code/nemo-sa/sft/mbridge/Megatron-Bridge/scripts/translate_mlm_to_bridge.py", line 1709, in main
    output = emit_mlm_args(result)
             ^^^^^^^^^^^^^^^^^^^^^
  File "/work/code/nemo-sa/sft/mbridge/Megatron-Bridge/scripts/translate_mlm_to_bridge.py", line 1596, in emit_mlm_args
    frag = _to_flag_and_value(mlm_name, True if val is None else val)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/work/code/nemo-sa/sft/mbridge/Megatron-Bridge/scripts/translate_mlm_to_bridge.py", line 1226, in _to_flag_and_value
    return f"--{name} {act.type(val)}"
                       ^^^^^^^^^^^^^
  File "/work/code/nemo-sa/sft/mbridge/Megatron-Bridge/3rdparty/Megatron-LM/megatron/training/arguments.py", line 1765, in <lambda>
    group.add_argument('--cuda-graph-scope', nargs='+', type=lambda scope: CudaGraphScope[scope] if scope != "full" else scope, default=[],
                                                                           ~~~~~~~~~~~~~~^^^^^^^
  File "/usr/lib/python3.12/enum.py", line 814, in __getitem__
    return cls._member_map_[name]
           ~~~~~~~~~~~~~~~~^^^^^^
KeyError: 'attn mamba moe_router moe_preprocess'
```

- Result after fixing the cuda-graph-scope
```bash
# ═══════════════════════════════════════════════════════════
# Megatron-LM pretrain_gpt.py args (translated from Bridge)
# ═══════════════════════════════════════════════════════════
#
# NOTE: squared_relu: model.activation_func=squared_relu → --squared-relu
# NOTE: mixed_precision=nemotron_3_super_bf16_with_nvfp4_mixed: unknown precision mode
# NOTE: max-position-embeddings not set; defaulting to seq-length for MLM assert
#

  --use-mcore-models \
  --transformer-impl transformer_engine \
  --group-query-attention \
  --squared-relu \
  --split 9999,8,2 \
  --cuda-graph-scope attn mamba moe_router moe_preprocess \
  --cuda-graph-impl transformer_engine \
  --seq-length 8192 \
  --max-position-embeddings 8192 \
  --seed 1234 \
  --micro-batch-size 1 \
  --global-batch-size 3072 \
  --train-iters 39735 \
  --manual-gc-interval 0 \
  --tensor-model-parallel-size 4 \
  --pipeline-model-parallel-size 1 \
  --sequence-parallel \
  --context-parallel-size 1 \
  --expert-model-parallel-size 8 \
  --expert-tensor-parallel-size 1 \
  --te-rng-tracker \
  --cross-entropy-loss-fusion \
  --cross-entropy-fusion-impl native \
  --no-overlap-p2p-communication \
  --num-layers 88 \
  --mtp-num-layers 2 \
  --mtp-loss-scaling-factor 0.3 \
  --hidden-size 4096 \
  --num-attention-heads 32 \
  --attention-backend AttnBackend.fused \
  --num-query-groups 2 \
  --ffn-hidden-size 2688 \
  --kv-channels 128 \
  --hidden-dropout 0.0 \
  --attention-dropout 0.0 \
  --norm-epsilon 1e-05 \
  --disable-bias-linear \
  --num-experts 512 \
  --normalization RMSNorm \
  --calculate-per-token-loss \
  --init-method-std 0.014 \
  --no-rope-fusion \
  --moe-shared-expert-intermediate-size 5376 \
  --moe-layer-freq 1 \
  --moe-ffn-hidden-size 2688 \
  --moe-router-load-balancing-type seq_aux_loss \
  --moe-router-topk 22 \
  --moe-router-num-groups 1 \
  --moe-router-group-topk 1 \
  --moe-router-topk-scaling-factor 5.0 \
  --moe-router-score-function sigmoid \
  --moe-router-dtype fp32 \
  --moe-router-enable-expert-bias \
  --moe-router-bias-update-rate 0.001 \
  --moe-grouped-gemm \
  --moe-aux-loss-coeff 0.0001 \
  --moe-token-dispatcher-type alltoall \
  --moe-permute-fusion \
  --cuda-graph-warmup-steps 3 \
  --untie-embeddings-and-output-weights \
  --position-embedding-type none \
  --rotary-percent 1.0 \
  --rotary-base 10000 \
  --make-vocab-size-divisible-by 128 \
  --padded-vocab-size 131072 \
  --lr 0.00045 \
  --min-lr 4.5e-06 \
  --weight-decay 0.1 \
  --adam-beta1 0.9 \
  --adam-beta2 0.95 \
  --adam-eps 1e-08 \
  --clip-grad 1.0 \
  --grad-reduce-in-fp32 \
  --overlap-grad-reduce \
  --overlap-param-gather \
  --use-distributed-optimizer \
  --eval-iters 32 \
  --eval-interval 1000 \
  --lr-decay-style WSD \
  --lr-wsd-decay-style minus_sqrt \
  --lr-warmup-iters 333 \
  --lr-warmup-samples 0 \
  --lr-warmup-init 0.0 \
  --override-opt-param-scheduler \
  --start-weight-decay 0.1 \
  --end-weight-decay 0.1 \
  --weight-decay-incr-style constant \
  --dataloader-type single \
  --num-workers 1 \
  --num-dataset-builder-threads 1 \
  --no-mmap-bin-files \
  --log-interval 10 \
  --tensorboard-dir /work/code/nemo-sa/sft/mbridge/Megatron-Bridge/nemo_experiments/default/tb_logs \
  --log-timers-to-tensorboard \
  --logging-level 20 \
  --vocab-extra-ids 0 \
  --tokenizer-type HuggingFaceTokenizer \
  --tokenizer-model nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16 \
  --tiktoken-num-special-tokens 1000 \
  --save /work/code/nemo-sa/sft/mbridge/Megatron-Bridge/nemo_experiments/default/checkpoints \
  --save-interval 200 \
  --load /work/code/nemo-sa/sft/mbridge/Megatron-Bridge/nemo_experiments/default/checkpoints \
  --ckpt-format torch_dist \
  --async-save \
  --use-persistent-ckpt-worker \
  --dist-ckpt-strictness log_all \
  --distributed-timeout-minutes 10 \

# ── Not supported: mapped keys with no value (set explicitly to use) ──
#   train.train_samples: mapped to --train-samples but value is None (not set)
#   train.exit_interval: mapped to --exit-interval but value is None (not set)
#   train.exit_duration_in_mins: mapped to --exit-duration-in-mins but value is None (not set)
#   model.virtual_pipeline_model_parallel_size: mapped to --num-virtual-stages-per-pipeline-rank but value is None (not set)
#   model.microbatch_group_size_per_vp_stage: mapped to --microbatch-group-size-per-virtual-pipeline-stage but value is None (not set)
#   model.num_layers_in_first_pipeline_stage: mapped to --decoder-first-pipeline-num-layers but value is None (not set)
#   model.num_layers_in_last_pipeline_stage: mapped to --decoder-last-pipeline-num-layers but value is None (not set)
#   model.pipeline_model_parallel_layout: mapped to --pipeline-model-parallel-layout but value is None (not set)
#   model.window_size: mapped to --window-size but value is None (not set)
#   model.recompute_granularity: mapped to --recompute-granularity but value is None (not set)
#   model.recompute_method: mapped to --recompute-method but value is None (not set)
#   model.recompute_num_layers: mapped to --recompute-num-layers but value is None (not set)
#   model.seq_len_interpolation_factor: mapped to --rotary-seq-len-interpolation-factor but value is None (not set)
#   optimizer.decoupled_lr: mapped to --decoupled-lr but value is None (not set)
#   optimizer.decoupled_min_lr: mapped to --decoupled-min-lr but value is None (not set)
#   scheduler.lr_decay_iters: mapped to --lr-decay-iters but value is None (not set)
#   scheduler.lr_decay_samples: mapped to --lr-decay-samples but value is None (not set)
#   scheduler.lr_wsd_decay_iters: mapped to --lr-wsd-decay-iters but value is None (not set)
#   scheduler.lr_wsd_decay_samples: mapped to --lr-wsd-decay-samples but value is None (not set)
#   scheduler.lr_warmup_fraction: mapped to --lr-warmup-fraction but value is None (not set)
#   dataset.path_to_cache: mapped to --data-cache-path but value is None (not set)
#   logger.wandb_project: mapped to --wandb-project but value is None (not set)
#   logger.wandb_exp_name: mapped to --wandb-exp-name but value is None (not set)
#   tokenizer.vocab_size: mapped to --vocab-size but value is None (not set)
#   tokenizer.vocab_file: mapped to --vocab-file but value is None (not set)
#   tokenizer.merge_file: mapped to --merge-file but value is None (not set)
#   checkpoint.pretrained_checkpoint: mapped to --pretrained-checkpoint but value is None (not set)

# ── Unknown Bridge keys (not mapped) ─────────────────────
#   tensor_inspect=None

# ── Skipped: 413 Bridge-only keys (no MLM equivalent)

```



# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CUDA graph scope argument handling to properly format and emit scope values as argument lists, improving support for various scope configuration formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->