### PR TITLE
chore: Bump Python3.12 also for FW container

### DIFF
--- a/docker/common/fw_pyproject.toml
+++ b/docker/common/fw_pyproject.toml
@@ -23,7 +23,7 @@ version = { attr = "_version.__version__" }
 name = "NeMo-FW"
 dynamic = ["version"]
 description = "NeMo FW container"
-requires-python = ">=3.10,<3.13"
+requires-python = ">=3.12,<3.13"
 license = { text = "Apache 2.0" }
 
 # Define the core libraries


### PR DESCRIPTION
# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package's Python version requirements. The minimum supported Python version has been raised to Python 3.12 (previously supported Python 3.10 or later). The maximum supported version remains at Python 3.12.x. Users must ensure their environment has Python 3.12 or higher available when running this package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->