### PR TITLE
fix(data): preserve Nemotron Omni packed sequence metadata

### DIFF
--- a/src/megatron/bridge/data/energon/nemotron_omni_task_encoder.py
+++ b/src/megatron/bridge/data/energon/nemotron_omni_task_encoder.py
@@ -88,6 +88,7 @@ class NemotronOmniTaskBatch(Batch):
     cu_seqlens: Optional[torch.Tensor] = None
     cu_seqlens_unpadded: Optional[torch.Tensor] = None
     cu_seqlens_argmin: Optional[torch.Tensor] = None
+    cu_seqlens_unpadded_argmin: Optional[torch.Tensor] = None
     max_seqlen: Optional[torch.Tensor] = None
 
 
@@ -494,6 +495,7 @@ class NemotronOmniTaskEncoder(DefaultTaskEncoder[ChatMLSample, NemotronOmniTaskS
         cu_seqlens_t: Optional[torch.Tensor] = None
         cu_seqlens_unpadded_t: Optional[torch.Tensor] = None
         cu_seqlens_argmin_t: Optional[torch.Tensor] = None
+        cu_seqlens_unpadded_argmin_t: Optional[torch.Tensor] = None
         max_seqlen_t: Optional[torch.Tensor] = None
 
         if self.pack_sequences:
@@ -525,6 +527,7 @@ class NemotronOmniTaskEncoder(DefaultTaskEncoder[ChatMLSample, NemotronOmniTaskS
             # pointing at the first sentinel. Here we emit an unpadded cu_seqlens and
             # set argmin = len(cu_seqlens) so the slice is a no-op (keeps every entry).
             cu_seqlens_argmin_t = torch.tensor(len(cu_seqlens), dtype=torch.int32)
+            cu_seqlens_unpadded_argmin_t = torch.tensor(len(cu_seqlens), dtype=torch.int32)
             max_seqlen_t = torch.tensor(max(lengths), dtype=torch.int32)
         else:
             max_seq_len = max(s.input_ids.size(0) for s in samples)
@@ -629,6 +632,7 @@ class NemotronOmniTaskEncoder(DefaultTaskEncoder[ChatMLSample, NemotronOmniTaskS
             cu_seqlens=cu_seqlens_t,
             cu_seqlens_unpadded=cu_seqlens_unpadded_t,
             cu_seqlens_argmin=cu_seqlens_argmin_t,
+            cu_seqlens_unpadded_argmin=cu_seqlens_unpadded_argmin_t,
             max_seqlen=max_seqlen_t,
         )
 
@@ -655,6 +659,7 @@ class NemotronOmniTaskEncoder(DefaultTaskEncoder[ChatMLSample, NemotronOmniTaskS
             "cu_seqlens": batch.cu_seqlens,
             "cu_seqlens_unpadded": batch.cu_seqlens_unpadded,
             "cu_seqlens_argmin": batch.cu_seqlens_argmin,
+            "cu_seqlens_unpadded_argmin": batch.cu_seqlens_unpadded_argmin,
             "max_seqlen": batch.max_seqlen,
         }
 

--- a/tests/unit_tests/data/energon/test_nemotron_omni_task_encoder.py
+++ b/tests/unit_tests/data/energon/test_nemotron_omni_task_encoder.py
@@ -210,6 +210,7 @@ def test_batch_packs_sequences_and_pads_audio_then_encode_batch():
     assert batch.cu_seqlens.tolist() == [0, 2, 5]
     assert batch.cu_seqlens_unpadded.tolist() == [0, 2, 5]
     assert batch.cu_seqlens_argmin.item() == 3
+    assert batch.cu_seqlens_unpadded_argmin.item() == 3
     assert batch.max_seqlen.item() == 3
     assert batch.visual_tensors["pixel_values"].shape == (1, 5, 3)
     assert batch.sound_clips.shape == (2, 2, 4)
@@ -222,5 +223,9 @@ def test_batch_packs_sequences_and_pads_audio_then_encode_batch():
     assert encoded["tokens"] is batch.input_ids
     assert encoded["sound_clips"] is batch.sound_clips
     assert encoded["cu_seqlens"] is batch.cu_seqlens
+    assert encoded["cu_seqlens_unpadded"] is batch.cu_seqlens_unpadded
+    assert encoded["cu_seqlens_argmin"] is batch.cu_seqlens_argmin
+    assert encoded["cu_seqlens_unpadded_argmin"] is batch.cu_seqlens_unpadded_argmin
+    assert encoded["max_seqlen"] is batch.max_seqlen
     assert isinstance(encoded["visual_inputs"], GenericVisualInputs)
     assert encoded["visual_inputs"].pixel_values.shape == (1, 5, 3)


### PR DESCRIPTION
## Summary

- Add `cu_seqlens_unpadded_argmin` to the Nemotron Omni Energon batch metadata.
- Populate it for in-batch packed sequences and forward it through `encode_batch()`.
- Extend the packed Energon unit test to cover the forwarded packed-sequence metadata.

## Root Cause

`NemotronOmniTaskEncoder.batch()` builds packed `cu_seqlens` metadata, but the unpadded argmin was not carried through the Energon batch dict. When `get_packed_seq_params()` receives `cu_seqlens_unpadded` without `cu_seqlens_unpadded_argmin`, it falls back to `torch.argmin(cu_seqlens_unpadded)`. For valid packed sequences the first entry is `0`, so the fallback truncates the unpadded cu-seqlens to an empty tensor, which can surface as a TE/cuDNN fused-attention bad parameter.

## Validation

- `pre-commit run --all-files`
- `python3 -m py_compile src/megatron/bridge/data/energon/nemotron_omni_task_encoder.py tests/unit_tests/data/energon/test_nemotron_omni_task_encoder.py`
- DFW rc8 packed Valor smoke, MBS=2, TP=2, EP=8, CP=1, real Energon data: job `12869551` completed with exit `0` and rank 0 logged `Step Time : 114.68s`. Logs: `/lustre/fs1/portfolios/coreai/projects/coreai_dlalgo_llm/users/chcui/vera-wandb/valor32k-energon-20260616/logs/valor32k-rc8-packdiag3_12869551.{out,err}`.

Not run locally:

- `uv run python -m pytest tests/unit_tests/data/energon/test_nemotron_omni_task_encoder.py -q` because this workstation resolves as `manylinux_2_31_x86_64`, while `nvidia-resiliency-ext==0.6.0` only publishes compatible wheels for `manylinux_2_39` on x86_64.
