### PR TITLE
[docs] docs: Clarify Quick Start model source workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,13 +129,26 @@ for name, weight in bridge.export_hf_weights(model, cpu=True):
 Training quickstart using pre-configured recipes:
 
 ```python
+from megatron.bridge import AutoBridge
 from megatron.bridge.recipes.llama import llama32_1b_pretrain_config
 from megatron.bridge.training.gpt_step import forward_step
 from megatron.bridge.training.pretrain import pretrain
 
 if __name__ == "__main__":
-    # The recipe uses the Llama 3.2 1B model configuration from HuggingFace
+    # The recipe uses the Llama 3.2 1B architecture from Hugging Face.
+    # This is random-init pretraining and does not require a converted Megatron checkpoint.
     cfg = llama32_1b_pretrain_config()
+
+    # Hugging Face model ID as the architecture source.
+    # The recipe uses this pattern internally; override cfg.model to choose a different source.
+    cfg.model = AutoBridge.from_hf_pretrained("meta-llama/Llama-3.2-1B").to_megatron_provider(load_weights=False)
+
+    # Optional: use a local Hugging Face model/config directory instead.
+    # cfg.model = AutoBridge.from_hf_pretrained("/path/to/local/hf_model").to_megatron_provider(load_weights=False)
+
+    # Optional: initialize weights from a converted Megatron checkpoint for SFT/PEFT
+    # or other pretrained-weight workflows.
+    # cfg.checkpoint.pretrained_checkpoint = "/path/to/megatron/checkpoint"
 
     # Override training parameters
     cfg.train.train_iters = 10
@@ -151,6 +164,14 @@ You can launch the above script with:
 ```sh
 uv run python -m torch.distributed.run --nproc-per-node=<num devices> /path/to/script.py
 ```
+
+HF → Megatron conversion is workflow-specific. Use it when you need pretrained HF weights as a Megatron checkpoint,
+such as for finetuning from converted weights or for checkpoint round-trip workflows. It is not required for
+random-init pretraining from an HF architecture, where `AutoBridge.from_hf_pretrained(...).to_megatron_provider(load_weights=False)`
+only reads the architecture configuration.
+
+For runnable recipe, data preparation, and training examples, see the repository
+[`tutorials/`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/tutorials) directory.
 
 More examples:
 

--- a/README.md
+++ b/README.md
@@ -139,9 +139,9 @@ if __name__ == "__main__":
     # This is random-init pretraining and does not require a converted Megatron checkpoint.
     cfg = llama32_1b_pretrain_config()
 
-    # Hugging Face model ID as the architecture source.
-    # The recipe uses this pattern internally; override cfg.model to choose a different source.
-    cfg.model = AutoBridge.from_hf_pretrained("meta-llama/Llama-3.2-1B").to_megatron_provider(load_weights=False)
+    # The recipe already sets cfg.model internally using this pattern.
+    # Override cfg.model to choose a different Hugging Face model ID as the architecture source.
+    # cfg.model = AutoBridge.from_hf_pretrained("meta-llama/Llama-3.2-1B").to_megatron_provider(load_weights=False)
 
     # Optional: use a local Hugging Face model/config directory instead.
     # cfg.model = AutoBridge.from_hf_pretrained("/path/to/local/hf_model").to_megatron_provider(load_weights=False)

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,9 @@ Welcome to the Megatron Bridge documentation! This guide helps you navigate our 
 → Check [NeMo 2 Migration Guide](nemo2-migration-guide.md) or [Megatron-LM Migration Guide](megatron-lm-to-megatron-bridge.md)
 
 **📊 Use training recipes**
-→ Read [Recipe Usage](recipe-usage.md) for pre-configured training recipes
+→ Read [Recipe Usage](recipe-usage.md) for pre-configured training recipes and browse the repository
+[`tutorials/`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/tutorials) directory for runnable data prep,
+recipe, and training examples
 
 **🔌 Add support for a new model**
 → Refer to [Adding New Models](adding-new-models.md)

--- a/tutorials/recipes/llama/00_quickstart_pretrain.py
+++ b/tutorials/recipes/llama/00_quickstart_pretrain.py
@@ -48,7 +48,7 @@ def main() -> None:
     config.scheduler.lr_warmup_iters = 2
 
     # Use your own data:
-    # config.data.data_path = "/path/to/your/dataset"
+    # config.dataset.data_path = "/path/to/your/dataset"
 
     # Adjust batch sizes for your GPU memory:
     # config.train.global_batch_size = 256

--- a/tutorials/recipes/llama/README.md
+++ b/tutorials/recipes/llama/README.md
@@ -73,7 +73,7 @@ Example YAML (`conf/llama32_1b_pretrain.yaml`):
 # Each section maps to a ConfigContainer field
 dataset:                           # GPTDatasetConfig
   data_path: /path/to/training/data
-  sequence_length: 4096
+  seq_length: 4096
 
 train:                             # TrainingConfig
   train_iters: 100
@@ -84,7 +84,7 @@ checkpoint:                        # CheckpointConfig
   save_interval: 50
 
 model:                             # Model Provider
-  seq_length: 4096                 # Must match data.sequence_length
+  seq_length: 4096                 # Must match dataset.seq_length
   tensor_model_parallel_size: 1
   
 optimizer:                         # OptimizerConfig
@@ -139,7 +139,7 @@ peft:                             # PEFT (LoRA config)
   alpha: 16   # LoRA alpha
 
 model:                            # Model Provider
-  seq_length: 4096                # Must match data.seq_length
+  seq_length: 4096                # Must match dataset.seq_length
   
 optimizer:                        # OptimizerConfig
   lr: 0.0001

--- a/tutorials/recipes/llama/README.md
+++ b/tutorials/recipes/llama/README.md
@@ -122,10 +122,10 @@ Example YAML (`conf/llama32_1b_finetune.yaml`):
 ```yaml
 # Each section maps to a ConfigContainer field
 dataset:                           # FinetuningDatasetConfig
-  data_path: /path/to/finetuning_dataset.jsonl
+  dataset_root: /path/to/finetuning_dataset_dir
   seq_length: 4096
 
-train:                             # TrainingConfig  
+train:                             # TrainingConfig
   train_iters: 100
   global_batch_size: 128
 

--- a/tutorials/recipes/llama/README.md
+++ b/tutorials/recipes/llama/README.md
@@ -11,8 +11,11 @@ uv run python -m torch.distributed.run --nproc_per_node=1 00_quickstart_pretrain
 ```
 
 This runs Llama 3.2 1B pretraining on a single GPU with mock data.
+It uses the Hugging Face architecture configuration for random initialization, so it does not require converting a
+Hugging Face checkpoint to Megatron format first.
 
-For finetuning, you first need a checkpoint in Megatron format. Convert from HuggingFace using the `AutoBridge`:
+For finetuning from pretrained weights, you need a checkpoint in Megatron format. Convert from Hugging Face using
+the `AutoBridge`:
 
 > **Note:** You must be authenticated with Hugging Face to download the model. Run `hf auth login --token $HF_TOKEN` if needed.
 

--- a/tutorials/recipes/llama/conf/llama32_1b_finetune.yaml
+++ b/tutorials/recipes/llama/conf/llama32_1b_finetune.yaml
@@ -18,8 +18,8 @@
 
 # Data configuration
 dataset:
-  # Replace with your dataset path (JSONL format recommended)
-  # data_path: /path/to/your/finetuning_dataset.jsonl
+  # Replace with a directory containing training.jsonl, validation.jsonl, and optionally test.jsonl
+  # dataset_root: /path/to/your/finetuning_dataset_dir
   seq_length: 4096
 
 # Training configuration
@@ -29,7 +29,7 @@ train:
   micro_batch_size: 2
   eval_iters: 10
   eval_interval: 50
-  
+
 
 # Optimizer configuration
 optimizer:

--- a/tutorials/recipes/llama/conf/llama32_1b_pretrain.yaml
+++ b/tutorials/recipes/llama/conf/llama32_1b_pretrain.yaml
@@ -20,7 +20,7 @@
 dataset:
   # Replace with your dataset path
   # data_path: /path/to/your/dataset
-  sequence_length: 4096
+  seq_length: 4096
 
 # Training configuration
 train:
@@ -49,7 +49,7 @@ checkpoint:
   save_interval: 50
 
 # Model configuration
-# Note: seq_length must match data.sequence_length
+# Note: seq_length must match dataset.seq_length
 model:
   seq_length: 4096
   tensor_model_parallel_size: 1


### PR DESCRIPTION
## Summary

- Clarifies that HF -> Megatron checkpoint conversion is workflow-specific, not required for random-init pretraining from an HF architecture.
- Shows the pre-configured recipe pattern for model sources: HF model ID, local HF path, and converted Megatron checkpoint initialization.
- Links the repository tutorials directory from the Quick Start path so users can find runnable data prep, recipe, and training examples earlier.
- Normalizes Llama tutorial dataset override examples so pretraining uses `dataset.data_path` and finetuning uses `dataset.dataset_root`.

## Scope

Addresses the Quickstart-work subset of #3814 and keeps the tutorial examples aligned with the config-name normalization covered by the training-docs PR. This PR does not cover the rest of the tracker items such as training workflow docs, NVFP4, checkpoint resume semantics, data prep guide expansion, or agent readiness.

## Verification

- `git diff --check`
- `pre-commit run --files README.md docs/README.md tutorials/recipes/llama/README.md`
- `pre-commit run --files tutorials/recipes/llama/00_quickstart_pretrain.py tutorials/recipes/llama/README.md tutorials/recipes/llama/conf/llama32_1b_finetune.yaml`
- `pre-commit run --all-files`
- Attempted `uv run pre-commit run --all-files`; blocked by local dependency resolution for `nvidia-resiliency-ext==0.6.0` on `manylinux_2_31_x86_64` before hooks ran.