### PR TITLE
[performance] fix: filter Slurm-only args from launched scripts

### DIFF
--- a/scripts/performance/setup_experiment.py
+++ b/scripts/performance/setup_experiment.py
@@ -58,9 +58,34 @@ SCRIPT_DIR = Path(__file__).parent.resolve()
 ENTRYPOINT_PEFORMANCE = "run_script.py"
 ENTRYPOINT_RECIPE = "run_recipe.py"
 
+# CLI flags consumed by setup_experiment.py that should NOT be forwarded to run_script.py.
+EXCLUDED_SCRIPT_ARGS = [
+    "--additional_slurm_params",
+]
+
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)  # pin level so nemo_run's WARNING root doesn't suppress INFO
+
+
+def filter_script_args(argv: List[str], excluded: List[str] = EXCLUDED_SCRIPT_ARGS) -> List[str]:
+    """Return a copy of argv with excluded flags and their values removed.
+
+    Handles ``--flag=value`` (skips one token) and ``--flag value`` (skips flag + one value token).
+    """
+    filtered = []
+    i = 0
+    while i < len(argv):
+        token = argv[i]
+        opt_name = token.split("=", 1)[0]
+
+        if opt_name in excluded:
+            # --flag=value: one combined token; --flag value: two tokens
+            i += 1 if "=" in token else 2
+        else:
+            filtered.append(token)
+            i += 1
+    return filtered
 
 
 def check_training_finished(log_file_paths: List[str], is_long_convergence_run: bool = True) -> bool:
@@ -488,7 +513,7 @@ def main(
         path=str(run_script_path),
         entrypoint="python",
         env={"PYTHONPATH": f"{SCRIPT_DIR}:$PYTHONPATH"},
-        args=list(sys.argv[1:]),
+        args=filter_script_args(sys.argv[1:]),
     )
 
     logger.info("Will launch the following command with Nemo-Run: %s", " ".join(nemorun_script.to_command()))


### PR DESCRIPTION
# What does this PR do ?

Filters setup-only Slurm arguments out of the Nemo-Run script command so `--additional_slurm_params` is only used when constructing the Slurm submission and is not forwarded to the final training script.

`--additional_slurm_params` may contain semicolons, as documented in the argument parser: https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/15d8eadcde212712d6bc9e271da5fef7d03732d7/scripts/performance/argument_parser.py#L479-L486

Without filtering, the generated command can include something like:

`Megatron-Bridge/scripts/performance/run_script.py ... --additional_slurm_params ...;...;... extra_hydra_config`
The semicolons then split what should be a single training command into multiple shell commands, which can produce unintended behavior or break the generated submit script.

# Changelog

- Add `EXCLUDED_SCRIPT_ARGS` for setup arguments that should not be forwarded to `run_script.py` or `run_recipe.py`.
- Add `filter_script_args()` to remove excluded flags in both `--flag value` and `--flag=value` forms.
- Apply the filter when constructing `run.Script(args=...)`, preventing semicolon-containing `--additional_slurm_params` values from affecting the generated submit script.
- Preserve current training completion detection behavior while resolving the cherry-pick conflict.


# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
