### PR TITLE
add mistral common to deps and lower bound transformers to 5.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,8 @@ classifiers = [
     "Topic :: Utilities",
 ]
 dependencies = [
-    "transformers>=5.0.0,<=5.6.0",
+    "transformers>=5.5.0,<=5.6.0",
+    "mistral-common>=1.10.0",
     "peft>=0.18.1",
     "datasets>=2.20.0",
     "accelerate",

--- a/src/megatron/bridge/models/conversion/transformers_compat.py
+++ b/src/megatron/bridge/models/conversion/transformers_compat.py
@@ -191,3 +191,33 @@ def rope_scaling_factor_from_hf(config, default: float = 1.0) -> float:
 
     # Return default if no scaling factor found
     return default
+
+
+def full_attention_interval_from_hf(config, default: int = 4) -> int:
+    """Extract the full-attention interval from a Qwen3-Next-style HuggingFace config.
+
+    In transformers <5.5 the interval was stored directly as
+    ``config.full_attention_interval``. In transformers >=5.5 the field was
+    removed; the kwarg is consumed in ``__post_init__`` and converted into
+    ``config.layer_types`` (a list whose ``i``-th entry is ``"linear_attention"``
+    or ``"full_attention"`` according to ``(i + 1) % interval``). This helper
+    handles both layouts.
+
+    Args:
+        config: HuggingFace configuration object (e.g. ``Qwen3NextConfig``).
+        default: Value to return if neither layout is present.
+
+    Returns:
+        int: The interval at which standard attention layers appear.
+    """
+    interval = getattr(config, "full_attention_interval", None)
+    if interval is not None:
+        return interval
+
+    layer_types = getattr(config, "layer_types", None)
+    if layer_types:
+        for i, layer_type in enumerate(layer_types):
+            if layer_type == "full_attention":
+                return i + 1
+
+    return default

--- a/src/megatron/bridge/models/kimi_vl/modeling_kimi_k25_vl.py
+++ b/src/megatron/bridge/models/kimi_vl/modeling_kimi_k25_vl.py
@@ -136,6 +136,11 @@ class KimiK25VLModel(MegatronModule):
             if not hasattr(MoonViT3dEncoder, "use_deterministic_attn"):
                 MoonViT3dEncoder.use_deterministic_attn = False
 
+            # transformers >=5.5 strictly validates `attn_implementation` at
+            # __init__ and selects `flash_attention_2` by default when flash-attn
+            # is installed. MoonViT3dPretrainedModel doesn't declare flash-attn-2
+            # support, so force eager attention before construction.
+            self.vision_tower_config._attn_implementation = "eager"
             self.vision_tower = MoonViT3dPretrainedModel(self.vision_tower_config)
             self.mm_projector = PatchMergerMLP(self.projector_config)  # TODO: support different types of mm projector
             # Ensure HF visual tower params are marked for TP grad sync and future assignments are hooked.

--- a/src/megatron/bridge/models/qwen/qwen3_next_bridge.py
+++ b/src/megatron/bridge/models/qwen/qwen3_next_bridge.py
@@ -30,6 +30,7 @@ from megatron.bridge.models.conversion.param_mapping import (  # noqa: F401
     ReplicatedMapping,
     RMSNorm2ZeroCenteredRMSNormMapping,
 )
+from megatron.bridge.models.conversion.transformers_compat import full_attention_interval_from_hf
 
 
 @MegatronModelBridge.register_bridge(source=Qwen3NextForCausalLM, target=GPTModel, model_type="qwen3_next")
@@ -82,7 +83,7 @@ class Qwen3NextBridge(MegatronModelBridge):
         # Qwen3-Next: hybrid gated delta net + standard attention
         provider.transformer_layer_spec = get_transformer_block_with_experimental_attention_variant_spec
         provider.experimental_attention_variant = "gated_delta_net"
-        provider.linear_attention_freq = hf_config.full_attention_interval
+        provider.linear_attention_freq = full_attention_interval_from_hf(hf_config)
         provider.linear_conv_kernel_dim = hf_config.linear_conv_kernel_dim
         provider.linear_key_head_dim = hf_config.linear_key_head_dim
         provider.linear_value_head_dim = hf_config.linear_value_head_dim

--- a/src/megatron/bridge/models/qwen_vl/qwen35_vl_bridge.py
+++ b/src/megatron/bridge/models/qwen_vl/qwen35_vl_bridge.py
@@ -47,6 +47,7 @@ from megatron.bridge.models.conversion.param_mapping import (
     ReplicatedMapping,
     RMSNorm2ZeroCenteredRMSNormMapping,
 )
+from megatron.bridge.models.conversion.transformers_compat import full_attention_interval_from_hf
 from megatron.bridge.models.hf_pretrained.vlm import PreTrainedVLM
 from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.model import Qwen3VLModel
 from megatron.bridge.models.qwen_vl.qwen35_vl_provider import (
@@ -131,7 +132,7 @@ class Qwen35VLMoEBridge(MegatronModelBridge):
         provider.experimental_attention_variant = "gated_delta_net"
         # full_attention_interval defines how often standard attention appears:
         # e.g., 4 means every 4th layer is standard attention (3 GDN + 1 Attn)
-        provider.linear_attention_freq = getattr(text_config, "full_attention_interval", 4)
+        provider.linear_attention_freq = full_attention_interval_from_hf(text_config)
         provider.rotary_percent = getattr(text_config, "rope_parameters", {}).get("partial_rotary_factor", 0.25)
 
         # --- MoE specific parameters ---
@@ -488,7 +489,7 @@ class Qwen35VLBridge(MegatronModelBridge):
         provider.layernorm_zero_centered_gamma = True
         provider.attention_output_gate = True
         provider.experimental_attention_variant = "gated_delta_net"
-        provider.linear_attention_freq = getattr(text_config, "full_attention_interval", 4)
+        provider.linear_attention_freq = full_attention_interval_from_hf(text_config)
         provider.rotary_percent = getattr(text_config, "rope_parameters", {}).get("partial_rotary_factor", 0.25)
 
         # --- GDN (Gated DeltaNet) specific parameters ---

--- a/tests/functional_tests/test_groups/models/kimi_vl/test_kimi_k25_vl_conversion.py
+++ b/tests/functional_tests/test_groups/models/kimi_vl/test_kimi_k25_vl_conversion.py
@@ -80,6 +80,16 @@ class TestKimiK25VLConversion:
             if hasattr(cfg, "quantization_config"):
                 delattr(cfg, "quantization_config")
 
+        # transformers >=5.5 validates `attn_implementation` at __init__ and
+        # defaults to `flash_attention_2` when flash-attn is installed. The
+        # Kimi K2.5 vision tower (`MoonViT3dPretrainedModel`, custom remote
+        # code) does not declare flash-attention-2 support, so construction
+        # raises. Force eager attention on every sub-config that drives this
+        # check, including the vision tower.
+        for cfg in (config, text, getattr(config, "vision_config", None)):
+            if cfg is not None:
+                cfg._attn_implementation = "eager"
+
         # Patch MoonViT3dEncoder before model instantiation.
         # The HF custom code references self.use_deterministic_attn in __init__
         # before assigning it, causing an AttributeError.  Inject a class-level
@@ -117,7 +127,7 @@ class TestKimiK25VLConversion:
         except Exception:
             pass
 
-        model = AutoModelForCausalLM.from_config(config, trust_remote_code=True)
+        model = AutoModelForCausalLM.from_config(config, trust_remote_code=True, attn_implementation="eager")
         model = model.to(dtype=torch.bfloat16)
 
         for m in model.modules():

--- a/tests/functional_tests/test_groups/models/nemotron_vl/test_nemotron_vl_conversion.py
+++ b/tests/functional_tests/test_groups/models/nemotron_vl/test_nemotron_vl_conversion.py
@@ -105,6 +105,14 @@ class TestNemotronVLConversion:
             for k, v in vision_config_overrides.items():
                 setattr(config.vision_config, k, v)
 
+        # transformers >=5.5 validates `attn_implementation` at __init__ and
+        # defaults to flash-attention-2 when flash-attn is installed. The
+        # Nemotron VL custom model class does not declare flash-attn-2
+        # support, so force eager on every PretrainedConfig-shaped sub-config.
+        for cfg in (config, getattr(config, "vision_config", None), getattr(config, "text_config", None)):
+            if cfg is not None:
+                cfg._attn_implementation = "eager"
+
         # Create model with random weights and convert to bfloat16
         model_class_ref = config.auto_map["AutoModelForCausalLM"]
         model_class = get_class_from_dynamic_module(

--- a/tests/functional_tests/test_groups/models/nemotron_vl/test_nemotron_vl_conversion.py
+++ b/tests/functional_tests/test_groups/models/nemotron_vl/test_nemotron_vl_conversion.py
@@ -109,7 +109,14 @@ class TestNemotronVLConversion:
         # defaults to flash-attention-2 when flash-attn is installed. The
         # Nemotron VL custom model class does not declare flash-attn-2
         # support, so force eager on every PretrainedConfig-shaped sub-config.
-        for cfg in (config, getattr(config, "vision_config", None), getattr(config, "text_config", None)):
+        # Nemotron VL's custom modeling builds the language model from
+        # `config.llm_config`, so that sub-config must also be covered.
+        for cfg in (
+            config,
+            getattr(config, "vision_config", None),
+            getattr(config, "text_config", None),
+            getattr(config, "llm_config", None),
+        ):
             if cfg is not None:
                 cfg._attn_implementation = "eager"
 

--- a/tests/functional_tests/test_groups/models/qwen_vl/test_qwen35_vl_conversion.py
+++ b/tests/functional_tests/test_groups/models/qwen_vl/test_qwen35_vl_conversion.py
@@ -402,7 +402,14 @@ class TestQwen35VLMoEConversion:
         assert "text_config" in config_data
         text_cfg = config_data["text_config"]
         assert text_cfg["num_experts"] == 4
-        assert text_cfg["full_attention_interval"] == 4
+        # transformers <5.5 saved `full_attention_interval` directly; >=5.5 stores
+        # the equivalent pattern under `layer_types` instead. Accept either layout.
+        if "full_attention_interval" in text_cfg:
+            assert text_cfg["full_attention_interval"] == 4
+        else:
+            layer_types = text_cfg["layer_types"]
+            full_idx = layer_types.index("full_attention")
+            assert full_idx + 1 == 4
 
         _ = Qwen3_5MoeForConditionalGeneration.from_pretrained(
             qwen35_vl_moe_toy_model_path,

--- a/tests/unit_tests/models/gemma/test_gemma3_bridge.py
+++ b/tests/unit_tests/models/gemma/test_gemma3_bridge.py
@@ -23,6 +23,10 @@ from transformers import Gemma3Config, Gemma3ForCausalLM, GenerationConfig
 
 from megatron.bridge.models import AutoBridge
 from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge
+from megatron.bridge.models.conversion.transformers_compat import (
+    rope_local_base_freq_from_hf,
+    rope_theta_from_hf,
+)
 from megatron.bridge.models.gemma.gemma3_bridge import Gemma3ModelBridge
 from megatron.bridge.models.gemma.gemma3_provider import Gemma3ModelProvider
 from megatron.bridge.models.hf_pretrained.causal_lm import PreTrainedCausalLM
@@ -227,7 +231,10 @@ class TestMegatronGemma3Bridge:
         assert result.hidden_size == gemma3_1b_config.hidden_size
         assert result.num_attention_heads == gemma3_1b_config.num_attention_heads
         assert result.seq_length == gemma3_1b_config.max_position_embeddings
-        assert result.rotary_base == (gemma3_1b_config.rope_local_base_freq, gemma3_1b_config.rope_theta)
+        assert result.rotary_base == (
+            rope_local_base_freq_from_hf(gemma3_1b_config),
+            rope_theta_from_hf(gemma3_1b_config),
+        )
 
     @patch("megatron.bridge.models.gemma.gemma3_bridge.AutoConfig.from_pretrained")
     def test_provider_bridge_basic_4b(self, mock_autoconfig, mock_pretrained_gemma3_4b, gemma3_4b_config):
@@ -248,7 +255,10 @@ class TestMegatronGemma3Bridge:
         assert result.hidden_size == gemma3_4b_config.hidden_size
         assert result.num_attention_heads == gemma3_4b_config.num_attention_heads
         assert result.seq_length == gemma3_4b_config.max_position_embeddings
-        assert result.rotary_base == (gemma3_4b_config.rope_local_base_freq, gemma3_4b_config.rope_theta)
+        assert result.rotary_base == (
+            rope_local_base_freq_from_hf(gemma3_4b_config),
+            rope_theta_from_hf(gemma3_4b_config),
+        )
 
     @patch("megatron.bridge.models.gemma.gemma3_bridge.AutoConfig.from_pretrained")
     def test_provider_bridge_basic_27b(self, mock_autoconfig, mock_pretrained_gemma3_27b, gemma3_27b_config):
@@ -269,7 +279,10 @@ class TestMegatronGemma3Bridge:
         assert result.hidden_size == gemma3_27b_config.hidden_size
         assert result.num_attention_heads == gemma3_27b_config.num_attention_heads
         assert result.seq_length == gemma3_27b_config.max_position_embeddings
-        assert result.rotary_base == (gemma3_27b_config.rope_local_base_freq, gemma3_27b_config.rope_theta)
+        assert result.rotary_base == (
+            rope_local_base_freq_from_hf(gemma3_27b_config),
+            rope_theta_from_hf(gemma3_27b_config),
+        )
 
     @patch("megatron.bridge.models.gemma.gemma3_bridge.AutoConfig.from_pretrained")
     def test_provider_bridge_vocabulary(self, mock_autoconfig, mock_pretrained_gemma3_1b, gemma3_1b_config):
@@ -329,7 +342,10 @@ class TestMegatronGemma3Bridge:
         result = bridge.provider_bridge(mock_pretrained_gemma3_1b)
 
         # Check position embedding - Gemma3 has dual rotary bases
-        assert result.rotary_base == (gemma3_1b_config.rope_local_base_freq, gemma3_1b_config.rope_theta)
+        assert result.rotary_base == (
+            rope_local_base_freq_from_hf(gemma3_1b_config),
+            rope_theta_from_hf(gemma3_1b_config),
+        )
 
     @patch("megatron.bridge.models.gemma.gemma3_bridge.AutoConfig.from_pretrained")
     def test_provider_bridge_gemma3_specific_features(
@@ -450,8 +466,8 @@ class TestMegatronGemma3Bridge:
         provider = bridge.provider_bridge(mock_pretrained_gemma3_4b)
         hf_config = bridge.megatron_to_hf_config(provider)
 
-        assert hf_config["rope_theta"] == gemma3_4b_config.rope_theta
-        assert hf_config["rope_local_base_freq"] == gemma3_4b_config.rope_local_base_freq
+        assert hf_config["rope_theta"] == rope_theta_from_hf(gemma3_4b_config)
+        assert hf_config["rope_local_base_freq"] == rope_local_base_freq_from_hf(gemma3_4b_config)
         assert hf_config["sliding_window"] == gemma3_4b_config.sliding_window
         assert hf_config["query_pre_attn_scalar"] == gemma3_4b_config.query_pre_attn_scalar
         assert hf_config["rope_scaling"] == {"factor": 8.0, "type": "linear"}
@@ -467,8 +483,8 @@ class TestMegatronGemma3Bridge:
         provider = bridge.provider_bridge(mock_pretrained_gemma3_1b)
         hf_config = bridge.megatron_to_hf_config(provider)
 
-        assert hf_config["rope_theta"] == gemma3_1b_config.rope_theta
-        assert hf_config["rope_local_base_freq"] == gemma3_1b_config.rope_local_base_freq
+        assert hf_config["rope_theta"] == rope_theta_from_hf(gemma3_1b_config)
+        assert hf_config["rope_local_base_freq"] == rope_local_base_freq_from_hf(gemma3_1b_config)
         assert hf_config["query_pre_attn_scalar"] == gemma3_1b_config.query_pre_attn_scalar
         assert hf_config["sliding_window"] == gemma3_1b_config.sliding_window
         assert "rope_scaling" not in hf_config

--- a/uv.lock
+++ b/uv.lock
@@ -2246,6 +2246,7 @@ dependencies = [
     { name = "imageio" },
     { name = "imageio-ffmpeg" },
     { name = "megatron-core", extra = ["dev", "mlm"] },
+    { name = "mistral-common" },
     { name = "mlflow" },
     { name = "nvidia-resiliency-ext" },
     { name = "omegaconf" },
@@ -2333,6 +2334,7 @@ requires-dist = [
     { name = "imageio-ffmpeg" },
     { name = "mamba-ssm", marker = "extra == 'ssm'" },
     { name = "megatron-core", extras = ["dev", "mlm"], editable = "3rdparty/Megatron-LM" },
+    { name = "mistral-common", specifier = ">=1.10.0" },
     { name = "mlflow", specifier = ">=3.9.0" },
     { name = "nemo-run", marker = "extra == 'recipes'" },
     { name = "nvdlfw-inspect", marker = "extra == 'tensor-inspect'", specifier = "==0.2.1" },
@@ -2352,7 +2354,7 @@ requires-dist = [
     { name = "torch", specifier = ">=2.6.0" },
     { name = "tqdm", specifier = ">=4.67.1" },
     { name = "transformer-engine", extras = ["core-cu13", "pytorch"], marker = "extra == 'te'" },
-    { name = "transformers", specifier = ">=5.0.0,<=5.6.0" },
+    { name = "transformers", specifier = ">=5.5.0,<=5.6.0" },
     { name = "typing-extensions" },
     { name = "wandb", specifier = ">=0.25.0" },
 ]
@@ -2571,6 +2573,25 @@ av-decode = [
     { name = "filetype" },
     { name = "sortedcontainers" },
     { name = "soundfile" },
+]
+
+[[package]]
+name = "mistral-common"
+version = "1.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsonschema" },
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "pydantic" },
+    { name = "pydantic-extra-types", extra = ["pycountry"] },
+    { name = "requests" },
+    { name = "tiktoken" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/15/12076a58b9dde4ad486b6de4afd2dfe3e8226fd049ef44553892e62f2e92/mistral_common-1.11.1.tar.gz", hash = "sha256:b784e1f9141bbcb26ab1f61b724c709f08cd3543e81730cb7248721499491840", size = 6356869, upload-time = "2026-04-29T07:24:43.234Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/6d/ab384c8b772390426472b623b85135e9b5f159ab31a21d87a6d46819d386/mistral_common-1.11.1-py3-none-any.whl", hash = "sha256:797fded812139069d359fc08a1a66bf994555e10bb51b613941281b91ee07135", size = 6531421, upload-time = "2026-04-29T07:24:40.516Z" },
 ]
 
 [[package]]
@@ -3617,6 +3638,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pycountry"
+version = "26.2.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/1d/061b9e7a48b85cfd69f33c33d2ef784a531c359399ad764243399673c8f5/pycountry-26.2.16.tar.gz", hash = "sha256:5b6027d453fcd6060112b951dd010f01f168b51b4bf8a1f1fc8c95c8d94a0801", size = 7711342, upload-time = "2026-02-17T03:42:52.367Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/42/7703bd45b62fecd44cd7d3495423097e2f7d28bc2e99e7c1af68892ab157/pycountry-26.2.16-py3-none-any.whl", hash = "sha256:115c4baf7cceaa30f59a4694d79483c9167dbce7a9de4d3d571c5f3ea77c305a", size = 8044600, upload-time = "2026-02-17T03:42:49.777Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3668,6 +3698,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5c/4f/86a832a9d14df58e663bfdf4627dc00d3317c2bd583c4fb23390b0f04b8e/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:f00a0961b125f1a47af7bcc17f00782e12f4cd056f83416006b30111d941dfa3", size = 1932428, upload-time = "2026-04-20T14:40:45.781Z" },
     { url = "https://files.pythonhosted.org/packages/11/1a/fe857968954d93fb78e0d4b6df5c988c74c4aaa67181c60be7cfe327c0ca/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:57697d7c056aca4bbb680200f96563e841a6386ac1129370a0102592f4dddff5", size = 1997550, upload-time = "2026-04-20T14:44:02.425Z" },
     { url = "https://files.pythonhosted.org/packages/17/eb/9d89ad2d9b0ba8cd65393d434471621b98912abb10fbe1df08e480ba57b5/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd35aa21299def8db7ef4fe5c4ff862941a9a158ca7b63d61e66fe67d30416b4", size = 2137657, upload-time = "2026-04-20T14:42:45.149Z" },
+]
+
+[[package]]
+name = "pydantic-extra-types"
+version = "2.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/71/dba38ee2651f84f7842206adbd2233d8bbdb59fb85e9fa14232486a8c471/pydantic_extra_types-2.11.1.tar.gz", hash = "sha256:46792d2307383859e923d8fcefa82108b1a141f8a9c0198982b3832ab5ef1049", size = 172002, upload-time = "2026-03-16T08:08:03.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/c1/3226e6d7f5a4f736f38ac11a6fbb262d701889802595cdb0f53a885ac2e0/pydantic_extra_types-2.11.1-py3-none-any.whl", hash = "sha256:1722ea2bddae5628ace25f2aa685b69978ef533123e5638cfbddb999e0100ec1", size = 79526, upload-time = "2026-03-16T08:08:02.533Z" },
+]
+
+[package.optional-dependencies]
+pycountry = [
+    { name = "pycountry" },
 ]
 
 [[package]]
@@ -4889,7 +4937,7 @@ dependencies = [
 
 [[package]]
 name = "transformers"
-version = "5.3.0"
+version = "5.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
@@ -4902,9 +4950,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/1a/70e830d53ecc96ce69cfa8de38f163712d2b43ac52fbd743f39f56025c31/transformers-5.3.0.tar.gz", hash = "sha256:009555b364029da9e2946d41f1c5de9f15e6b1df46b189b7293f33a161b9c557", size = 8830831, upload-time = "2026-03-04T17:41:46.119Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/14/e3eb58bd4c9df45af154f9de59a6e66a2ece30dd64434c710e40e5a4b1f1/transformers-5.6.0.tar.gz", hash = "sha256:291951976b79a6f93ec06d6ab14489a99aecdbc8f05aaabab538ea1d508c9a97", size = 8311711, upload-time = "2026-04-22T15:42:03.393Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/88/ae8320064e32679a5429a2c9ebbc05c2bf32cefb6e076f9b07f6d685a9b4/transformers-5.3.0-py3-none-any.whl", hash = "sha256:50ac8c89c3c7033444fb3f9f53138096b997ebb70d4b5e50a2e810bf12d3d29a", size = 10661827, upload-time = "2026-03-04T17:41:42.722Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/80/ac700df26a83969d2cf8d09d3dd191bb9bbe8156fa4607e614438b1da8c8/transformers-5.6.0-py3-none-any.whl", hash = "sha256:def5aac47b28e2f1386fa64f2f458a5474ba7733ab74c1765e7c67a79d1f1cbd", size = 10364790, upload-time = "2026-04-22T15:41:58.723Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Bump transformers version to 5.5.0 in pyproject.toml and uv.lock.
- Add mistral-common dependency with version >=1.10.0 in both files.
- Update uv.lock to include mistral-common package details and its dependencies.

# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
