### PR TITLE
[doc] feat: add Nemotron Super news and compact model support list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,6 @@ For a deeper dive into conversion design and advanced usage, see the [models REA
 
 Megatron Bridge provides out-of-the-box bridges and training recipes for a wide range of models, built on top of base model architectures from [Megatron Core](https://github.com/NVIDIA/Megatron-LM/tree/main/megatron/core). Refer to the [models directory](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/src/megatron/bridge/models) for the full list of model bridges.
 
-For more details, see our documentation: **[LLM](https://docs.nvidia.com/nemo/megatron-bridge/latest/models/llm/index.html)** | **[VLM](https://docs.nvidia.com/nemo/megatron-bridge/latest/models/vlm/index.html)**
-
 ### Nemotron (NVIDIA)
 
 - [Nemotron Nano v2](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/src/megatron/bridge/models/nemotronh) — [recipes (9B/12B)](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/src/megatron/bridge/recipes/nemotronh/nemotron_nano_v2.py)


### PR DESCRIPTION
## Summary

- Adds a news entry (03/30/2026) for day-0 Nemotron Super support, linking to the HuggingFace model and `super-v3` branch
- Replaces the large model support table with a compact, grouped list (Nemotron, LLM, VLM, Omni) with hyperlinks to model folders and recipe files
- Adds previously unlisted models: Kimi K2, GLM-4.5V, MiMo, Qwen2.5-Omni

## Test plan

- [ ] Verify all hyperlinks render correctly in the GitHub README
- [ ] Confirm Nemotron Super news entry is accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added announcement for Day 0 support for Nemotron Super with links to the model and conversion/training recipes.
  * Restructured the supported models section with explicit category groupings for easier navigation, replacing the previous table format with organized category lists including model links and recipe references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->