### PR TITLE
fix(docker): remove NeMo checkout step and audio/tts deps

### DIFF
--- a/docker/Dockerfile.fw_final
+++ b/docker/Dockerfile.fw_final
@@ -35,13 +35,7 @@ ARG NEMO_EVAL_COMMIT
 ARG NEMO_RUN_COMMIT
 
 # Update FW repository commit
-RUN pushd /opt/NeMo && \
-        git pull && \
-        git fetch origin $NEMO_COMMIT && \
-        git checkout FETCH_HEAD && \
-        echo "Container built with NeMo commit hash: $NEMO_COMMIT" && \
-    popd && \
-    pushd /opt/Export-Deploy && \
+RUN    pushd /opt/Export-Deploy && \
         git pull && \
         git fetch origin $NEMO_EXPORT_DEPLOY_COMMIT && \
         git checkout FETCH_HEAD && \

--- a/docker/common/fw_pyproject.toml
+++ b/docker/common/fw_pyproject.toml
@@ -30,8 +30,6 @@ license = { text = "Apache 2.0" }
 dependencies = [
     "nemo-export-deploy",
     "nemo-evaluator",
-    "nemo-toolkit[audio]",
-    "nemo-toolkit[tts]",
     "nemo-run",
     "nvidia-lm-eval",
     "langchain~=1.0.0",
@@ -44,7 +42,6 @@ test = ["coverage>=7.8.1"]
 [tool.uv.sources]
 "nemo-export-deploy" = { path = "/opt/Export-Deploy", editable = true }
 "nemo-evaluator" = { path = "/opt/Evaluator/packages/nemo-evaluator", editable = true }
-"nemo-toolkit" = { path = "/opt/NeMo", editable = true }
 "nemo-run" = { path = "/opt/Run", editable = true }
 
 [tool.uv]
@@ -54,8 +51,6 @@ override-dependencies = [
     "megatron-core[dev,mlm]; sys_platform == 'never'", # Installed by MBridge
     "nemo-export-deploy @ /opt/Export-Deploy",
     "megatron-bridge; sys_platform == 'never'",        # Installed by MBridge
-    "nemo-toolkit[audio] @ /opt/NeMo[audio]",
-    "nemo-toolkit[tts] @ /opt/NeMo[tts]",
     "nemo-run @ /opt/Run",
     "transformer-engine; sys_platform == 'never'",     # Installed by MBridge
     # Pinning versions to solve conflicts


### PR DESCRIPTION
<details><summary>Claude summary</summary>

Cherry-picks two Docker cleanup fixes from `r0.4.0` to `main`:

- **#3308** `fix(docker): remove NeMo checkout step from fw_final Dockerfile` — removes a redundant NeMo checkout step that is no longer needed in the `fw_final` build stage.
- **#3309** `fix(docker): remove nemo-toolkit audio/tts deps from fw_pyproject.toml` — drops unused `audio` and `tts` optional dependency groups from the NeMo pyproject config, reducing unnecessary installs.

</details>
