### PR TITLE
[data] fix: enable WAN sequence packing by default to fix rope_utils crash

### DIFF
--- a/src/megatron/bridge/data/energon/base_energon_datamodule.py
+++ b/src/megatron/bridge/data/energon/base_energon_datamodule.py
@@ -225,12 +225,11 @@ class EnergonMultiModalDataModule:
         Returns:
         EVAL_DATALOADERS: The DataLoader for the validation dataset.
         """
-        if self.val_dataloader_object:
-            return self.val_dataloader_object
-        worker_config = self._build_worker_config(self.num_val_workers, split="val")
-        val_dataset = self.datasets_provider(worker_config, split="val")
-        energon_loader = get_savable_loader(val_dataset, worker_config=worker_config)
-        self.val_dataloader_object = energon_loader
+        if self.val_dataloader_object is None:
+            worker_config = self._build_worker_config(self.num_val_workers, split="val")
+            val_dataset = self.datasets_provider(worker_config, split="val")
+            energon_loader = get_savable_loader(val_dataset, worker_config=worker_config)
+            self.val_dataloader_object = energon_loader
         return EnergonDataloader(self.val_dataloader_object)
 
     def test_dataloader(self) -> None:

--- a/src/megatron/bridge/diffusion/data/wan/wan_energon_datamodule.py
+++ b/src/megatron/bridge/diffusion/data/wan/wan_energon_datamodule.py
@@ -52,7 +52,7 @@ class WanDatasetConfig(DatasetProvider):
 
     path: Optional[Union[str, list]] = None
     seq_length: int = 1024
-    packing_buffer_size: Optional[int] = None
+    packing_buffer_size: Optional[int] = 200
     micro_batch_size: int = 1
     global_batch_size: int = 4
     num_workers: int = 16

--- a/src/megatron/bridge/diffusion/data/wan/wan_energon_datamodule.py
+++ b/src/megatron/bridge/diffusion/data/wan/wan_energon_datamodule.py
@@ -52,7 +52,7 @@ class WanDatasetConfig(DatasetProvider):
 
     path: Optional[Union[str, list]] = None
     seq_length: int = 1024
-    packing_buffer_size: Optional[int] = 200
+    packing_buffer_size: int = 200
     micro_batch_size: int = 1
     global_batch_size: int = 4
     num_workers: int = 16
@@ -68,6 +68,8 @@ class WanDatasetConfig(DatasetProvider):
     context_embeddings_dim: int = 4096
 
     def __post_init__(self):
+        if self.packing_buffer_size is None:
+            raise ValueError("WAN requires sequence packing: `packing_buffer_size` cannot be None.")
         self.sequence_length = self.seq_length
 
     def build_datasets(self, context: DatasetBuildContext):

--- a/src/megatron/bridge/diffusion/recipes/wan/wan.py
+++ b/src/megatron/bridge/diffusion/recipes/wan/wan.py
@@ -78,7 +78,7 @@ def wan_1_3B_pretrain_config() -> ConfigContainer:
     dataset = WanDatasetConfig(
         path=None,
         seq_length=1024,
-        packing_buffer_size=None,
+        packing_buffer_size=200,
         micro_batch_size=micro_batch_size,
         global_batch_size=global_batch_size,
         num_workers=16,
@@ -180,7 +180,7 @@ def wan_14B_pretrain_config() -> ConfigContainer:
     dataset = WanDatasetConfig(
         path=None,
         seq_length=1024,
-        packing_buffer_size=None,
+        packing_buffer_size=200,
         micro_batch_size=micro_batch_size,
         global_batch_size=global_batch_size,
         num_workers=16,


### PR DESCRIPTION
## Summary

Fixing:
(1) Main issue:
Wan always need to be run with sequence packing. However, packing_buffer_size is default to None, which will not run sequence packing. => Fix: set default value of packing_buffer_size to an integer value.

(2) Another separate bug found:
Error when running test iterations at the end of training finish. val_dataloader() correctly wraps the loader in EnergonDataloader (which supports next()) on the first call but returns the raw SavableDataLoader (which doesn't) on the second call, causing the test iterator — created from the second call in build_datasets() — to crash with TypeError: 'SavableDataLoader' object is not an iterator. => Fix: Changed `if self.val_dataloader_object:` to `if self.val_dataloader_object is None:` and moved the return EnergonDataloader(...) outside the if block, so every call always returns an EnergonDataloader wrapper instead of the raw loader on the second call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Modified default data buffering configuration for WAN model pretraining. The buffering settings have been updated for both the 1.3B and 14B pretraining model variants, affecting how training data is buffered, organized, and processed during dataset construction and the model training execution phases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->