### PR TITLE
[ci, test] chore: Split L0 converter launch script into conversion and generation

### DIFF
--- a/tests/functional_tests/launch_scripts/h100/active/L0_Launch_converter_generate.sh
+++ b/tests/functional_tests/launch_scripts/h100/active/L0_Launch_converter_generate.sh
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,6 +19,6 @@ export CUDA_VISIBLE_DEVICES="0,1"
 
 uv run coverage run --data-file=/opt/Megatron-Bridge/.coverage --source=/opt/Megatron-Bridge/ --parallel-mode -m pytest \
   -o log_cli=true -o log_cli_level=INFO -v -s -x -m "not pleasefixme" --tb=short -rA \
-  tests/functional_tests/test_groups/converter/test_checkpoint_conversion.py \
-  tests/functional_tests/test_groups/converter/test_multi_gpu_conversion.py
+  tests/functional_tests/test_groups/converter/test_generate_from_hf.py \
+  tests/functional_tests/test_groups/converter/test_generate_vlm_from_hf.py
 coverage combine -q


### PR DESCRIPTION
## Summary

- Split `L0_Launch_converter.sh` into two scripts so the heavier generation tests run as a separate CI matrix entry from the lighter import/export and multi-GPU conversion tests, halving per-job wall clock for either side.
- Drop an existing duplication: `test_hf_fsdp_conversion.py` was running both in the catch-all converter script and in the dedicated `L0_Launch_converter_fsdp.sh`. The split removes the duplicate run.
- No workflow changes — `cicd-main.yml`'s `generate-test-matrix` scans `h100/active/L0_*.sh` dynamically, so the new `L0_Launch_converter_generate.sh` is picked up automatically.

| Script | Tests covered |
|---|---|
| `L0_Launch_converter.sh` (modified) | `test_checkpoint_conversion.py` + `test_multi_gpu_conversion.py` |
| `L0_Launch_converter_generate.sh` (new) | `test_generate_from_hf.py` + `test_generate_vlm_from_hf.py` |
| `L0_Launch_converter_fsdp.sh` (unchanged) | `test_hf_fsdp_conversion.py` |

## Background

This was triggered by a CI timeout investigation on the converter L0 job. Locally on H100 with a populated HF cache, the full 10-test set passes cleanly (PP test = 47s call + 11s setup), so the CI timeout looks environmental (cold HF cache, `hf_xet` network behavior, runner contention) rather than a logic bug. Splitting the job gives each half its own timeout budget and isolates the heavier distributed-launch tests.

## Test plan

- [ ] CI: `L0_Launch_converter` passes (covers `test_checkpoint_conversion` + `test_multi_gpu_conversion`)
- [ ] CI: `L0_Launch_converter_generate` passes (covers `test_generate_from_hf` + `test_generate_vlm_from_hf`)
- [ ] CI: `L0_Launch_converter_fsdp` still passes (unchanged)
- [ ] Verify the matrix generator picks up the new script (it scans `h100/active/L0_*.sh` automatically)

## Follow-up (not in this PR)

- Same split could be applied symmetrically to `tests/functional_tests/launch_scripts/gb200/active/L0_Launch_converter.sh` for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)