### PR TITLE
fix(gemma4-vl): avoid checkpoint save timeout

### DIFF
--- a/src/megatron/bridge/models/gemma/gemma4_provider.py
+++ b/src/megatron/bridge/models/gemma/gemma4_provider.py
@@ -453,16 +453,19 @@ class Gemma4SelfAttention(SelfAttention):
         2. Full coverage of the global tensor — fails if only a subset of layers
            fill the group (e.g. 25 sliding layers can't cover a 30-slot group).
 
-        Fix: append '_sliding'/'_global' suffix to create per-type groups AND
-        remap the prepended layer axis in ShardedTensors so global_shape[0],
-        global_offset[0], and axis_fragmentations[0] reflect per-type layer
-        counts rather than the total layer count.
+        Fix: append '_sliding'/'_global' to the checkpoint storage keys to
+        create per-type groups AND remap the prepended layer axis in
+        ShardedTensors so global_shape[0], global_offset[0], and
+        axis_fragmentations[0] reflect per-type layer counts rather than the
+        total layer count.
 
         Example:
-            'decoder.layers.0.self_attention.'
-          → 'decoder.layers.0.self_attention_sliding.'  (or _global)
-        Loading works automatically because the same class produces the same
-        suffixed keys on load.
+            state dict key: 'decoder.layers.0.self_attention.linear_qkv.weight'
+            storage key:    'decoder.layers.0.self_attention_sliding.linear_qkv.weight'
+
+        The returned state dict keys must stay unsuffixed so
+        ``module.load_state_dict`` can load the tensors into the normal module
+        hierarchy.
         """
         import dataclasses as _dataclasses
 
@@ -471,15 +474,18 @@ class Gemma4SelfAttention(SelfAttention):
 
         is_global = not _is_local_attn_layer(self.layer_number, self.config.interleaved_attn_pattern)
         suffix = "_global" if is_global else "_sliding"
-        # Insert suffix before the trailing dot (prefix always ends with '.')
+        # Insert suffix before the trailing dot (prefix normally ends with '.')
         if prefix.endswith("."):
-            modified_prefix = prefix[:-1] + suffix + "."
+            storage_prefix = prefix[:-1] + suffix + "."
         else:
-            modified_prefix = prefix + suffix
+            storage_prefix = prefix + suffix
 
-        state_dict = super().sharded_state_dict(
-            prefix=modified_prefix, sharded_offsets=sharded_offsets, metadata=metadata
-        )
+        state_dict = super().sharded_state_dict(prefix=prefix, sharded_offsets=sharded_offsets, metadata=metadata)
+
+        def _storage_key(key: str) -> str:
+            if key.startswith(prefix):
+                return storage_prefix + key[len(prefix) :]
+            return key.replace(".self_attention.", f".self_attention{suffix}.", 1)
 
         # Compute per-type layer count and this layer's rank within its type.
         # layer_number is 1-indexed in MCore.
@@ -494,27 +500,31 @@ class Gemma4SelfAttention(SelfAttention):
 
         def _remap(t):
             if isinstance(t, _ST):
+                new_key = _storage_key(t.key)
                 # Only remap the prepended layer axis (axis 0 when prepend_axis_num > 0)
                 if t.prepend_axis_num <= 0 or t.global_shape[0] != total_layers:
-                    return t
+                    return _dataclasses.replace(t, key=new_key)
                 new_global_shape = (type_total,) + t.global_shape[1:]
                 new_global_offset = (type_rank,) + t.global_offset[1:]
                 new_frags = (type_total,) + t.axis_fragmentations[1:] if t.axis_fragmentations is not None else None
                 return _dataclasses.replace(
                     t,
+                    key=new_key,
                     global_shape=new_global_shape,
                     global_offset=new_global_offset,
                     axis_fragmentations=new_frags,
                 )
             if isinstance(t, _SO):
+                new_key = _storage_key(t.key)
                 # ShardedObject (e.g. TE _extra_state): remap first axis if it matches total layers.
                 # These have no prepend_axis_num — their global_shape IS the layer axis directly.
                 if not t.global_shape or t.global_shape[0] != total_layers:
-                    return t
+                    return _dataclasses.replace(t, key=new_key)
                 new_global_shape = (type_total,) + t.global_shape[1:]
                 new_global_offset = (type_rank,) + t.global_offset[1:]
                 return _dataclasses.replace(
                     t,
+                    key=new_key,
                     global_shape=new_global_shape,
                     global_offset=new_global_offset,
                 )

--- a/src/megatron/bridge/recipes/gemma4_vl/gemma4_vl.py
+++ b/src/megatron/bridge/recipes/gemma4_vl/gemma4_vl.py
@@ -132,6 +132,9 @@ def gemma4_vl_26b_sft_config(hf_path: str = _HF_PATH) -> ConfigContainer:
     cfg.train.train_iters = 40  # override common (was 50)
     cfg.validation.eval_interval = 10  # override common (was 5)
     cfg.validation.eval_iters = 5  # override common (was 10)
+    # Full Gemma 4 VL checkpoints are large enough that rank-0 DCP
+    # finalization can exceed the default 10-minute process-group timeout.
+    cfg.dist.distributed_timeout_minutes = 90
 
     # Optimizer — lower LR for full SFT
     opt_cfg, scheduler_cfg = distributed_fused_adam_with_cosine_annealing(

--- a/tests/unit_tests/models/gemma/test_gemma4_provider.py
+++ b/tests/unit_tests/models/gemma/test_gemma4_provider.py
@@ -14,10 +14,14 @@
 
 """Unit tests for Gemma4ModelProvider (text-only LLM provider)."""
 
+from types import SimpleNamespace
+
 import pytest
 import torch
+from megatron.core.dist_checkpointing.mapping import ShardedObject, ShardedTensor
+from megatron.core.transformer.attention import SelfAttention
 
-from megatron.bridge.models.gemma.gemma4_provider import Gemma4ModelProvider
+from megatron.bridge.models.gemma.gemma4_provider import Gemma4ModelProvider, Gemma4SelfAttention
 from megatron.bridge.models.gpt_provider import GPTModelProvider
 
 
@@ -176,3 +180,52 @@ class TestGemma4ModelProviderOverride:
     def test_override_vocab_size(self):
         p = Gemma4ModelProvider(vocab_size=300000)
         assert p.vocab_size == 300000
+
+
+class TestGemma4SelfAttentionShardedStateDict:
+    """Tests for Gemma 4 sliding/global attention checkpoint key handling."""
+
+    def test_global_attention_uses_suffixed_storage_keys_only(self, monkeypatch):
+        prefix = "language_model.decoder.layers.5.self_attention."
+        tensor_key = f"{prefix}linear_qkv.weight"
+        object_key = f"{prefix}linear_qkv._extra_state"
+
+        def fake_sharded_state_dict(self, prefix="", sharded_offsets=(), metadata=None):
+            assert prefix == "language_model.decoder.layers.5.self_attention."
+            return {
+                tensor_key: ShardedTensor.from_rank_offsets(
+                    tensor_key,
+                    torch.ones(2, 3),
+                    (0, 5, 30),
+                    prepend_axis_num=1,
+                ),
+                "nested": {
+                    object_key: ShardedObject(
+                        object_key,
+                        data={},
+                        global_shape=(30,),
+                        global_offset=(5,),
+                    ),
+                },
+            }
+
+        monkeypatch.setattr(SelfAttention, "sharded_state_dict", fake_sharded_state_dict)
+
+        attention = object.__new__(Gemma4SelfAttention)
+        attention.layer_number = 6
+        attention.config = SimpleNamespace(interleaved_attn_pattern=(5, 1), num_layers=30)
+
+        state_dict = attention.sharded_state_dict(prefix=prefix)
+
+        assert tensor_key in state_dict
+        sharded_tensor = state_dict[tensor_key]
+        assert sharded_tensor.key == "language_model.decoder.layers.5.self_attention_global.linear_qkv.weight"
+        assert sharded_tensor.global_shape == (5, 2, 3)
+        assert sharded_tensor.global_offset == (0, 0, 0)
+        assert sharded_tensor.axis_fragmentations == (5, 1, 1)
+
+        assert object_key in state_dict["nested"]
+        sharded_object = state_dict["nested"][object_key]
+        assert sharded_object.key == "language_model.decoder.layers.5.self_attention_global.linear_qkv._extra_state"
+        assert sharded_object.global_shape == (5,)
+        assert sharded_object.global_offset == (0,)

--- a/tests/unit_tests/recipes/test_gemma4_vl_recipes.py
+++ b/tests/unit_tests/recipes/test_gemma4_vl_recipes.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for Gemma 4 VL recipe configuration builders."""
+
+import importlib
+
+import pytest
+
+
+_gemma4_vl_module = importlib.import_module("megatron.bridge.recipes.gemma4_vl.gemma4_vl")
+
+
+class _FakeModelCfg:
+    """Fake model configuration for testing."""
+
+    def finalize(self):
+        return None
+
+
+class _FakeAutoBridge:
+    """Fake AutoBridge for testing."""
+
+    @staticmethod
+    def from_hf_pretrained(hf_path: str):
+        return _FakeAutoBridge()
+
+    def to_megatron_provider(self, load_weights: bool = False):
+        return _FakeModelCfg()
+
+
+def test_gemma4_vl_sft_uses_long_distributed_timeout(monkeypatch: pytest.MonkeyPatch):
+    """Full Gemma 4 VL SFT should allow long checkpoint-save finalization."""
+    monkeypatch.setattr(_gemma4_vl_module, "AutoBridge", _FakeAutoBridge)
+
+    cfg = _gemma4_vl_module.gemma4_vl_26b_sft_config()
+
+    assert cfg.dist.distributed_timeout_minutes == 90


### PR DESCRIPTION
## Summary
- keep Gemma4 attention module state-dict keys unsuffixed while suffixing only DCP storage keys for sliding/global attention groups
- increase Gemma4-VL full SFT distributed timeout to 90 minutes so large checkpoint rank-0 finalization does not trip the default 10-minute process-group timeout
- add focused unit tests for both the storage-key behavior and recipe timeout default

## Validation
- git diff --check
- python3 -m py_compile src/megatron/bridge/models/gemma/gemma4_provider.py src/megatron/bridge/recipes/gemma4_vl/gemma4_vl.py tests/unit_tests/models/gemma/test_gemma4_provider.py tests/unit_tests/recipes/test_gemma4_vl_recipes.py
- DFW rc7 focused pytest: 2 passed, 43 warnings
- DFW rc7 TP=8/PP=1 Gemma4-VL one-iteration SFT checkpoint save completed with strict_warnings=0, watchdogs=0, and successful torch_dist checkpoint save

## Blast Radius / Test Recommendation
- Blast radius: Gemma4 native checkpoint load/save metadata and Gemma4-VL full SFT recipe timeout only.
- L0: unit/model recipe tests are required and included.
- L1/L2: recommend Gemma4-VL checkpoint conversion plus full TP=8 SFT save validation before release because this touches distributed checkpoint behavior for a large VLM recipe.

No CI/full-test labels added.