### PR TITLE
fix(test): remove unused HFWeightTuple import

### DIFF
--- a/tests/unit_tests/models/test_auto_bridge.py
+++ b/tests/unit_tests/models/test_auto_bridge.py
@@ -24,7 +24,6 @@ from transformers import LlamaConfig
 from transformers.configuration_utils import PretrainedConfig
 
 from megatron.bridge.models.conversion.auto_bridge import AutoBridge
-from megatron.bridge.models.conversion.model_bridge import HFWeightTuple
 from megatron.bridge.models.gpt_provider import GPTModelProvider
 from megatron.bridge.models.hf_pretrained.causal_lm import PreTrainedCausalLM
 


### PR DESCRIPTION
## Summary

- Leftover unused import from the stale duplicate test removed in #3676.
- Fixes the ruff F401 lint error on `main`.

## Test plan

- [ ] `uv run ruff check .` passes
- [ ] `uv run pytest tests/unit_tests/models/test_auto_bridge.py::TestAutoBridge::test_export_adapter_weights` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)