### PR TITLE
[docs] docs: Add model variant pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ Megatron Bridge provides out-of-the-box bridges and training recipes for a wide 
 | [**OLMoE**](docs/models/olmoe/index.md) | OLMoE |
 | [**Qwen**](docs/models/qwen/index.md) | Qwen2 / Qwen2.5, Qwen3, Qwen3-MoE, Qwen3 Next, Qwen2.5-VL, Qwen3-VL, Qwen3.5-VL, Qwen3.6-VL, Qwen2 Audio, Qwen2.5-Omni, Qwen3-Omni, Qwen3-ASR |
 | [**Sarvam**](docs/models/sarvam/index.md) | Sarvam |
+| [**StepFun**](docs/models/stepfun/index.md) | Step-3.5-Flash |
 
 ### Launching Recipes
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,6 +50,7 @@ models/nemotron/index.md
 models/olmoe/index.md
 models/qwen/index.md
 models/sarvam/index.md
+models/stepfun/index.md
 ```
 
 ```{toctree}

--- a/docs/models/README.md
+++ b/docs/models/README.md
@@ -8,22 +8,23 @@ Megatron Bridge conversion, training recipe links, and model-specific notes.
 
 | Family | Model documentation |
 |----------------|---------------------|
-| **Bailing** | [Bailing](bailing/index.md) |
+| **Bailing** | [Ling 2.0](bailing/ling-2.md) |
 | **DeepSeek** | [DeepSeek V2](deepseek/deepseek-v2.md), [DeepSeek V3](deepseek/deepseek-v3.md), [DeepSeek V4](deepseek/deepseek-v4.md) |
-| **Falcon** | [Falcon](falcon/index.md) |
-| **Gemma** | [Gemma 2](gemma/gemma2.md), [Gemma 3](gemma/gemma3.md), [Gemma 3 VL](gemma/gemma3-vl.md), [Gemma 4 VL](gemma/gemma4-vl.md) |
-| **GLM** | [GLM 4.5](glm/glm45.md), [GLM-4.5V](glm/glm-45v.md) |
+| **Falcon** | [Falcon H1](falcon/falcon-h1.md) |
+| **Gemma** | [Gemma](gemma/gemma.md), [Gemma 2](gemma/gemma2.md), [Gemma 3](gemma/gemma3.md), [Gemma 3 VL](gemma/gemma3-vl.md), [Gemma 4 VL](gemma/gemma4-vl.md) |
+| **GLM** | [GLM 4.5](glm/glm45.md), [GLM-4.5V](glm/glm-45v.md), [GLM-4.7 / 4.7-Flash](glm/glm47.md), [GLM-5 / 5.1](glm/glm5.md) |
 | **GPT-OSS** | [GPT OSS](gpt_oss/gpt-oss.md) |
-| **Kimi** | [Kimi](kimi/index.md) |
-| **Llama** | [Llama 3](llama/llama3.md) |
-| **MiniMax** | [MiniMax](minimax/index.md) |
+| **Kimi** | [Kimi K2](kimi/kimi-k2.md), [Kimi-K2.5-VL](kimi/kimi-k25-vl.md) |
+| **Llama** | [Llama 2](llama/llama2.md), [Llama 3](llama/llama3.md) |
+| **MiniMax** | [MiniMax-M2 / M2.5 / M2.7](minimax/minimax-m2.md) |
 | **Mistral** | [Mistral](mistral/mistral.md), [Ministral 3](mistral/ministral3.md) |
-| **Xiaomi-MiMo** | [Xiaomi-MiMo](mimo/index.md) |
+| **Xiaomi-MiMo** | [Xiaomi-MiMo](mimo/mimo.md) |
 | **Moonlight** | [Moonlight](moonlight/moonlight.md) |
 | **Nemotron** | [Llama Nemotron](nemotron/llama-nemotron.md), [Nemotron H and Nemotron Nano v2](nemotron/nemotronh.md), [Nemotron-3 Nano](nemotron/nemotron3-nano.md), [Nemotron-3 Super](nemotron/nemotron3-super.md), [Nemotron Nano V2 VL](nemotron/nemotron-nano-v2-vl.md), [Nemotron-3 Nano Omni](nemotron/nemotron-3-omni.md) |
 | **OLMoE** | [OLMoE](olmoe/olmoe.md) |
-| **Qwen** | [Qwen](qwen/qwen.md), [Qwen2.5-VL](qwen/qwen2.5-vl.md), [Qwen3-VL](qwen/qwen3-vl.md), [Qwen3.5 / 3.6](qwen/qwen35-vl.md), [Qwen3-Omni](qwen/qwen3-omni.md) |
-| **Sarvam** | [Sarvam](sarvam/index.md) |
+| **Qwen** | [Qwen](qwen/qwen.md), [Qwen3-MoE](qwen/qwen3-moe.md), [Qwen3-Next](qwen/qwen3-next.md), [Qwen2.5-VL](qwen/qwen2.5-vl.md), [Qwen3-VL](qwen/qwen3-vl.md), [Qwen3.5 / 3.6](qwen/qwen35-vl.md), [Qwen2-Audio](qwen/qwen2-audio.md), [Qwen2.5-Omni](qwen/qwen25-omni.md), [Qwen3-Omni](qwen/qwen3-omni.md), [Qwen3-ASR](qwen/qwen3-asr.md) |
+| **Sarvam** | [Sarvam](sarvam/sarvam.md) |
+| **StepFun** | [Step-3.5-Flash](stepfun/step35.md) |
 
 ## Quick Navigation
 
@@ -57,7 +58,7 @@ Each model documentation page typically includes:
 
 ### Decoder-Only and Hybrid Backbones
 
-- Bailing, DeepSeek, Falcon, Gemma, GLM, GPT-OSS, Kimi, Llama, MiniMax, Mistral, Moonlight, Nemotron, OLMoE, Qwen, Sarvam, and Xiaomi-MiMo
+- Bailing, DeepSeek, Falcon, Gemma, GLM, GPT-OSS, Kimi, Llama, MiniMax, Mistral, Moonlight, Nemotron, OLMoE, Qwen, Sarvam, StepFun, and Xiaomi-MiMo
 - MoE and hybrid variants including Bailing, DeepSeek, GLM, GPT-OSS, MiniMax, Nemotron-3, OLMoE, Qwen3-MoE, Qwen3-Next, and Sarvam
 
 ### Multimodal Variants
@@ -67,7 +68,7 @@ Each model documentation page typically includes:
 - Kimi-K2.5-VL
 - Ministral 3
 - Nemotron Nano V2 VL and Nemotron-3 Nano Omni
-- Qwen2.5-VL, Qwen3-VL, Qwen3.5 / 3.6, and Qwen3-Omni
+- Qwen2-Audio, Qwen2.5-VL, Qwen2.5-Omni, Qwen3-VL, Qwen3.5 / 3.6, Qwen3-Omni, and Qwen3-ASR
 
 ## Related Documentation
 

--- a/docs/models/bailing/index.md
+++ b/docs/models/bailing/index.md
@@ -1,15 +1,13 @@
 # Bailing
 
-Bailing model support covers Ling 2.0 (Bailing) models through the Bridge system with auto-detected configuration and weight mapping.
+Bailing model documentation is organized by model variant.
 
-## Supported Variants
+```{toctree}
+:hidden:
 
-- Ling 2.0 (Bailing)
+ling-2.md
+```
 
-## Examples
-
-For checkpoint conversion and inference commands, see the [Bailing examples README](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/examples/models/bailing/README.md).
-
-## Implementation
-
-- Model bridge: [`src/megatron/bridge/models/bailing`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/src/megatron/bridge/models/bailing)
+| Variant | Guide |
+|---------|-------|
+| Ling 2.0 | [ling-2.md](ling-2.md) |

--- a/docs/models/bailing/ling-2.md
+++ b/docs/models/bailing/ling-2.md
@@ -1,0 +1,28 @@
+# Ling 2.0
+
+[Ling 2.0](https://github.com/inclusionAI/Ling-V2), documented in this repository under the Bailing family, is a high-sparsity Mixture-of-Experts language model family from inclusionAI. Megatron Bridge supports the Ling 2.0 MoE checkpoints through the Bailing bridge with auto-detected Hugging Face configuration and weight mapping.
+
+## Supported Variants
+
+| Variant | Hugging Face ID | Notes |
+|---------|-----------------|-------|
+| Ling-flash-2.0 | `inclusionAI/Ling-flash-2.0` | 100B total, 6.1B active |
+| Ling-flash-base-2.0 | `inclusionAI/Ling-flash-base-2.0` | Base checkpoint, 100B total, 6.1B active |
+| Ling-mini-2.0 | `inclusionAI/Ling-mini-2.0` | 16B total, 1.5B active |
+| Ling-mini-base-2.0 | `inclusionAI/Ling-mini-base-2.0` | Base checkpoint, 16B total, 1.5B active |
+
+## Architecture Notes
+
+- High-sparsity MoE with 256 routed experts and top-8 routing.
+- Sigmoid routing with QK-Norm and Half RoPE.
+- Custom Hugging Face model code is required, so conversion and inference commands use `--trust-remote-code`.
+
+## Examples
+
+For checkpoint import/export, round-trip validation, and inference commands, see the [Bailing examples README](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/examples/models/bailing/README.md).
+
+## Related Implementation
+
+- Bridge implementation: [`src/megatron/bridge/models/bailing`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/src/megatron/bridge/models/bailing)
+- Examples: [`examples/models/bailing`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/examples/models/bailing)
+

--- a/docs/models/falcon/falcon-h1.md
+++ b/docs/models/falcon/falcon-h1.md
@@ -1,0 +1,28 @@
+# Falcon H1
+
+[Falcon H1](https://huggingface.co/tiiuae/Falcon-H1-0.5B-Instruct) is a hybrid language model family that combines Mamba, attention, and MLP blocks in each decoder layer. Megatron Bridge supports Falcon H1 through a custom provider and model implementation.
+
+## Supported Variants
+
+The public examples target the smallest instruction checkpoint:
+
+- Falcon-H1-0.5B-Instruct: https://huggingface.co/tiiuae/Falcon-H1-0.5B-Instruct
+
+The bridge is registered for the `FalconH1ForCausalLM` architecture and can auto-detect compatible Falcon H1 checkpoints when their Hugging Face config uses the `falcon_h1` model type.
+
+## Architecture Notes
+
+- Uses a custom `FalconH1ModelProvider` and `FalconH1Model`.
+- Each decoder block is represented as a parallel Mamba, attention, and MLP layer.
+- The bridge maps Mamba input projections, convolution weights, state-space parameters, QKV projections, and gated MLP weights.
+- Falcon H1 checkpoints use custom Hugging Face code; examples pass `--trust-remote-code`.
+
+## Examples
+
+For checkpoint conversion, tokenizer asset export, round-trip validation, and inference, see the [Falcon H1 examples README](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/examples/models/falcon_h1/README.md).
+
+## Related Implementation
+
+- Bridge implementation: [`src/megatron/bridge/models/falcon_h1`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/src/megatron/bridge/models/falcon_h1)
+- Examples: [`examples/models/falcon_h1`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/examples/models/falcon_h1)
+

--- a/docs/models/falcon/index.md
+++ b/docs/models/falcon/index.md
@@ -1,15 +1,13 @@
 # Falcon
 
-Falcon model support covers Falcon H1 through the Bridge system with auto-detected configuration and weight mapping.
+Falcon model documentation is organized by model variant.
 
-## Supported Variants
+```{toctree}
+:hidden:
 
-- Falcon H1
+falcon-h1.md
+```
 
-## Examples
-
-For checkpoint conversion and inference commands, see the [Falcon H1 examples README](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/examples/models/falcon_h1/README.md).
-
-## Implementation
-
-- Model bridge: [`src/megatron/bridge/models/falcon_h1`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/src/megatron/bridge/models/falcon_h1)
+| Variant | Guide |
+|---------|-------|
+| Falcon H1 | [falcon-h1.md](falcon-h1.md) |

--- a/docs/models/gemma/gemma.md
+++ b/docs/models/gemma/gemma.md
@@ -1,0 +1,41 @@
+# Gemma
+
+[Gemma](https://huggingface.co/collections/google/gemma-release-65d5efbccdbb8c4202ec078b) is Google's original lightweight open model family. Megatron Bridge supports Gemma causal language models through the `GemmaBridge` implementation for the Hugging Face `GemmaForCausalLM` architecture.
+
+## Supported Variants
+
+Megatron Bridge supports Hugging Face Gemma checkpoints that use the `gemma` model type, including:
+
+- Gemma 2B: https://huggingface.co/google/gemma-2b
+- Gemma 7B: https://huggingface.co/google/gemma-7b
+- Gemma release collection: https://huggingface.co/collections/google/gemma-release-65d5efbccdbb8c4202ec078b
+
+## Architecture Notes
+
+- RMSNorm with zero-centered gamma.
+- GeGLU-style gated MLPs.
+- RoPE positional embeddings and flash attention backend.
+- Shared input/output embedding weights.
+
+## Examples
+
+Gemma uses the common conversion and generation entry points:
+
+```bash
+uv run python examples/conversion/convert_checkpoints.py import \
+  --hf-model google/gemma-2b \
+  --megatron-path /checkpoints/gemma_2b_megatron
+```
+
+```bash
+uv run python examples/conversion/hf_to_megatron_generate_text.py \
+  --hf_model_path google/gemma-2b \
+  --megatron_model_path /checkpoints/gemma_2b_megatron \
+  --prompt "What is artificial intelligence?"
+```
+
+## Related Implementation
+
+- Bridge implementation: [`src/megatron/bridge/models/gemma/gemma_bridge.py`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/src/megatron/bridge/models/gemma/gemma_bridge.py)
+- Conversion examples: [`examples/conversion`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/examples/conversion)
+

--- a/docs/models/gemma/index.md
+++ b/docs/models/gemma/index.md
@@ -5,6 +5,7 @@ Gemma model documentation is organized by model variant.
 ```{toctree}
 :hidden:
 
+gemma.md
 gemma2.md
 gemma3.md
 gemma3-vl.md
@@ -13,6 +14,7 @@ gemma4-vl.md
 
 | Variant | Guide |
 |---------|-------|
+| Gemma | [gemma.md](gemma.md) |
 | Gemma 2 | [gemma2.md](gemma2.md) |
 | Gemma 3 | [gemma3.md](gemma3.md) |
 | Gemma 3 VL | [gemma3-vl.md](gemma3-vl.md) |

--- a/docs/models/glm/glm47.md
+++ b/docs/models/glm/glm47.md
@@ -1,0 +1,28 @@
+# GLM-4.7 and GLM-4.7-Flash
+
+[GLM-4.7](https://huggingface.co/zai-org/GLM-4.7) and [GLM-4.7-Flash](https://huggingface.co/zai-org/GLM-4.7-Flash) are GLM MoE language models from Zhipu AI. Megatron Bridge supports both checkpoints, with the full GLM-4.7 model handled by the GLM-4.5 bridge registration and the Flash variant handled by a dedicated GLM-4.7-Flash bridge.
+
+## Supported Variants
+
+| Variant | Hugging Face ID | Bridge | Notes |
+|---------|-----------------|--------|-------|
+| GLM-4.7 | `zai-org/GLM-4.7` | `GLM45Bridge` | Full MoE model, about 358B total parameters and 32B active |
+| GLM-4.7-Flash | `zai-org/GLM-4.7-Flash` | `GLM47FlashBridge` | MLA + MoE model, about 30B total parameters and 3B active |
+
+## Architecture Notes
+
+- GLM-4.7 uses the `glm4_moe` architecture already covered by `GLM45Bridge`.
+- GLM-4.7-Flash uses `glm4_moe_lite`, Multi-Latent Attention, GLM-style MoE routing, and expert-bias routing.
+- GLM-4.7-Flash stores per-expert gate/up/down tensors in Hugging Face checkpoint format; the bridge maps them into Megatron MoE tensors.
+- `transformers >= 5.0.0rc0` is required for the GLM-4.7 Hugging Face model classes used by these bridges.
+
+## Examples
+
+For checkpoint conversion, inference, hardware notes, and validated parallelism settings, see the [GLM-4.7 examples README](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/examples/models/glm47/README.md).
+
+## Related Implementation
+
+- GLM-4.7 bridge path: [`src/megatron/bridge/models/glm/glm45_bridge.py`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/src/megatron/bridge/models/glm/glm45_bridge.py)
+- GLM-4.7-Flash bridge path: [`src/megatron/bridge/models/glm/glm47_flash_bridge.py`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/src/megatron/bridge/models/glm/glm47_flash_bridge.py)
+- Examples: [`examples/models/glm47`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/examples/models/glm47)
+

--- a/docs/models/glm/glm5.md
+++ b/docs/models/glm/glm5.md
@@ -1,0 +1,29 @@
+# GLM-5 and GLM-5.1
+
+[GLM-5](https://huggingface.co/zai-org/GLM-5) and [GLM-5.1](https://huggingface.co/zai-org/GLM-5.1) are large sparse MoE language models with Multi-Latent Attention and Dynamic Sparse Attention. Megatron Bridge supports both checkpoints through the shared `GLM5Bridge`.
+
+## Supported Variants
+
+| Variant | Hugging Face ID | Notes |
+|---------|-----------------|-------|
+| GLM-5 | `zai-org/GLM-5` | MoE + MLA + DSA architecture |
+| GLM-5.1 | `zai-org/GLM-5.1` | Same architecture and mapping shape as GLM-5 |
+
+## Architecture Notes
+
+- `GlmMoeDsaForCausalLM` architecture with 78 transformer layers.
+- First 3 layers are dense; remaining layers use MoE.
+- 256 routed experts with top-8 routing and one shared expert per MoE layer.
+- Uses MLA plus DSA indexer parameters (`index_head_dim`, `index_n_heads`, `index_topk`).
+- Requires `transformers >= 5.2.0`.
+- DSA requires the `fast-hadamard-transform` CUDA extension and MCore support for the DSA experimental attention variant.
+
+## Examples
+
+For conversion, inference, dependency notes, hardware requirements, and MCore patch requirements, see the [GLM-5 examples README](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/examples/models/glm/glm5/README.md).
+
+## Related Implementation
+
+- Bridge implementation: [`src/megatron/bridge/models/glm_moe_dsa/glm5_bridge.py`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/src/megatron/bridge/models/glm_moe_dsa/glm5_bridge.py)
+- Examples: [`examples/models/glm/glm5`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/examples/models/glm/glm5)
+

--- a/docs/models/glm/index.md
+++ b/docs/models/glm/index.md
@@ -7,15 +7,13 @@ GLM model documentation is organized by model variant.
 
 glm45.md
 glm-45v.md
+glm47.md
+glm5.md
 ```
 
 | Variant | Guide |
 |---------|-------|
 | GLM 4.5 | [glm45.md](glm45.md) |
 | GLM-4.5V | [glm-45v.md](glm-45v.md) |
-
-## Examples
-
-- GLM-4.5V examples: [`examples/models/glm/glm_45v/README.md`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/examples/models/glm/glm_45v/README.md)
-- GLM-4.7 examples: [`examples/models/glm47/README.md`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/examples/models/glm47/README.md)
-- GLM-5 examples: [`examples/models/glm/glm5/README.md`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/examples/models/glm/glm5/README.md)
+| GLM-4.7 / 4.7-Flash | [glm47.md](glm47.md) |
+| GLM-5 / 5.1 | [glm5.md](glm5.md) |

--- a/docs/models/kimi/index.md
+++ b/docs/models/kimi/index.md
@@ -1,17 +1,15 @@
 # Kimi
 
-Kimi model support covers Kimi K2 language models and Kimi-K2.5-VL vision-language models through the Bridge system with auto-detected configuration and weight mapping.
+Kimi model documentation is organized by model variant.
 
-## Supported Variants
+```{toctree}
+:hidden:
 
-- Kimi K2
-- Kimi-K2.5-VL
+kimi-k2.md
+kimi-k25-vl.md
+```
 
-## Examples
-
-For Kimi-K2.5-VL checkpoint conversion, inference, and training commands, see the [Kimi-K2.5-VL examples README](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/examples/models/kimi/kimi_k25_vl/README.md).
-
-## Recipes
-
-- Kimi K2 recipe: [`src/megatron/bridge/recipes/kimi/kimi_k2.py`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/src/megatron/bridge/recipes/kimi/kimi_k2.py)
-- Kimi-K2.5-VL recipe: [`src/megatron/bridge/recipes/kimi_vl/kimi_k25_vl.py`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/src/megatron/bridge/recipes/kimi_vl/kimi_k25_vl.py)
+| Variant | Guide |
+|---------|-------|
+| Kimi K2 | [kimi-k2.md](kimi-k2.md) |
+| Kimi-K2.5-VL | [kimi-k25-vl.md](kimi-k25-vl.md) |

--- a/docs/models/kimi/kimi-k2.md
+++ b/docs/models/kimi/kimi-k2.md
@@ -1,0 +1,25 @@
+# Kimi K2
+
+[Kimi K2](https://huggingface.co/moonshotai/Kimi-K2) is a large sparse MoE language model from Moonshot AI. Megatron Bridge supports Kimi K2 through the `KimiK2Bridge`, which reuses the common MLA/MoE mapping pattern used by DeepSeek-style architectures.
+
+## Supported Variants
+
+Megatron Bridge supports Kimi K2 checkpoints with the `KimiK2ForCausalLM` architecture and `kimi_k2` model type, including:
+
+- Kimi-K2: https://huggingface.co/moonshotai/Kimi-K2
+
+## Architecture Notes
+
+- Multi-Latent Attention with QK layernorm.
+- Sparse MoE layers with grouped GEMM, all-to-all token dispatch, expert bias, and shared expert overlap.
+- RMSNorm, gated MLPs, RoPE, and unshared input/output embeddings.
+- Vocab size is padded to a multiple of 1280 for Megatron execution.
+
+## Recipes
+
+Kimi K2 recipes live in [`src/megatron/bridge/recipes/kimi/kimi_k2.py`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/src/megatron/bridge/recipes/kimi/kimi_k2.py).
+
+## Related Implementation
+
+- Bridge implementation: [`src/megatron/bridge/models/kimi/kimi_bridge.py`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/src/megatron/bridge/models/kimi/kimi_bridge.py)
+

--- a/docs/models/kimi/kimi-k25-vl.md
+++ b/docs/models/kimi/kimi-k25-vl.md
@@ -1,0 +1,25 @@
+# Kimi-K2.5-VL
+
+[Kimi-K2.5-VL](https://huggingface.co/moonshotai/Kimi-K2.5) is a Moonshot AI vision-language model with a Kimi K2-style MoE + MLA language backbone and a vision encoder. Megatron Bridge supports it through a dedicated VLM bridge and provider.
+
+## Supported Variants
+
+- Kimi-K2.5: https://huggingface.co/moonshotai/Kimi-K2.5
+
+## Architecture Notes
+
+- Uses `KimiK25ForConditionalGeneration` on the Hugging Face side and `KimiK25VLModel` on the Megatron side.
+- The language backbone shares Kimi K2's MoE + MLA structure.
+- The bridge carries top-level multimodal fields such as the media placeholder token ID into the provider.
+- INT4-packed expert weights are dequantized during import and re-quantized for compatible Hugging Face export.
+
+## Examples
+
+For conversion, inference, SFT, PEFT, Slurm launch scripts, and dataset notes, see the [Kimi-K2.5-VL examples README](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/examples/models/kimi/kimi_k25_vl/README.md).
+
+## Related Implementation
+
+- Bridge implementation: [`src/megatron/bridge/models/kimi_vl`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/src/megatron/bridge/models/kimi_vl)
+- Recipes: [`src/megatron/bridge/recipes/kimi_vl/kimi_k25_vl.py`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/src/megatron/bridge/recipes/kimi_vl/kimi_k25_vl.py)
+- Examples: [`examples/models/kimi/kimi_k25_vl`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/examples/models/kimi/kimi_k25_vl)
+

--- a/docs/models/llama/index.md
+++ b/docs/models/llama/index.md
@@ -5,11 +5,13 @@ Llama model documentation is organized by model variant.
 ```{toctree}
 :hidden:
 
+llama2.md
 llama3.md
 ```
 
 | Variant | Guide |
 |---------|-------|
+| Llama 2 | [llama2.md](llama2.md) |
 | Llama 3 | [llama3.md](llama3.md) |
 
 ## Recipes

--- a/docs/models/llama/llama2.md
+++ b/docs/models/llama/llama2.md
@@ -1,0 +1,44 @@
+# Llama 2
+
+[Llama 2](https://huggingface.co/meta-llama/Llama-2-7b-hf) is Meta's decoder-only transformer model family. Megatron Bridge supports Llama 2 through the shared Llama bridge for the Hugging Face `LlamaForCausalLM` architecture.
+
+## Supported Variants
+
+The repository includes a pretraining recipe for:
+
+- Llama-2-7B: https://huggingface.co/meta-llama/Llama-2-7b-hf
+
+The same bridge can auto-detect compatible Llama 2 causal language model checkpoints.
+
+## Architecture Notes
+
+- RMSNorm with SwiGLU feed-forward layers.
+- RoPE positional embeddings.
+- Grouped Query Attention support follows the Hugging Face configuration.
+- Uses the same `LlamaBridge` implementation as later Llama 3 variants.
+
+## Examples
+
+Llama 2 uses the common conversion and generation entry points:
+
+```bash
+uv run python examples/conversion/convert_checkpoints.py import \
+  --hf-model meta-llama/Llama-2-7b-hf \
+  --megatron-path /checkpoints/llama2_7b_megatron
+```
+
+```bash
+uv run python examples/conversion/hf_to_megatron_generate_text.py \
+  --hf_model_path meta-llama/Llama-2-7b-hf \
+  --megatron_model_path /checkpoints/llama2_7b_megatron \
+  --prompt "What is artificial intelligence?"
+```
+
+## Recipes
+
+- Llama 2 recipe: [`src/megatron/bridge/recipes/llama/llama2.py`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/src/megatron/bridge/recipes/llama/llama2.py)
+
+## Related Implementation
+
+- Bridge implementation: [`src/megatron/bridge/models/llama/llama_bridge.py`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/src/megatron/bridge/models/llama/llama_bridge.py)
+

--- a/docs/models/mimo/index.md
+++ b/docs/models/mimo/index.md
@@ -1,15 +1,13 @@
 # Xiaomi-MiMo
 
-Xiaomi-MiMo model support covers MiMo models through the Bridge system with auto-detected configuration and weight mapping.
+Xiaomi-MiMo model documentation is organized by model variant.
 
-## Supported Variants
+```{toctree}
+:hidden:
 
-- Xiaomi-MiMo
+mimo.md
+```
 
-## Examples
-
-For training and conversion examples, see the [Xiaomi-MiMo examples directory](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/examples/megatron_mimo).
-
-## Implementation
-
-- Model bridge: [`src/megatron/bridge/models/mimo`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/src/megatron/bridge/models/mimo)
+| Variant | Guide |
+|---------|-------|
+| Xiaomi-MiMo | [mimo.md](mimo.md) |

--- a/docs/models/mimo/mimo.md
+++ b/docs/models/mimo/mimo.md
@@ -1,0 +1,24 @@
+# Xiaomi-MiMo
+
+Xiaomi-MiMo models use a Qwen2-style causal language backbone with Multi-Token Prediction support. Megatron Bridge supports MiMo causal language models through `MimoBridge`, which extends the Qwen2 bridge and adds MTP weight mappings.
+
+## Supported Variants
+
+Megatron Bridge supports Hugging Face checkpoints using the `MiMoForCausalLM` architecture and `mimo` model type.
+
+## Architecture Notes
+
+- Qwen2-style attention behavior with QKV bias enabled.
+- Optional MTP layers are enabled from `num_nextn_predict_layers` in the Hugging Face config.
+- The bridge maps MTP token/hidden layernorms, projection layers, attention weights, and gated MLP weights.
+- Input projection halves are swapped during import/export to match Megatron and Hugging Face layouts.
+
+## Examples
+
+General MiMo and heterogeneous multimodal training examples live under [`examples/megatron_mimo`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/examples/megatron_mimo).
+
+## Related Implementation
+
+- MiMo bridge: [`src/megatron/bridge/models/mimo/mimo_bridge.py`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/src/megatron/bridge/models/mimo/mimo_bridge.py)
+- Megatron-MiMo provider infrastructure: [`src/megatron/bridge/models/megatron_mimo`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/src/megatron/bridge/models/megatron_mimo)
+

--- a/docs/models/minimax/index.md
+++ b/docs/models/minimax/index.md
@@ -1,17 +1,13 @@
 # MiniMax
 
-MiniMax model support covers MiniMax-M2 family variants through the Bridge system with auto-detected configuration and weight mapping.
+MiniMax model documentation is organized by model variant.
 
-## Supported Variants
+```{toctree}
+:hidden:
 
-- MiniMax-M2
-- MiniMax-M2.5
-- MiniMax-M2.7
+minimax-m2.md
+```
 
-## Examples
-
-For checkpoint conversion and inference commands, see the [MiniMax-M2 examples README](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/examples/models/minimax/minimax_m2/README.md).
-
-## Implementation
-
-- Model bridge: [`src/megatron/bridge/models/minimax_m2`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/src/megatron/bridge/models/minimax_m2)
+| Variant | Guide |
+|---------|-------|
+| MiniMax-M2 / M2.5 / M2.7 | [minimax-m2.md](minimax-m2.md) |

--- a/docs/models/minimax/minimax-m2.md
+++ b/docs/models/minimax/minimax-m2.md
@@ -1,0 +1,29 @@
+# MiniMax-M2
+
+[MiniMax-M2](https://huggingface.co/MiniMaxAI/MiniMax-M2) is a large sparse MoE language model from MiniMaxAI. Megatron Bridge supports MiniMax-M2 and architecture-compatible M2.5/M2.7 checkpoints through the `MiniMaxM2Bridge`.
+
+## Supported Variants
+
+| Variant | Hugging Face ID | Notes |
+|---------|-----------------|-------|
+| MiniMax-M2 | `MiniMaxAI/MiniMax-M2` | 456B total, 45.9B active |
+| MiniMax-M2.5 | `MiniMaxAI/MiniMax-M2.5` | Same `MiniMaxM2ForCausalLM` architecture |
+| MiniMax-M2.7 | `MiniMaxAI/MiniMax-M2.7` | Same `MiniMaxM2ForCausalLM` architecture |
+
+## Architecture Notes
+
+- Sparse MoE with 256 experts and top-8 routing.
+- Sigmoid router with expert-bias correction.
+- FP8 block-wise checkpoint weights are dequantized during import.
+- Uses full-dimension QK RMSNorm; the bridge provides custom Q/K norm mappings for tensor-parallel shards.
+- MTP modules are not currently mapped.
+
+## Examples
+
+For Slurm conversion, inference, hardware requirements, and validated parallelism settings, see the [MiniMax-M2 examples README](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/examples/models/minimax/minimax_m2/README.md).
+
+## Related Implementation
+
+- Bridge implementation: [`src/megatron/bridge/models/minimax_m2`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/src/megatron/bridge/models/minimax_m2)
+- Examples: [`examples/models/minimax/minimax_m2`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/examples/models/minimax/minimax_m2)
+

--- a/docs/models/qwen/index.md
+++ b/docs/models/qwen/index.md
@@ -6,20 +6,26 @@ Qwen model documentation is organized by model variant.
 :hidden:
 
 qwen.md
+qwen3-moe.md
+qwen3-next.md
 qwen2.5-vl.md
 qwen3-vl.md
 qwen35-vl.md
+qwen2-audio.md
+qwen25-omni.md
 qwen3-omni.md
+qwen3-asr.md
 ```
 
 | Variant | Guide |
 |---------|-------|
 | Qwen | [qwen.md](qwen.md) |
+| Qwen3-MoE | [qwen3-moe.md](qwen3-moe.md) |
+| Qwen3-Next | [qwen3-next.md](qwen3-next.md) |
 | Qwen2.5-VL | [qwen2.5-vl.md](qwen2.5-vl.md) |
 | Qwen3-VL | [qwen3-vl.md](qwen3-vl.md) |
 | Qwen3.5 / 3.6 | [qwen35-vl.md](qwen35-vl.md) |
+| Qwen2-Audio | [qwen2-audio.md](qwen2-audio.md) |
+| Qwen2.5-Omni | [qwen25-omni.md](qwen25-omni.md) |
 | Qwen3-Omni | [qwen3-omni.md](qwen3-omni.md) |
-
-## Examples
-
-- Qwen examples: [`examples/models/qwen`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/examples/models/qwen)
+| Qwen3-ASR | [qwen3-asr.md](qwen3-asr.md) |

--- a/docs/models/qwen/qwen2-audio.md
+++ b/docs/models/qwen/qwen2-audio.md
@@ -1,0 +1,24 @@
+# Qwen2-Audio
+
+[Qwen2-Audio](https://huggingface.co/Qwen/Qwen2-Audio-7B-Instruct) is an audio-language model from the Qwen family. Megatron Bridge supports Qwen2-Audio through a dedicated audio model bridge and provider.
+
+## Supported Variants
+
+- Qwen2-Audio-7B-Instruct: https://huggingface.co/Qwen/Qwen2-Audio-7B-Instruct
+
+## Architecture Notes
+
+- Uses a Qwen2 language backbone with an audio encoder path.
+- The bridge maps Hugging Face `Qwen2AudioForConditionalGeneration` checkpoints to the Megatron audio-language model.
+- Inference supports remote audio URLs and local audio files through the audio generation helper.
+
+## Examples
+
+For runnable audio inference commands and expected output, see the [Qwen2-Audio examples README](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/examples/models/qwen/qwen2_audio/README.md).
+
+## Related Implementation
+
+- Bridge implementation: [`src/megatron/bridge/models/qwen_audio`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/src/megatron/bridge/models/qwen_audio)
+- Recipes: [`src/megatron/bridge/recipes/qwen2_audio`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/src/megatron/bridge/recipes/qwen2_audio)
+- Examples: [`examples/models/qwen/qwen2_audio`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/examples/models/qwen/qwen2_audio)
+

--- a/docs/models/qwen/qwen25-omni.md
+++ b/docs/models/qwen/qwen25-omni.md
@@ -1,0 +1,23 @@
+# Qwen2.5-Omni
+
+[Qwen2.5-Omni](https://huggingface.co/Qwen/Qwen2.5-Omni-7B) is a multimodal Qwen model for image, video, audio, and text understanding. Megatron Bridge supports it through the Qwen Omni bridge.
+
+## Supported Variants
+
+- Qwen2.5-Omni-7B: https://huggingface.co/Qwen/Qwen2.5-Omni-7B
+
+## Architecture Notes
+
+- Dense Qwen2 language backbone with multimodal RoPE.
+- Vision and audio inputs are routed through Qwen2.5-Omni multimodal components.
+- Video-with-audio inference depends on `qwen-omni-utils[decord]` and an available `ffmpeg` binary.
+
+## Examples
+
+For checkpoint import/export, round-trip validation, multimodal inference, and dependency notes, see the [Qwen2.5-Omni examples README](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/examples/models/qwen/qwen25_omni/README.md).
+
+## Related Implementation
+
+- Bridge implementation: [`src/megatron/bridge/models/qwen_omni/qwen25_omni_bridge.py`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/src/megatron/bridge/models/qwen_omni/qwen25_omni_bridge.py)
+- Examples: [`examples/models/qwen/qwen25_omni`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/examples/models/qwen/qwen25_omni)
+

--- a/docs/models/qwen/qwen3-asr.md
+++ b/docs/models/qwen/qwen3-asr.md
@@ -1,0 +1,23 @@
+# Qwen3-ASR
+
+[Qwen3-ASR](https://huggingface.co/Qwen/Qwen3-ASR-1.7B) is an audio speech recognition model from the Qwen3 family. Megatron Bridge supports checkpoint conversion and audio inference through the Qwen3-ASR bridge.
+
+## Supported Variants
+
+- Qwen3-ASR-1.7B: https://huggingface.co/Qwen/Qwen3-ASR-1.7B
+
+## Architecture Notes
+
+- Uses the `Qwen3ASRForConditionalGeneration` architecture on the Hugging Face side.
+- The Megatron implementation includes a Qwen3-ASR thinker model, transformer config, and ASR-specific RoPE support.
+- Example conversion and round-trip validation use `--trust-remote-code`.
+
+## Examples
+
+For checkpoint import/export, round-trip validation, and audio inference commands, see the [Qwen3-ASR examples README](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/examples/models/qwen/qwen3_asr/README.md).
+
+## Related Implementation
+
+- Bridge implementation: [`src/megatron/bridge/models/qwen3_asr`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/src/megatron/bridge/models/qwen3_asr)
+- Examples: [`examples/models/qwen/qwen3_asr`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/examples/models/qwen/qwen3_asr)
+

--- a/docs/models/qwen/qwen3-moe.md
+++ b/docs/models/qwen/qwen3-moe.md
@@ -1,0 +1,31 @@
+# Qwen3-MoE
+
+[Qwen3-MoE](https://huggingface.co/Qwen/Qwen3-30B-A3B) is the sparse Mixture-of-Experts branch of the Qwen3 model family. Megatron Bridge supports Qwen3-MoE through the `Qwen3MoeBridge` and dedicated pretraining, SFT, and PEFT recipes.
+
+## Supported Variants
+
+| Variant | Hugging Face ID | Notes |
+|---------|-----------------|-------|
+| Qwen3-30B-A3B | `Qwen/Qwen3-30B-A3B` | 30B total, 3B active |
+| Qwen3-235B-A22B | `Qwen/Qwen3-235B-A22B` | 235B total, 22B active |
+
+## Architecture Notes
+
+- Qwen3 transformer backbone with MoE feed-forward layers.
+- Supports grouped expert execution through Megatron expert parallelism.
+- Uses Qwen3-specific QK layernorm behavior.
+
+## Recipes
+
+Available recipe helpers include:
+
+- `qwen3_30b_a3b_pretrain_config`, `qwen3_30b_a3b_sft_config`, `qwen3_30b_a3b_peft_config`
+- `qwen3_235b_a22b_pretrain_config`, `qwen3_235b_a22b_sft_config`, `qwen3_235b_a22b_peft_config`
+
+See [`src/megatron/bridge/recipes/qwen/qwen3_moe.py`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/src/megatron/bridge/recipes/qwen/qwen3_moe.py).
+
+## Related Implementation
+
+- Bridge implementation: [`src/megatron/bridge/models/qwen/qwen3_moe_bridge.py`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/src/megatron/bridge/models/qwen/qwen3_moe_bridge.py)
+- Family overview: [qwen.md](qwen.md)
+

--- a/docs/models/qwen/qwen3-next.md
+++ b/docs/models/qwen/qwen3-next.md
@@ -1,0 +1,33 @@
+# Qwen3-Next
+
+[Qwen3-Next](https://huggingface.co/Qwen/Qwen3-Next-80B-A3B-Instruct) is a Qwen3 MoE variant with Gated-Delta Networks and Multi-Token Prediction support. Megatron Bridge supports it through the `Qwen3NextBridge`.
+
+## Supported Variants
+
+- Qwen3-Next-80B-A3B-Instruct: https://huggingface.co/Qwen/Qwen3-Next-80B-A3B-Instruct
+- Qwen3-Next-80B-A3B-Thinking: https://huggingface.co/Qwen/Qwen3-Next-80B-A3B-Thinking
+
+## Architecture Notes
+
+- MoE model with 80B total parameters and 3B active parameters.
+- Includes Gated-Delta Network layers, QK layernorm, Zero-Centered RMSNorm, and MTP.
+- Recipes currently cover pretraining and full SFT; PEFT is not available for Qwen3-Next.
+
+## Examples
+
+The Qwen3-Next example entrypoint supports YAML and CLI overrides for full finetuning:
+
+- [`examples/models/qwen/qwen3_next/finetune_qwen3_next_80b_a3b.py`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/examples/models/qwen/qwen3_next/finetune_qwen3_next_80b_a3b.py)
+
+## Recipes
+
+- `qwen3_next_80b_a3b_pretrain_config`
+- `qwen3_next_80b_a3b_sft_config`
+
+See [`src/megatron/bridge/recipes/qwen/qwen3_next.py`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/src/megatron/bridge/recipes/qwen/qwen3_next.py).
+
+## Related Implementation
+
+- Bridge implementation: [`src/megatron/bridge/models/qwen/qwen3_next_bridge.py`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/src/megatron/bridge/models/qwen/qwen3_next_bridge.py)
+- Family overview: [qwen.md](qwen.md)
+

--- a/docs/models/sarvam/index.md
+++ b/docs/models/sarvam/index.md
@@ -1,15 +1,13 @@
 # Sarvam
 
-Sarvam model support covers Sarvam language model variants through the Bridge system with auto-detected configuration and weight mapping.
+Sarvam model documentation is organized by model variant.
 
-## Supported Variants
+```{toctree}
+:hidden:
 
-- Sarvam
+sarvam.md
+```
 
-## Examples
-
-For checkpoint conversion and inference commands, see the [Sarvam examples README](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/examples/models/sarvam/README.md).
-
-## Implementation
-
-- Model bridge: [`src/megatron/bridge/models/sarvam`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/src/megatron/bridge/models/sarvam)
+| Variant | Guide |
+|---------|-------|
+| Sarvam | [sarvam.md](sarvam.md) |

--- a/docs/models/sarvam/sarvam.md
+++ b/docs/models/sarvam/sarvam.md
@@ -1,0 +1,26 @@
+# Sarvam
+
+[Sarvam](https://huggingface.co/sarvamai/sarvam-30b) language models are MoE models from Sarvam AI. Megatron Bridge supports Sarvam dense-MLA and MoE variants through the Sarvam bridge implementations.
+
+## Supported Variants
+
+| Variant | Hugging Face ID | Notes |
+|---------|-----------------|-------|
+| Sarvam 30B | `sarvamai/sarvam-30b` | 30B total, 3B active, 128 experts top-6 |
+| Sarvam 105B | `sarvamai/sarvam-105b` | 105B total, 10.3B active, 128 experts top-8 |
+
+## Architecture Notes
+
+- Sarvam MoE models use QKV layernorm and Grouped Query Attention.
+- MoE layers map router weights, expert bias, shared experts, and per-expert gate/up/down projections.
+- Examples use `--trust-remote-code` for Hugging Face loading.
+
+## Examples
+
+For checkpoint import/export, round-trip validation, and inference commands, see the [Sarvam examples README](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/examples/models/sarvam/README.md).
+
+## Related Implementation
+
+- Bridge implementation: [`src/megatron/bridge/models/sarvam`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/src/megatron/bridge/models/sarvam)
+- Examples: [`examples/models/sarvam`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/examples/models/sarvam)
+

--- a/docs/models/stepfun/index.md
+++ b/docs/models/stepfun/index.md
@@ -1,0 +1,14 @@
+# StepFun
+
+StepFun model documentation is organized by model variant.
+
+```{toctree}
+:hidden:
+
+step35.md
+```
+
+| Variant | Guide |
+|---------|-------|
+| Step-3.5-Flash | [step35.md](step35.md) |
+

--- a/docs/models/stepfun/step35.md
+++ b/docs/models/stepfun/step35.md
@@ -1,0 +1,26 @@
+# Step-3.5-Flash
+
+[Step-3.5-Flash](https://huggingface.co/stepfun-ai/Step-3.5-Flash) is a MoE language model from StepFun. Megatron Bridge supports checkpoint conversion, inference, and continued pretraining through a dedicated Step-3.5 bridge, provider, and recipe.
+
+## Supported Variants
+
+- Step-3.5-Flash: https://huggingface.co/stepfun-ai/Step-3.5-Flash
+
+## Architecture Notes
+
+- Hybrid attention pattern with full attention interleaved with sliding attention.
+- Fused per-head attention gate (`g_proj`) is merged into Megatron `linear_qkv` weights.
+- MoE decoder layers are surrounded by dense layers at the beginning/end and MTP layers.
+- The provider carries `layer_types`, full-attention settings, and sliding-attention settings from the Hugging Face config.
+- Current examples require Megatron-LM `dev` branch changes until the required MCore support reaches the pinned submodule.
+
+## Examples
+
+For conversion, inference, pretraining, Slurm launch scripts, and MCore branch notes, see the [Step-3.5-Flash examples README](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/examples/models/stepfun/step35/README.md).
+
+## Related Implementation
+
+- Bridge implementation: [`src/megatron/bridge/models/stepfun`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/src/megatron/bridge/models/stepfun)
+- Recipe: [`src/megatron/bridge/recipes/stepfun/step35.py`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/src/megatron/bridge/recipes/stepfun/step35.py)
+- Examples: [`examples/models/stepfun/step35`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/examples/models/stepfun/step35)
+


### PR DESCRIPTION
## Summary

Audit supported model variants after #3908 and add missing model-variant leaf pages where the repo clearly has bridge/example/recipe support but docs only had family/index coverage.

Added leaf pages for:
- Bailing: Ling 2.0
- Falcon: Falcon H1
- Gemma: Gemma
- GLM: GLM-4.7 / 4.7-Flash, GLM-5 / 5.1
- Kimi: Kimi K2, Kimi-K2.5-VL
- Llama: Llama 2
- MiniMax: MiniMax-M2 / M2.5 / M2.7
- Xiaomi-MiMo: Xiaomi-MiMo
- Qwen: Qwen3-MoE, Qwen3-Next, Qwen2-Audio, Qwen2.5-Omni, Qwen3-ASR
- Sarvam: Sarvam
- StepFun: Step-3.5-Flash, plus a new family index

Also updated family index toctrees, `docs/models/README.md`, `docs/index.md`, and the root README supported-model table for StepFun.

## Audit notes

Sources checked:
- `README.md` supported models table
- `docs/models/*/index.md` and existing `docs/models/*/*.md`
- `examples/models/*` and `examples/megatron_mimo`
- `src/megatron/bridge/models/*`
- `src/megatron/bridge/recipes/*`

Intentionally kept grouped rather than split further:
- DeepSeek V2/V3/V4, Gemma 2/3/3-VL/4-VL, GLM-4.5/4.5V, GPT-OSS, Mistral/Ministral 3, Moonlight, OLMoE, Qwen3-VL, Qwen3.5/3.6-VL, Qwen3-Omni, and existing Nemotron pages already had leaf coverage.
- Llama 3 / 3.1 / 3.2 / 3.3 remain under `llama3.md` because they share the existing Llama 3 page and recipe family.
- Qwen2 / Qwen2.5 / Qwen3 dense variants remain under `qwen.md` because the existing page already covers the shared dense Qwen bridge and recipes.
- Nemotron H and Nemotron Nano v2 remain combined in `nemotronh.md` because the page explicitly covers both shared hybrid SSM-attention families.
- MiniMax-M2.5 / M2.7 remain grouped with MiniMax-M2 because the bridge source documents them as the same `MiniMaxM2ForCausalLM` architecture.
- GLM-4.7 / 4.7-Flash and GLM-5 / 5.1 are grouped in pairs because each pair shares the same example area and closely related bridge support.

## Validation

- `git diff --check` passed.
- Focused changed-file local markdown link check passed: all changed-file local links resolve.
- Focused model toctree check passed: all `docs/models/*/index.md` toctree entries resolve.
- Requested command `cd docs && uv run --no-sync sphinx-build --fail-on-warning --builder html . _build/html` was blocked because the unsynced venv did not have `sphinx-build` installed.
- `cd docs && uv run --group docs sphinx-build --fail-on-warning --builder html . _build/html` was blocked by the local resolver/platform issue: `nvidia-resiliency-ext==0.6.0` has no wheel for this host's `manylinux_2_31_x86_64`; available wheels are `manylinux_2_39_*`.
- Docs-tool-only build passed: `cd docs && uv run --no-project --with sphinx --with myst-parser --with sphinx-autodoc2 --with nvidia-sphinx-theme --with sphinx-copybutton --with sphinxcontrib-mermaid sphinx-build --fail-on-warning --builder html . _build/html`.
- Required exact pre-commit command `uv run pre-commit run --all-files` was blocked by the same `nvidia-resiliency-ext` platform resolver issue.
- Pre-commit-tool-only fallback passed: `uv run --no-project --with pre-commit pre-commit run --all-files`.

Unit tests were not run, per task instructions.
