### PR TITLE
fix(docker): remove nemo-toolkit audio/tts deps from fw_pyproject.toml

### DIFF
--- a/docker/common/fw_pyproject.toml
+++ b/docker/common/fw_pyproject.toml
@@ -30,8 +30,6 @@ license = { text = "Apache 2.0" }
 dependencies = [
     "nemo-export-deploy",
     "nemo-evaluator",
-    "nemo-toolkit[audio]",
-    "nemo-toolkit[tts]",
     "nemo-run",
     "nvidia-lm-eval",
     "langchain~=1.0.0",
@@ -44,7 +42,6 @@ test = ["coverage>=7.8.1"]
 [tool.uv.sources]
 "nemo-export-deploy" = { path = "/opt/Export-Deploy", editable = true }
 "nemo-evaluator" = { path = "/opt/Evaluator/packages/nemo-evaluator", editable = true }
-"nemo-toolkit" = { path = "/opt/NeMo", editable = true }
 "nemo-run" = { path = "/opt/Run", editable = true }
 
 [tool.uv]
@@ -54,8 +51,6 @@ override-dependencies = [
     "megatron-core[dev,mlm]; sys_platform == 'never'", # Installed by MBridge
     "nemo-export-deploy @ /opt/Export-Deploy",
     "megatron-bridge; sys_platform == 'never'",        # Installed by MBridge
-    "nemo-toolkit[audio] @ /opt/NeMo[audio]",
-    "nemo-toolkit[tts] @ /opt/NeMo[tts]",
     "nemo-run @ /opt/Run",
     "transformer-engine; sys_platform == 'never'",     # Installed by MBridge
     # Pinning versions to solve conflicts


### PR DESCRIPTION
## Summary

- Removes `nemo-toolkit[audio]` and `nemo-toolkit[tts]` dependencies from `docker/common/fw_pyproject.toml`
- Removes the `/opt/NeMo` editable source path, as speech components are no longer included in the fw container
- Counterpart to #3308 which removes the NeMo checkout step from `Dockerfile.fw_final`

## Test plan

- [ ] Rebuild the fw container and verify it installs cleanly without the audio/tts extras

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed `nemo-toolkit` as an explicit project dependency, streamlining the dependency configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->