### PR TITLE
[model] fix: Support partial Nemotron-VL specs

### DIFF
--- a/src/megatron/bridge/models/nemotron_omni/nemotron_omni_provider.py
+++ b/src/megatron/bridge/models/nemotron_omni/nemotron_omni_provider.py
@@ -25,10 +25,10 @@ from megatron.core.models.mamba.mamba_layer_specs import mamba_stack_spec
 from megatron.core.models.multimodal.llava_model import LLaVAModel
 from megatron.core.models.vision.multimodal_projector import MultimodalProjector
 from megatron.core.models.vision.vit_layer_specs import get_vit_layer_with_transformer_engine_spec
-from megatron.core.transformer.spec_utils import get_submodules
 
 from megatron.bridge.models.mamba.mamba_provider import MambaModelProvider
 from megatron.bridge.models.nemotron_omni.modeling_nemotron_omni import NemotronOmniModel
+from megatron.bridge.models.nemotron_vl.nemotron_vl_provider import get_language_mlp_submodules
 
 
 @dataclass
@@ -232,7 +232,7 @@ class NemotronOmniModelProvider(NemotronVLModelProvider):
 
         language_spec = mamba_stack_spec
         vision_spec = get_vit_layer_with_transformer_engine_spec()
-        vision_proj_spec = copy.deepcopy(get_submodules(language_spec.submodules.mlp_layer.submodules.mlp))
+        vision_proj_spec = copy.deepcopy(get_language_mlp_submodules(language_spec))
 
         add_encoder_flag = parallel_state.is_pipeline_first_stage() if self.pipeline_model_parallel_size > 1 else True
         add_decoder_flag = True
@@ -246,7 +246,7 @@ class NemotronOmniModelProvider(NemotronVLModelProvider):
             sound_model = self._build_sound_encoder()
 
             sound_proj_cfg = self._build_sound_projection_config(language_cfg)
-            sound_proj_spec = copy.deepcopy(get_submodules(language_spec.submodules.mlp_layer.submodules.mlp))
+            sound_proj_spec = copy.deepcopy(get_language_mlp_submodules(language_spec))
             sound_projection = MultimodalProjector(
                 config=sound_proj_cfg,
                 submodules=sound_proj_spec,

--- a/src/megatron/bridge/models/nemotron_vl/nemotron_vl_provider.py
+++ b/src/megatron/bridge/models/nemotron_vl/nemotron_vl_provider.py
@@ -25,8 +25,18 @@ from megatron.core.transformer.spec_utils import get_submodules
 from megatron.bridge.models.mamba.mamba_provider import MambaModelProvider
 
 
-def _get_language_mlp_submodules(language_spec: Any) -> object:
-    """Extract MLP submodules from object-style or partial-wrapped specs."""
+def get_language_mlp_submodules(language_spec: Any) -> Any:
+    """Extract the language MLP submodules from a (possibly partial-wrapped) stack spec.
+
+    Walks ``stack_spec -> mlp_layer -> mlp`` via :func:`get_submodules` at every level,
+    so it works whether each level is an object-style spec (``.submodules`` attribute)
+    or a ``functools.partial``-wrapped spec. Used to clone the language MLP spec for the
+    multimodal (vision / sound) projectors; shared with ``nemotron_omni``.
+
+    Returns the MLP submodules (an MCore ``*Submodules`` dataclass, e.g.
+    ``MLPSubmodules``). Typed ``Any`` because ``get_submodules`` is itself dynamically
+    typed (returns ``object``).
+    """
     language_submodules = get_submodules(language_spec)
     mlp_layer_submodules = get_submodules(language_submodules.mlp_layer)
     return get_submodules(mlp_layer_submodules.mlp)
@@ -128,7 +138,7 @@ class NemotronVLModelProvider(MambaModelProvider):
 
         language_spec = mamba_stack_spec
         vision_spec = get_vit_layer_with_transformer_engine_spec()
-        vision_proj_spec = copy.deepcopy(_get_language_mlp_submodules(language_spec))
+        vision_proj_spec = copy.deepcopy(get_language_mlp_submodules(language_spec))
 
         llava_model = LLaVAModel(
             language_transformer_config=language_cfg,

--- a/src/megatron/bridge/models/nemotron_vl/nemotron_vl_provider.py
+++ b/src/megatron/bridge/models/nemotron_vl/nemotron_vl_provider.py
@@ -14,7 +14,7 @@
 
 import copy
 from dataclasses import dataclass
-from typing import Callable
+from typing import Any, Callable
 
 from megatron.core.activations import fast_gelu, squared_relu
 from megatron.core.models.mamba.mamba_layer_specs import mamba_stack_spec
@@ -23,6 +23,13 @@ from megatron.core.models.vision.vit_layer_specs import get_vit_layer_with_trans
 from megatron.core.transformer.spec_utils import get_submodules
 
 from megatron.bridge.models.mamba.mamba_provider import MambaModelProvider
+
+
+def _get_language_mlp_submodules(language_spec: Any) -> object:
+    """Extract MLP submodules from object-style or partial-wrapped specs."""
+    language_submodules = get_submodules(language_spec)
+    mlp_layer_submodules = get_submodules(language_submodules.mlp_layer)
+    return get_submodules(mlp_layer_submodules.mlp)
 
 
 @dataclass
@@ -121,7 +128,7 @@ class NemotronVLModelProvider(MambaModelProvider):
 
         language_spec = mamba_stack_spec
         vision_spec = get_vit_layer_with_transformer_engine_spec()
-        vision_proj_spec = copy.deepcopy(get_submodules(language_spec.submodules.mlp_layer.submodules.mlp))
+        vision_proj_spec = copy.deepcopy(_get_language_mlp_submodules(language_spec))
 
         llava_model = LLaVAModel(
             language_transformer_config=language_cfg,

--- a/tests/unit_tests/models/nemotron_vl/test_nemotron_vl_provider.py
+++ b/tests/unit_tests/models/nemotron_vl/test_nemotron_vl_provider.py
@@ -17,7 +17,7 @@ from types import SimpleNamespace
 
 from megatron.bridge.models.nemotron_vl.nemotron_vl_provider import (
     NemotronVLModelProvider,
-    _get_language_mlp_submodules,
+    get_language_mlp_submodules,
 )
 
 
@@ -74,7 +74,7 @@ class TestNemotronVLModelProvider:
             )
         )
 
-        assert _get_language_mlp_submodules(language_spec) is mlp_submodules
+        assert get_language_mlp_submodules(language_spec) is mlp_submodules
 
     def test_language_mlp_submodules_from_partial_specs(self):
         mlp_submodules = SimpleNamespace(linear_fc1=object(), linear_fc2=object())
@@ -88,4 +88,4 @@ class TestNemotronVLModelProvider:
             ),
         )
 
-        assert _get_language_mlp_submodules(language_spec) is mlp_submodules
+        assert get_language_mlp_submodules(language_spec) is mlp_submodules

--- a/tests/unit_tests/models/nemotron_vl/test_nemotron_vl_provider.py
+++ b/tests/unit_tests/models/nemotron_vl/test_nemotron_vl_provider.py
@@ -12,8 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from functools import partial
+from types import SimpleNamespace
+
 from megatron.bridge.models.nemotron_vl.nemotron_vl_provider import (
     NemotronVLModelProvider,
+    _get_language_mlp_submodules,
 )
 
 
@@ -61,3 +65,27 @@ class TestNemotronVLModelProvider:
         assert provider.freeze_language_model is True
         assert provider.freeze_vision_model is True
         assert provider.freeze_vision_projection is True
+
+    def test_language_mlp_submodules_from_object_specs(self):
+        mlp_submodules = SimpleNamespace(linear_fc1=object(), linear_fc2=object())
+        language_spec = SimpleNamespace(
+            submodules=SimpleNamespace(
+                mlp_layer=SimpleNamespace(submodules=SimpleNamespace(mlp=SimpleNamespace(submodules=mlp_submodules)))
+            )
+        )
+
+        assert _get_language_mlp_submodules(language_spec) is mlp_submodules
+
+    def test_language_mlp_submodules_from_partial_specs(self):
+        mlp_submodules = SimpleNamespace(linear_fc1=object(), linear_fc2=object())
+        language_spec = partial(
+            object,
+            submodules=SimpleNamespace(
+                mlp_layer=partial(
+                    object,
+                    submodules=SimpleNamespace(mlp=partial(object, submodules=mlp_submodules)),
+                )
+            ),
+        )
+
+        assert _get_language_mlp_submodules(language_spec) is mlp_submodules


### PR DESCRIPTION
## Summary
- Make Nemotron-VL vision projection spec extraction tolerate both object-style MCore specs and `functools.partial`-wrapped specs.
- Use `get_submodules()` at each language MLP spec boundary instead of directly traversing nested `.submodules` attributes.
- Add focused unit coverage for both object and partial spec shapes.

## Validation
- `uv run pre-commit run --all-files` attempted, but local `uv` sync is blocked by `nvidia-resiliency-ext==0.6.0` lacking a wheel for this host platform.
- `uv run --no-sync pre-commit run --all-files` passed.
- `git diff --check` passed.
- `python3 -m py_compile src/megatron/bridge/models/nemotron_vl/nemotron_vl_provider.py tests/unit_tests/models/nemotron_vl/test_nemotron_vl_provider.py` passed.
- DFW 26.06.rc1 inspection job `12290194` confirmed nested MLP is a `functools.partial` in the affected spec path.
- DFW 26.06.rc1 interactive functional job `12290312` passed: `python -m pytest -s -v tests/functional_tests/test_groups/models/nemotron_vl/test_nemotron_vl_conversion.py --tb=short` -> `3 passed, 37 warnings in 309.68s`.

Logs:
- `/lustre/fs1/portfolios/coreai/projects/coreai_dlalgo_llm/users/chcui/mbridge_home/logs/nemotron-vl-conversion-fix/nvvl-functional_12290312.out`
- `/lustre/fs1/portfolios/coreai/projects/coreai_dlalgo_llm/users/chcui/mbridge_home/logs/nemotron-vl-conversion-fix/nvvl-functional_12290312.err`