### PR TITLE
build: bump GitPython to 3.1.50 to address CVE-2026-42215 bypass

### DIFF
--- a/docker/Dockerfile.fw_final
+++ b/docker/Dockerfile.fw_final
@@ -87,7 +87,8 @@ RUN pip install "starlette==0.49.1" \
     "notebook>=7.5.6" \
     "jupyterlab>=4.5.7" \
     "jupyter-server>=2.18.0" \
-    "mistune>=3.2.1" && \
+    "mistune>=3.2.1" \
+    "GitPython>=3.1.50" && \
     # Address CVE from transitive dependency
     pip uninstall -y opencv-python-headless
 


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## Background

Security scan flagged GitPython `3.1.46` in the `fw_final` image:

> Newline injection in `config_writer()` section parameter bypasses CVE-2026-42215 patch, enabling RCE via `core.hooksPath`.

Site: `/usr/local/lib/python3.12/dist-packages/gitpython-3` (installed transitively by `Dockerfile.fw_final`).

## What changed

- `docker/Dockerfile.fw_final` — add `"GitPython>=3.1.50"` to the CVE-pin `pip install` block.

## Details

- Pins to `>=3.1.50` to inherit future patch releases; matches the style of adjacent `>=`-pinned CVE entries (`urllib3`, `aiohttp`, `pillow`, …).
- Single-site fix: only `Dockerfile.fw_final` carries the runtime resolution; `fw_pyproject.toml` does not list `GitPython` (it is transitive).

</details>

## Test plan

- [ ] `fw_final` container builds successfully
- [ ] `pip show GitPython` reports `>= 3.1.50` in the resulting image
