### PR TITLE
[model] fix: Match HF proportional RoPE shape in Gemma 4 global attention

### DIFF
--- a/src/megatron/bridge/models/gemma/gemma4_provider.py
+++ b/src/megatron/bridge/models/gemma/gemma4_provider.py
@@ -653,17 +653,22 @@ class Gemma4RotaryEmbedding(RotaryEmbedding):
         super().__init__(
             kv_channels=global_kv_channels,
             rotary_base=rotary_base,
-            rotary_percent=global_rotary_percent,
+            rotary_percent=1.0,
             **global_kwargs,
         )
 
         # Fix global inv_freq to match HF's proportional RoPE formula.
         # HF proportional: inv_freq = 1/(base^(arange / head_dim)) not 1/(base^(arange / dim))
         # where dim = int(head_dim * percent) and head_dim = global_kv_channels
+        # HF also zero-pads inv_freq to length head_dim//2 so rotate_half pairs (i, i+head_dim//2).
         dim = int(global_kv_channels * global_rotary_percent)  # 128
         device = self.inv_freq.device
-        self.inv_freq = 1.0 / (
-            rotary_base ** (torch.arange(0, dim, 2, dtype=torch.float32, device=device) / global_kv_channels)
+        self.inv_freq = torch.cat(
+            [
+                1.0
+                / (rotary_base ** (torch.arange(0, dim, 2, dtype=torch.float32, device=device) / global_kv_channels)),
+                torch.zeros(global_kv_channels // 2 - dim // 2, dtype=torch.float32, device=device),
+            ]
         )
 
         # Local RoPE: full rotary with low theta

--- a/tests/unit_tests/models/gemma/test_gemma4_provider.py
+++ b/tests/unit_tests/models/gemma/test_gemma4_provider.py
@@ -17,7 +17,7 @@
 import pytest
 import torch
 
-from megatron.bridge.models.gemma.gemma4_provider import Gemma4ModelProvider
+from megatron.bridge.models.gemma.gemma4_provider import Gemma4ModelProvider, Gemma4RotaryEmbedding
 from megatron.bridge.models.gpt_provider import GPTModelProvider
 
 
@@ -176,3 +176,62 @@ class TestGemma4ModelProviderOverride:
     def test_override_vocab_size(self):
         p = Gemma4ModelProvider(vocab_size=300000)
         assert p.vocab_size == 300000
+
+
+class TestGemma4RotaryEmbeddingProportionalShape:
+    """Regression tests for the global-attention proportional RoPE layout.
+
+    Gemma 4's ``full_attention`` layers use ``rope_type="proportional"`` in the
+    HF config. HF's ``_compute_proportional_rope_parameters`` builds ``inv_freq``
+    of length ``head_dim // 2`` -- ``int(head_dim * partial_rotary_factor) // 2``
+    real frequencies followed by zero-padding -- so ``rotate_half`` pairs head-dim
+    lanes ``(i, i + head_dim // 2)``.
+
+    These guard against the regression where the global ``inv_freq`` was built with
+    only the real frequencies (length 64 on the 31B/26B family) and no zero-pad,
+    which left the shape at 64 instead of 256 and paired the wrong head-dim lanes.
+    """
+
+    GLOBAL_HEAD_DIM = 512
+    GLOBAL_ROTARY_PERCENT = 0.25
+    GLOBAL_ROTARY_BASE = 1_000_000
+
+    @pytest.fixture
+    def global_rope(self):
+        # Mirrors how Gemma4ModelProvider.provide() constructs the RoPE module,
+        # but CPU-only (use_cpu_initialization=True) so the test needs no GPU.
+        return Gemma4RotaryEmbedding(
+            kv_channels=256,
+            rotary_percent=1.0,
+            rotary_base=self.GLOBAL_ROTARY_BASE,
+            rotary_base_local=10_000,
+            use_cpu_initialization=True,
+            global_kv_channels=self.GLOBAL_HEAD_DIM,
+            global_rotary_percent=self.GLOBAL_ROTARY_PERCENT,
+        )
+
+    def test_inv_freq_length_is_head_dim_half(self, global_rope):
+        """HF proportional RoPE pads inv_freq to head_dim // 2 (256), not the bare
+        real-frequency count (64)."""
+        assert global_rope.inv_freq.shape[0] == self.GLOBAL_HEAD_DIM // 2
+
+    def test_inv_freq_real_and_zero_pad_counts(self, global_rope):
+        """64 real (non-zero) frequencies followed by 192 trailing zeros."""
+        dim = int(self.GLOBAL_HEAD_DIM * self.GLOBAL_ROTARY_PERCENT)  # 128
+        num_real = dim // 2  # 64
+        num_pad = self.GLOBAL_HEAD_DIM // 2 - num_real  # 192
+        inv = global_rope.inv_freq
+        assert int((inv != 0).sum()) == num_real
+        assert int((inv == 0).sum()) == num_pad
+        assert torch.all(inv[:num_real] > 0)
+        assert torch.all(inv[num_real:] == 0)
+
+    def test_real_frequencies_use_proportional_denominator(self, global_rope):
+        """Real frequencies follow HF's proportional formula with the full head_dim
+        denominator: inv_freq[i] = 1 / base^(2i / head_dim)."""
+        dim = int(self.GLOBAL_HEAD_DIM * self.GLOBAL_ROTARY_PERCENT)  # 128
+        num_real = dim // 2  # 64
+        expected_real = 1.0 / (
+            self.GLOBAL_ROTARY_BASE ** (torch.arange(0, dim, 2, dtype=torch.float32) / self.GLOBAL_HEAD_DIM)
+        )
+        torch.testing.assert_close(global_rope.inv_freq[:num_real].float(), expected_real)


### PR DESCRIPTION
# What does this PR do ?

Fixes the global-attention rotary embedding in `Gemma4RotaryEmbedding` so its
`inv_freq` matches Hugging Face's proportional RoPE layout byte-for-byte. This
affects **all Gemma 4 variants** (MoE 26B-A4B, Dense 31B, and VL), since they all
build the global RoPE through `Gemma4ModelProvider.provide()`.

# Changelog

- `gemma4_provider.py`: pass `rotary_percent=1.0` to `RotaryEmbedding.__init__`
  (was `global_rotary_percent=0.25`) so the base builds machinery on the full `head_dim`.
- `gemma4_provider.py`: construct `inv_freq` as `cat(64 real freqs, zeros(head_dim//2 - 64))`
  so `rotate_half` pairs lanes `(i, i + head_dim//2)` exactly as HF does.
- `tests/unit_tests/models/gemma/test_gemma4_provider.py`: add
  `TestGemma4RotaryEmbeddingProportionalShape` asserting the global `inv_freq` length
  (`head_dim//2`), the real/zero-pad split (64 + 192), and the proportional-denominator
  values. Verified to fail on the pre-fix code.

# Scope

- Single shared code path: `Gemma4RotaryEmbedding` is instantiated only in
  `Gemma4ModelProvider.provide()`. All variants route through it:
  - MoE `gemma-4-26B-A4B`
  - Dense `gemma-4-31B`
  - Text / VL
- Only **global / `full_attention`** layers are affected; local sliding layers use a
  separate full-rotary `rope_local` (`rope_type="default"`) and are unchanged.

# Reference (HF official)

Reference implementation: `_compute_proportional_rope_parameters` in 🤗 transformers
`src/transformers/modeling_rope_utils.py`:

```python
rope_angles = int(rope_proportion * head_dim // 2)        # 64
inv_freq_rotated = 1.0 / (base ** (arange(0, ...) / head_dim))
nope_angles = head_dim // 2 - rope_angles                 # 192
inv_freq = cat([inv_freq_rotated, zeros(nope_angles)])    # length head_dim//2 = 256
```

Docstring: *"proportional RoPE will always return an encoding that is the size of
`head_dim`."* Mainline produced length 64 instead of 256.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci)
in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve
and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests? (inv_freq-shape regression test)
- [x] Did you add or update any necessary documentation? (n/a)
- [x] Does the PR affect components that are optional to install? (No)

# Additional Information

- Related to #4195 
