### PR TITLE
[training] fix: report memory on 2nd iteration to better reflect actual peak

### DIFF
--- a/src/megatron/bridge/training/train.py
+++ b/src/megatron/bridge/training/train.py
@@ -508,6 +508,7 @@ def train(
                 history_wct,
                 model,
                 log_max_attention_logit,
+                start_iteration=start_iteration,
             )
 
         if (

--- a/src/megatron/bridge/training/train.py
+++ b/src/megatron/bridge/training/train.py
@@ -508,7 +508,7 @@ def train(
                 history_wct,
                 model,
                 log_max_attention_logit,
-                start_iteration=start_iteration,
+                loaded_iteration=start_iteration,
             )
 
         if (

--- a/src/megatron/bridge/training/utils/train_utils.py
+++ b/src/megatron/bridge/training/utils/train_utils.py
@@ -348,7 +348,7 @@ def training_log(
     history_wct: list,
     model: list[MegatronModule],
     log_max_attention_logit: Optional[float] = None,
-    start_iteration: int = 0,
+    loaded_iteration: int = 0,
 ) -> bool:
     """Log training stats (losses, learning rate, timings, etc.).
 
@@ -834,7 +834,7 @@ def training_log(
                 memory_string += f" | {metric}: {value}"
             if torch.distributed.get_rank(group=pg_collection.dp) == 0:
                 print("[Rank {}] {}".format(torch.distributed.get_rank(), memory_string), flush=True)
-            if iteration > (start_iteration + 1):
+            if iteration > (loaded_iteration + 1):
                 # Make sure the memory after the second iteration is reported
                 # to include optimizer state memory.
                 report_memory_flag = False

--- a/src/megatron/bridge/training/utils/train_utils.py
+++ b/src/megatron/bridge/training/utils/train_utils.py
@@ -348,6 +348,7 @@ def training_log(
     history_wct: list,
     model: list[MegatronModule],
     log_max_attention_logit: Optional[float] = None,
+    start_iteration: int = 0,
 ) -> bool:
     """Log training stats (losses, learning rate, timings, etc.).
 
@@ -833,7 +834,10 @@ def training_log(
                 memory_string += f" | {metric}: {value}"
             if torch.distributed.get_rank(group=pg_collection.dp) == 0:
                 print("[Rank {}] {}".format(torch.distributed.get_rank(), memory_string), flush=True)
-            report_memory_flag = False
+            if iteration > (start_iteration + 1):
+                # Make sure the memory after the second iteration is reported
+                # to include optimizer state memory.
+                report_memory_flag = False
         timers.log(timers_to_log, normalizer=logger_config.log_interval)
 
     return report_memory_flag

--- a/tests/unit_tests/training/utils/test_train_utils.py
+++ b/tests/unit_tests/training/utils/test_train_utils.py
@@ -614,6 +614,114 @@ class TestTrainingLog:
     @mock.patch("megatron.bridge.training.utils.train_utils.reduce_max_stat_across_model_parallel_group")
     @mock.patch("megatron.bridge.training.utils.train_utils.get_world_size_safe")
     @mock.patch("megatron.bridge.training.utils.train_utils.print_rank_last")
+    @mock.patch("megatron.bridge.training.utils.train_utils.report_memory")
+    @mock.patch("megatron.bridge.training.utils.train_utils.report_theoretical_memory")
+    @mock.patch("torch.distributed.get_rank")
+    def test_memory_reporting_kept_on_second_iteration(
+        self,
+        mock_get_rank,
+        mock_report_theoretical,
+        mock_report_memory,
+        mock_print_rank_last,
+        mock_get_world_size,
+        mock_reduce_lr,
+        mock_get_microbatches,
+        mock_config,
+        mock_global_state,
+        loss_dict,
+    ):
+        """Test memory flag is kept on the second iteration to capture optimizer state peak."""
+        total_loss_dict = self.get_fresh_total_loss_dict()
+
+        mock_get_microbatches.return_value = 8
+        mock_reduce_lr.return_value = 1e-4
+        mock_get_world_size.return_value = 32
+        mock_get_rank.return_value = 0
+
+        # Iteration 1 with loaded_iteration=0: flag should be kept
+        mock_global_state.train_state.step = 1
+        mock_config.logger.log_interval = 1
+
+        result = training_log(
+            loss_dict=loss_dict,
+            total_loss_dict=total_loss_dict,
+            learning_rate=1e-4,
+            decoupled_learning_rate=None,
+            loss_scale=1024.0,
+            report_memory_flag=True,
+            skipped_iter=0,
+            grad_norm=2.5,
+            params_norm=15.2,
+            num_zeros_in_grad=0,
+            config=mock_config,
+            global_state=mock_global_state,
+            history_wct=None,
+            model=None,
+            loaded_iteration=0,
+        )
+
+        # Flag should remain True (iteration 1 <= loaded_iteration + 1)
+        assert result is True
+        mock_report_memory.assert_called_once()
+
+    @mock.patch("megatron.bridge.training.utils.train_utils.get_num_microbatches")
+    @mock.patch("megatron.bridge.training.utils.train_utils.reduce_max_stat_across_model_parallel_group")
+    @mock.patch("megatron.bridge.training.utils.train_utils.get_world_size_safe")
+    @mock.patch("megatron.bridge.training.utils.train_utils.print_rank_last")
+    @mock.patch("megatron.bridge.training.utils.train_utils.report_memory")
+    @mock.patch("megatron.bridge.training.utils.train_utils.report_theoretical_memory")
+    @mock.patch("torch.distributed.get_rank")
+    def test_memory_reporting_checkpoint_resume(
+        self,
+        mock_get_rank,
+        mock_report_theoretical,
+        mock_report_memory,
+        mock_print_rank_last,
+        mock_get_world_size,
+        mock_reduce_lr,
+        mock_get_microbatches,
+        mock_config,
+        mock_global_state,
+        loss_dict,
+    ):
+        """Test memory reporting after checkpoint resume reports for 2 iterations."""
+        total_loss_dict = self.get_fresh_total_loss_dict()
+
+        mock_get_microbatches.return_value = 8
+        mock_reduce_lr.return_value = 1e-4
+        mock_get_world_size.return_value = 32
+        mock_get_rank.return_value = 0
+
+        # First iteration after resume from checkpoint at iteration 100
+        mock_global_state.train_state.step = 101
+        mock_config.logger.log_interval = 1
+
+        result = training_log(
+            loss_dict=loss_dict,
+            total_loss_dict=total_loss_dict,
+            learning_rate=1e-4,
+            decoupled_learning_rate=None,
+            loss_scale=1024.0,
+            report_memory_flag=True,
+            skipped_iter=0,
+            grad_norm=2.5,
+            params_norm=15.2,
+            num_zeros_in_grad=0,
+            config=mock_config,
+            global_state=mock_global_state,
+            history_wct=None,
+            model=None,
+            loaded_iteration=100,
+        )
+
+        # Flag should remain True (101 <= 100 + 1)
+        assert result is True
+        mock_report_memory.assert_called_once()
+
+    @mock.patch("megatron.bridge.training.utils.train_utils.get_num_microbatches")
+    @mock.patch("megatron.bridge.training.utils.train_utils.reduce_max_stat_across_model_parallel_group")
+    @mock.patch("megatron.bridge.training.utils.train_utils.get_world_size_safe")
+    @mock.patch("megatron.bridge.training.utils.train_utils.print_rank_last")
     @mock.patch("megatron.bridge.training.utils.train_utils.track_moe_metrics")
     @mock.patch("megatron.bridge.training.utils.train_utils.report_runtime")
     @mock.patch("megatron.bridge.training.utils.train_utils.report_throughput")


### PR DESCRIPTION
## Summary
- Memory usage was only reported after the 1st training iteration, missing true peak memory because Adam optimizer states are lazily initialized during the first `optimizer.step()`
- Changed `report_memory_flag` to stay active until after the 2nd iteration (matching Megatron-LM's behavior), so both pre- and post-optimizer-init memory are captured
- Handles checkpoint resume correctly via `start_iteration`

Fixes https://github.com/NVIDIA-NeMo/Megatron-Bridge/issues/3165

## Test plan
- [x] Verify memory is reported on both iteration 1 and iteration 2 in training logs
- [x] Verify memory is NOT reported on iteration 3+
- [ ] Verify checkpoint resume reports memory on the first two iterations after resume

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved training iteration tracking for more accurate metric correlation during training runs.
  * Enhanced memory reporting behavior in training utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->