### PR TITLE
cp: `[training] fix: record CUDA memory history before snapshot so dumps are non-empty (#3487)` into `r0.4.0`

### DIFF
--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -740,6 +740,22 @@ class LoggerConfig(MTrainLoggerConfig):
 class ProfilingConfig(MTrainProfilingConfig):
     """Configuration settings for profiling the training process."""
 
+    profile_ranks: list[int] = field(default_factory=lambda: [0])
+    """Ranks to capture in memory snapshots / nsys / pytorch profiler.
+
+    Memory-snapshot and recording-start guards use a strict membership check,
+    so an empty list disables capture. Default ``[0]`` gives rank-0 capture
+    whenever ``record_memory_history=True`` or an nsys/pytorch profiler is
+    enabled, with no further override required.
+    """
+
+    memory_snapshot_path: str = "/nemo_run/snapshot.pickle"
+    """Path the per-rank pickle is written to (``_{rank}`` is inserted before
+    the extension). Defaults to ``/nemo_run/snapshot.pickle`` so the file lands
+    directly under the NeMo-Run experiment directory (bound at ``/nemo_run``
+    inside the container). Override for non-NeMo-Run setups.
+    """
+
     def finalize(self) -> None:
         """Validate profiling configuration."""
         assert not (self.use_pytorch_profiler and self.use_nsys_profiler), (

--- a/src/megatron/bridge/training/setup.py
+++ b/src/megatron/bridge/training/setup.py
@@ -50,6 +50,7 @@ from megatron.bridge.training.optim import setup_optimizer
 from megatron.bridge.training.state import GlobalState
 from megatron.bridge.training.tokenizers.tokenizer import build_tokenizer
 from megatron.bridge.training.utils.log_utils import append_to_progress_log, barrier_and_log, setup_logging
+from megatron.bridge.training.utils.train_utils import start_memory_history_recording
 from megatron.bridge.utils.common_utils import print_rank_0, get_rank_safe
 from megatron.bridge.training.tensor_inspect import (
     finalize_tensor_inspect_post_model_initialization,
@@ -222,6 +223,10 @@ def setup(
             return model
 
         _register_pre_wrap_hook(cfg.model, modelopt_pre_wrap_hook)
+
+    # Enable CUDA allocator history tracing before any model tensors are allocated,
+    # so snapshots dumped later in training contain a full timeline + stack context.
+    start_memory_history_recording(cfg.profiling)
 
     model = _build_distributed_model(cfg, pg_collection)
 

--- a/src/megatron/bridge/training/utils/train_utils.py
+++ b/src/megatron/bridge/training/utils/train_utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import inspect
+import logging
 import math
 import os
 import time
@@ -30,7 +31,7 @@ from megatron.core.transformer.moe.moe_utils import track_moe_metrics
 from megatron.core.transformer.multi_token_prediction import MTPLossLoggingHelper
 from megatron.core.utils import get_data_parallel_group_if_dtensor, to_local_if_dtensor
 
-from megatron.bridge.training.config import ConfigContainer, TrainingConfig
+from megatron.bridge.training.config import ConfigContainer, ProfilingConfig, TrainingConfig
 from megatron.bridge.training.forward_step_func_types import ForwardStepCallable
 from megatron.bridge.training.state import GlobalState, TrainState
 from megatron.bridge.training.utils.flop_utils import num_floating_point_operations
@@ -42,6 +43,55 @@ from megatron.bridge.utils.common_utils import get_rank_safe, get_world_size_saf
 
 if TYPE_CHECKING:
     from torch.distributed.distributed_c10d import ProcessGroup as TorchProcessGroup
+
+
+logger = logging.getLogger(__name__)
+
+
+def start_memory_history_recording(profiling: ProfilingConfig | None) -> None:
+    """Enable the CUDA caching allocator trace so memory snapshots contain history.
+
+    ``torch.cuda.memory._snapshot()`` only includes allocation/free events and
+    Python stack context after ``_record_memory_history()`` has been enabled.
+    Without this call, dumped snapshots contain only the current live
+    allocations — no timeline, no call sites.
+
+    Must be invoked before model construction so every tensor allocation is
+    captured. Guarded by ``profile_ranks`` so only ranks that will dump a
+    snapshot pay the recording overhead.
+    """
+    if profiling is None or not profiling.record_memory_history:
+        return
+    if get_rank_safe() not in profiling.profile_ranks:
+        return
+
+    torch.cuda.memory._record_memory_history(
+        True,
+        # Retain up to 100k alloc/free events.
+        trace_alloc_max_entries=100_000,
+        # Record the Python stack at each event — lets memory_viz show call sites.
+        trace_alloc_record_context=True,
+    )
+
+    def _oom_observer(device: int, alloc: int, device_alloc: int, device_free: int) -> None:
+        """Dump a snapshot on OOM so we can inspect what was live at the failure."""
+        import pickle
+
+        rank = get_rank_safe()
+        base, ext = os.path.splitext(profiling.memory_snapshot_path)
+        filename = f"{base}_oom_rank-{rank}{ext}"
+        snapshot = torch.cuda.memory._snapshot()
+        with open(filename, "wb") as f:
+            pickle.dump(snapshot, f)
+        # logger.info so the message reaches stderr on any profiled rank, not just rank 0.
+        logger.info(f"[OOM] rank {rank} saved memory snapshot to {filename}")
+
+    torch._C._cuda_attach_out_of_memory_observer(_oom_observer)
+    print_rank_0(
+        f"Memory history recording enabled (rank {get_rank_safe()}); "
+        f"snapshots will be written to '{profiling.memory_snapshot_path}'."
+    )
+
 
 try:
     from transformer_engine.pytorch.optimizers import multi_tensor_applier, multi_tensor_l2norm
@@ -469,11 +519,8 @@ def training_log(
         if hasattr(timers, "write_to_comet"):
             timers.write_to_comet(timers_to_log, comet_logger, iteration, normalizer=total_iterations, reset=True)
 
-    if config.profiling:
-        if config.profiling.record_memory_history and get_rank_safe() in config.profiling.profile_ranks:
-            assert config.logger.tensorboard_dir is not None, (
-                "Tensorboard directory must be set when profiling memory history"
-            )
+    if config.profiling and config.profiling.record_memory_history:
+        if get_rank_safe() in config.profiling.profile_ranks:
             snapshot = torch.cuda.memory._snapshot()
             from pickle import dump
 

--- a/tests/unit_tests/training/utils/test_train_utils.py
+++ b/tests/unit_tests/training/utils/test_train_utils.py
@@ -35,6 +35,7 @@ from megatron.bridge.training.utils.train_utils import (
     report_memory,
     report_runtime,
     report_throughput,
+    start_memory_history_recording,
     training_log,
 )
 
@@ -3090,3 +3091,95 @@ class TestCalcParamsL2Norm:
         # Both layers contribute: sqrt(25 + 25) = sqrt(50)
         expected_norm = math.sqrt(50)
         assert result == pytest.approx(expected_norm, rel=1e-5)
+
+
+class TestStartMemoryHistoryRecording:
+    """Tests for start_memory_history_recording.
+
+    Verifies the four guard paths (None config, disabled flag, rank not in
+    profile_ranks, happy path) and that the happy path wires up the CUDA
+    allocator trace + OOM observer as expected.
+    """
+
+    @mock.patch("megatron.bridge.training.utils.train_utils.torch.cuda.memory._record_memory_history")
+    @mock.patch("megatron.bridge.training.utils.train_utils.torch._C._cuda_attach_out_of_memory_observer")
+    def test_no_config_is_noop(self, mock_attach, mock_record):
+        start_memory_history_recording(None)
+        mock_record.assert_not_called()
+        mock_attach.assert_not_called()
+
+    @mock.patch("megatron.bridge.training.utils.train_utils.torch.cuda.memory._record_memory_history")
+    @mock.patch("megatron.bridge.training.utils.train_utils.torch._C._cuda_attach_out_of_memory_observer")
+    def test_disabled_flag_is_noop(self, mock_attach, mock_record):
+        profiling = mock.Mock()
+        profiling.record_memory_history = False
+        profiling.profile_ranks = [0]
+
+        start_memory_history_recording(profiling)
+        mock_record.assert_not_called()
+        mock_attach.assert_not_called()
+
+    @mock.patch("megatron.bridge.training.utils.train_utils.get_rank_safe", return_value=3)
+    @mock.patch("megatron.bridge.training.utils.train_utils.torch.cuda.memory._record_memory_history")
+    @mock.patch("megatron.bridge.training.utils.train_utils.torch._C._cuda_attach_out_of_memory_observer")
+    def test_rank_not_in_profile_ranks_is_noop(self, mock_attach, mock_record, _mock_rank):
+        profiling = mock.Mock()
+        profiling.record_memory_history = True
+        profiling.profile_ranks = [0, 7]
+
+        start_memory_history_recording(profiling)
+        mock_record.assert_not_called()
+        mock_attach.assert_not_called()
+
+    @mock.patch("megatron.bridge.training.utils.train_utils.get_rank_safe", return_value=0)
+    @mock.patch("megatron.bridge.training.utils.train_utils.torch.cuda.memory._record_memory_history")
+    @mock.patch("megatron.bridge.training.utils.train_utils.torch._C._cuda_attach_out_of_memory_observer")
+    def test_happy_path_enables_recording_and_attaches_observer(self, mock_attach, mock_record, _mock_rank):
+        profiling = mock.Mock()
+        profiling.record_memory_history = True
+        profiling.profile_ranks = [0]
+        profiling.memory_snapshot_path = "/nemo_run/snapshot.pickle"
+
+        start_memory_history_recording(profiling)
+
+        # Recording enabled with MLM-compatible settings
+        mock_record.assert_called_once()
+        _pos, kwargs = mock_record.call_args
+        assert _pos[0] is True
+        assert kwargs["trace_alloc_max_entries"] == 100_000
+        assert kwargs["trace_alloc_record_context"] is True
+
+        # OOM observer was attached
+        mock_attach.assert_called_once()
+        oom_cb = mock_attach.call_args.args[0]
+        assert callable(oom_cb)
+
+    @mock.patch("megatron.bridge.training.utils.train_utils.get_rank_safe", return_value=0)
+    @mock.patch("megatron.bridge.training.utils.train_utils.torch.cuda.memory._snapshot", return_value={"x": 1})
+    @mock.patch("megatron.bridge.training.utils.train_utils.torch.cuda.memory._record_memory_history")
+    @mock.patch("megatron.bridge.training.utils.train_utils.torch._C._cuda_attach_out_of_memory_observer")
+    def test_oom_observer_writes_rank_tagged_path(self, mock_attach, mock_record, mock_snapshot, _mock_rank, tmp_path):
+        """OOM observer must inject the rank tag via splitext, not as a prefix,
+        so absolute memory_snapshot_path values stay absolute."""
+        snapshot_dir = tmp_path / "run"
+        snapshot_dir.mkdir()
+        snapshot_path = str(snapshot_dir / "snapshot.pickle")
+
+        profiling = mock.Mock()
+        profiling.record_memory_history = True
+        profiling.profile_ranks = [0]
+        profiling.memory_snapshot_path = snapshot_path
+
+        start_memory_history_recording(profiling)
+        oom_cb = mock_attach.call_args.args[0]
+
+        # Fire the observer as torch would (device, alloc, device_alloc, device_free).
+        oom_cb(0, 0, 0, 0)
+
+        expected = snapshot_dir / "snapshot_oom_rank-0.pickle"
+        assert expected.exists(), f"OOM observer should have written {expected}"
+        # The snapshot content is the mocked dict, pickled.
+        import pickle
+
+        with expected.open("rb") as f:
+            assert pickle.load(f) == {"x": 1}


### PR DESCRIPTION
## Summary

Cherry-pick of #3487 into `r0.4.0`. The auto cherry-pick failed on a conflict in `src/megatron/bridge/training/setup.py` import block ordering; resolved manually.

Original change (verbatim from #3487 description):

- `torch.cuda.memory._snapshot()` returns only live allocations unless `torch.cuda.memory._record_memory_history()` has been enabled first. Bridge's snapshot dump in `training_log()` had no matching recording call anywhere in `src/megatron/bridge/`, so pickles written under `profiling.record_memory_history=true` contained no timeline or stacks and were unusable in https://pytorch.org/memory_viz.
- Add `start_memory_history_recording()` invoked from `setup()` right before model construction so every allocation appears in the trace; also attaches an OOM observer that dumps a labeled pickle on out-of-memory.
- Drop an unrelated tensorboard-directory assertion in the snapshot-dump path.
- Change `ProfilingConfig.profile_ranks` default from `[]` to `[0]` so `record_memory_history=true` captures rank 0 without a further Hydra override.
- Default `ProfilingConfig.memory_snapshot_path` to `/nemo_run/snapshot.pickle` so the file lands in the NeMo-Run experiment dir.
- Construct OOM snapshot path via `os.path.splitext` (same pattern as `training_log`).
- Log OOM message via module logger so it reaches stderr on any profiled rank (not just rank 0).
- Includes `tests/unit_tests/training/utils/test_train_utils.py::TestStartMemoryHistoryRecording` covering the four guard paths + the OOM rank-tag path.

Fixes #3166

## Test plan

Validated on `main` via #3487; cherry-pick diff is identical in scope — 4 files, 167 insertions, 6 deletions.