### PR TITLE
build: bump TransformerEngine to release_v2.14

### DIFF
--- a/.github/actions/test-template/action.yml
+++ b/.github/actions/test-template/action.yml
@@ -96,8 +96,11 @@ runs:
       shell: bash -x -e -u -o pipefail {0}
       if: ${{ contains(inputs.runner, 'aws') }}
       run: |
-        apt-get update
-        apt-get install -y uuid-runtime
+        for i in 1 2 3; do
+          apt-get update && apt-get install -y uuid-runtime && break
+          echo "Attempt $i failed, retrying in 10s..."
+          sleep 10
+        done
 
     - name: Start container
       shell: bash

--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -360,8 +360,11 @@ jobs:
       - name: Install GH CLI
         shell: bash
         run: |
-          apt-get update
-          apt-get install -y gh
+          for i in 1 2 3; do
+            apt-get update && apt-get install -y gh && break
+            echo "Attempt $i failed, retrying in 10s..."
+            sleep 10
+          done
 
       - name: Get last merged PR
         id: cache_from

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,7 @@ override-dependencies = [
     "torch; sys_platform == 'never'",
     "torchvision; sys_platform == 'never'",
     "triton; sys_platform == 'never'",
-    "transformer-engine @ git+https://github.com/NVIDIA/TransformerEngine.git@71bbefbf153418f943640df0f7373625dc93fa46",
+    "transformer-engine @ git+https://github.com/NVIDIA/TransformerEngine.git@f031cf87bd054c7558b887df7bed93975456667f",
     "mlflow>=3.9.0",    # To address CVE-2025-15031
     "cachetools>=5.0.0",
     "cryptography>=43.0.0,<47",

--- a/uv.lock
+++ b/uv.lock
@@ -20,7 +20,7 @@ overrides = [
     { name = "onnx", marker = "python_full_version < '3.13'", specifier = ">=1.21.0" },
     { name = "torch", marker = "sys_platform == 'never'" },
     { name = "torchvision", marker = "sys_platform == 'never'" },
-    { name = "transformer-engine", git = "https://github.com/NVIDIA/TransformerEngine.git?rev=71bbefbf153418f943640df0f7373625dc93fa46" },
+    { name = "transformer-engine", git = "https://github.com/NVIDIA/TransformerEngine.git?rev=f031cf87bd054c7558b887df7bed93975456667f" },
     { name = "triton", marker = "sys_platform == 'never'" },
     { name = "urllib3", specifier = ">=2.6.3" },
 ]
@@ -4879,8 +4879,8 @@ wheels = [
 
 [[package]]
 name = "transformer-engine"
-version = "2.14.0+71bbefbf"
-source = { git = "https://github.com/NVIDIA/TransformerEngine.git?rev=71bbefbf153418f943640df0f7373625dc93fa46#71bbefbf153418f943640df0f7373625dc93fa46" }
+version = "2.14.0+f031cf87"
+source = { git = "https://github.com/NVIDIA/TransformerEngine.git?rev=f031cf87bd054c7558b887df7bed93975456667f#f031cf87bd054c7558b887df7bed93975456667f" }
 dependencies = [
     { name = "einops" },
     { name = "importlib-metadata" },


### PR DESCRIPTION
## Summary

Bumps the pinned TransformerEngine commit from \`71bbefbf\` to \`f031cf87\` — the HEAD of the [\`release_v2.14\`](https://github.com/NVIDIA/TransformerEngine/tree/release_v2.14) branch.

- \`pyproject.toml\`: updated \`override-dependencies\` URL
- \`uv.lock\`: regenerated inside the \`megatron-bridge:latest\` container

Additionally hardens CI against transient Ubuntu mirror sync failures by wrapping all \`apt-get\` install steps in a 3-attempt retry loop:

- \`.github/workflows/cicd-main.yml\` — Install GH CLI
- \`.github/actions/test-template/action.yml\` — Install uuidgen
- \`.github/workflows/install-test.yml\` — Install git

## Example diff

\`\`\`toml
# pyproject.toml (override-dependencies)
-\"transformer-engine @ git+https://github.com/NVIDIA/TransformerEngine.git@71bbefbf153418f943640df0f7373625dc93fa46\",
+\"transformer-engine @ git+https://github.com/NVIDIA/TransformerEngine.git@f031cf87bd054c7558b887df7bed93975456667f\",
\`\`\`