### PR TITLE
cp: fix(test): clone mmap-backed tensors before overwriting safetensors file (#3335)

### DIFF
--- a/tests/functional_tests/test_groups/models/qwen_vl/test_qwen35_vl_conversion.py
+++ b/tests/functional_tests/test_groups/models/qwen_vl/test_qwen35_vl_conversion.py
@@ -335,7 +335,9 @@ def _fuse_moe_expert_weights(model_dir: Path, num_experts: int) -> None:
     if not keys_to_remove:
         return
 
-    new_state_dict = {k: v for k, v in state_dict.items() if k not in keys_to_remove}
+    # Clone kept tensors so they are no longer backed by the mmap of weights_path,
+    # which will be overwritten by save_file below.
+    new_state_dict = {k: v.clone() for k, v in state_dict.items() if k not in keys_to_remove}
 
     for prefix, experts in layers.items():
         gate_up = torch.stack(


### PR DESCRIPTION
## Summary
- Cherry-pick of the safetensors mmap fix from `fd648d56` (main, PR #3335)
- `_fuse_moe_expert_weights` loads tensors via safetensors (memory-mapped), then writes back to the same file path. On Docker overlay filesystems in CI, this causes `safetensors_rust.SafetensorError: I/O error: Bad address (os error 14)` because `save_file` truncates the file while kept tensors still reference the mmap'd regions
- Fix: clone kept tensors before saving (`v.clone()`)

## Test plan
- [x] Fixes [CI failure in Qwen3.5-VL MoE test](https://github.com/NVIDIA-NeMo/Megatron-Bridge/actions/runs/24601214402/job/71941857400?pr=3402)

🤖 Generated with [Claude Code](https://claude.com/claude-code)