### PR TITLE
[model] fix: expose word_embeddings on MTP shadow embedding for Qwen3-VL

### DIFF
--- a/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/text_model.py
+++ b/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/text_model.py
@@ -188,6 +188,7 @@ class Qwen3VLGPTModel(GPTModel):
                 out = _original_embedding(input_ids=input_ids, position_ids=position_ids)
                 return tensor_parallel.scatter_to_sequence_parallel_region(out)
 
+            _sp_scatter_embedding.word_embeddings = _original_embedding.word_embeddings
             self.__dict__["embedding"] = _sp_scatter_embedding
             _shadow_embedding = True
 


### PR DESCRIPTION
# What does this PR do?

Fix an `AttributeError` when using MTP with sequence parallelism in Qwen3-VL: the SP-scatter shadow embedding wrapper was missing the `word_embeddings` attribute that MTP postprocessing accesses.

# Changelog

- Forward `word_embeddings` from the original embedding onto the SP-scatter shadow function in `Qwen3VLGPTModel`, so MTP can access it during `_postprocess`

# GitHub Actions CI

See the CI section in the Contributing doc for how to trigger the CI.
A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

Pre checks:
- [x] Make sure you read and followed Contributor guidelines
- [ ] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

Single-line fix — the MTP path calls `self.embedding.word_embeddings` but the shadow closure didn't carry that attribute.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of embedding attributes when parallel processing features are enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->