### PR TITLE
[peft] revert: Validate PEFT target modules (#1747)

### DIFF
--- a/src/megatron/bridge/peft/base.py
+++ b/src/megatron/bridge/peft/base.py
@@ -22,7 +22,6 @@ import torch
 import torch.nn as nn
 from megatron.core.transformer.module import MegatronModule
 
-from megatron.bridge.peft.module_matcher import ModuleMatcher
 from megatron.bridge.peft.recompute import maybe_enable_recompute_inputs_grad
 from megatron.bridge.peft.walk_utils import walk
 
@@ -96,19 +95,6 @@ class PEFT(ABC):
         Returns:
             The same type as the input model, transformed with PEFT applied.
         """
-        if isinstance(self, ModuleMatcher):
-            self._reset_target_match_state()
-
-            def _validate_only(
-                module: nn.Module, name: Optional[str] = None, prefix: Optional[str] = None
-            ) -> nn.Module:
-                self.match(module, name, prefix)
-                return module
-
-            self._walk_model(model, _validate_only)
-            self._validate_target_matches()
-            self._reset_target_match_state()
-
         self.freeze_model(model, training=training)
 
         self._walk_model(model, self.transform)

--- a/src/megatron/bridge/peft/canonical_lora.py
+++ b/src/megatron/bridge/peft/canonical_lora.py
@@ -259,7 +259,6 @@ class CanonicalLoRA(PEFT, ModuleMatcher):
         }
 
         """
-        super().__post_init__()
         for target in self.target_modules:
             assert not target.endswith("linear_qkv"), (
                 "Canonical LoRA does not support target 'linear_qkv'. Either use 'linear_qkv' with LoRA() or "
@@ -270,27 +269,18 @@ class CanonicalLoRA(PEFT, ModuleMatcher):
                 "use ['linear_fc1_up', 'linear_fc1_gate'] with Canonical LoRA"
             )
 
-            canonical_target = target
-            canonical_component = target
-
             if target.endswith("linear_q"):
-                canonical_target = target.replace("linear_q", "linear_qkv")
-                canonical_component = "linear_q"
+                self.canonical_mapping[target.replace("linear_q", "linear_qkv")].add("linear_q")
             elif target.endswith("linear_k"):
-                canonical_target = target.replace("linear_k", "linear_qkv")
-                canonical_component = "linear_k"
+                self.canonical_mapping[target.replace("linear_k", "linear_qkv")].add("linear_k")
             elif target.endswith("linear_v"):
-                canonical_target = target.replace("linear_v", "linear_qkv")
-                canonical_component = "linear_v"
+                self.canonical_mapping[target.replace("linear_v", "linear_qkv")].add("linear_v")
             elif target.endswith("linear_fc1_up"):
-                canonical_target = target.replace("linear_fc1_up", "linear_fc1")
-                canonical_component = "linear_fc1_up"
+                self.canonical_mapping[target.replace("linear_fc1_up", "linear_fc1")].add("linear_fc1_up")
             elif target.endswith("linear_fc1_gate"):
-                canonical_target = target.replace("linear_fc1_gate", "linear_fc1")
-                canonical_component = "linear_fc1_gate"
-
-            self.register_target_alias(target, canonical_target)
-            self.canonical_mapping[canonical_target].add(canonical_component)
+                self.canonical_mapping[target.replace("linear_fc1_gate", "linear_fc1")].add("linear_fc1_gate")
+            else:
+                self.canonical_mapping[target].add(target)
 
     def transform(self, m: nn.Module, name: Optional[str] = None, prefix: Optional[str] = None) -> nn.Module:
         """

--- a/src/megatron/bridge/peft/dora.py
+++ b/src/megatron/bridge/peft/dora.py
@@ -68,7 +68,6 @@ class DoRA(PEFT, ModuleMatcher):
 
     def __post_init__(self):
         """Initialize attributes from parent classes and validate configuration."""
-        super().__post_init__()
         assert self.dropout_position == "pre", (
             "DoRA only supports pre-adapter dropout at this time. Please set DoRA(..., dropout_position='pre')"
         )

--- a/src/megatron/bridge/peft/module_matcher.py
+++ b/src/megatron/bridge/peft/module_matcher.py
@@ -62,16 +62,6 @@ class ModuleMatcher:
     )
     exclude_modules: List[str] = field(default_factory=list)
     canonical_mapping: Dict[str, Set] = field(default_factory=lambda: defaultdict(set))
-    # pattern = canonical matcher string used internally (e.g., "linear_fc1")
-    _pattern_to_alias: Dict[str, Set[str]] = field(default_factory=lambda: defaultdict(set), init=False, repr=False)
-    # alias = user supplied target_modules entry that maps to a pattern
-    _alias_to_pattern: Dict[str, str] = field(default_factory=dict, init=False, repr=False)
-    _alias_matches: Dict[str, Set[str]] = field(default_factory=lambda: defaultdict(set), init=False, repr=False)
-
-    def __post_init__(self) -> None:
-        """Initialize target-module alias bookkeeping for validation."""
-        for target in self.target_modules or []:
-            self.register_target_alias(target, target)
 
     def match(
         self, m: nn.Module, name: Optional[str] = None, prefix: Optional[str] = None
@@ -118,13 +108,11 @@ class ModuleMatcher:
             assert len(self.exclude_modules) == 0, "exclude_modules should be empty when using canonical_mapping"
             for pattern in self.canonical_mapping:
                 if name == pattern or wildcard_match(pattern, full_name):
-                    self._record_match(pattern, full_name)
                     return (pattern, full_name)
         elif len(self.target_modules or []) > 0:
             assert len(self.exclude_modules) == 0, "exclude_modules should be empty when using target_modules"
             for pattern in self.target_modules:
                 if name == pattern or wildcard_match(pattern, full_name):
-                    self._record_match(pattern, full_name)
                     return (pattern, full_name)
         else:
             linear_types = [ColumnParallelLinear, RowParallelLinear, nn.Linear]
@@ -141,40 +129,6 @@ class ModuleMatcher:
                 and not any(wildcard_match(pattern, full_name) for pattern in self.exclude_modules)
                 and isinstance(m, linear_types)
             ):
-                self._record_match(name, full_name)
                 return (name, full_name)
 
         return None
-
-    def register_target_alias(self, alias: str, pattern: str) -> None:
-        """Associate a user provided alias with the canonical pattern used for matching."""
-        if alias is None or pattern is None:
-            return
-
-        previous_pattern = self._alias_to_pattern.get(alias)
-        if previous_pattern:
-            self._pattern_to_alias[previous_pattern].discard(alias)
-
-        self._alias_to_pattern[alias] = pattern
-        self._pattern_to_alias[pattern].add(alias)
-        # Ensure alias has an entry in matches tracking so len(...) works without lookups later.
-        self._alias_matches.setdefault(alias, set())
-
-    def _record_match(self, pattern: str, full_name: Optional[str]) -> None:
-        """Track which aliases successfully matched modules during traversal."""
-        for alias in self._pattern_to_alias.get(pattern, []):
-            self._alias_matches.setdefault(alias, set()).add(full_name or alias)
-
-    def _reset_target_match_state(self) -> None:
-        """Reset per-call match tracking."""
-        for alias in self._alias_matches:
-            self._alias_matches[alias].clear()
-
-    def _validate_target_matches(self) -> None:
-        """Raise an error if any requested target aliases failed to match a module."""
-        if not self._alias_to_pattern:
-            return
-
-        unmatched = sorted(alias for alias, matches in self._alias_matches.items() if len(matches) == 0)
-        if unmatched:
-            raise ValueError("No modules matched the requested target_modules entries: " + ", ".join(unmatched))

--- a/tests/unit_tests/peft/test_canonical_lora.py
+++ b/tests/unit_tests/peft/test_canonical_lora.py
@@ -149,14 +149,6 @@ class NestedModel(nn.Module):
 class TestCanonicalLoRA:
     """Test suite for CanonicalLoRA PEFT implementation."""
 
-    def test_canonical_lora_raises_when_target_missing(self):
-        """Ensure CanonicalLoRA alerts when configured modules are not present in the model."""
-        model = SimpleModel()
-        lora = CanonicalLoRA(target_modules=["linear_q_typo"])
-
-        with pytest.raises(ValueError, match="linear_q_typo"):
-            lora(model, training=True)
-
     def test_canonical_lora_initialization(self):
         """Test CanonicalLoRA class initialization with default and custom parameters."""
         # Test default initialization
@@ -560,7 +552,7 @@ class TestCanonicalLoRA:
     def test_canonical_lora_training_vs_inference_mode(self):
         """Test CanonicalLoRA behavior in training vs inference mode."""
         model = SimpleModel()
-        lora = CanonicalLoRA(target_modules=["linear_proj", "linear_fc2"])
+        lora = CanonicalLoRA()
 
         # Test training mode
         training_model = lora(model, training=True)

--- a/tests/unit_tests/peft/test_lora.py
+++ b/tests/unit_tests/peft/test_lora.py
@@ -146,14 +146,6 @@ class TestLoRA:
         assert custom_lora.dropout_position == "post"
         assert custom_lora.lora_A_init_method == "uniform"
 
-    def test_lora_raises_when_target_missing(self):
-        """Ensure LoRA alerts when configured modules are not present in the model."""
-        model = SimpleModel()
-        lora = LoRA(target_modules=["linear_fc1_typo"])
-
-        with pytest.raises(ValueError, match="linear_fc1_typo"):
-            lora(model, training=True)
-
     def test_lora_transform_simple_model(self):
         """Test LoRA transformation on a simple model."""
         model = SimpleModel()


### PR DESCRIPTION
## Summary

Reverts #1747 ("feat: Validate PEFT target modules", merge commit `1396c27a67191fb4ddf5e9b97dbaebb12ee82378`).

The newly added validation in `module_matcher.py` / `canonical_lora.py` rejects target-module configurations that real finetune recipes rely on, breaking finetune tests on `main`. Reverting unblocks finetune; the validation can be re-introduced in a follow-up that accommodates the existing recipe target lists.

## Files reverted
- `src/megatron/bridge/peft/base.py`
- `src/megatron/bridge/peft/canonical_lora.py`
- `src/megatron/bridge/peft/dora.py`
- `src/megatron/bridge/peft/module_matcher.py`
- `tests/unit_tests/peft/test_canonical_lora.py`
- `tests/unit_tests/peft/test_lora.py`

## Test plan
- [ ] Re-run the finetune functional tests that failed on `main` after #1747 and confirm they pass with this revert.
- [ ] PEFT unit tests (`tests/unit_tests/peft/`) still pass against the pre-#1747 behavior.

cc @yaoyu-33