### PR TITLE
Fix convergence issue with mxfp8 param + full cuda graph

### DIFF
--- a/src/megatron/bridge/training/train.py
+++ b/src/megatron/bridge/training/train.py
@@ -1419,6 +1419,11 @@ def _handle_mxfp8_param_buffer_copy(
     2. Without forward_pre_hook, finish_param_sync() won't be called to zero the grad buffer,
        so the main grads will be polluted by the main params.
 
+    Exception: when a full-iteration CUDA graph has been captured, the all-gather
+    and subsequent param_data zero are baked into the graph and replay
+    unconditionally. We must populate param_data so the replayed AG gathers
+    correct weights, even when forward pre-hooks are disabled (first iteration).
+
     Args:
         optimizer: The MegatronOptimizer instance
         model: List of model chunks (MegatronModule instances)
@@ -1428,7 +1433,8 @@ def _handle_mxfp8_param_buffer_copy(
     if reuse_grad_buf_for_mxfp8_param_ag and overlap_param_gather:
         # Check if forward_pre_hook is enabled by checking if hooks are registered.
         forward_pre_hook_enabled = len(model[0].remove_forward_pre_hook_handles) > 0
-        if forward_pre_hook_enabled:
+        full_cg_captured = FullCudaGraphWrapper.cuda_graph.get("training") is not None
+        if forward_pre_hook_enabled or full_cg_captured:
             for optim_instance in optimizer.chained_optimizers:
                 if isinstance(optim_instance, DistributedOptimizer):
                     optim_instance._copy_main_params_to_param_buffer()


### PR DESCRIPTION
# What does this PR do ?

When using fp8_param_gather=True + reuse_grad_buf_for_mxfp8_param_ag=True + overlap_param_gather=True with full-iteration CUDA graph (cuda_graph_impl=local, cuda_graph_scope=full_iteration), the first training iteration after warmup produces zero grad norm and incorrect loss.

Root cause: _handle_mxfp8_param_buffer_copy() guards the _copy_main_params_to_param_buffer() call behind a forward_pre_hook_enabled check. The main training loop intentionally disables forward pre-hooks for the first iteration (line 283-284 of train.py), so the copy is skipped. Without CUDA graphs this is safe — params are already in param.data and no all-gather runs.

However, with full-iteration CUDA graph, the all-gather (and the subsequent copy-to-param.data + zero of param_data) are baked into the captured graph and replay unconditionally. On the first iteration:

zero_grad_buffer() zeros param_data
_handle_mxfp8_param_buffer_copy() is skipped (hooks disabled)
Graph replays → AG gathers from param_data (all zeros) → copies zeros to param.data
Forward runs with zero weights → zero gradients

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved parameter buffer handling during distributed training with CUDA graph acceleration, ensuring correct execution across all training iteration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->