### PR TITLE
[skills] chore: Document recursive skill discovery for perf-techniques

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,11 @@ The `skills/` directory contains structured guides for common tasks (adding
 models, running experiments, debugging multi-node jobs, performance tuning,
 etc.). Read the relevant `SKILL.md` before starting a task it covers.
 
+Skills are discovered **recursively** — any directory under `skills/` (at any
+depth) that contains a `SKILL.md` with valid `name` and `description`
+frontmatter is a registered skill. This includes nested directories such as
+`skills/perf-techniques/*/`.
+
 ## Boundaries
 
 **NEVER:**


### PR DESCRIPTION
## Summary
- Update AGENTS.md to document that skills are discovered recursively under `skills/`, not just as direct children
- This registers the 8 `skills/perf-techniques/` skills (cuda-graphs, expert-parallel-overlap, hybrid-context-parallel, megatron-fsdp, moe-comm-overlap, parallelism-strategies, sequence-packing, tp-dp-comm-overlap) as invocable slash commands

## Test plan
- [ ] Verify perf-techniques skills appear as available slash commands in a new Claude Code session
- [ ] Verify existing top-level skills still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Skills can now be organized in nested directories at any depth and will be automatically discovered when properly configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->