### PR TITLE
fix(qwen3-vl): fix ViT DP when CP feature for qwen3-vl and qwen35-vl

### DIFF
--- a/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/model.py
+++ b/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/model.py
@@ -482,13 +482,13 @@ class Qwen3VLModel(MegatronModule):
                     vision_embeds = AllGatherVisionEmbeddings.apply(
                         vision_embeds,
                         seqlen_on_cp_ranks,
-                        cp_group=self.pg_collection.cp,
+                        self.pg_collection.cp,
                     )
                     for i in range(len(deepstack_feature_lists)):
                         deepstack_feature_lists[i] = AllGatherVisionEmbeddings.apply(
                             deepstack_feature_lists[i],
                             seqlen_on_cp_ranks,
-                            cp_group=self.pg_collection.cp,
+                            self.pg_collection.cp,
                         )
 
             combined_embeddings = self.language_model.embedding(


### PR DESCRIPTION
# What does this PR do ?

Remove cp_group keyword from `AllGatherVisionEmbeddings.apply` to enable 'model.vision_dp_when_cp'.

# Changelog

- remove cp_group keyword from `AllGatherVisionEmbeddings.apply()`.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

# Additional Information

> From Engine Architecture Group 5, Engine Infrastructure Department, Xiaohongshu (RedNote).

We have already tested the accuracy of this feature, as shown below.



`model.vision_dp_when_cp` is a useful feature for handling large amounts of images during vision-language model training. Should we extend this Qwen3-series-only feature to generic VLMs? If the maintainers agree, I'd be happy to follow up with a PR.

Note to maintainers: please include the following trailers when squashing:

> Co-authored-by: ggboooy <754635415@qq.com>
