### PR TITLE
[examples] Add dynamic context parallel example

### DIFF
--- a/examples/training_features/long_context/README.md
+++ b/examples/training_features/long_context/README.md
@@ -1,0 +1,106 @@
+# Long-Context Examples
+
+This directory contains small examples for long-context training features.
+
+## Dynamic Context Parallel Packing
+
+`dynamic_context_parallel.py` is a local packing demo for Megatron-Core Dynamic
+Context Parallelism (DCP). It does not train a model, build a model, or launch
+distributed workers. The goal is to show what DCP does to variable-length
+samples before the forward pass.
+
+Run it after switching the Megatron-Core submodule to a dev commit that contains
+DCP:
+
+```bash
+./scripts/switch_mcore.sh dev
+uv sync
+uv run python examples/training_features/long_context/dynamic_context_parallel.py
+```
+
+The example uses Megatron-Core's `DefaultDynamicCPScheduler` on toy sequence
+lengths:
+
+```text
+[128, 96, 64, 48, 32, 24, 16, 8]
+```
+
+with `max_seqlen_per_rank=64`, `dp_size=2`, and `cp_size=2`.
+
+### What It Prints
+
+The first block shows the Bridge config knobs used in a real DCP run:
+
+```python
+cfg.model.dynamic_context_parallel = True
+cfg.model.sequence_packing_scheduler = "default_dynamic_cp"
+cfg.model.max_seqlen_per_dp_cp_rank = 64
+cfg.model.min_dynamic_context_parallel_size = 1
+cfg.train.micro_batch_size = 1
+```
+
+The second block shows each input sample length and how many DPxCP ranks it
+needs:
+
+```text
+sample 0: length=128, gpus_needed=2
+sample 2: length=64, gpus_needed=1
+```
+
+A length-128 sample needs two ranks because each rank is configured for at most
+64 sequence tokens. Length-64 and shorter samples fit on one rank.
+
+The scheduled microbatch block shows the packed THD-style batch metadata that
+the scheduled data iterator would yield:
+
+```text
+dpxcp_rank 3: sample_ids=[5, 6, 7], lengths=[24, 16, 8], local_cp_size=1
+  tokens.shape=(48,), cu_seqlens=[0, 24, 40, 48], max_seqlen=24
+```
+
+This means three short samples were packed onto one DPxCP rank:
+
+- `tokens.shape=(48,)`: the packed token tensor has `24 + 16 + 8` tokens.
+- `cu_seqlens=[0, 24, 40, 48]`: sequence boundaries inside the flat token
+  tensor.
+- `max_seqlen=24`: longest individual sequence in this packed microbatch.
+- `local_cp_size=1`: this packed microbatch does not need a multi-rank CP
+  group.
+
+For longer samples, the output may show the same `sample_id` on multiple DPxCP
+ranks with `local_cp_size=2`. In the real forward step, MCore reads
+`local_cp_size`, selects the matching dynamic CP group, and slices the packed
+THD batch with:
+
+```python
+get_batch_on_this_rank_for_sequence_packing(..., dynamic_cp=True)
+```
+
+### Useful Variations
+
+Change the toy lengths:
+
+```bash
+uv run python examples/training_features/long_context/dynamic_context_parallel.py \
+  --lengths 256 128 72 64 32 16
+```
+
+Change the rank capacity:
+
+```bash
+uv run python examples/training_features/long_context/dynamic_context_parallel.py \
+  --max-seqlen-per-rank 128
+```
+
+Change the toy DP/CP topology:
+
+```bash
+uv run python examples/training_features/long_context/dynamic_context_parallel.py \
+  --dp-size 4 --cp-size 2
+```
+
+## Long-Context SFT Launch Scripts
+
+The `qwen3_600m_sft_128k.sh` and `qwen3_600m_sft_yarn_128k.sh` scripts are
+separate long-context SFT launch examples. They are real training launch
+scripts, unlike the DCP packing demo above.

--- a/examples/training_features/long_context/dynamic_context_parallel.py
+++ b/examples/training_features/long_context/dynamic_context_parallel.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Show how Megatron-Core Dynamic CP packs variable-length samples.
+
+This is intentionally not a training script. It uses Megatron-Core's
+``DefaultDynamicCPScheduler`` to schedule a few toy sequence lengths, then
+prints the packed THD metadata that the scheduled data iterator would yield:
+``tokens``, ``cu_seqlens``, ``cu_seqlens_padded``, ``max_seqlen``, and
+``local_cp_size``.
+
+Run after switching the Megatron-Core submodule to a dev commit that contains
+Dynamic CP:
+
+    ./scripts/switch_mcore.sh dev
+    uv sync
+    uv run python examples/training_features/long_context/dynamic_context_parallel.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import itertools
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ToySample:
+    """One variable-length sample before DCP scheduling and packing."""
+
+    sample_id: int
+    tokens: torch.Tensor
+    labels: torch.Tensor
+    loss_mask: torch.Tensor
+    position_ids: torch.Tensor
+    original_seq_len: torch.Tensor
+    padded_seq_len: torch.Tensor
+
+
+def load_dynamic_cp_helpers() -> tuple[type[Any], Any]:
+    """Load the MCore dev Dynamic CP scheduler helpers."""
+    try:
+        from megatron.core.datasets.data_schedule import DefaultDynamicCPScheduler
+        from megatron.core.datasets.data_schedule_utils import dcp_gpus_needed
+    except ImportError as exc:
+        raise SystemExit(
+            "This example needs the Megatron-Core dev Dynamic CP scheduler. "
+            "Run `./scripts/switch_mcore.sh dev && uv sync` first."
+        ) from exc
+
+    return DefaultDynamicCPScheduler, dcp_gpus_needed
+
+
+def make_sample(sample_id: int, length: int) -> ToySample:
+    """Create one deterministic toy sample."""
+    tokens = torch.arange(sample_id * 1000, sample_id * 1000 + length, dtype=torch.long)
+    labels = torch.roll(tokens, shifts=-1, dims=0)
+    loss_mask = torch.ones(length, dtype=torch.float32)
+    loss_mask[-1] = 0.0
+
+    return ToySample(
+        sample_id=sample_id,
+        tokens=tokens,
+        labels=labels,
+        loss_mask=loss_mask,
+        position_ids=torch.arange(length, dtype=torch.long),
+        original_seq_len=torch.tensor([length], dtype=torch.int32),
+        padded_seq_len=torch.tensor([length], dtype=torch.int32),
+    )
+
+
+def pack_samples(samples: list[ToySample], local_cp_size: int) -> dict[str, torch.Tensor]:
+    """Pack samples into the THD-style tensors consumed by Dynamic CP."""
+    lengths = [int(sample.original_seq_len.item()) for sample in samples]
+    cu_seqlens = torch.tensor([0, *itertools.accumulate(lengths)], dtype=torch.int32)
+
+    return {
+        "tokens": torch.cat([sample.tokens for sample in samples], dim=0),
+        "labels": torch.cat([sample.labels for sample in samples], dim=0),
+        "loss_mask": torch.cat([sample.loss_mask for sample in samples], dim=0),
+        "position_ids": torch.cat([sample.position_ids for sample in samples], dim=0),
+        "cu_seqlens": cu_seqlens,
+        "cu_seqlens_padded": cu_seqlens.clone(),
+        "max_seqlen": torch.tensor(max(lengths), dtype=torch.int32),
+        "local_cp_size": torch.tensor(local_cp_size, dtype=torch.int32),
+    }
+
+
+def local_cp_size_for_rank(rank_sample_ids: list[int], microbatch_group: list[list[int]]) -> int:
+    """Mirror MCore's local CP size attached to each packed microbatch."""
+    if not rank_sample_ids:
+        return 0
+
+    first_sample_id = rank_sample_ids[0]
+    return sum(1 for sample_ids in microbatch_group if first_sample_id in sample_ids)
+
+
+def print_bridge_config_knobs(args: argparse.Namespace) -> None:
+    """Print the Bridge config fields users set when enabling DCP for training."""
+    logger.info("Bridge config knobs for a real run:")
+    logger.info("  cfg.model.dynamic_context_parallel = True")
+    logger.info('  cfg.model.sequence_packing_scheduler = "default_dynamic_cp"')
+    logger.info("  cfg.model.max_seqlen_per_dp_cp_rank = %s", args.max_seqlen_per_rank)
+    logger.info("  cfg.model.min_dynamic_context_parallel_size = %s", args.min_dynamic_cp_size)
+    logger.info("  cfg.train.micro_batch_size = 1")
+    logger.info("")
+
+
+def print_input_lengths(args: argparse.Namespace, dcp_gpus_needed: Any) -> None:
+    """Print the unscheduled sample lengths and per-sample CP demand."""
+    logger.info("Input samples:")
+    for sample_id, length in enumerate(args.lengths):
+        gpus_needed = dcp_gpus_needed(length, args.max_seqlen_per_rank, args.min_dynamic_cp_size)
+        logger.info("  sample %s: length=%s, gpus_needed=%s", sample_id, length, gpus_needed)
+    logger.info("")
+
+
+def print_scheduled_packing(args: argparse.Namespace, sample_id_groups: list[list[list[int]]]) -> None:
+    """Print packed tensors for every scheduled microbatch and DPxCP rank."""
+    samples = {sample_id: make_sample(sample_id, length) for sample_id, length in enumerate(args.lengths)}
+
+    logger.info("Scheduled packed microbatches over dp_size=%s, cp_size=%s:", args.dp_size, args.cp_size)
+    for microbatch_id, microbatch_group in enumerate(sample_id_groups):
+        logger.info("microbatch %s:", microbatch_id)
+        for dcp_rank, sample_ids in enumerate(microbatch_group):
+            if not sample_ids:
+                logger.info("  dpxcp_rank %s: idle", dcp_rank)
+                continue
+
+            rank_samples = [samples[sample_id] for sample_id in sample_ids]
+            local_cp_size = local_cp_size_for_rank(sample_ids, microbatch_group)
+            packed = pack_samples(rank_samples, local_cp_size)
+            lengths = [int(sample.original_seq_len.item()) for sample in rank_samples]
+            token_preview = packed["tokens"][: min(8, packed["tokens"].numel())].tolist()
+
+            logger.info(
+                "  dpxcp_rank %s: sample_ids=%s, lengths=%s, local_cp_size=%s",
+                dcp_rank,
+                sample_ids,
+                lengths,
+                int(packed["local_cp_size"].item()),
+            )
+            logger.info(
+                "    tokens.shape=%s, cu_seqlens=%s, max_seqlen=%s, tokens[:8]=%s",
+                tuple(packed["tokens"].shape),
+                packed["cu_seqlens"].tolist(),
+                int(packed["max_seqlen"].item()),
+                token_preview,
+            )
+    logger.info("")
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments for the packing demo."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--lengths",
+        type=int,
+        nargs="+",
+        default=[128, 96, 64, 48, 32, 24, 16, 8],
+        help="Toy sample lengths to schedule and pack.",
+    )
+    parser.add_argument("--max-seqlen-per-rank", type=int, default=64)
+    parser.add_argument("--min-dynamic-cp-size", type=int, default=1)
+    parser.add_argument("--dp-size", type=int, default=2)
+    parser.add_argument("--cp-size", type=int, default=2)
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Run the local Dynamic CP packing demo."""
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    args = parse_args()
+    if args.dp_size < 1 or args.cp_size < 1:
+        raise ValueError("dp-size and cp-size must be positive")
+
+    DefaultDynamicCPScheduler, dcp_gpus_needed = load_dynamic_cp_helpers()
+    scheduler = DefaultDynamicCPScheduler(
+        args.max_seqlen_per_rank,
+        args.cp_size,
+        args.dp_size,
+        None,
+        min_cp_size=args.min_dynamic_cp_size,
+    )
+    sample_id_seqlens = list(enumerate(args.lengths))
+    sample_id_groups = scheduler.get_groups_and_subsamples(sample_id_seqlens)
+
+    print_bridge_config_knobs(args)
+    print_input_lengths(args, dcp_gpus_needed)
+    print_scheduled_packing(args, sample_id_groups)
+    logger.info("Forward step input: call MCore get_batch_on_this_rank_for_sequence_packing(..., dynamic_cp=True).")
+    logger.info("It reads local_cp_size, chooses the matching dynamic CP group, then slices this THD batch.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/megatron/bridge/training/initialize.py
+++ b/src/megatron/bridge/training/initialize.py
@@ -789,10 +789,16 @@ def _initialize_distributed(
         if parallel_state.model_parallel_is_initialized():
             print("model parallel is already initialized")
         else:
-            # Guard for main/dev branch submodule compat: dev exposes dynamic_context_parallel instead.
-            # TODO(mcore-dev): remove once dev exposes hybrid_context_parallel or Bridge migrates the config.
+            # Guard for main/dev branch submodule compatibility while Bridge pins
+            # MCore commits across the Dynamic CP rename.
             _init_mp_params = set(inspect.signature(parallel_state.initialize_model_parallel).parameters)
             _optional_kwargs = {}
+            if "dynamic_context_parallel" in _init_mp_params and hasattr(model_config, "dynamic_context_parallel"):
+                _optional_kwargs["dynamic_context_parallel"] = model_config.dynamic_context_parallel
+            if "min_dynamic_context_parallel_size" in _init_mp_params and hasattr(
+                model_config, "min_dynamic_context_parallel_size"
+            ):
+                _optional_kwargs["min_dynamic_context_parallel_size"] = model_config.min_dynamic_context_parallel_size
             if "hybrid_context_parallel" in _init_mp_params:
                 _optional_kwargs["hybrid_context_parallel"] = model_config.hybrid_context_parallel
 


### PR DESCRIPTION
## Summary
- Add a minimal long-context Dynamic CP packing demo; it does not train a model or launch distributed workers.
- Use Megatron-Core dev `DefaultDynamicCPScheduler` to schedule toy variable-length samples, then print the packed THD metadata per DPxCP rank: `tokens.shape`, `cu_seqlens`, `max_seqlen`, and `local_cp_size`.
- Add `examples/training_features/long_context/README.md` explaining how to run the demo, how to read the output, and how the printed metadata maps to the real DCP forward-step path.
- Show the Bridge config knobs users set in a real run: `dynamic_context_parallel=True`, `sequence_packing_scheduler="default_dynamic_cp"`, `max_seqlen_per_dp_cp_rank`, `min_dynamic_context_parallel_size`, and `micro_batch_size=1`.
- Pass Dynamic CP initialization kwargs through Bridge distributed setup when the installed MCore supports them, so dev Dynamic CP groups are created correctly after the MCore bump.

## Testing
- `python -m py_compile examples/training_features/long_context/dynamic_context_parallel.py`
- `git diff --check`
- tmux window `1`, Docker container `7366a763896a` after `./scripts/switch_mcore.sh dev` + `uv sync`: `uv run python examples/training_features/long_context/dynamic_context_parallel.py` (prints per-sample `gpus_needed` and scheduled packed microbatches with `local_cp_size`)
- tmux window `1`: `uv run ruff check examples/training_features/long_context/dynamic_context_parallel.py src/megatron/bridge/training/initialize.py`
- tmux window `1`: `uv run ruff format --check examples/training_features/long_context/dynamic_context_parallel.py src/megatron/bridge/training/initialize.py`
- tmux window `1`: `uv run pre-commit run --all-files`
