### PR TITLE
fix(docker): suppress lightning from uv resolution in fw_pyproject

### DIFF
--- a/docker/common/fw_pyproject.toml
+++ b/docker/common/fw_pyproject.toml
@@ -84,6 +84,8 @@ override-dependencies = [
     "torch; sys_platform == 'never'",
     "torchvision; sys_platform == 'never'",
     "triton; sys_platform == 'never'",
+    "lightning; sys_platform == 'never'",           # Pre-installed in base container; depends on torch
+    "pytorch-lightning; sys_platform == 'never'",   # Pre-installed in base container; depends on torch
     "nvidia-cublas-cu12; sys_platform == 'never'",
     "nvidia-cuda-cupti-cu12; sys_platform == 'never'",
     "nvidia-cuda-nvrtc-cu12; sys_platform == 'never'",


### PR DESCRIPTION
<details><summary>Claude summary</summary>

`nemo-export-deploy` declares `lightning<2.5.0` as a dependency. The `lightning` package depends on `torch`, which is already excluded from uv's resolution via `sys_platform == 'never'` (pre-installed in the NGC PyTorch base container). Because torch is suppressed, uv sees no satisfiable version of `lightning`, making the `nemo-export-deploy` constraint unsolvable.

Fix: suppress `lightning` and `pytorch-lightning` with the same `sys_platform == 'never'` pattern. Both are pre-installed in the base container alongside torch, so suppression is safe.

</details>
