### PR TITLE
[model/training] fix: handle config edge cases

### DIFF
--- a/src/megatron/bridge/models/conversion/model_bridge.py
+++ b/src/megatron/bridge/models/conversion/model_bridge.py
@@ -497,6 +497,10 @@ class MegatronModelBridge(
             f"Unsupported activation function: {activation_func}. Supported: {list(ACTIVATION_FUNC_MAP.values())}"
         )
 
+    def _should_map_hf_config_field(self, hf_config: Any, hf_name: str, megatron_name: str, value: Any) -> bool:
+        """Return whether an HF config field should be mapped to provider kwargs."""
+        return True
+
     def hf_config_to_provider_kwargs(self, hf_config) -> dict:
         """Convert HF config to Megatron provider kwargs using CONFIG_MAPPING.
 
@@ -524,7 +528,11 @@ class MegatronModelBridge(
             else:
                 value = getattr(hf_config, hf_name, None)
                 has_value = hasattr(hf_config, hf_name)
-            if has_value and megatron_name not in provider_kwargs:
+            if (
+                has_value
+                and megatron_name not in provider_kwargs
+                and self._should_map_hf_config_field(hf_config, hf_name, megatron_name, value)
+            ):
                 provider_kwargs[megatron_name] = value
 
         # Extract rotary_base via compat function (handles both legacy rope_theta

--- a/src/megatron/bridge/models/gemma/gemma4_bridge.py
+++ b/src/megatron/bridge/models/gemma/gemma4_bridge.py
@@ -37,7 +37,7 @@ Key architecture-specific handling:
 """
 
 import re
-from typing import Mapping
+from typing import Any, Mapping
 
 import torch
 from megatron.core.models.gpt.gpt_model import GPTModel
@@ -109,6 +109,14 @@ class Gemma4Bridge(MegatronModelBridge):
         >>> bridge = AutoBridge.from_hf_pretrained("google/gemma-4-12B-A2B")
         >>> provider = bridge.to_megatron_provider()
     """
+
+    _CONDITIONAL_MOE_FIELDS = frozenset({"num_moe_experts", "moe_router_topk", "moe_ffn_hidden_size"})
+
+    def _should_map_hf_config_field(self, hf_config: Any, hf_name: str, megatron_name: str, value: Any) -> bool:
+        """Gate Gemma4 conditional MoE fields on the HF MoE block flag."""
+        if megatron_name in self._CONDITIONAL_MOE_FIELDS:
+            return getattr(hf_config, "enable_moe_block", True)
+        return super()._should_map_hf_config_field(hf_config, hf_name, megatron_name, value)
 
     def provider_bridge(self, hf_pretrained: PreTrainedCausalLM) -> Gemma4ModelProvider:
         """Convert HuggingFace config to Gemma4ModelProvider."""

--- a/src/megatron/bridge/models/qwen3_asr/hf_qwen3_asr/configuration_qwen3_asr.py
+++ b/src/megatron/bridge/models/qwen3_asr/hf_qwen3_asr/configuration_qwen3_asr.py
@@ -400,11 +400,15 @@ class Qwen3ASRConfig(PretrainedConfig):
         support_languages=None,
         **kwargs,
     ):
-        super().__init__(**kwargs)
         if thinker_config is None:
             thinker_config = {}
 
-        self.thinker_config = Qwen3ASRThinkerConfig(**thinker_config)
+        if isinstance(thinker_config, Qwen3ASRThinkerConfig):
+            self.thinker_config = thinker_config
+        else:
+            self.thinker_config = Qwen3ASRThinkerConfig(**thinker_config)
+
+        super().__init__(**kwargs)
         self.support_languages = support_languages
 
     def get_text_config(self, decoder=False) -> "PretrainedConfig":

--- a/tests/unit_tests/models/gemma/test_gemma4_bridge.py
+++ b/tests/unit_tests/models/gemma/test_gemma4_bridge.py
@@ -70,7 +70,7 @@ def mock_hf_dense_config():
     cfg.num_hidden_layers = 62
     cfg.hidden_size = 2816
     cfg.intermediate_size = 2112  # shared expert FFN
-    cfg.moe_intermediate_size = 704  # routed expert FFN
+    cfg.moe_intermediate_size = 1408  # distinct from provider default to catch config leaks
     cfg.num_attention_heads = 8
     cfg.num_key_value_heads = 4
     cfg.head_dim = 256
@@ -88,6 +88,8 @@ def mock_hf_dense_config():
     cfg.hidden_act = "gelu_pytorch_tanh"
     cfg.torch_dtype = "bfloat16"
     cfg.enable_moe_block = False
+    cfg.num_experts = 256
+    cfg.top_k_experts = 16
     cfg.layer_types = ["sliding_attention"] * 5 + ["full_attention"] + ["sliding_attention"] * 5 + ["full_attention"]
     cfg.final_logit_softcapping = 30.0
     return cfg
@@ -168,7 +170,7 @@ class TestGemma4BridgeProviderBridge:
         assert provider.moe_shared_expert_overlap is False
         assert provider.moe_shared_expert_gate is False
 
-    def tense_dense_config(self, bridge, mock_dense_pretrained):
+    def test_dense_config_keeps_default_moe_fields(self, bridge, mock_dense_pretrained):
         provider = bridge.provider_bridge(mock_dense_pretrained)
         assert provider.num_layers == 62
         assert provider.hidden_size == 2816
@@ -179,7 +181,9 @@ class TestGemma4BridgeProviderBridge:
         assert provider.seq_length == 131072
         assert provider.init_method_std == 0.02
         assert provider.layernorm_epsilon == 1e-6
-        assert provider.num_moe_experts is None
+        assert provider.num_moe_experts == 128
+        assert provider.moe_router_topk == 8
+        assert provider.moe_ffn_hidden_size == 704
 
     def test_window_size(self, bridge, mock_pretrained):
         provider = bridge.provider_bridge(mock_pretrained)

--- a/tests/unit_tests/models/qwen3_asr/test_qwen3_asr_config.py
+++ b/tests/unit_tests/models/qwen3_asr/test_qwen3_asr_config.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from megatron.bridge.models.qwen3_asr.hf_qwen3_asr.configuration_qwen3_asr import (
+    Qwen3ASRConfig,
+    Qwen3ASRThinkerConfig,
+)
+
+
+pytestmark = [pytest.mark.unit]
+
+
+def test_qwen3_asr_config_default_constructs_thinker_config():
+    config = Qwen3ASRConfig()
+
+    assert isinstance(config.thinker_config, Qwen3ASRThinkerConfig)
+    assert config.get_text_config() is config.thinker_config.text_config
+
+
+def test_qwen3_asr_config_from_dict_constructs_thinker_config():
+    config = Qwen3ASRConfig.from_dict(
+        {
+            "model_type": "qwen3_asr",
+            "thinker_config": {
+                "audio_config": {"encoder_layers": 2},
+                "text_config": {
+                    "hidden_size": 128,
+                    "intermediate_size": 256,
+                    "num_hidden_layers": 2,
+                    "num_attention_heads": 4,
+                    "num_key_value_heads": 2,
+                    "vocab_size": 512,
+                },
+            },
+        }
+    )
+
+    assert isinstance(config.thinker_config, Qwen3ASRThinkerConfig)
+    assert config.thinker_config.audio_config.encoder_layers == 2
+    assert config.thinker_config.text_config.hidden_size == 128


### PR DESCRIPTION
## Summary

Fixes two model-side config regressions and records the current-main status for the related TokenizerConfig issue:

- Keep Gemma4 dense-provider MoE defaults from being overwritten by base HF CONFIG_MAPPING when `enable_moe_block=False`, using a reusable mapping-gate hook.
- Construct Qwen3-ASR `thinker_config` before Transformers validation calls `get_text_config()` during config initialization.
- Confirm `TokenizerConfig` already has the MCore tokenizer padding fields on current `main` via PR #4075.

## NVBug Status

| NVBug | Current `main` status | PR status |
| --- | --- | --- |
| 6238889 | Not fixed. `Gemma4Bridge.provider_bridge()` still lets base `CONFIG_MAPPING` map HF MoE fields before the `enable_moe_block` guard. | Fixed in this PR by adding a base mapping-gate hook and using it to skip Gemma4 conditional MoE fields when HF disables the MoE block. Dense-config coverage was added. |
| 6238113 | Already fixed by PR #4075. `TokenizerConfig` now has `make_vocab_size_divisible_by`, `tensor_model_parallel_size`, and `rank`. | No additional code change needed here; included for batch status tracking. |
| 6234510 | Not fixed. `Qwen3ASRConfig.__init__()` calls `PretrainedConfig.__init__()` before `thinker_config` exists, and Transformers validation calls `get_text_config()` during that window. | Fixed in this PR by constructing `thinker_config` before the base initializer and adding config construction coverage. |

## Validation

- `ruff format src/megatron/bridge/models/conversion/model_bridge.py src/megatron/bridge/models/gemma/gemma4_bridge.py src/megatron/bridge/models/qwen3_asr/hf_qwen3_asr/configuration_qwen3_asr.py tests/unit_tests/models/gemma/test_gemma4_bridge.py tests/unit_tests/models/qwen3_asr/test_qwen3_asr_config.py`
- `ruff check --fix src/megatron/bridge/models/conversion/model_bridge.py src/megatron/bridge/models/gemma/gemma4_bridge.py src/megatron/bridge/models/qwen3_asr/hf_qwen3_asr/configuration_qwen3_asr.py tests/unit_tests/models/gemma/test_gemma4_bridge.py tests/unit_tests/models/qwen3_asr/test_qwen3_asr_config.py`
- `python -m py_compile src/megatron/bridge/models/conversion/model_bridge.py src/megatron/bridge/models/gemma/gemma4_bridge.py src/megatron/bridge/models/qwen3_asr/hf_qwen3_asr/configuration_qwen3_asr.py tests/unit_tests/models/gemma/test_gemma4_bridge.py tests/unit_tests/models/qwen3_asr/test_qwen3_asr_config.py`
- Direct Qwen3-ASR config repro: `Qwen3ASRConfig()`, `Qwen3ASRConfig.from_dict(...)`, and `AutoConfig.from_pretrained("Qwen/Qwen3-ASR-1.7B", trust_remote_code=True)` now expose `thinker_config`.
- `pre-commit run --all-files`

Attempted targeted pytest with `uv run python -m pytest ...`; local execution was blocked before collection by the platform wheel availability for `nvidia-resiliency-ext`. `uv run pre-commit run --all-files` hit the same local resolver blocker, so the installed pre-commit hooks were run directly. No full suite was run.

## Notes

- No changes under `3rdparty/Megatron-LM/`.
- Public text is sanitized.
