### PR TITLE
[ci] fix: allow remove-needs-author workflow to update labels

### DIFF
--- a/.github/workflows/remove-needs-author.yml
+++ b/.github/workflows/remove-needs-author.yml
@@ -3,8 +3,13 @@ name: Remove needs-author label
 on:
   issue_comment:
     types: [created]
-  pull_request:
+  pull_request_target:
     types: [synchronize]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
 
 jobs:
   remove-label-on-comment:
@@ -32,7 +37,7 @@ jobs:
             });
 
   remove-label-on-push:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     steps:
       - name: Remove needs-author if author pushed commits


### PR DESCRIPTION
## Summary
- add explicit `issues: write` and `pull-requests: write` permissions to the `remove-needs-author` workflow
- run the synchronize path on `pull_request_target` so the workflow can remove `needs-author` for fork-based PRs
- keep the workflow scoped to metadata-only label updates without checking out PR code

## Test plan
- [x] `pre-commit run --files .github/workflows/remove-needs-author.yml`
- [ ] exercise the workflow on a PR with `needs-author` by commenting as the author
- [ ] exercise the workflow on a fork PR by pushing a new commit as the author

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated internal CI/CD workflow configuration to enhance automation reliability and permissions handling.

---

**Note:** This update is an internal infrastructure change with no impact on product features or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->