### PR TITLE
cp: [model] fix: Align Gemma3 VL vision tower mapping (4278) into r0.5.0

### DIFF
--- a/src/megatron/bridge/models/gemma_vl/gemma3_vl_bridge.py
+++ b/src/megatron/bridge/models/gemma_vl/gemma3_vl_bridge.py
@@ -135,7 +135,7 @@ class Gemma3VLBridge(MegatronModelBridge):
             [
                 ReplicatedMapping(
                     megatron_param="vision_tower.**",
-                    hf_param="vision_tower.vision_model.**",
+                    hf_param="vision_tower.**",
                 ),
                 AutoMapping(
                     megatron_param="multi_modal_projector.proj.weight",

--- a/src/megatron/bridge/models/gemma_vl/modeling_gemma3_vl.py
+++ b/src/megatron/bridge/models/gemma_vl/modeling_gemma3_vl.py
@@ -91,9 +91,8 @@ class Gemma3VLModel(MegatronModule):
         self.post_process = post_process
         self.vp_stage = vp_stage
         if pre_process:
-            # Unwrap SiglipVisionModel → SiglipVisionTransformer so vision_tower params are
-            # always flat (vision_tower.embeddings.*), matching the bridge mapping that maps
-            # megatron vision_tower.** → HF vision_tower.vision_model.**.
+            # Unwrap SiglipVisionModel so vision_tower params stay flat
+            # (vision_tower.embeddings.*), matching HF checkpoint keys.
             _vc = config.vision_config
             _vc.vision_use_head = False
             _raw_vision = AutoModel.from_config(_vc)

--- a/tests/unit_tests/models/gemma_vl/test_gemma3_vl_bridge.py
+++ b/tests/unit_tests/models/gemma_vl/test_gemma3_vl_bridge.py
@@ -276,9 +276,19 @@ class TestGemma3VLBridgeMappingRegistry:
 
         vt_mapping = vision_mappings[0]
         assert str(vt_mapping.megatron_param) == "vision_tower.**", "Megatron vision_tower param should use wildcard"
-        assert str(vt_mapping.hf_param) == "vision_tower.vision_model.**", (
-            "HF param must map through vision_model.** to match SiglipVisionModel checkpoint keys"
+        assert str(vt_mapping.hf_param) == "vision_tower.**", (
+            "HF param must match the current Gemma3 checkpoint namespace"
         )
+
+    def test_mapping_registry_accepts_current_transformers_vision_tower_keys(self, gemma3_vl_bridge):
+        """Test mapping_registry accepts current transformers Gemma3 vision tower keys."""
+        registry = gemma3_vl_bridge.mapping_registry()
+
+        mapping = registry.hf_to_megatron_lookup("vision_tower.embeddings.patch_embedding.bias")
+
+        assert mapping is not None
+        assert str(mapping.megatron_param) == "vision_tower.embeddings.patch_embedding.bias"
+        assert str(mapping.hf_param) == "vision_tower.embeddings.patch_embedding.bias"
 
     def test_mapping_registry_multimodal_projector_params(self, gemma3_vl_bridge):
         """Test mapping_registry handles multimodal projector parameters correctly."""


### PR DESCRIPTION
## Summary

Cherry-picks the Gemma3-VL model/bridge fix from #4278 into `r0.5.0`.

Included changes:
- align Gemma3-VL vision tower HF mapping with current checkpoint keys (`vision_tower.**`)
- update the Gemma3-VL model comment to match the flat vision tower namespace
- backport the unit coverage for current Transformers vision tower keys

The original #4278 PR was stacked on a dependency bump. This backport intentionally includes only the Gemma3-VL model/bridge/test changes and excludes the unrelated `.main.commit`, `3rdparty/Megatron-LM`, and `uv.lock` updates.

## Validation

- `git diff --check origin/r0.5.0...HEAD`

Targeted unit tests were not run locally on this workstation.

Source PR: #4278
Cherry-picked commit: ee3dca6d236d66f0efaf3033fee93456f6a55489
