### PR TITLE
[training] fix: validate MXFP8 param gather overlap

### DIFF
--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -1226,7 +1226,7 @@ class ConfigContainer(Container):
         if self.dist.use_megatron_fsdp or self.ddp.use_megatron_fsdp:
             self._validate_and_apply_megatron_fsdp_configs()
 
-        # Validate reuse_grad_buf_for_mxfp8_param_ag when FSDP is not enabled
+        # Validate MXFP8 parameter all-gather requirements when FSDP is not enabled.
         is_fsdp = self.dist.use_megatron_fsdp or self.ddp.use_megatron_fsdp
         if (
             not is_fsdp
@@ -1237,6 +1237,10 @@ class ConfigContainer(Container):
             assert self.mixed_precision.reuse_grad_buf_for_mxfp8_param_ag, (
                 "When fp8_param_gather=True and fp8_recipe='mxfp8', "
                 "reuse_grad_buf_for_mxfp8_param_ag must be set to True"
+            )
+            assert self.ddp.overlap_param_gather, (
+                "When fp8_param_gather=True, fp8_recipe='mxfp8', and "
+                "reuse_grad_buf_for_mxfp8_param_ag=True, ddp.overlap_param_gather must be set to True"
             )
 
         # Deterministic mode validations and settings

--- a/tests/unit_tests/training/test_config.py
+++ b/tests/unit_tests/training/test_config.py
@@ -1172,8 +1172,7 @@ class TestConfigContainerValidation:
             restore_get_world_size_safe(og_ws, cfg_mod)
 
     def test_reuse_grad_buf_for_mxfp8_param_ag_required_without_fsdp(self, monkeypatch):
-        """Test that reuse_grad_buf_for_mxfp8_param_ag must be True when
-        FSDP is disabled, fp8_param_gather=True, and fp8_recipe='mxfp8'."""
+        """Test MXFP8 parameter gather requirements when FSDP is disabled."""
         gpt_model_cfg = create_test_gpt_config()
         train_cfg = create_test_training_config(train_iters=500, global_batch_size=16)
         sched_cfg = create_test_scheduler_config()
@@ -1194,12 +1193,30 @@ class TestConfigContainerValidation:
         finally:
             restore_get_world_size_safe(og_ws, cfg_mod)
 
-        # Case 2: Should pass when reuse_grad_buf_for_mxfp8_param_ag=True
+        # Case 2: Should raise when reuse_grad_buf_for_mxfp8_param_ag=True but overlap_param_gather=False
         container, og_ws, cfg_mod = create_test_config_container(
             world_size_override=1,
             model_config=gpt_model_cfg,
             train_config=train_cfg,
             scheduler_config=sched_cfg,
+            ddp_config=create_test_ddp_config(overlap_param_gather=False),
+        )
+        try:
+            container.mixed_precision = MixedPrecisionConfig(
+                fp8_param_gather=True, fp8_recipe="mxfp8", reuse_grad_buf_for_mxfp8_param_ag=True
+            )
+            with pytest.raises(AssertionError, match="ddp.overlap_param_gather must be set to True"):
+                container.validate()
+        finally:
+            restore_get_world_size_safe(og_ws, cfg_mod)
+
+        # Case 3: Should pass when both reuse_grad_buf_for_mxfp8_param_ag and overlap_param_gather are True
+        container, og_ws, cfg_mod = create_test_config_container(
+            world_size_override=1,
+            model_config=gpt_model_cfg,
+            train_config=train_cfg,
+            scheduler_config=sched_cfg,
+            ddp_config=create_test_ddp_config(overlap_param_gather=True),
         )
         try:
             container.mixed_precision = MixedPrecisionConfig(
@@ -1209,7 +1226,7 @@ class TestConfigContainerValidation:
         finally:
             restore_get_world_size_safe(og_ws, cfg_mod)
 
-        # Case 3: Should pass when fp8_param_gather=False (guard skips)
+        # Case 4: Should pass when fp8_param_gather=False (guard skips)
         container, og_ws, cfg_mod = create_test_config_container(
             world_size_override=1,
             model_config=gpt_model_cfg,
@@ -1224,7 +1241,7 @@ class TestConfigContainerValidation:
         finally:
             restore_get_world_size_safe(og_ws, cfg_mod)
 
-        # Case 4: Should pass when fp8_recipe is not mxfp8 (guard skips)
+        # Case 5: Should pass when fp8_recipe is not mxfp8 (guard skips)
         container, og_ws, cfg_mod = create_test_config_container(
             world_size_override=1,
             model_config=gpt_model_cfg,


### PR DESCRIPTION
# What does this PR do ?

Adds validation so the non-FSDP MXFP8 parameter-gather path requires `ddp.overlap_param_gather=True` when `reuse_grad_buf_for_mxfp8_param_ag=True` is enabled.

# Changelog

- Require `ddp.overlap_param_gather=True` with non-FSDP MXFP8 gradient-buffer reuse.
- Extend config validation coverage for the invalid overlap-disabled case and the valid overlap-enabled case.

# GitHub Actions CI

Local validation:

- `uvx pre-commit run --files src/megatron/bridge/training/config.py tests/unit_tests/training/test_config.py`
- `PYTHONPATH=src:3rdparty/Megatron-LM python -m pytest tests/unit_tests/training/test_config.py::TestConfigContainerValidation::test_reuse_grad_buf_for_mxfp8_param_ag_required_without_fsdp`

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation? Not needed for this validation-only fix.
- [x] Does the PR affect components that are optional to install? No.

# Additional Information

- Related to #3801
