### PR TITLE
fix(docker): pin peft>=0.18.1 in fw container

### DIFF
--- a/docker/common/fw_pyproject.toml
+++ b/docker/common/fw_pyproject.toml
@@ -81,6 +81,7 @@ override-dependencies = [
     "pytest==8.4.2",
     "wandb>=0.25.0",
     "nvidia-lm-eval==25.11.1",
+    "peft>=0.18.1",
     "lilcom==1.8.1",
     "onnx==1.21.0",                             # TRT-LLM hard dependency
     "pytest-coverage; sys_platform == 'never'",


### PR DESCRIPTION
## Summary

- The fw container's `/opt/venv` shipped `peft==0.13.2`, but `diffusers` requires `peft>=0.17.0` at import time
- This caused an `ImportError` for any script importing from `megatron.bridge.recipes` (including LLM-only workflows), because `recipes/__init__.py` eagerly pulls in diffusion recipes that import `diffusers`
- Pins `peft>=0.18.1` in `docker/common/fw_pyproject.toml` to align with what `uv.lock` already resolves

## Test plan

- [ ] Rebuild the fw container and verify `uv pip list | grep peft` shows `>=0.18.1`
- [ ] Confirm performance scripts (e.g. `run_script.py`) no longer crash on import

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency version constraints to ensure enhanced stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->