### PR TITLE
docs(perf): fix typos in scripts/performance README

### DIFF
--- a/scripts/performance/README.md
+++ b/scripts/performance/README.md
@@ -244,11 +244,11 @@ Mounting cached files is not enough by itself. If `HF_HUB_OFFLINE` remains `0`, 
 - `-wde/--wandb_entity_name`: Weights & Biases entity name.
 - `-wdj/--wandb_experiment_name`: Weights & Biases experiment/run name.
 - `-wds/--wandb_save_dir`: Weights & Biases save directory.
-- - `--save_config_filepath`: Path to save the task configuration file.
+- `--save_config_filepath`: Path to save the task configuration file.
 
 ##### Config variant arguments
 
-- `-cv/--config_variant`: Config variant to use (e.g., `"v1"`, `"v2"`). Defaults to `"v2"` (`"v1"` if `"v2"` doens't exist). Use `--list_config_variants` to see available options.
+- `-cv/--config_variant`: Config variant to use (e.g., `"v1"`, `"v2"`). Defaults to `"v2"` (`"v1"` if `"v2"` doesn't exist). Use `--list_config_variants` to see available options.
 - `--list_config_variants`: List available config variants for the specified model/task/gpu/dtype and interactively select one (with 15s timeout).
 
 ##### Testing arguments


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## Summary

Fixes two typos in `scripts/performance/README.md`:

- Remove the duplicate leading dash on the `--save_config_filepath` bullet (`- -` → `-`)
- Fix `doens't` → `doesn't` in the `--config_variant` description

Since all changes are confined to `scripts/performance/`, this PR exercises the new `perf_scripts_only` CI fast-path introduced in the base branch — no container build or GPU tests will be triggered.

</details>
