### PR TITLE
[vulnops][model] fix: Add security warning for trust_remote_code and remove hardcoded True

### DIFF
--- a/examples/conversion/convert_checkpoints.py
+++ b/examples/conversion/convert_checkpoints.py
@@ -142,6 +142,7 @@ def export_megatron_to_hf(
     hf_path: str,
     show_progress: bool = True,
     strict: bool = True,
+    trust_remote_code: bool = False,
 ) -> None:
     """
     Export a Megatron checkpoint to HuggingFace format.
@@ -152,6 +153,7 @@ def export_megatron_to_hf(
         hf_path: Directory path where the HuggingFace model will be saved
         show_progress: Display progress bar during weight export
         strict: Whether to perform strict validation during weight export
+        trust_remote_code: Whether to trust remote code when loading config
     """
     print(f"🔄 Starting export: {megatron_path} -> {hf_path}")
 
@@ -177,7 +179,7 @@ def export_megatron_to_hf(
     print(f"📋 Found configuration: {config_files[0]}")
 
     # Export always uses the config synthesized from checkpoint + HF reference.
-    bridge = AutoBridge.from_auto_config(megatron_path, hf_model)
+    bridge = AutoBridge.from_auto_config(megatron_path, hf_model, trust_remote_code=trust_remote_code)
 
     # Export using the convenience method
     print("📤 Exporting to HuggingFace format...")
@@ -238,6 +240,7 @@ def main():
     export_parser.add_argument(
         "--not-strict", action="store_true", help="Allow source and target checkpoint to have different keys"
     )
+    export_parser.add_argument("--trust-remote-code", action="store_true", help="Allow custom model code execution")
     args = parser.parse_args()
 
     if not args.command:
@@ -260,6 +263,7 @@ def main():
             hf_path=args.hf_path,
             show_progress=not args.no_progress,
             strict=not args.not_strict,
+            trust_remote_code=args.trust_remote_code,
         )
     else:
         raise RuntimeError(f"Unknown command: {args.command}")

--- a/src/megatron/bridge/models/conversion/auto_bridge.py
+++ b/src/megatron/bridge/models/conversion/auto_bridge.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import dataclasses
 import logging
-import warnings
 from functools import cached_property, partial
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Generic, Iterable, List, Optional, Type, TypeVar, Union
@@ -217,11 +216,9 @@ class AutoBridge(Generic[MegatronModelT]):
         # 1. Load config from both sides
         megatron_cfg, _ = load_model_config(str(run_config.parent))
         if trust_remote_code:
-            warnings.warn(
+            logger.warning(
                 "Loading a model with trust_remote_code=True allows arbitrary code execution "
-                "from the model repository. Only use this with models you trust.",
-                UserWarning,
-                stacklevel=2,
+                "from the model repository. Only use this with models you trust."
             )
         hf_cfg = AutoConfig.from_pretrained(hf_model_id, trust_remote_code=trust_remote_code)
         # 2. Translate Megatron config -> HF, conforming to reference config
@@ -323,11 +320,9 @@ class AutoBridge(Generic[MegatronModelT]):
         # First load just the config to check architecture support
         # Use thread-safe config loading to prevent race conditions
         if kwargs.get("trust_remote_code", False):
-            warnings.warn(
+            logger.warning(
                 "Loading a model with trust_remote_code=True allows arbitrary code execution "
-                "from the model repository. Only use this with models you trust.",
-                UserWarning,
-                stacklevel=2,
+                "from the model repository. Only use this with models you trust."
             )
         config = safe_load_config_with_retry(path, trust_remote_code=kwargs.get("trust_remote_code", False))
 

--- a/src/megatron/bridge/models/conversion/auto_bridge.py
+++ b/src/megatron/bridge/models/conversion/auto_bridge.py
@@ -319,12 +319,14 @@ class AutoBridge(Generic[MegatronModelT]):
         """
         # First load just the config to check architecture support
         # Use thread-safe config loading to prevent race conditions
-        if kwargs.get("trust_remote_code", False):
+        config_kwargs = dict(kwargs)
+        trust_remote_code = bool(config_kwargs.pop("trust_remote_code", False))
+        if trust_remote_code:
             logger.warning(
                 "Loading a model with trust_remote_code=True allows arbitrary code execution "
                 "from the model repository. Only use this with models you trust."
             )
-        config = safe_load_config_with_retry(path, trust_remote_code=kwargs.get("trust_remote_code", False))
+        config = safe_load_config_with_retry(path, trust_remote_code=trust_remote_code, **config_kwargs)
 
         cls._validate_config(config, str(path))
 

--- a/src/megatron/bridge/models/conversion/auto_bridge.py
+++ b/src/megatron/bridge/models/conversion/auto_bridge.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import dataclasses
 import logging
+import warnings
 from functools import cached_property, partial
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Generic, Iterable, List, Optional, Type, TypeVar, Union
@@ -168,7 +169,7 @@ class AutoBridge(Generic[MegatronModelT]):
         return any(arch.endswith(SUPPORTED_HF_ARCHITECTURES) for arch in architectures)
 
     @classmethod
-    def from_auto_config(cls, megatron_path: str, hf_model_id: str) -> "AutoBridge":
+    def from_auto_config(cls, megatron_path: str, hf_model_id: str, trust_remote_code: bool = False) -> "AutoBridge":
         """
         Create a config-only AutoBridge by synthesizing an HF config from a Megatron checkpoint.
 
@@ -181,6 +182,9 @@ class AutoBridge(Generic[MegatronModelT]):
             megatron_path: Directory path where the Megatron checkpoint is stored
             hf_model_id: HuggingFace model ID or path to model directory
                 Examples: "meta-llama/Meta-Llama-3-8B", "./my_model"
+            trust_remote_code: Whether to trust remote code when loading config.
+                Defaults to False for security. Set to True only for models that
+                require custom modeling code from the repository.
 
         Returns:
             AutoBridge: Bridge instance configured for the architecture
@@ -212,7 +216,14 @@ class AutoBridge(Generic[MegatronModelT]):
 
         # 1. Load config from both sides
         megatron_cfg, _ = load_model_config(str(run_config.parent))
-        hf_cfg = AutoConfig.from_pretrained(hf_model_id, trust_remote_code=True)
+        if trust_remote_code:
+            warnings.warn(
+                "Loading a model with trust_remote_code=True allows arbitrary code execution "
+                "from the model repository. Only use this with models you trust.",
+                UserWarning,
+                stacklevel=2,
+            )
+        hf_cfg = AutoConfig.from_pretrained(hf_model_id, trust_remote_code=trust_remote_code)
         # 2. Translate Megatron config -> HF, conforming to reference config
         bridge = cls.from_hf_config(hf_cfg)
         megatron_hf_cfg_dict = bridge._model_bridge.megatron_to_hf_config(megatron_cfg)
@@ -311,6 +322,13 @@ class AutoBridge(Generic[MegatronModelT]):
         """
         # First load just the config to check architecture support
         # Use thread-safe config loading to prevent race conditions
+        if kwargs.get("trust_remote_code", False):
+            warnings.warn(
+                "Loading a model with trust_remote_code=True allows arbitrary code execution "
+                "from the model repository. Only use this with models you trust.",
+                UserWarning,
+                stacklevel=2,
+            )
         config = safe_load_config_with_retry(path, trust_remote_code=kwargs.get("trust_remote_code", False))
 
         cls._validate_config(config, str(path))

--- a/tests/unit_tests/models/test_auto_bridge.py
+++ b/tests/unit_tests/models/test_auto_bridge.py
@@ -434,7 +434,7 @@ class TestAutoBridge:
 
         assert bridge is second_bridge
         assert second_bridge.hf_model_id == hf_model_id
-        mock_auto_cfg.assert_called_once_with(hf_model_id, trust_remote_code=True)
+        mock_auto_cfg.assert_called_once_with(hf_model_id, trust_remote_code=False)
         mock_load_cfg.assert_called_once_with(str(ckpt_dir))
         mock_conform.assert_called_once_with({"vocab_size": 64000}, {"vocab_size": 32000})
 


### PR DESCRIPTION
## Summary
- Remove hardcoded `trust_remote_code=True` in `from_auto_config` and accept it as an explicit parameter (default `False`)
- Add security warnings when `trust_remote_code=True` is used, alerting users about arbitrary code execution risk
- Addresses vulnerability: remote model repos can execute arbitrary code when `trust_remote_code=True` is passed to HuggingFace loading functions

## Test plan
- [ ] Verify models that don't need `trust_remote_code` still load correctly
- [ ] Verify models requiring `trust_remote_code=True` work when explicitly passed
- [ ] Verify security warning is emitted when `trust_remote_code=True` is used
- [ ] Verify `from_auto_config` without `trust_remote_code` defaults to `False`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Remote code execution during model loading can now be explicitly controlled via a new parameter, with a safer default of disabled.

* **Improvements**
  * Remote code execution now defaults to disabled for better security. Warning messages alert users when remote code execution is explicitly enabled, ensuring full transparency about this security-sensitive operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->