### PR TITLE
[misc] fix: move `set -euo pipefail` after #SBATCH directives in SLURM scripts

### DIFF
--- a/examples/models/vlm/qwen35_vl/slurm_inference.sh
+++ b/examples/models/vlm/qwen35_vl/slurm_inference.sh
@@ -143,7 +143,7 @@ CMD="uv run --no-sync python examples/conversion/hf_to_megatron_generate_vlm.py 
 
 # Only rank 0 on each node runs uv sync
 SYNC_CMD="if [ \"\$SLURM_LOCALID\" -eq 0 ]; then uv sync; else sleep 5; fi"
-FULL_CMD="$SYNC_CMD && $CMD"
+FULL_CMD="cd /opt/Megatron-Bridge && $SYNC_CMD && $CMD"
 
 echo "Executing inference..."
 echo "Command: $CMD"

--- a/examples/models/vlm/qwen35_vl/slurm_peft.sh
+++ b/examples/models/vlm/qwen35_vl/slurm_peft.sh
@@ -167,7 +167,7 @@ CLI_OVERRIDES="\
 # For multinode runs, the recipe's online HF path can be unstable. Pass --hf_path
 # with a local model directory for more reliable config loading, e.g.:
 #   --hf_path ${WORKSPACE}/models/Qwen/${HF_MODEL_NAME}
-CMD="uv run --no-sync python scripts/training/run_recipe.py \
+CMD="cd /opt/Megatron-Bridge && uv run --no-sync python scripts/training/run_recipe.py \
     --recipe $RECIPE \
     --step_func vlm_step \
     --peft_scheme lora \

--- a/examples/models/vlm/qwen35_vl/slurm_sft.sh
+++ b/examples/models/vlm/qwen35_vl/slurm_sft.sh
@@ -169,7 +169,7 @@ CLI_OVERRIDES="\
 # For multinode runs, the recipe's online HF path can be unstable. Pass --hf_path
 # with a local model directory for more reliable config loading, e.g.:
 #   --hf_path ${WORKSPACE}/models/Qwen/${HF_MODEL_NAME}
-CMD="uv run --no-sync python scripts/training/run_recipe.py \
+CMD="cd /opt/Megatron-Bridge && uv run --no-sync python scripts/training/run_recipe.py \
     --recipe $RECIPE \
     --step_func vlm_step \
     $CLI_OVERRIDES"

--- a/examples/models/vlm/qwen35_vl/slurm_sft_fsdp.sh
+++ b/examples/models/vlm/qwen35_vl/slurm_sft_fsdp.sh
@@ -112,7 +112,7 @@ CLI_OVERRIDES="\
     dataset.maker_name=make_${DATASET_NAME}_dataset \
     dataset.seq_length=$SEQ_LENGTH"
 
-CMD="uv run --no-sync python scripts/training/run_recipe.py \
+CMD="cd /opt/Megatron-Bridge && uv run --no-sync python scripts/training/run_recipe.py \
     --recipe $RECIPE \
     --step_func vlm_step \
     $CLI_OVERRIDES"


### PR DESCRIPTION
# What does this PR do?

Fix Qwen3.5-VL SLURM scripts where `set -euo pipefail` on line 2 causes `sbatch` to silently ignore all `#SBATCH` directives, leading to confusing submission errors.

# Changelog

- Move `set -euo pipefail` from line 2 (before `#SBATCH` block) to after the last `#SBATCH` directive in `slurm_sft.sh`, `slurm_peft.sh`, and `slurm_sft_fsdp.sh`

# GitHub Actions CI

See the CI section in the Contributing doc for how to trigger the CI.
A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

Pre checks:
- [x] Make sure you read and followed Contributor guidelines
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

# Additional Information

Per the `sbatch` man page, `#SBATCH` directives must appear before any executable statements. `set -euo pipefail` is an executable statement, so placing it on line 2 (before the `#SBATCH` block) caused SLURM to treat all subsequent `#SBATCH` lines as regular comments, silently ignoring account, partition, time, nodes, and all other job configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated shell script configuration in training example scripts to ensure proper error handling during execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->