### PR TITLE
[PEFT, ckpts] feat: modelopt for LoRA & deepseek arch

### DIFF
--- a/src/megatron/bridge/models/deepseek/common.py
+++ b/src/megatron/bridge/models/deepseek/common.py
@@ -45,6 +45,7 @@ def get_common_mapping_list(hf_config=None) -> list:
         # MoE
         "decoder.layers.*.mlp.router.weight": "model.layers.*.mlp.gate.weight",
         "decoder.layers.*.mlp.experts.linear_fc2.weight*": "model.layers.*.mlp.experts.*.down_proj.weight",
+        "decoder.layers.*.mlp.experts.local_experts.*.linear_fc2.weight": "model.layers.*.mlp.experts.*.down_proj.weight",
         "decoder.layers.*.mlp.shared_experts.linear_fc2.weight": "model.layers.*.mlp.shared_experts.down_proj.weight",
         # LM Head
         "decoder.final_layernorm.weight": "model.norm.weight",
@@ -77,6 +78,11 @@ def get_common_mapping_list(hf_config=None) -> list:
                 up="model.layers.*.mlp.experts.*.up_proj.weight",
             ),
             GatedMLPMapping(
+                megatron_param="decoder.layers.*.mlp.experts.local_experts.*.linear_fc1.weight",
+                gate="model.layers.*.mlp.experts.*.gate_proj.weight",
+                up="model.layers.*.mlp.experts.*.up_proj.weight",
+            ),
+            GatedMLPMapping(
                 megatron_param="decoder.layers.*.mlp.shared_experts.linear_fc1.weight",
                 gate="model.layers.*.mlp.shared_experts.gate_proj.weight",
                 up="model.layers.*.mlp.shared_experts.up_proj.weight",
@@ -94,9 +100,9 @@ def get_common_mapping_list(hf_config=None) -> list:
                 # Add layer-specific mappings for MTP transformer layers
                 for megatron_param, hf_param in param_mappings.items():
                     megatron_param_mtp = (
-                        megatron_param.replace(".*", ".*.mtp_model_layer")
+                        megatron_param.replace(".*", ".*.mtp_model_layer", 1)
                         .replace("decoder", "mtp")
-                        .replace(".*", f".{mtp_layer}")
+                        .replace(".*", f".{mtp_layer}", 1)
                     )
                     hf_param_mtp = hf_param.replace("layers.*", f"layers.{mtp_layer + num_transformer_layers}")
                     mapping_list.append(AutoMapping(megatron_param=megatron_param_mtp, hf_param=hf_param_mtp))
@@ -142,6 +148,11 @@ def get_common_mapping_list(hf_config=None) -> list:
                         ),
                         GatedMLPMapping(
                             megatron_param=f"mtp.layers.{mtp_layer}.mtp_model_layer.mlp.experts.linear_fc1.weight*",
+                            gate=f"model.layers.{mtp_layer + num_transformer_layers}.mlp.experts.*.gate_proj.weight",
+                            up=f"model.layers.{mtp_layer + num_transformer_layers}.mlp.experts.*.up_proj.weight",
+                        ),
+                        GatedMLPMapping(
+                            megatron_param=f"mtp.layers.{mtp_layer}.mtp_model_layer.mlp.experts.local_experts.*.linear_fc1.weight",
                             gate=f"model.layers.{mtp_layer + num_transformer_layers}.mlp.experts.*.gate_proj.weight",
                             up=f"model.layers.{mtp_layer + num_transformer_layers}.mlp.experts.*.up_proj.weight",
                         ),

--- a/src/megatron/bridge/peft/canonical_lora.py
+++ b/src/megatron/bridge/peft/canonical_lora.py
@@ -33,6 +33,7 @@ from megatron.bridge.peft.utils import (
     get_effective_lora_dim,
     is_expert_linear,
     is_grouped_expert_linear,
+    is_modelopt_linear,
 )
 
 
@@ -323,7 +324,7 @@ class CanonicalLoRA(PEFT, ModuleMatcher):
 
         if (ans := self.match(m, name, prefix)) is not None:
             (match, full_name) = ans
-            if isinstance(m, nn.Linear):
+            if isinstance(m, nn.Linear) and not is_modelopt_linear(m):
                 return LinearAdapter(
                     m, dim=self.dim, alpha=self.alpha, dropout=self.dropout, lora_A_init_method=self.lora_A_init_method
                 )

--- a/src/megatron/bridge/peft/lora.py
+++ b/src/megatron/bridge/peft/lora.py
@@ -42,6 +42,7 @@ from megatron.bridge.peft.utils import (
     get_effective_lora_dim,
     is_expert_linear,
     is_grouped_expert_linear,
+    is_modelopt_linear,
 )
 
 
@@ -126,7 +127,7 @@ class LoRA(PEFT, ModuleMatcher):
 
         if (ans := self.match(module, name, prefix)) is not None:
             _, full_name = ans
-            if isinstance(module, nn.Linear) or (module.__class__ == te.Linear):
+            if (isinstance(module, nn.Linear) or (module.__class__ == te.Linear)) and not is_modelopt_linear(module):
                 # Will use the `patch_linear_module` function if:
                 # - is FSDP v1
                 # - is DTensor (has _local_tensor attribute)

--- a/src/megatron/bridge/peft/utils.py
+++ b/src/megatron/bridge/peft/utils.py
@@ -73,6 +73,7 @@ HAVE_TE = all(
 )
 
 MixedFusedLayerNorm, HAVE_APEX = safe_import_from("apex.normalization.fused_layer_norm", "MixedFusedLayerNorm")
+ModelOptLinear, HAVE_MODELOPT_LINEAR = safe_import_from("megatron.core.post_training.modelopt.layers", "Linear")
 
 TECL = (TEColumnParallelLinear, TELayerNormColumnParallelLinear, TEColumnParallelGroupedLinear)
 TERL = (TERowParallelLinear, TERowParallelGroupedLinear)
@@ -80,8 +81,7 @@ TERL = (TERowParallelLinear, TERowParallelGroupedLinear)
 
 def is_modelopt_linear(m: nn.Module) -> bool:
     """Return whether a module is ModelOpt's local Megatron Linear."""
-    cls = type(m)
-    return cls.__name__ == "Linear" and cls.__module__ == "megatron.core.post_training.modelopt.layers"
+    return HAVE_MODELOPT_LINEAR and isinstance(m, ModelOptLinear)
 
 
 @dataclass(frozen=True)

--- a/src/megatron/bridge/peft/utils.py
+++ b/src/megatron/bridge/peft/utils.py
@@ -78,6 +78,12 @@ TECL = (TEColumnParallelLinear, TELayerNormColumnParallelLinear, TEColumnParalle
 TERL = (TERowParallelLinear, TERowParallelGroupedLinear)
 
 
+def is_modelopt_linear(m: nn.Module) -> bool:
+    """Return whether a module is ModelOpt's local Megatron Linear."""
+    cls = type(m)
+    return cls.__name__ == "Linear" and cls.__module__ == "megatron.core.post_training.modelopt.layers"
+
+
 @dataclass(frozen=True)
 class AdapterAttributes:
     """Container for base linear adapter attributes."""
@@ -125,6 +131,16 @@ def get_adapter_attributes_from_linear(m: nn.Module, is_expert: bool = False) ->
     disable_tensor_parallel_comm = getattr(m, "parallel_mode", "") is None or getattr(m, "explicit_expert_comm", False)
     if disable_tensor_parallel_comm:
         disable_sequence_parallel_comm = True
+
+    if is_modelopt_linear(m):
+        return AdapterAttributes(
+            input_is_parallel=False,
+            in_features=m.in_features,
+            out_features=m.out_features,
+            disable_tensor_parallel_comm=False,
+            disable_sequence_parallel_comm=True,
+            base_linear_is_parallel=False,
+        )
 
     if is_expert:
         tp_size = parallel_state.get_expert_tensor_parallel_world_size()

--- a/tests/unit_tests/peft/test_lora.py
+++ b/tests/unit_tests/peft/test_lora.py
@@ -30,7 +30,12 @@ from megatron.bridge.peft import utils as peft_utils
 from megatron.bridge.peft.canonical_lora import CanonicalLoRA
 from megatron.bridge.peft.lora import LoRA, LoRAMerge, VLMLoRA
 from megatron.bridge.peft.lora_layers import LinearAdapter, LoRALinear
-from megatron.bridge.peft.utils import AdapterAttributes, GroupedExpertLinearAdapter, get_adapter_attributes_from_linear, is_modelopt_linear
+from megatron.bridge.peft.utils import (
+    AdapterAttributes,
+    GroupedExpertLinearAdapter,
+    get_adapter_attributes_from_linear,
+    is_modelopt_linear,
+)
 
 
 class SimpleModel(nn.Module):
@@ -140,6 +145,8 @@ class GroupedExpertModel(nn.Module):
         grouped_linear = MockMegatronLinear(2048, 512)
         grouped_linear.num_gemms = 2
         layer.mlp.experts.linear_fc2 = grouped_linear
+
+
 G_MODEL_OPT_LINEAR_MODULE = "megatron.core.post_training.modelopt.layers"
 
 

--- a/tests/unit_tests/peft/test_lora.py
+++ b/tests/unit_tests/peft/test_lora.py
@@ -24,9 +24,12 @@ import torch.nn as nn
 from megatron.core.transformer.module import MegatronModule
 
 from megatron.bridge.models.gpt_provider import GPTModelProvider
+from megatron.bridge.peft import canonical_lora as canonical_lora_module
+from megatron.bridge.peft import lora as lora_module
+from megatron.bridge.peft.canonical_lora import CanonicalLoRA
 from megatron.bridge.peft.lora import LoRA, LoRAMerge, VLMLoRA
 from megatron.bridge.peft.lora_layers import LinearAdapter, LoRALinear
-from megatron.bridge.peft.utils import AdapterAttributes, GroupedExpertLinearAdapter
+from megatron.bridge.peft.utils import AdapterAttributes, GroupedExpertLinearAdapter, get_adapter_attributes_from_linear, is_modelopt_linear
 
 
 class SimpleModel(nn.Module):
@@ -136,6 +139,47 @@ class GroupedExpertModel(nn.Module):
         grouped_linear = MockMegatronLinear(2048, 512)
         grouped_linear.num_gemms = 2
         layer.mlp.experts.linear_fc2 = grouped_linear
+G_MODEL_OPT_LINEAR_MODULE = "megatron.core.post_training.modelopt.layers"
+
+
+class _ModelOptConfig:
+    sequence_parallel = False
+    use_transformer_engine_op_fuser = False
+    moe_router_topk = None
+
+
+def _init_modelopt_linear(self, in_features: int = 4, out_features: int = 3, bias: bool = False) -> None:
+    nn.Linear.__init__(self, in_features, out_features, bias=bias)
+    self.config = _ModelOptConfig()
+
+
+def _modelopt_forward(self, x: torch.Tensor) -> tuple[torch.Tensor, None]:
+    return nn.Linear.forward(self, x), None
+
+
+def _make_modelopt_linear_class(
+    class_name: str = "Linear", module_name: str = G_MODEL_OPT_LINEAR_MODULE
+) -> type[nn.Linear]:
+    return type(
+        class_name,
+        (nn.Linear,),
+        {
+            "__module__": module_name,
+            "__init__": _init_modelopt_linear,
+            "forward": _modelopt_forward,
+        },
+    )
+
+
+ModelOptLinear = _make_modelopt_linear_class()
+WrongModuleLinear = _make_modelopt_linear_class(module_name=__name__)
+WrongNameModelOptLinear = _make_modelopt_linear_class(class_name="ModelOptLinear")
+
+
+class _UnexpectedLinearAdapter(nn.Module):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__()
+        raise AssertionError("ModelOpt Linear should not use the nn.Linear adapter path")
 
 
 class TestLoRA:
@@ -457,6 +501,76 @@ class TestLoRA:
             assert isinstance(chunk.linear_proj, LinearAdapter)
             assert isinstance(chunk.linear_fc1, LinearAdapter)
             assert isinstance(chunk.linear_fc2, LinearAdapter)
+
+
+class TestModelOptLinear:
+    """Unit tests for ModelOpt Linear LoRA routing."""
+
+    def test_is_modelopt_linear_matches_only_modelopt_linear(self) -> None:
+        assert is_modelopt_linear(ModelOptLinear())
+
+        assert not is_modelopt_linear(WrongModuleLinear())
+        assert not is_modelopt_linear(WrongNameModelOptLinear())
+        assert not is_modelopt_linear(nn.Linear(4, 3))
+
+    def test_get_adapter_attributes_modelopt_linear(self) -> None:
+        linear = ModelOptLinear(in_features=5, out_features=7)
+        linear.config.sequence_parallel = True
+        linear.parallel_mode = None
+
+        attrs = get_adapter_attributes_from_linear(linear)
+
+        assert attrs == AdapterAttributes(
+            input_is_parallel=False,
+            in_features=5,
+            out_features=7,
+            disable_tensor_parallel_comm=False,
+            disable_sequence_parallel_comm=True,
+            base_linear_is_parallel=False,
+        )
+
+    def test_lora_wraps_modelopt_linear_with_parallel_adapter(self) -> None:
+        linear = ModelOptLinear(in_features=5, out_features=7)
+        parallel_adapter = nn.Identity()
+        lora = LoRA(target_modules=["linear_proj"], dim=2, alpha=4)
+
+        with (
+            patch.object(lora_module, "LinearAdapter", _UnexpectedLinearAdapter),
+            patch.object(lora_module, "ParallelLinearAdapter", return_value=parallel_adapter) as mock_adapter,
+        ):
+            transformed = lora.transform(linear, name="linear_proj")
+
+        assert isinstance(linear, nn.Linear)
+        assert is_modelopt_linear(linear)
+        assert isinstance(transformed, LoRALinear)
+        assert transformed.to_wrap is linear
+        assert transformed.adapter is parallel_adapter
+        mock_adapter.assert_called_once()
+        assert mock_adapter.call_args.args[:3] == (5, 7, 2)
+        assert mock_adapter.call_args.kwargs["base_linear_is_parallel"] is False
+
+    def test_canonical_lora_wraps_modelopt_linear_with_parallel_adapter(self) -> None:
+        linear = ModelOptLinear(in_features=5, out_features=7)
+        parallel_adapter = nn.Identity()
+        lora = CanonicalLoRA(target_modules=["linear_proj"], dim=2, alpha=4)
+
+        with (
+            patch.object(canonical_lora_module, "LinearAdapter", _UnexpectedLinearAdapter),
+            patch.object(
+                canonical_lora_module, "ParallelLinearAdapter", return_value=parallel_adapter
+            ) as mock_adapter,
+        ):
+            transformed = lora.transform(linear, name="linear_proj")
+
+        assert isinstance(linear, nn.Linear)
+        assert is_modelopt_linear(linear)
+        assert isinstance(transformed, LoRALinear)
+        assert transformed.to_wrap is linear
+        assert transformed.adapter is parallel_adapter
+        mock_adapter.assert_called_once()
+        assert mock_adapter.call_args.args[:2] == (5, 7)
+        assert mock_adapter.call_args.kwargs["dim"] == 2
+        assert mock_adapter.call_args.kwargs["base_linear_is_parallel"] is False
 
 
 class TestLoRANormalizeMoE:

--- a/tests/unit_tests/peft/test_lora.py
+++ b/tests/unit_tests/peft/test_lora.py
@@ -26,6 +26,7 @@ from megatron.core.transformer.module import MegatronModule
 from megatron.bridge.models.gpt_provider import GPTModelProvider
 from megatron.bridge.peft import canonical_lora as canonical_lora_module
 from megatron.bridge.peft import lora as lora_module
+from megatron.bridge.peft import utils as peft_utils
 from megatron.bridge.peft.canonical_lora import CanonicalLoRA
 from megatron.bridge.peft.lora import LoRA, LoRAMerge, VLMLoRA
 from megatron.bridge.peft.lora_layers import LinearAdapter, LoRALinear
@@ -506,12 +507,24 @@ class TestLoRA:
 class TestModelOptLinear:
     """Unit tests for ModelOpt Linear LoRA routing."""
 
+    @pytest.fixture(autouse=True)
+    def _patch_modelopt_linear_import(self):
+        with (
+            patch.object(peft_utils, "HAVE_MODELOPT_LINEAR", True),
+            patch.object(peft_utils, "ModelOptLinear", ModelOptLinear),
+        ):
+            yield
+
     def test_is_modelopt_linear_matches_only_modelopt_linear(self) -> None:
         assert is_modelopt_linear(ModelOptLinear())
 
         assert not is_modelopt_linear(WrongModuleLinear())
         assert not is_modelopt_linear(WrongNameModelOptLinear())
         assert not is_modelopt_linear(nn.Linear(4, 3))
+
+    def test_is_modelopt_linear_returns_false_when_modelopt_linear_unavailable(self) -> None:
+        with patch.object(peft_utils, "HAVE_MODELOPT_LINEAR", False):
+            assert not is_modelopt_linear(ModelOptLinear())
 
     def test_get_adapter_attributes_modelopt_linear(self) -> None:
         linear = ModelOptLinear(in_features=5, out_features=7)


### PR DESCRIPTION
# What does this PR do ?

As MoE with modelopt sets `moe_grouped_gemm` disabled, https://github.com/NVIDIA/Megatron-LM/blob/12f18dafbf9ea1a947f06c7aecde0208c0ada161/megatron/core/post_training/modelopt/gpt/model_specs.py#L146 additional mappings are needed here. Also, modelopt linear layers should be correctly recognized for lora.

# Changelog

- Add additional mappings support with moe_grouped_gemm disabled for Deepseek arch.
- Support wrapping modelopt linear layers for LoRA.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [X] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [X] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
