### PR TITLE
[data, tests] fix: stabilize LoRA packed finetune

### DIFF
--- a/scripts/training/pack_sft_data.py
+++ b/scripts/training/pack_sft_data.py
@@ -96,8 +96,8 @@ def main() -> None:
 
     # Cap tokenizer workers to avoid /dev/shm OOM from multiprocessing shared memory.
     # Default is -1 (all CPUs) which exhausts /dev/shm even on CPU nodes.
-    # Use 1 worker to avoid /dev/shm OOM: num_workers==1 runs single-threaded
-    # with no multiprocessing shared memory (see packed_sequence._retrieve_tokenized).
+    # Use 1 worker so serial materialization avoids multiprocessing shared memory
+    # (see packed_sequence._materialize_dataset_items).
     offline_packing_specs.num_tokenizer_workers = 1
 
     print(f"Recipe:   {args.recipe}")

--- a/src/megatron/bridge/data/datasets/packed_sequence.py
+++ b/src/megatron/bridge/data/datasets/packed_sequence.py
@@ -36,20 +36,20 @@ logger = logging.getLogger(__name__)
 _shared_dataset = None
 
 
-def _tokenize_get_item(i):
+def _get_shared_dataset_item(i):
     return _shared_dataset[i]
 
 
-def _tokenize_init_worker(dataset):
+def _init_shared_dataset_worker(dataset):
     global _shared_dataset
     _shared_dataset = dataset
 
 
-def _retrieve_tokenized(dataset, num_workers):
+def _materialize_dataset_items(dataset, num_workers):
     if num_workers <= 1:
         return np.array([dataset[i] for i in tqdm(range(len(dataset)))])
-    with Pool(num_workers, initializer=_tokenize_init_worker, initargs=(dataset,)) as pool:
-        return np.array(list(tqdm(pool.imap(_tokenize_get_item, range(len(dataset))), total=len(dataset))))
+    with Pool(num_workers, initializer=_init_shared_dataset_worker, initargs=(dataset,)) as pool:
+        return np.array(list(tqdm(pool.imap(_get_shared_dataset_item, range(len(dataset))), total=len(dataset))))
 
 
 def _pre_pad_data_point(data: dict, max_seq_length: int, max_length_to_pad: int, pad_id: int) -> None:
@@ -153,7 +153,7 @@ def tokenize_dataset(
     pad_id = dataset.tokenizer.eod
     pad_seq_length_to_mult = dataset.pad_seq_length_to_mult
     max_seq_length = dataset.max_seq_length
-    dataset = _retrieve_tokenized(dataset, num_tokenizer_workers)
+    dataset = _materialize_dataset_items(dataset, num_tokenizer_workers)
 
     if pad_seq_to_mult > 1:
 

--- a/src/megatron/bridge/data/datasets/packed_sequence.py
+++ b/src/megatron/bridge/data/datasets/packed_sequence.py
@@ -37,6 +37,31 @@ logger = logging.getLogger(__name__)
 _shared_dataset = None
 
 
+def _distributed_is_initialized() -> bool:
+    """Return whether torch.distributed is initialized without importing torch at module import time."""
+    try:
+        import torch
+
+        return torch.distributed.is_available() and torch.distributed.is_initialized()
+    except (AttributeError, ImportError, RuntimeError):
+        return False
+
+
+def _resolve_num_tokenizer_workers(num_workers: int) -> int:
+    """Resolve the tokenizer worker count used during packed data preparation."""
+    if num_workers > 0:
+        return num_workers
+
+    if _distributed_is_initialized():
+        logger.info(
+            "Using a single tokenizer worker for in-process distributed packing. "
+            "Set PackedSequenceSpecs.num_tokenizer_workers > 1 to opt into multiprocessing."
+        )
+        return 1
+
+    return mp.cpu_count()
+
+
 def _tokenize_get_item(i):
     return _shared_dataset[i]
 
@@ -47,9 +72,9 @@ def _tokenize_init_worker(dataset):
 
 
 def _retrieve_tokenized(dataset, num_workers):
+    num_workers = _resolve_num_tokenizer_workers(num_workers)
     if num_workers == 1:
         return np.array([dataset[i] for i in tqdm(range(len(dataset)))])
-    num_workers = num_workers if num_workers > 0 else mp.cpu_count()
     with Pool(num_workers, initializer=_tokenize_init_worker, initargs=(dataset,)) as pool:
         return np.array(list(tqdm(pool.imap(_tokenize_get_item, range(len(dataset))), total=len(dataset))))
 

--- a/src/megatron/bridge/data/datasets/packed_sequence.py
+++ b/src/megatron/bridge/data/datasets/packed_sequence.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 import json
 import logging
-import multiprocessing as mp
 import warnings
 from dataclasses import dataclass
 from multiprocessing import Pool
@@ -37,31 +36,6 @@ logger = logging.getLogger(__name__)
 _shared_dataset = None
 
 
-def _distributed_is_initialized() -> bool:
-    """Return whether torch.distributed is initialized without importing torch at module import time."""
-    try:
-        import torch
-
-        return torch.distributed.is_available() and torch.distributed.is_initialized()
-    except (AttributeError, ImportError, RuntimeError):
-        return False
-
-
-def _resolve_num_tokenizer_workers(num_workers: int) -> int:
-    """Resolve the tokenizer worker count used during packed data preparation."""
-    if num_workers > 0:
-        return num_workers
-
-    if _distributed_is_initialized():
-        logger.info(
-            "Using a single tokenizer worker for in-process distributed packing. "
-            "Set PackedSequenceSpecs.num_tokenizer_workers > 1 to opt into multiprocessing."
-        )
-        return 1
-
-    return mp.cpu_count()
-
-
 def _tokenize_get_item(i):
     return _shared_dataset[i]
 
@@ -72,8 +46,7 @@ def _tokenize_init_worker(dataset):
 
 
 def _retrieve_tokenized(dataset, num_workers):
-    num_workers = _resolve_num_tokenizer_workers(num_workers)
-    if num_workers == 1:
+    if num_workers <= 1:
         return np.array([dataset[i] for i in tqdm(range(len(dataset)))])
     with Pool(num_workers, initializer=_tokenize_init_worker, initargs=(dataset,)) as pool:
         return np.array(list(tqdm(pool.imap(_tokenize_get_item, range(len(dataset))), total=len(dataset))))
@@ -305,7 +278,7 @@ class PackedSequenceSpecs:
     num_tokenizer_workers: int = -1
     """
     The number of worker processes to use for tokenization when preparing the packed sequence dataset.
-    If -1, the number of workers will be set to the number of CPU cores available
+    If less than or equal to 1, tokenization runs serially. Values greater than 1 enable multiprocessing.
     """
 
     packed_train_data_path: str = None

--- a/tests/functional_tests/test_groups/training/test_finetune_lora.py
+++ b/tests/functional_tests/test_groups/training/test_finetune_lora.py
@@ -52,6 +52,7 @@ from tests.functional_tests.utils import (
 
 DEFAULT_GLOBAL_BATCH_SIZE = 8
 DEFAULT_SFT_DATASET_ROWS = 64
+PACKED_SFT_CONTEXT_REPETITIONS = 520
 
 
 @dataclass
@@ -270,7 +271,10 @@ class TestLoRAFinetune:
                 pretrain_checkpoint_dir,
                 packed_sequence_size,
                 packed_sequences=True,
-                dataset_root=self._write_sft_dataset(shared_base_dir),
+                dataset_root=self._write_sft_dataset(
+                    shared_base_dir,
+                    context_repetitions=PACKED_SFT_CONTEXT_REPETITIONS,
+                ),
             )
             # Ensure micro_batch_size is 1 for packed sequences (requirement)
             lora_cfg.train.micro_batch_size = 1
@@ -360,14 +364,18 @@ class TestLoRAFinetune:
             num_workers=1,
         )
 
-    def _write_sft_dataset(self, base_dir, num_rows=DEFAULT_SFT_DATASET_ROWS):
+    def _write_sft_dataset(self, base_dir, num_rows=DEFAULT_SFT_DATASET_ROWS, context_repetitions=0):
         """Create a tiny local SFT dataset shared by all distributed ranks."""
         dataset_root = os.path.join(base_dir, "sft_data")
         if torch.distributed.get_rank() == 0:
             os.makedirs(dataset_root, exist_ok=True)
-            rows = [
-                {"input": f"Question: {idx} + {idx}? Answer:", "output": str(idx + idx)} for idx in range(num_rows)
-            ]
+            context = " ".join(["context"] * context_repetitions)
+            rows = []
+            for idx in range(num_rows):
+                question = f"Question: {idx} + {idx}?"
+                if context:
+                    question = f"{question} Context: {context}."
+                rows.append({"input": f"{question} Answer:", "output": str(idx + idx)})
             with open(os.path.join(dataset_root, "training.jsonl"), "w", encoding="utf-8") as f:
                 for row in rows:
                     f.write(json.dumps(row) + "\n")

--- a/tests/unit_tests/data/datasets/test_packed_sequence.py
+++ b/tests/unit_tests/data/datasets/test_packed_sequence.py
@@ -14,7 +14,7 @@
 
 import torch
 
-from megatron.bridge.data.datasets.packed_sequence import _pre_pad_data_point
+from megatron.bridge.data.datasets.packed_sequence import _pre_pad_data_point, _resolve_num_tokenizer_workers
 
 
 PAD_ID = 0
@@ -71,3 +71,25 @@ def test_pre_pad_data_point_truncates_overlong():
 
     assert len(data["input_ids"]) == 16
     assert len(data["loss_mask"]) == 16
+
+
+def test_resolve_num_tokenizer_workers_keeps_explicit_worker_count(monkeypatch):
+    """Explicit worker counts should remain opt-in even when distributed is initialized."""
+    monkeypatch.setattr("megatron.bridge.data.datasets.packed_sequence._distributed_is_initialized", lambda: True)
+
+    assert _resolve_num_tokenizer_workers(2) == 2
+
+
+def test_resolve_num_tokenizer_workers_uses_one_worker_during_distributed_packing(monkeypatch):
+    """Default multiprocessing is unsafe after distributed signal handlers are installed."""
+    monkeypatch.setattr("megatron.bridge.data.datasets.packed_sequence._distributed_is_initialized", lambda: True)
+
+    assert _resolve_num_tokenizer_workers(-1) == 1
+
+
+def test_resolve_num_tokenizer_workers_uses_cpu_count_outside_distributed(monkeypatch):
+    """Outside distributed training, the historical default still uses all CPUs."""
+    monkeypatch.setattr("megatron.bridge.data.datasets.packed_sequence._distributed_is_initialized", lambda: False)
+    monkeypatch.setattr("megatron.bridge.data.datasets.packed_sequence.mp.cpu_count", lambda: 12)
+
+    assert _resolve_num_tokenizer_workers(-1) == 12

--- a/tests/unit_tests/data/datasets/test_packed_sequence.py
+++ b/tests/unit_tests/data/datasets/test_packed_sequence.py
@@ -14,7 +14,7 @@
 
 import torch
 
-from megatron.bridge.data.datasets.packed_sequence import _pre_pad_data_point, _resolve_num_tokenizer_workers
+from megatron.bridge.data.datasets.packed_sequence import _pre_pad_data_point, _retrieve_tokenized
 
 
 PAD_ID = 0
@@ -73,23 +73,20 @@ def test_pre_pad_data_point_truncates_overlong():
     assert len(data["loss_mask"]) == 16
 
 
-def test_resolve_num_tokenizer_workers_keeps_explicit_worker_count(monkeypatch):
-    """Explicit worker counts should remain opt-in even when distributed is initialized."""
-    monkeypatch.setattr("megatron.bridge.data.datasets.packed_sequence._distributed_is_initialized", lambda: True)
+def test_retrieve_tokenized_uses_serial_path_for_non_positive_workers(monkeypatch):
+    """Non-positive worker counts should not create a multiprocessing pool."""
 
-    assert _resolve_num_tokenizer_workers(2) == 2
+    class TinyDataset:
+        def __len__(self):
+            return 3
 
+        def __getitem__(self, index):
+            return index + 10
 
-def test_resolve_num_tokenizer_workers_uses_one_worker_during_distributed_packing(monkeypatch):
-    """Default multiprocessing is unsafe after distributed signal handlers are installed."""
-    monkeypatch.setattr("megatron.bridge.data.datasets.packed_sequence._distributed_is_initialized", lambda: True)
+    def fail_pool(*args, **kwargs):
+        raise AssertionError("Pool should not be constructed for non-positive worker counts")
 
-    assert _resolve_num_tokenizer_workers(-1) == 1
+    monkeypatch.setattr("megatron.bridge.data.datasets.packed_sequence.Pool", fail_pool)
 
-
-def test_resolve_num_tokenizer_workers_uses_cpu_count_outside_distributed(monkeypatch):
-    """Outside distributed training, the historical default still uses all CPUs."""
-    monkeypatch.setattr("megatron.bridge.data.datasets.packed_sequence._distributed_is_initialized", lambda: False)
-    monkeypatch.setattr("megatron.bridge.data.datasets.packed_sequence.mp.cpu_count", lambda: 12)
-
-    assert _resolve_num_tokenizer_workers(-1) == 12
+    assert _retrieve_tokenized(TinyDataset(), -1).tolist() == [10, 11, 12]
+    assert _retrieve_tokenized(TinyDataset(), 0).tolist() == [10, 11, 12]

--- a/tests/unit_tests/data/datasets/test_packed_sequence.py
+++ b/tests/unit_tests/data/datasets/test_packed_sequence.py
@@ -14,7 +14,7 @@
 
 import torch
 
-from megatron.bridge.data.datasets.packed_sequence import _pre_pad_data_point, _retrieve_tokenized
+from megatron.bridge.data.datasets.packed_sequence import _materialize_dataset_items, _pre_pad_data_point
 
 
 PAD_ID = 0
@@ -73,7 +73,7 @@ def test_pre_pad_data_point_truncates_overlong():
     assert len(data["loss_mask"]) == 16
 
 
-def test_retrieve_tokenized_uses_serial_path_for_non_positive_workers(monkeypatch):
+def test_materialize_dataset_items_uses_serial_path_for_non_positive_workers(monkeypatch):
     """Non-positive worker counts should not create a multiprocessing pool."""
 
     class TinyDataset:
@@ -88,5 +88,5 @@ def test_retrieve_tokenized_uses_serial_path_for_non_positive_workers(monkeypatc
 
     monkeypatch.setattr("megatron.bridge.data.datasets.packed_sequence.Pool", fail_pool)
 
-    assert _retrieve_tokenized(TinyDataset(), -1).tolist() == [10, 11, 12]
-    assert _retrieve_tokenized(TinyDataset(), 0).tolist() == [10, 11, 12]
+    assert _materialize_dataset_items(TinyDataset(), -1).tolist() == [10, 11, 12]
+    assert _materialize_dataset_items(TinyDataset(), 0).tolist() == [10, 11, 12]


### PR DESCRIPTION
## Summary
- make packed-data item materialization serial when `PackedSequenceSpecs.num_tokenizer_workers <= 1`; values greater than 1 remain explicit multiprocessing opt-in
- keep `0` safe as a user-facing value by avoiding `Pool(0)`
- make the LoRA packed-sequence functional fixture long enough to produce at least a full global batch after packing
- rename private helpers around dataset item materialization so they no longer imply tokenization happens outside `dataset[i]`

## Root cause
The packed LoRA functional fixture had 64 very short examples with `packed_sequence_size=4096`, so packing collapsed the training split to one packed row, below the test's global batch size of 8. Separately, the unset/non-positive tokenizer worker default was expanded to all CPU cores, so the default packing path used multiprocessing when a serial path is sufficient. This keeps the default simple and deterministic while preserving explicit multiprocessing for `num_tokenizer_workers > 1`.

## Testing
- cw single-node 2-GPU reproduction on main: focused packed test failed with `train dataset size (1) < global batch size (8)` (job 13115291)
- cw single-node 2-GPU full file on `249380c755b22448129f247ef7ad7d5d5c72226d`: `uv run --no-sync python -m torch.distributed.run --standalone --nproc_per_node=2 -m pytest -v -s -x --tb=short tests/functional_tests/test_groups/training/test_finetune_lora.py` passed (job 13119904)
- cw on `eff245c6051d2c50f4412917535356bab042b43a`: `uv run --no-sync python -m pytest -v tests/unit_tests/data/datasets/test_packed_sequence.py` passed, 5 tests (job 13120001)
- cw on `eff245c6051d2c50f4412917535356bab042b43a`: `uv run --no-sync pre-commit run --all-files` passed (job 13120001)