### PR TITLE
build: bump pillow to 12.2.0

### DIFF
--- a/docker/common/fw_pyproject.toml
+++ b/docker/common/fw_pyproject.toml
@@ -68,7 +68,7 @@ override-dependencies = [
     "urllib3>=2.0.7",
     "sh==2.2.2",
     "jupyter-core==5.8.1",
-    "pillow==12.1.1",
+    "pillow==12.2.0",
     "protobuf==6.33.5",
     "cuda-python>=13.0.0",
     "multi-storage-client!=0.36.0",


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## Background / motivation
- `pillow` is pinned to `12.1.1` in the NeMo-FW container dependency overrides; `12.2.0` is the current latest release. Bump to pick up upstream fixes.

## What changed
- `docker/common/fw_pyproject.toml`: `pillow==12.1.1` → `pillow==12.2.0` (the `[tool.uv] override-dependencies` pin).

## Details
- Single-line pin bump; no transitive changes.
- No lockfile regeneration — `fw_pyproject.toml` is a standalone container pyproject with no tracked `uv.lock`.
- `docker/Dockerfile.fw_final` keeps its `pillow>=12.1.1` floor inside the "Address CVE" pip block. That floor is a CVE-minimum (semantically distinct from the pin) and is already satisfied by 12.2.0, so it is left unchanged. Say the word if you'd also like it raised to `>=12.2.0`.

## Tested
- Not run locally — the NeMo-FW container build is the validation path; relies on CI.

</details>
