### PR TITLE
[training] fix: use int64 for TrainState counters to prevent overflow

### DIFF
--- a/src/megatron/bridge/training/state.py
+++ b/src/megatron/bridge/training/state.py
@@ -70,10 +70,10 @@ class TrainState(Stateful):
             their corresponding tensor representations.
         """
         return {
-            "step": torch.tensor(self.step, dtype=torch.int64),
-            "consumed_train_samples": torch.tensor(self.consumed_train_samples, dtype=torch.int64),
-            "skipped_train_samples": torch.tensor(self.skipped_train_samples, dtype=torch.int64),
-            "consumed_valid_samples": torch.tensor(self.consumed_valid_samples, dtype=torch.int64),
+            "step": torch.tensor(self.step, dtype=torch.uint64),
+            "consumed_train_samples": torch.tensor(self.consumed_train_samples, dtype=torch.uint64),
+            "skipped_train_samples": torch.tensor(self.skipped_train_samples, dtype=torch.uint64),
+            "consumed_valid_samples": torch.tensor(self.consumed_valid_samples, dtype=torch.uint64),
             "floating_point_operations_so_far": torch.tensor(
                 self.floating_point_operations_so_far, dtype=torch.float64
             ),

--- a/src/megatron/bridge/training/state.py
+++ b/src/megatron/bridge/training/state.py
@@ -70,10 +70,10 @@ class TrainState(Stateful):
             their corresponding tensor representations.
         """
         return {
-            "step": torch.tensor(self.step, dtype=torch.int32),
-            "consumed_train_samples": torch.tensor(self.consumed_train_samples, dtype=torch.int32),
-            "skipped_train_samples": torch.tensor(self.skipped_train_samples, dtype=torch.int32),
-            "consumed_valid_samples": torch.tensor(self.consumed_valid_samples, dtype=torch.int32),
+            "step": torch.tensor(self.step, dtype=torch.int64),
+            "consumed_train_samples": torch.tensor(self.consumed_train_samples, dtype=torch.int64),
+            "skipped_train_samples": torch.tensor(self.skipped_train_samples, dtype=torch.int64),
+            "consumed_valid_samples": torch.tensor(self.consumed_valid_samples, dtype=torch.int64),
             "floating_point_operations_so_far": torch.tensor(
                 self.floating_point_operations_so_far, dtype=torch.float64
             ),

--- a/tests/unit_tests/training/test_state.py
+++ b/tests/unit_tests/training/test_state.py
@@ -86,11 +86,11 @@ class TestTrainState:
         }
         assert set(state_dict.keys()) == expected_keys
 
-        # Check tensor types
-        assert state_dict["step"].dtype == torch.int32
-        assert state_dict["consumed_train_samples"].dtype == torch.int32
-        assert state_dict["skipped_train_samples"].dtype == torch.int32
-        assert state_dict["consumed_valid_samples"].dtype == torch.int32
+        # Check tensor types (int64 to avoid overflow on long training runs)
+        assert state_dict["step"].dtype == torch.int64
+        assert state_dict["consumed_train_samples"].dtype == torch.int64
+        assert state_dict["skipped_train_samples"].dtype == torch.int64
+        assert state_dict["consumed_valid_samples"].dtype == torch.int64
         assert state_dict["floating_point_operations_so_far"].dtype == torch.float64
         assert state_dict["do_train"].dtype == torch.bool
         assert state_dict["do_valid"].dtype == torch.bool

--- a/tests/unit_tests/training/test_state.py
+++ b/tests/unit_tests/training/test_state.py
@@ -86,11 +86,11 @@ class TestTrainState:
         }
         assert set(state_dict.keys()) == expected_keys
 
-        # Check tensor types (int64 to avoid overflow on long training runs)
-        assert state_dict["step"].dtype == torch.int64
-        assert state_dict["consumed_train_samples"].dtype == torch.int64
-        assert state_dict["skipped_train_samples"].dtype == torch.int64
-        assert state_dict["consumed_valid_samples"].dtype == torch.int64
+        # Check tensor types (uint64 to avoid overflow on long training runs)
+        assert state_dict["step"].dtype == torch.uint64
+        assert state_dict["consumed_train_samples"].dtype == torch.uint64
+        assert state_dict["skipped_train_samples"].dtype == torch.uint64
+        assert state_dict["consumed_valid_samples"].dtype == torch.uint64
         assert state_dict["floating_point_operations_so_far"].dtype == torch.float64
         assert state_dict["do_train"].dtype == torch.bool
         assert state_dict["do_valid"].dtype == torch.bool


### PR DESCRIPTION
## Summary

- `TrainState.state_dict()` serialized `step`, `consumed_train_samples`, `skipped_train_samples`, and `consumed_valid_samples` as `torch.int32` tensors, which overflow at ~2.1B
- Long training runs with large global batch sizes exceed this limit (e.g. 700K iterations × GBS 3072 = 2.15B consumed samples), causing `RuntimeError: value cannot be converted to type int32 without overflow` at checkpoint save time
- Fix: switch to `torch.int64` (max ~9.2×10¹⁸)
- Backward compatible — `load_state_dict()` uses `.item()` which returns a Python scalar regardless of the source tensor dtype, so existing int32 checkpoints load correctly

Note: Megatron-LM does not have this issue because it pickles the entire `args` namespace where counters are plain Python `int` (arbitrary precision). Bridge introduced int32 tensors as part of its `Stateful` checkpoint design.

Closes NFS-711

## Test plan

- [x] Verify `load_state_dict()` works with both int32 (old checkpoints) and int64 (new checkpoints) via `.item()`
- [ ] CI unit tests pass

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Modified training state checkpoint serialization format for progress counters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->