### PR TITLE
Revert "ci: Remove per-unit-test timeout and do not uv sync during te…

### DIFF
--- a/.github/actions/test-template/action.yml
+++ b/.github/actions/test-template/action.yml
@@ -69,6 +69,21 @@ runs:
         path: ${{ github.workspace }}/Megatron-Bridge
         submodules: recursive
 
+    - name: Update MCore submodule (if triggered from MCore)
+      if: ${{ github.event.inputs.mcore_commit != '' }}
+      shell: bash
+      working-directory: ${{ github.workspace }}/Megatron-Bridge
+      run: |
+        echo "🔄 Updating MCore submodule to commit: ${{ github.event.inputs.mcore_commit }}"
+        echo "📍 MCore repo: ${{ github.event.inputs.mcore_repo || 'https://github.com/NVIDIA/Megatron-LM.git' }}"
+        cd 3rdparty/Megatron-LM
+        git fetch ${{ github.event.inputs.mcore_repo || 'origin' }} ${{ github.event.inputs.mcore_commit }}
+        git checkout ${{ github.event.inputs.mcore_commit }}
+
+        ACTUAL_COMMIT=$(git rev-parse HEAD)
+        echo "✅ MCore submodule updated to: ${ACTUAL_COMMIT}"
+        git log -1 --oneline
+
     - name: Install Azure CLI
       if: ${{ inputs.has-azure-credentials == 'true' }}
       shell: bash
@@ -114,7 +129,6 @@ runs:
         cmd=$(cat <<RUN_TEST_EOF
         #!/bin/bash
         docker container rm -f nemo_container_${{ github.run_id }} || true
-
         docker run \
           --rm \
           -d \
@@ -127,8 +141,8 @@ runs:
           --env HF_HOME=/home/TestData/HF_HOME \
           --env NEMO_HOME=/home/TestData/nemo_home \
           --env RUN_ID=${{ github.run_id }} \
-          --env UV_NO_SYNC=1 \
           --workdir /opt/Megatron-Bridge \
+          --volume ${{ github.workspace }}/Megatron-Bridge:/opt/Megatron-Bridge \
           $VOLUME_ARGS \
           ${{ inputs.container-image }} \
           bash -c "sleep $(( ${{ inputs.timeout }} * 60 + 60 ))"

--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -350,6 +350,30 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Update MCore submodule (if triggered from MCore)
+        if: ${{ github.event.inputs.mcore_ref != '' }}
+        run: |
+          echo "🔄 Updating MCore submodule for unit tests..."
+          cd 3rdparty/Megatron-LM
+          git fetch ${{ github.event.inputs.mcore_repo || 'origin' }} ${{ github.event.inputs.mcore_ref }}
+          git checkout ${{ github.event.inputs.mcore_ref }}
+
+          ACTUAL_COMMIT=$(git rev-parse HEAD)
+          EXPECTED_COMMIT="${{ github.event.inputs.mcore_ref }}"
+
+          echo "🧪 UNIT TESTS - MCore verification:"
+          echo "Expected: ${EXPECTED_COMMIT}"
+          echo "Actual:   ${ACTUAL_COMMIT}"
+
+          if [ "${ACTUAL_COMMIT}" != "${EXPECTED_COMMIT}" ]; then
+            echo "❌ ERROR: MCore commit mismatch!"
+            exit 1
+          fi
+
+          echo "✅ MCore commit verified"
+          echo "📦 Container: ${{ needs.pre-flight.outputs.registry }}/megatron-bridge:${{ github.sha }}"
+          git log -1 --oneline
+
       - name: main
         uses: ./.github/actions/test-template
         with:
@@ -386,6 +410,30 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: recursive
+
+      - name: Update MCore submodule (if triggered from MCore)
+        if: ${{ github.event.inputs.mcore_ref != '' }}
+        run: |
+          echo "🔄 Updating MCore submodule for unit tests..."
+          cd 3rdparty/Megatron-LM
+          git fetch ${{ github.event.inputs.mcore_repo || 'origin' }} ${{ github.event.inputs.mcore_ref }}
+          git checkout ${{ github.event.inputs.mcore_ref }}
+
+          ACTUAL_COMMIT=$(git rev-parse HEAD)
+          EXPECTED_COMMIT="${{ github.event.inputs.mcore_ref }}"
+
+          echo "🧪 UNIT TESTS - MCore verification:"
+          echo "Expected: ${EXPECTED_COMMIT}"
+          echo "Actual:   ${ACTUAL_COMMIT}"
+
+          if [ "${ACTUAL_COMMIT}" != "${EXPECTED_COMMIT}" ]; then
+            echo "❌ ERROR: MCore commit mismatch!"
+            exit 1
+          fi
+
+          echo "✅ MCore commit verified"
+          echo "📦 Container: ${{ needs.pre-flight.outputs.registry }}/megatron-bridge:${{ github.sha }}"
+          git log -1 --oneline
 
       - name: main
         uses: ./.github/actions/test-template
@@ -475,6 +523,30 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Update MCore submodule (if triggered from MCore)
+        if: ${{ github.event.inputs.mcore_ref != '' }}
+        run: |
+          echo "🔄 Updating MCore submodule for functional tests..."
+          cd 3rdparty/Megatron-LM
+          git fetch ${{ github.event.inputs.mcore_repo || 'origin' }} ${{ github.event.inputs.mcore_ref }}
+          git checkout ${{ github.event.inputs.mcore_ref }}
+
+          ACTUAL_COMMIT=$(git rev-parse HEAD)
+          EXPECTED_COMMIT="${{ github.event.inputs.mcore_ref }}"
+
+          echo "🧪 FUNCTIONAL TESTS - MCore verification:"
+          echo "Expected: ${EXPECTED_COMMIT}"
+          echo "Actual:   ${ACTUAL_COMMIT}"
+
+          if [ "${ACTUAL_COMMIT}" != "${EXPECTED_COMMIT}" ]; then
+            echo "❌ ERROR: MCore commit mismatch!"
+            exit 1
+          fi
+
+          echo "✅ MCore commit verified"
+          echo "📦 Container: ${{ needs.pre-flight.outputs.registry }}/megatron-bridge:${{ github.sha }}"
+          git log -1 --oneline
+
       - name: main
         uses: ./.github/actions/test-template
         with:
@@ -518,6 +590,30 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: recursive
+
+      - name: Update MCore submodule (if triggered from MCore)
+        if: ${{ github.event.inputs.mcore_ref != '' }}
+        run: |
+          echo "🔄 Updating MCore submodule for functional tests..."
+          cd 3rdparty/Megatron-LM
+          git fetch ${{ github.event.inputs.mcore_repo || 'origin' }} ${{ github.event.inputs.mcore_ref }}
+          git checkout ${{ github.event.inputs.mcore_ref }}
+
+          ACTUAL_COMMIT=$(git rev-parse HEAD)
+          EXPECTED_COMMIT="${{ github.event.inputs.mcore_ref }}"
+
+          echo "🧪 FUNCTIONAL TESTS - MCore verification:"
+          echo "Expected: ${EXPECTED_COMMIT}"
+          echo "Actual:   ${ACTUAL_COMMIT}"
+
+          if [ "${ACTUAL_COMMIT}" != "${EXPECTED_COMMIT}" ]; then
+            echo "❌ ERROR: MCore commit mismatch!"
+            exit 1
+          fi
+
+          echo "✅ MCore commit verified"
+          echo "📦 Container: ${{ needs.pre-flight.outputs.registry }}/megatron-bridge:${{ github.sha }}"
+          git log -1 --oneline
 
       - name: main
         uses: ./.github/actions/test-template
@@ -563,6 +659,30 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Update MCore submodule (if triggered from MCore)
+        if: ${{ github.event.inputs.mcore_ref != '' }}
+        run: |
+          echo "🔄 Updating MCore submodule for functional tests..."
+          cd 3rdparty/Megatron-LM
+          git fetch ${{ github.event.inputs.mcore_repo || 'origin' }} ${{ github.event.inputs.mcore_ref }}
+          git checkout ${{ github.event.inputs.mcore_ref }}
+
+          ACTUAL_COMMIT=$(git rev-parse HEAD)
+          EXPECTED_COMMIT="${{ github.event.inputs.mcore_ref }}"
+
+          echo "🧪 FUNCTIONAL TESTS - MCore verification:"
+          echo "Expected: ${EXPECTED_COMMIT}"
+          echo "Actual:   ${ACTUAL_COMMIT}"
+
+          if [ "${ACTUAL_COMMIT}" != "${EXPECTED_COMMIT}" ]; then
+            echo "❌ ERROR: MCore commit mismatch!"
+            exit 1
+          fi
+
+          echo "✅ MCore commit verified"
+          echo "📦 Container: ${{ needs.pre-flight.outputs.registry }}/megatron-bridge:${{ github.sha }}"
+          git log -1 --oneline
+
       - name: main
         uses: ./.github/actions/test-template
         with:
@@ -597,6 +717,30 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: recursive
+
+      - name: Update MCore submodule (if triggered from MCore)
+        if: ${{ github.event.inputs.mcore_ref != '' }}
+        run: |
+          echo "🔄 Updating MCore submodule for functional tests..."
+          cd 3rdparty/Megatron-LM
+          git fetch ${{ github.event.inputs.mcore_repo || 'origin' }} ${{ github.event.inputs.mcore_ref }}
+          git checkout ${{ github.event.inputs.mcore_ref }}
+
+          ACTUAL_COMMIT=$(git rev-parse HEAD)
+          EXPECTED_COMMIT="${{ github.event.inputs.mcore_ref }}"
+
+          echo "🧪 FUNCTIONAL TESTS - MCore verification:"
+          echo "Expected: ${EXPECTED_COMMIT}"
+          echo "Actual:   ${ACTUAL_COMMIT}"
+
+          if [ "${ACTUAL_COMMIT}" != "${EXPECTED_COMMIT}" ]; then
+            echo "❌ ERROR: MCore commit mismatch!"
+            exit 1
+          fi
+
+          echo "✅ MCore commit verified"
+          echo "📦 Container: ${{ needs.pre-flight.outputs.registry }}/megatron-bridge:${{ github.sha }}"
+          git log -1 --oneline
 
       - name: main
         uses: ./.github/actions/test-template

--- a/tests/unit_tests/Launch_Unit_Tests_Core.sh
+++ b/tests/unit_tests/Launch_Unit_Tests_Core.sh
@@ -25,7 +25,14 @@ if [ -f "/opt/Megatron-Bridge/.mcore_commit_sha" ]; then
 fi
 echo ""
 
+# Skip timeout on Azure runners because the machines are slower
+TIMEOUT_ARG="--timeout=2"
+if [[ "${GHA_RUNNER:-}" == *"azure"* ]]; then
+    TIMEOUT_ARG=""
+fi
+
 CUDA_VISIBLE_DEVICES="0,1" uv run coverage run -a --data-file=/opt/Megatron-Bridge/.coverage --source=/opt/Megatron-Bridge/ -m pytest \
+    $TIMEOUT_ARG \
     -o log_cli=true \
     -o log_cli_level=INFO \
     --disable-warnings \

--- a/tests/unit_tests/Launch_Unit_Tests_Diffusion.sh
+++ b/tests/unit_tests/Launch_Unit_Tests_Diffusion.sh
@@ -25,7 +25,14 @@ if [ -f "/opt/Megatron-Bridge/.mcore_commit_sha" ]; then
 fi
 echo ""
 
+# Skip timeout on Azure runners because the machines are slower
+TIMEOUT_ARG="--timeout=2"
+if [[ "${GHA_RUNNER:-}" == *"azure"* ]]; then
+    TIMEOUT_ARG=""
+fi
+
 CUDA_VISIBLE_DEVICES="0,1" uv run coverage run -a --data-file=/opt/Megatron-Bridge/.coverage --source=/opt/Megatron-Bridge/ -m pytest \
+    $TIMEOUT_ARG \
     -o log_cli=true \
     -o log_cli_level=INFO \
     --disable-warnings \

--- a/tests/unit_tests/data/datasets/test_sft.py
+++ b/tests/unit_tests/data/datasets/test_sft.py
@@ -60,7 +60,6 @@ def get_gpt_sft(tmp_path, dataset_type="sft"):
             max_num_samples=num_samples,
             prompt_template="{input}\n\n### Response:\n{output}",
             truncation_field="output",
-            memmap_workers=1,
         )
     elif dataset_type == "packed":
         # Create a mock packed dataset file
@@ -83,7 +82,6 @@ def get_gpt_sft(tmp_path, dataset_type="sft"):
             label_key="output",
             prompt_template="{input}\n\n### Response:\n{output}",
             truncation_field="output",
-            memmap_workers=1,
         )
     else:
         dataset = GPTSFTChatDataset(
@@ -92,7 +90,6 @@ def get_gpt_sft(tmp_path, dataset_type="sft"):
             label_key="output",
             prompt_template="{input}\n\n### Response:\n{output}",
             truncation_field="output",
-            memmap_workers=1,
         )
 
     return dataset, num_samples


### PR DESCRIPTION
…st (#3010)"

This reverts commit e9f0dea60a8055b5d3fcfbeceb2618cb7e51b554.

# What does this PR do ?

It caused a mid-air collission that broke `megatron.training` - https://github.com/NVIDIA-NeMo/Megatron-Bridge/actions/runs/23762900554/job/69236198873?pr=2743 

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced MCore submodule management and verification in test workflows
  * Improved Azure runner compatibility with timeout adjustments

* **Chores**
  * Updated test infrastructure for improved CI/CD integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->