### PR TITLE
ci: Major refactor of release-workflows

### DIFF
--- a/.github/workflows/config/changelog-config.json
+++ b/.github/workflows/config/changelog-config.json
@@ -1,7 +1,7 @@
 {
     "categories": [],
     "ignore_labels": [
-      "ignore"
+        "ignore"
     ],
     "sort": "ASC",
     "template": "\n${{CHANGELOG}}\n\n<details><summary>Changelog Details</summary>\n\n${{UNCATEGORIZED}}\n</details>\n",
@@ -9,16 +9,21 @@
     "commit_template": "- ${{TITLE}} by @${{AUTHOR}}",
     "empty_template": "${{OWNER}}\n${{REPO}}\n${{FROM_TAG}}\n${{TO_TAG}}",
     "duplicate_filter": {
-      "pattern": ".+",
-      "on_property": "title",
-      "method": "match"
+        "pattern": ".+",
+        "on_property": "title",
+        "method": "match"
     },
-    "transformers": [],
+    "transformers": [
+        {
+            "pattern": "^cp:\\s*`(.+?)`\\s*into\\s*\\S+",
+            "target": "$1"
+        }
+    ],
     "max_tags_to_fetch": 100,
     "max_pull_requests": 500,
     "max_back_track_time_days": 365,
     "exclude_merge_branches": [],
     "tag_resolver": {
-      "method": "semver"
+        "method": "semver"
     }
 }

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -77,11 +77,10 @@ jobs:
       default_test_data_path: ${{ vars.DEFAULT_TEST_DATA_PATH }}
       non_nvidia_test_data_path: ${{ vars.NON_NVIDIA_TEST_DATA_PATH }}
       sso_users_filename: ${{ vars.SSO_USERS_FILENAME }}
-    secrets:
-      NVIDIA_MANAGEMENT_ORG_PAT: ${{ secrets.NVIDIA_MANAGEMENT_ORG_PAT }}
+    secrets: inherit
 
   release:
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@43d259e5b5f0a6cb4c14eefa04738a5bdf316fe1
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@d2f3dd32aad11b7034f3f1821174556507d61670
     needs: [pre-flight]
     if: |
       github.event_name == 'workflow_dispatch'
@@ -110,18 +109,7 @@ jobs:
       container-options: "--gpus all --runtime=nvidia"
       extra-no-build-isolation-packages: "grpcio-tools"
       restrict-to-admins: true
-    secrets:
-      TWINE_USERNAME: __token__
-      TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-      SLACK_WEBHOOK_ADMIN: ${{ secrets.SLACK_TEAM_GROUP_ID }}
-      BOT_KEY: ${{ secrets.BOT_KEY }}
-      AWS_ASSUME_ROLE_ARN: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AKAMAI_HOST: ${{ secrets.AKAMAI_HOST }}
-      AKAMAI_CLIENT_TOKEN: ${{ secrets.AKAMAI_CLIENT_TOKEN }}
-      AKAMAI_CLIENT_SECRET: ${{ secrets.AKAMAI_CLIENT_SECRET }}
-      AKAMAI_ACCESS_TOKEN: ${{ secrets.AKAMAI_ACCESS_TOKEN }}
+    secrets: inherit
       S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
 
   release-summary:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -81,7 +81,7 @@ jobs:
       NVIDIA_MANAGEMENT_ORG_PAT: ${{ secrets.NVIDIA_MANAGEMENT_ORG_PAT }}
 
   release:
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@cb5e93b1737dab3e8bfb87d8d9b743cd1d92f6d6
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@43d259e5b5f0a6cb4c14eefa04738a5bdf316fe1
     needs: [pre-flight]
     if: |
       github.event_name == 'workflow_dispatch'
@@ -114,7 +114,6 @@ jobs:
       TWINE_USERNAME: __token__
       TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
       SLACK_WEBHOOK_ADMIN: ${{ secrets.SLACK_TEAM_GROUP_ID }}
-      SLACK_WEBHOOK: ${{ secrets.SLACK_RELEASE_ENDPOINT }}
       BOT_KEY: ${{ secrets.BOT_KEY }}
       AWS_ASSUME_ROLE_ARN: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -80,7 +80,7 @@ jobs:
     secrets: inherit
 
   release:
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@d2f3dd32aad11b7034f3f1821174556507d61670
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@64293f6d11ccd1a14a8d23c403761a543b4c21f9
     needs: [pre-flight]
     if: |
       github.event_name == 'workflow_dispatch'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -81,7 +81,7 @@ jobs:
       NVIDIA_MANAGEMENT_ORG_PAT: ${{ secrets.NVIDIA_MANAGEMENT_ORG_PAT }}
 
   release:
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@b57ebf9bc8e9f7e60cd84f196e0afc8f774a3045
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@cb5e93b1737dab3e8bfb87d8d9b743cd1d92f6d6
     needs: [pre-flight]
     if: |
       github.event_name == 'workflow_dispatch'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -81,7 +81,7 @@ jobs:
       NVIDIA_MANAGEMENT_ORG_PAT: ${{ secrets.NVIDIA_MANAGEMENT_ORG_PAT }}
 
   release:
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@2f00056b5f23aa546dd2587652b63dc359e94317
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@b57ebf9bc8e9f7e60cd84f196e0afc8f774a3045
     needs: [pre-flight]
     if: |
       github.event_name == 'workflow_dispatch'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -110,7 +110,6 @@ jobs:
       extra-no-build-isolation-packages: "grpcio-tools"
       restrict-to-admins: true
     secrets: inherit
-      S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
 
   release-summary:
     needs: [pre-flight, release]

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -113,13 +113,7 @@ jobs:
 
   release-summary:
     needs: [pre-flight, release]
-    if: |
-      (
-        needs.pre-flight.outputs.docs_only == 'true'
-        || needs.pre-flight.outputs.is_deployment_workflow == 'true'
-        || always()
-      )
-      && !cancelled()
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - name: Result

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -83,8 +83,8 @@ jobs:
     uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@v1.0.0
     needs: [pre-flight]
     if: |
-      github.event_name == 'workflow_dispatch'
-      || !(needs.pre-flight.outputs.docs_only == 'true'
+      !cancelled() && !failure()
+      && !(needs.pre-flight.outputs.docs_only == 'true'
            || needs.pre-flight.outputs.is_deployment_workflow == 'true')
     with:
       release-ref: ${{ inputs.release-ref || github.sha }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -77,7 +77,7 @@ jobs:
       default_test_data_path: ${{ vars.DEFAULT_TEST_DATA_PATH }}
       non_nvidia_test_data_path: ${{ vars.NON_NVIDIA_TEST_DATA_PATH }}
       sso_users_filename: ${{ vars.SSO_USERS_FILENAME }}
-    secrets: inherit
+    secrets: inherit  # pragma: allowlist secret
 
   release:
     uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@v1.0.0
@@ -109,7 +109,7 @@ jobs:
       container-options: "--gpus all --runtime=nvidia"
       extra-no-build-isolation-packages: "grpcio-tools"
       restrict-to-admins: true
-    secrets: inherit
+    secrets: inherit  # pragma: allowlist secret
 
   release-summary:
     needs: [pre-flight, release]

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -80,7 +80,7 @@ jobs:
     secrets: inherit
 
   release:
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@64293f6d11ccd1a14a8d23c403761a543b4c21f9
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@v1.0.0
     needs: [pre-flight]
     if: |
       github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
## Why

See the design discussion in NVIDIA-NeMo/FW-CI-templates#466.

## What

- **Delete** `.github/workflows/build-test-publish-wheel.yml`.
- **Rewrite** `.github/workflows/release.yaml` as the single caller for both `push` and `workflow_dispatch`.

## Test plan

- [ ] PR validate-only (push (mirror), sha 5eeb09acd9, 2026-05-07T11:28:02Z, success): https://github.com/NVIDIA-NeMo/Megatron-Bridge/actions/runs/25493015919
- [ ] `workflow_dispatch dry-run=true` (sha 5eeb09acd9, 2026-05-07T11:28:49Z, success): https://github.com/NVIDIA-NeMo/Megatron-Bridge/actions/runs/25493050305
- [ ] Real release via `workflow_dispatch dry-run=false` on the next planned RC.

## Rollout

1. Land FW-CI-templates#466.
2. Cut FW-CI-templates `v1.0.0`.
3. Bump the SHA pin in this PR → tag.
