### PR TITLE
[build] chore: remove custom aws-ofi-nccl build stage from fw_base

### DIFF
--- a/docker/Dockerfile.fw_base
+++ b/docker/Dockerfile.fw_base
@@ -15,10 +15,8 @@
 # Build layer variables
 # To install trtllm set FW_DEP_BUILDER=trtllm_builder, FW_BASE_FINAL=trtllm_install
 # To exclude trtllm set FW_DEP_BUILDER=base, FW_BASE_FINAL=fw_toolkit_builder
-# To skip AWS-OFI-NCCL set FW_NETWORK_LAYER=fw_dep_builder
 ARG FW_DEP_BUILDER
 ARG FW_BASE_FINAL
-ARG FW_NETWORK_LAYER=aws_ofi_builder
 
 ARG NEMO_FW_BASE_IMAGE
 FROM ${NEMO_FW_BASE_IMAGE} AS base
@@ -179,98 +177,11 @@ RUN curl -LsSf https://astral.sh/uv/${UV_VERSION}/install.sh | XDG_BIN_HOME=/usr
 
 ##############################################################################
 ##
-## AWS-OFI-NCCL upgrade stage
-##
-## Upgrade AWS-OFI-NCCL from v1.17.0 to v1.17.3
-##
-## IMPORTANT: Do NOT remove ibverbs/libmlx5 packages — they are required for
-## InfiniBand/RDMA transport on Slurm clusters with Mellanox ConnectX adapters.
-## The EFA stack is installed alongside (not replacing) the existing IB stack.
-##
-## To skip this stage, set FW_NETWORK_LAYER=fw_dep_builder
-##
-##############################################################################
-
-FROM fw_dep_builder AS aws_ofi_builder
-
-RUN apt-get update -y
-
-#################################################
-## Remove existing EFA and aws-ofi-nccl only (preserve ibverbs/mlx5)
-RUN rm -rf /opt/amazon
-
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-unauthenticated \
-    autoconf \
-    automake \
-    build-essential \
-    check \
-    cmake \
-    curl \
-    git \
-    gcc \
-    libtool \
-    pkg-config
-
-## Install EFA installer (coexists with Mellanox IB stack)
-ARG EFA_INSTALLER_VERSION=1.46.0
-RUN cd $HOME \
-&& curl -O https://efa-installer.amazonaws.com/aws-efa-installer-${EFA_INSTALLER_VERSION}.tar.gz \
-&& tar -xf $HOME/aws-efa-installer-${EFA_INSTALLER_VERSION}.tar.gz \
-&& cd aws-efa-installer \
-&& ./efa_installer.sh -y -g -d --skip-kmod --skip-limit-conf --no-verify \
-&& rm -rf $HOME/aws-efa-installer
-
-## EFA installer re-creates /opt/amazon/ofi-nccl with an EFA-specific libnccl-net.so
-## and registers it via 100_ofinccl.conf in ldconfig. On Slurm, this causes NCCL to
-## load the EFA plugin instead of /opt/hpcx/nccl_rdma_sharp_plugin/lib/libnccl-net.so
-## (HPC-X RDMA SHARP), which has no Mellanox IB support → 18% regression.
-## Remove it so Slurm gets the HPC-X plugin. AWS uses LD_LIBRARY_PATH in settings.sh.
-RUN rm -rf /opt/amazon/ofi-nccl \
-    && rm -f /etc/ld.so.conf.d/100_ofinccl.conf \
-    && ldconfig
-
-## Reinstall ibverbs/mlx5 packages in case EFA installer overwrote them
-RUN apt-get update && apt-get install -y --allow-change-held-packages \
-    ibverbs-utils \
-    libibverbs-dev \
-    libibverbs1 \
-    libmlx5-1 \
-    && apt-get clean
-
-## Build aws-ofi-nccl v1.17.3 WITHOUT --enable-platform-aws so it works on
-## both AWS EFA and Slurm IB infrastructure. The FI_PROVIDER=efa env var in
-## settings.sh already ensures EFA is selected on AWS at runtime.
-ENV AWS_OFI_NCCL_VERSION=v1.17.3
-RUN export LD_LIBRARY_PATH=/opt/amazon/efa/lib:/opt/amazon/openmpi/lib:${LD_LIBRARY_PATH} && \
-    export PATH=/opt/amazon/efa/bin:/opt/amazon/openmpi/bin:${PATH} && \
-    rm -rf /opt/amazon/aws-ofi-nccl && \
-    apt-get update && \
-    apt-get install -y libhwloc-dev && \
-    apt-get clean && \
-    curl -OL https://github.com/aws/aws-ofi-nccl/releases/download/${AWS_OFI_NCCL_VERSION}/aws-ofi-nccl-${AWS_OFI_NCCL_VERSION//v}.tar.gz \
-    && tar -xf aws-ofi-nccl-${AWS_OFI_NCCL_VERSION//v}.tar.gz \
-    && cd aws-ofi-nccl-${AWS_OFI_NCCL_VERSION//v} \
-    && ./configure --prefix=/opt/amazon/aws-ofi-nccl \
-        --with-mpi=/usr/local/mpi \
-        --with-libfabric=/opt/amazon/efa \
-        --with-cuda=/usr/local/cuda \
-        --disable-nccl-net-library \
-    && make -j $(nproc) install \
-    && rm -f /opt/amazon/aws-ofi-nccl/lib/lib*.la /opt/amazon/aws-ofi-nccl/lib/libnccl-ofi-tuner.so \
-    && cd .. \
-    && rm -rf aws-ofi-nccl-${AWS_OFI_NCCL_VERSION//v} \
-    && rm aws-ofi-nccl-${AWS_OFI_NCCL_VERSION//v}.tar.gz
-
-##############################################################################
-##
 ## CUDA toolkit + DeepEP stage
 ##
-## Chains from FW_NETWORK_LAYER (default: aws_ofi_builder).
-## Set FW_NETWORK_LAYER=fw_dep_builder to skip the AWS-OFI-NCCL stage.
-##
 ##############################################################################
 
-FROM ${FW_NETWORK_LAYER} AS fw_toolkit_builder
+FROM fw_dep_builder AS fw_toolkit_builder
 
 ##############################################################################
 ##
@@ -319,15 +230,14 @@ ENV RDMA_CORE_HOME=/opt/rdma-core/build
 ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64/:$LD_LIBRARY_PATH
 RUN --mount=type=bind,source=docker/patches/deepep.patch,target=/opt/deepep.patch \
     if [ "$INSTALL_DEEPEP" = "True" ]; then \
-    # Upgrade system rdma-core to v60 (EFA brings this when aws_ofi_builder runs; make it
-    # explicit so the DeepEP build works even when FW_NETWORK_LAYER=fw_dep_builder).
-    # libibverbs-dev supplies the unversioned libibverbs.so symlink required at link time.
+    # Upgrade system rdma-core to v60; libibverbs-dev supplies the unversioned
+    # libibverbs.so symlink required at link time.
     apt-get update && apt-get install -y --allow-change-held-packages \
         rdma-core libibverbs-dev && \
     apt-get clean && \
     ARCH_LIB=$(dpkg-architecture -qDEB_HOST_MULTIARCH) && \
-    # libmlx5-dev is not available in the apt sources; EFA installer (aws_ofi_builder)
-    # provides libmlx5.so — create it from the versioned symlink as a fallback.
+    # libmlx5-dev is not available in the apt sources; create the unversioned
+    # symlink from the versioned one as a fallback for the DeepEP build.
     test -f /usr/lib/${ARCH_LIB}/libmlx5.so || \
         ln -sf /usr/lib/${ARCH_LIB}/libmlx5.so.1 /usr/lib/${ARCH_LIB}/libmlx5.so && \
     # Expose the system install under RDMA_CORE_HOME so DeepEP setup.py finds

--- a/docker/Dockerfile.fw_base
+++ b/docker/Dockerfile.fw_base
@@ -121,6 +121,20 @@ RUN --mount=type=bind,from=trtllm_repo,source=/src/tensorrt_llm/docker/common,ta
     pip install "polygraphy==0.49.9" && \
     bash tensorrt_llm/docker/common/install_mpi4py.sh
 
+# install_tensorrt.sh installs libcublas-dev-13-1 whose headers land in
+# /usr/local/cuda-13.1/include/. When the base image CUDA version is newer
+# (e.g. 13.2), /usr/local/cuda -> /usr/local/cuda-13.2 so nvcc won't find
+# them. Symlink any missing cuBLAS headers into the active CUDA include path.
+RUN CUDA_INC=/usr/local/cuda/include && \
+    SRC_INC=/usr/local/cuda-13.1/include && \
+    if [ -d "$SRC_INC" ] && [ -d "$CUDA_INC" ] && [ "$SRC_INC" != "$CUDA_INC" ]; then \
+        find "$SRC_INC" -maxdepth 1 -name 'cublas*.h' | \
+        while read h; do \
+            base=$(basename "$h"); \
+            [ -e "$CUDA_INC/$base" ] || ln -sf "$h" "$CUDA_INC/$base"; \
+        done; \
+    fi
+
 ##############################################################################
 ##
 ## TRT-LLM wheel

--- a/docker/Dockerfile.fw_base
+++ b/docker/Dockerfile.fw_base
@@ -121,17 +121,24 @@ RUN --mount=type=bind,from=trtllm_repo,source=/src/tensorrt_llm/docker/common,ta
     pip install "polygraphy==0.49.9" && \
     bash tensorrt_llm/docker/common/install_mpi4py.sh
 
-# install_tensorrt.sh installs libcublas-dev-13-1 whose headers land in
-# /usr/local/cuda-13.1/targets/<arch>/include/ (not directly in include/).
-# With CUDA 13.2 as the base image, /usr/local/cuda -> cuda-13.2 so nvcc
-# won't find them. Recurse into the cuda-13.1 tree and symlink any missing
-# cuBLAS headers into the active CUDA include path.
+# install_tensorrt.sh installs libcublas{,-dev}-13-1 whose files land in
+# /usr/local/cuda-13.1/targets/<arch>/{include,lib}/ (not in the top-level
+# cuda/ tree). With CUDA 13.2 as the base image /usr/local/cuda -> cuda-13.2,
+# so neither nvcc nor the dynamic linker finds them. Symlink headers into the
+# active CUDA include path and libraries into the active CUDA lib64 path.
 RUN CUDA_INC=/usr/local/cuda/include && \
+    CUDA_LIB=/usr/local/cuda/lib64 && \
     find /usr/local/cuda-13.1 -name 'cublas*.h' 2>/dev/null | \
     while read h; do \
         base=$(basename "$h"); \
         [ -e "${CUDA_INC}/$base" ] || ln -sf "$h" "${CUDA_INC}/$base"; \
-    done
+    done && \
+    find /usr/local/cuda-13.1 -name 'libcublas*.so*' 2>/dev/null | \
+    while read f; do \
+        base=$(basename "$f"); \
+        [ -e "${CUDA_LIB}/$base" ] || ln -sf "$f" "${CUDA_LIB}/$base"; \
+    done && \
+    ldconfig
 
 ##############################################################################
 ##

--- a/docker/Dockerfile.fw_base
+++ b/docker/Dockerfile.fw_base
@@ -121,19 +121,20 @@ RUN --mount=type=bind,from=trtllm_repo,source=/src/tensorrt_llm/docker/common,ta
     pip install "polygraphy==0.49.9" && \
     bash tensorrt_llm/docker/common/install_mpi4py.sh
 
-# install_tensorrt.sh installs libcublas{,-dev}-13-1 whose files land in
-# /usr/local/cuda-13.1/targets/<arch>/{include,lib}/ (not in the top-level
-# cuda/ tree). With CUDA 13.2 as the base image /usr/local/cuda -> cuda-13.2,
-# so neither nvcc nor the dynamic linker finds them. Symlink headers into the
-# active CUDA include path and libraries into the active CUDA lib64 path.
+# install_tensorrt.sh installs CUDA 13.1 packages (libcublas, cuda-nvrtc, …)
+# whose files land in /usr/local/cuda-13.1/targets/<arch>/{include,lib}/.
+# With CUDA 13.2 as the base image /usr/local/cuda -> cuda-13.2, so neither
+# nvcc, cmake's FindCUDAToolkit, nor the dynamic linker find them. Symlink
+# every header and library from the cuda-13.1 targets tree into the active
+# CUDA paths so all downstream builds see a coherent CUDA 13.2 environment.
 RUN CUDA_INC=/usr/local/cuda/include && \
     CUDA_LIB=/usr/local/cuda/lib64 && \
-    find /usr/local/cuda-13.1 -name 'cublas*.h' 2>/dev/null | \
-    while read h; do \
-        base=$(basename "$h"); \
-        [ -e "${CUDA_INC}/$base" ] || ln -sf "$h" "${CUDA_INC}/$base"; \
+    find /usr/local/cuda-13.1 -name '*.h' 2>/dev/null | \
+    while read f; do \
+        base=$(basename "$f"); \
+        [ -e "${CUDA_INC}/$base" ] || ln -sf "$f" "${CUDA_INC}/$base"; \
     done && \
-    find /usr/local/cuda-13.1 -name 'libcublas*.so*' 2>/dev/null | \
+    find /usr/local/cuda-13.1 \( -name '*.so*' -o -name '*.a' \) 2>/dev/null | \
     while read f; do \
         base=$(basename "$f"); \
         [ -e "${CUDA_LIB}/$base" ] || ln -sf "$f" "${CUDA_LIB}/$base"; \

--- a/docker/Dockerfile.fw_base
+++ b/docker/Dockerfile.fw_base
@@ -121,26 +121,6 @@ RUN --mount=type=bind,from=trtllm_repo,source=/src/tensorrt_llm/docker/common,ta
     pip install "polygraphy==0.49.9" && \
     bash tensorrt_llm/docker/common/install_mpi4py.sh
 
-# install_tensorrt.sh installs CUDA 13.1 packages (libcublas, cuda-nvrtc, …)
-# whose files land in /usr/local/cuda-13.1/targets/<arch>/{include,lib}/.
-# With CUDA 13.2 as the base image /usr/local/cuda -> cuda-13.2, so neither
-# nvcc, cmake's FindCUDAToolkit, nor the dynamic linker find them. Symlink
-# every header and library from the cuda-13.1 targets tree into the active
-# CUDA paths so all downstream builds see a coherent CUDA 13.2 environment.
-RUN CUDA_INC=/usr/local/cuda/include && \
-    CUDA_LIB=/usr/local/cuda/lib64 && \
-    find /usr/local/cuda-13.1 -name '*.h' 2>/dev/null | \
-    while read f; do \
-        base=$(basename "$f"); \
-        [ -e "${CUDA_INC}/$base" ] || ln -sf "$f" "${CUDA_INC}/$base"; \
-    done && \
-    find /usr/local/cuda-13.1 \( -name '*.so*' -o -name '*.a' \) 2>/dev/null | \
-    while read f; do \
-        base=$(basename "$f"); \
-        [ -e "${CUDA_LIB}/$base" ] || ln -sf "$f" "${CUDA_LIB}/$base"; \
-    done && \
-    ldconfig
-
 ##############################################################################
 ##
 ## TRT-LLM wheel

--- a/docker/Dockerfile.fw_base
+++ b/docker/Dockerfile.fw_base
@@ -122,18 +122,16 @@ RUN --mount=type=bind,from=trtllm_repo,source=/src/tensorrt_llm/docker/common,ta
     bash tensorrt_llm/docker/common/install_mpi4py.sh
 
 # install_tensorrt.sh installs libcublas-dev-13-1 whose headers land in
-# /usr/local/cuda-13.1/include/. When the base image CUDA version is newer
-# (e.g. 13.2), /usr/local/cuda -> /usr/local/cuda-13.2 so nvcc won't find
-# them. Symlink any missing cuBLAS headers into the active CUDA include path.
+# /usr/local/cuda-13.1/targets/<arch>/include/ (not directly in include/).
+# With CUDA 13.2 as the base image, /usr/local/cuda -> cuda-13.2 so nvcc
+# won't find them. Recurse into the cuda-13.1 tree and symlink any missing
+# cuBLAS headers into the active CUDA include path.
 RUN CUDA_INC=/usr/local/cuda/include && \
-    SRC_INC=/usr/local/cuda-13.1/include && \
-    if [ -d "$SRC_INC" ] && [ -d "$CUDA_INC" ] && [ "$SRC_INC" != "$CUDA_INC" ]; then \
-        find "$SRC_INC" -maxdepth 1 -name 'cublas*.h' | \
-        while read h; do \
-            base=$(basename "$h"); \
-            [ -e "$CUDA_INC/$base" ] || ln -sf "$h" "$CUDA_INC/$base"; \
-        done; \
-    fi
+    find /usr/local/cuda-13.1 -name 'cublas*.h' 2>/dev/null | \
+    while read h; do \
+        base=$(basename "$h"); \
+        [ -e "${CUDA_INC}/$base" ] || ln -sf "$h" "${CUDA_INC}/$base"; \
+    done
 
 ##############################################################################
 ##

--- a/docker/README.md
+++ b/docker/README.md
@@ -11,6 +11,8 @@ container and the NeMo Framework (NeMo-FW) image stack.
 
 The full NeMo-FW stack is built in order: **fw-base → megatron-bridge → fw-final**.
 
+In production CI, this build is orchestrated by **nemo-ci**. The build arguments below map directly to variables in [`ci_build_vars.yml`](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/blob/main/.gitlab/workflows/ci_build_vars.yml) (`NEMO_FW_BASE_IMAGE`, `REINSTALL_NCCL`, `NCCL_VERSION`, etc.). When upgrading the base image, follow the [major-dependency-upgrade skill](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/blob/main/.claude/skills/major-dependency-upgrade/SKILL.md) in nemo-ci.
+
 ---
 
 ## Megatron-Bridge container

--- a/docker/README.md
+++ b/docker/README.md
@@ -115,7 +115,6 @@ docker build \
 | `NEMO_FW_BASE_IMAGE` | Base PyTorch container |
 | `FW_DEP_BUILDER` | Stage used as the `fw_dep_builder` base. `trtllm_builder` to include TRT-LLM, `base` to skip it |
 | `FW_BASE_FINAL` | Output stage. `trtllm_install` (with TRT-LLM) or `fw_toolkit_builder` (without) |
-| `FW_NETWORK_LAYER` | Stage used as the `fw_toolkit_builder` base. `aws_ofi_builder` (default) to reinstall EFA and build AWS-OFI-NCCL from source, `fw_dep_builder` to skip it |
 | `UV_VERSION` | uv version to install |
 | `VLLM_VERSION` | vLLM git tag to build |
 | `TRT_LLM_COMMIT` | TensorRT-LLM git commit or tag |

--- a/docker/README.md
+++ b/docker/README.md
@@ -11,8 +11,6 @@ container and the NeMo Framework (NeMo-FW) image stack.
 
 The full NeMo-FW stack is built in order: **fw-base → megatron-bridge → fw-final**.
 
-In production CI, this build is orchestrated by **nemo-ci**. The build arguments below map directly to variables in [`ci_build_vars.yml`](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/blob/main/.gitlab/workflows/ci_build_vars.yml) (`NEMO_FW_BASE_IMAGE`, `REINSTALL_NCCL`, `NCCL_VERSION`, etc.). When upgrading the base image, follow the [major-dependency-upgrade skill](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/blob/main/.claude/skills/major-dependency-upgrade/SKILL.md) in nemo-ci.
-
 ---
 
 ## Megatron-Bridge container


### PR DESCRIPTION
<details><summary>Claude summary</summary>

Removes the custom `aws_ofi_builder` Dockerfile stage that installed the EFA installer and built `aws-ofi-nccl` from source. `pytorch:26.04` ships a compatible `aws-ofi-nccl` already, making the custom build stage unnecessary.

Also cleans up now-stale comments in the DeepEP stage that referenced `aws_ofi_builder`.

</details>
