### PR TITLE
[Doc] Document latest Mcore toggle `moe_hybridep_pad_uneven_dispatch_inputs` for HybridEP THD training 

### DIFF
--- a/docs/parallelisms.md
+++ b/docs/parallelisms.md
@@ -223,6 +223,26 @@ model_config = GPTModelProvider(
 
 # Apply HybridEP optimization
 apply_flex_dispatcher_backend(model_config, moe_flex_dispatcher_backend="hybridep")
+
+# Opt in when local dispatch token counts can differ across HybridEP ranks.
+model_config.moe_hybridep_pad_uneven_dispatch_inputs = True
+```
+
+`moe_hybridep_pad_uneven_dispatch_inputs` is an explicit opt-in. Enable it
+when ranks in the HybridEP communication group can enter dispatch with different
+token counts, such as dynamically packed THD batches. HybridEP then takes the
+group-wide maximum token count, aligns it for the kernel, pads each rank before
+dispatch, and removes the padding after combine.
+
+Leave the option disabled when every rank already supplies the same number of
+tokens. Sequence packing alone does not imply that dispatcher inputs are uneven,
+and enabling this path unnecessarily adds a MAX all-reduce and padding overhead.
+The option does not enable HybridEP or sequence packing; configure those
+separately. With `scripts/training/run_recipe.py`, the equivalent trailing CLI
+override is:
+
+```bash
+model.moe_hybridep_pad_uneven_dispatch_inputs=true
 ```
 
 **GPU Architecture Requirements:**

--- a/docs/training/packed-sequences.md
+++ b/docs/training/packed-sequences.md
@@ -67,10 +67,19 @@ The durable constraints for packed sequences in Bridge are:
   evaluation CP constraints and `CP * TP` when sequence parallelism is enabled
 - for fine-tuning with CP enabled, per-token loss behavior and reduction
   settings matter
+- HybridEP users whose local dispatch token counts differ across ranks must
+  explicitly set `model.moe_hybridep_pad_uneven_dispatch_inputs=True`; this
+  pads only to the group-wide aligned maximum before dispatch and trims the
+  padding after combine
 - CUDA-graph-friendly packed metadata requires additional padding constraints
 
 Model-family support is not universal. Some families and recipe paths explicitly
 opt out of packed sequences or related packing modes.
+
+The HybridEP option is not enabled automatically by in-batch packing. Some
+packed datasets already produce equal dispatcher sizes, while variable-sized
+inputs can also occur without sequence packing. Keeping the option explicit
+avoids an unnecessary synchronization and padding cost for equal-sized inputs.
 
 ## Relationship to Long-Sequence Training
 


### PR DESCRIPTION
# What does this PR do ?

Mcore dependency PR should be merged first: 

Mcore dev: https://github.com/NVIDIA/Megatron-LM/pull/5048

Mcore main: 
- https://github.com/NVIDIA/Megatron-LM/pull/4816
- https://github.com/NVIDIA/Megatron-LM/pull/5008

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
