### PR TITLE
Filter out slurm args from run_script.

### DIFF
--- a/scripts/performance/setup_experiment.py
+++ b/scripts/performance/setup_experiment.py
@@ -63,6 +63,25 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)  # pin level so nemo_run's WARNING root doesn't suppress INFO
 
 
+def _filter_run_script_args(argv: List[str]) -> List[str]:
+    """Drop launcher-only args before forwarding argv to the rank-local script."""
+    filtered_args = []
+    skip_next = False
+
+    for arg in argv:
+        if skip_next:
+            skip_next = False
+            continue
+        if arg == "--additional_slurm_params":
+            skip_next = True
+            continue
+        if arg.startswith("--additional_slurm_params="):
+            continue
+        filtered_args.append(arg)
+
+    return filtered_args
+
+
 def check_training_finished(log_file_paths: List[str], is_long_convergence_run: bool = True) -> bool:
     """Check if training is finished.
 
@@ -465,7 +484,7 @@ def main(
         path=str(run_script_path),
         entrypoint="python",
         env={"PYTHONPATH": f"{SCRIPT_DIR}:$PYTHONPATH"},
-        args=list(sys.argv[1:]),
+        args=_filter_run_script_args(sys.argv[1:]),
     )
 
     logger.info("Will launch the following command with Nemo-Run: %s", " ".join(nemorun_script.to_command()))


### PR DESCRIPTION
There is currently a bug in mbridge arg parse logic as it forwards all flags to 'run_script.py' The slurm args params can container semicolons as separators. This breaks the bash parsing the in `bash -c ' < run_script.py>' ` script.

Quick and dirty fix to filter out only the slurm args for the upcoming llmb release. I think a longer term fix would be to split up the arg parsers into those that actually need to be passed to run_script and those that are only applicable to setup_script.py.