### PR TITLE
[r0.4.0] cherry-pick: adapt to modelopt quant_cfg list format (#3456)

### DIFF
--- a/examples/quantization/quantize_utils.py
+++ b/examples/quantization/quantize_utils.py
@@ -64,29 +64,29 @@ def get_modelopt_torch_quantization_config(
     # Use deepcopy to avoid mutating the original config in QUANT_CFG_CHOICES
     mtq_config = copy.deepcopy(QUANT_CFG_CHOICES[export_quant_cfg])
 
-    fp8_config = {"enable": True, "num_bits": (4, 3), "axis": None}
-    fp4_config = {
+    fp8_cfg = {"num_bits": (4, 3), "axis": None}
+    fp4_cfg = {
         "num_bits": (2, 1),
         "block_sizes": {-1: 16, "type": "dynamic", "scale_bits": (4, 3)},
         "axis": None,
-        "enable": True,
     }
 
     if "fp8" == export_quant_cfg:
         # Enable Medusa heads and kv-cache quantization
-        mtq_config["quant_cfg"]["*medusa_heads**"] = fp8_config
+        mtq_config["quant_cfg"].append({"quantizer_name": "*medusa_heads**", "cfg": fp8_cfg})
     if "fp4" in export_quant_cfg:
         # Enable Medusa heads and kv-cache quantization
-        mtq_config["quant_cfg"]["*medusa_heads**"] = fp4_config
+        mtq_config["quant_cfg"].append({"quantizer_name": "*medusa_heads**", "cfg": fp4_cfg})
     if "awq" in export_quant_cfg:
-        weight_quantizer = mtq_config["quant_cfg"]["*weight_quantizer"]  # type: ignore
-        if isinstance(weight_quantizer, list):
-            weight_quantizer = weight_quantizer[0]
-        weight_quantizer["block_sizes"][-1] = 128
+        weight_entry = mtq.config.find_quant_cfg_entry_by_path(mtq_config["quant_cfg"], "*weight_quantizer")
+        weight_cfg = weight_entry["cfg"]
+        if isinstance(weight_cfg, list):
+            weight_cfg = weight_cfg[0]
+        weight_cfg["block_sizes"][-1] = 128
     if export_kv_cache_quant:
-        mtq_config["quant_cfg"]["*linear_qkv.output_quantizer"] = fp8_config
+        mtq_config["quant_cfg"].append({"quantizer_name": "*linear_qkv.output_quantizer", "cfg": fp8_cfg})
     if weight_only:
-        mtq_config["quant_cfg"]["*input_quantizer"] = {"enable": False}
+        mtq_config["quant_cfg"].append({"quantizer_name": "*input_quantizer", "enable": False})
 
     return mtq_config
 

--- a/examples/quantization/quantize_vlm.py
+++ b/examples/quantization/quantize_vlm.py
@@ -328,7 +328,7 @@ def main(
         mtq_config = get_modelopt_torch_quantization_config(export_quant_cfg, export_kv_cache_quant, weight_only)
 
         # Disable quantization for entire vision_model (all HuggingFace vision components)
-        mtq_config["quant_cfg"]["*vision_model*"] = {"enable": False}
+        mtq_config["quant_cfg"].append({"quantizer_name": "*vision_model*", "enable": False})
 
         # Define forward loop function for calibration
         def ptq_forward_loop_func(model):


### PR DESCRIPTION
## Summary

Backport of #3456 to `r0.4.0`.

NVIDIA Model Optimizer changed the `quant_cfg` field in quantization configs from a dict keyed by wildcard patterns to an ordered list of `QuantizerCfgEntry` items (`{"quantizer_name": ..., "cfg": ..., "enable": ...}`). The example quantization scripts on `r0.4.0` still assume the old dict layout, so once `r0.4.0` picks up the next mcore/ModelOpt bump (#3591), the L1/L2 quantization tests fail with:

```
File "examples/quantization/quantize_utils.py", line 77, in get_modelopt_torch_quantization_config
    mtq_config["quant_cfg"]["*medusa_heads**"] = fp8_config
TypeError: list indices must be integers or slices, not str
```

This cherry-picks the fix verbatim from `main`. Same two files, same diff (+12/-12).

## Test plan

- [ ] Confirm L1_Launch_post_training_quantization passes
- [ ] Confirm L2_Launch_models_{nemotronh,qwen,qwen_vl}_quantization pass
- [ ] Confirm L2_Launch_quantization_aware_training passes
- [ ] Once green, this unblocks #3591 (mcore/uv.lock bump for r0.4.0)