### PR TITLE
fix(mfsdp): skip tokenizer save in convert_checkpoints_fsdp.py

### DIFF
--- a/examples/conversion/mfsdp/convert_checkpoints_fsdp.py
+++ b/examples/conversion/mfsdp/convert_checkpoints_fsdp.py
@@ -148,25 +148,18 @@ def import_hf_to_megatron_fsdp(
 
     bridge.load_hf_weights(megatron_model)
 
-    hf_tokenizer_kwargs = {}
-    if hasattr(bridge._model_bridge, "get_hf_tokenizer_kwargs"):
-        hf_tokenizer_kwargs = bridge._model_bridge.get_hf_tokenizer_kwargs() or {}
-    if trust_remote_code:
-        hf_tokenizer_kwargs["trust_remote_code"] = True
-
     effective_low_memory_save = low_memory_save
     if ckpt_format == "fsdp_dtensor" and low_memory_save:
         # fsdp_dtensor save path requires the live model object.
         print_rank_0("low_memory_save is not supported with fsdp_dtensor. Forcing low_memory_save=False.")
         effective_low_memory_save = False
 
+    # Skip tokenizer save to match `examples/conversion/convert_checkpoints.py`.
     print_rank_0(f"Saving Megatron checkpoint to: {megatron_path}")
     save_native_megatron_model(
         megatron_model,
         megatron_path,
         ckpt_format=ckpt_format,
-        hf_tokenizer_path=hf_model,
-        hf_tokenizer_kwargs=hf_tokenizer_kwargs,
         low_memory_save=effective_low_memory_save,
     )
     print_rank_0(f"Import complete: {megatron_path}")


### PR DESCRIPTION
`examples/conversion/convert_checkpoints.py` does not bundle the tokenizer with the converted Megatron checkpoint; the mfsdp variant should match. Drop the `hf_tokenizer_path` / `hf_tokenizer_kwargs` arguments from the `save_native_megatron_model` call (and the unused upstream kwargs collection block). The HuggingFace source ID is still recorded in `run_config.yaml`, so downstream consumers can fetch the tokenizer separately via `huggingface_hub` when needed.

This also sidesteps an `AttributeError` raised at the `build_tokenizer -> _set_padded_vocab_size -> vocab_size_with_padding` chain when Bridge's dataclass-based `TokenizerConfig` is passed to Megatron-LM's `build_tokenizer` (which expects argparse-style attrs `make_vocab_size_divisible_by` / `tensor_model_parallel_size` / `rank`).

# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
