### PR TITLE
[doc] feat: add Qwen3-ASR news and model support list entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 
 ## 📣 News
 
+- [04/10/2026] [**Qwen3-ASR**](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/examples/models/audio_lm/qwen3_asr) is now supported! Checkpoint conversion and inference for [Qwen3's ASR model](https://github.com/QwenLM/Qwen3-ASR) are available on **main**.
+
 - [04/09/2026] [**Bailing MoE V2**](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/examples/models/bailing) is now supported! Checkpoint conversion and inference for the Bailing MoE V2 model are available on **main**. Thank you to [@ccclyu](https://github.com/ccclyu) for the community contribution!
 
 - [04/07/2026] Megatron Bridge’s PEFT support was featured at [PyTorch Conference Europe 2026 Talk](https://pytorchconferenceeu2026.sched.com/event/2Juce/optimizing-reinforcement-learning-at-trillion-parameter-scale-songlin-jiang-aalto-university-mind-lab).
@@ -201,6 +203,7 @@ Megatron Bridge provides out-of-the-box bridges and training recipes for a wide 
 
 - [Qwen2 Audio](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/src/megatron/bridge/models/qwen_audio)
 - [Qwen2.5-Omni](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/src/megatron/bridge/models/qwen_omni)
+- [Qwen3-ASR](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/src/megatron/bridge/models/qwen3_asr)
 
 #### Launching Recipes
 


### PR DESCRIPTION
## Summary

- Adds `[04/10/2026]` news entry for Qwen3-ASR support (landed via #2836)
- Adds Qwen3-ASR to the Omni Models section of the model support list

## Test plan
- [ ] README renders correctly on GitHub

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Announced support for Qwen3-ASR model with links to example model directory and upstream repository
  * Added Qwen3-ASR to the Supported Models list as an available Omni Model
  * Documented checkpoint conversion and inference availability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->