### PR TITLE
[training, test] fix: update get_batch_on_this_cp_rank mock for is_hybrid_cp kwarg

### DIFF
--- a/tests/unit_tests/training/test_gpt_step.py
+++ b/tests/unit_tests/training/test_gpt_step.py
@@ -117,7 +117,7 @@ class TestGetBatch:
         _set_middle_pp_stage(monkeypatch)
         monkeypatch.setattr(
             "megatron.bridge.training.gpt_step.get_batch_on_this_cp_rank",
-            lambda batch, cp_group: batch,
+            lambda batch, is_hybrid_cp, cp_group: batch,
         )
 
         tokens = _as_nocuda(torch.tensor([[1, 2, 3, 4, 5, 6, 7, 8]]))


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## What broke

`Launch_Unit_Tests_Core` is failing on `origin/main` (and consequently every PR that picks up `main`, e.g. #3742):

```
FAILED tests/unit_tests/training/test_gpt_step.py::TestGetBatch::test_middle_pp_stage_preserves_full_packed_batch
TypeError: <lambda>() got an unexpected keyword argument 'is_hybrid_cp'
```

## Root cause

Two recently-merged PRs collided on `main`:

- **#3926** (`2d58a6fe5`, _Preserve packed SFT metadata on middle PP stages_) added the test with a 2-arg lambda mock at `tests/unit_tests/training/test_gpt_step.py:120`:
  ```python
  "megatron.bridge.training.gpt_step.get_batch_on_this_cp_rank",
  lambda batch, cp_group: batch,
  ```
- **#3944** (`92deeef43`, _Adapt MCore main bump compatibility_) added the `is_hybrid_cp` kwarg to the production call site in `src/megatron/bridge/training/gpt_step.py:212`:
  ```python
  batch = get_batch_on_this_cp_rank(batch, is_hybrid_cp=False, cp_group=pg_collection.cp)
  ```

Neither PR updated the other's contract, so the mock now rejects the new kwarg.

## Fix

Extend the lambda signature to accept the new kwarg:

```diff
-            lambda batch, cp_group: batch,
+            lambda batch, is_hybrid_cp, cp_group: batch,
```

This unbreaks `Launch_Unit_Tests_Core` on every open PR rebased onto current `main`.
</details>
