### PR TITLE
Cherry Pick: Dump the env for rank0 for slurm based runs. (#2991)

### DIFF
--- a/scripts/performance/argument_parser.py
+++ b/scripts/performance/argument_parser.py
@@ -759,6 +759,12 @@ def parse_cli_args():
         default=None,
     )
     logging_args.add_argument("--save_config_filepath", type=str, help="Path to save the task configuration file")
+    logging_args.add_argument(
+        "--dump_env",
+        action="store_true",
+        help="Write environment variables to /nemo_run/env_<SLURM_JOB_ID>.log on rank 0. "
+        "Useful for post-run debugging of NCCL, CUDA, and SLURM settings.",
+    )
 
     # Config variant selection
     config_variant_args = parser.add_argument_group("Config variant arguments")

--- a/scripts/performance/run_script.py
+++ b/scripts/performance/run_script.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 import logging
+import os
+import re
 
 import torch
 from argument_parser import parse_cli_args
@@ -26,6 +28,36 @@ from megatron.bridge.training.vlm_step import forward_step as vlm_forward_step
 
 
 logger = logging.getLogger(__name__)
+SENSITIVE_ENV_VAR_PATTERN = re.compile(
+    r"(^|_)(TOKEN|SECRET|PASSWORD|PASSWD|API_KEY|ACCESS_KEY|SECRET_KEY|PRIVATE_KEY|AUTHORIZATION)(_|$)",
+    re.IGNORECASE,
+)
+
+
+def _dump_env_rank0() -> None:
+    """Capture the container environment to /nemo_run/env_<SLURM_JOB_ID>.log on rank 0.
+
+    The file lands alongside log*.out and configs/ inside the per-run nemo_run
+    directory for easy post-run debugging.
+    """
+    if os.environ.get("SLURM_JOB_ID") is None:
+        return
+    if int(os.environ.get("SLURM_PROCID", "-1")) != 0:
+        return
+    job_id = os.environ["SLURM_JOB_ID"]
+    env_path = f"/nemo_run/env_{job_id}.log"
+    try:
+        fd = os.open(env_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w") as f:
+            for k, v in sorted(os.environ.items()):
+                if SENSITIVE_ENV_VAR_PATTERN.search(k):
+                    f.write(f"{k}=[REDACTED]\n")
+                else:
+                    safe_v = v.replace("\r", "\\r").replace("\n", "\\n")
+                    f.write(f"{k}={safe_v}\n")
+        logger.info(f"Environment dump written to {env_path} (mode 600)")
+    except OSError as e:
+        logger.warning(f"Failed to write environment dump to {env_path}: {e}")
 
 
 def main():
@@ -34,6 +66,9 @@ def main():
     # `argparse.parse_known_args()` returns the unknown args as a `list[str]`.
     parser = parse_cli_args()
     args, cli_overrides = parser.parse_known_args()
+
+    if args.dump_env:
+        _dump_env_rank0()
 
     recipe = get_perf_optimized_recipe(
         model_family_name=args.model_family_name,


### PR DESCRIPTION
Cherry pick #2991 for r0.4.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--dump_env` command-line flag to enable environment variable logging for post-run debugging of SLURM, NCCL, and CUDA configurations. When enabled during job execution, all environment variables are logged to a file for troubleshooting purposes. Variables containing sensitive terms like secrets, tokens, and keys are automatically redacted to protect credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->