### PR TITLE
initial commit on the megatron bridge part

### DIFF
--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -141,6 +141,72 @@ _DIRECT_ITERATION_DIR_SENTINEL = -2
 # ============================================================================
 
 
+def _sync_hybrid_optimizer_param_copies_from_model(optimizer: MegatronOptimizer) -> bool:
+    """Refresh HybridDeviceOptimizer copies after model-only checkpoint loads.
+
+    MCore's hybrid CPU-offload optimizer keeps CPU parameter clones in addition
+    to the distributed optimizer's FP32 shards. When Bridge loads finetune
+    weights after optimizer construction, those copies can still contain the
+    random initialization unless they are explicitly synchronized from the
+    loaded model parameters.
+    """
+
+    def _iter_optimizers(opt):
+        chained_optimizers = getattr(opt, "chained_optimizers", None)
+        if chained_optimizers is not None:
+            yield from chained_optimizers
+        else:
+            yield opt
+
+    def _sync_distributed_optimizer(distributed_optimizer) -> bool:
+        hybrid_optimizer = getattr(distributed_optimizer, "optimizer", None)
+        has_distributed_param_groups = all(
+            hasattr(distributed_optimizer, attr)
+            for attr in (
+                "model_float16_groups",
+                "shard_fp32_from_float16_groups",
+                "_get_model_param_range_map",
+            )
+        )
+        has_hybrid_param_copies = hasattr(hybrid_optimizer, "gpu_params_map_cpu_copy") or hasattr(
+            hybrid_optimizer, "update_fp32_param_by_new_param"
+        )
+        if not has_distributed_param_groups or not has_hybrid_param_copies:
+            return False
+
+        with torch.no_grad():
+            for model_group, shard_main_group in zip(
+                distributed_optimizer.model_float16_groups,
+                distributed_optimizer.shard_fp32_from_float16_groups,
+            ):
+                for model_param, shard_main_param in zip(model_group, shard_main_group):
+                    if shard_main_param is None:
+                        continue
+                    param_range = distributed_optimizer._get_model_param_range_map(model_param)["param"]
+                    shard_model_param = model_param.view(-1)[param_range.start : param_range.end]
+                    shard_main_param.data.copy_(shard_model_param)
+
+            for gpu_param, cpu_clone in getattr(hybrid_optimizer, "gpu_params_map_cpu_copy", {}).items():
+                cpu_clone.data.copy_(gpu_param.data)
+
+            if hasattr(hybrid_optimizer, "update_fp32_param_by_new_param"):
+                hybrid_optimizer.update_fp32_param_by_new_param()
+
+        return True
+
+    applied = False
+    for opt in _iter_optimizers(optimizer):
+        applied |= _sync_distributed_optimizer(opt)
+
+    if applied:
+        print_rank_0(
+            "Synced HybridDeviceOptimizer parameter copies from loaded model weights "
+            "(distributed FP32 shards and CPU offload clones)."
+        )
+
+    return applied
+
+
 def set_checkpoint_version(value: float) -> None:
     """Set the global checkpoint version number.
 
@@ -2497,6 +2563,8 @@ def _load_checkpoint_from_path(
                 optimizer.reload_model_params(state_dict=state_dict)
             else:
                 optimizer.reload_model_params()
+            if getattr(cfg.optimizer, "optimizer_cpu_offload", False):
+                _sync_hybrid_optimizer_param_copies_from_model(optimizer)
 
     # Load rerun state
     if not ignore_rerun_state:

--- a/tests/unit_tests/training/test_checkpointing.py
+++ b/tests/unit_tests/training/test_checkpointing.py
@@ -16,6 +16,7 @@
 import os
 import tempfile
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import Mock, mock_open, patch
 
 import pytest
@@ -49,6 +50,7 @@ from megatron.bridge.training.checkpointing import (
     load_checkpoint,
     read_metadata,
     save_checkpoint,
+    _sync_hybrid_optimizer_param_copies_from_model,
 )
 from megatron.bridge.training.config import CheckpointConfig, ConfigContainer
 from megatron.bridge.training.state import GlobalState, TrainState
@@ -729,6 +731,39 @@ def load_checkpoint_fixtures():
 
 class TestLoadCheckpoint:
     """Test checkpoint loading functionality."""
+
+    @pytest.mark.unit
+    def test_sync_hybrid_optimizer_param_copies_from_model(self):
+        """Hybrid CPU-offload optimizer copies are refreshed from loaded model params."""
+        model_param = torch.tensor([10.0, 20.0, 30.0, 40.0], dtype=torch.bfloat16)
+        shard_main_param = torch.full((2,), -1.0, dtype=torch.float32)
+        cpu_clone = torch.full((2,), -2.0, dtype=torch.float32)
+        hybrid_optimizer = SimpleNamespace(
+            gpu_params_map_cpu_copy={shard_main_param: cpu_clone},
+            update_fp32_param_by_new_param=Mock(),
+        )
+        distributed_optimizer = SimpleNamespace(
+            optimizer=hybrid_optimizer,
+            model_float16_groups=[[model_param]],
+            shard_fp32_from_float16_groups=[[shard_main_param]],
+        )
+        distributed_optimizer._get_model_param_range_map = Mock(
+            return_value={"param": SimpleNamespace(start=1, end=3)}
+        )
+
+        applied = _sync_hybrid_optimizer_param_copies_from_model(distributed_optimizer)
+
+        assert applied is True
+        torch.testing.assert_close(shard_main_param, torch.tensor([20.0, 30.0]))
+        torch.testing.assert_close(cpu_clone, torch.tensor([20.0, 30.0]))
+        hybrid_optimizer.update_fp32_param_by_new_param.assert_called_once_with()
+
+    @pytest.mark.unit
+    def test_sync_hybrid_optimizer_param_copies_ignores_non_hybrid_optimizer(self):
+        """Non-hybrid optimizers are left to reload_model_params()."""
+        optimizer = SimpleNamespace(optimizer=SimpleNamespace())
+
+        assert _sync_hybrid_optimizer_param_copies_from_model(optimizer) is False
 
     @patch("megatron.bridge.training.checkpointing._load_base_checkpoint")
     @patch("megatron.bridge.training.checkpointing.read_train_state")


### PR DESCRIPTION
## What does this PR do?

Fixes a finetuning checkpoint-load bug when Megatron Bridge uses mixed precision, distributed optimizer, and optimizer CPU offload.

When model weights are loaded after optimizer construction, `optimizer.reload_model_params()` refreshes the normal distributed optimizer FP32 main params, but the hybrid CPU-offload optimizer also owns CPU parameter clones used by CPU sub-optimizers. Those copies can remain at random initialization and later overwrite the loaded checkpoint weights on optimizer step.

This PR explicitly synchronizes the hybrid optimizer parameter copies from the loaded model weights after model-only checkpoint loads.

## Why is this needed?

The risky configuration is:

- `bf16` or `fp16`
- `use_distributed_optimizer=True`
- `optimizer_cpu_offload=True`
- finetuning / pretrained checkpoint load without loading optimizer state

Bridge builds the model and optimizer before loading the finetuning checkpoint. After the checkpoint load, the BF16/FP16 model params are correct, but CPU-offload optimizer copies can still contain the pre-load random initialization. The first optimizer step can then update and copy those stale values back into the model.

## Implementation

- Adds a Bridge-side helper to refresh HybridDeviceOptimizer copies after model-only checkpoint loads.
- Synchronizes loaded model params into:
  - distributed optimizer FP32 shards (`shard_fp32_from_float16_groups`)
  - CPU offload clones (`gpu_params_map_cpu_copy`)
  - HybridDeviceOptimizer FP32 copies via `update_fp32_param_by_new_param()`
- Calls the helper only when `cfg.optimizer.optimizer_cpu_offload` is enabled, after the existing `optimizer.reload_model_params()` path.
- Adds focused unit coverage for both the hybrid sync path and the non-hybrid no-op path.

## Test plan

Passed focused regression test in a Slurm job using a NeMo container `.sqsh`:

```bash
IMAGE=/fsx/peng/containers/megatron-bridge-nemo-26.04-nvrx.sqsh \
  sbatch slurm_scripts/run_checkpointing_sync_test.slurm
```

The job ran:

```bash
python3 -m pytest tests/unit_tests/training/test_checkpointing.py \
  -k sync_hybrid_optimizer_param_copies -q
```

Result:

```text
2 passed, 117 deselected, 33 warnings in 7.05s
```

