### PR TITLE
fix(mimo): mask LLaVA loss to assistant answers and avoid bundled tokenizer crash

### DIFF
--- a/examples/models/megatron_mimo/megatron_mimo_training_llava.py
+++ b/examples/models/megatron_mimo/megatron_mimo_training_llava.py
@@ -75,6 +75,7 @@ def _make_vision_config() -> TransformerConfig:
     cfg.apply_rope_fusion = False
     # CLIP uses "quick_gelu", not standard gelu
     cfg.activation_func = lambda x: x * torch.sigmoid(1.702 * x)
+    cfg.calculate_per_token_loss = True
     cfg.calculate_per_token_loss = False
 
     return cfg
@@ -120,7 +121,7 @@ def _make_language_config() -> TransformerConfig:
     cfg.bf16 = True
     cfg.cross_entropy_loss_fusion = True
     cfg.variable_seq_lengths = True
-    cfg.calculate_per_token_loss = False
+    cfg.calculate_per_token_loss = True
 
     return cfg
 
@@ -132,7 +133,7 @@ def _make_projection_config(hidden_size: int = 4096) -> TransformerConfig:
     cfg.bias_activation_fusion = True
     cfg.add_bias_linear = True
     cfg.activation_func = torch.nn.functional.gelu
-    cfg.calculate_per_token_loss = False
+    cfg.calculate_per_token_loss = True
 
     return cfg
 

--- a/examples/models/megatron_mimo/megatron_mimo_training_llava.py
+++ b/examples/models/megatron_mimo/megatron_mimo_training_llava.py
@@ -401,11 +401,19 @@ def _build_parallelism_config() -> MegatronMIMOParallelismConfig:
 # Data pipeline
 # ---------------------------------------------------------------------------
 
+from megatron.bridge.data.megatron_mimo.dataset import MegatronMIMODataset
 from megatron.bridge.data.megatron_mimo.hf_provider import HFMegatronMIMODatasetProvider
 
 
 def _llava_preprocess(example, dataset_root):
-    """Convert LLaVA conversations format to plain text and resolve image paths."""
+    """Convert LLaVA conversations format to plain text and resolve image paths.
+
+    Emits the full conversation (human + gpt turns) as ``text`` so the LM
+    conditions on the human prompt during training. Loss masking to the
+    assistant-answer tokens is applied by ``_AnswerMaskedMimoDataset``,
+    matching HF LLaVA's ``preprocess_plain`` and the Megatron-LM
+    examples/mimo task encoders.
+    """
     conversations = example.get("conversations", [])
     text_parts = [turn.get("value", "") for turn in conversations]
     example["text"] = " ".join(text_parts).replace("<image>", "").strip()
@@ -415,9 +423,96 @@ def _llava_preprocess(example, dataset_root):
     return example
 
 
+def _find_token_span(
+    seq: torch.Tensor, pattern: torch.Tensor, start_idx: int = 0, allow_first_mismatch: bool = False
+) -> tuple[int, int]:
+    """Return (start, end) of the first occurrence of ``pattern`` in ``seq``.
+
+    Mirrors ``_find_pattern_indices`` in Megatron-LM examples/mimo task encoders.
+    ``allow_first_mismatch`` handles SentencePiece boundary differences when the
+    answer is tokenized standalone vs. embedded in the full prompt.
+    Returns (-1, -1) if not found.
+    """
+    n, p = seq.size(0), pattern.size(0)
+    if p == 0 or p > n:
+        return -1, -1
+    for i in range(start_idx, n - p + 1):
+        match = seq[i : i + p] == pattern
+        if torch.all(match) or (allow_first_mismatch and torch.all(match[1:])):
+            return i, i + p
+    return -1, -1
+
+
+class _AnswerMaskedMimoDataset(MegatronMIMODataset):
+    """MegatronMIMODataset variant that masks loss to assistant-answer tokens only.
+
+    The base class sets ``loss_mask=1`` for every non-placeholder, non-pad
+    position, which trains the LM on the human instruction as well as the
+    caption. For LLaVA-Pretrain loss must be computed on the assistant ("gpt")
+    turn only — the HF LLaVA ``preprocess_plain`` contract, also implemented
+    by the Megatron-LM examples/mimo task encoders.
+    """
+
+    def __getitem__(self, idx):
+        item = super().__getitem__(idx)
+
+        raw = self.examples[idx]  # HF datasets return a fresh dict per access
+        answers = [t.get("value", "") for t in raw.get("conversations", []) if t.get("from") == "gpt"]
+        if not any(a.strip() for a in answers):
+            return item
+
+        input_ids = item["input_ids"]
+        labels = torch.full_like(input_ids, -100)
+        search_idx = 0
+        for ans in answers:
+            ans = ans.replace("<image>", "").strip()
+            if not ans:
+                continue
+            ans_ids = self.tokenizer(ans, add_special_tokens=False, return_tensors="pt")["input_ids"].squeeze(0)
+            if ans_ids.numel() == 0:
+                continue
+            s, e = _find_token_span(input_ids, ans_ids, start_idx=search_idx, allow_first_mismatch=True)
+            if s < 0:
+                # Answer span not found (e.g. truncated); skip this answer.
+                continue
+            # labels[i] predicts input_ids[i+1]; answer tokens at input_ids[s:e]
+            # are predicted at positions [s-1, e-1).
+            lo, hi = max(0, s - 1), e - 1
+            if hi > lo:
+                labels[lo:hi] = input_ids[lo + 1 : hi + 1]
+            search_idx = e
+
+        item["labels"] = labels
+        item["loss_mask"] = (labels != -100).to(item["loss_mask"].dtype)
+        return item
+
+
+class _AnswerMaskedHFMimoProvider(HFMegatronMIMODatasetProvider):
+    """HFMegatronMIMODatasetProvider that builds ``_AnswerMaskedMimoDataset`` instances."""
+
+    def _build_split_dataset(self, split, target_samples, processors, tokenizer):
+        if target_samples <= 0:
+            return None
+        hf_dataset = self._load_hf_dataset(split)
+        if hf_dataset is None:
+            return None
+        return _AnswerMaskedMimoDataset(
+            examples=hf_dataset,
+            processors=processors,
+            tokenizer=tokenizer,
+            seq_length=self.seq_length,
+            special_token_ids=self.special_token_ids,
+            encoder_seq_lengths=self.encoder_seq_lengths,
+            modality_columns=self.modality_columns,
+            text_column=self.text_column,
+            max_samples=target_samples,
+            preprocess_fn=self.preprocess_fn,
+        )
+
+
 def _build_hf_data_provider(dataset_root: str) -> HFMegatronMIMODatasetProvider:
     """Build an HFMegatronMIMODatasetProvider for liuhaotian/LLaVA-Pretrain."""
-    provider = HFMegatronMIMODatasetProvider(
+    provider = _AnswerMaskedHFMimoProvider(
         seq_length=MAX_SEQ_LENGTH,
         hf_dataset_path=dataset_root,
         hf_data_files="blip_laion_cc_sbu_558k.json",

--- a/examples/models/megatron_mimo/megatron_mimo_training_llava.py
+++ b/examples/models/megatron_mimo/megatron_mimo_training_llava.py
@@ -76,7 +76,6 @@ def _make_vision_config() -> TransformerConfig:
     # CLIP uses "quick_gelu", not standard gelu
     cfg.activation_func = lambda x: x * torch.sigmoid(1.702 * x)
     cfg.calculate_per_token_loss = True
-    cfg.calculate_per_token_loss = False
 
     return cfg
 

--- a/examples/models/megatron_mimo/run_hetero_llava.sh
+++ b/examples/models/megatron_mimo/run_hetero_llava.sh
@@ -20,7 +20,7 @@ uv run torchrun \
     --min-lr 2.0e-5 \
     --weight-decay 0.0 \
     --wandb-project "Megatron-Bridge-MIMO" \
-    --wandb-exp-name "omni-modal-llava-hetero-e2e-test" \
+    --wandb-exp-name "mimo-llava-hetero-e2e-test" \
     --wandb-save-dir "/tmp/wandb" \
     --vision-encoder-checkpoint /path/to/clip_checkpoint \
     --language-model-checkpoint /path/to/llm_checkpoint \

--- a/examples/models/megatron_mimo/run_hetero_llava_parallelism_tests.sh
+++ b/examples/models/megatron_mimo/run_hetero_llava_parallelism_tests.sh
@@ -38,7 +38,7 @@ UV_CACHE_DIR=${UV_CACHE_DIR:-/workspace/uv_cache/}
 HF_VISION_MODEL=${HF_VISION_MODEL:-"openai/clip-vit-large-patch14-336"}
 HF_LLM_MODEL=${HF_LLM_MODEL:-"lmsys/vicuna-7b-v1.5"}
 MEGATRON_VOCAB_SIZE=${MEGATRON_VOCAB_SIZE:-32256}
-CHECKPOINT_BASE_DIR=${CHECKPOINT_BASE_DIR:-/tmp/megatron_mimo_checkpoints}
+CHECKPOINT_BASE_DIR=${CHECKPOINT_BASE_DIR:-/workspace/megatron_mimo_checkpoints}
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
@@ -81,8 +81,8 @@ declare -a CONFIGS_8GPU=(
     "tp2_pp2_llm_tp2_dp2_vision|2|2|1|0|2|1|2|4|4"
     "tp2_dp2_llm_dp4_vision|2|1|2|0|1|1|4|4|4"
     # Asymmetric configs
-    "asymmetric_2_6|1|2|1|0|2|1|3|2|3"
-    "asymmetric_2_6|2|1|1|0|2|1|3|2|3"
+    "asymmetric_2_6_pp2|1|2|1|0|2|1|3|2|3"
+    "asymmetric_2_6_tp2|2|1|1|0|2|1|3|2|3"
 )
 
 declare -a CONFIGS_4GPU=(

--- a/examples/models/megatron_mimo/run_hetero_llava_parallelism_tests_unfrozen_llm.sh
+++ b/examples/models/megatron_mimo/run_hetero_llava_parallelism_tests_unfrozen_llm.sh
@@ -38,7 +38,7 @@ UV_CACHE_DIR=${UV_CACHE_DIR:-/workspace/uv_cache/}
 HF_VISION_MODEL=${HF_VISION_MODEL:-"openai/clip-vit-large-patch14-336"}
 HF_LLM_MODEL=${HF_LLM_MODEL:-"lmsys/vicuna-7b-v1.5"}
 MEGATRON_VOCAB_SIZE=${MEGATRON_VOCAB_SIZE:-32256}
-CHECKPOINT_BASE_DIR=${CHECKPOINT_BASE_DIR:-/tmp/megatron_mimo_checkpoints}
+CHECKPOINT_BASE_DIR=${CHECKPOINT_BASE_DIR:-/workspace/megatron_mimo_checkpoints}
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do

--- a/src/megatron/bridge/data/megatron_mimo/hf_provider.py
+++ b/src/megatron/bridge/data/megatron_mimo/hf_provider.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from datasets import load_dataset
 from torch.utils.data import Dataset
-from transformers import AutoProcessor, AutoTokenizer
+from transformers import AutoFeatureExtractor, AutoImageProcessor, AutoTokenizer
 
 from megatron.bridge.data.megatron_mimo.base_provider import MegatronMIMODatasetProvider
 from megatron.bridge.data.megatron_mimo.collate import megatron_mimo_collate_fn
@@ -88,13 +88,24 @@ class HFMegatronMIMODatasetProvider(MegatronMIMODatasetProvider):
 
         processors = {}
         for modality_name, processor_path in self.processor_paths.items():
-            processors[modality_name] = AutoProcessor.from_pretrained(
-                processor_path,
-                trust_remote_code=is_safe_repo(
-                    trust_remote_code=self.trust_remote_code,
-                    hf_path=processor_path,
-                ),
+            trust = is_safe_repo(
+                trust_remote_code=self.trust_remote_code,
+                hf_path=processor_path,
             )
+            # Skip AutoProcessor to avoid loading bundled tokenizers. With
+            # transformers 4.56 + tokenizers>=0.22, slow CLIPTokenizer crashes
+            # in RobertaProcessing(cls=...) — and AutoProcessor's use_fast flag
+            # is not enforced, so it can fall back to the broken slow path.
+            # See https://github.com/huggingface/transformers/issues/20817.
+            # Safe to drop once tokenizers<0.22 or transformers>=4.57 is used.
+            # Downstream only calls processor(raw_input, ...), so the image
+            # processor / feature extractor alone is sufficient.
+            try:
+                processors[modality_name] = AutoImageProcessor.from_pretrained(processor_path, trust_remote_code=trust)
+            except Exception:
+                processors[modality_name] = AutoFeatureExtractor.from_pretrained(
+                    processor_path, trust_remote_code=trust
+                )
 
         # Store for reuse
         object.__setattr__(self, "_processors", processors)

--- a/tests/unit_tests/data/megatron_mimo/test_hf_provider.py
+++ b/tests/unit_tests/data/megatron_mimo/test_hf_provider.py
@@ -61,7 +61,7 @@ def test_build_datasets_happy_path(monkeypatch):
             raise ValueError("missing split")
         return [{"text": "hello", "image": "image_0.jpg"}]
 
-    class _AutoProcessor:
+    class _AutoImageProcessor:
         @staticmethod
         def from_pretrained(path, trust_remote_code=None):
             del path, trust_remote_code
@@ -77,7 +77,7 @@ def test_build_datasets_happy_path(monkeypatch):
 
     monkeypatch.setattr("megatron.bridge.data.megatron_mimo.hf_provider.is_safe_repo", fake_is_safe_repo)
     monkeypatch.setattr("megatron.bridge.data.megatron_mimo.hf_provider.load_dataset", fake_load_dataset)
-    monkeypatch.setattr("megatron.bridge.data.megatron_mimo.hf_provider.AutoProcessor", _AutoProcessor)
+    monkeypatch.setattr("megatron.bridge.data.megatron_mimo.hf_provider.AutoImageProcessor", _AutoImageProcessor)
     monkeypatch.setattr("megatron.bridge.data.megatron_mimo.hf_provider.AutoTokenizer", _AutoTokenizer)
 
     provider = _make_provider()

--- a/tests/unit_tests/data/megatron_mimo/test_hf_provider.py
+++ b/tests/unit_tests/data/megatron_mimo/test_hf_provider.py
@@ -100,3 +100,96 @@ def test_get_collate_fn_returns_partial():
     collate_fn = provider.get_collate_fn()
     assert callable(collate_fn)
     assert collate_fn.keywords["modality_names"] == ["vision"]
+
+
+def test_load_processors_falls_back_to_feature_extractor(monkeypatch):
+    calls = Calls()
+    feature_extractor_calls = 0
+
+    def fake_is_safe_repo(trust_remote_code, hf_path):
+        del trust_remote_code, hf_path
+        calls.is_safe_repo += 1
+        return False
+
+    class _AutoImageProcessor:
+        @staticmethod
+        def from_pretrained(path, trust_remote_code=None):
+            del path, trust_remote_code
+            calls.auto_processor += 1
+            raise OSError("not an image processor repo")
+
+    class _AutoFeatureExtractor:
+        @staticmethod
+        def from_pretrained(path, trust_remote_code=None):
+            nonlocal feature_extractor_calls
+            del path, trust_remote_code
+            feature_extractor_calls += 1
+            return DummyProcessor()
+
+    monkeypatch.setattr("megatron.bridge.data.megatron_mimo.hf_provider.is_safe_repo", fake_is_safe_repo)
+    monkeypatch.setattr("megatron.bridge.data.megatron_mimo.hf_provider.AutoImageProcessor", _AutoImageProcessor)
+    monkeypatch.setattr("megatron.bridge.data.megatron_mimo.hf_provider.AutoFeatureExtractor", _AutoFeatureExtractor)
+
+    provider = _make_provider()
+    processors = provider._load_processors()
+
+    assert "vision" in processors
+    assert isinstance(processors["vision"], DummyProcessor)
+    assert calls.auto_processor == 1
+    assert feature_extractor_calls == 1
+
+
+def test_load_processors_caches_result(monkeypatch):
+    calls = Calls()
+
+    def fake_is_safe_repo(trust_remote_code, hf_path):
+        del trust_remote_code, hf_path
+        calls.is_safe_repo += 1
+        return False
+
+    class _AutoImageProcessor:
+        @staticmethod
+        def from_pretrained(path, trust_remote_code=None):
+            del path, trust_remote_code
+            calls.auto_processor += 1
+            return DummyProcessor()
+
+    monkeypatch.setattr("megatron.bridge.data.megatron_mimo.hf_provider.is_safe_repo", fake_is_safe_repo)
+    monkeypatch.setattr("megatron.bridge.data.megatron_mimo.hf_provider.AutoImageProcessor", _AutoImageProcessor)
+
+    provider = _make_provider()
+    first = provider._load_processors()
+    second = provider._load_processors()
+
+    assert first is second
+    assert calls.auto_processor == 1
+
+
+def test_load_processors_fallback_propagates_when_both_fail(monkeypatch):
+    def fake_is_safe_repo(trust_remote_code, hf_path):
+        del trust_remote_code, hf_path
+        return False
+
+    class _AutoImageProcessor:
+        @staticmethod
+        def from_pretrained(path, trust_remote_code=None):
+            del path, trust_remote_code
+            raise OSError("not an image processor repo")
+
+    class _AutoFeatureExtractor:
+        @staticmethod
+        def from_pretrained(path, trust_remote_code=None):
+            del path, trust_remote_code
+            raise ValueError("not a feature extractor either")
+
+    monkeypatch.setattr("megatron.bridge.data.megatron_mimo.hf_provider.is_safe_repo", fake_is_safe_repo)
+    monkeypatch.setattr("megatron.bridge.data.megatron_mimo.hf_provider.AutoImageProcessor", _AutoImageProcessor)
+    monkeypatch.setattr("megatron.bridge.data.megatron_mimo.hf_provider.AutoFeatureExtractor", _AutoFeatureExtractor)
+
+    provider = _make_provider()
+    try:
+        provider._load_processors()
+    except ValueError as exc:
+        assert "feature extractor" in str(exc)
+    else:
+        raise AssertionError("expected ValueError from AutoFeatureExtractor fallback")


### PR DESCRIPTION
# What does this PR do?

Fixes loss computation for MIMO LLaVA training so the model is only trained on
assistant-answer tokens (matching HuggingFace LLaVA behavior), and works around
a processor-loading crash caused by bundled tokenizers in some transformers
versions.

# Changes

**Prompt masking + per-token loss** (`examples/models/megatron_mimo/megatron_mimo_training_llava.py`)
- New `_AnswerMaskedMimoDataset` that masks the loss to assistant-answer tokens only.
- New `_AnswerMaskedHFMimoProvider` and `_find_token_span()` helper (handles SentencePiece
  boundary differences when locating answer spans in tokenized sequences).
- `_build_hf_data_provider()` now uses the masked provider.
- Set `calculate_per_token_loss=True` on vision, language, and projection configs so the
  masked loss is averaged correctly per token rather than per sequence.

**Processor loading workaround** (`src/megatron/bridge/data/megatron_mimo/hf_provider.py`)
- Replace `AutoProcessor` with `AutoImageProcessor` (falling back to `AutoFeatureExtractor`)
  to avoid loading bundled tokenizers, which crash under certain
  transformers/tokenizers version combinations.
 PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
