### PR TITLE
[data] fix: prepare HF dataset before packing; preflight zstd in DCLM decompress

### DIFF
--- a/scripts/training/pack_sft_data.py
+++ b/scripts/training/pack_sft_data.py
@@ -86,6 +86,14 @@ def main() -> None:
             if field.name not in dataloader_field_names
         },
     )
+
+    # For HF datasets, download + apply process_example_fn → training.jsonl. The
+    # packer in prepare_packed_data() reads that JSONL; without this step the
+    # cache directory is empty and packing fails with FileNotFoundError.
+    if isinstance(builder, HFDatasetBuilder):
+        print("Preparing HF dataset (download + tokenize examples to JSONL)...")
+        builder.prepare_data()
+
     builder.prepare_packed_data()
 
     print("Done.")

--- a/tutorials/data/dclm/decompress.py
+++ b/tutorials/data/dclm/decompress.py
@@ -27,9 +27,12 @@ import numpy as np
 def _check_zstd_available() -> None:
     """Verify the ``zstd`` binary is on PATH before launching the worker pool.
 
-    Without this check, each worker fails inside ``subprocess.run`` with a
-    cryptic ``FileNotFoundError`` and the error is easy to miss when many
-    workers crash in parallel.
+    Without this check, worker ``FileNotFoundError`` exceptions from
+    ``subprocess.run`` are stored in the futures returned by
+    ``ProcessPoolExecutor.map()`` but never re-raised because the iterator is
+    discarded. The script then prints
+    ``"Files were successfully decompressed in 0.0 minutes."`` and exits 0 —
+    a silent failure that looks like success.
     """
     if shutil.which("zstd") is None:
         print("ERROR: 'zstd' binary not found on PATH.", file=sys.stderr)

--- a/tutorials/data/dclm/decompress.py
+++ b/tutorials/data/dclm/decompress.py
@@ -15,11 +15,25 @@
 import argparse
 import glob
 import os
+import shutil
 import subprocess
+import sys
 import time
 from concurrent.futures import ProcessPoolExecutor
 
 import numpy as np
+
+
+def _check_zstd_available() -> None:
+    """Verify the ``zstd`` binary is on PATH before launching the worker pool.
+
+    Without this check, each worker fails inside ``subprocess.run`` with a
+    cryptic ``FileNotFoundError`` and the error is easy to miss when many
+    workers crash in parallel.
+    """
+    if shutil.which("zstd") is None:
+        print("ERROR: 'zstd' binary not found on PATH.", file=sys.stderr)
+        sys.exit(1)
 
 
 def arguments():
@@ -65,6 +79,8 @@ def decompress_data(path_to_save: str, source_dir: str, num_workers: int = 1) ->
         source_dir (str): path to downloaded dataset.
         num_workers (int): number of workers to be used for parallel decompressing.
     """
+    _check_zstd_available()
+
     start_time = time.time()
     print("Decompressing files...")
 


### PR DESCRIPTION
  - `scripts/training/pack_sft_data.py`: call builder.prepare_data() for HFDatasetBuilder before `prepare_packed_data()`. Without this the dataset cache is empty and packing fails with FileNotFoundError when reading `training.jsonl`.                                                     
  - `tutorials/data/dclm/decompress.py`: check that the zstd binary is on PATH before launching the worker pool. Without this preflight the `ProcessPoolExecutor.map()` iterator is discarded, so worker `FileNotFoundError` exceptions are swallowed and the script prints "Files were successfully decompressed in 0.0 minutes." and exits 0, a silent failure that looks like success.    