### PR TITLE
mirror: fix(gemma4): map dense MLP pre-FFN norm to pre_feedforward_layernorm

### DIFF
--- a/src/megatron/bridge/models/gemma/gemma4_bridge.py
+++ b/src/megatron/bridge/models/gemma/gemma4_bridge.py
@@ -398,7 +398,12 @@ class Gemma4Bridge(MegatronModelBridge):
             # (Gemma4TopKRouter.scale) so it round-trips on export without needing the
             # reference HF checkpoint.  Mapped via ReplicatedMapping below.
             "decoder.layers.*.mlp.linear_fc2.weight": ("model.layers.*.mlp.down_proj.weight"),
-            "decoder.layers.*.mlp.linear_fc1.layer_norm_weight": "model.layers.*.post_attention_layernorm.weight",
+            # === Dense MLP fused pre-FFN norm ===
+            # TE backend fuses the pre-MLP RMSNorm into linear_fc1 as
+            # linear_fc1.layer_norm_weight.  In Gemma 4 the pre-MLP norm is
+            # pre_feedforward_layernorm (post_attention_layernorm is a separate
+            # norm already mapped to self_attention.linear_proj.post_layernorm).
+            "decoder.layers.*.mlp.linear_fc1.layer_norm_weight": "model.layers.*.pre_feedforward_layernorm.weight",
         }
 
         mapping_list = []

--- a/src/megatron/bridge/models/gemma_vl/gemma4_vl_bridge.py
+++ b/src/megatron/bridge/models/gemma_vl/gemma4_vl_bridge.py
@@ -361,7 +361,12 @@ class Gemma4VLBridge(MegatronModelBridge):
             "language_model.decoder.layers.*.mlp.linear_fc2.weight": (
                 "model.language_model.layers.*.mlp.down_proj.weight"
             ),
-            "language_model.decoder.layers.*.mlp.linear_fc1.layer_norm_weight": "model.language_model.layers.*.post_attention_layernorm.weight",
+            # === Dense MLP fused pre-FFN norm ===
+            # TE backend fuses the pre-MLP RMSNorm into linear_fc1 as
+            # linear_fc1.layer_norm_weight.  In Gemma 4 the pre-MLP norm is
+            # pre_feedforward_layernorm (post_attention_layernorm is a separate
+            # norm already mapped to self_attention.linear_proj.post_layernorm).
+            "language_model.decoder.layers.*.mlp.linear_fc1.layer_norm_weight": "model.language_model.layers.*.pre_feedforward_layernorm.weight",
         }
 
         mapping_list = []

--- a/tests/unit_tests/models/gemma/test_gemma4_bridge.py
+++ b/tests/unit_tests/models/gemma/test_gemma4_bridge.py
@@ -526,3 +526,20 @@ class TestGemma4BridgeMappingRegistry:
     def test_has_layer_scalar_mapping(self, bridge):
         names = self._collect_names(bridge.mapping_registry())
         assert any("layer_scalar" in n for n in names)
+
+    def test_dense_mlp_pre_norm_maps_to_pre_feedforward_layernorm(self, bridge):
+        """Dense MLP fused pre-norm must load pre_feedforward_layernorm, not post_attention_layernorm.
+
+        Regression test for the bug where linear_fc1.layer_norm_weight (the
+        TE-fused pre-MLP RMSNorm) was mapped to post_attention_layernorm,
+        leaving the dense MLP without its real pre-FFN normalization.
+        """
+        hf_target = None
+        for m in bridge.mapping_registry().mappings:
+            megatron_param = getattr(m, "megatron_param", "")
+            if isinstance(megatron_param, str) and megatron_param.endswith("mlp.linear_fc1.layer_norm_weight"):
+                hf_target = m.hf_param
+                break
+        assert hf_target is not None, "linear_fc1.layer_norm_weight mapping not found"
+        assert hf_target.endswith("pre_feedforward_layernorm.weight")
+        assert "post_attention_layernorm" not in hf_target

--- a/tests/unit_tests/models/gemma_vl/test_gemma4_vl_bridge.py
+++ b/tests/unit_tests/models/gemma_vl/test_gemma4_vl_bridge.py
@@ -331,6 +331,23 @@ class TestGemma4VLBridgeMappingRegistry:
         names = self._collect_names(bridge.mapping_registry())
         assert any("post_moe_layernorm" in n for n in names)
 
+    def test_dense_mlp_pre_norm_maps_to_pre_feedforward_layernorm(self, bridge):
+        """Dense MLP fused pre-norm must load pre_feedforward_layernorm, not post_attention_layernorm.
+
+        Regression test for the bug where linear_fc1.layer_norm_weight (the
+        TE-fused pre-MLP RMSNorm) was mapped to post_attention_layernorm,
+        leaving the dense MLP without its real pre-FFN normalization.
+        """
+        hf_target = None
+        for m in bridge.mapping_registry().mappings:
+            megatron_param = getattr(m, "megatron_param", "")
+            if isinstance(megatron_param, str) and megatron_param.endswith("mlp.linear_fc1.layer_norm_weight"):
+                hf_target = m.hf_param
+                break
+        assert hf_target is not None, "linear_fc1.layer_norm_weight mapping not found"
+        assert hf_target.endswith("pre_feedforward_layernorm.weight")
+        assert "post_attention_layernorm" not in hf_target
+
 
 # ---------------------------------------------------------------------------
 # Edge cases


### PR DESCRIPTION
<details><summary>Claude summary</summary>

Mirror of #4201 by @rayandasoriya — copied into the upstream repo so the full CI pipeline runs natively (cross-fork PRs cannot trigger it).

- **Original PR:** #4201
- **Author:** @rayandasoriya
- **Source:** `rayandasoriya/Megatron-Bridge:fix/gemma4-pre-ffn-norm-4200`

Commits are copied verbatim with authorship preserved. Review and discussion remain on #4201.

</details>
