### PR TITLE
build(docker): parameterize DEEPEP_REPO_URL for fork overrides

### DIFF
--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -38,6 +38,7 @@ RUN curl -LsSf https://astral.sh/uv/${UV_VERSION}/install.sh | sh && \
 
 ARG INSTALL_DEEPEP=True
 ARG DEEPEP_COMMIT=34152ae28f80bcc3ee38d7a12cb2ad87cfd4ea72
+ARG DEEPEP_REPO_URL=https://github.com/deepseek-ai/DeepEP.git
 
 ENV HYBRID_EP_MULTINODE=1
 ENV RDMA_CORE_HOME=/opt/rdma-core/build
@@ -59,7 +60,7 @@ RUN --mount=type=bind,source=docker/patches/deepep.patch,target=/opt/deepep.patc
     mkdir -p ${RDMA_CORE_HOME} && \
     ln -sfn /usr/include ${RDMA_CORE_HOME}/include && \
     ln -sfn /usr/lib/${ARCH_LIB} ${RDMA_CORE_HOME}/lib && \
-    git clone https://github.com/deepseek-ai/DeepEP.git && \
+    git clone ${DEEPEP_REPO_URL} DeepEP && \
     pushd DeepEP && \
         git pull && \
         git fetch origin $DEEPEP_COMMIT && \


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## What

Add an `ARG DEEPEP_REPO_URL=https://github.com/deepseek-ai/DeepEP.git` to `docker/Dockerfile.ci` so the DeepEP install stage's `git clone` can be redirected to a fork. Defaults to upstream — no behavior change when the override isn't passed.

## Why

DeepEP `34152ae` (the currently-pinned commit on `hybrid-ep`) is missing upstream PR #564 *"Nvshmem 3 5 runtime fixes"* (squash-merged to `main` as `29d31c0`). PR #564 is **not** on the `hybrid-ep` branch — needs to be cherry-picked there. Until that cherry-pick lands upstream, we need to point the build at a fork that carries it (in this case: `ko3n1g/DeepEP`, branch `ko3n1g/fix/nvshmem-3.5-runtime-fixes-on-hybrid-ep`, commit `379eef7a927d15a092fb3037d359caa5187c007a`) so we can verify the fix.

PR #564 fixes two compounding ABI breaks in NVSHMEM 3.5+ that are responsible for the multi-node B200 DeepEP `dispatch CPU` timeout under the pytorch:26.04 container (`moe_recv_*_counter[*] = -1`):
1. Force `__CUDACC_RDC__` when NVSHMEM is enabled, so DeepEP doesn't end up with a static shadow copy of `nvshmemi_ibgda_device_state_d`.
2. Templated `ibgda_get_rc` dispatching on `nvshmemi_ibgda_device_state_v1` vs `_v2`, since the RC-QP array layout changed in NVSHMEM 3.5.21.

See the analysis in `dl/JoC/nemo-ci`#4032.

## Test plan

- [ ] nemo-ci probe: bump `DEEPEP_REF` to `379eef7a927d15a092fb3037d359caa5187c007a` and pass `DEEPEP_REPO_URL=https://github.com/ko3n1g/DeepEP.git` as a `--build-arg`. Run `qwen3_next_80b_a3b_b200_fp8_mx_50steps_perf` on prenyx; expect heal.

</details>
