### PR TITLE
Update training script and test configurations for MIMO LLaVA

### DIFF
--- a/tests/e2e/mimo/run_hetero_llava.sh
+++ b/tests/e2e/mimo/run_hetero_llava.sh
@@ -10,7 +10,7 @@ uv run torchrun \
     tests/e2e/mimo/test_mimo_training_llava.py \
     --micro-batch-size 4 \
     --global-batch-size 128 \
-    --train-iters 2000 \
+    --train-iters 1000 \
     --adam-beta1 0.9 \
     --adam-beta2 0.95 \
     --clip-grad 1.0 \
@@ -20,7 +20,7 @@ uv run torchrun \
     --min-lr 2.0e-5 \
     --weight-decay 0.0 \
     --wandb-project "Megatron-Bridge-MIMO" \
-    --wandb-exp-name "mimo-llava-e2e-test" \
+    --wandb-exp-name "mimo-llava-hetero-e2e-test" \
     --wandb-save-dir "/tmp/wandb" \
     --vision-encoder-checkpoint /path/to/clip_checkpoint \
     --language-model-checkpoint /path/to/llm_checkpoint \

--- a/tests/e2e/mimo/run_hetero_llava_parallelism_tests_unfrozen_llm.sh
+++ b/tests/e2e/mimo/run_hetero_llava_parallelism_tests_unfrozen_llm.sh
@@ -77,28 +77,11 @@ declare -a CONFIGS_8GPU=(
     "pp4_llm_tp2dp2_vision|1|4|1|0|2|1|2|4|2"
     "pp2_dp2_llm_tp2dp2_vision|1|2|2|0|2|1|2|4|2"
     "tp4_llm_tp2dp2_vision|4|1|1|0|2|1|2|4|2"
-    # Asymmetric 2+6 split (MBS=3)
-    "asymmetric_2_6_pp2|1|2|1|0|2|1|3|2|3"
-    "asymmetric_2_6_tp2|2|1|1|0|2|1|3|2|3"
-)
-
-declare -a CONFIGS_4GPU=(
-    "pp2_llm_tp2_vision|1|2|1|0|2|1|1|2|2"
-    "pp2_llm_dp2_vision|1|2|1|0|1|1|2|2|2"
-    "tp2_llm_dp2_vision|2|1|1|0|1|1|2|2|2"
-)
-
-declare -a CONFIGS_2GPU=(
-    "tp1_both|1|1|1|0|1|1|1|1|2"
 )
 
 # Select configs based on GPU count
 if [[ $NUM_GPUS -ge 8 ]]; then
     CONFIGS=("${CONFIGS_8GPU[@]}")
-elif [[ $NUM_GPUS -ge 4 ]]; then
-    CONFIGS=("${CONFIGS_4GPU[@]}")
-else
-    CONFIGS=("${CONFIGS_2GPU[@]}")
 fi
 
 # Track results

--- a/tests/e2e/mimo/test_mimo_training_llava.py
+++ b/tests/e2e/mimo/test_mimo_training_llava.py
@@ -24,6 +24,16 @@ from megatron.core.transformer.mlp import MLPSubmodules
 from megatron.core.transformer.spec_utils import ModuleSpec
 from megatron.core.transformer.transformer_config import TransformerConfig
 
+from typing import Optional
+
+
+class CLIPViTNoCLS(CLIPViTModel):
+    """CLIPViTModel that drops the CLS token to match HF LLaVA (mm_vision_select_feature='patch')."""
+
+    def forward(self, x: torch.Tensor, attention_mask: Optional[torch.Tensor] = None) -> torch.Tensor:
+        x = super().forward(x, attention_mask=attention_mask)
+        return x[:, self.class_token_len :, :]
+
 
 # ---------------------------------------------------------------------------
 # LLaVA model configs (Vicuna-7B + CLIP ViT-L/14 + MLP projection)
@@ -35,14 +45,14 @@ CLIP_OUTPUT_DIM = 1024  # CLIP ViT-L/14 hidden size
 MAX_SEQ_LENGTH = 4096
 _IMG_SIZE = 336
 _PATCH_DIM = 14
-# CLIP ViT-L/14 @ 336×336: (336/14)^2 = 576 patches + 1 class token = 577
-_ENCODER_SEQ_LEN = 577
+# CLIP ViT-L/14 @ 336×336: (336/14)^2 = 576 patches (CLS token dropped per HF LLaVA)
+_ENCODER_SEQ_LEN = 576
 
 
 def _make_vision_config() -> TransformerConfig:
-    """CLIP ViT-L/14 vision encoder config."""
+    """CLIP ViT-L/14 vision encoder config (23 layers = penultimate layer output per HF LLaVA)."""
     cfg = TransformerConfig(
-        num_layers=24,
+        num_layers=23,
         hidden_size=1024,
         ffn_hidden_size=4096,
         num_attention_heads=16,
@@ -136,7 +146,7 @@ def _build_model_specs():
 
     # CLIP ViT-L/14 encoder
     vision_encoder = ModuleSpec(
-        module=CLIPViTModel,
+        module=CLIPViTNoCLS,
         params={
             "transformer_config": vision_config,
             "transformer_layer_spec": get_vit_layer_with_transformer_engine_spec(),
@@ -603,6 +613,17 @@ def _log(msg):
     print(line, end="", flush=True)
 
 
+def _str2bool(v):
+    """Parse boolean values from command line arguments."""
+    if isinstance(v, bool):
+        return v
+    if v.lower() in ("yes", "true", "t", "1"):
+        return True
+    if v.lower() in ("no", "false", "f", "0"):
+        return False
+    raise argparse.ArgumentTypeError(f"Boolean value expected, got '{v}'")
+
+
 def parse_args():
     parser = argparse.ArgumentParser(description="MIMO LLaVA training")
     parser.add_argument("--micro-batch-size", type=int, default=1, help="Micro batch size per GPU")
@@ -638,9 +659,9 @@ def parse_args():
         "--lr-warmup-iters", type=int, default=20, help="Number of iterations to linearly warmup learning rate"
     )
     parser.add_argument("--dataset-root", type=str, required=True, help="Root directory of the LLaVA-Pretrain dataset")
-    parser.add_argument("--freeze-vision", type=bool, default=True, help="Freeze the vision encoder (default: True)")
-    parser.add_argument("--freeze-llm", type=bool, default=True, help="Freeze the language model (default: True)")
-    parser.add_argument("--freeze-projector", type=bool, default=False, help="Freeze the projector (default: False)")
+    parser.add_argument("--freeze-vision", type=_str2bool, default=True, help="Freeze the vision encoder (default: True)")
+    parser.add_argument("--freeze-llm", type=_str2bool, default=True, help="Freeze the language model (default: True)")
+    parser.add_argument("--freeze-projector", type=_str2bool, default=False, help="Freeze the projector (default: False)")
     return parser.parse_args()
 
 


### PR DESCRIPTION
- Adjusted training iterations from 2000 to 1000 in run_hetero_llava.sh
- Renamed experiment in wandb from "mimo-llava-e2e-test" to "mimo-llava-hetero-e2e-test"
- Removed unused parallelism configurations in run_hetero_llava_parallelism_tests_unfrozen_llm.sh
- Introduced CLIPViTNoCLS class in test_mimo_training_llava.py to drop CLS token
- Updated encoder sequence length to 576 in test_mimo_training_llava.py
- Modified argument parsing for freeze options to use custom boolean parser

# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
