### PR TITLE
[misc] fix: Handle bracketed entries inside mixed Slurm nodelists

### DIFF
--- a/src/megatron/bridge/utils/slurm_utils.py
+++ b/src/megatron/bridge/utils/slurm_utils.py
@@ -125,6 +125,7 @@ def _parse_slurm_nodelist(nodelist: str) -> str:
     - Simple list: "node001,node002" -> "node001"
     - Range: "node[001-004]" -> "node001"
     - List in brackets: "node[001,003,005]" -> "node001"
+    - Mixed entries: "nodeA,nodeB[1-3],nodeC" -> "nodeA"
 
     Args:
         nodelist: The SLURM nodelist string to parse.
@@ -132,19 +133,24 @@ def _parse_slurm_nodelist(nodelist: str) -> str:
     Returns:
         The hostname of the first node in the list.
     """
-    # Handle bracket notation: "prefix[range]" or "prefix[list]"
-    if "[" in nodelist:
-        # Split into base and range part
-        # e.g., "node[001-004]" -> base="node", range_part="001-004"
-        base = nodelist.split("[")[0]
-        range_part = nodelist.split("[")[1].split("]")[0]
+    # Find the first entry by scanning for a top-level comma (i.e., one
+    # that is not inside a "[...]" group).
+    in_bracket = False
+    end = len(nodelist)
+    for i, ch in enumerate(nodelist):
+        if ch == "[":
+            in_bracket = True
+        elif ch == "]":
+            in_bracket = False
+        elif ch == "," and not in_bracket:
+            end = i
+            break
+    first = nodelist[:end].strip()
 
-        # Handle both ranges (001-004) and lists (001,003,005)
-        # Extract first element
-        first_element = range_part.split(",")[0].split("-")[0]
-
+    # If the first entry itself uses bracket expansion, expand to the first node.
+    if "[" in first:
+        base, _, rest = first.partition("[")
+        inside = rest.split("]")[0]
+        first_element = inside.split(",")[0].split("-")[0]
         return f"{base}{first_element}"
-    else:
-        # Simple comma-separated list
-        # e.g., "node001,node002,node003" -> "node001"
-        return nodelist.split(",")[0].strip()
+    return first

--- a/tests/unit_tests/utils/test_slurm_utils.py
+++ b/tests/unit_tests/utils/test_slurm_utils.py
@@ -128,6 +128,29 @@ class TestParseSLURMNodelist:
         """Test parsing preserves zero-padded numbers."""
         assert _parse_slurm_nodelist("node[001-100]") == "node001"
 
+    def test_mixed_entries_bracket_in_middle(self):
+        """First entry is a plain node; a bracketed entry appears later in the list."""
+        nodelist = "nodeA,nodeB[001,003],nodeC"
+        assert _parse_slurm_nodelist(nodelist) == "nodeA"
+
+    def test_mixed_entries_bracket_first(self):
+        """First entry uses bracket expansion, followed by plain nodes."""
+        nodelist = "nodeA[001-003],nodeB,nodeC"
+        assert _parse_slurm_nodelist(nodelist) == "nodeA001"
+
+    def test_multiple_bracket_groups(self):
+        """Multiple bracketed groups in the list — must not merge them."""
+        assert _parse_slurm_nodelist("nodeA[001-003],nodeB[005-007]") == "nodeA001"
+
+    def test_mixed_plain_and_bracketed_entries(self):
+        """Long list of plain hostnames with a bracketed entry buried in the middle."""
+        nodelist = (
+            "hostA01,hostA02,hostB01,hostA03,hostA04,hostB02,"
+            "hostC[10,12],hostA05,hostB03,hostC04,hostA06,"
+            "hostC05,hostA07,hostB04,hostA08"
+        )
+        assert _parse_slurm_nodelist(nodelist) == "hostA01"
+
 
 class TestResolveSLURMMasterAddr:
     """Test resolve_slurm_master_addr function."""


### PR DESCRIPTION
_parse_slurm_nodelist took the bracket branch whenever "[" appeared anywhere in the nodelist, then split on the first "[" — so a nodelist like "nodeA,nodeB[001,003],nodeC" produced "nodeA,nodeB001" instead of "nodeA".

To test the previous version in isolation:
```python3
def _parse_slurm_nodelist(nodelist: str) -> str:
    """Parse a SLURM nodelist string and extract the first node.

    Handles common SLURM nodelist formats:
    - Simple list: "node001,node002" -> "node001"
    - Range: "node[001-004]" -> "node001"
    - List in brackets: "node[001,003,005]" -> "node001"

    Args:
        nodelist: The SLURM nodelist string to parse.

    Returns:
        The hostname of the first node in the list.
    """
    # Handle bracket notation: "prefix[range]" or "prefix[list]"
    if "[" in nodelist:
        # Split into base and range part
        # e.g., "node[001-004]" -> base="node", range_part="001-004"
        base = nodelist.split("[")[0]
        range_part = nodelist.split("[")[1].split("]")[0]

        # Handle both ranges (001-004) and lists (001,003,005)
        # Extract first element
        first_element = range_part.split(",")[0].split("-")[0]

        return f"{base}{first_element}"
    else:
        # Simple comma-separated list
        # e.g., "node001,node002,node003" -> "node001"
        return nodelist.split(",")[0].strip()


nodelist = "nodeA,nodeB[001,003],nodeC"
print(_parse_slurm_nodelist(nodelist))
```
Run:
```console
$ python3 test.py
nodeA,nodeB001
```