### PR TITLE
fix: update copyright year to 2026 in run_recipe.py

### DIFF
--- a/src/megatron/bridge/models/qwen/qwen3_next_bridge.py
+++ b/src/megatron/bridge/models/qwen/qwen3_next_bridge.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## Summary

Updates the copyright year from 2025 to 2026 in `src/megatron/bridge/models/qwen/qwen3_next_bridge.py`.

This change touches a file **outside** `scripts/performance/`, so it exercises the **normal** CI path (container build + full test suite) — in contrast to the sibling PR (#3472) which only touches `scripts/performance/README.md` and hits the new `perf_scripts_only` fast-path.

</details>