### PR TITLE
[ckpt] fix: Add GDN handling to FSDP DTensor preprocessing

### DIFF
--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -104,6 +104,11 @@ try:
 except ImportError:
     HAVE_MEGATRON_FSDP = False
 
+try:
+    from megatron.core.transformer.fsdp_dtensor_checkpoint import handle_gdn_in_state_dict
+except ImportError:
+    handle_gdn_in_state_dict = None
+
 TRACKER_PREFIX = "latest"
 _CHECKPOINT_VERSION = None
 
@@ -1492,6 +1497,21 @@ def preprocess_fsdp_dtensor_state_dict(cfg, raw_state_dict: dict[str, Any], mode
             state_dict["optimizer"] = optimizer_state_dict
         else:
             model_state_dict, _ = handle_swiglu_in_state_dict(model, state_dict["model"], None)
+            state_dict["model"] = model_state_dict
+
+    # Handle GDN (Gated DeltaNet) fused projections — split in_proj / conv1d
+    # into per-component sub-tensors for TP-correct checkpoint resharding.
+    # No-op when handle_gdn_in_state_dict is unavailable (older megatron-core)
+    # or when the model contains no GDN layers.
+    if handle_gdn_in_state_dict is not None:
+        if "optimizer" in state_dict:
+            model_state_dict, optimizer_state_dict = handle_gdn_in_state_dict(
+                model, state_dict["model"], state_dict["optimizer"]
+            )
+            state_dict["model"] = model_state_dict
+            state_dict["optimizer"] = optimizer_state_dict
+        else:
+            model_state_dict, _ = handle_gdn_in_state_dict(model, state_dict["model"], None)
             state_dict["model"] = model_state_dict
 
     # Handle expert parameters for Expert Parallel (DeepSeek-v3 style MoE)

--- a/tests/unit_tests/training/test_checkpointing.py
+++ b/tests/unit_tests/training/test_checkpointing.py
@@ -2612,6 +2612,7 @@ class TestFSDPDTensorFunctionality:
                 patch(
                     "megatron.bridge.training.checkpointing.preprocess_state_dict_for_uneven_dtensor"
                 ) as mock_uneven,
+                patch("megatron.bridge.training.checkpointing.handle_gdn_in_state_dict", None),
             ):
                 raw_state_dict = {"model": {"test_param": torch.tensor([1.0])}}
                 result = preprocess_fsdp_dtensor_state_dict(mock_cfg, raw_state_dict, mock_model)


### PR DESCRIPTION
## Summary
- MCore PR NVIDIA/Megatron-LM#3936 (`76e4daa4`) introduced `handle_gdn_in_state_dict` for splitting GDN (Gated DeltaNet) fused `in_proj`/`conv1d` projections during FSDP checkpoint save
- The mcore bump CI (PR #3171) fails because Bridge's `preprocess_fsdp_dtensor_state_dict` doesn't yet integrate this new function, and the unit test uses a bare `Mock` model that isn't iterable when `handle_gdn_in_state_dict` calls `model.named_modules()`
- Added conditional import with graceful fallback, GDN handling in the preprocessing pipeline, and patched the test

## Test plan
- [ ] Existing `test_preprocess_fsdp_dtensor_state_dict` should pass with bumped mcore
- [ ] Merge this before or alongside mcore bump PR #3171

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Gated DeltaNet (GDN) checkpoint preprocessing to handle both model and optimizer state dictionaries while maintaining backward compatibility with older Megatron-Core versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->