### PR TITLE
docs: fix broken README model links breaking docs build

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,8 +216,8 @@ Megatron Bridge provides out-of-the-box bridges and training recipes for a wide 
 |----------------|--------------------|
 | [**Bailing**](docs/models/bailing/index.md) | Ling 2.0 / Ling MoE V2 (Bailing) |
 | [**DeepSeek**](docs/models/deepseek/index.md) | DeepSeek V2 / V2 Lite, DeepSeek V3, DeepSeek V4 / V4 Flash |
-| [**Diffusion**](src/megatron/bridge/diffusion/models) | FLUX, LLaDA 1.5, Nemotron-Labs Diffusion, WAN |
-| **Ernie** | [Ernie 4.5 MoE](src/megatron/bridge/models/ernie), [Ernie 4.5 VL MoE](src/megatron/bridge/models/ernie_vl) |
+| [**Diffusion**](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/src/megatron/bridge/diffusion/models) | FLUX, LLaDA 1.5, Nemotron-Labs Diffusion, WAN |
+| **Ernie** | [Ernie 4.5 MoE](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/src/megatron/bridge/models/ernie), [Ernie 4.5 VL MoE](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/src/megatron/bridge/models/ernie_vl) |
 | [**Falcon**](docs/models/falcon/index.md) | Falcon H1 |
 | [**Gemma**](docs/models/gemma/index.md) | Gemma / Gemma 2, Gemma 3, Gemma 3-VL, Gemma 4 (26B-A4B MoE / 31B dense), Gemma 4-VL (26B-A4B MoE) |
 | [**GLM**](docs/models/glm/index.md) | GLM-4.5 / 4.7 / 4.7-Flash, GLM-4.5V, GLM-5 / 5.1 |


### PR DESCRIPTION
## Background

The `release / finalize / build-docs` job fails the Sphinx build with `--fail-on-warning`:

```
README.md:220: WARNING: 'myst' cross-reference target not found: 'src/megatron/bridge/diffusion/models' [myst.xref_missing]
README.md:221: WARNING: 'myst' cross-reference target not found: 'src/megatron/bridge/models/ernie' [myst.xref_missing]
README.md:221: WARNING: 'myst' cross-reference target not found: 'src/megatron/bridge/models/ernie_vl' [myst.xref_missing]
build finished with problems, 3 warnings (with warnings treated as errors).
```

`docs/index.md` pulls the root README in via `{include} ../README.md`, so MyST resolves the README's relative links as cross-references. The three Diffusion/Ernie rows in the Supported Models table linked to bare source directories, which have no doc target and fail resolution.

## What changed

- Convert the Diffusion / Ernie / Ernie-VL source-directory links to full GitHub URLs.

## Details

- The repo already uses full `https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/...` URLs for every other source-code reference in the README (e.g. model bridges, PEFT, recipes); rows backed by a doc page keep their `docs/models/<family>/index.md` link. This change just makes the three offending rows follow the same convention.
- External URLs are not treated as MyST cross-references, so the `--fail-on-warning` build passes.
- Verified no other bare relative source/example/script links remain in the README.