### PR TITLE
[vulnops] fix: _contains_code_references allowlist bypass leads to RCE

### DIFF
--- a/src/megatron/bridge/models/config.py
+++ b/src/megatron/bridge/models/config.py
@@ -309,6 +309,29 @@ def _convert_value_to_dict(value: Any) -> Any:
         return value
 
 
+# Exact set of _target_ values considered safe (no code execution risk).
+# Using an exact-match allowlist prevents bypass via dangerous callables
+# in allowed modules (e.g. builtins.exec, builtins.eval, builtins.__import__).
+_SAFE_TARGETS = frozenset(
+    {
+        "str",
+        "int",
+        "float",
+        "bool",
+        "list",
+        "dict",
+        "tuple",
+        "builtins.str",
+        "builtins.int",
+        "builtins.float",
+        "builtins.bool",
+        "builtins.list",
+        "builtins.dict",
+        "builtins.tuple",
+    }
+)
+
+
 def _contains_code_references(config_dict: Dict[str, Any]) -> bool:
     """
     Check if a configuration dictionary contains code references.
@@ -321,10 +344,9 @@ def _contains_code_references(config_dict: Dict[str, Any]) -> bool:
     """
     if isinstance(config_dict, dict):
         for key, value in config_dict.items():
-            # Check for _target_ that's not a built-in type
+            # Check for _target_ that's not a safe built-in type
             if key == "_target_" and isinstance(value, str):
-                # Consider it a code reference if it's not a basic type
-                if not value.startswith(("builtins.", "str", "int", "float", "bool", "list", "dict", "tuple")):
+                if value not in _SAFE_TARGETS:
                     return True
             # Check for _call_ = False which indicates a code reference
             if key == "_call_" and value is False:

--- a/tests/unit_tests/models/test_config.py
+++ b/tests/unit_tests/models/test_config.py
@@ -22,6 +22,7 @@ import yaml
 
 from megatron.bridge.models.config import (
     ConfigProtocol,
+    _contains_code_references,
     from_hf_pretrained,
     save_hf_pretrained,
 )
@@ -181,3 +182,85 @@ class TestSavePretrained:
 
         assert save_dir.exists()
         assert (save_dir / "config.json").exists()
+
+
+class TestContainsCodeReferences:
+    """Tests for _contains_code_references security guard."""
+
+    @pytest.mark.parametrize(
+        "target",
+        [
+            "str",
+            "int",
+            "float",
+            "bool",
+            "list",
+            "dict",
+            "tuple",
+            "builtins.str",
+            "builtins.int",
+            "builtins.float",
+            "builtins.bool",
+            "builtins.list",
+            "builtins.dict",
+            "builtins.tuple",
+        ],
+    )
+    def test_safe_targets_allowed(self, target):
+        """Safe built-in type targets should not be flagged."""
+        assert _contains_code_references({"_target_": target}) is False
+
+    @pytest.mark.parametrize(
+        "target",
+        [
+            "builtins.exec",
+            "builtins.eval",
+            "builtins.__import__",
+            "builtins.compile",
+            "builtins.getattr",
+            "builtins.setattr",
+            "builtins.delattr",
+            "builtins.globals",
+            "builtins.open",
+        ],
+    )
+    def test_dangerous_builtins_blocked(self, target):
+        """Dangerous builtins must be flagged even though they share the builtins. prefix."""
+        assert _contains_code_references({"_target_": target}) is True
+
+    def test_arbitrary_module_blocked(self):
+        """Arbitrary module paths must be flagged."""
+        assert _contains_code_references({"_target_": "os.system"}) is True
+        assert _contains_code_references({"_target_": "subprocess.call"}) is True
+
+    def test_nested_dangerous_target_blocked(self):
+        """Dangerous targets nested inside config dicts must be detected."""
+        config = {
+            "model": {
+                "_target_": "builtins.exec",
+                "_args_": ["print('pwned')"],
+            }
+        }
+        assert _contains_code_references(config) is True
+
+    def test_dangerous_target_in_list_blocked(self):
+        """Dangerous targets inside lists must be detected."""
+        config = [{"_target_": "builtins.eval", "_args_": ["1+1"]}]
+        assert _contains_code_references(config) is True
+
+    def test_call_false_flagged(self):
+        """_call_=False is a code reference indicator and must be flagged."""
+        assert _contains_code_references({"_call_": False}) is True
+
+    def test_no_target_is_safe(self):
+        """Config with no _target_ or _call_ should not be flagged."""
+        assert _contains_code_references({"hidden_size": 768, "num_layers": 12}) is False
+
+    def test_from_hf_pretrained_blocks_builtins_exec(self, tmp_path):
+        """Loading a config with builtins.exec must raise even without trust_remote_code."""
+        config_file = tmp_path / "config.json"
+        with open(config_file, "w") as f:
+            json.dump({"_target_": "builtins.exec", "_args_": ["print('pwned')"]}, f)
+
+        with pytest.raises(ValueError, match="trust_remote_code"):
+            from_hf_pretrained(MockConfig, str(tmp_path), trust_remote_code=False)


### PR DESCRIPTION
## Summary

- **Security fix**: Replace `startswith()` prefix allowlist in `_contains_code_references()` with an exact-match `frozenset` of safe target names
- The old check allowed `builtins.exec`, `builtins.eval`, `builtins.__import__`, etc. to pass as "safe" because they match the `"builtins."` prefix, enabling arbitrary code execution even with `trust_remote_code=False`
- Add regression tests covering all dangerous builtin bypass vectors, nested configs, and list configs

## Root Cause

`_contains_code_references()` in `src/megatron/bridge/models/config.py` used:
```python
if not value.startswith(("builtins.", "str", "int", "float", "bool", ...)):
    return True
```

Since `"builtins.exec".startswith("builtins.")` is `True`, the guard deemed it safe and `instantiate()` resolved and invoked `builtins.exec` with attacker-controlled arguments.

## Fix

Replace the prefix check with an exact-match allowlist (`_SAFE_TARGETS` frozenset) containing only the seven safe built-in type constructors:
```python
_SAFE_TARGETS = frozenset({"str", "int", "float", "bool", "list", "dict", "tuple",
                           "builtins.str", "builtins.int", ...})

if value not in _SAFE_TARGETS:
    return True
```

## Test plan

- [ ] `TestContainsCodeReferences::test_safe_targets_allowed` — all 14 safe targets still pass
- [ ] `TestContainsCodeReferences::test_dangerous_builtins_blocked` — `builtins.exec`, `builtins.eval`, `builtins.__import__`, `builtins.compile`, `builtins.getattr`, `builtins.setattr`, `builtins.delattr`, `builtins.globals`, `builtins.open` all blocked
- [ ] `TestContainsCodeReferences::test_arbitrary_module_blocked` — `os.system`, `subprocess.call` blocked
- [ ] `TestContainsCodeReferences::test_nested_dangerous_target_blocked` — nested dict detection
- [ ] `TestContainsCodeReferences::test_dangerous_target_in_list_blocked` — list detection
- [ ] `TestContainsCodeReferences::test_from_hf_pretrained_blocks_builtins_exec` — end-to-end: loading poisoned config.json raises `ValueError`
- [ ] Existing `TestFromPretrained` and `TestSavePretrained` tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Enhanced configuration validation to better detect and prevent code injection attacks through model configuration files.
  * Strengthened safeguards when loading models from remote sources with `trust_remote_code=False`.

* **Tests**
  * Added comprehensive test coverage for security validation of model configurations, including protection against dangerous built-in functions and arbitrary module execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->