### PR TITLE
[model] fix: fix gpt oss export

### DIFF
--- a/examples/conversion/hf_megatron_roundtrip_multi_gpu.py
+++ b/examples/conversion/hf_megatron_roundtrip_multi_gpu.py
@@ -53,7 +53,6 @@ from rich.table import Table
 from megatron.bridge import AutoBridge
 from megatron.bridge.models.decorators import torchrun_main
 from megatron.bridge.models.hf_pretrained.utils import is_safe_repo
-from megatron.bridge.utils.common_utils import fix_gpt_oss_export_transpose, get_hf_model_type
 
 
 HF_MODEL_ID = "meta-llama/Llama-3.2-1B"
@@ -189,11 +188,7 @@ def main(
     all_match = True
     fp8_skip_count = 0
     fp8_skip_samples: list[str] = []
-    # TODO: Remove fix_gpt_oss_export_transpose once GPT-OSS bridge export is fixed.
-    weight_iter = bridge.export_hf_weights(megatron_model, show_progress=False)
-    if get_hf_model_type(bridge) == "gpt_oss":
-        weight_iter = fix_gpt_oss_export_transpose(weight_iter)
-    for name, param in weight_iter:
+    for name, param in bridge.export_hf_weights(megatron_model, show_progress=False):
         if is_rank_0:
             original_param = bridge.hf_pretrained.state[name]
             compare_param = param

--- a/src/megatron/bridge/models/conversion/auto_bridge.py
+++ b/src/megatron/bridge/models/conversion/auto_bridge.py
@@ -822,12 +822,6 @@ class AutoBridge(Generic[MegatronModelT]):
 
             generator = _filter_quant(generator)
 
-        # TODO: Remove once GPT-OSS bridge export no longer transposes per-expert weights.
-        from megatron.bridge.utils.common_utils import fix_gpt_oss_export_transpose, get_hf_model_type
-
-        if get_hf_model_type(self) == "gpt_oss":
-            generator = fix_gpt_oss_export_transpose(generator)
-
         # Check if the state source is SafeTensorsStateSource for streaming save.
         if (
             hasattr(self.hf_pretrained, "state")

--- a/src/megatron/bridge/models/conversion/utils.py
+++ b/src/megatron/bridge/models/conversion/utils.py
@@ -43,14 +43,8 @@ def weights_verification_table(bridge, megatron_model) -> Table:
     table.add_column("Device")
     table.add_column("Matches Original", justify="center")
 
-    # TODO: Remove fix_gpt_oss_export_transpose once GPT-OSS bridge export is fixed.
-    from megatron.bridge.utils.common_utils import fix_gpt_oss_export_transpose, get_hf_model_type
-
-    weight_iter = bridge.export_hf_weights(megatron_model, show_progress=True)
-    if get_hf_model_type(bridge) == "gpt_oss":
-        weight_iter = fix_gpt_oss_export_transpose(weight_iter)
     # Check each weight against the original HF-model
-    for name, param in weight_iter:
+    for name, param in bridge.export_hf_weights(megatron_model, show_progress=True):
         original_param = bridge.hf_pretrained.state[name]
         table.add_row(
             name,

--- a/src/megatron/bridge/models/gpt_oss/gpt_oss_bridge.py
+++ b/src/megatron/bridge/models/gpt_oss/gpt_oss_bridge.py
@@ -106,9 +106,7 @@ class GPTOSSBridge(MegatronModelBridge):
     ) -> torch.Tensor:
         """Load weights from HuggingFace state dict with MXFP4 dequantization support.
 
-        down_proj transpose on export is handled in GPTOSSMLPDownProjMapping.megatron_to_hf,
-        which transposes the per-expert weight from Megatron's [in, out] storage to
-        HF's expected [out, in] layout.
+        down_proj is handled in GPTOSSMLPDownProjMapping.
 
         gate_up_proj is handled directly in GPTOSSMLPGateUpProjMapping.hf_to_megatron via
         _align_expert_weight_to_shape, which auto-detects the orientation difference between
@@ -212,11 +210,7 @@ class GPTOSSBridge(MegatronModelBridge):
 
 
 class GPTOSSMLPDownProjMapping(AutoMapping):
-    """MLPDownProj for expert weights in GPT-OSS models.
-
-    megatron_to_hf transposes the per-expert weight from Megatron's [in, out]
-    storage to HF's expected [out, in] layout.
-    """
+    """MLPDownProj for expert weights in GPT-OSS models."""
 
     is_grouped_export = True
 
@@ -235,8 +229,6 @@ class GPTOSSMLPDownProjMapping(AutoMapping):
     def megatron_to_hf(self, megatron_weights: torch.Tensor, megatron_module: nn.Module) -> Dict[str, torch.Tensor]:
         if megatron_weights is None:
             return super().megatron_to_hf(megatron_weights, megatron_module)
-        if len(megatron_weights.shape) == 2:
-            megatron_weights = megatron_weights.transpose(0, 1)
         return super().megatron_to_hf(megatron_weights.contiguous(), megatron_module)
 
 

--- a/src/megatron/bridge/utils/common_utils.py
+++ b/src/megatron/bridge/utils/common_utils.py
@@ -251,33 +251,6 @@ def hook_hf_module_setattr_for_tp_grad_sync(module: torch.nn.Module) -> torch.nn
     return module
 
 
-def get_hf_model_type(bridge) -> str | None:
-    """Extract the HF ``model_type`` string from a bridge instance.
-
-    Works with both ``AutoBridge`` (reads ``bridge.hf_pretrained.config.model_type``)
-    and registered bridge subclasses (falls back to the ``MODEL_TYPE`` class attribute).
-    """
-    hf_config = getattr(getattr(bridge, "hf_pretrained", None), "config", None)
-    return getattr(hf_config, "model_type", None) or getattr(bridge, "MODEL_TYPE", None)
-
-
-# TODO: Remove once GPT-OSS bridge export no longer transposes per-expert weights.
-_GPT_OSS_TRANSPOSED_SUFFIXES = ("mlp.experts.down_proj",)
-
-
-def fix_gpt_oss_export_transpose(gen):
-    """Wrap a weight generator to undo GPT-OSS per-expert transpose on export.
-
-    The GPT-OSS bridge transposes down_proj expert weights in ``megatron_to_hf``
-    for vLLM compatibility.  This wrapper transposes them back so saved
-    checkpoints match the original HF layout.
-    """
-    for name, tensor in gen:
-        if name.endswith(_GPT_OSS_TRANSPOSED_SUFFIXES):
-            tensor = tensor.transpose(-2, -1).contiguous()
-        yield name, tensor
-
-
 def extract_expert_number_from_param(param_name: str) -> int:
     """Extract the expert number from a parameter name.
     Args:


### PR DESCRIPTION
## Summary
Move the transpose of `down_proj` for GPT-OSS expert weights to NeMo-RL side instead of bridge side to avoid mismatch layout when saving checkpoint.

**History:**
- #3162 fixed a double-transpose bug: both import and export were transposing `down_proj`. The import-side transpose was removed, leaving only the export transpose in `GPTOSSMLPDownProjMapping.megatron_to_hf`. This helps fixing Megatron `[in, out]` layout and vLLM `[out, in]` layout.
- However, the intermediate `[out, in]` layout produced by the bridge transpose corrupted saved checkpoints (`save_hf_pretrained` wrote weights that didn't match the original HF `[in, out]` layout).
- #3250 papered over this with a post-export generator wrapper that un-transposed before saving — correct but "transpose then un-transpose".

**Root cause:** The transpose is a NeMo-RL refit concern, not a bridge concern. The bridge's `megatron_to_hf` should always produce standard HF layout.

## Changes
- Reverts #3250 (`transpose_on_export` adaptive wrapper in `GPTOSSMLPDownProjMapping`).
- Removes the `down_proj` transpose from `GPTOSSMLPDownProjMapping.megatron_to_hf`. The export path now returns weights in the correct HF `[in, out]` layout for checkpoint saving.

## Testing
Validated. See validate steps and results in https://github.com/NVIDIA-NeMo/RL/pull/2249.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined weight export logic by removing model-specific conditional handling across conversion utilities and bridge modules.

* **Chores**
  * Updated documentation to reflect simplified weight handling approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->