### PR TITLE
qwen_fix_env_var_2604

### DIFF
--- a/scripts/performance/perf_plugins.py
+++ b/scripts/performance/perf_plugins.py
@@ -285,6 +285,11 @@ class PerfEnvPlugin(Plugin):
                     if gpu in ["gb300", "h100"]:
                         executor.env_vars["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
                         executor.env_vars["NCCL_GRAPH_REGISTER"] = "0"
+        if model_family_name == "qwen" and compute_dtype == "fp8_mx":
+            if model_recipe_name == "qwen3_30b_a3b":
+                executor.env_vars["NUM_OF_TOKENS_PER_CHUNK_COMBINE_API"] = 128
+            if model_recipe_name == "qwen3_235b_a22b" and gpu in ["gb200", "gb300"]:
+                executor.env_vars["NUM_OF_TOKENS_PER_CHUNK_COMBINE_API"] = 128
 
         del_cudnn_ln = True
         if gpu in ["h100"]:

--- a/scripts/performance/perf_plugins.py
+++ b/scripts/performance/perf_plugins.py
@@ -287,9 +287,9 @@ class PerfEnvPlugin(Plugin):
                         executor.env_vars["NCCL_GRAPH_REGISTER"] = "0"
         if model_family_name == "qwen" and compute_dtype == "fp8_mx":
             if model_recipe_name == "qwen3_30b_a3b":
-                executor.env_vars["NUM_OF_TOKENS_PER_CHUNK_COMBINE_API"] = 128
+                executor.env_vars["NUM_OF_TOKENS_PER_CHUNK_COMBINE_API"] = "128"
             if model_recipe_name == "qwen3_235b_a22b" and gpu in ["gb200", "gb300"]:
-                executor.env_vars["NUM_OF_TOKENS_PER_CHUNK_COMBINE_API"] = 128
+                executor.env_vars["NUM_OF_TOKENS_PER_CHUNK_COMBINE_API"] = "128"
 
         del_cudnn_ln = True
         if gpu in ["h100"]:


### PR DESCRIPTION
# What does this PR do ?

address regression due to combine kernel

# Changelog

```
executor.env_vars["NUM_OF_TOKENS_PER_CHUNK_COMBINE_API"] = 128
```

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized performance configuration for Qwen models across multiple variants and GPU types to enhance execution efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->