### PR TITLE
[diffusion] fix: make `select_samples_to_pack` shuffle deterministic across resume

### DIFF
--- a/src/megatron/bridge/diffusion/data/common/diffusion_task_encoder_with_sp.py
+++ b/src/megatron/bridge/diffusion/data/common/diffusion_task_encoder_with_sp.py
@@ -77,6 +77,7 @@ class DiffusionTaskEncoderWithSequencePacking(DefaultTaskEncoder, ABC):  # noqa:
     def encode_sample(self, sample: dict) -> dict:
         raise NotImplementedError
 
+    @stateless(restore_seeds=True)
     def select_samples_to_pack(self, samples: List[DiffusionSample]) -> List[List[DiffusionSample]]:
         """
         Selects sequences to pack for mixed image-video training.

--- a/tests/unit_tests/diffusion/data/common/test_diffusion_task_encoder.py
+++ b/tests/unit_tests/diffusion/data/common/test_diffusion_task_encoder.py
@@ -70,8 +70,23 @@ def create_diffusion_sample(key: str, seq_len: int, video_shape=(16, 8), embeddi
     )
 
 
-def test_select_samples_to_pack():
+def _patch_worker_config(monkeypatch):
+    """Set up a fake WorkerConfig so @stateless(restore_seeds=True) works in tests."""
+    from megatron.energon.task_encoder.base import WorkerConfig
+
+    class _FakeWorkerCfg:
+        def worker_seed(self):
+            return 42
+
+        active_worker_sample_index = 0
+
+    monkeypatch.setattr(WorkerConfig, "active_worker_config", _FakeWorkerCfg(), raising=False)
+
+
+def test_select_samples_to_pack(monkeypatch):
     """Test select_samples_to_pack method."""
+    _patch_worker_config(monkeypatch)
+
     # Create encoder with seq_length=20
     encoder = ConcreteDiffusionTaskEncoder(seq_length=20)
 
@@ -107,6 +122,23 @@ def test_select_samples_to_pack():
 
     print(f"✓ Successfully packed {len(samples)} samples into {len(result)} bins")
     print(f"  Bin sizes: {[sum(s.seq_len_q.item() for s in group) for group in result]}")
+
+
+def test_select_samples_to_pack_deterministic(monkeypatch):
+    """Shuffle in select_samples_to_pack must be deterministic given the same worker seed."""
+    _patch_worker_config(monkeypatch)
+
+    encoder = ConcreteDiffusionTaskEncoder(seq_length=20)
+    samples = [
+        create_diffusion_sample(f"s{i}", seq_len=length) for i, length in enumerate([8, 12, 5, 7, 3])
+    ]
+
+    result1 = encoder.select_samples_to_pack(samples)
+    result2 = encoder.select_samples_to_pack(samples)
+
+    keys1 = [[s.__key__ for s in group] for group in result1]
+    keys2 = [[s.__key__ for s in group] for group in result2]
+    assert keys1 == keys2, "Shuffle must be deterministic with the same worker seed"
 
 
 def test_pack_selected_samples():

--- a/tests/unit_tests/diffusion/data/common/test_diffusion_task_encoder.py
+++ b/tests/unit_tests/diffusion/data/common/test_diffusion_task_encoder.py
@@ -129,9 +129,7 @@ def test_select_samples_to_pack_deterministic(monkeypatch):
     _patch_worker_config(monkeypatch)
 
     encoder = ConcreteDiffusionTaskEncoder(seq_length=20)
-    samples = [
-        create_diffusion_sample(f"s{i}", seq_len=length) for i, length in enumerate([8, 12, 5, 7, 3])
-    ]
+    samples = [create_diffusion_sample(f"s{i}", seq_len=length) for i, length in enumerate([8, 12, 5, 7, 3])]
 
     result1 = encoder.select_samples_to_pack(samples)
     result2 = encoder.select_samples_to_pack(samples)


### PR DESCRIPTION
### Summary

- Add `@stateless(restore_seeds=True)` to [`DiffusionTaskEncoderWithSequencePacking.select_samples_to_pack`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/src/megatron/bridge/diffusion/data/common/diffusion_task_encoder_with_sp.py#L80-L86) to fix non-deterministic bin ordering after checkpoint resume
- Add `test_select_samples_to_pack_deterministic` to verify the fix

### Problem

[`select_samples_to_pack`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/d3a05599/src/megatron/bridge/diffusion/data/common/diffusion_task_encoder_with_sp.py#L80-L86) uses `random.shuffle` to randomize bin order after packing, but the Python global RNG state is not checkpointed:
  ```python                                                                          
  def select_samples_to_pack(self, samples):                                         
      results = first_fit_decreasing(samples, self.seq_length)                       
      random.shuffle(results)   # Python global RNG — not checkpointed               
      return results                                                                 
  ```       
[`PackingDataset`](https://github.com/NVIDIA/Megatron-Energon/blob/main/src/megatron/energon/wrappers/packing_dataset.py) checkpoints the following state via [`_savable_fields`](https://github.com/NVIDIA/Megatron-Energon/blob/main/src/megatron/energon/wrappers/packing_dataset.py#L76-L83):

- `_pre_packing_buffer` / `_pre_packing_lengths` — bins that have already been packed by `select_samples_to_pack`. These are consumed in FIFO order by `next_final_pack()` without re-calling `select_samples_to_pack`, so their ordering is correctly reproduced after resume.
- `_reading_buffer` — samples that have been read from the source but not yet packed. After resume, these are passed to `select_samples_to_pack` again. this is where `random.shuffle` produces a different result, because the Python global RNG state is not part of the checkpoint.

### Why `@stateless(restore_seeds=True)` is appropriate

This PR uses the seed-pinning mechanism of `@stateless(restore_seeds=True)`. The `__stateless__` flag set by the decorator is not used by `PackingDataset` for `pre_packer` (i.e., `select_samples_to_pack`) and is harmless (see note below).

`@stateless(restore_seeds=True)` makes `random.shuffle` deterministic across resume by:

1. Saving the outer RNG state (`random`, `numpy`, `torch`)
2. Seeding all global RNGs from `(worker_seed, current_sample_index)` — both are already checkpointed by [`_pre_packing_sample_index`](https://github.com/NVIDIA/Megatron-Energon/blob/main/src/megatron/energon/wrappers/packing_dataset.py#L63)
3. Running the function
4. Restoring the outer RNG state

The decorator also sets `__stateless__ = True` on the function. `PackingDataset` tracks `final_packer_stateless` (for `pack_selected_samples`) and `sample_encoder_stateless` (for `encode_sample`) but does not track `pre_packer_stateless` ([code](https://github.com/NVIDIA/Megatron-Energon/blob/main/src/megatron/energon/wrappers/packing_dataset.py#L88-L98)).
So the `__stateless__` flag set on `select_samples_to_pack` is unused and harmless.

### Test plan

- [x] Existing `test_select_samples_to_pack` updated with `WorkerConfig` fixture (required by `@stateless(restore_seeds=True)`)
- [x] New `test_select_samples_to_pack_deterministic`: verifies that two calls with the same seed produce identical bin ordering