### PR TITLE
fix(perf): revert canonical 'rajpurkar/squad' HF dataset id

### DIFF
--- a/docs/training/peft.md
+++ b/docs/training/peft.md
@@ -303,7 +303,7 @@ config = ConfigContainer(
         lr_decay_iters=1000,
     ),
     dataset=HFDatasetConfig(
-        dataset_name="rajpurkar/squad",
+        dataset_name="squad",
         process_example_fn=process_squad_example,
         seq_length=512,
     ),

--- a/scripts/performance/utils/datasets.py
+++ b/scripts/performance/utils/datasets.py
@@ -77,7 +77,7 @@ def create_squad_dataset_config(
         packed_sequence_specs = PackedSequenceSpecs(packed_sequence_size=seq_length, pad_seq_to_mult=pad_seq_to_mult)
 
     return HFDatasetConfig(
-        dataset_name="rajpurkar/squad",  # Hugging Face dataset name (canonical namespaced id)
+        dataset_name="squad",  # Hugging Face dataset name
         process_example_fn=process_squad_example,  # Processing function
         dataset_root=dataset_root,  # Local cache/processed files location
         seq_length=seq_length,

--- a/src/megatron/bridge/recipes/utils/finetune_utils.py
+++ b/src/megatron/bridge/recipes/utils/finetune_utils.py
@@ -88,7 +88,7 @@ def default_squad_config(seq_length: int, packed_sequence: bool = True, pad_seq_
     dataloader_type = "batch"
 
     return HFDatasetConfig(
-        dataset_name="rajpurkar/squad",
+        dataset_name="squad",
         process_example_fn=process_squad_example,
         seq_length=seq_length,
         seed=5678,  # Different from pretrain seed

--- a/src/megatron/bridge/training/utils/flop_utils.py
+++ b/src/megatron/bridge/training/utils/flop_utils.py
@@ -355,7 +355,7 @@ def num_floating_point_operations(
             cfg.model.num_attention_heads if cfg.model.num_query_groups is None else cfg.model.num_query_groups
         )
 
-        is_squad = getattr(getattr(cfg, "dataset", None), "dataset_name", None) in ("squad", "rajpurkar/squad")
+        is_squad = getattr(getattr(cfg, "dataset", None), "dataset_name", None) == "squad"
         hf_model_id = getattr(cfg.model, "hf_model_id", None)
         is_llama3_70b = hf_model_id is not None and "Meta-Llama-3-70B" in hf_model_id
         packed_specs = getattr(getattr(cfg, "dataset", None), "packed_sequence_specs", None)

--- a/tests/functional_tests/test_groups/training/test_finetune_dora.py
+++ b/tests/functional_tests/test_groups/training/test_finetune_dora.py
@@ -197,7 +197,7 @@ class TestDoRAFinetune:
     def _create_squad_dataset_config(self, seq_length, seed=5678):
         """Create a SQuAD dataset configuration."""
         return HFDatasetConfig(
-            dataset_name="rajpurkar/squad",
+            dataset_name="squad",
             process_example_fn=process_squad_example,
             seq_length=seq_length,
             seed=seed,

--- a/tests/functional_tests/test_groups/training/test_finetune_lora.py
+++ b/tests/functional_tests/test_groups/training/test_finetune_lora.py
@@ -356,7 +356,7 @@ class TestLoRAFinetune:
             packed_sequence_specs = None
 
         config = HFDatasetConfig(
-            dataset_name="rajpurkar/squad",
+            dataset_name="squad",
             process_example_fn=process_squad_example,
             seq_length=seq_length,
             seed=seed,

--- a/tests/functional_tests/test_groups/training/test_seqpacking_cp_example.py
+++ b/tests/functional_tests/test_groups/training/test_seqpacking_cp_example.py
@@ -74,7 +74,7 @@ class TestPeftSftExample:
 
         # Use a small packed SQuAD dataset to exercise THD/context-parallel slicing
         cfg.dataset = HFDatasetConfig(
-            dataset_name="rajpurkar/squad",
+            dataset_name="squad",
             process_example_fn=process_squad_example,
             seq_length=256,
             dataloader_type="batch",

--- a/tests/unit_tests/recipes/utils/test_dataset_utils.py
+++ b/tests/unit_tests/recipes/utils/test_dataset_utils.py
@@ -335,7 +335,7 @@ class TestApplyDatasetOverride:
         config = _make_mock_config()
         result = apply_dataset_override(config, "llm-finetune", seq_length=512)
         assert isinstance(result.dataset, HFDatasetConfig)
-        assert result.dataset.dataset_name == "rajpurkar/squad"
+        assert result.dataset.dataset_name == "squad"
 
     def test_llm_finetune_extracts_dataset_name_from_cli(self):
         from megatron.bridge.data.builders.hf_dataset import HFDatasetConfig


### PR DESCRIPTION
<details><summary>Claude summary</summary>

Reverts [#3957](https://github.com/NVIDIA-NeMo/Megatron-Bridge/pull/3957) (commit `118ff1ae820001088f84f98181fdb4864ae6ed52`).

## Why

The renamed `dataset_name="rajpurkar/squad"` in `scripts/performance/utils/datasets.py:create_squad_dataset_config` causes the HF `datasets` library shipped in the current `nvcr.io/nvidian/nemo:dgxctestingtemp-nemofw-nightly.*` container to fail with:

```
File "/opt/venv/lib/python3.12/site-packages/datasets/features/features.py", line 1473, in generate_from_dict
    field_names = {f.name for f in fields(class_type)}
File "/usr/lib/python3.12/dataclasses.py", line 1282, in fields
    raise TypeError('must be called with a dataclass type or instance') from None
TypeError: must be called with a dataclass type or instance
```

The canonical id's exported `dataset_info` features dict references a class type the installed `datasets` version cannot resolve via `dataclasses.fields()`.

## Impact

All four `*_perf_finetune_*` jobs in nightly pipeline [`53148002`](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/53148002) failed with the identical trace:

| Job | Test case |
|---|---|
| [329804508](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/329804508) | `llama3_70b_8gpu_gb300_fp8_mx_50steps_perf_finetune_lora` |
| [329804509](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/329804509) | `llama3_70b_8gpu_gb200_fp8_mx_50steps_perf_finetune_lora` |
| [329804507](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/329804507) | `llama3_70b_32gpu_gb200_fp8_mx_50steps_perf_finetune_sft` |
| [329804505](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/329804505) | `llama3_70b_32gpu_gb300_fp8_mx_50steps_perf_finetune_sft` |

## Bisect window

Healthy run: nightly job [329129243](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/329129243) @ 2026-05-29 10:13 UTC, MBridge `a21b6b4f`.
Bad run: nightly job [329804508](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/329804508) @ 2026-05-30 09:17 UTC, MBridge `1ace3e2e`.

The only commit in that window that touches the failing code path is #3957.

## Follow-up

Re-land #3957 once the container's `datasets` library is bumped to a version that handles `rajpurkar/squad`'s exported info schema (or once a `revision=...` pin is added in `create_squad_dataset_config`).

## Verification

Confirmation probe launched against this branch with the original bad pipeline's `NCC_IMAGE_NAME=nvcr.io/nvidian/nemo:dgxctestingtemp-nemofw-nightly.53141951`. Pipeline link will follow in a comment.

</details>
