### PR TITLE
fix(ci): run lint-check on docs-only PRs; skip Coverage on perf-scripts-only

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -222,14 +222,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [pre-flight]
     if: |
-      (
-        needs.pre-flight.outputs.is_deployment_workflow == 'false'
-          && needs.pre-flight.outputs.is_ci_workload == 'true'
-      ) || (
-        needs.pre-flight.outputs.is_deployment_workflow == 'false'
-          && needs.pre-flight.outputs.is_ci_workload == 'false'
-          && needs.pre-flight.outputs.docs_only == 'false'
-      ) || github.event_name == 'workflow_dispatch'
+      needs.pre-flight.outputs.is_deployment_workflow == 'false'
+      || github.event_name == 'workflow_dispatch'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -1081,11 +1075,12 @@ jobs:
 
   Coverage:
     runs-on: ubuntu-latest
-    needs: [Nemo_CICD_Test, pre-flight]
+    needs: [Nemo_CICD_Test, pre-flight, configure]
     if: |
       needs.Nemo_CICD_Test.result == 'success'
       && needs.pre-flight.outputs.docs_only == 'false'
       && needs.pre-flight.outputs.is_deployment_workflow == 'false'
+      && needs.configure.outputs.perf_scripts_only == 'false'
       && github.event.inputs.mcore_ref == ''
       && !cancelled()
     strategy:

--- a/scripts/performance/setup_experiment.py
+++ b/scripts/performance/setup_experiment.py
@@ -288,9 +288,11 @@ def main(
 
     # Disable PCT binding for certain models on specific hardware/precision combos
     if (
-        (model_family_name == "nemotronh" and model_recipe_name == "nemotron_3_super" and compute_dtype == "bf16" and gpu == "b300") or
-        (model_family_name == "deepseek" and model_recipe_name == "deepseek_v3" and gpu == "b300")
-    ):
+        model_family_name == "nemotronh"
+        and model_recipe_name == "nemotron_3_super"
+        and compute_dtype == "bf16"
+        and gpu == "b300"
+    ) or (model_family_name == "deepseek" and model_recipe_name == "deepseek_v3" and gpu == "b300"):
         enable_pct_binding = False
 
     if wandb_key is not None:


### PR DESCRIPTION
<details><summary>Claude summary</summary>

Two CI condition fixes in `cicd-main.yml`:

**1. `lint-check` now runs on `docs-only` PRs**

The previous condition excluded `docs_only == 'true'` when the run wasn't a CI workload, causing linting to be silently skipped on docs-only labeled PRs. The new condition simply requires `is_deployment_workflow == 'false'` (or `workflow_dispatch`), so linting always runs for non-deployment runs regardless of labels.

**2. `Coverage` now skips on `perf-scripts-only` changes**

`Coverage_Fake` already generates a fake codecov/patch status when `perf_scripts_only == 'true'`, but the real `Coverage` job had no such guard. Added `needs.configure.outputs.perf_scripts_only == 'false'` to the `Coverage` condition (and `configure` to its `needs`) to prevent the real coverage job from running in that case.

</details>
