### PR TITLE
fix(perf): stop infinite test re-evaluation when convergence check fails

### DIFF
--- a/scripts/performance/argument_parser.py
+++ b/scripts/performance/argument_parser.py
@@ -855,6 +855,19 @@ def _testing_args(parser):
         default=False,
     )
     testing_args.add_argument(
+        "--retry_on_testing_failure",
+        action="store_true",
+        help=(
+            "If true, when the post-training convergence/perf check fails, the "
+            "experiment is retrained from scratch and re-tested in the next "
+            "outer-loop iteration (bounded by --max_retries). Off by default: "
+            "a single failed test surfaces immediately as AssertionError, "
+            "which is the right behavior for CI."
+        ),
+        required=False,
+        default=False,
+    )
+    testing_args.add_argument(
         "--golden_values_path",
         type=str,
         help="Path to golden values file",

--- a/scripts/performance/setup_experiment.py
+++ b/scripts/performance/setup_experiment.py
@@ -275,6 +275,7 @@ def main(
     performance_params: Dict[str, Any],
     memory_params: Dict[str, Any],
     max_retries: int,
+    retry_on_testing_failure: bool,
     dgxc_base_url: str,
     dgxc_cluster: str,
     dgxc_kube_apiserver_url: str,
@@ -641,9 +642,28 @@ def main(
             logger.removeHandler(_dup_handler)
             _dup_file.close()
 
-            if not is_long_convergence_run:
+            if not retry_on_testing_failure:
+                # Train-then-test: each experiment runs the convergence/perf
+                # check exactly once. Force-exit the outer loop here — the
+                # post-loop block raises AssertionError(error_msg) when testing
+                # failed. Without this, a long-convergence run whose testing
+                # fails would otherwise spin re-evaluating the same finished
+                # training forever until the slurm walltime cap killed it.
                 n_attempts = max_retries + 1
-                is_finished_experiment = True
+            elif not is_testing_passed:
+                # Opt-in retry: redo training + testing in the next outer-loop
+                # iteration. Bump n_attempts so the outer loop bounds the
+                # retries. Reset is_finished_experiment so the inner training
+                # loop runs again; clear wandb_run_id so the retry logs to a
+                # fresh wandb run instead of resuming the failed one.
+                n_attempts += 1
+                if n_attempts <= max_retries:
+                    is_finished_experiment = False
+                    wandb_run_id = None
+                    logger.error(
+                        f"Testing failed; retrying full train+test "
+                        f"({n_attempts + 1} of {max_retries + 1}) for {exp_name}"
+                    )
 
         if is_finished_experiment and is_testing_passed:
             break
@@ -771,6 +791,7 @@ if __name__ == "__main__":
             "memory_threshold": args.memory_threshold,
         },
         max_retries=args.max_retries,
+        retry_on_testing_failure=args.retry_on_testing_failure,
         dgxc_base_url=args.dgxc_base_url,
         dgxc_cluster=args.dgxc_cluster,
         dgxc_kube_apiserver_url=args.dgxc_kube_apiserver_url,


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## What

Stops the infinite test re-evaluation loop in `scripts/performance/setup_experiment.py` and replaces the implicit `is_long_convergence_run` gate on retry-after-failed-test with an explicit `--retry_on_testing_failure` flag, **off by default**.

## Why

Observed today on the `wan_1_3b_text2image_128gpu_h100_nightly` job (`main` @ `4998c4c4`): training reached step 100 and the convergence check completed — but tripped on NaN-stitched metrics from a slurm-resumed slice and reported a regression. The outer `while n_attempts <= max_retries:` in `main()` then kept calling `calc_convergence_and_performance` on the same finished training run forever, because:

- `is_finished_experiment` was True (training did finish)
- `is_testing_passed` was False (regression)
- neither was mutated, and `n_attempts` was only incremented inside the inner training loop
- the `if not is_long_convergence_run:` early-exit at the old line 644 only fired for short runs

Result: the job spun for the full 4 h walltime cap until slurm cancelled it.

## How

```python
# Before
if not is_long_convergence_run:
    n_attempts = max_retries + 1
    is_finished_experiment = True

# After
if not retry_on_testing_failure:
    # train-then-test: testing runs exactly once; failure raises via
    # the post-loop AssertionError(error_msg) path.
    n_attempts = max_retries + 1
elif not is_testing_passed:
    # opt-in retry: retrain + re-test in the next outer iteration,
    # bounded by --max_retries. Fresh wandb run on retry.
    n_attempts += 1
    if n_attempts <= max_retries:
        is_finished_experiment = False
        wandb_run_id = None
        logger.error(
            f"Testing failed; retrying full train+test "
            f"({n_attempts + 1} of {max_retries + 1}) for {exp_name}"
        )
```

- Inner training-resubmit loop (walltime resume + flaky-failure retries) is untouched.
- Default `--retry_on_testing_failure=false` matches what CI wants: a regression should fail the job fast, not eat the walltime cap.
- `--is_long_convergence_run` no longer doubles as a retry policy — it now only controls whether resume-from-checkpoint semantics apply to the inner training loop.

## Behavior matrix

| `--retry_on_testing_failure` | Training | Testing | Outcome |
|---|---|---|---|
| `false` *(default)* | finishes | passes | success |
| `false` | finishes | fails | `AssertionError(error_msg)` — fails immediately |
| `true` | finishes | passes | success |
| `true` | finishes | fails | retrain + re-test, bounded by `--max_retries` |

## Test plan

- [ ] Re-run `wan_1_3b_text2image_128gpu_h100_nightly` on this branch — expect immediate failure with the existing regression `AssertionError`, not a 4 h walltime cancel.
- [ ] One short-path test (e.g. `gpt3_15b_pretrain` at default `n_repeat=5`) to confirm the existing happy path still passes.
- [ ] Optional: one run with `--retry_on_testing_failure --max_retries 1` against a known-flaky test to confirm the retry resets state and runs a fresh wandb run.

</details>
