### PR TITLE
[model] fix: guard GLM fused expert detection

### DIFF
--- a/src/megatron/bridge/models/glm/glm45_bridge.py
+++ b/src/megatron/bridge/models/glm/glm45_bridge.py
@@ -301,36 +301,23 @@ class GLM45Bridge(MegatronModelBridge):
 
         return MegatronMappingRegistry(*mapping_list)
 
-    def _hf_source_and_keys(self):
-        """Return HF state source and cached key order for expert-mapping helpers."""
-        hf_source = self.hf_pretrained.state.source
-        if getattr(self, "_cached_hf_state_source", None) is not hf_source:
-            self._cached_hf_state_source = hf_source
-            self._cached_hf_keys = hf_source.get_all_keys()
-        return hf_source, self._cached_hf_keys
+    def _hf_state_source(self):
+        """Return HF state source when mappings can inspect checkpoint weights."""
+        hf_state = getattr(self.hf_pretrained, "state", None)
+        if hf_state is None:
+            return None
+        return getattr(hf_state, "source", None)
 
     def _uses_fused_experts(self) -> bool:
-        hf_source, hf_keys = self._hf_source_and_keys()
-        if hf_keys:
-            if any("mlp.experts.gate_up_proj" in key for key in hf_keys) or any(
-                "mlp.experts.down_proj" in key for key in hf_keys
-            ):
-                return True
-
-        if hf_source is not None:
-            return hf_source.has_glob("*mlp.experts.gate_up_proj*") or hf_source.has_glob("*mlp.experts.down_proj*")
-
-        # Config-only path (no HF weights to inspect): GLM 4.5 HuggingFace models
-        # always use fused expert weights (gate_up_proj / down_proj), so default True.
-        return True
+        hf_source = self._hf_state_source()
+        return bool(
+            hf_source is not None
+            and (hf_source.has_glob("*mlp.experts.gate_up_proj*") or hf_source.has_glob("*mlp.experts.down_proj*"))
+        )
 
     def _hf_expert_suffix(self, base_name: str) -> str:
-        hf_source, hf_keys = self._hf_source_and_keys()
-        if any(f"{base_name}.weight" in key for key in hf_keys):
-            return ".weight"
-
+        hf_source = self._hf_state_source()
         if hf_source is not None and hf_source.has_glob(f"*{base_name}.weight"):
             return ".weight"
 
-        # Config-only path: GLM 4.5 fused expert tensors have no .weight suffix.
         return ""

--- a/src/megatron/bridge/models/glm_vl/glm_45v_bridge.py
+++ b/src/megatron/bridge/models/glm_vl/glm_45v_bridge.py
@@ -202,32 +202,22 @@ class GLM45VBridge(MegatronModelBridge):
             )
         return MegatronMappingRegistry(*mapping_list)
 
-    def _hf_source_and_keys(self):
-        """Return HF state source and cached key order for expert-mapping helpers."""
-        hf_source = self.hf_pretrained.state.source
-        if getattr(self, "_cached_hf_state_source", None) is not hf_source:
-            self._cached_hf_state_source = hf_source
-            self._cached_hf_keys = hf_source.get_all_keys()
-        return hf_source, self._cached_hf_keys
+    def _hf_state_source(self):
+        """Return HF state source when mappings can inspect checkpoint weights."""
+        hf_state = getattr(self.hf_pretrained, "state", None)
+        if hf_state is None:
+            return None
+        return getattr(hf_state, "source", None)
 
     def _uses_fused_experts(self) -> bool:
-        hf_source, hf_keys = self._hf_source_and_keys()
-        if hf_keys:
-            if any("mlp.experts.gate_up_proj" in key for key in hf_keys) or any(
-                "mlp.experts.down_proj" in key for key in hf_keys
-            ):
-                return True
-
-        if hf_source is not None:
-            return hf_source.has_glob("*mlp.experts.gate_up_proj*") or hf_source.has_glob("*mlp.experts.down_proj*")
-
-        return False
+        hf_source = self._hf_state_source()
+        return bool(
+            hf_source is not None
+            and (hf_source.has_glob("*mlp.experts.gate_up_proj*") or hf_source.has_glob("*mlp.experts.down_proj*"))
+        )
 
     def _hf_expert_suffix(self, base_name: str) -> str:
-        hf_source, hf_keys = self._hf_source_and_keys()
-        if any(f"{base_name}.weight" in key for key in hf_keys):
-            return ".weight"
-
+        hf_source = self._hf_state_source()
         if hf_source is not None and hf_source.has_glob(f"*{base_name}.weight"):
             return ".weight"
 

--- a/tests/functional_tests/test_groups/models/glm/test_glm45_conversion.py
+++ b/tests/functional_tests/test_groups/models/glm/test_glm45_conversion.py
@@ -342,17 +342,7 @@ class TestGLM45Conversion:
             raise
 
     @pytest.mark.run_only_on("GPU")
-    def test_glm45_autoconfig_roundtrip(self, glm45_toy_model_path, tmp_path, monkeypatch):
-        from megatron.bridge.models.glm.glm45_bridge import GLM45Bridge
+    def test_glm45_autoconfig_roundtrip(self, glm45_toy_model_path, tmp_path):
         from tests.functional_tests.utils import autoconfig_roundtrip
 
-        original_hf_source_and_keys = GLM45Bridge._hf_source_and_keys
-
-        def _hf_source_and_keys_for_config_only(self):
-            hf_state = getattr(getattr(self, "hf_pretrained", None), "state", None)
-            if hf_state is not None and hasattr(hf_state, "source"):
-                return original_hf_source_and_keys(self)
-            return None, []
-
-        monkeypatch.setattr(GLM45Bridge, "_hf_source_and_keys", _hf_source_and_keys_for_config_only)
         autoconfig_roundtrip(glm45_toy_model_path, tmp_path)

--- a/tests/unit_tests/models/glm/test_glm45_bridge.py
+++ b/tests/unit_tests/models/glm/test_glm45_bridge.py
@@ -23,6 +23,12 @@ import torch
 from transformers import GenerationConfig
 
 from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge
+from megatron.bridge.models.conversion.param_mapping import (
+    AutoMapping,
+    FusedExpertMapping,
+    FusedGatedExpertMapping,
+    GatedMLPMapping,
+)
 from megatron.bridge.models.glm.glm45_bridge import GLM45Bridge
 from megatron.bridge.models.gpt_provider import GPTModelProvider
 from megatron.bridge.models.hf_pretrained.causal_lm import PreTrainedCausalLM
@@ -30,6 +36,12 @@ from megatron.bridge.models.hf_pretrained.causal_lm import PreTrainedCausalLM
 
 class TestGLM45Bridge:
     """Test cases for GLM45Bridge."""
+
+    @staticmethod
+    def _expert_mappings(registry):
+        return [
+            mapping for mapping in registry.mappings if "mlp.experts" in str(getattr(mapping, "megatron_param", ""))
+        ]
 
     @pytest.fixture
     def glm45_355b_config(self):
@@ -230,6 +242,53 @@ class TestGLM45Bridge:
         # Check LM head mapping
         assert "output_layer.weight" in mapping_dict
         assert mapping_dict["output_layer.weight"] == "lm_head.weight"
+
+    def test_mapping_registry_config_only_uses_unfused_expert_mappings(self, mock_pretrained_355b):
+        """Test config-only bridge builds mappings without HF state and defaults to unfused experts."""
+        bridge = GLM45Bridge()
+        bridge.hf_pretrained = mock_pretrained_355b.config
+        bridge.hf_config = mock_pretrained_355b.config
+        registry = bridge.mapping_registry()
+
+        expert_mappings = self._expert_mappings(registry)
+        assert not any(
+            isinstance(mapping, (FusedGatedExpertMapping, FusedExpertMapping)) for mapping in expert_mappings
+        )
+        assert any(
+            isinstance(mapping, GatedMLPMapping)
+            and mapping.hf_param["gate"] == "model.layers.*.mlp.experts.*.gate_proj.weight"
+            and mapping.hf_param["up"] == "model.layers.*.mlp.experts.*.up_proj.weight"
+            for mapping in expert_mappings
+        )
+        assert any(
+            isinstance(mapping, AutoMapping) and mapping.hf_param == "model.layers.*.mlp.experts.*.down_proj.weight"
+            for mapping in expert_mappings
+        )
+
+    def test_mapping_registry_uses_fused_expert_mappings_from_state_source(self, mock_pretrained_355b):
+        """Test fused expert layout is detected from HF state source without enumerating all keys."""
+        source = mock_pretrained_355b.state.source
+        source.get_all_keys.side_effect = AssertionError("mapping registry should not enumerate all HF keys")
+        source.has_glob.side_effect = lambda pattern: pattern in {
+            "*mlp.experts.gate_up_proj*",
+            "*mlp.experts.down_proj*",
+        }
+
+        bridge = GLM45Bridge()
+        bridge.hf_pretrained = mock_pretrained_355b
+        bridge.hf_config = mock_pretrained_355b.config
+        registry = bridge.mapping_registry()
+
+        expert_mappings = self._expert_mappings(registry)
+        assert any(
+            isinstance(mapping, FusedGatedExpertMapping)
+            and mapping.hf_param == "model.layers.*.mlp.experts.gate_up_proj"
+            for mapping in expert_mappings
+        )
+        assert any(
+            isinstance(mapping, FusedExpertMapping) and mapping.hf_param == "model.layers.*.mlp.experts.down_proj"
+            for mapping in expert_mappings
+        )
 
     def test_dtype_mapping_fp16(self, glm45_355b_config):
         """Test dtype mapping for FP16 models."""

--- a/tests/unit_tests/models/glm_vl/test_glm_45v_bridge.py
+++ b/tests/unit_tests/models/glm_vl/test_glm_45v_bridge.py
@@ -17,6 +17,12 @@ from unittest.mock import Mock
 import pytest
 
 from megatron.bridge.models.conversion.mapping_registry import MegatronMappingRegistry
+from megatron.bridge.models.conversion.param_mapping import (
+    AutoMapping,
+    FusedExpertMapping,
+    FusedGatedExpertMapping,
+    GatedMLPMapping,
+)
 from megatron.bridge.models.glm_vl.glm_45v_bridge import GLM45VBridge
 from megatron.bridge.models.glm_vl.glm_45v_provider import GLM45VModelProvider
 from megatron.bridge.models.hf_pretrained.vlm import PreTrainedVLM
@@ -226,11 +232,67 @@ class TestGLM45VBridgeTokenizerKwargs:
 class TestGLM45VBridgeMappingRegistry:
     """Test mapping_registry method functionality."""
 
+    @staticmethod
+    def _expert_mappings(registry):
+        return [
+            mapping for mapping in registry.mappings if "mlp.experts" in str(getattr(mapping, "megatron_param", ""))
+        ]
+
     def test_mapping_registry_returns_correct_type(self, glm_45v_bridge):
         """Test mapping_registry returns MegatronMappingRegistry."""
         registry = glm_45v_bridge.mapping_registry()
 
         assert isinstance(registry, MegatronMappingRegistry)
+
+    def test_mapping_registry_config_only_uses_unfused_expert_mappings(self, mock_hf_config):
+        """Test config-only bridge builds mappings without HF state and defaults to unfused experts."""
+        config_only = Mock(spec=["text_config", "vision_config"])
+        config_only.text_config = mock_hf_config.text_config
+        config_only.vision_config = mock_hf_config.vision_config
+
+        bridge = GLM45VBridge()
+        bridge.hf_pretrained = config_only
+        bridge.hf_config = config_only
+        registry = bridge.mapping_registry()
+
+        expert_mappings = self._expert_mappings(registry)
+        assert not any(
+            isinstance(mapping, (FusedGatedExpertMapping, FusedExpertMapping)) for mapping in expert_mappings
+        )
+        assert any(
+            isinstance(mapping, GatedMLPMapping)
+            and mapping.hf_param["gate"] == "model.language_model.layers.*.mlp.experts.*.gate_proj.weight"
+            and mapping.hf_param["up"] == "model.language_model.layers.*.mlp.experts.*.up_proj.weight"
+            for mapping in expert_mappings
+        )
+        assert any(
+            isinstance(mapping, AutoMapping)
+            and mapping.hf_param == "model.language_model.layers.*.mlp.experts.*.down_proj.weight"
+            for mapping in expert_mappings
+        )
+
+    def test_mapping_registry_uses_fused_expert_mappings_from_state_source(self, glm_45v_bridge, mock_hf_pretrained):
+        """Test fused expert layout is detected from HF state source without enumerating all keys."""
+        source = mock_hf_pretrained.state.source
+        source.get_all_keys.side_effect = AssertionError("mapping registry should not enumerate all HF keys")
+        source.has_glob.side_effect = lambda pattern: pattern in {
+            "*mlp.experts.gate_up_proj*",
+            "*mlp.experts.down_proj*",
+        }
+
+        registry = glm_45v_bridge.mapping_registry()
+
+        expert_mappings = self._expert_mappings(registry)
+        assert any(
+            isinstance(mapping, FusedGatedExpertMapping)
+            and mapping.hf_param == "model.language_model.layers.*.mlp.experts.gate_up_proj"
+            for mapping in expert_mappings
+        )
+        assert any(
+            isinstance(mapping, FusedExpertMapping)
+            and mapping.hf_param == "model.language_model.layers.*.mlp.experts.down_proj"
+            for mapping in expert_mappings
+        )
 
     def test_mapping_registry_contains_required_mappings(self, glm_45v_bridge):
         """Test mapping_registry contains all required parameter mappings."""


### PR DESCRIPTION
## Summary
- Guard GLM 4.5 and GLM 4.5V fused expert layout detection for config-only bridges.
- Detect fused expert checkpoint layouts with `state.source.has_glob()` instead of enumerating all HF keys.
- Default config-only GLM expert mappings to the current unfused HF layout while preserving fused mapping support when checkpoint state indicates fused keys.

## Testing
- `UV_CACHE_DIR=/tmp/uv-cache-mbridge-precommit-tool uv tool run pre-commit run --all-files`
- `uv sync --group test && uv run --no-sync python -m pytest tests/unit_tests/models/glm/test_glm45_bridge.py tests/unit_tests/models/glm_vl/test_glm_45v_bridge.py -q` (43 passed)
