### PR TITLE
fix(perf): keep PCT binding for deepseek_v3 large_scale on b300

### DIFF
--- a/scripts/performance/setup_experiment.py
+++ b/scripts/performance/setup_experiment.py
@@ -294,7 +294,12 @@ def main(
         and model_recipe_name == "nemotron_3_super"
         and compute_dtype == "bf16"
         and gpu == "b300"
-    ) or (model_family_name == "deepseek" and model_recipe_name == "deepseek_v3" and gpu == "b300"):
+    ) or (
+        model_family_name == "deepseek"
+        and model_recipe_name == "deepseek_v3"
+        and gpu == "b300"
+        and config_variant != "large_scale"
+    ):
         enable_pct_binding = False
 
     if wandb_key is not None:


### PR DESCRIPTION
<details><summary>Claude summary</summary>

Restores the PCT-binding disable for `deepseek_v3` on `b300` (originally added in #3549, removed in commit `9ef86c8`), but narrows it so the `large_scale` config variant keeps PCT binding enabled.

The condition now reads:

```python
if (
    model_family_name == "nemotronh"
    and model_recipe_name == "nemotron_3_super"
    and compute_dtype == "bf16"
    and gpu == "b300"
) or (
    model_family_name == "deepseek"
    and model_recipe_name == "deepseek_v3"
    and gpu == "b300"
    and config_variant != "large_scale"
):
    enable_pct_binding = False
```

- `deepseek_v3` + `b300` + non-`large_scale` variants → PCT binding disabled (prior behavior).
- `deepseek_v3` + `b300` + `large_scale` → PCT binding remains enabled.

</details>
