### PR TITLE
[model] fix: remove TP <= num_query_groups guard for Qwen3.5 VL providers

### DIFF
--- a/src/megatron/bridge/models/qwen_vl/qwen35_vl_provider.py
+++ b/src/megatron/bridge/models/qwen_vl/qwen35_vl_provider.py
@@ -181,22 +181,6 @@ class Qwen35VLModelProvider(GPTModelProvider):
             self.vision_config = Qwen3_5VisionConfig()
         super().__post_init__()
 
-    def finalize(self) -> None:
-        self.validate_parallelism()
-        super().finalize()
-
-    def validate_parallelism(self):
-        """Validate that parallelism settings are compatible with this model's architecture.
-
-        Call this after mutating parallelism attributes (e.g. tensor_model_parallel_size)
-        on an already-constructed provider, since finalize() only runs once before provide().
-        """
-        if self.num_query_groups < self.tensor_model_parallel_size:
-            raise ValueError(
-                f"TP size {self.tensor_model_parallel_size} should be less than or equal to "
-                f"num_query_groups {self.num_query_groups}. Please use a smaller TP size."
-            )
-
     def provide(self, pre_process=None, post_process=None, vp_stage=None) -> Qwen3VLModel:
         """Provide a Qwen3.5 VL dense model instance with vision and language components."""
         from megatron.bridge.models.gpt_provider import mtp_block_spec
@@ -361,22 +345,6 @@ class Qwen35VLMoEModelProvider(GPTModelProvider):
         if self.vision_config is None:
             self.vision_config = Qwen3_5MoeVisionConfig()
         super().__post_init__()
-
-    def finalize(self) -> None:
-        self.validate_parallelism()
-        super().finalize()
-
-    def validate_parallelism(self):
-        """Validate that parallelism settings are compatible with this model's architecture.
-
-        Call this after mutating parallelism attributes (e.g. tensor_model_parallel_size)
-        on an already-constructed provider, since finalize() only runs once before provide().
-        """
-        if self.num_query_groups < self.tensor_model_parallel_size:
-            raise ValueError(
-                f"TP size {self.tensor_model_parallel_size} should be less than or equal to "
-                f"num_query_groups {self.num_query_groups}. Please use a smaller TP size."
-            )
 
     def provide(self, pre_process=None, post_process=None, vp_stage=None) -> Qwen3VLModel:
         """Provide a Qwen3.5 VL model instance with vision and language components.

--- a/tests/unit_tests/models/qwen_vl/test_qwen35_vl_provider.py
+++ b/tests/unit_tests/models/qwen_vl/test_qwen35_vl_provider.py
@@ -146,17 +146,6 @@ class TestQwen35VLModelProvider:
         assert hasattr(provider, "provide") and callable(provider.provide)
         assert hasattr(provider, "provide_language_model") and callable(provider.provide_language_model)
 
-    def test_tp_validation(self):
-        provider = Qwen35VLModelProvider(
-            num_layers=64,
-            hidden_size=5120,
-            num_attention_heads=24,
-            num_query_groups=2,
-            tensor_model_parallel_size=4,
-        )
-        with pytest.raises(ValueError, match="TP size"):
-            provider.finalize()
-
 
 @pytest.mark.skipif(not _TRANSFORMERS_HAS_QWEN3_5_MOE, reason="transformers does not have qwen3_5_moe support")
 class TestQwen35VLMoEModelProvider:
@@ -231,14 +220,3 @@ class TestQwen35VLMoEModelProvider:
             num_attention_heads=32,
         )
         assert isinstance(provider.vision_config, Qwen3_5MoeVisionConfig)
-
-    def test_tp_validation(self):
-        provider = Qwen35VLMoEModelProvider(
-            num_layers=60,
-            hidden_size=4096,
-            num_attention_heads=32,
-            num_query_groups=2,
-            tensor_model_parallel_size=4,
-        )
-        with pytest.raises(ValueError, match="TP size"):
-            provider.finalize()


### PR DESCRIPTION
# What does this PR do?

Remove overly restrictive `validate_parallelism()` guards from `Qwen35VLModelProvider` and `Qwen35VLMoEModelProvider` that blocked TP > `num_query_groups`.

# Changelog

- Remove `validate_parallelism()` and `finalize()` overrides from `Qwen35VLModelProvider` and `Qwen35VLMoEModelProvider`
- Megatron Core now supports TP > `num_query_groups` via QKV activation sub-sharding (NVIDIA/Megatron-LM#2565), so the Bridge-side guard is no longer needed

# GitHub Actions CI

See the CI section in the Contributing doc for how to trigger the CI.
A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

Pre checks:
- [x] Make sure you read and followed Contributor guidelines
- [ ] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

# Additional Information

Upstream support: NVIDIA/Megatron-LM#2565 ("Support TP greater than num_kv_heads by supporting QKV activation sub-sharding")

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified Qwen 3.5 VL model provider implementation by removing internal validation overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->