### PR TITLE
[docs] fix: exclude generated skill artifacts

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,6 +59,8 @@ exclude_patterns = [
     ".DS_Store",
     "skills/linting-and-formatting/SKILL.md",
     "skills/parity-testing/SKILL.md",
+    "skills/**/BENCHMARK.md",
+    "skills/**/skill-card.md",
 ]
 
 suppress_warnings = [


### PR DESCRIPTION
## What

Exclude generated skill catalog artifacts from the Sphinx docs build:

- `skills/**/BENCHMARK.md`
- `skills/**/skill-card.md`

The docs build copies the repository `skills/` tree into `docs/skills`. The user-facing `SKILL.md` pages are listed in `docs/skills-index.md`, but generated benchmark/card artifacts are not documentation pages and currently produce warnings that fail docs CI with `fail-on-warning: true`.

## Why

Main docs CI is failing in run https://github.com/NVIDIA-NeMo/Megatron-Bridge/actions/runs/26651112045/job/78550816287 with 271 warnings, including:

- `myst.header` warnings from generated `skill-card.md` files
- `myst.xref_missing` warnings from generated `skill-card.md` links
- `toc.not_included` warnings for generated `BENCHMARK.md` and `skill-card.md` files

## Validation

- Static check confirmed all `BENCHMARK.md` and `skill-card.md` files under `skills/` match the new exclude patterns.
- `uv run --group docs sphinx-build -W --keep-going -b html docs docs/_build/html` could not run locally because this host cannot install `nvidia-resiliency-ext==0.6.0`: the available wheel targets `manylinux_2_39_x86_64`, while this host resolves as `manylinux_2_31_x86_64`.
- `uv run pre-commit run --all-files` hit the same local wheel compatibility blocker.
