### PR TITLE
fix: Patch vllm to not treat 26.04 pytorch as torch >= 2.12.0.dev

### DIFF
--- a/docker/Dockerfile.fw_base
+++ b/docker/Dockerfile.fw_base
@@ -130,8 +130,10 @@ RUN --mount=type=bind,source=docker/common/install_nsys.sh,target=/opt/install_n
 
 # Copy Wheels
 RUN --mount=type=bind,from=vllm_wheel,source=/src/vllm/,target=/tmp/vllm/ \
+    --mount=type=bind,source=docker/patches/vllm.patch,target=/opt/vllm.patch \
     pip install /tmp/vllm/vllm*.whl && \
     pushd /usr/local/lib/python3.12/dist-packages/vllm && \
+    patch -p1 < /opt/vllm.patch && \
     popd
 
 ##############################################################################

--- a/docker/patches/vllm.patch
+++ b/docker/patches/vllm.patch
@@ -1,0 +1,14 @@
+diff --git a/utils/torch_utils.py b/utils/torch_utils.py
+index 1eb9306ed..0e0008aab 100644
+--- a/utils/torch_utils.py
++++ b/utils/torch_utils.py
+@@ -788,6 +788,9 @@ def is_torch_equal_or_newer(target: str) -> bool:
+     Returns:
+         Whether the condition meets.
+     """
++    if target == "2.12.0.dev":
++        return False
++
+     try:
+         return _is_torch_equal_or_newer(str(torch.__version__), target)
+     except Exception:


### PR DESCRIPTION
# What does this PR do ?

fix: Patch vllm to not treat 26.04 pytorch as torch >= 2.12.0.dev

Probably every release we need to be updating this patch. We had to do it last time as well. Without this, vllm will go down a path that fails on 26.04 pytorch container.

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
