### PR TITLE
[model] fix: fix gpt-oss down_proj weight handling

### DIFF
--- a/src/megatron/bridge/models/gpt_oss/gpt_oss_bridge.py
+++ b/src/megatron/bridge/models/gpt_oss/gpt_oss_bridge.py
@@ -106,9 +106,9 @@ class GPTOSSBridge(MegatronModelBridge):
     ) -> torch.Tensor:
         """Load weights from HuggingFace state dict with MXFP4 dequantization support.
 
-        down_proj expert weights are stored transposed vs Megatron (HF: [in, out], Megatron: [out, in]).
-        We transpose them once here so that GPTOSSMLPDownProjMapping.hf_to_megatron can treat the
-        per-expert slice as-is, and megatron_to_hf symmetrically transposes back on export.
+        down_proj transpose on export is handled in GPTOSSMLPDownProjMapping.megatron_to_hf,
+        which transposes the per-expert weight from Megatron's [in, out] storage to
+        HF's expected [out, in] layout.
 
         gate_up_proj is handled directly in GPTOSSMLPGateUpProjMapping.hf_to_megatron via
         _align_expert_weight_to_shape, which auto-detects the orientation difference between
@@ -118,15 +118,11 @@ class GPTOSSBridge(MegatronModelBridge):
         if isinstance(hf_param, str):
             if hf_param in hf_state_dict:
                 hf_weights = hf_state_dict[hf_param]
-                if ".mlp.experts.down_proj" in hf_param and hf_weights.ndim == 3:
-                    hf_weights = hf_weights.transpose(-1, -2)
                 return hf_weights
             blocks_key = hf_param + "_blocks"
             scales_key = hf_param + "_scales"
             if blocks_key in hf_state_dict and scales_key in hf_state_dict:
                 hf_weights = _dequantize_mxfp4(hf_state_dict[blocks_key], hf_state_dict[scales_key])
-                if ".mlp.experts.down_proj" in hf_param and hf_weights.ndim == 3:
-                    hf_weights = hf_weights.transpose(-1, -2)
                 return hf_weights
             raise KeyError(
                 f"Cannot locate weights for '{hf_param}'. Missing both de-quantized tensor and "
@@ -218,7 +214,8 @@ class GPTOSSBridge(MegatronModelBridge):
 class GPTOSSMLPDownProjMapping(AutoMapping):
     """MLPDownProj for expert weights in GPT-OSS models.
 
-    GPT-OSS stores fc2 weight transposed vs Megatron when using BF16.
+    megatron_to_hf transposes the per-expert weight from Megatron's [in, out]
+    storage to HF's expected [out, in] layout.
     """
 
     is_grouped_export = True


### PR DESCRIPTION
## Problem

NeMo-RL's `grpo-gptoss-20b-8n8g-megatron` regressed with `train/gen_kl_error ≈ 13` (expected < 0.002) and `train/reward ≈ 0` from step 0.

## Root cause

`down_proj` was being double-transposed, causing both Megatron and vLLM to receive incorrect weights:

  import:  W_HF [in, out]  →  W_HF.T [out, in]   (stored in Megatron) ✗
  export:  W_HF.T          →  W_HF   [in, out]    (sent to vLLM)       ✗

Megatron's forward pass requires `down_proj` in `[in, out]` layout, and vLLM expects `[out, in]`. The import transpose caused Megatron to compute with transposed weights (high gen_kl_error), while the export transpose on top made vLLM also receive the wrong layout (zero reward).

## Fix

Remove the import transpose from `maybe_modify_loaded_hf_weight` and restore the export transpose in `GPTOSSMLPDownProjMapping.megatron_to_hf`:

  import:  W_HF [in, out]  →  W_HF   [in, out]   (stored in Megatron) ✓
  export:  W_HF             →  W_HF.T [out, in]   (sent to vLLM)       ✓

## Testing

Fixes NeMo-RL's `grpo-gptoss-20b-8n8g-megatron` nightly test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved efficiency of model weight loading during import by reorganizing transposition logic, enhancing system reliability without affecting user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->