### PR TITLE
Update Qwen3-VL pretrain perf configs for 30B and 235B

### DIFF
--- a/scripts/performance/configs/qwen_vl/__init__.py
+++ b/scripts/performance/configs/qwen_vl/__init__.py
@@ -6,6 +6,16 @@ except ModuleNotFoundError:
     HAVE_MEGATRON_BRIDGE = False
 
 if HAVE_MEGATRON_BRIDGE:
+    from .qwen3_vl_pretrain import (
+        qwen3_vl_30b_a3b_pretrain_config_b200,
+        qwen3_vl_30b_a3b_pretrain_config_gb200,
+        qwen3_vl_30b_a3b_pretrain_config_gb300,
+        qwen3_vl_30b_a3b_pretrain_config_h100,
+        qwen3_vl_235b_a22b_pretrain_config_b200,
+        qwen3_vl_235b_a22b_pretrain_config_gb200,
+        qwen3_vl_235b_a22b_pretrain_config_gb300,
+        qwen3_vl_235b_a22b_pretrain_config_h100,
+    )
     from .qwen35_vl_pretrain import (
         qwen35_vl_35b_a3b_pretrain_config_b200,
         qwen35_vl_35b_a3b_pretrain_config_b300,
@@ -167,6 +177,15 @@ __all__ = [
 if HAVE_MEGATRON_BRIDGE:
     __all__.extend(
         [
+            # Qwen3-VL
+            "qwen3_vl_30b_a3b_pretrain_config_b200",
+            "qwen3_vl_30b_a3b_pretrain_config_gb200",
+            "qwen3_vl_30b_a3b_pretrain_config_gb300",
+            "qwen3_vl_30b_a3b_pretrain_config_h100",
+            "qwen3_vl_235b_a22b_pretrain_config_b200",
+            "qwen3_vl_235b_a22b_pretrain_config_gb200",
+            "qwen3_vl_235b_a22b_pretrain_config_gb300",
+            "qwen3_vl_235b_a22b_pretrain_config_h100",
             # Qwen3.5-VL
             "qwen35_vl_35b_a3b_pretrain_config_b200",
             "qwen35_vl_35b_a3b_pretrain_config_b300",

--- a/scripts/performance/configs/qwen_vl/qwen3_vl_pretrain.py
+++ b/scripts/performance/configs/qwen_vl/qwen3_vl_pretrain.py
@@ -100,8 +100,12 @@ def qwen3_vl_235b_a22b_pretrain_config_gb300(
 ) -> ConfigContainer:
     """GB300, baseline config."""
     return _qwen3_vl_pretrain_config(
-        "qwen3_vl_235b_a22b", "gb300", qwen3_vl_235b_a22b_pretrain_mock_config,
-        precision=precision, mock=mock, config_variant=config_variant,
+        "qwen3_vl_235b_a22b",
+        "gb300",
+        qwen3_vl_235b_a22b_pretrain_mock_config,
+        precision=precision,
+        mock=mock,
+        config_variant=config_variant,
     )
 
 
@@ -110,8 +114,12 @@ def qwen3_vl_235b_a22b_pretrain_config_gb200(
 ) -> ConfigContainer:
     """GB200, baseline config."""
     cfg = _qwen3_vl_pretrain_config(
-        "qwen3_vl_235b_a22b", "gb200", qwen3_vl_235b_a22b_pretrain_mock_config,
-        precision=precision, mock=mock, config_variant=config_variant,
+        "qwen3_vl_235b_a22b",
+        "gb200",
+        qwen3_vl_235b_a22b_pretrain_mock_config,
+        precision=precision,
+        mock=mock,
+        config_variant=config_variant,
     )
     cfg.model.cuda_graph_impl = "transformer_engine"
     cfg.model.cuda_graph_scope = ["moe_router", "moe_preprocess"]
@@ -125,8 +133,12 @@ def qwen3_vl_235b_a22b_pretrain_config_b200(
 ) -> ConfigContainer:
     """B200, baseline config."""
     cfg = _qwen3_vl_pretrain_config(
-        "qwen3_vl_235b_a22b", "b200", qwen3_vl_235b_a22b_pretrain_mock_config,
-        precision=precision, mock=mock, config_variant=config_variant,
+        "qwen3_vl_235b_a22b",
+        "b200",
+        qwen3_vl_235b_a22b_pretrain_mock_config,
+        precision=precision,
+        mock=mock,
+        config_variant=config_variant,
     )
 
     if precision == "fp8_mx":  # keeping this enabled causes NaN grad norm
@@ -142,8 +154,12 @@ def qwen3_vl_235b_a22b_pretrain_config_h100(
 ) -> ConfigContainer:
     """H100, baseline config."""
     return _qwen3_vl_pretrain_config(
-        "qwen3_vl_235b_a22b", "h100", qwen3_vl_235b_a22b_pretrain_mock_config,
-        precision=precision, mock=mock, config_variant=config_variant,
+        "qwen3_vl_235b_a22b",
+        "h100",
+        qwen3_vl_235b_a22b_pretrain_mock_config,
+        precision=precision,
+        mock=mock,
+        config_variant=config_variant,
         tp_comm_overlap=False,
     )
 
@@ -158,8 +174,12 @@ def qwen3_vl_30b_a3b_pretrain_config_gb300(
 ) -> ConfigContainer:
     """GB300, baseline config."""
     return _qwen3_vl_pretrain_config(
-        "qwen3_vl_30b_a3b", "gb300", qwen3_vl_30b_a3b_pretrain_mock_config,
-        precision=precision, mock=mock, config_variant=config_variant,
+        "qwen3_vl_30b_a3b",
+        "gb300",
+        qwen3_vl_30b_a3b_pretrain_mock_config,
+        precision=precision,
+        mock=mock,
+        config_variant=config_variant,
     )
 
 
@@ -168,8 +188,12 @@ def qwen3_vl_30b_a3b_pretrain_config_gb200(
 ) -> ConfigContainer:
     """GB200, baseline config."""
     cfg = _qwen3_vl_pretrain_config(
-        "qwen3_vl_30b_a3b", "gb200", qwen3_vl_30b_a3b_pretrain_mock_config,
-        precision=precision, mock=mock, config_variant=config_variant,
+        "qwen3_vl_30b_a3b",
+        "gb200",
+        qwen3_vl_30b_a3b_pretrain_mock_config,
+        precision=precision,
+        mock=mock,
+        config_variant=config_variant,
     )
     cfg.model.cuda_graph_impl = "transformer_engine"
     cfg.model.cuda_graph_scope = ["moe_router", "moe_preprocess"]
@@ -181,8 +205,12 @@ def qwen3_vl_30b_a3b_pretrain_config_b200(
 ) -> ConfigContainer:
     """B200, baseline config."""
     return _qwen3_vl_pretrain_config(
-        "qwen3_vl_30b_a3b", "b200", qwen3_vl_30b_a3b_pretrain_mock_config,
-        precision=precision, mock=mock, config_variant=config_variant,
+        "qwen3_vl_30b_a3b",
+        "b200",
+        qwen3_vl_30b_a3b_pretrain_mock_config,
+        precision=precision,
+        mock=mock,
+        config_variant=config_variant,
     )
 
 
@@ -191,7 +219,11 @@ def qwen3_vl_30b_a3b_pretrain_config_h100(
 ) -> ConfigContainer:
     """H100, baseline config."""
     return _qwen3_vl_pretrain_config(
-        "qwen3_vl_30b_a3b", "h100", qwen3_vl_30b_a3b_pretrain_mock_config,
-        precision=precision, mock=mock, config_variant=config_variant,
+        "qwen3_vl_30b_a3b",
+        "h100",
+        qwen3_vl_30b_a3b_pretrain_mock_config,
+        precision=precision,
+        mock=mock,
+        config_variant=config_variant,
         tp_comm_overlap=True,
     )

--- a/scripts/performance/configs/qwen_vl/qwen3_vl_pretrain.py
+++ b/scripts/performance/configs/qwen_vl/qwen3_vl_pretrain.py
@@ -16,6 +16,7 @@ import logging
 
 from utils.overrides import set_workload_base_configs
 from utils.precision import get_precision_config
+from utils.utils import get_workload_base_config
 
 from megatron.bridge.recipes.qwen_vl.qwen3_vl import (
     qwen3_vl_30b_a3b_pretrain_mock_config,
@@ -23,31 +24,6 @@ from megatron.bridge.recipes.qwen_vl.qwen3_vl import (
 )
 from megatron.bridge.training.comm_overlap import CommOverlapConfig
 from megatron.bridge.training.config import ConfigContainer
-
-from .qwen3_vl_workload_base_configs import (
-    QWEN3_VL_30B_A3B_PRETRAIN_CONFIG_B200_BF16,
-    QWEN3_VL_30B_A3B_PRETRAIN_CONFIG_B200_FP8_CS,
-    QWEN3_VL_30B_A3B_PRETRAIN_CONFIG_B200_FP8_MX,
-    QWEN3_VL_30B_A3B_PRETRAIN_CONFIG_GB200_BF16,
-    QWEN3_VL_30B_A3B_PRETRAIN_CONFIG_GB200_FP8_CS,
-    QWEN3_VL_30B_A3B_PRETRAIN_CONFIG_GB200_FP8_MX,
-    QWEN3_VL_30B_A3B_PRETRAIN_CONFIG_GB300_BF16,
-    QWEN3_VL_30B_A3B_PRETRAIN_CONFIG_GB300_FP8_CS,
-    QWEN3_VL_30B_A3B_PRETRAIN_CONFIG_GB300_FP8_MX,
-    QWEN3_VL_30B_A3B_PRETRAIN_CONFIG_H100_BF16,
-    QWEN3_VL_30B_A3B_PRETRAIN_CONFIG_H100_FP8_CS,
-    QWEN3_VL_235B_A22B_PRETRAIN_CONFIG_B200_BF16,
-    QWEN3_VL_235B_A22B_PRETRAIN_CONFIG_B200_FP8_CS,
-    QWEN3_VL_235B_A22B_PRETRAIN_CONFIG_B200_FP8_MX,
-    QWEN3_VL_235B_A22B_PRETRAIN_CONFIG_GB200_BF16,
-    QWEN3_VL_235B_A22B_PRETRAIN_CONFIG_GB200_FP8_CS,
-    QWEN3_VL_235B_A22B_PRETRAIN_CONFIG_GB200_FP8_MX,
-    QWEN3_VL_235B_A22B_PRETRAIN_CONFIG_GB300_BF16,
-    QWEN3_VL_235B_A22B_PRETRAIN_CONFIG_GB300_FP8_CS,
-    QWEN3_VL_235B_A22B_PRETRAIN_CONFIG_GB300_FP8_MX,
-    QWEN3_VL_235B_A22B_PRETRAIN_CONFIG_H100_BF16,
-    QWEN3_VL_235B_A22B_PRETRAIN_CONFIG_H100_FP8_CS,
-)
 
 
 logger = logging.getLogger(__name__)
@@ -60,6 +36,7 @@ def set_qwen3_vl_common_configs(cfg: ConfigContainer) -> None:
     cfg.model.recompute_method = None
     cfg.model.recompute_num_layers = None
     cfg.model.moe_router_fusion = True
+    cfg.model.apply_rope_fusion = False
 
     cfg.model.seq_length = 4096
     cfg.dataset.seq_length = 4096
@@ -69,6 +46,10 @@ def set_qwen3_vl_common_configs(cfg: ConfigContainer) -> None:
 
     cfg.model.moe_router_force_load_balancing = True  # required for token dropless
 
+    # CUDA graphs for moe_router and moe_preprocess only — "attn" scope is not compatible with Qwen3VLModel
+    cfg.model.cuda_graph_impl = "transformer_engine"
+    cfg.model.cuda_graph_scope = ["moe_router", "moe_preprocess"]
+
     # qwen_vl does not support overlap_grad_reduce=True and overlap_param_gather=True in current implementation
     cfg.ddp.overlap_grad_reduce = False
     cfg.ddp.overlap_param_gather = False
@@ -77,23 +58,30 @@ def set_qwen3_vl_common_configs(cfg: ConfigContainer) -> None:
     cfg.comm_overlap.overlap_grad_reduce = False
 
 
-def qwen3_vl_235b_a22b_pretrain_config_gb300(
-    precision: str = "bf16", mock: bool = True, config_variant: str = "v1"
+def _qwen3_vl_pretrain_config(
+    model_recipe_name: str,
+    gpu: str,
+    recipe_fn,
+    precision: str = "bf16",
+    mock: bool = True,
+    config_variant: str = "v1",
+    tp_comm_overlap: bool = True,
 ) -> ConfigContainer:
-    """GB300, baseline config."""
-    if precision == "bf16":
-        base_cfg = QWEN3_VL_235B_A22B_PRETRAIN_CONFIG_GB300_BF16
-        precision_config = get_precision_config(precision)
-    else:
-        base_cfg = QWEN3_VL_235B_A22B_PRETRAIN_CONFIG_GB300_FP8_CS
-        if precision == "fp8_mx":
-            base_cfg = QWEN3_VL_235B_A22B_PRETRAIN_CONFIG_GB300_FP8_MX
-        precision_config = get_precision_config(precision)
+    """Build a Qwen3-VL pretrain config for a given model size and GPU."""
+    base_cfg = get_workload_base_config(
+        model_family_name="qwen_vl",
+        model_recipe_name=model_recipe_name,
+        gpu=gpu,
+        compute_dtype=precision.upper(),
+        task="pretrain",
+        config_variant=config_variant,
+    )
+    precision_config = get_precision_config(precision)
 
-    cfg = qwen3_vl_235b_a22b_pretrain_mock_config(
+    cfg = recipe_fn(
         mock=mock,
         precision_config=precision_config,
-        comm_overlap_config=CommOverlapConfig(tp_comm_overlap=True),
+        comm_overlap_config=CommOverlapConfig(tp_comm_overlap=tp_comm_overlap),
         moe_flex_dispatcher_backend=base_cfg.moe_flex_dispatcher_backend,
     )
     set_workload_base_configs(cfg, base_cfg)
@@ -102,28 +90,33 @@ def qwen3_vl_235b_a22b_pretrain_config_gb300(
     return cfg
 
 
+# =============================================================================
+# Qwen3-VL 235B-A22B pretrain configs
+# =============================================================================
+
+
+def qwen3_vl_235b_a22b_pretrain_config_gb300(
+    precision: str = "bf16", mock: bool = True, config_variant: str = "v1"
+) -> ConfigContainer:
+    """GB300, baseline config."""
+    return _qwen3_vl_pretrain_config(
+        "qwen3_vl_235b_a22b", "gb300", qwen3_vl_235b_a22b_pretrain_mock_config,
+        precision=precision, mock=mock, config_variant=config_variant,
+    )
+
+
 def qwen3_vl_235b_a22b_pretrain_config_gb200(
     precision: str = "bf16", mock: bool = True, config_variant: str = "v1"
 ) -> ConfigContainer:
     """GB200, baseline config."""
-    if precision == "bf16":
-        base_cfg = QWEN3_VL_235B_A22B_PRETRAIN_CONFIG_GB200_BF16
-        precision_config = get_precision_config(precision)
-    else:
-        base_cfg = QWEN3_VL_235B_A22B_PRETRAIN_CONFIG_GB200_FP8_CS
-        if precision == "fp8_mx":
-            base_cfg = QWEN3_VL_235B_A22B_PRETRAIN_CONFIG_GB200_FP8_MX
-        precision_config = get_precision_config(precision)
-
-    cfg = qwen3_vl_235b_a22b_pretrain_mock_config(
-        mock=mock,
-        precision_config=precision_config,
-        comm_overlap_config=CommOverlapConfig(tp_comm_overlap=True),
-        moe_flex_dispatcher_backend=base_cfg.moe_flex_dispatcher_backend,
+    cfg = _qwen3_vl_pretrain_config(
+        "qwen3_vl_235b_a22b", "gb200", qwen3_vl_235b_a22b_pretrain_mock_config,
+        precision=precision, mock=mock, config_variant=config_variant,
     )
-    set_workload_base_configs(cfg, base_cfg)
-    set_qwen3_vl_common_configs(cfg)
-
+    cfg.model.cuda_graph_impl = "transformer_engine"
+    cfg.model.cuda_graph_scope = ["moe_router", "moe_preprocess"]
+    cfg.model.num_layers_in_first_pipeline_stage = 10
+    cfg.model.num_layers_in_last_pipeline_stage = 12
     return cfg
 
 
@@ -131,25 +124,12 @@ def qwen3_vl_235b_a22b_pretrain_config_b200(
     precision: str = "bf16", mock: bool = True, config_variant: str = "v1"
 ) -> ConfigContainer:
     """B200, baseline config."""
-    if precision == "bf16":
-        base_cfg = QWEN3_VL_235B_A22B_PRETRAIN_CONFIG_B200_BF16
-        precision_config = get_precision_config(precision)
-    else:
-        base_cfg = QWEN3_VL_235B_A22B_PRETRAIN_CONFIG_B200_FP8_CS
-        if precision == "fp8_mx":
-            base_cfg = QWEN3_VL_235B_A22B_PRETRAIN_CONFIG_B200_FP8_MX
-        precision_config = get_precision_config(precision)
-
-    cfg = qwen3_vl_235b_a22b_pretrain_mock_config(
-        mock=mock,
-        precision_config=precision_config,
-        comm_overlap_config=CommOverlapConfig(tp_comm_overlap=True),
-        moe_flex_dispatcher_backend=base_cfg.moe_flex_dispatcher_backend,
+    cfg = _qwen3_vl_pretrain_config(
+        "qwen3_vl_235b_a22b", "b200", qwen3_vl_235b_a22b_pretrain_mock_config,
+        precision=precision, mock=mock, config_variant=config_variant,
     )
-    set_workload_base_configs(cfg, base_cfg)
-    set_qwen3_vl_common_configs(cfg)
 
-    if precision == "fp8_mx":  # keeping this eanbled causes NaN grad norm
+    if precision == "fp8_mx":  # keeping this enabled causes NaN grad norm
         cfg.comm_overlap.overlap_param_gather = False
         cfg.ddp.overlap_param_gather = False
         cfg.optimizer.overlap_param_gather = False
@@ -161,72 +141,38 @@ def qwen3_vl_235b_a22b_pretrain_config_h100(
     precision: str = "bf16", mock: bool = True, config_variant: str = "v1"
 ) -> ConfigContainer:
     """H100, baseline config."""
-    if precision == "bf16":
-        base_cfg = QWEN3_VL_235B_A22B_PRETRAIN_CONFIG_H100_BF16
-        precision_config = get_precision_config(precision)
-    else:
-        base_cfg = QWEN3_VL_235B_A22B_PRETRAIN_CONFIG_H100_FP8_CS
-        precision_config = get_precision_config(precision)
-
-    cfg = qwen3_vl_235b_a22b_pretrain_mock_config(
-        mock=mock,
-        precision_config=precision_config,
-        comm_overlap_config=CommOverlapConfig(tp_comm_overlap=False),
-        moe_flex_dispatcher_backend=base_cfg.moe_flex_dispatcher_backend,
+    return _qwen3_vl_pretrain_config(
+        "qwen3_vl_235b_a22b", "h100", qwen3_vl_235b_a22b_pretrain_mock_config,
+        precision=precision, mock=mock, config_variant=config_variant,
+        tp_comm_overlap=False,
     )
-    set_workload_base_configs(cfg, base_cfg)
-    set_qwen3_vl_common_configs(cfg)
 
-    return cfg
+
+# =============================================================================
+# Qwen3-VL 30B-A3B pretrain configs
+# =============================================================================
 
 
 def qwen3_vl_30b_a3b_pretrain_config_gb300(
     precision: str = "bf16", mock: bool = True, config_variant: str = "v1"
 ) -> ConfigContainer:
     """GB300, baseline config."""
-    if precision == "bf16":
-        base_cfg = QWEN3_VL_30B_A3B_PRETRAIN_CONFIG_GB300_BF16
-        precision_config = get_precision_config(precision)
-    else:
-        base_cfg = QWEN3_VL_30B_A3B_PRETRAIN_CONFIG_GB300_FP8_CS
-        if precision == "fp8_mx":
-            base_cfg = QWEN3_VL_30B_A3B_PRETRAIN_CONFIG_GB300_FP8_MX
-        precision_config = get_precision_config(precision)
-
-    cfg = qwen3_vl_30b_a3b_pretrain_mock_config(
-        mock=mock,
-        precision_config=precision_config,
-        comm_overlap_config=CommOverlapConfig(tp_comm_overlap=True),
-        moe_flex_dispatcher_backend=base_cfg.moe_flex_dispatcher_backend,
+    return _qwen3_vl_pretrain_config(
+        "qwen3_vl_30b_a3b", "gb300", qwen3_vl_30b_a3b_pretrain_mock_config,
+        precision=precision, mock=mock, config_variant=config_variant,
     )
-    set_workload_base_configs(cfg, base_cfg)
-    set_qwen3_vl_common_configs(cfg)
-
-    return cfg
 
 
 def qwen3_vl_30b_a3b_pretrain_config_gb200(
     precision: str = "bf16", mock: bool = True, config_variant: str = "v1"
 ) -> ConfigContainer:
     """GB200, baseline config."""
-    if precision == "bf16":
-        base_cfg = QWEN3_VL_30B_A3B_PRETRAIN_CONFIG_GB200_BF16
-        precision_config = get_precision_config(precision)
-    else:
-        base_cfg = QWEN3_VL_30B_A3B_PRETRAIN_CONFIG_GB200_FP8_CS
-        if precision == "fp8_mx":
-            base_cfg = QWEN3_VL_30B_A3B_PRETRAIN_CONFIG_GB200_FP8_MX
-        precision_config = get_precision_config(precision)
-
-    cfg = qwen3_vl_30b_a3b_pretrain_mock_config(
-        mock=mock,
-        precision_config=precision_config,
-        comm_overlap_config=CommOverlapConfig(tp_comm_overlap=True),
-        moe_flex_dispatcher_backend=base_cfg.moe_flex_dispatcher_backend,
+    cfg = _qwen3_vl_pretrain_config(
+        "qwen3_vl_30b_a3b", "gb200", qwen3_vl_30b_a3b_pretrain_mock_config,
+        precision=precision, mock=mock, config_variant=config_variant,
     )
-    set_workload_base_configs(cfg, base_cfg)
-    set_qwen3_vl_common_configs(cfg)
-
+    cfg.model.cuda_graph_impl = "transformer_engine"
+    cfg.model.cuda_graph_scope = ["moe_router", "moe_preprocess"]
     return cfg
 
 
@@ -234,45 +180,18 @@ def qwen3_vl_30b_a3b_pretrain_config_b200(
     precision: str = "bf16", mock: bool = True, config_variant: str = "v1"
 ) -> ConfigContainer:
     """B200, baseline config."""
-    if precision == "bf16":
-        base_cfg = QWEN3_VL_30B_A3B_PRETRAIN_CONFIG_B200_BF16
-        precision_config = get_precision_config(precision)
-    else:
-        base_cfg = QWEN3_VL_30B_A3B_PRETRAIN_CONFIG_B200_FP8_CS
-        if precision == "fp8_mx":
-            base_cfg = QWEN3_VL_30B_A3B_PRETRAIN_CONFIG_B200_FP8_MX
-        precision_config = get_precision_config(precision)
-
-    cfg = qwen3_vl_30b_a3b_pretrain_mock_config(
-        mock=mock,
-        precision_config=precision_config,
-        comm_overlap_config=CommOverlapConfig(tp_comm_overlap=True),
-        moe_flex_dispatcher_backend=base_cfg.moe_flex_dispatcher_backend,
+    return _qwen3_vl_pretrain_config(
+        "qwen3_vl_30b_a3b", "b200", qwen3_vl_30b_a3b_pretrain_mock_config,
+        precision=precision, mock=mock, config_variant=config_variant,
     )
-    set_workload_base_configs(cfg, base_cfg)
-    set_qwen3_vl_common_configs(cfg)
-
-    return cfg
 
 
 def qwen3_vl_30b_a3b_pretrain_config_h100(
     precision: str = "bf16", mock: bool = True, config_variant: str = "v1"
 ) -> ConfigContainer:
     """H100, baseline config."""
-    if precision == "bf16":
-        base_cfg = QWEN3_VL_30B_A3B_PRETRAIN_CONFIG_H100_BF16
-        precision_config = get_precision_config(precision)
-    else:
-        base_cfg = QWEN3_VL_30B_A3B_PRETRAIN_CONFIG_H100_FP8_CS
-        precision_config = get_precision_config(precision)
-
-    cfg = qwen3_vl_30b_a3b_pretrain_mock_config(
-        mock=mock,
-        precision_config=precision_config,
-        comm_overlap_config=CommOverlapConfig(tp_comm_overlap=True),
-        moe_flex_dispatcher_backend=base_cfg.moe_flex_dispatcher_backend,
+    return _qwen3_vl_pretrain_config(
+        "qwen3_vl_30b_a3b", "h100", qwen3_vl_30b_a3b_pretrain_mock_config,
+        precision=precision, mock=mock, config_variant=config_variant,
+        tp_comm_overlap=True,
     )
-    set_workload_base_configs(cfg, base_cfg)
-    set_qwen3_vl_common_configs(cfg)
-
-    return cfg

--- a/scripts/performance/configs/qwen_vl/qwen3_vl_pretrain.py
+++ b/scripts/performance/configs/qwen_vl/qwen3_vl_pretrain.py
@@ -121,8 +121,6 @@ def qwen3_vl_235b_a22b_pretrain_config_gb200(
         mock=mock,
         config_variant=config_variant,
     )
-    cfg.model.cuda_graph_impl = "transformer_engine"
-    cfg.model.cuda_graph_scope = ["moe_router", "moe_preprocess"]
     cfg.model.num_layers_in_first_pipeline_stage = 10
     cfg.model.num_layers_in_last_pipeline_stage = 12
     return cfg
@@ -187,7 +185,7 @@ def qwen3_vl_30b_a3b_pretrain_config_gb200(
     precision: str = "bf16", mock: bool = True, config_variant: str = "v1"
 ) -> ConfigContainer:
     """GB200, baseline config."""
-    cfg = _qwen3_vl_pretrain_config(
+    return _qwen3_vl_pretrain_config(
         "qwen3_vl_30b_a3b",
         "gb200",
         qwen3_vl_30b_a3b_pretrain_mock_config,
@@ -195,9 +193,6 @@ def qwen3_vl_30b_a3b_pretrain_config_gb200(
         mock=mock,
         config_variant=config_variant,
     )
-    cfg.model.cuda_graph_impl = "transformer_engine"
-    cfg.model.cuda_graph_scope = ["moe_router", "moe_preprocess"]
-    return cfg
 
 
 def qwen3_vl_30b_a3b_pretrain_config_b200(

--- a/scripts/performance/configs/qwen_vl/qwen3_vl_workload_base_configs.py
+++ b/scripts/performance/configs/qwen_vl/qwen3_vl_workload_base_configs.py
@@ -71,22 +71,24 @@ QWEN3_VL_235B_A22B_PRETRAIN_CONFIG_GB300_FP8_MX = QWEN3_VL_235B_A22B_PRETRAIN_CO
 QWEN3_VL_235B_A22B_PRETRAIN_CONFIG_GB200_BF16 = replace(
     BASE_QWEN3_VL_235B_A22B_CONFIG,
     num_gpus=64,
+    micro_batch_size=2,
     pipeline_model_parallel_size=8,
     expert_model_parallel_size=8,
     moe_flex_dispatcher_backend="hybridep",
     cuda_graph_impl="transformer_engine",
-    cuda_graph_scope=["attn", "moe_router", "moe_preprocess"],
+    cuda_graph_scope=["moe_router", "moe_preprocess"],
 )
 
 
 QWEN3_VL_235B_A22B_PRETRAIN_CONFIG_GB200_FP8_CS = replace(
     BASE_QWEN3_VL_235B_A22B_CONFIG,
     num_gpus=64,
+    micro_batch_size=2,
     pipeline_model_parallel_size=8,
     expert_model_parallel_size=8,
     moe_flex_dispatcher_backend="hybridep",
     cuda_graph_impl="transformer_engine",
-    cuda_graph_scope=["attn", "moe_router", "moe_preprocess"],
+    cuda_graph_scope=["moe_router", "moe_preprocess"],
 )
 
 

--- a/scripts/performance/configs/qwen_vl/qwen3_vl_workload_base_configs.py
+++ b/scripts/performance/configs/qwen_vl/qwen3_vl_workload_base_configs.py
@@ -172,7 +172,7 @@ QWEN3_VL_30B_A3B_PRETRAIN_CONFIG_GB200_BF16 = replace(
     micro_batch_size=4,
     moe_flex_dispatcher_backend="hybridep",
     cuda_graph_impl="transformer_engine",
-    cuda_graph_scope=["attn", "moe_router", "moe_preprocess"],
+    cuda_graph_scope=["moe_router", "moe_preprocess"],
 )
 
 
@@ -182,7 +182,7 @@ QWEN3_VL_30B_A3B_PRETRAIN_CONFIG_GB200_FP8_CS = replace(
     micro_batch_size=4,
     moe_flex_dispatcher_backend="hybridep",
     cuda_graph_impl="transformer_engine",
-    cuda_graph_scope=["attn", "moe_router", "moe_preprocess"],
+    cuda_graph_scope=["moe_router", "moe_preprocess"],
 )
 
 

--- a/src/megatron/bridge/recipes/qwen_vl/qwen3_vl.py
+++ b/src/megatron/bridge/recipes/qwen_vl/qwen3_vl.py
@@ -251,7 +251,7 @@ def qwen3_vl_235b_a22b_pretrain_mock_config(**user_kwargs: Unpack[Qwen3VLCommonK
     See `_qwen3_vl_common` for the full list of parameters.
     """
     recommended_kwargs: Qwen3VLCommonKwargs = {
-        "hf_path": "Qwen/Qwen3-VL-235B-A22B",
+        "hf_path": "Qwen/Qwen3-VL-235B-A22B-Instruct",
         "tensor_model_parallel_size": 4,
         "pipeline_model_parallel_size": 16,
         "expert_model_parallel_size": 8,
@@ -573,7 +573,7 @@ def qwen3_vl_235b_a22b_sft_config() -> ConfigContainer:
     cfg = _sft_common_vlm()
 
     # Model configuration
-    hf_path = "Qwen/Qwen3-VL-235B-A22B"
+    hf_path = "Qwen/Qwen3-VL-235B-A22B-Instruct"
     cfg.model = AutoBridge.from_hf_pretrained(hf_path).to_megatron_provider(load_weights=False)
     cfg.model.seq_length = 4096
 
@@ -1007,7 +1007,7 @@ def qwen3_vl_235b_a22b_peft_config(peft_scheme: str | PEFT = "lora") -> ConfigCo
         cfg.peft = peft_scheme
 
     # Model configuration
-    hf_path = "Qwen/Qwen3-VL-235B-A22B"
+    hf_path = "Qwen/Qwen3-VL-235B-A22B-Instruct"
     cfg.model = AutoBridge.from_hf_pretrained(hf_path).to_megatron_provider(load_weights=False)
     cfg.model.seq_length = 4096
 


### PR DESCRIPTION
# What does this PR do ?

  - Add performance-optimized pretraining configs for Qwen3-VL 30B-A3B and 235B-A22B across GB300, GB200, B200, and H100 GPUs                               
  - Refactor `qwen3_vl_pretrain.py` to use `get_workload_base_config()` pattern (consistent with `qwen35_vl_pretrain.py`)                                   
  - Fix 235B HF path (`Qwen/Qwen3-VL-235B-A22B` → `Qwen/Qwen3-VL-235B-A22B-Instruct`)                                                                       
  - Disable `"attn"` CUDA graph scope for Qwen3VLModel (causes `position_embedding_type` AttributeError) — keep `moe_router` + `moe_preprocess` only        
  - GB200 235B: set MBS=2 and uneven PP split (10/12) for best throughput                                                                                   
  - Set common VLM-specific configs: `apply_rope_fusion=False`, `moe_router_force_load_balancing=True`, disable `overlap_grad/param_gather`  

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added pretraining configurations for Qwen3.5-VL models (35B, 122B, and 397B variants) across multiple GPU types with BF16 and FP8 precision support.

* **Improvements**
  * Updated Qwen3-VL recipes to use the Instruct variant checkpoint for better instruction-following capabilities.
  * Enhanced mock data generation for vision language model datasets with improved variability.
  * Improved parallel group size handling for encoder-parallel configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->