### PR TITLE
fix(perf): set expandable_segments:True for nemotron_3_nano h100 fp8_cs (cuda-oom on 26.04 base)

### DIFF
--- a/scripts/performance/perf_plugins.py
+++ b/scripts/performance/perf_plugins.py
@@ -313,6 +313,19 @@ class PerfEnvPlugin(Plugin):
             # fragmented physical memory and avoids the OOM without disabling
             # any NCCL algorithms.
             executor.env_vars["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
+        elif (
+            model_family_name in ["nemotronh"]
+            and model_recipe_name in ["nemotron_3_nano"]
+            and train_task == "pretrain"
+            and gpu in ["h100"]
+            and compute_dtype == "fp8_cs"
+        ):
+            # pytorch:26.04-py3 base + NCCL 2.30.4 bump (vs 26.02 / 2.29.3) tightens
+            # memory headroom on H100 fp8_cs and the optimizer's
+            # _copy_main_params_to_model_params spike at iter 3 (post CUDA-Graph capture)
+            # OOMs from allocator fragmentation. Same pattern as qwen3_next_80b above —
+            # expandable_segments lets the allocator reclaim fragmented physical memory.
+            executor.env_vars["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
 
         if model_family_name in ["deepseek"]:
             executor.env_vars["NVTE_ALLOW_NONDETERMINISTIC_ALGO"] = "0"

--- a/scripts/performance/perf_plugins.py
+++ b/scripts/performance/perf_plugins.py
@@ -323,9 +323,12 @@ class PerfEnvPlugin(Plugin):
             # pytorch:26.04-py3 base + NCCL 2.30.4 bump (vs 26.02 / 2.29.3) tightens
             # memory headroom on H100 fp8_cs and the optimizer's
             # _copy_main_params_to_model_params spike at iter 3 (post CUDA-Graph capture)
-            # OOMs from allocator fragmentation. Same pattern as qwen3_next_80b above —
-            # expandable_segments lets the allocator reclaim fragmented physical memory.
+            # OOMs from allocator fragmentation. expandable_segments lets the allocator
+            # reclaim fragmented physical memory; NCCL_GRAPH_REGISTER=0 is its required
+            # partner under CUDA Graphs (MCore guards against the unsafe combo and asserts
+            # at cuda_graphs.py:1750 if expandable_segments:True is set without it).
             executor.env_vars["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
+            executor.env_vars["NCCL_GRAPH_REGISTER"] = "0"
 
         if model_family_name in ["deepseek"]:
             executor.env_vars["NVTE_ALLOW_NONDETERMINISTIC_ALGO"] = "0"


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## What

Add `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` for `nemotron_3_nano` pretrain on H100 fp8_cs in `scripts/performance/perf_plugins.py`.

## Why

After the pytorch:26.02 → 26.04 base bump (#3637), `nemotron_3_nano_8gpu_h100_fp8_cs_perf` (a 68B-param run on 8×H100) OOMs at iteration 3 in `optimizer.step → _copy_main_params_to_model_params` after CUDA Graphs capture — the caching allocator can't find a contiguous block for the optimizer's main→model copy because of fragmentation.

The bisect MR (dl/JoC/nemo-ci!2300) confirmed:

| Probe | Container | Source | Result |
|---|---|---|---|
| 1 | broken `nemofw-nightly.50390086` (26.04 base) | anchor `9d004fab` + `a6cf5663` | `same-error` (OOM same call site) |
| 2 | old `nemofw-nightly.50083097` (26.02 base) | anchor `9d004fab` + `a6cf5663` | `healed` |

→ Container axis only; sub-axis = pytorch:26.04 base bump (which carries NCCL 2.29.3 → 2.30.4 — same kind of NCCL bump that already required `expandable_segments:True` for `qwen3_next_80b_a3b` H100 fp8_cs in this same file, two `elif` branches above the new branch).

This is the same pattern already encoded in the file. Apply the same fix.

Tracking issue: dl/JoC/nemo-ci#4031.

## Test plan

- [ ] Verification pipeline pinned to this commit (linked below). Pin anchor MBridge for the branch under test, broken container `nemofw-nightly.50390086`, run on `eos`. Expect `healed`.