### PR TITLE
[training] feat: enable fp4_param_gather in MixedPrecisionConfig

### DIFF
--- a/scripts/performance/configs/nemotronh/nemotron_3_llm_pretrain.py
+++ b/scripts/performance/configs/nemotronh/nemotron_3_llm_pretrain.py
@@ -23,6 +23,7 @@ from utils.utils import get_workload_base_config
 from megatron.bridge.recipes.nemotronh.nemotron_3_nano import nemotron_3_nano_pretrain_config
 from megatron.bridge.recipes.nemotronh.nemotron_3_super import nemotron_3_super_pretrain_config
 from megatron.bridge.training.config import ConfigContainer
+from megatron.bridge.training.mixed_precision import nemotron_3_super_bf16_with_nvfp4_mixed
 
 
 logger = logging.getLogger(__name__)
@@ -38,17 +39,18 @@ def set_nemotron_3_nano_common_configs(cfg: ConfigContainer) -> None:
 
 def set_nemotron_3_super_common_configs(cfg: ConfigContainer, precision: str) -> None:
     """Common Nemotron 3 Super pretrain perf settings; restores model recipe fields for ``precision``."""
+    if precision.lower() == "nvfp4":
+        cfg.mixed_precision = nemotron_3_super_bf16_with_nvfp4_mixed()
+        # Disabled until MCore PR 4358 lands.
+        cfg.mixed_precision.fp4_param_gather = False
+        cfg.model.quant_recipe = load_quantization_recipe(os.path.join(os.path.dirname(__file__), "te_quant.cfg"))
+
     cfg.mixed_precision.grad_reduce_in_fp32 = False
     cfg.ddp.grad_reduce_in_fp32 = False
 
     cfg.model.moe_router_force_load_balancing = True
 
     cfg.checkpoint.async_save = False
-
-    if precision.lower() == "nvfp4":
-        cfg.mixed_precision.first_last_layers_bf16 = True
-        cfg.mixed_precision.num_layers_at_end_in_bf16 = 14
-        cfg.model.quant_recipe = load_quantization_recipe(os.path.join(os.path.dirname(__file__), "te_quant.cfg"))
 
     if precision.lower() in ("nvfp4", "fp8_mx"):
         cfg.model.moe_router_padding_for_quantization = True

--- a/src/megatron/bridge/training/mixed_precision.py
+++ b/src/megatron/bridge/training/mixed_precision.py
@@ -62,6 +62,8 @@ class MixedPrecisionConfig:
     # fp4 related
     fp4: Optional[str] = None
     fp4_recipe: str = "nvfp4"
+    fp4_param: Optional[bool] = None
+    fp4_param_gather: bool = False
     # FP16 Loss scaling
     loss_scale: Optional[float] = None
     initial_loss_scale: Optional[float] = 4294967296  # 2**32
@@ -84,10 +86,22 @@ class MixedPrecisionConfig:
             if self.fp8_param_gather != value:
                 object.__setattr__(self, "fp8_param_gather", value)
 
+        # Keep fp4_param and fp4_param_gather in sync
+        if name == "fp4_param_gather" and hasattr(self, "fp4_param"):
+            if self.fp4_param != value:
+                object.__setattr__(self, "fp4_param", value)
+        elif name == "fp4_param" and hasattr(self, "fp4_param_gather"):
+            if self.fp4_param_gather != value:
+                object.__setattr__(self, "fp4_param_gather", value)
+
     def finalize(self):
         # If fp8_param is None, initialize it from fp8_param_gather
         if self.fp8_param is None:
             self.fp8_param = self.fp8_param_gather
+
+        # If fp4_param is None, initialize it from fp4_param_gather
+        if self.fp4_param is None:
+            self.fp4_param = self.fp4_param_gather
 
         # Validate that mxfp8 recipe requires reuse_grad_buf_for_mxfp8_param_ag=True when fp8_param_gather=True
         if self.fp8_param_gather and self.fp8_recipe == "mxfp8":
@@ -405,7 +419,7 @@ def bf16_with_nvfp4_mixed() -> MixedPrecisionConfig:
     cfg.fp4 = "e2m1"
     cfg.fp4_recipe = "nvfp4"
     cfg.fp8_param_gather = False
-    cfg.fp8_recipe = None
+    cfg.fp4_param_gather = True
     return cfg
 
 

--- a/tests/functional_tests/test_groups/recipes/test_perf_config_integration.py
+++ b/tests/functional_tests/test_groups/recipes/test_perf_config_integration.py
@@ -113,6 +113,28 @@ class TestPerfConfigIntegration:
         assert cfg.model is not None
         assert cfg.mixed_precision is not None
 
+    def test_nemotron_3_super_perf_config_instantiation(self):
+        """Test that Nemotron 3 Super perf configs can be instantiated correctly."""
+        from configs.nemotronh.nemotron_3_llm_pretrain import nemotron_3_super_pretrain_config_gb300
+
+        cfg = nemotron_3_super_pretrain_config_gb300(precision="bf16", mock=True)
+
+        assert cfg is not None
+        assert cfg.model is not None
+        assert cfg.mixed_precision is not None
+
+    def test_nemotron_3_super_perf_config_nvfp4(self):
+        """Test that Nemotron 3 Super NVFP4 perf config uses the NT3-Super-specific recipe."""
+        from configs.nemotronh.nemotron_3_llm_pretrain import nemotron_3_super_pretrain_config_gb300
+
+        cfg = nemotron_3_super_pretrain_config_gb300(precision="nvfp4", mock=True)
+
+        assert cfg is not None
+        assert cfg.model is not None
+        assert cfg.mixed_precision is not None
+        assert cfg.mixed_precision.first_last_layers_bf16 is True
+        assert cfg.mixed_precision.num_layers_at_end_in_bf16 == 14
+
     def test_gpt_oss_120b_perf_config_instantiation(self):
         """Test that GPT-OSS 120B perf configs can be instantiated correctly."""
         from configs.gpt_oss.gpt_oss_llm_pretrain import gpt_oss_120b_pretrain_config_h100


### PR DESCRIPTION
## Summary
- Add \`fp4_param\` and \`fp4_param_gather\` fields to \`MixedPrecisionConfig\`, mirroring the existing \`fp8_param\` / \`fp8_param_gather\` pair (sync in \`__setattr__\`, default in \`finalize\`).
- Enable \`fp4_param_gather=True\` by default in \`bf16_with_nvfp4_mixed()\` so NVFP4 runs pick up the new packed-uint8 parameter all-gather path introduced by MCore [PR #4005](https://github.com/NVIDIA/Megatron-LM/pull/4005).

## Context
MCore's \`fp4_param_gather\` packs NVFP4 model weights as uint8 (2 values per byte) in the DDP param buffer and all-gathers them in that packed form; the grad buffer stays full-width BF16. Both \`DistributedDataParallelConfig.fp4_param_gather\` and \`TransformerConfig.fp4_param\` must be set for the feature to apply end-to-end, which is why we add both Bridge fields and keep them synced (same pattern MCore itself uses at \`megatron/training/arguments.py:1732\`).

## Validation
Measured on DeepSeek-V3 256×GB300 pretrain (NVFP4 V2 config, GBS=4096, PP=2/VPP=8/EP=32, \`recompute_modules=[\"mla_up_proj\"]\`):

| Metric (Rank 0 / PP stage 0) | Baseline (no fp4pg) | This PR (fp4pg on) | Δ |
|---|---:|---:|---:|
| \`mem-max-allocated\` (iter 2) | 235.15 GB | 202.75 GB | **−32.40 GB** |
| \`mem-max-reserved\` (iter 2) | 249.25 GB | 214.40 GB | **−34.85 GB** |

Loss trajectory over iters 3–6 tracks the baseline within ≤0.2 nat (within noise). No per-iter throughput regression observed on this workload; the win is memory headroom, which unlocks dropping recompute in subsequent tuning.

## Test plan
- [x] Existing \`bf16_with_nvfp4_mixed\` recipe consumers pick up \`fp4_param_gather=True\` automatically and propagate via \`update_config_with_precision_overrides\` to both \`DistributedDataParallelConfig.fp4_param_gather\` and \`TransformerConfig.fp4_param\` (verified in training log).
- [x] DeepSeek-V3 256×GB300 pretrain run completes iter 1+ without crash, loss trajectory matches prior NVFP4 run, memory drops as shown above.
- [ ] Add a unit test covering the new sync/finalize logic for the \`fp4_param\` / \`fp4_param_gather\` pair.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added FP4 mixed precision configuration options to control parameter gathering behavior during training.

* **Updates**
  * Modified the default FP4 recipe configuration to enable parameter gathering for optimized training behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->