### PR TITLE
fix(perf): read baseline values from golden values when using new format

### DIFF
--- a/scripts/performance/utils/evaluate.py
+++ b/scripts/performance/utils/evaluate.py
@@ -616,6 +616,10 @@ def calc_convergence_and_performance(
     with open(expected_golden_values_path, "r") as f:
         expected_golden_values = json.load(f)
 
+    # Normalize: new format stores baseline data under a "baseline" key.
+    if "baseline" in expected_golden_values:
+        expected_golden_values = expected_golden_values["baseline"]
+
     steps = []
     golden_train_loss = {}
     golden_iter_time = {}


### PR DESCRIPTION
## Summary

- Golden values files are transitioning from a flat structure (step keys at root) to an explicit `{"baseline": {...}, "current": {...}}` format
- `evaluate.py` now normalizes on load: if a `"baseline"` key is present, it extracts that sub-dict before iterating
- Fully backward-compatible: files still in the old flat format are unaffected

## Example

**New format (nemo-ci side):**
```json
{
  "baseline": {
    "0": {"lm loss": 11.9, "elapsed time per iteration (ms)": 24500.0},
    "alloc": 61.6,
    "max_alloc": 82.3
  },
  "current": { ... }
}
```

**Old format (unchanged behaviour):**
```json
{
  "0": {"lm loss": 11.9, "elapsed time per iteration (ms)": 24500.0},
  "alloc": 61.6,
  "max_alloc": 82.3
}
```

## Test plan
- [ ] Verify `calc_convergence_and_performance` runs correctly with a golden values file in the new `baseline`/`current` format
- [ ] Verify it still works with an old flat-format golden values file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed performance metric evaluation to properly normalize and extract baseline metrics from updated data structures
  * Ensures accurate convergence and performance validation with improved handling of baseline metric data formats

<!-- end of auto-generated comment: release notes by coderabbit.ai -->