### PR TITLE
ci: bump _release_library.yml to v1.4.3

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -80,7 +80,7 @@ jobs:
     secrets: inherit  # pragma: allowlist secret
 
   release:
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@v1.4.0
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@v1.4.3
     needs: [pre-flight]
     if: |
       !cancelled() && !failure()


### PR DESCRIPTION
<details><summary>Claude summary</summary>

### What changed

- Bump the `_release_library.yml` reusable-workflow pin from `v1.4.0` to `v1.4.3` (latest FW-CI-templates release).

### Details

- `.github/workflows/release.yaml`: `_release_library.yml@v1.4.0` → `@v1.4.3`.
- The nested `_build_test_publish_wheel.yml` is called via a local `./` path, so it inherits whichever tag this entry point pins.

</details>
