### PR TITLE
ci: add GitHub merge queue support

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -133,9 +133,9 @@ jobs:
             fi
           fi
 
-          # EXPECT_L2: schedule or workflow_dispatch only
+          # EXPECT_L2: schedule, workflow_dispatch, or full-test-suite label
           EXPECT_L2=false
-          if [[ "$EXPECT_L0" == "true" && ("$EVENT_NAME" == "schedule" || "$EVENT_NAME" == "workflow_dispatch") ]]; then
+          if [[ "$EXPECT_L0" == "true" && ("$EVENT_NAME" == "schedule" || "$EVENT_NAME" == "workflow_dispatch" || "$FULL_TEST_SUITE" == "true") ]]; then
             EXPECT_L2=true
           fi
 
@@ -156,6 +156,7 @@ jobs:
           _SCHED=$( [[ "$EVENT_NAME" == "schedule"          ]] && echo "**→**" || echo "" )
           _WD=$(    [[ "$EVENT_NAME" == "workflow_dispatch" ]] && echo "**→**" || echo "" )
           _NMT=$(   [[ "$NEEDS_MORE_TESTS" == "true"        ]] && echo "**→**" || echo "" )
+          _FTS=$(   [[ "$FULL_TEST_SUITE"  == "true"        ]] && echo "**→**" || echo "" )
 
           cat <<SUMMARY >> "$GITHUB_STEP_SUMMARY"
           ## CI Configuration
@@ -175,7 +176,7 @@ jobs:
           |---|---|---|
           | $_L0 | **L0** | any non-docs/deployment run |
           | $_L1 | **L1** | \`main\` / \`schedule\` / \`workflow_dispatch\` / \`merge_group\` / label _needs-more-tests_ |
-          | $_L2 | **L2** | \`schedule\` / \`workflow_dispatch\` only |
+          | $_L2 | **L2** | \`schedule\` / \`workflow_dispatch\` / label _full-test-suite_ |
 
           ### Decision tree
 
@@ -195,6 +196,7 @@ jobs:
           | $_WD    | \`workflow_dispatch\` |
           | $_MG    | \`merge_group\` |
           | $_NMT   | Label: _needs-more-tests_ |
+          | $_FTS   | Label: _full-test-suite_ |
           SUMMARY
 
   lint-check:


### PR DESCRIPTION
## Summary

- Adds \`merge_group\` trigger so CI runs when a PR enters GitHub's native merge queue
- Skips \`cicd-wait-in-queue\` for merge queue events (GitHub's queue handles ordering natively)
- Propagates \`merge_group\` as a valid condition through all test job \`if\` guards (container build, unit tests, L0/L1 functional tests)
- Runs L1 tests on merge queue entries as the final pre-merge gate (same as \`main\` push)

**Introduces a \`configure\` job** — a single early job (needs only \`pre-flight\`) that:
- Fetches PR labels and computes \`expect_l0 / expect_l1 / expect_l2\` as explicit outputs
- Absorbs the old \`check-labels\` job, which ran unnecessarily late (after container build)
- Publishes a step summary with a configuration table and decision tree

**Fixes a fundamental bug in skip-detection (\`EXPECT_L*\`):** the old outer gate was \`is_ci_workload == 'true'\`, which is \`false\` for PR branches (\`pull-request/N\`) and \`merge_group\` events — silently disabling the skip-detection safety net for every PR run and every merge queue run. The correct gate is \`docs_only != 'true' && is_deployment_workflow != 'true'\`, covering only the two cases where tests genuinely do not run.

## Enabling the merge queue

After merging, enable the merge queue in **Settings → Branches → Branch protection rules** for \`main\`:
1. Check **Require merge queue**
2. Add \`Nemo_CICD_Test\` as a required status check for the merge queue

## Example step summary

| Setting | Value |
|---|---|
| \`docs_only\` | \`false\` |
| \`is_deployment_workflow\` | \`false\` |
| \`needs_more_tests\` | \`false\` |
| \`full_test_suite\` | \`false\` |

| | Tier | Condition |
|---|---|---|
| **→** | **L0** | any non-docs/deployment run |
| | **L1** | \`main\` / \`schedule\` / \`workflow_dispatch\` / \`merge_group\` / label _needs-more-tests_ |
| | **L2** | \`schedule\` / \`workflow_dispatch\` / label _full-test-suite_ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)