### PR TITLE
Allow mtp_num_layers to be None

### DIFF
--- a/src/megatron/bridge/models/mamba/mamba_provider.py
+++ b/src/megatron/bridge/models/mamba/mamba_provider.py
@@ -182,7 +182,7 @@ class MambaModelProvider(TransformerConfig, ModelProviderMixin[MCoreMambaModel])
             # Include the pattern at least once so the MTP block (and its weights)
             # are created even when mtp_num_layers=0.
             if self.mtp_use_repeated_layer:
-                num_pattern_copies = max(1, self.mtp_num_layers)
+                num_pattern_copies = max(1, self.mtp_num_layers or 0)
             else:
                 num_pattern_copies = self.mtp_num_layers
             self.hybrid_layer_pattern = (

--- a/src/megatron/bridge/models/mamba/mamba_provider.py
+++ b/src/megatron/bridge/models/mamba/mamba_provider.py
@@ -137,7 +137,7 @@ class MambaModelProvider(TransformerConfig, ModelProviderMixin[MCoreMambaModel])
     _pg_collection: Optional[ProcessGroupCollection] = None
 
     # MTP
-    mtp_num_layers: int = 0
+    mtp_num_layers: int | None = 0
     mtp_hybrid_override_pattern: Optional[str] = None
     keep_mtp_spec_in_bf16: bool = False
 

--- a/src/megatron/bridge/models/mamba/mamba_provider.py
+++ b/src/megatron/bridge/models/mamba/mamba_provider.py
@@ -184,7 +184,7 @@ class MambaModelProvider(TransformerConfig, ModelProviderMixin[MCoreMambaModel])
             if self.mtp_use_repeated_layer:
                 num_pattern_copies = max(1, self.mtp_num_layers or 0)
             else:
-                num_pattern_copies = self.mtp_num_layers
+                num_pattern_copies = self.mtp_num_layers or 0
             self.hybrid_layer_pattern = (
                 main_pattern + sep + sep.join([self.mtp_hybrid_override_pattern] * num_pattern_copies)
             )

--- a/tests/unit_tests/models/mamba/test_mamba_provider.py
+++ b/tests/unit_tests/models/mamba/test_mamba_provider.py
@@ -315,3 +315,50 @@ class TestMambaModelProvider:
 
         assert provider.num_layers == 9
         mock_finalize.assert_called_once_with(provider)
+
+    def test_finalize_mtp_num_layers_none_with_repeated_layer(self):
+        """finalize must not crash when mtp_num_layers is None and mtp_use_repeated_layer is True.
+
+        With repeated layers the shared MTP block is always materialized at least once,
+        so a None mtp_num_layers must be coerced to 0 before the max(1, ...) clamp.
+        """
+        sep = mamba_provider.Symbols.MTP_SEPARATOR
+        provider = MambaModelProvider(
+            hidden_size=128,
+            num_attention_heads=1,
+            hybrid_layer_pattern="M-M-M-M-",
+            mtp_hybrid_override_pattern="M*",
+            mtp_num_layers=None,
+            mtp_use_repeated_layer=True,
+        )
+
+        with patch.object(mamba_provider.TransformerConfig, "finalize", autospec=True):
+            provider.finalize()
+
+        # The shared MTP block is included exactly once (max(1, None or 0) == 1).
+        assert provider.hybrid_layer_pattern == "M-M-M-M-" + sep + "M*"
+        # mtp_num_layers is inferred from the constructed pattern rather than left as None.
+        assert provider.mtp_num_layers is not None
+
+    def test_finalize_mtp_num_layers_none_without_repeated_layer(self):
+        """finalize must not crash when mtp_num_layers is None and mtp_use_repeated_layer is False.
+
+        Without repeated layers the copy count is mtp_num_layers directly; a None value must be
+        coerced to 0 so the pattern construction (`[pattern] * count`) does not raise TypeError.
+        """
+        sep = mamba_provider.Symbols.MTP_SEPARATOR
+        provider = MambaModelProvider(
+            hidden_size=128,
+            num_attention_heads=1,
+            hybrid_layer_pattern="M-M-M-M-",
+            mtp_hybrid_override_pattern="M*",
+            mtp_num_layers=None,
+            mtp_use_repeated_layer=False,
+        )
+
+        with patch.object(mamba_provider.TransformerConfig, "finalize", autospec=True):
+            provider.finalize()
+
+        # Zero copies of the MTP block are appended (None or 0 == 0).
+        assert provider.hybrid_layer_pattern == "M-M-M-M-" + sep
+        assert provider.mtp_num_layers is None


### PR DESCRIPTION
# What does this PR do ?

Previously, there would be an error if mtp_num_layers were set to None at runtime.

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
