### PR TITLE
test: register internal and gpu pytest markers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -243,6 +243,8 @@ markers = [
     "system: marks test working at the highest integration level (deselect with '-m \"not system\"')",
     "acceptance: marks test checking whether the developed product/model passes the user defined acceptance criteria (deselect with '-m \"not acceptance\"')",
     "docs: mark tests related to documentation (deselect with '-m \"not docs\"')",
+    "internal: marks tests requiring internal NVIDIA infrastructure or resources",
+    "gpu: marks tests requiring GPU hardware",
     "skipduringci: marks tests that are skipped ci as they are addressed by Jenkins jobs but should be run to test user setups",
     "pleasefixme: marks tests that are broken and need fixing",
 ]


### PR DESCRIPTION
Backports the pytest marker registrations from main commit e9529c3a8e7d822886a80ce81778e119b66cb61e to unblock strict-marker unit test collection on r0.5.0.

The full main commit also carries unrelated dependency, uv.lock, .main.commit, and Megatron-LM submodule changes, so this PR carries only the pyproject.toml marker hunk.

Validation:
- python3 -m pre_commit run --all-files: passed
- uv run pre-commit run --all-files: blocked on macOS ARM because nvidia-resiliency-ext==0.6.0 has no compatible wheel
- uv run python -m pytest tests/unit_tests/models/qwen_vl/modelling_qwen3_vl/test_attention.py --collect-only -q: blocked by the same dependency resolution issue