### PR TITLE
fix(scripts): dispatch diffusion forward step in sft/lora paths

### DIFF
--- a/scripts/performance/run_recipe.py
+++ b/scripts/performance/run_recipe.py
@@ -252,7 +252,11 @@ def main():
     elif args.task in ["sft", "lora"]:
         logging.info("Starting finetuning")
         from megatron.bridge.training.finetune import finetune
-        from megatron.bridge.training.gpt_step import forward_step
+
+        if args.model_family_name in DIFFUSION_FAMILIES:
+            forward_step = _get_diffusion_step(args.model_family_name)
+        else:
+            from megatron.bridge.training.gpt_step import forward_step
 
         finetune(config=recipe, forward_step_func=forward_step)
     else:


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## What

`scripts/performance/run_recipe.py` dispatches `WanForwardStep` / `FluxForwardStep` in the **pretrain** branch when `--model_family_name` is in `DIFFUSION_FAMILIES`, but the **sft / lora** branch is hardcoded to `gpt_step.forward_step`. Running a diffusion SFT recipe (e.g. `wan_1_3b_sft_config`) therefore loads the correct Wan model + Wan dataset, then hands them to the GPT forward step, which immediately crashes in `get_pretrain_batch_on_this_cp_rank` while trying to reshape video-latent tensors as text-token batches.

```text
File "/opt/Megatron-Bridge/3rdparty/Megatron-LM/megatron/core/utils.py", line 2353, in get_pretrain_batch_on_this_cp_rank
    val = val.view(...)
RuntimeError: shape '[37440, 16, 0]' is invalid for input of size 37440
```

## Fix

Mirror the pretrain branch's diffusion dispatch in the sft/lora branch:

```python
elif args.task in ["sft", "lora"]:
    from megatron.bridge.training.finetune import finetune

    if args.model_family_name in DIFFUSION_FAMILIES:
        forward_step = _get_diffusion_step(args.model_family_name)
    else:
        from megatron.bridge.training.gpt_step import forward_step

    finetune(config=recipe, forward_step_func=forward_step)
```

## Repro / context

Found while wiring the new `diffusion` downstream pipeline in nemo-ci (`dl/joc/nemo-ci!2366`): the `wan_1_3b_text2video_128gpu_*` jobs run `--task sft --model_family_name wan --pretrained_checkpoint <text2image-checkpoint>` and consistently crashed before the first step until this dispatch was corrected.

</details>
