### PR TITLE
qwen3 next env var fix

### DIFF
--- a/scripts/performance/perf_plugins.py
+++ b/scripts/performance/perf_plugins.py
@@ -296,6 +296,7 @@ class PerfEnvPlugin(Plugin):
             # fragmentation pattern at MBS=4 under HybridEP + TE-scoped CUDA
             # graphs (attn/moe_router/moe_preprocess), so the same fix applies.
             executor.env_vars["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
+            executor.env_vars["NCCL_GRAPH_REGISTER"] = "0"
         elif (
             model_family_name in ["nemotronh"]
             and model_recipe_name in ["nemotron_3_super"]


### PR DESCRIPTION
# What does this PR do ?

Add `NCCL_GRAPH_REGISTER="0"` to `executor.env_vars` to avoid functional error when using cuda graphs with `PYTORCH_CUDA_ALLOC_CONF="expandable_segments:True"` env var.

# Changelog

```
executor.env_vars["NCCL_GRAPH_REGISTER"] = "0"
```

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
