### PR TITLE
Re-apply transformers 5.8.1 for CI investigation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ classifiers = [
     "Topic :: Utilities",
 ]
 dependencies = [
-    "transformers>=5.5.0,<=5.6.0",
+    "transformers>=5.8.1,<5.9.0",
     "mistral-common>=1.10.0",
     "peft>=0.18.1",
     "datasets>=2.20.0",

--- a/skills/cicd/SKILL.md
+++ b/skills/cicd/SKILL.md
@@ -87,6 +87,17 @@ gh pr checks "$PR_NUMBER" --repo NVIDIA-NeMo/Megatron-Bridge
    ```
 6. **Cross-reference the changeset** against the failing step.
 
+### Hugging Face Model Access In CI
+
+Assume CI functional-test containers run with Hugging Face models offline
+(`HF_HUB_OFFLINE=1`) and a pre-populated `HF_HOME`. When reproducing or
+fixing CI failures involving HF models, mirror this locally by setting
+`HF_HUB_OFFLINE=1` after warming the cache. Test fixtures must not depend on
+live Hub API calls such as `list_repo_files()` or uncached downloads during CI.
+For `trust_remote_code=True` toy checkpoints, copy custom Python modules from
+the already loaded local/cache source files or a local snapshot, not by listing
+the remote repo at test time.
+
 ## Common Failure Patterns
 
 | Symptom | Likely Cause | Action |
@@ -96,6 +107,7 @@ gh pr checks "$PR_NUMBER" --repo NVIDIA-NeMo/Megatron-Bridge
 | Container build fails | Dependency conflict or stale `uv.lock` | Re-run `uv lock` inside Docker and commit updated lock |
 | Unit tests fail | Code regression or missing import | Run failing test locally; check the PR diff |
 | Functional test (L0) fails | Integration breakage | Check GPU runner logs; reproduce with `L0_Launch_*.sh` |
+| HF model fixture passes locally but fails in CI with `OfflineModeIsEnabled` | Test made a live Hugging Face Hub API/download call; CI has `HF_HUB_OFFLINE=1` | Warm local cache, reproduce with `HF_HUB_OFFLINE=1`, and change the fixture to use cached/local artifacts only |
 | `cicd-wait-in-queue` running long | Many PRs queued; automation serializes runners to avoid interleaving | Wait; or check queue depth in the Actions tab |
 | MCore submodule mismatch | Pinned commit out of sync | Update `3rdparty/Megatron-LM` submodule and re-lock |
 | Stale checkpoint auto-resume | `nemo_experiments/` from a previous run exists | `rm -rf nemo_experiments` before starting fresh |

--- a/tests/functional_tests/test_groups/models/glm_vl/test_glm_45v_conversion.py
+++ b/tests/functional_tests/test_groups/models/glm_vl/test_glm_45v_conversion.py
@@ -88,6 +88,39 @@ HF_GLM_45V_TOY_MODEL_CONFIG = {
 }
 
 
+def _save_minimal_fast_tokenizer(save_directory: Path) -> None:
+    """Save a small tokenizer.json so Transformers 5.x can load the toy checkpoint offline."""
+    from tokenizers import Tokenizer
+    from tokenizers.models import WordLevel
+    from tokenizers.pre_tokenizers import Whitespace
+    from transformers import PreTrainedTokenizerFast
+
+    end_of_text = "<|endoftext|>"
+    unknown = "<unk>"
+    tokenizer = Tokenizer(
+        WordLevel(
+            {
+                end_of_text: 0,
+                unknown: 1,
+                "<|image|>": 2,
+                "<|video|>": 3,
+            },
+            unk_token=unknown,
+        )
+    )
+    tokenizer.pre_tokenizer = Whitespace()
+
+    hf_tokenizer = PreTrainedTokenizerFast(
+        tokenizer_object=tokenizer,
+        bos_token=end_of_text,
+        eos_token=end_of_text,
+        pad_token=end_of_text,
+        unk_token=unknown,
+        model_max_length=HF_GLM_45V_TOY_MODEL_CONFIG["text_config"]["max_position_embeddings"],
+    )
+    hf_tokenizer.save_pretrained(save_directory)
+
+
 class TestGLM45VConversion:
     """
     Test GLM-4.5V model conversion from local HuggingFace model with different parallelism configurations.
@@ -133,28 +166,10 @@ class TestGLM45VConversion:
             print(f"Before save - {name}: {param.dtype}")
             break  # Just check the first parameter
 
-        # Download and save tokenizer from a reference Qwen25 VL model
-        # We use the smallest available Qwen25 VL model for tokenizer artifacts
-        try:
-            from transformers import AutoTokenizer
-
-            tokenizer = AutoTokenizer.from_pretrained("zai-org/GLM-4.5V")
-            tokenizer.save_pretrained(model_dir)
-        except Exception as e:
-            print(f"Warning: Could not download tokenizer, creating minimal tokenizer files: {e}")
-            # Create minimal tokenizer files if download fails
-            # This is a fallback for offline environments
-            tokenizer_config = {
-                "tokenizer_class": "Qwen2Tokenizer",
-                "vocab_size": 151936,
-                "bos_token": "<|endoftext|>",
-                "eos_token": "<|endoftext|>",
-                "pad_token": "<|endoftext|>",
-                "unk_token": "<|endoftext|>",
-            }
-
-            with open(model_dir / "tokenizer_config.json", "w") as f:
-                json.dump(tokenizer_config, f, indent=2)
+        # The conversion only needs tokenizer artifacts to be loadable and saveable.
+        # A deterministic fast tokenizer keeps this fixture independent of optional
+        # tiktoken/sentencepiece installs required by the full GLM tokenizer.
+        _save_minimal_fast_tokenizer(model_dir)
 
         # Save model and config to directory
         model.save_pretrained(model_dir, safe_serialization=True)

--- a/tests/functional_tests/test_groups/models/kimi_vl/test_kimi_k25_vl_conversion.py
+++ b/tests/functional_tests/test_groups/models/kimi_vl/test_kimi_k25_vl_conversion.py
@@ -31,11 +31,80 @@ from pathlib import Path
 
 import pytest
 import torch
-from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
+from transformers import AutoConfig, AutoModelForCausalLM
 
 # Patch is_torch_fx_available (removed in transformers 5.x) before any Kimi
 # custom model code is loaded via trust_remote_code.
 import megatron.bridge.models.conversion.transformers_compat  # noqa: F401
+
+
+def _copy_custom_code_from_source(model_dir: Path, source_file: str | Path) -> None:
+    """Copy custom Python modules needed for local trust_remote_code loading."""
+    copied_files: set[str] = set()
+    source_file = Path(source_file)
+    source_dir = source_file.parent
+
+    for py_file in source_dir.glob("*.py"):
+        target = model_dir / py_file.name
+        shutil.copy2(py_file, target)
+        copied_files.add(py_file.name)
+
+    from transformers.dynamic_module_utils import get_relative_import_files
+
+    for source in map(Path, get_relative_import_files(source_file)):
+        target = model_dir / source.name
+        if target.name not in copied_files:
+            shutil.copy2(source, target)
+            copied_files.add(target.name)
+
+
+def _make_recursive_imports_direct(module_file: Path) -> None:
+    """Work around Transformers 5.x local dynamic-module copying of only direct relative imports."""
+    from transformers.dynamic_module_utils import get_relative_import_files, get_relative_imports
+
+    direct_imports = set(get_relative_imports(module_file))
+    recursive_imports = {Path(path).stem for path in get_relative_import_files(module_file)}
+    missing_direct_imports = sorted(recursive_imports - direct_imports)
+    if not missing_direct_imports:
+        return
+
+    with open(module_file, "a") as f:
+        f.write("\n# Ensure Transformers copies recursive dynamic-module dependencies from local checkpoints.\n")
+        for module_name in missing_direct_imports:
+            f.write(f"from .{module_name} import *  # noqa: F403\n")
+
+
+def _save_minimal_fast_tokenizer(save_directory: Path) -> None:
+    """Save tokenizer artifacts that Transformers 5.x can reload without tiktoken."""
+    from tokenizers import Tokenizer
+    from tokenizers.models import WordLevel
+    from tokenizers.pre_tokenizers import Whitespace
+    from transformers import PreTrainedTokenizerFast
+
+    end_of_text = "<|endoftext|>"
+    unknown = "<unk>"
+    tokenizer = Tokenizer(
+        WordLevel(
+            {
+                end_of_text: 0,
+                unknown: 1,
+                "<image>": 2,
+                "<video>": 3,
+            },
+            unk_token=unknown,
+        )
+    )
+    tokenizer.pre_tokenizer = Whitespace()
+
+    hf_tokenizer = PreTrainedTokenizerFast(
+        tokenizer_object=tokenizer,
+        bos_token=end_of_text,
+        eos_token=end_of_text,
+        pad_token=end_of_text,
+        unk_token=unknown,
+        model_max_length=4096,
+    )
+    hf_tokenizer.save_pretrained(save_directory)
 
 
 class TestKimiK25VLConversion:
@@ -139,24 +208,12 @@ class TestKimiK25VLConversion:
         # Copy custom code files so the saved checkpoint can be loaded with
         # trust_remote_code=True from the local path.
         source_file = inspect.getfile(type(model))
-        source_dir = Path(source_file).parent
-        for py_file in source_dir.glob("*.py"):
-            target = model_dir / py_file.name
-            if not target.exists():
-                shutil.copy2(py_file, target)
+        _copy_custom_code_from_source(model_dir, source_file)
+        _make_recursive_imports_direct(model_dir / Path(source_file).name)
 
         config.save_pretrained(model_dir)
 
-        try:
-            tokenizer = AutoTokenizer.from_pretrained("moonshotai/Kimi-K2.5", trust_remote_code=True)
-            tokenizer.save_pretrained(model_dir)
-        except Exception:
-            tokenizer_config = {
-                "tokenizer_class": "PreTrainedTokenizerFast",
-                "vocab_size": 2048,
-            }
-            with open(model_dir / "tokenizer_config.json", "w") as f:
-                json.dump(tokenizer_config, f, indent=2)
+        _save_minimal_fast_tokenizer(model_dir)
 
         return str(model_dir)
 

--- a/tests/functional_tests/test_groups/models/nemotronh/test_nemotron_h_conversion.py
+++ b/tests/functional_tests/test_groups/models/nemotronh/test_nemotron_h_conversion.py
@@ -45,6 +45,37 @@ def _fix_tied_weights_keys(model: nn.Module):
             module._tied_weights_keys = {k: k for k in tied}
 
 
+def _copy_custom_code_from_source(model_dir: Path, source_file: str | Path) -> None:
+    """Copy custom modeling/configuration modules needed for local trust_remote_code loading."""
+    copied_files: set[str] = set()
+
+    source_file = Path(source_file)
+    source_dir = source_file.parent
+    for py_file in source_dir.glob("*.py"):
+        target = model_dir / py_file.name
+        shutil.copy2(py_file, target)
+        copied_files.add(target.name)
+
+    from transformers.dynamic_module_utils import get_relative_import_files
+
+    for source in map(Path, get_relative_import_files(source_file)):
+        target = model_dir / source.name
+        if target.name not in copied_files:
+            shutil.copy2(source, target)
+            copied_files.add(target.name)
+
+
+def _set_temp_hf_modules_cache(monkeypatch: pytest.MonkeyPatch, temp_hf_modules_cache: Path) -> None:
+    """Point dynamic module loading at a per-test cache and clear stale local modules."""
+    monkeypatch.setattr(dynamic_module_utils, "HF_MODULES_CACHE", str(temp_hf_modules_cache))
+    monkeypatch.syspath_prepend(str(temp_hf_modules_cache))
+    (temp_hf_modules_cache / "__init__.py").touch()
+
+    for module_name in list(sys.modules):
+        if module_name == "transformers_modules" or module_name.startswith("transformers_modules."):
+            monkeypatch.delitem(sys.modules, module_name)
+
+
 # Overrides for 8B size
 HF_NEMOTRONH_TOY_MODEL_OVERRIDES = {
     "attention_head_dim": 48,
@@ -130,7 +161,7 @@ class TestNemotronHConversion:
         # directly from the HF Hub and are unaffected.
         model.save_pretrained(model_dir, safe_serialization=True, save_original_format=False)
         modeling_filepath = os.path.abspath(sys.modules[model_class.__module__].__file__)
-        shutil.copy(modeling_filepath, model_dir)
+        _copy_custom_code_from_source(model_dir, modeling_filepath)
 
         # Ensure config.json exists with expected keys
         config_path = model_dir / "config.json"
@@ -413,7 +444,7 @@ class TestNemotron3NanoConversion:
         # Check the notes above in TestNemotronHConversion.test_toy_model_creation for more details.
         model.save_pretrained(model_dir, safe_serialization=True, save_original_format=False)
         modeling_filepath = os.path.abspath(sys.modules[model_class.__module__].__file__)
-        shutil.copy(modeling_filepath, model_dir)
+        _copy_custom_code_from_source(model_dir, modeling_filepath)
 
         # Ensure config.json exists with expected keys
         config_path = model_dir / "config.json"
@@ -427,7 +458,7 @@ class TestNemotron3NanoConversion:
         """Change transformers.dynamic_module_utils.HF_MODULES_CACHE to a temp path"""
         temp_hf_modules_cache = tmp_path / "hf_modules_cache"
         temp_hf_modules_cache.mkdir(exist_ok=True)
-        monkeypatch.setattr(dynamic_module_utils, "HF_MODULES_CACHE", temp_hf_modules_cache)
+        _set_temp_hf_modules_cache(monkeypatch, temp_hf_modules_cache)
         yield temp_hf_modules_cache
 
     def test_toy_model_creation(self, nemotron_3_nano_toy_model_path, temp_hf_modules):
@@ -709,7 +740,7 @@ class TestNemotron3SuperConversion:
             ]
         model.save_pretrained(model_dir, safe_serialization=True)
         modeling_filepath = os.path.abspath(sys.modules[model_class.__module__].__file__)
-        shutil.copy(modeling_filepath, model_dir)
+        _copy_custom_code_from_source(model_dir, modeling_filepath)
 
         # Ensure config.json exists with expected keys
         config_path = model_dir / "config.json"
@@ -723,7 +754,7 @@ class TestNemotron3SuperConversion:
         """Change transformers.dynamic_module_utils.HF_MODULES_CACHE to a temp path"""
         temp_hf_modules_cache = tmp_path / "hf_modules_cache"
         temp_hf_modules_cache.mkdir(exist_ok=True)
-        monkeypatch.setattr(dynamic_module_utils, "HF_MODULES_CACHE", temp_hf_modules_cache)
+        _set_temp_hf_modules_cache(monkeypatch, temp_hf_modules_cache)
         yield temp_hf_modules_cache
 
     def test_toy_model_creation(self, nemotron_3_super_toy_model_path, temp_hf_modules):

--- a/tests/functional_tests/test_groups/recipes/utils.py
+++ b/tests/functional_tests/test_groups/recipes/utils.py
@@ -267,6 +267,8 @@ def run_pretrain_vl_recipe_test(
 
         # Keep runs short and consistent across tests
         config.train.train_iters = 10
+        config.train.eval_interval = None
+        config.train.eval_iters = None
         config.validation.eval_interval = 5
         config.validation.eval_iters = 2
         # Standardize batch sizes for functional tests

--- a/uv.lock
+++ b/uv.lock
@@ -2467,7 +2467,7 @@ requires-dist = [
     { name = "torch", specifier = ">=2.6.0" },
     { name = "tqdm", specifier = ">=4.67.1" },
     { name = "transformer-engine", extras = ["core-cu13", "pytorch"], marker = "extra == 'te'" },
-    { name = "transformers", specifier = ">=5.5.0,<=5.6.0" },
+    { name = "transformers", specifier = "==5.8.1" },
     { name = "typing-extensions" },
     { name = "wandb", specifier = ">=0.25.0" },
 ]
@@ -5163,7 +5163,7 @@ dependencies = [
 
 [[package]]
 name = "transformers"
-version = "5.6.0"
+version = "5.8.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
@@ -5176,9 +5176,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/88/14/e3eb58bd4c9df45af154f9de59a6e66a2ece30dd64434c710e40e5a4b1f1/transformers-5.6.0.tar.gz", hash = "sha256:291951976b79a6f93ec06d6ab14489a99aecdbc8f05aaabab538ea1d508c9a97", size = 8311711, upload-time = "2026-04-22T15:42:03.393Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/e6/4134ea2fbea322cddc7ffc94a0d8ee47fe32ce8e876b320cd37d88edfc4d/transformers-5.8.1.tar.gz", hash = "sha256:4dd5b6de4105725104d84fd6abd74b305f4debfc251b38c648ee5dd087cf543b", size = 8532019, upload-time = "2026-05-13T03:21:57.234Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e8/80/ac700df26a83969d2cf8d09d3dd191bb9bbe8156fa4607e614438b1da8c8/transformers-5.6.0-py3-none-any.whl", hash = "sha256:def5aac47b28e2f1386fa64f2f458a5474ba7733ab74c1765e7c67a79d1f1cbd", size = 10364790, upload-time = "2026-04-22T15:41:58.723Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b1/8be7e7ef0b5200491312201918b6125ef9c9df9dd0f0240ccef9ac824e6b/transformers-5.8.1-py3-none-any.whl", hash = "sha256:5340fb95962162cdfdae5cc91d7f8fedd92ed75216c1154c5e1f590fcf56dd0e", size = 10632882, upload-time = "2026-05-13T03:21:52.876Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = "==3.12.*"
 resolution-markers = [
     "platform_machine != 's390x'",
@@ -2467,7 +2467,7 @@ requires-dist = [
     { name = "torch", specifier = ">=2.6.0" },
     { name = "tqdm", specifier = ">=4.67.1" },
     { name = "transformer-engine", extras = ["core-cu13", "pytorch"], marker = "extra == 'te'" },
-    { name = "transformers", specifier = "==5.8.1" },
+    { name = "transformers", specifier = ">=5.8.1,<5.9.0" },
     { name = "typing-extensions" },
     { name = "wandb", specifier = ">=0.25.0" },
 ]
@@ -5151,14 +5151,9 @@ name = "transformer-engine"
 version = "2.15.0+42b84005"
 source = { git = "https://github.com/NVIDIA/TransformerEngine.git?rev=release_v2.15#42b840051647eef89761a16dfdff87e82bb253ab" }
 dependencies = [
-    { name = "einops" },
     { name = "importlib-metadata" },
-    { name = "nvdlfw-inspect" },
-    { name = "onnx" },
-    { name = "onnxscript" },
     { name = "packaging" },
     { name = "pydantic" },
-    { name = "torch", marker = "sys_platform == 'never'" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Replays #3829 on top of current `main` after revert #3850.
- This branch intentionally restores the exact #3829 tree so CI can reproduce and isolate the main breakage.

## Context
- Original PR: #3829
- Revert PR: #3850

## Validation
- `uvx pre-commit==3.6.0 run --all-files --show-diff-on-failure --color=always`
- Verified `git diff --quiet 601b3249f1680b7d68b1893a41267d68ea168d59 HEAD`, so the replayed tree matches the original #3829 merge.

This is for CI investigation before preparing the actual fix.
