### PR TITLE
[vulnops] fix: Add SSRF protection to audio URL loading

### DIFF
--- a/examples/conversion/hf_to_megatron_generate_audio_lm.py
+++ b/examples/conversion/hf_to_megatron_generate_audio_lm.py
@@ -47,7 +47,6 @@ Example:
 import argparse
 from io import BytesIO
 from typing import Optional
-from urllib.request import urlopen
 
 import torch
 import torch.distributed as dist
@@ -58,6 +57,7 @@ from transformers import AutoProcessor, AutoTokenizer
 from megatron.bridge import AutoBridge
 from megatron.bridge.models.hf_pretrained.utils import is_safe_repo
 from megatron.bridge.utils.common_utils import get_last_rank, print_rank_0
+from megatron.bridge.utils.safe_url import is_safe_public_http_url, safe_url_open
 
 
 # Try to import librosa for audio loading
@@ -165,7 +165,11 @@ def load_audio(audio_path: str, sampling_rate: int = 16000):
         raise ImportError("librosa is required for audio loading. Please install it: pip install librosa")
 
     if audio_path.startswith(("http://", "https://")):
-        audio_data, _ = librosa.load(BytesIO(urlopen(audio_path).read()), sr=sampling_rate)
+        is_safe, reason = is_safe_public_http_url(audio_path)
+        if not is_safe:
+            raise ValueError(f"Refusing to fetch audio URL ({reason}): {audio_path}")
+        with safe_url_open(audio_path) as resp:
+            audio_data, _ = librosa.load(BytesIO(resp.read()), sr=sampling_rate)
     else:
         audio_data, _ = librosa.load(audio_path, sr=sampling_rate)
 

--- a/tests/unit_tests/utils/test_safe_url.py
+++ b/tests/unit_tests/utils/test_safe_url.py
@@ -15,7 +15,8 @@
 """SSRF-guard tests for megatron.bridge.utils.safe_url.
 
 Covers ``is_safe_public_http_url``, ``safe_url_open``, and integration
-with ``load_image`` in ``vlm_generate_utils``.
+with ``load_image`` in ``vlm_generate_utils`` and ``load_audio`` in
+``hf_to_megatron_generate_audio_lm``.
 """
 
 import socket
@@ -229,3 +230,54 @@ class TestLoadImageSsrf:
             result = vlm_generate_utils.load_image(str(img_path))
         mocked_check.assert_not_called()
         assert isinstance(result, Image.Image)
+
+
+class TestLoadAudioSsrf:
+    """Integration tests verifying ``load_audio`` in ``hf_to_megatron_generate_audio_lm`` rejects unsafe URLs."""
+
+    @pytest.fixture(autouse=True)
+    def _import_audio_module(self):
+        """Import the audio module, skipping the entire class if dependencies are missing."""
+        try:
+            from examples.conversion import hf_to_megatron_generate_audio_lm
+
+            self.audio_module = hf_to_megatron_generate_audio_lm
+        except ImportError as exc:
+            pytest.skip(f"audio_lm module not importable: {exc}")
+
+    def test_private_url_raises_value_error(self):
+        """A URL resolving to a loopback address must raise ValueError."""
+        with mock.patch.object(self.audio_module, "HAS_LIBROSA", True):
+            with mock.patch("socket.getaddrinfo", side_effect=_fake_getaddrinfo("127.0.0.1")):
+                with pytest.raises(ValueError, match="Refusing to fetch audio URL"):
+                    self.audio_module.load_audio("http://attacker.example.com/evil.mp3")
+
+    def test_metadata_endpoint_blocked(self):
+        """Cloud metadata endpoint (169.254.169.254) must be blocked."""
+        with mock.patch.object(self.audio_module, "HAS_LIBROSA", True):
+            with mock.patch("socket.getaddrinfo", side_effect=_fake_getaddrinfo("169.254.169.254")):
+                with pytest.raises(ValueError, match="non-public"):
+                    self.audio_module.load_audio("http://169.254.169.254/latest/meta-data/audio.mp3")
+
+    def test_safe_url_never_called_for_unsafe_url(self):
+        """When URL validation fails, the fetch function must never be invoked."""
+        with mock.patch.object(self.audio_module, "HAS_LIBROSA", True):
+            with mock.patch.object(self.audio_module, "safe_url_open") as mocked_open:
+                with mock.patch("socket.getaddrinfo", side_effect=_fake_getaddrinfo("10.0.0.1")):
+                    with pytest.raises(ValueError):
+                        self.audio_module.load_audio("http://internal.example.com/secret.mp3")
+            mocked_open.assert_not_called()
+
+    def test_local_file_path_not_validated(self, tmp_path):
+        """Local file paths must be loaded directly without SSRF validation."""
+        dummy_audio_path = str(tmp_path / "test.wav")
+
+        fake_audio_data = "fake_audio_array"
+        with mock.patch.object(self.audio_module, "HAS_LIBROSA", True):
+            with mock.patch.object(self.audio_module, "librosa") as mocked_librosa:
+                mocked_librosa.load.return_value = (fake_audio_data, 16000)
+                with mock.patch.object(self.audio_module, "is_safe_public_http_url") as mocked_check:
+                    result = self.audio_module.load_audio(dummy_audio_path)
+        mocked_check.assert_not_called()
+        mocked_librosa.load.assert_called_once_with(dummy_audio_path, sr=16000)
+        assert result == fake_audio_data


### PR DESCRIPTION
## Summary
- Applies SSRF protection to `load_audio()` in `hf_to_megatron_generate_audio_lm.py`, which was missed in #3630
- Replaces bare `urlopen` with `is_safe_public_http_url` + `safe_url_open` from `megatron.bridge.utils.safe_url`
- Adds `TestLoadAudioSsrf` integration tests mirroring the existing `TestLoadImageSsrf` pattern

## Test plan
- [ ] `uv run python -m pytest tests/unit_tests/utils/test_safe_url.py -v` — all SSRF guard tests pass (including new audio tests)
- [ ] `uv run pre-commit run --all-files` — lint/format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)