### PR TITLE
perf(nsys): reduce CPU-side overhead in profiling defaults

### DIFF
--- a/scripts/performance/perf_plugins.py
+++ b/scripts/performance/perf_plugins.py
@@ -121,12 +121,19 @@ class NsysPlugin(Plugin):
         if self.nsys_trace is not None:
             launcher.nsys_trace = self.nsys_trace
 
-        # Combine default extra args with user-provided extra args
+        # Override nemo_run defaults to reduce CPU-side collection overhead
+        launcher.nsys_extra_args = [
+            "--force-overwrite=true",
+            "--capture-range=cudaProfilerApi",
+            "--capture-range-end=stop",
+            "--cuda-event-trace=false",
+            "--cpuctxsw=none",
+            "--backtrace=none",
+        ]
+
+        # Combine with user-provided extra args (user args first for precedence)
         if self.nsys_extra_args is not None:
-            # Get existing launcher extra args (nemo_run defaults)
-            existing_extra_args = launcher.nsys_extra_args or []
-            # Combine user args with existing args (user args first for precedence)
-            launcher.nsys_extra_args = self.nsys_extra_args + existing_extra_args
+            launcher.nsys_extra_args = self.nsys_extra_args + launcher.nsys_extra_args
             logger.info(f"Combined nsys_extra_args: {launcher.nsys_extra_args}")
 
         if isinstance(executor, SlurmExecutor):

--- a/scripts/performance/perf_plugins.py
+++ b/scripts/performance/perf_plugins.py
@@ -121,15 +121,12 @@ class NsysPlugin(Plugin):
         if self.nsys_trace is not None:
             launcher.nsys_trace = self.nsys_trace
 
-        # Override nemo_run defaults to reduce CPU-side collection overhead
-        launcher.nsys_extra_args = [
-            "--force-overwrite=true",
-            "--capture-range=cudaProfilerApi",
-            "--capture-range-end=stop",
-            "--cuda-event-trace=false",
-            "--cpuctxsw=none",
-            "--backtrace=none",
-        ]
+        # Reduce CPU-side collection overhead: disable context-switch tracing,
+        # backtrace collection, and CUDA graph node tracing.
+        existing = launcher.nsys_extra_args or []
+        existing = [a for a in existing if not a.startswith("--cuda-graph-trace")]
+        existing.extend(["--cpuctxsw=none", "--backtrace=none"])
+        launcher.nsys_extra_args = existing
 
         # Combine with user-provided extra args (user args first for precedence)
         if self.nsys_extra_args is not None:

--- a/scripts/performance/rubin_launch_interactive.sh
+++ b/scripts/performance/rubin_launch_interactive.sh
@@ -124,7 +124,6 @@ if [ "${ENABLE_NSYS}" = "1" ]; then
         --force-overwrite true
         --capture-range=cudaProfilerApi
         --capture-range-end=stop
-        --cuda-event-trace=false
     )
 fi
 

--- a/scripts/performance/rubin_launch_interactive.sh
+++ b/scripts/performance/rubin_launch_interactive.sh
@@ -117,11 +117,14 @@ if [ "${ENABLE_NSYS}" = "1" ]; then
     NSYS_PREFIX=(
         nsys profile
         -s none
+        --cpuctxsw=none
+        --backtrace=none
         -t "${NSYS_TRACE}"
         -o "${NSYS_OUTPUT}"
         --force-overwrite true
         --capture-range=cudaProfilerApi
         --capture-range-end=stop
+        --cuda-event-trace=false
     )
 fi
 

--- a/src/megatron/bridge/recipes/run_plugins.py
+++ b/src/megatron/bridge/recipes/run_plugins.py
@@ -297,6 +297,16 @@ class NsysPlugin(Plugin):
         launcher.nsys_profile = True
         launcher.nsys_trace = self.nsys_trace or ["nvtx", "cuda"]
 
+        # Override nemo_run defaults to reduce CPU-side collection overhead
+        launcher.nsys_extra_args = [
+            "--force-overwrite=true",
+            "--capture-range=cudaProfilerApi",
+            "--capture-range-end=stop",
+            "--cuda-event-trace=false",
+            "--cpuctxsw=none",
+            "--backtrace=none",
+        ]
+
         if isinstance(executor, SlurmExecutor):
             # NOTE: DO NOT change to f-string, `%q{}` is Slurm placeholder
             launcher.nsys_filename = "profile_%p_%q{SLURM_JOB_ID}_node%q{SLURM_NODEID}_rank%q{SLURM_PROCID}"

--- a/src/megatron/bridge/recipes/run_plugins.py
+++ b/src/megatron/bridge/recipes/run_plugins.py
@@ -297,15 +297,12 @@ class NsysPlugin(Plugin):
         launcher.nsys_profile = True
         launcher.nsys_trace = self.nsys_trace or ["nvtx", "cuda"]
 
-        # Override nemo_run defaults to reduce CPU-side collection overhead
-        launcher.nsys_extra_args = [
-            "--force-overwrite=true",
-            "--capture-range=cudaProfilerApi",
-            "--capture-range-end=stop",
-            "--cuda-event-trace=false",
-            "--cpuctxsw=none",
-            "--backtrace=none",
-        ]
+        # Reduce CPU-side collection overhead: disable context-switch tracing,
+        # backtrace collection, and CUDA graph node tracing.
+        existing = launcher.nsys_extra_args or []
+        existing = [a for a in existing if not a.startswith("--cuda-graph-trace")]
+        existing.extend(["--cpuctxsw=none", "--backtrace=none"])
+        launcher.nsys_extra_args = existing
 
         if isinstance(executor, SlurmExecutor):
             # NOTE: DO NOT change to f-string, `%q{}` is Slurm placeholder


### PR DESCRIPTION
## Summary
- Override nemo_run's default `nsys_extra_args` to disable CPU context-switch tracing (`--cpuctxsw=none`), backtrace collection (`--backtrace=none`), and remove CUDA graph node tracing (`--cuda-graph-trace=node`)
- These flags eliminate unnecessary CPU-side activity during GPU profiling, reducing profiling overhead
- Applied to both `NsysPlugin` implementations (recipes + perf scripts) and the interactive launch script

## Changes vs nemo_run defaults

| Flag | nemo_run default | After this PR |
|------|-----------------|---------------|
| `--cpuctxsw` | `process-tree` (nsys default) | `none` |
| `--backtrace` | `auto` (nsys default) | `none` |
| `--cuda-graph-trace` | `node` | removed |

Since `-s none` (disable CPU sampling) is already set by nemo_run, `--backtrace=none` is defensive — there are no CPU samples to attach backtraces to. `--cpuctxsw=none` is the main win, stopping OS thread scheduling trace collection that was active by default.

## Test plan
- [ ] Verify nsys profiling still produces valid `.nsys-rep` files
- [ ] Confirm NVTX ranges and CUDA kernels are still captured
- [ ] Check that `nsys_extra_args` user override still works (user args take precedence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)