### PR TITLE
fix NemotronLabsDiffusionBridge inference bug

### DIFF
--- a/examples/models/nemotron_labs_diffusion/inference_nemotron_labs_diffusion.py
+++ b/examples/models/nemotron_labs_diffusion/inference_nemotron_labs_diffusion.py
@@ -49,13 +49,16 @@ import torch
 import torch.distributed as dist
 from transformers import AutoTokenizer
 
-# Register NemotronLabsDiffusionBridge so AutoBridge can match NemotronLabsDiffusionModel architecture
-import megatron.bridge.diffusion.conversion.nemotron_labs_diffusion.nemotron_labs_diffusion_bridge  # noqa: F401
+# Bridge + provider imports for direct model construction (avoids AutoBridge architecture validation)
+from megatron.bridge.diffusion.conversion.nemotron_labs_diffusion.nemotron_labs_diffusion_bridge import (
+    NemotronLabsDiffusionBridge,
+)
 from megatron.bridge.diffusion.models.nemotron_labs_diffusion.inference_nemotron_labs_diffusion import (
     generate_ar,
     generate_dllm,
     set_tp_group,
 )
+from megatron.bridge.models.hf_pretrained.causal_lm import PreTrainedCausalLM
 
 
 def parse_args():
@@ -152,11 +155,17 @@ def parse_args():
 
 
 def load_model(args):
-    """Load the NemotronLabsDiffusion model from a Megatron checkpoint via AutoBridge."""
-    from megatron.bridge import AutoBridge
+    """Load the NemotronLabsDiffusion model from a Megatron checkpoint.
 
-    bridge = AutoBridge.from_hf_pretrained(args.hf_model, trust_remote_code=True, torch_dtype=torch.bfloat16)
-    model_provider = bridge.to_megatron_provider(load_weights=False)
+    Uses NemotronLabsDiffusionBridge directly so that both NemotronLabsDiffusion
+    HF configs (nvidia/Nemotron-Labs-Diffusion-*) and the original Ministral
+    base models (mistralai/Ministral-3-*) are accepted as --hf-model.
+    """
+    hf_pretrained = PreTrainedCausalLM.from_pretrained(args.hf_model, trust_remote_code=True)
+    bridge = NemotronLabsDiffusionBridge()
+    model_provider = bridge.provider_bridge(hf_pretrained)
+    model_provider.share_embeddings_and_output_weights = False
+    model_provider.perform_initialization = False
     model_provider.tensor_model_parallel_size = args.tp
     model_provider.pipeline_model_parallel_size = 1
     model_provider.pipeline_dtype = torch.bfloat16


### PR DESCRIPTION

# What does this PR do ?

Fixes the inference script to use NemotronLabsDiffusionBridge directly instead of AutoBridge, so that Ministral base model configs (mistralai/Ministral-3-*) are       
  accepted as --hf-model — the same models users pass during training.

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
