### PR TITLE
[perf] feat: Add --dryrun config saving to run_script.py and run_recipe.py

### DIFF
--- a/scripts/performance/argument_parser.py
+++ b/scripts/performance/argument_parser.py
@@ -257,7 +257,9 @@ def parse_cli_args():
     parser.add_argument(
         "-d",
         "--dryrun",
-        help="If true, prints sbatch script to terminal without launching experiment.",
+        help="Dry-run mode. In setup_experiment.py: prints the sbatch script without launching. "
+        "In run_script.py / run_recipe.py: builds the full ConfigContainer with all overrides, "
+        "saves it to --save_config_filepath (default: ConfigContainer.yaml), and exits without training.",
         required=False,
         action="store_true",
     )

--- a/scripts/performance/run_recipe.py
+++ b/scripts/performance/run_recipe.py
@@ -18,6 +18,8 @@ This script runs inside the container and handles the actual training execution.
 """
 
 import logging
+import os
+import sys
 
 import torch
 from argument_parser import parse_cli_args
@@ -189,6 +191,14 @@ def main():
     )
 
     recipe = set_user_overrides(recipe, args)
+
+    if args.dryrun:
+        save_path = args.save_config_filepath or "ConfigContainer.yaml"
+        os.makedirs(os.path.dirname(os.path.abspath(save_path)), exist_ok=True)
+        recipe.to_yaml(save_path)
+        logging.info(f"ConfigContainer saved to: {os.path.abspath(save_path)}")
+        recipe.print_yaml()
+        sys.exit(0)
 
     # Log final configuration
     if get_rank_safe() == 0:

--- a/scripts/performance/run_script.py
+++ b/scripts/performance/run_script.py
@@ -15,6 +15,7 @@
 import logging
 import os
 import re
+import sys
 
 import torch
 from argument_parser import parse_cli_args
@@ -94,6 +95,14 @@ def main():
         user_gbs=args.global_batch_size,
         config_variant=args.config_variant,
     )
+
+    if args.dryrun:
+        save_path = args.save_config_filepath or "ConfigContainer.yaml"
+        os.makedirs(os.path.dirname(os.path.abspath(save_path)), exist_ok=True)
+        recipe.to_yaml(save_path)
+        logger.info(f"ConfigContainer saved to: {os.path.abspath(save_path)}")
+        recipe.print_yaml()
+        sys.exit(0)
 
     # Select forward step function based on the model family name.
     if args.domain == "vlm":


### PR DESCRIPTION
## Summary

- Extend `--dryrun` to work in `run_script.py` and `run_recipe.py`: builds the full `ConfigContainer` with all overrides applied, saves it to YAML, prints it, and exits **without launching training**. No GPU required.
- In `setup_experiment.py`, `--dryrun` continues to print the sbatch script without submitting, as before.

### Usage

```bash
# Perf-optimized configs (run_script.py)
python scripts/performance/run_script.py \
  -m llama -mr llama3_70b -g gb300 -ng 64 -c bf16 \
  --dryrun --save_config_filepath ./config.yaml

# Library recipes (run_recipe.py)
python scripts/performance/run_recipe.py \
  -m llama -mr llama3_70b -g gb300 -ng 64 \
  --use_recipes --dryrun --save_config_filepath ./config.yaml
```

If `--save_config_filepath` is omitted, defaults to `ConfigContainer.yaml` in the current directory.

## Changes

| File | Change |
|------|--------|
| `scripts/performance/argument_parser.py` | Updated `--dryrun` help text to document dual behavior |
| `scripts/performance/run_script.py` | Add dryrun early-exit: save YAML + print + exit after all overrides are applied |
| `scripts/performance/run_recipe.py` | Same dryrun early-exit after user overrides are applied |

## Test plan

- [ ] `python run_script.py -m llama -mr llama3_70b -g gb300 -ng 64 --dryrun` saves and prints ConfigContainer
- [ ] `python run_recipe.py -m llama -mr llama3_70b -g gb300 -ng 64 --use_recipes --dryrun` saves and prints ConfigContainer
- [ ] `python run_script.py ...` without `--dryrun` still trains normally (no regression)
- [ ] `python setup_experiment.py --dryrun ...` still prints sbatch script (no regression)