### PR TITLE
perf: Allow TE cudnn norm with gpt_oss_20b

### DIFF
--- a/scripts/performance/perf_plugins.py
+++ b/scripts/performance/perf_plugins.py
@@ -322,6 +322,8 @@ class PerfEnvPlugin(Plugin):
             if model_family_name == "kimi":
                 if compute_dtype == "fp8_mx":
                     del_cudnn_ln = False
+            if model_family_name == "gpt_oss" and model_recipe_name == "gpt_oss_20b" and train_task == "pretrain":
+                del_cudnn_ln = False
         if model_family_name in ["llama"] and train_task in ["sft"]:
             del_cudnn_ln = False
         if model_recipe_name in ["nemotron_3_nano"]:


### PR DESCRIPTION
# What does this PR do ?

This adds an entry to the perf plugin that allows gpt_oss_20b to run with CUDNN NORM, this is used by MLPerf.

# Changelog

- fix perf plugin to allow CUDNN NORM with gpt_oss_20b recipes

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
