### PR TITLE
cp: `Update release workflow to use v0.92.0` into `r0.4.0`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,7 +67,7 @@ jobs:
       NVIDIA_MANAGEMENT_ORG_PAT: ${{ secrets.NVIDIA_MANAGEMENT_ORG_PAT }}
 
   release:
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@v0.77.0
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@v0.92.0
     needs: [pre-flight]
     with:
       release-ref: ${{ inputs.release-ref || github.sha }}
@@ -89,6 +89,7 @@ jobs:
       submodules: recursive
       container-options: "--gpus all --runtime=nvidia"
       gh-release-from-tag: ${{ inputs.gh-release-from-tag }}
+      extra-no-build-isolation-packages: "grpcio-tools"
     secrets:
       TWINE_USERNAME: __token__
       TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}


### PR DESCRIPTION
## Summary

Cherry-pick of 88714c969cf96ac6348fe739473d61c8db515b2f into `r0.4.0`.

Updates the release workflow to use `v0.92.0`.

## Original PR

- Original commit: 88714c969cf96ac6348fe739473d61c8db515b2f