### PR TITLE
[model] fix: Remove Stepfun loguru dependency

### DIFF
--- a/src/megatron/bridge/data/vlm_datasets/step37_flickr8k/preprocess.py
+++ b/src/megatron/bridge/data/vlm_datasets/step37_flickr8k/preprocess.py
@@ -29,12 +29,12 @@ model (already on CUDA, with ``images`` = ``list[ImageForInsert]``):
 
 from __future__ import annotations
 
+import logging
 from io import BytesIO
 from typing import Any
 
 import numpy as np
 import torch
-from loguru import logger
 from PIL import Image
 
 from megatron.bridge.data.vlm_datasets.step37_flickr8k.multimodal_utils import (
@@ -46,6 +46,7 @@ from megatron.bridge.data.vlm_datasets.step37_flickr8k.multimodal_utils import (
 
 _CLIP_MEAN = (0.48145466, 0.4578275, 0.40821073)
 _CLIP_STD = (0.26862954, 0.26130258, 0.27577711)
+logger = logging.getLogger(__name__)
 
 
 def _load_image(path: str) -> Image.Image:
@@ -60,7 +61,7 @@ def _load_image(path: str) -> Image.Image:
                 return Image.open(BytesIO(f.read())).convert("RGB")
         return Image.open(path).convert("RGB")
     except Exception as exc:  # noqa: BLE001
-        logger.warning(f"Image from {path} is broken or unavailable; using zero-image. Error: {exc}")
+        logger.warning("Image from %s is broken or unavailable; using zero-image. Error: %s", path, exc)
         return Image.new(size=(224, 224), mode="RGB")
 
 

--- a/src/megatron/bridge/data/vlm_datasets/step37_flickr8k/template.py
+++ b/src/megatron/bridge/data/vlm_datasets/step37_flickr8k/template.py
@@ -27,12 +27,12 @@ determines the token sequence produced for a given input dialog.
 from __future__ import annotations
 
 import copy
+import logging
 from collections.abc import Callable
 from typing import Any, Optional
 
 import numpy as np
 import torch
-from loguru import logger
 
 from megatron.bridge.data.vlm_datasets.step37_flickr8k.multimodal_utils import (
     IMAGE_ITEM_TYPE,
@@ -49,6 +49,7 @@ PATCH_START_TOKEN = "<patch_start>"
 PATCH_END_TOKEN = "<patch_end>"
 IMAGE_TOKEN_COUNT = 169
 PATCH_TOKEN_COUNT = 81
+logger = logging.getLogger(__name__)
 
 
 def _identity_path(path: str) -> str:
@@ -223,7 +224,7 @@ class Step37MultimodalTemplate:
 
         if len(all_tokens) > self.max_sequence_length + 1:
             logger.warning(
-                "Tokenized Step3.7 multimodal sample length {} exceeds max_sequence_length+1={}; "
+                "Tokenized Step3.7 multimodal sample length %s exceeds max_sequence_length+1=%s; "
                 "the packed dataloader oversize policy will decide whether to drop it.",
                 len(all_tokens),
                 self.max_sequence_length + 1,

--- a/src/megatron/bridge/models/stepfun/modelling_step37/image_insert_embedding.py
+++ b/src/megatron/bridge/models/stepfun/modelling_step37/image_insert_embedding.py
@@ -47,12 +47,15 @@ the GPTModel.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from typing import Optional, Union
 
 import torch
-from loguru import logger
 from torch import nn
+
+
+logger = logging.getLogger(__name__)
 
 
 # ─── ImageForInsert dataclass (model-interface type) ────────────────────────
@@ -166,9 +169,10 @@ class ImageInsertEmbedding(nn.Module):
 
         if len(feature_list) != insert_locations.shape[0]:
             logger.warning(
-                "Mismatch between image features and insert locations: "
-                f"{len(feature_list)} features vs {insert_locations.shape[0]} locations; "
-                "truncating to the overlap."
+                "Mismatch between image features and insert locations: %s features vs %s locations; "
+                "truncating to the overlap.",
+                len(feature_list),
+                insert_locations.shape[0],
             )
         count = min(len(feature_list), insert_locations.shape[0])
         if count == 0:


### PR DESCRIPTION
## Summary
- replace Stepfun Step-3.7 `loguru` imports with stdlib `logging`
- update warning calls to use stdlib logging formatting
- remove the undeclared dependency from package import paths

## Testing
- `git diff --check`
- `uv run --active --no-sync pre-commit run --files src/megatron/bridge/data/vlm_datasets/step37_flickr8k/preprocess.py src/megatron/bridge/data/vlm_datasets/step37_flickr8k/template.py src/megatron/bridge/models/stepfun/modelling_step37/image_insert_embedding.py`
- `uv run --active --no-sync python -m py_compile src/megatron/bridge/data/vlm_datasets/step37_flickr8k/preprocess.py src/megatron/bridge/data/vlm_datasets/step37_flickr8k/template.py src/megatron/bridge/models/stepfun/modelling_step37/image_insert_embedding.py`

Full package import smoke was blocked locally by an unrelated dependency-version assertion before test execution.