### PR TITLE
Support for modelopt with MoE QAT

### DIFF
--- a/src/megatron/bridge/models/conversion/model_bridge.py
+++ b/src/megatron/bridge/models/conversion/model_bridge.py
@@ -280,26 +280,37 @@ def _megatron_local_name_to_global(
     # EP — fetched lazily because dense models may not have an EP group at all
     # (and for the decentralized PG path, ``pg_collection.ep`` may be ``None``).
     # For now adapters are not sharded across EP ranks.
-    is_expert_param = ".mlp.experts.linear_fc" in param_name and not ".adapter." in param_name
+    is_grouped_expert_param = ".mlp.experts.linear_fc" in param_name
+    is_local_expert_param = ".mlp.experts.local_experts." in param_name
+    is_expert_param = (is_grouped_expert_param or is_local_expert_param) and ".adapter." not in param_name
     ep_group = _get_ep_group(models) if is_expert_param else None
     if is_expert_param and ep_group is not None and get_pg_size(ep_group) > 1:
         num_experts = config.num_moe_experts
         num_experts_per_rank = num_experts // ep_group.size()
 
-        def _update_expert_number(param_name: str, param_type: str) -> str:
+        def _update_grouped_expert_number(param_name: str, param_type: str) -> str:
             """Update expert number from local to global for weight or bias parameters."""
-            local_expert_number = int(param_name.split(f".{param_type}")[-1])
+            expert_match = re.search(rf"\.{param_type}(\d+)(?=$|\.)", param_name)
+            if expert_match is None:
+                return param_name
+            local_expert_number = int(expert_match.group(1))
             global_expert_number = num_experts_per_rank * ep_group.rank() + local_expert_number
-            return param_name.replace(
-                f".{param_type}{local_expert_number}",
-                f".{param_type}{global_expert_number}",
-            )
+            return f"{param_name[: expert_match.start(1)]}{global_expert_number}{param_name[expert_match.end(1) :]}"
 
-        # Handle weight and bias parameters
-        if ".weight" in param_name:
-            param_name = _update_expert_number(param_name, "weight")
-        elif ".bias" in param_name:
-            param_name = _update_expert_number(param_name, "bias")
+        if is_local_expert_param:
+            local_experts_match = re.search(r"\.local_experts\.(\d+)\.", param_name)
+            if local_experts_match:
+                local_expert_number = int(local_experts_match.group(1))
+                global_expert_number = num_experts_per_rank * ep_group.rank() + local_expert_number
+                param_name = param_name.replace(
+                    f".local_experts.{local_expert_number}.",
+                    f".local_experts.{global_expert_number}.",
+                    1,
+                )
+        elif re.search(r"\.weight\d+(?=$|\.)", param_name):
+            param_name = _update_grouped_expert_number(param_name, "weight")
+        elif re.search(r"\.bias\d+(?=$|\.)", param_name):
+            param_name = _update_grouped_expert_number(param_name, "bias")
     return param_name
 
 

--- a/src/megatron/bridge/models/conversion/param_mapping.py
+++ b/src/megatron/bridge/models/conversion/param_mapping.py
@@ -1185,6 +1185,7 @@ class AutoMapping(MegatronParamMapping[torch.Tensor]):
         "column": {
             "ColumnParallelLinear",
             "LinearCrossEntropyModule",
+            "QuantColumnParallelLinear",
             "TEColumnParallelLinear",
             "TELayerNormColumnParallelLinear",
             "InferenceLayerNormColumnParallelLinear",
@@ -1195,6 +1196,7 @@ class AutoMapping(MegatronParamMapping[torch.Tensor]):
         },
         "row": {
             "RowParallelLinear",
+            "QuantRowParallelLinear",
             "TERowParallelLinear",
             "InferenceRowParallelLinear",
             "TERowParallelGroupedLinear",
@@ -1213,6 +1215,7 @@ class AutoMapping(MegatronParamMapping[torch.Tensor]):
             "TopKRouter",
         },
     }
+    _FUSED_LAYER_NORM_COLUMN_PARALLEL_SUBSTRING = "LayerNormColumnParallelLinear"
 
     @classmethod
     def register_module_type(cls, module_name: str, parallelism_type: str):
@@ -1269,7 +1272,8 @@ class AutoMapping(MegatronParamMapping[torch.Tensor]):
         # Handle fused modules like TELayerNormColumnParallelLinear
         # These modules have both column-parallel weights (weight, bias)
         # and replicated layer norm weights (layer_norm_weight, layer_norm_bias)
-        if module_type in ("TELayerNormColumnParallelLinear", "InferenceLayerNormColumnParallelLinear"):
+        is_layernorm_column_parallel = self._FUSED_LAYER_NORM_COLUMN_PARALLEL_SUBSTRING in module_type
+        if is_layernorm_column_parallel:
             # Check the actual parameter name to determine the correct parallelism type
             if self.megatron_param and (
                 self.megatron_param.endswith("layer_norm_weight") or self.megatron_param.endswith("layer_norm_bias")

--- a/src/megatron/bridge/models/conversion/param_mapping.py
+++ b/src/megatron/bridge/models/conversion/param_mapping.py
@@ -763,8 +763,8 @@ class MegatronParamMapping(ABC, Generic[WeightType]):
         global_expert_number = extract_expert_number_from_param(self.megatron_param)
         local_expert_number = global_expert_number % num_experts_per_rank
 
-        # Compute global expert numbers for all EP ranks
-        # use regex to replace the local expert number with the global expert number
+        # Compute global expert numbers for all EP ranks. HF MoE params use
+        # experts.N naming here; local_experts.N would require a separate pattern.
         gathered_expert_param_names = [
             re.sub(
                 r"experts\.(\d+)", f"experts.{int(local_expert_number) + num_experts_per_rank * i}", str(hf_param_name)

--- a/src/megatron/bridge/models/conversion/utils.py
+++ b/src/megatron/bridge/models/conversion/utils.py
@@ -273,10 +273,15 @@ def extract_sort_key(param_name: str):
     layer_match = re.search(r"layers\.(\d+)", param_name)
     if layer_match:
         numbers.append(int(layer_match.group(1)))
-    # Find expert number after bias or weight
+    # Find expert number after bias or weight for grouped experts.
     expert_match = re.search(r"(?:bias|weight)(\d+)", param_name)
     if expert_match:
         numbers.append(int(expert_match.group(1)))
+    else:
+        # SequentialMLP names use local_experts.<N> instead.
+        local_experts_match = re.search(r"local_experts\.(\d+)", param_name)
+        if local_experts_match:
+            numbers.append(int(local_experts_match.group(1)))
     # Pad to ensure consistent comparison (max 2 numbers)
     while len(numbers) < 2:
         numbers.append(-1)

--- a/src/megatron/bridge/utils/common_utils.py
+++ b/src/megatron/bridge/utils/common_utils.py
@@ -253,18 +253,26 @@ def hook_hf_module_setattr_for_tp_grad_sync(module: torch.nn.Module) -> torch.nn
 
 def extract_expert_number_from_param(param_name: str) -> int:
     """Extract the expert number from a parameter name.
+
     Args:
         param_name: The parameter name to extract the expert number from.
+
     Returns:
         The expert number.
     """
-    pattern = r"(?:experts\.|weight|bias)(\d+)"
-    match = re.search(pattern, param_name)
-    if not match:
-        raise ValueError(
-            f"No expert number found in parameter name: {param_name}. Please update the regex {pattern} if necessary."
-        )
-    return int(match.group(1))
+    patterns = (
+        r"local_experts\.(\d+)",
+        r"(?:weight|bias)(\d+)",
+        r"experts\.(\d+)",
+    )
+    for pattern in patterns:
+        match = re.search(pattern, param_name)
+        if match:
+            return int(match.group(1))
+    raise ValueError(
+        f"No expert number found in parameter name: {param_name}. "
+        f"Please update the regex patterns {patterns} if necessary."
+    )
 
 
 def disable_mtp_for_inference(m: torch.nn.Module) -> None:

--- a/tests/unit_tests/models/test_qat_bridge_support.py
+++ b/tests/unit_tests/models/test_qat_bridge_support.py
@@ -1,0 +1,185 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from megatron.bridge.models.conversion import model_bridge
+from megatron.bridge.models.conversion import param_mapping as param_mapping_module
+from megatron.bridge.models.conversion.param_mapping import AutoMapping, DirectMapping
+from megatron.bridge.models.conversion.peft_bridge import MegatronPeftBridge
+from megatron.bridge.models.conversion.utils import extract_sort_key
+from megatron.bridge.utils.common_utils import extract_expert_number_from_param
+
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeGroup:
+    def __init__(self, size: int, rank: int = 0) -> None:
+        self._size = size
+        self._rank = rank
+
+    def size(self) -> int:
+        return self._size
+
+    def rank(self) -> int:
+        return self._rank
+
+
+class _FakeModel(torch.nn.Module):
+    def __init__(self, *, pp_size: int = 1, ep_size: int = 1, ep_rank: int = 0) -> None:
+        super().__init__()
+        self.pg_collection = SimpleNamespace(
+            pp=_FakeGroup(pp_size),
+            ep=_FakeGroup(ep_size, ep_rank),
+        )
+
+
+def test_extract_expert_number_supports_sequential_mlp_local_experts() -> None:
+    assert extract_expert_number_from_param("decoder.layers.0.mlp.experts.local_experts.3.linear_fc1.weight") == 3
+    assert extract_expert_number_from_param("decoder.layers.0.mlp.experts.linear_fc1.weight7") == 7
+    assert extract_expert_number_from_param("model.layers.0.mlp.experts.11.gate_proj.weight") == 11
+
+
+def test_extract_sort_key_supports_local_experts() -> None:
+    assert extract_sort_key("decoder.layers.12.mlp.experts.local_experts.3.linear_fc1.weight") == (
+        [12, 3],
+        "decoder.layers.12.mlp.experts.local_experts.3.linear_fc1.weight",
+    )
+
+
+def test_local_expert_name_maps_to_global_expert_rank(monkeypatch) -> None:
+    monkeypatch.setattr(model_bridge, "get_pg_size", lambda group: group.size())
+    model = _FakeModel(ep_size=4, ep_rank=2)
+    config = SimpleNamespace(num_moe_experts=8)
+
+    global_name = model_bridge._megatron_local_name_to_global(
+        [model],
+        config,
+        "decoder.layers.0.mlp.experts.local_experts.1.linear_fc1.weight",
+    )
+
+    assert global_name == "decoder.layers.0.mlp.experts.local_experts.5.linear_fc1.weight"
+
+
+def test_local_expert_name_mapping_skips_adapter_params(monkeypatch) -> None:
+    monkeypatch.setattr(model_bridge, "get_pg_size", lambda group: group.size())
+    model = _FakeModel(ep_size=4, ep_rank=2)
+    config = SimpleNamespace(num_moe_experts=8)
+    param_name = "decoder.layers.0.mlp.experts.local_experts.1.linear_fc1.adapter.linear_in.weight"
+
+    assert model_bridge._megatron_local_name_to_global([model], config, param_name) == param_name
+
+
+def test_grouped_expert_name_mapping_ignores_quantizer_params(monkeypatch) -> None:
+    monkeypatch.setattr(model_bridge, "get_pg_size", lambda group: group.size())
+    model = _FakeModel(ep_size=4, ep_rank=2)
+    config = SimpleNamespace(num_moe_experts=8)
+    param_name = "decoder.layers.0.mlp.experts.linear_fc1.weight_quantizer._amax"
+
+    assert model_bridge._megatron_local_name_to_global([model], config, param_name) == param_name
+
+
+def test_grouped_expert_name_maps_numbered_weight_and_bias(monkeypatch) -> None:
+    monkeypatch.setattr(model_bridge, "get_pg_size", lambda group: group.size())
+    model = _FakeModel(ep_size=4, ep_rank=2)
+    config = SimpleNamespace(num_moe_experts=8)
+
+    assert (
+        model_bridge._megatron_local_name_to_global(
+            [model],
+            config,
+            "decoder.layers.0.mlp.experts.linear_fc1.weight1",
+        )
+        == "decoder.layers.0.mlp.experts.linear_fc1.weight5"
+    )
+    assert (
+        model_bridge._megatron_local_name_to_global(
+            [model],
+            config,
+            "decoder.layers.0.mlp.experts.linear_fc1.bias1",
+        )
+        == "decoder.layers.0.mlp.experts.linear_fc1.bias5"
+    )
+
+
+def test_ep_gather_supports_sequential_mlp_local_experts(monkeypatch) -> None:
+    monkeypatch.setattr(param_mapping_module, "get_pg_size", lambda group: group.size())
+    mapping = DirectMapping(
+        "decoder.layers.0.mlp.experts.local_experts.5.linear_fc1.weight",
+        "model.layers.0.mlp.experts.5.gate_proj.weight",
+    )
+    mapping.ep_group = _FakeGroup(4)
+    monkeypatch.setattr(mapping, "broadcast_obj_from_pp_rank", lambda obj, cache_key=None: obj)
+
+    def fake_all_gather(output: list[torch.Tensor], tensor: torch.Tensor, group: _FakeGroup) -> None:
+        del tensor, group
+        for index, gathered_tensor in enumerate(output):
+            gathered_tensor.fill_(index)
+
+    monkeypatch.setattr(torch.distributed, "all_gather", fake_all_gather)
+
+    result = mapping.gather_from_ep_ranks(
+        torch.tensor([9.0]),
+        SimpleNamespace(config=SimpleNamespace(num_moe_experts=8)),
+        "model.layers.0.mlp.experts.5.gate_proj.weight",
+    )
+
+    assert list(result) == [
+        "model.layers.0.mlp.experts.1.gate_proj.weight",
+        "model.layers.0.mlp.experts.3.gate_proj.weight",
+        "model.layers.0.mlp.experts.5.gate_proj.weight",
+        "model.layers.0.mlp.experts.7.gate_proj.weight",
+    ]
+    assert [tensor.item() for tensor in result.values()] == [0.0, 1.0, 2.0, 3.0]
+
+
+def test_adapter_filter_is_peft_only() -> None:
+    bridge = MegatronPeftBridge()
+
+    assert bridge._is_adapter_param_name("decoder.layers.0.self_attention.linear_qkv.adapter.linear_in.weight")
+    assert not bridge._is_adapter_param_name("decoder.layers.0.self_attention.linear_qkv.weight_quantizer._amax")
+    assert not bridge._is_adapter_param_name("decoder.layers.0.self_attention.linear_qkv.weight")
+
+
+def test_auto_mapping_detects_quantized_layernorm_column_parallel_modules() -> None:
+    QuantLayerNormColumnParallelLinear = type("QuantLayerNormColumnParallelLinear", (torch.nn.Module,), {})
+
+    weight_mapping = AutoMapping(
+        megatron_param="decoder.layers.0.self_attention.linear_qkv.weight",
+        hf_param="model.layers.0.self_attn.q_proj.weight",
+    )
+    norm_mapping = AutoMapping(
+        megatron_param="decoder.layers.0.self_attention.linear_qkv.layer_norm_weight",
+        hf_param="model.layers.0.input_layernorm.weight",
+    )
+
+    module = QuantLayerNormColumnParallelLinear()
+
+    assert weight_mapping._detect_parallelism_type(module) == "column"
+    assert norm_mapping._detect_parallelism_type(module) == "replicated"
+
+
+def test_auto_mapping_registers_quantized_parallel_linear_types() -> None:
+    assert "QuantColumnParallelLinear" in AutoMapping._MODULE_TYPE_REGISTRY["column"]
+    assert "QuantRowParallelLinear" in AutoMapping._MODULE_TYPE_REGISTRY["row"]
+
+
+def test_gpt_provider_exposes_modelopt_transformer_layer_spec() -> None:
+    from megatron.bridge.models.gpt_provider import modelopt_transformer_layer_spec
+
+    assert callable(modelopt_transformer_layer_spec)

--- a/tests/unit_tests/models/test_qat_bridge_support.py
+++ b/tests/unit_tests/models/test_qat_bridge_support.py
@@ -174,6 +174,29 @@ def test_auto_mapping_detects_quantized_layernorm_column_parallel_modules() -> N
     assert norm_mapping._detect_parallelism_type(module) == "replicated"
 
 
+def test_auto_mapping_detects_dynamic_layernorm_column_parallel_modules(monkeypatch) -> None:
+    class FakeDynamicModule(torch.nn.Module):
+        def get_original_cls_by_level(self, *, level: int) -> type[torch.nn.Module]:
+            assert level == 0
+            return type("QuantLayerNormColumnParallelLinear", (torch.nn.Module,), {})
+
+    monkeypatch.setattr(param_mapping_module, "is_modelopt_dynamic_module", lambda _module: True)
+
+    weight_mapping = AutoMapping(
+        megatron_param="decoder.layers.0.self_attention.linear_qkv.weight",
+        hf_param="model.layers.0.self_attn.q_proj.weight",
+    )
+    norm_mapping = AutoMapping(
+        megatron_param="decoder.layers.0.self_attention.linear_qkv.layer_norm_weight",
+        hf_param="model.layers.0.input_layernorm.weight",
+    )
+
+    module = FakeDynamicModule()
+
+    assert weight_mapping._detect_parallelism_type(module) == "column"
+    assert norm_mapping._detect_parallelism_type(module) == "replicated"
+
+
 def test_auto_mapping_registers_quantized_parallel_linear_types() -> None:
     assert "QuantColumnParallelLinear" in AutoMapping._MODULE_TYPE_REGISTRY["column"]
     assert "QuantRowParallelLinear" in AutoMapping._MODULE_TYPE_REGISTRY["row"]


### PR DESCRIPTION
# What does this PR do ?

Move all the patches for supporting modelopt based QAT on verl side to Megatron Bridge.

# Changelog

- Referring to https://github.com/verl-project/verl/pull/6335/changes/b96c8fb46f9800cbd098fbb7f425c45e797c9a79 & https://github.com/verl-project/verl/pull/6335/changes/04542a17210ebedd4872025203d1c3d83be5152e

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [X] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [X] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)

<img width="1980" height="294" alt="image" src="https://github.com/user-attachments/assets/a33848bf-e7aa-4d0e-8483-b7e5ff82a898" />
