### PR TITLE
fix: honor attention backend for checkpoint inference

### DIFF
--- a/scripts/inference/text_generation.py
+++ b/scripts/inference/text_generation.py
@@ -358,6 +358,29 @@ def _apply_provider_parallelism(provider: object, args: argparse.Namespace, dtyp
         setattr(provider, "inference_moe_token_dispatcher_type", args.inference_moe_token_dispatcher_type)
 
 
+def _build_megatron_checkpoint_overrides(
+    provider: object, args: argparse.Namespace, dtype: torch.dtype
+) -> dict[str, object]:
+    mp_overrides = {
+        "tensor_model_parallel_size": args.tp,
+        "pipeline_model_parallel_size": args.pp,
+        "expert_model_parallel_size": args.ep,
+        "expert_tensor_parallel_size": args.etp,
+        "sequence_parallel": args.sequence_parallel,
+        "params_dtype": dtype,
+        "pipeline_dtype": dtype,
+        "bf16": dtype == torch.bfloat16,
+        "fp16": dtype == torch.float16,
+    }
+    if args.attention_backend is not None:
+        mp_overrides["attention_backend"] = AttnBackend[args.attention_backend]
+    if hasattr(provider, "cache_mla_latents"):
+        mp_overrides["cache_mla_latents"] = bool(getattr(provider, "cache_mla_latents"))
+    if args.inference_moe_token_dispatcher_type is not None:
+        mp_overrides["inference_moe_token_dispatcher_type"] = args.inference_moe_token_dispatcher_type
+    return mp_overrides
+
+
 def _prepare_model_list(model_list: list[torch.nn.Module]) -> torch.nn.Module:
     if len(model_list) != 1:
         raise ValueError("MegatronLLM supports one local model stage; virtual pipeline parallelism is not supported.")
@@ -379,21 +402,7 @@ def _load_model(args: argparse.Namespace, hf_model_path: str, dtype: torch.dtype
         _apply_provider_parallelism(provider, args, dtype)
         provider.finalize()
         provider.initialize_model_parallel(seed=args.seed)
-        mp_overrides = {
-            "tensor_model_parallel_size": args.tp,
-            "pipeline_model_parallel_size": args.pp,
-            "expert_model_parallel_size": args.ep,
-            "expert_tensor_parallel_size": args.etp,
-            "sequence_parallel": args.sequence_parallel,
-            "params_dtype": dtype,
-            "pipeline_dtype": dtype,
-            "bf16": dtype == torch.bfloat16,
-            "fp16": dtype == torch.float16,
-        }
-        if hasattr(provider, "cache_mla_latents"):
-            mp_overrides["cache_mla_latents"] = bool(getattr(provider, "cache_mla_latents"))
-        if args.inference_moe_token_dispatcher_type is not None:
-            mp_overrides["inference_moe_token_dispatcher_type"] = args.inference_moe_token_dispatcher_type
+        mp_overrides = _build_megatron_checkpoint_overrides(provider, args, dtype)
         model_list = bridge.load_megatron_model(
             args.megatron_model_path,
             mp_overrides=mp_overrides,

--- a/tests/unit_tests/scripts/test_text_generation.py
+++ b/tests/unit_tests/scripts/test_text_generation.py
@@ -203,3 +203,35 @@ def test_maybe_initialize_distributed_is_noop_when_dist_unavailable(monkeypatch,
     )
 
     text_generation._maybe_initialize_distributed(timeout_minutes=1)
+
+
+def test_megatron_checkpoint_overrides_preserve_attention_backend(text_generation):
+    provider = types.SimpleNamespace(cache_mla_latents=True)
+    args = types.SimpleNamespace(
+        tp=2,
+        pp=2,
+        ep=4,
+        etp=1,
+        sequence_parallel=True,
+        attention_backend="local",
+        inference_moe_token_dispatcher_type="nvls",
+    )
+
+    overrides = text_generation._build_megatron_checkpoint_overrides(
+        provider,
+        args,
+        text_generation.torch.bfloat16,
+    )
+
+    assert overrides["attention_backend"] is text_generation.AttnBackend.local
+    assert overrides["tensor_model_parallel_size"] == 2
+    assert overrides["pipeline_model_parallel_size"] == 2
+    assert overrides["expert_model_parallel_size"] == 4
+    assert overrides["expert_tensor_parallel_size"] == 1
+    assert overrides["sequence_parallel"] is True
+    assert overrides["params_dtype"] is text_generation.torch.bfloat16
+    assert overrides["pipeline_dtype"] is text_generation.torch.bfloat16
+    assert overrides["bf16"] is True
+    assert overrides["fp16"] is False
+    assert overrides["cache_mla_latents"] is True
+    assert overrides["inference_moe_token_dispatcher_type"] == "nvls"


### PR DESCRIPTION
## Summary
- Forward `--attention-backend` into the Megatron checkpoint load override path used by `scripts/inference/text_generation.py`.
- Keep imported/SFT Megatron checkpoint inference aligned with the direct HF path when users request local attention.
- Add unit coverage for the checkpoint override dictionary so the attention backend is not dropped again.

## Root Cause
`examples/models/gpt_oss/inference.sh` passes `--attention-backend local` for direct HF, imported Megatron checkpoint, exported HF, and SFT checkpoint inference.

The direct HF paths apply that CLI override before constructing the model. The Megatron checkpoint path builds an initial provider with the override, but then calls `bridge.load_megatron_model(...)` using an `mp_overrides` dictionary that did not include `attention_backend`. That lets the checkpoint-saved/default attention backend win when reconstructing the model from the Megatron checkpoint.

For GPT-OSS, that can rebuild the imported Megatron checkpoint with TE/cuDNN fused attention instead of local attention. GPT-OSS has learnable attention sinks mapped to `core_attention.softmax_offset`, and cuDNN fused attention decode fails with sink tokens in the reported rc8 path.

NVBug: https://nvbugspro.nvidia.com/bug/6327789

## Validation
- `python3 -m py_compile scripts/inference/text_generation.py tests/unit_tests/scripts/test_text_generation.py`
- `git diff --check`
- `pre-commit run --all-files --show-diff-on-failure --color=never`

Notes:
- Local `uv run python -m pytest tests/unit_tests/scripts/test_text_generation.py -q` is blocked on this host by the known `nvidia-resiliency-ext==0.6.0` manylinux wheel/platform mismatch.
- I staged the tree for DFW rc8 focused pytest, but the submitted interactive job `12840059` stayed pending on `QOSMaxNodePerUserLimit` because a separate 2-node interactive allocation was already running under `chcui`; I cancelled only that pending pytest job.

## Blast Radius / Test Level
- Blast radius: `scripts/inference/text_generation.py` Megatron checkpoint inference override handling. Direct HF inference and generic checkpoint loading APIs are unchanged.
- L0: Required and covered by the added unit test plus CI lint/import checks.
- L1: Recommended if available for GPT-OSS inference smoke because this fixes a user-facing model inference path.
- L2: Not required; no training, conversion mapping, distributed checkpoint format, or shared runtime internals are changed.
