### PR TITLE
cp: [vulnops][data] fix: Replace allow_pickle=True with restricted unpickler in packed dataset loading (#3616 → r0.4.0)

### DIFF
--- a/src/megatron/bridge/data/datasets/packing_utils.py
+++ b/src/megatron/bridge/data/datasets/packing_utils.py
@@ -19,6 +19,8 @@ from typing import Dict, List, Tuple
 import numpy as np
 from tqdm import tqdm
 
+from megatron.bridge.utils.safe_pickle import safe_load_npy
+
 
 PACKING_ALGOS = ["first_fit_decreasing", "first_fit_shuffle"]
 
@@ -349,7 +351,8 @@ def calculate_avg_seqlen(
     Raises:
         ValueError: If no rows remain after applying drop_remainder, or if no sequences are found.
     """
-    data = np.load(dataset_file, allow_pickle=True)
+    with open(dataset_file, "rb") as f:
+        data = safe_load_npy(f.read())
 
     total_len_accum = 0
     seqlen_sq_accum = 0

--- a/src/megatron/bridge/data/datasets/sft.py
+++ b/src/megatron/bridge/data/datasets/sft.py
@@ -36,6 +36,7 @@ from megatron.bridge.data.datasets.utils import (
     _tokenize,
 )
 from megatron.bridge.training.tokenizers.tokenizer import MegatronTokenizer
+from megatron.bridge.utils.safe_pickle import safe_load_npy
 
 
 DEFAULT_NEMO_CACHE_HOME = Path.home() / ".cache" / "nemo"
@@ -59,6 +60,24 @@ PREFIX_STR = (
 
 __idx_version__ = "0.2"  # index file version
 __idx_suffix__ = "idx"  # index file suffix
+
+
+def _safe_load_packed_npy(file_path: str | Path) -> np.ndarray:
+    """Load a packed ``.npy`` dataset without enabling unrestricted pickle.
+
+    Reads the raw file bytes (with MSC support) and delegates to
+    :func:`~megatron.bridge.utils.safe_pickle.safe_load_npy` which uses a
+    restricted unpickler for object arrays.
+    """
+    if MultiStorageClientFeature.is_enabled():
+        msc = MultiStorageClientFeature.import_package()
+        with msc.open(str(file_path), "rb") as f:
+            data = f.read()
+    else:
+        with open(file_path, "rb") as f:
+            data = f.read()
+
+    return safe_load_npy(data)
 
 
 def get_dataset_root(name: str) -> Path:
@@ -829,11 +848,7 @@ class GPTSFTPackedDataset(GPTSFTDataset):
 
     def _load_dataset(self):
         try:
-            if MultiStorageClientFeature.is_enabled():
-                msc = MultiStorageClientFeature.import_package()
-                self.indexed_dataset = msc.numpy.load(self.file_path, allow_pickle=True)
-            else:
-                self.indexed_dataset = np.load(self.file_path, allow_pickle=True)
+            self.indexed_dataset = _safe_load_packed_npy(self.file_path)
         except Exception as e:
             logger.error(
                 f"Failed to load packed dataset. The dataset should be a `.npy` file. "

--- a/src/megatron/bridge/utils/safe_pickle.py
+++ b/src/megatron/bridge/utils/safe_pickle.py
@@ -17,30 +17,33 @@ import pickle
 from types import MappingProxyType
 
 
+_BUILTIN_SAFE_TYPES = frozenset(
+    {
+        "list",
+        "dict",
+        "tuple",
+        "set",
+        "frozenset",
+        "bytes",
+        "bytearray",
+        "str",
+        "int",
+        "float",
+        "bool",
+        "complex",
+        "slice",
+        "range",
+        "NoneType",
+    }
+)
+
+
 class _RestrictedUnpickler(pickle.Unpickler):
     """Unpickler that only allows safe built-in types to prevent arbitrary code execution."""
 
     _SAFE_MODULES = MappingProxyType(
         {
-            "builtins": frozenset(
-                {
-                    "list",
-                    "dict",
-                    "tuple",
-                    "set",
-                    "frozenset",
-                    "bytes",
-                    "bytearray",
-                    "str",
-                    "int",
-                    "float",
-                    "bool",
-                    "complex",
-                    "slice",
-                    "range",
-                    "NoneType",
-                }
-            ),
+            "builtins": _BUILTIN_SAFE_TYPES,
             "collections": frozenset({"OrderedDict"}),
         }
     )
@@ -53,6 +56,40 @@ class _RestrictedUnpickler(pickle.Unpickler):
         )
 
 
+class _NumpyRestrictedUnpickler(pickle.Unpickler):
+    """Unpickler that allows safe builtins and the narrow set of numpy types needed for object array reconstruction.
+
+    NumPy object arrays (dtype='O') are serialized via pickle inside ``.npy``
+    files.  The pickle stream references ``numpy.core.multiarray._reconstruct``,
+    ``numpy.ndarray``, and ``numpy.dtype`` to rebuild the array container, while
+    the *elements* (dicts, lists, ints, …) use only standard builtins.
+
+    This unpickler permits exactly those types and nothing else — in particular,
+    ``os``, ``subprocess``, ``builtins.eval``, etc. are blocked, preventing
+    arbitrary-code-execution attacks via crafted ``.npy`` files.
+    """
+
+    _SAFE_MODULES = MappingProxyType(
+        {
+            "builtins": _BUILTIN_SAFE_TYPES,
+            "collections": frozenset({"OrderedDict"}),
+            # numpy types required to reconstruct an ndarray from pickle
+            "numpy": frozenset({"ndarray", "dtype"}),
+            "numpy.core.multiarray": frozenset({"_reconstruct", "scalar"}),
+            # numpy ≥ 2.0 moved internals under ``numpy._core``
+            "numpy._core.multiarray": frozenset({"_reconstruct", "scalar"}),
+        }
+    )
+
+    def find_class(self, module: str, name: str) -> type:
+        if module in self._SAFE_MODULES and name in self._SAFE_MODULES[module]:
+            return super().find_class(module, name)
+        raise pickle.UnpicklingError(
+            f"Restricted unpickler refused to load '{module}.{name}'. "
+            "Only safe built-in and numpy array types are allowed."
+        )
+
+
 def safe_pickle_load(fp) -> object:
     """Deserialize from a file using a restricted unpickler that only allows safe types."""
     return _RestrictedUnpickler(fp).load()
@@ -61,3 +98,38 @@ def safe_pickle_load(fp) -> object:
 def safe_pickle_loads(data: bytes) -> object:
     """Deserialize pickle data using a restricted unpickler that only allows safe types."""
     return _RestrictedUnpickler(io.BytesIO(data)).load()
+
+
+def safe_load_npy(data: bytes):
+    """Load a ``.npy`` file from raw bytes without enabling unrestricted pickle.
+
+    For numeric arrays the fast ``allow_pickle=False`` path is used.  For object
+    arrays (packed datasets storing dicts of variable-length lists) the pickle
+    payload is deserialized through :class:`_NumpyRestrictedUnpickler`, which
+    blocks dangerous modules like ``os`` and ``subprocess``.
+
+    Args:
+        data: Raw bytes of a ``.npy`` file.
+
+    Returns:
+        numpy.ndarray loaded from the file.
+    """
+    import numpy as np
+    import numpy.lib.format as _fmt
+
+    buf = io.BytesIO(data)
+
+    # Fast path: non-object arrays don't need pickle at all.
+    try:
+        return np.load(buf, allow_pickle=False)
+    except ValueError:
+        pass
+
+    # Object array: read past the .npy header so the buffer is positioned
+    # at the pickle payload, then deserialize through the restricted unpickler.
+    buf.seek(0)
+    version = _fmt.read_magic(buf)
+    reader = _fmt.read_array_header_1_0 if version[0] == 1 else _fmt.read_array_header_2_0
+    reader(buf)  # advances past header
+
+    return np.asarray(_NumpyRestrictedUnpickler(buf).load(), dtype=object)

--- a/tests/unit_tests/data/datasets/test_chat_template.py
+++ b/tests/unit_tests/data/datasets/test_chat_template.py
@@ -1217,7 +1217,7 @@ class TestPackedDatasetWithChatTemplateEdgeCases:
         mock_tokenizer = MagicMock()
         mock_tokenizer.eos_id = 2
 
-        with patch("numpy.load") as mock_load:
+        with patch("megatron.bridge.data.datasets.sft._safe_load_packed_npy") as mock_load:
             mock_load.return_value = np.array([{"input_ids": [1, 2], "seq_start_id": [0], "loss_mask": [1, 1]}])
 
             # Even with chat=True, should create GPTSFTPackedDataset for .npy

--- a/tests/unit_tests/utils/test_safe_pickle.py
+++ b/tests/unit_tests/utils/test_safe_pickle.py
@@ -16,12 +16,15 @@
 """Tests for safe_pickle module."""
 
 import io
+import os
 import pickle
+import subprocess
 from collections import OrderedDict
 
+import numpy as np
 import pytest
 
-from megatron.bridge.utils.safe_pickle import safe_pickle_load, safe_pickle_loads
+from megatron.bridge.utils.safe_pickle import safe_load_npy, safe_pickle_load, safe_pickle_loads
 
 
 class TestSafePickleRoundTrip:
@@ -110,3 +113,122 @@ class TestAllowlistImmutability:
 
         with pytest.raises((TypeError, AttributeError)):
             _RestrictedUnpickler._SAFE_MODULES["builtins"].add("eval")
+
+
+# ---------------------------------------------------------------------------
+# safe_load_npy — restricted loading of .npy files
+# ---------------------------------------------------------------------------
+
+
+def _make_npy_bytes(obj) -> bytes:
+    """Save *obj* via ``np.save`` and return the raw .npy bytes."""
+    buf = io.BytesIO()
+    np.save(buf, obj)
+    return buf.getvalue()
+
+
+def _make_malicious_npy_bytes(payload) -> bytes:
+    """Build a .npy file whose object-array pickle payload contains *payload*.
+
+    Creates a valid .npy header for an object array, then replaces the pickle
+    payload with one that will attempt to instantiate *payload* on load.
+    """
+    buf = io.BytesIO()
+    np.save(buf, np.array([None], dtype=object))
+    buf.seek(0)
+
+    version = np.lib.format.read_magic(buf)
+    reader = np.lib.format.read_array_header_1_0 if version[0] == 1 else np.lib.format.read_array_header_2_0
+    reader(buf)
+    header_len = buf.tell()
+
+    buf.seek(0)
+    header = buf.read(header_len)
+    return header + pickle.dumps(payload)
+
+
+class TestSafeLoadNpyNumericArrays:
+    """Numeric arrays use the fast allow_pickle=False path and should round-trip unchanged."""
+
+    def test_int_array(self):
+        """A plain int64 array should load without invoking the restricted unpickler."""
+        arr = np.array([1, 2, 3], dtype=np.int64)
+        result = safe_load_npy(_make_npy_bytes(arr))
+        np.testing.assert_array_equal(result, arr)
+
+    def test_float_array(self):
+        """A multi-dimensional float32 array should preserve shape and values."""
+        arr = np.arange(12, dtype=np.float32).reshape(3, 4)
+        result = safe_load_npy(_make_npy_bytes(arr))
+        np.testing.assert_array_equal(result, arr)
+
+
+class TestSafeLoadNpyObjectArrays:
+    """Object arrays (packed SFT datasets) should load through the restricted unpickler."""
+
+    def test_packed_dataset_round_trip(self):
+        """The exact dict-of-lists shape produced by packed_sequence.py should survive a save/load cycle."""
+        output_data = [
+            {"input_ids": [1, 2, 3], "loss_mask": [True, False, True], "seq_start_id": [0, 3]},
+            {"input_ids": [4, 5, 6, 7], "loss_mask": [True, True, True, False], "seq_start_id": [0, 4]},
+        ]
+        result = safe_load_npy(_make_npy_bytes(output_data))
+        assert len(result) == 2
+        assert result[0]["input_ids"] == [1, 2, 3]
+        assert result[1]["loss_mask"] == [True, True, True, False]
+
+    def test_empty_packed_dataset(self):
+        """An empty list saved as an object array should load as a zero-length array."""
+        result = safe_load_npy(_make_npy_bytes([]))
+        assert len(result) == 0
+
+
+class TestSafeLoadNpyRejectsMalicious:
+    """Malicious .npy files that embed dangerous pickle payloads must be rejected."""
+
+    def test_rejects_os_system(self):
+        """A pickle referencing os.system should be blocked by the numpy restricted unpickler."""
+        data = _make_malicious_npy_bytes(os.system)
+        with pytest.raises(pickle.UnpicklingError, match="Restricted unpickler refused"):
+            safe_load_npy(data)
+
+    def test_rejects_subprocess_popen(self):
+        """A pickle referencing subprocess.Popen should be blocked."""
+        data = _make_malicious_npy_bytes(subprocess.Popen)
+        with pytest.raises(pickle.UnpicklingError, match="Restricted unpickler refused"):
+            safe_load_npy(data)
+
+    def test_rejects_eval(self):
+        """A pickle referencing builtins.eval should be blocked."""
+        data = _make_malicious_npy_bytes(eval)
+        with pytest.raises(pickle.UnpicklingError, match="Restricted unpickler refused"):
+            safe_load_npy(data)
+
+    def test_rejects_reduce_exploit(self):
+        """A classic __reduce__-based RCE payload (os.system via a crafted class) should be blocked."""
+
+        class Exploit:
+            def __reduce__(self):
+                return (os.system, ("echo pwned",))
+
+        data = _make_malicious_npy_bytes(Exploit())
+        with pytest.raises(pickle.UnpicklingError, match="Restricted unpickler refused"):
+            safe_load_npy(data)
+
+
+class TestNumpyAllowlistImmutability:
+    """The numpy restricted unpickler allowlist must be immutable to prevent runtime tampering."""
+
+    def test_cannot_mutate_modules(self):
+        """Adding a new module to the allowlist at runtime should raise TypeError."""
+        from megatron.bridge.utils.safe_pickle import _NumpyRestrictedUnpickler
+
+        with pytest.raises(TypeError):
+            _NumpyRestrictedUnpickler._SAFE_MODULES["os"] = frozenset({"system"})
+
+    def test_cannot_mutate_allowed_names(self):
+        """Adding a name to an existing module's frozenset should raise TypeError or AttributeError."""
+        from megatron.bridge.utils.safe_pickle import _NumpyRestrictedUnpickler
+
+        with pytest.raises((TypeError, AttributeError)):
+            _NumpyRestrictedUnpickler._SAFE_MODULES["builtins"].add("eval")


### PR DESCRIPTION
<details><summary>Claude summary</summary>

Cherry-pick of #3616 onto `r0.4.0`.

Replaces `allow_pickle=True` in packed `.npy` dataset loading with a restricted unpickler (`safe_load_npy`), closing the arbitrary code execution vector from untrusted pickle payloads.

Two call sites conflicted and were resolved manually:
- `packing_utils.py` — `calculate_avg_seqlen` still used bare `np.load(..., allow_pickle=True)`
- `sft.py` — `GPTSFTPackedDataset._load_dataset` still used the MSC-aware `allow_pickle=True` path

Both were replaced with the already-backported helpers (`safe_load_npy` / `_safe_load_packed_npy`).

</details>
