### PR TITLE
[docs, model] feat: add MiniMax-M2 model documentation page

### DIFF
--- a/docs/models/llm/README.md
+++ b/docs/models/llm/README.md
@@ -14,7 +14,7 @@ Megatron Bridge supports the following LLM families:
 | **Gemma 3** | [gemma3.md](gemma3.md) | Google Gemma 3 models |
 | **GLM-4.5** | [glm45.md](glm45.md) | GLM-4.5 model family |
 | **GPT-OSS** | [gpt-oss.md](gpt-oss.md) | Open-source GPT-style models |
-| **MiniMax-M2** | — | MiniMax-M2 / M2.5 / M2.7 (456B MoE, FP8) |
+| **MiniMax-M2** | [minimax-m2.md](minimax-m2.md) | MiniMax-M2 / M2.5 / M2.7 (456B MoE, FP8) |
 | **LLaMA 3** | [llama3.md](llama3.md) | Meta LLaMA 3 models |
 | **LLaMA Nemotron** | [llama-nemotron.md](llama-nemotron.md) | NVIDIA LLaMA Nemotron models |
 | **Mistral** | [mistral.md](mistral.md) | Mistral AI models |

--- a/docs/models/llm/index.md
+++ b/docs/models/llm/index.md
@@ -13,6 +13,7 @@ glm45.md
 gpt-oss.md
 llama3.md
 llama-nemotron.md
+minimax-m2.md
 mistral.md
 moonlight.md
 nemotron3.md

--- a/docs/models/llm/minimax-m2.md
+++ b/docs/models/llm/minimax-m2.md
@@ -1,0 +1,87 @@
+# MiniMax-M2
+
+[MiniMax-M2](https://huggingface.co/MiniMaxAI/MiniMax-M2) from **MiniMax AI**
+is a large sparse Mixture-of-Experts model with **456B total parameters
+(45.9B active)**, **256 experts**, and **FP8 block-wise quantization**.
+
+The same Bridge supports the closely related
+[MiniMax-M2.5](https://huggingface.co/MiniMaxAI/MiniMax-M2.5) and
+[MiniMax-M2.7](https://huggingface.co/MiniMaxAI/MiniMax-M2.7) checkpoints —
+they share the `MiniMaxM2ForCausalLM` architecture and route through the same
+[`MiniMaxM2Bridge`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/src/megatron/bridge/models/minimax_m2/minimax_m2_bridge.py).
+
+## Hardware requirements
+
+MiniMax-M2 requires **at least 2 nodes (16 GPUs)** for inference and
+checkpoint conversion. It cannot fit on a single 8-GPU node:
+
+- `TEGroupedMLP` workspace is proportional to `num_experts / EP`. With `EP=8`
+  on a single node the workspace alone OOMs.
+- Tensor parallelism does **not** reduce expert memory — use **expert
+  parallelism** instead.
+- Minimum recommended layout: `TP=1, EP=16, PP=1` (2 nodes × 8 GPUs).
+
+## FP8 block-wise quantization
+
+The HF checkpoint ships in FP8 with 128×128 block-wise scaling. The Bridge
+dequantizes weights to BF16 on import using the block scale tensor stored
+next to each FP8 weight — there is no separate "FP8 mode" you need to enable
+on the Bridge side. On export the Bridge writes BF16 by default; passing
+through the original FP8 quantization is not currently supported.
+
+## Conversion with 🤗 Hugging Face
+
+### Load HF → Megatron
+
+```python
+from megatron.bridge import AutoBridge
+
+# Works for M2 / M2.5 / M2.7 — same MiniMaxM2ForCausalLM architecture
+bridge = AutoBridge.from_hf_pretrained("MiniMaxAI/MiniMax-M2")
+provider = bridge.to_megatron_provider()
+
+# Required parallelism shape on 2 × H100 nodes
+provider.tensor_model_parallel_size = 1
+provider.expert_model_parallel_size = 16
+provider.pipeline_model_parallel_size = 1
+provider.sequence_parallel = True
+
+provider.finalize()
+model = provider.provide_distributed_model(wrap_with_ddp=False)
+```
+
+For larger clusters, `(TP, PP, EP)` sweeps verified end-to-end against
+the round-trip test in `examples/models/minimax_m2/slurm_conversion.sh`
+include `2,1,8`, `1,2,8`, and `2,2,4`.
+
+### Export Megatron → HF
+
+```python
+bridge.export_ckpt(
+    megatron_path="/results/minimax_m2/checkpoints/iter_0010000",
+    hf_path="./minimax-m2-hf-export",
+)
+```
+
+## Examples
+
+The end-to-end Slurm scripts live in
+[`examples/models/minimax_m2/`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/examples/models/minimax_m2):
+
+- [`slurm_conversion.sh`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/examples/models/minimax_m2/slurm_conversion.sh)
+  — sweeps multiple `TP/PP/EP` configs and verifies HF↔Megatron round-trip
+- [`slurm_inference.sh`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/examples/models/minimax_m2/slurm_inference.sh)
+  — text generation on the full FP8 checkpoint with `TP=1, EP=16`
+
+## Recipes
+
+MiniMax-M2 currently ships **conversion + inference** through the Bridge.
+Pretrain / SFT / PEFT recipes are not yet included in
+`src/megatron/bridge/recipes/`. If you need to train this model family,
+build your config on top of the provider returned by
+`AutoBridge.from_hf_pretrained(...)` and look at the multi-node Slurm
+patterns under `examples/models/minimax_m2/` as a starting point.
+
+For more context on parallelism shape, see
+[`../../parallelisms.md`](../../parallelisms.md) and
+[`../../training/moe-optimization.md`](../../training/moe-optimization.md).


### PR DESCRIPTION
## Summary

The Available Models table in \`docs/models/llm/README.md\` lists MiniMax-M2 (456B MoE, FP8) as supported but has \`—\` in the Documentation column. The bridge has shipped since 0.4.0 and serves **M2 / M2.5 / M2.7** (all use the \`MiniMaxM2ForCausalLM\` architecture), plus there are working Slurm conversion/inference examples under \`examples/models/minimax_m2/\` — so the docs gap is the only thing missing.

## What this PR adds

### \`docs/models/llm/minimax-m2.md\` (new)

- Model family overview (456B total / 45.9B active, 256 experts, FP8 block-wise quantization)
- M2 / M2.5 / M2.7 share architecture and the same Bridge
- **Hardware requirements** — minimum 2 nodes / 16 GPUs, \`TEGroupedMLP\` workspace constraints, why TP doesn't help and EP must be used
- **FP8 block-wise import note** — Bridge dequantizes 128×128 blocks to BF16 automatically; FP8 passthrough on export not supported
- HF → Megatron load with the recommended \`TP=1 EP=16 PP=1\` layout (and verified \`(TP, PP, EP)\` configs from the round-trip script)
- Megatron → HF export snippet
- Pointer to the Slurm scripts in \`examples/models/minimax_m2/\`
- Honest "recipes not yet shipped" note pointing users at the example scripts as a starting point

### \`docs/models/llm/index.md\` (modified)

- Add \`minimax-m2.md\` to the toctree in alphabetical position

### \`docs/models/llm/README.md\` (modified)

- Replace \`—\` with the link in the Available Models row

## Test plan

- [x] Docs-only change — no code, API, or tests touched
- [x] Architecture / hardware details verified against \`src/megatron/bridge/models/minimax_m2/minimax_m2_bridge.py\` (FP8 dequantization) and \`examples/models/minimax_m2/README.md\` (hardware reqs, verified configs)
- [x] Eligible for \`docs-only\` label which skips functional CI
- [ ] Docs build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)