### PR TITLE
add missing docstring params in qwen3_asr classes

### DIFF
--- a/src/megatron/bridge/models/qwen3_asr/hf_qwen3_asr/modeling_qwen3_asr.py
+++ b/src/megatron/bridge/models/qwen3_asr/hf_qwen3_asr/modeling_qwen3_asr.py
@@ -993,6 +993,10 @@ class Qwen3ASRThinkerTextModel(Qwen3ASRPreTrainedModel):
         cache_position: Optional[torch.LongTensor] = None,
         **kwargs: Unpack[FlashAttentionKwargs],
     ) -> Union[tuple, BaseModelOutputWithPast]:
+        """
+        cache_position (`torch.Tensor`):
+            Indices depicting the position of the input sequence tokens in the sequence.
+        """
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
 
@@ -1184,6 +1188,8 @@ class Qwen3ASRThinkerForConditionalGeneration(Qwen3ASRPreTrainedModelForConditio
             Labels for computing the masked language modeling loss. Indices should either be in `[0, ...,
             config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored
             (masked), the loss is only computed for the tokens with labels in `[0, ..., config.vocab_size]`.
+        cache_position (`torch.Tensor`):
+            Indices depicting the position of the input sequence tokens in the sequence.
         """
 
         if inputs_embeds is None:


### PR DESCRIPTION
# What does this PR do ?

Add missing docstring params to silence verbose `[ERROR]` messages coming from `transformers`'s `auto_docstring` decorator.

# Changelog

- Add `cache_position` params to docstrings of two Qwen3 ASR classes. The description is copied verbatim from another class that uses the parameter.