### PR TITLE
perf(qwen3-next): set expandable_segments on GB300 BF16/FP8_MX to fix OOM

### DIFF
--- a/scripts/performance/perf_plugins.py
+++ b/scripts/performance/perf_plugins.py
@@ -284,13 +284,17 @@ class PerfEnvPlugin(Plugin):
             model_family_name in ["qwen"]
             and model_recipe_name in ["qwen3_next_80b_a3b"]
             and train_task == "pretrain"
-            and gpu in ["h100"]
-            and compute_dtype == "fp8_cs"
+            and (
+                (gpu == "h100" and compute_dtype == "fp8_cs")
+                or (gpu == "gb300" and compute_dtype in ["bf16", "fp8_mx"])
+            )
         ):
             # NCCL 2.29.7 increases memory pressure on H100, causing allocator
             # fragmentation OOM. expandable_segments lets the allocator reclaim
             # fragmented physical memory and avoids the OOM without disabling
-            # any NCCL algorithms.
+            # any NCCL algorithms. The GB300 BF16/FP8_MX path hits the same
+            # fragmentation pattern at MBS=4 under HybridEP + TE-scoped CUDA
+            # graphs (attn/moe_router/moe_preprocess), so the same fix applies.
             executor.env_vars["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
 
         if model_family_name in ["deepseek"]:


### PR DESCRIPTION
<details><summary>Claude summary</summary>

### Context
The `qwen3_next_80b_a3b_gb300_bf16_50steps_perf` (and FP8_MX twin) test in the nemo-ci pipeline OOMs at first forward on the lyris cluster: `RuntimeError: Triton Error [CUDA]: out of memory` from rank 52 during DDP setup. Reference failing job: <https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/314607989>.

### Cause hypothesis
The GB300 BF16/FP8_MX config is the only GB-series qwen3-next variant with `micro_batch_size=4` (the GB200 sister uses MBS=2; B200/B300/H100 use MBS=1). With HybridEP + TE-scoped CUDA graphs (`attn`, `moe_router`, `moe_preprocess`) the allocator suffers fragmentation when the captured-graph and HybridEP buffer scratch interleave, exactly the same pattern as the existing H100 FP8_CS branch in `perf_plugins.py`.

### Fix
Extend the existing qwen3-next H100 FP8_CS branch to also cover GB300 BF16 and FP8_MX with `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`. **No model-config changes**, no recompute, no MBS reduction — TFLOPs preserved.

```diff
 elif (
     model_family_name in ["qwen"]
     and model_recipe_name in ["qwen3_next_80b_a3b"]
     and train_task == "pretrain"
-    and gpu in ["h100"]
-    and compute_dtype == "fp8_cs"
+    and (
+        (gpu == "h100" and compute_dtype == "fp8_cs")
+        or (gpu == "gb300" and compute_dtype in ["bf16", "fp8_mx"])
+    )
 ):
     executor.env_vars["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
```

### Verification plan
- Triage container `nvcr.io/nvidian/nemo:dgxctestingtemp-nemofw-nightly.50761024` (the exact image the failing pipeline used).
- nemo-ci pipeline TBD (run on lyris, single test case).
- Pass criterion: training step 0 completes (i.e. no OOM at first forward).
- If still OOM: fall through to `recompute_modules=["core_attn"]`, then `["core_attn","moe_act"]`.

</details>
