### PR TITLE
[examples] fix: Correct GLM-4.5V fine-tuning scripts

### DIFF
--- a/examples/models/glm/glm_45v/README.md
+++ b/examples/models/glm/glm_45v/README.md
@@ -13,7 +13,7 @@ export WORKSPACE=/your/custom/path
 ```
 
 Directory structure:
-- `${WORKSPACE}/models/` - Converted checkpoints
+- `${WORKSPACE}/models/` - Converted checkpoint roots, with iteration directories such as `iter_0000000/`
 - `${WORKSPACE}/results/` - Training outputs and experiment results
 
 ## Checkpoint Conversion
@@ -25,6 +25,8 @@ uv run python examples/conversion/convert_checkpoints.py import \
 --hf-model zai-org/GLM-4.5V \
 --megatron-path /models/GLM-4.5V
 ```
+
+The import writes the Megatron checkpoint under `/models/GLM-4.5V/iter_0000000`. Use that iteration directory for fine-tuning.
 
 ### Export Megatron → HF
 ```bash
@@ -84,13 +86,15 @@ Here's a breakdown of the information presented:
 
 - See: [bridge.recipes.glm_vl](../../../../docs/apidocs/bridge/bridge.recipes.glm_vl.md)
 - Available recipes:
-  - `glm_45v_finetune_config`: Finetuning for GLM-4.5V model with PEFT support
+  - `glm_45v_sft_config`: Full supervised fine-tuning for GLM-4.5V
+  - `glm_45v_peft_config`: Parameter-efficient fine-tuning for GLM-4.5V with LoRA or DoRA
 
 Before training, ensure the following environment variables are set:
-1. `SAVE_DIR`: checkpoint and log saving directory
-2. `HF_TOKEN`: to download models from HF Hub (if required)
-3. `HF_HOME`: (optional) to avoid re-downloading models and datasets
-4. `WANDB_API_KEY`: (optional) to enable WandB logging
+1. `WORKSPACE`: checkpoint and log saving directory
+2. `PRETRAINED_CHECKPOINT`: optional override for the converted iteration checkpoint, for example `${WORKSPACE}/models/GLM-4.5V/iter_0000000`
+3. `HF_TOKEN`: to download models from HF Hub (if required)
+4. `HF_HOME`: (optional) to avoid re-downloading models and datasets
+5. `WANDB_API_KEY`: (optional) to enable WandB logging
 
 ### Pretraining
 

--- a/examples/models/glm/glm_45v/slurm_peft.sh
+++ b/examples/models/glm/glm_45v/slurm_peft.sh
@@ -45,7 +45,7 @@
 WORKSPACE=${WORKSPACE:-/workspace}
 
 # Model and training configurations
-PRETRAINED_CHECKPOINT=${WORKSPACE}/models/GLM-4.5V
+PRETRAINED_CHECKPOINT=${PRETRAINED_CHECKPOINT:-${WORKSPACE}/models/GLM-4.5V/iter_0000000}
 MODEL_NAME=glm_45v
 DATASET_NAME=cord_v2
 SEQ_LENGTH=8192
@@ -136,7 +136,7 @@ CLI_OVERRIDES="\
 # If mounting a workspace that requires re-syncing dependencies, uncomment the uv sync line:
 # CMD="if [ \"\$SLURM_LOCALID\" -eq 0 ]; then uv sync; else sleep 2; fi && "
 CMD="uv run --no-sync python scripts/training/run_recipe.py"
-CMD="$CMD --recipe ${MODEL_NAME}_finetune_config"
+CMD="$CMD --recipe ${MODEL_NAME}_peft_config"
 CMD="$CMD --step_func vlm_step"
 CMD="$CMD --peft_scheme lora"
 CMD="$CMD $CLI_OVERRIDES"

--- a/examples/models/glm/glm_45v/slurm_sft.sh
+++ b/examples/models/glm/glm_45v/slurm_sft.sh
@@ -45,7 +45,7 @@
 WORKSPACE=${WORKSPACE:-/workspace}
 
 # Model and training configurations
-PRETRAINED_CHECKPOINT=${WORKSPACE}/models/GLM-4.5V
+PRETRAINED_CHECKPOINT=${PRETRAINED_CHECKPOINT:-${WORKSPACE}/models/GLM-4.5V/iter_0000000}
 MODEL_NAME=glm_45v
 DATASET_NAME=cord_v2
 SEQ_LENGTH=8192
@@ -135,7 +135,7 @@ CLI_OVERRIDES="\
 # If mounting a workspace that requires re-syncing dependencies, uncomment the uv sync line:
 # CMD="if [ \"\$SLURM_LOCALID\" -eq 0 ]; then uv sync; else sleep 2; fi && "
 CMD="uv run --no-sync python scripts/training/run_recipe.py"
-CMD="$CMD --recipe ${MODEL_NAME}_finetune_config"
+CMD="$CMD --recipe ${MODEL_NAME}_sft_config"
 CMD="$CMD --step_func vlm_step"
 CMD="$CMD $CLI_OVERRIDES"
 


### PR DESCRIPTION
## What
- Fix GLM-4.5V PEFT and SFT Slurm scripts to use the exported recipe names: `glm_45v_peft_config` and `glm_45v_sft_config`.
- Default `PRETRAINED_CHECKPOINT` to the converted iteration checkpoint `${WORKSPACE}/models/GLM-4.5V/iter_0000000` while preserving env override support.
- Update the GLM-4.5V README to document the actual recipes and the expected converted checkpoint path.

## Why
NVBug 6302885 reports that the example scripts pass nonexistent `glm_45v_finetune_config`. I reproduced that failure in `nvidian/nemo:26.06.rc6`. The second PEFT failure reproduces when the parent checkpoint root is passed; the existing loader accepts the direct `iter_0000000` checkpoint directory, so the examples should point to that path.

## Validation
- Reproduced `glm_45v_finetune_config` `AttributeError` in rc6.
- Verified `glm_45v_sft_config` and `glm_45v_peft_config` load in rc6.
- Reproduced checkpoint-root PEFT guard failure and verified direct `iter_0000000` path passes/resolves in rc6.
- `bash -n examples/models/glm/glm_45v/slurm_peft.sh`
- `bash -n examples/models/glm/glm_45v/slurm_sft.sh`
- `git diff --check`
- `uv run pre-commit run --all-files` in rc6 container
