### PR TITLE
[examples] fix: update Bailing inference recipe

### DIFF
--- a/examples/models/bailing/inference.sh
+++ b/examples/models/bailing/inference.sh
@@ -26,7 +26,7 @@ uv run python -m torch.distributed.run --nproc_per_node=8 scripts/inference/text
     --hf_model_path inclusionAI/Ling-flash-2.0 \
     --prompt "$PROMPT" \
     --max_new_tokens "$MAX_NEW_TOKENS" \
-    --tp 2 --ep 4 \
+    --tp 1 --ep 8 \
     --use-coordinator \
     --coordinator-host "${COORDINATOR_HOST}" \
     --trust-remote-code
@@ -38,7 +38,7 @@ if [ -d "$MEGATRON_MODEL_PATH" ]; then
         --megatron_model_path "$MEGATRON_MODEL_PATH" \
         --prompt "$PROMPT" \
         --max_new_tokens "$MAX_NEW_TOKENS" \
-        --tp 2 --ep 4 \
+        --tp 1 --ep 8 \
         --use-coordinator \
         --coordinator-host "${COORDINATOR_HOST}" \
         --trust-remote-code
@@ -50,7 +50,7 @@ if [ -d "$HF_EXPORT_PATH" ]; then
         --hf_model_path "$HF_EXPORT_PATH" \
         --prompt "$PROMPT" \
         --max_new_tokens "$MAX_NEW_TOKENS" \
-        --tp 2 --ep 4 \
+        --tp 1 --ep 8 \
         --use-coordinator \
         --coordinator-host "${COORDINATOR_HOST}" \
         --trust-remote-code


### PR DESCRIPTION
## Summary
- update the Bailing Ling-flash-2.0 inference example from TP=2/EP=4 to TP=1/EP=8
- keep the current main inference flow unchanged

## Validation
- `uv run --no-sync pre-commit run --all-files`
- Private single-node validation on latest main (`ab1d5e41`) with this TP1/EP8 recipe did not reproduce a CUDA/NCCL OOM on one 8-GPU H100 80GB node. The imported-checkpoint phase loaded and ran with peak sampled memory around 75.1 GiB/GPU, leaving around 5.9 GiB free, before manual cancellation while generation was still running.

Note: a normal `uv run pre-commit run --all-files` sync attempt failed before hooks because TransformerEngine metadata build isolation could not import `setuptools`; the no-sync hook run passed.