### PR TITLE
docs(skills): include review-pr skill in toctree

### DIFF
--- a/docs/skills-index.md
+++ b/docs/skills-index.md
@@ -13,6 +13,7 @@ skills/build-and-dependency/SKILL
 skills/bump-dependency/SKILL
 skills/testing/SKILL
 skills/cicd/SKILL
+skills/review-pr/SKILL
 skills/nemo-mbridge-mlm-bridge-training/SKILL
 skills/nemo-mbridge-recipe-recommender/SKILL
 ```


### PR DESCRIPTION
## Summary
- Add the generated review-pr skill document to the skills index toctree.
- Fixes the Sphinx toc.not_included warning for docs/skills/review-pr/SKILL.md.

## Validation
- uv run --only-group docs sphinx-build -b dummy -W --keep-going docs docs/_build/skills-check docs/skills-index.md
- uv run --only-group dev pre-commit run --all-files