### PR TITLE
fix(flux): set qk_layernorm=True in FluxSingleAttention to satisfy Megatron-LM validation

### DIFF
--- a/src/megatron/bridge/diffusion/models/flux/flux_attention.py
+++ b/src/megatron/bridge/diffusion/models/flux/flux_attention.py
@@ -399,8 +399,8 @@ class FluxSingleAttention(SelfAttention):
         cp_comm_type: str = None,
         **kwargs,
     ):
-        # Use RMSnorm for qk norm
         config.normalization = "RMSNorm"
+        config.qk_layernorm = True
         super().__init__(
             config=config,
             submodules=submodules,

--- a/src/megatron/bridge/diffusion/models/flux/flux_attention.py
+++ b/src/megatron/bridge/diffusion/models/flux/flux_attention.py
@@ -399,6 +399,7 @@ class FluxSingleAttention(SelfAttention):
         cp_comm_type: str = None,
         **kwargs,
     ):
+        # Use RMSnorm for qk norm
         config.normalization = "RMSNorm"
         config.qk_layernorm = True
         super().__init__(


### PR DESCRIPTION
## Problem

`FluxSingleAttention` (which inherits from `SelfAttention`) passes `q_layernorm=TENorm` and `k_layernorm=TENorm` in its `SelfAttentionSubmodules` spec. Megatron-LM commit [e15ec3c](https://github.com/NVIDIA/Megatron-LM/commit/e15ec3c0434186d6ae8fe33009221ad99478f24f) ("Add QK layernorm support for dot-product attention in MambaModel") added a validation to `SelfAttention.__init__` that rejects a non-`None`/`IdentityOp` `q_layernorm` in the spec unless `config.qk_layernorm` or `config.qk_l2_norm` is enabled:

```
ValueError: spec sets q_layernorm=<class 'megatron.core.extensions.transformer_engine.TENorm'>
but qk_layernorm/qk_l2_norm are disabled when instantiating FluxSingleAttention
```

## Fix

Set `config.qk_layernorm = True` in `FluxSingleAttention.__init__` before calling `super().__init__()`, following the same pattern already used for `config.normalization = "RMSNorm"`. This tells `SelfAttention.__init__` that q/k layernorm is intentionally enabled, which allows it to wire up `TENorm` from the spec as expected.

## Example

Before (fails with Megatron-LM ≥ e15ec3c):
```python
config.normalization = "RMSNorm"
super().__init__(config=config, submodules=submodules, ...)
```

After:
```python
config.normalization = "RMSNorm"
config.qk_layernorm = True
super().__init__(config=config, submodules=submodules, ...)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal attention model configuration settings for improved normalization handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->