### PR TITLE
cp: `feat(training): expose distributed_timeout_minutes in perf launcher (4385)` into `r0.5.0`

### DIFF
--- a/scripts/performance/argument_parser.py
+++ b/scripts/performance/argument_parser.py
@@ -293,6 +293,15 @@ def parse_cli_args():
         "--seq_length",
         type=int,
     )
+    training_args.add_argument(
+        "--distributed_timeout_minutes",
+        type=int,
+        help=(
+            "Process-group init timeout in minutes (dist.distributed_timeout_minutes). "
+            "Widen above the 10-minute default when a one-time dataset index build on rank 0 "
+            "can outlast the NCCL collective watchdog while other ranks wait at the setup barrier."
+        ),
+    )
 
     # Optimizer
     optimizer_args = parser.add_argument_group("Optimizer arguments")

--- a/scripts/performance/run_recipe.py
+++ b/scripts/performance/run_recipe.py
@@ -65,6 +65,10 @@ def set_user_overrides(config, args):
     if args.micro_batch_size:
         config.train.micro_batch_size = args.micro_batch_size
 
+    # Distributed init configuration
+    if args.distributed_timeout_minutes:
+        config.dist.distributed_timeout_minutes = args.distributed_timeout_minutes
+
     # Optimizer configuration
     if args.lr:
         config.optimizer.lr = args.lr


### PR DESCRIPTION
<details><summary>Claude summary</summary>

Cherry-pick of #4385 (`26f2f20`) into `r0.5.0`.

**What changed**
- Adds `--distributed_timeout_minutes` CLI flag to the perf launcher (`scripts/performance/argument_parser.py`).
- Wires it through to `config.dist.distributed_timeout_minutes` in `scripts/performance/run_recipe.py`.

**Why**
- Widens the process-group init timeout above the 10-minute default so a one-time rank-0 dataset index build can outlast the NCCL collective watchdog while other ranks wait at the setup barrier.

**Details**
- Clean cherry-pick (`-x`), no conflicts; diff is byte-identical to the source commit (2 files, +13).

</details>
