### PR TITLE
[feature] Add dense CP support for Qwen3-Omni

### DIFF
--- a/src/megatron/bridge/models/qwen_omni/modeling_qwen3_omni/thinker_model.py
+++ b/src/megatron/bridge/models/qwen_omni/modeling_qwen3_omni/thinker_model.py
@@ -399,6 +399,7 @@ class Qwen3OmniThinkerModel(MegatronModule):
             if not has_multimodal_inputs:
                 position_ids = _build_text_only_mrope_position_ids(input_ids)
             else:
+                rope_attention_mask = None if cp_size > 1 and packed_seq_params is None else attention_mask
                 position_ids, _ = get_rope_index(
                     self.config.spatial_merge_size,
                     self.image_token_id,
@@ -411,7 +412,7 @@ class Qwen3OmniThinkerModel(MegatronModule):
                     image_grid_thw=image_grid_thw,
                     video_grid_thw=video_grid_thw,
                     second_per_grids=video_second_per_grid,
-                    attention_mask=attention_mask,
+                    attention_mask=rope_attention_mask,
                     audio_seqlens=audio_feature_lengths,
                 )
 

--- a/src/megatron/bridge/models/qwen_omni/qwen3_omni_step.py
+++ b/src/megatron/bridge/models/qwen_omni/qwen3_omni_step.py
@@ -16,13 +16,14 @@
 
 from __future__ import annotations
 
+import math
 from functools import partial
 from typing import TYPE_CHECKING, Any, Iterable
 
 import torch
 from megatron.core.models.gpt import GPTModel
 from megatron.core.pipeline_parallel.utils import is_pp_first_stage, is_pp_last_stage
-from megatron.core.utils import get_model_config
+from megatron.core.utils import get_batch_on_this_cp_rank, get_model_config
 
 from megatron.bridge.training.losses import (
     create_masked_next_token_loss_function as _create_loss_function,
@@ -156,6 +157,59 @@ def get_batch(data_iterator: Iterable, cfg: "ConfigContainer", use_mtp: bool = F
     )
 
 
+def pad_batch_sequences_for_context_parallel(
+    tokens: torch.Tensor,
+    labels: torch.Tensor | None,
+    loss_mask: torch.Tensor | None,
+    attention_mask: torch.Tensor | None,
+    position_ids: torch.Tensor | None,
+    pg_collection,
+    *,
+    force_to_seq_length: bool = False,
+    seq_length: int | None = None,
+) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor | None, torch.Tensor | None, torch.Tensor | None]:
+    """Pad dense sequence tensors before Megatron's CP zigzag split.
+
+    Dense CP partitions each sequence into ``2 * cp_size`` chunks.  Padding here
+    keeps the step-level tensors compatible with Megatron's CP slicing while the
+    full ``input_ids`` tensor remains available for model-internal mRoPE.
+    """
+
+    tp_size = pg_collection.tp.size()
+    cp_size = pg_collection.cp.size()
+    divisible_by = tp_size * cp_size * 2 if cp_size > 1 else tp_size
+    target_len = math.ceil(tokens.size(1) / divisible_by) * divisible_by
+    if force_to_seq_length:
+        if seq_length is None:
+            raise ValueError("seq_length must be set when force_to_seq_length=True")
+        if seq_length % divisible_by != 0:
+            raise ValueError(
+                f"seq_length={seq_length} must be divisible by TP*CP*2={divisible_by} for dense context parallelism"
+            )
+        target_len = seq_length
+
+    tokens = pad_or_truncate_2d_to_len(tokens, target_len, target_len, pad_value=0)
+    labels = pad_or_truncate_2d_to_len(labels, target_len, target_len, pad_value=-100)
+    loss_mask = pad_or_truncate_2d_to_len(loss_mask, target_len, target_len, pad_value=0)
+    attention_mask = pad_or_truncate_attn_to_len(attention_mask, target_len, target_len)
+    position_ids = pad_or_truncate_pos_to_len(position_ids, target_len, target_len)
+    return tokens, labels, loss_mask, attention_mask, position_ids
+
+
+def _get_dense_batch_on_this_cp_rank(batch: dict[str, Any], cp_group) -> dict[str, Any]:
+    """Slice dense CP tensors, including 2D attention masks from VLM datasets."""
+
+    attention_mask = batch.get("attention_mask")
+    if attention_mask is not None and attention_mask.dim() == 2:
+        batch = dict(batch)
+        batch["_attention_mask_2d"] = batch.pop("attention_mask")
+        batch = get_batch_on_this_cp_rank(batch, cp_group=cp_group)
+        batch["attention_mask"] = batch.pop("_attention_mask_2d")
+        return batch
+
+    return get_batch_on_this_cp_rank(batch, cp_group=cp_group)
+
+
 def forward_step(
     state: "GlobalState",
     data_iterator: Iterable,
@@ -178,8 +232,21 @@ def forward_step(
         )
     timers("batch-generator").stop()
 
+    pack_sequences_in_batch = getattr(state.cfg.dataset, "pack_sequences_in_batch", False)
+    if pack_sequences_in_batch:
+        raise NotImplementedError("Qwen3-Omni packed sequence support is not implemented yet.")
+
     if pg_collection.cp.size() > 1:
-        raise NotImplementedError("Qwen3-Omni training supports SP/EP, but CP is not supported yet.")
+        tokens, labels, loss_mask, attention_mask, position_ids = pad_batch_sequences_for_context_parallel(
+            tokens,
+            labels,
+            loss_mask,
+            attention_mask,
+            position_ids,
+            pg_collection,
+            force_to_seq_length=pg_collection.pp.size() > 1 or pg_collection.ep.size() > 1,
+            seq_length=getattr(config, "seq_length", getattr(state.cfg.model, "seq_length", None)),
+        )
 
     forward_args = {
         "input_ids": tokens,
@@ -188,10 +255,17 @@ def forward_step(
         "labels": labels,
         "loss_mask": loss_mask,
     }
+
+    if pg_collection.cp.size() > 1:
+        original_tokens = tokens.clone()
+        forward_args = _get_dense_batch_on_this_cp_rank(forward_args, cp_group=pg_collection.cp)
+        forward_args["input_ids"] = original_tokens
+
     forward_args.update(multimodal_inputs)
 
     # The Omni thinker computes multimodal mRoPE internally from full input_ids.
     forward_args["position_ids"] = None
+    loss_mask = forward_args["loss_mask"]
 
     check_for_nan_in_loss = state.cfg.rerun_state_machine.check_for_nan_in_loss
     check_for_spiky_loss = state.cfg.rerun_state_machine.check_for_spiky_loss
@@ -201,7 +275,11 @@ def forward_step(
                 "overlap_moe_expert_parallel_comm must be enabled to return the schedule plan"
             )
             schedule_plan = model.build_schedule_plan(
-                tokens, position_ids, attention_mask, labels=labels, loss_mask=loss_mask
+                forward_args["input_ids"],
+                forward_args["position_ids"],
+                forward_args["attention_mask"],
+                labels=forward_args["labels"],
+                loss_mask=loss_mask,
             )
             loss_function = _create_loss_function(loss_mask, check_for_nan_in_loss, check_for_spiky_loss)
             return schedule_plan, loss_function

--- a/tests/unit_tests/models/qwen_omni/modeling_qwen3_omni/test_omni_model.py
+++ b/tests/unit_tests/models/qwen_omni/modeling_qwen3_omni/test_omni_model.py
@@ -383,6 +383,75 @@ class TestQwen3OmniModel:
         assert calls["scatter"] == 1
         assert calls["split"] == 1
 
+    def test_cp_mrope_uses_full_input_without_local_attention_mask(self, thinker_config, monkeypatch):
+        model = self._build_model(thinker_config)
+
+        class _MockProcessGroup:
+            def __init__(self, size=1, rank=0):
+                self._size = size
+                self._rank = rank
+
+            def size(self):
+                return self._size
+
+            def rank(self):
+                return self._rank
+
+        model.thinker.pg_collection = SimpleNamespace(
+            cp=_MockProcessGroup(size=2),
+            tp=_MockProcessGroup(size=1),
+        )
+
+        class _FakeLanguageModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.forward_kwargs = None
+
+            def embedding(self, input_ids, position_ids):  # noqa: ARG002
+                return torch.zeros(input_ids.size(1), input_ids.size(0), HIDDEN_SIZE, device=input_ids.device)
+
+            def forward(self, **kwargs):
+                self.forward_kwargs = kwargs
+                return torch.tensor(0.0, device=kwargs["decoder_input"].device)
+
+        fake_language_model = _FakeLanguageModel()
+        model.thinker.language_model = fake_language_model
+
+        rope_calls = {}
+
+        def _fake_get_rope_index(*args, **kwargs):  # noqa: ARG001
+            input_ids = args[7]
+            rope_calls["attention_mask"] = kwargs.get("attention_mask")
+            position_ids = torch.zeros(
+                3, input_ids.size(0), input_ids.size(1), dtype=torch.long, device=input_ids.device
+            )
+            return position_ids, torch.zeros(input_ids.size(0), 1, dtype=torch.long, device=input_ids.device)
+
+        monkeypatch.setattr(
+            "megatron.bridge.models.qwen_omni.modeling_qwen3_omni.thinker_model.get_rope_index",
+            _fake_get_rope_index,
+        )
+        monkeypatch.setattr(
+            "megatron.bridge.models.qwen_omni.modeling_qwen3_omni.thinker_model.split_data_cp_rank",
+            lambda x, *args, **kwargs: x,
+        )
+        monkeypatch.setattr(
+            "megatron.bridge.models.qwen_omni.modeling_qwen3_omni.thinker_model.split_deepstack_embs",
+            lambda visual_pos_masks, deepstack_visual_embeds, **kwargs: (visual_pos_masks, deepstack_visual_embeds),
+        )
+
+        input_ids = torch.tensor([[AUDIO_START_TOKEN_ID, AUDIO_TOKEN_ID, 12, 13]])
+        attention_mask = torch.tensor([[1, 1]])
+        output = model.thinker(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            audio_feature_lengths=torch.tensor([1]),
+        )
+
+        assert output is not None
+        assert rope_calls["attention_mask"] is None
+        assert fake_language_model.forward_kwargs["attention_mask"] is attention_mask
+
     def test_audio_forward(self, thinker_config):
         model = self._build_model(thinker_config)
         if torch.cuda.is_available():

--- a/tests/unit_tests/models/qwen_omni/test_qwen3_omni_step.py
+++ b/tests/unit_tests/models/qwen_omni/test_qwen3_omni_step.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 import torch
 
 from megatron.bridge.models.qwen_omni.qwen3_omni_step import (
@@ -19,6 +20,7 @@ from megatron.bridge.models.qwen_omni.qwen3_omni_step import (
     forward_step,
     get_batch,
     get_batch_from_iterator,
+    pad_batch_sequences_for_context_parallel,
 )
 from megatron.bridge.training.utils.visual_inputs import Qwen2_5_VLVisualInputs
 
@@ -215,25 +217,40 @@ def test_forward_step_passes_omni_multimodal_args(monkeypatch):
     assert "audio_feature_lengths" in model.kwargs
 
 
-def test_forward_step_rejects_context_parallel(monkeypatch):
+@pytest.mark.parametrize(
+    ("cp_rank", "local_labels", "local_loss_mask"),
+    [
+        (0, torch.tensor([[10, 11, 12, 13]]), torch.tensor([[1.0, 1.0, 1.0, 0.0]])),
+        (1, torch.tensor([[20, 21, 22, 23]]), torch.tensor([[0.0, 1.0, 1.0, 1.0]])),
+    ],
+)
+def test_forward_step_supports_dense_context_parallel(monkeypatch, cp_rank, local_labels, local_loss_mask):
     class _MockProcessGroup:
+        def __init__(self, size=1, rank=0):
+            self._size = size
+            self._rank = rank
+
         def rank(self):
-            return 0
+            return self._rank
 
         def size(self):
-            return 2
+            return self._size
 
     class _MockPGCollection:
         def __init__(self):
             self.pp = _MockProcessGroup()
-            self.cp = _MockProcessGroup()
+            self.cp = _MockProcessGroup(size=2, rank=cp_rank)
+            self.tp = _MockProcessGroup()
+            self.ep = _MockProcessGroup()
 
     class _Model:
         def __init__(self):
             self.config = type("Cfg", (), {"mtp_num_layers": 0, "overlap_moe_expert_parallel_comm": True})()
+            self.kwargs = None
 
-        def __call__(self, **kwargs):  # noqa: ARG002
-            raise AssertionError("model forward should not run when CP is enabled")
+        def __call__(self, **kwargs):
+            self.kwargs = kwargs
+            return torch.tensor(0.0)
 
     class _Timer:
         def __call__(self, *args, **kwargs):  # noqa: ARG002
@@ -268,9 +285,11 @@ def test_forward_step_rejects_context_parallel(monkeypatch):
     state.timers = _Timer()
     state.straggler_timer = _Strag()
 
-    tokens = torch.tensor([[1, 2, 3, 4, 5, 6, 7, 8]])
-    labels = torch.tensor([[2, 3, 4, 5, 6, 7, 8, -100]])
-    loss_mask = torch.ones(1, 8)
+    tokens = torch.tensor([[1, 2, 3, 4, 5, 6, 7]])
+    labels = torch.tensor([[2, 3, 4, 5, 6, 7, -100]])
+    pixel_values = torch.randn(2, 3, 4, 4)
+    input_features = torch.randn(1, 80, 6)
+    slice_calls = []
 
     monkeypatch.setattr(
         "megatron.bridge.models.qwen_omni.qwen3_omni_step.get_pg_collection",
@@ -285,20 +304,369 @@ def test_forward_step_rejects_context_parallel(monkeypatch):
         lambda data_iterator, cfg, use_mtp, pg_collection: (
             tokens,
             labels,
-            loss_mask,
-            torch.ones(1, 8, dtype=torch.bool),
-            torch.arange(8).unsqueeze(0),
+            torch.ones(1, 7),
+            torch.ones(1, 7, dtype=torch.bool),
+            torch.arange(7).unsqueeze(0),
+            {
+                "pixel_values": pixel_values,
+                "image_grid_thw": torch.tensor([[1, 2, 2], [1, 2, 2]]),
+                "input_features": input_features,
+                "feature_attention_mask": torch.tensor([[1, 1, 1, 1, 0, 0]]),
+            },
+        ),
+    )
+
+    def _mock_get_batch_on_this_cp_rank(batch, cp_group):
+        slice_calls.append((batch, cp_group))
+        assert cp_group.rank() == cp_rank
+        assert "attention_mask" not in batch
+        assert "_attention_mask_2d" in batch
+        return {
+            "input_ids": batch["input_ids"][:, :4],
+            "position_ids": batch["position_ids"][:, :4],
+            "_attention_mask_2d": batch["_attention_mask_2d"][:, :4],
+            "labels": local_labels,
+            "loss_mask": local_loss_mask,
+        }
+
+    monkeypatch.setattr(
+        "megatron.bridge.models.qwen_omni.qwen3_omni_step.get_batch_on_this_cp_rank",
+        _mock_get_batch_on_this_cp_rank,
+    )
+
+    model = _Model()
+    output, loss_fn = forward_step(state, iter([{}]), model)
+
+    assert isinstance(output, torch.Tensor)
+    assert callable(loss_fn)
+    assert model.kwargs is not None
+    assert model.kwargs["input_ids"].shape == (1, 8)
+    assert model.kwargs["input_ids"][0, :7].tolist() == tokens[0].tolist()
+    assert torch.equal(model.kwargs["labels"], local_labels)
+    assert torch.equal(model.kwargs["loss_mask"], local_loss_mask)
+    assert model.kwargs["attention_mask"].shape == (1, 4)
+    assert model.kwargs["position_ids"] is None
+    assert model.kwargs["pixel_values"] is pixel_values
+    assert model.kwargs["input_features"] is input_features
+    assert len(slice_calls) == 1
+
+
+def test_forward_step_schedule_plan_uses_dense_context_parallel_batch(monkeypatch):
+    class _MockProcessGroup:
+        def __init__(self, size=1, rank=0):
+            self._size = size
+            self._rank = rank
+
+        def rank(self):
+            return self._rank
+
+        def size(self):
+            return self._size
+
+    class _MockPGCollection:
+        def __init__(self):
+            self.pp = _MockProcessGroup()
+            self.cp = _MockProcessGroup(size=2)
+            self.tp = _MockProcessGroup()
+            self.ep = _MockProcessGroup()
+
+    class _Model:
+        def __init__(self):
+            self.config = type("Cfg", (), {"mtp_num_layers": 0, "overlap_moe_expert_parallel_comm": True})()
+            self.schedule_args = None
+
+        def __call__(self, **kwargs):  # noqa: ARG002
+            raise AssertionError("model forward should not run when returning a schedule plan")
+
+        def build_schedule_plan(self, input_ids, position_ids, attention_mask, labels=None, loss_mask=None):
+            self.schedule_args = {
+                "input_ids": input_ids,
+                "position_ids": position_ids,
+                "attention_mask": attention_mask,
+                "labels": labels,
+                "loss_mask": loss_mask,
+            }
+            return torch.tensor(1.0)
+
+    class _Timer:
+        def __call__(self, *args, **kwargs):  # noqa: ARG002
+            return self
+
+        def start(self):
+            return self
+
+        def stop(self):
+            return self
+
+    class _Strag:
+        def __call__(self, *args, **kwargs):  # noqa: ARG002
+            return self
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):  # noqa: ARG002
+            return False
+
+    state = type("State", (), {})()
+    state.cfg = type(
+        "Cfg",
+        (),
+        {
+            "dataset": type("D", (), {"skip_getting_attention_mask_from_dataset": False})(),
+            "model": type("M", (), {"pipeline_model_parallel_size": 1, "seq_length": 8})(),
+            "rerun_state_machine": type("R", (), {"check_for_nan_in_loss": False, "check_for_spiky_loss": False})(),
+        },
+    )()
+    state.timers = _Timer()
+    state.straggler_timer = _Strag()
+
+    tokens = torch.tensor([[1, 2, 3, 4, 5, 6, 7]])
+    local_labels = torch.tensor([[10, 11, 12, 13]])
+    local_loss_mask = torch.tensor([[1.0, 1.0, 0.0, 0.0]])
+
+    monkeypatch.setattr(
+        "megatron.bridge.models.qwen_omni.qwen3_omni_step.get_pg_collection",
+        lambda model: _MockPGCollection(),
+    )
+    monkeypatch.setattr(
+        "megatron.bridge.models.qwen_omni.qwen3_omni_step.get_model_config",
+        lambda model: model.config,
+    )
+    monkeypatch.setattr(
+        "megatron.bridge.models.qwen_omni.qwen3_omni_step.get_batch",
+        lambda data_iterator, cfg, use_mtp, pg_collection: (
+            tokens,
+            torch.tensor([[2, 3, 4, 5, 6, 7, -100]]),
+            torch.ones(1, 7),
+            torch.ones(1, 7, dtype=torch.bool),
+            torch.arange(7).unsqueeze(0),
             {},
         ),
     )
 
+    def _mock_get_batch_on_this_cp_rank(batch, cp_group):  # noqa: ARG001
+        return {
+            "input_ids": batch["input_ids"][:, :4],
+            "position_ids": batch["position_ids"][:, :4],
+            "_attention_mask_2d": batch["_attention_mask_2d"][:, :4],
+            "labels": local_labels,
+            "loss_mask": local_loss_mask,
+        }
+
+    monkeypatch.setattr(
+        "megatron.bridge.models.qwen_omni.qwen3_omni_step.get_batch_on_this_cp_rank",
+        _mock_get_batch_on_this_cp_rank,
+    )
+
     model = _Model()
-    try:
-        forward_step(state, iter([{}]), model)
-    except NotImplementedError as exc:
-        assert "CP is not supported yet" in str(exc)
-    else:
-        raise AssertionError("expected NotImplementedError for Qwen3-Omni CP")
+    schedule_plan, loss_fn = forward_step(state, iter([{}]), model, return_schedule_plan=True)
+
+    assert torch.equal(schedule_plan, torch.tensor(1.0))
+    assert callable(loss_fn)
+    assert model.schedule_args is not None
+    assert model.schedule_args["input_ids"].shape == (1, 8)
+    assert model.schedule_args["input_ids"][0, :7].tolist() == tokens[0].tolist()
+    assert model.schedule_args["position_ids"] is None
+    assert model.schedule_args["attention_mask"].shape == (1, 4)
+    assert torch.equal(model.schedule_args["labels"], local_labels)
+    assert torch.equal(model.schedule_args["loss_mask"], local_loss_mask)
+
+
+def test_pad_batch_sequences_for_context_parallel_pads_to_zigzag_multiple():
+    class _MockProcessGroup:
+        def __init__(self, size):
+            self._size = size
+
+        def size(self):
+            return self._size
+
+    pg_collection = type(
+        "PG",
+        (),
+        {
+            "tp": _MockProcessGroup(1),
+            "cp": _MockProcessGroup(2),
+        },
+    )()
+
+    tokens = torch.tensor([[1, 2, 3, 4, 5, 6, 7]])
+    labels = torch.tensor([[2, 3, 4, 5, 6, 7, -100]])
+    loss_mask = torch.ones(1, 7)
+    attention_mask = torch.ones(1, 7, dtype=torch.bool)
+    position_ids = torch.arange(7).unsqueeze(0)
+
+    tokens, labels, loss_mask, attention_mask, position_ids = pad_batch_sequences_for_context_parallel(
+        tokens,
+        labels,
+        loss_mask,
+        attention_mask,
+        position_ids,
+        pg_collection,
+    )
+
+    assert tokens.shape == (1, 8)
+    assert labels.shape == (1, 8)
+    assert loss_mask.shape == (1, 8)
+    assert attention_mask.shape == (1, 8)
+    assert position_ids.shape == (1, 8)
+    assert tokens[0, -1].item() == 0
+    assert labels[0, -1].item() == -100
+    assert loss_mask[0, -1].item() == 0
+
+
+def test_pad_batch_sequences_for_context_parallel_can_force_seq_length():
+    class _MockProcessGroup:
+        def __init__(self, size):
+            self._size = size
+
+        def size(self):
+            return self._size
+
+    pg_collection = type(
+        "PG",
+        (),
+        {
+            "tp": _MockProcessGroup(1),
+            "cp": _MockProcessGroup(2),
+        },
+    )()
+
+    tokens = torch.tensor([[1, 2, 3, 4, 5, 6, 7]])
+    labels = torch.tensor([[2, 3, 4, 5, 6, 7, -100]])
+    loss_mask = torch.ones(1, 7)
+    attention_mask = torch.ones(1, 1, 7, 7, dtype=torch.bool)
+    position_ids = torch.arange(7).unsqueeze(0)
+
+    tokens, labels, loss_mask, attention_mask, position_ids = pad_batch_sequences_for_context_parallel(
+        tokens,
+        labels,
+        loss_mask,
+        attention_mask,
+        position_ids,
+        pg_collection,
+        force_to_seq_length=True,
+        seq_length=12,
+    )
+
+    assert tokens.shape == (1, 12)
+    assert labels.shape == (1, 12)
+    assert loss_mask.shape == (1, 12)
+    assert attention_mask.shape == (1, 1, 12, 12)
+    assert position_ids.shape == (1, 12)
+
+
+def test_pad_batch_sequences_for_context_parallel_rejects_bad_forced_seq_length():
+    class _MockProcessGroup:
+        def __init__(self, size):
+            self._size = size
+
+        def size(self):
+            return self._size
+
+    pg_collection = type(
+        "PG",
+        (),
+        {
+            "tp": _MockProcessGroup(1),
+            "cp": _MockProcessGroup(2),
+        },
+    )()
+
+    tokens = torch.tensor([[1, 2, 3, 4]])
+
+    with pytest.raises(ValueError, match="must be divisible"):
+        pad_batch_sequences_for_context_parallel(
+            tokens,
+            labels=None,
+            loss_mask=None,
+            attention_mask=None,
+            position_ids=None,
+            pg_collection=pg_collection,
+            force_to_seq_length=True,
+            seq_length=10,
+        )
+
+
+def test_forward_step_rejects_packed_sequence_before_model_forward(monkeypatch):
+    class _MockProcessGroup:
+        def rank(self):
+            return 0
+
+        def size(self):
+            return 1
+
+    class _MockPGCollection:
+        def __init__(self):
+            self.pp = _MockProcessGroup()
+            self.cp = _MockProcessGroup()
+
+    class _Model:
+        def __init__(self):
+            self.config = type("Cfg", (), {"mtp_num_layers": 0, "overlap_moe_expert_parallel_comm": True})()
+
+        def __call__(self, **kwargs):  # noqa: ARG002
+            raise AssertionError("model forward should not run when packed sequence is enabled")
+
+    class _Timer:
+        def __call__(self, *args, **kwargs):  # noqa: ARG002
+            return self
+
+        def start(self):
+            return self
+
+        def stop(self):
+            return self
+
+    class _Strag:
+        def __call__(self, *args, **kwargs):  # noqa: ARG002
+            return self
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):  # noqa: ARG002
+            return False
+
+    state = type("State", (), {})()
+    state.cfg = type(
+        "Cfg",
+        (),
+        {
+            "dataset": type(
+                "D",
+                (),
+                {"skip_getting_attention_mask_from_dataset": False, "pack_sequences_in_batch": True},
+            )(),
+            "model": type("M", (), {"pipeline_model_parallel_size": 1, "seq_length": 8})(),
+            "rerun_state_machine": type("R", (), {"check_for_nan_in_loss": False, "check_for_spiky_loss": False})(),
+        },
+    )()
+    state.timers = _Timer()
+    state.straggler_timer = _Strag()
+
+    monkeypatch.setattr(
+        "megatron.bridge.models.qwen_omni.qwen3_omni_step.get_pg_collection",
+        lambda model: _MockPGCollection(),
+    )
+    monkeypatch.setattr(
+        "megatron.bridge.models.qwen_omni.qwen3_omni_step.get_model_config",
+        lambda model: model.config,
+    )
+    monkeypatch.setattr(
+        "megatron.bridge.models.qwen_omni.qwen3_omni_step.get_batch",
+        lambda data_iterator, cfg, use_mtp, pg_collection: (
+            torch.tensor([[1, 2, 3, 4]]),
+            torch.tensor([[2, 3, 4, -100]]),
+            torch.ones(1, 4),
+            torch.ones(1, 4, dtype=torch.bool),
+            torch.arange(4).unsqueeze(0),
+            {},
+        ),
+    )
+
+    with pytest.raises(NotImplementedError, match="packed sequence support"):
+        forward_step(state, iter([{}]), _Model())
 
 
 def test_get_batch_pads_2d_attention_mask_for_pipeline_parallel():


### PR DESCRIPTION
# What does this PR do ?

Add dense context parallelism support for Qwen3-Omni thinker training.

# Changelog

- Enable dense CP batch padding and slicing for Qwen3-Omni.
- Preserve full `input_ids` for mRoPE while using local CP tensors for loss/attention.
- Add unit tests for dense CP behavior and mRoPE handling.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

Validation:
- `ruff check`
- `ruff format --check`
- `git diff --check`
- Focused Qwen3-Omni unit tests: `12 passed`
- Focused Qwen3-Omni mRoPE unit test: `1 passed`
- Local 4-GPU A800 smoke: CP=2, EP=2
- 4-node / 32-GPU validation checked via TensorBoard: CP=2, TP=2, PP=2, EP=4

Upcoming follow-up:
- Add packed sequence support for Qwen3-Omni dense CP in a separate PR.

Related to #3317
