### PR TITLE
[recipe, data] fix: use canonical 'rajpurkar/squad' Hub slug for SQuAD (#3956)

### DIFF
--- a/src/megatron/bridge/recipes/utils/finetune_utils.py
+++ b/src/megatron/bridge/recipes/utils/finetune_utils.py
@@ -69,10 +69,15 @@ def default_squad_config(seq_length: int, packed_sequence: bool = True, pad_seq_
 
     Note:
         Uses consistent settings across all finetuning recipes:
-        - SQuAD dataset with appropriate dataloader type
+        - SQuAD dataset (``rajpurkar/squad`` on the Hub) with appropriate dataloader type
         - 10% validation split
         - Seed 5678 (different from pretrain seed 1234)
         - Packed sequences when enabled improve training efficiency
+
+    The canonical namespaced slug ``rajpurkar/squad`` is used because
+    ``huggingface_hub >= 1.16`` rejects bare single-segment ids
+    (``HfUriError: Repository id must be 'namespace/name'``). The Hub serves the
+    same canonical SQuAD dataset under this slug.
     """
     if packed_sequence:
         # Packed sequence configuration
@@ -88,7 +93,7 @@ def default_squad_config(seq_length: int, packed_sequence: bool = True, pad_seq_
     dataloader_type = "batch"
 
     return HFDatasetConfig(
-        dataset_name="squad",
+        dataset_name="rajpurkar/squad",
         process_example_fn=process_squad_example,
         seq_length=seq_length,
         seed=5678,  # Different from pretrain seed

--- a/src/megatron/bridge/training/utils/flop_utils.py
+++ b/src/megatron/bridge/training/utils/flop_utils.py
@@ -357,7 +357,9 @@ def num_floating_point_operations(
             cfg.model.num_attention_heads if cfg.model.num_query_groups is None else cfg.model.num_query_groups
         )
 
-        is_squad = getattr(getattr(cfg, "dataset", None), "dataset_name", None) == "squad"
+        # Accept both the canonical Hub slug "rajpurkar/squad" (required by huggingface_hub >= 1.16)
+        # and the legacy bare "squad" so older user configs still hit this LoRA-specific fast path.
+        is_squad = getattr(getattr(cfg, "dataset", None), "dataset_name", None) in ("rajpurkar/squad", "squad")
         hf_model_id = getattr(cfg.model, "hf_model_id", None)
         is_llama3_70b = hf_model_id is not None and "Meta-Llama-3-70B" in hf_model_id
         packed_specs = getattr(getattr(cfg, "dataset", None), "packed_sequence_specs", None)

--- a/tests/functional_tests/test_groups/training/test_finetune_dora.py
+++ b/tests/functional_tests/test_groups/training/test_finetune_dora.py
@@ -197,7 +197,7 @@ class TestDoRAFinetune:
     def _create_squad_dataset_config(self, seq_length, seed=5678):
         """Create a SQuAD dataset configuration."""
         return HFDatasetConfig(
-            dataset_name="squad",
+            dataset_name="rajpurkar/squad",
             process_example_fn=process_squad_example,
             seq_length=seq_length,
             seed=seed,

--- a/tests/functional_tests/test_groups/training/test_finetune_lora.py
+++ b/tests/functional_tests/test_groups/training/test_finetune_lora.py
@@ -356,7 +356,7 @@ class TestLoRAFinetune:
             packed_sequence_specs = None
 
         config = HFDatasetConfig(
-            dataset_name="squad",
+            dataset_name="rajpurkar/squad",
             process_example_fn=process_squad_example,
             seq_length=seq_length,
             seed=seed,

--- a/tests/functional_tests/test_groups/training/test_seqpacking_cp_example.py
+++ b/tests/functional_tests/test_groups/training/test_seqpacking_cp_example.py
@@ -74,7 +74,7 @@ class TestPeftSftExample:
 
         # Use a small packed SQuAD dataset to exercise THD/context-parallel slicing
         cfg.dataset = HFDatasetConfig(
-            dataset_name="squad",
+            dataset_name="rajpurkar/squad",
             process_example_fn=process_squad_example,
             seq_length=256,
             dataloader_type="batch",

--- a/tests/unit_tests/recipes/utils/test_dataset_utils.py
+++ b/tests/unit_tests/recipes/utils/test_dataset_utils.py
@@ -335,7 +335,9 @@ class TestApplyDatasetOverride:
         config = _make_mock_config()
         result = apply_dataset_override(config, "llm-finetune", seq_length=512)
         assert isinstance(result.dataset, HFDatasetConfig)
-        assert result.dataset.dataset_name == "squad"
+        # The preset key is "squad" (CLI-facing label) but the Hub repo id is the
+        # canonical namespaced slug required by huggingface_hub >= 1.16. See #3956.
+        assert result.dataset.dataset_name == "rajpurkar/squad"
 
     def test_llm_finetune_extracts_dataset_name_from_cli(self):
         from megatron.bridge.data.builders.hf_dataset import HFDatasetConfig

--- a/tests/unit_tests/recipes/utils/test_finetune_utils.py
+++ b/tests/unit_tests/recipes/utils/test_finetune_utils.py
@@ -20,9 +20,11 @@ from megatron.bridge.data.builders.hf_dataset import HFDatasetConfig
 from megatron.bridge.data.datasets.packed_sequence import PackedSequenceSpecs
 from megatron.bridge.data.hf_processors.gsm8k import process_gsm8k_example
 from megatron.bridge.data.hf_processors.openmathinstruct2 import process_openmathinstruct2_example
+from megatron.bridge.data.hf_processors.squad import process_squad_example
 from megatron.bridge.recipes.utils.finetune_utils import (
     default_gsm8k_config,
     default_openmathinstruct2_config,
+    default_squad_config,
 )
 
 
@@ -187,6 +189,73 @@ class TestDefaultGsm8kConfig:
     def test_pad_seq_to_mult_ignored_without_packing(self):
         cfg = default_gsm8k_config(packed_sequence=False, pad_seq_to_mult=4)
         assert cfg.packed_sequence_specs is None
+
+
+@pytest.mark.unit
+class TestDefaultSquadConfig:
+    """Test cases for default_squad_config.
+
+    Regression coverage for issue #3956: the bare slug ``"squad"`` is rejected by
+    ``huggingface_hub >= 1.16`` (``HfUriError: Repository id must be 'namespace/name'``).
+    The Hub serves the canonical SQuAD dataset under ``rajpurkar/squad``.
+    """
+
+    def test_returns_hf_dataset_config(self):
+        cfg = default_squad_config(seq_length=2048)
+        assert isinstance(cfg, HFDatasetConfig)
+
+    def test_dataset_name_is_canonical_namespaced_slug(self):
+        cfg = default_squad_config(seq_length=2048)
+        assert cfg.dataset_name == "rajpurkar/squad"
+
+    def test_dataset_name_is_not_bare_slug(self):
+        # Bare slug "squad" is rejected by huggingface_hub >= 1.16. Belt-and-suspenders
+        # check so a future regression cannot silently re-introduce the broken slug.
+        cfg = default_squad_config(seq_length=2048)
+        assert cfg.dataset_name != "squad"
+        assert "/" in cfg.dataset_name, "dataset_name must be 'namespace/name' for huggingface_hub >= 1.16"
+
+    def test_process_fn_is_squad(self):
+        cfg = default_squad_config(seq_length=2048)
+        assert cfg.process_example_fn is process_squad_example
+
+    def test_default_seed(self):
+        cfg = default_squad_config(seq_length=2048)
+        assert cfg.seed == 5678
+
+    def test_dataloader_type_batch(self):
+        cfg = default_squad_config(seq_length=2048)
+        assert cfg.dataloader_type == "batch"
+
+    def test_validation_enabled_with_default_proportion(self):
+        cfg = default_squad_config(seq_length=2048)
+        assert cfg.do_validation is True
+        assert cfg.val_proportion == 0.1
+        assert cfg.do_test is False
+
+    def test_custom_seq_length(self):
+        cfg = default_squad_config(seq_length=8192)
+        assert cfg.seq_length == 8192
+
+    def test_packed_sequence_default_enabled(self):
+        # ``default_squad_config`` enables packed sequences by default.
+        cfg = default_squad_config(seq_length=4096)
+        assert isinstance(cfg.packed_sequence_specs, PackedSequenceSpecs)
+        assert cfg.packed_sequence_specs.packed_sequence_size == 4096
+        assert cfg.dataset_kwargs == {"pad_to_max_length": True}
+
+    def test_packed_sequence_disabled(self):
+        cfg = default_squad_config(seq_length=4096, packed_sequence=False)
+        assert cfg.packed_sequence_specs is None
+        assert cfg.dataset_kwargs == {}
+
+    def test_pad_seq_to_mult_propagates_when_packed(self):
+        cfg = default_squad_config(seq_length=4096, packed_sequence=True, pad_seq_to_mult=8)
+        assert cfg.packed_sequence_specs.pad_seq_to_mult == 8
+
+    def test_rewrite_disabled(self):
+        cfg = default_squad_config(seq_length=2048)
+        assert cfg.rewrite is False
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

Restores the Llama-3 PEFT/SFT recipes (and any recipe that flows through
`default_squad_config`) on `huggingface_hub >= 1.16`, which now rejects
bare single-segment dataset ids with `HfUriError: Repository id must be
'namespace/name'`.

Closes #3956.

## What breaks today

```
huggingface_hub.errors.HfUriError: Invalid HF URI
  'hf://datasets/squad@<sha>/.huggingface.yaml'.
  Repository id must be 'namespace/name', got 'squad'.
```

Repro (from the issue):

```python
from megatron.bridge.recipes.llama.llama3 import llama3_8b_peft_config
from megatron.bridge.training.finetune import finetune
from megatron.bridge.training.gpt_step import forward_step

cfg = llama3_8b_peft_config(peft_scheme='lora')
finetune(cfg, forward_step_func=forward_step)
```

Equivalent: `datasets.load_dataset("squad")` raises the same `HfUriError`
in the same environment.

## Fix

The Hub serves the canonical SQuAD dataset under `rajpurkar/squad`
(`HEAD /datasets/squad` → 307 → `rajpurkar/squad`). Switching the slug
satisfies the new client-side validation rule without pinning
`huggingface_hub<1.16` (which would also block other unrelated changes
in newer Hub clients).

### Production code

- **`src/megatron/bridge/recipes/utils/finetune_utils.py`** —
  `default_squad_config` now sets `dataset_name="rajpurkar/squad"`.
  Docstring explains the canonical-slug requirement.

- **`src/megatron/bridge/training/utils/flop_utils.py`** — the LoRA-only
  FLOPs averaged-seqlen accounting path used to match exactly `"squad"`.
  Broadened to `in ("rajpurkar/squad", "squad")` so users with older
  configs still hit the same fast path, and so the new default keeps
  hitting it.

- The **internal CLI preset key** (`"squad"` in `LLM_FINETUNE_PRESETS`)
  is intentionally **left as-is** — that is a user-facing CLI label, not
  a Hub repo id. The factory it points to now produces the canonical
  slug, so existing `dataset.dataset_name=squad` overrides continue to
  work and produce the correct Hub id.

### Tests

- **New `TestDefaultSquadConfig` class** in
  `tests/unit_tests/recipes/utils/test_finetune_utils.py` mirrors the
  existing `TestDefaultGsm8kConfig` / `TestDefaultOpenmathinstruct2Config`
  coverage and explicitly asserts:
  - `dataset_name == "rajpurkar/squad"`
  - `dataset_name != "squad"`
  - `"/" in dataset_name` — the structural invariant `huggingface_hub`
    now enforces (belt-and-suspenders against future regressions)

- **`test_llm_finetune_defaults_to_squad`** in `test_dataset_utils.py`
  updated to assert the canonical slug. The other `"squad"` references
  in this file (CLI-preset-key tests) remain unchanged on purpose.

- Three **functional tests** that construct `HFDatasetConfig` directly
  (`test_seqpacking_cp_example.py`, `test_finetune_lora.py`,
  `test_finetune_dora.py`) updated so they double as examples for users
  copying from the test suite.

## Test plan

- [x] `py_compile` on all 7 touched files passes.
- [x] No bare `"squad"` Hub-slug references remain in production code.
- [x] Audit verified: only the CLI preset key, the legacy fallback in
      `flop_utils.is_squad`, and test references to the preset key itself
      retain `"squad"` — all intentional.
- [ ] CI on NVIDIA runners (`/ok to test <commit-SHA>`).