### PR TITLE
build: bump go-git/v5 to 5.19.0 in dist-packages wandb-core

### DIFF
--- a/docker/Dockerfile.fw_final
+++ b/docker/Dockerfile.fw_final
@@ -140,6 +140,26 @@ RUN GRPC_VERSION=1.79.3 && \
         -o "${WANDB_CORE_BIN}" ./cmd/wandb-core/ && \
     rm -rf /tmp/wandb-src /tmp/go /tmp/gopath
 
+# Patch wandb-core (dist-packages copy): bump github.com/go-git/go-git/v5 to 5.19.0 (CVE fix).
+# This stock upstream binary ships with go-git v5.17.2 and is a separate wandb install from the
+# /opt/venv copy rebuilt above, so it must be rebuilt against its own wandb version (resolved via
+# the system interpreter that owns dist-packages) to avoid a python/wandb-core version mismatch.
+RUN GO_GIT_VERSION=5.19.0 && \
+    GO_VERSION=1.26.1 && \
+    WANDB_VERSION=$(/usr/bin/python3 -c "import wandb; print(wandb.__version__)") && \
+    WANDB_CORE_BIN=/usr/local/lib/python3.12/dist-packages/wandb/bin/wandb-core && \
+    curl -fsSL "https://dl.google.com/go/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz" | tar -C /tmp -xz && \
+    export PATH="/tmp/go/bin:$PATH" && \
+    export GOPATH=/tmp/gopath && \
+    git clone --depth 1 --branch "v${WANDB_VERSION}" https://github.com/wandb/wandb.git /tmp/wandb-src && \
+    cd /tmp/wandb-src/core && \
+    go get github.com/go-git/go-git/v5@v${GO_GIT_VERSION} && \
+    go mod tidy && \
+    go mod vendor && \
+    CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -trimpath -ldflags="-s -w" \
+        -o "${WANDB_CORE_BIN}" ./cmd/wandb-core/ && \
+    rm -rf /tmp/wandb-src /tmp/go /tmp/gopath
+
 ##############################################################################
 ##
 ## Finalize FW container


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## Background / motivation

- CVE scanners flag `github.com/go-git/go-git/v5` **v5.17.2** embedded in the wandb-core Go binary shipped under `/usr/local/lib/python3.12/dist-packages/wandb/bin/wandb-core`.
- There are **two** wandb installs in the image, each with its own prebuilt `wandb-core`:
  - `/opt/venv/.../wandb-core` — wandb **0.27.2**, already rebuilt by the existing grpc CVE patch (carries go-git **v5.19.1**) ✓
  - `/usr/local/lib/python3.12/dist-packages/.../wandb-core` — wandb **0.26.0**, stock upstream binary, **untouched** → still go-git **v5.17.2** ✗
- The existing grpc patch only targets the `/opt/venv` copy, so the dist-packages binary needs a separate rebuild.

## What changed

- Add a `Dockerfile.fw_final` step that rebuilds the dist-packages `wandb-core` with `go-git/v5` bumped to **v5.19.0**.

## Details

- `docker/Dockerfile.fw_final` — new `RUN` block in the "Address CVE" section, mirroring the existing grpc patch mechanics (download Go, clone wandb at its pinned version, `go get` + `go mod tidy` + `go mod vendor` + build).
- The wandb source version is resolved via the **system** interpreter (`/usr/bin/python3`) so it matches the dist-packages package (0.26.0), avoiding a python ↔ wandb-core version mismatch. (The grpc patch uses bare `python3`, which resolves to the venv's 0.27.2 — a different binary.)
- Target is the user's exact path: `/usr/local/lib/python3.12/dist-packages/wandb/bin/wandb-core`.

## Tested

Ran the exact step inside `nvcr.io/nvidian/nemo:26.06.rc6`:

- dist wandb version resolved to `0.26.0`
- `go get` upgraded `go-git/v5` **v5.17.2 → v5.19.0** (and `go-billy/v5` → v5.9.0 transitively)
- build succeeded; `go version -m` on the replaced binary reports `go-git/go-git/v5 v5.19.0` and `path github.com/wandb/wandb/core/cmd/wandb-core` (proper rebuild, no longer the stock `command-line-arguments`)
- `wandb-core` executes and `python3 -c "import wandb"` still imports `0.26.0`

```
=== old binary go-git ===  v5.17.2
go: upgraded github.com/go-git/go-git/v5 v5.17.2 => v5.19.0
=== verify embedded go-git in replaced binary ===
	dep	github.com/go-git/go-git/v5	v5.19.0
```

</details>
