### PR TITLE
[model] fix: Default Bailing MoE dispatcher to alltoall

### DIFF
--- a/src/megatron/bridge/models/bailing/bailing_moe2_bridge.py
+++ b/src/megatron/bridge/models/bailing/bailing_moe2_bridge.py
@@ -97,6 +97,7 @@ class BailingMoeV2Bridge(MegatronModelBridge):
         provider.moe_router_score_function = "sigmoid"
         provider.moe_router_enable_expert_bias = True
         provider.moe_router_dtype = "fp32"
+        provider.moe_token_dispatcher_type = "alltoall"
         provider.moe_permute_fusion = True
 
         provider.hidden_dropout = 0.0


### PR DESCRIPTION
## Summary
- Set Bailing MoE V2 provider default `moe_token_dispatcher_type` to `alltoall`
- Removed the previous shared `TransformerConfig` default override so other model families keep their existing defaults

## Context
Ling-flash TP1/EP8 debugging showed sparse/group-limited routing can legitimately send zero tokens to an expert-parallel rank. Bailing should use `alltoall` by default for this path instead of inheriting the MCore `allgather` default.

## Validation
- `git diff --check`
- `python -m py_compile src/megatron/bridge/models/bailing/bailing_moe2_bridge.py`
- Blocked: `uv run python -m pytest tests/functional_tests/test_groups/models/bailing/test_bailing_moe2_conversion.py -q` and `uv run pre-commit run --all-files` both fail during dependency resolution because `nvidia-resiliency-ext==0.6.0` has no wheel for this workstation platform (`manylinux_2_31_x86_64`).