### PR TITLE
[vulnops][data] fix: Validate URLs in VLM video loader to prevent SSRF

### DIFF
--- a/src/megatron/bridge/models/nemotron_vl/nemotron_vl_utils.py
+++ b/src/megatron/bridge/models/nemotron_vl/nemotron_vl_utils.py
@@ -14,13 +14,94 @@
 
 import base64
 import io
+import ipaddress
+import logging
 import mimetypes
 import os
+import socket
 from typing import Dict, List
+from urllib.parse import urlparse
 
 import torch
 from PIL import Image
 from transformers.video_utils import VideoMetadata
+
+
+logger = logging.getLogger(__name__)
+
+# Opt-out env var for the SSRF guard in ``_is_safe_public_http_url``. Set to
+# ``"1"`` when training on a trusted network where dataset URLs may legitimately
+# point at internal hosts. Defaults off — the guard blocks loopback / private /
+# link-local destinations (including cloud metadata at 169.254.169.254).
+_ALLOW_PRIVATE_URL_FETCH_ENV = "MEGATRON_BRIDGE_ALLOW_PRIVATE_URL_FETCH"
+
+
+def _is_safe_public_http_url(url: str) -> tuple[bool, str]:
+    """Check that ``url`` is a public http(s) URL safe to fetch.
+
+    Rejects non-http schemes, missing hostnames, and any hostname that
+    resolves to a loopback, private (RFC 1918), link-local, multicast,
+    reserved, or unspecified address. Used to mitigate SSRF when fetching
+    remote video URLs from untrusted dataset entries.
+
+    Set ``MEGATRON_BRIDGE_ALLOW_PRIVATE_URL_FETCH=1`` to bypass (trusted
+    networks only).
+
+    Returns:
+        Tuple of ``(is_safe, reason)``. ``reason`` is empty when safe.
+    """
+    if os.environ.get(_ALLOW_PRIVATE_URL_FETCH_ENV) == "1":
+        return True, ""
+    try:
+        parsed = urlparse(url)
+    except ValueError as exc:
+        return False, f"invalid URL: {exc}"
+    if parsed.scheme not in ("http", "https"):
+        return False, f"unsupported URL scheme: {parsed.scheme!r}"
+    host = parsed.hostname
+    if not host:
+        return False, "URL missing hostname"
+    try:
+        infos = socket.getaddrinfo(host, None)
+    except socket.gaierror as exc:
+        return False, f"DNS resolution failed: {exc}"
+    for info in infos:
+        ip_str = info[4][0]
+        try:
+            ip = ipaddress.ip_address(ip_str)
+        except ValueError:
+            return False, f"unparseable resolved address: {ip_str}"
+        if (
+            ip.is_loopback
+            or ip.is_private
+            or ip.is_link_local
+            or ip.is_multicast
+            or ip.is_reserved
+            or ip.is_unspecified
+        ):
+            return False, f"URL resolves to non-public address: {ip}"
+    return True, ""
+
+
+def _safe_url_open(url: str):
+    """Open ``url`` via a urllib opener that re-validates redirect targets.
+
+    Prevents SSRF via redirect: a public URL returning a 3xx to an internal
+    address would otherwise bypass :func:`_is_safe_public_http_url`. The
+    initial URL must already have been validated by the caller.
+    """
+    import urllib.error
+    import urllib.request
+
+    class _SafeRedirectHandler(urllib.request.HTTPRedirectHandler):
+        def redirect_request(self, req, fp, code, msg, headers, newurl):
+            is_safe, reason = _is_safe_public_http_url(newurl)
+            if not is_safe:
+                raise urllib.error.URLError(f"redirect blocked ({reason}): {newurl}")
+            return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+    opener = urllib.request.build_opener(_SafeRedirectHandler())
+    return opener.open(url)  # noqa: S310  -- URL validated by caller + redirect handler
 
 
 def encode_pil_to_jpeg_data_url(pil_image):
@@ -155,13 +236,18 @@ def maybe_path_or_url_to_data_urls(path_or_url, fps=1, nframe=0, nframe_max=-1):
     # Remote URL
     if low.startswith("http://") or low.startswith("https://"):
         if low.endswith(".mp4"):
+            is_safe, reason = _is_safe_public_http_url(val)
+            if not is_safe:
+                logger.warning("Refusing to fetch video URL (%s): %s", reason, val)
+                return [val], None
             try:
+                import shutil
                 import tempfile
-                import urllib.request
 
                 with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as tmpf:
-                    urllib.request.urlretrieve(val, tmpf.name)
                     local_path = tmpf.name
+                    with _safe_url_open(val) as resp:
+                        shutil.copyfileobj(resp, tmpf)
                 result = sample_video_frames_to_data_urls(local_path, fps=fps, nframe=nframe, nframe_max=nframe_max)
                 try:
                     os.unlink(local_path)

--- a/tests/unit_tests/models/nemotron_vl/test_nemotron_vl_utils.py
+++ b/tests/unit_tests/models/nemotron_vl/test_nemotron_vl_utils.py
@@ -1,0 +1,132 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""SSRF-guard regression tests for nemotron_vl_utils.
+
+Covers the ``_is_safe_public_http_url`` helper and the integration
+behavior of ``maybe_path_or_url_to_data_urls`` — notably that a
+malicious video URL is never handed to ``urllib`` for retrieval.
+"""
+
+import socket
+from unittest import mock
+
+import pytest
+
+from megatron.bridge.models.nemotron_vl import nemotron_vl_utils as vlu
+
+
+def _fake_getaddrinfo(ip: str):
+    """Return a ``getaddrinfo`` stub that resolves any host to ``ip``."""
+
+    def _stub(host, port, *args, **kwargs):
+        family = socket.AF_INET6 if ":" in ip else socket.AF_INET
+        return [(family, socket.SOCK_STREAM, 0, "", (ip, port or 0))]
+
+    return _stub
+
+
+class TestIsSafePublicHttpUrl:
+    def test_rejects_non_http_scheme(self):
+        ok, reason = vlu._is_safe_public_http_url("file:///etc/passwd")
+        assert not ok
+        assert "scheme" in reason
+
+    def test_rejects_missing_hostname(self):
+        ok, reason = vlu._is_safe_public_http_url("http:///x.mp4")
+        assert not ok
+        assert "hostname" in reason
+
+    @pytest.mark.parametrize(
+        "ip",
+        [
+            "127.0.0.1",  # loopback
+            "10.0.0.1",  # RFC 1918
+            "172.16.0.1",  # RFC 1918
+            "192.168.1.1",  # RFC 1918
+            "169.254.169.254",  # link-local (cloud metadata)
+            "0.0.0.0",  # unspecified
+            "::1",  # IPv6 loopback
+            "fc00::1",  # IPv6 unique local
+            "fe80::1",  # IPv6 link-local
+        ],
+    )
+    def test_rejects_non_public_addresses(self, ip):
+        with mock.patch("socket.getaddrinfo", side_effect=_fake_getaddrinfo(ip)):
+            ok, reason = vlu._is_safe_public_http_url("http://attacker.example.com/x.mp4")
+        assert not ok
+        assert "non-public" in reason
+
+    def test_accepts_public_address(self):
+        with mock.patch("socket.getaddrinfo", side_effect=_fake_getaddrinfo("93.184.216.34")):
+            ok, reason = vlu._is_safe_public_http_url("https://example.com/x.mp4")
+        assert ok
+        assert reason == ""
+
+    def test_rejects_when_any_resolved_ip_is_private(self):
+        # Multiple records where one is private — must be rejected
+        def stub(host, port, *args, **kwargs):
+            return [
+                (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0)),
+                (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("10.0.0.1", 0)),
+            ]
+
+        with mock.patch("socket.getaddrinfo", side_effect=stub):
+            ok, reason = vlu._is_safe_public_http_url("http://mixed.example.com/x.mp4")
+        assert not ok
+        assert "non-public" in reason
+
+    def test_rejects_when_dns_fails(self):
+        with mock.patch("socket.getaddrinfo", side_effect=socket.gaierror("no such host")):
+            ok, reason = vlu._is_safe_public_http_url("http://does-not-resolve.invalid/x.mp4")
+        assert not ok
+        assert "DNS" in reason
+
+    def test_opt_out_env_var_bypasses_check(self, monkeypatch):
+        monkeypatch.setenv(vlu._ALLOW_PRIVATE_URL_FETCH_ENV, "1")
+        # Would otherwise be rejected — env var bypasses the guard entirely.
+        ok, reason = vlu._is_safe_public_http_url("http://127.0.0.1/x.mp4")
+        assert ok
+        assert reason == ""
+
+    def test_opt_out_requires_exact_value(self, monkeypatch):
+        monkeypatch.setenv(vlu._ALLOW_PRIVATE_URL_FETCH_ENV, "true")  # not "1"
+        with mock.patch("socket.getaddrinfo", side_effect=_fake_getaddrinfo("127.0.0.1")):
+            ok, _ = vlu._is_safe_public_http_url("http://localhost/x.mp4")
+        assert not ok
+
+
+class TestMaybePathOrUrlSsrfIntegration:
+    def test_rejected_url_never_opens_socket(self, caplog):
+        """A loopback URL must return unchanged without opening any connection."""
+        with mock.patch.object(vlu, "_safe_url_open") as mocked_open:
+            with mock.patch("socket.getaddrinfo", side_effect=_fake_getaddrinfo("127.0.0.1")):
+                out, meta = vlu.maybe_path_or_url_to_data_urls("http://attacker.example.com/evil.mp4")
+
+        mocked_open.assert_not_called()
+        assert out == ["http://attacker.example.com/evil.mp4"]
+        assert meta is None
+
+    def test_metadata_endpoint_blocked(self):
+        with mock.patch.object(vlu, "_safe_url_open") as mocked_open:
+            out, _ = vlu.maybe_path_or_url_to_data_urls("http://169.254.169.254/latest/meta-data/evil.mp4")
+        mocked_open.assert_not_called()
+        assert out == ["http://169.254.169.254/latest/meta-data/evil.mp4"]
+
+    def test_non_mp4_http_url_not_fetched(self):
+        """Unchanged pre-existing behavior: non-.mp4 URLs are returned as-is."""
+        with mock.patch.object(vlu, "_safe_url_open") as mocked_open:
+            out, _ = vlu.maybe_path_or_url_to_data_urls("http://example.com/page.html")
+        mocked_open.assert_not_called()
+        assert out == ["http://example.com/page.html"]


### PR DESCRIPTION
## Summary

Fixes a blind SSRF vulnerability in the Nemotron-VL video data loader.
`maybe_path_or_url_to_data_urls()` in
`src/megatron/bridge/models/nemotron_vl/nemotron_vl_utils.py` called
`urllib.request.urlretrieve()` on any URL ending in `.mp4` without
validating the destination. A malicious training dataset could force the
training server to issue GET requests to internal services, cloud
metadata endpoints (e.g. `169.254.169.254`), or other network-reachable
targets.

## Fix

- New `_is_safe_public_http_url()` helper:
  - Requires `http`/`https` scheme and a non-empty hostname
  - Resolves the hostname via `socket.getaddrinfo` and rejects any
    resolved IP that is loopback / private (RFC 1918) / link-local
    (covers `169.254.169.254`) / multicast / reserved / unspecified
- New `_safe_url_open()` replaces `urlretrieve` and installs a custom
  `HTTPRedirectHandler` that re-validates each redirect target — a
  public URL cannot redirect into an internal address.
- On rejection the function logs a warning and returns the URL unchanged
  (same fallback as existing fetch-failure paths — no behavior change
  for legitimate public URLs).
- Opt-out for trusted networks: set
  `MEGATRON_BRIDGE_ALLOW_PRIVATE_URL_FETCH=1`.

## Residual risk

TOCTOU DNS rebinding between validation and fetch is not fully
mitigated — full mitigation would require pinning the fetch to a
resolved IP, which conflicts with TLS SNI / Host handling. Deferred
given the Low severity (CVSS 2.5) and blind nature of the vulnerability.

## Test plan

- [x] `test_rejects_non_http_scheme` — `file://`, etc. rejected
- [x] `test_rejects_missing_hostname` — `http:///x.mp4` rejected
- [x] `test_rejects_non_public_addresses` — loopback, RFC 1918,
  link-local, unspecified, IPv6 equivalents all rejected
- [x] `test_accepts_public_address` — public IP passes
- [x] `test_rejects_when_any_resolved_ip_is_private` — mixed records
  rejected if any record is private
- [x] `test_rejects_when_dns_fails` — resolution failure rejects
- [x] `test_opt_out_env_var_bypasses_check` — env var bypasses guard
- [x] `test_opt_out_requires_exact_value` — only `"1"` opts out
- [x] `test_rejected_url_never_opens_socket` — integration: SSRF
  payload never reaches urllib
- [x] `test_metadata_endpoint_blocked` — cloud metadata URL blocked
- [x] `test_non_mp4_http_url_not_fetched` — existing non-`.mp4` path
  unchanged

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>