### PR TITLE
[Training] Add memory estimator breakdown

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -47,6 +47,7 @@ training/training-loop-settings.md
 training/optimizer-scheduler.md
 training/logging.md
 training/profiling.md
+training/memory-estimator.md
 training/checkpointing.md
 training/megatron-fsdp.md
 training/resiliency.md

--- a/docs/training/README.md
+++ b/docs/training/README.md
@@ -52,6 +52,7 @@ This directory contains comprehensive documentation for training and customizing
 |----------|---------|--------------|
 | **[Logging](logging.md)** | Logging configuration and TensorBoard/WandB integration | Monitoring training progress |
 | **[Profiling](profiling.md)** | Performance profiling and analysis | Identifying bottlenecks |
+| **[Theoretical Memory Estimator](memory-estimator.md)** | Formula-based per-GPU memory planning | Sizing dense and MoE training configs |
 | **[Resiliency](resiliency.md)** | Handling failures and recovery | Building robust training pipelines |
 
 ### Advanced Features

--- a/docs/training/memory-estimator.md
+++ b/docs/training/memory-estimator.md
@@ -1,0 +1,73 @@
+# Theoretical Memory Estimator
+
+Megatron Bridge includes a formula-based training memory estimator for GPT-like
+model providers. It is intended for early configuration planning and for the
+training-time theoretical memory report printed alongside CUDA memory metrics.
+
+The estimator is available as a Python API:
+
+```python
+from megatron.bridge.training.utils.theoretical_memory_utils import (
+    estimate_training_memory,
+    format_training_memory_estimate,
+)
+
+estimate = estimate_training_memory(cfg, num_microbatches=num_microbatches)
+print(format_training_memory_estimate(estimate, unit="GB"))
+```
+
+`estimate_training_memory` returns a structured result with:
+
+- dense and embedding parameter memory on the most-loaded GPU shard
+- routed MoE expert parameter memory when `num_moe_experts` is set
+- activation memory when requested
+- total global parameter count covered by the estimator
+- assumptions attached to the estimate
+
+The training loop continues to use the same report hook:
+
+```text
+Theoretical memory footprints: weight and optimizer=..., activation=..., total=...
+```
+
+## What It Covers
+
+The model-state estimate covers weights, gradients, FP32 master weights, and
+Adam optimizer states. It uses the same byte model as the legacy utility:
+
+- `18` bytes per parameter when the distributed optimizer is disabled
+- `6 + 12 / shard_size` bytes per parameter when the distributed optimizer is enabled
+
+For dense parameters, `shard_size` is `data_parallel_size * context_parallel_size`.
+For routed MoE experts, expert parameters are divided by
+`expert_model_parallel_size * expert_tensor_parallel_size`, and optimizer state
+uses the expert data-parallel shard size, including context parallel ranks.
+
+The activation estimate follows the existing Megatron-LM theoretical formula and
+adds Bridge-aware accounting for MoE active expert width and context parallel
+partitioning. It is most meaningful when sequence parallelism and selective
+activation recomputation are enabled, which is also the condition used by the
+training-time report.
+
+## Assumptions
+
+The estimate reports the most-loaded GPU shard. Embeddings are assigned to the
+first and last pipeline stages; untied input/output embeddings both land on the
+same GPU only when `pipeline_model_parallel_size == 1`.
+
+The estimator does not model runtime allocator fragmentation, CUDA kernel
+workspace, NCCL buffers, CUDA graph static buffers, token-routing imbalance,
+dispatcher workspace, CPU offloading, or full activation recomputation. Use
+profiling and CUDA memory reports to validate final launch configurations.
+
+## MoE Notes
+
+MoE layer count follows `moe_layer_freq`, including list patterns. Routed expert
+parameters are counted separately from dense attention, dense MLP, shared expert,
+normalization, and embedding parameters. This keeps expert parallelism effects
+visible in the returned component breakdown.
+
+For memory tuning decisions, use this estimator as a planning signal together
+with the runtime guidance in [CPU Offloading](cpu-offloading.md),
+[Activation Recomputation](activation-recomputation.md), and
+[Megatron FSDP](megatron-fsdp.md).

--- a/skills/perf-memory-tuning/SKILL.md
+++ b/skills/perf-memory-tuning/SKILL.md
@@ -31,6 +31,20 @@ Beyond fragmentation, actual peak memory is determined by:
   micro-batch size
 - **Temporary / workspace memory** — CUDA kernels, NCCL buffers, CUDA graphs
 
+For configuration planning, use the Bridge theoretical estimator before launching
+large jobs:
+
+```python
+from megatron.bridge.training.utils.theoretical_memory_utils import estimate_training_memory
+
+estimate = estimate_training_memory(cfg, num_microbatches=num_microbatches)
+```
+
+The estimator reports the most-loaded GPU shard and separates dense/embedding,
+routed MoE expert, and activation components. It does not include allocator
+fragmentation, CUDA/NCCL workspace, CUDA graph buffers, token imbalance, or
+dispatcher workspace, so validate final configs with runtime memory metrics.
+
 ## Quick Decision
 
 When a training run OOMs or is close to the memory limit:
@@ -208,6 +222,7 @@ model_config = GPTModelProvider(
 |---|---|---|---|
 | OOM on a single rank despite headroom on others | Memory fragmentation | check if `expandable_segments:True` is set | set `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` |
 | OOM with `expandable_segments` already set | Genuine capacity limit | check `nvidia-smi` for param/optimizer memory | increase PP, use distributed optimizer, or add recompute |
+| Estimated memory exceeds GPU capacity before launch | model state or activations genuinely too large | run `estimate_training_memory` and inspect the largest component | adjust PP/TP/CP/EP, distributed optimizer, or recompute before launching |
 | `ValueError: PP + CPU offloading` | using cpu_offloading with PP > 1 | check PP config | disable CPU offloading or set PP=1 |
 | `RuntimeError` with `--use-nccl-ub` + expandable segments | NCCL UB incompatible with expandable allocator | check env vars | remove `expandable_segments:True` or disable `--use-nccl-ub` |
 
@@ -215,7 +230,8 @@ model_config = GPTModelProvider(
 
 - CPU offloading is blocked when PP > 1
 - Parallelism resizing (TP/PP) often has significant throughput costs
-- No automatic memory profiling to recommend the optimal strategy
+- The theoretical estimator is formula-based and does not replace runtime
+  profiling or CUDA memory reports
 
 ## Verification
 

--- a/src/megatron/bridge/training/utils/theoretical_memory_utils.py
+++ b/src/megatron/bridge/training/utils/theoretical_memory_utils.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Computes theoretical memory footprint for model training."""
+"""Formula-based theoretical memory estimates for model training."""
 
 import math
-from typing import Optional
+from dataclasses import dataclass
 
 import torch.nn.functional as F
 
@@ -24,6 +24,214 @@ from megatron.bridge.utils.vocab_utils import calculate_padded_vocab_size
 
 
 NUM_BYTES_IN_MEGABYTE: int = 1024 * 1024
+NUM_BYTES_IN_GIGABYTE: int = 1024 * 1024 * 1024
+
+
+@dataclass(frozen=True, slots=True)
+class MemoryComponentEstimate:
+    """Estimated memory for one per-GPU training memory component.
+
+    Args:
+        name: Human-readable component name.
+        parameter_count: Global parameter count covered by this component.
+        parameter_count_per_gpu: Parameter count on the most-loaded GPU shard.
+        bytes_per_parameter: Per-parameter bytes for weights, gradients, and optimizer states.
+        memory_bytes: Estimated memory on the most-loaded GPU shard.
+    """
+
+    name: str
+    parameter_count: float = 0.0
+    parameter_count_per_gpu: float = 0.0
+    bytes_per_parameter: float = 0.0
+    memory_bytes: float = 0.0
+
+    @property
+    def memory_mb(self) -> float:
+        """Memory in MiB."""
+        return self.memory_bytes / NUM_BYTES_IN_MEGABYTE
+
+    @property
+    def memory_gb(self) -> float:
+        """Memory in GiB."""
+        return self.memory_bytes / NUM_BYTES_IN_GIGABYTE
+
+
+@dataclass(frozen=True, slots=True)
+class TrainingMemoryEstimate:
+    """Structured theoretical per-GPU memory estimate for Bridge training.
+
+    Args:
+        model_state_components: Weight, gradient, and optimizer-state components.
+        activation: Activation component, if activation estimation was requested.
+        total_parameters: Global model parameter count covered by the estimator.
+        assumptions: Estimator assumptions and intentionally unsupported details.
+    """
+
+    model_state_components: tuple[MemoryComponentEstimate, ...]
+    activation: MemoryComponentEstimate | None
+    total_parameters: float
+    assumptions: tuple[str, ...]
+
+    @property
+    def weight_and_optimizer_bytes(self) -> float:
+        """Estimated per-GPU memory for weights, gradients, and optimizer states."""
+        return sum(component.memory_bytes for component in self.model_state_components)
+
+    @property
+    def total_memory_bytes(self) -> float:
+        """Estimated per-GPU training memory for all available components."""
+        activation_bytes = 0.0 if self.activation is None else self.activation.memory_bytes
+        return self.weight_and_optimizer_bytes + activation_bytes
+
+    @property
+    def total_memory_mb(self) -> float:
+        """Total estimated per-GPU memory in MiB."""
+        return self.total_memory_bytes / NUM_BYTES_IN_MEGABYTE
+
+    @property
+    def total_memory_gb(self) -> float:
+        """Total estimated per-GPU memory in GiB."""
+        return self.total_memory_bytes / NUM_BYTES_IN_GIGABYTE
+
+
+@dataclass(frozen=True, slots=True)
+class _LayerCounts:
+    dense: int
+    moe: int
+    total: int
+
+
+@dataclass(frozen=True, slots=True)
+class _ParameterCounts:
+    dense_transformer: float
+    routed_experts: float
+    embeddings: float
+
+    @property
+    def total(self) -> float:
+        return self.dense_transformer + self.routed_experts + self.embeddings
+
+
+def estimate_training_memory(
+    config: ConfigContainer,
+    num_microbatches: int | None = None,
+    *,
+    include_activation: bool = True,
+) -> TrainingMemoryEstimate:
+    """Estimate per-GPU training memory for a Bridge GPT-like model config.
+
+    The estimator is intentionally formula-based. It does not instantiate a Megatron
+    model or import UI/debug dependencies from the external prototype linked in
+    issue #1673. The returned structure separates dense/embedding model state,
+    routed expert model state, and activation memory so callers can display or
+    post-process the breakdown.
+
+    Args:
+        config: Bridge training configuration container.
+        num_microbatches: Number of microbatches in the pipeline schedule.
+            Supplying this improves activation estimates when PP is enabled.
+        include_activation: Include the activation-memory estimate. The activation
+            formula assumes sequence parallelism and selective recomputation, matching
+            the legacy training-time report.
+
+    Returns:
+        Structured per-GPU theoretical memory estimate.
+    """
+    model_config = config.model
+    parameter_counts = _count_parameters(model_config)
+
+    tensor_parallel_size = _positive_int_attr(model_config, "tensor_model_parallel_size", 1)
+    pipeline_parallel_size = _positive_int_attr(model_config, "pipeline_model_parallel_size", 1)
+    context_parallel_size = _positive_int_attr(model_config, "context_parallel_size", 1)
+    expert_parallel_size = _positive_int_attr(model_config, "expert_model_parallel_size", 1)
+    expert_tensor_parallel_size = _positive_int_attr(model_config, "expert_tensor_parallel_size", 1)
+
+    dense_parameters_per_gpu = parameter_counts.dense_transformer / (pipeline_parallel_size * tensor_parallel_size)
+    dense_parameters_per_gpu += _embedding_parameters_on_most_loaded_shard(model_config)
+    dense_optimizer_shard_size = _positive_int_attr(config, "data_parallel_size", 1) * context_parallel_size
+    dense_bytes_per_parameter = _bytes_per_parameter(config, dense_optimizer_shard_size)
+
+    components = [
+        MemoryComponentEstimate(
+            name="dense parameters and optimizer",
+            parameter_count=parameter_counts.dense_transformer + parameter_counts.embeddings,
+            parameter_count_per_gpu=dense_parameters_per_gpu,
+            bytes_per_parameter=dense_bytes_per_parameter,
+            memory_bytes=dense_parameters_per_gpu * dense_bytes_per_parameter,
+        )
+    ]
+
+    if parameter_counts.routed_experts > 0:
+        routed_expert_parameters_per_gpu = parameter_counts.routed_experts / (
+            pipeline_parallel_size * expert_parallel_size * expert_tensor_parallel_size
+        )
+        expert_optimizer_shard_size = _expert_optimizer_shard_size(
+            config,
+            tensor_parallel_size=tensor_parallel_size,
+            context_parallel_size=context_parallel_size,
+            expert_parallel_size=expert_parallel_size,
+            expert_tensor_parallel_size=expert_tensor_parallel_size,
+        )
+        expert_bytes_per_parameter = _bytes_per_parameter(config, expert_optimizer_shard_size)
+        components.append(
+            MemoryComponentEstimate(
+                name="routed expert parameters and optimizer",
+                parameter_count=parameter_counts.routed_experts,
+                parameter_count_per_gpu=routed_expert_parameters_per_gpu,
+                bytes_per_parameter=expert_bytes_per_parameter,
+                memory_bytes=routed_expert_parameters_per_gpu * expert_bytes_per_parameter,
+            )
+        )
+
+    activation = None
+    if include_activation:
+        activation = MemoryComponentEstimate(
+            name="activation",
+            memory_bytes=_compute_activation_memory_bytes(config, num_microbatches=num_microbatches),
+        )
+
+    assumptions = _estimate_assumptions(
+        config,
+        include_activation=include_activation,
+        has_routed_experts=parameter_counts.routed_experts > 0,
+    )
+    return TrainingMemoryEstimate(
+        model_state_components=tuple(components),
+        activation=activation,
+        total_parameters=parameter_counts.total,
+        assumptions=assumptions,
+    )
+
+
+def format_training_memory_estimate(estimate: TrainingMemoryEstimate, *, unit: str = "MB") -> str:
+    """Format a theoretical memory estimate as a compact single-line summary.
+
+    Args:
+        estimate: Structured estimate returned by :func:`estimate_training_memory`.
+        unit: Either ``"MB"`` for MiB output or ``"GB"`` for GiB output.
+
+    Returns:
+        Human-readable summary string.
+
+    Raises:
+        ValueError: If ``unit`` is not ``"MB"`` or ``"GB"``.
+    """
+    unit = unit.upper()
+    if unit == "MB":
+        scale = NUM_BYTES_IN_MEGABYTE
+    elif unit == "GB":
+        scale = NUM_BYTES_IN_GIGABYTE
+    else:
+        raise ValueError(f"Unsupported memory unit: {unit}")
+
+    component_parts = [
+        f"{component.name}={component.memory_bytes / scale:.2f} {unit}"
+        for component in estimate.model_state_components
+    ]
+    if estimate.activation is not None:
+        component_parts.append(f"{estimate.activation.name}={estimate.activation.memory_bytes / scale:.2f} {unit}")
+    component_parts.append(f"total={estimate.total_memory_bytes / scale:.2f} {unit}")
+    return "Theoretical memory footprints: " + ", ".join(component_parts)
 
 
 def compute_weight_and_optimizer_memory(config: ConfigContainer, verbose: bool = False) -> float:
@@ -43,82 +251,14 @@ def compute_weight_and_optimizer_memory(config: ConfigContainer, verbose: bool =
         float: Estimated memory footprint in bytes for weights and optimizer states
                on the most loaded GPU shard.
     """
-    model_config = config.model
-    # Attention projection size.
-    query_projection_size = model_config.kv_channels * model_config.num_attention_heads
-    query_projection_to_hidden_size_ratio = query_projection_size / model_config.hidden_size
-    # Group Query Attention.
-    num_query_groups = (
-        model_config.num_query_groups if model_config.num_query_groups else model_config.num_attention_heads
-    )
-    # MoE.
-    num_experts = 1 if model_config.num_moe_experts is None else model_config.num_moe_experts
-    gated_linear_multiplier = 3 / 2 if model_config.gated_linear_unit and model_config.activation_func == F.silu else 1
-    num_parameters_in_transformer_layers = (
-        2
-        * model_config.num_layers
-        * model_config.hidden_size
-        * model_config.hidden_size
-        * (
-            # Attention.
-            ((1 + (num_query_groups / model_config.num_attention_heads)) * query_projection_to_hidden_size_ratio)
-            # MLP.
-            + ((model_config.ffn_hidden_size / model_config.hidden_size) * num_experts * gated_linear_multiplier)
-            # Transformer layernorms.
-            + (2 / model_config.hidden_size)
-            # Final layernorm.
-            + (1 / (model_config.num_layers * model_config.hidden_size))
-        )
-    )
-    embedding_size = model_config.hidden_size * _get_vocab_size(model_config)
-    if not model_config.share_embeddings_and_output_weights:
-        num_parameters_in_embedding_layers = 2 * embedding_size
-    else:
-        num_parameters_in_embedding_layers = embedding_size
-    num_total_parameters = num_parameters_in_transformer_layers + num_parameters_in_embedding_layers
+    estimate = estimate_training_memory(config, include_activation=False)
     if verbose:
-        print(
-            f"Number of parameters in transformer layers in billions: "
-            f"{num_parameters_in_transformer_layers / 10**9: .2f}"
-        )
-        print(
-            f"Number of parameters in embedding layers in billions: {num_parameters_in_embedding_layers / 10**9:.2f}"
-        )
-        print(f"Total number of parameters in billions: {num_total_parameters / 10**9:.2f}")
+        _print_parameter_summary(estimate)
 
-    # Most loaded model shard has (1/pp_size transformer layers + 1 embedding layer) / tp_size.
-    num_parameters_on_most_loaded_model_shard = (
-        (num_parameters_in_transformer_layers / model_config.pipeline_model_parallel_size) + embedding_size
-    ) / model_config.tensor_model_parallel_size
-    if not model_config.share_embeddings_and_output_weights and model_config.pipeline_model_parallel_size == 1:
-        num_parameters_on_most_loaded_model_shard += embedding_size / model_config.tensor_model_parallel_size
-    if verbose:
-        print(
-            f"Number of parameters in most loaded shard in billions: "
-            f"{num_parameters_on_most_loaded_model_shard / 10**9:.4f}"
-        )
-
-    if model_config.pipeline_model_parallel_size > 1:
-        # Other shards just have (1/pp_size transformer layers) / tp_size.
-        num_parameters_on_other_model_shards = num_parameters_in_transformer_layers / (
-            model_config.pipeline_model_parallel_size * model_config.tensor_model_parallel_size
-        )
-        if verbose:
-            print(
-                f"Number of parameters in other shards in billions: {num_parameters_on_other_model_shards / 10**9:.4f}"
-            )
-
-    num_bytes_per_parameter = (
-        18 if not config.optimizer.use_distributed_optimizer else 6 + (12 / config.data_parallel_size)
-    )
-    weight_and_optimizer_memory = num_parameters_on_most_loaded_model_shard * num_bytes_per_parameter
-
-    return weight_and_optimizer_memory
+    return estimate.weight_and_optimizer_bytes
 
 
-def compute_activation_memory(
-    config: ConfigContainer, num_microbatches: Optional[int], verbose: bool = False
-) -> float:
+def compute_activation_memory(config: ConfigContainer, num_microbatches: int | None, verbose: bool = False) -> float:
     """Compute theoretical memory footprint for activations.
 
     Estimates activation memory based on the formula from the Megatron-LM paper
@@ -140,82 +280,11 @@ def compute_activation_memory(
     Returns:
         float: Estimated activation memory footprint in bytes on a single GPU shard.
     """
-    # Using formula in Table 2 of https://arxiv.org/pdf/2205.05198.pdf.
-    # We are trying to compute the maximum activation footprint, so all calculations in this
-    # function are for the first pipeline stage.
-
-    # TODO: This function needs to take into account query_projection_size potentially being
-    # different from hidden_size.
-
-    model_config = config.model
-    train_config = config.train
-
-    # Memory footprint from transformer layer (self-attention and MLP).
-    activation_memory = (model_config.seq_length * train_config.micro_batch_size * model_config.hidden_size) * (
-        18 + (4 * (model_config.ffn_hidden_size / model_config.hidden_size))
-    )
-    if verbose:
-        print(
-            f"Activation memory footprint per transformer layer: "
-            f"{activation_memory / NUM_BYTES_IN_MEGABYTE / model_config.tensor_model_parallel_size:.1f} MB"
-        )
-    activation_memory *= model_config.num_layers
-
-    # Now add activation memory required for input embeddings, last LayerNorm and output layer.
-
-    # Input to embedding (pp_size microbatches in flight).
-    activation_memory += (
-        8 * model_config.seq_length * train_config.micro_batch_size * model_config.pipeline_model_parallel_size
-    )
-    # Dropout in embedding layer (pp_size microbatches in flight).
-    activation_memory += (
-        model_config.seq_length
-        * train_config.micro_batch_size
-        * model_config.hidden_size
-        * model_config.pipeline_model_parallel_size
-    )
-
-    # Multiply by interleaved PP memory factor.
-    if model_config.virtual_pipeline_model_parallel_size is not None:
-        interleaved_schedule_memory_penalty = 1 + (
-            (model_config.pipeline_model_parallel_size - 1)
-            / (model_config.pipeline_model_parallel_size * model_config.virtual_pipeline_model_parallel_size)
-        )
-        in_flight_microbatches = math.ceil(
-            interleaved_schedule_memory_penalty * model_config.pipeline_model_parallel_size
-        )
-        if verbose:
-            print(f"Memory penalty from interleaved schedule: {interleaved_schedule_memory_penalty:.2f}")
-            print(f"Number of in-flight microbatches: {in_flight_microbatches}")
-        activation_memory *= interleaved_schedule_memory_penalty
-
-    # If using non-interleaved schedule, number of microbatches in pipeline can be less than pp_size,
-    # so discount accordingly.
-    if model_config.virtual_pipeline_model_parallel_size is None and model_config.pipeline_model_parallel_size > 1:
-        if num_microbatches is not None:
-            activation_memory *= min(1, num_microbatches / model_config.pipeline_model_parallel_size)
-            in_flight_microbatches = min(num_microbatches, model_config.pipeline_model_parallel_size)
-        else:
-            in_flight_microbatches = model_config.pipeline_model_parallel_size
-        if verbose:
-            print(f"Number of in-flight microbatches: {in_flight_microbatches}")
-
-    if model_config.pipeline_model_parallel_size == 1:
-        # Inputs to output layer and CE loss.
-        activation_memory += (
-            model_config.seq_length
-            * train_config.micro_batch_size
-            * model_config.hidden_size
-            * 4
-            * (1 + (_get_vocab_size(model_config) / model_config.hidden_size))
-        )
-
-    # Activation memory is partitioned by TP size due to tensor and sequence model parallelism.
-    return activation_memory / model_config.tensor_model_parallel_size
+    return _compute_activation_memory_bytes(config, num_microbatches=num_microbatches, verbose=verbose)
 
 
 def report_theoretical_memory(
-    config: ConfigContainer, num_microbatches: Optional[int] = None, verbose: bool = False
+    config: ConfigContainer, num_microbatches: int | None = None, verbose: bool = False
 ) -> None:
     """Compute and print the theoretical memory footprint components.
 
@@ -238,22 +307,357 @@ def report_theoretical_memory(
     if isinstance(config.model, MegatronMIMOProvider):
         return
 
-    weight_and_optimizer_memory = compute_weight_and_optimizer_memory(config, verbose=verbose) / NUM_BYTES_IN_MEGABYTE
+    should_report_activation = config.model.sequence_parallel and config.model.recompute_granularity == "selective"
+    estimate = estimate_training_memory(
+        config,
+        num_microbatches=num_microbatches,
+        include_activation=should_report_activation,
+    )
+    if verbose:
+        _print_parameter_summary(estimate)
 
     # Formulae here assume sequence parallelism and selective activation recomputation.
-    if not config.model.sequence_parallel or config.model.recompute_granularity != "selective":
-        print(f"Theoretical memory footprints: weight and optimizer={weight_and_optimizer_memory:.2f} MB")
+    if not should_report_activation:
+        print(
+            "Theoretical memory footprints: "
+            f"weight and optimizer={estimate.weight_and_optimizer_bytes / NUM_BYTES_IN_MEGABYTE:.2f} MB"
+        )
         return
 
-    activation_memory = (
-        compute_activation_memory(config, num_microbatches=num_microbatches, verbose=verbose) / NUM_BYTES_IN_MEGABYTE
-    )
-    total_memory = weight_and_optimizer_memory + activation_memory
+    activation_memory = 0.0 if estimate.activation is None else estimate.activation.memory_mb
+    total_memory = estimate.weight_and_optimizer_bytes / NUM_BYTES_IN_MEGABYTE + activation_memory
 
     print(
-        f"Theoretical memory footprints: weight and optimizer={weight_and_optimizer_memory:.2f} MB, "
+        f"Theoretical memory footprints: "
+        f"weight and optimizer={estimate.weight_and_optimizer_bytes / NUM_BYTES_IN_MEGABYTE:.2f} MB, "
         f"activation={activation_memory:.2f} MB, total={total_memory:.2f} MB\n"
     )
+
+
+def _compute_activation_memory_bytes(
+    config: ConfigContainer,
+    *,
+    num_microbatches: int | None,
+    verbose: bool = False,
+) -> float:
+    # Using formula in Table 2 of https://arxiv.org/pdf/2205.05198.pdf.
+    # We are trying to compute the maximum activation footprint, so all calculations in this
+    # function are for the first pipeline stage.
+    model_config = config.model
+    train_config = config.train
+
+    tensor_parallel_size = _positive_int_attr(model_config, "tensor_model_parallel_size", 1)
+    pipeline_parallel_size = _positive_int_attr(model_config, "pipeline_model_parallel_size", 1)
+    context_parallel_size = _positive_int_attr(model_config, "context_parallel_size", 1)
+    virtual_pipeline_parallel_size = getattr(model_config, "virtual_pipeline_model_parallel_size", None)
+
+    layer_counts = _get_layer_counts(model_config)
+    ffn_activation_ratio = _ffn_activation_ratio(model_config, layer_counts)
+
+    # Memory footprint from transformer layer (self-attention and MLP).
+    activation_memory = (
+        model_config.seq_length
+        * train_config.micro_batch_size
+        * model_config.hidden_size
+        * (18 + (4 * ffn_activation_ratio))
+    )
+    if verbose:
+        print(
+            "Activation memory footprint per transformer layer: "
+            f"{activation_memory / NUM_BYTES_IN_MEGABYTE / tensor_parallel_size / context_parallel_size:.1f} MB"
+        )
+    activation_memory *= layer_counts.total
+
+    # Now add activation memory required for input embeddings, last LayerNorm and output layer.
+
+    # Input to embedding (pp_size microbatches in flight).
+    activation_memory += 8 * model_config.seq_length * train_config.micro_batch_size * pipeline_parallel_size
+    # Dropout in embedding layer (pp_size microbatches in flight).
+    activation_memory += (
+        model_config.seq_length * train_config.micro_batch_size * model_config.hidden_size * pipeline_parallel_size
+    )
+
+    # Multiply by interleaved PP memory factor.
+    if virtual_pipeline_parallel_size is not None:
+        interleaved_schedule_memory_penalty = 1 + (
+            (pipeline_parallel_size - 1) / (pipeline_parallel_size * virtual_pipeline_parallel_size)
+        )
+        in_flight_microbatches = math.ceil(interleaved_schedule_memory_penalty * pipeline_parallel_size)
+        if verbose:
+            print(f"Memory penalty from interleaved schedule: {interleaved_schedule_memory_penalty:.2f}")
+            print(f"Number of in-flight microbatches: {in_flight_microbatches}")
+        activation_memory *= interleaved_schedule_memory_penalty
+
+    # If using non-interleaved schedule, number of microbatches in pipeline can be less than pp_size,
+    # so discount accordingly.
+    if virtual_pipeline_parallel_size is None and pipeline_parallel_size > 1:
+        if num_microbatches is not None:
+            activation_memory *= min(1, num_microbatches / pipeline_parallel_size)
+            in_flight_microbatches = min(num_microbatches, pipeline_parallel_size)
+        else:
+            in_flight_microbatches = pipeline_parallel_size
+        if verbose:
+            print(f"Number of in-flight microbatches: {in_flight_microbatches}")
+
+    if pipeline_parallel_size == 1:
+        # Inputs to output layer and CE loss.
+        activation_memory += (
+            model_config.seq_length
+            * train_config.micro_batch_size
+            * model_config.hidden_size
+            * 4
+            * (1 + (_get_vocab_size(model_config) / model_config.hidden_size))
+        )
+
+    # Activation memory is partitioned by TP/SP and CP.
+    return activation_memory / (tensor_parallel_size * context_parallel_size)
+
+
+def _count_parameters(model_config: object) -> _ParameterCounts:
+    hidden_size = model_config.hidden_size
+    layer_counts = _get_layer_counts(model_config)
+    ffn_projection_factor = _ffn_projection_factor(model_config)
+
+    query_projection_size = model_config.kv_channels * model_config.num_attention_heads
+    query_projection_to_hidden_size_ratio = query_projection_size / hidden_size
+    num_query_groups = (
+        model_config.num_query_groups if model_config.num_query_groups else model_config.num_attention_heads
+    )
+
+    attention_parameters_per_layer = (
+        2
+        * hidden_size
+        * hidden_size
+        * ((1 + (num_query_groups / model_config.num_attention_heads)) * query_projection_to_hidden_size_ratio)
+    )
+    layernorm_parameters = (4 * hidden_size * layer_counts.total) + (2 * hidden_size)
+    dense_mlp_parameters = ffn_projection_factor * hidden_size * model_config.ffn_hidden_size * layer_counts.dense
+
+    shared_expert_intermediate_size = _optional_positive_int_attr(
+        model_config,
+        "moe_shared_expert_intermediate_size",
+        0,
+    )
+    shared_expert_parameters = ffn_projection_factor * hidden_size * shared_expert_intermediate_size * layer_counts.moe
+
+    routed_expert_parameters = 0.0
+    latent_projection_parameters = 0.0
+    if _has_moe(model_config) and layer_counts.moe > 0:
+        moe_ffn_hidden_size = _optional_positive_int_attr(
+            model_config,
+            "moe_ffn_hidden_size",
+            model_config.ffn_hidden_size,
+        )
+        moe_latent_size = getattr(model_config, "moe_latent_size", None)
+        if moe_latent_size is None:
+            routed_expert_parameters = (
+                ffn_projection_factor
+                * hidden_size
+                * moe_ffn_hidden_size
+                * model_config.num_moe_experts
+                * layer_counts.moe
+            )
+        else:
+            routed_expert_parameters = (
+                ffn_projection_factor
+                * moe_latent_size
+                * moe_ffn_hidden_size
+                * model_config.num_moe_experts
+                * layer_counts.moe
+            )
+            latent_projection_parameters = 2 * hidden_size * moe_latent_size * layer_counts.moe
+
+    dense_transformer_parameters = (
+        (attention_parameters_per_layer * layer_counts.total)
+        + layernorm_parameters
+        + dense_mlp_parameters
+        + shared_expert_parameters
+        + latent_projection_parameters
+    )
+
+    embedding_size = hidden_size * _get_vocab_size(model_config)
+    embedding_parameters = embedding_size
+    if not model_config.share_embeddings_and_output_weights:
+        embedding_parameters += embedding_size
+
+    return _ParameterCounts(
+        dense_transformer=dense_transformer_parameters,
+        routed_experts=routed_expert_parameters,
+        embeddings=embedding_parameters,
+    )
+
+
+def _get_layer_counts(model_config: object) -> _LayerCounts:
+    num_layers = _positive_int_attr(model_config, "num_layers", 1)
+    if not _has_moe(model_config):
+        return _with_mtp_layers(model_config, dense=num_layers, moe=0)
+
+    moe_layer_freq = getattr(model_config, "moe_layer_freq", 1)
+    if isinstance(moe_layer_freq, int):
+        if moe_layer_freq <= 0:
+            raise ValueError("moe_layer_freq must be positive")
+        moe_layer_pattern = tuple(1 if layer_idx % moe_layer_freq == 0 else 0 for layer_idx in range(num_layers))
+    elif isinstance(moe_layer_freq, (list, tuple)):
+        if len(moe_layer_freq) != num_layers:
+            raise ValueError(f"Invalid moe_layer_freq length: expected {num_layers}, got {len(moe_layer_freq)}")
+        moe_layer_pattern = tuple(1 if layer else 0 for layer in moe_layer_freq)
+    else:
+        raise ValueError(f"Unsupported moe_layer_freq value: {moe_layer_freq}")
+
+    num_moe_layers = sum(moe_layer_pattern)
+    return _with_mtp_layers(model_config, dense=num_layers - num_moe_layers, moe=num_moe_layers)
+
+
+def _with_mtp_layers(model_config: object, *, dense: int, moe: int) -> _LayerCounts:
+    mtp_num_layers = getattr(model_config, "mtp_num_layers", None) or 0
+    if mtp_num_layers > 0:
+        last_layer_is_moe = 1 if moe > 0 and dense == 0 else 0
+        if _has_moe(model_config):
+            moe_layer_freq = getattr(model_config, "moe_layer_freq", 1)
+            if isinstance(moe_layer_freq, int):
+                last_layer_is_moe = 1 if ((model_config.num_layers - 1) % moe_layer_freq == 0) else 0
+            elif isinstance(moe_layer_freq, (list, tuple)):
+                last_layer_is_moe = 1 if moe_layer_freq[-1] else 0
+        moe += last_layer_is_moe * mtp_num_layers
+        dense += (1 - last_layer_is_moe) * mtp_num_layers
+    return _LayerCounts(dense=dense, moe=moe, total=dense + moe)
+
+
+def _embedding_parameters_on_most_loaded_shard(model_config: object) -> float:
+    embedding_size = model_config.hidden_size * _get_vocab_size(model_config)
+    tensor_parallel_size = _positive_int_attr(model_config, "tensor_model_parallel_size", 1)
+    pipeline_parallel_size = _positive_int_attr(model_config, "pipeline_model_parallel_size", 1)
+
+    embedding_parameters = embedding_size / tensor_parallel_size
+    if not model_config.share_embeddings_and_output_weights and pipeline_parallel_size == 1:
+        embedding_parameters += embedding_size / tensor_parallel_size
+    return embedding_parameters
+
+
+def _bytes_per_parameter(config: ConfigContainer, optimizer_shard_size: int) -> float:
+    if not getattr(config.optimizer, "use_distributed_optimizer", False):
+        return 18.0
+    return 6.0 + (12.0 / max(1, optimizer_shard_size))
+
+
+def _expert_optimizer_shard_size(
+    config: ConfigContainer,
+    *,
+    tensor_parallel_size: int,
+    context_parallel_size: int,
+    expert_parallel_size: int,
+    expert_tensor_parallel_size: int,
+) -> int:
+    data_parallel_size = _positive_int_attr(config, "data_parallel_size", 1)
+    shard_size = data_parallel_size * tensor_parallel_size * context_parallel_size
+    shard_size //= max(1, expert_parallel_size * expert_tensor_parallel_size)
+    return max(1, shard_size)
+
+
+def _estimate_assumptions(
+    config: ConfigContainer,
+    *,
+    include_activation: bool,
+    has_routed_experts: bool,
+) -> tuple[str, ...]:
+    model_config = config.model
+    assumptions = [
+        "Reports the most-loaded GPU shard; runtime allocator, kernel workspace, and CUDA graph buffers are excluded.",
+        "Weight/optimizer bytes use the Megatron Bridge Adam estimate: 18 B/parameter without distributed "
+        "optimizer, otherwise 6 B plus 12 B sharded over the relevant optimizer group.",
+        "Embedding parameters are assigned to first/last pipeline stages; untied embeddings double-count only when PP=1.",
+    ]
+    if has_routed_experts:
+        assumptions.append(
+            "Routed MoE expert parameters are sharded by expert_model_parallel_size and "
+            "expert_tensor_parallel_size; routed expert optimizer state uses the expert data-parallel shard size."
+        )
+    if _positive_int_attr(model_config, "context_parallel_size", 1) > 1:
+        assumptions.append("Dense optimizer state and activations are divided across context parallel ranks.")
+    if include_activation:
+        assumptions.append(
+            "Activation estimates assume sequence parallelism and selective activation recomputation; full "
+            "recompute, CPU offload, token imbalance, and dispatcher workspace are not modeled."
+        )
+    return tuple(assumptions)
+
+
+def _print_parameter_summary(estimate: TrainingMemoryEstimate) -> None:
+    dense_component = estimate.model_state_components[0]
+    routed_component = None
+    if len(estimate.model_state_components) > 1:
+        routed_component = estimate.model_state_components[1]
+
+    print(f"Number of dense and embedding parameters in billions: {dense_component.parameter_count / 10**9:.2f}")
+    if routed_component is not None:
+        print(f"Number of routed expert parameters in billions: {routed_component.parameter_count / 10**9:.2f}")
+    print(f"Total number of parameters in billions: {estimate.total_parameters / 10**9:.2f}")
+    print(
+        "Number of dense and embedding parameters in most loaded shard in billions: "
+        f"{dense_component.parameter_count_per_gpu / 10**9:.4f}"
+    )
+    if routed_component is not None:
+        print(
+            "Number of routed expert parameters in most loaded shard in billions: "
+            f"{routed_component.parameter_count_per_gpu / 10**9:.4f}"
+        )
+
+
+def _ffn_projection_factor(model_config: object) -> float:
+    # SwiGLU: h->2*ffn_h and ffn_h->h = 3 projections; otherwise two projections.
+    if getattr(model_config, "gated_linear_unit", False) and getattr(model_config, "activation_func", None) == F.silu:
+        return 3.0
+    return 2.0
+
+
+def _ffn_activation_ratio(model_config: object, layer_counts: _LayerCounts) -> float:
+    if layer_counts.total == 0:
+        return 0.0
+    dense_ffn = layer_counts.dense * model_config.ffn_hidden_size
+    moe_ffn = 0.0
+    if _has_moe(model_config) and layer_counts.moe > 0:
+        routed_to = _optional_positive_int_attr(
+            model_config,
+            "moe_router_topk",
+            _optional_positive_int_attr(model_config, "num_experts_routed_to", 1),
+        )
+        moe_ffn_hidden_size = _optional_positive_int_attr(
+            model_config,
+            "moe_ffn_hidden_size",
+            model_config.ffn_hidden_size,
+        )
+        shared_expert_intermediate_size = _optional_positive_int_attr(
+            model_config,
+            "moe_shared_expert_intermediate_size",
+            0,
+        )
+        moe_ffn = layer_counts.moe * ((moe_ffn_hidden_size * routed_to) + shared_expert_intermediate_size)
+    return (dense_ffn + moe_ffn) / (layer_counts.total * model_config.hidden_size)
+
+
+def _has_moe(model_config: object) -> bool:
+    num_experts = getattr(model_config, "num_moe_experts", None)
+    return num_experts is not None and num_experts > 0
+
+
+def _positive_int_attr(config: object, name: str, default: int) -> int:
+    value = getattr(config, name, default)
+    if value is None:
+        return default
+    value = int(value)
+    if value <= 0:
+        raise ValueError(f"{name} must be positive")
+    return value
+
+
+def _optional_positive_int_attr(config: object, name: str, default: int) -> int:
+    value = getattr(config, name, None)
+    if value is None:
+        return default
+    value = int(value)
+    if value < 0:
+        raise ValueError(f"{name} must be non-negative")
+    return value
 
 
 def _get_vocab_size(model_cfg) -> int:
@@ -265,7 +669,7 @@ def _get_vocab_size(model_cfg) -> int:
     Returns:
         int: The vocabulary size used.
     """
-    if model_cfg.should_pad_vocab:
+    if getattr(model_cfg, "should_pad_vocab", True):
         return calculate_padded_vocab_size(
             model_cfg.vocab_size,
             model_cfg.make_vocab_size_divisible_by,

--- a/src/megatron/bridge/training/utils/theoretical_memory_utils.py
+++ b/src/megatron/bridge/training/utils/theoretical_memory_utils.py
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Formula-based theoretical memory estimates for model training."""
+"""Formula-based theoretical memory estimates for model training.
+
+The estimator logic is adapted for Megatron Bridge from the public ISEEKYAN
+Megatron memory estimator implementation:
+https://github.com/ISEEKYAN/mbridge/tree/main/memory_estimator
+"""
 
 import math
 from dataclasses import dataclass
@@ -125,6 +130,9 @@ def estimate_training_memory(
     issue #1673. The returned structure separates dense/embedding model state,
     routed expert model state, and activation memory so callers can display or
     post-process the breakdown.
+
+    The estimator logic is adapted from the public ISEEKYAN Megatron memory
+    estimator implementation.
 
     Args:
         config: Bridge training configuration container.

--- a/tests/unit_tests/training/utils/test_theoretical_memory_utils.py
+++ b/tests/unit_tests/training/utils/test_theoretical_memory_utils.py
@@ -12,13 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from types import SimpleNamespace
+import sys
+from types import ModuleType, SimpleNamespace
 
 import pytest
 
 from megatron.bridge.training.utils.theoretical_memory_utils import (
     estimate_training_memory,
     format_training_memory_estimate,
+    report_theoretical_memory,
 )
 
 
@@ -63,6 +65,13 @@ def _make_config(**model_overrides):
         optimizer=SimpleNamespace(use_distributed_optimizer=True),
         data_parallel_size=4,
     )
+
+
+def _mock_megatron_mimo_provider(monkeypatch):
+    module_name = "megatron.bridge.models.megatron_mimo.megatron_mimo_provider"
+    module = ModuleType(module_name)
+    module.MegatronMIMOProvider = type("MegatronMIMOProvider", (), {})
+    monkeypatch.setitem(sys.modules, module_name, module)
 
 
 @pytest.mark.unit
@@ -167,3 +176,16 @@ def test_format_training_memory_estimate_rejects_unknown_unit():
 
     with pytest.raises(ValueError, match="Unsupported memory unit"):
         format_training_memory_estimate(estimate, unit="bytes")
+
+
+@pytest.mark.unit
+def test_report_theoretical_memory_uses_structured_estimate(monkeypatch, capsys):
+    _mock_megatron_mimo_provider(monkeypatch)
+    config = _make_config()
+
+    report_theoretical_memory(config, num_microbatches=4)
+
+    captured = capsys.readouterr()
+    assert "Theoretical memory footprints: weight and optimizer=0.03 MB" in captured.out
+    assert "activation=0.02 MB" in captured.out
+    assert "total=0.05 MB" in captured.out

--- a/tests/unit_tests/training/utils/test_theoretical_memory_utils.py
+++ b/tests/unit_tests/training/utils/test_theoretical_memory_utils.py
@@ -1,0 +1,169 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import pytest
+
+from megatron.bridge.training.utils.theoretical_memory_utils import (
+    estimate_training_memory,
+    format_training_memory_estimate,
+)
+
+
+def _make_config(**model_overrides):
+    model_defaults = {
+        "num_layers": 4,
+        "hidden_size": 16,
+        "seq_length": 8,
+        "ffn_hidden_size": 64,
+        "num_attention_heads": 4,
+        "num_query_groups": None,
+        "kv_channels": 4,
+        "vocab_size": 32,
+        "make_vocab_size_divisible_by": 1,
+        "should_pad_vocab": False,
+        "share_embeddings_and_output_weights": True,
+        "tensor_model_parallel_size": 2,
+        "pipeline_model_parallel_size": 2,
+        "virtual_pipeline_model_parallel_size": None,
+        "context_parallel_size": 1,
+        "expert_model_parallel_size": 1,
+        "expert_tensor_parallel_size": 1,
+        "num_moe_experts": None,
+        "moe_layer_freq": 1,
+        "moe_router_topk": 1,
+        "moe_ffn_hidden_size": None,
+        "moe_shared_expert_intermediate_size": None,
+        "moe_latent_size": None,
+        "mtp_num_layers": None,
+        "gated_linear_unit": False,
+        "activation_func": None,
+        "sequence_parallel": True,
+        "recompute_granularity": "selective",
+    }
+    for key, value in model_overrides.items():
+        if key not in model_defaults:
+            raise ValueError(f"Config has no field '{key}'")
+        model_defaults[key] = value
+    return SimpleNamespace(
+        model=SimpleNamespace(**model_defaults),
+        train=SimpleNamespace(micro_batch_size=2),
+        optimizer=SimpleNamespace(use_distributed_optimizer=True),
+        data_parallel_size=4,
+    )
+
+
+@pytest.mark.unit
+def test_dense_model_state_estimate_matches_legacy_arithmetic():
+    config = _make_config()
+
+    estimate = estimate_training_memory(config, include_activation=False)
+
+    assert len(estimate.model_state_components) == 1
+    dense_component = estimate.model_state_components[0]
+    assert dense_component.parameter_count == 13088
+    assert dense_component.parameter_count_per_gpu == 3400
+    assert dense_component.bytes_per_parameter == 9
+    assert estimate.weight_and_optimizer_bytes == 30600
+    assert estimate.total_parameters == 13088
+
+
+@pytest.mark.unit
+def test_moe_estimate_accounts_for_expert_parallel_sharding():
+    config = _make_config(
+        pipeline_model_parallel_size=1,
+        context_parallel_size=2,
+        num_moe_experts=8,
+        moe_layer_freq=2,
+        moe_ffn_hidden_size=32,
+        expert_model_parallel_size=4,
+    )
+    config.data_parallel_size = 8
+
+    estimate = estimate_training_memory(config, include_activation=False)
+
+    assert len(estimate.model_state_components) == 2
+    dense_component, routed_component = estimate.model_state_components
+    assert dense_component.parameter_count == 8992
+    assert dense_component.parameter_count_per_gpu == 4496
+    assert dense_component.bytes_per_parameter == 6.75
+    assert dense_component.memory_bytes == 30348
+    assert routed_component.parameter_count == 16384
+    assert routed_component.parameter_count_per_gpu == 4096
+    assert routed_component.bytes_per_parameter == 7.5
+    assert routed_component.memory_bytes == 30720
+    assert estimate.weight_and_optimizer_bytes == 61068
+
+
+@pytest.mark.unit
+def test_activation_estimate_is_partitioned_by_tensor_and_context_parallelism():
+    config = _make_config(pipeline_model_parallel_size=1, context_parallel_size=2)
+
+    estimate = estimate_training_memory(config, num_microbatches=1)
+
+    assert estimate.activation is not None
+    assert estimate.activation.memory_bytes == 9568
+    assert estimate.total_memory_bytes == estimate.weight_and_optimizer_bytes + 9568
+
+
+@pytest.mark.unit
+def test_moe_list_pattern_shared_expert_latent_and_mtp_counts():
+    config = _make_config(
+        pipeline_model_parallel_size=1,
+        num_moe_experts=4,
+        moe_layer_freq=[0, 1, 0, 1],
+        moe_ffn_hidden_size=32,
+        moe_shared_expert_intermediate_size=8,
+        moe_latent_size=4,
+        mtp_num_layers=1,
+    )
+
+    estimate = estimate_training_memory(config, include_activation=False)
+
+    dense_component, routed_component = estimate.model_state_components
+    assert dense_component.parameter_count == 11232
+    assert dense_component.parameter_count_per_gpu == 5616
+    assert routed_component.parameter_count == 3072
+    assert routed_component.parameter_count_per_gpu == 3072
+    assert estimate.total_parameters == 14304
+
+
+@pytest.mark.unit
+def test_activation_estimate_applies_virtual_pipeline_penalty():
+    config = _make_config(virtual_pipeline_model_parallel_size=2)
+
+    estimate = estimate_training_memory(config, num_microbatches=4)
+
+    assert estimate.activation is not None
+    assert estimate.activation.memory_bytes == 22240
+
+
+@pytest.mark.unit
+def test_format_training_memory_estimate_reports_components_and_units():
+    config = _make_config()
+    estimate = estimate_training_memory(config, include_activation=False)
+
+    formatted = format_training_memory_estimate(estimate, unit="GB")
+
+    assert "dense parameters and optimizer=0.00 GB" in formatted
+    assert "total=0.00 GB" in formatted
+
+
+@pytest.mark.unit
+def test_format_training_memory_estimate_rejects_unknown_unit():
+    estimate = estimate_training_memory(_make_config(), include_activation=False)
+
+    with pytest.raises(ValueError, match="Unsupported memory unit"):
+        format_training_memory_estimate(estimate, unit="bytes")


### PR DESCRIPTION
## Summary
- Add a structured `estimate_training_memory` API and formatter around the existing theoretical memory utility.
- Account for MoE layer patterns, routed expert EP/ETP sharding, context parallel partitioning, and distributed optimizer shard sizes.
- Preserve the existing training-time aggregate memory report while adding docs, focused arithmetic tests, and memory-tuning skill guidance.

Closes #1673

## Validation
- `git diff --check origin/main..HEAD`
- `python3 -m py_compile src/megatron/bridge/training/utils/theoretical_memory_utils.py tests/unit_tests/training/utils/test_theoretical_memory_utils.py`
- `/home/yuya/.local/bin/ruff format src/megatron/bridge/training/utils/theoretical_memory_utils.py tests/unit_tests/training/utils/test_theoretical_memory_utils.py`
- `/home/yuya/.local/bin/ruff check src/megatron/bridge/training/utils/theoretical_memory_utils.py tests/unit_tests/training/utils/test_theoretical_memory_utils.py`
- `/home/yuya/.local/bin/pre-commit run --all-files`

Not run:
- `uv run pre-commit run --all-files`: local `uv run` cannot install `nvidia-resiliency-ext==0.6.0` because this workstation is `manylinux_2_31_x86_64` and the locked wheel is only available for `manylinux_2_39_{x86_64,aarch64}`.
- Targeted pytest: not run locally per task instructions; `cw`, `sbatch`, and `srun` are not available in this environment.
