### PR TITLE
Fix check for when parameter does not have 'main_grad' attribute

### DIFF
--- a/src/megatron/bridge/training/utils/train_utils.py
+++ b/src/megatron/bridge/training/utils/train_utils.py
@@ -923,7 +923,7 @@ def report_l2_norm_grad(model: list[MegatronModule]) -> dict:
 
     for model_chunk in model:
         for name, p in model_chunk.named_parameters():
-            if p.main_grad is not None and p.requires_grad:
+            if p.requires_grad and p.main_grad is not None:
                 if f"l2_norm/grad/{name}" not in optimizer_metrics:
                     param_grad_norm = torch.linalg.vector_norm(p.main_grad)
                     optimizer_metrics[f"l2_norm/grad/{name}"] = param_grad_norm


### PR DESCRIPTION
# What does this PR do ?

When, for example, LoRA is used and some layers are frozen and the logger has `logger_config.log_l2_norm_grad_to_tensorboard` , the following exception occurs:

```
Traceback (most recent call last):
  File "/workspace/bionemo/src/bionemo/evo2/run/train.py", line 1053, in <module>
    main()
  File "/workspace/bionemo/src/bionemo/evo2/run/train.py", line 736, in main
    train(args=args)
  File "/workspace/bionemo/src/bionemo/evo2/run/train.py", line 1043, in train
    pretrain(cfg, forward_step_fn)
  File "/workspace/.venv/lib/python3.12/site-packages/megatron/bridge/utils/decorators.py", line 39, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/.venv/lib/python3.12/site-packages/megatron/bridge/training/pretrain.py", line 99, in pretrain
    _pretrain(state=state, forward_step_func=forward_step_func, callback_manager=callback_manager)
  File "/workspace/.venv/lib/python3.12/site-packages/megatron/bridge/training/pretrain.py", line 143, in _pretrain
    train(
  File "/workspace/.venv/lib/python3.12/site-packages/megatron/bridge/training/train.py", line 483, in train
    report_memory_flag = training_log(
                         ^^^^^^^^^^^^^
  File "/workspace/.venv/lib/python3.12/site-packages/megatron/bridge/training/utils/train_utils.py", line 519, in training_log
    l2_report = report_l2_norm_grad(model)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/.venv/lib/python3.12/site-packages/megatron/bridge/training/utils/train_utils.py", line 837, in report_l2_norm_grad
    if p.main_grad is not None and p.requires_grad:
```
# Changelog

- The following the line reverses the check so that once the `parameter.requires_grad = False` the second check is not performed.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
