### PR TITLE
fix(docker): rename NEMO_EVAL_COMMIT to NEMO_EVALUATOR_COMMIT

### DIFF
--- a/docker/Dockerfile.fw_final
+++ b/docker/Dockerfile.fw_final
@@ -31,7 +31,7 @@ RUN git clone --depth 1 https://github.com/NVIDIA-NeMo/NeMo.git && \
 
 ARG NEMO_COMMIT
 ARG NEMO_EXPORT_DEPLOY_COMMIT
-ARG NEMO_EVAL_COMMIT
+ARG NEMO_EVALUATOR_COMMIT
 ARG NEMO_RUN_COMMIT
 
 # Update FW repository commit
@@ -43,9 +43,9 @@ RUN    pushd /opt/Export-Deploy && \
     popd && \
     pushd /opt/Evaluator && \
         git pull && \
-        git fetch origin $NEMO_EVAL_COMMIT && \
+        git fetch origin $NEMO_EVALUATOR_COMMIT && \
         git checkout FETCH_HEAD && \
-        echo "Container built with NeMo-Eval commit hash: $NEMO_EVAL_COMMIT" && \
+        echo "Container built with NeMo-Eval commit hash: $NEMO_EVALUATOR_COMMIT" && \
     popd && \
     pushd /opt/Run && \
         git pull && \

--- a/docker/README.md
+++ b/docker/README.md
@@ -96,7 +96,7 @@ docker build \
   --build-arg NEMO_FW_FINAL_BASE_IMAGE=megatron-bridge:latest \
   --build-arg NEMO_COMMIT=<commit-sha> \
   --build-arg NEMO_EXPORT_DEPLOY_COMMIT=<commit-sha> \
-  --build-arg NEMO_EVAL_COMMIT=<commit-sha> \
+  --build-arg NEMO_EVALUATOR_COMMIT=<commit-sha> \
   --build-arg NEMO_RUN_COMMIT=<commit-sha> \
   -t fw-final:latest \
   .
@@ -149,7 +149,7 @@ docker build \
 | `NEMO_FW_FINAL_BASE_IMAGE` | Base image; must be a megatron-bridge image |
 | `NEMO_COMMIT` | NeMo git commit SHA |
 | `NEMO_EXPORT_DEPLOY_COMMIT` | NeMo Export-Deploy git commit SHA |
-| `NEMO_EVAL_COMMIT` | NeMo Evaluator git commit SHA |
+| `NEMO_EVALUATOR_COMMIT` | NeMo Evaluator git commit SHA |
 | `NEMO_RUN_COMMIT` | NeMo Run git commit SHA |
 
 ---


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## Background / motivation

- `build-NeMo-FW-final` jobs (e.g. nemo-ci `!2300` job `338266867`) silently dropped the evaluator pin and built against default-branch HEAD instead.
- Root cause: nemo-ci's `.gitlab/workflows/ci_build_vars.yml:114` passes `--build-arg NEMO_EVALUATOR_COMMIT=$${EVALUATOR_PIPELINE_SHA}` (matching `NEMO_COMMIT`, `NEMO_EXPORT_DEPLOY_COMMIT`, `NEMO_RUN_COMMIT`), but `docker/Dockerfile.fw_final` declared the odd-one-out `NEMO_EVAL_COMMIT`. Docker accepts unknown `--build-arg` flags silently → variable bound to empty → `git fetch origin` (no ref) → `git checkout FETCH_HEAD` lands on the shallow clone's default-branch tip.

## What changed

- Rename `NEMO_EVAL_COMMIT` → `NEMO_EVALUATOR_COMMIT` in `docker/Dockerfile.fw_final` and the matching `docker/README.md` reference table.

## Details

- `docker/Dockerfile.fw_final:34,46,48` — `ARG`, `git fetch origin $…`, and the echoed hash line.
- `docker/README.md:99,152` — example `--build-arg` and the args reference table row.

## Tested

- Evidence the pin was dropped before this fix (nemo-ci job `338266867`, pipeline `54357791`, ref `c3eb171f`):
  - `--build-arg NEMO_EVALUATOR_COMMIT=76c865c3c09132c1d102a0a84454c36823f19cff` (passed)
  - `git fetch origin $NEMO_EVAL_COMMIT` ran as `git fetch origin` (no ref)
  - `HEAD is now at 07c5c3a feat: Add new error type SOLVE_TIMEOUT (#1049)` — default-branch tip, NOT the requested commit
  - `Container built with NeMo-Eval commit hash: ` (empty)
- Will retrigger the same pipeline against this branch to confirm the pin is honored.

</details>
