### PR TITLE
Add ModelOpt NVFP4 HF weight export support

### DIFF
--- a/docs/modelopt/quantization.md
+++ b/docs/modelopt/quantization.md
@@ -6,6 +6,7 @@ This guide covers model quantization in Megatron Bridge using NVIDIA ModelOpt, i
 
 - [Overview](#overview)
 - [Post-Training Quantization (PTQ)](#post-training-quantization-ptq)
+- [Programmatic ModelOpt Export](#programmatic-modelopt-export)
 - [Quantization-Aware Training (QAT)](#quantization-aware-training-qat)
 
 ## Overview
@@ -128,6 +129,52 @@ uv run python -m torch.distributed.run --nproc_per_node 2 examples/quantization/
 - `--export-dir` - Output directory for unified HuggingFace checkpoint
 - `--dtype` - Export data type
 
+### Programmatic ModelOpt Export
+
+Use `AutoBridge.export_hf_weights_modelopt()` when you need to stream ModelOpt deployment weights from an
+already-loaded Megatron model instead of writing a full checkpoint through the export script. This is useful for
+integrations that consume Hugging Face weight names directly, such as inference-engine refit paths.
+
+The API currently only supports `quant_mode="nvfp4"`. Quantized parameters are yielded as the original Hugging Face
+`*.weight` name plus the ModelOpt NVFP4 scale tensors:
+
+- `*.weight`
+- `*.weight_scale`
+- `*.weight_scale_2`
+
+Unquantized parameters are yielded under their regular Hugging Face names. Quantizer-internal tensors are skipped.
+
+```python
+from safetensors.torch import save_file
+
+state_dict = {}
+for name, weight in bridge.export_hf_weights_modelopt(
+    model,
+    quant_mode="nvfp4",
+    cpu=True,
+    show_progress=False,
+):
+    state_dict[name] = weight.contiguous()
+
+save_file(state_dict, "modelopt-nvfp4.safetensors")
+```
+
+For large models, consume the iterator directly in the downstream writer or refit path instead of materializing the
+full `state_dict`.
+
+```python
+for name, weight in bridge.export_hf_weights_modelopt(
+    model,
+    quant_mode="nvfp4",
+    ignore_patterns=["lm_head", "*self_attn.o_proj*"],
+    show_progress=False,
+):
+    refit_engine.replace_weight(name, weight)
+```
+
+`ignore_patterns` are matched against Hugging Face parameter names. The matcher handles the optional `model.` prefix
+and ModelOpt scale suffixes, so a pattern can target the logical parameter name without separately listing
+`*.weight_scale` and `*.weight_scale_2`.
 
 ### Supported Models For PTQ
 
@@ -210,4 +257,3 @@ uv run python -m torch.distributed.run --nproc_per_node 4 pretrain_quantized_lla
 | Model | Support |
 |-------|---------|
 | Meta-Llama-3-8B | ✅ |
-

--- a/src/megatron/bridge/models/conversion/auto_bridge.py
+++ b/src/megatron/bridge/models/conversion/auto_bridge.py
@@ -548,6 +548,91 @@ class AutoBridge(Generic[MegatronModelT]):
             merge_adapter_weights=merge_adapter_weights,
         )
 
+    def export_hf_weights_modelopt(
+        self,
+        model: MegatronModelT | list[MegatronModelT],
+        quant_mode: str = "nvfp4",
+        cpu: bool = False,
+        show_progress: bool = True,
+        conversion_tasks: Optional[List[WeightConversionTask | None]] = None,
+        ignore_patterns: Optional[List[str]] = None,
+        merge_adapter_weights: bool = True,
+    ) -> Iterable["HFWeightTuple"]:
+        """Export Megatron weights to HuggingFace ModelOpt deployment format.
+
+        Args:
+            model: Megatron model instance or list of instances.
+            quant_mode: ModelOpt quantization mode to export. Currently supports ``"nvfp4"``.
+            cpu: Whether to move exported tensors to CPU before yielding.
+            show_progress: Display progress bar during base Hugging Face weight export.
+            conversion_tasks: Pre-built conversion tasks. If not provided, tasks will be built
+                automatically from the models.
+            ignore_patterns: Hugging Face parameter name patterns that should remain unquantized.
+                Scale tensor suffixes and the optional ``model.`` prefix are ignored when matching.
+            merge_adapter_weights: Whether to gather and merge LoRA adapter weights into the base
+                tensors during export.
+
+        Yields:
+            HFWeightTuple: Named tuples containing Hugging Face parameter names and tensors. Quantized
+            weights yield the packed weight under the original ``*.weight`` name followed by the
+            corresponding ``*.weight_scale`` and ``*.weight_scale_2`` tensors.
+
+        Raises:
+            RuntimeError: If a matched quantized Megatron parameter uses a qformat unsupported by
+                ``quant_mode``.
+        """
+        from megatron.bridge.models.conversion.modelopt_utils import (
+            build_hf_to_megatron_name_map,
+            collect_modelopt_quant_metadata,
+            get_modelopt_quant_exporter,
+            matches_quant_ignore_pattern,
+            sync_modelopt_quant_metadata,
+        )
+
+        expected_qformat, export_weight = get_modelopt_quant_exporter(quant_mode)
+
+        if not isinstance(model, list):
+            model = [model]
+        if conversion_tasks is None:
+            conversion_tasks = self._model_bridge.build_conversion_tasks(self.hf_pretrained, model)
+
+        hf_to_megatron_name = build_hf_to_megatron_name_map(conversion_tasks)
+        metadata = collect_modelopt_quant_metadata(conversion_tasks)
+
+        pp_group = model_bridge._get_pp_group(model)
+        if pp_group is not None and dist.is_initialized() and dist.get_world_size(group=pp_group) > 1:
+            sync_modelopt_quant_metadata(metadata, pp_group)
+
+        hf_weights = self.export_hf_weights(
+            model,
+            cpu=cpu,
+            show_progress=show_progress,
+            conversion_tasks=conversion_tasks,
+            merge_adapter_weights=merge_adapter_weights,
+        )
+
+        ignore_patterns = ignore_patterns or []
+        for hf_name, tensor in hf_weights:
+            if "_quantizer." in hf_name:
+                continue
+
+            meta = None
+            if hf_name.endswith(".weight") and not matches_quant_ignore_pattern(hf_name, ignore_patterns):
+                megatron_name = hf_to_megatron_name.get(hf_name)
+                if megatron_name is not None:
+                    meta = metadata.get(megatron_name)
+
+            if meta is None:
+                tensor = tensor.detach()
+                yield HFWeightTuple(hf_name, tensor.cpu() if cpu else tensor)
+                continue
+
+            if meta.qformat != expected_qformat:
+                raise RuntimeError(f"Unsupported qformat for ModelOpt {quant_mode} export: {meta.qformat}")
+
+            for quant_name, quant_tensor in export_weight(hf_name, tensor, meta):
+                yield HFWeightTuple(quant_name, quant_tensor.cpu() if cpu else quant_tensor)
+
     def export_hf_weights_quant(
         self,
         model: list[MegatronModelT],

--- a/src/megatron/bridge/models/conversion/modelopt_utils.py
+++ b/src/megatron/bridge/models/conversion/modelopt_utils.py
@@ -1,0 +1,184 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from fnmatch import fnmatchcase
+from typing import TYPE_CHECKING, Iterator
+
+import torch
+
+
+if TYPE_CHECKING:
+    from megatron.bridge.models.conversion.model_bridge import WeightConversionTask
+
+_NVFP4_AMAX_DENOMINATOR = 6.0 * 448.0
+_QUANT_IGNORE_NAME_SUFFIXES = (
+    ".weight",
+    ".weight_scale",
+    ".weight_scale_2",
+)
+
+
+@dataclass(frozen=True)
+class QuantMeta:
+    """ModelOpt quantization metadata for one Megatron parameter."""
+
+    qformat: str
+    block_size: int
+    weight_amax: torch.Tensor | None
+
+
+def _iter_quant_ignore_name_candidates(name: str) -> Iterator[str]:
+    yield name
+    for suffix in _QUANT_IGNORE_NAME_SUFFIXES:
+        if name.endswith(suffix):
+            yield name[: -len(suffix)]
+            break
+
+    alternate = name.removeprefix("model.") if name.startswith("model.") else f"model.{name}"
+
+    yield alternate
+    for suffix in _QUANT_IGNORE_NAME_SUFFIXES:
+        if alternate.endswith(suffix):
+            yield alternate[: -len(suffix)]
+            break
+
+
+def matches_quant_ignore_pattern(name: str, patterns: list[str]) -> bool:
+    """Return whether a parameter name matches any ModelOpt ignore pattern."""
+    return any(
+        fnmatchcase(candidate, pattern)
+        for candidate in _iter_quant_ignore_name_candidates(name)
+        for pattern in patterns
+    )
+
+
+def _iter_hf_param_names(mapping) -> Iterator[str]:
+    hf_param = mapping.hf_param
+    if isinstance(hf_param, str):
+        yield hf_param
+    else:
+        yield from hf_param.values()
+
+
+def build_hf_to_megatron_name_map(conversion_tasks: list[WeightConversionTask | None]) -> dict[str, str]:
+    """Build a map from Hugging Face parameter names to Megatron parameter names."""
+    return {
+        hf_name: task.global_param_name
+        for task in conversion_tasks
+        if task is not None
+        for hf_name in _iter_hf_param_names(task.mapping)
+    }
+
+
+def collect_modelopt_quant_metadata(conversion_tasks: list[WeightConversionTask | None]) -> dict[str, QuantMeta]:
+    """Collect ModelOpt quantization metadata from conversion task modules."""
+    from modelopt.torch.export.quant_utils import (
+        QUANTIZATION_NONE,
+        get_quantization_format,
+        get_weight_block_size,
+    )
+
+    metadata: dict[str, QuantMeta] = {}
+    for task in conversion_tasks:
+        if task is None or task.megatron_module is None or task.param_weight is None:
+            continue
+
+        qformat = get_quantization_format(task.megatron_module)
+        if qformat == QUANTIZATION_NONE:
+            continue
+
+        block_size = get_weight_block_size(task.megatron_module)
+        weight_quantizer = getattr(task.megatron_module, "weight_quantizer", None)
+        if block_size == 0 or weight_quantizer is None:
+            continue
+        weight_amax = getattr(weight_quantizer, "_amax", None)
+
+        metadata[task.global_param_name] = QuantMeta(
+            qformat=qformat,
+            block_size=block_size,
+            weight_amax=weight_amax.clone().cpu() if weight_amax is not None else None,
+        )
+    return metadata
+
+
+def sync_modelopt_quant_metadata(metadata: dict[str, QuantMeta], group) -> None:
+    """Synchronize ModelOpt quantization metadata across a distributed group."""
+    world_size = torch.distributed.get_world_size(group=group)
+    gathered: list[dict[str, QuantMeta] | None] = [None] * world_size
+    torch.distributed.all_gather_object(gathered, metadata, group=group)
+
+    for rank_metadata in gathered:
+        if rank_metadata:
+            metadata.update(rank_metadata)
+
+
+def compute_nvfp4_weight_scale(
+    weight: torch.Tensor,
+    block_size: int,
+    weight_scale_2: torch.Tensor,
+) -> torch.Tensor:
+    """Compute the NVFP4 per-block weight scale tensor for ModelOpt export."""
+    from modelopt.torch.quantization.qtensor.nvfp4_tensor import NVFP4QTensor
+
+    weight_scale = NVFP4QTensor.get_weights_scaling_factor(
+        weight,
+        block_size,
+        weights_scaling_factor_2=weight_scale_2.to(weight.device),
+        keep_high_precision=True,
+    )[0]
+    weight_scale = weight_scale.to(torch.float32).abs()
+    weight_scale[weight_scale == 0] = 1.0
+    return weight_scale.to(torch.float8_e4m3fn)
+
+
+def quantize_nvfp4_weight(
+    name: str,
+    weight: torch.Tensor,
+    meta: QuantMeta,
+) -> Iterator[tuple[str, torch.Tensor]]:
+    """Yield NVFP4 quantized weight tensors and associated scale tensors."""
+    from modelopt.torch.export.quant_utils import to_quantized_weight
+
+    if not name.endswith(".weight"):
+        raise ValueError(f"Expected '.weight' suffix for NVFP4 export parameter name: {name}")
+    if meta.weight_amax is None:
+        raise RuntimeError(f"Missing ModelOpt weight amax for quantized parameter {name}")
+
+    weight_amax = meta.weight_amax.to(weight.device).float().abs()
+    weight_scale_2 = weight_amax / _NVFP4_AMAX_DENOMINATOR
+    weight_scale = compute_nvfp4_weight_scale(weight, meta.block_size, weight_scale_2)
+    quantized = to_quantized_weight(
+        weight,
+        weight_scale,
+        meta.qformat,
+        weight_scale_2,
+        meta.block_size,
+    )
+
+    weight_name = name[: -len(".weight")]
+    yield name, quantized.detach()
+    yield f"{weight_name}.weight_scale", weight_scale.detach()
+    yield f"{weight_name}.weight_scale_2", weight_scale_2.detach()
+
+
+def get_modelopt_quant_exporter(quant_mode: str):
+    """Return the ModelOpt quantization format and exporter for a quantization mode."""
+    from modelopt.torch.export.quant_utils import QUANTIZATION_NVFP4
+
+    if quant_mode.lower() != "nvfp4":
+        raise ValueError(f"Unsupported ModelOpt quant_mode: {quant_mode}")
+    return QUANTIZATION_NVFP4, quantize_nvfp4_weight

--- a/tests/unit_tests/models/test_modelopt_utils.py
+++ b/tests/unit_tests/models/test_modelopt_utils.py
@@ -354,6 +354,96 @@ def test_auto_bridge_modelopt_export_quantizes_matching_weights(monkeypatch):
     assert export_calls[0][1]["conversion_tasks"] is conversion_tasks
 
 
+def test_auto_bridge_modelopt_export_accepts_single_model_and_builds_tasks(monkeypatch):
+    model = object()
+    conversion_tasks = [
+        _task(
+            "decoder.embedding.word_embeddings.weight",
+            "model.embed_tokens.weight",
+        )
+    ]
+    build_calls = []
+    export_calls = []
+
+    class FakeModelBridge:
+        def build_conversion_tasks(self, hf_pretrained, model_arg):
+            build_calls.append((hf_pretrained, model_arg))
+            return conversion_tasks
+
+    class FakeBridge:
+        hf_pretrained = object()
+        _model_bridge = FakeModelBridge()
+
+        def export_hf_weights(self, model_arg, **kwargs):
+            export_calls.append((model_arg, kwargs))
+            yield "model.embed_tokens.weight", torch.tensor([4.0])
+
+    fake_bridge = FakeBridge()
+    monkeypatch.setattr(modelopt_utils, "collect_modelopt_quant_metadata", lambda _tasks: {})
+    monkeypatch.setattr(
+        "megatron.bridge.models.conversion.auto_bridge.model_bridge._get_pp_group",
+        lambda _model: None,
+    )
+
+    output = list(
+        AutoBridge.export_hf_weights_modelopt(
+            fake_bridge,
+            model,
+            show_progress=False,
+            merge_adapter_weights=False,
+        )
+    )
+
+    assert [(name, tensor.tolist()) for name, tensor in output] == [("model.embed_tokens.weight", [4.0])]
+    assert build_calls == [(fake_bridge.hf_pretrained, [model])]
+    assert export_calls[0][0] == [model]
+    assert export_calls[0][1]["show_progress"] is False
+    assert export_calls[0][1]["merge_adapter_weights"] is False
+    assert export_calls[0][1]["conversion_tasks"] is conversion_tasks
+
+
+def test_auto_bridge_modelopt_export_streams_base_weights_lazily(monkeypatch):
+    conversion_tasks = [
+        _task(
+            "decoder.layers.0.mlp.up_proj.weight",
+            "model.layers.0.mlp.up_proj.weight",
+        )
+    ]
+    events = []
+
+    class FakeBridge:
+        hf_pretrained = object()
+        _model_bridge = SimpleNamespace(build_conversion_tasks=lambda *_args, **_kwargs: conversion_tasks)
+
+        def export_hf_weights(self, _model, **_kwargs):
+            events.append("start")
+            yield "model.layers.0.mlp.up_proj.weight", torch.tensor([1.0])
+            events.append("after-first")
+            yield "model.layers.0.mlp.down_proj.weight", torch.tensor([2.0])
+
+    monkeypatch.setattr(modelopt_utils, "collect_modelopt_quant_metadata", lambda _tasks: {})
+    monkeypatch.setattr(
+        "megatron.bridge.models.conversion.auto_bridge.model_bridge._get_pp_group",
+        lambda _model: None,
+    )
+
+    weights = AutoBridge.export_hf_weights_modelopt(
+        FakeBridge(),
+        [object()],
+        conversion_tasks=conversion_tasks,
+    )
+
+    assert events == []
+    first = next(weights)
+    assert first.param_name == "model.layers.0.mlp.up_proj.weight"
+    torch.testing.assert_close(first.weight, torch.tensor([1.0]))
+    assert events == ["start"]
+    second = next(weights)
+    assert second.param_name == "model.layers.0.mlp.down_proj.weight"
+    torch.testing.assert_close(second.weight, torch.tensor([2.0]))
+    assert events == ["start", "after-first"]
+
+
 def test_auto_bridge_modelopt_export_leaves_ignored_weights_unquantized(monkeypatch):
     conversion_tasks = [
         _task(

--- a/tests/unit_tests/models/test_modelopt_utils.py
+++ b/tests/unit_tests/models/test_modelopt_utils.py
@@ -1,0 +1,454 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+
+quant_utils = pytest.importorskip("modelopt.torch.export.quant_utils")
+QUANTIZATION_NONE = quant_utils.QUANTIZATION_NONE
+QUANTIZATION_NVFP4 = quant_utils.QUANTIZATION_NVFP4
+
+from megatron.bridge.models.conversion import modelopt_utils
+from megatron.bridge.models.conversion.auto_bridge import AutoBridge
+from megatron.bridge.models.conversion.modelopt_utils import (
+    QuantMeta,
+    build_hf_to_megatron_name_map,
+    collect_modelopt_quant_metadata,
+    compute_nvfp4_weight_scale,
+    get_modelopt_quant_exporter,
+    matches_quant_ignore_pattern,
+    quantize_nvfp4_weight,
+    sync_modelopt_quant_metadata,
+)
+
+
+def _task(
+    global_param_name,
+    hf_param,
+    *,
+    megatron_module=None,
+    param_weight=None,
+):
+    return SimpleNamespace(
+        global_param_name=global_param_name,
+        mapping=SimpleNamespace(hf_param=hf_param),
+        megatron_module=megatron_module,
+        param_weight=param_weight,
+    )
+
+
+def test_matches_quant_ignore_pattern_handles_model_prefix_and_scale_suffixes():
+    ignore_patterns = [
+        "lm_head",
+        "*self_attn*",
+        "*mlp.gate",
+        "*router*",
+    ]
+
+    assert matches_quant_ignore_pattern(
+        "model.layers.0.self_attn.o_proj.weight",
+        ignore_patterns,
+    )
+    assert matches_quant_ignore_pattern(
+        "layers.0.self_attn.o_proj.weight",
+        ignore_patterns,
+    )
+    assert matches_quant_ignore_pattern("model.layers.0.mlp.gate.weight", ignore_patterns)
+    assert matches_quant_ignore_pattern("model.layers.0.router.weight", ignore_patterns)
+    assert matches_quant_ignore_pattern("lm_head.weight", ignore_patterns)
+    assert matches_quant_ignore_pattern("model.layers.0.mlp.gate.weight_scale", ignore_patterns)
+    assert not matches_quant_ignore_pattern(
+        "model.layers.0.mlp.experts.0.w1.weight",
+        ignore_patterns,
+    )
+
+
+def test_build_hf_to_megatron_name_map_handles_string_dict_and_empty_tasks():
+    tasks = [
+        None,
+        _task(
+            "decoder.layers.0.mlp.linear_fc1.weight",
+            "model.layers.0.mlp.gate_proj.weight",
+        ),
+        _task(
+            "decoder.layers.0.self_attention.linear_qkv.weight",
+            {
+                "q": "model.layers.0.self_attn.q_proj.weight",
+                "k": "model.layers.0.self_attn.k_proj.weight",
+            },
+        ),
+    ]
+
+    assert build_hf_to_megatron_name_map(tasks) == {
+        "model.layers.0.mlp.gate_proj.weight": "decoder.layers.0.mlp.linear_fc1.weight",
+        "model.layers.0.self_attn.q_proj.weight": "decoder.layers.0.self_attention.linear_qkv.weight",
+        "model.layers.0.self_attn.k_proj.weight": "decoder.layers.0.self_attention.linear_qkv.weight",
+    }
+
+
+def test_collect_modelopt_quant_metadata_skips_unquantized_tasks(monkeypatch):
+    quantizer_amax = torch.tensor([-2688.0])
+    quant_module = SimpleNamespace(weight_quantizer=SimpleNamespace(_amax=quantizer_amax))
+    unquantized_module = SimpleNamespace(weight_quantizer=SimpleNamespace(_amax=torch.tensor([1.0])))
+    blockless_module = SimpleNamespace(weight_quantizer=SimpleNamespace(_amax=torch.tensor([2.0])))
+
+    qformat_by_module = {
+        id(quant_module): QUANTIZATION_NVFP4,
+        id(unquantized_module): QUANTIZATION_NONE,
+        id(blockless_module): QUANTIZATION_NVFP4,
+    }
+    block_size_by_module = {
+        id(quant_module): 16,
+        id(unquantized_module): 16,
+        id(blockless_module): 0,
+    }
+
+    monkeypatch.setattr(
+        quant_utils,
+        "get_quantization_format",
+        lambda module: qformat_by_module[id(module)],
+    )
+    monkeypatch.setattr(
+        quant_utils,
+        "get_weight_block_size",
+        lambda module: block_size_by_module[id(module)],
+    )
+
+    metadata = collect_modelopt_quant_metadata(
+        [
+            None,
+            _task("missing.module.weight", "hf.missing.weight", megatron_module=None, param_weight=torch.empty(1)),
+            _task("missing.param.weight", "hf.missing_param.weight", megatron_module=quant_module),
+            _task(
+                "unquantized.weight",
+                "hf.unquantized.weight",
+                megatron_module=unquantized_module,
+                param_weight=torch.empty(1),
+            ),
+            _task(
+                "blockless.weight",
+                "hf.blockless.weight",
+                megatron_module=blockless_module,
+                param_weight=torch.empty(1),
+            ),
+            _task(
+                "quantized.weight",
+                "hf.quantized.weight",
+                megatron_module=quant_module,
+                param_weight=torch.empty(1),
+            ),
+        ]
+    )
+
+    assert list(metadata) == ["quantized.weight"]
+    assert metadata["quantized.weight"].qformat == QUANTIZATION_NVFP4
+    assert metadata["quantized.weight"].block_size == 16
+    torch.testing.assert_close(metadata["quantized.weight"].weight_amax, quantizer_amax)
+    assert metadata["quantized.weight"].weight_amax.data_ptr() != quantizer_amax.data_ptr()
+
+
+def test_sync_modelopt_quant_metadata_merges_gathered_rank_metadata(monkeypatch):
+    rank1_meta = QuantMeta(
+        qformat=QUANTIZATION_NVFP4,
+        block_size=16,
+        weight_amax=torch.tensor([2.0]),
+    )
+    metadata = {
+        "rank0.weight": QuantMeta(
+            qformat=QUANTIZATION_NVFP4,
+            block_size=16,
+            weight_amax=torch.tensor([1.0]),
+        )
+    }
+
+    monkeypatch.setattr(torch.distributed, "get_world_size", lambda group=None: 2)
+
+    def fake_all_gather_object(gathered, local_metadata, group=None):
+        gathered[0] = dict(local_metadata)
+        gathered[1] = {"rank1.weight": rank1_meta}
+
+    monkeypatch.setattr(torch.distributed, "all_gather_object", fake_all_gather_object)
+
+    sync_modelopt_quant_metadata(metadata, group=object())
+
+    assert set(metadata) == {"rank0.weight", "rank1.weight"}
+    assert metadata["rank1.weight"] is rank1_meta
+
+
+def test_quantize_nvfp4_weight_uses_abs_global_scale_and_emits_scale_names(monkeypatch):
+    captured = {}
+
+    def fake_to_quantized_weight(
+        weight,
+        weight_scale,
+        qformat,
+        weight_scale_2,
+        block_size,
+    ):
+        captured.update(
+            weight=weight,
+            weight_scale=weight_scale,
+            qformat=qformat,
+            weight_scale_2=weight_scale_2,
+            block_size=block_size,
+        )
+        return torch.zeros(weight.shape, dtype=torch.uint8, device=weight.device)
+
+    monkeypatch.setattr(quant_utils, "to_quantized_weight", fake_to_quantized_weight)
+
+    tensors = dict(
+        quantize_nvfp4_weight(
+            "model.layers.0.mlp.up_proj.weight",
+            torch.tensor([[-1.0, 0.25, 0.5, 2.0]], dtype=torch.float32),
+            QuantMeta(
+                qformat=QUANTIZATION_NVFP4,
+                block_size=4,
+                weight_amax=torch.tensor([-2688.0]),
+            ),
+        )
+    )
+
+    assert set(tensors) == {
+        "model.layers.0.mlp.up_proj.weight",
+        "model.layers.0.mlp.up_proj.weight_scale",
+        "model.layers.0.mlp.up_proj.weight_scale_2",
+    }
+    assert tensors["model.layers.0.mlp.up_proj.weight"].dtype == torch.uint8
+    assert tensors["model.layers.0.mlp.up_proj.weight_scale"].dtype == torch.float8_e4m3fn
+    torch.testing.assert_close(
+        tensors["model.layers.0.mlp.up_proj.weight_scale_2"],
+        torch.tensor([1.0]),
+    )
+    assert captured["qformat"] == QUANTIZATION_NVFP4
+    assert captured["block_size"] == 4
+    assert captured["weight_scale"].dtype == torch.float8_e4m3fn
+    assert (captured["weight_scale"].to(torch.float32) >= 0).all()
+    torch.testing.assert_close(captured["weight_scale_2"], torch.tensor([1.0]))
+
+
+def test_quantize_nvfp4_weight_requires_weight_amax():
+    with pytest.raises(RuntimeError, match="Missing ModelOpt weight amax"):
+        list(
+            quantize_nvfp4_weight(
+                "model.layers.0.mlp.up_proj.weight",
+                torch.ones(1, 4),
+                QuantMeta(
+                    qformat=QUANTIZATION_NVFP4,
+                    block_size=4,
+                    weight_amax=None,
+                ),
+            )
+        )
+
+
+def test_quantize_nvfp4_weight_requires_weight_suffix():
+    with pytest.raises(ValueError, match="Expected '.weight' suffix"):
+        list(
+            quantize_nvfp4_weight(
+                "model.layers.0.mlp.up_proj",
+                torch.ones(1, 4),
+                QuantMeta(
+                    qformat=QUANTIZATION_NVFP4,
+                    block_size=4,
+                    weight_amax=torch.tensor([1.0]),
+                ),
+            )
+        )
+
+
+def test_compute_nvfp4_weight_scale_returns_non_negative_fp8_values():
+    weight_scale = compute_nvfp4_weight_scale(
+        torch.tensor([[-1.0, 0.25, 0.5, 2.0]], dtype=torch.float32),
+        block_size=4,
+        weight_scale_2=torch.tensor(1.0 / 448.0),
+    )
+
+    assert weight_scale.dtype == torch.float8_e4m3fn
+    assert (weight_scale.to(torch.float32) >= 0).all()
+
+
+def test_get_modelopt_quant_exporter_is_case_insensitive_and_rejects_unknown_modes():
+    qformat, export_weight = get_modelopt_quant_exporter("NVFP4")
+
+    assert qformat == QUANTIZATION_NVFP4
+    assert export_weight is quantize_nvfp4_weight
+    with pytest.raises(ValueError, match="Unsupported ModelOpt quant_mode"):
+        get_modelopt_quant_exporter("w4a8")
+
+
+def test_auto_bridge_modelopt_export_quantizes_matching_weights(monkeypatch):
+    conversion_tasks = [
+        _task(
+            "decoder.layers.0.mlp.up_proj.weight",
+            "model.layers.0.mlp.up_proj.weight",
+        )
+    ]
+    export_calls = []
+
+    class FakeBridge:
+        hf_pretrained = object()
+        _model_bridge = SimpleNamespace(build_conversion_tasks=lambda *_args, **_kwargs: conversion_tasks)
+
+        def export_hf_weights(self, model, **kwargs):
+            export_calls.append((model, kwargs))
+            yield "model.layers.0.mlp.up_proj.weight", torch.tensor([1.0])
+            yield "model.layers.0.mlp.up_proj.bias", torch.tensor([2.0])
+            yield "model.layers.0.mlp.up_proj._quantizer._amax", torch.tensor([3.0])
+
+    def fake_export_weight(name, tensor, meta):
+        assert name == "model.layers.0.mlp.up_proj.weight"
+        assert meta.qformat == QUANTIZATION_NVFP4
+        yield name, tensor.to(torch.uint8)
+        yield "model.layers.0.mlp.up_proj.weight_scale", torch.ones(1)
+
+    monkeypatch.setattr(
+        modelopt_utils,
+        "collect_modelopt_quant_metadata",
+        lambda _tasks: {
+            "decoder.layers.0.mlp.up_proj.weight": QuantMeta(
+                qformat=QUANTIZATION_NVFP4,
+                block_size=16,
+                weight_amax=torch.tensor([1.0]),
+            )
+        },
+    )
+    monkeypatch.setattr(
+        modelopt_utils,
+        "get_modelopt_quant_exporter",
+        lambda quant_mode: (QUANTIZATION_NVFP4, fake_export_weight),
+    )
+    monkeypatch.setattr(
+        "megatron.bridge.models.conversion.auto_bridge.model_bridge._get_pp_group",
+        lambda _model: None,
+    )
+
+    output = list(
+        AutoBridge.export_hf_weights_modelopt(
+            FakeBridge(),
+            [object()],
+            cpu=True,
+            conversion_tasks=conversion_tasks,
+        )
+    )
+
+    assert [(name, tensor.tolist()) for name, tensor in output] == [
+        ("model.layers.0.mlp.up_proj.weight", [1]),
+        ("model.layers.0.mlp.up_proj.weight_scale", [1.0]),
+        ("model.layers.0.mlp.up_proj.bias", [2.0]),
+    ]
+    assert export_calls[0][1]["cpu"] is True
+    assert export_calls[0][1]["conversion_tasks"] is conversion_tasks
+
+
+def test_auto_bridge_modelopt_export_leaves_ignored_weights_unquantized(monkeypatch):
+    conversion_tasks = [
+        _task(
+            "decoder.layers.0.self_attention.linear_proj.weight",
+            "model.layers.0.self_attn.o_proj.weight",
+        )
+    ]
+
+    class FakeBridge:
+        hf_pretrained = object()
+        _model_bridge = SimpleNamespace(build_conversion_tasks=lambda *_args, **_kwargs: conversion_tasks)
+
+        def export_hf_weights(self, _model, **_kwargs):
+            yield "model.layers.0.self_attn.o_proj.weight", torch.tensor([1.0])
+
+    def fail_export_weight(*_args, **_kwargs):
+        raise AssertionError("ignored weights should not be quantized")
+
+    monkeypatch.setattr(
+        modelopt_utils,
+        "collect_modelopt_quant_metadata",
+        lambda _tasks: {
+            "decoder.layers.0.self_attention.linear_proj.weight": QuantMeta(
+                qformat=QUANTIZATION_NVFP4,
+                block_size=16,
+                weight_amax=torch.tensor([1.0]),
+            )
+        },
+    )
+    monkeypatch.setattr(
+        modelopt_utils,
+        "get_modelopt_quant_exporter",
+        lambda quant_mode: (QUANTIZATION_NVFP4, fail_export_weight),
+    )
+    monkeypatch.setattr(
+        "megatron.bridge.models.conversion.auto_bridge.model_bridge._get_pp_group",
+        lambda _model: None,
+    )
+
+    output = list(
+        AutoBridge.export_hf_weights_modelopt(
+            FakeBridge(),
+            [object()],
+            conversion_tasks=conversion_tasks,
+            ignore_patterns=["*self_attn*"],
+        )
+    )
+
+    assert [(name, tensor.tolist()) for name, tensor in output] == [("model.layers.0.self_attn.o_proj.weight", [1.0])]
+
+
+def test_auto_bridge_modelopt_export_rejects_mismatched_qformat(monkeypatch):
+    conversion_tasks = [
+        _task(
+            "decoder.layers.0.mlp.up_proj.weight",
+            "model.layers.0.mlp.up_proj.weight",
+        )
+    ]
+
+    class FakeBridge:
+        hf_pretrained = object()
+        _model_bridge = SimpleNamespace(build_conversion_tasks=lambda *_args, **_kwargs: conversion_tasks)
+
+        def export_hf_weights(self, _model, **_kwargs):
+            yield "model.layers.0.mlp.up_proj.weight", torch.tensor([1.0])
+
+    def fail_export_weight(*_args, **_kwargs):
+        raise AssertionError("mismatched qformat should fail before quantizing weights")
+
+    monkeypatch.setattr(
+        modelopt_utils,
+        "collect_modelopt_quant_metadata",
+        lambda _tasks: {
+            "decoder.layers.0.mlp.up_proj.weight": QuantMeta(
+                qformat="unexpected_qformat",
+                block_size=16,
+                weight_amax=torch.tensor([1.0]),
+            )
+        },
+    )
+    monkeypatch.setattr(
+        modelopt_utils,
+        "get_modelopt_quant_exporter",
+        lambda quant_mode: (QUANTIZATION_NVFP4, fail_export_weight),
+    )
+    monkeypatch.setattr(
+        "megatron.bridge.models.conversion.auto_bridge.model_bridge._get_pp_group",
+        lambda _model: None,
+    )
+
+    with pytest.raises(RuntimeError, match="Unsupported qformat"):
+        list(
+            AutoBridge.export_hf_weights_modelopt(
+                FakeBridge(),
+                [object()],
+                conversion_tasks=conversion_tasks,
+            )
+        )


### PR DESCRIPTION
# What does this PR do ?

Adds a Megatron-Bridge export path for converting ModelOpt QAT NVFP4 Megatron weights into Hugging Face deployment-format tensors.

Corresponding downstream changes: https://github.com/NVIDIA-NeMo/RL/pull/2592/changes/5fd89d74dfd0d31ba87a3a175af78b2cc2a4bd0f

# Changelog

- Add `AutoBridge.export_hf_weights_modelopt(...)` for ModelOpt quantized HF weight export.
- Add ModelOpt conversion helpers for collecting quantization metadata from conversion tasks.
- Add pipeline-parallel metadata synchronization for quantized parameters before export.
- Add NVFP4 export support that emits quantized weights plus `weight_scale` and `weight_scale_2`.
- Add ignore-pattern matching so selected HF parameters remain unquantized during export.
- Skip ModelOpt `_quantizer` auxiliary tensors from exported HF weights.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [X] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [X] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [X] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [X] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
