### PR TITLE
Add HybridModel support to DeepSeek-V3

### DIFF
--- a/src/megatron/bridge/models/deepseek/__init__.py
+++ b/src/megatron/bridge/models/deepseek/__init__.py
@@ -14,9 +14,15 @@
 
 from megatron.bridge.models.deepseek.deepseek_v2_bridge import DeepSeekV2Bridge  # noqa: F401
 from megatron.bridge.models.deepseek.deepseek_v3_bridge import DeepSeekV3Bridge  # noqa: F401
+from megatron.bridge.models.deepseek.deepseek_v3_mamba_bridge import (  # noqa: F401
+    DeepSeekV3MambaBridge,
+    DeepSeekV3MambaProvider,
+)
 
 
 __all__ = [
     "DeepSeekV2Bridge",
     "DeepSeekV3Bridge",
+    "DeepSeekV3MambaBridge",
+    "DeepSeekV3MambaProvider",
 ]

--- a/src/megatron/bridge/models/deepseek/deepseek_v3_mamba_bridge.py
+++ b/src/megatron/bridge/models/deepseek/deepseek_v3_mamba_bridge.py
@@ -1,0 +1,135 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DeepSeek-V3 bridge variant that targets `MambaModel` instead of `GPTModel`.
+
+The default `DeepSeekV3Bridge` instantiates a Megatron-Core `GPTModel`.
+This module adds an opt-in subclass that swaps the base model
+class to `MambaModel` (the hybrid Mamba/attention stack), so the MLA
+attention and MoE configuration coming from the HF checkpoint can be combined
+with Mamba/hybrid layer layouts.
+
+Note:
+    This bridge is *not* registered via `@MegatronModelBridge.register_bridge`
+    because the auto-dispatch table in `model_bridge.py` is keyed by the HF
+    source class name alone — registering a second bridge for
+    `DeepseekV3ForCausalLM` would overwrite the default GPT-based bridge.
+    Use this class explicitly, e.g.:
+
+        bridge = DeepSeekV3MambaBridge()
+        bridge.hf_config = hf_pretrained.config
+        provider = bridge.provider_bridge(hf_pretrained)
+        provider.hybrid_layer_pattern = "M*" * hf_config.num_hidden_layers
+        provider.finalize()
+        model = provider.provide()
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+
+from megatron.core.models.mamba import MambaModel
+
+from megatron.bridge.models.deepseek.deepseek_v3_bridge import DeepSeekV3Bridge
+from megatron.bridge.models.hf_pretrained.causal_lm import PreTrainedCausalLM
+from megatron.bridge.models.mamba.mamba_provider import MambaModelProvider
+from megatron.bridge.models.transformer_config import MLATransformerConfig
+
+
+@dataclass
+class DeepSeekV3MambaProvider(MambaModelProvider, MLATransformerConfig):
+    """Provider that combines MLA attention config with the Mamba model backbone.
+
+    Method-resolution order places `MambaModelProvider` first, so
+    `provide` returns an `MCoreMambaModel` (the hybrid stack that can
+    host Mamba, attention, MLA, and DSA layers). `MLATransformerConfig`
+    contributes the MLA dataclass fields (`q_lora_rank`, `kv_lora_rank`,
+    `qk_head_dim`, `qk_pos_emb_head_dim`, `v_head_dim`, …) that DSv3
+    requires. `finalize()` chains through both parents via C3 linearization:
+    Mamba pattern processing runs first, then MLA post-init.
+
+    Users must supply a `hybrid_layer_pattern` (or the deprecated
+    `hybrid_override_pattern`) before calling `finalize()` so the hybrid
+    stack knows where to place Mamba vs. attention/MLA layers.
+    """
+
+    # MLA position embeddings must be "rope" even though MambaModelProvider
+    # defaults to "none" (pure-Mamba models have no position embeddings).
+    position_embedding_type: str = "rope"
+
+
+class DeepSeekV3MambaBridge(DeepSeekV3Bridge):
+    """DeepSeek-V3 bridge that instantiates `MambaModel` instead of `GPTModel`.
+
+    Inherits the HF→Megatron config translation from `DeepSeekV3Bridge`
+    (MLA params, MoE params, vocab sizing, …) but swaps the target model class
+    to `MambaModel` via `PROVIDER_CLASS`.
+
+    The default `provider_bridge` implementation carries over the
+    DSv3-specific MLA/MoE settings, then strips GPT-only spec wiring
+    (`transformer_layer_spec`) that is meaningless for the Mamba stack.
+    Callers are expected to assign `hybrid_layer_pattern` (and optionally
+    `mamba_stack_spec`) before calling `provider.finalize()`.
+    """
+
+    PROVIDER_CLASS = DeepSeekV3MambaProvider
+
+    # Advertised target so downstream tooling that inspects the bridge knows
+    # which MCore model class this variant produces.
+    TARGET_MODEL = MambaModel
+
+    def provider_bridge(self, hf_pretrained: PreTrainedCausalLM) -> DeepSeekV3MambaProvider:
+        """Build a `DeepSeekV3MambaProvider` from an HF DSv3 checkpoint.
+
+        Reuses the DSv3 MLA/MoE configuration produced by the parent
+        `DeepSeekV3Bridge` and then clears GPT-only fields that do not
+        apply to the Mamba backbone.
+        """
+        provider: DeepSeekV3MambaProvider = super().provider_bridge(hf_pretrained)
+
+        # GPT-specific spec used by GPTModel; MambaModel is built from
+        # `mamba_stack_spec` instead, so drop this to avoid confusion.
+        if hasattr(provider, "transformer_layer_spec"):
+            try:
+                provider.transformer_layer_spec = None
+            except (AttributeError, TypeError):
+                pass
+
+        # MLA attention requires rope positional embeddings; the Mamba provider
+        # default of "none" would disable them for the attention sub-layers.
+        provider.position_embedding_type = "rope"
+
+        return provider
+
+    def default_hybrid_layer_pattern(self, hf_pretrained: PreTrainedCausalLM) -> Optional[str]:
+        """Suggest a hybrid layer pattern equivalent to the HF DSv3 layout.
+
+        Each DSv3 transformer layer is `[MLA attention, MLP-or-MoE]`. In the
+        Mamba hybrid pattern this maps to `*-` for dense blocks and `*E` for
+        MoE blocks (`*` = attention, `-` = MLP, `E` = MoE). Callers can
+        use this helper to populate `provider.hybrid_layer_pattern` before
+        calling `finalize()`.
+
+        Returns `None` if `first_k_dense_replace` is missing from the HF
+        config (e.g. non-DSv3 variants).
+        """
+        hf_config = hf_pretrained.config
+        num_layers = getattr(hf_config, "num_hidden_layers", None)
+        first_k_dense = getattr(hf_config, "first_k_dense_replace", None)
+        if num_layers is None or first_k_dense is None:
+            return None
+
+        parts = []
+        for layer_idx in range(num_layers):
+            parts.append("*-" if layer_idx < first_k_dense else "*E")
+        return "".join(parts)

--- a/src/megatron/bridge/models/deepseek/deepseek_v3_mamba_bridge.py
+++ b/src/megatron/bridge/models/deepseek/deepseek_v3_mamba_bridge.py
@@ -15,71 +15,89 @@
 """DeepSeek-V3 bridge variant that targets `MambaModel` instead of `GPTModel`.
 
 The default `DeepSeekV3Bridge` instantiates a Megatron-Core `GPTModel`.
-This module adds an opt-in subclass that swaps the base model
-class to `MambaModel` (the hybrid Mamba/attention stack), so the MLA
-attention and MoE configuration coming from the HF checkpoint can be combined
-with Mamba/hybrid layer layouts.
+This module adds an opt-in subclass that swaps the base model class to
+`MambaModel` (the hybrid Mamba/attention stack), so the MLA and MoE
+configuration coming from the HF checkpoint can be combined with Mamba/hybrid
+layer layouts.
+
+Layout mapping (HF → Megatron decoder layers):
+
+    Each HF DSv3 block `i` is `[MLA, MLP-or-MoE]`. In the Mamba
+    hybrid stack that block is unrolled into two positions:
+
+        - Megatron decoder layer `2*i`     – MLA (`+`)
+        - Megatron decoder layer `2*i + 1` – MLP (`-`) or MoE (`E`)
+
+    The hybrid pattern is therefore `+-` for the first
+    `first_k_dense_replace` blocks and `+E` thereafter. The HF→Megatron
+    weight mapping uses the same index split.
 
 Note:
     This bridge is *not* registered via `@MegatronModelBridge.register_bridge`
     because the auto-dispatch table in `model_bridge.py` is keyed by the HF
-    source class name alone — registering a second bridge for
+    source class name alone – registering a second bridge for
     `DeepseekV3ForCausalLM` would overwrite the default GPT-based bridge.
     Use this class explicitly, e.g.:
 
         bridge = DeepSeekV3MambaBridge()
         bridge.hf_config = hf_pretrained.config
         provider = bridge.provider_bridge(hf_pretrained)
-        provider.hybrid_layer_pattern = "M*" * hf_config.num_hidden_layers
         provider.finalize()
         model = provider.provide()
 """
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import Dict, List, Tuple
 
+from megatron.core.models.hybrid.hybrid_layer_allocation import Symbols
 from megatron.core.models.mamba import MambaModel
 
+from megatron.bridge.models.conversion.mapping_registry import MegatronMappingRegistry
+from megatron.bridge.models.conversion.param_mapping import AutoMapping, GatedMLPMapping
+from megatron.bridge.models.deepseek.common import get_common_mapping_list
 from megatron.bridge.models.deepseek.deepseek_v3_bridge import DeepSeekV3Bridge
 from megatron.bridge.models.hf_pretrained.causal_lm import PreTrainedCausalLM
 from megatron.bridge.models.mamba.mamba_provider import MambaModelProvider
-from megatron.bridge.models.transformer_config import MLATransformerConfig
+from megatron.bridge.models.mla_provider import MLAModelProvider
 
 
 @dataclass
-class DeepSeekV3MambaProvider(MambaModelProvider, MLATransformerConfig):
-    """Provider that combines MLA attention config with the Mamba model backbone.
+class DeepSeekV3MambaProvider(MambaModelProvider, MLAModelProvider):
+    """Provider that combines MLA config with the Mamba model backbone.
 
-    Method-resolution order places `MambaModelProvider` first, so
-    `provide` returns an `MCoreMambaModel` (the hybrid stack that can
-    host Mamba, attention, MLA, and DSA layers). `MLATransformerConfig`
-    contributes the MLA dataclass fields (`q_lora_rank`, `kv_lora_rank`,
-    `qk_head_dim`, `qk_pos_emb_head_dim`, `v_head_dim`, …) that DSv3
-    requires. `finalize()` chains through both parents via C3 linearization:
-    Mamba pattern processing runs first, then MLA post-init.
+    Method-resolution order places `MambaModelProvider` first, so `provide()`
+    returns an `MCoreMambaModel` (the hybrid stack that can host Mamba,
+    attention, MLA, and DSA layers). `MLAModelProvider` contributes the MLA
+    dataclass fields (`q_lora_rank`, `kv_lora_rank`, `qk_head_dim`,
+    `qk_pos_emb_head_dim`, `v_head_dim`, ...) and – importantly – lets
+    `issubclass(..., MLAModelProvider)` return True so the base bridge's
+    MLA rope-scaling extraction path runs for DSv3 YaRN parameters.
 
-    Users must supply a `hybrid_layer_pattern` (or the deprecated
-    `hybrid_override_pattern`) before calling `finalize()` so the hybrid
-    stack knows where to place Mamba vs. attention/MLA layers.
+    `finalize()` chains through both parents via C3 linearization: Mamba
+    pattern processing runs first (deriving `num_layers` from the hybrid
+    pattern), then MLA post-init computes the derived MLA head dims.
     """
 
-    # MLA position embeddings must be "rope" even though MambaModelProvider
-    # defaults to "none" (pure-Mamba models have no position embeddings).
+    # MLA needs "rope" positional embeddings.
     position_embedding_type: str = "rope"
 
 
 class DeepSeekV3MambaBridge(DeepSeekV3Bridge):
     """DeepSeek-V3 bridge that instantiates `MambaModel` instead of `GPTModel`.
 
-    Inherits the HF→Megatron config translation from `DeepSeekV3Bridge`
-    (MLA params, MoE params, vocab sizing, …) but swaps the target model class
-    to `MambaModel` via `PROVIDER_CLASS`.
+    Inherits HF→Megatron config translation from `DeepSeekV3Bridge` (MLA
+    params, MoE params, vocab sizing, MTP, YaRN rope scaling, ...) and swaps
+    the target model class to `MambaModel` via `PROVIDER_CLASS`.
 
-    The default `provider_bridge` implementation carries over the
-    DSv3-specific MLA/MoE settings, then strips GPT-only spec wiring
-    (`transformer_layer_spec`) that is meaningless for the Mamba stack.
-    Callers are expected to assign `hybrid_layer_pattern` (and optionally
-    `mamba_stack_spec`) before calling `provider.finalize()`.
+    `provider_bridge` picks up DSv3 defaults from the parent bridge, then:
+    - Clears `transformer_layer_spec` (GPT-only).
+    - Auto-populates `hybrid_layer_pattern` from `first_k_dense_replace`.
+    - Resizes `moe_layer_freq` to match the doubled hybrid layer count.
+
+    `mapping_registry` rewrites the DSv3 common mappings so attention
+    params land on even Megatron decoder indices and MLP/MoE params land on
+    odd ones, matching the `+-` / `+E` hybrid pattern. MTP mappings are
+    carried over unchanged.
     """
 
     PROVIDER_CLASS = DeepSeekV3MambaProvider
@@ -92,44 +110,307 @@ class DeepSeekV3MambaBridge(DeepSeekV3Bridge):
         """Build a `DeepSeekV3MambaProvider` from an HF DSv3 checkpoint.
 
         Reuses the DSv3 MLA/MoE configuration produced by the parent
-        `DeepSeekV3Bridge` and then clears GPT-only fields that do not
-        apply to the Mamba backbone.
+        `DeepSeekV3Bridge`, then adjusts for the Mamba backbone: drops
+        GPT-only wiring, builds a hybrid layer pattern, and doubles
+        `moe_layer_freq` to match the pattern length.
         """
         provider: DeepSeekV3MambaProvider = super().provider_bridge(hf_pretrained)
+        hf_config = hf_pretrained.config
 
-        # GPT-specific spec used by GPTModel; MambaModel is built from
-        # `mamba_stack_spec` instead, so drop this to avoid confusion.
+        # GPT-specific decoder spec; MambaModel is built from `mamba_stack_spec`
+        # instead. Clearing avoids confusion for downstream tooling that
+        # introspects provider fields.
         if hasattr(provider, "transformer_layer_spec"):
             try:
                 provider.transformer_layer_spec = None
             except (AttributeError, TypeError):
                 pass
 
-        # MLA attention requires rope positional embeddings; the Mamba provider
-        # default of "none" would disable them for the attention sub-layers.
+        # MLA requires "rope"; the Mamba default of "none" disables it.
         provider.position_embedding_type = "rope"
+
+        # Build and install the hybrid layer pattern (`+-` dense / `+E` MoE).
+        pattern = self._build_hybrid_layer_pattern(hf_config)
+        provider.hybrid_layer_pattern = pattern
+        # `finalize()` will derive num_layers from the pattern; clear any prior
+        # value so the pattern-based derivation doesn't fail the equality check.
+        provider.num_layers = None
+
+        # moe_layer_freq must match the final num_layers (i.e., pattern length)
+        # for MCore validation. Dense hybrid positions use `-` (ignored), MoE
+        # positions use `E`; reflect this per-position freq.
+        provider.moe_layer_freq = [
+            1 if ch == Symbols.MOE else 0 for ch in pattern
+        ]
 
         return provider
 
-    def default_hybrid_layer_pattern(self, hf_pretrained: PreTrainedCausalLM) -> Optional[str]:
-        """Suggest a hybrid layer pattern equivalent to the HF DSv3 layout.
+    @staticmethod
+    def _build_hybrid_layer_pattern(hf_config) -> str:
+        """Translate the DSv3 HF layout into a hybrid layer pattern.
 
-        Each DSv3 transformer layer is `[MLA attention, MLP-or-MoE]`. In the
-        Mamba hybrid pattern this maps to `*-` for dense blocks and `*E` for
-        MoE blocks (`*` = attention, `-` = MLP, `E` = MoE). Callers can
-        use this helper to populate `provider.hybrid_layer_pattern` before
-        calling `finalize()`.
-
-        Returns `None` if `first_k_dense_replace` is missing from the HF
-        config (e.g. non-DSv3 variants).
+        Each HF transformer block expands to `+-` (dense) or `+E` (MoE)
+        in the hybrid stack.
         """
-        hf_config = hf_pretrained.config
-        num_layers = getattr(hf_config, "num_hidden_layers", None)
-        first_k_dense = getattr(hf_config, "first_k_dense_replace", None)
-        if num_layers is None or first_k_dense is None:
-            return None
-
+        num_layers = hf_config.num_hidden_layers
+        first_k_dense = getattr(hf_config, "first_k_dense_replace", 0) or 0
         parts = []
         for layer_idx in range(num_layers):
-            parts.append("*-" if layer_idx < first_k_dense else "*E")
+            if layer_idx < first_k_dense:
+                parts.append(Symbols.MLA + Symbols.MLP)
+            else:
+                parts.append(Symbols.MLA + Symbols.MOE)
         return "".join(parts)
+
+    # Pattern templates categorized by which Megatron hybrid-position they land on.
+    # `.*` is the (single) layer wildcard; trailing `*` (no dot) is the expert wildcard.
+    _ATTENTION_TEMPLATES: List[Tuple[str, str]] = [
+        ("decoder.layers.*.input_layernorm.weight", "model.layers.*.input_layernorm.weight"),
+        ("decoder.layers.*.self_attention.linear_proj.weight", "model.layers.*.self_attn.o_proj.weight"),
+        (
+            "decoder.layers.*.self_attention.linear_kv_down_proj.weight",
+            "model.layers.*.self_attn.kv_a_proj_with_mqa.weight",
+        ),
+        (
+            "decoder.layers.*.self_attention.linear_kv_up_proj.weight",
+            "model.layers.*.self_attn.kv_b_proj.weight",
+        ),
+        (
+            "decoder.layers.*.self_attention.linear_kv_up_proj.layer_norm_weight",
+            "model.layers.*.self_attn.kv_a_layernorm.weight",
+        ),
+        (
+            "decoder.layers.*.self_attention.kv_layernorm.weight",
+            "model.layers.*.self_attn.kv_a_layernorm.weight",
+        ),
+        (
+            "decoder.layers.*.self_attention.linear_q_down_proj.weight",
+            "model.layers.*.self_attn.q_a_proj.weight",
+        ),
+        (
+            "decoder.layers.*.self_attention.linear_q_up_proj.weight",
+            "model.layers.*.self_attn.q_b_proj.weight",
+        ),
+        (
+            "decoder.layers.*.self_attention.linear_q_up_proj.layer_norm_weight",
+            "model.layers.*.self_attn.q_a_layernorm.weight",
+        ),
+        (
+            "decoder.layers.*.self_attention.q_layernorm.weight",
+            "model.layers.*.self_attn.q_a_layernorm.weight",
+        ),
+        # Fallback for DSv3 variants without LoRA on Q.
+        (
+            "decoder.layers.*.self_attention.linear_q_proj.weight",
+            "model.layers.*.self_attn.q_proj.weight",
+        ),
+    ]
+
+    _MLP_TEMPLATES: List[Tuple[str, str]] = [
+        ("decoder.layers.*.pre_mlp_layernorm.weight", "model.layers.*.post_attention_layernorm.weight"),
+        (
+            "decoder.layers.*.mlp.linear_fc1.layer_norm_weight",
+            "model.layers.*.post_attention_layernorm.weight",
+        ),
+        ("decoder.layers.*.mlp.linear_fc2.weight", "model.layers.*.mlp.down_proj.weight"),
+        ("decoder.layers.*.mlp.router.weight", "model.layers.*.mlp.gate.weight"),
+        (
+            "decoder.layers.*.mlp.router.expert_bias",
+            "model.layers.*.mlp.gate.e_score_correction_bias",
+        ),
+        (
+            "decoder.layers.*.mlp.experts.linear_fc2.weight*",
+            "model.layers.*.mlp.experts.*.down_proj.weight",
+        ),
+        (
+            "decoder.layers.*.mlp.shared_experts.linear_fc2.weight",
+            "model.layers.*.mlp.shared_experts.down_proj.weight",
+        ),
+    ]
+
+    # (megatron, gate_hf, up_hf) – always on the MLP/MoE hybrid position.
+    _MLP_GATED_TEMPLATES: List[Tuple[str, str, str]] = [
+        (
+            "decoder.layers.*.mlp.linear_fc1.weight",
+            "model.layers.*.mlp.gate_proj.weight",
+            "model.layers.*.mlp.up_proj.weight",
+        ),
+        (
+            "decoder.layers.*.mlp.experts.linear_fc1.weight*",
+            "model.layers.*.mlp.experts.*.gate_proj.weight",
+            "model.layers.*.mlp.experts.*.up_proj.weight",
+        ),
+        (
+            "decoder.layers.*.mlp.shared_experts.linear_fc1.weight",
+            "model.layers.*.mlp.shared_experts.gate_proj.weight",
+            "model.layers.*.mlp.shared_experts.up_proj.weight",
+        ),
+    ]
+
+    # Top-level (non-layer) mappings – identical on both sides.
+    _STATIC_MAPPINGS: List[Tuple[str, str]] = [
+        ("embedding.word_embeddings.weight", "model.embed_tokens.weight"),
+        ("decoder.final_layernorm.weight", "model.norm.weight"),
+        ("output_layer.weight", "lm_head.weight"),
+    ]
+
+    @staticmethod
+    def _specialize(pattern: str, hf_idx: int, meg_idx: int) -> str:
+        """Substitute the first `.*.` with the Megatron index and any later
+        `.*.` with the HF index. Trailing `*` (no dot – expert wildcard)
+        is preserved.
+        """
+        # First wildcard = layer index
+        out = pattern.replace(".*.", f".{meg_idx}.", 1)
+        # Any remaining `.*.` is the HF *layer* wildcard (only on HF side).
+        # On Megatron side this won't match because only one layer wildcard
+        # exists in our templates.
+        return out
+
+    def mapping_registry(self) -> MegatronMappingRegistry:
+        """Build mappings that split HF layer i into Megatron layers 2i and 2i+1.
+
+        Attention-side templates are emitted at Megatron index `2*i`; MLP/MoE
+        templates at `2*i + 1`. MTP mappings are reused from the DSv3 common
+        list unchanged because MTP layers form a separate decoder namespace
+        (`mtp.layers.*`) whose internal structure has no hybrid split.
+        """
+        hf_config = self.hf_config
+        if hf_config is None:
+            # Fall back to the GPT-layout mappings (still useful for tooling
+            # that only inspects the registry without running conversion).
+            return super().mapping_registry()
+
+        num_layers = getattr(hf_config, "num_hidden_layers", None)
+        if num_layers is None:
+            return super().mapping_registry()
+
+        mapping_list = []
+
+        # Top-level, non-layer params are untouched.
+        for megatron_param, hf_param in self._STATIC_MAPPINGS:
+            mapping_list.append(AutoMapping(megatron_param=megatron_param, hf_param=hf_param))
+
+        # Per-layer unrolling.
+        for hf_layer_idx in range(num_layers):
+            attn_meg_idx = 2 * hf_layer_idx
+            mlp_meg_idx = 2 * hf_layer_idx + 1
+
+            for meg_tpl, hf_tpl in self._ATTENTION_TEMPLATES:
+                mapping_list.append(
+                    AutoMapping(
+                        megatron_param=self._specialize(meg_tpl, hf_layer_idx, attn_meg_idx),
+                        hf_param=hf_tpl.replace(".*.", f".{hf_layer_idx}.", 1),
+                    )
+                )
+
+            for meg_tpl, hf_tpl in self._MLP_TEMPLATES:
+                mapping_list.append(
+                    AutoMapping(
+                        megatron_param=self._specialize(meg_tpl, hf_layer_idx, mlp_meg_idx),
+                        hf_param=hf_tpl.replace(".*.", f".{hf_layer_idx}.", 1),
+                    )
+                )
+
+            for meg_tpl, gate_tpl, up_tpl in self._MLP_GATED_TEMPLATES:
+                mapping_list.append(
+                    GatedMLPMapping(
+                        megatron_param=self._specialize(meg_tpl, hf_layer_idx, mlp_meg_idx),
+                        gate=gate_tpl.replace(".*.", f".{hf_layer_idx}.", 1),
+                        up=up_tpl.replace(".*.", f".{hf_layer_idx}.", 1),
+                    )
+                )
+
+        # MTP mappings – delegate to the shared DSv3 helper. It emits MTP-only
+        # entries (under `mtp.layers.*` / `model.layers.{N + k}.*`) that are
+        # unaffected by the hybrid layer split.
+        mtp_mappings = self._mtp_mappings_only(hf_config)
+        mapping_list.extend(mtp_mappings)
+
+        # DSv3-specific router bias mapping inherited from the default bridge.
+        mapping_list.append(
+            AutoMapping(
+                megatron_param="decoder.layers.*.mlp.router.expert_bias",
+                hf_param="model.layers.*.mlp.gate.e_score_correction_bias",
+            )
+        )
+
+        return MegatronMappingRegistry(*mapping_list)
+
+    @staticmethod
+    def _mtp_mappings_only(hf_config) -> list:
+        """Extract only the MTP mappings from the DSv3 common mapping list.
+
+        The shared `get_common_mapping_list` builds both transformer-layer
+        mappings (for the GPT layout) and MTP mappings. We want only the MTP
+        half for the hybrid layout – filter by the Megatron param prefix.
+        """
+        common = get_common_mapping_list(hf_config=hf_config)
+        mtp_only = []
+        for mapping in common:
+            megatron_param = getattr(mapping, "megatron_param", "") or ""
+            if isinstance(megatron_param, str) and megatron_param.startswith("mtp."):
+                mtp_only.append(mapping)
+        return mtp_only
+
+    def maybe_modify_converted_hf_weight(
+        self,
+        task,
+        converted_weights_dict: Dict[str, "torch.Tensor"],  # noqa: F821 (runtime torch)
+        hf_state_dict,
+    ):
+        """Add rotary inv_freq based on Megatron input_layernorm → HF layer.
+
+        Mirrors the parent bridge's logic but resolves the HF layer index from
+        the doubled Megatron index: HF layer `i` corresponds to Megatron
+        attention layer `2*i`.
+        """
+        import torch
+
+        from megatron.bridge.models.conversion.transformers_compat import rope_theta_from_hf
+
+        global_name = task.global_param_name
+        if not global_name.startswith("decoder.layers.") or not global_name.endswith(".input_layernorm.weight"):
+            return converted_weights_dict
+
+        parts = global_name.split(".")
+        if len(parts) < 4 or not parts[2].isdigit():
+            return converted_weights_dict
+
+        megatron_layer_idx = int(parts[2])
+        # Only even megatron layers correspond to HF attention layers in the
+        # hybrid `+-` / `+E` layout. Odd layers are MLP/MoE and have no inv_freq.
+        if megatron_layer_idx % 2 != 0:
+            return converted_weights_dict
+        hf_layer_idx = megatron_layer_idx // 2
+
+        inv_freq_key = f"model.layers.{hf_layer_idx}.self_attn.rotary_emb.inv_freq"
+        if inv_freq_key in converted_weights_dict:
+            return converted_weights_dict
+
+        has_inv_freq = getattr(self, "_deepseek_has_inv_freq", None)
+        if has_inv_freq is None:
+            has_inv_freq = False
+            for key in hf_state_dict.keys():
+                if key.startswith("model.layers.") and key.endswith(".self_attn.rotary_emb.inv_freq"):
+                    has_inv_freq = True
+                    break
+            self._deepseek_has_inv_freq = has_inv_freq
+        if not has_inv_freq:
+            return converted_weights_dict
+
+        inv_freq = getattr(self, "_deepseek_inv_freq", None)
+        if inv_freq is None:
+            rotary_dim = self.hf_config.qk_rope_head_dim
+            rotary_base = rope_theta_from_hf(self.hf_config)
+            inv_freq = 1.0 / (rotary_base ** (torch.arange(0, rotary_dim, 2, dtype=torch.float32) / rotary_dim))
+            self._deepseek_inv_freq = inv_freq
+
+        if converted_weights_dict:
+            reference_tensor = next(iter(converted_weights_dict.values()))
+            if inv_freq.device != reference_tensor.device:
+                inv_freq = inv_freq.to(device=reference_tensor.device)
+                self._deepseek_inv_freq = inv_freq
+
+        converted_weights_dict[inv_freq_key] = inv_freq
+        return converted_weights_dict

--- a/src/megatron/bridge/models/deepseek/deepseek_v3_mamba_bridge.py
+++ b/src/megatron/bridge/models/deepseek/deepseek_v3_mamba_bridge.py
@@ -47,13 +47,13 @@ Note:
 """
 
 from dataclasses import dataclass
-from typing import Dict, List, Tuple
+from typing import Dict
 
 from megatron.core.models.hybrid.hybrid_layer_allocation import Symbols
 from megatron.core.models.mamba import MambaModel
 
 from megatron.bridge.models.conversion.mapping_registry import MegatronMappingRegistry
-from megatron.bridge.models.conversion.param_mapping import AutoMapping, GatedMLPMapping
+from megatron.bridge.models.conversion.param_mapping import AutoMapping, GatedMLPMapping, MegatronParamMapping
 from megatron.bridge.models.deepseek.common import get_common_mapping_list
 from megatron.bridge.models.deepseek.deepseek_v3_bridge import DeepSeekV3Bridge
 from megatron.bridge.models.hf_pretrained.causal_lm import PreTrainedCausalLM
@@ -94,10 +94,11 @@ class DeepSeekV3MambaBridge(DeepSeekV3Bridge):
     - Auto-populates `hybrid_layer_pattern` from `first_k_dense_replace`.
     - Resizes `moe_layer_freq` to match the doubled hybrid layer count.
 
-    `mapping_registry` rewrites the DSv3 common mappings so attention
-    params land on even Megatron decoder indices and MLP/MoE params land on
-    odd ones, matching the `+-` / `+E` hybrid pattern. MTP mappings are
-    carried over unchanged.
+    `mapping_registry` reuses `get_common_mapping_list` and rewrites each
+    `decoder.layers.*.*` template so attention params land on even Megatron
+    decoder indices and MLP/MoE params land on odd ones, matching the
+    `+-` / `+E` hybrid pattern. Everything else (embeddings, final
+    layernorm, LM head, MTP) passes through unchanged.
     """
 
     PROVIDER_CLASS = DeepSeekV3MambaProvider
@@ -111,7 +112,7 @@ class DeepSeekV3MambaBridge(DeepSeekV3Bridge):
 
         Reuses the DSv3 MLA/MoE configuration produced by the parent
         `DeepSeekV3Bridge`, then adjusts for the Mamba backbone: drops
-        GPT-only wiring, builds a hybrid layer pattern, and doubles
+        GPT-only wiring, builds a hybrid layer pattern, and resizes
         `moe_layer_freq` to match the pattern length.
         """
         provider: DeepSeekV3MambaProvider = super().provider_bridge(hf_pretrained)
@@ -139,9 +140,7 @@ class DeepSeekV3MambaBridge(DeepSeekV3Bridge):
         # moe_layer_freq must match the final num_layers (i.e., pattern length)
         # for MCore validation. Dense hybrid positions use `-` (ignored), MoE
         # positions use `E`; reflect this per-position freq.
-        provider.moe_layer_freq = [
-            1 if ch == Symbols.MOE else 0 for ch in pattern
-        ]
+        provider.moe_layer_freq = [1 if ch == Symbols.MOE else 0 for ch in pattern]
 
         return provider
 
@@ -162,196 +161,69 @@ class DeepSeekV3MambaBridge(DeepSeekV3Bridge):
                 parts.append(Symbols.MLA + Symbols.MOE)
         return "".join(parts)
 
-    # Pattern templates categorized by which Megatron hybrid-position they land on.
-    # `.*` is the (single) layer wildcard; trailing `*` (no dot) is the expert wildcard.
-    _ATTENTION_TEMPLATES: List[Tuple[str, str]] = [
-        ("decoder.layers.*.input_layernorm.weight", "model.layers.*.input_layernorm.weight"),
-        ("decoder.layers.*.self_attention.linear_proj.weight", "model.layers.*.self_attn.o_proj.weight"),
-        (
-            "decoder.layers.*.self_attention.linear_kv_down_proj.weight",
-            "model.layers.*.self_attn.kv_a_proj_with_mqa.weight",
-        ),
-        (
-            "decoder.layers.*.self_attention.linear_kv_up_proj.weight",
-            "model.layers.*.self_attn.kv_b_proj.weight",
-        ),
-        (
-            "decoder.layers.*.self_attention.linear_kv_up_proj.layer_norm_weight",
-            "model.layers.*.self_attn.kv_a_layernorm.weight",
-        ),
-        (
-            "decoder.layers.*.self_attention.kv_layernorm.weight",
-            "model.layers.*.self_attn.kv_a_layernorm.weight",
-        ),
-        (
-            "decoder.layers.*.self_attention.linear_q_down_proj.weight",
-            "model.layers.*.self_attn.q_a_proj.weight",
-        ),
-        (
-            "decoder.layers.*.self_attention.linear_q_up_proj.weight",
-            "model.layers.*.self_attn.q_b_proj.weight",
-        ),
-        (
-            "decoder.layers.*.self_attention.linear_q_up_proj.layer_norm_weight",
-            "model.layers.*.self_attn.q_a_layernorm.weight",
-        ),
-        (
-            "decoder.layers.*.self_attention.q_layernorm.weight",
-            "model.layers.*.self_attn.q_a_layernorm.weight",
-        ),
-        # Fallback for DSv3 variants without LoRA on Q.
-        (
-            "decoder.layers.*.self_attention.linear_q_proj.weight",
-            "model.layers.*.self_attn.q_proj.weight",
-        ),
-    ]
-
-    _MLP_TEMPLATES: List[Tuple[str, str]] = [
-        ("decoder.layers.*.pre_mlp_layernorm.weight", "model.layers.*.post_attention_layernorm.weight"),
-        (
-            "decoder.layers.*.mlp.linear_fc1.layer_norm_weight",
-            "model.layers.*.post_attention_layernorm.weight",
-        ),
-        ("decoder.layers.*.mlp.linear_fc2.weight", "model.layers.*.mlp.down_proj.weight"),
-        ("decoder.layers.*.mlp.router.weight", "model.layers.*.mlp.gate.weight"),
-        (
-            "decoder.layers.*.mlp.router.expert_bias",
-            "model.layers.*.mlp.gate.e_score_correction_bias",
-        ),
-        (
-            "decoder.layers.*.mlp.experts.linear_fc2.weight*",
-            "model.layers.*.mlp.experts.*.down_proj.weight",
-        ),
-        (
-            "decoder.layers.*.mlp.shared_experts.linear_fc2.weight",
-            "model.layers.*.mlp.shared_experts.down_proj.weight",
-        ),
-    ]
-
-    # (megatron, gate_hf, up_hf) – always on the MLP/MoE hybrid position.
-    _MLP_GATED_TEMPLATES: List[Tuple[str, str, str]] = [
-        (
-            "decoder.layers.*.mlp.linear_fc1.weight",
-            "model.layers.*.mlp.gate_proj.weight",
-            "model.layers.*.mlp.up_proj.weight",
-        ),
-        (
-            "decoder.layers.*.mlp.experts.linear_fc1.weight*",
-            "model.layers.*.mlp.experts.*.gate_proj.weight",
-            "model.layers.*.mlp.experts.*.up_proj.weight",
-        ),
-        (
-            "decoder.layers.*.mlp.shared_experts.linear_fc1.weight",
-            "model.layers.*.mlp.shared_experts.gate_proj.weight",
-            "model.layers.*.mlp.shared_experts.up_proj.weight",
-        ),
-    ]
-
-    # Top-level (non-layer) mappings – identical on both sides.
-    _STATIC_MAPPINGS: List[Tuple[str, str]] = [
-        ("embedding.word_embeddings.weight", "model.embed_tokens.weight"),
-        ("decoder.final_layernorm.weight", "model.norm.weight"),
-        ("output_layer.weight", "lm_head.weight"),
-    ]
-
-    @staticmethod
-    def _specialize(pattern: str, hf_idx: int, meg_idx: int) -> str:
-        """Substitute the first `.*.` with the Megatron index and any later
-        `.*.` with the HF index. Trailing `*` (no dot – expert wildcard)
-        is preserved.
-        """
-        # First wildcard = layer index
-        out = pattern.replace(".*.", f".{meg_idx}.", 1)
-        # Any remaining `.*.` is the HF *layer* wildcard (only on HF side).
-        # On Megatron side this won't match because only one layer wildcard
-        # exists in our templates.
-        return out
-
     def mapping_registry(self) -> MegatronMappingRegistry:
-        """Build mappings that split HF layer i into Megatron layers 2i and 2i+1.
+        """Reuse the shared DSv3 mappings, splitting HF layer `i` into
+        Megatron layers `2*i` (attention) and `2*i + 1` (MLP/MoE).
 
-        Attention-side templates are emitted at Megatron index `2*i`; MLP/MoE
-        templates at `2*i + 1`. MTP mappings are reused from the DSv3 common
-        list unchanged because MTP layers form a separate decoder namespace
-        (`mtp.layers.*`) whose internal structure has no hybrid split.
+        Non-layer mappings (embeddings, final layernorm, LM head, and the
+        `mtp.layers.*` MTP subtree) pass through unchanged.
         """
         hf_config = self.hf_config
         if hf_config is None:
-            # Fall back to the GPT-layout mappings (still useful for tooling
-            # that only inspects the registry without running conversion).
             return super().mapping_registry()
 
         num_layers = getattr(hf_config, "num_hidden_layers", None)
         if num_layers is None:
             return super().mapping_registry()
 
-        mapping_list = []
-
-        # Top-level, non-layer params are untouched.
-        for megatron_param, hf_param in self._STATIC_MAPPINGS:
-            mapping_list.append(AutoMapping(megatron_param=megatron_param, hf_param=hf_param))
-
-        # Per-layer unrolling.
-        for hf_layer_idx in range(num_layers):
-            attn_meg_idx = 2 * hf_layer_idx
-            mlp_meg_idx = 2 * hf_layer_idx + 1
-
-            for meg_tpl, hf_tpl in self._ATTENTION_TEMPLATES:
-                mapping_list.append(
-                    AutoMapping(
-                        megatron_param=self._specialize(meg_tpl, hf_layer_idx, attn_meg_idx),
-                        hf_param=hf_tpl.replace(".*.", f".{hf_layer_idx}.", 1),
-                    )
-                )
-
-            for meg_tpl, hf_tpl in self._MLP_TEMPLATES:
-                mapping_list.append(
-                    AutoMapping(
-                        megatron_param=self._specialize(meg_tpl, hf_layer_idx, mlp_meg_idx),
-                        hf_param=hf_tpl.replace(".*.", f".{hf_layer_idx}.", 1),
-                    )
-                )
-
-            for meg_tpl, gate_tpl, up_tpl in self._MLP_GATED_TEMPLATES:
-                mapping_list.append(
-                    GatedMLPMapping(
-                        megatron_param=self._specialize(meg_tpl, hf_layer_idx, mlp_meg_idx),
-                        gate=gate_tpl.replace(".*.", f".{hf_layer_idx}.", 1),
-                        up=up_tpl.replace(".*.", f".{hf_layer_idx}.", 1),
-                    )
-                )
-
-        # MTP mappings – delegate to the shared DSv3 helper. It emits MTP-only
-        # entries (under `mtp.layers.*` / `model.layers.{N + k}.*`) that are
-        # unaffected by the hybrid layer split.
-        mtp_mappings = self._mtp_mappings_only(hf_config)
-        mapping_list.extend(mtp_mappings)
-
-        # DSv3-specific router bias mapping inherited from the default bridge.
-        mapping_list.append(
+        # Shared DSv3 mappings (wildcard transformer templates + already-
+        # concretized MTP entries) plus the DSv3-specific router expert bias
+        # mapping that the parent bridge appends in `super().mapping_registry()`.
+        templated = list(get_common_mapping_list(hf_config=hf_config))
+        templated.append(
             AutoMapping(
                 megatron_param="decoder.layers.*.mlp.router.expert_bias",
                 hf_param="model.layers.*.mlp.gate.e_score_correction_bias",
             )
         )
 
-        return MegatronMappingRegistry(*mapping_list)
+        remapped = []
+        for mapping in templated:
+            meg_param = getattr(mapping, "megatron_param", "") or ""
+            if not (isinstance(meg_param, str) and meg_param.startswith("decoder.layers.")):
+                # Non-layer or MTP mapping – pass through unchanged.
+                remapped.append(mapping)
+                continue
+
+            is_attention = "self_attention" in meg_param or ".input_layernorm." in meg_param
+            for hf_layer_idx in range(num_layers):
+                meg_idx = (2 * hf_layer_idx) if is_attention else (2 * hf_layer_idx + 1)
+                remapped.append(self._concretize_layer_mapping(mapping, hf_layer_idx, meg_idx))
+
+        return MegatronMappingRegistry(*remapped)
 
     @staticmethod
-    def _mtp_mappings_only(hf_config) -> list:
-        """Extract only the MTP mappings from the DSv3 common mapping list.
+    def _concretize_layer_mapping(
+        mapping: MegatronParamMapping, hf_layer_idx: int, meg_idx: int
+    ) -> MegatronParamMapping:
+        """Replace the first `.*.` layer wildcard with concrete indices.
 
-        The shared `get_common_mapping_list` builds both transformer-layer
-        mappings (for the GPT layout) and MTP mappings. We want only the MTP
-        half for the hybrid layout – filter by the Megatron param prefix.
+        Preserves any trailing `*` expert wildcard and uses `type(mapping)`
+        so subclasses (AutoMapping, GatedMLPMapping, ...) round-trip cleanly.
         """
-        common = get_common_mapping_list(hf_config=hf_config)
-        mtp_only = []
-        for mapping in common:
-            megatron_param = getattr(mapping, "megatron_param", "") or ""
-            if isinstance(megatron_param, str) and megatron_param.startswith("mtp."):
-                mtp_only.append(mapping)
-        return mtp_only
+        meg_sub = f".{meg_idx}."
+        hf_sub = f".{hf_layer_idx}."
+
+        if isinstance(mapping, GatedMLPMapping):
+            return GatedMLPMapping(
+                megatron_param=mapping.megatron_param.replace(".*.", meg_sub, 1),
+                gate=mapping.gate.replace(".*.", hf_sub, 1),
+                up=mapping.up.replace(".*.", hf_sub, 1),
+            )
+        return type(mapping)(
+            megatron_param=mapping.megatron_param.replace(".*.", meg_sub, 1),
+            hf_param=mapping.hf_param.replace(".*.", hf_sub, 1),
+        )
 
     def maybe_modify_converted_hf_weight(
         self,

--- a/src/megatron/bridge/recipes/deepseek/__init__.py
+++ b/src/megatron/bridge/recipes/deepseek/__init__.py
@@ -16,6 +16,9 @@ from .deepseek_v3 import (
     deepseek_v3_pretrain_config_32nodes,
 )
 
+# DeepSeek V3 — Mamba/Hybrid backbone variant
+from .deepseek_v3_mamba import deepseek_v3_mamba_pretrain_config
+
 
 __all__ = [
     # DeepSeek V2/V2-Lite
@@ -24,4 +27,6 @@ __all__ = [
     # DeepSeek V3
     "deepseek_v3_pretrain_config",
     "deepseek_v3_pretrain_config_32nodes",
+    # DeepSeek V3 (Mamba)
+    "deepseek_v3_mamba_pretrain_config",
 ]

--- a/src/megatron/bridge/recipes/deepseek/deepseek_v3_mamba.py
+++ b/src/megatron/bridge/recipes/deepseek/deepseek_v3_mamba.py
@@ -1,0 +1,202 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DeepSeek-V3 pretraining recipe using `MambaModel` as the base class.
+
+Mirror of :mod:`megatron.bridge.recipes.deepseek.deepseek_v3` but constructs
+the provider via :class:`DeepSeekV3MambaBridge`, so the model is instantiated
+as a Megatron-Core `MambaModel` (hybrid stack with MLA attention + MLP/MoE)
+instead of `GPTModel`. See the bridge module for the `+-` / `+E` hybrid
+layer layout that this recipe produces.
+"""
+
+import os
+
+import torch
+from transformers import AutoConfig
+
+from megatron.bridge.models.deepseek.deepseek_v3_mamba_bridge import DeepSeekV3MambaBridge
+from megatron.bridge.models.hf_pretrained.causal_lm import _ConfigOnlyPretrainedShim
+from megatron.bridge.recipes.common import _pretrain_common
+from megatron.bridge.recipes.deepseek.deepseek_v3 import set_deepseek_v3_pipeline_model_parallel_layout
+from megatron.bridge.recipes.utils.tokenizer_utils import DEFAULT_NULL_TOKENIZER_VOCAB_SIZE
+from megatron.bridge.training.comm_overlap import CommOverlapConfig
+from megatron.bridge.training.config import ConfigContainer
+from megatron.bridge.training.flex_dispatcher_backend import apply_flex_dispatcher_backend
+from megatron.bridge.training.mixed_precision import MixedPrecisionConfig
+
+
+#: Env var override for the HF model path (useful in sandboxed clusters that
+#: cannot reach huggingface.co — point it at a local checkpoint directory).
+_HF_PATH_ENV = "DEEPSEEK_V3_HF_PATH"
+
+
+def _build_mamba_provider(hf_model_name: str | None = None):
+    """Construct a :class:`DeepSeekV3MambaProvider` from an HF model id or path.
+
+    `AutoBridge.from_hf_pretrained` would dispatch to the registered
+    :class:`DeepSeekV3Bridge` (GPT-backed), so we bypass it and drive the
+    bridge directly. ``hf_model_name`` defaults to the ``DEEPSEEK_V3_HF_PATH``
+    environment variable, falling back to ``deepseek-ai/DeepSeek-V3``.
+    """
+    if hf_model_name is None:
+        hf_model_name = os.environ.get(_HF_PATH_ENV, "deepseek-ai/DeepSeek-V3")
+    hf_config = AutoConfig.from_pretrained(hf_model_name, trust_remote_code=True)
+    shim = _ConfigOnlyPretrainedShim(hf_config)
+
+    bridge = DeepSeekV3MambaBridge()
+    bridge.hf_config = hf_config
+    return bridge.provider_bridge(shim)
+
+
+def deepseek_v3_mamba_pretrain_config() -> ConfigContainer:
+    """Return a pre-training config for DeepSeek-V3 with a Mamba/Hybrid backbone.
+
+    Parallelism defaults mirror :func:`deepseek_v3_pretrain_config`
+    (TP=2, PP=16, EP=64), but note that the hybrid layer count is ``2 *
+    num_hidden_layers`` (122 layers for DSv3), which may require revisiting
+    the pipeline-parallel layout.
+    """
+    cfg = _pretrain_common()
+
+    # Model config — built directly from our Mamba-backed bridge.
+    cfg.model = _build_mamba_provider()
+
+    # Tokenizer - uses NullTokenizer by default (no HF tokenizer download needed)
+    cfg.tokenizer.tokenizer_type = "NullTokenizer"
+    cfg.tokenizer.tokenizer_model = None
+    cfg.tokenizer.vocab_size = DEFAULT_NULL_TOKENIZER_VOCAB_SIZE
+
+    # Dataset config - mock data by default
+    cfg.dataset.blend = None
+    cfg.dataset.num_workers = 8
+
+    # Parallelism settings (MoE-specific: includes expert_model_parallel_size)
+    cfg.model.tensor_model_parallel_size = 2
+    cfg.model.pipeline_model_parallel_size = 16
+    cfg.model.pipeline_model_parallel_layout = None
+    cfg.model.pipeline_dtype = torch.bfloat16
+    cfg.model.virtual_pipeline_model_parallel_size = None
+    cfg.model.context_parallel_size = 1
+    cfg.model.expert_model_parallel_size = 64
+    cfg.model.expert_tensor_parallel_size = 1
+    cfg.model.sequence_parallel = True
+    cfg.model.seq_length = 4096
+
+    # MTP (Multi-Token Prediction) configuration
+    cfg.model.mtp_num_layers = 1
+    cfg.model.mtp_loss_scaling_factor = 0.1
+
+    # Model-specific settings
+    cfg.model.init_method_std = 0.006
+    cfg.model.rotary_base = 10000.0
+    cfg.model.rotary_scaling_factor = 40
+    cfg.model.rotary_base = float(cfg.model.rotary_base)
+    cfg.model.rotary_scaling_factor = int(cfg.model.rotary_scaling_factor)
+
+    # Pipeline split settings
+    cfg.model.account_for_embedding_in_pipeline_split = False
+    cfg.model.account_for_loss_in_pipeline_split = False
+    cfg.model.num_layers_in_first_pipeline_stage = None
+    cfg.model.num_layers_in_last_pipeline_stage = None
+
+    # Set pipeline layout (derived from mtp_num_layers + pp/vp sizes).
+    set_deepseek_v3_pipeline_model_parallel_layout(cfg.model)
+
+    # MoE Token Dispatcher settings
+    cfg.model.moe_token_dispatcher_type = "alltoall"
+    cfg.model.moe_flex_dispatcher_backend = "hybridep"
+    cfg.model.moe_hybridep_num_sms = 16
+
+    # Training config
+    cfg.train.train_iters = 1_000_000
+    cfg.train.global_batch_size = 4096
+    cfg.train.micro_batch_size = 1
+    cfg.validation.eval_interval = 2000
+    cfg.train.manual_gc = True
+    cfg.train.manual_gc_interval = 5
+    cfg.train.manual_gc_eval = 5
+
+    # Scheduler config
+    cfg.scheduler.lr_warmup_iters = 2000
+
+    # TE (Transformer Engine)
+    cfg.model.transformer_impl = "transformer_engine"
+
+    # CUDA Graph
+    cfg.model.cuda_graph_impl = "none"
+    cfg.model.cuda_graph_scope = "full"
+    cfg.model.cuda_graph_warmup_steps = 3
+
+    # Kernel selections
+    cfg.model.attention_backend = None
+    cfg.model.moe_router_fusion = False
+    cfg.model.moe_permute_fusion = True
+    cfg.model.moe_grouped_gemm = True
+    cfg.model.cross_entropy_loss_fusion = True
+    cfg.model.cross_entropy_fusion_impl = "te"
+
+    # Memory saving
+    cfg.model.recompute_granularity = "selective"
+    cfg.model.recompute_modules = None
+    cfg.model.recompute_method = None
+    cfg.model.recompute_num_layers = None
+    cfg.model.fine_grained_activation_offloading = False
+    cfg.model.offload_modules = None
+
+    # Mixed precision
+    cfg.mixed_precision = MixedPrecisionConfig(
+        bf16=True,
+        params_dtype=torch.bfloat16,
+        pipeline_dtype=torch.bfloat16,
+        autocast_enabled=False,
+        grad_reduce_in_fp32=False,
+    )
+    cfg.model.moe_router_padding_for_fp8 = False
+
+    # Optimizer settings
+    cfg.optimizer.use_precision_aware_optimizer = True
+    cfg.optimizer.main_params_dtype = torch.float32
+    cfg.optimizer.main_grads_dtype = torch.bfloat16
+    cfg.optimizer.exp_avg_dtype = torch.bfloat16
+    cfg.optimizer.exp_avg_sq_dtype = torch.bfloat16
+
+    # Communication overlap
+    cfg.comm_overlap = CommOverlapConfig(tp_comm_overlap=False)
+    cfg.comm_overlap.delay_wgrad_compute = False
+    cfg.comm_overlap.overlap_moe_expert_parallel_comm = False
+    cfg.model.moe_shared_expert_overlap = True
+
+    # Checkpoint config
+    cfg.checkpoint.save_interval = 2000
+    cfg.checkpoint.async_save = False
+
+    # DDP config
+    cfg.ddp.overlap_grad_reduce = True
+    cfg.ddp.overlap_param_gather = True
+    cfg.ddp.check_for_nan_in_grad = True
+    cfg.ddp.use_distributed_optimizer = True
+    cfg.ddp.use_megatron_fsdp = False
+    cfg.ddp.grad_reduce_in_fp32 = False
+    cfg.ddp.data_parallel_sharding_strategy = "no_shard"
+
+    # MoE Force Load Balancing
+    cfg.model.moe_router_force_load_balancing = False
+
+    if cfg.model.apply_rope_fusion:
+        cfg.dist.enable_megatron_core_experimental = True  # mla rope fusion is experimental
+
+    apply_flex_dispatcher_backend(cfg.model, cfg.model.moe_flex_dispatcher_backend)
+
+    return cfg


### PR DESCRIPTION
# What does this PR do ?

Add a new MambaBridge provider and recipe for DSv3 to enable easier testing and usage of the Hybrid model API.
Requires https://github.com/NVIDIA/Megatron-LM/pull/4452, so marked as draft until that is merged.