### PR TITLE
feat(perf): switch llama3 70B GB200/GB300 MXFP8 from 3D parallel to FSDP

### DIFF
--- a/scripts/performance/configs/llama/llama3_workload_base_configs.py
+++ b/scripts/performance/configs/llama/llama3_workload_base_configs.py
@@ -218,8 +218,9 @@ LLAMA3_70B_PRETRAIN_CONFIG_GB300_FP8_CS_V2 = replace(
 
 LLAMA3_70B_PRETRAIN_CONFIG_GB300_FP8_MX_V2 = replace(
     BASE_LLAMA3_70B_CONFIG_GBS256,
-    pipeline_model_parallel_size=4,
-    virtual_pipeline_model_parallel_size=5,
+    micro_batch_size=2,
+    use_megatron_fsdp=True,
+    cpu_offloading_num_layers=20,
 )
 
 LLAMA3_70B_PRETRAIN_CONFIG_GB300_NVFP4_V2 = replace(

--- a/scripts/performance/configs/llama/llama3_workload_base_configs.py
+++ b/scripts/performance/configs/llama/llama3_workload_base_configs.py
@@ -248,9 +248,9 @@ LLAMA3_70B_PRETRAIN_CONFIG_GB200_FP8_CS_V2 = replace(
 
 LLAMA3_70B_PRETRAIN_CONFIG_GB200_FP8_MX_V2 = replace(
     BASE_LLAMA3_70B_CONFIG_GBS256,
-    tensor_model_parallel_size=2,
-    pipeline_model_parallel_size=4,
-    virtual_pipeline_model_parallel_size=5,
+    micro_batch_size=2,
+    use_megatron_fsdp=True,
+    cpu_offloading_num_layers=45,
 )
 
 LLAMA3_70B_PRETRAIN_CONFIG_GB200_NVFP4_V2 = replace(


### PR DESCRIPTION
## Summary
- Switch llama3 70B GB200 MXFP8 V2 config from TP=2/PP=4/VPP=5 to FSDP with MBS=2 and 45 layers CPU offloading
- Switch llama3 70B GB300 MXFP8 V2 config from TP=1/PP=4 to FSDP with MBS=2 and 20 layers CPU offloading

🤖 Generated with [Claude Code](https://claude.com/claude-code)