### PR TITLE
[training] fix: Route batches to standalone MTP stages

### DIFF
--- a/docs/skills-index.md
+++ b/docs/skills-index.md
@@ -13,6 +13,7 @@ skills/build-and-dependency/SKILL
 skills/bump-dependency/SKILL
 skills/testing/SKILL
 skills/cicd/SKILL
+skills/review-pr/SKILL
 skills/nemo-mbridge-mlm-bridge-training/SKILL
 skills/nemo-mbridge-recipe-recommender/SKILL
 ```

--- a/src/megatron/bridge/training/gpt_step.py
+++ b/src/megatron/bridge/training/gpt_step.py
@@ -21,6 +21,8 @@ import torch
 from megatron.core import parallel_state
 from megatron.core.models.gpt import GPTModel
 from megatron.core.pipeline_parallel.utils import is_pp_first_stage, is_pp_last_stage
+from megatron.core.transformer.enums import LayerType
+from megatron.core.transformer.pipeline_parallel_layer_layout import PipelineParallelLayerLayout
 from megatron.core.utils import (
     get_batch_on_this_cp_rank,
     get_model_config,
@@ -55,6 +57,66 @@ def _middle_pp_stage_needs_batch(cfg: ConfigContainer) -> bool:
     dataset_cfg = getattr(cfg, "dataset", None)
     uses_custom_attention_mask = not getattr(dataset_cfg, "skip_getting_attention_mask_from_dataset", True)
     return uses_custom_attention_mask or _uses_packed_sequence_metadata(cfg)
+
+
+def _get_pp_group_rank(pp_group) -> int:
+    """Return this rank's index within the pipeline-parallel group."""
+    if pp_group is not None and hasattr(pp_group, "rank"):
+        return pp_group.rank()
+    return parallel_state.get_pipeline_model_parallel_rank()
+
+
+def _get_pp_group_size(pp_group, cfg: ConfigContainer) -> int:
+    """Return the pipeline-parallel group size."""
+    if pp_group is not None and hasattr(pp_group, "size"):
+        return pp_group.size()
+
+    model_cfg = getattr(cfg, "model", None)
+    return getattr(model_cfg, "pipeline_model_parallel_size", 1)
+
+
+def _layout_stage_has_mtp(layout, *, pp_rank: int, pp_size: int, vp_stage: int) -> bool:
+    """Return whether a parsed or raw pipeline layout stage owns MTP layers."""
+    if isinstance(layout, str):
+        layout = PipelineParallelLayerLayout.from_str(layout, pp_size)
+
+    if isinstance(layout, PipelineParallelLayerLayout):
+        stage_layout = layout.layout[pp_rank][vp_stage]
+    elif isinstance(layout, list):
+        stage_layout = layout[vp_stage * pp_size + pp_rank]
+    else:
+        return False
+
+    return any(
+        layer == "mtp" or layer == LayerType.mtp or getattr(layer, "name", None) == "mtp" for layer in stage_layout
+    )
+
+
+def _current_pp_stage_has_mtp(cfg: ConfigContainer, *, pg_collection) -> bool:
+    """Return whether the current PP/VPP stage owns the configured MTP block."""
+    model_cfg = getattr(cfg, "model", None)
+    layout = getattr(model_cfg, "pipeline_model_parallel_layout", None)
+    if layout is None:
+        return False
+
+    pp_group = getattr(pg_collection, "pp", None)
+    pp_rank = _get_pp_group_rank(pp_group)
+    pp_size = _get_pp_group_size(pp_group, cfg)
+    vp_stage = parallel_state.get_virtual_pipeline_model_parallel_rank()
+    if vp_stage is None:
+        vp_stage = 0
+
+    return _layout_stage_has_mtp(layout, pp_rank=pp_rank, pp_size=pp_size, vp_stage=vp_stage)
+
+
+def _current_pp_stage_needs_mtp_inputs(cfg: ConfigContainer, *, pg_collection, is_last: bool) -> bool:
+    """Return whether this stage needs token ids for MTP embedding lookup."""
+    model_cfg = getattr(cfg, "model", None)
+    layout = getattr(model_cfg, "pipeline_model_parallel_layout", None)
+    if layout is None:
+        return is_last
+
+    return _current_pp_stage_has_mtp(cfg, pg_collection=pg_collection)
 
 
 def _partition_packed_batch_for_cp(batch: dict[str, torch.Tensor], cp_size: int) -> dict[str, torch.Tensor]:
@@ -191,12 +253,15 @@ def get_batch(
     is_last = is_pp_last_stage(pg_collection.pp)
     is_middle = (not is_first) and (not is_last)
     include_full_batch_fields = is_middle and _middle_pp_stage_needs_batch(cfg)
-    if is_middle and not include_full_batch_fields:
+    include_mtp_inputs = use_mtp and _current_pp_stage_needs_mtp_inputs(
+        cfg, pg_collection=pg_collection, is_last=is_last
+    )
+    if is_middle and not include_full_batch_fields and not include_mtp_inputs:
         return None, None, None, None, None, None, None, None, None, None
 
     batch = get_batch_from_iterator(
         data_iterator,
-        use_mtp,
+        include_mtp_inputs,
         getattr(cfg.dataset, "skip_getting_attention_mask_from_dataset", True),
         is_first_pp_stage=is_first,
         is_last_pp_stage=is_last,

--- a/src/megatron/bridge/training/gpt_step.py
+++ b/src/megatron/bridge/training/gpt_step.py
@@ -26,6 +26,8 @@ from megatron.core.transformer.pipeline_parallel_layer_layout import PipelinePar
 from megatron.core.utils import (
     get_batch_on_this_cp_rank,
     get_model_config,
+    get_pg_rank,
+    get_pg_size,
     is_te_min_version,
     unwrap_model,
 )
@@ -59,22 +61,6 @@ def _middle_pp_stage_needs_batch(cfg: ConfigContainer) -> bool:
     return uses_custom_attention_mask or _uses_packed_sequence_metadata(cfg)
 
 
-def _get_pp_group_rank(pp_group) -> int:
-    """Return this rank's index within the pipeline-parallel group."""
-    if pp_group is not None and hasattr(pp_group, "rank"):
-        return pp_group.rank()
-    return parallel_state.get_pipeline_model_parallel_rank()
-
-
-def _get_pp_group_size(pp_group, cfg: ConfigContainer) -> int:
-    """Return the pipeline-parallel group size."""
-    if pp_group is not None and hasattr(pp_group, "size"):
-        return pp_group.size()
-
-    model_cfg = getattr(cfg, "model", None)
-    return getattr(model_cfg, "pipeline_model_parallel_size", 1)
-
-
 def _layout_stage_has_mtp(layout, *, pp_rank: int, pp_size: int, vp_stage: int) -> bool:
     """Return whether a parsed or raw pipeline layout stage owns MTP layers."""
     if isinstance(layout, str):
@@ -100,8 +86,8 @@ def _current_pp_stage_has_mtp(cfg: ConfigContainer, *, pg_collection) -> bool:
         return False
 
     pp_group = getattr(pg_collection, "pp", None)
-    pp_rank = _get_pp_group_rank(pp_group)
-    pp_size = _get_pp_group_size(pp_group, cfg)
+    pp_rank = get_pg_rank(pp_group)
+    pp_size = get_pg_size(pp_group)
     vp_stage = parallel_state.get_virtual_pipeline_model_parallel_rank()
     if vp_stage is None:
         vp_stage = 0
@@ -167,7 +153,7 @@ def _partition_packed_batch_for_cp(batch: dict[str, torch.Tensor], cp_size: int)
 
 def get_batch_from_iterator(
     data_iterator: Iterable,
-    use_mtp: bool = False,
+    include_mtp_inputs: bool = False,
     skip_getting_attention_mask_from_dataset: bool = True,
     *,
     is_first_pp_stage: bool,
@@ -178,7 +164,7 @@ def get_batch_from_iterator(
 
     Args:
         data_iterator: The data iterator to get the batch from.
-        use_mtp: Whether Multi-Token Prediction layers are enabled.
+        include_mtp_inputs: Whether this PP stage needs Multi-Token Prediction input tensors.
         skip_getting_attention_mask_from_dataset: If set, the dataset will pass a None attention mask.
         include_full_batch_fields: Whether to include all standard training tensors regardless of PP stage.
 
@@ -205,7 +191,7 @@ def get_batch_from_iterator(
             required_host_keys.add("cu_seqlens_unpadded_argmin")
 
     if not include_full_batch_fields:
-        if is_first_pp_stage or use_mtp:
+        if is_first_pp_stage or include_mtp_inputs:
             required_device_keys.update(("tokens", "position_ids"))
         if is_last_pp_stage:
             required_device_keys.update(("labels", "loss_mask"))
@@ -261,8 +247,10 @@ def get_batch(
 
     batch = get_batch_from_iterator(
         data_iterator,
-        include_mtp_inputs,
-        getattr(cfg.dataset, "skip_getting_attention_mask_from_dataset", True),
+        include_mtp_inputs=include_mtp_inputs,
+        skip_getting_attention_mask_from_dataset=getattr(
+            cfg.dataset, "skip_getting_attention_mask_from_dataset", True
+        ),
         is_first_pp_stage=is_first,
         is_last_pp_stage=is_last,
         include_full_batch_fields=include_full_batch_fields,

--- a/tests/unit_tests/training/test_gpt_step.py
+++ b/tests/unit_tests/training/test_gpt_step.py
@@ -115,6 +115,10 @@ def _set_last_pp_stage(monkeypatch):
     monkeypatch.setattr("megatron.bridge.training.gpt_step.is_pp_last_stage", lambda pg: True)
 
 
+def _set_distributed_initialized(monkeypatch):
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: True)
+
+
 class _NoopTimer:
     def __call__(self, *args, **kwargs):
         return self
@@ -213,6 +217,7 @@ class TestGetBatch:
     def test_middle_pp_stage_without_mtp_keeps_fast_path_when_mtp_enabled(self, monkeypatch):
         """Global MTP does not force ordinary middle PP stages to load a batch."""
         _set_middle_pp_stage(monkeypatch)
+        _set_distributed_initialized(monkeypatch)
         data_iterator = MagicMock()
 
         result = get_batch(
@@ -232,6 +237,7 @@ class TestGetBatch:
     def test_standalone_mtp_middle_pp_stage_loads_tokens_and_position_ids(self, monkeypatch):
         """A middle PP stage that owns MTP receives input ids for MCore MTP."""
         _set_middle_pp_stage(monkeypatch)
+        _set_distributed_initialized(monkeypatch)
         monkeypatch.setattr(
             "megatron.bridge.training.gpt_step.get_batch_on_this_cp_rank",
             lambda batch, is_hybrid_cp=False, cp_group=None, hybrid_cp_group_func=None: batch,
@@ -289,6 +295,7 @@ class TestGetBatch:
     def test_standalone_mtp_loss_stage_skips_mtp_inputs(self, monkeypatch):
         """The loss-only final PP stage does not load token ids for standalone MTP."""
         _set_last_pp_stage(monkeypatch)
+        _set_distributed_initialized(monkeypatch)
         monkeypatch.setattr(
             "megatron.bridge.training.gpt_step.get_batch_on_this_cp_rank",
             lambda batch, is_hybrid_cp=False, cp_group=None, hybrid_cp_group_func=None: batch,

--- a/tests/unit_tests/training/test_gpt_step.py
+++ b/tests/unit_tests/training/test_gpt_step.py
@@ -46,23 +46,25 @@ class _Iterator:
 
 
 class _MockProcessGroup:
+    def __init__(self, rank=0, size=1):
+        self._rank = rank
+        self._size = size
+
     def rank(self):
-        return 0
+        return self._rank
 
     def size(self):
-        return 1
+        return self._size
 
 
 class _MockPGCollection:
-    def __init__(self, cp_size=1):
-        self.pp = _MockProcessGroup()
+    def __init__(self, cp_size=1, pp_rank=0, pp_size=1):
+        self.pp = _MockProcessGroup(rank=pp_rank, size=pp_size)
         self._cp_size = cp_size
 
     @property
     def cp(self):
-        pg = _MockProcessGroup()
-        pg.size = lambda: self._cp_size
-        return pg
+        return _MockProcessGroup(size=self._cp_size)
 
 
 class _NoCudaTensor(torch.Tensor):
@@ -74,7 +76,14 @@ def _as_nocuda(tensor):
     return tensor.as_subclass(_NoCudaTensor)
 
 
-def _make_cfg(*, packed_sequence_specs=None, skip_getting_attention_mask_from_dataset=True):
+def _make_cfg(
+    *,
+    packed_sequence_specs=None,
+    skip_getting_attention_mask_from_dataset=True,
+    pipeline_model_parallel_layout=None,
+    pipeline_model_parallel_size=1,
+    mtp_num_layers=0,
+):
     cfg = type("Cfg", (), {})()
     cfg.dataset = type(
         "D",
@@ -84,12 +93,26 @@ def _make_cfg(*, packed_sequence_specs=None, skip_getting_attention_mask_from_da
             "skip_getting_attention_mask_from_dataset": skip_getting_attention_mask_from_dataset,
         },
     )()
+    cfg.model = type(
+        "M",
+        (),
+        {
+            "pipeline_model_parallel_layout": pipeline_model_parallel_layout,
+            "pipeline_model_parallel_size": pipeline_model_parallel_size,
+            "mtp_num_layers": mtp_num_layers,
+        },
+    )()
     return cfg
 
 
 def _set_middle_pp_stage(monkeypatch):
     monkeypatch.setattr("megatron.bridge.training.gpt_step.is_pp_first_stage", lambda pg: False)
     monkeypatch.setattr("megatron.bridge.training.gpt_step.is_pp_last_stage", lambda pg: False)
+
+
+def _set_last_pp_stage(monkeypatch):
+    monkeypatch.setattr("megatron.bridge.training.gpt_step.is_pp_first_stage", lambda pg: False)
+    monkeypatch.setattr("megatron.bridge.training.gpt_step.is_pp_last_stage", lambda pg: True)
 
 
 class _NoopTimer:
@@ -186,6 +209,130 @@ class TestGetBatch:
 
         assert result == (None, None, None, None, None, None, None, None, None, None)
         data_iterator.__next__.assert_not_called()
+
+    def test_middle_pp_stage_without_mtp_keeps_fast_path_when_mtp_enabled(self, monkeypatch):
+        """Global MTP does not force ordinary middle PP stages to load a batch."""
+        _set_middle_pp_stage(monkeypatch)
+        data_iterator = MagicMock()
+
+        result = get_batch(
+            data_iterator,
+            _make_cfg(
+                pipeline_model_parallel_layout=[["embedding", "decoder"], ["decoder"], ["mtp"], ["loss"]],
+                pipeline_model_parallel_size=4,
+                mtp_num_layers=1,
+            ),
+            use_mtp=True,
+            pg_collection=_MockPGCollection(pp_rank=1, pp_size=4),
+        )
+
+        assert result == (None, None, None, None, None, None, None, None, None, None)
+        data_iterator.__next__.assert_not_called()
+
+    def test_standalone_mtp_middle_pp_stage_loads_tokens_and_position_ids(self, monkeypatch):
+        """A middle PP stage that owns MTP receives input ids for MCore MTP."""
+        _set_middle_pp_stage(monkeypatch)
+        monkeypatch.setattr(
+            "megatron.bridge.training.gpt_step.get_batch_on_this_cp_rank",
+            lambda batch, is_hybrid_cp=False, cp_group=None, hybrid_cp_group_func=None: batch,
+        )
+        monkeypatch.setattr(
+            "megatron.bridge.training.gpt_step.parallel_state.get_virtual_pipeline_model_parallel_rank",
+            lambda: None,
+        )
+
+        tokens = _as_nocuda(torch.tensor([[1, 2, 3, 4]]))
+        labels = _as_nocuda(torch.tensor([[2, 3, 4, 5]]))
+        loss_mask = _as_nocuda(torch.ones(1, 4))
+        position_ids = _as_nocuda(torch.arange(4).unsqueeze(0))
+        batch = {
+            "tokens": tokens,
+            "labels": labels,
+            "loss_mask": loss_mask,
+            "attention_mask": None,
+            "position_ids": position_ids,
+        }
+
+        (
+            out_tokens,
+            out_labels,
+            out_loss_mask,
+            out_attention_mask,
+            out_position_ids,
+            out_cu_seqlens,
+            out_cu_seqlens_argmin,
+            out_max_seqlen,
+            out_cu_seqlens_unpadded,
+            out_cu_seqlens_unpadded_argmin,
+        ) = get_batch(
+            _Iterator(batch),
+            _make_cfg(
+                pipeline_model_parallel_layout=[["embedding", "decoder"], ["decoder"], ["mtp"], ["loss"]],
+                pipeline_model_parallel_size=4,
+                mtp_num_layers=1,
+            ),
+            use_mtp=True,
+            pg_collection=_MockPGCollection(pp_rank=2, pp_size=4),
+        )
+
+        assert torch.equal(out_tokens, tokens)
+        assert out_labels is None
+        assert out_loss_mask is None
+        assert out_attention_mask is None
+        assert torch.equal(out_position_ids, position_ids)
+        assert out_cu_seqlens is None
+        assert out_cu_seqlens_argmin is None
+        assert out_max_seqlen is None
+        assert out_cu_seqlens_unpadded is None
+        assert out_cu_seqlens_unpadded_argmin is None
+
+    def test_standalone_mtp_loss_stage_skips_mtp_inputs(self, monkeypatch):
+        """The loss-only final PP stage does not load token ids for standalone MTP."""
+        _set_last_pp_stage(monkeypatch)
+        monkeypatch.setattr(
+            "megatron.bridge.training.gpt_step.get_batch_on_this_cp_rank",
+            lambda batch, is_hybrid_cp=False, cp_group=None, hybrid_cp_group_func=None: batch,
+        )
+        monkeypatch.setattr(
+            "megatron.bridge.training.gpt_step.parallel_state.get_virtual_pipeline_model_parallel_rank",
+            lambda: None,
+        )
+
+        tokens = _as_nocuda(torch.tensor([[1, 2, 3, 4]]))
+        labels = _as_nocuda(torch.tensor([[2, 3, 4, 5]]))
+        loss_mask = _as_nocuda(torch.ones(1, 4))
+        position_ids = _as_nocuda(torch.arange(4).unsqueeze(0))
+        batch = {
+            "tokens": tokens,
+            "labels": labels,
+            "loss_mask": loss_mask,
+            "attention_mask": None,
+            "position_ids": position_ids,
+        }
+
+        (
+            out_tokens,
+            out_labels,
+            out_loss_mask,
+            out_attention_mask,
+            out_position_ids,
+            *_,
+        ) = get_batch(
+            _Iterator(batch),
+            _make_cfg(
+                pipeline_model_parallel_layout=[["embedding", "decoder"], ["decoder"], ["mtp"], ["loss"]],
+                pipeline_model_parallel_size=4,
+                mtp_num_layers=1,
+            ),
+            use_mtp=True,
+            pg_collection=_MockPGCollection(pp_rank=3, pp_size=4),
+        )
+
+        assert out_tokens is None
+        assert torch.equal(out_labels, labels)
+        assert torch.equal(out_loss_mask, loss_mask)
+        assert out_attention_mask is None
+        assert out_position_ids is None
 
     def test_forward_common_passes_packed_seq_params_on_middle_pp_stage(self, monkeypatch):
         """Forward path must pass packed metadata on middle PP stages."""


### PR DESCRIPTION
# What does this PR do?

Fixes an internally reported standalone MTP pipeline-layout issue in GPT batch routing.

When a custom pipeline layout places an MTP block on its own stage, that stage needs token and position metadata to build the MTP forward inputs. The previous middle-pipeline fast path returned all `None` values, so the standalone MTP stage could not receive the needed inputs.

This change updates GPT batch routing so:

- a pipeline stage that owns an MTP block receives `tokens` and `position_ids`;
- ordinary middle pipeline stages keep the existing all-`None` fast path;
- the standalone loss-only final stage does not receive unnecessary MTP inputs.

# Changelog

- Route GPT batches based on MTP-stage needs in addition to first/last pipeline-stage ownership.
- Preserve the existing non-MTP middle-stage fast path.
- Add targeted unit coverage for standalone MTP stage routing and loss-only final-stage behavior.

# Verification

- `uv run --no-sync pre-commit run --all-files`
- `uv run --no-sync python -m pytest tests/unit_tests/training/test_gpt_step.py -v`
- Targeted multi-GPU standalone-MTP mock pretraining completed 5/5 iterations with MTP loss logged and zero skipped/nan iterations.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation? No public docs needed.
- [x] Does the PR affect components that are optional to install? No.
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
