### PR TITLE
[model] fix: apply MLA rope params for Kimi K2.5 VL bridge

### DIFF
--- a/src/megatron/bridge/models/kimi_vl/kimi_k25_vl_bridge.py
+++ b/src/megatron/bridge/models/kimi_vl/kimi_k25_vl_bridge.py
@@ -64,7 +64,7 @@ class KimiK25VLBridge(MegatronModelBridge):
         vision_config = hf_config.vision_config
 
         provider_kwargs = self.hf_config_to_provider_kwargs(text_config)
-        provider_kwargs.pop("_mla_rope_params", None)
+        mla_rope_params = provider_kwargs.pop("_mla_rope_params", None)
         valid_fields = KimiK25VLModelProvider.__dataclass_fields__
         provider = KimiK25VLModelProvider(**{k: v for k, v in provider_kwargs.items() if k in valid_fields})
 
@@ -77,6 +77,11 @@ class KimiK25VLBridge(MegatronModelBridge):
         provider.qk_layernorm = True
         provider.multi_latent_attention = True
         provider.position_embedding_type = "rope"
+
+        # Apply MLA rope params, otherwise rope scaling factor will be wrong.
+        if mla_rope_params:
+            for key, value in mla_rope_params.items():
+                setattr(provider, key, value)
 
         # MoE settings
         provider.moe_grouped_gemm = True


### PR DESCRIPTION
The Kimi K2.5 VL bridge was discarding `_mla_rope_params` extracted from the HF config's `rope_scaling` dict, causing `rotary_scaling_factor` to fall back to the MLATransformerConfig default of 40 instead of the HF config value of 64. Similarly `mscale_all_dim` stayed at 0.0 instead of 1.0.

Fix: retain the popped `_mla_rope_params` and apply them to the provider via setattr after construction.

Similar logic is in
https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/caa14efa16826ce0b2bee0e6a428ba94c49aa50e/src/megatron/bridge/models/conversion/model_bridge.py#L535-L537

# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
