### PR TITLE
Addressing .mp4 files that don't have captions when running openvid1M_preprocess.py

### DIFF
--- a/examples/diffusion/recipes/wan/prepare_dataset/openvid1M_dataset/README.md
+++ b/examples/diffusion/recipes/wan/prepare_dataset/openvid1M_dataset/README.md
@@ -33,7 +33,7 @@ The preprocessing script reads the CSV caption file and creates a sidecar `.json
 
 ```bash
 cd ${MBRIDGE_PATH}
-python examples/diffusion/recipes/wan/prepare_dataset/openvid1M_preprocess.py \
+python examples/diffusion/recipes/wan/prepare_dataset/openvid1M_dataset/openvid1M_preprocess.py \
   --csv_path ${PROCESSED_DATA_PATH}/OpenVidHD.csv \
   --video_dir ${PROCESSED_DATA_PATH}/OpenVidHD_part_1
 ```

--- a/examples/diffusion/recipes/wan/prepare_dataset/openvid1M_dataset/openvid1M_preprocess.py
+++ b/examples/diffusion/recipes/wan/prepare_dataset/openvid1M_dataset/openvid1M_preprocess.py
@@ -15,6 +15,7 @@
 import argparse
 import json
 import os
+import shutil
 
 import pandas as pd
 
@@ -41,7 +42,10 @@ def main():
     video_files = [f for f in os.listdir(video_dir) if f.endswith(".mp4")]
     print(f"Found {len(video_files)} videos in {video_dir}. Starting conversion...")
 
+    no_caption_dir = os.path.join(video_dir, "videos_without_captions")
+
     count = 0
+    no_caption_count = 0
     for video_name in video_files:
         if video_name in caption_map:
             # Construct the JSON content
@@ -57,9 +61,14 @@ def main():
 
             count += 1
         else:
-            print(f"Warning: No caption found for {video_name}")
+            print(f"Warning: No caption found for {video_name}, moving to {no_caption_dir}")
+            os.makedirs(no_caption_dir, exist_ok=True)
+            shutil.move(os.path.join(video_dir, video_name), os.path.join(no_caption_dir, video_name))
+            no_caption_count += 1
 
     print(f"Finished! Created {count} JSON files in {video_dir}.")
+    if no_caption_count:
+        print(f"Moved {no_caption_count} videos without captions to {no_caption_dir}.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# What does this PR do ?

Addressing .mp4 files that don't have captions when running openvid1M_preprocess.py. Moving those .mp4 files into a specific directory, which would not affect the subsequent steps.

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated dataset preprocessing documentation with corrected command path for OpenVid-1M dataset preparation.

* **New Features**
  * Videos missing captions are now automatically organized into a separate subdirectory during preprocessing, with a summary count of moved files displayed at completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->