### PR TITLE
ci: move venv import check from Dockerfile RUN to GH Actions job

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -468,6 +468,35 @@ jobs:
           secrets: |
             GH_TOKEN=${{ secrets.PAT }}
 
+  cicd-import-check:
+    if: |
+      (
+        success()
+        || needs.pre-flight.outputs.is_ci_workload == 'true'
+        || needs.pre-flight.outputs.force_run_all == 'true'
+        || github.event_name == 'merge_group'
+      )
+      && !cancelled()
+      && needs.configure.outputs.perf_scripts_only != 'true'
+    needs: [pre-flight, configure, cicd-wait-in-queue, cicd-container-build]
+    runs-on: ${{ needs.pre-flight.outputs.runner_prefix }}
+    name: Launch_Import_Check
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Run venv import check
+        shell: bash -e -u -o pipefail {0}
+        env:
+          IMAGE: ${{ needs.pre-flight.outputs.registry }}/megatron-bridge:${{ github.sha }}
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}/docker/common:/opt/import-check:ro" \
+            "$IMAGE" \
+            python /opt/import-check/import_check.py \
+              --jobs 16 \
+              --skip-file /opt/import-check/import_check_skip.txt
+
   cicd-unit-tests-core:
     if: |
       (
@@ -983,6 +1012,7 @@ jobs:
     needs:
       - pre-flight
       - configure
+      - cicd-import-check
       - cicd-unit-tests-core
       - cicd-unit-tests-diffusion
       - cicd-functional-tests-l0

--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -111,17 +111,3 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     uv cache prune ${UV_CACHE_PRUNE_ARGS}
 
 COPY --chmod=644 . /opt/Megatron-Bridge
-
-##############################################################################
-##
-## Verify the environment imports
-##
-##############################################################################
-
-# Fail the build if any installed package in /opt/venv cannot be imported. A
-# version/ABI skew can leave a package installed yet unimportable, which
-# `pip check` does not catch. The build has no GPU, so modules that need a
-# driver or host library at import are exempted in import_check_skip.txt.
-RUN --mount=type=bind,source=docker/common/import_check.py,target=/opt/import_check.py \
-    --mount=type=bind,source=docker/common/import_check_skip.txt,target=/opt/import_check_skip.txt \
-    python /opt/import_check.py --jobs 16 --skip-file /opt/import_check_skip.txt

--- a/docker/Dockerfile.fw_base
+++ b/docker/Dockerfile.fw_base
@@ -148,16 +148,3 @@ FROM ${FW_BASE_FINAL} AS nemo_fw_base_final
 
 WORKDIR /opt
 
-##############################################################################
-##
-## Verify the environment imports
-##
-##############################################################################
-
-# Fail the build if any installed package in /opt/venv cannot be imported. A
-# version/ABI skew can leave a package installed yet unimportable, which
-# `pip check` does not catch. The build has no GPU, so modules that need a
-# driver or host library at import are exempted in import_check_skip.txt.
-RUN --mount=type=bind,source=docker/common/import_check.py,target=/opt/import_check.py \
-    --mount=type=bind,source=docker/common/import_check_skip.txt,target=/opt/import_check_skip.txt \
-    python /opt/import_check.py --jobs 16 --skip-file /opt/import_check_skip.txt

--- a/docker/Dockerfile.fw_final
+++ b/docker/Dockerfile.fw_final
@@ -141,20 +141,6 @@ RUN GRPC_VERSION=1.79.3 && \
 
 ##############################################################################
 ##
-## Verify the environment imports
-##
-##############################################################################
-
-# Fail the build if any installed package in /opt/venv cannot be imported. A
-# version/ABI skew can leave a package installed yet unimportable, which
-# `pip check` does not catch. The build has no GPU, so modules that need a
-# driver or host library at import are exempted in import_check_skip.txt.
-RUN --mount=type=bind,source=docker/common/import_check.py,target=/opt/import_check.py \
-    --mount=type=bind,source=docker/common/import_check_skip.txt,target=/opt/import_check_skip.txt \
-    python /opt/import_check.py --jobs 16 --skip-file /opt/import_check_skip.txt
-
-##############################################################################
-##
 ## Finalize FW container
 ##
 ##############################################################################

--- a/docker/common/import_check_skip.txt
+++ b/docker/common/import_check_skip.txt
@@ -29,3 +29,7 @@ mfusepy
 
 # Legacy DALI/MXNet helper script that imports mxnet, which is not installed:
 rec2idx
+
+# Pytest plugin shipped by `hypothesis`; eagerly imports `pytest`, which is not
+# installed in the fw_base/fw_final runtime venvs (test-time-only dependency):
+_hypothesis_pytestplugin


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## Background / motivation

- #4233 introduced a build-time `RUN` gate in `Dockerfile.{fw_base,fw_final,ci}` that ran `import_check.py` against the venv before the image was finalized.
- First downstream nemo-ci build of `main` after the merge tripped on `_hypothesis_pytestplugin` ([job 337054621](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/337054621#L326)): the plugin module ships with `hypothesis` and imports `pytest` unconditionally, but `pytest` is test-time-only and absent from `fw_base`/`fw_final` runtime venvs.
- Two issues with the build-time RUN gate surfaced:
  1. Every skip-list miss forces an image rebuild.
  2. Failures show up as opaque BuildKit output rather than a named CI job.

## What changed

- **`docker/Dockerfile.{fw_base,fw_final,ci}`** — drop the build-time `RUN` gate; the script is no longer baked into the image.
- **`.github/workflows/cicd-main.yml`** — add `cicd-import-check`, a dedicated job that depends on `cicd-container-build` and `docker run`s the freshly-built image with `docker/common/` bind-mounted from the checkout.
- **`docker/common/import_check_skip.txt`** — append `_hypothesis_pytestplugin` with justification.

## Details

- The check runs from a checkout, not from the image — script + skip-list edits are immediately effective without a rebuild.
- Job uses the existing `runner_prefix` self-hosted runner so `docker pull` of the `${registry}/megatron-bridge:${github.sha}` tag works against the same registry the unit-test jobs already use.
- Added to `Nemo_CICD_Test.needs` so a failure blocks the final gate.
- Mirror change in nemo-ci: `dl/joc/nemo-ci!2487` — adds `verify-NeMo-FW-{base,final}-imports[-sbsa]` jobs that run the same check against the freshly-built `fw-base`/`fw-final` images. Merge `!2487` first (redundant with the RUN gate), then this PR (RUN gate goes away, verify jobs take over).

```mermaid
flowchart TD
  build[cicd-container-build] --> chk[cicd-import-check]
  build --> unit[cicd-unit-tests-*]
  chk --> gate[Nemo_CICD_Test]
  unit --> gate
```

## Tested

- Pending CI: the new job will run on this PR against the freshly-built image. Expected: `import check: N ok, 0 failed, 8 skipped` (after `_hypothesis_pytestplugin` is skipped).

</details>