### PR TITLE
[examples] fix: Make Qwen2-Audio SFT runnable by default

### DIFF
--- a/examples/models/qwen/qwen2_audio/sft.sh
+++ b/examples/models/qwen/qwen2_audio/sft.sh
@@ -29,6 +29,7 @@ LOG_FILE=./qwen2_audio_7b_asr.log
 exec > >(tee "${LOG_FILE}") 2>&1
 
 export TORCHDYNAMO_DISABLE=1
+export WANDB_MODE=${WANDB_MODE:-disabled}
 
 set -euo pipefail
 
@@ -37,9 +38,8 @@ WORKSPACE=${WORKSPACE:-/workspace/Megatron-Bridge/examples/models/qwen/qwen2_aud
 NPROC=${NPROC:-8}
 HF_MODEL=${HF_MODEL:-Qwen/Qwen2-Audio-7B}
 
-# Before training, make sure to set WANDB_API_KEY or disable wandb logging
+# Before training, set WANDB_MODE=online and WANDB_API_KEY to enable wandb logging.
 # export WANDB_API_KEY=<your_wandb_api_key>
-# export WANDB_MODE=disabled
 
 # Common configurations
 MODEL_NAME=qwen2_audio_7b
@@ -102,12 +102,12 @@ for par_config in "${PARALLELISM_CONFIGS[@]}"; do
         logger.wandb_project=$WANDB_PROJECT \
         logger.wandb_exp_name=${MODEL_NAME}_asr_tp${TP}_pp${PP} \
         dataset.maker_name=make_default_audio_dataset \
-        "dataset.maker_kwargs.path_or_dataset=yuekai/aishell" \
-        "dataset.maker_kwargs.subset=train" \
-        "dataset.maker_kwargs.split=test" \
-        "+dataset.maker_kwargs.prompt='Detect the language and recognize the speech: <|zh|>'" \
-        "dataset.val_maker_kwargs.subset=dev" \
-        "dataset.val_maker_kwargs.split=test" \
+        "dataset.maker_kwargs.path_or_dataset=ysdede/commonvoice_17_tr_fixed" \
+        "dataset.maker_kwargs.split=train" \
+        "dataset.maker_kwargs.text_column=transcription" \
+        "dataset.maker_kwargs.remove_text_spaces=false" \
+        "+dataset.maker_kwargs.prompt='Transcribe the Turkish audio clip.'" \
+        "dataset.val_maker_kwargs.split=validation" \
         dataset.skip_test=true \
         dataset.pack_sequences_in_batch=true \
         rng.seed=42 \

--- a/examples/models/qwen/qwen2_audio/sft.sh
+++ b/examples/models/qwen/qwen2_audio/sft.sh
@@ -101,12 +101,9 @@ for par_config in "${PARALLELISM_CONFIGS[@]}"; do
         logger.log_interval=$LOG_INTERVAL \
         logger.wandb_project=$WANDB_PROJECT \
         logger.wandb_exp_name=${MODEL_NAME}_asr_tp${TP}_pp${PP} \
-        dataset.maker_name=make_default_audio_dataset \
+        dataset.maker_name=make_cv17_dataset \
         "dataset.maker_kwargs.path_or_dataset=ysdede/commonvoice_17_tr_fixed" \
         "dataset.maker_kwargs.split=train" \
-        "dataset.maker_kwargs.text_column=transcription" \
-        "dataset.maker_kwargs.remove_text_spaces=false" \
-        "dataset.maker_kwargs.prompt='Transcribe the Turkish audio clip.'" \
         "dataset.val_maker_kwargs.split=validation" \
         dataset.skip_test=true \
         dataset.pack_sequences_in_batch=true \

--- a/examples/models/qwen/qwen2_audio/sft.sh
+++ b/examples/models/qwen/qwen2_audio/sft.sh
@@ -106,7 +106,7 @@ for par_config in "${PARALLELISM_CONFIGS[@]}"; do
         "dataset.maker_kwargs.split=train" \
         "dataset.maker_kwargs.text_column=transcription" \
         "dataset.maker_kwargs.remove_text_spaces=false" \
-        "+dataset.maker_kwargs.prompt='Transcribe the Turkish audio clip.'" \
+        "dataset.maker_kwargs.prompt='Transcribe the Turkish audio clip.'" \
         "dataset.val_maker_kwargs.split=validation" \
         dataset.skip_test=true \
         dataset.pack_sequences_in_batch=true \

--- a/src/megatron/bridge/data/vlm_datasets/hf_dataset_makers.py
+++ b/src/megatron/bridge/data/vlm_datasets/hf_dataset_makers.py
@@ -401,7 +401,10 @@ def make_valor32k_avqa_dataset(
 
 
 def make_cv17_dataset(
-    path_or_dataset: str = "ysdede/commonvoice_17_tr_fixed", split: str = "train", **kwargs
+    path_or_dataset: str = "ysdede/commonvoice_17_tr_fixed",
+    split: str = "train",
+    prompt: str = "Transcribe the Turkish audio clip.",
+    **kwargs,
 ) -> List[Dict[str, Any]]:
     """Load and preprocess the CommonVoice 17 dataset for audio-to-text fine-tuning."""
     import io
@@ -447,8 +450,14 @@ def make_cv17_dataset(
         array, sr = _decode_audio(example["audio"])
         return {
             "conversation": [
-                {"role": "user", "content": "<|audio_1|>Transcribe the Turkish audio clip."},
-                {"role": "assistant", "content": example["transcription"]},
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "audio", "audio_url": "placeholder"},
+                        {"type": "text", "text": prompt},
+                    ],
+                },
+                {"role": "assistant", "content": [{"type": "text", "text": example["transcription"]}]},
             ],
             "audio": (array, sr),
         }

--- a/src/megatron/bridge/recipes/qwen2_audio/qwen2_audio.py
+++ b/src/megatron/bridge/recipes/qwen2_audio/qwen2_audio.py
@@ -92,7 +92,7 @@ def _qwen2_audio_common(
     peft: Optional[Union[str, PEFT]] = None,
     finetune_lr: Optional[float] = None,
     # Dataset
-    maker_name: str = "make_default_audio_dataset",
+    maker_name: str = "make_cv17_dataset",
     maker_kwargs: Optional[dict] = None,  # defaults applied below
     val_maker_kwargs: Optional[dict] = None,  # per-split overrides for validation
     test_maker_kwargs: Optional[dict] = None,  # per-split overrides for test
@@ -138,9 +138,6 @@ def _qwen2_audio_common(
         maker_kwargs = {
             "path_or_dataset": "ysdede/commonvoice_17_tr_fixed",
             "split": "train",
-            "text_column": "transcription",
-            "prompt": "Transcribe the Turkish audio clip.",
-            "remove_text_spaces": False,
         }
     if val_maker_kwargs is None:
         val_maker_kwargs = {

--- a/src/megatron/bridge/recipes/qwen2_audio/qwen2_audio.py
+++ b/src/megatron/bridge/recipes/qwen2_audio/qwen2_audio.py
@@ -136,14 +136,15 @@ def _qwen2_audio_common(
     # Dataset: HF conversation provider with audio maker
     if maker_kwargs is None:
         maker_kwargs = {
-            "path_or_dataset": "yuekai/aishell",
-            "subset": "train",
+            "path_or_dataset": "ysdede/commonvoice_17_tr_fixed",
             "split": "train",
+            "text_column": "transcription",
+            "prompt": "Transcribe the Turkish audio clip.",
+            "remove_text_spaces": False,
         }
     if val_maker_kwargs is None:
         val_maker_kwargs = {
-            "subset": "dev",
-            "split": "test",
+            "split": "validation",
         }
     dataset_cfg = HFDatasetConversationProvider(
         seq_length=seq_length,

--- a/tests/unit_tests/data/vlm_datasets/test_hf_dataset_makers.py
+++ b/tests/unit_tests/data/vlm_datasets/test_hf_dataset_makers.py
@@ -81,6 +81,8 @@ def test_make_cv17_dataset(monkeypatch):
     _monkeypatch_load_dataset(monkeypatch, rows)
     out = makers.make_cv17_dataset()
     assert out and isinstance(out[0]["audio"], tuple)
+    assert out[0]["conversation"][0]["content"][0]["type"] == "audio"
+    assert out[0]["conversation"][1]["content"][0]["text"] == "hello"
 
 
 def test_make_default_audio_dataset_custom_text_column_keeps_spaces(monkeypatch):

--- a/tests/unit_tests/data/vlm_datasets/test_hf_dataset_makers.py
+++ b/tests/unit_tests/data/vlm_datasets/test_hf_dataset_makers.py
@@ -83,6 +83,21 @@ def test_make_cv17_dataset(monkeypatch):
     assert out and isinstance(out[0]["audio"], tuple)
 
 
+def test_make_default_audio_dataset_custom_text_column_keeps_spaces(monkeypatch):
+    rows = [{"audio": {"array": [0.1, 0.2], "sampling_rate": 16000}, "transcription": "hello world"}]
+    _monkeypatch_load_dataset(monkeypatch, rows)
+
+    out = makers.make_default_audio_dataset(
+        path_or_dataset="ysdede/commonvoice_17_tr_fixed",
+        split="train",
+        text_column="transcription",
+        remove_text_spaces=False,
+    )
+
+    assert out[0]["conversation"][1]["content"][0]["text"] == "hello world"
+    assert out[0]["audio"] == ([0.1, 0.2], 16000)
+
+
 def test_make_raven_dataset(monkeypatch):
     # Simulate a row with images and the expected texts structure
     rows = [

--- a/tests/unit_tests/recipes/test_qwen2_audio_recipes.py
+++ b/tests/unit_tests/recipes/test_qwen2_audio_recipes.py
@@ -152,12 +152,10 @@ class TestQwen2AudioFinetuneConfig:
         cfg = _qwen2_audio_module.qwen2_audio_7b_finetune_config()
 
         assert isinstance(cfg.dataset, HFDatasetConversationProvider)
-        assert cfg.dataset.maker_name == "make_default_audio_dataset"
+        assert cfg.dataset.maker_name == "make_cv17_dataset"
         assert cfg.dataset.hf_processor_path == "Qwen/Qwen2-Audio-7B-Instruct"
         assert cfg.dataset.maker_kwargs["path_or_dataset"] == "ysdede/commonvoice_17_tr_fixed"
         assert cfg.dataset.maker_kwargs["split"] == "train"
-        assert cfg.dataset.maker_kwargs["text_column"] == "transcription"
-        assert cfg.dataset.maker_kwargs["remove_text_spaces"] is False
         assert cfg.dataset.val_maker_kwargs["split"] == "validation"
 
     def test_finetune_config_full_sft_uses_low_lr(self):

--- a/tests/unit_tests/recipes/test_qwen2_audio_recipes.py
+++ b/tests/unit_tests/recipes/test_qwen2_audio_recipes.py
@@ -154,9 +154,11 @@ class TestQwen2AudioFinetuneConfig:
         assert isinstance(cfg.dataset, HFDatasetConversationProvider)
         assert cfg.dataset.maker_name == "make_default_audio_dataset"
         assert cfg.dataset.hf_processor_path == "Qwen/Qwen2-Audio-7B-Instruct"
-        # Default split selection — train uses train, val uses dev.
-        assert cfg.dataset.maker_kwargs["subset"] == "train"
-        assert cfg.dataset.val_maker_kwargs["subset"] == "dev"
+        assert cfg.dataset.maker_kwargs["path_or_dataset"] == "ysdede/commonvoice_17_tr_fixed"
+        assert cfg.dataset.maker_kwargs["split"] == "train"
+        assert cfg.dataset.maker_kwargs["text_column"] == "transcription"
+        assert cfg.dataset.maker_kwargs["remove_text_spaces"] is False
+        assert cfg.dataset.val_maker_kwargs["split"] == "validation"
 
     def test_finetune_config_full_sft_uses_low_lr(self):
         """When peft is None (full SFT), the entry point picks lr=5e-6."""


### PR DESCRIPTION
## Summary
- default Qwen2-Audio SFT script to `WANDB_MODE=disabled` unless users opt into W&B
- replace the script-backed `yuekai/aishell` default with `ysdede/commonvoice_17_tr_fixed`
- use the CommonVoice-specific `make_cv17_dataset` path so audio is decoded with the existing `soundfile` dependency instead of HF `Audio` auto-decoding that requires `torchcodec`
- format CV17 examples with structured audio/text conversation content so the Qwen2-Audio processor emits the expected audio tokens
- update Qwen2-Audio recipe defaults and focused unit coverage for the dataset defaults/audio example format

## NVBug
- https://nvbugspro.nvidia.com/bug/6308027

## Validation
- `uv run --no-project --with pre-commit pre-commit run --all-files`
- Earlier focused Docker unit test on this PR branch: `python -m pytest tests/unit_tests/recipes/test_qwen2_audio_recipes.py tests/unit_tests/data/vlm_datasets/test_hf_dataset_makers.py` — 29 passed
- EOS rc5 dataset probe using `/lustre/fsw/coreai_dlalgo_llm/aot/sqsh/2606rc5.sqsh`: verified `datasets 4.8.5` rejects `yuekai/aishell` with `Dataset scripts are no longer supported, but found aishell.py`, and loads `ysdede/commonvoice_17_tr_fixed` with `audio` and `transcription` columns
- cw-dfw rc5 full `sft.sh` smoke/training run:
  - container: `/lustre/fs1/portfolios/coreai/users/chcui/nvbug6169351/containers/nvidian_nemo_26.06.rc5.sqsh`
  - job: `12739441` on 8x H100
  - commit: `e74e5f102d40542439c22cab3bb65efa7bb2f6cc`
  - result: loaded the imported Qwen2-Audio checkpoint, built CV17 train/validation/test datasets, entered training, and logged finite iterations through at least iteration 235
  - sample line: iteration 210, `lm loss: 9.072549E-01`, `loss scale: 1.0`, skipped/nan iterations 0
  - cancelled after successful validation to release GPUs

## Notes
- Exact EOS Pyxis import of `nvcr.io#nvidian/nemo:26.06.rc7` returned NGC `401 Unauthorized` with available enroot credentials, so dataset probing used the existing shared rc5 image.
- The successful cw-dfw rc5 validation preserved the image's `/opt/venv` via `UV_PROJECT_ENVIRONMENT=/opt/venv`; a plain `uv sync` in the container changes the package set and triggers HF audio auto-decode/`torchcodec` issues.
- Latest local focused pytest on the workstation is blocked by `nvidia-resiliency-ext==0.6.0` wheel platform compatibility for the host (`manylinux_2_31_x86_64`).