### PR TITLE
[docs] chore: bump versions1.json to 0.4.0 (latest)

### DIFF
--- a/docs/versions1.json
+++ b/docs/versions1.json
@@ -4,14 +4,15 @@
     "url": "https://docs.nvidia.com/nemo/megatron-bridge/nightly/"
   },
   {
+    "name": "0.4.0 (latest)",
     "version": "0.4.0",
-    "url": "https://docs.nvidia.com/nemo/megatron-bridge/0.4.0/"
-  },
-  {
-    "name": "0.3.1 (latest)",
-    "version": "0.3.1",
     "url": "https://docs.nvidia.com/nemo/megatron-bridge/latest/",
     "preferred": true
+  },
+  {
+    "name": "0.3.1",
+    "version": "0.3.1",
+    "url": "https://docs.nvidia.com/nemo/megatron-bridge/0.3.1/"
   },
   {
     "name": "0.3.0",


### PR DESCRIPTION
## Summary

- `versions1.json`: promotes `0.4.0` to `(latest)` pointing to `latest/`, demotes `0.3.1` to versioned URL

## Before / After

**Before:**
```json
{ "version": "0.4.0", "url": ".../0.4.0/" },
{ "name": "0.3.1 (latest)", "version": "0.3.1", "url": ".../latest/", "preferred": true }
```

**After:**
```json
{ "name": "0.4.0 (latest)", "version": "0.4.0", "url": ".../latest/", "preferred": true },
{ "name": "0.3.1", "version": "0.3.1", "url": ".../0.3.1/" }
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the default documentation version to 0.4.0 (latest).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->