### PR TITLE
feat(model): thread weight_dtype through HF export for plain-dtype DeepSeek-V4 output

### DIFF
--- a/examples/conversion/convert_checkpoints_multi_gpu.py
+++ b/examples/conversion/convert_checkpoints_multi_gpu.py
@@ -329,9 +329,10 @@ def main():
         choices=sorted(DTYPE_MAP),
         default=None,
         help=(
-            "Emit plain weights in this dtype instead of re-creating the source repo's "
-            "quantized weight/scale layout (currently honored by the DeepSeek-V4 bridge). "
-            "Use for SFT products that need exact train/inference numerical parity."
+            "Emit plain weights cast to this dtype. For bridges that recreate a quantized "
+            "source layout on export (e.g. DeepSeek-V4) this also skips the requantization, "
+            "so no *.scale companions are written. Use for SFT products that need exact "
+            "train/inference numerical parity."
         ),
     )
     args = parser.parse_args()

--- a/examples/conversion/convert_checkpoints_multi_gpu.py
+++ b/examples/conversion/convert_checkpoints_multi_gpu.py
@@ -177,6 +177,7 @@ def export_megatron_to_hf(
     distributed_save: bool = False,
     save_every_n_ranks: int = 1,
     distributed_timeout_minutes: int | None = None,
+    export_weight_dtype: str | None = None,
 ) -> None:
     """Export a distributed Megatron checkpoint to HuggingFace format."""
     _ensure_distributed_initialized(distributed_timeout_minutes)
@@ -262,6 +263,7 @@ def export_megatron_to_hf(
         strict=strict,
         distributed_save=distributed_save,
         save_every_n_ranks=save_every_n_ranks,
+        weight_dtype=_parse_dtype(export_weight_dtype) if export_weight_dtype else None,
     )
     print_rank_0(f"Export complete: {hf_path}")
 
@@ -322,6 +324,16 @@ def main():
         default=1,
         help="Only every N-th rank writes files (reduces I/O, only with --distributed-save)",
     )
+    export_parser.add_argument(
+        "--export-weight-dtype",
+        choices=sorted(DTYPE_MAP),
+        default=None,
+        help=(
+            "Emit plain weights in this dtype instead of re-creating the source repo's "
+            "quantized weight/scale layout (currently honored by the DeepSeek-V4 bridge). "
+            "Use for SFT products that need exact train/inference numerical parity."
+        ),
+    )
     args = parser.parse_args()
 
     if not args.command:
@@ -356,6 +368,7 @@ def main():
             distributed_save=args.distributed_save,
             save_every_n_ranks=args.save_every_n_ranks,
             distributed_timeout_minutes=args.distributed_timeout_minutes,
+            export_weight_dtype=args.export_weight_dtype,
         )
 
 

--- a/src/megatron/bridge/models/conversion/auto_bridge.py
+++ b/src/megatron/bridge/models/conversion/auto_bridge.py
@@ -508,6 +508,7 @@ class AutoBridge(Generic[MegatronModelT]):
         show_progress: bool = True,
         conversion_tasks: Optional[List[WeightConversionTask]] = None,
         merge_adapter_weights: bool = True,
+        weight_dtype: Optional[torch.dtype] = None,
     ) -> Iterable["HFWeightTuple"]:
         """
         Export Megatron model weights to HuggingFace format.
@@ -563,6 +564,7 @@ class AutoBridge(Generic[MegatronModelT]):
             show_progress=show_progress,
             conversion_tasks=conversion_tasks,
             merge_adapter_weights=merge_adapter_weights,
+            weight_dtype=weight_dtype,
         )
 
     def export_hf_weights_modelopt(
@@ -814,6 +816,7 @@ class AutoBridge(Generic[MegatronModelT]):
         merge_adapter_weights: bool = True,
         distributed_save: bool = False,
         save_every_n_ranks: int = 1,
+        weight_dtype: Optional[torch.dtype] = None,
     ) -> None:
         """
         Save a Megatron model in HuggingFace format.
@@ -926,6 +929,7 @@ class AutoBridge(Generic[MegatronModelT]):
             merge_adapter_weights=merge_adapter_weights,
             distributed_save=distributed_save,
             save_every_n_ranks=save_every_n_ranks,
+            weight_dtype=weight_dtype,
         )
 
     def save_hf_weights(
@@ -937,6 +941,7 @@ class AutoBridge(Generic[MegatronModelT]):
         merge_adapter_weights: bool = True,
         distributed_save: bool = False,
         save_every_n_ranks: int = 1,
+        weight_dtype: Optional[torch.dtype] = None,
     ) -> None:
         """
         Save Megatron model weights in HuggingFace safetensors format.
@@ -989,6 +994,7 @@ class AutoBridge(Generic[MegatronModelT]):
             cpu=True,
             show_progress=show_progress,
             merge_adapter_weights=merge_adapter_weights,
+            weight_dtype=weight_dtype,
         )
         model_instance = self._get_model_instance(model)
         quant_tensors = None

--- a/src/megatron/bridge/models/conversion/auto_bridge.py
+++ b/src/megatron/bridge/models/conversion/auto_bridge.py
@@ -532,6 +532,7 @@ class AutoBridge(Generic[MegatronModelT]):
                 carefully adjust based on your needs.*
             merge_adapter_weights: Whether to gather and merge LoRA adapter weights into the base
                 tensors during export (defaults to True). Set to False to export only the base tensors.
+            weight_dtype: Plain export dtype; skips quantized *.scale companions when set.
 
 
         Yields:
@@ -853,6 +854,7 @@ class AutoBridge(Generic[MegatronModelT]):
                 For example, if set to 2, only ranks 0, 2, 4, ... will save weights.
                 This is useful for reducing I/O pressure when dealing with large-scale distributed
                 training. Only effective when distributed_save=True. Default is 1 (all ranks save).
+            weight_dtype: Plain export dtype; skips quantized *.scale companions when set.
 
         Example:
             >>> # Save model after training
@@ -967,6 +969,7 @@ class AutoBridge(Generic[MegatronModelT]):
                 part of weights independently.
             save_every_n_ranks: Interval for saving weights across ranks in distributed mode.
                 For example, if set to 2, only ranks 0, 2, 4, ... will save weights.
+            weight_dtype: Plain export dtype; skips quantized *.scale companions when set.
 
         Raises:
             ValueError: If the state source doesn't support streaming save

--- a/src/megatron/bridge/models/conversion/model_bridge.py
+++ b/src/megatron/bridge/models/conversion/model_bridge.py
@@ -19,7 +19,7 @@ import itertools
 import logging
 import math
 import re
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from typing import (
     Any,
     Callable,
@@ -120,8 +120,8 @@ class WeightConversionTask(Generic[MappingT]):
             sub-module that owns the parameter (required for loads).
         param_weight (Optional[torch.Tensor]): The actual parameter tensor that will
             receive the converted weight (required for loads).
-        weight_dtype (Optional[torch.dtype]): When set, bridges that re-create a quantized
-            source layout on export emit plain weights in this dtype instead.
+        weight_dtype (Optional[torch.dtype]): Export only. Cast float weights to this
+            dtype; bridges that requantize on export skip it (no scale companions).
 
     """
 
@@ -899,6 +899,18 @@ class MegatronModelBridge(
         """
         return converted_weights_dict
 
+    @staticmethod
+    def _cast_export_weight_dtype(
+        weights: Dict[str, torch.Tensor], weight_dtype: Optional[torch.dtype]
+    ) -> Dict[str, torch.Tensor]:
+        """Cast float export weights to ``weight_dtype`` (no-op if None; ints untouched)."""
+        if weight_dtype is None:
+            return weights
+        return {
+            name: (weight.to(weight_dtype) if weight.is_floating_point() else weight)
+            for name, weight in weights.items()
+        }
+
     def _accumulate_grouped_export(
         self,
         task: "WeightConversionTask",
@@ -1254,10 +1266,16 @@ class MegatronModelBridge(
         unwrapped_model_list = unwrap_model(megatron_model)
         # Use provided conversion tasks or build them
         if conversion_tasks is None:
-            conversion_tasks = self.build_conversion_tasks(hf_pretrained, unwrapped_model_list)
-        if weight_dtype is not None:
-            # WeightConversionTask is frozen — rebuild the tasks with the dtype set
-            conversion_tasks = [replace(task, weight_dtype=weight_dtype) for task in conversion_tasks]
+            conversion_tasks = self.build_conversion_tasks(
+                hf_pretrained, unwrapped_model_list, weight_dtype=weight_dtype
+            )
+        elif weight_dtype is not None:
+            # Prebuilt tasks bypass build_conversion_tasks (where weight_dtype is recorded);
+            # fail loudly instead of silently dropping it (this also rejects the fp8-tasks combo).
+            raise ValueError(
+                "weight_dtype is not supported with caller-supplied conversion_tasks; "
+                "omit conversion_tasks so the dtype can be recorded at task-build time."
+            )
 
         # Collect adapter conversion tasks when merge is requested
         adapter_tasks_by_base: Dict[str, List[AdapterWeightConversionTask]] = {}
@@ -1312,6 +1330,7 @@ class MegatronModelBridge(
                     task, converted_weights_dict, model_config, _grouped_buffers, hf_state_dict
                 )
                 if merged_result is not None:
+                    merged_result = self._cast_export_weight_dtype(merged_result, task.weight_dtype)
                     for hf_name, tensor in merged_result.items():
                         yield HFWeightTuple(hf_name, tensor.cpu() if cpu else tensor)
                 continue
@@ -1335,6 +1354,8 @@ class MegatronModelBridge(
                     converted_weights_dict,
                     adapter_weights,
                 )
+
+            converted_weights_dict = self._cast_export_weight_dtype(converted_weights_dict, task.weight_dtype)
 
             for hf_name, tensor in converted_weights_dict.items():
                 final_tensor = tensor.cpu() if cpu else tensor
@@ -1554,8 +1575,12 @@ class MegatronModelBridge(
         self,
         hf_pretrained: HFPreTrained,
         megatron_model: List[MegatronModel],
+        weight_dtype: Optional[torch.dtype] = None,
     ) -> List[None | WeightConversionTask]:
         """Construct the conversion tasks between HF and megatron.
+
+        Args:
+            weight_dtype: Export dtype recorded on each task. Overrides must forward it.
 
         The algorithm walks over every parameter of every destination model,
         asks the :class:`MegatronMappingRegistry` whether it has a mapping for that
@@ -1639,6 +1664,7 @@ class MegatronModelBridge(
                     megatron_module=local_module,
                     param_weight=local_weights,
                     mapping=mapping,
+                    weight_dtype=weight_dtype,
                 )
 
         # Fill the remaining ones for pp communications
@@ -1659,6 +1685,7 @@ class MegatronModelBridge(
                     megatron_module=None,
                     param_weight=None,
                     mapping=mapping,
+                    weight_dtype=weight_dtype,
                 )
 
         return tasks
@@ -1997,7 +2024,6 @@ def stream_weights_megatron_to_hf(
     show_progress: bool = True,
     conversion_tasks: Optional[List[WeightConversionTask]] = None,
     merge_adapter_weights: bool = True,
-    weight_dtype: Optional[torch.dtype] = None,
 ) -> Iterable[HFWeightTuple]:
     """Bridge Megatron model state to HuggingFace format."""
     ...

--- a/src/megatron/bridge/models/conversion/model_bridge.py
+++ b/src/megatron/bridge/models/conversion/model_bridge.py
@@ -19,7 +19,7 @@ import itertools
 import logging
 import math
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import (
     Any,
     Callable,
@@ -120,6 +120,8 @@ class WeightConversionTask(Generic[MappingT]):
             sub-module that owns the parameter (required for loads).
         param_weight (Optional[torch.Tensor]): The actual parameter tensor that will
             receive the converted weight (required for loads).
+        weight_dtype (Optional[torch.dtype]): When set, bridges that re-create a quantized
+            source layout on export emit plain weights in this dtype instead.
 
     """
 
@@ -130,6 +132,7 @@ class WeightConversionTask(Generic[MappingT]):
     vp_stage: Optional[int] = None
     megatron_module: Optional[torch.nn.Module] = None
     param_weight: Optional[torch.Tensor] = None
+    weight_dtype: Optional[torch.dtype] = None
 
 
 class _HFNameSuffixMapping:
@@ -1192,6 +1195,7 @@ class MegatronModelBridge(
         show_progress: bool = True,
         conversion_tasks: Optional[List[WeightConversionTask]] = None,
         merge_adapter_weights: bool = True,
+        weight_dtype: Optional[torch.dtype] = None,
     ) -> Iterable[HFWeightTuple]:
         """Export Megatron weights to HuggingFace format.
 
@@ -1251,6 +1255,9 @@ class MegatronModelBridge(
         # Use provided conversion tasks or build them
         if conversion_tasks is None:
             conversion_tasks = self.build_conversion_tasks(hf_pretrained, unwrapped_model_list)
+        if weight_dtype is not None:
+            # WeightConversionTask is frozen — rebuild the tasks with the dtype set
+            conversion_tasks = [replace(task, weight_dtype=weight_dtype) for task in conversion_tasks]
 
         # Collect adapter conversion tasks when merge is requested
         adapter_tasks_by_base: Dict[str, List[AdapterWeightConversionTask]] = {}
@@ -1990,6 +1997,7 @@ def stream_weights_megatron_to_hf(
     show_progress: bool = True,
     conversion_tasks: Optional[List[WeightConversionTask]] = None,
     merge_adapter_weights: bool = True,
+    weight_dtype: Optional[torch.dtype] = None,
 ) -> Iterable[HFWeightTuple]:
     """Bridge Megatron model state to HuggingFace format."""
     ...

--- a/src/megatron/bridge/models/deepseek/deepseek_v4_bridge.py
+++ b/src/megatron/bridge/models/deepseek/deepseek_v4_bridge.py
@@ -911,8 +911,16 @@ class DeepSeekV4Bridge(MegatronModelBridge):
         converted_weights_dict: Dict[str, torch.Tensor],
         hf_state_dict: Mapping[str, torch.Tensor],
     ) -> Dict[str, torch.Tensor]:
-        """Recreate DSv4 quantized weight/scale pairs expected by the source shard index."""
-        del task
+        """Recreate DSv4 quantized weight/scale pairs expected by the source shard index.
+
+        When ``task.weight_dtype`` is set, plain weights are emitted in that dtype
+        instead (no ``*.scale`` companions).
+        """
+        if task.weight_dtype is not None:
+            return {
+                name: (weight.to(task.weight_dtype) if weight.is_floating_point() else weight)
+                for name, weight in converted_weights_dict.items()
+            }
         return quantization_utils.requantize_hf_weight_scale_pairs(
             converted_weights_dict,
             hf_state_dict,

--- a/src/megatron/bridge/models/deepseek/deepseek_v4_bridge.py
+++ b/src/megatron/bridge/models/deepseek/deepseek_v4_bridge.py
@@ -913,14 +913,11 @@ class DeepSeekV4Bridge(MegatronModelBridge):
     ) -> Dict[str, torch.Tensor]:
         """Recreate DSv4 quantized weight/scale pairs expected by the source shard index.
 
-        When ``task.weight_dtype`` is set, plain weights are emitted in that dtype
-        instead (no ``*.scale`` companions).
+        When ``task.weight_dtype`` is set, skip requantization and return the weights
+        unchanged — the generic export path casts the dtype.
         """
         if task.weight_dtype is not None:
-            return {
-                name: (weight.to(task.weight_dtype) if weight.is_floating_point() else weight)
-                for name, weight in converted_weights_dict.items()
-            }
+            return converted_weights_dict
         return quantization_utils.requantize_hf_weight_scale_pairs(
             converted_weights_dict,
             hf_state_dict,

--- a/src/megatron/bridge/models/kimi_vl/kimi_k25_vl_bridge.py
+++ b/src/megatron/bridge/models/kimi_vl/kimi_k25_vl_bridge.py
@@ -204,6 +204,7 @@ class KimiK25VLBridge(MegatronModelBridge):
         self,
         hf_pretrained,
         megatron_model,
+        weight_dtype=None,
     ) -> List:
         """Override to synthesize virtual weight keys from INT4 quantized triplets.
 
@@ -227,7 +228,7 @@ class KimiK25VLBridge(MegatronModelBridge):
 
         hf_pretrained.state.source.get_all_keys = _get_all_keys_with_virtual
         try:
-            return super().build_conversion_tasks(hf_pretrained, megatron_model)
+            return super().build_conversion_tasks(hf_pretrained, megatron_model, weight_dtype=weight_dtype)
         finally:
             hf_pretrained.state.source.get_all_keys = original_get_all_keys
 

--- a/src/megatron/bridge/models/nemotronh/nemotron_h_bridge.py
+++ b/src/megatron/bridge/models/nemotronh/nemotron_h_bridge.py
@@ -255,7 +255,7 @@ class NemotronHBridge(MegatronModelBridge):
         super().__init__()
         self._mtp_layers_per_block: Optional[int] = None
 
-    def build_conversion_tasks(self, hf_pretrained: PreTrainedCausalLM, megatron_model):
+    def build_conversion_tasks(self, hf_pretrained: PreTrainedCausalLM, megatron_model, weight_dtype=None):
         # Cache MTP block depth (len of mtp_hybrid_override_pattern) so mapping_registry()
         # can compute the flattened HF layer indices deterministically.
         mtp_pattern = getattr(getattr(hf_pretrained, "config", None), "mtp_hybrid_override_pattern", None)
@@ -264,7 +264,7 @@ class NemotronHBridge(MegatronModelBridge):
         else:
             self._mtp_layers_per_block = 0
 
-        return super().build_conversion_tasks(hf_pretrained, megatron_model)
+        return super().build_conversion_tasks(hf_pretrained, megatron_model, weight_dtype=weight_dtype)
 
     def provider_bridge(self, hf_pretrained: PreTrainedCausalLM) -> MambaModelProvider:
         """Convert HuggingFace Nemotron-H config to MambaModelProvider."""

--- a/tests/unit_tests/models/deepseek/test_deepseek_v4_bridge.py
+++ b/tests/unit_tests/models/deepseek/test_deepseek_v4_bridge.py
@@ -441,7 +441,7 @@ class TestDeepSeekV4HardwareDefaults:
 
 
 class TestDeepSeekV4ExportWeightDtype:
-    def test_weight_dtype_set_emits_plain_weights(self):
+    def test_weight_dtype_set_skips_requantization(self, monkeypatch):
         from dataclasses import replace
         from unittest.mock import MagicMock
 
@@ -451,18 +451,30 @@ class TestDeepSeekV4ExportWeightDtype:
         bridge = DeepSeekV4Bridge.__new__(DeepSeekV4Bridge)
         task = WeightConversionTask(param_name="w", global_param_name="w", mapping=MagicMock())
         task = replace(task, weight_dtype=torch.bfloat16)  # frozen: must be settable via replace
+
+        def fail_requantize(*args, **kwargs):
+            raise AssertionError("requantize must be skipped when weight_dtype is set")
+
+        monkeypatch.setattr(quantization_utils, "requantize_hf_weight_scale_pairs", fail_requantize)
         weight = torch.randn(4, 4, dtype=torch.float32)
-        converted = {
-            "model.layers.0.mlp.weight": weight,
-            "model.layers.0.mlp.bias_idx": torch.ones(2, dtype=torch.int32),
-        }
+        converted = {"model.layers.0.mlp.weight": weight}
         hf_state = {"model.layers.0.mlp.weight": weight, "model.layers.0.mlp.scale": torch.ones(1)}
 
         out = bridge.maybe_modify_converted_hf_weight(task, converted, hf_state)
 
-        assert set(out) == set(converted)
+        assert out is converted  # returned unchanged; generic path casts the dtype
+
+    def test_generic_export_cast_applies_plain_dtype(self):
+        from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge
+
+        weights = {
+            "model.layers.0.mlp.weight": torch.randn(4, 4, dtype=torch.float32),
+            "model.layers.0.mlp.bias_idx": torch.ones(2, dtype=torch.int32),
+        }
+        out = MegatronModelBridge._cast_export_weight_dtype(weights, torch.bfloat16)
         assert out["model.layers.0.mlp.weight"].dtype == torch.bfloat16
-        assert out["model.layers.0.mlp.bias_idx"].dtype == torch.int32
+        assert out["model.layers.0.mlp.bias_idx"].dtype == torch.int32  # int preserved
+        assert MegatronModelBridge._cast_export_weight_dtype(weights, None) is weights
 
     def test_no_weight_dtype_requantizes_by_default(self, monkeypatch):
         from unittest.mock import MagicMock

--- a/tests/unit_tests/models/deepseek/test_deepseek_v4_bridge.py
+++ b/tests/unit_tests/models/deepseek/test_deepseek_v4_bridge.py
@@ -57,7 +57,9 @@ def _by_megatron(registry):
 
 
 def _dummy_task():
-    return SimpleNamespace(param_name="", global_param_name="", mapping=None)
+    from megatron.bridge.models.conversion.model_bridge import WeightConversionTask
+
+    return WeightConversionTask(param_name="", global_param_name="", mapping=None)
 
 
 def _deepseek_v4_hf_config():
@@ -436,3 +438,47 @@ class TestDeepSeekV4HardwareDefaults:
 
         assert out.apply_dsa_kernel_fusion is True
         assert out.use_fused_mhc is True
+
+
+class TestDeepSeekV4ExportWeightDtype:
+    def test_weight_dtype_set_emits_plain_weights(self):
+        from dataclasses import replace
+        from unittest.mock import MagicMock
+
+        from megatron.bridge.models.conversion.model_bridge import WeightConversionTask
+        from megatron.bridge.models.deepseek.deepseek_v4_bridge import DeepSeekV4Bridge
+
+        bridge = DeepSeekV4Bridge.__new__(DeepSeekV4Bridge)
+        task = WeightConversionTask(param_name="w", global_param_name="w", mapping=MagicMock())
+        task = replace(task, weight_dtype=torch.bfloat16)  # frozen: must be settable via replace
+        weight = torch.randn(4, 4, dtype=torch.float32)
+        converted = {
+            "model.layers.0.mlp.weight": weight,
+            "model.layers.0.mlp.bias_idx": torch.ones(2, dtype=torch.int32),
+        }
+        hf_state = {"model.layers.0.mlp.weight": weight, "model.layers.0.mlp.scale": torch.ones(1)}
+
+        out = bridge.maybe_modify_converted_hf_weight(task, converted, hf_state)
+
+        assert set(out) == set(converted)
+        assert out["model.layers.0.mlp.weight"].dtype == torch.bfloat16
+        assert out["model.layers.0.mlp.bias_idx"].dtype == torch.int32
+
+    def test_no_weight_dtype_requantizes_by_default(self, monkeypatch):
+        from unittest.mock import MagicMock
+
+        from megatron.bridge.models.conversion.model_bridge import WeightConversionTask
+        from megatron.bridge.models.deepseek.deepseek_v4_bridge import DeepSeekV4Bridge
+
+        bridge = DeepSeekV4Bridge.__new__(DeepSeekV4Bridge)
+        task = WeightConversionTask(param_name="w", global_param_name="w", mapping=MagicMock())
+        called = {}
+
+        def fake_requantize(converted, hf_state, *, use_mxfp4=None):
+            called["hit"] = True
+            return {"quantized": torch.zeros(1)}
+
+        monkeypatch.setattr(quantization_utils, "requantize_hf_weight_scale_pairs", fake_requantize)
+        out = bridge.maybe_modify_converted_hf_weight(task, {"a.weight": torch.ones(1)}, {})
+
+        assert called.get("hit") and "quantized" in out

--- a/tests/unit_tests/models/test_auto_bridge.py
+++ b/tests/unit_tests/models/test_auto_bridge.py
@@ -686,6 +686,7 @@ class TestAutoBridge:
                     merge_adapter_weights=True,
                     distributed_save=False,
                     save_every_n_ranks=1,
+                    weight_dtype=None,
                 )
 
     @patch("torch.distributed.is_initialized", return_value=False)
@@ -801,6 +802,7 @@ class TestAutoBridge:
                     merge_adapter_weights=True,
                     distributed_save=False,
                     save_every_n_ranks=1,
+                    weight_dtype=None,
                 )
 
     def test_export_hf_weights(self):
@@ -841,6 +843,7 @@ class TestAutoBridge:
                         show_progress=True,
                         conversion_tasks=None,
                         merge_adapter_weights=True,
+                        weight_dtype=None,
                     )
 
     def test_export_adapter_weights(self):
@@ -1500,6 +1503,7 @@ class TestAutoBridge:
                 cpu=True,
                 show_progress=True,
                 merge_adapter_weights=True,
+                weight_dtype=None,
             )
 
             # The quantizer tensor should have been saved via torch.save sidecar
@@ -1556,6 +1560,7 @@ class TestAutoBridge:
                 cpu=True,
                 show_progress=True,
                 merge_adapter_weights=True,
+                weight_dtype=None,
             )
             mock_torch_save.assert_not_called()
 


### PR DESCRIPTION
## What

Thread `weight_dtype: Optional[torch.dtype] = None` through the HF export path — `export_hf_weights` / `save_hf_pretrained` / `stream_weights_megatron_to_hf` — carried per-task via a new optional `WeightConversionTask.weight_dtype` field. When set, the DeepSeek-V4 bridge emits **plain weights in that dtype** (no `*.scale` companions) instead of re-creating the source repo's quantized layout. Default (`None`) keeps today's behavior. CLI: `--export-weight-dtype` on the export subcommand.

## Why

DSv4 HF export unconditionally re-creates the source repo's quantized weight/scale layout (`maybe_modify_converted_hf_weight` → `requantize_hf_weight_scale_pairs`, from #3969). That's right for checkpoint conversion, but bf16-SFT'd weights get silently post-hoc quantized — a user found `*.scale` tensors in their SFT export and asked about train/inference parity.

**Design (revised after reviewer feedback):** the requantize hook runs on *both* export consumers — online weight streaming to rollout engines (`export_hf_weights`, e.g. verl RL weight sync) and on-disk checkpoints (`save_hf_pretrained`) — so a bridge-level boolean cannot configure them independently. A dtype-typed parameter on each public API lets callers choose per path (e.g. bf16 to rollout for RL parity, quantized to disk for serving-format artifacts, or vice versa). Hook signatures are unchanged (the dtype rides on the task), so the other bridges overriding this hook (dsv3, gemma4, kimi, mimo, flux) are unaffected; DSv3 can adopt the same field later.

## Verified

- the saver streams only yielded tensors (omitting `.scale` keys is safe); exported `config.json` is built fresh (`torch_dtype: bfloat16`, no quantization fields); safetensors index regenerated from written tensors;
- unit tests cover dtype-set (plain weights, non-float tensors untouched) and default (requantize) paths.

## Notes

- AI-assisted (Claude); analysis, validation and review by the human author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
