### PR TITLE
fix(model): normalize Step35 MTP layer types

### DIFF
--- a/src/megatron/bridge/models/stepfun/configuration_step35.py
+++ b/src/megatron/bridge/models/stepfun/configuration_step35.py
@@ -17,6 +17,22 @@ from typing import Any, Optional
 from transformers.configuration_utils import PretrainedConfig
 
 
+def _split_mtp_layer_types(
+    layer_types: list[str] | None,
+    num_hidden_layers: int,
+    num_nextn_predict_layers: int,
+) -> tuple[list[str] | None, list[str] | None]:
+    """Split published main-decoder + MTP layer types before parent validation."""
+    if layer_types is None:
+        return None, None
+
+    total_layer_count = num_hidden_layers + num_nextn_predict_layers
+    if num_nextn_predict_layers > 0 and len(layer_types) == total_layer_count:
+        return layer_types[:num_hidden_layers], layer_types[num_hidden_layers:]
+
+    return layer_types, None
+
+
 class Step35Config(PretrainedConfig):
     """Configuration for the Step-3.5-Flash (``Step35``) Mixture-of-Experts model.
 
@@ -52,6 +68,9 @@ class Step35Config(PretrainedConfig):
             weights so they sum to 1.
         layer_types: Optional per-layer type override (e.g. attention
             variant); ``None`` uses the default for every layer.
+        mtp_layer_types: Optional per-MTP-layer type override split from
+            ``layer_types`` when the published config includes both main
+            decoder and MTP entries.
         attention_other_setting: Sliding-attention shape override from the HF
             config.
         use_head_wise_attn_gate: Whether Step-3.5 uses per-head ``g_proj``
@@ -96,6 +115,7 @@ class Step35Config(PretrainedConfig):
         head_dim: int = 128,
         norm_expert_weight: bool = True,
         layer_types: list[str] | None = None,
+        mtp_layer_types: list[str] | None = None,
         attention_other_setting: dict[str, Any] | None = None,
         use_head_wise_attn_gate: bool = True,
         sliding_window: Optional[int] = None,
@@ -146,6 +166,14 @@ class Step35Config(PretrainedConfig):
         ),
         **kwargs,
     ) -> None:
+        layer_types, inferred_mtp_layer_types = _split_mtp_layer_types(
+            layer_types,
+            num_hidden_layers,
+            num_nextn_predict_layers,
+        )
+        if mtp_layer_types is None:
+            mtp_layer_types = inferred_mtp_layer_types
+
         self.hidden_size = hidden_size
         self.intermediate_size = intermediate_size
         self.num_attention_heads = num_attention_heads
@@ -166,6 +194,7 @@ class Step35Config(PretrainedConfig):
         self.norm_expert_weight = norm_expert_weight
         self.moe_layers_enum = moe_layers_enum
         self.layer_types = layer_types
+        self.mtp_layer_types = mtp_layer_types
         self.attention_other_setting = attention_other_setting
         self.use_head_wise_attn_gate = use_head_wise_attn_gate
         self.sliding_window = sliding_window

--- a/src/megatron/bridge/models/stepfun/step35_bridge.py
+++ b/src/megatron/bridge/models/stepfun/step35_bridge.py
@@ -235,6 +235,9 @@ class Step35Bridge(MegatronModelBridge):
         provider = super().provider_bridge(hf_pretrained)
 
         hf_config = hf_pretrained.config
+        mtp_layer_types = getattr(hf_config, "mtp_layer_types", None)
+        if provider.layer_types is not None and mtp_layer_types:
+            provider.layer_types = list(provider.layer_types) + list(mtp_layer_types)
 
         # ── Per-layer partial RoPE ────────────────────────────────────────
         partial_rotary_factors = getattr(hf_config, "partial_rotary_factors", None)

--- a/src/megatron/bridge/models/stepfun/step35_provider.py
+++ b/src/megatron/bridge/models/stepfun/step35_provider.py
@@ -185,9 +185,9 @@ class Step35ModelProvider(GPTModelProvider):
     Adds Step3.5-specific fields on top of ``GPTModelProvider``:
 
     * ``layer_types``: 0-indexed list of attention types (e.g.
-      ``"full_attention"`` / ``"sliding_attention"``), one entry per main
-      decoder layer. Read by ``Step35DecoderLayer`` to decide whether the
-      current layer is a sliding-attention layer.
+      ``"full_attention"`` / ``"sliding_attention"``). The provider may carry
+      main decoder entries plus MTP entries because ``Step35DecoderLayer``
+      indexes MTP layers after ``config.num_layers``.
     * ``attention_other_setting``: HF dict that enables and describes the
       sliding-attention override.
     * ``sliding_attention_setting``: normalized Megatron-facing shape overrides

--- a/tests/unit_tests/models/mimo_v2_flash/test_mimo_v2_flash_bridge.py
+++ b/tests/unit_tests/models/mimo_v2_flash/test_mimo_v2_flash_bridge.py
@@ -19,6 +19,7 @@ from unittest.mock import Mock, patch
 import pytest
 import torch
 
+from megatron.bridge.models.conversion.auto_bridge import AutoBridge
 from megatron.bridge.models.hf_pretrained.causal_lm import PreTrainedCausalLM
 from megatron.bridge.models.mimo_v2_flash.mimo_v2_flash_bridge import (
     MiMoV2FlashBridge,
@@ -102,6 +103,15 @@ def _make_mock_pretrained(with_state=False):
     if not with_state:
         del pretrained.state
     return pretrained
+
+
+class TestMiMoV2FlashAutoBridgeRegistration:
+    def test_live_hf_architecture_name_is_registered(self):
+        config = _make_mock_config()
+
+        AutoBridge._validate_config(config, "XiaomiMiMo/MiMo-V2-Flash")
+
+        assert "MiMoV2FlashForCausalLM" in AutoBridge.list_supported_models()
 
 
 class TestMiMoV2FlashBridgeProviderBridge:

--- a/tests/unit_tests/models/stepfun/test_step35_bridge.py
+++ b/tests/unit_tests/models/stepfun/test_step35_bridge.py
@@ -279,6 +279,24 @@ class TestStep35BridgeProviderBridge:
             "kv_channels": 128,
         }
 
+    def test_provider_restores_mtp_layer_types_after_config_validation_split(self):
+        main_layer_types = [
+            "full_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "sliding_attention",
+        ]
+        mtp_layer_types = ["full_attention", "sliding_attention"]
+
+        _, p = self._run(
+            hf_overrides={
+                "layer_types": main_layer_types,
+                "mtp_layer_types": mtp_layer_types,
+            },
+        )
+
+        assert p.layer_types == main_layer_types + mtp_layer_types
+
     def test_rotary_percents_copied_from_partial_rotary_factors(self):
         """``rotary_percents`` is the Megatron-facing rename of HF's
         ``partial_rotary_factors`` and is indexed per layer by

--- a/tests/unit_tests/models/stepfun/test_step35_provider.py
+++ b/tests/unit_tests/models/stepfun/test_step35_provider.py
@@ -62,6 +62,24 @@ class TestStep35Config:
         assert cfg.moe_num_experts == 8
         assert cfg.head_dim == 64
 
+    def test_layer_types_with_mtp_entries_are_normalized_to_decoder_layers(self):
+        layer_types = [
+            "full_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "sliding_attention",
+        ] * 12
+
+        cfg = Step35Config(
+            num_hidden_layers=45,
+            num_nextn_predict_layers=3,
+            layer_types=layer_types,
+        )
+
+        assert len(layer_types) == cfg.num_hidden_layers + cfg.num_nextn_predict_layers
+        assert cfg.layer_types == layer_types[: cfg.num_hidden_layers]
+        assert cfg.mtp_layer_types == layer_types[cfg.num_hidden_layers :]
+
 
 # ---------------------------------------------------------------------------
 # Step35ModelProvider


### PR DESCRIPTION
## Summary
- split Step-3.5-Flash `layer_types` into main decoder entries plus retained MTP entries before Transformers parent validation
- reattach retained MTP layer types when building the Step35 provider so MTP layer indexing still sees the full effective layer-type pattern
- add regression coverage for Step35 config/provider behavior and MiMo-V2-Flash AutoBridge registration

## NVBugs
- 6270246: Step-3.5-Flash config load fails with 45 hidden layers vs 48 layer types
- 6270147: MiMo-V2-Flash rc3 AutoBridge rejects `MiMoV2FlashForCausalLM`

## Verification
- Reproduced 6270246 with config-only load: `num_hidden_layers` 45 vs 48 `layer_types`
- Reproduced 6270147 against the rc3 runtime: AutoBridge rejects `MiMoV2FlashForCausalLM`
- `uv run --active --no-sync python -m pytest tests/unit_tests/models/stepfun/test_step35_provider.py tests/unit_tests/models/stepfun/test_step35_bridge.py tests/unit_tests/models/mimo_v2_flash/test_mimo_v2_flash_bridge.py -q`
- Config/provider runtime validation with `load_weights=False` for `stepfun-ai/Step-3.5-Flash` and `XiaomiMiMo/MiMo-V2-Flash`
- `uv run --active --no-sync pre-commit run --all-files`
