### PR TITLE
[model] fix: Handle Qwen VL MTP with context parallelism

### DIFF
--- a/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/text_model.py
+++ b/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/text_model.py
@@ -32,6 +32,7 @@ from torch import Tensor
 
 from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.rope import Qwen3VLMultimodalRotaryEmbedding
 from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.transformer_block import Qwen3VLTransformerBlock
+from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.utils import split_data_cp_rank
 from megatron.bridge.models.transformer_config import TransformerConfig
 
 
@@ -175,9 +176,31 @@ class Qwen3VLGPTModel(GPTModel):
             **(extra_block_kwargs or {}),
         )
 
-        # MTP calls self.embedding directly (bypassing the manual SP scatter that
-        # model.py does for the combined VL embeddings). Temporarily wrap the embedding
-        # to apply the SP scatter so its output shape matches hidden_states.
+        # MTP calls self.embedding directly. Mirror the VL path's CP/SP handling so
+        # MCore MTP rolls and embeds tensors with the same sequence sharding as
+        # hidden_states.
+        postprocess_input_ids = input_ids
+        postprocess_position_ids = position_ids
+        cp_size = self.pg_collection.cp.size()
+        if self.mtp_process and cp_size > 1 and packed_seq_params is None:
+            cp_rank = self.pg_collection.cp.rank()
+            postprocess_input_ids = split_data_cp_rank(
+                postprocess_input_ids,
+                cp_size,
+                postprocess_input_ids.dim() - 1,
+                cp_rank,
+            )
+            if postprocess_position_ids is not None:
+                postprocess_position_ids = split_data_cp_rank(
+                    postprocess_position_ids,
+                    cp_size,
+                    postprocess_position_ids.dim() - 1,
+                    cp_rank,
+                )
+
+        # MTP's embedding call still bypasses the manual SP scatter that model.py
+        # does for the combined VL embeddings. Temporarily wrap the embedding to
+        # apply SP scatter so its output shape matches hidden_states.
         # We write to self.__dict__ directly to bypass nn.Module.__setattr__'s type
         # check, which rejects non-Module values for registered child modules.
         _shadow_embedding = False
@@ -192,27 +215,28 @@ class Qwen3VLGPTModel(GPTModel):
             self.__dict__["embedding"] = _sp_scatter_embedding
             _shadow_embedding = True
 
-        result = self._postprocess(
-            hidden_states=hidden_states,
-            input_ids=input_ids,
-            position_ids=position_ids,
-            labels=labels,
-            rotary_pos_emb=rotary_pos_emb,
-            rotary_pos_cos=rotary_pos_cos,
-            rotary_pos_sin=rotary_pos_sin,
-            mtp_in_postprocess=self.mtp_process,
-            loss_mask=loss_mask,
-            decoder_input=decoder_input,
-            attention_mask=attention_mask,
-            inference_params=inference_params,
-            packed_seq_params=packed_seq_params,
-            sequence_len_offset=sequence_len_offset,
-            runtime_gather_output=runtime_gather_output,
-            extra_block_kwargs=extra_block_kwargs,
-            inference_context=inference_context,
-        )
-
-        if _shadow_embedding:
-            del self.__dict__["embedding"]
+        try:
+            result = self._postprocess(
+                hidden_states=hidden_states,
+                input_ids=postprocess_input_ids,
+                position_ids=postprocess_position_ids,
+                labels=labels,
+                rotary_pos_emb=rotary_pos_emb,
+                rotary_pos_cos=rotary_pos_cos,
+                rotary_pos_sin=rotary_pos_sin,
+                mtp_in_postprocess=self.mtp_process,
+                loss_mask=loss_mask,
+                decoder_input=decoder_input,
+                attention_mask=attention_mask,
+                inference_params=inference_params,
+                packed_seq_params=packed_seq_params,
+                sequence_len_offset=sequence_len_offset,
+                runtime_gather_output=runtime_gather_output,
+                extra_block_kwargs=extra_block_kwargs,
+                inference_context=inference_context,
+            )
+        finally:
+            if _shadow_embedding:
+                del self.__dict__["embedding"]
 
         return result

--- a/tests/unit_tests/models/qwen_vl/modelling_qwen3_vl/test_text_model_forward.py
+++ b/tests/unit_tests/models/qwen_vl/modelling_qwen3_vl/test_text_model_forward.py
@@ -14,6 +14,7 @@
 
 """Unit tests for Qwen3VL text model forward behavior."""
 
+import pytest
 import torch
 
 from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.text_model import Qwen3VLGPTModel
@@ -28,10 +29,34 @@ class _DummyDecoder:
         return torch.zeros(1, 1, 1)
 
 
+class _DummyContextParallelGroup:
+    def __init__(self, size=1, rank=0):
+        self._size = size
+        self._rank = rank
+
+    def size(self):
+        return self._size
+
+    def rank(self):
+        return self._rank
+
+
+class _DummyProcessGroupCollection:
+    def __init__(self, cp_size=1, cp_rank=0):
+        self.cp = _DummyContextParallelGroup(size=cp_size, rank=cp_rank)
+
+
+class _DummyConfig:
+    def __init__(self, *, sequence_parallel=False):
+        self.sequence_parallel = sequence_parallel
+
+
 class _DummyModel:
-    def __init__(self):
+    def __init__(self, *, mtp_process=False, cp_size=1, cp_rank=0, sequence_parallel=False):
         self.decoder = _DummyDecoder()
-        self.mtp_process = False
+        self.mtp_process = mtp_process
+        self.pg_collection = _DummyProcessGroupCollection(cp_size=cp_size, cp_rank=cp_rank)
+        self.config = _DummyConfig(sequence_parallel=sequence_parallel)
         self.preprocess_output = None
         self.postprocess_args = None
 
@@ -74,3 +99,25 @@ def test_forward_accepts_extra_preprocess_output():
     assert dummy.decoder.called_with["sequence_len_offset"] is preproc[4]
     assert not any(value is preproc[5] for value in dummy.decoder.called_with.values())
     assert dummy.postprocess_args["decoder_input"] is preproc[0]
+
+
+@pytest.mark.unit
+def test_mtp_postprocess_gets_cp_local_input_ids_and_position_ids():
+    """MTP postprocess should receive CP-local token tensors."""
+    dummy = _DummyModel(mtp_process=True, cp_size=2, cp_rank=1)
+    input_ids = torch.arange(16, dtype=torch.long).view(1, 16)
+    position_ids = torch.arange(3 * 16, dtype=torch.long).view(3, 1, 16)
+    attention_mask = torch.ones((1, 16), dtype=torch.long)
+
+    output = Qwen3VLGPTModel.forward(
+        dummy,
+        input_ids=input_ids,
+        position_ids=position_ids,
+        attention_mask=attention_mask,
+    )
+
+    expected_input_ids = torch.cat([input_ids[:, 4:8], input_ids[:, 8:12]], dim=-1)
+    expected_position_ids = torch.cat([position_ids[..., 4:8], position_ids[..., 8:12]], dim=-1)
+    assert output == "ok"
+    assert torch.equal(dummy.postprocess_args["input_ids"], expected_input_ids)
+    assert torch.equal(dummy.postprocess_args["position_ids"], expected_position_ids)


### PR DESCRIPTION
## Summary
- CP-localize Qwen VL MTP `input_ids` and `position_ids` before MCore postprocess when context parallelism is active.
- Keep the existing sequence-parallel embedding scatter wrapper for MTP and guarantee cleanup with `try/finally`.
- Add a CPU-only unit test that asserts MTP postprocess receives the CP-local zigzag token and position-id slices.

Fixes #3881.

## Validation
- Reproduced pre-fix on DFW interactive allocation `11920458`, log `/lustre/fs1/portfolios/coreai/projects/coreai_dlalgo_llm/users/chcui/logs/issue3881_mtp_cp_qwen_vl/repro_pre_fix_20260519_161753.log`: ranks 0-3 failed in `MultiTokenPredictionLayer._concat_embeddings` with `Expected size 128 but got size 64`.
- Validated post-fix on DFW interactive allocation `11920502`, log `/lustre/fs1/portfolios/coreai/projects/coreai_dlalgo_llm/users/chcui/logs/issue3881_mtp_cp_qwen_vl/repro_post_fix_20260519_162314.log`: completed `0:0`; `iteration 1/1`, `lm loss: 1.354103E+01`, `mtp_1 loss: 6.454011E+00`, `grad norm: 7.894`, `number of nan iterations: 0`.
- `git diff --check`
- `python3 -m py_compile src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/text_model.py tests/unit_tests/models/qwen_vl/modelling_qwen3_vl/test_text_model_forward.py`
- `uv tool run ruff check tests/unit_tests/models/qwen_vl/modelling_qwen3_vl/test_text_model_forward.py src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/text_model.py`
- `uv tool run ruff format --check tests/unit_tests/models/qwen_vl/modelling_qwen3_vl/test_text_model_forward.py src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/text_model.py`

## Notes
- `uv run pre-commit run --all-files` and `uv run --group test python -m pytest tests/unit_tests/models/qwen_vl/modelling_qwen3_vl/test_text_model_forward.py -q` could not start on the local host because the locked `nvidia-resiliency-ext==0.6.0` wheel requires `manylinux_2_39`, while this host resolves as `manylinux_2_31_x86_64`.
- System Python on this host does not have pytest installed, so the targeted pytest was not run outside `uv` either.