### PR TITLE
Adding condition for how nccl_chunk_size var is being set as currentl…

### DIFF
--- a/scripts/performance/perf_plugins.py
+++ b/scripts/performance/perf_plugins.py
@@ -460,13 +460,10 @@ class PerfEnvPlugin(Plugin):
         # Set the chunk size of P2P communications
         nccl_pp_comm_chunksize = (
             2097152
-            if self.model_recipe_name in ["llama3_70b", "llama31_405b"] and self.train_task == "pretrain"
+            if (self.model_recipe_name in ["llama3_70b", "llama31_405b"] and self.train_task == "pretrain")
+            or (self.model_family_name in ["llama"] and self.train_task in ["sft"])
             else None
         )
-        if nccl_pp_comm_chunksize is None:
-            nccl_pp_comm_chunksize = (
-                2097152 if self.model_family_name in ["llama"] and self.train_task in ["sft"] else None
-            )
         self._set_nccl_pp_comm_chunksize(task, executor, nccl_pp_comm_chunksize, pp_size)
 
         # Configure manual garbage collection

--- a/scripts/performance/perf_plugins.py
+++ b/scripts/performance/perf_plugins.py
@@ -463,9 +463,10 @@ class PerfEnvPlugin(Plugin):
             if self.model_recipe_name in ["llama3_70b", "llama31_405b"] and self.train_task == "pretrain"
             else None
         )
-        nccl_pp_comm_chunksize = (
-            2097152 if self.model_family_name in ["llama"] and self.train_task in ["sft"] else None
-        )
+        if nccl_pp_comm_chunksize is None:
+            nccl_pp_comm_chunksize = (
+                2097152 if self.model_family_name in ["llama"] and self.train_task in ["sft"] else None
+            )
         self._set_nccl_pp_comm_chunksize(task, executor, nccl_pp_comm_chunksize, pp_size)
 
         # Configure manual garbage collection


### PR DESCRIPTION
Fix: NCCL_P2P_NET_CHUNKSIZE being silently dropped for pretrain tasks

Problem:
The NCCL_P2P_NET_CHUNKSIZE environment variable was not being set for pretrain runs of llama3_70b and llama31_405b, causing a ~8% performance regression in PP SendRecv communication time at large GPU scales (e.g., 512 GPUs with PP=4).
The root cause is a variable clobbering bug in perf_plugins.py. The pretrain chunksize assignment on line 461 is unconditionally overwritten by the SFT chunksize assignment on line 466:

```
# First assignment: correctly sets 2097152 for pretrain
nccl_pp_comm_chunksize = (
    2097152
    if self.model_recipe_name in ["llama3_70b", "llama31_405b"] and self.train_task == "pretrain"
    else None
)
# Second assignment: overwrites the above — since train_task is "pretrain" (not "sft"),
# this evaluates to None, clobbering the correct value
nccl_pp_comm_chunksize = (
    2097152 if self.model_family_name in ["llama"] and self.train_task in ["sft"] else None
)
```

This was introduced when SFT chunksize support was added between 26.02.00 (f7a9428) and 26.02.01 (a3e78cb). The 26.02.00 code only had the pretrain assignment and worked correctly.

Impact:
Without NCCL_P2P_NET_CHUNKSIZE=2097152, NCCL falls back to a smaller default chunk size for P2P transfers. At 512 GPUs with PP=4, the network fabric is heavily loaded with concurrent DP collectives, and smaller P2P chunks lead to more round-trips and worse bandwidth utilization. WiT analysis showed PP SendRecv alone accounted for ~5.76% of the total 8.17% step time regression (297ms increase per step).

Fix:
Guard the SFT assignment with if nccl_pp_comm_chunksize is None: so it only applies when the pretrain check didn't already set a value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the performance plugin configuration to properly initialize network communication settings. The setup logic now correctly respects previously configured values instead of unconditionally overwriting them during initialization.


The gitlab issue this corresponds to is: https://gitlab-master.nvidia.com/unified-cloud-benchmarking/llm-benchmarking-collection-internal/-/issues/285 @bdubauski @nv-mollys 


<!-- end of auto-generated comment: release notes by coderabbit.ai -->