### PR TITLE
[training] fix: Preserve packed SFT metadata on middle PP stages

### DIFF
--- a/src/megatron/bridge/training/gpt_step.py
+++ b/src/megatron/bridge/training/gpt_step.py
@@ -110,6 +110,7 @@ def get_batch_from_iterator(
     *,
     is_first_pp_stage: bool,
     is_last_pp_stage: bool,
+    include_full_batch_fields: bool = False,
 ) -> dict[str, torch.Tensor]:
     """Get a batch of data from the iterator.
 
@@ -117,6 +118,7 @@ def get_batch_from_iterator(
         data_iterator: The data iterator to get the batch from.
         use_mtp: Whether Multi-Token Prediction layers are enabled.
         skip_getting_attention_mask_from_dataset: If set, the dataset will pass a None attention mask.
+        include_full_batch_fields: Whether to include all standard training tensors regardless of PP stage.
 
     Returns:
         dict[str, torch.Tensor]: A dictionary containing the batch data.
@@ -126,7 +128,9 @@ def get_batch_from_iterator(
     required_device_keys = set()
     required_host_keys = set()
 
-    if not skip_getting_attention_mask_from_dataset:
+    if include_full_batch_fields:
+        required_device_keys.update(("tokens", "labels", "loss_mask", "attention_mask", "position_ids"))
+    elif not skip_getting_attention_mask_from_dataset:
         required_device_keys.add("attention_mask")
 
     if "cu_seqlens" in batch:
@@ -138,10 +142,11 @@ def get_batch_from_iterator(
         if "cu_seqlens_unpadded_argmin" in batch:
             required_host_keys.add("cu_seqlens_unpadded_argmin")
 
-    if is_first_pp_stage or use_mtp:
-        required_device_keys.update(("tokens", "position_ids"))
-    if is_last_pp_stage:
-        required_device_keys.update(("labels", "loss_mask"))
+    if not include_full_batch_fields:
+        if is_first_pp_stage or use_mtp:
+            required_device_keys.update(("tokens", "position_ids"))
+        if is_last_pp_stage:
+            required_device_keys.update(("labels", "loss_mask"))
 
     _batch_required_keys = {}
     for key, val in batch.items():
@@ -185,15 +190,17 @@ def get_batch(
     is_first = is_pp_first_stage(pg_collection.pp)
     is_last = is_pp_last_stage(pg_collection.pp)
     is_middle = (not is_first) and (not is_last)
-    if is_middle and not _middle_pp_stage_needs_batch(cfg):
+    include_full_batch_fields = is_middle and _middle_pp_stage_needs_batch(cfg)
+    if is_middle and not include_full_batch_fields:
         return None, None, None, None, None, None, None, None, None, None
 
     batch = get_batch_from_iterator(
         data_iterator,
-        use_mtp and not is_middle,
+        use_mtp,
         getattr(cfg.dataset, "skip_getting_attention_mask_from_dataset", True),
         is_first_pp_stage=is_first,
         is_last_pp_stage=is_last,
+        include_full_batch_fields=include_full_batch_fields,
     )
 
     cp_size = pg_collection.cp.size()
@@ -218,50 +225,6 @@ def get_batch(
         batch.get("cu_seqlens_unpadded"),
         batch.get("cu_seqlens_unpadded_argmin"),
     )
-
-
-def _get_total_tokens_from_cu_seqlens(
-    cu_seqlens: torch.Tensor,
-    cu_seqlens_argmin: torch.Tensor | None,
-) -> int | None:
-    """Derive the packed token count from cumulative sequence lengths."""
-    cu_seqlens = cu_seqlens.squeeze()
-    if cu_seqlens.numel() == 0:
-        return None
-
-    if cu_seqlens_argmin is not None:
-        argmin = int(cu_seqlens_argmin.squeeze().item())
-        if argmin > 0 and argmin <= cu_seqlens.numel():
-            return int(cu_seqlens[argmin - 1].item())
-
-    padding_positions = torch.nonzero(cu_seqlens < 0, as_tuple=False)
-    if padding_positions.numel() > 0:
-        first_padding_index = int(padding_positions.flatten()[0].item())
-        if first_padding_index == 0:
-            return 0
-        return int(cu_seqlens[first_padding_index - 1].item())
-
-    return int(cu_seqlens[-1].item())
-
-
-def _get_packed_total_tokens(
-    tokens: torch.Tensor | None,
-    labels: torch.Tensor | None,
-    cu_seqlens: torch.Tensor,
-    cu_seqlens_argmin: torch.Tensor | None,
-    config,
-) -> int | None:
-    """Return total tokens for hybrid packed sequence params."""
-    if tokens is not None:
-        return tokens.size(1)
-    if labels is not None:
-        return labels.size(1)
-
-    total_tokens = _get_total_tokens_from_cu_seqlens(cu_seqlens, cu_seqlens_argmin)
-    if total_tokens is not None:
-        return total_tokens
-
-    return getattr(config, "seq_length", None)
 
 
 def _forward_step_common(
@@ -321,9 +284,12 @@ def _forward_step_common(
         # which is only needed for Mamba/hybrid SSM layers. Skip it for pure
         # transformer models to avoid per-step CUDA overhead.
         if getattr(config, "is_hybrid_model", False):
-            packed_seq_params["total_tokens"] = _get_packed_total_tokens(
-                tokens, labels, cu_seqlens, cu_seqlens_argmin, config
-            )
+            if tokens is not None:
+                packed_seq_params["total_tokens"] = tokens.size(1)
+            elif labels is not None:
+                packed_seq_params["total_tokens"] = labels.size(1)
+            else:
+                packed_seq_params["total_tokens"] = getattr(config, "seq_length", None)
         forward_args["packed_seq_params"] = get_packed_seq_params(packed_seq_params)
 
     with straggler_timer:

--- a/src/megatron/bridge/training/gpt_step.py
+++ b/src/megatron/bridge/training/gpt_step.py
@@ -39,6 +39,24 @@ from megatron.bridge.training.utils.pg_utils import get_pg_collection
 logger = logging.getLogger(__name__)
 
 
+def _uses_packed_sequence_metadata(cfg: ConfigContainer) -> bool:
+    """Return whether the dataset is expected to provide packed sequence metadata."""
+    dataset_cfg = getattr(cfg, "dataset", None)
+    packed_sequence_specs = getattr(dataset_cfg, "packed_sequence_specs", None)
+    if packed_sequence_specs is not None:
+        packed_sequence_size = getattr(packed_sequence_specs, "packed_sequence_size", None)
+        return packed_sequence_size is None or packed_sequence_size > 0
+
+    return getattr(dataset_cfg, "pack_sequences_in_batch", False)
+
+
+def _middle_pp_stage_needs_batch(cfg: ConfigContainer) -> bool:
+    """Return whether middle PP stages need batch metadata for attention."""
+    dataset_cfg = getattr(cfg, "dataset", None)
+    uses_custom_attention_mask = not getattr(dataset_cfg, "skip_getting_attention_mask_from_dataset", True)
+    return uses_custom_attention_mask or _uses_packed_sequence_metadata(cfg)
+
+
 def _partition_packed_batch_for_cp(batch: dict[str, torch.Tensor], cp_size: int) -> dict[str, torch.Tensor]:
     """Partition THD/packed batches across context-parallel ranks.
 
@@ -166,12 +184,13 @@ def get_batch(
     # Determine pipeline stage role via process group collection
     is_first = is_pp_first_stage(pg_collection.pp)
     is_last = is_pp_last_stage(pg_collection.pp)
-    if (not is_first) and (not is_last):
+    is_middle = (not is_first) and (not is_last)
+    if is_middle and not _middle_pp_stage_needs_batch(cfg):
         return None, None, None, None, None, None, None, None, None, None
 
     batch = get_batch_from_iterator(
         data_iterator,
-        use_mtp,
+        use_mtp and not is_middle,
         getattr(cfg.dataset, "skip_getting_attention_mask_from_dataset", True),
         is_first_pp_stage=is_first,
         is_last_pp_stage=is_last,
@@ -199,6 +218,50 @@ def get_batch(
         batch.get("cu_seqlens_unpadded"),
         batch.get("cu_seqlens_unpadded_argmin"),
     )
+
+
+def _get_total_tokens_from_cu_seqlens(
+    cu_seqlens: torch.Tensor,
+    cu_seqlens_argmin: torch.Tensor | None,
+) -> int | None:
+    """Derive the packed token count from cumulative sequence lengths."""
+    cu_seqlens = cu_seqlens.squeeze()
+    if cu_seqlens.numel() == 0:
+        return None
+
+    if cu_seqlens_argmin is not None:
+        argmin = int(cu_seqlens_argmin.squeeze().item())
+        if argmin > 0 and argmin <= cu_seqlens.numel():
+            return int(cu_seqlens[argmin - 1].item())
+
+    padding_positions = torch.nonzero(cu_seqlens < 0, as_tuple=False)
+    if padding_positions.numel() > 0:
+        first_padding_index = int(padding_positions.flatten()[0].item())
+        if first_padding_index == 0:
+            return 0
+        return int(cu_seqlens[first_padding_index - 1].item())
+
+    return int(cu_seqlens[-1].item())
+
+
+def _get_packed_total_tokens(
+    tokens: torch.Tensor | None,
+    labels: torch.Tensor | None,
+    cu_seqlens: torch.Tensor,
+    cu_seqlens_argmin: torch.Tensor | None,
+    config,
+) -> int | None:
+    """Return total tokens for hybrid packed sequence params."""
+    if tokens is not None:
+        return tokens.size(1)
+    if labels is not None:
+        return labels.size(1)
+
+    total_tokens = _get_total_tokens_from_cu_seqlens(cu_seqlens, cu_seqlens_argmin)
+    if total_tokens is not None:
+        return total_tokens
+
+    return getattr(config, "seq_length", None)
 
 
 def _forward_step_common(
@@ -258,7 +321,9 @@ def _forward_step_common(
         # which is only needed for Mamba/hybrid SSM layers. Skip it for pure
         # transformer models to avoid per-step CUDA overhead.
         if getattr(config, "is_hybrid_model", False):
-            packed_seq_params["total_tokens"] = tokens.size(1) if tokens is not None else labels.size(1)
+            packed_seq_params["total_tokens"] = _get_packed_total_tokens(
+                tokens, labels, cu_seqlens, cu_seqlens_argmin, config
+            )
         forward_args["packed_seq_params"] = get_packed_seq_params(packed_seq_params)
 
     with straggler_timer:

--- a/tests/unit_tests/training/test_gpt_step.py
+++ b/tests/unit_tests/training/test_gpt_step.py
@@ -112,25 +112,30 @@ class _NoopTimer:
 class TestGetBatch:
     """Tests for the get_batch helper."""
 
-    def test_middle_pp_stage_preserves_packed_metadata(self, monkeypatch):
-        """Middle PP stages need packed metadata to preserve sequence boundaries."""
+    def test_middle_pp_stage_preserves_full_packed_batch(self, monkeypatch):
+        """Middle PP stages load full tensors when packed metadata is active."""
         _set_middle_pp_stage(monkeypatch)
         monkeypatch.setattr(
             "megatron.bridge.training.gpt_step.get_batch_on_this_cp_rank",
             lambda batch, cp_group: batch,
         )
 
+        tokens = _as_nocuda(torch.tensor([[1, 2, 3, 4, 5, 6, 7, 8]]))
+        labels = _as_nocuda(torch.tensor([[2, 3, 4, 5, 6, 7, 8, 9]]))
+        loss_mask = _as_nocuda(torch.ones(1, 8))
+        attention_mask = _as_nocuda(torch.ones(1, 1, 8, 8, dtype=torch.bool))
+        position_ids = _as_nocuda(torch.arange(8).unsqueeze(0))
         cu_seqlens = _as_nocuda(torch.tensor([[0, 3, 8, -1]], dtype=torch.int32))
         cu_seqlens_unpadded = _as_nocuda(torch.tensor([[0, 2, 7, -1]], dtype=torch.int32))
         cu_seqlens_argmin = torch.tensor(3)
         cu_seqlens_unpadded_argmin = torch.tensor(3)
         max_seqlen = torch.tensor([[5]], dtype=torch.int32)
         batch = {
-            "tokens": torch.tensor([[1, 2, 3, 4, 5, 6, 7, 8]]),
-            "labels": torch.tensor([[2, 3, 4, 5, 6, 7, 8, 9]]),
-            "loss_mask": torch.ones(1, 8),
-            "attention_mask": None,
-            "position_ids": torch.arange(8).unsqueeze(0),
+            "tokens": tokens,
+            "labels": labels,
+            "loss_mask": loss_mask,
+            "attention_mask": attention_mask,
+            "position_ids": position_ids,
             "cu_seqlens": cu_seqlens,
             "cu_seqlens_argmin": cu_seqlens_argmin,
             "max_seqlen": max_seqlen,
@@ -156,11 +161,11 @@ class TestGetBatch:
             pg_collection=_MockPGCollection(),
         )
 
-        assert tokens is None
-        assert labels is None
-        assert loss_mask is None
-        assert attention_mask is None
-        assert position_ids is None
+        assert torch.equal(tokens, batch["tokens"])
+        assert torch.equal(labels, batch["labels"])
+        assert torch.equal(loss_mask, batch["loss_mask"])
+        assert torch.equal(attention_mask, batch["attention_mask"])
+        assert torch.equal(position_ids, batch["position_ids"])
         assert torch.equal(out_cu_seqlens, cu_seqlens)
         assert torch.equal(out_cu_seqlens_argmin, cu_seqlens_argmin)
         assert torch.equal(out_max_seqlen, max_seqlen)
@@ -183,8 +188,12 @@ class TestGetBatch:
         data_iterator.__next__.assert_not_called()
 
     def test_forward_common_passes_packed_seq_params_on_middle_pp_stage(self, monkeypatch):
-        """Forward path must pass packed metadata even without token tensors."""
+        """Forward path must pass packed metadata on middle PP stages."""
         sentinel_packed_seq_params = object()
+        tokens = torch.tensor([[1, 2, 3, 4, 5, 6, 7, 8]])
+        labels = torch.tensor([[2, 3, 4, 5, 6, 7, 8, 9]])
+        loss_mask = torch.ones(1, 8)
+        position_ids = torch.arange(8).unsqueeze(0)
         cu_seqlens = torch.tensor([[0, 3, 8, -1]], dtype=torch.int32)
         cu_seqlens_argmin = torch.tensor(3)
         max_seqlen = torch.tensor([[5]], dtype=torch.int32)
@@ -208,11 +217,11 @@ class TestGetBatch:
         monkeypatch.setattr(
             "megatron.bridge.training.gpt_step.get_batch",
             lambda data_iterator, cfg, use_mtp, pg_collection: (
+                tokens,
+                labels,
+                loss_mask,
                 None,
-                None,
-                None,
-                None,
-                None,
+                position_ids,
                 cu_seqlens,
                 cu_seqlens_argmin,
                 max_seqlen,
@@ -225,15 +234,15 @@ class TestGetBatch:
             Mock(return_value=sentinel_packed_seq_params),
         )
 
-        output, loss_mask = _forward_step_common(state, _Iterator({}), model)
+        output, returned_loss_mask = _forward_step_common(state, _Iterator({}), model)
 
         assert torch.equal(output, torch.tensor(1.0))
-        assert loss_mask is None
+        assert torch.equal(returned_loss_mask, loss_mask)
         model.assert_called_once_with(
-            input_ids=None,
-            position_ids=None,
+            input_ids=tokens,
+            position_ids=position_ids,
             attention_mask=None,
-            labels=None,
+            labels=labels,
             packed_seq_params=sentinel_packed_seq_params,
         )
 

--- a/tests/unit_tests/training/test_gpt_step.py
+++ b/tests/unit_tests/training/test_gpt_step.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from functools import partial
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import modelopt.torch.distill as mtd
 import torch
@@ -21,11 +21,221 @@ from megatron.core.packed_seq_params import PackedSeqParams
 
 from megatron.bridge.training.gpt_step import (
     _create_loss_function_modelopt,
+    _forward_step_common,
+    get_batch,
     get_packed_seq_params,
 )
 from megatron.bridge.training.losses import (
     create_masked_next_token_loss_function as _create_loss_function,
 )
+
+
+class _Iterator:
+    def __init__(self, batch):
+        self.batch = batch
+        self._done = False
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self._done:
+            raise StopIteration
+        self._done = True
+        return self.batch
+
+
+class _MockProcessGroup:
+    def rank(self):
+        return 0
+
+    def size(self):
+        return 1
+
+
+class _MockPGCollection:
+    def __init__(self, cp_size=1):
+        self.pp = _MockProcessGroup()
+        self._cp_size = cp_size
+
+    @property
+    def cp(self):
+        pg = _MockProcessGroup()
+        pg.size = lambda: self._cp_size
+        return pg
+
+
+class _NoCudaTensor(torch.Tensor):
+    def cuda(self, non_blocking=False):  # type: ignore[override]
+        return self
+
+
+def _as_nocuda(tensor):
+    return tensor.as_subclass(_NoCudaTensor)
+
+
+def _make_cfg(*, packed_sequence_specs=None, skip_getting_attention_mask_from_dataset=True):
+    cfg = type("Cfg", (), {})()
+    cfg.dataset = type(
+        "D",
+        (),
+        {
+            "packed_sequence_specs": packed_sequence_specs,
+            "skip_getting_attention_mask_from_dataset": skip_getting_attention_mask_from_dataset,
+        },
+    )()
+    return cfg
+
+
+def _set_middle_pp_stage(monkeypatch):
+    monkeypatch.setattr("megatron.bridge.training.gpt_step.is_pp_first_stage", lambda pg: False)
+    monkeypatch.setattr("megatron.bridge.training.gpt_step.is_pp_last_stage", lambda pg: False)
+
+
+class _NoopTimer:
+    def __call__(self, *args, **kwargs):
+        return self
+
+    def start(self):
+        return None
+
+    def stop(self):
+        return None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return False
+
+
+class TestGetBatch:
+    """Tests for the get_batch helper."""
+
+    def test_middle_pp_stage_preserves_packed_metadata(self, monkeypatch):
+        """Middle PP stages need packed metadata to preserve sequence boundaries."""
+        _set_middle_pp_stage(monkeypatch)
+        monkeypatch.setattr(
+            "megatron.bridge.training.gpt_step.get_batch_on_this_cp_rank",
+            lambda batch, cp_group: batch,
+        )
+
+        cu_seqlens = _as_nocuda(torch.tensor([[0, 3, 8, -1]], dtype=torch.int32))
+        cu_seqlens_unpadded = _as_nocuda(torch.tensor([[0, 2, 7, -1]], dtype=torch.int32))
+        cu_seqlens_argmin = torch.tensor(3)
+        cu_seqlens_unpadded_argmin = torch.tensor(3)
+        max_seqlen = torch.tensor([[5]], dtype=torch.int32)
+        batch = {
+            "tokens": torch.tensor([[1, 2, 3, 4, 5, 6, 7, 8]]),
+            "labels": torch.tensor([[2, 3, 4, 5, 6, 7, 8, 9]]),
+            "loss_mask": torch.ones(1, 8),
+            "attention_mask": None,
+            "position_ids": torch.arange(8).unsqueeze(0),
+            "cu_seqlens": cu_seqlens,
+            "cu_seqlens_argmin": cu_seqlens_argmin,
+            "max_seqlen": max_seqlen,
+            "cu_seqlens_unpadded": cu_seqlens_unpadded,
+            "cu_seqlens_unpadded_argmin": cu_seqlens_unpadded_argmin,
+        }
+
+        (
+            tokens,
+            labels,
+            loss_mask,
+            attention_mask,
+            position_ids,
+            out_cu_seqlens,
+            out_cu_seqlens_argmin,
+            out_max_seqlen,
+            out_cu_seqlens_unpadded,
+            out_cu_seqlens_unpadded_argmin,
+        ) = get_batch(
+            _Iterator(batch),
+            _make_cfg(packed_sequence_specs=object()),
+            use_mtp=False,
+            pg_collection=_MockPGCollection(),
+        )
+
+        assert tokens is None
+        assert labels is None
+        assert loss_mask is None
+        assert attention_mask is None
+        assert position_ids is None
+        assert torch.equal(out_cu_seqlens, cu_seqlens)
+        assert torch.equal(out_cu_seqlens_argmin, cu_seqlens_argmin)
+        assert torch.equal(out_max_seqlen, max_seqlen)
+        assert torch.equal(out_cu_seqlens_unpadded, cu_seqlens_unpadded)
+        assert torch.equal(out_cu_seqlens_unpadded_argmin, cu_seqlens_unpadded_argmin)
+
+    def test_middle_pp_stage_keeps_non_packed_fast_path(self, monkeypatch):
+        """Middle PP stages without attention metadata keep the all-None fast path."""
+        _set_middle_pp_stage(monkeypatch)
+        data_iterator = MagicMock()
+
+        result = get_batch(
+            data_iterator,
+            _make_cfg(packed_sequence_specs=None),
+            use_mtp=False,
+            pg_collection=_MockPGCollection(),
+        )
+
+        assert result == (None, None, None, None, None, None, None, None, None, None)
+        data_iterator.__next__.assert_not_called()
+
+    def test_forward_common_passes_packed_seq_params_on_middle_pp_stage(self, monkeypatch):
+        """Forward path must pass packed metadata even without token tensors."""
+        sentinel_packed_seq_params = object()
+        cu_seqlens = torch.tensor([[0, 3, 8, -1]], dtype=torch.int32)
+        cu_seqlens_argmin = torch.tensor(3)
+        max_seqlen = torch.tensor([[5]], dtype=torch.int32)
+        model = Mock(return_value=torch.tensor(1.0))
+        state = Mock()
+        state.cfg = _make_cfg(packed_sequence_specs=object())
+        state.timers = _NoopTimer()
+        state.straggler_timer = _NoopTimer()
+        config = type(
+            "Config",
+            (),
+            {
+                "is_hybrid_model": False,
+                "mtp_num_layers": 0,
+                "overlap_moe_expert_parallel_comm": False,
+            },
+        )()
+
+        monkeypatch.setattr("megatron.bridge.training.gpt_step.get_model_config", lambda model: config)
+        monkeypatch.setattr("megatron.bridge.training.gpt_step.get_pg_collection", lambda model: _MockPGCollection())
+        monkeypatch.setattr(
+            "megatron.bridge.training.gpt_step.get_batch",
+            lambda data_iterator, cfg, use_mtp, pg_collection: (
+                None,
+                None,
+                None,
+                None,
+                None,
+                cu_seqlens,
+                cu_seqlens_argmin,
+                max_seqlen,
+                None,
+                None,
+            ),
+        )
+        monkeypatch.setattr(
+            "megatron.bridge.training.gpt_step.get_packed_seq_params",
+            Mock(return_value=sentinel_packed_seq_params),
+        )
+
+        output, loss_mask = _forward_step_common(state, _Iterator({}), model)
+
+        assert torch.equal(output, torch.tensor(1.0))
+        assert loss_mask is None
+        model.assert_called_once_with(
+            input_ids=None,
+            position_ids=None,
+            attention_mask=None,
+            labels=None,
+            packed_seq_params=sentinel_packed_seq_params,
+        )
 
 
 class TestGetPackedSeqParams:


### PR DESCRIPTION
## Summary

Closes #2952.

Fixes GPT packed SFT batch generation for pipeline-parallel middle stages. Middle PP stages now keep the existing all-None fast path for non-packed/default attention, but load attention metadata when packed sequence specs or dataset-provided attention masks are active. This preserves `cu_seqlens`, `cu_seqlens_argmin`, `max_seqlen`, optional unpadded cu-seqlens, and explicit attention masks through transformer middle stages.

Also avoids hybrid-model `total_tokens` crashes on metadata-only middle stages by deriving the value from packed cu-seqlens when token/label tensors are absent.

## CW evidence

Pre-fix deterministic repro failed on cw before patching:
- Job: `11976945`
- Log: `/lustre/fs1/portfolios/coreai/projects/coreai_dlalgo_llm/users/yuya/logs/issue2952-mira/pre_repro_11976945.log`
- Command: `uv run --active --no-sync python -m pytest tests/unit_tests/training/test_gpt_step.py -v`
- Result: `test_middle_pp_stage_preserves_packed_metadata` failed because `out_cu_seqlens` was `None` on a middle PP stage.

Post-fix rerun of the same repro passed:
- Job: `11977013`
- Log: `/lustre/fs1/portfolios/coreai/projects/coreai_dlalgo_llm/users/yuya/logs/issue2952-mira/post_repro_11977013.log`
- Result: `21 passed`

Additional packing validation on cw:
- Job: `11977108`
- Log: `/lustre/fs1/portfolios/coreai/projects/coreai_dlalgo_llm/users/yuya/logs/issue2952-mira/post_packing_11977108.log`
- `uv run --active --no-sync python -m pytest tests/unit_tests/training/utils/test_packed_seq_utils.py -v`: `11 passed`
- `uv run --active --no-sync python -m pytest tests/unit_tests/training/test_config.py -k \"packed_sequence or pack_sequences_in_batch or context_parallel_seq_length_divisibility or context_parallel_finetuning_validations\" -v`: `14 passed, 159 deselected`

Full DeepSeek-V3 loss repro was not run; the targeted metadata repro directly exercises the suspected middle-PP metadata drop and avoids the much larger 12-way PP MoE SFT setup.

## Local checks

- `git diff --check`: passed
- `uv run --no-sync ruff check src/megatron/bridge/training/gpt_step.py tests/unit_tests/training/test_gpt_step.py`: passed
- `uv run --no-sync ruff format --check src/megatron/bridge/training/gpt_step.py tests/unit_tests/training/test_gpt_step.py`: passed
- `uv run pre-commit run --all-files`: blocked by local NRX wheel platform resolution (`manylinux_2_31` host vs `manylinux_2_39` wheel)
- `uv run --active --no-sync pre-commit run --all-files`: passed