### PR TITLE
[recipes] refactor: Sync Qwen3-VL Energon task encoder in finalize() instead of build_datasets()

### DIFF
--- a/src/megatron/bridge/recipes/qwen_vl/qwen3_vl.py
+++ b/src/megatron/bridge/recipes/qwen_vl/qwen3_vl.py
@@ -29,7 +29,6 @@ from typing_extensions import TypedDict, Unpack
 
 from megatron.bridge import AutoBridge
 from megatron.bridge.data.energon.energon_provider import EnergonProvider
-from megatron.bridge.data.utils import DatasetBuildContext
 from megatron.bridge.data.vlm_datasets import MockVLMConversationProvider
 from megatron.bridge.models.qwen_vl.data.energon import QwenVLTaskEncoder
 from megatron.bridge.peft.base import PEFT
@@ -271,8 +270,9 @@ def qwen3_vl_235b_a22b_pretrain_mock_config(**user_kwargs: Unpack[Qwen3VLCommonK
 class QwenVLEnergonProvider(EnergonProvider):
     """EnergonProvider subclass that exposes task-encoder knobs as CLI-overridable fields.
 
-    The task encoder is constructed eagerly (same as before), but build_datasets
-    syncs these fields onto it after CLI overrides have been applied.
+    The task encoder is constructed eagerly (same as before), but ``finalize`` (called by
+    ``ConfigContainer.validate`` after CLI/YAML overrides are merged) syncs these fields
+    onto it.
     """
 
     min_pixels: int = 200704
@@ -281,7 +281,8 @@ class QwenVLEnergonProvider(EnergonProvider):
     max_num_frames: int | None = 60
     max_visual_tokens: int | None = 16384
 
-    def build_datasets(self, context: DatasetBuildContext):
+    def finalize(self) -> None:
+        super().finalize()
         if self.task_encoder is not None:
             self.task_encoder.seq_len = self.seq_length
             self.task_encoder.seq_length = self.seq_length
@@ -290,7 +291,6 @@ class QwenVLEnergonProvider(EnergonProvider):
             self.task_encoder.max_num_images = self.max_num_images
             self.task_encoder.max_num_frames = self.max_num_frames
             self.task_encoder.max_visual_tokens = self.max_visual_tokens
-        return super().build_datasets(context)
 
 
 def _make_energon_dataset(

--- a/tests/unit_tests/recipes/qwen_vl/test_qwen_vl_energon_provider.py
+++ b/tests/unit_tests/recipes/qwen_vl/test_qwen_vl_energon_provider.py
@@ -14,13 +14,12 @@
 
 #
 # Test purpose:
-# - Verify QwenVLEnergonProvider.build_datasets propagates dataset-config knobs
-#   (seq_length, min_pixels, max_pixels, max_num_images, max_num_frames,
-#   max_visual_tokens) onto the task encoder *before* delegating to the parent.
-#   The propagation step is what makes these fields CLI-overridable for users.
+# - Verify QwenVLEnergonProvider.finalize() propagates dataset-config knobs
+#   (seq_length, seq_len, min_pixels, max_pixels, max_num_images, max_num_frames,
+#   max_visual_tokens) onto the eagerly-built task encoder. finalize() is called by
+#   ConfigContainer.validate() after CLI/YAML overrides are merged, which is what makes
+#   these fields overridable.
 #
-
-import pytest
 
 from megatron.bridge.recipes.qwen_vl.qwen3_vl import QwenVLEnergonProvider
 
@@ -54,14 +53,7 @@ def _make_provider(task_encoder, **overrides):
     return QwenVLEnergonProvider(**defaults)
 
 
-@pytest.fixture
-def fake_context():
-    # build_datasets is stubbed before reaching the real parent, so a None-like
-    # context is acceptable; we only need an object the override path won't touch.
-    return object()
-
-
-def test_build_datasets_syncs_all_fields_to_task_encoder(monkeypatch, fake_context):
+def test_finalize_syncs_all_fields_to_task_encoder():
     encoder = _FakeTaskEncoder()
     provider = _make_provider(
         encoder,
@@ -73,25 +65,9 @@ def test_build_datasets_syncs_all_fields_to_task_encoder(monkeypatch, fake_conte
         max_visual_tokens=999,
     )
 
-    # Stub the parent so build_datasets returns immediately after the sync block.
-    captured = {}
+    provider.finalize()
 
-    def fake_super_build(self, context):
-        captured["called_with"] = context
-        return "stubbed"
-
-    # Patch the parent's build_datasets in-place; restored automatically by monkeypatch.
-    from megatron.bridge.data.energon.energon_provider import EnergonProvider
-
-    monkeypatch.setattr(EnergonProvider, "build_datasets", fake_super_build)
-
-    result = provider.build_datasets(fake_context)
-
-    # Parent was invoked (so super().build_datasets ran) and got the right context.
-    assert result == "stubbed"
-    assert captured["called_with"] is fake_context
-
-    # Every overridable field is now reflected on the encoder.
+    # seq_length / seq_len and the Qwen-VL-specific knobs are all synced by finalize().
     assert encoder.seq_len == 2048
     assert encoder.seq_length == 2048
     assert encoder.min_pixels == 12345
@@ -101,16 +77,10 @@ def test_build_datasets_syncs_all_fields_to_task_encoder(monkeypatch, fake_conte
     assert encoder.max_visual_tokens == 999
 
 
-def test_build_datasets_no_op_when_task_encoder_is_none(monkeypatch, fake_context):
+def test_finalize_no_op_when_task_encoder_is_none():
     provider = _make_provider(task_encoder=None)
-
-    from megatron.bridge.data.energon.energon_provider import EnergonProvider
-
-    monkeypatch.setattr(EnergonProvider, "build_datasets", lambda self, context: "stubbed")
-
     # Should not raise even though task_encoder is None.
-    result = provider.build_datasets(fake_context)
-    assert result == "stubbed"
+    provider.finalize()
 
 
 def test_provider_default_field_values():
@@ -136,7 +106,7 @@ def test_provider_accepts_none_for_unbounded_limits():
     assert provider.max_visual_tokens is None
 
 
-def test_build_datasets_propagates_none_limits(monkeypatch, fake_context):
+def test_finalize_propagates_none_limits():
     encoder = _FakeTaskEncoder()
     provider = _make_provider(
         encoder,
@@ -145,11 +115,7 @@ def test_build_datasets_propagates_none_limits(monkeypatch, fake_context):
         max_visual_tokens=None,
     )
 
-    from megatron.bridge.data.energon.energon_provider import EnergonProvider
-
-    monkeypatch.setattr(EnergonProvider, "build_datasets", lambda self, context: "stubbed")
-
-    provider.build_datasets(fake_context)
+    provider.finalize()
 
     assert encoder.max_num_images is None
     assert encoder.max_num_frames is None


### PR DESCRIPTION
## Summary

- Move `QwenVLEnergonProvider`'s task-encoder config sync (`seq_len`, `seq_length`, `min_pixels`, `max_pixels`, `max_num_images`, `max_num_frames`, `max_visual_tokens`) from `build_datasets()` into a `finalize()` override, so it runs through the framework's standard post-override hook of `ConfigContainer`.
    
    ```diff
    -    def build_datasets(self, context: DatasetBuildContext):
    +    def finalize(self) -> None:
    +        super().finalize()
             if self.task_encoder is not None:
                 self.task_encoder.seq_len = self.seq_length
                 self.task_encoder.seq_length = self.seq_length
                 self.task_encoder.min_pixels = self.min_pixels
                 self.task_encoder.max_pixels = self.max_pixels
                 self.task_encoder.max_num_images = self.max_num_images
                 self.task_encoder.max_num_frames = self.max_num_frames
                 self.task_encoder.max_visual_tokens = self.max_visual_tokens
    -        return super().build_datasets(context)
    ```

- Current overriden `build_datasets()` falls back to the base `EnergonProvider` implementation (pure dataset construction); the now-unused `DatasetBuildContext` import is dropped.
- Update `tests/unit_tests/recipes/qwen_vl/test_qwen_vl_energon_provider.py` to call `finalize()` directly. Since `finalize()` has no I/O, the tests no longer stub dataset construction — dropping the `build_datasets` `monkeypatch`, the `fake_context` fixture, and the `import pytest` for a smaller, more direct test surface.

No behavior change for Qwen3-VL when the config is run through the normal training entrypoints (`pretrain()` / `finetune()`): they call `runtime_config_update()` → `ConfigContainer.validate()` → `dataset.finalize()` before datasets are built, so the synced values still reach the task encoder before data loading.

## Context

The task encoder is built eagerly at recipe-build time (capturing scalars such as `seq_length`) and stored on the provider.
CLI/YAML config override of a provider field (e.g. `dataset.seq_length=8192`) updates the dataclass field but not the value already assigned inside the task encoder.

The current sync scheme was added in [#3691](https://github.com/NVIDIA-NeMo/Megatron-Bridge/pull/3691) inside `build_datasets()`, which works because `build_datasets()` runs after all overrides happened. 

This PR moves it to the place the framework already reserves for post-override reconciliation: `ConfigContainer.validate()` calls `self.dataset.finalize()` exactly once, after any overrides are applied.

`finalize()` is a better hook than `build_datasets()` for several reasons:

- Correct timing: the sync runs right after overrides are merged, so everything downstream of `validate()` (validation logic, config logging/snapshots, early assertions) sees a config and task encoder that already agree. With the `build_datasets()` sync, they stay inconsistent until just before data construction.
- Fail fast: subclasses can put validation that depends on task-encoder state (e.g. packing constraints) in `finalize()` and have it fail at `validate()` time, instead of surfacing only after distributed init and model construction.
- Separation of concerns: config reconciliation and dataset construction become separate methods, returning `build_datasets()` to pure construction.
- Simpler to test: `finalize()` is lighter than `build_datasets()`, making the tests simpler.

These seem to be the reasons why other `ConfigContainer` subclasses sync overridden configs this way: `DistributedDataParallelConfig`, `OptimizerConfig`, `DataloaderConfig`, `GPTDatasetConfig`, `SchedulerConfig`, `TrainingConfig`, `CheckpointConfig`, `LoggerConfig`, and others all defer post-init/derived-value work to `finalize()`.

## Validation

- `uvx ruff check` and `uvx ruff format --check` on the changed files: passed.
- `python -m py_compile` on the changed files: passed.
- Blocked locally: the full unit test (`python -m pytest tests/unit_tests/recipes/qwen_vl/test_qwen_vl_energon_provider.py`) was not run on this workstation because the `3rdparty/Megatron-LM` submodule / GPU dependencies are not installed here; it is left for CI. The tests are pure config-mutation checks (construct provider → `finalize()` → assert encoder fields) with no I/O.
