### PR TITLE
fix: strip stale auto_map from HF exports

### DIFF
--- a/examples/models/nemotron/nemotron_3/nano/conversion.sh
+++ b/examples/models/nemotron/nemotron_3/nano/conversion.sh
@@ -22,21 +22,23 @@ MODEL_NAME=NVIDIA-Nemotron-3-Nano-30B-A3B-Base-BF16
 HF_MODEL_ID=nvidia/$MODEL_NAME
 
 # Import HF → Megatron
-uv run python examples/conversion/convert_checkpoints.py import \
+uv run torchrun --nproc_per_node=8 examples/conversion/convert_checkpoints_multi_gpu.py import \
     --hf-model $HF_MODEL_ID \
     --megatron-path ${WORKSPACE}/models/$MODEL_NAME \
-    --trust-remote-code
+    --tp 1 --ep 8
+
 
 # Export Megatron → HF
-uv run python examples/conversion/convert_checkpoints.py export \
+uv run torchrun --nproc_per_node=8 examples/conversion/convert_checkpoints_multi_gpu.py export \
     --hf-model $HF_MODEL_ID \
     --megatron-path ${WORKSPACE}/models/$MODEL_NAME/iter_0000000 \
-    --hf-path ${WORKSPACE}/models/$MODEL_NAME-hf-export
+    --hf-path ${WORKSPACE}/models/$MODEL_NAME-hf-export \
+    --tp 1 --ep 8 
+
 
 # Round-trip validation
-uv run python -m torch.distributed.run --nproc_per_node=8 \
+uv run torchrun --nproc_per_node=8 \
     examples/conversion/hf_megatron_roundtrip_multi_gpu.py \
     --hf-model-id $HF_MODEL_ID \
     --megatron-load-path ${WORKSPACE}/models/$MODEL_NAME/iter_0000000 \
-    --tp 2 --ep 8 \
-    --trust-remote-code
+    --tp 1 --ep 8

--- a/src/megatron/bridge/models/conversion/auto_bridge.py
+++ b/src/megatron/bridge/models/conversion/auto_bridge.py
@@ -129,6 +129,8 @@ class AutoBridge(Generic[MegatronModelT]):
         # Data type for exporting weights
         self.export_weight_dtype: Literal["bf16", "fp16", "fp8"] = "bf16"
         self.hf_model_id: Optional[str] = None
+        trust_remote_code = getattr(hf_pretrained, "trust_remote_code", False)
+        self.trust_remote_code = trust_remote_code if isinstance(trust_remote_code, bool) else False
 
     @classmethod
     def list_supported_models(cls) -> list[str]:
@@ -234,6 +236,7 @@ class AutoBridge(Generic[MegatronModelT]):
         synthesized_config = type(hf_cfg)(**megatron_hf_cfg_dict)
         bridge = cls.from_hf_config(synthesized_config)
         bridge.hf_model_id = hf_model_id
+        bridge.trust_remote_code = trust_remote_code
 
         return bridge
 
@@ -699,15 +702,17 @@ class AutoBridge(Generic[MegatronModelT]):
             if is_config_only:
                 import json
 
-                # Config-only path: write config.json and download modeling files from Hub.
+                # Config-only path: write config.json and optionally download modeling files from Hub.
                 Path(path).mkdir(parents=True, exist_ok=True)
                 config_dict = self.hf_pretrained.to_dict()
+                if not self.trust_remote_code:
+                    config_dict.pop("auto_map", None)
                 with open(Path(path) / "config.json", "w") as _f:
                     json.dump(config_dict, _f, indent=2, sort_keys=True, allow_nan=True)
 
-                # Download custom modeling files so the output is loadable with from_pretrained().
+                # Download custom modeling files only when the export is meant to preserve remote code.
                 hub_repo = self.hf_model_id
-                if hub_repo:
+                if hub_repo and self.trust_remote_code:
                     try:
                         from huggingface_hub import hf_hub_download, list_repo_files
 

--- a/src/megatron/bridge/models/hf_pretrained/base.py
+++ b/src/megatron/bridge/models/hf_pretrained/base.py
@@ -72,6 +72,18 @@ class PreTrainedBase(ABC):
         """Get the artifacts dictionary mapping artifact names to their attribute names."""
         return {artifact: f"_{artifact}" for artifact in self.ARTIFACTS}
 
+    @staticmethod
+    def _cleanup_hf_local_dir_cache(target_path: Path) -> None:
+        """Remove Hugging Face Hub metadata created by hf_hub_download(local_dir=...)."""
+        huggingface_cache = target_path / ".cache" / "huggingface"
+        if huggingface_cache.exists():
+            shutil.rmtree(huggingface_cache, ignore_errors=True)
+
+        try:
+            (target_path / ".cache").rmdir()
+        except OSError:
+            pass
+
     def _copy_custom_modeling_files(
         self,
         source_path: Union[str, Path],
@@ -138,6 +150,7 @@ class PreTrainedBase(ABC):
                         except Exception:
                             # Silently skip files that can't be downloaded
                             pass
+                self._cleanup_hf_local_dir_cache(target_path)
 
             except Exception:
                 # If HuggingFace Hub operations fail, silently continue
@@ -174,7 +187,16 @@ class PreTrainedBase(ABC):
             if hasattr(self._config, "quantization_config"):
                 # quantized export is not supported currently
                 del self._config.quantization_config
-            self._config.save_pretrained(save_path)
+            auto_map_missing = object()
+            auto_map = vars(self._config).get("auto_map", auto_map_missing)
+            strip_auto_map = auto_map is not auto_map_missing and getattr(self, "trust_remote_code", False) is not True
+            if strip_auto_map:
+                delattr(self._config, "auto_map")
+            try:
+                self._config.save_pretrained(save_path)
+            finally:
+                if strip_auto_map:
+                    self._config.auto_map = auto_map
 
         # Iterate over required artifacts to save them in a predictable order
         for name in self.ARTIFACTS:

--- a/tests/unit_tests/models/hf_pretrained/test_base.py
+++ b/tests/unit_tests/models/hf_pretrained/test_base.py
@@ -14,10 +14,13 @@
 # limitations under the License.
 
 
+import json
 import sys
 import tempfile
 from pathlib import Path
 from unittest.mock import Mock, patch
+
+from transformers.configuration_utils import PretrainedConfig
 
 
 # Add the src directory to Python path for imports
@@ -119,6 +122,33 @@ def test_copy_custom_modeling_files_nonexistent_source():
         print("✅ test_copy_custom_modeling_files_nonexistent_source passed")
 
 
+def test_hub_download_cleans_local_dir_cache():
+    """Test Hub downloads do not leave local_dir cache metadata in the export directory."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir)
+        target_dir = tmp_path / "target"
+        target_dir.mkdir()
+
+        def fake_hf_hub_download(repo_id, filename, local_dir, local_dir_use_symlinks):
+            del repo_id, local_dir_use_symlinks
+            local_dir = Path(local_dir)
+            (local_dir / filename).write_text("# downloaded file")
+            metadata_dir = local_dir / ".cache" / "huggingface" / "download"
+            metadata_dir.mkdir(parents=True)
+            (metadata_dir / f"{filename}.metadata").write_text("metadata")
+
+        base = MockPreTrainedBase()
+        with patch("huggingface_hub.list_repo_files", return_value=["nano_v3_reasoning_parser.py"]):
+            with patch("huggingface_hub.hf_hub_download", side_effect=fake_hf_hub_download):
+                copied_files = base._copy_custom_modeling_files(
+                    "org/repo", target_dir, file_patterns=["*reasoning_parser.py"]
+                )
+
+        assert copied_files == ["nano_v3_reasoning_parser.py"]
+        assert (target_dir / "nano_v3_reasoning_parser.py").exists()
+        assert not (target_dir / ".cache").exists()
+
+
 def test_save_artifacts_with_trust_remote_code_true():
     """Test save_artifacts preserves custom files when trust_remote_code=True."""
     with tempfile.TemporaryDirectory() as tmp_dir:
@@ -175,6 +205,53 @@ def test_save_artifacts_with_trust_remote_code_false():
         assert not (target_dir / "modeling_custom.py").exists()
 
         print("✅ test_save_artifacts_with_trust_remote_code_false passed")
+
+
+def test_save_artifacts_strips_auto_map_without_trust_remote_code():
+    """Test save_artifacts drops remote-code auto_map when remote code is not preserved."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir)
+        target_dir = tmp_path / "target"
+
+        base = MockPreTrainedBase(trust_remote_code=False)
+        config = PretrainedConfig()
+        config.auto_map = {
+            "AutoConfig": "configuration_custom.CustomConfig",
+            "AutoModelForCausalLM": "modeling_custom.CustomForCausalLM",
+        }
+        base._config = config
+
+        base.save_artifacts(target_dir)
+
+        saved_config = json.loads((target_dir / "config.json").read_text())
+        assert "auto_map" not in saved_config
+        assert config.auto_map == {
+            "AutoConfig": "configuration_custom.CustomConfig",
+            "AutoModelForCausalLM": "modeling_custom.CustomForCausalLM",
+        }
+
+
+def test_save_artifacts_preserves_auto_map_with_trust_remote_code():
+    """Test save_artifacts keeps auto_map when remote code is preserved."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir)
+        target_dir = tmp_path / "target"
+
+        base = MockPreTrainedBase(trust_remote_code=True)
+        config = PretrainedConfig()
+        config.auto_map = {
+            "AutoConfig": "configuration_custom.CustomConfig",
+            "AutoModelForCausalLM": "modeling_custom.CustomForCausalLM",
+        }
+        base._config = config
+
+        base.save_artifacts(target_dir)
+
+        saved_config = json.loads((target_dir / "config.json").read_text())
+        assert saved_config["auto_map"] == {
+            "AutoConfig": "configuration_custom.CustomConfig",
+            "AutoModelForCausalLM": "modeling_custom.CustomForCausalLM",
+        }
 
 
 def test_save_artifacts_without_model_name_or_path():
@@ -459,8 +536,11 @@ def main():
     try:
         test_copy_custom_modeling_files_basic()
         test_copy_custom_modeling_files_nonexistent_source()
+        test_hub_download_cleans_local_dir_cache()
         test_save_artifacts_with_trust_remote_code_true()
         test_save_artifacts_with_trust_remote_code_false()
+        test_save_artifacts_strips_auto_map_without_trust_remote_code()
+        test_save_artifacts_preserves_auto_map_with_trust_remote_code()
         test_save_artifacts_without_model_name_or_path()
         test_copy_handles_permission_errors()
 

--- a/tests/unit_tests/models/test_auto_bridge.py
+++ b/tests/unit_tests/models/test_auto_bridge.py
@@ -16,6 +16,7 @@
 Unit tests for AutoBridge automatic bridge selection and bridge functionality.
 """
 
+import json
 from unittest.mock import Mock, PropertyMock, patch
 
 import pytest
@@ -659,6 +660,59 @@ class TestAutoBridge:
         assert (tmp_path / "config.json").exists()
         mock_download.assert_not_called()
         mock_save_hf_weights.assert_called_once()
+
+    @patch("torch.distributed.is_initialized", return_value=False)
+    @patch("torch.distributed.is_available", return_value=False)
+    def test_save_hf_pretrained_config_only_strips_auto_map_without_remote_code(
+        self, _mock_dist_avail, _mock_dist_init, tmp_path
+    ):
+        """Config-only save omits stale remote-code metadata when remote code is not preserved."""
+        config = PretrainedConfig()
+        config.auto_map = {
+            "AutoConfig": "configuration_custom.CustomConfig",
+            "AutoModelForCausalLM": "modeling_custom.CustomForCausalLM",
+        }
+        bridge = AutoBridge(config)
+        bridge.hf_model_id = "some-org/some-model"
+
+        with patch.object(AutoBridge, "save_hf_weights"):
+            with patch("huggingface_hub.list_repo_files") as mock_list_repo_files:
+                bridge.save_hf_pretrained([Mock()], str(tmp_path))
+
+        saved_config = json.loads((tmp_path / "config.json").read_text())
+        assert "auto_map" not in saved_config
+        mock_list_repo_files.assert_not_called()
+
+    @patch("torch.distributed.is_initialized", return_value=False)
+    @patch("torch.distributed.is_available", return_value=False)
+    def test_save_hf_pretrained_config_only_preserves_auto_map_with_remote_code(
+        self, _mock_dist_avail, _mock_dist_init, tmp_path
+    ):
+        """Config-only save keeps auto_map and copies code when remote code is preserved."""
+        config = PretrainedConfig()
+        config.auto_map = {
+            "AutoConfig": "configuration_custom.CustomConfig",
+            "AutoModelForCausalLM": "modeling_custom.CustomForCausalLM",
+        }
+        bridge = AutoBridge(config)
+        bridge.hf_model_id = "some-org/some-model"
+        bridge.trust_remote_code = True
+
+        with patch.object(AutoBridge, "save_hf_weights"):
+            with patch("huggingface_hub.list_repo_files", return_value=["modeling_custom.py", "README.md"]):
+                with patch("huggingface_hub.hf_hub_download") as mock_download:
+                    bridge.save_hf_pretrained([Mock()], str(tmp_path))
+
+        saved_config = json.loads((tmp_path / "config.json").read_text())
+        assert saved_config["auto_map"] == {
+            "AutoConfig": "configuration_custom.CustomConfig",
+            "AutoModelForCausalLM": "modeling_custom.CustomForCausalLM",
+        }
+        mock_download.assert_called_once_with(
+            repo_id="some-org/some-model",
+            filename="modeling_custom.py",
+            local_dir=str(tmp_path),
+        )
 
     @patch("torch.distributed.get_rank", return_value=1)
     @patch("torch.distributed.is_initialized", return_value=True)


### PR DESCRIPTION
 This PR fixes HF export behavior for models whose original repository includes `auto_map` remote-code metadata, but whose architecture is now supported directly by Transformers.

  **Problem**

  - Exported HF checkpoints could omit remote Python files while still preserving auto_map in config.json.
  - This creates a stale config: users loading with trust_remote_code=True may trigger missing remote-code imports.
  - Downloading extra sidecar files via hf_hub_download(local_dir=...) also left .cache/huggingface metadata inside the exported model directory.

  **Solution**

  - Strip auto_map from exported configs when trust_remote_code is not enabled.
  - Preserve auto_map and remote-code behavior when trust_remote_code=True.
  - Clean Hugging Face Hub local-dir metadata after downloading additional export files.
  - Add unit tests covering normal artifact export, config-only export, and local-dir cache cleanup.
