### PR TITLE
feat(perf): add --qos flag to plumb #SBATCH --qos through the slurm executor

### DIFF
--- a/scripts/performance/argument_parser.py
+++ b/scripts/performance/argument_parser.py
@@ -411,6 +411,15 @@ def parse_cli_args():
         help="Slurm partition to use for experiment",
     )
     slurm_args.add_argument(
+        "--qos",
+        type=str,
+        default=None,
+        help="Slurm QOS to request via #SBATCH --qos. Required on clusters where the "
+        "user's association has no DefaultQOS and the alphabetically-first QOS is "
+        "incompatible with the requested resources (e.g. a cpu-only QOS rejecting a "
+        "GPU job).",
+    )
+    slurm_args.add_argument(
         "-t",
         "--time_limit",
         type=str,

--- a/scripts/performance/setup_experiment.py
+++ b/scripts/performance/setup_experiment.py
@@ -255,6 +255,7 @@ def main(
     nemo_home: str,
     account: str,
     partition: str,
+    qos: Optional[str],
     log_dir: str,
     gpus_per_node: int,
     time_limit: str,
@@ -392,6 +393,9 @@ def main(
 
     if nccl_ub:
         custom_env_vars.update({"NCCL_NVLS_ENABLE": "1", "NCCL_CTA_POLICY": "1"})
+
+    if qos:
+        additional_slurm_params = {**(additional_slurm_params or {}), "qos": qos}
 
     if kubeflow_namespace:
         executor = kubeflow_executor(
@@ -759,6 +763,7 @@ if __name__ == "__main__":
         nemo_home=args.nemo_home,
         account=args.account,
         partition=args.partition,
+        qos=args.qos,
         log_dir=args.log_dir,
         gpus_per_node=gpus_per_node,
         time_limit=args.time_limit,


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## Background / motivation

- Onboarding nemo-ci's `nsc_svg_slurm_1` cluster surfaced a `QOSMinGRES` sbatch failure: the cluster admin team has not assigned a `DefaultQOS` to our service-account's association, so slurm picks the alphabetically-first QOS (`cpu-datamover`) which sets `MaxTRES=gres/gpu=0` and rejects GPU jobs.
- The slurm executor already supports arbitrary `additional_slurm_params`, but `qos` is a common-enough lever that having it as a discoverable flag is worth the small surface-area cost.

## What changed

- `argument_parser.py`: add `--qos` flag in the `Slurm arguments` group.
- `setup_experiment.py`: thread `args.qos` into `main()` and merge it into `additional_slurm_params` as `{"qos": ...}` so the `SlurmExecutor` emits `#SBATCH --qos=<value>`.

## Details

- `scripts/performance/argument_parser.py` — new optional `--qos` arg, defaults to `None`.
- `scripts/performance/setup_experiment.py` — `main()` accepts `qos: Optional[str]`; before the executor is constructed, `additional_slurm_params = {**(additional_slurm_params or {}), "qos": qos}` when set. No behavior change when unset.
- No change to `executors.py` — the existing `additional_slurm_params` plumbing already forwards the dict to `run.SlurmExecutor(additional_parameters=...)`.

## Tested

- `python -c "from argument_parser import parse_cli_args; p = parse_cli_args(); p.parse_args(['--qos', 'normal', ...])"` resolves `args.qos == 'normal'`.
- Will be exercised end-to-end by the next nemo-ci pipeline on `nsc_svg_slurm_1` with `QOS=normal` env exported from the cluster ENV_SCRIPT — see the consumer change in nemo-ci `ko3n1g/add-nsc-svg-slurm-1-cluster`.

</details>
