### PR TITLE
ci(claude-review): use --body inline and require explicit test names

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -91,12 +91,15 @@ jobs:
             If no perf/recipe configs are touched, write "No perf tests impacted."
 
             End the review by posting it as a top-level PR comment:
-              gh pr comment <PR NUMBER> --repo <REPO> --body-file <tmpfile>
-            Write the body to a tmpfile first and pass --body-file (never a HEREDOC).
-            The body must include the "Suggested test cases" list. If there is nothing
-            to flag, the body is just "LGTM" followed by the test-case list.
-            Inline comments via mcp__github_inline_comment__create_inline_comment are
-            optional — use them only for specific code suggestions.
+              gh pr comment <PR NUMBER> --repo <REPO> --body "<review body>"
+            Pass the body as a single --body argument. Do NOT use --body-file,
+            output redirection, or HEREDOCs — the action sandbox blocks all
+            three. Use literal "\n" inside the quoted string for newlines.
+            The body must include the "Suggested test cases" list. If there
+            is nothing to flag, the body is just "LGTM" followed by the
+            test-case list. Inline comments via
+            mcp__github_inline_comment__create_inline_comment are optional —
+            use them only for specific code suggestions.
 
   manual-review:
     if: github.event_name == 'issue_comment' && github.event.issue.pull_request != null && contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
@@ -141,11 +144,14 @@ jobs:
         If no perf/recipe configs are touched, write "No perf tests impacted."
 
         End the review by posting it as a top-level PR comment:
-          gh pr comment <PR NUMBER> --repo <REPO> --body-file <tmpfile>
-        Write the body to a tmpfile first and pass --body-file (never a HEREDOC).
-        The body must include the "Suggested test cases" list. If there is nothing
-        to flag, the body is just "LGTM" followed by the test-case list.
-        Inline comments via mcp__github_inline_comment__create_inline_comment are
-        optional — use them only for specific code suggestions.
+          gh pr comment <PR NUMBER> --repo <REPO> --body "<review body>"
+        Pass the body as a single --body argument. Do NOT use --body-file,
+        output redirection, or HEREDOCs — the action sandbox blocks all
+        three. Use literal "\n" inside the quoted string for newlines.
+        The body must include the "Suggested test cases" list. If there
+        is nothing to flag, the body is just "LGTM" followed by the
+        test-case list. Inline comments via
+        mcp__github_inline_comment__create_inline_comment are optional —
+        use them only for specific code suggestions.
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -87,7 +87,14 @@ jobs:
             - A base config `<MODEL>_..._<GPU>_<PRECISION>_V<N>` impacts that precision,
               plus any V<N+1> / LARGE_SCALE configs derived from it via `replace(...)`.
 
-            Each bullet should be a glob, e.g. `qwen3_235b_a22b_*gpu_b300_{bf16,fp8_mx,nvfp4}_*_perf`.
+            Each bullet must be an explicit test case name — do NOT use globs
+            or brace expansion. Enumerate every relevant combination, e.g.
+            `qwen3_235b_a22b_512gpu_b300_bf16_perf`,
+            `qwen3_235b_a22b_512gpu_b300_fp8_cs_perf`,
+            `qwen3_235b_a22b_512gpu_b300_fp8_mx_perf`,
+            `qwen3_235b_a22b_512gpu_b300_nvfp4_perf`. Discover the exact names
+            by grepping the diff and the `scripts/performance/configs/` tree
+            for the affected model/GPU/precision combinations.
             If no perf/recipe configs are touched, write "No perf tests impacted."
 
             End the review by posting it as a top-level PR comment:
@@ -140,7 +147,14 @@ jobs:
         - A base config `<MODEL>_..._<GPU>_<PRECISION>_V<N>` impacts that precision,
           plus any V<N+1> / LARGE_SCALE configs derived from it via `replace(...)`.
 
-        Each bullet should be a glob, e.g. `qwen3_235b_a22b_*gpu_b300_{bf16,fp8_mx,nvfp4}_*_perf`.
+        Each bullet must be an explicit test case name — do NOT use globs
+        or brace expansion. Enumerate every relevant combination, e.g.
+        `qwen3_235b_a22b_512gpu_b300_bf16_perf`,
+        `qwen3_235b_a22b_512gpu_b300_fp8_cs_perf`,
+        `qwen3_235b_a22b_512gpu_b300_fp8_mx_perf`,
+        `qwen3_235b_a22b_512gpu_b300_nvfp4_perf`. Discover the exact names
+        by grepping the diff and the `scripts/performance/configs/` tree
+        for the affected model/GPU/precision combinations.
         If no perf/recipe configs are touched, write "No perf tests impacted."
 
         End the review by posting it as a top-level PR comment:


### PR DESCRIPTION
<details><summary>Claude summary</summary>

Follow-up to #3659. Two issues with the previous prompt that surfaced once the auto-poster was actually exercised:

## Why

1. **`--body-file <tmpfile>` does not work in the action sandbox.** A subsequent run failed with:

   ```
   Output redirection to '/home/runner/work/Megatron-Bridge/Megatron-Bridge/.claude-pr/review_3490.md'
   was blocked. For security, Claude Code may only write to files in the allowed working directories
   for this session.
   ```

   The allowed-tools list contains `Bash(gh pr comment:*)` only — no `Write`, no generic `Bash` — and the sandbox blocks output redirection (`>`, `>>`, HEREDOCs) even inside the workspace. So the only shape that works is passing the body as a single `--body "<...>"` argument.

2. **Glob/brace expansion in suggested-tests is unhelpful.** The previous example `qwen3_235b_a22b_*gpu_b300_{bf16,fp8_mx,nvfp4}_*_perf` has to be mentally expanded before the names can be pasted into nemo-ci's `launch_pipeline.py`. The user wants a flat enumerated list.

## What

```yaml
End the review by posting it as a top-level PR comment:
  gh pr comment <PR NUMBER> --repo <REPO> --body "<review body>"
Pass the body as a single --body argument. Do NOT use --body-file,
output redirection, or HEREDOCs — the action sandbox blocks all
three. Use literal "\n" inside the quoted string for newlines.
```

```yaml
Each bullet must be an explicit test case name — do NOT use globs
or brace expansion. Enumerate every relevant combination, e.g.
`qwen3_235b_a22b_512gpu_b300_bf16_perf`,
`qwen3_235b_a22b_512gpu_b300_fp8_cs_perf`,
`qwen3_235b_a22b_512gpu_b300_fp8_mx_perf`,
`qwen3_235b_a22b_512gpu_b300_nvfp4_perf`.
```

Both prompts (auto-review and manual-review) are updated.

## Test plan

- [ ] Trigger `/claude review` on a follow-up PR and confirm a top-level comment lands on the PR.
- [ ] Confirm the suggested-tests list contains explicit names, not globs.

</details>
