### PR TITLE
build(docker): revert nemo-evaluator source to packages subdir

### DIFF
--- a/docker/common/fw_pyproject.toml
+++ b/docker/common/fw_pyproject.toml
@@ -41,7 +41,7 @@ test = ["coverage>=7.8.1"]
 
 [tool.uv.sources]
 "nemo-export-deploy" = { path = "/opt/Export-Deploy", editable = true }
-"nemo-evaluator" = { path = "/opt/Evaluator", editable = true }
+"nemo-evaluator" = { path = "/opt/Evaluator/packages/nemo-evaluator", editable = true }
 "nemo-run" = { path = "/opt/Run", editable = true }
 "lightning" = { path = "stubs/lightning" }
 


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## Background / motivation

- #4099 repointed the `nemo-evaluator` uv source from `/opt/Evaluator/packages/nemo-evaluator` to the `/opt/Evaluator` repo root in the FW container.
- This revert restores the original `packages/nemo-evaluator` subdirectory path on the `r0.5.0` release branch.

## What changed

- Revert of `7c324e5397f1a689d96d2f4a3c8808049fe6aa3d` (`build(docker): point nemo-evaluator source at /opt/Evaluator root (#4099)`).

## Details

- `docker/common/fw_pyproject.toml` → `[tool.uv.sources]`:

  ```toml
  -"nemo-evaluator" = { path = "/opt/Evaluator", editable = true }
  +"nemo-evaluator" = { path = "/opt/Evaluator/packages/nemo-evaluator", editable = true }
  ```

- Single-line change; reverts cleanly — no subsequent commit on `r0.5.0` touched this line.

## Tested

- Pending CI on `r0.5.0`.

</details>
