### PR TITLE
fix(data): add Ministral3 assistant mask boundaries

### DIFF
--- a/src/megatron/bridge/models/ministral3/data/collate_fn.py
+++ b/src/megatron/bridge/models/ministral3/data/collate_fn.py
@@ -17,11 +17,38 @@
 import torch
 from PIL import Image
 
-from megatron.bridge.data.datasets.utils import IGNORE_INDEX
+from megatron.bridge.data.datasets.utils import GENERATION_REGEX, IGNORE_INDEX
 from megatron.bridge.data.vlm_datasets.collate_utils import PASSTHROUGH_VISUAL_KEYS
 from megatron.bridge.data.vlm_datasets.token_utils import extract_skipped_token_ids
-from megatron.bridge.data.vlm_processing import AssistantMaskBoundaryConfig, build_assistant_loss_mask
+from megatron.bridge.data.vlm_processing import (
+    AssistantMaskBoundaryConfig,
+    assistant_mask_boundary_config_from_markers,
+    build_assistant_loss_mask,
+)
 from megatron.bridge.training.utils.visual_inputs import GenericVisualInputs
+
+
+MISTRAL3_ASSISTANT_START = "[/INST]"
+MISTRAL3_ASSISTANT_END = "</s>"
+
+
+def _has_generation_chat_template(processor) -> bool:
+    tokenizer = getattr(processor, "tokenizer", None)
+    for template_owner in (processor, tokenizer):
+        template = getattr(template_owner, "chat_template", None)
+        if isinstance(template, str) and GENERATION_REGEX.search(template) is not None:
+            return True
+    return False
+
+
+def _default_ministral3_assistant_mask_boundary_config(processor) -> AssistantMaskBoundaryConfig:
+    tokenizer = getattr(processor, "tokenizer", processor)
+    assistant_end = getattr(tokenizer, "eos_token", None) or MISTRAL3_ASSISTANT_END
+    return assistant_mask_boundary_config_from_markers(
+        processor,
+        assistant_start=MISTRAL3_ASSISTANT_START,
+        assistant_end=assistant_end,
+    )
 
 
 def ministral3_collate_fn(
@@ -32,6 +59,8 @@ def ministral3_collate_fn(
 ) -> dict[str, torch.Tensor]:
     """Collate function for Ministral 3 VL model."""
     skipped_tokens = extract_skipped_token_ids(processor)
+    if assistant_mask_boundary_config is None and not _has_generation_chat_template(processor):
+        assistant_mask_boundary_config = _default_ministral3_assistant_mask_boundary_config(processor)
 
     if processor.chat_template is not None:
         batch = processor.apply_chat_template(

--- a/tests/unit_tests/data/vlm_datasets/test_collate.py
+++ b/tests/unit_tests/data/vlm_datasets/test_collate.py
@@ -602,6 +602,54 @@ def test_gemma4_registered_fn_matches_alias():
     assert collate.COLLATE_FNS["Gemma4Processor"] is collate.gemma4_vl_collate_fn
 
 
+class _Ministral3InstructionProcessor:
+    """Minimal Ministral3 processor stub without HF generation mask support."""
+
+    chat_template = "{{ messages }}"
+
+    class _Tok:
+        pad_token_id = 0
+        pad_token = "<pad>"
+        eos_token = "</s>"
+        added_tokens_decoder = {}
+        chat_template = "{{ messages }}"
+
+        def encode(self, text, add_special_tokens=False):
+            return self(text, add_special_tokens=add_special_tokens)["input_ids"]
+
+        def __call__(self, text, add_special_tokens=False, **kwargs):
+            mapping = {
+                "[/INST]": [30],
+                "</s>": [2],
+            }
+            return {"input_ids": mapping.get(text, [99])}
+
+    def __init__(self):
+        self.tokenizer = self._Tok()
+
+    def apply_chat_template(self, conversations, tokenize=False, **kwargs):
+        if not tokenize:
+            return "<s>[INST]question[/INST]answer</s>"
+        return {"input_ids": torch.tensor([[1, 11, 30, 31, 2]], dtype=torch.long)}
+
+
+def test_ministral3_collate_uses_declared_instruction_boundaries_without_generation_template():
+    """Ministral3 templates lack HF generation blocks, so the collator must declare boundaries."""
+    examples = [
+        {
+            "conversation": [
+                {"role": "user", "content": [{"type": "text", "text": "question"}]},
+                {"role": "assistant", "content": [{"type": "text", "text": "answer"}]},
+            ]
+        }
+    ]
+
+    batch = collate.ministral3_collate_fn(examples, _Ministral3InstructionProcessor())
+
+    assert batch["loss_mask"].tolist() == [[0.0, 0.0, 1.0, 1.0, 0.0]]
+    assert batch["labels"].tolist() == [[-100, -100, 31, 2, -100]]
+
+
 class _Gemma4ProcessorBase:
     """Minimal Gemma4Processor stub for ministral3_collate_fn tests."""
 


### PR DESCRIPTION
## Summary
- add a Ministral3 assistant loss-mask boundary fallback for `[\/INST]` through tokenizer EOS when the chat template lacks HF `{% generation %}` blocks
- preserve caller-provided boundary configs, including Gemma4's wrapper path
- add a focused no-generation Ministral3 collate regression test

## Testing
- `git diff --check`
- `ruff check src/megatron/bridge/models/ministral3/data/collate_fn.py tests/unit_tests/data/vlm_datasets/test_collate.py`
- `ruff format --check src/megatron/bridge/models/ministral3/data/collate_fn.py tests/unit_tests/data/vlm_datasets/test_collate.py`
- `python3 -m py_compile src/megatron/bridge/models/ministral3/data/collate_fn.py tests/unit_tests/data/vlm_datasets/test_collate.py`
- `pre-commit run --files src/megatron/bridge/models/ministral3/data/collate_fn.py tests/unit_tests/data/vlm_datasets/test_collate.py`
- `pre-commit run --all-files`

Not run: Torch-importing pytest locally; runtime validation should be covered by CI for this PR.