### PR TITLE
[docs] docs: update MoE dispatcher selection guidance

### DIFF
--- a/docs/training/moe-optimization.md
+++ b/docs/training/moe-optimization.md
@@ -259,12 +259,34 @@ dispatcher backend controls how this communication is implemented:
 
 | Hardware | Recommended Dispatcher | Rationale |
 |---|---|---|
-| H100 / B200 (NVL8) | DeepEP | Optimized for node-based topologies |
-| GB200 / GB300 (NVL72) | HybridEP | Exploits NVLink domain for lower latency |
+| H100 / B200 (NVL8) | DeepEP, if installed | Optimized for node-based topologies |
+| GB200 / GB300 (NVL72) | HybridEP, if installed | Exploits NVLink domain for lower latency |
 
 HybridEP advantage usually grows with EP degree because it fuses intra-node
 NVLink transfers with inter-node IB work, avoiding much of the two-phase
 overhead of standard all-to-all at large EP sizes.
+
+Treat dispatcher package availability as part of the experiment setup, not as a
+given. `alltoall` is the correctness fallback and should be the first smoke test
+on a new container. DeepEP and HybridEP require their corresponding runtime
+packages to be installed; otherwise the config can select
+`moe_token_dispatcher_type="flex"` and still fail during model construction.
+Keep the container, CUDA graph scope, routing mode, and MoE kernel-fusion flags
+fixed when comparing dispatcher throughput.
+
+### Short-run H100 sanity check
+
+On 2026-05-17, a 16-GPU H100 smoke run of Qwen3 30B A3B BF16 with EP=16 and
+the recipe's Transformer Engine CUDA graph scopes (`moe_router`,
+`moe_preprocess`) completed with `alltoall` after disabling
+`moe_permute_fusion` for a Triton JIT compatibility issue in the container.
+The five-step run had a 45.65 s mean step time after the first warmup step,
+132.9 mean TFLOP/s/GPU after warmup, final loss 11.44050, and 61.351 GB peak
+max allocated memory. In the same container, DeepEP and HybridEP selected the
+requested flex backend in the dumped config but failed before iteration 1
+because the DeepEP/HybridEP packages were not installed. Use this as an
+availability caveat, not as evidence that `alltoall` is faster than flex
+dispatchers on H100.
 
 ## Long-Context MoE Training
 

--- a/skills/perf-moe-dispatcher-selection/SKILL.md
+++ b/skills/perf-moe-dispatcher-selection/SKILL.md
@@ -15,9 +15,9 @@ Card: @skills/perf-moe-dispatcher-selection/card.yaml
 
 | Hardware | First choice | Why |
 |---|---|---|
-| H100 | DeepEP | Strong default for cross-node EP on Hopper |
-| B200 | DeepEP | Good first choice unless a platform-specific HybridEP path is available |
-| GB200 / GB300 NVL72 | HybridEP | Best fit for NVLink-domain-aware dispatch and lower memory pressure |
+| H100 | DeepEP, if the runtime package is installed | Strong default for cross-node EP on Hopper |
+| B200 | DeepEP, if the runtime package is installed | Good first choice unless a platform-specific HybridEP path is available |
+| GB200 / GB300 NVL72 | HybridEP, if the runtime package is installed | Best fit for NVLink-domain-aware dispatch and lower memory pressure |
 | Unknown or first bring-up | `alltoall` | Easiest path for correctness and debugging |
 
 ### By EP degree
@@ -39,6 +39,29 @@ Card: @skills/perf-moe-dispatcher-selection/card.yaml
 | MoE VLMs | Start simple, then test HybridEP on GB200-class systems | Vision workloads are sensitive to both memory and host overhead |
 
 ## Rounded Evidence Summary
+
+### Backend availability gate
+
+Do not interpret a dispatcher timing until the container has proven that the
+selected backend package is available. `--moe_flex_dispatcher_backend None`
+selects the standard `alltoall` dispatcher, while `deepep` and `hybridep`
+select `moe_token_dispatcher_type="flex"` and then require their corresponding
+runtime packages at model construction time. If DeepEP or HybridEP is missing,
+record the import failure as an environment limitation and treat `alltoall` as
+the only measured correctness fallback for that run.
+
+### Qwen3 30B A3B on H100
+
+A short 2026-05-17 H100 smoke run used Qwen3 30B A3B BF16, 16 GPUs, EP=16,
+the recipe's Transformer Engine CUDA graph scopes (`moe_router`,
+`moe_preprocess`), and `model.moe_permute_fusion=false` due to a Triton JIT
+compatibility issue in the run container. The `alltoall` fallback completed five
+steps with 45.65 s mean step time after warmup, 132.9 mean TFLOP/s/GPU after
+warmup, final loss 11.44050, and 61.351 GB peak max allocated memory. DeepEP
+and HybridEP selected the requested flex backend in the dumped configs but
+failed before the first iteration because the packages were not installed. This
+confirms the availability gate; it is not a throughput ranking for flex
+dispatchers on H100.
 
 ### DSV3 on GB200 or GB300
 
@@ -86,6 +109,9 @@ DeepEP is selected by setting
 
 Tune the SM count allocated to DeepEP communication kernels (default 20).
 The optimal value depends on the workload and EP degree.
+First confirm the DeepEP package imports in the target container; a missing
+package fails during model construction, before any dispatcher timing is
+available.
 
 ### HybridEP
 
@@ -102,6 +128,9 @@ for the target hardware. Set
 `NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN` to match the NVLink domain size of
 the deployment. If it does not match the actual topology, performance and
 sometimes correctness will suffer.
+First confirm the HybridEP package imports in the target container; a missing
+package fails during model construction, before any dispatcher timing is
+available.
 
 ### Routing mode
 
@@ -160,3 +189,8 @@ more comparable across dispatcher backends.
 5. **Memory and throughput can trade off differently by model**: Qwen3-style
    runs may show a smaller speed delta than DSV3, but still justify HybridEP for
    memory headroom.
+
+6. **Backend import failures are not performance data**: if DeepEP or HybridEP
+   is missing from the container, do not compare its failed job against a
+   completed `alltoall` job. Fix the environment first, then rerun the same
+   stack.


### PR DESCRIPTION
## Summary
- Add dispatcher backend availability checks to the MoE optimization docs and dispatcher-selection skill.
- Record the 2026-05-17 H100 Qwen3 30B A3B short-run outcome without treating missing DeepEP/HybridEP packages as throughput data.
- Clarify that all-to-all is the correctness fallback when flex dispatcher packages are unavailable.

## Experiment
- Ran a short 16-GPU H100 Qwen3 30B A3B dispatcher-selection smoke on cw.
- All-to-all completed after disabling MoE permute fusion for the container-specific Triton JIT failure.
- DeepEP and HybridEP selected the requested flex backend but failed at model construction because their packages were not installed in the run container.

## Validation
- UV_CACHE_DIR=.local/uv-cache uv run pre-commit run --all-files
- No local unit tests run, per handoff.