### PR TITLE
docs: note 26.04 drops PyAV by default and document runtime install

### DIFF
--- a/docker/common/README.md
+++ b/docker/common/README.md
@@ -98,18 +98,29 @@ To change them, rebuild the container.
 
 Running uv pip install outside any of the two directories above might lead to a re-install of torch, thus breaking all dependencies that have been compiled against the original torch version. By running uv pip install inside any of the two directories, we can avoid this unwanted side-effect.
 
-### Reinstalling PyAV (`av`) at runtime
+### Reinstalling video / image decoding packages (`av`, `decord`, `opencv-python-headless`) at runtime
 
-Starting with the 26.04 (r0.4.0) release, the [`av`](https://pypi.org/project/av/) (PyAV) Python package is **not installed** in the container. PyAV ships its own FFmpeg binaries, and the bundled FFmpeg version carried an unfixed CVE — so `av` is suppressed via a `sys_platform == 'never'` override in both `/opt/Megatron-Bridge/pyproject.toml` and `/opt/NeMo-FW/pyproject.toml`. The same override is propagated to transitive consumers such as `qwen-vl-utils` and `decord`'s `av-decode` extra, so `uv sync` and `uv pip install av` will silently skip it.
+Starting with the 26.04 (r0.4.0) release, the following Python packages are **not installed** in the container:
 
-If your workflow needs PyAV at runtime (for example, video decoding in multimodal data pipelines), install it directly with `pip`, which does not consult uv's override list:
+| Package | Why it was removed |
+|---------|---------------------|
+| [`av`](https://pypi.org/project/av/) (PyAV) | Vendored FFmpeg binaries carried an unfixed CVE. |
+| [`decord`](https://pypi.org/project/decord/) | Unmaintained; vendored FFmpeg binaries carried an unfixed CVE. |
+| [`opencv-python-headless`](https://pypi.org/project/opencv-python-headless/) | Bundled native libs carried an unfixed CVE. The Dockerfile also explicitly runs `pip uninstall -y opencv-python-headless` after the base-container install to scrub any pre-existing copy. |
+
+These packages are suppressed via `sys_platform == 'never'` overrides in `/opt/Megatron-Bridge/pyproject.toml` (for `av`) and `/opt/NeMo-FW/pyproject.toml` (for all three). The override propagates to transitive consumers such as `qwen-vl-utils` and `decord[av-decode]`, so `uv sync` and `uv pip install <pkg>` will silently skip them.
+
+If your workflow needs any of these at runtime (for example, video decoding in multimodal data pipelines), install them directly with `pip`, which does not consult uv's override list:
 
 ```bash
+# install any combination you need
 pip install --no-deps av
+pip install --no-deps decord
+pip install --no-deps opencv-python-headless
 ```
 
 Notes:
 
 - `--no-deps` keeps the install from re-resolving torch or other framework packages, preserving the container's pinned versions.
-- You accept the CVE risk in PyAV's vendored FFmpeg by reinstalling it. Restrict this to workloads where you control the input media.
+- You accept the CVE risk in each package's vendored native libraries by reinstalling it. Restrict this to workloads where you control the input media.
 - The install is not persistent — rebuild it into your own image (or your job's startup script) if you need it across container restarts.

--- a/docker/common/README.md
+++ b/docker/common/README.md
@@ -97,3 +97,19 @@ To change them, rebuild the container.
 **general note:**
 
 Running uv pip install outside any of the two directories above might lead to a re-install of torch, thus breaking all dependencies that have been compiled against the original torch version. By running uv pip install inside any of the two directories, we can avoid this unwanted side-effect.
+
+### Reinstalling PyAV (`av`) at runtime
+
+Starting with the 26.04 (r0.4.0) release, the [`av`](https://pypi.org/project/av/) (PyAV) Python package is **not installed** in the container. PyAV ships its own FFmpeg binaries, and the bundled FFmpeg version carried an unfixed CVE — so `av` is suppressed via a `sys_platform == 'never'` override in both `/opt/Megatron-Bridge/pyproject.toml` and `/opt/NeMo-FW/pyproject.toml`. The same override is propagated to transitive consumers such as `qwen-vl-utils` and `decord`'s `av-decode` extra, so `uv sync` and `uv pip install av` will silently skip it.
+
+If your workflow needs PyAV at runtime (for example, video decoding in multimodal data pipelines), install it directly with `pip`, which does not consult uv's override list:
+
+```bash
+pip install --no-deps av
+```
+
+Notes:
+
+- `--no-deps` keeps the install from re-resolving torch or other framework packages, preserving the container's pinned versions.
+- You accept the CVE risk in PyAV's vendored FFmpeg by reinstalling it. Restrict this to workloads where you control the input media.
+- The install is not persistent — rebuild it into your own image (or your job's startup script) if you need it across container restarts.

--- a/docs/releases/known-issues.md
+++ b/docs/releases/known-issues.md
@@ -4,7 +4,12 @@ This page lists known issues and limitations in the current release.
 
 ## 26.04
 
-- The [`av`](https://pypi.org/project/av/) (PyAV) Python package is no longer installed by default in the NeMo Framework 26.04 container (`nvcr.io/nvidia/nemo:26.04`) to mitigate a CVE in the bundled FFmpeg binaries. Workflows that rely on `av` for video decoding (for example, certain multimodal data pipelines and `qwen-vl-utils` video paths) must reinstall it at runtime — see [`docker/common/README.md`](../../docker/common/README.md#reinstalling-pyav-av-at-runtime) for instructions.
+- The following video / image decoding packages are no longer installed by default in the NeMo Framework 26.04 container (`nvcr.io/nvidia/nemo:26.04`) to mitigate CVEs in their vendored native binaries:
+  - [`av`](https://pypi.org/project/av/) (PyAV)
+  - [`decord`](https://pypi.org/project/decord/)
+  - [`opencv-python-headless`](https://pypi.org/project/opencv-python-headless/)
+
+  Workflows that depend on any of these (for example, multimodal video pipelines, `qwen-vl-utils` video paths, or `decord[av-decode]`) must reinstall them at runtime — see [`docker/common/README.md`](../../docker/common/README.md#reinstalling-video--image-decoding-packages-av-decord-opencv-python-headless-at-runtime) for instructions.
 
 ## 26.02
 

--- a/docs/releases/known-issues.md
+++ b/docs/releases/known-issues.md
@@ -2,6 +2,10 @@
 
 This page lists known issues and limitations in the current release.
 
+## 26.04
+
+- The [`av`](https://pypi.org/project/av/) (PyAV) Python package is no longer installed by default in the NeMo Framework 26.04 container (`nvcr.io/nvidia/nemo:26.04`) to mitigate a CVE in the bundled FFmpeg binaries. Workflows that rely on `av` for video decoding (for example, certain multimodal data pipelines and `qwen-vl-utils` video paths) must reinstall it at runtime — see [`docker/common/README.md`](../../docker/common/README.md#reinstalling-pyav-av-at-runtime) for instructions.
+
 ## 26.02
 
 - AWS EKS only: Due to AWS-OFI-NCCL v1.17.0 long-running jobs suffer a memory leak that causes performance regression over time. This can be mitigated by upgrading to [v1.17.3](https://github.com/aws/aws-ofi-nccl/releases/tag/v1.17.3).


### PR DESCRIPTION
<details><summary>Claude summary</summary>

### What changed

The 26.04 (r0.4.0) NeMo Framework container no longer installs three video / image decoding packages by default, all for CVE reasons in their vendored native binaries:

| Package | Suppression site |
|---------|------------------|
| [`av`](https://pypi.org/project/av/) (PyAV) | `pyproject.toml` + `docker/common/fw_pyproject.toml` (`sys_platform == 'never'`) |
| [`decord`](https://pypi.org/project/decord/) | `docker/common/fw_pyproject.toml` (`sys_platform == 'never'`) |
| [`opencv-python-headless`](https://pypi.org/project/opencv-python-headless/) | `docker/common/fw_pyproject.toml` (`sys_platform == 'never'`) **plus** explicit `pip uninstall -y opencv-python-headless` at the end of the FW Dockerfile pip step |

Workflows that depend on any of these (multimodal video pipelines, `qwen-vl-utils` video paths, `decord[av-decode]`, opencv-based preprocessing) silently lose those capabilities when they migrate to the 26.04 container — this PR documents the change and the runtime workaround.

### Doc updates

1. `docs/releases/known-issues.md` — adds a `26.04` section listing all three packages with a link to the runtime-install instructions.
2. `docker/common/README.md` — adds a *Reinstalling video / image decoding packages at runtime* subsection. It explains that the uv override propagates to transitive consumers (so `uv sync` / `uv pip install <pkg>` are no-ops) and recommends `pip install --no-deps <pkg>` to bypass the override without re-resolving torch.

```bash
# inside the running container, install any combination you need
pip install --no-deps av
pip install --no-deps decord
pip install --no-deps opencv-python-headless
```

### Cherrypick

Tagged with `r0.4.0` for automatic cherry-pick to the release branch.

</details>