### PR TITLE
fix(ckpt): auto-generate DSv4 pipeline layout on export when run_config lacks it

### DIFF
--- a/examples/conversion/convert_checkpoints_multi_gpu.py
+++ b/examples/conversion/convert_checkpoints_multi_gpu.py
@@ -216,6 +216,18 @@ def export_megatron_to_hf(
                     model_provider.pipeline_model_parallel_layout = saved_layout
                     print_rank_0(f"  Read pipeline layout from checkpoint ({len(saved_layout)} stages)")
                     break
+        # run_config.yaml serializes an already-finalized layout as an object stub
+        # (the layout data is lost), so fall back to auto-generation like import does.
+        if not isinstance(getattr(model_provider, "pipeline_model_parallel_layout", None), list) and hasattr(
+            bridge._model_bridge, "generate_pipeline_layout"
+        ):
+            hf_config = bridge.hf_pretrained.config
+            num_layers = hf_config.num_hidden_layers
+            mtp = getattr(hf_config, "num_nextn_predict_layers", 0) or 0
+            model_provider.pipeline_model_parallel_layout = bridge._model_bridge.generate_pipeline_layout(
+                num_layers, pp, mtp
+            )
+            print_rank_0(f"  Auto-generated pipeline layout for PP={pp} ({num_layers} layers, {mtp} MTP)")
     model_provider.finalize()
     model_provider.initialize_model_parallel(seed=0)
 

--- a/examples/conversion/convert_checkpoints_multi_gpu.py
+++ b/examples/conversion/convert_checkpoints_multi_gpu.py
@@ -228,6 +228,8 @@ def export_megatron_to_hf(
                 num_layers, pp, mtp
             )
             print_rank_0(f"  Auto-generated pipeline layout for PP={pp} ({num_layers} layers, {mtp} MTP)")
+    # Capture before finalize() turns the list into a PipelineParallelLayerLayout.
+    resolved_pp_layout = model_provider.pipeline_model_parallel_layout if pp > 1 else None
     model_provider.finalize()
     model_provider.initialize_model_parallel(seed=0)
 
@@ -239,6 +241,10 @@ def export_megatron_to_hf(
         "pipeline_dtype": dtype,
         "params_dtype": dtype,
     }
+    # load_megatron_model rebuilds the provider from the checkpoint's run_config,
+    # which lost the layout the same way — forward the resolved layout explicitly.
+    if isinstance(resolved_pp_layout, list):
+        mp_overrides["pipeline_model_parallel_layout"] = resolved_pp_layout
 
     print_rank_0(f"Loading Megatron checkpoint from: {megatron_path}")
     megatron_model = bridge.load_megatron_model(

--- a/src/megatron/bridge/models/model_provider.py
+++ b/src/megatron/bridge/models/model_provider.py
@@ -519,6 +519,7 @@ class ModelParallelKwargs(TypedDict, total=False):
     sequence_parallel: bool
     virtual_pipeline_model_parallel_size: int | None
     hierarchical_context_parallel_sizes: list[int] | None
+    pipeline_model_parallel_layout: list[list[str]] | None
     pipeline_dtype: torch.dtype
 
 


### PR DESCRIPTION
## What

PP>1 export falls back to `bridge.generate_pipeline_layout(...)` when `run_config.yaml` cannot provide a usable layout — exactly like the import path already does.

## Why (round-trip bug)

`import` → `export` of a DeepSeek-V4 checkpoint at PP>1 currently fails with `AssertionError: pipeline_model_parallel_layout must be set when using hash MoE layers with pipeline parallelism (PP > 1)`.

Root cause: by save time the provider's layout has been finalized into a `PipelineParallelLayerLayout` **object**, and `run_config.yaml` serializes it as an instantiation stub — the actual layout data is lost:

```yaml
pipeline_model_parallel_layout:
  _call_: true
  _target_: megatron.core.transformer.pipeline_parallel_layer_layout.PipelineParallelLayerLayout
```

The export-side reader only accepts a list, finds the stub, and the provider then asserts. Reproduced on a full DeepSeek-V4-Flash TP1/PP4/EP8 checkpoint (imported with this same script); with the fallback the export proceeds.

A deeper fix would be serializing the layout in its list form in `run_config.yaml` (checkpointing owners' call); this script-level fallback restores the import→export round trip now.

## Notes
- AI-assisted (Claude); analysis, repro and review by the human author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
