### PR TITLE
ci: smoke-import installed packages in docker build stages

### DIFF
--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -111,3 +111,17 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     uv cache prune ${UV_CACHE_PRUNE_ARGS}
 
 COPY --chmod=644 . /opt/Megatron-Bridge
+
+##############################################################################
+##
+## Verify the environment imports
+##
+##############################################################################
+
+# Fail the build if any installed package in /opt/venv cannot be imported. A
+# version/ABI skew can leave a package installed yet unimportable, which
+# `pip check` does not catch. The build has no GPU, so modules that need a
+# driver or host library at import are exempted in import_check_skip.txt.
+RUN --mount=type=bind,source=docker/common/import_check.py,target=/opt/import_check.py \
+    --mount=type=bind,source=docker/common/import_check_skip.txt,target=/opt/import_check_skip.txt \
+    python /opt/import_check.py --jobs 16 --skip-file /opt/import_check_skip.txt

--- a/docker/Dockerfile.fw_base
+++ b/docker/Dockerfile.fw_base
@@ -147,3 +147,17 @@ RUN --mount=type=bind,from=vllm_wheel,source=/src/vllm/,target=/tmp/vllm/ \
 FROM ${FW_BASE_FINAL} AS nemo_fw_base_final
 
 WORKDIR /opt
+
+##############################################################################
+##
+## Verify the environment imports
+##
+##############################################################################
+
+# Fail the build if any installed package in /opt/venv cannot be imported. A
+# version/ABI skew can leave a package installed yet unimportable, which
+# `pip check` does not catch. The build has no GPU, so modules that need a
+# driver or host library at import are exempted in import_check_skip.txt.
+RUN --mount=type=bind,source=docker/common/import_check.py,target=/opt/import_check.py \
+    --mount=type=bind,source=docker/common/import_check_skip.txt,target=/opt/import_check_skip.txt \
+    python /opt/import_check.py --jobs 16 --skip-file /opt/import_check_skip.txt

--- a/docker/Dockerfile.fw_final
+++ b/docker/Dockerfile.fw_final
@@ -141,6 +141,20 @@ RUN GRPC_VERSION=1.79.3 && \
 
 ##############################################################################
 ##
+## Verify the environment imports
+##
+##############################################################################
+
+# Fail the build if any installed package in /opt/venv cannot be imported. A
+# version/ABI skew can leave a package installed yet unimportable, which
+# `pip check` does not catch. The build has no GPU, so modules that need a
+# driver or host library at import are exempted in import_check_skip.txt.
+RUN --mount=type=bind,source=docker/common/import_check.py,target=/opt/import_check.py \
+    --mount=type=bind,source=docker/common/import_check_skip.txt,target=/opt/import_check_skip.txt \
+    python /opt/import_check.py --jobs 16 --skip-file /opt/import_check_skip.txt
+
+##############################################################################
+##
 ## Finalize FW container
 ##
 ##############################################################################

--- a/docker/common/fw_pyproject.toml
+++ b/docker/common/fw_pyproject.toml
@@ -73,6 +73,10 @@ override-dependencies = [
     "protobuf==6.33.5",
     "cuda-python>=13.0.0",
     "multi-storage-client!=0.36.0",
+    # 0.1.12rc0's tvm_ffi is incompatible with the TVM that tilelang vendors and
+    # breaks `import tilelang`/`import mamba_ssm`; an explicit pin is required
+    # because prerelease="allow" would otherwise float the unlocked sync onto it.
+    "apache-tvm-ffi==0.1.11",
     "levenshtein; sys_platform == 'never'",
     "pytest==8.4.2",
     "wandb>=0.25.0",

--- a/docker/common/import_check.py
+++ b/docker/common/import_check.py
@@ -1,0 +1,256 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Smoke-import every installed distribution's top-level modules.
+
+This guards against shipping an environment whose installed packages cannot
+actually be imported -- for example an ABI or version skew between a vendored
+shared library and its Python bindings. ``pip check`` only validates declared
+version ranges; it never exercises an import, so a nominally-satisfied
+dependency that crashes the moment it is imported slips through. This script
+closes that gap: it enumerates installed distributions, resolves each one's
+top-level importable modules, imports every module in an isolated subprocess,
+and exits non-zero if any import raises (or hangs).
+
+Run with no arguments to check the active interpreter's environment::
+
+    python import_check.py
+
+Because an image is built without a GPU, packages that require a driver or a
+host library at import time are not importable at build time. List those in a
+skip file (one module per line, ``#`` comments allowed) and pass it via
+``--skip-file``; every other import error then fails the build.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.metadata as md
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class ImportResult:
+    """Outcome of importing a single top-level module.
+
+    Attributes:
+        module: The top-level module name that was imported.
+        ok: True when the import subprocess exited cleanly.
+        detail: Trailing diagnostic output when the import failed, else "".
+    """
+
+    module: str
+    ok: bool
+    detail: str
+
+
+def _clean_module_name(filename: str) -> str | None:
+    """Reduce a top-level filename to the module name Python would import.
+
+    Extension modules carry an ABI tag (``foo.cpython-312-x86_64-linux-gnu.so``)
+    that is not part of the import name, so everything from the first dot is
+    dropped. Pure-Python files lose their ``.py`` suffix.
+
+    Args:
+        filename: The basename of a top-level file.
+
+    Returns:
+        The import name, or None when the file is not an importable module.
+    """
+    if filename.endswith((".so", ".pyd")):
+        return filename.split(".", 1)[0]
+    if filename.endswith(".py"):
+        return filename[:-3]
+    return None
+
+
+def _modules_from_files(dist: md.Distribution) -> set[str]:
+    """Derive importable top-level modules from a distribution's file list.
+
+    Deriving from the recorded files (rather than ``top_level.txt``) reflects
+    what is actually on disk, which avoids both stale metadata entries that name
+    non-importable helpers and ABI-tagged extension filenames.
+
+    Args:
+        dist: The installed distribution to inspect.
+
+    Returns:
+        The set of importable top-level module names.
+    """
+    modules: set[str] = set()
+    for entry in dist.files or []:
+        parts = entry.parts
+        if not parts:
+            continue
+        head = parts[0]
+        if head.endswith((".dist-info", ".data", ".egg-info")) or head == "__pycache__":
+            continue
+        if len(parts) == 1:
+            name = _clean_module_name(head)
+            candidate = name if name and name != "__init__" else None
+        else:
+            candidate = head if entry.suffix in {".py", ".so", ".pyd"} else None
+        if candidate and candidate.isidentifier():
+            modules.add(candidate)
+    return modules
+
+
+def _modules_from_top_level_txt(dist: md.Distribution) -> set[str]:
+    """Return importable module names declared in ``top_level.txt``.
+
+    Used only when the file list is unavailable.
+
+    Args:
+        dist: The installed distribution to inspect.
+
+    Returns:
+        The set of top-level module names that are valid identifiers.
+    """
+    text = dist.read_text("top_level.txt")
+    if not text:
+        return set()
+    return {line.strip() for line in text.splitlines() if line.strip().isidentifier()}
+
+
+def discover_modules(skip: set[str]) -> dict[str, list[str]]:
+    """Map each importable top-level module to the distributions providing it.
+
+    Args:
+        skip: Module names to exclude from the result.
+
+    Returns:
+        A mapping of module name to the sorted list of distribution names that
+        provide it, excluding any module in ``skip``.
+    """
+    providers: dict[str, set[str]] = {}
+    for dist in md.distributions():
+        name = dist.metadata["Name"] or "<unknown>"
+        modules = _modules_from_files(dist) or _modules_from_top_level_txt(dist)
+        for module in modules:
+            if module in skip:
+                continue
+            providers.setdefault(module, set()).add(name)
+    return {module: sorted(names) for module, names in providers.items()}
+
+
+def import_one(module: str, timeout: float) -> ImportResult:
+    """Import a single module in a fresh subprocess.
+
+    Isolation in a subprocess keeps a hard crash (segfault, ``os._exit``) or a
+    hang in one module from aborting the whole sweep.
+
+    Args:
+        module: The top-level module name to import.
+        timeout: Seconds to allow before treating the import as hung.
+
+    Returns:
+        The :class:`ImportResult` for this module.
+    """
+    try:
+        proc = subprocess.run(
+            [sys.executable, "-c", f"import {module}"],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return ImportResult(module, False, f"timed out after {timeout:.0f}s")
+    if proc.returncode == 0:
+        return ImportResult(module, True, "")
+    tail = "\n".join((proc.stderr or proc.stdout).strip().splitlines()[-3:])
+    return ImportResult(module, False, tail or f"exit code {proc.returncode}")
+
+
+def load_skip(skip_file: Path | None) -> set[str]:
+    """Read a newline-delimited skip list, ignoring blanks and comments.
+
+    Args:
+        skip_file: Path to the skip file, or None.
+
+    Returns:
+        The set of module names to skip.
+    """
+    if skip_file is None or not skip_file.exists():
+        return set()
+    skip: set[str] = set()
+    for line in skip_file.read_text().splitlines():
+        token = line.split("#", 1)[0].strip()
+        if token:
+            skip.add(token)
+    return skip
+
+
+def run(skip: set[str], jobs: int, timeout: float) -> list[ImportResult]:
+    """Import every discovered module and collect results.
+
+    Args:
+        skip: Module names to exclude.
+        jobs: Maximum number of concurrent import subprocesses.
+        timeout: Per-import timeout in seconds.
+
+    Returns:
+        The import results sorted by module name.
+    """
+    modules = discover_modules(skip)
+    with ThreadPoolExecutor(max_workers=jobs) as pool:
+        results = pool.map(lambda m: import_one(m, timeout), sorted(modules))
+    return list(results)
+
+
+def report(results: list[ImportResult], skipped: set[str]) -> int:
+    """Print a summary and return the process exit code.
+
+    Args:
+        results: The import results to summarize.
+        skipped: Module names that were skipped.
+
+    Returns:
+        1 if any import failed, otherwise 0.
+    """
+    failures = [r for r in results if not r.ok]
+    for failure in failures:
+        print(f"FAIL  {failure.module}")
+        for line in failure.detail.splitlines():
+            print(f"        {line}")
+    passed = len(results) - len(failures)
+    print(f"\nimport check: {passed} ok, {len(failures)} failed, {len(skipped)} skipped, {len(results)} total")
+    return 1 if failures else 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point for the import-check CLI.
+
+    Args:
+        argv: Argument vector, defaulting to ``sys.argv``.
+
+    Returns:
+        The process exit code.
+    """
+    parser = argparse.ArgumentParser(description="Smoke-import installed packages.")
+    parser.add_argument("--skip-file", type=Path, default=None)
+    parser.add_argument("--jobs", type=int, default=8)
+    parser.add_argument("--timeout", type=float, default=120.0)
+    args = parser.parse_args(argv)
+
+    skip = load_skip(args.skip_file)
+    results = run(skip, args.jobs, args.timeout)
+    return report(results, skip)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docker/common/import_check_skip.txt
+++ b/docker/common/import_check_skip.txt
@@ -1,0 +1,30 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Modules exempt from docker/common/import_check.py. A Dockerfile RUN executes
+# without a GPU, driver, or optional host libraries, so these modules raise at
+# import even though the package is installed correctly. Every entry MUST carry
+# a justification; the check fails on any import error that is not listed here.
+
+# Require an NVIDIA driver / libcuda.so.1, present only at runtime on a GPU host:
+deep_ep
+deep_ep_cpp
+hybrid_ep_cpp
+torch_tensorrt
+
+# Requires the libfuse system library (multi-storage-client FUSE backend; optional):
+mfusepy
+
+# Legacy DALI/MXNet helper script that imports mxnet, which is not installed:
+rec2idx

--- a/docker/common/import_check_skip.txt
+++ b/docker/common/import_check_skip.txt
@@ -22,6 +22,7 @@ deep_ep
 deep_ep_cpp
 hybrid_ep_cpp
 torch_tensorrt
+quack  # imports nvidia-cutlass-dsl MLIR libs, which dlopen libcuda at import
 
 # Requires the libfuse system library (multi-storage-client FUSE backend; optional):
 mfusepy


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## Background / motivation

- The 26.06 FW container shipped `apache-tvm-ffi 0.1.12rc0` (a pre-release). Its `tvm_ffi` registry is API-incompatible with the TVM that `tilelang 0.1.8` vendors, so `import tilelang` — and therefore `import mamba_ssm` (which eagerly imports `Mamba3 → tilelang`) — crashes with `AttributeError: attribute '__dict__' of 'type' objects is not writable`.
- `pip check` passed: the version range was nominally satisfied. It validates declared ranges but never imports, so an installed-but-unimportable package ships undetected.

## What changed

- **`docker/common/import_check.py`** — stdlib-only smoke importer: enumerates installed distributions, resolves each one's top-level modules, imports each in an isolated subprocess, exits non-zero on any failure.
- **`docker/common/import_check_skip.txt`** — justified exemptions for modules that cannot import at build time (no GPU/driver/host libs).
- **One `RUN` gate per Dockerfile** — `Dockerfile.fw_base`, `Dockerfile.ci`, `Dockerfile.fw_final`.

## Details

- Runs via `--mount=type=bind` so the script + skip-file are not baked into the image layer.
- Subprocess-per-import isolates a segfault/hang (per-import timeout) so one bad module can't abort the sweep.
- Module discovery derives names from each distribution's recorded files (not stale `top_level.txt`), strips ABI tags from extension filenames, and keeps only valid identifiers — no spurious candidates.
- **Skip-list policy**: a Dockerfile `RUN` builds without a GPU, so `deep_ep`, `deep_ep_cpp`, `hybrid_ep_cpp`, `torch_tensorrt` (need `libcuda`/driver), `mfusepy` (needs `libfuse`), and `rec2idx` (legacy DALI/mxnet shim) are exempted with justification. Any **other** import error fails the build.

```mermaid
flowchart TD
  b[Dockerfile.fw_base] --> gb[RUN import_check.py]
  c[Dockerfile.ci] --> gc[RUN import_check.py]
  f[Dockerfile.fw_final] --> gf[RUN import_check.py]
  gb --> q{any import fails?}
  gc --> q
  gf --> q
  q -- yes --> x[build fails]
  q -- no --> ok[image OK]
```

## Tested

Validated the **committed** script + skip-file against the broken `26.06.rc5` image:

- Broken venv (`apache-tvm-ffi 0.1.12rc0`):
  ```
  FAIL  mamba_ssm
  FAIL  tilelang
  import check: 604 ok, 2 failed, 6 skipped, 606 total   # exit 1 -> build fails
  ```
- Fixed venv (`apache-tvm-ffi==0.1.11`) + skip-file:
  ```
  import check: 606 ok, 0 failed, 6 skipped, 606 total   # exit 0 -> build passes
  ```

> **Draft note:** the skip-list is seeded from the `fw_final` package set. `fw_base`/`ci` have different package sets and may surface a few additional build-time-only (GPU/host-lib) imports; those will be appended to the skip-list as the first CI build reports them.

</details>
