### PR TITLE
cp: `[model] fix: apply MLA rope params for Kimi K2.5 VL bridge (3128)` into `r0.4.0`

### DIFF
--- a/src/megatron/bridge/models/kimi_vl/kimi_k25_vl_bridge.py
+++ b/src/megatron/bridge/models/kimi_vl/kimi_k25_vl_bridge.py
@@ -64,7 +64,7 @@ class KimiK25VLBridge(MegatronModelBridge):
         vision_config = hf_config.vision_config
 
         provider_kwargs = self.hf_config_to_provider_kwargs(text_config)
-        provider_kwargs.pop("_mla_rope_params", None)
+        mla_rope_params = provider_kwargs.pop("_mla_rope_params", None)
         valid_fields = KimiK25VLModelProvider.__dataclass_fields__
         provider = KimiK25VLModelProvider(**{k: v for k, v in provider_kwargs.items() if k in valid_fields})
 
@@ -77,6 +77,11 @@ class KimiK25VLBridge(MegatronModelBridge):
         provider.qk_layernorm = True
         provider.multi_latent_attention = True
         provider.position_embedding_type = "rope"
+
+        # Apply MLA rope params, otherwise rope scaling factor will be wrong.
+        if mla_rope_params:
+            for key, value in mla_rope_params.items():
+                setattr(provider, key, value)
 
         # MoE settings
         provider.moe_grouped_gemm = True


### PR DESCRIPTION
Cherry-pick of #3128 to `r0.4.0`, manually resolved.

## Why the automated pick failed

`kimi_vl` was added to `main` in #2743 and is not yet in `r0.4.0` directly — its backport lives in the still-open PR #3093 (`cherrypick/2743-to-r0.4.0`). The bot tried to apply the fix against bare `r0.4.0` where the file doesn't exist, making a 3-way merge impossible.

## Resolution

Based this branch on `cherrypick/2743-to-r0.4.0` (PR #3093) where `kimi_k25_vl_bridge.py` exists, then applied the one-line fix manually.

**Merge order:** PR #3093 must merge into `r0.4.0` before this PR, or both can be squash-merged together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model configuration handling to ensure MLA RoPE parameters are properly propagated to the model provider, enhancing configuration accuracy and model initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->