### PR TITLE
PyT memory snapshot for only user defined step(s)

### DIFF
--- a/src/megatron/bridge/training/utils/train_utils.py
+++ b/src/megatron/bridge/training/utils/train_utils.py
@@ -800,13 +800,14 @@ def training_log(
         if hasattr(timers, "write_to_comet"):
             timers.write_to_comet(timers_to_log, comet_logger, iteration, normalizer=total_iterations, reset=True)
 
-    if config.profiling and config.profiling.record_memory_history:
-        if get_rank_safe() in config.profiling.profile_ranks:
+    if config.profiling and config.profiling.record_memory_history and iteration == config.profiling.profile_step_end:
+        rank = get_rank_safe()
+        if rank in config.profiling.profile_ranks:
             snapshot = torch.cuda.memory._snapshot()
             from pickle import dump
 
             filename, ext = os.path.splitext(config.profiling.memory_snapshot_path)
-            filename = f"{filename}_{get_rank_safe()}{ext}"
+            filename = f"{filename}_{rank}{ext}"
             with open(filename, "wb") as f:
                 dump(snapshot, f)
                 print_rank_0(f"Saved memory snapshot to {filename}")

--- a/tests/unit_tests/training/utils/test_train_utils.py
+++ b/tests/unit_tests/training/utils/test_train_utils.py
@@ -1353,9 +1353,9 @@ class TestTrainingLog:
     @mock.patch("megatron.bridge.training.utils.train_utils.report_l2_norm_grad")
     def test_profiling_memory_snapshot_skips_non_stop_step(
         self,
-        mock_report_runtime,
-        mock_report_throughput,
         mock_report_l2_norm_grad,
+        mock_report_throughput,
+        mock_report_runtime,
         mock_pickle_dump,
         mock_open,
         mock_memory_snapshot,

--- a/tests/unit_tests/training/utils/test_train_utils.py
+++ b/tests/unit_tests/training/utils/test_train_utils.py
@@ -1309,10 +1309,11 @@ class TestTrainingLog:
         mock_profiling_config.record_memory_history = True
         mock_profiling_config.memory_snapshot_path = "/tmp/memory_snapshot.pkl"
         mock_profiling_config.profile_ranks = [7]
+        mock_profiling_config.profile_step_end = 10
         mock_config.profiling = mock_profiling_config
         mock_config.logger.tensorboard_dir = "/tmp/tb"
 
-        # Set iteration (snapshot itself is not gated by tensorboard log interval anymore)
+        # Set iteration to the configured snapshot dump step.
         mock_global_state.train_state.step = 10
 
         training_log(
@@ -1337,6 +1338,79 @@ class TestTrainingLog:
         mock_open.assert_called_once_with("/tmp/memory_snapshot_7.pkl", "wb")
         mock_pickle_dump.assert_called_once_with({"mock": "snapshot"}, mock_file_handle)
         mock_print_rank_0.assert_any_call("Saved memory snapshot to /tmp/memory_snapshot_7.pkl")
+
+    @mock.patch("megatron.bridge.training.utils.train_utils.get_num_microbatches")
+    @mock.patch("megatron.bridge.training.utils.train_utils.reduce_max_stat_across_model_parallel_group")
+    @mock.patch("megatron.bridge.training.utils.train_utils.get_world_size_safe")
+    @mock.patch("megatron.bridge.training.utils.train_utils.get_rank_safe")
+    @mock.patch("megatron.bridge.training.utils.train_utils.print_rank_0")
+    @mock.patch("megatron.bridge.training.utils.train_utils.print_rank_last")
+    @mock.patch("torch.cuda.memory._snapshot")
+    @mock.patch("builtins.open")
+    @mock.patch("pickle.dump")
+    @mock.patch("megatron.bridge.training.utils.train_utils.report_runtime")
+    @mock.patch("megatron.bridge.training.utils.train_utils.report_throughput")
+    @mock.patch("megatron.bridge.training.utils.train_utils.report_l2_norm_grad")
+    def test_profiling_memory_snapshot_skips_non_stop_step(
+        self,
+        mock_report_runtime,
+        mock_report_throughput,
+        mock_report_l2_norm_grad,
+        mock_pickle_dump,
+        mock_open,
+        mock_memory_snapshot,
+        mock_print_rank_last,
+        mock_print_rank_0,
+        mock_get_rank_safe,
+        mock_get_world_size,
+        mock_reduce_lr,
+        mock_get_microbatches,
+        mock_config,
+        mock_global_state,
+        loss_dict,
+    ):
+        """Test memory snapshot is not dumped before the profiling stop step."""
+        total_loss_dict = self.get_fresh_total_loss_dict()
+
+        mock_report_l2_norm_grad.return_value = {}
+        mock_report_throughput.return_value = {}
+        mock_report_runtime.return_value = {}
+        mock_get_microbatches.return_value = 8
+        mock_reduce_lr.return_value = 1e-4
+        mock_get_world_size.return_value = 32
+        mock_get_rank_safe.return_value = 7
+
+        mock_profiling_config = mock.MagicMock()
+        mock_profiling_config.record_memory_history = True
+        mock_profiling_config.memory_snapshot_path = "/tmp/memory_snapshot.pkl"
+        mock_profiling_config.profile_ranks = [7]
+        mock_profiling_config.profile_step_end = 10
+        mock_config.profiling = mock_profiling_config
+        mock_config.logger.tensorboard_dir = "/tmp/tb"
+        mock_global_state.train_state.step = 9
+
+        training_log(
+            loss_dict=loss_dict,
+            total_loss_dict=total_loss_dict,
+            learning_rate=1e-4,
+            decoupled_learning_rate=None,
+            loss_scale=1024.0,
+            report_memory_flag=False,
+            skipped_iter=0,
+            grad_norm=2.5,
+            params_norm=15.2,
+            num_zeros_in_grad=0,
+            config=mock_config,
+            global_state=mock_global_state,
+            history_wct=None,
+            model=None,
+        )
+
+        mock_get_rank_safe.assert_not_called()
+        mock_memory_snapshot.assert_not_called()
+        mock_open.assert_not_called()
+        mock_pickle_dump.assert_not_called()
+        mock_print_rank_0.assert_not_called()
 
     @mock.patch("megatron.bridge.training.utils.train_utils.get_num_microbatches")
     @mock.patch("megatron.bridge.training.utils.train_utils.reduce_max_stat_across_model_parallel_group")


### PR DESCRIPTION
# What does this PR do ?

Memory snapshot is being written and overwritten for every train step.
Fix it to write only for the user-defined profiling step(s).

# Changelog

```
if config.profiling and config.profiling.record_memory_history and iteration == config.profiling.profile_step_end:
        rank = get_rank_safe()
        if rank in config.profiling.profile_ranks:
            snapshot = torch.cuda.memory._snapshot()
            from pickle import dump

            filename, ext = os.path.splitext(config.profiling.memory_snapshot_path)
            filename = f"{filename}_{get_rank_safe()}{ext}"
            filename = f"{filename}_{rank}{ext}"
```

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
