### PR TITLE
fix(kimi-vl): require trusted remote code for vision modules

### DIFF
--- a/src/megatron/bridge/models/kimi_vl/kimi_k25_vl_bridge.py
+++ b/src/megatron/bridge/models/kimi_vl/kimi_k25_vl_bridge.py
@@ -128,6 +128,7 @@ class KimiK25VLBridge(MegatronModelBridge):
         # VL-specific overrides
         provider.vision_config = vision_config
         provider.hf_model_path = hf_pretrained._model_name_or_path
+        provider.trust_remote_code = bool(getattr(hf_pretrained, "trust_remote_code", False))
         provider.generation_config = hf_pretrained.generation_config
 
         # media_placeholder_token_id is on the top-level KimiK25Config, not on text_config

--- a/src/megatron/bridge/models/kimi_vl/kimi_k25_vl_provider.py
+++ b/src/megatron/bridge/models/kimi_vl/kimi_k25_vl_provider.py
@@ -48,6 +48,9 @@ class KimiK25VLModelProvider(MLAModelProvider):
     # of MoonViT3d, PatchMergerMLP, and other custom model classes).
     hf_model_path: Optional[str] = None
 
+    # Whether loading the custom Kimi vision module from hf_model_path is allowed.
+    trust_remote_code: bool = False
+
     # Token IDs (from Kimi K2.5 config.json)
     bos_token_id: int = 163584
     eos_token_id: int = 163585

--- a/src/megatron/bridge/models/kimi_vl/modeling_kimi_k25_vl.py
+++ b/src/megatron/bridge/models/kimi_vl/modeling_kimi_k25_vl.py
@@ -103,10 +103,18 @@ class KimiK25VLModel(MegatronModule):
             raise ValueError("hf_model_path must be set.")
 
         if pre_process:
+            trust_remote_code = bool(getattr(config, "trust_remote_code", False))
+            if not trust_remote_code:
+                raise ValueError(
+                    "Kimi K2.5 VL vision components require loading custom HuggingFace model code. "
+                    "Pass trust_remote_code=True only for trusted model repositories."
+                )
+
             # Load vision tower and projector classes from the custom HuggingFace model code
             MoonViT3dPretrainedModel = get_class_from_dynamic_module(
                 "modeling_kimi_k25.MoonViT3dPretrainedModel",
                 config.hf_model_path,
+                trust_remote_code=trust_remote_code,
             )
             # Patch MoonViT3dEncoder to add missing use_deterministic_attn attribute
             import importlib
@@ -126,21 +134,24 @@ class KimiK25VLModel(MegatronModule):
             PatchMergerMLP = get_class_from_dynamic_module(
                 "modeling_kimi_k25.PatchMergerMLP",
                 config.hf_model_path,
+                trust_remote_code=trust_remote_code,
             )
             ProjectorConfig = get_class_from_dynamic_module(
                 "modeling_kimi_k25.ProjectorConfig",
                 config.hf_model_path,
+                trust_remote_code=trust_remote_code,
             )
             VisionTowerConfig = get_class_from_dynamic_module(
                 "modeling_kimi_k25.VisionTowerConfig",
                 config.hf_model_path,
+                trust_remote_code=trust_remote_code,
             )
 
             # load vision config from hf model path
             from megatron.bridge.models.hf_pretrained.safe_config_loader import safe_load_config_with_retry
 
             config.vision_config = safe_load_config_with_retry(
-                config.hf_model_path, trust_remote_code=True
+                config.hf_model_path, trust_remote_code=trust_remote_code
             ).vision_config
 
             self.vision_tower_config = VisionTowerConfig(config.vision_config)
@@ -152,6 +163,7 @@ class KimiK25VLModel(MegatronModule):
             MoonViT3dEncoder = get_class_from_dynamic_module(
                 "modeling_kimi_k25.MoonViT3dEncoder",
                 config.hf_model_path,
+                trust_remote_code=trust_remote_code,
             )
             if not hasattr(MoonViT3dEncoder, "use_deterministic_attn"):
                 MoonViT3dEncoder.use_deterministic_attn = False

--- a/tests/unit_tests/models/kimi_vl/test_kimi_k25_vl_bridge.py
+++ b/tests/unit_tests/models/kimi_vl/test_kimi_k25_vl_bridge.py
@@ -122,6 +122,7 @@ def mock_hf_pretrained(mock_hf_config):
     pretrained = Mock(spec=PreTrainedVLM)
     pretrained.config = mock_hf_config
     pretrained._model_name_or_path = "/path/to/kimi_k25_vl"
+    pretrained.trust_remote_code = False
     pretrained.generation_config = None
     return pretrained
 
@@ -206,6 +207,19 @@ class TestKimiK25VLBridgeProviderBridge:
         """Test HF model path is stored on provider."""
         provider = kimi_bridge.provider_bridge(mock_hf_pretrained)
         assert provider.hf_model_path == "/path/to/kimi_k25_vl"
+
+    def test_provider_bridge_trust_remote_code_default(self, kimi_bridge, mock_hf_pretrained):
+        """Test remote code trust is disabled by default."""
+        provider = kimi_bridge.provider_bridge(mock_hf_pretrained)
+        assert provider.trust_remote_code is False
+
+    def test_provider_bridge_trust_remote_code_propagates(self, kimi_bridge, mock_hf_pretrained):
+        """Test remote code trust is propagated from the HF wrapper."""
+        mock_hf_pretrained.trust_remote_code = True
+
+        provider = kimi_bridge.provider_bridge(mock_hf_pretrained)
+
+        assert provider.trust_remote_code is True
 
     def test_provider_bridge_different_hidden_sizes(self, kimi_bridge, mock_hf_pretrained):
         """Test provider_bridge with different hidden sizes."""

--- a/tests/unit_tests/models/kimi_vl/test_kimi_k25_vl_provider.py
+++ b/tests/unit_tests/models/kimi_vl/test_kimi_k25_vl_provider.py
@@ -39,6 +39,7 @@ class TestKimiK25VLModelProvider:
         assert provider.freeze_language_model is False
         assert provider.freeze_vision_model is False
         assert provider.freeze_vision_projection is False
+        assert provider.trust_remote_code is False
 
     def test_token_id_defaults(self, mock_vision_config):
         """Test token ID defaults."""

--- a/tests/unit_tests/models/kimi_vl/test_modeling_kimi_k25_vl.py
+++ b/tests/unit_tests/models/kimi_vl/test_modeling_kimi_k25_vl.py
@@ -368,6 +368,7 @@ class TestKimiK25VLModelInit:
         """Create mock config for model init."""
         config = Mock()
         config.hf_model_path = "/path/to/model"
+        config.trust_remote_code = True
         config.share_embeddings_and_output_weights = False
         config.sequence_parallel = False
         config.media_placeholder_token_id = IMAGE_TOKEN_ID
@@ -399,7 +400,9 @@ class TestKimiK25VLModelInit:
         mock_vit = Mock()
         mock_projector = Mock()
 
-        def side_effect(name, path):
+        def side_effect(name, path, **kwargs):
+            assert path == config.hf_model_path
+            assert kwargs == {"trust_remote_code": True}
             if "MoonViT3dPretrainedModel" in name:
                 cls = Mock(return_value=mock_vit)
                 cls.__module__ = "test_module"
@@ -426,10 +429,25 @@ class TestKimiK25VLModelInit:
         assert hasattr(model, "vision_tower")
         assert hasattr(model, "mm_projector")
         assert hasattr(model, "language_model")
+        mock_safe_load.assert_called_once_with(config.hf_model_path, trust_remote_code=True)
+
+    @patch("megatron.bridge.models.kimi_vl.modeling_kimi_k25_vl.get_class_from_dynamic_module")
+    def test_init_rejects_remote_code_without_trust(self, mock_get_class):
+        """Test initialization fails closed before loading remote Kimi vision code."""
+        config = self._make_mock_config()
+        config.trust_remote_code = False
+
+        from megatron.bridge.models.kimi_vl.modeling_kimi_k25_vl import KimiK25VLModel
+
+        with pytest.raises(ValueError, match="trust_remote_code=True"):
+            KimiK25VLModel(config=config, pre_process=True, post_process=True)
+
+        mock_get_class.assert_not_called()
 
     def test_init_without_pre_process(self):
         """Test initialization with pre_process=False skips vision components."""
         config = self._make_mock_config()
+        config.trust_remote_code = False
 
         from megatron.bridge.models.kimi_vl.modeling_kimi_k25_vl import KimiK25VLModel
 


### PR DESCRIPTION
# What does this PR do ?

Hardens Kimi K2.5 VL model construction so custom Hugging Face vision module code is loaded only when the caller explicitly opted in with `trust_remote_code=True`.

# Changelog

- Propagate the HF wrapper's `trust_remote_code` setting onto `KimiK25VLModelProvider`.
- Fail closed before Kimi vision dynamic-module loading when `trust_remote_code` is not enabled.
- Pass the explicit trust setting through Kimi dynamic class loading and config loading.
- Add focused unit coverage for default-deny and explicit-opt-in behavior.

# Testing

- `uvx ruff format --check src/megatron/bridge/models/kimi_vl/kimi_k25_vl_provider.py src/megatron/bridge/models/kimi_vl/kimi_k25_vl_bridge.py src/megatron/bridge/models/kimi_vl/modeling_kimi_k25_vl.py tests/unit_tests/models/kimi_vl/test_kimi_k25_vl_bridge.py tests/unit_tests/models/kimi_vl/test_kimi_k25_vl_provider.py tests/unit_tests/models/kimi_vl/test_modeling_kimi_k25_vl.py`
- `uvx ruff check src/megatron/bridge/models/kimi_vl/kimi_k25_vl_provider.py src/megatron/bridge/models/kimi_vl/kimi_k25_vl_bridge.py src/megatron/bridge/models/kimi_vl/modeling_kimi_k25_vl.py tests/unit_tests/models/kimi_vl/test_kimi_k25_vl_bridge.py tests/unit_tests/models/kimi_vl/test_kimi_k25_vl_provider.py tests/unit_tests/models/kimi_vl/test_modeling_kimi_k25_vl.py`
- `git diff --check`

`uv run pre-commit run --all-files` was attempted, but this macOS arm64 environment cannot install `nvidia-resiliency-ext==0.6.0`, which only publishes Linux wheels. Targeted pytest should be run in the Linux/CW environment.

# Additional Information

No public issue.
