### PR TITLE
fix(data): Avoid VLM package collate import cycle

### DIFF
--- a/src/megatron/bridge/data/vlm_datasets/__init__.py
+++ b/src/megatron/bridge/data/vlm_datasets/__init__.py
@@ -16,33 +16,16 @@
 VLM dataset utilities.
 
 Public API re-exports:
-- Collate fns: model-specific batch builders
 - Providers: VLM-specific mock and preloaded dataset providers
 """
 
 from megatron.bridge.data.energon.energon_provider import EnergonProvider
-from megatron.bridge.data.vlm_datasets.collate import (
-    COLLATE_FNS,
-    gemma3_vl_collate_fn,
-    nemotron_nano_v2_vl_collate_fn,
-    nemotron_omni_collate_fn,
-    qwen2_5_collate_fn,
-    qwen2_audio_collate_fn,
-)
 from megatron.bridge.data.vlm_datasets.mock_provider import MockVLMConversationProvider
 from megatron.bridge.data.vlm_datasets.preloaded_provider import PreloadedVLMConversationProvider
 
 
 __all__ = [
-    # Providers
     "PreloadedVLMConversationProvider",
     "MockVLMConversationProvider",
     "EnergonProvider",
-    # Collation utilities
-    "COLLATE_FNS",
-    "gemma3_vl_collate_fn",
-    "qwen2_5_collate_fn",
-    "qwen2_audio_collate_fn",
-    "nemotron_nano_v2_vl_collate_fn",
-    "nemotron_omni_collate_fn",
 ]

--- a/tests/unit_tests/data/vlm_datasets/test_imports.py
+++ b/tests/unit_tests/data/vlm_datasets/test_imports.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import subprocess
+import sys
+
+import pytest
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_direct_qwen_vl_collate_import_has_no_vlm_dataset_cycle():
+    result = subprocess.run(
+        [sys.executable, "-c", "import megatron.bridge.models.qwen_vl.data.collate_fn"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_vlm_datasets_package_import_does_not_load_collate_registry():
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import sys; "
+                "import megatron.bridge.data.vlm_datasets; "
+                "assert 'megatron.bridge.data.vlm_datasets.collate' not in sys.modules"
+            ),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_vlm_datasets_collate_registry_remains_available_from_explicit_module():
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "from megatron.bridge.data.vlm_datasets.collate import COLLATE_FNS, qwen2_5_collate_fn; "
+                "assert COLLATE_FNS['Qwen2_5_VLProcessor'] is qwen2_5_collate_fn"
+            ),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- Stop importing `megatron.bridge.data.vlm_datasets.collate` during `vlm_datasets` package initialization.
- Keep the `vlm_datasets` package root limited to provider re-exports; collate registry/functions remain available from `megatron.bridge.data.vlm_datasets.collate`.
- Add subprocess-based unit regression coverage for direct Qwen VL collate import, lightweight package initialization, and explicit collate registry import.

## Root Cause
`megatron.bridge.models.qwen_vl.data.collate_fn` imports `THW_GRID_VISUAL_KEYS` from `megatron.bridge.data.vlm_datasets.collate_utils`. Python initializes the parent package `megatron.bridge.data.vlm_datasets` before importing that submodule. The old package `__init__.py` eagerly imported `vlm_datasets.collate`, and the collate registry imports `qwen2_5_collate_fn` back from the Qwen module that is still initializing, producing a partially-initialized-module circular import.

## Import Audit
Package-root imports in the repo only use provider exports, primarily `MockVLMConversationProvider`. Collate users already import `megatron.bridge.data.vlm_datasets.collate` explicitly, so dropping package-level collate re-exports does not require production call-site changes.

## Validation
- `git grep -n "from megatron\.bridge\.data\.vlm_datasets import\|import megatron\.bridge\.data\.vlm_datasets" -- ':!3rdparty/Megatron-LM'`
- `git grep -n "vlm_datasets import .*COLLATE\|vlm_datasets import .*collate\|vlm_datasets import .*qwen2_5\|vlm_datasets import .*gemma\|vlm_datasets import .*nemotron\|vlm_datasets import .*qwen2_audio" -- ':!3rdparty/Megatron-LM'`
- `uv run --no-sync ruff check src/megatron/bridge/data/vlm_datasets/__init__.py tests/unit_tests/data/vlm_datasets/test_imports.py`
- `uv run --no-sync ruff format --check src/megatron/bridge/data/vlm_datasets/__init__.py tests/unit_tests/data/vlm_datasets/test_imports.py`
- `uv run --no-sync python -m py_compile src/megatron/bridge/data/vlm_datasets/__init__.py tests/unit_tests/data/vlm_datasets/test_imports.py`
- `git diff --check`
- `uv run --no-sync pre-commit run --all-files`

Targeted pytest was attempted with `uv run python -m pytest tests/unit_tests/data/vlm_datasets/test_imports.py -q`, but this host cannot sync the project environment because `nvidia-resiliency-ext==0.6.0` has no wheel for `manylinux_2_31_x86_64`.
