### PR TITLE
Sharing Wan wandb public results

### DIFF
--- a/examples/diffusion/recipes/wan/README.md
+++ b/examples/diffusion/recipes/wan/README.md
@@ -127,7 +127,7 @@ Run WAN pretraining with the generic **run_recipe** script (same entry point as 
 
 **Recipe:** [megatron.bridge.diffusion.recipes.wan.wan](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/src/megatron/bridge/diffusion/recipes/wan/wan.py)
 
-Example W&B results runs can be found at: ([W&B results](https://api.wandb.ai/links/nvidia-nemo-fw-public/lbk87jeh))
+Example W&B results (for pre-training, SFT for different parallelism configs) runs can be found at: ([W&B results](https://api.wandb.ai/links/nvidia-nemo-fw-public/lbk87jeh))
 
 From the **Megatron-Bridge repository root**:
 

--- a/examples/diffusion/recipes/wan/README.md
+++ b/examples/diffusion/recipes/wan/README.md
@@ -127,7 +127,7 @@ Run WAN pretraining with the generic **run_recipe** script (same entry point as 
 
 **Recipe:** [megatron.bridge.diffusion.recipes.wan.wan](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/src/megatron/bridge/diffusion/recipes/wan/wan.py)
 
-Example W&B results runs can be found at: [W&B results]([https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/src/megatron/bridge/diffusion/recipes/wan/wan.py](https://api.wandb.ai/links/nvidia-nemo-fw-public/lbk87jeh))
+Example W&B results runs can be found at: ([W&B results](https://api.wandb.ai/links/nvidia-nemo-fw-public/lbk87jeh))
 
 From the **Megatron-Bridge repository root**:
 

--- a/examples/diffusion/recipes/wan/README.md
+++ b/examples/diffusion/recipes/wan/README.md
@@ -127,6 +127,8 @@ Run WAN pretraining with the generic **run_recipe** script (same entry point as 
 
 **Recipe:** [megatron.bridge.diffusion.recipes.wan.wan](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/src/megatron/bridge/diffusion/recipes/wan/wan.py)
 
+Example W&B results runs can be found at: [W&B results]([https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/src/megatron/bridge/diffusion/recipes/wan/wan.py](https://api.wandb.ai/links/nvidia-nemo-fw-public/lbk87jeh))
+
 From the **Megatron-Bridge repository root**:
 
 ### Sequence packing


### PR DESCRIPTION
# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added reference links to example Weights & Biases experiment runs in the WAN 2.1 pretraining documentation section. Users can now easily access sample training results, comprehensive performance metrics, and detailed benchmarks from reference implementations, helping teams review best practices, understand expected model performance outcomes, and validate their own configurations against established baselines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->