### PR TITLE
Add weight and bias property for LoRALinear

### DIFF
--- a/src/megatron/bridge/models/conversion/peft_bridge.py
+++ b/src/megatron/bridge/models/conversion/peft_bridge.py
@@ -39,7 +39,7 @@ from megatron.bridge.models.conversion.utils import (
     persistent_buffers,
 )
 from megatron.bridge.peft.canonical_lora import ModuleDict
-from megatron.bridge.peft.lora import LoRAMerge
+from megatron.bridge.peft.lora_merge import LoRAMerge
 from megatron.bridge.peft.utils import (
     get_adapter_attributes_from_linear,
     is_expert_linear,

--- a/src/megatron/bridge/models/conversion/peft_bridge.py
+++ b/src/megatron/bridge/models/conversion/peft_bridge.py
@@ -1197,7 +1197,6 @@ class MegatronPeftBridge:
                 linear_in_on_base,
                 alpha,
                 dim,
-                tp_size=1,
                 tp_group=None,
             )
 
@@ -1361,7 +1360,6 @@ class MegatronPeftBridge:
             linear_in_on_base,
             alpha,
             dim,
-            tp_size=1,
             tp_group=None,
         )
         return merged.to(orig_dtype)

--- a/src/megatron/bridge/peft/lora.py
+++ b/src/megatron/bridge/peft/lora.py
@@ -17,7 +17,6 @@ from dataclasses import dataclass, field
 from typing import List, Literal, Optional
 
 import torch
-import torch.distributed as dist
 import torch.nn as nn
 import transformer_engine.pytorch as te
 from megatron.core import parallel_state
@@ -273,82 +272,3 @@ class VLMLoRA(LoRA):
                 model.module.train(mode=True)
             else:
                 model.train(mode=True)
-
-
-class LoRAMerge:
-    """
-    Tensor helper for merging LoRA adapter weights into base weights.
-    """
-
-    def merge(
-        self,
-        base_weight: torch.Tensor,
-        linear_out: torch.Tensor,
-        linear_in: torch.Tensor,
-        alpha: int,
-        dim: int,
-        *,
-        tp_size: int,
-        tp_group,
-    ) -> torch.Tensor:
-        """
-        Merges the LoRA adapter weights with the base model weights.
-        Handles tensor parallelism by gathering sharded dimensions.
-
-        For ColumnParallelLinear (e.g., linear_qkv, linear_fc1):
-            - base_weight: (out_features/TP, in_features)
-            - linear_in: (dim/TP, in_features) ← Need to gather this
-            - linear_out: (out_features/TP, dim)
-            - Target: (out_features/TP, dim) @ (dim, in_features) = (out_features/TP, in_features)
-
-        For RowParallelLinear (e.g., linear_proj, linear_fc2):
-            - base_weight: (out_features, in_features/TP)
-            - linear_in: (dim, in_features/TP)
-            - linear_out: (out_features/TP, dim) ← Need to gather this
-            - Target: (out_features, dim) @ (dim, in_features/TP) = (out_features, in_features/TP)
-
-        Args:
-            base_weight (torch.Tensor): The base model weights.
-            linear_out (torch.Tensor): LoRA's B matrix.
-            linear_in (torch.Tensor): LoRA's A matrix.
-            alpha (int): Weighting factor for the low-rank projection.
-            dim (int): Dimension of the low-rank projection space.
-            tp_size (int): Tensor-parallel world size for the adapter shard.
-            tp_group: Tensor-parallel process group for the adapter shard.
-
-        Returns:
-            torch.Tensor: The merged weights.
-        """
-
-        if tp_size == 1:
-            # No tensor parallelism, simple multiplication
-            lora_weight = alpha / dim * (linear_out @ linear_in)
-            return base_weight + lora_weight
-
-        # Case 1: ColumnParallelLinear - linear_in is sharded on dim 0
-        # linear_in: (dim/TP, in_features), linear_out: (out_features/TP, dim)
-        if linear_in.shape[0] * tp_size == dim and linear_out.shape[1] == dim:
-            # Gather linear_in along dimension 0 to get full dim
-            linear_in_list = [torch.empty_like(linear_in) for _ in range(tp_size)]
-            dist.all_gather(linear_in_list, linear_in, group=tp_group)
-            linear_in_full = torch.cat(linear_in_list, dim=0)
-
-            # Multiply: (out_features/TP, dim) @ (dim, in_features)
-            lora_weight = alpha / dim * (linear_out @ linear_in_full)
-
-        # Case 2: RowParallelLinear - linear_out is sharded on dim 0
-        # linear_in: (dim, in_features/TP), linear_out: (out_features/TP, dim)
-        elif linear_out.shape[0] * tp_size == base_weight.shape[0]:
-            # Gather linear_out along dimension 0 to get full out_features
-            linear_out_list = [torch.empty_like(linear_out) for _ in range(tp_size)]
-            dist.all_gather(linear_out_list, linear_out, group=tp_group)
-            linear_out_full = torch.cat(linear_out_list, dim=0)
-
-            # Multiply: (out_features, dim) @ (dim, in_features/TP)
-            lora_weight = alpha / dim * (linear_out_full @ linear_in)
-
-        else:
-            # Fallback: no gathering needed or already full-size
-            lora_weight = alpha / dim * (linear_out @ linear_in)
-
-        return base_weight + lora_weight

--- a/src/megatron/bridge/peft/lora_layers.py
+++ b/src/megatron/bridge/peft/lora_layers.py
@@ -21,6 +21,7 @@ import transformer_engine.pytorch as te
 from megatron.core.transformer.moe.moe_utils import apply_random_logits
 
 from megatron.bridge.peft.adapter_wrapper import AdapterWrapper
+from megatron.bridge.peft.lora_merge import LoRAMerge
 from megatron.bridge.utils.import_utils import safe_import
 
 
@@ -38,6 +39,44 @@ class LoRALinear(AdapterWrapper):
     where the adapter's output is added to the main module's output. It extends the AdapterWrapper
     class to provide a specific implementation of the forward method.
     """
+
+    @property
+    def weight(self) -> torch.Tensor:
+        """Return the effective base weight, including the LoRA delta when enabled."""
+        base_weight = self.to_wrap.weight
+        if not self._adapter_enabled:
+            return base_weight
+
+        linear_in_weight = self.adapter.linear_in.weight
+        linear_out_weight = self.adapter.linear_out.weight
+        tp_size = 1
+        if getattr(self.adapter, "input_is_parallel", False):
+            if linear_out_weight.shape[0] != base_weight.shape[0]:
+                tp_size = base_weight.shape[0] // linear_out_weight.shape[0]
+        elif linear_in_weight.shape[0] != linear_out_weight.shape[1]:
+            tp_size = linear_out_weight.shape[1] // linear_in_weight.shape[0]
+
+        merged_weight = LoRAMerge().merge(
+            base_weight,
+            linear_out_weight,
+            linear_in_weight,
+            self.adapter.alpha,
+            self.adapter.dim,
+            tp_size=tp_size,
+            tp_group=getattr(self.adapter, "tp_group", None),
+            scale=getattr(self.adapter, "scale", None),
+        )
+        if merged_weight.shape != base_weight.shape:
+            raise RuntimeError(
+                "LoRA effective weight shape mismatch: "
+                f"base={tuple(base_weight.shape)}, merged={tuple(merged_weight.shape)}"
+            )
+        return merged_weight.to(device=base_weight.device, dtype=base_weight.dtype)
+
+    @property
+    def bias(self) -> torch.Tensor | None:
+        """Return the wrapped linear bias."""
+        return getattr(self.to_wrap, "bias", None)
 
     def forward(self, x: torch.Tensor, *args: Any, **kwargs: Any) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
         """Forward pass that combines the wrapped module output with the adapter output.

--- a/src/megatron/bridge/peft/lora_layers.py
+++ b/src/megatron/bridge/peft/lora_layers.py
@@ -57,7 +57,6 @@ class LoRALinear(AdapterWrapper):
             self.adapter.alpha,
             self.adapter.dim,
             tp_group=getattr(self.adapter, "tp_group", None),
-            scale=getattr(self.adapter, "scale", None),
         )
         if merged_weight.shape != base_weight.shape:
             raise RuntimeError(

--- a/src/megatron/bridge/peft/lora_layers.py
+++ b/src/megatron/bridge/peft/lora_layers.py
@@ -49,12 +49,6 @@ class LoRALinear(AdapterWrapper):
 
         linear_in_weight = self.adapter.linear_in.weight
         linear_out_weight = self.adapter.linear_out.weight
-        tp_size = 1
-        if getattr(self.adapter, "input_is_parallel", False):
-            if linear_out_weight.shape[0] != base_weight.shape[0]:
-                tp_size = base_weight.shape[0] // linear_out_weight.shape[0]
-        elif linear_in_weight.shape[0] != linear_out_weight.shape[1]:
-            tp_size = linear_out_weight.shape[1] // linear_in_weight.shape[0]
 
         merged_weight = LoRAMerge().merge(
             base_weight,
@@ -62,7 +56,6 @@ class LoRALinear(AdapterWrapper):
             linear_in_weight,
             self.adapter.alpha,
             self.adapter.dim,
-            tp_size=tp_size,
             tp_group=getattr(self.adapter, "tp_group", None),
             scale=getattr(self.adapter, "scale", None),
         )

--- a/src/megatron/bridge/peft/lora_merge.py
+++ b/src/megatron/bridge/peft/lora_merge.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional
+
+import torch
+import torch.distributed as dist
+
+
+class LoRAMerge:
+    """
+    Tensor helper for merging LoRA adapter weights into base weights.
+    """
+
+    def merge(
+        self,
+        base_weight: torch.Tensor,
+        linear_out: torch.Tensor,
+        linear_in: torch.Tensor,
+        alpha: int,
+        dim: int,
+        *,
+        tp_size: int,
+        tp_group: Optional[torch.distributed.ProcessGroup],
+        scale: Optional[float] = None,
+    ) -> torch.Tensor:
+        """
+        Merges the LoRA adapter weights with the base model weights.
+        Handles tensor parallelism by gathering sharded dimensions.
+
+        For ColumnParallelLinear (e.g., linear_qkv, linear_fc1):
+            - base_weight: (out_features/TP, in_features)
+            - linear_in: (dim/TP, in_features) <- Need to gather this
+            - linear_out: (out_features/TP, dim)
+            - Target: (out_features/TP, dim) @ (dim, in_features) = (out_features/TP, in_features)
+
+        For RowParallelLinear (e.g., linear_proj, linear_fc2):
+            - base_weight: (out_features, in_features/TP)
+            - linear_in: (dim, in_features/TP)
+            - linear_out: (out_features/TP, dim) <- Need to gather this
+            - Target: (out_features, dim) @ (dim, in_features/TP) = (out_features, in_features/TP)
+
+        Args:
+            base_weight (torch.Tensor): The base model weights.
+            linear_out (torch.Tensor): LoRA's B matrix.
+            linear_in (torch.Tensor): LoRA's A matrix.
+            alpha (int): Weighting factor for the low-rank projection.
+            dim (int): Dimension of the low-rank projection space.
+            tp_size (int): Tensor-parallel world size for the adapter shard.
+            tp_group: Tensor-parallel process group for the adapter shard.
+            scale: Optional precomputed LoRA scale. Defaults to alpha / dim.
+
+        Returns:
+            torch.Tensor: The merged weights.
+        """
+
+        lora_scale = alpha / dim if scale is None else scale
+
+        if tp_size == 1:
+            lora_weight = lora_scale * (linear_out @ linear_in)
+            return base_weight + lora_weight
+
+        if linear_in.shape[0] * tp_size == dim and linear_out.shape[1] == dim:
+            linear_in_list = [torch.empty_like(linear_in) for _ in range(tp_size)]
+            dist.all_gather(linear_in_list, linear_in, group=tp_group)
+            linear_in_full = torch.cat(linear_in_list, dim=0)
+            lora_weight = lora_scale * (linear_out @ linear_in_full)
+
+        elif linear_out.shape[0] * tp_size == base_weight.shape[0]:
+            linear_out_list = [torch.empty_like(linear_out) for _ in range(tp_size)]
+            dist.all_gather(linear_out_list, linear_out, group=tp_group)
+            linear_out_full = torch.cat(linear_out_list, dim=0)
+            lora_weight = lora_scale * (linear_out_full @ linear_in)
+
+        else:
+            lora_weight = lora_scale * (linear_out @ linear_in)
+
+        return base_weight + lora_weight

--- a/src/megatron/bridge/peft/lora_merge.py
+++ b/src/megatron/bridge/peft/lora_merge.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
-
 import torch
 import torch.distributed as dist
 
@@ -31,9 +29,8 @@ class LoRAMerge:
         alpha: int,
         dim: int,
         *,
-        tp_size: int,
-        tp_group: Optional[torch.distributed.ProcessGroup],
-        scale: Optional[float] = None,
+        tp_group: dist.ProcessGroup | None,
+        scale: float | None = None,
     ) -> torch.Tensor:
         """
         Merges the LoRA adapter weights with the base model weights.
@@ -57,7 +54,6 @@ class LoRAMerge:
             linear_in (torch.Tensor): LoRA's A matrix.
             alpha (int): Weighting factor for the low-rank projection.
             dim (int): Dimension of the low-rank projection space.
-            tp_size (int): Tensor-parallel world size for the adapter shard.
             tp_group: Tensor-parallel process group for the adapter shard.
             scale: Optional precomputed LoRA scale. Defaults to alpha / dim.
 
@@ -66,6 +62,7 @@ class LoRAMerge:
         """
 
         lora_scale = alpha / dim if scale is None else scale
+        tp_size = 1 if tp_group is None else tp_group.size()
 
         if tp_size == 1:
             lora_weight = lora_scale * (linear_out @ linear_in)

--- a/src/megatron/bridge/peft/lora_merge.py
+++ b/src/megatron/bridge/peft/lora_merge.py
@@ -14,6 +14,7 @@
 
 import torch
 import torch.distributed as dist
+from megatron.core.utils import get_pg_size
 
 
 class LoRAMerge:
@@ -62,7 +63,7 @@ class LoRAMerge:
         """
 
         lora_scale = alpha / dim if scale is None else scale
-        tp_size = 1 if tp_group is None else tp_group.size()
+        tp_size = get_pg_size(tp_group)
 
         if tp_size == 1:
             lora_weight = lora_scale * (linear_out @ linear_in)

--- a/tests/unit_tests/peft/test_lora.py
+++ b/tests/unit_tests/peft/test_lora.py
@@ -28,8 +28,9 @@ from megatron.bridge.peft import canonical_lora as canonical_lora_module
 from megatron.bridge.peft import lora as lora_module
 from megatron.bridge.peft import utils as peft_utils
 from megatron.bridge.peft.canonical_lora import CanonicalLoRA
-from megatron.bridge.peft.lora import LoRA, LoRAMerge, VLMLoRA
+from megatron.bridge.peft.lora import LoRA, VLMLoRA
 from megatron.bridge.peft.lora_layers import LinearAdapter, LoRALinear
+from megatron.bridge.peft.lora_merge import LoRAMerge
 from megatron.bridge.peft.utils import (
     AdapterAttributes,
     GroupedExpertLinearAdapter,
@@ -933,7 +934,7 @@ class TestLoRAMerge:
 
         # Mock the distributed environment for TP=2
         tp_size = 2
-        with patch("megatron.bridge.peft.lora.dist") as mock_dist:
+        with patch("megatron.bridge.peft.lora_merge.dist") as mock_dist:
             # Mock all_gather to simulate gathering from 2 ranks
             def mock_all_gather(tensor_list, tensor, group=None):
                 # Simulate gathering: each rank has identical shards for this test
@@ -990,7 +991,7 @@ class TestLoRAMerge:
 
         # Mock the distributed environment for TP=2
         tp_size = 2
-        with patch("megatron.bridge.peft.lora.dist") as mock_dist:
+        with patch("megatron.bridge.peft.lora_merge.dist") as mock_dist:
             # Mock all_gather to simulate gathering from 2 ranks
             def mock_all_gather(tensor_list, tensor, group=None):
                 # Simulate gathering: each rank has identical shards for this test

--- a/tests/unit_tests/peft/test_lora.py
+++ b/tests/unit_tests/peft/test_lora.py
@@ -942,7 +942,10 @@ class TestLoRAMerge:
 
         # Mock the distributed environment for TP=2
         tp_size = 2
-        with patch("megatron.bridge.peft.lora_merge.dist") as mock_dist:
+        with (
+            patch("megatron.bridge.peft.lora_merge.dist") as mock_dist,
+            patch("megatron.bridge.peft.lora_merge.get_pg_size", return_value=tp_size),
+        ):
             # Mock all_gather to simulate gathering from 2 ranks
             def mock_all_gather(tensor_list, tensor, group=None):
                 # Simulate gathering: each rank has identical shards for this test
@@ -998,7 +1001,10 @@ class TestLoRAMerge:
 
         # Mock the distributed environment for TP=2
         tp_size = 2
-        with patch("megatron.bridge.peft.lora_merge.dist") as mock_dist:
+        with (
+            patch("megatron.bridge.peft.lora_merge.dist") as mock_dist,
+            patch("megatron.bridge.peft.lora_merge.get_pg_size", return_value=tp_size),
+        ):
             # Mock all_gather to simulate gathering from 2 ranks
             def mock_all_gather(tensor_list, tensor, group=None):
                 # Simulate gathering: each rank has identical shards for this test

--- a/tests/unit_tests/peft/test_lora.py
+++ b/tests/unit_tests/peft/test_lora.py
@@ -39,6 +39,16 @@ from megatron.bridge.peft.utils import (
 )
 
 
+class MockProcessGroup:
+    """Process group test double exposing the size used by LoRAMerge."""
+
+    def __init__(self, size: int) -> None:
+        self._size = size
+
+    def size(self) -> int:
+        return self._size
+
+
 class SimpleModel(nn.Module):
     """Simple test model with various linear layers."""
 
@@ -853,7 +863,6 @@ class TestLoRAMerge:
             adapter.linear_in.weight,
             adapter.alpha,
             adapter.dim,
-            tp_size=1,
             tp_group=None,
         )
 
@@ -895,7 +904,6 @@ class TestLoRAMerge:
             adapter.linear_in.weight,
             adapter.alpha,
             adapter.dim,
-            tp_size=1,
             tp_group=None,
         )
 
@@ -951,8 +959,7 @@ class TestLoRAMerge:
                 adapter.linear_in.weight,
                 adapter.alpha,
                 adapter.dim,
-                tp_size=tp_size,
-                tp_group=None,
+                tp_group=MockProcessGroup(tp_size),
             )
 
         # Verify the merge used gathered weights
@@ -1008,8 +1015,7 @@ class TestLoRAMerge:
                 adapter.linear_in.weight,
                 adapter.alpha,
                 adapter.dim,
-                tp_size=tp_size,
-                tp_group=None,
+                tp_group=MockProcessGroup(tp_size),
             )
 
         # Verify the merge used gathered weights

--- a/tests/unit_tests/peft/test_lora_layers.py
+++ b/tests/unit_tests/peft/test_lora_layers.py
@@ -44,14 +44,24 @@ from megatron.bridge.peft.utils import AdapterAttributes
 class MockLinearWithTupleReturn(nn.Module):
     """Mock linear module that returns tuples like Megatron layers."""
 
-    def __init__(self, in_features=10, out_features=10):
+    def __init__(self, in_features=10, out_features=10, bias=True):
         super().__init__()
-        self.linear = nn.Linear(in_features, out_features)
+        self.linear = nn.Linear(in_features, out_features, bias=bias)
 
     def forward(self, x, *args, **kwargs):
         """Return tuple format like Megatron linear layers."""
         output = self.linear(x)
         return output, None  # (output, bias)
+
+    @property
+    def weight(self):
+        """Return the wrapped linear weight."""
+        return self.linear.weight
+
+    @property
+    def bias(self):
+        """Return the wrapped linear bias."""
+        return self.linear.bias
 
 
 class MockParallelLinearAdapter(nn.Module):
@@ -66,6 +76,23 @@ class MockParallelLinearAdapter(nn.Module):
     def forward(self, x):
         """Forward pass returning tuple format."""
         return self.linear(x) * 0.1  # Scale down to simulate adapter
+
+
+class MockLoRAAdapter(nn.Module):
+    """Mock LoRA adapter with explicit A/B matrices for testing effective weights."""
+
+    def __init__(self, in_features=10, out_features=10, dim=2, alpha=4):
+        """Initialize mock LoRA adapter."""
+        super().__init__()
+        self.dim = dim
+        self.alpha = alpha
+        self.scale = alpha / dim
+        self.linear_in = nn.Linear(in_features, dim, bias=False)
+        self.linear_out = nn.Linear(dim, out_features, bias=False)
+
+    def forward(self, x):
+        """Return only the scaled LoRA delta."""
+        return self.linear_out(self.linear_in(x)) * self.scale
 
 
 class TestLoRALinear:
@@ -116,6 +143,65 @@ class TestLoRALinear:
         # Verify addition
         expected = base_output + adapter_output
         assert torch.allclose(lora_output, expected, atol=1e-6)
+
+    def test_lora_linear_weight_returns_effective_weight(self):
+        """Test that LoRALinear.weight includes the active LoRA delta."""
+        base = MockLinearWithTupleReturn(in_features=3, out_features=2)
+        adapter = MockLoRAAdapter(in_features=3, out_features=2, dim=2, alpha=4)
+
+        with torch.no_grad():
+            base.weight.copy_(torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]))
+            adapter.linear_in.weight.copy_(torch.tensor([[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]))
+            adapter.linear_out.weight.copy_(torch.tensor([[0.7, 0.8], [0.9, 1.0]]))
+
+        lora_linear = LoRALinear(base, adapter)
+        expected_weight = base.weight + adapter.scale * (adapter.linear_out.weight @ adapter.linear_in.weight)
+
+        assert torch.allclose(lora_linear.weight, expected_weight)
+
+    def test_lora_linear_weight_returns_base_weight_when_disabled(self):
+        """Test that disabled adapters expose the original base weight."""
+        base = MockLinearWithTupleReturn(in_features=3, out_features=2)
+        adapter = MockLoRAAdapter(in_features=3, out_features=2, dim=2, alpha=4)
+        lora_linear = LoRALinear(base, adapter)
+
+        lora_linear.disable_adapter_layers()
+
+        assert lora_linear.weight is base.weight
+
+    def test_lora_linear_bias_returns_base_bias(self):
+        """Test that LoRALinear.bias exposes the wrapped module bias."""
+        base = MockLinearWithTupleReturn(in_features=3, out_features=2)
+        adapter = MockLoRAAdapter(in_features=3, out_features=2, dim=2, alpha=4)
+        lora_linear = LoRALinear(base, adapter)
+
+        assert lora_linear.bias is base.bias
+
+    def test_lora_linear_bias_returns_none_without_base_bias(self):
+        """Test that LoRALinear.bias is None when the wrapped module has no bias."""
+        base = MockLinearWithTupleReturn(in_features=3, out_features=2, bias=False)
+        adapter = MockLoRAAdapter(in_features=3, out_features=2, dim=2, alpha=4)
+        lora_linear = LoRALinear(base, adapter)
+
+        assert lora_linear.bias is None
+
+    def test_lora_linear_weight_matches_forward_delta(self):
+        """Test that the effective weight reproduces the LoRALinear forward output."""
+        base = MockLinearWithTupleReturn(in_features=3, out_features=2)
+        adapter = MockLoRAAdapter(in_features=3, out_features=2, dim=2, alpha=4)
+
+        with torch.no_grad():
+            adapter.linear_in.weight.copy_(torch.tensor([[0.2, -0.1, 0.3], [0.4, 0.5, -0.2]]))
+            adapter.linear_out.weight.copy_(torch.tensor([[0.6, -0.3], [0.1, 0.7]]))
+
+        lora_linear = LoRALinear(base, adapter)
+        x = torch.randn(5, 3)
+
+        output, bias = lora_linear(x)
+        expected_output = torch.nn.functional.linear(x, lora_linear.weight, base.bias)
+
+        assert bias is None
+        assert torch.allclose(output, expected_output, atol=1e-6)
 
 
 class TestLinearAdapter:


### PR DESCRIPTION
# What does this PR do ?

To make LoRALinear layers look like it's not lora specific.

For MLA absorption code when LoRA is enabled:
https://github.com/NVIDIA/Megatron-LM/blob/b0eb9143c39b5b7a34eabadfdaa8ce5389ad1efa/megatron/core/transformer/multi_latent_attention.py#L1051-L1053

# Changelog

- Add weight property for LoRALinear, get weight with lora merge.
- Add bias property for LoRALinear by directly accessing the wrapped base bias.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [X] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [X] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
