### PR TITLE
revert: no recompute default (#3470)

### DIFF
--- a/scripts/performance/utils/overrides.py
+++ b/scripts/performance/utils/overrides.py
@@ -141,12 +141,11 @@ def _set_recompute_overrides(
         recipe.model.cpu_offloading = True
         recipe.model.cpu_offloading_weights = False
         recipe.model.cpu_offloading_num_layers = cpu_offloading_num_layers
-
     if recompute_num_layers is not None:
         recipe.model.recompute_granularity = "full"
         recipe.model.recompute_method = "block"
         recipe.model.recompute_num_layers = recompute_num_layers
-    elif recompute_modules is not None:
+    if recompute_modules is not None:
         recipe.model.recompute_modules = recompute_modules
         recipe.model.recompute_granularity = "selective"
     # No else: if the caller has no recompute configuration to apply, leave


### PR DESCRIPTION
<details><summary>Claude summary</summary>

Single-commit PR: reverts #3470 ("no recompute default") to restore activation recomputation as the default behaviour.

</details>

# What does this PR do?

Reverts #3470, which disabled activation recomputation by default. This change caused regressions and is being reverted while the root cause is investigated.

# Changelog

- revert: re-enable activation recompute by default (reverts #3470)