### PR TITLE
[models/deepseek_v4] feat: add weight mapping + CSA/HCA scaffolding

### DIFF
--- a/examples/models/deepseek_v4/verify_roundtrip.py
+++ b/examples/models/deepseek_v4/verify_roundtrip.py
@@ -1,0 +1,183 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Toy-proxy HF→Megatron→HF roundtrip.
+
+Procedure:
+  1. Build reference Transformer on a small config; fill every parameter with
+     randn.
+  2. "Import": apply `translate_hf_to_megatron` to move each tensor into a
+     Megatron-mirror state_dict, then load_state_dict into the mirror model.
+  3. "Export": walk the mirror's parameters and invert the mapping.
+  4. Assert every exported tensor is bit-identical to the original HF tensor
+     (same dtype, same device, elementwise equal).
+
+No GPU, no Megatron-Core, no transformers — this exercises the bridge mapping
+in isolation.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import torch
+
+
+# ---- minimal loader (same pattern as verify_weight_mapping.py) -------------
+_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+_PKG = _ROOT / "src" / "megatron" / "bridge" / "models" / "deepseek_v4"
+
+
+def _load(mod_name: str, file_rel: str):
+    spec = importlib.util.spec_from_file_location(mod_name, _PKG / file_rel)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_reference = _load("deepseek_v4_reference", "modeling_deepseek_v4/reference.py")
+sys.modules["megatron.bridge.models.deepseek_v4.modeling_deepseek_v4.reference"] = _reference
+_mirror = _load("deepseek_v4_mirror", "modeling_deepseek_v4/megatron_mirror.py")
+_bridge = _load("deepseek_v4_bridge", "deepseek_v4_bridge.py")
+
+DeepSeekV4ModelArgs = _reference.DeepSeekV4ModelArgs
+DeepSeekV4Transformer = _reference.DeepSeekV4Transformer
+DeepSeekV4MegatronModel = _mirror.DeepSeekV4MegatronModel
+build_translation_table = _bridge.build_translation_table
+
+
+def toy_args() -> DeepSeekV4ModelArgs:
+    """Tiny config covering every V4 branch (hash layer, dense/compress/index attn, MTP)."""
+    return DeepSeekV4ModelArgs(
+        max_batch_size=1,
+        max_seq_len=64,
+        vocab_size=256,
+        dim=64,
+        moe_inter_dim=64,
+        n_layers=6,
+        n_hash_layers=1,
+        n_mtp_layers=1,
+        n_heads=4,
+        n_routed_experts=4,
+        n_shared_experts=1,
+        n_activated_experts=2,
+        q_lora_rank=128,
+        head_dim=64,
+        rope_head_dim=16,
+        o_groups=2,
+        o_lora_rank=128,
+        window_size=16,
+        compress_ratios=(0, 0, 4, 128, 4, 0, 4),
+        index_n_heads=4,
+        index_head_dim=32,
+        index_topk=8,
+        hc_mult=4,
+    )
+
+
+def _seed_random(model: torch.nn.Module, seed: int = 0) -> None:
+    gen = torch.Generator().manual_seed(seed)
+    for name, p in model.named_parameters():
+        if p.dtype.is_floating_point:
+            p.data = torch.randn(p.shape, generator=gen, dtype=p.dtype)
+        elif p.dtype == torch.int32:
+            p.data = torch.randint(0, 32, p.shape, generator=gen, dtype=p.dtype)
+
+
+import_hf_to_megatron = _bridge.import_hf_state_dict
+export_megatron_to_hf = _bridge.export_hf_state_dict
+
+
+def run() -> int:
+    """Seed randomly, import to mirror, export, assert bit-identical roundtrip."""
+    args = toy_args()
+    torch.manual_seed(42)
+
+    print("[build HF-side reference with random weights]")
+    hf_model = DeepSeekV4Transformer(args)
+    _seed_random(hf_model, seed=1)
+    hf_sd_original = {k: v.detach().clone() for k, v in hf_model.state_dict().items()}
+    print(f"  {len(hf_sd_original)} params seeded")
+
+    print("[build Megatron-mirror]")
+    mg_model = DeepSeekV4MegatronModel(args)
+    print(f"  {len(mg_model.state_dict())} params allocated (pre-load)")
+
+    print("[HF -> Megatron import]")
+    mg_sd_imported = import_hf_to_megatron(hf_sd_original, args)
+    # Load into the mirror to exercise nn.Module load path end-to-end.
+    missing, unexpected = mg_model.load_state_dict(mg_sd_imported, strict=False)
+    if missing or unexpected:
+        print(f"  missing={len(missing)}, unexpected={len(unexpected)}")
+        for k in missing[:5]:
+            print(f"    missing: {k}")
+        for k in unexpected[:5]:
+            print(f"    unexpected: {k}")
+    mg_sd_post_load = dict(mg_model.state_dict())
+
+    # Compare tensors pre-load and post-load to confirm the mirror stores them intact.
+    post_load_mismatches = []
+    for k, v in mg_sd_imported.items():
+        if not torch.equal(mg_sd_post_load[k], v):
+            post_load_mismatches.append(k)
+    if post_load_mismatches:
+        print(f"  ERROR: mirror mutated {len(post_load_mismatches)} tensors on load")
+        for k in post_load_mismatches[:5]:
+            print(f"    - {k}")
+        return 1
+    print(f"  mirror holds {len(mg_sd_post_load)} tensors intact")
+
+    print("[Megatron -> HF export]")
+    hf_sd_export = export_megatron_to_hf(mg_sd_post_load, args)
+    print(f"  re-exported {len(hf_sd_export)} HF keys")
+
+    print("[key set equality]")
+    orig_keys = set(hf_sd_original)
+    new_keys = set(hf_sd_export)
+    missing_after_rt = orig_keys - new_keys
+    extra_after_rt = new_keys - orig_keys
+    if missing_after_rt or extra_after_rt:
+        print(f"  ERROR: key drift (missing={len(missing_after_rt)}, extra={len(extra_after_rt)})")
+        for k in sorted(missing_after_rt)[:5]:
+            print(f"    - {k}")
+        for k in sorted(extra_after_rt)[:5]:
+            print(f"    + {k}")
+        return 1
+    print(f"  OK: same {len(orig_keys)} keys")
+
+    print("[elementwise equality on every tensor]")
+    mismatches = []
+    for k, v_orig in hf_sd_original.items():
+        v_new = hf_sd_export[k]
+        if v_orig.dtype != v_new.dtype:
+            mismatches.append((k, "dtype", v_orig.dtype, v_new.dtype))
+            continue
+        if v_orig.shape != v_new.shape:
+            mismatches.append((k, "shape", tuple(v_orig.shape), tuple(v_new.shape)))
+            continue
+        if not torch.equal(v_orig, v_new):
+            max_abs = (v_orig.float() - v_new.float()).abs().max().item()
+            mismatches.append((k, "values", "", f"max|Δ|={max_abs}"))
+    if mismatches:
+        print(f"  ERROR: {len(mismatches)} tensor(s) differ after roundtrip")
+        for k, kind, lhs, rhs in mismatches[:10]:
+            print(f"    {kind:>6}  {k}  {lhs} vs {rhs}")
+        return 1
+    print(f"  OK: all {len(hf_sd_original)} tensors elementwise equal")
+
+    print()
+    print("=" * 60)
+    print("RESULT: toy roundtrip passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(run())

--- a/examples/models/deepseek_v4/verify_weight_mapping.py
+++ b/examples/models/deepseek_v4/verify_weight_mapping.py
@@ -1,0 +1,264 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Verify DeepSeek-V4 HF ↔ Megatron weight-name + shape parity on a toy config.
+
+Usage (toy, no GPU, runs anywhere):
+    uv run python examples/models/deepseek_v4/verify_weight_mapping.py
+
+With `--hf-index <path/to/model.safetensors.index.json>` the real Flash
+checkpoint's key list is cross-checked against what the reference port
+produces (sizes are not fetched).
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from dataclasses import asdict
+from pathlib import Path
+
+import torch
+
+
+# Load the three deepseek_v4 modules by file path so this script can run in a
+# bare Python env (the top-level `megatron.bridge` package pulls in heavy
+# Megatron-Core / TransformerEngine deps that aren't available on every box).
+_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+_PKG = _ROOT / "src" / "megatron" / "bridge" / "models" / "deepseek_v4"
+
+
+def _load(mod_name: str, file_rel: str):
+    spec = importlib.util.spec_from_file_location(mod_name, _PKG / file_rel)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_reference = _load(
+    "deepseek_v4_reference",
+    "modeling_deepseek_v4/reference.py",
+)
+DeepSeekV4ModelArgs = _reference.DeepSeekV4ModelArgs
+DeepSeekV4Transformer = _reference.DeepSeekV4Transformer
+
+# The sibling modules import `from megatron.bridge...deepseek_v4.modeling_deepseek_v4.reference`;
+# register our hand-loaded reference under that package path so the imports resolve
+# without needing to build the full `megatron.bridge` package.
+sys.modules.setdefault("megatron.bridge.models.deepseek_v4.modeling_deepseek_v4.reference", _reference)
+
+_mirror = _load("deepseek_v4_mirror", "modeling_deepseek_v4/megatron_mirror.py")
+DeepSeekV4MegatronModel = _mirror.DeepSeekV4MegatronModel
+
+_bridge = _load("deepseek_v4_bridge", "deepseek_v4_bridge.py")
+build_translation_table = _bridge.build_translation_table
+translate_hf_to_megatron = _bridge.translate_hf_to_megatron
+
+
+def toy_args() -> DeepSeekV4ModelArgs:
+    """Small enough to instantiate on CPU in seconds; exercises every branch:
+    hash layers present, dense + compressed + indexed attention layers, MTP."""
+    return DeepSeekV4ModelArgs(
+        max_batch_size=1,
+        max_seq_len=64,
+        vocab_size=256,
+        dim=64,
+        moe_inter_dim=64,
+        n_layers=6,
+        n_hash_layers=1,
+        n_mtp_layers=1,
+        n_heads=4,
+        n_routed_experts=4,
+        n_shared_experts=1,
+        n_activated_experts=2,
+        q_lora_rank=128,
+        head_dim=64,
+        rope_head_dim=16,
+        o_groups=2,
+        o_lora_rank=128,
+        window_size=16,
+        # Mix of 0 (pure sliding), 4 (compress+index), and 128 (compress-only).
+        # Length is n_layers + n_mtp_layers (matches real config convention).
+        compress_ratios=(0, 0, 4, 128, 4, 0, 4),
+        index_n_heads=4,
+        index_head_dim=32,
+        index_topk=8,
+        hc_mult=4,
+    )
+
+
+def run(hf_index: Path | None) -> int:
+    """Build both toy models and check name/shape/dtype parity (incl. fanouts)."""
+    args = toy_args()
+    print("[toy config]")
+    for k, v in asdict(args).items():
+        print(f"  {k}: {v}")
+    print()
+
+    print("[build reference (HF-side) model]")
+    with torch.device("meta"):
+        hf_model = DeepSeekV4Transformer(args)
+    hf_keys = set(hf_model.state_dict().keys())
+    print(f"  {len(hf_keys)} params")
+
+    print("[build megatron-mirror model]")
+    with torch.device("meta"):
+        mg_model = DeepSeekV4MegatronModel(args)
+    mg_keys = set(mg_model.state_dict().keys())
+    print(f"  {len(mg_keys)} params")
+    print()
+
+    print("[enumerate expected HF keys via build_translation_table]")
+    table = build_translation_table(args)
+    enum_hf = {e.hf for e in table}
+    enum_mg = {e.megatron for e in table}
+
+    # Cross-checks
+    status = 0
+    missing_from_enum = hf_keys - enum_hf
+    extra_in_enum = enum_hf - hf_keys
+    if missing_from_enum:
+        status = 1
+        print(f"  ERROR: {len(missing_from_enum)} HF key(s) emitted by reference but NOT in build_translation_table:")
+        for k in sorted(missing_from_enum)[:20]:
+            print(f"    - {k}")
+    if extra_in_enum:
+        status = 1
+        print(f"  ERROR: {len(extra_in_enum)} key(s) in build_translation_table but NOT emitted by reference:")
+        for k in sorted(extra_in_enum)[:20]:
+            print(f"    - {k}")
+
+    mg_missing = enum_mg - mg_keys
+    mg_extra = mg_keys - enum_mg
+    if mg_missing:
+        status = 1
+        print(f"  ERROR: {len(mg_missing)} Megatron key(s) expected by table but NOT emitted by megatron_mirror:")
+        for k in sorted(mg_missing)[:20]:
+            print(f"    - {k}")
+    if mg_extra:
+        status = 1
+        print(f"  ERROR: {len(mg_extra)} Megatron key(s) emitted by megatron_mirror but NOT expected by table:")
+        for k in sorted(mg_extra)[:20]:
+            print(f"    - {k}")
+
+    print()
+    print("[shape parity — honours 1→N fanouts]")
+    hf_sd = hf_model.state_dict()
+    mg_sd = mg_model.state_dict()
+    shape_mismatches: list[tuple[object, tuple, tuple]] = []
+    dtype_mismatches: list[tuple[object, object, object]] = []
+    # Group table entries by HF key — multi-entry groups are fanouts.
+    from collections import defaultdict
+
+    by_hf: dict[str, list] = defaultdict(list)
+    for e in table:
+        by_hf[e.hf].append(e)
+
+    for hf_key, group in by_hf.items():
+        hf_t = hf_sd[hf_key]
+        if len(group) == 1:
+            mg_t = mg_sd[group[0].megatron]
+            if tuple(hf_t.shape) != tuple(mg_t.shape):
+                shape_mismatches.append((group[0], tuple(hf_t.shape), tuple(mg_t.shape)))
+            if hf_t.dtype != mg_t.dtype:
+                dtype_mismatches.append((group[0], hf_t.dtype, mg_t.dtype))
+        else:
+            # fanout: expect total numel(mg pieces) == numel(hf)
+            mg_ts = [mg_sd[e.megatron] for e in group]
+            total = sum(t.numel() for t in mg_ts)
+            if total != hf_t.numel():
+                shape_mismatches.append((group[0], tuple(hf_t.shape), f"fanout {len(group)} pieces, total={total}"))
+            for e, mg_t in zip(group, mg_ts):
+                if hf_t.dtype != mg_t.dtype:
+                    dtype_mismatches.append((e, hf_t.dtype, mg_t.dtype))
+
+    if shape_mismatches:
+        status = 1
+        print(f"  ERROR: {len(shape_mismatches)} shape mismatch(es):")
+        for e, hs, ms in shape_mismatches[:20]:
+            print(f"    {e.hf}  {hs}  vs  {e.megatron}  {ms}")
+    else:
+        print(f"  OK: all {len(by_hf)} HF params covered (with fanouts honoured)")
+
+    print()
+    print("[dtype parity]")
+    if dtype_mismatches:
+        status = 1
+        print(f"  ERROR: {len(dtype_mismatches)} dtype mismatch(es):")
+        for e, hd, md in dtype_mismatches[:20]:
+            print(f"    {e.hf}  {hd}  vs  {e.megatron}  {md}")
+    else:
+        print(f"  OK: all {len(table)} (megatron-side) entries dtype-aligned")
+
+    if hf_index is not None:
+        print()
+        print(f"[cross-check against real checkpoint index: {hf_index}]")
+        idx = json.loads(hf_index.read_text())
+        real_keys = set(idx["weight_map"].keys())
+        status |= _cross_check_real_keys(real_keys)
+
+    print()
+    print("=" * 60)
+    if status == 0:
+        print("RESULT: all checks passed")
+    else:
+        print("RESULT: one or more checks failed")
+    return status
+
+
+def _cross_check_real_keys(real_keys: set[str]) -> int:
+    """Translate every real HF key via `translate_hf_to_megatron`. Collect any
+    untranslatable keys as gaps in the mapping. Returns non-zero if any gaps."""
+    status = 0
+    unmapped: dict[str, int] = {}
+    translated = 0
+    mg_keys: set[str] = set()
+    for k in real_keys:
+        try:
+            mg_keys.add(translate_hf_to_megatron(k))
+            translated += 1
+        except KeyError:
+            # Coarse-bucket so we don't print 200 identical-shape entries.
+            bucket = _bucket_key(k)
+            unmapped[bucket] = unmapped.get(bucket, 0) + 1
+
+    total = len(real_keys)
+    print(f"  translated {translated}/{total} real keys -> {len(mg_keys)} unique megatron keys")
+    if unmapped:
+        status = 1
+        print(f"  unmapped buckets ({len(unmapped)}):")
+        for bucket, count in sorted(unmapped.items(), key=lambda kv: -kv[1])[:20]:
+            print(f"    [{count:>5}x]  {bucket}")
+    return status
+
+
+def _bucket_key(k: str) -> str:
+    """Replace all digit runs with `*` so many similar keys collapse to one."""
+    import re as _re
+
+    return _re.sub(r"\d+", "*", k)
+
+
+def main() -> int:
+    """CLI entry point."""
+    p = argparse.ArgumentParser()
+    p.add_argument(
+        "--hf-index",
+        type=Path,
+        default=None,
+        help="Path to model.safetensors.index.json from the real DSV4-Flash checkpoint.",
+    )
+    args = p.parse_args()
+    return run(args.hf_index)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/megatron/bridge/models/deepseek_v4/__init__.py
+++ b/src/megatron/bridge/models/deepseek_v4/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from megatron.bridge.models.deepseek_v4 import deepseek_v4_bridge  # noqa: F401

--- a/src/megatron/bridge/models/deepseek_v4/deepseek_v4_bridge.py
+++ b/src/megatron/bridge/models/deepseek_v4/deepseek_v4_bridge.py
@@ -1,0 +1,425 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DeepSeek-V4-Flash weight mapping.
+
+The HF checkpoint ships in inference format (keys like `layers.0.attn.wq_a.weight`).
+On the Megatron side we target:
+
+* HC:  block-level `hc_attn` / `hc_ffn` matching `mcore.HyperConnectionModule`:
+       `mapping_proj.weight [n²+2n, n·C]` + `bias [n²+2n]` + three scalar
+       `alpha_pre / alpha_post / alpha_res [1]`.
+       Head-level `hc_head_*` stays raw (the inference head uses an n-row
+       variant that mcore's HC module does not cover).
+* CSA: `self_attention.*` — Compressed Sparse Attention block (low-rank Q,
+       single KV, grouped HCA O, optional Compressor + Indexer).
+* HCA: `self_attention.o_head_grouped.linear_o_{down,up}_proj.*`.
+* MoE: `mlp.*`.
+* MTP: `mtp.layers.N.*` with `mtp_model_layer.*` for the inner block.
+
+Some mappings are 1-to-1 renames. A few are structural:
+
+* HF `hc_*_scale [3]` fans out to 3 separate scalar params on the mcore side.
+* HF `hc_*_fn`  → `mapping_proj.weight`;  HF `hc_*_base` → `bias` — same shape.
+
+Export (`megatron → hf`) is the inverse: the three alphas are stacked into a
+length-3 tensor. Roundtrip preserves identity.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Dict, Iterator, List
+
+import torch
+
+from megatron.bridge.models.deepseek_v4.modeling_deepseek_v4.reference import DeepSeekV4ModelArgs
+
+
+# ============================================================================
+# Rename tables (1-to-1 static keys within each sub-tree)
+# ============================================================================
+
+# Attention sub-tree — HF `attn.*` → Megatron `self_attention.*`.
+_ATTN_RENAMES: Dict[str, str] = {
+    "attn.attn_sink": "self_attention.attn_sink",
+    "attn.wq_a.weight": "self_attention.linear_q_down_proj.weight",
+    "attn.wq_a.scale": "self_attention.linear_q_down_proj.scale",
+    "attn.wq_b.weight": "self_attention.linear_q_up_proj.weight",
+    "attn.wq_b.scale": "self_attention.linear_q_up_proj.scale",
+    "attn.q_norm.weight": "self_attention.q_layernorm.weight",
+    "attn.wkv.weight": "self_attention.linear_kv_proj.weight",
+    "attn.wkv.scale": "self_attention.linear_kv_proj.scale",
+    "attn.kv_norm.weight": "self_attention.kv_layernorm.weight",
+    # HCA: grouped low-rank O-projection.
+    "attn.wo_a.weight": "self_attention.o_head_grouped.linear_o_down_proj.weight",
+    "attn.wo_a.scale": "self_attention.o_head_grouped.linear_o_down_proj.scale",
+    "attn.wo_b.weight": "self_attention.o_head_grouped.linear_o_up_proj.weight",
+    "attn.wo_b.scale": "self_attention.o_head_grouped.linear_o_up_proj.scale",
+    # CSA optional — Compressor (compress_ratio != 0)
+    "attn.compressor.ape": "self_attention.compressor.ape",
+    "attn.compressor.wkv.weight": "self_attention.compressor.wkv.weight",
+    "attn.compressor.wgate.weight": "self_attention.compressor.wgate.weight",
+    "attn.compressor.norm.weight": "self_attention.compressor.norm.weight",
+    # CSA optional — Indexer (compress_ratio == 4), extends mcore DSA indexer.
+    "attn.indexer.wq_b.weight": "self_attention.indexer.linear_q_up_proj.weight",
+    "attn.indexer.wq_b.scale": "self_attention.indexer.linear_q_up_proj.scale",
+    "attn.indexer.weights_proj.weight": "self_attention.indexer.weights_proj.weight",
+    "attn.indexer.compressor.ape": "self_attention.indexer.compressor.ape",
+    "attn.indexer.compressor.wkv.weight": "self_attention.indexer.compressor.wkv.weight",
+    "attn.indexer.compressor.wgate.weight": "self_attention.indexer.compressor.wgate.weight",
+    "attn.indexer.compressor.norm.weight": "self_attention.indexer.compressor.norm.weight",
+}
+
+_MOE_FIXED_RENAMES: Dict[str, str] = {
+    "ffn.gate.weight": "mlp.router.weight",
+    "ffn.gate.bias": "mlp.router.bias",
+    "ffn.gate.tid2eid": "mlp.router.tid2eid",
+    "ffn.shared_experts.w1.weight": "mlp.shared_experts.linear_fc1_gate.weight",
+    "ffn.shared_experts.w1.scale": "mlp.shared_experts.linear_fc1_gate.scale",
+    "ffn.shared_experts.w3.weight": "mlp.shared_experts.linear_fc1_up.weight",
+    "ffn.shared_experts.w3.scale": "mlp.shared_experts.linear_fc1_up.scale",
+    "ffn.shared_experts.w2.weight": "mlp.shared_experts.linear_fc2.weight",
+    "ffn.shared_experts.w2.scale": "mlp.shared_experts.linear_fc2.scale",
+}
+
+_EXPERT_W_TO_MEGATRON = {"w1": "linear_fc1_gate", "w2": "linear_fc2", "w3": "linear_fc1_up"}
+_EXPERT_RE = re.compile(r"^ffn\.experts\.(\d+)\.(w[123])\.(weight|scale)$")
+
+# Per-block HC: the fn / base rename to mapping_proj.weight / bias. The `scale`
+# fan-out is handled separately (not a 1-to-1 rename).
+_HC_BLOCK_SIMPLE_RENAMES: Dict[str, str] = {
+    "hc_attn_fn": "hc_attn.mapping_proj.weight",
+    "hc_attn_base": "hc_attn.bias",
+    "hc_ffn_fn": "hc_ffn.mapping_proj.weight",
+    "hc_ffn_base": "hc_ffn.bias",
+}
+
+# HF `hc_*_scale [3]` -> ordered list of 3 mcore scalar params.
+_HC_SCALE_FANOUT: Dict[str, List[str]] = {
+    "hc_attn_scale": ["hc_attn.alpha_pre", "hc_attn.alpha_post", "hc_attn.alpha_res"],
+    "hc_ffn_scale": ["hc_ffn.alpha_pre", "hc_ffn.alpha_post", "hc_ffn.alpha_res"],
+}
+
+_LAYER_FIXED_RENAMES: Dict[str, str] = {
+    "attn_norm.weight": "input_layernorm.weight",
+    "ffn_norm.weight": "pre_mlp_layernorm.weight",
+    **_HC_BLOCK_SIMPLE_RENAMES,
+}
+
+_MTP_FIXED_RENAMES: Dict[str, str] = {
+    "e_proj.weight": "e_proj.weight",
+    "e_proj.scale": "e_proj.scale",
+    "h_proj.weight": "h_proj.weight",
+    "h_proj.scale": "h_proj.scale",
+    "enorm.weight": "enorm.weight",
+    "hnorm.weight": "hnorm.weight",
+    "norm.weight": "final_layernorm.weight",
+    "hc_head_fn": "hc_head_fn",
+    "hc_head_base": "hc_head_base",
+    "hc_head_scale": "hc_head_scale",
+}
+
+_ROOT_RENAMES: Dict[str, str] = {
+    "embed.weight": "embedding.word_embeddings.weight",
+    "norm.weight": "decoder.final_layernorm.weight",
+    "head.weight": "output_layer.weight",
+    "hc_head_fn": "decoder.hc_head_fn",
+    "hc_head_base": "decoder.hc_head_base",
+    "hc_head_scale": "decoder.hc_head_scale",
+}
+
+
+_LAYER_RE = re.compile(r"^layers\.(\d+)\.(.+)$")
+_MTP_RE = re.compile(r"^mtp\.(\d+)\.(.+)$")
+
+
+# ============================================================================
+# Public API — import / export a state_dict.
+#
+# The mapping is not a pure rename: HC scale fans 1→3. We therefore operate on
+# whole state_dicts (not single keys) so the structural ops live in one place.
+# ============================================================================
+
+
+@dataclass(frozen=True)
+class TranslationEntry:
+    """One row of the HF ↔ Megatron name translation table.
+
+    `kind` is `"rename"` for 1-to-1 mappings and `"hc_scale_split"` when the
+    same HF key fans out to multiple Megatron params (the 3 alphas).
+    """
+
+    hf: str
+    megatron: str
+    kind: str = "rename"  # "rename" | "hc_scale_split" | "hc_scale_join"
+
+
+def import_hf_state_dict(hf_sd: Dict[str, torch.Tensor], args: DeepSeekV4ModelArgs) -> Dict[str, torch.Tensor]:
+    """Translate an HF-format state_dict into the Megatron-mirror layout."""
+    out: Dict[str, torch.Tensor] = {}
+    for hf_key, tensor in hf_sd.items():
+        _translate_and_place(hf_key, tensor, out)
+    _sanity_check_count(hf_sd, out, args, direction="hf->mg")
+    return out
+
+
+def export_hf_state_dict(mg_sd: Dict[str, torch.Tensor], args: DeepSeekV4ModelArgs) -> Dict[str, torch.Tensor]:
+    """Inverse — produce an HF-format state_dict from a Megatron-mirror one."""
+    out: Dict[str, torch.Tensor] = {}
+    # Pre-build a set of mcore keys we'll need to JOIN back into hc_*_scale.
+    for hf_key in _enumerate_hf_keys(args):
+        _export_one(hf_key, mg_sd, out)
+    _sanity_check_count(mg_sd, out, args, direction="mg->hf")
+    return out
+
+
+# --- implementation details -------------------------------------------------
+
+
+def _translate_and_place(hf_key: str, tensor: torch.Tensor, out: Dict[str, torch.Tensor]) -> None:
+    if hf_key in _ROOT_RENAMES:
+        out[_ROOT_RENAMES[hf_key]] = tensor
+        return
+
+    m = _LAYER_RE.match(hf_key)
+    if m is not None:
+        layer_idx, suffix = m.group(1), m.group(2)
+        prefix = f"decoder.layers.{layer_idx}"
+        for mg_suffix, piece in _translate_block_key(suffix, tensor, is_mtp=False):
+            out[f"{prefix}.{mg_suffix}"] = piece
+        return
+
+    m = _MTP_RE.match(hf_key)
+    if m is not None:
+        mtp_idx, suffix = m.group(1), m.group(2)
+        prefix = f"mtp.layers.{mtp_idx}"
+        for mg_suffix, piece in _translate_block_key(suffix, tensor, is_mtp=True):
+            out[f"{prefix}.{mg_suffix}"] = piece
+        return
+
+    raise KeyError(f"Unrecognized DeepSeek-V4 HF key: {hf_key!r}")
+
+
+def _translate_block_key(suffix: str, tensor: torch.Tensor, *, is_mtp: bool) -> Iterator[tuple[str, torch.Tensor]]:
+    """Yield (megatron-suffix, tensor) pairs for a single HF block-relative key.
+
+    Fanout: `hc_*_scale [3]` → three `(mcore_name, scalar)` pairs.
+    """
+    if is_mtp and suffix in _MTP_FIXED_RENAMES:
+        yield _MTP_FIXED_RENAMES[suffix], tensor
+        return
+
+    for mg_suffix, piece in _translate_inner(suffix, tensor):
+        yield (f"mtp_model_layer.{mg_suffix}" if is_mtp else mg_suffix, piece)
+
+
+def _translate_inner(suffix: str, tensor: torch.Tensor) -> Iterator[tuple[str, torch.Tensor]]:
+    if suffix in _LAYER_FIXED_RENAMES:
+        yield _LAYER_FIXED_RENAMES[suffix], tensor
+        return
+    if suffix in _ATTN_RENAMES:
+        yield _ATTN_RENAMES[suffix], tensor
+        return
+    if suffix in _MOE_FIXED_RENAMES:
+        yield _MOE_FIXED_RENAMES[suffix], tensor
+        return
+    if suffix in _HC_SCALE_FANOUT:
+        names = _HC_SCALE_FANOUT[suffix]
+        # Split tensor [3] into three scalar params of shape [1].
+        if tensor.shape != (3,):
+            raise ValueError(f"Expected HF {suffix} to be shape (3,), got {tuple(tensor.shape)}")
+        for i, mg_name in enumerate(names):
+            yield mg_name, tensor[i : i + 1].clone()
+        return
+    m = _EXPERT_RE.match(suffix)
+    if m is not None:
+        idx, w, t = m.group(1), m.group(2), m.group(3)
+        yield f"mlp.experts.{idx}.{_EXPERT_W_TO_MEGATRON[w]}.{t}", tensor
+        return
+    raise KeyError(f"Unrecognized DeepSeek-V4 block-relative key: {suffix!r}")
+
+
+def _export_one(hf_key: str, mg_sd: Dict[str, torch.Tensor], out: Dict[str, torch.Tensor]) -> None:
+    # Find the *set* of mcore keys that map to this HF key (1, or 3 for scale).
+    mg_names = _hf_key_to_megatron_keys(hf_key)
+    if len(mg_names) == 1:
+        out[hf_key] = mg_sd[mg_names[0]]
+    else:
+        # hc_*_scale: concatenate three [1] tensors into [3].
+        pieces = [mg_sd[name] for name in mg_names]
+        out[hf_key] = torch.cat(pieces, dim=0)
+
+
+def _hf_key_to_megatron_keys(hf_key: str) -> List[str]:
+    if hf_key in _ROOT_RENAMES:
+        return [_ROOT_RENAMES[hf_key]]
+    m = _LAYER_RE.match(hf_key)
+    if m is not None:
+        layer_idx, suffix = m.group(1), m.group(2)
+        prefix = f"decoder.layers.{layer_idx}"
+        return [f"{prefix}.{s}" for s in _inner_mcore_suffixes(suffix, is_mtp=False)]
+    m = _MTP_RE.match(hf_key)
+    if m is not None:
+        mtp_idx, suffix = m.group(1), m.group(2)
+        prefix = f"mtp.layers.{mtp_idx}"
+        return [f"{prefix}.{s}" for s in _inner_mcore_suffixes(suffix, is_mtp=True)]
+    raise KeyError(f"Unrecognized DeepSeek-V4 HF key: {hf_key!r}")
+
+
+def _inner_mcore_suffixes(suffix: str, *, is_mtp: bool) -> List[str]:
+    if is_mtp and suffix in _MTP_FIXED_RENAMES:
+        return [_MTP_FIXED_RENAMES[suffix]]
+    base = _inner_mcore_block_suffixes(suffix)
+    return [f"mtp_model_layer.{s}" if is_mtp else s for s in base]
+
+
+def _inner_mcore_block_suffixes(suffix: str) -> List[str]:
+    if suffix in _LAYER_FIXED_RENAMES:
+        return [_LAYER_FIXED_RENAMES[suffix]]
+    if suffix in _ATTN_RENAMES:
+        return [_ATTN_RENAMES[suffix]]
+    if suffix in _MOE_FIXED_RENAMES:
+        return [_MOE_FIXED_RENAMES[suffix]]
+    if suffix in _HC_SCALE_FANOUT:
+        return list(_HC_SCALE_FANOUT[suffix])
+    m = _EXPERT_RE.match(suffix)
+    if m is not None:
+        idx, w, t = m.group(1), m.group(2), m.group(3)
+        return [f"mlp.experts.{idx}.{_EXPERT_W_TO_MEGATRON[w]}.{t}"]
+    raise KeyError(f"Unrecognized DeepSeek-V4 block-relative key: {suffix!r}")
+
+
+# ============================================================================
+# Enumeration (used by tests; cheap to call)
+# ============================================================================
+
+
+def _enumerate_hf_keys(args: DeepSeekV4ModelArgs) -> Iterator[str]:
+    yield "embed.weight"
+    yield "norm.weight"
+    yield "head.weight"
+    yield "hc_head_fn"
+    yield "hc_head_base"
+    yield "hc_head_scale"
+    for layer_idx in range(args.n_layers):
+        for key in _enumerate_block_keys(layer_idx, args):
+            yield f"layers.{layer_idx}.{key}"
+    for i in range(args.n_mtp_layers):
+        layer_id = args.n_layers + i
+        for key in _enumerate_block_keys(layer_id, args):
+            yield f"mtp.{i}.{key}"
+        yield from (f"mtp.{i}.{k}" for k in _MTP_FIXED_RENAMES)
+
+
+def _enumerate_block_keys(layer_id: int, args: DeepSeekV4ModelArgs) -> Iterator[str]:
+    yield "attn_norm.weight"
+    yield "ffn_norm.weight"
+    yield "hc_attn_fn"
+    yield "hc_attn_base"
+    yield "hc_attn_scale"
+    yield "hc_ffn_fn"
+    yield "hc_ffn_base"
+    yield "hc_ffn_scale"
+    yield "attn.attn_sink"
+    yield "attn.wq_a.weight"
+    yield "attn.wq_a.scale"
+    yield "attn.wq_b.weight"
+    yield "attn.wq_b.scale"
+    yield "attn.q_norm.weight"
+    yield "attn.wkv.weight"
+    yield "attn.wkv.scale"
+    yield "attn.kv_norm.weight"
+    yield "attn.wo_a.weight"
+    yield "attn.wo_a.scale"
+    yield "attn.wo_b.weight"
+    yield "attn.wo_b.scale"
+    compress_ratio = args.compress_ratios[layer_id]
+    if compress_ratio:
+        yield "attn.compressor.ape"
+        yield "attn.compressor.wkv.weight"
+        yield "attn.compressor.wgate.weight"
+        yield "attn.compressor.norm.weight"
+        if compress_ratio == 4:
+            yield "attn.indexer.wq_b.weight"
+            yield "attn.indexer.wq_b.scale"
+            yield "attn.indexer.weights_proj.weight"
+            yield "attn.indexer.compressor.ape"
+            yield "attn.indexer.compressor.wkv.weight"
+            yield "attn.indexer.compressor.wgate.weight"
+            yield "attn.indexer.compressor.norm.weight"
+    yield "ffn.gate.weight"
+    if layer_id < args.n_hash_layers:
+        yield "ffn.gate.tid2eid"
+    else:
+        yield "ffn.gate.bias"
+    for i in range(args.n_routed_experts):
+        for w in ("w1", "w2", "w3"):
+            yield f"ffn.experts.{i}.{w}.weight"
+            yield f"ffn.experts.{i}.{w}.scale"
+    for w in ("w1", "w2", "w3"):
+        yield f"ffn.shared_experts.{w}.weight"
+        yield f"ffn.shared_experts.{w}.scale"
+
+
+def _sanity_check_count(
+    inputs: Dict[str, torch.Tensor],
+    outputs: Dict[str, torch.Tensor],
+    args: DeepSeekV4ModelArgs,
+    *,
+    direction: str,
+) -> None:
+    # On HF->Mg, 3 HF scale params per HC-block expand to 3+3=6 mcore alphas,
+    # plus 2 for fn/base renames (unchanged count for those). Net: +2 per HC
+    # group per block. Track it precisely.
+    expected_mg = _expected_megatron_key_count(args)
+    expected_hf = sum(1 for _ in _enumerate_hf_keys(args))
+    if direction == "hf->mg":
+        if len(outputs) != expected_mg:
+            raise AssertionError(f"hf->mg produced {len(outputs)} keys, expected {expected_mg}")
+    else:
+        if len(outputs) != expected_hf:
+            raise AssertionError(f"mg->hf produced {len(outputs)} keys, expected {expected_hf}")
+
+
+def _expected_megatron_key_count(args: DeepSeekV4ModelArgs) -> int:
+    n_hf = sum(1 for _ in _enumerate_hf_keys(args))
+    # Each block has 2 HC scales (attn, ffn) that fan 1→3, so +2 keys per scale.
+    blocks = args.n_layers + args.n_mtp_layers
+    hc_scale_fanout_extra = 2 * 2 * blocks  # 2 scales * (3-1 extra) = 4 extra per block
+    return n_hf + hc_scale_fanout_extra
+
+
+# ============================================================================
+# Backward-compat helpers (used by earlier verification scripts)
+# ============================================================================
+
+
+def translate_hf_to_megatron(hf_key: str) -> str:
+    """Single-key rename — returns the *first* mcore key for 1→N fanouts."""
+    return _hf_key_to_megatron_keys(hf_key)[0]
+
+
+def build_translation_table(args: DeepSeekV4ModelArgs):
+    """Flat list of HF-key / megatron-key pairs (multi-entry for fanouts)."""
+    entries: List[TranslationEntry] = []
+    for hf_key in _enumerate_hf_keys(args):
+        mg_keys = _hf_key_to_megatron_keys(hf_key)
+        if len(mg_keys) == 1:
+            entries.append(TranslationEntry(hf=hf_key, megatron=mg_keys[0]))
+        else:
+            for mg in mg_keys:
+                entries.append(TranslationEntry(hf=hf_key, megatron=mg, kind="hc_scale_split"))
+    return entries

--- a/src/megatron/bridge/models/deepseek_v4/modeling_deepseek_v4/__init__.py
+++ b/src/megatron/bridge/models/deepseek_v4/modeling_deepseek_v4/__init__.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from megatron.bridge.models.deepseek_v4.modeling_deepseek_v4.megatron_mirror import (
+    DeepSeekV4MegatronModel,
+)
+from megatron.bridge.models.deepseek_v4.modeling_deepseek_v4.reference import (
+    DeepSeekV4ModelArgs,
+    DeepSeekV4Transformer,
+)
+
+
+__all__ = [
+    "DeepSeekV4ModelArgs",
+    "DeepSeekV4Transformer",
+    "DeepSeekV4MegatronModel",
+]

--- a/src/megatron/bridge/models/deepseek_v4/modeling_deepseek_v4/megatron_mirror.py
+++ b/src/megatron/bridge/models/deepseek_v4/modeling_deepseek_v4/megatron_mirror.py
@@ -1,0 +1,320 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Megatron-side mirror of DeepSeek-V4-Flash.
+
+Parameter names follow Megatron conventions, with two V4-specific sub-modules
+introduced:
+
+* **CSA** — Compressed Sparse Attention. Full V4 attention block: low-rank Q
+  (linear_q_down_proj / q_layernorm / linear_q_up_proj), single KV projection
+  (linear_kv_proj / kv_layernorm), per-layer Compressor + Indexer (extending
+  mcore's DSA pattern), and the grouped low-rank O delegated to HCA.
+* **HCA** — Head-grouped Compressed Attention. The V4-specific grouped
+  low-rank O projection (`linear_o_down_proj` of shape
+  `[n_heads·head_dim/n_groups, n_groups·o_lora_rank]`, then `linear_o_up_proj`).
+  Isolated so alternative O variants can be slotted in without touching CSA.
+
+Block-level HC (hc_attn, hc_ffn) uses mcore's `HyperConnectionModule` parameter
+layout (fused `mapping_proj.weight [n²+2n, n·C]` + `bias` + three scalar alphas)
+so a real Megatron training run can drop in `mcore.HyperConnectionModule`
+directly. The head-level HC (`hc_head_*`) stays as raw parameters: the inference
+head uses a smaller (n-row) form that mcore's HC module does not cover.
+
+This mirror is a pure `nn.Module` container — forward is deferred; it exists to
+validate parameter-name, shape, and dtype parity via the bridge mapping.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+from torch import nn
+
+from megatron.bridge.models.deepseek_v4.modeling_deepseek_v4.reference import (
+    DeepSeekV4ModelArgs,
+    RMSNorm,
+)
+
+
+# ---------------------------------------------------------------------------
+# Building blocks
+# ---------------------------------------------------------------------------
+
+
+class _Linear(nn.Module):
+    """Mirror `reference.Linear`: `.weight` + optional `.scale` (FP8 block)."""
+
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        *,
+        dtype: Optional[torch.dtype] = None,
+        emit_scale: bool = True,
+        block_size: int = 128,
+    ) -> None:
+        super().__init__()
+        dtype = dtype or torch.bfloat16
+        self.weight = nn.Parameter(torch.empty(out_features, in_features, dtype=dtype))
+        if emit_scale:
+            scale_rows = (out_features + block_size - 1) // block_size
+            scale_cols = (in_features + block_size - 1) // block_size
+            self.scale = nn.Parameter(torch.empty(scale_rows, scale_cols, dtype=torch.float32))
+        else:
+            self.register_parameter("scale", None)
+
+
+# ---------------------------------------------------------------------------
+# HC — mcore-compatible block-level layout
+# ---------------------------------------------------------------------------
+
+
+class _MegatronHC(nn.Module):
+    """Param-for-param compatible with `mcore.HyperConnectionModule`.
+
+    * `mapping_proj.weight [n²+2n, n·C]` — the fused H_pre/H_post/H_res logits
+      projection. Matches HF's `hc_attn_fn` / `hc_ffn_fn` when n = hc_mult.
+    * `bias [n²+2n]`                     — static biases; matches HF's
+      `hc_attn_base` / `hc_ffn_base`.
+    * `alpha_pre / alpha_post / alpha_res [1]` — three learnable gates; together
+      they correspond to HF's `hc_*_scale [3]` in a fixed order.
+    """
+
+    def __init__(self, n: int, hidden_size: int) -> None:
+        super().__init__()
+        mix = n * n + 2 * n
+        self.mapping_proj = nn.Linear(n * hidden_size, mix, bias=False)
+        self.alpha_pre = nn.Parameter(torch.empty(1, dtype=torch.float32))
+        self.alpha_post = nn.Parameter(torch.empty(1, dtype=torch.float32))
+        self.alpha_res = nn.Parameter(torch.empty(1, dtype=torch.float32))
+        self.bias = nn.Parameter(torch.empty(mix, dtype=torch.float32))
+
+    def _reset(self) -> None:  # pragma: no cover - placeholder for real init
+        self.mapping_proj.weight.data.zero_()
+        self.bias.data.zero_()
+        self.alpha_pre.data.zero_()
+        self.alpha_post.data.zero_()
+        self.alpha_res.data.zero_()
+
+
+# ---------------------------------------------------------------------------
+# HCA — Head-grouped Compressed Attention (grouped low-rank O)
+# ---------------------------------------------------------------------------
+
+
+class HeadGroupedCompressedAttention(nn.Module):
+    """V4 grouped low-rank O-projection.
+
+    Given `n_heads` heads split across `n_groups`, each group owns an
+    `o_lora_rank`-sized latent dimension. Export shapes match the HF
+    inference checkpoint verbatim:
+
+    * `linear_o_down_proj.weight`  [n_groups · o_lora_rank, n_heads·head_dim / n_groups]
+    * `linear_o_up_proj.weight`    [hidden_size, n_groups · o_lora_rank]
+
+    Forward is intentionally omitted here — see notes at the module level.
+    """
+
+    def __init__(self, args: DeepSeekV4ModelArgs) -> None:
+        super().__init__()
+        self.n_groups = args.o_groups
+        self.o_lora_rank = args.o_lora_rank
+        self.n_heads = args.n_heads
+        self.head_dim = args.head_dim
+        self.linear_o_down_proj = _Linear(
+            self.n_heads * self.head_dim // self.n_groups,
+            self.n_groups * self.o_lora_rank,
+            dtype=torch.bfloat16,
+            emit_scale=True,
+        )
+        self.linear_o_up_proj = _Linear(
+            self.n_groups * self.o_lora_rank,
+            args.dim,
+            emit_scale=True,
+        )
+
+
+# ---------------------------------------------------------------------------
+# CSA — Compressed Sparse Attention (V4 full attention block)
+# ---------------------------------------------------------------------------
+
+
+class _Compressor(nn.Module):
+    """KV Compressor: wkv/wgate/ape/norm. BF16 params; no `.scale`."""
+
+    def __init__(self, args: DeepSeekV4ModelArgs, compress_ratio: int, head_dim: int) -> None:
+        super().__init__()
+        overlap = compress_ratio == 4
+        coff = 1 + overlap
+        self.ape = nn.Parameter(torch.empty(compress_ratio, coff * head_dim, dtype=torch.float32))
+        self.wkv = _Linear(args.dim, coff * head_dim, dtype=torch.float32, emit_scale=False)
+        self.wgate = _Linear(args.dim, coff * head_dim, dtype=torch.float32, emit_scale=False)
+        self.norm = RMSNorm(head_dim, args.norm_eps)
+
+
+class _Indexer(nn.Module):
+    """Top-k sparse-attention indexer. Present when compress_ratio == 4."""
+
+    def __init__(self, args: DeepSeekV4ModelArgs, compress_ratio: int) -> None:
+        super().__init__()
+        self.linear_q_up_proj = _Linear(args.q_lora_rank, args.index_n_heads * args.index_head_dim, emit_scale=True)
+        self.weights_proj = _Linear(args.dim, args.index_n_heads, dtype=torch.bfloat16, emit_scale=False)
+        self.compressor = _Compressor(args, compress_ratio, args.index_head_dim)
+
+
+class CompressedSparseAttention(nn.Module):
+    """V4 attention block: low-rank Q + single KV + HCA O + optional
+    Compressor/Indexer. Extends mcore DSA (indexer/sparse_attn) with a learned
+    Compressor over KV so sparse-attention can attend to compressed slots."""
+
+    def __init__(self, layer_id: int, args: DeepSeekV4ModelArgs) -> None:
+        super().__init__()
+        self.layer_id = layer_id
+        compress_ratio = args.compress_ratios[layer_id]
+
+        self.attn_sink = nn.Parameter(torch.empty(args.n_heads, dtype=torch.float32))
+        self.linear_q_down_proj = _Linear(args.dim, args.q_lora_rank, emit_scale=True)
+        self.q_layernorm = RMSNorm(args.q_lora_rank, args.norm_eps)
+        self.linear_q_up_proj = _Linear(args.q_lora_rank, args.n_heads * args.head_dim, emit_scale=True)
+        self.linear_kv_proj = _Linear(args.dim, args.head_dim, emit_scale=True)
+        self.kv_layernorm = RMSNorm(args.head_dim, args.norm_eps)
+
+        # HCA: grouped low-rank O-projection.
+        self.o_head_grouped = HeadGroupedCompressedAttention(args)
+
+        if compress_ratio:
+            self.compressor = _Compressor(args, compress_ratio, args.head_dim)
+            if compress_ratio == 4:
+                self.indexer = _Indexer(args, compress_ratio)
+
+
+# ---------------------------------------------------------------------------
+# MoE — Router (hash / score) + Experts
+# ---------------------------------------------------------------------------
+
+
+class _Router(nn.Module):
+    def __init__(self, layer_id: int, args: DeepSeekV4ModelArgs) -> None:
+        super().__init__()
+        self.hash = layer_id < args.n_hash_layers
+        self.weight = nn.Parameter(torch.empty(args.n_routed_experts, args.dim, dtype=torch.bfloat16))
+        if self.hash:
+            self.tid2eid = nn.Parameter(
+                torch.empty(args.vocab_size, args.n_activated_experts, dtype=torch.int32),
+                requires_grad=False,
+            )
+            self.register_parameter("bias", None)
+        else:
+            self.bias = nn.Parameter(torch.empty(args.n_routed_experts, dtype=torch.float32))
+            self.register_parameter("tid2eid", None)
+
+
+class _Expert(nn.Module):
+    def __init__(self, dim: int, inter_dim: int, *, emit_scale: bool) -> None:
+        super().__init__()
+        self.linear_fc1_gate = _Linear(dim, inter_dim, emit_scale=emit_scale)
+        self.linear_fc1_up = _Linear(dim, inter_dim, emit_scale=emit_scale)
+        self.linear_fc2 = _Linear(inter_dim, dim, emit_scale=emit_scale)
+
+
+class _MoE(nn.Module):
+    def __init__(self, layer_id: int, args: DeepSeekV4ModelArgs) -> None:
+        super().__init__()
+        self.router = _Router(layer_id, args)
+        self.experts = nn.ModuleList(
+            [_Expert(args.dim, args.moe_inter_dim, emit_scale=True) for _ in range(args.n_routed_experts)]
+        )
+        self.shared_experts = _Expert(args.dim, args.moe_inter_dim, emit_scale=True)
+
+
+# ---------------------------------------------------------------------------
+# Transformer / MTP / Root
+# ---------------------------------------------------------------------------
+
+
+class _TransformerBlock(nn.Module):
+    def __init__(self, layer_id: int, args: DeepSeekV4ModelArgs) -> None:
+        super().__init__()
+        self.self_attention = CompressedSparseAttention(layer_id, args)
+        self.mlp = _MoE(layer_id, args)
+        self.input_layernorm = RMSNorm(args.dim, args.norm_eps)
+        self.pre_mlp_layernorm = RMSNorm(args.dim, args.norm_eps)
+        self.hc_attn = _MegatronHC(args.hc_mult, args.dim)
+        self.hc_ffn = _MegatronHC(args.hc_mult, args.dim)
+
+
+class _MTPLayer(nn.Module):
+    def __init__(self, layer_id: int, args: DeepSeekV4ModelArgs) -> None:
+        super().__init__()
+        self.mtp_model_layer = _TransformerBlock(layer_id, args)
+        self.e_proj = _Linear(args.dim, args.dim, emit_scale=True)
+        self.h_proj = _Linear(args.dim, args.dim, emit_scale=True)
+        self.enorm = RMSNorm(args.dim, args.norm_eps)
+        self.hnorm = RMSNorm(args.dim, args.norm_eps)
+        self.final_layernorm = RMSNorm(args.dim, args.norm_eps)
+        hc_mult = args.hc_mult
+        hc_dim = hc_mult * args.dim
+        self.hc_head_fn = nn.Parameter(torch.empty(hc_mult, hc_dim, dtype=torch.float32))
+        self.hc_head_base = nn.Parameter(torch.empty(hc_mult, dtype=torch.float32))
+        self.hc_head_scale = nn.Parameter(torch.empty(1, dtype=torch.float32))
+
+
+class _WordEmbeddings(nn.Module):
+    def __init__(self, vocab_size: int, dim: int) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(torch.empty(vocab_size, dim, dtype=torch.bfloat16))
+
+
+class _Embedding(nn.Module):
+    def __init__(self, vocab_size: int, dim: int) -> None:
+        super().__init__()
+        self.word_embeddings = _WordEmbeddings(vocab_size, dim)
+
+
+class _OutputLayer(nn.Module):
+    def __init__(self, vocab_size: int, dim: int) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(torch.empty(vocab_size, dim, dtype=torch.float32))
+
+
+class _Decoder(nn.Module):
+    def __init__(self, args: DeepSeekV4ModelArgs) -> None:
+        super().__init__()
+        self.layers = nn.ModuleList([_TransformerBlock(i, args) for i in range(args.n_layers)])
+        self.final_layernorm = RMSNorm(args.dim, args.norm_eps)
+        hc_mult = args.hc_mult
+        hc_dim = hc_mult * args.dim
+        self.hc_head_fn = nn.Parameter(torch.empty(hc_mult, hc_dim, dtype=torch.float32))
+        self.hc_head_base = nn.Parameter(torch.empty(hc_mult, dtype=torch.float32))
+        self.hc_head_scale = nn.Parameter(torch.empty(1, dtype=torch.float32))
+
+
+class _MTPStack(nn.Module):
+    def __init__(self, args: DeepSeekV4ModelArgs) -> None:
+        super().__init__()
+        self.layers = nn.ModuleList([_MTPLayer(args.n_layers + i, args) for i in range(args.n_mtp_layers)])
+
+
+class DeepSeekV4MegatronModel(nn.Module):
+    """Megatron-style layout; `state_dict()` keys are the bridge's target set."""
+
+    def __init__(self, args: DeepSeekV4ModelArgs) -> None:
+        super().__init__()
+        self.args = args
+        self.embedding = _Embedding(args.vocab_size, args.dim)
+        self.decoder = _Decoder(args)
+        self.output_layer = _OutputLayer(args.vocab_size, args.dim)
+        self.mtp = _MTPStack(args)

--- a/src/megatron/bridge/models/deepseek_v4/modeling_deepseek_v4/reference.py
+++ b/src/megatron/bridge/models/deepseek_v4/modeling_deepseek_v4/reference.py
@@ -1,0 +1,325 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pure-PyTorch reference port of DeepSeek-V4-Flash `inference/model.py`.
+
+Parameter layout — including names, shapes, and dtypes — is byte-identical to
+the upstream inference script so that `state_dict()` keys match the HF
+safetensors shards exactly. This is used as the "HF side" for weight-mapping
+verification.
+
+The forward path is simplified: custom CUDA kernels (`fp8_gemm`, `fp4_gemm`,
+`sparse_attn`, `hc_split_sinkhorn`) are replaced with straightforward PyTorch
+equivalents. Numerical parity with the real inference is NOT a goal here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal, Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+
+@dataclass
+class DeepSeekV4ModelArgs:
+    """Mirrors `ModelArgs` in inference/model.py. Field names match HF config keys."""
+
+    max_batch_size: int = 4
+    max_seq_len: int = 4096
+    dtype: Literal["bf16", "fp8"] = "bf16"
+    scale_fmt: Literal[None, "ue8m0"] = None
+    expert_dtype: Literal[None, "fp4"] = None
+    scale_dtype: Literal["fp32", "fp8"] = "fp32"
+    vocab_size: int = 129280
+    dim: int = 4096
+    moe_inter_dim: int = 4096
+    n_layers: int = 7
+    n_hash_layers: int = 0
+    n_mtp_layers: int = 1
+    n_heads: int = 64
+    # moe
+    n_routed_experts: int = 8
+    n_shared_experts: int = 1
+    n_activated_experts: int = 2
+    score_func: Literal["softmax", "sigmoid", "sqrtsoftplus"] = "sqrtsoftplus"
+    route_scale: float = 1.0
+    swiglu_limit: float = 0.0
+    # mla + grouped-O
+    q_lora_rank: int = 1024
+    head_dim: int = 512
+    rope_head_dim: int = 64
+    norm_eps: float = 1e-6
+    o_groups: int = 8
+    o_lora_rank: int = 1024
+    window_size: int = 128
+    compress_ratios: Tuple[int, ...] = field(default_factory=lambda: (0, 0, 4, 128, 4, 128, 4, 0))
+    # yarn / rope
+    compress_rope_theta: float = 40000.0
+    original_seq_len: int = 0
+    rope_theta: float = 10000.0
+    rope_factor: float = 40
+    beta_fast: int = 32
+    beta_slow: int = 1
+    # indexer
+    index_n_heads: int = 64
+    index_head_dim: int = 128
+    index_topk: int = 512
+    # hyper-connections
+    hc_mult: int = 4
+    hc_sinkhorn_iters: int = 20
+    hc_eps: float = 1e-6
+
+
+class Linear(nn.Module):
+    """Plain dense Linear. No quantization. Optionally carries a `scale` param so
+    state_dict keys match the FP8 checkpoint (present for quantized layers in
+    the real model; elided for BF16 layers like the Compressor)."""
+
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        *,
+        bias: bool = False,
+        dtype: Optional[torch.dtype] = None,
+        emit_scale: bool = True,
+        block_size: int = 128,
+    ) -> None:
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        dtype = dtype or torch.bfloat16
+        self.weight = nn.Parameter(torch.empty(out_features, in_features, dtype=dtype))
+        if emit_scale:
+            scale_rows = (out_features + block_size - 1) // block_size
+            scale_cols = (in_features + block_size - 1) // block_size
+            self.scale = nn.Parameter(torch.empty(scale_rows, scale_cols, dtype=torch.float32))
+        else:
+            self.register_parameter("scale", None)
+        if bias:
+            self.bias = nn.Parameter(torch.empty(out_features, dtype=dtype))
+        else:
+            self.register_parameter("bias", None)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:  # pragma: no cover - toy path
+        return F.linear(x, self.weight.to(x.dtype), self.bias)
+
+
+class RMSNorm(nn.Module):
+    """Root-mean-square normalization; same as inference/model.py."""
+
+    def __init__(self, dim: int, eps: float = 1e-6) -> None:
+        super().__init__()
+        self.dim = dim
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        dtype = x.dtype
+        x = x.float()
+        var = x.square().mean(-1, keepdim=True)
+        return (self.weight * x * torch.rsqrt(var + self.eps)).to(dtype)
+
+
+class Compressor(nn.Module):
+    """Learned KV compressor (wkv + wgate + ape + norm). BF16 params, no `.scale`."""
+
+    def __init__(self, args: DeepSeekV4ModelArgs, compress_ratio: int = 4, head_dim: int = 512) -> None:
+        super().__init__()
+        self.compress_ratio = compress_ratio
+        self.head_dim = head_dim
+        self.overlap = compress_ratio == 4
+        coff = 1 + self.overlap
+        self.ape = nn.Parameter(torch.empty(compress_ratio, coff * head_dim, dtype=torch.float32))
+        self.wkv = Linear(args.dim, coff * head_dim, dtype=torch.float32, emit_scale=False)
+        self.wgate = Linear(args.dim, coff * head_dim, dtype=torch.float32, emit_scale=False)
+        self.norm = RMSNorm(head_dim, args.norm_eps)
+
+
+class Indexer(nn.Module):
+    """Sparse-attention top-k indexer. Only present when compress_ratio == 4."""
+
+    def __init__(self, args: DeepSeekV4ModelArgs, compress_ratio: int = 4) -> None:
+        super().__init__()
+        self.n_heads = args.index_n_heads
+        self.head_dim = args.index_head_dim
+        # wq_b is quantized (has .scale); weights_proj is bf16 (no .scale)
+        self.wq_b = Linear(args.q_lora_rank, self.n_heads * self.head_dim, emit_scale=True)
+        self.weights_proj = Linear(args.dim, self.n_heads, dtype=torch.bfloat16, emit_scale=False)
+        self.compressor = Compressor(args, compress_ratio, self.head_dim)
+
+
+class Attention(nn.Module):
+    """Per-layer attention: low-rank Q (wq_a→q_norm→wq_b), single KV proj (wkv→kv_norm),
+    grouped low-rank O (wo_a→wo_b). Optional Compressor + Indexer per-layer."""
+
+    def __init__(self, layer_id: int, args: DeepSeekV4ModelArgs) -> None:
+        super().__init__()
+        self.layer_id = layer_id
+        self.n_heads = args.n_heads
+        self.head_dim = args.head_dim
+        self.rope_head_dim = args.rope_head_dim
+        self.q_lora_rank = args.q_lora_rank
+        self.o_lora_rank = args.o_lora_rank
+        self.n_groups = args.o_groups
+        self.compress_ratio = args.compress_ratios[layer_id]
+
+        self.attn_sink = nn.Parameter(torch.empty(self.n_heads, dtype=torch.float32))
+        self.wq_a = Linear(args.dim, args.q_lora_rank, emit_scale=True)
+        self.q_norm = RMSNorm(args.q_lora_rank, args.norm_eps)
+        self.wq_b = Linear(args.q_lora_rank, self.n_heads * self.head_dim, emit_scale=True)
+        self.wkv = Linear(args.dim, self.head_dim, emit_scale=True)
+        self.kv_norm = RMSNorm(self.head_dim, args.norm_eps)
+        # wo_a lives as [n_heads*head_dim/n_groups, n_groups*o_lora_rank] per inference impl
+        self.wo_a = Linear(
+            self.n_heads * self.head_dim // self.n_groups,
+            self.n_groups * args.o_lora_rank,
+            dtype=torch.bfloat16,
+            emit_scale=True,
+        )
+        self.wo_b = Linear(self.n_groups * args.o_lora_rank, args.dim, emit_scale=True)
+
+        if self.compress_ratio:
+            self.compressor = Compressor(args, self.compress_ratio, self.head_dim)
+            if self.compress_ratio == 4:
+                self.indexer = Indexer(args, self.compress_ratio)
+
+
+class Gate(nn.Module):
+    """Routing gate. Hash layers use a lookup `tid2eid`; score layers have a `bias`."""
+
+    def __init__(self, layer_id: int, args: DeepSeekV4ModelArgs) -> None:
+        super().__init__()
+        self.hash = layer_id < args.n_hash_layers
+        self.weight = nn.Parameter(torch.empty(args.n_routed_experts, args.dim, dtype=torch.bfloat16))
+        if self.hash:
+            self.tid2eid = nn.Parameter(
+                torch.empty(args.vocab_size, args.n_activated_experts, dtype=torch.int32),
+                requires_grad=False,
+            )
+            self.register_parameter("bias", None)
+        else:
+            self.bias = nn.Parameter(torch.empty(args.n_routed_experts, dtype=torch.float32))
+            self.register_parameter("tid2eid", None)
+
+
+class Expert(nn.Module):
+    """SwiGLU expert. w1=gate, w3=up, w2=down. FP4/FP8 weights in real ckpt."""
+
+    def __init__(self, dim: int, inter_dim: int, *, emit_scale: bool = True) -> None:
+        super().__init__()
+        self.w1 = Linear(dim, inter_dim, emit_scale=emit_scale)
+        self.w2 = Linear(inter_dim, dim, emit_scale=emit_scale)
+        self.w3 = Linear(dim, inter_dim, emit_scale=emit_scale)
+
+
+class MoE(nn.Module):
+    """Mixture-of-experts: routing gate + per-rank experts + one shared expert."""
+
+    def __init__(self, layer_id: int, args: DeepSeekV4ModelArgs) -> None:
+        super().__init__()
+        self.gate = Gate(layer_id, args)
+        # Experts are FP4 in real ckpt; we use BF16 here but keep `.scale` so the
+        # state_dict-key shape matches.
+        self.experts = nn.ModuleList(
+            [Expert(args.dim, args.moe_inter_dim, emit_scale=True) for _ in range(args.n_routed_experts)]
+        )
+        assert args.n_shared_experts == 1
+        self.shared_experts = Expert(args.dim, args.moe_inter_dim, emit_scale=True)
+
+
+class Block(nn.Module):
+    """Transformer block with Hyper-Connections (HC) pre/post mixing params."""
+
+    def __init__(self, layer_id: int, args: DeepSeekV4ModelArgs) -> None:
+        super().__init__()
+        self.attn = Attention(layer_id, args)
+        self.ffn = MoE(layer_id, args)
+        self.attn_norm = RMSNorm(args.dim, args.norm_eps)
+        self.ffn_norm = RMSNorm(args.dim, args.norm_eps)
+        hc_mult = args.hc_mult
+        mix_hc = (2 + hc_mult) * hc_mult
+        hc_dim = hc_mult * args.dim
+        self.hc_attn_fn = nn.Parameter(torch.empty(mix_hc, hc_dim, dtype=torch.float32))
+        self.hc_ffn_fn = nn.Parameter(torch.empty(mix_hc, hc_dim, dtype=torch.float32))
+        self.hc_attn_base = nn.Parameter(torch.empty(mix_hc, dtype=torch.float32))
+        self.hc_ffn_base = nn.Parameter(torch.empty(mix_hc, dtype=torch.float32))
+        self.hc_attn_scale = nn.Parameter(torch.empty(3, dtype=torch.float32))
+        self.hc_ffn_scale = nn.Parameter(torch.empty(3, dtype=torch.float32))
+
+
+class MTPBlock(Block):
+    """MTP head: adds e_proj/h_proj, enorm/hnorm/norm, and hc_head_* HC params."""
+
+    def __init__(self, layer_id: int, args: DeepSeekV4ModelArgs) -> None:
+        super().__init__(layer_id, args)
+        self.e_proj = Linear(args.dim, args.dim, emit_scale=True)
+        self.h_proj = Linear(args.dim, args.dim, emit_scale=True)
+        self.enorm = RMSNorm(args.dim, args.norm_eps)
+        self.hnorm = RMSNorm(args.dim, args.norm_eps)
+        self.norm = RMSNorm(args.dim, args.norm_eps)
+        hc_mult = args.hc_mult
+        hc_dim = hc_mult * args.dim
+        self.hc_head_fn = nn.Parameter(torch.empty(hc_mult, hc_dim, dtype=torch.float32))
+        self.hc_head_base = nn.Parameter(torch.empty(hc_mult, dtype=torch.float32))
+        self.hc_head_scale = nn.Parameter(torch.empty(1, dtype=torch.float32))
+
+
+class DeepSeekV4Transformer(nn.Module):
+    """Top-level model. Mirrors inference `Transformer` class; parameter names in
+    `state_dict()` match the HF safetensors keys byte-for-byte."""
+
+    def __init__(self, args: DeepSeekV4ModelArgs) -> None:
+        super().__init__()
+        self.args = args
+        self.embed = nn.Parameter(torch.empty(args.vocab_size, args.dim, dtype=torch.bfloat16))
+        # Rename trick: original code uses `self.embed = ParallelEmbedding(...)`; its
+        # state_dict key is `embed.weight`. We expose the bare Parameter `embed` to
+        # make the top-level module's state_dict key just `embed`. Downstream, the
+        # actual HF key is `embed.weight`; we remap in the bridge.
+        #
+        # To keep parity with inference state_dict (which uses `embed.weight`), we
+        # wrap the bare parameter in a tiny sub-module.
+        del self.embed  # drop the bare param we just created
+        self.embed = _EmbedModule(args.vocab_size, args.dim)
+
+        self.layers = nn.ModuleList([Block(i, args) for i in range(args.n_layers)])
+        self.norm = RMSNorm(args.dim, args.norm_eps)
+        self.head = _HeadModule(args.vocab_size, args.dim)
+        self.mtp = nn.ModuleList([MTPBlock(args.n_layers + i, args) for i in range(args.n_mtp_layers)])
+
+        hc_mult = args.hc_mult
+        hc_dim = hc_mult * args.dim
+        self.hc_head_fn = nn.Parameter(torch.empty(hc_mult, hc_dim, dtype=torch.float32))
+        self.hc_head_base = nn.Parameter(torch.empty(hc_mult, dtype=torch.float32))
+        self.hc_head_scale = nn.Parameter(torch.empty(1, dtype=torch.float32))
+
+
+class _EmbedModule(nn.Module):
+    """Emits `embed.weight` to match the HF key."""
+
+    def __init__(self, vocab_size: int, dim: int) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(torch.empty(vocab_size, dim, dtype=torch.bfloat16))
+
+
+class _HeadModule(nn.Module):
+    """Emits `head.weight` to match the HF key. FP32 in ckpt."""
+
+    def __init__(self, vocab_size: int, dim: int) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(torch.empty(vocab_size, dim, dtype=torch.float32))


### PR DESCRIPTION
HF safetensors for DeepSeek-V4-Flash ship in inference format (no `model.` prefix, `attn`/`ffn` modules) with no `modeling_deepseek.py` / `auto_map`, so the standard `AutoBridge.from_hf_pretrained` path does not apply. This drop provides the weight-layer scaffolding:

* reference.py           — pure-PyTorch port of `inference/model.py`;
                           state_dict keys byte-identical to HF safetensors.
* megatron_mirror.py     — Megatron-convention layout. `_MegatronHC` is
                           param-for-param compatible with mcore's
                           `HyperConnectionModule` (fused
                           `mapping_proj.weight`, `bias`, three `alpha_*`).
                           `CompressedSparseAttention` (CSA) wraps low-rank
                           Q, single KV, optional Compressor + Indexer
                           (extends mcore DSA). `HeadGroupedCompressedAttention`
                           (HCA) isolates the V4 grouped low-rank O-projection.
* deepseek_v4_bridge.py  — `import_hf_state_dict` / `export_hf_state_dict`
                           handle all renames plus the 1→3 split/join of
                           `hc_*_scale`. Name-only helpers (`build_translation_table`,
                           `translate_hf_to_megatron`) retained for tooling.
* verify_roundtrip.py    — toy config: HF→mirror→HF is bit-exact
                           (elementwise `torch.equal`) on every param.
* verify_weight_mapping.py
                         — toy name/shape/dtype parity check + `--hf-index`
                           cross-check against the real 69,187-key ckpt.

Also bumps `3rdparty/Megatron-LM` to the pinned dev commit (7ff046b1c, matching `.dev.commit`) so `mcore.HyperConnectionModule` is available for a follow-up wiring pass.

Verified:
  * toy roundtrip  : 424/424 tensors elementwise equal
  * toy parity     : 424/424 HF params covered, 452/452 mcore entries
  * real ckpt keys : 69,187/69,187 translate cleanly

Out of scope (next): CSA/HCA forward paths using mcore DSA + mHC, an `AutoBridge`-compatible entry point, and `.scale` FP8 sidecar handling.

# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
