### PR TITLE
[ckpt] fix: Use device_map="cuda" for HF model in compare.py on multi-GPU nodes

### DIFF
--- a/examples/conversion/compare_hf_and_megatron/compare.py
+++ b/examples/conversion/compare_hf_and_megatron/compare.py
@@ -446,7 +446,7 @@ def _load_hf_model(args, is_vl_model: bool):
     hf_model = model_class.from_pretrained(
         args.hf_model_path,
         torch_dtype=torch.bfloat16,
-        device_map="auto",
+        device_map="cuda",
         trust_remote_code=is_safe_repo(
             trust_remote_code=args.trust_remote_code,
             hf_path=args.hf_model_path,


### PR DESCRIPTION
## Summary
- Fix `RuntimeError` in `compare.py` when running on multi-GPU nodes (8 GPUs)
- `device_map="auto"` spread the HF model across GPUs, placing embeddings on `cuda:7` while inputs were on `cuda:0`
- Changed to `device_map="cuda"` to load the full HF model on the current CUDA device, consistent with the roundtrip model loading already in the same file

## Test plan
- [x] Reproduced the bug on EOS cluster (8-GPU node) with `Qwen/Qwen3-1.7B` — got `RuntimeError: Expected all tensors to be on the same device`
- [x] Applied fix, reran — `EXIT=0`, token match ✅, cosine similarity 99.99% ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated example code to improve GPU device placement for HuggingFace model loading, ensuring more reliable memory management during model initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->