### PR TITLE
chore: Add fast-hadamard-transform to no-build-isolation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,7 @@ no-build-isolation-package = [
     "nv-grouped-gemm",
     "flash_mla",
     "flash-linear-attention",
+    "fast-hadamard-transform",
 ]
 prerelease = "allow"
 override-dependencies = [


### PR DESCRIPTION
# What does this PR do ?

chore: Add fast-hadamard-transform to no-build-isolation

There is a MCore PR that is going to be merged soon that includes this dependency and it needs to be built with no-build-isolation. 
https://github.com/NVIDIA/Megatron-LM/pull/3026

Will validate with a separate build to see if this PR works with that PR.

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
