### PR TITLE
[vulnops][ckpt] fix: Use weights_only=True in ModelOpt checkpoint loading

### DIFF
--- a/src/megatron/bridge/training/post_training/checkpointing.py
+++ b/src/megatron/bridge/training/post_training/checkpointing.py
@@ -85,7 +85,7 @@ def has_modelopt_state(checkpoint_path: str) -> bool:
     if not os.path.isdir(modelopt_state_path):
         return False
 
-    modelopt_state = torch.load(modelopt_state_path + "/" + COMMON_STATE_FNAME, weights_only=False)
+    modelopt_state = torch.load(modelopt_state_path + "/" + COMMON_STATE_FNAME, weights_only=True)
     modes = modelopt_state["modelopt_state_dict"]
     if len(modes) == 1 and modes[0][0] == "kd_loss":
         # Ignore KD state


### PR DESCRIPTION
## Summary
- Change `weights_only=False` to `weights_only=True` in `torch.load()` call for ModelOpt state in `has_modelopt_state()`
- Prevents arbitrary code execution via malicious pickle payloads in checkpoint files
- The ModelOpt state dict only contains simple Python types (lists of tuples of strings) so `weights_only=True` is sufficient

## Test plan
- [ ] Verify ModelOpt checkpoint loading still works with `weights_only=True`
- [ ] Verify `has_modelopt_state()` correctly detects modelopt state
- [ ] Run post-training tests if available

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved checkpoint loading security by restricting deserialization to tensor and weights content only, preventing potential unwanted data from being loaded during model checkpoint restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->