### PR TITLE
remove stale tests/e2e/__init__.py 

### DIFF
--- a/tests/e2e/__init__.py
+++ b/tests/e2e/__init__.py
@@ -1,2 +1,0 @@
-# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
-"""End-to-end tests for Megatron-Bridge."""


### PR DESCRIPTION
Removes the orphaned `tests/e2e/__init__.py` left behind after the  `tests/e2e/` directory was deleted in https://github.com/NVIDIA-NeMo/Megatron-Bridge/pull/3340

The entire `tests/e2e` is removed (all files have been moved to `examples/models/megatron_mimo`)