### PR TITLE
[perf] Disable PCT binding by default

### DIFF
--- a/scripts/performance/argument_parser.py
+++ b/scripts/performance/argument_parser.py
@@ -494,9 +494,9 @@ def parse_cli_args():
     slurm_args.add_argument(
         "--enable_pct_binding",
         type=bool_arg,
-        help="Enable PCT binding. Enabled by default.",
+        help="Enable PCT binding. Disabled by default.",
         required=False,
-        default=True,
+        default=False,
     )
 
     # DGXCloud

--- a/scripts/performance/setup_experiment.py
+++ b/scripts/performance/setup_experiment.py
@@ -305,22 +305,6 @@ def main(
             "to the cache directory. NullTokenizer to be used soon."
         )
 
-    # Disable PCT binding for certain models on specific hardware/precision combos
-    if (
-        model_family_name == "nemotronh"
-        and model_recipe_name == "nemotron_3_super"
-        and compute_dtype == "bf16"
-        and gpu == "b300"
-    ) or (
-        model_family_name == "deepseek"
-        and model_recipe_name == "deepseek_v3"
-        and gpu == "b300"
-        and config_variant != "large_scale"
-    ) or (
-        model_family_name == "llama" and task == "pretrain" and gpu == "b300"
-    ):
-        enable_pct_binding = False
-
     if wandb_key is not None:
         assert wandb_project_name is not None and wandb_experiment_name is not None, (
             "both wandb_project_name and wandb_experiment_name are required for logging with WandB"

--- a/scripts/performance/utils/executors.py
+++ b/scripts/performance/utils/executors.py
@@ -69,7 +69,7 @@ def slurm_executor(
     additional_slurm_params: Dict[str, Any] = None,
     gres: Optional[str] = None,
     packager: str = "git",
-    enable_pct_binding: bool = True,
+    enable_pct_binding: bool = False,
 ) -> run.SlurmExecutor:
     """
     Slurm cluster definition with appropriate cluster params and NeMo container params needed for pre-training


### PR DESCRIPTION
Flip the default for PCT (Priority Core Turbo) fixed-core CPU binding to disabled, in both the --enable_pct_binding CLI arg and the slurm executor signature.

Binding is now opt-in: pass --enable_pct_binding True on systems where Intel Granite Rapids PCT is configured. Mbridge's existing per-workload logic in setup_experiment.py is unchanged, so it still auto-disables binding for the b300 model/precision combos where it is known to hurt. This avoids applying core pinning on systems where PCT is not set up, without requiring recipes to disable it manually.

