### PR TITLE
[recipe] feat: add Qwen3-0.6B 128K SFT recipe with YaRN RoPE scaling

### DIFF
--- a/examples/long_context/qwen3_600m_sft_yarn_128k.sh
+++ b/examples/long_context/qwen3_600m_sft_yarn_128k.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Workspace directory for checkpoints and results
+WORKSPACE=${WORKSPACE:-/workspace}
+
+# Before training, make sure to set WANDB_API_KEY or disable wandb logging
+# export WANDB_API_KEY=<your_wandb_api_key>
+# export WANDB_MODE=disabled
+
+PRETRAINED_CHECKPOINT=${PRETRAINED_CHECKPOINT:-${WORKSPACE}/models/Qwen3-0.6B}
+MODEL_NAME=qwen3_600m
+DATASET_NAME=nemotron_cascade_math
+SEQ_LENGTH=131072
+TRAIN_ITERS=100
+GLOBAL_BATCH_SIZE=2
+MICRO_BATCH_SIZE=1
+EVAL_ITERS=10
+EVAL_INTERVAL=30
+LR_WARMUP_ITERS=10
+LOG_INTERVAL=1
+WANDB_PROJECT=megatron-bridge-${DATASET_NAME}
+
+# TP=1, CP=8 — required for 128K context parallelism (8 GPUs minimum)
+uv run python -m torch.distributed.run --nproc_per_node=8 scripts/training/run_recipe.py \
+    --recipe ${MODEL_NAME}_sft_yarn_128k_config \
+    checkpoint.pretrained_checkpoint=$PRETRAINED_CHECKPOINT \
+    train.train_iters=$TRAIN_ITERS \
+    train.global_batch_size=$GLOBAL_BATCH_SIZE \
+    train.micro_batch_size=$MICRO_BATCH_SIZE \
+    validation.eval_iters=$EVAL_ITERS \
+    validation.eval_interval=$EVAL_INTERVAL \
+    scheduler.lr_warmup_iters=$LR_WARMUP_ITERS \
+    checkpoint.save=${WORKSPACE}/results/${MODEL_NAME}_yarn_128k_sft \
+    checkpoint.load=${WORKSPACE}/results/${MODEL_NAME}_yarn_128k_sft \
+    logger.log_interval=$LOG_INTERVAL \
+    logger.wandb_project=$WANDB_PROJECT \
+    logger.wandb_exp_name=${MODEL_NAME}_${DATASET_NAME}_yarn_128k_sft

--- a/examples/long_context/qwen3_600m_sft_yarn_128k.sh
+++ b/examples/long_context/qwen3_600m_sft_yarn_128k.sh
@@ -25,12 +25,13 @@ MODEL_NAME=qwen3_600m
 DATASET_NAME=nemotron_cascade_math
 SEQ_LENGTH=131072
 TRAIN_ITERS=100
-GLOBAL_BATCH_SIZE=2
+GLOBAL_BATCH_SIZE=8
 MICRO_BATCH_SIZE=1
 EVAL_ITERS=10
 EVAL_INTERVAL=30
 LR_WARMUP_ITERS=10
 LOG_INTERVAL=1
+DISTRIBUTED_TIMEOUT_MINUTES=30
 WANDB_PROJECT=megatron-bridge-${DATASET_NAME}
 
 # TP=1, CP=8 — required for 128K context parallelism (8 GPUs minimum)
@@ -43,6 +44,7 @@ uv run python -m torch.distributed.run --nproc_per_node=8 scripts/training/run_r
     validation.eval_iters=$EVAL_ITERS \
     validation.eval_interval=$EVAL_INTERVAL \
     scheduler.lr_warmup_iters=$LR_WARMUP_ITERS \
+    dist.distributed_timeout_minutes=$DISTRIBUTED_TIMEOUT_MINUTES \
     checkpoint.save=${WORKSPACE}/results/${MODEL_NAME}_yarn_128k_sft \
     checkpoint.load=${WORKSPACE}/results/${MODEL_NAME}_yarn_128k_sft \
     logger.log_interval=$LOG_INTERVAL \

--- a/src/megatron/bridge/recipes/qwen/__init__.py
+++ b/src/megatron/bridge/recipes/qwen/__init__.py
@@ -67,6 +67,7 @@ from .qwen3 import (
     qwen3_600m_pretrain_config,
     qwen3_600m_sft_128k_config,
     qwen3_600m_sft_config,
+    qwen3_600m_sft_yarn_128k_config,
 )
 
 # Qwen3 MoE models
@@ -129,6 +130,7 @@ __all__ = [
     "qwen3_32b_pretrain_config",
     "qwen3_600m_sft_config",
     "qwen3_600m_sft_128k_config",
+    "qwen3_600m_sft_yarn_128k_config",
     "qwen3_1p7b_sft_config",
     "qwen3_4b_sft_config",
     "qwen3_8b_sft_config",

--- a/src/megatron/bridge/recipes/qwen/qwen3.py
+++ b/src/megatron/bridge/recipes/qwen/qwen3.py
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Any, Optional
+
 import torch
 
 from megatron.bridge import AutoBridge
+from megatron.bridge.data.builders.hf_dataset import HFDatasetConfig
 from megatron.bridge.peft.base import PEFT
 from megatron.bridge.recipes.common import _peft_common, _pretrain_common, _sft_common
 from megatron.bridge.recipes.utils.finetune_utils import default_peft_config
@@ -624,6 +627,90 @@ def qwen3_600m_sft_128k_config() -> ConfigContainer:
     cfg.optimizer.use_distributed_optimizer = False
 
     # Fewer warmup steps for long-context SFT
+    cfg.scheduler.lr_warmup_iters = 10
+    cfg.scheduler.lr_warmup_init = 1.0e-11
+
+    return cfg
+
+
+def qwen3_600m_sft_yarn_128k_config() -> ConfigContainer:
+    """Return a 128K full SFT config for Qwen3 600M with YaRN scaling.
+
+    This recipe uses the ``math`` subset of
+    ``nvidia/Nemotron-Cascade-2-SFT-Data`` with the Hugging Face chat
+    template from ``Qwen/Qwen3-0.6B``.
+
+    Recommended parallelism: TP=1, CP=8 (minimum 8 GPUs).
+    """
+    cfg = qwen3_600m_sft_config()
+    hf_path = "Qwen/Qwen3-0.6B"
+
+    def process_hf_chat_messages_example(
+        example: dict[str, Any], tokenizer: Optional[Any] = None
+    ) -> dict[str, list[dict[str, str]]]:
+        """Return HF chat-format messages unchanged for chat-template SFT."""
+        del tokenizer
+        return {"messages": example["messages"]}
+
+    # Model and tokenizer use the same HF checkpoint so the chat template matches the dataset.
+    cfg.model = AutoBridge.from_hf_pretrained(hf_path).to_megatron_provider(load_weights=False)
+    cfg.tokenizer.tokenizer_model = hf_path
+
+    # 128K context parallelism.
+    cfg.model.context_parallel_size = 8
+
+    # 128K sequence length with chat-format HF dataset input.
+    cfg.model.seq_length = 128 * 1024
+    cfg.dataset = HFDatasetConfig(
+        dataset_name="nvidia/Nemotron-Cascade-2-SFT-Data",
+        dataset_subset="math",
+        process_example_fn=process_hf_chat_messages_example,
+        split="train[:10000]",
+        hf_kwargs={
+            "data_files": {"train": "math/math_notool.jsonl"},
+        },
+        seq_length=cfg.model.seq_length,
+        seed=5678,
+        memmap_workers=1,
+        dataloader_type="batch",
+        do_validation=True,
+        do_test=False,
+        val_proportion=0.001,
+        num_workers=2,
+        data_sharding=True,
+        pin_memory=True,
+        persistent_workers=False,
+        packed_sequence_specs=None,
+        dataset_kwargs={
+            "chat": True,
+            "use_hf_tokenizer_chat_template": True,
+            "pad_to_max_length": True,
+        },
+        rewrite=False,
+    )
+
+    # Apply YaRN RoPE scaling from the model's native 40K context window to 128K.
+    cfg.model.position_embedding_type = "yarn"
+    cfg.model.yarn_original_max_position_embeddings = 40960
+    cfg.model.yarn_rotary_scaling_factor = cfg.model.seq_length / cfg.model.yarn_original_max_position_embeddings
+    cfg.model.yarn_beta_fast = 32.0
+    cfg.model.yarn_beta_slow = 1.0
+    cfg.model.yarn_mscale = 1.0
+    cfg.model.yarn_mscale_all_dim = 1.0
+    cfg.model.yarn_correction_range_round_to_int = False
+
+    # Smaller batch size to fit long sequences.
+    cfg.train.global_batch_size = 2
+
+    # Required for CP > 1 in long-context SFT.
+    cfg.model.cross_entropy_loss_fusion = False
+    cfg.model.calculate_per_token_loss = True
+    cfg.ddp.average_in_collective = False
+
+    # Long-context SFT stability overrides.
+    cfg.optimizer.lr = 1.0e-6
+    cfg.optimizer.min_lr = 1.0e-6
+    cfg.optimizer.use_distributed_optimizer = False
     cfg.scheduler.lr_warmup_iters = 10
     cfg.scheduler.lr_warmup_init = 1.0e-11
 

--- a/src/megatron/bridge/recipes/qwen/qwen3.py
+++ b/src/megatron/bridge/recipes/qwen/qwen3.py
@@ -665,13 +665,13 @@ def qwen3_600m_sft_yarn_128k_config() -> ConfigContainer:
         dataset_name="nvidia/Nemotron-Cascade-2-SFT-Data",
         dataset_subset="math",
         process_example_fn=process_hf_chat_messages_example,
-        split="train[:10000]",
+        split="train",
         hf_kwargs={
             "data_files": {"train": "math/math_notool.jsonl"},
         },
         seq_length=cfg.model.seq_length,
         seed=5678,
-        memmap_workers=1,
+        memmap_workers=8,
         dataloader_type="batch",
         do_validation=True,
         do_test=False,
@@ -700,7 +700,7 @@ def qwen3_600m_sft_yarn_128k_config() -> ConfigContainer:
     cfg.model.yarn_correction_range_round_to_int = False
 
     # Smaller batch size to fit long sequences.
-    cfg.train.global_batch_size = 2
+    cfg.train.global_batch_size = 8
 
     # Required for CP > 1 in long-context SFT.
     cfg.model.cross_entropy_loss_fusion = False
@@ -713,6 +713,9 @@ def qwen3_600m_sft_yarn_128k_config() -> ConfigContainer:
     cfg.optimizer.use_distributed_optimizer = False
     cfg.scheduler.lr_warmup_iters = 10
     cfg.scheduler.lr_warmup_init = 1.0e-11
+
+    # Timeout for distributed training to avoid timeout errors in dataset loading.
+    cfg.dist.distributed_timeout_minutes = 30
 
     return cfg
 


### PR DESCRIPTION
# What does this PR do ?

Adds a new SFT training recipe for Qwen3-0.6B at 128K context length using YaRN RoPE scaling, together with a reference launch script.

YaRN scaling extends Qwen3-0.6B's native 40K context window to 128K:
  - yarn_rotary_scaling_factor = 128K / 40K = 3.2
  - yarn_beta_fast = 32.0, yarn_beta_slow = 1.0

  Long-context SFT stability settings:
  - cross_entropy_loss_fusion = False
  - calculate_per_token_loss = True
  - ddp.average_in_collective = False
  - use_distributed_optimizer = False

# Dataset
Specific data file to avoid too mush time spend on data download.
nvidia/Nemotron-Cascade-2-SFT-Data
- subset: math
- split:train
- file: math/math_notool.jsonl
- first 10000 samples

## Overview of dataset
```bash
=== Sequence length stats over 10000 examples ===
  min   : 350
  max   : 140459
  mean  : 18371.6
  median: 12432.5
  p90   : 43089
  p95   : 57582
  p99   : 84679
  > 40K : 1104 (11.0%) # 40k is the original seqlen of qwen3-0.6B
  > 128K: 1 (0.0%)
```

# Result
<img width="952" height="1035" alt="image" src="https://github.com/user-attachments/assets/a4db61bd-261a-4282-9da9-864125900f13" />


# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added supervised fine-tuning support for Qwen3 600M model with 128K extended sequence length for long-context training.
  * Provided training script and optimized configuration for distributed fine-tuning workflows.
  * Configured with advanced position scaling and specialized optimizations for long-context scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->