### PR TITLE
Add GLM5 MTP mapping support

### DIFF
--- a/src/megatron/bridge/models/glm_moe_dsa/glm5_bridge.py
+++ b/src/megatron/bridge/models/glm_moe_dsa/glm5_bridge.py
@@ -74,8 +74,8 @@ class GLM5Bridge(MegatronModelBridge):
         provider.qk_layernorm = True
         provider.multi_latent_attention = True
 
-        # Disable MTP (Multi-Token Prediction) — HF config has num_nextn_predict_layers=1
-        # but Bridge does not yet have MTP weight mappings for GLM-5.
+        # Disable MTP (Multi-Token Prediction) by default
+        # HF config has num_nextn_predict_layers=1
         provider.mtp_num_layers = None
 
         provider.moe_grouped_gemm = True
@@ -156,6 +156,9 @@ class GLM5Bridge(MegatronModelBridge):
             # MoE shared experts
             "decoder.layers.*.mlp.shared_experts.router.weight": "model.layers.*.mlp.shared_experts.gate.weight",
             "decoder.layers.*.mlp.shared_experts.linear_fc2.weight": "model.layers.*.mlp.shared_experts.down_proj.weight",
+            # MoE expert weights (per-expert format: experts.N.down_proj)
+            "decoder.layers.*.mlp.experts.linear_fc2.weight*": "model.layers.*.mlp.experts.*.down_proj.weight",
+            "decoder.layers.*.mlp.experts.local_experts.*.linear_fc2.weight": "model.layers.*.mlp.experts.*.down_proj.weight",
         }
 
         mapping_list = [AutoMapping(megatron_param=k, hf_param=v) for k, v in param_mappings.items()]
@@ -190,7 +193,7 @@ class GLM5Bridge(MegatronModelBridge):
             ]
         )
 
-        # MoE expert weights (per-expert format: experts.N.gate_proj / up_proj / down_proj)
+        # MoE expert weights (per-expert format: experts.N.gate_proj / up_proj)
         mapping_list.extend(
             [
                 GatedMLPMapping(
@@ -198,11 +201,85 @@ class GLM5Bridge(MegatronModelBridge):
                     gate="model.layers.*.mlp.experts.*.gate_proj.weight",
                     up="model.layers.*.mlp.experts.*.up_proj.weight",
                 ),
-                AutoMapping(
-                    megatron_param="decoder.layers.*.mlp.experts.linear_fc2.weight*",
-                    hf_param="model.layers.*.mlp.experts.*.down_proj.weight",
+                GatedMLPMapping(
+                    megatron_param="decoder.layers.*.mlp.experts.local_experts.*.linear_fc1.weight",
+                    gate="model.layers.*.mlp.experts.*.gate_proj.weight",
+                    up="model.layers.*.mlp.experts.*.up_proj.weight",
                 ),
             ]
         )
+
+        hf_config = self.hf_config
+        num_mtp_layers = getattr(hf_config, "num_nextn_predict_layers", 0)
+        num_transformer_layers = hf_config.num_hidden_layers
+        for mtp_layer in range(num_mtp_layers):
+            # MTP specific mappings
+            mapping_list.extend(
+                [
+                    AutoMapping(
+                        megatron_param=f"mtp.layers.{mtp_layer}.enorm.weight",
+                        hf_param=f"model.layers.{mtp_layer + num_transformer_layers}.enorm.weight",
+                    ),
+                    AutoMapping(
+                        megatron_param=f"mtp.layers.{mtp_layer}.hnorm.weight",
+                        hf_param=f"model.layers.{mtp_layer + num_transformer_layers}.hnorm.weight",
+                    ),
+                    AutoMapping(
+                        megatron_param=f"mtp.layers.{mtp_layer}.eh_proj.weight",
+                        hf_param=f"model.layers.{mtp_layer + num_transformer_layers}.eh_proj.weight",
+                    ),
+                    AutoMapping(
+                        megatron_param=f"mtp.layers.{mtp_layer}.final_layernorm.weight",
+                        hf_param=f"model.layers.{mtp_layer + num_transformer_layers}.shared_head.norm.weight",
+                    ),
+                ]
+            )
+
+            for layer_prefix in ("transformer_layer", "mtp_model_layer"):
+                for megatron_param, hf_param in param_mappings.items():
+                    megatron_param = (
+                        megatron_param.replace(".*", f".*.{layer_prefix}", 1)
+                        .replace("decoder", "mtp")
+                        .replace(".*", f".{mtp_layer}", 1)
+                    )
+                    hf_param = hf_param.replace("layers.*", f"layers.{mtp_layer + num_transformer_layers}")
+                    mapping_list.append(AutoMapping(megatron_param=megatron_param, hf_param=hf_param))
+                # Special mappings that require parameter concatenation/transformation
+                mapping_list.extend(
+                    [
+                        QKVMapping(
+                            megatron_param=f"mtp.layers.{mtp_layer}.{layer_prefix}.self_attention.linear_qkv.weight",
+                            q=f"model.layers.{mtp_layer + num_transformer_layers}.self_attn.q_proj.weight",
+                            k=f"model.layers.{mtp_layer + num_transformer_layers}.self_attn.k_proj.weight",
+                            v=f"model.layers.{mtp_layer + num_transformer_layers}.self_attn.v_proj.weight",
+                        ),
+                        QKVMapping(
+                            megatron_param=f"mtp.layers.{mtp_layer}.{layer_prefix}.self_attention.linear_qkv.bias",
+                            q=f"model.layers.{mtp_layer + num_transformer_layers}.self_attn.q_proj.bias",
+                            k=f"model.layers.{mtp_layer + num_transformer_layers}.self_attn.k_proj.bias",
+                            v=f"model.layers.{mtp_layer + num_transformer_layers}.self_attn.v_proj.bias",
+                        ),
+                        GatedMLPMapping(
+                            megatron_param=f"mtp.layers.{mtp_layer}.{layer_prefix}.mlp.linear_fc1.weight",
+                            gate=f"model.layers.{mtp_layer + num_transformer_layers}.mlp.gate_proj.weight",
+                            up=f"model.layers.{mtp_layer + num_transformer_layers}.mlp.up_proj.weight",
+                        ),
+                        GatedMLPMapping(
+                            megatron_param=f"mtp.layers.{mtp_layer}.{layer_prefix}.mlp.shared_experts.linear_fc1.weight",
+                            gate=f"model.layers.{mtp_layer + num_transformer_layers}.mlp.shared_experts.gate_proj.weight",
+                            up=f"model.layers.{mtp_layer + num_transformer_layers}.mlp.shared_experts.up_proj.weight",
+                        ),
+                        GatedMLPMapping(
+                            megatron_param=f"mtp.layers.{mtp_layer}.{layer_prefix}.mlp.experts.linear_fc1.weight*",
+                            gate=f"model.layers.{mtp_layer + num_transformer_layers}.mlp.experts.*.gate_proj.weight",
+                            up=f"model.layers.{mtp_layer + num_transformer_layers}.mlp.experts.*.up_proj.weight",
+                        ),
+                        GatedMLPMapping(
+                            megatron_param=f"mtp.layers.{mtp_layer}.{layer_prefix}.mlp.experts.local_experts.*.linear_fc1.weight",
+                            gate=f"model.layers.{mtp_layer + num_transformer_layers}.mlp.experts.*.gate_proj.weight",
+                            up=f"model.layers.{mtp_layer + num_transformer_layers}.mlp.experts.*.up_proj.weight",
+                        ),
+                    ]
+                )
 
         return MegatronMappingRegistry(*mapping_list)

--- a/tests/unit_tests/models/glm_moe_dsa/test_glm5_bridge.py
+++ b/tests/unit_tests/models/glm_moe_dsa/test_glm5_bridge.py
@@ -1,0 +1,136 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the GLM-5 MoE DSA bridge."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from megatron.bridge.models.conversion.param_mapping import AutoMapping, GatedMLPMapping, QKVMapping
+from megatron.bridge.models.glm_moe_dsa.glm5_bridge import GLM5Bridge
+
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def glm5_bridge() -> GLM5Bridge:
+    """Create a GLM-5 bridge with only the config fields read by mapping_registry."""
+    bridge = GLM5Bridge()
+    bridge.hf_config = SimpleNamespace(num_hidden_layers=4, num_nextn_predict_layers=1)
+    return bridge
+
+
+def _mapping_by_megatron_param(bridge: GLM5Bridge) -> dict[str, object]:
+    return {mapping.megatron_param: mapping for mapping in bridge.mapping_registry()}
+
+
+def test_mapping_registry_includes_grouped_and_local_expert_fc2_paths(glm5_bridge: GLM5Bridge) -> None:
+    """GLM-5 MoE export supports both packed and local-expert down-projection names."""
+    mappings = _mapping_by_megatron_param(glm5_bridge)
+
+    grouped_mapping = mappings["decoder.layers.*.mlp.experts.linear_fc2.weight*"]
+    assert isinstance(grouped_mapping, AutoMapping)
+    assert grouped_mapping.hf_param == "model.layers.*.mlp.experts.*.down_proj.weight"
+
+    local_expert_mapping = mappings["decoder.layers.*.mlp.experts.local_experts.*.linear_fc2.weight"]
+    assert isinstance(local_expert_mapping, AutoMapping)
+    assert local_expert_mapping.hf_param == "model.layers.*.mlp.experts.*.down_proj.weight"
+
+    registry = glm5_bridge.mapping_registry()
+    grouped_lookup = registry.megatron_to_hf_lookup("decoder.layers.2.mlp.experts.linear_fc2.weight3")
+    assert grouped_lookup is not None
+    assert grouped_lookup.hf_param == "model.layers.2.mlp.experts.3.down_proj.weight"
+
+    local_expert_lookup = registry.megatron_to_hf_lookup(
+        "decoder.layers.2.mlp.experts.local_experts.3.linear_fc2.weight"
+    )
+    assert local_expert_lookup is not None
+    assert local_expert_lookup.hf_param == "model.layers.2.mlp.experts.3.down_proj.weight"
+
+
+@pytest.mark.parametrize("layer_prefix", ["transformer_layer", "mtp_model_layer"])
+def test_mapping_registry_includes_mtp_moe_mappings(glm5_bridge: GLM5Bridge, layer_prefix: str) -> None:
+    """Each GLM-5 MTP block mirrors the decoder MoE mappings for both layer replicas."""
+    mappings = _mapping_by_megatron_param(glm5_bridge)
+
+    router_mapping = mappings[f"mtp.layers.0.{layer_prefix}.mlp.router.expert_bias"]
+    assert isinstance(router_mapping, AutoMapping)
+    assert router_mapping.hf_param == "model.layers.4.mlp.gate.e_score_correction_bias"
+
+    expert_fc1_mapping = mappings[f"mtp.layers.0.{layer_prefix}.mlp.experts.local_experts.*.linear_fc1.weight"]
+    assert isinstance(expert_fc1_mapping, GatedMLPMapping)
+    assert expert_fc1_mapping.hf_param == {
+        "gate": "model.layers.4.mlp.experts.*.gate_proj.weight",
+        "up": "model.layers.4.mlp.experts.*.up_proj.weight",
+    }
+
+    expert_fc2_mapping = mappings[f"mtp.layers.0.{layer_prefix}.mlp.experts.local_experts.*.linear_fc2.weight"]
+    assert isinstance(expert_fc2_mapping, AutoMapping)
+    assert expert_fc2_mapping.hf_param == "model.layers.4.mlp.experts.*.down_proj.weight"
+
+    registry = glm5_bridge.mapping_registry()
+    expert_fc2_lookup = registry.megatron_to_hf_lookup(
+        f"mtp.layers.0.{layer_prefix}.mlp.experts.local_experts.7.linear_fc2.weight"
+    )
+    assert expert_fc2_lookup is not None
+    assert expert_fc2_lookup.hf_param == "model.layers.4.mlp.experts.7.down_proj.weight"
+
+
+@pytest.mark.parametrize("layer_prefix", ["transformer_layer", "mtp_model_layer"])
+def test_mapping_registry_includes_mtp_attention_and_dense_mlp_mappings(
+    glm5_bridge: GLM5Bridge, layer_prefix: str
+) -> None:
+    """MTP attention and dense MLP mappings point at the appended HF layer index."""
+    mappings = _mapping_by_megatron_param(glm5_bridge)
+
+    qkv_mapping = mappings[f"mtp.layers.0.{layer_prefix}.self_attention.linear_qkv.weight"]
+    assert isinstance(qkv_mapping, QKVMapping)
+    assert qkv_mapping.hf_param == {
+        "q": "model.layers.4.self_attn.q_proj.weight",
+        "k": "model.layers.4.self_attn.k_proj.weight",
+        "v": "model.layers.4.self_attn.v_proj.weight",
+    }
+
+    mlp_mapping = mappings[f"mtp.layers.0.{layer_prefix}.mlp.linear_fc1.weight"]
+    assert isinstance(mlp_mapping, GatedMLPMapping)
+    assert mlp_mapping.hf_param == {
+        "gate": "model.layers.4.mlp.gate_proj.weight",
+        "up": "model.layers.4.mlp.up_proj.weight",
+    }
+
+
+def test_mapping_registry_includes_mtp_standalone_weights(glm5_bridge: GLM5Bridge) -> None:
+    """GLM-5 MTP-only weights map to the appended HF MTP layer."""
+    mappings = _mapping_by_megatron_param(glm5_bridge)
+
+    expected_hf_params = {
+        "mtp.layers.0.enorm.weight": "model.layers.4.enorm.weight",
+        "mtp.layers.0.hnorm.weight": "model.layers.4.hnorm.weight",
+        "mtp.layers.0.eh_proj.weight": "model.layers.4.eh_proj.weight",
+        "mtp.layers.0.final_layernorm.weight": "model.layers.4.shared_head.norm.weight",
+    }
+    for megatron_param, hf_param in expected_hf_params.items():
+        mapping = mappings[megatron_param]
+        assert isinstance(mapping, AutoMapping)
+        assert mapping.hf_param == hf_param
+
+
+def test_mapping_registry_omits_mtp_mappings_without_nextn_layers() -> None:
+    """No MTP mappings are registered when the HF config has no MTP layers."""
+    bridge = GLM5Bridge()
+    bridge.hf_config = SimpleNamespace(num_hidden_layers=4, num_nextn_predict_layers=0)
+
+    assert all(not mapping.megatron_param.startswith("mtp.") for mapping in bridge.mapping_registry())


### PR DESCRIPTION
# What does this PR do ?

Add GLM5 MTP mapping support

# Changelog

- Add the missing GLM5 MTP mapping from https://github.com/NVIDIA-NeMo/Megatron-Bridge/pull/2469

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [X] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
