### PR TITLE
[training] fix: support MCore tokenizer padding fields

### DIFF
--- a/src/megatron/bridge/training/tokenizers/config.py
+++ b/src/megatron/bridge/training/tokenizers/config.py
@@ -24,6 +24,15 @@ from megatron.bridge.utils.common_utils import warn_rank_0
 class TokenizerConfig(MTrainTokenizerConfig):
     """Configuration settings for tokenizers."""
 
+    make_vocab_size_divisible_by: int = 1
+    """Keep MCore tokenizer padding neutral; model providers apply vocab padding."""
+
+    tensor_model_parallel_size: int = 1
+    """Tensor parallel size used by MCore tokenizer padded vocab-size calculation."""
+
+    rank: int = 0
+    """Distributed rank used by MCore tokenizer helper logging."""
+
     hf_tokenizer_kwargs: dict[str, Any] | None = field(default_factory=dict)
     """Additional keyword arguments to pass to HuggingFace AutoTokenizer.from_pretrained.
 

--- a/tests/unit_tests/training/test_model_load_save.py
+++ b/tests/unit_tests/training/test_model_load_save.py
@@ -1109,11 +1109,23 @@ class TestLoadTokenizer:
 
             assert mock_tokenizer_cfg.tokenizer_model == new_asset_path
 
+            # test setting tokenizer config fields used by MCore's padded vocab calculation
+            _ = load_tokenizer(
+                ckpt_path,
+                tensor_model_parallel_size=2,
+                make_vocab_size_divisible_by=256,
+                rank=3,
+            )
+
+            assert mock_tokenizer_cfg.tensor_model_parallel_size == 2
+            assert mock_tokenizer_cfg.make_vocab_size_divisible_by == 256
+            assert mock_tokenizer_cfg.rank == 3
+
             # test setting attribute that doesn't exist
             with pytest.raises(
-                AttributeError, match="Attempting to set a non-existent attribute 'tensor_model_parallel_size'"
+                AttributeError, match="Attempting to set a non-existent attribute 'invalid_tokenizer_kwarg'"
             ):
-                load_tokenizer(ckpt_path, tensor_model_parallel_size=1)
+                load_tokenizer(ckpt_path, invalid_tokenizer_kwarg=True)
 
     @patch("megatron.bridge.training.model_load_save.build_tokenizer")
     @patch("megatron.bridge.utils.instantiate_utils.instantiate")


### PR DESCRIPTION
## Summary

Add the MCore tokenizer padding fields that Bridge's `TokenizerConfig` needs when it is passed through `megatron.core.tokenizers.utils.build_tokenizer`:

- `make_vocab_size_divisible_by`
- `tensor_model_parallel_size`
- `rank`

The defaults are neutral for Bridge checkpoint conversion because Bridge applies model vocab padding separately.

## Testing

- `uv run --active --no-sync pre-commit run --all-files`
- `uv run --active --no-sync ruff check src/megatron/bridge/training/tokenizers/config.py tests/unit_tests/training/test_model_load_save.py`
- `uv run --active --no-sync ruff format --check src/megatron/bridge/training/tokenizers/config.py tests/unit_tests/training/test_model_load_save.py`
- `uv run --active --no-sync python -m py_compile src/megatron/bridge/training/tokenizers/config.py tests/unit_tests/training/test_model_load_save.py`

Targeted pytest was attempted locally, but this workstation Python environment is missing Transformer Engine, which prevents importing the full `megatron.bridge` package before the selected test starts.
