### PR TITLE
fix(recipe): use current Nemotron Nano VL finetune configs

### DIFF
--- a/examples/models/nemotron/nemotron_vl/finetune_nemotron_nano_v2_vl.py
+++ b/examples/models/nemotron/nemotron_vl/finetune_nemotron_nano_v2_vl.py
@@ -29,6 +29,10 @@ from typing import Tuple
 import torch
 from omegaconf import OmegaConf
 
+from megatron.bridge.recipes.nemotron_vl.nemotron_nano_v2_vl import (
+    nemotron_nano_v2_vl_12b_peft_config,
+    nemotron_nano_v2_vl_12b_sft_config,
+)
 from megatron.bridge.training.config import ConfigContainer
 from megatron.bridge.training.finetune import finetune
 from megatron.bridge.training.llava_step import forward_step
@@ -105,16 +109,16 @@ def main() -> None:
         datefmt="%Y-%m-%d %H:%M:%S",
     )
 
-    from megatron.bridge.recipes.nemotron_vl.nemotron_nano_v2_vl import nemotron_nano_v2_vl_12b_finetune_config
-
-    cfg: ConfigContainer = nemotron_nano_v2_vl_12b_finetune_config(
-        hf_model_path=args.hf_model_path,
-        pretrained_checkpoint=args.pretrained_checkpoint,
-        lora_on_language_model=args.lora_on_language_model,
-        lora_on_vision_model=args.lora_on_vision_model,
-    )
-
-    logger.info("Loaded base configuration for finetuning")
+    config_kwargs = {
+        "hf_model_path": args.hf_model_path,
+        "pretrained_checkpoint": args.pretrained_checkpoint,
+    }
+    if args.lora_on_language_model or args.lora_on_vision_model:
+        cfg: ConfigContainer = nemotron_nano_v2_vl_12b_peft_config(**config_kwargs)
+        logger.info("Loaded base configuration for PEFT")
+    else:
+        cfg = nemotron_nano_v2_vl_12b_sft_config(**config_kwargs)
+        logger.info("Loaded base configuration for SFT")
 
     if get_rank_safe() == 0:
         cfg.print_yaml()

--- a/examples/models/nemotron/nemotron_vl/finetune_nemotron_nano_v2_vl.py
+++ b/examples/models/nemotron/nemotron_vl/finetune_nemotron_nano_v2_vl.py
@@ -114,7 +114,11 @@ def main() -> None:
         "pretrained_checkpoint": args.pretrained_checkpoint,
     }
     if args.lora_on_language_model or args.lora_on_vision_model:
-        cfg: ConfigContainer = nemotron_nano_v2_vl_12b_peft_config(**config_kwargs)
+        cfg: ConfigContainer = nemotron_nano_v2_vl_12b_peft_config(
+            **config_kwargs,
+            lora_on_language_model=args.lora_on_language_model,
+            lora_on_vision_model=args.lora_on_vision_model,
+        )
         logger.info("Loaded base configuration for PEFT")
     else:
         cfg = nemotron_nano_v2_vl_12b_sft_config(**config_kwargs)

--- a/src/megatron/bridge/recipes/nemotron_vl/nemotron_nano_v2_vl.py
+++ b/src/megatron/bridge/recipes/nemotron_vl/nemotron_nano_v2_vl.py
@@ -21,6 +21,7 @@ import torch
 
 from megatron.bridge import AutoBridge
 from megatron.bridge.peft.base import PEFT
+from megatron.bridge.peft.dora import DoRA
 from megatron.bridge.peft.lora import VLMLoRA
 from megatron.bridge.recipes.common import _peft_common_vlm, _sft_common_vlm
 from megatron.bridge.recipes.utils.optimizer_utils import distributed_fused_adam_with_cosine_annealing
@@ -45,39 +46,55 @@ _VISION_LORA_TARGET_MODULES = [
 ]
 
 
-def _nemotron_vl_lora_config(
+def _nemotron_vl_target_modules(
     *,
-    dora: bool = False,
     lora_on_language_model: bool = True,
     lora_on_vision_model: bool = True,
-) -> VLMLoRA:
-    """Build a Nemotron VL LoRA config that respects component selection flags."""
+) -> list[str]:
+    """Return adapter target modules for the selected Nemotron VL components."""
     if not lora_on_language_model and not lora_on_vision_model:
         raise ValueError("At least one of lora_on_language_model or lora_on_vision_model must be True.")
 
     if lora_on_language_model and lora_on_vision_model:
+        return _ALL_COMPONENT_LORA_TARGET_MODULES.copy()
+
+    if lora_on_language_model:
+        return _LANGUAGE_LORA_TARGET_MODULES.copy()
+
+    return _VISION_LORA_TARGET_MODULES.copy()
+
+
+def _nemotron_vl_lora_config(
+    *,
+    lora_on_language_model: bool = True,
+    lora_on_vision_model: bool = True,
+) -> VLMLoRA:
+    """Build a Nemotron VL LoRA config that respects component selection flags."""
+    target_modules = _nemotron_vl_target_modules(
+        lora_on_language_model=lora_on_language_model,
+        lora_on_vision_model=lora_on_vision_model,
+    )
+
+    if lora_on_language_model and lora_on_vision_model:
         return VLMLoRA(
-            target_modules=_ALL_COMPONENT_LORA_TARGET_MODULES.copy(),
+            target_modules=target_modules,
             dim=16,
             alpha=32,
-            dora=dora,
         )
 
     if lora_on_language_model:
         return VLMLoRA(
-            target_modules=_LANGUAGE_LORA_TARGET_MODULES.copy(),
+            target_modules=target_modules,
             dim=16,
             alpha=32,
-            dora=dora,
             freeze_vision_model=False,
             freeze_vision_projection=False,
         )
 
     return VLMLoRA(
-        target_modules=_VISION_LORA_TARGET_MODULES.copy(),
+        target_modules=target_modules,
         dim=16,
         alpha=32,
-        dora=dora,
         freeze_language_model=False,
     )
 
@@ -237,10 +254,13 @@ def nemotron_nano_v2_vl_12b_peft_config(
             lora_on_vision_model=lora_on_vision_model,
         )
     elif isinstance(peft_scheme, str) and peft_scheme.lower() == "dora":
-        cfg.peft = _nemotron_vl_lora_config(
-            dora=True,
-            lora_on_language_model=lora_on_language_model,
-            lora_on_vision_model=lora_on_vision_model,
+        cfg.peft = DoRA(
+            target_modules=_nemotron_vl_target_modules(
+                lora_on_language_model=lora_on_language_model,
+                lora_on_vision_model=lora_on_vision_model,
+            ),
+            dim=16,
+            alpha=32,
         )
     else:
         cfg.peft = peft_scheme

--- a/src/megatron/bridge/recipes/nemotron_vl/nemotron_nano_v2_vl.py
+++ b/src/megatron/bridge/recipes/nemotron_vl/nemotron_nano_v2_vl.py
@@ -28,6 +28,58 @@ from megatron.bridge.training.config import ConfigContainer
 
 
 _DEFAULT_HF_MODEL_PATH = "nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16"
+_ALL_COMPONENT_LORA_TARGET_MODULES = ["linear_qkv", "linear_proj", "linear_fc1", "linear_fc2"]
+_LANGUAGE_LORA_TARGET_MODULES = [
+    "*language_model*.linear_qkv",
+    "*language_model*.linear_proj",
+    "*language_model*.linear_fc1",
+    "*language_model*.linear_fc2",
+]
+_VISION_LORA_TARGET_MODULES = [
+    "*vision_model*.linear_qkv",
+    "*vision_model*.linear_proj",
+    "*vision_model*.linear_fc1",
+    "*vision_model*.linear_fc2",
+    "*vision_projection*.linear_fc1",
+    "*vision_projection*.linear_fc2",
+]
+
+
+def _nemotron_vl_lora_config(
+    *,
+    dora: bool = False,
+    lora_on_language_model: bool = True,
+    lora_on_vision_model: bool = True,
+) -> VLMLoRA:
+    """Build a Nemotron VL LoRA config that respects component selection flags."""
+    if not lora_on_language_model and not lora_on_vision_model:
+        raise ValueError("At least one of lora_on_language_model or lora_on_vision_model must be True.")
+
+    if lora_on_language_model and lora_on_vision_model:
+        return VLMLoRA(
+            target_modules=_ALL_COMPONENT_LORA_TARGET_MODULES.copy(),
+            dim=16,
+            alpha=32,
+            dora=dora,
+        )
+
+    if lora_on_language_model:
+        return VLMLoRA(
+            target_modules=_LANGUAGE_LORA_TARGET_MODULES.copy(),
+            dim=16,
+            alpha=32,
+            dora=dora,
+            freeze_vision_model=False,
+            freeze_vision_projection=False,
+        )
+
+    return VLMLoRA(
+        target_modules=_VISION_LORA_TARGET_MODULES.copy(),
+        dim=16,
+        alpha=32,
+        dora=dora,
+        freeze_language_model=False,
+    )
 
 
 # =============================================================================
@@ -158,6 +210,8 @@ def nemotron_nano_v2_vl_12b_peft_config(
     *,
     hf_model_path: str = _DEFAULT_HF_MODEL_PATH,
     pretrained_checkpoint: str | None = None,
+    lora_on_language_model: bool = True,
+    lora_on_vision_model: bool = True,
 ) -> ConfigContainer:
     """Return a PEFT config for Nemotron Nano V2 VL 12B.
 
@@ -171,22 +225,22 @@ def nemotron_nano_v2_vl_12b_peft_config(
             Note: Default uses VLMLoRA targeting all model components.
         hf_model_path: Hugging Face model path used for provider and processor setup.
         pretrained_checkpoint: Optional checkpoint path to load before finetuning.
+        lora_on_language_model: Whether LoRA targets the language model when PEFT is "lora" or "dora".
+        lora_on_vision_model: Whether LoRA targets the vision model when PEFT is "lora" or "dora".
     """
     cfg = _peft_common_vlm()
 
     # PEFT scheme - Nemotron uses VLMLoRA by default
     if isinstance(peft_scheme, str) and peft_scheme.lower() == "lora":
-        cfg.peft = VLMLoRA(
-            target_modules=["linear_qkv", "linear_proj", "linear_fc1", "linear_fc2"],
-            dim=16,
-            alpha=32,
+        cfg.peft = _nemotron_vl_lora_config(
+            lora_on_language_model=lora_on_language_model,
+            lora_on_vision_model=lora_on_vision_model,
         )
     elif isinstance(peft_scheme, str) and peft_scheme.lower() == "dora":
-        cfg.peft = VLMLoRA(
-            target_modules=["linear_qkv", "linear_proj", "linear_fc1", "linear_fc2"],
-            dim=16,
-            alpha=32,
+        cfg.peft = _nemotron_vl_lora_config(
             dora=True,
+            lora_on_language_model=lora_on_language_model,
+            lora_on_vision_model=lora_on_vision_model,
         )
     else:
         cfg.peft = peft_scheme

--- a/src/megatron/bridge/recipes/nemotron_vl/nemotron_nano_v2_vl.py
+++ b/src/megatron/bridge/recipes/nemotron_vl/nemotron_nano_v2_vl.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Nemotron Nano V2 VL finetuning recipes with parameterless API.
+"""Nemotron Nano V2 VL finetuning recipes with parameterless defaults.
 
 This module provides SFT and PEFT configurations for Nemotron Nano V2 VL 12B.
 """
@@ -27,21 +27,31 @@ from megatron.bridge.recipes.utils.optimizer_utils import distributed_fused_adam
 from megatron.bridge.training.config import ConfigContainer
 
 
+_DEFAULT_HF_MODEL_PATH = "nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16"
+
+
 # =============================================================================
 # Nemotron Nano V2 VL 12B SFT Configuration
 # =============================================================================
-def nemotron_nano_v2_vl_12b_sft_config() -> ConfigContainer:
+def nemotron_nano_v2_vl_12b_sft_config(
+    hf_model_path: str = _DEFAULT_HF_MODEL_PATH,
+    pretrained_checkpoint: str | None = None,
+) -> ConfigContainer:
     """Return a full SFT config for Nemotron Nano V2 VL 12B.
 
     Default configuration: 1 node, 8 GPUs
     - TP=4, PP=1
     - LR=1e-5 (finetune default)
     - Sequence length: 4096
+
+    Args:
+        hf_model_path: Hugging Face model path used for provider and processor setup.
+        pretrained_checkpoint: Optional checkpoint path to load before finetuning.
     """
     cfg = _sft_common_vlm()
 
     # Model configuration
-    hf_path = "nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16"
+    hf_path = hf_model_path
     cfg.model = AutoBridge.from_hf_pretrained(hf_path, trust_remote_code=True).to_megatron_provider(load_weights=False)
     cfg.model.seq_length = 4096
 
@@ -121,6 +131,8 @@ def nemotron_nano_v2_vl_12b_sft_config() -> ConfigContainer:
 
     # Checkpoint config - override save_interval from common
     cfg.checkpoint.save_interval = 200
+    if pretrained_checkpoint is not None:
+        cfg.checkpoint.pretrained_checkpoint = pretrained_checkpoint
 
     # FP8 and MXFP8 settings (disabled by default)
     cfg.mixed_precision = "bf16_mixed"
@@ -141,7 +153,12 @@ def nemotron_nano_v2_vl_12b_sft_config() -> ConfigContainer:
 # =============================================================================
 # Nemotron Nano V2 VL 12B PEFT Configuration
 # =============================================================================
-def nemotron_nano_v2_vl_12b_peft_config(peft_scheme: str | PEFT = "lora") -> ConfigContainer:
+def nemotron_nano_v2_vl_12b_peft_config(
+    peft_scheme: str | PEFT = "lora",
+    *,
+    hf_model_path: str = _DEFAULT_HF_MODEL_PATH,
+    pretrained_checkpoint: str | None = None,
+) -> ConfigContainer:
     """Return a PEFT config for Nemotron Nano V2 VL 12B.
 
     Default configuration: 1 node, 8 GPUs
@@ -152,6 +169,8 @@ def nemotron_nano_v2_vl_12b_peft_config(peft_scheme: str | PEFT = "lora") -> Con
     Args:
         peft_scheme: PEFT scheme - "lora", "dora", or a custom PEFT instance.
             Note: Default uses VLMLoRA targeting all model components.
+        hf_model_path: Hugging Face model path used for provider and processor setup.
+        pretrained_checkpoint: Optional checkpoint path to load before finetuning.
     """
     cfg = _peft_common_vlm()
 
@@ -173,7 +192,7 @@ def nemotron_nano_v2_vl_12b_peft_config(peft_scheme: str | PEFT = "lora") -> Con
         cfg.peft = peft_scheme
 
     # Model configuration
-    hf_path = "nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16"
+    hf_path = hf_model_path
     cfg.model = AutoBridge.from_hf_pretrained(hf_path, trust_remote_code=True).to_megatron_provider(load_weights=False)
     cfg.model.seq_length = 4096
 
@@ -253,6 +272,8 @@ def nemotron_nano_v2_vl_12b_peft_config(peft_scheme: str | PEFT = "lora") -> Con
 
     # Checkpoint config - override save_interval from common
     cfg.checkpoint.save_interval = 200
+    if pretrained_checkpoint is not None:
+        cfg.checkpoint.pretrained_checkpoint = pretrained_checkpoint
 
     # FP8 and MXFP8 settings (disabled by default)
     cfg.mixed_precision = "bf16_mixed"

--- a/tests/unit_tests/examples/test_nemotron_vl_finetune.py
+++ b/tests/unit_tests/examples/test_nemotron_vl_finetune.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Import smoke test for the Nemotron Nano V2 VL finetune example."""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+_SCRIPT_PATH = _REPO_ROOT / "examples" / "models" / "nemotron" / "nemotron_vl" / "finetune_nemotron_nano_v2_vl.py"
+
+
+def test_nemotron_nano_v2_vl_finetune_example_imports():
+    """Test that the finetune example does not import removed recipe symbols."""
+    spec = importlib.util.spec_from_file_location("nemotron_vl_finetune_under_test", _SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.modules.pop(spec.name, None)

--- a/tests/unit_tests/recipes/test_nemotron_vl_recipes.py
+++ b/tests/unit_tests/recipes/test_nemotron_vl_recipes.py
@@ -62,10 +62,15 @@ class _FakeModelCfg:
 class _FakeAutoBridge:
     """Fake AutoBridge for testing."""
 
-    @staticmethod
-    def from_hf_pretrained(hf_path: str, **kwargs):
+    last_hf_path = None
+    last_kwargs = None
+
+    @classmethod
+    def from_hf_pretrained(cls, hf_path: str, **kwargs):
         """Mock from_hf_pretrained method."""
-        return _FakeAutoBridge()
+        cls.last_hf_path = hf_path
+        cls.last_kwargs = kwargs
+        return cls()
 
     def to_megatron_provider(self, load_weights: bool = False):
         """Return a fake model config."""
@@ -175,6 +180,38 @@ def test_nemotron_vl_12b_peft_defaults(monkeypatch: pytest.MonkeyPatch):
     assert cfg.model.pipeline_model_parallel_size == 1
 
     # Check PEFT config (uses VLMLoRA)
+    assert cfg.peft is not None
+
+
+def test_nemotron_vl_12b_sft_accepts_finetune_inputs(monkeypatch: pytest.MonkeyPatch):
+    """Test that 12B SFT accepts the finetune example's model and checkpoint inputs."""
+    monkeypatch.setattr(_nemotron_vl_module, "AutoBridge", _FakeAutoBridge)
+
+    cfg = _nemotron_vl_module.nemotron_nano_v2_vl_12b_sft_config(
+        hf_model_path="test/nemotron-nano-v2-vl",
+        pretrained_checkpoint="/checkpoints/nemotron-nano-v2-vl",
+    )
+
+    assert _FakeAutoBridge.last_hf_path == "test/nemotron-nano-v2-vl"
+    assert _FakeAutoBridge.last_kwargs == {"trust_remote_code": True}
+    assert cfg.dataset.hf_processor_path == "test/nemotron-nano-v2-vl"
+    assert cfg.checkpoint.pretrained_checkpoint == "/checkpoints/nemotron-nano-v2-vl"
+    assert cfg.peft is None
+
+
+def test_nemotron_vl_12b_peft_accepts_finetune_inputs(monkeypatch: pytest.MonkeyPatch):
+    """Test that 12B PEFT accepts the finetune example's model and checkpoint inputs."""
+    monkeypatch.setattr(_nemotron_vl_module, "AutoBridge", _FakeAutoBridge)
+
+    cfg = _nemotron_vl_module.nemotron_nano_v2_vl_12b_peft_config(
+        hf_model_path="test/nemotron-nano-v2-vl",
+        pretrained_checkpoint="/checkpoints/nemotron-nano-v2-vl",
+    )
+
+    assert _FakeAutoBridge.last_hf_path == "test/nemotron-nano-v2-vl"
+    assert _FakeAutoBridge.last_kwargs == {"trust_remote_code": True}
+    assert cfg.dataset.hf_processor_path == "test/nemotron-nano-v2-vl"
+    assert cfg.checkpoint.pretrained_checkpoint == "/checkpoints/nemotron-nano-v2-vl"
     assert cfg.peft is not None
 
 

--- a/tests/unit_tests/recipes/test_nemotron_vl_recipes.py
+++ b/tests/unit_tests/recipes/test_nemotron_vl_recipes.py
@@ -383,6 +383,20 @@ def test_nemotron_vl_peft_uses_vlm_lora(monkeypatch: pytest.MonkeyPatch):
     assert isinstance(cfg.peft, VLMLoRA)
 
 
+def test_nemotron_vl_peft_dora_uses_dora_adapter(monkeypatch: pytest.MonkeyPatch):
+    """Test that Nemotron Nano V2 VL uses DoRA when requested."""
+    monkeypatch.setattr(_nemotron_vl_module, "AutoBridge", _FakeAutoBridge)
+
+    cfg = _nemotron_vl_module.nemotron_nano_v2_vl_12b_peft_config(peft_scheme="dora")
+
+    from megatron.bridge.peft.dora import DoRA
+
+    assert isinstance(cfg.peft, DoRA)
+    assert cfg.peft.target_modules == ["linear_qkv", "linear_proj", "linear_fc1", "linear_fc2"]
+    assert cfg.peft.dim == 16
+    assert cfg.peft.alpha == 32
+
+
 def test_nemotron_vl_sft_training_params(monkeypatch: pytest.MonkeyPatch):
     """Test that training parameters are correctly set for SFT."""
     # Monkeypatch AutoBridge

--- a/tests/unit_tests/recipes/test_nemotron_vl_recipes.py
+++ b/tests/unit_tests/recipes/test_nemotron_vl_recipes.py
@@ -77,6 +77,13 @@ class _FakeAutoBridge:
         return _FakeModelCfg()
 
 
+@pytest.fixture(autouse=True)
+def _reset_fake_auto_bridge_state():
+    """Reset fake bridge call state between tests."""
+    _FakeAutoBridge.last_hf_path = None
+    _FakeAutoBridge.last_kwargs = None
+
+
 def _assert_basic_config(cfg):
     """Assert that a config has all required components."""
     from megatron.bridge.training.config import ConfigContainer
@@ -213,6 +220,70 @@ def test_nemotron_vl_12b_peft_accepts_finetune_inputs(monkeypatch: pytest.Monkey
     assert cfg.dataset.hf_processor_path == "test/nemotron-nano-v2-vl"
     assert cfg.checkpoint.pretrained_checkpoint == "/checkpoints/nemotron-nano-v2-vl"
     assert cfg.peft is not None
+
+
+def test_nemotron_vl_12b_configs_keep_default_pretrained_checkpoint(monkeypatch: pytest.MonkeyPatch):
+    """Test that default configs do not set a pretrained checkpoint."""
+    monkeypatch.setattr(_nemotron_vl_module, "AutoBridge", _FakeAutoBridge)
+
+    sft_cfg = _nemotron_vl_module.nemotron_nano_v2_vl_12b_sft_config()
+    peft_cfg = _nemotron_vl_module.nemotron_nano_v2_vl_12b_peft_config()
+
+    assert sft_cfg.checkpoint.pretrained_checkpoint is None
+    assert peft_cfg.checkpoint.pretrained_checkpoint is None
+
+
+def test_nemotron_vl_12b_peft_language_only_lora(monkeypatch: pytest.MonkeyPatch):
+    """Test that language-only LoRA keeps the existing language adapter scope."""
+    monkeypatch.setattr(_nemotron_vl_module, "AutoBridge", _FakeAutoBridge)
+
+    cfg = _nemotron_vl_module.nemotron_nano_v2_vl_12b_peft_config(
+        lora_on_language_model=True,
+        lora_on_vision_model=False,
+    )
+
+    assert cfg.peft.target_modules == [
+        "*language_model*.linear_qkv",
+        "*language_model*.linear_proj",
+        "*language_model*.linear_fc1",
+        "*language_model*.linear_fc2",
+    ]
+    assert cfg.peft.freeze_language_model is True
+    assert cfg.peft.freeze_vision_model is False
+    assert cfg.peft.freeze_vision_projection is False
+
+
+def test_nemotron_vl_12b_peft_vision_only_lora(monkeypatch: pytest.MonkeyPatch):
+    """Test that vision-only LoRA targets vision modules without targeting language modules."""
+    monkeypatch.setattr(_nemotron_vl_module, "AutoBridge", _FakeAutoBridge)
+
+    cfg = _nemotron_vl_module.nemotron_nano_v2_vl_12b_peft_config(
+        lora_on_language_model=False,
+        lora_on_vision_model=True,
+    )
+
+    assert cfg.peft.target_modules == [
+        "*vision_model*.linear_qkv",
+        "*vision_model*.linear_proj",
+        "*vision_model*.linear_fc1",
+        "*vision_model*.linear_fc2",
+        "*vision_projection*.linear_fc1",
+        "*vision_projection*.linear_fc2",
+    ]
+    assert cfg.peft.freeze_language_model is False
+    assert cfg.peft.freeze_vision_model is True
+    assert cfg.peft.freeze_vision_projection is True
+
+
+def test_nemotron_vl_12b_peft_requires_lora_target_component(monkeypatch: pytest.MonkeyPatch):
+    """Test that LoRA PEFT must target at least one model component."""
+    monkeypatch.setattr(_nemotron_vl_module, "AutoBridge", _FakeAutoBridge)
+
+    with pytest.raises(ValueError, match="At least one"):
+        _nemotron_vl_module.nemotron_nano_v2_vl_12b_peft_config(
+            lora_on_language_model=False,
+            lora_on_vision_model=False,
+        )
 
 
 def test_nemotron_vl_sft_has_hf_dataset_provider(monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
## Summary
- Fix NVBug 6317337 by replacing the removed `nemotron_nano_v2_vl_12b_finetune_config` import in the Nemotron Nano V2 VL finetune example.
- Route LoRA/PEFT runs to `nemotron_nano_v2_vl_12b_peft_config` and full SFT runs to `nemotron_nano_v2_vl_12b_sft_config`.
- Allow both recipe factories to accept the finetune example's `hf_model_path` and `pretrained_checkpoint` inputs.
- Add focused unit coverage for those inputs plus an import smoke test for the example.

## Tests
- `git diff --check`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile examples/models/nemotron/nemotron_vl/finetune_nemotron_nano_v2_vl.py src/megatron/bridge/recipes/nemotron_vl/nemotron_nano_v2_vl.py tests/unit_tests/recipes/test_nemotron_vl_recipes.py tests/unit_tests/examples/test_nemotron_vl_finetune.py`
- `pre-commit run --files examples/models/nemotron/nemotron_vl/finetune_nemotron_nano_v2_vl.py src/megatron/bridge/recipes/nemotron_vl/nemotron_nano_v2_vl.py tests/unit_tests/recipes/test_nemotron_vl_recipes.py tests/unit_tests/examples/test_nemotron_vl_finetune.py`
- Not run locally: `uv run python -m pytest ...` and `uv run pre-commit run --all-files` both failed before test/hook execution because `nvidia-resiliency-ext==0.6.0` has no wheel for this local `manylinux_2_31_x86_64` platform.

## Blast Radius / CI
- Scope: Nemotron VL recipe config and one Nemotron VL example script. No shared runtime, distributed training logic, checkpoint conversion, or dependency changes.
- L0: recommended, targeted unit tests for `tests/unit_tests/recipes/test_nemotron_vl_recipes.py` and `tests/unit_tests/examples/test_nemotron_vl_finetune.py`.
- L1: not required for this import/recipe wiring fix unless reviewers want a recipe-level smoke.
- L2: not required.

Fixes NVBug 6317337.