### PR TITLE
[model] fix: Support direct Mamba conv params

### DIFF
--- a/src/megatron/bridge/models/falcon_h1/falconh1_bridge.py
+++ b/src/megatron/bridge/models/falcon_h1/falconh1_bridge.py
@@ -162,12 +162,17 @@ class FalconH1Bridge(MegatronModelBridge):
             )
         )
 
-        # Mamba conv1d components
-        for conv_component in ["weight", "bias"]:
+        # Mamba conv1d components. Keep legacy dotted names for older Megatron-Core pins.
+        for megatron_conv1d_param, hf_conv1d_param in [
+            ("conv1d_weight", "conv1d.weight"),
+            ("conv1d_bias", "conv1d.bias"),
+            ("conv1d.weight", "conv1d.weight"),
+            ("conv1d.bias", "conv1d.bias"),
+        ]:
             mapping_list.append(
                 MambaConv1dMapping(
-                    megatron_param=f"decoder.layers.*.mamba_mixer.conv1d.{conv_component}",
-                    hf_param=f"model.layers.*.mamba.conv1d.{conv_component}",
+                    megatron_param=f"decoder.layers.*.mamba_mixer.{megatron_conv1d_param}",
+                    hf_param=f"model.layers.*.mamba.{hf_conv1d_param}",
                 )
             )
 

--- a/src/megatron/bridge/models/nemotron_vl/nemotron_vl_bridge.py
+++ b/src/megatron/bridge/models/nemotron_vl/nemotron_vl_bridge.py
@@ -145,12 +145,17 @@ class NemotronVLBridge(MegatronModelBridge):
                 ),
             ]
         )
-        for conv1d_sub_module in ["weight", "bias"]:
+        for megatron_conv1d_param, hf_conv1d_param in [
+            ("conv1d_weight", "conv1d.weight"),
+            ("conv1d_bias", "conv1d.bias"),
+            ("conv1d.weight", "conv1d.weight"),
+            ("conv1d.bias", "conv1d.bias"),
+        ]:
             mapping_list.extend(
                 [
                     MambaConv1dMapping(
-                        megatron_param=rf"llava_model.language_model.decoder.layers.*.mixer.conv1d.{conv1d_sub_module}",
-                        hf_param=rf"language_model.backbone.layers.*.mixer.conv1d.{conv1d_sub_module}",
+                        megatron_param=rf"llava_model.language_model.decoder.layers.*.mixer.{megatron_conv1d_param}",
+                        hf_param=rf"language_model.backbone.layers.*.mixer.{hf_conv1d_param}",
                     ),
                 ]
             )

--- a/src/megatron/bridge/models/nemotronh/nemotron_h_bridge.py
+++ b/src/megatron/bridge/models/nemotronh/nemotron_h_bridge.py
@@ -498,12 +498,17 @@ class NemotronHBridge(MegatronModelBridge):
                 ),
             ]
         )
-        for conv1d_sub_module in ["weight", "bias"]:
+        for megatron_conv1d_param, hf_conv1d_param in [
+            ("conv1d_weight", "conv1d.weight"),
+            ("conv1d_bias", "conv1d.bias"),
+            ("conv1d.weight", "conv1d.weight"),
+            ("conv1d.bias", "conv1d.bias"),
+        ]:
             mapping_list.extend(
                 [
                     MambaConv1dMapping(
-                        megatron_param=rf"decoder.layers.*.mixer.conv1d.{conv1d_sub_module}",
-                        hf_param=rf"backbone.layers.*.mixer.conv1d.{conv1d_sub_module}",
+                        megatron_param=rf"decoder.layers.*.mixer.{megatron_conv1d_param}",
+                        hf_param=rf"backbone.layers.*.mixer.{hf_conv1d_param}",
                     ),
                 ]
             )

--- a/tests/unit_tests/models/falcon_h1/test_falcon_h1_bridge.py
+++ b/tests/unit_tests/models/falcon_h1/test_falcon_h1_bridge.py
@@ -193,10 +193,18 @@ def test_mapping_registry_contains_falcon_h1_weight_families():
     assert "output_layer.weight" in megatron_params
     assert "decoder.final_norm.weight" in megatron_params
     assert "decoder.layers.*.mamba_mixer.in_proj.weight" in megatron_params
+    assert "decoder.layers.*.mamba_mixer.conv1d_weight" in megatron_params
+    assert "decoder.layers.*.mamba_mixer.conv1d_bias" in megatron_params
     assert "decoder.layers.*.mamba_mixer.conv1d.weight" in megatron_params
+    assert "decoder.layers.*.mamba_mixer.conv1d.bias" in megatron_params
     assert "decoder.layers.*.self_attention.linear_qkv.weight" in megatron_params
     assert "decoder.layers.*.mlp.linear_fc1.weight" in megatron_params
     assert "decoder.layers.*.mlp.linear_fc2.weight" in megatron_params
+
+    reverse_weight = registry.hf_to_megatron_lookup("model.layers.0.mamba.conv1d.weight")
+    reverse_bias = registry.hf_to_megatron_lookup("model.layers.0.mamba.conv1d.bias")
+    assert reverse_weight.megatron_param == "decoder.layers.0.mamba_mixer.conv1d_weight"
+    assert reverse_bias.megatron_param == "decoder.layers.0.mamba_mixer.conv1d_bias"
 
     assert any(isinstance(mapping, MambaInProjMapping) for mapping in registry)
     assert any(isinstance(mapping, MambaConv1dMapping) for mapping in registry)

--- a/tests/unit_tests/models/nemotron_vl/test_nemotron_vl_bridge.py
+++ b/tests/unit_tests/models/nemotron_vl/test_nemotron_vl_bridge.py
@@ -145,3 +145,13 @@ class TestNemotronVLBridgeMappingRegistry:
         assert any("language_model" in n for n in names)
         # QKV mappings should be present for both language and vision
         assert any("linear_qkv" in n for n in names)
+
+        assert "llava_model.language_model.decoder.layers.*.mixer.conv1d_weight" in names
+        assert "llava_model.language_model.decoder.layers.*.mixer.conv1d_bias" in names
+        assert "llava_model.language_model.decoder.layers.*.mixer.conv1d.weight" in names
+        assert "llava_model.language_model.decoder.layers.*.mixer.conv1d.bias" in names
+
+        reverse_weight = registry.hf_to_megatron_lookup("language_model.backbone.layers.0.mixer.conv1d.weight")
+        reverse_bias = registry.hf_to_megatron_lookup("language_model.backbone.layers.0.mixer.conv1d.bias")
+        assert reverse_weight.megatron_param == "llava_model.language_model.decoder.layers.0.mixer.conv1d_weight"
+        assert reverse_bias.megatron_param == "llava_model.language_model.decoder.layers.0.mixer.conv1d_bias"

--- a/tests/unit_tests/models/nemotronh/test_nemotron_h_bridge.py
+++ b/tests/unit_tests/models/nemotronh/test_nemotron_h_bridge.py
@@ -215,6 +215,25 @@ class TestNemotronHBridge:
         # assert any([isinstance(m, PrunedVocabMapping) for m in mapping_registry.mappings])
         assert any([isinstance(m, QKVMapping) for m in mapping_registry.mappings])
 
+    def test_mapping_registry_contains_mamba_conv1d_compat_mappings(self):
+        """Test that Mamba conv mappings support old and new Megatron-Core names."""
+        registry = NemotronHBridge().mapping_registry()
+
+        new_weight = registry.megatron_to_hf_lookup("decoder.layers.0.mixer.conv1d_weight")
+        new_bias = registry.megatron_to_hf_lookup("decoder.layers.0.mixer.conv1d_bias")
+        old_weight = registry.megatron_to_hf_lookup("decoder.layers.0.mixer.conv1d.weight")
+        old_bias = registry.megatron_to_hf_lookup("decoder.layers.0.mixer.conv1d.bias")
+
+        assert new_weight.hf_param == "backbone.layers.0.mixer.conv1d.weight"
+        assert new_bias.hf_param == "backbone.layers.0.mixer.conv1d.bias"
+        assert old_weight.hf_param == "backbone.layers.0.mixer.conv1d.weight"
+        assert old_bias.hf_param == "backbone.layers.0.mixer.conv1d.bias"
+
+        reverse_weight = registry.hf_to_megatron_lookup("backbone.layers.0.mixer.conv1d.weight")
+        reverse_bias = registry.hf_to_megatron_lookup("backbone.layers.0.mixer.conv1d.bias")
+        assert reverse_weight.megatron_param == "decoder.layers.0.mixer.conv1d_weight"
+        assert reverse_bias.megatron_param == "decoder.layers.0.mixer.conv1d_bias"
+
     def test_provider_bridge_fixed_settings(self, mock_pretrained_nemotronh):
         """Test fixed settings that should always be set regardless of config."""
         bridge = NemotronHBridge()


### PR DESCRIPTION
## Summary
- Prepare Megatron-Bridge for NVIDIA/Megatron-LM#4899, which moves Mamba conv parameters from a `conv1d` child module to direct `MambaMixer` parameters (`conv1d_weight`, `conv1d_bias`).
- Add Mamba conv1d Bridge mappings for current Megatron-Core direct parameters (`conv1d_weight`, `conv1d_bias`).
- Keep legacy dotted mappings (`conv1d.weight`, `conv1d.bias`) so Bridge remains compatible with older Megatron-Core pins.
- Cover Nemotron-H, Nemotron-VL, and Falcon-H1 mapping registries.

## Testing
- `uv run pre-commit run --all-files`
- `uv run ruff format --check src/megatron/bridge/models/nemotronh/nemotron_h_bridge.py src/megatron/bridge/models/nemotron_vl/nemotron_vl_bridge.py src/megatron/bridge/models/falcon_h1/falconh1_bridge.py tests/unit_tests/models/nemotronh/test_nemotron_h_bridge.py tests/unit_tests/models/nemotron_vl/test_nemotron_vl_bridge.py tests/unit_tests/models/falcon_h1/test_falcon_h1_bridge.py`
- `uv run ruff check src/megatron/bridge/models/nemotronh/nemotron_h_bridge.py src/megatron/bridge/models/nemotron_vl/nemotron_vl_bridge.py src/megatron/bridge/models/falcon_h1/falconh1_bridge.py tests/unit_tests/models/nemotronh/test_nemotron_h_bridge.py tests/unit_tests/models/nemotron_vl/test_nemotron_vl_bridge.py tests/unit_tests/models/falcon_h1/test_falcon_h1_bridge.py`
- `uv run python -m pytest -q tests/unit_tests/models/nemotronh/test_nemotron_h_bridge.py::TestNemotronHBridge::test_mapping_registry_contains_mamba_conv1d_compat_mappings tests/unit_tests/models/nemotron_vl/test_nemotron_vl_bridge.py::TestNemotronVLBridgeMappingRegistry::test_mapping_registry_contains_expected_groups tests/unit_tests/models/falcon_h1/test_falcon_h1_bridge.py::test_mapping_registry_contains_falcon_h1_weight_families`

## Regression Check
- The new compatibility assertions fail on unpatched `origin/main` with missing `conv1d_weight` / `conv1d_bias` mappings.
- Existing unpatched Bridge model-family tests still pass (`66 passed`), so the new assertions are needed to catch this.