### PR TITLE
cp: `[build] chore: bump transformer-engine to release_v2.16.post` into `r0.5.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,7 +128,7 @@ override-dependencies = [
     "torch; sys_platform == 'never'",
     "torchvision; sys_platform == 'never'",
     "triton; sys_platform == 'never'",
-    "transformer-engine @ git+https://github.com/NVIDIA/TransformerEngine.git@4220403e831d29e93868f7793693ea83f6b8b05b",
+    "transformer-engine @ git+https://github.com/NVIDIA/TransformerEngine.git@b9d690e042b1c4e455214e7dab65d6d3512c05d6",
     "mlflow>=3.9.0",                                        # To address CVE-2025-15031
     "cachetools>=5.0.0",
     "cryptography>=43.0.0,<47",

--- a/uv.lock
+++ b/uv.lock
@@ -21,7 +21,7 @@ overrides = [
     { name = "onnx", marker = "python_full_version < '3.13'", specifier = ">=1.21.0" },
     { name = "torch", marker = "sys_platform == 'never'" },
     { name = "torchvision", marker = "sys_platform == 'never'" },
-    { name = "transformer-engine", git = "https://github.com/NVIDIA/TransformerEngine.git?rev=4220403e831d29e93868f7793693ea83f6b8b05b" },
+    { name = "transformer-engine", git = "https://github.com/NVIDIA/TransformerEngine.git?rev=b9d690e042b1c4e455214e7dab65d6d3512c05d6" },
     { name = "triton", marker = "sys_platform == 'never'" },
     { name = "urllib3", specifier = ">=2.6.3" },
 ]
@@ -4816,8 +4816,8 @@ wheels = [
 
 [[package]]
 name = "transformer-engine"
-version = "2.16.0+4220403e"
-source = { git = "https://github.com/NVIDIA/TransformerEngine.git?rev=4220403e831d29e93868f7793693ea83f6b8b05b#4220403e831d29e93868f7793693ea83f6b8b05b" }
+version = "2.16.0+b9d690e0"
+source = { git = "https://github.com/NVIDIA/TransformerEngine.git?rev=b9d690e042b1c4e455214e7dab65d6d3512c05d6#b9d690e042b1c4e455214e7dab65d6d3512c05d6" }
 dependencies = [
     { name = "einops" },
     { name = "importlib-metadata" },


### PR DESCRIPTION
## Background

`r0.5.0` currently pins TransformerEngine to the `v2.16` tag (`4220403`). This bumps it to the head of the upstream `release_v2.16.post` branch (`b9d690e`), matching the bump going onto `main`. Companion bumps land on Megatron-Bridge `main`, Megatron-LM `main`, and Megatron-LM `core_r0.18.0`.

## What changed

- `override-dependencies` TE pin `4220403e` → `b9d690e0` (`release_v2.16.post` head).
- Regenerated `uv.lock` (TE entry only).

## Details

- `pyproject.toml:131` — `transformer-engine @ git+...@b9d690e042b1c4e455214e7dab65d6d3512c05d6`.
- `uv.lock` — `transformer-engine` `2.16.0+4220403e` → `2.16.0+b9d690e0`; TE's transitive `dependencies` unchanged. Lockfile stays `revision = 2`.
- Relocked in-container (`uv lock`) so the CUDA-extension packages resolve identically to CI.

## Tested

- `uv lock` clean: `Resolved 344 packages`, `Updated transformer-engine v2.16.0+4220403e -> v2.16.0+b9d690e0`.
- CI via `Run CICD` label.
