### PR TITLE
[doc] fix: add sched.com to linkcheck ignore list

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -135,6 +135,7 @@ html_extra_path = ["project.json", "versions1.json"]
 linkcheck_ignore = [
     ".*github\\.com.*",
     ".*githubusercontent\\.com.*",
+    ".*sched\\.com.*",
 ]
 linkcheck_retries = 10
 linkcheck_rate_limit_timeout = 600


### PR DESCRIPTION
## Summary
- Add `sched.com` to `linkcheck_ignore` in `docs/conf.py` — the PyTorch Conference EU 2026 schedule links return 403 from CI runners.

## Test plan
- [ ] Docs linkcheck CI passes without false positives on sched.com URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation build configuration to exclude certain external URL patterns from link validation, improving build stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->