### PR TITLE
[model] fix: adapt Gemma4 PLE recompute to MCore dev

### DIFF
--- a/src/megatron/bridge/diffusion/models/common/dit_attention.py
+++ b/src/megatron/bridge/diffusion/models/common/dit_attention.py
@@ -102,10 +102,20 @@ class DiTSelfAttention(SelfAttention):  # noqa: D101
         else:
             self.k_layernorm = None
 
-    def get_query_key_value_tensors(self, hidden_states, key_value_states=None, output_gate=None, split_qkv=True):
+    def get_query_key_value_tensors(
+        self,
+        hidden_states,
+        key_value_states=None,
+        output_gate=None,
+        split_qkv=True,
+        head_wise_gate=False,
+    ):
         """
         Derives `query`, `key` and `value` tensors from `hidden_states`.
         """
+        if head_wise_gate:
+            raise ValueError("DiTSelfAttention does not support head_wise_attn_gate.")
+
         # Attention heads [sq, b, h] --> [sq, b, ng * (np/ng + 2) * hn)]
         mixed_qkv, _ = self.linear_qkv(hidden_states)
 
@@ -256,14 +266,25 @@ class DiTCrossAttention(CrossAttention):  # noqa: D101
             name=(name + ".linear_kv") if name is not None else None,
         )
 
-    def get_query_key_value_tensors(self, hidden_states, key_value_states, output_gate=None, split_qkv=True):
+    def get_query_key_value_tensors(
+        self,
+        hidden_states,
+        key_value_states,
+        output_gate=None,
+        split_qkv=True,
+        head_wise_gate=False,
+    ):
         """
         Derives `query` tensor from `hidden_states`, and `key`/`value` tensors
         from `key_value_states`.
         """
 
         query, key, value = super().get_query_key_value_tensors(
-            hidden_states, key_value_states, output_gate=output_gate, split_qkv=split_qkv
+            hidden_states,
+            key_value_states,
+            output_gate=output_gate,
+            split_qkv=split_qkv,
+            head_wise_gate=head_wise_gate,
         )
 
         # gather query and key heads across TP ranks if self.layernorm_across_heads is True

--- a/src/megatron/bridge/diffusion/models/common/dit_attention.py
+++ b/src/megatron/bridge/diffusion/models/common/dit_attention.py
@@ -15,6 +15,7 @@
 # pylint: disable=C0115,C0116,C0301
 
 import copy
+import inspect
 from dataclasses import dataclass
 from typing import Union
 
@@ -29,6 +30,23 @@ from megatron.core.transformer.attention import (
 from megatron.core.transformer.enums import AttnMaskType
 from megatron.core.transformer.spec_utils import ModuleSpec, build_module
 from megatron.core.transformer.transformer_config import TransformerConfig
+
+
+def _method_supports_keyword(method, keyword: str) -> bool:
+    try:
+        signature = inspect.signature(method)
+    except (TypeError, ValueError):
+        return False
+
+    return keyword in signature.parameters or any(
+        parameter.kind is inspect.Parameter.VAR_KEYWORD for parameter in signature.parameters.values()
+    )
+
+
+_CROSS_ATTENTION_SUPPORTS_HEAD_WISE_GATE = _method_supports_keyword(
+    CrossAttention.get_query_key_value_tensors,
+    "head_wise_gate",
+)
 
 
 @dataclass
@@ -279,12 +297,20 @@ class DiTCrossAttention(CrossAttention):  # noqa: D101
         from `key_value_states`.
         """
 
+        if head_wise_gate:
+            raise ValueError("DiTCrossAttention does not support head_wise_attn_gate.")
+
+        super_kwargs = {
+            "output_gate": output_gate,
+            "split_qkv": split_qkv,
+        }
+        if _CROSS_ATTENTION_SUPPORTS_HEAD_WISE_GATE:
+            super_kwargs["head_wise_gate"] = head_wise_gate
+
         query, key, value = super().get_query_key_value_tensors(
             hidden_states,
             key_value_states,
-            output_gate=output_gate,
-            split_qkv=split_qkv,
-            head_wise_gate=head_wise_gate,
+            **super_kwargs,
         )
 
         # gather query and key heads across TP ranks if self.layernorm_across_heads is True

--- a/src/megatron/bridge/models/deepseek/deepseek_v4_bridge.py
+++ b/src/megatron/bridge/models/deepseek/deepseek_v4_bridge.py
@@ -105,10 +105,21 @@ _DSV4_COMPRESS_RATIO_TO_LAYER_TYPE = {
 def deepseek_v4_supports_blackwell_fused_kernels() -> bool:
     """Return whether DSv4 Blackwell-only fused kernels should default on."""
     if not torch.cuda.is_available():
-        return True
+        return False
 
     major, _minor = torch.cuda.get_device_capability()
     return major >= 10
+
+
+def deepseek_v4_supports_fused_dsa_kernels() -> bool:
+    """Return whether DSv4 fused DSA kernels can be enabled."""
+    try:
+        from cudnn import DSA  # noqa: F401
+        from flash_mla import flash_mla_sparse_fwd  # noqa: F401
+    except ImportError:
+        return False
+
+    return True
 
 
 def set_deepseek_v4_pipeline_model_parallel_layout(model_cfg: MLAModelProvider) -> None:
@@ -380,6 +391,7 @@ class DeepSeekV4Bridge(MegatronModelBridge):
         provider = super().provider_bridge(hf_pretrained)
         hf_config = hf_pretrained.config
         use_blackwell_fused_kernels = deepseek_v4_supports_blackwell_fused_kernels()
+        use_dsa_kernel_fusion = use_blackwell_fused_kernels and deepseek_v4_supports_fused_dsa_kernels()
 
         # ---- Attention ----
         provider.experimental_attention_variant = "dsv4_hybrid"
@@ -457,7 +469,7 @@ class DeepSeekV4Bridge(MegatronModelBridge):
         provider.dsa_indexer_n_heads = hf_config.index_n_heads  # 64
         provider.dsa_indexer_head_dim = hf_config.index_head_dim  # 128
         provider.dsa_indexer_topk = hf_config.index_topk  # 512
-        provider.apply_dsa_kernel_fusion = use_blackwell_fused_kernels
+        provider.apply_dsa_kernel_fusion = use_dsa_kernel_fusion
 
         # ---- Hyper-Connections (mHC) ----
         provider.enable_hyper_connections = True

--- a/src/megatron/bridge/models/gemma/modeling_gemma4.py
+++ b/src/megatron/bridge/models/gemma/modeling_gemma4.py
@@ -28,6 +28,7 @@ MoE layer specification:
 """
 
 import copy
+import inspect
 import types
 import weakref
 from dataclasses import dataclass
@@ -898,6 +899,19 @@ def _gemma4_layer_input(
     return per_layer_inputs[:, :, global_layer_idx, :].transpose(0, 1)
 
 
+def _gemma4_layer_accepts_input_ids(layer: "torch.nn.Module") -> bool:
+    forward_attention = getattr(layer, "_forward_attention", None)
+    if forward_attention is None:
+        return False
+    try:
+        parameters = inspect.signature(forward_attention).parameters
+    except (TypeError, ValueError):
+        return False
+    return "input_ids" in parameters or any(
+        parameter.kind == inspect.Parameter.VAR_KEYWORD for parameter in parameters.values()
+    )
+
+
 def _gemma4_checkpointed_forward(
     self: "torch.nn.Module",
     hidden_states: Tensor,
@@ -965,7 +979,11 @@ def _gemma4_checkpointed_forward(
                     padding_mask=padding_mask,
                     per_layer_input=_gemma4_layer_input(per_layer_inputs, layer),
                 )
-                if input_ids is not None:
+                if (
+                    input_ids is not None
+                    and isinstance(layer, TransformerLayer)
+                    and _gemma4_layer_accepts_input_ids(layer)
+                ):
                     layer_kwargs["input_ids"] = input_ids
                 with inner_quantization_context:
                     if isinstance(layer, TransformerLayer):

--- a/src/megatron/bridge/models/gemma/modeling_gemma4.py
+++ b/src/megatron/bridge/models/gemma/modeling_gemma4.py
@@ -911,6 +911,7 @@ def _gemma4_checkpointed_forward(
     padding_mask: "Optional[Tensor]" = None,
     extract_layer_indices: "Optional[set[int]]" = None,
     layer_offset: int = 0,
+    input_ids: "Optional[Tensor]" = None,
     per_layer_inputs: "Optional[Tensor]" = None,
 ):
     """MCore recompute helper variant that carries Gemma4 PLE through checkpoint args."""
@@ -964,6 +965,8 @@ def _gemma4_checkpointed_forward(
                     padding_mask=padding_mask,
                     per_layer_input=_gemma4_layer_input(per_layer_inputs, layer),
                 )
+                if input_ids is not None:
+                    layer_kwargs["input_ids"] = input_ids
                 with inner_quantization_context:
                     if isinstance(layer, TransformerLayer):
                         hidden_states, context = layer(**layer_kwargs)
@@ -1075,13 +1078,28 @@ def _patch_ple_block_threading(decoder: "torch.nn.Module") -> None:
 
         previous = getattr(self, "_gemma4_current_per_layer_inputs", None)
         had_previous = hasattr(self, "_gemma4_current_per_layer_inputs")
-        orig_checkpointed_forward = transformer_block_module.checkpointed_forward
+        orig_module_checkpointed_forward = getattr(transformer_block_module, "checkpointed_forward", None)
+        orig_instance_checkpointed_forward = getattr(self, "_checkpointed_forward", None)
+        had_instance_checkpointed_forward = "_checkpointed_forward" in getattr(self, "__dict__", {})
+        patched_module_checkpointed_forward = False
+        patched_instance_checkpointed_forward = False
         self._gemma4_current_per_layer_inputs = per_layer_inputs
 
-        def _checkpointed_forward_with_ple(block, *cf_args, **cf_kwargs):
+        def _module_checkpointed_forward_with_ple(block, *cf_args, **cf_kwargs):
             block_per_layer_inputs = getattr(block, "_gemma4_current_per_layer_inputs", None)
             if block is not self or block_per_layer_inputs is None:
-                return orig_checkpointed_forward(block, *cf_args, **cf_kwargs)
+                return orig_module_checkpointed_forward(block, *cf_args, **cf_kwargs)
+            return _gemma4_checkpointed_forward(
+                block,
+                *cf_args,
+                **cf_kwargs,
+                per_layer_inputs=block_per_layer_inputs,
+            )
+
+        def _instance_checkpointed_forward_with_ple(block, *cf_args, **cf_kwargs):
+            block_per_layer_inputs = getattr(block, "_gemma4_current_per_layer_inputs", None)
+            if block_per_layer_inputs is None:
+                return orig_instance_checkpointed_forward(*cf_args, **cf_kwargs)
             return _gemma4_checkpointed_forward(
                 block,
                 *cf_args,
@@ -1090,11 +1108,24 @@ def _patch_ple_block_threading(decoder: "torch.nn.Module") -> None:
             )
 
         if per_layer_inputs is not None:
-            transformer_block_module.checkpointed_forward = _checkpointed_forward_with_ple
+            # TODO: remove this guard when both MCore main and dev call
+            # TransformerBlock._checkpointed_forward directly.
+            if orig_module_checkpointed_forward is not None:
+                transformer_block_module.checkpointed_forward = _module_checkpointed_forward_with_ple
+                patched_module_checkpointed_forward = True
+            if orig_instance_checkpointed_forward is not None:
+                self._checkpointed_forward = types.MethodType(_instance_checkpointed_forward_with_ple, self)
+                patched_instance_checkpointed_forward = True
         try:
             return orig_decoder_forward(*args, **kwargs)
         finally:
-            transformer_block_module.checkpointed_forward = orig_checkpointed_forward
+            if patched_module_checkpointed_forward:
+                transformer_block_module.checkpointed_forward = orig_module_checkpointed_forward
+            if patched_instance_checkpointed_forward:
+                if had_instance_checkpointed_forward:
+                    self._checkpointed_forward = orig_instance_checkpointed_forward
+                else:
+                    delattr(self, "_checkpointed_forward")
             if had_previous:
                 self._gemma4_current_per_layer_inputs = previous
             else:

--- a/src/megatron/bridge/models/stepfun/step35_bridge.py
+++ b/src/megatron/bridge/models/stepfun/step35_bridge.py
@@ -22,6 +22,7 @@ from megatron.core.models.gpt.gpt_layer_specs import (
     get_gpt_layer_with_transformer_engine_spec,
 )
 from megatron.core.models.gpt.gpt_model import GPTModel
+from megatron.core.transformer.transformer_config import TransformerConfig as MCoreTransformerConfig
 from transformers import AutoConfig
 
 from megatron.bridge.models.conversion.mapping_registry import MegatronMappingRegistry
@@ -54,6 +55,10 @@ logger = logging.getLogger(__name__)
 # `AutoConfig.from_pretrained("stepfun-ai/Step-3.5-Flash")` would route to a
 # different config class and the bridge resolution below would fail.
 AutoConfig.register("step3p5", Step35Config, exist_ok=True)
+
+
+def _mcore_supports_head_wise_attn_gate() -> bool:
+    return "head_wise_attn_gate" in getattr(MCoreTransformerConfig, "__dataclass_fields__", {})
 
 
 class StackedExpertAutoMapping(AutoMapping):
@@ -234,9 +239,13 @@ class Step35Bridge(MegatronModelBridge):
         """
         provider = super().provider_bridge(hf_pretrained)
 
-        if provider.head_wise_attn_gate and getattr(provider, "attention_output_gate", False):
-            # MCore dev treats the full-head-dim output gate and Step-3.5's
-            # scalar per-head gate as separate, mutually exclusive layouts.
+        if (
+            getattr(provider, "head_wise_attn_gate", False)
+            and getattr(provider, "attention_output_gate", False)
+            and _mcore_supports_head_wise_attn_gate()
+        ):
+            # Native head-wise gates and the full-head output gate are mutually
+            # exclusive. Older MCore versions need the output-gate fallback.
             provider.attention_output_gate = False
 
         hf_config = hf_pretrained.config
@@ -382,9 +391,8 @@ class Step35Bridge(MegatronModelBridge):
 
         mapping_list.extend(
             [
-                # QKV + per-head gate: merge Q, K, V (GQA-interleaved) and
-                # append the scalar g_proj rows for MCore's head_wise_attn_gate
-                # layout.
+                # QKV + per-head gate: select the native scalar-gate layout or
+                # the expanded attention_output_gate fallback via the provider.
                 QKVGMapping(
                     megatron_param="decoder.layers.*.self_attention.linear_qkv.weight",
                     q="model.layers.*.self_attn.q_proj.weight",

--- a/src/megatron/bridge/models/stepfun/step35_bridge.py
+++ b/src/megatron/bridge/models/stepfun/step35_bridge.py
@@ -234,6 +234,11 @@ class Step35Bridge(MegatronModelBridge):
         """
         provider = super().provider_bridge(hf_pretrained)
 
+        if provider.head_wise_attn_gate and getattr(provider, "attention_output_gate", False):
+            # MCore dev treats the full-head-dim output gate and Step-3.5's
+            # scalar per-head gate as separate, mutually exclusive layouts.
+            provider.attention_output_gate = False
+
         hf_config = hf_pretrained.config
         mtp_layer_types = getattr(hf_config, "mtp_layer_types", None)
         if provider.layer_types is not None and mtp_layer_types:
@@ -377,8 +382,9 @@ class Step35Bridge(MegatronModelBridge):
 
         mapping_list.extend(
             [
-                # QKV + per-head gate: merge Q, K, V (GQA-interleaved) and expand
-                # the scalar g_proj rows into MCore's attention_output_gate layout.
+                # QKV + per-head gate: merge Q, K, V (GQA-interleaved) and
+                # append the scalar g_proj rows for MCore's head_wise_attn_gate
+                # layout.
                 QKVGMapping(
                     megatron_param="decoder.layers.*.self_attention.linear_qkv.weight",
                     q="model.layers.*.self_attn.q_proj.weight",

--- a/src/megatron/bridge/models/stepfun/step35_provider.py
+++ b/src/megatron/bridge/models/stepfun/step35_provider.py
@@ -195,7 +195,7 @@ class Step35ModelProvider(GPTModelProvider):
     * ``sliding_attention_setting``: normalized Megatron-facing shape overrides
       derived from ``attention_other_setting``.
     * ``head_wise_attn_gate``: whether to map HF's per-head ``g_proj`` gate
-      through Megatron-Core's ``attention_output_gate`` path.
+      through Megatron-Core's per-head gate rows in ``linear_qkv``.
 
     These fields are populated from the HF config inside
     ``Step35Bridge.provider_bridge``.

--- a/src/megatron/bridge/models/stepfun/step35_provider.py
+++ b/src/megatron/bridge/models/stepfun/step35_provider.py
@@ -195,7 +195,8 @@ class Step35ModelProvider(GPTModelProvider):
     * ``sliding_attention_setting``: normalized Megatron-facing shape overrides
       derived from ``attention_other_setting``.
     * ``head_wise_attn_gate``: whether to map HF's per-head ``g_proj`` gate
-      through Megatron-Core's per-head gate rows in ``linear_qkv``.
+      through native per-head gate rows when MCore supports them. Older MCore
+      versions use the full-head ``attention_output_gate`` layout as a fallback.
 
     These fields are populated from the HF config inside
     ``Step35Bridge.provider_bridge``.

--- a/tests/functional_tests/test_groups/recipes/test_nemotronh_recipes_pretrain.py
+++ b/tests/functional_tests/test_groups/recipes/test_nemotronh_recipes_pretrain.py
@@ -139,6 +139,9 @@ NEMOTRON_3_SUPER_PRETRAIN_RECIPES = [
             "mtp_num_layers": 2,
             "mtp_hybrid_override_pattern": "*E",
             "moe_router_topk": 2,
+            # Keep this tiny MTP smoke out of MCore's MoE metric tracker path:
+            # decoder and MTP routers initialize different layer-count views.
+            "moe_aux_loss_coeff": 0.0,
             # Disable CUDA graphs in CI — TE/MCore RNG state mismatch causes
             # 'Tensor' object has no attribute 'get_state' in make_graphed_callables.
             "cuda_graph_impl": "none",

--- a/tests/unit_tests/diffusion/model/common/test_dit_attention.py
+++ b/tests/unit_tests/diffusion/model/common/test_dit_attention.py
@@ -267,6 +267,18 @@ class TestDiTSelfAttentionGetQKV:
         assert q is not None and k is not None and v is not None
 
     @patch("megatron.bridge.diffusion.models.common.dit_attention.parallel_state")
+    def test_accepts_mcore_head_wise_gate_keyword(self, mock_ps):
+        mock_ps.get_tensor_model_parallel_world_size.return_value = 1
+        attn = self._make_attn(hidden_size=64, num_heads=4, with_layernorm=False)
+        q, k, v = attn.get_query_key_value_tensors(torch.randn(8, 2, 64), head_wise_gate=False)
+        assert q is not None and k is not None and v is not None
+
+    def test_rejects_enabled_head_wise_gate(self):
+        attn = self._make_attn(hidden_size=64, num_heads=4, with_layernorm=False)
+        with pytest.raises(ValueError, match="head_wise_attn_gate"):
+            attn.get_query_key_value_tensors(torch.randn(8, 2, 64), head_wise_gate=True)
+
+    @patch("megatron.bridge.diffusion.models.common.dit_attention.parallel_state")
     def test_gqa_shapes(self, mock_ps):
         """Group Query Attention: fewer KV groups than query heads."""
         mock_ps.get_tensor_model_parallel_world_size.return_value = 1
@@ -392,9 +404,10 @@ class TestDiTCrossAttentionGetQKV:
         hidden = torch.randn(8, 2, 64)
         kv_states = torch.randn(8, 2, 64)
 
-        q_out, k_out, v_out = attn.get_query_key_value_tensors(hidden, kv_states)
+        q_out, k_out, v_out = attn.get_query_key_value_tensors(hidden, kv_states, head_wise_gate=False)
 
         mock_super_qkv.assert_called_once()
+        assert mock_super_qkv.call_args.kwargs["head_wise_gate"] is False
         assert torch.equal(q_out, q)
         assert torch.equal(k_out, k)
         assert torch.equal(v_out, v)

--- a/tests/unit_tests/diffusion/model/common/test_dit_attention.py
+++ b/tests/unit_tests/diffusion/model/common/test_dit_attention.py
@@ -21,6 +21,7 @@ import torch.nn as nn
 from megatron.core.transformer.attention import SelfAttentionSubmodules
 from megatron.core.transformer.enums import AttnMaskType
 
+from megatron.bridge.diffusion.models.common import dit_attention as dit_attention_module
 from megatron.bridge.diffusion.models.common.dit_attention import (
     DiTCrossAttention,
     DiTCrossAttentionSubmodules,
@@ -393,7 +394,34 @@ class TestDiTCrossAttentionGetQKV:
 
     @patch("megatron.bridge.diffusion.models.common.dit_attention.parallel_state")
     @patch("megatron.bridge.diffusion.models.common.dit_attention.CrossAttention.get_query_key_value_tensors")
-    def test_delegates_to_super(self, mock_super_qkv, mock_ps):
+    def test_delegates_to_super_without_head_wise_gate_when_parent_does_not_support_it(
+        self, mock_super_qkv, mock_ps, monkeypatch
+    ):
+        monkeypatch.setattr(dit_attention_module, "_CROSS_ATTENTION_SUPPORTS_HEAD_WISE_GATE", False)
+        mock_ps.get_tensor_model_parallel_world_size.return_value = 1
+        q = torch.randn(8, 2, 4, 16)
+        k = torch.randn(8, 2, 4, 16)
+        v = torch.randn(8, 2, 4, 16)
+        mock_super_qkv.return_value = (q, k, v)
+
+        attn = self._make_attn(with_layernorm=False)
+        hidden = torch.randn(8, 2, 64)
+        kv_states = torch.randn(8, 2, 64)
+
+        q_out, k_out, v_out = attn.get_query_key_value_tensors(hidden, kv_states, head_wise_gate=False)
+
+        mock_super_qkv.assert_called_once()
+        assert "head_wise_gate" not in mock_super_qkv.call_args.kwargs
+        assert torch.equal(q_out, q)
+        assert torch.equal(k_out, k)
+        assert torch.equal(v_out, v)
+
+    @patch("megatron.bridge.diffusion.models.common.dit_attention.parallel_state")
+    @patch("megatron.bridge.diffusion.models.common.dit_attention.CrossAttention.get_query_key_value_tensors")
+    def test_delegates_to_super_with_head_wise_gate_when_parent_supports_it(
+        self, mock_super_qkv, mock_ps, monkeypatch
+    ):
+        monkeypatch.setattr(dit_attention_module, "_CROSS_ATTENTION_SUPPORTS_HEAD_WISE_GATE", True)
         mock_ps.get_tensor_model_parallel_world_size.return_value = 1
         q = torch.randn(8, 2, 4, 16)
         k = torch.randn(8, 2, 4, 16)
@@ -411,6 +439,15 @@ class TestDiTCrossAttentionGetQKV:
         assert torch.equal(q_out, q)
         assert torch.equal(k_out, k)
         assert torch.equal(v_out, v)
+
+    @patch("megatron.bridge.diffusion.models.common.dit_attention.CrossAttention.get_query_key_value_tensors")
+    def test_rejects_enabled_head_wise_gate(self, mock_super_qkv):
+        attn = self._make_attn(with_layernorm=False)
+
+        with pytest.raises(ValueError, match="head_wise_attn_gate"):
+            attn.get_query_key_value_tensors(torch.randn(8, 2, 64), torch.randn(8, 2, 64), head_wise_gate=True)
+
+        mock_super_qkv.assert_not_called()
 
     @patch("megatron.bridge.diffusion.models.common.dit_attention.parallel_state")
     @patch("megatron.bridge.diffusion.models.common.dit_attention.CrossAttention.get_query_key_value_tensors")

--- a/tests/unit_tests/models/deepseek/test_deepseek_v4_bridge.py
+++ b/tests/unit_tests/models/deepseek/test_deepseek_v4_bridge.py
@@ -418,13 +418,17 @@ class TestDeepSeekV4HardwareDefaults:
             patch.object(MegatronModelBridge, "provider_bridge", return_value=provider),
             patch.object(torch.cuda, "is_available", return_value=True),
             patch.object(torch.cuda, "get_device_capability", return_value=capability),
+            patch(
+                "megatron.bridge.models.deepseek.deepseek_v4_bridge.deepseek_v4_supports_fused_dsa_kernels",
+                return_value=True,
+            ),
         ):
             out = bridge.provider_bridge(hf_pretrained)
 
         assert out.apply_dsa_kernel_fusion is expected
         assert out.use_fused_mhc is expected
 
-    def test_provider_bridge_preserves_fused_defaults_without_cuda(self):
+    def test_provider_bridge_disables_blackwell_only_fusions_without_cuda(self):
         hf_pretrained = MagicMock()
         hf_pretrained.config = _deepseek_v4_hf_config()
         provider = MagicMock()
@@ -436,7 +440,27 @@ class TestDeepSeekV4HardwareDefaults:
         ):
             out = bridge.provider_bridge(hf_pretrained)
 
-        assert out.apply_dsa_kernel_fusion is True
+        assert out.apply_dsa_kernel_fusion is False
+        assert out.use_fused_mhc is False
+
+    def test_provider_bridge_disables_dsa_fusion_when_optional_kernels_are_missing(self):
+        hf_pretrained = MagicMock()
+        hf_pretrained.config = _deepseek_v4_hf_config()
+        provider = MagicMock()
+
+        bridge = DeepSeekV4Bridge.__new__(DeepSeekV4Bridge)
+        with (
+            patch.object(MegatronModelBridge, "provider_bridge", return_value=provider),
+            patch.object(torch.cuda, "is_available", return_value=True),
+            patch.object(torch.cuda, "get_device_capability", return_value=(10, 0)),
+            patch(
+                "megatron.bridge.models.deepseek.deepseek_v4_bridge.deepseek_v4_supports_fused_dsa_kernels",
+                return_value=False,
+            ),
+        ):
+            out = bridge.provider_bridge(hf_pretrained)
+
+        assert out.apply_dsa_kernel_fusion is False
         assert out.use_fused_mhc is True
 
 

--- a/tests/unit_tests/models/gemma/test_gemma4_modeling.py
+++ b/tests/unit_tests/models/gemma/test_gemma4_modeling.py
@@ -1471,10 +1471,12 @@ class TestGemma4PLEHelpers:
             pg_collection=SimpleNamespace(tp=None),
         )
         per_layer_inputs = torch.tensor([[[[10.0], [20.0], [30.0]]]])
+        input_ids = torch.tensor([1])
 
         hidden_states, intermediates = _gemma4_checkpointed_forward(
             block,
             torch.tensor(0.0),
+            input_ids=input_ids,
             attention_mask="mask",
             context="context",
             context_mask="context_mask",
@@ -1493,10 +1495,13 @@ class TestGemma4PLEHelpers:
         torch.testing.assert_close(
             block.layers[0].calls[0]["per_layer_input"], per_layer_inputs[:, :, 0, :].transpose(0, 1)
         )
+        assert block.layers[0].calls[0]["input_ids"] is input_ids
         assert block.layers[1].calls[0]["attention_mask"] == "mask"
+        assert block.layers[1].calls[0]["input_ids"] is input_ids
         torch.testing.assert_close(
             block.layers[2].calls[0]["per_layer_input"], per_layer_inputs[:, :, 2, :].transpose(0, 1)
         )
+        assert block.layers[2].calls[0]["input_ids"] is input_ids
 
     def test_gemma4_checkpointed_forward_block_recompute_extracts_start_layers(self, monkeypatch):
         from megatron.core import tensor_parallel

--- a/tests/unit_tests/models/gemma/test_gemma4_modeling.py
+++ b/tests/unit_tests/models/gemma/test_gemma4_modeling.py
@@ -1430,6 +1430,9 @@ class TestGemma4PLEHelpers:
                 self.layer_number = layer_number
                 self.calls = []
 
+            def _forward_attention(self, input_ids=None):
+                del input_ids
+
             def __call__(self, **kwargs):
                 self.calls.append(kwargs)
                 return (
@@ -1497,11 +1500,66 @@ class TestGemma4PLEHelpers:
         )
         assert block.layers[0].calls[0]["input_ids"] is input_ids
         assert block.layers[1].calls[0]["attention_mask"] == "mask"
-        assert block.layers[1].calls[0]["input_ids"] is input_ids
+        assert "input_ids" not in block.layers[1].calls[0]
         torch.testing.assert_close(
             block.layers[2].calls[0]["per_layer_input"], per_layer_inputs[:, :, 2, :].transpose(0, 1)
         )
         assert block.layers[2].calls[0]["input_ids"] is input_ids
+
+    def test_gemma4_checkpointed_forward_skips_input_ids_without_mcore_support(self, monkeypatch):
+        from megatron.core import tensor_parallel
+
+        class FakeTransformerLayer:
+            def __init__(self, layer_number):
+                self.layer_number = layer_number
+                self.calls = []
+
+            def _forward_attention(self):
+                pass
+
+            def __call__(self, **kwargs):
+                self.calls.append(kwargs)
+                return kwargs["hidden_states"] + float(self.layer_number), None
+
+        def fake_checkpoint(function, distribute_saved_activations, *args):
+            del distribute_saved_activations
+            return function(*args)
+
+        monkeypatch.setattr(
+            "megatron.bridge.models.gemma.modeling_gemma4.TransformerLayer",
+            FakeTransformerLayer,
+        )
+        monkeypatch.setattr(tensor_parallel, "checkpoint", fake_checkpoint)
+        block = SimpleNamespace(
+            layers=[FakeTransformerLayer(1)],
+            config=SimpleNamespace(
+                recompute_method="uniform",
+                recompute_num_layers=1,
+                fp8=False,
+                fp4=False,
+                distribute_saved_activations=False,
+            ),
+            num_layers_per_pipeline_rank=1,
+            pg_collection=SimpleNamespace(tp=None),
+        )
+        input_ids = torch.tensor([1])
+
+        hidden_states = _gemma4_checkpointed_forward(
+            block,
+            torch.tensor(0.0),
+            input_ids=input_ids,
+            attention_mask="mask",
+            context="context",
+            context_mask="context_mask",
+            rotary_pos_emb="rope",
+            attention_bias="bias",
+            packed_seq_params="packed",
+            use_inner_quantization_context=True,
+            padding_mask="padding",
+        )
+
+        torch.testing.assert_close(hidden_states, torch.tensor(1.0))
+        assert "input_ids" not in block.layers[0].calls[0]
 
     def test_gemma4_checkpointed_forward_block_recompute_extracts_start_layers(self, monkeypatch):
         from megatron.core import tensor_parallel

--- a/tests/unit_tests/models/gemma/test_gemma4_modeling.py
+++ b/tests/unit_tests/models/gemma/test_gemma4_modeling.py
@@ -1341,7 +1341,7 @@ class TestGemma4PLEHelpers:
         torch.testing.assert_close(out, torch.tensor(1.0) + first_expected.sum() + second_expected.sum())
         assert not hasattr(decoder, "_gemma4_current_per_layer_inputs")
 
-    def test_patch_ple_block_threading_wraps_checkpointed_forward(self, monkeypatch):
+    def test_patch_ple_block_threading_wraps_module_checkpointed_forward(self, monkeypatch):
         from megatron.core.transformer import transformer_block as transformer_block_module
 
         calls = []
@@ -1363,7 +1363,12 @@ class TestGemma4PLEHelpers:
             calls.append(("gemma4", block, args, per_layer_inputs, kwargs))
             return "gemma4"
 
-        monkeypatch.setattr(transformer_block_module, "checkpointed_forward", fake_orig_checkpointed_forward)
+        monkeypatch.setattr(
+            transformer_block_module,
+            "checkpointed_forward",
+            fake_orig_checkpointed_forward,
+            raising=False,
+        )
         monkeypatch.setattr(
             "megatron.bridge.models.gemma.modeling_gemma4._gemma4_checkpointed_forward",
             fake_gemma4_checkpointed_forward,
@@ -1378,6 +1383,42 @@ class TestGemma4PLEHelpers:
         assert calls[0][0] == "gemma4"
         assert calls[0][3] is per_layer_inputs
         assert transformer_block_module.checkpointed_forward is fake_orig_checkpointed_forward
+
+    def test_patch_ple_block_threading_wraps_instance_checkpointed_forward(self, monkeypatch):
+        calls = []
+
+        class FakeDecoder(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.layers = torch.nn.ModuleList()
+
+            def _checkpointed_forward(self, hidden_states, attention_mask, input_ids=None):
+                calls.append(("orig", self, (hidden_states, attention_mask), {"input_ids": input_ids}))
+                return "orig"
+
+            def forward(self, hidden_states, **kwargs):
+                del kwargs
+                return self._checkpointed_forward(hidden_states, "mask", input_ids="tokens")
+
+        def fake_gemma4_checkpointed_forward(block, *args, per_layer_inputs=None, **kwargs):
+            calls.append(("gemma4", block, args, per_layer_inputs, kwargs))
+            return "gemma4"
+
+        monkeypatch.setattr(
+            "megatron.bridge.models.gemma.modeling_gemma4._gemma4_checkpointed_forward",
+            fake_gemma4_checkpointed_forward,
+        )
+        decoder = FakeDecoder()
+        per_layer_inputs = torch.ones(1, 2, 1, 3)
+
+        _patch_ple_block_threading(decoder)
+        out = decoder(torch.tensor(1.0), per_layer_inputs=per_layer_inputs)
+
+        assert out == "gemma4"
+        assert calls[0][0] == "gemma4"
+        assert calls[0][3] is per_layer_inputs
+        assert calls[0][4]["input_ids"] == "tokens"
+        assert "_checkpointed_forward" not in decoder.__dict__
 
     def test_gemma4_checkpointed_forward_uniform_threads_ple_inputs(self, monkeypatch):
         from megatron.core import tensor_parallel

--- a/tests/unit_tests/models/stepfun/test_step35_bridge.py
+++ b/tests/unit_tests/models/stepfun/test_step35_bridge.py
@@ -254,8 +254,9 @@ class TestStep35BridgeProviderBridge:
         _, p = self._run()
         assert p.head_wise_attn_gate is True
 
-    def test_head_wise_gate_disables_attention_output_gate_for_mcore_dev(self):
-        """MCore dev rejects simultaneous head-wise and output gate layouts."""
+    def test_native_head_wise_gate_disables_attention_output_gate(self, monkeypatch):
+        """MCore versions with native scalar gates do not need the fallback."""
+        monkeypatch.setattr(_step35_bridge_mod, "_mcore_supports_head_wise_attn_gate", lambda: True)
         _, p = self._run(
             hf_overrides={
                 "attention_output_gate": True,
@@ -265,6 +266,19 @@ class TestStep35BridgeProviderBridge:
 
         assert p.head_wise_attn_gate is True
         assert p.attention_output_gate is False
+
+    def test_attention_output_gate_preserved_as_legacy_mcore_fallback(self, monkeypatch):
+        """MCore versions without native scalar gates need expanded gate rows."""
+        monkeypatch.setattr(_step35_bridge_mod, "_mcore_supports_head_wise_attn_gate", lambda: False)
+        _, p = self._run(
+            hf_overrides={
+                "attention_output_gate": True,
+                "use_head_wise_attn_gate": True,
+            },
+        )
+
+        assert p.head_wise_attn_gate is True
+        assert p.attention_output_gate is True
 
     def test_attention_output_gate_preserved_without_head_wise_gate(self):
         _, p = self._run(

--- a/tests/unit_tests/models/stepfun/test_step35_bridge.py
+++ b/tests/unit_tests/models/stepfun/test_step35_bridge.py
@@ -65,6 +65,7 @@ def _make_hf_config(**overrides) -> SimpleNamespace:
         moe_intermediate_size=64,
         share_expert_dim=64,
         use_head_wise_attn_gate=True,
+        attention_output_gate=True,
         attention_other_setting={
             "attention_type": "sliding_attention",
             "num_attention_heads": 96,
@@ -198,6 +199,7 @@ class TestStep35BridgeProviderBridge:
         provider.moe_router_topk = hf_config.moe_top_k
         provider.moe_shared_expert_intermediate_size = hf_config.share_expert_dim
         provider.head_wise_attn_gate = hf_config.use_head_wise_attn_gate
+        provider.attention_output_gate = hf_config.attention_output_gate
         provider.layer_types = hf_config.layer_types
         provider.kv_channels = hf_config.head_dim
         for k, v in (provider_overrides or {}).items():
@@ -230,17 +232,16 @@ class TestStep35BridgeProviderBridge:
         assert kwargs["layer_types"] == hf_config.layer_types
 
     def test_attention_output_gate_mapped_by_base_bridge_path(self):
-        # HF Step-3.5-Flash carries ``attention_output_gate`` verbatim into the
-        # Megatron provider (same field name on both sides). It's the MCore
-        # switch that drives ``merge_qkvg_weights`` to splice g_proj into linear_qkv.
+        # HF Step-3.5-Flash can carry ``attention_output_gate`` verbatim into
+        # the base provider kwargs. Step35Bridge.provider_bridge normalizes it
+        # later when ``head_wise_attn_gate`` is also enabled.
         hf_config = _make_hf_config(attention_output_gate=True)
         kwargs = Step35Bridge().hf_config_to_provider_kwargs(hf_config)
         assert kwargs["attention_output_gate"] is True
 
     def test_attention_output_gate_entry_in_config_mapping(self):
-        # Regression guard: removing this CONFIG_MAPPING entry silently breaks
-        # ckpt conversion because the provider's ``attention_output_gate`` then
-        # defaults to False and QKVG fusion drops the g_proj rows.
+        # Regression guard for non-head-wise-gate configs that still request
+        # MCore's full output-gate layout.
         assert ("attention_output_gate", "attention_output_gate") in Step35Bridge.CONFIG_MAPPING
 
     def test_head_wise_attn_gate_preserved_through_step35_provider_bridge(self):
@@ -252,6 +253,29 @@ class TestStep35BridgeProviderBridge:
         """
         _, p = self._run()
         assert p.head_wise_attn_gate is True
+
+    def test_head_wise_gate_disables_attention_output_gate_for_mcore_dev(self):
+        """MCore dev rejects simultaneous head-wise and output gate layouts."""
+        _, p = self._run(
+            hf_overrides={
+                "attention_output_gate": True,
+                "use_head_wise_attn_gate": True,
+            },
+        )
+
+        assert p.head_wise_attn_gate is True
+        assert p.attention_output_gate is False
+
+    def test_attention_output_gate_preserved_without_head_wise_gate(self):
+        _, p = self._run(
+            hf_overrides={
+                "attention_output_gate": True,
+                "use_head_wise_attn_gate": False,
+            },
+        )
+
+        assert p.head_wise_attn_gate is False
+        assert p.attention_output_gate is True
 
     def test_sliding_attention_setting_populated_from_hf_config(self):
         """Shape fields are pulled out of HF's ``attention_other_setting`` and
@@ -721,7 +745,7 @@ class TestStackedExpertGatedMLPMapping:
 
 
 class TestQKVGMappingHelpers:
-    def test_head_wise_scalar_gate_expands_for_mcore_attention_output_gate(self):
+    def test_scalar_gate_expands_for_mcore_attention_output_gate_layout(self):
         provider = SimpleNamespace(
             attention_output_gate=True,
             num_attention_heads=4,


### PR DESCRIPTION
## Summary
- Original bump PR: https://github.com/NVIDIA-NeMo/Megatron-Bridge/pull/4437
- Target: `dev`
- Classification: MCore broke Bridge
- Root cause: the 2026-06-22 MCore dev bump updates `3rdparty/Megatron-LM` from `d1410e15e164923f23b8e1a3384bf22c29640fcc` to `3346fa8a2614efe6e4f459bca0bdda4f97a2f0a8`; in that range MCore changed full-recompute execution from the module-level `transformer_block.checkpointed_forward` helper to `TransformerBlock._checkpointed_forward`. Gemma4 PLE threading still unconditionally read and patched the old module symbol, causing the `Launch_Unit_Tests_Core` Gemma4 failures.

## Fix
- Wrap the current instance-level `TransformerBlock._checkpointed_forward` path to thread Gemma4 `per_layer_inputs` during full recompute.
- Keep the older module-level `checkpointed_forward` path guarded by feature detection so Bridge can still work with MCore commits that have not moved to the instance method.
- Thread `input_ids` through the Gemma4 recompute shim when MCore supplies it.

## Guards
- Added one feature guard for the old module-level `checkpointed_forward` API.
- Removal TODO: remove the guard when both MCore main and dev call `TransformerBlock._checkpointed_forward` directly.
- Removed guards: none.

## Validation
- 2026-06-22 America/Los_Angeles, CW interactive: `uv run --no-sync python -m pytest tests/unit_tests/models/gemma/test_gemma4_modeling.py::TestGemma4PLEHelpers::test_patch_ple_block_threading_injects_layer_inputs_and_restores_state tests/unit_tests/models/gemma/test_gemma4_modeling.py::TestGemma4PLEHelpers::test_patch_ple_block_threading_wraps_module_checkpointed_forward tests/unit_tests/models/gemma/test_gemma4_modeling.py::TestGemma4PLEHelpers::test_patch_ple_block_threading_wraps_instance_checkpointed_forward tests/unit_tests/models/gemma/test_gemma4_provider.py::TestGemma4PLEBlockThreading::test_threads_per_layer_inputs_to_each_layer -q` -> 4 passed, 35 warnings.
- 2026-06-22 America/Los_Angeles, CW interactive: `uv run --no-sync python -m pytest tests/unit_tests/models/gemma/test_gemma4_modeling.py tests/unit_tests/models/gemma/test_gemma4_provider.py -q` -> 123 passed, 37 warnings.
- 2026-06-22 America/Los_Angeles, CW interactive: `uv run --no-sync pre-commit run --all-files` -> passed.
