### PR TITLE
[docs] docs: Record MoE overlap smoke results

### DIFF
--- a/docs/training/communication-overlap.md
+++ b/docs/training/communication-overlap.md
@@ -71,10 +71,13 @@ Measured repo evidence today is strongest for MoE EP overlap. The pattern is
 mixed rather than universally positive:
 
 - small-EP `alltoall` runs can be correct but flat or slower
-- larger MoE runs show stronger evidence that the overlap path is operationally
-  useful
-- `delay_wgrad_compute` can help some schedules, but it is not a guaranteed
-  speedup over overlap-only
+- a short 2026-05-16 H100 x16 Qwen3 30B-A3B mock-data run with `EP=16`,
+  `alltoall`, CUDA graphs disabled, and `moe_permute_fusion=false` reduced
+  steady-state step time from 43.1s to 32.6s when enabling EP overlap
+- in that same run, adding `delay_wgrad_compute` was neutral: 32.5s versus
+  32.6s for overlap-only
+- `delay_wgrad_compute` can still help some schedules, but it is not a
+  guaranteed speedup over overlap-only
 
 So, in this repo, EP overlap is better described as correctness-backed and
 workload-sensitive rather than universally speedup-backed.
@@ -129,7 +132,8 @@ For config examples and minimal runnable commands, see:
 | `step_time` | down | TP overlap with `TP >= 2`, sequence parallelism, and supported TE path | expected |
 | `pipeline_idle_time` | down | interleaved PP where p2p cost is visible | expected |
 | `step_time` | flat to mixed | small-EP MoE with `alltoall` | measured |
-| `step_time` | mixed | larger MoE with EP overlap plus delayed wgrad | measured |
+| `step_time` | down in one short EP16 H100 run | Qwen3 30B-A3B, `alltoall`, CUDA graphs off, `moe_permute_fusion=false` | measured |
+| `step_time` | neutral in one short EP16 H100 run | same run, EP overlap plus delayed wgrad versus EP overlap-only | measured |
 
 Do not assume one overlap win transfers automatically to another mode. The
 correct question is always "which communication path is exposed in this run?"
@@ -143,6 +147,10 @@ correct question is always "which communication path is exposed in this run?"
 - Setting `moe_flex_dispatcher_backend` alone does not activate DeepEP or HybridEP; the dispatcher must actually switch to `flex`.
 - Small-EP `alltoall` MoE runs can get slower because scheduling overhead is
   larger than the communication being hidden.
+- Fused MoE permutation may depend on the exact Transformer Engine and Triton
+  stack. If a bring-up fails inside `transformer_engine.pytorch.permutation`,
+  disable `moe_permute_fusion` for the smoke run and retest the fusion in a
+  matched runtime before treating the timing as final.
 
 ## Related Docs
 

--- a/docs/training/communication-overlap.md
+++ b/docs/training/communication-overlap.md
@@ -71,11 +71,12 @@ Measured repo evidence today is strongest for MoE EP overlap. The pattern is
 mixed rather than universally positive:
 
 - small-EP `alltoall` runs can be correct but flat or slower
-- a short 2026-05-16 H100 x16 Qwen3 30B-A3B mock-data run with `EP=16`,
-  `alltoall`, CUDA graphs disabled, and `moe_permute_fusion=false` reduced
-  steady-state step time from 43.1s to 32.6s when enabling EP overlap
-- in that same run, adding `delay_wgrad_compute` was neutral: 32.5s versus
-  32.6s for overlap-only
+- a 2026-05-18 current-main H100 x16 Qwen3 30B-A3B mock-data rerun with
+  `EP=16`, `alltoall`, CUDA graphs disabled, and `moe_permute_fusion=false`
+  reduced steady-state step time from 41.25s to 31.31s when enabling EP
+  overlap
+- in that same run, adding `delay_wgrad_compute` was neutral: 31.20s versus
+  31.31s for overlap-only
 - `delay_wgrad_compute` can still help some schedules, but it is not a
   guaranteed speedup over overlap-only
 
@@ -132,8 +133,8 @@ For config examples and minimal runnable commands, see:
 | `step_time` | down | TP overlap with `TP >= 2`, sequence parallelism, and supported TE path | expected |
 | `pipeline_idle_time` | down | interleaved PP where p2p cost is visible | expected |
 | `step_time` | flat to mixed | small-EP MoE with `alltoall` | measured |
-| `step_time` | down in one short EP16 H100 run | Qwen3 30B-A3B, `alltoall`, CUDA graphs off, `moe_permute_fusion=false` | measured |
-| `step_time` | neutral in one short EP16 H100 run | same run, EP overlap plus delayed wgrad versus EP overlap-only | measured |
+| `step_time` | down in repeated short EP16 H100 runs | Qwen3 30B-A3B, `alltoall`, CUDA graphs off, `moe_permute_fusion=false` | measured |
+| `step_time` | neutral in repeated short EP16 H100 runs | same shape, EP overlap plus delayed wgrad versus EP overlap-only | measured |
 
 Do not assume one overlap win transfers automatically to another mode. The
 correct question is always "which communication path is exposed in this run?"

--- a/skills/perf-expert-parallel-overlap/SKILL.md
+++ b/skills/perf-expert-parallel-overlap/SKILL.md
@@ -122,18 +122,52 @@ Use this as the correctness-first starting point. Add delayed wgrad, flex
 dispatch, and CUDA-graph interactions only after the plain overlap path is
 known to work.
 
+## Measured Short-Run Evidence
+
+A 2026-05-18 current-main H100 x16 Qwen3 30B-A3B mock pretraining run used
+`EP=16`, `alltoall`, BF16, global batch size 1024, CUDA graphs disabled, and
+`moe_permute_fusion=false`. With iterations 3-8 as the steady window:
+
+| Case | Steady mean | Relative |
+|---|---:|---:|
+| no EP overlap | 41.25s | 1.000x |
+| EP overlap | 31.31s | 1.317x |
+| EP overlap plus `delay_wgrad_compute` | 31.20s | 1.322x |
+
+This is evidence for enabling plain EP overlap on this inter-node all-to-all
+shape. It does not show a meaningful independent win from delayed wgrad, and it
+does not validate fused MoE permutation because that path was disabled for the
+runtime stack.
+
 ## Minimal Runnable Command
 
-Performance harness example:
+Performance harness example inside a Slurm allocation. Keep the model,
+parallelism, dispatcher, and runtime fixed, and vary only the two overlap
+overrides:
 
 ```bash
-uv run python scripts/performance/setup_experiment.py \
-  --model qwen3-30b-a3b \
-  --moe_a2a_overlap \
-  --num_nodes 2 \
-  --gpus_per_node 8 \
-  --max_steps 20
+uv run python scripts/performance/run_script.py \
+  -m qwen \
+  -mr qwen3_30b_a3b \
+  --task pretrain \
+  -g h100 \
+  -c bf16 \
+  -ng 16 \
+  -gn 8 \
+  --max_steps 8 \
+  --config_variant v1 \
+  --cuda_graph_impl none \
+  --moe_flex_dispatcher_backend None \
+  --moe_a2a_overlap false \
+  --tokenizer_type NullTokenizer \
+  comm_overlap.overlap_moe_expert_parallel_comm=true \
+  comm_overlap.delay_wgrad_compute=false \
+  model.moe_shared_expert_overlap=false
 ```
+
+Do not use `--moe_a2a_overlap true` when separating plain EP overlap from
+delayed wgrad: the performance harness helper enables both
+`overlap_moe_expert_parallel_comm` and `delay_wgrad_compute`.
 
 Unit test verification:
 

--- a/skills/perf-expert-parallel-overlap/SKILL.md
+++ b/skills/perf-expert-parallel-overlap/SKILL.md
@@ -127,7 +127,7 @@ known to work.
 Performance harness example:
 
 ```bash
-python scripts/performance/setup_experiment.py \
+uv run python scripts/performance/setup_experiment.py \
   --model qwen3-30b-a3b \
   --moe_a2a_overlap \
   --num_nodes 2 \

--- a/skills/perf-moe-comm-overlap/SKILL.md
+++ b/skills/perf-moe-comm-overlap/SKILL.md
@@ -54,6 +54,23 @@ You must also set `moe_token_dispatcher_type = "flex"`.
   attention or MoE-router work.
 - In practice, selective recompute is the safer pairing when overlap is enabled.
 
+## Measured Short-Run Caveat
+
+A 2026-05-16 H100 x16 smoke on Qwen3 30B-A3B mock pretraining used `EP=16`,
+`alltoall`, global batch size 1024, CUDA graphs disabled, and
+`moe_permute_fusion=false` because the ad hoc PyTorch 25.11 / TE / Triton stack
+failed in Transformer Engine fused permutation before iteration 1.
+
+Results were directional rather than release-grade:
+
+- no EP overlap: 43.1s steady-state mean, excluding iteration 1
+- EP overlap: 32.6s steady-state mean
+- EP overlap plus `delay_wgrad_compute`: 32.5s steady-state mean
+
+Treat this as evidence that EP overlap can help an inter-node `alltoall` MoE
+shape when communication is exposed. It is not proof that delayed wgrad is a
+separate win, and it does not validate the fused permutation path.
+
 ## Code Anchors
 
 - Overlap validation: `src/megatron/bridge/training/comm_overlap.py`
@@ -86,3 +103,30 @@ You must also set `moe_token_dispatcher_type = "flex"`.
 Look for overlap-related log messages during initialization. The comm overlap
 validation in `comm_overlap.py` will raise if prerequisites are not met, so a
 clean startup confirms the feature is active.
+
+For a short performance-harness smoke, keep the command shape explicit and vary
+only one overlap knob at a time:
+
+```bash
+uv run python scripts/performance/run_script.py \
+  -m qwen \
+  -mr qwen3_30b_a3b \
+  --task pretrain \
+  -g h100 \
+  -c bf16 \
+  -ng 16 \
+  -gn 8 \
+  --max_steps 5 \
+  --config_variant v1 \
+  --cuda_graph_impl none \
+  --moe_flex_dispatcher_backend None \
+  --moe_a2a_overlap false \
+  --tokenizer_type NullTokenizer \
+  comm_overlap.overlap_moe_expert_parallel_comm=true \
+  comm_overlap.delay_wgrad_compute=false \
+  model.moe_shared_expert_overlap=false
+```
+
+If fused MoE permutation fails during bring-up, add
+`model.moe_permute_fusion=false` to separate overlap timing from runtime-stack
+validation, then retest with the matched production container.

--- a/skills/perf-moe-comm-overlap/SKILL.md
+++ b/skills/perf-moe-comm-overlap/SKILL.md
@@ -56,20 +56,22 @@ You must also set `moe_token_dispatcher_type = "flex"`.
 
 ## Measured Short-Run Caveat
 
-A 2026-05-16 H100 x16 smoke on Qwen3 30B-A3B mock pretraining used `EP=16`,
-`alltoall`, global batch size 1024, CUDA graphs disabled, and
-`moe_permute_fusion=false` because the ad hoc PyTorch 25.11 / TE / Triton stack
-failed in Transformer Engine fused permutation before iteration 1.
+A 2026-05-18 current-main H100 x16 smoke on Qwen3 30B-A3B mock pretraining
+used `EP=16`, `alltoall`, global batch size 1024, CUDA graphs disabled, and
+`moe_permute_fusion=false` because the PyTorch 25.11 / TE / Triton stack failed
+in Transformer Engine fused permutation in prior bring-up.
 
 Results were directional rather than release-grade:
 
-- no EP overlap: 43.1s steady-state mean, excluding iteration 1
-- EP overlap: 32.6s steady-state mean
-- EP overlap plus `delay_wgrad_compute`: 32.5s steady-state mean
+- no EP overlap: 41.25s steady-state mean over iterations 3-8
+- EP overlap: 31.31s steady-state mean over iterations 3-8
+- EP overlap plus `delay_wgrad_compute`: 31.20s steady-state mean over
+  iterations 3-8
 
 Treat this as evidence that EP overlap can help an inter-node `alltoall` MoE
 shape when communication is exposed. It is not proof that delayed wgrad is a
-separate win, and it does not validate the fused permutation path.
+separate win, and it does not validate the fused permutation path. An earlier
+2026-05-16 short smoke on the same shape showed the same pattern.
 
 ## Code Anchors
 
@@ -116,7 +118,7 @@ uv run python scripts/performance/run_script.py \
   -c bf16 \
   -ng 16 \
   -gn 8 \
-  --max_steps 5 \
+  --max_steps 8 \
   --config_variant v1 \
   --cuda_graph_impl none \
   --moe_flex_dispatcher_backend None \


### PR DESCRIPTION
## Summary

Record measured MoE EP-overlap smoke results from short Qwen3 30B A3B pretrain experiments and update the related docs/skills with conservative caveats.

Current-main rerun on the same focused shape:

| Case | Knobs | Steady mean, iters 3-8 | Relative |
|---|---|---:|---:|
| A0 | alltoall, no EP overlap | 41.25s | 1.000x |
| A1 | EP overlap | 31.31s | 1.317x |
| A2 | EP overlap + delayed wgrad | 31.20s | 1.322x |

Key caveat: this remains a short smoke on the available PyTorch 25.11 / TE / Triton stack, and the measured runs keep `model.moe_permute_fusion=false` because the fused MoE permutation path failed in prior bring-up. The docs phrase the evidence as workload-specific and recommend rerunning on a branch-matched production container before generalizing.

## Files changed

- `docs/training/communication-overlap.md`
- `skills/perf-moe-comm-overlap/SKILL.md`
- `skills/perf-expert-parallel-overlap/SKILL.md`

## Validation

- `UV_CACHE_DIR=.local/uv-cache uv run pre-commit run --all-files`
- `git diff --check`
- No local unit tests run, per handoff.

## Notes

The detailed experiment report remains local under `.local/` and is not committed because it contains environment-specific cluster paths.