### PR TITLE
[model] fix: pass Step35 layer names through MTP

### DIFF
--- a/src/megatron/bridge/models/stepfun/step35_provider.py
+++ b/src/megatron/bridge/models/stepfun/step35_provider.py
@@ -89,6 +89,7 @@ class Step35DecoderLayer(TransformerLayer):
         is_mtp_layer: bool = False,
         add_layer_offset: bool = True,
         pp_layer_offset: Optional[int] = None,
+        name: str | None = None,
     ):
         pp_rank = get_pg_rank(pg_collection.pp)
         if is_mtp_layer:
@@ -139,6 +140,7 @@ class Step35DecoderLayer(TransformerLayer):
             is_mtp_layer=is_mtp_layer,
             add_layer_offset=add_layer_offset,
             pp_layer_offset=pp_layer_offset,
+            name=name,
         )
 
 

--- a/tests/unit_tests/models/stepfun/test_step35_provider.py
+++ b/tests/unit_tests/models/stepfun/test_step35_provider.py
@@ -145,9 +145,11 @@ class _SuperInitRecorder:
 
     def __init__(self):
         self.captured_config = None
+        self.captured_kwargs = None
 
-    def __call__(self, instance, config, **_):
+    def __call__(self, instance, config, **kwargs):
         self.captured_config = config
+        self.captured_kwargs = kwargs
 
 
 class TestStep35DecoderLayerIsSliding:
@@ -166,6 +168,31 @@ class TestStep35DecoderLayerIsSliding:
         sliding_setting=_UNSET,
         offset_return=0,
         pp_rank=0,
+    ):
+        config, recorder = self._build_with_recorder(
+            layer_number=layer_number,
+            is_mtp_layer=is_mtp_layer,
+            add_layer_offset=add_layer_offset,
+            layer_types=layer_types,
+            attention_other_setting=attention_other_setting,
+            sliding_setting=sliding_setting,
+            offset_return=offset_return,
+            pp_rank=pp_rank,
+        )
+        return config, recorder.captured_config
+
+    def _build_with_recorder(
+        self,
+        *,
+        layer_number,
+        is_mtp_layer=False,
+        add_layer_offset=True,
+        layer_types=None,
+        attention_other_setting=True,
+        sliding_setting=_UNSET,
+        offset_return=0,
+        pp_rank=0,
+        name=_UNSET,
     ):
         layer_types = (
             layer_types
@@ -190,17 +217,20 @@ class TestStep35DecoderLayerIsSliding:
                 return_value=offset_return,
             ),
         ):
-            Step35DecoderLayer(
-                config=config,
-                submodules=None,
-                layer_number=layer_number,
-                pg_collection=SimpleNamespace(pp="dummy"),
-                vp_stage=None,
-                is_mtp_layer=is_mtp_layer,
-                add_layer_offset=add_layer_offset,
-            )
+            layer_kwargs = {
+                "config": config,
+                "submodules": None,
+                "layer_number": layer_number,
+                "pg_collection": SimpleNamespace(pp="dummy"),
+                "vp_stage": None,
+                "is_mtp_layer": is_mtp_layer,
+                "add_layer_offset": add_layer_offset,
+            }
+            if name is not _UNSET:
+                layer_kwargs["name"] = name
+            Step35DecoderLayer(**layer_kwargs)
 
-        return config, recorder.captured_config
+        return config, recorder
 
     def test_full_attention_keeps_original_config(self):
         original, captured = self._build(layer_number=1)  # layer_idx=0 -> full_attention
@@ -231,6 +261,18 @@ class TestStep35DecoderLayerIsSliding:
             pp_rank=2,
         )
         assert captured is original  # full attention
+
+    def test_mtp_layer_forwards_name_to_transformer_layer(self):
+        """MCore's MTP builder passes ``name`` into the nested transformer layer."""
+        name = "decoder.layers.0.mtp_model_layer"
+        original, recorder = self._build_with_recorder(
+            layer_number=1,
+            is_mtp_layer=True,
+            name=name,
+        )
+
+        assert recorder.captured_config is original
+        assert recorder.captured_kwargs["name"] == name
 
     def test_pp_offset_applied_for_main_decoder(self):
         """With ``add_layer_offset=True`` the resolved index is


### PR DESCRIPTION
## Summary
- Accept and forward the MCore `name` constructor kwarg in `Step35DecoderLayer`
- Add focused unit coverage for the MTP-layer path forwarding `name` to `TransformerLayer`
- Audited custom Bridge TransformerLayer/decoder-layer subclasses for the same constructor-contract issue; no additional clear MTP decoder-layer cases found

## Testing
- `python3` AST check confirmed `Step35DecoderLayer.__init__` now includes `name`
- `uv tool run ruff check src/megatron/bridge/models/stepfun/step35_provider.py tests/unit_tests/models/stepfun/test_step35_provider.py`
- `uv tool run ruff format --check src/megatron/bridge/models/stepfun/step35_provider.py tests/unit_tests/models/stepfun/test_step35_provider.py`
- `python3 -m py_compile src/megatron/bridge/models/stepfun/step35_provider.py tests/unit_tests/models/stepfun/test_step35_provider.py`
- `git diff --check`
- `uv run --active --no-sync pre-commit run --files src/megatron/bridge/models/stepfun/step35_provider.py tests/unit_tests/models/stepfun/test_step35_provider.py`

Focused pytest and full pre-commit were attempted with `uv run`, but local environment resolution is blocked because `nvidia-resiliency-ext==0.6.0` has no compatible wheel for this workstation platform (`manylinux_2_31_x86_64`; available wheels target `manylinux_2_39`).