### PR TITLE
[build] chore: bump transformer-engine to release_v2.16

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,7 +128,7 @@ override-dependencies = [
     "torch; sys_platform == 'never'",
     "torchvision; sys_platform == 'never'",
     "triton; sys_platform == 'never'",
-    "transformer-engine @ git+https://github.com/NVIDIA/TransformerEngine.git@release_v2.15",
+    "transformer-engine @ git+https://github.com/NVIDIA/TransformerEngine.git@release_v2.16",
     "mlflow>=3.9.0",                                        # To address CVE-2025-15031
     "cachetools>=5.0.0",
     "cryptography>=43.0.0,<47",

--- a/uv.lock
+++ b/uv.lock
@@ -23,7 +23,7 @@ overrides = [
     { name = "onnx", marker = "python_full_version < '3.13'", specifier = ">=1.21.0" },
     { name = "torch", marker = "sys_platform == 'never'" },
     { name = "torchvision", marker = "sys_platform == 'never'" },
-    { name = "transformer-engine", git = "https://github.com/NVIDIA/TransformerEngine.git?rev=release_v2.15" },
+    { name = "transformer-engine", git = "https://github.com/NVIDIA/TransformerEngine.git?rev=release_v2.16" },
     { name = "triton", marker = "sys_platform == 'never'" },
     { name = "urllib3", specifier = ">=2.6.3" },
 ]
@@ -4823,8 +4823,8 @@ wheels = [
 
 [[package]]
 name = "transformer-engine"
-version = "2.15.0+42b84005"
-source = { git = "https://github.com/NVIDIA/TransformerEngine.git?rev=release_v2.15#42b840051647eef89761a16dfdff87e82bb253ab" }
+version = "2.16.0+289e5a6b"
+source = { git = "https://github.com/NVIDIA/TransformerEngine.git?rev=release_v2.16#289e5a6b20e64540dfec975e24086b9ef98e63d7" }
 dependencies = [
     { name = "einops" },
     { name = "importlib-metadata" },


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## What
- Bump `transformer-engine` to `release_v2.16` (commit `289e5a6b`).
- Regenerate `uv.lock`.

## Lockfile delta
```
Updated transformer-engine v2.15.0+42b84005 -> v2.16.0+289e5a6b
```

## Test plan
- [ ] L0 CI green
- [ ] L1 CI green (label `needs-more-tests` applied)
- [ ] L2 CI green (label `full-test-suite` applied)

## Quarantined tests (this bump)
_None yet — will be appended as flakes are identified during CI iteration._

</details>
