### PR TITLE
Fix Megatron-FSDP load_state_dict key prefix, handled in the adapter …

### DIFF
--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -92,6 +92,7 @@ from megatron.bridge.utils.import_utils import safe_import
 _, HAVE_RESIL = safe_import("nvidia_resiliency_ext.checkpointing")
 
 try:
+    from megatron.core.distributed.fsdp.src.megatron_fsdp import MegatronFSDP
     from megatron.core.distributed.fsdp.src.megatron_fsdp.uneven_dtensor import (
         preprocess_state_dict_for_uneven_dtensor,
     )
@@ -1728,6 +1729,12 @@ def load_checkpoint(
 
 def _load_model_state_dict(module: torch.nn.Module, state_dict: dict[str, Any], strict: bool):
     """Helper function to load state dict with fallback for missing extra states."""
+    if HAVE_MEGATRON_FSDP and isinstance(module, MegatronFSDP):
+        # Because the state dictionary was generated from the nested module of Megatron-FSDP,
+        # but MegatronFSDP.load_state_dict() is called at MegatronFSDP(torch.nn.Module).
+        # In Megatron-LM, handled via adapter: FullyShardedDataParallel.load_state_dict().
+        for key in list(state_dict.keys()):
+            state_dict[f"module.{key}"] = state_dict.pop(key)
     try:
         module.load_state_dict(state_dict, strict=strict)
     except Exception as e:


### PR DESCRIPTION
…in MLM.

# What does this PR do ?

- Fix `_load_model_state_dict` for Megatron-FSDP in Megatron-Bridge.
- Without this fix, any transformations you perform on the state after loading in the checkpoint, is not effective, since the keys all have wrong FQN's. (Still triggers the state dict loading hook though, so the original checkpoint's compute weights are installed, which was fixed by the previous PR.) Tested on swizzling, we finally have model parity: https://github.com/rachitgarg91/Megatron-Bridge/pull/2

# Changelog

- After unlocking the model state dictionary load in https://github.com/NVIDIA-NeMo/Megatron-Bridge/pull/3397, the load was not fully effective because the state dictionary was generated at the `MegatronFSDP.module` level, while being loaded at the `MegatronFSDP` level. (This is missing logic from [mcore_fsdp_adapter.py](https://github.com/NVIDIA/Megatron-LM/blob/main/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py#L192), which appends the `module.` prefix for MLM's training loop, but the model load was skipped in Megatron-Bridge for a long time now.) So we simply update the keys of the sharded state dictionary prior to loading when using Megatron-FSDP.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
