### PR TITLE
fix(model): fix Falcon H1 static inference

### DIFF
--- a/src/megatron/bridge/models/falcon_h1/modeling_falconh1/falconh1_layer.py
+++ b/src/megatron/bridge/models/falcon_h1/modeling_falconh1/falconh1_layer.py
@@ -23,6 +23,28 @@ from megatron.bridge.models.falcon_h1.modeling_falconh1.falconh1_model import Fa
 logger = logging.getLogger(__name__)
 
 
+def _run_mamba_mixer_with_static_cache_namespace(
+    mamba_mixer: MambaMixer,
+    hidden_states: torch.Tensor,
+    inference_context: Optional[BaseInferenceContext],
+    *,
+    use_attention: bool,
+) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+    """Run Mamba without colliding with attention KV cache keys in static inference."""
+    should_namespace_cache = (
+        inference_context is not None and inference_context.is_static_batching() and use_attention
+    )
+    if not should_namespace_cache:
+        return mamba_mixer(hidden_states, inference_context=inference_context)
+
+    original_layer_number = mamba_mixer.layer_number
+    mamba_mixer.layer_number = ("mamba", original_layer_number)
+    try:
+        return mamba_mixer(hidden_states, inference_context=inference_context)
+    finally:
+        mamba_mixer.layer_number = original_layer_number
+
+
 class FalconH1MambaMixer(MambaMixer):
     """Mamba mixer with Falcon H1 projection multipliers."""
 
@@ -368,9 +390,11 @@ class FalconH1Layer(MegatronModule):
 
         # SSM Forward: MambaMixer
         if self.use_mamba and self.mamba_mixer is not None:
-            mamba_output, mamba_bias = self.mamba_mixer(
+            mamba_output, mamba_bias = _run_mamba_mixer_with_static_cache_namespace(
+                self.mamba_mixer,
                 hidden_states * self.config.ssm_in_multiplier,
-                inference_context=inference_context,
+                inference_context,
+                use_attention=self.use_attention and self.self_attention is not None,
             )
             mamba_output = mamba_output * self.config.ssm_out_multiplier
             outputs.append(mamba_output)

--- a/src/megatron/bridge/models/falcon_h1/modeling_falconh1/falconh1_layer.py
+++ b/src/megatron/bridge/models/falcon_h1/modeling_falconh1/falconh1_layer.py
@@ -31,9 +31,7 @@ def _run_mamba_mixer_with_static_cache_namespace(
     use_attention: bool,
 ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
     """Run Mamba without colliding with attention KV cache keys in static inference."""
-    should_namespace_cache = (
-        inference_context is not None and inference_context.is_static_batching() and use_attention
-    )
+    should_namespace_cache = inference_context is not None and inference_context.is_static_batching() and use_attention
     if not should_namespace_cache:
         return mamba_mixer(hidden_states, inference_context=inference_context)
 

--- a/src/megatron/bridge/models/falcon_h1/modeling_falconh1/falconh1_model.py
+++ b/src/megatron/bridge/models/falcon_h1/modeling_falconh1/falconh1_model.py
@@ -356,8 +356,12 @@ class FalconH1Model(LanguageModule):
         if self.share_embeddings_and_output_weights:
             output_weight = self.shared_embedding_or_output_weight()
 
-        if in_inference_mode and inference_context.materialize_only_last_token_logits:
-            hidden_states = hidden_states[-1, :, :].unsqueeze(0)
+        if (
+            in_inference_mode
+            and inference_context is not None
+            and inference_context.config.materialize_only_last_token_logits
+        ):
+            hidden_states = hidden_states[-1:, :, :]
 
         logits, _ = self.output_layer(hidden_states, weight=output_weight, runtime_gather_output=runtime_gather_output)
         logits = logits * self.config.lm_head_multiplier

--- a/tests/unit_tests/models/falcon_h1/test_falcon_h1_layers.py
+++ b/tests/unit_tests/models/falcon_h1/test_falcon_h1_layers.py
@@ -140,9 +140,7 @@ def test_static_mamba_cache_key_is_namespaced_when_layer_uses_attention():
         (False, True, 7),
     ],
 )
-def test_mamba_cache_key_is_not_namespaced_outside_static_attention_layers(
-    is_static, use_attention, expected_key
-):
+def test_mamba_cache_key_is_not_namespaced_outside_static_attention_layers(is_static, use_attention, expected_key):
     context = _FakeInferenceContext(is_static=is_static)
     mixer = _FakeMambaMixer(layer_number=7)
 

--- a/tests/unit_tests/models/falcon_h1/test_falcon_h1_layers.py
+++ b/tests/unit_tests/models/falcon_h1/test_falcon_h1_layers.py
@@ -23,6 +23,7 @@ from megatron.bridge.models.falcon_h1.modeling_falconh1.falconh1_layer import (
     FalconH1MLP,
     FalconH1SelfAttention,
     SelfAttention,
+    _run_mamba_mixer_with_static_cache_namespace,
 )
 from megatron.bridge.models.falcon_h1.modeling_falconh1.falconh1_model import FalconH1Config
 
@@ -40,6 +41,26 @@ def _minimal_config(**overrides):
     }
     kwargs.update(overrides)
     return FalconH1Config(**kwargs)
+
+
+class _FakeInferenceContext:
+    def __init__(self, *, is_static: bool):
+        self._is_static = is_static
+        self.key_value_memory_dict = {}
+
+    def is_static_batching(self):
+        return self._is_static
+
+
+class _FakeMambaMixer:
+    def __init__(self, *, layer_number: int):
+        self.layer_number = layer_number
+        self.called_layer_numbers = []
+
+    def __call__(self, hidden_states, *, inference_context):
+        self.called_layer_numbers.append(self.layer_number)
+        inference_context.key_value_memory_dict[self.layer_number] = ("mamba-conv", "mamba-ssm")
+        return hidden_states + 1, None
 
 
 def test_config_rejects_invalid_a_init_distribution():
@@ -89,6 +110,53 @@ def test_self_attention_applies_key_multiplier():
     torch.testing.assert_close(scaled_query, query)
     torch.testing.assert_close(scaled_key, torch.tensor([6.0]))
     torch.testing.assert_close(scaled_value, value)
+
+
+def test_static_mamba_cache_key_is_namespaced_when_layer_uses_attention():
+    context = _FakeInferenceContext(is_static=True)
+    context.key_value_memory_dict[7] = ("attention-key", "attention-value")
+    mixer = _FakeMambaMixer(layer_number=7)
+    hidden_states = torch.zeros(1, 1, 1)
+
+    output, output_bias = _run_mamba_mixer_with_static_cache_namespace(
+        mixer,
+        hidden_states,
+        context,
+        use_attention=True,
+    )
+
+    torch.testing.assert_close(output, torch.ones(1, 1, 1))
+    assert output_bias is None
+    assert mixer.layer_number == 7
+    assert mixer.called_layer_numbers == [("mamba", 7)]
+    assert context.key_value_memory_dict[7] == ("attention-key", "attention-value")
+    assert context.key_value_memory_dict[("mamba", 7)] == ("mamba-conv", "mamba-ssm")
+
+
+@pytest.mark.parametrize(
+    ("is_static", "use_attention", "expected_key"),
+    [
+        (True, False, 7),
+        (False, True, 7),
+    ],
+)
+def test_mamba_cache_key_is_not_namespaced_outside_static_attention_layers(
+    is_static, use_attention, expected_key
+):
+    context = _FakeInferenceContext(is_static=is_static)
+    mixer = _FakeMambaMixer(layer_number=7)
+
+    _run_mamba_mixer_with_static_cache_namespace(
+        mixer,
+        torch.zeros(1, 1, 1),
+        context,
+        use_attention=use_attention,
+    )
+
+    assert mixer.layer_number == 7
+    assert mixer.called_layer_numbers == [expected_key]
+    assert expected_key in context.key_value_memory_dict
+    assert ("mamba", 7) not in context.key_value_memory_dict
 
 
 def test_mamba_mixer_applies_ssm_multipliers():


### PR DESCRIPTION
## Summary
- Fix Falcon H1 legacy/static inference for NVBug 6327239.
- Keep Mamba static inference state from colliding with attention KV cache entries in Falcon H1 layers that use both modules.
- Read `materialize_only_last_token_logits` from `inference_context.config`, matching MCore GPT/hybrid model behavior for `StaticInferenceContext`.
- Add focused unit coverage for the static cache namespace behavior.

## Root Cause
Falcon H1 combines Mamba and attention in the same layer. In the legacy static engine, MCore stores inference state in `StaticInferenceContext.key_value_memory_dict` keyed by `layer_number`. Falcon H1 passed the same layer number to Mamba and attention, so Mamba populated the cache with `(conv_state, ssm_state)` and attention later interpreted that tuple as `(key_memory, value_memory)`. That made attention see the wrong tensor shape and trigger the misleading max sequence length assertion.

After fixing that collision, the same repro exposed one more Falcon H1 static-context mismatch: the model read `materialize_only_last_token_logits` directly from the context, while the current static context stores it on `inference_context.config`.

NVBug: https://nvbugspro.nvidia.com/bug/6327239

## Validation
- `git diff --check`
- `python3 -m py_compile src/megatron/bridge/models/falcon_h1/modeling_falconh1/falconh1_layer.py src/megatron/bridge/models/falcon_h1/modeling_falconh1/falconh1_model.py tests/unit_tests/models/falcon_h1/test_falcon_h1_layers.py`
- DFW rc8 container repro: `bash examples/models/falcon_h1/inference.sh` passed and generated a full answer for `tiiuae/Falcon-H1-0.5B-Instruct`.
  - Job: `12839064`
  - Image: `/lustre/fs1/portfolios/coreai/projects/coreai_dlalgo_llm/users/chcui/nvidian+nemo+26.06.rc8.sqsh`
  - Log: `/lustre/fs1/portfolios/coreai/projects/coreai_dlalgo_llm/users/chcui/nvbug6327239-falconh1/logs/fix_rc8_fresh_20260615_133700.log`
- DFW rc8 container checks:
  - `uv run python -m pytest tests/unit_tests/models/falcon_h1/test_falcon_h1_layers.py -q` -> 8 passed
  - `uv run pre-commit run --files src/megatron/bridge/models/falcon_h1/modeling_falconh1/falconh1_layer.py src/megatron/bridge/models/falcon_h1/modeling_falconh1/falconh1_model.py tests/unit_tests/models/falcon_h1/test_falcon_h1_layers.py` -> passed
  - Job: `12839157`
  - Log: `/lustre/fs1/portfolios/coreai/projects/coreai_dlalgo_llm/users/chcui/nvbug6327239-falconh1/logs/checks_rc8_20260615_134400.log`

## Blast Radius / Test Level
- Blast radius: Falcon H1 model inference path only; no shared MCore, dependency, recipe, CI, or checkpoint format changes.
- L0: Required and covered by the focused unit test plus direct example repro.
- L1: Recommended through normal PR CI/model smoke because this is a user-facing inference path with HF model loading.
- L2: Not required; this does not touch distributed training, conversion, data pipelines, or shared runtime behavior outside Falcon H1.
