### PR TITLE
[model] fix: improve apply_rope_fusion assert message for Qwen3-VL

### DIFF
--- a/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/rope.py
+++ b/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/rope.py
@@ -315,7 +315,23 @@ def apply_rotary_pos_emb_absolute(
 
     In Qwen3-VL, the shape of freqs is (seq_length, bs, 1, 2 * dim) instead of [max_seqlen, 1, 1, 2 * dim]
     """
-    assert not config.apply_rope_fusion
+    # Fused RoPE (TE kernels) is not supported for Qwen3-VL / Qwen3.5-VL because:
+    # 1. This function uses per-token absolute freqs with shape (seq_len, bs, 1, 2*dim),
+    #    which differs from the standard mcore format (max_seqlen, 1, 1, 2*dim).
+    #    TE's fused_apply_rotary_pos_emb / fused_apply_rotary_pos_emb_thd expect the
+    #    standard format and would produce incorrect results with absolute freqs.
+    # 2. Qwen3VLSelfAttention calls this function directly, bypassing the mcore
+    #    apply_rotary_pos_emb() dispatcher that routes to fused kernels.
+    # 3. validate_rope_fusion_compatibility() already blocks fusion for mrope models
+    #    (position_embedding_type='mrope'), so provide() resets the flag to False.
+    #    This assert is a safety net in case the flag is forced on after provide().
+    assert not config.apply_rope_fusion, (
+        "apply_rope_fusion is not supported for Qwen3-VL / Qwen3.5-VL models. "
+        "This code path uses per-token absolute positional frequencies that are incompatible "
+        "with TE's fused RoPE kernels. Setting apply_rope_fusion=True would not actually "
+        "enable fusion (Qwen3VLSelfAttention bypasses the fused dispatch), but the flag "
+        "must remain False to avoid misleading configuration state."
+    )
     orig_t_dtype = t.dtype
     if config.apply_rotary_pos_emb_in_fp32:
         t = t.float()


### PR DESCRIPTION
## Summary
- Replaces bare `assert not config.apply_rope_fusion` in `rope.py` with a descriptive assertion message and detailed comments explaining why fused RoPE is unsupported for Qwen3-VL / Qwen3.5-VL
- Verified on cluster that even removing the assert and forcing `apply_rope_fusion=True` never actually enables TE fused kernels due to three upstream guards:
  1. `validate_rope_fusion_compatibility()` blocks `position_embedding_type="mrope"`
  2. `Qwen3VLSelfAttention` calls `apply_rotary_pos_emb_absolute()` directly (bypasses fused dispatch)
  3. Per-token absolute freq format `(seq_len, bs, 1, 2*dim)` is incompatible with TE's expected `(max_seqlen, 1, 1, 2*dim)`

Closes #3296

## Test plan
- [ ] Existing unit tests pass (`tests/unit_tests/models/qwen_vl/`)
- [ ] No functional change — assert behavior is identical, only the error message improves

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced configuration validation error messages to help users better understand which settings are incompatible and why.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->