### PR TITLE
fix(training): route MTP inputs from model chunk

### DIFF
--- a/src/megatron/bridge/data/iterator_utils.py
+++ b/src/megatron/bridge/data/iterator_utils.py
@@ -14,7 +14,6 @@
 
 """Iterator utilities for handling virtual pipeline parallelism."""
 
-import queue
 from typing import Iterator, TypeVar, Union
 
 
@@ -29,8 +28,8 @@ def make_data_iterator_list(
     With interleaved/virtual pipeline parallelism, Megatron expects a list of one data
     iterator per model chunk. Each model chunk independently gets data from its data
     iterator, so we need to interact with the data iterator multiple times for each
-    microbatch step. Instead of incorporating this logic into the data loader, we cache
-    the iterator's output to the first model chunk and reuse it in the other model chunks.
+    microbatch step. Instead of incorporating this logic into the data loader, we lazily
+    cache the source iterator by microbatch index and expose one cache view per model chunk.
 
     Args:
         model: List of model chunks (when virtual PP is used) or single-element list
@@ -39,8 +38,8 @@ def make_data_iterator_list(
     Returns:
         If model has only 1 chunk: returns the iterator as-is
         If model has multiple chunks: returns a list of iterators with caching behavior
-            - First iterator in list consumes from data_iterator and caches values
-            - Remaining iterators are proxies that read from the cache
+            - Each iterator can advance independently
+            - All iterators see the same microbatch sequence regardless of scheduler order
 
     Example:
         >>> # With virtual PP size = 2 (model has 2 chunks)
@@ -54,52 +53,39 @@ def make_data_iterator_list(
     if not isinstance(model, list) or len(model) <= 1:
         return data_iterator
 
-    class CachingIterator:
-        """Iterator wrapper that caches values for proxy iterators.
+    class SharedCache:
+        """Shared lazy cache over an iterator.
 
-        When the main iterator is advanced, it caches the value and distributes
-        it to all registered proxy iterators.
+        Any model chunk may be scheduled first. Fetching by index fills the cache
+        up to that position, so all chunk iterators see the same microbatch
+        sequence without assuming chunk 0 advances first.
         """
-
-        class Proxy:
-            """Proxy iterator that reads from the cache.
-
-            Assumed to never advance past the caching iterator.
-            """
-
-            def __init__(self):
-                self.cache = queue.Queue()
-
-            def __iter__(self):
-                return self
-
-            def __next__(self):
-                return self.cache.get_nowait()
 
         def __init__(self, iterator: Iterator[DataT]):
             self.iterator = iterator
-            self.proxies = []
+            self.cache: list[DataT] = []
 
-        def make_proxy(self):
-            """Create a new proxy iterator that reads from this cache."""
-            self.proxies.append(CachingIterator.Proxy())
-            return self.proxies[-1]
+        def get(self, index: int) -> DataT:
+            """Return the cached value at index, reading the source iterator if needed."""
+            while len(self.cache) <= index:
+                self.cache.append(next(self.iterator))
+            return self.cache[index]
+
+    class CacheView:
+        """Per-model-chunk iterator view into a shared cache."""
+
+        def __init__(self, cache: SharedCache):
+            self.cache = cache
+            self.index = 0
 
         def __iter__(self):
             return self
 
         def __next__(self):
-            """Advance the main iterator and cache the value for all proxies."""
-            val = next(self.iterator)
-            for proxy in self.proxies:
-                proxy.cache.put(val)
+            """Return the next value for this chunk from the shared cache."""
+            val = self.cache.get(self.index)
+            self.index += 1
             return val
 
-    # Create list of iterator wrappers - one per model chunk
-    # First iterator is the main caching iterator
-    # Remaining iterators are proxies that read from the cache
-    iters = [CachingIterator(data_iterator)]
-    while len(iters) < len(model):
-        iters.append(iters[0].make_proxy())
-
-    return iters
+    shared_cache = SharedCache(data_iterator)
+    return [CacheView(shared_cache) for _ in model]

--- a/src/megatron/bridge/models/model_provider.py
+++ b/src/megatron/bridge/models/model_provider.py
@@ -678,6 +678,7 @@ def _create_model(
                 vp_stage=i,
             )
             this_model.model_type = model_type
+            this_model.vp_stage = i
             model.append(this_model)
     else:
         pre_process = is_pp_first_stage(pp_group)

--- a/src/megatron/bridge/training/gpt_step.py
+++ b/src/megatron/bridge/training/gpt_step.py
@@ -78,8 +78,8 @@ def _layout_stage_has_mtp(layout, *, pp_rank: int, pp_size: int, vp_stage: int) 
     )
 
 
-def _current_pp_stage_has_mtp(cfg: ConfigContainer, *, pg_collection) -> bool:
-    """Return whether the current PP/VPP stage owns the configured MTP block."""
+def _infer_current_stage_has_mtp_from_layout(cfg: ConfigContainer, *, pg_collection) -> bool:
+    """Infer whether the current PP/VPP stage owns the configured MTP block from layout."""
     model_cfg = getattr(cfg, "model", None)
     layout = getattr(model_cfg, "pipeline_model_parallel_layout", None)
     if layout is None:
@@ -95,14 +95,19 @@ def _current_pp_stage_has_mtp(cfg: ConfigContainer, *, pg_collection) -> bool:
     return _layout_stage_has_mtp(layout, pp_rank=pp_rank, pp_size=pp_size, vp_stage=vp_stage)
 
 
-def _current_pp_stage_needs_mtp_inputs(cfg: ConfigContainer, *, pg_collection, is_last: bool) -> bool:
-    """Return whether this stage needs token ids for MTP embedding lookup."""
+def _infer_current_stage_needs_mtp_inputs(cfg: ConfigContainer, *, pg_collection, is_last: bool) -> bool:
+    """Infer whether this stage needs token ids for MTP embedding lookup."""
     model_cfg = getattr(cfg, "model", None)
     layout = getattr(model_cfg, "pipeline_model_parallel_layout", None)
     if layout is None:
         return is_last
 
-    return _current_pp_stage_has_mtp(cfg, pg_collection=pg_collection)
+    return _infer_current_stage_has_mtp_from_layout(cfg, pg_collection=pg_collection)
+
+
+def _model_chunk_needs_mtp_inputs(model: GPTModel) -> bool:
+    """Return whether the current model chunk owns an MTP block."""
+    return bool(getattr(unwrap_model(model), "mtp_process", False))
 
 
 def _partition_packed_batch_for_cp(batch: dict[str, torch.Tensor], cp_size: int) -> dict[str, torch.Tensor]:
@@ -209,7 +214,12 @@ def get_batch_from_iterator(
 
 
 def get_batch(
-    data_iterator: Iterable, cfg: ConfigContainer, use_mtp: bool = False, *, pg_collection
+    data_iterator: Iterable,
+    cfg: ConfigContainer,
+    use_mtp: bool = False,
+    *,
+    pg_collection,
+    include_mtp_inputs: bool | None = None,
 ) -> tuple[
     torch.Tensor,
     torch.Tensor,
@@ -228,6 +238,8 @@ def get_batch(
         data_iterator: Input data iterator
         cfg: Configuration container
         use_mtp: Whether Multi-Token Prediction layers are enabled
+        include_mtp_inputs: Whether this specific model chunk needs MTP input tensors. If unset,
+            the value is inferred from the pipeline layout.
 
     Returns:
         tuple of tensors containing tokens, labels, loss_mask, attention_mask, position_ids,
@@ -239,9 +251,12 @@ def get_batch(
     is_last = is_pp_last_stage(pg_collection.pp)
     is_middle = (not is_first) and (not is_last)
     include_full_batch_fields = is_middle and _middle_pp_stage_needs_batch(cfg)
-    include_mtp_inputs = use_mtp and _current_pp_stage_needs_mtp_inputs(
-        cfg, pg_collection=pg_collection, is_last=is_last
-    )
+    if include_mtp_inputs is None:
+        include_mtp_inputs = use_mtp and _infer_current_stage_needs_mtp_inputs(
+            cfg, pg_collection=pg_collection, is_last=is_last
+        )
+    else:
+        include_mtp_inputs = use_mtp and include_mtp_inputs
     if is_middle and not include_full_batch_fields and not include_mtp_inputs:
         return None, None, None, None, None, None, None, None, None, None
 
@@ -314,7 +329,13 @@ def _forward_step_common(
             max_seqlen,
             cu_seqlens_unpadded,
             cu_seqlens_unpadded_argmin,
-        ) = get_batch(data_iterator, state.cfg, use_mtp, pg_collection=pg_collection)
+        ) = get_batch(
+            data_iterator,
+            state.cfg,
+            use_mtp,
+            pg_collection=pg_collection,
+            include_mtp_inputs=_model_chunk_needs_mtp_inputs(model) if use_mtp else False,
+        )
     timers("batch-generator").stop()
 
     forward_args = {

--- a/src/megatron/bridge/training/gpt_step.py
+++ b/src/megatron/bridge/training/gpt_step.py
@@ -78,8 +78,8 @@ def _layout_stage_has_mtp(layout, *, pp_rank: int, pp_size: int, vp_stage: int) 
     )
 
 
-def _infer_current_stage_has_mtp_from_layout(cfg: ConfigContainer, *, pg_collection) -> bool:
-    """Infer whether the current PP/VPP stage owns the configured MTP block from layout."""
+def _current_stage_has_mtp_from_layout(cfg: ConfigContainer, *, pg_collection) -> bool:
+    """Return whether the current PP/VPP stage owns the configured MTP block, derived from layout."""
     model_cfg = getattr(cfg, "model", None)
     layout = getattr(model_cfg, "pipeline_model_parallel_layout", None)
     if layout is None:
@@ -95,14 +95,14 @@ def _infer_current_stage_has_mtp_from_layout(cfg: ConfigContainer, *, pg_collect
     return _layout_stage_has_mtp(layout, pp_rank=pp_rank, pp_size=pp_size, vp_stage=vp_stage)
 
 
-def _infer_current_stage_needs_mtp_inputs(cfg: ConfigContainer, *, pg_collection, is_last: bool) -> bool:
-    """Infer whether this stage needs token ids for MTP embedding lookup."""
+def _current_stage_needs_mtp_inputs_from_layout(cfg: ConfigContainer, *, pg_collection, is_last: bool) -> bool:
+    """Return whether this stage needs token ids for MTP embedding lookup, derived from layout."""
     model_cfg = getattr(cfg, "model", None)
     layout = getattr(model_cfg, "pipeline_model_parallel_layout", None)
     if layout is None:
         return is_last
 
-    return _infer_current_stage_has_mtp_from_layout(cfg, pg_collection=pg_collection)
+    return _current_stage_has_mtp_from_layout(cfg, pg_collection=pg_collection)
 
 
 def _model_chunk_needs_mtp_inputs(model: GPTModel) -> bool:
@@ -252,7 +252,7 @@ def get_batch(
     is_middle = (not is_first) and (not is_last)
     include_full_batch_fields = is_middle and _middle_pp_stage_needs_batch(cfg)
     if include_mtp_inputs is None:
-        include_mtp_inputs = use_mtp and _infer_current_stage_needs_mtp_inputs(
+        include_mtp_inputs = use_mtp and _current_stage_needs_mtp_inputs_from_layout(
             cfg, pg_collection=pg_collection, is_last=is_last
         )
     else:

--- a/src/megatron/bridge/training/gpt_step.py
+++ b/src/megatron/bridge/training/gpt_step.py
@@ -20,10 +20,16 @@ import modelopt.torch.distill as mtd
 import torch
 from megatron.core import parallel_state
 from megatron.core.models.gpt import GPTModel
-from megatron.core.pipeline_parallel.utils import is_pp_first_stage, is_pp_last_stage
+from megatron.core.pipeline_parallel.utils import (
+    is_pp_first_stage,
+    is_pp_last_stage,
+    is_vp_first_stage,
+    is_vp_last_stage,
+)
 from megatron.core.transformer.enums import LayerType
 from megatron.core.transformer.pipeline_parallel_layer_layout import PipelineParallelLayerLayout
 from megatron.core.utils import (
+    get_attr_wrapped_model,
     get_batch_on_this_cp_rank,
     get_model_config,
     get_pg_rank,
@@ -78,7 +84,7 @@ def _layout_stage_has_mtp(layout, *, pp_rank: int, pp_size: int, vp_stage: int) 
     )
 
 
-def _current_stage_has_mtp_from_layout(cfg: ConfigContainer, *, pg_collection) -> bool:
+def _current_stage_has_mtp_from_layout(cfg: ConfigContainer, *, pg_collection, vp_stage: int | None = None) -> bool:
     """Return whether the current PP/VPP stage owns the configured MTP block, derived from layout."""
     model_cfg = getattr(cfg, "model", None)
     layout = getattr(model_cfg, "pipeline_model_parallel_layout", None)
@@ -88,26 +94,33 @@ def _current_stage_has_mtp_from_layout(cfg: ConfigContainer, *, pg_collection) -
     pp_group = getattr(pg_collection, "pp", None)
     pp_rank = get_pg_rank(pp_group)
     pp_size = get_pg_size(pp_group)
-    vp_stage = parallel_state.get_virtual_pipeline_model_parallel_rank()
+    if vp_stage is None:
+        vp_stage = parallel_state.get_virtual_pipeline_model_parallel_rank()
     if vp_stage is None:
         vp_stage = 0
 
     return _layout_stage_has_mtp(layout, pp_rank=pp_rank, pp_size=pp_size, vp_stage=vp_stage)
 
 
-def _current_stage_needs_mtp_inputs_from_layout(cfg: ConfigContainer, *, pg_collection, is_last: bool) -> bool:
+def _current_stage_needs_mtp_inputs_from_layout(
+    cfg: ConfigContainer, *, pg_collection, is_last: bool, vp_stage: int | None = None
+) -> bool:
     """Return whether this stage needs token ids for MTP embedding lookup, derived from layout."""
     model_cfg = getattr(cfg, "model", None)
     layout = getattr(model_cfg, "pipeline_model_parallel_layout", None)
     if layout is None:
         return is_last
 
-    return _current_stage_has_mtp_from_layout(cfg, pg_collection=pg_collection)
+    return _current_stage_has_mtp_from_layout(cfg, pg_collection=pg_collection, vp_stage=vp_stage)
 
 
-def _model_chunk_needs_mtp_inputs(model: GPTModel) -> bool:
-    """Return whether the current model chunk owns an MTP block."""
-    return bool(getattr(unwrap_model(model), "mtp_process", False))
+def _model_chunk_vp_stage(model: GPTModel) -> int | None:
+    """Return the virtual pipeline stage owned by the current model chunk."""
+    try:
+        vp_stage = get_attr_wrapped_model(model, "vp_stage", allow_none=False)
+    except RuntimeError:
+        return None
+    return vp_stage if isinstance(vp_stage, int) else None
 
 
 def _partition_packed_batch_for_cp(batch: dict[str, torch.Tensor], cp_size: int) -> dict[str, torch.Tensor]:
@@ -219,7 +232,7 @@ def get_batch(
     use_mtp: bool = False,
     *,
     pg_collection,
-    include_mtp_inputs: bool | None = None,
+    vp_stage: int | None = None,
 ) -> tuple[
     torch.Tensor,
     torch.Tensor,
@@ -238,8 +251,7 @@ def get_batch(
         data_iterator: Input data iterator
         cfg: Configuration container
         use_mtp: Whether Multi-Token Prediction layers are enabled
-        include_mtp_inputs: Whether this specific model chunk needs MTP input tensors. If unset,
-            the value is inferred from the pipeline layout.
+        vp_stage: Virtual pipeline stage for the current model chunk.
 
     Returns:
         tuple of tensors containing tokens, labels, loss_mask, attention_mask, position_ids,
@@ -247,16 +259,19 @@ def get_batch(
         cu_seqlens_unpadded_argmin
     """
     # Determine pipeline stage role via process group collection
-    is_first = is_pp_first_stage(pg_collection.pp)
-    is_last = is_pp_last_stage(pg_collection.pp)
+    model_cfg = getattr(cfg, "model", None)
+    vp_size = getattr(model_cfg, "virtual_pipeline_model_parallel_size", None)
+    is_first = is_pp_first_stage(pg_collection.pp) and (
+        vp_stage is None or is_vp_first_stage(vp_stage=vp_stage, vp_size=vp_size)
+    )
+    is_last = is_pp_last_stage(pg_collection.pp) and (
+        vp_stage is None or is_vp_last_stage(vp_stage=vp_stage, vp_size=vp_size)
+    )
     is_middle = (not is_first) and (not is_last)
     include_full_batch_fields = is_middle and _middle_pp_stage_needs_batch(cfg)
-    if include_mtp_inputs is None:
-        include_mtp_inputs = use_mtp and _current_stage_needs_mtp_inputs_from_layout(
-            cfg, pg_collection=pg_collection, is_last=is_last
-        )
-    else:
-        include_mtp_inputs = use_mtp and include_mtp_inputs
+    include_mtp_inputs = use_mtp and _current_stage_needs_mtp_inputs_from_layout(
+        cfg, pg_collection=pg_collection, is_last=is_last, vp_stage=vp_stage
+    )
     if is_middle and not include_full_batch_fields and not include_mtp_inputs:
         return None, None, None, None, None, None, None, None, None, None
 
@@ -334,7 +349,7 @@ def _forward_step_common(
             state.cfg,
             use_mtp,
             pg_collection=pg_collection,
-            include_mtp_inputs=_model_chunk_needs_mtp_inputs(model) if use_mtp else False,
+            vp_stage=_model_chunk_vp_stage(model),
         )
     timers("batch-generator").stop()
 

--- a/tests/unit_tests/data/test_iterator_utils.py
+++ b/tests/unit_tests/data/test_iterator_utils.py
@@ -80,6 +80,19 @@ def test_make_data_iterator_list_two_chunks():
         assert val1 == expected_val
 
 
+def test_make_data_iterator_list_supports_out_of_order_chunks():
+    """Test that later chunks can consume before earlier chunks."""
+    data = iter([{"batch": 1}, {"batch": 2}])
+    model = ["chunk1", "chunk2"]
+
+    result = make_data_iterator_list(model, data)
+
+    assert next(result[1]) == {"batch": 1}
+    assert next(result[0]) == {"batch": 1}
+    assert next(result[1]) == {"batch": 2}
+    assert next(result[0]) == {"batch": 2}
+
+
 def test_make_data_iterator_list_empty_model_list():
     """Test with empty model list."""
     data = iter([1, 2, 3])

--- a/tests/unit_tests/models/test_model_instantiation.py
+++ b/tests/unit_tests/models/test_model_instantiation.py
@@ -154,6 +154,7 @@ class TestCreateModel:
         assert isinstance(result, list)
         assert len(result) == 2
         assert all(model.model_type == ModelType.encoder_or_decoder for model in result)
+        assert [model.vp_stage for model in result] == [0, 1]
         assert model_provider.provide.call_count == 2
 
     @patch("megatron.bridge.models.model_provider.tensor_parallel")

--- a/tests/unit_tests/training/test_gpt_step.py
+++ b/tests/unit_tests/training/test_gpt_step.py
@@ -136,6 +136,17 @@ class _NoopTimer:
         return False
 
 
+class _RecordingModel:
+    def __init__(self, *, mtp_process=False, output=None):
+        self.mtp_process = mtp_process
+        self.output = output if output is not None else torch.tensor(1.0)
+        self.forward_kwargs = None
+
+    def __call__(self, **kwargs):
+        self.forward_kwargs = kwargs
+        return self.output
+
+
 class TestGetBatch:
     """Tests for the get_batch helper."""
 
@@ -341,6 +352,124 @@ class TestGetBatch:
         assert out_attention_mask is None
         assert out_position_ids is None
 
+    def test_forward_common_uses_model_chunk_mtp_process_for_vpp_stage(self, monkeypatch):
+        """Interleaved MTP chunks load tokens even when global VPP rank is unset."""
+        _set_last_pp_stage(monkeypatch)
+        _set_distributed_initialized(monkeypatch)
+        monkeypatch.setattr(
+            "megatron.bridge.training.gpt_step.get_batch_on_this_cp_rank",
+            lambda batch, is_hybrid_cp=False, cp_group=None, hybrid_cp_group_func=None: batch,
+        )
+        monkeypatch.setattr(
+            "megatron.bridge.training.gpt_step.parallel_state.get_virtual_pipeline_model_parallel_rank",
+            lambda: None,
+        )
+
+        tokens = _as_nocuda(torch.tensor([[1, 2, 3, 4]]))
+        labels = _as_nocuda(torch.tensor([[2, 3, 4, 5]]))
+        loss_mask = _as_nocuda(torch.ones(1, 4))
+        position_ids = _as_nocuda(torch.arange(4).unsqueeze(0))
+        batch = {
+            "tokens": tokens,
+            "labels": labels,
+            "loss_mask": loss_mask,
+            "attention_mask": None,
+            "position_ids": position_ids,
+        }
+        model = _RecordingModel(mtp_process=True)
+        state = Mock()
+        state.cfg = _make_cfg(
+            pipeline_model_parallel_layout="Et*4|(t*4|)*14tmL",
+            pipeline_model_parallel_size=8,
+            mtp_num_layers=1,
+        )
+        state.timers = _NoopTimer()
+        state.straggler_timer = _NoopTimer()
+        config = type(
+            "Config",
+            (),
+            {
+                "is_hybrid_model": False,
+                "mtp_num_layers": 1,
+                "overlap_moe_expert_parallel_comm": False,
+            },
+        )()
+
+        monkeypatch.setattr("megatron.bridge.training.gpt_step.get_model_config", lambda model: config)
+        monkeypatch.setattr(
+            "megatron.bridge.training.gpt_step.get_pg_collection",
+            lambda model: _MockPGCollection(pp_rank=7, pp_size=8),
+        )
+
+        output, returned_loss_mask = _forward_step_common(state, _Iterator(batch), model)
+
+        assert torch.equal(output, torch.tensor(1.0))
+        assert torch.equal(returned_loss_mask, loss_mask)
+        assert model.forward_kwargs is not None
+        assert torch.equal(model.forward_kwargs["input_ids"], tokens)
+        assert torch.equal(model.forward_kwargs["position_ids"], position_ids)
+        assert torch.equal(model.forward_kwargs["labels"], labels)
+
+    def test_forward_common_uses_model_chunk_mtp_process_instead_of_layout_fallback(self, monkeypatch):
+        """A non-MTP model chunk must not load tokens just because layout inference would."""
+        _set_last_pp_stage(monkeypatch)
+        _set_distributed_initialized(monkeypatch)
+        monkeypatch.setattr(
+            "megatron.bridge.training.gpt_step.get_batch_on_this_cp_rank",
+            lambda batch, is_hybrid_cp=False, cp_group=None, hybrid_cp_group_func=None: batch,
+        )
+        monkeypatch.setattr(
+            "megatron.bridge.training.gpt_step.parallel_state.get_virtual_pipeline_model_parallel_rank",
+            lambda: 1,
+        )
+
+        tokens = _as_nocuda(torch.tensor([[1, 2, 3, 4]]))
+        labels = _as_nocuda(torch.tensor([[2, 3, 4, 5]]))
+        loss_mask = _as_nocuda(torch.ones(1, 4))
+        position_ids = _as_nocuda(torch.arange(4).unsqueeze(0))
+        batch = {
+            "tokens": tokens,
+            "labels": labels,
+            "loss_mask": loss_mask,
+            "attention_mask": None,
+            "position_ids": position_ids,
+        }
+        layout = [[] for _ in range(16)]
+        layout[15] = ["mtp"]
+        model = _RecordingModel(mtp_process=False)
+        state = Mock()
+        state.cfg = _make_cfg(
+            pipeline_model_parallel_layout=layout,
+            pipeline_model_parallel_size=8,
+            mtp_num_layers=1,
+        )
+        state.timers = _NoopTimer()
+        state.straggler_timer = _NoopTimer()
+        config = type(
+            "Config",
+            (),
+            {
+                "is_hybrid_model": False,
+                "mtp_num_layers": 1,
+                "overlap_moe_expert_parallel_comm": False,
+            },
+        )()
+
+        monkeypatch.setattr("megatron.bridge.training.gpt_step.get_model_config", lambda model: config)
+        monkeypatch.setattr(
+            "megatron.bridge.training.gpt_step.get_pg_collection",
+            lambda model: _MockPGCollection(pp_rank=7, pp_size=8),
+        )
+
+        output, returned_loss_mask = _forward_step_common(state, _Iterator(batch), model)
+
+        assert torch.equal(output, torch.tensor(1.0))
+        assert torch.equal(returned_loss_mask, loss_mask)
+        assert model.forward_kwargs is not None
+        assert model.forward_kwargs["input_ids"] is None
+        assert model.forward_kwargs["position_ids"] is None
+        assert torch.equal(model.forward_kwargs["labels"], labels)
+
     def test_forward_common_passes_packed_seq_params_on_middle_pp_stage(self, monkeypatch):
         """Forward path must pass packed metadata on middle PP stages."""
         sentinel_packed_seq_params = object()
@@ -370,7 +499,7 @@ class TestGetBatch:
         monkeypatch.setattr("megatron.bridge.training.gpt_step.get_pg_collection", lambda model: _MockPGCollection())
         monkeypatch.setattr(
             "megatron.bridge.training.gpt_step.get_batch",
-            lambda data_iterator, cfg, use_mtp, pg_collection: (
+            lambda data_iterator, cfg, use_mtp, *, pg_collection, include_mtp_inputs=None: (
                 tokens,
                 labels,
                 loss_mask,

--- a/tests/unit_tests/training/test_gpt_step.py
+++ b/tests/unit_tests/training/test_gpt_step.py
@@ -82,6 +82,7 @@ def _make_cfg(
     skip_getting_attention_mask_from_dataset=True,
     pipeline_model_parallel_layout=None,
     pipeline_model_parallel_size=1,
+    virtual_pipeline_model_parallel_size=None,
     mtp_num_layers=0,
 ):
     cfg = type("Cfg", (), {})()
@@ -99,6 +100,7 @@ def _make_cfg(
         {
             "pipeline_model_parallel_layout": pipeline_model_parallel_layout,
             "pipeline_model_parallel_size": pipeline_model_parallel_size,
+            "virtual_pipeline_model_parallel_size": virtual_pipeline_model_parallel_size,
             "mtp_num_layers": mtp_num_layers,
         },
     )()
@@ -137,14 +139,23 @@ class _NoopTimer:
 
 
 class _RecordingModel:
-    def __init__(self, *, mtp_process=False, output=None):
-        self.mtp_process = mtp_process
+    def __init__(self, *, vp_stage=None, output=None):
+        self.vp_stage = vp_stage
         self.output = output if output is not None else torch.tensor(1.0)
         self.forward_kwargs = None
 
     def __call__(self, **kwargs):
         self.forward_kwargs = kwargs
         return self.output
+
+
+class _VpStageWrapper:
+    def __init__(self, module):
+        self.vp_stage = None
+        self.module = module
+
+    def __call__(self, **kwargs):
+        return self.module(**kwargs)
 
 
 class TestGetBatch:
@@ -352,8 +363,8 @@ class TestGetBatch:
         assert out_attention_mask is None
         assert out_position_ids is None
 
-    def test_forward_common_uses_model_chunk_mtp_process_for_vpp_stage(self, monkeypatch):
-        """Interleaved MTP chunks load tokens even when global VPP rank is unset."""
+    def test_forward_common_uses_model_chunk_vp_stage_for_vpp_stage(self, monkeypatch):
+        """Interleaved MTP chunks load tokens using the model chunk VP stage."""
         _set_last_pp_stage(monkeypatch)
         _set_distributed_initialized(monkeypatch)
         monkeypatch.setattr(
@@ -376,11 +387,15 @@ class TestGetBatch:
             "attention_mask": None,
             "position_ids": position_ids,
         }
-        model = _RecordingModel(mtp_process=True)
+        layout = [[] for _ in range(16)]
+        layout[15] = ["mtp"]
+        inner_model = _RecordingModel(vp_stage=1)
+        model = _VpStageWrapper(inner_model)
         state = Mock()
         state.cfg = _make_cfg(
-            pipeline_model_parallel_layout="Et*4|(t*4|)*14tmL",
+            pipeline_model_parallel_layout=layout,
             pipeline_model_parallel_size=8,
+            virtual_pipeline_model_parallel_size=2,
             mtp_num_layers=1,
         )
         state.timers = _NoopTimer()
@@ -405,13 +420,13 @@ class TestGetBatch:
 
         assert torch.equal(output, torch.tensor(1.0))
         assert torch.equal(returned_loss_mask, loss_mask)
-        assert model.forward_kwargs is not None
-        assert torch.equal(model.forward_kwargs["input_ids"], tokens)
-        assert torch.equal(model.forward_kwargs["position_ids"], position_ids)
-        assert torch.equal(model.forward_kwargs["labels"], labels)
+        assert inner_model.forward_kwargs is not None
+        assert torch.equal(inner_model.forward_kwargs["input_ids"], tokens)
+        assert torch.equal(inner_model.forward_kwargs["position_ids"], position_ids)
+        assert torch.equal(inner_model.forward_kwargs["labels"], labels)
 
-    def test_forward_common_uses_model_chunk_mtp_process_instead_of_layout_fallback(self, monkeypatch):
-        """A non-MTP model chunk must not load tokens just because layout inference would."""
+    def test_forward_common_uses_model_chunk_vp_stage_instead_of_global_vpp_rank(self, monkeypatch):
+        """The model chunk VP stage must override stale global VPP rank state."""
         _set_last_pp_stage(monkeypatch)
         _set_distributed_initialized(monkeypatch)
         monkeypatch.setattr(
@@ -436,11 +451,12 @@ class TestGetBatch:
         }
         layout = [[] for _ in range(16)]
         layout[15] = ["mtp"]
-        model = _RecordingModel(mtp_process=False)
+        model = _RecordingModel(vp_stage=0)
         state = Mock()
         state.cfg = _make_cfg(
             pipeline_model_parallel_layout=layout,
             pipeline_model_parallel_size=8,
+            virtual_pipeline_model_parallel_size=2,
             mtp_num_layers=1,
         )
         state.timers = _NoopTimer()
@@ -464,11 +480,11 @@ class TestGetBatch:
         output, returned_loss_mask = _forward_step_common(state, _Iterator(batch), model)
 
         assert torch.equal(output, torch.tensor(1.0))
-        assert torch.equal(returned_loss_mask, loss_mask)
+        assert returned_loss_mask is None
         assert model.forward_kwargs is not None
         assert model.forward_kwargs["input_ids"] is None
         assert model.forward_kwargs["position_ids"] is None
-        assert torch.equal(model.forward_kwargs["labels"], labels)
+        assert model.forward_kwargs["labels"] is None
 
     def test_forward_common_passes_packed_seq_params_on_middle_pp_stage(self, monkeypatch):
         """Forward path must pass packed metadata on middle PP stages."""
@@ -499,7 +515,7 @@ class TestGetBatch:
         monkeypatch.setattr("megatron.bridge.training.gpt_step.get_pg_collection", lambda model: _MockPGCollection())
         monkeypatch.setattr(
             "megatron.bridge.training.gpt_step.get_batch",
-            lambda data_iterator, cfg, use_mtp, *, pg_collection, include_mtp_inputs=None: (
+            lambda data_iterator, cfg, use_mtp, *, pg_collection, vp_stage=None: (
                 tokens,
                 labels,
                 loss_mask,


### PR DESCRIPTION
## Summary
- route MTP batch fields from the current `GPTModel` chunk instead of inferring from PP/VPP layout rank state
- keep the layout/rank helper as a fallback for direct `get_batch(..., include_mtp_inputs=None)` callers
- add unit coverage for VPP stages where only the model chunk owns the MTP block

## Why
GitLab job 336688788 failed in DeepSeek V3 GB200 MXFP8 perf with PP=4, VPP=4, `mtp_num_layers=1`, and a layout ending in `mtp,loss`. The failing ranks reached MTP embedding with `input_ids=None`, producing:

```text
TypeError: embedding(): argument indices (position 2) must be Tensor, not NoneType
```

PR 4208 inferred whether to include MTP inputs from pipeline layout and the global virtual pipeline rank. During interleaved VPP, Bridge does not get the active `vp_stage` in `forward_step_func`, while the MCore model chunk already carries the correct `mtp_process` flag. Using the chunk flag avoids routing token ids to the wrong stage.

## Validation
- `uv run --no-sync ruff check src/megatron/bridge/training/gpt_step.py tests/unit_tests/training/test_gpt_step.py`
- `uv run --no-sync ruff format --check src/megatron/bridge/training/gpt_step.py tests/unit_tests/training/test_gpt_step.py`
- `uv run --no-sync pre-commit run --all-files`
- cw toy smoke, job 12683919: PP=4, VPP=2, layout `Et|t|t|t|t|t|t|mL`, `mtp_num_layers=1`, 2 train iterations completed with `mtp_1 loss`, exit 0

Local full `uv run python -m pytest ...` was blocked by local dependency resolution for `nvidia-resiliency-ext==0.6.0` on the host platform; the cw smoke ran inside the standard training container.