### PR TITLE
docs(deepseek): update H100 Flash parallelism

### DIFF
--- a/examples/models/deepseek_v4/README.md
+++ b/examples/models/deepseek_v4/README.md
@@ -119,7 +119,7 @@ DSv4 currently requires **TP=1** because MLA tensor parallelism is not supported
 | Model | TP | PP | EP | GPUs | GPU | Verified |
 |-------|---:|---:|---:|-----:|-----|----------|
 | DeepSeek-V4-Flash | 1 | 1 | 4 | 4 | GB200 192GB | Import, export, inference |
-| DeepSeek-V4-Flash | 1 | 1 | 8 | 8 | H100 80GB | Import, export, inference |
+| DeepSeek-V4-Flash | 1 | 1 | 16 | 16 | H100 80GB | Import, export, inference |
 | DeepSeek-V4-Flash-Base | 1 | 1 | 4 | 4 | GB200 192GB | Import, export, inference |
 | DeepSeek-V4-Pro | 1 | 4 | 8 | 32 | GB200 192GB | Import, export, inference |
 | DeepSeek-V4-Pro | 1 | 16 | 8 | 128 | H100 80GB | Import, export, inference |


### PR DESCRIPTION
## Summary
- Update the DeepSeek-V4-Flash H100 row from 8 GPUs / EP=8 to 16 GPUs / EP=16.

## Validation
- `git diff --check`
- `pre-commit run --all-files`
- DFW H100 EP16 construction probe: job `12758737` completed, `TP=1 PP=1 EP=16`, `LOAD_WEIGHTS=0`, `CPU_INIT=0`, reached `MODEL_INSTANTIATED` with `after_model: cuda_allocated_gib=47.57 cuda_reserved_gib=48.36` and exited `0:0`.
- DFW H100 EP16 unfused inference smoke: job `12759301` completed, loaded DeepSeek-V4-Flash from HF with `use_fused_mhc=False`, `apply_rope_fusion=False`, `apply_dsa_kernel_fusion=False`, reached `Generation step 0`, and generated `Hello2`; exited `0:0`.

Additional note: the default HF-direct inference path without overrides failed on H100 in job `12759131` in the fused mHC cuTile path: `tileiras ... --gpu-name sm_90 ... Cannot find option named sm_90`. This was not an OOM.

Note: `uv run pre-commit run --all-files` could not start on this host because `nvidia-resiliency-ext==0.6.0` has no compatible wheel for the local platform tag. The system `pre-commit` fallback passed.