### PR TITLE
[docs] docs: update MoE CUDA graph guidance

### DIFF
--- a/docs/training/cuda-graphs.md
+++ b/docs/training/cuda-graphs.md
@@ -43,7 +43,7 @@ It is less about changing the math and more about reducing runtime overhead.
 
 | Dimension | Effect | Confidence | Why |
 |---|---|---|---|
-| `speed` | ~10-30% faster step time | medium | Replays pre-captured GPU work and reduces launch overhead. The gain is biggest when the run is visibly launch-bound. |
+| `speed` | neutral/slightly slower to ~30% faster step time | medium | Replays pre-captured GPU work and reduces launch overhead. The gain is biggest when the run is visibly launch-bound; already-optimized or communication-bound runs may not improve. |
 | `memory` | near-neutral to several GB higher, depending on scope | high | Graph buffers stay allocated for replay. TE-scoped paths can be modest, while larger models or deeper PP can make memory noticeably tighter. |
 | `scale` | neutral to slightly positive | low | Can help at scale if host overhead matters, but extra memory residency can also gate larger configs. |
 | `convergence` | no change expected | medium | Intended to preserve training math when capture constraints are satisfied. |
@@ -122,25 +122,35 @@ capture and a small model recipe.
 
 | Metric | Expected Change | Conditions | Evidence |
 |---|---|---|---|
-| `step_time` | ~10-25% down | Static shapes, launch-bound training, especially TE-scoped MoE paths | measured |
-| `tokens_per_sec` | ~10-30% up | Same as above | measured |
+| `step_time` | neutral/slightly slower to ~25% down | Static shapes, launch-bound training, especially TE-scoped MoE paths | measured |
+| `tokens_per_sec` | neutral to ~30% up | Same as above | measured |
 | `peak_memory` | flat to moderately higher | TE-scoped paths with headroom | measured |
 | `OOM risk` | up | Tight memory budget or large MoE configs | measured |
 
 Do not assume a fixed throughput gain across models. The improvement depends on
-how launch-bound the workload is and how much scope is captured.
+how launch-bound the workload is and how much scope is captured. Compare replay
+iterations after CUDA graph capture; the capture step itself is not
+steady-state timing.
 
 ## Representative Validation Patterns
 
 ### Mid-sized MoE pretrain
 
-On mid-sized MoE pretrain runs with TE-scoped graphs
-(`attn + moe_router + moe_preprocess`), the common pattern is:
+On launch-bound mid-sized MoE pretrain runs with TE-scoped graphs
+(`attn + moe_router + moe_preprocess`), the common positive pattern is:
 
 - low-teens to low-20s percent faster step time
 - corresponding throughput gains when the eager baseline is launch-bound
 - short-run loss behavior that stays close to baseline
 - little or no obvious memory penalty in the friendliest TE-scoped cases
+
+There are also valid neutral cases. In a short Qwen3 30B A3B H100 BF16
+pretrain run with the all-to-all dispatcher, TE-scoped
+`attn + moe_router + moe_preprocess` graphs captured successfully after three
+warmup steps (`48` graphable layers, about `6.9 s` capture time on rank 0) but
+replay iterations 5-8 averaged `42.00 s` versus `41.36 s` for eager. Treat this
+as evidence to validate CUDA graphs on the target dispatcher, container, and
+batch shape rather than enabling them blindly.
 
 ### Packed-sequence SFT and LoRA
 
@@ -169,6 +179,8 @@ Larger MoE runs can become memory-gated before graph replay pays off:
 - `local` `full_iteration` graphs fail when NaN-loss checking is still enabled.
 - Illegal scope combinations such as `moe` with `moe_router` fail validation.
 - Runs that fit in eager mode can OOM after enabling graphs because buffers stay pinned.
+- Short runs can show neutral or slightly slower replay time if the eager
+  baseline is already efficient or the workload is not launch-bound.
 - Full activation recompute (`recompute_granularity=full`) with TE-scoped graphs
   asserts: `full recompute is only supported with full iteration CUDA graph`.
   Disable recompute or switch to `local` implementation.

--- a/docs/training/moe-optimization.md
+++ b/docs/training/moe-optimization.md
@@ -196,7 +196,10 @@ Two modes, different trade-offs:
 
 Partial CUDA graphs capture static components while leaving dynamic expert
 computation outside the graph, which is why they are the safer default for
-dropless MoE.
+dropless MoE. Validate the replay window against an eager run on the same
+dispatcher and container: TE-scoped capture can be neutral or slightly slower
+on all-to-all fallback shapes that are not visibly launch-bound, even when
+capture succeeds.
 
 For full CUDA Graphs on dropless MoE, three techniques are needed:
 

--- a/skills/perf-cuda-graphs/SKILL.md
+++ b/skills/perf-cuda-graphs/SKILL.md
@@ -21,7 +21,8 @@ host-driver overhead. Bridge supports two implementations:
 
 ## Quick Decision
 
-Start with TE-scoped graphs for most training workloads:
+Start with TE-scoped graphs for most training workloads, then verify replay
+timing against eager on the same dispatcher, layout, and container:
 
 - dense models: `attn`, then optionally `mlp`
 - dropless MoE: `attn moe_router moe_preprocess`
@@ -78,15 +79,25 @@ cfg.rng.te_rng_tracker = True
 ### Performance harness CLI
 
 ```bash
-python scripts/performance/run_performance_workload.py \
+uv run python scripts/performance/run_script.py \
+  -m qwen \
+  -mr qwen3_30b_a3b \
+  --task pretrain \
+  -g h100 \
+  -c bf16 \
+  -ng 16 \
   --cuda_graph_impl transformer_engine \
-  --cuda_graph_scope attn moe_router moe_preprocess \
+  --cuda_graph_scope attn,moe_router,moe_preprocess \
   ...
 ```
 
 Valid CLI values live in `scripts/performance/argument_parser.py`:
 - `VALID_CUDA_GRAPH_IMPLS`: `["none", "local", "transformer_engine"]`
 - `VALID_CUDA_GRAPH_SCOPES`: `["full_iteration", "attn", "mlp", "moe", "moe_router", "moe_preprocess", "mamba"]`
+
+The performance harness uses a comma-separated `--cuda_graph_scope` value and
+auto-enables `model.use_te_rng_tracker` plus `rng.te_rng_tracker` when
+`--cuda_graph_impl` is not `none`.
 
 ### Required constraints
 
@@ -108,7 +119,9 @@ Valid CLI values live in `scripts/performance/argument_parser.py`:
 2. Fix sequence length and micro-batch size.
 3. Enable the narrowest useful graph scope.
 4. Confirm replay is active and memory is still acceptable.
-5. Only then widen scope or combine with overlap features.
+5. Compare eager against graph replay iterations after warmup and capture; do
+   not include the capture step in steady-state timing.
+6. Only then widen scope or combine with overlap features.
 
 ## Code Anchors
 
@@ -293,7 +306,15 @@ def _delete_cuda_graphs(cuda_graph_helper):
 
 12. **Benchmark numbers are workload-specific**: graph wins are usually real
     when host overhead is visible, but the exact gain depends on batch shape,
-    PP depth, recompute, and whether the eager baseline was already optimized.
+    PP depth, recompute, dispatcher backend, and whether the eager baseline was
+    already optimized.
+
+13. **A successful capture is not a speedup guarantee**: On 2026-05-18,
+    Qwen3 30B A3B H100 BF16 pretrain with the all-to-all dispatcher captured
+    TE-scoped `attn,moe_router,moe_preprocess` graphs successfully (`48`
+    graphable layers, about `6.9 s` capture time on rank 0), but replay
+    iterations 5-8 averaged `42.00 s` versus `41.36 s` for eager. Treat
+    scoped graphs as a bring-up candidate and validate on the target stack.
 
 ## Verification
 

--- a/skills/perf-cuda-graphs/card.yaml
+++ b/skills/perf-cuda-graphs/card.yaml
@@ -1,5 +1,5 @@
 title: cuda_graphs
-validated_on: "2026-03-23"
+validated_on: "2026-05-18"
 summary: >
   Megatron Bridge supports CUDA graph capture through two implementations:
   local full-iteration graphs (MCore FullCudaGraphWrapper) and Transformer
@@ -7,11 +7,14 @@ summary: >
   attention, MLP, and MoE router modules. Requires static tensor shapes
   and TE RNG tracker. Verified on Qwen3-30B-A3B and GPT-OSS-20B MoE pretrain
   with TE-scoped graphs, showing roughly 15-25% lower iteration time and
-  20-33% higher throughput. Large-model rollout remains memory-sensitive
-  (GPT-OSS-120B blocked OOM), and packed-sequence finetuning remains fragile:
-  Qwen3 SFT hits the non-Tensor `packed_seq_params` graph assertion, while
-  GPT-OSS SFT/LoRA were blocked earlier by missing TE packed-sequence
-  attention backends in the tested container.
+  20-33% higher throughput when the eager baseline is launch-bound. A later
+  H100 Qwen3-30B-A3B all-to-all short run captured successfully but was
+  neutral/slightly slower in replay, so target-stack validation is required.
+  Large-model rollout remains memory-sensitive (GPT-OSS-120B blocked OOM),
+  and packed-sequence finetuning remains fragile: Qwen3 SFT hits the
+  non-Tensor `packed_seq_params` graph assertion, while GPT-OSS SFT/LoRA were
+  blocked earlier by missing TE packed-sequence attention backends in the
+  tested container.
 validation_status:
   config_validation:
     - code_verified  # config.py:1524-1531
@@ -39,6 +42,8 @@ validation_status:
     - unclear  # test file exists but tests were not executed
   qwen3_moe_pretrain_te_scoped:
     - measured  # Qwen3-30B-A3B, TP2 PP2 EP4, 2x H100 nodes
+  qwen3_moe_h100_alltoall_te_scoped_neutral:
+    - measured  # Qwen3-30B-A3B H100 BF16, alltoall, replay 42.00s vs 41.36s eager
   qwen3_sft_packed_sequence_block:
     - measured  # packed_seq_params is not a Tensor for TE-scoped graphs
   gpt_oss_20b_pretrain_te_scoped:
@@ -49,13 +54,16 @@ validation_status:
     - measured  # GPT-OSS-120B, TP2 PP4 EP8, 4x H100 nodes, job 10111518
 training_dimensions:
   speed:
-    effect: "++"
-    confidence: high
+    effect: "+/-"
+    confidence: medium
     rationale: >
       Measured throughput gains on two MoE pretrain workloads with TE-scoped
       graphs: Qwen3-30B-A3B improves from 623ms to 484ms steady-state and
       214 to 274 TFLOP/s/GPU; GPT-OSS-20B improves from 467-520ms to
-      391-399ms and 37.9-42.2 to 49.4-50.4 TFLOP/s/GPU.
+      391-399ms and 37.9-42.2 to 49.4-50.4 TFLOP/s/GPU. A 2026-05-18
+      Qwen3-30B-A3B H100 BF16 all-to-all run captured 48 TE-scoped graphable
+      layers but replay was slightly slower than eager, so speedup depends on
+      launch overhead and dispatcher/container shape.
   memory:
     effect: "-"
     confidence: medium


### PR DESCRIPTION
## Summary
- Add measured MoE CUDA graph guidance for a Qwen3 30B A3B H100 BF16 short run.
- Clarify that TE-scoped graph capture is valid but not a guaranteed speedup.
- Update the CUDA graph skill CLI example to use the current performance harness and comma-separated scopes.

## Experiment
- Ran eager vs TE-scoped `attn,moe_router,moe_preprocess` CUDA graphs on Qwen3 30B A3B pretrain.
- Scale: 2 H100 nodes, 16 GPUs total, all-to-all dispatcher fixed across both runs.
- Result: graph capture succeeded, but replay iterations were slightly slower than eager on this all-to-all fallback shape.

## Validation
- `UV_CACHE_DIR=.local/uv-cache uv run pre-commit run --all-files`
- No local unit tests run, per handoff.
