### PR TITLE
[ci, perf] fix: retry on NCCL collective-timeout hangs and scan all rank logs

### DIFF
--- a/scripts/performance/setup_experiment.py
+++ b/scripts/performance/setup_experiment.py
@@ -275,7 +275,9 @@ def is_flaky_failure(log_file_path: str) -> bool:
         or "illegal memory access" in log
         or "illegal instruction" in log
         or "torch.distributed.DistNetworkError" in log
+        or "torch.distributed.DistBackendError" in log
         or "ncclRemoteError" in log
+        or "Watchdog caught collective operation timeout" in log
         or "Segmentation fault" in log
         or "found NaN in" in log
         or "For debugging consider passing CUDA_LAUNCH_BLOCKING=1" in log
@@ -373,7 +375,7 @@ def maybe_increase_n_attempts_on_flaky_failure(
         return n_attempts
     if is_long_convergence_run and made_progress:
         return n_attempts
-    if is_flaky_failure(log_file_paths[-1]):
+    if any(is_flaky_failure(p) for p in log_file_paths):
         n_attempts += 1  # flaky: retry, bounded by max_retries
     else:
         # non-flaky: give up now. max_retries + 1 (not max_retries) so the outer


### PR DESCRIPTION
## Background / motivation

- A nightly nemo-ci run (`nemotron_nano_12b_v2_64gpu_gb200_nightly`, job `345695676`) failed on a **transient NCCL collective-timeout during distributed init** — a 600s `ALLREDUCE` watchdog timeout in `_initialize_distributed`, before step 0 (`ncclRemoteError: … Connection closed by remote peer`).
- This is exactly the failure class the flaky-failure relaunch loop in `setup_experiment.py` exists to absorb (re-submit on fresh nodes, bounded by `max_retries`). It did **not** retry — one TrainJob, then a hard fail.
- Root cause: the run was a long-convergence run that made no forward progress (`made_progress=False`), so it correctly fell through to `is_flaky_failure(...)` — which returned `False` despite `ncclRemoteError` already being in the marker list.

## What changed

- `is_flaky_failure` is now evaluated against **every** rank log, not just one.
- Added two markers for the collective-timeout / backend-error family.

## Details

Two independent defects in the classifier (`scripts/performance/setup_experiment.py`) let the hang through:

1. **Single-log inspection.** `maybe_increase_n_attempts_on_flaky_failure` called `is_flaky_failure(log_file_paths[-1])` — only the last, arbitrarily glob-ordered rank log. On a multi-node gang the timeout/peer-disconnect markers land on rank 0 / a different node's log (or `[-1]` is truncated when the gang is killed), so the marker was missed. Changed to `any(is_flaky_failure(p) for p in log_file_paths)`.
2. **Missing markers.** The list matched `ncclRemoteError` and `Some NCCL operations have failed or timed out.` but not the canonical watchdog/backend signatures. Added:
   - `torch.distributed.DistBackendError`
   - `Watchdog caught collective operation timeout`

Retries remain bounded by `max_retries`; genuine (non-flaky) failures still hit the `n_attempts = max_retries + 1` give-up path on the first attempt, so no extra GPU-hours are spent on real regressions.

```python
# before
if is_flaky_failure(log_file_paths[-1]):
# after
if any(is_flaky_failure(p) for p in log_file_paths):
```

## Tested

- `ruff 0.9.9 check` + `format --check` on the changed file — pass.
- Traced the failing run against `main` at its build commit (`991c87247`): the control flow reaches `is_flaky_failure` with `made_progress=False`; the single-log read returned `False` (no `Starting attempt 2 of N` line in the trace, confirming exactly one submission). Both changes make the marker reachable, so the relaunch loop fires.
- No unit tests reference `is_flaky_failure` / `maybe_increase_n_attempts_on_flaky_failure`.
