### PR TITLE
[doc] fix: deduplicate Performance TOC entries and surface summary at top level

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3,12 +3,18 @@
 ```
 
 ```{toctree}
+:caption: Performance
+:hidden:
+
+performance-summary.md
+performance-summary-archive.md
+```
+
+```{toctree}
 :caption: Guides
 :hidden:
 
 parallelisms.md
-performance-summary.md
-performance-summary-archive.md
 performance-guide.md
 recipe-usage.md
 nemo2-migration-guide.md

--- a/docs/performance-summary-archive.md
+++ b/docs/performance-summary-archive.md
@@ -1,6 +1,6 @@
-NOTE: This page contains performance summary for past releases. You can find summary for the latest release at [performance-summary.md](performance-summary.md).
+# Performance Archive
 
-# Performance
+NOTE: This page contains performance summaries for past releases. You can find the summary for the latest release at [performance-summary.md](performance-summary.md).
 
 As part of the NVIDIA NeMo Framework, Megatron Bridge, provides optimal performance for training advanced generative AI models by incorporating the most recent training techniques, such as model parallelization, optimized attention mechanisms, and more, to achieve high training throughput.
 


### PR DESCRIPTION
## Summary

The docs sidebar was showing **two identical "Performance" entries** under the **Guides** caption because both `docs/performance-summary.md` and `docs/performance-summary-archive.md` use `# Performance` as their H1.

This PR:

- Splits the toctree in `docs/index.md`: pulls `performance-summary.md` and `performance-summary-archive.md` out of **Guides** into their own top-level **Performance** caption (the perf summary is a top-level reference page, not a how-to guide).
- Renames the archive H1 from `# Performance` → `# Performance Archive` so the TOC label is unique.
- Reflows the archive's intro so the "past releases" note sits below the new title.

`docs/performance-guide.md` (Performance Tuning Guide) stays under **Guides** — it is a tuning how-to, not a benchmark page.

## Before / After (TOC)

Before:
- Guides
  - Parallelisms Guide
  - **Performance**       <-- duplicate
  - **Performance**       <-- duplicate (archive)
  - Performance Tuning Guide
  - ...

After:
- **Performance** (new top-level caption)
  - Performance
  - Performance Archive
- Guides
  - Parallelisms Guide
  - Performance Tuning Guide
  - ...

## Test plan

- [ ] Build the docs locally / on CI and confirm the sidebar shows a single top-level **Performance** section with two distinct entries (Performance, Performance Archive), and no duplicates remain under **Guides**.