### PR TITLE
[build] chore: bump package version to 0.4.2

### DIFF
--- a/src/megatron/bridge/package_info.py
+++ b/src/megatron/bridge/package_info.py
@@ -15,7 +15,7 @@
 
 MAJOR = 0
 MINOR = 4
-PATCH = 1
+PATCH = 2
 PRE_RELEASE = ""
 
 # Use the following formatting: (major, minor, patch, pre-release)


### PR DESCRIPTION
<details><summary>Claude summary</summary>

Bumps `src/megatron/bridge/package_info.py` to version `0.4.2` for the `r0.4.0` release branch.

```python
PATCH = 2  # was 1
```

Resulting `__version__`: `0.4.2`.

</details>
