### PR TITLE
fix(mimo): Scale encoder gradients for heterogeneous DP in multimodule finalization

### DIFF
--- a/src/megatron/bridge/data/loaders.py
+++ b/src/megatron/bridge/data/loaders.py
@@ -175,6 +175,41 @@ def build_train_valid_test_data_loaders(
     Returns:
         A tuple (train_dataloader, valid_dataloader, test_dataloader).
     """
+    # Check for MIMO path
+    from megatron.bridge.data.mimo.base_provider import MimoDatasetProvider
+    from megatron.bridge.models.mimo.mimo_provider import MimoModelProvider
+
+    if isinstance(cfg.model, MimoModelProvider):
+        if not isinstance(cfg.dataset, MimoDatasetProvider):
+            raise ValueError(
+                "MIMO models require cfg.dataset to be a MimoDatasetProvider. "
+                "Use HFMimoDatasetProvider, MockMimoProvider, or a subclass of MimoDatasetProvider."
+            )
+        from megatron.bridge.data.mimo.loaders import build_mimo_data_loaders
+
+        train_samples, valid_samples, test_samples = get_train_valid_test_num_samples(cfg)
+        train_dataloader, valid_dataloader, test_dataloader = build_mimo_data_loaders(
+            cfg=cfg,
+            train_state=train_state,
+            mimo_provider=cfg.dataset,
+            train_samples=train_samples,
+            valid_samples=valid_samples,
+            test_samples=test_samples,
+        )
+
+        # Sync train_state flags across all ranks.
+        # Use all_reduce(MAX) since some ranks may not have loaders in heterogeneous MIMO.
+        do_train = train_dataloader is not None and cfg.train.train_iters > 0
+        do_valid = valid_dataloader is not None and cfg.train.eval_iters > 0
+        do_test = test_dataloader is not None and cfg.train.eval_iters > 0
+        flags = torch.tensor([int(do_train), int(do_valid), int(do_test)], dtype=torch.long, device="cuda")
+        torch.distributed.all_reduce(flags, op=torch.distributed.ReduceOp.MAX)
+        train_state.do_train = flags[0].item()
+        train_state.do_valid = flags[1].item()
+        train_state.do_test = flags[2].item()
+
+        return train_dataloader, valid_dataloader, test_dataloader
+
     (train_dataloader, valid_dataloader, test_dataloader) = (None, None, None)
 
     print_rank_0("> building train, validation, and test datasets ...")

--- a/src/megatron/bridge/data/mimo/__init__.py
+++ b/src/megatron/bridge/data/mimo/__init__.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+"""MIMO multi-encoder data loading utilities."""
+
+from megatron.bridge.data.mimo.dataset import MimoDataset
+from megatron.bridge.data.mimo.collate import mimo_collate_fn
+from megatron.bridge.data.mimo.dp_utils import get_mimo_dp_info
+from megatron.bridge.data.mimo.loaders import build_mimo_data_loaders
+
+# Providers
+from megatron.bridge.data.mimo.base_provider import MimoDatasetProvider
+from megatron.bridge.data.mimo.hf_provider import HFMimoDatasetProvider
+from megatron.bridge.data.mimo.mock_provider import MockMimoProvider
+
+__all__ = [
+    # Core
+    "MimoDataset",
+    "mimo_collate_fn",
+    # Providers (base + implementations)
+    "MimoDatasetProvider",
+    "HFMimoDatasetProvider",
+    "MockMimoProvider",
+    # Utilities
+    "get_mimo_dp_info",
+    "build_mimo_data_loaders",
+]

--- a/src/megatron/bridge/data/mimo/__init__.py
+++ b/src/megatron/bridge/data/mimo/__init__.py
@@ -1,15 +1,15 @@
 # Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
 """MIMO multi-encoder data loading utilities."""
 
-from megatron.bridge.data.mimo.dataset import MimoDataset
-from megatron.bridge.data.mimo.collate import mimo_collate_fn
-from megatron.bridge.data.mimo.dp_utils import get_mimo_dp_info
-from megatron.bridge.data.mimo.loaders import build_mimo_data_loaders
-
 # Providers
 from megatron.bridge.data.mimo.base_provider import MimoDatasetProvider
+from megatron.bridge.data.mimo.collate import mimo_collate_fn
+from megatron.bridge.data.mimo.dataset import MimoDataset
+from megatron.bridge.data.mimo.dp_utils import get_mimo_dp_info, get_mimo_sampling_info, slice_batch_for_mimo
 from megatron.bridge.data.mimo.hf_provider import HFMimoDatasetProvider
+from megatron.bridge.data.mimo.loaders import build_mimo_data_loaders
 from megatron.bridge.data.mimo.mock_provider import MockMimoProvider
+
 
 __all__ = [
     # Core
@@ -21,5 +21,7 @@ __all__ = [
     "MockMimoProvider",
     # Utilities
     "get_mimo_dp_info",
+    "get_mimo_sampling_info",
+    "slice_batch_for_mimo",
     "build_mimo_data_loaders",
 ]

--- a/src/megatron/bridge/data/mimo/base_provider.py
+++ b/src/megatron/bridge/data/mimo/base_provider.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+"""Base class for MIMO dataset providers."""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from dataclasses import dataclass
+from typing import Callable, Optional, Tuple
+
+from torch.utils.data import Dataset
+
+from megatron.bridge.training.config import DatasetBuildContext, DatasetProvider
+
+
+@dataclass(kw_only=True)
+class MimoDatasetProvider(DatasetProvider):
+    """Abstract base class for MIMO dataset providers.
+    
+    All MIMO dataset providers must inherit from this class and implement
+    the required methods. This ensures a consistent interface for MIMO
+    data loading.
+    
+    Required methods:
+        - build_datasets: Build train/valid/test datasets
+        - get_collate_fn: Return the collate function for batching
+    
+    Example:
+        >>> class MyMimoProvider(MimoDatasetProvider):
+        ...     def build_datasets(self, context):
+        ...         # Build and return datasets
+        ...         return train_ds, valid_ds, test_ds
+        ...     
+        ...     def get_collate_fn(self):
+        ...         # Return collate function
+        ...         return my_collate_fn
+    """
+    
+    @abstractmethod
+    def build_datasets(
+        self, context: DatasetBuildContext
+    ) -> Tuple[Optional[Dataset], Optional[Dataset], Optional[Dataset]]:
+        """Build train, validation, and test datasets.
+        
+        Args:
+            context: Build context with sample counts.
+            
+        Returns:
+            Tuple of (train_dataset, valid_dataset, test_dataset).
+            Any element can be None if not needed.
+        """
+        ...
+    
+    @abstractmethod
+    def get_collate_fn(self) -> Callable:
+        """Return the collate function for batching.
+        
+        The collate function should handle the modality_inputs dict
+        and batch them appropriately for the model.
+        
+        Returns:
+            Callable that takes a list of samples and returns a batch dict.
+        """
+        ...

--- a/src/megatron/bridge/data/mimo/collate.py
+++ b/src/megatron/bridge/data/mimo/collate.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+"""Collate functions for MIMO datasets."""
+
+from __future__ import annotations
+
+import warnings
+from typing import Any, Dict, List
+
+import torch
+
+
+def mimo_collate_fn(
+    batch: List[Dict[str, Any]],
+    modality_names: List[str],
+) -> Dict[str, Any]:
+    """Collate function for MIMO datasets.
+    
+    Stacks batch items and organizes modality inputs into a structure
+    suitable for MIMO model forward pass.
+    
+    Args:
+        batch: List of examples from MimoDataset, each containing:
+            - input_ids: Token IDs with placeholder tokens
+            - labels: Labels for causal LM training
+            - attention_mask: Attention mask
+            - position_ids: Position indices
+            - modality_inputs: Dict[str, Dict[str, Any]] with preprocessed inputs
+        modality_names: List of modality names to collate.
+        
+    Returns:
+        Dict containing:
+            - input_ids: (batch, seq) stacked token IDs
+            - labels: (batch, seq) stacked labels
+            - attention_mask: (batch, seq) attention mask
+            - position_ids: (batch, seq) position indices
+            - modality_inputs: Dict[str, Dict[str, Tensor]] with batched modality tensors
+              Each modality's tensors are stacked along batch dimension.
+              
+    Example:
+        >>> batch = [
+        ...     {
+        ...         "input_ids": torch.tensor([32000, 1, 2, 3]),
+        ...         "labels": torch.tensor([32000, 1, 2, 3]),
+        ...         "attention_mask": torch.ones(4),
+        ...         "position_ids": torch.arange(4),
+        ...         "modality_inputs": {
+        ...             "vision": {"pixel_values": torch.randn(3, 224, 224)},
+        ...         },
+        ...     },
+        ...     # ... more examples
+        ... ]
+        >>> collated = mimo_collate_fn(batch, modality_names=["vision"])
+    """
+    if not batch:
+        return {}
+    
+    # Stack standard fields
+    input_ids = torch.stack([item["input_ids"] for item in batch])
+    labels = torch.stack([item["labels"] for item in batch])
+    attention_mask = torch.stack([item["attention_mask"] for item in batch])
+    position_ids = torch.stack([item["position_ids"] for item in batch])
+    loss_mask = torch.stack([item["loss_mask"] for item in batch])
+    
+    # Collate modality inputs
+    modality_inputs: Dict[str, Dict[str, Any]] = {}
+    
+    for modality_name in modality_names:
+        # Collect all tensors for this modality across the batch
+        modality_batch_items = [
+            item.get("modality_inputs", {}).get(modality_name, {})
+            for item in batch
+        ]
+        
+        # Skip if no items have this modality
+        if not any(modality_batch_items):
+            continue
+        
+        # Get all keys from the first non-empty item
+        first_non_empty = next(
+            (item for item in modality_batch_items if item), 
+            {}
+        )
+        
+        if not first_non_empty:
+            continue
+        
+        modality_inputs[modality_name] = {}
+        
+        for key in first_non_empty.keys():
+            values = []
+            for item in modality_batch_items:
+                if key in item:
+                    val = item[key]
+                    if isinstance(val, torch.Tensor):
+                        values.append(val)
+                    else:
+                        # Non-tensor values are kept as lists
+                        values.append(val)
+            
+            if values and isinstance(values[0], torch.Tensor):
+                # Stack tensors along batch dimension
+                try:
+                    modality_inputs[modality_name][key] = torch.stack(values)
+                except RuntimeError as e:
+                    # Tensors have different shapes - keep as list but warn user
+                    warnings.warn(
+                        f"Cannot stack tensors for '{modality_name}.{key}' - shapes differ "
+                        f"across batch. Keeping as list. This may cause issues in model "
+                        f"forward pass. Consider padding inputs to uniform shapes. Error: {e}",
+                        stacklevel=2,
+                    )
+                    modality_inputs[modality_name][key] = values
+            elif values:
+                # Keep non-tensor values as list
+                modality_inputs[modality_name][key] = values
+    
+    return {
+        "input_ids": input_ids,
+        "labels": labels,
+        "loss_mask": loss_mask,
+        "attention_mask": attention_mask,
+        "position_ids": position_ids,
+        "modality_inputs": modality_inputs,
+    }

--- a/src/megatron/bridge/data/mimo/dataset.py
+++ b/src/megatron/bridge/data/mimo/dataset.py
@@ -1,0 +1,244 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+"""Dataset wrapper for MIMO multi-encoder models."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, List, Optional, Union
+
+import torch
+from torch.utils.data import Dataset
+
+
+class MimoDataset(Dataset):
+    """Dataset for MIMO models with per-modality preprocessing.
+    
+    Wraps a data source (HuggingFace dataset or list of examples) and applies
+    per-modality processors to convert raw inputs (images, audio, etc.) into
+    preprocessed tensors (pixel_values, input_features) that encoders consume
+    during the forward pass.
+    
+    Args:
+        examples: Data source - either a HuggingFace Dataset or a list of dicts.
+        processors: Dict mapping modality name to HF processor, e.g.,
+            {"vision": AutoProcessor.from_pretrained("openai/clip-vit-large-patch14")}.
+        tokenizer: Tokenizer for text processing.
+        seq_length: Total sequence length for the model (encoder placeholders + text tokens).
+            Must be greater than sum(encoder_seq_lengths.values()) to leave room for text.
+            Text is truncated to fit: max_text_tokens = seq_length - total_encoder_tokens.
+        special_token_ids: Per-encoder placeholder token IDs, e.g., {"vision": 32000}.
+        encoder_seq_lengths: Per-encoder output sequence lengths, e.g., {"vision": 577}.
+            Determines how many placeholder tokens to insert for each modality.
+            For CLIP ViT-L/14 with 224x224 images, this would be 577 (576 patches + 1 CLS).
+        modality_columns: Dict mapping modality name to column name in dataset,
+            e.g., {"vision": "image", "audio": "audio_path"}.
+        text_column: Column name for text/conversation data. Default: "text".
+        max_samples: Optional limit on dataset size for debugging.
+        preprocess_fn: Optional function to preprocess each example before
+            modality processing.
+        
+    Example:
+        >>> from datasets import load_dataset
+        >>> from transformers import AutoProcessor, AutoTokenizer
+        >>>
+        >>> # Using HuggingFace Dataset
+        >>> hf_ds = load_dataset("liuhaotian/LLaVA-Instruct-150K", split="train")
+        >>> processor = AutoProcessor.from_pretrained("openai/clip-vit-large-patch14")
+        >>> tokenizer = AutoTokenizer.from_pretrained("meta-llama/Llama-2-7b-hf")
+        >>>
+        >>> dataset = MimoDataset(
+        ...     examples=hf_ds,
+        ...     processors={"vision": processor},
+        ...     tokenizer=tokenizer,
+        ...     seq_length=2048,
+        ...     special_token_ids={"vision": 32000},
+        ...     encoder_seq_lengths={"vision": 577},  # CLIP ViT-L/14 output tokens
+        ...     modality_columns={"vision": "image"},
+        ... )
+        >>>
+        >>> # Or using a simple list of dicts for testing/prototyping
+        >>> examples = [
+        ...     {"text": "Describe this image.", "image": "img1.jpg"},
+        ...     {"text": "What do you see?", "image": "img2.jpg"},
+        ... ]
+        >>> dataset = MimoDataset(
+        ...     examples=examples,
+        ...     processors={"vision": processor},
+        ...     tokenizer=tokenizer,
+        ...     seq_length=2048,
+        ...     special_token_ids={"vision": 32000},
+        ...     encoder_seq_lengths={"vision": 577},
+        ...     modality_columns={"vision": "image"},
+        ... )
+    """
+    
+    def __init__(
+        self,
+        examples: Any,  # HF Dataset or List[Dict]
+        processors: Dict[str, Any],
+        tokenizer: Any,
+        seq_length: int,
+        special_token_ids: Dict[str, int],
+        encoder_seq_lengths: Dict[str, int],
+        modality_columns: Dict[str, str],
+        text_column: str = "text",
+        max_samples: Optional[int] = None,
+        preprocess_fn: Optional[Callable[[Dict[str, Any]], Dict[str, Any]]] = None,
+    ) -> None:
+        # Validate encoder tokens fit within seq_length
+        total_encoder_tokens = sum(encoder_seq_lengths.values())
+        if total_encoder_tokens >= seq_length:
+            raise ValueError(
+                f"Total encoder tokens ({total_encoder_tokens}) must be less than "
+                f"seq_length ({seq_length}) to leave room for text tokens. "
+                f"encoder_seq_lengths: {encoder_seq_lengths}"
+            )
+        
+        self.examples = examples
+        self.processors = processors
+        self.tokenizer = tokenizer
+        self.seq_length = seq_length
+        self.special_token_ids = special_token_ids
+        self.encoder_seq_lengths = encoder_seq_lengths
+        self.modality_columns = modality_columns
+        self.text_column = text_column
+        self.preprocess_fn = preprocess_fn
+        
+        # Limit dataset size if requested
+        self._size = len(examples)
+        if max_samples is not None and max_samples > 0:
+            self._size = min(self._size, max_samples)
+    
+    def __len__(self) -> int:
+        return self._size
+    
+    def __getitem__(self, idx: int) -> Dict[str, Any]:
+        """Get a single example with preprocessed modality inputs.
+        
+        Returns:
+            Dict containing:
+                - input_ids: Tokenized text with placeholder tokens
+                - labels: Shifted input_ids for next-token prediction (-100 for masked positions)
+                - loss_mask: Float mask (0.0 for padding/image placeholder targets, 1.0 otherwise)
+                - attention_mask: Attention mask
+                - position_ids: Position indices
+                - modality_inputs: Dict[str, Any] with preprocessed inputs per modality
+                  e.g., {"vision": {"pixel_values": tensor, ...}}
+        """
+        if idx >= self._size:
+            raise IndexError(f"Index {idx} out of range for dataset of size {self._size}")
+        
+        example = self.examples[idx]
+        
+        # Apply custom preprocessing if provided
+        if self.preprocess_fn is not None:
+            example = self.preprocess_fn(example)
+        
+        # Process each modality
+        modality_inputs: Dict[str, Dict[str, Any]] = {}
+        for modality_name, column_name in self.modality_columns.items():
+            if column_name not in example or example[column_name] is None:
+                continue
+                
+            raw_input = example[column_name]
+            processor = self.processors.get(modality_name)
+            
+            if processor is not None:
+                # Apply HF processor to get preprocessed inputs
+                # This typically returns pixel_values for vision, input_features for audio
+                processed = processor(raw_input, return_tensors="pt")
+                # Remove batch dimension added by processor
+                modality_inputs[modality_name] = {
+                    k: v.squeeze(0) if isinstance(v, torch.Tensor) else v
+                    for k, v in processed.items()
+                }
+        
+        # Process text with placeholder tokens
+        text = example.get(self.text_column, "")
+        input_ids = self._tokenize_with_placeholders(text, modality_inputs)
+        
+        # Create attention mask and position ids
+        attention_mask = torch.ones_like(input_ids)
+        position_ids = torch.arange(len(input_ids))
+        
+        # Shift labels by 1 for next-token prediction: label[i] = input_ids[i+1]
+        labels = input_ids.clone()
+        labels[:-1] = input_ids[1:]
+        labels[-1] = -100  # ignore index for the last position
+
+        # Build loss_mask: no loss on padding or encoder placeholder token positions
+        pad_token_id = self.tokenizer.pad_token_id or 0
+        placeholder_ids = set(self.special_token_ids.values())
+
+        # loss_mask[i] = 0 when the target (labels[i]) is padding or a placeholder
+        loss_mask = torch.ones_like(input_ids, dtype=torch.float32)
+        loss_mask[-1] = 0.0  # last position has no valid target
+        for pid in placeholder_ids:
+            loss_mask[labels == pid] = 0.0
+        loss_mask[labels == pad_token_id] = 0.0
+
+        # Also mask labels with -100 so CrossEntropyLoss ignores them
+        labels[loss_mask == 0.0] = -100
+
+        return {
+            "input_ids": input_ids,
+            "labels": labels,
+            "loss_mask": loss_mask,
+            "attention_mask": attention_mask,
+            "position_ids": position_ids,
+            "modality_inputs": modality_inputs,
+        }
+    
+    def _tokenize_with_placeholders(
+        self, 
+        text: str, 
+        modality_inputs: Dict[str, Dict[str, Any]],
+    ) -> torch.Tensor:
+        """Tokenize text and insert placeholder tokens for each modality.
+        
+        For each modality present, inserts N placeholder tokens at the beginning
+        of the sequence, where N = encoder_seq_lengths[modality_name]. This matches
+        the number of embeddings the encoder will produce, enabling 1:1 replacement
+        during the model forward pass.
+        
+        Args:
+            text: Raw text to tokenize.
+            modality_inputs: Dict of preprocessed modality inputs.
+            
+        Returns:
+            Token IDs tensor with placeholder tokens inserted.
+        """
+        # Tokenize the text
+        encoded = self.tokenizer(
+            text,
+            truncation=True,
+            max_length=self.seq_length,
+            return_tensors="pt",
+        )
+        input_ids = encoded["input_ids"].squeeze(0)
+        
+        # Insert placeholder tokens for each modality at the beginning
+        # The order follows the order of modality_inputs (Python 3.7+ dict ordering)
+        prefix_tokens = []
+        for modality_name in modality_inputs.keys():
+            if modality_name in self.special_token_ids:
+                token_id = self.special_token_ids[modality_name]
+                num_tokens = self.encoder_seq_lengths.get(modality_name, 1)
+                prefix_tokens.extend([token_id] * num_tokens)
+        
+        if prefix_tokens:
+            prefix = torch.tensor(prefix_tokens, dtype=input_ids.dtype)
+            # Truncate text tokens to make room for placeholders
+            max_text_len = self.seq_length - len(prefix_tokens)
+            input_ids = input_ids[:max_text_len]
+            input_ids = torch.cat([prefix, input_ids])
+        
+        # Pad or truncate to seq_length
+        if len(input_ids) < self.seq_length:
+            pad_len = self.seq_length - len(input_ids)
+            pad_token_id = self.tokenizer.pad_token_id or 0
+            padding = torch.full((pad_len,), pad_token_id, dtype=input_ids.dtype)
+            input_ids = torch.cat([input_ids, padding])
+        else:
+            input_ids = input_ids[:self.seq_length]
+        
+        return input_ids

--- a/src/megatron/bridge/data/mimo/dp_utils.py
+++ b/src/megatron/bridge/data/mimo/dp_utils.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+"""Data parallel utilities for MIMO data loading."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Dict, Tuple
+
+import torch.distributed as dist
+
+if TYPE_CHECKING:
+    from megatron.core.hyper_comm_grid import HyperCommGrid
+    from megatron.bridge.models.mimo.mimo_config import MimoParallelismConfig
+
+
+def get_mimo_dp_info(
+    mimo_cfg: "MimoParallelismConfig",
+    grids: Dict[str, "HyperCommGrid"],
+) -> Tuple[int, int, bool, str]:
+    """Get DP rank, size, data-loading responsibility, and loader module for MIMO.
+    
+    Determines which module's DP settings to use for data loading based on
+    current rank's participation in heterogeneous deployment.
+    
+    In heterogeneous mode, each rank uses its own module's DP settings.
+    
+    Args:
+        mimo_cfg: MIMO parallelism configuration.
+        grids: Module name to HyperCommGrid mapping from build_hypercomm_grids().
+        
+    Returns:
+        Tuple of (dp_rank, dp_size, needs_data, loader_module):
+        - dp_rank: This rank's position in DP group.
+        - dp_size: Size of DP group for data sharding.
+        - needs_data: Whether this rank needs to load data (first/last PP stage).
+        - loader_module: Which module's DP settings are being used.
+    
+    Example:
+        >>> from megatron.bridge.models.mimo.mimo_builder import build_hypercomm_grids
+        >>> grids = build_hypercomm_grids(mimo_cfg)
+        >>> dp_rank, dp_size, needs_data, loader_module = get_mimo_dp_info(mimo_cfg, grids)
+        >>> if needs_data:
+        ...     # Build data loader with dp_rank and dp_size
+        ...     sampler = DistributedSampler(dataset, num_replicas=dp_size, rank=dp_rank)
+    """
+    current_rank = dist.get_rank()
+
+    # Heterogeneous: find which module this rank belongs to
+    my_grid = None
+    my_module = None
+    for module_name, grid in grids.items():
+        if grid.rank_offset <= current_rank < (grid.rank_offset + grid.size):
+            my_grid = grid
+            my_module = module_name
+            break
+
+    if my_grid is None or my_module is None:
+        # Rank doesn't participate in any module
+        return 0, 1, False, "llm"
+
+    dp_rank = my_grid.get_pg(["dp"]).rank()
+    dp_size = my_grid.get_pg(["dp"]).size()
+
+    pp_group = my_grid.get_pg(["pp"])
+    pp_rank = pp_group.rank()
+    pp_size = pp_group.size()
+
+    if my_module == "llm":
+        needs_data = (pp_rank == 0) or (pp_rank == pp_size - 1)
+    else:
+        needs_data = pp_rank == 0
+
+    return dp_rank, dp_size, needs_data, my_module

--- a/src/megatron/bridge/data/mimo/dp_utils.py
+++ b/src/megatron/bridge/data/mimo/dp_utils.py
@@ -6,9 +6,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Dict, Tuple
 
 import torch.distributed as dist
+from megatron.core.models.mimo.config.role import MIMO_LANGUAGE_MODULE_KEY
+
 
 if TYPE_CHECKING:
     from megatron.core.hyper_comm_grid import HyperCommGrid
+
     from megatron.bridge.models.mimo.mimo_config import MimoParallelismConfig
 
 
@@ -17,23 +20,23 @@ def get_mimo_dp_info(
     grids: Dict[str, "HyperCommGrid"],
 ) -> Tuple[int, int, bool, str]:
     """Get DP rank, size, data-loading responsibility, and loader module for MIMO.
-    
+
     Determines which module's DP settings to use for data loading based on
     current rank's participation in heterogeneous deployment.
-    
+
     In heterogeneous mode, each rank uses its own module's DP settings.
-    
+
     Args:
         mimo_cfg: MIMO parallelism configuration.
         grids: Module name to HyperCommGrid mapping from build_hypercomm_grids().
-        
+
     Returns:
         Tuple of (dp_rank, dp_size, needs_data, loader_module):
         - dp_rank: This rank's position in DP group.
         - dp_size: Size of DP group for data sharding.
         - needs_data: Whether this rank needs to load data (first/last PP stage).
         - loader_module: Which module's DP settings are being used.
-    
+
     Example:
         >>> from megatron.bridge.models.mimo.mimo_builder import build_hypercomm_grids
         >>> grids = build_hypercomm_grids(mimo_cfg)
@@ -55,7 +58,7 @@ def get_mimo_dp_info(
 
     if my_grid is None or my_module is None:
         # Rank doesn't participate in any module
-        return 0, 1, False, "llm"
+        return 0, 1, False, MIMO_LANGUAGE_MODULE_KEY
 
     dp_rank = my_grid.get_pg(["dp"]).rank()
     dp_size = my_grid.get_pg(["dp"]).size()
@@ -64,7 +67,7 @@ def get_mimo_dp_info(
     pp_rank = pp_group.rank()
     pp_size = pp_group.size()
 
-    if my_module == "llm":
+    if my_module == MIMO_LANGUAGE_MODULE_KEY:
         needs_data = (pp_rank == 0) or (pp_rank == pp_size - 1)
     else:
         needs_data = pp_rank == 0

--- a/src/megatron/bridge/data/mimo/dp_utils.py
+++ b/src/megatron/bridge/data/mimo/dp_utils.py
@@ -16,64 +16,96 @@ if TYPE_CHECKING:
     from megatron.bridge.models.mimo.mimo_config import MimoParallelismConfig
 
 
+def _find_rank_module(
+    grids: Dict[str, "HyperCommGrid"],
+) -> Tuple["HyperCommGrid | None", "str | None"]:
+    """Find which module grid the current rank belongs to."""
+    current_rank = dist.get_rank()
+    for module_name, grid in grids.items():
+        if grid.rank_offset <= current_rank < (grid.rank_offset + grid.size):
+            return grid, module_name
+    return None, None
+
+
+def _needs_data_for_module(grid: "HyperCommGrid", module_name: str) -> bool:
+    """Determine if the current rank needs to load data for the given module.
+
+    LLM: first and last PP stage need data (input_ids and labels respectively).
+    Encoders: only the first PP stage needs raw modality inputs.
+    """
+    pp_group = grid.get_pg(["pp"])
+    pp_rank = pp_group.rank()
+    pp_size = pp_group.size()
+    if module_name == MIMO_LANGUAGE_MODULE_KEY:
+        return (pp_rank == 0) or (pp_rank == pp_size - 1)
+    return pp_rank == 0
+
+
 def get_mimo_dp_info(
     mimo_cfg: "MimoParallelismConfig",
     grids: Dict[str, "HyperCommGrid"],
 ) -> Tuple[int, int, bool, str]:
-    """Get DP rank, size, data-loading responsibility, and loader module for MIMO.
+    """Get **module-local** DP rank, size, data-loading flag, and module name.
 
-    Determines which module's DP settings to use for data loading based on
-    current rank's participation in heterogeneous deployment.
+    Returns the DP settings for the module that the current rank participates
+    in.  These are used by :func:`slice_batch_for_mimo` to sub-shard a global
+    micro-batch into per-module DP shards.
 
-    In heterogeneous mode, each rank uses its own module's DP settings.
+    .. note::
+        Do **not** use these values to construct a ``DistributedSampler``.
+        For sampler construction use :func:`get_mimo_sampling_info` instead,
+        which returns settings that keep all data-loading ranks synchronised
+        on the same sample order.
 
     Args:
         mimo_cfg: MIMO parallelism configuration.
         grids: Module name to HyperCommGrid mapping from build_hypercomm_grids().
 
     Returns:
-        Tuple of (dp_rank, dp_size, needs_data, loader_module):
-        - dp_rank: This rank's position in DP group.
-        - dp_size: Size of DP group for data sharding.
-        - needs_data: Whether this rank needs to load data (first/last PP stage).
-        - loader_module: Which module's DP settings are being used.
-
-    Example:
-        >>> from megatron.bridge.models.mimo.mimo_builder import build_hypercomm_grids
-        >>> grids = build_hypercomm_grids(mimo_cfg)
-        >>> dp_rank, dp_size, needs_data, loader_module = get_mimo_dp_info(mimo_cfg, grids)
-        >>> if needs_data:
-        ...     # Build data loader with dp_rank and dp_size
-        ...     sampler = DistributedSampler(dataset, num_replicas=dp_size, rank=dp_rank)
+        Tuple of (dp_rank, dp_size, needs_data, loader_module).
     """
-    current_rank = dist.get_rank()
-
-    # Heterogeneous: find which module this rank belongs to
-    my_grid = None
-    my_module = None
-    for module_name, grid in grids.items():
-        if grid.rank_offset <= current_rank < (grid.rank_offset + grid.size):
-            my_grid = grid
-            my_module = module_name
-            break
-
+    my_grid, my_module = _find_rank_module(grids)
     if my_grid is None or my_module is None:
-        # Rank doesn't participate in any module
         return 0, 1, False, MIMO_LANGUAGE_MODULE_KEY
 
     dp_rank = my_grid.get_pg(["dp"]).rank()
     dp_size = my_grid.get_pg(["dp"]).size()
-
-    pp_group = my_grid.get_pg(["pp"])
-    pp_rank = pp_group.rank()
-    pp_size = pp_group.size()
-
-    if my_module == MIMO_LANGUAGE_MODULE_KEY:
-        needs_data = (pp_rank == 0) or (pp_rank == pp_size - 1)
-    else:
-        needs_data = pp_rank == 0
-
+    needs_data = _needs_data_for_module(my_grid, my_module)
     return dp_rank, dp_size, needs_data, my_module
+
+
+def get_mimo_sampling_info(
+    mimo_cfg: "MimoParallelismConfig",
+    grids: Dict[str, "HyperCommGrid"],
+) -> Tuple[int, int, bool]:
+    """Get sampler DP rank, size, and data-loading flag for MIMO.
+
+    In heterogeneous MIMO, modules may have different DP sizes.  The data
+    loader must give every data-loading rank the **same global micro-batch**
+    so that :func:`slice_batch_for_mimo` (called in the forward step) can
+    sub-shard it consistently with the :class:`BridgeCommunicator` fan-in /
+    fan-out routing.
+
+    This function therefore returns ``dp_size=1, dp_rank=0`` for all ranks,
+    disabling DP sharding at the sampler level.  Per-module DP sharding is
+    deferred to :func:`slice_batch_for_mimo`.
+
+    Args:
+        mimo_cfg: MIMO parallelism configuration.
+        grids: Module name to HyperCommGrid mapping.
+
+    Returns:
+        Tuple of (sampler_dp_rank, sampler_dp_size, needs_data).
+    """
+    my_grid, my_module = _find_rank_module(grids)
+    if my_grid is None or my_module is None:
+        return 0, 1, False
+
+    needs_data = _needs_data_for_module(my_grid, my_module)
+    # All data-loading ranks use the same sampler settings so they load
+    # identical global micro-batches.  Module-local DP slicing happens later
+    # in forward_step via slice_batch_for_mimo.
+    return 0, 1, needs_data
 
 
 def slice_batch_for_mimo(
@@ -81,31 +113,33 @@ def slice_batch_for_mimo(
     dp_rank: int,
     dp_size: int,
 ) -> Dict[str, Any]:
-    """Slice a global batch for this rank's DP shard.
-    
-    Takes a global batch (same data on all ranks) and returns the portion
-    that this rank should process based on its DP rank and size.
-    
-    Used by both training and evaluation to ensure consistent data sharding
-    across heterogeneous MIMO modules.
-    
+    """Slice a global micro-batch for this rank's module-local DP shard.
+
+    All data-loading ranks receive the same global micro-batch (the sampler
+    uses ``dp_size=1``).  This function contiguously slices it so that each
+    module-local DP replica processes the correct subset.  The slicing is
+    contiguous to match the :class:`BridgeCommunicator`'s batch-dimension
+    split / concatenate logic for fan-out and fan-in routing.
+
+    Handles nested dicts (e.g. ``modality_inputs``) by recursing.
+
     Args:
         batch: Global batch dictionary with tensors of shape [global_batch, ...].
-        dp_rank: This rank's position in its DP group.
-        dp_size: Total size of the DP group.
-        
+            May contain nested dicts (e.g. modality_inputs → encoder → kwargs).
+        dp_rank: This rank's position in its **module-local** DP group.
+        dp_size: Size of the module-local DP group.
+
     Returns:
-        Dict[str, Any]: Sliced batch with tensors of shape [local_batch, ...].
-        
+        Dict with tensors sliced to shape [global_batch // dp_size, ...].
+
     Example:
-        >>> # Global batch of 16 samples, DP size 4, this is DP rank 1
-        >>> global_batch = {'tokens': torch.randn(16, 2048)}
-        >>> local_batch = slice_batch_for_mimo(global_batch, dp_rank=1, dp_size=4)
+        >>> global_batch = {'tokens': torch.randn(12, 2048)}
+        >>> local_batch = slice_batch_for_mimo(global_batch, dp_rank=1, dp_size=3)
         >>> local_batch['tokens'].shape  # torch.Size([4, 2048])
     """
     if dp_size == 1:
         return batch
-    
+
     sliced = {}
     for key, value in batch.items():
         if isinstance(value, torch.Tensor):
@@ -114,14 +148,17 @@ def slice_batch_for_mimo(
             if batch_size % dp_size != 0:
                 raise ValueError(
                     f"Batch size {batch_size} for key '{key}' is not divisible "
-                    f"by DP size {dp_size}"
+                    f"by DP size {dp_size}. Ensure micro_batch_size is divisible "
+                    f"by every module's data_parallel_size."
                 )
             local_batch_size = batch_size // dp_size
             start_idx = dp_rank * local_batch_size
             end_idx = start_idx + local_batch_size
             sliced[key] = value[start_idx:end_idx]
+        elif isinstance(value, dict):
+            # Recurse into nested dicts (e.g. modality_inputs)
+            sliced[key] = slice_batch_for_mimo(value, dp_rank, dp_size)
         elif isinstance(value, list) and len(value) > 0:
-            # Handle list values (e.g., metadata lists)
             list_len = len(value)
             if list_len % dp_size == 0:
                 local_len = list_len // dp_size
@@ -134,5 +171,5 @@ def slice_batch_for_mimo(
         else:
             # Keep non-tensor, non-list values as-is
             sliced[key] = value
-    
+
     return sliced

--- a/src/megatron/bridge/data/mimo/dp_utils.py
+++ b/src/megatron/bridge/data/mimo/dp_utils.py
@@ -3,8 +3,9 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Dict, Tuple
+from typing import TYPE_CHECKING, Any, Dict, Tuple
 
+import torch
 import torch.distributed as dist
 from megatron.core.models.mimo.config.role import MIMO_LANGUAGE_MODULE_KEY
 
@@ -73,3 +74,65 @@ def get_mimo_dp_info(
         needs_data = pp_rank == 0
 
     return dp_rank, dp_size, needs_data, my_module
+
+
+def slice_batch_for_mimo(
+    batch: Dict[str, Any],
+    dp_rank: int,
+    dp_size: int,
+) -> Dict[str, Any]:
+    """Slice a global batch for this rank's DP shard.
+    
+    Takes a global batch (same data on all ranks) and returns the portion
+    that this rank should process based on its DP rank and size.
+    
+    Used by both training and evaluation to ensure consistent data sharding
+    across heterogeneous MIMO modules.
+    
+    Args:
+        batch: Global batch dictionary with tensors of shape [global_batch, ...].
+        dp_rank: This rank's position in its DP group.
+        dp_size: Total size of the DP group.
+        
+    Returns:
+        Dict[str, Any]: Sliced batch with tensors of shape [local_batch, ...].
+        
+    Example:
+        >>> # Global batch of 16 samples, DP size 4, this is DP rank 1
+        >>> global_batch = {'tokens': torch.randn(16, 2048)}
+        >>> local_batch = slice_batch_for_mimo(global_batch, dp_rank=1, dp_size=4)
+        >>> local_batch['tokens'].shape  # torch.Size([4, 2048])
+    """
+    if dp_size == 1:
+        return batch
+    
+    sliced = {}
+    for key, value in batch.items():
+        if isinstance(value, torch.Tensor):
+            # Slice along batch dimension (dim=0)
+            batch_size = value.size(0)
+            if batch_size % dp_size != 0:
+                raise ValueError(
+                    f"Batch size {batch_size} for key '{key}' is not divisible "
+                    f"by DP size {dp_size}"
+                )
+            local_batch_size = batch_size // dp_size
+            start_idx = dp_rank * local_batch_size
+            end_idx = start_idx + local_batch_size
+            sliced[key] = value[start_idx:end_idx]
+        elif isinstance(value, list) and len(value) > 0:
+            # Handle list values (e.g., metadata lists)
+            list_len = len(value)
+            if list_len % dp_size == 0:
+                local_len = list_len // dp_size
+                start_idx = dp_rank * local_len
+                end_idx = start_idx + local_len
+                sliced[key] = value[start_idx:end_idx]
+            else:
+                # Keep as-is if not evenly divisible (global metadata)
+                sliced[key] = value
+        else:
+            # Keep non-tensor, non-list values as-is
+            sliced[key] = value
+    
+    return sliced

--- a/src/megatron/bridge/data/mimo/hf_provider.py
+++ b/src/megatron/bridge/data/mimo/hf_provider.py
@@ -1,0 +1,206 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+"""HuggingFace dataset provider for MIMO multi-encoder models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from functools import partial
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+
+from datasets import load_dataset
+from torch.utils.data import Dataset
+from transformers import AutoProcessor, AutoTokenizer
+
+from megatron.bridge.data.mimo.base_provider import MimoDatasetProvider
+from megatron.bridge.data.mimo.collate import mimo_collate_fn
+from megatron.bridge.data.mimo.dataset import MimoDataset
+from megatron.bridge.models.hf_pretrained.utils import is_safe_repo
+from megatron.bridge.training.config import DatasetBuildContext
+
+
+@dataclass(kw_only=True)
+class HFMimoDatasetProvider(MimoDatasetProvider):
+    """DatasetProvider for MIMO models using HuggingFace datasets.
+    
+    Loads datasets from HuggingFace Hub and applies per-modality processors
+    to convert raw inputs (images, audio, text) into preprocessed tensors
+    that MIMO encoder modules consume during training.
+    
+    For testing with synthetic data, use MockMimoProvider instead.
+    
+    Args:
+        seq_length: Total sequence length for the model (encoder placeholders + text tokens).
+            Must be greater than sum(encoder_seq_lengths.values()) to leave room for text.
+            Text is truncated to fit: max_text_tokens = seq_length - total_encoder_tokens.
+        hf_dataset_path: HuggingFace dataset identifier, e.g., "liuhaotian/LLaVA-Instruct-150K".
+        hf_dataset_name: Optional dataset configuration name.
+        hf_tokenizer_path: HuggingFace tokenizer identifier.
+        processor_paths: Per-modality processor paths, e.g.,
+            {"vision": "openai/clip-vit-large-patch14"}.
+        special_token_ids: Per-encoder placeholder token IDs, e.g., {"vision": 32000}.
+        encoder_seq_lengths: Per-encoder output sequence lengths, e.g., {"vision": 577}.
+            Determines how many placeholder tokens to insert for each modality.
+        modality_columns: Map modality name to dataset column, e.g., {"vision": "image"}.
+        text_column: Column name for text data. Default: "text".
+        train_split: Dataset split for training. Default: "train".
+        valid_split: Dataset split for validation. Default: "validation".
+        test_split: Dataset split for testing. Default: "test".
+        trust_remote_code: Whether to trust remote code for HF models/processors.
+        
+    Example:
+        >>> provider = HFMimoDatasetProvider(
+        ...     seq_length=2048,
+        ...     hf_dataset_path="liuhaotian/LLaVA-Instruct-150K",
+        ...     hf_tokenizer_path="meta-llama/Llama-2-7b-hf",
+        ...     processor_paths={"vision": "openai/clip-vit-large-patch14"},
+        ...     special_token_ids={"vision": 32000},
+        ...     encoder_seq_lengths={"vision": 577},  # CLIP ViT-L/14 output tokens
+        ...     modality_columns={"vision": "image"},
+        ... )
+        >>> context = DatasetBuildContext(train_samples=10000, valid_samples=1000, test_samples=1000)
+        >>> train_ds, valid_ds, test_ds = provider.build_datasets(context)
+    """
+    
+    seq_length: int
+    hf_dataset_path: str
+    hf_dataset_name: Optional[str] = None
+    hf_tokenizer_path: str = ""
+    processor_paths: Dict[str, str] = field(default_factory=dict)
+    special_token_ids: Dict[str, int] = field(default_factory=dict)
+    encoder_seq_lengths: Dict[str, int] = field(default_factory=dict)
+    modality_columns: Dict[str, str] = field(default_factory=dict)
+    text_column: str = "text"
+    train_split: str = "train"
+    valid_split: str = "validation"
+    test_split: str = "test"
+    trust_remote_code: Optional[bool] = None
+    hf_data_files: Optional[Union[str, List[str]]] = None
+    preprocess_fn: Optional[Callable] = None
+
+    # Cached processors and tokenizer (loaded once)
+    _processors: Optional[Dict[str, Any]] = field(default=None, repr=False)
+    _tokenizer: Optional[Any] = field(default=None, repr=False)
+    
+    def _load_processors(self) -> Dict[str, Any]:
+        """Load HuggingFace processors for each modality."""
+        if self._processors is not None:
+            return self._processors
+
+        processors = {}
+        for modality_name, processor_path in self.processor_paths.items():
+            processors[modality_name] = AutoProcessor.from_pretrained(
+                processor_path,
+                trust_remote_code=is_safe_repo(
+                    trust_remote_code=self.trust_remote_code,
+                    hf_path=processor_path,
+                ),
+            )
+        
+        # Store for reuse
+        object.__setattr__(self, "_processors", processors)
+        return processors
+    
+    def _load_tokenizer(self) -> Any:
+        """Load HuggingFace tokenizer."""
+        if self._tokenizer is not None:
+            return self._tokenizer
+
+        tokenizer = AutoTokenizer.from_pretrained(
+            self.hf_tokenizer_path,
+            trust_remote_code=is_safe_repo(
+                trust_remote_code=self.trust_remote_code,
+                hf_path=self.hf_tokenizer_path,
+            ),
+        )
+        
+        # Ensure pad token is set
+        if tokenizer.pad_token is None:
+            tokenizer.pad_token = tokenizer.eos_token
+        
+        # Store for reuse
+        object.__setattr__(self, "_tokenizer", tokenizer)
+        return tokenizer
+    
+    def _load_hf_dataset(self, split: str) -> Any:
+        """Load a HuggingFace dataset split."""
+        try:
+            dataset = load_dataset(
+                self.hf_dataset_path,
+                name=self.hf_dataset_name,
+                data_files=self.hf_data_files,
+                split=split,
+                trust_remote_code=is_safe_repo(
+                    trust_remote_code=self.trust_remote_code,
+                    hf_path=self.hf_dataset_path,
+                ),
+            )
+            return dataset
+        except ValueError:
+            # Split doesn't exist
+            return None
+    
+    def _build_split_dataset(
+        self,
+        split: str,
+        target_samples: int,
+        processors: Dict[str, Any],
+        tokenizer: Any,
+    ) -> Optional[MimoDataset]:
+        """Build dataset for a single split."""
+        if target_samples <= 0:
+            return None
+        
+        hf_dataset = self._load_hf_dataset(split)
+        if hf_dataset is None:
+            return None
+        
+        return MimoDataset(
+            examples=hf_dataset,
+            processors=processors,
+            tokenizer=tokenizer,
+            seq_length=self.seq_length,
+            special_token_ids=self.special_token_ids,
+            encoder_seq_lengths=self.encoder_seq_lengths,
+            modality_columns=self.modality_columns,
+            text_column=self.text_column,
+            max_samples=target_samples,
+            preprocess_fn=self.preprocess_fn,
+        )
+    
+    def build_datasets(
+        self, context: DatasetBuildContext
+    ) -> Tuple[Optional[Dataset], Optional[Dataset], Optional[Dataset]]:
+        """Build train, validation, and test datasets.
+        
+        Args:
+            context: Build context with sample counts.
+            
+        Returns:
+            Tuple of (train_dataset, valid_dataset, test_dataset).
+            Any element can be None if split doesn't exist or sample count is 0.
+        """
+        processors = self._load_processors()
+        tokenizer = self._load_tokenizer()
+        
+        train_ds = self._build_split_dataset(
+            self.train_split, context.train_samples, processors, tokenizer
+        )
+        valid_ds = self._build_split_dataset(
+            self.valid_split, context.valid_samples, processors, tokenizer
+        )
+        test_ds = self._build_split_dataset(
+            self.test_split, context.test_samples, processors, tokenizer
+        )
+        
+        return train_ds, valid_ds, test_ds
+    
+    def get_collate_fn(self) -> Callable:
+        """Return collate function for MIMO datasets.
+        
+        Returns:
+            Partial function of mimo_collate_fn with modality names pre-filled.
+        """
+        return partial(
+            mimo_collate_fn,
+            modality_names=list(self.modality_columns.keys()),
+        )

--- a/src/megatron/bridge/data/mimo/loaders.py
+++ b/src/megatron/bridge/data/mimo/loaders.py
@@ -1,0 +1,130 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+"""Data loader utilities for MIMO training."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Dict, Optional, Tuple
+
+import torch
+from torch.utils.data import DataLoader
+
+from megatron.bridge.data.mimo.dp_utils import get_mimo_dp_info
+from megatron.bridge.training.config import DatasetBuildContext, DatasetProvider
+from megatron.bridge.utils.common_utils import print_rank_0
+
+if TYPE_CHECKING:
+    from megatron.bridge.training.config import ConfigContainer
+    from megatron.bridge.training.state import TrainState
+
+
+def build_mimo_data_loaders(
+    cfg: "ConfigContainer",
+    train_state: "TrainState",
+    mimo_provider: DatasetProvider,
+    train_samples: int,
+    valid_samples: int,
+    test_samples: int,
+) -> Tuple[Optional[DataLoader], Optional[DataLoader], Optional[DataLoader]]:
+    """Build MIMO data loaders with per-module DP settings.
+    
+    Creates data loaders with DP-aware sampling based on the MIMO parallelism
+    configuration. Only ranks that need data (first/last PP stage) will get
+    non-None loaders.
+    
+    Args:
+        cfg: Configuration container with MimoModelProvider as cfg.model.
+        train_state: Current training state.
+        mimo_provider: MIMO dataset provider (e.g., MockMimoDatasetProvider)
+            with get_collate_fn() method.
+        train_samples: Number of training samples.
+        valid_samples: Number of validation samples.
+        test_samples: Number of test samples.
+        
+    Returns:
+        Tuple of (train_loader, valid_loader, test_loader).
+        Returns (None, None, None) if this rank doesn't need data.
+        
+    Raises:
+        ValueError: If cfg.model is not MimoModelProvider or mimo_parallelism_config is None.
+    
+    Example:
+        >>> from megatron.bridge.data.mimo import MockMimoProvider, build_mimo_data_loaders
+        >>> provider = MockMimoProvider(
+        ...     seq_length=2048,
+        ...     processor_paths={"vision": "openai/clip-vit-large-patch14"},
+        ...     tokenizer_path="meta-llama/Llama-2-7b-hf",
+        ...     special_token_ids={"vision": 32000},
+        ...     modality_configs={"vision": {"type": "image", "width": 224, "height": 224}},
+        ... )
+        >>> train_loader, valid_loader, test_loader = build_mimo_data_loaders(
+        ...     cfg, train_state, provider,
+        ...     train_samples=10000, valid_samples=1000, test_samples=1000,
+        ... )
+    """
+    from megatron.bridge.models.mimo.mimo_provider import MimoModelProvider
+    
+    if not isinstance(cfg.model, MimoModelProvider):
+        raise ValueError("cfg.model must be MimoModelProvider for MIMO data loading.")
+    
+    if cfg.model.mimo_parallelism_config is None:
+        raise ValueError("mimo_parallelism_config must be set for MIMO data loading.")
+    
+    if cfg.model._grids is None:
+        raise ValueError(
+            "MimoModelProvider._grids is None. "
+            "Ensure build_model() is called before building data loaders."
+        )
+
+    print_rank_0("> building MIMO train, validation, and test datasets ...")
+
+    # Use cached grids from build_model()
+    grids = cfg.model._grids
+    
+    dp_rank, dp_size, needs_data, loader_module = get_mimo_dp_info(
+        cfg.model.mimo_parallelism_config, grids
+    )
+
+    if not needs_data:
+        return None, None, None
+
+    # Build datasets
+    context = DatasetBuildContext(
+        train_samples=train_samples,
+        valid_samples=valid_samples,
+        test_samples=test_samples,
+        tokenizer=None,
+    )
+    train_ds, valid_ds, test_ds = mimo_provider.build_datasets(context)
+
+    print_rank_0(f"  Built datasets: train={len(train_ds) if train_ds else 0}, "
+                 f"valid={len(valid_ds) if valid_ds else 0}, "
+                 f"test={len(test_ds) if test_ds else 0}")
+
+    # Build data loaders with DP-aware sampling
+    collate_fn = mimo_provider.get_collate_fn()
+    micro_batch_size = cfg.train.micro_batch_size
+    
+    def _make_loader(dataset, shuffle: bool = True) -> Optional[DataLoader]:
+        if dataset is None:
+            return None
+        sampler = torch.utils.data.DistributedSampler(
+            dataset,
+            num_replicas=dp_size,
+            rank=dp_rank,
+            shuffle=shuffle,
+        )
+        return DataLoader(
+            dataset,
+            batch_size=micro_batch_size,
+            sampler=sampler,
+            num_workers=mimo_provider.num_workers,
+            collate_fn=collate_fn,
+            pin_memory=mimo_provider.pin_memory,
+            drop_last=mimo_provider.drop_last,
+        )
+
+    train_loader = _make_loader(train_ds, shuffle=True)
+    valid_loader = _make_loader(valid_ds, shuffle=False)
+    test_loader = _make_loader(test_ds, shuffle=False)
+    
+    return train_loader, valid_loader, test_loader

--- a/src/megatron/bridge/data/mimo/loaders.py
+++ b/src/megatron/bridge/data/mimo/loaders.py
@@ -3,14 +3,15 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Dict, Optional, Tuple
+from typing import TYPE_CHECKING, Optional, Tuple
 
 import torch
 from torch.utils.data import DataLoader
 
-from megatron.bridge.data.mimo.dp_utils import get_mimo_dp_info
+from megatron.bridge.data.mimo.dp_utils import get_mimo_sampling_info
 from megatron.bridge.training.config import DatasetBuildContext, DatasetProvider
 from megatron.bridge.utils.common_utils import print_rank_0
+
 
 if TYPE_CHECKING:
     from megatron.bridge.training.config import ConfigContainer
@@ -25,12 +26,14 @@ def build_mimo_data_loaders(
     valid_samples: int,
     test_samples: int,
 ) -> Tuple[Optional[DataLoader], Optional[DataLoader], Optional[DataLoader]]:
-    """Build MIMO data loaders with per-module DP settings.
-    
-    Creates data loaders with DP-aware sampling based on the MIMO parallelism
-    configuration. Only ranks that need data (first/last PP stage) will get
-    non-None loaders.
-    
+    """Build MIMO data loaders with globally consistent sampling.
+
+    All data-loading ranks receive identical global micro-batches (the sampler
+    uses dp_size=1).  Per-module DP sub-sharding is deferred to
+    ``slice_batch_for_mimo`` in the forward step, ensuring consistency with
+    the BridgeCommunicator's fan-in/fan-out routing for asymmetric DP configs.
+    Only ranks that need data (first/last PP stage) will get non-None loaders.
+
     Args:
         cfg: Configuration container with MimoModelProvider as cfg.model.
         train_state: Current training state.
@@ -39,14 +42,14 @@ def build_mimo_data_loaders(
         train_samples: Number of training samples.
         valid_samples: Number of validation samples.
         test_samples: Number of test samples.
-        
+
     Returns:
         Tuple of (train_loader, valid_loader, test_loader).
         Returns (None, None, None) if this rank doesn't need data.
-        
+
     Raises:
         ValueError: If cfg.model is not MimoModelProvider or mimo_parallelism_config is None.
-    
+
     Example:
         >>> from megatron.bridge.data.mimo import MockMimoProvider, build_mimo_data_loaders
         >>> provider = MockMimoProvider(
@@ -62,27 +65,36 @@ def build_mimo_data_loaders(
         ... )
     """
     from megatron.bridge.models.mimo.mimo_provider import MimoModelProvider
-    
+
     if not isinstance(cfg.model, MimoModelProvider):
         raise ValueError("cfg.model must be MimoModelProvider for MIMO data loading.")
-    
+
     if cfg.model.mimo_parallelism_config is None:
         raise ValueError("mimo_parallelism_config must be set for MIMO data loading.")
-    
+
     if cfg.model._grids is None:
         raise ValueError(
-            "MimoModelProvider._grids is None. "
-            "Ensure build_model() is called before building data loaders."
+            "MimoModelProvider._grids is None. Ensure build_model() is called before building data loaders."
+        )
+
+    # Validate that micro_batch_size is divisible by every module's DP size.
+    # slice_batch_for_mimo divides the micro-batch contiguously by the module's
+    # DP size in forward_step; a non-divisible MBS would leave a remainder.
+    micro_batch_size = cfg.train.micro_batch_size
+    for mod_name, mod_cfg in cfg.model.mimo_parallelism_config.module_parallelisms.items():
+        dp = mod_cfg.data_parallel_size
+        assert micro_batch_size % dp == 0, (
+            f"micro_batch_size ({micro_batch_size}) must be divisible by "
+            f"data_parallel_size ({dp}) of module '{mod_name}'. "
+            f"slice_batch_for_mimo requires an evenly divisible micro-batch."
         )
 
     print_rank_0("> building MIMO train, validation, and test datasets ...")
 
     # Use cached grids from build_model()
     grids = cfg.model._grids
-    
-    dp_rank, dp_size, needs_data, loader_module = get_mimo_dp_info(
-        cfg.model.mimo_parallelism_config, grids
-    )
+
+    sampler_dp_rank, sampler_dp_size, needs_data = get_mimo_sampling_info(cfg.model.mimo_parallelism_config, grids)
 
     if not needs_data:
         return None, None, None
@@ -96,21 +108,25 @@ def build_mimo_data_loaders(
     )
     train_ds, valid_ds, test_ds = mimo_provider.build_datasets(context)
 
-    print_rank_0(f"  Built datasets: train={len(train_ds) if train_ds else 0}, "
-                 f"valid={len(valid_ds) if valid_ds else 0}, "
-                 f"test={len(test_ds) if test_ds else 0}")
+    print_rank_0(
+        f"  Built datasets: train={len(train_ds) if train_ds else 0}, "
+        f"valid={len(valid_ds) if valid_ds else 0}, "
+        f"test={len(test_ds) if test_ds else 0}"
+    )
 
-    # Build data loaders with DP-aware sampling
+    # Build data loaders with globally consistent sampling.
+    # sampler_dp_size=1 so all data-loading ranks see the same batches.
+    # Per-module DP sub-sharding is done later by slice_batch_for_mimo.
     collate_fn = mimo_provider.get_collate_fn()
     micro_batch_size = cfg.train.micro_batch_size
-    
+
     def _make_loader(dataset, shuffle: bool = True) -> Optional[DataLoader]:
         if dataset is None:
             return None
         sampler = torch.utils.data.DistributedSampler(
             dataset,
-            num_replicas=dp_size,
-            rank=dp_rank,
+            num_replicas=sampler_dp_size,
+            rank=sampler_dp_rank,
             shuffle=shuffle,
         )
         return DataLoader(
@@ -126,5 +142,5 @@ def build_mimo_data_loaders(
     train_loader = _make_loader(train_ds, shuffle=True)
     valid_loader = _make_loader(valid_ds, shuffle=False)
     test_loader = _make_loader(test_ds, shuffle=False)
-    
+
     return train_loader, valid_loader, test_loader

--- a/src/megatron/bridge/data/mimo/mock_provider.py
+++ b/src/megatron/bridge/data/mimo/mock_provider.py
@@ -1,0 +1,249 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+"""Mock dataset provider for MIMO testing with synthetic multimodal data.
+
+This module produces synthetic multimodal inputs (random images, audio, etc.)
+that are compatible with HuggingFace processors. It follows the same pattern
+as vlm_datasets/mock_provider.py - generating fake input data but using real
+processors for preprocessing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from functools import partial
+from typing import Any, Callable, Dict, List, Literal, Optional, Tuple
+
+import numpy as np
+from PIL import Image
+
+from megatron.bridge.data.mimo.base_provider import MimoDatasetProvider
+from megatron.bridge.data.mimo.dataset import MimoDataset
+from megatron.bridge.models.hf_pretrained.utils import is_safe_repo
+from megatron.bridge.training.config import DatasetBuildContext
+
+
+def _generate_random_image(
+    width: int, height: int, rng: np.random.Generator
+) -> Image.Image:
+    """Generate a random RGB image."""
+    pixels = rng.integers(low=0, high=256, size=(height, width, 3), dtype=np.uint8)
+    return Image.fromarray(pixels, mode="RGB")
+
+
+def _generate_random_audio(
+    duration_sec: float, sample_rate: int, rng: np.random.Generator
+) -> np.ndarray:
+    """Generate random audio waveform."""
+    num_samples = int(duration_sec * sample_rate)
+    # Generate random float32 audio in [-1, 1]
+    return rng.uniform(-1.0, 1.0, size=(num_samples,)).astype(np.float32)
+
+
+@dataclass(kw_only=True)
+class MockMimoProvider(MimoDatasetProvider):
+    """DatasetProvider for mock MIMO datasets with synthetic multimodal data.
+    
+    Generates synthetic multimodal inputs (random images, audio, etc.) and uses
+    real HuggingFace processors to preprocess them. This tests the full data
+    pipeline without requiring real datasets.
+    
+    Follows the same pattern as vlm_datasets/MockVLMConversationProvider.
+    
+    Args:
+        seq_length: Total sequence length for the model (encoder placeholders + text tokens).
+            Must be greater than sum(encoder_seq_lengths.values()) to leave room for text.
+        processor_paths: Per-modality HF processor paths, e.g.,
+            {"vision": "openai/clip-vit-large-patch14"}.
+        tokenizer_path: HuggingFace tokenizer identifier.
+        special_token_ids: Per-encoder placeholder token IDs, e.g., {"vision": 32000}.
+        encoder_seq_lengths: Per-encoder output sequence lengths, e.g., {"vision": 577}.
+            Determines how many placeholder tokens to insert for each modality.
+        modality_configs: Per-modality generation config, e.g.,
+            {"vision": {"type": "image", "width": 224, "height": 224}}.
+        text_prompt: Default text prompt for synthetic examples.
+        random_seed: Seed for random generation.
+        
+    Example:
+        >>> provider = MockMimoProvider(
+        ...     seq_length=2048,
+        ...     processor_paths={"vision": "openai/clip-vit-large-patch14"},
+        ...     tokenizer_path="meta-llama/Llama-2-7b-hf",
+        ...     special_token_ids={"vision": 32000},
+        ...     encoder_seq_lengths={"vision": 577},  # CLIP ViT-L/14 output tokens
+        ...     modality_configs={"vision": {"type": "image", "width": 224, "height": 224}},
+        ... )
+        >>> context = DatasetBuildContext(train_samples=1000, valid_samples=100, test_samples=100)
+        >>> train_ds, valid_ds, test_ds = provider.build_datasets(context)
+    """
+    
+    seq_length: int
+    processor_paths: Dict[str, str] = field(default_factory=dict)
+    tokenizer_path: str = ""
+    special_token_ids: Dict[str, int] = field(default_factory=dict)
+    encoder_seq_lengths: Dict[str, int] = field(default_factory=dict)
+    modality_configs: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    text_prompt: str = "Describe this input."
+    random_seed: int = 0
+    trust_remote_code: bool = False
+    
+    # DataloaderConfig fields
+    dataloader_type: Optional[Literal["single", "cyclic", "external"]] = "single"
+    
+    # Cached processors and tokenizer
+    _processors: Optional[Dict[str, Any]] = field(default=None, repr=False)
+    _tokenizer: Optional[Any] = field(default=None, repr=False)
+    
+    def _load_processors(self) -> Dict[str, Any]:
+        """Load HuggingFace processors for each modality."""
+        if self._processors is not None:
+            return self._processors
+        
+        from transformers import AutoProcessor
+        
+        processors = {}
+        for modality_name, processor_path in self.processor_paths.items():
+            processors[modality_name] = AutoProcessor.from_pretrained(
+                processor_path,
+                trust_remote_code=is_safe_repo(
+                    trust_remote_code=self.trust_remote_code,
+                    hf_path=processor_path,
+                ),
+            )
+        
+        object.__setattr__(self, "_processors", processors)
+        return processors
+    
+    def _load_tokenizer(self) -> Any:
+        """Load HuggingFace tokenizer."""
+        if self._tokenizer is not None:
+            return self._tokenizer
+        
+        if not self.tokenizer_path:
+            raise ValueError(
+                "tokenizer_path must be set for MockMimoProvider. "
+                "Provide a valid HuggingFace tokenizer path (e.g., 'gpt2', 'meta-llama/Llama-2-7b-hf')."
+            )
+        
+        from transformers import AutoTokenizer
+        
+        tokenizer = AutoTokenizer.from_pretrained(
+            self.tokenizer_path,
+            trust_remote_code=is_safe_repo(
+                trust_remote_code=self.trust_remote_code,
+                hf_path=self.tokenizer_path,
+            ),
+        )
+        
+        if tokenizer.pad_token is None:
+            tokenizer.pad_token = tokenizer.eos_token
+        
+        object.__setattr__(self, "_tokenizer", tokenizer)
+        return tokenizer
+    
+    def _generate_synthetic_examples(
+        self, 
+        size: int, 
+        seed_offset: int = 0,
+    ) -> List[Dict[str, Any]]:
+        """Generate synthetic multimodal examples.
+        
+        Args:
+            size: Number of examples to generate.
+            seed_offset: Offset to add to random seed for different splits.
+            
+        Returns:
+            List of examples with synthetic modality data.
+        """
+        rng = np.random.default_rng(seed=self.random_seed + seed_offset)
+        examples = []
+        
+        for i in range(size):
+            example = {"text": f"{self.text_prompt} Sample {i}."}
+            
+            for modality_name, config in self.modality_configs.items():
+                modality_type = config.get("type", "image")
+                
+                if modality_type == "image":
+                    width = config.get("width", 224)
+                    height = config.get("height", 224)
+                    example[modality_name] = _generate_random_image(width, height, rng)
+                    
+                elif modality_type == "audio":
+                    duration = config.get("duration_sec", 3.0)
+                    sample_rate = config.get("sample_rate", 16000)
+                    example[modality_name] = _generate_random_audio(duration, sample_rate, rng)
+                    
+                else:
+                    # Default to image
+                    example[modality_name] = _generate_random_image(224, 224, rng)
+            
+            examples.append(example)
+        
+        return examples
+    
+    def _build_split_dataset(
+        self,
+        size: int,
+        processors: Dict[str, Any],
+        tokenizer: Any,
+        seed_offset: int = 0,
+    ) -> Optional[MimoDataset]:
+        """Build dataset for a single split."""
+        if size <= 0:
+            return None
+        
+        examples = self._generate_synthetic_examples(size, seed_offset)
+        
+        # Build modality_columns mapping (modality_name -> column_name)
+        # In synthetic data, we use modality_name as column_name
+        modality_columns = {name: name for name in self.modality_configs.keys()}
+        
+        return MimoDataset(
+            examples=examples,
+            processors=processors,
+            tokenizer=tokenizer,
+            seq_length=self.seq_length,
+            special_token_ids=self.special_token_ids,
+            encoder_seq_lengths=self.encoder_seq_lengths,
+            modality_columns=modality_columns,
+            text_column="text",
+        )
+    
+    def build_datasets(
+        self, context: DatasetBuildContext
+    ) -> Tuple[Optional[MimoDataset], Optional[MimoDataset], Optional[MimoDataset]]:
+        """Build train, validation, and test datasets with synthetic data.
+        
+        Args:
+            context: Build context with sample counts.
+            
+        Returns:
+            Tuple of (train_dataset, valid_dataset, test_dataset).
+        """
+        processors = self._load_processors()
+        tokenizer = self._load_tokenizer()
+        
+        train_ds = self._build_split_dataset(
+            context.train_samples, processors, tokenizer, seed_offset=0
+        )
+        valid_ds = self._build_split_dataset(
+            context.valid_samples, processors, tokenizer, seed_offset=1000000
+        )
+        test_ds = self._build_split_dataset(
+            context.test_samples, processors, tokenizer, seed_offset=2000000
+        )
+        
+        return train_ds, valid_ds, test_ds
+    
+    def get_collate_fn(self) -> Callable:
+        """Return collate function for MIMO datasets.
+        
+        Returns:
+            Partial function of mimo_collate_fn with modality names pre-filled.
+        """
+        from megatron.bridge.data.mimo.collate import mimo_collate_fn
+        
+        return partial(
+            mimo_collate_fn,
+            modality_names=list(self.modality_configs.keys()),
+        )

--- a/src/megatron/bridge/models/mimo/__init__.py
+++ b/src/megatron/bridge/models/mimo/__init__.py
@@ -12,9 +12,9 @@ from megatron.bridge.models.mimo.mimo_provider import (
 
 
 __all__ = [
+    "LlavaMimoProvider",
+    "MimoModelInfra",
+    "MimoModelProvider",
     "MimoParallelismConfig",
     "ModuleParallelismConfig",
-    "MimoModelProvider",
-    "MimoModelInfra",
-    "LlavaMimoProvider",
 ]

--- a/src/megatron/bridge/models/mimo/llava_provider.py
+++ b/src/megatron/bridge/models/mimo/llava_provider.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 """LLaVA-style Vision-Language Model provider."""
 
 from dataclasses import dataclass, field
@@ -45,9 +45,6 @@ class LlavaMimoProvider(MimoModelProvider):
 
     # Optional custom configs
     language_config: Optional[TransformerConfig] = None
-
-    # Make parent's required field optional (we build it in __post_init__)
-    language_model_spec: Optional[ModuleSpec] = None
 
     def __post_init__(self):
         """Build specs after initialization."""

--- a/src/megatron/bridge/models/mimo/mimo_builder.py
+++ b/src/megatron/bridge/models/mimo/mimo_builder.py
@@ -50,6 +50,7 @@ def build_hypercomm_grids(
         _ = grid.create_pg(["tp", "pp"])
         _ = grid.create_pg(["tp", "ep", "pp"])
         _ = grid.create_pg(["dp", "ep"])
+        _ = grid.create_pg(["tp", "cp", "ep", "pp", "dp"])
 
         grids[module_name] = grid
 

--- a/src/megatron/bridge/models/mimo/mimo_builder.py
+++ b/src/megatron/bridge/models/mimo/mimo_builder.py
@@ -1,19 +1,20 @@
-# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
-
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Dict, List
+from typing import TYPE_CHECKING, Dict, Optional, Tuple
+
+import torch.distributed as dist
 
 from megatron.bridge.models.mimo.mimo_config import MimoParallelismConfig
 
 
 if TYPE_CHECKING:
-    from megatron.core.process_groups_config import HyperCommGrid
+    from megatron.core.hyper_comm_grid import HyperCommGrid
 
 
 def build_hypercomm_grids(
     mimo_parallelism_config: MimoParallelismConfig,
-) -> Dict[str, HyperCommGrid]:
+) -> Dict[str, "HyperCommGrid"]:
     """Create HyperCommGrid objects per module from MIMO parallelism config.
 
     Creates grids on ALL ranks (required for consistent collective calls),
@@ -45,14 +46,75 @@ def build_hypercomm_grids(
         # Create all standard process groups
         for dim in ("tp", "cp", "ep", "pp", "dp"):
             _ = grid.create_pg([dim])
-        # Create dp_cp composite group for gradient reduction
         _ = grid.create_pg(["dp", "cp"])
+        _ = grid.create_pg(["tp", "pp"])
+        _ = grid.create_pg(["tp", "ep", "pp"])
+        _ = grid.create_pg(["dp", "ep"])
 
         grids[module_name] = grid
 
     return grids
 
 
-def _default_topology(mimo_parallelism_config: MimoParallelismConfig) -> Dict[str, List[str]]:
-    """Infer a default multi-encoder -> LLM topology."""
-    return {name: ["llm"] for name in mimo_parallelism_config.module_names if name != "llm"} | {"llm": []}
+def populate_embedding_and_position_groups(
+    pp_group: dist.ProcessGroup,
+) -> Tuple[Optional[dist.ProcessGroup], Optional[dist.ProcessGroup]]:
+    """Create embedding-related process groups from PP group ranks.
+
+    Following MCore semantics:
+    - pos_embd_pg: Only rank 0 of PP (first stage) - for position embeddings
+    - embd_pg: Ranks 0 and -1 of PP (first and last stages) - for tied word embeddings
+
+    IMPORTANT: This calls dist.new_group which is a collective operation.
+    Must be called on all ranks that could participate.
+
+    Args:
+        pp_group: The pipeline parallel process group.
+
+    Returns:
+        Tuple of (pos_embd_pg, embd_pg). Returns (None, None) if pp_group is None.
+    """
+    if pp_group is None:
+        return None, None
+
+    pp_ranks = sorted(dist.get_process_group_ranks(pp_group))
+
+    # Position embeddings only on first PP stage
+    pos_embd_ranks = [pp_ranks[0]]
+    pos_embd_pg = dist.new_group(ranks=pos_embd_ranks)
+
+    # Word embeddings on first and last PP stages (for tied embeddings)
+    embd_ranks = [pp_ranks[0]]
+    if len(pp_ranks) > 1 and pp_ranks[-1] != pp_ranks[0]:
+        embd_ranks.append(pp_ranks[-1])
+    embd_pg = dist.new_group(ranks=embd_ranks)
+
+    return pos_embd_pg, embd_pg
+
+
+def is_pp_first_stage(pp_group: Optional[dist.ProcessGroup]) -> bool:
+    """Check if current rank is first stage in pipeline."""
+    if pp_group is None:
+        return True
+    pp_ranks = sorted(dist.get_process_group_ranks(pp_group))
+    return dist.get_rank() == pp_ranks[0]
+
+
+def is_pp_last_stage(pp_group: Optional[dist.ProcessGroup]) -> bool:
+    """Check if current rank is last stage in pipeline."""
+    if pp_group is None:
+        return True
+    pp_ranks = sorted(dist.get_process_group_ranks(pp_group))
+    return dist.get_rank() == pp_ranks[-1]
+
+
+def is_current_rank_in_grid(grid: "HyperCommGrid") -> bool:
+    """Check if the current rank participates in this grid.
+
+    Args:
+        grid: A HyperCommGrid instance.
+
+    Returns:
+        True if dist.get_rank() is within the grid's rank range.
+    """
+    return grid.rank_offset <= dist.get_rank() < (grid.rank_offset + grid.size)

--- a/src/megatron/bridge/models/mimo/mimo_config.py
+++ b/src/megatron/bridge/models/mimo/mimo_config.py
@@ -1,5 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
-
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 from __future__ import annotations
 
 import warnings
@@ -68,7 +67,6 @@ class MimoParallelismConfig:
 
     module_parallelisms: dict[str, ModuleParallelismConfig]
     special_token_ids: dict[str, int] = field(default_factory=dict)
-    # TODO: Add optional topology when supporting non-encoder-to-LLM flows.
 
     def get_parallelism(self, module_name: str) -> ModuleParallelismConfig:
         return self.module_parallelisms[module_name]
@@ -98,8 +96,62 @@ class MimoParallelismConfig:
             if cur_start < prev_end:
                 raise ValueError("rank_offset ranges overlap in heterogeneous deployment.")
 
-    def finalize(self, world_size: Optional[int]) -> None:
-        """Finalize parallelism config: compute data_parallel_size and validate."""
+    def _validate_parallelism_constraints(self) -> None:
+        """Validate parallelism constraints for cross-module communication.
+
+        - TP sizes must be powers of 2
+        - DP sizes must be pairwise divisible (one divides the other)
+        """
+
+        def is_power_of_two(n: int) -> bool:
+            return n > 0 and (n & (n - 1)) == 0
+
+        # Validate TP is power of 2
+        for name, p in self.module_parallelisms.items():
+            tp = p.tensor_model_parallel_size
+            if not is_power_of_two(tp):
+                raise ValueError(
+                    f"Module '{name}' has TP={tp}, but TP size must be a power of 2 "
+                    f"(1, 2, 4, 8, ...) for cross-module communication compatibility."
+                )
+
+        # Validate DP sizes are pairwise divisible
+        module_names = list(self.module_parallelisms.keys())
+        for i, name1 in enumerate(module_names):
+            for name2 in module_names[i + 1 :]:
+                dp1 = self.module_parallelisms[name1].data_parallel_size
+                dp2 = self.module_parallelisms[name2].data_parallel_size
+                if dp1 is None or dp2 is None:
+                    continue
+                if dp1 % dp2 != 0 and dp2 % dp1 != 0:
+                    raise ValueError(
+                        f"DP sizes must be divisible between modules. "
+                        f"Module '{name1}' has DP={dp1}, module '{name2}' has DP={dp2}. "
+                        f"One must divide the other for BridgeCommunicator."
+                    )
+
+        # Validate encoder DP >= LLM DP for embedding alignment
+        # Encoder modules produce embeddings consumed by LLM. If encoder DP < LLM DP,
+        # the same encoder batch would need to align with different LLM batches, which fails.
+        llm_dp = self.module_parallelisms["llm"].data_parallel_size
+        if llm_dp is not None:
+            for name, p in self.module_parallelisms.items():
+                if name == "llm":
+                    continue
+                encoder_dp = p.data_parallel_size
+                if encoder_dp is not None and encoder_dp < llm_dp:
+                    raise ValueError(
+                        f"Encoder module '{name}' has DP={encoder_dp} < LLM DP={llm_dp}. "
+                        f"Encoder DP must be >= LLM DP for embedding alignment across batches."
+                    )
+
+    def finalize(self, world_size: int) -> None:
+        """Finalize parallelism config: compute data_parallel_size and validate.
+
+        Args:
+            world_size: Total number of ranks in the distributed world.
+                MIMO requires a distributed environment, so this must always be provided.
+        """
         if "llm" not in self.module_parallelisms:
             raise ValueError(
                 f"LLM module 'llm' must be in module_parallelisms. "
@@ -111,8 +163,8 @@ class MimoParallelismConfig:
             parallelism.finalize(None)
 
         self._validate_heterogeneous()
+        self._validate_parallelism_constraints()
 
-        if world_size and world_size > 1:
-            expected = self.total_world_size
-            if expected and world_size != expected:
-                raise ValueError(f"MIMO world size mismatch: expected {expected}, got {world_size}.")
+        expected = self.total_world_size
+        if expected and world_size != expected:
+            raise ValueError(f"MIMO world size mismatch: expected {expected}, got {world_size}.")

--- a/src/megatron/bridge/models/mimo/mimo_config.py
+++ b/src/megatron/bridge/models/mimo/mimo_config.py
@@ -5,6 +5,8 @@ import warnings
 from dataclasses import dataclass, field
 from typing import Optional
 
+from megatron.core.models.mimo.config.role import MIMO_LANGUAGE_MODULE_KEY
+
 
 @dataclass
 class ModuleParallelismConfig:
@@ -62,7 +64,7 @@ class MimoParallelismConfig:
     Note: Phase 1 only supports heterogeneous deployment where each module
     can have different parallelism configurations and rank offsets.
 
-    The LLM module must be named "llm" in module_parallelisms.
+    The language module must be named MIMO_LANGUAGE_MODULE_KEY ("language") in module_parallelisms.
     """
 
     module_parallelisms: dict[str, ModuleParallelismConfig]
@@ -133,10 +135,10 @@ class MimoParallelismConfig:
         # Validate encoder DP >= LLM DP for embedding alignment
         # Encoder modules produce embeddings consumed by LLM. If encoder DP < LLM DP,
         # the same encoder batch would need to align with different LLM batches, which fails.
-        llm_dp = self.module_parallelisms["llm"].data_parallel_size
+        llm_dp = self.module_parallelisms[MIMO_LANGUAGE_MODULE_KEY].data_parallel_size
         if llm_dp is not None:
             for name, p in self.module_parallelisms.items():
-                if name == "llm":
+                if name == MIMO_LANGUAGE_MODULE_KEY:
                     continue
                 encoder_dp = p.data_parallel_size
                 if encoder_dp is not None and encoder_dp < llm_dp:
@@ -152,9 +154,9 @@ class MimoParallelismConfig:
             world_size: Total number of ranks in the distributed world.
                 MIMO requires a distributed environment, so this must always be provided.
         """
-        if "llm" not in self.module_parallelisms:
+        if MIMO_LANGUAGE_MODULE_KEY not in self.module_parallelisms:
             raise ValueError(
-                f"LLM module 'llm' must be in module_parallelisms. "
+                f"Language module '{MIMO_LANGUAGE_MODULE_KEY}' must be in module_parallelisms. "
                 f"Found modules: {list(self.module_parallelisms.keys())}"
             )
 

--- a/src/megatron/bridge/models/mimo/mimo_ddp.py
+++ b/src/megatron/bridge/models/mimo/mimo_ddp.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+"""DDP wrapping utilities for MIMO models.
+
+Called from the training layer after MimoModelProvider.provide().
+
+Note: This module only supports DDP wrapping. FSDP is not yet implemented.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Dict, Optional
+
+from megatron.bridge.models.mimo.mimo_builder import is_current_rank_in_grid
+
+if TYPE_CHECKING:
+    from megatron.core.distributed import DistributedDataParallelConfig
+    from megatron.core.hyper_comm_grid import HyperCommGrid
+    from megatron.core.models.mimo import MimoModel
+    from megatron.core.process_groups_config import ProcessGroupCollection
+    from megatron.bridge.models.mimo.mimo_config import MimoParallelismConfig
+
+
+def wrap_mimo_model_distributed(
+    mimo_model: "MimoModel",
+    ddp_config: "DistributedDataParallelConfig",
+    mimo_parallelism_config: "MimoParallelismConfig",
+    grids: Dict[str, "HyperCommGrid"],
+    pg_collections: Dict[str, Optional["ProcessGroupCollection"]],
+) -> "MimoModel":
+    """Wrap MIMO model's submodules with DDP.
+
+    Modifies mimo_model in-place and returns it.
+
+    Args:
+        mimo_model: The MimoModel to wrap.
+        ddp_config: DDP configuration from Bridge.
+        mimo_parallelism_config: MIMO parallelism configuration.
+        grids: Module name to HyperCommGrid mapping.
+        pg_collections: Module name to ProcessGroupCollection mapping.
+
+    Returns:
+        The same mimo_model with wrapped submodules.
+    """
+    from megatron.core.distributed import DistributedDataParallel
+
+    # Wrap language model if present and rank participates
+    if mimo_model.language_model is not None:
+        llm_grid = grids.get("llm")
+        if llm_grid is not None and is_current_rank_in_grid(llm_grid):
+            llm_pg = pg_collections.get("llm")
+            if llm_pg is not None:
+                mimo_model.language_model = DistributedDataParallel(
+                    config=mimo_model.language_model.config,
+                    ddp_config=ddp_config,
+                    module=mimo_model.language_model,
+                    pg_collection=llm_pg,
+                )
+
+    # Wrap modality submodules
+    if hasattr(mimo_model, 'modality_submodules'):
+        for module_name, submodule in mimo_model.modality_submodules.items():
+            if submodule is None:
+                continue
+            module_grid = grids.get(module_name)
+            if module_grid is None:
+                continue
+            if not is_current_rank_in_grid(module_grid):
+                continue
+
+            module_pg = pg_collections.get(module_name)
+            if module_pg is None:
+                continue
+
+            # Get config from first encoder in the submodule.
+            # Note: We use the first encoder's config for DDP bucket sizing.
+            # This assumes all encoders in a modality submodule share similar
+            # parallelism settings, which is typical for MIMO models.
+            if hasattr(submodule, 'encoders') and submodule.encoders:
+                encoder_key = next(iter(submodule.encoders.keys()))
+                first_encoder = submodule.encoders[encoder_key]
+                
+                if not hasattr(first_encoder, 'config'):
+                    raise AttributeError(
+                        f"Encoder '{encoder_key}' in modality '{module_name}' does not have "
+                        f"a 'config' attribute. Encoders must be MegatronModule subclasses."
+                    )
+
+                wrapped = DistributedDataParallel(
+                    config=first_encoder.config,
+                    ddp_config=ddp_config,
+                    module=submodule,
+                    pg_collection=module_pg,
+                )
+                mimo_model.modality_submodules[module_name] = wrapped
+
+    return mimo_model

--- a/src/megatron/bridge/models/mimo/mimo_ddp.py
+++ b/src/megatron/bridge/models/mimo/mimo_ddp.py
@@ -53,12 +53,20 @@ def wrap_mimo_model_distributed(
         if llm_grid is not None and is_current_rank_in_grid(llm_grid):
             llm_pg = pg_collections.get(MIMO_LANGUAGE_MODULE_KEY)
             if llm_pg is not None:
-                mimo_model.language_model = DistributedDataParallel(
+                wrapped_lm = DistributedDataParallel(
                     config=mimo_model.language_model.config,
                     ddp_config=ddp_config,
                     module=mimo_model.language_model,
                     pg_collection=llm_pg,
                 )
+                # MCore's DDP wrapper does not proxy arbitrary module methods.
+                # MimoModel._forward_language_module() checks for and calls
+                # language_model.set_input_tensor(...) on non-first PP stages.
+                # Preserve that method on the wrapper so decoder input tensors
+                # are wired correctly when language_model is DDP-wrapped.
+                if hasattr(wrapped_lm.module, "set_input_tensor"):
+                    wrapped_lm.set_input_tensor = wrapped_lm.module.set_input_tensor
+                mimo_model.language_model = wrapped_lm
 
     # Wrap modality submodules
     if hasattr(mimo_model, "modality_submodules"):

--- a/src/megatron/bridge/models/mimo/mimo_ddp.py
+++ b/src/megatron/bridge/models/mimo/mimo_ddp.py
@@ -5,17 +5,22 @@ Called from the training layer after MimoModelProvider.provide().
 
 Note: This module only supports DDP wrapping. FSDP is not yet implemented.
 """
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Dict, Optional
 
+from megatron.core.models.mimo.config.role import MIMO_LANGUAGE_MODULE_KEY
+
 from megatron.bridge.models.mimo.mimo_builder import is_current_rank_in_grid
+
 
 if TYPE_CHECKING:
     from megatron.core.distributed import DistributedDataParallelConfig
     from megatron.core.hyper_comm_grid import HyperCommGrid
     from megatron.core.models.mimo import MimoModel
     from megatron.core.process_groups_config import ProcessGroupCollection
+
     from megatron.bridge.models.mimo.mimo_config import MimoParallelismConfig
 
 
@@ -44,9 +49,9 @@ def wrap_mimo_model_distributed(
 
     # Wrap language model if present and rank participates
     if mimo_model.language_model is not None:
-        llm_grid = grids.get("llm")
+        llm_grid = grids.get(MIMO_LANGUAGE_MODULE_KEY)
         if llm_grid is not None and is_current_rank_in_grid(llm_grid):
-            llm_pg = pg_collections.get("llm")
+            llm_pg = pg_collections.get(MIMO_LANGUAGE_MODULE_KEY)
             if llm_pg is not None:
                 mimo_model.language_model = DistributedDataParallel(
                     config=mimo_model.language_model.config,
@@ -56,7 +61,7 @@ def wrap_mimo_model_distributed(
                 )
 
     # Wrap modality submodules
-    if hasattr(mimo_model, 'modality_submodules'):
+    if hasattr(mimo_model, "modality_submodules"):
         for module_name, submodule in mimo_model.modality_submodules.items():
             if submodule is None:
                 continue
@@ -74,11 +79,11 @@ def wrap_mimo_model_distributed(
             # Note: We use the first encoder's config for DDP bucket sizing.
             # This assumes all encoders in a modality submodule share similar
             # parallelism settings, which is typical for MIMO models.
-            if hasattr(submodule, 'encoders') and submodule.encoders:
+            if hasattr(submodule, "encoders") and submodule.encoders:
                 encoder_key = next(iter(submodule.encoders.keys()))
                 first_encoder = submodule.encoders[encoder_key]
-                
-                if not hasattr(first_encoder, 'config'):
+
+                if not hasattr(first_encoder, "config"):
                     raise AttributeError(
                         f"Encoder '{encoder_key}' in modality '{module_name}' does not have "
                         f"a 'config' attribute. Encoders must be MegatronModule subclasses."

--- a/src/megatron/bridge/models/mimo/mimo_provider.py
+++ b/src/megatron/bridge/models/mimo/mimo_provider.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 """MIMO Model Provider for heterogeneous multi-module training.
 
 This module provides MimoModelProvider, which integrates with the standard
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Union
 
 import torch
 import torch.distributed as dist
-from megatron.core.distributed import DistributedDataParallel, DistributedDataParallelConfig
+from megatron.core.distributed import DistributedDataParallelConfig
 from megatron.core.models.mimo import MimoModel
 from megatron.core.models.mimo.config.base_configs import MimoModelConfig
 from megatron.core.process_groups_config import ProcessGroupCollection
@@ -27,10 +27,13 @@ from megatron.core.transformer.spec_utils import ModuleSpec
 from megatron.core.utils import get_model_config
 
 from megatron.bridge.models.mimo.mimo_builder import (
-    _default_topology,
     build_hypercomm_grids,
+    is_pp_first_stage,
+    is_pp_last_stage,
+    populate_embedding_and_position_groups,
 )
 from megatron.bridge.models.mimo.mimo_config import MimoParallelismConfig
+from megatron.bridge.models.mimo.mimo_ddp import wrap_mimo_model_distributed
 from megatron.bridge.models.model_provider import ModelProviderMixin
 
 
@@ -96,13 +99,21 @@ class MimoModelProvider(ModelProviderMixin[MimoModel]):
         >>> infra = provider.build_infra()
     """
 
-    # Model specs (user provides, like llava_vlm.py example)
-    language_model_spec: ModuleSpec
+    # Model specs (user provides, like llava_vlm.py example).
+    # Optional so subclasses (e.g. LlavaMimoProvider) can build it in __post_init__.
+    language_model_spec: Optional[ModuleSpec] = None
     modality_submodules_spec: Dict[str, ModuleSpec] = field(default_factory=dict)
     special_token_ids: Dict[str, int] = field(default_factory=dict)
 
-    # Parallelism config (Bridge's value-add)
     mimo_parallelism_config: Optional[MimoParallelismConfig] = None
+
+    # Module data-flow DAG for MultiModulePipelineCommunicator.
+    # If None, auto-derived as: all modality_submodules → "llm" (terminal).
+    # Set explicitly for non-standard topologies (e.g., llm → generator).
+    topology: Optional[Dict[str, List[str]]] = None
+
+    # Cached grids after build_model() - used by data loading
+    _grids: Optional[Dict[str, "HyperCommGrid"]] = field(default=None, repr=False)
 
     # Freezing options
     freeze_language_model: bool = False
@@ -110,39 +121,10 @@ class MimoModelProvider(ModelProviderMixin[MimoModel]):
     freeze_modality_projections: Dict[str, bool] = field(default_factory=dict)
 
     # Fields required by ModelProviderMixin / get_model()
-    # These have sensible defaults for MIMO
     fp16: bool = False
     bf16: bool = True
     use_cpu_initialization: bool = False
     init_model_with_meta_device: bool = False
-    virtual_pipeline_model_parallel_size: Optional[int] = None
-
-    # Internal state
-    _cached_infra: Optional[MimoModelInfra] = field(default=None, repr=False)
-
-    @property
-    def tensor_model_parallel_size(self) -> int:
-        """Return LLM's tensor parallel size for compatibility with standard code paths."""
-        if self.mimo_parallelism_config is None:
-            return 1
-        llm_parallelism = self.mimo_parallelism_config.get_parallelism("llm")
-        return llm_parallelism.tensor_model_parallel_size
-
-    @property
-    def pipeline_model_parallel_size(self) -> int:
-        """Return LLM's pipeline parallel size for compatibility with standard code paths."""
-        if self.mimo_parallelism_config is None:
-            return 1
-        llm_parallelism = self.mimo_parallelism_config.get_parallelism("llm")
-        return llm_parallelism.pipeline_model_parallel_size
-
-    @property
-    def context_parallel_size(self) -> int:
-        """Return LLM's context parallel size for compatibility with standard code paths."""
-        if self.mimo_parallelism_config is None:
-            return 1
-        llm_parallelism = self.mimo_parallelism_config.get_parallelism("llm")
-        return llm_parallelism.context_parallel_size
 
     def build_infra(self) -> MimoModelInfra:
         """Build MIMO parallelism infrastructure.
@@ -155,18 +137,23 @@ class MimoModelProvider(ModelProviderMixin[MimoModel]):
         validate the parallelism configuration.
 
         Returns:
-            MimoModelInfra containing grids, topology, pg_collections, and
-            the list of modules this rank participates in.
+            MimoModelInfra containing grids, topology, pg_collections,
+            and the list of modules this rank participates in.
         """
         if self.mimo_parallelism_config is not None:
             grids = build_hypercomm_grids(self.mimo_parallelism_config)
             pg_collections = self._get_pg_collections_from_grids(grids)
-            topology = _default_topology(self.mimo_parallelism_config)
         else:
-            # No parallelism - use global process groups
             grids = {}
             pg_collections = {}
-            topology = {}
+
+        if self.topology is not None:
+            topology = self.topology
+        else:
+            topology = {name: ["llm"] for name in self.modality_submodules_spec} | {"llm": []}
+
+        # Cache grids for later use (e.g., data loading)
+        object.__setattr__(self, "_grids", grids)
 
         participating_modules = [name for name, pg in pg_collections.items() if pg is not None]
 
@@ -183,6 +170,7 @@ class MimoModelProvider(ModelProviderMixin[MimoModel]):
     ) -> Dict[str, Optional[ProcessGroupCollection]]:
         """Get ProcessGroupCollections from HyperCommGrids.
 
+        Creates all standard process groups plus embedding groups for PP > 1.
         Returns None for modules this rank doesn't participate in.
         """
         pg_collections: Dict[str, Optional[ProcessGroupCollection]] = {}
@@ -191,13 +179,26 @@ class MimoModelProvider(ModelProviderMixin[MimoModel]):
         for module_name, grid in grids.items():
             # Check if current rank is in this grid's range
             if grid.rank_offset <= current_rank < (grid.rank_offset + grid.size):
+                pp_group = grid.get_pg(["pp"])
+
+                # Create embedding groups for PP > 1 (collective operation on all PP ranks)
+                pos_embd_pg, embd_pg = populate_embedding_and_position_groups(pp_group)
+
+                # Only assign embedding groups to ranks that should have them
+                first_stage = is_pp_first_stage(pp_group)
+                last_stage = is_pp_last_stage(pp_group)
+
                 pg_collections[module_name] = ProcessGroupCollection(
                     tp=grid.get_pg(["tp"]),
                     dp=grid.get_pg(["dp"]),
-                    pp=grid.get_pg(["pp"]),
+                    pp=pp_group,
                     cp=grid.get_pg(["cp"]),
                     ep=grid.get_pg(["ep"]),
                     dp_cp=grid.get_pg(["dp", "cp"]),
+                    mp=grid.get_pg(["tp", "pp"]),
+                    tp_ep_pp=grid.get_pg(["tp", "ep", "pp"]),
+                    pos_embd=pos_embd_pg if first_stage else None,
+                    embd=embd_pg if (first_stage or last_stage) else None,
                 )
             else:
                 pg_collections[module_name] = None
@@ -208,12 +209,18 @@ class MimoModelProvider(ModelProviderMixin[MimoModel]):
         self,
         spec: ModuleSpec,
         pg_collection: ProcessGroupCollection,
+        pre_process: Optional[bool] = None,
+        post_process: Optional[bool] = None,
     ) -> ModuleSpec:
-        """Deep copy language model spec and inject pg_collection into params."""
+        """Deep copy language model spec and inject stage-aware params."""
         spec = copy.deepcopy(spec)
         if spec.params is None:
             spec.params = {}
         spec.params["pg_collection"] = pg_collection
+        if pre_process is not None:
+            spec.params["pre_process"] = pre_process
+        if post_process is not None:
+            spec.params["post_process"] = post_process
         return spec
 
     def _inject_pg_collection_into_modality_spec(
@@ -226,7 +233,7 @@ class MimoModelProvider(ModelProviderMixin[MimoModel]):
 
         # Inject into encoders
         if spec.submodules and "encoders" in spec.submodules:
-            for encoder_name, encoder_spec in spec.submodules["encoders"].items():
+            for _encoder_name, encoder_spec in spec.submodules["encoders"].items():
                 if encoder_spec.params is None:
                     encoder_spec.params = {}
                 encoder_spec.params["pg_collection"] = pg_collection
@@ -267,9 +274,15 @@ class MimoModelProvider(ModelProviderMixin[MimoModel]):
             consistent with other providers. This method returns a CPU model.
 
         Raises:
-            ValueError: If this rank doesn't participate in any module
-                (indicates invalid parallelism configuration).
+            ValueError: If language_model_spec is not set, or if this rank
+                doesn't participate in any module.
         """
+        if self.language_model_spec is None:
+            raise ValueError(
+                "language_model_spec must be set before calling provide(). "
+                "Set it directly or use a subclass that populates it in __post_init__."
+            )
+
         # Build infrastructure
         infra = self.build_infra()
 
@@ -278,7 +291,12 @@ class MimoModelProvider(ModelProviderMixin[MimoModel]):
         if self.mimo_parallelism_config:
             llm_pg = infra.pg_collections.get("llm")
             if llm_pg is not None:
-                language_spec = self._inject_pg_collection_into_language_spec(language_spec, llm_pg)
+                language_spec = self._inject_pg_collection_into_language_spec(
+                    language_spec,
+                    llm_pg,
+                    pre_process=is_pp_first_stage(llm_pg.pp),
+                    post_process=is_pp_last_stage(llm_pg.pp),
+                )
 
         # Inject pg_collection into modality specs
         modality_specs: Dict[str, ModuleSpec] = {}
@@ -293,6 +311,8 @@ class MimoModelProvider(ModelProviderMixin[MimoModel]):
             language_model_spec=language_spec,
             modality_submodules_spec=modality_specs,
             special_token_ids=self.special_token_ids,
+            module_to_grid_map=(infra.module_to_grid_map if self.mimo_parallelism_config is not None else None),
+            language_module_key="llm" if self.mimo_parallelism_config is not None else None,
         )
 
         mimo_model = MimoModel(mimo_model_config)
@@ -313,7 +333,7 @@ class MimoModelProvider(ModelProviderMixin[MimoModel]):
         use_torch_fsdp2: bool = False,
         wrap_with_ddp: bool = True,
         data_parallel_random_init: bool = True,
-        use_cpu_initialization: Optional[bool] = False,
+        use_cpu_initialization: Optional[bool] = None,
         init_model_with_meta_device: Optional[bool] = None,
         pre_wrap_hook: Optional[
             Union[
@@ -322,7 +342,6 @@ class MimoModelProvider(ModelProviderMixin[MimoModel]):
             ]
         ] = None,
         post_wrap_hook: Optional[Callable[[List[MegatronModule]], List[MegatronModule]]] = None,
-        mixed_precision_wrapper: Optional[Callable] = None,
     ) -> List[MegatronModule]:
         """Build MIMO model with heterogeneous parallelism and DDP wrapping.
 
@@ -330,15 +349,17 @@ class MimoModelProvider(ModelProviderMixin[MimoModel]):
         - Uses per-module HyperCommGrids instead of global mpu
         - Has different pg_collections per module
         - May have ranks that don't participate in all modules
+        - Requires per-submodule DDP wrapping for correct gradient sync
 
         The method:
         1. Calls finalize() to validate parallelism config
         2. Calls build_infra() to create grids and pg_collections
         3. Calls provide() to build the model
         4. Applies pre-wrap hooks
-        5. Moves to device and applies mixed precision
-        6. Wraps with DDP using LLM's pg_collection
-        7. Applies post-wrap hooks
+        5. Moves to device
+        6. Wraps each submodule with DDP using its own pg_collection
+        7. Casts to fp16/bf16 (direct casting, not Float16Module)
+        8. Applies post-wrap hooks
 
         Args:
             ddp_config: Configuration for distributed data parallel.
@@ -354,7 +375,6 @@ class MimoModelProvider(ModelProviderMixin[MimoModel]):
             init_model_with_meta_device: Initialize model on meta device.
             pre_wrap_hook: Callable(s) to modify model before wrapping.
             post_wrap_hook: Callable to modify model after wrapping.
-            mixed_precision_wrapper: Wrapper for mixed precision (e.g., Float16Module).
 
         Returns:
             List containing the wrapped MimoModel.
@@ -363,11 +383,13 @@ class MimoModelProvider(ModelProviderMixin[MimoModel]):
             ValueError: If this rank doesn't participate in any module
                 (indicates invalid parallelism configuration).
         """
-        # Import here to avoid circular imports
-        from megatron.core.transformer.module import Float16Module
-
         if wrap_with_ddp and ddp_config is None:
             raise ValueError("ddp_config is required when wrap_with_ddp is True")
+
+        if use_megatron_fsdp or use_torch_fsdp2:
+            raise NotImplementedError(
+                "FSDP is not yet supported for MIMO models. Use DDP (wrap_with_ddp=True) instead."
+            )
 
         # Finalize parallelism config
         self.finalize()
@@ -389,40 +411,47 @@ class MimoModelProvider(ModelProviderMixin[MimoModel]):
             if result is not None:
                 model_list = result
 
+        # Resolve initialization settings from provider defaults if not specified
+        local_use_cpu_init = (
+            use_cpu_initialization if use_cpu_initialization is not None else self.use_cpu_initialization
+        )
+        local_init_meta_device = (
+            init_model_with_meta_device
+            if init_model_with_meta_device is not None
+            else self.init_model_with_meta_device
+        )
+
         # Move to device
-        if not use_cpu_initialization and not init_model_with_meta_device:
+        if not local_use_cpu_init and not local_init_meta_device:
             for m in model_list:
                 m.cuda(torch.cuda.current_device())
 
-        # Apply mixed precision wrapper
+        # Set variable_seq_lengths=True for multimodule pipeline support (required by PR 3212)
+        # This must be set before the model is used in the training loop
+        for m in model_list:
+            model_config = get_model_config(m)
+            model_config.variable_seq_lengths = True
+
+        # Dtype cast must precede DDP wrapping so hooks bind to final parameters.
         use_fp16 = fp16 if fp16 is not None else self.fp16
         use_bf16 = bf16 if bf16 is not None else self.bf16
-        if (use_fp16 or use_bf16) and mixed_precision_wrapper is not None:
-            model_config = get_model_config(model_list[0])
-            model_list = [mixed_precision_wrapper(model_config, m) for m in model_list]
-        elif (use_fp16 or use_bf16) and mixed_precision_wrapper is None:
-            # Use default Float16Module
-            model_config = get_model_config(model_list[0])
-            model_config.fp16 = use_fp16
-            model_config.bf16 = use_bf16
-            model_list = [Float16Module(model_config, m) for m in model_list]
+        if use_fp16:
+            model_list = [m.half() for m in model_list]
+        elif use_bf16:
+            model_list = [m.bfloat16() for m in model_list]
 
-        # Wrap with DDP
-        if wrap_with_ddp and ddp_config is not None:
-            # Get LLM's pg_collection for DDP (whole model uses LLM's parallelism for DDP)
-            if self.mimo_parallelism_config:
-                pg_collection = infra.pg_collections.get("llm")
-            else:
-                pg_collection = ProcessGroupCollection.use_mpu_process_groups()
-
-            if pg_collection is not None:
-                model_list = self._wrap_with_ddp(
-                    model_list,
-                    ddp_config,
-                    pg_collection,
-                    data_parallel_random_init,
-                    overlap_param_gather_with_optimizer_step,
+        # Per-submodule DDP for heterogeneous parallelism
+        if wrap_with_ddp and ddp_config is not None and self.mimo_parallelism_config:
+            model_list = [
+                wrap_mimo_model_distributed(
+                    mimo_model=m,
+                    ddp_config=ddp_config,
+                    mimo_parallelism_config=self.mimo_parallelism_config,
+                    grids=infra.module_to_grid_map,
+                    pg_collections=infra.pg_collections,
                 )
+                for m in model_list
+            ]
 
         # Apply post-wrap hooks
         if final_post_wrap_hook:
@@ -456,56 +485,22 @@ class MimoModelProvider(ModelProviderMixin[MimoModel]):
             return pre_wrap_hook
         return self.pre_wrap_hook
 
-    def _wrap_with_ddp(
-        self,
-        model_list: List[MegatronModule],
-        ddp_config: DistributedDataParallelConfig,
-        pg_collection: ProcessGroupCollection,
-        data_parallel_random_init: bool,
-        overlap_param_gather_with_optimizer_step: bool,
-    ) -> List[MegatronModule]:
-        """Wrap model with DistributedDataParallel."""
-        ddp_stream = torch.cuda.Stream()
-        ddp_stream.wait_stream(torch.cuda.current_stream())
-
-        with torch.cuda.stream(ddp_stream):
-            model_list = [
-                DistributedDataParallel(
-                    config=get_model_config(model_chunk),
-                    ddp_config=ddp_config,
-                    module=model_chunk,
-                    disable_bucketing=(idx > 0) or overlap_param_gather_with_optimizer_step,
-                    pg_collection=pg_collection,
-                )
-                for idx, model_chunk in enumerate(model_list)
-            ]
-
-        torch.cuda.current_stream().wait_stream(ddp_stream)
-
-        # Broadcast params from data parallel src rank
-        if data_parallel_random_init:
-            for m in model_list:
-                m.broadcast_params()
-
-        return model_list
-
     def initialize_model_parallel(
         self,
         seed: Optional[int] = None,
         seed_kwargs: Optional[dict] = None,
         **model_parallel_kwargs,
     ) -> None:
-        """MIMO uses its own parallelism via MimoParallelismConfig.
+        """MIMO uses per-module HyperCommGrids, not global MPU state.
 
-        This method is a no-op for MIMO. Parallelism is set up in build_infra()
-        using HyperCommGrids, not global mpu state.
-
-        Note:
-            Call finalize() to validate the parallelism configuration, then
-            build_infra() to create the HyperCommGrids.
+        Raises NotImplementedError to prevent accidental global MPU initialization,
+        which would corrupt process groups for heterogeneous parallelism.
+        Use finalize() + build_infra() instead.
         """
-        # MIMO manages its own parallelism via HyperCommGrids
-        pass
+        raise NotImplementedError(
+            "MIMO does not use global model parallelism initialization. "
+            "Use finalize() to validate config and build_infra() to create HyperCommGrids."
+        )
 
     def _apply_freezing(self, model: MimoModel) -> None:
         """Apply freezing based on configuration."""
@@ -538,44 +533,12 @@ class MimoModelProvider(ModelProviderMixin[MimoModel]):
         Raises:
             ValueError: If any rank doesn't participate in at least one module.
                 This indicates the parallelism configuration doesn't cover all
-                ranks in the world.
+                ranks in the world (validated by MimoParallelismConfig.finalize()).
         """
         if self.mimo_parallelism_config is not None:
-            world_size = dist.get_world_size() if dist.is_initialized() else None
-            self.mimo_parallelism_config.finalize(world_size)
-
-            # Validate all ranks participate in at least one module
-            self._validate_all_ranks_participate(world_size)
-
-    def _validate_all_ranks_participate(self, world_size: Optional[int]) -> None:
-        """Validate that all ranks participate in at least one module.
-
-        Args:
-            world_size: Total number of ranks. If None, validation is skipped.
-
-        Raises:
-            ValueError: If any rank doesn't participate in a module.
-        """
-        if world_size is None or self.mimo_parallelism_config is None:
-            return
-
-        # Build grids to determine rank coverage
-        grids = build_hypercomm_grids(self.mimo_parallelism_config)
-
-        # Collect all ranks that participate in at least one module
-        participating_ranks = set()
-        for module_name, grid in grids.items():
-            for rank in range(grid.rank_offset, grid.rank_offset + grid.size):
-                participating_ranks.add(rank)
-
-        # Check for non-participating ranks
-        all_ranks = set(range(world_size))
-        non_participating_ranks = all_ranks - participating_ranks
-
-        if non_participating_ranks:
-            raise ValueError(
-                f"Ranks {sorted(non_participating_ranks)} do not participate in any MIMO module. "
-                f"All {world_size} ranks must be assigned to at least one module. "
-                f"Adjust MimoParallelismConfig to cover all ranks, or reduce world_size to "
-                f"{len(participating_ranks)}."
-            )
+            if not dist.is_initialized():
+                raise RuntimeError(
+                    "MIMO requires torch.distributed to be initialized before finalize(). "
+                    "Call torch.distributed.init_process_group() first."
+                )
+            self.mimo_parallelism_config.finalize(dist.get_world_size())

--- a/src/megatron/bridge/models/mimo/mimo_provider.py
+++ b/src/megatron/bridge/models/mimo/mimo_provider.py
@@ -110,7 +110,7 @@ class MimoModelProvider(ModelProviderMixin[MimoModel]):
     mimo_parallelism_config: Optional[MimoParallelismConfig] = None
 
     # Module data-flow DAG for MultiModulePipelineCommunicator.
-    # If None, auto-derived as: all modality_submodules → language module (terminal).
+    # If None, auto-derived as: all modality_submodules → MIMO_LANGUAGE_MODULE_KEY (terminal).
     # Set explicitly for non-standard topologies (e.g., language → generator).
     topology: Optional[Dict[str, List[str]]] = None
 
@@ -167,6 +167,7 @@ class MimoModelProvider(ModelProviderMixin[MimoModel]):
         participating_modules = [name for name, pg in pg_collections.items() if pg is not None]
 
         # Derive module output tensor dimensionality if not explicitly configured.
+        # Language module produces 3D [S, B, H]; modality encoders produce 2D [S, H].
         if self.module_output_ndim is not None:
             output_ndim = self.module_output_ndim
         else:

--- a/src/megatron/bridge/models/mimo/mimo_provider.py
+++ b/src/megatron/bridge/models/mimo/mimo_provider.py
@@ -21,6 +21,7 @@ import torch.distributed as dist
 from megatron.core.distributed import DistributedDataParallelConfig
 from megatron.core.models.mimo import MimoModel
 from megatron.core.models.mimo.config.base_configs import MimoModelConfig
+from megatron.core.models.mimo.config.role import MIMO_LANGUAGE_MODULE_KEY
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.transformer.module import MegatronModule
 from megatron.core.transformer.spec_utils import ModuleSpec
@@ -60,6 +61,7 @@ class MimoModelInfra:
     topology: Dict[str, List[str]]
     pg_collections: Dict[str, Optional[ProcessGroupCollection]]
     participating_modules: List[str]
+    module_output_ndim: Dict[str, int] = field(default_factory=dict)
 
 
 @dataclass
@@ -83,7 +85,7 @@ class MimoModelProvider(ModelProviderMixin[MimoModel]):
     Example:
         >>> mimo_parallelism_config = MimoParallelismConfig(
         ...     module_parallelisms={
-        ...         "llm": ModuleParallelismConfig(tensor_model_parallel_size=8),
+        ...         "language": ModuleParallelismConfig(tensor_model_parallel_size=8),
         ...         "clip_encoder": ModuleParallelismConfig(tensor_model_parallel_size=2),
         ...     }
         ... )
@@ -108,9 +110,14 @@ class MimoModelProvider(ModelProviderMixin[MimoModel]):
     mimo_parallelism_config: Optional[MimoParallelismConfig] = None
 
     # Module data-flow DAG for MultiModulePipelineCommunicator.
-    # If None, auto-derived as: all modality_submodules → "llm" (terminal).
-    # Set explicitly for non-standard topologies (e.g., llm → generator).
+    # If None, auto-derived as: all modality_submodules → language module (terminal).
+    # Set explicitly for non-standard topologies (e.g., language → generator).
     topology: Optional[Dict[str, List[str]]] = None
+
+    # Output tensor dimensionality per module for bridge communicator routing.
+    # Vision/audio encoders typically produce 2D [S, H]; language modules produce 3D [S, B, H].
+    # If None, auto-derived: language module → 3, all others → 2.
+    module_output_ndim: Optional[Dict[str, int]] = None
 
     # Cached grids after build_model() - used by data loading
     _grids: Optional[Dict[str, "HyperCommGrid"]] = field(default=None, repr=False)
@@ -150,18 +157,30 @@ class MimoModelProvider(ModelProviderMixin[MimoModel]):
         if self.topology is not None:
             topology = self.topology
         else:
-            topology = {name: ["llm"] for name in self.modality_submodules_spec} | {"llm": []}
+            topology = {name: [MIMO_LANGUAGE_MODULE_KEY] for name in self.modality_submodules_spec} | {
+                MIMO_LANGUAGE_MODULE_KEY: []
+            }
 
         # Cache grids for later use (e.g., data loading)
         object.__setattr__(self, "_grids", grids)
 
         participating_modules = [name for name, pg in pg_collections.items() if pg is not None]
 
+        # Derive module output tensor dimensionality if not explicitly configured.
+        if self.module_output_ndim is not None:
+            output_ndim = self.module_output_ndim
+        else:
+            output_ndim = {
+                name: 3 if name == MIMO_LANGUAGE_MODULE_KEY else 2
+                for name in grids
+            }
+
         return MimoModelInfra(
             module_to_grid_map=grids,
             topology=topology,
             pg_collections=pg_collections,
             participating_modules=participating_modules,
+            module_output_ndim=output_ndim,
         )
 
     def _get_pg_collections_from_grids(
@@ -289,7 +308,7 @@ class MimoModelProvider(ModelProviderMixin[MimoModel]):
         # Inject pg_collection into language model spec
         language_spec = self.language_model_spec
         if self.mimo_parallelism_config:
-            llm_pg = infra.pg_collections.get("llm")
+            llm_pg = infra.pg_collections.get(MIMO_LANGUAGE_MODULE_KEY)
             if llm_pg is not None:
                 language_spec = self._inject_pg_collection_into_language_spec(
                     language_spec,
@@ -312,7 +331,6 @@ class MimoModelProvider(ModelProviderMixin[MimoModel]):
             modality_submodules_spec=modality_specs,
             special_token_ids=self.special_token_ids,
             module_to_grid_map=(infra.module_to_grid_map if self.mimo_parallelism_config is not None else None),
-            language_module_key="llm" if self.mimo_parallelism_config is not None else None,
         )
 
         mimo_model = MimoModel(mimo_model_config)

--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -674,6 +674,12 @@ def save_checkpoint(
                         pg_collection.dp_cp,
                         ckpt_cfg.ckpt_assume_constant_structure,
                     )
+            # MiMo + torch_dist can hit known access-pattern validation failures
+            # for nested DDP language model tensors in PP>1 runs when
+            # fully_parallel_save is disabled. Keep validation enabled otherwise.
+            is_mimo = len(model) == 1 and hasattr(model[0], "mimo_config")
+            if is_mimo and ckpt_cfg.ckpt_format == "torch_dist" and not ckpt_cfg.fully_parallel_save:
+                validate_sharding_integrity = False
             # Store save strategy for future checkpoint saves
             if checkpointing_context is not None:
                 checkpointing_context["save_strategy"] = save_strategy
@@ -1314,6 +1320,7 @@ def load_checkpoint(
     strict: bool = True,
     checkpointing_context: Optional[dict[str, Any]] = None,
     skip_load_to_model_and_opt: bool = False,
+    pg_collection: Optional[ProcessGroupCollection] = None,
 ) -> tuple[int, int]:
     """Load a model checkpoint.
 
@@ -1330,6 +1337,9 @@ def load_checkpoint(
         checkpointing_context: Dictionary to store context across loads (e.g., strategies).
         skip_load_to_model_and_opt: If True, only loads metadata (iteration, rng) but
                                       skips loading state into model and optimizer modules.
+        pg_collection: Optional ProcessGroupCollection. When provided, uses this instead of
+                      extracting from model via get_pg_collection(). Required for MiMo where
+                      model-level PG extraction may not reflect rank-local topology.
 
     Returns:
         A tuple containing:
@@ -1352,7 +1362,8 @@ def load_checkpoint(
         cfg.checkpoint.finetune = True
 
     return _load_checkpoint_from_path(
-        load_dir, state, model, optimizer, opt_param_scheduler, strict, checkpointing_context
+        load_dir, state, model, optimizer, opt_param_scheduler, strict, checkpointing_context,
+        pg_collection=pg_collection,
     )
 
 
@@ -1381,6 +1392,7 @@ def _load_checkpoint_from_path(
     checkpointing_context: Optional[dict[str, Any]] = None,
     skip_load_to_model_and_opt: bool = False,
     ignore_ckpt_step: bool = False,
+    pg_collection: Optional[ProcessGroupCollection] = None,
 ) -> tuple[int, int]:
     """Load a checkpoint from a given path.
 
@@ -1396,6 +1408,9 @@ def _load_checkpoint_from_path(
                                       skips loading state into model and optimizer modules.
         ignore_ckpt_step: If True, ignores the ckpt_step config and loads latest checkpoint.
                           Used when loading pretrained checkpoints in PEFT scenarios.
+        pg_collection: Optional ProcessGroupCollection. When provided, uses this instead of
+                      extracting from model via get_pg_collection(). Required for MiMo where
+                      model-level PG extraction may not reflect rank-local topology.
 
     Returns:
         A tuple containing:
@@ -1404,7 +1419,7 @@ def _load_checkpoint_from_path(
     """
     cfg = state.cfg
     model = unwrap_model(model)
-    pg_collection = get_pg_collection(model)
+    pg_collection = pg_collection or get_pg_collection(model)
     ckpt_format = cfg.checkpoint.ckpt_format
 
     # Step 1: Load base checkpoint with rank0=True (torch_dist only)
@@ -1416,6 +1431,7 @@ def _load_checkpoint_from_path(
             checkpointing_context=checkpointing_context,
             ignore_ckpt_step=ignore_ckpt_step,
             cfg=cfg,
+            is_mimo=False,
             pg_collection=pg_collection,
         )
 
@@ -1437,19 +1453,31 @@ def _load_checkpoint_from_path(
             print_rank_0("run_config.yaml not found, extracting config from legacy Megatron-LM checkpoint")
             run_config = _extract_megatron_lm_args_from_state_dict(state_dict)
 
-        ckpt_tp_pp = (
-            run_config["model"]["tensor_model_parallel_size"],
-            run_config["model"]["pipeline_model_parallel_size"],
+        # MiMo manages per-module parallelism via MimoParallelismConfig,
+        # so there is no single global (TP, PP) to compare.  Skip the
+        # compatibility check entirely for MiMo configs.
+        _is_mimo = (
+            "mimo_parallelism_config" in run_config.get("model", {})
+            or hasattr(cfg.model, "mimo_parallelism_config")
         )
-        run_tp_pp = (
-            cfg.model.tensor_model_parallel_size,
-            cfg.model.pipeline_model_parallel_size,
-        )
-        mismatch_msg = "(TP, PP) mismatch after resume ({} vs {} from checkpoint)".format(run_tp_pp, ckpt_tp_pp)
+        if _is_mimo:
+            tp_pp_match = True
+            mismatch_msg = ""
+        else:
+            ckpt_tp_pp = (
+                run_config["model"]["tensor_model_parallel_size"],
+                run_config["model"]["pipeline_model_parallel_size"],
+            )
+            run_tp_pp = (
+                cfg.model.tensor_model_parallel_size,
+                cfg.model.pipeline_model_parallel_size,
+            )
+            tp_pp_match = ckpt_tp_pp == run_tp_pp
+            mismatch_msg = "(TP, PP) mismatch after resume ({} vs {} from checkpoint)".format(run_tp_pp, ckpt_tp_pp)
 
         # Determine if RNG state will be loaded
         if (
-            ckpt_tp_pp == run_tp_pp
+            tp_pp_match
             and not release
             and not cfg.checkpoint.finetune
             and cfg.checkpoint.load_rng
@@ -1461,7 +1489,7 @@ def _load_checkpoint_from_path(
         else:
             ignore_rng_state = True
             gen_sd_rng_state = None
-            if ckpt_tp_pp != run_tp_pp:
+            if not tp_pp_match:
                 print_rank_0("{}: RNG state will be ignored".format(mismatch_msg))
 
         sharded_sd_metadata = dist_checkpointing.load_content_metadata(preloaded_state_dict=state_dict)
@@ -1487,7 +1515,7 @@ def _load_checkpoint_from_path(
                         ),
                     }
                 if (
-                    ckpt_tp_pp != run_tp_pp
+                    not tp_pp_match
                     and sharded_sd_metadata["distrib_optim_sharding_type"]
                     not in DistributedOptimizer.checkpoint_fully_reshardable_formats
                 ):
@@ -1502,7 +1530,7 @@ def _load_checkpoint_from_path(
 
         # Determine if rerun state will be loaded
         if (
-            ckpt_tp_pp == run_tp_pp
+            tp_pp_match
             and not release
             and not cfg.checkpoint.finetune
             and "rerun_state_machine" in state_dict
@@ -1514,7 +1542,7 @@ def _load_checkpoint_from_path(
             ignore_rerun_state = False
         else:
             gen_sd_rerun_state = None
-            if ckpt_tp_pp != run_tp_pp:
+            if not tp_pp_match:
                 print_rank_0("{}: Rerun state will be ignored".format(mismatch_msg))
 
         sharded_sd_metadata["dp_cp_group"] = pg_collection.dp_cp
@@ -1628,6 +1656,7 @@ def _load_checkpoint_from_path(
         checkpointing_context=checkpointing_context,
         ignore_ckpt_step=ignore_ckpt_step,
         cfg=cfg,
+        is_mimo=(_is_mimo if ckpt_format == "torch_dist" else False),
         pg_collection=pg_collection,
         **load_kwargs,
     )
@@ -1687,7 +1716,18 @@ def _load_checkpoint_from_path(
                 and optimizer is not None
                 and not getattr(optimizer, "is_stub_optimizer", False)
             ):
-                optimizer.load_state_dict(state_dict["optimizer"])
+                # For MiMo with torch_dist, skip optimizer.load_state_dict():
+                # dist_checkpointing only saves common state from rank 0, but
+                # non-colocated MiMo has different common state per rank (each
+                # rank only holds its active module's param_groups).  The sharded
+                # param states are already loaded by dist_checkpointing.load,
+                # and the optimizer was pre-initialized via
+                # sharded_state_dict(is_loading=True).
+                # TODO: Make dist_checkpointing.save collect common state from
+                # all ranks in MiMo, or have MiMo replicate all modules' common
+                # state on every rank during save.  That fix belongs in MCore.
+                if not (ckpt_format == "torch_dist" and _is_mimo):
+                    optimizer.load_state_dict(state_dict["optimizer"])
 
             if opt_param_scheduler is not None:
                 if "lr_scheduler" in state_dict:
@@ -2063,6 +2103,7 @@ def _load_global_dist_base_checkpoint(
     iteration: int,
     release: bool,
     checkpointing_context: Optional[dict[str, Any]] = None,
+    is_mimo: bool = False,
     *,
     pg_collection: ProcessGroupCollection,
 ) -> tuple[dict[str, Any], str, bool, CheckpointType]:
@@ -2081,8 +2122,15 @@ def _load_global_dist_base_checkpoint(
         load_strategy = FullyParallelLoadStrategyWrapper(load_strategy, pg_collection.dp_cp)
     if checkpointing_context is not None:
         checkpointing_context["load_strategy"] = load_strategy
+    validate_sharding_integrity = True
+    if is_mimo and ckpt_cfg.ckpt_format == "torch_dist" and not ckpt_cfg.fully_parallel_save:
+        validate_sharding_integrity = False
     state_dict = dist_checkpointing.load(
-        sharded_state_dict, checkpoint_name, load_strategy, strict=ckpt_cfg.dist_ckpt_strictness
+        sharded_state_dict,
+        checkpoint_name,
+        load_strategy,
+        strict=ckpt_cfg.dist_ckpt_strictness,
+        validate_access_integrity=validate_sharding_integrity,
     )
     return state_dict, checkpoint_name, release, CheckpointType.GLOBAL
 
@@ -2095,6 +2143,7 @@ def _load_base_checkpoint(
     checkpointing_context: Optional[dict[str, Any]] = None,
     ignore_ckpt_step: bool = False,
     cfg: Optional[ConfigContainer] = None,
+    is_mimo: bool = False,
     *,
     pg_collection: ProcessGroupCollection,
 ) -> tuple[Optional[dict[str, Any]], str, bool, Optional[CheckpointType]]:
@@ -2183,6 +2232,7 @@ def _load_base_checkpoint(
             iteration,
             release,
             checkpointing_context=checkpointing_context,
+            is_mimo=is_mimo,
             pg_collection=pg_collection,
         )
     elif ckpt_format == "fsdp_dtensor":

--- a/src/megatron/bridge/training/eval.py
+++ b/src/megatron/bridge/training/eval.py
@@ -22,11 +22,24 @@ from megatron.core.num_microbatches_calculator import get_num_microbatches
 from megatron.core.pipeline_parallel import get_forward_backward_func
 from megatron.core.pipeline_parallel.p2p_communication import P2PCommunicator
 from megatron.core.pipeline_parallel.utils import is_pp_last_stage
+from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.rerun_state_machine import RerunDataIterator, RerunMode, get_rerun_state_machine
 from megatron.core.transformer import MegatronModule
 from megatron.core.transformer.enums import CudaGraphScope
 from megatron.core.utils import get_model_config
 from modelopt.torch.distill.plugins.megatron import get_tensor_shapes_adjust_fn_for_distillation
+
+
+# Multimodule support from PR 3212 (optional - fallback if not available)
+try:
+    from megatron.core.pipeline_parallel.multimodule_communicator import MultiModulePipelineCommunicator
+    from megatron.core.process_groups_config import MultiModuleProcessGroupCollection
+
+    _MULTIMODULE_AVAILABLE = True
+except ImportError:
+    MultiModulePipelineCommunicator = None  # type: ignore
+    MultiModuleProcessGroupCollection = None  # type: ignore
+    _MULTIMODULE_AVAILABLE = False
 
 from megatron.bridge.data.finetuning import prepare_finetuning_batch
 from megatron.bridge.data.iterator_utils import make_data_iterator_list
@@ -49,6 +62,8 @@ def evaluate(
     config: ConfigContainer,
     verbose: bool = False,
     non_loss_data_func: Optional[Callable] = None,
+    p2p_communicator: Optional[Union[P2PCommunicator, "MultiModulePipelineCommunicator"]] = None,
+    pg_collection: Optional[Union[ProcessGroupCollection, "MultiModuleProcessGroupCollection"]] = None,
     callback_manager: CallbackManager | None = None,
     is_test: bool = False,
 ) -> tuple[Optional[dict[str, torch.Tensor]], Optional[Any], bool]:
@@ -63,6 +78,12 @@ def evaluate(
         config (ConfigContainer): Configuration container (potentially redundant).
         verbose (bool, optional): Whether to print evaluation progress. Defaults to False.
         non_loss_data_func (Optional[Callable], optional): Function to compute non-loss data. Defaults to None.
+        p2p_communicator (Optional[Union[P2PCommunicator, MultiModulePipelineCommunicator]], optional):
+            Custom communicator for pipeline parallelism. If None, creates a default P2PCommunicator.
+            For MIMO models, pass a MultiModulePipelineCommunicator. Defaults to None.
+        pg_collection (Optional[Union[ProcessGroupCollection, MultiModuleProcessGroupCollection]], optional):
+            Custom process group collection. If None, extracts from model via get_pg_collection().
+            For MIMO models, pass a MultiModuleProcessGroupCollection. Defaults to None.
         callback_manager (Optional[CallbackManager]): Optional callback manager for firing callbacks.
         is_test (bool, optional): Whether this is test evaluation (vs validation). Defaults to False.
             Controls which callback events are fired (on_test_* vs on_eval_*).
@@ -88,7 +109,9 @@ def evaluate(
         model_module.eval()
 
     # Retrieve process group collection and model config from the model
-    pg_collection = get_pg_collection(model)
+    # Use injected pg_collection if provided, otherwise extract from model
+    if pg_collection is None:
+        pg_collection = get_pg_collection(model)
     model_config = get_model_config(model[0])
 
     # Disable result validation during evaluation
@@ -101,6 +124,11 @@ def evaluate(
     # make validation batch size independent from training batch size
     eval_batch_size = state.cfg.train.global_batch_size
     eval_num_microbatches = eval_batch_size // (state.cfg.train.micro_batch_size * state.cfg.data_parallel_size)
+
+    # Determine if this is a multimodule evaluation (MIMO)
+    is_multimodule = isinstance(pg_collection, MultiModuleProcessGroupCollection) or isinstance(
+        p2p_communicator, MultiModulePipelineCommunicator
+    )
 
     if not state.cfg.dist.use_decentralized_pg:
         adjust_tensor_shapes_fn = get_tensor_shapes_adjust_fn_for_distillation(
@@ -116,7 +144,15 @@ def evaluate(
         if verbose:
             print_rank_0(f"Evaluating on {state.cfg.validation.eval_iters * eval_batch_size} samples")
 
-        if (
+        if is_multimodule:
+            # For multimodule, use forward_backward_pipelining_without_interleaving directly
+            # CUDA graphs not yet supported for multimodule
+            from megatron.core.pipeline_parallel.schedules import (
+                forward_backward_pipelining_without_interleaving,
+            )
+
+            forward_backward_func = forward_backward_pipelining_without_interleaving
+        elif (
             state.cfg.model.cuda_graph_impl == "local"
             and CudaGraphScope.full_iteration in state.cfg.model.cuda_graph_scope
         ):
@@ -163,7 +199,11 @@ def evaluate(
             # Don't care about timing during evaluation
             config.timers = None
             fault_tolerance.on_eval_step_start(state)
-            p2p_communicator = P2PCommunicator(pp_group=pg_collection.pp, config=model_config)
+
+            # Use injected communicator or create default P2PCommunicator
+            eval_p2p_communicator = p2p_communicator
+            if eval_p2p_communicator is None:
+                eval_p2p_communicator = P2PCommunicator(pp_group=pg_collection.pp, config=model_config)
 
             if should_fire(callback_manager, step_start_event):
                 callback_manager.fire(
@@ -184,7 +224,7 @@ def evaluate(
                 micro_batch_size=state.cfg.train.micro_batch_size,
                 forward_only=True,
                 adjust_tensor_shapes_fn=adjust_tensor_shapes_fn,
-                p2p_communicator=p2p_communicator,
+                p2p_communicator=eval_p2p_communicator,
                 pg_collection=pg_collection,
             )
             fault_tolerance.on_eval_step_end(state)
@@ -212,8 +252,21 @@ def evaluate(
             if state.cfg.train.empty_unused_memory_level >= 1:
                 torch.cuda.empty_cache()
 
-            if is_pp_last_stage(pg_collection.pp):
+            # Check if this is the last pipeline stage
+            # For multimodule, use communicator property; for single module, use pg_collection.pp
+            if is_multimodule:
+                is_last_stage = eval_p2p_communicator.is_pp_last_stage
+            else:
+                is_last_stage = is_pp_last_stage(pg_collection.pp)
+
+            if is_last_stage:
                 # Reduce across processes.
+                # For multimodule, get dp_cp from the language model's pg_collection
+                if is_multimodule:
+                    dp_cp_group = pg_collection.get_language_model_collection().dp_cp
+                else:
+                    dp_cp_group = pg_collection.dp_cp
+
                 for key in loss_dicts[0].keys():
                     if key not in total_loss_dict:
                         total_loss_dict[key] = torch.tensor([0.0, 0.0], dtype=torch.float).cuda()
@@ -221,7 +274,7 @@ def evaluate(
 
                     if val[0].numel() == 2:
                         val = torch.vstack(val).sum(dim=0)
-                        torch.distributed.all_reduce(val, group=pg_collection.dp_cp)
+                        torch.distributed.all_reduce(val, group=dp_cp_group)
                         total_loss_dict[key] += val
                     elif val[0].numel() == 1:
                         val = torch.cat(val).sum()
@@ -265,7 +318,11 @@ def evaluate(
                     data_iterator=non_loss_microbatch_iterator,
                 )
 
-            p2p_communicator = P2PCommunicator(pp_group=pg_collection.pp, config=model_config)
+            # Use injected communicator or create default P2PCommunicator
+            non_loss_p2p_communicator = p2p_communicator
+            if non_loss_p2p_communicator is None:
+                non_loss_p2p_communicator = P2PCommunicator(pp_group=pg_collection.pp, config=model_config)
+
             collected_non_loss_data = forward_backward_func(
                 forward_step_func=wrapped_forward_step,
                 data_iterator=non_loss_data_iterator,
@@ -275,7 +332,7 @@ def evaluate(
                 micro_batch_size=state.cfg.train.micro_batch_size,
                 forward_only=True,
                 collect_non_loss_data=True,
-                p2p_communicator=p2p_communicator,
+                p2p_communicator=non_loss_p2p_communicator,
                 pg_collection=pg_collection,
             )
 
@@ -306,6 +363,8 @@ def evaluate_and_print_results(
     write_to_tensorboard: bool = True,
     process_non_loss_data_func: Optional[Callable] = None,
     non_loss_data_func: Optional[Callable] = None,
+    p2p_communicator: Optional[Union[P2PCommunicator, "MultiModulePipelineCommunicator"]] = None,
+    pg_collection: Optional[Union[ProcessGroupCollection, "MultiModuleProcessGroupCollection"]] = None,
     callback_manager: CallbackManager | None = None,
     is_test: bool = False,
 ) -> None:
@@ -322,6 +381,10 @@ def evaluate_and_print_results(
         write_to_tensorboard (bool, optional): Whether to write results to TensorBoard. Defaults to True.
         process_non_loss_data_func (Optional[Callable], optional): Function to process non-loss data. Defaults to None.
         non_loss_data_func (Optional[Callable], optional): Function to compute non-loss data. Defaults to None.
+        p2p_communicator (Optional[Union[P2PCommunicator, MultiModulePipelineCommunicator]], optional):
+            Custom communicator for pipeline parallelism. Passed to evaluate(). Defaults to None.
+        pg_collection (Optional[Union[ProcessGroupCollection, MultiModuleProcessGroupCollection]], optional):
+            Custom process group collection. Passed to evaluate(). Defaults to None.
         callback_manager (Optional[CallbackManager]): Optional callback manager for firing callbacks.
         is_test (bool, optional): Whether this is test evaluation (vs validation). Defaults to False.
             Controls which callback events are fired (on_test_* vs on_eval_*).
@@ -356,6 +419,8 @@ def evaluate_and_print_results(
         config,
         verbose,
         non_loss_data_func,
+        p2p_communicator=p2p_communicator,
+        pg_collection=pg_collection,
         callback_manager=callback_manager,
         is_test=is_test,
     )

--- a/src/megatron/bridge/training/mimo_parallel_utils.py
+++ b/src/megatron/bridge/training/mimo_parallel_utils.py
@@ -1,0 +1,291 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+"""Multi-module process group utilities for MIMO heterogeneous parallel training.
+
+This module provides utilities for building process group structures and handling
+gradients across modules with different parallelism configurations.
+
+Key functions:
+- unwrap_mimo_model(): Unwrap Float16Module/DDP to get underlying MimoModel
+- build_pg_collection_for_schedule(): Build pg_collection compatible with schedule
+- multimodule_no_sync(): Context manager for gradient sync during microbatch accumulation
+- finalize_model_grads_multimodule(): Finalize gradients for each module
+- zero_grad_buffer_for_multimodule(): Reset gradient buffers for all modules
+- validate_no_stub_ranks(): Ensure every rank participates in at least one module
+- validate_data_loader_contract(): Validate data loading constraints
+"""
+
+from __future__ import annotations
+
+import logging
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Dict, List, Tuple
+
+import torch.distributed as dist
+from megatron.core.distributed.finalize_model_grads import finalize_model_grads as _finalize_model_grads
+from megatron.core.models.mimo import MimoModel
+
+from megatron.bridge.models.mimo.mimo_provider import MimoModelInfra
+
+
+if TYPE_CHECKING:
+    from megatron.core.hyper_comm_grid import HyperCommGrid
+
+
+logger = logging.getLogger(__name__)
+
+
+def unwrap_mimo_model(model) -> MimoModel:
+    """Unwrap Float16Module/DDP wrappers to get the underlying MimoModel.
+
+    When using mixed precision (bf16/fp16), models are wrapped in Float16Module.
+    This function unwraps the model to access MimoModel-specific attributes
+    like `role`, `mimo_config`, `language_model`, `modality_submodules`, etc.
+
+    Args:
+        model: A MimoModel or a wrapped version (Float16Module, DDP).
+
+    Returns:
+        The underlying MimoModel instance.
+
+    Raises:
+        RuntimeError: If the model cannot be unwrapped to a MimoModel.
+    """
+    unwrapped = model
+    while not isinstance(unwrapped, MimoModel) and hasattr(unwrapped, "module"):
+        unwrapped = unwrapped.module
+    if not isinstance(unwrapped, MimoModel):
+        raise RuntimeError(f"Failed to unwrap model to MimoModel, got {type(unwrapped)}")
+    return unwrapped
+
+
+def is_current_rank_in_grid(grid: "HyperCommGrid") -> bool:
+    """Check if current rank participates in the given grid.
+
+    Args:
+        grid: HyperCommGrid to check participation in.
+
+    Returns:
+        True if current rank is within the grid's rank range.
+    """
+    current_rank = dist.get_rank()
+    return grid.rank_offset <= current_rank < (grid.rank_offset + grid.size)
+
+
+def get_module_to_grid_tuple(
+    mimo_model: MimoModel,
+    infra: MimoModelInfra,
+) -> List[Tuple]:
+    """Build list of (module, grid) tuples for all modules the current rank participates in.
+
+    Args:
+        mimo_model: The MimoModel instance.
+        infra: MimoModelInfra containing module_to_grid_map.
+
+    Returns:
+        List of (module, grid) tuples for modules this rank participates in.
+    """
+    module_to_grid_tuple = []
+
+    # Unwrap Float16Module/DDP if present (used in mixed precision training)
+    unwrapped_model = unwrap_mimo_model(mimo_model)
+
+    for module_name, grid in infra.module_to_grid_map.items():
+        if not is_current_rank_in_grid(grid):
+            continue
+
+        # Get the actual module from the unwrapped model
+        if module_name == "llm":
+            module = unwrapped_model.language_model
+        elif hasattr(unwrapped_model, "modality_submodules") and module_name in unwrapped_model.modality_submodules:
+            module = unwrapped_model.modality_submodules[module_name]
+        else:
+            logger.warning(f"Module {module_name} not found in MimoModel, skipping")
+            continue
+
+        module_to_grid_tuple.append((module, grid))
+
+    return module_to_grid_tuple
+
+
+def build_pg_collection_for_schedule(infra: MimoModelInfra):
+    """Build pg_collection compatible with schedule.
+
+    Primary: Use MultiModuleProcessGroupCollection if PR 3212 allows
+             missing LLM PG on encoder-only ranks.
+    Fallback: Return list of ProcessGroupCollections for participating modules.
+
+    IMPORTANT: Uses infra.pg_collections directly. Do NOT rebuild PGs.
+
+    Args:
+        infra: MimoModelInfra with pg_collections for each module.
+
+    Returns:
+        MultiModuleProcessGroupCollection or list of ProcessGroupCollections.
+    """
+    try:
+        from megatron.core.process_groups_config import MultiModuleProcessGroupCollection
+
+        module_pgs = {k: v for k, v in infra.pg_collections.items() if v is not None}
+        if not module_pgs:
+            raise ValueError("module_pgs dict cannot be empty")
+        language_model_module_name = "llm" if "llm" in module_pgs else None
+        return MultiModuleProcessGroupCollection(
+            module_pgs=module_pgs,
+            language_model_module_name=language_model_module_name,
+        )
+    except (ImportError, ValueError, TypeError) as e:
+        logger.warning(f"MultiModuleProcessGroupCollection failed ({e}), using list-based fallback")
+        return [pg for pg in infra.pg_collections.values() if pg is not None]
+
+
+@contextmanager
+def multimodule_no_sync(*, module_to_grid_tuple: List[Tuple]):
+    """Context manager to disable gradient sync for all modules during microbatch accumulation.
+
+    This function is designed to be used with functools.partial() to pre-bind
+    the module_to_grid_tuple parameter, since the schedule calls no_sync_func()
+    with no arguments.
+
+    Args:
+        module_to_grid_tuple: List of (module, grid) tuples (keyword-only, bound via partial).
+
+    Yields:
+        None - context manager for gradient sync control.
+    """
+    contexts = []
+    for module, grid in module_to_grid_tuple:
+        if module is not None and is_current_rank_in_grid(grid):
+            contexts.append(module.no_sync())
+
+    # Enter all contexts
+    for ctx in contexts:
+        ctx.__enter__()
+
+    try:
+        yield
+    finally:
+        # Exit all contexts in reverse order
+        for ctx in reversed(contexts):
+            ctx.__exit__(None, None, None)
+
+
+def finalize_model_grads_multimodule(
+    model,
+    num_tokens=None,
+    pg_collection=None,
+    force_all_reduce=None,
+    *,
+    infra: MimoModelInfra,
+    module_to_grid_tuple: List[Tuple],
+):
+    """Finalize gradients for each module using infra.pg_collections.
+
+    IMPORTANT: Signature matches schedule's call pattern:
+        config.finalize_model_grads_func([model], num_tokens, pg_collection, force_all_reduce=flag)
+
+    The `infra` and `module_to_grid_tuple` parameters are pre-bound via partial().
+    We ignore the schedule-provided `pg_collection` and use per-module PGs.
+
+    Args:
+        model: Model list (passed by schedule, ignored - we use module_to_grid_tuple).
+        num_tokens: Token count for gradient scaling.
+        pg_collection: Schedule-provided PG (ignored - we use per-module PGs).
+        force_all_reduce: Schedule-provided flag (ignored - per-module PGs control sync).
+        infra: MimoModelInfra with per-module pg_collections (keyword-only, bound via partial).
+        module_to_grid_tuple: List of (module, grid) tuples (keyword-only, bound via partial).
+    """
+    for module, grid in module_to_grid_tuple:
+        if module is not None and is_current_rank_in_grid(grid):
+            # Get the module's pg_collection from infra
+            # Find the module name by matching the grid
+            module_pg = None
+            for module_name, mod_grid in infra.module_to_grid_map.items():
+                if mod_grid is grid:
+                    module_pg = infra.pg_collections.get(module_name)
+                    break
+
+            if module_pg is not None:
+                _finalize_model_grads([module], num_tokens=num_tokens, pg_collection=module_pg)
+
+
+def zero_grad_buffer_for_multimodule(module_to_grid_tuple: List[Tuple]):
+    """Reset gradient buffers for all DDP-wrapped modules.
+
+    Args:
+        module_to_grid_tuple: List of (module, grid) tuples.
+    """
+    for module, grid in module_to_grid_tuple:
+        if module is not None and is_current_rank_in_grid(grid):
+            if hasattr(module, "zero_grad_buffer"):
+                module.zero_grad_buffer()
+
+
+def validate_no_stub_ranks(module_to_grid_map: Dict[str, "HyperCommGrid"], world_size: int):
+    """Ensure every rank participates in at least one module.
+
+    Stub ranks (ranks not participating in any module) are NOT supported.
+    This validation runs at setup time to fail fast with a clear error.
+
+    Args:
+        module_to_grid_map: Mapping of module names to their HyperCommGrids.
+        world_size: Total number of ranks in the world.
+
+    Raises:
+        ValueError: If any rank doesn't participate in a module.
+    """
+    participating_ranks = set()
+    for module_name, grid in module_to_grid_map.items():
+        # Add all ranks in this grid's range
+        for rank in range(grid.rank_offset, grid.rank_offset + grid.size):
+            participating_ranks.add(rank)
+
+    all_ranks = set(range(world_size))
+    stub_ranks = all_ranks - participating_ranks
+
+    if stub_ranks:
+        raise ValueError(
+            f"Ranks {sorted(stub_ranks)} do not participate in any module. "
+            f"Stub ranks are not supported. Adjust parallelism config to use all {world_size} GPUs, "
+            f"or reduce world_size to {len(participating_ranks)}."
+        )
+
+
+def validate_data_loader_contract(
+    infra: MimoModelInfra,
+    global_batch_size: int,
+    micro_batch_size: int,
+    num_microbatches: int,
+):
+    """Validate data loading constraints for multimodule training.
+
+    Checks:
+    - Global batch size divisible by all module DP sizes
+    - Micro-batch size consistent with per-module sharding
+    - num_microbatches * micro_batch_size == global_batch_size / DP_size (per module)
+
+    Args:
+        infra: MimoModelInfra with module_to_grid_map.
+        global_batch_size: Total batch size across all data parallel ranks.
+        micro_batch_size: Batch size per microbatch.
+        num_microbatches: Number of microbatches per iteration.
+
+    Raises:
+        ValueError: If any constraint is violated.
+    """
+    for module_name, grid in infra.module_to_grid_map.items():
+        # Get DP size from grid
+        dp_size = grid.get_pg_size(["dp"])
+
+        # Check global batch divisibility
+        if global_batch_size % dp_size != 0:
+            raise ValueError(f"Global batch size {global_batch_size} not divisible by {module_name} DP size {dp_size}")
+
+        # Check micro-batch alignment
+        per_dp_batch = global_batch_size // dp_size
+        expected = num_microbatches * micro_batch_size
+        if per_dp_batch != expected:
+            raise ValueError(
+                f"Microbatch mismatch for {module_name}: "
+                f"{num_microbatches} * {micro_batch_size} = {expected} != {per_dp_batch} "
+                f"(global_batch / DP_size)"
+            )

--- a/src/megatron/bridge/training/mimo_parallel_utils.py
+++ b/src/megatron/bridge/training/mimo_parallel_utils.py
@@ -35,6 +35,16 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _get_dp_size_from_grid(grid: "HyperCommGrid") -> int:
+    """Get the DP dimension size from a grid's shape metadata.
+
+    Uses grid.shape / grid.dim_names rather than process groups so that
+    it works on ALL ranks, including those outside the grid.
+    """
+    dp_idx = grid.dim_names.index("dp")
+    return grid.shape[dp_idx]
+
+
 def unwrap_mimo_model(model) -> MimoModel:
     """Unwrap Float16Module/DDP wrappers to get the underlying MimoModel.
 
@@ -187,6 +197,13 @@ def finalize_model_grads_multimodule(
     The `infra` and `module_to_grid_tuple` parameters are pre-bound via partial().
     We ignore the schedule-provided `pg_collection` and use per-module PGs.
 
+    When encoder DP > LLM DP (heterogeneous), the LLM's loss normalization
+    divides by tokens for ALL samples it processes, but after bridge fan-out
+    each encoder DP rank only carries gradient for (encoder_dp / llm_dp) fewer
+    samples.  This makes encoder gradients too small by a factor of
+    encoder_dp / llm_dp.  We compensate after DDP finalization by scaling
+    encoder gradients back up.  
+
     Args:
         model: Model list (passed by schedule, ignored - we use module_to_grid_tuple).
         num_tokens: Token count for gradient scaling.
@@ -195,6 +212,25 @@ def finalize_model_grads_multimodule(
         infra: MimoModelInfra with per-module pg_collections (keyword-only, bound via partial).
         module_to_grid_tuple: List of (module, grid) tuples (keyword-only, bound via partial).
     """
+    # Compute LLM DP size for heterogeneous gradient correction.
+    # The config enforces encoder_dp >= llm_dp (mimo_config.py), so llm_dp is
+    # the reference.  When encoder_dp > llm_dp the encoder gradients arriving
+    # via bridge fan-out are pre-divided by too many tokens and need rescaling.
+    llm_grid = infra.module_to_grid_map.get(MIMO_LANGUAGE_MODULE_KEY)
+    llm_dp = _get_dp_size_from_grid(llm_grid) if llm_grid is not None else 1
+
+    # When calculate_per_token_loss=True, num_tokens carries the LLM's
+    # total_num_tokens from the schedule.  However, only LLM last-stage ranks
+    # accumulate a non-zero value; encoder-only ranks see 0.  Broadcast the
+    # correct count from an LLM rank so that every module (including encoders)
+    # can scale its gradients by 1/total_num_tokens in _finalize_model_grads.
+    if num_tokens is not None and llm_grid is not None:
+        # Pick the last rank in the LLM grid as the source — it is guaranteed
+        # to be the LLM's last pipeline stage and therefore holds the correct
+        # accumulated total_num_tokens.
+        llm_last_rank = llm_grid.rank_offset + llm_grid.size - 1
+        dist.broadcast(num_tokens, src=llm_last_rank)
+
     for module, grid in module_to_grid_tuple:
         if module is not None and is_current_rank_in_grid(grid):
             # Get the module's pg_collection from infra
@@ -207,6 +243,11 @@ def finalize_model_grads_multimodule(
 
             if module_pg is not None:
                 _finalize_model_grads([module], num_tokens=num_tokens, pg_collection=module_pg)
+
+                # Compensate for heterogeneous DP gradient scale mismatch.
+                module_dp = _get_dp_size_from_grid(grid)
+                if module_dp != llm_dp:
+                    module.scale_gradients(float(module_dp) / float(llm_dp))
 
 
 def zero_grad_buffer_for_multimodule(module_to_grid_tuple: List[Tuple]):

--- a/src/megatron/bridge/training/mimo_parallel_utils.py
+++ b/src/megatron/bridge/training/mimo_parallel_utils.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING, Dict, List, Tuple
 import torch.distributed as dist
 from megatron.core.distributed.finalize_model_grads import finalize_model_grads as _finalize_model_grads
 from megatron.core.models.mimo import MimoModel
+from megatron.core.models.mimo.config.role import MIMO_LANGUAGE_MODULE_KEY
 
 from megatron.bridge.models.mimo.mimo_provider import MimoModelInfra
 
@@ -94,7 +95,7 @@ def get_module_to_grid_tuple(
             continue
 
         # Get the actual module from the unwrapped model
-        if module_name == "llm":
+        if module_name == MIMO_LANGUAGE_MODULE_KEY:
             module = unwrapped_model.language_model
         elif hasattr(unwrapped_model, "modality_submodules") and module_name in unwrapped_model.modality_submodules:
             module = unwrapped_model.modality_submodules[module_name]
@@ -128,7 +129,7 @@ def build_pg_collection_for_schedule(infra: MimoModelInfra):
         module_pgs = {k: v for k, v in infra.pg_collections.items() if v is not None}
         if not module_pgs:
             raise ValueError("module_pgs dict cannot be empty")
-        language_model_module_name = "llm" if "llm" in module_pgs else None
+        language_model_module_name = MIMO_LANGUAGE_MODULE_KEY if MIMO_LANGUAGE_MODULE_KEY in module_pgs else None
         return MultiModuleProcessGroupCollection(
             module_pgs=module_pgs,
             language_model_module_name=language_model_module_name,

--- a/src/megatron/bridge/training/mimo_step.py
+++ b/src/megatron/bridge/training/mimo_step.py
@@ -157,9 +157,8 @@ def forward_step(
     needs_data = True
     if mimo_model.role is not None:
         if mimo_model.role.has_language_module:
-            module_name = MIMO_LANGUAGE_MODULE_KEY
-            is_first_stage = mimo_model.role.is_first_stage(module_name)
-            is_last_stage = mimo_model.role.is_last_stage(module_name)
+            is_first_stage = mimo_model.role.is_first_stage(MIMO_LANGUAGE_MODULE_KEY)
+            is_last_stage = mimo_model.role.is_last_stage(MIMO_LANGUAGE_MODULE_KEY)
             needs_data = is_first_stage or is_last_stage
         elif mimo_model.role.has_modality_modules:
             modality_modules = mimo_model.role.modality_module_names

--- a/src/megatron/bridge/training/mimo_step.py
+++ b/src/megatron/bridge/training/mimo_step.py
@@ -1,0 +1,207 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+"""MIMO-specific forward step function for use with pipeline schedules.
+
+This module provides the forward step function for MIMO model training.
+Key design notes (per PR 3212):
+- The schedule expects dict-based outputs: {module_name: tensor} instead of single tensors
+- The MimoModel's forward returns output tensors that the schedule sends via MultiModulePipelineCommunicator
+- The schedule's backward_step_multimodule() handles dict-based backward pass automatically
+- Only the LLM module produces a loss - encoders just produce activations
+"""
+
+from __future__ import annotations
+
+import logging
+from functools import partial
+from typing import TYPE_CHECKING, Dict, Iterable, Optional, Tuple
+
+import torch
+from megatron.core.models.mimo import MimoModel
+
+from megatron.bridge.training.mimo_parallel_utils import unwrap_mimo_model
+from megatron.bridge.training.state import GlobalState
+
+
+if TYPE_CHECKING:
+    pass
+
+
+logger = logging.getLogger(__name__)
+
+
+def loss_func(loss_mask: torch.Tensor, output_tensor: torch.Tensor) -> Tuple:
+    """Loss function for MIMO model training.
+
+    Called at the terminal stage (LLM's last PP stage).
+
+    Args:
+        loss_mask: Mask indicating which tokens contribute to the loss.
+        output_tensor: Model output tensor (losses per token).
+
+    Returns:
+        Tuple of (total_loss, num_tokens, {'lm loss': reporting_loss}).
+
+    Note:
+        Only the LLM module produces a loss. Encoders produce activations
+        that are consumed by the LLM, but don't have their own loss.
+    """
+    losses = output_tensor.float()
+
+    loss_mask = loss_mask.contiguous().view(-1).float()
+
+    total_tokens = loss_mask.sum().clone().detach().to(torch.int)
+    total_loss = torch.sum(losses.view(-1) * loss_mask)
+    reporting_loss = torch.cat([total_loss.clone().detach().view(1), total_tokens.view(1)])
+
+    return (total_loss, total_tokens, {"lm loss": reporting_loss})
+
+
+def get_batch(data_iterator: Iterable) -> Optional[Dict[str, torch.Tensor]]:
+    """Get batch from data iterator.
+
+    Returns dict with:
+    - input_ids, labels, loss_mask, position_ids (for LLM)
+    - modality_inputs: {modality_name: preprocessed_tensors} (for encoders)
+
+    Uses existing MimoDataset format from Phase 3.
+
+    Args:
+        data_iterator: Iterator over the dataset.
+
+    Returns:
+        Batch dictionary or None if iterator is exhausted.
+    """
+    if data_iterator is None:
+        return None
+
+    try:
+        batch = next(data_iterator)
+    except StopIteration:
+        return None
+
+    # Move tensors to GPU if not already there
+    def _move_to_cuda(obj):
+        if isinstance(obj, torch.Tensor):
+            return obj.cuda(non_blocking=True) if not obj.is_cuda else obj
+        if isinstance(obj, dict):
+            return {k: _move_to_cuda(v) for k, v in obj.items()}
+        if isinstance(obj, (list, tuple)):
+            converted = [_move_to_cuda(v) for v in obj]
+            return type(obj)(converted)
+        return obj
+
+    if batch is not None:
+        batch = _move_to_cuda(batch)
+
+    return batch
+
+
+def forward_step(
+    state: GlobalState,
+    data_iterator: Iterable,
+    model: MimoModel,
+) -> Tuple[torch.Tensor, Optional[partial]]:
+    """Forward step for MIMO model training.
+
+    Uses 3-arg signature with GlobalState for Bridge compatibility.
+    The training loop wraps this with prepare_forward_step_func() which:
+    - Injects GlobalState automatically if forward_step accepts it
+    - Provides access to state.timers, state.cfg, state.train_state
+
+    The MimoModel handles dict-based tensor flow internally:
+    - Encoder modules produce activations sent via BridgeCommunicator
+    - LLM module receives encoder outputs and produces loss
+
+    At terminal stage: returns (loss_tensor, loss_func)
+    At intermediate stages: returns (output_dict, None) - schedule handles communication
+
+    GUARDRAIL: At last stage, assert output is scalar tensor (not dict) to catch
+    misconfigurations early with a clear error message.
+
+    Args:
+        state: GlobalState containing timers, config, train_state.
+        data_iterator: Iterator over the dataset.
+        model: MimoModel instance.
+
+    Returns:
+        Tuple of (output_tensor, loss_function or None).
+    """
+    # Get the model's role to determine if we're at first pipeline stage
+    mimo_model = unwrap_mimo_model(model)
+
+    # Determine if this rank needs data.
+    # - LLM ranks: first stage needs input_ids; last stage needs labels/loss_mask.
+    # - Modality ranks: only first stage needs raw modality inputs.
+    needs_data = True
+    if mimo_model.role is not None:
+        if mimo_model.role.has_language_module:
+            module_name = mimo_model.role.language_module_name
+            is_first_stage = mimo_model.role.is_first_stage(module_name)
+            is_last_stage = mimo_model.role.is_last_stage(module_name)
+            needs_data = is_first_stage or is_last_stage
+        elif mimo_model.role.has_modality_modules:
+            modality_modules = mimo_model.role.modality_module_names
+            needs_data = any(mimo_model.role.is_first_stage(mod) for mod in modality_modules)
+
+    if needs_data:
+        data_batch = get_batch(data_iterator)
+        if data_batch is None:
+            raise RuntimeError(
+                "get_batch returned None at a stage that requires data. "
+                "This indicates a data-loading or parallelism misconfiguration."
+            )
+    else:
+        # Non-data stages consume hidden states from pipeline input tensors.
+        data_batch = {
+            "input_ids": None,
+            "position_ids": None,
+            "attention_mask": None,
+            "labels": None,
+            "loss_mask": None,
+            "modality_inputs": None,
+        }
+
+    # Extract loss_mask before forward pass
+    loss_mask = data_batch.get("loss_mask")
+
+    # Run forward pass
+    # MimoModel.forward() returns (output_tensor, loss_mask) or just output_tensor
+    output = model(**data_batch)
+
+    # Handle tuple return from model
+    if isinstance(output, tuple):
+        output_tensor, model_loss_mask = output
+        # Use model-provided loss_mask if available
+        if model_loss_mask is not None:
+            loss_mask = model_loss_mask
+    else:
+        output_tensor = output
+
+    # Check if we're at the last pipeline stage for the language module
+    # mimo_model was already unwrapped at the start of this function
+    if mimo_model.role is None:
+        is_last_stage = True
+    elif mimo_model.role.has_language_module:
+        is_last_stage = mimo_model.role.is_last_stage(mimo_model.role.language_module_name)
+    else:
+        is_last_stage = False
+
+    if is_last_stage:
+        # GUARDRAIL: Verify scalar loss at last stage
+        if isinstance(output_tensor, dict):
+            raise ValueError(
+                f"Last pipeline stage must return scalar loss tensor, got dict with keys: {output_tensor.keys()}. "
+                f"Ensure the LLM module's final stage produces a loss, not activations."
+            )
+
+        # Return output and loss function
+        if loss_mask is not None:
+            return output_tensor, partial(loss_func, loss_mask)
+        else:
+            # Create default loss mask if not provided
+            logger.warning("No loss_mask provided, using all-ones mask")
+            default_mask = torch.ones_like(output_tensor)
+            return output_tensor, partial(loss_func, default_mask)
+
+    # Intermediate stage - return output for activation passing
+    return output_tensor, None

--- a/src/megatron/bridge/training/mimo_step.py
+++ b/src/megatron/bridge/training/mimo_step.py
@@ -13,21 +13,42 @@ from __future__ import annotations
 
 import logging
 from functools import partial
-from typing import TYPE_CHECKING, Dict, Iterable, Optional, Tuple
+from typing import Dict, Iterable, Optional, Tuple
 
 import torch
 from megatron.core.models.mimo import MimoModel
 from megatron.core.models.mimo.config.role import MIMO_LANGUAGE_MODULE_KEY
 
+from megatron.bridge.data.mimo.dp_utils import slice_batch_for_mimo
 from megatron.bridge.training.mimo_parallel_utils import unwrap_mimo_model
 from megatron.bridge.training.state import GlobalState
 
 
-if TYPE_CHECKING:
-    pass
-
-
 logger = logging.getLogger(__name__)
+
+
+def _get_module_dp_info(
+    mimo_model: MimoModel,
+) -> Tuple[int, int]:
+    """Get module-local DP rank and size for the current rank.
+
+    Used to slice the global micro-batch via :func:`slice_batch_for_mimo`.
+    Returns (0, 1) when grids are not configured (colocated mode).
+    """
+    grids = getattr(mimo_model.mimo_config, "module_to_grid_map", None)
+    if not grids:
+        return 0, 1
+
+    import torch.distributed as _dist
+
+    current_rank = _dist.get_rank()
+    for _name, grid in grids.items():
+        if grid.rank_offset <= current_rank < (grid.rank_offset + grid.size):
+            dp_rank = grid.get_pg(["dp"]).rank()
+            dp_size = grid.get_pg(["dp"]).size()
+            return dp_rank, dp_size
+
+    return 0, 1
 
 
 def loss_func(loss_mask: torch.Tensor, output_tensor: torch.Tensor) -> Tuple:
@@ -151,6 +172,12 @@ def forward_step(
                 "get_batch returned None at a stage that requires data. "
                 "This indicates a data-loading or parallelism misconfiguration."
             )
+        # Slice the global micro-batch for this module's DP shard.
+        # All data-loading ranks receive identical batches (sampler dp_size=1).
+        # slice_batch_for_mimo contiguously sub-shards to match the
+        # BridgeCommunicator's fan-in/fan-out batch-dimension routing.
+        dp_rank, dp_size = _get_module_dp_info(mimo_model)
+        data_batch = slice_batch_for_mimo(data_batch, dp_rank, dp_size)
     else:
         # Non-data stages consume hidden states from pipeline input tensors.
         data_batch = {

--- a/src/megatron/bridge/training/mimo_step.py
+++ b/src/megatron/bridge/training/mimo_step.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Dict, Iterable, Optional, Tuple
 
 import torch
 from megatron.core.models.mimo import MimoModel
+from megatron.core.models.mimo.config.role import MIMO_LANGUAGE_MODULE_KEY
 
 from megatron.bridge.training.mimo_parallel_utils import unwrap_mimo_model
 from megatron.bridge.training.state import GlobalState
@@ -135,7 +136,7 @@ def forward_step(
     needs_data = True
     if mimo_model.role is not None:
         if mimo_model.role.has_language_module:
-            module_name = mimo_model.role.language_module_name
+            module_name = MIMO_LANGUAGE_MODULE_KEY
             is_first_stage = mimo_model.role.is_first_stage(module_name)
             is_last_stage = mimo_model.role.is_last_stage(module_name)
             needs_data = is_first_stage or is_last_stage
@@ -182,7 +183,7 @@ def forward_step(
     if mimo_model.role is None:
         is_last_stage = True
     elif mimo_model.role.has_language_module:
-        is_last_stage = mimo_model.role.is_last_stage(mimo_model.role.language_module_name)
+        is_last_stage = mimo_model.role.is_last_stage(MIMO_LANGUAGE_MODULE_KEY)
     else:
         is_last_stage = False
 

--- a/src/megatron/bridge/training/pretrain_mimo.py
+++ b/src/megatron/bridge/training/pretrain_mimo.py
@@ -16,11 +16,14 @@ import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, List, Optional
 
+import torch
 import torch.distributed as dist
 from megatron.core.models.mimo import MimoModel
 from megatron.core.pipeline_parallel.multimodule_communicator import MultiModulePipelineCommunicator
 from megatron.core.utils import get_model_config
 
+from megatron.bridge.training.checkpointing import init_checkpointing_context, load_checkpoint
+from megatron.bridge.training.utils.checkpoint_utils import checkpoint_exists
 from megatron.bridge.training.config import ConfigContainer
 from megatron.bridge.training.mimo_parallel_utils import (
     build_pg_collection_for_schedule,
@@ -55,6 +58,8 @@ class MimoSetupOutput:
         train_data_iterator: Training data iterator.
         valid_data_iterator: Validation data iterator (optional).
         global_state: GlobalState containing timers, config, train_state.
+        checkpointing_context: Dictionary holding checkpoint-related state
+            (save strategy cache, LocalCheckpointManager for local saves).
     """
 
     model: "MimoModel"
@@ -65,6 +70,7 @@ class MimoSetupOutput:
     train_data_iterator: Iterator
     valid_data_iterator: Optional[Iterator]
     global_state: GlobalState
+    checkpointing_context: Dict[str, Any]
 
 
 def setup_mimo(
@@ -108,9 +114,10 @@ def setup_mimo(
         )
         train_state = TrainState()
         global_state = GlobalState()
-        global_state.cfg = cfg
         global_state._timers = timers
         global_state.train_state = train_state
+
+    global_state.cfg = cfg
 
     logger.info(f"Rank {dist.get_rank()}: Setting up MIMO training")
 
@@ -182,6 +189,17 @@ def setup_mimo(
         logger.info(f"Rank {dist.get_rank()}: Building data iterators")
         train_data_iterator, valid_data_iterator = build_data_iterators_fn(cfg, mimo_infra)
 
+    # Initialize async checkpoint worker (idempotent if already initialized).
+    global_state.initialize_async_checkpoint_worker()
+
+    # Initialize checkpointing context (save strategy cache + LocalCheckpointManager).
+    checkpointing_context = init_checkpointing_context(cfg.checkpoint)
+
+    # Align start_time across ranks so duration-based exit is consistent.
+    start_time_tensor = torch.tensor([global_state.start_time], dtype=torch.double, device="cuda")
+    dist.all_reduce(start_time_tensor, op=dist.ReduceOp.MIN)
+    global_state.start_time = start_time_tensor.item()
+
     logger.info(f"Rank {dist.get_rank()}: MIMO setup complete")
 
     return MimoSetupOutput(
@@ -193,6 +211,7 @@ def setup_mimo(
         train_data_iterator=train_data_iterator,
         valid_data_iterator=valid_data_iterator,
         global_state=global_state,
+        checkpointing_context=checkpointing_context,
     )
 
 
@@ -235,21 +254,27 @@ def pretrain_mimo(
     # Initialize num-microbatches calculator if not already set.
     from megatron.core import num_microbatches_calculator as nmc
 
+    rampup_batch_size = getattr(cfg.train, "rampup_batch_size", None)
+    assert rampup_batch_size is None, (
+        "Microbatch rampup is not supported in MiMo training. "
+        "Set rampup_batch_size to None."
+    )
+
     if nmc._GLOBAL_NUM_MICROBATCHES_CALCULATOR is None:
         nmc.init_num_microbatches_calculator(
             dist.get_rank(),
-            getattr(cfg.train, "rampup_batch_size", None),
+            rampup_batch_size,
             cfg.train.global_batch_size,
             cfg.train.micro_batch_size,
             cfg.data_parallel_size,
             getattr(cfg.train, "decrease_batch_size_if_needed", False),
         )
 
-    # Setup MIMO components
+    # Setup MIMO components (iterators deferred until after checkpoint load)
     setup_output = setup_mimo(
         cfg=cfg,
         mimo_provider=mimo_provider,
-        build_data_iterators_fn=build_data_iterators_fn,
+        build_data_iterators_fn=None,
         global_state=global_state,
     )
 
@@ -298,6 +323,85 @@ def pretrain_mimo(
                 )
         logger.info(f"Rank {dist.get_rank()}: Auto-created schedulers for modules: {list(schedulers.keys())}")
 
+    # Select rank-local PG collection for non-colocated MiMo.
+    # Each rank participates in exactly one module, so "first non-None" is unambiguous.
+    active_pgs = [pg for pg in setup_output.mimo_infra.pg_collections.values() if pg is not None]
+    assert len(active_pgs) == 1, (
+        f"Non-colocated MiMo requires exactly one active ProcessGroupCollection per rank, "
+        f"got {len(active_pgs)}. Colocated MiMo is not supported by this code path."
+    )
+    local_pg_collection = active_pgs[0]
+
+    # Bridge MiMo's per-module process groups into Megatron's global parallel
+    # state.  MiMo intentionally skips global MPU init (see
+    # MimoModelProvider.initialize_model_parallel), but checkpoint save/load
+    # paths (sharded_state_dict, ensure_metadata_has_dp_cp_group) rely on the
+    # globals.  For non-colocated MiMo every rank is active in exactly one
+    # module, so we can safely set the globals from that module's collection.
+    from megatron.core import parallel_state as mpu
+
+    mpu._TENSOR_MODEL_PARALLEL_GROUP = local_pg_collection.tp
+    mpu._DATA_PARALLEL_GROUP = local_pg_collection.dp
+    mpu._DATA_PARALLEL_GROUP_WITH_CP = getattr(local_pg_collection, "dp_cp", local_pg_collection.dp)
+    if hasattr(local_pg_collection, "pp"):
+        mpu._PIPELINE_MODEL_PARALLEL_GROUP = local_pg_collection.pp
+
+    first_scheduler = next(iter(schedulers.values()), None) if schedulers else None
+
+    # Broadened load-intent gating: includes non-persistent resume intent
+    has_persistent = cfg.checkpoint.load is not None and checkpoint_exists(cfg.checkpoint.load)
+    has_pretrained = (
+        cfg.checkpoint.pretrained_checkpoint is not None
+        and checkpoint_exists(cfg.checkpoint.pretrained_checkpoint)
+    )
+    wants_non_persistent = cfg.checkpoint.non_persistent_ckpt_type is not None
+    should_load = has_persistent or has_pretrained or wants_non_persistent
+
+    if should_load:
+        timers = setup_output.global_state.timers
+        timers("load-checkpoint", log_level=0).start(barrier=True)
+        load_checkpoint(
+            setup_output.global_state,
+            model=[setup_output.model],
+            optimizer=optimizer,
+            opt_param_scheduler=first_scheduler,
+            checkpointing_context=setup_output.checkpointing_context,
+            pg_collection=local_pg_collection,
+        )
+        timers("load-checkpoint").stop(barrier=True)
+        timers.log(["load-checkpoint"])
+
+        # Fan out loaded scheduler state to all active module schedulers.
+        # v1: checkpoints contain a single scheduler blob (first_scheduler).
+        if first_scheduler is not None and len(schedulers) > 1:
+            loaded_state = first_scheduler.state_dict()
+            for sched in schedulers.values():
+                if sched is not first_scheduler:
+                    sched.load_state_dict(loaded_state)
+
+    # Build data iterators after load decision (resume-safe ordering).
+    # When resuming, train_state has restored consumed-sample offsets that
+    # the iterator builder must honor to avoid replaying data from sample 0.
+    train_state = setup_output.global_state.train_state
+    is_resuming = train_state.step > 0
+
+    if is_resuming:
+        import inspect
+
+        sig = inspect.signature(build_data_iterators_fn)
+        if "train_state" in sig.parameters:
+            train_data_iterator, valid_data_iterator = build_data_iterators_fn(
+                cfg, setup_output.mimo_infra, train_state=train_state,
+            )
+        else:
+            raise RuntimeError(
+                "Resuming from checkpoint but build_data_iterators_fn does not accept "
+                "'train_state' argument. The iterator builder must support a train_state "
+                "keyword argument to honor restored consumed-sample offsets during resume."
+            )
+    else:
+        train_data_iterator, valid_data_iterator = build_data_iterators_fn(cfg, setup_output.mimo_infra)
+
     logger.info(f"Rank {dist.get_rank()}: Starting training loop")
 
     # Run training loop
@@ -306,11 +410,12 @@ def pretrain_mimo(
         model=setup_output.model,
         optimizer=optimizer,
         schedulers=schedulers,
-        train_data_iterator=setup_output.train_data_iterator,
-        valid_data_iterator=setup_output.valid_data_iterator,
+        train_data_iterator=train_data_iterator,
+        valid_data_iterator=valid_data_iterator,
         global_state=setup_output.global_state,
         mimo_infra=setup_output.mimo_infra,
         multimodule_communicator=setup_output.multimodule_communicator,
+        checkpointing_context=setup_output.checkpointing_context,
     )
 
     logger.info("MIMO pretraining completed")

--- a/src/megatron/bridge/training/pretrain_mimo.py
+++ b/src/megatron/bridge/training/pretrain_mimo.py
@@ -16,14 +16,12 @@ import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, List, Optional
 
-import torch
 import torch.distributed as dist
 from megatron.core.models.mimo import MimoModel
 from megatron.core.pipeline_parallel.multimodule_communicator import MultiModulePipelineCommunicator
 from megatron.core.utils import get_model_config
 
 from megatron.bridge.training.checkpointing import init_checkpointing_context, load_checkpoint
-from megatron.bridge.training.utils.checkpoint_utils import checkpoint_exists
 from megatron.bridge.training.config import ConfigContainer
 from megatron.bridge.training.mimo_parallel_utils import (
     build_pg_collection_for_schedule,
@@ -33,6 +31,7 @@ from megatron.bridge.training.mimo_parallel_utils import (
 )
 from megatron.bridge.training.state import GlobalState
 from megatron.bridge.training.train_mimo import train_mimo
+from megatron.bridge.training.utils.checkpoint_utils import checkpoint_exists
 
 
 if TYPE_CHECKING:
@@ -256,8 +255,7 @@ def pretrain_mimo(
 
     rampup_batch_size = getattr(cfg.train, "rampup_batch_size", None)
     assert rampup_batch_size is None, (
-        "Microbatch rampup is not supported in MiMo training. "
-        "Set rampup_batch_size to None."
+        "Microbatch rampup is not supported in MiMo training. Set rampup_batch_size to None."
     )
 
     if nmc._GLOBAL_NUM_MICROBATCHES_CALCULATOR is None:
@@ -350,9 +348,8 @@ def pretrain_mimo(
 
     # Broadened load-intent gating: includes non-persistent resume intent
     has_persistent = cfg.checkpoint.load is not None and checkpoint_exists(cfg.checkpoint.load)
-    has_pretrained = (
-        cfg.checkpoint.pretrained_checkpoint is not None
-        and checkpoint_exists(cfg.checkpoint.pretrained_checkpoint)
+    has_pretrained = cfg.checkpoint.pretrained_checkpoint is not None and checkpoint_exists(
+        cfg.checkpoint.pretrained_checkpoint
     )
     wants_non_persistent = cfg.checkpoint.non_persistent_ckpt_type is not None
     should_load = has_persistent or has_pretrained or wants_non_persistent
@@ -391,7 +388,9 @@ def pretrain_mimo(
         sig = inspect.signature(build_data_iterators_fn)
         if "train_state" in sig.parameters:
             train_data_iterator, valid_data_iterator = build_data_iterators_fn(
-                cfg, setup_output.mimo_infra, train_state=train_state,
+                cfg,
+                setup_output.mimo_infra,
+                train_state=train_state,
             )
         else:
             raise RuntimeError(

--- a/src/megatron/bridge/training/pretrain_mimo.py
+++ b/src/megatron/bridge/training/pretrain_mimo.py
@@ -1,0 +1,320 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+"""Entry point for MIMO pretraining.
+
+This module provides the entry point for MIMO pretraining with heterogeneous
+parallelism support. It uses a setup_mimo() helper that composes with existing
+setup logic rather than duplicating pretrain.py.
+
+Key components:
+- setup_mimo(): MIMO-specific setup helper
+- pretrain_mimo(): Entry point for MIMO pretraining
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, List, Optional
+
+import torch.distributed as dist
+from megatron.core.models.mimo import MimoModel
+from megatron.core.pipeline_parallel.multimodule_communicator import MultiModulePipelineCommunicator
+from megatron.core.utils import get_model_config
+
+from megatron.bridge.training.config import ConfigContainer
+from megatron.bridge.training.mimo_parallel_utils import (
+    build_pg_collection_for_schedule,
+    get_module_to_grid_tuple,
+    unwrap_mimo_model,
+    validate_no_stub_ranks,
+)
+from megatron.bridge.training.state import GlobalState
+from megatron.bridge.training.train_mimo import train_mimo
+
+
+if TYPE_CHECKING:
+    from megatron.core.optimizer.optimizer_config import OptimizerConfig
+    from megatron.core.optimizer.optimizer_param_scheduler import OptimizerParamScheduler
+
+    from megatron.bridge.models.mimo.mimo_provider import MimoModelInfra, MimoModelProvider
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class MimoSetupOutput:
+    """Output from setup_mimo() containing all components needed for training.
+
+    Attributes:
+        model: MimoModel (distributed, DDP-wrapped).
+        mimo_infra: MimoModelInfra (grids, topology, pg_collections).
+        multimodule_pg_collection: PG collection for schedule.
+        multimodule_communicator: MultiModulePipelineCommunicator for P2P.
+        module_to_grid_tuple: List of (module, grid) tuples for gradient handling.
+        train_data_iterator: Training data iterator.
+        valid_data_iterator: Validation data iterator (optional).
+        global_state: GlobalState containing timers, config, train_state.
+    """
+
+    model: "MimoModel"
+    mimo_infra: "MimoModelInfra"
+    multimodule_pg_collection: Any
+    multimodule_communicator: MultiModulePipelineCommunicator
+    module_to_grid_tuple: List
+    train_data_iterator: Iterator
+    valid_data_iterator: Optional[Iterator]
+    global_state: GlobalState
+
+
+def setup_mimo(
+    cfg: ConfigContainer,
+    mimo_provider: "MimoModelProvider",
+    build_data_iterators_fn: Optional[Callable] = None,
+    global_state: Optional[GlobalState] = None,
+) -> MimoSetupOutput:
+    """MIMO-specific setup helper.
+
+    This function sets up all components needed for MIMO training:
+    - Builds distributed model via MimoModelProvider
+    - Builds MIMO infrastructure (grids, topology, pg_collections)
+    - Creates MultiModulePipelineCommunicator
+    - Builds data iterators (if function provided)
+    - Validates configuration
+
+    Args:
+        cfg: ConfigContainer with training configuration.
+        mimo_provider: MimoModelProvider for building model and infrastructure.
+        build_data_iterators_fn: Optional function to build data iterators.
+            Should have signature: (cfg, mimo_infra) -> (train_iter, valid_iter)
+        global_state: Optional GlobalState. If not provided, creates a new one.
+
+    Returns:
+        MimoSetupOutput containing all components for training.
+
+    Reuses from setup.py:
+        - Logging setup (via global_state)
+        - Timer infrastructure (via global_state)
+    """
+    # Create GlobalState if not provided
+    if global_state is None:
+        from megatron.core.timers import Timers
+
+        from megatron.bridge.training.state import GlobalState, TrainState
+
+        timers = Timers(
+            log_level=cfg.logger.timing_log_level,
+            log_option=cfg.logger.timing_log_option,
+        )
+        train_state = TrainState()
+        global_state = GlobalState()
+        global_state.cfg = cfg
+        global_state._timers = timers
+        global_state.train_state = train_state
+
+    logger.info(f"Rank {dist.get_rank()}: Setting up MIMO training")
+
+    # Finalize and build infrastructure
+    mimo_provider.finalize()
+    mimo_infra = mimo_provider.build_infra()
+
+    # Validate no stub ranks
+    world_size = dist.get_world_size()
+    validate_no_stub_ranks(mimo_infra.module_to_grid_map, world_size)
+
+    logger.info(f"Rank {dist.get_rank()}: Building distributed model")
+
+    # Build distributed model
+    # Use DDP config from cfg if available
+    from megatron.core.distributed import DistributedDataParallelConfig
+
+    ddp_config = DistributedDataParallelConfig(
+        grad_reduce_in_fp32=getattr(cfg.train, "grad_reduce_in_fp32", False),
+        overlap_grad_reduce=getattr(cfg.train, "overlap_grad_reduce", True),
+        use_distributed_optimizer=getattr(cfg.train, "use_distributed_optimizer", False),
+        check_for_nan_in_grad=getattr(cfg.train, "check_for_nan_in_grad", False),
+    )
+
+    model_list = mimo_provider.provide_distributed_model(
+        ddp_config=ddp_config,
+        fp16=cfg.model.fp16 if hasattr(cfg.model, "fp16") else False,
+        bf16=cfg.model.bf16 if hasattr(cfg.model, "bf16") else True,
+    )
+    model = model_list[0]
+
+    logger.info(f"Rank {dist.get_rank()}: Creating multimodule communicator")
+
+    # Create MultiModulePipelineCommunicator
+    # IMPORTANT: MimoModel produces SBH tensors (seq, batch, hidden), NOT BSH
+    # See MimoModel.align_embeddings_by_token_positions() which returns [s, b, h]
+    model_config = get_model_config(model)
+
+    # Ensure pipeline_dtype is set for P2P communication (required when any module uses PP > 1)
+    # The model config may not have this set if individual modules don't use PP
+    import torch
+
+    if model_config.pipeline_dtype is None:
+        if getattr(model_config, "bf16", False):
+            model_config.pipeline_dtype = torch.bfloat16
+        elif getattr(model_config, "fp16", False):
+            model_config.pipeline_dtype = torch.float16
+        else:
+            model_config.pipeline_dtype = torch.float32
+
+    multimodule_communicator = MultiModulePipelineCommunicator(
+        mimo_infra.module_to_grid_map,
+        mimo_infra.topology,
+        model_config,
+        dim_mapping={"s": 0, "b": 1, "h": 2},  # SBH mapping - matches MimoModel output
+    )
+
+    # Build pg_collection for schedule
+    multimodule_pg_collection = build_pg_collection_for_schedule(mimo_infra)
+
+    # Build module-to-grid tuple for gradient operations
+    module_to_grid_tuple = get_module_to_grid_tuple(model, mimo_infra)
+
+    # Build data iterators if function provided
+    train_data_iterator = None
+    valid_data_iterator = None
+    if build_data_iterators_fn is not None:
+        logger.info(f"Rank {dist.get_rank()}: Building data iterators")
+        train_data_iterator, valid_data_iterator = build_data_iterators_fn(cfg, mimo_infra)
+
+    logger.info(f"Rank {dist.get_rank()}: MIMO setup complete")
+
+    return MimoSetupOutput(
+        model=model,
+        mimo_infra=mimo_infra,
+        multimodule_pg_collection=multimodule_pg_collection,
+        multimodule_communicator=multimodule_communicator,
+        module_to_grid_tuple=module_to_grid_tuple,
+        train_data_iterator=train_data_iterator,
+        valid_data_iterator=valid_data_iterator,
+        global_state=global_state,
+    )
+
+
+def pretrain_mimo(
+    cfg: ConfigContainer,
+    mimo_provider: "MimoModelProvider",
+    forward_step_func: Callable,
+    build_data_iterators_fn: Callable,
+    opt_config: "OptimizerConfig",
+    schedulers: Optional[Dict[str, "OptimizerParamScheduler"]] = None,
+    global_state: Optional[GlobalState] = None,
+) -> None:
+    """Entry point for MIMO pretraining.
+
+    Steps:
+    1. Call setup_mimo() to get model, infra, communicators
+    2. Validate constructor-time MIMO config wiring
+    3. Create MimoOptimizer using get_mimo_optimizer()
+    4. Call train_mimo() with all components
+
+    Args:
+        cfg: ConfigContainer with training configuration.
+        mimo_provider: MimoModelProvider for building model and infrastructure.
+        forward_step_func: Forward step function for training.
+        build_data_iterators_fn: Function to build data iterators.
+            Signature: (cfg, mimo_infra) -> (train_iter, valid_iter)
+        opt_config: OptimizerConfig for creating MimoOptimizer.
+        schedulers: Per-module learning rate schedulers {module_name: scheduler}.
+        global_state: Optional GlobalState. If not provided, creates a new one.
+    """
+    if schedulers is None:
+        schedulers = {}
+
+    logger.info("Starting MIMO pretraining")
+
+    # Ensure optimizer config computes derived fields expected by core optimizers.
+    if hasattr(opt_config, "finalize"):
+        opt_config.finalize()
+
+    # Initialize num-microbatches calculator if not already set.
+    from megatron.core import num_microbatches_calculator as nmc
+
+    if nmc._GLOBAL_NUM_MICROBATCHES_CALCULATOR is None:
+        nmc.init_num_microbatches_calculator(
+            dist.get_rank(),
+            getattr(cfg.train, "rampup_batch_size", None),
+            cfg.train.global_batch_size,
+            cfg.train.micro_batch_size,
+            cfg.data_parallel_size,
+            getattr(cfg.train, "decrease_batch_size_if_needed", False),
+        )
+
+    # Setup MIMO components
+    setup_output = setup_mimo(
+        cfg=cfg,
+        mimo_provider=mimo_provider,
+        build_data_iterators_fn=build_data_iterators_fn,
+        global_state=global_state,
+    )
+
+    # Unwrap Float16Module/DDP wrapper to access mimo_config on the underlying MimoModel
+    unwrapped_model = unwrap_mimo_model(setup_output.model)
+    if setup_output.mimo_infra.module_to_grid_map:
+        # Role/materialization decisions happen in MimoModel.__init__. Provider wiring
+        # must pass these fields at construction time, not by mutating afterwards.
+        assert unwrapped_model.mimo_config.module_to_grid_map is not None, (
+            "MimoModelConfig.module_to_grid_map must be set at model construction time. "
+            "Ensure MimoModelProvider.provide() passes module_to_grid_map for MIMO parallelism."
+        )
+        assert unwrapped_model.mimo_config.language_module_key is not None, (
+            "MimoModelConfig.language_module_key must be set at model construction time. "
+            "Ensure MimoModelProvider.provide() sets language_module_key for MIMO parallelism."
+        )
+
+    logger.info(f"Rank {dist.get_rank()}: Creating MimoOptimizer")
+
+    # Create MimoOptimizer using the factory function
+    # Note: get_mimo_optimizer needs the unwrapped MimoModel to access mimo_config and submodules
+    from megatron.core.models.mimo.optimizer import get_mimo_optimizer
+
+    optimizer = get_mimo_optimizer(unwrapped_model, opt_config)
+
+    # Auto-create per-module LR schedulers when none are provided
+    if not schedulers:
+        cfg._calculate_scheduler_steps()
+
+        from megatron.core.optimizer_param_scheduler import OptimizerParamScheduler
+
+        schedulers = {}
+        for name, info in optimizer.module_infos.items():
+            if info.is_active and info.optimizer is not None:
+                schedulers[name] = OptimizerParamScheduler(
+                    info.optimizer,
+                    init_lr=cfg.scheduler.lr_warmup_init,
+                    max_lr=opt_config.lr,
+                    min_lr=opt_config.min_lr,
+                    lr_warmup_steps=cfg.scheduler.lr_warmup_steps,
+                    lr_decay_steps=cfg.scheduler.lr_decay_steps,
+                    lr_decay_style=cfg.scheduler.lr_decay_style,
+                    start_wd=cfg.scheduler.start_weight_decay,
+                    end_wd=cfg.scheduler.end_weight_decay,
+                    wd_incr_steps=cfg.scheduler.wd_incr_steps,
+                    wd_incr_style=cfg.scheduler.weight_decay_incr_style,
+                    use_checkpoint_opt_param_scheduler=cfg.scheduler.use_checkpoint_opt_param_scheduler,
+                    override_opt_param_scheduler=cfg.scheduler.override_opt_param_scheduler,
+                    wsd_decay_steps=cfg.scheduler.wsd_decay_steps,
+                    lr_wsd_decay_style=cfg.scheduler.lr_wsd_decay_style,
+                )
+        logger.info(f"Rank {dist.get_rank()}: Auto-created schedulers for modules: {list(schedulers.keys())}")
+
+    logger.info(f"Rank {dist.get_rank()}: Starting training loop")
+
+    # Run training loop
+    train_mimo(
+        forward_step_func=forward_step_func,
+        model=setup_output.model,
+        optimizer=optimizer,
+        schedulers=schedulers,
+        train_data_iterator=setup_output.train_data_iterator,
+        valid_data_iterator=setup_output.valid_data_iterator,
+        global_state=setup_output.global_state,
+        mimo_infra=setup_output.mimo_infra,
+        multimodule_communicator=setup_output.multimodule_communicator,
+    )
+
+    logger.info("MIMO pretraining completed")

--- a/src/megatron/bridge/training/pretrain_mimo.py
+++ b/src/megatron/bridge/training/pretrain_mimo.py
@@ -166,6 +166,7 @@ def setup_mimo(
         mimo_infra.topology,
         model_config,
         dim_mapping={"s": 0, "b": 1, "h": 2},  # SBH mapping - matches MimoModel output
+        module_output_ndim=mimo_infra.module_output_ndim,
     )
 
     # Build pg_collection for schedule
@@ -261,11 +262,6 @@ def pretrain_mimo(
             "MimoModelConfig.module_to_grid_map must be set at model construction time. "
             "Ensure MimoModelProvider.provide() passes module_to_grid_map for MIMO parallelism."
         )
-        assert unwrapped_model.mimo_config.language_module_key is not None, (
-            "MimoModelConfig.language_module_key must be set at model construction time. "
-            "Ensure MimoModelProvider.provide() sets language_module_key for MIMO parallelism."
-        )
-
     logger.info(f"Rank {dist.get_rank()}: Creating MimoOptimizer")
 
     # Create MimoOptimizer using the factory function

--- a/src/megatron/bridge/training/train.py
+++ b/src/megatron/bridge/training/train.py
@@ -1071,6 +1071,7 @@ def save_checkpoint_and_time(
     checkpointing_context: dict[str, Any],
     non_persistent_ckpt: bool = False,
     train_data_iterator: Optional[Union[RerunDataIterator, list[RerunDataIterator]]] = None,
+    pg_collection: Optional[ProcessGroupCollection] = None,
 ) -> None:
     """Saves a checkpoint and logs the timing.
 
@@ -1088,6 +1089,8 @@ def save_checkpoint_and_time(
         non_persistent_ckpt: Flag indicating if this is a non-persistent
                              (local) checkpoint. Defaults to False.
         train_data_iterator: Optional training data iterator to save its state.
+        pg_collection: Optional process group collection for MiMo topologies.
+                       When None, save_checkpoint falls back to model-attached PGs.
     """
     timers = state.timers
     energy_monitor = state.energy_monitor
@@ -1119,6 +1122,7 @@ def save_checkpoint_and_time(
         checkpointing_context=checkpointing_context,
         non_persistent_ckpt=non_persistent_ckpt,
         train_data_iterator=train_data_iterator,
+        pg_collection=pg_collection,
     )
     if state.cfg.model.fp8 is not None:
         # Run garbage collection after checkpoint saving to free memory from
@@ -1145,6 +1149,7 @@ def checkpoint_and_decide_exit(
     num_floating_point_operations_so_far: float,
     checkpointing_context: dict[str, Any],
     train_data_iterator: Optional[Union[RerunDataIterator, list[RerunDataIterator]]],
+    pg_collection: Optional[ProcessGroupCollection] = None,
 ) -> bool:
     """Handles checkpointing decisions and determines if training should exit.
 
@@ -1160,6 +1165,8 @@ def checkpoint_and_decide_exit(
         num_floating_point_operations_so_far: Cumulative TFLOPs up to this point.
         checkpointing_context: Dictionary holding checkpointing-related state.
         train_data_iterator: Optional training data iterator to save its state.
+        pg_collection: Optional process group collection for MiMo topologies.
+                       When None, save_checkpoint falls back to model-attached PGs.
 
     Returns:
         True if the training loop should exit, False otherwise.
@@ -1179,6 +1186,7 @@ def checkpoint_and_decide_exit(
                     num_floating_point_operations_so_far,
                     checkpointing_context,
                     train_data_iterator=train_data_iterator,
+                    pg_collection=pg_collection,
                 )
             barrier_and_log("exiting program after receiving SIGTERM.")
 
@@ -1198,6 +1206,7 @@ def checkpoint_and_decide_exit(
             num_floating_point_operations_so_far,
             checkpointing_context,
             train_data_iterator=train_data_iterator,
+            pg_collection=pg_collection,
         )
         saved_checkpoint = True
 
@@ -1215,6 +1224,7 @@ def checkpoint_and_decide_exit(
             checkpointing_context,
             non_persistent_ckpt=True,
             train_data_iterator=train_data_iterator,
+            pg_collection=pg_collection,
         )
         saved_checkpoint = True
 
@@ -1234,6 +1244,7 @@ def checkpoint_and_decide_exit(
                     num_floating_point_operations_so_far,
                     checkpointing_context,
                     train_data_iterator=train_data_iterator,
+                    pg_collection=pg_collection,
                 )
             barrier_and_log(f"exiting program after {train_time} minutes")
 
@@ -1250,6 +1261,7 @@ def checkpoint_and_decide_exit(
                 num_floating_point_operations_so_far,
                 checkpointing_context,
                 train_data_iterator=train_data_iterator,
+                pg_collection=pg_collection,
             )
         barrier_and_log(f"exiting program at iteration {state.train_state.step}")
 
@@ -1266,6 +1278,7 @@ def checkpoint_and_decide_exit(
                 num_floating_point_operations_so_far,
                 checkpointing_context,
                 train_data_iterator=train_data_iterator,
+                pg_collection=pg_collection,
             )
         barrier_and_log("Exiting program due to straggler detection.")
         return True

--- a/src/megatron/bridge/training/train_mimo.py
+++ b/src/megatron/bridge/training/train_mimo.py
@@ -29,7 +29,6 @@ from megatron.core.pipeline_parallel.schedules import forward_backward_pipelinin
 from megatron.core.utils import get_model_config
 
 from megatron.bridge.training.checkpointing import maybe_finalize_async_save
-from megatron.bridge.training.train import checkpoint_and_decide_exit, save_checkpoint_and_time
 from megatron.bridge.training.eval import evaluate_and_print_results
 from megatron.bridge.training.mimo_parallel_utils import (
     build_pg_collection_for_schedule,
@@ -46,6 +45,7 @@ from megatron.bridge.training.profiling import (
     should_profile_rank,
 )
 from megatron.bridge.training.state import GlobalState
+from megatron.bridge.training.train import checkpoint_and_decide_exit
 from megatron.bridge.training.utils.train_utils import (
     prepare_forward_step_func,
     training_log,

--- a/src/megatron/bridge/training/train_mimo.py
+++ b/src/megatron/bridge/training/train_mimo.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING, Callable, Dict, Iterator, List, Optional, Tupl
 
 import torch
 import torch.distributed as dist
+from megatron.core.models.mimo.config.role import MIMO_LANGUAGE_MODULE_KEY
 from megatron.core.num_microbatches_calculator import get_num_microbatches
 from megatron.core.pipeline_parallel.schedules import forward_backward_pipelining_without_interleaving
 from megatron.core.utils import get_model_config
@@ -144,10 +145,10 @@ def train_step_mimo(
         if mimo_model.role is None:
             is_last_stage = True
         elif mimo_model.role.has_language_module:
-            is_last_stage = mimo_model.role.is_last_stage(mimo_model.role.language_module_name)
+            is_last_stage = mimo_model.role.is_last_stage(MIMO_LANGUAGE_MODULE_KEY)
 
         if is_last_stage:
-            llm_pg = infra.pg_collections.get("llm") if infra.pg_collections else None
+            llm_pg = infra.pg_collections.get(MIMO_LANGUAGE_MODULE_KEY) if infra.pg_collections else None
             for key in losses_reduced[0].keys():
                 val = [x[key].view(-1) for x in losses_reduced]
                 if val[0].numel() == 2:

--- a/src/megatron/bridge/training/train_mimo.py
+++ b/src/megatron/bridge/training/train_mimo.py
@@ -1,0 +1,455 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+"""MIMO Training Loop for heterogeneous multi-module training.
+
+This module provides the dedicated training loop for MIMO models with
+heterogeneous parallelism. It uses MultiModulePipelineCommunicator for
+cross-module communication and supports per-module gradient handling.
+
+Key differences from standard train():
+- Creates MultiModulePipelineCommunicator for cross-module communication
+- Creates MultiModuleProcessGroupCollection for the schedule
+- Uses forward_backward_pipelining_without_interleaving with multimodule support
+- Uses zero_grad_buffer_for_multimodule() for gradient clearing
+- Supports per-module optimizers
+
+Note: Stub ranks are disallowed - validated at setup time.
+"""
+
+from __future__ import annotations
+
+import logging
+from functools import partial
+from typing import TYPE_CHECKING, Callable, Dict, Iterator, List, Optional, Tuple
+
+import torch
+import torch.distributed as dist
+from megatron.core.num_microbatches_calculator import get_num_microbatches
+from megatron.core.pipeline_parallel.schedules import forward_backward_pipelining_without_interleaving
+from megatron.core.utils import get_model_config
+
+from megatron.bridge.training.checkpointing import maybe_finalize_async_save, save_checkpoint
+from megatron.bridge.training.eval import evaluate_and_print_results
+from megatron.bridge.training.mimo_parallel_utils import (
+    build_pg_collection_for_schedule,
+    finalize_model_grads_multimodule,
+    get_module_to_grid_tuple,
+    multimodule_no_sync,
+    unwrap_mimo_model,
+    zero_grad_buffer_for_multimodule,
+)
+from megatron.bridge.training.profiling import (
+    handle_profiling_step,
+    handle_profiling_stop,
+    initialize_pytorch_profiler,
+    should_profile_rank,
+)
+from megatron.bridge.training.state import GlobalState
+from megatron.bridge.training.utils.train_utils import (
+    prepare_forward_step_func,
+    training_log,
+)
+
+
+if TYPE_CHECKING:
+    from megatron.core.models.mimo import MimoModel
+    from megatron.core.models.mimo.optimizer import MimoOptimizer
+    from megatron.core.optimizer.optimizer_param_scheduler import OptimizerParamScheduler
+    from megatron.core.pipeline_parallel.multimodule_communicator import MultiModulePipelineCommunicator
+
+    from megatron.bridge.models.mimo.mimo_provider import MimoModelInfra
+
+
+logger = logging.getLogger(__name__)
+
+
+def train_step_mimo(
+    forward_step_func: Callable,
+    data_iterator: Iterator,
+    model: "MimoModel",
+    optimizer: "MimoOptimizer",
+    schedulers: Dict[str, "OptimizerParamScheduler"],
+    global_state: GlobalState,
+    multimodule_communicator: "MultiModulePipelineCommunicator",
+    multimodule_pg_collection,
+    infra: "MimoModelInfra",
+    module_to_grid_tuple: List,
+    num_microbatches: int,
+    seq_length: int,
+    micro_batch_size: int,
+) -> Tuple[Dict[str, torch.Tensor], Optional[float], Optional[int]]:
+    """Single MIMO training step.
+
+    Args:
+        forward_step_func: Forward step function (wrapped with GlobalState).
+        data_iterator: Iterator over the dataset.
+        model: MimoModel instance.
+        optimizer: MimoOptimizer managing per-module optimizers.
+        schedulers: Per-module learning rate schedulers {module_name: scheduler}.
+        global_state: GlobalState containing timers, config, train_state.
+        multimodule_communicator: MultiModulePipelineCommunicator for P2P.
+        multimodule_pg_collection: PG collection for schedule.
+        infra: MimoModelInfra with grids, topology, pg_collections.
+        module_to_grid_tuple: List of (module, grid) tuples.
+        num_microbatches: Number of microbatches per iteration.
+        seq_length: Sequence length.
+        micro_batch_size: Micro batch size.
+
+    Returns:
+        Tuple of (loss_dict, skipped_iter, grad_norm, num_zeros_in_grad).
+    """
+    timers = global_state.timers
+
+    # Zero gradients for all modules
+    zero_grad_buffer_for_multimodule(module_to_grid_tuple)
+
+    # Run forward-backward schedule
+    timers("forward-backward", log_level=1).start(barrier=False)
+
+    losses_reduced = forward_backward_pipelining_without_interleaving(
+        forward_step_func=forward_step_func,
+        data_iterator=data_iterator,
+        model=[model],
+        num_microbatches=num_microbatches,
+        seq_length=seq_length,
+        micro_batch_size=micro_batch_size,
+        forward_only=False,
+        p2p_communicator=multimodule_communicator,
+        pg_collection=multimodule_pg_collection,
+    )
+
+    timers("forward-backward").stop()
+
+    # Optimizer step - MimoOptimizer handles all modules and computes global grad norm
+    timers("optimizer", log_level=1).start(barrier=False)
+
+    update_successful, grad_norm, num_zeros_in_grad = optimizer.step()
+
+    timers("optimizer").stop()
+
+    # Step learning rate schedulers
+    if update_successful:
+        increment = num_microbatches * micro_batch_size * global_state.cfg.data_parallel_size
+        for module_name, scheduler in schedulers.items():
+            if scheduler is not None:
+                scheduler.step(increment=increment)
+        skipped_iter = 0
+    else:
+        skipped_iter = 1
+
+    loss_dict = {}
+    if losses_reduced:
+        is_last_stage = False
+        # Access role from unwrapped model (handles Float16Module wrapper)
+        mimo_model = unwrap_mimo_model(model)
+        if mimo_model.role is None:
+            is_last_stage = True
+        elif mimo_model.role.has_language_module:
+            is_last_stage = mimo_model.role.is_last_stage(mimo_model.role.language_module_name)
+
+        if is_last_stage:
+            llm_pg = infra.pg_collections.get("llm") if infra.pg_collections else None
+            for key in losses_reduced[0].keys():
+                val = [x[key].view(-1) for x in losses_reduced]
+                if val[0].numel() == 2:
+                    val = torch.vstack(val).sum(dim=0)
+                    if llm_pg is not None and llm_pg.dp_cp is not None:
+                        torch.distributed.all_reduce(val, group=llm_pg.dp_cp)
+                    loss_dict[key] = val[0] / val[1]
+                elif val[0].numel() == 1:
+                    loss_dict[key] = torch.cat(val).mean()
+                else:
+                    raise ValueError(f"Invalid value shape: {val[0].shape} for key {key}")
+
+    # Broadcast loss_dict to all ranks (the last rank is the logging rank for
+    # W&B/TensorBoard). Use broadcast_object_list from the source rank so every
+    # rank ends up with the same dict — no fragile P2P or GPU-side pickle needed.
+    last_rank = dist.get_world_size() - 1
+    my_rank = dist.get_rank()
+
+    # All ranks agree on which rank holds the loss (pick highest rank with data).
+    has_loss = 1 if loss_dict else 0
+    source_tensor = torch.tensor([my_rank if has_loss else -1], dtype=torch.int32, device="cuda")
+    torch.distributed.all_reduce(source_tensor, op=torch.distributed.ReduceOp.MAX)
+    source_rank = int(source_tensor.item())
+
+    # Only broadcast if the source and logging rank differ and a valid source exists.
+    if source_rank >= 0 and source_rank != last_rank:
+        obj = [loss_dict if my_rank == source_rank else None]
+        torch.distributed.broadcast_object_list(obj, src=source_rank)
+        if my_rank == last_rank:
+            received = obj[0] or {}
+            # Tensors inside the received dict carry the source rank's CUDA device;
+            # move them to this rank's device so training_log arithmetic works.
+            loss_dict = {k: v.cuda() if isinstance(v, torch.Tensor) else v for k, v in received.items()}
+
+    return loss_dict, skipped_iter, grad_norm, num_zeros_in_grad
+
+
+def train_mimo(
+    forward_step_func: Callable,
+    model: "MimoModel",
+    optimizer: "MimoOptimizer",
+    schedulers: Dict[str, "OptimizerParamScheduler"],
+    train_data_iterator: Iterator,
+    valid_data_iterator: Optional[Iterator],
+    global_state: GlobalState,
+    mimo_infra: "MimoModelInfra",
+    multimodule_communicator: "MultiModulePipelineCommunicator",
+) -> None:
+    """Main MIMO training loop.
+
+    Key differences from standard train():
+    - Creates MultiModuleProcessGroupCollection for the schedule
+    - Uses forward_backward_pipelining_without_interleaving with multimodule support
+    - Uses zero_grad_buffer_for_multimodule() for gradient clearing
+    - Uses MimoOptimizer for coordinated gradient clipping with global norm
+
+    Reuses from existing Bridge training:
+    - GlobalState for timers, config, train_state
+    - training_log() for metrics reporting
+    - handle_profiling_step() and handle_profiling_stop() for profiler lifecycle
+    - save_checkpoint() with MimoOptimizer for checkpointing
+    - evaluate_and_print_results() for validation with multimodule support
+    - maybe_finalize_async_save() for async checkpoint finalization
+
+
+    Args:
+        forward_step_func: Forward step function.
+        model: MimoModel instance.
+        optimizer: MimoOptimizer managing per-module optimizers.
+        schedulers: Per-module learning rate schedulers {module_name: scheduler}.
+        train_data_iterator: Training data iterator.
+        valid_data_iterator: Validation data iterator (optional).
+        global_state: GlobalState containing timers, config, train_state.
+        mimo_infra: MimoModelInfra with grids, topology, pg_collections.
+        multimodule_communicator: MultiModulePipelineCommunicator for P2P.
+    """
+    timers = global_state.timers
+    train_state = global_state.train_state
+    cfg = global_state.cfg
+
+    # Get training config
+    train_config = cfg.train
+    num_microbatches = get_num_microbatches()
+    seq_length = cfg.dataset.seq_length
+    micro_batch_size = train_config.micro_batch_size
+
+    # Prepare forward step function with GlobalState injection
+    wrapped_forward_step_func = prepare_forward_step_func(forward_step_func, global_state)
+
+    # Build module-to-grid mapping for gradient operations
+    module_to_grid_tuple = get_module_to_grid_tuple(model, mimo_infra)
+
+    # Build pg_collection for schedule
+    multimodule_pg_collection = build_pg_collection_for_schedule(mimo_infra)
+
+    # Guard against list fallback - MIMO training requires MultiModuleProcessGroupCollection
+    if isinstance(multimodule_pg_collection, list):
+        raise RuntimeError(
+            "MultiModuleProcessGroupCollection is required for MIMO training. "
+            "The list-based fallback is not supported. Ensure Megatron-LM PR 3212 is available."
+        )
+
+    # Use rank-local module PG for logging reductions to avoid global MPU fallback.
+    # NOTE: In non-colocated MIMO each rank participates in exactly one module, so
+    # "first non-None" unambiguously selects that module's PG. For colocated MIMO
+    # (where a rank participates in multiple modules), this selection must be
+    # replaced with per-module logging or an explicit module-aware reduction strategy.
+    local_pg_collection = next((pg for pg in mimo_infra.pg_collections.values() if pg is not None), None)
+    if local_pg_collection is None:
+        raise RuntimeError(
+            "No local ProcessGroupCollection found for this rank. "
+            "Ensure rank participation is correctly configured in MIMO infrastructure."
+        )
+
+    # Configure gradient hooks on model config
+    model_config = get_model_config(model)
+
+    # Bind custom parameters via partial(), leaving schedule-provided args unbound
+    model_config.no_sync_func = partial(multimodule_no_sync, module_to_grid_tuple=module_to_grid_tuple)
+
+    model_config.finalize_model_grads_func = partial(
+        finalize_model_grads_multimodule,
+        infra=mimo_infra,
+        module_to_grid_tuple=module_to_grid_tuple,
+    )
+
+    # Optional: Set grad_scale_func from MimoOptimizer
+    if optimizer is not None and hasattr(optimizer, "scale_loss"):
+        model_config.grad_scale_func = optimizer.scale_loss
+
+    # Validation: variable_seq_lengths should already be True (set by MimoModelProvider)
+    assert model_config.variable_seq_lengths, (
+        "variable_seq_lengths must be True for MIMO training. "
+        "This should be set by MimoModelProvider.provide_distributed_model()."
+    )
+
+    # Initialize tracking variables
+    total_loss_dict = {}
+    history_wct = []
+    report_memory_flag = True
+
+    # Get first scheduler for checkpoint saving.
+    # All modules share the same LR schedule, so first scheduler state is representative.
+    first_scheduler = next(iter(schedulers.values()), None) if schedulers else None
+
+    # Profiler setup (mirrors train.py behavior)
+    prof = None
+    nsys_nvtx_context = None
+    prof_config = cfg.profiling
+    if prof_config and should_profile_rank(prof_config, dist.get_rank()):
+        if prof_config.use_pytorch_profiler:
+            prof = initialize_pytorch_profiler(prof_config, cfg.logger.tensorboard_dir)
+            prof.start()
+
+    logger.info(f"Rank {dist.get_rank()}: Starting MIMO training loop")
+
+    # Main training loop
+    timers("interval-time", log_level=0).start(barrier=True)
+
+    while train_state.step < train_config.train_iters:
+        # Handle profiling
+        nsys_ctx = handle_profiling_step(
+            prof_config,
+            train_state.step,
+            dist.get_rank(),
+            prof,
+        )
+        if nsys_ctx is not None:
+            nsys_nvtx_context = nsys_ctx
+
+        # Start iteration timer
+        timers("iteration-time", log_level=0).start(barrier=False)
+
+        # Run single training step
+        loss_dict, skipped_iter, grad_norm, num_zeros_in_grad = train_step_mimo(
+            forward_step_func=wrapped_forward_step_func,
+            data_iterator=train_data_iterator,
+            model=model,
+            optimizer=optimizer,
+            schedulers=schedulers,
+            global_state=global_state,
+            multimodule_communicator=multimodule_communicator,
+            multimodule_pg_collection=multimodule_pg_collection,
+            infra=mimo_infra,
+            module_to_grid_tuple=module_to_grid_tuple,
+            num_microbatches=num_microbatches,
+            seq_length=seq_length,
+            micro_batch_size=micro_batch_size,
+        )
+
+        # Stop iteration timer
+        timers("iteration-time").stop(barrier=False)
+        iteration_time = timers("iteration-time").elapsed(reset=True, barrier=False)
+        history_wct.append(iteration_time)
+
+        # Update training state
+        train_state.step += 1
+        train_state.consumed_train_samples += micro_batch_size * num_microbatches * cfg.data_parallel_size
+
+        # Get learning rate from first scheduler
+        learning_rate = None
+        if schedulers:
+            sched = next(iter(schedulers.values()))
+            if sched is not None:
+                learning_rate = sched.get_lr(sched.optimizer.param_groups[0])
+
+        # Log training metrics
+        if not cfg.logger.skip_train_metrics_log:
+            # Get loss scale from MimoOptimizer
+            if optimizer is not None and hasattr(optimizer, "get_loss_scale"):
+                loss_scale = optimizer.get_loss_scale()
+                if hasattr(loss_scale, "item"):
+                    loss_scale = loss_scale.item()
+            else:
+                loss_scale = 1.0
+
+            report_memory_flag = training_log(
+                loss_dict=loss_dict,
+                total_loss_dict=total_loss_dict,
+                learning_rate=learning_rate,
+                decoupled_learning_rate=None,
+                loss_scale=loss_scale,
+                report_memory_flag=report_memory_flag,
+                skipped_iter=skipped_iter,
+                grad_norm=grad_norm,
+                params_norm=None,
+                num_zeros_in_grad=num_zeros_in_grad,
+                config=cfg,
+                global_state=global_state,
+                history_wct=history_wct,
+                model=[model],
+                pg_collection=local_pg_collection,
+            )
+
+            # Log iteration-time directly for MIMO models.
+            # training_log only logs this inside a hasattr(config.model, "kv_channels")
+            # block which MIMO models don't satisfy, so we log it here as a workaround.
+            if cfg.logger.log_timers_to_tensorboard and train_state.step % cfg.logger.log_interval == 0:
+                writer = global_state.tensorboard_logger
+                if writer:
+                    writer.add_scalar("iteration-time", iteration_time, train_state.step)
+                wandb_writer = global_state.wandb_logger
+                if wandb_writer:
+                    wandb_writer.log({"iteration-time": iteration_time}, train_state.step)
+
+        # Evaluation at specified intervals
+        if (
+            train_config.eval_interval is not None
+            and train_state.step % train_config.eval_interval == 0
+            and valid_data_iterator is not None
+        ):
+            timers("evaluate", log_level=0).start(barrier=True)
+            evaluate_and_print_results(
+                state=global_state,
+                prefix=f"iteration {train_state.step}",
+                forward_step_func=forward_step_func,
+                data_iterator=valid_data_iterator,
+                model=[model],
+                config=cfg,
+                verbose=False,
+                write_to_tensorboard=True,
+                p2p_communicator=multimodule_communicator,
+                pg_collection=multimodule_pg_collection,
+            )
+            timers("evaluate").stop()
+
+        # Checkpointing at specified intervals
+        if cfg.checkpoint.save_interval is not None and train_state.step % cfg.checkpoint.save_interval == 0:
+            timers("save-checkpoint", log_level=0).start(barrier=True)
+            save_checkpoint(
+                state=global_state,
+                model=[model],
+                optimizer=optimizer,
+                opt_param_scheduler=first_scheduler,
+                num_floating_point_operations_so_far=0,  # TODO: Add proper FLOPs tracking
+            )
+            timers("save-checkpoint").stop()
+
+        # Finalize any pending async saves (non-blocking during training)
+        maybe_finalize_async_save(
+            global_state=global_state,
+            ckpt_cfg=cfg.checkpoint,
+            blocking=False,
+        )
+
+    # Stop profiling
+    handle_profiling_stop(
+        prof_config,
+        train_state.step,
+        dist.get_rank(),
+        prof,
+        nsys_nvtx_context,
+    )
+
+    # Finalize any remaining async saves before exit
+    maybe_finalize_async_save(
+        global_state=global_state,
+        ckpt_cfg=cfg.checkpoint,
+        blocking=True,
+        terminate=True,
+    )
+
+    timers("interval-time").stop()
+
+    logger.info(f"Rank {dist.get_rank()}: MIMO training completed")

--- a/src/megatron/bridge/training/train_mimo.py
+++ b/src/megatron/bridge/training/train_mimo.py
@@ -28,7 +28,8 @@ from megatron.core.num_microbatches_calculator import get_num_microbatches
 from megatron.core.pipeline_parallel.schedules import forward_backward_pipelining_without_interleaving
 from megatron.core.utils import get_model_config
 
-from megatron.bridge.training.checkpointing import maybe_finalize_async_save, save_checkpoint
+from megatron.bridge.training.checkpointing import maybe_finalize_async_save
+from megatron.bridge.training.train import checkpoint_and_decide_exit, save_checkpoint_and_time
 from megatron.bridge.training.eval import evaluate_and_print_results
 from megatron.bridge.training.mimo_parallel_utils import (
     build_pg_collection_for_schedule,
@@ -196,6 +197,7 @@ def train_mimo(
     global_state: GlobalState,
     mimo_infra: "MimoModelInfra",
     multimodule_communicator: "MultiModulePipelineCommunicator",
+    checkpointing_context: Optional[Dict] = None,
 ) -> None:
     """Main MIMO training loop.
 
@@ -209,10 +211,9 @@ def train_mimo(
     - GlobalState for timers, config, train_state
     - training_log() for metrics reporting
     - handle_profiling_step() and handle_profiling_stop() for profiler lifecycle
-    - save_checkpoint() with MimoOptimizer for checkpointing
+    - save_checkpoint_and_time() / checkpoint_and_decide_exit() for checkpointing
     - evaluate_and_print_results() for validation with multimodule support
     - maybe_finalize_async_save() for async checkpoint finalization
-
 
     Args:
         forward_step_func: Forward step function.
@@ -224,6 +225,9 @@ def train_mimo(
         global_state: GlobalState containing timers, config, train_state.
         mimo_infra: MimoModelInfra with grids, topology, pg_collections.
         multimodule_communicator: MultiModulePipelineCommunicator for P2P.
+        checkpointing_context: Dictionary holding checkpoint-related state
+            (save strategy cache, LocalCheckpointManager). Created by
+            init_checkpointing_context() in pretrain_mimo.
     """
     timers = global_state.timers
     train_state = global_state.train_state
@@ -251,17 +255,18 @@ def train_mimo(
             "The list-based fallback is not supported. Ensure Megatron-LM PR 3212 is available."
         )
 
-    # Use rank-local module PG for logging reductions to avoid global MPU fallback.
-    # NOTE: In non-colocated MIMO each rank participates in exactly one module, so
-    # "first non-None" unambiguously selects that module's PG. For colocated MIMO
-    # (where a rank participates in multiple modules), this selection must be
-    # replaced with per-module logging or an explicit module-aware reduction strategy.
-    local_pg_collection = next((pg for pg in mimo_infra.pg_collections.values() if pg is not None), None)
-    if local_pg_collection is None:
-        raise RuntimeError(
-            "No local ProcessGroupCollection found for this rank. "
-            "Ensure rank participation is correctly configured in MIMO infrastructure."
-        )
+    # Use rank-local module PG for logging reductions and checkpoint saving to
+    # avoid global MPU fallback. In non-colocated MIMO each rank participates in
+    # exactly one module, so "first non-None" unambiguously selects that module's PG.
+    active_pgs = [pg for pg in mimo_infra.pg_collections.values() if pg is not None]
+    assert len(active_pgs) == 1, (
+        f"Non-colocated MiMo requires exactly one active ProcessGroupCollection per rank, "
+        f"got {len(active_pgs)}. Colocated MiMo is not supported by this code path."
+    )
+    local_pg_collection = active_pgs[0]
+
+    if checkpointing_context is None:
+        checkpointing_context = {}
 
     # Configure gradient hooks on model config
     model_config = get_model_config(model)
@@ -309,6 +314,14 @@ def train_mimo(
     timers("interval-time", log_level=0).start(barrier=True)
 
     while train_state.step < train_config.train_iters:
+        # Finalize any pending async saves (non-blocking). Placed at the top
+        # of the loop so async saves get a full iteration to complete.
+        maybe_finalize_async_save(
+            global_state=global_state,
+            ckpt_cfg=cfg.checkpoint,
+            blocking=False,
+        )
+
         # Handle profiling
         nsys_ctx = handle_profiling_step(
             prof_config,
@@ -415,24 +428,20 @@ def train_mimo(
             )
             timers("evaluate").stop()
 
-        # Checkpointing at specified intervals
-        if cfg.checkpoint.save_interval is not None and train_state.step % cfg.checkpoint.save_interval == 0:
-            timers("save-checkpoint", log_level=0).start(barrier=True)
-            save_checkpoint(
-                state=global_state,
-                model=[model],
-                optimizer=optimizer,
-                opt_param_scheduler=first_scheduler,
-                num_floating_point_operations_so_far=0,  # TODO: Add proper FLOPs tracking
-            )
-            timers("save-checkpoint").stop()
-
-        # Finalize any pending async saves (non-blocking during training)
-        maybe_finalize_async_save(
-            global_state=global_state,
-            ckpt_cfg=cfg.checkpoint,
-            blocking=False,
+        # Checkpointing (interval, signal, duration, exit-interval) and exit decision.
+        # TODO: MiMo FLOPs estimation is non-trivial (heterogeneous modules); pass 0 for now.
+        should_exit = checkpoint_and_decide_exit(
+            state=global_state,
+            model=[model],
+            optimizer=optimizer,
+            opt_param_scheduler=first_scheduler,
+            num_floating_point_operations_so_far=0,
+            checkpointing_context=checkpointing_context,
+            train_data_iterator=train_data_iterator,
+            pg_collection=local_pg_collection,
         )
+        if should_exit:
+            break
 
     # Stop profiling
     handle_profiling_stop(

--- a/src/megatron/bridge/training/utils/train_utils.py
+++ b/src/megatron/bridge/training/utils/train_utils.py
@@ -347,6 +347,7 @@ def training_log(
     global_state: GlobalState,
     history_wct: list,
     model: list[MegatronModule],
+    pg_collection: Optional[Any] = None,
     log_max_attention_logit: Optional[float] = None,
 ) -> bool:
     """Log training stats (losses, learning rate, timings, etc.).
@@ -370,6 +371,8 @@ def training_log(
         global_state: The global training state.
         history_wct (list): list of elapsed time per each iteration.
         model (list[MegatronModule]): megatron model state.
+        pg_collection (Optional[Any]): ProcessGroupCollection to use for logging reductions.
+            If None, falls back to extracting from model wrappers.
         log_max_attention_logit (Optional[float]): Maximum attention logit if available, None otherwise.
     Returns:
         bool: The updated report_memory_flag.
@@ -383,7 +386,7 @@ def training_log(
     energy_monitor = global_state.energy_monitor
     logger_config = config.logger
     train_config = config.train
-    pg_collection = get_pg_collection(model)
+    pg_collection = pg_collection or get_pg_collection(model)
 
     # Advanced, skipped, and Nan iterations.
     advanced_iters_key = "advanced iterations"
@@ -609,24 +612,25 @@ def training_log(
             if mlflow_logger:
                 mlflow_logger.log_metrics({"max-attention-logit": log_max_attention_logit}, step=iteration)
 
-    if config.model.num_moe_experts is not None:
+    num_moe_experts = getattr(config.model, "num_moe_experts", None)
+    if num_moe_experts is not None:
         moe_loss_scale = 1 / get_num_microbatches()
         track_names = []
 
-        moe_router_load_balancing_type = config.model.moe_router_load_balancing_type
+        moe_router_load_balancing_type = getattr(config.model, "moe_router_load_balancing_type", "")
         if "aux_loss" in moe_router_load_balancing_type:
             track_names.append("load_balancing_loss")
         if "seq_aux_loss" in moe_router_load_balancing_type:
             track_names.append("seq_load_balancing_loss")
         if "global_aux_loss" in moe_router_load_balancing_type:
             track_names.append("global_load_balancing_loss")
-        if config.model.moe_z_loss_coeff is not None:
+        if getattr(config.model, "moe_z_loss_coeff", None) is not None:
             track_names.append("z_loss")
 
-        if config.model.is_hybrid_model:
-            layers = config.model.hybrid_override_pattern.count("E")
+        if getattr(config.model, "is_hybrid_model", False):
+            layers = getattr(config.model, "hybrid_override_pattern", "").count("E")
         else:
-            layers = config.model.num_layers
+            layers = getattr(config.model, "num_layers", None)
 
         track_moe_metrics(
             loss_scale=moe_loss_scale,
@@ -634,15 +638,15 @@ def training_log(
             writer=writer,
             wandb_writer=wandb_writer,
             total_loss_dict=total_loss_dict,
-            per_layer_logging=config.model.moe_per_layer_logging,
+            per_layer_logging=getattr(config.model, "moe_per_layer_logging", False),
             force_initialize=True,
             track_names=track_names,
             num_layers=layers,
-            moe_layer_freq=config.model.moe_layer_freq,
-            mtp_num_layers=config.model.mtp_num_layers,
+            moe_layer_freq=getattr(config.model, "moe_layer_freq", None),
+            mtp_num_layers=getattr(config.model, "mtp_num_layers", None),
             pg_collection=pg_collection,
         )
-    if config.model.mtp_num_layers is not None:
+    if getattr(config.model, "mtp_num_layers", None) is not None:
         mtp_loss_scale = 1 / get_num_microbatches()
         MTPLossLoggingHelper.track_mtp_metrics(mtp_loss_scale, iteration, writer, wandb_writer, total_loss_dict)
 
@@ -651,6 +655,8 @@ def training_log(
         elapsed_time_per_iteration = elapsed_time / total_iterations
 
         # Calculate GPU utilization
+    num_flops = None
+    if hasattr(config.model, "kv_channels") and hasattr(config.model, "num_attention_heads"):
         num_flops = num_floating_point_operations(config, batch_size)
         per_gpu_tf = num_flops / elapsed_time_per_iteration / get_world_size_safe() / 1e12
         print_rank_0(

--- a/tests/e2e/__init__.py
+++ b/tests/e2e/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+"""End-to-end tests for Megatron-Bridge."""

--- a/tests/e2e/mimo/run_hetero_llava.sh
+++ b/tests/e2e/mimo/run_hetero_llava.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Heterogeneous MIMO LLaVA training — LLM on ranks 0-3, CLIP on ranks 4-7.
+
+GPUS_PER_NODE=8
+NUM_NODES=1
+
+uv run torchrun \
+    --nproc_per_node "$GPUS_PER_NODE" \
+    --nnodes "$NUM_NODES" \
+    tests/e2e/mimo/test_mimo_training_llava.py \
+    --micro-batch-size 2 \
+    --global-batch-size 32 \
+    --train-iters 500 \
+    --adam-beta1 0.9 \
+    --adam-beta2 0.95 \
+    --clip-grad 1.0 \
+    --log-interval 1 \
+    --lr 1e-4 \
+    --lr-warmup-iters 20 \
+    --min-lr 2.0e-5 \
+    --weight-decay 0.01 \
+    --wandb-project "Megatron-Bridge-MIMO" \
+    --wandb-exp-name "mimo-llava-e2e-test" \
+    --wandb-save-dir "/tmp/wandb" \
+    --dataset-root /path/to/llava/pretrain/dataset

--- a/tests/e2e/mimo/run_mimo_checkpoint_resume.sh
+++ b/tests/e2e/mimo/run_mimo_checkpoint_resume.sh
@@ -1,0 +1,175 @@
+#!/bin/bash
+# MIMO checkpoint save→resume round-trip e2e test.
+#
+# Runs the test in two phases (separate torchrun invocations) for each
+# parallelism configuration:
+#   Phase 1 (save):   Train for 5 steps, save checkpoint.
+#   Phase 2 (resume): Resume from checkpoint, train to 10 steps, verify continuity.
+#
+# Usage:
+#   ./run_mimo_checkpoint_resume.sh                         # 8 GPUs, all configs
+#   ./run_mimo_checkpoint_resume.sh --gpus 8                # explicit GPU count
+#   ./run_mimo_checkpoint_resume.sh --config tp4_both       # single config only
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEST_FILE="${SCRIPT_DIR}/test_mimo_checkpoint_resume_e2e.py"
+
+NUM_GPUS=${NUM_GPUS:-8}
+SINGLE_CONFIG=""
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --gpus) NUM_GPUS="$2"; shift 2 ;;
+        --config) SINGLE_CONFIG="$2"; shift 2 ;;
+        *) echo "Unknown argument: $1"; exit 1 ;;
+    esac
+done
+
+echo "=========================================="
+echo "MIMO Checkpoint Resume E2E Tests"
+echo "GPUs: ${NUM_GPUS}"
+echo "=========================================="
+
+# Config format: "name|llm_tp|llm_pp|llm_dp|llm_offset|vision_tp|vision_pp|vision_dp|vision_offset"
+# Note: CLIPViT does not support PP > 1; only LLM can use PP.
+declare -a CONFIGS_8GPU=(
+    "dp4_both|1|1|4|0|1|1|4|4"
+    "tp4_both|4|1|1|0|4|1|1|4"
+    "tp2_dp2_both|2|1|2|0|2|1|2|4"
+    "pp2_llm_dp4_vision|1|2|2|0|1|1|4|4"
+)
+
+declare -a CONFIGS_4GPU=(
+    "dp2_both|1|1|2|0|1|1|2|2"
+    "tp2_both|2|1|1|0|2|1|1|2"
+)
+
+declare -a CONFIGS_2GPU=(
+    "dp1_both|1|1|1|0|1|1|1|1"
+)
+
+if [[ $NUM_GPUS -ge 8 ]]; then
+    CONFIGS=("${CONFIGS_8GPU[@]}")
+elif [[ $NUM_GPUS -ge 4 ]]; then
+    CONFIGS=("${CONFIGS_4GPU[@]}")
+else
+    CONFIGS=("${CONFIGS_2GPU[@]}")
+fi
+
+declare -a RESULTS=()
+declare -a FAILED_CONFIGS=()
+TOTAL=0
+PASSED=0
+
+run_config() {
+    local config="$1"
+    local name llm_tp llm_pp llm_dp llm_offset vision_tp vision_pp vision_dp vision_offset
+    IFS='|' read -r name llm_tp llm_pp llm_dp llm_offset vision_tp vision_pp vision_dp vision_offset <<< "$config"
+
+    echo ""
+    echo "----------------------------------------"
+    echo "Config: ${name}"
+    echo "  LLM:    TP=${llm_tp}, PP=${llm_pp}, DP=${llm_dp}, offset=${llm_offset}"
+    echo "  Vision: TP=${vision_tp}, PP=${vision_pp}, DP=${vision_dp}, offset=${vision_offset}"
+    echo "----------------------------------------"
+
+    TOTAL=$((TOTAL + 1))
+    local start_time=$(date +%s)
+
+    CKPT_DIR=$(mktemp -d -t "mimo_ckpt_${name}_XXXXXX")
+
+    local env_prefix="MIMO_LLM_TP=${llm_tp} MIMO_LLM_PP=${llm_pp} MIMO_LLM_DP=${llm_dp} MIMO_LLM_OFFSET=${llm_offset}"
+    env_prefix="${env_prefix} MIMO_VISION_TP=${vision_tp} MIMO_VISION_PP=${vision_pp} MIMO_VISION_DP=${vision_dp} MIMO_VISION_OFFSET=${vision_offset}"
+
+    local ok=true
+
+    echo "  Phase 1: SAVE"
+    if ! env ${env_prefix} \
+        python -m torch.distributed.run --nproc_per_node="${NUM_GPUS}" \
+        "${TEST_FILE}" --phase save --ckpt-dir "${CKPT_DIR}" 2>&1; then
+        ok=false
+    fi
+
+    if $ok; then
+        echo "  Phase 2: RESUME"
+        if ! env ${env_prefix} \
+            python -m torch.distributed.run --nproc_per_node="${NUM_GPUS}" \
+            "${TEST_FILE}" --phase resume --ckpt-dir "${CKPT_DIR}" 2>&1; then
+            ok=false
+        fi
+    fi
+
+    rm -rf "${CKPT_DIR}"
+
+    local end_time=$(date +%s)
+    local duration=$((end_time - start_time))
+
+    if $ok; then
+        RESULTS+=("PASS|${name}|${duration}s")
+        PASSED=$((PASSED + 1))
+        echo "  [PASS] ${name} (${duration}s)"
+    else
+        RESULTS+=("FAIL|${name}|${duration}s")
+        FAILED_CONFIGS+=("${name}")
+        echo "  [FAIL] ${name} (${duration}s)"
+        return 1
+    fi
+    return 0
+}
+
+if [[ -n "${SINGLE_CONFIG}" ]]; then
+    found=false
+    for config in "${CONFIGS[@]}"; do
+        name="${config%%|*}"
+        if [[ "${name}" == "${SINGLE_CONFIG}" ]]; then
+            run_config "${config}"
+            found=true
+            break
+        fi
+    done
+    if [[ "${found}" == "false" ]]; then
+        echo "Error: Config '${SINGLE_CONFIG}' not found. Available:"
+        for config in "${CONFIGS[@]}"; do echo "  - ${config%%|*}"; done
+        exit 1
+    fi
+else
+    for config in "${CONFIGS[@]}"; do
+        if ! run_config "${config}"; then
+            name="${config%%|*}"
+            echo ""
+            echo "=========================================="
+            echo "FATAL: Config '${name}' failed. Aborting."
+            echo "=========================================="
+            exit 1
+        fi
+    done
+fi
+
+echo ""
+echo "=========================================="
+echo "SUMMARY: ${PASSED}/${TOTAL} passed"
+echo "=========================================="
+printf "%-6s | %-25s | %s\n" "Status" "Configuration" "Time"
+echo "-------|---------------------------|-------"
+for result in "${RESULTS[@]}"; do
+    IFS='|' read -r status name duration <<< "$result"
+    if [[ "${status}" == "PASS" ]]; then
+        printf "\033[32m%-6s\033[0m | %-25s | %s\n" "${status}" "${name}" "${duration}"
+    else
+        printf "\033[31m%-6s\033[0m | %-25s | %s\n" "${status}" "${name}" "${duration}"
+    fi
+done
+echo "=========================================="
+
+if [[ ${#FAILED_CONFIGS[@]} -gt 0 ]]; then
+    echo ""
+    echo "Failed configurations:"
+    for cfg in "${FAILED_CONFIGS[@]}"; do echo "  - ${cfg}"; done
+    exit 1
+fi
+
+echo ""
+echo "All checkpoint resume tests passed!"
+exit 0

--- a/tests/e2e/mimo/run_mimo_parallelism_tests.sh
+++ b/tests/e2e/mimo/run_mimo_parallelism_tests.sh
@@ -1,0 +1,184 @@
+#!/bin/bash
+# Run MIMO E2E test with various parallelism configurations
+# Usage: ./run_mimo_parallelism_tests.sh [--gpus N] [--config CONFIG_NAME]
+#
+# Examples:
+#   ./run_mimo_parallelism_tests.sh                    # Run all configs with 8 GPUs
+#   ./run_mimo_parallelism_tests.sh --gpus 4           # Run all configs with 4 GPUs
+#   ./run_mimo_parallelism_tests.sh --config tp2_both  # Run only tp2_both config
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEST_FILE="${SCRIPT_DIR}/test_mimo_training_e2e.py"
+
+# Default values
+NUM_GPUS=${NUM_GPUS:-8}
+SINGLE_CONFIG=""
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --gpus)
+            NUM_GPUS="$2"
+            shift 2
+            ;;
+        --config)
+            SINGLE_CONFIG="$2"
+            shift 2
+            ;;
+        *)
+            echo "Unknown argument: $1"
+            exit 1
+            ;;
+    esac
+done
+
+echo "=========================================="
+echo "MIMO Parallelism E2E Tests"
+echo "GPUs: ${NUM_GPUS}"
+echo "=========================================="
+
+# Define configurations as: "name|llm_tp|llm_pp|llm_dp|llm_offset|vision_tp|vision_pp|vision_dp|vision_offset"
+# Note: Vision encoder (CLIPViT) does not support PP > 1, only LLM can use PP
+declare -a CONFIGS_8GPU=(
+    "baseline_dp_only|1|1|4|0|1|1|4|4"
+    # "tp2_both|2|1|2|0|2|1|2|4"
+    # "tp2_llm_dp_vision|2|1|2|0|1|1|4|4"
+    # "pp2_llm_only|1|2|2|0|1|1|4|4"
+    # "tp4_both|4|1|1|0|4|1|1|4"
+    # "tp4_llm_tp2_vision|4|1|1|0|2|1|2|4"
+    # "3d_llm_dp_vision|2|2|1|0|1|1|4|4"
+    # "asymmetric_6_2_pp|2|3|1|0|2|1|1|6"
+)
+
+# Note: PP > 1 not included for 4 GPU configs (would need at least 2 ranks for PP)
+declare -a CONFIGS_4GPU=(
+    "baseline_dp_only|1|1|2|0|1|1|2|2"
+    "tp2_both|2|1|1|0|2|1|1|2"
+)
+
+declare -a CONFIGS_2GPU=(
+    "baseline_dp_only|1|1|1|0|1|1|1|1"
+)
+
+# Select configs based on GPU count
+if [[ $NUM_GPUS -ge 8 ]]; then
+    CONFIGS=("${CONFIGS_8GPU[@]}")
+elif [[ $NUM_GPUS -ge 4 ]]; then
+    CONFIGS=("${CONFIGS_4GPU[@]}")
+else
+    CONFIGS=("${CONFIGS_2GPU[@]}")
+fi
+
+# Track results
+declare -a RESULTS=()
+declare -a FAILED_CONFIGS=()
+TOTAL=0
+PASSED=0
+
+run_config() {
+    local config="$1"
+    local name llm_tp llm_pp llm_dp llm_offset vision_tp vision_pp vision_dp vision_offset
+    
+    IFS='|' read -r name llm_tp llm_pp llm_dp llm_offset vision_tp vision_pp vision_dp vision_offset <<< "$config"
+    
+    echo ""
+    echo "----------------------------------------"
+    echo "Running: ${name}"
+    echo "  LLM:    TP=${llm_tp}, PP=${llm_pp}, DP=${llm_dp}, offset=${llm_offset}"
+    echo "  Vision: TP=${vision_tp}, PP=${vision_pp}, DP=${vision_dp}, offset=${vision_offset}"
+    echo "----------------------------------------"
+    
+    TOTAL=$((TOTAL + 1))
+    
+    # Set environment variables and run
+    local start_time=$(date +%s)
+    
+    if MIMO_LLM_TP="${llm_tp}" \
+       MIMO_LLM_PP="${llm_pp}" \
+       MIMO_LLM_DP="${llm_dp}" \
+       MIMO_LLM_OFFSET="${llm_offset}" \
+       MIMO_VISION_TP="${vision_tp}" \
+       MIMO_VISION_PP="${vision_pp}" \
+       MIMO_VISION_DP="${vision_dp}" \
+       MIMO_VISION_OFFSET="${vision_offset}" \
+       python -m torch.distributed.run --nproc_per_node="${NUM_GPUS}" "${TEST_FILE}" 2>&1; then
+        local end_time=$(date +%s)
+        local duration=$((end_time - start_time))
+        RESULTS+=("PASS|${name}|${duration}s")
+        PASSED=$((PASSED + 1))
+        echo "[PASS] ${name} (${duration}s)"
+    else
+        local end_time=$(date +%s)
+        local duration=$((end_time - start_time))
+        RESULTS+=("FAIL|${name}|${duration}s")
+        FAILED_CONFIGS+=("${name}")
+        echo "[FAIL] ${name} (${duration}s)"
+        return 1
+    fi
+    return 0
+}
+
+# Run tests
+if [[ -n "${SINGLE_CONFIG}" ]]; then
+    # Run single config
+    found=false
+    for config in "${CONFIGS[@]}"; do
+        name="${config%%|*}"
+        if [[ "${name}" == "${SINGLE_CONFIG}" ]]; then
+            run_config "${config}"
+            found=true
+            break
+        fi
+    done
+    if [[ "${found}" == "false" ]]; then
+        echo "Error: Config '${SINGLE_CONFIG}' not found. Available configs:"
+        for config in "${CONFIGS[@]}"; do
+            echo "  - ${config%%|*}"
+        done
+        exit 1
+    fi
+else
+    # Run all configs - abort on any failure
+    for config in "${CONFIGS[@]}"; do
+        if ! run_config "${config}"; then
+            name="${config%%|*}"
+            echo ""
+            echo "=========================================="
+            echo "FATAL: Config '${name}' failed. Aborting."
+            echo "=========================================="
+            exit 1
+        fi
+    done
+fi
+
+# Print summary
+echo ""
+echo "=========================================="
+echo "SUMMARY: ${PASSED}/${TOTAL} passed"
+echo "=========================================="
+printf "%-6s | %-25s | %s\n" "Status" "Configuration" "Time"
+echo "-------|---------------------------|-------"
+for result in "${RESULTS[@]}"; do
+    IFS='|' read -r status name duration <<< "$result"
+    if [[ "${status}" == "PASS" ]]; then
+        printf "\033[32m%-6s\033[0m | %-25s | %s\n" "${status}" "${name}" "${duration}"
+    else
+        printf "\033[31m%-6s\033[0m | %-25s | %s\n" "${status}" "${name}" "${duration}"
+    fi
+done
+echo "=========================================="
+
+if [[ ${#FAILED_CONFIGS[@]} -gt 0 ]]; then
+    echo ""
+    echo "Failed configurations:"
+    for cfg in "${FAILED_CONFIGS[@]}"; do
+        echo "  - ${cfg}"
+    done
+    exit 1
+fi
+
+echo ""
+echo "All tests passed!"
+exit 0

--- a/tests/e2e/mimo/test_mimo_checkpoint_resume_e2e.py
+++ b/tests/e2e/mimo/test_mimo_checkpoint_resume_e2e.py
@@ -51,6 +51,7 @@ from megatron.bridge.training.pretrain_mimo import pretrain_mimo
 from megatron.bridge.training.state import GlobalState, TrainState
 from megatron.bridge.training.tokenizers.config import TokenizerConfig
 
+
 logger = logging.getLogger(__name__)
 
 SAVE_STEPS = 5
@@ -70,9 +71,15 @@ _PATCH_DIM = 16
 
 def _make_vision_config() -> TransformerConfig:
     cfg = TransformerConfig(
-        num_layers=2, hidden_size=64, ffn_hidden_size=256, num_attention_heads=4,
-        use_cpu_initialization=True, pipeline_dtype=torch.bfloat16, bf16=True,
-        variable_seq_lengths=True, moe_token_dispatcher_type="alltoall",
+        num_layers=2,
+        hidden_size=64,
+        ffn_hidden_size=256,
+        num_attention_heads=4,
+        use_cpu_initialization=True,
+        pipeline_dtype=torch.bfloat16,
+        bf16=True,
+        variable_seq_lengths=True,
+        moe_token_dispatcher_type="alltoall",
     )
     cfg.add_bias_linear = True
     cfg.add_qkv_bias = True
@@ -91,9 +98,15 @@ def _make_vision_config() -> TransformerConfig:
 
 def _make_language_config() -> TransformerConfig:
     return TransformerConfig(
-        num_layers=2, hidden_size=64, ffn_hidden_size=256, num_attention_heads=4,
-        use_cpu_initialization=True, pipeline_dtype=torch.bfloat16, bf16=True,
-        variable_seq_lengths=True, moe_token_dispatcher_type="alltoall",
+        num_layers=2,
+        hidden_size=64,
+        ffn_hidden_size=256,
+        num_attention_heads=4,
+        use_cpu_initialization=True,
+        pipeline_dtype=torch.bfloat16,
+        bf16=True,
+        variable_seq_lengths=True,
+        moe_token_dispatcher_type="alltoall",
         cross_entropy_loss_fusion=True,
     )
 
@@ -107,11 +120,14 @@ def _build_model_specs():
         params={
             "transformer_config": vision_config,
             "transformer_layer_spec": get_vit_layer_with_transformer_engine_spec(),
-            "patch_dim": _PATCH_DIM, "img_h": _IMG_SIZE, "img_w": _IMG_SIZE,
+            "patch_dim": _PATCH_DIM,
+            "img_h": _IMG_SIZE,
+            "img_w": _IMG_SIZE,
         },
     )
     vision_submodule_spec = ModuleSpec(
-        module=VisionModalitySubmodules, params={},
+        module=VisionModalitySubmodules,
+        params={},
         submodules={"encoders": {"clip": vision_encoder}},
     )
     language_model_spec = ModuleSpec(
@@ -119,7 +135,8 @@ def _build_model_specs():
         params={
             "config": language_config,
             "transformer_layer_spec": get_gpt_layer_with_transformer_engine_spec(),
-            "vocab_size": _VOCAB_SIZE, "max_sequence_length": _SEQ_LENGTH,
+            "vocab_size": _VOCAB_SIZE,
+            "max_sequence_length": _SEQ_LENGTH,
         },
     )
     return language_model_spec, {"vision": vision_submodule_spec}, {"vision": _SPECIAL_TOKEN_ID}
@@ -134,7 +151,7 @@ def _build_parallelism_config() -> MimoParallelismConfig:
     """
     return MimoParallelismConfig(
         module_parallelisms={
-            "llm": ModuleParallelismConfig(
+            "language": ModuleParallelismConfig(
                 tensor_model_parallel_size=int(os.environ.get("MIMO_LLM_TP", "4")),
                 pipeline_model_parallel_size=int(os.environ.get("MIMO_LLM_PP", "1")),
                 data_parallel_size=int(os.environ.get("MIMO_LLM_DP", "1")),
@@ -234,7 +251,9 @@ def _build_config(
     max_dp = max(p.data_parallel_size for p in par_cfg.module_parallelisms.values())
 
     train_cfg = TrainingConfig(
-        micro_batch_size=1, global_batch_size=max_dp, train_iters=train_iters,
+        micro_batch_size=1,
+        global_batch_size=max_dp,
+        train_iters=train_iters,
     )
     train_cfg.num_microbatches = 1
     train_cfg.grad_reduce_in_fp32 = False
@@ -246,7 +265,7 @@ def _build_config(
     logger_cfg = LoggerConfig()
     logger_cfg.log_interval = 1
 
-    llm_pp = par_cfg.module_parallelisms["llm"].pipeline_model_parallel_size
+    llm_pp = par_cfg.module_parallelisms["language"].pipeline_model_parallel_size
     ckpt_cfg = CheckpointConfig(
         save_interval=save_interval,
         save=ckpt_dir,
@@ -295,7 +314,7 @@ def _run_phase_save(ckpt_dir: str) -> None:
         modality_submodules_spec=modality_specs,
         special_token_ids=special_tokens,
         mimo_parallelism_config=_build_parallelism_config(),
-        topology={"vision": ["llm"], "llm": []},
+        topology={"vision": ["language"], "language": []},
         use_cpu_initialization=True,
     )
     if not hasattr(mimo_provider, "num_moe_experts"):
@@ -306,22 +325,33 @@ def _run_phase_save(ckpt_dir: str) -> None:
     mock_data = _build_mock_data_provider()
     bridge_opt = BridgeOptimizerConfig(lr=1e-4, use_distributed_optimizer=True)
     mcore_opt = MCoreOptimizerConfig(
-        optimizer="adam", lr=1e-4, min_lr=0.0, weight_decay=0.01,
-        clip_grad=1.0, bf16=True, use_distributed_optimizer=True,
+        optimizer="adam",
+        lr=1e-4,
+        min_lr=0.0,
+        weight_decay=0.01,
+        clip_grad=1.0,
+        bf16=True,
+        use_distributed_optimizer=True,
     )
 
     cfg = _build_config(
-        mimo_provider, mock_data, bridge_opt, ckpt_dir,
-        train_iters=SAVE_STEPS, save_interval=SAVE_STEPS,
+        mimo_provider,
+        mock_data,
+        bridge_opt,
+        ckpt_dir,
+        train_iters=SAVE_STEPS,
+        save_interval=SAVE_STEPS,
     )
 
     global_state = GlobalState()
 
     pretrain_mimo(
-        cfg=cfg, mimo_provider=mimo_provider,
+        cfg=cfg,
+        mimo_provider=mimo_provider,
         forward_step_func=mimo_forward_step,
         build_data_iterators_fn=_build_data_iterators,
-        opt_config=mcore_opt, schedulers={},
+        opt_config=mcore_opt,
+        schedulers={},
         global_state=global_state,
     )
 
@@ -360,7 +390,7 @@ def _run_phase_resume(ckpt_dir: str) -> None:
         modality_submodules_spec=modality_specs,
         special_token_ids=special_tokens,
         mimo_parallelism_config=_build_parallelism_config(),
-        topology={"vision": ["llm"], "llm": []},
+        topology={"vision": ["language"], "language": []},
         use_cpu_initialization=True,
     )
     if not hasattr(mimo_provider, "num_moe_experts"):
@@ -371,13 +401,22 @@ def _run_phase_resume(ckpt_dir: str) -> None:
     mock_data = _build_mock_data_provider()
     bridge_opt = BridgeOptimizerConfig(lr=1e-4, use_distributed_optimizer=True)
     mcore_opt = MCoreOptimizerConfig(
-        optimizer="adam", lr=1e-4, min_lr=0.0, weight_decay=0.01,
-        clip_grad=1.0, bf16=True, use_distributed_optimizer=True,
+        optimizer="adam",
+        lr=1e-4,
+        min_lr=0.0,
+        weight_decay=0.01,
+        clip_grad=1.0,
+        bf16=True,
+        use_distributed_optimizer=True,
     )
 
     cfg = _build_config(
-        mimo_provider, mock_data, bridge_opt, ckpt_dir,
-        train_iters=TOTAL_STEPS, save_interval=TOTAL_STEPS,
+        mimo_provider,
+        mock_data,
+        bridge_opt,
+        ckpt_dir,
+        train_iters=TOTAL_STEPS,
+        save_interval=TOTAL_STEPS,
         load_dir=ckpt_dir,
     )
     # Save phase used train_iters=SAVE_STEPS, so checkpoint scheduler state
@@ -390,10 +429,12 @@ def _run_phase_resume(ckpt_dir: str) -> None:
     global_state = GlobalState()
 
     pretrain_mimo(
-        cfg=cfg, mimo_provider=mimo_provider,
+        cfg=cfg,
+        mimo_provider=mimo_provider,
         forward_step_func=mimo_forward_step,
         build_data_iterators_fn=_build_data_iterators,
-        opt_config=mcore_opt, schedulers={},
+        opt_config=mcore_opt,
+        schedulers={},
         global_state=global_state,
     )
 
@@ -402,9 +443,7 @@ def _run_phase_resume(ckpt_dir: str) -> None:
     _log(f"Phase RESUME complete: step={ts.step}, consumed_train_samples={ts.consumed_train_samples}")
 
     # Verify step continuity
-    assert ts.step == TOTAL_STEPS, (
-        f"Step continuity failed: expected {TOTAL_STEPS}, got {ts.step}"
-    )
+    assert ts.step == TOTAL_STEPS, f"Step continuity failed: expected {TOTAL_STEPS}, got {ts.step}"
 
     # Verify consumed_train_samples did not reset to 0
     assert ts.consumed_train_samples >= saved_marker["consumed_train_samples"], (

--- a/tests/e2e/mimo/test_mimo_checkpoint_resume_e2e.py
+++ b/tests/e2e/mimo/test_mimo_checkpoint_resume_e2e.py
@@ -1,0 +1,479 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+"""End-to-end MIMO checkpoint save→resume round-trip test.
+
+Validates that MiMo checkpoint loading/resume produces correct train_state
+continuity: step, consumed_train_samples, and scheduler state are restored.
+
+Two-phase test (separate torchrun invocations required):
+  Phase 1 (save):   Train for SAVE_STEPS steps, save checkpoint.
+  Phase 2 (resume): Resume from checkpoint, train to TOTAL_STEPS, verify continuity.
+
+Run via wrapper:
+    bash tests/e2e/mimo/run_mimo_checkpoint_resume.sh
+Or manually:
+    CKPT_DIR=$(mktemp -d)
+    torchrun --nproc_per_node=8 tests/e2e/mimo/test_mimo_checkpoint_resume_e2e.py --phase save   --ckpt-dir $CKPT_DIR
+    torchrun --nproc_per_node=8 tests/e2e/mimo/test_mimo_checkpoint_resume_e2e.py --phase resume --ckpt-dir $CKPT_DIR
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+
+import torch
+import torch.distributed as dist
+from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_with_transformer_engine_spec
+from megatron.core.models.gpt.gpt_model import GPTModel
+from megatron.core.models.mimo.submodules.vision import VisionModalitySubmodules
+from megatron.core.models.vision.clip_vit_model import CLIPViTModel
+from megatron.core.models.vision.vit_layer_specs import get_vit_layer_with_transformer_engine_spec
+from megatron.core.optimizer.optimizer_config import OptimizerConfig as MCoreOptimizerConfig
+from megatron.core.transformer.spec_utils import ModuleSpec
+from megatron.core.transformer.transformer_config import TransformerConfig
+
+from megatron.bridge.data.mimo.mock_provider import MockMimoProvider
+from megatron.bridge.models.mimo.mimo_config import MimoParallelismConfig, ModuleParallelismConfig
+from megatron.bridge.models.mimo.mimo_provider import MimoModelProvider
+from megatron.bridge.training.config import (
+    CheckpointConfig,
+    ConfigContainer,
+    LoggerConfig,
+    SchedulerConfig,
+    TrainingConfig,
+)
+from megatron.bridge.training.config import OptimizerConfig as BridgeOptimizerConfig
+from megatron.bridge.training.mimo_step import forward_step as mimo_forward_step
+from megatron.bridge.training.pretrain_mimo import pretrain_mimo
+from megatron.bridge.training.state import GlobalState, TrainState
+from megatron.bridge.training.tokenizers.config import TokenizerConfig
+
+logger = logging.getLogger(__name__)
+
+SAVE_STEPS = 5
+TOTAL_STEPS = 10
+_ENCODER_SEQ_LEN = 197
+_SPECIAL_TOKEN_ID = 32000
+_VOCAB_SIZE = 50304
+_SEQ_LENGTH = 256
+_IMG_SIZE = 224
+_PATCH_DIM = 16
+
+
+# ---------------------------------------------------------------------------
+# Model helpers (same as test_mimo_training_e2e.py)
+# ---------------------------------------------------------------------------
+
+
+def _make_vision_config() -> TransformerConfig:
+    cfg = TransformerConfig(
+        num_layers=2, hidden_size=64, ffn_hidden_size=256, num_attention_heads=4,
+        use_cpu_initialization=True, pipeline_dtype=torch.bfloat16, bf16=True,
+        variable_seq_lengths=True, moe_token_dispatcher_type="alltoall",
+    )
+    cfg.add_bias_linear = True
+    cfg.add_qkv_bias = True
+    cfg.hidden_dropout = 0.0
+    cfg.attention_dropout = 0.0
+    cfg.gated_linear_unit = False
+    cfg.layernorm_zero_centered_gamma = False
+    cfg.apply_query_key_layer_scaling = False
+    cfg.bias_activation_fusion = False
+    cfg.bias_dropout_fusion = False
+    cfg.attention_softmax_in_fp32 = True
+    cfg.normalization = "LayerNorm"
+    cfg.apply_rope_fusion = False
+    return cfg
+
+
+def _make_language_config() -> TransformerConfig:
+    return TransformerConfig(
+        num_layers=2, hidden_size=64, ffn_hidden_size=256, num_attention_heads=4,
+        use_cpu_initialization=True, pipeline_dtype=torch.bfloat16, bf16=True,
+        variable_seq_lengths=True, moe_token_dispatcher_type="alltoall",
+        cross_entropy_loss_fusion=True,
+    )
+
+
+def _build_model_specs():
+    vision_config = _make_vision_config()
+    language_config = _make_language_config()
+
+    vision_encoder = ModuleSpec(
+        module=CLIPViTModel,
+        params={
+            "transformer_config": vision_config,
+            "transformer_layer_spec": get_vit_layer_with_transformer_engine_spec(),
+            "patch_dim": _PATCH_DIM, "img_h": _IMG_SIZE, "img_w": _IMG_SIZE,
+        },
+    )
+    vision_submodule_spec = ModuleSpec(
+        module=VisionModalitySubmodules, params={},
+        submodules={"encoders": {"clip": vision_encoder}},
+    )
+    language_model_spec = ModuleSpec(
+        module=GPTModel,
+        params={
+            "config": language_config,
+            "transformer_layer_spec": get_gpt_layer_with_transformer_engine_spec(),
+            "vocab_size": _VOCAB_SIZE, "max_sequence_length": _SEQ_LENGTH,
+        },
+    )
+    return language_model_spec, {"vision": vision_submodule_spec}, {"vision": _SPECIAL_TOKEN_ID}
+
+
+def _build_parallelism_config() -> MimoParallelismConfig:
+    """Build parallelism config from MIMO_* env vars (set by shell wrapper).
+
+    Env vars (with defaults for 8-GPU TP=4 both):
+        MIMO_LLM_TP, MIMO_LLM_PP, MIMO_LLM_DP, MIMO_LLM_OFFSET
+        MIMO_VISION_TP, MIMO_VISION_PP, MIMO_VISION_DP, MIMO_VISION_OFFSET
+    """
+    return MimoParallelismConfig(
+        module_parallelisms={
+            "llm": ModuleParallelismConfig(
+                tensor_model_parallel_size=int(os.environ.get("MIMO_LLM_TP", "4")),
+                pipeline_model_parallel_size=int(os.environ.get("MIMO_LLM_PP", "1")),
+                data_parallel_size=int(os.environ.get("MIMO_LLM_DP", "1")),
+                rank_offset=int(os.environ.get("MIMO_LLM_OFFSET", "0")),
+            ),
+            "vision": ModuleParallelismConfig(
+                tensor_model_parallel_size=int(os.environ.get("MIMO_VISION_TP", "4")),
+                pipeline_model_parallel_size=int(os.environ.get("MIMO_VISION_PP", "1")),
+                data_parallel_size=int(os.environ.get("MIMO_VISION_DP", "1")),
+                rank_offset=int(os.environ.get("MIMO_VISION_OFFSET", "4")),
+            ),
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Data helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_mock_data_provider() -> MockMimoProvider:
+    provider = MockMimoProvider(
+        seq_length=_SEQ_LENGTH,
+        processor_paths={"vision": "openai/clip-vit-base-patch16"},
+        tokenizer_path="gpt2",
+        special_token_ids={"vision": _SPECIAL_TOKEN_ID},
+        encoder_seq_lengths={"vision": _ENCODER_SEQ_LEN},
+        modality_configs={"vision": {"type": "image", "width": _IMG_SIZE, "height": _IMG_SIZE}},
+    )
+    provider.drop_last = True
+    return provider
+
+
+def _wrap_iter(loader_iter):
+    for batch in loader_iter:
+        for key, value in batch.items():
+            if isinstance(value, torch.Tensor):
+                batch[key] = value.cuda(non_blocking=True)
+            elif isinstance(value, dict):
+                for k, v in value.items():
+                    if isinstance(v, torch.Tensor):
+                        value[k] = v.cuda(non_blocking=True)
+                    elif isinstance(v, dict):
+                        for kk, vv in v.items():
+                            if isinstance(vv, torch.Tensor):
+                                value[k][kk] = vv.cuda(non_blocking=True)
+
+        mi = batch.get("modality_inputs")
+        if mi and "vision" in mi:
+            pv = mi["vision"].get("pixel_values")
+            if pv is not None:
+                mi["vision"] = {"clip": {"x": pv.to(torch.bfloat16)}}
+
+        if "loss_mask" not in batch or batch["loss_mask"] is None:
+            batch["loss_mask"] = torch.ones_like(batch["input_ids"], dtype=torch.float)
+
+        batch["attention_mask"] = None
+        yield batch
+
+
+def _build_data_iterators(cfg, mimo_infra, *, train_state=None):
+    """Build data iterators. Accepts optional train_state for resume support."""
+    from megatron.bridge.data.mimo.loaders import build_mimo_data_loaders
+
+    if train_state is None:
+        train_state = TrainState()
+
+    train_samples = cfg.train.train_iters * cfg.train.global_batch_size
+    train_loader, _, _ = build_mimo_data_loaders(
+        cfg=cfg,
+        train_state=train_state,
+        mimo_provider=cfg.dataset,
+        train_samples=max(train_samples, 10),
+        valid_samples=0,
+        test_samples=0,
+    )
+    train_iter = _wrap_iter(train_loader) if train_loader is not None else None
+    return train_iter, None
+
+
+# ---------------------------------------------------------------------------
+# Config builder
+# ---------------------------------------------------------------------------
+
+
+def _build_config(
+    mimo_provider: MimoModelProvider,
+    mock_data_provider: MockMimoProvider,
+    opt_config: BridgeOptimizerConfig,
+    ckpt_dir: str,
+    *,
+    train_iters: int,
+    save_interval: int,
+    load_dir: str | None = None,
+) -> ConfigContainer:
+    par_cfg = mimo_provider.mimo_parallelism_config
+    max_dp = max(p.data_parallel_size for p in par_cfg.module_parallelisms.values())
+
+    train_cfg = TrainingConfig(
+        micro_batch_size=1, global_batch_size=max_dp, train_iters=train_iters,
+    )
+    train_cfg.num_microbatches = 1
+    train_cfg.grad_reduce_in_fp32 = False
+    train_cfg.overlap_grad_reduce = False
+    train_cfg.use_distributed_optimizer = True
+    train_cfg.check_for_nan_in_grad = False
+    train_cfg.log_interval = 1
+
+    logger_cfg = LoggerConfig()
+    logger_cfg.log_interval = 1
+
+    llm_pp = par_cfg.module_parallelisms["llm"].pipeline_model_parallel_size
+    ckpt_cfg = CheckpointConfig(
+        save_interval=save_interval,
+        save=ckpt_dir,
+        ckpt_format="torch_dist",
+        # TODO: Re-enable fully_parallel_save for PP>1 after fixing MIMO sharded
+        # checkpoint access pattern validation for nested DDP language model params.
+        fully_parallel_save=(llm_pp == 1),
+        dist_ckpt_optim_fully_reshardable=True,
+        # MiMo RNG save is not yet supported: each module produces ShardedObject
+        # with key "rng_state" using module-local PP/TP/DP ranks, causing
+        # duplicate shard keys across modules.  Disable until upstream fix.
+        save_rng=False,
+    )
+    if load_dir is not None:
+        ckpt_cfg.load = load_dir
+
+    cfg = ConfigContainer(
+        train=train_cfg,
+        model=mimo_provider,
+        optimizer=opt_config,
+        scheduler=SchedulerConfig(start_weight_decay=0.0, end_weight_decay=0.0),
+        dataset=mock_data_provider,
+        logger=logger_cfg,
+        tokenizer=TokenizerConfig(),
+        checkpoint=ckpt_cfg,
+    )
+    cfg.data_parallel_size = max_dp
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# Phases
+# ---------------------------------------------------------------------------
+
+MARKER_FILE = "resume_marker.json"
+
+
+def _run_phase_save(ckpt_dir: str) -> None:
+    """Phase 1: Train for SAVE_STEPS steps and save checkpoint."""
+    rank = dist.get_rank()
+    _log(f"Phase SAVE: training for {SAVE_STEPS} steps, saving to {ckpt_dir}")
+
+    language_spec, modality_specs, special_tokens = _build_model_specs()
+    mimo_provider = MimoModelProvider(
+        language_model_spec=language_spec,
+        modality_submodules_spec=modality_specs,
+        special_token_ids=special_tokens,
+        mimo_parallelism_config=_build_parallelism_config(),
+        topology={"vision": ["llm"], "llm": []},
+        use_cpu_initialization=True,
+    )
+    if not hasattr(mimo_provider, "num_moe_experts"):
+        mimo_provider.num_moe_experts = None
+    if not hasattr(mimo_provider, "fp8"):
+        mimo_provider.fp8 = None
+
+    mock_data = _build_mock_data_provider()
+    bridge_opt = BridgeOptimizerConfig(lr=1e-4, use_distributed_optimizer=True)
+    mcore_opt = MCoreOptimizerConfig(
+        optimizer="adam", lr=1e-4, min_lr=0.0, weight_decay=0.01,
+        clip_grad=1.0, bf16=True, use_distributed_optimizer=True,
+    )
+
+    cfg = _build_config(
+        mimo_provider, mock_data, bridge_opt, ckpt_dir,
+        train_iters=SAVE_STEPS, save_interval=SAVE_STEPS,
+    )
+
+    global_state = GlobalState()
+
+    pretrain_mimo(
+        cfg=cfg, mimo_provider=mimo_provider,
+        forward_step_func=mimo_forward_step,
+        build_data_iterators_fn=_build_data_iterators,
+        opt_config=mcore_opt, schedulers={},
+        global_state=global_state,
+    )
+
+    ts = global_state.train_state
+    _log(f"Phase SAVE complete: step={ts.step}, consumed_train_samples={ts.consumed_train_samples}")
+
+    if rank == 0:
+        marker = {
+            "step": ts.step,
+            "consumed_train_samples": ts.consumed_train_samples,
+            "floating_point_operations_so_far": ts.floating_point_operations_so_far,
+        }
+        marker_path = os.path.join(ckpt_dir, MARKER_FILE)
+        with open(marker_path, "w") as f:
+            json.dump(marker, f)
+        _log(f"Wrote marker: {marker}")
+
+    dist.barrier()
+    assert ts.step == SAVE_STEPS, f"Expected step={SAVE_STEPS}, got {ts.step}"
+    _log("Phase SAVE: PASSED")
+
+
+def _run_phase_resume(ckpt_dir: str) -> None:
+    """Phase 2: Resume from checkpoint, train to TOTAL_STEPS, verify continuity."""
+    rank = dist.get_rank()
+    _log(f"Phase RESUME: loading from {ckpt_dir}, training to {TOTAL_STEPS} steps")
+
+    marker_path = os.path.join(ckpt_dir, MARKER_FILE)
+    with open(marker_path, "r") as f:
+        saved_marker = json.load(f)
+    _log(f"Loaded marker from phase 1: {saved_marker}")
+
+    language_spec, modality_specs, special_tokens = _build_model_specs()
+    mimo_provider = MimoModelProvider(
+        language_model_spec=language_spec,
+        modality_submodules_spec=modality_specs,
+        special_token_ids=special_tokens,
+        mimo_parallelism_config=_build_parallelism_config(),
+        topology={"vision": ["llm"], "llm": []},
+        use_cpu_initialization=True,
+    )
+    if not hasattr(mimo_provider, "num_moe_experts"):
+        mimo_provider.num_moe_experts = None
+    if not hasattr(mimo_provider, "fp8"):
+        mimo_provider.fp8 = None
+
+    mock_data = _build_mock_data_provider()
+    bridge_opt = BridgeOptimizerConfig(lr=1e-4, use_distributed_optimizer=True)
+    mcore_opt = MCoreOptimizerConfig(
+        optimizer="adam", lr=1e-4, min_lr=0.0, weight_decay=0.01,
+        clip_grad=1.0, bf16=True, use_distributed_optimizer=True,
+    )
+
+    cfg = _build_config(
+        mimo_provider, mock_data, bridge_opt, ckpt_dir,
+        train_iters=TOTAL_STEPS, save_interval=TOTAL_STEPS,
+        load_dir=ckpt_dir,
+    )
+    # Save phase used train_iters=SAVE_STEPS, so checkpoint scheduler state
+    # has lr_decay_steps / wd_incr_steps derived from SAVE_STEPS.  Resume uses
+    # TOTAL_STEPS which produces different values.  override_opt_param_scheduler
+    # tells the scheduler to use the current (resume) values without asserting
+    # against the checkpoint.  Scheduler progress (num_steps) is still restored.
+    cfg.scheduler.override_opt_param_scheduler = True
+
+    global_state = GlobalState()
+
+    pretrain_mimo(
+        cfg=cfg, mimo_provider=mimo_provider,
+        forward_step_func=mimo_forward_step,
+        build_data_iterators_fn=_build_data_iterators,
+        opt_config=mcore_opt, schedulers={},
+        global_state=global_state,
+    )
+
+    ts = global_state.train_state
+
+    _log(f"Phase RESUME complete: step={ts.step}, consumed_train_samples={ts.consumed_train_samples}")
+
+    # Verify step continuity
+    assert ts.step == TOTAL_STEPS, (
+        f"Step continuity failed: expected {TOTAL_STEPS}, got {ts.step}"
+    )
+
+    # Verify consumed_train_samples did not reset to 0
+    assert ts.consumed_train_samples >= saved_marker["consumed_train_samples"], (
+        f"consumed_train_samples reset detected: "
+        f"saved={saved_marker['consumed_train_samples']}, resumed={ts.consumed_train_samples}"
+    )
+
+    # Verify consumed_train_samples advanced beyond the saved value
+    expected_consumed = saved_marker["consumed_train_samples"] + (
+        (TOTAL_STEPS - SAVE_STEPS) * cfg.train.global_batch_size
+    )
+    assert ts.consumed_train_samples == expected_consumed, (
+        f"consumed_train_samples mismatch: expected {expected_consumed}, got {ts.consumed_train_samples}"
+    )
+
+    _log("Phase RESUME: PASSED — all continuity assertions hold")
+
+
+# ---------------------------------------------------------------------------
+# Logging + main
+# ---------------------------------------------------------------------------
+
+_rank_log_file = None
+
+
+def _log(msg):
+    global _rank_log_file
+    rank = dist.get_rank() if dist.is_initialized() else "?"
+    line = f"[Rank {rank}] {msg}\n"
+    if _rank_log_file:
+        _rank_log_file.write(line)
+        _rank_log_file.flush()
+    print(line, end="", flush=True)
+
+
+def main():
+    global _rank_log_file
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--phase", required=True, choices=["save", "resume"])
+    parser.add_argument("--ckpt-dir", required=True)
+    args = parser.parse_args()
+
+    dist.init_process_group("nccl")
+    rank = dist.get_rank()
+    local_rank = int(os.environ.get("LOCAL_RANK", 0))
+    torch.cuda.set_device(local_rank)
+
+    log_dir = "/tmp/mimo_resume_e2e_logs"
+    os.makedirs(log_dir, exist_ok=True)
+    _rank_log_file = open(f"{log_dir}/rank_{rank}_{args.phase}.log", "w")
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format=f"[Rank {rank}] %(name)s: %(message)s",
+        handlers=[
+            logging.FileHandler(f"{log_dir}/rank_{rank}_{args.phase}_full.log", mode="w"),
+            logging.StreamHandler(sys.stderr),
+        ],
+        force=True,
+    )
+
+    if args.phase == "save":
+        _run_phase_save(args.ckpt_dir)
+    else:
+        _run_phase_resume(args.ckpt_dir)
+
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/e2e/mimo/test_mimo_training_e2e.py
+++ b/tests/e2e/mimo/test_mimo_training_e2e.py
@@ -1,0 +1,382 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+"""End-to-end MIMO training test.
+
+Exercises the full training loop: pretrain_mimo -> setup_mimo -> train_mimo
+on 8 GPUs with synthetic data using the real data pipeline.
+LLM on ranks 0-3 (TP=4), vision encoder on ranks 4-7 (TP=4).
+
+Run:
+    torchrun --nproc_per_node=8 tests/e2e/mimo/test_mimo_training_e2e.py
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+
+import torch
+import torch.distributed as dist
+from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_with_transformer_engine_spec
+from megatron.core.models.gpt.gpt_model import GPTModel
+from megatron.core.models.mimo.submodules.vision import VisionModalitySubmodules
+from megatron.core.models.vision.clip_vit_model import CLIPViTModel
+from megatron.core.models.vision.vit_layer_specs import get_vit_layer_with_transformer_engine_spec
+from megatron.core.transformer.spec_utils import ModuleSpec
+from megatron.core.transformer.transformer_config import TransformerConfig
+
+
+def _make_vision_config() -> TransformerConfig:
+    cfg = TransformerConfig(
+        num_layers=2,
+        hidden_size=64,
+        ffn_hidden_size=256,
+        num_attention_heads=4,
+        use_cpu_initialization=True,
+        pipeline_dtype=torch.bfloat16,
+        bf16=True,
+        variable_seq_lengths=True,
+        moe_token_dispatcher_type="alltoall",
+    )
+    cfg.add_bias_linear = True
+    cfg.add_qkv_bias = True
+    cfg.hidden_dropout = 0.0
+    cfg.attention_dropout = 0.0
+    cfg.gated_linear_unit = False
+    cfg.layernorm_zero_centered_gamma = False
+    cfg.apply_query_key_layer_scaling = False
+    cfg.bias_activation_fusion = False
+    cfg.bias_dropout_fusion = False
+    cfg.attention_softmax_in_fp32 = True
+    cfg.normalization = "LayerNorm"
+    cfg.apply_rope_fusion = False
+    return cfg
+
+
+def _make_language_config() -> TransformerConfig:
+    return TransformerConfig(
+        num_layers=2,
+        hidden_size=64,
+        ffn_hidden_size=256,
+        num_attention_heads=4,
+        use_cpu_initialization=True,
+        pipeline_dtype=torch.bfloat16,
+        bf16=True,
+        variable_seq_lengths=True,
+        moe_token_dispatcher_type="alltoall",
+        cross_entropy_loss_fusion=True,
+    )
+
+
+_ENCODER_SEQ_LEN = 197  # (224/16)^2 = 196 patches + 1 class token
+_SPECIAL_TOKEN_ID = 32000
+_VOCAB_SIZE = 50304
+_SEQ_LENGTH = 256
+_IMG_SIZE = 224
+_PATCH_DIM = 16
+
+
+def _build_model_specs():
+    """Return (language_model_spec, modality_submodules_spec, special_token_ids)."""
+    vision_config = _make_vision_config()
+    language_config = _make_language_config()
+
+    vision_encoder = ModuleSpec(
+        module=CLIPViTModel,
+        params={
+            "transformer_config": vision_config,
+            "transformer_layer_spec": get_vit_layer_with_transformer_engine_spec(),
+            "patch_dim": _PATCH_DIM,
+            "img_h": _IMG_SIZE,
+            "img_w": _IMG_SIZE,
+        },
+    )
+
+    vision_submodule_spec = ModuleSpec(
+        module=VisionModalitySubmodules,
+        params={},
+        submodules={
+            "encoders": {"clip": vision_encoder},
+        },
+    )
+
+    language_model_spec = ModuleSpec(
+        module=GPTModel,
+        params={
+            "config": language_config,
+            "transformer_layer_spec": get_gpt_layer_with_transformer_engine_spec(),
+            "vocab_size": _VOCAB_SIZE,
+            "max_sequence_length": _SEQ_LENGTH,
+        },
+    )
+
+    modality_submodules_spec = {"vision": vision_submodule_spec}
+    special_token_ids = {"vision": _SPECIAL_TOKEN_ID}
+    return language_model_spec, modality_submodules_spec, special_token_ids
+
+
+from megatron.bridge.models.mimo.mimo_config import (
+    MimoParallelismConfig,
+    ModuleParallelismConfig,
+)
+
+
+def _build_parallelism_config() -> MimoParallelismConfig:
+    return MimoParallelismConfig(
+        module_parallelisms={
+            "llm": ModuleParallelismConfig(
+                tensor_model_parallel_size=4,
+                pipeline_model_parallel_size=1,
+                data_parallel_size=1,
+                rank_offset=0,
+            ),
+            "vision": ModuleParallelismConfig(
+                tensor_model_parallel_size=4,
+                pipeline_model_parallel_size=1,
+                data_parallel_size=1,
+                rank_offset=4,
+            ),
+        },
+    )
+
+
+from megatron.bridge.data.mimo.mock_provider import MockMimoProvider
+
+
+def _build_mock_data_provider() -> MockMimoProvider:
+    """Build a MockMimoProvider with HF processor (CLIP) and tokenizer (GPT-2)."""
+    provider = MockMimoProvider(
+        seq_length=_SEQ_LENGTH,
+        processor_paths={"vision": "openai/clip-vit-base-patch16"},
+        tokenizer_path="gpt2",
+        special_token_ids={"vision": _SPECIAL_TOKEN_ID},
+        encoder_seq_lengths={"vision": _ENCODER_SEQ_LEN},
+        modality_configs={
+            "vision": {"type": "image", "width": _IMG_SIZE, "height": _IMG_SIZE},
+        },
+    )
+    provider.drop_last = True
+    return provider
+
+
+def _wrap_iter(loader_iter):
+    """Adapt data-loader batches for the MIMO model.
+
+    Transforms:
+    - modality_inputs["vision"]["pixel_values"] -> modality_inputs["vision"]["clip"]["x"]
+      so VisionModalitySubmodules.encode() finds the "clip" encoder key and
+      CLIPViTModel.forward() receives ``x=...``.
+    - Sets attention_mask=None (not needed for this test).
+    - Generates loss_mask if not present.
+    """
+    for batch in loader_iter:
+        for key, value in batch.items():
+            if isinstance(value, torch.Tensor):
+                batch[key] = value.cuda(non_blocking=True)
+            elif isinstance(value, dict):
+                for k, v in value.items():
+                    if isinstance(v, torch.Tensor):
+                        value[k] = v.cuda(non_blocking=True)
+                    elif isinstance(v, dict):
+                        for kk, vv in v.items():
+                            if isinstance(vv, torch.Tensor):
+                                value[k][kk] = vv.cuda(non_blocking=True)
+
+        mi = batch.get("modality_inputs")
+        if mi and "vision" in mi:
+            pv = mi["vision"].get("pixel_values")
+            if pv is not None:
+                mi["vision"] = {"clip": {"x": pv.to(torch.bfloat16)}}
+
+        if "loss_mask" not in batch or batch["loss_mask"] is None:
+            batch["loss_mask"] = torch.ones_like(batch["input_ids"], dtype=torch.float)
+
+        batch["attention_mask"] = None
+
+        yield batch
+
+
+def _build_data_iterators(cfg, mimo_infra):
+    """Build data iterators compatible with setup_mimo's build_data_iterators_fn."""
+    from megatron.bridge.data.mimo.loaders import build_mimo_data_loaders
+    from megatron.bridge.training.state import TrainState
+
+    train_state = TrainState()
+
+    train_samples = cfg.train.train_iters * cfg.train.global_batch_size
+    valid_samples = 0
+    test_samples = 0
+
+    train_loader, valid_loader, _ = build_mimo_data_loaders(
+        cfg=cfg,
+        train_state=train_state,
+        mimo_provider=cfg.dataset,
+        train_samples=max(train_samples, 10),
+        valid_samples=valid_samples,
+        test_samples=test_samples,
+    )
+
+    train_iter = _wrap_iter(train_loader) if train_loader is not None else None
+    valid_iter = None
+    return train_iter, valid_iter
+
+
+from megatron.core.optimizer.optimizer_config import OptimizerConfig as MCoreOptimizerConfig
+
+from megatron.bridge.models.mimo.mimo_provider import MimoModelProvider
+from megatron.bridge.training.config import (
+    CheckpointConfig,
+    ConfigContainer,
+    LoggerConfig,
+    SchedulerConfig,
+    TrainingConfig,
+)
+from megatron.bridge.training.config import OptimizerConfig as BridgeOptimizerConfig
+from megatron.bridge.training.tokenizers.config import TokenizerConfig
+
+
+def _build_config(
+    mimo_provider: MimoModelProvider,
+    mock_data_provider: MockMimoProvider,
+    opt_config: BridgeOptimizerConfig,
+    log_interval: int = 1,
+    wandb_project: str | None = None,
+    wandb_exp_name: str | None = None,
+    wandb_entity: str | None = None,
+    wandb_save_dir: str | None = None,
+) -> ConfigContainer:
+    train_cfg = TrainingConfig(
+        micro_batch_size=1,
+        global_batch_size=1,
+        train_iters=2,
+    )
+    train_cfg.num_microbatches = 1
+    train_cfg.grad_reduce_in_fp32 = False
+    train_cfg.overlap_grad_reduce = False
+    train_cfg.use_distributed_optimizer = True
+    train_cfg.check_for_nan_in_grad = False
+    train_cfg.log_interval = log_interval
+
+    logger_cfg = LoggerConfig()
+    logger_cfg.log_interval = log_interval
+    logger_cfg.wandb_project = wandb_project
+    logger_cfg.wandb_exp_name = wandb_exp_name
+    logger_cfg.wandb_entity = wandb_entity
+    logger_cfg.wandb_save_dir = wandb_save_dir
+    logger_cfg.tensorboard_dir = os.path.join(wandb_save_dir or "/tmp/tb_logs", "tb_logs") if wandb_project else None
+
+    cfg = ConfigContainer(
+        train=train_cfg,
+        model=mimo_provider,
+        optimizer=opt_config,
+        scheduler=SchedulerConfig(start_weight_decay=0.0, end_weight_decay=0.0),
+        dataset=mock_data_provider,
+        logger=logger_cfg,
+        tokenizer=TokenizerConfig(),
+        checkpoint=CheckpointConfig(),
+    )
+    cfg.data_parallel_size = 1
+    return cfg
+
+
+from megatron.bridge.training.mimo_step import forward_step as mimo_forward_step
+from megatron.bridge.training.pretrain_mimo import pretrain_mimo
+
+
+_rank_log_file = None
+
+
+def _log(msg):
+    """Write with rank prefix to per-rank log file and flush."""
+    global _rank_log_file
+    rank = dist.get_rank() if dist.is_initialized() else "?"
+    line = f"[Rank {rank}] {msg}\n"
+    if _rank_log_file:
+        _rank_log_file.write(line)
+        _rank_log_file.flush()
+    print(line, end="", flush=True)
+
+
+def main():
+    global _rank_log_file
+
+    dist.init_process_group("nccl")
+    rank = dist.get_rank()
+    local_rank = int(os.environ.get("LOCAL_RANK", 0))
+    torch.cuda.set_device(local_rank)
+
+    log_dir = "/tmp/mimo_e2e_logs"
+    os.makedirs(log_dir, exist_ok=True)
+    _rank_log_file = open(f"{log_dir}/rank_{rank}.log", "w")
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format=f"[Rank {rank}] %(name)s: %(message)s",
+        handlers=[
+            logging.FileHandler(f"{log_dir}/rank_{rank}_full.log", mode="w"),
+            logging.StreamHandler(sys.stderr),
+        ],
+        force=True,
+    )
+    logging.getLogger("megatron.core.pipeline_parallel.bridge_communicator").setLevel(logging.DEBUG)
+    logging.getLogger("megatron.core.pipeline_parallel.multimodule_communicator").setLevel(logging.DEBUG)
+
+    _log(f"distributed initialized (world_size={dist.get_world_size()})")
+
+    _log("building model specs")
+    language_model_spec, modality_submodules_spec, special_token_ids = _build_model_specs()
+    mimo_parallelism_config = _build_parallelism_config()
+
+    mimo_provider = MimoModelProvider(
+        language_model_spec=language_model_spec,
+        modality_submodules_spec=modality_submodules_spec,
+        special_token_ids=special_token_ids,
+        mimo_parallelism_config=mimo_parallelism_config,
+        topology={"vision": ["llm"], "llm": []},
+        use_cpu_initialization=True,
+    )
+    if not hasattr(mimo_provider, "num_moe_experts"):
+        mimo_provider.num_moe_experts = None
+
+    _log("building data provider")
+    mock_data_provider = _build_mock_data_provider()
+
+    mcore_opt_config = MCoreOptimizerConfig(
+        optimizer="adam",
+        lr=1e-4,
+        min_lr=0.0,
+        weight_decay=0.01,
+        clip_grad=1.0,
+        bf16=True,
+        use_distributed_optimizer=True,
+    )
+    bridge_opt_config = BridgeOptimizerConfig(lr=1e-4)
+
+    _log("building config")
+    cfg = _build_config(
+        mimo_provider,
+        mock_data_provider,
+        bridge_opt_config,
+        wandb_project=os.environ.get("WANDB_PROJECT", "Megatron-Bridge-MIMO"),
+        wandb_exp_name=os.environ.get("WANDB_EXP_NAME", "mimo-e2e-test"),
+        wandb_entity=os.environ.get("WANDB_ENTITY"),
+        wandb_save_dir=os.environ.get("WANDB_SAVE_DIR", "/tmp/wandb"),
+    )
+
+    _log("launching pretrain_mimo")
+    pretrain_mimo(
+        cfg=cfg,
+        mimo_provider=mimo_provider,
+        forward_step_func=mimo_forward_step,
+        build_data_iterators_fn=_build_data_iterators,
+        opt_config=mcore_opt_config,
+        schedulers={},
+    )
+
+    _log("PASSED")
+
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/e2e/mimo/test_mimo_training_e2e.py
+++ b/tests/e2e/mimo/test_mimo_training_e2e.py
@@ -124,7 +124,7 @@ from megatron.bridge.models.mimo.mimo_config import (
 def _build_parallelism_config() -> MimoParallelismConfig:
     return MimoParallelismConfig(
         module_parallelisms={
-            "llm": ModuleParallelismConfig(
+            "language": ModuleParallelismConfig(
                 tensor_model_parallel_size=4,
                 pipeline_model_parallel_size=1,
                 data_parallel_size=1,
@@ -332,7 +332,7 @@ def main():
         modality_submodules_spec=modality_submodules_spec,
         special_token_ids=special_token_ids,
         mimo_parallelism_config=mimo_parallelism_config,
-        topology={"vision": ["llm"], "llm": []},
+        topology={"vision": ["language"], "language": []},
         use_cpu_initialization=True,
     )
     if not hasattr(mimo_provider, "num_moe_experts"):

--- a/tests/e2e/mimo/test_mimo_training_llava.py
+++ b/tests/e2e/mimo/test_mimo_training_llava.py
@@ -193,7 +193,7 @@ from megatron.bridge.models.mimo.mimo_config import (
 def _build_parallelism_config() -> MimoParallelismConfig:
     return MimoParallelismConfig(
         module_parallelisms={
-            "llm": ModuleParallelismConfig(
+            "language": ModuleParallelismConfig(
                 tensor_model_parallel_size=4,
                 pipeline_model_parallel_size=1,
                 data_parallel_size=1,
@@ -493,7 +493,7 @@ def main():
         modality_submodules_spec=modality_submodules_spec,
         special_token_ids=special_token_ids,
         mimo_parallelism_config=mimo_parallelism_config,
-        topology={"images": ["llm"], "llm": []},
+        topology={"images": ["language"], "language": []},
         use_cpu_initialization=True,
         bf16=True,
     )

--- a/tests/e2e/mimo/test_mimo_training_llava.py
+++ b/tests/e2e/mimo/test_mimo_training_llava.py
@@ -1,0 +1,572 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import random
+import sys
+
+import numpy as np
+import torch
+import torch.distributed as dist
+from megatron.core.extensions.transformer_engine import (
+    TEColumnParallelLinear,
+    TERowParallelLinear,
+)
+from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_with_transformer_engine_spec
+from megatron.core.models.gpt.gpt_model import GPTModel
+from megatron.core.models.mimo.submodules.vision import VisionModalitySubmodules
+from megatron.core.models.vision.clip_vit_model import CLIPViTModel
+from megatron.core.models.vision.multimodal_projector import MultimodalProjector
+from megatron.core.models.vision.vit_layer_specs import get_vit_layer_with_transformer_engine_spec
+from megatron.core.transformer.mlp import MLPSubmodules
+from megatron.core.transformer.spec_utils import ModuleSpec
+from megatron.core.transformer.transformer_config import TransformerConfig
+
+
+# ---------------------------------------------------------------------------
+# LLaVA model configs (Vicuna-7B + CLIP ViT-L/14 + MLP projection)
+# ---------------------------------------------------------------------------
+
+IMAGE_SPECIAL_TOKEN_ID = 32000
+VOCAB_SIZE = 32256
+CLIP_OUTPUT_DIM = 1024  # CLIP ViT-L/14 hidden size
+MAX_SEQ_LENGTH = 4096
+_IMG_SIZE = 336
+_PATCH_DIM = 14
+# CLIP ViT-L/14 @ 336×336: (336/14)^2 = 576 patches + 1 class token = 577
+_ENCODER_SEQ_LEN = 577
+
+
+def _make_vision_config() -> TransformerConfig:
+    """CLIP ViT-L/14 vision encoder config."""
+    cfg = TransformerConfig(
+        num_layers=24,
+        hidden_size=1024,
+        ffn_hidden_size=4096,
+        num_attention_heads=16,
+        use_cpu_initialization=True,
+        pipeline_dtype=torch.bfloat16,
+        bf16=True,
+        variable_seq_lengths=True,
+        moe_token_dispatcher_type="alltoall",
+    )
+    cfg.add_bias_linear = True
+    cfg.add_qkv_bias = True
+    cfg.hidden_dropout = 0.0
+    cfg.attention_dropout = 0.0
+    cfg.gated_linear_unit = False
+    cfg.layernorm_zero_centered_gamma = False
+    cfg.apply_query_key_layer_scaling = False
+    cfg.bias_activation_fusion = False
+    cfg.bias_dropout_fusion = False
+    cfg.attention_softmax_in_fp32 = True
+    cfg.normalization = "LayerNorm"
+    cfg.apply_rope_fusion = False
+    return cfg
+
+
+def _make_language_config() -> TransformerConfig:
+    """Vicuna-7B language model config (same arch as Llama-7B)."""
+    cfg = TransformerConfig(
+        num_layers=32,
+        hidden_size=4096,
+        num_attention_heads=32,
+        use_cpu_initialization=True,
+    )
+
+    cfg.ffn_hidden_size = 11008
+    cfg.activation_func = torch.nn.functional.silu
+    cfg.gated_linear_unit = True
+
+    cfg.normalization = "RMSNorm"
+    cfg.rms_norm_eps = 1e-5
+
+    cfg.position_embedding_type = "rope"
+    cfg.rotary_base = 10000
+    cfg.rotary_percent = 1.0
+
+    cfg.seq_length = MAX_SEQ_LENGTH
+    cfg.max_position_embeddings = MAX_SEQ_LENGTH
+
+    cfg.attention_dropout = 0.0
+    cfg.hidden_dropout = 0.0
+
+    cfg.num_query_groups = 32
+    cfg.add_bias_linear = False
+    cfg.untie_embeddings_and_output_weights = False
+
+    cfg.bias_activation_fusion = True
+    cfg.masked_softmax_fusion = True
+    cfg.persist_layer_norm = True
+    cfg.bias_dropout_fusion = True
+    cfg.apply_rope_fusion = True
+
+    cfg.pipeline_dtype = torch.bfloat16
+    cfg.bf16 = True
+    cfg.cross_entropy_loss_fusion = True
+    cfg.variable_seq_lengths = True
+
+    return cfg
+
+
+def _make_projection_config(hidden_size: int = 4096) -> TransformerConfig:
+    """Vision→language projection MLP config."""
+    cfg = TransformerConfig(num_layers=1, hidden_size=hidden_size, num_attention_heads=1)
+    cfg.ffn_hidden_size = 4096
+    cfg.bias_activation_fusion = True
+    cfg.add_bias_linear = True
+    cfg.activation_func = torch.nn.functional.gelu
+    return cfg
+
+
+def _build_model_specs():
+    """Return (language_model_spec, modality_submodules_spec, special_token_ids)."""
+    vision_config = _make_vision_config()
+    language_config = _make_language_config()
+    projection_config = _make_projection_config(hidden_size=language_config.hidden_size)
+
+    # CLIP ViT-L/14 encoder
+    vision_encoder = ModuleSpec(
+        module=CLIPViTModel,
+        params={
+            "transformer_config": vision_config,
+            "transformer_layer_spec": get_vit_layer_with_transformer_engine_spec(),
+            "patch_dim": _PATCH_DIM,
+            "img_h": _IMG_SIZE,
+            "img_w": _IMG_SIZE,
+        },
+    )
+
+    # Vision→language projection MLP
+    vision_projection = ModuleSpec(
+        module=MultimodalProjector,
+        params={
+            "config": projection_config,
+            "submodules": MLPSubmodules(
+                linear_fc1=TEColumnParallelLinear,
+                linear_fc2=TERowParallelLinear,
+            ),
+            "projector_type": "mlp",
+            "input_size": CLIP_OUTPUT_DIM,
+        },
+    )
+
+    vision_submodule_spec = ModuleSpec(
+        module=VisionModalitySubmodules,
+        params={},
+        submodules={
+            "encoders": {"clip": vision_encoder},
+            "input_projections": [vision_projection],
+        },
+    )
+
+    language_model_spec = ModuleSpec(
+        module=GPTModel,
+        params={
+            "config": language_config,
+            "transformer_layer_spec": get_gpt_layer_with_transformer_engine_spec(),
+            "vocab_size": VOCAB_SIZE,
+            "max_sequence_length": MAX_SEQ_LENGTH,
+            "position_embedding_type": "rope",
+        },
+    )
+
+    modality_submodules_spec = {"images": vision_submodule_spec}
+    special_token_ids = {"images": IMAGE_SPECIAL_TOKEN_ID}
+    return language_model_spec, modality_submodules_spec, special_token_ids
+
+
+# ---------------------------------------------------------------------------
+# Parallelism config (8 GPUs: TP=4 for both modules)
+# ---------------------------------------------------------------------------
+
+from megatron.bridge.models.mimo.mimo_config import (
+    MimoParallelismConfig,
+    ModuleParallelismConfig,
+)
+
+
+def _build_parallelism_config() -> MimoParallelismConfig:
+    return MimoParallelismConfig(
+        module_parallelisms={
+            "llm": ModuleParallelismConfig(
+                tensor_model_parallel_size=4,
+                pipeline_model_parallel_size=1,
+                data_parallel_size=1,
+                rank_offset=0,
+            ),
+            "images": ModuleParallelismConfig(
+                tensor_model_parallel_size=4,
+                pipeline_model_parallel_size=1,
+                data_parallel_size=1,
+                rank_offset=4,
+            ),
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Data pipeline
+# ---------------------------------------------------------------------------
+
+from megatron.bridge.data.mimo.hf_provider import HFMimoDatasetProvider
+
+
+def _llava_preprocess(example, dataset_root):
+    """Convert LLaVA conversations format to plain text and resolve image paths."""
+    conversations = example.get("conversations", [])
+    text_parts = [turn.get("value", "") for turn in conversations]
+    example["text"] = " ".join(text_parts).replace("<image>", "").strip()
+    # Resolve relative image paths to absolute paths
+    if "image" in example and example["image"] and not os.path.isabs(example["image"]):
+        example["image"] = os.path.join(dataset_root, example["image"])
+    return example
+
+
+def _build_hf_data_provider(dataset_root: str) -> HFMimoDatasetProvider:
+    """Build an HFMimoDatasetProvider for liuhaotian/LLaVA-Pretrain."""
+    provider = HFMimoDatasetProvider(
+        seq_length=MAX_SEQ_LENGTH,
+        hf_dataset_path=dataset_root,
+        hf_data_files="blip_laion_cc_sbu_558k.json",
+        hf_tokenizer_path="llava-hf/llava-1.5-7b-hf",
+        processor_paths={"images": "openai/clip-vit-large-patch14-336"},
+        special_token_ids={"images": IMAGE_SPECIAL_TOKEN_ID},
+        encoder_seq_lengths={"images": _ENCODER_SEQ_LEN},
+        modality_columns={"images": "image"},
+        text_column="text",
+        train_split="train",
+        preprocess_fn=lambda example: _llava_preprocess(example, dataset_root),
+    )
+    provider.drop_last = True
+
+    return provider
+
+
+def _wrap_iter(loader_iter):
+    """Adapt data-loader batches for the MIMO model.
+
+    Transforms:
+    - modality_inputs["images"]["pixel_values"] → modality_inputs["images"]["clip"]["x"]
+      so VisionModalitySubmodules.encode() finds the "clip" encoder key and
+      CLIPViTModel.forward() receives ``x=...``.
+    - Sets attention_mask=None (not needed for this test).
+    - Generates loss_mask if not present.
+    """
+    for batch in loader_iter:
+        # Move tensors to GPU
+        for key, value in batch.items():
+            if isinstance(value, torch.Tensor):
+                batch[key] = value.cuda(non_blocking=True)
+            elif isinstance(value, dict):
+                for k, v in value.items():
+                    if isinstance(v, torch.Tensor):
+                        value[k] = v.cuda(non_blocking=True)
+                    elif isinstance(v, dict):
+                        for kk, vv in v.items():
+                            if isinstance(vv, torch.Tensor):
+                                value[k][kk] = vv.cuda(non_blocking=True)
+
+        # Rewrap modality_inputs: {"images": {"pixel_values": t}} → {"images": {"clip": {"x": t}}}
+        # Cast to bfloat16 to match model weights
+        mi = batch.get("modality_inputs")
+        if mi and "images" in mi:
+            pv = mi["images"].get("pixel_values")
+            if pv is not None:
+                mi["images"] = {"clip": {"x": pv.to(torch.bfloat16)}}
+
+        # Ensure loss_mask exists
+        if "loss_mask" not in batch or batch["loss_mask"] is None:
+            batch["loss_mask"] = torch.ones_like(batch["input_ids"], dtype=torch.float)
+
+        # Drop attention_mask (not needed)
+        batch["attention_mask"] = None
+
+        yield batch
+
+
+def _build_data_iterators(cfg, mimo_infra):
+    """Build data iterators compatible with setup_mimo's build_data_iterators_fn.
+
+    Signature: (cfg, mimo_infra) -> (train_iter, valid_iter)
+    Uses build_mimo_data_loaders which auto-detects MIMO path via cfg.model.
+    """
+    from megatron.bridge.data.mimo.loaders import build_mimo_data_loaders
+    from megatron.bridge.training.state import TrainState
+
+    train_state = TrainState()
+
+    # Compute sample counts
+    train_samples = cfg.train.train_iters * cfg.train.global_batch_size
+    valid_samples = 0
+    test_samples = 0
+
+    train_loader, _, _ = build_mimo_data_loaders(
+        cfg=cfg,
+        train_state=train_state,
+        mimo_provider=cfg.dataset,
+        train_samples=max(train_samples, 10),  # min 10 samples
+        valid_samples=valid_samples,
+        test_samples=test_samples,
+    )
+
+    train_iter = _wrap_iter(train_loader) if train_loader is not None else None
+    valid_iter = None
+    return train_iter, valid_iter
+
+
+# ---------------------------------------------------------------------------
+# Config assembly
+# ---------------------------------------------------------------------------
+
+from megatron.core.optimizer.optimizer_config import OptimizerConfig as MCoreOptimizerConfig
+
+from megatron.bridge.models.mimo.mimo_provider import MimoModelProvider
+from megatron.bridge.training.config import (
+    CheckpointConfig,
+    ConfigContainer,
+    LoggerConfig,
+    SchedulerConfig,
+    TrainingConfig,
+)
+from megatron.bridge.training.config import OptimizerConfig as BridgeOptimizerConfig
+from megatron.bridge.training.tokenizers.config import TokenizerConfig
+
+
+def _build_config(
+    mimo_provider: MimoModelProvider,
+    data_provider: HFMimoDatasetProvider,
+    opt_config: BridgeOptimizerConfig,
+    micro_batch_size: int = 1,
+    global_batch_size: int = 1,
+    train_iters: int = 2,
+    log_interval: int = 1,
+    wandb_project: str | None = None,
+    wandb_exp_name: str | None = None,
+    wandb_entity: str | None = None,
+    wandb_save_dir: str | None = None,
+    lr_warmup_iters: int = 0,
+) -> ConfigContainer:
+    train_cfg = TrainingConfig(
+        micro_batch_size=micro_batch_size,
+        global_batch_size=global_batch_size,
+        train_iters=train_iters,
+    )
+    # Runtime patches for MIMO
+    train_cfg.num_microbatches = 1
+    train_cfg.grad_reduce_in_fp32 = False
+    train_cfg.overlap_grad_reduce = False
+    train_cfg.use_distributed_optimizer = True
+    train_cfg.check_for_nan_in_grad = False
+    train_cfg.log_interval = log_interval
+
+    logger_cfg = LoggerConfig()
+    logger_cfg.log_timers_to_tensorboard = True
+    logger_cfg.log_interval = log_interval
+    logger_cfg.wandb_project = wandb_project
+    logger_cfg.wandb_exp_name = wandb_exp_name
+    logger_cfg.wandb_entity = wandb_entity
+    logger_cfg.wandb_save_dir = wandb_save_dir
+    logger_cfg.tensorboard_dir = os.path.join(wandb_save_dir or "/tmp/tb_logs", "tb_logs") if wandb_project else None
+
+    scheduler_cfg = SchedulerConfig(
+        lr_decay_style="cosine",
+        lr_warmup_iters=lr_warmup_iters,
+        lr_warmup_init=opt_config.min_lr,
+        start_weight_decay=opt_config.weight_decay,
+        end_weight_decay=opt_config.weight_decay,
+    )
+
+    cfg = ConfigContainer(
+        train=train_cfg,
+        model=mimo_provider,
+        optimizer=opt_config,
+        scheduler=scheduler_cfg,
+        dataset=data_provider,
+        logger=logger_cfg,
+        tokenizer=TokenizerConfig(),
+        checkpoint=CheckpointConfig(),
+    )
+    cfg.data_parallel_size = 1
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+from megatron.bridge.training.mimo_step import forward_step as mimo_forward_step
+from megatron.bridge.training.pretrain_mimo import pretrain_mimo
+
+
+_rank_log_file = None
+
+
+def _log(msg):
+    """Write with rank prefix to per-rank log file and flush."""
+    global _rank_log_file
+    rank = dist.get_rank() if dist.is_initialized() else "?"
+    line = f"[Rank {rank}] {msg}\n"
+    if _rank_log_file:
+        _rank_log_file.write(line)
+        _rank_log_file.flush()
+    print(line, end="", flush=True)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="MIMO LLaVA training")
+    parser.add_argument("--micro-batch-size", type=int, default=1, help="Micro batch size per GPU")
+    parser.add_argument("--global-batch-size", type=int, default=1, help="Global batch size across all GPUs")
+    parser.add_argument("--train-iters", type=int, default=2, help="Number of training iterations")
+    parser.add_argument("--min-lr", type=float, default=2.0e-5)
+    parser.add_argument("--adam-beta1", type=float, default=0.9)
+    parser.add_argument("--adam-beta2", type=float, default=0.95)
+    parser.add_argument("--clip-grad", type=float, default=1.0)
+    parser.add_argument("--log-interval", type=int, default=1)
+    parser.add_argument("--checkpoint-interval", type=int, default=None, help="Checkpoint save interval (iterations)")
+    parser.add_argument("--checkpoint-dir", type=str, default=None, help="Checkpoint output directory")
+    parser.add_argument("--load-checkpoint", type=str, default=None, help="Checkpoint directory to resume from")
+    parser.add_argument("--lr", type=float, default=2e-5)
+    parser.add_argument("--weight-decay", type=float, default=0.01)
+    parser.add_argument("--wandb-project", type=str, default="Megatron-Bridge-MIMO", help="W&B project name")
+    parser.add_argument("--wandb-exp-name", type=str, default="mimo-llava-e2e-test", help="W&B experiment name")
+    parser.add_argument("--wandb-entity", type=str, default=None, help="W&B entity")
+    parser.add_argument("--wandb-save-dir", type=str, default="/tmp/wandb", help="W&B save directory")
+    parser.add_argument(
+        "--lr-warmup-iters", type=int, default=20, help="Number of iterations to linearly warmup learning rate"
+    )
+    parser.add_argument("--dataset-root", type=str, required=True, help="Root directory of the LLaVA-Pretrain dataset")
+    return parser.parse_args()
+
+
+def main():
+    global _rank_log_file
+
+    args = parse_args()
+
+    # 1. Initialize distributed first so we know rank
+    dist.init_process_group("nccl")
+    rank = dist.get_rank()
+    local_rank = int(os.environ.get("LOCAL_RANK", 0))
+    torch.cuda.set_device(local_rank)
+
+    # Seed all RNGs for reproducible weight initialization
+    seed = 42
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+
+    # Open per-rank log file
+    log_dir = os.environ.get("MIMO_LOG_DIR", "/tmp/mimo_llava_logs")
+    os.makedirs(log_dir, exist_ok=True)
+    _rank_log_file = open(f"{log_dir}/rank_{rank}.log", "w")
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format=f"[Rank {rank}] %(name)s: %(message)s",
+        handlers=[logging.FileHandler(f"{log_dir}/rank_{rank}_full.log", mode="w"), logging.StreamHandler(sys.stderr)],
+        force=True,
+    )
+    # Enable debug logging for bridge communicator to trace P2P ops
+    logging.getLogger("megatron.core.pipeline_parallel.bridge_communicator").setLevel(logging.DEBUG)
+    logging.getLogger("megatron.core.pipeline_parallel.multimodule_communicator").setLevel(logging.DEBUG)
+
+    _log(f"distributed initialized (world_size={dist.get_world_size()})")
+
+    # No parallel_state.initialize_model_parallel() — MIMO manages its own
+    # parallelism via HyperCommGrids and pg_collections. Float16Module is
+    # skipped (direct bf16 cast), and cross_entropy_loss_fusion=True ensures
+    # the fused CE path uses pg_collection.tp instead of global parallel_state.
+
+    # 2. Build model provider
+    _log("building model specs")
+    language_model_spec, modality_submodules_spec, special_token_ids = _build_model_specs()
+    mimo_parallelism_config = _build_parallelism_config()
+
+    mimo_provider = MimoModelProvider(
+        language_model_spec=language_model_spec,
+        modality_submodules_spec=modality_submodules_spec,
+        special_token_ids=special_token_ids,
+        mimo_parallelism_config=mimo_parallelism_config,
+        topology={"images": ["llm"], "llm": []},
+        use_cpu_initialization=True,
+        bf16=True,
+    )
+    # Patch: training_log accesses config.model.num_moe_experts
+    if not hasattr(mimo_provider, "num_moe_experts"):
+        mimo_provider.num_moe_experts = None
+
+    # 4. Build data provider
+    _log("building data provider")
+    data_provider = _build_hf_data_provider(args.dataset_root)
+
+    # 5. Build optimizer configs
+    # MCore OptimizerConfig (with __post_init__) for get_mimo_optimizer
+    _log("building optimizer configs")
+    print_rank_0 = lambda msg: _log(msg) if dist.get_rank() == 0 else None
+    print_rank_0(
+        f"Optimizer config: lr={args.lr}, min_lr={args.min_lr}, weight_decay={args.weight_decay}, "
+        f"adam_beta1={args.adam_beta1}, adam_beta2={args.adam_beta2}, clip_grad={args.clip_grad}"
+    )
+    mcore_opt_config = MCoreOptimizerConfig(
+        optimizer="adam",
+        lr=args.lr,
+        min_lr=args.min_lr,
+        weight_decay=args.weight_decay,
+        adam_beta1=args.adam_beta1,
+        adam_beta2=args.adam_beta2,
+        clip_grad=args.clip_grad,
+        bf16=True,
+        use_distributed_optimizer=True,
+    )
+    # Bridge OptimizerConfig (deferred post_init) for ConfigContainer
+    bridge_opt_config = BridgeOptimizerConfig(lr=args.lr, min_lr=args.min_lr, use_distributed_optimizer=True)
+
+    # 6. Build config container
+    _log("building config")
+    cfg = _build_config(
+        mimo_provider,
+        data_provider,
+        bridge_opt_config,
+        micro_batch_size=args.micro_batch_size,
+        global_batch_size=args.global_batch_size,
+        train_iters=args.train_iters,
+        log_interval=args.log_interval,
+        wandb_project=args.wandb_project,
+        wandb_exp_name=args.wandb_exp_name,
+        wandb_entity=args.wandb_entity,
+        wandb_save_dir=args.wandb_save_dir,
+        lr_warmup_iters=args.lr_warmup_iters,
+    )
+
+    # Configure checkpointing from CLI args
+    if args.checkpoint_interval is not None:
+        cfg.checkpoint.save_interval = args.checkpoint_interval
+    if args.checkpoint_dir is not None:
+        cfg.checkpoint.save = args.checkpoint_dir
+    if args.load_checkpoint is not None:
+        cfg.checkpoint.load = args.load_checkpoint
+
+    # 7. Run training
+    _log("launching pretrain_mimo")
+    pretrain_mimo(
+        cfg=cfg,
+        mimo_provider=mimo_provider,
+        forward_step_func=mimo_forward_step,
+        build_data_iterators_fn=_build_data_iterators,
+        opt_config=mcore_opt_config,
+    )
+
+    _log("PASSED")
+
+    # 8. Cleanup
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit_tests/data/mimo/__init__.py
+++ b/tests/unit_tests/data/mimo/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.

--- a/tests/unit_tests/data/mimo/test_collate.py
+++ b/tests/unit_tests/data/mimo/test_collate.py
@@ -1,0 +1,133 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+"""Unit tests for MIMO collate functions."""
+
+import torch
+
+from megatron.bridge.data.mimo.collate import mimo_collate_fn
+
+
+def make_sample(
+    seq_length: int = 64,
+    modalities: dict = None,
+) -> dict:
+    """Create a sample item for testing."""
+    if modalities is None:
+        modalities = {"vision": {"pixel_values": torch.randn(3, 224, 224)}}
+
+    return {
+        "input_ids": torch.randint(0, 1000, (seq_length,)),
+        "labels": torch.randint(0, 1000, (seq_length,)),
+        "loss_mask": torch.ones(seq_length, dtype=torch.float32),
+        "attention_mask": torch.ones(seq_length),
+        "position_ids": torch.arange(seq_length),
+        "modality_inputs": modalities,
+    }
+
+
+class TestMimoCollateFn:
+    """Test suite for mimo_collate_fn."""
+
+    def test_basic_collation(self):
+        """Test basic batch collation."""
+        batch = [make_sample() for _ in range(4)]
+
+        result = mimo_collate_fn(batch, modality_names=["vision"])
+
+        assert "input_ids" in result
+        assert "labels" in result
+        assert "loss_mask" in result
+        assert "attention_mask" in result
+        assert "position_ids" in result
+        assert "modality_inputs" in result
+
+    def test_batch_dimension(self):
+        """Test that batch dimension is correct."""
+        batch_size = 8
+        seq_length = 64
+        batch = [make_sample(seq_length=seq_length) for _ in range(batch_size)]
+
+        result = mimo_collate_fn(batch, modality_names=["vision"])
+
+        assert result["input_ids"].shape == (batch_size, seq_length)
+        assert result["labels"].shape == (batch_size, seq_length)
+        assert result["loss_mask"].shape == (batch_size, seq_length)
+        assert result["attention_mask"].shape == (batch_size, seq_length)
+        assert result["position_ids"].shape == (batch_size, seq_length)
+
+    def test_modality_inputs_batched(self):
+        """Test that modality inputs are properly batched."""
+        batch_size = 4
+        image_shape = (3, 224, 224)
+
+        batch = [
+            make_sample(modalities={"vision": {"pixel_values": torch.randn(*image_shape)}}) for _ in range(batch_size)
+        ]
+
+        result = mimo_collate_fn(batch, modality_names=["vision"])
+
+        assert "vision" in result["modality_inputs"]
+        assert "pixel_values" in result["modality_inputs"]["vision"]
+        assert result["modality_inputs"]["vision"]["pixel_values"].shape == (batch_size, *image_shape)
+
+    def test_multiple_modalities(self):
+        """Test collation with multiple modalities."""
+        batch_size = 4
+
+        batch = [
+            make_sample(
+                modalities={
+                    "vision": {"pixel_values": torch.randn(3, 224, 224)},
+                    "audio": {"input_features": torch.randn(128, 3000)},
+                }
+            )
+            for _ in range(batch_size)
+        ]
+
+        result = mimo_collate_fn(batch, modality_names=["vision", "audio"])
+
+        assert "vision" in result["modality_inputs"]
+        assert "audio" in result["modality_inputs"]
+        assert result["modality_inputs"]["vision"]["pixel_values"].shape == (batch_size, 3, 224, 224)
+        assert result["modality_inputs"]["audio"]["input_features"].shape == (batch_size, 128, 3000)
+
+    def test_empty_batch(self):
+        """Test handling of empty batch."""
+        result = mimo_collate_fn([], modality_names=["vision"])
+        assert result == {}
+
+    def test_missing_modality_in_some_items(self):
+        """Test handling when some items lack a modality."""
+        # Item 0 has vision, item 1 doesn't
+        batch = [
+            make_sample(modalities={"vision": {"pixel_values": torch.randn(3, 224, 224)}}),
+            make_sample(modalities={}),  # No modality
+        ]
+
+        result = mimo_collate_fn(batch, modality_names=["vision"])
+
+        # Should still have basic fields
+        assert result["input_ids"].shape[0] == 2
+        # Vision should only have 1 item (from first sample)
+        if "vision" in result["modality_inputs"]:
+            assert result["modality_inputs"]["vision"]["pixel_values"].shape[0] == 1
+
+    def test_multiple_tensors_per_modality(self):
+        """Test modality with multiple tensor outputs."""
+        batch_size = 4
+
+        batch = [
+            make_sample(
+                modalities={
+                    "vision": {
+                        "pixel_values": torch.randn(3, 224, 224),
+                        "image_grid_thw": torch.tensor([1, 14, 14]),
+                    }
+                }
+            )
+            for _ in range(batch_size)
+        ]
+
+        result = mimo_collate_fn(batch, modality_names=["vision"])
+
+        assert "pixel_values" in result["modality_inputs"]["vision"]
+        assert "image_grid_thw" in result["modality_inputs"]["vision"]

--- a/tests/unit_tests/data/mimo/test_dataset.py
+++ b/tests/unit_tests/data/mimo/test_dataset.py
@@ -1,0 +1,443 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+"""Unit tests for MimoDataset."""
+
+import pytest
+import torch
+
+from megatron.bridge.data.mimo.dataset import MimoDataset
+
+
+class MockExamples:
+    """Mock data source (HuggingFace dataset or list) for testing."""
+    
+    def __init__(self, size: int = 100):
+        self._size = size
+        self._data = [
+            {
+                "text": f"Sample text {i} with some content.",
+                "image": f"image_{i}.jpg",  # Fake image path
+                "audio": f"audio_{i}.wav",  # Fake audio path
+            }
+            for i in range(size)
+        ]
+    
+    def __len__(self) -> int:
+        return self._size
+    
+    def __getitem__(self, idx: int):
+        return self._data[idx]
+
+
+class MockProcessor:
+    """Mock HuggingFace processor for testing."""
+    
+    def __init__(self, output_key: str = "pixel_values", output_shape: tuple = (3, 224, 224)):
+        self.output_key = output_key
+        self.output_shape = output_shape
+    
+    def __call__(self, inputs, return_tensors: str = "pt"):
+        # Return mock processed output
+        return {
+            self.output_key: torch.randn(1, *self.output_shape),
+        }
+
+
+class MockTokenizer:
+    """Mock HuggingFace tokenizer for testing."""
+    
+    def __init__(self, vocab_size: int = 32000):
+        self.vocab_size = vocab_size
+        self.pad_token = "<pad>"
+        self.pad_token_id = 0
+        self.eos_token = "</s>"
+    
+    def __call__(
+        self,
+        text: str,
+        truncation: bool = True,
+        max_length: int = 512,
+        return_tensors: str = "pt",
+    ):
+        # Generate fake token IDs based on text length
+        num_tokens = min(len(text.split()) * 2, max_length)
+        input_ids = torch.randint(1, self.vocab_size, (1, num_tokens))
+        return {"input_ids": input_ids}
+
+
+class TestMimoDataset:
+    """Test suite for MimoDataset."""
+    
+    def test_basic_construction(self):
+        """Test basic dataset construction."""
+        examples = MockExamples(size=50)
+        processors = {"vision": MockProcessor()}
+        tokenizer = MockTokenizer()
+        
+        dataset = MimoDataset(
+            examples=examples,
+            processors=processors,
+            tokenizer=tokenizer,
+            seq_length=128,
+            special_token_ids={"vision": 32000},
+            encoder_seq_lengths={"vision": 1},
+            modality_columns={"vision": "image"},
+        )
+        
+        assert len(dataset) == 50
+    
+    def test_max_samples_limit(self):
+        """Test that max_samples limits dataset size."""
+        examples = MockExamples(size=100)
+        processors = {"vision": MockProcessor()}
+        tokenizer = MockTokenizer()
+        
+        dataset = MimoDataset(
+            examples=examples,
+            processors=processors,
+            tokenizer=tokenizer,
+            seq_length=128,
+            special_token_ids={"vision": 32000},
+            encoder_seq_lengths={"vision": 1},
+            modality_columns={"vision": "image"},
+            max_samples=25,
+        )
+        
+        assert len(dataset) == 25
+    
+    def test_getitem_returns_expected_keys(self):
+        """Test that __getitem__ returns expected dict keys."""
+        examples = MockExamples(size=10)
+        processors = {"vision": MockProcessor()}
+        tokenizer = MockTokenizer()
+        
+        dataset = MimoDataset(
+            examples=examples,
+            processors=processors,
+            tokenizer=tokenizer,
+            seq_length=128,
+            special_token_ids={"vision": 32000},
+            encoder_seq_lengths={"vision": 1},
+            modality_columns={"vision": "image"},
+        )
+        
+        item = dataset[0]
+        
+        assert "input_ids" in item
+        assert "labels" in item
+        assert "attention_mask" in item
+        assert "position_ids" in item
+        assert "modality_inputs" in item
+    
+    def test_getitem_shapes(self):
+        """Test that __getitem__ returns correct tensor shapes."""
+        seq_length = 64
+        examples = MockExamples(size=10)
+        processors = {"vision": MockProcessor(output_shape=(3, 224, 224))}
+        tokenizer = MockTokenizer()
+        
+        dataset = MimoDataset(
+            examples=examples,
+            processors=processors,
+            tokenizer=tokenizer,
+            seq_length=seq_length,
+            special_token_ids={"vision": 32000},
+            encoder_seq_lengths={"vision": 1},
+            modality_columns={"vision": "image"},
+        )
+        
+        item = dataset[0]
+        
+        assert item["input_ids"].shape == (seq_length,)
+        assert item["labels"].shape == (seq_length,)
+        assert item["attention_mask"].shape == (seq_length,)
+        assert item["position_ids"].shape == (seq_length,)
+    
+    def test_modality_inputs_present(self):
+        """Test that modality_inputs contains processed tensors."""
+        examples = MockExamples(size=10)
+        processors = {"vision": MockProcessor(output_shape=(3, 224, 224))}
+        tokenizer = MockTokenizer()
+        
+        dataset = MimoDataset(
+            examples=examples,
+            processors=processors,
+            tokenizer=tokenizer,
+            seq_length=64,
+            special_token_ids={"vision": 32000},
+            encoder_seq_lengths={"vision": 1},
+            modality_columns={"vision": "image"},
+        )
+        
+        item = dataset[0]
+        
+        assert "vision" in item["modality_inputs"]
+        assert "pixel_values" in item["modality_inputs"]["vision"]
+        # Shape should be (3, 224, 224) - batch dim squeezed
+        assert item["modality_inputs"]["vision"]["pixel_values"].shape == (3, 224, 224)
+    
+    def test_multiple_modalities(self):
+        """Test dataset with multiple modalities."""
+        examples = MockExamples(size=10)
+        processors = {
+            "vision": MockProcessor(output_key="pixel_values", output_shape=(3, 224, 224)),
+            "audio": MockProcessor(output_key="input_features", output_shape=(128, 3000)),
+        }
+        tokenizer = MockTokenizer()
+        
+        dataset = MimoDataset(
+            examples=examples,
+            processors=processors,
+            tokenizer=tokenizer,
+            seq_length=64,
+            special_token_ids={"vision": 32000, "audio": 32001},
+            encoder_seq_lengths={"vision": 1, "audio": 1},
+            modality_columns={"vision": "image", "audio": "audio"},
+        )
+        
+        item = dataset[0]
+        
+        assert "vision" in item["modality_inputs"]
+        assert "audio" in item["modality_inputs"]
+        assert "pixel_values" in item["modality_inputs"]["vision"]
+        assert "input_features" in item["modality_inputs"]["audio"]
+    
+    def test_placeholder_token_inserted(self):
+        """Test that N placeholder tokens are inserted in input_ids based on encoder_seq_lengths."""
+        examples = MockExamples(size=10)
+        processors = {"vision": MockProcessor()}
+        tokenizer = MockTokenizer()
+        
+        vision_placeholder = 32000
+        encoder_seq_length = 10  # Insert 10 placeholder tokens
+        
+        dataset = MimoDataset(
+            examples=examples,
+            processors=processors,
+            tokenizer=tokenizer,
+            seq_length=64,
+            special_token_ids={"vision": vision_placeholder},
+            encoder_seq_lengths={"vision": encoder_seq_length},
+            modality_columns={"vision": "image"},
+        )
+        
+        item = dataset[0]
+        
+        # First N tokens should all be the vision placeholder
+        for i in range(encoder_seq_length):
+            assert item["input_ids"][i].item() == vision_placeholder, \
+                f"Position {i} should be placeholder token {vision_placeholder}"
+        
+        # Token at position N should NOT be the placeholder (should be text)
+        assert item["input_ids"][encoder_seq_length].item() != vision_placeholder, \
+            f"Position {encoder_seq_length} should not be placeholder token"
+    
+    def test_index_out_of_range(self):
+        """Test that accessing out-of-range index raises error."""
+        examples = MockExamples(size=10)
+        processors = {"vision": MockProcessor()}
+        tokenizer = MockTokenizer()
+        
+        dataset = MimoDataset(
+            examples=examples,
+            processors=processors,
+            tokenizer=tokenizer,
+            seq_length=64,
+            special_token_ids={"vision": 32000},
+            encoder_seq_lengths={"vision": 1},
+            modality_columns={"vision": "image"},
+        )
+        
+        with pytest.raises(IndexError):
+            _ = dataset[100]
+    
+    def test_custom_text_column(self):
+        """Test using custom text column name."""
+        # Create dataset with different column name
+        examples = MockExamples(size=10)
+        # Modify data to use different column
+        for item in examples._data:
+            item["content"] = item.pop("text")
+        
+        processors = {"vision": MockProcessor()}
+        tokenizer = MockTokenizer()
+        
+        dataset = MimoDataset(
+            examples=examples,
+            processors=processors,
+            tokenizer=tokenizer,
+            seq_length=64,
+            special_token_ids={"vision": 32000},
+            encoder_seq_lengths={"vision": 1},
+            modality_columns={"vision": "image"},
+            text_column="content",
+        )
+        
+        # Should not raise
+        item = dataset[0]
+        assert item["input_ids"].shape == (64,)
+    
+    def test_list_as_examples(self):
+        """Test that a plain list works as examples."""
+        examples = [
+            {"text": "Hello world", "image": "img1.jpg"},
+            {"text": "Another sample", "image": "img2.jpg"},
+        ]
+        processors = {"vision": MockProcessor()}
+        tokenizer = MockTokenizer()
+        
+        dataset = MimoDataset(
+            examples=examples,
+            processors=processors,
+            tokenizer=tokenizer,
+            seq_length=64,
+            special_token_ids={"vision": 32000},
+            encoder_seq_lengths={"vision": 1},
+            modality_columns={"vision": "image"},
+        )
+        
+        assert len(dataset) == 2
+        item = dataset[0]
+        assert "input_ids" in item
+
+
+class TestMimoDatasetPreprocessing:
+    """Test preprocessing functionality."""
+    
+    def test_custom_preprocess_fn(self):
+        """Test that custom preprocess_fn is applied."""
+        examples = MockExamples(size=10)
+        processors = {"vision": MockProcessor()}
+        tokenizer = MockTokenizer()
+        
+        def custom_preprocess(example):
+            example["text"] = example["text"].upper()
+            return example
+        
+        dataset = MimoDataset(
+            examples=examples,
+            processors=processors,
+            tokenizer=tokenizer,
+            seq_length=64,
+            special_token_ids={"vision": 32000},
+            encoder_seq_lengths={"vision": 1},
+            modality_columns={"vision": "image"},
+            preprocess_fn=custom_preprocess,
+        )
+        
+        # Should not raise
+        item = dataset[0]
+        assert "input_ids" in item
+
+
+class TestMimoDatasetEncoderSeqLengths:
+    """Test encoder_seq_lengths functionality."""
+    
+    def test_encoder_seq_lengths_validation(self):
+        """Test that encoder_seq_lengths >= seq_length raises ValueError."""
+        examples = MockExamples(size=10)
+        processors = {"vision": MockProcessor()}
+        tokenizer = MockTokenizer()
+        
+        # encoder_seq_lengths (100) >= seq_length (64) should raise
+        with pytest.raises(ValueError, match="must be less than"):
+            MimoDataset(
+                examples=examples,
+                processors=processors,
+                tokenizer=tokenizer,
+                seq_length=64,
+                special_token_ids={"vision": 32000},
+                encoder_seq_lengths={"vision": 100},  # Too large!
+                modality_columns={"vision": "image"},
+            )
+    
+    def test_encoder_seq_lengths_validation_equal(self):
+        """Test that encoder_seq_lengths == seq_length raises ValueError."""
+        examples = MockExamples(size=10)
+        processors = {"vision": MockProcessor()}
+        tokenizer = MockTokenizer()
+        
+        # encoder_seq_lengths (64) == seq_length (64) should raise
+        with pytest.raises(ValueError, match="must be less than"):
+            MimoDataset(
+                examples=examples,
+                processors=processors,
+                tokenizer=tokenizer,
+                seq_length=64,
+                special_token_ids={"vision": 32000},
+                encoder_seq_lengths={"vision": 64},  # Equal, no room for text!
+                modality_columns={"vision": "image"},
+            )
+    
+    def test_multiple_modality_placeholders(self):
+        """Test correct placeholder insertion for multiple modalities."""
+        examples = MockExamples(size=10)
+        processors = {
+            "vision": MockProcessor(output_key="pixel_values", output_shape=(3, 224, 224)),
+            "audio": MockProcessor(output_key="input_features", output_shape=(128, 3000)),
+        }
+        tokenizer = MockTokenizer()
+        
+        vision_placeholder = 32000
+        audio_placeholder = 32001
+        vision_seq_len = 10
+        audio_seq_len = 5
+        
+        dataset = MimoDataset(
+            examples=examples,
+            processors=processors,
+            tokenizer=tokenizer,
+            seq_length=64,
+            special_token_ids={"vision": vision_placeholder, "audio": audio_placeholder},
+            encoder_seq_lengths={"vision": vision_seq_len, "audio": audio_seq_len},
+            modality_columns={"vision": "image", "audio": "audio"},
+        )
+        
+        item = dataset[0]
+        
+        # First vision_seq_len tokens should be vision placeholder
+        for i in range(vision_seq_len):
+            assert item["input_ids"][i].item() == vision_placeholder, \
+                f"Position {i} should be vision placeholder"
+        
+        # Next audio_seq_len tokens should be audio placeholder
+        for i in range(vision_seq_len, vision_seq_len + audio_seq_len):
+            assert item["input_ids"][i].item() == audio_placeholder, \
+                f"Position {i} should be audio placeholder"
+        
+        # Token after all placeholders should not be a placeholder
+        first_text_pos = vision_seq_len + audio_seq_len
+        assert item["input_ids"][first_text_pos].item() not in (vision_placeholder, audio_placeholder), \
+            f"Position {first_text_pos} should be text, not placeholder"
+    
+    def test_encoder_seq_lengths_text_truncation(self):
+        """Test that text is properly truncated when encoder tokens take most of seq_length."""
+        examples = MockExamples(size=10)
+        processors = {"vision": MockProcessor()}
+        tokenizer = MockTokenizer()
+        
+        vision_placeholder = 32000
+        encoder_seq_length = 50  # Takes most of the 64 seq_length
+        
+        dataset = MimoDataset(
+            examples=examples,
+            processors=processors,
+            tokenizer=tokenizer,
+            seq_length=64,
+            special_token_ids={"vision": vision_placeholder},
+            encoder_seq_lengths={"vision": encoder_seq_length},
+            modality_columns={"vision": "image"},
+        )
+        
+        item = dataset[0]
+        
+        # Should have exactly seq_length tokens
+        assert item["input_ids"].shape == (64,)
+        
+        # First encoder_seq_length tokens should be placeholders
+        for i in range(encoder_seq_length):
+            assert item["input_ids"][i].item() == vision_placeholder
+        
+        # Remaining tokens should be text (or padding)
+        # Just verify they're not placeholders
+        for i in range(encoder_seq_length, 64):
+            assert item["input_ids"][i].item() != vision_placeholder

--- a/tests/unit_tests/data/mimo/test_dp_utils.py
+++ b/tests/unit_tests/data/mimo/test_dp_utils.py
@@ -1,0 +1,130 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+"""Tests for MIMO DP utilities."""
+
+import torch.distributed as dist
+
+from megatron.bridge.data.mimo.dp_utils import get_mimo_dp_info
+from megatron.bridge.models.mimo.mimo_config import MimoParallelismConfig, ModuleParallelismConfig
+
+
+class FakePG:
+    """Fake process group for testing."""
+    
+    def __init__(self, rank: int, size: int):
+        self._rank = rank
+        self._size = size
+
+    def rank(self) -> int:
+        return self._rank
+
+    def size(self) -> int:
+        return self._size
+
+
+class FakeGrid:
+    """Fake HyperCommGrid for testing."""
+    
+    def __init__(self, rank_offset: int, size: int, dp_rank: int, dp_size: int, 
+                 pp_rank: int, pp_size: int):
+        self.rank_offset = rank_offset
+        self.size = size
+        self._pgs = {
+            ("dp",): FakePG(dp_rank, dp_size),
+            ("pp",): FakePG(pp_rank, pp_size),
+        }
+
+    def get_pg(self, dims):
+        return self._pgs[tuple(dims)]
+
+
+def _make_mimo_cfg() -> MimoParallelismConfig:
+    """Create test MIMO config for heterogeneous deployment."""
+    module_parallelisms = {
+        "vision": ModuleParallelismConfig(tensor_model_parallel_size=1, data_parallel_size=2, rank_offset=0),
+        "llm": ModuleParallelismConfig(tensor_model_parallel_size=1, data_parallel_size=4, rank_offset=4),
+    }
+    return MimoParallelismConfig(
+        module_parallelisms=module_parallelisms,
+    )
+
+
+def test_get_mimo_dp_info_encoder_first_pp(monkeypatch):
+    """Test heterogeneous mode, rank in encoder module, first PP stage."""
+    mimo_cfg = _make_mimo_cfg()
+    monkeypatch.setattr(dist, "get_rank", lambda: 0)
+
+    grids = {
+        "vision": FakeGrid(0, 4, dp_rank=0, dp_size=2, pp_rank=0, pp_size=2),
+        "llm": FakeGrid(4, 4, dp_rank=0, dp_size=4, pp_rank=0, pp_size=1),
+    }
+
+    dp_rank, dp_size, needs_data, loader_module = get_mimo_dp_info(mimo_cfg, grids)
+    
+    assert loader_module == "vision"
+    assert dp_rank == 0
+    assert dp_size == 2
+    assert needs_data is True  # First PP stage
+
+
+def test_get_mimo_dp_info_encoder_non_first_pp(monkeypatch):
+    """Test heterogeneous mode, rank in encoder module, not first PP stage."""
+    mimo_cfg = _make_mimo_cfg()
+    monkeypatch.setattr(dist, "get_rank", lambda: 1)
+
+    grids = {
+        "vision": FakeGrid(0, 4, dp_rank=0, dp_size=2, pp_rank=1, pp_size=2),
+        "llm": FakeGrid(4, 4, dp_rank=0, dp_size=4, pp_rank=0, pp_size=1),
+    }
+
+    dp_rank, dp_size, needs_data, loader_module = get_mimo_dp_info(mimo_cfg, grids)
+    
+    assert loader_module == "vision"
+    assert needs_data is False  # Not first PP stage
+
+
+def test_get_mimo_dp_info_llm_first_pp(monkeypatch):
+    """Test heterogeneous mode, rank in LLM module, first PP stage."""
+    mimo_cfg = _make_mimo_cfg()
+    monkeypatch.setattr(dist, "get_rank", lambda: 4)
+
+    grids = {
+        "vision": FakeGrid(0, 4, dp_rank=0, dp_size=2, pp_rank=0, pp_size=1),
+        "llm": FakeGrid(4, 4, dp_rank=0, dp_size=4, pp_rank=0, pp_size=2),
+    }
+
+    dp_rank, dp_size, needs_data, loader_module = get_mimo_dp_info(mimo_cfg, grids)
+    
+    assert loader_module == "llm"
+    assert needs_data is True  # First PP stage
+
+
+def test_get_mimo_dp_info_llm_last_pp(monkeypatch):
+    """Test heterogeneous mode, rank in LLM module, last PP stage."""
+    mimo_cfg = _make_mimo_cfg()
+    monkeypatch.setattr(dist, "get_rank", lambda: 5)
+
+    grids = {
+        "vision": FakeGrid(0, 4, dp_rank=0, dp_size=2, pp_rank=0, pp_size=1),
+        "llm": FakeGrid(4, 4, dp_rank=1, dp_size=4, pp_rank=1, pp_size=2),
+    }
+
+    dp_rank, dp_size, needs_data, loader_module = get_mimo_dp_info(mimo_cfg, grids)
+    
+    assert loader_module == "llm"
+    assert needs_data is True  # Last PP stage
+
+
+def test_get_mimo_dp_info_non_participating_rank(monkeypatch):
+    """Test heterogeneous mode, rank not in any module."""
+    mimo_cfg = _make_mimo_cfg()
+    monkeypatch.setattr(dist, "get_rank", lambda: 10)  # Outside all grids
+
+    grids = {
+        "vision": FakeGrid(0, 4, dp_rank=0, dp_size=2, pp_rank=0, pp_size=1),
+        "llm": FakeGrid(4, 4, dp_rank=0, dp_size=4, pp_rank=0, pp_size=1),
+    }
+
+    dp_rank, dp_size, needs_data, loader_module = get_mimo_dp_info(mimo_cfg, grids)
+    
+    assert needs_data is False
+    assert loader_module == "llm"  # Default to LLM

--- a/tests/unit_tests/data/mimo/test_dp_utils.py
+++ b/tests/unit_tests/data/mimo/test_dp_utils.py
@@ -9,7 +9,7 @@ from megatron.bridge.models.mimo.mimo_config import MimoParallelismConfig, Modul
 
 class FakePG:
     """Fake process group for testing."""
-    
+
     def __init__(self, rank: int, size: int):
         self._rank = rank
         self._size = size
@@ -23,9 +23,8 @@ class FakePG:
 
 class FakeGrid:
     """Fake HyperCommGrid for testing."""
-    
-    def __init__(self, rank_offset: int, size: int, dp_rank: int, dp_size: int, 
-                 pp_rank: int, pp_size: int):
+
+    def __init__(self, rank_offset: int, size: int, dp_rank: int, dp_size: int, pp_rank: int, pp_size: int):
         self.rank_offset = rank_offset
         self.size = size
         self._pgs = {
@@ -41,7 +40,7 @@ def _make_mimo_cfg() -> MimoParallelismConfig:
     """Create test MIMO config for heterogeneous deployment."""
     module_parallelisms = {
         "vision": ModuleParallelismConfig(tensor_model_parallel_size=1, data_parallel_size=2, rank_offset=0),
-        "llm": ModuleParallelismConfig(tensor_model_parallel_size=1, data_parallel_size=4, rank_offset=4),
+        "language": ModuleParallelismConfig(tensor_model_parallel_size=1, data_parallel_size=4, rank_offset=4),
     }
     return MimoParallelismConfig(
         module_parallelisms=module_parallelisms,
@@ -55,11 +54,11 @@ def test_get_mimo_dp_info_encoder_first_pp(monkeypatch):
 
     grids = {
         "vision": FakeGrid(0, 4, dp_rank=0, dp_size=2, pp_rank=0, pp_size=2),
-        "llm": FakeGrid(4, 4, dp_rank=0, dp_size=4, pp_rank=0, pp_size=1),
+        "language": FakeGrid(4, 4, dp_rank=0, dp_size=4, pp_rank=0, pp_size=1),
     }
 
     dp_rank, dp_size, needs_data, loader_module = get_mimo_dp_info(mimo_cfg, grids)
-    
+
     assert loader_module == "vision"
     assert dp_rank == 0
     assert dp_size == 2
@@ -73,11 +72,11 @@ def test_get_mimo_dp_info_encoder_non_first_pp(monkeypatch):
 
     grids = {
         "vision": FakeGrid(0, 4, dp_rank=0, dp_size=2, pp_rank=1, pp_size=2),
-        "llm": FakeGrid(4, 4, dp_rank=0, dp_size=4, pp_rank=0, pp_size=1),
+        "language": FakeGrid(4, 4, dp_rank=0, dp_size=4, pp_rank=0, pp_size=1),
     }
 
     dp_rank, dp_size, needs_data, loader_module = get_mimo_dp_info(mimo_cfg, grids)
-    
+
     assert loader_module == "vision"
     assert needs_data is False  # Not first PP stage
 
@@ -89,12 +88,12 @@ def test_get_mimo_dp_info_llm_first_pp(monkeypatch):
 
     grids = {
         "vision": FakeGrid(0, 4, dp_rank=0, dp_size=2, pp_rank=0, pp_size=1),
-        "llm": FakeGrid(4, 4, dp_rank=0, dp_size=4, pp_rank=0, pp_size=2),
+        "language": FakeGrid(4, 4, dp_rank=0, dp_size=4, pp_rank=0, pp_size=2),
     }
 
     dp_rank, dp_size, needs_data, loader_module = get_mimo_dp_info(mimo_cfg, grids)
-    
-    assert loader_module == "llm"
+
+    assert loader_module == "language"
     assert needs_data is True  # First PP stage
 
 
@@ -105,12 +104,12 @@ def test_get_mimo_dp_info_llm_last_pp(monkeypatch):
 
     grids = {
         "vision": FakeGrid(0, 4, dp_rank=0, dp_size=2, pp_rank=0, pp_size=1),
-        "llm": FakeGrid(4, 4, dp_rank=1, dp_size=4, pp_rank=1, pp_size=2),
+        "language": FakeGrid(4, 4, dp_rank=1, dp_size=4, pp_rank=1, pp_size=2),
     }
 
     dp_rank, dp_size, needs_data, loader_module = get_mimo_dp_info(mimo_cfg, grids)
-    
-    assert loader_module == "llm"
+
+    assert loader_module == "language"
     assert needs_data is True  # Last PP stage
 
 
@@ -121,10 +120,10 @@ def test_get_mimo_dp_info_non_participating_rank(monkeypatch):
 
     grids = {
         "vision": FakeGrid(0, 4, dp_rank=0, dp_size=2, pp_rank=0, pp_size=1),
-        "llm": FakeGrid(4, 4, dp_rank=0, dp_size=4, pp_rank=0, pp_size=1),
+        "language": FakeGrid(4, 4, dp_rank=0, dp_size=4, pp_rank=0, pp_size=1),
     }
 
     dp_rank, dp_size, needs_data, loader_module = get_mimo_dp_info(mimo_cfg, grids)
-    
+
     assert needs_data is False
-    assert loader_module == "llm"  # Default to LLM
+    assert loader_module == "language"  # Default to LLM

--- a/tests/unit_tests/models/mimo/test_llava_provider.py
+++ b/tests/unit_tests/models/mimo/test_llava_provider.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 """Unit tests for LLaVA MIMO Provider."""
 
 from unittest.mock import Mock

--- a/tests/unit_tests/models/mimo/test_llava_provider.py
+++ b/tests/unit_tests/models/mimo/test_llava_provider.py
@@ -224,7 +224,7 @@ class TestLlavaMimoProvider:
         mock_vision_encoder = Mock
         mimo_config = MimoParallelismConfig(
             module_parallelisms={
-                "llm": ModuleParallelismConfig(tensor_model_parallel_size=4),
+                "language": ModuleParallelismConfig(tensor_model_parallel_size=4),
             }
         )
 

--- a/tests/unit_tests/models/mimo/test_mimo_builder.py
+++ b/tests/unit_tests/models/mimo/test_mimo_builder.py
@@ -1,9 +1,9 @@
-# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 """Unit tests for MIMO builder utilities."""
 
 from unittest.mock import MagicMock, patch
 
-from megatron.bridge.models.mimo.mimo_builder import _default_topology, build_hypercomm_grids
+from megatron.bridge.models.mimo.mimo_builder import build_hypercomm_grids
 from megatron.bridge.models.mimo.mimo_config import MimoParallelismConfig, ModuleParallelismConfig
 
 
@@ -214,93 +214,3 @@ class TestBuildHypercommGrids:
 
         encoder_kwargs = mock_grid_class.call_args_list[1][1]
         assert encoder_kwargs["rank_offset"] == 4
-
-
-class TestDefaultTopology:
-    """Test cases for _default_topology()."""
-
-    def test_topology_with_single_encoder(self):
-        """Test topology with LLM and one encoder."""
-        mimo_config = MimoParallelismConfig(
-            module_parallelisms={
-                "llm": ModuleParallelismConfig(tensor_model_parallel_size=2),
-                "clip_encoder": ModuleParallelismConfig(tensor_model_parallel_size=2),
-            }
-        )
-
-        topology = _default_topology(mimo_config)
-
-        # Encoder should point to LLM
-        assert topology["clip_encoder"] == ["llm"]
-        # LLM should have no downstream
-        assert topology["llm"] == []
-
-    def test_topology_with_multiple_encoders(self):
-        """Test topology with LLM and multiple encoders."""
-        mimo_config = MimoParallelismConfig(
-            module_parallelisms={
-                "llm": ModuleParallelismConfig(tensor_model_parallel_size=2),
-                "clip_encoder": ModuleParallelismConfig(tensor_model_parallel_size=2),
-                "dino_encoder": ModuleParallelismConfig(tensor_model_parallel_size=2),
-                "audio_encoder": ModuleParallelismConfig(tensor_model_parallel_size=2),
-            }
-        )
-
-        topology = _default_topology(mimo_config)
-
-        # All encoders should point to LLM
-        assert topology["clip_encoder"] == ["llm"]
-        assert topology["dino_encoder"] == ["llm"]
-        assert topology["audio_encoder"] == ["llm"]
-        # LLM should have no downstream
-        assert topology["llm"] == []
-
-    def test_topology_with_llm_only(self):
-        """Test topology with only LLM module."""
-        mimo_config = MimoParallelismConfig(
-            module_parallelisms={
-                "llm": ModuleParallelismConfig(tensor_model_parallel_size=2),
-            }
-        )
-
-        topology = _default_topology(mimo_config)
-
-        # LLM should have no downstream
-        assert topology["llm"] == []
-        # Should only have one entry
-        assert len(topology) == 1
-
-    def test_topology_structure(self):
-        """Test that topology has correct structure (dict of lists)."""
-        mimo_config = MimoParallelismConfig(
-            module_parallelisms={
-                "llm": ModuleParallelismConfig(tensor_model_parallel_size=2),
-                "encoder": ModuleParallelismConfig(tensor_model_parallel_size=2),
-            }
-        )
-
-        topology = _default_topology(mimo_config)
-
-        # Check it's a dict
-        assert isinstance(topology, dict)
-        # Check values are lists
-        for value in topology.values():
-            assert isinstance(value, list)
-
-    def test_topology_all_modules_present(self):
-        """Test that all modules appear in topology."""
-        mimo_config = MimoParallelismConfig(
-            module_parallelisms={
-                "llm": ModuleParallelismConfig(tensor_model_parallel_size=2),
-                "encoder1": ModuleParallelismConfig(tensor_model_parallel_size=2),
-                "encoder2": ModuleParallelismConfig(tensor_model_parallel_size=2),
-            }
-        )
-
-        topology = _default_topology(mimo_config)
-
-        # All modules should be present in topology
-        assert "llm" in topology
-        assert "encoder1" in topology
-        assert "encoder2" in topology
-        assert len(topology) == 3

--- a/tests/unit_tests/models/mimo/test_mimo_builder.py
+++ b/tests/unit_tests/models/mimo/test_mimo_builder.py
@@ -15,7 +15,7 @@ class TestBuildHypercommGrids:
         """Test build_hypercomm_grids with single LLM module."""
         mimo_config = MimoParallelismConfig(
             module_parallelisms={
-                "llm": ModuleParallelismConfig(
+                "language": ModuleParallelismConfig(
                     tensor_model_parallel_size=2,
                     context_parallel_size=1,
                     expert_tensor_parallel_size=1,
@@ -32,8 +32,8 @@ class TestBuildHypercommGrids:
         grids = build_hypercomm_grids(mimo_config)
 
         # Should create one grid
-        assert "llm" in grids
-        assert grids["llm"] == mock_grid
+        assert "language" in grids
+        assert grids["language"] == mock_grid
 
         # Check grid was created with correct shape
         mock_grid_class.assert_called_once()
@@ -57,7 +57,7 @@ class TestBuildHypercommGrids:
         """Test build_hypercomm_grids with multiple modules."""
         mimo_config = MimoParallelismConfig(
             module_parallelisms={
-                "llm": ModuleParallelismConfig(
+                "language": ModuleParallelismConfig(
                     tensor_model_parallel_size=4,
                     data_parallel_size=2,
                     rank_offset=0,
@@ -82,7 +82,7 @@ class TestBuildHypercommGrids:
         grids = build_hypercomm_grids(mimo_config)
 
         # Should create three grids
-        assert "llm" in grids
+        assert "language" in grids
         assert "clip_encoder" in grids
         assert "dino_encoder" in grids
         assert len(grids) == 3
@@ -95,7 +95,7 @@ class TestBuildHypercommGrids:
         """Test grids with different parallelism configs per module."""
         mimo_config = MimoParallelismConfig(
             module_parallelisms={
-                "llm": ModuleParallelismConfig(
+                "language": ModuleParallelismConfig(
                     tensor_model_parallel_size=8,
                     pipeline_model_parallel_size=2,
                     data_parallel_size=1,
@@ -134,7 +134,7 @@ class TestBuildHypercommGrids:
         """Test that all dimension process groups are created."""
         mimo_config = MimoParallelismConfig(
             module_parallelisms={
-                "llm": ModuleParallelismConfig(
+                "language": ModuleParallelismConfig(
                     tensor_model_parallel_size=2,
                     context_parallel_size=2,
                     expert_tensor_parallel_size=2,
@@ -170,7 +170,7 @@ class TestBuildHypercommGrids:
         """Test that grids use nccl backend."""
         mimo_config = MimoParallelismConfig(
             module_parallelisms={
-                "llm": ModuleParallelismConfig(tensor_model_parallel_size=2, data_parallel_size=2),
+                "language": ModuleParallelismConfig(tensor_model_parallel_size=2, data_parallel_size=2),
             }
         )
 
@@ -189,7 +189,7 @@ class TestBuildHypercommGrids:
         """Test that rank_offset is correctly passed to grids."""
         mimo_config = MimoParallelismConfig(
             module_parallelisms={
-                "llm": ModuleParallelismConfig(
+                "language": ModuleParallelismConfig(
                     tensor_model_parallel_size=2,
                     data_parallel_size=2,
                     rank_offset=0,

--- a/tests/unit_tests/models/mimo/test_mimo_ddp.py
+++ b/tests/unit_tests/models/mimo/test_mimo_ddp.py
@@ -1,0 +1,358 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+"""Unit tests for MIMO DDP wrapping utilities."""
+
+from unittest.mock import MagicMock, patch
+
+from megatron.bridge.models.mimo.mimo_builder import is_current_rank_in_grid
+from megatron.bridge.models.mimo.mimo_ddp import wrap_mimo_model_distributed
+from megatron.bridge.models.mimo.mimo_config import MimoParallelismConfig, ModuleParallelismConfig
+
+
+class TestIsCurrentRankInGrid:
+    """Test cases for is_current_rank_in_grid helper."""
+
+    @patch('torch.distributed.get_rank')
+    def test_rank_in_grid(self, mock_get_rank):
+        """Rank within grid range should return True."""
+        mock_get_rank.return_value = 2
+        
+        mock_grid = MagicMock()
+        mock_grid.rank_offset = 0
+        mock_grid.size = 4
+        
+        assert is_current_rank_in_grid(mock_grid) is True
+
+    @patch('torch.distributed.get_rank')
+    def test_rank_at_grid_start(self, mock_get_rank):
+        """Rank at grid start should return True."""
+        mock_get_rank.return_value = 4
+        
+        mock_grid = MagicMock()
+        mock_grid.rank_offset = 4
+        mock_grid.size = 4
+        
+        assert is_current_rank_in_grid(mock_grid) is True
+
+    @patch('torch.distributed.get_rank')
+    def test_rank_at_grid_end_exclusive(self, mock_get_rank):
+        """Rank at grid end (exclusive) should return False."""
+        mock_get_rank.return_value = 8
+        
+        mock_grid = MagicMock()
+        mock_grid.rank_offset = 4
+        mock_grid.size = 4
+        
+        assert is_current_rank_in_grid(mock_grid) is False
+
+    @patch('torch.distributed.get_rank')
+    def test_rank_before_grid(self, mock_get_rank):
+        """Rank before grid range should return False."""
+        mock_get_rank.return_value = 2
+        
+        mock_grid = MagicMock()
+        mock_grid.rank_offset = 4
+        mock_grid.size = 4
+        
+        assert is_current_rank_in_grid(mock_grid) is False
+
+    @patch('torch.distributed.get_rank')
+    def test_rank_after_grid(self, mock_get_rank):
+        """Rank after grid range should return False."""
+        mock_get_rank.return_value = 10
+        
+        mock_grid = MagicMock()
+        mock_grid.rank_offset = 0
+        mock_grid.size = 4
+        
+        assert is_current_rank_in_grid(mock_grid) is False
+
+
+class TestWrapMimoModelDistributed:
+    """Test cases for wrap_mimo_model_distributed."""
+
+    def _create_mock_mimo_model(self, has_language_model=True, modality_names=None):
+        """Create a mock MimoModel for testing."""
+        mock_model = MagicMock()
+        
+        if has_language_model:
+            mock_model.language_model = MagicMock()
+            mock_model.language_model.config = MagicMock()
+        else:
+            mock_model.language_model = None
+        
+        if modality_names:
+            mock_model.modality_submodules = {}
+            for name in modality_names:
+                submodule = MagicMock()
+                submodule.encoders = {"encoder": MagicMock()}
+                submodule.encoders["encoder"].config = MagicMock()
+                mock_model.modality_submodules[name] = submodule
+        else:
+            mock_model.modality_submodules = {}
+        
+        return mock_model
+
+    def _create_mock_grid(self, rank_offset=0, size=4):
+        """Create a mock HyperCommGrid."""
+        mock_grid = MagicMock()
+        mock_grid.rank_offset = rank_offset
+        mock_grid.size = size
+        return mock_grid
+
+    def _create_mimo_parallelism_config(self, modules):
+        """Create a MimoParallelismConfig."""
+        module_parallelisms = {
+            name: ModuleParallelismConfig(
+                tensor_model_parallel_size=config.get("tp", 1),
+                data_parallel_size=config.get("dp", 1),
+                rank_offset=config.get("rank_offset", 0),
+            )
+            for name, config in modules.items()
+        }
+        return MimoParallelismConfig(
+            module_parallelisms=module_parallelisms,
+        )
+
+    @patch('megatron.core.distributed.DistributedDataParallel')
+    @patch('torch.distributed.get_rank')
+    def test_wrap_language_model(self, mock_get_rank, mock_ddp):
+        """Test that language model is wrapped with DDP when rank participates."""
+        mock_get_rank.return_value = 0
+        mock_ddp.return_value = MagicMock()
+        
+        mimo_model = self._create_mock_mimo_model(has_language_model=True)
+        ddp_config = MagicMock()
+        mimo_parallelism_config = self._create_mimo_parallelism_config({
+            "llm": {"tp": 2, "dp": 2},
+        })
+        
+        grids = {"llm": self._create_mock_grid(rank_offset=0, size=4)}
+        pg_collections = {"llm": MagicMock()}
+        
+        result = wrap_mimo_model_distributed(
+            mimo_model, ddp_config, mimo_parallelism_config, grids, pg_collections
+        )
+        
+        # Should wrap language model
+        mock_ddp.assert_called_once()
+        assert result.language_model == mock_ddp.return_value
+
+    @patch('megatron.core.distributed.DistributedDataParallel')
+    @patch('torch.distributed.get_rank')
+    def test_skip_language_model_non_participating_rank(self, mock_get_rank, mock_ddp):
+        """Test that language model is NOT wrapped when rank doesn't participate."""
+        mock_get_rank.return_value = 10  # Outside grid range
+        
+        mimo_model = self._create_mock_mimo_model(has_language_model=True)
+        original_lm = mimo_model.language_model
+        
+        ddp_config = MagicMock()
+        mimo_parallelism_config = self._create_mimo_parallelism_config({
+            "llm": {"tp": 2, "dp": 2},
+        })
+        
+        grids = {"llm": self._create_mock_grid(rank_offset=0, size=4)}
+        pg_collections = {"llm": MagicMock()}
+        
+        result = wrap_mimo_model_distributed(
+            mimo_model, ddp_config, mimo_parallelism_config, grids, pg_collections
+        )
+        
+        # Should NOT wrap language model
+        mock_ddp.assert_not_called()
+        assert result.language_model == original_lm
+
+    @patch('megatron.core.distributed.DistributedDataParallel')
+    @patch('torch.distributed.get_rank')
+    def test_wrap_modality_submodules(self, mock_get_rank, mock_ddp):
+        """Test that modality submodules are wrapped with DDP."""
+        mock_get_rank.return_value = 0
+        mock_ddp.return_value = MagicMock()
+        
+        mimo_model = self._create_mock_mimo_model(
+            has_language_model=True, 
+            modality_names=["images"]
+        )
+        ddp_config = MagicMock()
+        mimo_parallelism_config = self._create_mimo_parallelism_config({
+            "llm": {"tp": 2, "dp": 2},
+            "images": {"tp": 1, "dp": 4},
+        })
+        
+        grids = {
+            "llm": self._create_mock_grid(rank_offset=0, size=4),
+            "images": self._create_mock_grid(rank_offset=0, size=4),
+        }
+        pg_collections = {
+            "llm": MagicMock(),
+            "images": MagicMock(),
+        }
+        
+        wrap_mimo_model_distributed(
+            mimo_model, ddp_config, mimo_parallelism_config, grids, pg_collections
+        )
+        
+        # Should wrap both language model and images submodule
+        assert mock_ddp.call_count == 2
+
+    @patch('megatron.core.distributed.DistributedDataParallel')
+    @patch('torch.distributed.get_rank')
+    def test_skip_modality_submodule_no_grid(self, mock_get_rank, mock_ddp):
+        """Test that modality submodules without grids are skipped."""
+        mock_get_rank.return_value = 0
+        mock_ddp.return_value = MagicMock()
+        
+        mimo_model = self._create_mock_mimo_model(
+            has_language_model=True, 
+            modality_names=["images", "audio"]
+        )
+        ddp_config = MagicMock()
+        mimo_parallelism_config = self._create_mimo_parallelism_config({
+            "llm": {"tp": 2, "dp": 2},
+            "images": {"tp": 1, "dp": 4},
+            # Note: no "audio" in parallelism config
+        })
+        
+        # Only llm and images have grids
+        grids = {
+            "llm": self._create_mock_grid(rank_offset=0, size=4),
+            "images": self._create_mock_grid(rank_offset=0, size=4),
+        }
+        pg_collections = {
+            "llm": MagicMock(),
+            "images": MagicMock(),
+        }
+        
+        wrap_mimo_model_distributed(
+            mimo_model, ddp_config, mimo_parallelism_config, grids, pg_collections
+        )
+        
+        # Should wrap llm and images, but not audio (no grid)
+        assert mock_ddp.call_count == 2
+
+    @patch('megatron.core.distributed.DistributedDataParallel')
+    @patch('torch.distributed.get_rank')
+    def test_heterogeneous_different_rank_ranges(self, mock_get_rank, mock_ddp):
+        """Test heterogeneous deployment with different rank ranges per module."""
+        mock_get_rank.return_value = 4  # In images grid but not llm grid
+        mock_ddp.return_value = MagicMock()
+        
+        mimo_model = self._create_mock_mimo_model(
+            has_language_model=True, 
+            modality_names=["images"]
+        )
+        original_lm = mimo_model.language_model
+        
+        ddp_config = MagicMock()
+        mimo_parallelism_config = self._create_mimo_parallelism_config({
+            "llm": {"tp": 2, "dp": 2, "rank_offset": 0},
+            "images": {"tp": 2, "dp": 2, "rank_offset": 4},
+        })
+        
+        grids = {
+            "llm": self._create_mock_grid(rank_offset=0, size=4),
+            "images": self._create_mock_grid(rank_offset=4, size=4),
+        }
+        pg_collections = {
+            "llm": None,  # Rank 4 doesn't participate in LLM
+            "images": MagicMock(),
+        }
+        
+        result = wrap_mimo_model_distributed(
+            mimo_model, ddp_config, mimo_parallelism_config, grids, pg_collections
+        )
+        
+        # Should wrap only images (rank 4 is in images grid, not llm grid)
+        assert mock_ddp.call_count == 1
+        # Language model should be unchanged
+        assert result.language_model == original_lm
+
+    @patch('megatron.core.distributed.DistributedDataParallel')
+    @patch('torch.distributed.get_rank')
+    def test_no_language_model(self, mock_get_rank, mock_ddp):
+        """Test model without language model."""
+        mock_get_rank.return_value = 0
+        mock_ddp.return_value = MagicMock()
+        
+        mimo_model = self._create_mock_mimo_model(
+            has_language_model=False, 
+            modality_names=["images"]
+        )
+        ddp_config = MagicMock()
+        mimo_parallelism_config = self._create_mimo_parallelism_config({
+            "llm": {"tp": 2, "dp": 2},
+            "images": {"tp": 1, "dp": 4},
+        })
+        
+        grids = {
+            "llm": self._create_mock_grid(rank_offset=0, size=4),
+            "images": self._create_mock_grid(rank_offset=0, size=4),
+        }
+        pg_collections = {
+            "llm": MagicMock(),
+            "images": MagicMock(),
+        }
+        
+        result = wrap_mimo_model_distributed(
+            mimo_model, ddp_config, mimo_parallelism_config, grids, pg_collections
+        )
+        
+        # Should wrap only images (no language model)
+        assert mock_ddp.call_count == 1
+        assert result.language_model is None
+
+    @patch('megatron.core.distributed.DistributedDataParallel')
+    @patch('torch.distributed.get_rank')
+    def test_returns_same_model_instance(self, mock_get_rank, mock_ddp):
+        """Test that wrap_mimo_model_distributed returns the same model instance."""
+        mock_get_rank.return_value = 0
+        mock_ddp.return_value = MagicMock()
+        
+        mimo_model = self._create_mock_mimo_model(has_language_model=True)
+        ddp_config = MagicMock()
+        mimo_parallelism_config = self._create_mimo_parallelism_config({
+            "llm": {"tp": 2, "dp": 2},
+        })
+        
+        grids = {"llm": self._create_mock_grid(rank_offset=0, size=4)}
+        pg_collections = {"llm": MagicMock()}
+        
+        result = wrap_mimo_model_distributed(
+            mimo_model, ddp_config, mimo_parallelism_config, grids, pg_collections
+        )
+        
+        # Should return the same model instance (modified in-place)
+        assert result is mimo_model
+
+    @patch('megatron.core.distributed.DistributedDataParallel')
+    @patch('torch.distributed.get_rank')
+    def test_ddp_called_with_correct_args(self, mock_get_rank, mock_ddp):
+        """Test that DDP is called with correct arguments."""
+        mock_get_rank.return_value = 0
+        mock_ddp.return_value = MagicMock()
+        
+        mimo_model = self._create_mock_mimo_model(has_language_model=True)
+        # Capture original config before wrapping (wrapping replaces language_model)
+        original_lm_config = mimo_model.language_model.config
+        original_lm = mimo_model.language_model
+        
+        ddp_config = MagicMock()
+        mimo_parallelism_config = self._create_mimo_parallelism_config({
+            "llm": {"tp": 2, "dp": 2},
+        })
+        
+        grids = {"llm": self._create_mock_grid(rank_offset=0, size=4)}
+        llm_pg_collection = MagicMock()
+        pg_collections = {"llm": llm_pg_collection}
+        
+        wrap_mimo_model_distributed(
+            mimo_model, ddp_config, mimo_parallelism_config, grids, pg_collections
+        )
+        
+        # Verify DDP call arguments
+        mock_ddp.assert_called_once()
+        call_kwargs = mock_ddp.call_args.kwargs
+        assert call_kwargs["ddp_config"] == ddp_config
+        assert call_kwargs["pg_collection"] == llm_pg_collection
+        assert call_kwargs["config"] == original_lm_config
+        assert call_kwargs["module"] == original_lm

--- a/tests/unit_tests/models/mimo/test_mimo_ddp.py
+++ b/tests/unit_tests/models/mimo/test_mimo_ddp.py
@@ -4,66 +4,66 @@
 from unittest.mock import MagicMock, patch
 
 from megatron.bridge.models.mimo.mimo_builder import is_current_rank_in_grid
-from megatron.bridge.models.mimo.mimo_ddp import wrap_mimo_model_distributed
 from megatron.bridge.models.mimo.mimo_config import MimoParallelismConfig, ModuleParallelismConfig
+from megatron.bridge.models.mimo.mimo_ddp import wrap_mimo_model_distributed
 
 
 class TestIsCurrentRankInGrid:
     """Test cases for is_current_rank_in_grid helper."""
 
-    @patch('torch.distributed.get_rank')
+    @patch("torch.distributed.get_rank")
     def test_rank_in_grid(self, mock_get_rank):
         """Rank within grid range should return True."""
         mock_get_rank.return_value = 2
-        
+
         mock_grid = MagicMock()
         mock_grid.rank_offset = 0
         mock_grid.size = 4
-        
+
         assert is_current_rank_in_grid(mock_grid) is True
 
-    @patch('torch.distributed.get_rank')
+    @patch("torch.distributed.get_rank")
     def test_rank_at_grid_start(self, mock_get_rank):
         """Rank at grid start should return True."""
         mock_get_rank.return_value = 4
-        
+
         mock_grid = MagicMock()
         mock_grid.rank_offset = 4
         mock_grid.size = 4
-        
+
         assert is_current_rank_in_grid(mock_grid) is True
 
-    @patch('torch.distributed.get_rank')
+    @patch("torch.distributed.get_rank")
     def test_rank_at_grid_end_exclusive(self, mock_get_rank):
         """Rank at grid end (exclusive) should return False."""
         mock_get_rank.return_value = 8
-        
+
         mock_grid = MagicMock()
         mock_grid.rank_offset = 4
         mock_grid.size = 4
-        
+
         assert is_current_rank_in_grid(mock_grid) is False
 
-    @patch('torch.distributed.get_rank')
+    @patch("torch.distributed.get_rank")
     def test_rank_before_grid(self, mock_get_rank):
         """Rank before grid range should return False."""
         mock_get_rank.return_value = 2
-        
+
         mock_grid = MagicMock()
         mock_grid.rank_offset = 4
         mock_grid.size = 4
-        
+
         assert is_current_rank_in_grid(mock_grid) is False
 
-    @patch('torch.distributed.get_rank')
+    @patch("torch.distributed.get_rank")
     def test_rank_after_grid(self, mock_get_rank):
         """Rank after grid range should return False."""
         mock_get_rank.return_value = 10
-        
+
         mock_grid = MagicMock()
         mock_grid.rank_offset = 0
         mock_grid.size = 4
-        
+
         assert is_current_rank_in_grid(mock_grid) is False
 
 
@@ -73,13 +73,13 @@ class TestWrapMimoModelDistributed:
     def _create_mock_mimo_model(self, has_language_model=True, modality_names=None):
         """Create a mock MimoModel for testing."""
         mock_model = MagicMock()
-        
+
         if has_language_model:
             mock_model.language_model = MagicMock()
             mock_model.language_model.config = MagicMock()
         else:
             mock_model.language_model = None
-        
+
         if modality_names:
             mock_model.modality_submodules = {}
             for name in modality_names:
@@ -89,7 +89,7 @@ class TestWrapMimoModelDistributed:
                 mock_model.modality_submodules[name] = submodule
         else:
             mock_model.modality_submodules = {}
-        
+
         return mock_model
 
     def _create_mock_grid(self, rank_offset=0, size=4):
@@ -113,242 +113,230 @@ class TestWrapMimoModelDistributed:
             module_parallelisms=module_parallelisms,
         )
 
-    @patch('megatron.core.distributed.DistributedDataParallel')
-    @patch('torch.distributed.get_rank')
+    @patch("megatron.core.distributed.DistributedDataParallel")
+    @patch("torch.distributed.get_rank")
     def test_wrap_language_model(self, mock_get_rank, mock_ddp):
         """Test that language model is wrapped with DDP when rank participates."""
         mock_get_rank.return_value = 0
         mock_ddp.return_value = MagicMock()
-        
+
         mimo_model = self._create_mock_mimo_model(has_language_model=True)
         ddp_config = MagicMock()
-        mimo_parallelism_config = self._create_mimo_parallelism_config({
-            "llm": {"tp": 2, "dp": 2},
-        })
-        
-        grids = {"llm": self._create_mock_grid(rank_offset=0, size=4)}
-        pg_collections = {"llm": MagicMock()}
-        
-        result = wrap_mimo_model_distributed(
-            mimo_model, ddp_config, mimo_parallelism_config, grids, pg_collections
+        mimo_parallelism_config = self._create_mimo_parallelism_config(
+            {
+                "language": {"tp": 2, "dp": 2},
+            }
         )
-        
+
+        grids = {"language": self._create_mock_grid(rank_offset=0, size=4)}
+        pg_collections = {"language": MagicMock()}
+
+        result = wrap_mimo_model_distributed(mimo_model, ddp_config, mimo_parallelism_config, grids, pg_collections)
+
         # Should wrap language model
         mock_ddp.assert_called_once()
         assert result.language_model == mock_ddp.return_value
 
-    @patch('megatron.core.distributed.DistributedDataParallel')
-    @patch('torch.distributed.get_rank')
+    @patch("megatron.core.distributed.DistributedDataParallel")
+    @patch("torch.distributed.get_rank")
     def test_skip_language_model_non_participating_rank(self, mock_get_rank, mock_ddp):
         """Test that language model is NOT wrapped when rank doesn't participate."""
         mock_get_rank.return_value = 10  # Outside grid range
-        
+
         mimo_model = self._create_mock_mimo_model(has_language_model=True)
         original_lm = mimo_model.language_model
-        
+
         ddp_config = MagicMock()
-        mimo_parallelism_config = self._create_mimo_parallelism_config({
-            "llm": {"tp": 2, "dp": 2},
-        })
-        
-        grids = {"llm": self._create_mock_grid(rank_offset=0, size=4)}
-        pg_collections = {"llm": MagicMock()}
-        
-        result = wrap_mimo_model_distributed(
-            mimo_model, ddp_config, mimo_parallelism_config, grids, pg_collections
+        mimo_parallelism_config = self._create_mimo_parallelism_config(
+            {
+                "language": {"tp": 2, "dp": 2},
+            }
         )
-        
+
+        grids = {"language": self._create_mock_grid(rank_offset=0, size=4)}
+        pg_collections = {"language": MagicMock()}
+
+        result = wrap_mimo_model_distributed(mimo_model, ddp_config, mimo_parallelism_config, grids, pg_collections)
+
         # Should NOT wrap language model
         mock_ddp.assert_not_called()
         assert result.language_model == original_lm
 
-    @patch('megatron.core.distributed.DistributedDataParallel')
-    @patch('torch.distributed.get_rank')
+    @patch("megatron.core.distributed.DistributedDataParallel")
+    @patch("torch.distributed.get_rank")
     def test_wrap_modality_submodules(self, mock_get_rank, mock_ddp):
         """Test that modality submodules are wrapped with DDP."""
         mock_get_rank.return_value = 0
         mock_ddp.return_value = MagicMock()
-        
-        mimo_model = self._create_mock_mimo_model(
-            has_language_model=True, 
-            modality_names=["images"]
-        )
+
+        mimo_model = self._create_mock_mimo_model(has_language_model=True, modality_names=["images"])
         ddp_config = MagicMock()
-        mimo_parallelism_config = self._create_mimo_parallelism_config({
-            "llm": {"tp": 2, "dp": 2},
-            "images": {"tp": 1, "dp": 4},
-        })
-        
+        mimo_parallelism_config = self._create_mimo_parallelism_config(
+            {
+                "language": {"tp": 2, "dp": 2},
+                "images": {"tp": 1, "dp": 4},
+            }
+        )
+
         grids = {
-            "llm": self._create_mock_grid(rank_offset=0, size=4),
+            "language": self._create_mock_grid(rank_offset=0, size=4),
             "images": self._create_mock_grid(rank_offset=0, size=4),
         }
         pg_collections = {
-            "llm": MagicMock(),
+            "language": MagicMock(),
             "images": MagicMock(),
         }
-        
-        wrap_mimo_model_distributed(
-            mimo_model, ddp_config, mimo_parallelism_config, grids, pg_collections
-        )
-        
+
+        wrap_mimo_model_distributed(mimo_model, ddp_config, mimo_parallelism_config, grids, pg_collections)
+
         # Should wrap both language model and images submodule
         assert mock_ddp.call_count == 2
 
-    @patch('megatron.core.distributed.DistributedDataParallel')
-    @patch('torch.distributed.get_rank')
+    @patch("megatron.core.distributed.DistributedDataParallel")
+    @patch("torch.distributed.get_rank")
     def test_skip_modality_submodule_no_grid(self, mock_get_rank, mock_ddp):
         """Test that modality submodules without grids are skipped."""
         mock_get_rank.return_value = 0
         mock_ddp.return_value = MagicMock()
-        
-        mimo_model = self._create_mock_mimo_model(
-            has_language_model=True, 
-            modality_names=["images", "audio"]
-        )
+
+        mimo_model = self._create_mock_mimo_model(has_language_model=True, modality_names=["images", "audio"])
         ddp_config = MagicMock()
-        mimo_parallelism_config = self._create_mimo_parallelism_config({
-            "llm": {"tp": 2, "dp": 2},
-            "images": {"tp": 1, "dp": 4},
-            # Note: no "audio" in parallelism config
-        })
-        
+        mimo_parallelism_config = self._create_mimo_parallelism_config(
+            {
+                "language": {"tp": 2, "dp": 2},
+                "images": {"tp": 1, "dp": 4},
+                # Note: no "audio" in parallelism config
+            }
+        )
+
         # Only llm and images have grids
         grids = {
-            "llm": self._create_mock_grid(rank_offset=0, size=4),
+            "language": self._create_mock_grid(rank_offset=0, size=4),
             "images": self._create_mock_grid(rank_offset=0, size=4),
         }
         pg_collections = {
-            "llm": MagicMock(),
+            "language": MagicMock(),
             "images": MagicMock(),
         }
-        
-        wrap_mimo_model_distributed(
-            mimo_model, ddp_config, mimo_parallelism_config, grids, pg_collections
-        )
-        
+
+        wrap_mimo_model_distributed(mimo_model, ddp_config, mimo_parallelism_config, grids, pg_collections)
+
         # Should wrap llm and images, but not audio (no grid)
         assert mock_ddp.call_count == 2
 
-    @patch('megatron.core.distributed.DistributedDataParallel')
-    @patch('torch.distributed.get_rank')
+    @patch("megatron.core.distributed.DistributedDataParallel")
+    @patch("torch.distributed.get_rank")
     def test_heterogeneous_different_rank_ranges(self, mock_get_rank, mock_ddp):
         """Test heterogeneous deployment with different rank ranges per module."""
         mock_get_rank.return_value = 4  # In images grid but not llm grid
         mock_ddp.return_value = MagicMock()
-        
-        mimo_model = self._create_mock_mimo_model(
-            has_language_model=True, 
-            modality_names=["images"]
-        )
+
+        mimo_model = self._create_mock_mimo_model(has_language_model=True, modality_names=["images"])
         original_lm = mimo_model.language_model
-        
+
         ddp_config = MagicMock()
-        mimo_parallelism_config = self._create_mimo_parallelism_config({
-            "llm": {"tp": 2, "dp": 2, "rank_offset": 0},
-            "images": {"tp": 2, "dp": 2, "rank_offset": 4},
-        })
-        
+        mimo_parallelism_config = self._create_mimo_parallelism_config(
+            {
+                "language": {"tp": 2, "dp": 2, "rank_offset": 0},
+                "images": {"tp": 2, "dp": 2, "rank_offset": 4},
+            }
+        )
+
         grids = {
-            "llm": self._create_mock_grid(rank_offset=0, size=4),
+            "language": self._create_mock_grid(rank_offset=0, size=4),
             "images": self._create_mock_grid(rank_offset=4, size=4),
         }
         pg_collections = {
-            "llm": None,  # Rank 4 doesn't participate in LLM
+            "language": None,  # Rank 4 doesn't participate in LLM
             "images": MagicMock(),
         }
-        
-        result = wrap_mimo_model_distributed(
-            mimo_model, ddp_config, mimo_parallelism_config, grids, pg_collections
-        )
-        
+
+        result = wrap_mimo_model_distributed(mimo_model, ddp_config, mimo_parallelism_config, grids, pg_collections)
+
         # Should wrap only images (rank 4 is in images grid, not llm grid)
         assert mock_ddp.call_count == 1
         # Language model should be unchanged
         assert result.language_model == original_lm
 
-    @patch('megatron.core.distributed.DistributedDataParallel')
-    @patch('torch.distributed.get_rank')
+    @patch("megatron.core.distributed.DistributedDataParallel")
+    @patch("torch.distributed.get_rank")
     def test_no_language_model(self, mock_get_rank, mock_ddp):
         """Test model without language model."""
         mock_get_rank.return_value = 0
         mock_ddp.return_value = MagicMock()
-        
-        mimo_model = self._create_mock_mimo_model(
-            has_language_model=False, 
-            modality_names=["images"]
-        )
+
+        mimo_model = self._create_mock_mimo_model(has_language_model=False, modality_names=["images"])
         ddp_config = MagicMock()
-        mimo_parallelism_config = self._create_mimo_parallelism_config({
-            "llm": {"tp": 2, "dp": 2},
-            "images": {"tp": 1, "dp": 4},
-        })
-        
+        mimo_parallelism_config = self._create_mimo_parallelism_config(
+            {
+                "language": {"tp": 2, "dp": 2},
+                "images": {"tp": 1, "dp": 4},
+            }
+        )
+
         grids = {
-            "llm": self._create_mock_grid(rank_offset=0, size=4),
+            "language": self._create_mock_grid(rank_offset=0, size=4),
             "images": self._create_mock_grid(rank_offset=0, size=4),
         }
         pg_collections = {
-            "llm": MagicMock(),
+            "language": MagicMock(),
             "images": MagicMock(),
         }
-        
-        result = wrap_mimo_model_distributed(
-            mimo_model, ddp_config, mimo_parallelism_config, grids, pg_collections
-        )
-        
+
+        result = wrap_mimo_model_distributed(mimo_model, ddp_config, mimo_parallelism_config, grids, pg_collections)
+
         # Should wrap only images (no language model)
         assert mock_ddp.call_count == 1
         assert result.language_model is None
 
-    @patch('megatron.core.distributed.DistributedDataParallel')
-    @patch('torch.distributed.get_rank')
+    @patch("megatron.core.distributed.DistributedDataParallel")
+    @patch("torch.distributed.get_rank")
     def test_returns_same_model_instance(self, mock_get_rank, mock_ddp):
         """Test that wrap_mimo_model_distributed returns the same model instance."""
         mock_get_rank.return_value = 0
         mock_ddp.return_value = MagicMock()
-        
+
         mimo_model = self._create_mock_mimo_model(has_language_model=True)
         ddp_config = MagicMock()
-        mimo_parallelism_config = self._create_mimo_parallelism_config({
-            "llm": {"tp": 2, "dp": 2},
-        })
-        
-        grids = {"llm": self._create_mock_grid(rank_offset=0, size=4)}
-        pg_collections = {"llm": MagicMock()}
-        
-        result = wrap_mimo_model_distributed(
-            mimo_model, ddp_config, mimo_parallelism_config, grids, pg_collections
+        mimo_parallelism_config = self._create_mimo_parallelism_config(
+            {
+                "language": {"tp": 2, "dp": 2},
+            }
         )
-        
+
+        grids = {"language": self._create_mock_grid(rank_offset=0, size=4)}
+        pg_collections = {"language": MagicMock()}
+
+        result = wrap_mimo_model_distributed(mimo_model, ddp_config, mimo_parallelism_config, grids, pg_collections)
+
         # Should return the same model instance (modified in-place)
         assert result is mimo_model
 
-    @patch('megatron.core.distributed.DistributedDataParallel')
-    @patch('torch.distributed.get_rank')
+    @patch("megatron.core.distributed.DistributedDataParallel")
+    @patch("torch.distributed.get_rank")
     def test_ddp_called_with_correct_args(self, mock_get_rank, mock_ddp):
         """Test that DDP is called with correct arguments."""
         mock_get_rank.return_value = 0
         mock_ddp.return_value = MagicMock()
-        
+
         mimo_model = self._create_mock_mimo_model(has_language_model=True)
         # Capture original config before wrapping (wrapping replaces language_model)
         original_lm_config = mimo_model.language_model.config
         original_lm = mimo_model.language_model
-        
+
         ddp_config = MagicMock()
-        mimo_parallelism_config = self._create_mimo_parallelism_config({
-            "llm": {"tp": 2, "dp": 2},
-        })
-        
-        grids = {"llm": self._create_mock_grid(rank_offset=0, size=4)}
-        llm_pg_collection = MagicMock()
-        pg_collections = {"llm": llm_pg_collection}
-        
-        wrap_mimo_model_distributed(
-            mimo_model, ddp_config, mimo_parallelism_config, grids, pg_collections
+        mimo_parallelism_config = self._create_mimo_parallelism_config(
+            {
+                "language": {"tp": 2, "dp": 2},
+            }
         )
-        
+
+        grids = {"language": self._create_mock_grid(rank_offset=0, size=4)}
+        llm_pg_collection = MagicMock()
+        pg_collections = {"language": llm_pg_collection}
+
+        wrap_mimo_model_distributed(mimo_model, ddp_config, mimo_parallelism_config, grids, pg_collections)
+
         # Verify DDP call arguments
         mock_ddp.assert_called_once()
         call_kwargs = mock_ddp.call_args.kwargs

--- a/tests/unit_tests/models/mimo/test_mimo_provider.py
+++ b/tests/unit_tests/models/mimo/test_mimo_provider.py
@@ -1,10 +1,8 @@
-# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 """Unit tests for MIMO Model Provider."""
 
 from unittest.mock import MagicMock, Mock, patch
 
-import pytest
-import torch.nn as nn
 from megatron.core.transformer.spec_utils import ModuleSpec
 
 from megatron.bridge.models.mimo import (
@@ -12,33 +10,6 @@ from megatron.bridge.models.mimo import (
     MimoModelProvider,
 )
 from megatron.bridge.models.mimo.mimo_config import MimoParallelismConfig, ModuleParallelismConfig
-
-
-class MockModule(nn.Module):
-    """Mock Module for testing that is a proper torch.nn.Module subclass."""
-
-    def __init__(self, *args, **kwargs):
-        super().__init__()
-        self.args = args
-        self.kwargs = kwargs
-        # Add config attribute that Float16Module looks for
-        self.config = MagicMock()
-
-    def forward(self, *args, **kwargs):
-        return None
-
-    def cuda(self, device=None):
-        """Mock cuda() method."""
-        # Return self to avoid actual CUDA calls
-        return self
-
-    def bfloat16(self):
-        """Mock bfloat16() method."""
-        return self
-
-    def half(self):
-        """Mock half() method."""
-        return self
 
 
 class TestMimoModelProvider:
@@ -93,7 +64,6 @@ class TestMimoModelProvider:
         assert hasattr(provider, "bf16")
         assert hasattr(provider, "use_cpu_initialization")
         assert hasattr(provider, "init_model_with_meta_device")
-        assert hasattr(provider, "virtual_pipeline_model_parallel_size")
 
         # Check defaults
         assert provider.fp16 is False
@@ -121,10 +91,13 @@ class TestMimoModelProvider:
 
         # Should not build grids when no parallelism config
         mock_build_grids.assert_not_called()
+        config_arg = mock_mimo_model.call_args[0][0]
+        assert config_arg.module_to_grid_map is None
+        assert config_arg.language_module_key is None
 
     @patch("megatron.bridge.models.mimo.mimo_provider.MimoModel")
     @patch("megatron.bridge.models.mimo.mimo_provider.build_hypercomm_grids")
-    def test_provide_signature_matches_mixin(self, mock_build_grids, mock_mimo_model):
+    def test_provide_signature_matches_mixin(self, _mock_build_grids, mock_mimo_model):
         """Test provide() accepts standard mixin signature arguments."""
         language_spec = ModuleSpec(module=Mock, params={"config": Mock()})
         provider = MimoModelProvider(language_model_spec=language_spec)
@@ -145,22 +118,25 @@ class TestMimoModelProvider:
 
         infra = provider.build_infra()
 
-        # Should return empty infrastructure
+        # Should return infrastructure with auto-derived topology
         assert isinstance(infra, MimoModelInfra)
         assert infra.module_to_grid_map == {}
-        assert infra.topology == {}
+        assert infra.topology == {"llm": []}
         assert infra.pg_collections == {}
         assert infra.participating_modules == []
 
         # Should not build grids
         mock_build_grids.assert_not_called()
 
+    @patch("torch.distributed.new_group")
+    @patch("torch.distributed.get_process_group_ranks")
     @patch("torch.distributed.get_rank")
     @patch("megatron.bridge.models.mimo.mimo_provider.build_hypercomm_grids")
-    @patch("megatron.bridge.models.mimo.mimo_provider._default_topology")
-    def test_build_infra_with_parallelism(self, mock_topology, mock_build_grids, mock_get_rank):
+    def test_build_infra_with_parallelism(self, mock_build_grids, mock_get_rank, mock_get_pg_ranks, mock_new_group):
         """Test build_infra() with parallelism config."""
         mock_get_rank.return_value = 0
+        mock_get_pg_ranks.return_value = [0, 1, 2, 3]
+        mock_new_group.return_value = MagicMock()
         language_spec = ModuleSpec(module=Mock, params={"config": Mock()})
 
         mimo_parallelism_config = MimoParallelismConfig(
@@ -178,7 +154,6 @@ class TestMimoModelProvider:
         mock_grid.size = 4
         mock_grid.get_pg.return_value = MagicMock()
         mock_build_grids.return_value = {"llm": mock_grid}
-        mock_topology.return_value = {"llm": []}
 
         provider = MimoModelProvider(
             language_model_spec=language_spec,
@@ -196,17 +171,20 @@ class TestMimoModelProvider:
         assert "llm" in infra.pg_collections
         assert "llm" in infra.participating_modules
 
+    @patch("torch.distributed.new_group")
+    @patch("torch.distributed.get_process_group_ranks")
     @patch("torch.distributed.get_rank")
     @patch("megatron.bridge.models.mimo.mimo_provider.build_hypercomm_grids")
-    @patch("megatron.bridge.models.mimo.mimo_provider._default_topology")
-    def test_build_infra_is_idempotent(self, mock_topology, mock_build_grids, mock_get_rank):
+    def test_build_infra_is_idempotent(self, mock_build_grids, mock_get_rank, mock_get_pg_ranks, mock_new_group):
         """Test build_infra() can be called multiple times."""
         mock_get_rank.return_value = 0
+        mock_get_pg_ranks.return_value = [0, 1]
+        mock_new_group.return_value = MagicMock()
         language_spec = ModuleSpec(module=Mock, params={"config": Mock()})
 
         mimo_parallelism_config = MimoParallelismConfig(
             module_parallelisms={
-                "llm": ModuleParallelismConfig(tensor_model_parallel_size=2),
+                "llm": ModuleParallelismConfig(tensor_model_parallel_size=2, data_parallel_size=1, rank_offset=0),
             },
         )
 
@@ -215,7 +193,6 @@ class TestMimoModelProvider:
         mock_grid.size = 2
         mock_grid.get_pg.return_value = MagicMock()
         mock_build_grids.return_value = {"llm": mock_grid}
-        mock_topology.return_value = {"llm": []}
 
         provider = MimoModelProvider(
             language_model_spec=language_spec,
@@ -229,13 +206,18 @@ class TestMimoModelProvider:
         # Should return equivalent results (not cached, but same structure)
         assert infra1.participating_modules == infra2.participating_modules
 
+    @patch("torch.distributed.new_group")
+    @patch("torch.distributed.get_process_group_ranks")
     @patch("torch.distributed.get_rank")
     @patch("megatron.bridge.models.mimo.mimo_provider.MimoModel")
     @patch("megatron.bridge.models.mimo.mimo_provider.build_hypercomm_grids")
-    @patch("megatron.bridge.models.mimo.mimo_provider._default_topology")
-    def test_provide_with_parallelism(self, mock_topology, mock_build_grids, mock_mimo_model, mock_get_rank):
+    def test_provide_with_parallelism(
+        self, mock_build_grids, mock_mimo_model, mock_get_rank, mock_get_pg_ranks, mock_new_group
+    ):
         """Test provide() with parallelism config."""
         mock_get_rank.return_value = 0
+        mock_get_pg_ranks.return_value = [0, 1, 2, 3]
+        mock_new_group.return_value = MagicMock()
         language_spec = ModuleSpec(module=Mock, params={"config": Mock()})
 
         mimo_parallelism_config = MimoParallelismConfig(
@@ -252,7 +234,6 @@ class TestMimoModelProvider:
         mock_grid.size = 4
         mock_grid.get_pg.return_value = MagicMock()
         mock_build_grids.return_value = {"llm": mock_grid}
-        mock_topology.return_value = {"llm": []}
 
         provider = MimoModelProvider(
             language_model_spec=language_spec,
@@ -266,64 +247,14 @@ class TestMimoModelProvider:
 
         # Should return model directly
         assert model == mock_model_instance
+        config_arg = mock_mimo_model.call_args[0][0]
+        assert config_arg.module_to_grid_map == {"llm": mock_grid}
+        assert config_arg.language_module_key == "llm"
 
         # Infrastructure should be available via build_infra()
         infra = provider.build_infra()
         assert "llm" in infra.module_to_grid_map
         assert "llm" in infra.pg_collections
-
-    @patch("torch.distributed.is_initialized")
-    @patch("torch.distributed.get_world_size")
-    @patch("torch.distributed.get_rank")
-    @patch("megatron.bridge.models.mimo.mimo_provider.build_hypercomm_grids")
-    def test_non_participating_rank_raises_error(
-        self, mock_build_grids, mock_get_rank, mock_get_world_size, mock_is_initialized
-    ):
-        """Test that non-participating ranks raise ValueError during finalize().
-
-        This tests the gap scenario: world_size=12, but modules only cover
-        ranks 0-3 and 8-11, leaving ranks 4-7 as non-participating.
-        """
-        mock_is_initialized.return_value = True
-        mock_get_world_size.return_value = 12  # World has 12 ranks
-        mock_get_rank.return_value = 5  # Rank 5 is in the gap
-
-        language_spec = ModuleSpec(module=Mock, params={"config": Mock()})
-        # Create config with a gap: llm at 0-3, encoder at 8-11, gap at 4-7
-        mimo_parallelism_config = MimoParallelismConfig(
-            module_parallelisms={
-                "llm": ModuleParallelismConfig(
-                    tensor_model_parallel_size=2,
-                    data_parallel_size=2,
-                    rank_offset=0,  # ranks 0-3
-                ),
-                "encoder": ModuleParallelismConfig(
-                    tensor_model_parallel_size=2,
-                    data_parallel_size=2,
-                    rank_offset=8,  # ranks 8-11
-                ),
-            },
-        )
-
-        # Mock grids with the gap (ranks 4-7 not covered)
-        llm_grid = MagicMock()
-        llm_grid.rank_offset = 0
-        llm_grid.size = 4  # ranks 0-3
-
-        encoder_grid = MagicMock()
-        encoder_grid.rank_offset = 8
-        encoder_grid.size = 4  # ranks 8-11
-
-        mock_build_grids.return_value = {"llm": llm_grid, "encoder": encoder_grid}
-
-        provider = MimoModelProvider(
-            language_model_spec=language_spec,
-            mimo_parallelism_config=mimo_parallelism_config,
-        )
-
-        # Should raise ValueError because ranks 4-7 don't participate
-        with pytest.raises(ValueError, match="do not participate in any MIMO module"):
-            provider.finalize()
 
     def test_inject_pg_collection_into_language_spec(self):
         """Test that pg_collection is injected into language specs."""
@@ -374,192 +305,23 @@ class TestMimoModelProvider:
             freeze_language_model=True,
         )
 
-        _ = provider.provide()
+        provider.provide()
 
         # Check parameter was frozen
         assert mock_param.requires_grad is False
 
-    @patch("megatron.bridge.models.mimo.mimo_provider.MimoModel")
-    def test_freezing_modality_encoders(self, mock_mimo_model):
-        """Test freeze_modality_encoders works."""
-        language_spec = ModuleSpec(module=Mock, params={"config": Mock()})
-
-        # Create mock model with modality submodules
-        mock_model = MagicMock()
-        mock_param = MagicMock()
-        mock_param.requires_grad = True
-
-        # Create mock encoder with parameters
-        mock_encoder = MagicMock()
-        mock_encoder.parameters.return_value = [mock_param]
-
-        # Create mock modality submodule with encoders
-        mock_submodule = MagicMock()
-        mock_submodule.encoders = mock_encoder
-
-        mock_model.modality_submodules = {"images": mock_submodule}
-        mock_mimo_model.return_value = mock_model
-
-        provider = MimoModelProvider(
-            language_model_spec=language_spec,
-            freeze_modality_encoders={"images": True},
-        )
-
-        _ = provider.provide()
-
-        # Check encoder parameters were frozen
-        assert mock_param.requires_grad is False
-
-    @patch("megatron.bridge.models.mimo.mimo_provider.MimoModel")
-    def test_freezing_modality_projections(self, mock_mimo_model):
-        """Test freeze_modality_projections works."""
-        language_spec = ModuleSpec(module=Mock, params={"config": Mock()})
-
-        # Create mock model with modality submodules
-        mock_model = MagicMock()
-        mock_param = MagicMock()
-        mock_param.requires_grad = True
-
-        # Create mock projection with parameters
-        mock_projection = MagicMock()
-        mock_projection.parameters.return_value = [mock_param]
-
-        # Create mock modality submodule with projections
-        mock_submodule = MagicMock()
-        mock_submodule.input_projections = mock_projection
-
-        mock_model.modality_submodules = {"images": mock_submodule}
-        mock_mimo_model.return_value = mock_model
-
-        provider = MimoModelProvider(
-            language_model_spec=language_spec,
-            freeze_modality_projections={"images": True},
-        )
-
-        _ = provider.provide()
-
-        # Check projection parameters were frozen
-        assert mock_param.requires_grad is False
-
-    @patch("megatron.bridge.models.mimo.mimo_provider.MimoModel")
-    def test_combined_freezing(self, mock_mimo_model):
-        """Test freezing language model, encoders, and projections together."""
-        language_spec = ModuleSpec(module=Mock, params={"config": Mock()})
-
-        # Create mock model with all components
-        mock_model = MagicMock()
-
-        # Language model param
-        mock_lang_param = MagicMock()
-        mock_lang_param.requires_grad = True
-        mock_model.language_model.parameters.return_value = [mock_lang_param]
-
-        # Encoder param
-        mock_enc_param = MagicMock()
-        mock_enc_param.requires_grad = True
-        mock_encoder = MagicMock()
-        mock_encoder.parameters.return_value = [mock_enc_param]
-
-        # Projection param
-        mock_proj_param = MagicMock()
-        mock_proj_param.requires_grad = True
-        mock_projection = MagicMock()
-        mock_projection.parameters.return_value = [mock_proj_param]
-
-        # Modality submodule
-        mock_submodule = MagicMock()
-        mock_submodule.encoders = mock_encoder
-        mock_submodule.input_projections = mock_projection
-
-        mock_model.modality_submodules = {"images": mock_submodule}
-        mock_mimo_model.return_value = mock_model
-
-        provider = MimoModelProvider(
-            language_model_spec=language_spec,
-            freeze_language_model=True,
-            freeze_modality_encoders={"images": True},
-            freeze_modality_projections={"images": True},
-        )
-
-        _ = provider.provide()
-
-        # Check all parameters were frozen
-        assert mock_lang_param.requires_grad is False
-        assert mock_enc_param.requires_grad is False
-        assert mock_proj_param.requires_grad is False
-
-    @patch("megatron.bridge.models.mimo.mimo_provider.MimoModel")
-    def test_partial_modality_freezing(self, mock_mimo_model):
-        """Test freezing only specific modalities."""
-        language_spec = ModuleSpec(module=Mock, params={"config": Mock()})
-
-        # Create mock model with multiple modalities
-        mock_model = MagicMock()
-
-        # Images modality (frozen)
-        mock_images_param = MagicMock()
-        mock_images_param.requires_grad = True
-        mock_images_encoder = MagicMock()
-        mock_images_encoder.parameters.return_value = [mock_images_param]
-        mock_images_submodule = MagicMock()
-        mock_images_submodule.encoders = mock_images_encoder
-
-        # Audio modality (not frozen)
-        mock_audio_param = MagicMock()
-        mock_audio_param.requires_grad = True
-        mock_audio_encoder = MagicMock()
-        mock_audio_encoder.parameters.return_value = [mock_audio_param]
-        mock_audio_submodule = MagicMock()
-        mock_audio_submodule.encoders = mock_audio_encoder
-
-        mock_model.modality_submodules = {
-            "images": mock_images_submodule,
-            "audio": mock_audio_submodule,
-        }
-        mock_mimo_model.return_value = mock_model
-
-        provider = MimoModelProvider(
-            language_model_spec=language_spec,
-            freeze_modality_encoders={"images": True},  # Only freeze images
-        )
-
-        _ = provider.provide()
-
-        # Check only images parameters were frozen
-        assert mock_images_param.requires_grad is False
-        assert mock_audio_param.requires_grad is True  # Should remain unfrozen
-
-    @patch("megatron.bridge.models.mimo.mimo_provider.MimoModel")
-    def test_freezing_with_missing_attributes(self, mock_mimo_model):
-        """Test freezing handles missing attributes gracefully."""
-        language_spec = ModuleSpec(module=Mock, params={"config": Mock()})
-
-        # Create mock model without expected attributes
-        mock_model = MagicMock()
-        # No language_model attribute
-        del mock_model.language_model
-        # No modality_submodules attribute
-        del mock_model.modality_submodules
-
-        mock_mimo_model.return_value = mock_model
-
-        provider = MimoModelProvider(
-            language_model_spec=language_spec,
-            freeze_language_model=True,
-            freeze_modality_encoders={"images": True},
-            freeze_modality_projections={"images": True},
-        )
-
-        # Should not raise an error
-        _ = provider.provide()
-
+    @patch("torch.distributed.new_group")
+    @patch("torch.distributed.get_process_group_ranks")
     @patch("torch.distributed.get_rank")
     @patch("megatron.bridge.models.mimo.mimo_provider.MimoModel")
     @patch("megatron.bridge.models.mimo.mimo_provider.build_hypercomm_grids")
-    @patch("megatron.bridge.models.mimo.mimo_provider._default_topology")
-    def test_per_encoder_parallelism(self, mock_topology, mock_build_grids, mock_mimo_model, mock_get_rank):
+    def test_per_encoder_parallelism(
+        self, mock_build_grids, mock_mimo_model, mock_get_rank, mock_get_pg_ranks, mock_new_group
+    ):
         """Test per-encoder parallelism with different TP per encoder."""
         mock_get_rank.return_value = 0
+        mock_get_pg_ranks.return_value = [0, 1, 2, 3]
+        mock_new_group.return_value = MagicMock()
         language_spec = ModuleSpec(module=Mock, params={"config": Mock()})
         clip_spec = ModuleSpec(module=Mock, params={})
         dino_spec = ModuleSpec(module=Mock, params={})
@@ -594,12 +356,6 @@ class TestMimoModelProvider:
             "dino_encoder": dino_grid,
         }
 
-        mock_topology.return_value = {
-            "clip_encoder": ["llm"],
-            "dino_encoder": ["llm"],
-            "llm": [],
-        }
-
         provider = MimoModelProvider(
             language_model_spec=language_spec,
             modality_submodules_spec={
@@ -630,542 +386,49 @@ class TestMimoModelProvider:
         # Should return model directly
         assert model == mock_model_instance
 
-    def test_initialize_model_parallel_is_noop(self):
-        """Test that initialize_model_parallel() is a no-op for MIMO."""
+    def test_initialize_model_parallel_raises(self):
+        """Test that initialize_model_parallel() raises NotImplementedError for MIMO."""
         language_spec = ModuleSpec(module=Mock, params={"config": Mock()})
         provider = MimoModelProvider(language_model_spec=language_spec)
 
-        # Should not raise, should be a no-op
-        provider.initialize_model_parallel(seed=42)
-        provider.initialize_model_parallel()
+        import pytest
 
-    def test_tensor_model_parallel_size_property_with_config(self):
-        """Test tensor_model_parallel_size property returns LLM's TP size."""
-        language_spec = ModuleSpec(module=Mock, params={"config": Mock()})
-        mimo_config = MimoParallelismConfig(
-            module_parallelisms={
-                "llm": ModuleParallelismConfig(tensor_model_parallel_size=8),
-            }
-        )
+        with pytest.raises(NotImplementedError, match="MIMO does not use global model parallelism"):
+            provider.initialize_model_parallel(seed=42)
+        with pytest.raises(NotImplementedError, match="MIMO does not use global model parallelism"):
+            provider.initialize_model_parallel()
 
-        provider = MimoModelProvider(
-            language_model_spec=language_spec,
-            mimo_parallelism_config=mimo_config,
-        )
-
-        assert provider.tensor_model_parallel_size == 8
-
-    def test_tensor_model_parallel_size_property_without_config(self):
-        """Test tensor_model_parallel_size property returns 1 without config."""
-        language_spec = ModuleSpec(module=Mock, params={"config": Mock()})
-        provider = MimoModelProvider(language_model_spec=language_spec)
-
-        assert provider.tensor_model_parallel_size == 1
-
-    def test_pipeline_model_parallel_size_property_with_config(self):
-        """Test pipeline_model_parallel_size property returns LLM's PP size."""
-        language_spec = ModuleSpec(module=Mock, params={"config": Mock()})
-        mimo_config = MimoParallelismConfig(
-            module_parallelisms={
-                "llm": ModuleParallelismConfig(pipeline_model_parallel_size=4),
-            }
-        )
-
-        provider = MimoModelProvider(
-            language_model_spec=language_spec,
-            mimo_parallelism_config=mimo_config,
-        )
-
-        assert provider.pipeline_model_parallel_size == 4
-
-    def test_pipeline_model_parallel_size_property_without_config(self):
-        """Test pipeline_model_parallel_size property returns 1 without config."""
-        language_spec = ModuleSpec(module=Mock, params={"config": Mock()})
-        provider = MimoModelProvider(language_model_spec=language_spec)
-
-        assert provider.pipeline_model_parallel_size == 1
-
-    def test_context_parallel_size_property_with_config(self):
-        """Test context_parallel_size property returns LLM's CP size."""
-        language_spec = ModuleSpec(module=Mock, params={"config": Mock()})
-        mimo_config = MimoParallelismConfig(
-            module_parallelisms={
-                "llm": ModuleParallelismConfig(context_parallel_size=2),
-            }
-        )
-
-        provider = MimoModelProvider(
-            language_model_spec=language_spec,
-            mimo_parallelism_config=mimo_config,
-        )
-
-        assert provider.context_parallel_size == 2
-
-    def test_context_parallel_size_property_without_config(self):
-        """Test context_parallel_size property returns 1 without config."""
-        language_spec = ModuleSpec(module=Mock, params={"config": Mock()})
-        provider = MimoModelProvider(language_model_spec=language_spec)
-
-        assert provider.context_parallel_size == 1
-
-
-class TestMimoModelProviderDistributed:
-    """Test cases for MimoModelProvider.provide_distributed_model()."""
-
-    @patch("torch.cuda.current_device")
-    @patch("torch.distributed.is_initialized")
-    @patch("torch.distributed.get_world_size")
-    @patch("torch.distributed.get_rank")
+    @patch("megatron.core.transformer.module.Float16Module")
+    @patch("megatron.bridge.models.mimo.mimo_provider.get_model_config")
     @patch("megatron.bridge.models.mimo.mimo_provider.MimoModel")
     @patch("megatron.bridge.models.mimo.mimo_provider.build_hypercomm_grids")
-    @patch("megatron.bridge.models.mimo.mimo_provider._default_topology")
-    def test_basic_provide_distributed_model_flow(
-        self,
-        mock_topology,
-        mock_build_grids,
-        mock_mimo_model,
-        mock_get_rank,
-        mock_get_world_size,
-        mock_is_initialized,
-        mock_current_device,
+    @patch("torch.distributed.is_initialized")
+    def test_provide_distributed_model_sets_variable_seq_lengths(
+        self, mock_is_init, mock_build_grids, mock_mimo_model, mock_get_config, mock_float16
     ):
-        """Test basic provide_distributed_model() flow without DDP."""
-        mock_is_initialized.return_value = True
-        mock_get_world_size.return_value = 4
-        mock_get_rank.return_value = 0
-        mock_current_device.return_value = 0
-
+        """Test that provide_distributed_model sets variable_seq_lengths=True."""
+        mock_is_init.return_value = False
         language_spec = ModuleSpec(module=Mock, params={"config": Mock()})
-        mimo_config = MimoParallelismConfig(
-            module_parallelisms={
-                "llm": ModuleParallelismConfig(tensor_model_parallel_size=2, data_parallel_size=2),
-            }
-        )
-
-        mock_grid = MagicMock()
-        mock_grid.rank_offset = 0
-        mock_grid.size = 4
-        mock_grid.get_pg.return_value = MagicMock()
-        mock_build_grids.return_value = {"llm": mock_grid}
-        mock_topology.return_value = {"llm": []}
-
-        mock_model = MockModule()
-        mock_mimo_model.return_value = mock_model
 
         provider = MimoModelProvider(
             language_model_spec=language_spec,
-            mimo_parallelism_config=mimo_config,
+            bf16=False,  # Disable to simplify test
+            fp16=False,
         )
 
-        result = provider.provide_distributed_model(wrap_with_ddp=False)
-
-        # Should return list with model
-        assert isinstance(result, list)
-        assert len(result) == 1
-        assert result[0] is not None
-
-    @patch("torch.cuda.stream")
-    @patch("torch.cuda.is_available")
-    @patch("torch.cuda.set_device")
-    @patch("torch.cuda.device_count")
-    @patch("torch.cuda.Stream")
-    @patch("torch.cuda.current_stream")
-    @patch("torch.cuda.current_device")
-    @patch("torch.distributed.is_initialized")
-    @patch("torch.distributed.get_world_size")
-    @patch("torch.distributed.get_rank")
-    @patch("megatron.bridge.models.mimo.mimo_provider.MimoModel")
-    @patch("megatron.bridge.models.mimo.mimo_provider.DistributedDataParallel")
-    @patch("megatron.bridge.models.mimo.mimo_provider.build_hypercomm_grids")
-    @patch("megatron.bridge.models.mimo.mimo_provider._default_topology")
-    @patch("megatron.bridge.models.mimo.mimo_provider.get_model_config")
-    def test_with_ddp_wrapping(
-        self,
-        mock_get_config,
-        mock_topology,
-        mock_build_grids,
-        mock_ddp,
-        mock_mimo_model,
-        mock_get_rank,
-        mock_get_world_size,
-        mock_is_initialized,
-        mock_current_device,
-        mock_current_stream,
-        mock_stream_class,
-        mock_device_count,
-        mock_set_device,
-        mock_is_available,
-        mock_stream_ctx,
-    ):
-        """Test DDP wrapping with data_parallel_random_init=True."""
-        from megatron.core.distributed import DistributedDataParallelConfig
-
-        mock_is_initialized.return_value = True
-        mock_get_world_size.return_value = 4
-        mock_get_rank.return_value = 0
-        mock_current_device.return_value = 0
-        mock_device_count.return_value = 8  # Mock sufficient GPUs
-        mock_set_device.return_value = None  # Mock set_device to avoid CUDA calls
-        mock_is_available.return_value = True  # Mock CUDA availability
-
-        # Mock the stream context manager
-        mock_stream_ctx.return_value.__enter__ = MagicMock(return_value=None)
-        mock_stream_ctx.return_value.__exit__ = MagicMock(return_value=None)
-
-        # Mock streams
-        mock_stream = MagicMock()
-        mock_stream_class.return_value = mock_stream
-        mock_current_stream.return_value = MagicMock()
-
-        language_spec = ModuleSpec(module=Mock, params={"config": Mock()})
-        mimo_config = MimoParallelismConfig(
-            module_parallelisms={
-                "llm": ModuleParallelismConfig(tensor_model_parallel_size=2, data_parallel_size=2),
-            }
-        )
-
-        mock_grid = MagicMock()
-        mock_grid.rank_offset = 0
-        mock_grid.size = 4
-        mock_grid.get_pg.return_value = MagicMock()
-        mock_build_grids.return_value = {"llm": mock_grid}
-        mock_topology.return_value = {"llm": []}
-
-        mock_model = MockModule()
-        mock_mimo_model.return_value = mock_model
-        mock_get_config.return_value = Mock()
-
-        # Mock DDP wrapper
-        mock_ddp_model = MagicMock()
-        mock_ddp_model.broadcast_params = MagicMock()
-        mock_ddp.return_value = mock_ddp_model
-
-        provider = MimoModelProvider(
-            language_model_spec=language_spec,
-            mimo_parallelism_config=mimo_config,
-        )
-
-        ddp_config = DistributedDataParallelConfig()
-        provider.provide_distributed_model(ddp_config=ddp_config, wrap_with_ddp=True, data_parallel_random_init=True)
-
-        # Should wrap with DDP
-        assert mock_ddp.called
-        # Should broadcast params
-        mock_ddp_model.broadcast_params.assert_called_once()
-
-    @patch("torch.cuda.current_device")
-    @patch("torch.distributed.is_initialized")
-    @patch("megatron.bridge.models.mimo.mimo_provider.MimoModel")
-    def test_ddp_config_required_when_wrap_with_ddp_true(
-        self, mock_mimo_model, mock_is_initialized, mock_current_device
-    ):
-        """Test ValueError raised when wrap_with_ddp=True but ddp_config=None."""
-        mock_is_initialized.return_value = False
-        language_spec = ModuleSpec(module=Mock, params={"config": Mock()})
-
-        provider = MimoModelProvider(language_model_spec=language_spec)
-
-        with pytest.raises(ValueError, match="ddp_config is required when wrap_with_ddp is True"):
-            provider.provide_distributed_model(wrap_with_ddp=True, ddp_config=None)
-
-    @patch("torch.cuda.current_device")
-    @patch("torch.distributed.is_initialized")
-    @patch("megatron.bridge.models.mimo.mimo_provider.MimoModel")
-    def test_cpu_initialization(self, mock_mimo_model, mock_is_initialized, mock_current_device):
-        """Test model stays on CPU when use_cpu_initialization=True."""
-        mock_is_initialized.return_value = False
-        language_spec = ModuleSpec(module=Mock, params={"config": Mock()})
-
-        mock_model = MockModule()
-        mock_mimo_model.return_value = mock_model
-
-        provider = MimoModelProvider(language_model_spec=language_spec)
-
-        result = provider.provide_distributed_model(wrap_with_ddp=False, use_cpu_initialization=True)
-
-        # Should NOT move to CUDA (we can't easily assert on MockModule methods, so just check result)
-        assert len(result) == 1
-
-    @patch("torch.cuda.current_device")
-    @patch("torch.distributed.is_initialized")
-    @patch("megatron.bridge.models.mimo.mimo_provider.MimoModel")
-    def test_meta_device_initialization(self, mock_mimo_model, mock_is_initialized, mock_current_device):
-        """Test model stays on meta device when init_model_with_meta_device=True."""
-        mock_is_initialized.return_value = False
-        language_spec = ModuleSpec(module=Mock, params={"config": Mock()})
-
-        mock_model = MockModule()
-        mock_mimo_model.return_value = mock_model
-
-        provider = MimoModelProvider(language_model_spec=language_spec)
-
-        result = provider.provide_distributed_model(wrap_with_ddp=False, init_model_with_meta_device=True)
-
-        # Should NOT move to CUDA (we can't easily assert on MockModule methods, so just check result)
-        assert len(result) == 1
-
-    @patch("torch.cuda.current_device")
-    @patch("torch.distributed.is_initialized")
-    @patch("megatron.bridge.models.mimo.mimo_provider.MimoModel")
-    @patch("megatron.bridge.models.mimo.mimo_provider.get_model_config")
-    def test_fp16_handling(self, mock_get_config, mock_mimo_model, mock_is_initialized, mock_current_device):
-        """Test FP16 mixed precision wrapper."""
-        mock_is_initialized.return_value = False
-        mock_current_device.return_value = 0
-        language_spec = ModuleSpec(module=Mock, params={"config": Mock()})
-
-        mock_model = MockModule()
-        mock_mimo_model.return_value = mock_model
+        mock_model_instance = MagicMock()
+        mock_model_instance.cuda = MagicMock(return_value=None)
+        mock_mimo_model.return_value = mock_model_instance
 
         mock_config = MagicMock()
+        mock_config.variable_seq_lengths = False  # Initial value
         mock_get_config.return_value = mock_config
 
-        provider = MimoModelProvider(language_model_spec=language_spec)
+        # No parallelism config means no DDP wrapping needed
+        provider.provide_distributed_model(wrap_with_ddp=False)
 
-        with patch("megatron.core.transformer.module.Float16Module") as mock_float16:
-            mock_wrapped = MagicMock()
-            mock_float16.return_value = mock_wrapped
-
-            result = provider.provide_distributed_model(wrap_with_ddp=False, fp16=True)
-
-            # Should wrap with Float16Module
-            mock_float16.assert_called_once()
-            assert mock_config.fp16 is True
-            assert result[0] == mock_wrapped
-
-    @patch("torch.cuda.current_device")
-    @patch("torch.distributed.is_initialized")
-    @patch("megatron.bridge.models.mimo.mimo_provider.MimoModel")
-    @patch("megatron.bridge.models.mimo.mimo_provider.get_model_config")
-    def test_bf16_handling(self, mock_get_config, mock_mimo_model, mock_is_initialized, mock_current_device):
-        """Test BF16 mixed precision wrapper (default)."""
-        mock_is_initialized.return_value = False
-        mock_current_device.return_value = 0
-        language_spec = ModuleSpec(module=Mock, params={"config": Mock()})
-
-        mock_model = MockModule()
-        mock_mimo_model.return_value = mock_model
-
-        mock_config = MagicMock()
-        mock_get_config.return_value = mock_config
-
-        provider = MimoModelProvider(language_model_spec=language_spec, bf16=True)
-
-        with patch("megatron.core.transformer.module.Float16Module") as mock_float16:
-            mock_wrapped = MagicMock()
-            mock_float16.return_value = mock_wrapped
-
-            provider.provide_distributed_model(wrap_with_ddp=False)
-
-            # Should wrap with Float16Module for BF16
-            mock_float16.assert_called_once()
-            assert mock_config.bf16 is True
-
-    @patch("torch.cuda.current_device")
-    @patch("torch.distributed.is_initialized")
-    @patch("megatron.bridge.models.mimo.mimo_provider.MimoModel")
-    @patch("megatron.bridge.models.mimo.mimo_provider.get_model_config")
-    def test_custom_mixed_precision_wrapper(
-        self, mock_get_config, mock_mimo_model, mock_is_initialized, mock_current_device
-    ):
-        """Test custom mixed precision wrapper is used."""
-        mock_is_initialized.return_value = False
-        mock_current_device.return_value = 0
-        language_spec = ModuleSpec(module=Mock, params={"config": Mock()})
-
-        mock_model = MagicMock()
-        mock_model.cuda = MagicMock(return_value=mock_model)
-        mock_mimo_model.return_value = mock_model
-
-        mock_config = MagicMock()
-        mock_get_config.return_value = mock_config
-
-        # Custom wrapper
-        mock_custom_wrapper = MagicMock()
-        mock_wrapped = MagicMock()
-        mock_custom_wrapper.return_value = mock_wrapped
-
-        provider = MimoModelProvider(language_model_spec=language_spec, fp16=True)
-
-        result = provider.provide_distributed_model(wrap_with_ddp=False, mixed_precision_wrapper=mock_custom_wrapper)
-
-        # Should use custom wrapper instead of Float16Module
-        mock_custom_wrapper.assert_called_once_with(mock_config, mock_model)
-        assert result[0] == mock_wrapped
-
-    @patch("torch.cuda.current_device")
-    @patch("torch.distributed.is_initialized")
-    @patch("megatron.bridge.models.mimo.mimo_provider.MimoModel")
-    def test_pre_wrap_hook_single(self, mock_mimo_model, mock_is_initialized, mock_current_device):
-        """Test single pre-wrap hook is called."""
-        mock_is_initialized.return_value = False
-        mock_current_device.return_value = 0
-        language_spec = ModuleSpec(module=Mock, params={"config": Mock()})
-
-        mock_model = MockModule()
-        mock_mimo_model.return_value = mock_model
-
-        # Pre-wrap hook
-        hook_called = []
-
-        def pre_hook(models):
-            hook_called.append(True)
-            return models
-
-        provider = MimoModelProvider(language_model_spec=language_spec)
-
-        provider.provide_distributed_model(wrap_with_ddp=False, pre_wrap_hook=pre_hook)
-
-        # Hook should be called
-        assert len(hook_called) == 1
-
-    @patch("torch.cuda.current_device")
-    @patch("torch.distributed.is_initialized")
-    @patch("megatron.bridge.models.mimo.mimo_provider.MimoModel")
-    def test_pre_wrap_hooks_multiple(self, mock_mimo_model, mock_is_initialized, mock_current_device):
-        """Test multiple pre-wrap hooks are called in order."""
-        mock_is_initialized.return_value = False
-        mock_current_device.return_value = 0
-        language_spec = ModuleSpec(module=Mock, params={"config": Mock()})
-
-        mock_model = MockModule()
-        mock_mimo_model.return_value = mock_model
-
-        # Track hook execution order
-        hook_order = []
-
-        def hook1(models):
-            hook_order.append(1)
-            return models
-
-        def hook2(models):
-            hook_order.append(2)
-            return models
-
-        provider = MimoModelProvider(language_model_spec=language_spec)
-
-        provider.provide_distributed_model(wrap_with_ddp=False, pre_wrap_hook=[hook1, hook2])
-
-        # Hooks should be called in order
-        assert hook_order == [1, 2]
-
-    @patch("torch.cuda.current_device")
-    @patch("torch.distributed.is_initialized")
-    @patch("megatron.bridge.models.mimo.mimo_provider.MimoModel")
-    def test_post_wrap_hook(self, mock_mimo_model, mock_is_initialized, mock_current_device):
-        """Test post-wrap hook is called after everything."""
-        mock_is_initialized.return_value = False
-        mock_current_device.return_value = 0
-        language_spec = ModuleSpec(module=Mock, params={"config": Mock()})
-
-        mock_model = MockModule()
-        mock_mimo_model.return_value = mock_model
-
-        # Post-wrap hook
-        hook_called = []
-
-        def post_hook(models):
-            hook_called.append(True)
-            return models
-
-        provider = MimoModelProvider(language_model_spec=language_spec)
-
-        provider.provide_distributed_model(wrap_with_ddp=False, post_wrap_hook=post_hook)
-
-        # Hook should be called
-        assert len(hook_called) == 1
-
-    @patch("torch.cuda.stream")
-    @patch("torch.cuda.is_available")
-    @patch("torch.cuda.set_device")
-    @patch("torch.cuda.device_count")
-    @patch("torch.cuda.Stream")
-    @patch("torch.cuda.current_stream")
-    @patch("torch.cuda.current_device")
-    @patch("torch.distributed.is_initialized")
-    @patch("torch.distributed.get_world_size")
-    @patch("torch.distributed.get_rank")
-    @patch("megatron.bridge.models.mimo.mimo_provider.MimoModel")
-    @patch("megatron.bridge.models.mimo.mimo_provider.DistributedDataParallel")
-    @patch("megatron.bridge.models.mimo.mimo_provider.build_hypercomm_grids")
-    @patch("megatron.bridge.models.mimo.mimo_provider._default_topology")
-    @patch("megatron.bridge.models.mimo.mimo_provider.get_model_config")
-    def test_overlap_param_gather(
-        self,
-        mock_get_config,
-        mock_topology,
-        mock_build_grids,
-        mock_ddp,
-        mock_mimo_model,
-        mock_get_rank,
-        mock_get_world_size,
-        mock_is_initialized,
-        mock_current_device,
-        mock_current_stream,
-        mock_stream_class,
-        mock_device_count,
-        mock_set_device,
-        mock_is_available,
-        mock_stream_ctx,
-    ):
-        """Test overlap_param_gather_with_optimizer_step sets disable_bucketing."""
-        from megatron.core.distributed import DistributedDataParallelConfig
-
-        mock_is_initialized.return_value = True
-        mock_get_world_size.return_value = 4
-        mock_get_rank.return_value = 0
-        mock_current_device.return_value = 0
-        mock_device_count.return_value = 8  # Mock sufficient GPUs
-        mock_set_device.return_value = None  # Mock set_device to avoid CUDA calls
-        mock_is_available.return_value = True  # Mock CUDA availability
-
-        # Mock the stream context manager
-        mock_stream_ctx.return_value.__enter__ = MagicMock(return_value=None)
-        mock_stream_ctx.return_value.__exit__ = MagicMock(return_value=None)
-
-        # Mock streams
-        mock_stream = MagicMock()
-        mock_stream_class.return_value = mock_stream
-        mock_current_stream.return_value = MagicMock()
-
-        language_spec = ModuleSpec(module=Mock, params={"config": Mock()})
-        mimo_config = MimoParallelismConfig(
-            module_parallelisms={
-                "llm": ModuleParallelismConfig(tensor_model_parallel_size=2, data_parallel_size=2),
-            }
-        )
-
-        mock_grid = MagicMock()
-        mock_grid.rank_offset = 0
-        mock_grid.size = 4
-        mock_grid.get_pg.return_value = MagicMock()
-        mock_build_grids.return_value = {"llm": mock_grid}
-        mock_topology.return_value = {"llm": []}
-
-        mock_model = MockModule()
-        mock_mimo_model.return_value = mock_model
-        mock_get_config.return_value = Mock()
-
-        mock_ddp_model = MagicMock()
-        mock_ddp_model.broadcast_params = MagicMock()
-        mock_ddp.return_value = mock_ddp_model
-
-        provider = MimoModelProvider(
-            language_model_spec=language_spec,
-            mimo_parallelism_config=mimo_config,
-        )
-
-        ddp_config = DistributedDataParallelConfig()
-        provider.provide_distributed_model(
-            ddp_config=ddp_config,
-            wrap_with_ddp=True,
-            overlap_param_gather_with_optimizer_step=True,
-            data_parallel_random_init=False,
-        )
-
-        # Check disable_bucketing was set correctly
-        call_kwargs = mock_ddp.call_args[1]
-        assert call_kwargs["disable_bucketing"] is True
+        # Should have set variable_seq_lengths=True
+        assert mock_config.variable_seq_lengths is True
 
 
 class TestMimoModelInfra:
@@ -1189,3 +452,263 @@ class TestMimoModelInfra:
         assert infra.topology == topology
         assert infra.pg_collections == pg_collections
         assert infra.participating_modules == participating
+
+
+class TestEmbeddingGroupHelpers:
+    """Test cases for embedding group helper functions."""
+
+    @patch("torch.distributed.new_group")
+    @patch("torch.distributed.get_process_group_ranks")
+    def test_populate_embedding_groups_single_pp_rank(self, mock_get_ranks, mock_new_group):
+        """Test embedding groups with single PP rank (PP=1)."""
+        from megatron.bridge.models.mimo.mimo_builder import (
+            populate_embedding_and_position_groups,
+        )
+
+        mock_pp_group = MagicMock()
+        mock_get_ranks.return_value = [0]  # Single PP rank
+        mock_new_group.return_value = MagicMock()
+
+        populate_embedding_and_position_groups(mock_pp_group)
+
+        # Should create groups for both position and word embeddings
+        assert mock_new_group.call_count == 2
+        # Both groups should include only rank 0
+        calls = mock_new_group.call_args_list
+        assert calls[0].kwargs["ranks"] == [0]
+        assert calls[1].kwargs["ranks"] == [0]
+
+    @patch("torch.distributed.new_group")
+    @patch("torch.distributed.get_process_group_ranks")
+    def test_populate_embedding_groups_multiple_pp_ranks(self, mock_get_ranks, mock_new_group):
+        """Test embedding groups with multiple PP ranks (PP>1)."""
+        from megatron.bridge.models.mimo.mimo_builder import (
+            populate_embedding_and_position_groups,
+        )
+
+        mock_pp_group = MagicMock()
+        mock_get_ranks.return_value = [0, 4, 8, 12]  # PP=4
+        mock_new_group.return_value = MagicMock()
+
+        populate_embedding_and_position_groups(mock_pp_group)
+
+        # Should create two groups
+        assert mock_new_group.call_count == 2
+        calls = mock_new_group.call_args_list
+        # pos_embd only on first rank
+        assert calls[0].kwargs["ranks"] == [0]
+        # embd on first and last ranks
+        assert calls[1].kwargs["ranks"] == [0, 12]
+
+    def test_populate_embedding_groups_none_pp_group(self):
+        """Test embedding groups with None PP group."""
+        from megatron.bridge.models.mimo.mimo_builder import (
+            populate_embedding_and_position_groups,
+        )
+
+        pos_embd_pg, embd_pg = populate_embedding_and_position_groups(None)
+
+        assert pos_embd_pg is None
+        assert embd_pg is None
+
+    @patch("torch.distributed.get_process_group_ranks")
+    @patch("torch.distributed.get_rank")
+    def test_is_pp_first_stage_true(self, mock_get_rank, mock_get_ranks):
+        """Test is_pp_first_stage returns True for first stage."""
+        from megatron.bridge.models.mimo.mimo_builder import is_pp_first_stage
+
+        mock_pp_group = MagicMock()
+        mock_get_ranks.return_value = [0, 4, 8, 12]
+        mock_get_rank.return_value = 0
+
+        assert is_pp_first_stage(mock_pp_group) is True
+
+    @patch("torch.distributed.get_process_group_ranks")
+    @patch("torch.distributed.get_rank")
+    def test_is_pp_first_stage_false(self, mock_get_rank, mock_get_ranks):
+        """Test is_pp_first_stage returns False for non-first stage."""
+        from megatron.bridge.models.mimo.mimo_builder import is_pp_first_stage
+
+        mock_pp_group = MagicMock()
+        mock_get_ranks.return_value = [0, 4, 8, 12]
+        mock_get_rank.return_value = 4
+
+        assert is_pp_first_stage(mock_pp_group) is False
+
+    def test_is_pp_first_stage_none_group(self):
+        """Test is_pp_first_stage returns True for None group (no PP)."""
+        from megatron.bridge.models.mimo.mimo_builder import is_pp_first_stage
+
+        assert is_pp_first_stage(None) is True
+
+    @patch("torch.distributed.get_process_group_ranks")
+    @patch("torch.distributed.get_rank")
+    def test_is_pp_last_stage_true(self, mock_get_rank, mock_get_ranks):
+        """Test is_pp_last_stage returns True for last stage."""
+        from megatron.bridge.models.mimo.mimo_builder import is_pp_last_stage
+
+        mock_pp_group = MagicMock()
+        mock_get_ranks.return_value = [0, 4, 8, 12]
+        mock_get_rank.return_value = 12
+
+        assert is_pp_last_stage(mock_pp_group) is True
+
+    @patch("torch.distributed.get_process_group_ranks")
+    @patch("torch.distributed.get_rank")
+    def test_is_pp_last_stage_false(self, mock_get_rank, mock_get_ranks):
+        """Test is_pp_last_stage returns False for non-last stage."""
+        from megatron.bridge.models.mimo.mimo_builder import is_pp_last_stage
+
+        mock_pp_group = MagicMock()
+        mock_get_ranks.return_value = [0, 4, 8, 12]
+        mock_get_rank.return_value = 4
+
+        assert is_pp_last_stage(mock_pp_group) is False
+
+    def test_is_pp_last_stage_none_group(self):
+        """Test is_pp_last_stage returns True for None group (no PP)."""
+        from megatron.bridge.models.mimo.mimo_builder import is_pp_last_stage
+
+        assert is_pp_last_stage(None) is True
+
+
+class TestProcessGroupCollectionWithEmbeddingGroups:
+    """Test that ProcessGroupCollection includes embedding groups."""
+
+    @patch("megatron.bridge.models.mimo.mimo_provider.is_pp_last_stage")
+    @patch("megatron.bridge.models.mimo.mimo_provider.is_pp_first_stage")
+    @patch("megatron.bridge.models.mimo.mimo_provider.populate_embedding_and_position_groups")
+    @patch("torch.distributed.get_rank")
+    def test_pg_collection_includes_embedding_groups_first_stage(
+        self, mock_get_rank, mock_populate, mock_is_first, mock_is_last
+    ):
+        """Test that pg_collection includes embedding groups for first PP stage."""
+        mock_get_rank.return_value = 0
+        mock_pos_embd = MagicMock()
+        mock_embd = MagicMock()
+        mock_populate.return_value = (mock_pos_embd, mock_embd)
+        mock_is_first.return_value = True
+        mock_is_last.return_value = False
+
+        language_spec = ModuleSpec(module=Mock, params={"config": Mock()})
+        mimo_parallelism_config = MimoParallelismConfig(
+            module_parallelisms={
+                "llm": ModuleParallelismConfig(tensor_model_parallel_size=2, data_parallel_size=2),
+            },
+        )
+
+        # Mock grid
+        mock_grid = MagicMock()
+        mock_grid.rank_offset = 0
+        mock_grid.size = 4
+        mock_grid.get_pg.return_value = MagicMock()
+
+        provider = MimoModelProvider(
+            language_model_spec=language_spec,
+            mimo_parallelism_config=mimo_parallelism_config,
+        )
+
+        pg_collections = provider._get_pg_collections_from_grids({"llm": mock_grid})
+
+        # First stage should have pos_embd but not embd (not last stage)
+        assert pg_collections["llm"].pos_embd == mock_pos_embd
+        assert pg_collections["llm"].embd == mock_embd  # First stage gets embd too
+
+    @patch("megatron.bridge.models.mimo.mimo_provider.is_pp_last_stage")
+    @patch("megatron.bridge.models.mimo.mimo_provider.is_pp_first_stage")
+    @patch("megatron.bridge.models.mimo.mimo_provider.populate_embedding_and_position_groups")
+    @patch("torch.distributed.get_rank")
+    def test_pg_collection_middle_stage_no_embedding_groups(
+        self, mock_get_rank, mock_populate, mock_is_first, mock_is_last
+    ):
+        """Test that middle PP stages don't get embedding groups."""
+        mock_get_rank.return_value = 4
+        mock_pos_embd = MagicMock()
+        mock_embd = MagicMock()
+        mock_populate.return_value = (mock_pos_embd, mock_embd)
+        mock_is_first.return_value = False
+        mock_is_last.return_value = False
+
+        language_spec = ModuleSpec(module=Mock, params={"config": Mock()})
+        mimo_parallelism_config = MimoParallelismConfig(
+            module_parallelisms={
+                "llm": ModuleParallelismConfig(tensor_model_parallel_size=2, data_parallel_size=2),
+            },
+        )
+
+        # Mock grid
+        mock_grid = MagicMock()
+        mock_grid.rank_offset = 0
+        mock_grid.size = 8
+        mock_grid.get_pg.return_value = MagicMock()
+
+        provider = MimoModelProvider(
+            language_model_spec=language_spec,
+            mimo_parallelism_config=mimo_parallelism_config,
+        )
+
+        pg_collections = provider._get_pg_collections_from_grids({"llm": mock_grid})
+
+        # Middle stage should have neither embedding group
+        assert pg_collections["llm"].pos_embd is None
+        assert pg_collections["llm"].embd is None
+
+    @patch("megatron.bridge.models.mimo.mimo_provider.is_pp_last_stage")
+    @patch("megatron.bridge.models.mimo.mimo_provider.is_pp_first_stage")
+    @patch("megatron.bridge.models.mimo.mimo_provider.populate_embedding_and_position_groups")
+    @patch("torch.distributed.get_rank")
+    def test_pg_collection_includes_composite_groups(self, mock_get_rank, mock_populate, mock_is_first, mock_is_last):
+        """Test that pg_collection includes mp, tp_ep_pp, and expt_dp composite groups."""
+        mock_get_rank.return_value = 0
+        mock_populate.return_value = (MagicMock(), MagicMock())
+        mock_is_first.return_value = True
+        mock_is_last.return_value = True
+
+        language_spec = ModuleSpec(module=Mock, params={"config": Mock()})
+        mimo_parallelism_config = MimoParallelismConfig(
+            module_parallelisms={
+                "llm": ModuleParallelismConfig(tensor_model_parallel_size=2, data_parallel_size=2),
+            },
+        )
+
+        mock_tp = MagicMock(name="tp_pg")
+        mock_dp = MagicMock(name="dp_pg")
+        mock_pp = MagicMock(name="pp_pg")
+        mock_cp = MagicMock(name="cp_pg")
+        mock_ep = MagicMock(name="ep_pg")
+        mock_dp_cp = MagicMock(name="dp_cp_pg")
+        mock_mp = MagicMock(name="mp_pg")
+        mock_tp_ep_pp = MagicMock(name="tp_ep_pp_pg")
+
+        pg_map = {
+            ("tp",): mock_tp,
+            ("dp",): mock_dp,
+            ("pp",): mock_pp,
+            ("cp",): mock_cp,
+            ("ep",): mock_ep,
+            ("dp", "cp"): mock_dp_cp,
+            ("tp", "pp"): mock_mp,
+            ("tp", "ep", "pp"): mock_tp_ep_pp,
+        }
+
+        mock_grid = MagicMock()
+        mock_grid.rank_offset = 0
+        mock_grid.size = 4
+        mock_grid.get_pg.side_effect = lambda dims: pg_map[tuple(dims)]
+
+        provider = MimoModelProvider(
+            language_model_spec=language_spec,
+            mimo_parallelism_config=mimo_parallelism_config,
+        )
+
+        pg_collections = provider._get_pg_collections_from_grids({"llm": mock_grid})
+
+        pgc = pg_collections["llm"]
+        assert pgc.tp == mock_tp
+        assert pgc.dp == mock_dp
+        assert pgc.pp == mock_pp
+        assert pgc.cp == mock_cp
+        assert pgc.ep == mock_ep
+        assert pgc.dp_cp == mock_dp_cp
+        assert pgc.mp == mock_mp
+        assert pgc.tp_ep_pp == mock_tp_ep_pp

--- a/tests/unit_tests/models/mimo/test_mimo_provider.py
+++ b/tests/unit_tests/models/mimo/test_mimo_provider.py
@@ -34,7 +34,7 @@ class TestMimoModelProvider:
         modality_spec = ModuleSpec(module=Mock, params={})
         mimo_parallelism_config = MimoParallelismConfig(
             module_parallelisms={
-                "llm": ModuleParallelismConfig(tensor_model_parallel_size=2),
+                "language": ModuleParallelismConfig(tensor_model_parallel_size=2),
             },
         )
 
@@ -93,7 +93,6 @@ class TestMimoModelProvider:
         mock_build_grids.assert_not_called()
         config_arg = mock_mimo_model.call_args[0][0]
         assert config_arg.module_to_grid_map is None
-        assert config_arg.language_module_key is None
 
     @patch("megatron.bridge.models.mimo.mimo_provider.MimoModel")
     @patch("megatron.bridge.models.mimo.mimo_provider.build_hypercomm_grids")
@@ -121,7 +120,7 @@ class TestMimoModelProvider:
         # Should return infrastructure with auto-derived topology
         assert isinstance(infra, MimoModelInfra)
         assert infra.module_to_grid_map == {}
-        assert infra.topology == {"llm": []}
+        assert infra.topology == {"language": []}
         assert infra.pg_collections == {}
         assert infra.participating_modules == []
 
@@ -141,7 +140,7 @@ class TestMimoModelProvider:
 
         mimo_parallelism_config = MimoParallelismConfig(
             module_parallelisms={
-                "llm": ModuleParallelismConfig(
+                "language": ModuleParallelismConfig(
                     tensor_model_parallel_size=2,
                     data_parallel_size=2,
                 ),
@@ -153,7 +152,7 @@ class TestMimoModelProvider:
         mock_grid.rank_offset = 0
         mock_grid.size = 4
         mock_grid.get_pg.return_value = MagicMock()
-        mock_build_grids.return_value = {"llm": mock_grid}
+        mock_build_grids.return_value = {"language": mock_grid}
 
         provider = MimoModelProvider(
             language_model_spec=language_spec,
@@ -167,9 +166,9 @@ class TestMimoModelProvider:
 
         # Should return populated infrastructure
         assert isinstance(infra, MimoModelInfra)
-        assert "llm" in infra.module_to_grid_map
-        assert "llm" in infra.pg_collections
-        assert "llm" in infra.participating_modules
+        assert "language" in infra.module_to_grid_map
+        assert "language" in infra.pg_collections
+        assert "language" in infra.participating_modules
 
     @patch("torch.distributed.new_group")
     @patch("torch.distributed.get_process_group_ranks")
@@ -184,7 +183,7 @@ class TestMimoModelProvider:
 
         mimo_parallelism_config = MimoParallelismConfig(
             module_parallelisms={
-                "llm": ModuleParallelismConfig(tensor_model_parallel_size=2, data_parallel_size=1, rank_offset=0),
+                "language": ModuleParallelismConfig(tensor_model_parallel_size=2, data_parallel_size=1, rank_offset=0),
             },
         )
 
@@ -192,7 +191,7 @@ class TestMimoModelProvider:
         mock_grid.rank_offset = 0
         mock_grid.size = 2
         mock_grid.get_pg.return_value = MagicMock()
-        mock_build_grids.return_value = {"llm": mock_grid}
+        mock_build_grids.return_value = {"language": mock_grid}
 
         provider = MimoModelProvider(
             language_model_spec=language_spec,
@@ -222,7 +221,7 @@ class TestMimoModelProvider:
 
         mimo_parallelism_config = MimoParallelismConfig(
             module_parallelisms={
-                "llm": ModuleParallelismConfig(
+                "language": ModuleParallelismConfig(
                     tensor_model_parallel_size=2,
                     data_parallel_size=2,
                 ),
@@ -233,7 +232,7 @@ class TestMimoModelProvider:
         mock_grid.rank_offset = 0
         mock_grid.size = 4
         mock_grid.get_pg.return_value = MagicMock()
-        mock_build_grids.return_value = {"llm": mock_grid}
+        mock_build_grids.return_value = {"language": mock_grid}
 
         provider = MimoModelProvider(
             language_model_spec=language_spec,
@@ -248,13 +247,12 @@ class TestMimoModelProvider:
         # Should return model directly
         assert model == mock_model_instance
         config_arg = mock_mimo_model.call_args[0][0]
-        assert config_arg.module_to_grid_map == {"llm": mock_grid}
-        assert config_arg.language_module_key == "llm"
+        assert config_arg.module_to_grid_map == {"language": mock_grid}
 
         # Infrastructure should be available via build_infra()
         infra = provider.build_infra()
-        assert "llm" in infra.module_to_grid_map
-        assert "llm" in infra.pg_collections
+        assert "language" in infra.module_to_grid_map
+        assert "language" in infra.pg_collections
 
     def test_inject_pg_collection_into_language_spec(self):
         """Test that pg_collection is injected into language specs."""
@@ -328,7 +326,7 @@ class TestMimoModelProvider:
 
         mimo_parallelism_config = MimoParallelismConfig(
             module_parallelisms={
-                "llm": ModuleParallelismConfig(tensor_model_parallel_size=8, data_parallel_size=1),
+                "language": ModuleParallelismConfig(tensor_model_parallel_size=8, data_parallel_size=1),
                 "clip_encoder": ModuleParallelismConfig(tensor_model_parallel_size=2, data_parallel_size=1),
                 "dino_encoder": ModuleParallelismConfig(tensor_model_parallel_size=4, data_parallel_size=1),
             },
@@ -351,7 +349,7 @@ class TestMimoModelProvider:
         dino_grid.get_pg.return_value = MagicMock()
 
         mock_build_grids.return_value = {
-            "llm": llm_grid,
+            "language": llm_grid,
             "clip_encoder": clip_grid,
             "dino_encoder": dino_grid,
         }
@@ -379,7 +377,7 @@ class TestMimoModelProvider:
         mock_build_grids.assert_called_with(mimo_parallelism_config)
 
         # Should have pg_collections for all modules
-        assert "llm" in infra.pg_collections
+        assert "language" in infra.pg_collections
         assert "clip_encoder" in infra.pg_collections
         assert "dino_encoder" in infra.pg_collections
 
@@ -436,10 +434,10 @@ class TestMimoModelInfra:
 
     def test_infra_initialization(self):
         """Test infrastructure dataclass initializes correctly."""
-        grids = {"llm": MagicMock()}
-        topology = {"llm": []}
-        pg_collections = {"llm": MagicMock()}
-        participating = ["llm"]
+        grids = {"language": MagicMock()}
+        topology = {"language": []}
+        pg_collections = {"language": MagicMock()}
+        participating = ["language"]
 
         infra = MimoModelInfra(
             module_to_grid_map=grids,
@@ -593,7 +591,7 @@ class TestProcessGroupCollectionWithEmbeddingGroups:
         language_spec = ModuleSpec(module=Mock, params={"config": Mock()})
         mimo_parallelism_config = MimoParallelismConfig(
             module_parallelisms={
-                "llm": ModuleParallelismConfig(tensor_model_parallel_size=2, data_parallel_size=2),
+                "language": ModuleParallelismConfig(tensor_model_parallel_size=2, data_parallel_size=2),
             },
         )
 
@@ -608,11 +606,11 @@ class TestProcessGroupCollectionWithEmbeddingGroups:
             mimo_parallelism_config=mimo_parallelism_config,
         )
 
-        pg_collections = provider._get_pg_collections_from_grids({"llm": mock_grid})
+        pg_collections = provider._get_pg_collections_from_grids({"language": mock_grid})
 
         # First stage should have pos_embd but not embd (not last stage)
-        assert pg_collections["llm"].pos_embd == mock_pos_embd
-        assert pg_collections["llm"].embd == mock_embd  # First stage gets embd too
+        assert pg_collections["language"].pos_embd == mock_pos_embd
+        assert pg_collections["language"].embd == mock_embd  # First stage gets embd too
 
     @patch("megatron.bridge.models.mimo.mimo_provider.is_pp_last_stage")
     @patch("megatron.bridge.models.mimo.mimo_provider.is_pp_first_stage")
@@ -632,7 +630,7 @@ class TestProcessGroupCollectionWithEmbeddingGroups:
         language_spec = ModuleSpec(module=Mock, params={"config": Mock()})
         mimo_parallelism_config = MimoParallelismConfig(
             module_parallelisms={
-                "llm": ModuleParallelismConfig(tensor_model_parallel_size=2, data_parallel_size=2),
+                "language": ModuleParallelismConfig(tensor_model_parallel_size=2, data_parallel_size=2),
             },
         )
 
@@ -647,11 +645,11 @@ class TestProcessGroupCollectionWithEmbeddingGroups:
             mimo_parallelism_config=mimo_parallelism_config,
         )
 
-        pg_collections = provider._get_pg_collections_from_grids({"llm": mock_grid})
+        pg_collections = provider._get_pg_collections_from_grids({"language": mock_grid})
 
         # Middle stage should have neither embedding group
-        assert pg_collections["llm"].pos_embd is None
-        assert pg_collections["llm"].embd is None
+        assert pg_collections["language"].pos_embd is None
+        assert pg_collections["language"].embd is None
 
     @patch("megatron.bridge.models.mimo.mimo_provider.is_pp_last_stage")
     @patch("megatron.bridge.models.mimo.mimo_provider.is_pp_first_stage")
@@ -667,7 +665,7 @@ class TestProcessGroupCollectionWithEmbeddingGroups:
         language_spec = ModuleSpec(module=Mock, params={"config": Mock()})
         mimo_parallelism_config = MimoParallelismConfig(
             module_parallelisms={
-                "llm": ModuleParallelismConfig(tensor_model_parallel_size=2, data_parallel_size=2),
+                "language": ModuleParallelismConfig(tensor_model_parallel_size=2, data_parallel_size=2),
             },
         )
 
@@ -701,9 +699,9 @@ class TestProcessGroupCollectionWithEmbeddingGroups:
             mimo_parallelism_config=mimo_parallelism_config,
         )
 
-        pg_collections = provider._get_pg_collections_from_grids({"llm": mock_grid})
+        pg_collections = provider._get_pg_collections_from_grids({"language": mock_grid})
 
-        pgc = pg_collections["llm"]
+        pgc = pg_collections["language"]
         assert pgc.tp == mock_tp
         assert pgc.dp == mock_dp
         assert pgc.pp == mock_pp

--- a/tests/unit_tests/training/mimo/__init__.py
+++ b/tests/unit_tests/training/mimo/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+"""Unit tests for MIMO training modules."""

--- a/tests/unit_tests/training/mimo/test_mimo_checkpointing.py
+++ b/tests/unit_tests/training/mimo/test_mimo_checkpointing.py
@@ -1,0 +1,1159 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+"""Unit tests for MiMo checkpoint saving and loading wiring.
+
+Tests validate that MiMo training correctly uses shared checkpoint helpers
+(save_checkpoint_and_time, checkpoint_and_decide_exit, load_checkpoint) with
+the right arguments, without actually saving/loading checkpoints.
+"""
+
+from __future__ import annotations
+
+import inspect
+import time
+from types import SimpleNamespace
+from typing import Any, Dict
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_scheduler_mock() -> MagicMock:
+    """Create a scheduler mock that supports param_groups[0] access."""
+    sched = MagicMock()
+    sched.optimizer.param_groups = [{"lr": 1e-4}]
+    sched.get_lr.return_value = 1e-4
+    return sched
+
+
+def _make_mimo_infra(*, num_active_pgs: int = 1) -> Mock:
+    """Create a mock MimoModelInfra with the given number of active PG collections."""
+    infra = Mock()
+    pgs: Dict[str, Any] = {}
+    for i in range(num_active_pgs):
+        pgs[f"module_{i}"] = Mock()
+    infra.pg_collections = pgs
+    infra.module_to_grid_map = {"llm": Mock()}
+    infra.topology = Mock()
+    return infra
+
+
+def _make_global_state(
+    *,
+    save_interval: int | None = 10,
+    save_dir: str | None = "/tmp/ckpt",
+    train_iters: int = 100,
+    step: int = 0,
+    non_persistent_save_interval: int | None = None,
+    exit_signal_handler: bool = False,
+    exit_duration_in_mins: float | None = None,
+    exit_interval: int | None = None,
+) -> SimpleNamespace:
+    """Create a minimal GlobalState-like namespace for train_mimo tests."""
+    timer_handle = Mock()
+    timers = Mock(return_value=timer_handle)
+    timers.log = Mock()
+
+    state = SimpleNamespace(
+        timers=timers,
+        energy_monitor=None,
+        cfg=SimpleNamespace(
+            train=SimpleNamespace(
+                train_iters=train_iters,
+                micro_batch_size=1,
+                exit_signal_handler=exit_signal_handler,
+                exit_duration_in_mins=exit_duration_in_mins,
+                exit_interval=exit_interval,
+                eval_interval=None,
+            ),
+            dataset=SimpleNamespace(seq_length=128),
+            checkpoint=SimpleNamespace(
+                save=save_dir,
+                save_interval=save_interval,
+                non_persistent_save_interval=non_persistent_save_interval,
+                async_save=False,
+            ),
+            ddp=SimpleNamespace(use_megatron_fsdp=False, overlap_param_gather=True),
+            optimizer=SimpleNamespace(use_distributed_optimizer=True),
+            model=SimpleNamespace(fp8=None, seq_length=128),
+            logger=SimpleNamespace(
+                log_progress=False,
+                skip_train_metrics_log=True,
+                timing_log_level=0,
+                timing_log_option="minmax",
+                log_timers_to_tensorboard=False,
+                log_interval=1,
+            ),
+            profiling=None,
+            data_parallel_size=1,
+        ),
+        train_state=SimpleNamespace(
+            step=step,
+            consumed_train_samples=0,
+            floating_point_operations_so_far=0,
+        ),
+        start_time=time.time(),
+        signal_handler=Mock(),
+        nvrx_straggler_manager=None,
+        tensorboard_logger=None,
+        wandb_logger=None,
+    )
+    state.signal_handler.signals_received.return_value = []
+    return state
+
+
+# ---------------------------------------------------------------------------
+# Tests: pg_collection forwarding in shared helpers
+# ---------------------------------------------------------------------------
+
+
+class TestPgCollectionForwarding:
+    """Verify save_checkpoint_and_time and checkpoint_and_decide_exit
+    forward pg_collection to save_checkpoint."""
+
+    @patch("megatron.bridge.training.train.force_param_sync")
+    @patch("megatron.bridge.training.train.should_disable_forward_pre_hook", return_value=False)
+    @patch("megatron.bridge.training.train.save_checkpoint")
+    def test_save_checkpoint_and_time_forwards_pg_collection(
+        self,
+        mock_save_checkpoint,
+        mock_should_disable,
+        mock_force_param_sync,
+    ):
+        from megatron.bridge.training.train import save_checkpoint_and_time
+
+        state = _make_global_state()
+        pg = Mock()
+
+        save_checkpoint_and_time(
+            state=state,
+            model=[Mock()],
+            optimizer=Mock(),
+            opt_param_scheduler=Mock(),
+            num_floating_point_operations_so_far=0,
+            checkpointing_context={},
+            pg_collection=pg,
+        )
+
+        _, kwargs = mock_save_checkpoint.call_args
+        assert kwargs["pg_collection"] is pg
+
+    @patch("megatron.bridge.training.train.force_param_sync")
+    @patch("megatron.bridge.training.train.should_disable_forward_pre_hook", return_value=False)
+    @patch("megatron.bridge.training.train.save_checkpoint")
+    def test_save_checkpoint_and_time_defaults_pg_collection_to_none(
+        self,
+        mock_save_checkpoint,
+        mock_should_disable,
+        mock_force_param_sync,
+    ):
+        from megatron.bridge.training.train import save_checkpoint_and_time
+
+        state = _make_global_state()
+
+        save_checkpoint_and_time(
+            state=state,
+            model=[Mock()],
+            optimizer=Mock(),
+            opt_param_scheduler=Mock(),
+            num_floating_point_operations_so_far=0,
+            checkpointing_context={},
+        )
+
+        _, kwargs = mock_save_checkpoint.call_args
+        assert kwargs["pg_collection"] is None
+
+    @patch("megatron.bridge.training.train.save_checkpoint_and_time")
+    @patch("megatron.bridge.training.train.barrier_and_log")
+    @patch("megatron.bridge.training.train.check_nvrx_straggler_detection", return_value=False)
+    def test_checkpoint_and_decide_exit_forwards_pg_collection(
+        self,
+        mock_check_nvrx,
+        mock_barrier_log,
+        mock_save_and_time,
+    ):
+        from megatron.bridge.training.train import checkpoint_and_decide_exit
+
+        state = _make_global_state(save_interval=5, step=10)
+        pg = Mock()
+
+        checkpoint_and_decide_exit(
+            state=state,
+            model=[Mock()],
+            optimizer=Mock(),
+            opt_param_scheduler=Mock(),
+            num_floating_point_operations_so_far=0,
+            checkpointing_context={},
+            train_data_iterator=None,
+            pg_collection=pg,
+        )
+
+        _, kwargs = mock_save_and_time.call_args
+        assert kwargs["pg_collection"] is pg
+
+
+# ---------------------------------------------------------------------------
+# Tests: pretrain_mimo setup wiring
+# ---------------------------------------------------------------------------
+
+
+class TestPretrainMimoSetup:
+    """Verify pretrain_mimo properly initializes checkpointing runtime."""
+
+    @patch("megatron.bridge.training.pretrain_mimo.init_checkpointing_context")
+    @patch("megatron.bridge.training.pretrain_mimo.MultiModulePipelineCommunicator")
+    @patch("megatron.bridge.training.pretrain_mimo.get_model_config")
+    @patch("megatron.bridge.training.pretrain_mimo.validate_no_stub_ranks")
+    @patch("megatron.bridge.training.pretrain_mimo.build_pg_collection_for_schedule")
+    @patch("megatron.bridge.training.pretrain_mimo.get_module_to_grid_tuple")
+    @patch("torch.distributed.all_reduce")
+    @patch("torch.distributed.get_rank", return_value=0)
+    @patch("torch.distributed.get_world_size", return_value=2)
+    def test_setup_mimo_initializes_checkpointing_context(
+        self,
+        mock_world_size,
+        mock_get_rank,
+        mock_all_reduce,
+        mock_get_grid,
+        mock_build_pg,
+        mock_validate,
+        mock_get_config,
+        mock_communicator,
+        mock_init_ctx,
+    ):
+        from megatron.bridge.training.pretrain_mimo import setup_mimo
+
+        mock_init_ctx.return_value = {"test": "context"}
+
+        model_config = Mock()
+        model_config.pipeline_dtype = None
+        model_config.bf16 = True
+        mock_get_config.return_value = model_config
+
+        global_state = Mock()
+        global_state.start_time = time.time()
+        global_state.cfg = None
+
+        cfg = Mock()
+        cfg.checkpoint = Mock()
+        cfg.train = Mock()
+        cfg.train.grad_reduce_in_fp32 = False
+        cfg.train.overlap_grad_reduce = True
+        cfg.train.use_distributed_optimizer = False
+        cfg.train.check_for_nan_in_grad = False
+        cfg.model = Mock()
+        cfg.model.fp16 = False
+        cfg.model.bf16 = True
+
+        provider = Mock()
+        infra = Mock()
+        infra.module_to_grid_map = {"llm": Mock()}
+        infra.topology = Mock()
+        infra.pg_collections = {"llm": Mock()}
+        provider.build_infra.return_value = infra
+        provider.provide_distributed_model.return_value = [Mock()]
+
+        result = setup_mimo(cfg, provider, global_state=global_state)
+
+        mock_init_ctx.assert_called_once_with(cfg.checkpoint)
+        global_state.initialize_async_checkpoint_worker.assert_called_once()
+        assert result.checkpointing_context == {"test": "context"}
+
+    def test_rampup_guard_rejects_rampup_batch_size(self):
+        from megatron.bridge.training.pretrain_mimo import pretrain_mimo
+
+        cfg = Mock()
+        cfg.train.rampup_batch_size = [100, 200, 300]
+
+        with pytest.raises(AssertionError, match="Microbatch rampup is not supported"):
+            pretrain_mimo(
+                cfg=cfg,
+                mimo_provider=Mock(),
+                forward_step_func=Mock(),
+                build_data_iterators_fn=Mock(),
+                opt_config=Mock(),
+            )
+
+
+# ---------------------------------------------------------------------------
+# Tests: non-colocated runtime guard
+# ---------------------------------------------------------------------------
+
+
+class TestNonColocatedGuard:
+    """Verify the non-colocated topology assertion in train_mimo."""
+
+    @patch("megatron.bridge.training.train_mimo.build_pg_collection_for_schedule", return_value=Mock(spec=[]))
+    @patch("megatron.bridge.training.train_mimo.get_module_to_grid_tuple")
+    @patch("megatron.bridge.training.train_mimo.get_model_config")
+    @patch("megatron.bridge.training.train_mimo.prepare_forward_step_func")
+    @patch("megatron.bridge.training.train_mimo.get_num_microbatches", return_value=1)
+    @patch("torch.distributed.get_rank", return_value=0)
+    def test_rejects_multiple_active_pgs(self, *_mocks):
+        from megatron.bridge.training.train_mimo import train_mimo
+
+        infra = _make_mimo_infra(num_active_pgs=2)
+        state = _make_global_state(train_iters=0)
+
+        with pytest.raises(AssertionError, match="exactly one active ProcessGroupCollection"):
+            train_mimo(
+                forward_step_func=Mock(),
+                model=Mock(),
+                optimizer=Mock(),
+                schedulers={},
+                train_data_iterator=Mock(),
+                valid_data_iterator=None,
+                global_state=state,
+                mimo_infra=infra,
+                multimodule_communicator=Mock(),
+                checkpointing_context={},
+            )
+
+    @patch("megatron.bridge.training.train_mimo.build_pg_collection_for_schedule", return_value=Mock(spec=[]))
+    @patch("megatron.bridge.training.train_mimo.get_module_to_grid_tuple")
+    @patch("megatron.bridge.training.train_mimo.get_model_config")
+    @patch("megatron.bridge.training.train_mimo.prepare_forward_step_func")
+    @patch("megatron.bridge.training.train_mimo.get_num_microbatches", return_value=1)
+    @patch("torch.distributed.get_rank", return_value=0)
+    def test_rejects_zero_active_pgs(self, *_mocks):
+        from megatron.bridge.training.train_mimo import train_mimo
+
+        infra = _make_mimo_infra(num_active_pgs=0)
+        state = _make_global_state(train_iters=0)
+
+        with pytest.raises(AssertionError, match="exactly one active ProcessGroupCollection"):
+            train_mimo(
+                forward_step_func=Mock(),
+                model=Mock(),
+                optimizer=Mock(),
+                schedulers={},
+                train_data_iterator=Mock(),
+                valid_data_iterator=None,
+                global_state=state,
+                mimo_infra=infra,
+                multimodule_communicator=Mock(),
+                checkpointing_context={},
+            )
+
+
+# ---------------------------------------------------------------------------
+# Tests: checkpoint_and_decide_exit integration in train_mimo
+# ---------------------------------------------------------------------------
+
+
+class TestTrainMimoCheckpointIntegration:
+    """Verify train_mimo calls checkpoint_and_decide_exit with the right args."""
+
+    @patch("megatron.bridge.training.train_mimo.checkpoint_and_decide_exit", return_value=False)
+    @patch("megatron.bridge.training.train_mimo.maybe_finalize_async_save")
+    @patch("megatron.bridge.training.train_mimo.train_step_mimo")
+    @patch("megatron.bridge.training.train_mimo.build_pg_collection_for_schedule")
+    @patch("megatron.bridge.training.train_mimo.get_module_to_grid_tuple")
+    @patch("megatron.bridge.training.train_mimo.get_model_config")
+    @patch("megatron.bridge.training.train_mimo.prepare_forward_step_func")
+    @patch("megatron.bridge.training.train_mimo.get_num_microbatches", return_value=1)
+    @patch("torch.distributed.get_rank", return_value=0)
+    @patch("torch.distributed.get_world_size", return_value=1)
+    def test_calls_checkpoint_and_decide_exit_with_pg_collection(
+        self,
+        mock_world_size,
+        mock_rank,
+        mock_num_mb,
+        mock_prep_fwd,
+        mock_get_config,
+        mock_get_grid,
+        mock_build_pg,
+        mock_train_step,
+        mock_async_finalize,
+        mock_ckpt_exit,
+    ):
+        from megatron.bridge.training.train_mimo import train_mimo
+
+        mock_train_step.return_value = ({}, 0, 0.0, 0)
+        mock_config = Mock()
+        mock_config.variable_seq_lengths = True
+        mock_get_config.return_value = mock_config
+
+        pg = Mock()
+        infra = Mock()
+        infra.pg_collections = {"llm": pg}
+        infra.module_to_grid_map = {"llm": Mock()}
+        infra.topology = Mock()
+
+        mock_build_pg.return_value = Mock(spec=[])  # not a list
+
+        state = _make_global_state(train_iters=1, step=0)
+        ctx = {"key": "value"}
+        train_iter = Mock()
+
+        train_mimo(
+            forward_step_func=Mock(),
+            model=Mock(),
+            optimizer=Mock(),
+            schedulers={"llm": _make_scheduler_mock()},
+            train_data_iterator=train_iter,
+            valid_data_iterator=None,
+            global_state=state,
+            mimo_infra=infra,
+            multimodule_communicator=Mock(),
+            checkpointing_context=ctx,
+        )
+
+        mock_ckpt_exit.assert_called_once()
+        _, kwargs = mock_ckpt_exit.call_args
+        assert kwargs["pg_collection"] is pg
+        assert kwargs["checkpointing_context"] is ctx
+        assert kwargs["train_data_iterator"] is train_iter
+        assert kwargs["num_floating_point_operations_so_far"] == 0
+
+    @patch("megatron.bridge.training.train_mimo.checkpoint_and_decide_exit", return_value=True)
+    @patch("megatron.bridge.training.train_mimo.maybe_finalize_async_save")
+    @patch("megatron.bridge.training.train_mimo.train_step_mimo")
+    @patch("megatron.bridge.training.train_mimo.build_pg_collection_for_schedule")
+    @patch("megatron.bridge.training.train_mimo.get_module_to_grid_tuple")
+    @patch("megatron.bridge.training.train_mimo.get_model_config")
+    @patch("megatron.bridge.training.train_mimo.prepare_forward_step_func")
+    @patch("megatron.bridge.training.train_mimo.get_num_microbatches", return_value=1)
+    @patch("torch.distributed.get_rank", return_value=0)
+    @patch("torch.distributed.get_world_size", return_value=1)
+    def test_exits_loop_when_checkpoint_and_decide_exit_returns_true(
+        self,
+        mock_world_size,
+        mock_rank,
+        mock_num_mb,
+        mock_prep_fwd,
+        mock_get_config,
+        mock_get_grid,
+        mock_build_pg,
+        mock_train_step,
+        mock_async_finalize,
+        mock_ckpt_exit,
+    ):
+        from megatron.bridge.training.train_mimo import train_mimo
+
+        mock_train_step.return_value = ({}, 0, 0.0, 0)
+        mock_config = Mock()
+        mock_config.variable_seq_lengths = True
+        mock_get_config.return_value = mock_config
+
+        infra = Mock()
+        infra.pg_collections = {"llm": Mock()}
+        infra.module_to_grid_map = {"llm": Mock()}
+        infra.topology = Mock()
+        mock_build_pg.return_value = Mock(spec=[])
+
+        state = _make_global_state(train_iters=100, step=0)
+
+        train_mimo(
+            forward_step_func=Mock(),
+            model=Mock(),
+            optimizer=Mock(),
+            schedulers={"llm": _make_scheduler_mock()},
+            train_data_iterator=Mock(),
+            valid_data_iterator=None,
+            global_state=state,
+            mimo_infra=infra,
+            multimodule_communicator=Mock(),
+            checkpointing_context={},
+        )
+
+        # Should have exited after 1 iteration, not 100
+        assert mock_train_step.call_count == 1
+        assert state.train_state.step == 1
+
+    @patch("megatron.bridge.training.train_mimo.checkpoint_and_decide_exit", return_value=False)
+    @patch("megatron.bridge.training.train_mimo.maybe_finalize_async_save")
+    @patch("megatron.bridge.training.train_mimo.train_step_mimo")
+    @patch("megatron.bridge.training.train_mimo.build_pg_collection_for_schedule")
+    @patch("megatron.bridge.training.train_mimo.get_module_to_grid_tuple")
+    @patch("megatron.bridge.training.train_mimo.get_model_config")
+    @patch("megatron.bridge.training.train_mimo.prepare_forward_step_func")
+    @patch("megatron.bridge.training.train_mimo.get_num_microbatches", return_value=1)
+    @patch("torch.distributed.get_rank", return_value=0)
+    @patch("torch.distributed.get_world_size", return_value=1)
+    def test_async_finalize_called_at_top_of_loop(
+        self,
+        mock_world_size,
+        mock_rank,
+        mock_num_mb,
+        mock_prep_fwd,
+        mock_get_config,
+        mock_get_grid,
+        mock_build_pg,
+        mock_train_step,
+        mock_async_finalize,
+        mock_ckpt_exit,
+    ):
+        from megatron.bridge.training.train_mimo import train_mimo
+
+        mock_train_step.return_value = ({}, 0, 0.0, 0)
+        mock_config = Mock()
+        mock_config.variable_seq_lengths = True
+        mock_get_config.return_value = mock_config
+
+        infra = Mock()
+        infra.pg_collections = {"llm": Mock()}
+        infra.module_to_grid_map = {"llm": Mock()}
+        infra.topology = Mock()
+        mock_build_pg.return_value = Mock(spec=[])
+
+        state = _make_global_state(train_iters=2, step=0)
+
+        train_mimo(
+            forward_step_func=Mock(),
+            model=Mock(),
+            optimizer=Mock(),
+            schedulers={"llm": _make_scheduler_mock()},
+            train_data_iterator=Mock(),
+            valid_data_iterator=None,
+            global_state=state,
+            mimo_infra=infra,
+            multimodule_communicator=Mock(),
+            checkpointing_context={},
+        )
+
+        # 2 non-blocking calls (top of each iteration) + 1 blocking call (shutdown)
+        assert mock_async_finalize.call_count == 3
+
+        non_blocking_calls = [
+            c for c in mock_async_finalize.call_args_list if c.kwargs.get("blocking") is False
+        ]
+        blocking_calls = [
+            c for c in mock_async_finalize.call_args_list if c.kwargs.get("blocking") is True
+        ]
+        assert len(non_blocking_calls) == 2
+        assert len(blocking_calls) == 1
+        assert blocking_calls[0].kwargs.get("terminate") is True
+
+    @patch("megatron.bridge.training.train_mimo.checkpoint_and_decide_exit", return_value=False)
+    @patch("megatron.bridge.training.train_mimo.maybe_finalize_async_save")
+    @patch("megatron.bridge.training.train_mimo.train_step_mimo")
+    @patch("megatron.bridge.training.train_mimo.build_pg_collection_for_schedule")
+    @patch("megatron.bridge.training.train_mimo.get_module_to_grid_tuple")
+    @patch("megatron.bridge.training.train_mimo.get_model_config")
+    @patch("megatron.bridge.training.train_mimo.prepare_forward_step_func")
+    @patch("megatron.bridge.training.train_mimo.get_num_microbatches", return_value=1)
+    @patch("torch.distributed.get_rank", return_value=0)
+    @patch("torch.distributed.get_world_size", return_value=1)
+    def test_no_inline_save_checkpoint_call(
+        self,
+        mock_world_size,
+        mock_rank,
+        mock_num_mb,
+        mock_prep_fwd,
+        mock_get_config,
+        mock_get_grid,
+        mock_build_pg,
+        mock_train_step,
+        mock_async_finalize,
+        mock_ckpt_exit,
+    ):
+        """Verify there is no inline save_checkpoint call — all saves go through
+        checkpoint_and_decide_exit."""
+        from megatron.bridge.training.train_mimo import train_mimo
+
+        mock_train_step.return_value = ({}, 0, 0.0, 0)
+        mock_config = Mock()
+        mock_config.variable_seq_lengths = True
+        mock_get_config.return_value = mock_config
+
+        infra = Mock()
+        infra.pg_collections = {"llm": Mock()}
+        infra.module_to_grid_map = {"llm": Mock()}
+        infra.topology = Mock()
+        mock_build_pg.return_value = Mock(spec=[])
+
+        state = _make_global_state(save_interval=1, train_iters=3, step=0)
+
+        with patch("megatron.bridge.training.train_mimo.save_checkpoint_and_time") as mock_direct_save:
+            train_mimo(
+                forward_step_func=Mock(),
+                model=Mock(),
+                optimizer=Mock(),
+                schedulers={"llm": _make_scheduler_mock()},
+                train_data_iterator=Mock(),
+                valid_data_iterator=None,
+                global_state=state,
+                mimo_infra=infra,
+                multimodule_communicator=Mock(),
+                checkpointing_context={},
+            )
+
+            # save_checkpoint_and_time should NOT be called directly from train_mimo.
+            # All saves should go through checkpoint_and_decide_exit.
+            mock_direct_save.assert_not_called()
+
+        # But checkpoint_and_decide_exit should have been called
+        assert mock_ckpt_exit.call_count == 3
+
+
+# ---------------------------------------------------------------------------
+# Helpers for load-side tests
+# ---------------------------------------------------------------------------
+
+
+def _make_setup_output_for_load(
+    *,
+    pg_collections: Dict[str, Any] | None = None,
+    train_state_step: int = 0,
+    consumed_train_samples: int = 0,
+    floating_point_operations_so_far: int = 0,
+) -> SimpleNamespace:
+    """Create a MimoSetupOutput-like namespace suitable for pretrain_mimo load tests."""
+    if pg_collections is None:
+        pg_collections = {"llm": Mock()}
+
+    train_state = SimpleNamespace(
+        step=train_state_step,
+        consumed_train_samples=consumed_train_samples,
+        floating_point_operations_so_far=floating_point_operations_so_far,
+    )
+    timers_handle = Mock()
+    timers = Mock(return_value=timers_handle)
+    timers.log = Mock()
+
+    global_state = Mock()
+    global_state.timers = timers
+    global_state.train_state = train_state
+
+    return SimpleNamespace(
+        model=MagicMock(),
+        mimo_infra=SimpleNamespace(
+            module_to_grid_map={"llm": Mock()},
+            pg_collections=pg_collections,
+            topology=Mock(),
+        ),
+        multimodule_communicator=MagicMock(),
+        train_data_iterator=None,
+        valid_data_iterator=None,
+        global_state=global_state,
+        checkpointing_context={"test": "context"},
+    )
+
+
+def _make_pretrain_cfg(
+    *,
+    load_path: str | None = None,
+    pretrained_path: str | None = None,
+    non_persistent_ckpt_type: str | None = None,
+) -> MagicMock:
+    """Create a ConfigContainer-like mock for pretrain_mimo tests."""
+    cfg = MagicMock()
+    cfg.train = SimpleNamespace(
+        rampup_batch_size=None,
+        global_batch_size=1,
+        micro_batch_size=1,
+        decrease_batch_size_if_needed=False,
+    )
+    cfg.data_parallel_size = 1
+    cfg.checkpoint = SimpleNamespace(
+        load=load_path,
+        pretrained_checkpoint=pretrained_path,
+        non_persistent_ckpt_type=non_persistent_ckpt_type,
+    )
+    cfg.scheduler = SimpleNamespace(
+        lr_warmup_init=0.0,
+        lr_warmup_steps=0,
+        lr_decay_steps=100,
+        lr_decay_style="linear",
+        start_weight_decay=0.0,
+        end_weight_decay=0.0,
+        wd_incr_steps=0,
+        weight_decay_incr_style="constant",
+        use_checkpoint_opt_param_scheduler=False,
+        override_opt_param_scheduler=False,
+        wsd_decay_steps=None,
+        lr_wsd_decay_style=None,
+    )
+    return cfg
+
+
+def _run_pretrain_mimo(
+    *,
+    cfg: MagicMock | None = None,
+    setup_output: SimpleNamespace | None = None,
+    schedulers: Dict[str, Any] | None = None,
+    checkpoint_exists_return: bool = False,
+    build_data_iterators_fn: Any | None = None,
+) -> Dict[str, Mock]:
+    """Run pretrain_mimo with full mocking and return all mock handles.
+
+    Returns dict with keys: setup_mimo, load_checkpoint, checkpoint_exists,
+    train_mimo, build_data_iterators_fn, unwrap.
+    """
+    from megatron.bridge.training.pretrain_mimo import pretrain_mimo
+
+    if cfg is None:
+        cfg = _make_pretrain_cfg()
+    if setup_output is None:
+        setup_output = _make_setup_output_for_load()
+    if schedulers is None:
+        schedulers = {}
+    if build_data_iterators_fn is None:
+        build_data_iterators_fn = Mock(return_value=(iter([]), None))
+
+    mocks = {}
+
+    with (
+        patch("megatron.bridge.training.pretrain_mimo.train_mimo") as m_train,
+        patch("megatron.bridge.training.pretrain_mimo.setup_mimo", return_value=setup_output) as m_setup,
+        patch("megatron.bridge.training.pretrain_mimo.unwrap_mimo_model") as m_unwrap,
+        patch("megatron.bridge.training.pretrain_mimo.load_checkpoint") as m_load,
+        patch(
+            "megatron.bridge.training.pretrain_mimo.checkpoint_exists",
+            return_value=checkpoint_exists_return,
+        ) as m_ckpt_exists,
+        patch("megatron.bridge.training.pretrain_mimo.dist") as m_dist,
+        patch("megatron.core.num_microbatches_calculator._GLOBAL_NUM_MICROBATCHES_CALCULATOR", None),
+        patch("megatron.core.num_microbatches_calculator.init_num_microbatches_calculator"),
+        patch("megatron.core.models.mimo.optimizer.get_mimo_optimizer") as m_get_opt,
+    ):
+        m_dist.get_rank.return_value = 0
+        m_dist.get_world_size.return_value = 2
+        m_unwrap.return_value = MagicMock(
+            mimo_config=SimpleNamespace(module_to_grid_map={"llm": Mock()}, language_module_key="llm"),
+        )
+        mock_optimizer = MagicMock()
+        mock_optimizer.module_infos = {}
+        mock_optimizer.is_stub_optimizer = False
+        m_get_opt.return_value = mock_optimizer
+
+        pretrain_mimo(
+            cfg=cfg,
+            mimo_provider=MagicMock(),
+            forward_step_func=MagicMock(),
+            build_data_iterators_fn=build_data_iterators_fn,
+            opt_config=MagicMock(finalize=MagicMock(), lr=1e-4, min_lr=1e-5),
+            schedulers=schedulers,
+            global_state=setup_output.global_state,
+        )
+
+        mocks["setup_mimo"] = m_setup
+        mocks["load_checkpoint"] = m_load
+        mocks["checkpoint_exists"] = m_ckpt_exists
+        mocks["train_mimo"] = m_train
+        mocks["build_data_iterators_fn"] = build_data_iterators_fn
+        mocks["unwrap"] = m_unwrap
+
+    return mocks
+
+
+# ---------------------------------------------------------------------------
+# Tests: load_checkpoint invocation from pretrain_mimo
+# ---------------------------------------------------------------------------
+
+
+class TestPretrainMimoLoadCheckpoint:
+    """Verify pretrain_mimo invokes load_checkpoint with correct arguments."""
+
+    def test_load_invoked_when_persistent_checkpoint_exists(self):
+        cfg = _make_pretrain_cfg(load_path="/tmp/ckpt")
+        mocks = _run_pretrain_mimo(cfg=cfg, checkpoint_exists_return=True)
+        mocks["load_checkpoint"].assert_called_once()
+
+    def test_load_invoked_when_pretrained_checkpoint_exists(self):
+        cfg = _make_pretrain_cfg(pretrained_path="/tmp/pretrained")
+        mocks = _run_pretrain_mimo(cfg=cfg, checkpoint_exists_return=True)
+        mocks["load_checkpoint"].assert_called_once()
+
+    def test_load_invoked_for_non_persistent_intent_without_persistent_path(self):
+        """Non-persistent resume intent should trigger load even without cfg.checkpoint.load."""
+        cfg = _make_pretrain_cfg(non_persistent_ckpt_type="local")
+        mocks = _run_pretrain_mimo(cfg=cfg, checkpoint_exists_return=False)
+        mocks["load_checkpoint"].assert_called_once()
+
+    def test_load_not_invoked_when_no_checkpoint_intent(self):
+        cfg = _make_pretrain_cfg()
+        mocks = _run_pretrain_mimo(cfg=cfg, checkpoint_exists_return=False)
+        mocks["load_checkpoint"].assert_not_called()
+
+    def test_load_forwards_list_wrapped_model(self):
+        cfg = _make_pretrain_cfg(load_path="/tmp/ckpt")
+        setup_output = _make_setup_output_for_load()
+        mocks = _run_pretrain_mimo(
+            cfg=cfg, setup_output=setup_output, checkpoint_exists_return=True,
+        )
+        _, kwargs = mocks["load_checkpoint"].call_args
+        assert isinstance(kwargs["model"], list)
+        assert len(kwargs["model"]) == 1
+        assert kwargs["model"][0] is setup_output.model
+
+    def test_load_forwards_explicit_pg_collection(self):
+        pg = Mock()
+        setup_output = _make_setup_output_for_load(pg_collections={"llm": pg})
+        cfg = _make_pretrain_cfg(load_path="/tmp/ckpt")
+        mocks = _run_pretrain_mimo(
+            cfg=cfg, setup_output=setup_output, checkpoint_exists_return=True,
+        )
+        _, kwargs = mocks["load_checkpoint"].call_args
+        assert kwargs["pg_collection"] is pg
+
+    def test_load_forwards_checkpointing_context(self):
+        setup_output = _make_setup_output_for_load()
+        cfg = _make_pretrain_cfg(load_path="/tmp/ckpt")
+        mocks = _run_pretrain_mimo(
+            cfg=cfg, setup_output=setup_output, checkpoint_exists_return=True,
+        )
+        _, kwargs = mocks["load_checkpoint"].call_args
+        assert kwargs["checkpointing_context"] is setup_output.checkpointing_context
+
+    def test_load_forwards_first_scheduler(self):
+        sched_a = _make_scheduler_mock()
+        sched_b = _make_scheduler_mock()
+        schedulers = {"llm": sched_a, "vision": sched_b}
+        cfg = _make_pretrain_cfg(load_path="/tmp/ckpt")
+        mocks = _run_pretrain_mimo(
+            cfg=cfg, schedulers=schedulers, checkpoint_exists_return=True,
+        )
+        _, kwargs = mocks["load_checkpoint"].call_args
+        assert kwargs["opt_param_scheduler"] is sched_a
+
+
+# ---------------------------------------------------------------------------
+# Tests: non-colocated PG guard in pretrain_mimo load path
+# ---------------------------------------------------------------------------
+
+
+class TestPretrainMimoLoadPgGuard:
+    """Verify pretrain_mimo fails fast when PG topology is invalid."""
+
+    def test_rejects_zero_active_pgs_in_pretrain(self):
+        setup_output = _make_setup_output_for_load(pg_collections={})
+        cfg = _make_pretrain_cfg(load_path="/tmp/ckpt")
+        with pytest.raises(AssertionError, match="exactly one active ProcessGroupCollection"):
+            _run_pretrain_mimo(
+                cfg=cfg, setup_output=setup_output, checkpoint_exists_return=True,
+            )
+
+    def test_rejects_multiple_active_pgs_in_pretrain(self):
+        setup_output = _make_setup_output_for_load(
+            pg_collections={"llm": Mock(), "vision": Mock()},
+        )
+        cfg = _make_pretrain_cfg(load_path="/tmp/ckpt")
+        with pytest.raises(AssertionError, match="exactly one active ProcessGroupCollection"):
+            _run_pretrain_mimo(
+                cfg=cfg, setup_output=setup_output, checkpoint_exists_return=True,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Tests: scheduler v1 fanout behavior
+# ---------------------------------------------------------------------------
+
+
+class TestSchedulerV1Fanout:
+    """Verify scheduler state is loaded into first_scheduler and fanned out."""
+
+    def test_scheduler_fanout_after_load(self):
+        """After load, all schedulers should have the state of first_scheduler."""
+        sched_a = MagicMock()
+        sched_a.optimizer.param_groups = [{"lr": 1e-4}]
+        sched_a.state_dict.return_value = {"step": 50, "lr": 0.001}
+
+        sched_b = MagicMock()
+        sched_b.optimizer.param_groups = [{"lr": 1e-4}]
+
+        schedulers = {"llm": sched_a, "vision": sched_b}
+        cfg = _make_pretrain_cfg(load_path="/tmp/ckpt")
+
+        # Simulate load succeeding and setting step > 0 via side_effect.
+        # load_checkpoint modifies global_state.train_state in-place, but
+        # in mock context it doesn't. We need step to remain 0 so iterator
+        # builder doesn't require train_state kwarg.
+        _run_pretrain_mimo(cfg=cfg, schedulers=schedulers, checkpoint_exists_return=True)
+
+        # sched_b should have received the fanout
+        sched_b.load_state_dict.assert_called_once_with({"step": 50, "lr": 0.001})
+        # sched_a should NOT have load_state_dict called by fanout (it's the source)
+        sched_a.load_state_dict.assert_not_called()
+
+    def test_no_fanout_when_single_scheduler(self):
+        sched = MagicMock()
+        sched.optimizer.param_groups = [{"lr": 1e-4}]
+        sched.state_dict.return_value = {"step": 50}
+
+        schedulers = {"llm": sched}
+        cfg = _make_pretrain_cfg(load_path="/tmp/ckpt")
+        _run_pretrain_mimo(cfg=cfg, schedulers=schedulers, checkpoint_exists_return=True)
+
+        # No fanout needed with single scheduler
+        sched.load_state_dict.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Tests: iterator resume semantics
+# ---------------------------------------------------------------------------
+
+
+class TestIteratorResumeSemanticsLoad:
+    """Verify iterators are built after load and receive train_state when resuming."""
+
+    def test_iterators_built_after_setup_not_during(self):
+        """setup_mimo should be called with build_data_iterators_fn=None."""
+        cfg = _make_pretrain_cfg()
+        mocks = _run_pretrain_mimo(cfg=cfg)
+        _, kwargs = mocks["setup_mimo"].call_args
+        assert kwargs["build_data_iterators_fn"] is None
+
+    def test_iterator_builder_called_without_train_state_when_not_resuming(self):
+        cfg = _make_pretrain_cfg()
+        build_fn = Mock(return_value=(iter([]), None))
+        mocks = _run_pretrain_mimo(cfg=cfg, build_data_iterators_fn=build_fn)
+        build_fn.assert_called_once()
+        args, kwargs = build_fn.call_args
+        assert "train_state" not in kwargs
+
+    def test_iterator_builder_receives_train_state_mock(self):
+        """When resuming (step > 0), builder receives train_state kwarg."""
+        build_fn = MagicMock(return_value=(iter([]), None))
+        # Give mock the train_state parameter so inspect.signature finds it
+        import types
+
+        def _sig_fn(cfg, mimo_infra, *, train_state=None):
+            pass
+
+        build_fn.__signature__ = inspect.signature(_sig_fn)
+
+        cfg = _make_pretrain_cfg(load_path="/tmp/ckpt")
+        setup_output = _make_setup_output_for_load(train_state_step=10, consumed_train_samples=500)
+
+        _run_pretrain_mimo(
+            cfg=cfg,
+            setup_output=setup_output,
+            checkpoint_exists_return=True,
+            build_data_iterators_fn=build_fn,
+        )
+
+        build_fn.assert_called_once()
+        _, kwargs = build_fn.call_args
+        assert "train_state" in kwargs
+        assert kwargs["train_state"].step == 10
+        assert kwargs["train_state"].consumed_train_samples == 500
+
+    def test_iterator_builder_fails_fast_if_no_train_state_param_on_resume(self):
+        """Resuming with a builder that lacks train_state param raises RuntimeError."""
+
+        def legacy_builder(cfg, mimo_infra):
+            return (iter([]), None)
+
+        build_fn = MagicMock(return_value=(iter([]), None))
+        build_fn.__signature__ = inspect.signature(legacy_builder)
+
+        cfg = _make_pretrain_cfg(load_path="/tmp/ckpt")
+        setup_output = _make_setup_output_for_load(train_state_step=10)
+
+        with pytest.raises(RuntimeError, match="build_data_iterators_fn does not accept"):
+            _run_pretrain_mimo(
+                cfg=cfg,
+                setup_output=setup_output,
+                checkpoint_exists_return=True,
+                build_data_iterators_fn=build_fn,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Tests: MimoOptimizer load-side compatibility
+# ---------------------------------------------------------------------------
+
+
+class TestMimoOptimizerLoadCompat:
+    """Verify MimoOptimizer load methods work correctly."""
+
+    def _make_mimo_optimizer(self):
+        from megatron.core.models.mimo.optimizer import MimoOptimizer, ModuleOptimizerInfo
+
+        opt_a = MagicMock()
+        opt_b = MagicMock()
+
+        module_infos = {
+            "llm": ModuleOptimizerInfo(optimizer=opt_a, grid=Mock(), pg_collection=Mock(), is_active=True),
+            "vision": ModuleOptimizerInfo(optimizer=opt_b, grid=Mock(), pg_collection=Mock(), is_active=True),
+        }
+        config = MagicMock()
+        return MimoOptimizer(module_infos, config), opt_a, opt_b
+
+    def test_load_state_dict_dispatches_per_module(self):
+        mimo_opt, opt_a, opt_b = self._make_mimo_optimizer()
+        state = {"llm": {"param": 1}, "vision": {"param": 2}}
+        mimo_opt.load_state_dict(state)
+        opt_a.load_state_dict.assert_called_once_with({"param": 1})
+        opt_b.load_state_dict.assert_called_once_with({"param": 2})
+
+    def test_load_state_dict_skips_missing_keys(self):
+        mimo_opt, opt_a, opt_b = self._make_mimo_optimizer()
+        state = {"llm": {"param": 1}}
+        mimo_opt.load_state_dict(state)
+        opt_a.load_state_dict.assert_called_once()
+        opt_b.load_state_dict.assert_not_called()
+
+    def test_sharded_state_dict_generates_per_module(self):
+        mimo_opt, opt_a, opt_b = self._make_mimo_optimizer()
+        opt_a.sharded_state_dict.return_value = {"a": "sharded_a"}
+        opt_b.sharded_state_dict.return_value = {"b": "sharded_b"}
+
+        result = mimo_opt.sharded_state_dict({}, is_loading=True)
+        assert "llm" in result
+        assert "vision" in result
+        assert result["llm"] == {"a": "sharded_a"}
+        assert result["vision"] == {"b": "sharded_b"}
+
+    def test_reload_model_params_delegates_to_all_active(self):
+        mimo_opt, opt_a, opt_b = self._make_mimo_optimizer()
+        mimo_opt.reload_model_params(state_dict={"model": {}})
+        opt_a.reload_model_params.assert_called_once_with({"model": {}})
+        opt_b.reload_model_params.assert_called_once_with({"model": {}})
+
+    def test_is_stub_optimizer_when_no_active(self):
+        from megatron.core.models.mimo.optimizer import MimoOptimizer, ModuleOptimizerInfo
+
+        module_infos = {
+            "llm": ModuleOptimizerInfo(optimizer=None, grid=Mock(), pg_collection=Mock(), is_active=False),
+        }
+        mimo_opt = MimoOptimizer(module_infos, MagicMock())
+        assert mimo_opt.is_stub_optimizer is True
+
+
+# ---------------------------------------------------------------------------
+# Tests: train state restoration smoke
+# ---------------------------------------------------------------------------
+
+
+class TestTrainStateRestorationSmoke:
+    """Smoke tests for train_state being accessible after load."""
+
+    def test_train_state_step_accessible_after_load(self):
+        setup_output = _make_setup_output_for_load(train_state_step=42, consumed_train_samples=1000)
+        cfg = _make_pretrain_cfg(load_path="/tmp/ckpt")
+
+        def builder(cfg, mimo_infra, *, train_state=None):
+            return (iter([]), None)
+
+        build_fn = MagicMock(return_value=(iter([]), None))
+        build_fn.__signature__ = inspect.signature(builder)
+
+        mocks = _run_pretrain_mimo(
+            cfg=cfg,
+            setup_output=setup_output,
+            checkpoint_exists_return=True,
+            build_data_iterators_fn=build_fn,
+        )
+
+        # train_state is passed to train_mimo via global_state
+        _, kwargs = mocks["train_mimo"].call_args
+        ts = kwargs["global_state"].train_state
+        assert ts.step == 42
+        assert ts.consumed_train_samples == 1000
+
+    def test_floating_point_ops_preserved(self):
+        setup_output = _make_setup_output_for_load(floating_point_operations_so_far=99999)
+        cfg = _make_pretrain_cfg(load_path="/tmp/ckpt")
+        mocks = _run_pretrain_mimo(
+            cfg=cfg, setup_output=setup_output, checkpoint_exists_return=True,
+        )
+        _, kwargs = mocks["train_mimo"].call_args
+        assert kwargs["global_state"].train_state.floating_point_operations_so_far == 99999
+
+
+# ---------------------------------------------------------------------------
+# Tests: local checkpoint resume plumbing
+# ---------------------------------------------------------------------------
+
+
+class TestLocalCheckpointResumePlumbing:
+    """Verify non-persistent local checkpoint intent triggers load."""
+
+    def test_local_non_persistent_triggers_load(self):
+        cfg = _make_pretrain_cfg(non_persistent_ckpt_type="local")
+        mocks = _run_pretrain_mimo(cfg=cfg, checkpoint_exists_return=False)
+        mocks["load_checkpoint"].assert_called_once()
+
+    def test_global_non_persistent_triggers_load(self):
+        cfg = _make_pretrain_cfg(non_persistent_ckpt_type="global")
+        mocks = _run_pretrain_mimo(cfg=cfg, checkpoint_exists_return=False)
+        mocks["load_checkpoint"].assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Tests: no-checkpoint graceful fallback
+# ---------------------------------------------------------------------------
+
+
+class TestNoCheckpointGracefulFallback:
+    """Verify load is not attempted and training starts from random init."""
+
+    def test_no_load_no_crash(self):
+        """When no checkpoint intent exists, load is skipped and training starts cleanly."""
+        cfg = _make_pretrain_cfg()
+        mocks = _run_pretrain_mimo(cfg=cfg, checkpoint_exists_return=False)
+        mocks["load_checkpoint"].assert_not_called()
+        mocks["train_mimo"].assert_called_once()
+
+    def test_iterators_still_built_without_checkpoint(self):
+        cfg = _make_pretrain_cfg()
+        build_fn = Mock(return_value=(iter([]), None))
+        mocks = _run_pretrain_mimo(cfg=cfg, build_data_iterators_fn=build_fn)
+        build_fn.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Tests: load_checkpoint pg_collection explicit threading
+# ---------------------------------------------------------------------------
+
+
+class TestLoadCheckpointPgThreading:
+    """Verify load_checkpoint and _load_checkpoint_from_path accept and
+    thread explicit pg_collection."""
+
+    def test_load_checkpoint_forwards_pg_collection_to_inner(self):
+        from megatron.bridge.training.checkpointing import load_checkpoint
+
+        pg = Mock()
+        state = Mock()
+        state.cfg.checkpoint.load = "/tmp/ckpt"
+        state.cfg.checkpoint.pretrained_checkpoint = None
+
+        with patch(
+            "megatron.bridge.training.checkpointing._load_checkpoint_from_path",
+            return_value=(0, 0),
+        ) as m_inner:
+            with patch(
+                "megatron.bridge.training.checkpointing.checkpoint_exists",
+                return_value=True,
+            ):
+                load_checkpoint(
+                    state=state,
+                    model=[Mock()],
+                    optimizer=Mock(),
+                    opt_param_scheduler=Mock(),
+                    pg_collection=pg,
+                )
+                _, kwargs = m_inner.call_args
+                assert kwargs["pg_collection"] is pg
+
+    def test_load_checkpoint_defaults_pg_collection_to_none(self):
+        from megatron.bridge.training.checkpointing import load_checkpoint
+
+        state = Mock()
+        state.cfg.checkpoint.load = "/tmp/ckpt"
+        state.cfg.checkpoint.pretrained_checkpoint = None
+
+        with patch(
+            "megatron.bridge.training.checkpointing._load_checkpoint_from_path",
+            return_value=(0, 0),
+        ) as m_inner:
+            with patch(
+                "megatron.bridge.training.checkpointing.checkpoint_exists",
+                return_value=True,
+            ):
+                load_checkpoint(
+                    state=state,
+                    model=[Mock()],
+                    optimizer=Mock(),
+                    opt_param_scheduler=Mock(),
+                )
+                _, kwargs = m_inner.call_args
+                assert kwargs["pg_collection"] is None

--- a/tests/unit_tests/training/mimo/test_mimo_checkpointing.py
+++ b/tests/unit_tests/training/mimo/test_mimo_checkpointing.py
@@ -37,7 +37,7 @@ def _make_mimo_infra(*, num_active_pgs: int = 1) -> Mock:
     for i in range(num_active_pgs):
         pgs[f"module_{i}"] = Mock()
     infra.pg_collections = pgs
-    infra.module_to_grid_map = {"llm": Mock()}
+    infra.module_to_grid_map = {"language": Mock()}
     infra.topology = Mock()
     return infra
 
@@ -251,9 +251,9 @@ class TestPretrainMimoSetup:
 
         provider = Mock()
         infra = Mock()
-        infra.module_to_grid_map = {"llm": Mock()}
+        infra.module_to_grid_map = {"language": Mock()}
         infra.topology = Mock()
-        infra.pg_collections = {"llm": Mock()}
+        infra.pg_collections = {"language": Mock()}
         provider.build_infra.return_value = infra
         provider.provide_distributed_model.return_value = [Mock()]
 
@@ -380,8 +380,8 @@ class TestTrainMimoCheckpointIntegration:
 
         pg = Mock()
         infra = Mock()
-        infra.pg_collections = {"llm": pg}
-        infra.module_to_grid_map = {"llm": Mock()}
+        infra.pg_collections = {"language": pg}
+        infra.module_to_grid_map = {"language": Mock()}
         infra.topology = Mock()
 
         mock_build_pg.return_value = Mock(spec=[])  # not a list
@@ -394,7 +394,7 @@ class TestTrainMimoCheckpointIntegration:
             forward_step_func=Mock(),
             model=Mock(),
             optimizer=Mock(),
-            schedulers={"llm": _make_scheduler_mock()},
+            schedulers={"language": _make_scheduler_mock()},
             train_data_iterator=train_iter,
             valid_data_iterator=None,
             global_state=state,
@@ -441,8 +441,8 @@ class TestTrainMimoCheckpointIntegration:
         mock_get_config.return_value = mock_config
 
         infra = Mock()
-        infra.pg_collections = {"llm": Mock()}
-        infra.module_to_grid_map = {"llm": Mock()}
+        infra.pg_collections = {"language": Mock()}
+        infra.module_to_grid_map = {"language": Mock()}
         infra.topology = Mock()
         mock_build_pg.return_value = Mock(spec=[])
 
@@ -452,7 +452,7 @@ class TestTrainMimoCheckpointIntegration:
             forward_step_func=Mock(),
             model=Mock(),
             optimizer=Mock(),
-            schedulers={"llm": _make_scheduler_mock()},
+            schedulers={"language": _make_scheduler_mock()},
             train_data_iterator=Mock(),
             valid_data_iterator=None,
             global_state=state,
@@ -496,8 +496,8 @@ class TestTrainMimoCheckpointIntegration:
         mock_get_config.return_value = mock_config
 
         infra = Mock()
-        infra.pg_collections = {"llm": Mock()}
-        infra.module_to_grid_map = {"llm": Mock()}
+        infra.pg_collections = {"language": Mock()}
+        infra.module_to_grid_map = {"language": Mock()}
         infra.topology = Mock()
         mock_build_pg.return_value = Mock(spec=[])
 
@@ -507,7 +507,7 @@ class TestTrainMimoCheckpointIntegration:
             forward_step_func=Mock(),
             model=Mock(),
             optimizer=Mock(),
-            schedulers={"llm": _make_scheduler_mock()},
+            schedulers={"language": _make_scheduler_mock()},
             train_data_iterator=Mock(),
             valid_data_iterator=None,
             global_state=state,
@@ -519,12 +519,8 @@ class TestTrainMimoCheckpointIntegration:
         # 2 non-blocking calls (top of each iteration) + 1 blocking call (shutdown)
         assert mock_async_finalize.call_count == 3
 
-        non_blocking_calls = [
-            c for c in mock_async_finalize.call_args_list if c.kwargs.get("blocking") is False
-        ]
-        blocking_calls = [
-            c for c in mock_async_finalize.call_args_list if c.kwargs.get("blocking") is True
-        ]
+        non_blocking_calls = [c for c in mock_async_finalize.call_args_list if c.kwargs.get("blocking") is False]
+        blocking_calls = [c for c in mock_async_finalize.call_args_list if c.kwargs.get("blocking") is True]
         assert len(non_blocking_calls) == 2
         assert len(blocking_calls) == 1
         assert blocking_calls[0].kwargs.get("terminate") is True
@@ -562,8 +558,8 @@ class TestTrainMimoCheckpointIntegration:
         mock_get_config.return_value = mock_config
 
         infra = Mock()
-        infra.pg_collections = {"llm": Mock()}
-        infra.module_to_grid_map = {"llm": Mock()}
+        infra.pg_collections = {"language": Mock()}
+        infra.module_to_grid_map = {"language": Mock()}
         infra.topology = Mock()
         mock_build_pg.return_value = Mock(spec=[])
 
@@ -574,7 +570,7 @@ class TestTrainMimoCheckpointIntegration:
                 forward_step_func=Mock(),
                 model=Mock(),
                 optimizer=Mock(),
-                schedulers={"llm": _make_scheduler_mock()},
+                schedulers={"language": _make_scheduler_mock()},
                 train_data_iterator=Mock(),
                 valid_data_iterator=None,
                 global_state=state,
@@ -605,7 +601,7 @@ def _make_setup_output_for_load(
 ) -> SimpleNamespace:
     """Create a MimoSetupOutput-like namespace suitable for pretrain_mimo load tests."""
     if pg_collections is None:
-        pg_collections = {"llm": Mock()}
+        pg_collections = {"language": Mock()}
 
     train_state = SimpleNamespace(
         step=train_state_step,
@@ -623,7 +619,7 @@ def _make_setup_output_for_load(
     return SimpleNamespace(
         model=MagicMock(),
         mimo_infra=SimpleNamespace(
-            module_to_grid_map={"llm": Mock()},
+            module_to_grid_map={"language": Mock()},
             pg_collections=pg_collections,
             topology=Mock(),
         ),
@@ -715,7 +711,7 @@ def _run_pretrain_mimo(
         m_dist.get_rank.return_value = 0
         m_dist.get_world_size.return_value = 2
         m_unwrap.return_value = MagicMock(
-            mimo_config=SimpleNamespace(module_to_grid_map={"llm": Mock()}, language_module_key="llm"),
+            mimo_config=SimpleNamespace(module_to_grid_map={"language": Mock()}),
         )
         mock_optimizer = MagicMock()
         mock_optimizer.module_infos = {}
@@ -775,7 +771,9 @@ class TestPretrainMimoLoadCheckpoint:
         cfg = _make_pretrain_cfg(load_path="/tmp/ckpt")
         setup_output = _make_setup_output_for_load()
         mocks = _run_pretrain_mimo(
-            cfg=cfg, setup_output=setup_output, checkpoint_exists_return=True,
+            cfg=cfg,
+            setup_output=setup_output,
+            checkpoint_exists_return=True,
         )
         _, kwargs = mocks["load_checkpoint"].call_args
         assert isinstance(kwargs["model"], list)
@@ -784,10 +782,12 @@ class TestPretrainMimoLoadCheckpoint:
 
     def test_load_forwards_explicit_pg_collection(self):
         pg = Mock()
-        setup_output = _make_setup_output_for_load(pg_collections={"llm": pg})
+        setup_output = _make_setup_output_for_load(pg_collections={"language": pg})
         cfg = _make_pretrain_cfg(load_path="/tmp/ckpt")
         mocks = _run_pretrain_mimo(
-            cfg=cfg, setup_output=setup_output, checkpoint_exists_return=True,
+            cfg=cfg,
+            setup_output=setup_output,
+            checkpoint_exists_return=True,
         )
         _, kwargs = mocks["load_checkpoint"].call_args
         assert kwargs["pg_collection"] is pg
@@ -796,7 +796,9 @@ class TestPretrainMimoLoadCheckpoint:
         setup_output = _make_setup_output_for_load()
         cfg = _make_pretrain_cfg(load_path="/tmp/ckpt")
         mocks = _run_pretrain_mimo(
-            cfg=cfg, setup_output=setup_output, checkpoint_exists_return=True,
+            cfg=cfg,
+            setup_output=setup_output,
+            checkpoint_exists_return=True,
         )
         _, kwargs = mocks["load_checkpoint"].call_args
         assert kwargs["checkpointing_context"] is setup_output.checkpointing_context
@@ -804,10 +806,12 @@ class TestPretrainMimoLoadCheckpoint:
     def test_load_forwards_first_scheduler(self):
         sched_a = _make_scheduler_mock()
         sched_b = _make_scheduler_mock()
-        schedulers = {"llm": sched_a, "vision": sched_b}
+        schedulers = {"language": sched_a, "vision": sched_b}
         cfg = _make_pretrain_cfg(load_path="/tmp/ckpt")
         mocks = _run_pretrain_mimo(
-            cfg=cfg, schedulers=schedulers, checkpoint_exists_return=True,
+            cfg=cfg,
+            schedulers=schedulers,
+            checkpoint_exists_return=True,
         )
         _, kwargs = mocks["load_checkpoint"].call_args
         assert kwargs["opt_param_scheduler"] is sched_a
@@ -826,17 +830,21 @@ class TestPretrainMimoLoadPgGuard:
         cfg = _make_pretrain_cfg(load_path="/tmp/ckpt")
         with pytest.raises(AssertionError, match="exactly one active ProcessGroupCollection"):
             _run_pretrain_mimo(
-                cfg=cfg, setup_output=setup_output, checkpoint_exists_return=True,
+                cfg=cfg,
+                setup_output=setup_output,
+                checkpoint_exists_return=True,
             )
 
     def test_rejects_multiple_active_pgs_in_pretrain(self):
         setup_output = _make_setup_output_for_load(
-            pg_collections={"llm": Mock(), "vision": Mock()},
+            pg_collections={"language": Mock(), "vision": Mock()},
         )
         cfg = _make_pretrain_cfg(load_path="/tmp/ckpt")
         with pytest.raises(AssertionError, match="exactly one active ProcessGroupCollection"):
             _run_pretrain_mimo(
-                cfg=cfg, setup_output=setup_output, checkpoint_exists_return=True,
+                cfg=cfg,
+                setup_output=setup_output,
+                checkpoint_exists_return=True,
             )
 
 
@@ -857,7 +865,7 @@ class TestSchedulerV1Fanout:
         sched_b = MagicMock()
         sched_b.optimizer.param_groups = [{"lr": 1e-4}]
 
-        schedulers = {"llm": sched_a, "vision": sched_b}
+        schedulers = {"language": sched_a, "vision": sched_b}
         cfg = _make_pretrain_cfg(load_path="/tmp/ckpt")
 
         # Simulate load succeeding and setting step > 0 via side_effect.
@@ -876,7 +884,7 @@ class TestSchedulerV1Fanout:
         sched.optimizer.param_groups = [{"lr": 1e-4}]
         sched.state_dict.return_value = {"step": 50}
 
-        schedulers = {"llm": sched}
+        schedulers = {"language": sched}
         cfg = _make_pretrain_cfg(load_path="/tmp/ckpt")
         _run_pretrain_mimo(cfg=cfg, schedulers=schedulers, checkpoint_exists_return=True)
 
@@ -911,7 +919,6 @@ class TestIteratorResumeSemanticsLoad:
         """When resuming (step > 0), builder receives train_state kwarg."""
         build_fn = MagicMock(return_value=(iter([]), None))
         # Give mock the train_state parameter so inspect.signature finds it
-        import types
 
         def _sig_fn(cfg, mimo_infra, *, train_state=None):
             pass
@@ -970,7 +977,7 @@ class TestMimoOptimizerLoadCompat:
         opt_b = MagicMock()
 
         module_infos = {
-            "llm": ModuleOptimizerInfo(optimizer=opt_a, grid=Mock(), pg_collection=Mock(), is_active=True),
+            "language": ModuleOptimizerInfo(optimizer=opt_a, grid=Mock(), pg_collection=Mock(), is_active=True),
             "vision": ModuleOptimizerInfo(optimizer=opt_b, grid=Mock(), pg_collection=Mock(), is_active=True),
         }
         config = MagicMock()
@@ -978,14 +985,14 @@ class TestMimoOptimizerLoadCompat:
 
     def test_load_state_dict_dispatches_per_module(self):
         mimo_opt, opt_a, opt_b = self._make_mimo_optimizer()
-        state = {"llm": {"param": 1}, "vision": {"param": 2}}
+        state = {"language": {"param": 1}, "vision": {"param": 2}}
         mimo_opt.load_state_dict(state)
         opt_a.load_state_dict.assert_called_once_with({"param": 1})
         opt_b.load_state_dict.assert_called_once_with({"param": 2})
 
     def test_load_state_dict_skips_missing_keys(self):
         mimo_opt, opt_a, opt_b = self._make_mimo_optimizer()
-        state = {"llm": {"param": 1}}
+        state = {"language": {"param": 1}}
         mimo_opt.load_state_dict(state)
         opt_a.load_state_dict.assert_called_once()
         opt_b.load_state_dict.assert_not_called()
@@ -996,9 +1003,9 @@ class TestMimoOptimizerLoadCompat:
         opt_b.sharded_state_dict.return_value = {"b": "sharded_b"}
 
         result = mimo_opt.sharded_state_dict({}, is_loading=True)
-        assert "llm" in result
+        assert "language" in result
         assert "vision" in result
-        assert result["llm"] == {"a": "sharded_a"}
+        assert result["language"] == {"a": "sharded_a"}
         assert result["vision"] == {"b": "sharded_b"}
 
     def test_reload_model_params_delegates_to_all_active(self):
@@ -1011,7 +1018,7 @@ class TestMimoOptimizerLoadCompat:
         from megatron.core.models.mimo.optimizer import MimoOptimizer, ModuleOptimizerInfo
 
         module_infos = {
-            "llm": ModuleOptimizerInfo(optimizer=None, grid=Mock(), pg_collection=Mock(), is_active=False),
+            "language": ModuleOptimizerInfo(optimizer=None, grid=Mock(), pg_collection=Mock(), is_active=False),
         }
         mimo_opt = MimoOptimizer(module_infos, MagicMock())
         assert mimo_opt.is_stub_optimizer is True
@@ -1052,7 +1059,9 @@ class TestTrainStateRestorationSmoke:
         setup_output = _make_setup_output_for_load(floating_point_operations_so_far=99999)
         cfg = _make_pretrain_cfg(load_path="/tmp/ckpt")
         mocks = _run_pretrain_mimo(
-            cfg=cfg, setup_output=setup_output, checkpoint_exists_return=True,
+            cfg=cfg,
+            setup_output=setup_output,
+            checkpoint_exists_return=True,
         )
         _, kwargs = mocks["train_mimo"].call_args
         assert kwargs["global_state"].train_state.floating_point_operations_so_far == 99999

--- a/tests/unit_tests/training/mimo/test_mimo_config.py
+++ b/tests/unit_tests/training/mimo/test_mimo_config.py
@@ -22,7 +22,7 @@ def test_mimo_heterogeneous_rank_offset_overlap():
     """Test that overlapping rank ranges are detected in heterogeneous deployment."""
     module_parallelisms = {
         "encoder": ModuleParallelismConfig(tensor_model_parallel_size=1, data_parallel_size=4, rank_offset=0),
-        "llm": ModuleParallelismConfig(tensor_model_parallel_size=1, data_parallel_size=4, rank_offset=2),
+        "language": ModuleParallelismConfig(tensor_model_parallel_size=1, data_parallel_size=4, rank_offset=2),
     }
     mimo_parallelism_config = MimoParallelismConfig(
         module_parallelisms=module_parallelisms,
@@ -36,7 +36,7 @@ def test_mimo_heterogeneous_valid_contiguous():
     # Note: encoder DP must be >= LLM DP for embedding alignment
     module_parallelisms = {
         "encoder": ModuleParallelismConfig(tensor_model_parallel_size=1, data_parallel_size=4, rank_offset=0),
-        "llm": ModuleParallelismConfig(tensor_model_parallel_size=1, data_parallel_size=2, rank_offset=4),
+        "language": ModuleParallelismConfig(tensor_model_parallel_size=1, data_parallel_size=2, rank_offset=4),
     }
     mimo_parallelism_config = MimoParallelismConfig(
         module_parallelisms=module_parallelisms,

--- a/tests/unit_tests/training/mimo/test_mimo_config.py
+++ b/tests/unit_tests/training/mimo/test_mimo_config.py
@@ -1,7 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
-
-import warnings
-
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 import pytest
 
 from megatron.bridge.models.mimo.mimo_config import MimoParallelismConfig, ModuleParallelismConfig
@@ -31,176 +28,19 @@ def test_mimo_heterogeneous_rank_offset_overlap():
         module_parallelisms=module_parallelisms,
     )
     with pytest.raises(ValueError, match="overlap"):
-        mimo_parallelism_config.finalize(world_size=None)
+        mimo_parallelism_config.finalize(world_size=6)
 
 
-def test_module_parallelism_total_model_parallel_size_property():
-    """Test total_model_parallel_size calculation."""
-    parallelism = ModuleParallelismConfig(
-        tensor_model_parallel_size=2,
-        pipeline_model_parallel_size=2,
-        context_parallel_size=2,
-        expert_tensor_parallel_size=2,
-    )
-    assert parallelism.total_model_parallel_size == 16  # 2 * 2 * 2 * 2
-
-
-def test_module_parallelism_total_ranks_property():
-    """Test total_ranks property."""
-    parallelism = ModuleParallelismConfig(
-        tensor_model_parallel_size=2,
-        pipeline_model_parallel_size=2,
-        data_parallel_size=4,
-    )
-    assert parallelism.total_ranks == 16  # (2 * 2) * 4
-
-
-def test_module_parallelism_total_ranks_raises_without_dp():
-    """Test total_ranks raises error when data_parallel_size is None."""
-    parallelism = ModuleParallelismConfig(
-        tensor_model_parallel_size=2,
-        pipeline_model_parallel_size=2,
-    )
-    with pytest.raises(ValueError, match="data_parallel_size must be set"):
-        _ = parallelism.total_ranks
-
-
-def test_module_parallelism_expert_tensor_parallel_warning():
-    """Test warning when using expert_tensor_parallel_size > 1 with pipeline > 1."""
-    parallelism = ModuleParallelismConfig(
-        tensor_model_parallel_size=2,
-        pipeline_model_parallel_size=2,
-        expert_tensor_parallel_size=2,
-        data_parallel_size=2,
-    )
-
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        parallelism.finalize(world_size=None)
-
-        # Check warning was raised
-        assert len(w) == 1
-        assert "expert_tensor_parallel_size > 1 with pipeline_model_parallel_size > 1" in str(w[0].message)
-
-
-def test_module_parallelism_data_parallel_validation():
-    """Test data_parallel_size validation."""
-    parallelism = ModuleParallelismConfig(
-        tensor_model_parallel_size=2,
-        data_parallel_size=0,  # Invalid
-    )
-    with pytest.raises(ValueError, match="data_parallel_size must be positive"):
-        parallelism.finalize(world_size=None)
-
-
-def test_mimo_parallelism_total_world_size_property():
-    """Test total_world_size calculation."""
-    mimo_config = MimoParallelismConfig(
-        module_parallelisms={
-            "llm": ModuleParallelismConfig(
-                tensor_model_parallel_size=2,
-                data_parallel_size=2,
-                rank_offset=0,
-            ),
-            "encoder": ModuleParallelismConfig(
-                tensor_model_parallel_size=2,
-                data_parallel_size=2,
-                rank_offset=4,
-            ),
-        }
-    )
-
-    # Total world size should be 8 (ranks 0-7)
-    assert mimo_config.total_world_size == 8
-
-
-def test_mimo_parallelism_module_names_property():
-    """Test module_names property."""
-    mimo_config = MimoParallelismConfig(
-        module_parallelisms={
-            "llm": ModuleParallelismConfig(tensor_model_parallel_size=2),
-            "clip_encoder": ModuleParallelismConfig(tensor_model_parallel_size=2),
-            "dino_encoder": ModuleParallelismConfig(tensor_model_parallel_size=2),
-        }
-    )
-
-    module_names = mimo_config.module_names
-    assert "llm" in module_names
-    assert "clip_encoder" in module_names
-    assert "dino_encoder" in module_names
-    assert len(module_names) == 3
-
-
-def test_mimo_heterogeneous_edge_touching_ranges():
-    """Test that edge-touching ranges (no overlap) are valid."""
+def test_mimo_heterogeneous_valid_contiguous():
+    """Test that contiguous rank allocation works correctly."""
+    # Note: encoder DP must be >= LLM DP for embedding alignment
     module_parallelisms = {
-        "llm": ModuleParallelismConfig(
-            tensor_model_parallel_size=2,
-            data_parallel_size=2,
-            rank_offset=0,  # ranks 0-3
-        ),
-        "encoder": ModuleParallelismConfig(
-            tensor_model_parallel_size=2,
-            data_parallel_size=2,
-            rank_offset=4,  # ranks 4-7 (touching but not overlapping)
-        ),
+        "encoder": ModuleParallelismConfig(tensor_model_parallel_size=1, data_parallel_size=4, rank_offset=0),
+        "llm": ModuleParallelismConfig(tensor_model_parallel_size=1, data_parallel_size=2, rank_offset=4),
     }
-    mimo_config = MimoParallelismConfig(module_parallelisms=module_parallelisms)
-
-    # Should not raise an error
-    mimo_config.finalize(world_size=None)
-
-
-def test_mimo_heterogeneous_multiple_overlaps():
-    """Test detection of multiple overlapping ranges."""
-    module_parallelisms = {
-        "llm": ModuleParallelismConfig(
-            tensor_model_parallel_size=2,
-            data_parallel_size=2,
-            rank_offset=0,  # ranks 0-3
-        ),
-        "encoder1": ModuleParallelismConfig(
-            tensor_model_parallel_size=2,
-            data_parallel_size=2,
-            rank_offset=2,  # ranks 2-5 (overlaps with llm)
-        ),
-        "encoder2": ModuleParallelismConfig(
-            tensor_model_parallel_size=2,
-            data_parallel_size=2,
-            rank_offset=6,  # ranks 6-9
-        ),
-    }
-    mimo_config = MimoParallelismConfig(module_parallelisms=module_parallelisms)
-
-    # Should detect overlap
-    with pytest.raises(ValueError, match="overlap"):
-        mimo_config.finalize(world_size=None)
-
-
-def test_mimo_finalize_missing_llm_module():
-    """Test that finalize raises error when 'llm' module is missing."""
-    mimo_config = MimoParallelismConfig(
-        module_parallelisms={
-            "encoder": ModuleParallelismConfig(tensor_model_parallel_size=2, data_parallel_size=2),
-        }
+    mimo_parallelism_config = MimoParallelismConfig(
+        module_parallelisms=module_parallelisms,
     )
-
-    with pytest.raises(ValueError, match="LLM module 'llm' must be in module_parallelisms"):
-        mimo_config.finalize(world_size=None)
-
-
-def test_mimo_finalize_world_size_mismatch():
-    """Test that finalize detects world size mismatch."""
-    mimo_config = MimoParallelismConfig(
-        module_parallelisms={
-            "llm": ModuleParallelismConfig(
-                tensor_model_parallel_size=2,
-                data_parallel_size=2,
-                rank_offset=0,
-            ),
-        }
-    )
-
-    # Expected world size is 4, but providing 8
-    with pytest.raises(ValueError, match="MIMO world size mismatch"):
-        mimo_config.finalize(world_size=8)
+    # No gaps, no overlap, encoder DP >= LLM DP - should pass
+    mimo_parallelism_config.finalize(world_size=6)
+    assert mimo_parallelism_config.total_world_size == 6

--- a/tests/unit_tests/training/mimo/test_mimo_parallel_utils.py
+++ b/tests/unit_tests/training/mimo/test_mimo_parallel_utils.py
@@ -1,0 +1,271 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+"""Unit tests for MIMO parallel utilities."""
+
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+
+class TestIsCurrentRankInGrid:
+    """Test cases for is_current_rank_in_grid()."""
+    
+    @patch('megatron.bridge.training.mimo_parallel_utils.dist')
+    def test_rank_in_grid(self, mock_dist):
+        """Test rank within grid range returns True."""
+        from megatron.bridge.training.mimo_parallel_utils import is_current_rank_in_grid
+        
+        mock_dist.get_rank.return_value = 2
+        mock_grid = MagicMock()
+        mock_grid.rank_offset = 0
+        mock_grid.size = 4
+        
+        assert is_current_rank_in_grid(mock_grid) is True
+    
+    @patch('megatron.bridge.training.mimo_parallel_utils.dist')
+    def test_rank_not_in_grid(self, mock_dist):
+        """Test rank outside grid range returns False."""
+        from megatron.bridge.training.mimo_parallel_utils import is_current_rank_in_grid
+        
+        mock_dist.get_rank.return_value = 5
+        mock_grid = MagicMock()
+        mock_grid.rank_offset = 0
+        mock_grid.size = 4
+        
+        assert is_current_rank_in_grid(mock_grid) is False
+    
+    @patch('megatron.bridge.training.mimo_parallel_utils.dist')
+    def test_rank_at_grid_boundary(self, mock_dist):
+        """Test rank at grid boundary."""
+        from megatron.bridge.training.mimo_parallel_utils import is_current_rank_in_grid
+        
+        mock_grid = MagicMock()
+        mock_grid.rank_offset = 4
+        mock_grid.size = 4
+        
+        # At start boundary (inclusive)
+        mock_dist.get_rank.return_value = 4
+        assert is_current_rank_in_grid(mock_grid) is True
+        
+        # At end boundary (exclusive)
+        mock_dist.get_rank.return_value = 8
+        assert is_current_rank_in_grid(mock_grid) is False
+
+
+class TestValidateNoStubRanks:
+    """Test cases for validate_no_stub_ranks()."""
+    
+    def test_all_ranks_participate(self):
+        """Test validation passes when all ranks participate."""
+        from megatron.bridge.training.mimo_parallel_utils import validate_no_stub_ranks
+        
+        mock_grid1 = MagicMock()
+        mock_grid1.rank_offset = 0
+        mock_grid1.size = 4
+        
+        mock_grid2 = MagicMock()
+        mock_grid2.rank_offset = 4
+        mock_grid2.size = 4
+        
+        module_to_grid_map = {
+            "encoder": mock_grid1,
+            "llm": mock_grid2,
+        }
+        
+        # Should not raise
+        validate_no_stub_ranks(module_to_grid_map, world_size=8)
+    
+    def test_stub_ranks_detected(self):
+        """Test validation fails when stub ranks exist."""
+        from megatron.bridge.training.mimo_parallel_utils import validate_no_stub_ranks
+        
+        mock_grid = MagicMock()
+        mock_grid.rank_offset = 0
+        mock_grid.size = 4
+        
+        module_to_grid_map = {"llm": mock_grid}
+        
+        with pytest.raises(ValueError, match="do not participate in any module"):
+            validate_no_stub_ranks(module_to_grid_map, world_size=8)
+    
+    def test_overlapping_grids(self):
+        """Test validation with overlapping grids (colocated case)."""
+        from megatron.bridge.training.mimo_parallel_utils import validate_no_stub_ranks
+        
+        mock_grid1 = MagicMock()
+        mock_grid1.rank_offset = 0
+        mock_grid1.size = 4
+        
+        mock_grid2 = MagicMock()
+        mock_grid2.rank_offset = 0
+        mock_grid2.size = 4
+        
+        module_to_grid_map = {
+            "encoder": mock_grid1,
+            "llm": mock_grid2,
+        }
+        
+        # Should not raise (all 4 ranks participate)
+        validate_no_stub_ranks(module_to_grid_map, world_size=4)
+
+
+class TestValidateDataLoaderContract:
+    """Test cases for validate_data_loader_contract()."""
+    
+    def test_valid_configuration(self):
+        """Test validation passes for valid configuration."""
+        from megatron.bridge.training.mimo_parallel_utils import validate_data_loader_contract
+        
+        mock_grid = MagicMock()
+        mock_grid.get_pg_size.return_value = 2  # DP size = 2
+        
+        mock_infra = MagicMock()
+        mock_infra.module_to_grid_map = {"llm": mock_grid}
+        
+        # global_batch=16, dp=2, per_dp_batch=8, microbatches=4, micro_batch_size=2
+        # 4 * 2 = 8 == 16 / 2 ✓
+        validate_data_loader_contract(
+            infra=mock_infra,
+            global_batch_size=16,
+            micro_batch_size=2,
+            num_microbatches=4,
+        )
+    
+    def test_batch_not_divisible_by_dp(self):
+        """Test validation fails when batch not divisible by DP size."""
+        from megatron.bridge.training.mimo_parallel_utils import validate_data_loader_contract
+        
+        mock_grid = MagicMock()
+        mock_grid.get_pg_size.return_value = 3  # DP size = 3
+        
+        mock_infra = MagicMock()
+        mock_infra.module_to_grid_map = {"llm": mock_grid}
+        
+        with pytest.raises(ValueError, match="not divisible"):
+            validate_data_loader_contract(
+                infra=mock_infra,
+                global_batch_size=16,
+                micro_batch_size=2,
+                num_microbatches=4,
+            )
+
+
+class TestBuildPgCollectionForSchedule:
+    """Test cases for build_pg_collection_for_schedule()."""
+    
+    def test_fallback_to_list(self):
+        """Test fallback to list when MultiModuleProcessGroupCollection not available."""
+        from megatron.bridge.training.mimo_parallel_utils import build_pg_collection_for_schedule
+        
+        mock_pg1 = MagicMock()
+        mock_pg2 = MagicMock()
+        
+        mock_infra = MagicMock()
+        mock_infra.pg_collections = {
+            "encoder": mock_pg1,
+            "llm": mock_pg2,
+        }
+        
+        # This will likely fall back to list since import may fail in test env
+        result = build_pg_collection_for_schedule(mock_infra)
+        
+        # Should be either a list or MultiModuleProcessGroupCollection
+        assert result is not None
+    
+    def test_filters_none_pg_collections(self):
+        """Test that None pg_collections are filtered out."""
+        from megatron.bridge.training.mimo_parallel_utils import build_pg_collection_for_schedule
+        
+        mock_pg = MagicMock()
+        
+        mock_infra = MagicMock()
+        mock_infra.pg_collections = {
+            "encoder": None,  # Non-participating module
+            "llm": mock_pg,
+        }
+        
+        result = build_pg_collection_for_schedule(mock_infra)
+        
+        # Should filter out None values
+        if isinstance(result, list):
+            assert len(result) == 1
+            assert mock_pg in result
+
+
+class TestMultimoduleNoSync:
+    """Test cases for multimodule_no_sync context manager."""
+    
+    @patch('megatron.bridge.training.mimo_parallel_utils.is_current_rank_in_grid')
+    def test_enters_and_exits_contexts(self, mock_in_grid):
+        """Test that no_sync contexts are properly entered and exited."""
+        from megatron.bridge.training.mimo_parallel_utils import multimodule_no_sync
+        
+        mock_in_grid.return_value = True
+        
+        mock_module = MagicMock()
+        mock_context = MagicMock()
+        mock_module.no_sync.return_value = mock_context
+        
+        mock_grid = MagicMock()
+        
+        module_to_grid_tuple = [(mock_module, mock_grid)]
+        
+        with multimodule_no_sync(module_to_grid_tuple=module_to_grid_tuple):
+            pass
+        
+        # Verify context was entered and exited
+        mock_context.__enter__.assert_called_once()
+        mock_context.__exit__.assert_called_once()
+    
+    @patch('megatron.bridge.training.mimo_parallel_utils.is_current_rank_in_grid')
+    def test_skips_non_participating_modules(self, mock_in_grid):
+        """Test that non-participating modules are skipped."""
+        from megatron.bridge.training.mimo_parallel_utils import multimodule_no_sync
+        
+        mock_in_grid.return_value = False  # Not participating
+        
+        mock_module = MagicMock()
+        mock_grid = MagicMock()
+        
+        module_to_grid_tuple = [(mock_module, mock_grid)]
+        
+        with multimodule_no_sync(module_to_grid_tuple=module_to_grid_tuple):
+            pass
+        
+        # no_sync should not be called
+        mock_module.no_sync.assert_not_called()
+
+
+class TestZeroGradBufferForMultimodule:
+    """Test cases for zero_grad_buffer_for_multimodule()."""
+    
+    @patch('megatron.bridge.training.mimo_parallel_utils.is_current_rank_in_grid')
+    def test_zeros_grad_buffers(self, mock_in_grid):
+        """Test gradient buffers are zeroed for participating modules."""
+        from megatron.bridge.training.mimo_parallel_utils import zero_grad_buffer_for_multimodule
+        
+        mock_in_grid.return_value = True
+        
+        mock_module = MagicMock()
+        mock_grid = MagicMock()
+        
+        module_to_grid_tuple = [(mock_module, mock_grid)]
+        
+        zero_grad_buffer_for_multimodule(module_to_grid_tuple)
+        
+        mock_module.zero_grad_buffer.assert_called_once()
+    
+    @patch('megatron.bridge.training.mimo_parallel_utils.is_current_rank_in_grid')
+    def test_skips_non_participating(self, mock_in_grid):
+        """Test non-participating modules are skipped."""
+        from megatron.bridge.training.mimo_parallel_utils import zero_grad_buffer_for_multimodule
+        
+        mock_in_grid.return_value = False
+        
+        mock_module = MagicMock()
+        mock_grid = MagicMock()
+        
+        module_to_grid_tuple = [(mock_module, mock_grid)]
+        
+        zero_grad_buffer_for_multimodule(module_to_grid_tuple)
+        
+        mock_module.zero_grad_buffer.assert_not_called()

--- a/tests/unit_tests/training/mimo/test_mimo_parallel_utils.py
+++ b/tests/unit_tests/training/mimo/test_mimo_parallel_utils.py
@@ -1,51 +1,51 @@
 # Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
 """Unit tests for MIMO parallel utilities."""
 
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 
 class TestIsCurrentRankInGrid:
     """Test cases for is_current_rank_in_grid()."""
-    
-    @patch('megatron.bridge.training.mimo_parallel_utils.dist')
+
+    @patch("megatron.bridge.training.mimo_parallel_utils.dist")
     def test_rank_in_grid(self, mock_dist):
         """Test rank within grid range returns True."""
         from megatron.bridge.training.mimo_parallel_utils import is_current_rank_in_grid
-        
+
         mock_dist.get_rank.return_value = 2
         mock_grid = MagicMock()
         mock_grid.rank_offset = 0
         mock_grid.size = 4
-        
+
         assert is_current_rank_in_grid(mock_grid) is True
-    
-    @patch('megatron.bridge.training.mimo_parallel_utils.dist')
+
+    @patch("megatron.bridge.training.mimo_parallel_utils.dist")
     def test_rank_not_in_grid(self, mock_dist):
         """Test rank outside grid range returns False."""
         from megatron.bridge.training.mimo_parallel_utils import is_current_rank_in_grid
-        
+
         mock_dist.get_rank.return_value = 5
         mock_grid = MagicMock()
         mock_grid.rank_offset = 0
         mock_grid.size = 4
-        
+
         assert is_current_rank_in_grid(mock_grid) is False
-    
-    @patch('megatron.bridge.training.mimo_parallel_utils.dist')
+
+    @patch("megatron.bridge.training.mimo_parallel_utils.dist")
     def test_rank_at_grid_boundary(self, mock_dist):
         """Test rank at grid boundary."""
         from megatron.bridge.training.mimo_parallel_utils import is_current_rank_in_grid
-        
+
         mock_grid = MagicMock()
         mock_grid.rank_offset = 4
         mock_grid.size = 4
-        
+
         # At start boundary (inclusive)
         mock_dist.get_rank.return_value = 4
         assert is_current_rank_in_grid(mock_grid) is True
-        
+
         # At end boundary (exclusive)
         mock_dist.get_rank.return_value = 8
         assert is_current_rank_in_grid(mock_grid) is False
@@ -53,74 +53,74 @@ class TestIsCurrentRankInGrid:
 
 class TestValidateNoStubRanks:
     """Test cases for validate_no_stub_ranks()."""
-    
+
     def test_all_ranks_participate(self):
         """Test validation passes when all ranks participate."""
         from megatron.bridge.training.mimo_parallel_utils import validate_no_stub_ranks
-        
+
         mock_grid1 = MagicMock()
         mock_grid1.rank_offset = 0
         mock_grid1.size = 4
-        
+
         mock_grid2 = MagicMock()
         mock_grid2.rank_offset = 4
         mock_grid2.size = 4
-        
+
         module_to_grid_map = {
             "encoder": mock_grid1,
-            "llm": mock_grid2,
+            "language": mock_grid2,
         }
-        
+
         # Should not raise
         validate_no_stub_ranks(module_to_grid_map, world_size=8)
-    
+
     def test_stub_ranks_detected(self):
         """Test validation fails when stub ranks exist."""
         from megatron.bridge.training.mimo_parallel_utils import validate_no_stub_ranks
-        
+
         mock_grid = MagicMock()
         mock_grid.rank_offset = 0
         mock_grid.size = 4
-        
-        module_to_grid_map = {"llm": mock_grid}
-        
+
+        module_to_grid_map = {"language": mock_grid}
+
         with pytest.raises(ValueError, match="do not participate in any module"):
             validate_no_stub_ranks(module_to_grid_map, world_size=8)
-    
+
     def test_overlapping_grids(self):
         """Test validation with overlapping grids (colocated case)."""
         from megatron.bridge.training.mimo_parallel_utils import validate_no_stub_ranks
-        
+
         mock_grid1 = MagicMock()
         mock_grid1.rank_offset = 0
         mock_grid1.size = 4
-        
+
         mock_grid2 = MagicMock()
         mock_grid2.rank_offset = 0
         mock_grid2.size = 4
-        
+
         module_to_grid_map = {
             "encoder": mock_grid1,
-            "llm": mock_grid2,
+            "language": mock_grid2,
         }
-        
+
         # Should not raise (all 4 ranks participate)
         validate_no_stub_ranks(module_to_grid_map, world_size=4)
 
 
 class TestValidateDataLoaderContract:
     """Test cases for validate_data_loader_contract()."""
-    
+
     def test_valid_configuration(self):
         """Test validation passes for valid configuration."""
         from megatron.bridge.training.mimo_parallel_utils import validate_data_loader_contract
-        
+
         mock_grid = MagicMock()
         mock_grid.get_pg_size.return_value = 2  # DP size = 2
-        
+
         mock_infra = MagicMock()
-        mock_infra.module_to_grid_map = {"llm": mock_grid}
-        
+        mock_infra.module_to_grid_map = {"language": mock_grid}
+
         # global_batch=16, dp=2, per_dp_batch=8, microbatches=4, micro_batch_size=2
         # 4 * 2 = 8 == 16 / 2 ✓
         validate_data_loader_contract(
@@ -129,17 +129,17 @@ class TestValidateDataLoaderContract:
             micro_batch_size=2,
             num_microbatches=4,
         )
-    
+
     def test_batch_not_divisible_by_dp(self):
         """Test validation fails when batch not divisible by DP size."""
         from megatron.bridge.training.mimo_parallel_utils import validate_data_loader_contract
-        
+
         mock_grid = MagicMock()
         mock_grid.get_pg_size.return_value = 3  # DP size = 3
-        
+
         mock_infra = MagicMock()
-        mock_infra.module_to_grid_map = {"llm": mock_grid}
-        
+        mock_infra.module_to_grid_map = {"language": mock_grid}
+
         with pytest.raises(ValueError, match="not divisible"):
             validate_data_loader_contract(
                 infra=mock_infra,
@@ -151,40 +151,40 @@ class TestValidateDataLoaderContract:
 
 class TestBuildPgCollectionForSchedule:
     """Test cases for build_pg_collection_for_schedule()."""
-    
+
     def test_fallback_to_list(self):
         """Test fallback to list when MultiModuleProcessGroupCollection not available."""
         from megatron.bridge.training.mimo_parallel_utils import build_pg_collection_for_schedule
-        
+
         mock_pg1 = MagicMock()
         mock_pg2 = MagicMock()
-        
+
         mock_infra = MagicMock()
         mock_infra.pg_collections = {
             "encoder": mock_pg1,
-            "llm": mock_pg2,
+            "language": mock_pg2,
         }
-        
+
         # This will likely fall back to list since import may fail in test env
         result = build_pg_collection_for_schedule(mock_infra)
-        
+
         # Should be either a list or MultiModuleProcessGroupCollection
         assert result is not None
-    
+
     def test_filters_none_pg_collections(self):
         """Test that None pg_collections are filtered out."""
         from megatron.bridge.training.mimo_parallel_utils import build_pg_collection_for_schedule
-        
+
         mock_pg = MagicMock()
-        
+
         mock_infra = MagicMock()
         mock_infra.pg_collections = {
             "encoder": None,  # Non-participating module
-            "llm": mock_pg,
+            "language": mock_pg,
         }
-        
+
         result = build_pg_collection_for_schedule(mock_infra)
-        
+
         # Should filter out None values
         if isinstance(result, list):
             assert len(result) == 1
@@ -193,79 +193,79 @@ class TestBuildPgCollectionForSchedule:
 
 class TestMultimoduleNoSync:
     """Test cases for multimodule_no_sync context manager."""
-    
-    @patch('megatron.bridge.training.mimo_parallel_utils.is_current_rank_in_grid')
+
+    @patch("megatron.bridge.training.mimo_parallel_utils.is_current_rank_in_grid")
     def test_enters_and_exits_contexts(self, mock_in_grid):
         """Test that no_sync contexts are properly entered and exited."""
         from megatron.bridge.training.mimo_parallel_utils import multimodule_no_sync
-        
+
         mock_in_grid.return_value = True
-        
+
         mock_module = MagicMock()
         mock_context = MagicMock()
         mock_module.no_sync.return_value = mock_context
-        
+
         mock_grid = MagicMock()
-        
+
         module_to_grid_tuple = [(mock_module, mock_grid)]
-        
+
         with multimodule_no_sync(module_to_grid_tuple=module_to_grid_tuple):
             pass
-        
+
         # Verify context was entered and exited
         mock_context.__enter__.assert_called_once()
         mock_context.__exit__.assert_called_once()
-    
-    @patch('megatron.bridge.training.mimo_parallel_utils.is_current_rank_in_grid')
+
+    @patch("megatron.bridge.training.mimo_parallel_utils.is_current_rank_in_grid")
     def test_skips_non_participating_modules(self, mock_in_grid):
         """Test that non-participating modules are skipped."""
         from megatron.bridge.training.mimo_parallel_utils import multimodule_no_sync
-        
+
         mock_in_grid.return_value = False  # Not participating
-        
+
         mock_module = MagicMock()
         mock_grid = MagicMock()
-        
+
         module_to_grid_tuple = [(mock_module, mock_grid)]
-        
+
         with multimodule_no_sync(module_to_grid_tuple=module_to_grid_tuple):
             pass
-        
+
         # no_sync should not be called
         mock_module.no_sync.assert_not_called()
 
 
 class TestZeroGradBufferForMultimodule:
     """Test cases for zero_grad_buffer_for_multimodule()."""
-    
-    @patch('megatron.bridge.training.mimo_parallel_utils.is_current_rank_in_grid')
+
+    @patch("megatron.bridge.training.mimo_parallel_utils.is_current_rank_in_grid")
     def test_zeros_grad_buffers(self, mock_in_grid):
         """Test gradient buffers are zeroed for participating modules."""
         from megatron.bridge.training.mimo_parallel_utils import zero_grad_buffer_for_multimodule
-        
+
         mock_in_grid.return_value = True
-        
+
         mock_module = MagicMock()
         mock_grid = MagicMock()
-        
+
         module_to_grid_tuple = [(mock_module, mock_grid)]
-        
+
         zero_grad_buffer_for_multimodule(module_to_grid_tuple)
-        
+
         mock_module.zero_grad_buffer.assert_called_once()
-    
-    @patch('megatron.bridge.training.mimo_parallel_utils.is_current_rank_in_grid')
+
+    @patch("megatron.bridge.training.mimo_parallel_utils.is_current_rank_in_grid")
     def test_skips_non_participating(self, mock_in_grid):
         """Test non-participating modules are skipped."""
         from megatron.bridge.training.mimo_parallel_utils import zero_grad_buffer_for_multimodule
-        
+
         mock_in_grid.return_value = False
-        
+
         mock_module = MagicMock()
         mock_grid = MagicMock()
-        
+
         module_to_grid_tuple = [(mock_module, mock_grid)]
-        
+
         zero_grad_buffer_for_multimodule(module_to_grid_tuple)
-        
+
         mock_module.zero_grad_buffer.assert_not_called()

--- a/tests/unit_tests/training/mimo/test_mimo_step.py
+++ b/tests/unit_tests/training/mimo/test_mimo_step.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
 """Unit tests for MIMO forward step functions."""
 
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
@@ -9,165 +9,165 @@ import torch
 
 class TestLossFunc:
     """Test cases for loss_func()."""
-    
+
     def test_loss_computation(self):
         """Test loss is computed correctly with mask."""
         from megatron.bridge.training.mimo_step import loss_func
-        
+
         # Create test data
         output_tensor = torch.tensor([1.0, 2.0, 3.0, 4.0])
         loss_mask = torch.tensor([1.0, 1.0, 0.0, 1.0])  # Mask out 3rd element
-        
+
         total_loss, num_tokens, metrics = loss_func(loss_mask, output_tensor)
-        
+
         # Expected: (1.0*1 + 2.0*1 + 3.0*0 + 4.0*1) = 7.0
         assert total_loss.item() == 7.0
         # Expected tokens: 3 (sum of mask)
         assert num_tokens.item() == 3
         # Check metrics dict structure
-        assert 'lm loss' in metrics
-    
+        assert "lm loss" in metrics
+
     def test_loss_with_all_ones_mask(self):
         """Test loss with all-ones mask."""
         from megatron.bridge.training.mimo_step import loss_func
-        
+
         output_tensor = torch.tensor([1.0, 2.0, 3.0])
         loss_mask = torch.ones(3)
-        
+
         total_loss, num_tokens, metrics = loss_func(loss_mask, output_tensor)
-        
+
         assert total_loss.item() == 6.0
         assert num_tokens.item() == 3
-    
+
     def test_loss_with_all_zeros_mask(self):
         """Test loss with all-zeros mask."""
         from megatron.bridge.training.mimo_step import loss_func
-        
+
         output_tensor = torch.tensor([1.0, 2.0, 3.0])
         loss_mask = torch.zeros(3)
-        
+
         total_loss, num_tokens, metrics = loss_func(loss_mask, output_tensor)
-        
+
         assert total_loss.item() == 0.0
         assert num_tokens.item() == 0
 
 
 class TestGetBatch:
     """Test cases for get_batch()."""
-    
+
     def test_returns_none_for_none_iterator(self):
         """Test returns None when iterator is None."""
         from megatron.bridge.training.mimo_step import get_batch
-        
+
         result = get_batch(None)
         assert result is None
-    
+
     def test_returns_none_on_stop_iteration(self):
         """Test returns None when iterator is exhausted."""
         from megatron.bridge.training.mimo_step import get_batch
-        
+
         empty_iter = iter([])
         result = get_batch(empty_iter)
         assert result is None
-    
+
     def test_returns_batch_from_iterator(self):
         """Test returns batch from iterator."""
         from megatron.bridge.training.mimo_step import get_batch
-        
-        batch = {'input_ids': torch.tensor([1, 2, 3])}
+
+        batch = {"input_ids": torch.tensor([1, 2, 3])}
         data_iter = iter([batch])
-        
+
         result = get_batch(data_iter)
-        
+
         assert result is not None
-        assert 'input_ids' in result
+        assert "input_ids" in result
 
 
 class TestForwardStep:
     """Test cases for forward_step()."""
-    
-    @patch('megatron.bridge.training.mimo_step.unwrap_mimo_model')
+
+    @patch("megatron.bridge.training.mimo_step.unwrap_mimo_model")
     def test_forward_step_last_stage(self, mock_unwrap):
         """Test forward step at last pipeline stage returns loss func."""
         from megatron.bridge.training.mimo_step import forward_step
-        
+
         # Create mock state
         mock_state = MagicMock()
-        
+
         # Create mock model with role=None (indicates last stage)
         mock_model = MagicMock()
         mock_model.role = None  # role=None means is_last_stage=True
         mock_output = torch.tensor([1.0, 2.0])
         mock_loss_mask = torch.ones(2)
         mock_model.return_value = (mock_output, mock_loss_mask)
-        
+
         # unwrap_mimo_model returns the mock model itself
         mock_unwrap.return_value = mock_model
-        
+
         # Create mock iterator
-        batch = {'input_ids': torch.tensor([1, 2])}
+        batch = {"input_ids": torch.tensor([1, 2])}
         data_iter = iter([batch])
-        
+
         output, loss_fn = forward_step(mock_state, data_iter, mock_model)
-        
+
         # At last stage, should return loss function
         assert loss_fn is not None
         assert callable(loss_fn)
-    
-    @patch('megatron.bridge.training.mimo_step.unwrap_mimo_model')
+
+    @patch("megatron.bridge.training.mimo_step.unwrap_mimo_model")
     def test_forward_step_intermediate_stage(self, mock_unwrap):
         """Test forward step at intermediate stage returns None for loss func."""
         from megatron.bridge.training.mimo_step import forward_step
-        
+
         mock_state = MagicMock()
         mock_model = MagicMock()
         # Configure role to indicate intermediate stage (not last stage)
         mock_role = MagicMock()
         mock_role.has_language_module = True
         mock_role.has_modality_modules = False
-        mock_role.language_module_name = 'llm'
         mock_role.is_last_stage.return_value = False
         mock_role.is_first_stage.return_value = True
         mock_model.role = mock_role
         mock_model.return_value = (torch.tensor([1.0]), None)
-        
+
         mock_unwrap.return_value = mock_model
-        
-        batch = {'input_ids': torch.tensor([1, 2])}
+
+        batch = {"input_ids": torch.tensor([1, 2])}
         data_iter = iter([batch])
-        
+
         output, loss_fn = forward_step(mock_state, data_iter, mock_model)
-        
+
         # Intermediate stage should return None for loss_fn
         assert loss_fn is None
-    
-    @patch('megatron.bridge.training.mimo_step.unwrap_mimo_model')
+
+    @patch("megatron.bridge.training.mimo_step.unwrap_mimo_model")
     def test_forward_step_rejects_dict_at_last_stage(self, mock_unwrap):
         """Test forward step raises error if dict returned at last stage."""
         from megatron.bridge.training.mimo_step import forward_step
-        
+
         mock_state = MagicMock()
         mock_model = MagicMock()
         mock_model.role = None  # role=None means is_last_stage=True
         # Return dict (incorrect for last stage)
-        mock_model.return_value = ({'encoder': torch.tensor([1.0])}, None)
-        
+        mock_model.return_value = ({"encoder": torch.tensor([1.0])}, None)
+
         mock_unwrap.return_value = mock_model
-        
-        batch = {'input_ids': torch.tensor([1, 2])}
+
+        batch = {"input_ids": torch.tensor([1, 2])}
         data_iter = iter([batch])
-        
+
         with pytest.raises(ValueError, match="Last pipeline stage must return scalar loss"):
             forward_step(mock_state, data_iter, mock_model)
-    
+
     def test_forward_step_uses_global_state_signature(self):
         """Test forward step uses 3-arg signature with GlobalState."""
-        from megatron.bridge.training.mimo_step import forward_step
         import inspect
-        
+
+        from megatron.bridge.training.mimo_step import forward_step
+
         sig = inspect.signature(forward_step)
         params = list(sig.parameters.keys())
-        
+
         # Should have state as first parameter
-        assert params[0] == 'state'
+        assert params[0] == "state"
         assert len(params) == 3

--- a/tests/unit_tests/training/mimo/test_mimo_step.py
+++ b/tests/unit_tests/training/mimo/test_mimo_step.py
@@ -1,0 +1,173 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+"""Unit tests for MIMO forward step functions."""
+
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+import torch
+
+
+class TestLossFunc:
+    """Test cases for loss_func()."""
+    
+    def test_loss_computation(self):
+        """Test loss is computed correctly with mask."""
+        from megatron.bridge.training.mimo_step import loss_func
+        
+        # Create test data
+        output_tensor = torch.tensor([1.0, 2.0, 3.0, 4.0])
+        loss_mask = torch.tensor([1.0, 1.0, 0.0, 1.0])  # Mask out 3rd element
+        
+        total_loss, num_tokens, metrics = loss_func(loss_mask, output_tensor)
+        
+        # Expected: (1.0*1 + 2.0*1 + 3.0*0 + 4.0*1) = 7.0
+        assert total_loss.item() == 7.0
+        # Expected tokens: 3 (sum of mask)
+        assert num_tokens.item() == 3
+        # Check metrics dict structure
+        assert 'lm loss' in metrics
+    
+    def test_loss_with_all_ones_mask(self):
+        """Test loss with all-ones mask."""
+        from megatron.bridge.training.mimo_step import loss_func
+        
+        output_tensor = torch.tensor([1.0, 2.0, 3.0])
+        loss_mask = torch.ones(3)
+        
+        total_loss, num_tokens, metrics = loss_func(loss_mask, output_tensor)
+        
+        assert total_loss.item() == 6.0
+        assert num_tokens.item() == 3
+    
+    def test_loss_with_all_zeros_mask(self):
+        """Test loss with all-zeros mask."""
+        from megatron.bridge.training.mimo_step import loss_func
+        
+        output_tensor = torch.tensor([1.0, 2.0, 3.0])
+        loss_mask = torch.zeros(3)
+        
+        total_loss, num_tokens, metrics = loss_func(loss_mask, output_tensor)
+        
+        assert total_loss.item() == 0.0
+        assert num_tokens.item() == 0
+
+
+class TestGetBatch:
+    """Test cases for get_batch()."""
+    
+    def test_returns_none_for_none_iterator(self):
+        """Test returns None when iterator is None."""
+        from megatron.bridge.training.mimo_step import get_batch
+        
+        result = get_batch(None)
+        assert result is None
+    
+    def test_returns_none_on_stop_iteration(self):
+        """Test returns None when iterator is exhausted."""
+        from megatron.bridge.training.mimo_step import get_batch
+        
+        empty_iter = iter([])
+        result = get_batch(empty_iter)
+        assert result is None
+    
+    def test_returns_batch_from_iterator(self):
+        """Test returns batch from iterator."""
+        from megatron.bridge.training.mimo_step import get_batch
+        
+        batch = {'input_ids': torch.tensor([1, 2, 3])}
+        data_iter = iter([batch])
+        
+        result = get_batch(data_iter)
+        
+        assert result is not None
+        assert 'input_ids' in result
+
+
+class TestForwardStep:
+    """Test cases for forward_step()."""
+    
+    @patch('megatron.bridge.training.mimo_step.unwrap_mimo_model')
+    def test_forward_step_last_stage(self, mock_unwrap):
+        """Test forward step at last pipeline stage returns loss func."""
+        from megatron.bridge.training.mimo_step import forward_step
+        
+        # Create mock state
+        mock_state = MagicMock()
+        
+        # Create mock model with role=None (indicates last stage)
+        mock_model = MagicMock()
+        mock_model.role = None  # role=None means is_last_stage=True
+        mock_output = torch.tensor([1.0, 2.0])
+        mock_loss_mask = torch.ones(2)
+        mock_model.return_value = (mock_output, mock_loss_mask)
+        
+        # unwrap_mimo_model returns the mock model itself
+        mock_unwrap.return_value = mock_model
+        
+        # Create mock iterator
+        batch = {'input_ids': torch.tensor([1, 2])}
+        data_iter = iter([batch])
+        
+        output, loss_fn = forward_step(mock_state, data_iter, mock_model)
+        
+        # At last stage, should return loss function
+        assert loss_fn is not None
+        assert callable(loss_fn)
+    
+    @patch('megatron.bridge.training.mimo_step.unwrap_mimo_model')
+    def test_forward_step_intermediate_stage(self, mock_unwrap):
+        """Test forward step at intermediate stage returns None for loss func."""
+        from megatron.bridge.training.mimo_step import forward_step
+        
+        mock_state = MagicMock()
+        mock_model = MagicMock()
+        # Configure role to indicate intermediate stage (not last stage)
+        mock_role = MagicMock()
+        mock_role.has_language_module = True
+        mock_role.has_modality_modules = False
+        mock_role.language_module_name = 'llm'
+        mock_role.is_last_stage.return_value = False
+        mock_role.is_first_stage.return_value = True
+        mock_model.role = mock_role
+        mock_model.return_value = (torch.tensor([1.0]), None)
+        
+        mock_unwrap.return_value = mock_model
+        
+        batch = {'input_ids': torch.tensor([1, 2])}
+        data_iter = iter([batch])
+        
+        output, loss_fn = forward_step(mock_state, data_iter, mock_model)
+        
+        # Intermediate stage should return None for loss_fn
+        assert loss_fn is None
+    
+    @patch('megatron.bridge.training.mimo_step.unwrap_mimo_model')
+    def test_forward_step_rejects_dict_at_last_stage(self, mock_unwrap):
+        """Test forward step raises error if dict returned at last stage."""
+        from megatron.bridge.training.mimo_step import forward_step
+        
+        mock_state = MagicMock()
+        mock_model = MagicMock()
+        mock_model.role = None  # role=None means is_last_stage=True
+        # Return dict (incorrect for last stage)
+        mock_model.return_value = ({'encoder': torch.tensor([1.0])}, None)
+        
+        mock_unwrap.return_value = mock_model
+        
+        batch = {'input_ids': torch.tensor([1, 2])}
+        data_iter = iter([batch])
+        
+        with pytest.raises(ValueError, match="Last pipeline stage must return scalar loss"):
+            forward_step(mock_state, data_iter, mock_model)
+    
+    def test_forward_step_uses_global_state_signature(self):
+        """Test forward step uses 3-arg signature with GlobalState."""
+        from megatron.bridge.training.mimo_step import forward_step
+        import inspect
+        
+        sig = inspect.signature(forward_step)
+        params = list(sig.parameters.keys())
+        
+        # Should have state as first parameter
+        assert params[0] == 'state'
+        assert len(params) == 3

--- a/tests/unit_tests/training/mimo/test_pretrain_mimo.py
+++ b/tests/unit_tests/training/mimo/test_pretrain_mimo.py
@@ -1,0 +1,123 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+"""Unit tests for MIMO pretrain entrypoint wiring."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _make_cfg():
+    cfg = MagicMock()
+    cfg.train = SimpleNamespace(
+        rampup_batch_size=None,
+        global_batch_size=1,
+        micro_batch_size=1,
+        decrease_batch_size_if_needed=False,
+    )
+    cfg.data_parallel_size = 1
+    return cfg
+
+
+def _make_setup_output(module_to_grid_map):
+    return SimpleNamespace(
+        model=MagicMock(),
+        mimo_infra=SimpleNamespace(module_to_grid_map=module_to_grid_map),
+        multimodule_communicator=MagicMock(),
+        train_data_iterator=iter([]),
+        valid_data_iterator=None,
+        global_state=MagicMock(),
+    )
+
+
+@patch("megatron.bridge.training.pretrain_mimo.train_mimo")
+@patch("megatron.bridge.training.pretrain_mimo.setup_mimo")
+@patch("megatron.bridge.training.pretrain_mimo.unwrap_mimo_model")
+@patch("megatron.bridge.training.pretrain_mimo.dist")
+def test_pretrain_mimo_uses_constructor_wired_config(
+    mock_dist, mock_unwrap_mimo_model, mock_setup_mimo, mock_train_mimo
+):
+    """Pretrain path should use constructor-wired config, not mutate it."""
+    from megatron.bridge.training.pretrain_mimo import pretrain_mimo
+
+    cfg = _make_cfg()
+    opt_config = MagicMock()
+    opt_config.finalize = MagicMock()
+    schedulers = {}
+    forward_step_func = MagicMock()
+
+    mock_dist.get_rank.return_value = 0
+
+    sentinel_grid_map = {"llm": MagicMock()}
+    setup_output = _make_setup_output(module_to_grid_map=sentinel_grid_map)
+    mock_setup_mimo.return_value = setup_output
+
+    original_grid_map = {"llm": MagicMock()}
+    unwrapped_model = MagicMock()
+    unwrapped_model.mimo_config = SimpleNamespace(
+        module_to_grid_map=original_grid_map,
+        language_module_key="llm",
+    )
+    mock_unwrap_mimo_model.return_value = unwrapped_model
+
+    with (
+        patch("megatron.core.num_microbatches_calculator._GLOBAL_NUM_MICROBATCHES_CALCULATOR", None),
+        patch("megatron.core.num_microbatches_calculator.init_num_microbatches_calculator"),
+        patch("megatron.core.models.mimo.optimizer.get_mimo_optimizer") as mock_get_optimizer,
+    ):
+        mock_get_optimizer.return_value = MagicMock()
+
+        pretrain_mimo(
+            cfg=cfg,
+            mimo_provider=MagicMock(),
+            forward_step_func=forward_step_func,
+            build_data_iterators_fn=MagicMock(),
+            opt_config=opt_config,
+            schedulers=schedulers,
+            global_state=MagicMock(),
+        )
+
+    # No post-construction mutation: keep original references/values.
+    assert unwrapped_model.mimo_config.module_to_grid_map is original_grid_map
+    assert unwrapped_model.mimo_config.language_module_key == "llm"
+    mock_train_mimo.assert_called_once()
+
+
+@patch("megatron.bridge.training.pretrain_mimo.setup_mimo")
+@patch("megatron.bridge.training.pretrain_mimo.unwrap_mimo_model")
+@patch("megatron.bridge.training.pretrain_mimo.dist")
+def test_pretrain_mimo_asserts_when_constructor_fields_missing(mock_dist, mock_unwrap_mimo_model, mock_setup_mimo):
+    """Guardrail should fail when constructor-time config wiring is missing."""
+    from megatron.bridge.training.pretrain_mimo import pretrain_mimo
+
+    cfg = _make_cfg()
+    opt_config = MagicMock()
+    opt_config.finalize = MagicMock()
+
+    mock_dist.get_rank.return_value = 0
+
+    # Infra indicates MIMO-parallel path is active.
+    mock_setup_mimo.return_value = _make_setup_output(module_to_grid_map={"llm": MagicMock()})
+
+    # Missing constructor-wired fields should trigger assertion.
+    unwrapped_model = MagicMock()
+    unwrapped_model.mimo_config = SimpleNamespace(
+        module_to_grid_map=None,
+        language_module_key=None,
+    )
+    mock_unwrap_mimo_model.return_value = unwrapped_model
+
+    with (
+        patch("megatron.core.num_microbatches_calculator._GLOBAL_NUM_MICROBATCHES_CALCULATOR", None),
+        patch("megatron.core.num_microbatches_calculator.init_num_microbatches_calculator"),
+    ):
+        with pytest.raises(AssertionError, match="module_to_grid_map must be set"):
+            pretrain_mimo(
+                cfg=cfg,
+                mimo_provider=MagicMock(),
+                forward_step_func=MagicMock(),
+                build_data_iterators_fn=MagicMock(),
+                opt_config=opt_config,
+                schedulers={},
+                global_state=MagicMock(),
+            )

--- a/tests/unit_tests/training/mimo/test_pretrain_mimo.py
+++ b/tests/unit_tests/training/mimo/test_pretrain_mimo.py
@@ -29,7 +29,7 @@ def _make_setup_output(module_to_grid_map):
         model=MagicMock(),
         mimo_infra=SimpleNamespace(
             module_to_grid_map=module_to_grid_map,
-            pg_collections={"llm": MagicMock()},
+            pg_collections={"language": MagicMock()},
         ),
         multimodule_communicator=MagicMock(),
         train_data_iterator=iter([]),

--- a/tests/unit_tests/training/mimo/test_pretrain_mimo.py
+++ b/tests/unit_tests/training/mimo/test_pretrain_mimo.py
@@ -16,17 +16,26 @@ def _make_cfg():
         decrease_batch_size_if_needed=False,
     )
     cfg.data_parallel_size = 1
+    cfg.checkpoint.load = None
+    cfg.checkpoint.pretrained_checkpoint = None
+    cfg.checkpoint.non_persistent_ckpt_type = None
     return cfg
 
 
 def _make_setup_output(module_to_grid_map):
+    global_state = MagicMock()
+    global_state.train_state.step = 0
     return SimpleNamespace(
         model=MagicMock(),
-        mimo_infra=SimpleNamespace(module_to_grid_map=module_to_grid_map),
+        mimo_infra=SimpleNamespace(
+            module_to_grid_map=module_to_grid_map,
+            pg_collections={"llm": MagicMock()},
+        ),
         multimodule_communicator=MagicMock(),
         train_data_iterator=iter([]),
         valid_data_iterator=None,
-        global_state=MagicMock(),
+        global_state=global_state,
+        checkpointing_context=None,
     )
 
 
@@ -70,7 +79,7 @@ def test_pretrain_mimo_uses_constructor_wired_config(
             cfg=cfg,
             mimo_provider=MagicMock(),
             forward_step_func=forward_step_func,
-            build_data_iterators_fn=MagicMock(),
+            build_data_iterators_fn=MagicMock(return_value=(iter([]), None)),
             opt_config=opt_config,
             schedulers=schedulers,
             global_state=MagicMock(),

--- a/tests/unit_tests/training/mimo/test_pretrain_mimo.py
+++ b/tests/unit_tests/training/mimo/test_pretrain_mimo.py
@@ -48,15 +48,14 @@ def test_pretrain_mimo_uses_constructor_wired_config(
 
     mock_dist.get_rank.return_value = 0
 
-    sentinel_grid_map = {"llm": MagicMock()}
+    sentinel_grid_map = {"language": MagicMock()}
     setup_output = _make_setup_output(module_to_grid_map=sentinel_grid_map)
     mock_setup_mimo.return_value = setup_output
 
-    original_grid_map = {"llm": MagicMock()}
+    original_grid_map = {"language": MagicMock()}
     unwrapped_model = MagicMock()
     unwrapped_model.mimo_config = SimpleNamespace(
         module_to_grid_map=original_grid_map,
-        language_module_key="llm",
     )
     mock_unwrap_mimo_model.return_value = unwrapped_model
 
@@ -79,7 +78,6 @@ def test_pretrain_mimo_uses_constructor_wired_config(
 
     # No post-construction mutation: keep original references/values.
     assert unwrapped_model.mimo_config.module_to_grid_map is original_grid_map
-    assert unwrapped_model.mimo_config.language_module_key == "llm"
     mock_train_mimo.assert_called_once()
 
 
@@ -97,13 +95,12 @@ def test_pretrain_mimo_asserts_when_constructor_fields_missing(mock_dist, mock_u
     mock_dist.get_rank.return_value = 0
 
     # Infra indicates MIMO-parallel path is active.
-    mock_setup_mimo.return_value = _make_setup_output(module_to_grid_map={"llm": MagicMock()})
+    mock_setup_mimo.return_value = _make_setup_output(module_to_grid_map={"language": MagicMock()})
 
     # Missing constructor-wired fields should trigger assertion.
     unwrapped_model = MagicMock()
     unwrapped_model.mimo_config = SimpleNamespace(
         module_to_grid_map=None,
-        language_module_key=None,
     )
     mock_unwrap_mimo_model.return_value = unwrapped_model
 


### PR DESCRIPTION

# What does this PR do ?

When encoder_dp > llm_dp in heterogeneous parallelism, the LLM's loss normalization divides by all tokens it processes, but after bridge fan-out each encoder DP rank only carries gradients for llm_dp / encoder_dp of the samples. This makes encoder gradients too small. Fix by scaling encoder gradients up by encoder_dp / llm_dp after DDP finalization.
Broadcast num_tokens from the LLM's last pipeline stage to all ranks so that encoder-only ranks (which see num_tokens=0) can correctly scale their gradients by 1/total_num_tokens.
Add helper _get_dp_size_from_grid() that reads DP size from grid shape metadata, working on all ranks including those outside the grid.
Details
In finalize_model_grads_multimodule, after each module's _finalize_model_grads call, we now compare the module's DP size against the LLM's DP size. If they differ (heterogeneous case), we call module.scale_gradients(module_dp / llm_dp) to compensate for the normalization mismatch.

The num_tokens broadcast ensures that when calculate_per_token_loss=True, all ranks — including encoder-only ranks that never accumulate token counts — receive the correct total from the LLM's last pipeline stage.


# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
