### PR TITLE
Bump uv.lock to include modelopt 0.43.0rc4 bug fixes

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = "==3.12.*"
 resolution-markers = [
     "platform_machine != 's390x'",
@@ -1831,7 +1831,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.3.0a1"
+version = "1.3.0a2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
@@ -1843,9 +1843,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cf/5b/5c94d33fda04911cd67edadadee559970e77c1ca0b63a20c9138dee2846e/langchain_core-1.3.0a1.tar.gz", hash = "sha256:db956c2348a4a2dd5ac0f1ff9286348b81c0458284f4a462a4412331c9bcdc79", size = 853092, upload-time = "2026-04-10T16:01:30.458Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/bc/0bff31fcaff174d86031cc713471a3e85ed4ec8e5cd95ad0217f2aced20e/langchain_core-1.3.0a2.tar.gz", hash = "sha256:52d978c84552b74b9a3f16c1fced84f9e27cc96d7a67c601925ce6cbc4ea3cf9", size = 854580, upload-time = "2026-04-13T14:37:55.745Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/ca/5a54e791e22ad0c4ccebb3097ba61c0834055b58d3eda7026c8570b7cdd8/langchain_core-1.3.0a1-py3-none-any.whl", hash = "sha256:4dd90e418ac72fa4d7324100c7bb721e723cfe10a8ce21b807718844ed097768", size = 509729, upload-time = "2026-04-10T16:01:28.948Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/14/03c09686602567059f26af29de0c44546a83af2f2aa29925e61040e43ea2/langchain_core-1.3.0a2-py3-none-any.whl", hash = "sha256:9e929a34f0b0c6c1255e395a1de34f8626893ceb4cdae550a22a0bd18c87be54", size = 510233, upload-time = "2026-04-13T14:37:54.277Z" },
 ]
 
 [[package]]
@@ -2028,7 +2028,7 @@ wheels = [
 
 [[package]]
 name = "logsage"
-version = "0.1.5"
+version = "0.1.7"
 source = { registry = "https://pypi.nvidia.com/" }
 dependencies = [
     { name = "drain3" },
@@ -2042,7 +2042,7 @@ dependencies = [
     { name = "requests" },
 ]
 wheels = [
-    { url = "https://pypi.nvidia.com/logsage/logsage-0.1.5-py3-none-any.whl", hash = "sha256:4c144ea2b339f370e943929dc2d1f755b04351a75a2d8fd4201bd6d90045ed7a" },
+    { url = "https://pypi.nvidia.com/logsage/logsage-0.1.7-py3-none-any.whl", hash = "sha256:690e9f6dc56bf369b90aad91d7463e4c1689feb589148481955437ec8d33088a" },
 ]
 
 [[package]]
@@ -2742,7 +2742,7 @@ wheels = [
 
 [[package]]
 name = "mypy"
-version = "1.20.0"
+version = "1.20.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
@@ -2750,16 +2750,16 @@ dependencies = [
     { name = "pathspec" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f8/5c/b0089fe7fef0a994ae5ee07029ced0526082c6cfaaa4c10d40a10e33b097/mypy-1.20.0.tar.gz", hash = "sha256:eb96c84efcc33f0b5e0e04beacf00129dd963b67226b01c00b9dfc8affb464c3", size = 3815028, upload-time = "2026-03-31T16:55:14.959Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/3d/5b373635b3146264eb7a68d09e5ca11c305bbb058dfffbb47c47daf4f632/mypy-1.20.1.tar.gz", hash = "sha256:6fc3f4ecd52de81648fed1945498bf42fa2993ddfad67c9056df36ae5757f804", size = 3815892, upload-time = "2026-04-13T02:46:51.474Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/dd/3afa29b58c2e57c79116ed55d700721c3c3b15955e2b6251dd165d377c0e/mypy-1.20.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:002b613ae19f4ac7d18b7e168ffe1cb9013b37c57f7411984abbd3b817b0a214", size = 14509525, upload-time = "2026-03-31T16:55:01.824Z" },
-    { url = "https://files.pythonhosted.org/packages/54/eb/227b516ab8cad9f2a13c5e7a98d28cd6aa75e9c83e82776ae6c1c4c046c7/mypy-1.20.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a9336b5e6712f4adaf5afc3203a99a40b379049104349d747eb3e5a3aa23ac2e", size = 13326469, upload-time = "2026-03-31T16:51:41.23Z" },
-    { url = "https://files.pythonhosted.org/packages/57/d4/1ddb799860c1b5ac6117ec307b965f65deeb47044395ff01ab793248a591/mypy-1.20.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f13b3e41bce9d257eded794c0f12878af3129d80aacd8a3ee0dee51f3a978651", size = 13705953, upload-time = "2026-03-31T16:48:55.69Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/b7/54a720f565a87b893182a2a393370289ae7149e4715859e10e1c05e49154/mypy-1.20.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9804c3ad27f78e54e58b32e7cb532d128b43dbfb9f3f9f06262b821a0f6bd3f5", size = 14710363, upload-time = "2026-03-31T16:53:26.948Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/2a/74810274848d061f8a8ea4ac23aaad43bd3d8c1882457999c2e568341c57/mypy-1.20.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:697f102c5c1d526bdd761a69f17c6070f9892eebcb94b1a5963d679288c09e78", size = 14947005, upload-time = "2026-03-31T16:50:17.591Z" },
-    { url = "https://files.pythonhosted.org/packages/77/91/21b8ba75f958bcda75690951ce6fa6b7138b03471618959529d74b8544e2/mypy-1.20.0-cp312-cp312-win_amd64.whl", hash = "sha256:0ecd63f75fdd30327e4ad8b5704bd6d91fc6c1b2e029f8ee14705e1207212489", size = 10880616, upload-time = "2026-03-31T16:52:19.986Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/15/3d8198ef97c1ca03aea010cce4f1d4f3bc5d9849e8c0140111ca2ead9fdd/mypy-1.20.0-cp312-cp312-win_arm64.whl", hash = "sha256:f194db59657c58593a3c47c6dfd7bad4ef4ac12dbc94d01b3a95521f78177e33", size = 9813091, upload-time = "2026-03-31T16:53:44.385Z" },
-    { url = "https://files.pythonhosted.org/packages/21/66/4d734961ce167f0fd8380769b3b7c06dbdd6ff54c2190f3f2ecd22528158/mypy-1.20.0-py3-none-any.whl", hash = "sha256:a6e0641147cbfa7e4e94efdb95c2dab1aff8cfc159ded13e07f308ddccc8c48e", size = 2636365, upload-time = "2026-03-31T16:51:44.911Z" },
+    { url = "https://files.pythonhosted.org/packages/69/1b/75a7c825a02781ca10bc2f2f12fba2af5202f6d6005aad8d2d1f264d8d78/mypy-1.20.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:36ee2b9c6599c230fea89bbd79f401f9f9f8e9fcf0c777827789b19b7da90f51", size = 14494077, upload-time = "2026-04-13T02:45:55.085Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/54/5e5a569ea5c2b4d48b729fb32aa936eeb4246e4fc3e6f5b3d36a2dfbefb9/mypy-1.20.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fba3fb0968a7b48806b0c90f38d39296f10766885a94c83bd21399de1e14eb28", size = 13319495, upload-time = "2026-04-13T02:45:29.674Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a4/a1945b19f33e91721b59deee3abb484f2fa5922adc33bb166daf5325d76d/mypy-1.20.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef1415a637cd3627d6304dfbeddbadd21079dafc2a8a753c477ce4fc0c2af54f", size = 13696948, upload-time = "2026-04-13T02:46:15.006Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/c6/75e969781c2359b2f9c15b061f28ec6d67c8b61865ceda176e85c8e7f2de/mypy-1.20.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ef3461b1ad5cd446e540016e90b5984657edda39f982f4cc45ca317b628f5a37", size = 14706744, upload-time = "2026-04-13T02:46:00.482Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/6e/b221b1de981fc4262fe3e0bf9ec272d292dfe42394a689c2d49765c144c4/mypy-1.20.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:542dd63c9e1339b6092eb25bd515f3a32a1453aee8c9521d2ddb17dacd840237", size = 14949035, upload-time = "2026-04-13T02:45:06.021Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/4b/298ba2de0aafc0da3ff2288da06884aae7ba6489bc247c933f87847c41b3/mypy-1.20.1-cp312-cp312-win_amd64.whl", hash = "sha256:1d55c7cd8ca22e31f93af2a01160a9e95465b5878de23dba7e48116052f20a8d", size = 10883216, upload-time = "2026-04-13T02:45:47.232Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/f9/5e25b8f0b8cb92f080bfed9c21d3279b2a0b6a601cdca369a039ba84789d/mypy-1.20.1-cp312-cp312-win_arm64.whl", hash = "sha256:f5b84a79070586e0d353ee07b719d9d0a4aa7c8ee90c0ea97747e98cbe193019", size = 9814299, upload-time = "2026-04-13T02:45:21.934Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/28/926bd972388e65a39ee98e188ccf67e81beb3aacfd5d6b310051772d974b/mypy-1.20.1-py3-none-any.whl", hash = "sha256:1aae28507f253fe82d883790d1c0a0d35798a810117c88184097fe8881052f06", size = 2636553, upload-time = "2026-04-13T02:46:30.45Z" },
 ]
 
 [[package]]
@@ -2963,7 +2963,7 @@ wheels = [
 
 [[package]]
 name = "nvidia-modelopt"
-version = "0.43.0rc3"
+version = "0.43.0rc4"
 source = { registry = "https://pypi.nvidia.com/" }
 dependencies = [
     { name = "ninja" },
@@ -2983,7 +2983,7 @@ dependencies = [
     { name = "tqdm" },
 ]
 wheels = [
-    { url = "https://pypi.nvidia.com/nvidia-modelopt/nvidia_modelopt-0.43.0rc3-py3-none-any.whl", hash = "sha256:bc334a4bd337d0223c9059dd723c4db717e6d18eca015afd2faa300720e75a32" },
+    { url = "https://pypi.nvidia.com/nvidia-modelopt/nvidia_modelopt-0.43.0rc4-py3-none-any.whl", hash = "sha256:42efcdb2f598cb21a177e11a4ae228740ce0650bf899703cb2491744f012f443" },
 ]
 
 [[package]]
@@ -3629,7 +3629,7 @@ wheels = [
 
 [[package]]
 name = "pydantic"
-version = "2.13.0b3"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
@@ -3637,39 +3637,39 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/30/79/44a2d12b66ecdfc4cc78f6091c3a130202aefce50319d31b3de30b8b3e46/pydantic-2.13.0b3.tar.gz", hash = "sha256:dd32af63e25fcdf3d77ce589c5afb3843023992378677f0a51c3c93cb0df73ff", size = 841035, upload-time = "2026-03-31T06:51:52.522Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/6b/69fd5c7194b21ebde0f8637e2a4ddc766ada29d472bfa6a5ca533d79549a/pydantic-2.13.0.tar.gz", hash = "sha256:b89b575b6e670ebf6e7448c01b41b244f471edd276cd0b6fe02e7e7aca320070", size = 843468, upload-time = "2026-04-13T10:51:35.571Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/bd/5a9758ded101a0540ee5729a0bc27d534fbdead7f9d505a6db7b6d1007e1/pydantic-2.13.0b3-py3-none-any.whl", hash = "sha256:caf96f77486183e1efc53d21fcca0547ef12e6320b3430d54cffd02707e80792", size = 470565, upload-time = "2026-03-31T06:51:50.457Z" },
+    { url = "https://files.pythonhosted.org/packages/01/d7/c3a52c61f5b7be648e919005820fbac33028c6149994cd64453f49951c17/pydantic-2.13.0-py3-none-any.whl", hash = "sha256:ab0078b90da5f3e2fd2e71e3d9b457ddcb35d0350854fbda93b451e28d56baaf", size = 471872, upload-time = "2026-04-13T10:51:33.343Z" },
 ]
 
 [[package]]
 name = "pydantic-core"
-version = "2.45.0"
+version = "2.46.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c3/3c/db023b31f61152c665512032467c3c7fb3a21a997e4b54d54cd50ee55895/pydantic_core-2.45.0.tar.gz", hash = "sha256:a3ff659217dcb3d13442ed348e12e12ed6c876791154a575def1fea9bb667d8e", size = 471391, upload-time = "2026-03-31T06:48:02.102Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/0a/9414cddf82eda3976b14048cc0fa8f5b5d1aecb0b22e1dcd2dbfe0e139b1/pydantic_core-2.46.0.tar.gz", hash = "sha256:82d2498c96be47b47e903e1378d1d0f770097ec56ea953322f39936a7cf34977", size = 471441, upload-time = "2026-04-13T09:06:33.813Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/ba/297280e3e66e45e4bdee9f836051adb810587b6c9e50fb2966cf88cd17c9/pydantic_core-2.45.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a1a485448914ad97bc4820daae93df624c1b4fa0204c70dccb2a74aac37b0d2d", size = 2123187, upload-time = "2026-03-31T06:49:02.429Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/c6/bb169d3745df9c5a8389c09192d88a8a1c3a31ae3382a0f0cce940b723fd/pydantic_core-2.45.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a47b60e205656fa98770701a8bee76b7dcce4378293da6542cbac42dbdbe51b8", size = 1951891, upload-time = "2026-03-31T06:49:06.207Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/93/c5786b112728f61dee1325b9bad8d7c8338869419f32da2595a17aabc9a9/pydantic_core-2.45.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4facc84a813f2189ea6087fecb656b87ff0b1b8bf4b396addfe9808add8a33a9", size = 1976519, upload-time = "2026-03-31T06:47:15.746Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/15/44b4570e237b61c69fc7aa676674e6e0f6a798e1eb2acde1bb195b3c9c0e/pydantic_core-2.45.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9cffc8807b01ba05ee38bddfe34a5d90635d917bee049381d777478de00233c7", size = 2068657, upload-time = "2026-03-31T06:48:50.217Z" },
-    { url = "https://files.pythonhosted.org/packages/81/0d/207add3b97bfce3fd19525b87a6abab8c8efe9f1523ca0ab699f0294b5be/pydantic_core-2.45.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1490a3c2d134593f66018f9021c550a26144f1bd17d0425886fd9a8116d1f603", size = 2238278, upload-time = "2026-03-31T06:49:36.434Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/d8/f156c913d38a9141d98d7c536eda6338c2b71d4eb321ee6d7aff30373635/pydantic_core-2.45.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:31f91bbd2d616b19fe2e9c8d9c2842695fdd9652531a96c6e78038fe7d0ef8b6", size = 2318551, upload-time = "2026-03-31T06:47:41.966Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/d1/ba76e14b8aff8cac4a0abc83b51fe70f2c8785251515d2e55bb31be81b78/pydantic_core-2.45.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ce4185b614b40877b9796f9d30cf9117cdc372b0391c3035c6384e73440114a6", size = 2099763, upload-time = "2026-03-31T06:48:52.229Z" },
-    { url = "https://files.pythonhosted.org/packages/15/68/cef9e7ccf166fb2b1600a31ca3904c8a699d0269f99074cb530335444e15/pydantic_core-2.45.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:7518e13195d6461e281f7e1bb0f09d585e29935b8f6b0768963d3b89474704b3", size = 2165700, upload-time = "2026-03-31T06:48:32.317Z" },
-    { url = "https://files.pythonhosted.org/packages/df/8f/26a65e53a84f6d5aee92dac3f83930d6d8ea2f4f987e0d8802d79a4bbccf/pydantic_core-2.45.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:57b8abbcc3c049e41cd69661a1411be83d3f3d4691f238903020117ccd65f91f", size = 2206822, upload-time = "2026-03-31T06:48:48.361Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/dc/dc67644bcde4280b2ecfe8f8582d49005cebc730f815bf3e191a5da064cd/pydantic_core-2.45.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:f6de709108f10db47046a0f83212285d891ba5b13d1db71176a56227463bbfe5", size = 2188070, upload-time = "2026-03-31T06:48:17.99Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/74/0eeea715d1f612233abb6caa4aa11ef8d688eab36219f96cdfffd0cf26c6/pydantic_core-2.45.0-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:64cf3a497772e8a43fa0264bd753bcbc9a0cff61e2fff719696d386ec0e8dfa9", size = 2340750, upload-time = "2026-03-31T06:47:53.745Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/7d/9750b7afa0ac5600647e24cabeb56ed188975fd25e1c2cd94b2785799c96/pydantic_core-2.45.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:342d06ff590e194f1d854ef04e83f01f77f535bef45869c406a8ba03d90ff1cd", size = 2386658, upload-time = "2026-03-31T06:47:55.592Z" },
-    { url = "https://files.pythonhosted.org/packages/24/f7/d787661afdf9762c8f0b745bc82567031ffe0318a1a96088ed8582eb7842/pydantic_core-2.45.0-cp312-cp312-win32.whl", hash = "sha256:1577c221b9205f0c23f82fca58827320a7f34c1b3092130bda25ef71bfb3633f", size = 1977737, upload-time = "2026-03-31T06:47:32.935Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/3e/d5e18ccae68205243f301c269409bd104cf99a8fb688185452f83b38c792/pydantic_core-2.45.0-cp312-cp312-win_amd64.whl", hash = "sha256:b441bab50486ded5198501102504be9a05d0cdd22cd997816cd9f00bf1ca15cd", size = 2071884, upload-time = "2026-03-31T06:47:57.009Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/68/43c0f3c90742bb0ed7416ec73aba835e3482f0b9392d5add9e5eb7723b59/pydantic_core-2.45.0-cp312-cp312-win_arm64.whl", hash = "sha256:9bc46ab9813110ce84cbd2fc231bb9a1908e9533c7bab1eab3b6058b3eed598f", size = 2034034, upload-time = "2026-03-31T06:47:47.869Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/04/9abe85f6ff1ae753a26494cd2692e1f50ff9fbf35b29358d6ad977cfe38f/pydantic_core-2.45.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:7755f18fbbdfa947bdfac33567b464ee00d79887077d8a7d69ed3b756cc55a5c", size = 2112273, upload-time = "2026-03-31T06:50:22.398Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/58/c262adf721de0810f52c393cb876cab55ac5b4fadeb60ed8c5776b746681/pydantic_core-2.45.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:4ca086408e19971c0a8e23d66217d180a943fec24cae45aad0096a12a615226c", size = 1937096, upload-time = "2026-03-31T06:48:14.648Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/29/a63c3fb447616d9b08b4a4073f3b7b3d31db91e8f5dcf57621a8d408365a/pydantic_core-2.45.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9769300207f485fdeb4122d401b2e761e320e9fceba6c4ebe323a1e7b406010b", size = 1995967, upload-time = "2026-03-31T06:50:33.452Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/47/35c20932e3a6cc6ef7bde6b082f958cde963df5c2c48c38ada792e725cb3/pydantic_core-2.45.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1986e09fc3f28e915082d8d9dd864f4b0e53a0f2eae169d3b5b68ead993af8aa", size = 2156224, upload-time = "2026-03-31T06:48:30.562Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/d2/206c72ad47071559142a35f71efc29eb16448a4a5ae9487230ab8e4e292b/pydantic_core-2.46.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:66ccedb02c934622612448489824955838a221b3a35875458970521ef17b2f9c", size = 2117060, upload-time = "2026-04-13T09:04:47.443Z" },
+    { url = "https://files.pythonhosted.org/packages/17/2c/7a53b33f91c8b77e696b1a6aa3bed609bf9374bdc0f8dcda681bc7d922b8/pydantic_core-2.46.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a44f27f4d2788ef9876ec47a43739b118c5904d74f418f53398f6ced3bbcacf2", size = 1951802, upload-time = "2026-04-13T09:05:34.591Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/20/90e548c1f6d38800ef11c915881525770ce270d8e5e887563ff046a08674/pydantic_core-2.46.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f26a1032bcce6ca4b4670eb3f7d8195bd0a8b8f255f1307823e217ca3cfa7c27", size = 1976621, upload-time = "2026-04-13T09:04:03.909Z" },
+    { url = "https://files.pythonhosted.org/packages/20/3c/9c5810ca70b60c623488cdd80f7e9ee1a0812df81e97098b64788719860f/pydantic_core-2.46.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1b8d1412f725060527e56675904b17a2d421dddcf861eecf7c75b9dda47921a4", size = 2056721, upload-time = "2026-04-13T09:04:40.992Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/a3/d6e5f4cdec84278431c75540f90838c9d0a4dfe9402a8f3902073660ff28/pydantic_core-2.46.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dc3d1569edd859cabaa476cabce9eecd05049a7966af7b4a33b541bfd4ca1104", size = 2239634, upload-time = "2026-04-13T09:03:52.478Z" },
+    { url = "https://files.pythonhosted.org/packages/46/42/ef58aacf330d8de6e309d62469aa1f80e945eaf665929b4037ac1bfcebc1/pydantic_core-2.46.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:38108976f2d8afaa8f5067fd1390a8c9f5cc580175407cda636e76bc76e88054", size = 2315739, upload-time = "2026-04-13T09:05:04.971Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/86/c63b12fafa2d86a515bfd1840b39c23a49302f02b653161bf9c3a0566c50/pydantic_core-2.46.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3a5a06d8ed01dad5575056b5187e5959b336793c6047920a3441ee5b03533836", size = 2098169, upload-time = "2026-04-13T09:07:27.151Z" },
+    { url = "https://files.pythonhosted.org/packages/76/19/b5b33a2f6be4755b21a20434293c4364be255f4c1a108f125d101d4cc4ee/pydantic_core-2.46.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:04017ace142da9ce27cafd423a480872571b5c7e80382aec22f7d715ca8eb870", size = 2170830, upload-time = "2026-04-13T09:04:39.448Z" },
+    { url = "https://files.pythonhosted.org/packages/99/ae/7559f99a29b7d440012ddb4da897359304988a881efaca912fd2f655652e/pydantic_core-2.46.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2629ad992ed1b1c012e6067f5ffafd3336fcb9b54569449fabb85621f1444ed3", size = 2203901, upload-time = "2026-04-13T09:04:01.048Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/0e/b0ef945a39aeb4ac58da316813e1106b7fbdfbf20ac141c1c27904355ac5/pydantic_core-2.46.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:3068b1e7bd986aebc88f6859f8353e72072538dcf92a7fb9cf511a0f61c5e729", size = 2191789, upload-time = "2026-04-13T09:06:39.915Z" },
+    { url = "https://files.pythonhosted.org/packages/90/f4/830484e07188c1236b013995818888ab93bab8fd88aa9689b1d8fd22220d/pydantic_core-2.46.0-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:1e366916ff69ff700aa9326601634e688581bc24c5b6b4f8738d809ec7d72611", size = 2344423, upload-time = "2026-04-13T09:05:12.252Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/ba/e455c18cbdc333177af754e740be4fe9d1de173d65bbe534daf88da02ac0/pydantic_core-2.46.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:485a23e8f4618a1b8e23ac744180acde283fffe617f96923d25507d5cade62ec", size = 2384037, upload-time = "2026-04-13T09:06:24.503Z" },
+    { url = "https://files.pythonhosted.org/packages/78/1f/b35d20d73144a41e78de0ae398e60fdd8bed91667daa1a5a92ab958551ba/pydantic_core-2.46.0-cp312-cp312-win32.whl", hash = "sha256:520940e1b702fe3b33525d0351777f25e9924f1818ca7956447dabacf2d339fd", size = 1967068, upload-time = "2026-04-13T09:05:23.374Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/84/4b6252e9606e8295647b848233cc4137ee0a04ebba8f0f9fb2977655b38c/pydantic_core-2.46.0-cp312-cp312-win_amd64.whl", hash = "sha256:90d2048e0339fa365e5a66aefe760ddd3b3d0a45501e088bc5bc7f4ed9ff9571", size = 2071008, upload-time = "2026-04-13T09:05:21.392Z" },
+    { url = "https://files.pythonhosted.org/packages/39/95/d08eb508d4d5560ccbd226ee5971e5ef9b749aba9b413c0c4ed6e406d4f6/pydantic_core-2.46.0-cp312-cp312-win_arm64.whl", hash = "sha256:a70247649b7dffe36648e8f34be5ce8c5fa0a27ff07b071ea780c20a738c05ce", size = 2036634, upload-time = "2026-04-13T09:05:48.299Z" },
+    { url = "https://files.pythonhosted.org/packages/74/0c/106ed5cc50393d90523f09adcc50d05e42e748eb107dc06aea971137f02d/pydantic_core-2.46.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:bc0e2fefe384152d7da85b5c2fe8ce2bf24752f68a58e3f3ea42e28a29dfdeb2", size = 2104968, upload-time = "2026-04-13T09:06:26.967Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/71/b494cef3165e3413ee9bbbb5a9eedc9af0ea7b88d8638beef6c2061b110e/pydantic_core-2.46.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:a2ab0e785548be1b4362a62c4004f9217598b7ee465f1f420fc2123e2a5b5b02", size = 1940442, upload-time = "2026-04-13T09:06:29.332Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/3e/a4d578c8216c443e26a1124f8c1e07c0654264ce5651143d3883d85ff140/pydantic_core-2.46.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:16d45aecb18b8cba1c68eeb17c2bb2d38627ceed04c5b30b882fc9134e01f187", size = 1999672, upload-time = "2026-04-13T09:04:42.798Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/c1/9114560468685525a21770138382fd0cb849aaf351ff2c7b97f760d121e0/pydantic_core-2.46.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5078f6c377b002428e984259ac327ef8902aacae6c14b7de740dd4869a491501", size = 2154533, upload-time = "2026-04-13T09:04:50.868Z" },
 ]
 
 [[package]]
@@ -4363,14 +4363,14 @@ wheels = [
 
 [[package]]
 name = "smart-open"
-version = "7.5.1"
+version = "7.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e8/be/a66598b305763861a9ab15ff0f2fbc44e47b1ce7a776797337a4eef37c66/smart_open-7.5.1.tar.gz", hash = "sha256:3f08e16827c4733699e6b2cc40328a3568f900cb12ad9a3ad233ba6c872d9fe7", size = 54034, upload-time = "2026-02-23T11:01:28.979Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/14/33/7a00ac9b4a63afb4279b99a766f6cbe56c443526dcbf5db97b219e21fde9/smart_open-7.6.0.tar.gz", hash = "sha256:44717f46b5ff276fac03b88e5d13d1c416f064f3b7b081381b0fa8889004bd7e", size = 54548, upload-time = "2026-04-13T09:48:04.347Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5e/ea/dcdecd68acebb49d3fd560473a43499b1635076f7f1ae8641c060fe7ce74/smart_open-7.5.1-py3-none-any.whl", hash = "sha256:3e07cbbd9c8a908bcb8e25d48becf1a5cbb4886fa975e9f34c672ed171df2318", size = 64108, upload-time = "2026-02-23T11:01:27.429Z" },
+    { url = "https://files.pythonhosted.org/packages/de/bc/2761410d0541e975f384bc89f062d716bf119499dd097eb1af33dcd3b1c0/smart_open-7.6.0-py3-none-any.whl", hash = "sha256:2a78f454610a826aa688065b54b4a0a9b12a5599fa61d5190e9bac2df5e5f53f", size = 64591, upload-time = "2026-04-13T09:48:02.687Z" },
 ]
 
 [[package]]
@@ -4985,24 +4985,24 @@ wheels = [
 
 [[package]]
 name = "uuid-utils"
-version = "0.14.1"
+version = "0.15.0a1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7b/d1/38a573f0c631c062cf42fa1f5d021d4dd3c31fb23e4376e4b56b0c9fbbed/uuid_utils-0.14.1.tar.gz", hash = "sha256:9bfc95f64af80ccf129c604fb6b8ca66c6f256451e32bc4570f760e4309c9b69", size = 22195, upload-time = "2026-02-20T22:50:38.833Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/42/62b53305480e39d8a80f69bbea2f7fa8837f3b14d64ac4a2215e1c0075db/uuid_utils-0.15.0a1.tar.gz", hash = "sha256:a2f43e9cbf6bd62774db32f5a5617023d47be4fb3ae92b18dde01b0ab4f8d34d", size = 24135, upload-time = "2026-04-13T11:47:21.085Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/b7/add4363039a34506a58457d96d4aa2126061df3a143eb4d042aedd6a2e76/uuid_utils-0.14.1-cp39-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:93a3b5dc798a54a1feb693f2d1cb4cf08258c32ff05ae4929b5f0a2ca624a4f0", size = 604679, upload-time = "2026-02-20T22:50:27.469Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/84/d1d0bef50d9e66d31b2019997c741b42274d53dde2e001b7a83e9511c339/uuid_utils-0.14.1-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:ccd65a4b8e83af23eae5e56d88034b2fe7264f465d3e830845f10d1591b81741", size = 309346, upload-time = "2026-02-20T22:50:31.857Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/ed/b6d6fd52a6636d7c3eddf97d68da50910bf17cd5ac221992506fb56cf12e/uuid_utils-0.14.1-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b56b0cacd81583834820588378e432b0696186683b813058b707aedc1e16c4b1", size = 344714, upload-time = "2026-02-20T22:50:42.642Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/a7/a19a1719fb626fe0b31882db36056d44fe904dc0cf15b06fdf56b2679cf7/uuid_utils-0.14.1-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bb3cf14de789097320a3c56bfdfdd51b1225d11d67298afbedee7e84e3837c96", size = 350914, upload-time = "2026-02-20T22:50:36.487Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/fc/f6690e667fdc3bb1a73f57951f97497771c56fe23e3d302d7404be394d4f/uuid_utils-0.14.1-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:60e0854a90d67f4b0cc6e54773deb8be618f4c9bad98d3326f081423b5d14fae", size = 482609, upload-time = "2026-02-20T22:50:37.511Z" },
-    { url = "https://files.pythonhosted.org/packages/54/6e/dcd3fa031320921a12ec7b4672dea3bd1dd90ddffa363a91831ba834d559/uuid_utils-0.14.1-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ce6743ba194de3910b5feb1a62590cd2587e33a73ab6af8a01b642ceb5055862", size = 345699, upload-time = "2026-02-20T22:50:46.87Z" },
-    { url = "https://files.pythonhosted.org/packages/04/28/e5220204b58b44ac0047226a9d016a113fde039280cc8732d9e6da43b39f/uuid_utils-0.14.1-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:043fb58fde6cf1620a6c066382f04f87a8e74feb0f95a585e4ed46f5d44af57b", size = 372205, upload-time = "2026-02-20T22:50:28.438Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/d9/3d2eb98af94b8dfffc82b6a33b4dfc87b0a5de2c68a28f6dde0db1f8681b/uuid_utils-0.14.1-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c915d53f22945e55fe0d3d3b0b87fd965a57f5fd15666fd92d6593a73b1dd297", size = 521836, upload-time = "2026-02-20T22:50:23.057Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/15/0eb106cc6fe182f7577bc0ab6e2f0a40be247f35c5e297dbf7bbc460bd02/uuid_utils-0.14.1-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:0972488e3f9b449e83f006ead5a0e0a33ad4a13e4462e865b7c286ab7d7566a3", size = 625260, upload-time = "2026-02-20T22:50:25.949Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/17/f539507091334b109e7496830af2f093d9fc8082411eafd3ece58af1f8ba/uuid_utils-0.14.1-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:1c238812ae0c8ffe77d8d447a32c6dfd058ea4631246b08b5a71df586ff08531", size = 587824, upload-time = "2026-02-20T22:50:35.225Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/c2/d37a7b2e41f153519367d4db01f0526e0d4b06f1a4a87f1c5dfca5d70a8b/uuid_utils-0.14.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:bec8f8ef627af86abf8298e7ec50926627e29b34fa907fcfbedb45aaa72bca43", size = 551407, upload-time = "2026-02-20T22:50:44.915Z" },
-    { url = "https://files.pythonhosted.org/packages/65/36/2d24b2cbe78547c6532da33fb8613debd3126eccc33a6374ab788f5e46e9/uuid_utils-0.14.1-cp39-abi3-win32.whl", hash = "sha256:b54d6aa6252d96bac1fdbc80d26ba71bad9f220b2724d692ad2f2310c22ef523", size = 183476, upload-time = "2026-02-20T22:50:32.745Z" },
-    { url = "https://files.pythonhosted.org/packages/83/92/2d7e90df8b1a69ec4cff33243ce02b7a62f926ef9e2f0eca5a026889cd73/uuid_utils-0.14.1-cp39-abi3-win_amd64.whl", hash = "sha256:fc27638c2ce267a0ce3e06828aff786f91367f093c80625ee21dad0208e0f5ba", size = 187147, upload-time = "2026-02-20T22:50:45.807Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/26/529f4beee17e5248e37e0bc17a2761d34c0fa3b1e5729c88adb2065bae6e/uuid_utils-0.14.1-cp39-abi3-win_arm64.whl", hash = "sha256:b04cb49b42afbc4ff8dbc60cf054930afc479d6f4dd7f1ec3bbe5dbfdde06b7a", size = 188132, upload-time = "2026-02-20T22:50:41.718Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/2f/f0d6bbe972cd0eabe1db722631b6ac69dd89038cebbf11e011da126e1df2/uuid_utils-0.15.0a1-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:d33b657abdc5d0afdb0f4b6db88bd70b29645bf1de9844fe9d466e503467ec51", size = 568896, upload-time = "2026-04-13T11:48:13.334Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/d8/52a6fd302104b299bbfd1e5b76c4c9787feeca184fc3f64deaf881f7a31b/uuid_utils-0.15.0a1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f5d922ad70296d8c3713af2d1676166c21144973e3f4d59e731f51a997409738", size = 293361, upload-time = "2026-04-13T11:46:59.088Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/d9/a29192da2654ba5975f46c68a4586eefc69122b479f58adb5f6024b32b09/uuid_utils-0.15.0a1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7d8f47b0c17892c10df82f8f463b1a8d7bd8781298dfc9bbd9eb4d2f72e49dc3", size = 326678, upload-time = "2026-04-13T11:48:30.645Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/16/36a5e257430afcc9065c07ea687d1359699b94d3a3a7cdb36a3453b109f1/uuid_utils-0.15.0a1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:494b3510bdfae6294cc735eefa1ebb6cf296295ad720e14acdefaf10fff84665", size = 334452, upload-time = "2026-04-13T11:47:23.851Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/d8/56ee779c73a5ab696fbe968b4487ced157d65f3df929942c258e7518086c/uuid_utils-0.15.0a1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cbcc3093e5a0df62ac3fd93e371c3d8f0b9fa85347f407650c9561cf5f5bd4a4", size = 448232, upload-time = "2026-04-13T11:47:02.745Z" },
+    { url = "https://files.pythonhosted.org/packages/69/95/35d86189f73f19bcaa1c5c8f648fa032de981e9d099cfaa7d601d09596a8/uuid_utils-0.15.0a1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6e565f54a136bedc0e3e637a8b1adfe9e33bd053e873b5aa28a54922f67ad632", size = 329030, upload-time = "2026-04-13T11:47:42.818Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/64/45843834ef55b79a1727536a2c33831d573087f61032c1be01de80902847/uuid_utils-0.15.0a1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fb9b9a75b3c5aa198323d8c7963c2375df2910dffba8b662c59815a0abea6c78", size = 351334, upload-time = "2026-04-13T11:47:34.097Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b1/d3ab7988bca3009223e239a8f2116367d24d28688c54bb26653bc005ca96/uuid_utils-0.15.0a1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1a4df5c5816f3b4c8d8b719eefb38a5a58ddb3868d2df17ec7f929b0ecbd4e19", size = 503555, upload-time = "2026-04-13T11:47:03.877Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/d9/9fd46087831b33ea8fd65fe507bde1799510c0b4a08d981d34046f829f92/uuid_utils-0.15.0a1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:a97147c130db66f4cb2075b4774f4b770d546bf61e1bb4135bfb7447e11466c8", size = 609882, upload-time = "2026-04-13T11:47:10.064Z" },
+    { url = "https://files.pythonhosted.org/packages/98/38/fcd6a3981ddd5ca41b4932cd61ce1cf744f6a6cdfef8a365972e3c56bdc8/uuid_utils-0.15.0a1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:ed0572a43c019cb69183048f56636cffa83147bb27a0a3e70812828ce35bd059", size = 567784, upload-time = "2026-04-13T11:46:25.342Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/76/42b2494b5119927e6be4aec5ec47b3f31dd37326c24537c35013c46bd149/uuid_utils-0.15.0a1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b261141029669b8d24ad2697611dd90d6a008d5a97318b4dcc61fee75f502dbc", size = 533613, upload-time = "2026-04-13T11:47:36.551Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/66/89b99da8202ce73464f22b2c9f15ac1bbcc4c92429eaec93865d4c95a05c/uuid_utils-0.15.0a1-cp312-cp312-win32.whl", hash = "sha256:4c5a180c22c1f48ae8dbfb91d74cde81a21f6ae274e0bf47e75fb68efe233f50", size = 168006, upload-time = "2026-04-13T11:48:37.564Z" },
+    { url = "https://files.pythonhosted.org/packages/59/69/3d713ae354e87c98bcf219dc6a1752ef17fe4f9416b5ad3b6d8e59d3d719/uuid_utils-0.15.0a1-cp312-cp312-win_amd64.whl", hash = "sha256:d59c28df0bde42ecdb7e975fa58a23d8db8c9e706fa13ef728d94850453a1baf", size = 174213, upload-time = "2026-04-13T11:48:21.594Z" },
+    { url = "https://files.pythonhosted.org/packages/80/1b/43eadd685a3c031a862c37839154b66996bb02e21ffd751a21a960fe0f91/uuid_utils-0.15.0a1-cp312-cp312-win_arm64.whl", hash = "sha256:13d69c6bcf9a1306484c9524a0fb30505e98339ac5c299b23739b931a58e289f", size = 171813, upload-time = "2026-04-13T11:47:00.145Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# What does this PR do ?

Official 0.43.0 release might be delayed to tomorrow but has some recent bug fixes reported in 26.04 QA. 0.43.0rc4 is created to unblock testing - its essentially going to be same as 0.43.0 once it comes out

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
