### PR TITLE
perf(llama): default B300/B200 pretrain recipes + auto-disable PCT fo…

### DIFF
--- a/scripts/performance/configs/llama/llama31_llm_pretrain.py
+++ b/scripts/performance/configs/llama/llama31_llm_pretrain.py
@@ -113,13 +113,13 @@ def llama31_405b_pretrain_config_gb200(
 
 
 def llama31_405b_pretrain_config_b300(
-    precision: str = "bf16", mock: bool = True, config_variant: str = "v1"
+    precision: str = "bf16", mock: bool = True, config_variant: str = "v2"
 ) -> ConfigContainer:
     """B300, baseline config."""
     base_cfg = get_workload_base_config(
         model_family_name="llama",
         model_recipe_name="llama31_405b",
-        gpu="b300",
+        gpu="gb300",
         compute_dtype=precision.upper(),
         task="pretrain",
         config_variant=config_variant,
@@ -143,13 +143,13 @@ def llama31_405b_pretrain_config_b300(
 
 
 def llama31_405b_pretrain_config_b200(
-    precision: str = "bf16", mock: bool = True, config_variant: str = "v1"
+    precision: str = "bf16", mock: bool = True, config_variant: str = "v2"
 ) -> ConfigContainer:
     """B200, baseline config."""
     base_cfg = get_workload_base_config(
         model_family_name="llama",
         model_recipe_name="llama31_405b",
-        gpu="b200",
+        gpu="gb200",
         compute_dtype=precision.upper(),
         task="pretrain",
         config_variant=config_variant,

--- a/scripts/performance/configs/llama/llama3_llm_pretrain.py
+++ b/scripts/performance/configs/llama/llama3_llm_pretrain.py
@@ -118,7 +118,7 @@ def llama3_70b_pretrain_config_gb200(
 
 
 def llama3_70b_pretrain_config_b300(
-    precision: str = "bf16", mock: bool = True, config_variant: str = "v1"
+    precision: str = "bf16", mock: bool = True, config_variant: str = "v2"
 ) -> ConfigContainer:
     """B300, baseline config."""
     base_cfg = get_workload_base_config(
@@ -153,7 +153,7 @@ def llama3_70b_pretrain_config_b300(
 
 
 def llama3_70b_pretrain_config_b200(
-    precision: str = "bf16", mock: bool = True, config_variant: str = "v1"
+    precision: str = "bf16", mock: bool = True, config_variant: str = "v2"
 ) -> ConfigContainer:
     """B200, baseline config."""
     base_cfg = get_workload_base_config(
@@ -326,7 +326,7 @@ def llama3_8b_pretrain_config_b300(
     base_cfg = get_workload_base_config(
         model_family_name="llama",
         model_recipe_name="llama3_8b",
-        gpu="b300",
+        gpu="gb300",
         compute_dtype=precision.upper(),
         task="pretrain",
         config_variant=config_variant,
@@ -351,7 +351,7 @@ def llama3_8b_pretrain_config_b200(
     base_cfg = get_workload_base_config(
         model_family_name="llama",
         model_recipe_name="llama3_8b",
-        gpu="b200",
+        gpu="gb200",
         compute_dtype=precision.upper(),
         task="pretrain",
         config_variant=config_variant,

--- a/scripts/performance/setup_experiment.py
+++ b/scripts/performance/setup_experiment.py
@@ -292,7 +292,11 @@ def main(
         and model_recipe_name == "nemotron_3_super"
         and compute_dtype == "bf16"
         and gpu == "b300"
-    ) or (model_family_name == "deepseek" and model_recipe_name == "deepseek_v3" and gpu == "b300"):
+    ) or (
+        model_family_name == "deepseek" and model_recipe_name == "deepseek_v3" and gpu == "b300"
+    ) or (
+        model_family_name == "llama" and task == "pretrain" and gpu == "b300"
+    ):
         enable_pct_binding = False
 
     if wandb_key is not None:


### PR DESCRIPTION
What
Three small changes to the llama performance recipes:
scripts/performance/setup_experiment.py — add llama × pretrain × b300 to the existing PCT auto-disable list (already covers nemotronh and deepseek on B300).
scripts/performance/configs/llama/llama3_llm_pretrain.py — point the b300 / b200 recipe builders for 8B at the gb300 / gb200 V1 presets, and bump the 70B b300 / b200 builders to default config_variant="v2".
scripts/performance/configs/llama/llama31_llm_pretrain.py — same idea for 405B: b300 / b200 builders now point at the gb300 / gb200 V2 presets and default config_variant="v2".
Why
Bakes the empirically-validated 26.04 deployment defaults for llama on B300/B200 silicon into the existing *_pretrain_config_b300 / _b200 builders, so a stock llmb-run submit … --gpu b300 … (or --gpu b200) picks up the recommended preset without callers needing to override --config_variant or --gpu. Other workloads / model families / sft / lora paths are untouched.
Diff size
3 files, +13 / −9 lines.
> Same PR is being submitted against both r0.4.0 and main (file paths and behavior are identical on both branches).