### PR TITLE
[test] fix: Update DiT attention test submodules

### DIFF
--- a/tests/unit_tests/diffusion/model/common/test_dit_attention.py
+++ b/tests/unit_tests/diffusion/model/common/test_dit_attention.py
@@ -70,6 +70,7 @@ def _make_self_attn_submodules(q_layernorm=None, k_layernorm=None):
     sub = SelfAttentionSubmodules(
         linear_qkv=MagicMock(),
         core_attention=MagicMock(),
+        linear_proj=MagicMock(),
     )
     sub.q_layernorm = q_layernorm
     sub.k_layernorm = k_layernorm


### PR DESCRIPTION
## Summary
- Fixes the DiT attention unit-test helper for the MCore main signature change tracked by Linear MB-371 and bump PR #3843.
- Adds the required `linear_proj=MagicMock()` field to the mocked `SelfAttentionSubmodules`.
- Production specs already pass `linear_proj`; this is a test-helper compatibility fix.

## Validation
- `git diff --check`
- `uv run --no-sync ruff check tests/unit_tests/diffusion/model/common/test_dit_attention.py`
- `uv run --no-sync ruff format --check tests/unit_tests/diffusion/model/common/test_dit_attention.py`
- cw Slurm job 11782931: `uv sync && uv run --no-sync python -m pytest tests/unit_tests/diffusion/model/common/test_dit_attention.py -v`
- Result: 18 passed, 33 warnings in 2.81s

Related: #3843, MB-371