### PR TITLE
Fix dense FLOPS accounting under context parallelism

### DIFF
--- a/src/megatron/bridge/training/gpt_step.py
+++ b/src/megatron/bridge/training/gpt_step.py
@@ -368,6 +368,7 @@ def _forward_step_common(
     accumulate_flops_metadata(
         state,
         tokens,
+        config_seq_len=getattr(config, "seq_length", None),
         cu_seqlens=cu_seqlens if cp_use_thd else None,
         cu_seqlens_argmin=cu_seqlens_argmin if cp_use_thd else None,
         cu_seqlens_unpadded=cu_seqlens_unpadded if cp_use_thd else None,

--- a/src/megatron/bridge/training/utils/flop_utils.py
+++ b/src/megatron/bridge/training/utils/flop_utils.py
@@ -176,6 +176,7 @@ def accumulate_flops_metadata(
     state,
     tokens: torch.Tensor | None,
     *,
+    config_seq_len: int | None = None,
     cu_seqlens: torch.Tensor | None = None,
     cu_seqlens_argmin: torch.Tensor | None = None,
     cu_seqlens_unpadded: torch.Tensor | None = None,
@@ -187,7 +188,9 @@ def accumulate_flops_metadata(
     Writes three accumulators consumed by ``train.py`` at end of step:
 
     - ``_flops_seqlen_sum``: ``mbs * tokens.shape[1]`` (padded total tokens
-      this microbatch contributes). Drives the linear MLP/proj/logit terms.
+      this microbatch contributes), or ``mbs * config_seq_len`` for dense
+      non-packed batches whose tensors were already context-parallel sliced.
+      Drives the linear MLP/proj/logit terms.
     - ``_flops_seqlen_sq_sum``: the THD attention term Σᵢ sᵢ², computed inline from
       ``cu_seqlens`` (preferring ``cu_seqlens_unpadded``). The per-pack sub-sequence
       lengths are reduced via :func:`_scalar_sum_for_accumulator`, which keeps the
@@ -195,7 +198,9 @@ def accumulate_flops_metadata(
       sync-free and the single host sync happens once per step in
       :func:`resolve_global_flops_seqlen_stats`. When ``cu_seqlens`` is absent
       (dense / non-packed) or degenerate, the host-int BSHD fallback
-      ``mbs * seq_len²`` is accumulated instead (bit-exact with the pre-fix value).
+      ``mbs * dense_seq_len²`` is accumulated instead (bit-exact with the
+      pre-fix value). ``dense_seq_len`` is ``config_seq_len`` when provided,
+      otherwise ``tokens.shape[1]``.
     - ``_flops_vision_patches``: running total of ``num_vision_patches``.
 
     ``num_vision_patches`` is the precomputed number of vision patches in this
@@ -213,8 +218,8 @@ def accumulate_flops_metadata(
         return
 
     mbs = tokens.shape[0]
-    seq_len = tokens.shape[1]
-    _add_flops_accumulator(state, "_flops_seqlen_sum", mbs * seq_len)
+    tensor_seq_len = tokens.shape[1]
+    dense_seq_len = config_seq_len if isinstance(config_seq_len, int) and config_seq_len > 0 else tensor_seq_len
 
     # THD attention term Σᵢ sᵢ², computed inline from cu_seqlens. The squared
     # sub-sequence lengths stay on-device (``_scalar_sum_for_accumulator`` returns a
@@ -224,12 +229,14 @@ def accumulate_flops_metadata(
     # (which would force a data-dependent-size sync) is needed.
     sub_seq_lens = _real_subseq_lengths(cu_seqlens, cu_seqlens_argmin, cu_seqlens_unpadded, cu_seqlens_unpadded_argmin)
     if sub_seq_lens is not None and sub_seq_lens.numel() > 0:
+        _add_flops_accumulator(state, "_flops_seqlen_sum", mbs * tensor_seq_len)
         setattr(state, "_flops_requires_global_reduce", True)
         _add_flops_accumulator(state, "_flops_seqlen_sq_sum", _scalar_sum_for_accumulator(sub_seq_lens.long() ** 2))
     else:
         # No cu_seqlens (dense / non-packed) or a degenerate pack with no real
         # sub-sequences → BSHD fallback (single pack-length sequence).
-        _add_flops_accumulator(state, "_flops_seqlen_sq_sum", mbs * seq_len**2)
+        _add_flops_accumulator(state, "_flops_seqlen_sum", mbs * dense_seq_len)
+        _add_flops_accumulator(state, "_flops_seqlen_sq_sum", mbs * dense_seq_len**2)
 
     if num_vision_patches is not None:
         _add_flops_accumulator(state, "_flops_vision_patches", num_vision_patches)

--- a/tests/unit_tests/training/utils/test_flop_utils.py
+++ b/tests/unit_tests/training/utils/test_flop_utils.py
@@ -2018,6 +2018,17 @@ class TestAccumulateFlopsMetadata:
         assert state._flops_seqlen_sq_sum == 2 * 512**2
         assert not getattr(state, "_flops_requires_global_reduce", False)
 
+    def test_bshd_fallback_uses_full_sequence_length_for_cp_sliced_tokens(self):
+        # Dense GPT batches are sliced along sequence dimension before the
+        # forward step under context parallelism. FLOPS should still be based on
+        # the full model sequence length, not the CP-local token length.
+        state = _State()
+        tokens = torch.zeros(1, 2048)
+        accumulate_flops_metadata(state, tokens, config_seq_len=4096)
+        assert state._flops_seqlen_sum == 4096
+        assert state._flops_seqlen_sq_sum == 4096**2
+        assert not getattr(state, "_flops_requires_global_reduce", False)
+
     def test_mock_state_accumulators_start_at_zero(self):
         state = MagicMock()
         tokens = torch.zeros(1, 8)
@@ -2035,6 +2046,18 @@ class TestAccumulateFlopsMetadata:
         accumulate_flops_metadata(state, tokens, cu_seqlens=cu_seqlens)
         assert state._flops_seqlen_sum == 1 * 4096
         assert state._flops_seqlen_sq_sum == 256**2 + 256**2 + 3584**2
+        assert state._flops_requires_global_reduce
+
+    def test_config_seq_len_does_not_override_thd_cu_seqlens(self):
+        # config_seq_len is only a dense/non-packed fallback. THD still uses
+        # the actual packed tensor length for linear terms and cu_seqlens for
+        # attention work.
+        state = _State()
+        tokens = torch.zeros(1, 2048)
+        cu_seqlens = torch.tensor([0, 512, 2048])
+        accumulate_flops_metadata(state, tokens, config_seq_len=4096, cu_seqlens=cu_seqlens)
+        assert state._flops_seqlen_sum == 2048
+        assert state._flops_seqlen_sq_sum == 512**2 + 1536**2
         assert state._flops_requires_global_reduce
 
     def test_thd_padded_cu_seqlens_with_argmin(self):


### PR DESCRIPTION
## Summary
- Use the configured full sequence length for dense/non-packed FLOPS metadata when GPT token tensors have already been context-parallel sliced.
- Keep the THD/cu_seqlens path on actual packed tensor length and real sub-sequence boundaries.
- Add unit coverage for CP-sliced dense fallback and for ensuring `config_seq_len` does not override THD accounting.

## Testing
- `ruff format --check src/megatron/bridge/training/utils/flop_utils.py src/megatron/bridge/training/gpt_step.py tests/unit_tests/training/utils/test_flop_utils.py`
- `ruff check src/megatron/bridge/training/utils/flop_utils.py src/megatron/bridge/training/gpt_step.py tests/unit_tests/training/utils/test_flop_utils.py`
- `git diff --check`
- `python3 -m py_compile src/megatron/bridge/training/utils/flop_utils.py src/megatron/bridge/training/gpt_step.py tests/unit_tests/training/utils/test_flop_utils.py`
- Lightweight stubbed execution of the changed helper behavior for dense CP-sliced fallback and THD override guard.

Full pytest was not runnable in this local environment because dependency resolution for `nvidia-resiliency-ext==0.6.0` did not provide a compatible wheel for the host platform.