### PR TITLE
chore: bump transformer-engine to f8a01cd5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,7 +128,7 @@ override-dependencies = [
     "torch; sys_platform == 'never'",
     "torchvision; sys_platform == 'never'",
     "triton; sys_platform == 'never'",
-    "transformer-engine @ git+https://github.com/NVIDIA/TransformerEngine.git@release_v2.16",
+    "transformer-engine @ git+https://github.com/NVIDIA/TransformerEngine.git@f8a01cd5ac55a6b669bacc4b222242bfff2c822a",
     "mlflow>=3.9.0",                                        # To address CVE-2025-15031
     "cachetools>=5.0.0",
     "cryptography>=43.0.0,<47",

--- a/uv.lock
+++ b/uv.lock
@@ -23,7 +23,7 @@ overrides = [
     { name = "onnx", marker = "python_full_version < '3.13'", specifier = ">=1.21.0" },
     { name = "torch", marker = "sys_platform == 'never'" },
     { name = "torchvision", marker = "sys_platform == 'never'" },
-    { name = "transformer-engine", git = "https://github.com/NVIDIA/TransformerEngine.git?rev=release_v2.16" },
+    { name = "transformer-engine", git = "https://github.com/NVIDIA/TransformerEngine.git?rev=f8a01cd5ac55a6b669bacc4b222242bfff2c822a" },
     { name = "triton", marker = "sys_platform == 'never'" },
     { name = "urllib3", specifier = ">=2.6.3" },
 ]
@@ -4821,8 +4821,8 @@ wheels = [
 
 [[package]]
 name = "transformer-engine"
-version = "2.16.0+fa90e582"
-source = { git = "https://github.com/NVIDIA/TransformerEngine.git?rev=release_v2.16#fa90e58202b220462b4249ab84bfaa71b41280ab" }
+version = "2.16.0+f8a01cd5"
+source = { git = "https://github.com/NVIDIA/TransformerEngine.git?rev=f8a01cd5ac55a6b669bacc4b222242bfff2c822a#f8a01cd5ac55a6b669bacc4b222242bfff2c822a" }
 dependencies = [
     { name = "einops" },
     { name = "importlib-metadata" },


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## What
- Bump `transformer-engine` to `f8a01cd5ac55a6b669bacc4b222242bfff2c822a` (current tip of `release_v2.16`).
- Regenerate `uv.lock`.

## Lockfile delta
```
Updated transformer-engine v2.16.0+fa90e582 -> v2.16.0+f8a01cd5
```

```toml
"transformer-engine @ git+https://github.com/NVIDIA/TransformerEngine.git@f8a01cd5ac55a6b669bacc4b222242bfff2c822a"
```

## Test plan
- [ ] L0 CI green
- [ ] L1 CI green (label `needs-more-tests` applied)
- [ ] L2 CI green (label `full-test-suite` applied — high-blast-radius bump)

## Quarantined tests (this bump)
_None yet — will be appended as flakes are identified during CI iteration._

</details>
