### PR TITLE
[build] chore: uninstall nvidia-modelopt from fw_base

### DIFF
--- a/docker/Dockerfile.fw_base
+++ b/docker/Dockerfile.fw_base
@@ -148,3 +148,14 @@ FROM ${FW_BASE_FINAL} AS nemo_fw_base_final
 
 WORKDIR /opt
 
+##############################################################################
+##
+## Remove nvidia-modelopt
+##
+## nvidia-modelopt ships in the NeMo FW base image but is not used by
+## Megatron-Bridge; uninstall it to keep the final image lean.
+##
+##############################################################################
+
+RUN pip uninstall -y nvidia-modelopt || true
+


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## Background / motivation

- `nvidia-modelopt` ships in the NeMo FW base image (`NEMO_FW_BASE_IMAGE`) but is **not used** by Megatron-Bridge.
- Carrying it bloats the `fw_base` image for all downstream consumers.

## What changed

- `docker/Dockerfile.fw_base`: uninstall `nvidia-modelopt` in the final stage so it is removed from the produced image.

## Details

- Added to the `nemo_fw_base_final` stage (`FROM ${FW_BASE_FINAL}`) — the last stage that yields the output image, so the removal applies regardless of the build path selected by `FW_DEP_BUILDER` / `FW_BASE_FINAL`.
- `RUN pip uninstall -y nvidia-modelopt || true` — the `|| true` guard mirrors the existing `pip3 uninstall -y tensorrt || true` convention so the build does not break if the package is absent in a given base image.

## Tested

- nemo-ci build-only pipeline launched against this ref (`fw_base` build, no functional tests) — see PR comment for the pipeline link.

</details>
