### PR TITLE
[misc] feat: Add NVTX ranges for train_step and optimizer_step

### DIFF
--- a/src/megatron/bridge/training/train.py
+++ b/src/megatron/bridge/training/train.py
@@ -58,6 +58,9 @@ from megatron.core.utils import (
     check_param_hashes_across_dp_replicas,
     get_attr_wrapped_model,
     get_model_config,
+    nvtx_decorator,
+    nvtx_range_pop,
+    nvtx_range_push,
 )
 from modelopt.torch.distill.plugins.megatron import get_tensor_shapes_adjust_fn_for_distillation
 
@@ -805,6 +808,7 @@ def train(
         )
 
 
+@nvtx_decorator()
 def train_step(
     forward_step_func: ForwardStepCallable,
     data_iterator: Optional[Union[RerunDataIterator, list[RerunDataIterator]]],
@@ -918,6 +922,7 @@ def train_step(
         torch.cuda.empty_cache()
 
     # Update parameters.
+    nvtx_range_push(suffix="optimizer_step")
     timers("optimizer", log_level=1).start(barrier=optim_config.barrier_with_L1_time)
     update_successful, grad_norm, num_zeros_in_grad = optimizer.step()
 
@@ -928,6 +933,7 @@ def train_step(
         log_max_attention_logit = clip_qk(model)
 
     timers("optimizer").stop()
+    nvtx_range_pop(suffix="optimizer_step")
 
     # when freezing sub-models we may have a mixture of successful and unsucessful ranks,
     # so we must gather across mp ranks


### PR DESCRIPTION
# What does this PR do ?

Add @nvtx_decorator() on train_step to emit an NVTX range named megatron.bridge.training.train.train_step, and add explicit nvtx_range_push/pop around the optimizer step block within train_step.

These ranges are gated by the nvtx_ranges profiling config and require the nvtx_decorator call-time fix in Megatron-LM (NVIDIA/Megatron-LM#4184).

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
