### PR TITLE
[ci] fix: check-imports action lookup on ARC container runner

### DIFF
--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -214,15 +214,8 @@ jobs:
         shell: bash
         run: bash docker/common/install.sh --base-image pytorch --use-uv
 
-      - name: Checkout check-imports
-        uses: actions/checkout@v6
-        with:
-          repository: NVIDIA-NeMo/FW-CI-templates
-          ref: v0.80.1
-          path: FW-CI-templates
-
       - name: Check imports for megatron-bridge
-        uses: ./FW-CI-templates/.github/actions/check-imports
+        uses: NVIDIA-NeMo/FW-CI-templates/.github/actions/check-imports@v0.80.1
         with:
           package-name: megatron.bridge
           python-binary: ${{ env.UV_PROJECT_ENVIRONMENT }}/bin/python


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## What

Replaces the explicit `actions/checkout` + local-action `uses: ./...` pattern with a direct remote reference to the `check-imports` composite action.

```diff
-      - name: Checkout check-imports
-        uses: actions/checkout@v6
-        with:
-          repository: NVIDIA-NeMo/FW-CI-templates
-          ref: v0.80.1
-          path: FW-CI-templates
-
       - name: Check imports for megatron-bridge
-        uses: ./FW-CI-templates/.github/actions/check-imports
+        uses: NVIDIA-NeMo/FW-CI-templates/.github/actions/check-imports@v0.80.1
```

## Why

On the ARC self-hosted container runner, the in-container workspace path (`/__w/Megatron-Bridge/Megatron-Bridge`) and the host workspace path (`/home/runner/_work/Megatron-Bridge/Megatron-Bridge`) diverge. `actions/checkout` runs in-container and writes `FW-CI-templates/` to the container path, but the GitHub Actions local-action loader resolves `uses: ./...` against the host path, so it cannot find `action.yml`:

```
##[error]Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under
'/home/runner/_work/Megatron-Bridge/Megatron-Bridge/FW-CI-templates/.github/actions/check-imports'.
Did you forget to run actions/checkout before running your local action?
```

This failure reproduces across PRs (3772, 3545, …) — i.e. the workflow on `main` itself is broken.

Because `check-imports` is a composite action hosted in a public repo, referencing it via `NVIDIA-NeMo/FW-CI-templates/.github/actions/check-imports@v0.80.1` sidesteps the checkout entirely — the runner fetches and caches the action via its standard remote-action path, which works regardless of container/host path mapping.

</details>
