### PR TITLE
[perf] fix: create parent dir for save_config_filepath

### DIFF
--- a/scripts/performance/utils/overrides.py
+++ b/scripts/performance/utils/overrides.py
@@ -14,6 +14,7 @@
 
 import argparse
 import logging
+import os
 from typing import List, Optional
 
 from omegaconf import OmegaConf
@@ -204,6 +205,9 @@ def _set_checkpoint_overrides(recipe: ConfigContainer, args: argparse.Namespace)
 
     if args.save_config_filepath is not None:
         recipe.logger.save_config_filepath = args.save_config_filepath
+        # maybe_log_and_save_config calls cfg.to_yaml() during training startup; that uses
+        # plain open(..., "w") and fails if the parent dir doesn't exist. Ensure it does.
+        os.makedirs(os.path.dirname(os.path.abspath(args.save_config_filepath)), exist_ok=True)
 
     return recipe
 
@@ -314,6 +318,9 @@ def set_user_overrides(recipe: ConfigContainer, args: argparse.Namespace) -> Con
         recipe.logger.wandb_save_dir = "/nemo_run/wandb"
 
     recipe.logger.save_config_filepath = args.save_config_filepath or "/nemo_run/configs/ConfigContainer.yaml"
+    # maybe_log_and_save_config calls cfg.to_yaml() during training startup; that uses
+    # plain open(..., "w") and fails if the parent dir doesn't exist. Ensure it does.
+    os.makedirs(os.path.dirname(os.path.abspath(recipe.logger.save_config_filepath)), exist_ok=True)
 
     if args.max_steps is not None:
         recipe.train.train_iters = args.max_steps


### PR DESCRIPTION
## Summary

`ConfigContainer.yaml` stopped appearing in CI artifacts under `scripts/performance/`. Root cause: Bridge's `maybe_log_and_save_config` (`src/megatron/bridge/training/setup.py:587`) calls `cfg.to_yaml(cfg.logger.save_config_filepath)`, and `to_yaml` uses a plain `open(yaml_path, \"w\")` which raises `FileNotFoundError` when the parent directory doesn't exist. The failure is swallowed by `maybe_log_and_save_config`'s `try/except` and the CI after-script's `cp ... || true`, so the absence is silent.

The CI passes `--save_config_filepath /lustre/fsw/.../<JOB_ID>/configs/ConfigContainer.yaml` but nothing creates that `configs/` subdir before training starts (the CI's `mkdir -p ./configs/` is post-training, in the local working dir).

## Fix

Both call sites in `scripts/performance/utils/overrides.py` that assign `recipe.logger.save_config_filepath` now also create the parent directory via `os.makedirs(..., exist_ok=True)`:

- `_set_checkpoint_overrides` (CLI-provided path)
- `set_user_overrides` (CLI path or fallback `/nemo_run/configs/ConfigContainer.yaml`)

This is identical to what the existing `--dryrun` branches in `run_script.py:107` and `run_recipe.py:231` already do.

## Test plan

- [ ] CI pipeline produces `${PERSISTENT_DIR}/configs/ConfigContainer.yaml` (after-script `cp` no longer silently fails)
- [ ] `--dryrun` path unaffected (it has its own makedirs)
- [ ] No regression on jobs that already had the dir pre-existing (`exist_ok=True`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)