### PR TITLE
[docs] docs: Add MLPerf Training 6.0 news

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 </div>
 
 ## 📣 News
+- [06/16/2026] NVIDIA topped [MLPerf Training v6.0](https://developer.nvidia.com/blog/nvidia-blackwell-tops-mlperf-training-6-0-with-industry-leading-scale-and-performance/) across every benchmark, including the new DeepSeek-V3 and GPT-OSS MoE training workloads. Megatron Bridge serves as the packaging layer for the NeMo 26.06 training stack that integrates full-iteration CUDA graphs, HybridEP/router optimizations, all-to-all overlap, MXFP8 attention, and pipeline-layout balancing; the blog highlights DeepSeek-V3 training at **1,648 TFLOPS/GPU** (**6,338 tokens/sec/GPU**) on GB300, with the corresponding container expected with the NeMo 26.06 release soon.
+
 - [06/04/2026] [**NVIDIA Nemotron 3 Ultra**](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16) is now public! Day-0 support for the 550B-A55B hybrid Mamba-Transformer MoE model is available on the [`nemotron_3_ultra`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/nemotron_3_ultra) branch, including checkpoint conversion, inference, SFT, PEFT (LoRA), and pretraining examples. Read the [NVIDIA Technical Blog](https://developer.nvidia.com/blog/nvidia-nemotron-3-ultra-powers-faster-more-efficient-reasoning-for-long-running-agents/) and see the [examples README](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/nemotron_3_ultra/examples/models/nemotron/nemotron_3/ultra/README.md) for the full walkthrough.
 
 - [05/28/2026] [**Step-3.7-Flash**](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/examples/models/stepfun/step37) is now merged on **main**! See the [examples README](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/examples/models/stepfun/step37/README.md) for sft training details.


### PR DESCRIPTION
## Summary
- Add a README news item for NVIDIA's MLPerf Training v6.0 results.
- Highlight Megatron Bridge as the NeMo 26.06 training-stack packaging layer called out in the NVIDIA Technical Blog.
- Call out the DeepSeek-V3 result highlighted in the blog: 1,648 TFLOPS/GPU and 6,338 tokens/sec/GPU on GB300.

## Verification
- `git diff --check`
- `uv run --no-sync pre-commit run --all-files`

Note: `uv run pre-commit run --all-files` without `--no-sync` is blocked on this host because the fresh uv environment cannot install `nvidia-resiliency-ext==0.6.0` for the local `manylinux_2_31_x86_64` platform. The no-sync pre-commit run executed the configured hooks successfully.