### PR TITLE
feat: add deterministic training support

### DIFF
--- a/scripts/performance/README.md
+++ b/scripts/performance/README.md
@@ -75,6 +75,63 @@ uv run python scripts/performance/setup_experiment.py \
 - `-a/--account` (Mandatory for Slurm based clusters)
 - `-p/--partition` (Mandatory for Slurm based clusters)
 
+## Determinism
+
+Deterministic training guarantees that two runs with identical inputs produce identical outputs at every step.  It is useful for debugging (isolating regressions) and for reproducibility studies.
+
+### What `--deterministic` does
+
+**Environment variables** (set on the Slurm executor via `PerfEnvPlugin`):
+
+| Variable | Value | Reason |
+|---|---|---|
+| `NCCL_ALGO` | `Ring` | Disables tree/NVLink collectives that are non-deterministic |
+| `NVTE_ALLOW_NONDETERMINISTIC_ALGO` | `0` | Forces TE to use deterministic algorithms |
+| `CUBLAS_WORKSPACE_CONFIG` | `:4096:8` | Disables cuBLAS heuristic workspace selection |
+
+**Model config overrides** (applied by `apply_determinism_overrides` in the recipe layer):
+
+| Field | Value |
+|---|---|
+| `model.deterministic_mode` | `True` |
+| `model.cross_entropy_loss_fusion` | `False` |
+| `comm_overlap.tp_comm_overlap` | `False` |
+
+### Example commands
+
+```bash
+# Llama 3 70B — deterministic, H100 64-GPU
+python scripts/performance/setup_experiment.py \
+  --account <account> --partition <partition> \
+  --gpu h100 -m llama3 -s 70b -ng 64 -gn 8 \
+  --container_image <image> --task pretrain \
+  --deterministic
+
+# Llama 3.1 405B — deterministic, H100 512-GPU
+python scripts/performance/setup_experiment.py \
+  --account <account> --partition <partition> \
+  --gpu h100 -m llama31 -s 405b -ng 512 -gn 8 \
+  --container_image <image> --task pretrain \
+  --deterministic
+```
+
+### Using the recipe library directly
+
+`apply_determinism_overrides` is also importable for use outside the performance script layer:
+
+```python
+from megatron.bridge.recipes.llama import llama3_70b_pretrain_deterministic_config
+
+cfg = llama3_70b_pretrain_deterministic_config(mock=True)
+
+# Or, apply overrides to any existing recipe:
+from megatron.bridge.recipes.utils import apply_determinism_overrides
+from megatron.bridge.recipes.llama import llama3_70b_pretrain_config
+
+cfg = llama3_70b_pretrain_config(mock=True)
+apply_determinism_overrides(cfg)
+```
+
 #### <ins>Configuration Options</ins>
 
 ##### Container Image

--- a/scripts/performance/README.md
+++ b/scripts/performance/README.md
@@ -75,63 +75,6 @@ uv run python scripts/performance/setup_experiment.py \
 - `-a/--account` (Mandatory for Slurm based clusters)
 - `-p/--partition` (Mandatory for Slurm based clusters)
 
-## Determinism
-
-Deterministic training guarantees that two runs with identical inputs produce identical outputs at every step.  It is useful for debugging (isolating regressions) and for reproducibility studies.
-
-### What `--deterministic` does
-
-**Environment variables** (set on the Slurm executor via `PerfEnvPlugin`):
-
-| Variable | Value | Reason |
-|---|---|---|
-| `NCCL_ALGO` | `Ring` | Disables tree/NVLink collectives that are non-deterministic |
-| `NVTE_ALLOW_NONDETERMINISTIC_ALGO` | `0` | Forces TE to use deterministic algorithms |
-| `CUBLAS_WORKSPACE_CONFIG` | `:4096:8` | Disables cuBLAS heuristic workspace selection |
-
-**Model config overrides** (applied by `apply_determinism_overrides` in the recipe layer):
-
-| Field | Value |
-|---|---|
-| `model.deterministic_mode` | `True` |
-| `model.cross_entropy_loss_fusion` | `False` |
-| `comm_overlap.tp_comm_overlap` | `False` |
-
-### Example commands
-
-```bash
-# Llama 3 70B — deterministic, H100 64-GPU
-python scripts/performance/setup_experiment.py \
-  --account <account> --partition <partition> \
-  --gpu h100 -m llama3 -s 70b -ng 64 -gn 8 \
-  --container_image <image> --task pretrain \
-  --deterministic
-
-# Llama 3.1 405B — deterministic, H100 512-GPU
-python scripts/performance/setup_experiment.py \
-  --account <account> --partition <partition> \
-  --gpu h100 -m llama31 -s 405b -ng 512 -gn 8 \
-  --container_image <image> --task pretrain \
-  --deterministic
-```
-
-### Using the recipe library directly
-
-`apply_determinism_overrides` is also importable for use outside the performance script layer:
-
-```python
-from megatron.bridge.recipes.llama import llama3_70b_pretrain_deterministic_config
-
-cfg = llama3_70b_pretrain_deterministic_config(mock=True)
-
-# Or, apply overrides to any existing recipe:
-from megatron.bridge.recipes.utils import apply_determinism_overrides
-from megatron.bridge.recipes.llama import llama3_70b_pretrain_config
-
-cfg = llama3_70b_pretrain_config(mock=True)
-apply_determinism_overrides(cfg)
-```
-
 #### <ins>Configuration Options</ins>
 
 ##### Container Image
@@ -320,3 +263,62 @@ Mounting cached files is not enough by itself. If `HF_HUB_OFFLINE` remains `0`, 
 - `--max_outlier_ratio`: Maximum ratio of outliers allowed. Default `0.1`.
 - `--outlier_threshold`: Outlier detection threshold (sigma). Default `3.0`.
 - `--skip_first_percent_loss`: Percentage of loss points to skip from beginning for convergence analysis. Default `0.20` (20%).
+
+## Determinism
+
+Deterministic training guarantees that two runs with identical inputs produce identical outputs at every step.  It is useful for debugging (isolating regressions) and for reproducibility studies.
+
+### What `--deterministic` does
+
+**Environment variables** (set on the Slurm executor via `PerfEnvPlugin`):
+
+| Variable | Value | Reason |
+|---|---|---|
+| `NCCL_ALGO` | `Ring` | Disables tree/NVLink collectives that are non-deterministic |
+| `NVTE_ALLOW_NONDETERMINISTIC_ALGO` | `0` | Forces TE to use deterministic algorithms |
+| `CUBLAS_WORKSPACE_CONFIG` | `:4096:8` | Disables cuBLAS heuristic workspace selection |
+
+**Model config overrides** (applied by `apply_determinism_overrides` in the recipe layer):
+
+| Field | Value |
+|---|---|
+| `model.deterministic_mode` | `True` |
+| `model.cross_entropy_loss_fusion` | `False` |
+| `comm_overlap.tp_comm_overlap` | `False` |
+
+### Example commands
+
+```bash
+# Llama 3 70B — deterministic, H100 64-GPU
+python scripts/performance/setup_experiment.py \
+  --account <account> --partition <partition> \
+  --gpu h100 -m llama3 -s 70b -ng 64 -gn 8 \
+  --container_image <image> --task pretrain \
+  --deterministic
+
+# Llama 3.1 405B — deterministic, H100 512-GPU
+python scripts/performance/setup_experiment.py \
+  --account <account> --partition <partition> \
+  --gpu h100 -m llama31 -s 405b -ng 512 -gn 8 \
+  --container_image <image> --task pretrain \
+  --deterministic
+```
+
+### Using the recipe library directly
+
+`apply_determinism_overrides` is also importable for use outside the performance script layer:
+
+```python
+from megatron.bridge.recipes.llama import llama3_70b_pretrain_deterministic_config
+
+cfg = llama3_70b_pretrain_deterministic_config(mock=True)
+
+# Or, apply overrides to any existing recipe:
+from megatron.bridge.recipes.utils import apply_determinism_overrides
+from megatron.bridge.recipes.llama import llama3_70b_pretrain_config
+
+cfg = llama3_70b_pretrain_config(mock=True)
+apply_determinism_overrides(cfg)
+```
+
+Note: bit-exact reproducibility additionally requires the executor-side env vars listed above. The recipe-only path covers the model config, not the runtime environment.

--- a/scripts/performance/argument_parser.py
+++ b/scripts/performance/argument_parser.py
@@ -759,6 +759,13 @@ def parse_cli_args():
         required=False,
         default=-1,
     )
+    performance_args.add_argument(
+        "--deterministic",
+        help="Enable deterministic training. Sets NCCL_ALGO=Ring, "
+        "NVTE_ALLOW_NONDETERMINISTIC_ALGO=0, and CUBLAS_WORKSPACE_CONFIG env vars, "
+        "and disables non-deterministic model ops.",
+        action="store_true",
+    )
 
     # Logging
     logging_args = parser.add_argument_group("Logging arguments")

--- a/scripts/performance/argument_parser.py
+++ b/scripts/performance/argument_parser.py
@@ -761,9 +761,8 @@ def parse_cli_args():
     )
     performance_args.add_argument(
         "--deterministic",
-        help="Enable deterministic training. Sets NCCL_ALGO=Ring, "
-        "NVTE_ALLOW_NONDETERMINISTIC_ALGO=0, and CUBLAS_WORKSPACE_CONFIG env vars, "
-        "and disables non-deterministic model ops.",
+        help="Enable bit-exact deterministic training. Sets NCCL/cuBLAS/TE env vars "
+        "and disables fused cross-entropy loss and TP comm overlap.",
         action="store_true",
     )
 

--- a/scripts/performance/perf_plugins.py
+++ b/scripts/performance/perf_plugins.py
@@ -238,6 +238,14 @@ class PerfEnvPlugin(Plugin):
     compute_dtype: str
     train_task: str
     config_variant: str = "v1"
+    deterministic: bool = False
+
+    def _set_determinism_env_vars(self, executor: "run.Executor") -> None:
+        """Set env vars required for bit-exact reproducibility."""
+        executor.env_vars["NCCL_ALGO"] = "Ring"
+        executor.env_vars["NVTE_ALLOW_NONDETERMINISTIC_ALGO"] = "0"
+        executor.env_vars["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
+        logger.info("Deterministic mode enabled: NCCL_ALGO=Ring, NVTE_ALLOW_NONDETERMINISTIC_ALGO=0")
 
     def _set_num_cuda_device_max_connections(
         self,
@@ -594,6 +602,9 @@ class PerfEnvPlugin(Plugin):
         # Set NVFP4-specific environment variables
         if self.compute_dtype == "nvfp4":
             executor.env_vars["NVTE_USE_FAST_MATH"] = "1"
+
+        if self.deterministic:
+            self._set_determinism_env_vars(executor)
 
 
 @dataclass

--- a/scripts/performance/perf_plugins.py
+++ b/scripts/performance/perf_plugins.py
@@ -245,7 +245,7 @@ class PerfEnvPlugin(Plugin):
         executor.env_vars["NCCL_ALGO"] = "Ring"
         executor.env_vars["NVTE_ALLOW_NONDETERMINISTIC_ALGO"] = "0"
         executor.env_vars["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
-        logger.info("Deterministic mode enabled: NCCL_ALGO=Ring, NVTE_ALLOW_NONDETERMINISTIC_ALGO=0")
+        logger.info("Deterministic mode enabled")
 
     def _set_num_cuda_device_max_connections(
         self,

--- a/scripts/performance/run_recipe.py
+++ b/scripts/performance/run_recipe.py
@@ -176,6 +176,12 @@ def set_user_overrides(config, args):
     if args.wandb_save_dir:
         config.logger.wandb_save_dir = args.wandb_save_dir
 
+    # Determinism overrides
+    if args.deterministic:
+        from megatron.bridge.recipes.utils.determinism_utils import apply_determinism_overrides
+
+        apply_determinism_overrides(config)
+
     # Handle convergence mode configuration
     config.logger.log_interval = 1
 

--- a/scripts/performance/run_recipe.py
+++ b/scripts/performance/run_recipe.py
@@ -30,6 +30,7 @@ from utils.datasets import (
 )
 from utils.utils import get_library_recipe
 
+from megatron.bridge.recipes.utils.determinism_utils import apply_determinism_overrides
 from megatron.bridge.utils.common_utils import get_rank_safe
 
 
@@ -176,10 +177,7 @@ def set_user_overrides(config, args):
     if args.wandb_save_dir:
         config.logger.wandb_save_dir = args.wandb_save_dir
 
-    # Determinism overrides
     if args.deterministic:
-        from megatron.bridge.recipes.utils.determinism_utils import apply_determinism_overrides
-
         apply_determinism_overrides(config)
 
     # Handle convergence mode configuration

--- a/scripts/performance/setup_experiment.py
+++ b/scripts/performance/setup_experiment.py
@@ -268,6 +268,7 @@ def main(
     kubeflow_workdir_pvc: str,
     kubeflow_workdir_pvc_path: str,
     kubeflow_image_pull_secrets: List[str],
+    deterministic: bool = False,
     config_variant: str = "v1",
     gres: Optional[str] = None,
     packager: str = "git",
@@ -440,6 +441,7 @@ def main(
                 compute_dtype=compute_dtype,
                 train_task=task,
                 config_variant=config_variant,
+                deterministic=deterministic,
             )
         )
 
@@ -758,6 +760,7 @@ if __name__ == "__main__":
         kubeflow_workdir_pvc=args.kubeflow_workdir_pvc,
         kubeflow_workdir_pvc_path=args.kubeflow_workdir_pvc_path,
         kubeflow_image_pull_secrets=args.kubeflow_image_pull_secrets,
+        deterministic=args.deterministic,
         config_variant=config_variant,
         gres=args.gres,
         packager=args.packager,

--- a/scripts/performance/utils/overrides.py
+++ b/scripts/performance/utils/overrides.py
@@ -19,8 +19,8 @@ from typing import List, Optional
 from omegaconf import OmegaConf
 
 from megatron.bridge.recipes.deepseek.deepseek_v3 import set_deepseek_v3_pipeline_model_parallel_layout
-from megatron.bridge.recipes.utils.determinism_utils import apply_determinism_overrides
 from megatron.bridge.recipes.kimi.kimi_k2 import _get_kimi_k2_pipeline_layout
+from megatron.bridge.recipes.utils.determinism_utils import apply_determinism_overrides
 from megatron.bridge.training.comm_overlap import *
 from megatron.bridge.training.config import ConfigContainer, TokenizerConfig
 from megatron.bridge.training.flex_dispatcher_backend import apply_flex_dispatcher_backend

--- a/scripts/performance/utils/overrides.py
+++ b/scripts/performance/utils/overrides.py
@@ -19,6 +19,7 @@ from typing import List, Optional
 from omegaconf import OmegaConf
 
 from megatron.bridge.recipes.deepseek.deepseek_v3 import set_deepseek_v3_pipeline_model_parallel_layout
+from megatron.bridge.recipes.utils.determinism_utils import apply_determinism_overrides
 from megatron.bridge.recipes.kimi.kimi_k2 import _get_kimi_k2_pipeline_layout
 from megatron.bridge.training.comm_overlap import *
 from megatron.bridge.training.config import ConfigContainer, TokenizerConfig
@@ -455,6 +456,9 @@ def set_user_overrides(recipe: ConfigContainer, args: argparse.Namespace) -> Con
     pp_size = getattr(recipe.model, "pipeline_model_parallel_size", 1) or 1
     if args.task == "lora" and pp_size > 1 and not recipe.ddp.use_megatron_fsdp:
         recipe.dist.use_tp_pp_dp_mapping = True
+
+    if args.deterministic:
+        apply_determinism_overrides(recipe)
 
     return recipe
 

--- a/src/megatron/bridge/recipes/llama/__init__.py
+++ b/src/megatron/bridge/recipes/llama/__init__.py
@@ -31,6 +31,7 @@ from .llama3 import (
     llama3_70b_peft_config,
     llama3_70b_pretrain_config,
     llama3_70b_sft_config,
+    llama3_70b_pretrain_deterministic_config,
     # Llama3.1 models
     llama31_8b_peft_config,
     llama31_8b_pretrain_config,
@@ -41,6 +42,7 @@ from .llama3 import (
     llama31_405b_peft_config,
     llama31_405b_pretrain_config,
     llama31_405b_sft_config,
+    llama31_405b_pretrain_deterministic_config,
     # Llama3.2 models
     llama32_1b_peft_config,
     llama32_1b_pretrain_config,
@@ -61,12 +63,14 @@ __all__ = [
     "llama3_8b_128k_pretrain_config",
     "llama3_8b_low_precision_pretrain_config",
     "llama3_70b_pretrain_config",
+    "llama3_70b_pretrain_deterministic_config",
     "llama3_70b_16k_pretrain_config",
     "llama3_70b_64k_pretrain_config",
     # Llama3.1 models
     "llama31_8b_pretrain_config",
     "llama31_70b_pretrain_config",
     "llama31_405b_pretrain_config",
+    "llama31_405b_pretrain_deterministic_config",
     # Llama3.2 models
     "llama32_1b_pretrain_config",
     "llama32_3b_pretrain_config",

--- a/src/megatron/bridge/recipes/llama/__init__.py
+++ b/src/megatron/bridge/recipes/llama/__init__.py
@@ -30,8 +30,8 @@ from .llama3 import (
     llama3_70b_64k_pretrain_config,
     llama3_70b_peft_config,
     llama3_70b_pretrain_config,
-    llama3_70b_sft_config,
     llama3_70b_pretrain_deterministic_config,
+    llama3_70b_sft_config,
     # Llama3.1 models
     llama31_8b_peft_config,
     llama31_8b_pretrain_config,
@@ -41,8 +41,8 @@ from .llama3 import (
     llama31_70b_sft_config,
     llama31_405b_peft_config,
     llama31_405b_pretrain_config,
-    llama31_405b_sft_config,
     llama31_405b_pretrain_deterministic_config,
+    llama31_405b_sft_config,
     # Llama3.2 models
     llama32_1b_peft_config,
     llama32_1b_pretrain_config,

--- a/src/megatron/bridge/recipes/llama/llama3.py
+++ b/src/megatron/bridge/recipes/llama/llama3.py
@@ -17,6 +17,7 @@ import torch
 from megatron.bridge import AutoBridge
 from megatron.bridge.peft.base import PEFT
 from megatron.bridge.recipes.common import _peft_common, _pretrain_common, _sft_common
+from megatron.bridge.recipes.utils.determinism_utils import apply_determinism_overrides
 from megatron.bridge.recipes.utils.finetune_utils import default_peft_config
 from megatron.bridge.recipes.utils.tokenizer_utils import DEFAULT_NULL_TOKENIZER_VOCAB_SIZE
 from megatron.bridge.training.comm_overlap import (
@@ -745,6 +746,19 @@ def llama3_70b_pretrain_config() -> ConfigContainer:
     return cfg
 
 
+def llama3_70b_pretrain_deterministic_config() -> ConfigContainer:
+    """Return a deterministic pre-training config for Llama 3 70B.
+
+    Wraps :func:`llama3_70b_pretrain_config` and applies
+    :func:`~megatron.bridge.recipes.utils.determinism_utils.apply_determinism_overrides`.
+    Bit-exact reproducibility also requires the executor-side env vars set by
+    ``PerfEnvPlugin(deterministic=True)``.
+    """
+    cfg = llama3_70b_pretrain_config()
+    apply_determinism_overrides(cfg)
+    return cfg
+
+
 def llama3_70b_16k_pretrain_config() -> ConfigContainer:
     """Return a pre-training config for Llama 3 70B 16K.
 
@@ -1192,6 +1206,19 @@ def llama31_405b_pretrain_config() -> ConfigContainer:
 
     cfg.mixed_precision = bf16_mixed()
 
+    return cfg
+
+
+def llama31_405b_pretrain_deterministic_config() -> ConfigContainer:
+    """Return a deterministic pre-training config for Llama 3.1 405B.
+
+    Wraps :func:`llama31_405b_pretrain_config` and applies
+    :func:`~megatron.bridge.recipes.utils.determinism_utils.apply_determinism_overrides`.
+    Bit-exact reproducibility also requires the executor-side env vars set by
+    ``PerfEnvPlugin(deterministic=True)``.
+    """
+    cfg = llama31_405b_pretrain_config()
+    apply_determinism_overrides(cfg)
     return cfg
 
 

--- a/src/megatron/bridge/recipes/utils/__init__.py
+++ b/src/megatron/bridge/recipes/utils/__init__.py
@@ -1,0 +1,3 @@
+from .determinism_utils import apply_determinism_overrides
+
+__all__ = ["apply_determinism_overrides"]

--- a/src/megatron/bridge/recipes/utils/__init__.py
+++ b/src/megatron/bridge/recipes/utils/__init__.py
@@ -1,3 +1,18 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from .determinism_utils import apply_determinism_overrides
+
 
 __all__ = ["apply_determinism_overrides"]

--- a/src/megatron/bridge/recipes/utils/determinism_utils.py
+++ b/src/megatron/bridge/recipes/utils/determinism_utils.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Config-level overrides for deterministic training."""
+
+from megatron.bridge.training.config import ConfigContainer
+
+
+def apply_determinism_overrides(cfg: ConfigContainer) -> None:
+    """Apply determinism config overrides to an existing ConfigContainer in-place.
+
+    Sets the model-level flags required for bit-exact reproducibility and
+    disables TP comm overlap (which uses non-deterministic NCCL collectives).
+    Attention backend selection is a separate concern and is not touched here.
+
+    Args:
+        cfg: Recipe config to modify.
+    """
+    cfg.model.deterministic_mode = True
+    cfg.model.cross_entropy_loss_fusion = False
+
+    if cfg.comm_overlap is not None:
+        cfg.comm_overlap.tp_comm_overlap = False

--- a/src/megatron/bridge/recipes/utils/determinism_utils.py
+++ b/src/megatron/bridge/recipes/utils/determinism_utils.py
@@ -24,6 +24,19 @@ def apply_determinism_overrides(cfg: ConfigContainer) -> None:
     disables TP comm overlap (which uses non-deterministic NCCL collectives).
     Attention backend selection is a separate concern and is not touched here.
 
+    The matching validator that enforces these flags at training time is
+    :meth:`megatron.bridge.training.config.ConfigContainer._validate_and_apply_deterministic_mode`.
+
+    This function is idempotent and is safe to call on configs with
+    ``comm_overlap = None``.
+
+    Note:
+        Bit-exact reproducibility additionally requires runtime env vars
+        (``NCCL_ALGO=Ring``, ``NVTE_ALLOW_NONDETERMINISTIC_ALGO=0``,
+        ``CUBLAS_WORKSPACE_CONFIG=:4096:8``). The performance launcher sets
+        these via ``PerfEnvPlugin(deterministic=True)``; callers outside that
+        launcher must set them themselves.
+
     Args:
         cfg: Recipe config to modify.
     """

--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -30,7 +30,6 @@ from megatron.core.optimizer import (
     ParamKey,
 )
 from megatron.core.process_groups_config import ProcessGroupCollection
-from megatron.core.transformer.enums import AttnBackend
 from megatron.core.transformer.module import MegatronModule
 from megatron.core.transformer.transformer_config import MLATransformerConfig as MCoreMLATransformerConfig
 from megatron.core.transformer.transformer_config import TransformerConfig as MCoreTransformerConfig
@@ -1069,10 +1068,6 @@ class ConfigContainer(Container):
         """
         if not getattr(self.model, "deterministic_mode", False):
             return
-
-        # Disallow flash attention when running deterministically
-        if getattr(self.model, "attention_backend", None) == AttnBackend.flash:
-            raise AssertionError("Flash attention can not be used in deterministic mode.")
 
         # Disallow cross-entropy loss fusion as it is not deterministic
         assert not getattr(self.model, "cross_entropy_loss_fusion", False), (

--- a/tests/unit_tests/recipes/test_llama_recipes.py
+++ b/tests/unit_tests/recipes/test_llama_recipes.py
@@ -506,3 +506,20 @@ def test_llama3_8b_low_precision_nvfp4_defaults(monkeypatch: pytest.MonkeyPatch)
     assert cfg.mixed_precision.first_last_layers_bf16 is True
     assert cfg.mixed_precision.num_layers_at_start_in_bf16 == 0
     assert cfg.mixed_precision.num_layers_at_end_in_bf16 == 4
+
+
+@pytest.mark.parametrize(
+    "recipe_name",
+    ["llama3_70b_pretrain_deterministic_config", "llama31_405b_pretrain_deterministic_config"],
+)
+def test_llama_deterministic_wrapper_applies_overrides(recipe_name: str, monkeypatch: pytest.MonkeyPatch):
+    mod = importlib.import_module("megatron.bridge.recipes.llama.llama3")
+    monkeypatch.setattr(mod, "AutoBridge", _FakeBridge)
+
+    recipe_func = getattr(_llama_module, recipe_name)
+    cfg = recipe_func()
+
+    _assert_basic_config(cfg)
+    assert cfg.model.deterministic_mode is True
+    assert cfg.model.cross_entropy_loss_fusion is False
+    assert cfg.comm_overlap.tp_comm_overlap is False

--- a/tests/unit_tests/scripts/performance/test_perf_plugins.py
+++ b/tests/unit_tests/scripts/performance/test_perf_plugins.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for scripts/performance/perf_plugins.py PerfEnvPlugin determinism wiring."""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+_PERF_SCRIPTS_DIR = Path(__file__).resolve().parents[4] / "scripts" / "performance"
+if str(_PERF_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_PERF_SCRIPTS_DIR))
+
+try:
+    import nemo_run  # noqa: F401
+
+    HAS_NEMO_RUN = True
+except ImportError:
+    HAS_NEMO_RUN = False
+
+pytestmark = pytest.mark.skipif(not HAS_NEMO_RUN, reason="nemo_run not installed")
+
+if HAS_NEMO_RUN:
+    from perf_plugins import PerfEnvPlugin
+
+
+def test_set_determinism_env_vars_writes_three_keys():
+    plugin = PerfEnvPlugin(
+        deterministic=True,
+        model_family_name="llama",
+        model_recipe_name="llama3_70b",
+        gpu="h100",
+        compute_dtype="bf16",
+        train_task="pretrain",
+    )
+    executor = MagicMock()
+    executor.env_vars = {}
+
+    plugin._set_determinism_env_vars(executor)
+
+    assert executor.env_vars["NCCL_ALGO"] == "Ring"
+    assert executor.env_vars["NVTE_ALLOW_NONDETERMINISTIC_ALGO"] == "0"
+    assert executor.env_vars["CUBLAS_WORKSPACE_CONFIG"] == ":4096:8"

--- a/tests/unit_tests/training/test_config.py
+++ b/tests/unit_tests/training/test_config.py
@@ -432,27 +432,19 @@ class TestMockGPTDatasetConfig:
 
 
 class TestConfigContainerValidation:
-    def test_deterministic_mode_disallows_flash_and_ce_fusion(self, monkeypatch):
-        """Test that deterministic mode disallows flash attention and cross-entropy loss fusion."""
-        from megatron.core.transformer.enums import AttnBackend
-
+    def test_deterministic_mode_disallows_ce_fusion(self, monkeypatch):
+        """Test that deterministic mode disallows cross-entropy loss fusion."""
         gpt_model_cfg = create_test_gpt_config(
             deterministic_mode=True,
-            attention_backend=AttnBackend.flash,
             cross_entropy_loss_fusion=True,
         )
 
-        # Ensure NCCL_ALGO present but valid, so we fail earlier on flash/ce fusion
+        # Ensure NCCL_ALGO present but valid, so we fail on CE fusion
         monkeypatch.setenv("NCCL_ALGO", "Tree")
 
         container, og_ws, cfg_mod = create_test_config_container(world_size_override=1, model_config=gpt_model_cfg)
 
         try:
-            with pytest.raises(AssertionError, match="Flash attention can not be used in deterministic mode"):
-                container.validate()
-
-            # Fix attention, still CE fusion should fail
-            container.model.attention_backend = AttnBackend.local
             with pytest.raises(AssertionError, match="Cross Entropy Fusion is currently not deterministic"):
                 container.validate()
         finally:


### PR DESCRIPTION
  Description:

  Adds a --deterministic flag to scripts/performance/setup_experiment.py for bit-exact reproducible runs.

  - Sets env vars: NCCL_ALGO=Ring, NVTE_ALLOW_NONDETERMINISTIC_ALGO=0, CUBLAS_WORKSPACE_CONFIG=:4096:8
  - Sets config: deterministic_mode=True, disables cross_entropy_loss_fusion and tp_comm_overlap
  - New apply_determinism_overrides() helper + pre-baked llama3_70b / llama31_405b deterministic recipe
  variants
  - Unit tests + README section
  - flash attention is [deterministic](https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/api/pytorch.html) now so remove invalid assertion.
 
Verified: 
* the determinism setup were verified across dense + MoE recipes (Llama 3, Qwen3 MoE) in bf16, FP8, and NVFP4
  on H100 and GB300.
* This PR was verified with two 64×H100 llama3_70b --deterministic runs (20 steps, mock data) — all 20 iterations bit-exact identical on lm loss and grad norm.

# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
