### PR TITLE
[model] feat: Add limited Gemma4 dense model support

### DIFF
--- a/src/megatron/bridge/models/gemma/gemma4_bridge.py
+++ b/src/megatron/bridge/models/gemma/gemma4_bridge.py
@@ -377,7 +377,7 @@ class Gemma4Bridge(MegatronModelBridge):
             # MCore's router also receives the normed input.
             "decoder.layers.*.pre_mlp_layernorm.weight": ("model.layers.*.pre_feedforward_layernorm_2.weight"),
             # === Dense MLP → Shared Expert ===
-            "decoder.layers.*.mlp.shared_experts.linear_fc2.weight": ("model.layers.*.mlp.down_proj.weight"),
+            "decoder.layers.*.mlp.shared_experts.linear_fc2.weight": "model.layers.*.mlp.down_proj.weight",
             # Post-dense-MLP RMSNorm (Gemma 4: post_feedforward_layernorm_1)
             "decoder.layers.*.mlp.shared_experts.linear_fc2.post_layernorm.weight": (
                 "model.layers.*.post_feedforward_layernorm_1.weight"
@@ -388,6 +388,8 @@ class Gemma4Bridge(MegatronModelBridge):
             # router.scale is fused into router.weight on import; stored as an inert buffer
             # (Gemma4TopKRouter.scale) so it round-trips on export without needing the
             # reference HF checkpoint.  Mapped via ReplicatedMapping below.
+            "decoder.layers.*.mlp.linear_fc2.weight": ("model.layers.*.mlp.down_proj.weight"),
+            "decoder.layers.*.mlp.linear_fc1.layer_norm_weight": "model.layers.*.post_attention_layernorm.weight",
         }
 
         mapping_list = []
@@ -409,6 +411,12 @@ class Gemma4Bridge(MegatronModelBridge):
                 # === Dense MLP → Shared Expert gated FC1 ===
                 GatedMLPMapping(
                     megatron_param="decoder.layers.*.mlp.shared_experts.linear_fc1.weight",
+                    gate="model.layers.*.mlp.gate_proj.weight",
+                    up="model.layers.*.mlp.up_proj.weight",
+                ),
+                # === Dense MLP ===
+                GatedMLPMapping(
+                    megatron_param="decoder.layers.*.mlp.linear_fc1.weight",
                     gate="model.layers.*.mlp.gate_proj.weight",
                     up="model.layers.*.mlp.up_proj.weight",
                 ),

--- a/src/megatron/bridge/models/gemma/gemma4_provider.py
+++ b/src/megatron/bridge/models/gemma/gemma4_provider.py
@@ -94,6 +94,7 @@ class Gemma4ModelProvider(GPTModelProvider):
     attention_backend: AttnBackend = AttnBackend.auto
     softmax_scale: float = 1.0  # Gemma 4 uses QK norm; no 1/sqrt(d) scaling
     qk_layernorm: bool = True
+    attention_k_eq_v: bool = False
 
     # Global attention overrides (applied per-layer in custom SelfAttention)
     global_head_dim: int = 512
@@ -345,8 +346,8 @@ def _install_tied_kv(model: "torch.nn.Module", provider: "Gemma4ModelProvider") 
     :meth:`Gemma4SelfAttention.get_query_key_value_tensors` can enforce V=K in
     the forward pass.
 
-    Skips dense models (``provider.num_moe_experts is None``) where K=V sharing
-    has not been verified.  Must be called after model construction so that the
+    K-V sharing is decided base on attention_k_eq_v field.
+    Must be called after model construction so that the
     attention modules are already built.
 
     Note on gradient routing for LoRA: since V-rows = K-rows in the loaded
@@ -354,8 +355,7 @@ def _install_tied_kv(model: "torch.nn.Module", provider: "Gemma4ModelProvider") 
     modification.  Full gradient routing (accumulating dL/dV into K-rows) is
     left as a future improvement.
     """
-    # Only confirmed for MoE models (26B-A4B family); skip dense variants
-    if getattr(provider, "num_moe_experts", None) is None:
+    if not getattr(provider, "attention_k_eq_v", False):
         return
 
     num_global_kv_heads = getattr(provider, "num_global_key_value_heads", None)

--- a/src/megatron/bridge/models/gemma/gemma4_provider.py
+++ b/src/megatron/bridge/models/gemma/gemma4_provider.py
@@ -346,7 +346,7 @@ def _install_tied_kv(model: "torch.nn.Module", provider: "Gemma4ModelProvider") 
     :meth:`Gemma4SelfAttention.get_query_key_value_tensors` can enforce V=K in
     the forward pass.
 
-    K-V sharing is decided base on attention_k_eq_v field.
+    K-V sharing is decided based on attention_k_eq_v field.
     Must be called after model construction so that the
     attention modules are already built.
 

--- a/src/megatron/bridge/models/gemma_vl/gemma4_vl_bridge.py
+++ b/src/megatron/bridge/models/gemma_vl/gemma4_vl_bridge.py
@@ -75,10 +75,10 @@ class Gemma4VLBridge(MegatronModelBridge):
         text_config = hf_config.text_config
         vision_config = hf_config.vision_config
 
-        if not getattr(text_config, "enable_moe_block", False):
+        if not getattr(text_config, "enable_moe_block", False) and getattr(text_config, "hidden_size_per_layer_input", 0):
             raise ValueError(
-                f"Gemma4VLBridge only supports MoE models (enable_moe_block=True). "
-                f"Model '{getattr(hf_config, '_name_or_path', 'unknown')}' has enable_moe_block=False. "
+                f"Gemma4VLBridge only supports MoE models (enable_moe_block=True) or model without hidden_size_per_layer_input. "
+                f"Model '{getattr(hf_config, '_name_or_path', 'unknown')}' has enable_moe_block=False and hidden_size_per_layer_input={getattr(text_config, 'hidden_size_per_layer_input')}."
                 f"Dense Gemma 4 models require per-layer ffn_hidden_size support in MCore, "
                 f"which is not yet implemented."
             )
@@ -118,13 +118,15 @@ class Gemma4VLBridge(MegatronModelBridge):
             provider.interleaved_attn_pattern = _infer_attn_pattern(layer_types)
 
         # MoE MLP configuration
-        provider.num_moe_experts = getattr(text_config, "num_experts", None) or 128
-        provider.moe_router_topk = getattr(text_config, "top_k_experts", None) or 8
-        provider.moe_ffn_hidden_size = getattr(text_config, "moe_intermediate_size", None) or 704
-        provider.moe_shared_expert_intermediate_size = getattr(text_config, "intermediate_size", 2112)
-        provider.moe_shared_expert_overlap = False
-        provider.moe_shared_expert_gate = False
-        provider.moe_layer_freq = 1
+        is_moe = getattr(text_config, "enable_moe_block", False)
+        if is_moe:
+            provider.num_moe_experts = getattr(text_config, "num_experts", None) or 128
+            provider.moe_router_topk = getattr(text_config, "top_k_experts", None) or 8
+            provider.moe_ffn_hidden_size = getattr(text_config, "moe_intermediate_size", None) or 704
+            provider.moe_shared_expert_intermediate_size = getattr(text_config, "intermediate_size", 2112)
+            provider.moe_shared_expert_overlap = False
+            provider.moe_shared_expert_gate = False
+            provider.moe_layer_freq = 1
 
         # Logit softcapping
         provider.final_logit_softcapping = getattr(text_config, "final_logit_softcapping", 30.0)
@@ -352,6 +354,12 @@ class Gemma4VLBridge(MegatronModelBridge):
             ),
             # MoE Router
             "language_model.decoder.layers.*.mlp.router.weight": ("model.language_model.layers.*.router.proj.weight"),
+
+            "language_model.decoder.layers.*.mlp.linear_fc2.weight": (
+                "model.language_model.layers.*.mlp.down_proj.weight"
+            ),
+
+            "language_model.decoder.layers.*.mlp.linear_fc1.layer_norm_weight": "model.language_model.layers.*.post_attention_layernorm.weight",
         }
 
         mapping_list = []
@@ -373,6 +381,12 @@ class Gemma4VLBridge(MegatronModelBridge):
                 # === Dense MLP → Shared Expert gated FC1 ===
                 GatedMLPMapping(
                     megatron_param="language_model.decoder.layers.*.mlp.shared_experts.linear_fc1.weight",
+                    gate="model.language_model.layers.*.mlp.gate_proj.weight",
+                    up="model.language_model.layers.*.mlp.up_proj.weight",
+                ),
+                # === Dense MLP ===
+                GatedMLPMapping(
+                    megatron_param="language_model.decoder.layers.*.mlp.linear_fc1.weight",
                     gate="model.language_model.layers.*.mlp.gate_proj.weight",
                     up="model.language_model.layers.*.mlp.up_proj.weight",
                 ),

--- a/src/megatron/bridge/models/gemma_vl/gemma4_vl_bridge.py
+++ b/src/megatron/bridge/models/gemma_vl/gemma4_vl_bridge.py
@@ -75,7 +75,9 @@ class Gemma4VLBridge(MegatronModelBridge):
         text_config = hf_config.text_config
         vision_config = hf_config.vision_config
 
-        if not getattr(text_config, "enable_moe_block", False) and getattr(text_config, "hidden_size_per_layer_input", 0):
+        if not getattr(text_config, "enable_moe_block", False) and getattr(
+            text_config, "hidden_size_per_layer_input", 0
+        ):
             raise ValueError(
                 f"Gemma4VLBridge only supports MoE models (enable_moe_block=True) or model without hidden_size_per_layer_input. "
                 f"Model '{getattr(hf_config, '_name_or_path', 'unknown')}' has enable_moe_block=False and hidden_size_per_layer_input={getattr(text_config, 'hidden_size_per_layer_input')}."
@@ -105,6 +107,8 @@ class Gemma4VLBridge(MegatronModelBridge):
         # Global attention overrides
         provider.global_head_dim = getattr(text_config, "global_head_dim", 512)
         provider.num_global_key_value_heads = getattr(text_config, "num_global_key_value_heads", 2)
+
+        provider.attention_k_eq_v = getattr(text_config, "attention_k_eq_v", False)
 
         # Parse partial_rotary_factor
         rope_params = getattr(text_config, "rope_parameters", {})
@@ -354,11 +358,9 @@ class Gemma4VLBridge(MegatronModelBridge):
             ),
             # MoE Router
             "language_model.decoder.layers.*.mlp.router.weight": ("model.language_model.layers.*.router.proj.weight"),
-
             "language_model.decoder.layers.*.mlp.linear_fc2.weight": (
                 "model.language_model.layers.*.mlp.down_proj.weight"
             ),
-
             "language_model.decoder.layers.*.mlp.linear_fc1.layer_norm_weight": "model.language_model.layers.*.post_attention_layernorm.weight",
         }
 

--- a/src/megatron/bridge/models/gemma_vl/gemma4_vl_bridge.py
+++ b/src/megatron/bridge/models/gemma_vl/gemma4_vl_bridge.py
@@ -79,8 +79,8 @@ class Gemma4VLBridge(MegatronModelBridge):
             text_config, "hidden_size_per_layer_input", 0
         ):
             raise ValueError(
-                f"Gemma4VLBridge only supports MoE models (enable_moe_block=True) or model without hidden_size_per_layer_input. "
-                f"Model '{getattr(hf_config, '_name_or_path', 'unknown')}' has enable_moe_block=False and hidden_size_per_layer_input={getattr(text_config, 'hidden_size_per_layer_input')}."
+                f"Gemma4VLBridge only supports MoE models (enable_moe_block=True) or dense model withouts per-layer hidden sizes. "
+                f"Model '{getattr(hf_config, '_name_or_path', 'unknown')}' has enable_moe_block=False and hidden_size_per_layer_input={getattr(text_config, 'hidden_size_per_layer_input')}. "
                 f"Dense Gemma 4 models require per-layer ffn_hidden_size support in MCore, "
                 f"which is not yet implemented."
             )

--- a/tests/functional_tests/test_groups/models/gemma/test_gemma4_conversion.py
+++ b/tests/functional_tests/test_groups/models/gemma/test_gemma4_conversion.py
@@ -1,0 +1,296 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+import torch
+from transformers import Gemma4ForCausalLM, Gemma4TextConfig, GemmaTokenizer
+
+
+HF_GEMMA4_TOY_MODEL_CONFIG = {
+    "architectures": ["Gemma4ForCausalLM"],
+    "attention_bias": False,
+    "attention_dropout": 0.0,
+    "attention_k_eq_v": True,
+    "bos_token_id": 2,
+    "eos_token_id": 1,
+    "head_dim": 256,
+    "hidden_size_per_layer_input": 0,
+    "global_head_dim": 512,
+    "hidden_act": "gelu_pytorch_tanh",
+    "hidden_activation": "gelu_pytorch_tanh",
+    "hidden_size": 1152,  # Smaller than real 1B for faster testing
+    "initializer_range": 0.02,
+    "intermediate_size": 2304,  # Reduced for TP compatibility testing
+    "max_position_embeddings": 8192,
+    "model_type": "gemma4_text",
+    "num_attention_heads": 4,
+    "num_hidden_layers": 2,  # Much smaller for testing
+    "num_key_value_heads": 2,  # Changed from 1 to 2 to be divisible by TP=2
+    "num_global_key_value_heads": 2,
+    "pad_token_id": 0,
+    "query_pre_attn_scalar": 256,
+    "rms_norm_eps": 1e-06,
+    "rope_local_base_freq": 10000.0,
+    "rope_theta": 1000000.0,
+    "sliding_window": 512,
+    "torch_dtype": "bfloat16",
+    "transformers_version": "5.9.0",
+    "use_cache": True,
+    "vocab_size": 262144,
+    "rope_parameters": {
+        "full_attention": {
+            "partial_rotary_factor": 0.25,
+            "rope_theta": 1000000.0,
+            "rope_type": "proportional",
+        },
+        "sliding_attention": {
+            "rope_theta": 10000.0,
+            "rope_type": "default",
+        },
+    },
+    "layer_types": [
+        "sliding_attention",
+        "full_attention",
+    ],
+}
+
+
+class TestGemma4Conversion:
+    """
+    Test gemma4 model conversion from local HuggingFace model with different parallelism configurations.
+    """
+
+    @pytest.fixture(scope="class")
+    def gemma4_toy_model_path(self, tmp_path_factory):
+        """
+        Create and save a HuggingFace gemma4 toy model from config to a temporary directory.
+
+        Args:
+            tmp_path_factory: Pytest temporary path factory for class-scoped fixtures
+
+        Returns:
+            str: Path to the saved HuggingFace model directory
+        """
+        # Create a temporary directory for this test class
+        temp_dir = tmp_path_factory.mktemp("gemma4_toy_model")
+        model_dir = temp_dir / "gemma4_toy"
+
+        # Create gemma4 config from the toy model config
+        config = Gemma4TextConfig(**HF_GEMMA4_TOY_MODEL_CONFIG)
+        config.torch_dtype = torch.bfloat16  # Explicitly set the torch_dtype in config
+
+        # Create model with random weights and convert to bfloat16
+        model = Gemma4ForCausalLM(config)
+        model = model.bfloat16()  # Use .bfloat16() method instead of .to()
+
+        # Debug: Check model dtype before saving
+        for name, param in model.named_parameters():
+            print(f"Before save - {name}: {param.dtype}")
+            break  # Just check the first parameter
+
+        # Download and save tokenizer from a reference Gemma model
+        # We use the smallest available Gemma model for tokenizer artifacts.
+        # Download tokenizer directly from Hugging Face; caching is handled by transformers/HF.
+        tokenizer = GemmaTokenizer.from_pretrained("google/gemma-2b")
+        tokenizer.save_pretrained(model_dir)
+
+        # Save model and config to directory
+        model.save_pretrained(model_dir, safe_serialization=True)
+
+        # Also save config.json explicitly to ensure compatibility with correct torch_dtype
+        config_to_save = HF_GEMMA4_TOY_MODEL_CONFIG.copy()
+        config_path = model_dir / "config.json"
+        with open(config_path, "w") as f:
+            json.dump(config_to_save, f, indent=2)
+
+        return str(model_dir)
+
+    def test_toy_model_creation(self, gemma4_toy_model_path):
+        """
+        Test that the toy model is created correctly and can be loaded.
+
+        Args:
+            gemma4_toy_model_path: Path to the toy gemma4 model (from fixture)
+        """
+        # Verify the model directory exists
+        model_path = Path(gemma4_toy_model_path)
+        assert model_path.exists(), f"Model directory not found at {model_path}"
+
+        # Check essential files exist
+        config_file = model_path / "config.json"
+        assert config_file.exists(), f"config.json not found at {config_file}"
+
+        # Check for model weights (safetensors preferred)
+        weights_file = model_path / "model.safetensors"
+        if not weights_file.exists():
+            weights_file = model_path / "pytorch_model.bin"
+        assert weights_file.exists(), f"Model weights file not found in {model_path}"
+
+        # Check for tokenizer files
+        tokenizer_config_file = model_path / "tokenizer_config.json"
+        assert tokenizer_config_file.exists(), f"tokenizer_config.json not found at {tokenizer_config_file}"
+
+        # Load and verify config
+        with open(config_file) as f:
+            config_data = json.load(f)
+
+        assert config_data["model_type"] == "gemma4_text"
+        assert config_data["hidden_size"] == 1152
+        assert config_data["intermediate_size"] == 2304
+        assert config_data["num_hidden_layers"] == 2
+        assert config_data["num_attention_heads"] == 4
+        assert config_data["num_key_value_heads"] == 2
+        assert config_data["vocab_size"] == 262144
+        assert config_data["head_dim"] == 256
+        # Check gemma4-specific parameters
+        assert config_data["query_pre_attn_scalar"] == 256
+        assert config_data["sliding_window"] == 512
+        assert config_data["rope_local_base_freq"] == 10000.0
+        assert config_data["rope_theta"] == 1000000.0
+
+        # Try loading the model to verify it's valid
+        try:
+            model = Gemma4ForCausalLM.from_pretrained(
+                gemma4_toy_model_path,
+                torch_dtype=torch.bfloat16,
+                low_cpu_mem_usage=False,  # Ensure full loading
+            )
+
+            # Try loading the tokenizer as well
+            try:
+                tokenizer = GemmaTokenizer.from_pretrained(gemma4_toy_model_path)
+                print(f"Tokenizer loaded successfully with vocab_size: {tokenizer.vocab_size}")
+            except Exception as e:
+                print(f"Warning: Could not load tokenizer (this might be OK for conversion testing): {e}")
+
+            # Verify model structure
+            assert hasattr(model, "model")
+            assert hasattr(model.model, "layers")
+            assert len(model.model.layers) == 2  # num_hidden_layers
+
+            print(f"SUCCESS: Toy model created and validated at {gemma4_toy_model_path}")
+            print("Model weights are correctly in bfloat16 format")
+
+        except Exception as e:
+            assert False, f"Failed to load created toy model: {e}"
+
+    @pytest.mark.run_only_on("GPU")
+    @pytest.mark.parametrize(
+        "tp,pp,test_name",
+        [
+            (2, 1, "TP"),
+            (1, 2, "PP"),
+        ],
+    )
+    def test_gemma4_conversion_parallelism(self, gemma4_toy_model_path, tmp_path, tp, pp, test_name):
+        """
+        Test gemma4 model conversion with different parallelism configurations.
+
+        Args:
+            gemma4_toy_model_path: Path to the toy gemma4 model (from fixture)
+            tmp_path: Pytest temporary path fixture
+            tp: Tensor parallelism size
+            pp: Pipeline parallelism size
+            test_name: Name of the test for identification
+        """
+        # Create temporary output directory for conversion results
+        test_output_dir = tmp_path / f"gemma4_{test_name}"
+        test_output_dir.mkdir(exist_ok=True)
+
+        cmd = [
+            "python",
+            "-m",
+            "torch.distributed.run",
+            "--nproc_per_node=2",
+            "--nnodes=1",
+            "-m",
+            "coverage",
+            "run",
+            "--data-file=/opt/Megatron-Bridge/.coverage",
+            "--source=/opt/Megatron-Bridge/",
+            "--parallel-mode",
+            "examples/conversion/hf_megatron_roundtrip_multi_gpu.py",
+            "--hf-model-id",
+            gemma4_toy_model_path,
+            "--output-dir",
+            str(test_output_dir),
+            "--tp",
+            str(tp),
+            "--pp",
+            str(pp),
+        ]
+
+        try:
+            result = subprocess.run(
+                cmd, capture_output=True, text=True, cwd=Path(__file__).parent.parent.parent.parent.parent.parent
+            )
+
+            # Check that the conversion completed successfully
+            if result.returncode != 0:
+                print(f"STDOUT: {result.stdout}")
+                print(f"STDERR: {result.stderr}")
+                assert False, f"gemma4 {test_name} conversion failed with return code {result.returncode}"
+
+            # Verify that the converted model was saved
+            # The output directory should be named after the last part of the model path
+            model_name = Path(gemma4_toy_model_path).name  # "gemma4_toy"
+            converted_model_dir = test_output_dir / model_name
+            assert converted_model_dir.exists(), f"Converted model directory not found at {converted_model_dir}"
+
+            # Check that essential model files exist
+            config_file = converted_model_dir / "config.json"
+            assert config_file.exists(), f"config.json not found in converted model at {config_file}"
+
+            # Check for model weights file (could be either safetensors or pytorch_model.bin)
+            weights_file_safetensors = converted_model_dir / "model.safetensors"
+            weights_file_pytorch = converted_model_dir / "pytorch_model.bin"
+            assert weights_file_safetensors.exists() or weights_file_pytorch.exists(), (
+                f"Model weights file not found in converted model at {converted_model_dir}"
+            )
+
+            # Verify the config contains gemma4-specific parameters
+            with open(config_file) as f:
+                saved_config = json.load(f)
+
+            assert saved_config["model_type"] == "gemma4_text", "Model type should be gemma4_text"
+            assert saved_config["hidden_size"] == 1152, "Hidden size should match toy config"
+            assert saved_config["intermediate_size"] == 2304, "Intermediate size should match toy config"
+            assert saved_config["num_attention_heads"] == 4, "Number of attention heads should match toy config"
+            assert saved_config["num_key_value_heads"] == 2, "Number of key-value heads should match toy config"
+            assert saved_config["head_dim"] == 256, "Head dimension should match toy config"
+            # Verify gemma4-specific parameters
+            assert saved_config["query_pre_attn_scalar"] == 256, "Query pre-attention scalar should match"
+            assert saved_config["sliding_window"] == 512, "Sliding window should match"
+
+            print(f"SUCCESS: gemma4 {test_name} conversion test completed successfully")
+            print(f"Converted model saved at: {converted_model_dir}")
+
+        except Exception as e:
+            print(f"Error during gemma4 {test_name} conversion test: {e}")
+            raise
+
+    @pytest.mark.run_only_on("GPU")
+    def test_gemma4_autoconfig_roundtrip(self, gemma4_toy_model_path, tmp_path):
+        from tests.functional_tests.utils import (
+            autoconfig_roundtrip,
+        )
+
+        autoconfig_roundtrip(
+            local_model_path=gemma4_toy_model_path,
+            tmp_path=tmp_path,
+        )

--- a/tests/functional_tests/test_groups/models/gemma_vl/test_gemma4_vl_conversion.py
+++ b/tests/functional_tests/test_groups/models/gemma_vl/test_gemma4_vl_conversion.py
@@ -297,7 +297,7 @@ class TestGemma4VLConversion:
 
 
 class TestGemma4DenseVLConversion:
-    """Round-trip conversion test for the Gemma 4 VL MoE bridge."""
+    """Round-trip conversion test for the Gemma 4 VL Dense  bridge."""
 
     @pytest.fixture(scope="class")
     def gemma4_vl_toy_dense_model_path(self, tmp_path_factory):

--- a/tests/functional_tests/test_groups/models/gemma_vl/test_gemma4_vl_conversion.py
+++ b/tests/functional_tests/test_groups/models/gemma_vl/test_gemma4_vl_conversion.py
@@ -101,6 +101,59 @@ HF_GEMMA4_VL_TOY_MODEL_CONFIG = {
 }
 
 
+# Tiny model loosely based on google/gemma-4-31B-it
+HF_GEMMA4_VL_TOY_DENSE_MODEL_CONFIG = {
+    "architectures": ["Gemma4ForConditionalGeneration"],
+    "model_type": "gemma4",
+    "torch_dtype": "bfloat16",
+    "bos_token_id": 2,
+    "eos_token_id": 1,
+    "pad_token_id": 0,
+    "image_token_id": 200,
+    "video_token_id": 201,
+    "vision_soft_tokens_per_image": 16,
+    "text_config": {
+        "model_type": "gemma4_text",
+        "hidden_size": 256,
+        "intermediate_size": 256,
+        "num_hidden_layers": 2,
+        "num_attention_heads": 8,
+        "num_key_value_heads": 4,
+        "hidden_size_per_layer_input": 0,
+        "head_dim": 64,
+        "global_head_dim": 128,
+        "num_global_key_value_heads": 2,
+        "attention_k_eq_v": True,
+        "vocab_size": 2048,
+        "max_position_embeddings": 4096,
+        "rms_norm_eps": 1e-6,
+        "sliding_window": 1024,
+        "rope_theta": 1000000.0,
+        "rope_local_base_freq": 10000.0,
+        "rope_parameters": {
+            "full_attention": {"rope_theta": 1000000.0, "partial_rotary_factor": 0.25},
+            "sliding_attention": {"rope_theta": 10000.0},
+        },
+        "enable_moe_block": False,
+        "layer_types": ["sliding_attention", "full_attention"],
+        "final_logit_softcapping": 30.0,
+        "hidden_act": "gelu_pytorch_tanh",
+        "torch_dtype": "bfloat16",
+    },
+    "vision_config": {
+        "model_type": "siglip_vision_model",
+        "hidden_size": 256,
+        "intermediate_size": 1024,
+        "num_hidden_layers": 2,
+        "num_attention_heads": 4,
+        "patch_size": 14,
+        "image_size": 224,
+        "rms_norm_eps": 1e-6,
+        "vision_use_head": False,
+    },
+}
+
+
 class TestGemma4VLConversion:
     """Round-trip conversion test for the Gemma 4 VL MoE bridge."""
 
@@ -241,3 +294,139 @@ class TestGemma4VLConversion:
         assert "vision_config" in saved_config, "VL model should have vision_config"
         assert saved_config["text_config"]["num_experts"] == 4, "Number of experts should match toy config"
         assert saved_config["text_config"]["enable_moe_block"] is True, "MoE block should be enabled"
+
+
+class TestGemma4DenseVLConversion:
+    """Round-trip conversion test for the Gemma 4 VL MoE bridge."""
+
+    @pytest.fixture(scope="class")
+    def gemma4_vl_toy_dense_model_path(self, tmp_path_factory):
+        """Build and save a tiny Gemma 4 VL Dense checkpoint."""
+        temp_dir = tmp_path_factory.mktemp("gemma4_vl_toy_model")
+        model_dir = temp_dir / "gemma4_vl_toy"
+
+        config_dict = json.loads(json.dumps(HF_GEMMA4_VL_TOY_DENSE_MODEL_CONFIG))
+        config = Gemma4Config(**config_dict)
+        config.torch_dtype = torch.bfloat16
+
+        # Force eager attention on every sub-config: HF defaults to
+        # flash_attention_2 in transformers >=5.5 when flash-attn is
+        # installed, but the toy vision tower may not declare support.
+        for sub in (config, getattr(config, "text_config", None), getattr(config, "vision_config", None)):
+            if sub is not None:
+                sub._attn_implementation = "eager"
+
+        model = Gemma4ForConditionalGeneration(config)
+        model = model.to(dtype=torch.bfloat16)
+
+        model.save_pretrained(model_dir, safe_serialization=True)
+
+        # Persist the dict form of config.json so the round-trip script
+        # sees the toy values exactly as written (HF may re-emit defaults).
+        with open(model_dir / "config.json", "w") as f:
+            json.dump(config_dict, f, indent=2)
+
+        # Best-effort tokenizer download; fall back to a minimal stub.
+        try:
+            tokenizer = AutoTokenizer.from_pretrained("google/gemma-2b")
+            tokenizer.save_pretrained(model_dir)
+        except Exception:
+            tokenizer_config = {
+                "tokenizer_class": "GemmaTokenizer",
+                "vocab_size": 2048,
+                "bos_token": "<bos>",
+                "eos_token": "<eos>",
+                "pad_token": "<pad>",
+                "unk_token": "<unk>",
+            }
+            with open(model_dir / "tokenizer_config.json", "w") as f:
+                json.dump(tokenizer_config, f, indent=2)
+
+        return str(model_dir)
+
+    def test_toy_model_creation(self, gemma4_vl_toy_dense_model_path):
+        """Sanity-check the toy checkpoint shape and config."""
+        model_path = Path(gemma4_vl_toy_dense_model_path)
+        assert model_path.exists(), f"Model directory not found at {model_path}"
+
+        config_file = model_path / "config.json"
+        assert config_file.exists(), f"config.json not found at {config_file}"
+
+        weights_file = model_path / "model.safetensors"
+        if not weights_file.exists():
+            weights_file = model_path / "model.safetensors.index.json"
+        if not weights_file.exists():
+            weights_file = model_path / "pytorch_model.bin"
+        assert weights_file.exists(), f"Model weights file not found in {model_path}"
+
+        with open(config_file) as f:
+            config_data = json.load(f)
+
+        assert config_data["model_type"] == "gemma4"
+        text_cfg = config_data["text_config"]
+        assert text_cfg["num_hidden_layers"] == 2
+        assert text_cfg["enable_moe_block"] is False
+        assert text_cfg["layer_types"] == ["sliding_attention", "full_attention"]
+        assert "vision_config" in config_data
+
+    @pytest.mark.run_only_on("GPU")
+    @pytest.mark.parametrize(
+        "tp,pp,test_name",
+        [
+            (2, 1, "TP"),
+        ],
+    )
+    def test_gemma4_vl_conversion_parallelism(self, gemma4_vl_toy_dense_model_path, tmp_path, tp, pp, test_name):
+        """Run HF → Megatron → HF round-trip across TP / ETP configs."""
+        test_output_dir = tmp_path / f"gemma4_vl_{test_name}"
+        test_output_dir.mkdir(exist_ok=True)
+
+        cmd = [
+            "python",
+            "-m",
+            "torch.distributed.run",
+            "--nproc_per_node=2",
+            "--nnodes=1",
+            "-m",
+            "coverage",
+            "run",
+            "--data-file=/opt/Megatron-Bridge/.coverage",
+            "--source=/opt/Megatron-Bridge/",
+            "--parallel-mode",
+            "examples/conversion/hf_megatron_roundtrip_multi_gpu.py",
+            "--hf-model-id",
+            gemma4_vl_toy_dense_model_path,
+            "--output-dir",
+            str(test_output_dir),
+            "--tp",
+            str(tp),
+            "--pp",
+            str(pp),
+        ]
+
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            cwd=Path(__file__).parent.parent.parent.parent.parent.parent,
+        )
+
+        if result.returncode != 0:
+            print(f"STDOUT: {result.stdout}")
+            print(f"STDERR: {result.stderr}")
+            assert False, f"Gemma4 VL {test_name} conversion failed with return code {result.returncode}"
+
+        model_name = Path(gemma4_vl_toy_dense_model_path).name
+        converted_model_dir = test_output_dir / model_name
+        assert converted_model_dir.exists(), f"Converted model directory not found at {converted_model_dir}"
+
+        config_file = converted_model_dir / "config.json"
+        assert config_file.exists(), f"config.json not found in converted model at {config_file}"
+
+        with open(config_file) as f:
+            saved_config = json.load(f)
+
+        assert saved_config["model_type"] == "gemma4", "Model type should be gemma4"
+        assert "text_config" in saved_config, "VL model should have text_config"
+        assert "vision_config" in saved_config, "VL model should have vision_config"
+        assert saved_config["text_config"]["enable_moe_block"] is False, "MoE block should be disabled"

--- a/tests/unit_tests/models/gemma_vl/test_gemma4_vl_bridge.py
+++ b/tests/unit_tests/models/gemma_vl/test_gemma4_vl_bridge.py
@@ -101,6 +101,64 @@ def mock_hf_pretrained_moe(mock_hf_config_moe):
 
 
 @pytest.fixture
+def mock_text_config_dense():
+    """Mock text config for Gemma 4 26B-A4B (MoE model)."""
+    config = Mock(spec=[])
+    config.num_hidden_layers = 62
+    config.hidden_size = 2816
+    config.intermediate_size = 2112  # shared expert FFN size
+    config.moe_intermediate_size = 704  # routed expert FFN size
+    config.num_attention_heads = 8
+    config.num_key_value_heads = 4
+    config.head_dim = 256
+    config.global_head_dim = 512
+    config.num_global_key_value_heads = 2
+    config.initializer_range = 0.02
+    config.rms_norm_eps = 1e-6
+    config.vocab_size = 262144
+    config.max_position_embeddings = 131072
+    config.sliding_window = 1024
+    config.rope_theta = 1000000.0
+    config.query_pre_attn_scalar = 1.0  # not used for scale (softmax_scale=1.0)
+    config.rope_scaling = None
+    config.rope_local_base_freq = 10000.0
+    config.rope_parameters = {"rope_local_base_freq": 10000.0}
+    config.hidden_act = "gelu_pytorch_tanh"
+    config.torch_dtype = "bfloat16"
+    config.hidden_size_per_layer_input = 0
+    # MoE fields
+    config.enable_moe_block = False
+
+    # Attention pattern
+    config.layer_types = (
+        ["sliding_attention"] * 5 + ["full_attention"] + ["sliding_attention"] * 5 + ["full_attention"]
+    )
+    config.final_logit_softcapping = 30.0
+    return config
+
+
+@pytest.fixture
+def mock_hf_config_dense(mock_text_config_dense, mock_vision_config):
+    config = Mock()
+    config.text_config = mock_text_config_dense
+    config.vision_config = mock_vision_config
+    config.vision_soft_tokens_per_image = 280
+    config.bos_token_id = 2
+    config.eos_token_id = 1
+    config.image_token_id = 258_880
+    config.video_token_id = 258_884
+    return config
+
+
+@pytest.fixture
+def mock_hf_pretrained_dense(mock_hf_config_dense):
+    pretrained = Mock(spec=PreTrainedVLM)
+    pretrained.config = mock_hf_config_dense
+    pretrained.generation_config = GenerationConfig()
+    return pretrained
+
+
+@pytest.fixture
 def bridge():
     return Gemma4VLBridge()
 
@@ -187,23 +245,29 @@ class TestGemma4VLBridgeProviderBridgeMoE:
 
 
 # ---------------------------------------------------------------------------
-# provider_bridge — dense model rejected
+# provider_bridge — dense model
 # ---------------------------------------------------------------------------
 
 
-class TestGemma4VLBridgeProviderBridgeDenseRejected:
-    def test_raises_for_dense_model(self, bridge):
-        """provider_bridge must raise ValueError for non-MoE (dense) models."""
+class TestGemma4VLBridgeProviderBridgeDense:
+    def test_raises_for_dense_with_hidden_size_per_layer_model(self, bridge):
+        """provider_bridge must raise ValueError for dense models with per-layer hidden size."""
         dense_text_config = Mock(spec=[])
         dense_text_config.enable_moe_block = False
+        dense_text_config.torch_dtype = "bfloat16"
+        dense_text_config.hidden_size_per_layer_input = 1
         hf_config = Mock()
         hf_config.text_config = dense_text_config
         hf_config.vision_config = Mock()
         hf_config._name_or_path = "google/gemma-4-e2b-it"
         pretrained = Mock(spec=PreTrainedVLM)
         pretrained.config = hf_config
-        with pytest.raises(ValueError, match="enable_moe_block=False"):
+        with pytest.raises(ValueError, match="hidden_size_per_layer_input=1"):
             bridge.provider_bridge(pretrained)
+
+    def test_returns_provider(self, bridge, mock_hf_pretrained_dense):
+        provider = bridge.provider_bridge(mock_hf_pretrained_dense)
+        assert isinstance(provider, Gemma4VLModelProvider)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/models/gemma_vl/test_gemma4_vl_provider.py
+++ b/tests/unit_tests/models/gemma_vl/test_gemma4_vl_provider.py
@@ -131,7 +131,7 @@ class TestGemma4VLModelProviderDefaults:
 class TestInstallTiedKV:
     """Tests for _install_tied_kv layer marking behavior."""
 
-    def test_install_tied_kv_skips_dense_model(self):
+    def test_install_tied_kv_skips_with_flag(self):
         """_install_tied_kv does nothing when num_moe_experts is None."""
         from megatron.bridge.models.gemma.gemma4_provider import (
             Gemma4ModelProvider,
@@ -142,6 +142,7 @@ class TestInstallTiedKV:
             num_layers=6,
             hidden_size=64,
             num_attention_heads=4,
+            attention_k_eq_v=False,
         )
         provider.num_moe_experts = None  # Dense model
 
@@ -153,7 +154,7 @@ class TestInstallTiedKV:
                 layers = [FakeLayer()]
 
         _install_tied_kv(FakeModel(), provider)
-        # No _tied_kv flag should be set since it's a dense model
+        # No _tied_kv flag should be set since attention_k_eq_v is False
         assert not getattr(FakeLayer, "_tied_kv", False)
 
     def test_install_tied_kv_marks_global_layers(self):
@@ -173,6 +174,7 @@ class TestInstallTiedKV:
             global_head_dim=16,
             interleaved_attn_pattern=(5, 1),  # layers 1-5 sliding, layer 6 global
             num_moe_experts=4,
+            attention_k_eq_v=True,
         )
 
         class FakeLinear(nn.Module):


### PR DESCRIPTION
# What does this PR do ?

Current implementation of Gemma4VL Bridge supports only MoE models.
This restrictions is loosed to support Gemma4 31B model, since it does not have a per-layer embeddings

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
