### PR TITLE
feat(glm): add GLM5 indexer LoRA targets

### DIFF
--- a/src/megatron/bridge/models/__init__.py
+++ b/src/megatron/bridge/models/__init__.py
@@ -67,7 +67,6 @@ from megatron.bridge.models.glm import (
 from megatron.bridge.models.glm_moe_dsa import (
     GLM5Bridge,
     GLM5LoRA,
-    glm5_lora_target_modules,
 )
 from megatron.bridge.models.glm_vl import (
     GLM45VBridge,
@@ -206,7 +205,6 @@ __all__ = [
     "GLM47FlashBridge",
     "GLM5Bridge",
     "GLM5LoRA",
-    "glm5_lora_target_modules",
     "GLM45VBridge",
     "GLM45VModelProvider",
     "GPTModelProvider",

--- a/src/megatron/bridge/models/__init__.py
+++ b/src/megatron/bridge/models/__init__.py
@@ -66,6 +66,8 @@ from megatron.bridge.models.glm import (
 )
 from megatron.bridge.models.glm_moe_dsa import (
     GLM5Bridge,
+    GLM5LoRA,
+    glm5_lora_target_modules,
 )
 from megatron.bridge.models.glm_vl import (
     GLM45VBridge,
@@ -203,6 +205,8 @@ __all__ = [
     "GLM45Bridge",
     "GLM47FlashBridge",
     "GLM5Bridge",
+    "GLM5LoRA",
+    "glm5_lora_target_modules",
     "GLM45VBridge",
     "GLM45VModelProvider",
     "GPTModelProvider",

--- a/src/megatron/bridge/models/glm_moe_dsa/__init__.py
+++ b/src/megatron/bridge/models/glm_moe_dsa/__init__.py
@@ -12,9 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from megatron.bridge.models.glm_moe_dsa.glm5_bridge import GLM5Bridge
+from megatron.bridge.models.glm_moe_dsa.glm5_bridge import (
+    GLM5_DSA_INDEXER_LORA_TARGET_MODULES,
+    GLM5_MLA_LORA_TARGET_MODULES,
+    GLM5_MLP_LORA_TARGET_MODULES,
+    GLM5_ROUTER_LORA_TARGET_MODULES,
+    GLM5Bridge,
+    GLM5LoRA,
+    glm5_lora_target_modules,
+)
 
 
 __all__ = [
     "GLM5Bridge",
+    "GLM5LoRA",
+    "GLM5_DSA_INDEXER_LORA_TARGET_MODULES",
+    "GLM5_MLA_LORA_TARGET_MODULES",
+    "GLM5_MLP_LORA_TARGET_MODULES",
+    "GLM5_ROUTER_LORA_TARGET_MODULES",
+    "glm5_lora_target_modules",
 ]

--- a/src/megatron/bridge/models/glm_moe_dsa/__init__.py
+++ b/src/megatron/bridge/models/glm_moe_dsa/__init__.py
@@ -13,22 +13,12 @@
 # limitations under the License.
 
 from megatron.bridge.models.glm_moe_dsa.glm5_bridge import (
-    GLM5_DSA_INDEXER_LORA_TARGET_MODULES,
-    GLM5_MLA_LORA_TARGET_MODULES,
-    GLM5_MLP_LORA_TARGET_MODULES,
-    GLM5_ROUTER_LORA_TARGET_MODULES,
     GLM5Bridge,
     GLM5LoRA,
-    glm5_lora_target_modules,
 )
 
 
 __all__ = [
     "GLM5Bridge",
     "GLM5LoRA",
-    "GLM5_DSA_INDEXER_LORA_TARGET_MODULES",
-    "GLM5_MLA_LORA_TARGET_MODULES",
-    "GLM5_MLP_LORA_TARGET_MODULES",
-    "GLM5_ROUTER_LORA_TARGET_MODULES",
-    "glm5_lora_target_modules",
 ]

--- a/src/megatron/bridge/models/glm_moe_dsa/glm5_bridge.py
+++ b/src/megatron/bridge/models/glm_moe_dsa/glm5_bridge.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+from dataclasses import dataclass, field
 
 from megatron.core.models.gpt.gpt_model import GPTModel
 from transformers import GlmMoeDsaForCausalLM
@@ -26,9 +27,124 @@ from megatron.bridge.models.conversion.param_mapping import (
 )
 from megatron.bridge.models.hf_pretrained.causal_lm import PreTrainedCausalLM
 from megatron.bridge.models.mla_provider import MLAModelProvider
+from megatron.bridge.peft.lora import LoRA
 
 
 logger = logging.getLogger(__name__)
+
+GLM5_MLA_LORA_TARGET_MODULES = [
+    "linear_q_down_proj",
+    "linear_q_up_proj",
+    "linear_kv_down_proj",
+    "linear_kv_up_proj",
+    "linear_proj",
+]
+GLM5_MLP_LORA_TARGET_MODULES = ["linear_fc1", "linear_fc2"]
+GLM5_DSA_INDEXER_LORA_TARGET_MODULES = [
+    "linear_wq_b",
+    "linear_wk",
+    "linear_weights_proj",
+]
+GLM5_ROUTER_LORA_TARGET_MODULES = ["router"]
+
+_GLM5_LORA_TARGET_MODULE_ALIASES = {
+    # Hugging Face / SGLang names -> Megatron-Core module names.
+    "q_a_proj": "linear_q_down_proj",
+    "q_b_proj": "linear_q_up_proj",
+    "kv_a_proj_with_mqa": "linear_kv_down_proj",
+    "kv_b_proj": "linear_kv_up_proj",
+    "o_proj": "linear_proj",
+    "gate_proj": "linear_fc1",
+    "up_proj": "linear_fc1",
+    "down_proj": "linear_fc2",
+    "indexer.wq_b": "indexer.linear_wq_b",
+    "wq_b": "linear_wq_b",
+    "indexer.wk": "indexer.linear_wk",
+    "wk": "linear_wk",
+    "indexer.weights_proj": "indexer.linear_weights_proj",
+    "weights_proj": "linear_weights_proj",
+}
+
+
+def glm5_lora_target_modules(
+    *,
+    include_mla: bool = True,
+    include_mlp: bool = True,
+    include_indexer: bool = True,
+    include_router: bool = False,
+) -> list[str]:
+    """Return Megatron-Core module names for GLM5 LoRA targeting.
+
+    Args:
+        include_mla: Include GLM5 MLA attention projection linears.
+        include_mlp: Include dense MLP, shared expert, and routed expert linears.
+        include_indexer: Include the DSA Indexer linears. The Indexer norm is
+            intentionally excluded because LoRA targets linear/router modules.
+        include_router: Include MoE router modules. Off by default to avoid
+            changing router behavior unless requested explicitly.
+
+    Returns:
+        Ordered list of Megatron-Core module names for ``LoRA.target_modules``.
+    """
+
+    target_modules: list[str] = []
+    if include_mla:
+        target_modules.extend(GLM5_MLA_LORA_TARGET_MODULES)
+    if include_mlp:
+        target_modules.extend(GLM5_MLP_LORA_TARGET_MODULES)
+    if include_indexer:
+        target_modules.extend(GLM5_DSA_INDEXER_LORA_TARGET_MODULES)
+    if include_router:
+        target_modules.extend(GLM5_ROUTER_LORA_TARGET_MODULES)
+    return target_modules
+
+
+def _glm5_lora_target_to_megatron(target: str) -> str:
+    """Translate GLM5 HF/SGLang target suffixes to Megatron-Core names."""
+
+    for alias, megatron_name in sorted(_GLM5_LORA_TARGET_MODULE_ALIASES.items(), key=lambda item: -len(item[0])):
+        if target == alias:
+            if "." in alias:
+                return f"*.{megatron_name}"
+            return megatron_name
+        if target.endswith(f".{alias}"):
+            return f"{target[: -len(alias)]}{megatron_name}"
+    return target
+
+
+@dataclass
+class GLM5LoRA(LoRA):
+    """LoRA preset for GLM5 / GLM5.1 / GLM5.2 MLA, MoE, and DSA Indexer modules.
+
+    The default target set follows the GLM5 architecture instead of Bridge's
+    generic QKV/MLP defaults. It also accepts Hugging Face and SGLang-style
+    suffixes such as ``wq_b``, ``wk``, and ``weights_proj`` by translating them
+    to Megatron-Core's ``linear_*`` module names before matching.
+    """
+
+    target_modules: list[str] = field(default_factory=glm5_lora_target_modules)
+
+    def __post_init__(self) -> None:
+        """Eagerly build alias mappings for callers that inspect them before use."""
+
+        self._init_target_match_state()
+
+    def _init_target_match_state(self) -> None:
+        """Build GLM5 target aliases from the current ``target_modules``."""
+
+        if not self.target_modules:
+            super()._init_target_match_state()
+            return
+
+        self.canonical_mapping.clear()
+        self._pattern_to_alias.clear()
+        self._alias_to_pattern.clear()
+        self._alias_matches.clear()
+
+        for target in self.target_modules:
+            megatron_target = _glm5_lora_target_to_megatron(target)
+            self.register_target_alias(target, megatron_target)
+            self.canonical_mapping[megatron_target].add(target)
 
 
 @MegatronModelBridge.register_bridge(

--- a/src/megatron/bridge/models/glm_moe_dsa/glm5_bridge.py
+++ b/src/megatron/bridge/models/glm_moe_dsa/glm5_bridge.py
@@ -47,24 +47,6 @@ GLM5_DSA_INDEXER_LORA_TARGET_MODULES = [
 ]
 GLM5_ROUTER_LORA_TARGET_MODULES = ["router"]
 
-_GLM5_LORA_TARGET_MODULE_ALIASES = {
-    # Hugging Face / SGLang names -> Megatron-Core module names.
-    "q_a_proj": "linear_q_down_proj",
-    "q_b_proj": "linear_q_up_proj",
-    "kv_a_proj_with_mqa": "linear_kv_down_proj",
-    "kv_b_proj": "linear_kv_up_proj",
-    "o_proj": "linear_proj",
-    "gate_proj": "linear_fc1",
-    "up_proj": "linear_fc1",
-    "down_proj": "linear_fc2",
-    "indexer.wq_b": "indexer.linear_wq_b",
-    "wq_b": "linear_wq_b",
-    "indexer.wk": "indexer.linear_wk",
-    "wk": "linear_wk",
-    "indexer.weights_proj": "indexer.linear_weights_proj",
-    "weights_proj": "linear_weights_proj",
-}
-
 
 def glm5_lora_target_modules(
     *,
@@ -99,52 +81,15 @@ def glm5_lora_target_modules(
     return target_modules
 
 
-def _glm5_lora_target_to_megatron(target: str) -> str:
-    """Translate GLM5 HF/SGLang target suffixes to Megatron-Core names."""
-
-    for alias, megatron_name in sorted(_GLM5_LORA_TARGET_MODULE_ALIASES.items(), key=lambda item: -len(item[0])):
-        if target == alias:
-            if "." in alias:
-                return f"*.{megatron_name}"
-            return megatron_name
-        if target.endswith(f".{alias}"):
-            return f"{target[: -len(alias)]}{megatron_name}"
-    return target
-
-
 @dataclass
 class GLM5LoRA(LoRA):
     """LoRA preset for GLM5 / GLM5.1 / GLM5.2 MLA, MoE, and DSA Indexer modules.
 
     The default target set follows the GLM5 architecture instead of Bridge's
-    generic QKV/MLP defaults. It also accepts Hugging Face and SGLang-style
-    suffixes such as ``wq_b``, ``wk``, and ``weights_proj`` by translating them
-    to Megatron-Core's ``linear_*`` module names before matching.
+    generic QKV/MLP defaults.
     """
 
     target_modules: list[str] = field(default_factory=glm5_lora_target_modules)
-
-    def __post_init__(self) -> None:
-        """Eagerly build alias mappings for callers that inspect them before use."""
-
-        self._init_target_match_state()
-
-    def _init_target_match_state(self) -> None:
-        """Build GLM5 target aliases from the current ``target_modules``."""
-
-        if not self.target_modules:
-            super()._init_target_match_state()
-            return
-
-        self.canonical_mapping.clear()
-        self._pattern_to_alias.clear()
-        self._alias_to_pattern.clear()
-        self._alias_matches.clear()
-
-        for target in self.target_modules:
-            megatron_target = _glm5_lora_target_to_megatron(target)
-            self.register_target_alias(target, megatron_target)
-            self.canonical_mapping[megatron_target].add(target)
 
 
 @MegatronModelBridge.register_bridge(

--- a/src/megatron/bridge/models/glm_moe_dsa/glm5_bridge.py
+++ b/src/megatron/bridge/models/glm_moe_dsa/glm5_bridge.py
@@ -32,53 +32,22 @@ from megatron.bridge.peft.lora import LoRA
 
 logger = logging.getLogger(__name__)
 
-GLM5_MLA_LORA_TARGET_MODULES = [
-    "linear_q_down_proj",
-    "linear_q_up_proj",
-    "linear_kv_down_proj",
-    "linear_kv_up_proj",
-    "linear_proj",
-]
-GLM5_MLP_LORA_TARGET_MODULES = ["linear_fc1", "linear_fc2"]
-GLM5_DSA_INDEXER_LORA_TARGET_MODULES = [
-    "linear_wq_b",
-    "linear_wk",
-    "linear_weights_proj",
-]
-GLM5_ROUTER_LORA_TARGET_MODULES = ["router"]
 
+def _glm5_lora_target_modules() -> list[str]:
+    """Return default Megatron-Core module names for GLM5 LoRA targeting."""
 
-def glm5_lora_target_modules(
-    *,
-    include_mla: bool = True,
-    include_mlp: bool = True,
-    include_indexer: bool = True,
-    include_router: bool = False,
-) -> list[str]:
-    """Return Megatron-Core module names for GLM5 LoRA targeting.
-
-    Args:
-        include_mla: Include GLM5 MLA attention projection linears.
-        include_mlp: Include dense MLP, shared expert, and routed expert linears.
-        include_indexer: Include the DSA Indexer linears. The Indexer norm is
-            intentionally excluded because LoRA targets linear/router modules.
-        include_router: Include MoE router modules. Off by default to avoid
-            changing router behavior unless requested explicitly.
-
-    Returns:
-        Ordered list of Megatron-Core module names for ``LoRA.target_modules``.
-    """
-
-    target_modules: list[str] = []
-    if include_mla:
-        target_modules.extend(GLM5_MLA_LORA_TARGET_MODULES)
-    if include_mlp:
-        target_modules.extend(GLM5_MLP_LORA_TARGET_MODULES)
-    if include_indexer:
-        target_modules.extend(GLM5_DSA_INDEXER_LORA_TARGET_MODULES)
-    if include_router:
-        target_modules.extend(GLM5_ROUTER_LORA_TARGET_MODULES)
-    return target_modules
+    return [
+        "linear_q_down_proj",
+        "linear_q_up_proj",
+        "linear_kv_down_proj",
+        "linear_kv_up_proj",
+        "linear_proj",
+        "linear_fc1",
+        "linear_fc2",
+        "linear_wq_b",
+        "linear_wk",
+        "linear_weights_proj",
+    ]
 
 
 @dataclass
@@ -89,7 +58,7 @@ class GLM5LoRA(LoRA):
     generic QKV/MLP defaults.
     """
 
-    target_modules: list[str] = field(default_factory=glm5_lora_target_modules)
+    target_modules: list[str] = field(default_factory=_glm5_lora_target_modules)
 
 
 @MegatronModelBridge.register_bridge(

--- a/tests/unit_tests/models/glm/test_glm5_peft.py
+++ b/tests/unit_tests/models/glm/test_glm5_peft.py
@@ -15,12 +15,7 @@
 import torch.nn as nn
 
 from megatron.bridge.models.glm_moe_dsa import (
-    GLM5_DSA_INDEXER_LORA_TARGET_MODULES,
-    GLM5_MLA_LORA_TARGET_MODULES,
-    GLM5_MLP_LORA_TARGET_MODULES,
-    GLM5_ROUTER_LORA_TARGET_MODULES,
     GLM5LoRA,
-    glm5_lora_target_modules,
 )
 from megatron.bridge.peft.lora_layers import LinearAdapter
 
@@ -79,22 +74,25 @@ class _FakeGLM5Model(nn.Module):
 
 
 def test_glm5_lora_target_modules_include_indexer_by_default():
-    target_modules = glm5_lora_target_modules()
+    target_modules = GLM5LoRA().target_modules
 
     assert target_modules == [
-        *GLM5_MLA_LORA_TARGET_MODULES,
-        *GLM5_MLP_LORA_TARGET_MODULES,
-        *GLM5_DSA_INDEXER_LORA_TARGET_MODULES,
+        "linear_q_down_proj",
+        "linear_q_up_proj",
+        "linear_kv_down_proj",
+        "linear_kv_up_proj",
+        "linear_proj",
+        "linear_fc1",
+        "linear_fc2",
+        "linear_wq_b",
+        "linear_wk",
+        "linear_weights_proj",
     ]
     assert "linear_wq_b" in target_modules
     assert "linear_wk" in target_modules
     assert "linear_weights_proj" in target_modules
     assert "k_norm" not in target_modules
-    assert GLM5_ROUTER_LORA_TARGET_MODULES[0] not in target_modules
-
-
-def test_glm5_lora_target_modules_can_include_router():
-    assert glm5_lora_target_modules(include_router=True)[-1] == GLM5_ROUTER_LORA_TARGET_MODULES[0]
+    assert "router" not in target_modules
 
 
 def test_glm5_lora_wraps_indexer_targets_and_excludes_norm():

--- a/tests/unit_tests/models/glm/test_glm5_peft.py
+++ b/tests/unit_tests/models/glm/test_glm5_peft.py
@@ -97,10 +97,10 @@ def test_glm5_lora_target_modules_can_include_router():
     assert glm5_lora_target_modules(include_router=True)[-1] == GLM5_ROUTER_LORA_TARGET_MODULES[0]
 
 
-def test_glm5_lora_wraps_indexer_alias_targets_and_excludes_norm():
+def test_glm5_lora_wraps_indexer_targets_and_excludes_norm():
     model = _FakeGLM5Model()
 
-    peft = GLM5LoRA(target_modules=["indexer.wq_b", "indexer.wk", "indexer.weights_proj"], dim=2, alpha=4)
+    peft = GLM5LoRA(target_modules=["linear_wq_b", "linear_wk", "linear_weights_proj"], dim=2, alpha=4)
     peft(model)
 
     indexer = model.decoder.layers[0].self_attention.core_attention.indexer

--- a/tests/unit_tests/models/glm/test_glm5_peft.py
+++ b/tests/unit_tests/models/glm/test_glm5_peft.py
@@ -1,0 +1,131 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch.nn as nn
+
+from megatron.bridge.models.glm_moe_dsa import (
+    GLM5_DSA_INDEXER_LORA_TARGET_MODULES,
+    GLM5_MLA_LORA_TARGET_MODULES,
+    GLM5_MLP_LORA_TARGET_MODULES,
+    GLM5_ROUTER_LORA_TARGET_MODULES,
+    GLM5LoRA,
+    glm5_lora_target_modules,
+)
+from megatron.bridge.peft.lora_layers import LinearAdapter
+
+
+class _FakeIndexer(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear_wq_b = nn.Linear(8, 8, bias=False)
+        self.linear_wk = nn.Linear(8, 8, bias=False)
+        self.k_norm = nn.LayerNorm(8)
+        self.linear_weights_proj = nn.Linear(8, 4, bias=False)
+
+
+class _FakeCoreAttention(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.indexer = _FakeIndexer()
+
+
+class _FakeSelfAttention(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear_q_down_proj = nn.Linear(8, 4, bias=False)
+        self.linear_q_up_proj = nn.Linear(4, 8, bias=False)
+        self.linear_kv_down_proj = nn.Linear(8, 4, bias=False)
+        self.linear_kv_up_proj = nn.Linear(4, 8, bias=False)
+        self.linear_proj = nn.Linear(8, 8, bias=False)
+        self.core_attention = _FakeCoreAttention()
+
+
+class _FakeMLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear_fc1 = nn.Linear(8, 16, bias=False)
+        self.linear_fc2 = nn.Linear(16, 8, bias=False)
+        self.router = nn.Linear(8, 4, bias=False)
+
+
+class _FakeLayer(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.self_attention = _FakeSelfAttention()
+        self.mlp = _FakeMLP()
+
+
+class _FakeDecoder(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.layers = nn.ModuleList([_FakeLayer()])
+
+
+class _FakeGLM5Model(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.decoder = _FakeDecoder()
+
+
+def test_glm5_lora_target_modules_include_indexer_by_default():
+    target_modules = glm5_lora_target_modules()
+
+    assert target_modules == [
+        *GLM5_MLA_LORA_TARGET_MODULES,
+        *GLM5_MLP_LORA_TARGET_MODULES,
+        *GLM5_DSA_INDEXER_LORA_TARGET_MODULES,
+    ]
+    assert "linear_wq_b" in target_modules
+    assert "linear_wk" in target_modules
+    assert "linear_weights_proj" in target_modules
+    assert "k_norm" not in target_modules
+    assert GLM5_ROUTER_LORA_TARGET_MODULES[0] not in target_modules
+
+
+def test_glm5_lora_target_modules_can_include_router():
+    assert glm5_lora_target_modules(include_router=True)[-1] == GLM5_ROUTER_LORA_TARGET_MODULES[0]
+
+
+def test_glm5_lora_wraps_indexer_alias_targets_and_excludes_norm():
+    model = _FakeGLM5Model()
+
+    peft = GLM5LoRA(target_modules=["indexer.wq_b", "indexer.wk", "indexer.weights_proj"], dim=2, alpha=4)
+    peft(model)
+
+    indexer = model.decoder.layers[0].self_attention.core_attention.indexer
+    assert isinstance(indexer.linear_wq_b, LinearAdapter)
+    assert isinstance(indexer.linear_wk, LinearAdapter)
+    assert isinstance(indexer.linear_weights_proj, LinearAdapter)
+    assert isinstance(indexer.k_norm, nn.LayerNorm)
+    assert not any(param.requires_grad for param in indexer.k_norm.parameters())
+
+
+def test_glm5_lora_wraps_default_mla_mlp_and_indexer_targets():
+    model = _FakeGLM5Model()
+
+    peft = GLM5LoRA(dim=2, alpha=4)
+    peft(model)
+
+    layer = model.decoder.layers[0]
+    assert isinstance(layer.self_attention.linear_q_down_proj, LinearAdapter)
+    assert isinstance(layer.self_attention.linear_q_up_proj, LinearAdapter)
+    assert isinstance(layer.self_attention.linear_kv_down_proj, LinearAdapter)
+    assert isinstance(layer.self_attention.linear_kv_up_proj, LinearAdapter)
+    assert isinstance(layer.self_attention.linear_proj, LinearAdapter)
+    assert isinstance(layer.self_attention.core_attention.indexer.linear_wq_b, LinearAdapter)
+    assert isinstance(layer.self_attention.core_attention.indexer.linear_wk, LinearAdapter)
+    assert isinstance(layer.self_attention.core_attention.indexer.linear_weights_proj, LinearAdapter)
+    assert isinstance(layer.mlp.linear_fc1, LinearAdapter)
+    assert isinstance(layer.mlp.linear_fc2, LinearAdapter)
+    assert isinstance(layer.mlp.router, nn.Linear)


### PR DESCRIPTION
## Summary
- add GLM5-specific LoRA target groups for MLA, MLP/MoE, DSA Indexer, and optional router targeting
- add `GLM5LoRA`, which defaults to MLA + MLP/MoE + Indexer linears and accepts HF/SGLang-style aliases such as `indexer.wq_b`, `indexer.wk`, and `indexer.weights_proj`
- add unit coverage that Indexer linears are wrapped and `k_norm` remains excluded

## Upstream research
- Hugging Face Transformers models GLM-MoE-DSA Indexer as trainable `wq_b`, `wk`, and `weights_proj` linear modules plus `k_norm`: https://github.com/huggingface/transformers/blob/main/src/transformers/models/glm_moe_dsa/modeling_glm_moe_dsa.py
- SGLang explicitly supports DSA Indexer LoRA targets via `DSA_INDEXER_LORA_NAMES = {indexer.wq_b, indexer.wk, indexer.weights_proj}`: https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/lora/utils.py
- VeOmni's GLM-MoE-DSA patch follows the same Indexer linear names and leaves `weights_proj` as a plain linear: https://github.com/ByteDance-Seed/VeOmni/blob/main/veomni/models/transformers/glm_moe_dsa/generated/patched_modeling_glm_moe_dsa_gpu.py
- HF PEFT supports explicit target module names / `all-linear`; I did not find a GLM-specific PEFT default in PEFT or Unsloth: https://github.com/huggingface/peft/blob/main/src/peft/tuners/lora/config.py

## Validation
- `uvx pre-commit run --all-files`
- `python3 -m py_compile src/megatron/bridge/models/glm_moe_dsa/glm5_bridge.py src/megatron/bridge/models/glm_moe_dsa/__init__.py src/megatron/bridge/models/__init__.py tests/unit_tests/models/glm/test_glm5_peft.py`

## Notes
- Local pytest could not run on this macOS ARM host because `uv run` cannot install Linux-only `nvidia-resiliency-ext==0.6.0`, and `UV_NO_SYNC=1` lacks Torch/PyTest in the local venv.
- I did not find `cw`/`cws` installed in this workspace, so CW validation still needs to run from an environment with that launcher.
