### PR TITLE
[ckpt] fix: Prevent int32 overflow for high train sample counts.

### DIFF
--- a/src/megatron/bridge/training/state.py
+++ b/src/megatron/bridge/training/state.py
@@ -70,10 +70,10 @@ class TrainState(Stateful):
             their corresponding tensor representations.
         """
         return {
-            "step": torch.tensor(self.step, dtype=torch.int32),
-            "consumed_train_samples": torch.tensor(self.consumed_train_samples, dtype=torch.int32),
-            "skipped_train_samples": torch.tensor(self.skipped_train_samples, dtype=torch.int32),
-            "consumed_valid_samples": torch.tensor(self.consumed_valid_samples, dtype=torch.int32),
+            "step": torch.tensor(self.step, dtype=torch.int64),
+            "consumed_train_samples": torch.tensor(self.consumed_train_samples, dtype=torch.int64),
+            "skipped_train_samples": torch.tensor(self.skipped_train_samples, dtype=torch.int64),
+            "consumed_valid_samples": torch.tensor(self.consumed_valid_samples, dtype=torch.int64),
             "floating_point_operations_so_far": torch.tensor(
                 self.floating_point_operations_so_far, dtype=torch.float64
             ),


### PR DESCRIPTION
# What does this PR do ?

Previously, when creating the TrainState for checkpointing int32 was used as type for encoding the number of consumed samples and related values. For longer trainings, torch will detect this as potential overflow and crash with `RuntimeError: value cannot be converted to type int32 without overflow`. We saw this crash while checkpointing step 700,000 while training with sequence length 8192 and batch size of 3072, so at 2,150,400,000 (> 2^31 - 1 = 2,147,483,648) samples.

# Changelog

- Switched from int32 to int64 for all values using this type in TrainState.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved integer precision in training state serialization. Counter values are now stored as 64-bit integers instead of 32-bit, preventing potential overflow issues during extended training runs. This ensures reliable checkpoint persistence and stability when handling large training step and sample count values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->