### PR TITLE
[perf] fix: skip CPU offloading when activation_offload_layers=0

### DIFF
--- a/scripts/performance/utils/overrides.py
+++ b/scripts/performance/utils/overrides.py
@@ -132,7 +132,7 @@ def _set_recompute_overrides(
     recompute_modules: Optional[List[str]] = None,
 ) -> ConfigContainer:
     """Set the recompute and CPU offloading overrides."""
-    if cpu_offloading_num_layers is not None:
+    if cpu_offloading_num_layers is not None and cpu_offloading_num_layers > 0:
         recipe.model.cpu_offloading = True
         recipe.model.cpu_offloading_weights = False
         recipe.model.cpu_offloading_num_layers = cpu_offloading_num_layers


### PR DESCRIPTION
## Summary

- Fix incorrect CPU offloading activation when `activation_offload_layers=0` (or `cpu_offloading_num_layers=0`)
- Previously, the `is not None` check alone enabled CPU offloading even for a value of `0`, causing a `ValueError` when pipeline parallelism was also in use
- Changed condition to `is not None and cpu_offloading_num_layers > 0`

Fixes #2992

## Test plan

- [ ] Verify training with `activation_offload_layers=0` and `pp > 1` no longer raises `ValueError: Currently there is no support for Pipeline parallelism with CPU offloading`
- [ ] Verify training with `activation_offload_layers > 0` still correctly enables CPU offloading

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CPU offloading configuration to not activate when the number of layers is set to zero or negative values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->