### PR TITLE
fix(gemma4): map dense MLP pre-FFN norm to pre_feedforward_layernorm

### DIFF
--- a/src/megatron/bridge/models/gemma/gemma4_bridge.py
+++ b/src/megatron/bridge/models/gemma/gemma4_bridge.py
@@ -398,7 +398,12 @@ class Gemma4Bridge(MegatronModelBridge):
             # (Gemma4TopKRouter.scale) so it round-trips on export without needing the
             # reference HF checkpoint.  Mapped via ReplicatedMapping below.
             "decoder.layers.*.mlp.linear_fc2.weight": ("model.layers.*.mlp.down_proj.weight"),
-            "decoder.layers.*.mlp.linear_fc1.layer_norm_weight": "model.layers.*.post_attention_layernorm.weight",
+            # === Dense MLP fused pre-FFN norm ===
+            # TE backend fuses the pre-MLP RMSNorm into linear_fc1 as
+            # linear_fc1.layer_norm_weight.  In Gemma 4 the pre-MLP norm is
+            # pre_feedforward_layernorm (post_attention_layernorm is a separate
+            # norm already mapped to self_attention.linear_proj.post_layernorm).
+            "decoder.layers.*.mlp.linear_fc1.layer_norm_weight": "model.layers.*.pre_feedforward_layernorm.weight",
         }
 
         mapping_list = []

--- a/src/megatron/bridge/models/gemma_vl/gemma4_vl_bridge.py
+++ b/src/megatron/bridge/models/gemma_vl/gemma4_vl_bridge.py
@@ -361,7 +361,12 @@ class Gemma4VLBridge(MegatronModelBridge):
             "language_model.decoder.layers.*.mlp.linear_fc2.weight": (
                 "model.language_model.layers.*.mlp.down_proj.weight"
             ),
-            "language_model.decoder.layers.*.mlp.linear_fc1.layer_norm_weight": "model.language_model.layers.*.post_attention_layernorm.weight",
+            # === Dense MLP fused pre-FFN norm ===
+            # TE backend fuses the pre-MLP RMSNorm into linear_fc1 as
+            # linear_fc1.layer_norm_weight.  In Gemma 4 the pre-MLP norm is
+            # pre_feedforward_layernorm (post_attention_layernorm is a separate
+            # norm already mapped to self_attention.linear_proj.post_layernorm).
+            "language_model.decoder.layers.*.mlp.linear_fc1.layer_norm_weight": "model.language_model.layers.*.pre_feedforward_layernorm.weight",
         }
 
         mapping_list = []

--- a/tests/unit_tests/models/gemma/test_gemma4_bridge.py
+++ b/tests/unit_tests/models/gemma/test_gemma4_bridge.py
@@ -526,3 +526,20 @@ class TestGemma4BridgeMappingRegistry:
     def test_has_layer_scalar_mapping(self, bridge):
         names = self._collect_names(bridge.mapping_registry())
         assert any("layer_scalar" in n for n in names)
+
+    def test_dense_mlp_pre_norm_maps_to_pre_feedforward_layernorm(self, bridge):
+        """Dense MLP fused pre-norm must load pre_feedforward_layernorm, not post_attention_layernorm.
+
+        Regression test for the bug where linear_fc1.layer_norm_weight (the
+        TE-fused pre-MLP RMSNorm) was mapped to post_attention_layernorm,
+        leaving the dense MLP without its real pre-FFN normalization.
+        """
+        hf_target = None
+        for m in bridge.mapping_registry().mappings:
+            megatron_param = getattr(m, "megatron_param", "")
+            if isinstance(megatron_param, str) and megatron_param.endswith("mlp.linear_fc1.layer_norm_weight"):
+                hf_target = m.hf_param
+                break
+        assert hf_target is not None, "linear_fc1.layer_norm_weight mapping not found"
+        assert hf_target.endswith("pre_feedforward_layernorm.weight")
+        assert "post_attention_layernorm" not in hf_target

--- a/tests/unit_tests/models/gemma_vl/test_gemma4_vl_bridge.py
+++ b/tests/unit_tests/models/gemma_vl/test_gemma4_vl_bridge.py
@@ -331,6 +331,23 @@ class TestGemma4VLBridgeMappingRegistry:
         names = self._collect_names(bridge.mapping_registry())
         assert any("post_moe_layernorm" in n for n in names)
 
+    def test_dense_mlp_pre_norm_maps_to_pre_feedforward_layernorm(self, bridge):
+        """Dense MLP fused pre-norm must load pre_feedforward_layernorm, not post_attention_layernorm.
+
+        Regression test for the bug where linear_fc1.layer_norm_weight (the
+        TE-fused pre-MLP RMSNorm) was mapped to post_attention_layernorm,
+        leaving the dense MLP without its real pre-FFN normalization.
+        """
+        hf_target = None
+        for m in bridge.mapping_registry().mappings:
+            megatron_param = getattr(m, "megatron_param", "")
+            if isinstance(megatron_param, str) and megatron_param.endswith("mlp.linear_fc1.layer_norm_weight"):
+                hf_target = m.hf_param
+                break
+        assert hf_target is not None, "linear_fc1.layer_norm_weight mapping not found"
+        assert hf_target.endswith("pre_feedforward_layernorm.weight")
+        assert "post_attention_layernorm" not in hf_target
+
 
 # ---------------------------------------------------------------------------
 # Edge cases


### PR DESCRIPTION
# What does this PR do ?

Fixes the Gemma4 dense MLP loading the wrong pre-FFN norm: `linear_fc1.layer_norm_weight` was mapped to `post_attention_layernorm` instead of `pre_feedforward_layernorm`.

# Changelog

- `src/megatron/bridge/models/gemma/gemma4_bridge.py`: map `decoder.layers.*.mlp.linear_fc1.layer_norm_weight` → `model.layers.*.pre_feedforward_layernorm.weight` (was `post_attention_layernorm.weight`).
- `src/megatron/bridge/models/gemma_vl/gemma4_vl_bridge.py`: same fix for the VL bridge (`model.language_model.layers.*.pre_feedforward_layernorm.weight`).
- Added regression tests in both bridge unit tests asserting `linear_fc1.layer_norm_weight` maps to `pre_feedforward_layernorm` and not `post_attention_layernorm`.

## Why

In MCore (TE backend) the per-layer pre-MLP RMSNorm is fused into `linear_fc1` as `linear_fc1.layer_norm_weight`. In Gemma 4 this norm is `pre_feedforward_layernorm`. `post_attention_layernorm` is a different norm and is already correctly mapped to `self_attention.linear_proj.post_layernorm.weight`. As a result the dense MLP never received its real pre-FFN normalization — the actual `pre_feedforward_layernorm` weights were loaded only into the inert `pffl_weight` buffer and never applied.

## Impact (google/gemma-4-31B-it, dense → loads via Gemma4VLBridge)

| Metric | Before | After |
| --- | --- | --- |
| Initial SFT loss | ~22.6 (worse than uniform over 262k vocab, ln(262144) ≈ 12.5) | ~6.9 |
| Global grad norm | ~17000 | ~1000 |

Before the fix `mlp.linear_fc1.weight`'s gradient was ~90x larger than all other params, inflating the global grad norm ~10x and distorting the optimizer update under `clip_grad=1.0`.

# GitHub Actions CI

A NVIDIA developer will need to approve and trigger CI for this external contribution.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)

# Additional Information

- Closes #4200