### PR TITLE
ci(claude-review): require ANSI-C quoting for newlines in --body

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -97,11 +97,14 @@ jobs:
             for the affected model/GPU/precision combinations.
             If no perf/recipe configs are touched, write "No perf tests impacted."
 
-            End the review by posting it as a top-level PR comment:
-              gh pr comment <PR NUMBER> --repo <REPO> --body "<review body>"
-            Pass the body as a single --body argument. Do NOT use --body-file,
-            output redirection, or HEREDOCs — the action sandbox blocks all
-            three. Use literal "\n" inside the quoted string for newlines.
+            End the review by posting it as a top-level PR comment using
+            bash ANSI-C quoting so newlines render correctly:
+              gh pr comment <PR NUMBER> --repo <REPO> --body $'line1\nline2\n...'
+            Use $'...' (NOT plain "..."). Inside "..." the sequence \n is
+            passed to gh literally and shows up as the two characters \n in
+            the rendered comment; inside $'...' bash expands \n to a real
+            newline before gh sees it. Do NOT use --body-file, output
+            redirection, or HEREDOCs — the action sandbox blocks all three.
             The body must include the "Suggested test cases" list. If there
             is nothing to flag, the body is just "LGTM" followed by the
             test-case list. Inline comments via
@@ -157,11 +160,14 @@ jobs:
         for the affected model/GPU/precision combinations.
         If no perf/recipe configs are touched, write "No perf tests impacted."
 
-        End the review by posting it as a top-level PR comment:
-          gh pr comment <PR NUMBER> --repo <REPO> --body "<review body>"
-        Pass the body as a single --body argument. Do NOT use --body-file,
-        output redirection, or HEREDOCs — the action sandbox blocks all
-        three. Use literal "\n" inside the quoted string for newlines.
+        End the review by posting it as a top-level PR comment using
+        bash ANSI-C quoting so newlines render correctly:
+          gh pr comment <PR NUMBER> --repo <REPO> --body $'line1\nline2\n...'
+        Use $'...' (NOT plain "..."). Inside "..." the sequence \n is
+        passed to gh literally and shows up as the two characters \n in
+        the rendered comment; inside $'...' bash expands \n to a real
+        newline before gh sees it. Do NOT use --body-file, output
+        redirection, or HEREDOCs — the action sandbox blocks all three.
         The body must include the "Suggested test cases" list. If there
         is nothing to flag, the body is just "LGTM" followed by the
         test-case list. Inline comments via


### PR DESCRIPTION
<details><summary>Claude summary</summary>

Follow-up to #3660. The first auto-posted review came through with literal `\n` characters instead of newlines:

```
LGTM\n\nBoth changes are consistent and complementary: ...\n\n## Suggested test cases\n\n- qwen3_235b_a22b_64gpu_b300_bf16_perf
```

## Why

`gh pr comment --body "..."` does not interpret backslash escapes — `\n` inside a normal double-quoted shell string is two literal characters. The previous prompt told Claude `Use literal "\n" inside the quoted string for newlines`, which produced exactly the broken output above.

## What

Switch the example to bash ANSI-C quoting (`$'...\n...'`), which expands `\n` to a real newline before `gh` ever sees the body. Both auto-review and manual-review prompts updated.

```yaml
End the review by posting it as a top-level PR comment using
bash ANSI-C quoting so newlines render correctly:
  gh pr comment <PR NUMBER> --repo <REPO> --body $'line1\nline2\n...'
Use $'...' (NOT plain "..."). Inside "..." the sequence \n is
passed to gh literally and shows up as the two characters \n in
the rendered comment; inside $'...' bash expands \n to a real
newline before gh sees it.
```

## Test plan

- [ ] Trigger `/claude review` on a PR and confirm the rendered comment has real line breaks (not literal `\n`).

</details>
