### PR TITLE
[data, model, training] fix: Stabilize Qwen3-VL packed SFT

### DIFF
--- a/src/megatron/bridge/data/vlm_datasets/collate.py
+++ b/src/megatron/bridge/data/vlm_datasets/collate.py
@@ -215,25 +215,34 @@ def qwen2_5_collate_fn(examples: list, processor) -> dict[str, torch.Tensor]:
         pad_id = getattr(processor.tokenizer, "pad_token_id", 0) or 0
         in_with = batch_with["input_ids"]
         in_without = batch_without["input_ids"]
+        attention_mask_with_images = batch_with["attention_mask"]
+        attention_mask_without_images = batch_without["attention_mask"]
         max_len = max(in_with.shape[1], in_without.shape[1])
 
-        def pad_to(x, tgt_len):
+        def pad_to(x, tgt_len, pad_value):
             if x.shape[1] == tgt_len:
                 return x
             pad_len = tgt_len - x.shape[1]
-            return F.pad(x, (0, pad_len), value=pad_id)
+            return F.pad(x, (0, pad_len), value=pad_value)
 
-        in_with = pad_to(in_with, max_len)
-        in_without = pad_to(in_without, max_len)
+        in_with = pad_to(in_with, max_len, pad_id)
+        in_without = pad_to(in_without, max_len, pad_id)
+        attention_mask_with_images = pad_to(attention_mask_with_images, max_len, 0)
+        attention_mask_without_images = pad_to(attention_mask_without_images, max_len, 0)
 
-        input_ids = torch.full((len(examples), max_len), pad_id, dtype=in_with.dtype)
+        input_ids = torch.full((len(examples), max_len), pad_id, dtype=in_with.dtype, device=in_with.device)
+        attention_mask = torch.zeros(
+            (len(examples), max_len), dtype=attention_mask_with_images.dtype, device=attention_mask_with_images.device
+        )
         # Place rows
         for row, i in enumerate(idx_with):
             input_ids[i] = in_with[row]
+            attention_mask[i] = attention_mask_with_images[row]
         for row, i in enumerate(idx_without):
             input_ids[i] = in_without[row]
+            attention_mask[i] = attention_mask_without_images[row]
 
-        batch = {"input_ids": input_ids}
+        batch = {"input_ids": input_ids, "attention_mask": attention_mask}
         # Carry over vision tensors if present
         if "pixel_values" in batch_with:
             batch["pixel_values"] = batch_with["pixel_values"]

--- a/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/model.py
+++ b/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/model.py
@@ -349,6 +349,7 @@ class Qwen3VLModel(MegatronModule):
         video_input_mask: torch.Tensor = None,
         cp_img_num: list[int] = None,
         images_padded: list[bool] = None,
+        moe_padding_mask: torch.Tensor = None,
         inference_context: object | None = None,
         runtime_gather_output: bool | None = None,
         mm_token_type_ids: torch.Tensor = None,
@@ -380,6 +381,27 @@ class Qwen3VLModel(MegatronModule):
         del inference_context, runtime_gather_output, mm_token_type_ids  # Unused, kept for API compatibility
         assert inference_params is None, "not support inference"
 
+        def _packed_cu_seqlens_for_rope(packed_params: PackedSeqParams | None) -> torch.Tensor | None:
+            if packed_params is None:
+                return None
+            cu_seqlens = packed_params.cu_seqlens_q_padded
+            if cu_seqlens is None:
+                cu_seqlens = packed_params.cu_seqlens_q
+            return cu_seqlens.reshape(-1) if cu_seqlens is not None else None
+
+        def _packed_thd_to_bshd(packed_values: torch.Tensor, cu_seqlens: torch.Tensor) -> torch.Tensor:
+            seqlens = cu_seqlens[1:] - cu_seqlens[:-1]
+            output = packed_values.new_zeros((seqlens.numel(), int(seqlens.max().item()), *packed_values.shape[2:]))
+            for i, (start, seqlen) in enumerate(zip(cu_seqlens[:-1].tolist(), seqlens.tolist())):
+                output[i, :seqlen] = packed_values[0, start : start + seqlen]
+            return output
+
+        def _packed_bshd_to_thd(unpacked_values: torch.Tensor, cu_seqlens: torch.Tensor) -> torch.Tensor:
+            output = unpacked_values.new_zeros((1, int(cu_seqlens[-1].item()), *unpacked_values.shape[2:]))
+            for i, (start, end) in enumerate(zip(cu_seqlens[:-1].tolist(), cu_seqlens[1:].tolist())):
+                output[0, start:end] = unpacked_values[i, : end - start]
+            return output
+
         vision_grid_thw = None
         vision_data = None
         vision_mask = None
@@ -399,6 +421,7 @@ class Qwen3VLModel(MegatronModule):
         # so it must be a real tensor. For packed sequences we use the THD-format
         # input_ids_thd (updated below); for regular sequences we use input_ids as-is.
         lm_input_ids = input_ids
+        moe_padding_mask_for_lm = moe_padding_mask
 
         if self.pre_process:
             # can reorganize_inputs at dataset
@@ -510,6 +533,13 @@ class Qwen3VLModel(MegatronModule):
                     input_ids, attention_mask, pre_process=True, pg_collection=self.pg_collection
                 )
                 lm_input_ids = input_ids_thd
+                if moe_padding_mask_for_lm is not None:
+                    moe_padding_mask_for_lm = preprocess_packed_seqs(
+                        moe_padding_mask_for_lm.to(dtype=torch.int32),
+                        attention_mask,
+                        pre_process=True,
+                        pg_collection=self.pg_collection,
+                    )[0].bool()
                 _, _, vision_mask_thd = reorganize_inputs(
                     input_ids=input_ids_thd,
                     pixel_values=pixel_values,
@@ -565,6 +595,13 @@ class Qwen3VLModel(MegatronModule):
                 lm_input_ids, _ = preprocess_packed_seqs(
                     input_ids, attention_mask, pre_process=True, pg_collection=self.pg_collection
                 )
+                if moe_padding_mask_for_lm is not None:
+                    moe_padding_mask_for_lm = preprocess_packed_seqs(
+                        moe_padding_mask_for_lm.to(dtype=torch.int32),
+                        attention_mask,
+                        pre_process=True,
+                        pg_collection=self.pg_collection,
+                    )[0].bool()
 
         visual_pos_masks = vision_mask
         deepstack_visual_embeds = deepstack_feature_lists
@@ -591,37 +628,48 @@ class Qwen3VLModel(MegatronModule):
                 )
 
         if position_ids is None:
-            # BSHD
-            # Megatron uses 4D bool masks ([B|1,1,S,S], True=masked); HF uses 2D keep masks ([B,S], 1=keep)
-            # For simplicity, we set hf_attention_mask to None.
-            hf_attention_mask = None
+            packed_rope_cu_seqlens = _packed_cu_seqlens_for_rope(packed_seq_params)
+            convert_rope_input_from_thd = packed_rope_cu_seqlens is not None and input_ids.shape[0] == 1
+            input_ids_for_rope = (
+                _packed_thd_to_bshd(input_ids, packed_rope_cu_seqlens) if convert_rope_input_from_thd else input_ids
+            )
+            # Megatron uses 4D bool masks ([B|1,1,S,S], True=masked); HF uses 2D keep masks ([B,S], 1=keep).
+            # Qwen3-VL computes MRoPE on the full sequence and masks loss/MoE separately.
             position_ids, _ = get_rope_index(
                 self.config.spatial_merge_size,
                 self.image_token_id,
                 self.video_token_id,
                 self.vision_start_token_id,
-                input_ids,
+                input_ids_for_rope,
                 image_grid_thw=image_grid_thw,
                 video_grid_thw=video_grid_thw,
-                attention_mask=hf_attention_mask,
+                attention_mask=None,
             )  #  [3*b*s]
             if packed_seq_params is not None:
                 # convert position_ids to THD format
-                position_ids = (
-                    preprocess_packed_seqs(
+                if convert_rope_input_from_thd:
+                    position_ids = _packed_bshd_to_thd(position_ids.permute(1, 2, 0), packed_rope_cu_seqlens).permute(
+                        2, 0, 1
+                    )
+                else:
+                    position_ids = preprocess_packed_seqs(
                         position_ids.permute(1, 2, 0),
                         attention_mask,
                         pre_process=True,
                         pg_collection=self.pg_collection,
-                    )[0]
-                    .permute(2, 0, 1)
-                    .contiguous()
-                )
+                    )[0].permute(2, 0, 1)
+                position_ids = position_ids.contiguous()
                 attention_mask = None
                 self.language_model.rotary_pos_emb.is_thd_format = True
 
         torch.cuda.nvtx.range_pop()
         torch.cuda.nvtx.range_push("Qwen3VLModel.forward.language_model")
+
+        padding_mask_for_moe = None
+        if moe_padding_mask_for_lm is not None:
+            padding_mask_for_moe = moe_padding_mask_for_lm.bool()
+        elif packed_seq_params is not None and lm_input_ids is not None:
+            padding_mask_for_moe = lm_input_ids.eq(0)
 
         output = self.language_model(
             input_ids=lm_input_ids,
@@ -630,6 +678,7 @@ class Qwen3VLModel(MegatronModule):
             decoder_input=combined_embeddings,  # only not None in the first decoder PP stage
             labels=labels,  # only not None in the last decoder PP stage
             loss_mask=loss_mask,  # Added for THD training compatibility
+            padding_mask=padding_mask_for_moe,
             inference_params=inference_params,  # currently always None
             packed_seq_params=packed_seq_params,  # currently always None
             visual_pos_masks=visual_pos_masks,

--- a/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/text_model.py
+++ b/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/text_model.py
@@ -120,6 +120,7 @@ class Qwen3VLGPTModel(GPTModel):
         *,
         inference_params: Optional[BaseInferenceContext] = None,
         loss_mask: Optional[Tensor] = None,
+        padding_mask: Optional[Tensor] = None,
         # args for deepstack
         visual_pos_masks: Optional[torch.Tensor] = None,
         deepstack_visual_embeds: Optional[list[torch.Tensor]] = None,
@@ -140,14 +141,15 @@ class Qwen3VLGPTModel(GPTModel):
         inference_context = deprecate_inference_params(inference_context, inference_params)
 
         # `_preprocess` can optionally return an extra fused cos/sin buffer (for
-        # flash decode). Match the upstream GPTModel handling to avoid unpack
-        # errors when six values are returned.
+        # flash decode). Keep the first six fields aligned with the upstream
+        # GPTModel contract; Qwen3-VL reads padding_mask from index 5 below.
         preproc_output = self._preprocess(
             input_ids=input_ids,
             position_ids=position_ids,
             decoder_input=decoder_input,
             inference_context=inference_context,
             packed_seq_params=packed_seq_params,
+            padding_mask=padding_mask,
         )
 
         (
@@ -156,7 +158,19 @@ class Qwen3VLGPTModel(GPTModel):
             rotary_pos_cos,
             rotary_pos_sin,
             sequence_len_offset,
-        ) = preproc_output[:5]
+            padding_mask,
+        ) = preproc_output[:6]
+        if (
+            padding_mask is not None
+            and decoder_input is not None
+            and getattr(getattr(self, "config", None), "sequence_parallel", False)
+            and padding_mask.shape[-1] != decoder_input.shape[0]
+        ):
+            padding_mask = (
+                tensor_parallel.scatter_to_sequence_parallel_region(padding_mask.transpose(0, 1).contiguous())
+                .transpose(0, 1)
+                .contiguous()
+            )
 
         # Run decoder.
         hidden_states = self.decoder(
@@ -170,6 +184,7 @@ class Qwen3VLGPTModel(GPTModel):
             # the standard components only.
             packed_seq_params=packed_seq_params,
             sequence_len_offset=sequence_len_offset,
+            padding_mask=padding_mask,
             visual_pos_masks=visual_pos_masks,
             deepstack_visual_embeds=deepstack_visual_embeds,
             **(extra_block_kwargs or {}),

--- a/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/transformer_block.py
+++ b/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/transformer_block.py
@@ -503,6 +503,7 @@ class Qwen3VLTransformerBlock(TransformerBlock):
         rotary_pos_emb: Tensor,
         attention_bias: Tensor,
         packed_seq_params: PackedSeqParams,
+        padding_mask: Optional[Tensor],
         use_inner_fp8_context: bool,
         # args for deepstack
         visual_pos_masks: Optional[torch.Tensor] = None,
@@ -517,6 +518,7 @@ class Qwen3VLTransformerBlock(TransformerBlock):
                 context,
                 context_mask,
                 rotary_pos_emb,
+                padding_mask,
                 visual_pos_masks,
                 *deepstack_visual_embeds_args,
             ):
@@ -538,6 +540,7 @@ class Qwen3VLTransformerBlock(TransformerBlock):
                             attention_bias=attention_bias,
                             inference_context=None,
                             packed_seq_params=packed_seq_params,
+                            padding_mask=padding_mask,
                         )
 
                         if self.pre_process and deepstack_visual_embeds is not None:
@@ -567,6 +570,7 @@ class Qwen3VLTransformerBlock(TransformerBlock):
                     context,
                     context_mask,
                     rotary_pos_emb,
+                    padding_mask,
                     visual_pos_masks,
                     *deepstack_visual_embeds_tuple,
                 )
@@ -579,6 +583,7 @@ class Qwen3VLTransformerBlock(TransformerBlock):
                     context,
                     context_mask,
                     rotary_pos_emb,
+                    padding_mask,
                     visual_pos_masks,
                     *deepstack_visual_embeds_tuple,
                 )
@@ -618,6 +623,7 @@ class Qwen3VLTransformerBlock(TransformerBlock):
                         context,
                         context_mask,
                         rotary_pos_emb,
+                        padding_mask,
                         visual_pos_masks,
                         *deepstack_visual_embeds_tuple,
                     )
@@ -639,6 +645,7 @@ class Qwen3VLTransformerBlock(TransformerBlock):
         inference_context: Optional[BaseInferenceContext] = None,
         packed_seq_params: Optional[PackedSeqParams] = None,
         sequence_len_offset: Optional[Tensor] = None,
+        padding_mask: Optional[Tensor] = None,
         *,
         inference_params: Optional[BaseInferenceContext] = None,
         # args for deepstack
@@ -730,6 +737,7 @@ class Qwen3VLTransformerBlock(TransformerBlock):
                     rotary_pos_emb=rotary_pos_emb,
                     attention_bias=attention_bias,
                     packed_seq_params=packed_seq_params,
+                    padding_mask=padding_mask,
                     use_inner_fp8_context=use_inner_fp8_context,
                     visual_pos_masks=visual_pos_masks,
                     deepstack_visual_embeds=deepstack_visual_embeds,
@@ -754,6 +762,7 @@ class Qwen3VLTransformerBlock(TransformerBlock):
                             inference_context=inference_context,
                             packed_seq_params=packed_seq_params,
                             sequence_len_offset=sequence_len_offset,
+                            padding_mask=padding_mask,
                         )
 
                         if self.pre_process and deepstack_visual_embeds is not None:

--- a/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/utils.py
+++ b/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/utils.py
@@ -200,7 +200,7 @@ def split_part_by_cp_tp(cp_size, cp_rank, tp_size, tp_rank, split_size):
 
 def split_deepstack_embs(
     visual_pos_masks: torch.Tensor,
-    deepstack_visual_embeds: list[torch.Tensor],
+    deepstack_visual_embeds: list[torch.Tensor] | None,
     tp_size: int = 1,
     tp_rank: int = 0,
     cp_size: int = 1,
@@ -230,7 +230,7 @@ def split_deepstack_embs(
     split_size = tp_size
     if cp_size > 1:
         split_size *= cp_size * 2
-    if split_size == 1 or visual_pos_masks is None:
+    if split_size == 1 or visual_pos_masks is None or deepstack_visual_embeds is None:
         return visual_pos_masks, deepstack_visual_embeds
 
     assert visual_pos_masks.dim() == 2
@@ -636,7 +636,9 @@ def pack_dist_train_vision_module_output(
     deepstack_feature_lists: Sequence[torch.Tensor],
 ) -> dict[str, torch.Tensor]:
     """Concat deepstack features and final vision embeddings; shape as 3D for bridge communicator."""
-    vision_module_output_tensor = torch.cat([vision_embeds, *deepstack_feature_lists], dim=0)
+    # ``set_dist_train_input_tensors`` unpacks all leading chunks as deepstack features and the final
+    # chunk as the final vision embedding.
+    vision_module_output_tensor = torch.cat([*deepstack_feature_lists, vision_embeds], dim=0)
     # 2D [batch*seq, hidden] -> 3D [1, batch*seq, hidden]
     vision_module_output_tensor = vision_module_output_tensor.unsqueeze(0)
     return {"vision_module": vision_module_output_tensor}

--- a/src/megatron/bridge/models/qwen_vl/qwen3_vl_step.py
+++ b/src/megatron/bridge/models/qwen_vl/qwen3_vl_step.py
@@ -94,6 +94,10 @@ def get_batch_from_iterator(
         else:
             _batch_required_keys[key] = None
 
+    raw_attn = batch.get("attention_mask")
+    if isinstance(raw_attn, torch.Tensor) and raw_attn.dim() == 2:
+        _batch_required_keys["_padding_mask"] = raw_attn.cuda(non_blocking=True)
+
     return _batch_required_keys
 
 
@@ -111,6 +115,7 @@ def get_batch(
     torch.Tensor,
     torch.Tensor,
     Any,
+    torch.Tensor,
 ]:
     """Generate a batch.
 
@@ -148,6 +153,7 @@ def get_batch(
         batch.get("attention_mask"),
         batch.get("position_ids"),
         multi_modal_inputs,
+        batch.get("_padding_mask"),
     )
 
 
@@ -157,11 +163,20 @@ def pack_or_pad_batch_sequences(
     loss_mask: torch.Tensor,
     attention_mask: torch.Tensor,
     position_ids: torch.Tensor,
+    padding_mask: torch.Tensor | None,
     this_pg_collection,
     use_fp8_padding: bool = False,
     force_to_pad_to_seq_len: bool = False,
     seq_length: int = None,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, PackedSeqParams]:
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor | None,
+    PackedSeqParams,
+]:
     """
     Pad or truncate the batch sequences to the target length, and build packed sequences.
     If is_qwen3vl, return bshd tokens for be compatible with qwen3vl model.
@@ -185,6 +200,7 @@ def pack_or_pad_batch_sequences(
     loss_mask = pad_or_truncate_2d_to_len(loss_mask, target_len=target_len, max_cap=target_len, pad_value=0)
     attention_mask = pad_or_truncate_attn_to_len(attention_mask, target_len=target_len, max_cap=target_len)
     position_ids = pad_or_truncate_pos_to_len(position_ids, target_len=target_len, max_cap=target_len)
+    padding_mask = pad_or_truncate_2d_to_len(padding_mask, target_len=target_len, max_cap=target_len, pad_value=0)
 
     seqlens_in_batch = torch.ones(batch_size, dtype=torch.int32, device=device) * target_len
     seqlens_in_batch_padded = torch.ones(batch_size, dtype=torch.int32, device=device) * target_len
@@ -204,7 +220,7 @@ def pack_or_pad_batch_sequences(
         cu_seqlens_kv_padded=cu_seqlens_padded,
     )
 
-    return tokens, labels, loss_mask, attention_mask, position_ids, packed_seq_params
+    return tokens, labels, loss_mask, attention_mask, position_ids, padding_mask, packed_seq_params
 
 
 def forward_step(
@@ -243,6 +259,7 @@ def forward_step(
             attention_mask,
             position_ids,
             multi_modal_inputs,
+            padding_mask,
         ) = get_batch(data_iterator, state.cfg, use_mtp, is_first_pp_stage=is_first, is_last_pp_stage=is_last)
     timers("batch-generator").stop()
 
@@ -250,26 +267,32 @@ def forward_step(
     # Qwen3VL model need the original input and do cp and sp split in model.forward.
     pack_sequences_in_batch = getattr(state.cfg.dataset, "pack_sequences_in_batch", False)
 
-    tokens, labels, loss_mask, attention_mask, position_ids, packed_seq_params = pack_or_pad_batch_sequences(
-        tokens,
-        labels,
-        loss_mask,
-        attention_mask,
-        position_ids,
-        this_pg_collection,
-        use_fp8_padding=True,
-        force_to_pad_to_seq_len=this_pg_collection.pp.size() > 1 or this_pg_collection.ep.size() > 1,
-        seq_length=config.seq_length,
+    tokens, labels, loss_mask, attention_mask, position_ids, padding_mask, packed_seq_params = (
+        pack_or_pad_batch_sequences(
+            tokens,
+            labels,
+            loss_mask,
+            attention_mask,
+            position_ids,
+            padding_mask,
+            this_pg_collection,
+            use_fp8_padding=True,
+            force_to_pad_to_seq_len=this_pg_collection.pp.size() > 1 or this_pg_collection.ep.size() > 1,
+            seq_length=config.seq_length,
+        )
     )
+    moe_padding_mask = ~padding_mask.bool() if padding_mask is not None else None
     forward_args = {
         "input_ids": tokens,
         "labels": labels,
         "loss_mask": loss_mask,
         "attention_mask": attention_mask,
         "position_ids": position_ids,
+        "moe_padding_mask": moe_padding_mask,
     }
 
     original_tokens = tokens.clone()
+    original_moe_padding_mask = moe_padding_mask
     forward_args = get_batch_on_this_cp_rank(forward_args, cp_group=this_pg_collection.cp)
     forward_args["packed_seq_params"] = None
     forward_args["input_ids"] = original_tokens
@@ -288,6 +311,7 @@ def forward_step(
         # qwen3vl need the original input_ids and position_ids
         # use split attention mask for calculate loss
         forward_args["packed_seq_params"] = packed_seq_params
+        forward_args["moe_padding_mask"] = original_moe_padding_mask
 
     # use cp split loss mask for calculate loss
     loss_mask = forward_args["loss_mask"]

--- a/tests/unit_tests/data/vlm_datasets/test_collate.py
+++ b/tests/unit_tests/data/vlm_datasets/test_collate.py
@@ -42,7 +42,7 @@ class _DummyProcessor:
     def __call__(self, text=None, images=None, padding=True, return_tensors="pt", **kwargs):
         # Minimal shape/value outputs used by qwen2_5_collate_fn
         input_ids = torch.tensor([[1, 2, 3]])
-        out = {"input_ids": input_ids}
+        out = {"input_ids": input_ids, "attention_mask": torch.ones_like(input_ids)}
         if images is not None:
             # Create 1-batch, N images = len(images)
             n = len(images)
@@ -147,6 +147,41 @@ def test_qwen2_5_collate_fn_handles_with_images(monkeypatch):
     vi = batch["visual_inputs"]
     # Ensure fields exist when images present
     assert hasattr(vi, "pixel_values")
+
+
+def test_qwen2_5_collate_fn_preserves_attention_mask_for_mixed_image_text_batch(monkeypatch):
+    monkeypatch.setattr(collate, "HAVE_QWEN_VL_UTILS", True)
+
+    def _fake_pvi(conv):
+        if "with image" in str(conv):
+            return ([object()], None)
+        return (None, None)
+
+    monkeypatch.setattr(collate, "process_vision_info", _fake_pvi)
+
+    class _MixedProcessor(_DummyProcessor):
+        def __call__(self, text=None, images=None, padding=True, return_tensors="pt", **kwargs):
+            if images is not None:
+                input_ids = torch.tensor([[11, 12, 13, 14]])
+                return {
+                    "input_ids": input_ids,
+                    "attention_mask": torch.ones_like(input_ids),
+                    "pixel_values": torch.randn(1, 1, 3, 4, 4),
+                    "image_grid_thw": torch.tensor([[[1, 2, 2]]]),
+                }
+            input_ids = torch.tensor([[21, 22]])
+            return {"input_ids": input_ids, "attention_mask": torch.ones_like(input_ids)}
+
+    examples = [
+        {"conversation": [{"role": "user", "content": [{"type": "text", "text": "with image"}]}]},
+        {"conversation": [{"role": "user", "content": [{"type": "text", "text": "text only"}]}]},
+    ]
+
+    batch = collate.qwen2_5_collate_fn(examples, _MixedProcessor())
+
+    assert "attention_mask" in batch
+    assert batch["input_ids"].tolist() == [[11, 12, 13, 14], [21, 22, 0, 0]]
+    assert batch["attention_mask"].tolist() == [[1, 1, 1, 1], [1, 1, 0, 0]]
 
 
 def test_expand_image_tokens_handles_multiple_images_and_temporal_grids():

--- a/tests/unit_tests/models/qwen_vl/modelling_qwen3_vl/test_model.py
+++ b/tests/unit_tests/models/qwen_vl/modelling_qwen3_vl/test_model.py
@@ -603,6 +603,184 @@ class TestQwen3VLModel:
         assert language_model.last_kwargs["visual_pos_masks"] is None
         assert language_model.last_kwargs["decoder_input"].shape == (2, 1, 4)
 
+    def test_forward_packed_thd_rope_uses_padded_cu_seqlens(self, monkeypatch):
+        """Packed THD MRoPE should unpack with padded cu_seqlens and repack to THD."""
+
+        monkeypatch.setattr(
+            "megatron.bridge.models.qwen_vl.modelling_qwen3_vl.model.reorganize_inputs",
+            lambda **_kwargs: (None, None, None),
+        )
+        monkeypatch.setattr(
+            "megatron.bridge.models.qwen_vl.modelling_qwen3_vl.model.torch.cuda.nvtx.range_push",
+            lambda *_args, **_kwargs: None,
+        )
+        monkeypatch.setattr(
+            "megatron.bridge.models.qwen_vl.modelling_qwen3_vl.model.torch.cuda.nvtx.range_pop",
+            lambda *_args, **_kwargs: None,
+        )
+
+        captured = {}
+
+        def fake_get_rope_index(*args, **kwargs):
+            input_ids = kwargs["input_ids"] if "input_ids" in kwargs else args[4]
+            captured["input_ids"] = input_ids.clone()
+            positions = torch.arange(input_ids.shape[1], dtype=input_ids.dtype, device=input_ids.device)
+            return positions.view(1, 1, -1).expand(3, input_ids.shape[0], -1).clone(), None
+
+        monkeypatch.setattr(
+            "megatron.bridge.models.qwen_vl.modelling_qwen3_vl.model.get_rope_index",
+            fake_get_rope_index,
+        )
+
+        class DummyLanguageModel:
+            def __init__(self):
+                self.rotary_pos_emb = SimpleNamespace(is_thd_format=False)
+                self.last_kwargs = None
+
+            def embedding(self, input_ids, position_ids=None):
+                del position_ids
+                batch_size, seq_len = input_ids.shape
+                return torch.zeros((seq_len, batch_size, 4), dtype=torch.float32)
+
+            def __call__(self, **kwargs):
+                self.last_kwargs = kwargs
+                return torch.ones(1)
+
+        language_model = DummyLanguageModel()
+        model = SimpleNamespace(
+            pre_process=True,
+            square_merge_size=4,
+            config=SimpleNamespace(
+                vision_dp_when_cp=False,
+                sequence_parallel=False,
+                spatial_merge_size=4,
+            ),
+            pg_collection=SimpleNamespace(
+                cp=SimpleNamespace(rank=lambda: 0, size=lambda: 1),
+                tp=SimpleNamespace(rank=lambda: 0, size=lambda: 1),
+                pp=object(),
+            ),
+            language_model=language_model,
+            image_token_id=1,
+            video_token_id=2,
+            vision_start_token_id=3,
+            use_dist_train=False,
+        )
+
+        input_ids = torch.tensor([[10, 11, 0, 20, 21, 22]], dtype=torch.long)
+        packed_seq_params = SimpleNamespace(
+            cu_seqlens_q=torch.tensor([0, 2, 5], dtype=torch.int32),
+            cu_seqlens_q_padded=torch.tensor([0, 3, 6], dtype=torch.int32),
+        )
+
+        output = Qwen3VLModel.forward(
+            model,
+            input_ids=input_ids,
+            attention_mask=torch.ones_like(input_ids, dtype=torch.bool),
+            pixel_values=None,
+            pixel_values_videos=None,
+            image_grid_thw=None,
+            video_grid_thw=None,
+            packed_seq_params=packed_seq_params,
+        )
+
+        assert torch.equal(output, torch.ones(1))
+        assert torch.equal(captured["input_ids"], torch.tensor([[10, 11, 0], [20, 21, 22]]))
+        assert torch.equal(
+            language_model.last_kwargs["position_ids"],
+            torch.tensor([[[0, 1, 2, 0, 1, 2]], [[0, 1, 2, 0, 1, 2]], [[0, 1, 2, 0, 1, 2]]]),
+        )
+        assert language_model.rotary_pos_emb.is_thd_format is True
+
+    def test_forward_packed_thd_passes_explicit_moe_padding_mask(self, monkeypatch):
+        """Packed THD should pass the explicit MoE padding mask after packing."""
+
+        monkeypatch.setattr(
+            "megatron.bridge.models.qwen_vl.modelling_qwen3_vl.model.reorganize_inputs",
+            lambda **_kwargs: (None, None, None),
+        )
+        monkeypatch.setattr(
+            "megatron.bridge.models.qwen_vl.modelling_qwen3_vl.model.torch.cuda.nvtx.range_push",
+            lambda *_args, **_kwargs: None,
+        )
+        monkeypatch.setattr(
+            "megatron.bridge.models.qwen_vl.modelling_qwen3_vl.model.torch.cuda.nvtx.range_pop",
+            lambda *_args, **_kwargs: None,
+        )
+
+        def fake_get_rope_index(*args, **kwargs):
+            input_ids = kwargs["input_ids"] if "input_ids" in kwargs else args[4]
+            positions = torch.arange(input_ids.shape[1], dtype=input_ids.dtype, device=input_ids.device)
+            return positions.view(1, 1, -1).expand(3, input_ids.shape[0], -1).clone(), None
+
+        monkeypatch.setattr(
+            "megatron.bridge.models.qwen_vl.modelling_qwen3_vl.model.get_rope_index",
+            fake_get_rope_index,
+        )
+
+        class DummyLanguageModel:
+            def __init__(self):
+                self.rotary_pos_emb = SimpleNamespace(is_thd_format=False)
+                self.last_kwargs = None
+
+            def embedding(self, input_ids, position_ids=None):
+                del position_ids
+                batch_size, seq_len = input_ids.shape
+                return torch.zeros((seq_len, batch_size, 4), dtype=torch.float32)
+
+            def __call__(self, **kwargs):
+                self.last_kwargs = kwargs
+                return torch.ones(1)
+
+        language_model = DummyLanguageModel()
+        model = SimpleNamespace(
+            pre_process=True,
+            square_merge_size=4,
+            config=SimpleNamespace(
+                vision_dp_when_cp=False,
+                sequence_parallel=False,
+                spatial_merge_size=4,
+            ),
+            pg_collection=SimpleNamespace(
+                cp=SimpleNamespace(rank=lambda: 0, size=lambda: 1),
+                tp=SimpleNamespace(rank=lambda: 0, size=lambda: 1),
+                pp=object(),
+            ),
+            language_model=language_model,
+            image_token_id=1,
+            video_token_id=2,
+            vision_start_token_id=3,
+            use_dist_train=False,
+        )
+
+        input_ids = torch.tensor([[10, 11, 0], [20, 99, 22]], dtype=torch.long)
+        attention_mask = torch.ones_like(input_ids, dtype=torch.bool)
+        moe_padding_mask = torch.tensor([[False, False, True], [False, True, False]])
+        packed_seq_params = SimpleNamespace(
+            cu_seqlens_q=torch.tensor([0, 3, 6], dtype=torch.int32),
+            cu_seqlens_q_padded=torch.tensor([0, 3, 6], dtype=torch.int32),
+        )
+
+        output = Qwen3VLModel.forward(
+            model,
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            pixel_values=None,
+            pixel_values_videos=None,
+            image_grid_thw=None,
+            video_grid_thw=None,
+            packed_seq_params=packed_seq_params,
+            moe_padding_mask=moe_padding_mask,
+        )
+
+        assert torch.equal(output, torch.ones(1))
+        assert language_model.last_kwargs is not None
+        assert torch.equal(language_model.last_kwargs["input_ids"], torch.tensor([[10, 11, 0, 20, 99, 22]]))
+        assert torch.equal(
+            language_model.last_kwargs["padding_mask"],
+            torch.tensor([[False, False, True, False, True, False]]),
+        )
+
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="Qwen3VLModel.forward requires CUDA")
     @pytest.mark.timeout(120)
     def test_forward_non_dist_train(self, hf_config, processor, random_image):

--- a/tests/unit_tests/models/qwen_vl/modelling_qwen3_vl/test_text_model_forward.py
+++ b/tests/unit_tests/models/qwen_vl/modelling_qwen3_vl/test_text_model_forward.py
@@ -42,6 +42,7 @@ class _DummyModel:
             torch.randn(1, 1),
             torch.randn(1, 1),
             torch.tensor([0]),
+            None,
             torch.randn(1, 1),
         )
         return self.preprocess_output
@@ -72,5 +73,6 @@ def test_forward_accepts_extra_preprocess_output():
     assert dummy.decoder.called_with["rotary_pos_cos"] is preproc[2]
     assert dummy.decoder.called_with["rotary_pos_sin"] is preproc[3]
     assert dummy.decoder.called_with["sequence_len_offset"] is preproc[4]
-    assert not any(value is preproc[5] for value in dummy.decoder.called_with.values())
+    assert dummy.decoder.called_with["padding_mask"] is preproc[5]
+    assert not any(value is preproc[6] for value in dummy.decoder.called_with.values())
     assert dummy.postprocess_args["decoder_input"] is preproc[0]

--- a/tests/unit_tests/models/qwen_vl/modelling_qwen3_vl/test_utils.py
+++ b/tests/unit_tests/models/qwen_vl/modelling_qwen3_vl/test_utils.py
@@ -190,6 +190,38 @@ class TestQwen3VLUtils:
         assert split_part_by_cp_tp(cp_size, 1, tp_size, 0, split_size) == [2, 3]
         assert split_part_by_cp_tp(cp_size, 1, tp_size, 1, split_size) == [4, 5]
 
+    def test_split_deepstack_embs_returns_inputs_when_deepstack_is_none(self):
+        """Pure-text microbatch: deepstack=None should not crash."""
+        visual_pos_masks = torch.zeros(1, 8, dtype=torch.bool)
+
+        out_masks, out_embeds = split_deepstack_embs(
+            visual_pos_masks=visual_pos_masks,
+            deepstack_visual_embeds=None,
+            tp_size=2,
+            tp_rank=0,
+            cp_size=1,
+            cp_rank=0,
+            sequence_parallel=True,
+        )
+
+        assert out_embeds is None
+        assert torch.equal(out_masks, visual_pos_masks)
+
+    def test_pack_dist_train_vision_module_output_matches_unpack_contract(self):
+        """DistTrain receiver expects deepstack chunks first and final vision embedding last."""
+        vision_embeds = torch.full((2, 3), 3.0)
+        deepstack_feature_lists = [
+            torch.full((2, 3), 1.0),
+            torch.full((2, 3), 2.0),
+        ]
+
+        packed = pack_dist_train_vision_module_output(vision_embeds, deepstack_feature_lists)
+        chunks = torch.chunk(packed["vision_module"].reshape(-1, 3), chunks=3, dim=0)
+
+        assert torch.equal(chunks[0], deepstack_feature_lists[0])
+        assert torch.equal(chunks[1], deepstack_feature_lists[1])
+        assert torch.equal(chunks[-1], vision_embeds)
+
     def test_reorganize_inputs(self):
         """Test reorganize_inputs for image-only and video-only."""
         image_token_id = 151655
@@ -330,7 +362,7 @@ class TestQwen3VLUtils:
         assert list(out.keys()) == ["vision_module"]
         tensor = out["vision_module"]
         assert tensor.shape == (1, 6, hidden)
-        expected = torch.cat([vision_embeds, ds0, ds1], dim=0).unsqueeze(0)
+        expected = torch.cat([ds0, ds1, vision_embeds], dim=0).unsqueeze(0)
         assert torch.equal(tensor, expected)
 
     def test_pack_dist_train_vision_module_output_no_deepstack(self):


### PR DESCRIPTION
# What does this PR do ?

Fixes several Qwen3-VL packed SFT issues that can corrupt MRoPE position ids, route padding tokens through MoE experts, or swap dist-train vision/deepstack tensors. These issues are most visible with packed THD training, mixed image/text-only VLM batches, MoE, and dist-train vision-module splitting.

# Bugfix Summary

- **Packed THD MRoPE**: compute MRoPE from the padded packed sequence layout, temporarily unpack THD input ids to BSHD when needed, then repack position ids back to THD. This avoids position-id/layout mismatch for packed Qwen3-VL forward.
- **MoE padding mask**: preserve the dataset 2D padding mask through Qwen3-VL batch packing, model forward, text model, and decoder block calls. MoE now receives the real padding mask first and only falls back to `lm_input_ids.eq(0)` when no mask exists.
- **Qwen VLM collate mask preservation**: when a batch mixes image examples and text-only examples, keep and merge each processor `attention_mask` alongside `input_ids`. This lets packed SFT derive `padding_mask` and `moe_padding_mask` from real padding metadata instead of token id heuristics.
- **Dist-train vision payload order**: pack deepstack feature chunks first and final `vision_embeds` last, matching `set_dist_train_input_tensors`, which unpacks `chunks[:-1]` as deepstack and `chunks[-1]` as final vision embeddings.
- **Pure-text/deepstack handling**: allow `deepstack_visual_embeds=None` in `split_deepstack_embs` so pure-text microbatches do not crash.

# Validation Findings

## THD MRoPE probe, micro-batch size 3

I added a tiny local probe that feeds already-packed THD `input_ids` with shape `[1, 18]`, `micro_batch_size=3`, `seq_len=6`, and `cu_seqlens=[0, 6, 12, 18]`. The probe stubs the language model and inspects the exact `position_ids` passed from `Qwen3VLModel.forward` into the LM.

With this PR:

```text
rope input shape seen by get_rope_index: [3, 6]
position_ids: 0 1 2 3 4 5 | 0 1 2 3 4 5 | 0 1 2 3 4 5
```

Without this PR, at base `39b79eb78`:

```text
rope input shape seen by get_rope_index: [1, 18]
position_ids: 0 1 2 3 4 5 | 6 7 8 9 10 11 | 12 13 14 15 16 17
```

So the fix makes packed THD MRoPE reset per packed sample using `cu_seqlens`; without it, the flat THD row receives one continuous RoPE index across the whole microbatch.

## Zero-LR MoE BSHD/THD parity check

I also ran a fake-small Qwen3-VL MoE model with padded input, `micro_batch_size=2`, 4 experts, top-2 routing, and `lr=0`, comparing BSHD against THD while holding weights fixed.

```text
steps: 20
max_abs_loss_diff: 0.0
max_abs_forward_diff: 0.0
max_active_abs_forward_diff: 0.0
one-step global_max_abs_grad_diff: 2.2351741790771484e-08
```

The tiny gradient delta is float32 roundoff scale from different layout/reduction order, while forward output and loss are exactly aligned for the same padded tokens and MoE padding mask.

# Tests

- Added focused unit coverage for packed THD MRoPE, explicit packed THD MoE padding-mask propagation, Qwen collate attention-mask preservation, dist-train vision payload order, pure-text deepstack handling, and text-model padding-mask passthrough.

Local checks run:

- `uv run pre-commit run --all-files`
- `uv --project /lustre/fs1/portfolios/coreai/projects/coreai_dlalgo_mcore/users/jinliangl/repos/Megatron-Bridge run python -m pytest /lustre/fs1/portfolios/coreai/projects/coreai_dlalgo_mcore/users/jinliangl/repos/Megatron-Bridge/tests/unit_tests/models/qwen_vl/modelling_qwen3_vl/test_model.py -k "packed_thd" -q`
- `uv --project /lustre/fs1/portfolios/coreai/projects/coreai_dlalgo_mcore/users/jinliangl/repos/Megatron-Bridge run python -m pytest /lustre/fs1/portfolios/coreai/projects/coreai_dlalgo_mcore/users/jinliangl/repos/Megatron-Bridge/tests/unit_tests/data/vlm_datasets/test_collate.py -k "qwen2_5_collate_fn" -q`
- `uv --project /lustre/fs1/portfolios/coreai/projects/coreai_dlalgo_mcore/users/jinliangl/repos/Megatron-Bridge run python -m pytest /lustre/fs1/portfolios/coreai/projects/coreai_dlalgo_mcore/users/jinliangl/repos/Megatron-Bridge/tests/unit_tests/models/qwen_vl/modelling_qwen3_vl/test_text_model_forward.py -q`
- `uv --project /lustre/fs1/portfolios/coreai/projects/coreai_dlalgo_mcore/users/jinliangl/repos/Megatron-Bridge run ruff check /lustre/fs1/portfolios/coreai/projects/coreai_dlalgo_mcore/users/jinliangl/repos/Megatron-Bridge/tests/unit_tests/models/qwen_vl/modelling_qwen3_vl/test_model.py /lustre/fs1/portfolios/coreai/projects/coreai_dlalgo_mcore/users/jinliangl/repos/Megatron-Bridge/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/text_model.py`

Note: pytest was run from `/tmp` because this checkout already has `nemo_experiments/` in the repo root and the global test fixture refuses to run when that directory exists.

# GitHub Actions CI

External branch from wplf fork. An NVIDIA developer may need to trigger CI with `/ok to test 0b9d864f` if copy-pr-bot does not start automatically.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed Contributor guidelines
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation? Not needed; code and tests only.
- [x] Does the PR affect components that are optional to install? No.