### PR TITLE
Fix SQuAD dataset name with newer Hugging Face Hub version

### DIFF
--- a/docker/common/fw_pyproject.toml
+++ b/docker/common/fw_pyproject.toml
@@ -60,7 +60,7 @@ override-dependencies = [
     "ctc_segmentation==1.7.4",
     "pyzmq==25.1.2",                            # @URL: https://github.com/NVIDIA/NeMo/issues/13625
     "tiktoken>=0.9.0",                          # let megatron-hub win over nemo-toolkit
-    "datasets==3.1.0",
+    "datasets==4.8.5",
     "fsspec[http]>=2023.1.0,<=2024.9.0",
     "transformers; sys_platform == 'never'",    # Defer to transformers in MBridge install
     "packaging>=25.0",

--- a/docs/training/peft.md
+++ b/docs/training/peft.md
@@ -268,7 +268,7 @@ config = ConfigContainer(
         lr_decay_iters=1000,
     ),
     dataset=HFDatasetConfig(
-        dataset_name="squad",
+        dataset_name="rajpurkar/squad",
         process_example_fn=process_squad_example,
         seq_length=512,
     ),

--- a/scripts/performance/utils/datasets.py
+++ b/scripts/performance/utils/datasets.py
@@ -77,7 +77,7 @@ def create_squad_dataset_config(
         packed_sequence_specs = PackedSequenceSpecs(packed_sequence_size=seq_length, pad_seq_to_mult=pad_seq_to_mult)
 
     return HFDatasetConfig(
-        dataset_name="squad",  # Hugging Face dataset name
+        dataset_name="rajpurkar/squad",  # Hugging Face dataset name (canonical namespaced id)
         process_example_fn=process_squad_example,  # Processing function
         dataset_root=dataset_root,  # Local cache/processed files location
         seq_length=seq_length,

--- a/src/megatron/bridge/data/builders/hf_dataset.py
+++ b/src/megatron/bridge/data/builders/hf_dataset.py
@@ -34,6 +34,11 @@ from megatron.bridge.utils.common_utils import print_rank_0
 
 logger = logging.getLogger(__name__)
 
+# Canonicalize legacy short names that may break with newer huggingface_hub URI parsing.
+_HF_DATASET_NAME_ALIASES = {
+    "squad": "rajpurkar/squad",
+}
+
 
 class ProcessExampleOutput(TypedDict):
     """Legacy output structure for input/output-style processors.
@@ -217,6 +222,18 @@ def preprocess_and_split_data(
                 p.unlink()
 
 
+def _resolve_hf_dataset_name(dataset_name: str) -> str:
+    """Resolve legacy shorthand dataset IDs to canonical HF Hub IDs."""
+    resolved = _HF_DATASET_NAME_ALIASES.get(dataset_name, dataset_name)
+    if resolved != dataset_name:
+        logger.warning(
+            "Resolved legacy dataset id '%s' to canonical id '%s' for HF loading.",
+            dataset_name,
+            resolved,
+        )
+    return resolved
+
+
 class HFDatasetBuilder(FinetuningDatasetBuilder):
     """Builder class for Hugging Face datasets.
 
@@ -347,9 +364,10 @@ class HFDatasetBuilder(FinetuningDatasetBuilder):
     def _load_dataset(self) -> DatasetDict:
         """Load the dataset from Hugging Face or use the provided dataset."""
         if isinstance(self.dataset_name, str):
-            logger.info(f"Loading HF dataset from {self.dataset_name} to {self.dataset_root}")
+            resolved_dataset_name = _resolve_hf_dataset_name(self.dataset_name)
+            logger.info(f"Loading HF dataset from {resolved_dataset_name} to {self.dataset_root}")
             dataset = load_dataset(
-                self.dataset_name,
+                resolved_dataset_name,
                 name=self.dataset_subset,
                 cache_dir=str(self.dataset_root),
                 split=self.split,

--- a/src/megatron/bridge/recipes/utils/finetune_utils.py
+++ b/src/megatron/bridge/recipes/utils/finetune_utils.py
@@ -85,7 +85,7 @@ def default_squad_config(seq_length: int, packed_sequence: bool = True, pad_seq_
     dataloader_type = "batch"
 
     return HFDatasetConfig(
-        dataset_name="squad",
+        dataset_name="rajpurkar/squad",
         process_example_fn=process_squad_example,
         seq_length=seq_length,
         seed=5678,  # Different from pretrain seed

--- a/src/megatron/bridge/training/utils/flop_utils.py
+++ b/src/megatron/bridge/training/utils/flop_utils.py
@@ -209,7 +209,7 @@ def num_floating_point_operations(cfg: ConfigContainer, batch_size: int = 1):
             cfg.model.num_attention_heads if cfg.model.num_query_groups is None else cfg.model.num_query_groups
         )
 
-        is_squad = getattr(getattr(cfg, "dataset", None), "dataset_name", None) == "squad"
+        is_squad = getattr(getattr(cfg, "dataset", None), "dataset_name", None) in ("squad", "rajpurkar/squad")
         hf_model_id = getattr(cfg.model, "hf_model_id", None)
         is_llama3_70b = hf_model_id is not None and "Meta-Llama-3-70B" in hf_model_id
         packed_specs = getattr(getattr(cfg, "dataset", None), "packed_sequence_specs", None)

--- a/tests/functional_tests/test_groups/training/test_finetune_dora.py
+++ b/tests/functional_tests/test_groups/training/test_finetune_dora.py
@@ -197,7 +197,7 @@ class TestDoRAFinetune:
     def _create_squad_dataset_config(self, seq_length, seed=5678):
         """Create a SQuAD dataset configuration."""
         return HFDatasetConfig(
-            dataset_name="squad",
+            dataset_name="rajpurkar/squad",
             process_example_fn=process_squad_example,
             seq_length=seq_length,
             seed=seed,

--- a/tests/functional_tests/test_groups/training/test_finetune_lora.py
+++ b/tests/functional_tests/test_groups/training/test_finetune_lora.py
@@ -356,7 +356,7 @@ class TestLoRAFinetune:
             packed_sequence_specs = None
 
         config = HFDatasetConfig(
-            dataset_name="squad",
+            dataset_name="rajpurkar/squad",
             process_example_fn=process_squad_example,
             seq_length=seq_length,
             seed=seed,

--- a/tests/functional_tests/test_groups/training/test_seqpacking_cp_example.py
+++ b/tests/functional_tests/test_groups/training/test_seqpacking_cp_example.py
@@ -74,7 +74,7 @@ class TestPeftSftExample:
 
         # Use a small packed SQuAD dataset to exercise THD/context-parallel slicing
         cfg.dataset = HFDatasetConfig(
-            dataset_name="squad",
+            dataset_name="rajpurkar/squad",
             process_example_fn=process_squad_example,
             seq_length=256,
             dataloader_type="batch",

--- a/tests/unit_tests/recipes/utils/test_dataset_utils.py
+++ b/tests/unit_tests/recipes/utils/test_dataset_utils.py
@@ -335,7 +335,7 @@ class TestApplyDatasetOverride:
         config = _make_mock_config()
         result = apply_dataset_override(config, "llm-finetune", seq_length=512)
         assert isinstance(result.dataset, HFDatasetConfig)
-        assert result.dataset.dataset_name == "squad"
+        assert result.dataset.dataset_name == "rajpurkar/squad"
 
     def test_llm_finetune_extracts_dataset_name_from_cli(self):
         from megatron.bridge.data.builders.hf_dataset import HFDatasetConfig


### PR DESCRIPTION
## Summary

This fixes SQuAD dataset loading for environments using newer `huggingface-hub` versions.

The existing config used the legacy dataset id `squad`, which can fail with newer HF URI parsing because the Hub expects canonical `namespace/name` dataset repo IDs. For SQuAD, the canonical ID is `rajpurkar/squad`.