### PR TITLE
feat(performance): add --mlperf_flavor for MLPerf v6.0 apples-to-appl…

### DIFF
--- a/scripts/performance/argument_parser.py
+++ b/scripts/performance/argument_parser.py
@@ -324,7 +324,7 @@ def parse_cli_args():
     data_args.add_argument(
         "--mlperf_flavor",
         action="store_true",
-        help="Apply MLPerf v5.1 apples-to-apples config: forces v5.1 shape per (model_recipe_name, compute_dtype, num_gpus), enables MLPerf-parity recipe/env knobs, and swaps to MLPerf C4 dataset. See utils/mlperf_flavor.py.",
+        help="Apply MLPerf v6.0 apples-to-apples config: forces canonical MLPerf v6.0 shape per (model_recipe_name, compute_dtype, num_gpus), enables MLPerf-parity recipe/env knobs (TE op fuser, BUCKET=768MB, AMAX, CUDA_GRAPH, FP8_DPA-FP4, CUDA_DEVICE_MAX_CONNECTIONS=1, NCCL_{MIN,MAX}_CTAS, NVTE_DPA_FP8_RECIPE), and swaps to MLPerf C4 dataset. GB200 only. See utils/mlperf_flavor.py.",
     )
 
     # Tokenizer configuration

--- a/scripts/performance/argument_parser.py
+++ b/scripts/performance/argument_parser.py
@@ -321,6 +321,11 @@ def parse_cli_args():
     data_args.add_argument("--dataset_name", type=str, help="Dataset name (deprecated)")
     data_args.add_argument("--packed_sequence", action="store_true", help="Use packed sequences")
     data_args.add_argument("--head_only", action="store_true", help="Use only head data (for rp2 dataset)")
+    data_args.add_argument(
+        "--mlperf_flavor",
+        action="store_true",
+        help="Apply MLPerf v5.1 apples-to-apples config: forces v5.1 shape per (model_recipe_name, compute_dtype, num_gpus), enables MLPerf-parity recipe/env knobs, and swaps to MLPerf C4 dataset. See utils/mlperf_flavor.py.",
+    )
 
     # Tokenizer configuration
     tokenizer_args = parser.add_argument_group("Tokenizer arguments")

--- a/scripts/performance/perf_plugins.py
+++ b/scripts/performance/perf_plugins.py
@@ -512,13 +512,13 @@ class PerfEnvPlugin(Plugin):
         if self.compute_dtype == "nvfp4":
             executor.env_vars["NVTE_USE_FAST_MATH"] = "1"
 
-        # MLPerf v5.1 apples-to-apples parity (opt-in). Runs LAST so it can
+        # MLPerf v6.0 apples-to-apples parity (opt-in). Runs LAST so it can
         # override defaults set by earlier methods (e.g. CUDA_DEVICE_MAX_CONNECTIONS,
         # which _set_num_cuda_device_max_connections set to 32 for GB200).
         self._set_mlperf_parity_env_overrides(executor)
 
     def _set_mlperf_parity_env_overrides(self, executor: "run.Executor"):
-        """Forward MLPerf v5.1 parity env vars host->container; gated by MLPERF_PARITY_{F16_ATTN,FP4_ATTN,405B}; pairs with overrides.py for recipe knobs."""
+        """Forward MLPerf v6.0 parity env vars host->container; gated by MLPERF_PARITY_{F16_ATTN,FP4_ATTN,405B}; pairs with overrides.py for recipe knobs."""
         f16_only = bool(os.environ.get("MLPERF_PARITY_F16_ATTN"))
         fp4_attn = bool(os.environ.get("MLPERF_PARITY_FP4_ATTN"))
         parity_405b = bool(os.environ.get("MLPERF_PARITY_405B"))
@@ -537,17 +537,17 @@ class PerfEnvPlugin(Plugin):
         if bucket_mb:
             executor.env_vars["MLPERF_PARITY_BUCKET_MB"] = bucket_mb
 
-        # DPA recipe + FP4 NVFP4 quantization flags (effective env from v5.1 config source chains).
+        # DPA recipe + FP4 NVFP4 quantization flags (effective env from v6.0 config source chains).
         if fp4_attn:
-            # v5.1 8B FP4: config_common_fp4.sh + _fp8attn.sh effective env (CurrentScaling wins).
+            # v6.0 8B FP4: config_common_fp4.sh + _fp8attn.sh effective env (CurrentScaling wins).
             executor.env_vars["NVTE_DPA_FP8_RECIPE"] = "Float8CurrentScaling"
             executor.env_vars["NVTE_NVFP4_DISABLE_RHT"] = "1"
             executor.env_vars["NVTE_DPA_FP8CS_O_in_F16"] = "1"
             executor.env_vars["NVTE_DPA_FP8_FORMAT"] = "HYBRID"
         elif f16_only or parity_405b:
-            # v5.1 8B FP8, 405B FP8, 405B FP4 all set NVTE_DPA_FP8_RECIPE=F16 (no _fp8attn.sh in source chain).
+            # v6.0 8B FP8, 405B FP8, 405B FP4 all set NVTE_DPA_FP8_RECIPE=F16 (no _fp8attn.sh in source chain).
             executor.env_vars["NVTE_DPA_FP8_RECIPE"] = "F16"
-            # v5.1 405B FP4 also sets NVFP4 quantization flags (config_common_fp4.sh, no _8b.sh override for 405B).
+            # v6.0 405B FP4 also sets NVFP4 quantization flags (config_common_fp4.sh, no _8b.sh override for 405B).
             if parity_405b and self.compute_dtype == "nvfp4":
                 executor.env_vars["NVTE_NVFP4_DISABLE_RHT"] = "1"
                 executor.env_vars["NVTE_NVFP4_DISABLE_STOCHASTIC_ROUNDING"] = "1"

--- a/scripts/performance/perf_plugins.py
+++ b/scripts/performance/perf_plugins.py
@@ -512,6 +512,63 @@ class PerfEnvPlugin(Plugin):
         if self.compute_dtype == "nvfp4":
             executor.env_vars["NVTE_USE_FAST_MATH"] = "1"
 
+        # MLPerf v5.1 apples-to-apples parity (opt-in). Runs LAST so it can
+        # override defaults set by earlier methods (e.g. CUDA_DEVICE_MAX_CONNECTIONS,
+        # which _set_num_cuda_device_max_connections set to 32 for GB200).
+        self._set_mlperf_parity_env_overrides(executor)
+
+    def _set_mlperf_parity_env_overrides(self, executor: "run.Executor"):
+        """Forward MLPerf v5.1 parity env vars host->container; gated by MLPERF_PARITY_{F16_ATTN,FP4_ATTN,405B}; pairs with overrides.py for recipe knobs."""
+        f16_only = bool(os.environ.get("MLPERF_PARITY_F16_ATTN"))
+        fp4_attn = bool(os.environ.get("MLPERF_PARITY_FP4_ATTN"))
+        parity_405b = bool(os.environ.get("MLPERF_PARITY_405B"))
+        if not (f16_only or fp4_attn or parity_405b):
+            return
+
+        # Forward parity flag(s) so in-container overrides.py applies the recipe knobs.
+        if f16_only:
+            executor.env_vars["MLPERF_PARITY_F16_ATTN"] = "1"
+        if fp4_attn:
+            executor.env_vars["MLPERF_PARITY_FP4_ATTN"] = "1"
+        if parity_405b:
+            executor.env_vars["MLPERF_PARITY_405B"] = "1"
+
+        bucket_mb = os.environ.get("MLPERF_PARITY_BUCKET_MB")
+        if bucket_mb:
+            executor.env_vars["MLPERF_PARITY_BUCKET_MB"] = bucket_mb
+
+        # DPA recipe + FP4 NVFP4 quantization flags (effective env from v5.1 config source chains).
+        if fp4_attn:
+            # v5.1 8B FP4: config_common_fp4.sh + _fp8attn.sh effective env (CurrentScaling wins).
+            executor.env_vars["NVTE_DPA_FP8_RECIPE"] = "Float8CurrentScaling"
+            executor.env_vars["NVTE_NVFP4_DISABLE_RHT"] = "1"
+            executor.env_vars["NVTE_DPA_FP8CS_O_in_F16"] = "1"
+            executor.env_vars["NVTE_DPA_FP8_FORMAT"] = "HYBRID"
+        elif f16_only or parity_405b:
+            # v5.1 8B FP8, 405B FP8, 405B FP4 all set NVTE_DPA_FP8_RECIPE=F16 (no _fp8attn.sh in source chain).
+            executor.env_vars["NVTE_DPA_FP8_RECIPE"] = "F16"
+            # v5.1 405B FP4 also sets NVFP4 quantization flags (config_common_fp4.sh, no _8b.sh override for 405B).
+            if parity_405b and self.compute_dtype == "nvfp4":
+                executor.env_vars["NVTE_NVFP4_DISABLE_RHT"] = "1"
+                executor.env_vars["NVTE_NVFP4_DISABLE_STOCHASTIC_ROUNDING"] = "1"
+                executor.env_vars["NVTE_NVFP4_DISABLE_2D_QUANTIZATION"] = "1"
+
+        # MLPerf runtime env defaults (overridable for gap-chase via MLPERF_PARITY_CUDA_MAX_CONN / _NCCL_MIN_CTAS / _MAX_CTAS).
+        cuda_max_conn = os.environ.get("MLPERF_PARITY_CUDA_MAX_CONN", "1")
+        executor.env_vars["CUDA_DEVICE_MAX_CONNECTIONS"] = cuda_max_conn
+        nccl_min_ctas = os.environ.get("MLPERF_PARITY_NCCL_MIN_CTAS", "16")
+        nccl_max_ctas = os.environ.get("MLPERF_PARITY_NCCL_MAX_CTAS", "32")
+        executor.env_vars["NCCL_MIN_CTAS"] = nccl_min_ctas
+        executor.env_vars["NCCL_MAX_CTAS"] = nccl_max_ctas
+
+        mode = "FP4_ATTN" if fp4_attn else ("405B" if parity_405b else "F16_ATTN")
+        logger.info(
+            f"MLPERF_PARITY_{mode}=1: forwarded to container env. "
+            f"CUDA_DEVICE_MAX_CONNECTIONS={cuda_max_conn}, "
+            f"NCCL_MIN_CTAS={nccl_min_ctas}, NCCL_MAX_CTAS={nccl_max_ctas}, "
+            f"NVTE_DPA_FP8_RECIPE={executor.env_vars['NVTE_DPA_FP8_RECIPE']}"
+        )
+
 
 @dataclass
 class PyTorchProfilerPluginScriptArgs:

--- a/scripts/performance/setup_experiment.py
+++ b/scripts/performance/setup_experiment.py
@@ -651,7 +651,7 @@ if __name__ == "__main__":
             task=args.task,
         )
 
-    # --mlperf_flavor: mutate args in place to apply MLPerf v5.1 apples-to-apples shape/dataset/mounts; sets MLPERF_PARITY_* env vars for perf_plugins to pick up.
+    # --mlperf_flavor: mutate args in place to apply MLPerf v6.0 apples-to-apples shape/dataset/mounts; sets MLPERF_PARITY_* env vars for perf_plugins to pick up.
     if getattr(args, "mlperf_flavor", False):
         from utils.mlperf_flavor import apply_mlperf_flavor
         apply_mlperf_flavor(args)

--- a/scripts/performance/setup_experiment.py
+++ b/scripts/performance/setup_experiment.py
@@ -651,6 +651,11 @@ if __name__ == "__main__":
             task=args.task,
         )
 
+    # --mlperf_flavor: mutate args in place to apply MLPerf v5.1 apples-to-apples shape/dataset/mounts; sets MLPERF_PARITY_* env vars for perf_plugins to pick up.
+    if getattr(args, "mlperf_flavor", False):
+        from utils.mlperf_flavor import apply_mlperf_flavor
+        apply_mlperf_flavor(args)
+
     main(
         use_recipes=args.use_recipes,
         model_family_name=args.model_family_name,

--- a/scripts/performance/utils/mlperf_flavor.py
+++ b/scripts/performance/utils/mlperf_flavor.py
@@ -14,33 +14,45 @@ Validated end-to-end against MLPerf v6.0 reference (Llama 3.1 8B, 8/16/32/64 GPU
 import argparse
 import logging
 import os
-from typing import Dict, Tuple
+import sys
+from typing import Dict, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
-# (model_recipe_name, compute_dtype, num_gpus) -> (TP, PP, VP, CP, MBS, GBS, parity_mode)
-# Shapes derived from MLPerf v6.0 NVIDIA submission configs on GB200:
-#   - 8B 8 GPU:    config_GB200_2x4x2xtp1pp1cp1_8b[_fp4].sh           (TP1/PP1/CP1, MBS=2, GBS=16)
-#   - 8B 16/32/64 FP8:   down-scaled config_GB200_18x4x1xtp1pp1cp2_8b.sh        (TP1/PP1/CP2, MBS=1)
-#   - 8B 16/32/64 FP4:   down-scaled config_GB200_18x4x1xtp1pp1cp1_8b_fp4.sh    (TP1/PP1/CP1, MBS=1)
-#   - 8B 72 GPU:   config_GB200_18x4x1xtp1pp1cp2_8b.sh                 (TP1/PP1/CP2, MBS=1)
-#   - 8B 128 FP8:  down-scaled config_GB200_128x4x1xtp2pp1cp4_8b.sh    (TP2/PP1/CP4, MBS=1)
-#   - 405B:        config_GB200_128x4x{112,128}xtp4pp8cp2_cg_fp4.sh    (TP4/PP8/VP8/CP2, MBS=1)
-_MLPERF_SHAPES: Dict[Tuple[str, str, int], Tuple[int, int, int, int, int, int, str]] = {
-    ("llama3_8b",   "fp8_cs",   8):   (1, 1, 1, 1, 2, 16,   "F16_ATTN"),
-    ("llama3_8b",   "fp8_cs",   16):  (1, 1, 1, 2, 1, 8,    "F16_ATTN"),
-    ("llama3_8b",   "fp8_cs",   32):  (1, 1, 1, 2, 1, 16,   "F16_ATTN"),
-    ("llama3_8b",   "fp8_cs",   64):  (1, 1, 1, 2, 1, 32,   "F16_ATTN"),
-    ("llama3_8b",   "fp8_cs",   72):  (1, 1, 1, 2, 1, 36,   "F16_ATTN"),
-    ("llama3_8b",   "fp8_cs",   128): (2, 1, 1, 4, 1, 16,   "F16_ATTN"),
-    ("llama3_8b",   "nvfp4",    8):   (1, 1, 1, 1, 2, 16,   "FP4_ATTN"),
-    ("llama3_8b",   "nvfp4",    16):  (1, 1, 1, 1, 1, 16,   "FP4_ATTN"),
-    ("llama3_8b",   "nvfp4",    32):  (1, 1, 1, 1, 1, 32,   "FP4_ATTN"),
-    ("llama3_8b",   "nvfp4",    64):  (1, 1, 1, 1, 1, 64,   "FP4_ATTN"),
-    ("llama31_405b","fp8_cs",   256): (4, 8, 8, 2, 1, 576,  "405B"),
-    ("llama31_405b","fp8_cs",   512): (4, 8, 8, 2, 1, 1152, "405B"),
-    ("llama31_405b","nvfp4",    256): (4, 8, 8, 2, 1, 576,  "405B"),
-    ("llama31_405b","nvfp4",    512): (4, 8, 8, 2, 1, 1152, "405B"),
+# (model_recipe_name, compute_dtype, num_gpus, gpu) -> (TP, PP, VP, CP, MBS, GBS, parity_mode)
+# Shapes derived from MLPerf v6.0 NVIDIA submission configs (per-gpu source-of-truth differs):
+#   - GB200 8B 8 GPU:   config_GB200_2x4x2xtp1pp1cp1_8b[_fp4].sh       (TP1/PP1/CP1, MBS=2, GBS=16)
+#   - GB200 8B 72 GPU:  config_GB200_18x4x1xtp1pp1cp2_8b.sh            (TP1/PP1/CP2, MBS=1)
+#   - GB200 8B 128 FP8: down-scaled config_GB200_128x4x1xtp2pp1cp4_8b.sh (TP2/PP1/CP4, MBS=1)
+#   - GB200 405B:       config_GB200_128x4x{112,128}xtp4pp8cp2_cg_fp4.sh (TP4/PP8/VP8/CP2, MBS=1)
+#   - GB300 405B:       config_GB300_128x4x56xtp2pp8cp2_cg_fp4.sh      (TP2/PP8/VP8/CP2, MBS=1)
+# Note: 16/32/64/128 GPU entries for 8B are down-scaled from canonical 72/512 GPU shapes (same TP/PP/CP).
+_MLPERF_SHAPES: Dict[Tuple[str, str, int, str], Tuple[int, int, Optional[int], int, int, int, str]] = {
+    # 8B PP=1 -> VP=None (Megatron rejects VP>0 with PP=1; matches INTERLEAVED_PIPELINE=null in optimized.git).
+    ("llama3_8b",   "fp8_cs",   8,   "gb200"): (1, 1, None, 1, 2, 16,   "F16_ATTN"),
+    ("llama3_8b",   "fp8_cs",   16,  "gb200"): (1, 1, None, 2, 1, 8,    "F16_ATTN"),
+    ("llama3_8b",   "fp8_cs",   32,  "gb200"): (1, 1, None, 2, 1, 16,   "F16_ATTN"),
+    ("llama3_8b",   "fp8_cs",   64,  "gb200"): (1, 1, None, 2, 1, 32,   "F16_ATTN"),
+    ("llama3_8b",   "fp8_cs",   72,  "gb200"): (1, 1, None, 2, 1, 36,   "F16_ATTN"),
+    ("llama3_8b",   "fp8_cs",   128, "gb200"): (2, 1, None, 4, 1, 16,   "F16_ATTN"),
+    ("llama3_8b",   "nvfp4",    8,   "gb200"): (1, 1, None, 1, 2, 16,   "FP4_ATTN"),
+    ("llama3_8b",   "nvfp4",    16,  "gb200"): (1, 1, None, 1, 1, 16,   "FP4_ATTN"),
+    ("llama3_8b",   "nvfp4",    32,  "gb200"): (1, 1, None, 1, 1, 32,   "FP4_ATTN"),
+    ("llama3_8b",   "nvfp4",    64,  "gb200"): (1, 1, None, 1, 1, 64,   "FP4_ATTN"),
+    # 405B entries deferred: GB200 + GB300 not yet validated against MLPerf-canonical GBS=896 shapes.
+    # 8B FP8 GB300 — same shapes as GB200 (canonical optimized.git configs use identical TP/PP/CP/MBS).
+    ("llama3_8b",   "fp8_cs",   8,   "gb300"): (1, 1, None, 1, 2, 16,   "F16_ATTN"),
+    ("llama3_8b",   "fp8_cs",   16,  "gb300"): (1, 1, None, 2, 1, 8,    "F16_ATTN"),
+    ("llama3_8b",   "fp8_cs",   32,  "gb300"): (1, 1, None, 2, 1, 16,   "F16_ATTN"),
+    ("llama3_8b",   "fp8_cs",   64,  "gb300"): (1, 1, None, 2, 1, 32,   "F16_ATTN"),
+    ("llama3_8b",   "fp8_cs",   72,  "gb300"): (1, 1, None, 2, 1, 36,   "F16_ATTN"),
+    ("llama3_8b",   "fp8_cs",   128, "gb300"): (2, 1, None, 4, 1, 16,   "F16_ATTN"),
+    # 8B FP4 GB300 — same shapes as GB200.
+    ("llama3_8b",   "nvfp4",    8,   "gb300"): (1, 1, None, 1, 2, 16,   "FP4_ATTN"),
+    ("llama3_8b",   "nvfp4",    16,  "gb300"): (1, 1, None, 1, 1, 16,   "FP4_ATTN"),
+    ("llama3_8b",   "nvfp4",    32,  "gb300"): (1, 1, None, 1, 1, 32,   "FP4_ATTN"),
+    ("llama3_8b",   "nvfp4",    64,  "gb300"): (1, 1, None, 1, 1, 64,   "FP4_ATTN"),
+    ("llama3_8b",   "nvfp4",    72,  "gb300"): (1, 1, None, 1, 1, 72,   "FP4_ATTN"),
 }
 
 
@@ -81,11 +93,11 @@ def apply_mlperf_flavor(args: argparse.Namespace) -> None:
     """Mutate args in place to apply MLPerf v6.0 apples-to-apples configuration; sets MLPERF_PARITY_* env vars for perf_plugins/overrides to pick up."""
     # Shape table is derived from MLPerf v6.0 NVIDIA GB200 submission configs.
     # Other GPU types have different MLPerf shapes and need separate validation.
-    if args.gpu != "gb200":
+    if args.gpu not in ("gb200", "gb300"):
         raise RuntimeError(
-            f"--mlperf_flavor currently only supports gpu=gb200, got '{args.gpu}'. Other GPU types not yet validated."
+            f"--mlperf_flavor currently only supports gpu in (gb200, gb300), got '{args.gpu}'. Other GPU types not yet validated."
         )
-    key = (args.model_recipe_name, args.compute_dtype, args.num_gpus)
+    key = (args.model_recipe_name, args.compute_dtype, args.num_gpus, args.gpu)
     shape = _MLPERF_SHAPES.get(key)
     if shape is None:
         raise RuntimeError(
@@ -123,6 +135,24 @@ def apply_mlperf_flavor(args: argparse.Namespace) -> None:
     # Set MLPERF_PARITY_* env vars so perf_plugins (host-side) + overrides.py (in-container) pick them up.
     env_var = {"F16_ATTN": "MLPERF_PARITY_F16_ATTN", "FP4_ATTN": "MLPERF_PARITY_FP4_ATTN", "405B": "MLPERF_PARITY_405B"}[parity_mode]
     os.environ[env_var] = "1"
+
+    # Forward shape + data to inner script (setup_experiment.py forwards original sys.argv).
+    shape_argv = [
+        "--tensor_model_parallel_size", str(tp),
+        "--pipeline_model_parallel_size", str(pp),
+        "--context_parallel_size", str(cp),
+        "--micro_batch_size", str(mbs),
+        "--global_batch_size", str(gbs),
+    ]
+    if vp is not None:
+        shape_argv.extend(["--virtual_pipeline_model_parallel_size", str(vp)])
+    sys.argv.extend(shape_argv)
+    if os.environ.get("MLPERF_DATA_ROOT"):
+        sys.argv.extend([
+            "--data", "rp2",
+            "--dataset_paths", data_prefix,
+            "--index_mapping_dir", index_cache_dir,
+        ])
 
     logger.info(
         f"--mlperf_flavor (v6.0): {args.model_recipe_name}/{args.compute_dtype}/{args.num_gpus} -> "

--- a/scripts/performance/utils/mlperf_flavor.py
+++ b/scripts/performance/utils/mlperf_flavor.py
@@ -5,7 +5,11 @@
 # You may obtain a copy of the License at
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
-"""MLPerf v5.1 apples-to-apples flavor (--mlperf_flavor): resolves shape, dataset, mounts, and parity env vars."""
+"""MLPerf v6.0 apples-to-apples flavor (--mlperf_flavor): resolves shape, dataset, mounts, and parity env vars.
+
+Shapes here mirror the canonical NVIDIA MLPerf v6.0 training submission configs on GB200.
+Validated end-to-end against MLPerf v6.0 reference (Llama 3.1 8B, 8/16/32/64 GPU FP8 + FP4).
+"""
 
 import argparse
 import logging
@@ -14,15 +18,25 @@ from typing import Dict, Tuple
 
 logger = logging.getLogger(__name__)
 
-# (model_recipe_name, compute_dtype, num_gpus) -> (TP, PP, VP, CP, MBS, GBS, parity_mode); shapes derived from v5.1 NVIDIA submission configs.
-_MLPERF_V51_SHAPES: Dict[Tuple[str, str, int], Tuple[int, int, int, int, int, int, str]] = {
-    ("llama3_8b",   "fp8_cs",   8):   (1, 1, 1, 1, 1, 8,    "F16_ATTN"),
+# (model_recipe_name, compute_dtype, num_gpus) -> (TP, PP, VP, CP, MBS, GBS, parity_mode)
+# Shapes derived from MLPerf v6.0 NVIDIA submission configs on GB200:
+#   - 8B 8 GPU:    config_GB200_2x4x2xtp1pp1cp1_8b[_fp4].sh           (TP1/PP1/CP1, MBS=2, GBS=16)
+#   - 8B 16/32/64 FP8:   down-scaled config_GB200_18x4x1xtp1pp1cp2_8b.sh        (TP1/PP1/CP2, MBS=1)
+#   - 8B 16/32/64 FP4:   down-scaled config_GB200_18x4x1xtp1pp1cp1_8b_fp4.sh    (TP1/PP1/CP1, MBS=1)
+#   - 8B 72 GPU:   config_GB200_18x4x1xtp1pp1cp2_8b.sh                 (TP1/PP1/CP2, MBS=1)
+#   - 8B 128 FP8:  down-scaled config_GB200_128x4x1xtp2pp1cp4_8b.sh    (TP2/PP1/CP4, MBS=1)
+#   - 405B:        config_GB200_128x4x{112,128}xtp4pp8cp2_cg_fp4.sh    (TP4/PP8/VP8/CP2, MBS=1)
+_MLPERF_SHAPES: Dict[Tuple[str, str, int], Tuple[int, int, int, int, int, int, str]] = {
+    ("llama3_8b",   "fp8_cs",   8):   (1, 1, 1, 1, 2, 16,   "F16_ATTN"),
     ("llama3_8b",   "fp8_cs",   16):  (1, 1, 1, 2, 1, 8,    "F16_ATTN"),
     ("llama3_8b",   "fp8_cs",   32):  (1, 1, 1, 2, 1, 16,   "F16_ATTN"),
     ("llama3_8b",   "fp8_cs",   64):  (1, 1, 1, 2, 1, 32,   "F16_ATTN"),
     ("llama3_8b",   "fp8_cs",   72):  (1, 1, 1, 2, 1, 36,   "F16_ATTN"),
     ("llama3_8b",   "fp8_cs",   128): (2, 1, 1, 4, 1, 16,   "F16_ATTN"),
     ("llama3_8b",   "nvfp4",    8):   (1, 1, 1, 1, 2, 16,   "FP4_ATTN"),
+    ("llama3_8b",   "nvfp4",    16):  (1, 1, 1, 1, 1, 16,   "FP4_ATTN"),
+    ("llama3_8b",   "nvfp4",    32):  (1, 1, 1, 1, 1, 32,   "FP4_ATTN"),
+    ("llama3_8b",   "nvfp4",    64):  (1, 1, 1, 1, 1, 64,   "FP4_ATTN"),
     ("llama31_405b","fp8_cs",   256): (4, 8, 8, 2, 1, 576,  "405B"),
     ("llama31_405b","fp8_cs",   512): (4, 8, 8, 2, 1, 1152, "405B"),
     ("llama31_405b","nvfp4",    256): (4, 8, 8, 2, 1, 576,  "405B"),
@@ -31,7 +45,13 @@ _MLPERF_V51_SHAPES: Dict[Tuple[str, str, int], Tuple[int, int, int, int, int, in
 
 
 def _resolve_dataset(model_recipe_name: str) -> Tuple[str, str]:
-    """Return (data_prefix, index_cache_dir) for the model size."""
+    """Return (data_prefix, index_cache_dir) for the model size.
+
+    Expects MLPERF_DATA_ROOT to contain <size>/c4-train.en_6_text_document.{bin,idx}.
+    On clusters with the shared MLPerf training C4 preproc, set:
+        MLPERF_DATA_ROOT=/lustre/share/coreai_mlperf_training/data/c4
+    (same layout that MLPerf v6.0 reference configs expect).
+    """
     data_root = os.environ.get("MLPERF_DATA_ROOT")
     if not data_root:
         raise RuntimeError(
@@ -58,18 +78,19 @@ def _resolve_dataset(model_recipe_name: str) -> Tuple[str, str]:
 
 
 def apply_mlperf_flavor(args: argparse.Namespace) -> None:
-    """Mutate args in place to apply MLPerf v5.1 apples-to-apples configuration; sets MLPERF_PARITY_* env vars for perf_plugins/overrides to pick up."""
-    # Shape table is derived from v5.1 GB200 reference configs; other GPU types have different v5.1 shapes and need separate validation.
+    """Mutate args in place to apply MLPerf v6.0 apples-to-apples configuration; sets MLPERF_PARITY_* env vars for perf_plugins/overrides to pick up."""
+    # Shape table is derived from MLPerf v6.0 NVIDIA GB200 submission configs.
+    # Other GPU types have different MLPerf shapes and need separate validation.
     if args.gpu != "gb200":
         raise RuntimeError(
             f"--mlperf_flavor currently only supports gpu=gb200, got '{args.gpu}'. Other GPU types not yet validated."
         )
     key = (args.model_recipe_name, args.compute_dtype, args.num_gpus)
-    shape = _MLPERF_V51_SHAPES.get(key)
+    shape = _MLPERF_SHAPES.get(key)
     if shape is None:
         raise RuntimeError(
-            f"--mlperf_flavor: no v5.1 shape mapping for {key}. "
-            f"Supported: {sorted(_MLPERF_V51_SHAPES.keys())}"
+            f"--mlperf_flavor: no MLPerf shape mapping for {key}. "
+            f"Supported: {sorted(_MLPERF_SHAPES.keys())}"
         )
     tp, pp, vp, cp, mbs, gbs, parity_mode = shape
 
@@ -80,25 +101,30 @@ def apply_mlperf_flavor(args: argparse.Namespace) -> None:
     args.micro_batch_size = mbs
     args.global_batch_size = gbs
 
-    # Dataset: MLPerf C4 shards via rp2; tokenizer left at MBridge default (same vocab as preprocessed shards).
-    data_prefix, index_cache_dir = _resolve_dataset(args.model_recipe_name)
-    args.data = "rp2"
-    args.dataset_paths = [data_prefix]
-    args.index_mapping_dir = index_cache_dir
-
-    # Bind-mount data + index cache into container (Lustre paths aren't auto-mounted by NeMo-Run).
-    data_root = os.path.dirname(os.path.dirname(data_prefix))
-    if args.custom_mounts is None:
-        args.custom_mounts = []
-    for mount in (data_root, index_cache_dir):
-        if mount not in args.custom_mounts:
-            args.custom_mounts.append(mount)
+    # Dataset: MLPerf C4 shards via rp2 if MLPERF_DATA_ROOT is set; otherwise keep MBridge default (mock).
+    # C4 is optional - the shape + parity knobs are the primary apples-to-apples levers; the C4 dataset
+    # typically adds +4-8% TFLOPS/GPU over mock, but the comparison is still meaningful without it.
+    if os.environ.get("MLPERF_DATA_ROOT"):
+        data_prefix, index_cache_dir = _resolve_dataset(args.model_recipe_name)
+        args.data = "rp2"
+        args.dataset_paths = [data_prefix]
+        args.index_mapping_dir = index_cache_dir
+        # Bind-mount data + index cache into container (Lustre paths aren't auto-mounted by NeMo-Run).
+        data_root = os.path.dirname(os.path.dirname(data_prefix))
+        if args.custom_mounts is None:
+            args.custom_mounts = []
+        for mount in (data_root, index_cache_dir):
+            if mount not in args.custom_mounts:
+                args.custom_mounts.append(mount)
+        dataset_msg = f"data={data_prefix}"
+    else:
+        dataset_msg = "data=MBridge default (mock; set MLPERF_DATA_ROOT to use MLPerf C4 for full apples-to-apples)"
 
     # Set MLPERF_PARITY_* env vars so perf_plugins (host-side) + overrides.py (in-container) pick them up.
     env_var = {"F16_ATTN": "MLPERF_PARITY_F16_ATTN", "FP4_ATTN": "MLPERF_PARITY_FP4_ATTN", "405B": "MLPERF_PARITY_405B"}[parity_mode]
     os.environ[env_var] = "1"
 
     logger.info(
-        f"--mlperf_flavor: {args.model_recipe_name}/{args.compute_dtype}/{args.num_gpus} -> "
-        f"TP={tp} PP={pp} VP={vp} CP={cp} MBS={mbs} GBS={gbs} parity={parity_mode} data={data_prefix}"
+        f"--mlperf_flavor (v6.0): {args.model_recipe_name}/{args.compute_dtype}/{args.num_gpus} -> "
+        f"TP={tp} PP={pp} VP={vp} CP={cp} MBS={mbs} GBS={gbs} parity={parity_mode} {dataset_msg}"
     )

--- a/scripts/performance/utils/mlperf_flavor.py
+++ b/scripts/performance/utils/mlperf_flavor.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""MLPerf v5.1 apples-to-apples flavor (--mlperf_flavor): resolves shape, dataset, mounts, and parity env vars."""
+
+import argparse
+import logging
+import os
+from typing import Dict, Tuple
+
+logger = logging.getLogger(__name__)
+
+# (model_recipe_name, compute_dtype, num_gpus) -> (TP, PP, VP, CP, MBS, GBS, parity_mode); shapes derived from v5.1 NVIDIA submission configs.
+_MLPERF_V51_SHAPES: Dict[Tuple[str, str, int], Tuple[int, int, int, int, int, int, str]] = {
+    ("llama3_8b",   "fp8_cs",   8):   (1, 1, 1, 1, 1, 8,    "F16_ATTN"),
+    ("llama3_8b",   "fp8_cs",   16):  (1, 1, 1, 2, 1, 8,    "F16_ATTN"),
+    ("llama3_8b",   "fp8_cs",   32):  (1, 1, 1, 2, 1, 16,   "F16_ATTN"),
+    ("llama3_8b",   "fp8_cs",   64):  (1, 1, 1, 2, 1, 32,   "F16_ATTN"),
+    ("llama3_8b",   "fp8_cs",   72):  (1, 1, 1, 2, 1, 36,   "F16_ATTN"),
+    ("llama3_8b",   "fp8_cs",   128): (2, 1, 1, 4, 1, 16,   "F16_ATTN"),
+    ("llama3_8b",   "nvfp4",    8):   (1, 1, 1, 1, 2, 16,   "FP4_ATTN"),
+    ("llama31_405b","fp8_cs",   256): (4, 8, 8, 2, 1, 576,  "405B"),
+    ("llama31_405b","fp8_cs",   512): (4, 8, 8, 2, 1, 1152, "405B"),
+    ("llama31_405b","nvfp4",    256): (4, 8, 8, 2, 1, 576,  "405B"),
+    ("llama31_405b","nvfp4",    512): (4, 8, 8, 2, 1, 1152, "405B"),
+}
+
+
+def _resolve_dataset(model_recipe_name: str) -> Tuple[str, str]:
+    """Return (data_prefix, index_cache_dir) for the model size."""
+    data_root = os.environ.get("MLPERF_DATA_ROOT")
+    if not data_root:
+        raise RuntimeError(
+            "--mlperf_flavor requires MLPERF_DATA_ROOT pointing to a dir containing "
+            "<size>/c4-train.en_6_text_document.{bin,idx}."
+        )
+
+    size = "8b" if "8b" in model_recipe_name else "405b" if "405b" in model_recipe_name else None
+    if size is None:
+        raise RuntimeError(f"--mlperf_flavor: cannot map model_recipe_name '{model_recipe_name}' to a dataset size.")
+
+    prefix = os.path.join(data_root, size, "c4-train.en_6_text_document")
+    if not (os.path.isfile(prefix + ".bin") and os.path.isfile(prefix + ".idx")):
+        raise RuntimeError(
+            f"--mlperf_flavor: MLPerf C4 dataset not found at {prefix}.{{bin,idx}}. "
+            "Set MLPERF_DATA_ROOT to the directory containing <size>/c4-train.en_6_text_document.{bin,idx}."
+        )
+
+    index_cache_dir = os.environ.get("MLPERF_INDEX_CACHE_DIR") or os.path.join(
+        os.environ.get("LLMB_INSTALL", "/tmp"), ".cache", f"mlperf_idx_{size}"
+    )
+    os.makedirs(index_cache_dir, exist_ok=True)
+    return prefix, index_cache_dir
+
+
+def apply_mlperf_flavor(args: argparse.Namespace) -> None:
+    """Mutate args in place to apply MLPerf v5.1 apples-to-apples configuration; sets MLPERF_PARITY_* env vars for perf_plugins/overrides to pick up."""
+    # Shape table is derived from v5.1 GB200 reference configs; other GPU types have different v5.1 shapes and need separate validation.
+    if args.gpu != "gb200":
+        raise RuntimeError(
+            f"--mlperf_flavor currently only supports gpu=gb200, got '{args.gpu}'. Other GPU types not yet validated."
+        )
+    key = (args.model_recipe_name, args.compute_dtype, args.num_gpus)
+    shape = _MLPERF_V51_SHAPES.get(key)
+    if shape is None:
+        raise RuntimeError(
+            f"--mlperf_flavor: no v5.1 shape mapping for {key}. "
+            f"Supported: {sorted(_MLPERF_V51_SHAPES.keys())}"
+        )
+    tp, pp, vp, cp, mbs, gbs, parity_mode = shape
+
+    args.tensor_model_parallel_size = tp
+    args.pipeline_model_parallel_size = pp
+    args.virtual_pipeline_model_parallel_size = vp
+    args.context_parallel_size = cp
+    args.micro_batch_size = mbs
+    args.global_batch_size = gbs
+
+    # Dataset: MLPerf C4 shards via rp2; tokenizer left at MBridge default (same vocab as preprocessed shards).
+    data_prefix, index_cache_dir = _resolve_dataset(args.model_recipe_name)
+    args.data = "rp2"
+    args.dataset_paths = [data_prefix]
+    args.index_mapping_dir = index_cache_dir
+
+    # Bind-mount data + index cache into container (Lustre paths aren't auto-mounted by NeMo-Run).
+    data_root = os.path.dirname(os.path.dirname(data_prefix))
+    if args.custom_mounts is None:
+        args.custom_mounts = []
+    for mount in (data_root, index_cache_dir):
+        if mount not in args.custom_mounts:
+            args.custom_mounts.append(mount)
+
+    # Set MLPERF_PARITY_* env vars so perf_plugins (host-side) + overrides.py (in-container) pick them up.
+    env_var = {"F16_ATTN": "MLPERF_PARITY_F16_ATTN", "FP4_ATTN": "MLPERF_PARITY_FP4_ATTN", "405B": "MLPERF_PARITY_405B"}[parity_mode]
+    os.environ[env_var] = "1"
+
+    logger.info(
+        f"--mlperf_flavor: {args.model_recipe_name}/{args.compute_dtype}/{args.num_gpus} -> "
+        f"TP={tp} PP={pp} VP={vp} CP={cp} MBS={mbs} GBS={gbs} parity={parity_mode} data={data_prefix}"
+    )

--- a/scripts/performance/utils/overrides.py
+++ b/scripts/performance/utils/overrides.py
@@ -14,6 +14,7 @@
 
 import argparse
 import logging
+import os
 from typing import List, Optional
 
 from omegaconf import OmegaConf
@@ -484,5 +485,102 @@ def set_post_overrides(
             logger.info(
                 f"Scaled global batch size from {workload_base_config.global_batch_size} to {new_gbs} based on {num_gpus} GPUs."
             )
+
+    # MLPerf v5.1 vs Megatron-Bridge 26.04.x parity (opt-in via env). Must run
+    # AFTER set_workload_base_configs / _set_common_perf_overrides (which
+    # force-disables use_transformer_engine_op_fuser) AND after the recipe
+    # builder has populated cfg.comm_overlap. set_post_overrides is the last
+    # override hook before pretrain() in run_script.py, so this satisfies both.
+    _apply_mlperf_parity_code_overrides(recipe, compute_dtype)
+
+    return recipe
+
+
+def _apply_mlperf_parity_code_overrides(recipe: ConfigContainer, compute_dtype: str) -> ConfigContainer:
+    """Apply MLPerf v5.1 apples-to-apples recipe knobs; gated by MLPERF_PARITY_{F16_ATTN,FP4_ATTN,405B} env vars (set by perf_plugins)."""
+    f16_only = bool(os.environ.get("MLPERF_PARITY_F16_ATTN"))
+    fp4_attn = bool(os.environ.get("MLPERF_PARITY_FP4_ATTN"))
+    parity_405b = bool(os.environ.get("MLPERF_PARITY_405B"))
+    if not (f16_only or fp4_attn or parity_405b):
+        return recipe
+
+    # 405B leaves 8B-only knobs (USE_TE_OPS / BUCKET_SIZE / FUSED_QKV_ROPE) unset; skip them under MLPERF_PARITY_405B.
+    apply_8b_recipe_knobs = (f16_only or fp4_attn) and not parity_405b
+    mode = "405B" if parity_405b else ("FP4_ATTN" if fp4_attn else "F16_ATTN")
+
+    applied: List[str] = []
+    skipped: List[str] = []
+
+    if apply_8b_recipe_knobs:
+        # Knob 1: TE op fuser (NeMo USE_TE_OPS=True). MBridge force-disables in _set_common_perf_overrides.
+        if hasattr(recipe.model, "use_transformer_engine_op_fuser"):
+            recipe.model.use_transformer_engine_op_fuser = True
+            applied.append("model.use_transformer_engine_op_fuser=True")
+        else:
+            skipped.append("model.use_transformer_engine_op_fuser")
+
+        # Knob 2: DDP grad bucket (NeMo BUCKET_SIZE=768000000). Override via MLPERF_PARITY_BUCKET_MB for gap-chase sweeps.
+        if recipe.comm_overlap is not None and hasattr(recipe.comm_overlap, "bucket_size"):
+            bucket_mb_override = os.environ.get("MLPERF_PARITY_BUCKET_MB")
+            if bucket_mb_override:
+                try:
+                    recipe.comm_overlap.bucket_size = int(bucket_mb_override) * 1024 * 1024
+                    applied.append(f"comm_overlap.bucket_size={bucket_mb_override}MB (override)")
+                except ValueError:
+                    logger.warning(f"MLPERF_PARITY_BUCKET_MB={bucket_mb_override!r} not int; using 768MB.")
+                    recipe.comm_overlap.bucket_size = 768 * 1024 * 1024
+                    applied.append("comm_overlap.bucket_size=768MB")
+            else:
+                recipe.comm_overlap.bucket_size = 768 * 1024 * 1024
+                applied.append("comm_overlap.bucket_size=768MB")
+        else:
+            skipped.append("comm_overlap.bucket_size (None at call site)")
+
+        # Knob 3: Fused QKV+RoPE (NeMo FUSED_QKV_ROPE=True).
+        if hasattr(recipe.model, "fused_single_qkv_rope"):
+            recipe.model.fused_single_qkv_rope = True
+            applied.append("model.fused_single_qkv_rope=True")
+        else:
+            skipped.append("model.fused_single_qkv_rope")
+
+        # Knob 4: TP-only amax reduction (NeMo Hydra default True; MBridge default False).
+        if hasattr(recipe.model, "tp_only_amax_red"):
+            recipe.model.tp_only_amax_red = True
+            applied.append("model.tp_only_amax_red=True")
+        else:
+            skipped.append("model.tp_only_amax_red")
+
+    # Knob 5: CUDA graphs (NeMo MCORE_CUDA_GRAPH=1 + FULL_CUDA_GRAPH=1). MBridge llama recipes hardcode "none".
+    if hasattr(recipe.model, "cuda_graph_impl"):
+        recipe.model.cuda_graph_impl = "local"
+        applied.append("model.cuda_graph_impl=local")
+        if hasattr(recipe.model, "cuda_graph_scope"):
+            recipe.model.cuda_graph_scope = "full_iteration"
+            applied.append("model.cuda_graph_scope=full_iteration")
+        if hasattr(recipe.model, "use_te_rng_tracker"):
+            recipe.model.use_te_rng_tracker = True
+            applied.append("model.use_te_rng_tracker=True")
+        if hasattr(recipe, "rng") and hasattr(recipe.rng, "te_rng_tracker"):
+            recipe.rng.te_rng_tracker = True
+            applied.append("rng.te_rng_tracker=True")
+    else:
+        skipped.append("model.cuda_graph_impl")
+
+    # Knob 6 (FP4 only): FP8 DPA (MLPerf FP8_DPA=True; NVFP4 invalid for DPA, must route through FP8).
+    if fp4_attn:
+        if recipe.mixed_precision is None or isinstance(recipe.mixed_precision, str):
+            skipped.append("mixed_precision (None or str) [FP4_ATTN]")
+        else:
+            mp = recipe.mixed_precision
+            if hasattr(mp, "fp8_dot_product_attention"):
+                mp.fp8_dot_product_attention = True
+                applied.append("fp8_dot_product_attention=True [FP4_ATTN]")
+            else:
+                skipped.append("fp8_dot_product_attention [FP4_ATTN]")
+
+    logger.warning(f"MLPerf parity: mode=MLPERF_PARITY_{mode}=1")
+    logger.warning(f"MLPerf parity: applied recipe overrides: {'; '.join(applied)}")
+    if skipped:
+        logger.warning(f"MLPerf parity: skipped: {'; '.join(skipped)}")
 
     return recipe

--- a/scripts/performance/utils/overrides.py
+++ b/scripts/performance/utils/overrides.py
@@ -486,7 +486,7 @@ def set_post_overrides(
                 f"Scaled global batch size from {workload_base_config.global_batch_size} to {new_gbs} based on {num_gpus} GPUs."
             )
 
-    # MLPerf v5.1 vs Megatron-Bridge 26.04.x parity (opt-in via env). Must run
+    # MLPerf v6.0 vs Megatron-Bridge 26.04.x parity (opt-in via env). Must run
     # AFTER set_workload_base_configs / _set_common_perf_overrides (which
     # force-disables use_transformer_engine_op_fuser) AND after the recipe
     # builder has populated cfg.comm_overlap. set_post_overrides is the last
@@ -497,7 +497,7 @@ def set_post_overrides(
 
 
 def _apply_mlperf_parity_code_overrides(recipe: ConfigContainer, compute_dtype: str) -> ConfigContainer:
-    """Apply MLPerf v5.1 apples-to-apples recipe knobs; gated by MLPERF_PARITY_{F16_ATTN,FP4_ATTN,405B} env vars (set by perf_plugins)."""
+    """Apply MLPerf v6.0 apples-to-apples recipe knobs; gated by MLPERF_PARITY_{F16_ATTN,FP4_ATTN,405B} env vars (set by perf_plugins)."""
     f16_only = bool(os.environ.get("MLPERF_PARITY_F16_ATTN"))
     fp4_attn = bool(os.environ.get("MLPERF_PARITY_FP4_ATTN"))
     parity_405b = bool(os.environ.get("MLPERF_PARITY_405B"))
@@ -550,7 +550,10 @@ def _apply_mlperf_parity_code_overrides(recipe: ConfigContainer, compute_dtype: 
         else:
             skipped.append("model.tp_only_amax_red")
 
-    # Knob 5: CUDA graphs (NeMo MCORE_CUDA_GRAPH=1 + FULL_CUDA_GRAPH=1). MBridge llama recipes hardcode "none".
+    # Knob 5: CUDA graphs (NeMo MCORE_CUDA_GRAPH=1 + FULL_CUDA_GRAPH=1). Note: the
+    # pretrain_llama3.1 workload base config on GB200 already defaults cuda_graph_impl=local,
+    # so this knob is typically a no-op for that recipe. Kept for explicit gating + for
+    # recipes where the default is still "none".
     if hasattr(recipe.model, "cuda_graph_impl"):
         recipe.model.cuda_graph_impl = "local"
         applied.append("model.cuda_graph_impl=local")


### PR DESCRIPTION
Adds --mlperf_flavor to scripts/performance/setup_experiment.py for MLPerf v6.0 apples-to-apples Llama3.1 runs on GB200. New utils/mlperf_flavor.py resolves the v6.0 shape per (model_recipe_name, compute_dtype, num_gpus) for Llama3 8B (8/16/32/64/72/128 GPU FP8 + 8 GPU NVFP4) and Llama3.1 405B (256/512 GPU FP8+NVFP4), wires the MLPerf preprocessed C4 dataset, appends container mounts, and triggers gated parity knobs in utils/overrides.py (up to 6 recipe knobs incl. CUDA graphs) + perf_plugins.py (parity env vars matching the v5.1 effective env). Gated to gpu=gb200 since shapes are derived from v6.0 GB200 reference configs; other GPU types not yet validated. Fully opt-in; no behavior change without the flag.