### PR TITLE
cp: `build: bump go-git/v5 to 5.19.0 in dist-packages wandb-core (4289)` into `r0.5.0`

### DIFF
--- a/docker/Dockerfile.fw_final
+++ b/docker/Dockerfile.fw_final
@@ -140,6 +140,26 @@ RUN GRPC_VERSION=1.79.3 && \
         -o "${WANDB_CORE_BIN}" ./cmd/wandb-core/ && \
     rm -rf /tmp/wandb-src /tmp/go /tmp/gopath
 
+# Patch wandb-core (dist-packages copy): bump github.com/go-git/go-git/v5 to 5.19.0 (CVE fix).
+# This stock upstream binary ships with go-git v5.17.2 and is a separate wandb install from the
+# /opt/venv copy rebuilt above, so it must be rebuilt against its own wandb version (resolved via
+# the system interpreter that owns dist-packages) to avoid a python/wandb-core version mismatch.
+RUN GO_GIT_VERSION=5.19.0 && \
+    GO_VERSION=1.26.1 && \
+    WANDB_VERSION=$(/usr/bin/python3 -c "import wandb; print(wandb.__version__)") && \
+    WANDB_CORE_BIN=/usr/local/lib/python3.12/dist-packages/wandb/bin/wandb-core && \
+    curl -fsSL "https://dl.google.com/go/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz" | tar -C /tmp -xz && \
+    export PATH="/tmp/go/bin:$PATH" && \
+    export GOPATH=/tmp/gopath && \
+    git clone --depth 1 --branch "v${WANDB_VERSION}" https://github.com/wandb/wandb.git /tmp/wandb-src && \
+    cd /tmp/wandb-src/core && \
+    go get github.com/go-git/go-git/v5@v${GO_GIT_VERSION} && \
+    go mod tidy && \
+    go mod vendor && \
+    CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -trimpath -ldflags="-s -w" \
+        -o "${WANDB_CORE_BIN}" ./cmd/wandb-core/ && \
+    rm -rf /tmp/wandb-src /tmp/go /tmp/gopath
+
 ##############################################################################
 ##
 ## Finalize FW container


### PR DESCRIPTION
<details><summary>Claude summary</summary>

Manual cherry-pick of #4289 into `r0.5.0`, created ahead of time so it can be merged together with the `main` PR once the nemo-ci build pipeline passes.

## What changed

- Rebuilds the dist-packages `wandb-core` with `github.com/go-git/go-git/v5` bumped **v5.17.2 → v5.19.0** (CVE fix). Single new `RUN` step in `docker/Dockerfile.fw_final`.

## Context

- The dist-packages wandb (0.26.0) ships a stock `wandb-core` embedding go-git **v5.17.2**, which CVE scanners flag.
- The existing grpc patch only rebuilds the `/opt/venv` copy (wandb 0.27.2), so this binary was untouched.
- Validated end-to-end inside `nvcr.io/nvidian/nemo:26.06.rc6`: go-git → v5.19.0, build succeeds, binary runs, `import wandb` still works. See #4289 for full details.

Cherry-picked from `main` commit `96bbf6c`.

</details>
