### PR TITLE
Improve Nemotron3 Super B200 BF16 Config

### DIFF
--- a/scripts/performance/configs/nemotronh/nemotron_3_workload_base_configs.py
+++ b/scripts/performance/configs/nemotronh/nemotron_3_workload_base_configs.py
@@ -140,14 +140,16 @@ NEMOTRON_3_SUPER_PRETRAIN_CONFIG_B300_NVFP4_V1 = NEMOTRON_3_SUPER_PRETRAIN_CONFI
 
 BASE_NEMOTRON_3_SUPER_CONFIG_B200 = replace(
     BASE_NEMOTRON_3_SUPER_CONFIG,
-    expert_model_parallel_size=64,
     cuda_graph_impl="none",
     recompute_modules=["moe_act", "layernorm"],
 )
-
 NEMOTRON_3_SUPER_PRETRAIN_CONFIG_B200_BF16_V1 = replace(
     BASE_NEMOTRON_3_SUPER_CONFIG_B200,
-    recompute_modules=["moe_act", "moe", "layernorm", "core_attn"],
+    tensor_model_parallel_size=2,
+    expert_model_parallel_size=8,
+    cuda_graph_impl="transformer_engine",
+    cuda_graph_scope=["mamba", "attn", "moe_router", "moe_preprocess"],
+    recompute_modules=["moe_act", "layernorm", "core_attn"],
 )
 NEMOTRON_3_SUPER_PRETRAIN_CONFIG_B200_FP8_MX_V1 = BASE_NEMOTRON_3_SUPER_CONFIG_B200
 NEMOTRON_3_SUPER_PRETRAIN_CONFIG_B200_NVFP4_V1 = replace(


### PR DESCRIPTION
Update Nemotron3 Super B200 BF16 Config to use GB200 Config
- Logic remains the same for B200 FP8 and NVFP4 Configs.
- `NEMOTRON_3_SUPER_PRETRAIN_CONFIG_B200_NVFP4_V1` already follows `BASE_NEMOTRON_3_SUPER_CONFIG_GB200`, meaning changing `BASE_NEMOTRON_3_SUPER_CONFIG_B200` would allow BF16 and NVFP4 to directly use it, only needing to change `NEMOTRON_3_SUPER_PRETRAIN_CONFIG_B200_FP8_MX_V1`.
- `BASE_NEMOTRON_3_SUPER_CONFIG_B200`'s `expert_model_parallel_size=64` is removed as it is already in `BASE_NEMOTRON_3_SUPER_CONFIG`
