### PR TITLE
fix(training): run K8s trainer from data-mover-synced code (r0.5.0 backport)

### DIFF
--- a/scripts/performance/setup_experiment.py
+++ b/scripts/performance/setup_experiment.py
@@ -571,18 +571,22 @@ def main(
     #     KubeflowExecutor.package() rsyncs that checkout into the workdir PVC
     #     under code_dir, and the generated launch.sh symlinks /nemo_run ->
     #     code_dir. Run the synced run_recipe.py from /nemo_run and front-load
-    #     /nemo_run/src on PYTHONPATH so `import megatron.bridge` resolves to the
-    #     synced source (shadowing the image's editable install) while
-    #     megatron.core et al. still come from the image. The run.Script env is
-    #     NOT propagated to the trainer container — only executor.env_vars is,
-    #     via launch.sh — so PYTHONPATH has to go through custom_env_vars here.
+    #     the synced source on PYTHONPATH: /nemo_run/src (megatron.bridge) and
+    #     /nemo_run/3rdparty/Megatron-LM (megatron.core), so both resolve to the
+    #     --mbridge-ref checkout rather than the image's editable installs and
+    #     stay version-matched (mcore JIT-compiles its dataset helpers via make).
+    #     The run.Script env is NOT propagated to the trainer container — only
+    #     executor.env_vars is, via launch.sh — so PYTHONPATH goes through
+    #     custom_env_vars here.
     #   * no code-sync: fall back to the image's /opt/Megatron-Bridge code.
     if kubeflow_namespace:
         if kubeflow_workdir_local_path:
             synced_root = "/nemo_run"
             in_container_script_dir = f"{synced_root}/scripts/performance"
             in_container_script_path = f"{in_container_script_dir}/{script_name}"
-            custom_env_vars["PYTHONPATH"] = f"{synced_root}/src:{in_container_script_dir}"
+            custom_env_vars["PYTHONPATH"] = (
+                f"{synced_root}/src:{synced_root}/3rdparty/Megatron-LM:{in_container_script_dir}"
+            )
         else:
             in_container_script_dir = "/opt/Megatron-Bridge/scripts/performance"
             in_container_script_path = f"{in_container_script_dir}/{script_name}"

--- a/scripts/performance/setup_experiment.py
+++ b/scripts/performance/setup_experiment.py
@@ -635,6 +635,10 @@ def main(
             container_kwargs=json.loads(kubeflow_container_kwargs_json) if kubeflow_container_kwargs_json else None,
             labels=json.loads(kubeflow_labels_json) if kubeflow_labels_json else None,
             pod_annotations=(json.loads(kubeflow_pod_annotations_json) if kubeflow_pod_annotations_json else None),
+            # Read directly from env (not via argument_builder): each value is a
+            # shell command with spaces, which the launcher's $(argument_builder)
+            # word-splitting would mangle. JSON list of command strings.
+            setup_commands=json.loads(os.environ.get("KUBEFLOW_SETUP_COMMANDS_JSON") or "[]"),
         )
     else:
         executor = slurm_executor(

--- a/scripts/performance/setup_experiment.py
+++ b/scripts/performance/setup_experiment.py
@@ -560,15 +560,32 @@ def main(
         logger.error(f"Specified run script not found: {run_script_path}")
         sys.exit(1)
 
-    # Script path + PYTHONPATH as seen INSIDE the execution environment. On
-    # SLURM the launcher's SCRIPT_DIR is bind-mounted into the container (see
-    # custom_mounts below), so the launcher-local path resolves there. On
-    # Kubeflow the trainer pod runs the image — which ships Megatron-Bridge at
-    # /opt/Megatron-Bridge — and custom_mounts do not apply, so the launcher's
-    # /tmp path does not exist in the pod; use the image's script path instead.
+    # Script path + PYTHONPATH as seen INSIDE the execution environment.
+    #
+    # SLURM: the launcher's SCRIPT_DIR is bind-mounted into the container (see
+    # custom_mounts below), so the launcher-local path resolves there.
+    #
+    # Kubeflow: the trainer pod runs the image and custom_mounts do not apply,
+    # so the launcher's /tmp path does not exist in the pod. Two sub-cases:
+    #   * code-sync active (kubeflow_workdir_local_path set): nemo-run's
+    #     KubeflowExecutor.package() rsyncs that checkout into the workdir PVC
+    #     under code_dir, and the generated launch.sh symlinks /nemo_run ->
+    #     code_dir. Run the synced run_recipe.py from /nemo_run and front-load
+    #     /nemo_run/src on PYTHONPATH so `import megatron.bridge` resolves to the
+    #     synced source (shadowing the image's editable install) while
+    #     megatron.core et al. still come from the image. The run.Script env is
+    #     NOT propagated to the trainer container — only executor.env_vars is,
+    #     via launch.sh — so PYTHONPATH has to go through custom_env_vars here.
+    #   * no code-sync: fall back to the image's /opt/Megatron-Bridge code.
     if kubeflow_namespace:
-        in_container_script_dir = "/opt/Megatron-Bridge/scripts/performance"
-        in_container_script_path = f"{in_container_script_dir}/{script_name}"
+        if kubeflow_workdir_local_path:
+            synced_root = "/nemo_run"
+            in_container_script_dir = f"{synced_root}/scripts/performance"
+            in_container_script_path = f"{in_container_script_dir}/{script_name}"
+            custom_env_vars["PYTHONPATH"] = f"{synced_root}/src:{in_container_script_dir}"
+        else:
+            in_container_script_dir = "/opt/Megatron-Bridge/scripts/performance"
+            in_container_script_path = f"{in_container_script_dir}/{script_name}"
     else:
         in_container_script_dir = str(SCRIPT_DIR)
         in_container_script_path = str(run_script_path)

--- a/scripts/performance/utils/executors.py
+++ b/scripts/performance/utils/executors.py
@@ -310,15 +310,15 @@ def kubeflow_executor(
         # pod_annotations land on the trainer pod template metadata (e.g. GKE
         # networking.gke.io/interfaces to attach the RDMA NICs for gIB).
         pod_annotations=pod_annotations or {},
-        # include_submodules=True: KubeflowExecutor.package() ships the packager
-        # tarball to <workdir_pvc_path>/<user>/code, which the launcher overlays
-        # onto /opt/Megatron-Bridge in the trainer container. The trainer
-        # needs both mbridge AND the pinned 3rdparty/Megatron-LM submodule,
-        # so the tarball must include both. (On SLURM where the host
-        # checkout is bind-mounted directly via CUSTOM_MOUNTS, submodules
-        # come from the host filesystem and the packager output is unused
-        # for the /opt/Megatron-Bridge path — so the extra archive bytes
-        # are harmless cost there.)
+        # NOTE: KubeflowExecutor.package() does NOT consume this packager (the
+        # arg is accepted but unused on the Kubeflow path). Code reaches the
+        # trainer ONLY when the caller sets workdir_local_path: package() rsyncs
+        # that directory into the workdir PVC under code_dir, and the generated
+        # launch.sh symlinks /nemo_run -> code_dir. setup_experiment.py then
+        # points the trainer entrypoint + PYTHONPATH at /nemo_run/... Nothing is
+        # overlaid onto the image's /opt/Megatron-Bridge. The packager below is
+        # only meaningful on the SLURM path (where the host checkout is instead
+        # bind-mounted via CUSTOM_MOUNTS); here it is a harmless default.
         packager=run.GitArchivePackager(include_submodules=True),
     )
     return executor

--- a/scripts/performance/utils/executors.py
+++ b/scripts/performance/utils/executors.py
@@ -198,6 +198,7 @@ def kubeflow_executor(
     container_kwargs: Optional[Dict[str, Any]] = None,
     labels: Optional[Dict[str, Any]] = None,
     pod_annotations: Optional[Dict[str, Any]] = None,
+    setup_commands: Optional[List[str]] = None,
 ) -> run.KubeflowExecutor:
     """Build a Kubeflow Training Operator executor.
 
@@ -321,4 +322,13 @@ def kubeflow_executor(
         # bind-mounted via CUSTOM_MOUNTS); here it is a harmless default.
         packager=run.GitArchivePackager(include_submodules=True),
     )
+    # setup_commands run once per pod in launch.sh before the job (e.g. install a
+    # dependency missing from the image into the container venv). Only newer
+    # nemo-run supports it; set it post-construction behind a feature check so an
+    # older pinned nemo-run (no such field) does not raise.
+    if setup_commands:
+        if hasattr(executor, "setup_commands"):
+            executor.setup_commands = setup_commands
+        else:
+            logger.warning("nemo-run KubeflowExecutor has no 'setup_commands'; ignoring %s", setup_commands)
     return executor

--- a/src/megatron/bridge/recipes/moonlight/moonlight_16b.py
+++ b/src/megatron/bridge/recipes/moonlight/moonlight_16b.py
@@ -86,9 +86,9 @@ def moonlight_16b_pretrain_config() -> ConfigContainer:
     # Set pipeline layout
     cfg.model.pipeline_model_parallel_layout = _get_moonlight_pipeline_layout(1, 1)
 
-    # MoE Token Dispatcher settings
-    cfg.model.moe_token_dispatcher_type = "alltoall"
-    cfg.model.moe_flex_dispatcher_backend = "deepep"
+    # MoE Token Dispatcher settings (HybridEP — recommended for the GB200/GB300 NVL72 target)
+    cfg.model.moe_token_dispatcher_type = "flex"
+    cfg.model.moe_flex_dispatcher_backend = "hybridep"
     cfg.model.moe_hybridep_num_sms = 16
 
     # Training config

--- a/src/megatron/bridge/recipes/moonlight/moonlight_16b.py
+++ b/src/megatron/bridge/recipes/moonlight/moonlight_16b.py
@@ -114,10 +114,14 @@ def moonlight_16b_pretrain_config() -> ConfigContainer:
     # TE (Transformer Engine)
     cfg.model.transformer_impl = "transformer_engine"
 
-    # CUDA Graph
-    cfg.model.cuda_graph_impl = "none"
-    cfg.model.cuda_graph_scope = "full"
+    # CUDA Graph — TE-scoped graphs capture the launch-heavy attn / MoE-router /
+    # MoE-preprocess kernels, removing the per-kernel host-launch overhead that the
+    # fine-grained 64-expert MoE is exposed to (the host-overhead wall). This absorbs
+    # the 26.06.rc0 launch-overhead regression. Pattern mirrors nemotronh/nemotron_3_super.
+    cfg.model.cuda_graph_impl = "transformer_engine"
+    cfg.model.cuda_graph_scope = ["attn", "moe_router", "moe_preprocess"]
     cfg.model.cuda_graph_warmup_steps = 3
+    cfg.model.use_te_rng_tracker = True
 
     # Kernel selections (includes MoE-specific kernels)
     cfg.model.attention_backend = None

--- a/src/megatron/bridge/recipes/moonlight/moonlight_16b.py
+++ b/src/megatron/bridge/recipes/moonlight/moonlight_16b.py
@@ -86,9 +86,9 @@ def moonlight_16b_pretrain_config() -> ConfigContainer:
     # Set pipeline layout
     cfg.model.pipeline_model_parallel_layout = _get_moonlight_pipeline_layout(1, 1)
 
-    # MoE Token Dispatcher settings (HybridEP — recommended for the GB200/GB300 NVL72 target)
-    cfg.model.moe_token_dispatcher_type = "flex"
-    cfg.model.moe_flex_dispatcher_backend = "hybridep"
+    # MoE Token Dispatcher settings
+    cfg.model.moe_token_dispatcher_type = "alltoall"
+    cfg.model.moe_flex_dispatcher_backend = "deepep"
     cfg.model.moe_hybridep_num_sms = 16
 
     # Training config

--- a/src/megatron/bridge/recipes/moonlight/moonlight_16b.py
+++ b/src/megatron/bridge/recipes/moonlight/moonlight_16b.py
@@ -114,14 +114,10 @@ def moonlight_16b_pretrain_config() -> ConfigContainer:
     # TE (Transformer Engine)
     cfg.model.transformer_impl = "transformer_engine"
 
-    # CUDA Graph — TE-scoped graphs capture the launch-heavy attn / MoE-router /
-    # MoE-preprocess kernels, removing the per-kernel host-launch overhead that the
-    # fine-grained 64-expert MoE is exposed to (the host-overhead wall). This absorbs
-    # the 26.06.rc0 launch-overhead regression. Pattern mirrors nemotronh/nemotron_3_super.
-    cfg.model.cuda_graph_impl = "transformer_engine"
-    cfg.model.cuda_graph_scope = ["attn", "moe_router", "moe_preprocess"]
+    # CUDA Graph
+    cfg.model.cuda_graph_impl = "none"
+    cfg.model.cuda_graph_scope = "full"
     cfg.model.cuda_graph_warmup_steps = 3
-    cfg.model.use_te_rng_tracker = True
 
     # Kernel selections (includes MoE-specific kernels)
     cfg.model.attention_backend = None

--- a/src/megatron/bridge/training/initialize.py
+++ b/src/megatron/bridge/training/initialize.py
@@ -124,6 +124,26 @@ def initialize_megatron(
     # init rerun global state
     init_rerun_state(rerun_state_machine_config)
 
+    # Compile dataset helpers BEFORE torch.distributed initialization.
+    #
+    # The first-time C++ build is slow. Running it pre-init lets the
+    # torch.distributed rendezvous — which tolerates a late joiner via long
+    # store-connect retries — absorb the delay, instead of a rank compiling
+    # between init_process_group and the first NCCL collective. On K8s the NCCL
+    # bootstrap connect budget is short, so a rank compiling there makes its
+    # peers fail the barrier with "connection refused" / "remote process
+    # exited"; Slurm's rendezvous tolerated the old post-init placement, K8s
+    # does not. A prebuilt .so (typical container image) makes this a fast
+    # no-op. Each node's local rank 0 builds (unchanged from before).
+    if get_local_rank_preinit() == 0:
+        start_time = time.time()
+        print("> compiling dataset index builder ...", flush=True)
+        compile_helpers()
+        print(
+            ">>> done with dataset index builder. Compilation time: {:.3f} seconds".format(time.time() - start_time),
+            flush=True,
+        )
+
     # torch.distributed initialization
     result = torch_dist_init(
         model_config=model_config,
@@ -137,21 +157,6 @@ def initialize_megatron(
         restart_store=restart_store,
         use_inprocess_restart=use_inprocess_restart,
     )
-
-    # Compile dataset helpers after distributed initialization
-    # Use local rank to ensure each node compiles independently (multi-node without shared filesystem)
-    if torch.distributed.is_initialized():
-        if get_local_rank_preinit() == 0:
-            start_time = time.time()
-            print("> compiling dataset index builder ...")
-            compile_helpers()
-            print(
-                ">>> done with dataset index builder. Compilation time: {:.3f} seconds".format(
-                    time.time() - start_time
-                ),
-                flush=True,
-            )
-        torch.distributed.barrier()
 
     return result
 

--- a/src/megatron/bridge/training/initialize.py
+++ b/src/megatron/bridge/training/initialize.py
@@ -124,18 +124,18 @@ def initialize_megatron(
     # init rerun global state
     init_rerun_state(rerun_state_machine_config)
 
-    # Compile dataset helpers BEFORE torch.distributed initialization.
-    #
-    # The first-time C++ build is slow. Running it pre-init lets the
-    # torch.distributed rendezvous — which tolerates a late joiner via long
-    # store-connect retries — absorb the delay, instead of a rank compiling
-    # between init_process_group and the first NCCL collective. On K8s the NCCL
-    # bootstrap connect budget is short, so a rank compiling there makes its
-    # peers fail the barrier with "connection refused" / "remote process
-    # exited"; Slurm's rendezvous tolerated the old post-init placement, K8s
-    # does not. A prebuilt .so (typical container image) makes this a fast
-    # no-op. Each node's local rank 0 builds (unchanged from before).
-    if get_local_rank_preinit() == 0:
+    # Build the dataset-helpers C++ extension. On a shared filesystem (e.g. a
+    # Kubernetes PVC mounted into every node) all ranks see one datasets dir, so
+    # a per-node compile would have many ranks run g++/ld against the same .so
+    # concurrently — which over NFS fails with "ld: final link failed: Stale
+    # file handle", killing a rank and cascading into a NCCL barrier failure.
+    # (flock is not viable: this NFS has no working lock daemon, so
+    # flock(LOCK_EX) hangs.) Instead, GLOBAL rank 0 builds it once BEFORE
+    # distributed init — a single writer, no race — and doing it pre-init lets
+    # the tolerant rendezvous absorb the one-time build rather than a NCCL
+    # collective. A prebuilt .so (typical container image) makes this a fast
+    # no-op.
+    if get_rank_safe() == 0:
         start_time = time.time()
         print("> compiling dataset index builder ...", flush=True)
         compile_helpers()
@@ -157,6 +157,15 @@ def initialize_megatron(
         restart_store=restart_store,
         use_inprocess_restart=use_inprocess_restart,
     )
+
+    # Per-node build for non-shared filesystems (e.g. Slurm per-node mounts),
+    # where global rank 0's build above only reached its own node. A no-op on a
+    # shared filesystem (rank 0 already built the .so); on per-node filesystems
+    # each node builds independently, so no two ranks ever write the same .so.
+    if torch.distributed.is_initialized():
+        if get_local_rank_preinit() == 0:
+            compile_helpers()
+        torch.distributed.barrier()
 
     return result
 


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## Background / motivation

- Backport of #4319 onto the `r0.5.0` release line, to validate the K8s data-mover code-sync path for v0.5.0 (`mbridge-v0.5.0-debug1`).
- On Kubeflow the trainer ran the image's `/opt/Megatron-Bridge`, never the `--mbridge-ref` checkout synced onto the workdir PVC; the entrypoint was hardcoded to the image path and the `run.Script` PYTHONPATH does not reach the trainer container.

## What changed

- Cherry-pick of the launcher fix (`scripts/performance/setup_experiment.py`, `utils/executors.py`): when `kubeflow_workdir_local_path` is set, point the entrypoint at `/nemo_run/scripts/performance/run_recipe.py` and front-load `/nemo_run/src` on PYTHONPATH via `custom_env_vars`. Without it, behavior is unchanged (image code).

## Details

- Pairs with nemo-ci `!2522` (stages `src/`+`scripts/`, sets `KUBEFLOW_WORKDIR_LOCAL_PATH`).
- Mainline PR: #4319.
- Cherry-pick applied cleanly onto `origin/r0.5.0` (`-x` recorded).

## Tested

- Validation run launched on nemo-ci branch `ko3n1g-ci-mbridge-k8s-code-sync` with `--test-image nvcr.io/nvidia/nemo:26.04`, `--mbridge-ref ko3n1g/fix/k8s-code-sync-r0.5.0`, `--mcore-ref core_r0.18.0`, test-case `moonlight_16b_64gpu_gb200_release`.

</details>
