### PR TITLE
fix(docker): resolve lightning not found on PyPI by providing local stub

### DIFF
--- a/docker/Dockerfile.fw_final
+++ b/docker/Dockerfile.fw_final
@@ -57,6 +57,7 @@ RUN    pushd /opt/Export-Deploy && \
 # Sync environment
 COPY --chmod=644 docker/common/fw_pyproject.toml /opt/NeMo-FW/pyproject.toml
 COPY --chmod=644 docker/common/_version.py docker/common/print_sha.sh /opt/NeMo-FW/
+COPY --chmod=644 docker/common/stubs/ /opt/NeMo-FW/stubs/
 RUN \
     cd /opt/NeMo-FW && \
     uv sync --no-cache-dir --all-groups --inexact && \

--- a/docker/common/fw_pyproject.toml
+++ b/docker/common/fw_pyproject.toml
@@ -84,6 +84,8 @@ override-dependencies = [
     "torch; sys_platform == 'never'",
     "torchvision; sys_platform == 'never'",
     "triton; sys_platform == 'never'",
+    "lightning; sys_platform == 'never'",           # Pre-installed in base container; depends on torch
+    "pytorch-lightning; sys_platform == 'never'",   # Pre-installed in base container; depends on torch
     "nvidia-cublas-cu12; sys_platform == 'never'",
     "nvidia-cuda-cupti-cu12; sys_platform == 'never'",
     "nvidia-cuda-nvrtc-cu12; sys_platform == 'never'",

--- a/docker/common/fw_pyproject.toml
+++ b/docker/common/fw_pyproject.toml
@@ -43,6 +43,7 @@ test = ["coverage>=7.8.1"]
 "nemo-export-deploy" = { path = "/opt/Export-Deploy", editable = true }
 "nemo-evaluator" = { path = "/opt/Evaluator/packages/nemo-evaluator", editable = true }
 "nemo-run" = { path = "/opt/Run", editable = true }
+"lightning" = { path = "stubs/lightning" }
 
 [tool.uv]
 prerelease = "allow"

--- a/docker/common/stubs/lightning/pyproject.toml
+++ b/docker/common/stubs/lightning/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "lightning"
+version = "2.5.0.post0"
+description = "Stub: lightning is pre-installed in the base container and blocked on PyPI"


### PR DESCRIPTION
<details><summary>Claude summary</summary>

`lightning` was removed from PyPI. uv 0.8.22 still performs index lookups during lock-file resolution even for dependencies marked `sys_platform == 'never'`, so the `override-dependencies` entry alone wasn't enough — resolution failed with:

```
× No solution found when resolving dependencies:
╰─▶ Because there are no versions of lightning{sys_platform == 'never'} and
    nemo-export-deploy==0.6.0+99958f8 depends on lightning{sys_platform == 'never'},
    we can conclude that nemo-export-deploy==0.6.0+99958f8 cannot be used.
```

**Fix:** provide uv with a minimal local stub so it can resolve `lightning` without hitting PyPI. The stub is never installed — the existing `lightning; sys_platform == 'never'` override-dependency ensures its marker is always false.

Changes:
- `docker/common/stubs/lightning/pyproject.toml` — minimal stub (`lightning 2.5.0.post0`)
- `docker/common/fw_pyproject.toml` — `[tool.uv.sources]` entry points `lightning` to the stub
- `docker/Dockerfile.fw_final` — `COPY` the stubs dir into `/opt/NeMo-FW/stubs/` before `uv sync`

</details>
