### PR TITLE
MIMO: add --deterministic flag to LLaVA(+audio) examples

### DIFF
--- a/examples/models/megatron_mimo/megatron_mimo_checkpoint_resume_e2e.py
+++ b/examples/models/megatron_mimo/megatron_mimo_checkpoint_resume_e2e.py
@@ -257,9 +257,6 @@ def _build_config(
         global_batch_size=max_dp * max_dp,
         train_iters=train_iters,
     )
-    train_cfg.num_microbatches = 1
-    train_cfg.log_interval = 1
-
     from megatron.core.distributed import DistributedDataParallelConfig
 
     ddp_cfg = DistributedDataParallelConfig(

--- a/examples/models/megatron_mimo/megatron_mimo_training_e2e.py
+++ b/examples/models/megatron_mimo/megatron_mimo_training_e2e.py
@@ -248,9 +248,6 @@ def _build_config(
         global_batch_size=1,
         train_iters=2,
     )
-    train_cfg.num_microbatches = 1
-    train_cfg.log_interval = log_interval
-
     logger_cfg = LoggerConfig()
     logger_cfg.log_interval = log_interval
     logger_cfg.wandb_project = wandb_project

--- a/examples/models/megatron_mimo/megatron_mimo_training_llava.py
+++ b/examples/models/megatron_mimo/megatron_mimo_training_llava.py
@@ -842,7 +842,9 @@ def main():
 
     # 2. Build model provider
     _log("building model specs")
-    language_model_spec, modality_submodules_spec, special_token_ids = _build_model_specs(deterministic=args.deterministic)
+    language_model_spec, modality_submodules_spec, special_token_ids = _build_model_specs(
+        deterministic=args.deterministic
+    )
     megatron_mimo_parallelism_config = _build_parallelism_config()
 
     # Propagate per-module pipeline parallelism size into the TransformerConfig

--- a/examples/models/megatron_mimo/megatron_mimo_training_llava.py
+++ b/examples/models/megatron_mimo/megatron_mimo_training_llava.py
@@ -21,6 +21,7 @@ from megatron.core.models.mimo.submodules.vision import VisionModalitySubmodules
 from megatron.core.models.vision.clip_vit_model import CLIPViTModel
 from megatron.core.models.vision.multimodal_projector import MultimodalProjector
 from megatron.core.models.vision.vit_layer_specs import get_vit_layer_with_transformer_engine_spec
+from megatron.core.transformer.enums import AttnBackend
 from megatron.core.transformer.mlp import MLPSubmodules
 from megatron.core.transformer.spec_utils import ModuleSpec
 from megatron.core.transformer.transformer_config import TransformerConfig
@@ -48,7 +49,7 @@ _PATCH_DIM = 14
 _ENCODER_SEQ_LEN = 576
 
 
-def _make_vision_config() -> TransformerConfig:
+def _make_vision_config(deterministic: bool = False) -> TransformerConfig:
     """CLIP ViT-L/14 vision encoder config (23 layers = penultimate layer output per HF LLaVA)."""
     cfg = TransformerConfig(
         num_layers=23,
@@ -56,8 +57,8 @@ def _make_vision_config() -> TransformerConfig:
         ffn_hidden_size=4096,
         num_attention_heads=16,
         use_cpu_initialization=True,
-        pipeline_dtype=torch.bfloat16,
-        bf16=True,
+        pipeline_dtype=torch.float32 if deterministic else torch.bfloat16,
+        bf16=not deterministic,
         variable_seq_lengths=True,
         moe_token_dispatcher_type="alltoall",
     )
@@ -77,10 +78,17 @@ def _make_vision_config() -> TransformerConfig:
     cfg.activation_func = lambda x: x * torch.sigmoid(1.702 * x)
     cfg.calculate_per_token_loss = True
 
+    if deterministic:
+        cfg.attention_backend = AttnBackend.unfused
+        cfg.deterministic_mode = True
+        cfg.recompute_granularity = "full"
+        cfg.recompute_method = "uniform"
+        cfg.recompute_num_layers = 1
+
     return cfg
 
 
-def _make_language_config() -> TransformerConfig:
+def _make_language_config(deterministic: bool = False) -> TransformerConfig:
     """Vicuna-7B language model config (same arch as Llama-7B)."""
     cfg = TransformerConfig(
         num_layers=32,
@@ -116,16 +124,23 @@ def _make_language_config() -> TransformerConfig:
     cfg.bias_dropout_fusion = True
     cfg.apply_rope_fusion = True
 
-    cfg.pipeline_dtype = torch.bfloat16
-    cfg.bf16 = True
-    cfg.cross_entropy_loss_fusion = True
+    cfg.pipeline_dtype = torch.float32 if deterministic else torch.bfloat16
+    cfg.bf16 = not deterministic
+    cfg.cross_entropy_loss_fusion = not deterministic
     cfg.variable_seq_lengths = True
     cfg.calculate_per_token_loss = True
+
+    if deterministic:
+        cfg.attention_backend = AttnBackend.unfused
+        cfg.deterministic_mode = True
+        cfg.recompute_granularity = "full"
+        cfg.recompute_method = "uniform"
+        cfg.recompute_num_layers = 1
 
     return cfg
 
 
-def _make_projection_config(hidden_size: int = 4096) -> TransformerConfig:
+def _make_projection_config(hidden_size: int = 4096, deterministic: bool = False) -> TransformerConfig:
     """Vision→language projection MLP config."""
     cfg = TransformerConfig(num_layers=1, hidden_size=hidden_size, num_attention_heads=1, use_cpu_initialization=True)
     cfg.ffn_hidden_size = 4096
@@ -133,15 +148,20 @@ def _make_projection_config(hidden_size: int = 4096) -> TransformerConfig:
     cfg.add_bias_linear = True
     cfg.activation_func = torch.nn.functional.gelu
     cfg.calculate_per_token_loss = True
+    cfg.pipeline_dtype = torch.float32 if deterministic else torch.bfloat16
+    cfg.bf16 = not deterministic
+
+    if deterministic:
+        cfg.deterministic_mode = True
 
     return cfg
 
 
-def _build_model_specs():
+def _build_model_specs(deterministic: bool = False):
     """Return (language_model_spec, modality_submodules_spec, special_token_ids)."""
-    vision_config = _make_vision_config()
-    language_config = _make_language_config()
-    projection_config = _make_projection_config(hidden_size=language_config.hidden_size)
+    vision_config = _make_vision_config(deterministic=deterministic)
+    language_config = _make_language_config(deterministic=deterministic)
+    projection_config = _make_projection_config(hidden_size=language_config.hidden_size, deterministic=deterministic)
 
     # CLIP ViT-L/14 encoder
     vision_encoder = ModuleSpec(
@@ -530,7 +550,7 @@ def _build_hf_data_provider(dataset_root: str) -> HFMegatronMIMODatasetProvider:
     return provider
 
 
-def _wrap_iter(loader_iter):
+def _wrap_iter(loader_iter, model_dtype=torch.bfloat16):
     """Adapt data-loader batches for the MIMO model.
 
     Transforms:
@@ -555,12 +575,12 @@ def _wrap_iter(loader_iter):
                                 value[k][kk] = vv.cuda(non_blocking=True)
 
         # Rewrap modality_inputs: {"images": {"pixel_values": t}} → {"images": {"clip": {"x": t}}}
-        # Cast to bfloat16 to match model weights
+        # Cast to match model weights
         mi = batch.get("modality_inputs")
         if mi and "images" in mi:
             pv = mi["images"].get("pixel_values")
             if pv is not None:
-                mi["images"] = {"clip": {"x": pv.to(torch.bfloat16)}}
+                mi["images"] = {"clip": {"x": pv.to(model_dtype)}}
 
         # Ensure loss_mask exists
         if "loss_mask" not in batch or batch["loss_mask"] is None:
@@ -599,7 +619,8 @@ def _build_data_iterators(cfg, _megatron_mimo_infra, *, train_state=None):
         test_samples=test_samples,
     )
 
-    train_iter = _wrap_iter(train_loader) if train_loader is not None else None
+    model_dtype = torch.bfloat16 if getattr(cfg.model, "bf16", True) else torch.float32
+    train_iter = _wrap_iter(train_loader, model_dtype=model_dtype) if train_loader is not None else None
     valid_iter = None
     return train_iter, valid_iter
 
@@ -635,6 +656,7 @@ def _build_config(
     wandb_save_dir: str | None = None,
     lr_warmup_iters: int = 0,
     seed: int = 42,
+    deterministic: bool = False,
 ) -> ConfigContainer:
     train_cfg = TrainingConfig(
         micro_batch_size=micro_batch_size,
@@ -643,7 +665,6 @@ def _build_config(
     )
     # Runtime patches for MIMO
     train_cfg.num_microbatches = 1
-    train_cfg.grad_reduce_in_fp32 = False
     train_cfg.overlap_grad_reduce = False
     train_cfg.use_distributed_optimizer = True
     train_cfg.check_for_nan_in_grad = False
@@ -677,6 +698,8 @@ def _build_config(
         checkpoint=CheckpointConfig(),
     )
     cfg.rng.seed = seed
+    # grad_reduce_in_fp32 lives on DistributedDataParallelConfig, not TrainingConfig.
+    cfg.ddp.grad_reduce_in_fp32 = deterministic
     # data_parallel_size=1 because the sampler does not shard by DP.
     # All data-loading ranks receive identical global micro-batches;
     # per-module DP sub-sharding is handled by slice_batch_for_megatron_mimo in the
@@ -761,6 +784,13 @@ def parse_args():
     parser.add_argument(
         "--freeze-projector", type=_str2bool, default=False, help="Freeze the projector (default: False)"
     )
+    parser.add_argument(
+        "--deterministic",
+        action="store_true",
+        default=False,
+        help="Enable deterministic mode: FP32 precision, unfused attention, disabled CE-loss fusion, "
+        "full activation recompute, deterministic torch/cuDNN/NCCL/TE algorithms (slower, more reproducible).",
+    )
     return parser.parse_args()
 
 
@@ -775,6 +805,11 @@ def main():
     rank = dist.get_rank()
     local_rank = int(os.environ.get("LOCAL_RANK", 0))
     torch.cuda.set_device(local_rank)
+    if args.deterministic:
+        torch.use_deterministic_algorithms(True)
+        torch.backends.cudnn.benchmark = False
+        torch.backends.cuda.matmul.allow_tf32 = False
+        torch.backends.cudnn.allow_tf32 = False
 
     # Seed all RNGs for reproducible weight initialization.
     # NOTE: _set_megatron_mimo_random_seeds() in setup_megatron_mimo re-seeds all RNGs with
@@ -807,7 +842,7 @@ def main():
 
     # 2. Build model provider
     _log("building model specs")
-    language_model_spec, modality_submodules_spec, special_token_ids = _build_model_specs()
+    language_model_spec, modality_submodules_spec, special_token_ids = _build_model_specs(deterministic=args.deterministic)
     megatron_mimo_parallelism_config = _build_parallelism_config()
 
     # Propagate per-module pipeline parallelism size into the TransformerConfig
@@ -825,7 +860,7 @@ def main():
         megatron_mimo_parallelism_config=megatron_mimo_parallelism_config,
         topology={"images": ["language"], "language": []},
         use_cpu_initialization=True,
-        bf16=True,
+        bf16=not args.deterministic,
         freeze_language_model=args.freeze_llm,
         freeze_modality_encoders={"images": args.freeze_vision},
         freeze_modality_projections={"images": args.freeze_projector},
@@ -867,7 +902,7 @@ def main():
         adam_beta1=args.adam_beta1,
         adam_beta2=args.adam_beta2,
         clip_grad=args.clip_grad,
-        bf16=True,
+        bf16=not args.deterministic,
         use_distributed_optimizer=True,
     )
 
@@ -887,6 +922,7 @@ def main():
         wandb_save_dir=args.wandb_save_dir,
         lr_warmup_iters=args.lr_warmup_iters,
         seed=seed,
+        deterministic=args.deterministic,
     )
 
     # Configure checkpointing from CLI args

--- a/examples/models/megatron_mimo/megatron_mimo_training_llava.py
+++ b/examples/models/megatron_mimo/megatron_mimo_training_llava.py
@@ -663,12 +663,6 @@ def _build_config(
         global_batch_size=global_batch_size,
         train_iters=train_iters,
     )
-    # Runtime patches for MIMO
-    train_cfg.num_microbatches = 1
-    train_cfg.overlap_grad_reduce = False
-    train_cfg.use_distributed_optimizer = True
-    train_cfg.check_for_nan_in_grad = False
-    train_cfg.log_interval = log_interval
 
     logger_cfg = LoggerConfig()
     logger_cfg.log_timers_to_tensorboard = True
@@ -698,7 +692,10 @@ def _build_config(
         checkpoint=CheckpointConfig(),
     )
     cfg.rng.seed = seed
-    # grad_reduce_in_fp32 lives on DistributedDataParallelConfig, not TrainingConfig.
+    cfg.ddp.overlap_grad_reduce = False
+    cfg.ddp.check_for_nan_in_grad = False
+    cfg.ddp.use_distributed_optimizer = True
+    cfg.optimizer.use_distributed_optimizer = True
     cfg.ddp.grad_reduce_in_fp32 = deterministic
     # data_parallel_size=1 because the sampler does not shard by DP.
     # All data-loading ranks receive identical global micro-batches;

--- a/examples/models/megatron_mimo/megatron_mimo_training_llava_audio.py
+++ b/examples/models/megatron_mimo/megatron_mimo_training_llava_audio.py
@@ -149,7 +149,9 @@ def _build_model_specs(deterministic: bool = False):  # pragma: no cover
     )
 
     # Audio→language projection MLP
-    audio_projection_config = _make_projection_config(hidden_size=language_config.hidden_size, deterministic=deterministic)
+    audio_projection_config = _make_projection_config(
+        hidden_size=language_config.hidden_size, deterministic=deterministic
+    )
     audio_projection = ModuleSpec(
         module=MultimodalProjector,
         params={
@@ -716,7 +718,9 @@ def main():  # pragma: no cover
 
     # 2. Build model provider
     _log("building model specs")
-    language_model_spec, modality_submodules_spec, special_token_ids = _build_model_specs(deterministic=args.deterministic)
+    language_model_spec, modality_submodules_spec, special_token_ids = _build_model_specs(
+        deterministic=args.deterministic
+    )
     megatron_mimo_parallelism_config = _build_parallelism_config()
 
     # Propagate per-module pipeline parallelism size into the TransformerConfig

--- a/examples/models/megatron_mimo/megatron_mimo_training_llava_audio.py
+++ b/examples/models/megatron_mimo/megatron_mimo_training_llava_audio.py
@@ -20,6 +20,7 @@ from megatron.core.models.mimo.submodules.audio import AudioModalitySubmodules
 from megatron.core.models.mimo.submodules.vision import VisionModalitySubmodules
 from megatron.core.models.vision.multimodal_projector import MultimodalProjector
 from megatron.core.models.vision.vit_layer_specs import get_vit_layer_with_transformer_engine_spec
+from megatron.core.transformer.enums import AttnBackend
 from megatron.core.transformer.mlp import MLPSubmodules
 from megatron.core.transformer.spec_utils import ModuleSpec
 from megatron.core.transformer.transformer_config import TransformerConfig
@@ -57,7 +58,7 @@ _AUDIO_NUM_MEL_BINS = 80
 _AUDIO_MAX_SOURCE_POSITIONS = 1500
 
 
-def _make_audio_config() -> TransformerConfig:
+def _make_audio_config(deterministic: bool = False) -> TransformerConfig:
     """Whisper-base audio encoder config (6 encoder layers, d_model=512)."""
     cfg = TransformerConfig(
         num_layers=6,
@@ -65,8 +66,8 @@ def _make_audio_config() -> TransformerConfig:
         ffn_hidden_size=2048,
         num_attention_heads=8,
         use_cpu_initialization=True,
-        pipeline_dtype=torch.bfloat16,
-        bf16=True,
+        pipeline_dtype=torch.float32 if deterministic else torch.bfloat16,
+        bf16=not deterministic,
         variable_seq_lengths=True,
         moe_token_dispatcher_type="alltoall",
     )
@@ -83,15 +84,23 @@ def _make_audio_config() -> TransformerConfig:
     cfg.normalization = "LayerNorm"
     cfg.apply_rope_fusion = False
     cfg.calculate_per_token_loss = True
+
+    if deterministic:
+        cfg.attention_backend = AttnBackend.unfused
+        cfg.deterministic_mode = True
+        cfg.recompute_granularity = "full"
+        cfg.recompute_method = "uniform"
+        cfg.recompute_num_layers = 1
+
     return cfg
 
 
-def _build_model_specs():  # pragma: no cover
+def _build_model_specs(deterministic: bool = False):  # pragma: no cover
     """Return (language_model_spec, modality_submodules_spec, special_token_ids)."""
-    vision_config = _make_vision_config()
-    audio_config = _make_audio_config()
-    language_config = _make_language_config()
-    projection_config = _make_projection_config(hidden_size=language_config.hidden_size)
+    vision_config = _make_vision_config(deterministic=deterministic)
+    audio_config = _make_audio_config(deterministic=deterministic)
+    language_config = _make_language_config(deterministic=deterministic)
+    projection_config = _make_projection_config(hidden_size=language_config.hidden_size, deterministic=deterministic)
 
     # CLIP ViT-L/14 encoder
     vision_encoder = ModuleSpec(
@@ -140,7 +149,7 @@ def _build_model_specs():  # pragma: no cover
     )
 
     # Audio→language projection MLP
-    audio_projection_config = _make_projection_config(hidden_size=language_config.hidden_size)
+    audio_projection_config = _make_projection_config(hidden_size=language_config.hidden_size, deterministic=deterministic)
     audio_projection = ModuleSpec(
         module=MultimodalProjector,
         params={
@@ -452,7 +461,7 @@ def _build_hf_data_provider(
     return provider
 
 
-def _wrap_iter(loader_iter):
+def _wrap_iter(loader_iter, model_dtype=torch.bfloat16):
     """Adapt data-loader batches for the MIMO model.
 
     Transforms:
@@ -483,17 +492,17 @@ def _wrap_iter(loader_iter):
                             if isinstance(vv, torch.Tensor):
                                 value[k][kk] = vv.cuda(non_blocking=True)
 
-        # Rewrap modality_inputs to encoder-keyed dicts and cast to bfloat16
+        # Rewrap modality_inputs to encoder-keyed dicts and cast to match model weights
         mi = batch.get("modality_inputs")
         if mi and "images" in mi:
             pv = mi["images"].get("pixel_values")
             if pv is not None:
-                mi["images"] = {"clip": {"x": pv.to(torch.bfloat16)}}
+                mi["images"] = {"clip": {"x": pv.to(model_dtype)}}
 
         if mi and "audios" in mi:
             af = mi["audios"].get("input_features")
             if af is not None:
-                audio_kwargs = {"input_features": af.to(torch.bfloat16)}
+                audio_kwargs = {"input_features": af.to(model_dtype)}
 
                 # Compute per-sample valid encoder output lengths.
                 # WhisperFeatureExtractor pads mel spectrograms with zeros;
@@ -552,7 +561,8 @@ def _build_data_iterators(cfg, _megatron_mimo_infra, *, train_state=None):
         test_samples=test_samples,
     )
 
-    train_iter = _wrap_iter(train_loader) if train_loader is not None else None
+    model_dtype = torch.bfloat16 if getattr(cfg.model, "bf16", True) else torch.float32
+    train_iter = _wrap_iter(train_loader, model_dtype=model_dtype) if train_loader is not None else None
     valid_iter = None
     return train_iter, valid_iter
 
@@ -648,6 +658,13 @@ def parse_args():  # pragma: no cover
     parser.add_argument(
         "--freeze-audio-projector", type=_str2bool, default=False, help="Freeze the audio projector (default: False)"
     )
+    parser.add_argument(
+        "--deterministic",
+        action="store_true",
+        default=False,
+        help="Enable deterministic mode: FP32 precision, unfused attention, disabled CE-loss fusion, "
+        "full activation recompute, deterministic torch/cuDNN/NCCL/TE algorithms (slower, more reproducible).",
+    )
     return parser.parse_args()
 
 
@@ -662,6 +679,11 @@ def main():  # pragma: no cover
     rank = dist.get_rank()
     local_rank = int(os.environ.get("LOCAL_RANK", 0))
     torch.cuda.set_device(local_rank)
+    if args.deterministic:
+        torch.use_deterministic_algorithms(True)
+        torch.backends.cudnn.benchmark = False
+        torch.backends.cuda.matmul.allow_tf32 = False
+        torch.backends.cudnn.allow_tf32 = False
 
     # Seed all RNGs for reproducible weight initialization.
     # NOTE: _set_megatron_mimo_random_seeds() in setup_megatron_mimo re-seeds all RNGs with
@@ -694,7 +716,7 @@ def main():  # pragma: no cover
 
     # 2. Build model provider
     _log("building model specs")
-    language_model_spec, modality_submodules_spec, special_token_ids = _build_model_specs()
+    language_model_spec, modality_submodules_spec, special_token_ids = _build_model_specs(deterministic=args.deterministic)
     megatron_mimo_parallelism_config = _build_parallelism_config()
 
     # Propagate per-module pipeline parallelism size into the TransformerConfig
@@ -712,7 +734,7 @@ def main():  # pragma: no cover
         megatron_mimo_parallelism_config=megatron_mimo_parallelism_config,
         topology={"images": ["language"], "audios": ["language"], "language": []},
         use_cpu_initialization=True,
-        bf16=True,
+        bf16=not args.deterministic,
         freeze_language_model=args.freeze_llm,
         freeze_modality_encoders={"images": args.freeze_vision, "audios": args.freeze_audio},
         freeze_modality_projections={"images": args.freeze_vision_projector, "audios": args.freeze_audio_projector},
@@ -760,7 +782,7 @@ def main():  # pragma: no cover
         adam_beta1=args.adam_beta1,
         adam_beta2=args.adam_beta2,
         clip_grad=args.clip_grad,
-        bf16=True,
+        bf16=not args.deterministic,
         use_distributed_optimizer=True,
     )
 
@@ -780,6 +802,7 @@ def main():  # pragma: no cover
         wandb_save_dir=args.wandb_save_dir,
         lr_warmup_iters=args.lr_warmup_iters,
         seed=seed,
+        deterministic=args.deterministic,
     )
 
     # Configure checkpointing from CLI args

--- a/examples/models/megatron_mimo/run_hetero_llava.sh
+++ b/examples/models/megatron_mimo/run_hetero_llava.sh
@@ -4,24 +4,54 @@
 GPUS_PER_NODE=8
 NUM_NODES=1
 
+# Set DETERMINISTIC=1 to export deterministic NCCL/CUBLAS/cuDNN/TE env vars
+# AND pass --deterministic to the training script (FP32, unfused attention, etc.).
+# Also disables gradient clipping (clip-grad=0.0), which is non-associative under
+# distributed reductions and introduces run-to-run variance.
+DETERMINISTIC=${DETERMINISTIC:-1}
+DETERMINISTIC_FLAG=""
+EXP_SUFFIX=""
+CLIP_GRAD=1.0
+if [[ "${DETERMINISTIC}" == "1" ]]; then
+    DETERMINISTIC_FLAG="--deterministic"
+    EXP_SUFFIX="-fp32"
+    CLIP_GRAD=0.0
+    # Pin Ring algorithm for deterministic reduction order.
+    # Tree is faster for some message sizes but NCCL 2.28 Tree doesn't support
+    # AllGather with Int8 (used by torch.distributed.all_gather_object), and
+    # letting NCCL choose per-operation (^NVLS) still leaves Tree/Ring selection
+    # non-deterministic.  Ring supports all collective ops.
+    export NCCL_ALGO=Ring
+    export NCCL_PROTO=Simple
+    # Disable NCCL's topology-aware optimizations that can change paths between runs
+    export NCCL_TUNER_PLUGIN=""
+    # For full CUDA-level determinism
+    export CUBLAS_WORKSPACE_CONFIG=:4096:8
+    # Force deterministic cuDNN attention (disable non-deterministic workspace)
+    export CUDNN_FRONTEND_ATTN_DP_WORKSPACE_LIMIT=0
+    # Required by Transformer Engine when deterministic_mode=True
+    export NVTE_ALLOW_NONDETERMINISTIC_ALGO=0
+fi
+
 uv run torchrun \
     --nproc_per_node "$GPUS_PER_NODE" \
     --nnodes "$NUM_NODES" \
     examples/models/megatron_mimo/megatron_mimo_training_llava.py \
     --micro-batch-size 4 \
     --global-batch-size 128 \
-    --train-iters 1000 \
+    --train-iters 100 \
     --adam-beta1 0.9 \
     --adam-beta2 0.95 \
-    --clip-grad 1.0 \
+    --clip-grad ${CLIP_GRAD} \
     --log-interval 1 \
     --lr 1e-3 \
     --lr-warmup-iters 60 \
     --min-lr 2.0e-5 \
     --weight-decay 0.0 \
     --wandb-project "Megatron-Bridge-MIMO" \
-    --wandb-exp-name "mimo-llava-hetero-e2e-test" \
+    --wandb-exp-name "mimo-llava-hetero-e2e-test${EXP_SUFFIX}" \
     --wandb-save-dir "/tmp/wandb" \
+    ${DETERMINISTIC_FLAG} \
     --vision-encoder-checkpoint /path/to/clip_checkpoint \
     --language-model-checkpoint /path/to/llm_checkpoint \
     --dataset-root /path/to/llava/pretrain/dataset

--- a/examples/models/megatron_mimo/run_hetero_llava.sh
+++ b/examples/models/megatron_mimo/run_hetero_llava.sh
@@ -8,7 +8,7 @@ NUM_NODES=1
 # AND pass --deterministic to the training script (FP32, unfused attention, etc.).
 # Also disables gradient clipping (clip-grad=0.0), which is non-associative under
 # distributed reductions and introduces run-to-run variance.
-DETERMINISTIC=${DETERMINISTIC:-1}
+DETERMINISTIC=${DETERMINISTIC:-0}
 DETERMINISTIC_FLAG=""
 EXP_SUFFIX=""
 CLIP_GRAD=1.0

--- a/examples/models/megatron_mimo/run_hetero_llava_audio.sh
+++ b/examples/models/megatron_mimo/run_hetero_llava_audio.sh
@@ -9,27 +9,57 @@ set -euo pipefail
 GPUS_PER_NODE=8
 NUM_NODES=1
 
+# Set DETERMINISTIC=1 to export deterministic NCCL/CUBLAS/cuDNN/TE env vars
+# AND pass --deterministic to the training script (FP32, unfused attention, etc.).
+# Also disables gradient clipping (clip-grad=0.0), which is non-associative under
+# distributed reductions and introduces run-to-run variance.
+DETERMINISTIC=${DETERMINISTIC:-0}
+DETERMINISTIC_FLAG=""
+EXP_SUFFIX=""
+CLIP_GRAD=1.0
+if [[ "${DETERMINISTIC}" == "1" ]]; then
+    DETERMINISTIC_FLAG="--deterministic"
+    EXP_SUFFIX="-fp32"
+    CLIP_GRAD=0.0
+    # Pin Ring algorithm for deterministic reduction order.
+    # Tree is faster for some message sizes but NCCL 2.28 Tree doesn't support
+    # AllGather with Int8 (used by torch.distributed.all_gather_object), and
+    # letting NCCL choose per-operation (^NVLS) still leaves Tree/Ring selection
+    # non-deterministic.  Ring supports all collective ops.
+    export NCCL_ALGO=Ring
+    export NCCL_PROTO=Simple
+    # Disable NCCL's topology-aware optimizations that can change paths between runs
+    export NCCL_TUNER_PLUGIN=""
+    # For full CUDA-level determinism
+    export CUBLAS_WORKSPACE_CONFIG=:4096:8
+    # Force deterministic cuDNN attention (disable non-deterministic workspace)
+    export CUDNN_FRONTEND_ATTN_DP_WORKSPACE_LIMIT=0
+    # Required by Transformer Engine when deterministic_mode=True
+    export NVTE_ALLOW_NONDETERMINISTIC_ALGO=0
+fi
+
 uv run torchrun \
     --nproc_per_node "$GPUS_PER_NODE" \
     --nnodes "$NUM_NODES" \
     examples/models/megatron_mimo/megatron_mimo_training_llava_audio.py \
     --micro-batch-size 4 \
     --global-batch-size 128 \
-    --train-iters 1000 \
+    --train-iters 100 \
     --adam-beta1 0.9 \
     --adam-beta2 0.95 \
-    --clip-grad 1.0 \
+    --clip-grad ${CLIP_GRAD} \
     --log-interval 1 \
     --lr 1e-3 \
     --lr-warmup-iters 60 \
     --min-lr 2.0e-5 \
     --weight-decay 0.0 \
     --wandb-project "Megatron-Bridge-MIMO" \
-    --wandb-exp-name "mimo-llava-audio-hetero-e2e-test" \
+    --wandb-exp-name "mimo-llava-audio-hetero-e2e-test${EXP_SUFFIX}" \
     --wandb-save-dir "/tmp/wandb" \
     --dataset-root /path/to/LLaVA-Pretrain-Audio-Augmented \
     --hf-data-files "blip_laion_cc_sbu_558k_with_audio.json" \
     --audio-column audio \
+    ${DETERMINISTIC_FLAG} \
     --vision-encoder-checkpoint /path/to/clip_checkpoint \
     --language-model-checkpoint /path/to/llm_checkpoint \
     --audio-encoder-checkpoint /path/to/whisper_checkpoint

--- a/examples/models/megatron_mimo/run_hetero_llava_audio_parallelism_tests.sh
+++ b/examples/models/megatron_mimo/run_hetero_llava_audio_parallelism_tests.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
 # Run heterogeneous MIMO LLaVA+audio E2E test with various parallelism configurations
-# Usage: ./run_hetero_llava_audio_parallelism_tests.sh [--gpus N] [--config CONFIG_NAME]
+# Usage: ./run_hetero_llava_audio_parallelism_tests.sh [--gpus N] [--config CONFIG_NAME] [--deterministic]
+#
+# Set DETERMINISTIC=1 (env var) or pass --deterministic to enable deterministic mode:
+# exports deterministic NCCL/CUBLAS/cuDNN/TE env vars AND passes --deterministic
+# to the training script (FP32 precision, unfused attention, full recompute, etc.).
 #
 # Examples:
 #   ./run_hetero_llava_audio_parallelism_tests.sh                              # Run all configs with 8 GPUs
 #   ./run_hetero_llava_audio_parallelism_tests.sh --config tp4_llm_tp2_vis_tp2_aud  # Run a single config
+#   ./run_hetero_llava_audio_parallelism_tests.sh --deterministic              # Run in deterministic mode
 
 set -euo pipefail
 
@@ -14,6 +19,8 @@ TEST_FILE="${SCRIPT_DIR}/megatron_mimo_training_llava_audio.py"
 # Default values
 NUM_GPUS=${NUM_GPUS:-8}
 SINGLE_CONFIG=""
+DETERMINISTIC=${DETERMINISTIC:-0}
+
 
 # Training defaults (can be overridden via env vars)
 # MBS is set per-config (must be divisible by every module's DP size).
@@ -26,7 +33,6 @@ LR_WARMUP_ITERS=${LR_WARMUP_ITERS:-60}
 WEIGHT_DECAY=${WEIGHT_DECAY:-0.0}
 ADAM_BETA1=${ADAM_BETA1:-0.9}
 ADAM_BETA2=${ADAM_BETA2:-0.95}
-CLIP_GRAD=${CLIP_GRAD:-0.0}
 LOG_INTERVAL=${LOG_INTERVAL:-1}
 WANDB_PROJECT=${WANDB_PROJECT:-"Megatron-Bridge-MIMO"}
 WANDB_SAVE_DIR=${WANDB_SAVE_DIR:-"/tmp/wandb"}
@@ -56,6 +62,10 @@ while [[ $# -gt 0 ]]; do
             SINGLE_CONFIG="$2"
             shift 2
             ;;
+        --deterministic)
+            DETERMINISTIC=1
+            shift
+            ;;
         *)
             echo "Unknown argument: $1"
             exit 1
@@ -63,9 +73,39 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+# Export determinism env vars, prepare --deterministic flag, and disable grad
+# clipping iff DETERMINISTIC=1.  Grad clipping's all-reduce-of-norms is
+# non-associative and introduces run-to-run variance.  Both CLIP_GRAD defaults
+# still honor an explicit user override.
+DETERMINISTIC_FLAG=""
+EXP_SUFFIX=""
+if [[ "${DETERMINISTIC}" == "1" ]]; then
+    DETERMINISTIC_FLAG="--deterministic"
+    EXP_SUFFIX="-fp32"
+    CLIP_GRAD=${CLIP_GRAD:-0.0}
+    # Pin Ring algorithm for deterministic reduction order.
+    # Tree is faster for some message sizes but NCCL 2.28 Tree doesn't support
+    # AllGather with Int8 (used by torch.distributed.all_gather_object), and
+    # letting NCCL choose per-operation (^NVLS) still leaves Tree/Ring selection
+    # non-deterministic.  Ring supports all collective ops.
+    export NCCL_ALGO=Ring
+    export NCCL_PROTO=Simple
+    # Disable NCCL's topology-aware optimizations that can change paths between runs
+    export NCCL_TUNER_PLUGIN=""
+    # For full CUDA-level determinism
+    export CUBLAS_WORKSPACE_CONFIG=:4096:8
+    # Force deterministic cuDNN attention (disable non-deterministic workspace)
+    export CUDNN_FRONTEND_ATTN_DP_WORKSPACE_LIMIT=0
+    # Required by Transformer Engine when deterministic_mode=True
+    export NVTE_ALLOW_NONDETERMINISTIC_ALGO=0
+else
+    CLIP_GRAD=${CLIP_GRAD:-1.0}
+fi
+
 echo "=========================================="
 echo "Hetero MIMO LLaVA Parallelism E2E Tests"
 echo "GPUs: ${NUM_GPUS}"
+echo "Deterministic: ${DETERMINISTIC}"
 echo "=========================================="
 
 # Define configurations as:
@@ -235,7 +275,7 @@ run_config() {
            --min-lr "${MIN_LR}" \
            --weight-decay "${WEIGHT_DECAY}" \
            --wandb-project "${WANDB_PROJECT}" \
-           --wandb-exp-name "${exp_name}" \
+           --wandb-exp-name "${exp_name}${EXP_SUFFIX}" \
            --wandb-save-dir "${WANDB_SAVE_DIR}" \
            --dataset-root "${DATASET_ROOT}" \
            --hf-data-files "${HF_DATA_FILES}" \
@@ -243,6 +283,7 @@ run_config() {
            --vision-encoder-checkpoint "${CONVERTED_CLIP_CKPT}" \
            --language-model-checkpoint "${CONVERTED_LLM_CKPT}" \
            --audio-encoder-checkpoint "${CONVERTED_WHISPER_CKPT}" \
+           ${DETERMINISTIC_FLAG} \
            2>&1; then
         local end_time=$(date +%s)
         local duration=$((end_time - start_time))

--- a/examples/models/megatron_mimo/run_hetero_llava_parallelism_tests.sh
+++ b/examples/models/megatron_mimo/run_hetero_llava_parallelism_tests.sh
@@ -1,11 +1,16 @@
 #!/bin/bash
 # Run heterogeneous MIMO LLaVA E2E test with various parallelism configurations
-# Usage: ./run_hetero_llava_parallelism_tests.sh [--gpus N] [--config CONFIG_NAME]
+# Usage: ./run_hetero_llava_parallelism_tests.sh [--gpus N] [--config CONFIG_NAME] [--deterministic]
+#
+# Set DETERMINISTIC=1 (env var) or pass --deterministic to enable deterministic mode:
+# exports deterministic NCCL/CUBLAS/cuDNN/TE env vars AND passes --deterministic
+# to the training script (FP32 precision, unfused attention, full recompute, etc.).
 #
 # Examples:
 #   ./run_hetero_llava_parallelism_tests.sh                    # Run all configs with 8 GPUs
 #   ./run_hetero_llava_parallelism_tests.sh --gpus 4           # Run all configs with 4 GPUs
 #   ./run_hetero_llava_parallelism_tests.sh --config tp2_dp2   # Run only tp2_dp2 config
+#   ./run_hetero_llava_parallelism_tests.sh --deterministic    # Run in deterministic mode
 
 set -euo pipefail
 
@@ -15,6 +20,7 @@ TEST_FILE="${SCRIPT_DIR}/megatron_mimo_training_llava.py"
 # Default values
 NUM_GPUS=${NUM_GPUS:-8}
 SINGLE_CONFIG=""
+DETERMINISTIC=${DETERMINISTIC:-0}
 
 # Training defaults (can be overridden via env vars)
 # MBS is set per-config (must be divisible by every module's DP size).
@@ -27,7 +33,6 @@ LR_WARMUP_ITERS=${LR_WARMUP_ITERS:-60}
 WEIGHT_DECAY=${WEIGHT_DECAY:-0.0}
 ADAM_BETA1=${ADAM_BETA1:-0.9}
 ADAM_BETA2=${ADAM_BETA2:-0.95}
-CLIP_GRAD=${CLIP_GRAD:-1.0}
 LOG_INTERVAL=${LOG_INTERVAL:-1}
 WANDB_PROJECT=${WANDB_PROJECT:-"Megatron-Bridge-MIMO"}
 WANDB_SAVE_DIR=${WANDB_SAVE_DIR:-"/tmp/wandb"}
@@ -51,6 +56,10 @@ while [[ $# -gt 0 ]]; do
             SINGLE_CONFIG="$2"
             shift 2
             ;;
+        --deterministic)
+            DETERMINISTIC=1
+            shift
+            ;;
         *)
             echo "Unknown argument: $1"
             exit 1
@@ -58,9 +67,39 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+# Export determinism env vars, prepare --deterministic flag, and disable grad
+# clipping iff DETERMINISTIC=1.  Grad clipping's all-reduce-of-norms is
+# non-associative and introduces run-to-run variance.  Both CLIP_GRAD defaults
+# still honor an explicit user override.
+DETERMINISTIC_FLAG=""
+EXP_SUFFIX=""
+if [[ "${DETERMINISTIC}" == "1" ]]; then
+    DETERMINISTIC_FLAG="--deterministic"
+    EXP_SUFFIX="-fp32"
+    CLIP_GRAD=${CLIP_GRAD:-0.0}
+    # Pin Ring algorithm for deterministic reduction order.
+    # Tree is faster for some message sizes but NCCL 2.28 Tree doesn't support
+    # AllGather with Int8 (used by torch.distributed.all_gather_object), and
+    # letting NCCL choose per-operation (^NVLS) still leaves Tree/Ring selection
+    # non-deterministic.  Ring supports all collective ops.
+    export NCCL_ALGO=Ring
+    export NCCL_PROTO=Simple
+    # Disable NCCL's topology-aware optimizations that can change paths between runs
+    export NCCL_TUNER_PLUGIN=""
+    # For full CUDA-level determinism
+    export CUBLAS_WORKSPACE_CONFIG=:4096:8
+    # Force deterministic cuDNN attention (disable non-deterministic workspace)
+    export CUDNN_FRONTEND_ATTN_DP_WORKSPACE_LIMIT=0
+    # Required by Transformer Engine when deterministic_mode=True
+    export NVTE_ALLOW_NONDETERMINISTIC_ALGO=0
+else
+    CLIP_GRAD=${CLIP_GRAD:-1.0}
+fi
+
 echo "=========================================="
 echo "Hetero MIMO LLaVA Parallelism E2E Tests"
 echo "GPUs: ${NUM_GPUS}"
+echo "Deterministic: ${DETERMINISTIC}"
 echo "=========================================="
 
 # Define configurations as: "name|llm_tp|llm_pp|llm_dp|llm_offset|vision_tp|vision_pp|vision_dp|vision_offset|mbs"
@@ -206,11 +245,12 @@ run_config() {
            --min-lr "${MIN_LR}" \
            --weight-decay "${WEIGHT_DECAY}" \
            --wandb-project "${WANDB_PROJECT}" \
-           --wandb-exp-name "${exp_name}" \
+           --wandb-exp-name "${exp_name}${EXP_SUFFIX}" \
            --wandb-save-dir "${WANDB_SAVE_DIR}" \
            --dataset-root "${DATASET_ROOT}" \
            --vision-encoder-checkpoint "${CONVERTED_CLIP_CKPT}" \
            --language-model-checkpoint "${CONVERTED_LLM_CKPT}" \
+           ${DETERMINISTIC_FLAG} \
            2>&1; then
         local end_time=$(date +%s)
         local duration=$((end_time - start_time))

--- a/examples/models/megatron_mimo/run_hetero_llava_parallelism_tests_unfrozen_llm.sh
+++ b/examples/models/megatron_mimo/run_hetero_llava_parallelism_tests_unfrozen_llm.sh
@@ -1,11 +1,16 @@
 #!/bin/bash
 # Run heterogeneous MIMO LLaVA E2E test with various parallelism configurations
-# Usage: ./run_hetero_llava_parallelism_tests.sh [--gpus N] [--config CONFIG_NAME]
+# Usage: ./run_hetero_llava_parallelism_tests_unfrozen_llm.sh [--gpus N] [--config CONFIG_NAME] [--deterministic]
+#
+# Set DETERMINISTIC=1 (env var) or pass --deterministic to enable deterministic mode:
+# exports deterministic NCCL/CUBLAS/cuDNN/TE env vars AND passes --deterministic
+# to the training script (FP32 precision, unfused attention, full recompute, etc.).
 #
 # Examples:
-#   ./run_hetero_llava_parallelism_tests.sh                    # Run all configs with 8 GPUs
-#   ./run_hetero_llava_parallelism_tests.sh --gpus 4           # Run all configs with 4 GPUs
-#   ./run_hetero_llava_parallelism_tests.sh --config tp2_dp2   # Run only tp2_dp2 config
+#   ./run_hetero_llava_parallelism_tests_unfrozen_llm.sh                    # Run all configs with 8 GPUs
+#   ./run_hetero_llava_parallelism_tests_unfrozen_llm.sh --gpus 4           # Run all configs with 4 GPUs
+#   ./run_hetero_llava_parallelism_tests_unfrozen_llm.sh --config tp2_dp2   # Run only tp2_dp2 config
+#   ./run_hetero_llava_parallelism_tests_unfrozen_llm.sh --deterministic    # Run in deterministic mode
 
 set -euo pipefail
 
@@ -15,6 +20,7 @@ TEST_FILE="${SCRIPT_DIR}/megatron_mimo_training_llava.py"
 # Default values
 NUM_GPUS=${NUM_GPUS:-8}
 SINGLE_CONFIG=""
+DETERMINISTIC=${DETERMINISTIC:-0}
 
 # Training defaults (can be overridden via env vars)
 # MBS is set per-config (must be divisible by every module's DP size).
@@ -27,7 +33,6 @@ LR_WARMUP_ITERS=${LR_WARMUP_ITERS:-60}
 WEIGHT_DECAY=${WEIGHT_DECAY:-0.0}
 ADAM_BETA1=${ADAM_BETA1:-0.9}
 ADAM_BETA2=${ADAM_BETA2:-0.95}
-CLIP_GRAD=${CLIP_GRAD:-1.0}
 LOG_INTERVAL=${LOG_INTERVAL:-1}
 WANDB_PROJECT=${WANDB_PROJECT:-"Megatron-Bridge-MIMO"}
 WANDB_SAVE_DIR=${WANDB_SAVE_DIR:-"/tmp/wandb"}
@@ -51,6 +56,10 @@ while [[ $# -gt 0 ]]; do
             SINGLE_CONFIG="$2"
             shift 2
             ;;
+        --deterministic)
+            DETERMINISTIC=1
+            shift
+            ;;
         *)
             echo "Unknown argument: $1"
             exit 1
@@ -58,9 +67,39 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+# Export determinism env vars, prepare --deterministic flag, and disable grad
+# clipping iff DETERMINISTIC=1.  Grad clipping's all-reduce-of-norms is
+# non-associative and introduces run-to-run variance.  Both CLIP_GRAD defaults
+# still honor an explicit user override.
+DETERMINISTIC_FLAG=""
+EXP_SUFFIX=""
+if [[ "${DETERMINISTIC}" == "1" ]]; then
+    DETERMINISTIC_FLAG="--deterministic"
+    EXP_SUFFIX="-fp32"
+    CLIP_GRAD=${CLIP_GRAD:-0.0}
+    # Pin Ring algorithm for deterministic reduction order.
+    # Tree is faster for some message sizes but NCCL 2.28 Tree doesn't support
+    # AllGather with Int8 (used by torch.distributed.all_gather_object), and
+    # letting NCCL choose per-operation (^NVLS) still leaves Tree/Ring selection
+    # non-deterministic.  Ring supports all collective ops.
+    export NCCL_ALGO=Ring
+    export NCCL_PROTO=Simple
+    # Disable NCCL's topology-aware optimizations that can change paths between runs
+    export NCCL_TUNER_PLUGIN=""
+    # For full CUDA-level determinism
+    export CUBLAS_WORKSPACE_CONFIG=:4096:8
+    # Force deterministic cuDNN attention (disable non-deterministic workspace)
+    export CUDNN_FRONTEND_ATTN_DP_WORKSPACE_LIMIT=0
+    # Required by Transformer Engine when deterministic_mode=True
+    export NVTE_ALLOW_NONDETERMINISTIC_ALGO=0
+else
+    CLIP_GRAD=${CLIP_GRAD:-1.0}
+fi
+
 echo "=========================================="
 echo "Hetero MIMO LLaVA Parallelism E2E Tests"
 echo "GPUs: ${NUM_GPUS}"
+echo "Deterministic: ${DETERMINISTIC}"
 echo "=========================================="
 
 # Define configurations as: "name|llm_tp|llm_pp|llm_dp|llm_offset|vision_tp|vision_pp|vision_dp|vision_offset|mbs"
@@ -186,12 +225,13 @@ run_config() {
            --min-lr "${MIN_LR}" \
            --weight-decay "${WEIGHT_DECAY}" \
            --wandb-project "${WANDB_PROJECT}" \
-           --wandb-exp-name "${exp_name}" \
+           --wandb-exp-name "${exp_name}${EXP_SUFFIX}" \
            --wandb-save-dir "${WANDB_SAVE_DIR}" \
            --dataset-root "${DATASET_ROOT}" \
            --vision-encoder-checkpoint "${CONVERTED_CLIP_CKPT}" \
            --language-model-checkpoint "${CONVERTED_LLM_CKPT}" \
            --freeze-llm False \
+           ${DETERMINISTIC_FLAG} \
            2>&1; then
         local end_time=$(date +%s)
         local duration=$((end_time - start_time))

--- a/tests/functional_tests/test_groups/training/test_pretrain_megatron_mimo.py
+++ b/tests/functional_tests/test_groups/training/test_pretrain_megatron_mimo.py
@@ -23,6 +23,8 @@ Run:
 
 from __future__ import annotations
 
+import os
+
 import pytest
 import torch
 import torch.distributed as dist
@@ -31,6 +33,7 @@ from megatron.core.models.gpt.gpt_model import GPTModel
 from megatron.core.models.mimo.submodules.vision import VisionModalitySubmodules
 from megatron.core.models.vision.clip_vit_model import CLIPViTModel
 from megatron.core.models.vision.vit_layer_specs import get_vit_layer_with_transformer_engine_spec
+from megatron.core.transformer.enums import AttnBackend
 from megatron.core.transformer.spec_utils import ModuleSpec
 from megatron.core.transformer.transformer_config import TransformerConfig
 
@@ -68,14 +71,14 @@ _TRAIN_ITERS = 5
 # ── Model helpers ────────────────────────────────────────────────────────────
 
 
-def _make_vision_config() -> TransformerConfig:
+def _make_vision_config(deterministic: bool = False) -> TransformerConfig:
     cfg = TransformerConfig(
         num_layers=2,
         hidden_size=64,
         ffn_hidden_size=256,
         num_attention_heads=4,
-        pipeline_dtype=torch.bfloat16,
-        bf16=True,
+        pipeline_dtype=torch.float32 if deterministic else torch.bfloat16,
+        bf16=not deterministic,
         variable_seq_lengths=True,
         moe_token_dispatcher_type="alltoall",
     )
@@ -91,29 +94,42 @@ def _make_vision_config() -> TransformerConfig:
     cfg.attention_softmax_in_fp32 = True
     cfg.normalization = "LayerNorm"
     cfg.apply_rope_fusion = False
+    if deterministic:
+        cfg.attention_backend = AttnBackend.unfused
+        cfg.deterministic_mode = True
+        cfg.recompute_granularity = "full"
+        cfg.recompute_method = "uniform"
+        cfg.recompute_num_layers = 1
     return cfg
 
 
-def _make_language_config() -> TransformerConfig:
-    return TransformerConfig(
+def _make_language_config(deterministic: bool = False) -> TransformerConfig:
+    cfg = TransformerConfig(
         num_layers=2,
         hidden_size=64,
         ffn_hidden_size=256,
         num_attention_heads=4,
-        pipeline_dtype=torch.bfloat16,
-        bf16=True,
+        pipeline_dtype=torch.float32 if deterministic else torch.bfloat16,
+        bf16=not deterministic,
         variable_seq_lengths=True,
         moe_token_dispatcher_type="alltoall",
-        cross_entropy_loss_fusion=True,
+        cross_entropy_loss_fusion=not deterministic,
     )
+    if deterministic:
+        cfg.attention_backend = AttnBackend.unfused
+        cfg.deterministic_mode = True
+        cfg.recompute_granularity = "full"
+        cfg.recompute_method = "uniform"
+        cfg.recompute_num_layers = 1
+    return cfg
 
 
-def _build_model_specs():
+def _build_model_specs(deterministic: bool = False):
     """Return (language_model_spec, modality_submodules_spec, special_token_ids)."""
     vision_encoder = ModuleSpec(
         module=CLIPViTModel,
         params={
-            "transformer_config": _make_vision_config(),
+            "transformer_config": _make_vision_config(deterministic=deterministic),
             "transformer_layer_spec": get_vit_layer_with_transformer_engine_spec(),
             "patch_dim": _PATCH_DIM,
             "img_h": _IMG_SIZE,
@@ -128,7 +144,7 @@ def _build_model_specs():
     language_model_spec = ModuleSpec(
         module=GPTModel,
         params={
-            "config": _make_language_config(),
+            "config": _make_language_config(deterministic=deterministic),
             "transformer_layer_spec": get_gpt_layer_with_transformer_engine_spec(),
             "vocab_size": _VOCAB_SIZE,
             "max_sequence_length": _SEQ_LENGTH,
@@ -174,11 +190,13 @@ def _build_mock_data_provider() -> MockMegatronMIMOProvider:
     return provider
 
 
-def _wrap_iter(loader_iter):
+def _wrap_iter(loader_iter, vision_dtype: torch.dtype = torch.bfloat16):
     """Adapt data-loader batches for the MegatronMIMO model.
 
     Remaps modality_inputs["vision"]["pixel_values"] to
-    modality_inputs["vision"]["clip"]["x"] for CLIPViTModel.
+    modality_inputs["vision"]["clip"]["x"] for CLIPViTModel. ``vision_dtype``
+    must match the vision encoder's compute dtype — fp32 in deterministic
+    mode, bf16 otherwise.
     """
     for batch in loader_iter:
         for key, value in batch.items():
@@ -197,7 +215,7 @@ def _wrap_iter(loader_iter):
         if mi and "vision" in mi:
             pv = mi["vision"].get("pixel_values")
             if pv is not None:
-                mi["vision"] = {"clip": {"x": pv.to(torch.bfloat16)}}
+                mi["vision"] = {"clip": {"x": pv.to(vision_dtype)}}
 
         if "loss_mask" not in batch or batch["loss_mask"] is None:
             batch["loss_mask"] = torch.ones_like(batch["input_ids"], dtype=torch.float)
@@ -229,7 +247,12 @@ def _build_data_iterators(cfg, megatron_mimo_infra, *, train_state=None):
         test_samples=0,
     )
 
-    train_iter = _wrap_iter(train_loader) if train_loader is not None else None
+    # Match the vision encoder's compute dtype (fp32 under --deterministic, bf16 otherwise).
+    vision_cfg = (
+        cfg.model.modality_submodules_spec["vision"].submodules["encoders"]["clip"].params["transformer_config"]
+    )
+    vision_dtype = torch.bfloat16 if vision_cfg.bf16 else torch.float32
+    train_iter = _wrap_iter(train_loader, vision_dtype=vision_dtype) if train_loader is not None else None
     return train_iter, None
 
 
@@ -239,8 +262,9 @@ def _build_data_iterators(cfg, megatron_mimo_infra, *, train_state=None):
 def _build_config(
     parallelism_config: MegatronMIMOParallelismConfig,
     train_iters: int = _TRAIN_ITERS,
+    deterministic: bool = False,
 ) -> ConfigContainer:
-    language_model_spec, modality_submodules_spec, special_token_ids = _build_model_specs()
+    language_model_spec, modality_submodules_spec, special_token_ids = _build_model_specs(deterministic=deterministic)
 
     megatron_mimo_provider = MegatronMIMOProvider(
         language_model_spec=language_model_spec,
@@ -248,6 +272,10 @@ def _build_config(
         special_token_ids=special_token_ids,
         megatron_mimo_parallelism_config=parallelism_config,
         topology={"vision": ["language"], "language": []},
+        # MegatronMIMOProvider casts the whole model via .bfloat16() after build,
+        # overriding per-submodule TransformerConfig dtypes — flip it off in
+        # deterministic mode so the model stays fp32.
+        bf16=not deterministic,
     )
     if not hasattr(megatron_mimo_provider, "num_moe_experts"):
         megatron_mimo_provider.num_moe_experts = None
@@ -260,13 +288,13 @@ def _build_config(
     train_cfg.num_microbatches = 1
 
     opt_config = OptimizerConfig(
-        bf16=True,
+        bf16=not deterministic,
         use_distributed_optimizer=True,
         lr=1e-4,
         min_lr=0.0,
     )
 
-    return ConfigContainer(
+    cfg = ConfigContainer(
         train=train_cfg,
         model=megatron_mimo_provider,
         optimizer=opt_config,
@@ -276,6 +304,12 @@ def _build_config(
         tokenizer=TokenizerConfig(),
         checkpoint=CheckpointConfig(),
     )
+    # Mirrors the --deterministic flag plumbing in
+    # examples/models/megatron_mimo/megatron_mimo_training_llava.py: fp32 grad
+    # reduction is the part of "deterministic mode" that lives on DDP rather
+    # than TransformerConfig.
+    cfg.ddp.grad_reduce_in_fp32 = deterministic
+    return cfg
 
 
 # ── Index tracing for checkpoint-resume test ─────────────────────────────────
@@ -444,11 +478,18 @@ class TestMegatronMIMOTraining:
     """
 
     @pytest.mark.run_only_on("GPU")
-    def test_megatron_mimo_tp1_both(self):
+    @pytest.mark.parametrize("deterministic", [False, True], ids=["default", "deterministic"])
+    def test_megatron_mimo_tp1_both(self, deterministic):
         """Smoke test: MegatronMIMO training with TP=1 for both LLM and vision.
 
         LLM on rank 0 (TP=1, DP=1), vision on rank 1 (TP=1, DP=1).
         Trains for 5 iterations with synthetic data and verifies completion.
+
+        Parametrized over the ``--deterministic`` code path exposed by
+        ``examples/models/megatron_mimo/megatron_mimo_training_llava.py`` to
+        guard against regressions in the deterministic config knobs (FP32
+        dtypes, unfused attention, deterministic_mode, recompute, fp32 grad
+        reduction, and process-wide torch deterministic algorithms).
         """
         initialize_distributed()
 
@@ -479,13 +520,51 @@ class TestMegatronMIMOTraining:
             },
         )
 
-        cfg = _build_config(par_cfg)
+        cfg = _build_config(par_cfg, deterministic=deterministic)
 
-        pretrain_megatron_mimo(
-            cfg=cfg,
-            forward_step_func=megatron_mimo_forward_step,
-            build_data_iterators_fn=_build_data_iterators,
-        )
+        # Process-wide torch knobs and env vars the --deterministic flag flips.
+        # Toggle in a try/finally because they leak across pytest cases sharing
+        # this process. The env vars in particular are required:
+        #   - NVTE_ALLOW_NONDETERMINISTIC_ALGO=0 is checked by Transformer
+        #     Engine's TEDotProductAttention.__init__ when deterministic_mode
+        #     is set, and would raise otherwise.
+        #   - CUBLAS_WORKSPACE_CONFIG=:4096:8 is required by
+        #     torch.use_deterministic_algorithms(True) for some cuBLAS ops.
+        _DET_ENV = {
+            "NVTE_ALLOW_NONDETERMINISTIC_ALGO": "0",
+            "CUBLAS_WORKSPACE_CONFIG": ":4096:8",
+            "CUDNN_FRONTEND_ATTN_DP_WORKSPACE_LIMIT": "0",
+        }
+        prev_use_deterministic = torch.are_deterministic_algorithms_enabled()
+        prev_cudnn_benchmark = torch.backends.cudnn.benchmark
+        prev_matmul_tf32 = torch.backends.cuda.matmul.allow_tf32
+        prev_cudnn_tf32 = torch.backends.cudnn.allow_tf32
+        prev_env = {k: os.environ.get(k) for k in _DET_ENV}
+        if deterministic:
+            for k, v in _DET_ENV.items():
+                os.environ[k] = v
+            torch.use_deterministic_algorithms(True)
+            torch.backends.cudnn.benchmark = False
+            torch.backends.cuda.matmul.allow_tf32 = False
+            torch.backends.cudnn.allow_tf32 = False
+
+        try:
+            pretrain_megatron_mimo(
+                cfg=cfg,
+                forward_step_func=megatron_mimo_forward_step,
+                build_data_iterators_fn=_build_data_iterators,
+            )
+        finally:
+            if deterministic:
+                torch.use_deterministic_algorithms(prev_use_deterministic)
+                torch.backends.cudnn.benchmark = prev_cudnn_benchmark
+                torch.backends.cuda.matmul.allow_tf32 = prev_matmul_tf32
+                torch.backends.cudnn.allow_tf32 = prev_cudnn_tf32
+                for k, v in prev_env.items():
+                    if v is None:
+                        os.environ.pop(k, None)
+                    else:
+                        os.environ[k] = v
 
     @pytest.mark.run_only_on("GPU")
     def test_megatron_mimo_checkpoint_resume_dp1_both(self, tmp_path):

--- a/tests/unit_tests/models/megatron_mimo/test_training_llava_audio_helpers.py
+++ b/tests/unit_tests/models/megatron_mimo/test_training_llava_audio_helpers.py
@@ -427,11 +427,15 @@ class TestBuildParallelismConfig:
 @pytest.fixture(scope="module")
 def make_audio_config_fn():
     tc_mod = pytest.importorskip("megatron.core.transformer.transformer_config")
+    enums_mod = pytest.importorskip("megatron.core.transformer.enums")
     return _extract_node(
         TRAINING_PATH,
         "_make_audio_config",
         ast.FunctionDef,
-        globals_extra={"TransformerConfig": tc_mod.TransformerConfig},
+        globals_extra={
+            "TransformerConfig": tc_mod.TransformerConfig,
+            "AttnBackend": enums_mod.AttnBackend,
+        },
     )
 
 
@@ -458,6 +462,27 @@ class TestMakeAudioConfig:
         assert cfg.gated_linear_unit is False
         assert cfg.calculate_per_token_loss is True
         assert cfg.normalization == "LayerNorm"
+
+    def test_default_does_not_set_deterministic_knobs(self, make_audio_config_fn):
+        """The deterministic-only knobs must stay at their TransformerConfig defaults when off."""
+        cfg = make_audio_config_fn()
+        assert cfg.deterministic_mode is False
+        assert cfg.recompute_granularity is None
+
+    def test_deterministic_switches_to_fp32(self, make_audio_config_fn):
+        cfg = make_audio_config_fn(deterministic=True)
+        assert cfg.bf16 is False
+        assert cfg.pipeline_dtype == torch.float32
+
+    def test_deterministic_enables_unfused_attention_and_recompute(self, make_audio_config_fn):
+        """The --deterministic flag wires unfused attention + full activation recompute."""
+        enums_mod = pytest.importorskip("megatron.core.transformer.enums")
+        cfg = make_audio_config_fn(deterministic=True)
+        assert cfg.attention_backend == enums_mod.AttnBackend.unfused
+        assert cfg.deterministic_mode is True
+        assert cfg.recompute_granularity == "full"
+        assert cfg.recompute_method == "uniform"
+        assert cfg.recompute_num_layers == 1
 
 
 # ---------------------------------------------------------------------------
@@ -567,6 +592,26 @@ class TestWrapIter:
         }
         out = _consume_one(wrap_iter_fn, batch)
         assert out["modality_inputs"]["audios"]["whisper"]["input_features"].dtype == torch.bfloat16
+
+    def test_pixel_values_cast_to_fp32_when_model_dtype_is_fp32(self, wrap_iter_fn, cuda_is_noop):
+        """Deterministic mode runs the model in FP32; pixel cast must follow."""
+        pv = torch.randn(1, 3, 8, 8, dtype=torch.float32)
+        batch = {
+            "input_ids": torch.zeros(1, 4, dtype=torch.long),
+            "modality_inputs": {"images": {"pixel_values": pv}},
+        }
+        out = _consume_one(wrap_iter_fn, batch, model_dtype=torch.float32)
+        assert out["modality_inputs"]["images"]["clip"]["x"].dtype == torch.float32
+
+    def test_audio_input_features_cast_to_fp32_when_model_dtype_is_fp32(self, wrap_iter_fn, cuda_is_noop):
+        """Deterministic-mode audio path: FP32 cast end-to-end."""
+        af = torch.ones(1, 80, 4, dtype=torch.float32)
+        batch = {
+            "input_ids": torch.full((1, 4), _AUDIO_SPECIAL_TOKEN_ID, dtype=torch.long),
+            "modality_inputs": {"audios": {"input_features": af}},
+        }
+        out = _consume_one(wrap_iter_fn, batch, model_dtype=torch.float32)
+        assert out["modality_inputs"]["audios"]["whisper"]["input_features"].dtype == torch.float32
 
 
 # ---------------------------------------------------------------------------
@@ -749,7 +794,7 @@ def build_data_iterators_fn(monkeypatch):
     captured_wrap_calls = []
 
     def fake_wrap_iter(loader_iter, **kwargs):
-        captured_wrap_calls.append(loader_iter)
+        captured_wrap_calls.append({"loader_iter": loader_iter, "kwargs": kwargs})
         return iter([])  # dummy iterator
 
     fn = _extract_node(
@@ -766,10 +811,10 @@ def build_data_iterators_fn(monkeypatch):
 
 @pytest.mark.unit
 class TestBuildDataIterators:
-    def _cfg(self, *, train_iters=10, global_batch_size=4):
+    def _cfg(self, *, train_iters=10, global_batch_size=4, bf16=True):
         cfg = SimpleNamespace()
         cfg.train = SimpleNamespace(train_iters=train_iters, global_batch_size=global_batch_size)
-        cfg.model = SimpleNamespace(bf16=True)
+        cfg.model = SimpleNamespace(bf16=bf16)
         cfg.dataset = MagicMock()
         return cfg
 
@@ -815,3 +860,27 @@ class TestBuildDataIterators:
         train_iter, valid_iter = fn(self._cfg(), MagicMock())
         assert train_iter is None
         assert valid_iter is None
+
+    def test_bf16_model_passes_bfloat16_dtype_to_wrap_iter(self, build_data_iterators_fn):
+        fn, loaders_mock, _, captured = build_data_iterators_fn
+        loaders_mock.build_megatron_mimo_data_loaders.return_value = (MagicMock(), None, None)
+        fn(self._cfg(bf16=True), MagicMock())
+        assert captured[-1]["kwargs"] == {"model_dtype": torch.bfloat16}
+
+    def test_fp32_model_passes_float32_dtype_to_wrap_iter(self, build_data_iterators_fn):
+        """Deterministic mode sets cfg.model.bf16=False; pixels/audio must be cast to FP32."""
+        fn, loaders_mock, _, captured = build_data_iterators_fn
+        loaders_mock.build_megatron_mimo_data_loaders.return_value = (MagicMock(), None, None)
+        fn(self._cfg(bf16=False), MagicMock())
+        assert captured[-1]["kwargs"] == {"model_dtype": torch.float32}
+
+    def test_missing_bf16_attr_defaults_to_bfloat16(self, build_data_iterators_fn):
+        """`getattr(cfg.model, 'bf16', True)` falls back to True when the attr is absent."""
+        fn, loaders_mock, _, captured = build_data_iterators_fn
+        loaders_mock.build_megatron_mimo_data_loaders.return_value = (MagicMock(), None, None)
+        cfg = SimpleNamespace()
+        cfg.train = SimpleNamespace(train_iters=10, global_batch_size=4)
+        cfg.model = SimpleNamespace()  # no bf16 attribute
+        cfg.dataset = MagicMock()
+        fn(cfg, MagicMock())
+        assert captured[-1]["kwargs"] == {"model_dtype": torch.bfloat16}


### PR DESCRIPTION
# What does this PR do ?

MIMO: add --deterministic flag to LLaVA(+audio) examples

# Changelog

- Adds an opt-in `--deterministic` flag to the MIMO LLaVA and LLaVA-audio
  training scripts (`megatron_mimo_training_llava.py`,
  `megatron_mimo_training_llava_audio.py`). When set, vision, language, audio,
  and projection configs run in FP32 with unfused attention, loss fusion
  disabled, and full activation recompute so runs are bitwise reproducible.
- Threads the `deterministic` argument through the relevant config and model
  spec helpers so each sub-module is configured consistently.
- Updates the launcher shell scripts under
  `examples/models/megatron_mimo/` (`run_hetero_llava.sh`,
  `run_hetero_llava_audio.sh`, and the three `*_parallelism_tests*.sh`
  variants) to forward `--deterministic` and export the env vars required for
  deterministic execution (e.g. cuBLAS / NCCL settings).
- No behavior change when the flag is omitted — default training paths are
  untouched.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
