### PR TITLE
cp: [training] fix: guard optional nvrx_straggler import against non-import errors (#4124) into r0.5.0

### DIFF
--- a/src/megatron/bridge/training/nvrx_straggler.py
+++ b/src/megatron/bridge/training/nvrx_straggler.py
@@ -22,19 +22,30 @@ from megatron.bridge.training.config import NVRxStragglerDetectionConfig
 from megatron.bridge.utils.import_utils import MISSING_NVRX_MSG
 
 
+# NOTE: catch broadly here, not just (ImportError, ModuleNotFoundError).
+# ``nvidia-resiliency-ext`` is an optional dependency, and importing
+# ``nvidia_resiliency_ext.attribution`` eagerly pulls in a langchain-based log
+# analyzer. Its transitive dependencies can fail to import with errors *other*
+# than ImportError -- e.g. a ``pydantic.ValidationError`` raised at module load
+# when an incompatible pydantic version is resolved. Because this module is
+# imported by ``megatron.bridge.training.state`` (a core training import), a
+# narrow except would let such a failure crash unrelated training/conversion
+# code paths. Degrading to ``HAVE_NVRX = False`` keeps the optional feature
+# disabled without taking down the rest of the library.
 try:
     # Try the newer version first (nvidia-resiliency-ext >= 0.4)
     import nvidia_resiliency_ext.attribution.straggler as straggler
 
     HAVE_NVRX = True
-except (ImportError, ModuleNotFoundError):
+except Exception:
     try:
         # Fall back to the older version (nvidia-resiliency-ext < 0.4)
         import nvidia_resiliency_ext.straggler as straggler
 
         HAVE_NVRX = True
-    except (ImportError, ModuleNotFoundError):
+    except Exception as e:
         HAVE_NVRX = False
+        logging.getLogger(__name__).debug("nvidia-resiliency-ext unavailable, straggler detection disabled: %s", e)
 
 
 class NVRxStragglerDetectionManager:


### PR DESCRIPTION
## Summary

Backport of #4124 to `r0.5.0`.

This cherry-picks `ab3eb055fdbf7fedbef75c5cc33e80d81344e577` as `6954b3c45d8d8a1e2a9b637435424cffa812e70a`, preserving the `-x` provenance footer.

The fix broadens the optional `nvidia-resiliency-ext` straggler import guard so import-time failures from transitive optional dependencies disable NVRx straggler detection instead of breaking unrelated Bridge training/conversion imports.

## Validation

- `git diff --check HEAD~1..HEAD`
- `uv run --no-sync python -m py_compile src/megatron/bridge/training/nvrx_straggler.py`

Note: direct package import in the isolated release worktree was not used as validation because the worktree was not dependency-synced / Megatron-Core was not on the editable path.