### PR TITLE
build: add managed = true to [tool.uv]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,7 @@ dependencies = [
 version = { attr = "megatron.bridge.package_info.__version__" }
 
 [tool.uv]
+managed = true
 # Packages that require pre-installed torch/CUDA at build time (no PEP 517 isolation).
 # mamba-ssm, causal-conv1d, and transformer-engine are optional extras ([ssm], [te])
 # but kept here so they build correctly when installed.


### PR DESCRIPTION
## Summary
- Adds `managed = true` to `[tool.uv]` in `pyproject.toml`, declaring that uv manages this project's environment

## Test plan
- No functional change; CI passes as-is