### PR TITLE
[ci] fix: resolve test matrix from the PR merge commit, not the head

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -89,11 +89,25 @@ jobs:
       expect_l1:         ${{ steps.configure.outputs.expect_l1 }}
       expect_l2:         ${{ steps.configure.outputs.expect_l2 }}
       perf_scripts_only: ${{ steps.configure.outputs.perf_scripts_only }}
+      merge_sha:         ${{ steps.merge-sha.outputs.merge_sha }}
     steps:
       - name: Get PR info
         id: get-pr-info
         if: startsWith(github.ref, 'refs/heads/pull-request/')
         uses: nv-gha-runners/get-pr-info@main
+
+      - name: Resolve merge commit sha
+        id: merge-sha
+        shell: bash -e -u -o pipefail {0}
+        env:
+          IS_PR: ${{ startsWith(github.ref, 'refs/heads/pull-request/') }}
+        run: |
+          if [[ "$IS_PR" == "true" ]]; then
+            SHA=${{ fromJSON(steps.get-pr-info.outputs.pr-info || '{}').merge_commit_sha }}
+          else
+            SHA=${GITHUB_SHA}
+          fi
+          echo "merge_sha=${SHA}" | tee -a "$GITHUB_OUTPUT"
 
       - name: Configure
         id: configure
@@ -220,7 +234,7 @@ jobs:
   lint-check:
     name: Lint check
     runs-on: ubuntu-latest
-    needs: [pre-flight]
+    needs: [pre-flight, configure]
     if: |
       needs.pre-flight.outputs.is_deployment_workflow == 'false'
       || github.event_name == 'workflow_dispatch'
@@ -229,6 +243,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: "recursive"
+          ref: ${{ needs.configure.outputs.merge_sha }}
 
       - name: Update MCore submodule (if triggered from MCore)
         if: ${{ github.event.inputs.mcore_ref != '' }}
@@ -325,24 +340,11 @@ jobs:
         if: startsWith(github.ref, 'refs/heads/pull-request/')
         uses: nv-gha-runners/get-pr-info@main
 
-      - name: Get merge commit sha
-        shell: bash -x -e -u -o pipefail {0}
-        id: sha
-        env:
-          IS_PR: ${{ startsWith(github.ref, 'refs/heads/pull-request/') }}
-        run: |
-          if [[ "$IS_PR" == "true" ]]; then
-            SHA=${{ fromJSON(steps.get-pr-info.outputs.pr-info || '{}').merge_commit_sha }}
-          else
-            SHA=${GITHUB_SHA}
-          fi
-          echo "main=${SHA}" | tee -a "$GITHUB_OUTPUT"
-
       - name: Checkout
         uses: actions/checkout@v6
         with:
           submodules: recursive
-          ref: ${{ steps.sha.outputs.main }}
+          ref: ${{ needs.configure.outputs.merge_sha }}
 
       - name: Update MCore submodule (if triggered from MCore)
         if: ${{ github.event.inputs.mcore_ref != '' }}
@@ -464,7 +466,7 @@ jobs:
           no-cache: false
           tags: |
             ${{ matrix.registry }}/megatron-bridge:${{ steps.cache_keys.outputs.key }}
-            ${{ matrix.registry }}/megatron-bridge:${{ github.sha }}
+            ${{ matrix.registry }}/megatron-bridge:${{ needs.configure.outputs.merge_sha }}
           secrets: |
             GH_TOKEN=${{ secrets.PAT }}
 
@@ -484,11 +486,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.configure.outputs.merge_sha }}
 
       - name: Run venv import check
         shell: bash -e -u -o pipefail {0}
         env:
-          IMAGE: ${{ needs.pre-flight.outputs.registry }}/megatron-bridge:${{ github.sha }}
+          IMAGE: ${{ needs.pre-flight.outputs.registry }}/megatron-bridge:${{ needs.configure.outputs.merge_sha }}
         run: |
           docker run --rm \
             -v "${{ github.workspace }}/docker/common:/opt/import-check:ro" \
@@ -507,7 +511,7 @@ jobs:
       )
       && !cancelled()
       && (github.event.inputs.test_suite == '' || github.event.inputs.test_suite == 'all' || github.event.inputs.test_suite == 'unit-only' || contains('L0 L1 L2', github.event.inputs.test_suite))
-    needs: [pre-flight, cicd-wait-in-queue, cicd-container-build]
+    needs: [pre-flight, configure, cicd-wait-in-queue, cicd-container-build]
     runs-on: ${{ needs.pre-flight.outputs.runner_prefix }}
     name: Launch_Unit_Tests_Core
     env:
@@ -518,6 +522,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: recursive
+          ref: ${{ needs.configure.outputs.merge_sha }}
 
       - name: main
         uses: ./.github/actions/test-template
@@ -526,7 +531,7 @@ jobs:
           timeout: 18
           is_unit_test: "true"
           PAT: ${{ secrets.PAT }}
-          container-image: ${{ needs.pre-flight.outputs.registry }}/megatron-bridge:${{ github.sha }}
+          container-image: ${{ needs.pre-flight.outputs.registry }}/megatron-bridge:${{ needs.configure.outputs.merge_sha }}
           test-data-path: ${{ needs.pre-flight.outputs.test_data_path }}
           runner: ${{ needs.pre-flight.outputs.runner_prefix }}
 
@@ -540,7 +545,7 @@ jobs:
       )
       && !cancelled()
       && (github.event.inputs.test_suite == '' || github.event.inputs.test_suite == 'all' || github.event.inputs.test_suite == 'unit-only' || contains('L0 L1 L2', github.event.inputs.test_suite))
-    needs: [pre-flight, cicd-wait-in-queue, cicd-container-build]
+    needs: [pre-flight, configure, cicd-wait-in-queue, cicd-container-build]
     runs-on: ${{ needs.pre-flight.outputs.runner_prefix }}
     name: Launch_Unit_Tests_Diffusion
     env:
@@ -551,6 +556,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: recursive
+          ref: ${{ needs.configure.outputs.merge_sha }}
 
       - name: main
         uses: ./.github/actions/test-template
@@ -559,12 +565,12 @@ jobs:
           timeout: 18
           is_unit_test: "true"
           PAT: ${{ secrets.PAT }}
-          container-image: ${{ needs.pre-flight.outputs.registry }}/megatron-bridge:${{ github.sha }}
+          container-image: ${{ needs.pre-flight.outputs.registry }}/megatron-bridge:${{ needs.configure.outputs.merge_sha }}
           test-data-path: ${{ needs.pre-flight.outputs.test_data_path }}
           runner: ${{ needs.pre-flight.outputs.runner_prefix }}
 
   generate-test-matrix:
-    needs: [pre-flight, cicd-container-build]
+    needs: [pre-flight, configure, cicd-container-build]
     runs-on: ubuntu-latest
     outputs:
       matrix_l0: ${{ steps.scan.outputs.matrix_l0 }}
@@ -581,6 +587,8 @@ jobs:
       && !cancelled()
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.configure.outputs.merge_sha }}
       - id: scan
         shell: bash
         env:
@@ -629,7 +637,7 @@ jobs:
       fail-fast: false
       max-parallel: 16
       matrix: ${{ fromJSON(needs.generate-test-matrix.outputs.matrix_l0) }}
-    needs: [pre-flight, generate-test-matrix, cicd-unit-tests-core, cicd-unit-tests-diffusion]
+    needs: [pre-flight, configure, generate-test-matrix, cicd-unit-tests-core, cicd-unit-tests-diffusion]
     runs-on: ${{ matrix.runner }}
     if: |
       (
@@ -650,6 +658,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: recursive
+          ref: ${{ needs.configure.outputs.merge_sha }}
 
       - name: main
         uses: ./.github/actions/test-template
@@ -658,7 +667,7 @@ jobs:
           timeout: ${{ fromJSON(matrix.timeout || '30') }}
           is_unit_test: "false"
           PAT: ${{ secrets.PAT }}
-          container-image: ${{ needs.pre-flight.outputs.registry }}/megatron-bridge:${{ github.sha }}
+          container-image: ${{ needs.pre-flight.outputs.registry }}/megatron-bridge:${{ needs.configure.outputs.merge_sha }}
           test-data-path: ${{ needs.pre-flight.outputs.test_data_path }}
           runner: ${{ matrix.runner }}
 
@@ -690,6 +699,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: recursive
+          ref: ${{ needs.configure.outputs.merge_sha }}
 
       - name: main
         uses: ./.github/actions/test-template
@@ -698,7 +708,7 @@ jobs:
           timeout: ${{ fromJSON(matrix.timeout || '30') }}
           is_unit_test: "false"
           PAT: ${{ secrets.PAT }}
-          container-image: ${{ needs.pre-flight.outputs.registry }}/megatron-bridge:${{ github.sha }}
+          container-image: ${{ needs.pre-flight.outputs.registry }}/megatron-bridge:${{ needs.configure.outputs.merge_sha }}
           test-data-path: ${{ needs.pre-flight.outputs.test_data_path }}
           runner: ${{ matrix.runner }}
 
@@ -730,6 +740,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: recursive
+          ref: ${{ needs.configure.outputs.merge_sha }}
 
       - name: main
         uses: ./.github/actions/test-template
@@ -738,7 +749,7 @@ jobs:
           timeout: ${{ fromJSON(matrix.timeout || '30') }}
           is_unit_test: "false"
           PAT: ${{ secrets.PAT }}
-          container-image: ${{ needs.pre-flight.outputs.registry }}/megatron-bridge:${{ github.sha }}
+          container-image: ${{ needs.pre-flight.outputs.registry }}/megatron-bridge:${{ needs.configure.outputs.merge_sha }}
           test-data-path: ${{ needs.pre-flight.outputs.test_data_path }}
           runner: ${{ matrix.runner }}
 
@@ -748,7 +759,7 @@ jobs:
       fail-fast: false
       max-parallel: 16
       matrix: ${{ fromJSON(needs.generate-test-matrix.outputs.matrix_flaky) }}
-    needs: [pre-flight, generate-test-matrix, cicd-unit-tests-core, cicd-unit-tests-diffusion]
+    needs: [pre-flight, configure, generate-test-matrix, cicd-unit-tests-core, cicd-unit-tests-diffusion]
     runs-on: ${{ matrix.runner }}
     name: ${{ matrix.script }}
     env:
@@ -760,6 +771,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: recursive
+          ref: ${{ needs.configure.outputs.merge_sha }}
 
       - name: main
         uses: ./.github/actions/test-template
@@ -769,12 +781,12 @@ jobs:
           timeout: ${{ fromJSON(matrix.timeout || '30') }}
           is_unit_test: "false"
           PAT: ${{ secrets.PAT }}
-          container-image: ${{ needs.pre-flight.outputs.registry }}/megatron-bridge:${{ github.sha }}
+          container-image: ${{ needs.pre-flight.outputs.registry }}/megatron-bridge:${{ needs.configure.outputs.merge_sha }}
           test-data-path: ${{ needs.pre-flight.outputs.test_data_path }}
           runner: ${{ matrix.runner }}
 
   generate-gb200-test-matrix:
-    needs: [pre-flight, cicd-container-build]
+    needs: [pre-flight, configure, cicd-container-build]
     runs-on: ubuntu-latest
     outputs:
       matrix_gb200_l0:    ${{ steps.scan.outputs.matrix_gb200_l0 }}
@@ -792,6 +804,8 @@ jobs:
       && needs.pre-flight.outputs.is_member == 'true'
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.configure.outputs.merge_sha }}
       - id: scan
         shell: bash
         run: |
@@ -838,7 +852,7 @@ jobs:
       fail-fast: false
       max-parallel: 16
       matrix: ${{ fromJSON(needs.generate-gb200-test-matrix.outputs.matrix_gb200_l0) }}
-    needs: [pre-flight, generate-gb200-test-matrix, cicd-unit-tests-core, cicd-unit-tests-diffusion]
+    needs: [pre-flight, configure, generate-gb200-test-matrix, cicd-unit-tests-core, cicd-unit-tests-diffusion]
     runs-on: ${{ matrix.runner }}
     if: |
       (
@@ -861,6 +875,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: recursive
+          ref: ${{ needs.configure.outputs.merge_sha }}
 
       - name: main
         uses: ./.github/actions/test-template
@@ -874,7 +889,7 @@ jobs:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           PAT: ${{ secrets.PAT }}
-          container-image: ${{ env.container-registry-gb200 }}/megatron-bridge:${{ github.sha }}
+          container-image: ${{ env.container-registry-gb200 }}/megatron-bridge:${{ needs.configure.outputs.merge_sha }}
           test-data-path: ${{ needs.pre-flight.outputs.test_data_path }}
           runner: ${{ matrix.runner }}
 
@@ -908,6 +923,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: recursive
+          ref: ${{ needs.configure.outputs.merge_sha }}
 
       - name: main
         uses: ./.github/actions/test-template
@@ -921,7 +937,7 @@ jobs:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           PAT: ${{ secrets.PAT }}
-          container-image: ${{ env.container-registry-gb200 }}/megatron-bridge:${{ github.sha }}
+          container-image: ${{ env.container-registry-gb200 }}/megatron-bridge:${{ needs.configure.outputs.merge_sha }}
           test-data-path: ${{ needs.pre-flight.outputs.test_data_path }}
           runner: ${{ matrix.runner }}
 
@@ -955,6 +971,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: recursive
+          ref: ${{ needs.configure.outputs.merge_sha }}
 
       - name: main
         uses: ./.github/actions/test-template
@@ -968,7 +985,7 @@ jobs:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           PAT: ${{ secrets.PAT }}
-          container-image: ${{ env.container-registry-gb200 }}/megatron-bridge:${{ github.sha }}
+          container-image: ${{ env.container-registry-gb200 }}/megatron-bridge:${{ needs.configure.outputs.merge_sha }}
           test-data-path: ${{ needs.pre-flight.outputs.test_data_path }}
           runner: ${{ matrix.runner }}
 
@@ -978,7 +995,7 @@ jobs:
       fail-fast: false
       max-parallel: 16
       matrix: ${{ fromJSON(needs.generate-gb200-test-matrix.outputs.matrix_gb200_flaky) }}
-    needs: [pre-flight, generate-gb200-test-matrix, cicd-unit-tests-core, cicd-unit-tests-diffusion]
+    needs: [pre-flight, configure, generate-gb200-test-matrix, cicd-unit-tests-core, cicd-unit-tests-diffusion]
     runs-on: ${{ matrix.runner }}
     name: gb200_${{ matrix.script }}
     environment: ${{ contains(needs.pre-flight.outputs.registry, 'azure') && 'nemo-ci' || '' }}
@@ -991,6 +1008,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: recursive
+          ref: ${{ needs.configure.outputs.merge_sha }}
 
       - name: main
         uses: ./.github/actions/test-template
@@ -1004,7 +1022,7 @@ jobs:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           PAT: ${{ secrets.PAT }}
-          container-image: ${{ env.container-registry-gb200 }}/megatron-bridge:${{ github.sha }}
+          container-image: ${{ env.container-registry-gb200 }}/megatron-bridge:${{ needs.configure.outputs.merge_sha }}
           test-data-path: ${{ needs.pre-flight.outputs.test_data_path }}
           runner: ${{ matrix.runner }}
 
@@ -1027,6 +1045,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.configure.outputs.merge_sha }}
 
       - name: Get workflow result
         id: result
@@ -1126,6 +1146,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.configure.outputs.merge_sha }}
 
       - name: Download coverage reports of current branch
         uses: actions/download-artifact@v7


### PR DESCRIPTION
## Background / motivation

A large batch of functional jobs on PR #4466 failed with `bash: tests/functional_tests/launch_scripts/.../<NAME>.sh: No such file or directory` (exit 127), unrelated to the PR's actual change.

Root cause is a commit-resolution split inside `cicd-main.yml`:

- **`generate-test-matrix` / `generate-gb200-test-matrix`** scan a checkout that defaults to **`github.sha`** — the PR **head** branch tip.
- **`cicd-container-build`** checks out and builds from the PR **`merge_commit_sha`** (head merged into `main`), but tags the image with `github.sha`, which disguised the split. The launch scripts execute **inside that container** via `docker exec` (the host checkout is not mounted).

When `main` renames/recategorizes launch scripts (e.g. #4470 bumped tier prefixes `L0→L1→L2`), a PR that is behind `main` scans the **stale head-tree** names, schedules jobs under those names, and then can't find them in the **merge-commit container** → exit 127. Every non-renamed script still passes, which is why the failures look scattered.

## What changed

- Resolve the merge-commit SHA **once** in the `configure` job and expose it as a `merge_sha` output.
- Consume `merge_sha` **throughout** the workflow: every source checkout (`ref:`), the image build tag, and every `container-image` reference.
- Remove the now-redundant per-job merge-sha resolution in `cicd-container-build`.
- Add `configure` to the `needs:` of jobs that now consume the output.

The matrix is now scanned from the **same tree the container is built from**, so a PR behind a launch-script rename stays green without a rebase.

## Details

- `configure`: new `merge_sha` output + `Resolve merge commit sha` step (PR → `get-pr-info.merge_commit_sha`, non-PR → `$GITHUB_SHA`; identical logic to the old container-build step).
- `cicd-container-build`: drops its local `Get merge commit sha` step; checkout `ref` and the `:${{ github.sha }}` image tag → `:${{ needs.configure.outputs.merge_sha }}`.
- 12 image references (build tag + all consumers) and 17 source checkouts now use `merge_sha`.
- No other workflow consumes `megatron-bridge:${{ github.sha }}`, so nothing downstream breaks.

```mermaid
flowchart TD
    subgraph before["Before — split commit"]
        H1["github.sha (PR head)"] --> M1[generate-test-matrix]
        MC1["merge_commit_sha (head + main)"] --> B1[cicd-container-build]
        M1 -->|"old script names"| T1{{docker exec in container}}
        B1 -->|"new script names"| T1
        T1 --> X1["exit 127: No such file"]
    end
    subgraph after["After — single source"]
        CFG["configure.merge_sha = merge_commit_sha"] --> M2[generate-test-matrix]
        CFG --> B2[cicd-container-build]
        M2 -->|"same names"| T2{{docker exec in container}}
        B2 -->|"same names"| T2
        T2 --> OK2["tests run"]
    end
```

## Tested

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/cicd-main.yml'))"` → parses.
- Verified no `${{ github.sha }}` or `steps.sha.outputs.main` references remain in `cicd-main.yml`.
- Verified every job consuming `merge_sha` has `configure` in `needs` (no DAG cycle; `configure` only needs `pre-flight`).
- Full CI run on this PR exercises the end-to-end path.
