### PR TITLE
[model, docs] fix: typo in qwen3_vl rope comment ('seperate' -> 'separate')

### DIFF
--- a/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/rope.py
+++ b/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/rope.py
@@ -192,7 +192,7 @@ def get_rope_index(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Different from the original implementation, Qwen3VL use timestamps rather than absolute time position ids."""
 
-    # Since we use timestamps to seperate videos, like <t1> <vision_start> <frame1> <vision_end> <t2> <vision_start> <frame2> <vision_end>, the video_grid_thw should also be split
+    # Since we use timestamps to separate videos, like <t1> <vision_start> <frame1> <vision_end> <t2> <vision_start> <frame2> <vision_end>, the video_grid_thw should also be split
     if video_grid_thw is not None:
         video_grid_thw = torch.repeat_interleave(video_grid_thw, video_grid_thw[:, 0], dim=0)
         video_grid_thw[:, 0] = 1


### PR DESCRIPTION
## Summary

Single-character typo fix in a code comment inside \`src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/rope.py\`:

\`\`\`diff
-    # Since we use timestamps to seperate videos, ...
+    # Since we use timestamps to separate videos, ...
\`\`\`

## Test plan

- [x] Comment text only — no runtime, API, or behavior change
- [x] Single-file, single-line diff
- [ ] CI lint passes (no code changes affect tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)