### PR TITLE
[perf] fix: set NUM_OF_TOKENS_PER_CHUNK_COMBINE_API=128 for all hybrid-ep recipes

### DIFF
--- a/scripts/performance/perf_plugins.py
+++ b/scripts/performance/perf_plugins.py
@@ -285,12 +285,6 @@ class PerfEnvPlugin(Plugin):
                     if gpu in ["gb300", "h100"]:
                         executor.env_vars["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
                         executor.env_vars["NCCL_GRAPH_REGISTER"] = "0"
-        if model_family_name == "qwen" and compute_dtype == "fp8_mx":
-            if model_recipe_name == "qwen3_30b_a3b":
-                executor.env_vars["NUM_OF_TOKENS_PER_CHUNK_COMBINE_API"] = "128"
-            if model_recipe_name == "qwen3_235b_a22b" and gpu in ["gb200", "gb300"]:
-                executor.env_vars["NUM_OF_TOKENS_PER_CHUNK_COMBINE_API"] = "128"
-
         del_cudnn_ln = True
         if gpu in ["h100"]:
             if model_family_name == "llama" and model_recipe_name == "llama3_8b" and train_task == "pretrain":
@@ -357,6 +351,9 @@ class PerfEnvPlugin(Plugin):
                 executor.env_vars["NVLINK_DOMAIN_SIZE"] = "72"
                 executor.env_vars["USE_MNNVL"] = "1"
                 executor.env_vars["NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN"] = str(ep_size)
+            # Workaround for unfused combine performance regression in DeepEP hybrid-ep.
+            # Remove after https://github.com/NVIDIA/Megatron-LM/pull/4089 lands.
+            executor.env_vars["NUM_OF_TOKENS_PER_CHUNK_COMBINE_API"] = "128"
 
     def _set_nccl_pp_comm_chunksize(
         self,


### PR DESCRIPTION
## Summary
- Set `NUM_OF_TOKENS_PER_CHUNK_COMBINE_API=128` for **all** MoE recipes using hybrid-ep, not just qwen3 (supersedes the qwen-only fix from #3083).
- The env var is now set in `_set_nvl_domain_size()` inside the `moe_flex_dispatcher_backend == "hybridep"` gate, so it applies to deepseek, qwen, kimi, nemotron, gpt_oss, and qwen_vl recipes on all GPUs.
- Removes the qwen-specific overrides that are now redundant.

## Context
DeepEP hybrid-ep commit `a0d27f1` ("Add Permute/Unpermute Fusion") changed the C++ default combine chunk size from 128→64. This causes ~2x combine-kernel regression for unfused combine.

This is a temporary workaround — remove after https://github.com/NVIDIA/Megatron-LM/pull/4089 where combine fusion lands.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized token processing configuration for specific GPU setups to improve system performance and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->