### PR TITLE
cp: `build: bump GitPython to 3.1.50 to address CVE-2026-42215 bypass (4280)` into `r0.5.0`

### DIFF
--- a/docker/Dockerfile.fw_final
+++ b/docker/Dockerfile.fw_final
@@ -87,7 +87,8 @@ RUN pip install "starlette==0.49.1" \
     "notebook>=7.5.6" \
     "jupyterlab>=4.5.7" \
     "jupyter-server>=2.18.0" \
-    "mistune>=3.2.1" && \
+    "mistune>=3.2.1" \
+    "GitPython>=3.1.50" && \
     # Address CVE from transitive dependency
     pip uninstall -y opencv-python-headless
 


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## Background

Cherry-pick of [#4280](https://github.com/NVIDIA-NeMo/Megatron-Bridge/pull/4280) into `r0.5.0`. Addresses the GitPython CVE-2026-42215 bypass: newline injection in `config_writer()` section parameter enables RCE via `core.hooksPath`.

## What changed

- `docker/Dockerfile.fw_final` — add `"GitPython>=3.1.50"` to the CVE-pin `pip install` block.

## Details

- Clean cherry-pick (no conflicts); diff is identical to the `main` PR.
- Single-site fix: only `Dockerfile.fw_final` carries the runtime resolution; `fw_pyproject.toml` does not list GitPython (transitive).

</details>

## Test plan

- [ ] `fw_final` r0.5.0 container builds successfully
- [ ] `pip show GitPython` reports `>= 3.1.50` in the resulting image
