### PR TITLE
ci: Override onnx version to ensure lowerbound

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,7 @@ override-dependencies = [
     "cryptography>=43.0.0,<47",
     "nvidia-modelopt>=0.42.0a0",
     "urllib3>=2.6.3",    # To address CVE-2026-21441
+    "onnx>=1.21.0; python_version < '3.13'",  # onnx<1.21 has missing lower bound on ml-dtypes, uses float4_e2m1fn (requires ml-dtypes>=0.5.0)
 ]
 
 [[tool.uv.index]]

--- a/uv.lock
+++ b/uv.lock
@@ -24,6 +24,7 @@ overrides = [
     { name = "transformer-engine", git = "https://github.com/NVIDIA/TransformerEngine.git?rev=71bbefbf153418f943640df0f7373625dc93fa46" },
     { name = "triton", marker = "sys_platform == 'never'" },
     { name = "urllib3", specifier = ">=2.6.3" },
+    { name = "onnx", marker = "python_version < '3.13'", specifier = ">=1.21.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
# What does this PR do ?

Issue:

1. onnx 1.19.0 has a bug in its PyPI metadata -- it uses ml_dtypes.float4_e2m1fn (added in ml-dtypes 0.5.0) but declares ml-dtypes with no version constraint.

2. for Python >= 3.13 ml-dtypes>=0.5.0 requires numpy>=2.1.0, which conflicts with the build dependency group's numpy<2.0.0.

Solution:

- Added "onnx>=1.21.0; python_version < '3.13'" to override-dependencies in pyproject.toml to prevent future downgrades

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ONNX dependency version constraints to ensure compatibility across different Python versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->