### PR TITLE
fix: set 644 permissions on COPY'd files to match cloned repos

### DIFF
--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -54,4 +54,4 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     fi && \
     uv cache prune ${UV_CACHE_PRUNE_ARGS}
 
-COPY . /opt/Megatron-Bridge
+COPY --chmod=644 . /opt/Megatron-Bridge

--- a/docker/Dockerfile.fw_final
+++ b/docker/Dockerfile.fw_final
@@ -61,8 +61,8 @@ RUN pushd /opt/NeMo && \
     popd
 
 # Sync environment
-COPY docker/common/fw_pyproject.toml /opt/NeMo-FW/pyproject.toml
-COPY docker/common/_version.py docker/common/print_sha.sh /opt/NeMo-FW/
+COPY --chmod=644 docker/common/fw_pyproject.toml /opt/NeMo-FW/pyproject.toml
+COPY --chmod=644 docker/common/_version.py docker/common/print_sha.sh /opt/NeMo-FW/
 RUN \
     cd /opt/NeMo-FW && \
     uv sync --no-cache-dir --all-groups --inexact && \
@@ -154,7 +154,7 @@ ARG NVIDIA_BUILD_REF
 LABEL com.nvidia.build.ref="${NVIDIA_BUILD_REF}"
 ARG RC_DATE=00.00
 ARG TARGETARCH
-COPY docker/common/README.md README.md
+COPY --chmod=644 docker/common/README.md README.md
 
 # NOTICES.txt file points to where the OSS source code is archived
 RUN echo "This distribution includes open source which is archived at the following URL: https://opensource.nvidia.com/oss/teams/nvidia/nemo/${RC_DATE}:linux-${TARGETARCH}/index.html" > NOTICES.txt && \


### PR DESCRIPTION
# What does this PR do ?

  - Add --chmod=644 to Dockerfile COPY instructions so host filesystem permissions (0660) don't leak
   into the container, aligning with the 0644 permissions that git-cloned repos get from the
  container's default umask

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
