### PR TITLE
[skills] chore: extend developer-guide skill description with lockfile guidance

### DIFF
--- a/skills/developer-guide/SKILL.md
+++ b/skills/developer-guide/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: developer-guide
-description: Developer environment setup, CI/CD workflows, and CI failure debugging for Megatron Bridge. Covers container-based development, uv package management, pre-commit hooks, running tests, CI failure investigation, and common pitfalls. Use when onboarding, setting up a dev environment, troubleshooting build issues, or investigating CI failures.
+description: Developer environment setup, CI/CD workflows, and CI failure debugging for Megatron Bridge. Covers container-based development, uv package management, pre-commit hooks, running tests, CI failure investigation, and common pitfalls. Use when onboarding, setting up a dev environment, troubleshooting build issues, investigating CI failures, or dealing with lockfile issues (corrupted, regenerating, or updating uv.lock).
 ---
 
 # Developer Guide


### PR DESCRIPTION
## Summary

- Extends the `developer-guide` skill description to explicitly mention lockfile scenarios (corrupted, regenerating, updating `uv.lock`) so the skill is triggered in those contexts.

## Changes

The skill `description` field in `skills/developer-guide/SKILL.md` now includes:

> …or dealing with lockfile issues (corrupted, regenerating, or updating uv.lock).

This ensures Claude Code selects this skill when users ask about lockfile problems, not just general dev-env or CI failure questions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated developer guide documentation to include expanded coverage of lockfile-related issues and troubleshooting guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->