### PR TITLE
feat(distillation): add student_pre_conversion_hook to DistillationProvider

### DIFF
--- a/docs/modelopt/quantization.md
+++ b/docs/modelopt/quantization.md
@@ -2,6 +2,11 @@
 
 This guide covers model quantization in Megatron Bridge using NVIDIA ModelOpt, including post-training quantization (PTQ) and quantization-aware training (QAT).
 
+> **Note**: The scripts referenced in this guide are minimal, hard-coded reference examples. For more
+> comprehensive, production-quality quantization, export, and Quantization Aware Distillation (QAD)
+> scripts, see the NVIDIA Model Optimizer repository:
+> [examples/megatron_bridge/](https://github.com/NVIDIA/Model-Optimizer/tree/main/examples/megatron_bridge).
+
 ## Table of Contents
 
 - [Overview](#overview)

--- a/examples/quantization/README.md
+++ b/examples/quantization/README.md
@@ -2,6 +2,8 @@
 
 This directory contains example scripts for quantizing Megatron Bridge models using NVIDIA ModelOpt.
 
+> **Note**: These are minimal, hard-coded reference examples. For more comprehensive, production-quality post-training quantization (PTQ), export, and Quantization Aware Distillation (QAD) scripts, see the NVIDIA Model Optimizer repository: [examples/megatron_bridge/](https://github.com/NVIDIA/Model-Optimizer/tree/main/examples/megatron_bridge).
+
 ## Overview
 
 The quantization examples demonstrate how to:

--- a/src/megatron/bridge/models/distillation_provider.py
+++ b/src/megatron/bridge/models/distillation_provider.py
@@ -14,10 +14,11 @@
 
 import logging
 from dataclasses import dataclass, fields
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Callable, Optional
 
 import modelopt.torch.distill as mtd
 import modelopt.torch.distill.plugins.megatron as mtd_mcore
+from megatron.core.models.common.language_module.language_module import LanguageModule
 from megatron.core.models.gpt import GPTModel as MCoreGPTModel
 
 from megatron.bridge.models.gpt_provider import GPTModelProvider
@@ -41,6 +42,12 @@ class DistillationProvider(TransformerConfig):
 
     teacher: Optional[GPTModelProvider | MambaModelProvider] = None
     kd_config: Optional["ModelOptDistillConfig"] = None
+    # Optional callable run on the freshly built student model, *before* it is converted to a
+    # distillation model. It receives the student model and returns the (possibly replaced) student
+    # model. Useful to restore ModelOpt state from a checkpoint -- e.g. quantizers for Quantization
+    # Aware Distillation (QAD) -- which must happen before the distillation conversion since some
+    # ModelOpt restores are no-ops once a model is already converted.
+    student_pre_conversion_hook: Optional[Callable[[LanguageModule], LanguageModule]] = None
 
     def __init__(self, *args, **kwargs):
         raise NotImplementedError("Use `convert_to_distillation_provider()` to create an instance of this class.")
@@ -80,6 +87,10 @@ class DistillationProvider(TransformerConfig):
             raise ValueError("ModelOpt KD currently does not support virtual-pipeline parallel.")
 
         student_model = self._super_class.provide(self, pre_process, post_process, vp_stage)
+        # Optionally transform the student before the distillation conversion (e.g. restore ModelOpt
+        # quantizers from a checkpoint for QAD). Must run before mtd.convert below.
+        if self.student_pre_conversion_hook is not None:
+            student_model = self.student_pre_conversion_hook(student_model)
         # Hack to get teacher's pre-wrap hooks called to potentially load HF weights
         teacher_model = self.teacher.provide_distributed_model(wrap_with_ddp=False, mixed_precision_wrapper=None)[0]
 
@@ -128,8 +139,18 @@ def convert_to_distillation_provider(
     student_provider: GPTModelProvider | MambaModelProvider,
     teacher_provider: GPTModelProvider | MambaModelProvider,
     kd_config: Optional["ModelOptDistillConfig"] = None,
+    student_pre_conversion_hook: Optional[Callable[[LanguageModule], LanguageModule]] = None,
 ) -> "DistillationProvider":
-    """Convert a given model provider to a DistillationProvider."""
+    """Convert a given model provider to a DistillationProvider.
+
+    Args:
+        student_provider: The student model provider.
+        teacher_provider: The teacher model provider.
+        kd_config: The knowledge-distillation config.
+        student_pre_conversion_hook: Optional callable run on the freshly built student model before
+            the distillation conversion (see ``DistillationProvider.student_pre_conversion_hook``).
+            Useful to restore ModelOpt state -- e.g. quantizers for Quantization Aware Distillation.
+    """
 
     assert isinstance(student_provider, (GPTModelProvider, MambaModelProvider)), (
         "Student provider must be a subclass of GPTModelProvider or MambaModelProvider."
@@ -143,6 +164,7 @@ def convert_to_distillation_provider(
 
     student_provider.teacher = teacher_provider
     student_provider.kd_config = kd_config
+    student_provider.student_pre_conversion_hook = student_pre_conversion_hook
     student_provider.__post_init__()
 
     return student_provider


### PR DESCRIPTION
# What does this PR do ?

Add an optional `student_pre_conversion_hook` to `DistillationProvider` so callers can transform the freshly built student model **before** it is converted to a distillation model.

This is needed for Quantization Aware Distillation (QAD): the ModelOpt quantize mode must be restored on the *plain* student before `mtd.convert`, since `restore_sharded_modelopt_state` is a no-op once a model is already converted. `provide()` currently builds the student and converts it atomically with no seam in between, so there is no supported way to load a quantized Megatron checkpoint as the distillation student.

# Changelog

- `DistillationProvider`: add optional `student_pre_conversion_hook: Callable[[LanguageModule], LanguageModule]` field, invoked in `provide()` after the student is built and before `mtd.convert`.
- `convert_to_distillation_provider`: add a matching `student_pre_conversion_hook=` argument.
- `docs/modelopt/quantization.md`: note that comprehensive, production-quality quantization / export / QAD scripts live in the NVIDIA Model Optimizer `examples/megatron_bridge/` repo.

# GitHub Actions CI

External-contributor CI to be approved/triggered by an NVIDIA developer.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests? — additive, backward-compatible hook (defaults to `None`, no behavior change when unset). Validated end-to-end through the downstream ModelOpt QAD example (quantize → QAD → export, with the quantize mode preserved in the distilled checkpoint). Happy to add a focused unit test if preferred.
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? — No.

# Additional Information

The consumer is the NVIDIA Model Optimizer QAD example (`examples/megatron_bridge/distill.py`), which currently works around the missing seam by patching `DistillationProvider.provide` at the class level; this hook lets that workaround be removed.
