### PR TITLE
build(docker): point nemo-evaluator source at /opt/Evaluator root

### DIFF
--- a/docker/common/fw_pyproject.toml
+++ b/docker/common/fw_pyproject.toml
@@ -41,7 +41,7 @@ test = ["coverage>=7.8.1"]
 
 [tool.uv.sources]
 "nemo-export-deploy" = { path = "/opt/Export-Deploy", editable = true }
-"nemo-evaluator" = { path = "/opt/Evaluator/packages/nemo-evaluator", editable = true }
+"nemo-evaluator" = { path = "/opt/Evaluator", editable = true }
 "nemo-run" = { path = "/opt/Run", editable = true }
 "lightning" = { path = "stubs/lightning" }
 


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## Background / motivation

- The fw-final container build started failing with `error: Distribution not found at: file:///opt/Evaluator/packages/nemo-evaluator` (e.g. nemo-ci job `330634014`).
- Cause: [NVIDIA-NeMo/Evaluator](https://github.com/NVIDIA-NeMo/Evaluator) was restructured. The `nemo-evaluator` package no longer lives at `packages/nemo-evaluator/`; its `pyproject.toml` is now at the repo root and sources live under `src/nemo_evaluator/`. Only `packages/nemo-evaluator-launcher/` remains under `packages/`.

## What changed

- `docker/common/fw_pyproject.toml`: point the `nemo-evaluator` uv source at `/opt/Evaluator` instead of `/opt/Evaluator/packages/nemo-evaluator`.

## Details

- `docker/common/fw_pyproject.toml:44` — the only stale reference; `Dockerfile.fw_final` already clones into `/opt/Evaluator` directly, so no other changes are needed.

```toml
[tool.uv.sources]
"nemo-export-deploy" = { path = "/opt/Export-Deploy", editable = true }
-"nemo-evaluator" = { path = "/opt/Evaluator/packages/nemo-evaluator", editable = true }
+"nemo-evaluator" = { path = "/opt/Evaluator", editable = true }
"nemo-run" = { path = "/opt/Run", editable = true }
```

## Tested

- Pending CI on this PR (container build is the failing step that should now pass).

</details>
