### PR TITLE
perf: Set micro_batch_size=2 for qwen3 235B B300 V2 configs

### DIFF
--- a/scripts/performance/configs/qwen/qwen3_workload_base_configs.py
+++ b/scripts/performance/configs/qwen/qwen3_workload_base_configs.py
@@ -230,6 +230,7 @@ QWEN3_235B_A22B_PRETRAIN_CONFIG_B300_BF16_V2 = replace(
     QWEN3_235B_A22B_PRETRAIN_CONFIG_B300_BF16_V1,
     num_gpus=256,
     global_batch_size=8192,
+    micro_batch_size=2,
 )
 
 
@@ -237,6 +238,7 @@ QWEN3_235B_A22B_PRETRAIN_CONFIG_B300_FP8_CS_V2 = replace(
     QWEN3_235B_A22B_PRETRAIN_CONFIG_B300_FP8_CS_V1,
     num_gpus=256,
     global_batch_size=8192,
+    micro_batch_size=2,
 )
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated performance configurations for Qwen3 model training presets to optimize resource allocation and batch processing efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->