### PR TITLE
fix(training): guard optional nvrx_straggler import against non-import errors

### DIFF
--- a/src/megatron/bridge/training/nvrx_straggler.py
+++ b/src/megatron/bridge/training/nvrx_straggler.py
@@ -22,19 +22,30 @@ from megatron.bridge.training.config import NVRxStragglerDetectionConfig
 from megatron.bridge.utils.import_utils import MISSING_NVRX_MSG
 
 
+# NOTE: catch broadly here, not just (ImportError, ModuleNotFoundError).
+# ``nvidia-resiliency-ext`` is an optional dependency, and importing
+# ``nvidia_resiliency_ext.attribution`` eagerly pulls in a langchain-based log
+# analyzer. Its transitive dependencies can fail to import with errors *other*
+# than ImportError -- e.g. a ``pydantic.ValidationError`` raised at module load
+# when an incompatible pydantic version is resolved. Because this module is
+# imported by ``megatron.bridge.training.state`` (a core training import), a
+# narrow except would let such a failure crash unrelated training/conversion
+# code paths. Degrading to ``HAVE_NVRX = False`` keeps the optional feature
+# disabled without taking down the rest of the library.
 try:
     # Try the newer version first (nvidia-resiliency-ext >= 0.4)
     import nvidia_resiliency_ext.attribution.straggler as straggler
 
     HAVE_NVRX = True
-except (ImportError, ModuleNotFoundError):
+except Exception:
     try:
         # Fall back to the older version (nvidia-resiliency-ext < 0.4)
         import nvidia_resiliency_ext.straggler as straggler
 
         HAVE_NVRX = True
-    except (ImportError, ModuleNotFoundError):
+    except Exception as e:
         HAVE_NVRX = False
+        logging.getLogger(__name__).debug("nvidia-resiliency-ext unavailable, straggler detection disabled: %s", e)
 
 
 class NVRxStragglerDetectionManager:


### PR DESCRIPTION
## What does this PR do?

Hardens the optional `nvidia-resiliency-ext` import in
`src/megatron/bridge/training/nvrx_straggler.py` so that an **import-time failure
of that optional dependency cannot crash core training/conversion code paths**.

The existing guard only caught `(ImportError, ModuleNotFoundError)`. But importing
`nvidia_resiliency_ext.attribution.straggler` eagerly pulls in a langchain-based
log analyzer (`attribution.log_analyzer → langchain_nvidia_ai_endpoints →
langchain_core`), whose transitive dependencies can fail to import with errors
**other** than `ImportError` — most recently a `pydantic.ValidationError` raised
at module load when pydantic `2.14` is resolved against an incompatible
`langchain_core`. Because `megatron.bridge.training.state` imports this module,
that exception propagated all the way up and broke unrelated tests/code.

This PR broadens both `except` clauses to degrade gracefully (`HAVE_NVRX = False`,
logged at debug level) on any import-time failure of this optional dependency.

## Motivation — observed CI failure

In the MCore→MBridge downstream merge-queue tests, `L1_Launch_models_qwen2` and
`L1_Launch_models_nemotron` both failed with the **identical** error, unrelated to
those models:

```
langchain_core/runnables/passthrough.py:349: in <module>
    _graph_passthrough: RunnablePassthrough = RunnablePassthrough()
E   pydantic_core._pydantic_core.ValidationError: 1 validation error for RunnablePassthrough
E   name  Field required ...  https://errors.pydantic.dev/2.14/v/missing
```

Import chain (collection of a test helper, never reaching model code):

```
tests/functional_tests/utils.py
  → megatron.bridge.training.utils.checkpoint_utils
    → megatron.bridge.training.state
      → megatron.bridge.training.nvrx_straggler   (unguarded against ValidationError)
        → nvidia_resiliency_ext.attribution.straggler
          → ... → langchain_core → RunnablePassthrough()  → pydantic 2.14 ValidationError
```

Failed run: https://github.com/NVIDIA-NeMo/Megatron-Bridge/actions/runs/26840064744
(jobs `L1_Launch_models_qwen2`, `L1_Launch_models_nemotron`).

## Relationship to the root cause

The pydantic `2.14` resolution was introduced upstream by
[NVIDIA/Megatron-LM#3026](https://github.com/NVIDIA/Megatron-LM/pull/3026), which
added an **uncapped** `pydantic` to the `transformer-engine` `uv`
dependency-metadata block. A companion MCore PR caps that dependency
(`pydantic<2.14`) to fix the resolution.

This Bridge PR is **defense-in-depth** and is valuable independent of that fix:
a broken *optional* dependency should never be able to take down core
`megatron.bridge.training` imports. The two changes are complementary — the MCore
cap fixes the immediate version skew; this guard prevents the entire class of
"optional-dep transitive import raises a non-`ImportError`" breakage.

## Changelog

- `nvrx_straggler.py`: broaden the optional-import guard from
  `(ImportError, ModuleNotFoundError)` to `Exception`, with a debug log on the
  disabled path, and an explanatory comment.

## Testing

- No behavior change when `nvidia-resiliency-ext` imports cleanly (`HAVE_NVRX = True`).
- When the optional import raises **any** error at load, `HAVE_NVRX` is now `False`
  and importing `megatron.bridge.training.state` succeeds (previously raised).

## Before your PR is "Ready for review"

- [x] Read and followed the Contributor guidelines
- [x] Necessary tests (existing import-path coverage; behavior is import-time graceful degradation)
- [ ] Docs (n/a)
