### PR TITLE
[doc] feat: rewrite CPU offloading documentation with measured metrics

### DIFF
--- a/docs/skills-index.md
+++ b/docs/skills-index.md
@@ -37,6 +37,7 @@ skills/perf-techniques/sequence-packing/SKILL
 skills/perf-techniques/hybrid-context-parallel/SKILL
 skills/perf-techniques/expert-parallel-overlap/SKILL
 skills/perf-techniques/moe-comm-overlap/SKILL
+skills/perf-techniques/cpu-offloading/SKILL
 ```
 
 ```{toctree}

--- a/docs/training/cpu-offloading.md
+++ b/docs/training/cpu-offloading.md
@@ -1,76 +1,158 @@
 # CPU Offloading
 
-## Overview
+CPU offloading reduces per-GPU memory by moving data to host (CPU) memory
+during training, trading throughput for the ability to train models or
+configurations that would otherwise not fit in GPU memory.
 
-CPU Offloading in Megatron Bridge is a feature that reduces the peak memory usage of the GPU by offloading activations and inactive weights to CPU storage. Megatron Bridge supports offloading at the transformer layer level, allowing users to specify the number of transformer layers in their language model that require CPU offloading. During the forward pass, Megatron Bridge offloads activations at the optimal time and reloads them as needed during the backward pass.
+For operational setup, code anchors, and verification commands, see
+[skills/perf-techniques/cpu-offloading/SKILL.md](../../skills/perf-techniques/cpu-offloading/SKILL.md).
 
-## Features
+## What It Is
 
-- Supports training models with long sequence lengths by managing activation memory efficiently
-- Enables high batch sizes per GPU by offloading activation memory
-- Overlaps computation with data transfers (Host2Device and Device2Host) during offloading and reloading
+Megatron Bridge supports two independent CPU offloading mechanisms:
 
-## Configuration
+| Mechanism | What gets offloaded | Implementation |
+|---|---|---|
+| **Activation offloading** | Activations (and optionally weights) per transformer layer | MCore `cpu_offloading_context` in transformer block |
+| **Optimizer offloading** | Optimizer states (Adam momentum + variance) | MCore `HybridDeviceOptimizer` with configurable GPU/CPU split |
 
-CPU offloading is configured through the model provider parameters:
+Activation offloading moves layer activations to CPU during forward and
+reloads them during backward. Optimizer offloading keeps a configurable
+fraction of Adam optimizer states on CPU and runs the optimizer step there.
+
+These are independent features addressing different memory pools. They can
+be used separately but not always together due to constraint conflicts.
+
+## What Problem It Solves
+
+Large models, especially MoE architectures, can exhaust GPU memory even with
+standard parallelism techniques (TP, PP, EP). The two offloading mechanisms
+target different bottlenecks:
+
+- **Activation offloading** helps when activation memory dominates — common
+  with long sequences, large batch sizes, or when recomputation is disabled.
+- **Optimizer offloading** helps when optimizer state memory dominates — Adam
+  keeps two state tensors (momentum + variance) per parameter, doubling the
+  parameter memory footprint. For a 30B MoE model this can be 15+ GB per GPU.
+
+## Impacted Training Dimensions
+
+| Dimension | Effect | Confidence | Rationale |
+|-----------|--------|------------|-----------|
+| Speed | `--` | high | Throughput penalty scales linearly with offload fraction. CPU Adam compute and D2H/H2D transfers add latency. Measured 1.9x–4.2x slower on Qwen3-30B-A3B. |
+| Memory | `++` | high | Optimizer offload saves 3.8 GB per 25% of fraction on Qwen3-30B-A3B (up to 15.3 GB / 32% at 100%). Activation offload saves activation memory proportional to layers offloaded. |
+| Scale | `+` | medium | Enables training configurations that would otherwise OOM. Can free memory for larger batch sizes or additional parallelism. |
+| Convergence | `0` | high | All optimizer offload fractions (25–100%) produce identical loss within 0.001 across 20 iterations, validation, and test. |
+| Stability | `0` | high | No errors, hangs, or NCCL issues across 120 total iterations tested (6 configurations). |
+
+## When to Use It
+
+- GPU memory is tight and throughput regression is acceptable
+- The model requires PP > 1 to fit — use **optimizer offloading** (activation
+  offloading requires PP=1)
+- You want a tunable memory-speed tradeoff via `optimizer_offload_fraction`
+- Activation memory is the bottleneck and the model fits with PP=1 and no
+  recompute — use **activation offloading**
+
+## When Not to Use It
+
+- Throughput is the primary concern — offloading always adds overhead
+- The model already fits comfortably in GPU memory
+- CUDA graphs are enabled — activation offloading is incompatible
+- The model is large (30B+ MoE) and requires PP > 1 — activation offloading
+  is blocked by the PP=1 constraint
+- Alternative memory techniques (FSDP, activation recomputation) provide
+  sufficient savings without the throughput penalty
+
+## Feature Interactions
+
+| Feature | Interaction | Details |
+|---------|-------------|---------|
+| Pipeline parallelism (PP > 1) | **Blocks** activation offloading | Hard MCore constraint. Use optimizer offloading instead. |
+| Activation recomputation | **Blocks** activation offloading | Hard MCore constraint. Cannot combine. |
+| CUDA graphs | **Blocks** activation offloading | Hard MCore constraint. Optimizer offloading is unaffected. |
+| Fine-grained activation offloading | **Mutual exclusion** with layer-level activation offloading | Use one or the other. Fine-grained works with PP > 1. |
+| Distributed optimizer | **Required** for optimizer offloading | `use_distributed_optimizer=True` (default in most recipes). |
+| Megatron FSDP | Alternative | Shards parameters across DP ranks. Different tradeoff profile. |
+| Expert parallelism | Compatible | Both offloading mechanisms work with EP. |
+
+## Bridge Configuration
+
+### Optimizer CPU offloading
 
 ```python
-from megatron.bridge.models import GPTModelProvider
-
-# Basic CPU offloading configuration
-model_config = GPTModelProvider(
-    # Model architecture
-    hidden_size=4096,
-    num_layers=32,
-    
-    # CPU offloading settings
-    cpu_offloading=True,              # Enable CPU offloading
-    cpu_offloading_num_layers=16,     # Number of layers to offload (0 to num_layers-1)
-    cpu_offloading_activations=True,  # Offload activations
-    cpu_offloading_weights=True,      # Offload weights
-    
-    # ... other model parameters
-)
+cfg.optimizer.optimizer_cpu_offload = True
+cfg.optimizer.optimizer_offload_fraction = 0.5     # 0.0 to 1.0
+cfg.optimizer.overlap_cpu_optimizer_d2h_h2d = True # overlap transfers with compute
 ```
 
-### Configuration Parameters
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `optimizer_cpu_offload` | `False` | Master switch |
+| `optimizer_offload_fraction` | `0.0` | Fraction of optimizer states on CPU (0.0–1.0) |
+| `overlap_cpu_optimizer_d2h_h2d` | `False` | Overlap GPU↔CPU transfers with compute |
+| `use_torch_optimizer_for_cpu_offload` | `False` | Use `torch.optim` instead of fused optimizer for CPU portion |
 
-- **`cpu_offloading`**: Set to `True` to enable CPU offloading
-- **`cpu_offloading_num_layers`**: Number of transformer layers to offload (value between 0 and total number of layers minus one)
-- **`cpu_offloading_activations`**: Whether to offload activations to CPU memory (default: `True`)
-- **`cpu_offloading_weights`**: Whether to offload inactive weights to CPU memory (default: `False`)
-- **`cpu_offloading_double_buffering`**: Enable double buffering across layers while reloading activations from CPU (default: `False`)
+### Activation CPU offloading
 
-### Offloading Strategies
-
-You can configure different combinations of offloading based on your memory requirements:
-
-#### Activations Only
 ```python
-model_config = GPTModelProvider(
-    cpu_offloading=True,
-    cpu_offloading_num_layers=8,
-    cpu_offloading_activations=True,   # Offload activations
-    cpu_offloading_weights=False,      # Keep weights on GPU
-)
+cfg.model.cpu_offloading = True
+cfg.model.cpu_offloading_num_layers = 16
+cfg.model.cpu_offloading_activations = True
+cfg.model.cpu_offloading_weights = False
 ```
 
-#### Weights Only
-```python
-model_config = GPTModelProvider(
-    cpu_offloading=True,
-    cpu_offloading_num_layers=8,
-    cpu_offloading_activations=False,  # Keep activations on GPU
-    cpu_offloading_weights=True,       # Offload weights
-)
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `cpu_offloading` | `False` | Master switch |
+| `cpu_offloading_num_layers` | `0` | Number of transformer layers to offload (0 to num_layers-1) |
+| `cpu_offloading_activations` | `True` | Offload activations |
+| `cpu_offloading_weights` | `False` | Offload weights |
+| `cpu_offloading_double_buffering` | `False` | Double-buffer across layers while reloading |
+
+## Minimal Runnable Example
+
+Optimizer offload with 50% fraction on Qwen3-30B-A3B pretrain:
+
+```bash
+uv run python scripts/training/run_recipe.py \
+  --recipe qwen3_30b_a3b_pretrain_config \
+  optimizer.optimizer_cpu_offload=True \
+  optimizer.optimizer_offload_fraction=0.5 \
+  train.train_iters=20 \
+  train.global_batch_size=8 \
+  train.micro_batch_size=1
 ```
 
-#### Both Activations and Weights
-```python
-model_config = GPTModelProvider(
-    cpu_offloading=True,
-    cpu_offloading_num_layers=8,
-    cpu_offloading_activations=True,   # Offload activations
-    cpu_offloading_weights=True,       # Offload weights
-)
-```
+## Expected Metric Changes
+
+| Metric | Direction | Magnitude | Conditions | Evidence |
+|--------|-----------|-----------|------------|----------|
+| Steady-state memory (allocated) | down | 3.8 GB per 25% of optimizer offload fraction | Qwen3-30B-A3B, TP2 PP2 EP4, 2 nodes H100 | measured |
+| Step time | up | 1.9x at 25%, 2.5x at 50%, 3.2x at 75%, 4.2x at 100% offload | Same config | measured |
+| Step time with D2H/H2D overlap | up | 3.9x at 100% offload (vs 4.2x without overlap) | Same config + `overlap_cpu_optimizer_d2h_h2d=True` | measured |
+| Loss | neutral | max delta < 0.001 across all fractions | Same config, 20 iterations | measured |
+
+Memory savings and throughput penalty both scale linearly with
+`optimizer_offload_fraction`. The D2H/H2D overlap provides ~7% speedup at
+100% because CPU-side Adam compute — not the data transfers — is the
+dominant bottleneck.
+
+## Common Failure Modes
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `Currently there is no support for Pipeline parallelism with CPU offloading` | Activation offload with PP > 1 | Set PP=1 or switch to optimizer offloading |
+| `CPU offloading does not work when activation recomputation is enabled` | Activation offload with recompute enabled | Set `recompute_granularity=null` |
+| `CUDA graphs not supported with CPU offloading` | Activation offload with CUDA graphs | Set `cuda_graph_impl="none"` |
+| `fine_grained_activation_offloading cannot be enabled with cpu_offloading` | Both offloading types enabled | Use one or the other |
+| OOM with activation offloading on large model | Model too large for PP=1 | Switch to optimizer offloading (works with PP > 1) |
+| >4x throughput regression | 100% optimizer offload, CPU Adam bottleneck | Reduce fraction or enable `overlap_cpu_optimizer_d2h_h2d` |
+
+## Related Docs
+
+- [Activation Recomputation](activation-recomputation.md)
+- [Megatron FSDP](megatron-fsdp.md)
+- [Optimizer & Scheduler](optimizer-scheduler.md)
+- [CUDA Graphs](cuda-graphs.md)
+- [skills/perf-techniques/cpu-offloading/SKILL.md](../../skills/perf-techniques/cpu-offloading/SKILL.md)

--- a/docs/training/cpu-offloading.md
+++ b/docs/training/cpu-offloading.md
@@ -5,7 +5,7 @@ during training, trading throughput for the ability to train models or
 configurations that would otherwise not fit in GPU memory.
 
 For operational setup, code anchors, and verification commands, see
-[skills/perf-techniques/cpu-offloading/SKILL.md](../../skills/perf-techniques/cpu-offloading/SKILL.md).
+[skills/perf-techniques/cpu-offloading/SKILL.md](../skills/perf-techniques/cpu-offloading/SKILL.md).
 
 ## What It Is
 
@@ -44,6 +44,15 @@ target different bottlenecks:
 | Scale | enables otherwise-OOM configurations | medium | Can free memory for larger batch sizes or additional parallelism. |
 | Convergence | no change (loss delta < 0.001 across all fractions) | high | All optimizer offload fractions (25–100%) produce identical loss across 20 iterations. |
 | Stability | no issues observed | high | No errors, hangs, or NCCL issues across 120 total iterations tested (6 configurations). |
+
+D2H (device-to-host) and H2D (host-to-device) refer to data transfers between
+GPU and CPU memory. Each optimizer step copies gradients to CPU (D2H), runs
+Adam on CPU, then copies updated parameters back (H2D). The
+`overlap_cpu_optimizer_d2h_h2d` flag overlaps these transfers with compute.
+On Qwen3-30B-A3B MoE this provided only ~7% speedup because CPU-side Adam
+compute — not the transfers — was the dominant bottleneck. Other models with
+different parameter counts or optimizer configurations may see different
+transfer-to-compute ratios.
 
 ## When to Use It
 
@@ -87,21 +96,7 @@ CPU offloading is configured through two independent config namespaces:
   `model.cpu_offloading_num_layers`, and related `model.cpu_offloading_*` fields
 
 For config examples, parameter tables, and runnable commands, see
-[skills/perf-techniques/cpu-offloading/SKILL.md](../../skills/perf-techniques/cpu-offloading/SKILL.md).
-
-## Expected Metric Changes
-
-| Metric | Direction | Magnitude | Conditions | Evidence |
-|--------|-----------|-----------|------------|----------|
-| Steady-state memory (allocated) | down | 3.8 GB per 25% of optimizer offload fraction | Qwen3-30B-A3B, TP2 PP2 EP4, 2 nodes H100 | measured |
-| Step time | up | 1.9x at 25%, 2.5x at 50%, 3.2x at 75%, 4.2x at 100% offload | Same config | measured |
-| Step time with D2H/H2D overlap | up | 3.9x at 100% offload (vs 4.2x without overlap) | Same config + `overlap_cpu_optimizer_d2h_h2d=True` | measured |
-| Loss | neutral | max delta < 0.001 across all fractions | Same config, 20 iterations | measured |
-
-Memory savings and throughput penalty both scale linearly with
-`optimizer_offload_fraction`. The D2H/H2D overlap provides ~7% speedup at
-100% because CPU-side Adam compute — not the data transfers — is the
-dominant bottleneck.
+[skills/perf-techniques/cpu-offloading/SKILL.md](../skills/perf-techniques/cpu-offloading/SKILL.md).
 
 ## Common Failure Modes
 
@@ -120,4 +115,4 @@ dominant bottleneck.
 - [docs/training/megatron-fsdp.md](megatron-fsdp.md)
 - [docs/training/optimizer-scheduler.md](optimizer-scheduler.md)
 - [docs/training/cuda-graphs.md](cuda-graphs.md)
-- [skills/perf-techniques/cpu-offloading/SKILL.md](../../skills/perf-techniques/cpu-offloading/SKILL.md)
+- [skills/perf-techniques/cpu-offloading/SKILL.md](../skills/perf-techniques/cpu-offloading/SKILL.md)

--- a/docs/training/cpu-offloading.md
+++ b/docs/training/cpu-offloading.md
@@ -39,11 +39,11 @@ target different bottlenecks:
 
 | Dimension | Effect | Confidence | Rationale |
 |-----------|--------|------------|-----------|
-| Speed | `--` | high | Throughput penalty scales linearly with offload fraction. CPU Adam compute and D2H/H2D transfers add latency. Measured 1.9x–4.2x slower on Qwen3-30B-A3B. |
-| Memory | `++` | high | Optimizer offload saves 3.8 GB per 25% of fraction on Qwen3-30B-A3B (up to 15.3 GB / 32% at 100%). Activation offload saves activation memory proportional to layers offloaded. |
-| Scale | `+` | medium | Enables training configurations that would otherwise OOM. Can free memory for larger batch sizes or additional parallelism. |
-| Convergence | `0` | high | All optimizer offload fractions (25–100%) produce identical loss within 0.001 across 20 iterations, validation, and test. |
-| Stability | `0` | high | No errors, hangs, or NCCL issues across 120 total iterations tested (6 configurations). |
+| Speed | 1.9x–4.2x slower step time (scales linearly with offload fraction) | high | CPU Adam compute and D2H/H2D transfers add latency. Measured on Qwen3-30B-A3B TP2 PP2 EP4. D2H/H2D overlap reduces 100% penalty from 4.2x to 3.9x. |
+| Memory | 3.8 GB saved per 25% of optimizer offload fraction (up to 15.3 GB / 32% at 100%) | high | Measured on Qwen3-30B-A3B (47.2 GB baseline). Activation offload saves proportional to layers offloaded. |
+| Scale | enables otherwise-OOM configurations | medium | Can free memory for larger batch sizes or additional parallelism. |
+| Convergence | no change (loss delta < 0.001 across all fractions) | high | All optimizer offload fractions (25–100%) produce identical loss across 20 iterations. |
+| Stability | no issues observed | high | No errors, hangs, or NCCL issues across 120 total iterations tested (6 configurations). |
 
 ## When to Use It
 
@@ -78,51 +78,16 @@ target different bottlenecks:
 
 ## Bridge Configuration
 
-### Optimizer CPU offloading
+CPU offloading is configured through two independent config namespaces:
 
-```python
-cfg.optimizer.optimizer_cpu_offload = True
-cfg.optimizer.optimizer_offload_fraction = 0.5     # 0.0 to 1.0
-cfg.optimizer.overlap_cpu_optimizer_d2h_h2d = True # overlap transfers with compute
-```
+- **Optimizer offloading**: `optimizer.optimizer_cpu_offload`,
+  `optimizer.optimizer_offload_fraction`, and
+  `optimizer.overlap_cpu_optimizer_d2h_h2d`
+- **Activation offloading**: `model.cpu_offloading`,
+  `model.cpu_offloading_num_layers`, and related `model.cpu_offloading_*` fields
 
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `optimizer_cpu_offload` | `False` | Master switch |
-| `optimizer_offload_fraction` | `0.0` | Fraction of optimizer states on CPU (0.0–1.0) |
-| `overlap_cpu_optimizer_d2h_h2d` | `False` | Overlap GPU↔CPU transfers with compute |
-| `use_torch_optimizer_for_cpu_offload` | `False` | Use `torch.optim` instead of fused optimizer for CPU portion |
-
-### Activation CPU offloading
-
-```python
-cfg.model.cpu_offloading = True
-cfg.model.cpu_offloading_num_layers = 16
-cfg.model.cpu_offloading_activations = True
-cfg.model.cpu_offloading_weights = False
-```
-
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `cpu_offloading` | `False` | Master switch |
-| `cpu_offloading_num_layers` | `0` | Number of transformer layers to offload (0 to num_layers-1) |
-| `cpu_offloading_activations` | `True` | Offload activations |
-| `cpu_offloading_weights` | `False` | Offload weights |
-| `cpu_offloading_double_buffering` | `False` | Double-buffer across layers while reloading |
-
-## Minimal Runnable Example
-
-Optimizer offload with 50% fraction on Qwen3-30B-A3B pretrain:
-
-```bash
-uv run python scripts/training/run_recipe.py \
-  --recipe qwen3_30b_a3b_pretrain_config \
-  optimizer.optimizer_cpu_offload=True \
-  optimizer.optimizer_offload_fraction=0.5 \
-  train.train_iters=20 \
-  train.global_batch_size=8 \
-  train.micro_batch_size=1
-```
+For config examples, parameter tables, and runnable commands, see
+[skills/perf-techniques/cpu-offloading/SKILL.md](../../skills/perf-techniques/cpu-offloading/SKILL.md).
 
 ## Expected Metric Changes
 
@@ -151,8 +116,8 @@ dominant bottleneck.
 
 ## Related Docs
 
-- [Activation Recomputation](activation-recomputation.md)
-- [Megatron FSDP](megatron-fsdp.md)
-- [Optimizer & Scheduler](optimizer-scheduler.md)
-- [CUDA Graphs](cuda-graphs.md)
+- [docs/training/activation-recomputation.md](activation-recomputation.md)
+- [docs/training/megatron-fsdp.md](megatron-fsdp.md)
+- [docs/training/optimizer-scheduler.md](optimizer-scheduler.md)
+- [docs/training/cuda-graphs.md](cuda-graphs.md)
 - [skills/perf-techniques/cpu-offloading/SKILL.md](../../skills/perf-techniques/cpu-offloading/SKILL.md)

--- a/skills/perf-techniques/cpu-offloading/SKILL.md
+++ b/skills/perf-techniques/cpu-offloading/SKILL.md
@@ -61,6 +61,27 @@ cfg.model.recompute_granularity = None
 cfg.model.cuda_graph_impl = "none"
 ```
 
+## Config Parameter Reference
+
+### Optimizer offloading
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `optimizer_cpu_offload` | `False` | Master switch |
+| `optimizer_offload_fraction` | `0.0` | Fraction of optimizer states on CPU (0.0–1.0) |
+| `overlap_cpu_optimizer_d2h_h2d` | `False` | Overlap GPU↔CPU transfers with compute |
+| `use_torch_optimizer_for_cpu_offload` | `False` | Use `torch.optim` instead of fused optimizer for CPU portion |
+
+### Activation offloading
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `cpu_offloading` | `False` | Master switch |
+| `cpu_offloading_num_layers` | `0` | Number of transformer layers to offload (0 to num_layers-1) |
+| `cpu_offloading_activations` | `True` | Offload activations |
+| `cpu_offloading_weights` | `False` | Offload weights |
+| `cpu_offloading_double_buffering` | `False` | Double-buffer across layers while reloading |
+
 ## Compatibility And Constraints
 
 ### Activation offloading

--- a/skills/perf-techniques/cpu-offloading/SKILL.md
+++ b/skills/perf-techniques/cpu-offloading/SKILL.md
@@ -127,9 +127,37 @@ cfg.optimizer.overlap_cpu_optimizer_d2h_h2d = True
 cfg.model.cpu_offloading = True
 cfg.model.cpu_offloading_num_layers = 16
 cfg.model.cpu_offloading_activations = True
+cfg.model.cpu_offloading_weights = False
 cfg.model.pipeline_model_parallel_size = 1
 cfg.model.recompute_granularity = None
 ```
+
+### Weight offload only (small model, PP=1)
+
+```python
+cfg.model.cpu_offloading = True
+cfg.model.cpu_offloading_num_layers = 8
+cfg.model.cpu_offloading_activations = False
+cfg.model.cpu_offloading_weights = True
+cfg.model.pipeline_model_parallel_size = 1
+cfg.model.recompute_granularity = None
+```
+
+### Both activations and weights (small model, PP=1)
+
+```python
+cfg.model.cpu_offloading = True
+cfg.model.cpu_offloading_num_layers = 8
+cfg.model.cpu_offloading_activations = True
+cfg.model.cpu_offloading_weights = True
+cfg.model.pipeline_model_parallel_size = 1
+cfg.model.recompute_granularity = None
+```
+
+Weight offloading and activation offloading share the same constraints (PP=1,
+no recompute, no CUDA graphs). Weight offloading has not been tested in
+the Qwen3-30B-A3B experiments — the measured results cover optimizer
+offloading only.
 
 ## Minimal Runnable Command
 

--- a/skills/perf-techniques/cpu-offloading/SKILL.md
+++ b/skills/perf-techniques/cpu-offloading/SKILL.md
@@ -1,0 +1,255 @@
+---
+name: cpu-offloading
+description: Validate and use CPU offloading in Megatron Bridge, including layer-level activation offloading and fractional optimizer state offloading with HybridDeviceOptimizer. Use when the user asks about cpu_offloading, optimizer_cpu_offload, optimizer_offload_fraction, overlap_cpu_optimizer_d2h_h2d, CPU memory offloading, or reducing GPU memory usage via offloading.
+---
+
+# CPU Offloading
+
+## References
+
+- Stable docs: `docs/training/cpu-offloading.md`
+- Structured metadata: `skills/perf-techniques/cpu-offloading/card.yaml`
+
+## What It Is
+
+Two independent mechanisms to move data from GPU to CPU memory:
+
+| Mechanism | Config namespace | What gets offloaded | PP restriction |
+|---|---|---|---|
+| Activation offloading | `model.cpu_offloading*` | Activations (and optionally weights) per transformer layer | PP must be 1 |
+| Optimizer offloading | `optimizer.optimizer_cpu_offload` | Adam optimizer states (momentum + variance) via `HybridDeviceOptimizer` | None |
+
+## Quick Decision
+
+| Situation | Recommendation |
+|---|---|
+| Large MoE model (30B+), needs PP > 1 | Optimizer offloading — activation offloading is blocked by PP=1 |
+| Small/medium model, PP=1 fits, activation memory dominates | Activation offloading |
+| Want tunable memory-speed tradeoff | Optimizer offloading with fractional `optimizer_offload_fraction` |
+| Throughput is top priority | Don't enable — offloading always adds overhead |
+| CUDA graphs are needed | Only optimizer offloading — activation offloading is incompatible |
+| Memory pressure is moderate | Optimizer offload at 25–50% fraction for best efficiency |
+
+## Enablement
+
+### Optimizer CPU offloading (recommended for large models)
+
+```python
+cfg.optimizer.optimizer_cpu_offload = True
+cfg.optimizer.optimizer_offload_fraction = 1.0
+cfg.optimizer.overlap_cpu_optimizer_d2h_h2d = True
+```
+
+CLI overrides:
+
+```bash
+optimizer.optimizer_cpu_offload=True \
+optimizer.optimizer_offload_fraction=0.5 \
+optimizer.overlap_cpu_optimizer_d2h_h2d=True
+```
+
+### Activation CPU offloading (small/medium models only)
+
+```python
+cfg.model.cpu_offloading = True
+cfg.model.cpu_offloading_num_layers = 16
+cfg.model.cpu_offloading_activations = True
+cfg.model.cpu_offloading_weights = False
+
+cfg.model.pipeline_model_parallel_size = 1
+cfg.model.recompute_granularity = None
+cfg.model.cuda_graph_impl = "none"
+```
+
+## Compatibility And Constraints
+
+### Activation offloading
+
+- `pipeline_model_parallel_size` must be 1
+- `recompute_granularity` must be `None`
+- Cannot combine with `fine_grained_activation_offloading`
+- Cannot combine with CUDA graphs
+- `cpu_offloading_num_layers` must be in `[0, num_layers-1)`
+
+### Optimizer offloading
+
+- Requires `use_distributed_optimizer = True` (default in most recipes)
+- No PP, recompute, or CUDA graph restrictions
+- `optimizer_offload_fraction` must be in `[0.0, 1.0]`
+
+### Practical: large MoE models
+
+Activation offloading is blocked for Qwen3-30B-A3B and similar large MoE
+models. The PP=1 constraint means each GPU holds all 48 layers; model
+weights + optimizer states alone (~70 GB) exceed H100 80 GB capacity.
+
+## Minimal Working Config
+
+### Optimizer offload (50%, balanced)
+
+```python
+cfg.optimizer.optimizer_cpu_offload = True
+cfg.optimizer.optimizer_offload_fraction = 0.5
+```
+
+### Optimizer offload (100% + overlap, max savings)
+
+```python
+cfg.optimizer.optimizer_cpu_offload = True
+cfg.optimizer.optimizer_offload_fraction = 1.0
+cfg.optimizer.overlap_cpu_optimizer_d2h_h2d = True
+```
+
+### Activation offload (small model, PP=1)
+
+```python
+cfg.model.cpu_offloading = True
+cfg.model.cpu_offloading_num_layers = 16
+cfg.model.cpu_offloading_activations = True
+cfg.model.pipeline_model_parallel_size = 1
+cfg.model.recompute_granularity = None
+```
+
+## Minimal Runnable Command
+
+```bash
+uv run python scripts/training/run_recipe.py \
+  --recipe qwen3_30b_a3b_pretrain_config \
+  optimizer.optimizer_cpu_offload=True \
+  optimizer.optimizer_offload_fraction=0.5 \
+  train.train_iters=20 \
+  train.global_batch_size=8 \
+  train.micro_batch_size=1
+```
+
+## Verification
+
+### Unit tests
+
+```bash
+uv run python -m pytest \
+  tests/unit_tests/models/test_gpt_full_te_layer_autocast_spec.py -k "cpu_offload" \
+  tests/unit_tests/peft/test_utils.py -k "cpu_offload" -q
+```
+
+### Success criteria
+
+- Config validation passes for the selected offloading mode
+- Training completes without OOM or NCCL errors
+- Loss matches the non-offloaded baseline (max delta < 0.001)
+- Memory usage drops proportionally to offload fraction
+
+## Code Anchors
+
+### MCore activation offload constraints
+
+```1296:1310:3rdparty/Megatron-LM/megatron/core/transformer/transformer_config.py
+        if self.cpu_offloading and (
+            self.cpu_offloading_num_layers < 0 or self.cpu_offloading_num_layers >= self.num_layers
+        ):
+            raise ValueError(...)
+
+        if self.cpu_offloading and self.pipeline_model_parallel_size > 1:
+            raise ValueError(
+                "Currently there is no support for Pipeline parallelism with CPU offloading"
+            )
+
+        if self.cpu_offloading and self.recompute_granularity is not None:
+            raise ValueError(
+                "CPU offloading does not work when activation recomputation is enabled"
+            )
+```
+
+### MCore CUDA graph incompatibility
+
+```1943:1944:3rdparty/Megatron-LM/megatron/core/transformer/transformer_config.py
+            if self.cpu_offloading:
+                raise ValueError("CUDA graphs not supported with CPU offloading.")
+```
+
+### MCore fine-grained offloading mutual exclusion
+
+```1427:1430:3rdparty/Megatron-LM/megatron/core/transformer/transformer_config.py
+        if self.fine_grained_activation_offloading:
+            assert (
+                not self.cpu_offloading
+            ), "fine_grained_activation_offloading cannot be enabled with cpu_offloading."
+```
+
+### MCore HybridDeviceOptimizer instantiation
+
+```480:518:3rdparty/Megatron-LM/megatron/core/optimizer/__init__.py
+        if config.optimizer_cpu_offload:
+            # ... setup cpu/gpu optimizer classes ...
+            optimizer = HybridDeviceOptimizer(
+                param_groups,
+                offload_fraction=config.optimizer_offload_fraction,
+                cpu_optimizer_cls=cpu_optimizer_cls,
+                gpu_optimizer_cls=gpu_optimizer_cls,
+                overlap_cpu_optimizer_d2h_h2d=config.overlap_cpu_optimizer_d2h_h2d,
+                pin_cpu_grads=config.pin_cpu_grads,
+                pin_cpu_params=config.pin_cpu_params,
+            )
+```
+
+### Bridge CUDA graph guard
+
+```232:234:src/megatron/bridge/models/gpt_full_te_layer_autocast_spec.py
+        assert not config.cpu_offloading and config.recompute_granularity is None, "Cudagraphs not supported"
+```
+
+### Bridge activation offloading in PEFT
+
+```621:631:src/megatron/bridge/peft/utils.py
+        if self.config.cpu_offloading and self.config.cpu_offloading_activations:
+            x.activation_offloading = True
+        x, _ = self.linear_in(x)
+        x = self.activation(x)
+        if self.config.cpu_offloading and self.config.cpu_offloading_activations:
+            x.activation_offloading = True
+        x, _ = self.linear_out(x)
+```
+
+### MCore model_parallel_config fields
+
+```3rdparty/Megatron-LM/megatron/core/model_parallel_config.py
+    cpu_offloading: bool = False
+    cpu_offloading_num_layers: int = 0
+    cpu_offloading_activations: bool = True
+    cpu_offloading_weights: bool = False
+    cpu_offloading_double_buffering: bool = False
+    cpu_offloading_retain_pinned_cpu_buffers: bool = False
+```
+
+### MCore optimizer offload config
+
+```3rdparty/Megatron-LM/megatron/core/optimizer/optimizer_config.py
+    optimizer_cpu_offload: bool = False
+    optimizer_offload_fraction: float = 0.0
+    use_torch_optimizer_for_cpu_offload: bool = False
+    overlap_cpu_optimizer_d2h_h2d: bool = False
+```
+
+## Failure Diagnosis
+
+| Symptom | Likely Cause | How To Confirm | Fix |
+|---|---|---|---|
+| `Currently there is no support for Pipeline parallelism with CPU offloading` | Activation offload + PP > 1 | Check `pipeline_model_parallel_size` | Set PP=1 or use optimizer offloading |
+| `CPU offloading does not work when activation recomputation is enabled` | Activation offload + recompute | Check `recompute_granularity` | Set `recompute_granularity=null` |
+| `fine_grained_activation_offloading cannot be enabled with cpu_offloading` | Both offloading modes enabled | Check both flags | Use one or the other |
+| `CUDA graphs not supported with CPU offloading` | CUDA graphs + activation offload | Check `cuda_graph_impl` | Set `cuda_graph_impl="none"` |
+| OOM with activation offloading | Model too large for PP=1 | Check allocated memory vs 80 GB | Use optimizer offloading with PP > 1 |
+| Extreme slowdown (>4x) | 100% optimizer offload, CPU Adam bottleneck | Compare iter time at different fractions | Reduce fraction or enable `overlap_cpu_optimizer_d2h_h2d` |
+| OOM at partial optimizer offload | Insufficient offload for this config | Check memory at different fractions | Increase fraction or add PP |
+
+## Known Limitations
+
+- Activation offloading requires PP=1, making it impractical for large models
+  (30B+ MoE) that need pipeline parallelism.
+- Optimizer offloading throughput penalty scales linearly (~1.9x at 25%,
+  ~4.2x at 100% for Qwen3-30B-A3B).
+- D2H/H2D overlap provides only ~7% speedup because CPU Adam compute is
+  the dominant bottleneck.
+- `fine_grained_activation_offloading` is a separate module-level approach
+  that works with PP > 1 but cannot be combined with layer-level
+  `cpu_offloading`.

--- a/skills/perf-techniques/cpu-offloading/card.yaml
+++ b/skills/perf-techniques/cpu-offloading/card.yaml
@@ -41,30 +41,29 @@ validation_status:
     - measured  # Job 10611046
 training_dimensions:
   speed:
-    effect: "--"
+    effect: "1.9x-4.2x slower step time (scales linearly with offload fraction)"
     confidence: high
     rationale: >
-      Optimizer offloading incurs throughput penalty scaling linearly with
-      fraction: 1.9x at 25%, 2.5x at 50%, 3.2x at 75%, 4.2x at 100%.
-      D2H/H2D overlap reduces 100% penalty to 3.9x.
+      CPU Adam compute and D2H/H2D transfers add latency. Measured on
+      Qwen3-30B-A3B TP2 PP2 EP4, 2 nodes H100. D2H/H2D overlap reduces
+      100% penalty from 4.2x to 3.9x.
   memory:
-    effect: "++"
+    effect: "3.8 GB saved per 25% of offload fraction (up to 15.3 GB / 32% at 100%)"
     confidence: high
     rationale: >
-      Optimizer offloading saves memory linearly: 3.8 GB per 25% increment on
-      Qwen3-30B-A3B (47.2 GB baseline). At 100%, drops to 32.0 GB (-32%).
+      Measured on Qwen3-30B-A3B (47.2 GB baseline). Savings scale linearly.
   scale:
-    effect: "+"
+    effect: "enables otherwise-OOM configurations"
     confidence: medium
     rationale: >
-      Enables training configurations that would otherwise OOM.
+      Can free memory for larger batch sizes or additional parallelism.
   convergence:
-    effect: "0"
+    effect: "no change (loss delta < 0.001 across all fractions)"
     confidence: high
     rationale: >
-      All fractions produce identical loss within 0.001 across 20 iterations.
+      All fractions produce identical loss across 20 iterations on Qwen3-30B-A3B.
   stability:
-    effect: "0"
+    effect: "no issues observed"
     confidence: high
     rationale: >
       No errors, hangs, or NCCL issues across 120 total iterations tested.
@@ -205,7 +204,6 @@ evidence:
   - 3rdparty/Megatron-LM/megatron/core/optimizer/optimizer_config.py
   - 3rdparty/Megatron-LM/megatron/core/optimizer/__init__.py
   - src/megatron/bridge/models/gpt_full_te_layer_autocast_spec.py
-  - .local/cpu_offload_verification_report.md
 follow_up_validation:
   - Test optimizer offload + CUDA graphs combined
   - Test fine_grained_activation_offloading as alternative

--- a/skills/perf-techniques/cpu-offloading/card.yaml
+++ b/skills/perf-techniques/cpu-offloading/card.yaml
@@ -1,0 +1,213 @@
+title: cpu_offloading
+validated_on: "2026-03-30"
+summary: >
+  Megatron Bridge supports two CPU offloading mechanisms: layer-level activation
+  offloading (cpu_offloading) and fractional optimizer state offloading
+  (optimizer_cpu_offload via HybridDeviceOptimizer). Activation offloading requires
+  PP=1, no recompute, no CUDA graphs — impractical for large MoE models. Optimizer
+  offloading works with PP>1 and supports tunable fraction (0-100%) with linear
+  memory-speed tradeoff. Verified on Qwen3-30B-A3B MoE pretrain (TP2 PP2 EP4,
+  2 nodes H100): 25-100% offload saves 3.8-15.3 GB (-8% to -32%) at 1.9x-4.2x
+  slowdown. All variants numerically safe (loss delta < 0.001). D2H/H2D overlap
+  provides ~7% speedup at 100% offload.
+validation_status:
+  activation_offload_pp_constraint:
+    - code_verified  # transformer_config.py:1303-1306
+  activation_offload_recompute_constraint:
+    - code_verified  # transformer_config.py:1308-1310
+  activation_offload_cuda_graph_constraint:
+    - code_verified  # transformer_config.py:1943-1944
+  activation_offload_fine_grained_constraint:
+    - code_verified  # transformer_config.py:1427-1430
+  optimizer_offload_hybrid_optimizer:
+    - code_verified  # optimizer/__init__.py:480-518
+  optimizer_offload_config_fields:
+    - code_verified  # optimizer_config.py
+  bridge_cuda_graph_guard:
+    - code_verified  # gpt_full_te_layer_autocast_spec.py:234
+  bridge_peft_offloading:
+    - code_verified  # peft/utils.py:621-631
+  activation_offload_qwen3_moe:
+    - measured  # OOM at 70.3 GB, PP=1 on H100 80 GB. Jobs 10609511, 10609272
+  optimizer_offload_25pct:
+    - measured  # Qwen3-30B-A3B, TP2 PP2 EP4, 2x H100. Job 10611042
+  optimizer_offload_50pct:
+    - measured  # Job 10611043
+  optimizer_offload_75pct:
+    - measured  # Job 10611045
+  optimizer_offload_100pct:
+    - measured  # Job 10609512
+  optimizer_offload_100pct_overlap:
+    - measured  # Job 10611046
+training_dimensions:
+  speed:
+    effect: "--"
+    confidence: high
+    rationale: >
+      Optimizer offloading incurs throughput penalty scaling linearly with
+      fraction: 1.9x at 25%, 2.5x at 50%, 3.2x at 75%, 4.2x at 100%.
+      D2H/H2D overlap reduces 100% penalty to 3.9x.
+  memory:
+    effect: "++"
+    confidence: high
+    rationale: >
+      Optimizer offloading saves memory linearly: 3.8 GB per 25% increment on
+      Qwen3-30B-A3B (47.2 GB baseline). At 100%, drops to 32.0 GB (-32%).
+  scale:
+    effect: "+"
+    confidence: medium
+    rationale: >
+      Enables training configurations that would otherwise OOM.
+  convergence:
+    effect: "0"
+    confidence: high
+    rationale: >
+      All fractions produce identical loss within 0.001 across 20 iterations.
+  stability:
+    effect: "0"
+    confidence: high
+    rationale: >
+      No errors, hangs, or NCCL issues across 120 total iterations tested.
+enable_when:
+  - GPU memory is tight and throughput regression is acceptable
+  - model requires PP > 1 (use optimizer offloading, not activation offloading)
+  - want tunable memory-speed tradeoff via offload fraction
+avoid_when:
+  - throughput is the primary concern
+  - model already fits comfortably in GPU memory
+  - CUDA graphs are needed (incompatible with activation offloading)
+interactions:
+  required:
+    - optimizer.use_distributed_optimizer (for optimizer offloading)
+  conditional:
+    - pipeline_model_parallel_size must be 1 for activation offloading
+    - recompute_granularity must be None for activation offloading
+  incompatible:
+    - cpu_offloading with pipeline_model_parallel_size > 1
+    - cpu_offloading with recompute_granularity != None
+    - cpu_offloading with fine_grained_activation_offloading
+    - cpu_offloading with cuda_graph_impl != none
+feature_meaning:
+  cpu_offloading: >
+    Master switch for layer-level activation CPU offloading.
+  optimizer_cpu_offload: >
+    Master switch for optimizer state CPU offloading via HybridDeviceOptimizer.
+  optimizer_offload_fraction: >
+    Fraction of optimizer states on CPU. 0.0 = all GPU, 1.0 = all CPU.
+  overlap_cpu_optimizer_d2h_h2d: >
+    Overlap GPU-CPU transfers with compute during optimizer step.
+config_keys:
+  - model.cpu_offloading
+  - model.cpu_offloading_num_layers
+  - model.cpu_offloading_activations
+  - model.cpu_offloading_weights
+  - optimizer.optimizer_cpu_offload
+  - optimizer.optimizer_offload_fraction
+  - optimizer.overlap_cpu_optimizer_d2h_h2d
+recommended_path:
+  optimizer.optimizer_cpu_offload: true_when_memory_constrained
+  optimizer.optimizer_offload_fraction: 0.5_for_balanced_or_1.0_for_max_savings
+  optimizer.overlap_cpu_optimizer_d2h_h2d: true_at_high_fractions
+  model.cpu_offloading: only_for_small_models_where_pp1_fits
+expected_metric_change:
+  - metric: memory_allocated
+    direction: down
+    magnitude: 8-32%
+    conditions: optimizer offloading on Qwen3-30B-A3B MoE
+    evidence: measured_qwen3_30b_a3b
+  - metric: step_time
+    direction: up
+    magnitude: 1.9x-4.2x
+    conditions: optimizer offloading on Qwen3-30B-A3B MoE
+    evidence: measured_qwen3_30b_a3b
+measured_results:
+  - model: Qwen3-30B-A3B
+    config: baseline
+    iter_ms: 996
+    mem_allocated_gb: 47.2
+    job: "10119286"
+    status: success
+  - model: Qwen3-30B-A3B
+    config: optimizer_offload_25pct
+    iter_ms: 1871
+    slowdown: 1.9x
+    mem_allocated_gb: 43.4
+    mem_saved_gb: 3.8
+    loss_match: true
+    job: "10611042"
+    status: success
+  - model: Qwen3-30B-A3B
+    config: optimizer_offload_50pct
+    iter_ms: 2484
+    slowdown: 2.5x
+    mem_allocated_gb: 39.6
+    mem_saved_gb: 7.6
+    loss_match: true
+    job: "10611043"
+    status: success
+  - model: Qwen3-30B-A3B
+    config: optimizer_offload_75pct
+    iter_ms: 3187
+    slowdown: 3.2x
+    mem_allocated_gb: 35.6
+    mem_saved_gb: 11.6
+    loss_match: true
+    job: "10611045"
+    status: success
+  - model: Qwen3-30B-A3B
+    config: optimizer_offload_100pct
+    iter_ms: 4189
+    slowdown: 4.2x
+    mem_allocated_gb: 32.0
+    mem_saved_gb: 15.3
+    loss_match: true
+    job: "10609512"
+    status: success
+  - model: Qwen3-30B-A3B
+    config: optimizer_offload_100pct_overlap
+    iter_ms: 3877
+    slowdown: 3.9x
+    mem_allocated_gb: 32.0
+    overlap_speedup_pct: 7
+    loss_match: true
+    job: "10611046"
+    status: success
+  - model: Qwen3-30B-A3B
+    config: activation_offload_24_layers
+    mem_allocated_gb: 70.3
+    job: "10609511"
+    status: oom
+failure_modes:
+  - name: pp_constraint
+    symptom: "Currently there is no support for Pipeline parallelism with CPU offloading"
+    fix: set PP = 1 or use optimizer offloading
+  - name: recompute_constraint
+    symptom: "CPU offloading does not work when activation recomputation is enabled"
+    fix: set recompute_granularity = null
+  - name: cuda_graph_constraint
+    symptom: "CUDA graphs not supported with CPU offloading"
+    fix: set cuda_graph_impl = none
+  - name: large_model_oom
+    symptom: OOM with activation offloading even with many nodes
+    fix: use optimizer offloading instead
+known_constraints:
+  - cpu_offloading requires PP = 1 (transformer_config.py:1303)
+  - cpu_offloading requires recompute_granularity = None (transformer_config.py:1308)
+  - cpu_offloading incompatible with CUDA graphs (transformer_config.py:1943)
+  - optimizer_cpu_offload requires use_distributed_optimizer (optimizer/__init__.py:682)
+known_limitations:
+  - Activation offloading impractical for large MoE models due to PP=1 constraint
+  - Optimizer offloading throughput penalty scales linearly with fraction
+  - D2H/H2D overlap provides only ~7% improvement
+evidence:
+  - docs/training/cpu-offloading.md
+  - 3rdparty/Megatron-LM/megatron/core/transformer/transformer_config.py
+  - 3rdparty/Megatron-LM/megatron/core/optimizer/optimizer_config.py
+  - 3rdparty/Megatron-LM/megatron/core/optimizer/__init__.py
+  - src/megatron/bridge/models/gpt_full_te_layer_autocast_spec.py
+  - .local/cpu_offload_verification_report.md
+follow_up_validation:
+  - Test optimizer offload + CUDA graphs combined
+  - Test fine_grained_activation_offloading as alternative
+  - Test with larger GBS to amortize CPU optimizer overhead
+  - Test activation offloading on smaller models where PP=1 fits


### PR DESCRIPTION
## Summary

- Rewrites `docs/training/cpu-offloading.md` with experiment-backed data from Qwen3-30B-A3B verification runs on 2×H100 nodes
- Adds **optimizer offloading** documentation (previously undocumented) alongside existing activation offloading
- Adds feature interaction table, common failure modes, and measured memory/throughput tradeoffs
- Adds `skills/perf-techniques/cpu-offloading/` skill card for agent-assisted workflows

### Key measured data included:
- Memory savings: 3.8 GB per 25% optimizer offload fraction (up to 15.3 GB / 32% at 100%)
- Throughput penalty: 1.9x–4.2x depending on offload fraction
- Loss neutrality: < 0.001 delta across all fractions over 20 iterations
- D2H/H2D overlap: ~7% speedup (CPU Adam compute is the dominant bottleneck, not transfers)

## Test plan

- [ ] Doc renders correctly on GitHub
- [ ] Skill card YAML is valid
- [ ] Links to related docs are correct


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced CPU offloading documentation with clearer explanation of two independent mechanisms: activation offloading and optimizer offloading.
  * Added "When to Use" and "When Not to Use" guidance for improved decision-making.
  * Provided updated configuration instructions and compatibility constraints.
  * Included failure diagnosis and troubleshooting information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->