### PR TITLE
docs(training): clarify workflow and checkpoint guidance

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -59,6 +59,7 @@ models/stepfun/index.md
 
 training/config-container-overview.md
 training/entry-points.md
+training/data-preparation.md
 training/training-loop-settings.md
 training/optimizer-scheduler.md
 training/logging.md

--- a/docs/megatron-lm-to-megatron-bridge.md
+++ b/docs/megatron-lm-to-megatron-bridge.md
@@ -55,7 +55,7 @@ uv run python scripts/translate_mlm_to_bridge.py --reverse \
 | `--ffn-hidden-size N` | `model.ffn_hidden_size=N` | |
 | `--num-attention-heads N` | `model.num_attention_heads=N` | |
 | `--num-query-groups N` | `model.num_query_groups=N` | |
-| `--seq-length N` | `model.seq_length=N dataset.sequence_length=N` | Dual mapping |
+| `--seq-length N` | `model.seq_length=N dataset.seq_length=N` | Dual mapping |
 | `--swiglu` | `model.gated_linear_unit=true model.activation_func=silu` | Expanded to two keys |
 | `--squared-relu` | `model.activation_func=squared_relu` | |
 | `--data-path PATH [W PATH...]` | `dataset.data_path=PATH` | Space-separated paths (and optional weights) |
@@ -95,15 +95,17 @@ Flags not present in Bridge (e.g., `--use-mcore-models`, `--use-flash-attn`) are
 
 ## Quick start
 
-Run your example training entrypoint and override config keys directly:
+Run the generic recipe launcher and override config keys directly:
 
 ```bash
-uv run python examples/models/llama/pretrain_llama3_8b.py \
+uv run python scripts/training/run_recipe.py \
+  --recipe llama3_8b_pretrain_config \
+  --dataset llm-pretrain \
   train.micro_batch_size=2 \
   train.global_batch_size=128 \
   model.num_layers=32 model.hidden_size=4096 model.num_attention_heads=32 \
   model.max_position_embeddings=4096 \
-  dataset.sequence_length=4096 \
+  dataset.seq_length=4096 \
   checkpoint.save=/workspace/ckpts checkpoint.save_interval=1000 \
   logger.wandb_project=my_proj logger.wandb_exp_name=exp1
 ```

--- a/docs/nemo2-migration-guide.md
+++ b/docs/nemo2-migration-guide.md
@@ -286,12 +286,12 @@ recipe = llm.llama3_8b.pretrain_recipe(name="my_run", num_nodes=2)
 
 **Megatron Bridge**: Recipes in `megatron.bridge.recipes/`  
 ```python
-from megatron.bridge.recipes.llama.llama3_8b import pretrain_config
-from megatron.bridge.training import pretrain
+from megatron.bridge.recipes.llama import llama3_8b_pretrain_config
 from megatron.bridge.training.gpt_step import forward_step
+from megatron.bridge.training.pretrain import pretrain
 
 # Use pre-built recipe
-cfg = pretrain_config()
+cfg = llama3_8b_pretrain_config()
 
 # Customize as needed
 cfg.train.train_iters = 10000
@@ -384,7 +384,7 @@ from megatron.bridge.training.config import (
 )
 from megatron.core.optimizer import OptimizerConfig
 from megatron.bridge.models import GPTModelProvider
-from megatron.bridge.training import pretrain
+from megatron.bridge.training.pretrain import pretrain
 
 def llama3_8b_config(
     # Model/parallelism params
@@ -1221,8 +1221,9 @@ result = llm.finetune(
 In Megatron Bridge, training entry points take a single `ConfigContainer` and a `forward_step_func`:
 
 ```python
-from megatron.bridge.training import pretrain, finetune
 from megatron.bridge.training.config import ConfigContainer
+from megatron.bridge.training.finetune import finetune
+from megatron.bridge.training.pretrain import pretrain
 
 # Create unified configuration
 cfg = ConfigContainer(
@@ -1285,8 +1286,8 @@ For GPT models, use the provided {py:func}`bridge.training.gpt_step.forward_step
 Use `pretrain()` with `GPTDatasetConfig` for training models from scratch:
 
 ```python
-from megatron.bridge.training import pretrain
 from megatron.bridge.training.gpt_step import forward_step
+from megatron.bridge.training.pretrain import pretrain
 
 config = ConfigContainer(
     model=GPTModelProvider(
@@ -1321,8 +1322,8 @@ Use `finetune()` with `FinetuningDatasetConfig` for both full fine-tuning (SFT) 
 Full fine-tuning without PEFT - all model parameters are updated:
 
 ```python
-from megatron.bridge.training import finetune
 from megatron.bridge.training.gpt_step import forward_step
+from megatron.bridge.training.finetune import finetune
 
 config = ConfigContainer(
     model=GPTModelProvider(),

--- a/docs/recipe-usage.md
+++ b/docs/recipe-usage.md
@@ -1,6 +1,6 @@
 # Using Recipes
 
-Megatron Bridge provides production-ready training recipes for several popular models. You can find an overview of supported recipes and 🤗 HuggingFace bridges [here](index.md#supported-models).
+Megatron Bridge provides production-ready training recipes for several popular models. You can find an overview of supported recipes and 🤗 Hugging Face bridges [here](index.md#supported-models).
 This guide will cover the next steps to make use of a training recipe, including how to [override configuration](#overriding-configuration) and how to [launch a job](#launch-methods).
 
 ## Overview
@@ -10,12 +10,29 @@ This guide will cover the next steps to make use of a training recipe, including
 - **Integration**: Recipes return a single `ConfigContainer` that plugs directly into our training [entry points](training/entry-points.md) (see the published docs as well: https://docs.nvidia.com/nemo/megatron-bridge/latest/training/entry-points.html).
 - **Customization**: You can override any part of the recipe (Python, YAML, CLI) to adapt to your data, scale, and objectives.
 
+## Choosing a recipe or a new config
+
+Start from an exported recipe when the model family and workflow already exist in `megatron.bridge.recipes`. Recipe functions such as `llama3_8b_pretrain_config`, `llama32_1b_sft_config`, and `qwen3_8b_peft_config` provide model, optimizer, scheduler, precision, dataset, logger, and checkpoint defaults in one `ConfigContainer`. Override those defaults for your dataset, checkpoint paths, run length, parallelism, or precision before creating a new recipe.
+
+Create a new recipe or config when the base model architecture is not represented by an existing model provider, the checkpoint conversion needs a new bridge, the forward step or dataset provider is model-specific, or you need a reusable configuration that will be shared across jobs. If the Hugging Face model is already supported by `AutoBridge`, you usually only need to start from the closest recipe and override the model provider or `hf_path`.
+
+Training mode follows the recipe and dataset type:
+
+| Workflow | Typical config | Entry point | Checkpoint expectation |
+|----------|----------------|-------------|------------------------|
+| LLM pretraining or continued pretraining | `GPTDatasetConfig` | `pretrain()` | No checkpoint for from-scratch runs; use `checkpoint.load` for full resume or `checkpoint.pretrained_checkpoint` for model-weight initialization |
+| Full SFT | `FinetuningDatasetConfig`, `HFDatasetConfig`, or a dataset provider | `finetune()` | Use `checkpoint.pretrained_checkpoint` for the base model, or `checkpoint.load` for a full native Megatron resume |
+| PEFT / LoRA / DoRA | Same as SFT, plus `cfg.peft` | `finetune()` | `checkpoint.pretrained_checkpoint` is required for the frozen base model; `checkpoint.load` resumes adapter training |
+| VLM SFT or PEFT | VLM dataset provider such as Energon, HF, or preloaded JSON provider | `finetune()` with a VLM step function | Use the model-specific checkpoint guidance in the recipe or model docs |
+
+For dataset fields, prefer `seq_length` in Bridge examples. LLM pretraining uses `GPTDatasetConfig` with `data_path`, `blend`, or `blend_per_split`; SFT and PEFT use `dataset_root` for local JSONL data. Do not use `data_path` for SFT/PEFT JSONL roots.
+
 ## Overriding configuration
 
 Recipes are provided through a {py:class}`~bridge.training.config.ConfigContainer` object. This is a dataclass that holds all configuration objects needed for training. You can find a more detailed overview of the `ConfigContainer` [here](training/config-container-overview.md).
 The benefit of providing the full recipe through a pythonic structure is that it is agnostic to any configuration approach that a user may prefer, whether that's YAML, `argparse` or something else. In other words, the user may override the recipe however they see fit.
 
-The following sections detail a few different ways to override the configuration recipe. For a complete training script, please see [this example](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/examples/models/llama/pretrain_llama3_8b.py).
+The following sections detail a few different ways to override the configuration recipe. For a generic recipe launcher, see [`scripts/training/run_recipe.py`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/scripts/training/run_recipe.py).
 
 
 ### Python
@@ -23,10 +40,11 @@ The following sections detail a few different ways to override the configuration
 If you prefer to manage configuration in Python, you can directly modify attributes of the `ConfigContainer`:
 
 ```python
-from megatron.bridge.recipes.llama.llama3_8b import pretrain_config
+from megatron.bridge.recipes.llama import llama3_8b_pretrain_config
+from megatron.bridge.training.config import ConfigContainer
 
 # Get the base ConfigContainer from the recipe
-cfg: ConfigContainer = pretrain_config()
+cfg: ConfigContainer = llama3_8b_pretrain_config()
 
 # Apply overrides. Note the hierarchical structure
 cfg.train.train_iters = 20
@@ -38,18 +56,13 @@ cfg.logger.log_interval = 1
 You can also replace entire sub-configs of the `ConfigContainer`:
 
 ```python
-from megatron.bridge.recipes.llama.llama3_8b import pretrain_config
-from megatron.bridge.models.llama import Llama3ModelProvider
+from megatron.bridge.recipes.llama import llama32_1b_pretrain_config, llama3_8b_pretrain_config
+from megatron.bridge.training.config import ConfigContainer
 
-cfg: ConfigContainer = pretrain_config()
+cfg: ConfigContainer = llama3_8b_pretrain_config()
 
-small_llama = Llama3ModelProvider(
-    num_layers=2,
-    hidden_size=768,
-    ffn_hidden_size=2688,
-    num_attention_heads=16,
-)
-cfg.model = small_llama
+small_cfg: ConfigContainer = llama32_1b_pretrain_config()
+cfg.model = small_cfg.model
 ```
 
 ### YAML
@@ -57,13 +70,14 @@ Overriding a configuration recipe with a YAML file can be done using OmegaConf u
 
 ```python
 from omegaconf import OmegaConf
-from megatron.bridge.recipes.llama.llama3_8b import pretrain_config
+from megatron.bridge.recipes.llama import llama3_8b_pretrain_config
+from megatron.bridge.training.config import ConfigContainer
 from megatron.bridge.training.utils.omegaconf_utils import (
     apply_overrides,
     create_omegaconf_dict_config,
 )
 
-cfg: ConfigContainer = pretrain_config()
+cfg: ConfigContainer = llama3_8b_pretrain_config()
 yaml_filepath = "conf/llama3-8b-benchmark-cfg.yaml"
 
 # Convert the initial Python dataclass to an OmegaConf DictConfig for merging
@@ -88,14 +102,15 @@ Megatron Bridge provides some utilities to update the ConfigContainer using Hydr
 ```python
 import sys
 from omegaconf import OmegaConf
-from megatron.bridge.recipes.llama.llama3_8b import pretrain_config
+from megatron.bridge.recipes.llama import llama3_8b_pretrain_config
+from megatron.bridge.training.config import ConfigContainer
 from megatron.bridge.training.utils.omegaconf_utils import (
     apply_overrides,
     create_omegaconf_dict_config,
     parse_hydra_overrides,
 )
 
-cfg: ConfigContainer = pretrain_config()
+cfg: ConfigContainer = llama3_8b_pretrain_config()
 cli_overrides = sys.argv[1:]
 
 # Convert the initial Python dataclass to an OmegaConf DictConfig for merging
@@ -116,6 +131,27 @@ A script containing the above code could be called like so:
 ```sh
 uv run python -m torch.distributed.run <torchrun arguments> pretrain_cli_overrides.py model.tensor_model_parallel_size=4 train.train_iters=100000 ...
 ```
+
+Common dataset overrides:
+
+```python
+from megatron.bridge.recipes.llama import llama32_1b_sft_config, llama3_8b_pretrain_config
+
+pretrain_cfg = llama3_8b_pretrain_config()
+finetune_cfg = llama32_1b_sft_config()
+
+# LLM pretraining data on a pretrain recipe:
+# prefix path without .bin/.idx suffixes
+pretrain_cfg.dataset.data_path = "/data/dclm/preprocessed_text_document"
+pretrain_cfg.dataset.seq_length = 8192
+
+# SFT/PEFT local JSONL data on a finetune recipe:
+# directory containing training.jsonl, validation.jsonl, and optionally test.jsonl
+finetune_cfg.dataset.dataset_root = "/data/sft_jsonl"
+finetune_cfg.dataset.seq_length = 4096
+```
+
+For more detail on accepted dataset layouts, see [Data Preparation](training/data-preparation.md).
 
 ## Launch methods
 
@@ -184,7 +220,7 @@ if __name__ == "__main__":
     train_script = run.Script(..., args=args_to_fwd)
 ```
 
-For a complete example of the `run.Script` API, including argument forwarding, please see [this script](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/examples/models/llama/pretrain_llama3_8b_nemo_run_script.py).
+For a complete example of the `run.Script` API, including argument forwarding, see [`scripts/training/launch_with_nemo_run.py`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/scripts/training/launch_with_nemo_run.py).
 
 #### Plugins
 

--- a/docs/training/README.md
+++ b/docs/training/README.md
@@ -7,7 +7,7 @@ This directory contains comprehensive documentation for training and customizing
 ### I want to
 
 **🚀 Get started with training**
-→ Start with [Configuration Container Overview](config-container-overview.md) to understand the training setup
+→ Start with [Configuration Container Overview](config-container-overview.md) and [Data Preparation](data-preparation.md) to understand the training setup
 
 **⚙️ Configure training parameters**
 → See [Training Loop Settings](training-loop-settings.md) and [Optimizer & Scheduler](optimizer-scheduler.md)
@@ -32,6 +32,7 @@ This directory contains comprehensive documentation for training and customizing
 |----------|---------|--------------|
 | **[Configuration Container Overview](config-container-overview.md)** | Central configuration object for all training settings | First time setting up training |
 | **[Entry Points](entry-points.md)** | Training entry points and execution flow | Understanding how training starts |
+| **[Data Preparation](data-preparation.md)** | Dataset formats for pretraining, SFT, PEFT, and VLM fine-tuning | Preparing data or choosing dataset config fields |
 | **[Training Loop Settings](training-loop-settings.md)** | Training loop parameters and configuration | Configuring batch sizes, iterations, validation |
 
 ### Optimization and Performance
@@ -71,7 +72,7 @@ This directory contains comprehensive documentation for training and customizing
 A typical training workflow involves:
 
 1. **Configure Training** - Set up `ConfigContainer` with model, data, and training parameters
-2. **Prepare Data** - Configure dataset loading and preprocessing
+2. **Prepare Data** - Configure dataset loading and preprocessing with the right data format
 3. **Set Optimization** - Configure optimizer, scheduler, and mixed precision
 4. **Enable Monitoring** - Set up logging and profiling
 5. **Configure Checkpointing** - Set up checkpoint saving and resuming
@@ -93,9 +94,10 @@ A typical training workflow involves:
 ### 🆕 First-Time Training Setup
 
 1. [Configuration Container Overview](config-container-overview.md) - Understand the configuration system
-2. [Entry Points](entry-points.md) - Learn how to start training
-3. [Training Loop Settings](training-loop-settings.md) - Configure basic training parameters
-4. [Logging](logging.md) - Set up monitoring
+2. [Data Preparation](data-preparation.md) - Choose the right dataset format and config fields
+3. [Entry Points](entry-points.md) - Learn how to start training
+4. [Training Loop Settings](training-loop-settings.md) - Configure basic training parameters
+5. [Logging](logging.md) - Set up monitoring
 
 ### ⚡ Performance Optimization
 

--- a/docs/training/checkpointing.md
+++ b/docs/training/checkpointing.md
@@ -58,7 +58,7 @@ Asynchronous saving allows training to continue while checkpoint data is persist
 
 ### Loading Specific Checkpoint Iterations
 
-By default, Megatron Bridge loads the **latest checkpoint** available in the specified directory by reading from the tracker file (`latest_train_state.pt`). However, you can explicitly load from a specific checkpoint iteration using the `ckpt_step` parameter.
+By default, `checkpoint.load` loads the **latest checkpoint** available in the specified base directory by reading from the tracker file (`latest_train_state.pt`). You can explicitly load from a specific checkpoint iteration using the `ckpt_step` parameter.
 
 **Python API:**
 ```python
@@ -80,11 +80,42 @@ checkpoint = CheckpointConfig(
 The `load` parameter should always point to the base checkpoint directory (not the `iter_N` subdirectory). The `ckpt_step` parameter overrides which iteration is loaded from that directory.
 
 **Important:** If `ckpt_step` is specified but the checkpoint directory does not exist, training will **fail immediately** with a `FileNotFoundError`. This is intentional to prevent accidentally starting training from scratch when you meant to resume from a specific checkpoint.
+```
 
-**PEFT Note:** The `ckpt_step` parameter applies **only to the `load` path** (adapter checkpoints), not to `pretrained_checkpoint` (frozen base model). When resuming PEFT training:
-- `pretrained_checkpoint`: Always loads the latest/release checkpoint (base model)
-- `load` + `ckpt_step`: Can load a specific adapter checkpoint iteration
+### Default Recipe Resume Behavior
 
+Common recipes initialize both `checkpoint.save` and `checkpoint.load` to `./nemo_experiments/default/checkpoints`. If that directory already contains a checkpoint from a previous run, a new run with the same working directory may resume from it automatically.
+
+For a fresh run, set a new `checkpoint.save` path and clear `checkpoint.load`:
+
+```python
+cfg.checkpoint.save = "/checkpoints/my_new_run"
+cfg.checkpoint.load = None
+```
+
+For a full resume, keep `checkpoint.load` pointed at the base checkpoint directory:
+
+```python
+cfg.checkpoint.load = "/checkpoints/my_existing_run"
+```
+
+For model-weight initialization without optimizer, RNG, dataloader, or scheduler state, use `checkpoint.pretrained_checkpoint` instead of `checkpoint.load`.
+
+## Fine-tuning and Initialization Configuration
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `pretrained_checkpoint` | `Optional[str]` | `None` | Directory containing a pretrained full-model checkpoint for initialization |
+
+`checkpoint.pretrained_checkpoint` is used for model-weight initialization before a new training or fine-tuning run. It can point to:
+
+- A native Megatron base checkpoint directory containing tracker files such as `latest_train_state.pt` and `iter_*` subdirectories.
+- A native Megatron iteration directory such as `/checkpoints/my_model/iter_0001000/` that directly contains the checkpoint payload.
+- A local Hugging Face full-model directory containing `config.json` and model weight files. Remote Hugging Face model IDs are not accepted as checkpoint paths.
+
+`checkpoint.pretrained_checkpoint` does not load optimizer, RNG, dataloader, or scheduler state. Use `checkpoint.load` for full native Megatron resume.
+
+**PEFT note:** The `ckpt_step` parameter applies only to the `checkpoint.load` path, which is the adapter checkpoint when resuming PEFT. It does not select an iteration under `checkpoint.pretrained_checkpoint`. To use a specific frozen base checkpoint for PEFT, point `checkpoint.pretrained_checkpoint` directly at that `iter_N` directory.
 
 ### Checkpoint Loading Strictness
 
@@ -98,12 +129,6 @@ When loading distributed checkpoints, there may be mismatches between the keys i
 - **`return_unexpected`**: Return information about unexpected keys
 - **`return_all`**: Return information about all key mismatches
 - **`ignore_all`**: Ignore all key mismatches completely
-
-## Fine-tuning Configuration
-
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `pretrained_checkpoint` | `Optional[str]` | `None` | Directory containing pretrained model checkpoint **in Megatron format** for fine-tuning |
 
 ## Checkpoint Format
 
@@ -217,7 +242,7 @@ By default, Megatron Bridge saves all tokenizer files to the checkpoint director
 - **Reproducibility**: Exact tokenizer state is preserved
 
 The tokenizer files saved depend on the tokenizer type:
-- **HuggingFace tokenizers**: `tokenizer.json`, `tokenizer_config.json`, `special_tokens_map.json`, and vocab files
+- **Hugging Face tokenizers**: `tokenizer.json`, `tokenizer_config.json`, `special_tokens_map.json`, and vocab files
 - **SentencePiece tokenizers**: `tokenizer.model` file
 - **GPT2 BPE tokenizers**: `vocab.json` and `merges.txt`
 - **BERT tokenizers**: `vocab.txt`
@@ -408,9 +433,9 @@ The save and load methods receive context dataclasses that bundle all required p
 
 The custom checkpoint manager is designed for customizing the save/load **operations** during training. The following limitations apply:
 
-**Checkpoint format compatibility**: Custom managers that change the checkpoint directory structure or metadata files (e.g., `latest_train_state.pt`, `run_config.yaml`) are not well supported. Many utilities in Megatron Bridge assume the standard Megatron checkpoint format. For instance, HuggingFace ↔ custom format conversion is not supported.
+**Checkpoint format compatibility**: Custom managers that change the checkpoint directory structure or metadata files (e.g., `latest_train_state.pt`, `run_config.yaml`) are not well supported. Many utilities in Megatron Bridge assume the standard Megatron checkpoint format. For instance, Hugging Face ↔ custom format conversion is not supported.
 
-**PEFT with custom checkpoints**: When using PEFT (Parameter-Efficient Fine-Tuning), the `pretrained_checkpoint` path must point to a Megatron-format checkpoint. The custom manager only applies to the training save/load flow (the `save` and `load` configuration paths), not to base model loading for PEFT.
+**PEFT with custom checkpoints**: The custom manager only applies to the training save/load flow (the `save` and `load` configuration paths), not to base model loading for PEFT. `checkpoint.pretrained_checkpoint` is still loaded by the built-in base-model initialization path and should point to a native Megatron checkpoint or a local Hugging Face full-model directory.
 
 **Inference loading**: Loading checkpoints for inference via `model_load_save.py` utilities is undefined behavior with custom checkpoint formats. Use your custom format's loading utilities instead.
 

--- a/docs/training/data-preparation.md
+++ b/docs/training/data-preparation.md
@@ -1,0 +1,163 @@
+# Data Preparation
+
+Megatron Bridge uses different dataset config objects for pretraining, text fine-tuning, and multimodal fine-tuning. Choose the data path by workflow first, then keep the dataset sequence length aligned with `model.seq_length`.
+
+## Data Formats by Workflow
+
+| Workflow | Data format | Config or provider | Required path fields |
+|----------|-------------|--------------------|----------------------|
+| LLM pretraining | Megatron binary `.bin`/`.idx` prefixes | `GPTDatasetConfig` | `data_path`, `blend`, or `blend_per_split` |
+| LLM SFT or PEFT from local files | JSONL split files | `FinetuningDatasetConfig` | `dataset_root` |
+| LLM SFT or PEFT from Hugging Face datasets | Hugging Face dataset processed to JSONL | `HFDatasetConfig` | `dataset_name`, `process_example_fn`, optional `dataset_root` |
+| VLM SFT or PEFT | Energon/WebDataset, Hugging Face VLM dataset, or preloaded JSON | VLM `DatasetProvider` | Provider-specific fields such as `path`, `train_data_path`, or `image_folder` |
+
+Use `seq_length` in Bridge examples and CLI overrides. `GPTDatasetConfig` also stores this value as Megatron Core's inherited `sequence_length` field internally, but `FinetuningDatasetConfig` uses `seq_length`.
+
+## LLM Pretraining Data
+
+LLM pretraining uses Megatron binary indexed datasets. Each dataset is represented by a prefix with matching `.bin` and `.idx` files:
+
+```text
+/data/dclm/preprocessed_text_document.bin
+/data/dclm/preprocessed_text_document.idx
+```
+
+Pass the prefix without the `.bin` or `.idx` suffix:
+
+```python
+from megatron.bridge.training.config import GPTDatasetConfig
+
+dataset = GPTDatasetConfig(
+    seq_length=8192,
+    data_path="/data/dclm/preprocessed_text_document",
+    split="9999,8,2",
+    random_seed=1234,
+    reset_attention_mask=False,
+    reset_position_ids=False,
+    eod_mask_loss=False,
+)
+```
+
+The CLI-friendly `data_path` field is converted to Megatron Core's `blend` field during config finalization. For weighted multi-dataset training, use either a flattened `data_path` list with weights and prefixes or set `blend`/`blend_per_split` directly.
+
+```bash
+uv run python -m torch.distributed.run --nproc_per_node=8 scripts/training/run_recipe.py \
+    --recipe llama32_1b_pretrain_config \
+    --dataset llm-pretrain \
+    dataset.data_path=/data/dclm/preprocessed_text_document \
+    dataset.seq_length=8192
+```
+
+To create Megatron binary data from JSONL text, use the Megatron-LM `tools/preprocess_data.py` workflow. The DCLM tutorial shows a complete download, merge, shuffle, and preprocessing flow: [DCLM Data Preprocessing Tutorial](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/tutorials/data/dclm/README.md).
+
+## Local JSONL SFT and PEFT Data
+
+Text SFT and PEFT use a directory containing split files named `training.jsonl`, `validation.jsonl`, and optionally `test.jsonl`:
+
+```text
+/data/sft_jsonl/
+  training.jsonl
+  validation.jsonl
+  test.jsonl
+```
+
+The default text SFT dataset expects each JSONL record to contain prompt and answer fields compatible with the configured `prompt_template`. The common input/output format is:
+
+```json
+{"input": "Question: What is Megatron Bridge?", "output": "A PyTorch-native bridge for Megatron-Core workflows."}
+```
+
+Configure local JSONL data with `FinetuningDatasetConfig.dataset_root`:
+
+```python
+from megatron.bridge.training.config import FinetuningDatasetConfig
+
+dataset = FinetuningDatasetConfig(
+    dataset_root="/data/sft_jsonl",
+    seq_length=4096,
+)
+```
+
+Launch the generic recipe runner with the preloaded local JSONL dataset type:
+
+```bash
+uv run python -m torch.distributed.run --nproc_per_node=8 scripts/training/run_recipe.py \
+    --recipe llama32_1b_sft_config \
+    --dataset llm-finetune-preloaded \
+    dataset.dataset_root=/data/sft_jsonl \
+    dataset.seq_length=4096 \
+    checkpoint.pretrained_checkpoint=/checkpoints/base_model
+```
+
+For PEFT, use the PEFT recipe or set `cfg.peft`; the data layout stays the same. `checkpoint.pretrained_checkpoint` is required for the frozen base model, and `checkpoint.load` is used only when resuming adapter checkpoints.
+
+## Hugging Face Datasets for SFT and PEFT
+
+`HFDatasetConfig` downloads or reads a Hugging Face dataset, applies a processing function to each example, writes Bridge-compatible JSONL split files, and then builds the same fine-tuning dataset used by local JSONL.
+
+```python
+from megatron.bridge.data.builders.hf_dataset import HFDatasetConfig
+from megatron.bridge.data.hf_processors.squad import process_squad_example
+
+dataset = HFDatasetConfig(
+    dataset_name="rajpurkar/squad",
+    process_example_fn=process_squad_example,
+    dataset_root="/data/processed/squad",
+    seq_length=512,
+    val_proportion=0.1,
+    do_test=False,
+)
+```
+
+If `dataset_root` is omitted, the processed JSONL is cached under the NeMo datasets cache for the dataset name. Set `rewrite=False` when you want later runs to reuse already processed files.
+
+The generic launcher provides preset Hugging Face text datasets through `--dataset llm-finetune`:
+
+```bash
+uv run python -m torch.distributed.run --nproc_per_node=8 scripts/training/run_recipe.py \
+    --recipe llama32_1b_peft_config \
+    --dataset llm-finetune \
+    dataset.dataset_name=gsm8k \
+    checkpoint.pretrained_checkpoint=/checkpoints/base_model
+```
+
+## VLM Fine-Tuning Data
+
+VLM recipes usually use a dataset provider instead of `FinetuningDatasetConfig`. The provider owns both the storage format and the processor needed to turn image, video, audio, and text records into batches.
+
+For Energon/WebDataset data, create tar shards plus `.nv-meta` metadata and pass the dataset root to the recipe provider:
+
+```bash
+uv run python -m torch.distributed.run --nproc_per_node=8 scripts/training/run_recipe.py \
+    --recipe qwen3_vl_8b_peft_energon_config \
+    --dataset vlm-energon \
+    --step_func qwen3_vl_step \
+    dataset.path=/data/vlm_energon \
+    checkpoint.pretrained_checkpoint=/checkpoints/qwen3_vl_base
+```
+
+For preloaded VLM JSON or JSONL, use records with `messages` or `conversations` plus media paths. Relative image and video paths are resolved against `dataset.image_folder` by `PreloadedVLMConversationProvider`:
+
+```json
+{"messages": [{"role": "user", "content": "<image>Describe the image."}, {"role": "assistant", "content": "A receipt."}], "images": ["receipt_0001.jpg"]}
+```
+
+```bash
+uv run python -m torch.distributed.run --nproc_per_node=8 scripts/training/run_recipe.py \
+    --recipe qwen3_vl_8b_peft_config \
+    --dataset vlm-preloaded \
+    --step_func qwen3_vl_step \
+    dataset.train_data_path=/data/vlm/train.jsonl \
+    dataset.valid_data_path=/data/vlm/validation.jsonl \
+    dataset.image_folder=/data/vlm/images \
+    dataset.hf_processor_path=Qwen/Qwen3-VL-8B-Instruct \
+    checkpoint.pretrained_checkpoint=/checkpoints/qwen3_vl_base
+```
+
+For a complete WebDataset/Energon preparation example, see [VALOR32K-AVQA Dataset Preparation Guide](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/tutorials/data/valor32k-avqa/data-preparation.md).
+
+## Checkpoint Conversion Reminder
+
+Data preparation and checkpoint preparation are separate. From-scratch pretraining does not require a checkpoint. SFT and PEFT require base model weights through `checkpoint.pretrained_checkpoint` unless you are resuming from a complete native Megatron checkpoint with `checkpoint.load`.
+
+`checkpoint.pretrained_checkpoint` may point to a native Megatron checkpoint directory, a specific native `iter_N` directory, or a local Hugging Face full-model directory. For production and multi-node jobs, converting Hugging Face checkpoints to native Megatron format first is usually more repeatable.

--- a/docs/training/entry-points.md
+++ b/docs/training/entry-points.md
@@ -2,6 +2,26 @@
 
 Megatron Bridge provides unified training entry points for pretraining, Supervised Fine-Tuning (SFT), and Parameter-Efficient Fine-Tuning (PEFT). All training modes share the same underlying training loop architecture, differing primarily in their data handling and model configuration.
 
+## Choosing `pretrain()` or `finetune()`
+
+Use `pretrain()` for language-model pretraining jobs that use `GPTDatasetConfig` or `MockGPTDatasetConfig`. This includes training from scratch, continued pretraining on new corpora, and initializing model weights from `checkpoint.pretrained_checkpoint` before starting a new training run.
+
+Use `finetune()` for full SFT and PEFT. The function validates that either `checkpoint.pretrained_checkpoint` or `checkpoint.load` is set, then calls the same underlying training loop used by `pretrain()`. PEFT does not use a separate entry point: set `cfg.peft` to a LoRA or DoRA config, use a finetuning dataset config or provider, and launch through `finetune()`.
+
+The generic recipe launcher, `scripts/training/run_recipe.py`, follows the same split. Dataset types beginning with `llm-pretrain` run `pretrain()`. SFT, PEFT, VLM, and diffusion fine-tuning dataset types run `finetune()`.
+
+## Checkpoint Source by Workflow
+
+| Workflow | Dataset config | How to initialize or resume |
+|----------|----------------|-----------------------------|
+| From-scratch LLM pretraining | `GPTDatasetConfig` | Leave `checkpoint.pretrained_checkpoint` and `checkpoint.load` unset, or clear the recipe default `checkpoint.load` if an old local checkpoint directory exists. |
+| Full native Megatron resume | Any training workflow | Set `checkpoint.load` to the base checkpoint directory and optionally set `checkpoint.ckpt_step` for a specific iteration. `checkpoint.load` should not point to an `iter_N` directory. |
+| Initialize from native Megatron weights | Pretraining, SFT, or PEFT | Set `checkpoint.pretrained_checkpoint` to either the base checkpoint directory or a specific `iter_N` directory. |
+| Initialize from Hugging Face weights | Pretraining, SFT, or PEFT | Set `checkpoint.pretrained_checkpoint` to a local Hugging Face full-model directory containing `config.json` and weight files. A remote Hugging Face model ID is not a checkpoint path; download it locally or convert it first. |
+| Resume PEFT adapter training | PEFT | Keep `checkpoint.pretrained_checkpoint` pointed at the frozen base model and set `checkpoint.load` to the adapter checkpoint directory. `checkpoint.ckpt_step` applies to the adapter `load` path. |
+
+For multi-node jobs and repeatable production runs, converting a Hugging Face model to a native Megatron checkpoint first is usually the most robust option. Use `checkpoint.pretrained_checkpoint` for weight initialization and `checkpoint.load` for training-state resume; using a Hugging Face directory with `checkpoint.load` raises an error because HF format does not contain optimizer, RNG, dataloader, or scheduler state.
+
 ## Main Entry Points
 
 The {py:func}`bridge.training.pretrain.pretrain` and {py:func}`bridge.training.finetune.finetune` functions are the primary entry points for pretraining models—either from scratch or through fine-tuning. Each function accepts a {py:class}`bridge.training.config.ConfigContainer` along with a `forward_step_func` that defines how the training loop should be run.

--- a/docs/training/mixed-precision.md
+++ b/docs/training/mixed-precision.md
@@ -91,6 +91,54 @@ config = ConfigContainer(
 )
 ```
 
+## NVFP4 Training
+
+NVFP4 is a 4-bit floating-point training mode for Blackwell-generation GPUs, implemented through Transformer Engine. In Megatron Bridge it is configured through the `fp4` fields on {py:class}`bridge.training.mixed_precision.MixedPrecisionConfig`, not through the FP8 fields.
+
+NVFP4 and FP8 are mutually exclusive. If `fp4` and `fp8` are both set, configuration finalization raises an error. NVFP4 also requires a Transformer Engine build with NVFP4 block-scaling support.
+
+### NVFP4 Configuration Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `fp4` | `Optional[str]` | `None` | FP4 format. The predefined NVFP4 recipe uses `"e2m1"` |
+| `fp4_recipe` | `str` | `"nvfp4"` | FP4 recipe type |
+| `fp4_param` | `Optional[bool]` | `None` | Store module-level parameters in FP4; synchronized with `fp4_param_gather` |
+| `fp4_param_gather` | `bool` | `False` | Enable FP4 parameter gathering |
+
+### NVFP4 Recipe Examples
+
+Use the predefined NVFP4 mixed-precision recipe for pretraining, SFT, or PEFT:
+
+```python
+from megatron.bridge.training.config import ConfigContainer
+
+config = ConfigContainer(
+    mixed_precision="bf16_with_nvfp4_mixed",
+    # ... other config parameters
+)
+```
+
+The same field is used for fine-tuning:
+
+```python
+from megatron.bridge.recipes.llama import llama32_1b_peft_config
+
+cfg = llama32_1b_peft_config()
+cfg.mixed_precision = "bf16_with_nvfp4_mixed"
+cfg.checkpoint.pretrained_checkpoint = "/checkpoints/base_model"
+```
+
+Some model families expose tuned NVFP4 recipes. For example, Llama 3 8B has a low-precision pretraining helper:
+
+```python
+from megatron.bridge.recipes.llama import llama3_8b_low_precision_pretrain_config
+
+cfg = llama3_8b_low_precision_pretrain_config("bf16_with_nvfp4_mixed")
+```
+
+NVFP4 is related to FP8 in that both use Transformer Engine low-precision kernels and BF16 fallback for non-quantized state, but the configuration knobs are separate. Use FP8 recipes on Hopper or Blackwell when FP8 is the target precision; use NVFP4 recipes on Blackwell when the model and hardware have been validated for 4-bit training.
+
 ## Available Mixed Precision Recipes
 
 Megatron Bridge provides numerous predefined mixed precision recipes for different use cases. You can use the {py:func}`~megatron.bridge.training.mixed_precision.get_mixed_precision_config` utility function to convert from a string shortname to a class instance. For the complete list of available recipes and their specific configurations, see the {py:mod}`megatron.bridge.training.mixed_precision` module.

--- a/docs/training/peft.md
+++ b/docs/training/peft.md
@@ -18,8 +18,8 @@ As language models continue to grow in size, PEFT is gaining popularity for its 
 PEFT is configured as an optional attribute in `ConfigContainer`:
 
 ```python
-from megatron.bridge.training.config import ConfigContainer
 from megatron.bridge.peft.lora import LoRA
+from megatron.bridge.training.config import CheckpointConfig, ConfigContainer
 
 config = ConfigContainer(
     # ... other required configurations
@@ -30,14 +30,16 @@ config = ConfigContainer(
         dropout=0.1,
     ),
     checkpoint=CheckpointConfig(
-        pretrained_checkpoint="/path/to/pretrained/checkpoint",  # Required for PEFT
+        pretrained_checkpoint="/checkpoints/base_model",  # Required for PEFT
         save="/path/to/peft/checkpoints",
     ),
 )
 ```
 
 ```{note}
-**Requirements**: PEFT requires `checkpoint.pretrained_checkpoint` to be set to load the base model weights.
+**Requirement:** PEFT requires `checkpoint.pretrained_checkpoint` to load the frozen base model weights before adapters are inserted. This path may be a native Megatron checkpoint base directory, a specific native Megatron `iter_N` directory, or a local Hugging Face full-model directory containing `config.json` and model weight files. A remote Hugging Face model ID is not a checkpoint path; download it locally or convert it to Megatron format first.
+
+When resuming adapter training, keep `checkpoint.pretrained_checkpoint` pointed at the same base model and set `checkpoint.load` to the PEFT adapter checkpoint directory.
 ```
 
 ## Supported PEFT Methods
@@ -160,13 +162,13 @@ Let $A_q = A_k = A_v = A_{qkv}$ (weight tying)
 Then
 
 $$
-\begin{align}
-& [query \quad key \quad value] \\
-= & [W_q x + B_q A_q x \quad W_k x + B_k A_k x \quad W_v x + B_v A_v x] \quad\quad \text{(canonical formulation)} \\
-= & [W_q x + B_q (A_{qkv} x) \quad W_k x + B_k (A_{qkv} x) \quad W_v x + B_v (A_{qkv} x)] \\
-= & [W_q \quad W_k \quad W_v] x + [B_q \quad B_k \quad B_v]A_{qkv} x \\
-= & W_{qkv} x + B_{qkv} A_{qkv} x  \quad\quad \text{(performant formulation)}
-\end{align}
+\begin{aligned}
+[query \quad key \quad value]
+&= [W_q x + B_q A_q x \quad W_k x + B_k A_k x \quad W_v x + B_v A_v x] \quad\quad \text{(canonical formulation)} \\
+&= [W_q x + B_q (A_{qkv} x) \quad W_k x + B_k (A_{qkv} x) \quad W_v x + B_v (A_{qkv} x)] \\
+&= [W_q \quad W_k \quad W_v] x + [B_q \quad B_k \quad B_v]A_{qkv} x \\
+&= W_{qkv} x + B_{qkv} A_{qkv} x  \quad\quad \text{(performant formulation)}
+\end{aligned}
 $$
 
 Note: dimensions of weight matrices are as follows:
@@ -274,7 +276,10 @@ The following parameters define how LoRA is applied to your model. They control 
 
 ```python
 from megatron.bridge.training.config import (
-    ConfigContainer, TrainingConfig, CheckpointConfig
+    CheckpointConfig,
+    ConfigContainer,
+    SchedulerConfig,
+    TrainingConfig,
 )
 from megatron.bridge.data.builders.hf_dataset import HFDatasetConfig
 from megatron.bridge.data.hf_processors.squad import process_squad_example
@@ -308,7 +313,7 @@ config = ConfigContainer(
         seq_length=512,
     ),
     checkpoint=CheckpointConfig(
-        pretrained_checkpoint="/path/to/pretrained/model",  # Required
+        pretrained_checkpoint="/checkpoints/base_model",  # Required for PEFT
         save="/path/to/peft/checkpoints",
         save_interval=200,
     ),

--- a/scripts/training/README.md
+++ b/scripts/training/README.md
@@ -71,7 +71,7 @@ Configuration priority:
 2. Recipe defaults (lowest)
 
 Mode is inferred from the recipe name. If your recipe name doesn't include
-`pretrain`, `finetune`, `sft`, or `peft`, pass `--mode` explicitly.
+`pretrain`, `finetune`, `sft`, or `peft`, pass `--dataset` so the launcher can infer the mode from the dataset type.
 
 ## Step Function Selection
 


### PR DESCRIPTION
## Summary
- add a Training Data Preparation guide covering LLM pretraining bin/idx data, JSONL SFT/PEFT, Hugging Face dataset preprocessing, and VLM Energon/preloaded JSON providers
- clarify `pretrain()` vs `finetune()` workflows, PEFT checkpoint requirements, base checkpoint initialization vs full resume, and default recipe resume behavior
- add NVFP4 getting-started guidance and fix documentation correctness issues in recipe imports, stale launcher links, config naming, and PEFT LoRA math rendering

## Issue coverage
Covers the Training workflow work and Documentation correctness work sections of #3814.

## Verification
- `git diff --check`
- Markdown fence-balance check for changed Markdown files
- `pre-commit run --all-files`

## Notes
- `uv run pre-commit run --all-files` is blocked on this host before hooks run because `nvidia-resiliency-ext==0.6.0` has no compatible wheel for `manylinux_2_31_x86_64`; available wheels are `manylinux_2_39_aarch64` and `manylinux_2_39_x86_64`.
