### PR TITLE
[perf] fix: guard total_tokens behind is_hybrid_model to restore pure-transformer perf

### DIFF
--- a/src/megatron/bridge/training/gpt_step.py
+++ b/src/megatron/bridge/training/gpt_step.py
@@ -253,8 +253,12 @@ def _forward_step_common(
             "max_seqlen": max_seqlen,
             "cu_seqlens_unpadded": cu_seqlens_unpadded,
             "cu_seqlens_unpadded_argmin": cu_seqlens_unpadded_argmin,
-            "total_tokens": tokens.size(1) if tokens is not None else labels.size(1),
         }
+        # total_tokens drives seq_idx computation in PackedSeqParams.__post_init__,
+        # which is only needed for Mamba/hybrid SSM layers. Skip it for pure
+        # transformer models to avoid per-step CUDA overhead.
+        if getattr(config, "is_hybrid_model", False):
+            packed_seq_params["total_tokens"] = tokens.size(1) if tokens is not None else labels.size(1)
         forward_args["packed_seq_params"] = get_packed_seq_params(packed_seq_params)
 
     with straggler_timer:

--- a/src/megatron/bridge/training/llava_step.py
+++ b/src/megatron/bridge/training/llava_step.py
@@ -198,8 +198,12 @@ def forward_step(
             "cu_seqlens": cu_seqlens,
             "cu_seqlens_argmin": cu_seqlens_argmin,
             "max_seqlen": max_seqlen,
-            "total_tokens": input_ids.size(1) if input_ids is not None else labels.size(1),
         }
+        # total_tokens drives seq_idx computation in PackedSeqParams.__post_init__,
+        # which is only needed for Mamba/hybrid SSM layers. Skip it for pure
+        # transformer models to avoid per-step CUDA overhead.
+        if getattr(config, "is_hybrid_model", False):
+            packed_seq_params["total_tokens"] = input_ids.size(1) if input_ids is not None else labels.size(1)
         forward_args["packed_seq_params"] = get_packed_seq_params(packed_seq_params)
 
     check_for_nan_in_loss = state.cfg.rerun_state_machine.check_for_nan_in_loss

--- a/src/megatron/bridge/training/vlm_step.py
+++ b/src/megatron/bridge/training/vlm_step.py
@@ -448,8 +448,12 @@ def forward_step(
             "cu_seqlens": cu_seqlens,
             "max_seqlen": max_seqlen,
             "cu_seqlens_argmin": cu_seqlens_argmin,
-            "total_tokens": tokens.size(1) if tokens is not None else labels.size(1),
         }
+        # total_tokens drives seq_idx computation in PackedSeqParams.__post_init__,
+        # which is only needed for Mamba/hybrid SSM layers. Skip it for pure
+        # transformer models to avoid per-step CUDA overhead.
+        if getattr(config, "is_hybrid_model", False):
+            packed_seq_params["total_tokens"] = tokens.size(1) if tokens is not None else labels.size(1)
         forward_args["packed_seq_params"] = get_packed_seq_params(packed_seq_params)
 
     if loss_mask is not None:


### PR DESCRIPTION
PR #3484 added \`total_tokens\` unconditionally to \`PackedSeqParams\` in \`gpt_step\`, \`llava_step\`, and \`vlm_step\`. This triggers
  \`PackedSeqParams.__post_init__\` (introduced by MCore PR #3373) on every forward step for all models — \`torch.cat\`, \`repeat_interleave\`,
  \`arange\` — for all models.

  \`seq_idx\` is only consumed by Mamba/SSM layers. For pure-transformer models this work is wasted, causing a **~10% throughput regression** on
  GB300 70B LoRA.

  ## Fix

  Gate \`total_tokens\` on \`TransformerConfig.is_hybrid_model\` in \`gpt_step\`, \`llava_step\`, and \`vlm_step\`. \`config\` is already available
  via \`get_model_config(model)\` in each function.

  - Pure-transformer: \`is_hybrid_model=False\` → \`total_tokens=None\` → \`__post_init__\` is a no-op
  - Mamba/hybrid: \`is_hybrid_model=True\` → \`total_tokens\` set as before → \`seq_idx\` built correctly

  ## Test plan

  - [ ] Verify GB300 70B LoRA throughput regression is resolved
  - [ ] Run hybrid/Mamba model to confirm \`seq_idx\` still generated correctly
  - [ ] CI: \`tests/unit_tests/training/utils/test_packed_seq_utils.py\`