### PR TITLE
fix: Fix Gemma3-VL HF↔Megatron conversion for transformers ≥ 5.8

### DIFF
--- a/src/megatron/bridge/models/gemma_vl/gemma3_vl_bridge.py
+++ b/src/megatron/bridge/models/gemma_vl/gemma3_vl_bridge.py
@@ -80,7 +80,10 @@ class Gemma3VLBridge(MegatronModelBridge):
         provider.autocast_dtype = torch.bfloat16
         provider.make_vocab_size_divisible_by = 128
 
-        # Vision configuration
+        # Vision configuration — always disable the pooling head so the checkpoint
+        # and the reconstructed model are consistent (vision_use_head is absent in
+        # the default SiglipVisionConfig, which would otherwise default to True).
+        vision_config.vision_use_head = False
         provider.vision_config = vision_config
         provider.mm_tokens_per_image = hf_config.mm_tokens_per_image
 
@@ -132,7 +135,7 @@ class Gemma3VLBridge(MegatronModelBridge):
             [
                 ReplicatedMapping(
                     megatron_param="vision_tower.**",
-                    hf_param="vision_tower.**",
+                    hf_param="vision_tower.vision_model.**",
                 ),
                 AutoMapping(
                     megatron_param="multi_modal_projector.proj.weight",

--- a/src/megatron/bridge/models/gemma_vl/modeling_gemma3_vl.py
+++ b/src/megatron/bridge/models/gemma_vl/modeling_gemma3_vl.py
@@ -91,7 +91,13 @@ class Gemma3VLModel(MegatronModule):
         self.post_process = post_process
         self.vp_stage = vp_stage
         if pre_process:
-            self.vision_tower = AutoModel.from_config(config.vision_config)
+            # Unwrap SiglipVisionModel → SiglipVisionTransformer so vision_tower params are
+            # always flat (vision_tower.embeddings.*), matching the bridge mapping that maps
+            # megatron vision_tower.** → HF vision_tower.vision_model.**.
+            _vc = config.vision_config
+            _vc.vision_use_head = False
+            _raw_vision = AutoModel.from_config(_vc)
+            self.vision_tower = getattr(_raw_vision, "vision_model", _raw_vision)
             self.multi_modal_projector = Gemma3VLMultimodalProjector(config.vision_projector_config)
             # Ensure HF visual tower params are marked for TP grad sync and future assignments are hooked.
             hook_hf_module_setattr_for_tp_grad_sync(self.vision_tower)

--- a/tests/unit_tests/models/gemma_vl/test_gemma3_vl_bridge.py
+++ b/tests/unit_tests/models/gemma_vl/test_gemma3_vl_bridge.py
@@ -166,6 +166,7 @@ class TestGemma3VLBridgeProviderBridge:
 
         # Check vision config
         assert isinstance(provider.vision_config, SiglipVisionConfig)
+        assert provider.vision_config.vision_use_head is False
         assert provider.mm_tokens_per_image == 256
 
     def test_provider_bridge_vision_projector_config(self, gemma3_vl_bridge, mock_hf_pretrained):

--- a/tests/unit_tests/models/gemma_vl/test_gemma3_vl_bridge.py
+++ b/tests/unit_tests/models/gemma_vl/test_gemma3_vl_bridge.py
@@ -263,20 +263,26 @@ class TestGemma3VLBridgeMappingRegistry:
         """Test mapping_registry handles vision tower parameters correctly."""
         registry = gemma3_vl_bridge.mapping_registry()
 
-        # Should contain vision tower parameter mappings
-        mappings = registry.mappings
-        mapping_names = []
-        for mapping in mappings:
-            if hasattr(mapping, "megatron_param"):
-                mapping_names.append(str(getattr(mapping, "megatron_param")))
-            hf = getattr(mapping, "hf_param", None)
-            if isinstance(hf, dict):
-                mapping_names.extend([str(v) for v in hf.values()])
-            elif isinstance(hf, str):
-                mapping_names.append(hf)
+        # Find the ReplicatedMapping for vision_tower
+        from megatron.bridge.models.conversion.param_mapping import ReplicatedMapping
 
-        has_vision_tower = any("vision_tower" in name for name in mapping_names)
-        assert has_vision_tower, "Should contain vision tower parameter mappings"
+        vision_mappings = [
+            m
+            for m in registry.mappings
+            if isinstance(m, ReplicatedMapping) and "vision_tower" in str(getattr(m, "megatron_param", ""))
+        ]
+        assert len(vision_mappings) == 1, "Should have exactly one ReplicatedMapping for vision_tower"
+
+        vt_mapping = vision_mappings[0]
+        assert str(vt_mapping.megatron_param) == "vision_tower.**", (
+            "Megatron vision_tower param should use wildcard"
+        )
+        # Critical: HF param must include the vision_model.* wrapper present in the
+        # google/gemma-3-4b-it checkpoint (old format keys from SiglipVisionModel).
+        # Without this, all ~11,800 vision_tower keys fail to load.
+        assert str(vt_mapping.hf_param) == "vision_tower.vision_model.**", (
+            "HF param must map through vision_model.** to match SiglipVisionModel checkpoint keys"
+        )
 
     def test_mapping_registry_multimodal_projector_params(self, gemma3_vl_bridge):
         """Test mapping_registry handles multimodal projector parameters correctly."""

--- a/tests/unit_tests/models/gemma_vl/test_gemma3_vl_bridge.py
+++ b/tests/unit_tests/models/gemma_vl/test_gemma3_vl_bridge.py
@@ -274,12 +274,7 @@ class TestGemma3VLBridgeMappingRegistry:
         assert len(vision_mappings) == 1, "Should have exactly one ReplicatedMapping for vision_tower"
 
         vt_mapping = vision_mappings[0]
-        assert str(vt_mapping.megatron_param) == "vision_tower.**", (
-            "Megatron vision_tower param should use wildcard"
-        )
-        # Critical: HF param must include the vision_model.* wrapper present in the
-        # google/gemma-3-4b-it checkpoint (old format keys from SiglipVisionModel).
-        # Without this, all ~11,800 vision_tower keys fail to load.
+        assert str(vt_mapping.megatron_param) == "vision_tower.**", "Megatron vision_tower param should use wildcard"
         assert str(vt_mapping.hf_param) == "vision_tower.vision_model.**", (
             "HF param must map through vision_model.** to match SiglipVisionModel checkpoint keys"
         )


### PR DESCRIPTION
## Summary

Fixes conversion bugs that surface when running Gemma3-VL conversion with transformers 5.8+
, all rooted in a structural change to `SiglipVisionModel`
introduced in that release.

- **Bug 1 (import — wrong weight mapping):** `ReplicatedMapping` used `hf_param="vision_tower.**"`
  but the HF checkpoint stores vision weights under `vision_tower.vision_model.**`. In transformers
  ≤ 5.6, `SiglipVisionModel` wrapped a `SiglipVisionTransformer` as `self.vision_model`, making
  Megatron's `vision_tower` params naturally carry the `vision_model.*` prefix — accidentally
  matching the checkpoint. In 5.8 the wrapper was removed (flat layout), breaking the accidental
  alignment and causing 11,800+ "no mapping found" warnings. Fix: corrected `hf_param` to
  `"vision_tower.vision_model.**"` and unwrap the transformer in `Gemma3VLModel.__init__` via
  `getattr(_raw_vision, "vision_model", _raw_vision)` so Megatron always stores flat params
  regardless of transformers version.

- **Bug 2 (export — phantom `head.probe` key):** transformers 5.8 added `use_head` logic to
  `SiglipVisionModel`: when `vision_use_head` is absent from config it defaults to `True`, adding
  a `SiglipMultiheadAttentionPoolingHead`. Since `vision_use_head=False` is not part of the
  default `SiglipVisionConfig` schema it is silently dropped after OmegaConf round-trips
  `run_config.yaml`, causing the reconstructed model during export to include `head.probe` in
  its sharded state dict — a key absent from the checkpoint → `KeyError` in
  `_validate_global_shapes`. Fix: set `vision_config.vision_use_head = False` in
  `provider_bridge()` so it is persisted to YAML, with defense-in-depth in
  `Gemma3VLModel.__init__`.
