### PR TITLE
Add option to disable MLFlow artifact logging

### DIFF
--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -1215,6 +1215,8 @@ def save_checkpoint(
             )
 
         def mlflow_finalize_fn() -> None:
+            if not state.cfg.logger.mlflow_log_artifacts:
+                return
             mlflow_utils.on_save_checkpoint_success(
                 checkpoint_name,
                 save_dir,

--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -706,6 +706,9 @@ class LoggerConfig(MTrainLoggerConfig):
     mlflow_tags: Optional[dict[str, str]] = None
     """Optional tags to apply to the MLFlow run."""
 
+    mlflow_log_artifacts: bool = True
+    """Whether to upload checkpoint artifacts to MLFlow via HTTP after each save."""
+
     comet_project: Optional[str] = None
     """The Comet ML project name. Comet logging is disabled when this is None."""
 


### PR DESCRIPTION
# What does this PR do ?

Unlike other loggers, MLFlow's artifact logging uploads over http rather than creating a link / storing a path, which is outrageously slow for large checkpoints. Some users may still want this, but this gives the option to disable it (in my case for example, checkpoints are on lustre/nvme and sync'd in the background as-needed to avoid blocking the training process).

# Changelog

- Adds an arg to toggle MLFlow artifact logging which is the only action in the finalize currently.
