### PR TITLE
fix(tests): increase LoRA finetune data rows

### DIFF
--- a/tests/functional_tests/test_groups/training/test_finetune_lora.py
+++ b/tests/functional_tests/test_groups/training/test_finetune_lora.py
@@ -359,7 +359,8 @@ class TestLoRAFinetune:
         dataset_root = os.path.join(base_dir, "sft_data")
         if torch.distributed.get_rank() == 0:
             os.makedirs(dataset_root, exist_ok=True)
-            rows = [{"input": f"Question: {idx} + {idx}? Answer:", "output": str(idx + idx)} for idx in range(32)]
+            # Keep enough finite samples for dataloader_type="single" LoRA runs.
+            rows = [{"input": f"Question: {idx} + {idx}? Answer:", "output": str(idx + idx)} for idx in range(64)]
             with open(os.path.join(dataset_root, "training.jsonl"), "w", encoding="utf-8") as f:
                 for row in rows:
                     f.write(json.dumps(row) + "\n")


### PR DESCRIPTION
## Summary
- Increase the tiny LoRA SFT fixture from 32 to 64 rows.
- The finite SFT dataset had fewer rows than `train_iters * global_batch_size` for `dataloader_type="single"` (5 * 8 = 40), which can exhaust the iterator and raise `StopIteration`.
- Align the LoRA fixture size with the DoRA functional test fixture.

## Verification
- `git diff --check`
- `uv run --no-sync python -m py_compile tests/functional_tests/test_groups/training/test_finetune_lora.py`
- `uv run --no-sync pre-commit run --all-files`

## Not run
- Full functional GPU test; expected to run on CI GPU runners.