### PR TITLE
perf(llama): enable TE CUDA Graphs (mlp,attn) for 70B GB200 NVFP4 V2

### DIFF
--- a/scripts/performance/configs/llama/llama3_workload_base_configs.py
+++ b/scripts/performance/configs/llama/llama3_workload_base_configs.py
@@ -259,8 +259,8 @@ LLAMA3_70B_PRETRAIN_CONFIG_GB200_NVFP4_V2 = replace(
     pipeline_model_parallel_size=4,
     virtual_pipeline_model_parallel_size=5,
     context_parallel_size=1,
-    cuda_graph_impl="none",
-    cuda_graph_scope="full_iteration",
+    cuda_graph_impl="transformer_engine",
+    cuda_graph_scope=["mlp", "attn"],
 )
 
 


### PR DESCRIPTION
Backport of #4080 to `r0.5.0`.

Enables TransformerEngine CUDA Graphs scoped to `["mlp", "attn"]` on `LLAMA3_70B_PRETRAIN_CONFIG_GB200_NVFP4_V2` — empirically ~+7% TFLOPS over the previous `cuda_graph_impl="none"` default.

Cherry-picked cleanly from the `main` PR.