### PR TITLE
[ci] fix: drop duplicated -gpu-x2 from runner label suffix

### DIFF
--- a/.github/workflows/build-test-publish-wheel.yml
+++ b/.github/workflows/build-test-publish-wheel.yml
@@ -59,7 +59,7 @@ jobs:
       has-src-dir: true
       skip-test-wheel: true
       custom-container: nvcr.io/nvidia/pytorch:25.11-py3
-      runner: ${{ needs.pre-flight.outputs.runner_prefix }}-gpu-x2-container
+      runner: ${{ needs.pre-flight.outputs.runner_prefix }}-container
       no-build-isolation: true
       submodules: recursive
       container-options: "--gpus all --runtime=nvidia"

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -124,7 +124,7 @@ jobs:
     if: |
       !(needs.pre-flight.outputs.docs_only == 'true'
       || needs.pre-flight.outputs.is_deployment_workflow == 'true')
-    runs-on: ${{ needs.pre-flight.outputs.runner_prefix }}-gpu-x2-container
+    runs-on: ${{ needs.pre-flight.outputs.runner_prefix }}-container
     name: UV - Python${{ matrix.python-version }} - AMD64/Linux - NGC PyTorch
     container:
       image: nvcr.io/nvidia/pytorch:25.05-py3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -80,7 +80,7 @@ jobs:
       has-src-dir: true
       skip-test-wheel: true
       custom-container: nvcr.io/nvidia/pytorch:25.05-py3
-      runner: ${{ needs.pre-flight.outputs.runner_prefix }}-gpu-x2-container
+      runner: ${{ needs.pre-flight.outputs.runner_prefix }}-container
       no-build-isolation: true
       app-id: ${{ vars.BOT_ID }}
       gh-release-use-changelog-builder: ${{ inputs.generate-changelog }}


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## What

Drop the duplicated `-gpu-x2` from the runner suffix appended in three workflows:

- `.github/workflows/build-test-publish-wheel.yml`
- `.github/workflows/install-test.yml`
- `.github/workflows/release.yaml`

## Why

The repo variable `DEFAULT_RUNNER_PREFIX` is set to `nemo-ci-aws-gpu-x2` (already includes the GPU-size segment). These workflows append `-gpu-x2-container` on top, producing `nemo-ci-aws-gpu-x2-gpu-x2-container` — a label no runner matches, so jobs sit queued forever.

Concretely, this caused [run 25316731236 / job 74215904191](https://github.com/NVIDIA-NeMo/Megatron-Bridge/actions/runs/25316731236/job/74215904191?pr=3433):

> Requested labels: `nemo-ci-aws-gpu-x2-gpu-x2-container`

`cicd-main.yml` is unaffected — it uses `runner_prefix` directly without appending.

## Result

The resulting label becomes `nemo-ci-aws-gpu-x2-container` as intended.

```yaml
# before
runner: ${{ needs.pre-flight.outputs.runner_prefix }}-gpu-x2-container
# after
runner: ${{ needs.pre-flight.outputs.runner_prefix }}-container
```

</details>
