### PR TITLE
[data] fix: Handle empty PP-rank finetuning data

### DIFF
--- a/src/megatron/bridge/data/finetuning.py
+++ b/src/megatron/bridge/data/finetuning.py
@@ -90,11 +90,11 @@ def split_batch_into_microbatches(
 
 
 def prepare_finetuning_batch(
-    data_iterator: Iterator,
+    data_iterator: Iterator | None,
     num_microbatches: int,
     default_seq_length: int,
     seq_key: str = "tokens",
-) -> tuple[Iterator, int]:
+) -> tuple[Iterator | None, int]:
     """Prepare a finetuning batch by getting global batch and splitting into microbatches.
 
     This function handles the finetuning-specific data flow:
@@ -125,6 +125,9 @@ def prepare_finetuning_batch(
         >>> batch1 = next(microbatch_iter)
         >>> batch1['tokens'].shape  # torch.Size([4, 240])
     """
+    if data_iterator is None:
+        return data_iterator, default_seq_length
+
     # Get full global batch from dataloader
     global_batch = next(data_iterator)
 

--- a/src/megatron/bridge/data/loaders.py
+++ b/src/megatron/bridge/data/loaders.py
@@ -229,7 +229,11 @@ def build_train_valid_test_data_loaders(
     )
 
     # Check that the train dataset has at least one global batch of samples.
-    if cfg.dataset.dataloader_type != "external" and len(train_ds) < cfg.train.global_batch_size:
+    if (
+        train_ds is not None
+        and cfg.dataset.dataloader_type != "external"
+        and len(train_ds) < cfg.train.global_batch_size
+    ):
         raise RuntimeError(
             f"Not enough train samples for a single global batch: "
             f"train dataset size ({len(train_ds)}) < global batch size ({cfg.train.global_batch_size})."

--- a/tests/functional_tests/test_groups/data/test_loaders.py
+++ b/tests/functional_tests/test_groups/data/test_loaders.py
@@ -259,6 +259,43 @@ class TestDataLoaders:
         assert valid_dataloader is None
         assert test_dataloader is None
 
+    @mock.patch("torch.distributed.broadcast")
+    @mock.patch("torch.distributed.get_world_size", return_value=1)
+    @mock.patch("torch.distributed.get_rank", return_value=0)
+    @mock.patch("megatron.bridge.data.loaders.build_pretraining_data_loader")
+    @mock.patch("megatron.bridge.data.loaders.build_train_valid_test_datasets")
+    def test_build_train_valid_test_data_loaders_allows_none_train_dataset(
+        self, mock_build_datasets, mock_build_loader, mock_dp_rank, mock_dp_size, mock_broadcast
+    ):
+        cfg = create_simple_test_config()
+        cfg.validation.eval_iters = 0
+        train_state = TrainState()
+        dp_group = object()
+        dataset_provider = mock.Mock()
+
+        mock_build_datasets.return_value = (None, None, None)
+        mock_build_loader.return_value = None
+
+        train_dataloader, valid_dataloader, test_dataloader = build_train_valid_test_data_loaders(
+            cfg=cfg,
+            train_state=train_state,
+            build_train_valid_test_datasets_provider=dataset_provider,
+            dp_group=dp_group,
+        )
+
+        mock_build_loader.assert_called_once()
+        assert mock_build_loader.call_args.args[0] is None
+        mock_broadcast.assert_called_once_with(mock.ANY, 0)
+        actual_flags = mock_broadcast.call_args[0][0]
+        expected_flags = torch.tensor([0, 0, 0], dtype=torch.long, device="cuda")
+        assert torch.equal(actual_flags, expected_flags)
+        assert train_state.do_train == 0
+        assert train_state.do_valid == 0
+        assert train_state.do_test == 0
+        assert train_dataloader is None
+        assert valid_dataloader is None
+        assert test_dataloader is None
+
 
 class TestSampleBasedDataLoaders:
     """Tests for sample-based training data loader functionality."""

--- a/tests/unit_tests/data/test_finetuning.py
+++ b/tests/unit_tests/data/test_finetuning.py
@@ -19,6 +19,19 @@ import torch
 from megatron.bridge.data.finetuning import prepare_finetuning_batch
 
 
+def test_prepare_finetuning_batch_none_iterator():
+    """Test non-data-loading ranks can pass through a None iterator."""
+    microbatch_iter, seq_len = prepare_finetuning_batch(
+        data_iterator=None,
+        num_microbatches=4,
+        default_seq_length=2048,
+        seq_key="tokens",
+    )
+
+    assert microbatch_iter is None
+    assert seq_len == 2048
+
+
 def test_prepare_finetuning_batch_basic():
     """Test basic microbatch splitting."""
     # Create a global batch: GBS=8, seq_len=128


### PR DESCRIPTION
## Summary
- Guard the train-dataset size check so it only runs on ranks that actually build `train_ds`
- Let batch finetuning pass through `data_iterator=None` with the default sequence length
- Add regression coverage for both `train_ds=None` and `data_iterator=None`

## Context
NVBug 6181306 reproduces in `nvcr.io/nvidian/nemo:26.06.rc5` with GPT-OSS SFT at `TP=2 PP=2 EP=4`. Ranks on pipeline stage 1 receive `train_ds=None`, which is valid for non-data-loading PP ranks.

PR #3464 added the explicit undersized-dataset RuntimeError, but the new condition calls `len(train_ds)` before checking whether `train_ds` exists on the current rank. That turns the intended check into `TypeError: object of type 'NoneType' has no len()` on PP ranks without a local dataset.

This preserves #3464 behavior for real datasets while keeping the existing `None` dataset contract used by `build_pretraining_data_loader()`.

## Validation
- `git diff --check`
- `python -m py_compile src/megatron/bridge/data/loaders.py src/megatron/bridge/data/finetuning.py tests/unit_tests/data/test_finetuning.py tests/functional_tests/test_groups/data/test_loaders.py`
- Blocked locally: `uv run python -m pytest tests/unit_tests/data/test_finetuning.py tests/functional_tests/test_groups/data/test_loaders.py::TestDataLoaders::test_build_train_valid_test_data_loaders_allows_none_train_dataset` fails during dependency resolution because `nvidia-resiliency-ext==0.6.0` has no wheel for this workstation platform (`manylinux_2_31_x86_64`).
- Blocked locally: `uv run pre-commit run --all-files` fails for the same dependency-resolution/platform issue.