### PR TITLE
fix(model): keep full rotary_percent for DeepSeek-V4 MLA rope

### DIFF
--- a/src/megatron/bridge/models/deepseek/deepseek_v4_bridge.py
+++ b/src/megatron/bridge/models/deepseek/deepseek_v4_bridge.py
@@ -346,6 +346,12 @@ class DeepSeekV4Bridge(MegatronModelBridge):
         # head_dim = 512 (nope_dim + rope_dim = 448 + 64)
         provider.v_head_dim = hf_config.head_dim  # 512
         provider.qk_pos_emb_head_dim = hf_config.qk_rope_head_dim  # 64
+        # HF's partial_rotary_factor (0.125) is relative to head_dim (512); the rope split is
+        # already fully encoded by qk_pos_emb_head_dim (64). The generic partial_rotary_factor
+        # -> rotary_percent mapping would shrink the rope cache to 64*0.125 = 8 dims: the
+        # unfused path then silently rotates only 8 of 64 rope dims, and the fused MLA rope
+        # kernel reads cos/sin out of bounds (garbage values -> the SFT loss NaN).
+        provider.rotary_percent = 1.0
         # qk_head_dim and kv_lora_rank derived automatically in DSv4HybridConfig
         provider.q_lora_rank = hf_config.q_lora_rank  # 1024
         provider.o_groups = hf_config.o_groups  # 8

--- a/tests/unit_tests/models/deepseek/test_deepseek_v4_bridge.py
+++ b/tests/unit_tests/models/deepseek/test_deepseek_v4_bridge.py
@@ -340,3 +340,57 @@ class TestMTPEHProjSplit:
             elif isinstance(hf_param, dict):
                 for v in hf_param.values():
                     assert "eh_proj" not in v, f"deprecated eh_proj reference found in hf_param dict value: {v}"
+
+
+class TestDeepSeekV4RotaryPercent:
+    """Regression: HF partial_rotary_factor (relative to head_dim=512) must not shrink
+    the Megatron rope cache — qk_pos_emb_head_dim (64) already encodes the rope split.
+    rotary_percent=0.125 yields an 8-dim cos/sin cache: the unfused path silently
+    rotates 8/64 dims and the fused MLA rope kernel reads cos/sin out of bounds (SFT NaN)."""
+
+    def test_provider_bridge_forces_full_rotary_percent(self):
+        from unittest.mock import MagicMock, patch
+
+        from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge
+        from megatron.bridge.models.deepseek.deepseek_v4_bridge import DeepSeekV4Bridge
+
+        hf_config = SimpleNamespace(
+            head_dim=512,
+            qk_rope_head_dim=64,
+            q_lora_rank=1024,
+            o_groups=8,
+            o_lora_rank=1024,
+            rope_theta=10000,
+            compress_rope_theta=160000,
+            rope_scaling={"factor": 16, "original_max_position_embeddings": 65536},
+            num_hidden_layers=4,
+            num_nextn_predict_layers=1,
+            num_hash_layers=3,
+            compress_ratios=[0, 4, 128, 4, 0],
+            sliding_window=128,
+            index_n_heads=64,
+            index_head_dim=128,
+            index_topk=512,
+            hc_mult=4,
+            hc_sinkhorn_iters=20,
+            scoring_func="sqrtsoftplus",
+            num_experts_per_tok=6,
+            norm_topk_prob=True,
+            routed_scaling_factor=1.5,
+            vocab_size=129280,
+            swiglu_limit=10.0,
+            moe_intermediate_size=1024,
+            n_shared_experts=1,
+            tie_word_embeddings=False,
+        )
+        hf_pretrained = MagicMock()
+        hf_pretrained.config = hf_config
+        provider = MagicMock()
+        # what the generic partial_rotary_factor -> rotary_percent mapping produces
+        provider.rotary_percent = 0.125
+
+        bridge = DeepSeekV4Bridge.__new__(DeepSeekV4Bridge)
+        with patch.object(MegatronModelBridge, "provider_bridge", return_value=provider):
+            out = bridge.provider_bridge(hf_pretrained)
+
+        assert out.rotary_percent == 1.0


### PR DESCRIPTION
## What

One-line fix: force `rotary_percent = 1.0` in the DeepSeek-V4 bridge, plus a regression test.

## Why — root cause of the DSv4-Flash SFT NaN (NVIDIA/Megatron-LM#4468)

HF's `partial_rotary_factor` (0.125) is **relative to `head_dim` (512)**. The generic `partial_rotary_factor → rotary_percent` mapping applies it on top of `qk_pos_emb_head_dim` (64) — which **already encodes the rope split** (448 nope + 64 rope). The double-applied factor shrinks the rope cos/sin cache to 64 × 0.125 = **8 dims**, and then:

- the **unfused** path silently rotates only 8 of 64 rope dims (no crash — masked correctness issue on every DSv4 bridge run);
- the **fused** MLA yarn-rope kernel (`fused_mla_rope_inplace`, called with `emb_dim=64`) reads cos/sin **out of bounds**, producing huge garbage activations (q jumps ~5 → ~1e14, captured in-situ) → the iteration-2 `found NaN in local forward loss calculation` in DeepSeek-V4-Flash SFT, reproduced on both H100 and GB300.

Debug trail (single-variable isolations, in-situ capture, and replay) is in [NVIDIA/Megatron-LM#4468](https://github.com/NVIDIA/Megatron-LM/issues/4468). Pretrain never hit it because the mock data path uses fixed-length sequences and the validated pretrain configs didn't exercise the same cache shape.

## Validation (GB300, proxy DSv4-Flash SFT, EP4)

| Run | rotary_percent | apply_rope_fusion | Result |
|---|---|---|---|
| control | 0.125 (status quo) | False | trains, but rotates 8/64 dims |
| repro | 0.125 | True | **NaN at iteration 2** |
| fixed | **1.0** | False | clean, 10/10 iters |
| fixed | **1.0** | True | **clean, matches unfused control to 4 decimals** (12.46808→7.554 vs 12.46882→7.5535) |

Unit test: mocks the parent `provider_bridge` to inject `rotary_percent=0.125` (what the generic mapping produces) and asserts the DSv4 bridge forces it back to 1.0.

## Notes

- Related: #4131 (DSv4-Flash SFT recipes; independent — different hunks of the same file, no stacking needed). Also unblocks re-enabling `apply_rope_fusion` for DSv4 SFT (verl-project/verl#6603 ships it off as a workaround).
- A follow-up suggestion for Megatron-Core (tracked in #4468): `fused_mla_rope_inplace` should assert `cos.shape[-1] == emb_dim` instead of reading out of bounds.
- AI-assisted (Claude); debugging, validation runs, and review by the human author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
