### PR TITLE
docs: revise Qwen3.5 MegatronMIMO tutorial

### DIFF
--- a/tutorials/megatron_mimo/qwen35-vl-non-colocated-sft.md
+++ b/tutorials/megatron_mimo/qwen35-vl-non-colocated-sft.md
@@ -1,31 +1,85 @@
 # Heterogeneous Parallelism for Qwen3.5-VL with MegatronMIMO
 
-This tutorial shows how to fine-tune dense Qwen3.5-VL with *MegatronMIMO*,
-using *heterogeneous parallelism*. In the non-colocated setup covered here,
-the vision encoder and the language model run on disjoint GPU sets and can use
-different declared TP/PP/DP layouts.
+## Overview
 
-You will:
+[Qwen3.5-VL](https://huggingface.co/Qwen/Qwen3.5-27B) is a dense vision-language model: it
+takes interleaved **images and text** and produces text. Like every VLM, it is
+really two very different models stitched together: a large autoregressive
+**language model** and a comparatively tiny **vision encoder** that turns pixels
+into tokens the language model can read.
+
+This tutorial walks through a concrete, tested use case: **full-parameter
+supervised fine-tuning (SFT) of the 27B dense Qwen3.5-VL on real multimodal
+conversation data** — receipts, captions, medical images with question/answer
+text — using *MegatronMIMO* with *heterogeneous parallelism*.
+
+### Why heterogeneous parallelism
+
+Standard Megatron-Bridge trains Qwen3.5-VL as one integrated model on a single
+shared GPU layout. That means the small vision encoder is pinned to the **same
+ranks** as the language model and competes for its critical path, even though it
+needs a fraction of the compute. The encoder is the hidden drag on an otherwise
+efficient language-model pipeline.
+
+**MegatronMIMO** treats the model as a *graph of modules* — here `language` and
+`images` — connected by activation edges, and lets each module declare its own
+parallel layout and run on its **own GPU set**. Modules on disjoint ranks
+exchange forward activations and backward gradients through **boundary
+communicators**. Because the vision encoder fits on a single rank, moving it
+*off* the language ranks lets its work overlap the language model's critical
+path instead of blocking it.
+
+In the benchmarked 27B MIMO setup, that change yields up to **+44.7% active
+tokens/s/GPU** and **24–35% lower wall-clock step time** versus the strongest
+standard Megatron-Bridge baseline (§4), with **matching loss curves** in the
+reference run report (§5).
+
+### Key concepts
+
+Three terms recur throughout. Keep them straight and the rest follows:
+
+- **Model abstraction.** *non-MIMO* is the standard integrated Megatron model
+  (vision encoder, projector, and language model as internal submodules).
+  *MIMO* is the module-graph abstraction above — a graph of computational
+  modules connected by activation edges, with support for multiple encoders per
+  modality.
+- **Placement.** *colocated* means module rank sets overlap; *non-colocated*
+  means module rank sets are disjoint.
+- **Layout.** *homogeneous* means one declared parallel topology (or equivalent
+  declared component topologies); *heterogeneous* means at least two declared
+  component topologies differ.
+
+In those terms, the **standard baseline** is *non-MIMO + colocated +
+homogeneous*, and the path covered here is *MIMO + non-colocated +
+heterogeneous*: `language` and `images` run on disjoint rank sets and declare
+different TP/PP/DP layouts.
+
+### What you will do
 
 1. Convert a Hugging Face Qwen3.5-VL checkpoint into the MegatronMIMO format.
-2. Launch the validated 27B non-colocated SFT job on a multi-node cluster.
-3. Review the reported validation evidence: throughput gain and loss parity
-   against the standard Megatron-Bridge baseline.
+2. Launch the 27B non-colocated SFT job on a multi-node cluster.
+3. Review benchmark results and a Weights & Biases (W&B) reference report
+   showing loss parity and step-time behavior against the standard
+   Megatron-Bridge baseline.
 
 **Scope.** This tutorial is hands-on for the MegatronMIMO path. It covers
 **dense** Qwen3.5-VL, two components (`language` + `images`), and
-**non-colocated** full-parameter SFT on Hugging Face conversation data. The
-hands-on workflow uses the validated 27B layout. Performance is a first-class
-part of the tutorial: the results section reports a controlled comparison
-against the standard Megatron-Bridge Qwen3.5-VL path on the Hugging Face VLM
-datasets currently supported for this path:
+**non-colocated** full-parameter SFT on Hugging Face conversation data, using
+the reference 27B layout. In this tutorial, the **reference 27B layout** means
+the tested, known-good recipe for this workflow: it fits in memory and converges.
+Performance is a first-class part of the tutorial: the results section reports
+a controlled comparison against the standard
+Megatron-Bridge Qwen3.5-VL path on the Hugging Face VLM datasets currently
+supported for this path:
 [CORD-v2](https://huggingface.co/datasets/naver-clova-ix/cord-v2),
 [RDR](https://huggingface.co/datasets/quintend/rdr-items), and
 [MedPix-VQA](https://huggingface.co/datasets/mmoukouba/MedPix-VQA).
 
-Familiarity with standard Qwen3.5-VL SFT in Megatron-Bridge is helpful, but the
-hands-on steps below focus on what changes for MegatronMIMO. For the system
-design, colocated execution, and the full results, see the paper:
+**Assumed knowledge.** Familiarity with standard Qwen3.5-VL SFT in
+Megatron-Bridge and with Megatron parallelism (tensor/pipeline/data parallel —
+TP/PP/DP) is assumed; the hands-on steps below focus on what changes for
+MegatronMIMO. For the system design, colocated execution, and the full results,
+see the paper:
 [Heterogeneous Parallelism for Multimodal Large Language Model Training](https://arxiv.org/abs/2605.27678).
 
 
@@ -33,7 +87,7 @@ design, colocated execution, and the full results, see the paper:
 
 You need a Megatron-Bridge environment (the
 [NeMo Framework container](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo/tags)
-already provides one), Hugging Face access to the `Qwen/Qwen3.5-*` models, and
+already provides one), Hugging Face access to the `Qwen/Qwen3.5-27B` model, and
 a shared filesystem visible on every node and inside the container.
 
 Set a workspace and an experiment root:
@@ -51,13 +105,13 @@ ${EXPERIMENT_ROOT}/
   results/mimo/        # Slurm run outputs
 ```
 
-The 27B multi-node step needs 3 8-GPU nodes with the default launcher settings.
+The reference 27B training job uses 3 8-GPU nodes with the default launcher settings.
 
 
 ## 2. Convert a Hugging Face checkpoint
 
 Conversion imports the HF weights into the MegatronMIMO format and, as a
-round-trip check, exports them back to HF. For the validated 27B multi-node job,
+round-trip check, exports them back to HF. For the reference 27B training job,
 declare the per-component conversion layout explicitly:
 
 ```bash
@@ -86,31 +140,17 @@ The conversion layout above uses 5 ranks, while the training layout below uses
 17 ranks. That is expected: the MegatronMIMO checkpoint can be loaded into a
 different TP/PP/DP layout for training. In practice, use the smaller conversion
 layout to create the checkpoint, then let the Slurm training job declare the
-validated 17-rank layout.
+reference 17-rank layout.
 
 
 ## 3. Launch 27B non-colocated SFT
 
-Before launching the run, it helps to separate three terms that are used below:
+This run is **MIMO + non-colocated + heterogeneous** (see [Key
+concepts](#key-concepts)): `language` and `images` run on disjoint rank sets and
+declare different TP/PP/DP layouts. The standard baseline it is compared against
+is **non-MIMO + colocated + homogeneous**.
 
-- **Model abstraction.** The standard Qwen3.5-VL training loop already supported
-  in Megatron-Bridge is non-MIMO: a regular integrated Megatron model where the
-  vision encoder, projector, and language model are internal submodules.
-  MegatronMIMO uses the MIMO model abstraction: a graph of computational modules
-  connected by activation edges, with support for multiple encoders per
-  modality.
-- **Placement.** Colocated means module rank sets overlap; non-colocated means
-  module rank sets are disjoint.
-- **Layout.** Homogeneous means there is one declared parallel topology, or
-  equivalent declared component topologies. Heterogeneous means at least two
-  declared component topologies differ.
-
-Using those terms, the standard baseline used for validation is **non-MIMO +
-colocated + homogeneous**. The run below is **MIMO + non-colocated +
-heterogeneous**: `language` and `images` run on disjoint rank sets and declare
-different TP/PP/DP layouts.
-
-The validated 27B layout is:
+The reference 27B layout is:
 
 ```
 ranks 0-15   language   TP=4  PP=2  DP=2     (rank_offset=0)
@@ -126,14 +166,14 @@ image-encoder placement. The image encoder fits on one rank, so non-colocated
 MIMO keeps it off the language ranks and lets its work overlap the language
 model's critical path.
 
-The validated 27B job is launched with
+The reference 27B job is launched with
 `examples/megatron_mimo/qwen35_vl/slurm_sft.sh`. The script declares the
 17-rank MIMO layout, validates the allocation, and launches the language and
 image ranks with an MPMD `srun`.
 
 All knobs live in a single `USER CONFIGURATION` block at the top of the script,
 and each one is environment-overridable at submit time. The MIMO layout is set
-by these defaults (already the validated 17-rank layout):
+by these defaults (already the reference 17-rank layout):
 
 ```bash
 MIMO_LANGUAGE_TP=4   MIMO_LANGUAGE_PP=2   MIMO_LANGUAGE_DP=2   MIMO_LANGUAGE_OFFSET=0
@@ -180,36 +220,66 @@ settings for your own cluster.
 ### Monitoring the run
 
 At startup the job prints a banner with the resolved layout: language and image
-TP/PP/DP, active ranks, allocated GPUs, and batch sizes. Check that it matches
-the 17-rank layout above; if it does not, cancel the job and fix the launcher
-settings before rerunning.
+TP/PP/DP, active ranks, allocated GPUs, batch sizes, dataset, and checkpoint
+settings. Check that it matches the 17-rank layout above; if it does not,
+cancel the job and fix the launcher settings before rerunning.
+
+A healthy startup for the reference 27B MIMO layout looks like this
+(job-specific values shown as placeholders). The dataset, sequence length, and
+training-iteration values below are the launcher defaults; override them as
+needed for your run.
+
+```text
+======================================
+Qwen3.5-VL 27B MegatronMIMO SFT (non-colocated)
+======================================
+Job ID:          <job_id>
+Nodes:           3
+GPUs/node:       8
+Active ranks:    17
+Allocated GPUs:  24
+Language:        TP=4 PP=2 CP=1 DP=2 offset=0
+Images:          TP=1 PP=1 CP=1 DP=1 offset=16
+Batch:           MBS=2, GBS=32, language-local MBS=1, num_microbatches=16
+Dataset:         cord_v2
+Sequence length: 4096
+Train iters:     500
+Checkpoint:      ${EXPERIMENT_ROOT}/models/mimo/Qwen3.5-27B-mimo
+======================================
+Packed MPMD srun layout:
+  <node-0>: 8 task(s)
+  <node-1>: 8 task(s)
+  <node-2>: 1 task(s)
+```
 
 During training, each iteration logs its `lm loss` and step time to the Slurm
 output file (`qwen35vl_mimo_sft_<jobid>.out` in the directory you submitted
-from, at `LOG_INTERVAL=1`). A healthy run shows a finite `lm loss` that trends
-down and a per-iteration step time that stabilizes after the first few warmup
-iters. Set `WANDB_API_KEY` to also stream loss and step-time curves to Weights &
-Biases. Run artifacts land under `${EXPERIMENT_ROOT}/results/mimo/${RUN_NAME}`.
+from, at `LOG_INTERVAL=1`). Set `WANDB_API_KEY` to also stream loss and
+step-time curves to Weights & Biases. For expected training behavior, compare
+your run with the W&B reference report in
+[Loss parity and run report](#5-loss-parity-and-run-report); that section also
+embeds the loss-parity plot for offline review. Run
+artifacts land under `${EXPERIMENT_ROOT}/results/mimo/${RUN_NAME}`.
 
 MIMO tokens/s/GPU is not logged today (heterogeneous FLOPs accounting is not yet
-wired in — see [Limitations](#6-limitations-and-references)), so use the
+wired in — see [Limitations](#6-limitations)), so use the
 per-iteration step time as the throughput signal.
 
-## 4. Reported validation results — performance
 
-The numbers below are reported validation evidence from a controlled comparison
-between the standard baseline and MIMO on Qwen3.5-VL 27B (bf16). You do not
-need to run the standard baseline to use the MIMO workflow above.
+## 4. Benchmark results — performance
+
+The numbers below are benchmark results from a controlled comparison between the
+standard baseline and MIMO on Qwen3.5-VL 27B (bf16). You do not need to run the
+standard baseline to use the MIMO workflow above.
 
 **Comparison setup.** The standard Megatron-Bridge baseline is TP=4 PP=2 DP=2
-(16 GPUs), the strongest standard layout found by a parallelism sweep. In the
-terminology from Section 3, that baseline is **non-MIMO + colocated +
-homogeneous**. MIMO uses the same language layout plus a single image rank
-(language TP=4 PP=2 DP=2 + image TP=1 PP=1 DP=1, 17 active ranks), so the
-reported MIMO run is **MIMO + non-colocated + heterogeneous**. Both paths use
-Qwen3.5-VL 27B, bf16, the same supported HF VLM dataset path, and matched
-language-local microbatch size. The performance sweep ran 20 iterations; timing
-is the mean step time over iterations 3–20.
+(16 GPUs), the strongest standard layout found by a parallelism sweep — i.e.
+*non-MIMO + colocated + homogeneous*. MIMO uses the same language layout plus a
+single image rank (language TP=4 PP=2 DP=2 + image TP=1 PP=1 DP=1, 17 active
+ranks), i.e. *MIMO + non-colocated + heterogeneous*. Both paths use Qwen3.5-VL
+27B, bf16, the same supported HF VLM dataset path, and matched language-local
+microbatch size. The performance sweep ran 20 iterations; timing is the mean
+step time over iterations 3–20.
 
 **Metric.** We report **active tokens/s/GPU** — throughput divided by the number
 of ranks actually doing work (16 for the baseline, 17 for MIMO) — and the
@@ -218,7 +288,7 @@ wall-clock step-time reduction.
 The results use the Hugging Face VLM dataset makers currently supported by
 Megatron Bridge for this path. All three are real datasets with one image per
 sample: CORD-v2 is receipt parsing with variable image resolutions, RDR is
-image captioning with a fixed 768x768 image shape, and MedPix-VQA is medical VQA
+image captioning with a fixed 768×768 image shape, and MedPix-VQA is medical VQA
 with variable image resolutions and short question/answer text.
 
 MIMO-win deltas (higher is better) across the three datasets:
@@ -230,15 +300,15 @@ MIMO-win deltas (higher is better) across the three datasets:
 | 4096 / 32 | 23.5% | +23.0% | 23.7% | +23.3% | 23.7% | +23.3% |
 | 4096 / 64 | 27.7% | +30.2% | 27.9% | +30.6% | 26.2% | +27.5% |
 
-These deltas are measured for the validated 27B non-colocated setup. They are
+These deltas are measured for the reference MIMO 27B non-colocated setup. They are
 not a general guarantee for arbitrary models, encoders, datasets, or layouts;
 re-measure if you adapt the workflow to a different configuration.
 
 
-## 5. Reported validation results — loss parity
+## 5. Loss parity and run report
 
-A faster path is only useful if it trains the same model. In the reported
-validation run, the standard baseline and MIMO start from the same converted
+A faster path is only useful if it trains the same model. In the loss-parity
+run, the standard baseline and MIMO start from the same converted
 Qwen3.5-VL 27B checkpoint and produce matching loss trajectories.
 
 **Setup.** MedPix-VQA, seq=2048, GBS=32, 400 training iterations, from the
@@ -246,7 +316,14 @@ pretrained checkpoint. The standard baseline uses MBS=1 and MIMO uses MBS=2, so
 both paths see a language-local microbatch of 1. Both load model weights only;
 optimizer and RNG state start fresh.
 
-The plot below overlays the `lm loss` curves from the standard baseline and
+**Reference artifact.** The
+[Weights & Biases report](https://api.wandb.ai/links/nvidia-nemo-fw-public/6bfq1baw)
+is the primary interactive artifact for this run. It includes the standard-vs-MIMO
+`lm loss` comparison and per-iteration step-time curves. The static plot below
+is included so the loss-parity evidence remains visible in rendered docs and PR
+review without opening W&B.
+
+The embedded plot overlays the `lm loss` curves from the standard baseline and
 MIMO runs. The curves track each other over the 400-iteration window, with no
 systematic drift between the two paths.
 
@@ -256,24 +333,24 @@ In the plot legend, **Standard Qwen3.5-27B** is the standard Megatron-Bridge
 baseline (non-MIMO + colocated + homogeneous), and **MegatronMIMO Qwen3.5-27B**
 is the MIMO run (MIMO + non-colocated + heterogeneous).
 
-This is the expected loss-parity result for the validated 27B setup: MIMO uses a
-different rank layout, but it trains from the same checkpoint and follows the
-same loss trajectory as the standard Megatron-Bridge path.
+This is the expected loss-parity result for the reference MIMO 27B setup: MIMO
+uses a different rank layout, but it trains from the same checkpoint and follows
+the same loss trajectory as the standard Megatron-Bridge path.
 
 
-## 6. Limitations and references
+## 6. Limitations
 
 The current Qwen3.5-VL MegatronMIMO example targets one workflow well — dense,
 two-component, non-colocated full-parameter SFT. The following are not yet
-supported or validated, so you do not spend time on paths that will not work:
+supported or tested, so you can avoid paths that are not expected to work:
 
 - **MoE variants** — only dense Qwen3.5-VL is wired up.
 - **MTP** — the example disables Multi-Token Prediction layers.
-- **Packed sequences** — MIMO packed-sequence behavior is unvalidated.
+- **Packed sequences** — MIMO packed-sequence behavior is untested.
 - **Energon datasets** — use the HF conversation provider.
 - **Colocated layouts** — only non-colocated (disjoint ranks) is covered here.
 
-### References
+## 7. References
 
 - Paper: [Heterogeneous Parallelism for Multimodal Large Language Model Training](https://arxiv.org/abs/2605.27678)
 - MegatronMIMO examples: [`examples/megatron_mimo/`](../../examples/megatron_mimo/README.md)


### PR DESCRIPTION
  ## Summary

  - Reworked the Qwen3.5-VL MegatronMIMO non-colocated SFT tutorial with a clearer overview, use case, and terminology.
  - Added W&B report for the tutorial