### PR TITLE
cp: `fix(perf): set NCCL env vars when nccl_ub enabled via recipe config (3283)` into `r0.4.0`

### DIFF
--- a/scripts/performance/run_script.py
+++ b/scripts/performance/run_script.py
@@ -95,6 +95,11 @@ def main():
         config_variant=args.config_variant,
     )
 
+    # Set NCCL env vars for nccl_ub enabled via recipe config (not just CLI).
+    if getattr(recipe.ddp, "nccl_ub", False):
+        os.environ.setdefault("NCCL_NVLS_ENABLE", "1")
+        os.environ.setdefault("NCCL_CTA_POLICY", "1")
+
     # Select forward step function based on the model family name.
     if args.domain == "vlm":
         forward_step_func = vlm_forward_step


### PR DESCRIPTION
## Summary
- Cherry-pick of #3283 into `r0.4.0` release branch
- Sets `NCCL_NVLS_ENABLE=1` and `NCCL_CTA_POLICY=1` env vars when `nccl_ub` is enabled via recipe config (not just CLI)
- Conflict resolved: excluded unrelated `dryrun` block that exists on `main` but not on `r0.4.0`

## Test plan
- [ ] CI passes on `r0.4.0` base
- [ ] Verify NCCL env vars are set when `recipe.ddp.nccl_ub=True`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance**
  * Improved distributed training efficiency by enabling optimized NVIDIA collective communication settings based on runtime configuration, delivering enhanced performance when supported hardware and settings are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->