### PR TITLE
Support MegatronMIMO encoder DP slicing for packed visual input

### DIFF
--- a/src/megatron/bridge/data/megatron_mimo/dp_utils.py
+++ b/src/megatron/bridge/data/megatron_mimo/dp_utils.py
@@ -25,6 +25,87 @@ def _batch_dim_for_tensor(key: str, value: torch.Tensor) -> int:
     return 0
 
 
+def _is_patch_packed_visual_dict(value: Any) -> bool:
+    """Detect a patch-packed visual encoder input layout.
+
+    Some VLM adapters pack all image patches for a microbatch into one flat
+    tensor while keeping per-image grid metadata:
+
+    - ``hidden_states``: ``[sum(patches_across_images), patch_feature_dim]``
+    - ``grid_thw``:      ``[num_images, 3]``
+
+    Dim 0 of these two tensors means different things (patches vs images), so
+    they cannot be sliced independently by DP. They must be sliced jointly
+    along the per-image boundary.
+    """
+    return (
+        isinstance(value, dict)
+        and isinstance(value.get("hidden_states"), torch.Tensor)
+        and isinstance(value.get("grid_thw"), torch.Tensor)
+        and value["hidden_states"].dim() >= 1
+        and value["grid_thw"].dim() == 2
+        and value["grid_thw"].size(-1) == 3
+    )
+
+
+def _slice_patch_packed_visual_dict(value: Dict[str, Any], dp_rank: int, dp_size: int) -> Dict[str, Any]:
+    """Joint-slice a patch-packed ``{hidden_states, grid_thw, ...}`` dict.
+
+    Shards by image count, then derives the corresponding patch range from
+    ``cumsum(grid_thw.prod(dim=-1))``. Other keys in the dict are passed
+    through unchanged because they are treated as global encoder metadata.
+
+    Constraints:
+
+    - ``num_images`` (rows of ``grid_thw``) must be divisible by ``dp_size``.
+      For the encoder rank, ``num_images_per_microbatch`` is set by the
+      training-time MIMO MBS and the dataset's images-per-sample. With
+      single-image-per-sample data and MIMO ``MICRO_BATCH_SIZE`` divisible by
+      encoder ``DP``, this always holds.
+
+    TODO(mimo): This convention slices by image row. Multi-image samples with
+    uneven image counts need explicit per-sample image split metadata so DP
+    slices remain sample-aligned instead of only image-aligned.
+    """
+    g = value["grid_thw"]  # [num_images, 3]
+    hs = value["hidden_states"]  # [sum(patches), feat]
+    n_images = int(g.size(0))
+    if n_images % dp_size != 0:
+        raise ValueError(
+            f"Patch-packed visual input has num_images_in_microbatch ({n_images}) "
+            f"is not divisible by encoder DP ({dp_size}). Set MIMO MICRO_BATCH_SIZE "
+            f"so that each encoder DP shard receives a whole number of images."
+        )
+    imgs_per_shard = n_images // dp_size
+    img_lo = dp_rank * imgs_per_shard
+    img_hi = img_lo + imgs_per_shard
+
+    patches_per_image = g.prod(dim=-1).to(torch.long)  # [num_images]
+    total_patches = int(patches_per_image.sum().item())
+    if int(hs.size(0)) != total_patches:
+        raise ValueError(
+            f"Patch-packed visual input expected hidden_states dim 0 ({hs.size(0)}) "
+            f"to equal sum(grid_thw products) ({total_patches})."
+        )
+    patch_offsets = torch.zeros(n_images + 1, dtype=torch.long, device=patches_per_image.device)
+    patch_offsets[1:] = patches_per_image.cumsum(0)
+    patch_lo = int(patch_offsets[img_lo].item())
+    patch_hi = int(patch_offsets[img_hi].item())
+
+    out: Dict[str, Any] = {}
+    for key, sub_value in value.items():
+        if key == "grid_thw":
+            out[key] = g[img_lo:img_hi].contiguous()
+        elif key == "hidden_states":
+            out[key] = hs[patch_lo:patch_hi].contiguous()
+        else:
+            # Other entries (encoder kwargs, attention masks, etc.) are
+            # passed through as global metadata - same convention as the
+            # outer slicer's "non-divisible list" branch.
+            out[key] = sub_value
+    return out
+
+
 def _find_rank_module(
     grids: Dict[str, "HyperCommGrid"],
 ) -> Tuple["HyperCommGrid | None", "str | None"]:
@@ -171,8 +252,14 @@ def slice_batch_for_megatron_mimo(
             index[batch_dim] = builtins.slice(start_idx, end_idx)
             sliced[key] = value[tuple(index)]
         elif isinstance(value, dict):
-            # Recurse into nested dicts (e.g. modality_inputs)
-            sliced[key] = slice_batch_for_megatron_mimo(value, dp_rank, dp_size)
+            # Patch-packed visual encoder inputs use dim 0 for different units
+            # across fields (patches for hidden_states, images for grid_thw), so
+            # they need joint slicing instead of normal recursive tensor slicing.
+            if _is_patch_packed_visual_dict(value):
+                sliced[key] = _slice_patch_packed_visual_dict(value, dp_rank, dp_size)
+            else:
+                # Recurse into nested dicts (e.g. modality_inputs)
+                sliced[key] = slice_batch_for_megatron_mimo(value, dp_rank, dp_size)
         elif isinstance(value, list) and len(value) > 0:
             list_len = len(value)
             if list_len % dp_size == 0:

--- a/src/megatron/bridge/data/megatron_mimo/dp_utils.py
+++ b/src/megatron/bridge/data/megatron_mimo/dp_utils.py
@@ -37,6 +37,9 @@ def _is_patch_packed_visual_dict(value: Any) -> bool:
     Dim 0 of these two tensors means different things (patches vs images), so
     they cannot be sliced independently by DP. They must be sliced jointly
     along the per-image boundary.
+
+    TODO(mimo): This is very model-specific. We should revisit this to make it more generic.
+    maybe it should be handled by the model itself that defines how to slice the data.
     """
     return (
         isinstance(value, dict)

--- a/tests/unit_tests/data/megatron_mimo/test_dp_utils.py
+++ b/tests/unit_tests/data/megatron_mimo/test_dp_utils.py
@@ -262,3 +262,122 @@ class TestSliceBatchForMegatronMIMO:
         # This test documents that dp_size=1 early-return handles the common case.
         result = slice_batch_for_megatron_mimo({}, dp_rank=0, dp_size=1)
         assert result == {}
+
+
+class TestPatchPackedVisualSlice:
+    """Joint-slice for a patch-packed visual encoder dict.
+
+    Some visual adapters produce encoder dicts like:
+      - hidden_states: [sum(patches_across_images), feat]
+      - grid_thw:      [num_images, 3]
+
+    Naive dim-0 slicing corrupts the pair when per-image patch counts differ.
+    These tests verify the joint slicer keeps the pair consistent.
+    """
+
+    @staticmethod
+    def _make_batch(grids):
+        """Build a {modality_inputs: {images: {vision_encoder: {hidden_states, grid_thw}}}} batch.
+
+        ``grids`` is a list of (t, h, w) triples. Each image's hidden_states
+        rows are filled with its image index, so we can verify which image each
+        row came from after slicing.
+        """
+        grid_thw = torch.tensor(grids, dtype=torch.long)
+        patches_per_image = grid_thw.prod(dim=-1)
+        total_patches = int(patches_per_image.sum().item())
+        feat_dim = 4
+        hidden_states = torch.zeros(total_patches, feat_dim, dtype=torch.float32)
+        offset = 0
+        for img_idx, ppi in enumerate(patches_per_image.tolist()):
+            hidden_states[offset : offset + ppi].fill_(float(img_idx))
+            offset += ppi
+        return {
+            "modality_inputs": {
+                "images": {
+                    "vision_encoder": {
+                        "hidden_states": hidden_states,
+                        "grid_thw": grid_thw,
+                    }
+                }
+            }
+        }
+
+    def test_uniform_grid_dp2(self):
+        """Uniform grid: joint slice matches naive even split (regression-safe)."""
+        # 4 images, all (1, 4, 4): 16 patches each, 64 total.
+        batch = self._make_batch([(1, 4, 4)] * 4)
+        s0 = slice_batch_for_megatron_mimo(batch, dp_rank=0, dp_size=2)
+        s1 = slice_batch_for_megatron_mimo(batch, dp_rank=1, dp_size=2)
+
+        e0 = s0["modality_inputs"]["images"]["vision_encoder"]
+        e1 = s1["modality_inputs"]["images"]["vision_encoder"]
+
+        # grid_thw splits by image-count
+        assert e0["grid_thw"].shape == (2, 3)
+        assert e1["grid_thw"].shape == (2, 3)
+        # hidden_states splits by patch-count (= image-count * patches/image)
+        assert e0["hidden_states"].shape == (32, 4)
+        assert e1["hidden_states"].shape == (32, 4)
+        # Each rank's rows carry its image indices: rank 0 gets {0, 1}; rank 1 gets {2, 3}
+        assert set(e0["hidden_states"].unique().tolist()) == {0.0, 1.0}
+        assert set(e1["hidden_states"].unique().tolist()) == {2.0, 3.0}
+
+    def test_variable_grid_dp2(self):
+        """Variable grid: joint slice keeps hidden_states aligned with grid_thw."""
+        # Per-image patch counts: 4, 16, 9, 25; total 54 patches.
+        # Naive dim-0 split (54/2 = 27) would bisect mid-image. Joint slicer
+        # must split at image boundary: rank 0 gets images [0, 1], rank 1 gets [2, 3].
+        batch = self._make_batch([(1, 2, 2), (1, 4, 4), (1, 3, 3), (1, 5, 5)])
+        s0 = slice_batch_for_megatron_mimo(batch, dp_rank=0, dp_size=2)
+        s1 = slice_batch_for_megatron_mimo(batch, dp_rank=1, dp_size=2)
+
+        e0 = s0["modality_inputs"]["images"]["vision_encoder"]
+        e1 = s1["modality_inputs"]["images"]["vision_encoder"]
+
+        # 2 images per shard
+        assert e0["grid_thw"].shape == (2, 3)
+        assert e1["grid_thw"].shape == (2, 3)
+        # Rank 0: images 0+1 -> 4 + 16 = 20 patches
+        assert e0["hidden_states"].shape == (20, 4)
+        # Rank 1: images 2+3 -> 9 + 25 = 34 patches
+        assert e1["hidden_states"].shape == (34, 4)
+        # And each rank's patch rows correspond to its assigned images.
+        assert set(e0["hidden_states"].unique().tolist()) == {0.0, 1.0}
+        assert set(e1["hidden_states"].unique().tolist()) == {2.0, 3.0}
+
+    def test_dp4_with_variable_grids(self):
+        """4-way joint slice across 4 variable-size images."""
+        # 4 images, 4 different sizes: 1 image per shard at DP=4.
+        batch = self._make_batch([(1, 2, 2), (1, 4, 4), (1, 3, 3), (1, 5, 5)])
+        for rank in range(4):
+            sliced = slice_batch_for_megatron_mimo(batch, dp_rank=rank, dp_size=4)
+            enc = sliced["modality_inputs"]["images"]["vision_encoder"]
+            assert enc["grid_thw"].shape == (1, 3)
+            # Each rank's hidden_states is exactly that image's patches,
+            # all tagged with its image index.
+            expected_patches = int(enc["grid_thw"].prod().item())
+            assert enc["hidden_states"].shape == (expected_patches, 4)
+            assert enc["hidden_states"].unique().tolist() == [float(rank)]
+
+    def test_raises_when_num_images_not_divisible(self):
+        """3 images / DP=2 should raise with a clear error."""
+        batch = self._make_batch([(1, 2, 2), (1, 3, 3), (1, 4, 4)])
+        with pytest.raises(ValueError, match="not divisible by encoder DP"):
+            slice_batch_for_megatron_mimo(batch, dp_rank=0, dp_size=2)
+
+    def test_raises_when_patch_count_mismatch(self):
+        """hidden_states dim 0 must match the patch count implied by grid_thw."""
+        batch = self._make_batch([(1, 2, 2), (1, 3, 3)])
+        batch["modality_inputs"]["images"]["vision_encoder"]["hidden_states"] = torch.zeros(12, 4)
+        with pytest.raises(ValueError, match="sum\\(grid_thw products\\)"):
+            slice_batch_for_megatron_mimo(batch, dp_rank=0, dp_size=2)
+
+    def test_extra_keys_passed_through(self):
+        """Encoder dicts may carry other entries (kwargs, masks), and they pass through unchanged."""
+        batch = self._make_batch([(1, 2, 2), (1, 3, 3)])
+        # Inject a non-(hidden_states/grid_thw) entry. It should not be sliced.
+        batch["modality_inputs"]["images"]["vision_encoder"]["encoder_meta"] = "fixed-string"
+        sliced = slice_batch_for_megatron_mimo(batch, dp_rank=0, dp_size=2)
+        enc = sliced["modality_inputs"]["images"]["vision_encoder"]
+        assert enc["encoder_meta"] == "fixed-string"


### PR DESCRIPTION
 ## Summary
  - Add joint DP slicing for patch-packed visual encoder inputs with `hidden_states` flattened by patch and `grid_thw` stored per image.
  - Preserve image-boundary alignment when encoder DP > 1 and image grids have variable patch counts.
  - Add unit coverage for uniform grids, variable grids, DP4 slicing, invalid image splits, patch-count mismatch, and metadata passthrough.