### PR TITLE
fix(hf): validate safetensors shard paths

### DIFF
--- a/src/megatron/bridge/models/hf_pretrained/state.py
+++ b/src/megatron/bridge/models/hf_pretrained/state.py
@@ -20,7 +20,7 @@ from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Mapping
 from functools import lru_cache
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import (
     Dict,
     Iterable,
@@ -476,6 +476,52 @@ class SafeTensorsStateSource(StateSource):
         prefixes = tuple(ignored_source_key_prefixes)
         return {key: filename for key, filename in key_to_filename_map.items() if not key.startswith(prefixes)}
 
+    @staticmethod
+    def _validate_safetensors_filename(filename: str, tensor_key: str) -> Path:
+        if "\0" in filename or "\\" in filename:
+            raise ValueError(f"Invalid safetensors shard filename for tensor '{tensor_key}': {filename!r}")
+
+        filename_path = Path(filename)
+        windows_filename_path = PureWindowsPath(filename)
+        if filename_path.is_absolute() or windows_filename_path.is_absolute() or windows_filename_path.drive:
+            raise ValueError(f"Invalid safetensors shard filename for tensor '{tensor_key}': {filename!r}")
+        if filename_path.suffix != ".safetensors":
+            raise ValueError(f"Invalid safetensors shard filename for tensor '{tensor_key}': {filename!r}")
+        if ".." in filename_path.parts:
+            raise ValueError(f"Invalid safetensors shard filename for tensor '{tensor_key}': {filename!r}")
+        return filename_path
+
+    @staticmethod
+    def _resolve_validated_safetensors_output_path(base_path: Path, filename: str, tensor_key: str) -> Path:
+        filename_path = SafeTensorsStateSource._validate_safetensors_filename(filename, tensor_key)
+        resolved_base_path = base_path.resolve()
+        resolved_file_path = (resolved_base_path / filename_path).resolve()
+        if resolved_file_path != resolved_base_path and resolved_base_path not in resolved_file_path.parents:
+            raise ValueError(f"Invalid safetensors shard filename for tensor '{tensor_key}': {filename!r}")
+        return resolved_file_path
+
+    @staticmethod
+    def _validate_key_to_filename_map(
+        key_to_filename_map: Mapping[object, object],
+    ) -> Dict[str, str]:
+        validated_map = {}
+        for key, filename in key_to_filename_map.items():
+            if not isinstance(key, str):
+                raise ValueError(f"Invalid safetensors index tensor key: {key!r}")
+            if not isinstance(filename, str):
+                raise ValueError(f"Invalid safetensors shard filename for tensor '{key}': {filename!r}")
+            SafeTensorsStateSource._validate_safetensors_filename(filename, key)
+            validated_map[key] = filename
+        return validated_map
+
+    @staticmethod
+    def _prepare_safetensors_output_path(output_path: Path, filename: str, tensor_key: str) -> Path:
+        output_file_path = SafeTensorsStateSource._resolve_validated_safetensors_output_path(
+            output_path, filename, tensor_key
+        )
+        output_file_path.parent.mkdir(parents=True, exist_ok=True)
+        return output_file_path
+
     @property
     def path(self) -> Path:
         """
@@ -803,7 +849,9 @@ class SafeTensorsStateSource(StateSource):
                     # This shard is complete, save it.
                     tensors_to_save = {key: buffered_tensors[key] for key in keys_for_file}
 
-                    output_file_path = output_path / filename
+                    output_file_path = self._prepare_safetensors_output_path(
+                        output_path, filename, next(iter(keys_for_file))
+                    )
                     save_file(tensors_to_save, output_file_path)
 
                     # Free memory by removing saved tensors from the buffer.
@@ -834,7 +882,9 @@ class SafeTensorsStateSource(StateSource):
                 for filename in list(files_to_save.keys()):
                     keys_for_file = files_to_save[filename]
                     tensors_to_save = {key: buffered_tensors[key] for key in keys_for_file if key in buffered_tensors}
-                    output_file_path = output_path / filename
+                    output_file_path = self._prepare_safetensors_output_path(
+                        output_path, filename, next(iter(keys_for_file))
+                    )
                     save_file(tensors_to_save, output_file_path)
 
                     # Free memory by removing saved tensors from the buffer.
@@ -902,7 +952,7 @@ class SafeTensorsStateSource(StateSource):
                 try:
                     index_data = json.load(f)
                     if "weight_map" in index_data and isinstance(index_data["weight_map"], dict):
-                        return index_data["weight_map"]
+                        return SafeTensorsStateSource._validate_key_to_filename_map(index_data["weight_map"])
                 except json.JSONDecodeError:
                     return None
         return None
@@ -1018,7 +1068,10 @@ class SafeTensorsStateSource(StateSource):
                 tensors_to_save = {k: buffered_tensors[k] for k in keys_for_file if k in buffered_tensors}
                 if not tensors_to_save:
                     continue
-                save_file(tensors_to_save, output_path / fname)
+                output_file_path = self._prepare_safetensors_output_path(
+                    output_path, fname, next(iter(keys_for_file))
+                )
+                save_file(tensors_to_save, output_file_path)
                 actually_saved_keys.update(tensors_to_save.keys())
 
         # Rank 0 builds the index from the files that were actually written.
@@ -1032,7 +1085,9 @@ class SafeTensorsStateSource(StateSource):
 
                 all_saved_keys_aggregated = set()
                 for fname in all_filenames:
-                    file_path = output_path / fname
+                    file_path = self._resolve_validated_safetensors_output_path(
+                        output_path, fname, next(iter(filename_to_keys_map[fname]))
+                    )
                     if not file_path.exists():
                         continue
                     with safe_open(file_path, framework="pt", device="cpu") as f:

--- a/tests/unit_tests/models/hf_pretrained/test_state_dict.py
+++ b/tests/unit_tests/models/hf_pretrained/test_state_dict.py
@@ -427,6 +427,127 @@ class TestStateDictConvenienceMethods:
 class TestSafeTensorsStateSourceSave:
     """Test streaming safetensors save behavior."""
 
+    def test_save_generator_supports_nested_relative_shard_paths(self, tmp_path):
+        from safetensors.torch import save_file
+
+        source_dir = tmp_path / "source"
+        source_shard_dir = source_dir / "nested"
+        output_dir = tmp_path / "output"
+        source_shard_dir.mkdir(parents=True)
+        save_file({"model.weight": torch.ones(1)}, source_shard_dir / "model-00001-of-00001.safetensors")
+        with open(source_dir / "model.safetensors.index.json", "w") as f:
+            json.dump(
+                {
+                    "metadata": {},
+                    "weight_map": {"model.weight": "nested/model-00001-of-00001.safetensors"},
+                },
+                f,
+            )
+
+        source = SafeTensorsStateSource(source_dir)
+        source.save_generator(iter([("model.weight", torch.zeros(1))]), output_dir)
+
+        assert (output_dir / "nested" / "model-00001-of-00001.safetensors").exists()
+        with open(output_dir / "model.safetensors.index.json") as f:
+            output_index = json.load(f)
+        assert output_index["weight_map"] == {"model.weight": "nested/model-00001-of-00001.safetensors"}
+
+    def test_save_generator_accepts_source_shard_symlink_outside_source_dir(self, tmp_path):
+        from safetensors.torch import save_file
+
+        source_dir = tmp_path / "snapshots" / "revision"
+        blob_dir = tmp_path / "blobs"
+        output_dir = tmp_path / "output"
+        source_dir.mkdir(parents=True)
+        blob_dir.mkdir()
+        save_file({"model.weight": torch.ones(1)}, blob_dir / "shard")
+        (source_dir / "model-00001-of-00001.safetensors").symlink_to(Path("..") / ".." / "blobs" / "shard")
+        with open(source_dir / "model.safetensors.index.json", "w") as f:
+            json.dump(
+                {
+                    "metadata": {},
+                    "weight_map": {"model.weight": "model-00001-of-00001.safetensors"},
+                },
+                f,
+            )
+
+        source = SafeTensorsStateSource(source_dir)
+        source.save_generator(iter([("model.weight", torch.zeros(1))]), output_dir)
+
+        assert (output_dir / "model-00001-of-00001.safetensors").exists()
+        with open(output_dir / "model.safetensors.index.json") as f:
+            output_index = json.load(f)
+        assert output_index["weight_map"] == {"model.weight": "model-00001-of-00001.safetensors"}
+
+    @pytest.mark.parametrize(
+        "filename",
+        [
+            "../evil.safetensors",
+            "..\\evil.safetensors",
+            "../../site-packages/evil.pth",
+            "/tmp/evil.safetensors",
+            "C:\\tmp\\evil.safetensors",
+            "model.bin",
+            "model.safetensors\0.pth",
+        ],
+    )
+    def test_save_generator_rejects_invalid_shard_paths(self, tmp_path, filename):
+        source_dir = tmp_path / "source"
+        output_dir = tmp_path / "output"
+        source_dir.mkdir()
+        with open(source_dir / "model.safetensors.index.json", "w") as f:
+            json.dump(
+                {
+                    "metadata": {},
+                    "weight_map": {"model.weight": filename},
+                },
+                f,
+            )
+
+        source = SafeTensorsStateSource(source_dir)
+
+        with pytest.raises(ValueError, match="Invalid safetensors shard filename"):
+            source.save_generator(iter([("model.weight", torch.zeros(1))]), output_dir)
+
+        assert not (tmp_path / "evil.safetensors").exists()
+        assert not (tmp_path / "site-packages" / "evil.pth").exists()
+
+    def test_save_generator_rejects_non_string_shard_path(self, tmp_path):
+        source_dir = tmp_path / "source"
+        output_dir = tmp_path / "output"
+        source_dir.mkdir()
+        with open(source_dir / "model.safetensors.index.json", "w") as f:
+            json.dump(
+                {
+                    "metadata": {},
+                    "weight_map": {"model.weight": 123},
+                },
+                f,
+            )
+
+        source = SafeTensorsStateSource(source_dir)
+
+        with pytest.raises(ValueError, match="Invalid safetensors shard filename"):
+            source.save_generator(iter([("model.weight", torch.zeros(1))]), output_dir)
+
+    def test_distributed_save_generator_rejects_invalid_shard_paths_without_initialized_dist(self, tmp_path):
+        source_dir = tmp_path / "source"
+        output_dir = tmp_path / "output"
+        source_dir.mkdir()
+        with open(source_dir / "model.safetensors.index.json", "w") as f:
+            json.dump(
+                {
+                    "metadata": {},
+                    "weight_map": {"model.weight": "../evil.safetensors"},
+                },
+                f,
+            )
+
+        source = SafeTensorsStateSource(source_dir)
+
+        with pytest.raises(ValueError, match="Invalid safetensors shard filename"):
+            source.save_generator(iter([("model.weight", torch.zeros(1))]), output_dir, distributed_save=True)
+
     def test_save_generator_ignores_source_key_prefixes(self, tmp_path, capsys):
         from safetensors.torch import save_file
 


### PR DESCRIPTION
## Summary
- validate safetensors index weight_map filenames before using them for HF shard save/load paths
- preserve safe nested relative shard paths while rejecting traversal, absolute paths, Windows-style paths, NUL bytes, non-.safetensors targets, and non-string values
- enforce output-directory containment before writing normal and distributed safetensors shards

## Tests
- python3 AST syntax check for edited files
- git diff --check
- standalone validation check for safe symlinked source shard and invalid filename cases

## Not run
- uv run pre-commit run --all-files: blocked on macOS arm64 because nvidia-resiliency-ext==0.6.0 only provides Linux wheels
- uv run python -m pytest tests/unit_tests/models/hf_pretrained/test_state_dict.py -k "SafeTensorsStateSourceSave or index_file_parsing": same dependency resolution blocker