### PR TITLE
fix(training): handle packed SFT CP masks

### DIFF
--- a/examples/models/nemotron/nemotron_3/ultra/slurm_sft.sh
+++ b/examples/models/nemotron/nemotron_3/ultra/slurm_sft.sh
@@ -68,6 +68,28 @@ ETP=${ETP:-1}
 CP=${CP:-1}
 SP=${SP:-True}
 GPUS_PER_NODE=${GPUS_PER_NODE:-8}
+PAD_SEQ_TO_MULT=${PAD_SEQ_TO_MULT:-}
+
+if [ -z "$PAD_SEQ_TO_MULT" ]; then
+    if [ "$CP" -gt 1 ]; then
+        PAD_SEQ_TO_MULT=$((2 * CP))
+        case "$SP" in
+            True | true | TRUE | 1 | yes | YES)
+                CP_SP_MULT=$((CP * TP))
+                GCD_A=$PAD_SEQ_TO_MULT
+                GCD_B=$CP_SP_MULT
+                while [ "$GCD_B" -ne 0 ]; do
+                    GCD_TMP=$((GCD_A % GCD_B))
+                    GCD_A=$GCD_B
+                    GCD_B=$GCD_TMP
+                done
+                PAD_SEQ_TO_MULT=$((PAD_SEQ_TO_MULT / GCD_A * CP_SP_MULT))
+                ;;
+        esac
+    else
+        PAD_SEQ_TO_MULT=1
+    fi
+fi
 
 RECOMPUTE_GRANULARITY=${RECOMPUTE_GRANULARITY:-full}
 RECOMPUTE_METHOD=${RECOMPUTE_METHOD:-uniform}
@@ -146,6 +168,7 @@ CLI_OVERRIDES="\
     model.sequence_parallel=${SP} \
     model.context_parallel_size=${CP} \
     model.seq_length=${SEQ_LENGTH} \
+    dataset.packed_sequence_specs.pad_seq_to_mult=${PAD_SEQ_TO_MULT} \
     model.recompute_granularity=${RECOMPUTE_GRANULARITY} \
     dist.distributed_timeout_minutes=90"
 
@@ -179,6 +202,7 @@ echo "Nodes: ${SLURM_JOB_NUM_NODES}"
 echo "GPUs/node: ${GPUS_PER_NODE}"
 echo "Recipe: ${RECIPE_NAME}"
 echo "Parallelism: TP=${TP} PP=${PP} EP=${EP} ETP=${ETP} CP=${CP} SP=${SP}"
+echo "Packed pad_seq_to_mult: ${PAD_SEQ_TO_MULT}"
 echo "Recompute: ${RECOMPUTE_GRANULARITY} ${RECOMPUTE_METHOD:-} ${RECOMPUTE_MODULES}"
 echo "Save dir: ${SAVE_DIR}"
 echo "W&B: ${WANDB_ENTITY}/${WANDB_PROJECT} (${WANDB_MODE})"

--- a/src/megatron/bridge/data/datasets/sft.py
+++ b/src/megatron/bridge/data/datasets/sft.py
@@ -1039,7 +1039,7 @@ class GPTSFTPackedDataset(GPTSFTDataset):
                 max_seqlen, _ = seqlens.max(dim=1, keepdim=True)
 
             cu_seqlens_batch = {
-                "attention_mask": torch.LongTensor([1] * len(input_ids)),  # no attention mask is needed for packed seq
+                "attention_mask": None,  # no attention mask is needed for packed seq
                 "cu_seqlens": torch.IntTensor(cu_seqlens),  # cu_seqlens_q must be in dtype torch.int32
                 "cu_seqlens_argmin": cu_seqlens_argmin,  # only required for perf
                 "max_seqlen": max_seqlen,  # only required for perf

--- a/tests/unit_tests/data/datasets/test_chat_template.py
+++ b/tests/unit_tests/data/datasets/test_chat_template.py
@@ -1026,6 +1026,7 @@ class TestEOSIndexFixInPackedDataset:
 
         # Expect a single non-EOS token tracked without indexing errors.
         assert cu_unpadded == [0, 1]
+        assert processed["attention_mask"] is None
 
 
 class TestPackedChatDatasetIntegration:

--- a/tests/unit_tests/training/test_gpt_step.py
+++ b/tests/unit_tests/training/test_gpt_step.py
@@ -226,6 +226,41 @@ class TestGetBatch:
         assert all(torch.equal(cu, torch.tensor([0, 4, 8], dtype=torch.int32)) for cu in seen_cu_seqlens)
         assert torch.equal(out["tokens"], torch.tensor([[0, 1, 2, 3]]))
 
+    def test_partition_packed_batch_skips_none_attention_mask(self, monkeypatch):
+        """Packed CP slicing should keep the packed attention mask as None."""
+        seen_keys = []
+
+        def fake_thd_get_partitioned_indices(cu_seqlens, total_tokens, cp_size, cp_rank):
+            seen_keys.append(total_tokens)
+            return torch.tensor([0, 1, 2, 3], dtype=torch.long)
+
+        fake_tex = type(
+            "FakeTransformerEngineTorch",
+            (),
+            {"thd_get_partitioned_indices": staticmethod(fake_thd_get_partitioned_indices)},
+        )
+        monkeypatch.setitem(sys.modules, "transformer_engine_torch", fake_tex)
+        monkeypatch.setattr("megatron.bridge.training.gpt_step.is_te_min_version", lambda version: True)
+        monkeypatch.setattr(
+            "megatron.bridge.training.gpt_step.parallel_state.get_context_parallel_rank",
+            lambda: 0,
+        )
+
+        batch = {
+            "tokens": torch.arange(8).unsqueeze(0),
+            "labels": torch.arange(100, 108).unsqueeze(0),
+            "loss_mask": torch.ones(1, 8),
+            "attention_mask": None,
+            "position_ids": torch.arange(8).unsqueeze(0),
+            "cu_seqlens": torch.tensor([[0, 4, 8]], dtype=torch.int32),
+            "max_seqlen": torch.tensor([[4]], dtype=torch.int32),
+        }
+
+        out = _partition_packed_batch_for_cp(batch, cp_size=2)
+
+        assert out["attention_mask"] is None
+        assert seen_keys == [8, 8, 8, 8]
+
     def test_middle_pp_stage_preserves_full_packed_batch(self, monkeypatch):
         """Middle PP stages load full tensors when packed metadata is active."""
         _set_middle_pp_stage(monkeypatch)


### PR DESCRIPTION
## Summary

This PR is stacked on `chcui/r050-packed-thd-cp-slicing-base`, which is current `r0.5.0` plus the packed THD CP slicing cherry-pick from #4506.

Visible diff in this PR:

- Makes packed SFT batches return `attention_mask=None` instead of a 1-D sentinel tensor, matching the packed THD path where no conventional attention mask is used.
- Derives `dataset.packed_sequence_specs.pad_seq_to_mult` in the Nemotron Ultra SFT launcher for CP runs; for `TP=2 CP=2 SP=True`, this resolves to `4`.
- Adds focused regression coverage for the packed attention-mask behavior and CP partition path.

## Root Cause

During Lyris CP2 validation, the run failed before iteration 1 in `_partition_packed_batch_for_cp()` at `val.size(1)`. Packed SFT collate was emitting `attention_mask=torch.LongTensor([1])`; CP2 middle PP stages keep full packed metadata and attempted to partition that 1-D tensor along dimension 1.

## Validation

- `git diff --check origin/r0.5.0...HEAD`
- `bash -n examples/models/nemotron/nemotron_3/ultra/slurm_sft.sh`
- `python3 -m py_compile src/megatron/bridge/data/datasets/packed_parquet.py src/megatron/bridge/data/datasets/sft.py src/megatron/bridge/training/gpt_step.py tests/unit_tests/data/datasets/test_chat_template.py tests/unit_tests/training/test_gpt_step.py`
- `pre-commit run --all-files`
- Attempted `uv run pre-commit run --all-files`, but local host dependency resolution is blocked because `nvidia-resiliency-ext==0.6.0` has no compatible wheel for this host platform.
- Lyris GB200 QA: replacement CP2 job `2212819` generated/resolved `pad_seq_to_mult4` OpenMath packed files and reached iteration `4/1000` with `0` skipped and `0` NaN iterations; the previous `IndexError` did not recur.
- Lyris GB200 CP1 comparison job `2212274` remained healthy at iteration `718/1000`, also with `0` skipped and `0` NaN iterations.

After #4506 is merged into `r0.5.0`, this PR should be retargeted back to `r0.5.0`.
