### PR TITLE
[ci] feat: auto-remove needs-author label on author reply or push

### DIFF
--- a/.github/workflows/remove-needs-author.yml
+++ b/.github/workflows/remove-needs-author.yml
@@ -1,0 +1,56 @@
+name: Remove needs-author label
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request:
+    types: [synchronize]
+
+jobs:
+  remove-label-on-comment:
+    if: github.event_name == 'issue_comment' && github.event.issue.pull_request != null
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove needs-author if author commented
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const commenter = context.payload.comment.user.login;
+            const prAuthor = context.payload.issue.user.login;
+
+            if (commenter !== prAuthor) return;
+
+            const labels = context.payload.issue.labels.map(l => l.name);
+            if (!labels.includes('needs-author')) return;
+
+            await github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              name: 'needs-author',
+            });
+
+  remove-label-on-push:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove needs-author if author pushed commits
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const prAuthor = context.payload.pull_request.user.login;
+            const pusher = context.payload.sender.login;
+
+            if (pusher !== prAuthor) return;
+
+            const labels = context.payload.pull_request.labels.map(l => l.name);
+            if (!labels.includes('needs-author')) return;
+
+            await github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              name: 'needs-author',
+            });


### PR DESCRIPTION
## Summary

- Adds a new GitHub Actions workflow that automatically removes the `needs-author` label when the PR author takes action.
- Triggers on author **comment** on the PR (`issue_comment` event).
- Triggers on author **push/commit** to the PR branch (`pull_request: synchronize` event).
- Guards against non-author actors (maintainers, bots) accidentally triggering removal.
- Uses `GITHUB_TOKEN` — no PAT required.

## Test plan

- [ ] Add `needs-author` to a test PR, then comment as the author → label is removed
- [ ] Add `needs-author` to a test PR, then push a commit → label is removed
- [ ] Verify a non-author comment does NOT remove the label

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added GitHub Actions workflow to automatically remove the `needs-author` label from pull requests when the pull request author comments on or updates the pull request with new commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->