### PR TITLE
fix(data): route HF VLM sequence packing by collate support

### DIFF
--- a/src/megatron/bridge/data/vlm_datasets/hf_provider.py
+++ b/src/megatron/bridge/data/vlm_datasets/hf_provider.py
@@ -16,12 +16,14 @@
 Provider that builds conversation datasets from HuggingFace datasets.
 """
 
+import inspect
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Literal, Optional, Tuple
 
 import torch
 from transformers import AutoProcessor
 
+from megatron.bridge.data.vlm_datasets.collate import COLLATE_FNS
 from megatron.bridge.data.vlm_datasets.conversation_dataset import VLMConversationDataset
 from megatron.bridge.data.vlm_datasets.hf_dataset_makers import (
     make_cord_v2_dataset,
@@ -80,6 +82,13 @@ class HFDatasetConversationProvider(DatasetProvider):
     # Enable batch-level online sequence packing (dataset-level packing is available in FinetuneDatasetProvider)
     pack_sequences_in_batch: bool = False
 
+    def _collate_supports_packing(self, processor: Any) -> bool:
+        collate_key = type(processor).__name__ if processor is not None else "default"
+        selected_impl = self.collate_impl or COLLATE_FNS.get(collate_key)
+        if selected_impl is None:
+            return False
+        return "pack_sequences" in inspect.signature(selected_impl).parameters
+
     def _get_maker(self) -> Callable[..., List[Dict[str, Any]]]:
         registry: Dict[str, Callable[..., List[Dict[str, Any]]]] = {
             "make_rdr_dataset": make_rdr_dataset,
@@ -129,7 +138,7 @@ class HFDatasetConversationProvider(DatasetProvider):
             target_length=target_length,
             processor=processor,
             collate_impl=self.collate_impl,
-            pack_sequences=self.pack_sequences_in_batch,
+            pack_sequences=self.pack_sequences_in_batch and self._collate_supports_packing(processor),
         )
 
     def build_datasets(self, context: DatasetBuildContext) -> Tuple[Optional[Any], Optional[Any], Optional[Any]]:

--- a/tests/unit_tests/data/vlm_datasets/test_collate.py
+++ b/tests/unit_tests/data/vlm_datasets/test_collate.py
@@ -217,6 +217,67 @@ def test_qwen2_5_collate_fn_handles_with_videos(monkeypatch):
     assert "video_grid_thw" not in batch
 
 
+def test_qwen2_5_collate_fn_preserves_attention_mask_for_mixed_image_text_batch(monkeypatch):
+    monkeypatch.setattr(qwen_vl_collate, "HAVE_QWEN_VL_UTILS", True)
+
+    class _PadAwareProcessor:
+        class _Tok:
+            pad_token_id = 99
+            pad_token = "<pad>"
+            added_tokens_decoder = {}
+
+            def __call__(self, text, add_special_tokens=False):
+                return {"input_ids": [1]}
+
+        def __init__(self):
+            self.tokenizer = self._Tok()
+
+        def apply_chat_template(self, conversation, tokenize=False, **kwargs):
+            return conversation[0]["content"][-1]["text"]
+
+        def __call__(self, text=None, images=None, padding=True, return_tensors="pt", **kwargs):
+            texts = text if isinstance(text, list) else [text]
+            lengths = [3 if "short" in item else 5 for item in texts]
+            max_len = max(lengths)
+            input_ids = torch.full((len(texts), max_len), self.tokenizer.pad_token_id)
+            attention_mask = torch.zeros((len(texts), max_len), dtype=torch.long)
+            for row, length in enumerate(lengths):
+                input_ids[row, :length] = torch.arange(1, length + 1)
+                attention_mask[row, :length] = 1
+            out = {"input_ids": input_ids, "attention_mask": attention_mask}
+            if images is not None:
+                out["pixel_values"] = torch.randn(1, len(images), 3, 4, 4)
+                out["image_grid_thw"] = torch.tensor([[[1, 2, 2]] * len(images)])
+            return out
+
+    def _fake_pvi(conv):
+        if "short image" in str(conv):
+            return ([object()], None)
+        return (None, None)
+
+    monkeypatch.setattr(qwen_vl_collate, "process_vision_info", _fake_pvi)
+
+    examples = [
+        {
+            "conversation": [
+                {"role": "user", "content": [{"type": "text", "text": "short image"}]},
+                {"role": "assistant", "content": [{"type": "text", "text": "answer"}]},
+            ]
+        },
+        {
+            "conversation": [
+                {"role": "user", "content": [{"type": "text", "text": "long text only"}]},
+                {"role": "assistant", "content": [{"type": "text", "text": "answer"}]},
+            ]
+        },
+    ]
+
+    batch = collate.qwen2_5_collate_fn(examples, _PadAwareProcessor())
+
+    assert batch["input_ids"].tolist() == [[1, 2, 3, 99, 99], [1, 2, 3, 4, 5]]
+    assert batch["attention_mask"].tolist() == [[1, 1, 1, 0, 0], [1, 1, 1, 1, 1]]
+
+
 def test_expand_image_tokens_handles_multiple_images_and_temporal_grids():
     image_token_id = 163605
     input_ids = torch.tensor([11, image_token_id, 22, image_token_id, 33])

--- a/tests/unit_tests/data/vlm_datasets/test_dataset_provider.py
+++ b/tests/unit_tests/data/vlm_datasets/test_dataset_provider.py
@@ -62,6 +62,10 @@ def _example():
     return {"conversation": [{"role": "user", "content": [{"type": "text", "text": "hi"}]}]}
 
 
+def _packable_collate(examples, processor, *, pack_sequences=False):
+    return {"pack_sequences": pack_sequences}
+
+
 def test_vlm_conversation_dataset_basic():
     from megatron.bridge.data.vlm_datasets.conversation_dataset import VLMConversationDataset
 
@@ -116,3 +120,55 @@ def test_hf_provider_builds_splits_and_binds_collate(monkeypatch):
     # Ensure collate_fn is bound and callable
     batch = train_ds.collate_fn([_example()])
     assert isinstance(batch, dict)
+
+
+def test_hf_provider_keeps_runtime_packing_out_of_conversation_dataset(monkeypatch):
+    import transformers
+
+    from megatron.bridge.data.vlm_datasets import hf_provider as dp_mod
+
+    monkeypatch.setattr(transformers.AutoProcessor, "from_pretrained", staticmethod(lambda *a, **k: Gemma3Processor()))
+
+    def _fake_get_maker(self):
+        return lambda **kwargs: [_example(), _example()]
+
+    monkeypatch.setattr(dp_mod.HFDatasetConversationProvider, "_get_maker", _fake_get_maker)
+
+    provider = dp_mod.HFDatasetConversationProvider(
+        seq_length=16,
+        hf_processor_path="dummy/model",
+        maker_name="rdr",
+        pack_sequences_in_batch=True,
+    )
+
+    ctx = DatasetBuildContext(train_samples=2, valid_samples=0, test_samples=0)
+    train_ds, _, _ = provider.build_datasets(ctx)
+
+    assert train_ds is not None and len(train_ds) == 2
+
+
+def test_hf_provider_forwards_packing_to_supported_collate(monkeypatch):
+    import transformers
+
+    from megatron.bridge.data.vlm_datasets import hf_provider as dp_mod
+
+    monkeypatch.setattr(transformers.AutoProcessor, "from_pretrained", staticmethod(lambda *a, **k: Gemma3Processor()))
+
+    def _fake_get_maker(self):
+        return lambda **kwargs: [_example(), _example()]
+
+    monkeypatch.setattr(dp_mod.HFDatasetConversationProvider, "_get_maker", _fake_get_maker)
+
+    provider = dp_mod.HFDatasetConversationProvider(
+        seq_length=16,
+        hf_processor_path="dummy/model",
+        maker_name="rdr",
+        collate_impl=_packable_collate,
+        pack_sequences_in_batch=True,
+    )
+
+    ctx = DatasetBuildContext(train_samples=2, valid_samples=0, test_samples=0)
+    train_ds, _, _ = provider.build_datasets(ctx)
+
+    assert train_ds is not None
+    assert train_ds.collate_fn([_example()])["pack_sequences"] is True


### PR DESCRIPTION
## Summary
- Route `HFDatasetConversationProvider.pack_sequences_in_batch` into `VLMConversationDataset(pack_sequences=...)` only when the selected collate advertises a `pack_sequences` parameter.
- This lets Qwen/Qwen2.5-style HF conversation datasets keep `pack_sequences_in_batch=True` for `vlm_step` runtime packing without failing dataset construction, while preserving Nemotron Omni collate-level packing.
- Add regression coverage that Qwen mixed image/text collation preserves 2D `attention_mask`, which `vlm_step.pack_batch_sequences()` uses as `_padding_mask` for real sequence lengths.

## Test Plan
- `uv run --active --no-sync pre-commit run --all-files`
- `uv run --active --no-sync ruff check src/megatron/bridge/data/vlm_datasets/hf_provider.py tests/unit_tests/data/vlm_datasets/test_dataset_provider.py tests/unit_tests/data/vlm_datasets/test_collate.py`
- `uv run --active --no-sync ruff format --check src/megatron/bridge/data/vlm_datasets/hf_provider.py tests/unit_tests/data/vlm_datasets/test_dataset_provider.py tests/unit_tests/data/vlm_datasets/test_collate.py`
- `PYTHONPATH="$PWD/src:$PWD/3rdparty/Megatron-LM" uv run --active --no-sync python -m compileall -q src/megatron/bridge/data/vlm_datasets/hf_provider.py tests/unit_tests/data/vlm_datasets/test_dataset_provider.py tests/unit_tests/data/vlm_datasets/test_collate.py`
- Isolated import checks for HF provider packing routing and Qwen mixed-batch `attention_mask` merge.

Blocked locally:
- `uv run python -m pytest tests/unit_tests/data/vlm_datasets/test_dataset_provider.py tests/unit_tests/data/vlm_datasets/test_collate.py -k "hf_provider_keeps_runtime_packing or hf_provider_forwards_packing or qwen2_5_collate_fn_preserves_attention_mask" -q` cannot create the project env because `nvidia-resiliency-ext==0.6.0` has no wheel for this `manylinux_2_31_x86_64` platform.
- `uv run --active --no-sync python -m pytest ...` reaches pytest but fails in `tests/unit_tests/conftest.py` because the active env has an older `nvidia-resiliency-ext` than the Megatron-Core minimum 0.6.0.