### PR TITLE
ci: downsample persisted golden values for long-convergence runs

### DIFF
--- a/scripts/performance/utils/evaluate.py
+++ b/scripts/performance/utils/evaluate.py
@@ -42,6 +42,19 @@ except (ImportError, ModuleNotFoundError):
 logger = logging.getLogger(__name__)
 
 
+# Cap on the number of per-step entries persisted to a golden-values file. Long
+# convergence runs (e.g. 150k steps) would otherwise produce multi-MB files that
+# exceed the golden-values repo's 5 MiB/file push limit. The in-job convergence
+# check aligns current vs. golden by step key, so a downsampled (sparse) golden is
+# still compared correctly against the full-resolution run.
+MAX_PERSISTED_GOLDEN_STEPS = 10000
+
+# Step keys always retained when downsampling (in addition to the first and final
+# step): step "49" is the threshold step the downstream perf reporter
+# (nemo-ci report.py STEPS_THRESHOLD) requires to treat a golden file as comparable.
+_PINNED_GOLDEN_STEPS = ("0", "49")
+
+
 def get_metrics_from_logfiles(log_paths: List[str], metric: str):
     """
     Parse training log files and extract metrics.
@@ -556,20 +569,61 @@ def validate_memory(
     return results
 
 
+def downsample_golden_values(values: Dict[str, Any], max_steps: int = MAX_PERSISTED_GOLDEN_STEPS) -> Dict[str, Any]:
+    """Reduce per-step golden entries to at most ~``max_steps`` evenly-spaced points.
+
+    Scalar entries (``alloc``/``max_alloc``/``max_reserved``/``job_id``) and any other
+    non-step keys are preserved unchanged. When the number of per-step entries already
+    fits within ``max_steps`` the mapping is returned unchanged. Otherwise an evenly
+    strided subset of step keys is kept, always including the first step, the final step
+    (so final-loss validation is unaffected), and the pinned steps in
+    ``_PINNED_GOLDEN_STEPS`` when present.
+
+    The in-job convergence/perf check aligns current vs. golden by step key, so a
+    downsampled (sparse) golden is still compared correctly against a full-resolution
+    run; this only bounds the size of the persisted golden-values file.
+
+    Args:
+        values: Golden values mapping (step-keyed dicts plus scalar entries).
+        max_steps: Approximate upper bound on the number of per-step entries to keep.
+
+    Returns:
+        A new mapping with the per-step entries downsampled and all other keys intact.
+    """
+    step_keys = sorted((k for k in values if k.lstrip("-").isdigit()), key=int)
+    if len(step_keys) <= max_steps:
+        return dict(values)
+    stride = math.ceil(len(step_keys) / max_steps)
+    kept = set(step_keys[::stride])
+    kept.add(step_keys[-1])
+    kept.update(step for step in _PINNED_GOLDEN_STEPS if step in values)
+    return {k: v for k, v in values.items() if not k.lstrip("-").isdigit() or k in kept}
+
+
 def write_golden_values_to_disk(
-    current_values: Dict[str, Any], golden_values_path: str, wandb_run: Optional["wandb.Run"] = None
+    current_values: Dict[str, Any],
+    golden_values_path: str,
+    wandb_run: Optional["wandb.Run"] = None,
+    max_steps: int = MAX_PERSISTED_GOLDEN_STEPS,
 ):
     """
     Write golden values to a file.
+
+    Per-step entries are downsampled to at most ``max_steps`` points (see
+    ``downsample_golden_values``) so long-convergence runs stay under the golden-values
+    repo's file-size limit. Downsampling is applied only to the persisted copy; the
+    full-resolution ``current_values`` is left untouched for the caller (e.g. the
+    cumulative resume curve).
     """
+    persisted_values = downsample_golden_values(current_values, max_steps)
     os.makedirs(os.path.dirname(golden_values_path), exist_ok=True)
     with open(golden_values_path, "w") as f:
-        json.dump(current_values, f)
+        json.dump(persisted_values, f)
 
     if wandb_run is not None:
         artifact = wandb.Artifact("golden_values", type="dataset")
         with artifact.new_file("golden_values.json", "w") as f:
-            json.dump({datetime.now().strftime("%m.%d.%y"): current_values}, f)
+            json.dump({datetime.now().strftime("%m.%d.%y"): persisted_values}, f)
         wandb_run.log_artifact(artifact)
 
     logger.info(f"Golden values were saved for {golden_values_path}.")

--- a/tests/unit_tests/scripts/performance/test_evaluate.py
+++ b/tests/unit_tests/scripts/performance/test_evaluate.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for scripts/performance/utils/evaluate.py golden-value downsampling."""
+
+import sys
+from pathlib import Path
+
+
+_PERF_SCRIPTS_DIR = Path(__file__).resolve().parents[4] / "scripts" / "performance"
+if str(_PERF_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_PERF_SCRIPTS_DIR))
+
+from utils.evaluate import downsample_golden_values  # noqa: E402
+
+
+def _make_values(n_steps: int) -> dict:
+    """Build a golden-values mapping with n_steps per-step entries plus scalar keys."""
+    values = {str(i): {"lm loss": float(i), "GPU utilization": 1.0} for i in range(n_steps)}
+    values.update({"alloc": 5.95, "max_alloc": 19.3, "max_reserved": 19.5, "job_id": 123})
+    return values
+
+
+def _step_keys(values: dict) -> list:
+    return sorted((int(k) for k in values if k.lstrip("-").isdigit()))
+
+
+def test_downsample_noop_when_under_cap():
+    values = _make_values(100)
+    result = downsample_golden_values(values, max_steps=10000)
+    assert result == values
+    # A fresh mapping is returned (defensive copy), not the same object.
+    assert result is not values
+
+
+def test_downsample_caps_step_count():
+    values = _make_values(150000)
+    result = downsample_golden_values(values, max_steps=10000)
+    step_keys = _step_keys(result)
+    # Evenly strided subset plus a couple of pinned/final steps; comfortably bounded.
+    assert 10000 <= len(step_keys) <= 10010
+
+
+def test_downsample_preserves_scalars_and_endpoints():
+    values = _make_values(30000)
+    result = downsample_golden_values(values, max_steps=10000)
+    # Scalar metadata is untouched.
+    for key in ("alloc", "max_alloc", "max_reserved", "job_id"):
+        assert result[key] == values[key]
+    # First step, pinned threshold step (49), and the final step survive.
+    assert "0" in result
+    assert "49" in result
+    assert "29999" in result
+    # Every retained step is a real step from the input (no fabricated keys).
+    assert set(_step_keys(result)).issubset(set(_step_keys(values)))
+
+
+def test_downsample_does_not_mutate_input():
+    values = _make_values(30000)
+    before = len(values)
+    downsample_golden_values(values, max_steps=10000)
+    assert len(values) == before


### PR DESCRIPTION
## Background
- Long-convergence runs persist a per-step golden-values curve via `write_golden_values_to_disk` in `scripts/performance/utils/evaluate.py`.
- For `wan_1_3b_text2image` (150k steps) / `text2video` (30k steps) this produces 37 MB / 7.4 MB files, which exceed the nemo-ci golden-values repo's **5 MiB/file** push limit (companion baseline MR: dl/JoC/nemo-ci!2561).

## What changed
- Add `downsample_golden_values()` and call it from `write_golden_values_to_disk` to cap persisted per-step entries at `MAX_PERSISTED_GOLDEN_STEPS` (~10k) evenly-spaced points.
- Always retain step `0`, step `49` (downstream perf reporter `STEPS_THRESHOLD`), and the final step; scalar metrics (`alloc`/`max_alloc`/`max_reserved`/`job_id`) untouched.
- Add unit tests in `tests/unit_tests/scripts/performance/test_evaluate.py`.

## Details
- **Safe by construction:** the in-job convergence/perf check builds its arrays from `sorted(golden_train_loss.keys())` and `current.get(step)` — it aligns by **golden step key**, so a sparse golden is compared correctly against the full-resolution run.
- Downsampling applies **only to the persisted artifact**; the full-resolution curve returned to the caller (cumulative resume slice via `write_cumulative_golden_values`) is left intact, so resumed long runs keep full per-step fidelity in the persistent dir.

```mermaid
flowchart LR
  L[run logs<br/>every step] --> M[merged full curve]
  M -->|returned| C[cumulative persist<br/>full-res, resume]
  M -->|downsample ~10k| A[golden artifact<br/>&lt;5 MiB]
  A --> R[committed baseline]
  R -->|aligned by step key| V[next run convergence check]
```