### PR TITLE
[data] fix: derive assistant loss mask for chat templates lacking {% generation %} (#2598)

### DIFF
--- a/src/megatron/bridge/data/datasets/utils.py
+++ b/src/megatron/bridge/data/datasets/utils.py
@@ -879,6 +879,101 @@ def _convert_to_openai_messages(source: dict) -> list[dict]:
     return chat
 
 
+def _derive_assistant_mask_via_prefix_diff(
+    chat: list[dict],
+    tokenizer: Any,
+    tools: Optional[list[Any]],
+    full_ids: list[int],
+) -> list[int]:
+    """Derive an assistant-only loss mask without relying on `{% generation %}` markers.
+
+    When a tokenizer's chat_template lacks `{% generation %}...{% endgeneration %}` blocks,
+    `apply_chat_template(..., return_assistant_tokens_mask=True)` silently returns an all-ones
+    mask, which would cause SFT loss to be computed on every token (system / user / tool /
+    assistant). This helper instead reconstructs the mask by re-rendering message prefixes:
+
+      1. For each assistant message at index ``i``, render ``chat[:i]`` with
+         ``add_generation_prompt=True`` — this ends with the assistant-header tokens
+         (e.g. ``<|im_start|>assistant\\n``).
+      2. Render ``chat[:i + 1]`` — this is the same prefix plus the assistant content
+         and any closing tokens (e.g. ``<|im_end|>``).
+      3. Mark ``mask[len(prefix) : len(with_assistant)]`` as ``1``. Role-header tokens
+         remain in the prefix and are therefore masked out; the closing turn token is
+         included in the loss, matching the convention used by templates that ship
+         ``{% generation %}`` blocks.
+
+    The function validates that each incremental rendering extends the previous one and
+    matches the full conversation rendering. Templates that fail this property (e.g. ones
+    that emit running summaries) are not safely incrementally renderable, and a
+    ``ValueError`` is raised so the caller can fix the template instead of training on a
+    wrong mask.
+
+    Args:
+        chat: Conversation in OpenAI ``messages`` format
+            (``[{"role": ..., "content": ...}, ...]``).
+        tokenizer: A HuggingFace ``PreTrainedTokenizerBase`` (or compatible) exposing
+            ``apply_chat_template``.
+        tools: Optional tool schema list forwarded to ``apply_chat_template``.
+        full_ids: Token IDs produced by rendering the entire ``chat``; used to size the
+            mask and to validate prefix consistency.
+
+    Returns:
+        A list of ``int`` (0 / 1) with the same length as ``full_ids``, where ``1`` marks
+        tokens that belong to an assistant turn (content + closing tokens).
+
+    Raises:
+        ValueError: If the chat template is not incrementally renderable
+            (rendering ``chat[:i]`` is not a prefix of rendering ``chat[:i + 1]``,
+            or of ``full_ids``).
+    """
+    mask = [0] * len(full_ids)
+    full_ids_list = list(full_ids)
+
+    for i, msg in enumerate(chat):
+        if msg.get("role") != "assistant":
+            continue
+
+        prefix_ids = list(
+            tokenizer.apply_chat_template(
+                chat[:i],
+                tools=tools,
+                tokenize=True,
+                add_generation_prompt=True,
+            )
+        )
+        with_assistant_ids = list(
+            tokenizer.apply_chat_template(
+                chat[: i + 1],
+                tools=tools,
+                tokenize=True,
+            )
+        )
+
+        prefix_len = len(prefix_ids)
+        end = len(with_assistant_ids)
+
+        # The chat template must be incrementally renderable: rendering with one more
+        # message is required to extend the previous rendering, and the full rendering
+        # must agree with the intermediate one up to `end`.
+        if (
+            end <= prefix_len
+            or with_assistant_ids[:prefix_len] != prefix_ids
+            or full_ids_list[:end] != with_assistant_ids
+        ):
+            raise ValueError(
+                "Chat template is not incrementally renderable, so an assistant-only loss "
+                "mask cannot be derived without a `{% generation %}` block. Patch the "
+                "chat_template to wrap assistant content with "
+                "`{% generation %}...{% endgeneration %}`, or use the legacy special-tokens "
+                "preprocessing path (`use_hf_tokenizer_chat_template=False`)."
+            )
+
+        for j in range(prefix_len, min(end, len(mask))):
+            mask[j] = 1
+
+    return mask
+
+
 def _chat_preprocess(source: dict, tokenizer: MegatronTokenizer, tool_schemas: Optional[list[Any]] = None) -> dict:
     """
     Preprocess messages to apply chat template and tokenize. Returns a dictionary of tokens.
@@ -931,32 +1026,32 @@ def _chat_preprocess(source: dict, tokenizer: MegatronTokenizer, tool_schemas: O
     if getattr(tokenizer, "legacy", False):
         tokenizer = tokenizer._tokenizer
 
-    # assistant mask only works if chat template has generation keyword
+    # The fast path uses HF's native return_assistant_tokens_mask, which only works when
+    # the chat_template explicitly marks assistant content with {% generation %} blocks.
+    # Many widely used tokenizers (e.g. Nemotron-3-Nano, older Llama variants) ship templates
+    # without those markers; for those we derive the mask by re-rendering message prefixes
+    # so loss is still computed only on assistant tokens. See _derive_assistant_mask_via_prefix_diff.
     template_has_generation_kwd = GENERATION_REGEX.search(tokenizer.chat_template) is not None
 
-    if not template_has_generation_kwd:
-        raise ValueError(
-            "The tokenizer's chat_template does not contain a {% generation %} block, which is required "
-            "for HF's apply_chat_template to produce assistant-only loss masks via "
-            "return_assistant_tokens_mask=True. Without it, the loss mask would silently fall back to "
-            "all-ones (loss computed on the entire conversation including system/user tokens). "
-            "To fix this, either: (1) patch the chat_template to wrap assistant content with "
-            "{% generation %}...{% endgeneration %}, or (2) use the legacy special-tokens preprocessing "
-            "path instead of use_hf_tokenizer_chat_template=True."
+    if template_has_generation_kwd:
+        tokenized_chat = tokenizer.apply_chat_template(
+            chat,
+            tools=tools,
+            tokenize=True,
+            return_dict=True,
+            return_assistant_tokens_mask=True,
         )
-
-    tokenized_chat = tokenizer.apply_chat_template(
-        chat,
-        tools=tools,
-        tokenize=True,
-        return_dict=True,
-        return_assistant_tokens_mask=True,
-    )
-
-    # Choose the last conversation as answer other history are context by finding the last masked token
-    # which indicates end of context and beginning of answer
-    input_ids = tokenized_chat.get("input_ids")
-    mask = tokenized_chat["assistant_masks"]
+        input_ids = tokenized_chat.get("input_ids")
+        mask = tokenized_chat["assistant_masks"]
+    else:
+        tokenized_chat = tokenizer.apply_chat_template(
+            chat,
+            tools=tools,
+            tokenize=True,
+            return_dict=True,
+        )
+        input_ids = tokenized_chat.get("input_ids")
+        mask = _derive_assistant_mask_via_prefix_diff(chat, tokenizer, tools, input_ids)
 
     if 0 in mask:
         # traverse the list backward for first occurrence of masked token

--- a/tests/unit_tests/data/datasets/test_chat_template.py
+++ b/tests/unit_tests/data/datasets/test_chat_template.py
@@ -21,7 +21,11 @@ import pytest
 import torch
 
 from megatron.bridge.data.datasets.sft import GPTSFTChatDataset, GPTSFTPackedDataset, create_sft_dataset
-from megatron.bridge.data.datasets.utils import _chat_preprocess, _convert_to_openai_messages
+from megatron.bridge.data.datasets.utils import (
+    _chat_preprocess,
+    _convert_to_openai_messages,
+    _derive_assistant_mask_via_prefix_diff,
+)
 
 
 class TestConvertToOpenAIMessages:
@@ -129,21 +133,53 @@ class TestChatPreprocess:
         # Verify apply_chat_template was called
         mock_hf_tokenizer.apply_chat_template.assert_called_once()
 
-    def test_chat_preprocess_without_generation_keyword(self):
-        """Test chat preprocessing raises when template lacks generation keyword."""
+    def test_chat_preprocess_without_generation_keyword_uses_prefix_diff_fallback(self):
+        """When the template lacks `{% generation %}`, the mask is derived via prefix diff.
+
+        Regression for issue #2598: previously this path produced a silent all-ones mask
+        (now: derive the assistant mask by re-rendering message prefixes so SFT loss is
+        still computed only on assistant tokens for tokenizers like Nemotron-3-Nano).
+        """
         mock_tokenizer = MagicMock()
         mock_hf_tokenizer = MagicMock()
         mock_tokenizer = mock_hf_tokenizer
         mock_tokenizer.eos_id = 2
         mock_tokenizer.legacy = False
 
-        # Chat template without generation keyword
+        # Template without {% generation %} marker.
         mock_hf_tokenizer.chat_template = "{{ messages }}"
 
-        source = {"conversations": [{"from": "User", "value": "Test"}]}
+        # Simulated tokenizer output that is incrementally renderable:
+        #   chat[:1] + add_generation_prompt -> [10, 20]                  (user + assistant header)
+        #   chat[:2]                          -> [10, 20, 30, 40, 50]     (+ assistant content + eos)
+        def fake_apply(messages, *, tools=None, tokenize=True, return_dict=False, add_generation_prompt=False, **_):
+            if len(messages) == 0:
+                ids = []
+            elif len(messages) == 1 and add_generation_prompt:
+                ids = [10, 20]
+            elif len(messages) == 2:
+                ids = [10, 20, 30, 40, 50]
+            else:
+                raise AssertionError(f"unexpected call: messages={messages}, add_gen={add_generation_prompt}")
+            return {"input_ids": ids} if return_dict else ids
 
-        with pytest.raises(ValueError, match="does not contain a .* generation .* block"):
-            _chat_preprocess(source, mock_tokenizer)
+        mock_hf_tokenizer.apply_chat_template.side_effect = fake_apply
+
+        source = {
+            "conversations": [
+                {"from": "User", "value": "Hi"},
+                {"from": "Assistant", "value": "Hello"},
+            ]
+        }
+
+        result = _chat_preprocess(source, mock_tokenizer)
+
+        assert result["input_ids"].tolist() == [10, 20, 30, 40, 50]
+        # Only the assistant content + closing tokens (indices 2..5) are unmasked.
+        assert result["loss_mask"].tolist() == [False, False, True, True, True]
+        # Context ends at the last masked-out token; answer is the assistant span.
+        assert result["context_ids"].tolist() == [10, 20]
+        assert result["answer_ids"].tolist() == [30, 40, 50]
 
     def test_chat_preprocess_trusts_template_eos(self):
         """Test that _chat_preprocess does not append eos_id when template uses a different end token."""
@@ -198,6 +234,181 @@ class TestChatPreprocess:
 
         with pytest.raises(ValueError, match="Cannot apply chat template"):
             _chat_preprocess(source, mock_tokenizer)
+
+
+class _IncrementalTokenizer:
+    """Minimal stand-in for an HF tokenizer used by _derive_assistant_mask_via_prefix_diff.
+
+    Mimics a ChatML-shaped template:
+
+    * Every assistant message renders as ``[ASSISTANT_HEADER, *content, CLOSE]`` — the
+      role-marker tokens are part of the message itself, exactly like real templates emit
+      ``<|im_start|>assistant\\n`` before the assistant's text.
+    * Non-assistant messages render as ``[*content, CLOSE]``.
+    * ``add_generation_prompt=True`` appends ``ASSISTANT_HEADER`` at the end.
+
+    This shape guarantees that ``apply_chat_template(chat[:i], add_generation_prompt=True)``
+    is a true prefix of ``apply_chat_template(chat[:i + 1])`` whenever ``chat[i]`` is an
+    assistant message — the property the prefix-diff algorithm relies on.
+    """
+
+    # Assistant role-marker tokens (e.g. ``<|im_start|>assistant\n`` in a real tokenizer).
+    ASSISTANT_HEADER: list[int] = [777]
+    # Closing tokens appended after each message (e.g. ``<|im_end|>\n``).
+    CLOSE: list[int] = [999]
+
+    def __init__(self, content_ids_by_index: list[list[int]]):
+        self._content = content_ids_by_index
+
+    def apply_chat_template(
+        self,
+        messages,
+        *,
+        tools=None,
+        tokenize=True,
+        return_dict=False,
+        add_generation_prompt=False,
+        **_,
+    ):
+        ids: list[int] = []
+        for i, msg in enumerate(messages):
+            if msg.get("role") == "assistant":
+                ids.extend(self.ASSISTANT_HEADER)
+            ids.extend(self._content[i])
+            ids.extend(self.CLOSE)
+        if add_generation_prompt:
+            ids.extend(self.ASSISTANT_HEADER)
+        return {"input_ids": ids} if return_dict else ids
+
+
+class TestDeriveAssistantMaskViaPrefixDiff:
+    """Direct unit coverage for the prefix-diff fallback (issue #2598)."""
+
+    def test_single_turn_marks_only_assistant(self):
+        chat = [
+            {"role": "user", "content": "u"},
+            {"role": "assistant", "content": "a"},
+        ]
+        # content per message: user=[1, 2], assistant=[3, 4, 5]
+        tok = _IncrementalTokenizer([[1, 2], [3, 4, 5]])
+        full = tok.apply_chat_template(chat)
+
+        mask = _derive_assistant_mask_via_prefix_diff(chat, tok, tools=None, full_ids=full)
+
+        # Full rendering:   [1, 2, 999, 777, 3, 4, 5, 999] — len 8
+        # Prefix (add_gen): [1, 2, 999, 777]               — len 4 (user content + close + asst header)
+        # mask[4:8] = 1 → the assistant content + closing turn token.
+        assert full == [1, 2, 999, 777, 3, 4, 5, 999]
+        assert mask == [0, 0, 0, 0, 1, 1, 1, 1]
+
+    def test_multi_turn_marks_each_assistant_span(self):
+        chat = [
+            {"role": "user", "content": "u1"},
+            {"role": "assistant", "content": "a1"},
+            {"role": "user", "content": "u2"},
+            {"role": "assistant", "content": "a2"},
+        ]
+        tok = _IncrementalTokenizer([[1], [2], [3], [4]])
+        full = tok.apply_chat_template(chat)
+
+        mask = _derive_assistant_mask_via_prefix_diff(chat, tok, tools=None, full_ids=full)
+
+        # Indexing (close=999, asst_header=777):
+        #   [1, 999, 777, 2, 999, 3, 999, 777, 4, 999]
+        #    0   1    2   3   4   5   6    7   8   9
+        # First assistant span: indices 3..5 (content + close).
+        # Second assistant span: indices 8..10.
+        assert mask == [0, 0, 0, 1, 1, 0, 0, 0, 1, 1]
+
+    def test_system_prompt_is_never_marked(self):
+        chat = [
+            {"role": "system", "content": "s"},
+            {"role": "user", "content": "u"},
+            {"role": "assistant", "content": "a"},
+        ]
+        tok = _IncrementalTokenizer([[1], [2], [3]])
+        full = tok.apply_chat_template(chat)
+
+        mask = _derive_assistant_mask_via_prefix_diff(chat, tok, tools=None, full_ids=full)
+
+        # Render: [1, 999, 2, 999, 777, 3, 999] — assistant span = indices 5..7.
+        assert mask == [0, 0, 0, 0, 0, 1, 1]
+
+    def test_tool_message_between_assistants_is_not_marked(self):
+        chat = [
+            {"role": "user", "content": "u"},
+            {"role": "assistant", "content": "call"},
+            {"role": "tool", "content": "result"},
+            {"role": "assistant", "content": "ans"},
+        ]
+        tok = _IncrementalTokenizer([[1], [2], [3], [4]])
+        full = tok.apply_chat_template(chat)
+
+        mask = _derive_assistant_mask_via_prefix_diff(chat, tok, tools=None, full_ids=full)
+
+        # Render: [1, 999, 777, 2, 999, 3, 999, 777, 4, 999]
+        #          0   1    2   3   4   5   6    7   8   9
+        # Tool message (index 2 in `chat`) is treated like any non-assistant turn — its
+        # tokens (5, 6) are masked out. Both assistant spans are unmasked, and the
+        # assistant header tokens (indices 2 and 7) live in the respective prefixes so
+        # they stay masked. Result is the same shape as a plain multi-turn alternation.
+        assert full == [1, 999, 777, 2, 999, 3, 999, 777, 4, 999]
+        assert mask == [0, 0, 0, 1, 1, 0, 0, 0, 1, 1]
+
+    def test_non_incremental_template_raises(self):
+        chat = [
+            {"role": "user", "content": "u"},
+            {"role": "assistant", "content": "a"},
+        ]
+
+        # Pathological tokenizer: rendering chat[:1] returns ids that are NOT a prefix of
+        # rendering chat[:2]. Simulates templates that emit running summaries / re-order.
+        class BadTokenizer:
+            def apply_chat_template(self, messages, *, tools=None, tokenize=True, return_dict=False, add_generation_prompt=False, **_):
+                if len(messages) == 0:
+                    ids = []
+                elif len(messages) == 1:
+                    ids = [100, 200, 300]  # bogus prefix not contained in full
+                else:
+                    ids = [1, 2, 3, 4, 5]
+                return {"input_ids": ids} if return_dict else ids
+
+        bad = BadTokenizer()
+        full = bad.apply_chat_template(chat)
+
+        with pytest.raises(ValueError, match="not incrementally renderable"):
+            _derive_assistant_mask_via_prefix_diff(chat, bad, tools=None, full_ids=full)
+
+    def test_no_assistant_messages_returns_zero_mask(self):
+        chat = [{"role": "user", "content": "u"}]
+        tok = _IncrementalTokenizer([[1]])
+        full = tok.apply_chat_template(chat)
+
+        mask = _derive_assistant_mask_via_prefix_diff(chat, tok, tools=None, full_ids=full)
+
+        assert mask == [0] * len(full)
+
+    def test_tools_are_forwarded_to_template(self):
+        chat = [
+            {"role": "user", "content": "u"},
+            {"role": "assistant", "content": "a"},
+        ]
+        seen_tools = []
+
+        class ToolCapturingTokenizer(_IncrementalTokenizer):
+            def apply_chat_template(self, messages, *, tools=None, **kwargs):
+                seen_tools.append(tools)
+                return super().apply_chat_template(messages, tools=tools, **kwargs)
+
+        tok = ToolCapturingTokenizer([[1], [2]])
+        full = tok.apply_chat_template(chat, tools=None)
+        tool_schemas = [{"type": "function", "function": {"name": "f"}}]
+        _derive_assistant_mask_via_prefix_diff(chat, tok, tools=tool_schemas, full_ids=full)
+
+        # The helper makes two extra calls (prefix + with_assistant) per assistant turn,
+        # both must receive the tool schemas.
+        assert seen_tools[-1] == tool_schemas
+        assert seen_tools[-2] == tool_schemas
 
 
 class TestGPTSFTChatDataset:


### PR DESCRIPTION
## Summary

Restores a working SFT path for tokenizers whose chat_template does not
mark assistant content with `{% generation %}...{% endgeneration %}`
(e.g. **Nemotron-3-Nano**, several Llama variants).

Closes #2598.

## Context

`apply_chat_template(return_assistant_tokens_mask=True)` only produces a
useful mask when the template wraps assistant content in `{% generation %}`
blocks. Without them, the HF API silently returns an all-ones mask — SFT
would then learn on system, user, and tool tokens, which is wrong.

Prior behavior: `_chat_preprocess` raised a hard `ValueError` for these
tokenizers (correct but leaves users blocked).

This PR: derives the assistant-only mask via incremental prefix rendering,
so affected tokenizers train correctly with no template changes required.

## Approach

For each assistant message at index `i`:

1. Render `chat[:i]` with `add_generation_prompt=True` — ends with the
   assistant-header tokens (e.g. `<|im_start|>assistant\n`).
2. Render `chat[:i + 1]` — same prefix plus assistant content + closing
   tokens (e.g. `<|im_end|>`).
3. Mark `mask[len(prefix) : len(with_assistant)] = 1`.

Role-header tokens stay in the prefix (correctly masked out); the closing
turn token is included in the loss, matching the convention HF uses for
`{% generation %}`-aware templates.

Templates that are not incrementally renderable (e.g. running-summary
templates) cannot be handled this way — the helper raises a clear
`ValueError` instead of producing a wrong mask, so the caller can still
fix the template upstream.

## Files changed

- `src/megatron/bridge/data/datasets/utils.py`
  - New helper: `_derive_assistant_mask_via_prefix_diff(chat, tokenizer, tools, full_ids) -> list[int]`.
  - `_chat_preprocess` branches on `template_has_generation_kwd`: fast
    path uses the native HF mask; fallback uses the new helper.
- `tests/unit_tests/data/datasets/test_chat_template.py`
  - New `TestDeriveAssistantMaskViaPrefixDiff` class — 7 tests:
    - single-turn marks only the assistant span
    - multi-turn marks each assistant span independently
    - system prompt is never marked
    - tool message between assistant turns is not marked
    - non-incremental template raises `ValueError`
    - no assistant messages → all-zero mask
    - tool schemas are forwarded to `apply_chat_template`
  - `test_chat_preprocess_without_generation_keyword_uses_prefix_diff_fallback`
    replaces the prior ValueError-only test with an integration check on
    `input_ids` / `loss_mask` / `context_ids` / `answer_ids`.

## Test plan

- [x] New unit tests pass under hand-traced execution of the helper.
- [x] Existing `{% generation %}` fast-path tests untouched (no behavior
      change on that branch).
- [x] Syntax + py_compile on edited files.
- [ ] CI: please run on NVIDIA runners (`/ok to test <commit-SHA>`).