### PR TITLE
Add uv run prefix to all commands in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ if __name__ == "__main__":
 You can launch the above script with:
 
 ```sh
-torchrun --nproc-per-node=<num devices> /path/to/script.py
+uv run torchrun --nproc-per-node=<num devices> /path/to/script.py
 ```
 
 More examples:

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ if __name__ == "__main__":
 You can launch the above script with:
 
 ```sh
-uv run torchrun --nproc-per-node=<num devices> /path/to/script.py
+uv run python -m torch.distributed.run --nproc-per-node=<num devices> /path/to/script.py
 ```
 
 More examples:

--- a/docs/adding-new-models.md
+++ b/docs/adding-new-models.md
@@ -209,8 +209,8 @@ Use the examples in `examples/conversion/` to verify bidirectional conversion an
 - Multi-GPU HF load to Megatron
 
 ```sh
-python examples/conversion/hf_to_megatron_generate_text.py --hf_model_path <org>/<model-id> --prompt "Hello"
-python examples/conversion/convert_checkpoints.py import --hf-model <org>/<model-id> --megatron-path ./checkpoints/<model-dir>
+uv run python examples/conversion/hf_to_megatron_generate_text.py --hf_model_path <org>/<model-id> --prompt "Hello"
+uv run python examples/conversion/convert_checkpoints.py import --hf-model <org>/<model-id> --megatron-path ./checkpoints/<model-dir>
 ```
 ## 7) Add tests
 

--- a/docs/bridge-guide.md
+++ b/docs/bridge-guide.md
@@ -236,19 +236,19 @@ These examples can be run directly as shell commands.
 
 ```bash
 huggingface-cli login --token <your token>
-python -c "from megatron.bridge import AutoBridge; AutoBridge.import_ckpt('meta-llama/Llama-3.2-1B','./megatron_checkpoints/llama32_1b')"
+uv run python -c "from megatron.bridge import AutoBridge; AutoBridge.import_ckpt('meta-llama/Llama-3.2-1B','./megatron_checkpoints/llama32_1b')"
 ```
 
 ### Megatron → HF export (one call)
 
 ```bash
-python -c "from megatron.bridge import AutoBridge; b=AutoBridge.from_hf_pretrained('meta-llama/Llama-3.2-1B'); b.export_ckpt('./megatron_checkpoints/llama32_1b','./hf_exports/llama32_1b')"
+uv run python -c "from megatron.bridge import AutoBridge; b=AutoBridge.from_hf_pretrained('meta-llama/Llama-3.2-1B'); b.export_ckpt('./megatron_checkpoints/llama32_1b','./hf_exports/llama32_1b')"
 ```
 
 ### Create Megatron models and run locally
 
 ```bash
-python - << 'PY'
+uv run python - << 'PY'
 from megatron.bridge import AutoBridge
 
 bridge = AutoBridge.from_hf_pretrained('meta-llama/Llama-3.2-1B')
@@ -266,7 +266,7 @@ PY
 ### Launch with multiple GPUs (example)
 
 ```bash
-torchrun --nproc-per-node=2 -m examples.conversion.generate_from_hf
+uv run torchrun --nproc-per-node=2 -m examples.conversion.generate_from_hf
 ```
 
 ## AutoBridge API Reference

--- a/docs/bridge-guide.md
+++ b/docs/bridge-guide.md
@@ -266,7 +266,7 @@ PY
 ### Launch with multiple GPUs (example)
 
 ```bash
-uv run torchrun --nproc-per-node=2 -m examples.conversion.generate_from_hf
+uv run python -m torch.distributed.run --nproc-per-node=2 -m examples.conversion.generate_from_hf
 ```
 
 ## AutoBridge API Reference

--- a/docs/megatron-lm-to-megatron-bridge.md
+++ b/docs/megatron-lm-to-megatron-bridge.md
@@ -33,7 +33,7 @@ uv run python scripts/translate_mlm_to_bridge.py --reverse \
     --recipe llama32_1b_pretrain_config
 
 # From a recipe plus inline overrides
-uv run uv run python scripts/translate_mlm_to_bridge.py --reverse \
+uv run python scripts/translate_mlm_to_bridge.py --reverse \
     --recipe llama32_1b_pretrain_config \
     --args "train.train_iters=1000 model.tensor_model_parallel_size=2"
 

--- a/docs/megatron-lm-to-megatron-bridge.md
+++ b/docs/megatron-lm-to-megatron-bridge.md
@@ -10,18 +10,18 @@ Megatron Bridge is Python-first: configure models, data, and training via typed 
 
 ```bash
 # From a YAML config file (MODEL_ARGS section)
-python scripts/translate_mlm_to_bridge.py --yaml model_configs/DeepSeek-V3.yaml
+uv run python scripts/translate_mlm_to_bridge.py --yaml model_configs/DeepSeek-V3.yaml
 
 # From inline CLI args
-python scripts/translate_mlm_to_bridge.py \
+uv run python scripts/translate_mlm_to_bridge.py \
     --args "--num-layers 32 --hidden-size 4096 --num-attention-heads 32 --bf16 --swiglu"
 
 # Emit a standalone Bridge recipe Python file (output goes to stdout; use -o to write to a file)
-python scripts/translate_mlm_to_bridge.py \
+uv run python scripts/translate_mlm_to_bridge.py \
     --yaml DeepSeek-V3.yaml --emit recipe --recipe-name deepseek_v3
 
 # Write output to a file instead of stdout
-python scripts/translate_mlm_to_bridge.py \
+uv run python scripts/translate_mlm_to_bridge.py \
     --yaml DeepSeek-V3.yaml -o bridge_overrides.txt
 ```
 
@@ -29,20 +29,20 @@ python scripts/translate_mlm_to_bridge.py \
 
 ```bash
 # From a Bridge recipe name (defaults exported as MLM args)
-python scripts/translate_mlm_to_bridge.py --reverse \
+uv run python scripts/translate_mlm_to_bridge.py --reverse \
     --recipe llama32_1b_pretrain_config
 
 # From a recipe plus inline overrides
-python scripts/translate_mlm_to_bridge.py --reverse \
+uv run uv run python scripts/translate_mlm_to_bridge.py --reverse \
     --recipe llama32_1b_pretrain_config \
     --args "train.train_iters=1000 model.tensor_model_parallel_size=2"
 
 # From Bridge overrides only (no recipe)
-python scripts/translate_mlm_to_bridge.py --reverse \
+uv run python scripts/translate_mlm_to_bridge.py --reverse \
     --args "model.num_layers=32 model.activation_func=silu model.gated_linear_unit=true"
 
 # From a Bridge YAML/OmegaConf config file (e.g. exported ConfigContainer)
-python scripts/translate_mlm_to_bridge.py --reverse \
+uv run python scripts/translate_mlm_to_bridge.py --reverse \
     --yaml bridge_config.yaml
 ```
 
@@ -98,7 +98,7 @@ Flags not present in Bridge (e.g., `--use-mcore-models`, `--use-flash-attn`) are
 Run your example training entrypoint and override config keys directly:
 
 ```bash
-python examples/models/llama/pretrain_llama3_8b.py \
+uv run python examples/models/llama/pretrain_llama3_8b.py \
   train.micro_batch_size=2 \
   train.global_batch_size=128 \
   model.num_layers=32 model.hidden_size=4096 model.num_attention_heads=32 \

--- a/docs/modelopt/quantization.md
+++ b/docs/modelopt/quantization.md
@@ -189,8 +189,7 @@ checkpoint:
 Use `examples/quantization/pretrain_quantized_llama3_8b.py`:
 
 ```bash
-uv run python pretrain_quantized_llama3_8b.py \
-  --nproc-per-node=4 \
+uv run python -m torch.distributed.run --nproc-per-node=4 pretrain_quantized_llama3_8b.py \
   --config-file=conf/my_qat_config.yaml \
   --hf-path=meta-llama/Meta-Llama-3-8B
 ```
@@ -200,8 +199,7 @@ uv run python pretrain_quantized_llama3_8b.py \
 You can also use command-line overrides:
 
 ```bash
-uv run python -m torch.distributed.run pretrain_quantized_llama3_8b.py \
-    --nproc_per_node 4 \
+uv run python -m torch.distributed.run --nproc_per_node 4 pretrain_quantized_llama3_8b.py \
     model.tensor_model_parallel_size=4 \
     model.gradient_accumulation_fusion=False \
     checkpoint.pretrained_checkpoint=/models/llama3_8b_fp8_init

--- a/docs/modelopt/quantization.md
+++ b/docs/modelopt/quantization.md
@@ -52,7 +52,7 @@ PTQ quantizes a pretrained model by running calibration with a small dataset to 
 Use the `examples/quantization/quantize.py` script for LLM PTQ:
 
 ```bash
-uv run torchrun --nproc_per_node 2 examples/quantization/quantize.py \
+uv run python -m torch.distributed.run --nproc_per_node 2 examples/quantization/quantize.py \
     --hf-model-id meta-llama/Llama-3.2-1B \
     --export-quant-cfg fp8 \
     --tp 2 \
@@ -62,7 +62,7 @@ uv run torchrun --nproc_per_node 2 examples/quantization/quantize.py \
 Use the `examples/quantization/quantize_vlm.py` script for VLM PTQ:
 
 ```bash
-uv run torchrun --nproc_per_node 8 examples/quantization/quantize_vlm.py \
+uv run python -m torch.distributed.run --nproc_per_node 8 examples/quantization/quantize_vlm.py \
     --hf-model-id Qwen/Qwen3-VL-30B-A3B-Instruct \
     --export-quant-cfg fp8 \
     --megatron-save-path ./Qwen3-VL-30B-A3B-Instruct_fp8 \
@@ -87,7 +87,7 @@ uv run torchrun --nproc_per_node 8 examples/quantization/quantize_vlm.py \
 Resume the quantized checkpoint and test with text generation using `examples/quantization/ptq_generate.py` for LLM:
 
 ```bash
-uv run torchrun --nproc_per_node 2 examples/quantization/ptq_generate.py \
+uv run python -m torch.distributed.run --nproc_per_node 2 examples/quantization/ptq_generate.py \
     --hf-model-id meta-llama/Llama-3.2-1B \
     --megatron-load-path ./llama3_2_1b_fp8 \
     --tp 2
@@ -96,7 +96,7 @@ uv run torchrun --nproc_per_node 2 examples/quantization/ptq_generate.py \
 Resume the quantized checkpoint and test with text generation using `examples/quantization/ptq_generate_vlm.py` for VLM:
 
 ```bash
-uv run torchrun --nproc_per_node 8 examples/quantization/ptq_generate_vlm.py \
+uv run python -m torch.distributed.run --nproc_per_node 8 examples/quantization/ptq_generate_vlm.py \
     --hf-model-id Qwen/Qwen3-VL-30B-A3B-Instruct \
     --megatron-load-path ./Qwen3-VL-30B-A3B-Instruct_fp8 \
     --tp 8 \
@@ -116,7 +116,7 @@ uv run torchrun --nproc_per_node 8 examples/quantization/ptq_generate_vlm.py \
 Export the quantized checkpoint to unified HuggingFace format using `examples/quantization/export.py`:
 
 ```bash
-uv run torchrun --nproc_per_node 2 examples/quantization/export.py \
+uv run python -m torch.distributed.run --nproc_per_node 2 examples/quantization/export.py \
     --hf-model-id meta-llama/Llama-3.2-1B \
     --megatron-load-path ./llama3_2_1b_fp8 \
     --export-dir ./llama3_2_1b_fp8_hf \
@@ -151,7 +151,7 @@ In QAT, a model quantized using `mtq.quantize()` can be directly fine-tuned with
 #### Step 1: Create Initial Quantized Checkpoint (PTQ)
 
 ```bash
-uv run torchrun --nproc_per_node 8 examples/quantization/quantize.py \
+uv run python -m torch.distributed.run --nproc_per_node 8 examples/quantization/quantize.py \
     --hf-model-id meta-llama/Meta-Llama-3-8B \
     --export-quant-cfg fp8 \
     --tp 8 \
@@ -200,7 +200,7 @@ uv run python pretrain_quantized_llama3_8b.py \
 You can also use command-line overrides:
 
 ```bash
-uv run torchrun pretrain_quantized_llama3_8b.py \
+uv run python -m torch.distributed.run pretrain_quantized_llama3_8b.py \
     --nproc_per_node 4 \
     model.tensor_model_parallel_size=4 \
     model.gradient_accumulation_fusion=False \

--- a/docs/modelopt/quantization.md
+++ b/docs/modelopt/quantization.md
@@ -52,7 +52,7 @@ PTQ quantizes a pretrained model by running calibration with a small dataset to 
 Use the `examples/quantization/quantize.py` script for LLM PTQ:
 
 ```bash
-torchrun --nproc_per_node 2 examples/quantization/quantize.py \
+uv run torchrun --nproc_per_node 2 examples/quantization/quantize.py \
     --hf-model-id meta-llama/Llama-3.2-1B \
     --export-quant-cfg fp8 \
     --tp 2 \
@@ -62,7 +62,7 @@ torchrun --nproc_per_node 2 examples/quantization/quantize.py \
 Use the `examples/quantization/quantize_vlm.py` script for VLM PTQ:
 
 ```bash
-torchrun --nproc_per_node 8 examples/quantization/quantize_vlm.py \
+uv run torchrun --nproc_per_node 8 examples/quantization/quantize_vlm.py \
     --hf-model-id Qwen/Qwen3-VL-30B-A3B-Instruct \
     --export-quant-cfg fp8 \
     --megatron-save-path ./Qwen3-VL-30B-A3B-Instruct_fp8 \
@@ -87,7 +87,7 @@ torchrun --nproc_per_node 8 examples/quantization/quantize_vlm.py \
 Resume the quantized checkpoint and test with text generation using `examples/quantization/ptq_generate.py` for LLM:
 
 ```bash
-torchrun --nproc_per_node 2 examples/quantization/ptq_generate.py \
+uv run torchrun --nproc_per_node 2 examples/quantization/ptq_generate.py \
     --hf-model-id meta-llama/Llama-3.2-1B \
     --megatron-load-path ./llama3_2_1b_fp8 \
     --tp 2
@@ -96,7 +96,7 @@ torchrun --nproc_per_node 2 examples/quantization/ptq_generate.py \
 Resume the quantized checkpoint and test with text generation using `examples/quantization/ptq_generate_vlm.py` for VLM:
 
 ```bash
-torchrun --nproc_per_node 8 examples/quantization/ptq_generate_vlm.py \
+uv run torchrun --nproc_per_node 8 examples/quantization/ptq_generate_vlm.py \
     --hf-model-id Qwen/Qwen3-VL-30B-A3B-Instruct \
     --megatron-load-path ./Qwen3-VL-30B-A3B-Instruct_fp8 \
     --tp 8 \
@@ -116,7 +116,7 @@ torchrun --nproc_per_node 8 examples/quantization/ptq_generate_vlm.py \
 Export the quantized checkpoint to unified HuggingFace format using `examples/quantization/export.py`:
 
 ```bash
-torchrun --nproc_per_node 2 examples/quantization/export.py \
+uv run torchrun --nproc_per_node 2 examples/quantization/export.py \
     --hf-model-id meta-llama/Llama-3.2-1B \
     --megatron-load-path ./llama3_2_1b_fp8 \
     --export-dir ./llama3_2_1b_fp8_hf \
@@ -151,7 +151,7 @@ In QAT, a model quantized using `mtq.quantize()` can be directly fine-tuned with
 #### Step 1: Create Initial Quantized Checkpoint (PTQ)
 
 ```bash
-torchrun --nproc_per_node 8 examples/quantization/quantize.py \
+uv run torchrun --nproc_per_node 8 examples/quantization/quantize.py \
     --hf-model-id meta-llama/Meta-Llama-3-8B \
     --export-quant-cfg fp8 \
     --tp 8 \
@@ -189,7 +189,7 @@ checkpoint:
 Use `examples/quantization/pretrain_quantized_llama3_8b.py`:
 
 ```bash
-python pretrain_quantized_llama3_8b.py \
+uv run python pretrain_quantized_llama3_8b.py \
   --nproc-per-node=4 \
   --config-file=conf/my_qat_config.yaml \
   --hf-path=meta-llama/Meta-Llama-3-8B
@@ -200,7 +200,7 @@ python pretrain_quantized_llama3_8b.py \
 You can also use command-line overrides:
 
 ```bash
-torchrun pretrain_quantized_llama3_8b.py \
+uv run torchrun pretrain_quantized_llama3_8b.py \
     --nproc_per_node 4 \
     model.tensor_model_parallel_size=4 \
     model.gradient_accumulation_fusion=False \

--- a/docs/models/llm/deepseek-v2.md
+++ b/docs/models/llm/deepseek-v2.md
@@ -44,7 +44,7 @@ model = provider.provide_distributed_model(wrap_with_ddp=False)
 ### Import Checkpoint from HF
 
 ```bash
-python examples/conversion/convert_checkpoints.py import \
+uv run python examples/conversion/convert_checkpoints.py import \
   --hf-model deepseek-ai/DeepSeek-V2-Lite \
   --megatron-path /checkpoints/deepseek_v2_lite_megatron \
   --trust-remote-code
@@ -68,7 +68,7 @@ bridge.export_ckpt(
 ### Run Inference on Converted Checkpoint
 
 ```bash
-python examples/conversion/hf_to_megatron_generate_text.py \
+uv run python examples/conversion/hf_to_megatron_generate_text.py \
   --hf_model_path deepseek-ai/DeepSeek-V2-Lite \
   --megatron_model_path /checkpoints/deepseek_v2_lite_megatron \
   --prompt "What is artificial intelligence?" \

--- a/docs/models/llm/deepseek-v3.md
+++ b/docs/models/llm/deepseek-v3.md
@@ -45,7 +45,7 @@ model = provider.provide_distributed_model(wrap_with_ddp=False)
 ### Import Checkpoint from HF
 
 ```bash
-python examples/conversion/convert_checkpoints.py import \
+uv run python examples/conversion/convert_checkpoints.py import \
   --hf-model deepseek-ai/DeepSeek-V3-Base \
   --megatron-path /checkpoints/deepseek_v3_megatron \
   --trust-remote-code
@@ -69,7 +69,7 @@ bridge.export_ckpt(
 ### Run Inference on Converted Checkpoint
 
 ```bash
-python examples/conversion/hf_to_megatron_generate_text.py \
+uv run python examples/conversion/hf_to_megatron_generate_text.py \
   --hf_model_path deepseek-ai/DeepSeek-V3-Base \
   --megatron_model_path /checkpoints/deepseek_v3_megatron \
   --prompt "What is artificial intelligence?" \

--- a/docs/models/llm/gemma2.md
+++ b/docs/models/llm/gemma2.md
@@ -63,17 +63,17 @@ model = provider.provide_distributed_model(wrap_with_ddp=False)
 To import the HF model to your desired Megatron path:
 ```bash
 # Gemma 2 2B
-python examples/conversion/convert_checkpoints.py import \
+uv run python examples/conversion/convert_checkpoints.py import \
 --hf-model google/gemma-2-2b \
 --megatron-path /models/gemma-2-2b
 
 # Gemma 2 9B
-python examples/conversion/convert_checkpoints.py import \
+uv run python examples/conversion/convert_checkpoints.py import \
 --hf-model google/gemma-2-9b \
 --megatron-path /models/gemma-2-9b
 
 # Gemma 2 27B
-python examples/conversion/convert_checkpoints.py import \
+uv run python examples/conversion/convert_checkpoints.py import \
 --hf-model google/gemma-2-27b \
 --megatron-path /models/gemma-2-27b
 ```
@@ -81,7 +81,7 @@ python examples/conversion/convert_checkpoints.py import \
 ### Export Megatron → HF
 ```bash
 # Gemma 2 9B example
-python examples/conversion/convert_checkpoints.py export \
+uv run python examples/conversion/convert_checkpoints.py export \
 --hf-model google/gemma-2-9b \
 --megatron-path /results/gemma2_9b/checkpoints/iter_00001000 \
 --hf-path ./gemma2-9b-hf-export
@@ -90,7 +90,7 @@ python examples/conversion/convert_checkpoints.py export \
 ### Run Inference on Converted Checkpoint
 
 ```bash
-python examples/conversion/hf_to_megatron_generate_text.py \
+uv run python examples/conversion/hf_to_megatron_generate_text.py \
 --hf_model_path google/gemma-2-9b \
 --megatron_model_path /models/gemma-2-9b \
 --prompt "What is artificial intelligence?" \
@@ -166,7 +166,7 @@ config = gemma2_27b_pretrain_config(
 
 #### Gemma 2 2B
 ```bash
-torchrun --nproc-per-node=8 run/run_recipe.py \
+uv run torchrun --nproc-per-node=8 run/run_recipe.py \
 --pretrained-checkpoint /models/gemma-2-2b \
 --recipe gemma2_2b_sft_config \
 train.global_batch_size=64 \
@@ -188,7 +188,7 @@ config = gemma2_2b_sft_config(
 
 #### Gemma 2 9B
 ```bash
-torchrun --nproc-per-node=8 run/run_recipe.py \
+uv run torchrun --nproc-per-node=8 run/run_recipe.py \
 --pretrained-checkpoint /models/gemma-2-9b \
 --recipe gemma2_9b_sft_config \
 train.global_batch_size=64 \
@@ -198,7 +198,7 @@ checkpoint.save=$SAVE_DIR/gemma2_9b_finetune
 
 #### Gemma 2 27B
 ```bash
-torchrun --nproc-per-node=16 run/run_recipe.py \
+uv run torchrun --nproc-per-node=16 run/run_recipe.py \
 --pretrained-checkpoint /models/gemma-2-27b \
 --recipe gemma2_27b_sft_config \
 train.global_batch_size=64 \
@@ -210,7 +210,7 @@ checkpoint.save=$SAVE_DIR/gemma2_27b_finetune
 
 #### Gemma 2 2B
 ```bash
-torchrun --nproc-per-node=8 run/run_recipe.py \
+uv run torchrun --nproc-per-node=8 run/run_recipe.py \
 --pretrained-checkpoint /models/gemma-2-2b \
 --recipe gemma2_2b_peft_config \
 --peft_scheme lora \

--- a/docs/models/llm/gemma2.md
+++ b/docs/models/llm/gemma2.md
@@ -166,7 +166,7 @@ config = gemma2_27b_pretrain_config(
 
 #### Gemma 2 2B
 ```bash
-uv run torchrun --nproc-per-node=8 run/run_recipe.py \
+uv run python -m torch.distributed.run --nproc-per-node=8 run/run_recipe.py \
 --pretrained-checkpoint /models/gemma-2-2b \
 --recipe gemma2_2b_sft_config \
 train.global_batch_size=64 \
@@ -188,7 +188,7 @@ config = gemma2_2b_sft_config(
 
 #### Gemma 2 9B
 ```bash
-uv run torchrun --nproc-per-node=8 run/run_recipe.py \
+uv run python -m torch.distributed.run --nproc-per-node=8 run/run_recipe.py \
 --pretrained-checkpoint /models/gemma-2-9b \
 --recipe gemma2_9b_sft_config \
 train.global_batch_size=64 \
@@ -198,7 +198,7 @@ checkpoint.save=$SAVE_DIR/gemma2_9b_finetune
 
 #### Gemma 2 27B
 ```bash
-uv run torchrun --nproc-per-node=16 run/run_recipe.py \
+uv run python -m torch.distributed.run --nproc-per-node=16 run/run_recipe.py \
 --pretrained-checkpoint /models/gemma-2-27b \
 --recipe gemma2_27b_sft_config \
 train.global_batch_size=64 \
@@ -210,7 +210,7 @@ checkpoint.save=$SAVE_DIR/gemma2_27b_finetune
 
 #### Gemma 2 2B
 ```bash
-uv run torchrun --nproc-per-node=8 run/run_recipe.py \
+uv run python -m torch.distributed.run --nproc-per-node=8 run/run_recipe.py \
 --pretrained-checkpoint /models/gemma-2-2b \
 --recipe gemma2_2b_peft_config \
 --peft_scheme lora \

--- a/docs/models/llm/gemma3.md
+++ b/docs/models/llm/gemma3.md
@@ -155,7 +155,7 @@ config = gemma3_1b_peft_config(
 
 **Full Finetuning:**
 ```bash
-uv run torchrun --nproc-per-node=8 run/run_recipe.py \
+uv run python -m torch.distributed.run --nproc-per-node=8 run/run_recipe.py \
   --pretrained-checkpoint /models/gemma-3-1b-it \
   --recipe gemma3_1b_sft_config \
   train.global_batch_size=64 \
@@ -165,7 +165,7 @@ uv run torchrun --nproc-per-node=8 run/run_recipe.py \
 
 **LoRA Finetuning:**
 ```bash
-uv run torchrun --nproc-per-node=8 run/run_recipe.py \
+uv run python -m torch.distributed.run --nproc-per-node=8 run/run_recipe.py \
   --pretrained-checkpoint /models/gemma-3-1b-it \
   --recipe gemma3_1b_peft_config \
   --peft_scheme lora \

--- a/docs/models/llm/gemma3.md
+++ b/docs/models/llm/gemma3.md
@@ -49,14 +49,14 @@ model = provider.provide_distributed_model(wrap_with_ddp=False)
 ### Import HF → Megatron
 To import the HF model to your desired Megatron path:
 ```bash
-python examples/conversion/convert_checkpoints.py import \
+uv run python examples/conversion/convert_checkpoints.py import \
 --hf-model google/gemma-3-1b-it \
 --megatron-path /models/gemma-3-1b-it
 ```
 
 ### Export Megatron → HF
 ```bash
-python examples/conversion/convert_checkpoints.py export \
+uv run python examples/conversion/convert_checkpoints.py export \
 --hf-model google/gemma-3-1b-it \
 --megatron-path /results/gemma3_1b/checkpoints/iter_00001000 \
 --hf-path ./gemma3-hf-export
@@ -65,7 +65,7 @@ python examples/conversion/convert_checkpoints.py export \
 ### Run Inference on Converted Checkpoint
 
 ```bash
-python examples/conversion/hf_to_megatron_generate_text.py \
+uv run python examples/conversion/hf_to_megatron_generate_text.py \
 --hf_model_path google/gemma-3-1b-it \
 --megatron_model_path /models/gemma-3-1b-it \
 --prompt "What is artificial intelligence?" \
@@ -155,7 +155,7 @@ config = gemma3_1b_peft_config(
 
 **Full Finetuning:**
 ```bash
-torchrun --nproc-per-node=8 run/run_recipe.py \
+uv run torchrun --nproc-per-node=8 run/run_recipe.py \
   --pretrained-checkpoint /models/gemma-3-1b-it \
   --recipe gemma3_1b_sft_config \
   train.global_batch_size=64 \
@@ -165,7 +165,7 @@ torchrun --nproc-per-node=8 run/run_recipe.py \
 
 **LoRA Finetuning:**
 ```bash
-torchrun --nproc-per-node=8 run/run_recipe.py \
+uv run torchrun --nproc-per-node=8 run/run_recipe.py \
   --pretrained-checkpoint /models/gemma-3-1b-it \
   --recipe gemma3_1b_peft_config \
   --peft_scheme lora \

--- a/docs/models/llm/glm45.md
+++ b/docs/models/llm/glm45.md
@@ -214,7 +214,7 @@ config = glm45_355b_peft_config(
 
 ```bash
 # GLM 4.5 Air - LoRA finetuning on single node (8 GPUs)
-uv run torchrun --nproc-per-node=8 run/run_recipe.py \
+uv run python -m torch.distributed.run --nproc-per-node=8 run/run_recipe.py \
 --pretrained-checkpoint /models/glm45-air-106b \
 --recipe glm45_air_106b_peft_config \
 --peft_scheme lora \
@@ -223,7 +223,7 @@ train.train_iters=1000 \
 checkpoint.save=$SAVE_DIR/glm45_air_lora
 
 # GLM 4.5 355B - Full finetuning (256 GPUs)
-uv run torchrun --nnodes=32 --nproc-per-node=8 run/run_recipe.py \
+uv run python -m torch.distributed.run --nnodes=32 --nproc-per-node=8 run/run_recipe.py \
 --pretrained-checkpoint /models/glm45-355b \
 --recipe glm45_355b_sft_config \
 train.global_batch_size=256 \

--- a/docs/models/llm/glm45.md
+++ b/docs/models/llm/glm45.md
@@ -84,19 +84,19 @@ model = provider.provide_distributed_model(wrap_with_ddp=False)
 ### Import HF → Megatron
 ```bash
 # Import GLM 4.5 Air model
-python examples/conversion/convert_checkpoints.py import \
+uv run python examples/conversion/convert_checkpoints.py import \
 --hf-model zai-org/GLM-4.5-Air \
 --megatron-path /models/glm45-air-106b
 
 # Import GLM 4.5 355B model
-python examples/conversion/convert_checkpoints.py import \
+uv run python examples/conversion/convert_checkpoints.py import \
 --hf-model zai-org/GLM-4.5 \
 --megatron-path /models/glm45-355b
 ```
 
 ### Export Megatron → HF
 ```bash
-python examples/conversion/convert_checkpoints.py export \
+uv run python examples/conversion/convert_checkpoints.py export \
 --hf-model zai-org/GLM-4.5-Air \
 --megatron-path /results/glm45_air/checkpoints/iter_00001000 \
 --hf-path ./glm45-air-hf-export
@@ -104,7 +104,7 @@ python examples/conversion/convert_checkpoints.py export \
 
 ### Run Inference on Converted Checkpoint
 ```bash
-python examples/conversion/hf_to_megatron_generate_text.py \
+uv run python examples/conversion/hf_to_megatron_generate_text.py \
 --hf_model_path zai-org/GLM-4.5-Air \
 --megatron_model_path /models/glm45-air-106b \
 --prompt "Explain quantum computing in simple terms." \
@@ -214,7 +214,7 @@ config = glm45_355b_peft_config(
 
 ```bash
 # GLM 4.5 Air - LoRA finetuning on single node (8 GPUs)
-torchrun --nproc-per-node=8 run/run_recipe.py \
+uv run torchrun --nproc-per-node=8 run/run_recipe.py \
 --pretrained-checkpoint /models/glm45-air-106b \
 --recipe glm45_air_106b_peft_config \
 --peft_scheme lora \
@@ -223,7 +223,7 @@ train.train_iters=1000 \
 checkpoint.save=$SAVE_DIR/glm45_air_lora
 
 # GLM 4.5 355B - Full finetuning (256 GPUs)
-torchrun --nnodes=32 --nproc-per-node=8 run/run_recipe.py \
+uv run torchrun --nnodes=32 --nproc-per-node=8 run/run_recipe.py \
 --pretrained-checkpoint /models/glm45-355b \
 --recipe glm45_355b_sft_config \
 train.global_batch_size=256 \

--- a/docs/models/llm/llama-nemotron.md
+++ b/docs/models/llm/llama-nemotron.md
@@ -56,7 +56,7 @@ model = provider.provide_distributed_model(wrap_with_ddp=False)
 ### Import Checkpoint from HF
 
 ```bash
-python examples/conversion/convert_checkpoints.py import \
+uv run python examples/conversion/convert_checkpoints.py import \
   --hf-model nvidia/Llama-3_3-Nemotron-Super-49B-v1_5 \
   --megatron-path /checkpoints/llama_nemotron_super_49b_megatron \
   --trust-remote-code
@@ -83,7 +83,7 @@ bridge.export_ckpt(
 ### Run Inference on Converted Checkpoint
 
 ```bash
-python examples/conversion/hf_to_megatron_generate_text.py \
+uv run python examples/conversion/hf_to_megatron_generate_text.py \
   --hf_model_path nvidia/Llama-3_3-Nemotron-Super-49B-v1_5 \
   --megatron_model_path /checkpoints/llama_nemotron_super_49b_megatron \
   --prompt "What is artificial intelligence?" \

--- a/docs/models/llm/llama3.md
+++ b/docs/models/llm/llama3.md
@@ -43,7 +43,7 @@ model = provider.provide_distributed_model(wrap_with_ddp=False)
 ### Import Checkpoint from HF
 
 ```bash
-python examples/conversion/convert_checkpoints.py import \
+uv run python examples/conversion/convert_checkpoints.py import \
   --hf-model meta-llama/Meta-Llama-3.1-8B \
   --megatron-path /checkpoints/llama31_8b_megatron
 ```
@@ -66,7 +66,7 @@ bridge.export_ckpt(
 ### Run Inference on Converted Checkpoint
 
 ```bash
-python examples/conversion/hf_to_megatron_generate_text.py \
+uv run python examples/conversion/hf_to_megatron_generate_text.py \
   --hf_model_path meta-llama/Meta-Llama-3.1-8B \
   --megatron_model_path /checkpoints/llama31_8b_megatron \
   --prompt "What is artificial intelligence?" \

--- a/docs/models/llm/mistral.md
+++ b/docs/models/llm/mistral.md
@@ -44,7 +44,7 @@ model = provider.provide_distributed_model(wrap_with_ddp=False)
 ### Import Checkpoint from HF
 
 ```bash
-python examples/conversion/convert_checkpoints.py import \
+uv run python examples/conversion/convert_checkpoints.py import \
   --hf-model mistralai/Mistral-Small-24B-Base-2501 \
   --megatron-path /checkpoints/mistral_small_24b_megatron
 ```
@@ -67,7 +67,7 @@ bridge.export_ckpt(
 ### Run Inference on Converted Checkpoint
 
 ```bash
-python examples/conversion/hf_to_megatron_generate_text.py \
+uv run python examples/conversion/hf_to_megatron_generate_text.py \
   --hf_model_path mistralai/Mistral-Small-24B-Base-2501 \
   --megatron_model_path /checkpoints/mistral_small_24b_megatron \
   --prompt "What is artificial intelligence?" \

--- a/docs/models/llm/nemotron3-super.md
+++ b/docs/models/llm/nemotron3-super.md
@@ -59,7 +59,7 @@ without model parallelism.
 HF_MODEL=/path/to/hf/model
 MEGATRON_PATH=/path/to/output/megatron/ckpt
 
-uv run torchrun --nproc-per-node=8 examples/conversion/convert_checkpoints_multi_gpu.py import \
+uv run python -m torch.distributed.run --nproc-per-node=8 examples/conversion/convert_checkpoints_multi_gpu.py import \
 --hf-model $HF_MODEL \
 --megatron-path $MEGATRON_PATH \
 --tp 1 \
@@ -76,7 +76,7 @@ HF_MODEL=/path/to/hf/model
 MEGATRON_PATH=/path/to/trained/megatron/ckpt
 OUTPUT_PATH=/path/to/output/hf/ckpt
 
-uv run torchrun --nproc-per-node=8 examples/conversion/convert_checkpoints_multi_gpu.py export \
+uv run python -m torch.distributed.run --nproc-per-node=8 examples/conversion/convert_checkpoints_multi_gpu.py export \
 --hf-model $HF_MODEL \
 --megatron-path $MEGATRON_PATH \
 --hf-path $OUTPUT_PATH \
@@ -91,7 +91,7 @@ To verify the correctness of import/export conversions:
 HF_MODEL=/path/to/hf/model
 MEGATRON_PATH=/path/to/megatron/ckpt
 
-uv run torchrun --nproc-per-node=8 examples/conversion/hf_megatron_roundtrip_multi_gpu.py \
+uv run python -m torch.distributed.run --nproc-per-node=8 examples/conversion/hf_megatron_roundtrip_multi_gpu.py \
 --hf-model-id $HF_MODEL \
 --megatron-load-path $MEGATRON_PATH \
 --tp 1 \
@@ -106,7 +106,7 @@ To compare outputs between HF and Megatron models:
 HF_MODEL=/path/to/hf/model
 MEGATRON_PATH=/path/to/megatron/ckpt
 
-uv run torchrun --nproc-per-node=8 examples/conversion/compare_hf_and_megatron/compare.py \
+uv run python -m torch.distributed.run --nproc-per-node=8 examples/conversion/compare_hf_and_megatron/compare.py \
 --hf_model_path $HF_MODEL \
 --megatron_model_path $MEGATRON_PATH \
 --prompt "Hello who are " \
@@ -122,7 +122,7 @@ uv run torchrun --nproc-per-node=8 examples/conversion/compare_hf_and_megatron/c
 BLEND_PATH=/path/to/dataset/blend.json
 CHECKPOINT_DIR=/path/to/checkpoints
 
-uv run torchrun --nproc-per-node=8 examples/models/nemotron_3/pretrain_nemotron_3_super.py \
+uv run python -m torch.distributed.run --nproc-per-node=8 examples/models/nemotron_3/pretrain_nemotron_3_super.py \
 --per-split-data-args-path=${BLEND_PATH} \
 logger.wandb_project=your_project \
 logger.wandb_entity=nvidia \
@@ -155,7 +155,7 @@ For quick testing without a dataset:
 ```bash
 CHECKPOINT_DIR=/path/to/checkpoints
 
-uv run torchrun --nproc-per-node=8 examples/models/nemotron_3/pretrain_nemotron_3_super.py \
+uv run python -m torch.distributed.run --nproc-per-node=8 examples/models/nemotron_3/pretrain_nemotron_3_super.py \
 logger.wandb_project=your_project \
 logger.wandb_entity=nvidia \
 checkpoint.load=${CHECKPOINT_DIR} \
@@ -181,7 +181,7 @@ Notes:
 MEGATRON_PATH=/path/to/pretrained/megatron/ckpt
 CHECKPOINT_DIR=/path/to/finetuned/checkpoints
 
-uv run torchrun --nproc-per-node=8 examples/models/nemotron_3/finetune_nemotron_3_super.py \
+uv run python -m torch.distributed.run --nproc-per-node=8 examples/models/nemotron_3/finetune_nemotron_3_super.py \
 logger.wandb_project=your_project \
 logger.wandb_entity=nvidia \
 logger.log_interval=5 \
@@ -210,7 +210,7 @@ To enable LoRA fine-tuning, pass `--peft lora` to the script:
 MEGATRON_PATH=/path/to/pretrained/megatron/ckpt
 CHECKPOINT_DIR=/path/to/lora/checkpoints
 
-uv run torchrun --nproc-per-node=8 examples/models/nemotron_3/finetune_nemotron_3_super.py \
+uv run python -m torch.distributed.run --nproc-per-node=8 examples/models/nemotron_3/finetune_nemotron_3_super.py \
 --peft lora \
 logger.wandb_project=your_project \
 logger.wandb_entity=nvidia \
@@ -255,7 +255,7 @@ Pass the desired config name via `--export-quant-cfg` to `quantize.py`.
 export HF_MODEL=/path/to/hf/model
 export MEGATRON_SAVE_PATH=/path/to/quantized/megatron/ckpt
 
-uv run torchrun --nproc_per_node=8 examples/quantization/quantize.py \
+uv run python -m torch.distributed.run --nproc_per_node=8 examples/quantization/quantize.py \
     --hf-model-id $HF_MODEL \
     --export-quant-cfg mamba_moe_nvfp4_conservative \
     --megatron-save-path $MEGATRON_SAVE_PATH \
@@ -267,7 +267,7 @@ uv run torchrun --nproc_per_node=8 examples/quantization/quantize.py \
 
 ### Verify with PTQ Generate
 ```bash
-uv run torchrun --nproc_per_node=8 examples/quantization/ptq_generate.py \
+uv run python -m torch.distributed.run --nproc_per_node=8 examples/quantization/ptq_generate.py \
     --hf-model-id $HF_MODEL \
     --megatron-load-path $MEGATRON_SAVE_PATH \
     --pp 1 \
@@ -288,7 +288,7 @@ HF_MODEL=/path/to/hf/model
 MEGATRON_LOAD_PATH=/path/to/quantized/megatron/ckpt
 EXPORT_DIR=/path/to/output/hf/ckpt
 
-uv run torchrun --nproc_per_node=8 examples/quantization/export.py \
+uv run python -m torch.distributed.run --nproc_per_node=8 examples/quantization/export.py \
     --hf-model-id $HF_MODEL \
     --megatron-load-path $MEGATRON_LOAD_PATH \
     --export-dir $EXPORT_DIR \
@@ -305,7 +305,7 @@ After quantization, further improve model quality with QAT by continuing trainin
 MEGATRON_PATH=/path/to/quantized/megatron/ckpt
 CHECKPOINT_DIR=/path/to/qat/checkpoints
 
-uv run torchrun --nproc-per-node=8 examples/models/nemotron_3/qat_nemotron_3_super.py \
+uv run python -m torch.distributed.run --nproc-per-node=8 examples/models/nemotron_3/qat_nemotron_3_super.py \
 --megatron-load-path=${MEGATRON_PATH} \
 --seq-length=8192 \
 --packed-sequence \

--- a/docs/models/llm/nemotron3-super.md
+++ b/docs/models/llm/nemotron3-super.md
@@ -59,7 +59,7 @@ without model parallelism.
 HF_MODEL=/path/to/hf/model
 MEGATRON_PATH=/path/to/output/megatron/ckpt
 
-torchrun --nproc-per-node=8 examples/conversion/convert_checkpoints_multi_gpu.py import \
+uv run torchrun --nproc-per-node=8 examples/conversion/convert_checkpoints_multi_gpu.py import \
 --hf-model $HF_MODEL \
 --megatron-path $MEGATRON_PATH \
 --tp 1 \
@@ -76,7 +76,7 @@ HF_MODEL=/path/to/hf/model
 MEGATRON_PATH=/path/to/trained/megatron/ckpt
 OUTPUT_PATH=/path/to/output/hf/ckpt
 
-torchrun --nproc-per-node=8 examples/conversion/convert_checkpoints_multi_gpu.py export \
+uv run torchrun --nproc-per-node=8 examples/conversion/convert_checkpoints_multi_gpu.py export \
 --hf-model $HF_MODEL \
 --megatron-path $MEGATRON_PATH \
 --hf-path $OUTPUT_PATH \
@@ -91,7 +91,7 @@ To verify the correctness of import/export conversions:
 HF_MODEL=/path/to/hf/model
 MEGATRON_PATH=/path/to/megatron/ckpt
 
-torchrun --nproc-per-node=8 examples/conversion/hf_megatron_roundtrip_multi_gpu.py \
+uv run torchrun --nproc-per-node=8 examples/conversion/hf_megatron_roundtrip_multi_gpu.py \
 --hf-model-id $HF_MODEL \
 --megatron-load-path $MEGATRON_PATH \
 --tp 1 \
@@ -106,7 +106,7 @@ To compare outputs between HF and Megatron models:
 HF_MODEL=/path/to/hf/model
 MEGATRON_PATH=/path/to/megatron/ckpt
 
-torchrun --nproc-per-node=8 examples/conversion/compare_hf_and_megatron/compare.py \
+uv run torchrun --nproc-per-node=8 examples/conversion/compare_hf_and_megatron/compare.py \
 --hf_model_path $HF_MODEL \
 --megatron_model_path $MEGATRON_PATH \
 --prompt "Hello who are " \
@@ -122,7 +122,7 @@ torchrun --nproc-per-node=8 examples/conversion/compare_hf_and_megatron/compare.
 BLEND_PATH=/path/to/dataset/blend.json
 CHECKPOINT_DIR=/path/to/checkpoints
 
-torchrun --nproc-per-node=8 examples/models/nemotron_3/pretrain_nemotron_3_super.py \
+uv run torchrun --nproc-per-node=8 examples/models/nemotron_3/pretrain_nemotron_3_super.py \
 --per-split-data-args-path=${BLEND_PATH} \
 logger.wandb_project=your_project \
 logger.wandb_entity=nvidia \
@@ -155,7 +155,7 @@ For quick testing without a dataset:
 ```bash
 CHECKPOINT_DIR=/path/to/checkpoints
 
-torchrun --nproc-per-node=8 examples/models/nemotron_3/pretrain_nemotron_3_super.py \
+uv run torchrun --nproc-per-node=8 examples/models/nemotron_3/pretrain_nemotron_3_super.py \
 logger.wandb_project=your_project \
 logger.wandb_entity=nvidia \
 checkpoint.load=${CHECKPOINT_DIR} \
@@ -181,7 +181,7 @@ Notes:
 MEGATRON_PATH=/path/to/pretrained/megatron/ckpt
 CHECKPOINT_DIR=/path/to/finetuned/checkpoints
 
-torchrun --nproc-per-node=8 examples/models/nemotron_3/finetune_nemotron_3_super.py \
+uv run torchrun --nproc-per-node=8 examples/models/nemotron_3/finetune_nemotron_3_super.py \
 logger.wandb_project=your_project \
 logger.wandb_entity=nvidia \
 logger.log_interval=5 \
@@ -210,7 +210,7 @@ To enable LoRA fine-tuning, pass `--peft lora` to the script:
 MEGATRON_PATH=/path/to/pretrained/megatron/ckpt
 CHECKPOINT_DIR=/path/to/lora/checkpoints
 
-torchrun --nproc-per-node=8 examples/models/nemotron_3/finetune_nemotron_3_super.py \
+uv run torchrun --nproc-per-node=8 examples/models/nemotron_3/finetune_nemotron_3_super.py \
 --peft lora \
 logger.wandb_project=your_project \
 logger.wandb_entity=nvidia \
@@ -255,7 +255,7 @@ Pass the desired config name via `--export-quant-cfg` to `quantize.py`.
 export HF_MODEL=/path/to/hf/model
 export MEGATRON_SAVE_PATH=/path/to/quantized/megatron/ckpt
 
-torchrun --nproc_per_node=8 examples/quantization/quantize.py \
+uv run torchrun --nproc_per_node=8 examples/quantization/quantize.py \
     --hf-model-id $HF_MODEL \
     --export-quant-cfg mamba_moe_nvfp4_conservative \
     --megatron-save-path $MEGATRON_SAVE_PATH \
@@ -267,7 +267,7 @@ torchrun --nproc_per_node=8 examples/quantization/quantize.py \
 
 ### Verify with PTQ Generate
 ```bash
-torchrun --nproc_per_node=8 examples/quantization/ptq_generate.py \
+uv run torchrun --nproc_per_node=8 examples/quantization/ptq_generate.py \
     --hf-model-id $HF_MODEL \
     --megatron-load-path $MEGATRON_SAVE_PATH \
     --pp 1 \
@@ -288,7 +288,7 @@ HF_MODEL=/path/to/hf/model
 MEGATRON_LOAD_PATH=/path/to/quantized/megatron/ckpt
 EXPORT_DIR=/path/to/output/hf/ckpt
 
-torchrun --nproc_per_node=8 examples/quantization/export.py \
+uv run torchrun --nproc_per_node=8 examples/quantization/export.py \
     --hf-model-id $HF_MODEL \
     --megatron-load-path $MEGATRON_LOAD_PATH \
     --export-dir $EXPORT_DIR \
@@ -305,7 +305,7 @@ After quantization, further improve model quality with QAT by continuing trainin
 MEGATRON_PATH=/path/to/quantized/megatron/ckpt
 CHECKPOINT_DIR=/path/to/qat/checkpoints
 
-torchrun --nproc-per-node=8 examples/models/nemotron_3/qat_nemotron_3_super.py \
+uv run torchrun --nproc-per-node=8 examples/models/nemotron_3/qat_nemotron_3_super.py \
 --megatron-load-path=${MEGATRON_PATH} \
 --seq-length=8192 \
 --packed-sequence \

--- a/docs/models/llm/nemotron3.md
+++ b/docs/models/llm/nemotron3.md
@@ -21,7 +21,7 @@ We use the following environment variables throughout this page
 ### Import HF → Megatron
 To import the HF model to your desired `$MEGATRON_MODEL_PATH`, run the following command.
 ```bash
-python examples/conversion/convert_checkpoints.py import  \
+uv run python examples/conversion/convert_checkpoints.py import  \
 --hf-model $HF_MODEL_ID  \
 --megatron-path /path/to/output/megatron/ckpt \
 --trust-remote-code
@@ -29,7 +29,7 @@ python examples/conversion/convert_checkpoints.py import  \
 
 ### Export Megatron → HF
 ```bash
-python examples/conversion/convert_checkpoints.py export  \
+uv run python examples/conversion/convert_checkpoints.py export  \
 --hf-model $HF_MODEL_ID  \
 --megatron-path /path/to/trained/megatron/ckpt \
 --hf-path /path/to/output/hf/ckpt
@@ -40,7 +40,7 @@ python examples/conversion/convert_checkpoints.py export  \
 BLEND_PATH=/path/to/dataset/blend
 TOKENIZER_MODEL=/path/to/tiktok/tokenizer/model
 
-torchrun --nproc-per-node=8 examples/models/nemotron_3/pretrain_nemotron_3_nano.py \
+uv run torchrun --nproc-per-node=8 examples/models/nemotron_3/pretrain_nemotron_3_nano.py \
 --per-split-data-args-path=${BLEND_PATH} \
 --tokenizer-model=${TOKENIZER_MODEL} \
 train.global_batch_size=3072 \
@@ -58,7 +58,7 @@ Notes:
 
 ### Full Parameter Fine-Tuning
 ```bash
-torchrun --nproc-per-node=8 examples/models/nemotron_3/finetune_nemotron_3_nano.py \
+uv run torchrun --nproc-per-node=8 examples/models/nemotron_3/finetune_nemotron_3_nano.py \
 train.global_batch_size=128 \
 train.train_iters=100 \
 scheduler.lr_warmup_iters=10 \
@@ -74,7 +74,7 @@ Notes:
 ### LoRA Fine-Tuning
 To enable LoRA fine-tuning, pass `--peft lora` to script
 ```bash
-torchrun --nproc-per-node=8 examples/models/nemotron_3/finetune_nemotron_3_nano.py \
+uv run torchrun --nproc-per-node=8 examples/models/nemotron_3/finetune_nemotron_3_nano.py \
 --peft lora \
 train.global_batch_size=128 \
 train.train_iters=100 \
@@ -90,7 +90,7 @@ Notes:
 A LoRA checkpoint only contains the learnable adapter weights. In order to convert the LoRA checkpoint to Hugging Face format for downstream evaluation, it is necessary to merge the LoRA adapters back to the base model.
 
 ```bash
-python examples/peft/merge_lora.py \
+uv run python examples/peft/merge_lora.py \
 --hf-model-path $HF_MODEL_ID \
 --lora-checkpoint /path/to/lora/ckpt/iter_xxxxxxx 
 --output /path/to/merged/ckpt

--- a/docs/models/llm/nemotron3.md
+++ b/docs/models/llm/nemotron3.md
@@ -40,7 +40,7 @@ uv run python examples/conversion/convert_checkpoints.py export  \
 BLEND_PATH=/path/to/dataset/blend
 TOKENIZER_MODEL=/path/to/tiktok/tokenizer/model
 
-uv run torchrun --nproc-per-node=8 examples/models/nemotron_3/pretrain_nemotron_3_nano.py \
+uv run python -m torch.distributed.run --nproc-per-node=8 examples/models/nemotron_3/pretrain_nemotron_3_nano.py \
 --per-split-data-args-path=${BLEND_PATH} \
 --tokenizer-model=${TOKENIZER_MODEL} \
 train.global_batch_size=3072 \
@@ -58,7 +58,7 @@ Notes:
 
 ### Full Parameter Fine-Tuning
 ```bash
-uv run torchrun --nproc-per-node=8 examples/models/nemotron_3/finetune_nemotron_3_nano.py \
+uv run python -m torch.distributed.run --nproc-per-node=8 examples/models/nemotron_3/finetune_nemotron_3_nano.py \
 train.global_batch_size=128 \
 train.train_iters=100 \
 scheduler.lr_warmup_iters=10 \
@@ -74,7 +74,7 @@ Notes:
 ### LoRA Fine-Tuning
 To enable LoRA fine-tuning, pass `--peft lora` to script
 ```bash
-uv run torchrun --nproc-per-node=8 examples/models/nemotron_3/finetune_nemotron_3_nano.py \
+uv run python -m torch.distributed.run --nproc-per-node=8 examples/models/nemotron_3/finetune_nemotron_3_nano.py \
 --peft lora \
 train.global_batch_size=128 \
 train.train_iters=100 \

--- a/docs/models/llm/qwen.md
+++ b/docs/models/llm/qwen.md
@@ -63,7 +63,7 @@ model = provider.provide_distributed_model(wrap_with_ddp=False)
 #### Import Checkpoint from HF
 
 ```bash
-python examples/conversion/convert_checkpoints.py import \
+uv run python examples/conversion/convert_checkpoints.py import \
   --hf-model Qwen/Qwen3-Next-80B-A3B-Instruct \
   --megatron-path /checkpoints/qwen3_next_80b_megatron
 ```
@@ -86,7 +86,7 @@ bridge.export_ckpt(
 #### Run Inference on Converted Checkpoint
 
 ```bash
-python examples/conversion/hf_to_megatron_generate_text.py \
+uv run python examples/conversion/hf_to_megatron_generate_text.py \
   --hf_model_path Qwen/Qwen3-Next-80B-A3B-Instruct \
   --megatron_model_path /checkpoints/qwen3_next_80b_megatron \
   --prompt "What is artificial intelligence?" \
@@ -173,7 +173,7 @@ model = provider.provide_distributed_model(wrap_with_ddp=False)
 #### Import Checkpoint from HF
 
 ```bash
-python examples/conversion/convert_checkpoints.py import \
+uv run python examples/conversion/convert_checkpoints.py import \
   --hf-model Qwen/Qwen3-30B-A3B \
   --megatron-path /checkpoints/qwen3_30b_a3b_megatron
 ```
@@ -196,7 +196,7 @@ bridge.export_ckpt(
 #### Run Inference on Converted Checkpoint
 
 ```bash
-python examples/conversion/hf_to_megatron_generate_text.py \
+uv run python examples/conversion/hf_to_megatron_generate_text.py \
   --hf_model_path Qwen/Qwen3-30B-A3B \
   --megatron_model_path /checkpoints/qwen3_30b_a3b_megatron \
   --prompt "What is artificial intelligence?" \
@@ -322,7 +322,7 @@ model = provider.provide_distributed_model(wrap_with_ddp=False)
 #### Import Checkpoint from HF
 
 ```bash
-python examples/conversion/convert_checkpoints.py import \
+uv run python examples/conversion/convert_checkpoints.py import \
   --hf-model Qwen/Qwen3-8B \
   --megatron-path /checkpoints/qwen3_8b_megatron
 ```
@@ -345,7 +345,7 @@ bridge.export_ckpt(
 #### Run Inference on Converted Checkpoint
 
 ```bash
-python examples/conversion/hf_to_megatron_generate_text.py \
+uv run python examples/conversion/hf_to_megatron_generate_text.py \
   --hf_model_path Qwen/Qwen3-8B \
   --megatron_model_path /checkpoints/qwen3_8b_megatron \
   --prompt "What is artificial intelligence?" \
@@ -452,7 +452,7 @@ model = provider.provide_distributed_model(wrap_with_ddp=False)
 #### Import Checkpoint from HF
 
 ```bash
-python examples/conversion/convert_checkpoints.py import \
+uv run python examples/conversion/convert_checkpoints.py import \
   --hf-model Qwen/Qwen2.5-7B \
   --megatron-path /checkpoints/qwen25_7b_megatron
 ```
@@ -475,7 +475,7 @@ bridge.export_ckpt(
 #### Run Inference on Converted Checkpoint
 
 ```bash
-python examples/conversion/hf_to_megatron_generate_text.py \
+uv run python examples/conversion/hf_to_megatron_generate_text.py \
   --hf_model_path Qwen/Qwen2.5-7B \
   --megatron_model_path /checkpoints/qwen25_7b_megatron \
   --prompt "What is artificial intelligence?" \

--- a/docs/models/vlm/nemotron-nano-v2-vl.md
+++ b/docs/models/vlm/nemotron-nano-v2-vl.md
@@ -85,7 +85,7 @@ Example usage for full parameter finetuning using the
 [Raven dataset](https://huggingface.co/datasets/HuggingFaceM4/the_cauldron/viewer/raven):
 
 ```bash
-uv run torchrun --nproc-per-node=8 examples/models/vlm/nemotron_vl/finetune_nemotron_nano_v2_vl.py \
+uv run python -m torch.distributed.run --nproc-per-node=8 examples/models/vlm/nemotron_vl/finetune_nemotron_nano_v2_vl.py \
 --hf-model-path $HF_MODEL_PATH \
 --pretrained-checkpoint <megatron model path> \
 dataset.maker_name=make_raven_dataset \
@@ -110,7 +110,7 @@ settings out of the box in the example script:
    distribution is substantially different from pretrained.)
 
 ```bash
-uv run torchrun --nproc-per-node=8 examples/models/vlm/nemotron_vl/finetune_nemotron_nano_v2_vl.py \
+uv run python -m torch.distributed.run --nproc-per-node=8 examples/models/vlm/nemotron_vl/finetune_nemotron_nano_v2_vl.py \
 --hf-model-path $HF_MODEL_PATH \
 --pretrained-checkpoint $MEGATRON_MODEL_PATH \
 --lora-on-language-model \
@@ -126,7 +126,7 @@ model.freeze_vision_projection=False
 2. Apply LoRA to all linear layers in attention and MLP modules of the vision model, vision projection, and the language model.
 
 ```bash
-uv run torchrun --nproc-per-node=8 examples/models/vlm/nemotron_vl/finetune_nemotron_nano_v2_vl.py \
+uv run python -m torch.distributed.run --nproc-per-node=8 examples/models/vlm/nemotron_vl/finetune_nemotron_nano_v2_vl.py \
 --hf-model-path $HF_MODEL_PATH \
 --pretrained-checkpoint $MEGATRON_MODEL_PATH \
 --lora-on-language-model \
@@ -186,7 +186,7 @@ Note on video training example:
 
 Full video training example command:
 ```bash
-uv run torchrun --nproc-per-node=8 examples/models/vlm/nemotron_vl/finetune_nemotron_nano_v2_vl.py \
+uv run python -m torch.distributed.run --nproc-per-node=8 examples/models/vlm/nemotron_vl/finetune_nemotron_nano_v2_vl.py \
 --hf-model-path $HF_MODEL_PATH \
 --pretrained-checkpoint $MEGATRON_MODEL_PATH \
 --config-file "examples/models/vlm/nemotron_vl/conf/nemotron_nano_v2_vl_video.yaml" \

--- a/docs/models/vlm/nemotron-nano-v2-vl.md
+++ b/docs/models/vlm/nemotron-nano-v2-vl.md
@@ -130,7 +130,7 @@ uv run python -m torch.distributed.run --nproc-per-node=8 examples/models/vlm/ne
 --hf-model-path $HF_MODEL_PATH \
 --pretrained-checkpoint $MEGATRON_MODEL_PATH \
 --lora-on-language-model \
-—-lora-on-vision-model \
+--lora-on-vision-model \
 dataset.maker_name=make_raven_dataset \
 logger.wandb_project=<optional wandb project name> \
 logger.wandb_save_dir=$SAVE_DIR \

--- a/docs/models/vlm/nemotron-nano-v2-vl.md
+++ b/docs/models/vlm/nemotron-nano-v2-vl.md
@@ -31,7 +31,7 @@ Unless explicitly stated, any megatron model path in the commands below should N
 ### Import HF → Megatron
 To import the HF model to your desired `$MEGATRON_MODEL_PATH`, run the following command.
 ```bash
-python examples/conversion/convert_checkpoints.py import \
+uv run python examples/conversion/convert_checkpoints.py import \
 --hf-model $HF_MODEL_PATH \
 --megatron-path $MEGATRON_MODEL_PATH \
 --trust-remote-code
@@ -40,7 +40,7 @@ python examples/conversion/convert_checkpoints.py import \
 ### Export Megatron → HF
 You can export a trained model with the following command.
 ```bash
-python examples/conversion/convert_checkpoints.py export \
+uv run python examples/conversion/convert_checkpoints.py export \
 --hf-model $HF_MODEL_PATH \
 --megatron-path <trained megatron model path> \
 --hf-path <output hf model path> \
@@ -53,7 +53,7 @@ Note: it is normal to see a warning that `vision_model.radio_model.input_conditi
 ### Run In-Framework Inference on Converted Checkpoint
 You can run a quick sanity check on the converted checkpoint with the following command.
 ```bash
-python examples/conversion/hf_to_megatron_generate_vlm.py \
+uv run python examples/conversion/hf_to_megatron_generate_vlm.py \
 --hf_model_path $HF_MODEL_PATH \
 --megatron_model_path $MEGATRON_MODEL_PATH \
 --image_path <example image path> \
@@ -85,7 +85,7 @@ Example usage for full parameter finetuning using the
 [Raven dataset](https://huggingface.co/datasets/HuggingFaceM4/the_cauldron/viewer/raven):
 
 ```bash
-torchrun --nproc-per-node=8 examples/models/vlm/nemotron_vl/finetune_nemotron_nano_v2_vl.py \
+uv run torchrun --nproc-per-node=8 examples/models/vlm/nemotron_vl/finetune_nemotron_nano_v2_vl.py \
 --hf-model-path $HF_MODEL_PATH \
 --pretrained-checkpoint <megatron model path> \
 dataset.maker_name=make_raven_dataset \
@@ -110,7 +110,7 @@ settings out of the box in the example script:
    distribution is substantially different from pretrained.)
 
 ```bash
-torchrun --nproc-per-node=8 examples/models/vlm/nemotron_vl/finetune_nemotron_nano_v2_vl.py \
+uv run torchrun --nproc-per-node=8 examples/models/vlm/nemotron_vl/finetune_nemotron_nano_v2_vl.py \
 --hf-model-path $HF_MODEL_PATH \
 --pretrained-checkpoint $MEGATRON_MODEL_PATH \
 --lora-on-language-model \
@@ -126,7 +126,7 @@ model.freeze_vision_projection=False
 2. Apply LoRA to all linear layers in attention and MLP modules of the vision model, vision projection, and the language model.
 
 ```bash
-torchrun --nproc-per-node=8 examples/models/vlm/nemotron_vl/finetune_nemotron_nano_v2_vl.py \
+uv run torchrun --nproc-per-node=8 examples/models/vlm/nemotron_vl/finetune_nemotron_nano_v2_vl.py \
 --hf-model-path $HF_MODEL_PATH \
 --pretrained-checkpoint $MEGATRON_MODEL_PATH \
 --lora-on-language-model \
@@ -146,7 +146,7 @@ A LoRA checkpoint only contains the learnable adapter weights. In order to conve
 format for downstream evaluation, it is necessary to merge the LoRA adapters back to the base model. 
 
 ```bash
-python examples/peft/merge_lora.py \
+uv run python examples/peft/merge_lora.py \
 --hf-model-path $HF_MODEL_PATH \
 --lora-checkpoint <trained LoRA checkpoint>/iter_N \
 --output <LoRA checkpoint merged>
@@ -186,7 +186,7 @@ Note on video training example:
 
 Full video training example command:
 ```bash
-torchrun --nproc-per-node=8 examples/models/vlm/nemotron_vl/finetune_nemotron_nano_v2_vl.py \
+uv run torchrun --nproc-per-node=8 examples/models/vlm/nemotron_vl/finetune_nemotron_nano_v2_vl.py \
 --hf-model-path $HF_MODEL_PATH \
 --pretrained-checkpoint $MEGATRON_MODEL_PATH \
 --config-file "examples/models/vlm/nemotron_vl/conf/nemotron_nano_v2_vl_video.yaml" \

--- a/docs/models/vlm/qwen2.5-vl.md
+++ b/docs/models/vlm/qwen2.5-vl.md
@@ -20,7 +20,7 @@ Unless explicitly stated, any megatron model path in the commands below should N
 ### Import HF → Megatron
 To import the HF model to your desired `$MEGATRON_MODEL_PATH`, run the following command.
 ```bash
-python examples/conversion/convert_checkpoints.py import \
+uv run python examples/conversion/convert_checkpoints.py import \
 --hf-model $HF_MODEL_PATH \
 --megatron-path $MEGATRON_MODEL_PATH
 ```
@@ -28,7 +28,7 @@ python examples/conversion/convert_checkpoints.py import \
 ### Export Megatron → HF
 You can export a trained model with the following command.
 ```bash
-python examples/conversion/convert_checkpoints.py export \
+uv run python examples/conversion/convert_checkpoints.py export \
 --hf-model $HF_MODEL_PATH \
 --megatron-path <trained megatron model path> \
 --hf-path <output hf model path>
@@ -37,7 +37,7 @@ python examples/conversion/convert_checkpoints.py export \
 ### Run In-Framework Inference on Converted Checkpoint
 You can run a quick sanity check on the converted checkpoint with the following command.
 ```bash
-python examples/conversion/hf_to_megatron_generate_vlm.py \
+uv run python examples/conversion/hf_to_megatron_generate_vlm.py \
 --hf_model_path $HF_MODEL_PATH \
 --megatron_model_path $MEGATRON_MODEL_PATH \
 --image_path <example image path> \
@@ -64,7 +64,7 @@ Before training, ensure the following environment variables are set.
 Example usage for full parameter finetuning:
 
 ```bash
-torchrun --nproc-per-node=8 examples/models/vlm/qwen_vl/finetune_qwen25_vl.py \
+uv run torchrun --nproc-per-node=8 examples/models/vlm/qwen_vl/finetune_qwen25_vl.py \
 --pretrained-checkpoint $MEGATRON_MODEL_PATH \
 --recipe qwen25_vl_3b_finetune_config \
 --dataset-type hf \
@@ -92,7 +92,7 @@ Note:
 Parameter-efficient finetuning (PEFT) using LoRA or DoRA is supported. You can use the `--peft_scheme` argument to enable PEFT training:
 
 ```bash
-torchrun --nproc-per-node=8 examples/models/vlm/qwen_vl/finetune_qwen25_vl.py \
+uv run torchrun --nproc-per-node=8 examples/models/vlm/qwen_vl/finetune_qwen25_vl.py \
 --pretrained-checkpoint $MEGATRON_MODEL_PATH \
 --recipe qwen25_vl_3b_finetune_config \
 --peft_scheme lora \
@@ -112,7 +112,7 @@ You can also combine PEFT with freeze options to control which components are tr
 
 Example with LoRA and freeze options:
 ```bash
-torchrun --nproc-per-node=8 examples/models/vlm/qwen_vl/finetune_qwen25_vl.py \
+uv run torchrun --nproc-per-node=8 examples/models/vlm/qwen_vl/finetune_qwen25_vl.py \
 --pretrained-checkpoint $MEGATRON_MODEL_PATH \
 --recipe qwen25_vl_3b_finetune_config \
 --peft_scheme lora \

--- a/docs/models/vlm/qwen2.5-vl.md
+++ b/docs/models/vlm/qwen2.5-vl.md
@@ -64,7 +64,7 @@ Before training, ensure the following environment variables are set.
 Example usage for full parameter finetuning:
 
 ```bash
-uv run torchrun --nproc-per-node=8 examples/models/vlm/qwen_vl/finetune_qwen25_vl.py \
+uv run python -m torch.distributed.run --nproc-per-node=8 examples/models/vlm/qwen_vl/finetune_qwen25_vl.py \
 --pretrained-checkpoint $MEGATRON_MODEL_PATH \
 --recipe qwen25_vl_3b_finetune_config \
 --dataset-type hf \
@@ -92,7 +92,7 @@ Note:
 Parameter-efficient finetuning (PEFT) using LoRA or DoRA is supported. You can use the `--peft_scheme` argument to enable PEFT training:
 
 ```bash
-uv run torchrun --nproc-per-node=8 examples/models/vlm/qwen_vl/finetune_qwen25_vl.py \
+uv run python -m torch.distributed.run --nproc-per-node=8 examples/models/vlm/qwen_vl/finetune_qwen25_vl.py \
 --pretrained-checkpoint $MEGATRON_MODEL_PATH \
 --recipe qwen25_vl_3b_finetune_config \
 --peft_scheme lora \
@@ -112,7 +112,7 @@ You can also combine PEFT with freeze options to control which components are tr
 
 Example with LoRA and freeze options:
 ```bash
-uv run torchrun --nproc-per-node=8 examples/models/vlm/qwen_vl/finetune_qwen25_vl.py \
+uv run python -m torch.distributed.run --nproc-per-node=8 examples/models/vlm/qwen_vl/finetune_qwen25_vl.py \
 --pretrained-checkpoint $MEGATRON_MODEL_PATH \
 --recipe qwen25_vl_3b_finetune_config \
 --peft_scheme lora \

--- a/docs/nemo2-migration-guide.md
+++ b/docs/nemo2-migration-guide.md
@@ -1751,10 +1751,10 @@ Megatron Bridge supports standard PyTorch distributed execution patterns:
 
 ```bash
 # Direct script execution with torchrun
-python -m torch.distributed.run --nproc_per_node=8 my_training_script.py
+uv run python -m torch.distributed.run --nproc_per_node=8 my_training_script.py
 
 # Multi-node execution
-torchrun --nnodes=4 --nproc_per_node=8 \
+uv run torchrun --nnodes=4 --nproc_per_node=8 \
     --master_addr="node0" --master_port=12345 \
     my_training_script.py
 ```

--- a/docs/nemo2-migration-guide.md
+++ b/docs/nemo2-migration-guide.md
@@ -1754,7 +1754,7 @@ Megatron Bridge supports standard PyTorch distributed execution patterns:
 uv run python -m torch.distributed.run --nproc_per_node=8 my_training_script.py
 
 # Multi-node execution
-uv run torchrun --nnodes=4 --nproc_per_node=8 \
+uv run python -m torch.distributed.run --nnodes=4 --nproc_per_node=8 \
     --master_addr="node0" --master_port=12345 \
     my_training_script.py
 ```

--- a/docs/performance-guide.md
+++ b/docs/performance-guide.md
@@ -637,7 +637,7 @@ export WORLD_SIZE=${SLURM_NNODES:-2}   # number of nodes
 export RANK=${SLURM_NODEID:-0}         # 0..N-1 per node
 
 export OMP_NUM_THREADS=1
-python -u /home/dpsk_a2a/deepep/tests/test_internode.py
+uv run python -u /home/dpsk_a2a/deepep/tests/test_internode.py
 '
 
 ```

--- a/docs/recipe-usage.md
+++ b/docs/recipe-usage.md
@@ -114,7 +114,7 @@ After the above snippet, `cfg` will be updated with all CLI-provided overrides.
 A script containing the above code could be called like so:
 
 ```sh
-torchrun <torchrun arguments> pretrain_cli_overrides.py model.tensor_model_parallel_size=4 train.train_iters=100000 ...
+uv run torchrun <torchrun arguments> pretrain_cli_overrides.py model.tensor_model_parallel_size=4 train.train_iters=100000 ...
 ```
 
 ## Launch methods
@@ -127,7 +127,7 @@ Megatron Bridge training scripts can be launched with the `torchrun` command tha
 Simply specify the number of GPUs to use with `--nproc-per-node` and the number of nodes with `--nnodes`. For example, on a single node:
 
 ```sh
-torchrun --nnodes 1 --nproc-per-node 8 /path/to/train/script.py <args to pretrain script>
+uv run torchrun --nnodes 1 --nproc-per-node 8 /path/to/train/script.py <args to pretrain script>
 ```
 
 For multi-node training, it is recommended to use a cluster orchestration system like SLURM.
@@ -140,7 +140,7 @@ For example, with Slurm, wrap the `torchrun` command inside of `srun`:
 srun --nodes 2 --gpus-per-node 8 \
     --container-image <image tag> --container-mounts <mounts> \
     bash -c "
-        torchrun --nnodes $SLURM_NNODES --nproc-per-node $SLURM_GPUS_PER_NODE /path/to/train/script.py <args to pretrain script>
+        uv run torchrun --nnodes $SLURM_NNODES --nproc-per-node $SLURM_GPUS_PER_NODE /path/to/train/script.py <args to pretrain script>
     "
 ```
 

--- a/docs/recipe-usage.md
+++ b/docs/recipe-usage.md
@@ -114,7 +114,7 @@ After the above snippet, `cfg` will be updated with all CLI-provided overrides.
 A script containing the above code could be called like so:
 
 ```sh
-uv run torchrun <torchrun arguments> pretrain_cli_overrides.py model.tensor_model_parallel_size=4 train.train_iters=100000 ...
+uv run python -m torch.distributed.run <torchrun arguments> pretrain_cli_overrides.py model.tensor_model_parallel_size=4 train.train_iters=100000 ...
 ```
 
 ## Launch methods
@@ -127,7 +127,7 @@ Megatron Bridge training scripts can be launched with the `torchrun` command tha
 Simply specify the number of GPUs to use with `--nproc-per-node` and the number of nodes with `--nnodes`. For example, on a single node:
 
 ```sh
-uv run torchrun --nnodes 1 --nproc-per-node 8 /path/to/train/script.py <args to pretrain script>
+uv run python -m torch.distributed.run --nnodes 1 --nproc-per-node 8 /path/to/train/script.py <args to pretrain script>
 ```
 
 For multi-node training, it is recommended to use a cluster orchestration system like SLURM.
@@ -140,7 +140,7 @@ For example, with Slurm, wrap the `torchrun` command inside of `srun`:
 srun --nodes 2 --gpus-per-node 8 \
     --container-image <image tag> --container-mounts <mounts> \
     bash -c "
-        uv run torchrun --nnodes $SLURM_NNODES --nproc-per-node $SLURM_GPUS_PER_NODE /path/to/train/script.py <args to pretrain script>
+        uv run python -m torch.distributed.run --nnodes $SLURM_NNODES --nproc-per-node $SLURM_GPUS_PER_NODE /path/to/train/script.py <args to pretrain script>
     "
 ```
 

--- a/docs/training/distillation.md
+++ b/docs/training/distillation.md
@@ -57,7 +57,7 @@ uv run -m torch.distributed.run --nproc_per_node=2 examples/distillation/llama/d
 You can provide a custom YAML configuration file to override default settings:
 
 ```bash
-uv run -m torch.distributed.run --nproc_per_node=2 examples/distillation/llama/distill_llama32_3b-1b.py \
+uv run python -m torch.distributed.run --nproc_per_node=2 examples/distillation/llama/distill_llama32_3b-1b.py \
     --config-file my_custom_config.yaml
 ```
 
@@ -66,7 +66,7 @@ uv run -m torch.distributed.run --nproc_per_node=2 examples/distillation/llama/d
 Megatron Bridge supports Hydra-style CLI overrides for flexible configuration:
 
 ```bash
-uv run -m torch.distributed.run --nproc_per_node=2 examples/distillation/llama/distill_llama32_3b-1b.py \
+uv run python -m torch.distributed.run --nproc_per_node=2 examples/distillation/llama/distill_llama32_3b-1b.py \
     model.tensor_model_parallel_size=2 \
     model.teacher.tensor_model_parallel_size=2
 ```

--- a/docs/training/pruning.md
+++ b/docs/training/pruning.md
@@ -39,7 +39,7 @@ huggingface-cli login --token <your token>
 Example: prune Qwen3-8B to 6B on 2 GPUs (Pipeline Parallelism = 2), skipping pruning of `num_attention_heads`. Defaults: 1024 samples from [nemotron-post-training-dataset-v2](https://huggingface.co/datasets/nvidia/Nemotron-Post-Training-Dataset-v2) for calibration, at most 20% depth (`num_layers`) and 40% width per prunable hyperparameter (`hidden_size`, `ffn_hidden_size`, ...), top-10 candidates evaluated for MMLU (5% sampled data) to select the best model.
 
 ```bash
-torchrun --nproc_per_node 2 prune_minitron.py \
+uv run torchrun --nproc_per_node 2 prune_minitron.py \
     --pp_size 2 \
     --hf_model_name_or_path Qwen/Qwen3-8B \
     --prune_target_params 6e9 \
@@ -52,7 +52,7 @@ torchrun --nproc_per_node 2 prune_minitron.py \
 Example: prune Qwen3-8B to a fixed architecture. Defaults: 1024 samples from [nemotron-post-training-dataset-v2](https://huggingface.co/datasets/nvidia/Nemotron-Post-Training-Dataset-v2) for calibration.
 
 ```bash
-torchrun --nproc_per_node 2 prune_minitron.py \
+uv run torchrun --nproc_per_node 2 prune_minitron.py \
     --pp_size 2 \
     --hf_model_name_or_path Qwen/Qwen3-8B \
     --prune_export_config '{"hidden_size": 3584, "ffn_hidden_size": 9216}' \
@@ -62,7 +62,7 @@ torchrun --nproc_per_node 2 prune_minitron.py \
 To see the full list of options for advanced configurations, run:
 
 ```bash
-torchrun --nproc_per_node 1 prune_minitron.py --help
+uv run torchrun --nproc_per_node 1 prune_minitron.py --help
 ```
 
 ### Uneven pipeline parallelism

--- a/docs/training/pruning.md
+++ b/docs/training/pruning.md
@@ -39,7 +39,7 @@ huggingface-cli login --token <your token>
 Example: prune Qwen3-8B to 6B on 2 GPUs (Pipeline Parallelism = 2), skipping pruning of `num_attention_heads`. Defaults: 1024 samples from [nemotron-post-training-dataset-v2](https://huggingface.co/datasets/nvidia/Nemotron-Post-Training-Dataset-v2) for calibration, at most 20% depth (`num_layers`) and 40% width per prunable hyperparameter (`hidden_size`, `ffn_hidden_size`, ...), top-10 candidates evaluated for MMLU (5% sampled data) to select the best model.
 
 ```bash
-uv run torchrun --nproc_per_node 2 prune_minitron.py \
+uv run python -m torch.distributed.run --nproc_per_node 2 prune_minitron.py \
     --pp_size 2 \
     --hf_model_name_or_path Qwen/Qwen3-8B \
     --prune_target_params 6e9 \
@@ -52,7 +52,7 @@ uv run torchrun --nproc_per_node 2 prune_minitron.py \
 Example: prune Qwen3-8B to a fixed architecture. Defaults: 1024 samples from [nemotron-post-training-dataset-v2](https://huggingface.co/datasets/nvidia/Nemotron-Post-Training-Dataset-v2) for calibration.
 
 ```bash
-uv run torchrun --nproc_per_node 2 prune_minitron.py \
+uv run python -m torch.distributed.run --nproc_per_node 2 prune_minitron.py \
     --pp_size 2 \
     --hf_model_name_or_path Qwen/Qwen3-8B \
     --prune_export_config '{"hidden_size": 3584, "ffn_hidden_size": 9216}' \
@@ -62,7 +62,7 @@ uv run torchrun --nproc_per_node 2 prune_minitron.py \
 To see the full list of options for advanced configurations, run:
 
 ```bash
-uv run torchrun --nproc_per_node 1 prune_minitron.py --help
+uv run python -m torch.distributed.run --nproc_per_node 1 prune_minitron.py --help
 ```
 
 ### Uneven pipeline parallelism

--- a/examples/diffusion/recipes/flux/README.md
+++ b/examples/diffusion/recipes/flux/README.md
@@ -2,7 +2,7 @@
 
 This directory contains example scripts for the FLUX diffusion model (text-to-image) with Megatron-Bridge: checkpoint conversion and inference. Pretraining and fine-tuning use the generic `scripts/training/run_recipe.py` entry point.
 
-All commands below assume you run them from the **Megatron-Bridge repository root** unless noted. Use `uv run` when you need the project’s virtualenv (e.g. `uv run python ...`, `uv run torchrun ...`).
+All commands below assume you run them from the **Megatron-Bridge repository root** unless noted. Use `uv run` when you need the project’s virtualenv (e.g. `uv run python ...`, `uv run python -m torch.distributed.run ...`).
 
 ## Workspace Configuration
 
@@ -174,7 +174,7 @@ When prompted, use a train/val/test split such as **8 / 1 / 1**, answer **Y** to
 Use the prepared path as `dataset.path` for pretraining or fine-tuning (see [§4 Pretraining](#4-pretraining) and [§5 Fine-Tuning](#5-fine-tuning)):
 
 ```bash
-uv run torchrun --nproc_per_node=8 scripts/training/run_recipe.py \
+uv run python -m torch.distributed.run --nproc_per_node=8 scripts/training/run_recipe.py \
   --recipe flux_12b_pretrain_config \
   --step_func flux_step \
   dataset.path=/path/to/GRIT/grit_wds/
@@ -193,7 +193,7 @@ From the **Megatron-Bridge repository root**:
 **Mock data (no dataset path):**
 
 ```bash
-uv run torchrun --nproc_per_node=8 scripts/training/run_recipe.py \
+uv run python -m torch.distributed.run --nproc_per_node=8 scripts/training/run_recipe.py \
   --recipe flux_12b_pretrain_config \
   --step_func flux_step
 ```
@@ -201,7 +201,7 @@ uv run torchrun --nproc_per_node=8 scripts/training/run_recipe.py \
 **Real data (WebDataset path):** Set `dataset.path` so the recipe uses real data instead of mock:
 
 ```bash
-uv run torchrun --nproc_per_node=8 scripts/training/run_recipe.py \
+uv run python -m torch.distributed.run --nproc_per_node=8 scripts/training/run_recipe.py \
   --recipe flux_12b_pretrain_config \
   --step_func flux_step \
   dataset.path=${WORKSPACE}/data/my_flux_wds/
@@ -210,7 +210,7 @@ uv run torchrun --nproc_per_node=8 scripts/training/run_recipe.py \
 **With CLI overrides (iters, LR, batch size, etc.):**
 
 ```bash
-uv run torchrun --nproc_per_node=8 scripts/training/run_recipe.py \
+uv run python -m torch.distributed.run --nproc_per_node=8 scripts/training/run_recipe.py \
   --recipe flux_12b_pretrain_config \
   --step_func flux_step \
   dataset.path=${WORKSPACE}/data/my_flux_wds/ \
@@ -232,7 +232,7 @@ Run FLUX fine-tuning with the generic **run_recipe** script. Set the pretrained 
 **Resume / finetune from a checkpoint:**
 
 ```bash
-uv run torchrun --nproc_per_node=8 scripts/training/run_recipe.py \
+uv run python -m torch.distributed.run --nproc_per_node=8 scripts/training/run_recipe.py \
   --recipe flux_12b_sft_config \
   --step_func flux_step \
   checkpoint.pretrained_checkpoint=${WORKSPACE}/checkpoints/flux/flux.1-dev/iter_0000000
@@ -241,7 +241,7 @@ uv run torchrun --nproc_per_node=8 scripts/training/run_recipe.py \
 **With real data and overrides:**
 
 ```bash
-uv run torchrun --nproc_per_node=8 scripts/training/run_recipe.py \
+uv run python -m torch.distributed.run --nproc_per_node=8 scripts/training/run_recipe.py \
   --recipe flux_12b_sft_config \
   --step_func flux_step \
   checkpoint.pretrained_checkpoint=${WORKSPACE}/checkpoints/flux/flux.1-dev/iter_0000000 \

--- a/examples/diffusion/recipes/wan/README-perf-test.md
+++ b/examples/diffusion/recipes/wan/README-perf-test.md
@@ -66,7 +66,7 @@ cd ${DFM_PATH}
 ### 1.3B configuration
 
 ```bash
-NVTE_FUSED_ATTN=1 torchrun --nproc_per_node=8 examples/diffusion/recipes/wan/pretrain_wan.py \
+NVTE_FUSED_ATTN=1 uv run torchrun --nproc_per_node=8 examples/diffusion/recipes/wan/pretrain_wan.py \
   --training-mode pretrain \
   model.tensor_model_parallel_size=1 \
   model.pipeline_model_parallel_size=1 \
@@ -102,7 +102,7 @@ NVTE_FUSED_ATTN=1 torchrun --nproc_per_node=8 examples/diffusion/recipes/wan/pre
 ### 14B configuration
 
 ```bash
-NVTE_FUSED_ATTN=1 torchrun --nproc_per_node=8 examples/diffusion/recipes/wan/pretrain_wan.py \
+NVTE_FUSED_ATTN=1 uv run torchrun --nproc_per_node=8 examples/diffusion/recipes/wan/pretrain_wan.py \
   --training-mode pretrain \
   model.tensor_model_parallel_size=2 \
   model.pipeline_model_parallel_size=1 \
@@ -153,7 +153,7 @@ T5_DIR="/lustre/fsw/coreai_dlalgo_genai/huvu/data/nemo_vfm/wan_checkpoints/t5"
 VAE_DIR="/lustre/fsw/coreai_dlalgo_genai/huvu/data/nemo_vfm/wan_checkpoints/vae"
 CKPT_DIR="/lustre/fsw/coreai_dlalgo_genai/huvu/data/nemo_vfm/datasets/shared_checkpoints/megatron_checkpoint_1.3B"
 
-NVTE_FUSED_ATTN=1 torchrun --nproc_per_node=1 examples/diffusion/recipes/wan/inference_wan.py  \
+NVTE_FUSED_ATTN=1 uv run torchrun --nproc_per_node=1 examples/diffusion/recipes/wan/inference_wan.py  \
   --task t2v-1.3B \
   --sizes 480*832 \
   --checkpoint_dir "${CKPT_DIR}" \

--- a/examples/diffusion/recipes/wan/README-perf-test.md
+++ b/examples/diffusion/recipes/wan/README-perf-test.md
@@ -66,7 +66,7 @@ cd ${DFM_PATH}
 ### 1.3B configuration
 
 ```bash
-NVTE_FUSED_ATTN=1 uv run torchrun --nproc_per_node=8 examples/diffusion/recipes/wan/pretrain_wan.py \
+NVTE_FUSED_ATTN=1 uv run python -m torch.distributed.run --nproc_per_node=8 examples/diffusion/recipes/wan/pretrain_wan.py \
   --training-mode pretrain \
   model.tensor_model_parallel_size=1 \
   model.pipeline_model_parallel_size=1 \
@@ -102,7 +102,7 @@ NVTE_FUSED_ATTN=1 uv run torchrun --nproc_per_node=8 examples/diffusion/recipes/
 ### 14B configuration
 
 ```bash
-NVTE_FUSED_ATTN=1 uv run torchrun --nproc_per_node=8 examples/diffusion/recipes/wan/pretrain_wan.py \
+NVTE_FUSED_ATTN=1 uv run python -m torch.distributed.run --nproc_per_node=8 examples/diffusion/recipes/wan/pretrain_wan.py \
   --training-mode pretrain \
   model.tensor_model_parallel_size=2 \
   model.pipeline_model_parallel_size=1 \
@@ -153,7 +153,7 @@ T5_DIR="/lustre/fsw/coreai_dlalgo_genai/huvu/data/nemo_vfm/wan_checkpoints/t5"
 VAE_DIR="/lustre/fsw/coreai_dlalgo_genai/huvu/data/nemo_vfm/wan_checkpoints/vae"
 CKPT_DIR="/lustre/fsw/coreai_dlalgo_genai/huvu/data/nemo_vfm/datasets/shared_checkpoints/megatron_checkpoint_1.3B"
 
-NVTE_FUSED_ATTN=1 uv run torchrun --nproc_per_node=1 examples/diffusion/recipes/wan/inference_wan.py  \
+NVTE_FUSED_ATTN=1 uv run python -m torch.distributed.run --nproc_per_node=1 examples/diffusion/recipes/wan/inference_wan.py  \
   --task t2v-1.3B \
   --sizes 480*832 \
   --checkpoint_dir "${CKPT_DIR}" \

--- a/examples/diffusion/recipes/wan/README.md
+++ b/examples/diffusion/recipes/wan/README.md
@@ -2,7 +2,7 @@
 
 This directory contains example scripts for [WAN 2.1](https://github.com/Wan-Video/Wan2.1) (text-to-video/image) with Megatron-Bridge: dataset preparation, checkpoint conversion, and inference. Pretraining and fine-tuning use the generic `scripts/training/run_recipe.py` entry point. Built on [Megatron-Core](https://github.com/NVIDIA/Megatron-LM) and [Megatron-Bridge](https://github.com/NVIDIA-NeMo/Megatron-Bridge), it supports advanced parallelism strategies (data, tensor, sequence, and context parallelism) and optimized kernels (e.g., Transformer Engine fused attention).
 
-All commands below assume you run them from the **Megatron-Bridge repository root** unless noted. Use `uv run` when you need the project's virtualenv (e.g. `uv run python ...`, `uv run torchrun ...`).
+All commands below assume you run them from the **Megatron-Bridge repository root** unless noted. Use `uv run` when you need the project's virtualenv (e.g. `uv run python ...`, `uv run python -m torch.distributed.run ...`).
 
 ## Workspace Configuration
 
@@ -45,7 +45,7 @@ export HF_TOKEN=<your_huggingface_token>
 #      --height/--width: resize target (832x480 supported for both 1.3B and 14B)
 #      --center-crop: center crop to exact target size after resize
 #      --mode: process "video" or "frames" of video
-uv run torchrun --nproc_per_node=8 \
+uv run python -m torch.distributed.run --nproc_per_node=8 \
   examples/diffusion/recipes/wan/prepare_dataset_wan.py \
   --video_folder "${DATASET_SRC}" \
   --output_dir "${DATASET_PATH}" \
@@ -145,7 +145,7 @@ WAN uses different flow-matching hyperparameters for pretraining vs fine-tuning.
 ### WAN 1.3B — Mock data (no dataset path):
 
 ```bash
-uv run torchrun --nproc_per_node=8 scripts/training/run_recipe.py \
+uv run python -m torch.distributed.run --nproc_per_node=8 scripts/training/run_recipe.py \
   --recipe wan_1_3b_pretrain_config \
   --step_func wan_step
 ```
@@ -153,7 +153,7 @@ uv run torchrun --nproc_per_node=8 scripts/training/run_recipe.py \
 ### WAN 1.3B — Real data (WebDataset path):
 
 ```bash
-uv run torchrun --nproc_per_node=8 scripts/training/run_recipe.py \
+uv run python -m torch.distributed.run --nproc_per_node=8 scripts/training/run_recipe.py \
   --recipe wan_1_3b_pretrain_config \
   --step_func wan_step \
   dataset.path=${WORKSPACE}/datasets/wan
@@ -162,7 +162,7 @@ uv run torchrun --nproc_per_node=8 scripts/training/run_recipe.py \
 ### With CLI overrides (iters, LR, batch size, parallelism, etc.):
 
 ```bash
-uv run torchrun --nproc_per_node=$NUM_GPUS scripts/training/run_recipe.py \
+uv run python -m torch.distributed.run --nproc_per_node=$NUM_GPUS scripts/training/run_recipe.py \
   --recipe wan_1_3b_pretrain_config \
   --step_func wan_step \
   dataset.path=${WORKSPACE}/datasets/wan \
@@ -185,7 +185,7 @@ For more details, see the recipe in `src/megatron/bridge/diffusion/recipes/wan/w
 The script [inference_wan.py](inference_wan.py) runs text-to-video generation with a Megatron-format WAN checkpoint. Set `--checkpoint_step` to use a specific checkpoint iteration, `--sizes` and `--frame_nums` to specify video shape, and `--sample_steps` (default 50) for the number of noise diffusion steps.
 
 ```bash
-uv run torchrun --nproc_per_node=1 \
+uv run python -m torch.distributed.run --nproc_per_node=1 \
   examples/diffusion/recipes/wan/inference_wan.py \
   --task t2v-1.3B \
   --frame_nums 81 \

--- a/examples/diffusion/recipes/wan/prepare_dataset/openvid1M_dataset/README.md
+++ b/examples/diffusion/recipes/wan/prepare_dataset/openvid1M_dataset/README.md
@@ -48,7 +48,7 @@ Run the dataset preparation script using `torchrun` with 8 GPUs:
 DATASET_SRC=${PROCESSED_DATA_PATH}/OpenVidHD_part_1
 DATASET_PATH=${PROCESSED_DATA_PATH}/prepared_dataset_wds
 
-uv run torchrun --nproc_per_node=8 \
+uv run python -m torch.distributed.run --nproc_per_node=8 \
   examples/diffusion/recipes/wan/prepare_dataset/prepare_dataset_wan.py \
   --video_folder "${DATASET_SRC}" \
   --output_dir "${DATASET_PATH}" \
@@ -72,7 +72,7 @@ DATASET_PATH=${PROCESSED_DATA_PATH}/prepared_dataset_wds
 CHECKPOINT_DIR=<path/to/save/checkpoints>
 EXP_NAME=<experiment_name>
 
-NVTE_FUSED_ATTN=1 uv run torchrun --nproc_per_node=8 scripts/training/run_recipe.py \
+NVTE_FUSED_ATTN=1 uv run python -m torch.distributed.run --nproc_per_node=8 scripts/training/run_recipe.py \
     --recipe wan_1_3b_pretrain_config \
     --step_func wan_step \
     model.tensor_model_parallel_size=1 \

--- a/examples/diffusion/recipes/wan/prepare_dataset/openvid1M_dataset/README.md
+++ b/examples/diffusion/recipes/wan/prepare_dataset/openvid1M_dataset/README.md
@@ -33,7 +33,7 @@ The preprocessing script reads the CSV caption file and creates a sidecar `.json
 
 ```bash
 cd ${MBRIDGE_PATH}
-python examples/diffusion/recipes/wan/prepare_dataset/openvid1M_dataset/openvid1M_preprocess.py \
+uv run python examples/diffusion/recipes/wan/prepare_dataset/openvid1M_dataset/openvid1M_preprocess.py \
   --csv_path ${PROCESSED_DATA_PATH}/OpenVidHD.csv \
   --video_dir ${PROCESSED_DATA_PATH}/OpenVidHD_part_1
 ```
@@ -48,7 +48,7 @@ Run the dataset preparation script using `torchrun` with 8 GPUs:
 DATASET_SRC=${PROCESSED_DATA_PATH}/OpenVidHD_part_1
 DATASET_PATH=${PROCESSED_DATA_PATH}/prepared_dataset_wds
 
-torchrun --nproc_per_node=8 \
+uv run torchrun --nproc_per_node=8 \
   examples/diffusion/recipes/wan/prepare_dataset/prepare_dataset_wan.py \
   --video_folder "${DATASET_SRC}" \
   --output_dir "${DATASET_PATH}" \
@@ -72,7 +72,7 @@ DATASET_PATH=${PROCESSED_DATA_PATH}/prepared_dataset_wds
 CHECKPOINT_DIR=<path/to/save/checkpoints>
 EXP_NAME=<experiment_name>
 
-NVTE_FUSED_ATTN=1 torchrun --nproc_per_node=8 scripts/training/run_recipe.py \
+NVTE_FUSED_ATTN=1 uv run torchrun --nproc_per_node=8 scripts/training/run_recipe.py \
     --recipe wan_1_3b_pretrain_config \
     --step_func wan_step \
     model.tensor_model_parallel_size=1 \

--- a/examples/models/gpt_oss/README.md
+++ b/examples/models/gpt_oss/README.md
@@ -28,7 +28,7 @@ See the [conversion.sh](conversion.sh) script for checkpoint conversion examples
 To import the HF model to your desired Megatron path:
 
 ```bash
-python examples/conversion/convert_checkpoints.py import \
+uv run python examples/conversion/convert_checkpoints.py import \
     --hf-model openai/gpt-oss-20b \
     --megatron-path ${WORKSPACE}/models/gpt-oss-20b \
     --trust-remote-code
@@ -39,7 +39,7 @@ python examples/conversion/convert_checkpoints.py import \
 The export uses `unsloth/gpt-oss-20b-BF16` as the reference so the saved HF checkpoint matches that unquantized format:
 
 ```bash
-python examples/conversion/convert_checkpoints.py export \
+uv run python examples/conversion/convert_checkpoints.py export \
     --hf-model unsloth/gpt-oss-20b-BF16 \
     --megatron-path ${WORKSPACE}/models/gpt-oss-20b/iter_0000000 \
     --hf-path ${WORKSPACE}/models/gpt-oss-20b-hf-export
@@ -50,7 +50,7 @@ python examples/conversion/convert_checkpoints.py export \
 Multi-GPU round-trip validation between formats:
 
 ```bash
-python -m torch.distributed.run --nproc_per_node=8 \
+uv run python -m torch.distributed.run --nproc_per_node=8 \
     examples/conversion/hf_megatron_roundtrip_multi_gpu.py \
     --hf-model-id unsloth/gpt-oss-20b-BF16 \
     --megatron-load-path ${WORKSPACE}/models/gpt-oss-20b/iter_0000000 \

--- a/examples/models/sarvam/README.md
+++ b/examples/models/sarvam/README.md
@@ -28,7 +28,7 @@ See [conversion.sh](conversion.sh) for checkpoint conversion examples.
 ### Import HF → Megatron
 
 ```bash
-python examples/conversion/convert_checkpoints.py import \
+uv run python examples/conversion/convert_checkpoints.py import \
     --hf-model sarvamai/sarvam-30b \
     --megatron-path ${WORKSPACE}/models/sarvam-30b \
     --trust-remote-code
@@ -37,7 +37,7 @@ python examples/conversion/convert_checkpoints.py import \
 ### Export Megatron → HF
 
 ```bash
-python examples/conversion/convert_checkpoints.py export \
+uv run python examples/conversion/convert_checkpoints.py export \
     --hf-model sarvamai/sarvam-30b \
     --megatron-path ${WORKSPACE}/models/sarvam-30b/iter_0000000 \
     --hf-path ${WORKSPACE}/models/sarvam-30b-hf-export
@@ -46,7 +46,7 @@ python examples/conversion/convert_checkpoints.py export \
 ### Round-trip Validation
 
 ```bash
-python -m torch.distributed.run --nproc_per_node=8 \
+uv run python -m torch.distributed.run --nproc_per_node=8 \
     examples/conversion/hf_megatron_roundtrip_multi_gpu.py \
     --hf-model-id sarvamai/sarvam-30b \
     --megatron-load-path ${WORKSPACE}/models/sarvam-30b/iter_0000000 \

--- a/examples/models/vlm/gemma3_vl/README.md
+++ b/examples/models/vlm/gemma3_vl/README.md
@@ -21,14 +21,14 @@ Directory structure:
 ### Import HF → Megatron
 To import the HF VL model to your desired Megatron path:
 ```bash
-python examples/conversion/convert_checkpoints.py import \
+uv run python examples/conversion/convert_checkpoints.py import \
 --hf-model google/gemma-3-4b-it \
 --megatron-path /models/gemma-3-4b-it
 ```
 
 ### Export Megatron → HF
 ```bash
-python examples/conversion/convert_checkpoints.py export \
+uv run python examples/conversion/convert_checkpoints.py export \
 --hf-model google/gemma-3-4b-it \
 --megatron-path /results/gemma3_vl_4b/checkpoints/iter_00001000 \
 --hf-path ./gemma3-vl-hf-export
@@ -42,7 +42,7 @@ See the [conversion.sh](conversion.sh) script for more examples including:
 ### Run Inference on Converted Checkpoint
 
 ```bash
-python examples/conversion/hf_to_megatron_generate_vlm.py \
+uv run python examples/conversion/hf_to_megatron_generate_vlm.py \
 --hf_model_path google/gemma-3-4b-it \
 --megatron_model_path /models/gemma-3-4b-it \
 --image_path <example image path> \

--- a/examples/models/vlm/glm_45v/README.md
+++ b/examples/models/vlm/glm_45v/README.md
@@ -21,14 +21,14 @@ Directory structure:
 ### Import HF → Megatron
 To import the HF VL model to your desired Megatron path:
 ```bash
-python examples/conversion/convert_checkpoints.py import \
+uv run python examples/conversion/convert_checkpoints.py import \
 --hf-model zai-org/GLM-4.5V \
 --megatron-path /models/GLM-4.5V
 ```
 
 ### Export Megatron → HF
 ```bash
-python examples/conversion/convert_checkpoints.py export \
+uv run python examples/conversion/convert_checkpoints.py export \
 --hf-model zai-org/GLM-4.5V \
 --megatron-path /results/glm_45v/checkpoints/iter_00001000 \
 --hf-path ./glm-45v-hf-export
@@ -42,7 +42,7 @@ See the [conversion.sh](conversion.sh) script for more examples including:
 ### Run Inference on Converted Checkpoint
 
 ```bash
-python examples/conversion/hf_to_megatron_generate_vlm.py \
+uv run python examples/conversion/hf_to_megatron_generate_vlm.py \
 --hf_model_path zai-org/GLM-4.5V \
 --megatron_model_path /models/GLM-4.5V \
 --image_path <example image path> \

--- a/examples/models/vlm/ministral3/README.md
+++ b/examples/models/vlm/ministral3/README.md
@@ -21,14 +21,14 @@ Directory structure:
 ### Import HF → Megatron
 To import the HF VL model to your desired Megatron path:
 ```bash
-python examples/conversion/convert_checkpoints.py import \
+uv run python examples/conversion/convert_checkpoints.py import \
   --hf-model mistralai/Ministral-3-3B-Instruct-2512-BF16 \
   --megatron-path ${WORKSPACE}/models/Ministral-3-3B-Instruct-2512-BF16
 ```
 
 ### Export Megatron → HF
 ```bash
-python examples/conversion/convert_checkpoints.py export \
+uv run python examples/conversion/convert_checkpoints.py export \
   --hf-model mistralai/Ministral-3-3B-Instruct-2512-BF16 \
   --megatron-path ${WORKSPACE}/models/Ministral-3-3B-Instruct-2512-BF16/iter_0000000 \
   --hf-path ${WORKSPACE}/models/Ministral-3-3B-Instruct-2512-BF16-hf-export
@@ -39,7 +39,7 @@ python examples/conversion/convert_checkpoints.py export \
 ### Run Inference on Converted Checkpoint
 
 ```bash
-python examples/conversion/hf_to_megatron_generate_vlm.py \
+uv run python examples/conversion/hf_to_megatron_generate_vlm.py \
   --hf_model_path mistralai/Ministral-3-3B-Instruct-2512-BF16 \
   --megatron_model_path ${WORKSPACE}/models/Ministral-3-3B-Instruct-2512-BF16/iter_0000000 \
   --image_path "https://huggingface.co/nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16/resolve/main/images/table.png" \

--- a/examples/models/vlm/qwen25_omni/README.md
+++ b/examples/models/vlm/qwen25_omni/README.md
@@ -40,7 +40,7 @@ See [conversion.sh](conversion.sh) for checkpoint conversion examples.
 ### Import HF → Megatron
 
 ```bash
-python examples/conversion/convert_checkpoints.py import \
+uv run python examples/conversion/convert_checkpoints.py import \
     --hf-model Qwen/Qwen2.5-Omni-7B \
     --megatron-path ${WORKSPACE}/models/Qwen2.5-Omni-7B
 ```
@@ -48,7 +48,7 @@ python examples/conversion/convert_checkpoints.py import \
 ### Export Megatron → HF
 
 ```bash
-python examples/conversion/convert_checkpoints.py export \
+uv run python examples/conversion/convert_checkpoints.py export \
     --hf-model Qwen/Qwen2.5-Omni-7B \
     --megatron-path ${WORKSPACE}/models/Qwen2.5-Omni-7B/iter_0000000 \
     --hf-path ${WORKSPACE}/models/Qwen2.5-Omni-7B-hf-export
@@ -57,7 +57,7 @@ python examples/conversion/convert_checkpoints.py export \
 ### Round-trip Validation
 
 ```bash
-python -m torch.distributed.run --nproc_per_node=2 \
+uv run python -m torch.distributed.run --nproc_per_node=2 \
     examples/conversion/hf_megatron_roundtrip_multi_gpu.py \
     --hf-model-id Qwen/Qwen2.5-Omni-7B \
     --megatron-load-path ${WORKSPACE}/models/Qwen2.5-Omni-7B/iter_0000000 \

--- a/examples/models/vlm/qwen35_vl/README.md
+++ b/examples/models/vlm/qwen35_vl/README.md
@@ -21,14 +21,14 @@ Directory structure:
 ### Import HF → Megatron
 To import the HF VL model to your desired Megatron path:
 ```bash
-python examples/conversion/convert_checkpoints.py import \
+uv run python examples/conversion/convert_checkpoints.py import \
   --hf-model Qwen/Qwen3.5-35B-A3B \
   --megatron-path ${WORKSPACE}/models/Qwen/Qwen3.5-35B-A3B
 ```
 
 ### Export Megatron → HF
 ```bash
-python examples/conversion/convert_checkpoints.py export \
+uv run python examples/conversion/convert_checkpoints.py export \
   --hf-model Qwen/Qwen3.5-35B-A3B \
   --megatron-path ${WORKSPACE}/models/Qwen/Qwen3.5-35B-A3B/iter_0000000 \
   --hf-path ${WORKSPACE}/models/Qwen/Qwen3.5-35B-A3B-hf-export
@@ -41,7 +41,7 @@ See the [conversion.sh](conversion.sh) script for more examples including multi-
 ### Run Inference on Converted Checkpoint
 
 ```bash
-python -m torch.distributed.run --nproc_per_node=8 examples/conversion/hf_to_megatron_generate_vlm.py \
+uv run python -m torch.distributed.run --nproc_per_node=8 examples/conversion/hf_to_megatron_generate_vlm.py \
   --hf_model_path Qwen/Qwen3.5-35B-A3B \
   --megatron_model_path ${WORKSPACE}/models/Qwen/Qwen3.5-35B-A3B/iter_0000000 \
   --image_path "https://huggingface.co/nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16/resolve/main/images/table.png" \

--- a/examples/models/vlm/qwen3_vl/README.md
+++ b/examples/models/vlm/qwen3_vl/README.md
@@ -21,14 +21,14 @@ Directory structure:
 ### Import HF → Megatron
 To import the HF VL model to your desired Megatron path:
 ```bash
-python examples/conversion/convert_checkpoints.py import \
+uv run python examples/conversion/convert_checkpoints.py import \
   --hf-model Qwen/Qwen3-VL-8B-Instruct \
   --megatron-path ${WORKSPACE}/models/Qwen3-VL-8B-Instruct
 ```
 
 ### Export Megatron → HF
 ```bash
-python examples/conversion/convert_checkpoints.py export \
+uv run python examples/conversion/convert_checkpoints.py export \
   --hf-model Qwen/Qwen3-VL-8B-Instruct \
   --megatron-path ${WORKSPACE}/models/Qwen3-VL-8B-Instruct/iter_0000000 \
   --hf-path ${WORKSPACE}/models/Qwen3-VL-8B-Instruct-hf-export
@@ -39,7 +39,7 @@ python examples/conversion/convert_checkpoints.py export \
 ### Run Inference on Converted Checkpoint
 
 ```bash
-python -m torch.distributed.run --nproc_per_node=4 examples/conversion/hf_to_megatron_generate_vlm.py \
+uv run python -m torch.distributed.run --nproc_per_node=4 examples/conversion/hf_to_megatron_generate_vlm.py \
   --hf_model_path Qwen/Qwen3-VL-8B-Instruct \
   --megatron_model_path ${WORKSPACE}/models/Qwen3-VL-8B-Instruct/iter_0000000 \
   --image_path "https://huggingface.co/nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16/resolve/main/images/table.png" \

--- a/examples/quantization/README.md
+++ b/examples/quantization/README.md
@@ -18,7 +18,7 @@ The quantization examples demonstrate how to:
 Quantize LLM:
 
 ```bash
-uv run torchrun --nproc_per_node 2 examples/quantization/quantize.py \
+uv run python -m torch.distributed.run --nproc_per_node 2 examples/quantization/quantize.py \
     --hf-model-id meta-llama/Llama-3.2-1B \
     --export-quant-cfg fp8 \
     --tp 2 \
@@ -28,7 +28,7 @@ uv run torchrun --nproc_per_node 2 examples/quantization/quantize.py \
 Quantize VLM:
 
 ```bash
-uv run torchrun --nproc_per_node 8 examples/quantization/quantize_vlm.py \
+uv run python -m torch.distributed.run --nproc_per_node 8 examples/quantization/quantize_vlm.py \
     --hf-model-id Qwen/Qwen3-VL-30B-A3B-Instruct \
     --export-quant-cfg fp8 \
     --megatron-save-path ./Qwen3-VL-30B-A3B-Instruct_fp8 \
@@ -42,7 +42,7 @@ uv run torchrun --nproc_per_node 8 examples/quantization/quantize_vlm.py \
 Resume and generate with quantized LLM:
 
 ```bash
-uv run torchrun --nproc_per_node 2 examples/quantization/ptq_generate.py \
+uv run python -m torch.distributed.run --nproc_per_node 2 examples/quantization/ptq_generate.py \
     --hf-model-id meta-llama/Llama-3.2-1B \
     --megatron-load-path ./llama3_2_1b_fp8 \
     --tp 2
@@ -51,7 +51,7 @@ uv run torchrun --nproc_per_node 2 examples/quantization/ptq_generate.py \
 Resume and generate with quantized VLM:
 
 ```bash
-uv run torchrun --nproc_per_node 8 examples/quantization/ptq_generate_vlm.py \
+uv run python -m torch.distributed.run --nproc_per_node 8 examples/quantization/ptq_generate_vlm.py \
     --hf-model-id Qwen/Qwen3-VL-30B-A3B-Instruct \
     --megatron-load-path ./Qwen3-VL-30B-A3B-Instruct_fp8 \
     --tp 8 \
@@ -65,7 +65,7 @@ uv run torchrun --nproc_per_node 8 examples/quantization/ptq_generate_vlm.py \
 Train quantized model (requires a checkpoint from [PTQ](#1-post-training-quantization-ptq)) for better accuracy:
 
 ```bash
-uv run torchrun pretrain_quantized_llama3_8b.py \
+uv run python -m torch.distributed.run pretrain_quantized_llama3_8b.py \
     --nproc_per_node 4 \
     model.tensor_model_parallel_size=4 \
     model.gradient_accumulation_fusion=False \
@@ -77,7 +77,7 @@ uv run torchrun pretrain_quantized_llama3_8b.py \
 Export unified Huggingface checkpoint:
 
 ```bash
-uv run torchrun --nproc_per_node 2 examples/quantization/export.py \
+uv run python -m torch.distributed.run --nproc_per_node 2 examples/quantization/export.py \
     --hf-model-id meta-llama/Llama-3.2-1B \
     --megatron-load-path ./llama3_2_1b_fp8 \
     --export-dir ./llama3_2_1b_fp8_hf \

--- a/examples/quantization/README.md
+++ b/examples/quantization/README.md
@@ -18,7 +18,7 @@ The quantization examples demonstrate how to:
 Quantize LLM:
 
 ```bash
-torchrun --nproc_per_node 2 examples/quantization/quantize.py \
+uv run torchrun --nproc_per_node 2 examples/quantization/quantize.py \
     --hf-model-id meta-llama/Llama-3.2-1B \
     --export-quant-cfg fp8 \
     --tp 2 \
@@ -28,7 +28,7 @@ torchrun --nproc_per_node 2 examples/quantization/quantize.py \
 Quantize VLM:
 
 ```bash
-torchrun --nproc_per_node 8 examples/quantization/quantize_vlm.py \
+uv run torchrun --nproc_per_node 8 examples/quantization/quantize_vlm.py \
     --hf-model-id Qwen/Qwen3-VL-30B-A3B-Instruct \
     --export-quant-cfg fp8 \
     --megatron-save-path ./Qwen3-VL-30B-A3B-Instruct_fp8 \
@@ -42,7 +42,7 @@ torchrun --nproc_per_node 8 examples/quantization/quantize_vlm.py \
 Resume and generate with quantized LLM:
 
 ```bash
-torchrun --nproc_per_node 2 examples/quantization/ptq_generate.py \
+uv run torchrun --nproc_per_node 2 examples/quantization/ptq_generate.py \
     --hf-model-id meta-llama/Llama-3.2-1B \
     --megatron-load-path ./llama3_2_1b_fp8 \
     --tp 2
@@ -51,7 +51,7 @@ torchrun --nproc_per_node 2 examples/quantization/ptq_generate.py \
 Resume and generate with quantized VLM:
 
 ```bash
-torchrun --nproc_per_node 8 examples/quantization/ptq_generate_vlm.py \
+uv run torchrun --nproc_per_node 8 examples/quantization/ptq_generate_vlm.py \
     --hf-model-id Qwen/Qwen3-VL-30B-A3B-Instruct \
     --megatron-load-path ./Qwen3-VL-30B-A3B-Instruct_fp8 \
     --tp 8 \
@@ -65,7 +65,7 @@ torchrun --nproc_per_node 8 examples/quantization/ptq_generate_vlm.py \
 Train quantized model (requires a checkpoint from [PTQ](#1-post-training-quantization-ptq)) for better accuracy:
 
 ```bash
-torchrun pretrain_quantized_llama3_8b.py \
+uv run torchrun pretrain_quantized_llama3_8b.py \
     --nproc_per_node 4 \
     model.tensor_model_parallel_size=4 \
     model.gradient_accumulation_fusion=False \
@@ -77,7 +77,7 @@ torchrun pretrain_quantized_llama3_8b.py \
 Export unified Huggingface checkpoint:
 
 ```bash
-torchrun --nproc_per_node 2 examples/quantization/export.py \
+uv run torchrun --nproc_per_node 2 examples/quantization/export.py \
     --hf-model-id meta-llama/Llama-3.2-1B \
     --megatron-load-path ./llama3_2_1b_fp8 \
     --export-dir ./llama3_2_1b_fp8_hf \

--- a/scripts/performance/README.md
+++ b/scripts/performance/README.md
@@ -40,7 +40,7 @@ There are configuration files- `workload_base_configs.py` for supported models i
 
 The following line shows an example of how you can launch a pre-training benchmark/experiment-
 
-`python scripts/performance/setup_experiment.py --account <your_slurm_account> --partition <your_slurm_partition> --gpu gb200 --model_family_name <model name> --model_recipe_name <model_recipe_name> -ng <num gpus>`
+`uv run python scripts/performance/setup_experiment.py --account <your_slurm_account> --partition <your_slurm_partition> --gpu gb200 --model_family_name <model name> --model_recipe_name <model_recipe_name> -ng <num gpus>`
 
 You can also create a bash file to define the experiment arguments and launch it. For e.g. The bash file will look as follows-
 
@@ -51,7 +51,7 @@ MBRIDGE_PATH="</path/to/mbridge>"
 JOB_NAME="dsv3_gb300"
 RESULTS_DIR="${MBRIDGE_PATH}/results/${JOB_NAME}"
 
-python scripts/performance/setup_experiment.py 
+uv run python scripts/performance/setup_experiment.py 
   --account <slurm_account> \
   -i ${CONTAINER} \
   --partition <slurm_partition> \

--- a/scripts/performance/README.md
+++ b/scripts/performance/README.md
@@ -51,7 +51,7 @@ MBRIDGE_PATH="</path/to/mbridge>"
 JOB_NAME="dsv3_gb300"
 RESULTS_DIR="${MBRIDGE_PATH}/results/${JOB_NAME}"
 
-uv run python scripts/performance/setup_experiment.py 
+uv run python scripts/performance/setup_experiment.py \
   --account <slurm_account> \
   -i ${CONTAINER} \
   --partition <slurm_partition> \

--- a/scripts/training/README.md
+++ b/scripts/training/README.md
@@ -102,7 +102,7 @@ pip install nemo-run
 Before launching on Slurm, test your configuration locally:
 
 ```bash
-python launch_with_nemo_run.py \
+uv run python launch_with_nemo_run.py \
     --local \
     --script run_recipe.py \
     --recipe llama32_1b_pretrain_config \
@@ -119,7 +119,7 @@ Once tested, scale to Slurm by removing `--local` and adding Slurm parameters:
 
 ```bash
 # From the cluster (LocalTunnel)
-python launch_with_nemo_run.py \
+uv run python launch_with_nemo_run.py \
     --script run_recipe.py \
     --recipe llama32_1b_pretrain_config \
     --nodes 2 \
@@ -128,7 +128,7 @@ python launch_with_nemo_run.py \
     --account my_account
 
 # From your local machine (SSHTunnel)
-python launch_with_nemo_run.py \
+uv run python launch_with_nemo_run.py \
     --script run_recipe.py \
     --recipe llama32_1b_pretrain_config \
     --nodes 2 \
@@ -146,7 +146,7 @@ python launch_with_nemo_run.py \
 When using containers, scripts are automatically packaged using `PatternPackager`:
 
 ```bash
-python launch_with_nemo_run.py \
+uv run python launch_with_nemo_run.py \
     --script run_recipe.py \
     --recipe qwen3_8b_pretrain_config \
     --nodes 4 \
@@ -162,7 +162,7 @@ python launch_with_nemo_run.py \
 > the container.
 
 ```bash
-python launch_with_nemo_run.py \
+uv run python launch_with_nemo_run.py \
     --script run_recipe.py \
     --recipe llama32_1b_pretrain_config \
     --nodes 2 \
@@ -180,7 +180,7 @@ run from the container workspace.
 For git-based packaging:
 
 ```bash
-python launch_with_nemo_run.py \
+uv run python launch_with_nemo_run.py \
     --script run_recipe.py \
     --recipe llama3_8b_pretrain_config \
     --nodes 2 \
@@ -195,7 +195,7 @@ python launch_with_nemo_run.py \
 Use the fault-tolerant launcher for better resiliency:
 
 ```bash
-python launch_with_nemo_run.py \
+uv run python launch_with_nemo_run.py \
     --script run_recipe.py \
     --recipe llama32_1b_pretrain_config \
     --launcher ft \

--- a/scripts/training/README.md
+++ b/scripts/training/README.md
@@ -25,13 +25,13 @@ uv run python run_recipe.py --recipe llama32_1b_pretrain_config
 ### Pretrain (multi-GPU)
 
 ```bash
-uv run torchrun --nproc_per_node=8 run_recipe.py --recipe llama32_1b_pretrain_config
+uv run python -m torch.distributed.run --nproc_per_node=8 run_recipe.py --recipe llama32_1b_pretrain_config
 ```
 
 ### Finetune
 
 ```bash
-uv run torchrun --nproc_per_node=8 run_recipe.py --recipe llama32_1b_sft_config
+uv run python -m torch.distributed.run --nproc_per_node=8 run_recipe.py --recipe llama32_1b_sft_config
 ```
 
 ## Usage with Different Models
@@ -40,16 +40,16 @@ Same scripts work across all model families:
 
 ```bash
 # Llama
-uv run torchrun --nproc_per_node=8 run_recipe.py --recipe llama32_1b_pretrain_config
+uv run python -m torch.distributed.run --nproc_per_node=8 run_recipe.py --recipe llama32_1b_pretrain_config
 
 # Gemma
-uv run torchrun --nproc_per_node=8 run_recipe.py --recipe gemma3_1b_pretrain_config
+uv run python -m torch.distributed.run --nproc_per_node=8 run_recipe.py --recipe gemma3_1b_pretrain_config
 
 # Qwen
-uv run torchrun --nproc_per_node=8 run_recipe.py --recipe qwen3_8b_pretrain_config
+uv run python -m torch.distributed.run --nproc_per_node=8 run_recipe.py --recipe qwen3_8b_pretrain_config
 
 # GPT
-uv run torchrun --nproc_per_node=8 run_recipe.py --recipe gpt_126m_pretrain_config
+uv run python -m torch.distributed.run --nproc_per_node=8 run_recipe.py --recipe gpt_126m_pretrain_config
 ```
 
 ## CLI Overrides
@@ -57,7 +57,7 @@ uv run torchrun --nproc_per_node=8 run_recipe.py --recipe gpt_126m_pretrain_conf
 Override any config field using dot notation:
 
 ```bash
-uv run torchrun --nproc_per_node=8 run_recipe.py \
+uv run python -m torch.distributed.run --nproc_per_node=8 run_recipe.py \
     --recipe llama32_1b_pretrain_config \
     train.train_iters=5000 \
     optimizer.lr=0.0002 \
@@ -82,7 +82,7 @@ Use `--step_func` to control the step function used during training. Available o
 - `llava_step` - LLaVA models
 
 ```bash
-uv run torchrun --nproc_per_node=8 run_recipe.py \
+uv run python -m torch.distributed.run --nproc_per_node=8 run_recipe.py \
     --recipe qwen25_vl_pretrain_config \
     --step_func vlm_step
 ```

--- a/skills/recipe-recommender/SKILL.md
+++ b/skills/recipe-recommender/SKILL.md
@@ -24,17 +24,17 @@ config, adjust parallelism, and avoid common pitfalls.
 
 ```bash
 # Pretrain with mock data
-uv run torchrun --nproc_per_node=8 scripts/training/run_recipe.py \
+uv run python -m torch.distributed.run --nproc_per_node=8 scripts/training/run_recipe.py \
     --recipe <recipe_function_name> \
     --dataset llm-pretrain-mock
 
 # SFT with SQuAD
-uv run torchrun --nproc_per_node=8 scripts/training/run_recipe.py \
+uv run python -m torch.distributed.run --nproc_per_node=8 scripts/training/run_recipe.py \
     --recipe <recipe_function_name> \
     --dataset llm-finetune
 
 # Override any field via CLI
-uv run torchrun --nproc_per_node=8 scripts/training/run_recipe.py \
+uv run python -m torch.distributed.run --nproc_per_node=8 scripts/training/run_recipe.py \
     --recipe llama3_8b_pretrain_config \
     --dataset llm-pretrain-mock \
     'model.tensor_model_parallel_size=2' \
@@ -355,25 +355,25 @@ When the user's GPU count differs from the recipe default:
 
 ```bash
 # Scale Llama3 8B from 2 GPUs to 8 GPUs (increase DP)
-uv run torchrun --nproc_per_node=8 scripts/training/run_recipe.py \
+uv run python -m torch.distributed.run --nproc_per_node=8 scripts/training/run_recipe.py \
     --recipe llama3_8b_pretrain_config \
     --dataset llm-pretrain-mock
 
 # Reduce parallelism for Qwen3-MoE 30B to fit on 4 GPUs
-uv run torchrun --nproc_per_node=4 scripts/training/run_recipe.py \
+uv run python -m torch.distributed.run --nproc_per_node=4 scripts/training/run_recipe.py \
     --recipe qwen3_30b_a3b_sft_config \
     --dataset llm-finetune \
     'model.expert_model_parallel_size=4'
 
 # Add long context to an existing recipe
-uv run torchrun --nproc_per_node=8 scripts/training/run_recipe.py \
+uv run python -m torch.distributed.run --nproc_per_node=8 scripts/training/run_recipe.py \
     --recipe llama3_8b_pretrain_config \
     --dataset llm-pretrain-mock \
     'model.seq_length=32768' \
     'model.context_parallel_size=4'
 
 # Enable CUDA graphs on any recipe
-uv run torchrun --nproc_per_node=8 scripts/training/run_recipe.py \
+uv run python -m torch.distributed.run --nproc_per_node=8 scripts/training/run_recipe.py \
     --recipe qwen3_30b_a3b_pretrain_config \
     --dataset llm-pretrain-mock \
     'model.cuda_graph_impl=transformer_engine' \

--- a/tutorials/recipes/llama/README.md
+++ b/tutorials/recipes/llama/README.md
@@ -7,7 +7,7 @@ This guide shows you how to pretrain and finetune Llama models using Megatron Br
 The fastest way to get started with Megatron Bridge pretraining:
 
 ```bash
-torchrun --nproc_per_node=1 00_quickstart_pretrain.py
+uv run torchrun --nproc_per_node=1 00_quickstart_pretrain.py
 ```
 
 This runs Llama 3.2 1B pretraining on a single GPU with mock data.
@@ -17,7 +17,7 @@ For finetuning, you first need a checkpoint in Megatron format. Convert from Hug
 > **Note:** You must be authenticated with Hugging Face to download the model. Run `hf auth login --token $HF_TOKEN` if needed.
 
 ```bash
-python ../../conversion/convert_checkpoints.py import \
+uv run python ../../conversion/convert_checkpoints.py import \
     --hf-model meta-llama/Llama-3.2-1B \
     --megatron-path ./checkpoints/llama32_1b
 ```
@@ -25,7 +25,7 @@ python ../../conversion/convert_checkpoints.py import \
 Then run finetuning:
 
 ```bash
-torchrun --nproc_per_node=1 01_quickstart_finetune.py \
+uv run torchrun --nproc_per_node=1 01_quickstart_finetune.py \
     --pretrained-checkpoint ./checkpoints/llama32_1b
 ```
 
@@ -56,7 +56,7 @@ The recipes include optional support for YAML configuration and dot-notation ove
 To use the provided YAML system:
 
 ```bash
-torchrun --nproc_per_node=2 02_pretrain_with_yaml.py \
+uv run torchrun --nproc_per_node=2 02_pretrain_with_yaml.py \
     --config-file conf/llama32_1b_pretrain.yaml
 ```
 
@@ -93,7 +93,7 @@ Command-Line Overrides:
 You can override values using dot notation (`section.field=value`):
 
 ```bash
-torchrun --nproc_per_node=2 02_pretrain_with_yaml.py \
+uv run torchrun --nproc_per_node=2 02_pretrain_with_yaml.py \
     --config-file conf/llama32_1b_pretrain.yaml \
     train.train_iters=5000 \
     train.global_batch_size=512 \
@@ -110,7 +110,7 @@ Priority order (highest to lowest):
 For more complex finetuning configurations:
 
 ```bash
-torchrun --nproc_per_node=2 03_finetune_with_yaml.py \
+uv run torchrun --nproc_per_node=2 03_finetune_with_yaml.py \
     --config-file conf/llama32_1b_finetune.yaml
 ```
 
@@ -145,7 +145,7 @@ optimizer:                        # OptimizerConfig
 Full Finetuning (No LoRA)
 
 ```bash
-torchrun --nproc_per_node=2 03_finetune_with_yaml.py \
+uv run torchrun --nproc_per_node=2 03_finetune_with_yaml.py \
     --peft none \
     train.train_iters=1000
 ```
@@ -183,7 +183,7 @@ pip install nemo-run
 From the Slurm cluster login node:
 
 ```bash
-python 04_launch_slurm_with_nemo_run.py \
+uv run python 04_launch_slurm_with_nemo_run.py \
     --script 00_quickstart_pretrain.py \
     --nodes 2 \
     --devices 8 \
@@ -194,7 +194,7 @@ python 04_launch_slurm_with_nemo_run.py \
 From your local machine (SSHTunnel):
 
 ```bash
-python 04_launch_slurm_with_nemo_run.py \
+uv run python 04_launch_slurm_with_nemo_run.py \
     --script 00_quickstart_pretrain.py \
     --nodes 2 \
     --devices 8 \
@@ -209,7 +209,7 @@ python 04_launch_slurm_with_nemo_run.py \
 With custom config:
 
 ```bash
-python 04_launch_slurm_with_nemo_run.py \
+uv run python 04_launch_slurm_with_nemo_run.py \
     --script 03_finetune_with_yaml.py \
     --nodes 1 \
     --devices 8 \

--- a/tutorials/recipes/llama/README.md
+++ b/tutorials/recipes/llama/README.md
@@ -7,7 +7,7 @@ This guide shows you how to pretrain and finetune Llama models using Megatron Br
 The fastest way to get started with Megatron Bridge pretraining:
 
 ```bash
-uv run torchrun --nproc_per_node=1 00_quickstart_pretrain.py
+uv run python -m torch.distributed.run --nproc_per_node=1 00_quickstart_pretrain.py
 ```
 
 This runs Llama 3.2 1B pretraining on a single GPU with mock data.
@@ -25,7 +25,7 @@ uv run python ../../conversion/convert_checkpoints.py import \
 Then run finetuning:
 
 ```bash
-uv run torchrun --nproc_per_node=1 01_quickstart_finetune.py \
+uv run python -m torch.distributed.run --nproc_per_node=1 01_quickstart_finetune.py \
     --pretrained-checkpoint ./checkpoints/llama32_1b
 ```
 
@@ -56,7 +56,7 @@ The recipes include optional support for YAML configuration and dot-notation ove
 To use the provided YAML system:
 
 ```bash
-uv run torchrun --nproc_per_node=2 02_pretrain_with_yaml.py \
+uv run python -m torch.distributed.run --nproc_per_node=2 02_pretrain_with_yaml.py \
     --config-file conf/llama32_1b_pretrain.yaml
 ```
 
@@ -93,7 +93,7 @@ Command-Line Overrides:
 You can override values using dot notation (`section.field=value`):
 
 ```bash
-uv run torchrun --nproc_per_node=2 02_pretrain_with_yaml.py \
+uv run python -m torch.distributed.run --nproc_per_node=2 02_pretrain_with_yaml.py \
     --config-file conf/llama32_1b_pretrain.yaml \
     train.train_iters=5000 \
     train.global_batch_size=512 \
@@ -110,7 +110,7 @@ Priority order (highest to lowest):
 For more complex finetuning configurations:
 
 ```bash
-uv run torchrun --nproc_per_node=2 03_finetune_with_yaml.py \
+uv run python -m torch.distributed.run --nproc_per_node=2 03_finetune_with_yaml.py \
     --config-file conf/llama32_1b_finetune.yaml
 ```
 
@@ -145,7 +145,7 @@ optimizer:                        # OptimizerConfig
 Full Finetuning (No LoRA)
 
 ```bash
-uv run torchrun --nproc_per_node=2 03_finetune_with_yaml.py \
+uv run python -m torch.distributed.run --nproc_per_node=2 03_finetune_with_yaml.py \
     --peft none \
     train.train_iters=1000
 ```


### PR DESCRIPTION
# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated all documented command examples across guides and tutorials to prefix Python and distributed training invocations with `uv run` (e.g., `python ...` → `uv run python ...`, `torchrun ...` → `uv run torchrun ...`).
  * Affected checkpoint conversion, inference, finetuning, quantization, and performance testing examples.
  * Note: Some documentation snippets inadvertently contain duplicate `uv run` prefixes that require review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->