### PR TITLE
[training] chore: pass is_hybrid_cp=False to get_batch_on_this_cp_rank (mcore #4103)

### DIFF
--- a/src/megatron/bridge/models/qwen_vl/qwen3_vl_step.py
+++ b/src/megatron/bridge/models/qwen_vl/qwen3_vl_step.py
@@ -270,7 +270,7 @@ def forward_step(
     }
 
     original_tokens = tokens.clone()
-    forward_args = get_batch_on_this_cp_rank(forward_args, cp_group=this_pg_collection.cp)
+    forward_args = get_batch_on_this_cp_rank(forward_args, cp_group=this_pg_collection.cp, is_hybrid_cp=False)
     forward_args["packed_seq_params"] = None
     forward_args["input_ids"] = original_tokens
     # calculate position_ids in model forward

--- a/src/megatron/bridge/training/gpt_step.py
+++ b/src/megatron/bridge/training/gpt_step.py
@@ -183,7 +183,7 @@ def get_batch(
         batch = _partition_packed_batch_for_cp(batch, cp_size)
     else:
         # slice batch along sequence dimension for context parallelism
-        batch = get_batch_on_this_cp_rank(batch, cp_group=pg_collection.cp)
+        batch = get_batch_on_this_cp_rank(batch, cp_group=pg_collection.cp, is_hybrid_cp=False)
 
     return (
         batch["tokens"],

--- a/src/megatron/bridge/training/llava_step.py
+++ b/src/megatron/bridge/training/llava_step.py
@@ -126,7 +126,7 @@ def get_batch(
     images = batch.get("pixel_values")
 
     # slice batch along sequence dimension for context parallelism
-    batch = get_batch_on_this_cp_rank(batch, cp_group=pg_collection.cp)
+    batch = get_batch_on_this_cp_rank(batch, cp_group=pg_collection.cp, is_hybrid_cp=False)
     if images is not None:
         batch["images"] = images
 

--- a/src/megatron/bridge/utils/common_utils.py
+++ b/src/megatron/bridge/utils/common_utils.py
@@ -370,6 +370,7 @@ def slice_batch_for_context_parallel(
                 "attention_mask": attention_mask,
             },
             cp_group=cp_group,
+            is_hybrid_cp=False,
         )
 
         inputs_embeds = cp_batch.get("decoder_input")


### PR DESCRIPTION
## Status: DRAFT — gated on upstream PR

**Do not merge** until:
1. [NVIDIA/Megatron-LM#4103](https://github.com/NVIDIA/Megatron-LM/pull/4103) lands.
2. The `3rdparty/Megatron-LM` submodule is bumped to a commit containing #4103.

CI will fail in the meantime: the new `is_hybrid_cp` parameter does not exist on the currently pinned mcore.

## Summary

Adds `is_hybrid_cp=False` to all 4 call sites of `get_batch_on_this_cp_rank` to match the new required parameter that #4103 introduces. `False` preserves current behaviour — Bridge has no hybrid-CP code path.

## Affected call sites

- `src/megatron/bridge/training/gpt_step.py`
- `src/megatron/bridge/training/llava_step.py`
- `src/megatron/bridge/models/qwen_vl/qwen3_vl_step.py`
- `src/megatron/bridge/utils/common_utils.py`

## Follow-up (separate PR)

After #4103 lands, Bridge's `_partition_packed_batch_for_cp` (in `gpt_step.py`) and the inline THD branch in `common_utils.slice_batch_for_context_parallel` will be duplicated with mcore's new `get_sft_batch_on_this_cp_rank`. Worth a dedup PR.

## Test plan

- [ ] Wait for #4103 to merge upstream.
- [ ] Bump `3rdparty/Megatron-LM` to a commit containing #4103.
- [ ] Re-run CI.
- [ ] Smoke-test a CP>1 run on each step file (gpt, llava, qwen3_vl).

🤖 Generated with [Claude Code](https://claude.com/claude-code)