### PR TITLE
[model] fix: default dsa_indexer_loss_coeff to a non-None value in DeepSeek-V4 bridge

### DIFF
--- a/src/megatron/bridge/models/deepseek/deepseek_v4_bridge.py
+++ b/src/megatron/bridge/models/deepseek/deepseek_v4_bridge.py
@@ -402,6 +402,7 @@ class DeepSeekV4Bridge(MegatronModelBridge):
         provider.dsa_indexer_n_heads = hf_config.index_n_heads  # 64
         provider.dsa_indexer_head_dim = hf_config.index_head_dim  # 128
         provider.dsa_indexer_topk = hf_config.index_topk  # 512
+        provider.dsa_indexer_loss_coeff = 0.0
 
         # ---- Hyper-Connections (mHC) ----
         provider.enable_hyper_connections = True


### PR DESCRIPTION
# What does this PR do?

`DeepSeekV4Bridge.provider_bridge()` does not set `provider.dsa_indexer_loss_coeff`,
leaving it at the `MLATransformerConfig` default of `None`. The DSv4 attention path
reads the field via:

```python
# 3rdparty/Megatron-LM/.../experimental_attention_variant/csa.py
indexer_loss_coeff = getattr(self.config, 'dsa_indexer_loss_coeff', 0.0)
```

The intended `0.0` fallback never fires because the dataclass field always exists —
`getattr` returns `None`. Downstream
`3rdparty/Megatron-LM/.../experimental_attention_variant/dsa.py` then raises:

```
TypeError: unsupported operand type(s) for *: 'Tensor' and 'NoneType'
```

at `indexer_loss = kl_div * loss_coeff`.

Every existing DSv4 caller already works around this:
- `src/megatron/bridge/recipes/deepseek/deepseek_v4.py` sets `cfg.model.dsa_indexer_loss_coeff = 0.01`.
- `verl-project/verl#6473` sets `++override_transformer_config.dsa_indexer_loss_coeff=0.0`
  on both actor and ref configs of the GRPO example.

Install a safe default in the bridge itself, mirroring the sibling GLM5 DSA bridge
(`src/megatron/bridge/models/glm_moe_dsa/glm5_bridge.py`) which sets the same field
to `0.001` for the same reason. Recipe and external overrides continue to win as
before; this only affects callers that never set the field.

# Tests

No new tests. Mirrors the GLM5 sibling-bridge precedent (`glm5_bridge.py` sets
`dsa_indexer_loss_coeff = 0.001` without a dedicated unit test). Regression coverage
is implicit:
- Any caller going through `bridge.to_megatron_provider()` without overriding the
  field hits the DSA-active code path and would have failed loudly before this fix.
- The DSv4 recipe functional smoke (#3923) exercises the bridge end-to-end.

# AI attribution

This change was developed with AI-assisted coding (Claude). The author has reviewed
every changed line and verified the bug against the MCore `csa.py` / `dsa.py`
source paths cited above.