### PR TITLE
[training] fix: use int64 (not uint64) for TrainState counters

### DIFF
--- a/src/megatron/bridge/training/state.py
+++ b/src/megatron/bridge/training/state.py
@@ -73,10 +73,10 @@ class TrainState(Stateful):
             their corresponding tensor representations.
         """
         return {
-            "step": torch.tensor(self.step, dtype=torch.uint64),
-            "consumed_train_samples": torch.tensor(self.consumed_train_samples, dtype=torch.uint64),
-            "skipped_train_samples": torch.tensor(self.skipped_train_samples, dtype=torch.uint64),
-            "consumed_valid_samples": torch.tensor(self.consumed_valid_samples, dtype=torch.uint64),
+            "step": torch.tensor(self.step, dtype=torch.int64),
+            "consumed_train_samples": torch.tensor(self.consumed_train_samples, dtype=torch.int64),
+            "skipped_train_samples": torch.tensor(self.skipped_train_samples, dtype=torch.int64),
+            "consumed_valid_samples": torch.tensor(self.consumed_valid_samples, dtype=torch.int64),
             "floating_point_operations_so_far": torch.tensor(
                 self.floating_point_operations_so_far, dtype=torch.float64
             ),

--- a/tests/unit_tests/training/test_state.py
+++ b/tests/unit_tests/training/test_state.py
@@ -86,11 +86,13 @@ class TestTrainState:
         }
         assert set(state_dict.keys()) == expected_keys
 
-        # Check tensor types (uint64 to avoid overflow on long training runs)
-        assert state_dict["step"].dtype == torch.uint64
-        assert state_dict["consumed_train_samples"].dtype == torch.uint64
-        assert state_dict["skipped_train_samples"].dtype == torch.uint64
-        assert state_dict["consumed_valid_samples"].dtype == torch.uint64
+        # Check tensor types (int64 to avoid overflow on long training runs;
+        # torch.uint64 is not supported by torch's legacy pickle path used inside
+        # broadcast_object_list during dist-checkpoint save, so use int64 instead).
+        assert state_dict["step"].dtype == torch.int64
+        assert state_dict["consumed_train_samples"].dtype == torch.int64
+        assert state_dict["skipped_train_samples"].dtype == torch.int64
+        assert state_dict["consumed_valid_samples"].dtype == torch.int64
         assert state_dict["floating_point_operations_so_far"].dtype == torch.float64
         assert state_dict["do_train"].dtype == torch.bool
         assert state_dict["do_valid"].dtype == torch.bool


### PR DESCRIPTION
## Summary

- Switch `TrainState` counters (`step`, `consumed_train_samples`, `skipped_train_samples`, `consumed_valid_samples`) from `torch.uint64` back to `torch.int64` to restore dist-checkpoint save on current PyTorch.
- Update the matching dtype assertions in `tests/unit_tests/training/test_state.py`.

## Root cause

PR #3312 intended to bump these counters from `int32` to `int64` to prevent overflow on long training runs, but the change landed as `torch.uint64`. Unlike `int64`, `uint64` has **no corresponding `TypedStorage` subclass** in PyTorch. During `save_checkpoint` → `MCoreTensorAwareStateDict.from_state_dict` → `_validate_common_state_dict`, PyTorch invokes `torch.distributed.broadcast_object_list`, which pickles the common state dict on rank 0 and unpickles it on the other ranks via `_tensor_to_object` → `torch.load` → `_legacy_load.persistent_load`. That path executes:

```python
dtype = storage_type.dtype
```

For normal dtypes, `storage_type` is a `TypedStorage` subclass exposing `.dtype` as a class attribute. For `uint64`, it falls through to bare `torch.UntypedStorage`, which has no class-level `.dtype`, producing:

```
AttributeError: type object 'torch.storage.UntypedStorage' has no attribute 'dtype'
```

One rank crashes mid-collective → remaining ranks hang on the next NCCL op → watchdog timeout + segfault in teardown. This matches the regressions in `tests/functional_tests/test_groups/training/test_local_checkpointing.py::test_local_checkpoint_save_and_resume` and `::test_local_checkpoint_save_resume_with_most_recent_k`.

Full traceback excerpt from the failing functional test:

```
src/megatron/bridge/training/checkpointing.py:1021: in save_checkpoint
    state_dict_for_save, cacheable_metadata = MCoreTensorAwareStateDict.from_state_dict(
3rdparty/Megatron-LM/megatron/core/dist_checkpointing/validation.py:338: in _validate_common_state_dict
    torch.distributed.broadcast_object_list(object_list, src=0)
...
/usr/local/lib/python3.12/dist-packages/torch/serialization.py:1785: in persistent_load
    dtype = storage_type.dtype
E   AttributeError: type object 'torch.storage.UntypedStorage' has no attribute 'dtype'
```

## Fix

Switch the four counter dtypes to `torch.int64`. This still satisfies the original intent of PR #3312 (max value ~9.2e18 samples, no realistic overflow risk) and goes through the standard `LongStorage` typed-storage pickle path, so dist-checkpoint save works again.

## Test plan

- [x] `uv run pre-commit run` passes on touched files.
- [ ] `uv run python -m pytest tests/unit_tests/training/test_state.py -v` passes with updated `int64` assertions.
- [ ] Local-checkpoint functional tests pass on CI:
  - `tests/functional_tests/test_groups/training/test_local_checkpointing.py::TestLocalCheckpointing::test_local_checkpoint_save_and_resume`
  - `tests/functional_tests/test_groups/training/test_local_checkpointing.py::TestLocalCheckpointing::test_local_checkpoint_save_resume_with_most_recent_k`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed training state serialization compatibility with distributed checkpoint operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->