### PR TITLE
[perf] fix: guard cuda_graph_scope validation against None

### DIFF
--- a/scripts/performance/utils/overrides.py
+++ b/scripts/performance/utils/overrides.py
@@ -113,14 +113,17 @@ def _set_cuda_graph_overrides(
         else:  # this condition ensures we unset in case of user override to "none" from default
             recipe.rng.te_rng_tracker = recipe.model.use_te_rng_tracker = False
 
-        if cuda_graph_impl == "transformer_engine":
-            valid_te_scopes = ["attn", "mlp", "moe", "moe_router", "moe_preprocess", "mamba"]
-            assert all(scope in valid_te_scopes for scope in cuda_graph_scope), (
-                f"Invalid cuda graph scope: {cuda_graph_scope}. Valid options are: {valid_te_scopes}"
-            )
-
     if cuda_graph_scope is not None:
         recipe.model.cuda_graph_scope = cuda_graph_scope
+
+    # Validate post-override state so we check the effective recipe value,
+    # not the raw CLI input (which may be None when the recipe default is used).
+    if recipe.model.cuda_graph_impl == "transformer_engine":
+        valid_te_scopes = ["attn", "mlp", "moe", "moe_router", "moe_preprocess", "mamba"]
+        effective_scope = getattr(recipe.model, "cuda_graph_scope", None)
+        assert effective_scope is not None and all(scope in valid_te_scopes for scope in effective_scope), (
+            f"Invalid cuda graph scope: {effective_scope}. Valid options are: {valid_te_scopes}"
+        )
 
     return recipe
 


### PR DESCRIPTION
## Summary
- Fix `TypeError: 'NoneType' object is not iterable` in `_set_cuda_graph_overrides()` when `cuda_graph_scope` is not passed via CLI
- Move TE scope validation **after** both `cuda_graph_impl` and `cuda_graph_scope` writes so it validates the effective recipe state, not the raw CLI input
- When `cuda_graph_scope` is omitted, the recipe default from `set_workload_base_configs()` is now correctly used

Fixes #3247

## Test plan
- [ ] Run `python scripts/performance/run_script.py --cuda_graph_impl transformer_engine -m gpt_oss -mr gpt_oss_120b -g b300 -c bf16 --task pretrain -ng 64 -gn 8 -tp 1 -pp 1 -ep 8 -mb 4 -gb 1280 --detach false` without `--cuda_graph_scope` — should no longer crash
- [ ] Run with explicit `--cuda_graph_scope attn mlp` — should still work
- [ ] Run with invalid scope `--cuda_graph_scope bogus` — should raise `AssertionError` with a clear message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CUDA graph scope validation to correctly handle recipe defaults and apply validation at the appropriate stage in the configuration process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->