### PR TITLE
cp: `fix(docker): rename NEMO_EVAL_COMMIT to NEMO_EVALUATOR_COMMIT`

### DIFF
--- a/docker/Dockerfile.fw_final
+++ b/docker/Dockerfile.fw_final
@@ -31,7 +31,7 @@ RUN git clone --depth 1 https://github.com/NVIDIA-NeMo/NeMo.git && \
 
 ARG NEMO_COMMIT
 ARG NEMO_EXPORT_DEPLOY_COMMIT
-ARG NEMO_EVAL_COMMIT
+ARG NEMO_EVALUATOR_COMMIT
 ARG NEMO_RUN_COMMIT
 
 # Update FW repository commit
@@ -43,9 +43,9 @@ RUN    pushd /opt/Export-Deploy && \
     popd && \
     pushd /opt/Evaluator && \
         git pull && \
-        git fetch origin $NEMO_EVAL_COMMIT && \
+        git fetch origin $NEMO_EVALUATOR_COMMIT && \
         git checkout FETCH_HEAD && \
-        echo "Container built with NeMo-Eval commit hash: $NEMO_EVAL_COMMIT" && \
+        echo "Container built with NeMo-Eval commit hash: $NEMO_EVALUATOR_COMMIT" && \
     popd && \
     pushd /opt/Run && \
         git pull && \

--- a/docker/README.md
+++ b/docker/README.md
@@ -96,7 +96,7 @@ docker build \
   --build-arg NEMO_FW_FINAL_BASE_IMAGE=megatron-bridge:latest \
   --build-arg NEMO_COMMIT=<commit-sha> \
   --build-arg NEMO_EXPORT_DEPLOY_COMMIT=<commit-sha> \
-  --build-arg NEMO_EVAL_COMMIT=<commit-sha> \
+  --build-arg NEMO_EVALUATOR_COMMIT=<commit-sha> \
   --build-arg NEMO_RUN_COMMIT=<commit-sha> \
   -t fw-final:latest \
   .
@@ -149,7 +149,7 @@ docker build \
 | `NEMO_FW_FINAL_BASE_IMAGE` | Base image; must be a megatron-bridge image |
 | `NEMO_COMMIT` | NeMo git commit SHA |
 | `NEMO_EXPORT_DEPLOY_COMMIT` | NeMo Export-Deploy git commit SHA |
-| `NEMO_EVAL_COMMIT` | NeMo Evaluator git commit SHA |
+| `NEMO_EVALUATOR_COMMIT` | NeMo Evaluator git commit SHA |
 | `NEMO_RUN_COMMIT` | NeMo Run git commit SHA |
 
 ---


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## Background / motivation

- Cherrypick of #4291 onto `r0.5.0`.
- Same bug — `docker/Dockerfile.fw_final` declares `NEMO_EVAL_COMMIT`; nemo-ci passes `--build-arg NEMO_EVALUATOR_COMMIT`. Build arg silently ignored, evaluator lands on default-branch HEAD instead of the requested pin.

## What changed

- Rename `NEMO_EVAL_COMMIT` → `NEMO_EVALUATOR_COMMIT` in `docker/Dockerfile.fw_final` and `docker/README.md`.

## Details

- `docker/Dockerfile.fw_final:34,46,48`
- `docker/README.md:99,152`

## Tested

- Cherry-picked cleanly from main (`bf5861e6a`).
- Evidence on r26.06 (which pins r0.5.0) — nemo-ci job `338266867` shows `Container built with NeMo-Eval commit hash: ` (empty) and HEAD on default-branch tip instead of the pinned `76c865c3…`.

</details>
