### PR TITLE
fix(llama): cuda_graph_scope must be a list, not a comma-separated st…

### DIFF
--- a/scripts/performance/configs/llama/llama3_workload_base_configs.py
+++ b/scripts/performance/configs/llama/llama3_workload_base_configs.py
@@ -260,7 +260,7 @@ LLAMA3_70B_PRETRAIN_CONFIG_GB200_NVFP4_V2 = replace(
     virtual_pipeline_model_parallel_size=5,
     context_parallel_size=1,
     cuda_graph_impl="transformer_engine",
-    cuda_graph_scope="mlp,attn",
+    cuda_graph_scope=["mlp", "attn"],
 )
 
 


### PR DESCRIPTION
## What

One-line fix in `LLAMA3_70B_PRETRAIN_CONFIG_GB200_NVFP4_V2`:

```diff
-    cuda_graph_scope="mlp,attn",
+    cuda_graph_scope=["mlp", "attn"],