### PR TITLE
[PEFT] fix: fused fc1 projection mapping for MiniMax (`w1` & `w3`)

### DIFF
--- a/src/megatron/bridge/models/conversion/peft_bridge.py
+++ b/src/megatron/bridge/models/conversion/peft_bridge.py
@@ -250,15 +250,15 @@ class MegatronPeftBridge:
         linear_out_tensor: torch.Tensor,
         base_weight_shape: Optional[torch.Size] = None,
     ) -> bool:
-        """Detect fused FC1 (gate/up) adapters based on names and tensor shape."""
+        """Detect fused FC1 adapters based on names and tensor shape."""
 
         names = list(base_hf_weight_names)
         has_gate_up = (
             bool(names)
             and len(names) % 2 == 0
-            and all(("gate_proj" in name or "up_proj" in name) for name in names)
-            and any("gate_proj" in name for name in names)
-            and any("up_proj" in name for name in names)
+            and all(self._is_fused_fc1_gate_proj(name) or self._is_fused_fc1_up_proj(name) for name in names)
+            and any(self._is_fused_fc1_gate_proj(name) for name in names)
+            and any(self._is_fused_fc1_up_proj(name) for name in names)
         )
         if not has_gate_up:
             return False
@@ -289,6 +289,16 @@ class MegatronPeftBridge:
             if projection_key in hf_name:
                 return projection_key
         return None
+
+    def _is_fused_fc1_gate_proj(self, hf_name: str) -> bool:
+        """Return whether the HF name maps to the gate half of fused FC1."""
+
+        return "gate_proj" in hf_name or ".w1." in hf_name
+
+    def _is_fused_fc1_up_proj(self, hf_name: str) -> bool:
+        """Return whether the HF name maps to the up half of fused FC1."""
+
+        return "up_proj" in hf_name or ".w3." in hf_name
 
     def _infer_hf_expert_idx(self, hf_name: str) -> Optional[int]:
         """Return the expert index embedded in an HF MoE weight name."""
@@ -934,9 +944,9 @@ class MegatronPeftBridge:
             )
             per_base = {}
             for base_name in base_hf_weight_names:
-                if "gate_proj" in base_name:
+                if self._is_fused_fc1_gate_proj(base_name):
                     per_base[base_name] = gate_weight
-                elif "up_proj" in base_name:
+                elif self._is_fused_fc1_up_proj(base_name):
                     per_base[base_name] = up_weight
                 else:
                     raise ValueError(f"Unknown fused-fc1 base weight name: {base_name}")
@@ -1047,9 +1057,9 @@ class MegatronPeftBridge:
                         current_linear_out_weight,
                         is_expert=is_expert,
                     )
-                if "gate_proj" in hf_name:
+                if self._is_fused_fc1_gate_proj(hf_name):
                     current_linear_out_weight = fc1_gate_weight
-                elif "up_proj" in hf_name:
+                elif self._is_fused_fc1_up_proj(hf_name):
                     current_linear_out_weight = fc1_up_weight
                 else:
                     raise ValueError(f"Unknown weight name: {hf_name}")

--- a/tests/unit_tests/models/test_adapter_export.py
+++ b/tests/unit_tests/models/test_adapter_export.py
@@ -210,6 +210,19 @@ class TestMergeSingleAdapterWeight:
         assert merged.device == base.device
 
 
+class TestFusedFc1NameHelpers:
+    def test_gate_and_up_detection_supports_standard_and_minimax_names(self):
+        bridge = MegatronPeftBridge()
+
+        assert bridge._is_fused_fc1_gate_proj("model.layers.0.mlp.gate_proj.weight")
+        assert bridge._is_fused_fc1_gate_proj("model.layers.0.block_sparse_moe.experts.0.w1.weight")
+        assert not bridge._is_fused_fc1_gate_proj("model.layers.0.mlp.up_proj.weight")
+
+        assert bridge._is_fused_fc1_up_proj("model.layers.0.mlp.up_proj.weight")
+        assert bridge._is_fused_fc1_up_proj("model.layers.0.block_sparse_moe.experts.0.w3.weight")
+        assert not bridge._is_fused_fc1_up_proj("model.layers.0.mlp.gate_proj.weight")
+
+
 # ---------------------------------------------------------------------------
 # AutoBridge.save_hf_adapter
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/models/test_model_bridge_lora.py
+++ b/tests/unit_tests/models/test_model_bridge_lora.py
@@ -192,6 +192,42 @@ def test_merge_lora_adapter_weights_fused_fc1_tp_aware(monkeypatch):
     torch.testing.assert_close(updated["decoder.layers.0.mlp.up_proj.weight"], expected_up)
 
 
+def test_merge_lora_adapter_weights_fused_fc1_minimax_w13(monkeypatch):
+    bridge = DummyBridge()
+    base = torch.zeros(4, 4)
+    converted = {
+        "model.layers.0.block_sparse_moe.experts.0.w1.weight": base.clone(),
+        "model.layers.0.block_sparse_moe.experts.0.w3.weight": base.clone(),
+    }
+
+    linear_out = torch.cat([torch.eye(4), 2 * torch.eye(4)], dim=0)
+    adapter_weight = AdapterWeight(
+        global_base_prefix="decoder.layers.0.mlp.experts.linear_fc1",
+        adapter_key=None,
+        alpha=1,
+        dim=1,
+        linear_in_weight=MegatronWeightTuple("in", torch.eye(4), vp_stage=0),
+        linear_out_weight=MegatronWeightTuple("out", linear_out, vp_stage=0),
+    )
+
+    monkeypatch.setattr(
+        "megatron.bridge.models.conversion.peft_bridge.parallel_state.get_expert_model_parallel_world_size",
+        lambda: 1,
+    )
+    monkeypatch.setattr(
+        "megatron.bridge.models.conversion.peft_bridge.parallel_state.get_expert_tensor_parallel_world_size",
+        lambda: 1,
+    )
+
+    updated = bridge._merge_lora_adapter_weights(
+        [Mock(config=SimpleNamespace(num_moe_experts=1))],
+        converted,
+        [adapter_weight],
+    )
+    torch.testing.assert_close(updated["model.layers.0.block_sparse_moe.experts.0.w1.weight"], torch.eye(4))
+    torch.testing.assert_close(updated["model.layers.0.block_sparse_moe.experts.0.w3.weight"], 2 * torch.eye(4))
+
+
 def test_merge_lora_adapter_weights_qkv_split(monkeypatch):
     bridge = DummyBridge()
     config = SimpleNamespace(
@@ -791,6 +827,80 @@ def test_stream_adapter_weights_megatron_to_hf_fused_fc1(monkeypatch):
     assert names[1].endswith("gate_proj.lora_B.weight")
     assert names[2].endswith("up_proj.lora_A.weight")
     assert names[3].endswith("up_proj.lora_B.weight")
+
+    torch.testing.assert_close(weights[0].weight, torch.ones(2, 2))
+    torch.testing.assert_close(weights[1].weight, torch.full((2, 2), 1.0))
+    torch.testing.assert_close(weights[2].weight, torch.ones(2, 2))
+    torch.testing.assert_close(weights[3].weight, torch.full((2, 2), 2.0))
+
+
+def test_stream_adapter_weights_megatron_to_hf_fused_fc1_minimax_w13(monkeypatch):
+    bridge = DummyBridge()
+
+    adapter_task = AdapterWeightConversionTask(
+        global_base_prefix="decoder.layers.0.mlp.experts.linear_fc1",
+        adapter_key=None,
+        alpha=2,
+        dim=4,
+        linear_in_task=WeightConversionTask(
+            param_name="local_in",
+            global_param_name="decoder.layers.0.mlp.experts.linear_fc1.adapter.linear_in.weight",
+            mapping=Mock(),
+        ),
+        linear_out_task=WeightConversionTask(
+            param_name="local_out",
+            global_param_name="decoder.layers.0.mlp.experts.linear_fc1.adapter.linear_out.weight",
+            mapping=Mock(),
+        ),
+    )
+
+    linear_out = torch.cat([torch.full((2, 2), 1.0), torch.full((2, 2), 2.0)], dim=0)
+    adapter_weight = AdapterWeight(
+        global_base_prefix="decoder.layers.0.mlp.experts.linear_fc1",
+        adapter_key=None,
+        alpha=2,
+        dim=4,
+        linear_in_weight=MegatronWeightTuple("local_in", torch.ones(2, 2), vp_stage=0),
+        linear_out_weight=MegatronWeightTuple("local_out", linear_out, vp_stage=0),
+    )
+
+    monkeypatch.setattr(
+        bridge,
+        "build_adapter_conversion_tasks",
+        lambda *_: {"decoder.layers.0.mlp.experts.linear_fc1": [adapter_task]},
+    )
+    monkeypatch.setattr(bridge, "materialize_adapter_weights", lambda *_: [adapter_weight])
+    monkeypatch.setattr(
+        bridge,
+        "_get_base_hf_param_names_for_adapter",
+        lambda *_: [
+            "model.layers.0.block_sparse_moe.experts.0.w1.weight",
+            "model.layers.0.block_sparse_moe.experts.0.w3.weight",
+        ],
+    )
+    monkeypatch.setattr(
+        "megatron.bridge.models.conversion.peft_bridge.parallel_state.get_expert_model_parallel_world_size",
+        lambda: 1,
+    )
+    monkeypatch.setattr(
+        "megatron.bridge.models.conversion.peft_bridge.parallel_state.get_expert_tensor_parallel_world_size",
+        lambda: 1,
+    )
+
+    weights = list(
+        bridge.stream_adapter_weights_megatron_to_hf(
+            [SimpleNamespace(config=SimpleNamespace(num_moe_experts=1))],
+            cpu=False,
+            show_progress=False,
+        )
+    )
+
+    assert len(weights) == 4
+    names = [w.param_name for w in weights]
+    assert names[0].endswith("w1.lora_A.weight")
+    assert names[1].endswith("w1.lora_B.weight")
+    assert names[2].endswith("w3.lora_A.weight")
+    assert names[3].endswith("w3.lora_B.weight")
 
     torch.testing.assert_close(weights[0].weight, torch.ones(2, 2))
     torch.testing.assert_close(weights[1].weight, torch.full((2, 2), 1.0))


### PR DESCRIPTION
# What does this PR do ?

Support correctly splitting fused fc1 projection mapping for MiniMax (`w1` & `w3`) as well in addition to `gate_proj` and `up_proj`.

# Changelog

- mapping `w1` to `gate` and `w3` to `up`

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [X] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [X] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
