### PR TITLE
[model, doc] feat: add MiniMax-2.5 SFT/PEFT recipes and example scripts - DRAFT

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Megatron Bridge provides out-of-the-box bridges and training recipes for a wide 
 - [Ministral](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/src/megatron/bridge/models/ministral3) — [recipes (3B/8B/14B)](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/src/megatron/bridge/recipes/ministral3/ministral3.py)
 - [Mistral](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/src/megatron/bridge/models/mistral)
 - [MiniMax-M2](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/src/megatron/bridge/models/minimax_m2)
+- [MiniMax-2.5](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/src/megatron/bridge/models/minimax_m2) — [recipes](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/src/megatron/bridge/recipes/minimax_m2/minimax_m2_5.py)
 - [Moonlight](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/src/megatron/bridge/models/deepseek) — [recipes (16B)](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/src/megatron/bridge/recipes/moonlight/moonlight_16b.py)
 - [OlMoE](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/src/megatron/bridge/models/olmoe) — [recipes (7B)](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/src/megatron/bridge/recipes/olmoe/olmoe_7b.py)
 - [Qwen2 / Qwen2.5](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/src/megatron/bridge/models/qwen) — [recipes](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/src/megatron/bridge/recipes/qwen/qwen2.py)

--- a/examples/models/minimax_m2_5/README.md
+++ b/examples/models/minimax_m2_5/README.md
@@ -1,0 +1,76 @@
+# MiniMax-2.5 Examples
+
+This directory contains example scripts for [MiniMax-2.5](https://huggingface.co/MiniMaxAI/MiniMax-2.5), a large sparse MoE model with 456B total parameters (45.9B active), 256 experts, and FP8 quantization.
+
+## Hardware Requirements
+
+MiniMax-2.5 requires **at least 2 nodes (16 GPUs)** for inference and conversion. The model cannot fit on a single 8-GPU node because:
+
+- TEGroupedMLP workspace is proportional to `num_experts / EP`; with EP=8 on 1 node, workspace alone OOMs.
+- TP does **not** reduce expert memory — use EP instead.
+- Minimum recommended config: `TP=1, EP=16, PP=1` (2 nodes × 8 GPUs).
+
+## Checkpoint Conversion
+
+[slurm_conversion.sh](slurm_conversion.sh) sweeps multiple TP/PP/EP configs to verify HF ↔ Megatron round-trip conversion.
+
+### Setup
+
+Edit the variables at the top of `slurm_conversion.sh`:
+
+```bash
+CONTAINER_IMAGE="/path/to/container.sqsh"
+# Optional:
+export HF_TOKEN="hf_your_token_here"
+export HF_HOME="/path/to/shared/HF_HOME"
+```
+
+### Submit
+
+```bash
+sbatch examples/models/minimax_m2_5/slurm_conversion.sh
+```
+
+### Expected output (per config)
+
+```
+MiniMax-2.5 Round-Trip Conversion Sweep
+Job: <JOB_ID> | Nodes: 2
+Parallelism configs: 2,1,8 1,2,8 2,2,4
+======================================
+Config 1/3: TP=2, PP=1, EP=8
+...
+All parameters match: True ✅
+[OK] Config 1: TP=2, PP=1, EP=8 passed
+...
+All 3 configs passed
+======================================
+```
+
+## Inference
+
+[slurm_inference.sh](slurm_inference.sh) runs text generation on the full FP8 checkpoint with `TP=1, EP=16`.
+
+### Setup
+
+Edit the variables at the top of `slurm_inference.sh`:
+
+```bash
+CONTAINER_IMAGE="/path/to/container.sqsh"
+export HF_TOKEN="hf_your_token_here"
+```
+
+### Submit
+
+```bash
+sbatch examples/models/minimax_m2_5/slurm_inference.sh
+```
+
+### Expected output
+
+```
+======== GENERATED TEXT OUTPUT ========
+Prompt: What is artificial intelligence?
+Generated: What is artificial intelligence? ...
+=======================================
+```

--- a/examples/models/minimax_m2_5/slurm_conversion.sh
+++ b/examples/models/minimax_m2_5/slurm_conversion.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ==============================================================================
+# MiniMax-2.5 Conversion Round-Trip Verification (Multi-Node via Slurm)
+#
+# MiniMax-2.5 (MoE: 256 experts, top-8, ~230GB fp8)
+# The full model OOMs on a single 8-GPU node — minimum 2 nodes (16 GPUs)
+# with EP >= 8. FP8 weights are dequantized automatically by MiniMaxM2Bridge.
+#
+# Sweeps multiple parallelism configs (TP,PP,EP) to verify HF <-> Megatron
+# round-trip conversion. Each config runs sequentially.
+#
+# Usage:
+#   1. Fill in CONTAINER_IMAGE, CONTAINER_MOUNTS, and token exports
+#   2. Adjust PARALLELISM_CONFIGS if needed
+#   3. Submit: sbatch slurm_conversion.sh
+# ==============================================================================
+
+#SBATCH --job-name=minimax-m2-5-roundtrip
+#SBATCH --nodes=2
+#SBATCH --ntasks-per-node=8
+#SBATCH --gpus-per-node=8
+#SBATCH --time=4:00:00
+#SBATCH --account=<your-account>
+#SBATCH --partition=batch
+#SBATCH --output=logs/minimax_m2_5_roundtrip_%j.log
+#SBATCH --exclusive
+
+# ── Container ────────────────────────────────────────────────────────────
+CONTAINER_IMAGE=""
+# CONTAINER_IMAGE="/path/to/container.sqsh"
+CONTAINER_MOUNTS=""
+# CONTAINER_MOUNTS="/path/to/shared/storage:/mnt/storage,/path/to/project:/opt/Megatron-Bridge"
+WORKDIR="/opt/Megatron-Bridge"
+
+# ── Tokens / Caches ──────────────────────────────────────────────────────
+# export HF_TOKEN="hf_your_token_here"
+# export HF_HOME="/path/to/shared/HF_HOME"
+# export UV_CACHE_DIR="/path/to/shared/uv_cache"
+
+# ── Parallelism configs: "TP,PP,EP" per entry ────────────────────────────
+# TP*PP*EP must equal total GPUs (NODES * GPUS_PER_NODE).
+# EP must divide 256 (number of experts).
+# Note: TP=2,EP=4 on 8 GPUs (1 node) OOMs — use EP >= 8 with 2+ nodes.
+PARALLELISM_CONFIGS=("2,1,8" "1,2,8" "2,2,4")
+
+# ── Model ─────────────────────────────────────────────────────────────────
+MODEL_NAME=MiniMax-2.5
+HF_MODEL_ID=MiniMaxAI/$MODEL_NAME
+
+# ── Environment ───────────────────────────────────────────────────────────
+export TORCH_NCCL_AVOID_RECORD_STREAMS=1
+export NCCL_NVLS_ENABLE=0
+
+# ==============================================================================
+# Job Execution
+# ==============================================================================
+
+echo "======================================"
+echo "MiniMax-2.5 Round-Trip Conversion Sweep"
+echo "Job: $SLURM_JOB_ID | Nodes: $SLURM_JOB_NUM_NODES"
+echo "Parallelism configs: ${PARALLELISM_CONFIGS[*]}"
+echo "======================================"
+
+mkdir -p logs
+
+if [ -z "$CONTAINER_IMAGE" ]; then
+    echo "ERROR: CONTAINER_IMAGE must be set."
+    exit 1
+fi
+
+SRUN_CMD="srun --mpi=pmix --container-image=$CONTAINER_IMAGE"
+if [ -n "$CONTAINER_MOUNTS" ]; then
+    SRUN_CMD="$SRUN_CMD --container-mounts=$CONTAINER_MOUNTS"
+fi
+
+CONFIG_INDEX=0
+for CONFIG in "${PARALLELISM_CONFIGS[@]}"; do
+    IFS=',' read -r TP PP EP <<< "$CONFIG"
+    CONFIG_INDEX=$((CONFIG_INDEX + 1))
+
+    echo ""
+    echo "======================================"
+    echo "Config $CONFIG_INDEX/${#PARALLELISM_CONFIGS[@]}: TP=$TP, PP=$PP, EP=$EP"
+    echo "======================================"
+
+    CMD="if [ \"\$SLURM_LOCALID\" -eq 0 ]; then uv sync; else sleep 10; fi && "
+    CMD="${CMD}uv run --no-sync python examples/conversion/hf_megatron_roundtrip_multi_gpu.py"
+    CMD="$CMD --hf-model-id $HF_MODEL_ID"
+    CMD="$CMD --tp $TP --pp $PP --ep $EP"
+
+    echo "Executing: $CMD"
+
+    $SRUN_CMD bash -c "cd $WORKDIR && $CMD"
+    RUN_EXIT=$?
+    if [ $RUN_EXIT -ne 0 ]; then
+        echo "ERROR: Config TP=$TP, PP=$PP, EP=$EP failed (exit $RUN_EXIT)"
+        exit $RUN_EXIT
+    fi
+    echo "[OK] Config $CONFIG_INDEX: TP=$TP, PP=$PP, EP=$EP passed"
+done
+
+echo ""
+echo "======================================"
+echo "All ${#PARALLELISM_CONFIGS[@]} configs passed"
+echo "======================================"

--- a/examples/models/minimax_m2_5/slurm_inference.sh
+++ b/examples/models/minimax_m2_5/slurm_inference.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ==============================================================================
+# MiniMax-2.5 Inference (Multi-Node via Slurm)
+#
+# MiniMax-2.5 (MoE: 256 experts, top-8, ~230GB fp8)
+# The full model OOMs on a single 8-GPU node.
+# Minimum EP=16 (2 nodes) for inference; TP=2,EP=8 OOMs during forward pass.
+# Increasing TP does NOT reduce expert memory — increase EP instead.
+#
+# Usage:
+#   1. Fill in CONTAINER_IMAGE, CONTAINER_MOUNTS, and token exports
+#   2. Submit: sbatch slurm_inference.sh
+# ==============================================================================
+
+#SBATCH --job-name=minimax-m2-5-inference
+#SBATCH --nodes=2
+#SBATCH --ntasks-per-node=8
+#SBATCH --gpus-per-node=8
+#SBATCH --time=4:00:00
+#SBATCH --account=<your-account>
+#SBATCH --partition=batch
+#SBATCH --output=logs/minimax_m2_5_inference_%j.log
+#SBATCH --exclusive
+
+# ── Container ────────────────────────────────────────────────────────────
+CONTAINER_IMAGE=""
+# CONTAINER_IMAGE="/path/to/container.sqsh"
+CONTAINER_MOUNTS=""
+# CONTAINER_MOUNTS="/lustre:/lustre,/path/to/project:/opt/Megatron-Bridge"
+WORKDIR="/opt/Megatron-Bridge"
+
+# ── Tokens / Caches ──────────────────────────────────────────────────────
+# export HF_TOKEN="hf_your_token_here"
+# export HF_HOME="/path/to/shared/HF_HOME"
+# export UV_CACHE_DIR="/path/to/shared/uv_cache"
+
+# ── Model / Parallelism ──────────────────────────────────────────────────
+MODEL_NAME=MiniMax-2.5
+HF_MODEL_ID=MiniMaxAI/$MODEL_NAME
+PROMPT="What is artificial intelligence?"
+MAX_NEW_TOKENS=100
+TP=1
+EP=16
+PP=1
+
+# ── Environment ───────────────────────────────────────────────────────────
+export TORCH_NCCL_AVOID_RECORD_STREAMS=1
+export NCCL_NVLS_ENABLE=0
+
+# ==============================================================================
+# Job Execution
+# ==============================================================================
+
+echo "======================================"
+echo "MiniMax-2.5 Inference"
+echo "Job: $SLURM_JOB_ID | Nodes: $SLURM_JOB_NUM_NODES"
+echo "TP=$TP PP=$PP EP=$EP (Total GPUs: $((TP * EP * PP)))"
+echo "======================================"
+
+mkdir -p logs
+
+if [ -z "$CONTAINER_IMAGE" ]; then
+    echo "ERROR: CONTAINER_IMAGE must be set."
+    exit 1
+fi
+
+SRUN_CMD="srun --mpi=pmix --container-image=$CONTAINER_IMAGE"
+if [ -n "$CONTAINER_MOUNTS" ]; then
+    SRUN_CMD="$SRUN_CMD --container-mounts=$CONTAINER_MOUNTS"
+fi
+
+# Sync dependencies once per node, then run inference
+CMD="if [ \"\$SLURM_LOCALID\" -eq 0 ]; then uv sync; else sleep 10; fi && "
+CMD="${CMD}uv run --no-sync python examples/conversion/hf_to_megatron_generate_text.py"
+CMD="$CMD --hf_model_path $HF_MODEL_ID"
+CMD="$CMD --prompt '$PROMPT'"
+CMD="$CMD --max_new_tokens $MAX_NEW_TOKENS"
+CMD="$CMD --tp $TP --ep $EP"
+
+echo "Executing: $CMD"
+
+$SRUN_CMD bash -c "cd $WORKDIR && $CMD"
+
+echo "======================================"
+echo "Inference completed"
+echo "======================================"

--- a/src/megatron/bridge/recipes/__init__.py
+++ b/src/megatron/bridge/recipes/__init__.py
@@ -29,6 +29,7 @@ from megatron.bridge.recipes.gpt import *
 from megatron.bridge.recipes.gpt_oss import *
 from megatron.bridge.recipes.kimi_vl import *
 from megatron.bridge.recipes.llama import *
+from megatron.bridge.recipes.minimax_m2 import *
 from megatron.bridge.recipes.ministral3 import *
 from megatron.bridge.recipes.moonlight import *
 from megatron.bridge.recipes.nemotronh import *

--- a/src/megatron/bridge/recipes/minimax_m2/__init__.py
+++ b/src/megatron/bridge/recipes/minimax_m2/__init__.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from megatron.bridge.recipes.minimax_m2.minimax_m2_5 import (
+    minimax_m2_5_peft_config,
+    minimax_m2_5_sft_config,
+)
+
+
+__all__ = [
+    "minimax_m2_5_sft_config",
+    "minimax_m2_5_peft_config",
+]

--- a/src/megatron/bridge/recipes/minimax_m2/minimax_m2_5.py
+++ b/src/megatron/bridge/recipes/minimax_m2/minimax_m2_5.py
@@ -1,0 +1,255 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+
+from megatron.bridge import AutoBridge
+from megatron.bridge.peft.base import PEFT
+from megatron.bridge.recipes.common import _peft_common, _sft_common
+from megatron.bridge.recipes.utils.finetune_utils import default_peft_config
+from megatron.bridge.training.config import ConfigContainer
+
+
+_HF_PATH = "MiniMaxAI/MiniMax-2.5"
+
+
+def minimax_m2_5_sft_config() -> ConfigContainer:
+    """Return a full SFT config for MiniMax-2.5 (456B sparse MoE).
+
+    MiniMax-2.5 is a 456B sparse MoE model with 256 experts, top-8 sigmoid
+    routing, and FP8 block-wise quantized weights. Conversion from HuggingFace
+    dequantizes FP8 weights automatically via ``MiniMaxM2Bridge``.
+
+    Default parallelism: TP=1, PP=1, EP=32 (4 nodes / 32 GPUs).
+
+    Note:
+        MTP (Multi-Token Prediction) heads are not mapped by the bridge and
+        are disabled in this recipe (``mtp_num_layers=0``). Enable them only
+        when training from a Megatron checkpoint that already includes MTP weights.
+
+    Returns:
+        ConfigContainer: Pre-configured SFT config for MiniMax-2.5.
+    """
+    cfg = _sft_common()
+
+    # Model — dispatches to the existing MiniMaxM2Bridge (model_type="minimax_m2")
+    cfg.model = AutoBridge.from_hf_pretrained(_HF_PATH).to_megatron_provider(load_weights=False)
+
+    # Tokenizer
+    cfg.tokenizer.tokenizer_model = _HF_PATH
+
+    # Sequence length
+    seq_length = 2048
+    cfg.model.seq_length = seq_length
+    cfg.dataset.seq_length = seq_length
+
+    # Parallelism
+    # EP must divide 256 (number of experts). EP=32 → 8 experts per rank.
+    # Minimum hardware: 4 nodes × 8 GPUs (TP=1, PP=1, EP=32).
+    # TP does NOT reduce expert memory — increase EP instead.
+    cfg.model.tensor_model_parallel_size = 1
+    cfg.model.pipeline_model_parallel_size = 1
+    cfg.model.pipeline_dtype = None
+    cfg.model.virtual_pipeline_model_parallel_size = None
+    cfg.model.context_parallel_size = 1
+    cfg.model.expert_model_parallel_size = 32
+    cfg.model.sequence_parallel = False
+
+    # MTP is not supported by MiniMaxM2Bridge; disable it
+    cfg.model.mtp_num_layers = 0
+
+    # MoE token dispatcher
+    cfg.model.moe_token_dispatcher_type = "alltoall"
+    cfg.model.moe_router_fusion = False
+    cfg.model.moe_permute_fusion = True
+    cfg.model.moe_grouped_gemm = True
+    cfg.model.moe_router_force_load_balancing = False
+    cfg.model.moe_router_padding_for_fp8 = False
+
+    # Mixed precision
+    cfg.mixed_precision = "bf16_mixed"
+
+    # Training
+    cfg.train.train_iters = 1000
+    cfg.validation.eval_interval = 50
+    cfg.validation.eval_iters = 32
+    cfg.train.global_batch_size = 128
+    cfg.train.micro_batch_size = 1
+
+    # Logger
+    cfg.logger.log_interval = 1
+
+    # Optimizer
+    cfg.optimizer.adam_beta1 = 0.9
+    cfg.optimizer.adam_beta2 = 0.95
+    cfg.optimizer.adam_eps = 1e-8
+    cfg.optimizer.weight_decay = 0.1
+    cfg.optimizer.use_precision_aware_optimizer = False
+    cfg.optimizer.main_grads_dtype = torch.float32
+    cfg.optimizer.main_params_dtype = torch.float32
+    cfg.optimizer.exp_avg_dtype = torch.float32
+    cfg.optimizer.exp_avg_sq_dtype = torch.float32
+
+    # Scheduler
+    cfg.scheduler.lr_warmup_iters = 50
+    cfg.scheduler.max_lr = 5e-6
+
+    # Transformer Engine
+    cfg.model.transformer_impl = "transformer_engine"
+    cfg.model.cuda_graph_impl = "none"
+    cfg.model.cuda_graph_scope = "full"
+    cfg.model.cuda_graph_warmup_steps = 3
+
+    # Kernel selections
+    cfg.model.attention_backend = None
+    cfg.model.cross_entropy_loss_fusion = True
+    cfg.model.cross_entropy_fusion_impl = "te"
+
+    # Recompute / offloading
+    cfg.model.recompute_granularity = None
+    cfg.model.recompute_modules = None
+    cfg.model.fine_grained_activation_offloading = False
+    cfg.model.offload_modules = None
+
+    # Checkpoint
+    cfg.checkpoint.save_interval = 50
+    cfg.checkpoint.ckpt_format = "torch_dist"
+    cfg.checkpoint.fully_parallel_save = True
+    # cfg.checkpoint.pretrained_checkpoint = "/path/to/megatron/checkpoint"
+
+    # DDP — disable overlap to avoid OOM on 456B MoE during full fine-tuning
+    cfg.ddp.overlap_grad_reduce = False
+    cfg.ddp.overlap_param_gather = False
+    cfg.ddp.check_for_nan_in_grad = True
+    cfg.ddp.use_distributed_optimizer = False
+    cfg.ddp.grad_reduce_in_fp32 = False
+    cfg.ddp.use_megatron_fsdp = False
+
+    # RNG
+    cfg.rng.seed = 5678
+
+    return cfg
+
+
+def minimax_m2_5_peft_config(peft_scheme: str | PEFT = "lora") -> ConfigContainer:
+    """Return a PEFT (LoRA/DoRA) config for MiniMax-2.5 (456B sparse MoE).
+
+    Only adapter weights are trained, so fewer GPUs are required compared to
+    full SFT.
+
+    Default parallelism: TP=1, PP=1, EP=16 (2 nodes / 16 GPUs).
+
+    Note:
+        MTP heads are disabled (same limitation as SFT).
+
+    Args:
+        peft_scheme: PEFT method — ``"lora"``, ``"dora"``, or a custom
+            :class:`~megatron.bridge.peft.base.PEFT` instance. Defaults to
+            ``"lora"``.
+
+    Returns:
+        ConfigContainer: Pre-configured PEFT config for MiniMax-2.5.
+    """
+    cfg = _peft_common()
+
+    # Model — dispatches to the existing MiniMaxM2Bridge
+    cfg.model = AutoBridge.from_hf_pretrained(_HF_PATH).to_megatron_provider(load_weights=False)
+
+    # Tokenizer
+    cfg.tokenizer.tokenizer_model = _HF_PATH
+
+    # Sequence length
+    seq_length = 2048
+    cfg.model.seq_length = seq_length
+    cfg.dataset.seq_length = seq_length
+
+    # Parallelism
+    # EP=16 → 16 experts per rank. Minimum: 2 nodes × 8 GPUs (TP=1, PP=1, EP=16).
+    cfg.model.tensor_model_parallel_size = 1
+    cfg.model.pipeline_model_parallel_size = 1
+    cfg.model.pipeline_dtype = None
+    cfg.model.virtual_pipeline_model_parallel_size = None
+    cfg.model.context_parallel_size = 1
+    cfg.model.expert_model_parallel_size = 16
+    cfg.model.sequence_parallel = False
+
+    # MTP not supported by MiniMaxM2Bridge
+    cfg.model.mtp_num_layers = 0
+
+    # MoE token dispatcher
+    cfg.model.moe_token_dispatcher_type = "alltoall"
+    cfg.model.moe_router_fusion = False
+    cfg.model.moe_permute_fusion = True
+    cfg.model.moe_grouped_gemm = True
+    cfg.model.moe_router_force_load_balancing = False
+    cfg.model.moe_router_padding_for_fp8 = False
+
+    # Mixed precision
+    cfg.mixed_precision = "bf16_mixed"
+
+    # Training
+    cfg.train.train_iters = 1000
+    cfg.validation.eval_interval = 50
+    cfg.validation.eval_iters = 32
+    cfg.train.global_batch_size = 128
+    cfg.train.micro_batch_size = 1
+
+    # Logger
+    cfg.logger.log_interval = 1
+
+    # Optimizer
+    cfg.optimizer.use_precision_aware_optimizer = False
+    cfg.optimizer.main_grads_dtype = torch.float32
+    cfg.optimizer.main_params_dtype = torch.float32
+    cfg.optimizer.exp_avg_dtype = torch.float32
+    cfg.optimizer.exp_avg_sq_dtype = torch.float32
+
+    # Scheduler
+    cfg.scheduler.lr_warmup_iters = 50
+
+    # Transformer Engine
+    cfg.model.transformer_impl = "transformer_engine"
+    cfg.model.cuda_graph_impl = "none"
+    cfg.model.cuda_graph_scope = "full"
+    cfg.model.cuda_graph_warmup_steps = 3
+
+    # Kernel selections
+    cfg.model.attention_backend = None
+    cfg.model.cross_entropy_loss_fusion = True
+    cfg.model.cross_entropy_fusion_impl = "te"
+
+    # Recompute / offloading
+    cfg.model.recompute_granularity = None
+    cfg.model.recompute_modules = None
+    cfg.model.fine_grained_activation_offloading = False
+    cfg.model.offload_modules = None
+
+    # Checkpoint
+    cfg.checkpoint.save_interval = 50
+    cfg.checkpoint.ckpt_format = "torch_dist"
+    cfg.checkpoint.fully_parallel_save = True
+    # cfg.checkpoint.pretrained_checkpoint = "/path/to/megatron/checkpoint"
+
+    # DDP
+    cfg.ddp.overlap_grad_reduce = False
+    cfg.ddp.overlap_param_gather = False
+    cfg.ddp.check_for_nan_in_grad = True
+    cfg.ddp.use_distributed_optimizer = False
+    cfg.ddp.grad_reduce_in_fp32 = False
+    cfg.ddp.use_megatron_fsdp = False
+
+    # PEFT
+    cfg.peft = default_peft_config(peft_scheme)
+
+    return cfg


### PR DESCRIPTION
Reuses the existing MiniMaxM2Bridge (registered on MiniMaxM2ForCausalLM) for MiniMax-2.5, which shares the same HF architecture. Adds SFT and PEFT recipe configs, Slurm conversion/inference scripts, example README, and a README.md entry.

# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MiniMax-2.5 model support with configuration templates for supervised fine-tuning and parameter-efficient fine-tuning approaches.
  * Provided example workflows, checkpoint conversion procedures, and distributed multi-node text generation inference with parallelism configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->