### PR TITLE
ci: post merge comment with SHA after successful CI run

### DIFF
--- a/.github/workflows/_update_dependencies.yml
+++ b/.github/workflows/_update_dependencies.yml
@@ -209,6 +209,7 @@ jobs:
           git push origin ${{ env.SOURCE_BRANCH }}
 
       - name: Merge PR
+        id: merge-pr
         env:
           title: "chore(beep boop 🤖): Bump `uv.lock` (${{ env.TARGET_BRANCH}}, mcore-${{ inputs.mcore-branch }}) (${{ needs.pre-flight.outputs.date }})"
         run: |
@@ -226,4 +227,17 @@ jobs:
           git commit -m "${{ env.title }}"
           git pull --rebase origin ${{ env.TARGET_BRANCH }}
           git push origin ${{ env.TARGET_BRANCH }}
+          echo "merge-sha=$(git rev-parse HEAD)" | tee -a "$GITHUB_OUTPUT"
           git push origin --delete ${{ env.SOURCE_BRANCH }}
+
+      - name: Post merge comment
+        env:
+          GH_TOKEN: ${{ secrets.PAT }}
+        run: |
+          PR_NUMBER="${{ steps.create-pull-request.outputs.pull-request-number }}"
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No PR was created, skipping comment"
+            exit 0
+          fi
+          gh pr comment "$PR_NUMBER" --repo ${{ github.repository }} \
+            --body "🤖 Manually merged commit \`${{ steps.merge-pr.outputs.merge-sha }}\` after a successful CI run."


### PR DESCRIPTION
<details><summary>Claude summary</summary>

After a successful CI run the `_update_dependencies` workflow merges via plain `git push` (bypassing GitHub's merge button), which leaves no trace on the PR timeline. This change adds a post-merge comment with the exact commit SHA so there is an auditable record directly on the PR.

**Changes:**
- Added `id: merge-pr` to the "Merge PR" step and emitted `merge-sha` output via `tee -a $GITHUB_OUTPUT`.
- Added a new "Post merge comment" step that comments on the bump PR:

```
🤖 Manually merged commit `<sha>` after a successful CI run.
```

</details>
