### PR TITLE
[doc] fix: add missing GLM-4.5V and Qwen3.5 VL entries to VLM README table

### DIFF
--- a/docs/models/vlm/README.md
+++ b/docs/models/vlm/README.md
@@ -9,10 +9,12 @@ Megatron Bridge supports the following VLM families:
 | Model | Documentation | Description |
 |-------|---------------|-------------|
 | **Gemma 3 VL** | [gemma3-vl.md](gemma3-vl.md) | Google Gemma 3 Vision Language model |
+| **GLM-4.5V** | [glm-45v.md](glm-45v.md) | THUDM GLM-4.5V Vision Language model |
 | **Ministral 3** | [ministral3.md](ministral3.md) | Ministral 3 Vision Language model |
 | **Nemotron Nano V2 VL** | [nemotron-nano-v2-vl.md](nemotron-nano-v2-vl.md) | NVIDIA Nemotron Nano V2 Vision Language model |
 | **Qwen2.5 VL** | [qwen2.5-vl.md](qwen2.5-vl.md) | Alibaba Cloud Qwen2.5 Vision Language model |
 | **Qwen3 VL** | [qwen3-vl.md](qwen3-vl.md) | Alibaba Cloud Qwen3 Vision Language model |
+| **Qwen3.5 VL** | [qwen35-vl.md](qwen35-vl.md) | Alibaba Cloud Qwen3.5 Vision Language model |
 
 ## Quick Navigation
 


### PR DESCRIPTION
## Summary

- Adds **GLM-4.5V** and **Qwen3.5 VL** to the Available Models table in `docs/models/vlm/README.md`
- Both models had full documentation pages (`glm-45v.md`, `qwen35-vl.md`) but were missing from the index table
- Fixes parity between the directory contents and the README table (7 doc files → 7 table entries)

Fixes NVBug #6030962 (similar issue in root README.md, see #3060)

## Test plan
- [ ] Verify `docs/models/vlm/README.md` table now lists 7 VLM entries
- [ ] Confirm links to `glm-45v.md` and `qwen35-vl.md` resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added support documentation for two new Vision Language Models: GLM-4.5V and Qwen3.5 VL. Both models are now available in the models reference with comprehensive documentation links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->