### PR TITLE
[perf][recipe] fix: restore override precedence + fix DSv3 no-recompute default

### DIFF
--- a/scripts/performance/utils/overrides.py
+++ b/scripts/performance/utils/overrides.py
@@ -149,11 +149,10 @@ def _set_recompute_overrides(
     elif recompute_modules is not None:
         recipe.model.recompute_modules = recompute_modules
         recipe.model.recompute_granularity = "selective"
-    else:
-        recipe.model.recompute_granularity = None
-        recipe.model.recompute_method = None
-        recipe.model.recompute_num_layers = None
-        recipe.model.recompute_modules = []
+    # No else: if the caller has no recompute configuration to apply, leave
+    # whatever the recipe already has in place. Callers that want to *disable*
+    # recompute should set granularity=None / modules=[] at the recipe or via
+    # Hydra overrides explicitly.
 
     return recipe
 
@@ -493,7 +492,10 @@ def set_post_overrides(
 
     default_num_gpus = workload_base_config.num_gpus
     if user_gbs is None:
-        if num_gpus != default_num_gpus:
+        # Only auto-rescale if the recipe's current GBS still equals the
+        # workload default — i.e., no one (Hydra or earlier step) has already
+        # expressed an intent. Otherwise Hydra-set GBS gets silently stomped.
+        if recipe.train.global_batch_size == workload_base_config.global_batch_size and num_gpus != default_num_gpus:
             new_gbs = int(workload_base_config.gbs_scaling_factor * num_gpus)
             recipe.train.global_batch_size = new_gbs
             logger.info(

--- a/src/megatron/bridge/recipes/deepseek/deepseek_v3.py
+++ b/src/megatron/bridge/recipes/deepseek/deepseek_v3.py
@@ -134,8 +134,14 @@ def deepseek_v3_pretrain_config() -> ConfigContainer:
     cfg.model.cross_entropy_loss_fusion = True
     cfg.model.cross_entropy_fusion_impl = "te"  # Default from DeepSeekModelProvider
 
-    # Memory saving (recompute & offloading) - selective recompute for V3
-    cfg.model.recompute_granularity = "selective"
+    # Memory saving (recompute & offloading) — no recompute by default.
+    # Setting granularity="selective" with modules=None would cause MCore's
+    # post-init default-fill (transformer_config.py) to silently fill
+    # recompute_modules with ["core_attn"], giving a surprise recompute
+    # across all layers. Workloads that want recompute install it via
+    # their perf-config (scripts/performance/configs/...), or users can
+    # enable it via argparse (--recompute_modules ...) or Hydra.
+    cfg.model.recompute_granularity = None
     cfg.model.recompute_modules = None
     cfg.model.recompute_method = None
     cfg.model.recompute_num_layers = None

--- a/tests/unit_tests/recipes/test_override_precedence.py
+++ b/tests/unit_tests/recipes/test_override_precedence.py
@@ -25,7 +25,7 @@ import sys
 from pathlib import Path
 
 
-SCRIPTS_PERF_PATH = Path(__file__).parents[4] / "scripts" / "performance"
+SCRIPTS_PERF_PATH = Path(__file__).parents[3] / "scripts" / "performance"
 sys.path.insert(0, str(SCRIPTS_PERF_PATH))
 
 

--- a/tests/unit_tests/scripts/performance/test_override_precedence.py
+++ b/tests/unit_tests/scripts/performance/test_override_precedence.py
@@ -99,6 +99,23 @@ def _apply(recipe, cli_overrides=None, args_overrides=None, run_post=True, num_g
 # ---------------------------------------------------------------------------
 
 
+class TestRecipeDefault:
+    def test_recipe_default_disables_recompute(self):
+        """DSv3 recipe default must be 'no recompute' (granularity=None).
+
+        Rationale: MCore's transformer_config post-init fills
+        recompute_modules=None with ['core_attn'] when granularity is set.
+        Leaving granularity='selective' with modules=None would therefore
+        silently turn on core_attn recompute across all layers for any run
+        that doesn't explicitly configure recompute — defeating #3470's
+        stated 'no recompute default' intent."""
+        from megatron.bridge.recipes.deepseek.deepseek_v3 import deepseek_v3_pretrain_config
+
+        cfg = deepseek_v3_pretrain_config()
+        assert cfg.model.recompute_granularity is None
+        assert cfg.model.recompute_num_layers is None
+
+
 class TestRecomputePrecedence:
     def test_A_workload_default_survives_when_nothing_else_set(self):
         """Workload base for GB200 NVFP4 V1 has recompute_modules=['mlp']. With

--- a/tests/unit_tests/scripts/performance/test_override_precedence.py
+++ b/tests/unit_tests/scripts/performance/test_override_precedence.py
@@ -1,0 +1,237 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""
+Precedence tests for the perf-script override pipeline.
+
+Expected precedence (highest wins): argparse > Hydra CLI > workload base > recipe default.
+
+Exercises the real 4-step override pipeline from run_script.py:main:
+    1. get_perf_optimized_recipe()      # recipe default + workload base
+    2. set_cli_overrides(recipe, cli)   # Hydra/OmegaConf merge
+    3. set_user_overrides(recipe, args) # argparse Namespace
+    4. set_post_overrides(recipe, ...)  # post-processing (GBS auto-scale etc.)
+
+Focus on recompute_* and global_batch_size — the two fields where we observed
+silent wipes after upstream PR #3470 (2026-04-23).
+"""
+
+import sys
+from pathlib import Path
+
+
+SCRIPTS_PERF_PATH = Path(__file__).parents[4] / "scripts" / "performance"
+sys.path.insert(0, str(SCRIPTS_PERF_PATH))
+
+
+def _build_base_args(**overrides):
+    """Return a fully-populated argparse.Namespace using the real parser defaults.
+
+    Tests override only the fields they care about; every other field takes its
+    argparse-default (None for optional flags), matching what a real user CLI
+    invocation with only the required args would produce.
+    """
+    from argument_parser import parse_cli_args
+
+    parser = parse_cli_args()
+    # minimum required: -m, -mr, -g, -ng
+    argv = [
+        "-m",
+        "deepseek",
+        "-mr",
+        "deepseek_v3",
+        "--task",
+        "pretrain",
+        "-g",
+        "gb200",
+        "-ng",
+        "64",
+    ]
+    args, _ = parser.parse_known_args(argv)
+    for k, v in overrides.items():
+        setattr(args, k, v)
+    return args
+
+
+def _fresh_recipe():
+    from utils.utils import get_perf_optimized_recipe
+
+    return get_perf_optimized_recipe(
+        model_family_name="deepseek",
+        model_recipe_name="deepseek_v3",
+        train_task="pretrain",
+        gpu="gb200",
+        compute_dtype="nvfp4",
+        mock=True,
+        config_variant="v1",
+    )
+
+
+def _apply(recipe, cli_overrides=None, args_overrides=None, run_post=True, num_gpus=64):
+    from utils.overrides import set_cli_overrides, set_post_overrides, set_user_overrides
+
+    cli_overrides = cli_overrides or []
+    args = _build_base_args(**(args_overrides or {}))
+    recipe = set_cli_overrides(recipe, cli_overrides)
+    recipe = set_user_overrides(recipe, args)
+    if run_post:
+        recipe = set_post_overrides(
+            recipe,
+            model_family_name="deepseek",
+            model_recipe_name="deepseek_v3",
+            gpu="gb200",
+            num_gpus=num_gpus,
+            compute_dtype="nvfp4",
+            task="pretrain",
+            user_gbs=args.global_batch_size,
+            config_variant="v1",
+        )
+    return recipe
+
+
+# ---------------------------------------------------------------------------
+# Recompute precedence
+# ---------------------------------------------------------------------------
+
+
+class TestRecomputePrecedence:
+    def test_A_workload_default_survives_when_nothing_else_set(self):
+        """Workload base for GB200 NVFP4 V1 has recompute_modules=['mlp']. With
+        no Hydra and no argparse override, that value must reach the final
+        recipe."""
+        recipe = _fresh_recipe()
+        recipe = _apply(recipe, run_post=False)
+        assert recipe.model.recompute_modules == ["mlp"]
+        assert recipe.model.recompute_granularity == "selective"
+
+    def test_B_hydra_overrides_workload(self):
+        """Hydra `model.recompute_modules=[mlp,mla_up_proj]` must replace the
+        workload's ['mlp']."""
+        recipe = _fresh_recipe()
+        recipe = _apply(
+            recipe,
+            cli_overrides=["model.recompute_modules=[mlp,mla_up_proj]"],
+            run_post=False,
+        )
+        assert recipe.model.recompute_modules == ["mlp", "mla_up_proj"]
+        assert recipe.model.recompute_granularity == "selective"
+
+    def test_C_argparse_overrides_hydra(self):
+        """argparse `--recompute_modules foo,bar` must beat a Hydra override."""
+        recipe = _fresh_recipe()
+        recipe = _apply(
+            recipe,
+            cli_overrides=["model.recompute_modules=[mla_up_proj]"],
+            args_overrides={"recompute_modules": ["foo", "bar"]},
+            run_post=False,
+        )
+        assert recipe.model.recompute_modules == ["foo", "bar"]
+        assert recipe.model.recompute_granularity == "selective"
+
+    def test_D_explicit_disable_via_hydra(self):
+        """Explicit Hydra disable (used by GB300 dsv3.sh pattern) must produce
+        granularity=None and an empty module list."""
+        recipe = _fresh_recipe()
+        recipe = _apply(
+            recipe,
+            cli_overrides=[
+                "model.recompute_granularity=null",
+                "model.recompute_modules=[]",
+            ],
+            run_post=False,
+        )
+        assert recipe.model.recompute_granularity is None
+        assert recipe.model.recompute_modules == []
+
+    def test_E_argparse_recompute_num_layers_switches_to_full(self):
+        """argparse `--recompute_num_layers 5` must switch to full-block
+        recompute."""
+        recipe = _fresh_recipe()
+        recipe = _apply(
+            recipe,
+            args_overrides={"recompute_num_layers": 5},
+            run_post=False,
+        )
+        assert recipe.model.recompute_granularity == "full"
+        assert recipe.model.recompute_method == "block"
+        assert recipe.model.recompute_num_layers == 5
+
+
+# ---------------------------------------------------------------------------
+# GBS auto-rescale precedence
+# ---------------------------------------------------------------------------
+
+
+class TestGbsPrecedence:
+    def test_F_autoscale_fires_when_no_one_sets(self):
+        """When neither Hydra nor argparse sets GBS and num_gpus differs from
+        the workload default, set_post_overrides should rescale. This is the
+        existing intentional feature; verify it still works after the fix."""
+        recipe = _fresh_recipe()
+        # Workload default for GB200 V1 is GBS=2048 at 256 GPUs. At 64 GPUs,
+        # gbs_scaling_factor * 64 should be applied.
+        recipe = _apply(recipe, num_gpus=64)
+        assert recipe.train.global_batch_size != 2048, "GBS auto-scale did not fire for num_gpus=64 (default=256)"
+
+    def test_G_hydra_overrides_autoscale(self):
+        """Hydra `train.global_batch_size=128` must survive set_post_overrides
+        even though num_gpus differs from the workload default."""
+        recipe = _fresh_recipe()
+        recipe = _apply(
+            recipe,
+            cli_overrides=["train.global_batch_size=128"],
+            num_gpus=64,
+        )
+        assert recipe.train.global_batch_size == 128
+
+    def test_H_argparse_overrides_autoscale(self):
+        """argparse `-gb 256` must survive set_post_overrides."""
+        recipe = _fresh_recipe()
+        recipe = _apply(
+            recipe,
+            args_overrides={"global_batch_size": 256},
+            num_gpus=64,
+        )
+        assert recipe.train.global_batch_size == 256
+
+
+# ---------------------------------------------------------------------------
+# Consistency check: full override chain produces expected final state
+# ---------------------------------------------------------------------------
+
+
+class TestFullChainSanity:
+    def test_I_combined_overrides_end_to_end(self):
+        """Simulate the GB200 proxy script: Hydra for recompute modules +
+        pipeline/cuda_graph; argparse only for required fields. After the
+        fix, the Hydra recompute override must survive the full 4-step chain."""
+        recipe = _fresh_recipe()
+        recipe = _apply(
+            recipe,
+            cli_overrides=[
+                "model.num_layers=16",
+                "model.pipeline_model_parallel_size=1",
+                "model.virtual_pipeline_model_parallel_size=null",
+                "model.pipeline_model_parallel_layout=null",
+                "model.recompute_modules=[mlp,mla_up_proj]",
+                "model.cuda_graph_impl=none",
+                "model.cuda_graph_scope=[]",
+                "train.micro_batch_size=2",
+                "train.global_batch_size=128",
+            ],
+            num_gpus=64,
+        )
+        assert recipe.model.num_layers == 16
+        assert recipe.model.pipeline_model_parallel_size == 1
+        assert recipe.model.virtual_pipeline_model_parallel_size is None
+        assert recipe.model.recompute_modules == ["mlp", "mla_up_proj"]
+        assert recipe.model.recompute_granularity == "selective"
+        assert recipe.model.cuda_graph_impl == "none"
+        assert recipe.model.cuda_graph_scope == []
+        assert recipe.train.micro_batch_size == 2
+        assert recipe.train.global_batch_size == 128


### PR DESCRIPTION
## Summary

Three related bugs combined to produce silent recompute and silent override wipes in the perf-script pipeline. Restores the intended four-layer precedence (**argparse > Hydra CLI > workload base > recipe default**) and fixes the DSv3 recipe default to actually be "no recompute."

## Bugs fixed

### 1. `_set_recompute_overrides` wipes workload/Hydra values (regression from #3470)

`scripts/performance/utils/overrides.py::_set_recompute_overrides` is called at three sites during one run:

| Step | Call site | `recompute_modules` value |
|---|---|---|
| 1 | `set_workload_base_configs` | e.g. `["mlp"]` for GB200 NVFP4 V1 |
| 2 | *(Hydra path — `set_cli_overrides` uses OmegaConf merge, does not call this helper)* | — |
| 3 | `set_user_overrides` | `args.recompute_modules` → **`None`** when user didn't pass `--recompute_modules` |

PR #3470 (2026-04-23) added an unconditional `else` branch that resets `recompute_granularity=None, recompute_modules=[]` when all of `cpu_offloading_num_layers / recompute_num_layers / recompute_modules` are `None`. Step-3 calls the helper with all `None` whenever a user doesn't pass argparse recompute flags — so it actively **wipes** what step-1 (workload) and step-2 (Hydra) installed.

Silently affected every perf recipe with `recompute_modules=[...]` in its workload config (DeepSeek-V3 GB300 BF16, GB200 NVFP4, B300/B200, H100; plus other model families using the same helper).

### 2. `set_post_overrides` GBS auto-rescale ignores Hydra

`set_post_overrides` auto-rescales `train.global_batch_size` when `user_gbs is None and num_gpus != default_num_gpus`. `user_gbs` is sourced only from argparse, so a Hydra-set `train.global_batch_size` gets silently overwritten by the GPU-count-based rescale.

### 3. DSv3 recipe default silently turns on `core_attn` recompute

`src/megatron/bridge/recipes/deepseek/deepseek_v3.py` sets `recompute_granularity="selective"` with `recompute_modules=None`. MCore's `transformer_config` post-init fills `recompute_modules=None` with `["core_attn"]` when any granularity is configured, so every DSv3 run that didn't explicitly override recompute silently ran with `core_attn` recompute across all 61 layers — costing ~0.3–0.5 s/iter on TE's fused attention for no real memory benefit.

This also prevents #3470's stated "no recompute by default" intent from actually being realized, even after bug #1 is fixed.

## Fixes

1. **`_set_recompute_overrides`**: drop the `else` branch. The helper only sets values when the caller has one — matching `_set_cuda_graph_overrides`. Disabling recompute is an explicit user intent via Hydra (`model.recompute_granularity=null model.recompute_modules=[]`), not the side effect of a `None` argparse flag.
2. **`set_post_overrides` GBS auto-rescale**: guard the rescale by comparing `recipe.train.global_batch_size` to `workload_base_config.global_batch_size`. Only rescale when they still match — i.e., nobody (Hydra or earlier step) has expressed intent.
3. **DSv3 recipe default**: set `recompute_granularity=None` at recipe init. Workloads that want recompute install it via their perf-config (unchanged for GB200 NVFP4 V1, GB300 BF16 V1, B200/B300, H100 — all already set `recompute_modules` explicitly).

## Precedence after fix

| Source | Wins over | Mechanism |
|---|---|---|
| recipe default | — | base of recipe construction |
| workload base | recipe default | `set_workload_base_configs` applies `settings.*` |
| Hydra CLI | workload base | `set_cli_overrides` → OmegaConf merge |
| argparse | Hydra CLI | `set_user_overrides` applies `args.*` when non-`None` |

Explicit disable still works via Hydra (`model.recompute_granularity=null model.recompute_modules=[]`) — the `dsv3.sh` pattern used in existing perf scripts.

## Test plan

- [x] `tests/unit_tests/scripts/performance/test_override_precedence.py` with 10 cases covering all four precedence layers for `recompute_*` and `global_batch_size`, plus a recipe-default pin test.
- [x] Verified tests fail on pre-fix HEAD (4/9 fail) and pass on post-fix HEAD (10/10).
- [x] `ruff check` and `ruff format` clean.
- [x] End-to-end run on DSv3 GB200 NVFP4 proxy config (64 GPU) — ConfigContainer now reflects Hydra-set recompute and GBS as intended.

## Commits

1. `[perf] fix: restore override precedence after #3470 regression` — `_set_recompute_overrides` drops the `else` stomp; `set_post_overrides` guards GBS auto-rescale against a Hydra-set value.
2. `[tests] test: add override precedence tests for perf-script pipeline` — 9 precedence tests.
3. `[recipe] fix: set DeepSeek-V3 recipe default to no-recompute` — recipe default is now `granularity=None`, plus a pin test.