### PR TITLE
docs: adopt Conventional Commits for PR titles

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -32,7 +32,7 @@ reviews:
   auto_title_placeholder: '@coderabbitai title'
   # Auto Title Instructions - Custom instructions for auto-generating the PR/MR title.
   # Default: ""
-  auto_title_instructions: 'Format: "[{modules}] {type}: {description}". Modules: model, recipe, training, data, ckpt, peft, perf, ci, doc, test, build, misc. Use comma to separate multiple modules. Type must be one of: feat, fix, refactor, chore, test. Title should be concise (<= 80 chars). Example: "[model] feat: Add Qwen3 model bridge" or "[recipe, doc] feat: Add Llama 3.1 70B recipe".'
+  auto_title_instructions: 'Follow Conventional Commits 1.0.0 (https://www.conventionalcommits.org/en/v1.0.0/). Format: "<type>(<scope>): <description>". Scope is optional. Type must be one of: feat, fix, refactor, perf, docs, build, ci, test, chore. Scope (optional) must be one of: model, recipe, training, data, ckpt, peft, distill, prune, quant, diffusion, misc. Use "!" before ":" for breaking changes (e.g. "feat(training)!: ..."). Description uses imperative mood, lowercase first letter, no trailing period. Title should be concise (<= 80 chars). Examples: "feat(model): add Qwen3 model bridge", "docs(recipe): add Llama 3.1 70B walkthrough", "ci: bump runner image".'
   # Set the commit status to 'pending' when the review is in progress and 'success' when it is complete.
   # Default: true
   commit_status: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ the authoritative rules. For judgment calls not covered by tooling, see
 
 See @CONTRIBUTING.md for the full contributor guide, including:
 
-- Commit and PR title format (`[{areas}] {type}: {description}`)
+- Commit and PR title format ([Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/): `<type>(<scope>): <description>`)
 - PR labeling taxonomy (type, area, state, risk labels)
 - Testing conventions (unit preferred, functional max 2 GPUs, L0/L1/L2 tiers)
 - Dependency management policy

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,45 +160,49 @@ If you have write access to the repository (NVIDIA contributors):
 
 ## 📋 Commit and PR Title Format
 
-Format your commit messages and PR titles as:
+We follow [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/). Format your commit messages and PR titles as:
 
 ```text
-[{areas}] {type}: {description}
+<type>(<scope>): <description>
 ```
 
-**Areas** (use the most relevant ones, separate multiple with `,`):
+The scope is optional. Use the imperative mood, lowercase first letter, and no trailing period in the description.
+
+**Types**:
+- `feat` - New feature
+- `fix` - Bug fix
+- `refactor` - Code refactoring without changing functionality
+- `perf` - Performance optimizations and throughput improvements
+- `docs` - Documentation, examples, and contributor guidance
+- `build` - Dependencies, packaging, and environment setup
+- `ci` - CI, automation, and workflow infrastructure
+- `test` - Adding or updating tests
+- `chore` - Maintenance tasks
+
+**Scopes** (optional, pick the most relevant one):
 - `model` - Model implementations and HF bridge logic
 - `recipe` - Training recipes and launch configs
 - `training` - Training loop, callbacks, and runtime integration
 - `data` - Dataset builders, preprocessing, and samplers
 - `ckpt` - Checkpoint conversion, loading, export, and save paths
 - `peft` - PEFT methods (LoRA, adapters) and adapter export
-- `perf` - Performance optimizations and throughput improvements
 - `distill` - Knowledge distillation
 - `prune` - Pruning and sparsity
 - `quant` - Quantization (PTQ, QAT, FP8 recipes)
 - `diffusion` - Diffusion model implementations and training
-- `ci` - CI, automation, and workflow infrastructure
-- `docs` - Documentation, examples, and contributor guidance
-- `build` - Dependencies, packaging, and environment setup
 - `misc` - Cross-cutting utilities and other changes
 
-**Types**:
-- `feat` - New feature
-- `fix` - Bug fix
-- `refactor` - Code refactoring without changing functionality
-- `chore` - Maintenance tasks
-- `test` - Adding or updating tests
-
-**Breaking Changes**: If your PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
+**Breaking Changes**: If your PR breaks any API (CLI arguments, config, function signature, etc.), append `!` before the colon (e.g. `feat(training)!: …`).
 
 **Examples**:
 ```text
-[model] feat: Add Qwen3 model bridge
-[recipe, docs] feat: Add Llama 3.1 70B recipe with documentation
-[ckpt] fix: Handle missing keys in HF checkpoint conversion
-[BREAKING][training] refactor: Change optimizer config structure
-[ci, build] chore: Update ruff version
+feat(model): add Qwen3 model bridge
+fix(ckpt): handle missing keys in HF checkpoint conversion
+perf(training): reduce backward pass overhead
+docs(recipe): add Llama 3.1 70B recipe walkthrough
+ci: bump runner image
+build: pin transformer-engine to 1.10
+refactor(training)!: change optimizer config structure
 ```
 
 ## 🏷️ Labeling Your PR
@@ -406,7 +410,7 @@ uv lock
 
 ```bash
 git add pyproject.toml uv.lock
-git commit -s -m "[build] chore: Add $DEPENDENCY"
+git commit -s -m "build: add $DEPENDENCY"
 git push
 ```
 

--- a/skills/build-and-dependency/SKILL.md
+++ b/skills/build-and-dependency/SKILL.md
@@ -115,7 +115,7 @@ Commit both modified files:
 
 ```bash
 git add pyproject.toml uv.lock
-git commit -s -m "[build] chore: add <package>"
+git commit -s -m "build: add <package>"
 ```
 
 ### Regenerating uv.lock

--- a/skills/bump-dependency/SKILL.md
+++ b/skills/bump-dependency/SKILL.md
@@ -84,7 +84,7 @@ Sign-off + signed-commit + PR title format per @CONTRIBUTING.md and
 
 ```bash
 git add pyproject.toml uv.lock
-git commit -S -s -m "[build] chore: bump <package> to <ref>"
+git commit -S -s -m "build: bump <package> to <ref>"
 git push -u origin <branch-name>
 ```
 
@@ -276,7 +276,7 @@ When a `JOB <name> -> failure` event fires:
 4. **Commit, push, retrigger**:
 
    ```bash
-   git commit -S -s -m "[ci] chore: quarantine flaky <test> for <package> bump"
+   git commit -S -s -m "ci: quarantine flaky <test> for <package> bump"
    git push
    gh pr comment <N> --repo NVIDIA-NeMo/Megatron-Bridge \
      --body "/ok to test $(git rev-parse HEAD)"

--- a/skills/cicd/SKILL.md
+++ b/skills/cicd/SKILL.md
@@ -10,9 +10,9 @@ when_to_use: Investigating a CI failure, understanding the pipeline structure, w
 
 - **Never commit directly to `main`** — always create a feature branch.
 - **Always sign commits**: `git commit -s -m "message"`.
-- **PR title format**: `[{areas}] {type}: {description}`
-  (e.g., `[model] feat: Add Qwen3 model bridge`).
-See @CONTRIBUTING.md for the full PR workflow, area/type labels, and DCO requirements.
+- **PR title format**: [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) — `<type>(<scope>): <description>`
+  (e.g., `feat(model): add Qwen3 model bridge`).
+See @CONTRIBUTING.md for the full PR workflow, type/scope taxonomy, and DCO requirements.
 
 ## How CI Is Triggered
 


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## Background / motivation

- The current PR title format `[{areas}] {type}: {description}` is bespoke and does not match the broadly adopted [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- Aligns the repo with tooling that expects CC (release-please, semantic-release, GitHub semantic PR checks, CodeRabbit auto-title).

## What changed

- Adopt CC format `<type>(<scope>): <description>` across CONTRIBUTING, AGENTS, CodeRabbit config, and skills.
- Promote `ci`, `docs`, `build`, `perf` from areas to types (they are CC types, not scopes).
- Replace `[BREAKING]` prefix with the CC-native `!` indicator.

## Details

| File | Change |
|---|---|
| `CONTRIBUTING.md` (§ Commit and PR Title Format) | New format + types/scopes split + `!` for breaking + refreshed examples |
| `AGENTS.md:78` | Reference points to CC syntax |
| `.coderabbit.yaml:35` | Auto-title instructions rewritten for CC |
| `skills/cicd/SKILL.md:13-14` | PR title reference updated |
| `skills/build-and-dependency/SKILL.md:118` | `[build] chore: add <pkg>` → `build: add <pkg>` |
| `skills/bump-dependency/SKILL.md:87,279` | Bump + quarantine commit examples updated |

**Types**: `feat`, `fix`, `refactor`, `perf`, `docs`, `build`, `ci`, `test`, `chore`.

**Scopes** (optional): `model`, `recipe`, `training`, `data`, `ckpt`, `peft`, `distill`, `prune`, `quant`, `diffusion`, `misc`.

Example:

```text
feat(model): add Qwen3 model bridge
fix(ckpt): handle missing keys in HF checkpoint conversion
perf(training): reduce backward pass overhead
docs(recipe): add Llama 3.1 70B recipe walkthrough
ci: bump runner image
build: pin transformer-engine to 1.10
refactor(training)!: change optimizer config structure
```

## Tested

- Docs-only change; no code paths affected.
- `git log -1 --stat` confirms 6 files / +33 / -29.

</details>
