### PR TITLE
cp: `[build] chore: bump transformer-engine to release_v2.16_post (4527)` into `r0.5.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,7 +128,7 @@ override-dependencies = [
     "torch; sys_platform == 'never'",
     "torchvision; sys_platform == 'never'",
     "triton; sys_platform == 'never'",
-    "transformer-engine @ git+https://github.com/NVIDIA/TransformerEngine.git@4220403e831d29e93868f7793693ea83f6b8b05b",
+    "transformer-engine @ git+https://github.com/NVIDIA/TransformerEngine.git@d64bc14dc87eb658ab98839e4b7687595ee53e2d",
     "mlflow>=3.9.0",                                        # To address CVE-2025-15031
     "cachetools>=5.0.0",
     "cryptography>=43.0.0,<47",

--- a/uv.lock
+++ b/uv.lock
@@ -21,7 +21,7 @@ overrides = [
     { name = "onnx", marker = "python_full_version < '3.13'", specifier = ">=1.21.0" },
     { name = "torch", marker = "sys_platform == 'never'" },
     { name = "torchvision", marker = "sys_platform == 'never'" },
-    { name = "transformer-engine", git = "https://github.com/NVIDIA/TransformerEngine.git?rev=4220403e831d29e93868f7793693ea83f6b8b05b" },
+    { name = "transformer-engine", git = "https://github.com/NVIDIA/TransformerEngine.git?rev=d64bc14dc87eb658ab98839e4b7687595ee53e2d" },
     { name = "triton", marker = "sys_platform == 'never'" },
     { name = "urllib3", specifier = ">=2.6.3" },
 ]
@@ -4816,8 +4816,8 @@ wheels = [
 
 [[package]]
 name = "transformer-engine"
-version = "2.16.0+4220403e"
-source = { git = "https://github.com/NVIDIA/TransformerEngine.git?rev=4220403e831d29e93868f7793693ea83f6b8b05b#4220403e831d29e93868f7793693ea83f6b8b05b" }
+version = "2.16.0+d64bc14d"
+source = { git = "https://github.com/NVIDIA/TransformerEngine.git?rev=d64bc14dc87eb658ab98839e4b7687595ee53e2d#d64bc14dc87eb658ab98839e4b7687595ee53e2d" }
 dependencies = [
     { name = "einops" },
     { name = "importlib-metadata" },


### PR DESCRIPTION
## Background

Cherry-pick of #4527 into `r0.5.0`.

## What changed

- Bump `transformer-engine` pin to `release_v2.16_post` HEAD (`d64bc14d`).

## Details

- `pyproject.toml` / `uv.lock`: `transformer-engine` git rev `4220403e` → `d64bc14d` (`2.16.0+d64bc14d`).
- `d64bc14d` is the HEAD of TransformerEngine `release_v2.16_post`, 4 commits ahead / 0 behind the previous r0.5.0 pin — a clean forward bump on the same release line.
- Conflicts in both files were only the TE rev lines; resolved by taking the incoming rev.
