### PR TITLE
ci: add base_sha to codecov/codecov-action upload step

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -1068,6 +1068,11 @@ jobs:
           - unit-test
           - e2e
     steps:
+      - name: Get PR info
+        id: get-pr-info
+        if: startsWith(github.ref, 'refs/heads/pull-request/')
+        uses: nv-gha-runners/get-pr-info@main
+
       - name: Checkout
         uses: actions/checkout@v6
 
@@ -1095,6 +1100,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
           flags: ${{ matrix.flag }}
+          base_sha: ${{ fromJSON(steps.get-pr-info.outputs.pr-info || '{}').base.sha }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v6


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## Summary

- Added a `Get PR info` step (using `nv-gha-runners/get-pr-info@main`, the same pattern used elsewhere in this workflow) to the `Coverage` job
- Passes `base_sha` to `codecov/codecov-action@v5` using the PR's base SHA so Codecov can correctly compute the coverage diff against the PR's base commit

## Example

```yaml
- name: Get PR info
  id: get-pr-info
  if: startsWith(github.ref, 'refs/heads/pull-request/')
  uses: nv-gha-runners/get-pr-info@main

- name: Upload coverage reports to Codecov
  uses: codecov/codecov-action@v5
  with:
    token: ${{ secrets.CODECOV_TOKEN }}
    verbose: true
    flags: ${{ matrix.flag }}
    base_sha: ${{ fromJSON(steps.get-pr-info.outputs.pr-info || '{}').base.sha }}
```

</details>
