### PR TITLE
[misc] fix: lint issues in Qwen3.5-VL perf configs

### DIFF
--- a/scripts/performance/configs/qwen_vl/__init__.py
+++ b/scripts/performance/configs/qwen_vl/__init__.py
@@ -48,7 +48,6 @@ from .qwen3_vl_workload_base_configs import (
     QWEN3_VL_235B_A22B_PRETRAIN_CONFIG_H100_BF16,
     QWEN3_VL_235B_A22B_PRETRAIN_CONFIG_H100_FP8_CS,
 )
-
 from .qwen35_vl_workload_base_configs import (
     QWEN35_VL_35B_A3B_PRETRAIN_CONFIG_B200_BF16,
     QWEN35_VL_35B_A3B_PRETRAIN_CONFIG_B200_FP8_CS,

--- a/scripts/performance/configs/qwen_vl/qwen35_vl_pretrain.py
+++ b/scripts/performance/configs/qwen_vl/qwen35_vl_pretrain.py
@@ -105,8 +105,12 @@ def qwen35_vl_35b_a3b_pretrain_config_gb300(
 ) -> ConfigContainer:
     """GB300, baseline config."""
     return _qwen35_vl_pretrain_config(
-        "qwen35_vl_35b_a3b", "gb300", qwen35_vl_35b_a3b_pretrain_mock_config,
-        precision=precision, mock=mock, config_variant=config_variant,
+        "qwen35_vl_35b_a3b",
+        "gb300",
+        qwen35_vl_35b_a3b_pretrain_mock_config,
+        precision=precision,
+        mock=mock,
+        config_variant=config_variant,
     )
 
 
@@ -115,8 +119,12 @@ def qwen35_vl_35b_a3b_pretrain_config_b300(
 ) -> ConfigContainer:
     """B300, baseline config."""
     return _qwen35_vl_pretrain_config(
-        "qwen35_vl_35b_a3b", "b300", qwen35_vl_35b_a3b_pretrain_mock_config,
-        precision=precision, mock=mock, config_variant=config_variant,
+        "qwen35_vl_35b_a3b",
+        "b300",
+        qwen35_vl_35b_a3b_pretrain_mock_config,
+        precision=precision,
+        mock=mock,
+        config_variant=config_variant,
     )
 
 
@@ -125,8 +133,12 @@ def qwen35_vl_35b_a3b_pretrain_config_gb200(
 ) -> ConfigContainer:
     """GB200, baseline config."""
     return _qwen35_vl_pretrain_config(
-        "qwen35_vl_35b_a3b", "gb200", qwen35_vl_35b_a3b_pretrain_mock_config,
-        precision=precision, mock=mock, config_variant=config_variant,
+        "qwen35_vl_35b_a3b",
+        "gb200",
+        qwen35_vl_35b_a3b_pretrain_mock_config,
+        precision=precision,
+        mock=mock,
+        config_variant=config_variant,
     )
 
 
@@ -135,8 +147,12 @@ def qwen35_vl_35b_a3b_pretrain_config_b200(
 ) -> ConfigContainer:
     """B200, baseline config."""
     return _qwen35_vl_pretrain_config(
-        "qwen35_vl_35b_a3b", "b200", qwen35_vl_35b_a3b_pretrain_mock_config,
-        precision=precision, mock=mock, config_variant=config_variant,
+        "qwen35_vl_35b_a3b",
+        "b200",
+        qwen35_vl_35b_a3b_pretrain_mock_config,
+        precision=precision,
+        mock=mock,
+        config_variant=config_variant,
     )
 
 
@@ -145,8 +161,12 @@ def qwen35_vl_35b_a3b_pretrain_config_h100(
 ) -> ConfigContainer:
     """H100, baseline config."""
     return _qwen35_vl_pretrain_config(
-        "qwen35_vl_35b_a3b", "h100", qwen35_vl_35b_a3b_pretrain_mock_config,
-        precision=precision, mock=mock, config_variant=config_variant,
+        "qwen35_vl_35b_a3b",
+        "h100",
+        qwen35_vl_35b_a3b_pretrain_mock_config,
+        precision=precision,
+        mock=mock,
+        config_variant=config_variant,
         tp_comm_overlap=True,
     )
 
@@ -161,8 +181,12 @@ def qwen35_vl_122b_a10b_pretrain_config_gb300(
 ) -> ConfigContainer:
     """GB300, baseline config."""
     return _qwen35_vl_pretrain_config(
-        "qwen35_vl_122b_a10b", "gb300", qwen35_vl_122b_a10b_pretrain_mock_config,
-        precision=precision, mock=mock, config_variant=config_variant,
+        "qwen35_vl_122b_a10b",
+        "gb300",
+        qwen35_vl_122b_a10b_pretrain_mock_config,
+        precision=precision,
+        mock=mock,
+        config_variant=config_variant,
     )
 
 
@@ -171,8 +195,12 @@ def qwen35_vl_122b_a10b_pretrain_config_b300(
 ) -> ConfigContainer:
     """B300, baseline config."""
     return _qwen35_vl_pretrain_config(
-        "qwen35_vl_122b_a10b", "b300", qwen35_vl_122b_a10b_pretrain_mock_config,
-        precision=precision, mock=mock, config_variant=config_variant,
+        "qwen35_vl_122b_a10b",
+        "b300",
+        qwen35_vl_122b_a10b_pretrain_mock_config,
+        precision=precision,
+        mock=mock,
+        config_variant=config_variant,
     )
 
 
@@ -181,8 +209,12 @@ def qwen35_vl_122b_a10b_pretrain_config_gb200(
 ) -> ConfigContainer:
     """GB200, baseline config."""
     return _qwen35_vl_pretrain_config(
-        "qwen35_vl_122b_a10b", "gb200", qwen35_vl_122b_a10b_pretrain_mock_config,
-        precision=precision, mock=mock, config_variant=config_variant,
+        "qwen35_vl_122b_a10b",
+        "gb200",
+        qwen35_vl_122b_a10b_pretrain_mock_config,
+        precision=precision,
+        mock=mock,
+        config_variant=config_variant,
     )
 
 
@@ -191,8 +223,12 @@ def qwen35_vl_122b_a10b_pretrain_config_b200(
 ) -> ConfigContainer:
     """B200, baseline config."""
     return _qwen35_vl_pretrain_config(
-        "qwen35_vl_122b_a10b", "b200", qwen35_vl_122b_a10b_pretrain_mock_config,
-        precision=precision, mock=mock, config_variant=config_variant,
+        "qwen35_vl_122b_a10b",
+        "b200",
+        qwen35_vl_122b_a10b_pretrain_mock_config,
+        precision=precision,
+        mock=mock,
+        config_variant=config_variant,
     )
 
 
@@ -201,8 +237,12 @@ def qwen35_vl_122b_a10b_pretrain_config_h100(
 ) -> ConfigContainer:
     """H100, baseline config."""
     return _qwen35_vl_pretrain_config(
-        "qwen35_vl_122b_a10b", "h100", qwen35_vl_122b_a10b_pretrain_mock_config,
-        precision=precision, mock=mock, config_variant=config_variant,
+        "qwen35_vl_122b_a10b",
+        "h100",
+        qwen35_vl_122b_a10b_pretrain_mock_config,
+        precision=precision,
+        mock=mock,
+        config_variant=config_variant,
         tp_comm_overlap=False,
     )
 
@@ -217,8 +257,12 @@ def qwen35_vl_397b_a17b_pretrain_config_gb300(
 ) -> ConfigContainer:
     """GB300, baseline config."""
     return _qwen35_vl_pretrain_config(
-        "qwen35_vl_397b_a17b", "gb300", qwen35_vl_397b_a17b_pretrain_mock_config,
-        precision=precision, mock=mock, config_variant=config_variant,
+        "qwen35_vl_397b_a17b",
+        "gb300",
+        qwen35_vl_397b_a17b_pretrain_mock_config,
+        precision=precision,
+        mock=mock,
+        config_variant=config_variant,
     )
 
 
@@ -227,8 +271,12 @@ def qwen35_vl_397b_a17b_pretrain_config_b300(
 ) -> ConfigContainer:
     """B300, baseline config."""
     return _qwen35_vl_pretrain_config(
-        "qwen35_vl_397b_a17b", "b300", qwen35_vl_397b_a17b_pretrain_mock_config,
-        precision=precision, mock=mock, config_variant=config_variant,
+        "qwen35_vl_397b_a17b",
+        "b300",
+        qwen35_vl_397b_a17b_pretrain_mock_config,
+        precision=precision,
+        mock=mock,
+        config_variant=config_variant,
     )
 
 
@@ -237,8 +285,12 @@ def qwen35_vl_397b_a17b_pretrain_config_gb200(
 ) -> ConfigContainer:
     """GB200, baseline config."""
     return _qwen35_vl_pretrain_config(
-        "qwen35_vl_397b_a17b", "gb200", qwen35_vl_397b_a17b_pretrain_mock_config,
-        precision=precision, mock=mock, config_variant=config_variant,
+        "qwen35_vl_397b_a17b",
+        "gb200",
+        qwen35_vl_397b_a17b_pretrain_mock_config,
+        precision=precision,
+        mock=mock,
+        config_variant=config_variant,
     )
 
 
@@ -247,8 +299,12 @@ def qwen35_vl_397b_a17b_pretrain_config_b200(
 ) -> ConfigContainer:
     """B200, baseline config."""
     return _qwen35_vl_pretrain_config(
-        "qwen35_vl_397b_a17b", "b200", qwen35_vl_397b_a17b_pretrain_mock_config,
-        precision=precision, mock=mock, config_variant=config_variant,
+        "qwen35_vl_397b_a17b",
+        "b200",
+        qwen35_vl_397b_a17b_pretrain_mock_config,
+        precision=precision,
+        mock=mock,
+        config_variant=config_variant,
     )
 
 
@@ -257,7 +313,11 @@ def qwen35_vl_397b_a17b_pretrain_config_h100(
 ) -> ConfigContainer:
     """H100, baseline config."""
     return _qwen35_vl_pretrain_config(
-        "qwen35_vl_397b_a17b", "h100", qwen35_vl_397b_a17b_pretrain_mock_config,
-        precision=precision, mock=mock, config_variant=config_variant,
+        "qwen35_vl_397b_a17b",
+        "h100",
+        qwen35_vl_397b_a17b_pretrain_mock_config,
+        precision=precision,
+        mock=mock,
+        config_variant=config_variant,
         tp_comm_overlap=False,
     )

--- a/src/megatron/bridge/recipes/qwen_vl/qwen35_vl.py
+++ b/src/megatron/bridge/recipes/qwen_vl/qwen35_vl.py
@@ -620,4 +620,3 @@ def qwen35_vl_397b_a17b_peft_config(
     _qwen35_vl_apply_common(cfg, hf_path, tp=2, pp=1, max_lr=2e-4, min_lr=3e-5)
     _qwen35_vl_apply_moe(cfg, ep=32)
     return cfg
-


### PR DESCRIPTION
## Summary
- Fix pre-commit failures on `main` introduced by #3101
- **ruff-format**: reformat function call args in `qwen35_vl_pretrain.py` (line length violations)
- **ruff**: remove extra blank line in `scripts/performance/configs/qwen_vl/__init__.py`
- **end-of-file-fixer**: fix missing final newline in `src/megatron/bridge/recipes/qwen_vl/qwen35_vl.py`

## Test plan
- [x] `pre-commit run --all-files` passes after this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Code formatting improvements across configuration and recipe modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->