### PR TITLE
docs(releases): add 26.04 software component versions

### DIFF
--- a/docs/releases/software-versions.md
+++ b/docs/releases/software-versions.md
@@ -6,18 +6,17 @@
 |-------------------|---------|
 | PyTorch | 2.11.0a0+eb65b36914.nv26.02 |
 | Megatron Core | 0.17.0 |
-| Transformer Engine | 2.14 |
+| Transformer Engine | 2.14+71bbefb |
 | Megatron-Bridge | 0.4.0 |
 | Megatron-FSDP | 0.4.0 |
 | Export-Deploy | 0.5.0 |
 | Evaluator | 0.2.5 |
-| NeMo | 2.8.0 |
 | NeMo Run | 0.9.0 |
 | Nvidia-ModelOpt | 0.43.0 |
 | CUDA | 13.1.1 |
 | cuDNN | 9.20.0.48-1 |
 | TRT-LLM | 1.2.0 |
-| vLLM | 0.16.0 |
+| vLLM | 0.17.1 |
 
 ```{note}
 NVIDIA NeMo™ Framework Training container is built on top of NVIDIA Optimized Frameworks PyTorch 26.02 container: https://docs.nvidia.com/deeplearning/frameworks/pytorch-release-notes/index.html

--- a/docs/releases/software-versions.md
+++ b/docs/releases/software-versions.md
@@ -14,7 +14,6 @@
 | NeMo | 2.8.0 |
 | NeMo Run | 0.9.0 |
 | Nvidia-ModelOpt | 0.43.0 |
-| NVRX | 0.5.0 |
 | CUDA | 13.1.1 |
 | cuDNN | 9.20.0.48-1 |
 | TRT-LLM | 1.2.0 |

--- a/docs/releases/software-versions.md
+++ b/docs/releases/software-versions.md
@@ -21,7 +21,7 @@
 | vLLM | 0.16.0 |
 
 ```{note}
-NVIDIA NeMo™ Framework Training container is built on top of NVIDIA Optimized Frameworks PyTorch 25.06 container: https://docs.nvidia.com/deeplearning/frameworks/pytorch-release-notes/index.html
+NVIDIA NeMo™ Framework Training container is built on top of NVIDIA Optimized Frameworks PyTorch 26.02 container: https://docs.nvidia.com/deeplearning/frameworks/pytorch-release-notes/index.html
 ```
 
 ## NeMo Framework 26.02

--- a/docs/releases/software-versions.md
+++ b/docs/releases/software-versions.md
@@ -1,5 +1,29 @@
 # Software Component Versions
 
+## NeMo Framework 26.04
+
+| Software Component | Version |
+|-------------------|---------|
+| PyTorch | 2.11.0a0+eb65b36914.nv26.02 |
+| Megatron Core | 0.17.0 |
+| Transformer Engine | 2.14 |
+| Megatron-Bridge | 0.4.0 |
+| Megatron-FSDP | 0.4.0 |
+| Export-Deploy | 0.5.0 |
+| Evaluator | 0.2.5 |
+| NeMo | 2.8.0 |
+| NeMo Run | 0.9.0 |
+| Nvidia-ModelOpt | 0.43.0 |
+| NVRX | 0.5.0 |
+| CUDA | 13.1.1 |
+| cuDNN | 9.20.0.48-1 |
+| TRT-LLM | 1.2.0 |
+| vLLM | 0.16.0 |
+
+```{note}
+NVIDIA NeMo™ Framework Training container is built on top of NVIDIA Optimized Frameworks PyTorch 25.06 container: https://docs.nvidia.com/deeplearning/frameworks/pytorch-release-notes/index.html
+```
+
 ## NeMo Framework 26.02
 
 | Software Component | Version |


### PR DESCRIPTION
## Summary

Adds the NeMo Framework **26.04** software component versions table to `docs/releases/software-versions.md`.

Same set of libraries as 26.02 — no new entries added. Note updated to reference the correct PyTorch **26.02** base container.

| Software Component | Version |
|---|---|
| PyTorch | 2.11.0a0+eb65b36914.nv26.02 |
| Megatron Core | 0.17.0 |
| Transformer Engine | 2.14+71bbefb |
| Megatron-Bridge | 0.4.0 |
| Megatron-FSDP | 0.4.0 |
| Export-Deploy | 0.5.0 |
| Evaluator | 0.2.5 |
| NeMo Run | 0.9.0 |
| Nvidia-ModelOpt | 0.43.0 |
| CUDA | 13.1.1 |
| cuDNN | 9.20.0.48-1 |
| TRT-LLM | 1.2.0 |
| vLLM | 0.17.1 |