### PR TITLE
[model, ckpt, docs] fix: support HF→Megatron conversion under decentralized PGs

### DIFF
--- a/examples/decentralized_pg/pretrain_qwen3_simple.py
+++ b/examples/decentralized_pg/pretrain_qwen3_simple.py
@@ -42,22 +42,23 @@ from megatron.bridge.training.pretrain import pretrain
 
 def main() -> None:
     """Run Qwen3 pretraining with decentralized process groups enabled."""
-    # Get the standard Qwen3 4B pretrain config with overrides
-    cfg = qwen3_4b_pretrain_config(
-        # Use mock data for demo
-        mock=True,
-        # Parallelism
-        tensor_model_parallel_size=2,
-        pipeline_model_parallel_size=2,
-        # Training settings (small for demo)
-        train_iters=100,
-        seq_length=1024,
-        global_batch_size=32,
-        micro_batch_size=1,
-        # LR schedule (must fit within train_iters)
-        lr_warmup_iters=10,
-        lr_decay_iters=100,
-    )
+    # Get the standard Qwen3 4B pretrain config and apply overrides directly on it.
+    # qwen3_4b_pretrain_config() takes no arguments — all overrides are applied
+    # to the returned ConfigContainer.
+    cfg = qwen3_4b_pretrain_config()
+    # Mock data: leaving cfg.dataset.blend as None (default in the recipe) yields mock data
+    # Parallelism
+    cfg.model.tensor_model_parallel_size = 2
+    cfg.model.pipeline_model_parallel_size = 2
+    # Training settings (small for demo)
+    cfg.train.train_iters = 100
+    cfg.model.seq_length = 1024
+    cfg.dataset.seq_length = 1024
+    cfg.train.global_batch_size = 32
+    cfg.train.micro_batch_size = 1
+    # LR schedule (must fit within train_iters)
+    cfg.scheduler.lr_warmup_iters = 10
+    cfg.scheduler.lr_decay_iters = 100
     # known issue with share_embeddings_and_output_weights
     cfg.model.share_embeddings_and_output_weights = False
 

--- a/examples/decentralized_pg/pretrain_qwen3_with_decentralized_pg.py
+++ b/examples/decentralized_pg/pretrain_qwen3_with_decentralized_pg.py
@@ -70,6 +70,7 @@ from megatron.core.utils import get_pg_rank
 from megatron.bridge.data.loaders import setup_data_iterators
 from megatron.bridge.data.utils import get_dataset_provider
 from megatron.bridge.models import AutoBridge
+from megatron.bridge.training.checkpointing import DefaultCheckpointManager
 from megatron.bridge.training.config import (
     CheckpointConfig,
     ConfigContainer,
@@ -436,7 +437,11 @@ def run_training(args: argparse.Namespace, pg_collection: ProcessGroupCollection
     # expect pg_collection to be passed explicitly rather than reading from mpu.
 
     bridge = AutoBridge.from_hf_pretrained("Qwen/Qwen3-4B")
-    model_cfg = bridge.to_megatron_provider()
+    # This demo trains a downsized Qwen3-4B (e.g. ``--num-layers 4``) on mock
+    # data with ``NullTokenizer``, so the architecture deliberately does not
+    # match the real Qwen3-4B HF checkpoint. Skip weight loading; the model is
+    # initialized randomly, which is what the manual-PG demo needs.
+    model_cfg = bridge.to_megatron_provider(load_weights=False)
 
     # Parallelism - must match what we used to create pg_collection
     model_cfg.tensor_model_parallel_size = args.tp_size
@@ -451,6 +456,9 @@ def run_training(args: argparse.Namespace, pg_collection: ProcessGroupCollection
     model_cfg.attention_softmax_in_fp32 = True
     model_cfg.make_vocab_size_divisible_by = 128
     model_cfg.vocab_size = None
+    # Known issue: tied embeddings rely on Megatron-Core globals during
+    # checkpoint save, which are not populated in the decentralized PG path.
+    model_cfg.share_embeddings_and_output_weights = False
 
     train_cfg = TrainingConfig(
         train_iters=args.train_iters,
@@ -612,6 +620,7 @@ def run_training(args: argparse.Namespace, pg_collection: ProcessGroupCollection
     print_rank_0("")
 
     # Run the training loop
+    checkpoint_manager = DefaultCheckpointManager(checkpoint_config=cfg.checkpoint)
     train(
         forward_step_func=forward_step,
         model=model,
@@ -620,7 +629,7 @@ def run_training(args: argparse.Namespace, pg_collection: ProcessGroupCollection
         train_data_iterator=train_data_iterator,
         valid_data_iterator=valid_data_iterator,
         global_state=state,
-        checkpointing_context={},
+        checkpoint_manager=checkpoint_manager,
         pg_collection=pg_collection,  # <-- Pass to training loop!
     )
 

--- a/src/megatron/bridge/models/conversion/model_bridge.py
+++ b/src/megatron/bridge/models/conversion/model_bridge.py
@@ -1479,8 +1479,10 @@ class MegatronModelBridge(MegatronPeftBridge, Generic[HFPreTrained, ModelProvide
         ):
             # Broadcast embeddings and output weights from rank 0 to embedding group
             embd_group = _get_embedding_group(megatron_model)
+            if embd_group is None:
+                return
             embd_group_ranks = torch.distributed.get_process_group_ranks(embd_group)
-            if embd_group is not None and torch.distributed.get_rank() in embd_group_ranks:
+            if torch.distributed.get_rank() in embd_group_ranks:
                 # Get embeddings and output weights from rank 0
                 if hasattr(unwrapped_model, "embedding") and hasattr(unwrapped_model.embedding, "word_embeddings"):
                     embd_weights = unwrapped_model.embedding.word_embeddings.weight.data

--- a/src/megatron/bridge/models/conversion/model_bridge.py
+++ b/src/megatron/bridge/models/conversion/model_bridge.py
@@ -39,6 +39,7 @@ from typing import (
 import torch
 from megatron.core import parallel_state
 from megatron.core.distributed.fsdp.mcore_fsdp_adapter import FullyShardedDataParallel
+from megatron.core.pipeline_parallel.utils import is_pp_first_stage, is_pp_last_stage
 from megatron.core.transformer.module import MegatronModule
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.utils import get_pg_size
@@ -167,6 +168,92 @@ class _HFNameSuffixMapping:
         return {f"{k}{self._suffix}": v for k, v in out.items()}
 
 
+def _get_pg_collection_from_model(
+    megatron_model: MegatronModule | List[MegatronModule] | None,
+):
+    """Return the ProcessGroupCollection attached to a Megatron model, if any.
+
+    Megatron-Core's ``LanguageModule`` (parent of ``GPTModel``) stores the
+    ``ProcessGroupCollection`` it was constructed with on ``self.pg_collection``.
+    When users wire process groups manually via ``HyperCommGrid`` (decentralized
+    PG path) the global ``parallel_state`` singleton is never populated, but the
+    same groups are available through the model. Return ``None`` when no model
+    is supplied or no ``pg_collection`` is reachable so callers can fall back to
+    ``parallel_state``.
+    """
+    if megatron_model is None:
+        return None
+    models_list = megatron_model if isinstance(megatron_model, list) else [megatron_model]
+    if not models_list:
+        return None
+    unwrapped = unwrap_model(models_list[0])
+    # VLM wrappers expose the language model on ``.language_model``; the
+    # ``pg_collection`` lives on the inner ``LanguageModule``.
+    inner = getattr(unwrapped, "language_model", None)
+    if inner is not None:
+        unwrapped = inner
+    return getattr(unwrapped, "pg_collection", None)
+
+
+def _get_pp_group(megatron_model: MegatronModule | List[MegatronModule] | None):
+    """Return the pipeline-parallel group, preferring the model's pg_collection."""
+    pg = _get_pg_collection_from_model(megatron_model)
+    pp_group = getattr(pg, "pp", None) if pg is not None else None
+    if pp_group is not None:
+        return pp_group
+    return parallel_state.get_pipeline_model_parallel_group()
+
+
+def _get_pp_rank(megatron_model: MegatronModule | List[MegatronModule] | None) -> int:
+    """Return the pipeline-parallel rank, preferring the model's pg_collection."""
+    pg = _get_pg_collection_from_model(megatron_model)
+    pp_group = getattr(pg, "pp", None) if pg is not None else None
+    if pp_group is not None:
+        return torch.distributed.get_rank(group=pp_group)
+    return parallel_state.get_pipeline_model_parallel_rank()
+
+
+def _get_embedding_group(megatron_model: MegatronModule | List[MegatronModule] | None):
+    """Return the embedding group, preferring the model's pg_collection."""
+    pg = _get_pg_collection_from_model(megatron_model)
+    embd_group = getattr(pg, "embd", None) if pg is not None else None
+    if embd_group is not None:
+        return embd_group
+    return parallel_state.get_embedding_group()
+
+
+def _get_ep_group(megatron_model: MegatronModule | List[MegatronModule] | None):
+    """Return the expert-parallel group, preferring the model's pg_collection.
+
+    Returns ``None`` if the model has a ``pg_collection`` whose ``ep`` is ``None``
+    (typical for dense models in the decentralized PG path), so callers must
+    treat ``None`` as "EP size 1".
+    """
+    pg = _get_pg_collection_from_model(megatron_model)
+    if pg is not None:
+        return getattr(pg, "ep", None)
+    return parallel_state.get_expert_model_parallel_group()
+
+
+def _install_pg_collection_on_mappings(
+    mapping_registry: MegatronMappingRegistry,
+    megatron_model: MegatronModule | List[MegatronModule] | None,
+) -> None:
+    """Install the model's ``pg_collection`` onto every param mapping.
+
+    ``MegatronParamMapping.__init__`` snapshots Megatron-Core's ``mpu`` globals
+    when the registry is built. In the decentralized PG path those globals are
+    never populated, so the snapshot is all ``None`` and ``tp_size`` collapses
+    to ``world_size``. Re-install the user-supplied groups before running tasks
+    so per-mapping shape calculations match the actual parallelism topology.
+    """
+    pg_collection = _get_pg_collection_from_model(megatron_model)
+    if pg_collection is None:
+        return
+    for mapping in mapping_registry.get_all_mappings():
+        mapping.set_process_groups_from_pg_collection(pg_collection)
+
+
 def _megatron_local_name_to_global(
     models: MegatronModule | List[MegatronModule],
     config: TransformerConfig,
@@ -175,7 +262,7 @@ def _megatron_local_name_to_global(
 ) -> str:
     """Adjust layer number and expert number from local to global numbering."""
     # PP
-    pp_group = parallel_state.get_pipeline_model_parallel_group()
+    pp_group = _get_pp_group(models)
     if "layers." in param_name and get_pg_size(pp_group) > 1:
         match = re.match(r"^(.+?\.layers\.\d+)", param_name)
         assert match is not None
@@ -190,10 +277,12 @@ def _megatron_local_name_to_global(
                 f"layers.{global_layer_number}.",
             )
 
-    # EP
-    ep_group = parallel_state.get_expert_model_parallel_group()
-    # For now adapters are not sharded across EP ranks
-    if ".mlp.experts.linear_fc" in param_name and get_pg_size(ep_group) > 1 and not ".adapter." in param_name:
+    # EP — fetched lazily because dense models may not have an EP group at all
+    # (and for the decentralized PG path, ``pg_collection.ep`` may be ``None``).
+    # For now adapters are not sharded across EP ranks.
+    is_expert_param = ".mlp.experts.linear_fc" in param_name and not ".adapter." in param_name
+    ep_group = _get_ep_group(models) if is_expert_param else None
+    if is_expert_param and ep_group is not None and get_pg_size(ep_group) > 1:
         num_experts = config.num_moe_experts
         num_experts_per_rank = num_experts // ep_group.size()
 
@@ -661,7 +750,7 @@ class MegatronModelBridge(MegatronPeftBridge, Generic[HFPreTrained, ModelProvide
             return self._cached_param_names
 
         # Compute the result
-        pp_group = parallel_state.get_pipeline_model_parallel_group()
+        pp_group = _get_pp_group(megatron_model)
         model_config = unwrap_model(megatron_model)[0].config
         global_param_names = []
 
@@ -1384,11 +1473,12 @@ class MegatronModelBridge(MegatronPeftBridge, Generic[HFPreTrained, ModelProvide
         share_embeddings = self._share_embeddings_and_output_weights(model_config)
 
         # TODO(yuya): Fix for VPP, the vp stage needs to be passed in for stage checks
+        pp_group = _get_pp_group(megatron_model)
         if (share_embeddings and model_config.pipeline_model_parallel_size > 1) and (
-            parallel_state.is_pipeline_first_stage() or parallel_state.is_pipeline_last_stage()
+            is_pp_first_stage(pp_group) or is_pp_last_stage(pp_group)
         ):
             # Broadcast embeddings and output weights from rank 0 to embedding group
-            embd_group = parallel_state.get_embedding_group()
+            embd_group = _get_embedding_group(megatron_model)
             embd_group_ranks = torch.distributed.get_process_group_ranks(embd_group)
             if embd_group is not None and torch.distributed.get_rank() in embd_group_ranks:
                 # Get embeddings and output weights from rank 0
@@ -1448,10 +1538,11 @@ class MegatronModelBridge(MegatronPeftBridge, Generic[HFPreTrained, ModelProvide
         hf_keys: Optional[Iterable[str]] = hf_pretrained.state.source.get_all_keys() if has_hf_state else None
 
         mapping_registry = self.mapping_registry()
+        _install_pg_collection_on_mappings(mapping_registry, megatron_model)
         unwrapped_model = unwrap_model(megatron_model)[0]
         model_config = unwrapped_model.config
         embeddings_are_tied = self._share_embeddings_and_output_weights(model_config)
-        pp_rank = parallel_state.get_pipeline_model_parallel_rank()
+        pp_rank = _get_pp_rank(megatron_model)
         sorted_global_param_names_all_pp_ranks = self._megatron_global_param_names_all_pp_ranks(megatron_model)
 
         # Filter out output_layer related parameters if embeddings are tied
@@ -1630,8 +1721,9 @@ class MegatronModelBridge(MegatronPeftBridge, Generic[HFPreTrained, ModelProvide
         unwrapped_model = unwrap_model(megatron_model)[0]
         model_config = unwrapped_model.config
         embeddings_are_tied = self._share_embeddings_and_output_weights(model_config)
-        pp_rank = parallel_state.get_pipeline_model_parallel_rank()
-        pp_group = parallel_state.get_pipeline_model_parallel_group()
+        _install_pg_collection_on_mappings(mapping_registry, megatron_model)
+        pp_rank = _get_pp_rank(megatron_model)
+        pp_group = _get_pp_group(megatron_model)
         sorted_global_param_names_all_pp_ranks = self._megatron_global_param_names_all_pp_ranks(megatron_model)
 
         # Filter out output_layer related parameters if embeddings are tied

--- a/src/megatron/bridge/models/conversion/param_mapping.py
+++ b/src/megatron/bridge/models/conversion/param_mapping.py
@@ -128,6 +128,28 @@ class MegatronParamMapping(ABC, Generic[WeightType]):
         # allow_hf_name_mismatch should be set to True to bypass a check in `build_conversion_tasks`
         self.allow_hf_name_mismatch = False
 
+    def set_process_groups_from_pg_collection(self, pg_collection: Any) -> None:
+        """Override snapshotted Megatron-Core globals with a ``ProcessGroupCollection``.
+
+        Used by the decentralized PG path where ``mpu`` is never initialized.
+        ``__init__`` runs at registry construction time and snapshots whatever
+        Megatron-Core globals exist then; in the decentralized path those are
+        absent, so ``tp_size`` would default to ``world_size`` and conversions
+        would compute the wrong shard sizes. ``MegatronModelBridge`` calls this
+        right before running tasks to install the user-supplied groups.
+        """
+        if pg_collection is None:
+            return
+        for attr, field in (
+            ("pp_group", "pp"),
+            ("ep_group", "ep"),
+            ("_tp_group", "tp"),
+            ("_etp_group", "expt_tp"),
+        ):
+            group = getattr(pg_collection, field, None)
+            if group is not None:
+                setattr(self, attr, group)
+
     @property
     def tp_group(self):
         """Get the tensor model parallel group."""


### PR DESCRIPTION
## Summary

Two of three `examples/decentralized_pg/` examples failed on `nvcr.io/nvidian/nemo:26.04.rc7`. The bug in `pretrain_qwen3_with_decentralized_pg.py` is the load-bearing one: with `use_decentralized_pg=True`, Megatron-Core's `mpu` globals are never populated — process groups live only inside the user's `ProcessGroupCollection`. Two layers of the bridge were still reading those globals and asserted at HF→Megatron conversion time.

- `model_bridge.build_conversion_tasks` and `_broadcast_shared_embeddings` called `parallel_state.get_pipeline_model_parallel_*` / `get_embedding_group` unconditionally.
- `MegatronParamMapping.__init__` snapshotted `mpu` groups at registry construction; in the decentralized path the snapshot was all `None`, so `tp_size` collapsed to `world_size` and shape calculations were wrong.

This PR resolves PP/EP/embedding groups from the model's `pg_collection` (set by `LanguageModule`) with a fallback to `parallel_state` for the legacy MPU path, and adds `MegatronParamMapping.set_process_groups_from_pg_collection` so the bridge re-installs the user-supplied groups onto every mapping before running tasks. The four `parallel_state.*` call sites the bug report cited (and one EP sister site uncovered while testing) now go through small `_get_*` helpers.

Also refresh the two `decentralized_pg/` examples that the bug report cited — they had drifted from the recipe and training APIs:

- `pretrain_qwen3_simple.py`: `qwen3_4b_pretrain_config()` no longer takes any args; apply overrides on the returned config.
- `pretrain_qwen3_with_decentralized_pg.py`: `train()` takes `checkpoint_manager` (not `checkpointing_context`); add `share_embeddings_and_output_weights=False` to skirt the known MCore-globals issue during checkpoint save; `load_weights=False` since the demo deliberately downsizes the model and uses `NullTokenizer`.

## Test plan

Verified end-to-end on 4×H100 against the bug report's reproduction commands:

- [x] **Simple example** — exercises the fix end-to-end (HF Qwen3-4B weights loaded through the decentralized PG path):
  \`\`\`
  uv run python -m torch.distributed.run --nproc_per_node=4 \\
    examples/decentralized_pg/pretrain_qwen3_simple.py
  \`\`\`
  100 iters with TP=2 PP=2; lm loss 6.17 → 0.02.
- [x] **Manual example** — exercises the manual \`HyperCommGrid\` PG creation API:
  \`\`\`
  uv run python -m torch.distributed.run --nproc_per_node=4 \\
    examples/decentralized_pg/pretrain_qwen3_with_decentralized_pg.py \\
    --tp-size 2 --pp-size 2 --train-iters 5 --global-batch-size 4 --micro-batch-size 1
  \`\`\`
  5 iters with TP=2 PP=2 plus checkpoint save → "Training complete!".
- [x] Existing unit tests pass for the touched paths: \`tests/unit_tests/models/test_param_mapping.py\`, \`test_mapping_registry.py\`, \`test_auto_bridge.py\` (133 passed; one pre-existing failure on \`test_export_adapter_weights\` is unrelated and reproduces on \`main\`), \`test_qwen3_bridge.py\` (23 passed).
- [x] Cherry-pick to \`r0.4.0\` was prepared and applied (see linked PR); not a clean cherry-pick — see notes there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)