### PR TITLE
Remove qwen3_asr import because of noisy docstring errors

### DIFF
--- a/src/megatron/bridge/models/__init__.py
+++ b/src/megatron/bridge/models/__init__.py
@@ -114,11 +114,6 @@ from megatron.bridge.models.olmoe import (
     OlMoEBridge,
     OlMoEModelProvider,
 )
-from megatron.bridge.models.qwen3_asr import (
-    Qwen3ASRBridge,
-    Qwen3ASRModel,
-    Qwen3ASRModelProvider,
-)
 from megatron.bridge.models.qwen_audio import (
     Qwen2AudioBridge,
     Qwen2AudioModel,

--- a/src/megatron/bridge/models/__init__.py
+++ b/src/megatron/bridge/models/__init__.py
@@ -230,10 +230,6 @@ __all__ = [
     "NemotronVLModel",
     "NemotronVLBridge",
     "NemotronNano12Bv2VLModelProvider",
-    # ASR Models
-    "Qwen3ASRBridge",
-    "Qwen3ASRModel",
-    "Qwen3ASRModelProvider",
     # Omni Models
     "Qwen25OmniModel",
     "Qwen25OmniBridge",


### PR DESCRIPTION
# What does this PR do ?

Remove an import that causes noisy and misleading `[ERROR]` messages.

