### PR TITLE
[training] feat: port mcore PR #4687 MoE memory estimator fix

### DIFF
--- a/src/megatron/bridge/training/utils/theoretical_memory_utils.py
+++ b/src/megatron/bridge/training/utils/theoretical_memory_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,10 +29,16 @@ NUM_BYTES_IN_MEGABYTE: int = 1024 * 1024
 def compute_weight_and_optimizer_memory(config: ConfigContainer, verbose: bool = False) -> float:
     """Compute theoretical memory footprint for model weights and optimizer states.
 
-    Calculates the number of parameters for the model based on the configuration,
-    determines the number of parameters on the most loaded shard considering
-    pipeline and tensor parallelism, and estimates the memory needed based on
-    bytes per parameter (considering precision and optimizer type).
+    Splits parameters into three buckets — regular tensor-parallel-sharded,
+    replicated, and routed-expert — and applies the correct sharding factor
+    per bucket. Routed experts are sharded by ``expert_tensor_parallel_size *
+    expert_model_parallel_size``, with distributed-optimizer state sized by the
+    expert data-parallel domain. Other parameters use the regular TP and DP
+    domains. Supports MoE with optional shared experts, multi-latent attention
+    (DeepSeek), and Multi-Token Prediction (MTP) blocks.
+
+    Ported from ``megatron/training/theoretical_memory_usage.py`` in
+    Megatron-LM (NVIDIA/Megatron-LM PR #4687).
 
     Args:
         config (ConfigContainer): The main configuration container.
@@ -54,43 +60,271 @@ def compute_weight_and_optimizer_memory(config: ConfigContainer, verbose: bool =
     # MoE.
     num_experts = 1 if model_config.num_moe_experts is None else model_config.num_moe_experts
     gated_linear_multiplier = 3 / 2 if model_config.gated_linear_unit and model_config.activation_func == F.silu else 1
-    num_parameters_in_transformer_layers = (
-        2
-        * model_config.num_layers
-        * model_config.hidden_size
-        * model_config.hidden_size
-        * (
+
+    shared_expert_ffn_hidden_size = (
+        0
+        if model_config.moe_shared_expert_intermediate_size is None
+        else model_config.moe_shared_expert_intermediate_size
+    )
+
+    if model_config.num_moe_experts is not None:
+        if isinstance(model_config.moe_layer_freq, int):
+            moe_layer_pattern = [
+                1 if (i % model_config.moe_layer_freq == 0) else 0 for i in range(model_config.num_layers)
+            ]
+        elif isinstance(model_config.moe_layer_freq, list):
+            moe_layer_pattern = model_config.moe_layer_freq
+            assert len(moe_layer_pattern) == model_config.num_layers, (
+                f"Invalid length of moe_layer_pattern: {len(moe_layer_pattern)}, "
+                f"expected {model_config.num_layers}, "
+                f"current moe layer pattern: {model_config.moe_layer_freq}"
+            )
+        else:
+            raise TypeError(f"moe_layer_freq must be int or list, got {type(model_config.moe_layer_freq).__name__}")
+
+        num_dense_layers = model_config.num_layers - sum(moe_layer_pattern)
+        num_moe_layers = sum(moe_layer_pattern)
+        moe_ffn_hidden_size = model_config.moe_ffn_hidden_size
+    else:
+        moe_layer_pattern = [0] * model_config.num_layers
+        num_dense_layers = model_config.num_layers
+        num_moe_layers = 0
+        moe_ffn_hidden_size = 0
+    assert num_dense_layers + num_moe_layers == model_config.num_layers
+
+    mtp_num_layers = getattr(model_config, "mtp_num_layers", None)
+    if mtp_num_layers is not None:
+        mtp_layer_is_moe = moe_layer_pattern[-1]
+        mtp_num_moe_layers = mtp_layer_is_moe * mtp_num_layers
+        mtp_num_dense_layers = (1 - mtp_layer_is_moe) * mtp_num_layers
+    else:
+        mtp_num_moe_layers = 0
+        mtp_num_dense_layers = 0
+
+    # RMSNorm does not have bias, but LayerNorm has.
+    norm_size = 1 if model_config.normalization == "RMSNorm" else 2
+
+    if getattr(model_config, "multi_latent_attention", False):
+        q_lora_rank = getattr(model_config, "q_lora_rank", None)
+        kv_lora_rank = model_config.kv_lora_rank
+        qk_head_dim = model_config.qk_head_dim
+        qk_pos_emb_head_dim = model_config.qk_pos_emb_head_dim
+        v_head_dim = model_config.v_head_dim
+        if q_lora_rank is None:
+            q_term = model_config.hidden_size * model_config.num_attention_heads * (qk_head_dim + qk_pos_emb_head_dim)
+        else:
+            # q lora + rope + q norm
+            q_term = q_lora_rank * (
+                model_config.hidden_size
+                + model_config.num_attention_heads * (qk_head_dim + qk_pos_emb_head_dim)
+                + norm_size
+            )
+
+        self_attn_term = (
+            q_term
+            # kv lora + rope + kv norm
+            + kv_lora_rank
+            * (model_config.hidden_size + model_config.num_attention_heads * (qk_head_dim + v_head_dim) + norm_size)
+            + model_config.hidden_size * qk_pos_emb_head_dim
+            # o proj
+            + (model_config.num_attention_heads * v_head_dim) * model_config.hidden_size
+        )
+    else:
+        # Self-attention linear weights: fused QKV plus output projection.
+        self_attn_term = (
+            2
+            * model_config.hidden_size
+            * model_config.hidden_size
+            *
             # Attention.
             ((1 + (num_query_groups / model_config.num_attention_heads)) * query_projection_to_hidden_size_ratio)
-            # MLP.
-            + ((model_config.ffn_hidden_size / model_config.hidden_size) * num_experts * gated_linear_multiplier)
-            # Transformer layernorms.
-            + (2 / model_config.hidden_size)
-            # Final layernorm.
-            + (1 / (model_config.num_layers * model_config.hidden_size))
         )
+
+    # Per-layer attention linear parameters, sharded by the regular tensor-parallel group.
+    num_parameters_in_attention = self_attn_term
+    # Per-layer dense MLP parameters
+    num_parameters_in_dense_mlp = 2 * model_config.hidden_size * model_config.ffn_hidden_size * gated_linear_multiplier
+    # Per-layer routed expert MLP parameters across all experts
+    num_parameters_in_routed_experts = (
+        2 * model_config.hidden_size * moe_ffn_hidden_size * num_experts * gated_linear_multiplier
     )
+    # Per-layer routed expert parameters active for one token; top-k experts are used per token.
+    num_active_parameters_in_routed_experts = (
+        2 * model_config.hidden_size * moe_ffn_hidden_size * model_config.moe_router_topk * gated_linear_multiplier
+        if model_config.num_moe_experts is not None
+        else 0
+    )
+    # Per-layer shared expert MLP parameters; shared experts use regular TP, not ETP.
+    num_parameters_in_shared_experts = (
+        2 * model_config.hidden_size * shared_expert_ffn_hidden_size * gated_linear_multiplier
+    )
+    # Per-layer normalization parameters; the factor 2 counts input norm and pre-MLP norm.
+    num_parameters_in_layernorms = 2 * model_config.hidden_size * norm_size
+    # Per-layer optional shared expert gate weight, replicated across tensor-parallel ranks.
+    num_parameters_in_shared_expert_gate = (
+        model_config.hidden_size
+        if shared_expert_ffn_hidden_size > 0 and getattr(model_config, "moe_shared_expert_gate", False)
+        else 0
+    )
+    # Per-layer router gate parameters, replicated across tensor-parallel ranks.
+    num_parameters_in_router = (
+        (model_config.hidden_size * num_experts) + (num_experts if model_config.add_bias_linear else 0)
+        if model_config.num_moe_experts is not None
+        else 0
+    )
+
+    # Per dense transformer layer, parameters sharded by regular tensor parallelism.
+    num_tp_sharded_parameters_in_transformer_layer_dense = num_parameters_in_attention + num_parameters_in_dense_mlp
+    # Per dense transformer layer, parameters replicated across tensor-parallel ranks.
+    num_replicated_parameters_in_transformer_layer_dense = num_parameters_in_layernorms
+    # Per dense transformer layer, total logical parameters before any parallel sharding.
+    num_parameters_in_transformer_layer_dense = (
+        num_tp_sharded_parameters_in_transformer_layer_dense + num_replicated_parameters_in_transformer_layer_dense
+    )
+
+    # Per MoE transformer layer, non-routed parameters sharded by regular tensor parallelism.
+    num_tp_sharded_parameters_in_transformer_layer_moe = num_parameters_in_attention + num_parameters_in_shared_experts
+    # Per MoE transformer layer, non-routed parameters replicated across tensor-parallel ranks.
+    num_replicated_parameters_in_transformer_layer_moe = (
+        num_parameters_in_layernorms + num_parameters_in_router + num_parameters_in_shared_expert_gate
+    )
+    # Per MoE transformer layer, total logical parameters before any parallel sharding.
+    num_parameters_in_transformer_layer_moe = (
+        num_tp_sharded_parameters_in_transformer_layer_moe
+        + num_replicated_parameters_in_transformer_layer_moe
+        + num_parameters_in_routed_experts
+    )
+    # Per MoE transformer layer, logical parameters used by one routed token.
+    num_active_parameters_in_transformer_layer_moe = (
+        num_tp_sharded_parameters_in_transformer_layer_moe
+        + num_replicated_parameters_in_transformer_layer_moe
+        + num_active_parameters_in_routed_experts
+    )
+    # Input embedding table parameters.
     embedding_size = model_config.hidden_size * _get_vocab_size(model_config)
+    # Final normalization parameters, replicated across tensor-parallel ranks.
+    final_layernorm = norm_size * model_config.hidden_size
     if not model_config.share_embeddings_and_output_weights:
+        # Untied embeddings have separate input embedding and output LM-head tables.
         num_parameters_in_embedding_layers = 2 * embedding_size
     else:
+        # Tied embeddings share the input embedding and output LM-head table.
         num_parameters_in_embedding_layers = embedding_size
-    num_total_parameters = num_parameters_in_transformer_layers + num_parameters_in_embedding_layers
+
+    # Transformer block parameters that will be divided by regular tensor parallelism.
+    num_tp_sharded_parameters_in_transformer_block = (
+        num_tp_sharded_parameters_in_transformer_layer_dense * num_dense_layers
+        + num_tp_sharded_parameters_in_transformer_layer_moe * num_moe_layers
+    )
+    # Transformer block parameters replicated across regular tensor-parallel ranks.
+    num_replicated_parameters_in_transformer_block = (
+        num_replicated_parameters_in_transformer_layer_dense * num_dense_layers
+        + num_replicated_parameters_in_transformer_layer_moe * num_moe_layers
+        + final_layernorm
+    )
+    # Transformer block routed expert parameters that will be divided by ETP and EP.
+    num_routed_expert_parameters_in_transformer_block = num_parameters_in_routed_experts * num_moe_layers
+    # Total logical transformer block parameters before model-parallel sharding.
+    num_parameters_in_transformer_block = (
+        num_parameters_in_transformer_layer_dense * num_dense_layers
+        + num_parameters_in_transformer_layer_moe * num_moe_layers
+        + final_layernorm
+    )
+    # Total logical active transformer block parameters before model-parallel sharding.
+    num_active_parameters_in_transformer_block = (
+        num_parameters_in_transformer_layer_dense * num_dense_layers
+        + num_active_parameters_in_transformer_layer_moe * num_moe_layers
+        + final_layernorm
+    )
+
+    # MTP block parameters that will be divided by regular tensor parallelism.
+    num_tp_sharded_parameters_in_mtp_block = (
+        num_tp_sharded_parameters_in_transformer_layer_dense * mtp_num_dense_layers
+        + num_tp_sharded_parameters_in_transformer_layer_moe * mtp_num_moe_layers
+    )
+    # MTP block parameters replicated across regular tensor-parallel ranks.
+    num_replicated_parameters_in_mtp_block = (
+        num_replicated_parameters_in_transformer_layer_dense * mtp_num_dense_layers
+        + num_replicated_parameters_in_transformer_layer_moe * mtp_num_moe_layers
+    )
+    # MTP block routed expert parameters that will be divided by ETP and EP.
+    num_routed_expert_parameters_in_mtp_block = num_parameters_in_routed_experts * mtp_num_moe_layers
+    # Total logical MTP block parameters before model-parallel sharding.
+    num_parameters_in_mtp_block = (
+        num_parameters_in_transformer_layer_dense * mtp_num_dense_layers
+        + num_parameters_in_transformer_layer_moe * mtp_num_moe_layers
+    )
+
+    num_total_parameters = (
+        num_parameters_in_transformer_block + num_parameters_in_mtp_block + num_parameters_in_embedding_layers
+    )
+    num_active_parameters = (
+        num_active_parameters_in_transformer_block + num_parameters_in_mtp_block + num_parameters_in_embedding_layers
+    )
     if verbose:
         print(
-            f"Number of parameters in transformer layers in billions: "
-            f"{num_parameters_in_transformer_layers / 10**9: .2f}"
+            f"Number of parameters in transformer block in billions: "
+            f"{num_parameters_in_transformer_block / 10**9: .2f}"
         )
+        print(
+            f"Number of active parameters in transformer block in billions: "
+            f"{num_active_parameters_in_transformer_block / 10**9: .2f}"
+        )
+        if mtp_num_layers is not None:
+            print(f"Number of parameters in mtp block in billions: {num_parameters_in_mtp_block / 10**9: .2f}")
         print(
             f"Number of parameters in embedding layers in billions: {num_parameters_in_embedding_layers / 10**9:.2f}"
         )
         print(f"Total number of parameters in billions: {num_total_parameters / 10**9:.2f}")
+        print(f"Total number of active parameters in billions: {num_active_parameters / 10**9:.2f}")
 
-    # Most loaded model shard has (1/pp_size transformer layers + 1 embedding layer) / tp_size.
-    num_parameters_on_most_loaded_model_shard = (
-        (num_parameters_in_transformer_layers / model_config.pipeline_model_parallel_size) + embedding_size
+    # Number of ranks that shard each routed expert's tensor dimensions.
+    expert_tensor_parallel_size = (
+        model_config.expert_tensor_parallel_size
+        if model_config.expert_tensor_parallel_size is not None
+        else model_config.tensor_model_parallel_size
+    )
+    # Number of ranks that split the global set of routed experts.
+    expert_model_parallel_size = model_config.expert_model_parallel_size
+    # Number of ranks in one expert tensor/expert/pipeline model-parallel group.
+    expert_tensor_model_pipeline_parallel_size = (
+        expert_tensor_parallel_size * expert_model_parallel_size * model_config.pipeline_model_parallel_size
+    )
+    # Bridge's world_size is DP * TP * PP * CP. Mirror that here so the EDP
+    # derivation matches the global rank count Bridge expects.
+    world_size = (
+        config.data_parallel_size
+        * model_config.tensor_model_parallel_size
+        * model_config.pipeline_model_parallel_size
+        * model_config.context_parallel_size
+    )
+    # Data-parallel size used by expert parameters and distributed optimizer state.
+    expert_data_parallel_size = world_size // expert_tensor_model_pipeline_parallel_size
+
+    # Most loaded model shard has 1/pp_size transformer layers, 1 mtp block, and 1 embedding layer.
+    # TP-sharded dense/shared parameters use regular TP. Routed experts use ETP and EP. Router and
+    # normalization parameters are replicated across TP/ETP ranks.
+    num_tp_sharded_parameters_on_most_loaded_model_shard = (
+        (num_tp_sharded_parameters_in_transformer_block / model_config.pipeline_model_parallel_size)
+        + num_tp_sharded_parameters_in_mtp_block
+        + embedding_size
     ) / model_config.tensor_model_parallel_size
+    num_replicated_parameters_on_most_loaded_model_shard = (
+        num_replicated_parameters_in_transformer_block / model_config.pipeline_model_parallel_size
+    ) + num_replicated_parameters_in_mtp_block
+    num_routed_expert_parameters_on_most_loaded_model_shard = (
+        (num_routed_expert_parameters_in_transformer_block / model_config.pipeline_model_parallel_size)
+        + num_routed_expert_parameters_in_mtp_block
+    ) / (expert_tensor_parallel_size * expert_model_parallel_size)
+    num_parameters_on_most_loaded_model_shard = (
+        num_tp_sharded_parameters_on_most_loaded_model_shard
+        + num_replicated_parameters_on_most_loaded_model_shard
+        + num_routed_expert_parameters_on_most_loaded_model_shard
+    )
     if not model_config.share_embeddings_and_output_weights and model_config.pipeline_model_parallel_size == 1:
+        num_tp_sharded_parameters_on_most_loaded_model_shard += (
+            embedding_size / model_config.tensor_model_parallel_size
+        )
         num_parameters_on_most_loaded_model_shard += embedding_size / model_config.tensor_model_parallel_size
     if verbose:
         print(
@@ -99,19 +333,32 @@ def compute_weight_and_optimizer_memory(config: ConfigContainer, verbose: bool =
         )
 
     if model_config.pipeline_model_parallel_size > 1:
-        # Other shards just have (1/pp_size transformer layers) / tp_size.
-        num_parameters_on_other_model_shards = num_parameters_in_transformer_layers / (
-            model_config.pipeline_model_parallel_size * model_config.tensor_model_parallel_size
+        # Other shards just have 1/pp_size transformer layers.
+        num_parameters_on_other_model_shards = (
+            num_tp_sharded_parameters_in_transformer_block
+            / (model_config.pipeline_model_parallel_size * model_config.tensor_model_parallel_size)
+            + num_replicated_parameters_in_transformer_block / model_config.pipeline_model_parallel_size
+            + num_routed_expert_parameters_in_transformer_block
+            / (model_config.pipeline_model_parallel_size * expert_tensor_parallel_size * expert_model_parallel_size)
         )
         if verbose:
             print(
                 f"Number of parameters in other shards in billions: {num_parameters_on_other_model_shards / 10**9:.4f}"
             )
 
-    num_bytes_per_parameter = (
-        18 if not config.optimizer.use_distributed_optimizer else 6 + (12 / config.data_parallel_size)
+    # Bf16 training bytes per logical parameter for the given data-parallel domain.
+    # Assumes bf16 model params, fp32 main grads, fp32 main params, and fp32 Adam states.
+    def num_bytes_per_parameter(data_parallel_size: int) -> float:
+        if not config.optimizer.use_distributed_optimizer:
+            return 18
+        return 6 + (12 / data_parallel_size)
+
+    # Per-rank memory for weights, gradients, main params, and optimizer state.
+    weight_and_optimizer_memory = (
+        num_tp_sharded_parameters_on_most_loaded_model_shard + num_replicated_parameters_on_most_loaded_model_shard
+    ) * num_bytes_per_parameter(config.data_parallel_size) + (
+        num_routed_expert_parameters_on_most_loaded_model_shard * num_bytes_per_parameter(expert_data_parallel_size)
     )
-    weight_and_optimizer_memory = num_parameters_on_most_loaded_model_shard * num_bytes_per_parameter
 
     return weight_and_optimizer_memory
 

--- a/tests/unit_tests/training/utils/test_theoretical_memory_utils.py
+++ b/tests/unit_tests/training/utils/test_theoretical_memory_utils.py
@@ -1,0 +1,122 @@
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+
+import pytest
+import torch.nn.functional as F
+
+from megatron.bridge.training.utils.theoretical_memory_utils import compute_weight_and_optimizer_memory
+
+
+@dataclass
+class MockModelConfig:
+    # Core dims
+    num_layers: int = 4
+    hidden_size: int = 128
+    ffn_hidden_size: int = 512
+    num_attention_heads: int = 4
+    num_query_groups: int | None = 4
+    kv_channels: int = 32
+    vocab_size: int = 1024
+    make_vocab_size_divisible_by: int = 128
+    should_pad_vocab: bool = True
+    share_embeddings_and_output_weights: bool = True
+    normalization: str = "LayerNorm"
+    add_bias_linear: bool = False
+    gated_linear_unit: bool = True
+    activation_func: object = field(default=None)
+    # Parallelism
+    tensor_model_parallel_size: int = 1
+    pipeline_model_parallel_size: int = 1
+    context_parallel_size: int = 1
+    expert_model_parallel_size: int = 1
+    expert_tensor_parallel_size: int | None = None
+    virtual_pipeline_model_parallel_size: int | None = None
+    sequence_parallel: bool = False
+    recompute_granularity: str | None = None
+    # MoE
+    num_moe_experts: int | None = None
+    moe_layer_freq: int | list = 1
+    moe_router_topk: int = 1
+    moe_ffn_hidden_size: int | None = None
+    moe_shared_expert_intermediate_size: int | None = None
+    moe_shared_expert_gate: bool = False
+    # MTP / MLA
+    mtp_num_layers: int | None = None
+    multi_latent_attention: bool = False
+
+    def __post_init__(self):
+        if self.activation_func is None:
+            self.activation_func = F.silu
+
+
+def _make_config(*, model: MockModelConfig, world_size: int, distributed_opt: bool = False):
+    """Build a minimal SimpleNamespace mimicking ConfigContainer for the estimator."""
+    total_model_size = (
+        model.tensor_model_parallel_size * model.pipeline_model_parallel_size * model.context_parallel_size
+    )
+    if world_size % total_model_size != 0:
+        raise ValueError(f"world_size {world_size} not divisible by TP*PP*CP={total_model_size}")
+    return SimpleNamespace(
+        model=model,
+        optimizer=SimpleNamespace(use_distributed_optimizer=distributed_opt),
+        data_parallel_size=world_size // total_model_size,
+    )
+
+
+def test_dense_model_returns_positive_memory():
+    cfg = _make_config(model=MockModelConfig(), world_size=1)
+    assert compute_weight_and_optimizer_memory(cfg) > 0
+
+
+def test_moe_routes_experts_through_ep_etp():
+    """With EP > 1 the per-rank routed-expert weight should drop vs. EP = 1."""
+    base_kwargs = dict(
+        num_layers=4,
+        num_moe_experts=8,
+        moe_ffn_hidden_size=256,
+        moe_router_topk=2,
+        tensor_model_parallel_size=2,
+        expert_tensor_parallel_size=1,
+    )
+    ep1 = MockModelConfig(**base_kwargs, expert_model_parallel_size=1)
+    ep4 = MockModelConfig(**base_kwargs, expert_model_parallel_size=4)
+    # world = TP * PP * CP * DP = 2 * 1 * 1 * 4 = 8
+    mem_ep1 = compute_weight_and_optimizer_memory(_make_config(model=ep1, world_size=8))
+    mem_ep4 = compute_weight_and_optimizer_memory(_make_config(model=ep4, world_size=8))
+    assert mem_ep4 < mem_ep1, (
+        f"Increasing EP should reduce per-rank routed-expert memory; got EP=1 -> {mem_ep1}, EP=4 -> {mem_ep4}"
+    )
+
+
+def test_distributed_optimizer_scales_with_dp():
+    """Distributed optimizer state should shrink as data-parallel size grows."""
+    model = MockModelConfig()
+    cfg_dp1 = _make_config(model=model, world_size=1, distributed_opt=True)
+    cfg_dp8 = _make_config(model=model, world_size=8, distributed_opt=True)
+    assert compute_weight_and_optimizer_memory(cfg_dp8) < compute_weight_and_optimizer_memory(cfg_dp1)
+
+
+def test_moe_layer_freq_pattern_list():
+    """List form of moe_layer_freq must be honored (one MoE layer at index 1, dense elsewhere)."""
+    model = MockModelConfig(
+        num_layers=4,
+        num_moe_experts=4,
+        moe_ffn_hidden_size=256,
+        moe_layer_freq=[0, 1, 0, 0],
+    )
+    mem = compute_weight_and_optimizer_memory(_make_config(model=model, world_size=1))
+    # Compare to all-MoE; less aggregate routed-expert weight should cost less memory.
+    model_all_moe = MockModelConfig(
+        num_layers=4,
+        num_moe_experts=4,
+        moe_ffn_hidden_size=256,
+        moe_layer_freq=[1, 1, 1, 1],
+    )
+    mem_all = compute_weight_and_optimizer_memory(_make_config(model=model_all_moe, world_size=1))
+    assert mem < mem_all
+
+
+def test_invalid_moe_layer_freq_type_raises():
+    model = MockModelConfig(num_moe_experts=4, moe_ffn_hidden_size=256, moe_layer_freq="every-other")
+    with pytest.raises(TypeError):
+        compute_weight_and_optimizer_memory(_make_config(model=model, world_size=1))


### PR DESCRIPTION
## Summary

Ports the MoE-aware theoretical memory estimator from upstream **[NVIDIA/Megatron-LM#4687](https://github.com/NVIDIA/Megatron-LM/pull/4687)** (which fixes [NVIDIA/Megatron-LM#4050](https://github.com/NVIDIA/Megatron-LM/issues/4050)) into Bridge's local `theoretical_memory_utils.py`.

Bridge maintains its own copy of this estimator (it takes a `ConfigContainer`, not Megatron's argparse `args`), so the fix doesn't propagate automatically when the submodule is bumped — it has to be downstreamed by hand.

## Why

The previous Bridge formula divided **all** transformer-layer parameters — including routed experts — by `tensor_model_parallel_size`. Routed experts are actually sharded by `expert_tensor_parallel_size * expert_model_parallel_size`, with distributed-optimizer state sized by the expert data-parallel domain. The old formula silently under-reports MoE memory whenever `ETP * EP != TP`, which is the common case for Mixtral / DeepSeek / Qwen3-MoE / GPT-OSS recipes.

The new formula splits parameters into three buckets and applies the correct divisor to each:

| Bucket | Examples | Divisor |
|---|---|---|
| TP-sharded | attention, dense MLP, shared experts | TP |
| Replicated | layernorms, router gate, shared-expert gate | 1 |
| Routed experts | MoE FFN per expert | ETP × EP |

Distributed-optimizer state for routed experts uses the expert DP domain (`world_size / (ETP × EP × PP)`).

Also picks up several upstream features the prior Bridge version was missing:
- MoE layer patterns (`int` and `list` form of `moe_layer_freq`)
- Shared experts with optional gate (`moe_shared_expert_gate`)
- Multi-latent attention (DeepSeek-style `q_lora_rank` / `kv_lora_rank` / split `qk_head_dim` + RoPE term)
- Multi-Token Prediction (MTP) blocks
- Active-vs-total parameter counts in verbose output

The estimator is informational only — it does not affect training correctness or actual memory allocation. Users sizing jobs from the printed memory estimate will get accurate numbers for MoE recipes after this lands.

## Why draft

Upstream **PR #4687 is open, not merged**. The implementation can still change in review. This PR holds the port until #4687 merges, then we'll rebase to match the final upstream form before un-drafting.

## Test plan

- [x] Pre-commit (ruff + format + trailing-ws) — clean
- [x] Five new unit tests in `tests/unit_tests/training/utils/test_theoretical_memory_utils.py`:
  - Dense model returns positive memory
  - EP > 1 reduces per-rank routed-expert weight (vs. EP = 1)
  - Distributed optimizer state shrinks as DP grows
  - List form of `moe_layer_freq` is honored
  - Invalid `moe_layer_freq` type raises `TypeError`
- [ ] CI: `cicd-unit-tests-core` picks up the new module

## Checklist

- [x] Sign-off (DCO)
- [x] Copyright year 2026 on the production file
- [x] Function signature unchanged (still `compute_weight_and_optimizer_memory(config: ConfigContainer, verbose: bool = False) -> float`)
- [x] No new dependencies
- [x] Bridge `ConfigContainer` already exposes every needed field (verified against `mcore` `TransformerConfig` + `ModelParallelConfig`)
- [ ] Re-sync against final form of upstream #4687 before un-drafting

## Refs

- Upstream PR: NVIDIA/Megatron-LM#4687
- Upstream issue: NVIDIA/Megatron-LM#4050

🤖 Generated with [Claude Code](https://claude.com/claude-code)