### PR TITLE
[perf] feat: support te_precision_config_file via WorkloadBaseConfig

### DIFF
--- a/scripts/performance/utils/overrides.py
+++ b/scripts/performance/utils/overrides.py
@@ -220,6 +220,10 @@ def set_workload_base_configs(cfg: ConfigContainer, settings: WorkloadBaseConfig
         cpu_offloading_num_layers=settings.cpu_offloading_num_layers,
         recompute_num_layers=settings.recompute_num_layers,
     )
+    if settings.te_precision_config_file is not None:
+        from megatron.core.quantization.utils import load_quantization_recipe
+
+        cfg.model.quant_recipe = load_quantization_recipe(settings.te_precision_config_file)
     _set_common_perf_overrides(cfg)
 
     if settings.moe_flex_dispatcher_backend is not None:

--- a/scripts/performance/utils/utils.py
+++ b/scripts/performance/utils/utils.py
@@ -65,6 +65,9 @@ class WorkloadBaseConfig:
     # Pipeline parallelism layout
     pp_layout: Optional[str] = None
 
+    # TransformerEngine per-module precision overrides
+    te_precision_config_file: Optional[str] = None
+
     @property
     def sequence_parallel(self) -> bool:
         """Get the sequence parallel flag."""


### PR DESCRIPTION
## Summary

Aligns MBridge with MLM's `--te-precision-config-file` flag (#3102).

- Adds `te_precision_config_file: Optional[str] = None` field to `WorkloadBaseConfig` (`scripts/performance/utils/utils.py`)
- Wires it through `set_workload_base_configs()` in `scripts/performance/utils/overrides.py` — loads the YAML file via `megatron.core.quantization.utils.load_quantization_recipe()` and sets `recipe.model.quant_recipe`

No CLI arg added; the path lives alongside other performance settings in workload base config files:

```python
MY_CONFIG = replace(BASE_CONFIG, te_precision_config_file="/path/to/te_quant.cfg")
```

`TransformerConfig.quant_recipe` already exists in MCore, so no model-level changes are needed.

## Test plan

- [ ] Set `te_precision_config_file` in a workload config pointing to a valid `te_quant.cfg` and verify `recipe.model.quant_recipe` is populated
- [ ] Confirm omitting the field leaves `quant_recipe` unchanged (no regression)

Closes #3102

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for optional quantization recipe configuration files, enabling users to define precision-related overrides for model operations without manual intervention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->