### PR TITLE
[vulnops] fix: Add SSRF protection to image-loading utilities

### DIFF
--- a/examples/conversion/compare_hf_and_megatron/compare.py
+++ b/examples/conversion/compare_hf_and_megatron/compare.py
@@ -111,17 +111,18 @@ try:
 except ImportError:
     QWEN_VL_UTILS_AVAILABLE = False
     process_vision_info = None
+import io
 import os
 
 # Import debugger module from same directory
 import sys
 
-import requests
 from PIL import Image
 
 from megatron.bridge import AutoBridge
 from megatron.bridge.models.hf_pretrained.utils import is_safe_repo
 from megatron.bridge.utils.common_utils import disable_mtp_for_inference, get_last_rank, print_rank_0
+from megatron.bridge.utils.safe_url import is_safe_public_http_url, safe_url_open
 
 
 # Cosine similarity threshold: require at least 98% similarity (2% tolerance)
@@ -338,11 +339,12 @@ def load_image(image_path: str) -> Image.Image:
         PIL Image object
     """
     if image_path.startswith(("http://", "https://")):
-        response = requests.get(image_path)
-        response.raise_for_status()
-        return Image.open(requests.get(image_path, stream=True).raw)
-    else:
-        return Image.open(image_path)
+        is_safe, reason = is_safe_public_http_url(image_path)
+        if not is_safe:
+            raise ValueError(f"Refusing to fetch image URL ({reason}): {image_path}")
+        with safe_url_open(image_path) as resp:
+            return Image.open(io.BytesIO(resp.read()))
+    return Image.open(image_path)
 
 
 def pad_input_ids_to_tp_multiple(input_ids, tp_size: int, pad_token_id: int = 0):

--- a/examples/conversion/hf_to_megatron_generate_nemotron_vlm.py
+++ b/examples/conversion/hf_to_megatron_generate_nemotron_vlm.py
@@ -34,9 +34,9 @@ Examples with Nemotron Nano V2 VL:
 """
 
 import argparse
+import io
 from typing import Optional
 
-import requests
 import torch
 import torch.distributed as dist
 from megatron.core import parallel_state
@@ -48,6 +48,7 @@ from transformers import AutoProcessor, AutoTokenizer
 from megatron.bridge import AutoBridge
 from megatron.bridge.models.nemotron_vl.nemotron_vl_utils import adjust_image_tokens
 from megatron.bridge.utils.common_utils import get_last_rank, print_rank_0
+from megatron.bridge.utils.safe_url import is_safe_public_http_url, safe_url_open
 
 
 class SingleBatchIterator:
@@ -130,11 +131,12 @@ def load_image(image_path: str) -> Image.Image:
         PIL Image object
     """
     if image_path.startswith(("http://", "https://")):
-        response = requests.get(image_path)
-        response.raise_for_status()
-        return Image.open(requests.get(image_path, stream=True).raw)
-    else:
-        return Image.open(image_path)
+        is_safe, reason = is_safe_public_http_url(image_path)
+        if not is_safe:
+            raise ValueError(f"Refusing to fetch image URL ({reason}): {image_path}")
+        with safe_url_open(image_path) as resp:
+            return Image.open(io.BytesIO(resp.read()))
+    return Image.open(image_path)
 
 
 def process_image_inputs(processor, image_path: Optional[str], prompt: str, system_prompt: Optional[str] = None):

--- a/examples/conversion/vlm_generate_utils.py
+++ b/examples/conversion/vlm_generate_utils.py
@@ -14,11 +14,17 @@
 
 """Shared utilities for VLM generation scripts."""
 
+import io
+import logging
 from typing import Optional
 
-import requests
 import torch
 from PIL import Image
+
+from megatron.bridge.utils.safe_url import is_safe_public_http_url, safe_url_open
+
+
+logger = logging.getLogger(__name__)
 
 
 try:
@@ -109,7 +115,11 @@ def pad_input_ids_to_tp_multiple(input_ids, tp_size: int, pad_token_id: int = 0)
 def load_image(image_path: str) -> Image.Image:
     """Load an image from URL or file path."""
     if image_path.startswith(("http://", "https://")):
-        return Image.open(requests.get(image_path, stream=True).raw)
+        is_safe, reason = is_safe_public_http_url(image_path)
+        if not is_safe:
+            raise ValueError(f"Refusing to fetch image URL ({reason}): {image_path}")
+        with safe_url_open(image_path) as resp:
+            return Image.open(io.BytesIO(resp.read()))
     return Image.open(image_path)
 
 

--- a/src/megatron/bridge/models/nemotron_vl/nemotron_vl_utils.py
+++ b/src/megatron/bridge/models/nemotron_vl/nemotron_vl_utils.py
@@ -14,94 +14,28 @@
 
 import base64
 import io
-import ipaddress
 import logging
 import mimetypes
 import os
-import socket
 from typing import Dict, List
-from urllib.parse import urlparse
 
 import torch
 from PIL import Image
 from transformers.video_utils import VideoMetadata
 
+from megatron.bridge.utils.safe_url import (
+    ALLOW_PRIVATE_URL_FETCH_ENV,
+    is_safe_public_http_url,
+    safe_url_open,
+)
+
 
 logger = logging.getLogger(__name__)
 
-# Opt-out env var for the SSRF guard in ``_is_safe_public_http_url``. Set to
-# ``"1"`` when training on a trusted network where dataset URLs may legitimately
-# point at internal hosts. Defaults off — the guard blocks loopback / private /
-# link-local destinations (including cloud metadata at 169.254.169.254).
-_ALLOW_PRIVATE_URL_FETCH_ENV = "MEGATRON_BRIDGE_ALLOW_PRIVATE_URL_FETCH"
-
-
-def _is_safe_public_http_url(url: str) -> tuple[bool, str]:
-    """Check that ``url`` is a public http(s) URL safe to fetch.
-
-    Rejects non-http schemes, missing hostnames, and any hostname that
-    resolves to a loopback, private (RFC 1918), link-local, multicast,
-    reserved, or unspecified address. Used to mitigate SSRF when fetching
-    remote video URLs from untrusted dataset entries.
-
-    Set ``MEGATRON_BRIDGE_ALLOW_PRIVATE_URL_FETCH=1`` to bypass (trusted
-    networks only).
-
-    Returns:
-        Tuple of ``(is_safe, reason)``. ``reason`` is empty when safe.
-    """
-    if os.environ.get(_ALLOW_PRIVATE_URL_FETCH_ENV) == "1":
-        return True, ""
-    try:
-        parsed = urlparse(url)
-    except ValueError as exc:
-        return False, f"invalid URL: {exc}"
-    if parsed.scheme not in ("http", "https"):
-        return False, f"unsupported URL scheme: {parsed.scheme!r}"
-    host = parsed.hostname
-    if not host:
-        return False, "URL missing hostname"
-    try:
-        infos = socket.getaddrinfo(host, None)
-    except socket.gaierror as exc:
-        return False, f"DNS resolution failed: {exc}"
-    for info in infos:
-        ip_str = info[4][0]
-        try:
-            ip = ipaddress.ip_address(ip_str)
-        except ValueError:
-            return False, f"unparseable resolved address: {ip_str}"
-        if (
-            ip.is_loopback
-            or ip.is_private
-            or ip.is_link_local
-            or ip.is_multicast
-            or ip.is_reserved
-            or ip.is_unspecified
-        ):
-            return False, f"URL resolves to non-public address: {ip}"
-    return True, ""
-
-
-def _safe_url_open(url: str):
-    """Open ``url`` via a urllib opener that re-validates redirect targets.
-
-    Prevents SSRF via redirect: a public URL returning a 3xx to an internal
-    address would otherwise bypass :func:`_is_safe_public_http_url`. The
-    initial URL must already have been validated by the caller.
-    """
-    import urllib.error
-    import urllib.request
-
-    class _SafeRedirectHandler(urllib.request.HTTPRedirectHandler):
-        def redirect_request(self, req, fp, code, msg, headers, newurl):
-            is_safe, reason = _is_safe_public_http_url(newurl)
-            if not is_safe:
-                raise urllib.error.URLError(f"redirect blocked ({reason}): {newurl}")
-            return super().redirect_request(req, fp, code, msg, headers, newurl)
-
-    opener = urllib.request.build_opener(_SafeRedirectHandler())
-    return opener.open(url)  # noqa: S310  -- URL validated by caller + redirect handler
+# Backward-compatible private aliases so existing callers and tests keep working.
+_ALLOW_PRIVATE_URL_FETCH_ENV = ALLOW_PRIVATE_URL_FETCH_ENV
+_is_safe_public_http_url = is_safe_public_http_url
+_safe_url_open = safe_url_open
 
 
 def encode_pil_to_jpeg_data_url(pil_image):

--- a/src/megatron/bridge/utils/safe_url.py
+++ b/src/megatron/bridge/utils/safe_url.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""SSRF-safe URL fetching utilities.
+
+Provides helpers that validate URLs against non-public IP addresses before
+fetching, mitigating Server-Side Request Forgery (SSRF) when loading remote
+resources from untrusted inputs (e.g. dataset entries, user-supplied image
+URLs).
+"""
+
+import ipaddress
+import os
+import socket
+from urllib.parse import urlparse
+
+
+# Opt-out env var for the SSRF guard in ``is_safe_public_http_url``. Set to
+# ``"1"`` when training on a trusted network where dataset URLs may legitimately
+# point at internal hosts. Defaults off — the guard blocks loopback / private /
+# link-local destinations (including cloud metadata at 169.254.169.254).
+ALLOW_PRIVATE_URL_FETCH_ENV = "MEGATRON_BRIDGE_ALLOW_PRIVATE_URL_FETCH"
+
+
+def is_safe_public_http_url(url: str) -> tuple[bool, str]:
+    """Check that ``url`` is a public http(s) URL safe to fetch.
+
+    Rejects non-http schemes, missing hostnames, and any hostname that
+    resolves to a loopback, private (RFC 1918), link-local, multicast,
+    reserved, or unspecified address. Used to mitigate SSRF when fetching
+    remote URLs from untrusted inputs.
+
+    Set ``MEGATRON_BRIDGE_ALLOW_PRIVATE_URL_FETCH=1`` to bypass (trusted
+    networks only).
+
+    Returns:
+        Tuple of ``(is_safe, reason)``. ``reason`` is empty when safe.
+    """
+    if os.environ.get(ALLOW_PRIVATE_URL_FETCH_ENV) == "1":
+        return True, ""
+    try:
+        parsed = urlparse(url)
+    except ValueError as exc:
+        return False, f"invalid URL: {exc}"
+    if parsed.scheme not in ("http", "https"):
+        return False, f"unsupported URL scheme: {parsed.scheme!r}"
+    host = parsed.hostname
+    if not host:
+        return False, "URL missing hostname"
+    try:
+        infos = socket.getaddrinfo(host, None)
+    except socket.gaierror as exc:
+        return False, f"DNS resolution failed: {exc}"
+    for info in infos:
+        ip_str = info[4][0]
+        try:
+            ip = ipaddress.ip_address(ip_str)
+        except ValueError:
+            return False, f"unparseable resolved address: {ip_str}"
+        if not ip.is_global:
+            return False, f"URL resolves to non-public address: {ip}"
+    return True, ""
+
+
+def safe_url_open(url: str):
+    """Open ``url`` via a urllib opener that re-validates redirect targets.
+
+    Prevents SSRF via redirect: a public URL returning a 3xx to an internal
+    address would otherwise bypass :func:`is_safe_public_http_url`. The
+    initial URL must already have been validated by the caller.
+    """
+    import urllib.error
+    import urllib.request
+
+    class _SafeRedirectHandler(urllib.request.HTTPRedirectHandler):
+        def redirect_request(self, req, fp, code, msg, headers, newurl):
+            is_safe, reason = is_safe_public_http_url(newurl)
+            if not is_safe:
+                raise urllib.error.URLError(f"redirect blocked ({reason}): {newurl}")
+            return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+    opener = urllib.request.build_opener(_SafeRedirectHandler())
+    return opener.open(url)  # noqa: S310  -- URL validated by caller + redirect handler

--- a/tests/unit_tests/utils/test_safe_url.py
+++ b/tests/unit_tests/utils/test_safe_url.py
@@ -1,0 +1,161 @@
+"""SSRF-guard tests for megatron.bridge.utils.safe_url.
+
+Covers ``is_safe_public_http_url``, ``safe_url_open``, and integration
+with ``load_image`` in ``vlm_generate_utils``.
+"""
+
+import socket
+from unittest import mock
+
+import pytest
+
+from megatron.bridge.utils.safe_url import (
+    ALLOW_PRIVATE_URL_FETCH_ENV,
+    is_safe_public_http_url,
+    safe_url_open,
+)
+
+
+def _fake_getaddrinfo(ip: str):
+    """Return a ``getaddrinfo`` stub that resolves any host to ``ip``."""
+
+    def _stub(host, port, *args, **kwargs):
+        family = socket.AF_INET6 if ":" in ip else socket.AF_INET
+        return [(family, socket.SOCK_STREAM, 0, "", (ip, port or 0))]
+
+    return _stub
+
+
+class TestIsSafePublicHttpUrl:
+    def test_rejects_non_http_scheme(self):
+        ok, reason = is_safe_public_http_url("file:///etc/passwd")
+        assert not ok
+        assert "scheme" in reason
+
+    def test_rejects_ftp_scheme(self):
+        ok, reason = is_safe_public_http_url("ftp://example.com/file.bin")
+        assert not ok
+        assert "scheme" in reason
+
+    def test_rejects_missing_hostname(self):
+        ok, reason = is_safe_public_http_url("http:///image.png")
+        assert not ok
+        assert "hostname" in reason
+
+    @pytest.mark.parametrize(
+        "ip",
+        [
+            "127.0.0.1",  # loopback
+            "10.0.0.1",  # RFC 1918
+            "172.16.0.1",  # RFC 1918
+            "192.168.1.1",  # RFC 1918
+            "169.254.169.254",  # link-local (cloud metadata)
+            "100.64.0.1",  # RFC 6598 CGNAT / shared address space
+            "0.0.0.0",  # unspecified
+            "::1",  # IPv6 loopback
+            "fc00::1",  # IPv6 unique local
+            "fe80::1",  # IPv6 link-local
+        ],
+    )
+    def test_rejects_non_public_addresses(self, ip):
+        with mock.patch("socket.getaddrinfo", side_effect=_fake_getaddrinfo(ip)):
+            ok, reason = is_safe_public_http_url("http://attacker.example.com/image.png")
+        assert not ok
+        assert "non-public" in reason
+
+    def test_accepts_public_address(self):
+        with mock.patch("socket.getaddrinfo", side_effect=_fake_getaddrinfo("93.184.216.34")):
+            ok, reason = is_safe_public_http_url("https://example.com/image.png")
+        assert ok
+        assert reason == ""
+
+    def test_rejects_when_any_resolved_ip_is_private(self):
+        def stub(host, port, *args, **kwargs):
+            return [
+                (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0)),
+                (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("10.0.0.1", 0)),
+            ]
+
+        with mock.patch("socket.getaddrinfo", side_effect=stub):
+            ok, reason = is_safe_public_http_url("http://mixed.example.com/image.png")
+        assert not ok
+        assert "non-public" in reason
+
+    def test_rejects_when_dns_fails(self):
+        with mock.patch("socket.getaddrinfo", side_effect=socket.gaierror("no such host")):
+            ok, reason = is_safe_public_http_url("http://does-not-resolve.invalid/image.png")
+        assert not ok
+        assert "DNS" in reason
+
+    def test_opt_out_env_var_bypasses_check(self, monkeypatch):
+        monkeypatch.setenv(ALLOW_PRIVATE_URL_FETCH_ENV, "1")
+        ok, reason = is_safe_public_http_url("http://127.0.0.1/image.png")
+        assert ok
+        assert reason == ""
+
+    def test_opt_out_requires_exact_value(self, monkeypatch):
+        monkeypatch.setenv(ALLOW_PRIVATE_URL_FETCH_ENV, "true")  # not "1"
+        with mock.patch("socket.getaddrinfo", side_effect=_fake_getaddrinfo("127.0.0.1")):
+            ok, _ = is_safe_public_http_url("http://localhost/image.png")
+        assert not ok
+
+
+class TestSafeUrlOpen:
+    def test_redirect_to_private_ip_blocked(self):
+        with mock.patch("socket.getaddrinfo", side_effect=_fake_getaddrinfo("93.184.216.34")):
+            # Simulate a redirect to a private IP by mocking the opener
+            with mock.patch("urllib.request.OpenerDirector.open") as mock_open:
+                mock_open.return_value = mock.MagicMock()
+                safe_url_open("https://example.com/image.png")
+                mock_open.assert_called_once()
+
+        # Verify redirect handler rejects private IPs
+        with mock.patch("socket.getaddrinfo", side_effect=_fake_getaddrinfo("127.0.0.1")):
+            ok, reason = is_safe_public_http_url("http://evil-redirect.example.com/image.png")
+        assert not ok
+
+
+class TestLoadImageSsrf:
+    """Integration tests verifying load_image in vlm_generate_utils rejects unsafe URLs."""
+
+    def test_private_url_raises_value_error(self):
+        from examples.conversion.vlm_generate_utils import load_image
+
+        with mock.patch("socket.getaddrinfo", side_effect=_fake_getaddrinfo("127.0.0.1")):
+            with pytest.raises(ValueError, match="Refusing to fetch image URL"):
+                load_image("http://attacker.example.com/evil.png")
+
+    def test_metadata_endpoint_blocked(self):
+        from examples.conversion.vlm_generate_utils import load_image
+
+        with mock.patch("socket.getaddrinfo", side_effect=_fake_getaddrinfo("169.254.169.254")):
+            with pytest.raises(ValueError, match="non-public"):
+                load_image("http://169.254.169.254/latest/meta-data/image.png")
+
+    def test_safe_url_never_called_for_unsafe_url(self):
+        from examples.conversion import vlm_generate_utils
+
+        with mock.patch.object(vlm_generate_utils, "safe_url_open") as mocked_open:
+            with mock.patch("socket.getaddrinfo", side_effect=_fake_getaddrinfo("10.0.0.1")):
+                with pytest.raises(ValueError):
+                    vlm_generate_utils.load_image("http://internal.example.com/secret.png")
+        mocked_open.assert_not_called()
+
+    def test_local_file_path_not_validated(self, tmp_path):
+        from examples.conversion.vlm_generate_utils import load_image
+
+        # Create a minimal valid image file
+        from PIL import Image
+
+        img = Image.new("RGB", (1, 1))
+        img_path = tmp_path / "test.png"
+        img.save(img_path)
+
+        # Local file paths should not go through URL validation
+        with mock.patch.object(
+            __import__("megatron.bridge.utils.safe_url", fromlist=["is_safe_public_http_url"]),
+            "is_safe_public_http_url",
+        ) as mocked_check:
+            result = load_image(str(img_path))
+        mocked_check.assert_not_called()
+        assert isinstance(result, Image.Image)

--- a/tests/unit_tests/utils/test_safe_url.py
+++ b/tests/unit_tests/utils/test_safe_url.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """SSRF-guard tests for megatron.bridge.utils.safe_url.
 
 Covers ``is_safe_public_http_url``, ``safe_url_open``, and integration

--- a/tests/unit_tests/utils/test_safe_url.py
+++ b/tests/unit_tests/utils/test_safe_url.py
@@ -27,17 +27,22 @@ def _fake_getaddrinfo(ip: str):
 
 
 class TestIsSafePublicHttpUrl:
+    """Tests for the ``is_safe_public_http_url`` SSRF validation function."""
+
     def test_rejects_non_http_scheme(self):
+        """Reject file:// scheme which could read local filesystem."""
         ok, reason = is_safe_public_http_url("file:///etc/passwd")
         assert not ok
         assert "scheme" in reason
 
     def test_rejects_ftp_scheme(self):
+        """Reject ftp:// scheme — only http(s) is allowed."""
         ok, reason = is_safe_public_http_url("ftp://example.com/file.bin")
         assert not ok
         assert "scheme" in reason
 
     def test_rejects_missing_hostname(self):
+        """Reject URLs with empty hostname (e.g. http:///path)."""
         ok, reason = is_safe_public_http_url("http:///image.png")
         assert not ok
         assert "hostname" in reason
@@ -58,18 +63,22 @@ class TestIsSafePublicHttpUrl:
         ],
     )
     def test_rejects_non_public_addresses(self, ip):
+        """Reject URLs that resolve to any non-globally-routable IP address."""
         with mock.patch("socket.getaddrinfo", side_effect=_fake_getaddrinfo(ip)):
             ok, reason = is_safe_public_http_url("http://attacker.example.com/image.png")
         assert not ok
         assert "non-public" in reason
 
     def test_accepts_public_address(self):
+        """Allow URLs that resolve to a public, globally-routable IP address."""
         with mock.patch("socket.getaddrinfo", side_effect=_fake_getaddrinfo("93.184.216.34")):
             ok, reason = is_safe_public_http_url("https://example.com/image.png")
         assert ok
         assert reason == ""
 
     def test_rejects_when_any_resolved_ip_is_private(self):
+        """Reject if even one DNS record points to a private address (split-horizon DNS)."""
+
         def stub(host, port, *args, **kwargs):
             return [
                 (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0)),
@@ -82,18 +91,21 @@ class TestIsSafePublicHttpUrl:
         assert "non-public" in reason
 
     def test_rejects_when_dns_fails(self):
+        """Reject URLs whose hostname cannot be resolved."""
         with mock.patch("socket.getaddrinfo", side_effect=socket.gaierror("no such host")):
             ok, reason = is_safe_public_http_url("http://does-not-resolve.invalid/image.png")
         assert not ok
         assert "DNS" in reason
 
     def test_opt_out_env_var_bypasses_check(self, monkeypatch):
+        """Setting MEGATRON_BRIDGE_ALLOW_PRIVATE_URL_FETCH=1 disables the guard entirely."""
         monkeypatch.setenv(ALLOW_PRIVATE_URL_FETCH_ENV, "1")
         ok, reason = is_safe_public_http_url("http://127.0.0.1/image.png")
         assert ok
         assert reason == ""
 
     def test_opt_out_requires_exact_value(self, monkeypatch):
+        """The opt-out env var must be exactly '1' — 'true' or other truthy values are ignored."""
         monkeypatch.setenv(ALLOW_PRIVATE_URL_FETCH_ENV, "true")  # not "1"
         with mock.patch("socket.getaddrinfo", side_effect=_fake_getaddrinfo("127.0.0.1")):
             ok, _ = is_safe_public_http_url("http://localhost/image.png")
@@ -101,24 +113,70 @@ class TestIsSafePublicHttpUrl:
 
 
 class TestSafeUrlOpen:
-    def test_redirect_to_private_ip_blocked(self):
-        with mock.patch("socket.getaddrinfo", side_effect=_fake_getaddrinfo("93.184.216.34")):
-            # Simulate a redirect to a private IP by mocking the opener
-            with mock.patch("urllib.request.OpenerDirector.open") as mock_open:
-                mock_open.return_value = mock.MagicMock()
-                safe_url_open("https://example.com/image.png")
-                mock_open.assert_called_once()
+    """Tests for the ``safe_url_open`` redirect-validating URL opener."""
 
-        # Verify redirect handler rejects private IPs
+    def test_redirect_handler_rejects_private_redirect_target(self):
+        """The custom redirect handler must block redirects to non-public IPs.
+
+        Instantiates the redirect handler built by ``safe_url_open`` and
+        verifies that ``redirect_request`` raises ``URLError`` when the
+        redirect target resolves to a private address.
+        """
+        import urllib.error
+        import urllib.request
+
+        # Build the opener to get the redirect handler instance
+        with mock.patch("socket.getaddrinfo", side_effect=_fake_getaddrinfo("93.184.216.34")):
+            with mock.patch("urllib.request.OpenerDirector.open"):
+                safe_url_open("https://example.com/image.png")
+
+        # Extract the handler class from a fresh call and test it directly
+        handlers = []
+        original_build = urllib.request.build_opener
+
+        def capture_build(*handler_classes):
+            handlers.extend(handler_classes)
+            return original_build(*handler_classes)
+
+        with mock.patch("urllib.request.build_opener", side_effect=capture_build):
+            with mock.patch("urllib.request.OpenerDirector.open"):
+                safe_url_open("https://example.com/image.png")
+
+        redirect_handler = handlers[0]
+        req = urllib.request.Request("https://example.com/image.png")
+
         with mock.patch("socket.getaddrinfo", side_effect=_fake_getaddrinfo("127.0.0.1")):
-            ok, reason = is_safe_public_http_url("http://evil-redirect.example.com/image.png")
-        assert not ok
+            with pytest.raises(urllib.error.URLError, match="redirect blocked"):
+                redirect_handler.redirect_request(req, None, 302, "Found", {}, "http://evil.com/redir.png")
+
+    def test_redirect_handler_allows_public_redirect_target(self):
+        """The redirect handler must allow redirects to public IPs."""
+        import urllib.request
+
+        handlers = []
+        original_build = urllib.request.build_opener
+
+        def capture_build(*handler_classes):
+            handlers.extend(handler_classes)
+            return original_build(*handler_classes)
+
+        with mock.patch("urllib.request.build_opener", side_effect=capture_build):
+            with mock.patch("urllib.request.OpenerDirector.open"):
+                safe_url_open("https://example.com/image.png")
+
+        redirect_handler = handlers[0]
+        req = urllib.request.Request("https://example.com/image.png")
+
+        with mock.patch("socket.getaddrinfo", side_effect=_fake_getaddrinfo("93.184.216.34")):
+            result = redirect_handler.redirect_request(req, None, 302, "Found", {}, "https://cdn.example.com/img.png")
+        assert result is not None
 
 
 class TestLoadImageSsrf:
-    """Integration tests verifying load_image in vlm_generate_utils rejects unsafe URLs."""
+    """Integration tests verifying ``load_image`` in ``vlm_generate_utils`` rejects unsafe URLs."""
 
     def test_private_url_raises_value_error(self):
+        """A URL resolving to a loopback address must raise ValueError."""
         from examples.conversion.vlm_generate_utils import load_image
 
         with mock.patch("socket.getaddrinfo", side_effect=_fake_getaddrinfo("127.0.0.1")):
@@ -126,6 +184,7 @@ class TestLoadImageSsrf:
                 load_image("http://attacker.example.com/evil.png")
 
     def test_metadata_endpoint_blocked(self):
+        """Cloud metadata endpoint (169.254.169.254) must be blocked."""
         from examples.conversion.vlm_generate_utils import load_image
 
         with mock.patch("socket.getaddrinfo", side_effect=_fake_getaddrinfo("169.254.169.254")):
@@ -133,6 +192,7 @@ class TestLoadImageSsrf:
                 load_image("http://169.254.169.254/latest/meta-data/image.png")
 
     def test_safe_url_never_called_for_unsafe_url(self):
+        """When URL validation fails, the fetch function must never be invoked."""
         from examples.conversion import vlm_generate_utils
 
         with mock.patch.object(vlm_generate_utils, "safe_url_open") as mocked_open:
@@ -142,20 +202,16 @@ class TestLoadImageSsrf:
         mocked_open.assert_not_called()
 
     def test_local_file_path_not_validated(self, tmp_path):
-        from examples.conversion.vlm_generate_utils import load_image
-
-        # Create a minimal valid image file
+        """Local file paths must be opened directly without SSRF validation."""
+        from examples.conversion import vlm_generate_utils
         from PIL import Image
 
         img = Image.new("RGB", (1, 1))
         img_path = tmp_path / "test.png"
         img.save(img_path)
 
-        # Local file paths should not go through URL validation
-        with mock.patch.object(
-            __import__("megatron.bridge.utils.safe_url", fromlist=["is_safe_public_http_url"]),
-            "is_safe_public_http_url",
-        ) as mocked_check:
-            result = load_image(str(img_path))
+        # Patch on the module where the name is bound, not the source module
+        with mock.patch.object(vlm_generate_utils, "is_safe_public_http_url") as mocked_check:
+            result = vlm_generate_utils.load_image(str(img_path))
         mocked_check.assert_not_called()
         assert isinstance(result, Image.Image)


### PR DESCRIPTION
## Summary
- Extracts SSRF-safe URL helpers (`is_safe_public_http_url`, `safe_url_open`) from `nemotron_vl_utils.py` into a shared module at `megatron.bridge.utils.safe_url`
- Applies SSRF protection to `load_image()` in three example scripts that previously used `requests.get()` without URL validation
- Improves IP validation to use `not ip.is_global` which covers RFC 6598 CGNAT range (100.64.0.0/10) in addition to all previously blocked ranges
- Follows the same pattern established in #3482 for video URL SSRF protection

### Files changed
| File | Change |
|------|--------|
| `src/megatron/bridge/utils/safe_url.py` | **New** — shared SSRF-safe URL utilities |
| `src/megatron/bridge/models/nemotron_vl/nemotron_vl_utils.py` | Refactored to import from shared module; backward-compatible aliases preserved |
| `examples/conversion/vlm_generate_utils.py` | Secured `load_image()` with SSRF validation |
| `examples/conversion/hf_to_megatron_generate_nemotron_vlm.py` | Secured `load_image()`; also fixes double-fetch bug |
| `examples/conversion/compare_hf_and_megatron/compare.py` | Secured `load_image()` |
| `tests/unit_tests/utils/test_safe_url.py` | **New** — 14 test cases for SSRF guard and `load_image` integration |

## Test plan
- [ ] `uv run python -m pytest tests/unit_tests/utils/test_safe_url.py -v` — new SSRF guard tests
- [ ] `uv run python -m pytest tests/unit_tests/models/nemotron_vl/test_nemotron_vl_utils.py -v` — existing tests pass via backward-compatible aliases
- [ ] `uv run pre-commit run --all-files` — lint/format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)