### PR TITLE
[build] chore: bump transformer-engine to release_v2.16_post

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,7 +129,7 @@ override-dependencies = [
     "torch; sys_platform == 'never'",
     "torchvision; sys_platform == 'never'",
     "triton; sys_platform == 'never'",
-    "transformer-engine @ git+https://github.com/NVIDIA/TransformerEngine.git@f8a01cd5ac55a6b669bacc4b222242bfff2c822a",
+    "transformer-engine @ git+https://github.com/NVIDIA/TransformerEngine.git@d64bc14dc87eb658ab98839e4b7687595ee53e2d",
     "mlflow>=3.9.0",                                        # To address CVE-2025-15031
     "cachetools>=5.0.0",
     "cryptography>=43.0.0,<47",

--- a/uv.lock
+++ b/uv.lock
@@ -21,7 +21,7 @@ overrides = [
     { name = "onnx", marker = "python_full_version < '3.13'", specifier = ">=1.21.0" },
     { name = "torch", marker = "sys_platform == 'never'" },
     { name = "torchvision", marker = "sys_platform == 'never'" },
-    { name = "transformer-engine", git = "https://github.com/NVIDIA/TransformerEngine.git?rev=f8a01cd5ac55a6b669bacc4b222242bfff2c822a" },
+    { name = "transformer-engine", git = "https://github.com/NVIDIA/TransformerEngine.git?rev=d64bc14dc87eb658ab98839e4b7687595ee53e2d" },
     { name = "triton", marker = "sys_platform == 'never'" },
     { name = "urllib3", specifier = ">=2.6.3" },
 ]
@@ -4818,8 +4818,8 @@ wheels = [
 
 [[package]]
 name = "transformer-engine"
-version = "2.16.0+f8a01cd5"
-source = { git = "https://github.com/NVIDIA/TransformerEngine.git?rev=f8a01cd5ac55a6b669bacc4b222242bfff2c822a#f8a01cd5ac55a6b669bacc4b222242bfff2c822a" }
+version = "2.16.0+d64bc14d"
+source = { git = "https://github.com/NVIDIA/TransformerEngine.git?rev=d64bc14dc87eb658ab98839e4b7687595ee53e2d#d64bc14dc87eb658ab98839e4b7687595ee53e2d" }
 dependencies = [
     { name = "einops" },
     { name = "importlib-metadata" },


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## What
- Bump `transformer-engine` to `release_v2.16_post`.
- Regenerate `uv.lock`.

## Lockfile delta
```
Updated transformer-engine v2.16.0+f8a01cd5 -> v2.16.0+d64bc14d
```
Pinned to the resolved SHA `d64bc14dc87eb658ab98839e4b7687595ee53e2d` (TE `release_v2.16_post` HEAD) for reproducibility. Diff limited to the TE git ref in `override-dependencies` plus its `uv.lock` source refs (2 files, 8 lines).

## Test plan
- [ ] L0 CI green
- [ ] L1 CI green (label `needs-more-tests` applied)
- [ ] L2 CI green (label `full-test-suite` applied — high-blast-radius TE bump)

## Quarantined tests (this bump)
_None yet — will be appended as flakes are identified during CI iteration._

## Cherry-pick
- Labeled `r0.5.0` for auto-cherrypick to the release branch after merge.

</details>
