### PR TITLE
[examples] fix: use qwen3_vl_step in Qwen3.5 VL slurm scripts

### DIFF
--- a/examples/models/vlm/qwen35_vl/slurm_peft.sh
+++ b/examples/models/vlm/qwen35_vl/slurm_peft.sh
@@ -169,7 +169,7 @@ CLI_OVERRIDES="\
 #   --hf_path ${WORKSPACE}/models/Qwen/${HF_MODEL_NAME}
 CMD="cd /opt/Megatron-Bridge && uv run --no-sync python scripts/training/run_recipe.py \
     --recipe $RECIPE \
-    --step_func vlm_step \
+    --step_func qwen3_vl_step \
     --peft_scheme lora \
     $CLI_OVERRIDES"
 

--- a/examples/models/vlm/qwen35_vl/slurm_sft.sh
+++ b/examples/models/vlm/qwen35_vl/slurm_sft.sh
@@ -171,7 +171,7 @@ CLI_OVERRIDES="\
 #   --hf_path ${WORKSPACE}/models/Qwen/${HF_MODEL_NAME}
 CMD="cd /opt/Megatron-Bridge && uv run --no-sync python scripts/training/run_recipe.py \
     --recipe $RECIPE \
-    --step_func vlm_step \
+    --step_func qwen3_vl_step \
     $CLI_OVERRIDES"
 
 echo "Executing command..."

--- a/examples/models/vlm/qwen35_vl/slurm_sft_fsdp.sh
+++ b/examples/models/vlm/qwen35_vl/slurm_sft_fsdp.sh
@@ -114,7 +114,7 @@ CLI_OVERRIDES="\
 
 CMD="cd /opt/Megatron-Bridge && uv run --no-sync python scripts/training/run_recipe.py \
     --recipe $RECIPE \
-    --step_func vlm_step \
+    --step_func qwen3_vl_step \
     $CLI_OVERRIDES"
 
 echo "Executing command..."


### PR DESCRIPTION
## Summary

Switch the Qwen3.5 VL example slurm scripts to use the model-specific `qwen3_vl_step` forward step instead of the generic `vlm_step`, matching the convention already used by Qwen3 VL scripts (`examples/models/vlm/qwen3_vl/`).

Files changed:
- `examples/models/vlm/qwen35_vl/slurm_sft.sh`
- `examples/models/vlm/qwen35_vl/slurm_peft.sh`
- `examples/models/vlm/qwen35_vl/slurm_sft_fsdp.sh`

`qwen3_vl_step` (in `src/megatron/bridge/models/qwen_vl/qwen3_vl_step.py`) is the model-specific forward step for Qwen-VL that handles Qwen-VL packing and CP layout. The generic `vlm_step` was a leftover from earlier bring-up.

## Test plan

- [ ] Launch `slurm_sft.sh 4B` and confirm `--step_func qwen3_vl_step` is logged and training proceeds
- [ ] Launch `slurm_peft.sh 4B` and confirm LoRA training proceeds
- [ ] Launch `slurm_sft_fsdp.sh` and confirm FSDP training proceeds