### PR TITLE
fix: clean config-only export cache metadata

### DIFF
--- a/src/megatron/bridge/models/conversion/auto_bridge.py
+++ b/src/megatron/bridge/models/conversion/auto_bridge.py
@@ -44,6 +44,7 @@ from megatron.bridge.models.conversion.model_bridge import (
 )
 from megatron.bridge.models.conversion.utils import get_causal_lm_class_name_via_auto_map
 from megatron.bridge.models.gpt_provider import GPTModelProvider
+from megatron.bridge.models.hf_pretrained.base import PreTrainedBase
 from megatron.bridge.models.hf_pretrained.causal_lm import PreTrainedCausalLM, _ConfigOnlyPretrainedShim
 from megatron.bridge.models.hf_pretrained.safe_config_loader import safe_load_config_with_retry
 from megatron.bridge.models.hf_pretrained.state import SafeTensorsStateSource
@@ -732,6 +733,8 @@ class AutoBridge(Generic[MegatronModelT]):
                             hub_repo,
                             exc,
                         )
+                    finally:
+                        PreTrainedBase._cleanup_hf_local_dir_cache(Path(path))
 
             else:
                 # Get bridge-level ADDITIONAL_FILE_PATTERNS if configured

--- a/tests/unit_tests/models/test_auto_bridge.py
+++ b/tests/unit_tests/models/test_auto_bridge.py
@@ -17,6 +17,7 @@ Unit tests for AutoBridge automatic bridge selection and bridge functionality.
 """
 
 import json
+from pathlib import Path
 from unittest.mock import Mock, PropertyMock, patch
 
 import pytest
@@ -698,9 +699,17 @@ class TestAutoBridge:
         bridge.hf_model_id = "some-org/some-model"
         bridge.trust_remote_code = True
 
+        def fake_hf_hub_download(repo_id, filename, local_dir):
+            del repo_id
+            local_dir = Path(local_dir)
+            (local_dir / filename).write_text("# custom modeling code")
+            metadata_dir = local_dir / ".cache" / "huggingface" / "download"
+            metadata_dir.mkdir(parents=True)
+            (metadata_dir / f"{filename}.metadata").write_text("metadata")
+
         with patch.object(AutoBridge, "save_hf_weights"):
             with patch("huggingface_hub.list_repo_files", return_value=["modeling_custom.py", "README.md"]):
-                with patch("huggingface_hub.hf_hub_download") as mock_download:
+                with patch("huggingface_hub.hf_hub_download", side_effect=fake_hf_hub_download) as mock_download:
                     bridge.save_hf_pretrained([Mock()], str(tmp_path))
 
         saved_config = json.loads((tmp_path / "config.json").read_text())
@@ -708,6 +717,8 @@ class TestAutoBridge:
             "AutoConfig": "configuration_custom.CustomConfig",
             "AutoModelForCausalLM": "modeling_custom.CustomForCausalLM",
         }
+        assert (tmp_path / "modeling_custom.py").exists()
+        assert not (tmp_path / ".cache").exists()
         mock_download.assert_called_once_with(
             repo_id="some-org/some-model",
             filename="modeling_custom.py",


### PR DESCRIPTION
Follow-up to https://github.com/NVIDIA-NeMo/Megatron-Bridge/pull/3924, which removed stale remote-code metadata from HF exports and added cleanup for Hugging Face Hub `local_dir` metadata.

This extends the same `.cache/huggingface/` cleanup to the config-only export path, where remote-code files are downloaded directly with `hf_hub_download(...)`. The added unit test verifies that downloaded Python files remain while Hub metadata is removed from the exported model directory.
