### PR TITLE
[model] fix: use flash attention for Kimi vision tower

### DIFF
--- a/src/megatron/bridge/models/kimi_vl/modeling_kimi_k25_vl.py
+++ b/src/megatron/bridge/models/kimi_vl/modeling_kimi_k25_vl.py
@@ -21,12 +21,32 @@ from megatron.core.tensor_parallel import scatter_to_sequence_parallel_region
 from megatron.core.transformer.module import MegatronModule
 from torch import Tensor
 from transformers.dynamic_module_utils import get_class_from_dynamic_module
+from transformers.utils import is_flash_attn_2_available
 
 from megatron.bridge.models.gpt_provider import GPTModelProvider
 from megatron.bridge.utils.common_utils import hook_hf_module_setattr_for_tp_grad_sync
 
 
 logger = logging.getLogger(__name__)
+
+
+def _configure_kimi_vision_attention(vision_tower_config, vision_tower_cls) -> None:
+    """Use flash attention for Kimi vision when available.
+
+    Kimi's remote MoonViT code supports ``flash_attention_2`` through its own
+    attention dispatch table, but older remote metadata only advertises
+    ``_supports_flash_attn_2``. Transformers 5.6 checks ``_supports_flash_attn``
+    before allowing the model to initialize with flash attention.
+    """
+    if is_flash_attn_2_available():
+        vision_tower_config._attn_implementation = "flash_attention_2"
+        if getattr(vision_tower_cls, "_supports_flash_attn_2", False):
+            vision_tower_cls._supports_flash_attn = True
+        return
+
+    if getattr(vision_tower_config, "_attn_implementation", None) == "flash_attention_2":
+        logger.warning("flash-attn is not available; falling back to eager attention for Kimi K2.5 vision tower.")
+        vision_tower_config._attn_implementation = "eager"
 
 
 class KimiK25VLModel(MegatronModule):
@@ -136,11 +156,7 @@ class KimiK25VLModel(MegatronModule):
             if not hasattr(MoonViT3dEncoder, "use_deterministic_attn"):
                 MoonViT3dEncoder.use_deterministic_attn = False
 
-            # transformers >=5.5 strictly validates `attn_implementation` at
-            # __init__ and selects `flash_attention_2` by default when flash-attn
-            # is installed. MoonViT3dPretrainedModel doesn't declare flash-attn-2
-            # support, so force eager attention before construction.
-            self.vision_tower_config._attn_implementation = "eager"
+            _configure_kimi_vision_attention(self.vision_tower_config, MoonViT3dPretrainedModel)
             self.vision_tower = MoonViT3dPretrainedModel(self.vision_tower_config)
             self.mm_projector = PatchMergerMLP(self.projector_config)  # TODO: support different types of mm projector
             # Ensure HF visual tower params are marked for TP grad sync and future assignments are hooked.

--- a/tests/unit_tests/models/kimi_vl/test_modeling_kimi_k25_vl.py
+++ b/tests/unit_tests/models/kimi_vl/test_modeling_kimi_k25_vl.py
@@ -51,6 +51,43 @@ def helper():
     return MergeTestHelper()
 
 
+class TestKimiVisionAttentionConfig:
+    """Test Kimi vision attention backend configuration."""
+
+    def test_configures_flash_attention_when_available(self):
+        from megatron.bridge.models.kimi_vl.modeling_kimi_k25_vl import _configure_kimi_vision_attention
+
+        class DummyMoonViT:
+            _supports_flash_attn_2 = True
+
+        vision_config = Mock()
+        vision_config._attn_implementation = "eager"
+
+        with patch("megatron.bridge.models.kimi_vl.modeling_kimi_k25_vl.is_flash_attn_2_available", return_value=True):
+            _configure_kimi_vision_attention(vision_config, DummyMoonViT)
+
+        assert vision_config._attn_implementation == "flash_attention_2"
+        assert DummyMoonViT._supports_flash_attn is True
+
+    def test_falls_back_to_eager_when_flash_attention_unavailable(self):
+        from megatron.bridge.models.kimi_vl.modeling_kimi_k25_vl import _configure_kimi_vision_attention
+
+        class DummyMoonViT:
+            _supports_flash_attn_2 = True
+            _supports_flash_attn = False
+
+        vision_config = Mock()
+        vision_config._attn_implementation = "flash_attention_2"
+
+        with patch(
+            "megatron.bridge.models.kimi_vl.modeling_kimi_k25_vl.is_flash_attn_2_available", return_value=False
+        ):
+            _configure_kimi_vision_attention(vision_config, DummyMoonViT)
+
+        assert vision_config._attn_implementation == "eager"
+        assert DummyMoonViT._supports_flash_attn is False
+
+
 def _make_inputs(batch_size, seq_len, hidden_dim=HIDDEN_DIM):
     """Create basic input tensors."""
     input_ids = torch.randint(1000, 2000, (batch_size, seq_len))


### PR DESCRIPTION
## Summary
- Prefer `flash_attention_2` for the Kimi K2.5 VL vision tower when flash-attn is installed.
- Patch the Kimi remote MoonViT class metadata expected by Transformers 5.6 so the model can initialize with Flash Attention 2 instead of falling back to eager attention.
- Keep an eager fallback when flash-attn is unavailable.

## Validation
- `uv run ruff format src/megatron/bridge/models/kimi_vl/modeling_kimi_k25_vl.py tests/unit_tests/models/kimi_vl/test_modeling_kimi_k25_vl.py`
- `uv run ruff check src/megatron/bridge/models/kimi_vl/modeling_kimi_k25_vl.py tests/unit_tests/models/kimi_vl/test_modeling_kimi_k25_vl.py`
- `uv run pre-commit run --all-files`
- `uv run python -m pytest tests/unit_tests/models/kimi_vl/test_modeling_kimi_k25_vl.py -q`
- Targeted runtime validation confirmed Kimi `MoonViT3dPretrainedModel` constructs with `flash_attention_2` and MoonViT encoder layers receive `attn_implementation="flash_attention_2"`.
