### PR TITLE
Fix Qwen3.5-VL 122B SFT GPU guidance

### DIFF
--- a/examples/models/vlm/qwen35_vl/slurm_sft.sh
+++ b/examples/models/vlm/qwen35_vl/slurm_sft.sh
@@ -31,12 +31,13 @@
 #   9B (dense):      TP=4, PP=1         (1 node)
 #   27B (dense):     TP=4, PP=4         (2 nodes)
 #   35B-A3B (MoE):   TP=2, PP=1, EP=16  (2 nodes)
-#   122B-A10B (MoE): TP=2, PP=6, EP=8   (4 nodes)
+#   122B-A10B (MoE): TP=2, PP=6, EP=8   (6 nodes)
 #   397B-A17B (MoE): TP=2, PP=4, EP=32  (16 nodes)
 #
 # Examples:
 #   sbatch slurm_sft.sh 4B
 #   sbatch --nodes=2 slurm_sft.sh 27B
+#   sbatch --nodes=6 slurm_sft.sh 122B-A10B
 #   sbatch --nodes=16 slurm_sft.sh 397B-A17B
 # ==============================================================================
 

--- a/src/megatron/bridge/recipes/qwen_vl/qwen35_vl.py
+++ b/src/megatron/bridge/recipes/qwen_vl/qwen35_vl.py
@@ -424,7 +424,7 @@ def qwen35_vl_35b_a3b_fsdp_sft_config(hf_path: str = "Qwen/Qwen3.5-35B-A3B") -> 
 def qwen35_vl_122b_a10b_sft_config(hf_path: str = "Qwen/Qwen3.5-122B-A10B") -> ConfigContainer:
     """Return a full SFT config for Qwen3.5-VL 122B-A10B (MoE).
 
-    Default configuration: 4 nodes, 32 GPUs
+    Default configuration: 6 nodes, 48 GPUs
     - TP=2, PP=6, EP=8
     - LR=2e-5 (full SFT)
     - Sequence length: 4096

--- a/tests/unit_tests/recipes/qwen_vl/test_qwen35_vl_recipes.py
+++ b/tests/unit_tests/recipes/qwen_vl/test_qwen35_vl_recipes.py
@@ -441,6 +441,13 @@ def test_qwen35_vl_122b_a10b_sft_defaults(monkeypatch: pytest.MonkeyPatch):
     assert cfg.model.tensor_model_parallel_size == 2
     assert cfg.model.pipeline_model_parallel_size == 6
     assert cfg.model.expert_model_parallel_size == 8
+    assert cfg.model.expert_tensor_parallel_size == 1
+    assert (
+        cfg.model.pipeline_model_parallel_size
+        * cfg.model.expert_model_parallel_size
+        * cfg.model.expert_tensor_parallel_size
+        == 48
+    )
     assert cfg.model.pipeline_dtype == torch.bfloat16
     assert cfg.peft is None
     assert cfg.optimizer.lr == 2e-5


### PR DESCRIPTION
## Summary
- correct Qwen3.5-VL 122B-A10B full SFT default GPU guidance from 32 to 48 GPUs
- update the Slurm SFT example to recommend 6 nodes for the 122B-A10B preset
- add a unit assertion covering the 48-rank expert-side requirement from PP=6, EP=8, ETP=1

Fixes #3747

## Testing
- `uvx pre-commit run --files examples/models/vlm/qwen35_vl/slurm_sft.sh src/megatron/bridge/recipes/qwen_vl/qwen35_vl.py tests/unit_tests/recipes/qwen_vl/test_qwen35_vl_recipes.py`
- Unit test left to CI per request