### PR TITLE
ci: cache-from a single coherent buildcache donor

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -388,37 +388,6 @@ jobs:
         with:
           python-version: 3.12
 
-      - name: Install GH CLI
-        shell: bash
-        run: |
-          for i in 1 2 3; do
-            apt-get update && apt-get install -y gh && break
-            echo "Attempt $i failed, retrying in 10s..."
-            sleep 10
-          done
-
-      - name: Get last merged PR
-        id: cache_from
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          LAST_PRS=$(gh api graphql -f query='
-            query {
-              repository(owner: "NVIDIA-NeMo", name: "Megatron-Bridge") {
-                pullRequests(states: MERGED, first: 100, orderBy: {field: UPDATED_AT, direction: DESC}) {
-                  nodes {
-                    number
-                  }
-                }
-              }
-            }' | jq -r '.data.repository.pullRequests.nodes[].number' | while read -r number; do
-              echo "type=registry,ref=${{ matrix.registry }}/megatron-bridge:$number-buildcache,mode=max"
-            done)
-
-          echo "LAST_PRS<<EOF" | tee -a $GITHUB_OUTPUT
-          echo "$LAST_PRS" | tee -a $GITHUB_OUTPUT
-          echo "EOF" | tee -a $GITHUB_OUTPUT
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -435,7 +404,21 @@ jobs:
           else
             KEY="$BRANCH_SANITIZED"
           fi
+
+          # Single coherent cache donor. Dockerfile.ci builds non-reproducible
+          # from-source layers (DeepEP): same BuildKit cache key, different result
+          # digest on every cold build. Listing more than one cache-from donor lets
+          # BuildKit chain from a conflicting copy of such a layer and miss every
+          # layer downstream — a ~40 min cold rebuild even when a warm cache exists.
+          # So read EXACTLY ONE donor: PR builds integrate into main, so they seed
+          # from main; main/branch builds seed from their own chain.
+          if [[ -n "$PR_NUMBER" && "${{ github.ref }}" != "refs/heads/main" ]]; then
+            SEED="main"
+          else
+            SEED="$KEY"
+          fi
           echo "key=$KEY" | tee -a "$GITHUB_OUTPUT"
+          echo "seed=$SEED" | tee -a "$GITHUB_OUTPUT"
           echo "cache-to=type=registry,ref=${{ matrix.registry }}/megatron-bridge:${KEY}-buildcache,mode=max" | tee -a "$GITHUB_OUTPUT"
 
       - name: Compute platform
@@ -458,10 +441,7 @@ jobs:
             FROM_IMAGE_NAME=nvcr.io/nvidia/pytorch:25.09-py3
             MCORE_TRIGGERED_TESTING=${{ env.MCORE_TRIGGERED_TESTING || 'false' }}
             MCORE_COMMIT_SHA=${{ env.MCORE_COMMIT_SHA || 'unknown' }}
-          cache-from: |
-            type=registry,ref=${{ matrix.registry }}/megatron-bridge:${{ steps.cache_keys.outputs.key }}-buildcache,mode=max
-            type=registry,ref=${{ matrix.registry }}/megatron-bridge:main-buildcache,mode=max
-            ${{ steps.cache_from.outputs.LAST_PRS }}
+          cache-from: type=registry,ref=${{ matrix.registry }}/megatron-bridge:${{ steps.cache_keys.outputs.seed }}-buildcache,mode=max
           cache-to: ${{ steps.cache_keys.outputs.cache-to }}
           no-cache: false
           tags: |


### PR DESCRIPTION
## Background / motivation

* `build-and-push` cold-rebuilds the CI image (~40 min) on nearly every run.
* `docker/Dockerfile.ci` builds **non-reproducible from-source layers** (DeepEP: `git clone` + patch + `pip install`). Such a layer gets the **same** BuildKit cache key but a **different** result digest on every cold build.
* The `cache-from` block offered up to **~102 donors**: this PR/branch cache, `main`, **and the last 100 merged PRs** (the `Get last merged PR` step). With multiple donors carrying conflicting copies of that DeepEP layer, BuildKit can chain from the wrong copy and **miss every layer downstream** — a cold rebuild even when a warm cache exists.
* This is the same failure that `dl/joc/nemo-ci!2575` fixed for the equivalent GitLab build. The decisive A/B there (same SHA): single-source `cache-from` = **WARM (~170 s)** vs multi-source (+ main) = **COLD (2300 s+)**. More donors made it *worse*, not better.

## What changed

* `cache-from` now reads **exactly one coherent donor** instead of ~102.
* Removed the `Get last merged PR` step (the 100-PR fan-out) and the now-dead `Install GH CLI` step it depended on.

## Details

* `Compute cache keys` now also emits a `seed`:
  * PR builds integrate into `main` → seed from `main-buildcache`.
  * `main` / branch builds → seed from their own `${KEY}-buildcache` chain.
* `cache-to` is **unchanged** (still `${KEY}-buildcache`), so each PR keeps writing its own cache and rollback is trivial.
* Arch coherence is preserved: amd64 → ECR, arm64 → GAR (`matrix.registry` differs), so the single donor is per-arch automatically.
* No `resource_group` analog is needed: the workflow already has `concurrency` with `cancel-in-progress`, and `cache-to` is keyed per-PR, so cross-build clobbering of the donor doesn't occur.

```yaml
# before — up to ~102 donors, poisons the DeepEP layer
cache-from: |
  type=registry,ref=.../megatron-bridge:${key}-buildcache,mode=max
  type=registry,ref=.../megatron-bridge:main-buildcache,mode=max
  ${{ steps.cache_from.outputs.LAST_PRS }}   # last 100 merged PRs

# after — one coherent donor
cache-from: type=registry,ref=.../megatron-bridge:${seed}-buildcache,mode=max
```

```mermaid
flowchart TD
    A[Build and push] --> B{ref?}
    B -->|main| C[seed = main]
    B -->|PR| D[seed = main<br/>integration target]
    B -->|branch| E[seed = branch key]
    C --> F[cache-from: ONE donor]
    D --> F
    E --> F
    F --> G[cache-to: KEY-buildcache<br/>unchanged]
    subgraph old [removed]
        H[Install GH CLI] --> I[Get last merged PR<br/>100-PR fan-out]
    end
```

## Tested

* YAML validated (`yaml.safe_load`).
* Cache behavior is validated empirically by `dl/joc/nemo-ci!2575` on the identical DeepEP from-source layer; CI on this PR is the on-platform confirmation. Expect the second build on this branch to warm-hit instead of cold-rebuilding.
* Safe rollback: `cache-to` is unchanged, so reverting restores the old donor list without orphaning any cache ref.
