### PR TITLE
[ckpt] fix: Unwrap tuple output in Nemotron VLM forward step

### DIFF
--- a/examples/conversion/hf_to_megatron_generate_nemotron_vlm.py
+++ b/examples/conversion/hf_to_megatron_generate_nemotron_vlm.py
@@ -114,7 +114,10 @@ def vlm_forward_step(data_iterator, model, **kwargs) -> torch.Tensor:
     def loss_func(x, **kwargs):
         return x
 
-    return model(**forward_args), loss_func
+    output = model(**forward_args)
+    if isinstance(output, tuple):
+        output = output[0]
+    return output, loss_func
 
 
 def load_image(image_path: str) -> Image.Image:


### PR DESCRIPTION
## Summary
- The Nemotron VLM model (`nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16`) forward pass returns a tuple `(logits, aux_info)` instead of a single tensor
- The Megatron pipeline schedule's `forward_step_calc_loss` accesses `output_tensor.device`, which crashes with `AttributeError: 'tuple' object has no attribute 'device'`
- Fix: unwrap the tuple in `vlm_forward_step()` in `hf_to_megatron_generate_nemotron_vlm.py` so only the logits tensor is returned

## Test plan
- [x] Reproduced the crash on EOS cluster with the Nemotron Nano 12B VL model
- [x] Verified the fix produces valid generation output (EXIT=0, coherent image description)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed output handling in the Nemotron VLM model conversion example to ensure proper processing of model outputs during the conversion process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->