### PR TITLE
[docs] fix: clarify fast_hadamard_transform is required for DSv4 DSA, not optional

### DIFF
--- a/examples/models/deepseek_v4/README.md
+++ b/examples/models/deepseek_v4/README.md
@@ -54,6 +54,11 @@ DSv4 currently requires **TP=1** because MLA tensor parallelism is not supported
 
 - **Fused mHC is not supported on H100.** Set `use_fused_mhc=False` in the bridge config when running on Hopper GPUs. Fused mHC is enabled by default and works on GB200.
 
-- **`fast_hadamard_transform` is optional.** When unavailable, DSA falls back to a PyTorch hadamard implementation. Throughput is lower but numerical behavior is unchanged.
+- **`fast_hadamard_transform` is required by the DSA attention variant.** `csa.py` and `dsa.py` import `hadamard_transform` from this package and hard-assert availability — there is no in-tree PyTorch fallback. Install from the Dao-AILab git repo (the PyPI source distribution is incomplete; see the sibling GLM-5 [README](../glm/glm5/README.md#pre-requisites) for the same dependency):
+
+  ```bash
+  pip install --no-build-isolation \
+      git+https://github.com/Dao-AILab/fast-hadamard-transform.git
+  ```
 
 - **Logit parity is verified for Flash and Flash-Base** against the official inference stack at last-real-token logits. The remaining gap is structural, from different attention/HC kernel decompositions and accumulation precisions between MCore and official inference.


### PR DESCRIPTION
# What does this PR do?

The DSv4 example README's _Known Limitations_ section currently says:

> **`fast_hadamard_transform` is optional.** When unavailable, DSA falls back to a PyTorch hadamard implementation. Throughput is lower but numerical behavior is unchanged.

There is no such in-tree fallback. Both
`3rdparty/Megatron-LM/megatron/core/transformer/experimental_attention_variant/csa.py`
and `.../dsa.py` import `hadamard_transform` and hard-assert availability:

```python
try:
    from fast_hadamard_transform import hadamard_transform
except ImportError:
    hadamard_transform = None
...
assert hadamard_transform is not None, "fast_hadamard_transform is not installed."
```

Any caller exercising a DSv4 layer with `compress_ratio > 0` hits the assert
immediately. The sibling [GLM-5 README](../glm/glm5/README.md#pre-requisites)
already states the dependency correctly as **required** and points at the
Dao-AILab git source (the PyPI sdist is incomplete).

Replace the misleading bullet with the GLM-5-style required-dependency note,
including the same install command.

# Tests

`docs-only` — no code changes.

# AI attribution

This change was developed with AI-assisted coding (Claude). The author has
reviewed every changed line.