### PR TITLE
fix(docs): remove duplicate VLM processing helpers

### DIFF
--- a/src/megatron/bridge/data/vlm_processing.py
+++ b/src/megatron/bridge/data/vlm_processing.py
@@ -374,43 +374,6 @@ def chat_template_kwargs_from_example(
     return kwargs
 
 
-def _as_token_id_list(token_ids: Any) -> list[int]:
-    if token_ids is None:
-        return []
-    if isinstance(token_ids, torch.Tensor):
-        token_ids = token_ids.detach().cpu().tolist()
-    if isinstance(token_ids, (list, tuple)) and token_ids and isinstance(token_ids[0], torch.Tensor):
-        token_ids = [item.detach().cpu().tolist() for item in token_ids]
-    if isinstance(token_ids, (list, tuple)) and token_ids and isinstance(token_ids[0], (list, tuple)):
-        if len(token_ids) != 1:
-            return []
-        token_ids = token_ids[0]
-    return [int(token_id) for token_id in token_ids]
-
-
-def _conversation_from_example(
-    example_or_conversation: Mapping[str, Any] | Sequence[Mapping[str, Any]],
-) -> Sequence[Mapping[str, Any]]:
-    if isinstance(example_or_conversation, Mapping):
-        conversation = example_or_conversation.get("conversation", [])
-        return conversation if isinstance(conversation, Sequence) and not isinstance(conversation, str) else []
-    return example_or_conversation
-
-
-def chat_template_kwargs_from_example(
-    example_or_conversation: Mapping[str, Any] | Sequence[Mapping[str, Any]],
-) -> dict[str, Any]:
-    """Return optional HF chat-template kwargs stored alongside a conversation."""
-    if not isinstance(example_or_conversation, Mapping):
-        return {}
-
-    kwargs: dict[str, Any] = {}
-    tools = example_or_conversation.get("tools")
-    if tools is not None:
-        kwargs["tools"] = tools
-    return kwargs
-
-
 def find_token_span(sequence: Sequence[int] | torch.Tensor, pattern: Sequence[int], start: int = 0) -> tuple[int, int]:
     """Find the first ``[start, end)`` token span matching ``pattern``.
 


### PR DESCRIPTION
## Summary

Remove the repeated helper-definition block in `bridge.data.vlm_processing` so autodoc2 only sees each symbol once. This fixes the reported warnings:

- `WARNING: Duplicate item bridge.data.vlm_processing._as_token_id_list (function) [autodoc2.dup_item]`
- `WARNING: Duplicate item bridge.data.vlm_processing._conversation_from_example (function) [autodoc2.dup_item]`
- `WARNING: Duplicate item bridge.data.vlm_processing.chat_template_kwargs_from_example (function) [autodoc2.dup_item]`

The remaining helper implementations are unchanged.

## Validation

- `git diff --check`
- `uv run --no-project --with 'ruff>=0.9.9' ruff format src/megatron/bridge/data/vlm_processing.py`
- `uv run --no-project --with 'ruff>=0.9.9' ruff check src/megatron/bridge/data/vlm_processing.py`
- `uv run --no-project --with 'pre-commit>=3.6.0' pre-commit run --all-files`
- Targeted `autodoc2 create-db` for `bridge.data.vlm_processing` completed without duplicate warnings

Full project-environment docs build was not used because the fresh checkout did not initialize the Megatron-LM submodule; no submodule files were changed.
