### PR TITLE
[model, ckpt] fix: align GPT-OSS BF16 down_proj orientation on import (r0.4.0)

### DIFF
--- a/src/megatron/bridge/models/conversion/model_bridge.py
+++ b/src/megatron/bridge/models/conversion/model_bridge.py
@@ -1417,6 +1417,10 @@ class MegatronModelBridge(MegatronPeftBridge, Generic[HFPreTrained, ModelProvide
         if not isinstance(hf_pretrained, PretrainedConfig) and not has_hf_state:
             raise ValueError("hf_pretrained.state.source is required for weight ordering")
 
+        # Stash for subclass hooks (e.g. ``maybe_modify_loaded_hf_weight``) that need access
+        # to the source HF config to disambiguate ambiguous tensor shapes.
+        self.hf_pretrained = hf_pretrained
+
         hf_keys: Optional[Iterable[str]] = hf_pretrained.state.source.get_all_keys() if has_hf_state else None
 
         mapping_registry = self.mapping_registry()

--- a/src/megatron/bridge/models/gpt_oss/gpt_oss_bridge.py
+++ b/src/megatron/bridge/models/gpt_oss/gpt_oss_bridge.py
@@ -254,13 +254,18 @@ class GPTOSSMLPDownProjMapping(AutoMapping):
         return super().hf_to_megatron(hf_weights[global_expert_number], megatron_module)
 
     def megatron_to_hf(self, megatron_weights: torch.Tensor, megatron_module: nn.Module) -> Dict[str, torch.Tensor]:
-        # Megatron stores per-expert as (hidden, intermediate); HF down_proj is
-        # (E, intermediate, hidden). Transpose each per-expert tensor so the
-        # grouped-export stack assembles in HF's layout.
+        # Megatron stores per-expert weight as (hidden, intermediate); HF down_proj
+        # weight is (E, intermediate, hidden). Transpose the last two dims so the
+        # grouped-export stack assembles in HF's layout. Under EP the parent's gather
+        # may have already cat'd across the EP group, producing a 3D (ep_size, out, in)
+        # tensor — handle that too. The bias has no orientation to align (per-expert
+        # 1-D, stacked to (E, hidden) on export), so leave bias mappings untouched.
         if megatron_weights is not None:
             megatron_weights = megatron_weights.contiguous()
         result = super().megatron_to_hf(megatron_weights, megatron_module)
-        return {k: v.t().contiguous() if v.ndim == 2 else v for k, v in result.items()}
+        if self.hf_param.endswith("_bias"):
+            return result
+        return {k: v.transpose(-1, -2).contiguous() if v.ndim >= 2 else v for k, v in result.items()}
 
 
 class GPTOSSMLPGateUpProjMapping(AutoMapping):

--- a/src/megatron/bridge/models/gpt_oss/gpt_oss_bridge.py
+++ b/src/megatron/bridge/models/gpt_oss/gpt_oss_bridge.py
@@ -106,9 +106,15 @@ class GPTOSSBridge(MegatronModelBridge):
     ) -> torch.Tensor:
         """Load weights from HuggingFace state dict with MXFP4 dequantization support.
 
-        down_proj expert weights are stored transposed vs Megatron (HF: [in, out], Megatron: [out, in]).
-        We transpose them once here so that GPTOSSMLPDownProjMapping.hf_to_megatron can treat the
-        per-expert slice as-is, and megatron_to_hf symmetrically transposes back on export.
+        Per-expert ``down_proj`` is square for GPT-OSS-20B/120B (hidden == intermediate), so
+        the bridge cannot auto-detect orientation from shape alone. BF16 checkpoints (e.g.
+        ``unsloth/gpt-oss-20b-BF16``, and what ``transformers.GptOssForCausalLM`` produces at
+        init) store it as ``[E, intermediate, hidden]``, matching ``gate_up_proj``'s
+        ``[E, hidden, 2*intermediate]`` convention. MXFP4-dequantized weights come out as
+        ``[E, hidden, intermediate]``. Megatron's TE ``RowParallelGroupedLinear`` expects
+        per-expert ``(hidden, intermediate)``, so the BF16 path needs a transpose here while
+        the MXFP4 path is already aligned. Without this, BF16 imports silently store down_proj
+        in the wrong orientation and inference is broken.
 
         gate_up_proj is handled directly in GPTOSSMLPGateUpProjMapping.hf_to_megatron via
         _align_expert_weight_to_shape, which auto-detects the orientation difference between
@@ -118,15 +124,27 @@ class GPTOSSBridge(MegatronModelBridge):
         if isinstance(hf_param, str):
             if hf_param in hf_state_dict:
                 hf_weights = hf_state_dict[hf_param]
-                if ".mlp.experts.down_proj" in hf_param and hf_weights.ndim == 3:
-                    hf_weights = hf_weights.transpose(-1, -2)
+                if hf_param.endswith(".mlp.experts.down_proj") and hf_weights.ndim == 3:
+                    cfg = self.hf_pretrained.config
+                    hidden = cfg.hidden_size
+                    intermediate = cfg.intermediate_size
+                    last2 = tuple(hf_weights.shape[-2:])
+                    if last2 == (intermediate, hidden) and intermediate != hidden:
+                        # Unambiguous BF16 layout (E, intermediate, hidden); transpose to (E, hidden, intermediate).
+                        hf_weights = hf_weights.transpose(-1, -2).contiguous()
+                    elif last2 == (hidden, intermediate) and intermediate != hidden:
+                        # Already aligned with Megatron — no-op.
+                        pass
+                    elif intermediate == hidden:
+                        # Square: HF GptOssForCausalLM init produces (E, intermediate, hidden), so a plain BF16
+                        # checkpoint is in that layout. Transpose to (E, hidden, intermediate) for Megatron.
+                        hf_weights = hf_weights.transpose(-1, -2).contiguous()
                 return hf_weights
             blocks_key = hf_param + "_blocks"
             scales_key = hf_param + "_scales"
             if blocks_key in hf_state_dict and scales_key in hf_state_dict:
                 hf_weights = _dequantize_mxfp4(hf_state_dict[blocks_key], hf_state_dict[scales_key])
-                if ".mlp.experts.down_proj" in hf_param and hf_weights.ndim == 3:
-                    hf_weights = hf_weights.transpose(-1, -2)
+                # MXFP4 dequant already emits [E, hidden, intermediate] for down_proj — leave as-is.
                 return hf_weights
             raise KeyError(
                 f"Cannot locate weights for '{hf_param}'. Missing both de-quantized tensor and "
@@ -236,11 +254,13 @@ class GPTOSSMLPDownProjMapping(AutoMapping):
         return super().hf_to_megatron(hf_weights[global_expert_number], megatron_module)
 
     def megatron_to_hf(self, megatron_weights: torch.Tensor, megatron_module: nn.Module) -> Dict[str, torch.Tensor]:
-        if megatron_weights is None:
-            return super().megatron_to_hf(megatron_weights, megatron_module)
-        if len(megatron_weights.shape) == 2:
-            megatron_weights = megatron_weights.transpose(0, 1)
-        return super().megatron_to_hf(megatron_weights.contiguous(), megatron_module)
+        # Megatron stores per-expert as (hidden, intermediate); HF down_proj is
+        # (E, intermediate, hidden). Transpose each per-expert tensor so the
+        # grouped-export stack assembles in HF's layout.
+        if megatron_weights is not None:
+            megatron_weights = megatron_weights.contiguous()
+        result = super().megatron_to_hf(megatron_weights, megatron_module)
+        return {k: v.t().contiguous() if v.ndim == 2 else v for k, v in result.items()}
 
 
 class GPTOSSMLPGateUpProjMapping(AutoMapping):

--- a/tests/functional_tests/test_groups/models/gpt_oss/test_gpt_oss_conversion.py
+++ b/tests/functional_tests/test_groups/models/gpt_oss/test_gpt_oss_conversion.py
@@ -20,7 +20,9 @@ from pathlib import Path
 import pytest
 
 
-# Minimal GPT-OSS config used for building a tiny local HF directory to test conversion.
+# Minimal GPT-OSS config used for building tiny local HF directories to test conversion.
+# hidden_size and intermediate_size are different (and both divisible by 32) so the per-expert
+# down_proj/gate_up_proj are non-square and the bridge can detect orientation from shape.
 GPT_OSS_TOY_OVERRIDES = {
     "architectures": ["GptOssForCausalLM"],
     "hidden_size": 512,
@@ -34,59 +36,158 @@ GPT_OSS_TOY_OVERRIDES = {
 }
 
 
+def _build_toy_models(bf16_dir: Path, mxfp4_dir: Path, seed: int = 0):
+    """Build two faithful toy GPT-OSS checkpoints sharing the same underlying weights.
+
+    BF16 toy:
+        Stores per-expert ``gate_up_proj`` as ``[E, hidden, 2*intermediate]`` and
+        ``down_proj`` as ``[E, intermediate, hidden]`` — matching ``unsloth/gpt-oss-20b-BF16``
+        and what ``transformers.GptOssForCausalLM`` produces at init.
+
+    MXFP4 toy:
+        Stores ``*_blocks`` and ``*_scales`` whose dequantization (via
+        ``_dequantize_mxfp4``) yields the BF16 toy's per-expert values *transposed*
+        — i.e. ``[E, 2*intermediate, hidden]`` for gate_up_proj and ``[E, hidden,
+        intermediate]`` for down_proj — matching how ``openai/gpt-oss-20b`` ships.
+
+    The two toys are built so that BF16 == dequant(MXFP4).t(-1, -2) per expert,
+    which means a Megatron checkpoint imported from either source must contain
+    identical per-expert weights, and exporting that Megatron checkpoint back to
+    HF format must match the BF16 toy on every tensor.
+    """
+    import torch
+    from safetensors.torch import save_file
+    from transformers import GptOssConfig, GptOssForCausalLM
+
+    from megatron.bridge.models.gpt_oss.gpt_oss_bridge import _dequantize_mxfp4
+
+    config = GptOssConfig(**GPT_OSS_TOY_OVERRIDES)
+    model = GptOssForCausalLM(config).bfloat16()
+
+    e = config.num_local_experts
+    h = config.hidden_size
+    i_ = config.intermediate_size
+    num_layers = config.num_hidden_layers
+    assert h % 32 == 0 and i_ % 32 == 0, "Both dims must be divisible by MXFP4 block size 32"
+
+    gen = torch.Generator().manual_seed(seed)
+
+    # Per-layer MXFP4 generation, then dequantize to obtain BF16 reference values.
+    layer_data = []
+    for _ in range(num_layers):
+        gu_blocks = torch.randint(0, 256, (e, 2 * i_, h // 32, 16), dtype=torch.int32, generator=gen).to(torch.uint8)
+        # UE8M0 scales clustered near 127 so dequantized magnitudes are O(1).
+        gu_scales = torch.randint(124, 130, (e, 2 * i_, h // 32), dtype=torch.int32, generator=gen).to(torch.uint8)
+        # Dequant returns (E, 2*intermediate, hidden) = (E, out, in).
+        gu_dq = _dequantize_mxfp4(gu_blocks, gu_scales)
+        # BF16 HF layout is (E, in, out) = (E, hidden, 2*intermediate).
+        gu_bf16 = gu_dq.transpose(-1, -2).contiguous()
+
+        dn_blocks = torch.randint(0, 256, (e, h, i_ // 32, 16), dtype=torch.int32, generator=gen).to(torch.uint8)
+        dn_scales = torch.randint(124, 130, (e, h, i_ // 32), dtype=torch.int32, generator=gen).to(torch.uint8)
+        # Dequant returns (E, hidden, intermediate) = (E, out, in).
+        dn_dq = _dequantize_mxfp4(dn_blocks, dn_scales)
+        # BF16 HF layout is (E, in, out) = (E, intermediate, hidden).
+        dn_bf16 = dn_dq.transpose(-1, -2).contiguous()
+
+        layer_data.append(
+            {
+                "gu_blocks": gu_blocks,
+                "gu_scales": gu_scales,
+                "gu_bf16": gu_bf16,
+                "dn_blocks": dn_blocks,
+                "dn_scales": dn_scales,
+                "dn_bf16": dn_bf16,
+            }
+        )
+
+    # Inject the dequantized values back into the BF16 model so its on-disk weights match
+    # exactly what the MXFP4 path will produce after dequantization.
+    sd = dict(model.state_dict())
+    for li in range(num_layers):
+        sd[f"model.layers.{li}.mlp.experts.gate_up_proj"] = layer_data[li]["gu_bf16"]
+        sd[f"model.layers.{li}.mlp.experts.down_proj"] = layer_data[li]["dn_bf16"]
+    model.load_state_dict(sd)
+
+    # ---- BF16 toy ----
+    bf16_dir.mkdir(parents=True, exist_ok=True)
+    model.save_pretrained(bf16_dir, safe_serialization=True)
+    with open(bf16_dir / "config.json", "w") as f:
+        json.dump(model.config.to_dict(), f, indent=2)
+
+    # ---- MXFP4 toy ----
+    mxfp4_dir.mkdir(parents=True, exist_ok=True)
+    mxfp4_sd = {}
+    for n, p in model.state_dict().items():
+        if n.endswith(".mlp.experts.gate_up_proj") or n.endswith(".mlp.experts.down_proj"):
+            continue
+        mxfp4_sd[n] = p.detach().clone().contiguous()
+    for li in range(num_layers):
+        prefix = f"model.layers.{li}.mlp.experts"
+        mxfp4_sd[f"{prefix}.gate_up_proj_blocks"] = layer_data[li]["gu_blocks"]
+        mxfp4_sd[f"{prefix}.gate_up_proj_scales"] = layer_data[li]["gu_scales"]
+        mxfp4_sd[f"{prefix}.down_proj_blocks"] = layer_data[li]["dn_blocks"]
+        mxfp4_sd[f"{prefix}.down_proj_scales"] = layer_data[li]["dn_scales"]
+    save_file(mxfp4_sd, str(mxfp4_dir / "model.safetensors"))
+    with open(mxfp4_dir / "config.json", "w") as f:
+        json.dump(model.config.to_dict(), f, indent=2)
+
+    # Tokenizer (best-effort; both toys share it)
+    try:
+        from transformers import AutoTokenizer
+
+        tok = AutoTokenizer.from_pretrained("gpt2")
+        tok.save_pretrained(bf16_dir)
+        tok.save_pretrained(mxfp4_dir)
+    except Exception:
+        pass
+
+
 class TestGptOssConversion:
-    """Functional tests for GPT-OSS toy conversion paths."""
+    """Functional tests for GPT-OSS toy conversion paths.
+
+    Two toys are built once per class:
+      - ``bf16``: faithful BF16 layout (matches ``unsloth/gpt-oss-20b-BF16``).
+      - ``mxfp4``: faithful MXFP4 layout (matches ``openai/gpt-oss-20b``).
+
+    Each parallelism config is exercised against both sources. The MXFP4 path runs as a
+    two-step convert→roundtrip because the roundtrip script's verification table cannot
+    look up ``gate_up_proj``/``down_proj`` directly in a quantized state dict; instead we
+    import MXFP4 → save Megatron → reload Megatron → export → compare against the BF16
+    toy as the reference.
+    """
 
     @pytest.fixture(scope="class")
-    def gpt_oss_toy_model_path(self, tmp_path_factory):
-        tmp_dir = tmp_path_factory.mktemp("gptoss_toy_model")
-        model_dir = tmp_dir / "gpt_oss_toy"
+    def gpt_oss_toy_paths(self, tmp_path_factory):
+        tmp_dir = tmp_path_factory.mktemp("gptoss_toys")
+        bf16_dir = tmp_dir / "gpt_oss_toy_bf16"
+        mxfp4_dir = tmp_dir / "gpt_oss_toy_mxfp4"
 
-        # Importorskip ensures test is skipped gracefully if transformers lacks GPT-OSS
         transformers = pytest.importorskip("transformers")
-        GptOssForCausalLM = getattr(transformers, "GptOssForCausalLM", None)
-        GptOssConfig = getattr(transformers, "GptOssConfig", None)
-        if GptOssForCausalLM is None or GptOssConfig is None:
+        if not all(hasattr(transformers, n) for n in ("GptOssForCausalLM", "GptOssConfig")):
             pytest.skip("transformers installation does not include GPT-OSS classes")
 
-        # Build tiny config and model
-        config = GptOssConfig(**GPT_OSS_TOY_OVERRIDES)
-        model = GptOssForCausalLM(config)
-        if hasattr(model, "bfloat16"):
-            model = model.bfloat16()
-
-        # Save tokenizer (fallback to gpt2 tokenizer if GPT-OSS doesn't ship one)
-        try:
-            from transformers import AutoTokenizer
-
-            tok = AutoTokenizer.from_pretrained("gpt2")
-            tok.save_pretrained(model_dir)
-        except Exception:
-            pass
-
-        # Save model and config to directory
-        model.save_pretrained(model_dir, safe_serialization=True)
-
-        # Also save config.json explicitly to ensure compatibility with correct torch_dtype
-        config_path = model_dir / "config.json"
-        with open(config_path, "w") as f:
-            json.dump(model.config.to_dict(), f, indent=2)
-
-        return str(model_dir)
+        _build_toy_models(bf16_dir, mxfp4_dir)
+        return {"bf16": str(bf16_dir), "mxfp4": str(mxfp4_dir)}
 
     @pytest.mark.run_only_on("GPU")
     @pytest.mark.parametrize(
-        "tp,pp,ep,test_name",
+        "tp,pp,ep,parallel_name",
         [
             (1, 2, 1, "PP"),
             (1, 1, 2, "EP"),
         ],
     )
-    def test_gpt_oss_conversion_parallelism(self, gpt_oss_toy_model_path, tmp_path, tp, pp, ep, test_name):
-        out_dir = tmp_path / f"gpt_oss_{test_name}"
+    @pytest.mark.parametrize("source", ["bf16", "mxfp4"])
+    def test_gpt_oss_conversion_parallelism(self, gpt_oss_toy_paths, tmp_path, tp, pp, ep, parallel_name, source):
+        repo_root = Path(__file__).parent.parent.parent.parent.parent.parent
+        bf16_path = gpt_oss_toy_paths["bf16"]
+        toy_path = gpt_oss_toy_paths[source]
+
+        out_dir = tmp_path / f"gpt_oss_{source}_{parallel_name}"
         out_dir.mkdir(exist_ok=True)
 
-        cmd = [
+        common_dist_args = [
             "python",
             "-m",
             "torch.distributed.run",
@@ -98,40 +199,89 @@ class TestGptOssConversion:
             "--data-file=/opt/Megatron-Bridge/.coverage",
             "--source=/opt/Megatron-Bridge/",
             "--parallel-mode",
-            "examples/conversion/hf_megatron_roundtrip_multi_gpu.py",
-            "--hf-model-id",
-            gpt_oss_toy_model_path,
-            "--output-dir",
-            str(out_dir),
-            "--tp",
-            str(tp),
-            "--pp",
-            str(pp),
-            "--ep",
-            str(ep),
         ]
 
-        result = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            cwd=Path(__file__).parent.parent.parent.parent.parent.parent,
-        )
+        if source == "bf16":
+            # Single-step roundtrip: import + export + compare against the source.
+            cmd = common_dist_args + [
+                "examples/conversion/hf_megatron_roundtrip_multi_gpu.py",
+                "--hf-model-id",
+                bf16_path,
+                "--output-dir",
+                str(out_dir),
+                "--tp",
+                str(tp),
+                "--pp",
+                str(pp),
+                "--ep",
+                str(ep),
+            ]
+            result = subprocess.run(cmd, capture_output=True, text=True, cwd=repo_root)
+            if result.returncode != 0:
+                print(f"STDOUT: {result.stdout}")
+                print(f"STDERR: {result.stderr}")
+            assert result.returncode == 0, f"GPT-OSS bf16 {parallel_name} roundtrip failed with rc={result.returncode}"
+        else:
+            # Two-step: (1) import MXFP4 -> save Megatron, (2) reload Megatron and export,
+            # comparing exported HF tensors against the BF16 toy reference (which equals
+            # dequant(MXFP4) by construction).
+            mcore_dir = tmp_path / f"mcore_mxfp4_{parallel_name}"
+            mcore_dir.mkdir(exist_ok=True)
+            import_cmd = common_dist_args + [
+                "examples/conversion/convert_checkpoints_multi_gpu.py",
+                "import",
+                "--hf-model",
+                toy_path,
+                "--megatron-path",
+                str(mcore_dir),
+                "--tp",
+                str(tp),
+                "--pp",
+                str(pp),
+                "--ep",
+                str(ep),
+            ]
+            res = subprocess.run(import_cmd, capture_output=True, text=True, cwd=repo_root)
+            if res.returncode != 0:
+                print(f"STDOUT: {res.stdout}")
+                print(f"STDERR: {res.stderr}")
+            assert res.returncode == 0, f"GPT-OSS mxfp4 {parallel_name} import failed with rc={res.returncode}"
 
-        if result.returncode != 0:
-            print(f"STDOUT: {result.stdout}")
-            print(f"STDERR: {result.stderr}")
-        assert result.returncode == 0, f"GPT-OSS {test_name} conversion failed with {result.returncode}"
+            roundtrip_cmd = common_dist_args + [
+                "examples/conversion/hf_megatron_roundtrip_multi_gpu.py",
+                "--hf-model-id",
+                bf16_path,
+                "--megatron-load-path",
+                str(mcore_dir),
+                "--output-dir",
+                str(out_dir),
+                "--tp",
+                str(tp),
+                "--pp",
+                str(pp),
+                "--ep",
+                str(ep),
+                "--skip-save",
+            ]
+            res = subprocess.run(roundtrip_cmd, capture_output=True, text=True, cwd=repo_root)
+            if res.returncode != 0:
+                print(f"STDOUT: {res.stdout}")
+                print(f"STDERR: {res.stderr}")
+            assert res.returncode == 0, (
+                f"GPT-OSS mxfp4 {parallel_name} roundtrip-vs-bf16 failed with rc={res.returncode}"
+            )
+            # MXFP4 path uses --skip-save, so there's no exported HF directory to inspect; the
+            # roundtrip script's internal verification table is the assertion of correctness.
+            return
 
-        # Verify output structure
-        model_name = Path(gpt_oss_toy_model_path).name
+        # Verify output structure for the BF16 path.
+        model_name = Path(bf16_path).name
         converted_dir = out_dir / model_name
         assert converted_dir.exists()
 
         config_file = converted_dir / "config.json"
         assert config_file.exists()
 
-        # weights can be either consolidated or sharded, and in safetensors or bin
         weights_file_safetensors = converted_dir / "model.safetensors"
         weights_file_pytorch = converted_dir / "pytorch_model.bin"
         weights_found = weights_file_safetensors.exists() or weights_file_pytorch.exists()
@@ -144,11 +294,10 @@ class TestGptOssConversion:
         with open(config_file) as f:
             saved = json.load(f)
 
-        # Minimal sanity checks on saved config
         assert saved["num_hidden_layers"] == GPT_OSS_TOY_OVERRIDES["num_hidden_layers"]
         assert saved["num_attention_heads"] == GPT_OSS_TOY_OVERRIDES["num_attention_heads"]
         assert saved.get("num_local_experts", 0) == GPT_OSS_TOY_OVERRIDES["num_local_experts"]
         assert saved["vocab_size"] == GPT_OSS_TOY_OVERRIDES["vocab_size"]
 
-        print(f"SUCCESS: GPT-OSS {test_name} conversion test completed successfully")
+        print(f"SUCCESS: GPT-OSS {source} {parallel_name} conversion test completed successfully")
         print(f"Converted model saved at: {converted_dir}")


### PR DESCRIPTION
## Summary

Backports the GPT-OSS BF16 `down_proj` orientation fix from #3743 to the `r0.4.0` release branch.

This is a silent inference-correctness bug: BF16 GPT-OSS checkpoints (e.g. `unsloth/gpt-oss-20b-BF16`, or anything `transformers.GptOssForCausalLM` produces at init) imported through the bridge ran inference with `down_proj` weights stored in the wrong orientation. Forward-pass cosine similarity vs HF dropped to ~0.54 on a saved/reloaded BF16-imported Megatron checkpoint, even though the in-memory roundtrip looked clean (import and export were symmetrically broken on the BF16 path).

## Root cause

Per-expert `down_proj` is square for GPT-OSS-20B/120B (`hidden == intermediate`), so the bridge cannot auto-detect orientation from shape alone:

- BF16 checkpoints store it as `[E, intermediate, hidden]`, mirroring `gate_up_proj`'s `[E, hidden, 2*intermediate]` convention.
- MXFP4-dequantized weights come out as `[E, hidden, intermediate]`.
- Megatron's TE `RowParallelGroupedLinear` expects per-expert `(hidden, intermediate)`.

`gate_up_proj` is non-square, so `_align_expert_weight_to_shape` already auto-detects and transposes; `down_proj` was passed straight through with no orientation alignment, so MXFP4 happened to land correct (matching the GEMM layout) and BF16 silently landed transposed.

## Why prior PRs did not fully address this

- **#3162** (`fix gpt-oss down_proj weight handling`): Removed an incorrect import-side transpose and restored the export-side transpose to feed vLLM the HF-convention layout. Resolved the immediate vLLM divergence but left the bridge-internal layout assumption ("Megatron expects `[in, out]`") incorrect — the asymmetric import/export silently corrupted any saved/reloaded checkpoint.
- **#3250** (`adaptive transpose_on_export for GPT-OSS expert weights`): Identified that #3162's asymmetry corrupted save→reload cycles and tried to paper over it by adding an adaptive `transpose_on_export = True` wrapper. Worked for the cases it was tested against but added a special case that the rest of the bridge didn't model uniformly.
- **#3271** (`fix gpt oss export`): Reverted #3250's adaptive wrapper and removed the export-side transpose entirely on the grounds that "the transpose is a NeMo-RL refit concern, not a bridge concern." Restored the symmetric-broken state where BF16 in-memory roundtrip succeeds and inference is silently wrong.

What none of these caught is that **Megatron's TE GroupedLinear expects per-expert `(hidden, intermediate)`** — the standard PyTorch `nn.Linear` convention — not `(intermediate, hidden)`. With BF16 source, the import has to transpose, and the export has to transpose back. With MXFP4 source, dequantization already emits the right layout. A forward-pass cosine-similarity check against HF would have caught any of these regressions; it wasn't run on either prior fix's verification path.

## Fix

- **Import side** — in `GPTOSSBridge.maybe_modify_loaded_hf_weight`, transpose `down_proj` when loading from a non-quantized BF16 checkpoint. Disambiguation: when the per-expert shape is non-square, shape-vs-config uniquely identifies layout; when square (gpt-oss-20b/120b), default to the `transformers.GptOssForCausalLM` init layout `[E, intermediate, hidden]`.
- **Export side** — in `GPTOSSMLPDownProjMapping.megatron_to_hf`, transpose the last two dims of each `ndim>=2` weight tensor on the way out so the grouped-export stack reassembles in HF's `[E, intermediate, hidden]` layout. Under EP, `gather_from_ep_ranks` may have already concatenated per-rank experts into a 3-D `(ep_size, hidden, intermediate)` tensor, so the transpose runs unconditionally on the trailing two dims rather than only on 2-D inputs. Bias mappings are passed through untouched.
- **r0.4.0-only enabler** — restore one line in `MegatronModelBridge.build_conversion_tasks` that stashes `self.hf_pretrained = hf_pretrained`. On `main` this assignment is already present; on `r0.4.0` it was dropped by the decentralized-PG refactor in #3674. The shape-detection in `maybe_modify_loaded_hf_weight` reads `self.hf_pretrained.config`, so we restore the stash to keep that hook self-contained. No behavioral change beyond making the attribute reachable again.

The MXFP4 dequant branch is left as-is (already produces the GEMM-correct layout).

## Test changes

- `tests/functional_tests/test_groups/models/gpt_oss/test_gpt_oss_conversion.py` is rewritten to build two faithful toys from the same underlying weights:
  - BF16 toy with the unsloth-style `[E, hidden, 2*intermediate]` / `[E, intermediate, hidden]` layout.
  - MXFP4 toy with `*_blocks`/`*_scales` whose `_dequantize_mxfp4` output equals the BF16 toy transposed per expert, matching `openai/gpt-oss-20b`'s shipping layout.
- Parametrized over `source ∈ {bf16, mxfp4}` × `{PP=2, EP=2}`. MXFP4 runs as a two-step `convert_checkpoints_multi_gpu.py import` followed by `hf_megatron_roundtrip_multi_gpu.py --megatron-load-path` against the BF16 toy reference, since the verification table cannot resolve `down_proj`/`gate_up_proj` keys in a quantized state dict.
- `hidden_size != intermediate_size` is intentional so any wrong-direction transpose surfaces as a shape mismatch — the previous toy used the MXFP4-dequant orientation for `down_proj`, hiding the bug behind a symmetric pass-through.

## Verification

Real model on this branch (HF reference: `unsloth/gpt-oss-20b-BF16`, TP=1):

| Check | Result |
|---|---:|
| BF16 import → forward cos sim vs HF (PP=8) | 0.999973 ✅ |
| BF16 import → forward cos sim vs HF (EP=8) | 0.999975 ✅ |
| MXFP4 import → forward cos sim vs HF (PP=8) | 0.999973 ✅ |
| MXFP4 import → forward cos sim vs HF (EP=8) | 0.999975 ✅ |
| BF16 import → reload → roundtrip vs BF16 HF (PP=8) | 411/411 ✅ |
| BF16 import → reload → roundtrip vs BF16 HF (EP=8) | 411/411 ✅ |
| MXFP4 import → reload → roundtrip vs BF16 HF (PP=8) | 411/411 ✅ |
| MXFP4 import → reload → roundtrip vs BF16 HF (EP=8) | 411/411 ✅ |

Toy tests on this branch:

| Source | Parallelism | Status |
|---|---|---|
| BF16 | PP=2 | ✅ |
| BF16 | EP=2 | ✅ |
| MXFP4 | PP=2 | ✅ (two-step) |
| MXFP4 | EP=2 | ✅ (two-step) |

## Test plan

- [x] `examples/conversion/compare_hf_and_megatron/compare.py` cos sim vs HF for both BF16 and MXFP4 imports under PP=8 and EP=8
- [x] `examples/conversion/hf_megatron_roundtrip_multi_gpu.py` with `--megatron-load-path` from both BF16 and MXFP4 imports compared against unsloth BF16 under PP=8 and EP=8
- [x] `tests/functional_tests/test_groups/models/gpt_oss/test_gpt_oss_conversion.py` — all 4 parametrizations green
