### PR TITLE
Support DeepSeek V4 quantization scales during HF export

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 ## 📣 News
 - [05/28/2026] [**Step-3.7-Flash**](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/examples/models/stepfun/step37) is now merged on **main**! See the [examples README](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/examples/models/stepfun/step37/README.md) for sft training details.
 
+- [05/26/2026] [**DeepSeek V4**](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash) FP8 support is now available in Megatron Bridge, including HF↔Megatron conversion, quantized checkpoint export with regenerated scale tensors, and downstream verification with Megatron-backend GRPO.
+
 - [05/20/2026] [**DeepSeek V4**](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/examples/models/deepseek_v4) is now merged on **main**! See the [examples README](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/examples/models/deepseek_v4/README.md) for conversion and inference details.
 
 - [05/20/2026] [**Nemotron-3 Nano Omni**](https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16) day-0 branch support is now merged on **main**! The 30B-A3B MoE multimodal model supports image, video, audio, and text workflows with checkpoint conversion, inference, SFT, and PEFT (LoRA) examples. Read the [NVIDIA Blog](https://blogs.nvidia.com/blog/nemotron-3-nano-omni-multimodal-ai-agents/) and see the [examples README](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/examples/models/nemotron/nemotron_3_omni/README.md) for the full walkthrough.

--- a/skills/verl-e2e-testing/SKILL.md
+++ b/skills/verl-e2e-testing/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: verl-e2e-testing
-description: External verl end-to-end validation workflow for Megatron-Bridge model/provider changes. Covers running a small verl Megatron backend job from a Bridge checkout, choosing LoRA/DDP plus optional save/resume and parallelism variants, setting PYTHONPATH so verl imports the local Bridge tree, and reporting pass/fail evidence.
-when_to_use: Adding or changing a Megatron-Bridge model/provider and needing downstream verl compatibility validation; checking non-vanilla Bridge provider paths; testing PEFT/LoRA, DDP, checkpoint behavior, or explicitly requested advanced variants through verl; 'does this model work in verl', 'run verl e2e', 'external RL loop validation'.
+description: External verl end-to-end validation workflow for Megatron-Bridge changes. Covers running a small verl Megatron backend job from a Bridge checkout, choosing LoRA/DDP plus optional save/resume and parallelism variants, setting PYTHONPATH so verl imports the local Bridge tree, and reporting pass/fail evidence.
+when_to_use: Changing Megatron-Bridge code that needs downstream verl compatibility validation; checking non-vanilla Bridge paths; testing PEFT/LoRA, DDP, checkpoint behavior, or explicitly requested advanced variants through verl; 'does this work in verl', 'run verl e2e', 'external RL loop validation'.
 ---
 
 # verl E2E Testing
 
-Validate a Megatron-Bridge model addition through verl's Megatron backend. This catches integration issues that Bridge-only conversion tests miss: provider configuration, HF import through Bridge, PEFT wrapping, DDP wrapping, optimizer setup, rollout/ref wiring, and checkpoint ownership by an external RL loop.
+Validate a Megatron-Bridge change through verl's Megatron backend. This catches integration issues that Bridge-only tests miss: provider/configuration finalization, HF import through Bridge, PEFT wrapping, DDP wrapping, optimizer setup, rollout/ref wiring, and checkpoint ownership by an external RL loop.
 
-Use this as an external compatibility smoke test after the Bridge unit and functional tests for a new model provider are green.
+Use this as an external compatibility smoke test after the relevant Bridge unit and functional tests are green.
 
-This is not a replacement for Bridge model parity tests. The default verl PPO run proves that the provider can survive an external RL training loop; architecture-specific correctness still comes from Bridge import/export, logits/roundtrip, and model-specific inference tests.
+This is not a replacement for Bridge correctness tests. The default verl run proves that the changed Bridge path can survive an external RL training loop; numerical parity, import/export fidelity, and feature-specific behavior still come from focused Bridge tests.
 
 ## Scope
 
@@ -18,12 +18,12 @@ Think in coverage levels. Start with Level 0 and add only the levels justified b
 
 | Level | Required when | What it proves |
 |---|---|---|
-| 0: LoRA + DDP smoke | Any new provider or provider config change that claims verl compatibility | verl can import the local Bridge provider, apply PEFT, wrap with Megatron DDP, build optimizer state, run rollout/ref/critic wiring, and finish one PPO step |
+| 0: LoRA + DDP smoke | Any Bridge change that claims verl compatibility | verl can import the local Bridge checkout, apply PEFT, wrap with Megatron DDP, build optimizer state, run rollout/ref/critic wiring, and finish one training step |
 | 1: Save/resume | PEFT, checkpointing, HF export, adapter export, optimizer state, or resume behavior changed | verl-owned checkpoint scheduling can save and reload Bridge-built model state |
 | 2: Parallelism stress | Provider finalization, mpu-derived settings, TP/PP/CP/EP, sequence parallel, or dispatcher behavior changed | provider settings remain correct under non-trivial Megatron parallel state |
 | 3: Optional Megatron-FSDP | Only when downstream explicitly asks for verl Megatron-FSDP coverage or the change directly touches that integration path | the same provider works when verl selects Megatron-FSDP instead of DDP |
-| 4: Architecture-specific e2e | VLM, MoE, MTP, QAT/ModelOpt, quantized weights, or custom layer behavior is involved | the part of the architecture not exercised by text-only GSM8K also has a targeted runtime check |
-| 5: Convergence / learning signal | Optimizer, scheduler, loss, reward, PEFT trainability, gradient flow, or model-specific training stability changed | metrics move in the expected direction over a short run and do not silently produce zero/NaN/unstable updates |
+| 4: Feature-specific e2e | The change depends on runtime behavior not exercised by the default text-only smoke | the requested feature is activated by a targeted verl command or script |
+| 5: Convergence / learning signal | Optimizer, scheduler, loss, reward, PEFT trainability, gradient flow, or training stability changed | metrics move in the expected direction over a short run and do not silently produce zero/NaN/unstable updates |
 
 The default Level 0 target is a short, non-vanilla Bridge run in verl with LoRA enabled and Megatron DDP selected:
 
@@ -38,7 +38,7 @@ TOTAL_TRAIN_STEPS=1
 
 This is intentionally small. It exercises the Bridge-facing path in verl without making Megatron-Bridge own rollout scheduling, reward handling, optimizer scheduling, or checkpoint orchestration.
 
-Level 0 is not a convergence test. It only proves the training loop can complete one update. Use Level 5 when the question is whether the model actually learns under verl.
+Level 0 is not a convergence test. It only proves the training loop can complete one update. Use Level 5 when the question is whether the run shows a learning signal under verl.
 
 Megatron-FSDP is not part of the default validation expected for current provider compatibility work. Run it only for Level 3 coverage when FSDP is explicitly in scope:
 
@@ -121,7 +121,7 @@ bash tests/special_e2e/run_ppo_trainer_megatron.sh \
   "++ray_kwargs.ray_init.runtime_env.env_vars.PYTHONPATH=${PYTHONPATH}"
 ```
 
-If this import fails before model construction, fix the runtime environment first. The official verl image may not contain every Bridge dependency; for example, Bridge imports `modelopt` through `AutoBridge`, so a missing `nvidia-modelopt` can fail the smoke before verl exercises the provider:
+If this import fails before Bridge-managed construction, fix the runtime environment first. The official verl image may not contain every Bridge dependency; for example, Bridge imports `modelopt` through `AutoBridge`, so a missing `nvidia-modelopt` can fail the smoke before verl exercises the changed path:
 
 ```bash
 python -m pip show nvidia-modelopt || \
@@ -130,11 +130,11 @@ python -m pip show nvidia-modelopt || \
 
 Treat ad-hoc installs as container setup evidence, not repository changes. If the image lacks `uv`, run focused Bridge unit tests in a Bridge development environment instead of forcing them through the verl container.
 
-## Model Choice
+## Checkpoint Or Config Choice
 
-Prefer the smallest public HF checkpoint that uses the changed provider family. For example, use a 0.5B or 0.6B dense checkpoint for dense provider changes before testing larger variants.
+Prefer the smallest representative HF checkpoint or local converted checkpoint that exercises the changed Bridge path. Start small before testing larger variants.
 
-If there is no small public checkpoint for the new architecture, use verl's dummy-model path with a minimal HF config from that architecture:
+If there is no practical checkpoint for the changed path, use verl's dummy-config path with a minimal HF config:
 
 ```bash
 USE_DUMMY_MODEL=True
@@ -142,17 +142,17 @@ DUMMY_MODEL_CONFIG_PATH=/path/to/minimal_config.json
 MODEL_ID=<org>/<representative-model-name>
 ```
 
-Report dummy-model results carefully: they validate model construction and training mechanics, not pretrained weight compatibility.
+Report dummy-config results carefully: they validate construction and training mechanics, not pretrained weight compatibility.
 
-For VLMs, the generic GSM8K PPO run is text-only. It can validate the language-side Bridge provider and external-loop wrapping, but it does not prove image/video preprocessing or vision encoder execution. Pair it with the VLM conversion/inference tests from @skills/adding-model-support/tests-and-examples.md, or use a verl multimodal training command if one exists for the model family.
+The default text-only smoke does not activate every feature. If the change depends on a specialized runtime path, use the closest maintained verl example or project script that actually enables that path, and record the exact environment variables and Hydra overrides.
 
-For MoE models, Level 0 with `COMMON_EP=1` still catches many provider and PEFT issues, but it does not stress expert parallel routing. Add a Level 2 run with expert parallelism when the change touches expert layout, dispatcher config, router replay, or expert tensor parallelism.
+For distributed behavior, a Level 0 run with all parallel sizes set to 1 is not enough evidence. Add Level 2 coverage when the change touches tensor, pipeline, context, expert, sequence, dispatcher, or mpu-derived settings.
 
-For MTP, QAT/ModelOpt, or quantized checkpoint support, the generic wrapper may not activate the feature. Use the closest verl example or model-family script that turns the feature on, and record the extra Hydra overrides in the report.
+When a script already exists for the requested workflow, prefer it over reconstructing a long command by hand. Verify the log shows the requested RL algorithm and backend rather than inferring it from the script name.
 
 ## Bridge Checks First
 
-Run focused Bridge tests before the external verl e2e. Include any model-specific tests added by the change.
+Run focused Bridge tests before the external verl e2e. Include any change-specific tests added by the PR.
 
 ```bash
 cd "$BRIDGE_REPO"
@@ -160,22 +160,22 @@ uv run python -m pytest -q \
   tests/unit_tests/models/test_model_provider_mixin.py \
   tests/unit_tests/models/test_param_mapping.py \
   tests/unit_tests/training/test_integration.py \
-  <model-specific-test-paths>
+  <change-specific-test-paths>
 ```
 
-For a new model family, also run the relevant conversion or roundtrip test from the model's PR. See @skills/adding-model-support/tests-and-examples.md for model-test patterns.
+For changes that affect import/export, also run the relevant conversion, roundtrip, or parity test from the PR.
 
-Minimum Bridge-side evidence for a new model/provider:
+Minimum Bridge-side evidence for a new verl-facing Bridge path:
 
 - provider/config unit tests
 - parameter mapping tests
-- HF to Megatron import or roundtrip on a small model
-- model-specific generation or logits comparison when available
+- HF to Megatron import or roundtrip on a small checkpoint or config
+- change-specific runtime or parity check when available
 - this verl external-loop smoke after the above pass
 
 ## verl Data Setup
 
-verl's Megatron PPO smoke wrapper expects GSM8K parquet files by default. Prepare them once from the verl checkout if they are missing:
+verl's default Megatron smoke wrapper expects task parquet files. Prepare the default dataset once from the verl checkout if it is missing:
 
 ```bash
 cd "$VERL_REPO"
@@ -206,11 +206,11 @@ bash tests/special_e2e/run_ppo_trainer_megatron.sh \
   reward.reward_model.enable=False
 ```
 
-Report this as a limitation; it still tests Bridge actor/ref/critic construction, LoRA, DDP wrapping, rollout, and one PPO update, but not reward-model serving.
+Report this as a limitation; it still tests Bridge actor/ref/critic construction, LoRA, DDP wrapping, rollout, and one training update, but not reward-model serving.
 
 ## Minimal verl Run
 
-Use verl's maintained wrapper rather than constructing a long Hydra command manually:
+Use verl's maintained wrapper, or the closest maintained example script for the requested workflow, rather than constructing a long Hydra command manually:
 
 ```bash
 cd "$VERL_REPO"
@@ -264,6 +264,8 @@ grep -E "Training Progress|VANILLA_MBRIDGE|Traceback|RuntimeError|KeyError|Value
 
 Prefer a saved log over a pasted terminal excerpt in PR descriptions.
 
+Do not trust the command shape alone. Inspect the log or resolved config to confirm the requested algorithm, rollout backend, non-vanilla Bridge path, response length, checkpoint policy, and parallelism settings are actually active.
+
 For time-limited smoke runs where vLLM CUDA graph capture dominates setup and the goal is Bridge provider validation, it is acceptable to add:
 
 ```bash
@@ -271,7 +273,7 @@ bash tests/special_e2e/run_ppo_trainer_megatron.sh \
   actor_rollout_ref.rollout.enforce_eager=True
 ```
 
-Report this override as a limitation. It still validates Bridge import, HF import, LoRA, Megatron DDP, rollout wiring, and one PPO update, but not vLLM CUDA graph capture.
+Report this override as a limitation. It still validates Bridge import, HF import, LoRA, Megatron DDP, rollout wiring, and one training update, but not vLLM CUDA graph capture.
 
 ## Save/Resume Coverage
 
@@ -289,9 +291,11 @@ bash tests/special_e2e/run_ppo_trainer_megatron.sh
 
 Remove stale verl `checkpoints/` output between unrelated experiments. Keep it for resume validation.
 
+If save/load fails, first confirm whether verl expected keys from an original checkpoint that the Bridge export intentionally did not regenerate. Missing sibling tensors, stale source-key maps, or intentionally dropped auxiliary keys should be handled explicitly rather than ignored by a broad non-strict save.
+
 ## Parallelism Stress
 
-Use Level 2 when the provider reads or mutates parallelism-related fields, or when the change touches `provider.configure(...)`, Megatron `mpu`, sequence parallel, context parallel, MoE dispatcher behavior, or tensor/expert tensor parallel settings.
+Use Level 2 when the provider reads or mutates parallelism-related fields, or when the change touches `provider.configure(...)`, Megatron `mpu`, sequence parallel, context parallel, dispatcher behavior, or tensor/expert tensor parallel settings.
 
 The variants below assume the Level 0 exports above are still in the shell; each command overrides only the values being tested.
 
@@ -307,7 +311,7 @@ USE_MEGATRON_FSDP=False \
 bash tests/special_e2e/run_ppo_trainer_megatron.sh
 ```
 
-Example MoE stress variant, only for compatible MoE checkpoints:
+Example routed/expert stress variant, only when the checkpoint and change support it:
 
 ```bash
 COMMON_EP=2 \
@@ -342,7 +346,7 @@ For Bridge-native FSDP behavior and constraints, also read @skills/nemo-mbridge-
 
 Use Level 5 only when the change affects trainability or when downstream validation explicitly asks for convergence. Do not require it for every provider-only PR; RL convergence is slower, noisier, and more environment-dependent than the compatibility smoke.
 
-The goal is a short learning-signal run, not a full benchmark. Prefer a small model, fixed data, fixed seed when available, and enough steps to observe non-random metric movement:
+The goal is a short learning-signal run, not a full benchmark. Prefer a small representative checkpoint, fixed data, fixed seed when available, and enough steps to observe non-random metric movement:
 
 ```bash
 TOTAL_TRAIN_STEPS=20 \
@@ -368,6 +372,10 @@ Acceptable convergence evidence depends on the task, but the report should inclu
 - validation or reward trend compared against the starting point or a known-good baseline
 - no repeated zero gradients, frozen LoRA adapters, or constant logprobs unless expected
 
+Treat flat or saturated metrics as a real signal to triage. Constant rewards, constant critic values, repeated cap-hit response lengths, or near-identical rollout logprobs can indicate data, reward, rollout, masking, or Bridge-side integration problems.
+
+For response-generation changes, verify the configured max response length is long enough for the dataset and reward. If many samples hit the cap, the learning-signal run is not strong evidence; increase context/response limits or adjust batch sizing before interpreting metrics.
+
 Do not call a 20-step run "converged" in the benchmark sense. Call it "learning-signal passed" unless it reaches a pre-agreed metric threshold.
 
 ## Container Image
@@ -378,7 +386,7 @@ Use the official verl Docker images as the default source:
 https://hub.docker.com/r/verlai/verl
 ```
 
-For this skill's default PPO smoke path, pick a vLLM-flavored `verlai/verl` image tag unless the test intentionally changes the rollout engine. The maintained wrapper defaults to vLLM, and the command should make that explicit with:
+For this skill's default smoke path, pick a vLLM-flavored `verlai/verl` image tag unless the test intentionally changes the rollout engine. The maintained wrapper defaults to vLLM, and the command should make that explicit with:
 
 ```bash
 ENGINE=vllm
@@ -396,7 +404,7 @@ If the cluster requires Enroot/SquashFS images, convert or mirror the selected `
 
 ## Slurm or Container Runs
 
-Use the cluster's standard container and mount both checkouts into the container. Keep setup and the actual PPO run in the same container step when using node-local paths such as `/tmp`; node-local model caches and ad-hoc pip installs disappear when a fresh container step starts. Keep paths generic in scripts committed to Megatron-Bridge:
+Use the cluster's standard container and mount both checkouts into the container. Keep setup and the actual training run in the same container step when using node-local paths such as `/tmp`; node-local model caches and ad-hoc pip installs disappear when a fresh container step starts. Keep paths generic in scripts committed to Megatron-Bridge:
 
 ```bash
 export VERL_IMAGE=${VERL_IMAGE:-verlai/verl:<vllm-compatible-tag>}
@@ -431,6 +439,8 @@ If an attach helper enters a container that no longer sees the expected checkout
 
 On CUDA/H100 clusters, some launchers set both `CUDA_VISIBLE_DEVICES` and ROCm variables such as `ROCR_VISIBLE_DEVICES`. If verl workers fail before model construction with `Please don't set ROCR_VISIBLE_DEVICES when HIP/CUDA_VISIBLE_DEVICES is set`, fix the launcher/container environment or apply a temporary local verl workaround that drops `ROCR_VISIBLE_DEVICES` when CUDA is already set. Do not report this as a Bridge provider failure.
 
+Keep GPU usage proportional to the evidence needed. For OOMs, first reduce per-GPU load or adjust TP/PP/CP, micro-batches, rollout batch size, and response length tradeoffs. Increase node count only as far as needed for the requested validation, and record why the chosen scale was necessary.
+
 For general Slurm debugging and multi-node patterns, read @skills/nemo-mbridge-multi-node-slurm/SKILL.md.
 
 ## Pass Criteria
@@ -443,15 +453,15 @@ A useful pass has all of the following:
 - One training step reaches completion, for example `Training Progress: 100%|1/1|`.
 - No exception occurs during Bridge provider setup, HF import, LoRA wrapping, DDP wrapping, optional FSDP wrapping when enabled, optimizer setup, checkpoint manager setup, or the training step.
 
-Ray shutdown, Python resource-tracker warnings, or post-completion DataLoader worker termination can be acceptable if the training step completed, metrics for `training/global_step:1` were logged, and the process exits successfully. Mention them as residual log noise.
+Ray shutdown, Python resource-tracker warnings, or post-completion DataLoader worker termination can be acceptable if the requested training step completed, metrics for the expected global step were logged, and the process exits successfully. Mention them as residual log noise.
 
-Do not claim full model e2e if the run used a dummy config, text-only data for a VLM, `COMMON_EP=1` for an expert-parallel change, or disabled save/resume for a checkpointing change. Call it the exact level that passed.
+Do not overclaim coverage if the run used a dummy config, a generic dataset that does not activate the changed feature, trivial parallelism for a distributed change, or disabled save/resume for a checkpointing change. Call it the exact level that passed.
 
 Do not claim convergence from Level 0. Claim convergence only from Level 5, and distinguish "learning signal" from "benchmark convergence" in the report.
 
 ## Failure Triage
 
-If model construction fails, check whether the Bridge provider is finalized with the same parallel sizes that verl initialized through Megatron `mpu`.
+If construction fails, check whether the Bridge provider is finalized with the same parallel sizes that verl initialized through Megatron `mpu`.
 
 If LoRA fails, check target module names and whether the provider path uses the non-vanilla Bridge PEFT helpers expected by verl.
 
@@ -461,7 +471,7 @@ If rollout fails before actor construction, this may be a verl rollout engine is
 
 If the log shows the wrong Bridge path, stop. Any later failure or pass is not evidence for the local Bridge change.
 
-If the baseline fails before model build because of data, reward model, Ray, vLLM, or package setup, fix the environment first and do not report it as a provider failure.
+If the baseline fails before Bridge-managed construction because of data, reward model, Ray, vLLM, or package setup, fix the environment first and do not report it as a Bridge failure.
 
 If model download fails with `No space left on device`, move `HF_HOME`, `HF_HUB_CACHE`, and `MODEL_PATH` to a larger shared or node-local path, then rerun with the explicit local `MODEL_PATH`.
 
@@ -472,28 +482,28 @@ End every run with a short user-facing summary that answers "Did the requested d
 ```text
 Result: <Pass/Fail/Blocked> - <one sentence stating what was validated>
 Requested coverage: <Level 0/1/2/3/4/5 and requested variants>
-Model: <MODEL_ID or MODEL_PATH>
+Checkpoint/config: <MODEL_ID, MODEL_PATH, or dummy config>
 
 Deliverables:
 - Bridge-side checks: <Pass/Fail/Skipped> - <test command or skipped reason>
 - Local Bridge import in verl: <Pass/Fail> - <PYTHONPATH or imported Bridge path>
 - verl Megatron backend run: <Pass/Fail/Skipped> - <LoRA + DDP or requested variant>
-- Requested variants: <Pass/Fail/Skipped/Not requested> - <save/resume, parallelism stress, Megatron-FSDP, architecture-specific run, or learning-signal/convergence>
+- Requested variants: <Pass/Fail/Skipped/Not requested> - <save/resume, parallelism stress, Megatron-FSDP, feature-specific run, or learning-signal/convergence>
 - Log capture: <Pass/Fail> - <log path>
 
 Evidence:
 - Bridge repo: <commit> plus dirty files
 - verl repo: <commit> plus dirty files
 - Command: <exact command or script path>
-- Key lines: <VANILLA_MBRIDGE=False, Training Progress completion, training/global_step:1, or the first relevant error>
+- Key lines: <requested algorithm/backend, VANILLA_MBRIDGE=False, Training Progress completion, expected global-step metrics, or the first relevant error>
 
 Limitations:
-- <dummy model, skipped save/resume, COMMON_EP=1, text-only data for VLM, no convergence claim, known shutdown warnings, etc.>
+- <dummy config, skipped save/resume, trivial parallelism, generic data that did not activate a feature, no convergence claim, known shutdown warnings, etc.>
 
 Follow-ups:
 - <needed rerun, environment fix, provider fix, or "none">
 ```
 
-If the job is blocked before Bridge model/provider construction by data, reward model, Ray, vLLM, dependency, disk, or cluster setup, mark the overall result as `Blocked`, not `Fail`, and state that it is not evidence against the Bridge provider.
+If the job is blocked before Bridge-managed construction by data, reward model, Ray, vLLM, dependency, disk, or cluster setup, mark the overall result as `Blocked`, not `Fail`, and state that it is not evidence against the Bridge change.
 
 If any requested deliverable was not run, mark it `Skipped` or `Not requested` with the reason. Do not leave it implicit in the limitations.

--- a/src/megatron/bridge/models/conversion/auto_bridge.py
+++ b/src/megatron/bridge/models/conversion/auto_bridge.py
@@ -74,6 +74,44 @@ HF_ARCHITECTURE_ALIASES: dict[str, str] = {
     "Qwen2_5OmniModel": "Qwen2_5OmniForConditionalGeneration",
 }
 
+MTP_CONFIG_FIELDS: tuple[str, ...] = ("num_nextn_predict_layers", "mtp_num_hidden_layers", "mtp_num_layers")
+_MISSING = object()
+
+
+def _get_config_field(config: Any, field: str) -> Any:
+    if isinstance(config, dict):
+        return config.get(field, _MISSING)
+
+    return getattr(config, "__dict__", {}).get(field, _MISSING)
+
+
+def _config_disables_mtp(config: Any) -> bool:
+    """Return True when a config object or dict explicitly disables MTP layers."""
+    if config is None:
+        return False
+
+    for field in MTP_CONFIG_FIELDS:
+        value = _get_config_field(config, field)
+        if value is _MISSING or value is None:
+            continue
+
+        return int(value) == 0
+
+    text_config = _get_config_field(config, "text_config")
+    return text_config is not _MISSING and _config_disables_mtp(text_config)
+
+
+def _saved_config_disables_mtp(path: str | Path) -> bool:
+    """Check the final config.json written for an HF export."""
+    import json
+
+    config_path = Path(path) / "config.json"
+    if not config_path.exists():
+        return False
+    with open(config_path) as f:
+        return _config_disables_mtp(json.load(f))
+
+
 # Preformatted display string for error/help messages
 SUPPORTED_HF_ARCHITECTURES_DISPLAY = " or ".join(f"'{s}'" for s in SUPPORTED_HF_ARCHITECTURES)
 
@@ -841,12 +879,20 @@ class AutoBridge(Generic[MegatronModelT]):
             and hasattr(self.hf_pretrained.state, "source")
             and isinstance(self.hf_pretrained.state.source, SafeTensorsStateSource)
         ):
-            self.hf_pretrained.state.source.save_generator(
+            source = self.hf_pretrained.state.source
+            model_config = getattr(model_instance, "config", None)
+            hf_config = getattr(self.hf_pretrained, "config", self.hf_pretrained)
+            mtp_disabled = _saved_config_disables_mtp(path) or any(
+                _config_disables_mtp(config) for config in (hf_config, model_config)
+            )
+            ignored_source_key_prefixes = ("mtp.",) if mtp_disabled and source.has_glob("mtp.*") else None
+            source.save_generator(
                 generator,
                 path,
                 strict=strict,
                 distributed_save=distributed_save,
                 save_every_n_ranks=save_every_n_ranks,
+                ignored_source_key_prefixes=ignored_source_key_prefixes,
             )
         else:
             # Config-only path: shard and write safetensors directly

--- a/src/megatron/bridge/models/conversion/quantization_utils.py
+++ b/src/megatron/bridge/models/conversion/quantization_utils.py
@@ -139,6 +139,7 @@ def dequantize_fp8_e4m3fn_with_scale(
             scale_exp = scale_f32.unsqueeze(1)
         else:
             scale_exp = scale_f32.repeat_interleave(block_size)[: weight_f32.shape[0]].unsqueeze(1)
+        scale_exp = scale_exp.expand_as(weight_f32)
     elif scale_f32.dim() != 2:
         label = f" for {name!r}" if name else ""
         raise RuntimeError(f"Unsupported FP8 scale rank{label}: scale={tuple(scale.shape)}")

--- a/src/megatron/bridge/models/conversion/quantization_utils.py
+++ b/src/megatron/bridge/models/conversion/quantization_utils.py
@@ -13,17 +13,56 @@
 # limitations under the License.
 
 import math
+from collections.abc import Callable, Mapping
 
 import torch
+import torch.nn.functional as F
 
 
 FP8_BLOCK_SIZE = 128
 FP8_DTYPES = (torch.float8_e4m3fn, torch.float8_e5m2)
+FP8_E4M3_MAX = 448.0
+FP4_E2M1_MAX = 6.0
+MXFP4_BLOCK_SIZE = 32
+
+_FP4_E2M1_TABLE_VALUES = [
+    0.0,
+    0.5,
+    1.0,
+    1.5,
+    2.0,
+    3.0,
+    4.0,
+    6.0,
+    -0.0,
+    -0.5,
+    -1.0,
+    -1.5,
+    -2.0,
+    -3.0,
+    -4.0,
+    -6.0,
+]
 
 
 def is_fp8_tensor(tensor: torch.Tensor) -> bool:
     """Return whether *tensor* uses one of PyTorch's FP8 dtypes."""
     return tensor.dtype in FP8_DTYPES
+
+
+def is_float8_e8m0_dtype(dtype: torch.dtype) -> bool:
+    """Return whether *dtype* is PyTorch's E8M0 scale dtype."""
+    e8m0_dtype = getattr(torch, "float8_e8m0fnu", None)
+    return e8m0_dtype is not None and dtype == e8m0_dtype
+
+
+def scale_from_amax(amax: torch.Tensor, max_quantized_value: float, scale_dtype: torch.dtype) -> torch.Tensor:
+    """Build positive quantization scales in the same scale family as ``scale_dtype``."""
+    scale = torch.where(amax > 0, amax / max_quantized_value, torch.ones_like(amax))
+    if is_float8_e8m0_dtype(scale_dtype):
+        scale = scale.clamp(min=2.0**-127, max=2.0**127)
+        return torch.exp2(torch.ceil(torch.log2(scale)))
+    return scale
 
 
 def dequantize_fp8_blockwise(
@@ -80,6 +119,161 @@ def maybe_dequantize_fp8(
     return weight.to(dtype) * scale_inv.to(dtype)
 
 
+def dequantize_fp8_e4m3fn_with_scale(
+    weight: torch.Tensor,
+    scale: torch.Tensor,
+    *,
+    name: str = "",
+    block_size: int = FP8_BLOCK_SIZE,
+    dtype: torch.dtype = torch.bfloat16,
+) -> torch.Tensor:
+    """Dequantize FP8 E4M3 weights with a companion scale tensor.
+
+    Supports three common HF checkpoint scale layouts:
+    1-D per-row or row-block scales, 2-D per-row K tiles, and 2-D block scales.
+    """
+    weight_f32 = weight.to(torch.float32)
+    scale_f32 = scale.to(torch.float32)
+    if scale_f32.dim() == 1:
+        if scale_f32.shape[0] == weight_f32.shape[0]:
+            scale_exp = scale_f32.unsqueeze(1)
+        else:
+            scale_exp = scale_f32.repeat_interleave(block_size)[: weight_f32.shape[0]].unsqueeze(1)
+    elif scale_f32.dim() != 2:
+        label = f" for {name!r}" if name else ""
+        raise RuntimeError(f"Unsupported FP8 scale rank{label}: scale={tuple(scale.shape)}")
+    elif scale_f32.shape[0] == weight_f32.shape[0]:
+        tile_k = weight_f32.shape[1] // scale_f32.shape[1]
+        scale_exp = scale_f32.repeat_interleave(tile_k, dim=1)[:, : weight_f32.shape[1]]
+    else:
+        scale_exp = scale_f32.repeat_interleave(block_size, dim=0)[: weight_f32.shape[0]]
+        scale_exp = scale_exp.repeat_interleave(block_size, dim=1)[:, : weight_f32.shape[1]]
+    if scale_exp.shape != weight_f32.shape:
+        label = f" for {name!r}" if name else ""
+        raise RuntimeError(
+            f"FP8 dequant shape mismatch{label}: "
+            f"weight={tuple(weight_f32.shape)} scale={tuple(scale.shape)} "
+            f"scale_exp={tuple(scale_exp.shape)}"
+        )
+    return (weight_f32 * scale_exp).to(dtype)
+
+
+def _quantize_fp8_2d_blocks(
+    weight: torch.Tensor,
+    source_scale: torch.Tensor,
+    *,
+    name: str = "",
+    block_size: int = FP8_BLOCK_SIZE,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    rows, cols = weight.shape
+    scale_rows, scale_cols = source_scale.shape
+    expected_shape = (
+        (rows + block_size - 1) // block_size,
+        (cols + block_size - 1) // block_size,
+    )
+    if (scale_rows, scale_cols) != expected_shape:
+        label = f" for {name!r}" if name else ""
+        raise RuntimeError(
+            f"Unsupported FP8 scale geometry{label}: "
+            f"weight={tuple(weight.shape)} scale={tuple(source_scale.shape)} expected={expected_shape}"
+        )
+
+    weight_f32 = weight.to(torch.float32)
+    pad_rows = scale_rows * block_size - rows
+    pad_cols = scale_cols * block_size - cols
+    if pad_rows or pad_cols:
+        weight_f32 = F.pad(weight_f32, (0, pad_cols, 0, pad_rows))
+
+    blocks = weight_f32.view(scale_rows, block_size, scale_cols, block_size).transpose(1, 2)
+    scale_f32 = scale_from_amax(blocks.abs().amax(dim=(-1, -2)), FP8_E4M3_MAX, source_scale.dtype)
+    q_blocks = (blocks / scale_f32[:, :, None, None]).to(torch.float8_e4m3fn)
+    q_weight = q_blocks.transpose(1, 2).reshape(scale_rows * block_size, scale_cols * block_size)[:rows, :cols]
+    return q_weight.contiguous(), scale_f32.to(dtype=source_scale.dtype)
+
+
+def _quantize_fp8_per_row_tiles(
+    weight: torch.Tensor,
+    source_scale: torch.Tensor,
+    *,
+    name: str = "",
+) -> tuple[torch.Tensor, torch.Tensor]:
+    rows, cols = weight.shape
+    scale_rows, scale_cols = source_scale.shape
+    if scale_rows != rows or scale_cols <= 0 or cols % scale_cols != 0:
+        label = f" for {name!r}" if name else ""
+        raise RuntimeError(
+            f"Unsupported per-row FP8 scale geometry{label}: "
+            f"weight={tuple(weight.shape)} scale={tuple(source_scale.shape)}"
+        )
+
+    tile_cols = cols // scale_cols
+    grouped = weight.to(torch.float32).reshape(rows, scale_cols, tile_cols)
+    scale_f32 = scale_from_amax(grouped.abs().amax(dim=-1), FP8_E4M3_MAX, source_scale.dtype)
+    q_weight = (grouped / scale_f32[:, :, None]).to(torch.float8_e4m3fn).reshape(rows, cols)
+    return q_weight.contiguous(), scale_f32.to(dtype=source_scale.dtype)
+
+
+def _quantize_fp8_1d_scale(
+    weight: torch.Tensor,
+    source_scale: torch.Tensor,
+    *,
+    name: str = "",
+    block_size: int = FP8_BLOCK_SIZE,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    rows, _ = weight.shape
+    scale_len = source_scale.numel()
+    weight_f32 = weight.to(torch.float32)
+
+    if scale_len == rows:
+        scale_f32 = scale_from_amax(weight_f32.abs().amax(dim=1), FP8_E4M3_MAX, source_scale.dtype)
+        q_weight = (weight_f32 / scale_f32[:, None]).to(torch.float8_e4m3fn)
+        return q_weight.contiguous(), scale_f32.to(dtype=source_scale.dtype)
+
+    expected_len = (rows + block_size - 1) // block_size
+    if scale_len != expected_len:
+        label = f" for {name!r}" if name else ""
+        raise RuntimeError(
+            f"Unsupported 1-D FP8 scale geometry{label}: "
+            f"weight={tuple(weight.shape)} scale={tuple(source_scale.shape)} expected_len={expected_len}"
+        )
+
+    q_weight = torch.empty_like(weight_f32, dtype=torch.float8_e4m3fn)
+    scale_f32 = torch.empty(scale_len, dtype=torch.float32, device=weight.device)
+    for block_idx in range(scale_len):
+        row_start = block_idx * block_size
+        row_end = min(row_start + block_size, rows)
+        block = weight_f32[row_start:row_end]
+        block_scale = scale_from_amax(block.abs().amax().reshape(()), FP8_E4M3_MAX, source_scale.dtype)
+        q_weight[row_start:row_end] = (block / block_scale).to(torch.float8_e4m3fn)
+        scale_f32[block_idx] = block_scale
+    return q_weight.contiguous(), scale_f32.to(dtype=source_scale.dtype)
+
+
+def quantize_fp8_e4m3fn_like_scale(
+    weight: torch.Tensor,
+    source_scale: torch.Tensor,
+    *,
+    name: str = "",
+    block_size: int = FP8_BLOCK_SIZE,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize a 2-D weight to FP8 E4M3 using ``source_scale`` geometry and dtype."""
+    if weight.ndim != 2:
+        label = f" for {name!r}" if name else ""
+        raise RuntimeError(f"FP8 quantized export expects a 2-D weight{label}, got {weight.ndim}D")
+
+    if source_scale.ndim == 1:
+        return _quantize_fp8_1d_scale(weight, source_scale, name=name, block_size=block_size)
+
+    if source_scale.ndim != 2:
+        label = f" for {name!r}" if name else ""
+        raise RuntimeError(f"Unsupported FP8 scale rank{label}: scale={tuple(source_scale.shape)}")
+
+    if source_scale.shape[0] == weight.shape[0]:
+        return _quantize_fp8_per_row_tiles(weight, source_scale, name=name)
+
+    return _quantize_fp8_2d_blocks(weight, source_scale, name=name, block_size=block_size)
+
+
 def dequantize_mxfp4(
     blocks: torch.Tensor,
     scales: torch.Tensor,
@@ -89,26 +283,8 @@ def dequantize_mxfp4(
 ) -> torch.Tensor:
     """Dequantize GPT-OSS MXFP4 block/scales tensors."""
     assert blocks.shape[:-1] == scales.shape, f"{blocks.shape=} does not match {scales.shape=}"
-    fp4_values = [
-        +0.0,
-        +0.5,
-        +1.0,
-        +1.5,
-        +2.0,
-        +3.0,
-        +4.0,
-        +6.0,
-        -0.0,
-        -0.5,
-        -1.0,
-        -1.5,
-        -2.0,
-        -3.0,
-        -4.0,
-        -6.0,
-    ]
     scales = scales.to(torch.int32) - 127
-    lut = torch.tensor(fp4_values, dtype=dtype, device=blocks.device)
+    lut = torch.tensor(_FP4_E2M1_TABLE_VALUES, dtype=dtype, device=blocks.device)
 
     *prefix_shape, G, B = blocks.shape
     rows_total = math.prod(prefix_shape) * G
@@ -135,6 +311,164 @@ def dequantize_mxfp4(
         del idx_lo, idx_hi, blk, exp
 
     return out.reshape(*prefix_shape, G, B * 2).view(*prefix_shape, G * B * 2)
+
+
+def dequantize_mxfp4_e2m1_packed(
+    weight_packed: torch.Tensor,
+    scale: torch.Tensor,
+    *,
+    dtype: torch.dtype = torch.bfloat16,
+) -> torch.Tensor:
+    """Dequantize MXFP4 E2M1 weights packed two values per byte.
+
+    ``scale`` is expected to be one scale per row and per K tile. E8M0 scale
+    tensors can be passed directly; ``.to(torch.float32)`` materializes their
+    power-of-two values.
+    """
+    w_u8 = weight_packed.view(torch.uint8)
+    lo = (w_u8 & 0xF).to(torch.int64)
+    hi = (w_u8 >> 4).to(torch.int64)
+
+    table = torch.tensor(_FP4_E2M1_TABLE_VALUES, dtype=torch.float32, device=weight_packed.device)
+    logical = torch.stack([table[lo], table[hi]], dim=-1).reshape(weight_packed.shape[0], -1)
+
+    scale_f32 = scale.to(torch.float32)
+    if scale_f32.dim() != 2 or scale_f32.shape[0] != logical.shape[0] or logical.shape[1] % scale_f32.shape[1] != 0:
+        raise RuntimeError(
+            f"Unsupported MXFP4 scale geometry: "
+            f"weight={tuple(weight_packed.shape)} logical={tuple(logical.shape)} scale={tuple(scale.shape)}"
+        )
+    block_size = logical.shape[1] // scale_f32.shape[1]
+    scale_exp = scale_f32.repeat_interleave(block_size, dim=1)
+
+    return (logical * scale_exp).to(dtype)
+
+
+def is_mxfp4_e2m1_scale_geometry(
+    weight: torch.Tensor,
+    source_scale: torch.Tensor,
+    *,
+    block_size: int = MXFP4_BLOCK_SIZE,
+) -> bool:
+    """Return whether ``source_scale`` describes packed MXFP4 E2M1 K tiles."""
+    return (
+        weight.ndim == 2
+        and source_scale.ndim == 2
+        and source_scale.shape[0] == weight.shape[0]
+        and source_scale.shape[1] * block_size == weight.shape[1]
+    )
+
+
+def quantize_mxfp4_e2m1_like_scale(
+    weight: torch.Tensor,
+    source_scale: torch.Tensor,
+    *,
+    name: str = "",
+    block_size: int = MXFP4_BLOCK_SIZE,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize a 2-D weight to packed MXFP4 E2M1 using source scale geometry."""
+    if weight.ndim != 2:
+        label = f" for {name!r}" if name else ""
+        raise RuntimeError(f"MXFP4 quantized export expects a 2-D weight{label}, got {weight.ndim}D")
+
+    rows, cols = weight.shape
+    if cols % 2 != 0 or cols % block_size != 0 or source_scale.shape != (rows, cols // block_size):
+        label = f" for {name!r}" if name else ""
+        raise RuntimeError(
+            f"Unsupported MXFP4 geometry{label}: weight={tuple(weight.shape)} scale={tuple(source_scale.shape)}"
+        )
+
+    weight_f32 = weight.to(torch.float32)
+    packed = torch.empty((rows, cols // 2), dtype=torch.uint8, device=weight.device)
+    scale_f32 = torch.empty(tuple(source_scale.shape), dtype=torch.float32, device=weight.device)
+    boundaries = torch.tensor([0.25, 0.75, 1.25, 1.75, 2.5, 3.5, 5.0], dtype=torch.float32, device=weight.device)
+
+    max_chunk_elements = 16_000_000
+    rows_per_chunk = max(1, min(rows, max_chunk_elements // max(cols, 1)))
+    scale_cols = source_scale.shape[1]
+    for row_start in range(0, rows, rows_per_chunk):
+        row_end = min(row_start + rows_per_chunk, rows)
+        chunk = weight_f32[row_start:row_end].reshape(-1, scale_cols, block_size)
+        chunk_scale = scale_from_amax(chunk.abs().amax(dim=-1), FP4_E2M1_MAX, source_scale.dtype)
+        scale_f32[row_start:row_end] = chunk_scale
+
+        normalized = chunk / chunk_scale[:, :, None]
+        codes = torch.bucketize(normalized.abs(), boundaries).to(torch.uint8)
+        codes = (codes | ((normalized < 0).to(torch.uint8) * 8)).reshape(row_end - row_start, cols)
+
+        lo = codes[:, 0::2].to(torch.int16)
+        hi = codes[:, 1::2].to(torch.int16)
+        packed[row_start:row_end] = (lo | (hi << 4)).to(torch.uint8)
+
+    return packed.contiguous().view(torch.int8), scale_f32.to(dtype=source_scale.dtype)
+
+
+def maybe_dequantize_hf_quantized_weight(
+    hf_param: str | dict[str, str],
+    hf_state_dict: Mapping[str, torch.Tensor],
+    *,
+    dtype: torch.dtype = torch.bfloat16,
+) -> torch.Tensor | dict[str, torch.Tensor]:
+    """Load and dequantize HF ``*.weight`` tensors that carry sibling ``*.scale`` tensors."""
+    if isinstance(hf_param, dict):
+        return {k: maybe_dequantize_hf_quantized_weight(v, hf_state_dict, dtype=dtype) for k, v in hf_param.items()}
+
+    weight = hf_state_dict[hf_param]
+
+    if weight.dtype == torch.int8:
+        scale_key = hf_param[: -len(".weight")] + ".scale" if hf_param.endswith(".weight") else None
+        if scale_key is None or scale_key not in hf_state_dict:
+            return weight.to(dtype)
+        return dequantize_mxfp4_e2m1_packed(weight, hf_state_dict[scale_key], dtype=dtype)
+
+    if weight.dtype != torch.float8_e4m3fn:
+        return weight
+
+    if not hf_param.endswith(".weight"):
+        return weight.to(dtype)
+
+    scale_key = hf_param[: -len(".weight")] + ".scale"
+    if scale_key not in hf_state_dict:
+        return weight.to(dtype)
+
+    return dequantize_fp8_e4m3fn_with_scale(weight, hf_state_dict[scale_key], name=hf_param, dtype=dtype)
+
+
+def requantize_hf_weight_scale_pairs(
+    converted_weights_dict: Mapping[str, torch.Tensor],
+    hf_state_dict: Mapping[str, torch.Tensor],
+    *,
+    use_mxfp4: Callable[[str, torch.Tensor, torch.Tensor], bool] | None = None,
+) -> dict[str, torch.Tensor]:
+    """Recreate quantized HF ``*.weight``/``*.scale`` pairs using source scale layout.
+
+    ``use_mxfp4`` lets model bridges opt specific parameters into packed MXFP4
+    output. Other scaled weights are emitted as FP8 E4M3.
+    """
+    result: dict[str, torch.Tensor] = {}
+    for hf_param, weight in converted_weights_dict.items():
+        if not hf_param.endswith(".weight"):
+            if hf_param.endswith(".scale"):
+                weight_key = hf_param[: -len(".scale")] + ".weight"
+                if weight_key in converted_weights_dict:
+                    continue
+            result[hf_param] = weight
+            continue
+
+        scale_key = hf_param[: -len(".weight")] + ".scale"
+        if scale_key not in hf_state_dict:
+            result[hf_param] = weight
+            continue
+
+        source_scale = hf_state_dict[scale_key]
+        if use_mxfp4 is not None and use_mxfp4(hf_param, weight, source_scale):
+            q_weight, q_scale = quantize_mxfp4_e2m1_like_scale(weight, source_scale, name=hf_param)
+        else:
+            q_weight, q_scale = quantize_fp8_e4m3fn_like_scale(weight, source_scale, name=hf_param)
+
+        result[hf_param] = q_weight
+        result[scale_key] = q_scale
+    return result
 
 
 def dequantize_int4(

--- a/src/megatron/bridge/models/deepseek/deepseek_v4_bridge.py
+++ b/src/megatron/bridge/models/deepseek/deepseek_v4_bridge.py
@@ -69,6 +69,7 @@ from megatron.core.models.gpt.experimental_attention_variant_module_specs import
 )
 from megatron.core.models.gpt.gpt_model import GPTModel
 
+from megatron.bridge.models.conversion import quantization_utils
 from megatron.bridge.models.conversion.mapping_registry import MegatronMappingRegistry
 from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge, WeightConversionTask
 from megatron.bridge.models.conversion.param_mapping import (
@@ -162,6 +163,13 @@ def _dsv4_compress_ratios(hf_config) -> list[int]:
     return ratios[:expected_len]
 
 
+def _dsv4_use_mxfp4_export(hf_param: str, weight: torch.Tensor, source_scale: torch.Tensor) -> bool:
+    """Routed DSv4 experts use packed MXFP4; all other scaled weights export as FP8."""
+    if ".ffn.experts." not in hf_param or ".shared_experts." in hf_param:
+        return False
+    return quantization_utils.is_mxfp4_e2m1_scale_geometry(weight, source_scale)
+
+
 # ---------------------------------------------------------------------------
 # Custom mapping helpers
 # ---------------------------------------------------------------------------
@@ -252,16 +260,6 @@ class _HCAlphaSecondaryMapping(MegatronParamMapping):
     def megatron_to_hf(self, megatron_weights, megatron_module):
         # Already handled by the primary alpha_pre _HCAlphaMapping
         return {}
-
-
-# MXFP4 E2M1 lookup table: nibble value 0-15 → float32
-# FP4 E2M1 (sign=1, exponent=2, mantissa=1, exp_bias=1):
-#   positive: [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0]
-#   negative: [-0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0]
-_FP4_E2M1_TABLE = torch.tensor(
-    [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0, -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0],
-    dtype=torch.float32,
-)
 
 
 class _ReplicatedOptional(ReplicatedMapping):
@@ -500,52 +498,6 @@ class DeepSeekV4Bridge(MegatronModelBridge):
     # FP8 / MXFP4 dequantisation on import
     # ------------------------------------------------------------------
 
-    def _dequant_mxfp4(
-        self,
-        hf_param: str,
-        weight_i8: torch.Tensor,
-        hf_state_dict: Mapping[str, torch.Tensor],
-    ) -> torch.Tensor:
-        """Dequantize MXFP4-packed expert weights (I8 body + F8_E8M0 block scale).
-
-        Each I8 byte stores 2 FP4 E2M1 nibbles (low nibble = first element,
-        high nibble = second element, i.e. [lo0, hi0, lo1, hi1, ...]).
-        One E8M0 scale covers 32 consecutive FP4 elements along K.
-
-        Args:
-            hf_param: Weight tensor name (used to derive scale key).
-            weight_i8: Raw I8 tensor of shape (M, K//2).
-            hf_state_dict: Full HF state dict for scale lookup.
-
-        Returns:
-            Dequantised weight as bfloat16 of shape (M, K).
-        """
-        scale_key = hf_param[: -len(".weight")] + ".scale" if hf_param.endswith(".weight") else None
-        if scale_key is None or scale_key not in hf_state_dict:
-            return weight_i8.to(torch.bfloat16)
-
-        scale = hf_state_dict[scale_key]  # F8_E8M0, shape (M, K_scale)
-
-        # Reinterpret int8 as uint8 so bitwise ops give correct 0-15 nibbles
-        w_u8 = weight_i8.view(torch.uint8)  # (M, K_packed)
-        lo = (w_u8 & 0xF).to(torch.int64)  # (M, K_packed)
-        hi = (w_u8 >> 4).to(torch.int64)  # (M, K_packed)
-
-        table = _FP4_E2M1_TABLE.to(weight_i8.device)
-        # stack [lo_row, hi_row] along last dim then flatten → interleaved (M, K_logical)
-        # This creates a contiguous output avoiding slow strided writes.
-        logical = torch.stack([table[lo], table[hi]], dim=-1).reshape(
-            weight_i8.shape[0], -1
-        )  # (M, K_logical), float32
-
-        # E8M0 scale: value = 2^(e - 127), block_size = K_logical / K_scale = 32
-        scale_f32 = scale.to(torch.float32)  # E8M0 .to(f32) already gives 2^(e-127)
-        block_size = logical.shape[1] // scale_f32.shape[1]
-        # repeat_interleave along dim=1 expands (M, K_scale) → (M, K_logical)
-        scale_exp = scale_f32.repeat_interleave(block_size, dim=1)
-
-        return (logical * scale_exp).to(torch.bfloat16)
-
     def maybe_modify_loaded_hf_weight(
         self,
         hf_param,
@@ -558,54 +510,7 @@ class DeepSeekV4Bridge(MegatronModelBridge):
         F8_E8M0 per-32-element scales.  For dict hf_param (GatedMLPMapping etc.),
         dequantizes each key individually so expert gate/up weights are also handled.
         """
-        if isinstance(hf_param, dict):
-            # Recurse for each key so each string key gets dequantized individually
-            return {k: self.maybe_modify_loaded_hf_weight(v, hf_state_dict) for k, v in hf_param.items()}
-
-        weight = hf_state_dict[hf_param]
-
-        # MXFP4 packed (I8): expert FFN gate/up/down weights
-        if weight.dtype == torch.int8:
-            return self._dequant_mxfp4(hf_param, weight, hf_state_dict)
-
-        if weight.dtype != torch.float8_e4m3fn:
-            return weight
-
-        if not hf_param.endswith(".weight"):
-            return weight.to(torch.bfloat16)
-
-        scale_key = hf_param[: -len(".weight")] + ".scale"
-        if scale_key not in hf_state_dict:
-            return weight.to(torch.bfloat16)
-
-        scale = hf_state_dict[scale_key]  # [ceil(out/128), ceil(in/128)], float8_e8m0fnu
-        weight_bf16 = weight.to(torch.bfloat16)
-
-        # Detect scale format: 128-tile (attn) vs per-row/16-tile (expert FFN)
-        # Attention: scale = (ceil(M/128), ceil(K/128))
-        # Expert FFN: scale = (M, ceil(K/16))  [per-row, 16-element K-tiles]
-        scale_f32 = scale.to(torch.float32)
-        if scale_f32.dim() == 1:
-            # 1-D scale: single value per row (broadcast over K)
-            if scale_f32.shape[0] == weight_bf16.shape[0]:
-                scale_exp = scale_f32.unsqueeze(1)
-            else:
-                scale_exp = scale_f32.repeat_interleave(128)[: weight_bf16.shape[0]].unsqueeze(1)
-        elif scale_f32.shape[0] == weight_bf16.shape[0]:
-            # Per-row format: scale[i, j] covers weight[i, j*16:(j+1)*16]
-            tile_k = weight_bf16.shape[1] // scale_f32.shape[1]
-            scale_exp = scale_f32.repeat_interleave(tile_k, dim=1)[:, : weight_bf16.shape[1]]
-        else:
-            # 128-tile format: scale[i, j] covers weight[i*128:(i+1)*128, j*128:(j+1)*128]
-            scale_exp = scale_f32.repeat_interleave(128, dim=0)[: weight_bf16.shape[0]]
-            scale_exp = scale_exp.repeat_interleave(128, dim=1)[:, : weight_bf16.shape[1]]
-        if scale_exp.shape != weight_bf16.shape:
-            raise RuntimeError(
-                f"FP8 dequant shape mismatch for {hf_param!r}: "
-                f"weight={tuple(weight_bf16.shape)} scale={tuple(scale.shape)} "
-                f"scale_exp={tuple(scale_exp.shape)}"
-            )
-        return (weight_bf16.to(torch.float32) * scale_exp).to(torch.bfloat16)
+        return quantization_utils.maybe_dequantize_hf_quantized_weight(hf_param, hf_state_dict)
 
     # ------------------------------------------------------------------
     # Weight mapping registry
@@ -939,7 +844,7 @@ class DeepSeekV4Bridge(MegatronModelBridge):
         return MegatronMappingRegistry(*mappings)
 
     # ------------------------------------------------------------------
-    # Export: synthesise inv_freq (keeps roundtrip HF compat)
+    # Export: restore HF quantized weight/scale pairs
     # ------------------------------------------------------------------
 
     def maybe_modify_converted_hf_weight(
@@ -948,5 +853,10 @@ class DeepSeekV4Bridge(MegatronModelBridge):
         converted_weights_dict: Dict[str, torch.Tensor],
         hf_state_dict: Mapping[str, torch.Tensor],
     ) -> Dict[str, torch.Tensor]:
-        """No-op for V4: the checkpoint does not contain inv_freq tensors."""
-        return converted_weights_dict
+        """Recreate DSv4 quantized weight/scale pairs expected by the source shard index."""
+        del task
+        return quantization_utils.requantize_hf_weight_scale_pairs(
+            converted_weights_dict,
+            hf_state_dict,
+            use_mxfp4=_dsv4_use_mxfp4_export,
+        )

--- a/src/megatron/bridge/models/hf_pretrained/state.py
+++ b/src/megatron/bridge/models/hf_pretrained/state.py
@@ -733,6 +733,8 @@ class SafeTensorsStateSource(StateSource):
                 part of weights independently.
             save_every_n_ranks: Interval for saving weights across ranks in distributed mode.
                 For example, if set to 2, only ranks 0, 2, 4, ... will save weights.
+            ignored_source_key_prefixes: Source tensor key prefixes to omit from the expected
+                source sharding map when saving.
 
         """
         if distributed_save:

--- a/src/megatron/bridge/models/hf_pretrained/state.py
+++ b/src/megatron/bridge/models/hf_pretrained/state.py
@@ -463,6 +463,19 @@ class SafeTensorsStateSource(StateSource):
         self._keys_cache: Optional[List[str]] = None
         self._key_to_filename_map_cache: Optional[Dict[str, str]] = None
 
+    @staticmethod
+    def _ignore_source_key_prefixes(
+        key_to_filename_map: Mapping[str, str] | None,
+        ignored_source_key_prefixes: Iterable[str] | None,
+    ) -> Dict[str, str]:
+        if not key_to_filename_map:
+            return {}
+        if not ignored_source_key_prefixes:
+            return dict(key_to_filename_map)
+
+        prefixes = tuple(ignored_source_key_prefixes)
+        return {key: filename for key, filename in key_to_filename_map.items() if not key.startswith(prefixes)}
+
     @property
     def path(self) -> Path:
         """
@@ -693,6 +706,7 @@ class SafeTensorsStateSource(StateSource):
         strict: bool = True,
         distributed_save: bool = False,
         save_every_n_ranks: int = 1,
+        ignored_source_key_prefixes: Iterable[str] | None = None,
     ):
         """
         Saves tensors from a generator to `.safetensors` files, preserving the
@@ -723,7 +737,11 @@ class SafeTensorsStateSource(StateSource):
         """
         if distributed_save:
             return self._save_generator_distributed(
-                generator, output_path, strict, save_every_n_ranks=save_every_n_ranks
+                generator,
+                output_path,
+                strict,
+                save_every_n_ranks=save_every_n_ranks,
+                ignored_source_key_prefixes=ignored_source_key_prefixes,
             )
 
         # In a distributed environment, only rank 0 should write to disk.
@@ -743,7 +761,7 @@ class SafeTensorsStateSource(StateSource):
         output_path = Path(output_path)
         output_path.mkdir(parents=True, exist_ok=True)
 
-        key_to_filename_map = self.key_to_filename_map
+        key_to_filename_map = self._ignore_source_key_prefixes(self.key_to_filename_map, ignored_source_key_prefixes)
         all_expected_keys = set(key_to_filename_map.keys())
 
         if not key_to_filename_map:
@@ -893,6 +911,7 @@ class SafeTensorsStateSource(StateSource):
         output_path: Union[str, Path],
         strict: bool = True,
         save_every_n_ranks: int = 1,
+        ignored_source_key_prefixes: Iterable[str] | None = None,
     ):
         is_distributed = torch.distributed.is_available() and torch.distributed.is_initialized()
         if is_distributed:
@@ -919,7 +938,7 @@ class SafeTensorsStateSource(StateSource):
         if is_distributed:
             torch.distributed.barrier()
 
-        key_to_filename_map = self.key_to_filename_map
+        key_to_filename_map = self._ignore_source_key_prefixes(self.key_to_filename_map, ignored_source_key_prefixes)
 
         # Fallback: no sharding map, single-file save
         if not key_to_filename_map:

--- a/tests/unit_tests/models/deepseek/test_deepseek_v4_bridge.py
+++ b/tests/unit_tests/models/deepseek/test_deepseek_v4_bridge.py
@@ -211,6 +211,70 @@ class TestDeepSeekV4QuantizedExport:
         assert set(result) == {"norm.weight"}
         assert result["norm.weight"] is weight
 
+    def test_export_roundtrips_mixed_quantized_hf_state(self):
+        bridge = DeepSeekV4Bridge()
+        fp8_param = "layers.0.attn.wq_a.weight"
+        fp8_scale = "layers.0.attn.wq_a.scale"
+        mxfp4_param = "layers.0.ffn.experts.0.w1.weight"
+        mxfp4_scale = "layers.0.ffn.experts.0.w1.scale"
+        norm_param = "layers.0.attn_norm.weight"
+
+        fp8_weight = torch.full((4, 4), 2.0, dtype=torch.bfloat16)
+        mxfp4_values = torch.tensor(
+            [
+                0.0,
+                0.5,
+                1.0,
+                1.5,
+                2.0,
+                3.0,
+                4.0,
+                6.0,
+                -0.0,
+                -0.5,
+                -1.0,
+                -1.5,
+                -2.0,
+                -3.0,
+                -4.0,
+                -6.0,
+            ],
+            dtype=torch.float32,
+        ).repeat(2)
+        mxfp4_weight = mxfp4_values.reshape(1, 32).to(torch.bfloat16)
+        norm_weight = torch.arange(4, dtype=torch.float32).to(torch.bfloat16)
+
+        stale_scale = torch.full((1, 1), 9.0, dtype=torch.float32)
+        result = bridge.maybe_modify_converted_hf_weight(
+            _dummy_task(),
+            {
+                fp8_param: fp8_weight,
+                fp8_scale: stale_scale,
+                mxfp4_param: mxfp4_weight,
+                mxfp4_scale: stale_scale,
+                norm_param: norm_weight,
+            },
+            {
+                fp8_scale: torch.ones((1, 1), dtype=torch.float32),
+                mxfp4_scale: torch.ones((1, 1), dtype=torch.float32),
+            },
+        )
+
+        assert set(result) == {fp8_param, fp8_scale, mxfp4_param, mxfp4_scale, norm_param}
+        assert result[fp8_param].dtype == torch.float8_e4m3fn
+        assert result[mxfp4_param].dtype == torch.int8
+        assert result[mxfp4_param].shape == (1, 16)
+        assert result[fp8_scale].shape == (1, 1)
+        assert result[mxfp4_scale].shape == (1, 1)
+        assert not torch.equal(result[fp8_scale], stale_scale)
+        assert not torch.equal(result[mxfp4_scale], stale_scale)
+        assert result[norm_param] is norm_weight
+
+        restored_fp8 = bridge.maybe_modify_loaded_hf_weight(fp8_param, result)
+        restored_mxfp4 = bridge.maybe_modify_loaded_hf_weight(mxfp4_param, result)
+        assert torch.allclose(restored_fp8.float(), fp8_weight.float())
+        assert torch.equal(restored_mxfp4.float(), mxfp4_weight.float())
+
 
 class TestDecoderHCHeadMappings:
     """The global decoder HC-head triplet must be replicated mappings."""

--- a/tests/unit_tests/models/deepseek/test_deepseek_v4_bridge.py
+++ b/tests/unit_tests/models/deepseek/test_deepseek_v4_bridge.py
@@ -21,7 +21,9 @@ and ``h_proj`` mappings, and no deprecated concatenated ``eh_proj`` path.
 from types import SimpleNamespace
 
 import pytest
+import torch
 
+from megatron.bridge.models.conversion import quantization_utils
 from megatron.bridge.models.conversion.param_mapping import AutoMapping, ReplicatedMapping
 from megatron.bridge.models.deepseek.deepseek_v4_bridge import (
     DeepSeekV4Bridge,
@@ -50,6 +52,10 @@ def bridge_without_mtp():
 def _by_megatron(registry):
     """Index mappings by megatron_param for quick lookup in assertions."""
     return {m.megatron_param: m for m in registry.mappings}
+
+
+def _dummy_task():
+    return SimpleNamespace(param_name="", global_param_name="", mapping=None)
 
 
 class TestNativeDeepSeekV4ConfigTranslation:
@@ -94,6 +100,97 @@ class TestNativeDeepSeekV4ConfigTranslation:
 
         with pytest.raises(ValueError, match="contiguous prefix"):
             _dsv4_num_hash_layers(hf_config)
+
+
+class TestDeepSeekV4QuantizedExport:
+    """DSv4 export must regenerate quantized weights and scale tensors."""
+
+    def test_export_quantizes_fp8_weight_and_emits_scale(self):
+        bridge = DeepSeekV4Bridge()
+        hf_param = "layers.0.attn.wq_a.weight"
+        scale_key = "layers.0.attn.wq_a.scale"
+        weight = torch.full((4, 4), 2.0, dtype=torch.bfloat16)
+        source_state = {scale_key: torch.ones((1, 1), dtype=torch.float32)}
+
+        result = bridge.maybe_modify_converted_hf_weight(_dummy_task(), {hf_param: weight}, source_state)
+
+        assert set(result) == {hf_param, scale_key}
+        assert result[hf_param].dtype == torch.float8_e4m3fn
+        assert result[scale_key].shape == source_state[scale_key].shape
+        assert result[scale_key].dtype == source_state[scale_key].dtype
+
+        restored = bridge.maybe_modify_loaded_hf_weight(hf_param, result)
+        assert restored.dtype == torch.bfloat16
+        assert torch.allclose(restored.float(), weight.float())
+
+    def test_export_preserves_e8m0_scale_dtype(self):
+        e8m0_dtype = getattr(torch, "float8_e8m0fnu", None)
+        if e8m0_dtype is None:
+            pytest.skip("torch.float8_e8m0fnu is unavailable")
+        try:
+            source_scale = torch.ones((1, 1), dtype=e8m0_dtype)
+        except RuntimeError as exc:
+            pytest.skip(f"torch.float8_e8m0fnu tensor creation is unavailable: {exc}")
+
+        bridge = DeepSeekV4Bridge()
+        hf_param = "layers.0.attn.wq_a.weight"
+        scale_key = "layers.0.attn.wq_a.scale"
+        weight = torch.full((4, 4), 2.0, dtype=torch.bfloat16)
+
+        result = bridge.maybe_modify_converted_hf_weight(_dummy_task(), {hf_param: weight}, {scale_key: source_scale})
+
+        assert result[hf_param].dtype == torch.float8_e4m3fn
+        assert result[scale_key].dtype == e8m0_dtype
+        restored = bridge.maybe_modify_loaded_hf_weight(hf_param, result)
+        assert torch.allclose(restored.float(), weight.float())
+
+    def test_export_quantizes_routed_expert_to_mxfp4_and_emits_scale(self):
+        bridge = DeepSeekV4Bridge()
+        hf_param = "layers.0.ffn.experts.0.w1.weight"
+        scale_key = "layers.0.ffn.experts.0.w1.scale"
+        values = torch.tensor(
+            [
+                0.0,
+                0.5,
+                1.0,
+                1.5,
+                2.0,
+                3.0,
+                4.0,
+                6.0,
+                -0.0,
+                -0.5,
+                -1.0,
+                -1.5,
+                -2.0,
+                -3.0,
+                -4.0,
+                -6.0,
+            ],
+            dtype=torch.float32,
+        ).repeat(2)
+        weight = values.reshape(1, 32).to(torch.bfloat16)
+        source_state = {scale_key: torch.ones((1, 1), dtype=torch.float32)}
+
+        result = bridge.maybe_modify_converted_hf_weight(_dummy_task(), {hf_param: weight}, source_state)
+
+        assert set(result) == {hf_param, scale_key}
+        assert result[hf_param].dtype == torch.int8
+        assert result[hf_param].shape == (1, 16)
+        assert result[scale_key].shape == source_state[scale_key].shape
+        assert result[scale_key].dtype == source_state[scale_key].dtype
+
+        restored = quantization_utils.dequantize_mxfp4_e2m1_packed(result[hf_param], result[scale_key])
+        assert torch.equal(restored.float(), weight.float())
+
+    def test_export_leaves_unscaled_weight_unchanged(self):
+        bridge = DeepSeekV4Bridge()
+        weight = torch.ones(4, 4, dtype=torch.bfloat16)
+
+        result = bridge.maybe_modify_converted_hf_weight(_dummy_task(), {"norm.weight": weight}, {})
+
+        assert set(result) == {"norm.weight"}
+        assert result["norm.weight"] is weight
 
 
 class TestDecoderHCHeadMappings:

--- a/tests/unit_tests/models/deepseek/test_deepseek_v4_bridge.py
+++ b/tests/unit_tests/models/deepseek/test_deepseek_v4_bridge.py
@@ -183,6 +183,25 @@ class TestDeepSeekV4QuantizedExport:
         restored = quantization_utils.dequantize_mxfp4_e2m1_packed(result[hf_param], result[scale_key])
         assert torch.equal(restored.float(), weight.float())
 
+    @pytest.mark.parametrize(
+        "hf_param",
+        [
+            "layers.0.ffn.shared_experts.w1.weight",
+            "layers.0.ffn.experts.0.w1.weight",
+        ],
+    )
+    def test_export_uses_fp8_for_non_mxfp4_expert_scale_geometry(self, hf_param):
+        bridge = DeepSeekV4Bridge()
+        scale_key = hf_param.removesuffix(".weight") + ".scale"
+        weight = torch.full((4, 4), 2.0, dtype=torch.bfloat16)
+
+        result = bridge.maybe_modify_converted_hf_weight(
+            _dummy_task(), {hf_param: weight}, {scale_key: torch.ones(1, 1)}
+        )
+
+        assert result[hf_param].dtype == torch.float8_e4m3fn
+        assert result[scale_key].shape == (1, 1)
+
     def test_export_leaves_unscaled_weight_unchanged(self):
         bridge = DeepSeekV4Bridge()
         weight = torch.ones(4, 4, dtype=torch.bfloat16)

--- a/tests/unit_tests/models/hf_pretrained/test_state_dict.py
+++ b/tests/unit_tests/models/hf_pretrained/test_state_dict.py
@@ -467,6 +467,57 @@ class TestSafeTensorsStateSourceSave:
             output_index = json.load(f)
         assert output_index["weight_map"] == {"model.weight": "model-00001-of-00001.safetensors"}
 
+    def test_ignore_source_key_prefixes_filters_expected_map(self):
+        source_map = {
+            "model.weight": "model.safetensors",
+            "mtp.0.weight": "model.safetensors",
+            "mtp_extra.weight": "model.safetensors",
+        }
+
+        assert SafeTensorsStateSource._ignore_source_key_prefixes(None, ("mtp.",)) == {}
+        assert SafeTensorsStateSource._ignore_source_key_prefixes(source_map, None) == source_map
+        assert SafeTensorsStateSource._ignore_source_key_prefixes(source_map, ("mtp.",)) == {
+            "model.weight": "model.safetensors",
+            "mtp_extra.weight": "model.safetensors",
+        }
+
+    def test_distributed_save_generator_ignores_source_key_prefixes_without_initialized_dist(self, tmp_path):
+        from safetensors.torch import save_file
+
+        source_dir = tmp_path / "source"
+        output_dir = tmp_path / "output"
+        source_dir.mkdir()
+        save_file(
+            {
+                "model.weight": torch.ones(1),
+                "mtp.0.weight": torch.ones(1),
+            },
+            source_dir / "model-00001-of-00001.safetensors",
+        )
+        with open(source_dir / "model.safetensors.index.json", "w") as f:
+            json.dump(
+                {
+                    "metadata": {},
+                    "weight_map": {
+                        "model.weight": "model-00001-of-00001.safetensors",
+                        "mtp.0.weight": "model-00001-of-00001.safetensors",
+                    },
+                },
+                f,
+            )
+
+        source = SafeTensorsStateSource(source_dir)
+        source.save_generator(
+            iter([("model.weight", torch.zeros(1))]),
+            output_dir,
+            distributed_save=True,
+            ignored_source_key_prefixes=("mtp.",),
+        )
+
+        with open(output_dir / "model.safetensors.index.json") as f:
+            output_index = json.load(f)
+        assert output_index["weight_map"] == {"model.weight": "model-00001-of-00001.safetensors"}
+
 
 class TestStateDictCachingAndOptimization:
     """Test caching and optimization features."""

--- a/tests/unit_tests/models/hf_pretrained/test_state_dict.py
+++ b/tests/unit_tests/models/hf_pretrained/test_state_dict.py
@@ -424,6 +424,50 @@ class TestStateDictConvenienceMethods:
         assert all(key.startswith("transformer") and key.endswith("weight") for key in tensors)
 
 
+class TestSafeTensorsStateSourceSave:
+    """Test streaming safetensors save behavior."""
+
+    def test_save_generator_ignores_source_key_prefixes(self, tmp_path, capsys):
+        from safetensors.torch import save_file
+
+        source_dir = tmp_path / "source"
+        output_dir = tmp_path / "output"
+        source_dir.mkdir()
+        save_file(
+            {
+                "model.weight": torch.ones(1),
+                "mtp.0.weight": torch.ones(1),
+            },
+            source_dir / "model-00001-of-00001.safetensors",
+        )
+        with open(source_dir / "model.safetensors.index.json", "w") as f:
+            json.dump(
+                {
+                    "metadata": {},
+                    "weight_map": {
+                        "model.weight": "model-00001-of-00001.safetensors",
+                        "mtp.0.weight": "model-00001-of-00001.safetensors",
+                    },
+                },
+                f,
+            )
+
+        source = SafeTensorsStateSource(source_dir)
+        source.save_generator(
+            iter([("model.weight", torch.zeros(1))]),
+            output_dir,
+            ignored_source_key_prefixes=("mtp.",),
+        )
+
+        output = capsys.readouterr().out
+        assert "Error:" not in output
+        assert "Success: All tensors from the original checkpoint were written." in output
+
+        with open(output_dir / "model.safetensors.index.json") as f:
+            output_index = json.load(f)
+        assert output_index["weight_map"] == {"model.weight": "model-00001-of-00001.safetensors"}
+
+
 class TestStateDictCachingAndOptimization:
     """Test caching and optimization features."""
 

--- a/tests/unit_tests/models/test_auto_bridge.py
+++ b/tests/unit_tests/models/test_auto_bridge.py
@@ -140,9 +140,13 @@ class TestAutoBridge:
 
     def test_mtp_disabled_helpers(self, tmp_path):
         """Detect disabled MTP in object, nested, and saved HF configs."""
+        assert _config_disables_mtp(None) is False
         assert _config_disables_mtp(Mock(num_nextn_predict_layers=0)) is True
+        assert _config_disables_mtp({"num_nextn_predict_layers": None, "text_config": {"mtp_num_layers": "0"}}) is True
         assert _config_disables_mtp({"text_config": {"mtp_num_hidden_layers": 0}}) is True
         assert _config_disables_mtp(Mock(num_nextn_predict_layers=1)) is False
+        assert _config_disables_mtp({"mtp_num_layers": "2"}) is False
+        assert _saved_config_disables_mtp(tmp_path) is False
 
         with open(tmp_path / "config.json", "w") as f:
             json.dump({"num_nextn_predict_layers": 0}, f)
@@ -1501,3 +1505,47 @@ class TestAutoBridge:
                 merge_adapter_weights=True,
             )
             mock_torch_save.assert_not_called()
+
+    @patch("torch.distributed.barrier")
+    @patch("torch.distributed.is_available", return_value=True)
+    @patch("torch.distributed.is_initialized", return_value=True)
+    @patch("torch.distributed.get_rank", return_value=0)
+    def test_save_hf_weights_ignores_mtp_source_keys_when_mtp_disabled(
+        self, mock_get_rank, mock_is_init, mock_is_avail, mock_barrier, tmp_path
+    ):
+        """Pass MTP source-key ignore prefixes when the exported config disables MTP."""
+        from megatron.bridge.models.hf_pretrained.state import SafeTensorsStateSource
+
+        class ModelWrapper:
+            pass
+
+        class ModelInstance:
+            pass
+
+        model_instance = ModelInstance()
+        model_instance.config = {"num_nextn_predict_layers": 0}
+        wrapper = ModelWrapper()
+        wrapper.module = model_instance
+
+        mock_hf_model = Mock(spec=PreTrainedCausalLM)
+        mock_hf_model.config = {"num_nextn_predict_layers": 1}
+        mock_hf_model.state = Mock()
+        mock_source = Mock(spec=SafeTensorsStateSource)
+        mock_source.has_glob.return_value = True
+        mock_hf_model.state.source = mock_source
+
+        bridge = AutoBridge.__new__(AutoBridge)
+        bridge.hf_pretrained = mock_hf_model
+
+        mock_model_bridge = Mock()
+        mock_model_bridge.stream_weights_megatron_to_hf.return_value = iter([("model.weight", torch.ones(1))])
+
+        with (
+            patch.object(AutoBridge, "_model_bridge", new_callable=PropertyMock) as mock_model_bridge_prop,
+            patch("megatron.bridge.models.conversion.auto_bridge.is_quantized", return_value=False),
+        ):
+            mock_model_bridge_prop.return_value = mock_model_bridge
+            bridge.save_hf_weights([wrapper], tmp_path)
+
+        assert mock_source.save_generator.call_args.kwargs["ignored_source_key_prefixes"] == ("mtp.",)
+        mock_source.has_glob.assert_called_once_with("mtp.*")

--- a/tests/unit_tests/models/test_auto_bridge.py
+++ b/tests/unit_tests/models/test_auto_bridge.py
@@ -25,7 +25,7 @@ import torch
 from transformers import LlamaConfig
 from transformers.configuration_utils import PretrainedConfig
 
-from megatron.bridge.models.conversion.auto_bridge import AutoBridge
+from megatron.bridge.models.conversion.auto_bridge import AutoBridge, _config_disables_mtp, _saved_config_disables_mtp
 from megatron.bridge.models.gpt_provider import GPTModelProvider
 from megatron.bridge.models.hf_pretrained.causal_lm import PreTrainedCausalLM
 
@@ -137,6 +137,17 @@ class TestAutoBridge:
 
             assert "Failed to load configuration" in str(exc_info.value)
             assert "Config not found" in str(exc_info.value)
+
+    def test_mtp_disabled_helpers(self, tmp_path):
+        """Detect disabled MTP in object, nested, and saved HF configs."""
+        assert _config_disables_mtp(Mock(num_nextn_predict_layers=0)) is True
+        assert _config_disables_mtp({"text_config": {"mtp_num_hidden_layers": 0}}) is True
+        assert _config_disables_mtp(Mock(num_nextn_predict_layers=1)) is False
+
+        with open(tmp_path / "config.json", "w") as f:
+            json.dump({"num_nextn_predict_layers": 0}, f)
+
+        assert _saved_config_disables_mtp(tmp_path) is True
 
     def test_can_handle_supported_model(self, llama_config_mock):
         """Test can_handle returns True for supported models."""

--- a/tests/unit_tests/models/test_quantization_utils.py
+++ b/tests/unit_tests/models/test_quantization_utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 import torch
 
 from megatron.bridge.models.conversion.quantization_utils import (
@@ -20,8 +21,10 @@ from megatron.bridge.models.conversion.quantization_utils import (
     dequantize_int4,
     dequantize_mxfp4,
     dequantize_mxfp4_e2m1_packed,
+    is_mxfp4_e2m1_scale_geometry,
     maybe_dequantize_fp8,
     maybe_dequantize_fp8_blockwise,
+    maybe_dequantize_hf_quantized_weight,
     quantize_fp8_e4m3fn_like_scale,
     quantize_mxfp4_e2m1_like_scale,
     quantize_to_int4,
@@ -86,6 +89,68 @@ def test_quantize_fp8_e4m3fn_like_scale_roundtrips_scaled_weight():
     assert torch.allclose(result.float(), weight.float())
 
 
+@pytest.mark.parametrize(
+    ("weight", "source_scale", "block_size"),
+    [
+        (
+            torch.tensor([[1.0, -1.0], [2.0, -2.0]], dtype=torch.bfloat16),
+            torch.ones(2),
+            128,
+        ),
+        (
+            torch.tensor(
+                [
+                    [2.0, -2.0, 2.0, -2.0],
+                    [2.0, -2.0, 2.0, -2.0],
+                    [4.0, -4.0, 4.0, -4.0],
+                ],
+                dtype=torch.bfloat16,
+            ),
+            torch.ones(2),
+            2,
+        ),
+        (
+            torch.tensor([[1.0, -1.0, 2.0, -2.0], [3.0, -3.0, 4.0, -4.0]], dtype=torch.bfloat16),
+            torch.ones(2, 2),
+            128,
+        ),
+    ],
+)
+def test_quantize_fp8_e4m3fn_like_scale_roundtrips_supported_scale_layouts(weight, source_scale, block_size):
+    q_weight, q_scale = quantize_fp8_e4m3fn_like_scale(weight, source_scale, block_size=block_size)
+    result = dequantize_fp8_e4m3fn_with_scale(q_weight, q_scale, block_size=block_size)
+
+    assert q_weight.dtype == torch.float8_e4m3fn
+    assert q_scale.shape == source_scale.shape
+    assert q_scale.dtype == source_scale.dtype
+    assert torch.allclose(result.float(), weight.float())
+
+
+@pytest.mark.parametrize(
+    ("weight", "source_scale", "message"),
+    [
+        (torch.ones(2, 2, 2), torch.ones(2), "expects a 2-D weight"),
+        (torch.ones(2, 4), torch.ones(1, 1, 1), "Unsupported FP8 scale rank"),
+        (torch.ones(3, 4), torch.ones(4), "Unsupported 1-D FP8 scale geometry"),
+        (torch.ones(2, 5), torch.ones(2, 2), "Unsupported per-row FP8 scale geometry"),
+        (torch.ones(4, 4), torch.ones(3, 1), "Unsupported FP8 scale geometry"),
+    ],
+)
+def test_quantize_fp8_e4m3fn_like_scale_rejects_unsupported_geometry(weight, source_scale, message):
+    with pytest.raises(RuntimeError, match=message):
+        quantize_fp8_e4m3fn_like_scale(weight, source_scale, block_size=2)
+
+
+def test_dequantize_fp8_e4m3fn_with_scale_rejects_unsupported_geometry():
+    fp8_weight = torch.ones(2, 3, dtype=torch.float8_e4m3fn)
+
+    with pytest.raises(RuntimeError, match="Unsupported FP8 scale rank"):
+        dequantize_fp8_e4m3fn_with_scale(fp8_weight, torch.ones(1, 1, 1))
+
+    with pytest.raises(RuntimeError, match="FP8 dequant shape mismatch"):
+        dequantize_fp8_e4m3fn_with_scale(fp8_weight, torch.ones(2, 2))
+
+
 def test_quantize_dequantize_mxfp4_e2m1_packed_roundtrips_representable_values():
     values = torch.tensor(
         [
@@ -120,6 +185,52 @@ def test_quantize_dequantize_mxfp4_e2m1_packed_roundtrips_representable_values()
     assert torch.equal(result.float(), weight.float())
 
 
+def test_mxfp4_scale_geometry_checks_logical_unpacked_shape():
+    weight = torch.ones(2, 64)
+
+    assert is_mxfp4_e2m1_scale_geometry(weight, torch.ones(2, 2))
+    assert not is_mxfp4_e2m1_scale_geometry(weight, torch.ones(2, 1))
+    assert not is_mxfp4_e2m1_scale_geometry(torch.ones(2, 2, 32), torch.ones(2, 2))
+
+
+def test_mxfp4_helpers_reject_unsupported_geometry():
+    with pytest.raises(RuntimeError, match="Unsupported MXFP4 scale geometry"):
+        dequantize_mxfp4_e2m1_packed(torch.zeros(1, 16, dtype=torch.int8), torch.ones(2, 1))
+
+    with pytest.raises(RuntimeError, match="expects a 2-D weight"):
+        quantize_mxfp4_e2m1_like_scale(torch.ones(1, 1, 32), torch.ones(1, 1))
+
+    with pytest.raises(RuntimeError, match="Unsupported MXFP4 geometry"):
+        quantize_mxfp4_e2m1_like_scale(torch.ones(1, 30), torch.ones(1, 1))
+
+
+def test_maybe_dequantize_hf_quantized_weight_dispatches_by_dtype_and_sibling_scale():
+    fp8_weight = torch.ones(2, 2, dtype=torch.float8_e4m3fn)
+    mxfp4_weight = torch.zeros(1, 16, dtype=torch.int8)
+    hf_state_dict = {
+        "fp8.weight": fp8_weight,
+        "fp8.scale": torch.ones(2),
+        "fp8.activation": fp8_weight,
+        "mxfp4.weight": mxfp4_weight,
+        "mxfp4.scale": torch.ones(1, 1),
+        "int8_without_scale.weight": mxfp4_weight,
+        "bf16.weight": torch.ones(1, dtype=torch.bfloat16),
+    }
+
+    result = maybe_dequantize_hf_quantized_weight(
+        {"fp8": "fp8.weight", "mxfp4": "mxfp4.weight"},
+        hf_state_dict,
+        dtype=torch.float32,
+    )
+
+    assert set(result) == {"fp8", "mxfp4"}
+    assert result["fp8"].dtype == torch.float32
+    assert result["mxfp4"].dtype == torch.float32
+    assert maybe_dequantize_hf_quantized_weight("fp8.activation", hf_state_dict).dtype == torch.bfloat16
+    assert maybe_dequantize_hf_quantized_weight("int8_without_scale.weight", hf_state_dict).dtype == torch.bfloat16
+    assert maybe_dequantize_hf_quantized_weight("bf16.weight", hf_state_dict) is hf_state_dict["bf16.weight"]
+
+
 def test_requantize_hf_weight_scale_pairs_emits_scale_siblings():
     weight_key = "layers.0.ffn.experts.0.w1.weight"
     scale_key = "layers.0.ffn.experts.0.w1.scale"
@@ -137,6 +248,35 @@ def test_requantize_hf_weight_scale_pairs_emits_scale_siblings():
     assert result[weight_key].dtype == torch.int8
     assert result[scale_key].shape == source_scale.shape
     assert not torch.equal(result[scale_key], stale_scale)
+
+
+def test_requantize_hf_weight_scale_pairs_preserves_unscaled_weights_and_stale_scales():
+    weight_key = "layers.0.self_attn.q_proj.weight"
+    stale_scale_key = "layers.0.self_attn.k_proj.scale"
+    scaled_weight_key = "layers.0.mlp.down_proj.weight"
+    scaled_scale_key = "layers.0.mlp.down_proj.scale"
+    unscaled_weight = torch.ones(1, 2, dtype=torch.bfloat16)
+    stale_scale = torch.full((1, 1), 9.0)
+    scaled_weight = torch.full((2, 4), 2.0, dtype=torch.bfloat16)
+    source_scale = torch.ones(2)
+
+    result = requantize_hf_weight_scale_pairs(
+        {
+            weight_key: unscaled_weight,
+            stale_scale_key: stale_scale,
+            scaled_weight_key: scaled_weight,
+            scaled_scale_key: stale_scale,
+            "metadata": torch.tensor(1.0),
+        },
+        {scaled_scale_key: source_scale},
+    )
+
+    assert result[weight_key] is unscaled_weight
+    assert result["metadata"].item() == 1.0
+    assert stale_scale_key in result
+    assert scaled_scale_key in result
+    assert result[scaled_weight_key].dtype == torch.float8_e4m3fn
+    assert result[scaled_scale_key].shape == source_scale.shape
 
 
 def test_quantize_dequantize_int4_preserves_shape_and_dtype():

--- a/tests/unit_tests/models/test_quantization_utils.py
+++ b/tests/unit_tests/models/test_quantization_utils.py
@@ -16,11 +16,16 @@ import torch
 
 from megatron.bridge.models.conversion.quantization_utils import (
     dequantize_fp8_blockwise,
+    dequantize_fp8_e4m3fn_with_scale,
     dequantize_int4,
     dequantize_mxfp4,
+    dequantize_mxfp4_e2m1_packed,
     maybe_dequantize_fp8,
     maybe_dequantize_fp8_blockwise,
+    quantize_fp8_e4m3fn_like_scale,
+    quantize_mxfp4_e2m1_like_scale,
     quantize_to_int4,
+    requantize_hf_weight_scale_pairs,
 )
 
 
@@ -66,6 +71,72 @@ def test_dequantize_mxfp4_uses_low_then_high_nibbles():
 
     assert result.shape == (1, 2)
     assert torch.equal(result, torch.tensor([[0.5, 1.0]]))
+
+
+def test_quantize_fp8_e4m3fn_like_scale_roundtrips_scaled_weight():
+    weight = torch.full((4, 4), 2.0, dtype=torch.bfloat16)
+    source_scale = torch.ones((1, 1), dtype=torch.float32)
+
+    q_weight, q_scale = quantize_fp8_e4m3fn_like_scale(weight, source_scale)
+    result = dequantize_fp8_e4m3fn_with_scale(q_weight, q_scale)
+
+    assert q_weight.dtype == torch.float8_e4m3fn
+    assert q_scale.shape == source_scale.shape
+    assert q_scale.dtype == source_scale.dtype
+    assert torch.allclose(result.float(), weight.float())
+
+
+def test_quantize_dequantize_mxfp4_e2m1_packed_roundtrips_representable_values():
+    values = torch.tensor(
+        [
+            0.0,
+            0.5,
+            1.0,
+            1.5,
+            2.0,
+            3.0,
+            4.0,
+            6.0,
+            -0.0,
+            -0.5,
+            -1.0,
+            -1.5,
+            -2.0,
+            -3.0,
+            -4.0,
+            -6.0,
+        ],
+        dtype=torch.float32,
+    ).repeat(2)
+    weight = values.reshape(1, 32).to(torch.bfloat16)
+    source_scale = torch.ones((1, 1), dtype=torch.float32)
+
+    packed, scale = quantize_mxfp4_e2m1_like_scale(weight, source_scale)
+    result = dequantize_mxfp4_e2m1_packed(packed, scale)
+
+    assert packed.dtype == torch.int8
+    assert packed.shape == (1, 16)
+    assert scale.shape == source_scale.shape
+    assert torch.equal(result.float(), weight.float())
+
+
+def test_requantize_hf_weight_scale_pairs_emits_scale_siblings():
+    weight_key = "layers.0.ffn.experts.0.w1.weight"
+    scale_key = "layers.0.ffn.experts.0.w1.scale"
+    weight = torch.ones((1, 32), dtype=torch.bfloat16)
+    source_scale = torch.ones((1, 1), dtype=torch.float32)
+    stale_scale = torch.full((1, 1), 9.0, dtype=torch.float32)
+
+    result = requantize_hf_weight_scale_pairs(
+        {weight_key: weight, scale_key: stale_scale},
+        {scale_key: source_scale},
+        use_mxfp4=lambda *_: True,
+    )
+
+    assert set(result) == {weight_key, scale_key}
+    assert result[weight_key].dtype == torch.int8
+    assert result[scale_key].shape == source_scale.shape
+    assert not torch.equal(result[scale_key], stale_scale)
 
 
 def test_quantize_dequantize_int4_preserves_shape_and_dtype():


### PR DESCRIPTION
# What does this PR do ?

Regenerates DeepSeek V4 quantized HF weight/scale pairs during export so FP8 and MXFP4 checkpoints can be saved without missing scale tensors.

# Changelog

- Add shared quantization helpers for FP8 E4M3 dequantization/requantization with source scale geometry.
- Add MXFP4 E2M1 packed dequantization/requantization helpers for routed expert weights.
- Move DeepSeek V4 quantized import/export logic from model-specific code into reusable conversion utilities.
- Update DeepSeek V4 export to emit regenerated `.scale` tensors alongside quantized `.weight` tensors.
- Preserve source scale tensor shape and dtype, including E8M0 scale dtype when available.
- Add MTP-disabled config detection and skip source `mtp.*` keys during strict HF export when MTP is disabled.
- Add SafeTensors export support for ignoring source key prefixes.
- Add unit coverage for quantized FP8/MXFP4 export, scale emission, MTP-disabled detection, and ignored source keys.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will
need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
- [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

Validated through an end-to-end 16-node DeepSeek-V4-Flash GRPO run from verl with checkpoint save enabled. The HF export completed with:

`Success: All tensors from the original checkpoint were written.`

Related to #