### PR TITLE
[model, docs] feat: document GLM-5.1 support alongside GLM-5

### DIFF
--- a/examples/models/glm5/README.md
+++ b/examples/models/glm5/README.md
@@ -1,11 +1,13 @@
-# GLM-5 Examples
+# GLM-5 / GLM-5.1 Examples
 
-Scripts for [GLM-5](https://huggingface.co/zai-org/GLM-5) (`zai-org/GLM-5`), a large sparse MoE model with Multi-Latent Attention (MLA) and Dynamic Sparse Attention (DSA).
+Scripts for the GLM-5 family — [GLM-5](https://huggingface.co/zai-org/GLM-5) (`zai-org/GLM-5`) and [GLM-5.1](https://huggingface.co/zai-org/GLM-5.1) (`zai-org/GLM-5.1`) — large sparse MoE models with Multi-Latent Attention (MLA) and Dynamic Sparse Attention (DSA).
+
+GLM-5 and GLM-5.1 share the `GlmMoeDsaForCausalLM` architecture and identical MoE / MLA / DSA dimensions, so the same `GLM5Bridge` handles both. To run the GLM-5.1 checkpoint, replace `zai-org/GLM-5` with `zai-org/GLM-5.1` (or set `MODEL_NAME=GLM-5.1` in the slurm scripts).
 
 | Property | Value |
 |---|---|
-| HF model ID | `zai-org/GLM-5` |
-| Architecture | MoE + MLA + DSA |
+| HF model IDs | `zai-org/GLM-5`, `zai-org/GLM-5.1` |
+| Architecture | MoE + MLA + DSA (`GlmMoeDsaForCausalLM`) |
 | Layers | 78 transformer (first 3 dense, rest MoE) |
 | Routed experts | 256, top-8 per token |
 | Shared experts | 1 per MoE layer |
@@ -16,7 +18,7 @@ Scripts for [GLM-5](https://huggingface.co/zai-org/GLM-5) (`zai-org/GLM-5`), a l
 
 ## Hardware Requirements
 
-GLM-5 requires **at least 8 nodes (64 GPUs × 80 GB)** for full-model conversion and inference in BF16. Key constraints:
+Full-model conversion and inference in BF16 requires **at least 8 nodes (64 GPUs × 80 GB)**. Key constraints:
 
 - EP must divide 256 (number of routed experts). Valid: 1, 2, 4, 8, 16, 32, 64, 128, 256.
 - TP does **not** reduce expert memory — increase EP instead.
@@ -75,13 +77,14 @@ Both scripts resolve the HF model from the local cache to avoid `snapshot_downlo
 |---|---|
 | `CONTAINER_IMAGE` | Path to Singularity/SquashFS container image |
 | `BRIDGE_PATH` | Megatron-Bridge checkout on shared storage (bind-mounted as `/opt/Megatron-Bridge`) |
-| `HF_HOME` | HuggingFace cache directory (must contain the downloaded `zai-org/GLM-5` model) |
+| `HF_HOME` | HuggingFace cache directory (must contain the downloaded `zai-org/GLM-5` or `zai-org/GLM-5.1` model) |
 | `HF_TOKEN` | HuggingFace access token (for gated model access) |
+| `MODEL_NAME` | HF model name without the `zai-org/` prefix; defaults to `GLM-5`. Set to `GLM-5.1` to run the 5.1 checkpoint. |
 | `OUTPUT_DIR` | Conversion output directory (conversion script only) |
 
 ## MCore Patches Required
 
-GLM-5's DSA attention variant requires two patches to `megatron/core/models/gpt/experimental_attention_variant_module_specs.py`:
+The DSA attention variant requires two patches to `megatron/core/models/gpt/experimental_attention_variant_module_specs.py`:
 
 1. **DSA dispatch:** Add `elif config.experimental_attention_variant == "dsa"` to `get_experimental_attention_variant_module_spec` to call `get_dsa_module_spec_for_backend`.
 2. **MLA metainfo:** Add `metainfo={"fuse_input_layernorm": False}` to the `MLASelfAttention` `ModuleSpec` in `get_dsa_module_spec_for_backend`.

--- a/examples/models/glm5/slurm_conversion.sh
+++ b/examples/models/glm5/slurm_conversion.sh
@@ -14,9 +14,12 @@
 # limitations under the License.
 
 # ==============================================================================
-# GLM-5 Conversion Round-Trip Verification (Multi-Node via Slurm)
+# GLM-5 / GLM-5.1 Conversion Round-Trip Verification (Multi-Node via Slurm)
 #
-# GLM-5 (MoE + MLA + DSA: 256 routed experts, top-8, ~800B+ params, BF16)
+# GLM-5 and GLM-5.1 share the same GlmMoeDsaForCausalLM architecture
+# (MoE + MLA + DSA: 256 routed experts, top-8, ~800B+ params, BF16),
+# so this script handles both. Set MODEL_NAME=GLM-5.1 to run the 5.1 checkpoint.
+#
 # The full model requires multi-node — minimum 8 nodes (64 GPUs) with
 # EP >= 32.  TP does NOT reduce expert memory — increase EP instead.
 #
@@ -25,7 +28,9 @@
 # Usage:
 #   1. Fill in CONTAINER_IMAGE, CONTAINER_MOUNTS, and token exports
 #   2. Adjust PARALLELISM_CONFIGS if needed
-#   3. Submit: sbatch examples/models/glm5/slurm_conversion.sh
+#   3. Submit:
+#        sbatch examples/models/glm5/slurm_conversion.sh                  # GLM-5
+#        MODEL_NAME=GLM-5.1 sbatch examples/models/glm5/slurm_conversion.sh
 # ==============================================================================
 
 #SBATCH --job-name=glm5-roundtrip
@@ -56,7 +61,8 @@ WORKDIR="/opt/Megatron-Bridge"
 PARALLELISM_CONFIGS=("2,1,32")
 
 # ── Model ─────────────────────────────────────────────────────────────────
-MODEL_NAME=GLM-5
+# MODEL_NAME selects between GLM-5 and GLM-5.1 (same architecture).
+MODEL_NAME="${MODEL_NAME:-GLM-5}"
 HF_MODEL_ID=zai-org/$MODEL_NAME
 
 # ── Environment ───────────────────────────────────────────────────────────
@@ -68,7 +74,7 @@ export NCCL_NVLS_ENABLE=0
 # ==============================================================================
 
 echo "======================================"
-echo "GLM-5 Round-Trip Conversion Sweep"
+echo "${MODEL_NAME} Round-Trip Conversion Sweep"
 echo "Job: $SLURM_JOB_ID | Nodes: $SLURM_JOB_NUM_NODES"
 echo "Parallelism configs: ${PARALLELISM_CONFIGS[*]}"
 echo "======================================"

--- a/examples/models/glm5/slurm_inference.sh
+++ b/examples/models/glm5/slurm_inference.sh
@@ -14,9 +14,12 @@
 # limitations under the License.
 
 # ==============================================================================
-# GLM-5 Multi-Node Inference (Slurm)
+# GLM-5 / GLM-5.1 Multi-Node Inference (Slurm)
 #
-# GLM-5 (MoE + MLA + DSA: 256 routed experts, top-8, ~800B+ params, BF16)
+# GLM-5 and GLM-5.1 share the same GlmMoeDsaForCausalLM architecture
+# (MoE + MLA + DSA: 256 routed experts, top-8, ~800B+ params, BF16),
+# so this script handles both. Set MODEL_NAME=GLM-5.1 to run the 5.1 checkpoint.
+#
 # Full model requires 8 nodes (64 GPUs) minimum.
 # TP does NOT reduce expert memory — increase EP instead.
 # Recommended: TP=2, EP=32, PP=1 (64 GPUs, 8 nodes).
@@ -27,7 +30,8 @@
 # Requirements: transformers >= 5.2.0
 #
 # Usage:
-#   sbatch examples/models/glm5/slurm_inference.sh
+#   sbatch examples/models/glm5/slurm_inference.sh                  # GLM-5
+#   MODEL_NAME=GLM-5.1 sbatch examples/models/glm5/slurm_inference.sh
 # ==============================================================================
 
 #SBATCH --job-name=glm5-infer
@@ -52,9 +56,11 @@ export HF_HOME="${HF_HOME:?Set HF_HOME to your HuggingFace cache directory}"
 export UV_CACHE_DIR="${UV_CACHE_DIR:-/tmp/uv_cache}"
 
 # ── Model / Parallelism ──────────────────────────────────────────────────
+# MODEL_NAME selects between GLM-5 and GLM-5.1 (same architecture).
+MODEL_NAME="${MODEL_NAME:-GLM-5}"
 # Use the direct local snapshot path to avoid 64 processes calling
 # snapshot_download simultaneously (causes Lustre race conditions).
-HF_MODEL_PATH="${HF_HOME}/hub/models--zai-org--GLM-5/snapshots/$(ls ${HF_HOME}/hub/models--zai-org--GLM-5/snapshots/ | head -1)"
+HF_MODEL_PATH="${HF_HOME}/hub/models--zai-org--${MODEL_NAME}/snapshots/$(ls ${HF_HOME}/hub/models--zai-org--${MODEL_NAME}/snapshots/ | head -1)"
 TP=2
 EP=32
 PP=1
@@ -73,7 +79,7 @@ export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
 # ==============================================================================
 
 echo "======================================"
-echo "GLM-5 Inference"
+echo "${MODEL_NAME} Inference"
 echo "Job: $SLURM_JOB_ID | Nodes: $SLURM_JOB_NUM_NODES"
 echo "TP=$TP PP=$PP EP=$EP (Total GPUs: $((SLURM_JOB_NUM_NODES * 8)))"
 echo "======================================"

--- a/src/megatron/bridge/models/glm_moe_dsa/glm5_bridge.py
+++ b/src/megatron/bridge/models/glm_moe_dsa/glm5_bridge.py
@@ -36,18 +36,20 @@ logger = logging.getLogger(__name__)
 )
 class GLM5Bridge(MegatronModelBridge):
     """
-    Megatron Bridge for GLM-5 (MoE + MLA + DSA).
+    Megatron Bridge for GLM-5 / GLM-5.1 (MoE + MLA + DSA).
 
     This bridge handles conversion between HuggingFace GlmMoeDsaForCausalLM
-    and Megatron-Core GPTModel formats.
+    and Megatron-Core GPTModel formats. GLM-5 and GLM-5.1 share the same
+    architecture and configuration shape, so both ``zai-org/GLM-5`` and
+    ``zai-org/GLM-5.1`` are auto-detected through this bridge.
 
-    GLM-5 uses Multi-Latent Attention (MLA), Dynamic Sparse Attention (DSA)
-    indexer layers, and Mixture-of-Experts (MoE).
+    The architecture uses Multi-Latent Attention (MLA), Dynamic Sparse Attention
+    (DSA) indexer layers, and Mixture-of-Experts (MoE).
     Requires transformers>=5.2.0.
 
     Example:
         >>> from megatron.bridge import AutoBridge
-        >>> bridge = AutoBridge.from_hf_pretrained("zai-org/GLM-5")
+        >>> bridge = AutoBridge.from_hf_pretrained("zai-org/GLM-5.1")
         >>> provider = bridge.to_megatron_provider()
     """
 


### PR DESCRIPTION
## Summary

GLM-5 and GLM-5.1 share the `GlmMoeDsaForCausalLM` architecture with identical MoE / MLA / DSA dimensions, so the existing `GLM5Bridge` already auto-detects both checkpoints. This PR makes that explicit in the user-facing docs and parameterizes the slurm examples so users can run GLM-5.1 by setting `MODEL_NAME=GLM-5.1`.

- `examples/models/glm5/README.md` — title, intro, and env-var table list both models; new `MODEL_NAME` row.
- `examples/models/glm5/slurm_inference.sh`, `slurm_conversion.sh` — header comments cover both models; `MODEL_NAME` is now overridable (default unchanged: `GLM-5`).
- `src/megatron/bridge/models/glm_moe_dsa/glm5_bridge.py` — class docstring + example call out 5.1 support.

No code-path or bridge logic changes. Default behavior of the existing scripts is preserved.

## Verification

I verified that `zai-org/GLM-5` and `zai-org/GLM-5.1` configs are field-for-field identical (architectures, dims, MoE / MLA / DSA params), and pre-commit (ruff + ruff-format) passes on the bridge file.

A 64-GPU GLM-5.1 inference and round-trip conversion run is in flight on cw-dfw to confirm end-to-end behavior; will update once it completes.

## Test plan

- [x] Pre-commit / ruff / ruff-format pass on changed Python file.
- [x] Both slurm scripts parse cleanly under `bash -n`.
- [x] Default `MODEL_NAME` (unset) still resolves to `GLM-5` — no change for existing users.
- [ ] (in flight) Live `MODEL_NAME=GLM-5.1` inference and round-trip on 8 nodes / 64 GPUs.