### PR TITLE
docs(skills): fix agentic readiness paths

### DIFF
--- a/docs/training/cuda-graphs.md
+++ b/docs/training/cuda-graphs.md
@@ -113,7 +113,7 @@ For exact config snippets and runnable commands, see
 
 For a minimal Bridge-facing example, start from the functional smoke test:
 
-- `tests/functional_tests/recipes/test_llama_recipes_pretrain_cuda_graphs.py`
+- `tests/functional_tests/test_groups/recipes/test_llama_recipes_pretrain_cuda_graphs.py`
 
 For a lightweight CLI-driven path, use the performance harness with scoped
 capture and a small model recipe.

--- a/skills/adding-model-support/SKILL.md
+++ b/skills/adding-model-support/SKILL.md
@@ -56,15 +56,15 @@ weight dtypes such as `float8_e4m3fn` (FP8) or `uint8`/`uint4` with accompanying
 loads raw quantized values as-is. This produces a silently broken model (random-level loss, huge
 grad norms) instead of raising an error.
 
-**Fix:** Dequantize before conversion. Two approaches:
+**Fix:** Dequantize before or during conversion. The current in-repo pattern is to
+use a bridge hook plus the shared helpers in
+`src/megatron/bridge/models/conversion/quantization_utils.py`. Existing examples
+include `src/megatron/bridge/models/ministral3/ministral3_bridge.py`,
+`src/megatron/bridge/models/deepseek/deepseek_v3_bridge.py`, and
+`src/megatron/bridge/models/minimax_m2/minimax_m2_bridge.py`.
 
-1. **Standalone script** (recommended for user-facing models) — Write a
-   `dequant_fp8_for_bridge.py` in the model's examples folder.
-   Reference: `examples/models/mistral/ministral3/dequant_fp8_for_bridge.py`.
-   The pattern is: `w_bf16 = fp8_weight.to(bfloat16) * weight_scale_inv`.
-
-2. **In-bridge hook** — Override `maybe_modify_loaded_hf_weight()` in the bridge class to
-   dequantize on the fly during import:
+Override `maybe_modify_loaded_hf_weight()` in the bridge class to dequantize on
+the fly during import:
 
    ```python
    def maybe_modify_loaded_hf_weight(self, hf_param, hf_state_dict):
@@ -77,6 +77,8 @@ grad norms) instead of raising an error.
 
 Always add a sanity check in the verification workflow (e.g., print `std` of a weight tensor —
 quantized models typically have `std ≈ 13` before dequantization vs `std ≈ 0.006` after).
+Also add or update focused tests when touching export/import quantization paths; see
+`tests/unit_tests/models/test_fp8_param_export.py` for current FP8 export coverage.
 
 ## Phase 2: Bridge Support
 

--- a/skills/nemo-mbridge-perf-activation-recompute/SKILL.md
+++ b/skills/nemo-mbridge-perf-activation-recompute/SKILL.md
@@ -92,9 +92,14 @@ cfg.model.recompute_num_layers = 4
 ### Performance harness CLI
 
 ```bash
-python scripts/performance/run_performance_workload.py \
-  --recompute_granularity selective \
-  --recompute_modules core_attn layernorm \
+uv run python scripts/performance/run_script.py \
+  -m llama \
+  -mr llama3_8b \
+  --task pretrain \
+  -g h100 \
+  -c bf16 \
+  -ng 8 \
+  --recompute_modules core_attn,layernorm \
   ...
 ```
 

--- a/skills/nemo-mbridge-perf-activation-recompute/SKILL.md
+++ b/skills/nemo-mbridge-perf-activation-recompute/SKILL.md
@@ -10,24 +10,6 @@ when_to_use: Reducing GPU memory via activation recompute, or investigating a co
 Stable docs: @docs/training/activation-recomputation.md
 Card: @skills/nemo-mbridge-perf-activation-recompute/card.yaml
 
-## Answer Checklist
-
-For OOM or CUDA graph questions, lead with this exact sequence:
-
-1. First try `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`; many
-   borderline failures are allocator fragmentation, not activation capacity.
-2. Prefer selective recompute before full-layer recompute:
-   `recompute_granularity="selective"` with `recompute_modules=["core_attn"]`.
-3. If still borderline, optionally add `"layernorm"`; use `"mlp"` only as a
-   last resort because it has a large compute cost on wide dense FFNs.
-4. Use full-layer recompute only after selective recompute fails to fit, and
-   always name the required fields: `recompute_granularity="full"`,
-   `recompute_method`, and `recompute_num_layers`.
-5. If FP8 or TE-scoped CUDA graphs are enabled, call out the assertion risk:
-   full-layer recompute is incompatible with TE scopes such as `attn`, `mlp`,
-   and `moe_router`. Valid fixes are selective recompute, `cuda_graph_impl="none"`,
-   or `cuda_graph_impl="local"` with `cuda_graph_scope="full_iteration"`.
-
 ## What It Is
 
 Activation recompute trades GPU compute for memory by discarding intermediate
@@ -45,17 +27,19 @@ how many layers via `recompute_num_layers`.
 
 ## Quick Decision
 
-1. **Set `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` first** — most
-   borderline OOMs are caused by memory fragmentation, not capacity. This
-   fixes it at zero cost. See @skills/nemo-mbridge-perf-memory-tuning/SKILL.md.
-2. Start with `recompute_granularity=selective`, `recompute_modules=[core_attn]`
-   (often already the default in recipes).
-3. Add `layernorm` to recompute modules — nearly free compute-wise but saves
-   negligible memory. Only helps in extremely borderline cases.
-4. Add `mlp` as a last resort — saves ~3 GB but costs ~16% GPU utilization on
-   large dense models (Llama3 70B).
-5. Use `recompute_granularity=full` only when selective recompute still does
-   not fit.
+1. Rule out allocator fragmentation first with
+   `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`; see
+   @skills/nemo-mbridge-perf-memory-tuning/SKILL.md.
+2. For activation pressure, start with selective recompute:
+   `recompute_granularity="selective"` and `recompute_modules=["core_attn"]`.
+3. Add modules by cost: `"layernorm"` is cheap but saves little, while `"mlp"`
+   saves much more memory at a clear throughput cost.
+4. Use full-layer recompute only when selective recompute does not fit, and set
+   all required fields: `recompute_granularity="full"`, `recompute_method`, and
+   `recompute_num_layers`.
+5. With FP8 or TE-scoped CUDA graphs, avoid full-layer recompute unless graph
+   scope is `full_iteration`; otherwise use selective recompute or disable TE
+   graph capture.
 
 CPU offloading (`cpu_offloading=True`) is an alternative that avoids recompute
 cost entirely, but it is **incompatible with PP > 1**.
@@ -196,9 +180,9 @@ Key takeaways:
 
 | Symptom | Cause | Confirm | Fix |
 |---|---|---|---|
-| >15% GPU utilization drop | mlp recompute on large FFN | check `recompute_modules` includes `mlp` | check `expandable_segments:True` is set; consider reducing MBS |
-| Still OOM after adding layernorm | layernorm activations are too small | compare peak memory before/after | add mlp recompute or check `expandable_segments:True` |
-| `AssertionError: full recompute is only supported with full iteration CUDA graph` | layer-level recompute (`recompute_granularity=full` + `recompute_num_layers`) with TE-scoped graphs. FP8 CS configs default to `cuda_graph_impl=transformer_engine`, `scope=mlp`. | check `cuda_graph_impl` and `cuda_graph_scope` | use submodule recompute (`selective` + `recompute_modules`), or `cuda_graph_impl=none`, or `local` + `full_iteration` |
+| >15% GPU utilization drop | `mlp` recompute on a large FFN | check whether `recompute_modules` includes `mlp` | remove `mlp`, lower micro batch size, or use CPU offload if PP=1 |
+| Still OOM after adding layernorm | layernorm activations are too small to move the peak materially | compare peak memory before/after | switch to a higher-impact module or full-layer recompute |
+| `AssertionError: full recompute is only supported with full iteration CUDA graph` | layer-level recompute with TE-scoped graph capture | check `cuda_graph_impl` and `cuda_graph_scope` | use `selective`, set `cuda_graph_impl=none`, or use `local` + `full_iteration` |
 | ValueError: PP + CPU offloading | `cpu_offloading=True` with `pipeline_model_parallel_size > 1` | check PP config | disable CPU offloading or set PP=1 |
 | mlp+core_attn worse than mlp alone | double recompute overhead | compare Exp 1 vs Exp 2 | use mlp alone |
 

--- a/skills/nemo-mbridge-perf-cuda-graphs/SKILL.md
+++ b/skills/nemo-mbridge-perf-cuda-graphs/SKILL.md
@@ -241,7 +241,7 @@ def _delete_cuda_graphs(cuda_graph_helper):
 | `tests/unit_tests/training/test_config.py` | `full_iteration` NaN-check constraint |
 | `tests/unit_tests/training/test_comm_overlap.py` | `delay_wgrad` + CUDA graph interaction |
 | `tests/unit_tests/models/test_gpt_full_te_layer_autocast_spec.py` | TE autocast with CUDA graphs |
-| `tests/functional_tests/recipes/test_llama_recipes_pretrain_cuda_graphs.py` | End-to-end local and TE graph smoke tests |
+| `tests/functional_tests/test_groups/recipes/test_llama_recipes_pretrain_cuda_graphs.py` | End-to-end local and TE graph smoke tests |
 | `tests/unit_tests/recipes/kimi/test_kimi_k2.py` | TE + CUDA graph recipe config |
 | `tests/unit_tests/recipes/gpt/test_gpt3_175b.py` | TE + CUDA graph recipe config |
 | `tests/unit_tests/recipes/qwen_vl/test_qwen25_vl_recipes.py` | VLM CUDA graph settings |
@@ -332,7 +332,7 @@ uv run python -m pytest \
 
 ```bash
 uv run python -m pytest \
-  tests/functional_tests/recipes/test_llama_recipes_pretrain_cuda_graphs.py -q
+  tests/functional_tests/test_groups/recipes/test_llama_recipes_pretrain_cuda_graphs.py -q
 ```
 
 ### Success criteria

--- a/skills/nemo-mbridge-perf-cuda-graphs/card.yaml
+++ b/skills/nemo-mbridge-perf-cuda-graphs/card.yaml
@@ -229,8 +229,8 @@ measured_results:
 minimal_example:
   docs_example: docs/training/cuda-graphs.md
   skill_example: skills/nemo-mbridge-perf-cuda-graphs/SKILL.md
-  test_path: tests/functional_tests/recipes/test_llama_recipes_pretrain_cuda_graphs.py
-  cli_path: scripts/performance/run_performance_workload.py
+  test_path: tests/functional_tests/test_groups/recipes/test_llama_recipes_pretrain_cuda_graphs.py
+  cli_path: scripts/performance/run_script.py
 failure_modes:
   - name: missing_te_rng_tracker
     symptom: provider assertion before training starts
@@ -284,7 +284,7 @@ evidence:
   - src/megatron/bridge/training/comm_overlap.py
   - scripts/performance/utils/overrides.py
   - tests/unit_tests/training/test_config.py
-  - tests/functional_tests/recipes/test_llama_recipes_pretrain_cuda_graphs.py
+  - tests/functional_tests/test_groups/recipes/test_llama_recipes_pretrain_cuda_graphs.py
 follow_up_validation:
   - Re-run GPT-OSS-20B pretrain with lower LR and/or larger GBS for a meaningful loss comparison.
   - Retry GPT-OSS packed-sequence SFT and LoRA on a newer TE/container build.


### PR DESCRIPTION
## Summary

Fixes the remaining agentic-readiness documentation gaps from #3814:

- updates CUDA graph docs and skill metadata to point at the live functional test path
- replaces the nonexistent performance workload script reference with the current performance harness entry point
- removes the stale FP8 dequantization example script reference and points model-support guidance at current bridge hooks, helpers, examples, and tests
- deduplicates activation-recompute skill guidance after NVSkills content validation flagged the touched skill's repeated checklist/decision/failure-diagnosis content

This complements #4254 and #4259 by covering the issue's Agentic readiness section and the acceptance criteria around stale script/test/import references.

## Verification

- `git diff --check`
- `git grep -n "run_performance_workload.py\|tests/functional_tests/recipes/test_llama_recipes_pretrain_cuda_graphs.py\|examples/models/mistral/ministral3/dequant_fp8_for_bridge.py" -- docs skills scripts tests examples src` returned no matches
- `git ls-files --error-unmatch` for all replacement script/test/source paths
- Markdown fence balance check for modified markdown files
- YAML parse check for `skills/nemo-mbridge-perf-cuda-graphs/card.yaml`
- `pre-commit run --all-files`

Note: `uv run pre-commit run --all-files` was attempted after initializing `3rdparty/Megatron-LM`, but local resolution is blocked because `nvidia-resiliency-ext==0.6.0` has no wheel for this host platform (`manylinux_2_31_x86_64`; available wheels are `manylinux_2_39_*`).