### PR TITLE
Expose fully_parallel_save in save_megatron_model

### DIFF
--- a/src/megatron/bridge/models/conversion/auto_bridge.py
+++ b/src/megatron/bridge/models/conversion/auto_bridge.py
@@ -885,6 +885,7 @@ class AutoBridge(Generic[MegatronModelT]):
         low_memory_save: bool = False,
         hf_tokenizer_kwargs: Optional[dict] = None,
         fully_parallel_save: bool = True,
+        validate_access_integrity: bool = True,
     ) -> None:
         """
         Save a Megatron model in native Megatron checkpoint format without optimizer
@@ -948,6 +949,7 @@ class AutoBridge(Generic[MegatronModelT]):
             low_memory_save=low_memory_save,
             hf_tokenizer_kwargs=hf_tokenizer_kwargs,
             fully_parallel_save=fully_parallel_save,
+            validate_access_integrity=validate_access_integrity,
         )
 
     def load_megatron_model(

--- a/src/megatron/bridge/models/conversion/auto_bridge.py
+++ b/src/megatron/bridge/models/conversion/auto_bridge.py
@@ -884,6 +884,7 @@ class AutoBridge(Generic[MegatronModelT]):
         hf_tokenizer_path: Optional[str | Path] = None,
         low_memory_save: bool = False,
         hf_tokenizer_kwargs: Optional[dict] = None,
+        fully_parallel_save: bool = True,
     ) -> None:
         """
         Save a Megatron model in native Megatron checkpoint format without optimizer
@@ -907,6 +908,10 @@ class AutoBridge(Generic[MegatronModelT]):
             hf_tokenizer_kwargs: Optional dictionary of kwargs to pass to the HuggingFace tokenizer.
                 Common options include trust_remote_code=True for models with custom tokenizers,
                 or use_fast=True for models that require the fast tokenizer.
+            fully_parallel_save: If True (default), uses fully parallel save strategy which
+                requires all DP ranks to participate in collective operations. Set to False
+                when saving from contexts where not all ranks will enter the save path
+                (e.g., mixed training/inference worlds with non-colocated vLLM).
 
         Example:
             >>> # Save model checkpoint after conversion
@@ -942,6 +947,7 @@ class AutoBridge(Generic[MegatronModelT]):
             hf_tokenizer_path=hf_tokenizer_path,
             low_memory_save=low_memory_save,
             hf_tokenizer_kwargs=hf_tokenizer_kwargs,
+            fully_parallel_save=fully_parallel_save,
         )
 
     def load_megatron_model(

--- a/src/megatron/bridge/training/model_load_save.py
+++ b/src/megatron/bridge/training/model_load_save.py
@@ -447,6 +447,8 @@ def save_megatron_model(
     low_memory_save: bool = False,
     hf_tokenizer_kwargs: Optional[dict] = None,
     fully_parallel_save: bool = True,
+    validate_access_integrity: bool = True,
+    distributed_timeout_minutes: int = 10,
 ) -> None:
     """Save a Megatron model in native Megatron checkpoint format without optimizer state.
 
@@ -544,6 +546,7 @@ def save_megatron_model(
             ckpt_format=ckpt_format,
             dist_ckpt_optim_fully_reshardable=True,
             fully_parallel_save=fully_parallel_save,
+            ckpt_assume_constant_structure=not validate_access_integrity,
         ),
         dist=None,
     )

--- a/src/megatron/bridge/training/model_load_save.py
+++ b/src/megatron/bridge/training/model_load_save.py
@@ -446,6 +446,7 @@ def save_megatron_model(
     hf_tokenizer_path: Optional[Union[str, Path]] = None,
     low_memory_save: bool = False,
     hf_tokenizer_kwargs: Optional[dict] = None,
+    fully_parallel_save: bool = True,
 ) -> None:
     """Save a Megatron model in native Megatron checkpoint format without optimizer state.
 
@@ -472,6 +473,10 @@ def save_megatron_model(
             Default is False, preserving the model for further use.
         hf_tokenizer_kwargs: Optional dictionary of kwargs to pass to the HuggingFace tokenizer.
             Common options include trust_remote_code=True for models with custom tokenizers.
+        fully_parallel_save: If True (default), uses fully parallel save strategy which
+            requires all DP ranks to participate in collective operations. Set to False
+            when saving from contexts where not all ranks will enter the save path
+            (e.g., mixed training/inference worlds with non-colocated vLLM).
 
     Example:
         >>> # Save model checkpoint
@@ -538,6 +543,7 @@ def save_megatron_model(
             save_rng=False,
             ckpt_format=ckpt_format,
             dist_ckpt_optim_fully_reshardable=True,
+            fully_parallel_save=fully_parallel_save,
         ),
         dist=None,
     )

--- a/tests/unit_tests/models/test_auto_bridge.py
+++ b/tests/unit_tests/models/test_auto_bridge.py
@@ -1010,6 +1010,8 @@ class TestAutoBridge:
                 hf_tokenizer_path=None,
                 low_memory_save=True,
                 hf_tokenizer_kwargs=None,
+                fully_parallel_save=True,
+                validate_access_integrity=True,
             )
 
     def test_save_megatron_model_with_tokenizer(self):
@@ -1038,6 +1040,34 @@ class TestAutoBridge:
                 hf_tokenizer_path="meta-llama/Meta-Llama-3-8B",
                 low_memory_save=True,
                 hf_tokenizer_kwargs=None,
+                fully_parallel_save=True,
+                validate_access_integrity=True,
+            )
+
+    def test_save_megatron_model_forwards_save_options(self):
+        """Test save_megatron_model forwards non-default save options."""
+        mock_hf_model = Mock(spec=PreTrainedCausalLM)
+        bridge = AutoBridge.__new__(AutoBridge)
+        bridge.hf_pretrained = mock_hf_model
+
+        mock_megatron_model = [Mock()]
+
+        with patch("megatron.bridge.training.model_load_save.save_megatron_model") as mock_save_megatron_model:
+            bridge.save_megatron_model(
+                mock_megatron_model,
+                "./checkpoint_path",
+                fully_parallel_save=False,
+                validate_access_integrity=False,
+            )
+
+            mock_save_megatron_model.assert_called_once_with(
+                mock_megatron_model,
+                "./checkpoint_path",
+                hf_tokenizer_path=None,
+                low_memory_save=False,
+                hf_tokenizer_kwargs=None,
+                fully_parallel_save=False,
+                validate_access_integrity=False,
             )
 
     def test_save_megatron_model_import_error(self):


### PR DESCRIPTION
## Summary

Add `fully_parallel_save` parameter to `AutoBridge.save_megatron_model()` and the underlying `model_load_save.save_megatron_model()`, forwarded to `CheckpointConfig`.

Defaults to `True` — no behavior change for existing callers.

## Problem

`save_megatron_model()` always creates a `CheckpointConfig` with `fully_parallel_save=True` (the dataclass default). This activates `FullyParallelSaveStrategyWrapper`, which calls `all_gather_object` on DP sub-groups. When the distributed world includes ranks that never enter the save path (e.g., vLLM inference workers in NeMo RL non-colocated setups), these collectives deadlock permanently.

Callers have no way to disable this behavior through the public API.

## Fix

Thread `fully_parallel_save: bool = True` through both layers:
- `AutoBridge.save_megatron_model()` → `model_load_save.save_megatron_model()` → `CheckpointConfig(..., fully_parallel_save=...)`

## Motivation

Needed by NVIDIA-NeMo/RL#2226 which fixes a deadlock during HF-to-Megatron checkpoint conversion in non-colocated training/inference setups.

## Test plan

- [x] Default behavior unchanged (`fully_parallel_save=True`)
- [ ] Validate with NeMo RL non-colocated 120B recipe (NVIDIA-NeMo/RL#2226)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable option for model checkpoint saving in distributed training scenarios, allowing control over parallel save behavior during the checkpoint process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->