### PR TITLE
refactor(inference): decouple inference scripts from the Megatron-LM reference layer

### DIFF
--- a/scripts/inference/async_text_generation.py
+++ b/scripts/inference/async_text_generation.py
@@ -38,7 +38,7 @@ import torch.distributed as dist
 from megatron.core.inference.apis import MegatronAsyncLLM, SamplingParams
 
 from megatron.bridge.inference.text_generation import (
-    HuggingFaceTextTokenizer,
+    HFTokenizerAdapter,
     add_distributed_args,
     add_engine_args,
     add_model_loading_args,
@@ -48,13 +48,12 @@ from megatron.bridge.inference.text_generation import (
     build_inference_config,
     build_sampling_params,
     build_tokenizer,
-    dtype_from_name,
     load_bridge_model,
     load_prompts,
-    maybe_initialize_distributed,
     resolve_hf_model_path,
 )
-from megatron.bridge.utils.common_utils import print_rank_0
+from megatron.bridge.utils.activation_map import str_to_dtype
+from megatron.bridge.utils.common_utils import maybe_initialize_distributed, print_rank_0
 
 
 logger = logging.getLogger(__name__)
@@ -87,7 +86,7 @@ def _validate_args(args: argparse.Namespace) -> None:
 async def _generate(
     args: argparse.Namespace,
     model: object,
-    tokenizer: HuggingFaceTextTokenizer,
+    tokenizer: HFTokenizerAdapter,
     prompts: list[str],
     sampling_params: SamplingParams,
 ) -> None:
@@ -132,7 +131,7 @@ def main() -> None:
     logging.basicConfig(level=logging.INFO)
     _validate_args(args)
     maybe_initialize_distributed(args.distributed_timeout_minutes)
-    dtype = dtype_from_name(args.dtype)
+    dtype = str_to_dtype(args.dtype)
     hf_model_path = resolve_hf_model_path(args.hf_model_path, args.megatron_model_path)
     prompts = load_prompts(args.prompt, args.prompt_file, args.prompt_file_num_truncate, _DEFAULT_PROMPTS)
 

--- a/scripts/inference/async_text_generation.py
+++ b/scripts/inference/async_text_generation.py
@@ -12,101 +12,99 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Direct MCore-style concurrent async text generation with MegatronAsyncLLM."""
+"""Bridge-backed concurrent async text generation with MegatronAsyncLLM.
+
+Like ``text_generation.py`` but drives the asynchronous MCore engine and generates all
+prompts concurrently. Imports only from ``megatron.core`` and ``megatron.bridge``.
+"""
 
 from __future__ import annotations
 
 import argparse
 import asyncio
-import json
 import logging
 import sys
 from pathlib import Path
 
 
 G_REPO_ROOT = Path(__file__).resolve().parents[2]
+G_SRC_ROOT = G_REPO_ROOT / "src"
 G_MCORE_ROOT = G_REPO_ROOT / "3rdparty" / "Megatron-LM"
-if G_MCORE_ROOT.exists() and str(G_MCORE_ROOT) not in sys.path:
-    sys.path.append(str(G_MCORE_ROOT))
+for _path in (G_SRC_ROOT, G_MCORE_ROOT):
+    if _path.exists() and str(_path) not in sys.path:
+        sys.path.append(str(_path))
 
 import torch.distributed as dist
 from megatron.core.inference.apis import MegatronAsyncLLM, SamplingParams
-from megatron.core.tokenizers.utils.build_tokenizer import build_tokenizer
-from megatron.inference.utils import (
-    add_inference_args,
-    get_inference_config_from_model_and_args,
-    get_model_for_inference,
+
+from megatron.bridge.inference.text_generation import (
+    HuggingFaceTextTokenizer,
+    add_distributed_args,
+    add_engine_args,
+    add_model_loading_args,
+    add_parallelism_args,
+    add_prompt_args,
+    add_sampling_args,
+    build_inference_config,
+    build_sampling_params,
+    build_tokenizer,
+    dtype_from_name,
+    load_bridge_model,
+    load_prompts,
+    maybe_initialize_distributed,
+    resolve_hf_model_path,
 )
-from megatron.training import initialize_megatron
-from megatron.training.arguments import parse_and_validate_args
-from megatron.training.utils import print_rank_0
+from megatron.bridge.utils.common_utils import print_rank_0
 
 
 logger = logging.getLogger(__name__)
 
+_DEFAULT_PROMPTS = ["Megatron async inference is", "Concurrent generation is useful because"]
 
-def add_async_generation_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
-    """Add high-level async generation arguments."""
-    parser = add_inference_args(parser)
-    group = parser.add_argument_group(title="High-level async inference")
-    group.add_argument("--coordinator-host", type=str, default=None, help="Coordinator ZMQ host.")
-    group.add_argument("--coordinator-port", type=int, default=None, help="Coordinator ZMQ port.")
+
+def add_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+    """Add Bridge async text generation arguments."""
+    add_model_loading_args(parser)
+    add_parallelism_args(parser)
+    add_prompt_args(parser)
+    add_sampling_args(parser)
+    add_engine_args(parser)
+    add_distributed_args(parser)
+
+    coordinator_group = parser.add_argument_group("Coordinator")
+    coordinator_group.add_argument("--coordinator-host", type=str, default=None, help="Coordinator ZMQ host.")
+    coordinator_group.add_argument("--coordinator-port", type=int, default=None, help="Coordinator ZMQ port.")
     return parser
-
-
-def _prompt_from_json_line(line: str) -> str | None:
-    try:
-        value = json.loads(line)
-    except json.JSONDecodeError:
-        return None
-    if not isinstance(value, dict):
-        return None
-    prompt = value.get("text")
-    return prompt if isinstance(prompt, str) else None
-
-
-def _load_prompts(args: argparse.Namespace) -> list[str]:
-    if args.prompts:
-        return list(args.prompts)
-    if args.prompt_file:
-        prompts = []
-        with Path(args.prompt_file).open("r", encoding="utf-8") as prompt_file:
-            for line in prompt_file:
-                raw_prompt = line.rstrip("\n")
-                if not raw_prompt:
-                    continue
-                prompts.append(_prompt_from_json_line(raw_prompt) or raw_prompt)
-                if args.prompt_file_num_truncate is not None and len(prompts) >= args.prompt_file_num_truncate:
-                    break
-        return prompts
-    return ["Megatron async inference is", "Concurrent generation is useful because"]
 
 
 def _validate_args(args: argparse.Namespace) -> None:
     if args.top_n_logprobs > 0 and not args.return_log_probs:
         raise ValueError("--top-n-logprobs requires --return-log-probs.")
+    if args.distributed_timeout_minutes <= 0:
+        raise ValueError("--distributed-timeout-minutes must be positive.")
 
 
-def _build_sampling_params(args: argparse.Namespace) -> SamplingParams:
-    return SamplingParams(
-        temperature=args.temperature,
-        top_k=args.top_k,
-        top_p=args.top_p,
-        return_log_probs=args.return_log_probs,
-        skip_prompt_log_probs=args.skip_prompt_log_probs,
-        num_tokens_to_generate=args.num_tokens_to_generate,
-        termination_id=args.termination_id,
-        top_n_logprobs=args.top_n_logprobs,
-        stop_words=args.stop_words,
-    )
-
-
-async def _generate(args: argparse.Namespace, model: object, tokenizer: object, prompts: list[str]) -> None:
-    inference_config = get_inference_config_from_model_and_args(model, args)
+async def _generate(
+    args: argparse.Namespace,
+    model: object,
+    tokenizer: HuggingFaceTextTokenizer,
+    prompts: list[str],
+    sampling_params: SamplingParams,
+) -> None:
     longest_prompt = max(len(tokenizer.tokenize(prompt)) for prompt in prompts)
-    inference_config.max_sequence_length = max(
-        inference_config.max_sequence_length,
-        longest_prompt + args.num_tokens_to_generate,
+    # Async path grows the configured window to fit the longest request rather than raising.
+    max_sequence_length = max(args.max_seq_length, longest_prompt + args.max_new_tokens)
+    inference_config = build_inference_config(
+        model=model,
+        max_sequence_length=max_sequence_length,
+        max_batch_size=args.max_batch_size,
+        num_prompts=len(prompts),
+        tp=args.tp,
+        block_size_tokens=args.block_size_tokens,
+        kv_cache_buffer_size_gb=args.kv_cache_buffer_size_gb,
+        max_tokens=args.max_tokens,
+        return_log_probs=args.return_log_probs,
+        enable_chunked_prefill=args.enable_chunked_prefill,
     )
 
     async with MegatronAsyncLLM(
@@ -118,7 +116,6 @@ async def _generate(args: argparse.Namespace, model: object, tokenizer: object, 
         coordinator_port=args.coordinator_port,
     ) as llm:
         if llm.is_primary_rank:
-            sampling_params = _build_sampling_params(args)
             results = await asyncio.gather(*(llm.generate(prompt, sampling_params) for prompt in prompts))
             print_rank_0("======== ASYNC GENERATED TEXT OUTPUT ========")
             for idx, result in enumerate(results):
@@ -128,21 +125,48 @@ async def _generate(args: argparse.Namespace, model: object, tokenizer: object, 
 
 
 def main() -> None:
-    """Run concurrent async generation using direct MCore model loading."""
-    args = parse_and_validate_args(
-        extra_args_provider=add_async_generation_args,
-        args_defaults={"no_load_rng": True, "no_load_optim": True},
-    )
-    initialize_megatron()
+    """Run Bridge-backed concurrent async text generation."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    args = add_args(parser).parse_args()
 
     logging.basicConfig(level=logging.INFO)
     _validate_args(args)
-    prompts = _load_prompts(args)
-    tokenizer = build_tokenizer(args)
-    model = get_model_for_inference()
+    maybe_initialize_distributed(args.distributed_timeout_minutes)
+    dtype = dtype_from_name(args.dtype)
+    hf_model_path = resolve_hf_model_path(args.hf_model_path, args.megatron_model_path)
+    prompts = load_prompts(args.prompt, args.prompt_file, args.prompt_file_num_truncate, _DEFAULT_PROMPTS)
+
+    print_rank_0(f"Loading model config/tokenizer from: {hf_model_path}")
+    tokenizer = build_tokenizer(hf_model_path, args.trust_remote_code)
+    model = load_bridge_model(
+        hf_model_path=hf_model_path,
+        megatron_model_path=args.megatron_model_path,
+        tp=args.tp,
+        pp=args.pp,
+        ep=args.ep,
+        etp=args.etp,
+        sequence_parallel=args.sequence_parallel,
+        dtype=dtype,
+        seed=args.seed,
+        trust_remote_code=args.trust_remote_code,
+        attention_backend=args.attention_backend,
+        cache_mla_latents=args.cache_mla_latents,
+        inference_moe_token_dispatcher_type=args.inference_moe_token_dispatcher_type,
+    )
+    sampling_params = build_sampling_params(
+        temperature=args.temperature,
+        top_k=args.top_k,
+        top_p=args.top_p,
+        return_log_probs=args.return_log_probs,
+        skip_prompt_log_probs=args.skip_prompt_log_probs,
+        num_tokens_to_generate=args.max_new_tokens,
+        termination_id=args.termination_id if args.termination_id is not None else tokenizer.eod,
+        top_n_logprobs=args.top_n_logprobs,
+        stop_words=args.stop_words,
+    )
 
     try:
-        asyncio.run(_generate(args, model, tokenizer, prompts))
+        asyncio.run(_generate(args, model, tokenizer, prompts, sampling_params))
     finally:
         if dist.is_available() and dist.is_initialized():
             dist.destroy_process_group()

--- a/scripts/inference/openai_server.py
+++ b/scripts/inference/openai_server.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Direct MCore-style OpenAI-compatible server using MegatronAsyncLLM."""
+"""Bridge-backed OpenAI-compatible server using MegatronAsyncLLM.
+
+Imports only from ``megatron.core`` and ``megatron.bridge`` (no Megatron-LM reference layer).
+"""
 
 from __future__ import annotations
 
@@ -24,30 +27,41 @@ from pathlib import Path
 
 
 G_REPO_ROOT = Path(__file__).resolve().parents[2]
+G_SRC_ROOT = G_REPO_ROOT / "src"
 G_MCORE_ROOT = G_REPO_ROOT / "3rdparty" / "Megatron-LM"
-if G_MCORE_ROOT.exists() and str(G_MCORE_ROOT) not in sys.path:
-    sys.path.append(str(G_MCORE_ROOT))
+for _path in (G_SRC_ROOT, G_MCORE_ROOT):
+    if _path.exists() and str(_path) not in sys.path:
+        sys.path.append(str(_path))
 
 import torch.distributed as dist
 from megatron.core.inference.apis import MegatronAsyncLLM, ServeConfig
-from megatron.core.tokenizers.utils.build_tokenizer import build_tokenizer
 from megatron.core.utils import configure_nvtx_profiling
-from megatron.inference.utils import (
-    add_inference_args,
-    get_inference_config_from_model_and_args,
-    get_model_for_inference,
+
+from megatron.bridge.inference.text_generation import (
+    add_distributed_args,
+    add_engine_args,
+    add_model_loading_args,
+    add_parallelism_args,
+    build_inference_config,
+    build_tokenizer,
+    load_bridge_model,
+    resolve_hf_model_path,
 )
-from megatron.training import get_args, initialize_megatron
-from megatron.training.arguments import parse_and_validate_args
+from megatron.bridge.utils.activation_map import str_to_dtype
+from megatron.bridge.utils.common_utils import maybe_initialize_distributed
 
 
 logger = logging.getLogger(__name__)
 
 
 def add_server_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
-    """Add OpenAI-compatible server arguments."""
-    parser = add_inference_args(parser)
-    group = parser.add_argument_group(title="High-level inference server")
+    """Add Bridge OpenAI-compatible server arguments."""
+    add_model_loading_args(parser)
+    add_parallelism_args(parser)
+    add_engine_args(parser)
+    add_distributed_args(parser)
+
+    group = parser.add_argument_group(title="Inference server")
     group.add_argument("--coordinator-host", type=str, default=None, help="Coordinator ZMQ host.")
     group.add_argument("--coordinator-port", type=int, default=None, help="Coordinator ZMQ port.")
     group.add_argument("--host", type=str, default="0.0.0.0", help="HTTP bind host.")
@@ -60,11 +74,27 @@ def add_server_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         default=4,
         help="Number of HTTP frontend processes spawned on the primary rank.",
     )
+    group.add_argument("--return-log-probs", action="store_true", help="Materialize all logits for log probs.")
+
+    profiling = parser.add_argument_group(title="Profiling")
+    profiling.add_argument("--profile", action="store_true", help="Enable profiling hooks.")
+    profiling.add_argument("--nvtx-ranges", action="store_true", help="Emit NVTX ranges when profiling.")
     return parser
 
 
 async def _serve(args: argparse.Namespace, model: object, tokenizer: object) -> None:
-    inference_config = get_inference_config_from_model_and_args(model, args)
+    inference_config = build_inference_config(
+        model=model,
+        max_sequence_length=args.max_seq_length,
+        max_batch_size=args.max_batch_size,
+        num_prompts=None,  # server: let the engine auto-size max_requests when unset
+        tp=args.tp,
+        block_size_tokens=args.block_size_tokens,
+        kv_cache_buffer_size_gb=args.kv_cache_buffer_size_gb,
+        max_tokens=args.max_tokens,
+        return_log_probs=args.return_log_probs,
+        enable_chunked_prefill=args.enable_chunked_prefill,
+    )
     async with MegatronAsyncLLM(
         model=model,
         tokenizer=tokenizer,
@@ -86,20 +116,35 @@ async def _serve(args: argparse.Namespace, model: object, tokenizer: object) -> 
 
 
 def main() -> None:
-    """Launch an OpenAI-compatible HTTP server using direct MCore model loading."""
-    parse_and_validate_args(
-        extra_args_provider=add_server_args,
-        args_defaults={"no_load_rng": True, "no_load_optim": True},
-    )
-    initialize_megatron()
-    args = get_args()
+    """Launch a Bridge-backed OpenAI-compatible HTTP server."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    args = add_server_args(parser).parse_args()
 
     logging.basicConfig(level=logging.INFO)
+    if args.distributed_timeout_minutes <= 0:
+        raise ValueError("--distributed-timeout-minutes must be positive.")
+    maybe_initialize_distributed(args.distributed_timeout_minutes)
     if args.profile and args.nvtx_ranges:
         configure_nvtx_profiling(True)
 
-    tokenizer = build_tokenizer(args)
-    model = get_model_for_inference()
+    dtype = str_to_dtype(args.dtype)
+    hf_model_path = resolve_hf_model_path(args.hf_model_path, args.megatron_model_path)
+    tokenizer = build_tokenizer(hf_model_path, args.trust_remote_code)
+    model = load_bridge_model(
+        hf_model_path=hf_model_path,
+        megatron_model_path=args.megatron_model_path,
+        tp=args.tp,
+        pp=args.pp,
+        ep=args.ep,
+        etp=args.etp,
+        sequence_parallel=args.sequence_parallel,
+        dtype=dtype,
+        seed=args.seed,
+        trust_remote_code=args.trust_remote_code,
+        attention_backend=args.attention_backend,
+        cache_mla_latents=args.cache_mla_latents,
+        inference_moe_token_dispatcher_type=args.inference_moe_token_dispatcher_type,
+    )
 
     try:
         asyncio.run(_serve(args, model, tokenizer))

--- a/scripts/inference/text_generation.py
+++ b/scripts/inference/text_generation.py
@@ -37,7 +37,7 @@ from megatron.core.inference.model_inference_wrappers.gpt.gpt_inference_wrapper 
 from megatron.core.inference.text_generation_controllers.text_generation_controller import TextGenerationController
 
 from megatron.bridge.inference.text_generation import (
-    HuggingFaceTextTokenizer,
+    HFTokenizerAdapter,
     add_distributed_args,
     add_engine_args,
     add_model_loading_args,
@@ -47,14 +47,13 @@ from megatron.bridge.inference.text_generation import (
     build_inference_config,
     build_sampling_params,
     build_tokenizer,
-    dtype_from_name,
     load_bridge_model,
     load_prompts,
-    maybe_initialize_distributed,
     resolve_hf_model_path,
     validate_sequence_length,
 )
-from megatron.bridge.utils.common_utils import print_rank_0
+from megatron.bridge.utils.activation_map import str_to_dtype
+from megatron.bridge.utils.common_utils import maybe_initialize_distributed, print_rank_0
 
 
 logger = logging.getLogger(__name__)
@@ -110,14 +109,14 @@ def _print_results(prompts: list[str], outputs: list[object]) -> None:
     print_rank_0("=======================================")
 
 
-def _longest_prompt_tokens(tokenizer: HuggingFaceTextTokenizer, prompts: list[str]) -> int:
+def _longest_prompt_tokens(tokenizer: HFTokenizerAdapter, prompts: list[str]) -> int:
     return max(len(tokenizer.tokenize(prompt)) for prompt in prompts)
 
 
 def _generate_with_dynamic_engine(
     args: argparse.Namespace,
     model: object,
-    tokenizer: HuggingFaceTextTokenizer,
+    tokenizer: HFTokenizerAdapter,
     prompts: list[str],
     sampling_params: SamplingParams,
 ) -> None:
@@ -154,7 +153,7 @@ def _generate_with_dynamic_engine(
 def _generate_with_legacy_static_engine(
     args: argparse.Namespace,
     model: object,
-    tokenizer: HuggingFaceTextTokenizer,
+    tokenizer: HFTokenizerAdapter,
     prompts: list[str],
     sampling_params: SamplingParams,
 ) -> None:
@@ -188,7 +187,7 @@ def main() -> None:
     logging.basicConfig(level=logging.INFO)
     _validate_args(args)
     maybe_initialize_distributed(args.distributed_timeout_minutes)
-    dtype = dtype_from_name(args.dtype)
+    dtype = str_to_dtype(args.dtype)
     hf_model_path = resolve_hf_model_path(args.hf_model_path, args.megatron_model_path)
     prompts = load_prompts(
         args.prompt, args.prompt_file, args.prompt_file_num_truncate, ["Megatron Bridge inference is"]

--- a/scripts/inference/text_generation.py
+++ b/scripts/inference/text_generation.py
@@ -17,11 +17,8 @@
 from __future__ import annotations
 
 import argparse
-import json
 import logging
-import os
 import sys
-from datetime import timedelta
 from pathlib import Path
 
 
@@ -32,192 +29,51 @@ for _path in (G_SRC_ROOT, G_MCORE_ROOT):
     if _path.exists() and str(_path) not in sys.path:
         sys.path.append(str(_path))
 
-import torch
 import torch.distributed as dist
 from megatron.core.inference.apis import MegatronLLM, SamplingParams
-from megatron.core.inference.config import InferenceConfig, MambaInferenceStateConfig
 from megatron.core.inference.contexts import StaticInferenceContext
 from megatron.core.inference.engines.static_engine import StaticInferenceEngine
 from megatron.core.inference.model_inference_wrappers.gpt.gpt_inference_wrapper import GPTInferenceWrapper
 from megatron.core.inference.text_generation_controllers.text_generation_controller import TextGenerationController
-from megatron.core.transformer.enums import AttnBackend
-from transformers import AutoConfig, AutoTokenizer, PreTrainedTokenizerBase
 
-from megatron.bridge import AutoBridge
-from megatron.bridge.models.hf_pretrained.utils import is_safe_repo
-from megatron.bridge.training.utils.checkpoint_utils import get_hf_model_id_from_checkpoint
-from megatron.bridge.utils.common_utils import (
-    disable_mtp_for_inference,
-    get_local_rank_preinit,
-    get_master_addr_safe,
-    get_master_port_safe,
-    get_rank_safe,
-    get_world_size_safe,
-    print_rank_0,
+from megatron.bridge.inference.text_generation import (
+    HuggingFaceTextTokenizer,
+    add_distributed_args,
+    add_engine_args,
+    add_model_loading_args,
+    add_parallelism_args,
+    add_prompt_args,
+    add_sampling_args,
+    build_inference_config,
+    build_sampling_params,
+    build_tokenizer,
+    dtype_from_name,
+    load_bridge_model,
+    load_prompts,
+    maybe_initialize_distributed,
+    resolve_hf_model_path,
+    validate_sequence_length,
 )
+from megatron.bridge.utils.common_utils import print_rank_0
 
 
 logger = logging.getLogger(__name__)
 
 
-class HuggingFaceTextTokenizer:
-    """Adapter exposing the tokenizer methods expected by MCore text generation."""
-
-    def __init__(self, tokenizer: PreTrainedTokenizerBase) -> None:
-        self._tokenizer = tokenizer
-        if self._tokenizer.pad_token is None and self._tokenizer.eos_token is not None:
-            self._tokenizer.pad_token = self._tokenizer.eos_token
-
-    @property
-    def eod(self) -> int | None:
-        """End-of-document token id used for early termination."""
-        return self._tokenizer.eos_token_id
-
-    @property
-    def bos(self) -> int | None:
-        """Beginning-of-sequence token id."""
-        return self._tokenizer.bos_token_id
-
-    @property
-    def vocab_size(self) -> int:
-        """Tokenizer vocabulary size."""
-        return len(self._tokenizer)
-
-    def tokenize(self, text: str) -> list[int]:
-        """Tokenize text into token ids."""
-        return self._tokenizer.encode(text, add_special_tokens=False)
-
-    def detokenize(self, tokens: list[int], skip_special_tokens: bool = True) -> str:
-        """Convert token ids back to text."""
-        return self._tokenizer.decode(tokens, skip_special_tokens=skip_special_tokens)
-
-
 def add_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
     """Add Bridge offline text generation arguments."""
-    model_group = parser.add_argument_group("Model loading")
-    model_group.add_argument(
-        "--hf_model_path",
-        "--hf-model-path",
-        dest="hf_model_path",
-        default=None,
-        help=(
-            "Hugging Face model id/path used for config and tokenizer. Required unless checkpoint metadata records it."
-        ),
-    )
-    model_group.add_argument(
-        "--megatron_model_path",
-        "--megatron-model-path",
-        dest="megatron_model_path",
-        default=None,
-        help="Optional Megatron Bridge checkpoint path. If omitted, load and convert HF weights in-process.",
-    )
-    model_group.add_argument(
-        "--trust-remote-code",
-        action="store_true",
-        default=None,
-        help="Allow custom Hugging Face model/tokenizer code for trusted repositories.",
-    )
-    model_group.add_argument(
-        "--dtype",
-        choices=("bf16", "fp16", "fp32"),
-        default="bf16",
-        help="Model parameter dtype for in-process HF conversion and provider setup.",
-    )
+    add_model_loading_args(parser)
+    add_parallelism_args(parser)
+    add_prompt_args(parser)
+    add_sampling_args(parser)
+    add_engine_args(parser)
+    add_distributed_args(parser)
 
-    parallel_group = parser.add_argument_group("Parallelism")
-    parallel_group.add_argument("--tp", type=int, default=1, help="Tensor model parallel size.")
-    parallel_group.add_argument("--pp", type=int, default=1, help="Pipeline model parallel size.")
-    parallel_group.add_argument("--ep", type=int, default=1, help="Expert model parallel size.")
-    parallel_group.add_argument("--etp", type=int, default=1, help="Expert tensor parallel size.")
-    parallel_group.add_argument("--sequence-parallel", action="store_true", help="Enable sequence parallelism.")
-    parallel_group.add_argument("--seed", type=int, default=0, help="Model-parallel RNG seed.")
-    parallel_group.add_argument(
-        "--cache-mla-latents",
-        action=argparse.BooleanOptionalAction,
-        default=None,
-        help="Cache MLA latents for dynamic inference. Defaults on for MLA models.",
-    )
-
-    prompt_group = parser.add_argument_group("Prompts")
-    prompt_group.add_argument(
-        "--prompt",
-        action="append",
-        default=[],
-        help="Prompt text. May be provided multiple times. Defaults to a short prompt if no prompt file is set.",
-    )
-    prompt_group.add_argument(
-        "--prompt_file",
-        "--prompt-file",
-        dest="prompt_file",
-        default=None,
-        help="Line-oriented prompt file. JSONL lines use the `text` or `prompt` field; other lines are raw prompts.",
-    )
-    prompt_group.add_argument(
-        "--prompt-file-num-truncate",
-        type=int,
-        default=None,
-        help="Read at most this many prompts from --prompt_file.",
-    )
-
-    sampling_group = parser.add_argument_group("Sampling")
-    sampling_group.add_argument("--max_new_tokens", type=int, default=30, help="Maximum generated tokens per prompt.")
-    sampling_group.add_argument("--temperature", type=float, default=1.0, help="Sampling temperature.")
-    sampling_group.add_argument("--top_p", type=float, default=0.0, help="Top-p sampling.")
-    sampling_group.add_argument("--top_k", type=int, default=1, help="Top-k sampling.")
-    sampling_group.add_argument("--return-log-probs", action="store_true", help="Return token log probabilities.")
-    sampling_group.add_argument("--skip-prompt-log-probs", action="store_true", help="Skip prompt log probabilities.")
-    sampling_group.add_argument("--top-n-logprobs", type=int, default=0, help="Return top-n logprobs.")
-    sampling_group.add_argument("--termination-id", type=int, default=None, help="Override tokenizer EOD id.")
-    sampling_group.add_argument(
-        "--stop-words",
-        nargs="+",
-        default=None,
-        help="Stop words that terminate generation when produced.",
-    )
-
-    inference_group = parser.add_argument_group("Inference")
+    inference_group = parser.add_argument_group("Generation mode")
     inference_group.add_argument(
         "--use-legacy-generation",
         action="store_true",
         help="Use MCore legacy static-batching generation instead of the dynamic MegatronLLM engine.",
-    )
-    inference_group.add_argument(
-        "--attention-backend",
-        choices=("auto", "flash", "fused", "unfused", "local"),
-        default=None,
-        help="Override the provider attention backend before constructing the Megatron model.",
-    )
-    inference_group.add_argument(
-        "--max_seq_length",
-        type=int,
-        default=4096,
-        help="Prompt plus generation length limit.",
-    )
-    inference_group.add_argument(
-        "--max_batch_size",
-        type=int,
-        default=None,
-        help="Maximum active requests. Defaults to the number of prompts.",
-    )
-    inference_group.add_argument("--max_tokens", type=int, default=None, help="Maximum active tokens.")
-    inference_group.add_argument(
-        "--block_size_tokens",
-        type=int,
-        default=256,
-        help="KV-cache block size in tokens.",
-    )
-    inference_group.add_argument(
-        "--kv_cache_buffer_size_gb",
-        type=float,
-        default=20.0,
-        help="GPU buffer size reserved for KV cache.",
-    )
-    inference_group.add_argument("--enable-chunked-prefill", action="store_true", help="Enable chunked prefill.")
-    inference_group.add_argument(
-        "--inference-moe-token-dispatcher-type",
-        choices=("nccl", "nvls"),
-        default=None,
-        help="Override the MCore MoE token dispatcher used during inference.",
     )
 
     coordinator_group = parser.add_argument_group("Coordinator")
@@ -228,25 +84,7 @@ def add_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
     )
     coordinator_group.add_argument("--coordinator-host", default=None, help="Coordinator ZMQ host.")
     coordinator_group.add_argument("--coordinator-port", type=int, default=None, help="Coordinator ZMQ port.")
-
-    distributed_group = parser.add_argument_group("Distributed")
-    distributed_group.add_argument(
-        "--distributed-timeout-minutes",
-        type=int,
-        default=60,
-        help="Process-group timeout in minutes for slow multi-node model setup.",
-    )
     return parser
-
-
-def _dtype_from_name(name: str) -> torch.dtype:
-    if name == "bf16":
-        return torch.bfloat16
-    if name == "fp16":
-        return torch.float16
-    if name == "fp32":
-        return torch.float32
-    raise ValueError(f"Unsupported dtype: {name}")
 
 
 def _validate_args(args: argparse.Namespace) -> None:
@@ -262,229 +100,6 @@ def _validate_args(args: argparse.Namespace) -> None:
         raise ValueError("--distributed-timeout-minutes must be positive.")
 
 
-def _maybe_initialize_distributed(timeout_minutes: int) -> None:
-    if not dist.is_available() or dist.is_initialized():
-        return
-
-    os.environ["RANK"] = os.environ.get("RANK", str(get_rank_safe()))
-    os.environ["WORLD_SIZE"] = os.environ.get("WORLD_SIZE", str(get_world_size_safe()))
-    os.environ["LOCAL_RANK"] = os.environ.get("LOCAL_RANK", str(get_local_rank_preinit()))
-    os.environ["MASTER_ADDR"] = os.environ.get("MASTER_ADDR", get_master_addr_safe())
-    os.environ["MASTER_PORT"] = os.environ.get("MASTER_PORT", str(get_master_port_safe()))
-    torch.cuda.set_device(int(os.environ["LOCAL_RANK"]))
-    dist.init_process_group("nccl", timeout=timedelta(minutes=timeout_minutes))
-
-
-def _resolve_hf_model_path(args: argparse.Namespace) -> str:
-    if args.hf_model_path:
-        return args.hf_model_path
-    if args.megatron_model_path:
-        hf_model_path = get_hf_model_id_from_checkpoint(args.megatron_model_path)
-        if hf_model_path:
-            return hf_model_path
-    raise ValueError("--hf_model_path is required when checkpoint metadata does not include model.hf_model_id")
-
-
-def _get_prompt_from_json_line(line: str) -> str | None:
-    try:
-        value = json.loads(line)
-    except json.JSONDecodeError:
-        return None
-    if not isinstance(value, dict):
-        return None
-    for key in ("text", "prompt", "input"):
-        prompt = value.get(key)
-        if isinstance(prompt, str):
-            return prompt
-    return None
-
-
-def _load_prompts(args: argparse.Namespace) -> list[str]:
-    prompts = list(args.prompt)
-    if args.prompt_file:
-        prompt_path = Path(args.prompt_file)
-        with prompt_path.open("r", encoding="utf-8") as prompt_file:
-            for line in prompt_file:
-                raw_prompt = line.rstrip("\n")
-                if not raw_prompt:
-                    continue
-                prompts.append(_get_prompt_from_json_line(raw_prompt) or raw_prompt)
-                if args.prompt_file_num_truncate is not None and len(prompts) >= args.prompt_file_num_truncate:
-                    break
-    if not prompts:
-        prompts.append("Megatron Bridge inference is")
-    return prompts
-
-
-def _build_sampling_params(args: argparse.Namespace, tokenizer: HuggingFaceTextTokenizer) -> SamplingParams:
-    termination_id = args.termination_id if args.termination_id is not None else tokenizer.eod
-    return SamplingParams(
-        temperature=args.temperature,
-        top_k=args.top_k,
-        top_p=args.top_p,
-        return_log_probs=args.return_log_probs,
-        skip_prompt_log_probs=args.skip_prompt_log_probs,
-        num_tokens_to_generate=args.max_new_tokens,
-        termination_id=termination_id,
-        top_n_logprobs=args.top_n_logprobs,
-        stop_words=args.stop_words,
-    )
-
-
-def _apply_provider_parallelism(provider: object, args: argparse.Namespace, dtype: torch.dtype) -> None:
-    setattr(provider, "tensor_model_parallel_size", args.tp)
-    setattr(provider, "pipeline_model_parallel_size", args.pp)
-    setattr(provider, "expert_model_parallel_size", args.ep)
-    setattr(provider, "expert_tensor_parallel_size", args.etp)
-    setattr(provider, "sequence_parallel", args.sequence_parallel)
-    setattr(provider, "params_dtype", dtype)
-    setattr(provider, "pipeline_dtype", dtype)
-    setattr(provider, "bf16", dtype == torch.bfloat16)
-    setattr(provider, "fp16", dtype == torch.float16)
-    if args.attention_backend is not None:
-        setattr(provider, "attention_backend", AttnBackend[args.attention_backend])
-    is_mla_model = bool(getattr(provider, "multi_latent_attention", False))
-    use_mla_latent_cache = args.cache_mla_latents
-    if use_mla_latent_cache is None:
-        use_mla_latent_cache = is_mla_model
-    if args.cache_mla_latents is not None or is_mla_model or hasattr(provider, "cache_mla_latents"):
-        setattr(provider, "cache_mla_latents", use_mla_latent_cache)
-    if args.inference_moe_token_dispatcher_type is not None:
-        if not hasattr(provider, "inference_moe_token_dispatcher_type"):
-            raise ValueError(
-                "--inference-moe-token-dispatcher-type was set, but the selected provider "
-                "does not expose inference_moe_token_dispatcher_type."
-            )
-        setattr(provider, "inference_moe_token_dispatcher_type", args.inference_moe_token_dispatcher_type)
-
-
-def _build_megatron_checkpoint_overrides(
-    provider: object, args: argparse.Namespace, dtype: torch.dtype
-) -> dict[str, object]:
-    mp_overrides = {
-        "tensor_model_parallel_size": args.tp,
-        "pipeline_model_parallel_size": args.pp,
-        "expert_model_parallel_size": args.ep,
-        "expert_tensor_parallel_size": args.etp,
-        "sequence_parallel": args.sequence_parallel,
-        "params_dtype": dtype,
-        "pipeline_dtype": dtype,
-        "bf16": dtype == torch.bfloat16,
-        "fp16": dtype == torch.float16,
-    }
-    if args.attention_backend is not None:
-        mp_overrides["attention_backend"] = AttnBackend[args.attention_backend]
-    if hasattr(provider, "cache_mla_latents"):
-        mp_overrides["cache_mla_latents"] = bool(getattr(provider, "cache_mla_latents"))
-    if args.inference_moe_token_dispatcher_type is not None:
-        mp_overrides["inference_moe_token_dispatcher_type"] = args.inference_moe_token_dispatcher_type
-    return mp_overrides
-
-
-def _prepare_model_list(model_list: list[torch.nn.Module]) -> torch.nn.Module:
-    if len(model_list) != 1:
-        raise ValueError("MegatronLLM supports one local model stage; virtual pipeline parallelism is not supported.")
-    model = model_list[0].cuda()
-    model.eval()
-    disable_mtp_for_inference(model)
-    if hasattr(model, "config"):
-        model.config.grad_scale_func = None
-    return model
-
-
-def _load_model(args: argparse.Namespace, hf_model_path: str, dtype: torch.dtype) -> torch.nn.Module:
-    trust_remote_code = is_safe_repo(hf_path=hf_model_path, trust_remote_code=args.trust_remote_code)
-
-    if args.megatron_model_path:
-        config = AutoConfig.from_pretrained(hf_model_path, trust_remote_code=trust_remote_code)
-        bridge = AutoBridge.from_hf_config(config)
-        provider = bridge.to_megatron_provider(load_weights=False)
-        _apply_provider_parallelism(provider, args, dtype)
-        provider.finalize()
-        provider.initialize_model_parallel(seed=args.seed)
-        mp_overrides = _build_megatron_checkpoint_overrides(provider, args, dtype)
-        model_list = bridge.load_megatron_model(
-            args.megatron_model_path,
-            mp_overrides=mp_overrides,
-            wrap_with_ddp=False,
-        )
-    else:
-        bridge = AutoBridge.from_hf_pretrained(
-            hf_model_path,
-            torch_dtype=dtype,
-            trust_remote_code=trust_remote_code,
-        )
-        provider = bridge.to_megatron_provider(load_weights=True)
-        _apply_provider_parallelism(provider, args, dtype)
-        provider.finalize()
-        provider.initialize_model_parallel(seed=args.seed)
-        model_list = provider.provide_distributed_model(wrap_with_ddp=False)
-
-    return _prepare_model_list(model_list)
-
-
-def _build_tokenizer(hf_model_path: str, trust_remote_code: bool | None) -> HuggingFaceTextTokenizer:
-    tokenizer = AutoTokenizer.from_pretrained(
-        hf_model_path,
-        trust_remote_code=is_safe_repo(hf_path=hf_model_path, trust_remote_code=trust_remote_code),
-    )
-    return HuggingFaceTextTokenizer(tokenizer)
-
-
-def _validate_sequence_length(
-    args: argparse.Namespace,
-    tokenizer: HuggingFaceTextTokenizer,
-    prompts: list[str],
-) -> None:
-    longest_prompt = max(len(tokenizer.tokenize(prompt)) for prompt in prompts)
-    required_sequence_length = longest_prompt + args.max_new_tokens
-    if required_sequence_length > args.max_seq_length:
-        raise ValueError(
-            f"Longest prompt plus generation needs {required_sequence_length} tokens, "
-            f"but --max_seq_length is {args.max_seq_length}."
-        )
-
-
-def _build_inference_config(
-    args: argparse.Namespace,
-    model: torch.nn.Module,
-    tokenizer: HuggingFaceTextTokenizer,
-    prompts: list[str],
-) -> InferenceConfig:
-    _validate_sequence_length(args, tokenizer, prompts)
-    if getattr(getattr(model, "config", None), "cache_mla_latents", False) and args.block_size_tokens != 64:
-        print_rank_0(
-            f"Using block size 64 instead of {args.block_size_tokens} because MCore dynamic inference "
-            "requires 64-token blocks when caching MLA latents."
-        )
-        args.block_size_tokens = 64
-
-    max_requests = args.max_batch_size or len(prompts)
-    if max_requests % args.tp != 0:
-        rounded_max_requests = ((max_requests + args.tp - 1) // args.tp) * args.tp
-        if args.max_batch_size is not None:
-            raise ValueError(
-                f"--max_batch_size must be divisible by --tp ({args.tp}); got --max_batch_size {args.max_batch_size}."
-            )
-        print_rank_0(
-            f"Rounding max batch size from {max_requests} to {rounded_max_requests} "
-            f"so it is divisible by tensor parallel size {args.tp}."
-        )
-        max_requests = rounded_max_requests
-
-    return InferenceConfig(
-        block_size_tokens=args.block_size_tokens,
-        buffer_size_gb=args.kv_cache_buffer_size_gb,
-        max_requests=max_requests,
-        max_tokens=args.max_tokens,
-        max_sequence_length=args.max_seq_length,
-        mamba_inference_state_config=MambaInferenceStateConfig.from_model(model),
-        pg_collection=getattr(model, "pg_collection", None),
-        materialize_only_last_token_logits=not args.return_log_probs,
-        enable_chunked_prefill=args.enable_chunked_prefill,
-    )
-
-
 def _print_results(prompts: list[str], outputs: list[object]) -> None:
     print_rank_0("======== GENERATED TEXT OUTPUT ========")
     for idx, output in enumerate(outputs):
@@ -495,14 +110,34 @@ def _print_results(prompts: list[str], outputs: list[object]) -> None:
     print_rank_0("=======================================")
 
 
+def _longest_prompt_tokens(tokenizer: HuggingFaceTextTokenizer, prompts: list[str]) -> int:
+    return max(len(tokenizer.tokenize(prompt)) for prompt in prompts)
+
+
 def _generate_with_dynamic_engine(
     args: argparse.Namespace,
-    model: torch.nn.Module,
+    model: object,
     tokenizer: HuggingFaceTextTokenizer,
     prompts: list[str],
     sampling_params: SamplingParams,
 ) -> None:
-    inference_config = _build_inference_config(args, model, tokenizer, prompts)
+    validate_sequence_length(
+        longest_prompt_tokens=_longest_prompt_tokens(tokenizer, prompts),
+        num_new_tokens=args.max_new_tokens,
+        max_seq_length=args.max_seq_length,
+    )
+    inference_config = build_inference_config(
+        model=model,
+        max_sequence_length=args.max_seq_length,
+        max_batch_size=args.max_batch_size,
+        num_prompts=len(prompts),
+        tp=args.tp,
+        block_size_tokens=args.block_size_tokens,
+        kv_cache_buffer_size_gb=args.kv_cache_buffer_size_gb,
+        max_tokens=args.max_tokens,
+        return_log_probs=args.return_log_probs,
+        enable_chunked_prefill=args.enable_chunked_prefill,
+    )
     with MegatronLLM(
         model=model,
         tokenizer=tokenizer,
@@ -518,12 +153,16 @@ def _generate_with_dynamic_engine(
 
 def _generate_with_legacy_static_engine(
     args: argparse.Namespace,
-    model: torch.nn.Module,
+    model: object,
     tokenizer: HuggingFaceTextTokenizer,
     prompts: list[str],
     sampling_params: SamplingParams,
 ) -> None:
-    _validate_sequence_length(args, tokenizer, prompts)
+    validate_sequence_length(
+        longest_prompt_tokens=_longest_prompt_tokens(tokenizer, prompts),
+        num_new_tokens=args.max_new_tokens,
+        max_seq_length=args.max_seq_length,
+    )
     max_batch_size = args.max_batch_size or len(prompts)
     inference_context = StaticInferenceContext(
         max_batch_size=max_batch_size,
@@ -548,15 +187,41 @@ def main() -> None:
 
     logging.basicConfig(level=logging.INFO)
     _validate_args(args)
-    _maybe_initialize_distributed(args.distributed_timeout_minutes)
-    dtype = _dtype_from_name(args.dtype)
-    hf_model_path = _resolve_hf_model_path(args)
-    prompts = _load_prompts(args)
+    maybe_initialize_distributed(args.distributed_timeout_minutes)
+    dtype = dtype_from_name(args.dtype)
+    hf_model_path = resolve_hf_model_path(args.hf_model_path, args.megatron_model_path)
+    prompts = load_prompts(
+        args.prompt, args.prompt_file, args.prompt_file_num_truncate, ["Megatron Bridge inference is"]
+    )
 
     print_rank_0(f"Loading model config/tokenizer from: {hf_model_path}")
-    tokenizer = _build_tokenizer(hf_model_path, args.trust_remote_code)
-    model = _load_model(args, hf_model_path, dtype)
-    sampling_params = _build_sampling_params(args, tokenizer)
+    tokenizer = build_tokenizer(hf_model_path, args.trust_remote_code)
+    model = load_bridge_model(
+        hf_model_path=hf_model_path,
+        megatron_model_path=args.megatron_model_path,
+        tp=args.tp,
+        pp=args.pp,
+        ep=args.ep,
+        etp=args.etp,
+        sequence_parallel=args.sequence_parallel,
+        dtype=dtype,
+        seed=args.seed,
+        trust_remote_code=args.trust_remote_code,
+        attention_backend=args.attention_backend,
+        cache_mla_latents=args.cache_mla_latents,
+        inference_moe_token_dispatcher_type=args.inference_moe_token_dispatcher_type,
+    )
+    sampling_params = build_sampling_params(
+        temperature=args.temperature,
+        top_k=args.top_k,
+        top_p=args.top_p,
+        return_log_probs=args.return_log_probs,
+        skip_prompt_log_probs=args.skip_prompt_log_probs,
+        num_tokens_to_generate=args.max_new_tokens,
+        termination_id=args.termination_id if args.termination_id is not None else tokenizer.eod,
+        top_n_logprobs=args.top_n_logprobs,
+        stop_words=args.stop_words,
+    )
 
     if args.use_legacy_generation:
         _generate_with_legacy_static_engine(args, model, tokenizer, prompts, sampling_params)

--- a/src/megatron/bridge/inference/_tokenizer.py
+++ b/src/megatron/bridge/inference/_tokenizer.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared HuggingFace tokenizer adapter for MCore text generation.
+
+MCore's ``TextGenerationController`` expects a tokenizer exposing ``eod`` / ``bos`` /
+``vocab_size`` attributes and ``tokenize`` / ``detokenize`` methods. This adapter wraps a
+HuggingFace tokenizer to that interface and is shared by the text-generation scripts and the
+VLM inference controllers (which previously each defined their own near-identical wrapper).
+
+Behavior knobs let call sites preserve their historical semantics exactly:
+- ``set_pad_token``: default the pad token to EOS when unset (text generation).
+- ``expose_vocab_size``: expose ``len(tokenizer)`` vs ``None`` (VLM historically used ``None``).
+- ``force_skip_special_tokens``: when not ``None``, ``detokenize`` ignores the caller-supplied
+  ``skip_special_tokens`` and always uses this value. The MCore controller passes
+  ``skip_special_tokens`` only when the method accepts it, so VLM (which always kept special
+  tokens) sets this to ``False`` to retain its prior behavior.
+"""
+
+from __future__ import annotations
+
+
+class HFTokenizerAdapter:
+    """Adapt a HuggingFace tokenizer to the MCore text-generation tokenizer interface."""
+
+    def __init__(
+        self,
+        tokenizer,
+        *,
+        set_pad_token: bool = True,
+        expose_vocab_size: bool = True,
+        force_skip_special_tokens: bool | None = None,
+    ) -> None:
+        self._tokenizer = tokenizer
+        self._force_skip_special_tokens = force_skip_special_tokens
+        if set_pad_token and tokenizer.pad_token is None and tokenizer.eos_token is not None:
+            tokenizer.pad_token = tokenizer.eos_token
+        self.eod = tokenizer.eos_token_id
+        self.bos = tokenizer.bos_token_id
+        self.vocab_size = len(tokenizer) if expose_vocab_size else None
+
+    def tokenize(self, text: str) -> list[int]:
+        """Tokenize text into token ids (no special tokens added)."""
+        return self._tokenizer.encode(text, add_special_tokens=False)
+
+    def detokenize(self, tokens: list[int], skip_special_tokens: bool = True) -> str:
+        """Convert token ids back to text.
+
+        When ``force_skip_special_tokens`` was set at construction, it overrides the
+        caller-supplied ``skip_special_tokens``.
+        """
+        if self._force_skip_special_tokens is not None:
+            skip_special_tokens = self._force_skip_special_tokens
+        return self._tokenizer.decode(tokens, skip_special_tokens=skip_special_tokens)

--- a/src/megatron/bridge/inference/text_generation.py
+++ b/src/megatron/bridge/inference/text_generation.py
@@ -26,35 +26,24 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
-from datetime import timedelta
 from pathlib import Path
 
 import torch
-import torch.distributed as dist
 from megatron.core.inference.config import InferenceConfig, MambaInferenceStateConfig
 from megatron.core.inference.apis import SamplingParams
 from megatron.core.transformer.enums import AttnBackend
 from megatron.core.utils import get_attr_wrapped_model
-from transformers import AutoConfig, AutoTokenizer, PreTrainedTokenizerBase
+from transformers import AutoConfig, AutoTokenizer
 
 from megatron.bridge import AutoBridge
+from megatron.bridge.inference._tokenizer import HFTokenizerAdapter
 from megatron.bridge.models.hf_pretrained.utils import is_safe_repo
 from megatron.bridge.training.utils.checkpoint_utils import get_hf_model_id_from_checkpoint
-from megatron.bridge.utils.common_utils import (
-    disable_mtp_for_inference,
-    get_local_rank_preinit,
-    get_master_addr_safe,
-    get_master_port_safe,
-    get_rank_safe,
-    get_world_size_safe,
-    print_rank_0,
-)
+from megatron.bridge.utils.activation_map import str_to_dtype
+from megatron.bridge.utils.common_utils import disable_mtp_for_inference, print_rank_0
 
 __all__ = [
-    "HuggingFaceTextTokenizer",
-    "dtype_from_name",
-    "maybe_initialize_distributed",
+    "HFTokenizerAdapter",
     "resolve_hf_model_path",
     "build_tokenizer",
     "load_prompts",
@@ -71,65 +60,9 @@ __all__ = [
 ]
 
 
-class HuggingFaceTextTokenizer:
-    """Adapter exposing the tokenizer methods expected by MCore text generation."""
-
-    def __init__(self, tokenizer: PreTrainedTokenizerBase) -> None:
-        self._tokenizer = tokenizer
-        if self._tokenizer.pad_token is None and self._tokenizer.eos_token is not None:
-            self._tokenizer.pad_token = self._tokenizer.eos_token
-
-    @property
-    def eod(self) -> int | None:
-        """End-of-document token id used for early termination."""
-        return self._tokenizer.eos_token_id
-
-    @property
-    def bos(self) -> int | None:
-        """Beginning-of-sequence token id."""
-        return self._tokenizer.bos_token_id
-
-    @property
-    def vocab_size(self) -> int:
-        """Tokenizer vocabulary size."""
-        return len(self._tokenizer)
-
-    def tokenize(self, text: str) -> list[int]:
-        """Tokenize text into token ids."""
-        return self._tokenizer.encode(text, add_special_tokens=False)
-
-    def detokenize(self, tokens: list[int], skip_special_tokens: bool = True) -> str:
-        """Convert token ids back to text."""
-        return self._tokenizer.decode(tokens, skip_special_tokens=skip_special_tokens)
-
-
-def dtype_from_name(name: str) -> torch.dtype:
-    """Map a CLI dtype name to a ``torch.dtype``."""
-    if name == "bf16":
-        return torch.bfloat16
-    if name == "fp16":
-        return torch.float16
-    if name == "fp32":
-        return torch.float32
-    raise ValueError(f"Unsupported dtype: {name}")
-
-
-def maybe_initialize_distributed(timeout_minutes: int) -> None:
-    """Initialize the default process group from the standard launcher env vars.
-
-    No-op when torch.distributed is unavailable or already initialized. Mirrors the
-    minimal, MLM-free distributed bring-up used by the Bridge inference scripts.
-    """
-    if not dist.is_available() or dist.is_initialized():
-        return
-
-    os.environ["RANK"] = os.environ.get("RANK", str(get_rank_safe()))
-    os.environ["WORLD_SIZE"] = os.environ.get("WORLD_SIZE", str(get_world_size_safe()))
-    os.environ["LOCAL_RANK"] = os.environ.get("LOCAL_RANK", str(get_local_rank_preinit()))
-    os.environ["MASTER_ADDR"] = os.environ.get("MASTER_ADDR", get_master_addr_safe())
-    os.environ["MASTER_PORT"] = os.environ.get("MASTER_PORT", str(get_master_port_safe()))
-    torch.cuda.set_device(int(os.environ["LOCAL_RANK"]))
-    dist.init_process_group("nccl", timeout=timedelta(minutes=timeout_minutes))
+# Dtype string -> torch.dtype: use the shared resolver (``str_to_dtype``) instead of a local map.
+# Distributed bring-up: use ``megatron.bridge.utils.common_utils.maybe_initialize_distributed``.
+# Tokenizer adapter: use ``megatron.bridge.inference._tokenizer.HFTokenizerAdapter``.
 
 
 def resolve_hf_model_path(hf_model_path: str | None, megatron_model_path: str | None) -> str:
@@ -181,13 +114,13 @@ def load_prompts(
     return collected
 
 
-def build_tokenizer(hf_model_path: str, trust_remote_code: bool | None) -> HuggingFaceTextTokenizer:
+def build_tokenizer(hf_model_path: str, trust_remote_code: bool | None) -> HFTokenizerAdapter:
     """Build the HF-backed tokenizer adapter for MCore text generation."""
     tokenizer = AutoTokenizer.from_pretrained(
         hf_model_path,
         trust_remote_code=is_safe_repo(hf_path=hf_model_path, trust_remote_code=trust_remote_code),
     )
-    return HuggingFaceTextTokenizer(tokenizer)
+    return HFTokenizerAdapter(tokenizer)
 
 
 def _apply_provider_parallelism(

--- a/src/megatron/bridge/inference/text_generation.py
+++ b/src/megatron/bridge/inference/text_generation.py
@@ -307,7 +307,7 @@ def build_inference_config(
     model: torch.nn.Module,
     max_sequence_length: int,
     max_batch_size: int | None,
-    num_prompts: int,
+    num_prompts: int | None,
     tp: int,
     block_size_tokens: int,
     kv_cache_buffer_size_gb: float,
@@ -317,8 +317,12 @@ def build_inference_config(
 ) -> InferenceConfig:
     """Construct the runtime ``megatron.core.inference.config.InferenceConfig``.
 
-    Centralizes the KV-cache / batching translation so both the sync and async scripts share
+    Centralizes the KV-cache / batching translation so the offline scripts and the server share
     one source of truth. Pure: never mutates caller state.
+
+    ``max_requests`` resolves to ``max_batch_size`` if set, else ``num_prompts``. When both are
+    ``None`` (e.g. a server that should auto-size to the KV-cache memory buffer), ``max_requests``
+    is left as ``None`` for the engine to size.
     """
     effective_block_size = block_size_tokens
     if getattr(getattr(model, "config", None), "cache_mla_latents", False) and block_size_tokens != 64:
@@ -329,7 +333,7 @@ def build_inference_config(
         effective_block_size = 64
 
     max_requests = max_batch_size or num_prompts
-    if max_requests % tp != 0:
+    if max_requests is not None and max_requests % tp != 0:
         rounded = ((max_requests + tp - 1) // tp) * tp
         if max_batch_size is not None:
             raise ValueError(

--- a/src/megatron/bridge/inference/text_generation.py
+++ b/src/megatron/bridge/inference/text_generation.py
@@ -1,0 +1,597 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared building blocks for Bridge-backed MCore text generation.
+
+This module holds the model-loading, tokenizer, distributed-init, prompt, sampling, and
+``InferenceConfig`` helpers shared by the standalone scripts under ``scripts/inference/``
+(``text_generation.py`` and ``async_text_generation.py``). It depends only on
+``megatron.core`` and ``megatron.bridge`` -- never on the Megatron-LM reference layer
+(``megatron.inference`` / ``megatron.training``) -- so the scripts stay on the Bridge/Core
+layer and are insulated from refactors of Megatron-LM's inference entry points.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import timedelta
+from pathlib import Path
+
+import torch
+import torch.distributed as dist
+from megatron.core.inference.config import InferenceConfig, MambaInferenceStateConfig
+from megatron.core.inference.apis import SamplingParams
+from megatron.core.transformer.enums import AttnBackend
+from megatron.core.utils import get_attr_wrapped_model
+from transformers import AutoConfig, AutoTokenizer, PreTrainedTokenizerBase
+
+from megatron.bridge import AutoBridge
+from megatron.bridge.models.hf_pretrained.utils import is_safe_repo
+from megatron.bridge.training.utils.checkpoint_utils import get_hf_model_id_from_checkpoint
+from megatron.bridge.utils.common_utils import (
+    disable_mtp_for_inference,
+    get_local_rank_preinit,
+    get_master_addr_safe,
+    get_master_port_safe,
+    get_rank_safe,
+    get_world_size_safe,
+    print_rank_0,
+)
+
+__all__ = [
+    "HuggingFaceTextTokenizer",
+    "dtype_from_name",
+    "maybe_initialize_distributed",
+    "resolve_hf_model_path",
+    "build_tokenizer",
+    "load_prompts",
+    "load_bridge_model",
+    "build_inference_config",
+    "build_sampling_params",
+    "validate_sequence_length",
+    "add_model_loading_args",
+    "add_parallelism_args",
+    "add_prompt_args",
+    "add_sampling_args",
+    "add_engine_args",
+    "add_distributed_args",
+]
+
+
+class HuggingFaceTextTokenizer:
+    """Adapter exposing the tokenizer methods expected by MCore text generation."""
+
+    def __init__(self, tokenizer: PreTrainedTokenizerBase) -> None:
+        self._tokenizer = tokenizer
+        if self._tokenizer.pad_token is None and self._tokenizer.eos_token is not None:
+            self._tokenizer.pad_token = self._tokenizer.eos_token
+
+    @property
+    def eod(self) -> int | None:
+        """End-of-document token id used for early termination."""
+        return self._tokenizer.eos_token_id
+
+    @property
+    def bos(self) -> int | None:
+        """Beginning-of-sequence token id."""
+        return self._tokenizer.bos_token_id
+
+    @property
+    def vocab_size(self) -> int:
+        """Tokenizer vocabulary size."""
+        return len(self._tokenizer)
+
+    def tokenize(self, text: str) -> list[int]:
+        """Tokenize text into token ids."""
+        return self._tokenizer.encode(text, add_special_tokens=False)
+
+    def detokenize(self, tokens: list[int], skip_special_tokens: bool = True) -> str:
+        """Convert token ids back to text."""
+        return self._tokenizer.decode(tokens, skip_special_tokens=skip_special_tokens)
+
+
+def dtype_from_name(name: str) -> torch.dtype:
+    """Map a CLI dtype name to a ``torch.dtype``."""
+    if name == "bf16":
+        return torch.bfloat16
+    if name == "fp16":
+        return torch.float16
+    if name == "fp32":
+        return torch.float32
+    raise ValueError(f"Unsupported dtype: {name}")
+
+
+def maybe_initialize_distributed(timeout_minutes: int) -> None:
+    """Initialize the default process group from the standard launcher env vars.
+
+    No-op when torch.distributed is unavailable or already initialized. Mirrors the
+    minimal, MLM-free distributed bring-up used by the Bridge inference scripts.
+    """
+    if not dist.is_available() or dist.is_initialized():
+        return
+
+    os.environ["RANK"] = os.environ.get("RANK", str(get_rank_safe()))
+    os.environ["WORLD_SIZE"] = os.environ.get("WORLD_SIZE", str(get_world_size_safe()))
+    os.environ["LOCAL_RANK"] = os.environ.get("LOCAL_RANK", str(get_local_rank_preinit()))
+    os.environ["MASTER_ADDR"] = os.environ.get("MASTER_ADDR", get_master_addr_safe())
+    os.environ["MASTER_PORT"] = os.environ.get("MASTER_PORT", str(get_master_port_safe()))
+    torch.cuda.set_device(int(os.environ["LOCAL_RANK"]))
+    dist.init_process_group("nccl", timeout=timedelta(minutes=timeout_minutes))
+
+
+def resolve_hf_model_path(hf_model_path: str | None, megatron_model_path: str | None) -> str:
+    """Resolve the HF model id used for config/tokenizer, falling back to checkpoint metadata."""
+    if hf_model_path:
+        return hf_model_path
+    if megatron_model_path:
+        resolved = get_hf_model_id_from_checkpoint(megatron_model_path)
+        if resolved:
+            return resolved
+    raise ValueError(
+        "--hf_model_path is required when checkpoint metadata does not include model.hf_model_id"
+    )
+
+
+def _get_prompt_from_json_line(line: str) -> str | None:
+    try:
+        value = json.loads(line)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(value, dict):
+        return None
+    for key in ("text", "prompt", "input"):
+        prompt = value.get(key)
+        if isinstance(prompt, str):
+            return prompt
+    return None
+
+
+def load_prompts(
+    prompts: list[str] | None,
+    prompt_file: str | None,
+    prompt_file_num_truncate: int | None,
+    default_prompts: list[str],
+) -> list[str]:
+    """Collect prompts from explicit args and/or a line-oriented (optionally JSONL) file."""
+    collected = list(prompts or [])
+    if prompt_file:
+        with Path(prompt_file).open("r", encoding="utf-8") as handle:
+            for line in handle:
+                raw_prompt = line.rstrip("\n")
+                if not raw_prompt:
+                    continue
+                collected.append(_get_prompt_from_json_line(raw_prompt) or raw_prompt)
+                if prompt_file_num_truncate is not None and len(collected) >= prompt_file_num_truncate:
+                    break
+    if not collected:
+        collected = list(default_prompts)
+    return collected
+
+
+def build_tokenizer(hf_model_path: str, trust_remote_code: bool | None) -> HuggingFaceTextTokenizer:
+    """Build the HF-backed tokenizer adapter for MCore text generation."""
+    tokenizer = AutoTokenizer.from_pretrained(
+        hf_model_path,
+        trust_remote_code=is_safe_repo(hf_path=hf_model_path, trust_remote_code=trust_remote_code),
+    )
+    return HuggingFaceTextTokenizer(tokenizer)
+
+
+def _apply_provider_parallelism(
+    provider: object,
+    *,
+    tp: int,
+    pp: int,
+    ep: int,
+    etp: int,
+    sequence_parallel: bool,
+    dtype: torch.dtype,
+    attention_backend: str | None,
+    cache_mla_latents: bool | None,
+    inference_moe_token_dispatcher_type: str | None,
+) -> None:
+    setattr(provider, "tensor_model_parallel_size", tp)
+    setattr(provider, "pipeline_model_parallel_size", pp)
+    setattr(provider, "expert_model_parallel_size", ep)
+    setattr(provider, "expert_tensor_parallel_size", etp)
+    setattr(provider, "sequence_parallel", sequence_parallel)
+    setattr(provider, "params_dtype", dtype)
+    setattr(provider, "pipeline_dtype", dtype)
+    setattr(provider, "bf16", dtype == torch.bfloat16)
+    setattr(provider, "fp16", dtype == torch.float16)
+    if attention_backend is not None:
+        setattr(provider, "attention_backend", AttnBackend[attention_backend])
+    is_mla_model = bool(getattr(provider, "multi_latent_attention", False))
+    use_mla_latent_cache = cache_mla_latents
+    if use_mla_latent_cache is None:
+        use_mla_latent_cache = is_mla_model
+    if cache_mla_latents is not None or is_mla_model or hasattr(provider, "cache_mla_latents"):
+        setattr(provider, "cache_mla_latents", use_mla_latent_cache)
+    if inference_moe_token_dispatcher_type is not None:
+        if not hasattr(provider, "inference_moe_token_dispatcher_type"):
+            raise ValueError(
+                "--inference-moe-token-dispatcher-type was set, but the selected provider "
+                "does not expose inference_moe_token_dispatcher_type."
+            )
+        setattr(provider, "inference_moe_token_dispatcher_type", inference_moe_token_dispatcher_type)
+
+
+def _megatron_checkpoint_overrides(
+    provider: object,
+    *,
+    tp: int,
+    pp: int,
+    ep: int,
+    etp: int,
+    sequence_parallel: bool,
+    dtype: torch.dtype,
+    attention_backend: str | None,
+    inference_moe_token_dispatcher_type: str | None,
+) -> dict[str, object]:
+    overrides: dict[str, object] = {
+        "tensor_model_parallel_size": tp,
+        "pipeline_model_parallel_size": pp,
+        "expert_model_parallel_size": ep,
+        "expert_tensor_parallel_size": etp,
+        "sequence_parallel": sequence_parallel,
+        "params_dtype": dtype,
+        "pipeline_dtype": dtype,
+        "bf16": dtype == torch.bfloat16,
+        "fp16": dtype == torch.float16,
+    }
+    if attention_backend is not None:
+        overrides["attention_backend"] = AttnBackend[attention_backend]
+    if hasattr(provider, "cache_mla_latents"):
+        overrides["cache_mla_latents"] = bool(getattr(provider, "cache_mla_latents"))
+    if inference_moe_token_dispatcher_type is not None:
+        overrides["inference_moe_token_dispatcher_type"] = inference_moe_token_dispatcher_type
+    return overrides
+
+
+def _prepare_model_list(model_list: list[torch.nn.Module]) -> torch.nn.Module:
+    if len(model_list) != 1:
+        raise ValueError(
+            "MCore high-level inference supports one local model stage; "
+            "virtual pipeline parallelism is not supported."
+        )
+    model = model_list[0].cuda()
+    model.eval()
+    disable_mtp_for_inference(model)
+    if hasattr(model, "config"):
+        model.config.grad_scale_func = None
+    return model
+
+
+def load_bridge_model(
+    *,
+    hf_model_path: str,
+    megatron_model_path: str | None,
+    tp: int,
+    pp: int,
+    ep: int,
+    etp: int,
+    sequence_parallel: bool,
+    dtype: torch.dtype,
+    seed: int,
+    trust_remote_code: bool | None,
+    attention_backend: str | None = None,
+    cache_mla_latents: bool | None = None,
+    inference_moe_token_dispatcher_type: str | None = None,
+) -> torch.nn.Module:
+    """Build (and optionally load weights for) a single-stage Megatron model via AutoBridge.
+
+    When ``megatron_model_path`` is provided, the Megatron Bridge checkpoint is loaded with
+    the given parallelism overrides; otherwise HF weights are converted in-process.
+    """
+    safe_trust_remote_code = is_safe_repo(hf_path=hf_model_path, trust_remote_code=trust_remote_code)
+
+    parallelism = dict(
+        tp=tp,
+        pp=pp,
+        ep=ep,
+        etp=etp,
+        sequence_parallel=sequence_parallel,
+        dtype=dtype,
+        attention_backend=attention_backend,
+        inference_moe_token_dispatcher_type=inference_moe_token_dispatcher_type,
+    )
+
+    if megatron_model_path:
+        config = AutoConfig.from_pretrained(hf_model_path, trust_remote_code=safe_trust_remote_code)
+        bridge = AutoBridge.from_hf_config(config)
+        provider = bridge.to_megatron_provider(load_weights=False)
+        _apply_provider_parallelism(provider, cache_mla_latents=cache_mla_latents, **parallelism)
+        provider.finalize()
+        provider.initialize_model_parallel(seed=seed)
+        mp_overrides = _megatron_checkpoint_overrides(provider, **parallelism)
+        model_list = bridge.load_megatron_model(
+            megatron_model_path,
+            mp_overrides=mp_overrides,
+            wrap_with_ddp=False,
+        )
+    else:
+        bridge = AutoBridge.from_hf_pretrained(
+            hf_model_path,
+            torch_dtype=dtype,
+            trust_remote_code=safe_trust_remote_code,
+        )
+        provider = bridge.to_megatron_provider(load_weights=True)
+        _apply_provider_parallelism(provider, cache_mla_latents=cache_mla_latents, **parallelism)
+        provider.finalize()
+        provider.initialize_model_parallel(seed=seed)
+        model_list = provider.provide_distributed_model(wrap_with_ddp=False)
+
+    return _prepare_model_list(model_list)
+
+
+def validate_sequence_length(
+    *,
+    longest_prompt_tokens: int,
+    num_new_tokens: int,
+    max_seq_length: int,
+) -> None:
+    """Raise if the longest prompt plus generation exceeds the configured sequence length."""
+    required = longest_prompt_tokens + num_new_tokens
+    if required > max_seq_length:
+        raise ValueError(
+            f"Longest prompt plus generation needs {required} tokens, "
+            f"but --max_seq_length is {max_seq_length}."
+        )
+
+
+def _effective_max_sequence_length(model: torch.nn.Module, max_sequence_length: int) -> int:
+    """Clamp the requested sequence length to the model's table for learned-absolute pos-emb.
+
+    For ``learned_absolute`` position embeddings the context's ``max_sequence_length`` must not
+    exceed the model's, otherwise the position ids index past the embedding table. RoPE/other
+    embeddings are unaffected (pass-through).
+    """
+    try:
+        position_embedding_type = get_attr_wrapped_model(model, "position_embedding_type")
+        model_max_seq_len = get_attr_wrapped_model(model, "max_sequence_length")
+    except Exception:  # noqa: BLE001 - model may not expose these attrs; keep pass-through.
+        return max_sequence_length
+    if position_embedding_type == "learned_absolute" and model_max_seq_len:
+        return min(model_max_seq_len, max_sequence_length)
+    return max_sequence_length
+
+
+def build_inference_config(
+    *,
+    model: torch.nn.Module,
+    max_sequence_length: int,
+    max_batch_size: int | None,
+    num_prompts: int,
+    tp: int,
+    block_size_tokens: int,
+    kv_cache_buffer_size_gb: float,
+    max_tokens: int | None,
+    return_log_probs: bool,
+    enable_chunked_prefill: bool,
+) -> InferenceConfig:
+    """Construct the runtime ``megatron.core.inference.config.InferenceConfig``.
+
+    Centralizes the KV-cache / batching translation so both the sync and async scripts share
+    one source of truth. Pure: never mutates caller state.
+    """
+    effective_block_size = block_size_tokens
+    if getattr(getattr(model, "config", None), "cache_mla_latents", False) and block_size_tokens != 64:
+        print_rank_0(
+            f"Using block size 64 instead of {block_size_tokens} because MCore dynamic inference "
+            "requires 64-token blocks when caching MLA latents."
+        )
+        effective_block_size = 64
+
+    max_requests = max_batch_size or num_prompts
+    if max_requests % tp != 0:
+        rounded = ((max_requests + tp - 1) // tp) * tp
+        if max_batch_size is not None:
+            raise ValueError(
+                f"--max_batch_size must be divisible by --tp ({tp}); got --max_batch_size {max_batch_size}."
+            )
+        print_rank_0(
+            f"Rounding max batch size from {max_requests} to {rounded} "
+            f"so it is divisible by tensor parallel size {tp}."
+        )
+        max_requests = rounded
+
+    return InferenceConfig(
+        block_size_tokens=effective_block_size,
+        buffer_size_gb=kv_cache_buffer_size_gb,
+        max_requests=max_requests,
+        max_tokens=max_tokens,
+        max_sequence_length=_effective_max_sequence_length(model, max_sequence_length),
+        mamba_inference_state_config=MambaInferenceStateConfig.from_model(model),
+        pg_collection=getattr(model, "pg_collection", None),
+        materialize_only_last_token_logits=not return_log_probs,
+        enable_chunked_prefill=enable_chunked_prefill,
+    )
+
+
+def build_sampling_params(
+    *,
+    temperature: float,
+    top_k: int,
+    top_p: float,
+    return_log_probs: bool,
+    skip_prompt_log_probs: bool,
+    num_tokens_to_generate: int,
+    termination_id: int | None,
+    top_n_logprobs: int,
+    stop_words: list[str] | None,
+) -> SamplingParams:
+    """Build MCore ``SamplingParams`` from CLI-derived values."""
+    return SamplingParams(
+        temperature=temperature,
+        top_k=top_k,
+        top_p=top_p,
+        return_log_probs=return_log_probs,
+        skip_prompt_log_probs=skip_prompt_log_probs,
+        num_tokens_to_generate=num_tokens_to_generate,
+        termination_id=termination_id,
+        top_n_logprobs=top_n_logprobs,
+        stop_words=stop_words,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Argument groups shared by the standalone scripts.
+# ---------------------------------------------------------------------------
+
+
+def add_model_loading_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+    """Add model-loading args (HF/Megatron source, trust-remote-code, dtype)."""
+    group = parser.add_argument_group("Model loading")
+    group.add_argument(
+        "--hf_model_path",
+        "--hf-model-path",
+        dest="hf_model_path",
+        default=None,
+        help="Hugging Face model id/path for config and tokenizer. Required unless checkpoint "
+        "metadata records it.",
+    )
+    group.add_argument(
+        "--megatron_model_path",
+        "--megatron-model-path",
+        dest="megatron_model_path",
+        default=None,
+        help="Optional Megatron Bridge checkpoint path. If omitted, load and convert HF weights "
+        "in-process.",
+    )
+    group.add_argument(
+        "--trust-remote-code",
+        action="store_true",
+        default=None,
+        help="Allow custom Hugging Face model/tokenizer code for trusted repositories.",
+    )
+    group.add_argument(
+        "--dtype",
+        choices=("bf16", "fp16", "fp32"),
+        default="bf16",
+        help="Model parameter dtype for in-process HF conversion and provider setup.",
+    )
+    return parser
+
+
+def add_parallelism_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+    """Add parallelism + RNG-seed + MLA-cache args."""
+    group = parser.add_argument_group("Parallelism")
+    group.add_argument("--tp", type=int, default=1, help="Tensor model parallel size.")
+    group.add_argument("--pp", type=int, default=1, help="Pipeline model parallel size.")
+    group.add_argument("--ep", type=int, default=1, help="Expert model parallel size.")
+    group.add_argument("--etp", type=int, default=1, help="Expert tensor parallel size.")
+    group.add_argument("--sequence-parallel", action="store_true", help="Enable sequence parallelism.")
+    group.add_argument("--seed", type=int, default=0, help="Model-parallel RNG seed.")
+    group.add_argument(
+        "--cache-mla-latents",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Cache MLA latents for dynamic inference. Defaults on for MLA models.",
+    )
+    return parser
+
+
+def add_prompt_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+    """Add prompt-source args."""
+    group = parser.add_argument_group("Prompts")
+    group.add_argument(
+        "--prompt",
+        action="append",
+        default=[],
+        help="Prompt text. May be provided multiple times. Defaults to a short prompt if no "
+        "prompt file is set.",
+    )
+    group.add_argument(
+        "--prompt_file",
+        "--prompt-file",
+        dest="prompt_file",
+        default=None,
+        help="Line-oriented prompt file. JSONL lines use the `text`/`prompt`/`input` field; other "
+        "lines are raw prompts.",
+    )
+    group.add_argument(
+        "--prompt-file-num-truncate",
+        type=int,
+        default=None,
+        help="Read at most this many prompts from --prompt_file.",
+    )
+    return parser
+
+
+def add_sampling_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+    """Add sampling args. ``--max_new_tokens`` is the canonical generation-length flag."""
+    group = parser.add_argument_group("Sampling")
+    group.add_argument("--max_new_tokens", type=int, default=30, help="Maximum generated tokens per prompt.")
+    group.add_argument("--temperature", type=float, default=1.0, help="Sampling temperature.")
+    group.add_argument("--top_p", type=float, default=0.0, help="Top-p sampling.")
+    group.add_argument("--top_k", type=int, default=1, help="Top-k sampling.")
+    group.add_argument("--return-log-probs", action="store_true", help="Return token log probabilities.")
+    group.add_argument("--skip-prompt-log-probs", action="store_true", help="Skip prompt log probabilities.")
+    group.add_argument("--top-n-logprobs", type=int, default=0, help="Return top-n logprobs.")
+    group.add_argument("--termination-id", type=int, default=None, help="Override tokenizer EOD id.")
+    group.add_argument(
+        "--stop-words",
+        nargs="+",
+        default=None,
+        help="Stop words that terminate generation when produced.",
+    )
+    return parser
+
+
+def add_engine_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+    """Add KV-cache / batching / attention-backend engine args."""
+    group = parser.add_argument_group("Inference engine")
+    group.add_argument(
+        "--attention-backend",
+        choices=("auto", "flash", "fused", "unfused", "local"),
+        default=None,
+        help="Override the provider attention backend before constructing the Megatron model.",
+    )
+    group.add_argument("--max_seq_length", type=int, default=4096, help="Prompt plus generation length limit.")
+    group.add_argument(
+        "--max_batch_size",
+        type=int,
+        default=None,
+        help="Maximum active requests. Defaults to the number of prompts.",
+    )
+    group.add_argument("--max_tokens", type=int, default=None, help="Maximum active tokens.")
+    group.add_argument("--block_size_tokens", type=int, default=256, help="KV-cache block size in tokens.")
+    group.add_argument(
+        "--kv_cache_buffer_size_gb",
+        type=float,
+        default=20.0,
+        help="GPU buffer size reserved for KV cache.",
+    )
+    group.add_argument("--enable-chunked-prefill", action="store_true", help="Enable chunked prefill.")
+    group.add_argument(
+        "--inference-moe-token-dispatcher-type",
+        choices=("nccl", "nvls"),
+        default=None,
+        help="Override the MCore MoE token dispatcher used during inference.",
+    )
+    return parser
+
+
+def add_distributed_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+    """Add distributed-init timeout arg."""
+    group = parser.add_argument_group("Distributed")
+    group.add_argument(
+        "--distributed-timeout-minutes",
+        type=int,
+        default=60,
+        help="Process-group timeout in minutes for slow multi-node model setup.",
+    )
+    return parser

--- a/src/megatron/bridge/inference/text_generation.py
+++ b/src/megatron/bridge/inference/text_generation.py
@@ -29,8 +29,8 @@ import json
 from pathlib import Path
 
 import torch
-from megatron.core.inference.config import InferenceConfig, MambaInferenceStateConfig
 from megatron.core.inference.apis import SamplingParams
+from megatron.core.inference.config import InferenceConfig, MambaInferenceStateConfig
 from megatron.core.transformer.enums import AttnBackend
 from megatron.core.utils import get_attr_wrapped_model
 from transformers import AutoConfig, AutoTokenizer
@@ -39,8 +39,8 @@ from megatron.bridge import AutoBridge
 from megatron.bridge.inference._tokenizer import HFTokenizerAdapter
 from megatron.bridge.models.hf_pretrained.utils import is_safe_repo
 from megatron.bridge.training.utils.checkpoint_utils import get_hf_model_id_from_checkpoint
-from megatron.bridge.utils.activation_map import str_to_dtype
 from megatron.bridge.utils.common_utils import disable_mtp_for_inference, print_rank_0
+
 
 __all__ = [
     "HFTokenizerAdapter",
@@ -73,9 +73,7 @@ def resolve_hf_model_path(hf_model_path: str | None, megatron_model_path: str | 
         resolved = get_hf_model_id_from_checkpoint(megatron_model_path)
         if resolved:
             return resolved
-    raise ValueError(
-        "--hf_model_path is required when checkpoint metadata does not include model.hf_model_id"
-    )
+    raise ValueError("--hf_model_path is required when checkpoint metadata does not include model.hf_model_id")
 
 
 def _get_prompt_from_json_line(line: str) -> str | None:
@@ -197,8 +195,7 @@ def _megatron_checkpoint_overrides(
 def _prepare_model_list(model_list: list[torch.nn.Module]) -> torch.nn.Module:
     if len(model_list) != 1:
         raise ValueError(
-            "MCore high-level inference supports one local model stage; "
-            "virtual pipeline parallelism is not supported."
+            "MCore high-level inference supports one local model stage; virtual pipeline parallelism is not supported."
         )
     model = model_list[0].cuda()
     model.eval()
@@ -280,8 +277,7 @@ def validate_sequence_length(
     required = longest_prompt_tokens + num_new_tokens
     if required > max_seq_length:
         raise ValueError(
-            f"Longest prompt plus generation needs {required} tokens, "
-            f"but --max_seq_length is {max_seq_length}."
+            f"Longest prompt plus generation needs {required} tokens, but --max_seq_length is {max_seq_length}."
         )
 
 
@@ -397,16 +393,14 @@ def add_model_loading_args(parser: argparse.ArgumentParser) -> argparse.Argument
         "--hf-model-path",
         dest="hf_model_path",
         default=None,
-        help="Hugging Face model id/path for config and tokenizer. Required unless checkpoint "
-        "metadata records it.",
+        help="Hugging Face model id/path for config and tokenizer. Required unless checkpoint metadata records it.",
     )
     group.add_argument(
         "--megatron_model_path",
         "--megatron-model-path",
         dest="megatron_model_path",
         default=None,
-        help="Optional Megatron Bridge checkpoint path. If omitted, load and convert HF weights "
-        "in-process.",
+        help="Optional Megatron Bridge checkpoint path. If omitted, load and convert HF weights in-process.",
     )
     group.add_argument(
         "--trust-remote-code",
@@ -448,8 +442,7 @@ def add_prompt_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         "--prompt",
         action="append",
         default=[],
-        help="Prompt text. May be provided multiple times. Defaults to a short prompt if no "
-        "prompt file is set.",
+        help="Prompt text. May be provided multiple times. Defaults to a short prompt if no prompt file is set.",
     )
     group.add_argument(
         "--prompt_file",

--- a/src/megatron/bridge/inference/vlm/vlm_inference_controller.py
+++ b/src/megatron/bridge/inference/vlm/vlm_inference_controller.py
@@ -20,23 +20,25 @@ from megatron.core.inference.text_generation_controllers.text_generation_control
     TextGenerationController,
 )
 
+from megatron.bridge.inference._tokenizer import HFTokenizerAdapter
 
-class TokenizerWrapper:
-    """Wrapper around tokenizer to provide a unified interface for inference."""
+
+class TokenizerWrapper(HFTokenizerAdapter):
+    """Wrapper around tokenizer to provide a unified interface for inference.
+
+    Thin specialization of :class:`HFTokenizerAdapter` preserving the historical VLM behavior:
+    no pad-token defaulting, ``vocab_size`` left as ``None``, and detokenization that always
+    keeps special tokens.
+    """
 
     # pylint: disable=C0115,C0116
     def __init__(self, tokenizer):
-        self.eod = tokenizer.eos_token_id
-        self.vocab_size = None
-        self._tokenizer = tokenizer
-
-    def detokenize(self, tokens):
-        # pylint: disable=C0115,C0116
-        return self._tokenizer.decode(tokens, skip_special_tokens=False)
-
-    def tokenize(self, prompt):
-        # pylint: disable=C0115,C0116
-        return self._tokenizer.encode(prompt, add_special_tokens=False)
+        super().__init__(
+            tokenizer,
+            set_pad_token=False,
+            expose_vocab_size=False,
+            force_skip_special_tokens=False,
+        )
 
 
 class VLMTextGenerationController(TextGenerationController):

--- a/src/megatron/bridge/utils/common_utils.py
+++ b/src/megatron/bridge/utils/common_utils.py
@@ -16,6 +16,7 @@ import os
 import re
 import types
 import warnings
+from datetime import timedelta
 from pathlib import Path
 
 import torch
@@ -130,6 +131,29 @@ def print_rank_last(message: str) -> None:
             print(message, flush=True)
     else:
         print(message, flush=True)
+
+
+def maybe_initialize_distributed(timeout_minutes: int = 60) -> None:
+    """Initialize the default process group from the standard launcher env vars.
+
+    No-op when torch.distributed is unavailable or already initialized. This is the minimal
+    bring-up used by standalone (e.g. inference) entry points that set up model parallelism
+    separately; it does not perform MPU initialization (see ``training.initialize`` for the
+    full training path).
+
+    Args:
+        timeout_minutes: Process-group timeout in minutes (useful for slow multi-node setup).
+    """
+    if not torch.distributed.is_available() or torch.distributed.is_initialized():
+        return
+
+    os.environ["RANK"] = os.environ.get("RANK", str(get_rank_safe()))
+    os.environ["WORLD_SIZE"] = os.environ.get("WORLD_SIZE", str(get_world_size_safe()))
+    os.environ["LOCAL_RANK"] = os.environ.get("LOCAL_RANK", str(get_local_rank_preinit()))
+    os.environ["MASTER_ADDR"] = os.environ.get("MASTER_ADDR", get_master_addr_safe())
+    os.environ["MASTER_PORT"] = os.environ.get("MASTER_PORT", str(get_master_port_safe()))
+    torch.cuda.set_device(int(os.environ["LOCAL_RANK"]))
+    torch.distributed.init_process_group("nccl", timeout=timedelta(minutes=timeout_minutes))
 
 
 def hook_hf_module_setattr_for_tp_grad_sync(module: torch.nn.Module) -> torch.nn.Module:

--- a/tests/unit_tests/inference/test_tokenizer.py
+++ b/tests/unit_tests/inference/test_tokenizer.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the shared HFTokenizerAdapter."""
+
+from __future__ import annotations
+
+from megatron.bridge.inference._tokenizer import HFTokenizerAdapter
+
+
+class _FakeTokenizer:
+    """Minimal stand-in for a HuggingFace tokenizer."""
+
+    def __init__(self):
+        self.eos_token = "</s>"
+        self.eos_token_id = 2
+        self.bos_token_id = 1
+        self.pad_token = None
+        self.decode_calls = []
+
+    def __len__(self):
+        return 32000
+
+    def encode(self, text, add_special_tokens=False):
+        assert add_special_tokens is False
+        return [ord(c) for c in text]
+
+    def decode(self, tokens, skip_special_tokens=True):
+        self.decode_calls.append(skip_special_tokens)
+        return f"decoded({list(tokens)},sst={skip_special_tokens})"
+
+
+def test_text_generation_defaults():
+    tok = _FakeTokenizer()
+    adapter = HFTokenizerAdapter(tok)
+
+    assert adapter.eod == 2
+    assert adapter.bos == 1
+    assert adapter.vocab_size == 32000
+    # pad token defaulted to eos when unset
+    assert tok.pad_token == "</s>"
+    assert adapter.tokenize("AB") == [65, 66]
+    # default honors caller-supplied skip_special_tokens
+    adapter.detokenize([65], skip_special_tokens=True)
+    adapter.detokenize([65], skip_special_tokens=False)
+    assert tok.decode_calls == [True, False]
+
+
+def test_vlm_preserving_flags():
+    """VLM wrapper semantics: no pad mutation, vocab_size None, always keep special tokens."""
+    tok = _FakeTokenizer()
+    adapter = HFTokenizerAdapter(
+        tok,
+        set_pad_token=False,
+        expose_vocab_size=False,
+        force_skip_special_tokens=False,
+    )
+
+    assert adapter.vocab_size is None
+    assert tok.pad_token is None  # not defaulted
+    # force flag overrides whatever the controller passes
+    adapter.detokenize([65], skip_special_tokens=True)
+    assert tok.decode_calls == [False]
+
+
+def test_force_skip_special_tokens_none_honors_caller():
+    tok = _FakeTokenizer()
+    adapter = HFTokenizerAdapter(tok, force_skip_special_tokens=None)
+    adapter.detokenize([65], skip_special_tokens=False)
+    assert tok.decode_calls == [False]

--- a/tests/unit_tests/scripts/test_text_generation.py
+++ b/tests/unit_tests/scripts/test_text_generation.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Unit tests for ``scripts/inference/text_generation.py``."""
+"""Unit tests for ``megatron.bridge.inference.text_generation`` (shared helpers)."""
 
 from __future__ import annotations
 
@@ -27,7 +27,7 @@ import pytest
 
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
-_SCRIPT_PATH = _REPO_ROOT / "scripts" / "inference" / "text_generation.py"
+_MODULE_PATH = _REPO_ROOT / "src" / "megatron" / "bridge" / "inference" / "text_generation.py"
 
 
 class _AttnBackend(Enum):
@@ -55,19 +55,6 @@ class _PassthroughInit:
         self.kwargs = kwargs
 
 
-class _MegatronLLM(_PassthroughInit):
-    is_primary_rank = True
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc, traceback):
-        return None
-
-    def generate(self, prompts, sampling_params):
-        return []
-
-
 def _module(name: str, **attrs: object) -> types.ModuleType:
     module = types.ModuleType(name)
     for attr_name, value in attrs.items():
@@ -75,11 +62,10 @@ def _module(name: str, **attrs: object) -> types.ModuleType:
     return module
 
 
-def _install_text_generation_stubs(monkeypatch: pytest.MonkeyPatch) -> None:
+def _install_stubs(monkeypatch: pytest.MonkeyPatch) -> None:
     stubs = {
         "megatron.core.inference.apis": _module(
             "megatron.core.inference.apis",
-            MegatronLLM=_MegatronLLM,
             SamplingParams=_SamplingParams,
         ),
         "megatron.core.inference.config": _module(
@@ -87,25 +73,13 @@ def _install_text_generation_stubs(monkeypatch: pytest.MonkeyPatch) -> None:
             InferenceConfig=_PassthroughInit,
             MambaInferenceStateConfig=_MambaInferenceStateConfig,
         ),
-        "megatron.core.inference.contexts": _module(
-            "megatron.core.inference.contexts",
-            StaticInferenceContext=_PassthroughInit,
-        ),
-        "megatron.core.inference.engines.static_engine": _module(
-            "megatron.core.inference.engines.static_engine",
-            StaticInferenceEngine=_PassthroughInit,
-        ),
-        "megatron.core.inference.model_inference_wrappers.gpt.gpt_inference_wrapper": _module(
-            "megatron.core.inference.model_inference_wrappers.gpt.gpt_inference_wrapper",
-            GPTInferenceWrapper=_PassthroughInit,
-        ),
-        "megatron.core.inference.text_generation_controllers.text_generation_controller": _module(
-            "megatron.core.inference.text_generation_controllers.text_generation_controller",
-            TextGenerationController=_PassthroughInit,
-        ),
         "megatron.core.transformer.enums": _module(
             "megatron.core.transformer.enums",
             AttnBackend=_AttnBackend,
+        ),
+        "megatron.core.utils": _module(
+            "megatron.core.utils",
+            get_attr_wrapped_model=lambda model, attr: getattr(model, attr),
         ),
         "transformers": _module(
             "transformers",
@@ -139,8 +113,8 @@ def _install_text_generation_stubs(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @pytest.fixture
 def text_generation(monkeypatch):
-    _install_text_generation_stubs(monkeypatch)
-    spec = importlib.util.spec_from_file_location("text_generation_under_test", _SCRIPT_PATH)
+    _install_stubs(monkeypatch)
+    spec = importlib.util.spec_from_file_location("bridge_text_generation_under_test", _MODULE_PATH)
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
@@ -172,7 +146,7 @@ def test_maybe_initialize_distributed_populates_env_from_safe_helpers(monkeypatc
         lambda backend, timeout: init_calls.append({"backend": backend, "timeout": timeout}),
     )
 
-    text_generation._maybe_initialize_distributed(timeout_minutes=11)
+    text_generation.maybe_initialize_distributed(timeout_minutes=11)
 
     assert (
         dict(
@@ -202,25 +176,22 @@ def test_maybe_initialize_distributed_is_noop_when_dist_unavailable(monkeypatch,
         lambda device: pytest.fail("set_device should not be called"),
     )
 
-    text_generation._maybe_initialize_distributed(timeout_minutes=1)
+    text_generation.maybe_initialize_distributed(timeout_minutes=1)
 
 
 def test_megatron_checkpoint_overrides_preserve_attention_backend(text_generation):
     provider = types.SimpleNamespace(cache_mla_latents=True)
-    args = types.SimpleNamespace(
+
+    overrides = text_generation._megatron_checkpoint_overrides(
+        provider,
         tp=2,
         pp=2,
         ep=4,
         etp=1,
         sequence_parallel=True,
+        dtype=text_generation.torch.bfloat16,
         attention_backend="local",
         inference_moe_token_dispatcher_type="nvls",
-    )
-
-    overrides = text_generation._build_megatron_checkpoint_overrides(
-        provider,
-        args,
-        text_generation.torch.bfloat16,
     )
 
     assert overrides["attention_backend"] is text_generation.AttnBackend.local
@@ -235,3 +206,64 @@ def test_megatron_checkpoint_overrides_preserve_attention_backend(text_generatio
     assert overrides["fp16"] is False
     assert overrides["cache_mla_latents"] is True
     assert overrides["inference_moe_token_dispatcher_type"] == "nvls"
+
+
+def test_build_inference_config_rounds_max_requests_up_to_tp(text_generation):
+    model = types.SimpleNamespace(position_embedding_type="rope", max_sequence_length=8192)
+
+    config = text_generation.build_inference_config(
+        model=model,
+        max_sequence_length=4096,
+        max_batch_size=None,
+        num_prompts=3,
+        tp=2,
+        block_size_tokens=256,
+        kv_cache_buffer_size_gb=20.0,
+        max_tokens=None,
+        return_log_probs=False,
+        enable_chunked_prefill=False,
+    )
+
+    # 3 prompts rounded up to a multiple of tp=2 -> 4; rope is pass-through for max_sequence_length.
+    assert config.kwargs["max_requests"] == 4
+    assert config.kwargs["max_sequence_length"] == 4096
+    assert config.kwargs["materialize_only_last_token_logits"] is True
+
+
+def test_build_inference_config_clamps_learned_absolute_sequence_length(text_generation):
+    model = types.SimpleNamespace(position_embedding_type="learned_absolute", max_sequence_length=1024)
+
+    config = text_generation.build_inference_config(
+        model=model,
+        max_sequence_length=4096,
+        max_batch_size=2,
+        num_prompts=2,
+        tp=1,
+        block_size_tokens=256,
+        kv_cache_buffer_size_gb=20.0,
+        max_tokens=None,
+        return_log_probs=True,
+        enable_chunked_prefill=False,
+    )
+
+    # learned_absolute clamps to the model's table size (1024), not the requested 4096.
+    assert config.kwargs["max_sequence_length"] == 1024
+    assert config.kwargs["materialize_only_last_token_logits"] is False
+
+
+def test_megatron_checkpoint_overrides_explicit_for_divisible_batch(text_generation):
+    """max_batch_size already divisible by tp must not raise."""
+    model = types.SimpleNamespace(position_embedding_type="rope", max_sequence_length=8192)
+    config = text_generation.build_inference_config(
+        model=model,
+        max_sequence_length=2048,
+        max_batch_size=4,
+        num_prompts=10,
+        tp=2,
+        block_size_tokens=256,
+        kv_cache_buffer_size_gb=20.0,
+        max_tokens=None,
+        return_log_probs=False,
+        enable_chunked_prefill=False,
+    )
+    assert config.kwargs["max_requests"] == 4

--- a/tests/unit_tests/scripts/test_text_generation.py
+++ b/tests/unit_tests/scripts/test_text_generation.py
@@ -218,7 +218,7 @@ def test_build_inference_config_clamps_learned_absolute_sequence_length(text_gen
     assert config.kwargs["materialize_only_last_token_logits"] is False
 
 
-def test_megatron_checkpoint_overrides_explicit_for_divisible_batch(text_generation):
+def test_build_inference_config_explicit_for_divisible_batch(text_generation):
     """max_batch_size already divisible by tp must not raise."""
     model = types.SimpleNamespace(position_embedding_type="rope", max_sequence_length=8192)
     config = text_generation.build_inference_config(
@@ -234,3 +234,45 @@ def test_megatron_checkpoint_overrides_explicit_for_divisible_batch(text_generat
         enable_chunked_prefill=False,
     )
     assert config.kwargs["max_requests"] == 4
+
+
+def test_resolve_hf_model_path_prefers_explicit(text_generation):
+    assert text_generation.resolve_hf_model_path("meta-llama/Llama-3.2-1B", None) == "meta-llama/Llama-3.2-1B"
+
+
+def test_resolve_hf_model_path_falls_back_to_checkpoint_metadata(text_generation, monkeypatch):
+    monkeypatch.setattr(text_generation, "get_hf_model_id_from_checkpoint", lambda path: "org/model-from-ckpt")
+    assert text_generation.resolve_hf_model_path(None, "/ckpt") == "org/model-from-ckpt"
+
+
+def test_resolve_hf_model_path_raises_when_unresolvable(text_generation):
+    # stub get_hf_model_id_from_checkpoint returns None
+    with pytest.raises(ValueError, match="--hf_model_path is required"):
+        text_generation.resolve_hf_model_path(None, "/ckpt")
+
+
+def test_load_prompts_explicit_and_default(text_generation):
+    assert text_generation.load_prompts(["a", "b"], None, None, ["default"]) == ["a", "b"]
+    assert text_generation.load_prompts([], None, None, ["default"]) == ["default"]
+
+
+def test_load_prompts_from_file_with_jsonl_and_truncate(text_generation, tmp_path):
+    prompt_file = tmp_path / "prompts.txt"
+    prompt_file.write_text('{"text": "json prompt"}\nraw prompt\n\nthird\n', encoding="utf-8")
+
+    # JSONL `text` field is extracted; blank lines skipped; raw lines passed through.
+    assert text_generation.load_prompts(None, str(prompt_file), None, ["d"]) == [
+        "json prompt",
+        "raw prompt",
+        "third",
+    ]
+    # truncation caps the count
+    assert text_generation.load_prompts(None, str(prompt_file), 2, ["d"]) == ["json prompt", "raw prompt"]
+
+
+def test_validate_sequence_length(text_generation):
+    # fits -> no raise
+    text_generation.validate_sequence_length(longest_prompt_tokens=100, num_new_tokens=28, max_seq_length=4096)
+    # exceeds -> raise
+    with pytest.raises(ValueError, match="Longest prompt plus generation needs"):
+        text_generation.validate_sequence_length(longest_prompt_tokens=4090, num_new_tokens=30, max_seq_length=4096)

--- a/tests/unit_tests/scripts/test_text_generation.py
+++ b/tests/unit_tests/scripts/test_text_generation.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 import importlib.util
 import sys
 import types
-from datetime import timedelta
 from enum import Enum
 from pathlib import Path
 
@@ -85,9 +84,12 @@ def _install_stubs(monkeypatch: pytest.MonkeyPatch) -> None:
             "transformers",
             AutoConfig=_PassthroughInit,
             AutoTokenizer=_PassthroughInit,
-            PreTrainedTokenizerBase=object,
         ),
         "megatron.bridge": _module("megatron.bridge", AutoBridge=_PassthroughInit),
+        "megatron.bridge.inference._tokenizer": _module(
+            "megatron.bridge.inference._tokenizer",
+            HFTokenizerAdapter=_PassthroughInit,
+        ),
         "megatron.bridge.models.hf_pretrained.utils": _module(
             "megatron.bridge.models.hf_pretrained.utils",
             is_safe_repo=lambda *, hf_path, trust_remote_code: bool(trust_remote_code),
@@ -96,14 +98,13 @@ def _install_stubs(monkeypatch: pytest.MonkeyPatch) -> None:
             "megatron.bridge.training.utils.checkpoint_utils",
             get_hf_model_id_from_checkpoint=lambda path: None,
         ),
+        "megatron.bridge.utils.activation_map": _module(
+            "megatron.bridge.utils.activation_map",
+            str_to_dtype=lambda name: name,
+        ),
         "megatron.bridge.utils.common_utils": _module(
             "megatron.bridge.utils.common_utils",
             disable_mtp_for_inference=lambda model: None,
-            get_local_rank_preinit=lambda: 0,
-            get_master_addr_safe=lambda: "localhost",
-            get_master_port_safe=lambda: 29500,
-            get_rank_safe=lambda: 0,
-            get_world_size_safe=lambda: 1,
             print_rank_0=lambda message: None,
         ),
     }
@@ -123,60 +124,6 @@ def text_generation(monkeypatch):
         yield module
     finally:
         sys.modules.pop(spec.name, None)
-
-
-def test_maybe_initialize_distributed_populates_env_from_safe_helpers(monkeypatch, text_generation):
-    init_calls = []
-    set_device_calls = []
-
-    for key in ("RANK", "WORLD_SIZE", "LOCAL_RANK", "MASTER_ADDR", "MASTER_PORT"):
-        monkeypatch.delenv(key, raising=False)
-
-    monkeypatch.setattr(text_generation.dist, "is_available", lambda: True)
-    monkeypatch.setattr(text_generation.dist, "is_initialized", lambda: False)
-    monkeypatch.setattr(text_generation, "get_rank_safe", lambda: 7)
-    monkeypatch.setattr(text_generation, "get_world_size_safe", lambda: 16)
-    monkeypatch.setattr(text_generation, "get_local_rank_preinit", lambda: 3)
-    monkeypatch.setattr(text_generation, "get_master_addr_safe", lambda: "node-0")
-    monkeypatch.setattr(text_generation, "get_master_port_safe", lambda: 23456)
-    monkeypatch.setattr(text_generation.torch.cuda, "set_device", lambda device: set_device_calls.append(device))
-    monkeypatch.setattr(
-        text_generation.dist,
-        "init_process_group",
-        lambda backend, timeout: init_calls.append({"backend": backend, "timeout": timeout}),
-    )
-
-    text_generation.maybe_initialize_distributed(timeout_minutes=11)
-
-    assert (
-        dict(
-            RANK="7",
-            WORLD_SIZE="16",
-            LOCAL_RANK="3",
-            MASTER_ADDR="node-0",
-            MASTER_PORT="23456",
-        ).items()
-        <= dict(text_generation.os.environ).items()
-    )
-    assert set_device_calls == [3]
-    assert init_calls == [{"backend": "nccl", "timeout": timedelta(minutes=11)}]
-
-
-def test_maybe_initialize_distributed_is_noop_when_dist_unavailable(monkeypatch, text_generation):
-    monkeypatch.setattr(text_generation.dist, "is_available", lambda: False)
-    monkeypatch.setattr(text_generation.dist, "is_initialized", lambda: False)
-    monkeypatch.setattr(
-        text_generation.dist,
-        "init_process_group",
-        lambda *args, **kwargs: pytest.fail("init_process_group should not be called"),
-    )
-    monkeypatch.setattr(
-        text_generation.torch.cuda,
-        "set_device",
-        lambda device: pytest.fail("set_device should not be called"),
-    )
-
-    text_generation.maybe_initialize_distributed(timeout_minutes=1)
 
 
 def test_megatron_checkpoint_overrides_preserve_attention_backend(text_generation):

--- a/tests/unit_tests/scripts/test_text_generation.py
+++ b/tests/unit_tests/scripts/test_text_generation.py
@@ -177,6 +177,26 @@ def test_build_inference_config_rounds_max_requests_up_to_tp(text_generation):
     assert config.kwargs["materialize_only_last_token_logits"] is True
 
 
+def test_build_inference_config_auto_sizes_max_requests_when_unset(text_generation):
+    """Server path: max_batch_size and num_prompts both None -> max_requests left as None."""
+    model = types.SimpleNamespace(position_embedding_type="rope", max_sequence_length=8192)
+
+    config = text_generation.build_inference_config(
+        model=model,
+        max_sequence_length=4096,
+        max_batch_size=None,
+        num_prompts=None,
+        tp=2,
+        block_size_tokens=256,
+        kv_cache_buffer_size_gb=20.0,
+        max_tokens=None,
+        return_log_probs=False,
+        enable_chunked_prefill=False,
+    )
+
+    assert config.kwargs["max_requests"] is None
+
+
 def test_build_inference_config_clamps_learned_absolute_sequence_length(text_generation):
     model = types.SimpleNamespace(position_embedding_type="learned_absolute", max_sequence_length=1024)
 

--- a/tests/unit_tests/utils/test_common_utils.py
+++ b/tests/unit_tests/utils/test_common_utils.py
@@ -435,6 +435,7 @@ class TestMaybeInitializeDistributed:
         mock_init_pg.assert_not_called()
         mock_set_device.assert_not_called()
 
+    @patch.dict(os.environ, {}, clear=True)
     @patch("torch.distributed.is_available", return_value=True)
     @patch("torch.distributed.is_initialized", return_value=False)
     @patch("torch.distributed.init_process_group")
@@ -455,9 +456,7 @@ class TestMaybeInitializeDistributed:
         mock_init_pg,
         *_,
     ):
-        for key in ("RANK", "WORLD_SIZE", "LOCAL_RANK", "MASTER_ADDR", "MASTER_PORT"):
-            os.environ.pop(key, None)
-
+        # @patch.dict(clear=True) isolates os.environ so the vars set below do not leak.
         maybe_initialize_distributed(timeout_minutes=11)
 
         assert os.environ["RANK"] == "7"

--- a/tests/unit_tests/utils/test_common_utils.py
+++ b/tests/unit_tests/utils/test_common_utils.py
@@ -20,6 +20,8 @@ from unittest.mock import patch
 
 import pytest
 
+from datetime import timedelta
+
 from megatron.bridge.utils.common_utils import (
     get_local_rank_preinit,
     get_master_addr_safe,
@@ -27,6 +29,7 @@ from megatron.bridge.utils.common_utils import (
     get_rank_safe,
     get_world_size_safe,
     is_last_rank,
+    maybe_initialize_distributed,
     print_rank_0,
     print_rank_last,
 )
@@ -410,3 +413,58 @@ class TestSLURMFallback:
         """Test warning issued when defaulting to 29500."""
         with pytest.warns(UserWarning, match="Could not determine master port"):
             assert get_master_port_safe() == 29500
+
+
+class TestMaybeInitializeDistributed:
+    """Test maybe_initialize_distributed (minimal launcher-env process-group bring-up)."""
+
+    @patch("torch.distributed.is_available", return_value=False)
+    @patch("torch.distributed.is_initialized", return_value=False)
+    @patch("torch.distributed.init_process_group")
+    @patch("torch.cuda.set_device")
+    def test_noop_when_dist_unavailable(self, mock_set_device, mock_init_pg, *_):
+        maybe_initialize_distributed(timeout_minutes=1)
+        mock_init_pg.assert_not_called()
+        mock_set_device.assert_not_called()
+
+    @patch("torch.distributed.is_available", return_value=True)
+    @patch("torch.distributed.is_initialized", return_value=True)
+    @patch("torch.distributed.init_process_group")
+    @patch("torch.cuda.set_device")
+    def test_noop_when_already_initialized(self, mock_set_device, mock_init_pg, *_):
+        maybe_initialize_distributed(timeout_minutes=1)
+        mock_init_pg.assert_not_called()
+        mock_set_device.assert_not_called()
+
+    @patch("torch.distributed.is_available", return_value=True)
+    @patch("torch.distributed.is_initialized", return_value=False)
+    @patch("torch.distributed.init_process_group")
+    @patch("torch.cuda.set_device")
+    @patch("megatron.bridge.utils.common_utils.get_master_port_safe", return_value=23456)
+    @patch("megatron.bridge.utils.common_utils.get_master_addr_safe", return_value="node-0")
+    @patch("megatron.bridge.utils.common_utils.get_local_rank_preinit", return_value=3)
+    @patch("megatron.bridge.utils.common_utils.get_world_size_safe", return_value=16)
+    @patch("megatron.bridge.utils.common_utils.get_rank_safe", return_value=7)
+    def test_populates_env_and_initializes(
+        self,
+        _rank,
+        _world,
+        _local,
+        _addr,
+        _port,
+        mock_set_device,
+        mock_init_pg,
+        *_,
+    ):
+        for key in ("RANK", "WORLD_SIZE", "LOCAL_RANK", "MASTER_ADDR", "MASTER_PORT"):
+            os.environ.pop(key, None)
+
+        maybe_initialize_distributed(timeout_minutes=11)
+
+        assert os.environ["RANK"] == "7"
+        assert os.environ["WORLD_SIZE"] == "16"
+        assert os.environ["LOCAL_RANK"] == "3"
+        assert os.environ["MASTER_ADDR"] == "node-0"
+        assert os.environ["MASTER_PORT"] == "23456"
+        mock_set_device.assert_called_once_with(3)
+        mock_init_pg.assert_called_once_with("nccl", timeout=timedelta(minutes=11))

--- a/tests/unit_tests/utils/test_common_utils.py
+++ b/tests/unit_tests/utils/test_common_utils.py
@@ -16,11 +16,10 @@
 """Tests for common_utils module."""
 
 import os
+from datetime import timedelta
 from unittest.mock import patch
 
 import pytest
-
-from datetime import timedelta
 
 from megatron.bridge.utils.common_utils import (
     get_local_rank_preinit,


### PR DESCRIPTION
# What does this PR do ?

Decouples the standalone inference scripts under `scripts/inference/` from the Megatron-LM
reference layer. `async_text_generation.py` and `openai_server.py` both imported
`add_inference_args` / `get_inference_config_from_model_and_args` / `get_model_for_inference`
from `megatron.inference.utils`, plus `initialize_megatron` / `parse_and_validate_args` from
`megatron.training.*`. That couples Bridge scripts to Megatron-LM's reference training/inference
layer — outside our `megatron.core` dependency — so MLM-side refactors of those entry points
(e.g. NVIDIA/Megatron-LM#5169) can churn them.

This PR extracts the shared model-loading / `InferenceConfig` machinery — until now inlined in
the synchronous `text_generation.py` — into `megatron.bridge.inference.text_generation`, and
rewrites all three scripts (`text_generation.py`, `async_text_generation.py`, `openai_server.py`)
as thin CLIs on top of it. All now import **only** from `megatron.core` and `megatron.bridge`.

## Changes
- **New** `src/megatron/bridge/inference/text_generation.py`: shared inference helpers
  (`AutoBridge` model loading, core `InferenceConfig` builder, prompt/sampling helpers, argparse
  group adders).
- **New** `src/megatron/bridge/inference/_tokenizer.py`: a single `HFTokenizerAdapter` shared by
  the inference scripts and the VLM controller. The VLM `TokenizerWrapper` becomes a thin subclass
  preserving its exact prior behavior (no pad-token defaulting, `vocab_size=None`, detokenize
  always keeps special tokens) via constructor flags.
- **Reuse existing src utils** instead of reinventing: dtype strings via
  `megatron.bridge.utils.activation_map.str_to_dtype`; the minimal launcher-env distributed
  bring-up now lives in `megatron.bridge.utils.common_utils.maybe_initialize_distributed`.
- **Refactor** `text_generation.py` (sync), **rewrite** `async_text_generation.py` and
  `openai_server.py` as thin core+bridge CLIs (`MegatronLLM` / `MegatronAsyncLLM` /
  `MegatronAsyncLLM.serve`). `build_inference_config` now accepts `num_prompts=None` so the server
  can leave `max_requests` unset for the engine to auto-size (matching prior server behavior).
- **Tests**: `tests/unit_tests/inference/test_tokenizer.py` (shared adapter incl. VLM-preserving
  flags); distributed-init test in `tests/unit_tests/utils/test_common_utils.py`;
  `tests/unit_tests/scripts/test_text_generation.py` retargeted at the module with
  `build_inference_config` coverage (TP rounding, learned-absolute clamp, server auto-size).

## Behavior / CLI notes
`async_text_generation.py` and `openai_server.py` now load models the Bridge way (consistent with
the sync script) rather than via the MLM checkpoint path:
- Model source: `--hf_model_path` / `--megatron_model_path` via `AutoBridge` (was MLM `--load`).
- Flag renames to match the sync script: `--prompts` → `--prompt`, `num_tokens_to_generate` →
  `--max_new_tokens`, and the sync KV-cache / batching flags (`--block_size_tokens`,
  `--kv_cache_buffer_size_gb`, `--max_seq_length`, ...).
- Distributed bring-up via the Bridge env-var path instead of `initialize_megatron()`.

Also centralizes the `InferenceConfig` translation as a single source of truth and adds the
`learned_absolute` `max_sequence_length` clamp (no-op for RoPE).

Note: the VLM `TokenizerWrapper` now subclasses the shared adapter; behavior is intended to be
identical — flagging for VLM owners to confirm in review.

## Pre-checks
- [x] Updated/added relevant unit tests
- [ ] Ran autoformatter + unit tests on a GPU node (please verify in CI)
