### PR TITLE
build(deps): exclude CVE codecs (av/imageio/imageio-ffmpeg) from the image

### DIFF
--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -100,10 +100,10 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     if [ "$MCORE_TRIGGERED_TESTING" = "true" ]; then \
         echo "⚙️ MCore testing mode: skipping --locked flag"; \
         uv sync --only-group build && \
-        uv sync --link-mode copy --all-extras --all-groups; \
+        uv sync --link-mode copy --all-extras --all-groups --no-group diffusion; \
     else \
         uv sync --locked --only-group build && \
-        uv sync --link-mode copy --locked --all-extras --all-groups; \
+        uv sync --link-mode copy --locked --all-extras --all-groups --no-group diffusion; \
     fi && \
     # Create symlink for tilelang's libcudart_stub.so to the actual libcudart.so
     # Otherwise, the stub will be called in some cases and fail

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,8 +79,6 @@ dependencies = [
     "diffusers>=0.36.0",
     "peft>=0.18.0",
     "einops",
-    "imageio",
-    "imageio-ffmpeg",
     "omegaconf>=2.3.0",
     "tensorboard>=2.19.0",
     "typing-extensions",
@@ -125,7 +123,9 @@ no-build-isolation-package = [
 ]
 prerelease = "allow"
 override-dependencies = [
-    "av; sys_platform == 'never'",                          # Optional and addresses CVE from transitive dependency
+    "av; sys_platform == 'never'",                          # CVE: WAN-only codec; excluded from build, installed at test time via scripts/install_diffusion_deps.sh
+    "imageio; sys_platform == 'never'",                     # CVE: WAN-only codec; excluded from build, installed at test time via scripts/install_diffusion_deps.sh
+    "imageio-ffmpeg; sys_platform == 'never'",              # CVE: WAN-only codec; excluded from build, installed at test time via scripts/install_diffusion_deps.sh
     "torch; sys_platform == 'never'",
     "torchvision; sys_platform == 'never'",
     "triton; sys_platform == 'never'",
@@ -198,6 +198,14 @@ dev = [
     "mypy>=1.8.0",
 ]
 build = ["setuptools", "torch", "pybind11", "Cython>=3.0.0", "numpy", "ninja", "nvidia-mathdx"]
+# CVE-carrying WAN diffusion codecs, needed only by WAN video caching
+# (src/megatron/bridge/diffusion/models/wan/inference/utils.py). All three are suppressed
+# in the default build by the [tool.uv] override-dependencies above (each marked
+# `sys_platform == 'never'`), so they are never installed and appear only as `never`-marked
+# edges in uv.lock — keeping them out of both the image and SBOM/manifest scans. Install
+# them at test time with scripts/install_diffusion_deps.sh. This group is kept for
+# documentation only; `uv sync --group diffusion` will NOT install them on Linux.
+diffusion = ["imageio", "imageio-ffmpeg", "av"]
 
 [project.entry-points."nemo_run.cli"]
 lm = "megatron.bridge"

--- a/scripts/install_diffusion_deps.sh
+++ b/scripts/install_diffusion_deps.sh
@@ -1,0 +1,27 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/usr/bin/env bash
+# Install the WAN diffusion codecs (imageio, imageio-ffmpeg, av) into the active
+# environment at test time. All three carry CVEs and are excluded from the shipped
+# container via [tool.uv] override-dependencies (each marked `sys_platform == 'never'`),
+# so neither the build nor `uv sync` installs them and they appear only as `never`-marked
+# edges in uv.lock.
+#
+# Install them directly with `uv pip install --no-config`: --no-config ignores the
+# project's [tool.uv] config, so the `sys_platform == 'never'` override does not
+# neutralize the install.
+set -euo pipefail
+
+uv pip install --no-config imageio imageio-ffmpeg av

--- a/src/megatron/bridge/diffusion/models/wan/inference/utils.py
+++ b/src/megatron/bridge/diffusion/models/wan/inference/utils.py
@@ -17,7 +17,6 @@ import binascii
 import os
 import os.path as osp
 
-import imageio
 import torch
 import torchvision
 
@@ -35,6 +34,10 @@ def rand_name(length=8, suffix=""):
 
 
 def cache_video(tensor, save_file=None, fps=30, suffix=".mp4", nrow=8, normalize=True, value_range=(-1, 1), retry=5):  # noqa: D103
+    # imageio lives in the opt-in 'diffusion' dependency group, excluded from the default
+    # container build; import lazily so the module is importable without it installed.
+    import imageio
+
     # cache file
     cache_file = osp.join("/tmp", rand_name(suffix=suffix)) if save_file is None else save_file
 

--- a/tests/unit_tests/Launch_Unit_Tests_Diffusion.sh
+++ b/tests/unit_tests/Launch_Unit_Tests_Diffusion.sh
@@ -25,6 +25,10 @@ if [ -f "/opt/Megatron-Bridge/.mcore_commit_sha" ]; then
 fi
 echo ""
 
+# The 'diffusion' codecs (imageio/imageio-ffmpeg/av) are excluded from the shipped image;
+# install them so the WAN video-caching unit test runs instead of skips.
+bash /opt/Megatron-Bridge/scripts/install_diffusion_deps.sh
+
 CUDA_VISIBLE_DEVICES="0,1" uv run coverage run -a --data-file=/opt/Megatron-Bridge/.coverage --source=/opt/Megatron-Bridge/ -m pytest \
     -o log_cli=true \
     -o log_cli_level=INFO \

--- a/tests/unit_tests/diffusion/model/wan/inference/test_inference_utils.py
+++ b/tests/unit_tests/diffusion/model/wan/inference/test_inference_utils.py
@@ -16,6 +16,7 @@ import argparse
 import os
 import tempfile
 
+import pytest
 import torch
 
 from megatron.bridge.diffusion.models.wan.inference import utils as inf_utils
@@ -81,6 +82,9 @@ def test_cache_image_writes_file(tmp_path):
 
 
 def test_cache_video_uses_writer_and_returns_path(monkeypatch):
+    # imageio lives in the opt-in 'diffusion' group; skip when it is not installed
+    imageio = pytest.importorskip("imageio")
+
     # Stub imageio.get_writer to avoid codec dependency
     calls = {"frames": 0, "path": None}
 
@@ -95,7 +99,7 @@ def test_cache_video_uses_writer_and_returns_path(monkeypatch):
             pass
 
     monkeypatch.setattr(
-        inf_utils.imageio, "get_writer", lambda path, fps, codec, quality: _DummyWriter(path, fps, codec, quality)
+        imageio, "get_writer", lambda path, fps, codec, quality: _DummyWriter(path, fps, codec, quality)
     )
 
     # Stub make_grid to return a fixed CHW tensor regardless of input

--- a/uv.lock
+++ b/uv.lock
@@ -10,6 +10,8 @@ overrides = [
     { name = "av", marker = "sys_platform == 'never'" },
     { name = "cachetools", specifier = ">=5.0.0" },
     { name = "cryptography", specifier = ">=43.0.0,<47" },
+    { name = "imageio", marker = "sys_platform == 'never'" },
+    { name = "imageio-ffmpeg", marker = "sys_platform == 'never'" },
     { name = "langchain", specifier = ">=0.3.28" },
     { name = "langchain-core", specifier = ">=0.3.80" },
     { name = "mlflow", specifier = ">=3.9.0" },
@@ -1476,18 +1478,18 @@ wheels = [
 
 [[package]]
 name = "hf-xet"
-version = "1.5.1.dev1"
+version = "1.5.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d4/3b/56dda5101fa1993de540045f3f2dea7265c157b0a30f6cd784ea0f8d93a8/hf_xet-1.5.1.dev1.tar.gz", hash = "sha256:3a41435a522d55a57295b4c4733fcae1367181e50f4d2d05bf7f01241a02e2c1", size = 870929, upload-time = "2026-05-29T07:44:10.291Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/2d/57fd21d84d93efb4bd0b962383790e19dd1bc053501b4264c97903b4e83e/hf_xet-1.5.1.tar.gz", hash = "sha256:51ef4500dab3764b41135ee1381a4b62ce56fc54d4c92b719b59e597d6df5bf6", size = 876636, upload-time = "2026-06-08T23:02:53.897Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/43/347013398a2b2e58b51df70a50918ee5da9228121f2cf1fd94a92877f3d4/hf_xet-1.5.1.dev1-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:997def01858b5802b56a4b2e6d30ce8ed4587dc570a2554a8fbf02051161e704", size = 7029193, upload-time = "2026-05-29T07:43:36.768Z" },
-    { url = "https://files.pythonhosted.org/packages/96/06/3374926b0d6c13cabb430c9733a7a80748f05c742c82a60c3bab749acc7b/hf_xet-1.5.1.dev1-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:2a66fe763e91372f9814eb5f3c3c4930b82b1f9b75ece7e121c632e37e333ee0", size = 6630649, upload-time = "2026-05-29T07:43:34.93Z" },
-    { url = "https://files.pythonhosted.org/packages/55/7f/65e16a6c7253820e1720e0e83c85013372429c685d9357c58dfb2ea35b07/hf_xet-1.5.1.dev1-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef1ae87d6a084488710e81b571a6ba6952a2ebdefe9b8f00da2f0dc046059187", size = 63701377, upload-time = "2026-05-29T07:43:13.974Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/6a/1f1adebba6bf5531bfa3535e79c516ad5991846bb6013edc8b28f609af18/hf_xet-1.5.1.dev1-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2087e56a398c43b07853374501d7b36f52a39664e291e8336706315e9e8c1d59", size = 58617162, upload-time = "2026-05-29T07:43:09.186Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/93/12983f6296747c3ed40a20ec7ca7cf8c73f701c7f35c51493693f6a1f434/hf_xet-1.5.1.dev1-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:230bc164231e2b6596820013091a3957c076b9a6c659d78427a7e3218383f89c", size = 59099906, upload-time = "2026-05-29T07:43:53.291Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/3c/a1bf3b0f599b3b105f4f6d995a721ffbe3a864c08630bbfe33b7d3584b56/hf_xet-1.5.1.dev1-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6c2579d44f8df992fd9a9c3b32c0c71ef442d7661f2b4205e0a9a9214a269b1a", size = 60690140, upload-time = "2026-05-29T07:43:57.46Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/6b/1daa76c6ae6b4fc89944bada93c179a159ac75015e8ddb9600ed4890dbcc/hf_xet-1.5.1.dev1-cp37-abi3-win_amd64.whl", hash = "sha256:959c953ad47a97b7d36d0b154fa8b87fab2c834cc7275962bbb3ea8baee56527", size = 4028507, upload-time = "2026-05-29T07:44:16.915Z" },
-    { url = "https://files.pythonhosted.org/packages/54/73/a6d5f62fbdccb9f163646ee378991df5f11b42b051d58653bb886bf5140e/hf_xet-1.5.1.dev1-cp37-abi3-win_arm64.whl", hash = "sha256:b50ce272294ab951241ac07e2240d77dffc68c0ed7b9a931a5ed0432da1a106a", size = 3856851, upload-time = "2026-05-29T07:44:15.226Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/d8/5e54cf37434759d1f4f2ba9b66077ff9d4c4e1f37b6bd7975da5c40d94ab/hf_xet-1.5.1-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:6abd35c3221eff63836618ddfb954dcf84798603f71d8e33e3ed7b04acfdbe6e", size = 4077794, upload-time = "2026-06-08T23:02:40.656Z" },
+    { url = "https://files.pythonhosted.org/packages/35/94/4b2ecfbad8f8b04701a23aefb62f540b9137d058b7e1dbef16a32676f0e9/hf_xet-1.5.1-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:94e761bbd266bf4c03cee73753916062665ce8365aa40ed321f45afcb934b41e", size = 3845354, upload-time = "2026-06-08T23:02:42.702Z" },
+    { url = "https://files.pythonhosted.org/packages/de/cc/f99f4bc7295023d7bd9ebbfd51f75cc530ca262c1227666268b8208f4b77/hf_xet-1.5.1-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:892e3a3a3aecc12aded8b93cf4f9cd059282c7de0732f7d55026f3abdf474350", size = 4514864, upload-time = "2026-06-08T23:02:44.497Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/6e/21f7e5a2381278bd3b7b7a5a4d90038518bb6308a0c1daf5d9f8268bb178/hf_xet-1.5.1-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a93df2039190502835b1db8cd7e178b0b7b889fe9ab51299d5ced26e0dd879a4", size = 4303784, upload-time = "2026-06-08T23:02:46.203Z" },
+    { url = "https://files.pythonhosted.org/packages/35/0e/f992bb6927ac1cb30ef74e62268f551f338bc32b2191f7c96a44c6f7283e/hf_xet-1.5.1-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0c97106032ef70467b4f6bc2d0ccc266d7613ee076afc56516c502f87ce1c4a6", size = 4500703, upload-time = "2026-06-08T23:02:47.628Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/d1/90a498d05447980b977b1669246eeeeae4cfb0ea3e7a286eaba627f91bf9/hf_xet-1.5.1-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6208adb15d192b90e4c2ad2a27ed864359b2cb0f2494eb6d7c7f3699ac02e2bf", size = 4719498, upload-time = "2026-06-08T23:02:49.268Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/b6/20f99cfe97cc663a711f7b33cc21d4793e51968e9a26125b4afcd77315ba/hf_xet-1.5.1-cp37-abi3-win_amd64.whl", hash = "sha256:f7b3002f95d1c13e24bcb4537baa8f0eb3838957067c91bb4959bc004a6435f5", size = 4026419, upload-time = "2026-06-08T23:02:50.829Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/fa/77453694888f03e5a8c8852d1514a0894d8e81c622d39edbaf308ea0dcf4/hf_xet-1.5.1-cp37-abi3-win_arm64.whl", hash = "sha256:93d090b57b211133f6c0dab0205ef5cb6d89162979ba75a74845045cc3063b8e", size = 3855178, upload-time = "2026-06-08T23:02:52.452Z" },
 ]
 
 [[package]]
@@ -1650,14 +1652,6 @@ name = "imageio-ffmpeg"
 version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/44/bd/c3343c721f2a1b0c9fc71c1aebf1966a3b7f08c2eea8ed5437a2865611d6/imageio_ffmpeg-0.6.0.tar.gz", hash = "sha256:e2556bed8e005564a9f925bb7afa4002d82770d6b08825078b7697ab88ba1755", size = 25210, upload-time = "2025-01-16T21:34:32.747Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/58/87ef68ac83f4c7690961bce288fd8e382bc5f1513860fc7f90a9c1c1c6bf/imageio_ffmpeg-0.6.0-py3-none-macosx_10_9_intel.macosx_10_9_x86_64.whl", hash = "sha256:9d2baaf867088508d4a3458e61eeb30e945c4ad8016025545f66c4b5aaef0a61", size = 24932969, upload-time = "2025-01-16T21:34:20.464Z" },
-    { url = "https://files.pythonhosted.org/packages/40/5c/f3d8a657d362cc93b81aab8feda487317da5b5d31c0e1fdfd5e986e55d17/imageio_ffmpeg-0.6.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b1ae3173414b5fc5f538a726c4e48ea97edc0d2cdc11f103afee655c463fa742", size = 21113891, upload-time = "2025-01-16T21:34:00.277Z" },
-    { url = "https://files.pythonhosted.org/packages/33/e7/1925bfbc563c39c1d2e82501d8372734a5c725e53ac3b31b4c2d081e895b/imageio_ffmpeg-0.6.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:1d47bebd83d2c5fc770720d211855f208af8a596c82d17730aa51e815cdee6dc", size = 25632706, upload-time = "2025-01-16T21:33:53.475Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/2d/43c8522a2038e9d0e7dbdf3a61195ecc31ca576fb1527a528c877e87d973/imageio_ffmpeg-0.6.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:c7e46fcec401dd990405049d2e2f475e2b397779df2519b544b8aab515195282", size = 29498237, upload-time = "2025-01-16T21:34:13.726Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/13/59da54728351883c3c1d9fca1710ab8eee82c7beba585df8f25ca925f08f/imageio_ffmpeg-0.6.0-py3-none-win32.whl", hash = "sha256:196faa79366b4a82f95c0f4053191d2013f4714a715780f0ad2a68ff37483cc2", size = 19652251, upload-time = "2025-01-16T21:34:06.812Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/c6/fa760e12a2483469e2bf5058c5faff664acf66cadb4df2ad6205b016a73d/imageio_ffmpeg-0.6.0-py3-none-win_amd64.whl", hash = "sha256:02fa47c83703c37df6bfe4896aab339013f62bf02c5ebf2dce6da56af04ffc0a", size = 31246824, upload-time = "2025-01-16T21:34:28.6Z" },
-]
 
 [[package]]
 name = "imagesize"
@@ -2127,8 +2121,6 @@ dependencies = [
     { name = "flashinfer-cubin" },
     { name = "flashinfer-python" },
     { name = "hydra-core" },
-    { name = "imageio" },
-    { name = "imageio-ffmpeg" },
     { name = "megatron-core", extra = ["dev", "mlm"] },
     { name = "mistral-common" },
     { name = "mlflow" },
@@ -2186,6 +2178,11 @@ dev = [
     { name = "pre-commit" },
     { name = "ruff" },
 ]
+diffusion = [
+    { name = "av", marker = "sys_platform == 'never'" },
+    { name = "imageio", marker = "sys_platform == 'never'" },
+    { name = "imageio-ffmpeg", marker = "sys_platform == 'never'" },
+]
 docs = [
     { name = "myst-parser" },
     { name = "nvidia-sphinx-theme" },
@@ -2219,8 +2216,6 @@ requires-dist = [
     { name = "flashinfer-cubin", specifier = "==0.6.8.post1" },
     { name = "flashinfer-python", specifier = "==0.6.8.post1" },
     { name = "hydra-core", specifier = ">1.3,<=1.3.2" },
-    { name = "imageio" },
-    { name = "imageio-ffmpeg" },
     { name = "librosa", marker = "extra == 'audio'" },
     { name = "mamba-ssm", marker = "extra == 'ssm'" },
     { name = "megatron-core", extras = ["dev", "mlm"], editable = "3rdparty/Megatron-LM" },
@@ -2264,6 +2259,11 @@ dev = [
     { name = "mypy", specifier = ">=1.8.0" },
     { name = "pre-commit", specifier = ">=3.6.0" },
     { name = "ruff", specifier = ">=0.9.9" },
+]
+diffusion = [
+    { name = "av" },
+    { name = "imageio" },
+    { name = "imageio-ffmpeg" },
 ]
 docs = [
     { name = "myst-parser", specifier = ">=4.0.1" },


### PR DESCRIPTION
Keep CVE-carrying video/image codecs (`av`, `imageio`, `imageio-ffmpeg`) out of the default container **and out of its dependency manifest**, installing them only at test time.

<details><summary>Claude summary</summary>

## Background / motivation
- `av`, `imageio`, `imageio-ffmpeg` carry CVEs (bundled ffmpeg/libav) and are only needed by WAN diffusion video caching (`src/megatron/bridge/diffusion/models/wan/inference/utils.py` → `imageio.get_writer`), exercised only by the WAN functional test.
- Goal: not installed in the shipped image, **not flagged by SBOM/manifest scanners**, installed only at test time.

## What changed
- All three added to `[tool.uv] override-dependencies` with `sys_platform == 'never'` (`av` already had it) → never installed, and they appear only as `never`-marked edges in `uv.lock`, so SBOM/manifest scanners skip them (consistent with `av`).
- `imageio` import made lazy.
- One `scripts/install_diffusion_deps.sh` installs all three at test time via `uv pip install --no-config` (bypasses the override).
- Container build excludes the `diffusion` group; `uv.lock` regenerated.

## Details
- **`pyproject.toml`**: `override-dependencies` += `imageio; sys_platform=='never'`, `imageio-ffmpeg; sys_platform=='never'`. The `diffusion` group is kept for documentation (installs nothing on Linux due to the override).
- **`docker/Dockerfile.ci`**: both `uv sync ... --all-extras --all-groups` lines end with `--no-group diffusion`.
- **`src/.../wan/inference/utils.py`**: lazy `import imageio` inside `cache_video`.
- **`tests/.../test_inference_utils.py`**: `pytest.importorskip("imageio")` + retargeted monkeypatch.
- **`tests/unit_tests/Launch_Unit_Tests_Diffusion.sh`**: runs `install_diffusion_deps.sh` before pytest.
- **`scripts/install_diffusion_deps.sh`**: `uv pip install --no-config imageio imageio-ffmpeg av`.
- **`uv.lock`**: all three resolved edges are `sys_platform == 'never'`.

## Verified on the built image
- `av` / `imageio` / `imageio_ffmpeg` absent from every site-packages tree (find_spec + full-filesystem sweep); `import megatron.bridge` works without them; the install script re-adds all three.
- The only residual ffmpeg is NVIDIA **DALI**'s vendored `libavcodec.so.62` (NGC base image) — out of scope for this PR (base-image/upstream).

## Installing at test time
```bash
bash /opt/Megatron-Bridge/scripts/install_diffusion_deps.sh
# = uv pip install --no-config imageio imageio-ffmpeg av
```
The nemo-ci WAN test (companion MR `dl/joc/nemo-ci!2483`) runs the same script under `flock`.

</details>