### PR TITLE
fix(evaluate): skip non-dict golden value entries such as job_id

### DIFF
--- a/scripts/performance/utils/evaluate.py
+++ b/scripts/performance/utils/evaluate.py
@@ -633,6 +633,8 @@ def calc_convergence_and_performance(
         if key == max_alloc_metric:
             golden_max_alloc = value
             continue
+        if not isinstance(value, dict):
+            continue
         steps.append(key)
         golden_train_loss[key] = value[loss_metric]
         golden_iter_time[key] = value[timing_metric]


### PR DESCRIPTION
<details><summary>Claude summary</summary>

Single-commit fix: skip non-dict entries in the golden values comparison loop inside `calc_convergence_and_performance`. Entries like `job_id` are strings, not dicts, and previously caused a `TypeError` when accessed with `value[loss_metric]`.

</details>

# What does this PR do?

Adds a guard in the golden-value iteration to skip any entry that is not a `dict`. Non-dict entries such as `job_id` are metadata fields that should not be compared against training metrics.

# Changelog

- fix(evaluate): skip non-dict golden value entries such as `job_id`
