### PR TITLE
feat(training): expose distributed_timeout_minutes in perf launcher

### DIFF
--- a/scripts/performance/argument_parser.py
+++ b/scripts/performance/argument_parser.py
@@ -293,6 +293,15 @@ def parse_cli_args():
         "--seq_length",
         type=int,
     )
+    training_args.add_argument(
+        "--distributed_timeout_minutes",
+        type=int,
+        help=(
+            "Process-group init timeout in minutes (dist.distributed_timeout_minutes). "
+            "Widen above the 10-minute default when a one-time dataset index build on rank 0 "
+            "can outlast the NCCL collective watchdog while other ranks wait at the setup barrier."
+        ),
+    )
 
     # Optimizer
     optimizer_args = parser.add_argument_group("Optimizer arguments")

--- a/scripts/performance/run_recipe.py
+++ b/scripts/performance/run_recipe.py
@@ -65,6 +65,10 @@ def set_user_overrides(config, args):
     if args.micro_batch_size:
         config.train.micro_batch_size = args.micro_batch_size
 
+    # Distributed init configuration
+    if args.distributed_timeout_minutes:
+        config.dist.distributed_timeout_minutes = args.distributed_timeout_minutes
+
     # Optimizer configuration
     if args.lr:
         config.optimizer.lr = args.lr


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## Background / motivation

- A `moonlight_16b` GB200 weekly run failed with a NCCL collective watchdog timeout (`WorkNCCL(... OpType=ALLREDUCE, NumelIn=1 ...) ran for 600058 ms`).
- Root cause is **not** network/NCCL: rank 0 builds the GPTDataset sample/shuffle index over a large real-data corpus (~63.7M docs) on the critical path while the other ranks block on a 1-element barrier ALLREDUCE. The build outlasts the **default 10-minute** process-group timeout (`600000 ms`), so the watchdog tears the group down.
- The perf launcher had no way to widen this timeout per test — `dist.distributed_timeout_minutes` was only reachable by editing a recipe.

## What changed

- Expose `--distributed_timeout_minutes` on the performance launcher's shared arg parser.
- Apply it to `dist.distributed_timeout_minutes` in `run_recipe.py`'s `set_user_overrides` (only when set).

## Details

- `scripts/performance/argument_parser.py` — new `--distributed_timeout_minutes` (`int`) in the Training arguments group. No default → the recipe/MCore default (10 min) stands unless explicitly set.
- `scripts/performance/run_recipe.py` — `set_user_overrides` sets `config.dist.distributed_timeout_minutes` when the flag is provided.
- No `setup_experiment.py` change needed: it already forwards raw argv to `run_recipe.py` via `_filter_run_script_args(sys.argv[1:])`, and `argument_builder.py` auto-maps the parser action to the env var `DISTRIBUTED_TIMEOUT_MINUTES`, so CI test configs can set it like `MAX_STEPS` / `SAVE_INTERVAL`.

```mermaid
flowchart LR
    CI["CI var<br/>DISTRIBUTED_TIMEOUT_MINUTES"] --> AB["argument_builder.py<br/>env to --distributed_timeout_minutes"]
    AB --> SE["setup_experiment.py<br/>argv passthrough (_filter_run_script_args)"]
    SE --> RR["run_recipe.py<br/>set_user_overrides"]
    RR --> CFG["cfg.dist.distributed_timeout_minutes"]
```

Usage:

```bash
# direct
uv run python -m torch.distributed.run --nproc_per_node=8 \
  scripts/performance/run_recipe.py --recipe ... --distributed_timeout_minutes 30
```

```yaml
# CI (nemo-ci test config)
variables:
  DISTRIBUTED_TIMEOUT_MINUTES: 30
```

## Tested

- `uv run ruff check` + `ruff format --check` clean on both changed files.
- Contract verified statically: argparse derives dest `distributed_timeout_minutes` (consumed in `run_recipe.set_user_overrides`); `argument_builder.normalize_arg_name` maps the flag to `DISTRIBUTED_TIMEOUT_MINUTES`.

> Note: this PR only **exposes** the knob. The robustness fix lands when the companion nemo-ci change sets `DISTRIBUTED_TIMEOUT_MINUTES` on the moonlight GB200 test configs.

</details>
