### PR TITLE
recover qwen3_vl perf script 

### DIFF
--- a/scripts/performance/configs/qwen_vl/qwen3_vl_pretrain.py
+++ b/scripts/performance/configs/qwen_vl/qwen3_vl_pretrain.py
@@ -77,7 +77,7 @@ def set_qwen3_vl_common_configs(cfg: ConfigContainer) -> None:
     cfg.comm_overlap.overlap_grad_reduce = False
 
 
-def qwen3_vl_235b_a22b_pretrain_mock_config_gb300(
+def qwen3_vl_235b_a22b_pretrain_config_gb300(
     precision: str = "bf16", mock: bool = True, config_variant: str = "v1"
 ) -> ConfigContainer:
     """GB300, baseline config."""
@@ -102,7 +102,7 @@ def qwen3_vl_235b_a22b_pretrain_mock_config_gb300(
     return cfg
 
 
-def qwen3_vl_235b_a22b_pretrain_mock_config_gb200(
+def qwen3_vl_235b_a22b_pretrain_config_gb200(
     precision: str = "bf16", mock: bool = True, config_variant: str = "v1"
 ) -> ConfigContainer:
     """GB200, baseline config."""
@@ -127,7 +127,7 @@ def qwen3_vl_235b_a22b_pretrain_mock_config_gb200(
     return cfg
 
 
-def qwen3_vl_235b_a22b_pretrain_mock_config_b200(
+def qwen3_vl_235b_a22b_pretrain_config_b200(
     precision: str = "bf16", mock: bool = True, config_variant: str = "v1"
 ) -> ConfigContainer:
     """B200, baseline config."""
@@ -157,7 +157,7 @@ def qwen3_vl_235b_a22b_pretrain_mock_config_b200(
     return cfg
 
 
-def qwen3_vl_235b_a22b_pretrain_mock_config_h100(
+def qwen3_vl_235b_a22b_pretrain_config_h100(
     precision: str = "bf16", mock: bool = True, config_variant: str = "v1"
 ) -> ConfigContainer:
     """H100, baseline config."""
@@ -180,7 +180,7 @@ def qwen3_vl_235b_a22b_pretrain_mock_config_h100(
     return cfg
 
 
-def qwen3_vl_30b_a3b_pretrain_mock_config_gb300(
+def qwen3_vl_30b_a3b_pretrain_config_gb300(
     precision: str = "bf16", mock: bool = True, config_variant: str = "v1"
 ) -> ConfigContainer:
     """GB300, baseline config."""
@@ -205,7 +205,7 @@ def qwen3_vl_30b_a3b_pretrain_mock_config_gb300(
     return cfg
 
 
-def qwen3_vl_30b_a3b_pretrain_mock_config_gb200(
+def qwen3_vl_30b_a3b_pretrain_config_gb200(
     precision: str = "bf16", mock: bool = True, config_variant: str = "v1"
 ) -> ConfigContainer:
     """GB200, baseline config."""
@@ -230,7 +230,7 @@ def qwen3_vl_30b_a3b_pretrain_mock_config_gb200(
     return cfg
 
 
-def qwen3_vl_30b_a3b_pretrain_mock_config_b200(
+def qwen3_vl_30b_a3b_pretrain_config_b200(
     precision: str = "bf16", mock: bool = True, config_variant: str = "v1"
 ) -> ConfigContainer:
     """B200, baseline config."""
@@ -255,7 +255,7 @@ def qwen3_vl_30b_a3b_pretrain_mock_config_b200(
     return cfg
 
 
-def qwen3_vl_30b_a3b_pretrain_mock_config_h100(
+def qwen3_vl_30b_a3b_pretrain_config_h100(
     precision: str = "bf16", mock: bool = True, config_variant: str = "v1"
 ) -> ConfigContainer:
     """H100, baseline config."""


### PR DESCRIPTION
# What does this PR do ?
Recover function names from qwen3_vl_xxx_pretrain_mock_config_xxx to qwen3_vl_xxx_pretrain_config_xxx in scripts/performance/configs/qwen_vl/qwen3_vl_pretrain.py.

The script scripts/performance/run_script.py uses template matching to find the corresponding function in scripts/performance/configs/qwen_vl/qwen3_vl_pretrain.py, so the function name cannot be changed arbitrarily.
But these names are changed after https://github.com/NVIDIA-NeMo/Megatron-Bridge/pull/3100.
And we need recover them.

Add a one line overview of what this PR aims to accomplish.

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated configuration function naming for Qwen3 VL model pretraining across multiple hardware accelerator types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->