### PR TITLE
[training] fix flops computation

### DIFF
--- a/src/megatron/bridge/training/utils/flop_utils.py
+++ b/src/megatron/bridge/training/utils/flop_utils.py
@@ -522,7 +522,15 @@ def num_floating_point_operations(
                     effective_window = window_size[0] + window_size[1] + 1
                 else:
                     effective_window = window_size
-                swa_context = min(effective_window, effective_seq_length)
+                # Exact average causal SWA context:
+                # W * (W + 1) / 2 + (T - W) * W if W < T, else T * (T + 1) / 2.
+                # Both expressions are divided by T because the multiplication with T happens later.
+                if effective_window < effective_seq_length:
+                    swa_context = effective_window - effective_window * (effective_window - 1) / (
+                        2 * effective_seq_length
+                    )
+                else:
+                    swa_context = core_attn_seq_factor / 2
 
                 if window_attn_skip_freq is None:
                     num_swa_layers = num_layers
@@ -540,9 +548,8 @@ def num_floating_point_operations(
                     num_full_attn_layers = num_layers
 
                 # Full attention is quadratic in seq_len -> use core_attn_seq_factor.
-                # SWA core is bounded by window_size, so keep the averaged bound.
                 full_core = query_projection_size * core_attn_seq_factor / 2 * 2
-                swa_core = query_projection_size * swa_context / 2 * 2
+                swa_core = query_projection_size * swa_context * 2
 
                 self_attn_term = (
                     3

--- a/src/megatron/bridge/training/utils/flop_utils.py
+++ b/src/megatron/bridge/training/utils/flop_utils.py
@@ -15,8 +15,6 @@
 import importlib
 from pathlib import Path
 
-import torch.nn.functional as F
-
 from megatron.bridge.data.datasets.packing_utils import calculate_avg_seqlen
 from megatron.bridge.peft.lora import LoRA
 from megatron.bridge.training.config import ConfigContainer
@@ -442,9 +440,7 @@ def num_floating_point_operations(
             else cfg.model.moe_shared_expert_intermediate_size
         )
         # GLU: h->2*ffn_h and ffn_h->h = 3 projections; non-GLU: h->ffn_h and ffn_h->h = 2 projections.
-        ffn_expansion_factor = (
-            3 if cfg.model.gated_linear_unit is True else 2
-        )
+        ffn_expansion_factor = 3 if cfg.model.gated_linear_unit is True else 2
 
         if cfg.model.multi_latent_attention:
             """

--- a/src/megatron/bridge/training/utils/flop_utils.py
+++ b/src/megatron/bridge/training/utils/flop_utils.py
@@ -441,9 +441,9 @@ def num_floating_point_operations(
             if cfg.model.moe_shared_expert_intermediate_size is None
             else cfg.model.moe_shared_expert_intermediate_size
         )
-        # SwiGLU: h->2*ffn_h and ffn_h->h = 3 projections; non-SwiGLU: h->ffn_h and ffn_h->h = 2 projections.
+        # GLU: h->2*ffn_h and ffn_h->h = 3 projections; non-GLU: h->ffn_h and ffn_h->h = 2 projections.
         ffn_expansion_factor = (
-            3 if (cfg.model.gated_linear_unit is True and cfg.model.activation_func == F.silu) else 2
+            3 if cfg.model.gated_linear_unit is True else 2
         )
 
         if cfg.model.multi_latent_attention:

--- a/tests/unit_tests/training/utils/test_flop_utils.py
+++ b/tests/unit_tests/training/utils/test_flop_utils.py
@@ -972,9 +972,7 @@ class TestGluFfnExpansion:
         assert flops_glu_gelu == flops_glu_silu, "GLU FLOPs must not depend on activation_func"
 
         # Only the dense MLP term changes: expansion 3 vs 2 (attn + logit are identical).
-        expected_mlp_delta = (
-            batch_size * seq_length * 3 * 2 * hidden_size * ffn_hidden_size * num_layers
-        )
+        expected_mlp_delta = batch_size * seq_length * 3 * 2 * hidden_size * ffn_hidden_size * num_layers
         assert flops_glu_gelu - flops_no_glu == expected_mlp_delta
         assert flops_glu_silu - flops_no_glu == expected_mlp_delta
 
@@ -1069,8 +1067,7 @@ class TestSlidingWindowAttentionFlops:
         # Causal SWA: query at position t attends to min(t, W) keys.
         # Sum over t=1..T, then average (flop_utils divides by T; *T happens in seq_length).
         total_swa_keys = (
-            effective_window * (effective_window + 1) / 2
-            + (seq_length - effective_window) * effective_window
+            effective_window * (effective_window + 1) / 2 + (seq_length - effective_window) * effective_window
         )
         avg_swa_keys = total_swa_keys / seq_length
         core_diff_per_layer = query_projection_size * (seq_length - 2 * avg_swa_keys)

--- a/tests/unit_tests/training/utils/test_flop_utils.py
+++ b/tests/unit_tests/training/utils/test_flop_utils.py
@@ -930,6 +930,56 @@ class TestMoELatentTransformerPath:
 
 
 @pytest.mark.unit
+class TestGluFfnExpansion:
+    """Tests that gated_linear_unit uses ffn_expansion_factor=3 for any GLU activation."""
+
+    def test_glu_non_silu_uses_expansion_factor_three(self):
+        """GeGLU and SwiGLU both count three FFN projections; activation_func is not in the formula."""
+        import torch.nn.functional as F
+
+        batch_size = 1
+        seq_length = 512
+        hidden_size = 1024
+        ffn_hidden_size = 4096
+        num_layers = 4
+        vocab_size = 32000
+
+        base = dict(
+            num_layers=num_layers,
+            hidden_size=hidden_size,
+            seq_length=seq_length,
+            ffn_hidden_size=ffn_hidden_size,
+            num_attention_heads=8,
+            num_query_groups=4,
+            kv_channels=128,
+            vocab_size=vocab_size,
+            make_vocab_size_divisible_by=128,
+            tensor_model_parallel_size=1,
+        )
+
+        cfg_no_glu = MockConfigContainer(model=MockModelConfig(**base, gated_linear_unit=False))
+        cfg_glu_gelu = MockConfigContainer(
+            model=MockModelConfig(**base, gated_linear_unit=True, activation_func=F.gelu)
+        )
+        cfg_glu_silu = MockConfigContainer(
+            model=MockModelConfig(**base, gated_linear_unit=True, activation_func=F.silu)
+        )
+
+        flops_no_glu = num_floating_point_operations(cfg_no_glu, batch_size=batch_size)
+        flops_glu_gelu = num_floating_point_operations(cfg_glu_gelu, batch_size=batch_size)
+        flops_glu_silu = num_floating_point_operations(cfg_glu_silu, batch_size=batch_size)
+
+        assert flops_glu_gelu == flops_glu_silu, "GLU FLOPs must not depend on activation_func"
+
+        # Only the dense MLP term changes: expansion 3 vs 2 (attn + logit are identical).
+        expected_mlp_delta = (
+            batch_size * seq_length * 3 * 2 * hidden_size * ffn_hidden_size * num_layers
+        )
+        assert flops_glu_gelu - flops_no_glu == expected_mlp_delta
+        assert flops_glu_silu - flops_no_glu == expected_mlp_delta
+
+
+@pytest.mark.unit
 class TestSlidingWindowAttentionFlops:
     """Tests for sliding window attention (SWA) FLOPs in transformer_flops path."""
 

--- a/tests/unit_tests/training/utils/test_flop_utils.py
+++ b/tests/unit_tests/training/utils/test_flop_utils.py
@@ -1016,8 +1016,14 @@ class TestSlidingWindowAttentionFlops:
         query_projection_size = kv_channels * num_attention_heads
         effective_window = window_left + 0 + 1  # 512
 
-        # Core attention difference per SWA layer: Q * (S - W) (the /2 *2 cancels)
-        core_diff_per_layer = query_projection_size * (seq_length - effective_window)
+        # Causal SWA: query at position t attends to min(t, W) keys.
+        # Sum over t=1..T, then average (flop_utils divides by T; *T happens in seq_length).
+        total_swa_keys = (
+            effective_window * (effective_window + 1) / 2
+            + (seq_length - effective_window) * effective_window
+        )
+        avg_swa_keys = total_swa_keys / seq_length
+        core_diff_per_layer = query_projection_size * (seq_length - 2 * avg_swa_keys)
         expected_delta = batch_size * seq_length * 3 * 2 * num_swa_layers * core_diff_per_layer
         actual_delta = flops_full - flops_swa
 


### PR DESCRIPTION
# What does this PR do ?

This PR fixes two discrepancies found when analyzing GPT-OSS FLOPs numbers coming from MBridge:
- gated linear units were only being counted correctly when using SWIGLU activations. Other gated linear unit activation units were using an expansion factor of 2 rather than 3. Correct this to 3 for all GLU. For GPT-OSS 20B this is on the order of 10% of total FLOPS during a training step.
- sliding window attention was undercounting FLOPS because we were dividing by 2. Expand the formula for the two regimes so that we correctly compute those FLOPS. This has a minimal effect but worth including for correctness sake.

# Changelog

- fix FLOPS accounting for gated linear units
- fix FLOPS accounting for sliding window attention with small windows

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
