### PR TITLE
fix(perf): set NCCL env vars when nccl_ub enabled via recipe config

### DIFF
--- a/scripts/performance/run_script.py
+++ b/scripts/performance/run_script.py
@@ -96,6 +96,11 @@ def main():
         config_variant=args.config_variant,
     )
 
+    # Set NCCL env vars for nccl_ub enabled via recipe config (not just CLI).
+    if getattr(recipe.ddp, "nccl_ub", False):
+        os.environ.setdefault("NCCL_NVLS_ENABLE", "1")
+        os.environ.setdefault("NCCL_CTA_POLICY", "1")
+
     if args.dryrun:
         save_path = args.save_config_filepath or "ConfigContainer.yaml"
         os.makedirs(os.path.dirname(os.path.abspath(save_path)), exist_ok=True)


### PR DESCRIPTION
## Summary
- `NCCL_NVLS_ENABLE` and `NCCL_CTA_POLICY` env vars are only set in `setup_experiment.py` when `--nccl_ub` is passed via CLI
- When `nccl_ub` is enabled through `WorkloadBaseConfig` or hardcoded in recipe functions (e.g. FSDP configs set `cfg.ddp.nccl_ub = True`), the env vars are missing at runtime
- Fix: set them in `run_script.py` after the recipe is fully built, using `os.environ.setdefault` so CLI-provided values still take precedence

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced distributed training performance testing configuration to improve test execution in relevant scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->