### PR TITLE
[docs] docs: Record parallelism and recompute perf notes

### DIFF
--- a/docs/parallelisms.md
+++ b/docs/parallelisms.md
@@ -463,6 +463,14 @@ the primary scaling dimension.
 | 100-500B | TP=2-4 + PP=8-16 + EP=8-32 |
 | 500B+ | TP=2 + PP=16 + EP=32-64 |
 
+Measured short-run example: on Qwen3 30B A3B, H100 BF16, 16 GPUs,
+all-to-all dispatch, and EP overlap enabled, `TP=1, PP=1, EP=16` and
+`TP=1, PP=1, EP=8` both ran near 31 s/step after warmup. The EP=8 row used
+about 7 GB more peak memory, while `TP=2, PP=1, EP=16` roughly doubled steady
+step time despite lowering peak memory. For this class of small-active-parameter
+MoE run, increase TP only when memory requires it, and treat lower EP as a
+memory-for-communication trade.
+
 ### By Hardware Topology
 
 - **Single node with NVLink**: maximize TP within the node (up to TP=8).

--- a/docs/training/activation-recomputation.md
+++ b/docs/training/activation-recomputation.md
@@ -180,6 +180,14 @@ For MoE training, it is often better to start with selective recomputation of
 MoE-side modules, normalization, activation functions, or model-specific
 up-projection modules than to enable blanket full recomputation immediately.
 
+Measured short-run example: on Qwen3 30B A3B, H100 BF16, 16 GPUs,
+all-to-all dispatch, CUDA graphs off, and EP overlap off, selective `moe_act`
+recompute reduced observed peak allocation from about 61.4 GB to 58.9 GB at
+MBS=1 without a visible step-time penalty. Selective `core_attn` was slightly
+slower and did not reduce the observed peak on that shape. Selective `moe_act`
+and `mlp` still OOMed at MBS=2, so recompute alone was not enough to double the
+micro-batch size.
+
 ## Feature Interactions
 
 - TE-scoped CUDA graphs are usually paired with selective recomputation rather

--- a/skills/perf-activation-recompute/SKILL.md
+++ b/skills/perf-activation-recompute/SKILL.md
@@ -30,7 +30,8 @@ how many layers via `recompute_num_layers`.
    borderline OOMs are caused by memory fragmentation, not capacity. This
    fixes it at zero cost. See @skills/perf-memory-tuning/SKILL.md.
 2. Start with `recompute_granularity=selective`, `recompute_modules=[core_attn]`
-   (often already the default in recipes).
+   for dense or attention-memory-heavy recipes. For MoE recipes, also test
+   `moe_act` early because it can save MoE-side activation memory at low cost.
 3. Add `layernorm` to recompute modules — nearly free compute-wise but saves
    negligible memory. Only helps in extremely borderline cases.
 4. Add `mlp` as a last resort — saves ~3 GB but costs ~16% GPU utilization on
@@ -129,6 +130,21 @@ Key takeaways:
 - Combining `mlp` + `core_attn` is slightly worse than `mlp` alone
 - For this workload, the actual OOM fix was `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`
   (memory fragmentation, not capacity). See @skills/perf-memory-tuning/SKILL.md.
+
+Qwen3 30B A3B pretrain on 16x H100, BF16, all-to-all dispatch, CUDA graphs off,
+EP overlap off, MBS=1:
+
+| recompute_modules | Step time | Peak Mem (GB) | Result |
+|---|---:|---:|---|
+| None | 42.21 s | 61.35 | Baseline |
+| [core_attn] | 42.92 s | 63.14 | Slight slowdown, no peak-memory win |
+| [moe_act] | 41.79 s | 58.93 | About 2.4 GB lower peak, no measured tax |
+| [mlp] | 41.09 s | 61.35 | No observed peak-memory win on this MoE shape |
+
+MBS=2 stress rows with `[moe_act]` and `[mlp]` both OOMed after one iteration
+with about 73.4 GiB already allocated by PyTorch. For this recipe, `moe_act` is
+the best first selective recompute knob when a few GB are needed, but recompute
+alone was not enough to double the micro-batch size.
 
 ## Code Anchors
 

--- a/skills/perf-parallelism-strategies/SKILL.md
+++ b/skills/perf-parallelism-strategies/SKILL.md
@@ -52,6 +52,14 @@ Key patterns:
 - ETP (expert tensor parallelism) is rarely used. Llama 4 is an
   exception (ETP=4).
 
+Measured Qwen3 30B-A3B note, 2026-05-18: on 16 H100 GPUs with BF16,
+all-to-all dispatch, EP overlap on, CUDA graphs off, GBS=1024, and MBS=1,
+`TP=1, PP=1, EP=16` and `TP=1, PP=1, EP=8` were effectively tied at about
+31 seconds/step after warmup. EP=8 cost about 7 GB more peak memory. `TP=2,
+PP=1, EP=16` dropped memory but regressed to about 60 seconds/step. `PP=2,
+VPP=2, EP=8` was valid but did not beat the simpler PP=1 layouts. Use TP
+increases here as a memory-fit lever, not as the first throughput knob.
+
 These are starting points, not hard rules. Always profile the first
 iteration to verify memory and communication.
 


### PR DESCRIPTION
## Summary

- Add measured Qwen3 30B A3B H100 guidance for a small parallelism-layout sweep.
- Add measured selective recompute guidance for the same current performance recipe family.
- Keep the docs conservative: these were short mock-data smokes on the available all-to-all fallback stack, not release throughput claims.

## Experiment

- Layout sweep: Qwen3 30B A3B pretrain, 16x H100, BF16, all-to-all dispatcher, EP overlap on, CUDA graphs off, fixed GBS/MBS.
- Recompute sweep: Qwen3 30B A3B pretrain, 16x H100, BF16, all-to-all dispatcher, EP overlap off to isolate recompute, CUDA graphs off.
- Local detailed reports are under `.local/` and are not committed because they contain cluster paths.

## Validation

- `.venv/bin/pre-commit run --all-files`
- `git diff --check`
- No local unit tests run, per handoff.
