### PR TITLE
ci: add sync-skills workflow

### DIFF
--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -24,6 +24,6 @@ on:
 
 jobs:
   sync:
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_sync_skills.yml@main
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_sync_skills.yml@v0.91.0
     secrets:
       PAT: ${{ secrets.PAT }}

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,33 +24,6 @@ on:
 
 jobs:
   sync:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.PAT }}
-          ref: ${{ github.head_ref || github.ref_name }}
-
-      - name: Symlink skills/ into agent dirs
-        run: |
-          for dir in .claude .agents; do
-            mkdir -p "$dir"
-            ln -sfn ../skills "$dir/skills"
-          done
-
-      - name: Symlink AGENTS.md → CLAUDE.md
-        run: '[ -f AGENTS.md ] && ln -sf AGENTS.md CLAUDE.md || true'
-
-      - name: Commit and push if changed
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add .claude/skills .agents/skills CLAUDE.md
-          if git diff --cached --quiet; then
-            echo "No changes to commit"
-            exit 0
-          fi
-          BRANCH="${{ github.head_ref || github.ref_name }}"
-          git commit -m "chore(beep boop 🤖): symlink skills/ → .claude/skills, .agents/skills and AGENTS.md → CLAUDE.md"
-          git push origin HEAD:"$BRANCH"
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_sync_skills.yml@main
+    secrets:
+      PAT: ${{ secrets.PAT }}


### PR DESCRIPTION
## Summary

Replaces the self-contained `sync-skills.yml` workflow with a thin `workflow_call` wrapper that delegates to the shared reusable workflow in `NVIDIA-NeMo/FW-CI-templates`.

## Background

There is no common standard for markdown file discovery across agent frameworks — each tool looks in a different place. This PR addresses that gap by coupling the generic `AGENTS.md` / `skills/` layout with a sync job that runs on push to `main`, so every agent runtime finds the files it expects without per-framework duplication. The logic is centralised in FW-CI-templates so all repos pick up improvements automatically.

## What the delegated workflow does

`NVIDIA-NeMo/FW-CI-templates/.github/workflows/_sync_skills.yml` (called via `workflow_call`):

- Checks out the repo using the provided `PAT` secret
- Symlinks `skills/` → `.claude/skills` and `.agents/skills`
- Symlinks `AGENTS.md` → `CLAUDE.md`
- Commits and pushes any resulting changes back to the branch

## Example

```yaml
jobs:
  sync:
    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_sync_skills.yml@main
    secrets:
      PAT: ${{ secrets.PAT }}
```