### PR TITLE
build: bump starlette to 1.3.1 and tornado to 6.5.6 to fix container CVEs

### DIFF
--- a/docker/Dockerfile.fw_final
+++ b/docker/Dockerfile.fw_final
@@ -71,7 +71,7 @@ RUN \
 ##
 ##############################################################################
 
-RUN pip install "starlette==0.49.1" \
+RUN pip install "starlette==1.3.1" \
     "urllib3>=2.7.0" \
     "aiohttp>=3.13.3" \
     "jaraco-context>=6.1.0" \
@@ -81,7 +81,7 @@ RUN pip install "starlette==0.49.1" \
     "pillow>=12.1.1" \
     "protobuf==6.33.5" \
     "xgrammar>=0.1.32" \
-    "tornado==6.5.5" \
+    "tornado==6.5.6" \
     "black==26.3.1" \
     "onnx==1.21.0" \
     "notebook>=7.5.6" \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,6 +137,8 @@ override-dependencies = [
     "urllib3>=2.6.3",                                       # To address CVE-2026-21441
     "langchain>=0.3.28",                                    # To address CVE-2025-65106
     "langchain-core>=0.3.80",                               # To address CVE-2025-65106
+    "starlette>=1.3.1",                                     # To address GHSA-82w8-qh3p-5jfq and GHSA-wqp7-x3pw-xc5r
+    "prometheus-fastapi-instrumentator>=8.0.0",             # starlette>=1.3.1 requires the instrumentator's 8.x line
     "onnx>=1.21.0; python_version < '3.13'",                # onnx<1.21 has missing lower bound on ml-dtypes, uses float4_e2m1fn (requires ml-dtypes>=0.5.0)
     "nvidia-cudnn-frontend==1.23.0",
     "nvidia-cutlass-dsl[cu13]; sys_platform == 'never'"     # Rely on system site packages install

--- a/uv.lock
+++ b/uv.lock
@@ -19,6 +19,8 @@ overrides = [
     { name = "nvidia-cutlass-dsl", extras = ["cu13"], marker = "sys_platform == 'never'" },
     { name = "nvidia-modelopt", specifier = "==0.44.0rc5", index = "https://pypi.nvidia.com/" },
     { name = "onnx", marker = "python_full_version < '3.13'", specifier = ">=1.21.0" },
+    { name = "prometheus-fastapi-instrumentator", specifier = ">=8.0.0" },
+    { name = "starlette", specifier = ">=1.3.1" },
     { name = "torch", marker = "sys_platform == 'never'" },
     { name = "torchvision", marker = "sys_platform == 'never'" },
     { name = "transformer-engine", git = "https://github.com/NVIDIA/TransformerEngine.git?rev=f8a01cd5ac55a6b669bacc4b222242bfff2c822a" },
@@ -3385,15 +3387,15 @@ wheels = [
 
 [[package]]
 name = "prometheus-fastapi-instrumentator"
-version = "7.0.0"
+version = "8.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "prometheus-client" },
     { name = "starlette" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0e/42/eeb55ea9b0eae7d6854bef6aef3ecd34674f85813bc3877efdaeb582ab7e/prometheus_fastapi_instrumentator-7.0.0.tar.gz", hash = "sha256:5ba67c9212719f244ad7942d75ded80693b26331ee5dfc1e7571e4794a9ccbed", size = 20077, upload-time = "2024-03-13T16:25:08.564Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/7a/fe49b7060e585e2cfa28cc1d13ebfe9c2904dcd80cf11071d5de0f622ff2/prometheus_fastapi_instrumentator-8.0.0.tar.gz", hash = "sha256:c31ed192db077e75467b28b2fe5055362517f53369b798cb8dac9ff85f3f1c38", size = 20357, upload-time = "2026-05-29T13:04:43.327Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/59/66/2e93a8f56adb51ede41d0ef5f4f0277522acc4adc87937f5457b7b5692a8/prometheus_fastapi_instrumentator-7.0.0-py3-none-any.whl", hash = "sha256:96030c43c776ee938a3dae58485ec24caed7e05bfc60fe067161e0d5b5757052", size = 19005, upload-time = "2024-03-13T16:25:03.687Z" },
+    { url = "https://files.pythonhosted.org/packages/73/ad/b14ed2fe73bb1d37bcc947e75afae018f795526415d5b849aeb99c403cd1/prometheus_fastapi_instrumentator-8.0.0-py3-none-any.whl", hash = "sha256:e3c967c402124dfe81cf5aad35208d9f96db5452c6cb752350d9358ca0a96198", size = 19411, upload-time = "2026-05-29T13:04:44.17Z" },
 ]
 
 [[package]]
@@ -4595,15 +4597,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.52.1"
+version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Background / motivation

The `26.06.rc8` NeMo FW container scan flagged three **High**-severity CVEs across **two** Python installs in the image:

| CVE | Package | Summary | Patched |
|-----|---------|---------|---------|
| [GHSA-82w8-qh3p-5jfq](https://github.com/advisories/GHSA-82w8-qh3p-5jfq) | `starlette` | `request.form()` size limits silently ignored → DoS | `1.3.1` |
| [GHSA-wqp7-x3pw-xc5r](https://github.com/advisories/GHSA-wqp7-x3pw-xc5r) | `starlette` | `StaticFiles` UNC-path SSRF / NTLM theft (**Windows-only**) | `1.1.0` |
| [GHSA-mgf9-4vpg-hj56](https://github.com/advisories/GHSA-mgf9-4vpg-hj56) | `tornado` | `AsyncHTTPClient` accumulates decompressed chunks without limit (gzip bomb) → DoS | `6.5.6` |

Both starlette CVEs are patched only in the `1.x` line (no `0.x` backport).

The scan's **Package Location** column splits these across the two installs the image carries, and both are owned by this repo's Docker build:

- **`/opt/venv/.../site-packages`** — the uv-managed install (`uv.lock`): `starlette 0.52.1`.
- **`/usr/local/lib/python3.12/dist-packages`** — the system interpreter, pinned in `docker/Dockerfile.fw_final`'s "Address CVE" block: `starlette 0.49.1`, `tornado 6.5.5`.

## What changed

**uv-managed (`/opt/venv`):**
- Pin `starlette>=1.3.1` via `[tool.uv] override-dependencies` (transitive — pulled by `fastapi`, `mlflow-skinny`, `prometheus-fastapi-instrumentator`, `sphinx-autobuild`).
- Bump `prometheus-fastapi-instrumentator` `7.0.0 → 8.0.0` (its 7.x line caps `starlette<1.0.0`; 8.x requires `>=1.0.0`).
- Regenerated `uv.lock`: `starlette 0.52.1 → 1.3.1`, `prometheus-fastapi-instrumentator 7.0.0 → 8.0.0`. No other packages change.

**system interpreter (`/usr/local/lib/.../dist-packages`), `docker/Dockerfile.fw_final`:**
- `starlette==0.49.1 → 1.3.1`
- `tornado==6.5.5 → 6.5.6`

## Details

- The uv-side CVE floor follows the repo's existing `override-dependencies` pattern (`urllib3>=2.6.3`, `langchain>=0.3.28`, …).
- `fastapi` (`>=0.46.0`), `mlflow-skinny` (`<2`) and `sphinx-autobuild` (`>=0.35`) already permit `starlette 1.x`; only `prometheus-fastapi-instrumentator` had to move with it.
- The fw_final bumps stay in the block's existing exact-pin style. `tornado` is an **explicit** pin there (not just a `wandb[launch]` transitive), so it has to be bumped directly.

## Tested

- `uv lock --upgrade-package starlette --upgrade-package prometheus-fastapi-instrumentator` (run in container) resolved 349 packages cleanly, no rebuilds:
  - `Updated starlette v0.52.1 -> v1.3.1`
  - `Updated prometheus-fastapi-instrumentator v7.0.0 -> v8.0.0`
- `starlette==1.3.1` and `tornado==6.5.6` confirmed present on PyPI.
- `pre-commit` clean on changed files.
- CI to validate the full image build + test matrix (this crosses the `starlette` 0.x→1.x major boundary, so the build/functional jobs are the real check that `fastapi`/`vllm`/instrumentator paths still import cleanly).