### PR TITLE
[Training] Fix packed THD CP slicing

### DIFF
--- a/src/megatron/bridge/data/datasets/packed_parquet.py
+++ b/src/megatron/bridge/data/datasets/packed_parquet.py
@@ -327,6 +327,7 @@ class GPTSFTPackedParquetDataset(GPTSFTPackedDataset):
         tokenizer: "MegatronTokenizer",
         return_cu_seqlen: bool = True,
         pad_cu_seqlens: bool = False,
+        pad_seq_to_mult: int = 1,
         pack_metadata_file_path: str | None = None,
         **kwargs,
     ):
@@ -340,6 +341,7 @@ class GPTSFTPackedParquetDataset(GPTSFTPackedDataset):
             tokenizer: The tokenizer to use.
             return_cu_seqlen: Whether to return cu_seqlen for THD attention kernel.
             pad_cu_seqlens: Whether to pad cu_seqlens for cudagraphs compatibility.
+            pad_seq_to_mult: The multiple used for padding sequences during packing.
             pack_metadata_file_path: Path to the metadata JSON file for pad_cu_seqlens.
             **kwargs: Additional arguments passed to parent class.
         """
@@ -364,6 +366,7 @@ class GPTSFTPackedParquetDataset(GPTSFTPackedDataset):
             tokenizer=tokenizer,
             return_cu_seqlen=return_cu_seqlen,
             pad_cu_seqlens=pad_cu_seqlens,
+            pad_seq_to_mult=pad_seq_to_mult,
             pack_metadata_file_path=pack_metadata_file_path,
             **kwargs,
         )

--- a/src/megatron/bridge/data/datasets/sft.py
+++ b/src/megatron/bridge/data/datasets/sft.py
@@ -234,6 +234,7 @@ def create_sft_dataset(
         return GPTSFTPackedParquetDataset(
             pack_metadata_file_path=pack_metadata_file_path,
             pad_cu_seqlens=pad_cu_seqlens,
+            pad_seq_to_mult=pad_seq_to_mult,
             **gpt_sft_dataset_kwargs,
             **kwargs,
         )

--- a/src/megatron/bridge/training/gpt_step.py
+++ b/src/megatron/bridge/training/gpt_step.py
@@ -49,6 +49,24 @@ from megatron.bridge.training.utils.pg_utils import get_pg_collection
 logger = logging.getLogger(__name__)
 
 
+def _trim_padded_cu_seqlens_for_cp(cu_seqlens: torch.Tensor, cu_seqlens_argmin: torch.Tensor | None) -> torch.Tensor:
+    """Trim padded THD cu_seqlens without introducing a CUDA sync."""
+    if cu_seqlens_argmin is not None:
+        if cu_seqlens_argmin.is_cuda:
+            raise ValueError("Packed CP batches expect cu_seqlens_argmin on CPU to avoid device-to-host sync")
+        return cu_seqlens[: int(cu_seqlens_argmin.item())]
+
+    if cu_seqlens.is_cuda:
+        raise ValueError("Packed CP batches require cu_seqlens_argmin to trim cu_seqlens without GPU synchronization")
+
+    # Packed dataset padding uses -1 sentinels. Match the first negative entry
+    # instead of argmin so this stays correct for any negative sentinel value.
+    padding_indices = torch.nonzero(cu_seqlens < 0, as_tuple=True)[0]
+    if padding_indices.numel() == 0:
+        return cu_seqlens
+    return cu_seqlens[: int(padding_indices[0].item())]
+
+
 def _uses_packed_sequence_metadata(cfg: ConfigContainer) -> bool:
     """Return whether the dataset is expected to provide packed sequence metadata."""
     dataset_cfg = getattr(cfg, "dataset", None)
@@ -147,6 +165,8 @@ def _partition_packed_batch_for_cp(batch: dict[str, torch.Tensor], cp_size: int)
     if cu_seqlens.dim() > 1 and cu_seqlens.size(0) != 1:
         raise ValueError("Packed THD batches expect micro-batch size 1 for context-parallel slicing (THD layout)")
     cu_seqlens = cu_seqlens.squeeze()
+    cu_seqlens = _trim_padded_cu_seqlens_for_cp(cu_seqlens, batch.get("cu_seqlens_argmin"))
+
     cu_seqlens_unpadded = batch.get("cu_seqlens_unpadded")
     if cu_seqlens_unpadded is not None:
         batch["cu_seqlens_unpadded"] = cu_seqlens_unpadded.squeeze()

--- a/tests/unit_tests/data/datasets/test_chat_template.py
+++ b/tests/unit_tests/data/datasets/test_chat_template.py
@@ -463,6 +463,23 @@ class TestCreateSFTDataset:
         mock_parquet_class.assert_called_once()
 
     @patch("megatron.bridge.data.datasets.packed_parquet.GPTSFTPackedParquetDataset")
+    def test_create_packed_parquet_dataset_preserves_pad_seq_to_mult(self, mock_parquet_class):
+        """Test that packed Parquet datasets receive pad_seq_to_mult."""
+        from pathlib import Path
+
+        mock_tokenizer = MagicMock()
+        mock_parquet_class.return_value = MagicMock()
+
+        create_sft_dataset(
+            path=Path("test.idx.parquet"),
+            tokenizer=mock_tokenizer,
+            pad_seq_to_mult=4,
+        )
+
+        call_kwargs = mock_parquet_class.call_args[1]
+        assert call_kwargs["pad_seq_to_mult"] == 4
+
+    @patch("megatron.bridge.data.datasets.packed_parquet.GPTSFTPackedParquetDataset")
     def test_create_packed_parquet_dataset_idx_pq(self, mock_parquet_class):
         """Test that .idx.pq files create GPTSFTPackedParquetDataset."""
         from pathlib import Path

--- a/tests/unit_tests/training/test_gpt_step.py
+++ b/tests/unit_tests/training/test_gpt_step.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 from functools import partial
 from unittest.mock import MagicMock, Mock, patch
 
@@ -22,6 +23,7 @@ from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.bridge.training.gpt_step import (
     _create_loss_function_modelopt,
     _forward_step_common,
+    _partition_packed_batch_for_cp,
     get_batch,
     get_packed_seq_params,
 )
@@ -162,6 +164,118 @@ class _VpStageWrapper:
 
 class TestGetBatch:
     """Tests for the get_batch helper."""
+
+    def test_partition_packed_batch_trims_padded_cu_seqlens(self, monkeypatch):
+        """Packed CP slicing should ignore padded cu_seqlens sentinels."""
+        seen_cu_seqlens = []
+
+        def fake_thd_get_partitioned_indices(cu_seqlens, total_tokens, cp_size, cp_rank):
+            seen_cu_seqlens.append(cu_seqlens.clone())
+            assert total_tokens == 8
+            assert cp_size == 2
+            assert cp_rank == 0
+            return torch.tensor([0, 1, 2, 3], dtype=torch.long)
+
+        fake_tex = type(
+            "FakeTransformerEngineTorch",
+            (),
+            {"thd_get_partitioned_indices": staticmethod(fake_thd_get_partitioned_indices)},
+        )
+        monkeypatch.setitem(sys.modules, "transformer_engine_torch", fake_tex)
+        monkeypatch.setattr("megatron.bridge.training.gpt_step.is_te_min_version", lambda version: True)
+        monkeypatch.setattr(
+            "megatron.bridge.training.gpt_step.parallel_state.get_context_parallel_rank",
+            lambda: 0,
+        )
+
+        batch = {
+            "tokens": torch.arange(8).unsqueeze(0),
+            "labels": torch.arange(100, 108).unsqueeze(0),
+            "loss_mask": torch.ones(1, 8),
+            "position_ids": torch.arange(8).unsqueeze(0),
+            "cu_seqlens": torch.tensor([[0, 4, 6, 8, -1, -1]], dtype=torch.int32),
+            "cu_seqlens_argmin": torch.tensor([[4]]),
+            "max_seqlen": torch.tensor([[4]], dtype=torch.int32),
+        }
+
+        out = _partition_packed_batch_for_cp(batch, cp_size=2)
+
+        assert seen_cu_seqlens
+        assert all(torch.equal(cu, torch.tensor([0, 4, 6, 8], dtype=torch.int32)) for cu in seen_cu_seqlens)
+        assert torch.equal(out["tokens"], torch.tensor([[0, 1, 2, 3]]))
+        assert torch.equal(out["labels"], torch.tensor([[100, 101, 102, 103]]))
+        assert torch.equal(out["position_ids"], torch.tensor([[0, 1, 2, 3]]))
+        assert torch.equal(out["loss_mask"], torch.ones(1, 4))
+
+    def test_partition_packed_batch_trims_negative_sentinel_fallback(self, monkeypatch):
+        """Packed CP slicing can trim CPU cu_seqlens without a precomputed argmin."""
+        seen_cu_seqlens = []
+
+        def fake_thd_get_partitioned_indices(cu_seqlens, total_tokens, cp_size, cp_rank):
+            seen_cu_seqlens.append(cu_seqlens.clone())
+            return torch.tensor([0, 1, 2, 3], dtype=torch.long)
+
+        fake_tex = type(
+            "FakeTransformerEngineTorch",
+            (),
+            {"thd_get_partitioned_indices": staticmethod(fake_thd_get_partitioned_indices)},
+        )
+        monkeypatch.setitem(sys.modules, "transformer_engine_torch", fake_tex)
+        monkeypatch.setattr("megatron.bridge.training.gpt_step.is_te_min_version", lambda version: True)
+        monkeypatch.setattr(
+            "megatron.bridge.training.gpt_step.parallel_state.get_context_parallel_rank",
+            lambda: 0,
+        )
+
+        batch = {
+            "tokens": torch.arange(8).unsqueeze(0),
+            "labels": torch.arange(100, 108).unsqueeze(0),
+            "loss_mask": torch.ones(1, 8),
+            "position_ids": torch.arange(8).unsqueeze(0),
+            "cu_seqlens": torch.tensor([[0, 4, 6, 8, -1, -1]], dtype=torch.int32),
+            "max_seqlen": torch.tensor([[4]], dtype=torch.int32),
+        }
+
+        out = _partition_packed_batch_for_cp(batch, cp_size=2)
+
+        assert seen_cu_seqlens
+        assert all(torch.equal(cu, torch.tensor([0, 4, 6, 8], dtype=torch.int32)) for cu in seen_cu_seqlens)
+        assert torch.equal(out["tokens"], torch.tensor([[0, 1, 2, 3]]))
+
+    def test_partition_packed_batch_no_padding_passthrough(self, monkeypatch):
+        """Packed CP slicing should leave unpadded cu_seqlens unchanged."""
+        seen_cu_seqlens = []
+
+        def fake_thd_get_partitioned_indices(cu_seqlens, total_tokens, cp_size, cp_rank):
+            seen_cu_seqlens.append(cu_seqlens.clone())
+            return torch.tensor([0, 1, 2, 3], dtype=torch.long)
+
+        fake_tex = type(
+            "FakeTransformerEngineTorch",
+            (),
+            {"thd_get_partitioned_indices": staticmethod(fake_thd_get_partitioned_indices)},
+        )
+        monkeypatch.setitem(sys.modules, "transformer_engine_torch", fake_tex)
+        monkeypatch.setattr("megatron.bridge.training.gpt_step.is_te_min_version", lambda version: True)
+        monkeypatch.setattr(
+            "megatron.bridge.training.gpt_step.parallel_state.get_context_parallel_rank",
+            lambda: 0,
+        )
+
+        batch = {
+            "tokens": torch.arange(8).unsqueeze(0),
+            "labels": torch.arange(100, 108).unsqueeze(0),
+            "loss_mask": torch.ones(1, 8),
+            "position_ids": torch.arange(8).unsqueeze(0),
+            "cu_seqlens": torch.tensor([[0, 4, 8]], dtype=torch.int32),
+            "max_seqlen": torch.tensor([[4]], dtype=torch.int32),
+        }
+
+        out = _partition_packed_batch_for_cp(batch, cp_size=2)
+
+        assert seen_cu_seqlens
+        assert all(torch.equal(cu, torch.tensor([0, 4, 8], dtype=torch.int32)) for cu in seen_cu_seqlens)
+        assert torch.equal(out["tokens"], torch.tensor([[0, 1, 2, 3]]))
 
     def test_middle_pp_stage_preserves_full_packed_batch(self, monkeypatch):
         """Middle PP stages load full tensors when packed metadata is active."""


### PR DESCRIPTION
# What does this PR do ?

Fix packed THD context-parallel slicing so padded `cu_seqlens` sentinels are not passed to Transformer Engine's partition-index helper.

# Changelog

- Trim padded `cu_seqlens` before calling `thd_get_partitioned_indices` for packed CP batches.
- Require the CUDA packed-CP path to use precomputed host `cu_seqlens_argmin`, avoiding a fallback CUDA `argmin` sync.
- Forward `pad_seq_to_mult` into `GPTSFTPackedParquetDataset` so packed Parquet SFT datasets preserve sequence-padding settings.
- Add focused unit coverage for padded `cu_seqlens` CP slicing and packed Parquet factory argument forwarding.

# GitHub Actions CI

Draft PR. CI has not been triggered yet.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation? (No documentation update needed.)
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

# Additional Information

Regression background:

- The observed failure is due to the packed Parquet path. Previous CP + packed-sequence runs used the legacy `.npy` packed dataset path and were fine.
- Packed Parquet inherited the packed dataset collate/runtime path, but did not forward `pad_seq_to_mult`, so CP packed Parquet did not preserve the same padding metadata behavior as the working `.npy` path.
- The runtime trim in `gpt_step.py` keeps the shared packed-THD CP slicer from passing padded `cu_seqlens` sentinels to Transformer Engine. That protects this Parquet regression and any future packed source that emits padded `cu_seqlens`.
- Packed dataset `cu_seqlens` padding uses `-1` sentinels. The CPU fallback now trims at the first negative entry rather than using `argmin`, and the CUDA path requires precomputed host argmin metadata to avoid device-to-host synchronization.

Lyris debug evidence:

- Before the fix, CP=2 packed THD slicing dropped padded tail positions and selected extra real tokens. The CP=2 post-slice `loss_mask` sum was 496 versus CP=1's 488.
- After trimming padded `cu_seqlens`, CP=2 post-slice aggregate tensors matched CP=1 for tokens, labels, `loss_mask`, and `position_ids`.
- After the fix, layer-level activation comparison showed layer 0 input exactly equal and no layer relative L2 above 1e-2.

Local validation:

- PASS: `git diff --check`
- PASS: `python3 -m pre_commit run --all-files --show-diff-on-failure --color=always`
- PASS: `python3 -m py_compile src/megatron/bridge/training/gpt_step.py src/megatron/bridge/data/datasets/sft.py src/megatron/bridge/data/datasets/packed_parquet.py tests/unit_tests/training/test_gpt_step.py tests/unit_tests/data/datasets/test_chat_template.py`
- BLOCKED: `uv run python -m pytest tests/unit_tests/training/test_gpt_step.py::TestGetBatch::test_partition_packed_batch_trims_padded_cu_seqlens tests/unit_tests/training/test_gpt_step.py::TestGetBatch::test_partition_packed_batch_trims_negative_sentinel_fallback tests/unit_tests/training/test_gpt_step.py::TestGetBatch::test_partition_packed_batch_no_padding_passthrough tests/unit_tests/data/datasets/test_chat_template.py::TestCreateSFTDataset::test_create_packed_parquet_dataset_preserves_pad_seq_to_mult`
  - Local dependency resolution fails before tests run because `nvidia-resiliency-ext==0.6.0` has no wheel for this host's `manylinux_2_31_x86_64` baseline.
- BLOCKED: `uv run pre-commit run --all-files`
  - Same `nvidia-resiliency-ext==0.6.0` wheel compatibility blocker.

Impact:

- This is not model-family-specific. Any Bridge training path using packed THD data with `context_parallel_size > 1` and padded `cu_seqlens` could be affected.
- CP=1, non-packed/BSHD paths, and packed batches without padded `cu_seqlens` sentinels are not affected by this specific bug.
