### PR TITLE
[docs] docs: update README news

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@
 </div>
 
 ## 📣 News
+- [05/20/2026] [**DeepSeek V4**](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/examples/models/deepseek_v4) is now merged on **main**! See the [examples README](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/examples/models/deepseek_v4/README.md) for conversion and inference details.
+
+- [05/20/2026] [**Nemotron-3 Nano Omni**](https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16) day-0 branch support is now merged on **main**! The 30B-A3B MoE multimodal model supports image, video, audio, and text workflows with checkpoint conversion, inference, SFT, and PEFT (LoRA) examples. Read the [NVIDIA Blog](https://blogs.nvidia.com/blog/nemotron-3-nano-omni-multimodal-ai-agents/) and see the [examples README](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/examples/models/nemotron/nemotron_3_omni/README.md) for the full walkthrough.
+
+- [05/19/2026] [**Nemotron-Labs Diffusion**](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/examples/diffusion/recipes/nemotron_labs_diffusion) is now supported on **main** with autoregressive-to-diffusion conversion, continuous pretraining, checkpoint conversion, and inference workflows. Read the [NVIDIA Research blog](https://research.nvidia.com/publication/2026-05_nemotron-labs-diffusion-tri-mode-language-model-unifying-autoregressive) for the tri-mode language model overview.
+
 - [05/06/2026] [**Gemma 4 VL 26B-A4B**](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/examples/models/gemma/gemma4_vl) is now supported! Checkpoint conversion, SFT, and PEFT (LoRA) recipes for Google's MoE vision-language model (26B total / 4B active params, 128 experts top-k=8, dual sliding/global attention with K=V tying on full-attention layers) are available on **main**. See the [examples README](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/examples/models/gemma/gemma4_vl/README.md) for the full walkthrough.
 
 - [04/28/2026] Day 0 support for [**Nemotron-3 Nano Omni**](https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16), a 30B-A3B MoE multimodal model that jointly processes image, video, audio, and text. Checkpoint conversion, SFT, and LoRA recipes are available on the [`nemotron_3_omni`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/nemotron_3_omni) branch — see the [examples README](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/nemotron_3_omni/examples/models/vlm/nemotron_3_omni/README.md) for the full walkthrough.


### PR DESCRIPTION
## Summary
- Add new README News entries for DeepSeek V4, Nemotron-3 Nano Omni merged-on-main support, and Nemotron-Labs Diffusion while preserving the existing Gemma 4 and Nemotron-3 Nano Omni day-0 branch announcements.
- Keep DeepSeek V4 concise and point to the examples README.
- Add official NVIDIA Blog / NVIDIA Research links for Nemotron-3 Nano Omni and Nemotron-Labs Diffusion.
- Remove inconsequential News bullets per review feedback, including ModelOpt/external trainer helpers, Qwen3-VL Energon, GLM/Falcon, and Qwen3-Omni.

## Validation
- `git diff --check` passed.
- Targeted README News scan confirmed removed bullets/details are absent from the new News additions.
- Linked main-branch repo paths referenced by the new News entries were inspected locally.
- NVIDIA Research publication page was checked for the Nemotron-Labs Diffusion May 19, 2026 date and link target.
- `uv run pre-commit run --all-files` was attempted but blocked locally before hooks ran because `nvidia-resiliency-ext==0.6.0` has no wheel for this host platform: Linux `manylinux_2_31_x86_64`; available wheels are `manylinux_2_39_aarch64` and `manylinux_2_39_x86_64`.

## Blast Radius
- README documentation only.
- L0/L1/L2 not required; normal docs/lint coverage is sufficient if CI runs.