### PR TITLE
fix(docker): remove NeMo checkout step from fw_final Dockerfile

### DIFF
--- a/docker/Dockerfile.fw_final
+++ b/docker/Dockerfile.fw_final
@@ -35,13 +35,7 @@ ARG NEMO_EVAL_COMMIT
 ARG NEMO_RUN_COMMIT
 
 # Update FW repository commit
-RUN pushd /opt/NeMo && \
-        git pull && \
-        git fetch origin $NEMO_COMMIT && \
-        git checkout FETCH_HEAD && \
-        echo "Container built with NeMo commit hash: $NEMO_COMMIT" && \
-    popd && \
-    pushd /opt/Export-Deploy && \
+RUN    pushd /opt/Export-Deploy && \
         git pull && \
         git fetch origin $NEMO_EXPORT_DEPLOY_COMMIT && \
         git checkout FETCH_HEAD && \


### PR DESCRIPTION
## Summary

- Removes the stale NeMo repo checkout/update block from `Dockerfile.fw_final` — this step is no longer needed

## Test plan

- [ ] Rebuild the fw container and verify it builds successfully without the NeMo checkout step

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined Docker build configuration by removing redundant repository commit-pinning operations and simplifying build steps, while preserving all deployment and evaluation functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->