### PR TITLE
[sync][training] fix: mirror training sync fixes from MCore

### DIFF
--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -72,6 +72,12 @@ class DistributedDataParallelConfig(MCoreDistributedDataParallelConfig):
     for field modifications after construction but before computed fields are calculated.
     """
 
+    param_name_patterns_for_fp32_local_accumulation: Tuple[str, ...] = ()
+    """fnmatch patterns selecting parameters whose gradients should be locally
+    accumulated in FP32. The special pattern ``'all'`` matches every parameter.
+    Synced from MCore c586f6d56 (#4028); field will be inherited from the base
+    class after the next mcore bump."""
+
     def __post_init__(self) -> None:
         """Skip MCore post_init during initial construction.
 

--- a/src/megatron/bridge/training/train.py
+++ b/src/megatron/bridge/training/train.py
@@ -1018,6 +1018,7 @@ def get_start_time_from_progress_log(cfg: ConfigContainer) -> tuple[datetime, fl
     start_time = None
     start_num_floating_point_operations = None
     latest_num_floating_point_operations = 0
+    latest_num_floating_point_operations_uncommitted = None
 
     def _get_field(string, type):
         return type(string.split(": ")[1])
@@ -1029,6 +1030,12 @@ def get_start_time_from_progress_log(cfg: ConfigContainer) -> tuple[datetime, fl
             world_size_in_line = _get_field(line_tokens[2], int)
             if line_tokens[3] == "Saved checkpoint":
                 latest_num_floating_point_operations = _get_field(line_tokens[7], float)
+            elif line_tokens[3] == "Saving async checkpoint":
+                latest_num_floating_point_operations_uncommitted = _get_field(line_tokens[7], float)
+            elif line_tokens[3] == "Saved async checkpoint":
+                if latest_num_floating_point_operations_uncommitted is not None:
+                    latest_num_floating_point_operations = latest_num_floating_point_operations_uncommitted
+                    latest_num_floating_point_operations_uncommitted = None
             if world_size_in_line != get_world_size_safe():
                 # Re-start search if we see a different world size.
                 start_time = None
@@ -1352,7 +1359,7 @@ def _should_skip_and_handle_iteration(
         bool: True if the iteration was skipped, False otherwise
     """
     cfg = global_state.cfg
-    if global_state.train_state.step not in cfg.train.iterations_to_skip:
+    if (global_state.train_state.step + 1) not in cfg.train.iterations_to_skip:
         return False
 
     # Perform dummy train step to fast forward train_data_iterator

--- a/tests/unit_tests/training/test_pg_collection_wiring.py
+++ b/tests/unit_tests/training/test_pg_collection_wiring.py
@@ -33,10 +33,11 @@ def test_should_skip_iteration_uses_passed_pg_collection(monkeypatch):
     state = GlobalState()
 
     # Set up a minimal config needed by _should_skip_and_handle_iteration
-    # We skip step 0 so that the function executes the skip path.
+    # iterations_to_skip uses 1-based iteration numbers (matching MLM convention).
+    # {1} means "skip the 1st iteration", which fires when step=0 (step+1==1).
     state.cfg = SimpleNamespace(
         train=SimpleNamespace(
-            iterations_to_skip={0},
+            iterations_to_skip={1},
             micro_batch_size=4,
             exit_signal=signal.SIGTERM,
         )

--- a/tests/unit_tests/training/test_train.py
+++ b/tests/unit_tests/training/test_train.py
@@ -1172,9 +1172,9 @@ class TestIterationSkipping:
     @patch("megatron.bridge.training.train._dummy_train_step")
     @patch("megatron.bridge.training.train.get_num_microbatches", return_value=4)
     def test_should_skip_iteration_when_step_in_skip_list(self, mock_get_microbatches, mock_dummy_step):
-        """Test that iteration is skipped when step is in iterations_to_skip list."""
-        # Setup
-        global_state = self._create_mock_global_state(step=5, iterations_to_skip=[3, 5, 10])
+        """Test that iteration is skipped when step+1 matches iterations_to_skip (1-based)."""
+        # step=4 → iteration 5 (1-based), skip list contains 5
+        global_state = self._create_mock_global_state(step=4, iterations_to_skip=[3, 5, 10])
         train_data_iterator = Mock()
 
         # Call function
@@ -1186,15 +1186,15 @@ class TestIterationSkipping:
         mock_dummy_step.assert_called_once_with(global_state, train_data_iterator, fake_pg)
 
         # Verify state updates
-        assert global_state.train_state.step == 6  # incremented
+        assert global_state.train_state.step == 5  # incremented
         expected_batch_size = 2 * 4 * 4  # dp_world_size * micro_batch_size * num_microbatches
         assert global_state.train_state.consumed_train_samples == expected_batch_size
         assert global_state.train_state.skipped_train_samples == expected_batch_size
 
     @patch("megatron.bridge.training.train._dummy_train_step")
     def test_should_not_skip_iteration_when_step_not_in_skip_list(self, mock_dummy_step):
-        """Test that iteration is not skipped when step is not in iterations_to_skip list."""
-        # Setup
+        """Test that iteration is not skipped when step+1 is not in iterations_to_skip."""
+        # step=7 → iteration 8, not in [3, 5, 10]
         global_state = self._create_mock_global_state(step=7, iterations_to_skip=[3, 5, 10])
         train_data_iterator = Mock()
 
@@ -1230,8 +1230,8 @@ class TestIterationSkipping:
     @patch("megatron.bridge.training.train.get_num_microbatches", return_value=2)
     def test_batch_size_calculation_with_different_parallelism(self, mock_get_microbatches, mock_dummy_step):
         """Test batch size calculation with different parallelism settings."""
-        # Setup
-        global_state = self._create_mock_global_state(step=10, iterations_to_skip=[10], micro_batch_size=8)
+        # step=9 → iteration 10 (1-based), skip list contains 10
+        global_state = self._create_mock_global_state(step=9, iterations_to_skip=[10], micro_batch_size=8)
         train_data_iterator = Mock()
 
         # Call function


### PR DESCRIPTION
## Summary

Syncs 3 training-side fixes from recent MCore commits (last 2 weeks):

1. **FP32 local gradient accumulation** (MCore `c586f6d56` / #4028): Adds `param_name_patterns_for_fp32_local_accumulation` field to Bridge's `DistributedDataParallelConfig` for forward-compatibility. This allows users to selectively accumulate gradients in FP32 for matched parameters using fnmatch patterns. The field will also be inherited from the MCore base class after the next submodule bump.

2. **Async checkpoint progress log tracking** (MCore `b4e4d9618` / #3957): Fixes `get_start_time_from_progress_log` to correctly handle async checkpoints. Previously, the function only tracked `"Saved checkpoint"` entries, which meant cumulative throughput was miscalculated when `async_save=True` — the FLOPs counter would only update after the async save committed, potentially skipping completed iterations. The fix distinguishes `"Saving async checkpoint"` (uncommitted) from `"Saved async checkpoint"` (committed), using an intermediate variable to track uncommitted values until they're confirmed.

3. **`iterations_to_skip` off-by-one** (MCore `b4e4d9618` / #3957): Fixes the skip comparison from `step` (0-based) to `step + 1` (1-based), aligning with logged iteration numbers. Previously, to skip iteration 5 (as shown in logs/checkpoints), users had to put `4` in the skip list. Now the skip list values match what users see in training output.

### Items investigated but no code change needed

- **FSDP default sharding strategy** (MCore `3499efef8` / #3691): The `no_shard` → `optim_grads_params` default change was only in MLM's argparse, not in the MCore DDPConfig dataclass. Bridge recipes that use FSDP already explicitly set `data_parallel_sharding_strategy`, so no change is needed.

- **FSDP MixedPrecision DDPConfig wiring** (MCore `947bdbbd2` / #3992 + `f45619970` / #3903): The `megatron_fsdp_{main_params,main_grads,grad_comm}_dtype` fields already exist on MCore's `DistributedDataParallelConfig` and are inherited by Bridge's subclass. Since Bridge passes `cfg.ddp` directly to MCore's DDP wrapping (unlike MLM which manually copies from argparse), these fields are already properly wired. PR #2848 already cleaned up the old per-chunk kwargs path.

## Test plan

- [x] Updated `TestIterationSkipping` tests to use 1-based iteration numbers in skip lists
- [ ] CI unit tests pass
- [ ] Verify async checkpoint progress log tracking with a run using `async_save=True`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `param_name_patterns_for_fp32_local_accumulation` configuration parameter for distributed training, supporting pattern-based parameter selection.

* **Bug Fixes**
  * Enhanced async checkpoint progress tracking to correctly handle uncommitted FLOP counts.
  * Updated iteration skipping logic for improved training step management.

* **Tests**
  * Updated unit tests to reflect iteration counting behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->