### PR TITLE
docs: Fix link to docker README in docs

### DIFF
--- a/docs/releases/known-issues.md
+++ b/docs/releases/known-issues.md
@@ -9,7 +9,7 @@ This page lists known issues and limitations in the current release.
   - [`decord`](https://pypi.org/project/decord/)
   - [`opencv-python-headless`](https://pypi.org/project/opencv-python-headless/)
 
-  Workflows that depend on any of these (for example, multimodal video pipelines, `qwen-vl-utils` video paths, or `decord[av-decode]`) must reinstall them at runtime — see [`docker/common/README.md`](../../docker/common/README.md#reinstalling-video--image-decoding-packages-av-decord-opencv-python-headless-at-runtime) for instructions.
+  Workflows that depend on any of these (for example, multimodal video pipelines, `qwen-vl-utils` video paths, or `decord[av-decode]`) must reinstall them at runtime — see [`docker/common/README.md`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/docker/common/README.md#reinstalling-video--image-decoding-packages-av-decord-opencv-python-headless-at-runtime) for instructions.
 
 ## 26.02
 


### PR DESCRIPTION
# What does this PR do ?

docs: Fix link to docker README in docs

The reference to reinstalling some dependencies we recently added was failing docs build.

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
