### PR TITLE
refactor(diffusion): migrate bridges to model builders

### DIFF
--- a/examples/models/llada/llada15/README.md
+++ b/examples/models/llada/llada15/README.md
@@ -41,7 +41,7 @@ resolves the trust_remote_code class.
 ## Workflow
 
 ```
-HF safetensors  →  AutoBridge.to_megatron_model() (temporary diffusion fallback)  →  save_megatron_model()
+HF safetensors  →  AutoBridge.get_model_config() + get_megatron_model()  →  save_megatron_model()
                                                               ↓
                                                     iter_0000000/*.distcp
                                                               ↓

--- a/examples/models/llada/llada15/convert_llada15_hf_to_megatron.py
+++ b/examples/models/llada/llada15/convert_llada15_hf_to_megatron.py
@@ -77,8 +77,9 @@ def main():
     bridge = AutoBridge.from_hf_pretrained(args.hf_path, trust_remote_code=True)
 
     print("Building Megatron GPTModel and loading weights via the bridge...")
-    # Temporary compatibility path until the diffusion builder migration lands.
-    megatron_model = bridge.to_megatron_model(wrap_with_ddp=False)
+    model_config = bridge.get_model_config()
+    model_config.finalize()
+    megatron_model = bridge.get_megatron_model(model_config, wrap_with_ddp=False)
     if not isinstance(megatron_model, list):
         megatron_model = [megatron_model]
 
@@ -90,6 +91,7 @@ def main():
         args.out_path,
         hf_tokenizer_path=args.hf_path,
         hf_tokenizer_kwargs={"trust_remote_code": True},
+        model_config=model_config,
     )
     print("Done.")
 

--- a/src/megatron/bridge/diffusion/conversion/flux/flux_bridge.py
+++ b/src/megatron/bridge/diffusion/conversion/flux/flux_bridge.py
@@ -12,14 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, List, Mapping
+from typing import TYPE_CHECKING, Any, Dict, List, Mapping
 
 import torch
 from diffusers import FluxTransformer2DModel
+from megatron.core.transformer.utils import openai_gelu
 
 from megatron.bridge.diffusion.conversion.flux.flux_hf_pretrained import PreTrainedFlux
 from megatron.bridge.diffusion.models.flux.flux_model import Flux
-from megatron.bridge.diffusion.models.flux.flux_provider import FluxProvider
+from megatron.bridge.diffusion.models.flux.model_config import FluxModelConfig
 from megatron.bridge.models.conversion.mapping_registry import MegatronMappingRegistry
 from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge, WeightConversionTask
 from megatron.bridge.models.conversion.param_mapping import (
@@ -27,6 +28,10 @@ from megatron.bridge.models.conversion.param_mapping import (
     QKVMapping,
     RowParallelMapping,
 )
+
+
+if TYPE_CHECKING:
+    from megatron.bridge.diffusion.models.flux.flux_provider import FluxProvider
 
 
 def _flux_axes_dims_rope(hf_config) -> List[int]:
@@ -56,10 +61,48 @@ class FluxBridge(MegatronModelBridge):
     Example:
         >>> from megatron.bridge import AutoBridge
         >>> bridge = AutoBridge.from_hf_pretrained("black-forest-labs/FLUX.1-dev")
-        >>> provider = bridge.to_megatron_provider()
+        >>> model_config = bridge.to_megatron_model_config(load_weights=False)
     """
 
-    def provider_bridge(self, hf_pretrained: PreTrainedFlux) -> FluxProvider:
+    MODEL_CONFIG_CLASS = FluxModelConfig
+    CUSTOM_PROVIDER_MODEL_CONFIG_SUPPORTED = True
+
+    def hf_config_to_model_config_kwargs(self, hf_config: Any) -> dict[str, Any]:
+        """Map diffusers FLUX settings to pure model-config fields."""
+        hidden_size = hf_config.num_attention_heads * hf_config.attention_head_dim
+        self.hidden_size = hidden_size
+        return {
+            "num_layers": 1,
+            "hidden_size": hidden_size,
+            "ffn_hidden_size": _flux_ffn_hidden_size(hf_config, hidden_size),
+            "num_attention_heads": hf_config.num_attention_heads,
+            "num_query_groups": hf_config.num_attention_heads,
+            "kv_channels": hf_config.attention_head_dim,
+            "qk_layernorm": True,
+            "layernorm_epsilon": 1e-6,
+            "hidden_dropout": 0.0,
+            "attention_dropout": 0.0,
+            "activation_func": openai_gelu,
+            "add_qkv_bias": True,
+            "rotary_interleaved": True,
+            "apply_rope_fusion": False,
+            "gradient_accumulation_fusion": False,
+            "use_cpu_initialization": True,
+            "params_dtype": torch.float32,
+            "num_joint_layers": hf_config.num_layers,
+            "num_single_layers": hf_config.num_single_layers,
+            "in_channels": hf_config.in_channels,
+            "patch_size": hf_config.patch_size,
+            "context_dim": hf_config.joint_attention_dim,
+            "vec_in_dim": hf_config.pooled_projection_dim,
+            "guidance_embed": hf_config.guidance_embeds,
+            "axes_dims_rope": _flux_axes_dims_rope(hf_config),
+            "position_embedding_type": "none",
+        }
+
+    def provider_bridge(self, hf_pretrained: PreTrainedFlux) -> "FluxProvider":
+        from megatron.bridge.diffusion.models.flux.flux_provider import FluxProvider
+
         hf_config = hf_pretrained.config
 
         # Diffusers FLUX width is heads * per-head dim; defaults were wrong if we only set attention fields.

--- a/src/megatron/bridge/diffusion/conversion/flux/flux_bridge.py
+++ b/src/megatron/bridge/diffusion/conversion/flux/flux_bridge.py
@@ -61,11 +61,10 @@ class FluxBridge(MegatronModelBridge):
     Example:
         >>> from megatron.bridge import AutoBridge
         >>> bridge = AutoBridge.from_hf_pretrained("black-forest-labs/FLUX.1-dev")
-        >>> model_config = bridge.to_megatron_model_config(load_weights=False)
+        >>> model_config = bridge.get_model_config()
     """
 
     MODEL_CONFIG_CLASS = FluxModelConfig
-    CUSTOM_PROVIDER_MODEL_CONFIG_SUPPORTED = True
 
     def hf_config_to_model_config_kwargs(self, hf_config: Any) -> dict[str, Any]:
         """Map diffusers FLUX settings to pure model-config fields."""

--- a/src/megatron/bridge/diffusion/conversion/llada15/llada15_bridge.py
+++ b/src/megatron/bridge/diffusion/conversion/llada15/llada15_bridge.py
@@ -34,11 +34,13 @@ Key mapping decisions, anchored to the reference implementation
   fused into Megatron's TE ``linear_qkv``/``linear_fc1`` ``layer_norm_weight``.
 """
 
+from typing import TYPE_CHECKING
+
 import torch
 import torch.nn.functional as F
 from megatron.core.models.gpt.gpt_model import GPTModel
 
-from megatron.bridge.diffusion.models.llada15.llada15_provider import LLaDA15ModelProvider
+from megatron.bridge.diffusion.models.llada15.model_config import LLaDA15ModelConfig
 from megatron.bridge.models.conversion.mapping_registry import MegatronMappingRegistry
 from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge
 from megatron.bridge.models.conversion.param_mapping import (
@@ -49,19 +51,62 @@ from megatron.bridge.models.conversion.param_mapping import (
 from megatron.bridge.models.hf_pretrained.causal_lm import PreTrainedCausalLM
 
 
+if TYPE_CHECKING:
+    from megatron.bridge.diffusion.models.llada15.llada15_provider import LLaDA15ModelProvider
+
+
 # Registered under the trust_remote_code class name as a string so AutoBridge
 # can resolve it without importing the HF class (which lives in a dynamic
 # trust_remote_code module).
 @MegatronModelBridge.register_bridge(
     source="LLaDAModelLM",
     target=GPTModel,
-    provider=LLaDA15ModelProvider,
     model_type="llada",
 )
 class LLaDA15Bridge(MegatronModelBridge):
     """HF ``LLaDAModelLM`` ↔ Megatron ``GPTModel`` bridge."""
 
-    def provider_bridge(self, hf_pretrained: PreTrainedCausalLM) -> LLaDA15ModelProvider:
+    MODEL_CONFIG_CLASS = LLaDA15ModelConfig
+    CUSTOM_PROVIDER_MODEL_CONFIG_SUPPORTED = True
+
+    def hf_config_to_model_config_kwargs(self, hf_config) -> dict:
+        """Map LLaDA1.5 HF settings to builder-backed GPT config fields."""
+        num_kv_heads = hf_config.n_kv_heads if hf_config.n_kv_heads is not None else hf_config.n_heads
+        hidden_size = hf_config.d_model
+        ffn_hidden_size = (
+            hf_config.mlp_hidden_size if hf_config.mlp_hidden_size is not None else hf_config.mlp_ratio * hidden_size
+        )
+        vocab_size = hf_config.embedding_size or hf_config.vocab_size
+        return {
+            "num_layers": hf_config.n_layers,
+            "hidden_size": hidden_size,
+            "ffn_hidden_size": ffn_hidden_size,
+            "num_attention_heads": hf_config.n_heads,
+            "num_query_groups": num_kv_heads,
+            "kv_channels": hidden_size // hf_config.n_heads,
+            "vocab_size": vocab_size,
+            "seq_length": hf_config.max_sequence_length,
+            "layernorm_epsilon": hf_config.rms_norm_eps,
+            "rotary_base": hf_config.rope_theta,
+            "rotary_percent": 1.0,
+            "position_embedding_type": "rope",
+            "share_embeddings_and_output_weights": hf_config.weight_tying,
+            "add_bias_linear": hf_config.include_bias,
+            "add_qkv_bias": bool(hf_config.include_bias or hf_config.include_qkv_bias),
+            "normalization": "RMSNorm",
+            "gated_linear_unit": True,
+            "activation_func": F.silu,
+            "qk_layernorm": hf_config.attention_layer_norm,
+            "hidden_dropout": hf_config.residual_dropout,
+            "attention_dropout": hf_config.attention_dropout,
+            "bf16": True,
+            "params_dtype": torch.bfloat16,
+            "make_vocab_size_divisible_by": self.make_vocab_size_divisible_by(vocab_size),
+        }
+
+    def provider_bridge(self, hf_pretrained: PreTrainedCausalLM) -> "LLaDA15ModelProvider":
+        from megatron.bridge.diffusion.models.llada15.llada15_provider import LLaDA15ModelProvider
+
         hf_config = hf_pretrained.config
 
         # LLaDAConfig uses OLMo-style names (n_layers, d_model, n_heads, ...).

--- a/src/megatron/bridge/diffusion/conversion/llada15/llada15_bridge.py
+++ b/src/megatron/bridge/diffusion/conversion/llada15/llada15_bridge.py
@@ -67,7 +67,6 @@ class LLaDA15Bridge(MegatronModelBridge):
     """HF ``LLaDAModelLM`` ↔ Megatron ``GPTModel`` bridge."""
 
     MODEL_CONFIG_CLASS = LLaDA15ModelConfig
-    CUSTOM_PROVIDER_MODEL_CONFIG_SUPPORTED = True
 
     def hf_config_to_model_config_kwargs(self, hf_config) -> dict:
         """Map LLaDA1.5 HF settings to builder-backed GPT config fields."""
@@ -101,6 +100,7 @@ class LLaDA15Bridge(MegatronModelBridge):
             "attention_dropout": hf_config.attention_dropout,
             "bf16": True,
             "params_dtype": torch.bfloat16,
+            "autocast_dtype": torch.bfloat16,
             "make_vocab_size_divisible_by": self.make_vocab_size_divisible_by(vocab_size),
         }
 

--- a/src/megatron/bridge/diffusion/conversion/nemotron_labs_diffusion/nemotron_labs_diffusion_bridge.py
+++ b/src/megatron/bridge/diffusion/conversion/nemotron_labs_diffusion/nemotron_labs_diffusion_bridge.py
@@ -64,7 +64,6 @@ class NemotronLabsDiffusionBridge(MegatronModelBridge):
 
     _is_text_only: bool = True
     MODEL_CONFIG_CLASS = NemotronLabsDiffusionModelConfig
-    CUSTOM_PROVIDER_MODEL_CONFIG_SUPPORTED = True
 
     def hf_config_to_model_config_kwargs(self, hf_config: Any) -> dict[str, Any]:
         """Map Nemotron Labs Diffusion HF settings to pure GPT config fields."""
@@ -82,7 +81,11 @@ class NemotronLabsDiffusionBridge(MegatronModelBridge):
             "vocab_size": text_config.vocab_size,
             "seq_length": text_config.max_position_embeddings,
             "layernorm_epsilon": getattr(text_config, "rms_norm_eps", 1e-5),
-            "share_embeddings_and_output_weights": getattr(text_config, "tie_word_embeddings", False),
+            "share_embeddings_and_output_weights": getattr(
+                hf_config,
+                "tie_word_embeddings",
+                getattr(text_config, "tie_word_embeddings", False),
+            ),
             "rotary_base": text_config.rope_parameters["rope_theta"],
             "position_embedding_type": "none",
             "normalization": "RMSNorm",

--- a/src/megatron/bridge/diffusion/conversion/nemotron_labs_diffusion/nemotron_labs_diffusion_bridge.py
+++ b/src/megatron/bridge/diffusion/conversion/nemotron_labs_diffusion/nemotron_labs_diffusion_bridge.py
@@ -27,10 +27,15 @@ Supports two HF checkpoint formats (auto-detected from config):
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
+import torch
+import torch.nn.functional as F
 from megatron.core.models.gpt.gpt_model import GPTModel
 
+from megatron.bridge.diffusion.models.nemotron_labs_diffusion.model_config import (
+    NemotronLabsDiffusionModelConfig,
+)
 from megatron.bridge.models.conversion.mapping_registry import MegatronMappingRegistry
 from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge, register_bridge_implementation
 from megatron.bridge.models.conversion.param_mapping import (
@@ -58,6 +63,42 @@ class NemotronLabsDiffusionBridge(MegatronModelBridge):
     """
 
     _is_text_only: bool = True
+    MODEL_CONFIG_CLASS = NemotronLabsDiffusionModelConfig
+    CUSTOM_PROVIDER_MODEL_CONFIG_SUPPORTED = True
+
+    def hf_config_to_model_config_kwargs(self, hf_config: Any) -> dict[str, Any]:
+        """Map Nemotron Labs Diffusion HF settings to pure GPT config fields."""
+        text_config = getattr(hf_config, "text_config", hf_config)
+        self._is_text_only = not hasattr(hf_config, "text_config")
+        return {
+            "hidden_size": text_config.hidden_size,
+            "ffn_hidden_size": text_config.intermediate_size,
+            "num_layers": text_config.num_hidden_layers,
+            "num_attention_heads": text_config.num_attention_heads,
+            "num_query_groups": getattr(text_config, "num_key_value_heads", text_config.num_attention_heads),
+            "kv_channels": getattr(
+                text_config, "head_dim", text_config.hidden_size // text_config.num_attention_heads
+            ),
+            "vocab_size": text_config.vocab_size,
+            "seq_length": text_config.max_position_embeddings,
+            "layernorm_epsilon": getattr(text_config, "rms_norm_eps", 1e-5),
+            "share_embeddings_and_output_weights": getattr(text_config, "tie_word_embeddings", False),
+            "rotary_base": text_config.rope_parameters["rope_theta"],
+            "position_embedding_type": "none",
+            "normalization": "RMSNorm",
+            "gated_linear_unit": True,
+            "activation_func": F.silu,
+            "add_bias_linear": False,
+            "add_qkv_bias": False,
+            "hidden_dropout": 0.0,
+            "attention_dropout": 0.0,
+            "params_dtype": torch.bfloat16,
+            "autocast_dtype": torch.bfloat16,
+            "bf16": True,
+            "fp16": False,
+            "scatter_embedding_sequence_parallel": False,
+            "hf_config": hf_config.to_dict(),
+        }
 
     def provider_bridge(self, hf_pretrained: PreTrainedCausalLM) -> "NemotronLabsDiffusionModelProvider":
         # Imported lazily: the provider pulls in NemotronLabsDiffusionAttention ->

--- a/src/megatron/bridge/diffusion/conversion/wan/wan_bridge.py
+++ b/src/megatron/bridge/diffusion/conversion/wan/wan_bridge.py
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import TYPE_CHECKING, Any
+
 import torch
 from diffusers import WanTransformer3DModel
 
 from megatron.bridge.diffusion.conversion.wan.wan_hf_pretrained import PreTrainedWAN
+from megatron.bridge.diffusion.models.wan.model_config import WanModelConfig
 from megatron.bridge.diffusion.models.wan.wan_model import WanModel
-from megatron.bridge.diffusion.models.wan.wan_provider import WanModelProvider
 from megatron.bridge.models.conversion.mapping_registry import MegatronMappingRegistry
 from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge
 from megatron.bridge.models.conversion.param_mapping import (
@@ -27,6 +29,10 @@ from megatron.bridge.models.conversion.param_mapping import (
     ReplicatedMapping,
 )
 from megatron.bridge.models.conversion.utils import get_module_and_param_from_name
+
+
+if TYPE_CHECKING:
+    from megatron.bridge.diffusion.models.wan.wan_provider import WanModelProvider
 
 
 @MegatronModelBridge.register_bridge(source=WanTransformer3DModel, target=WanModel)
@@ -39,10 +45,50 @@ class WanBridge(MegatronModelBridge):
     Example:
         >>> from megatron.bridge import AutoBridge
         >>> bridge = AutoBridge.from_hf_pretrained("WAN-3D-1.3B-v1")
-        >>> provider = bridge.to_megatron_provider()
+        >>> model_config = bridge.to_megatron_model_config(load_weights=False)
     """
 
-    def provider_bridge(self, hf_pretrained: PreTrainedWAN) -> WanModelProvider:
+    MODEL_CONFIG_CLASS = WanModelConfig
+    CUSTOM_PROVIDER_MODEL_CONFIG_SUPPORTED = True
+
+    def hf_config_to_model_config_kwargs(self, hf_config: Any) -> dict[str, Any]:
+        """Map diffusers Wan settings to pure model-config fields."""
+        hidden_size = hf_config.num_attention_heads * hf_config.attention_head_dim
+        return {
+            "num_layers": hf_config.num_layers,
+            "hidden_size": hidden_size,
+            "kv_channels": hf_config.attention_head_dim,
+            "num_query_groups": hf_config.num_attention_heads,
+            "crossattn_emb_size": hidden_size,
+            "ffn_hidden_size": hf_config.ffn_dim,
+            "num_attention_heads": hf_config.num_attention_heads,
+            "in_channels": hf_config.in_channels,
+            "out_channels": hf_config.out_channels,
+            "text_dim": hf_config.text_dim,
+            "patch_spatial": hf_config.patch_size[1],
+            "patch_temporal": hf_config.patch_size[0],
+            "layernorm_epsilon": hf_config.eps,
+            "hidden_dropout": 0.0,
+            "attention_dropout": 0.0,
+            "use_cpu_initialization": True,
+            "freq_dim": hf_config.freq_dim,
+            "params_dtype": torch.float32,
+            "qk_layernorm": True,
+            "add_bias_linear": True,
+            "gated_linear_unit": False,
+            "normalization": "RMSNorm",
+            "layernorm_across_heads": True,
+            "add_qkv_bias": True,
+            "rotary_interleaved": True,
+            "qkv_format": "thd",
+            "apply_rope_fusion": True,
+            "bias_activation_fusion": True,
+            "position_embedding_type": "none",
+        }
+
+    def provider_bridge(self, hf_pretrained: PreTrainedWAN) -> "WanModelProvider":
+        from megatron.bridge.diffusion.models.wan.wan_provider import WanModelProvider
+
         hf_config = hf_pretrained.config
 
         cls = WanModelProvider

--- a/src/megatron/bridge/diffusion/conversion/wan/wan_bridge.py
+++ b/src/megatron/bridge/diffusion/conversion/wan/wan_bridge.py
@@ -45,11 +45,10 @@ class WanBridge(MegatronModelBridge):
     Example:
         >>> from megatron.bridge import AutoBridge
         >>> bridge = AutoBridge.from_hf_pretrained("WAN-3D-1.3B-v1")
-        >>> model_config = bridge.to_megatron_model_config(load_weights=False)
+        >>> model_config = bridge.get_model_config()
     """
 
     MODEL_CONFIG_CLASS = WanModelConfig
-    CUSTOM_PROVIDER_MODEL_CONFIG_SUPPORTED = True
 
     def hf_config_to_model_config_kwargs(self, hf_config: Any) -> dict[str, Any]:
         """Map diffusers Wan settings to pure model-config fields."""

--- a/src/megatron/bridge/diffusion/models/common/dit_attention.py
+++ b/src/megatron/bridge/diffusion/models/common/dit_attention.py
@@ -55,6 +55,7 @@ class DiTSelfAttention(SelfAttention):  # noqa: D101
         cp_comm_type: str = None,
         pg_collection=None,
         name: str | None = None,
+        layernorm_across_heads: bool | None = None,
     ):
         super().__init__(
             config,
@@ -66,7 +67,11 @@ class DiTSelfAttention(SelfAttention):  # noqa: D101
             name=name,
         )
 
-        self.layernorm_across_heads = getattr(self.config, "layernorm_across_heads", False)
+        self.layernorm_across_heads = (
+            layernorm_across_heads
+            if layernorm_across_heads is not None
+            else getattr(self.config, "layernorm_across_heads", False)
+        )
 
         # override q_layernorm
         if submodules.q_layernorm is not None:
@@ -195,6 +200,7 @@ class DiTCrossAttention(CrossAttention):  # noqa: D101
         cp_comm_type: str = None,
         pg_collection=None,
         name: str | None = None,
+        layernorm_across_heads: bool | None = None,
     ):
         super().__init__(
             config,
@@ -206,7 +212,11 @@ class DiTCrossAttention(CrossAttention):  # noqa: D101
             name=name,
         )
 
-        self.layernorm_across_heads = getattr(self.config, "layernorm_across_heads", False)
+        self.layernorm_across_heads = (
+            layernorm_across_heads
+            if layernorm_across_heads is not None
+            else getattr(self.config, "layernorm_across_heads", False)
+        )
 
         # override q_layernorm
         if submodules.q_layernorm is not None:

--- a/src/megatron/bridge/diffusion/models/common/nemotron_labs_diffusion_attention.py
+++ b/src/megatron/bridge/diffusion/models/common/nemotron_labs_diffusion_attention.py
@@ -157,6 +157,9 @@ class NemotronLabsDiffusionAttention(MegatronModule):
         softmax_scale: float = None,
         cp_comm_type: str = None,
         pg_collection: ProcessGroupCollection = None,
+        hf_config=None,
+        block_size: int | None = None,
+        apply_llama4_style_query_key_layer_scaling: bool = False,
     ):
         super().__init__(config=config)
         self.config = config
@@ -193,14 +196,17 @@ class NemotronLabsDiffusionAttention(MegatronModule):
         )
 
         # RoPE setup (always required)
-        hf_text_config = getattr(config.hf_config, "text_config", config.hf_config)
+        hf_config = hf_config if hf_config is not None else config.hf_config
+        hf_text_config = getattr(hf_config, "text_config", hf_config)
         hf_text_config.max_position_embeddings = config.seq_length
         self.rope_embedding_module = Ministral3RotaryEmbedding(hf_text_config)
 
         # Llama-4 style query scaling (optional)
         self.beta = None
         self.max_position_embeddings = None
-        if getattr(config, "apply_llama4_style_query_key_layer_scaling", False):
+        if apply_llama4_style_query_key_layer_scaling or getattr(
+            config, "apply_llama4_style_query_key_layer_scaling", False
+        ):
             self.beta = hf_text_config.rope_parameters["llama_4_scaling_beta"]
             self.max_position_embeddings = hf_text_config.rope_parameters["original_max_position_embeddings"]
             if (
@@ -210,8 +216,9 @@ class NemotronLabsDiffusionAttention(MegatronModule):
                 hf_text_config.rope_parameters["factor"] = config.yarn_rotary_scaling_factor
 
         # Pre-compute the sbd_block_diff block mask
+        effective_block_size = block_size if block_size is not None else getattr(config, "block_size", 16)
         self.mask = compute_block_mask(
-            block_size=getattr(config, "block_size", 16),
+            block_size=effective_block_size,
             max_seq_length=config.seq_length,
         )
 

--- a/src/megatron/bridge/diffusion/models/flux/__init__.py
+++ b/src/megatron/bridge/diffusion/models/flux/__init__.py
@@ -33,12 +33,6 @@ Components:
 """
 
 from megatron.bridge.diffusion.models.common.normalization import RMSNorm
-from megatron.bridge.diffusion.models.flux.flow_matching.flux_inference_pipeline import (
-    ClipConfig,
-    FlowMatchEulerDiscreteScheduler,
-    FluxInferencePipeline,
-    T5Config,
-)
 from megatron.bridge.diffusion.models.flux.flux_attention import (
     FluxSingleAttention,
     JointSelfAttention,
@@ -53,7 +47,6 @@ from megatron.bridge.diffusion.models.flux.flux_layer_spec import (
     get_flux_single_transformer_engine_spec,
 )
 from megatron.bridge.diffusion.models.flux.flux_model import Flux
-from megatron.bridge.diffusion.models.flux.flux_provider import FluxProvider
 from megatron.bridge.diffusion.models.flux.layers import (
     EmbedND,
     MLPEmbedder,
@@ -61,6 +54,19 @@ from megatron.bridge.diffusion.models.flux.layers import (
     Timesteps,
     rope,
 )
+
+
+def __getattr__(name: str):
+    """Lazily resolve heavyweight FLUX compatibility exports."""
+    if name == "FluxProvider":
+        from megatron.bridge.diffusion.models.flux.flux_provider import FluxProvider
+
+        return FluxProvider
+    if name in {"ClipConfig", "FlowMatchEulerDiscreteScheduler", "FluxInferencePipeline", "T5Config"}:
+        from megatron.bridge.diffusion.models.flux.flow_matching import flux_inference_pipeline
+
+        return getattr(flux_inference_pipeline, name)
+    raise AttributeError(name)
 
 
 __all__ = [

--- a/src/megatron/bridge/diffusion/models/flux/flux_model.py
+++ b/src/megatron/bridge/diffusion/models/flux/flux_model.py
@@ -75,15 +75,39 @@ class Flux(VisionModule):
     def __init__(
         self,
         config: TransformerConfig,
-        architecture_config=None,
         pre_process: bool = True,
         post_process: bool = True,
         fp16_lm_cross_entropy: bool = False,
         parallel_output: bool = True,
+        *,
+        num_joint_layers: int | None = None,
+        num_single_layers: int | None = None,
+        in_channels: int | None = None,
+        context_dim: int | None = None,
+        model_channels: int | None = None,
+        axes_dims_rope: list[int] | tuple[int, ...] | None = None,
+        patch_size: int | None = None,
+        guidance_embed: bool | None = None,
+        vec_in_dim: int | None = None,
         **kwargs,
     ):
         super(Flux, self).__init__(config=config)
-        architecture_config = architecture_config or config
+
+        num_joint_layers = (
+            num_joint_layers if num_joint_layers is not None else getattr(config, "num_joint_layers", 19)
+        )
+        num_single_layers = (
+            num_single_layers if num_single_layers is not None else getattr(config, "num_single_layers", 38)
+        )
+        in_channels = in_channels if in_channels is not None else getattr(config, "in_channels", 64)
+        context_dim = context_dim if context_dim is not None else getattr(config, "context_dim", 4096)
+        model_channels = model_channels if model_channels is not None else getattr(config, "model_channels", 256)
+        axes_dims_rope = (
+            axes_dims_rope if axes_dims_rope is not None else getattr(config, "axes_dims_rope", [16, 56, 56])
+        )
+        patch_size = patch_size if patch_size is not None else getattr(config, "patch_size", 1)
+        guidance_embed = guidance_embed if guidance_embed is not None else getattr(config, "guidance_embed", False)
+        vec_in_dim = vec_in_dim if vec_in_dim is not None else getattr(config, "vec_in_dim", 768)
 
         self.config: TransformerConfig = config
         self.pre_process = pre_process
@@ -95,29 +119,27 @@ class Flux(VisionModule):
         # TODO: remove this dependency ?
         self.model_type = ModelType.encoder_or_decoder
 
-        self.out_channels = architecture_config.in_channels
+        self.out_channels = in_channels
         self.hidden_size = config.hidden_size
         self.num_attention_heads = config.num_attention_heads
-        self.patch_size = architecture_config.patch_size
-        self.in_channels = architecture_config.in_channels
-        self.guidance_embed = architecture_config.guidance_embed
+        self.patch_size = patch_size
+        self.in_channels = in_channels
+        self.guidance_embed = guidance_embed
 
         # Position embedding for rotary embeddings
-        self.pos_embed = EmbedND(dim=self.hidden_size, theta=10000, axes_dim=architecture_config.axes_dims_rope)
+        self.pos_embed = EmbedND(dim=self.hidden_size, theta=10000, axes_dim=axes_dims_rope)
 
         # Input embeddings
-        self.img_embed = nn.Linear(architecture_config.in_channels, self.hidden_size)
-        self.txt_embed = nn.Linear(architecture_config.context_dim, self.hidden_size)
+        self.img_embed = nn.Linear(in_channels, self.hidden_size)
+        self.txt_embed = nn.Linear(context_dim, self.hidden_size)
 
         # Timestep and conditioning embeddings
-        self.timestep_embedding = TimeStepEmbedder(architecture_config.model_channels, self.hidden_size)
-        self.vector_embedding = MLPEmbedder(in_dim=architecture_config.vec_in_dim, hidden_dim=self.hidden_size)
+        self.timestep_embedding = TimeStepEmbedder(model_channels, self.hidden_size)
+        self.vector_embedding = MLPEmbedder(in_dim=vec_in_dim, hidden_dim=self.hidden_size)
 
         # Optional guidance embedding (for FLUX-dev)
-        if architecture_config.guidance_embed:
-            self.guidance_embedding = MLPEmbedder(
-                in_dim=architecture_config.model_channels, hidden_dim=self.hidden_size
-            )
+        if guidance_embed:
+            self.guidance_embedding = MLPEmbedder(in_dim=model_channels, hidden_dim=self.hidden_size)
 
         # Double blocks (MMDiT-style joint attention)
         self.double_blocks = nn.ModuleList(
@@ -128,7 +150,7 @@ class Flux(VisionModule):
                     layer_number=i,
                     context_pre_only=False,
                 )
-                for i in range(architecture_config.num_joint_layers)
+                for i in range(num_joint_layers)
             ]
         )
 
@@ -140,7 +162,7 @@ class Flux(VisionModule):
                     submodules=get_flux_single_transformer_engine_spec().submodules,
                     layer_number=i,
                 )
-                for i in range(architecture_config.num_single_layers)
+                for i in range(num_single_layers)
             ]
         )
 

--- a/src/megatron/bridge/diffusion/models/flux/flux_model.py
+++ b/src/megatron/bridge/diffusion/models/flux/flux_model.py
@@ -75,6 +75,7 @@ class Flux(VisionModule):
     def __init__(
         self,
         config: TransformerConfig,
+        architecture_config=None,
         pre_process: bool = True,
         post_process: bool = True,
         fp16_lm_cross_entropy: bool = False,
@@ -82,6 +83,7 @@ class Flux(VisionModule):
         **kwargs,
     ):
         super(Flux, self).__init__(config=config)
+        architecture_config = architecture_config or config
 
         self.config: TransformerConfig = config
         self.pre_process = pre_process
@@ -93,27 +95,29 @@ class Flux(VisionModule):
         # TODO: remove this dependency ?
         self.model_type = ModelType.encoder_or_decoder
 
-        self.out_channels = config.in_channels
+        self.out_channels = architecture_config.in_channels
         self.hidden_size = config.hidden_size
         self.num_attention_heads = config.num_attention_heads
-        self.patch_size = config.patch_size
-        self.in_channels = config.in_channels
-        self.guidance_embed = config.guidance_embed
+        self.patch_size = architecture_config.patch_size
+        self.in_channels = architecture_config.in_channels
+        self.guidance_embed = architecture_config.guidance_embed
 
         # Position embedding for rotary embeddings
-        self.pos_embed = EmbedND(dim=self.hidden_size, theta=10000, axes_dim=config.axes_dims_rope)
+        self.pos_embed = EmbedND(dim=self.hidden_size, theta=10000, axes_dim=architecture_config.axes_dims_rope)
 
         # Input embeddings
-        self.img_embed = nn.Linear(config.in_channels, self.hidden_size)
-        self.txt_embed = nn.Linear(config.context_dim, self.hidden_size)
+        self.img_embed = nn.Linear(architecture_config.in_channels, self.hidden_size)
+        self.txt_embed = nn.Linear(architecture_config.context_dim, self.hidden_size)
 
         # Timestep and conditioning embeddings
-        self.timestep_embedding = TimeStepEmbedder(config.model_channels, self.hidden_size)
-        self.vector_embedding = MLPEmbedder(in_dim=config.vec_in_dim, hidden_dim=self.hidden_size)
+        self.timestep_embedding = TimeStepEmbedder(architecture_config.model_channels, self.hidden_size)
+        self.vector_embedding = MLPEmbedder(in_dim=architecture_config.vec_in_dim, hidden_dim=self.hidden_size)
 
         # Optional guidance embedding (for FLUX-dev)
-        if config.guidance_embed:
-            self.guidance_embedding = MLPEmbedder(in_dim=config.model_channels, hidden_dim=self.hidden_size)
+        if architecture_config.guidance_embed:
+            self.guidance_embedding = MLPEmbedder(
+                in_dim=architecture_config.model_channels, hidden_dim=self.hidden_size
+            )
 
         # Double blocks (MMDiT-style joint attention)
         self.double_blocks = nn.ModuleList(
@@ -124,7 +128,7 @@ class Flux(VisionModule):
                     layer_number=i,
                     context_pre_only=False,
                 )
-                for i in range(config.num_joint_layers)
+                for i in range(architecture_config.num_joint_layers)
             ]
         )
 
@@ -136,7 +140,7 @@ class Flux(VisionModule):
                     submodules=get_flux_single_transformer_engine_spec().submodules,
                     layer_number=i,
                 )
-                for i in range(config.num_single_layers)
+                for i in range(architecture_config.num_single_layers)
             ]
         )
 

--- a/src/megatron/bridge/diffusion/models/flux/model_config.py
+++ b/src/megatron/bridge/diffusion/models/flux/model_config.py
@@ -54,7 +54,15 @@ class FluxModelBuilder(GPTModelBuilder):
         """Build one FLUX model stage."""
         return Flux(
             config=self._model_config.transformer,
-            architecture_config=self._model_config,
+            num_joint_layers=self._model_config.num_joint_layers,
+            num_single_layers=self._model_config.num_single_layers,
+            in_channels=self._model_config.in_channels,
+            context_dim=self._model_config.context_dim,
+            model_channels=self._model_config.model_channels,
+            axes_dims_rope=self._model_config.axes_dims_rope,
+            patch_size=self._model_config.patch_size,
+            guidance_embed=self._model_config.guidance_embed,
+            vec_in_dim=self._model_config.vec_in_dim,
             pre_process=True if pre_process is None else pre_process,
             post_process=True if post_process is None else post_process,
         )

--- a/src/megatron/bridge/diffusion/models/flux/model_config.py
+++ b/src/megatron/bridge/diffusion/models/flux/model_config.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pure model configuration and standalone builder for FLUX."""
+
+from dataclasses import dataclass, field
+from typing import ClassVar
+
+from megatron.core.process_groups_config import ProcessGroupCollection
+from megatron.training.models.gpt import GPTModelBuilder
+
+from megatron.bridge.diffusion.models.flux.flux_model import Flux
+from megatron.bridge.models.gpt.model_config import BridgeGPTModelConfig
+
+
+@dataclass(kw_only=True)
+class FluxModelConfig(BridgeGPTModelConfig):
+    """Serializable FLUX architecture and exact MCore transformer settings."""
+
+    builder: ClassVar[str] = "megatron.bridge.diffusion.models.flux.model_config.FluxModelBuilder"
+    num_joint_layers: int = 19
+    num_single_layers: int = 38
+    in_channels: int = 64
+    context_dim: int = 4096
+    model_channels: int = 256
+    axes_dims_rope: list[int] = field(default_factory=lambda: [16, 56, 56])
+    patch_size: int = 1
+    guidance_embed: bool = False
+    vec_in_dim: int = 768
+    guidance_scale: float = 3.5
+
+
+class FluxModelBuilder(GPTModelBuilder):
+    """Build FLUX stages without a model provider."""
+
+    def build_model(
+        self,
+        pg_collection: ProcessGroupCollection,
+        pre_process: bool | None = None,
+        post_process: bool | None = None,
+        vp_stage: int | None = None,
+    ) -> Flux:
+        """Build one FLUX model stage."""
+        return Flux(
+            config=self._model_config.transformer,
+            architecture_config=self._model_config,
+            pre_process=True if pre_process is None else pre_process,
+            post_process=True if post_process is None else post_process,
+        )
+
+
+__all__ = ["FluxModelBuilder", "FluxModelConfig"]

--- a/src/megatron/bridge/diffusion/models/llada15/__init__.py
+++ b/src/megatron/bridge/diffusion/models/llada15/__init__.py
@@ -14,7 +14,15 @@
 
 from megatron.bridge.diffusion.models.llada15.inference_llada15 import generate_block_diffusion
 from megatron.bridge.diffusion.models.llada15.llada15_attention import LLaDA15TEDotProductAttention
-from megatron.bridge.diffusion.models.llada15.llada15_provider import LLaDA15ModelProvider
+
+
+def __getattr__(name: str):
+    """Lazily resolve the legacy LLaDA1.5 provider export."""
+    if name == "LLaDA15ModelProvider":
+        from megatron.bridge.diffusion.models.llada15.llada15_provider import LLaDA15ModelProvider
+
+        return LLaDA15ModelProvider
+    raise AttributeError(name)
 
 
 __all__ = [

--- a/src/megatron/bridge/diffusion/models/llada15/model_config.py
+++ b/src/megatron/bridge/diffusion/models/llada15/model_config.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Provider-neutral builder configuration for LLaDA1.5."""
+
+from dataclasses import dataclass, field
+from typing import Callable
+
+from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_with_transformer_engine_spec
+from megatron.core.transformer import ModuleSpec
+
+from megatron.bridge.diffusion.models.llada15.llada15_attention import LLaDA15TEDotProductAttention
+from megatron.bridge.models.gpt.model_config import BridgeGPTModelConfig
+
+
+def llada15_layer_spec(config: BridgeGPTModelConfig) -> ModuleSpec:
+    """Build the bidirectional LLaDA1.5 Transformer Engine layer spec."""
+    transformer = config.transformer
+    spec = get_gpt_layer_with_transformer_engine_spec(
+        transformer.num_moe_experts,
+        transformer.moe_grouped_gemm,
+        transformer.qk_layernorm,
+        transformer.multi_latent_attention,
+    )
+    spec.submodules.self_attention.submodules.core_attention = LLaDA15TEDotProductAttention
+    return spec
+
+
+@dataclass(kw_only=True)
+class LLaDA15ModelConfig(BridgeGPTModelConfig):
+    """Serializable LLaDA1.5 GPT model configuration."""
+
+    transformer_layer_spec: Callable[..., ModuleSpec] = field(default_factory=lambda: llada15_layer_spec)
+
+
+__all__ = ["LLaDA15ModelConfig", "llada15_layer_spec"]

--- a/src/megatron/bridge/diffusion/models/nemotron_labs_diffusion/__init__.py
+++ b/src/megatron/bridge/diffusion/models/nemotron_labs_diffusion/__init__.py
@@ -12,9 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from megatron.bridge.diffusion.models.nemotron_labs_diffusion.nemotron_labs_diffusion_provider import (
-    NemotronLabsDiffusionModelProvider,
-)
+
+def __getattr__(name: str):
+    """Lazily resolve the legacy Nemotron Labs Diffusion provider export."""
+    if name == "NemotronLabsDiffusionModelProvider":
+        from megatron.bridge.diffusion.models.nemotron_labs_diffusion.nemotron_labs_diffusion_provider import (
+            NemotronLabsDiffusionModelProvider,
+        )
+
+        return NemotronLabsDiffusionModelProvider
+    raise AttributeError(name)
 
 
 __all__ = ["NemotronLabsDiffusionModelProvider"]

--- a/src/megatron/bridge/diffusion/models/nemotron_labs_diffusion/model_config.py
+++ b/src/megatron/bridge/diffusion/models/nemotron_labs_diffusion/model_config.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Provider-neutral model configuration for Nemotron Labs Diffusion."""
+
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+from typing import Any, Callable
+
+from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_with_transformer_engine_spec
+from megatron.core.transformer import ModuleSpec
+
+from megatron.bridge.diffusion.models.common.nemotron_labs_diffusion_attention import NemotronLabsDiffusionAttention
+from megatron.bridge.models.gpt.model_config import BridgeGPTModelConfig
+
+
+def _namespace(data: Any) -> Any:
+    if isinstance(data, dict):
+        values = dict(data)
+        text_config = values.get("text_config")
+        if isinstance(text_config, dict):
+            values["text_config"] = SimpleNamespace(**text_config)
+        return SimpleNamespace(**values)
+    return data
+
+
+def nemotron_labs_diffusion_layer_spec(config: "NemotronLabsDiffusionModelConfig") -> ModuleSpec:
+    """Build a GPT layer spec with semi-block-diffusion core attention."""
+    transformer = config.transformer
+    spec = get_gpt_layer_with_transformer_engine_spec(
+        transformer.num_moe_experts,
+        transformer.moe_grouped_gemm,
+        transformer.qk_layernorm,
+        transformer.multi_latent_attention,
+    )
+    spec.submodules.self_attention.submodules.core_attention = ModuleSpec(
+        module=NemotronLabsDiffusionAttention,
+        params={
+            "hf_config": _namespace(config.hf_config),
+            "block_size": config.block_size,
+            "apply_llama4_style_query_key_layer_scaling": config.apply_llama4_style_query_key_layer_scaling,
+        },
+    )
+    return spec
+
+
+@dataclass(kw_only=True)
+class NemotronLabsDiffusionModelConfig(BridgeGPTModelConfig):
+    """Serializable GPT build config for Nemotron Labs Diffusion."""
+
+    transformer_layer_spec: Callable[..., ModuleSpec] = field(
+        default_factory=lambda: nemotron_labs_diffusion_layer_spec
+    )
+    hf_config: dict[str, Any] = field(default_factory=dict)
+    mask_token_id: int = 100
+    dlm_paradigm: str = "sbd_block_diff"
+    block_size: int = 64
+    different_seed_per_dp: bool = True
+    apply_llama4_style_query_key_layer_scaling: bool = True
+    dlm_loss_weight: float = 0.3
+    ar_loss_weight: float = 1.0
+
+
+__all__ = ["NemotronLabsDiffusionModelConfig", "nemotron_labs_diffusion_layer_spec"]

--- a/src/megatron/bridge/diffusion/models/wan/flow_matching/flow_inference_pipeline.py
+++ b/src/megatron/bridge/diffusion/models/wan/flow_matching/flow_inference_pipeline.py
@@ -142,7 +142,7 @@ class FlowInferencePipeline:  # noqa: D101
         self.model = self.setup_model_from_checkpoint(wan_checkpoint_dir)
 
         # if we use context parallelism, we need to set qkv_format to "thd" for context parallelism
-        self.model.config.qkv_format = "thd"  # "sbhd"
+        self.model.qkv_format = "thd"  # "sbhd"
 
         # set self.sp_size=1 for later use, just to respect the original Wan inference code
         self.sp_size = 1
@@ -441,19 +441,20 @@ class FlowInferencePipeline:  # noqa: D101
             cu_kv_self = cu_q
             cu_kv_cross = torch.cat([torch.tensor([0]), torch.cumsum(torch.tensor(context_lens), dim=0)])
             cu_kv_cross = cu_kv_cross.to(torch.int32).to(self.device)
+            qkv_format = getattr(self.model, "qkv_format", "thd")
             packed_seq_params = {
                 "self_attention": PackedSeqParams(
                     cu_seqlens_q=cu_q,
                     cu_seqlens_q_padded=cu_q,
                     cu_seqlens_kv=cu_kv_self,
                     cu_seqlens_kv_padded=cu_kv_self,
-                    qkv_format=self.model.config.qkv_format,
+                    qkv_format=qkv_format,
                 ),
                 "cross_attention": PackedSeqParams(
                     cu_seqlens_q=cu_q,
                     cu_seqlens_q_padded=cu_q,
                     cu_seqlens_kv=cu_kv_cross,
-                    qkv_format=self.model.config.qkv_format,
+                    qkv_format=qkv_format,
                 ),
             }
 

--- a/src/megatron/bridge/diffusion/models/wan/model_config.py
+++ b/src/megatron/bridge/diffusion/models/wan/model_config.py
@@ -38,6 +38,8 @@ class WanModelConfig(BridgeGPTModelConfig):
     freq_dim: int = 256
     text_len: int = 512
     text_dim: int = 4096
+    layernorm_across_heads: bool = True
+    qkv_format: str = "thd"
 
 
 class WanModelBuilder(GPTModelBuilder):
@@ -57,7 +59,15 @@ class WanModelBuilder(GPTModelBuilder):
             post_process = parallel_state.is_pipeline_last_stage()
         return WanModel(
             self._model_config.transformer,
-            architecture_config=self._model_config,
+            crossattn_emb_size=self._model_config.crossattn_emb_size,
+            in_channels=self._model_config.in_channels,
+            out_channels=self._model_config.out_channels,
+            patch_spatial=self._model_config.patch_spatial,
+            patch_temporal=self._model_config.patch_temporal,
+            freq_dim=self._model_config.freq_dim,
+            text_dim=self._model_config.text_dim,
+            layernorm_across_heads=self._model_config.layernorm_across_heads,
+            qkv_format=self._model_config.qkv_format,
             pre_process=pre_process,
             post_process=post_process,
             fp16_lm_cross_entropy=self._model_config.fp16_lm_cross_entropy,

--- a/src/megatron/bridge/diffusion/models/wan/model_config.py
+++ b/src/megatron/bridge/diffusion/models/wan/model_config.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pure model configuration and standalone builder for Wan diffusion."""
+
+from dataclasses import dataclass
+from typing import ClassVar
+
+from megatron.core import parallel_state
+from megatron.core.process_groups_config import ProcessGroupCollection
+from megatron.training.models.gpt import GPTModelBuilder
+
+from megatron.bridge.diffusion.models.wan.wan_model import WanModel
+from megatron.bridge.models.gpt.model_config import BridgeGPTModelConfig
+
+
+@dataclass(kw_only=True)
+class WanModelConfig(BridgeGPTModelConfig):
+    """Serializable Wan architecture and exact MCore transformer settings."""
+
+    builder: ClassVar[str] = "megatron.bridge.diffusion.models.wan.model_config.WanModelBuilder"
+    crossattn_emb_size: int = 1536
+    in_channels: int = 16
+    out_channels: int = 16
+    patch_spatial: int = 2
+    patch_temporal: int = 1
+    freq_dim: int = 256
+    text_len: int = 512
+    text_dim: int = 4096
+
+
+class WanModelBuilder(GPTModelBuilder):
+    """Build Wan stages without a model provider."""
+
+    def build_model(
+        self,
+        pg_collection: ProcessGroupCollection,
+        pre_process: bool | None = None,
+        post_process: bool | None = None,
+        vp_stage: int | None = None,
+    ) -> WanModel:
+        """Build one Wan pipeline stage."""
+        if pre_process is None:
+            pre_process = parallel_state.is_pipeline_first_stage()
+        if post_process is None:
+            post_process = parallel_state.is_pipeline_last_stage()
+        return WanModel(
+            self._model_config.transformer,
+            architecture_config=self._model_config,
+            pre_process=pre_process,
+            post_process=post_process,
+            fp16_lm_cross_entropy=self._model_config.fp16_lm_cross_entropy,
+            parallel_output=self._model_config.parallel_output,
+        )
+
+
+__all__ = ["WanModelBuilder", "WanModelConfig"]

--- a/src/megatron/bridge/diffusion/models/wan/wan_layer_spec.py
+++ b/src/megatron/bridge/diffusion/models/wan/wan_layer_spec.py
@@ -273,8 +273,9 @@ class WanLayerWithAdaLN(TransformerLayer):
         return output, context
 
 
-def get_wan_block_with_transformer_engine_spec() -> ModuleSpec:  # noqa: D103
+def get_wan_block_with_transformer_engine_spec(*, layernorm_across_heads: bool = False) -> ModuleSpec:  # noqa: D103
     params = {"attn_mask_type": AttnMaskType.padding}
+    attention_params = {**params, "layernorm_across_heads": layernorm_across_heads}
     return ModuleSpec(
         module=WanLayerWithAdaLN,
         submodules=WanWithAdaLNSubmodules(
@@ -283,7 +284,7 @@ def get_wan_block_with_transformer_engine_spec() -> ModuleSpec:  # noqa: D103
             norm2=nn.LayerNorm,
             full_self_attention=ModuleSpec(
                 module=DiTSelfAttention,
-                params=params,
+                params=attention_params,
                 submodules=SelfAttentionSubmodules(
                     linear_qkv=TEColumnParallelLinear,
                     core_attention=TEDotProductAttention,
@@ -294,7 +295,7 @@ def get_wan_block_with_transformer_engine_spec() -> ModuleSpec:  # noqa: D103
             ),
             cross_attention=ModuleSpec(
                 module=DiTCrossAttention,
-                params=params,
+                params=attention_params,
                 submodules=DiTCrossAttentionSubmodules(
                     linear_q=TEColumnParallelLinear,
                     linear_kv=TEColumnParallelLinear,

--- a/src/megatron/bridge/diffusion/models/wan/wan_model.py
+++ b/src/megatron/bridge/diffusion/models/wan/wan_model.py
@@ -93,6 +93,7 @@ class WanModel(VisionModule):
     def __init__(
         self,
         config: TransformerConfig,
+        architecture_config=None,
         pre_process: bool = True,
         post_process: bool = True,
         fp16_lm_cross_entropy: bool = False,
@@ -101,6 +102,7 @@ class WanModel(VisionModule):
         **kwargs,
     ):
         super(WanModel, self).__init__(config=config)
+        self.architecture_config = architecture_config or config
 
         self.config: TransformerConfig = config
 
@@ -115,11 +117,11 @@ class WanModel(VisionModule):
         self.model_type = ModelType.encoder_or_decoder
 
         self.num_heads = self.config.num_attention_heads
-        self.freq_dim = self.config.freq_dim
-        self.in_channels = self.config.in_channels
-        self.out_channels = self.config.out_channels
-        self.patch_spatial = self.config.patch_spatial
-        self.patch_temporal = self.config.patch_temporal
+        self.freq_dim = self.architecture_config.freq_dim
+        self.in_channels = self.architecture_config.in_channels
+        self.out_channels = self.architecture_config.out_channels
+        self.patch_spatial = self.architecture_config.patch_spatial
+        self.patch_temporal = self.architecture_config.patch_temporal
         self.patch_size = (self.patch_temporal, self.patch_spatial, self.patch_spatial)
 
         # these attributes are unused for images/videos, we just set because bridge training requires for LLMs
@@ -135,9 +137,9 @@ class WanModel(VisionModule):
             )
 
         self.text_embedding = nn.Sequential(
-            nn.Linear(self.config.text_dim, self.config.crossattn_emb_size),
+            nn.Linear(self.architecture_config.text_dim, self.architecture_config.crossattn_emb_size),
             nn.GELU(approximate="tanh"),
-            nn.Linear(self.config.crossattn_emb_size, self.config.crossattn_emb_size),
+            nn.Linear(self.architecture_config.crossattn_emb_size, self.architecture_config.crossattn_emb_size),
         )
 
         # As in diffuser's Wan implementation

--- a/src/megatron/bridge/diffusion/models/wan/wan_model.py
+++ b/src/megatron/bridge/diffusion/models/wan/wan_model.py
@@ -38,6 +38,13 @@ from megatron.bridge.diffusion.models.wan.wan_layer_spec import (
 from .rope_utils import Wan3DRopeEmbeddings
 
 
+def _build_wan_layer_spec(factory, *, layernorm_across_heads: bool):
+    """Build the default Wan spec while preserving zero-argument custom factories."""
+    if factory is WanLayerWithAdaLNspec:
+        return factory(layernorm_across_heads=layernorm_across_heads)
+    return factory()
+
+
 def sinusoidal_embedding_1d(dim, position):  # noqa: D103
     # preprocess
     assert dim % 2 == 0
@@ -93,20 +100,47 @@ class WanModel(VisionModule):
     def __init__(
         self,
         config: TransformerConfig,
-        architecture_config=None,
         pre_process: bool = True,
         post_process: bool = True,
         fp16_lm_cross_entropy: bool = False,
         parallel_output: bool = True,
         transformer_decoder_layer_spec=WanLayerWithAdaLNspec,
+        *,
+        crossattn_emb_size: int | None = None,
+        in_channels: int | None = None,
+        out_channels: int | None = None,
+        patch_spatial: int | None = None,
+        patch_temporal: int | None = None,
+        freq_dim: int | None = None,
+        text_dim: int | None = None,
+        layernorm_across_heads: bool | None = None,
+        qkv_format: str | None = None,
         **kwargs,
     ):
         super(WanModel, self).__init__(config=config)
-        self.architecture_config = architecture_config or config
+
+        crossattn_emb_size = (
+            crossattn_emb_size if crossattn_emb_size is not None else getattr(config, "crossattn_emb_size", 1536)
+        )
+        in_channels = in_channels if in_channels is not None else getattr(config, "in_channels", 16)
+        out_channels = out_channels if out_channels is not None else getattr(config, "out_channels", 16)
+        patch_spatial = patch_spatial if patch_spatial is not None else getattr(config, "patch_spatial", 2)
+        patch_temporal = patch_temporal if patch_temporal is not None else getattr(config, "patch_temporal", 1)
+        freq_dim = freq_dim if freq_dim is not None else getattr(config, "freq_dim", 256)
+        text_dim = text_dim if text_dim is not None else getattr(config, "text_dim", 4096)
+        layernorm_across_heads = (
+            layernorm_across_heads
+            if layernorm_across_heads is not None
+            else getattr(config, "layernorm_across_heads", True)
+        )
+        qkv_format = qkv_format if qkv_format is not None else getattr(config, "qkv_format", "thd")
 
         self.config: TransformerConfig = config
 
-        self.transformer_decoder_layer_spec = transformer_decoder_layer_spec()
+        self.transformer_decoder_layer_spec = _build_wan_layer_spec(
+            transformer_decoder_layer_spec,
+            layernorm_across_heads=layernorm_across_heads,
+        )
         self.pre_process = pre_process
         self.post_process = post_process
         self.fp16_lm_cross_entropy = fp16_lm_cross_entropy
@@ -117,12 +151,13 @@ class WanModel(VisionModule):
         self.model_type = ModelType.encoder_or_decoder
 
         self.num_heads = self.config.num_attention_heads
-        self.freq_dim = self.architecture_config.freq_dim
-        self.in_channels = self.architecture_config.in_channels
-        self.out_channels = self.architecture_config.out_channels
-        self.patch_spatial = self.architecture_config.patch_spatial
-        self.patch_temporal = self.architecture_config.patch_temporal
+        self.freq_dim = freq_dim
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.patch_spatial = patch_spatial
+        self.patch_temporal = patch_temporal
         self.patch_size = (self.patch_temporal, self.patch_spatial, self.patch_spatial)
+        self.qkv_format = qkv_format
 
         # these attributes are unused for images/videos, we just set because bridge training requires for LLMs
         self.share_embeddings_and_output_weights = False
@@ -137,9 +172,9 @@ class WanModel(VisionModule):
             )
 
         self.text_embedding = nn.Sequential(
-            nn.Linear(self.architecture_config.text_dim, self.architecture_config.crossattn_emb_size),
+            nn.Linear(text_dim, crossattn_emb_size),
             nn.GELU(approximate="tanh"),
-            nn.Linear(self.architecture_config.crossattn_emb_size, self.architecture_config.crossattn_emb_size),
+            nn.Linear(crossattn_emb_size, crossattn_emb_size),
         )
 
         # As in diffuser's Wan implementation

--- a/src/megatron/bridge/diffusion/models/wan/wan_step.py
+++ b/src/megatron/bridge/diffusion/models/wan/wan_step.py
@@ -20,7 +20,7 @@ from typing import Iterable
 import torch
 from megatron.core.models.common.vision_module.vision_module import VisionModule
 from megatron.core.packed_seq_params import PackedSeqParams
-from megatron.core.utils import get_model_config
+from megatron.core.utils import get_model_config, unwrap_model
 
 from megatron.bridge.diffusion.models.wan.flow_matching.flow_matching_pipeline_wan import (
     WanAdapter,
@@ -31,6 +31,17 @@ from megatron.bridge.training.state import GlobalState
 
 
 logger = logging.getLogger(__name__)
+
+
+def _get_qkv_format(model: VisionModule) -> str:
+    """Read the Wan sequence layout from the unwrapped runtime model."""
+    runtime_model = unwrap_model(model)
+    if isinstance(runtime_model, list):
+        if len(runtime_model) != 1:
+            raise ValueError(f"Wan expects one model chunk, got {len(runtime_model)}.")
+        runtime_model = runtime_model[0]
+    config = get_model_config(runtime_model)
+    return getattr(runtime_model, "qkv_format", getattr(config, "qkv_format", "sbhd"))
 
 
 def wan_data_step(qkv_format, dataloader_iter):  # noqa: D103
@@ -140,11 +151,9 @@ class WanForwardStep:  # noqa: D101
         timers = state.timers
         straggler_timer = state.straggler_timer
 
-        config = get_model_config(model)
-
         timers("batch-generator", log_level=2).start()
 
-        qkv_format = getattr(config, "qkv_format", "sbhd")
+        qkv_format = _get_qkv_format(model)
         with straggler_timer(bdata=True):
             batch = wan_data_step(qkv_format, data_iterator)
         timers("batch-generator").stop()

--- a/src/megatron/bridge/diffusion/recipes/flux/flux.py
+++ b/src/megatron/bridge/diffusion/recipes/flux/flux.py
@@ -52,7 +52,7 @@ def flux_12b_pretrain_config() -> ConfigContainer:
 
     # TODO: Add AutoBridge support for diffusion models
     hf = PreTrainedFlux("black-forest-labs/FLUX.1-dev")
-    model_cfg = FluxBridge().provider_bridge(hf)
+    model_cfg = FluxBridge().model_config_bridge(hf)
     model_cfg.tensor_model_parallel_size = 2
     model_cfg.pipeline_model_parallel_size = 1
     model_cfg.pipeline_dtype = torch.bfloat16

--- a/src/megatron/bridge/diffusion/recipes/nemotron_labs_diffusion/ar_to_dlm.py
+++ b/src/megatron/bridge/diffusion/recipes/nemotron_labs_diffusion/ar_to_dlm.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import os
 from functools import partial
 from typing import Optional
@@ -22,8 +23,8 @@ from megatron.core.distributed import DistributedDataParallelConfig
 from megatron.bridge.diffusion.conversion.nemotron_labs_diffusion.nemotron_labs_diffusion_bridge import (
     NemotronLabsDiffusionBridge,
 )
-from megatron.bridge.diffusion.models.nemotron_labs_diffusion.nemotron_labs_diffusion_provider import (
-    NemotronLabsDiffusionModelProvider,
+from megatron.bridge.diffusion.models.nemotron_labs_diffusion.model_config import (
+    NemotronLabsDiffusionModelConfig,
 )
 from megatron.bridge.models.hf_pretrained.causal_lm import PreTrainedCausalLM
 from megatron.bridge.recipes.utils.dataset_utils import get_blend_fields_from_data_paths
@@ -41,6 +42,24 @@ from megatron.bridge.training.config import (
     TrainingConfig,
 )
 from megatron.bridge.training.mixed_precision import MixedPrecisionConfig
+
+
+def _apply_model_overrides(defaults: dict, user_kwargs: dict) -> dict:
+    """Apply model selection overrides to a model-size recipe.
+
+    A supplied ``model_config`` replaces the recipe's implicit HF source. An
+    explicitly non-null ``hf_path`` is mutually exclusive with it.
+    """
+    overrides = dict(user_kwargs)
+    if overrides.get("model_config") is not None:
+        if overrides.get("hf_path") is not None:
+            raise ValueError("model_config and hf_path are mutually exclusive.")
+        defaults["hf_path"] = None
+        overrides.pop("hf_path", None)
+    elif overrides.get("hf_path") is None:
+        overrides.pop("hf_path", None)
+    defaults.update(overrides)
+    return defaults
 
 
 def nemotron_labs_diffusion_pretrain_config(**user_kwargs) -> ConfigContainer:
@@ -67,9 +86,9 @@ def nemotron_labs_diffusion_3b_pretrain_config(**user_kwargs) -> ConfigContainer
         eval_interval=5000,
         save_interval=5000,
         tokenizer_model="mistralai/Ministral-3-3B-Base-2512",
+        hf_path="mistralai/Ministral-3-3B-Base-2512",
     )
-    defaults.update(user_kwargs)
-    return _nemotron_labs_diffusion_common(**defaults)
+    return _nemotron_labs_diffusion_common(**_apply_model_overrides(defaults, user_kwargs))
 
 
 def nemotron_labs_diffusion_8b_pretrain_config(**user_kwargs) -> ConfigContainer:
@@ -87,9 +106,9 @@ def nemotron_labs_diffusion_8b_pretrain_config(**user_kwargs) -> ConfigContainer
         eval_interval=5000,
         save_interval=5000,
         tokenizer_model="mistralai/Ministral-3-8B-Base-2512",
+        hf_path="mistralai/Ministral-3-8B-Base-2512",
     )
-    defaults.update(user_kwargs)
-    return _nemotron_labs_diffusion_common(**defaults)
+    return _nemotron_labs_diffusion_common(**_apply_model_overrides(defaults, user_kwargs))
 
 
 def nemotron_labs_diffusion_14b_pretrain_config(**user_kwargs) -> ConfigContainer:
@@ -107,13 +126,13 @@ def nemotron_labs_diffusion_14b_pretrain_config(**user_kwargs) -> ConfigContaine
         eval_interval=5000,
         save_interval=5000,
         tokenizer_model="mistralai/Ministral-3-14B-Base-2512",
+        hf_path="mistralai/Ministral-3-14B-Base-2512",
     )
-    defaults.update(user_kwargs)
-    return _nemotron_labs_diffusion_common(**defaults)
+    return _nemotron_labs_diffusion_common(**_apply_model_overrides(defaults, user_kwargs))
 
 
 def _nemotron_labs_diffusion_common(
-    model_provider: NemotronLabsDiffusionModelProvider | None = None,
+    model_config: NemotronLabsDiffusionModelConfig | None = None,
     hf_path: str | None = None,
     dir: str | None = None,
     name: str = "default",
@@ -155,11 +174,12 @@ def _nemotron_labs_diffusion_common(
     comm_overlap_config: CommOverlapConfig | None = None,
 ) -> ConfigContainer:
     """
-    Create a pre-training configuration for NemotronLabsDiffusion models using a given model provider.
+    Create a pre-training configuration for NemotronLabsDiffusion models using a builder-backed config.
 
     Args:
         hf_path (Optional[str]): HuggingFace model path (e.g., "Qwen/Qwen3-1.7B").
-        model_provider (NemotronLabsDiffusionModelProvider): Model provider for the model.
+        model_config: Optional pre-built serializable model config. Required when
+            ``hf_path`` is not provided.
         dir (Optional[str]): Base directory for saving logs and checkpoints.
         name (str): Name of the pre-training run.
         data_paths (Optional[List[str]]): List of paths to dataset files. If None, mock data will be used.
@@ -203,16 +223,20 @@ def _nemotron_labs_diffusion_common(
     blend, blend_per_split, split = get_blend_fields_from_data_paths(
         data_paths, data_args_path, train_data_path, valid_data_path, test_data_path, per_split_data_args_path, mock
     )
+    if hf_path is not None and model_config is not None:
+        raise ValueError("model_config and hf_path are mutually exclusive.")
     if hf_path is not None:
         hf_pretrained = PreTrainedCausalLM.from_pretrained(hf_path)
         bridge = NemotronLabsDiffusionBridge()
-        model_cfg = bridge.provider_bridge(hf_pretrained)
+        model_cfg = bridge.model_config_bridge(hf_pretrained)
         model_cfg.share_embeddings_and_output_weights = False  # dLLM needs separate diffusion_head
         model_cfg.perform_initialization = False
         if load_hf_checkpoint:
-            model_cfg.register_pre_wrap_hook(partial(bridge.load_weights_hf_to_megatron, hf_pretrained))
+            model_cfg.pre_wrap_hooks.append(partial(bridge.load_weights_hf_to_megatron, hf_pretrained))
+    elif model_config is not None:
+        model_cfg = copy.deepcopy(model_config)
     else:
-        model_cfg = model_provider()
+        raise ValueError("Either hf_path or model_config must be provided for NemotronLabsDiffusion pretraining.")
 
     model_cfg.tensor_model_parallel_size = tensor_parallelism
     model_cfg.pipeline_model_parallel_size = pipeline_parallelism

--- a/src/megatron/bridge/diffusion/recipes/nemotron_labs_diffusion/continuous_pretraining.py
+++ b/src/megatron/bridge/diffusion/recipes/nemotron_labs_diffusion/continuous_pretraining.py
@@ -18,7 +18,6 @@ from megatron.bridge.diffusion.conversion.nemotron_labs_diffusion.nemotron_labs_
     NemotronLabsDiffusionBridge,
 )
 from megatron.bridge.models.hf_pretrained.causal_lm import PreTrainedCausalLM
-from megatron.bridge.models.ministral3.ministral3_provider import Ministral3ModelProvider
 from megatron.bridge.recipes.common import _pretrain_common
 from megatron.bridge.recipes.utils.dataset_utils import get_blend_fields_from_data_paths
 from megatron.bridge.recipes.utils.optimizer_utils import distributed_fused_adam_with_cosine_annealing
@@ -49,19 +48,13 @@ def _nemotron_labs_diffusion_cpt_config(
     # which strips the vision encoder from VLM checkpoints.
     hf_pretrained = PreTrainedCausalLM.from_pretrained(hf_path)
     bridge = NemotronLabsDiffusionBridge()
-    provider = bridge.provider_bridge(hf_pretrained)
-    # For CPT, use standard attention (not NemotronLabsDiffusionAttention) by calling
-    # the grandparent's provide method which creates a plain GPTModel
-    provider.provide = (
-        lambda pre_process=None, post_process=None, vp_stage=None: Ministral3ModelProvider.provide_language_model(
-            provider, pre_process, post_process, vp_stage
-        )
-    )
-    cfg.model = provider
+    cfg.model = bridge.model_config_bridge(hf_pretrained)
+    # For CPT, use the stock GPT builder layer spec rather than diffusion attention.
+    cfg.model.transformer_layer_spec = None
     cfg.model.perform_initialization = False
-    cfg.model.register_pre_wrap_hook(partial(bridge.load_weights_hf_to_megatron, hf_pretrained))
+    cfg.model.pre_wrap_hooks.append(partial(bridge.load_weights_hf_to_megatron, hf_pretrained))
     cfg.model.share_embeddings_and_output_weights = False  # dLLM needs separate diffusion_head
-    cfg.model.register_pre_wrap_hook(_copy_embedding_to_output_layer)
+    cfg.model.pre_wrap_hooks.append(_copy_embedding_to_output_layer)
     cfg.model.seq_length = 4096
 
     # Parallel settings

--- a/src/megatron/bridge/utils/activation_map.py
+++ b/src/megatron/bridge/utils/activation_map.py
@@ -25,6 +25,7 @@ from typing import Callable
 import torch
 import torch.nn.functional as F
 from megatron.core.activations import fast_gelu, squared_relu
+from megatron.core.transformer.utils import openai_gelu
 
 
 try:
@@ -48,6 +49,7 @@ ACTIVATION_FUNC_MAP: dict[str, Callable] = {
     "squared_relu": squared_relu,
     "gelu_pytorch_tanh": fast_gelu,  # alias; canonical is fast_gelu (below)
     "fast_gelu": fast_gelu,
+    "openai_gelu": openai_gelu,
     "quick_gelu": quick_gelu,
 }
 

--- a/tests/functional_tests/test_groups/models/llada15/test_llada15_generate.py
+++ b/tests/functional_tests/test_groups/models/llada15/test_llada15_generate.py
@@ -32,6 +32,7 @@ import torch.nn.functional as F
 from megatron.core import parallel_state
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+from megatron.core.transformer import TransformerConfig
 
 from megatron.bridge.diffusion.models.llada15.inference_llada15 import _unwrap, generate_block_diffusion
 from megatron.bridge.diffusion.models.llada15.llada15_attention import LLaDA15TEDotProductAttention
@@ -73,14 +74,13 @@ def _init_distributed():
 
 def _build_toy_model():
     vocab_size = TOY["vocab_size"]
-    config = LLaDA15ModelConfig(
+    transformer = TransformerConfig(
         normalization="RMSNorm",
         gated_linear_unit=True,
         activation_func=F.silu,
         add_bias_linear=False,
         add_qkv_bias=False,
         qk_layernorm=False,
-        rotary_base=500000.0,
         bf16=True,
         params_dtype=torch.bfloat16,
         num_layers=TOY["num_layers"],
@@ -91,6 +91,10 @@ def _build_toy_model():
         ffn_hidden_size=TOY["ffn_hidden_size"],
         tensor_model_parallel_size=1,
         pipeline_model_parallel_size=1,
+    )
+    config = LLaDA15ModelConfig(
+        transformer=transformer,
+        rotary_base=500000.0,
         vocab_size=vocab_size,
         seq_length=TOY["seq_length"],
     )

--- a/tests/functional_tests/test_groups/models/llada15/test_llada15_generate.py
+++ b/tests/functional_tests/test_groups/models/llada15/test_llada15_generate.py
@@ -32,7 +32,6 @@ import torch.nn.functional as F
 from megatron.core import parallel_state
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
-from megatron.core.transformer import TransformerConfig
 
 from megatron.bridge.diffusion.models.llada15.inference_llada15 import _unwrap, generate_block_diffusion
 from megatron.bridge.diffusion.models.llada15.llada15_attention import LLaDA15TEDotProductAttention
@@ -74,7 +73,7 @@ def _init_distributed():
 
 def _build_toy_model():
     vocab_size = TOY["vocab_size"]
-    transformer = TransformerConfig(
+    config = LLaDA15ModelConfig(
         normalization="RMSNorm",
         gated_linear_unit=True,
         activation_func=F.silu,
@@ -92,9 +91,6 @@ def _build_toy_model():
         ffn_hidden_size=TOY["ffn_hidden_size"],
         tensor_model_parallel_size=1,
         pipeline_model_parallel_size=1,
-    )
-    config = LLaDA15ModelConfig(
-        transformer=transformer,
         vocab_size=vocab_size,
         seq_length=TOY["seq_length"],
     )
@@ -116,7 +112,7 @@ class TestLLaDA15ToyGenerate:
         _init_distributed()
         model = _build_toy_model()
         # Every layer's core attention must be the TE-backed LLaDA1.5 attention.
-        # _unwrap drops the Float16Module/DDP wrapper added by provide_distributed_model.
+        # _unwrap drops any mixed-precision or distributed wrapper added by the builder.
         for layer in _unwrap(model).decoder.layers:
             assert isinstance(layer.self_attention.core_attention, LLaDA15TEDotProductAttention)
 

--- a/tests/functional_tests/test_groups/models/llada15/test_llada15_generate.py
+++ b/tests/functional_tests/test_groups/models/llada15/test_llada15_generate.py
@@ -21,7 +21,7 @@ initialized** LLaDA1.5 Megatron model on GPU and exercises the *real*
 ``generate_block_diffusion`` loop end-to-end.
 
 No checkpoint and no HuggingFace download — the model is constructed directly
-from a toy ``LLaDA15ModelProvider`` config with random weights. Single GPU.
+from a toy ``LLaDA15ModelConfig`` with random weights. Single GPU.
 """
 
 import os
@@ -30,11 +30,13 @@ import pytest
 import torch
 import torch.nn.functional as F
 from megatron.core import parallel_state
+from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+from megatron.core.transformer import TransformerConfig
 
 from megatron.bridge.diffusion.models.llada15.inference_llada15 import _unwrap, generate_block_diffusion
 from megatron.bridge.diffusion.models.llada15.llada15_attention import LLaDA15TEDotProductAttention
-from megatron.bridge.diffusion.models.llada15.llada15_provider import LLaDA15ModelProvider
+from megatron.bridge.diffusion.models.llada15.model_config import LLaDA15ModelConfig
 
 
 # Tiny toy dims — small enough to build and run quickly on a single GPU.
@@ -71,7 +73,8 @@ def _init_distributed():
 
 
 def _build_toy_model():
-    provider = LLaDA15ModelProvider(
+    vocab_size = TOY["vocab_size"]
+    transformer = TransformerConfig(
         normalization="RMSNorm",
         gated_linear_unit=True,
         activation_func=F.silu,
@@ -81,12 +84,27 @@ def _build_toy_model():
         rotary_base=500000.0,
         bf16=True,
         params_dtype=torch.bfloat16,
-        **TOY,
+        num_layers=TOY["num_layers"],
+        hidden_size=TOY["hidden_size"],
+        num_attention_heads=TOY["num_attention_heads"],
+        num_query_groups=TOY["num_query_groups"],
+        kv_channels=TOY["kv_channels"],
+        ffn_hidden_size=TOY["ffn_hidden_size"],
+        tensor_model_parallel_size=1,
+        pipeline_model_parallel_size=1,
     )
-    provider.tensor_model_parallel_size = 1
-    provider.pipeline_model_parallel_size = 1
-    provider.finalize()
-    model = provider.provide_distributed_model(wrap_with_ddp=False, bf16=True)
+    config = LLaDA15ModelConfig(
+        transformer=transformer,
+        vocab_size=vocab_size,
+        seq_length=TOY["seq_length"],
+    )
+    config.finalize()
+    builder = config.get_builder_cls()(config)
+    model = builder.build_distributed_models(
+        pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
+        wrap_with_ddp=False,
+        data_parallel_random_init=False,
+    )
     return model[0].eval() if isinstance(model, list) else model.eval()
 
 

--- a/tests/unit_tests/diffusion/model/flux/conversion/test_flux_bridge.py
+++ b/tests/unit_tests/diffusion/model/flux/conversion/test_flux_bridge.py
@@ -16,6 +16,7 @@ import types
 
 import pytest
 import torch
+from megatron.core.transformer.utils import openai_gelu
 
 from megatron.bridge.diffusion.conversion.flux import flux_bridge as flux_bridge_module
 
@@ -88,6 +89,20 @@ def test_provider_bridge_constructs_provider_with_expected_fields():
 
     # hidden_size stored on bridge instance
     assert bridge.hidden_size == provider.hidden_size
+
+
+def test_model_config_bridge_preserves_flux_transformer_defaults():
+    class DummyHF:
+        def __init__(self, cfg):
+            self.config = cfg
+
+    config = flux_bridge_module.FluxBridge().model_config_bridge(DummyHF(_make_cfg()))
+    transformer = config.transformer
+
+    assert transformer.hidden_dropout == 0.0
+    assert transformer.attention_dropout == 0.0
+    assert transformer.layernorm_epsilon == 1e-6
+    assert transformer.activation_func is openai_gelu
 
 
 def test_mapping_registry_registers_module_types_and_builds_mappings(monkeypatch):

--- a/tests/unit_tests/diffusion/model/llada15/conversion/test_llada15_bridge.py
+++ b/tests/unit_tests/diffusion/model/llada15/conversion/test_llada15_bridge.py
@@ -24,6 +24,7 @@ the GPU round-trip script).
 import types
 
 import pytest
+import torch
 
 from megatron.bridge.diffusion.conversion.llada15.llada15_bridge import LLaDA15Bridge
 from megatron.bridge.diffusion.models.llada15.llada15_provider import LLaDA15ModelProvider
@@ -115,6 +116,19 @@ class TestProviderBridge:
     def test_qk_layernorm_follows_config(self):
         assert self._provider(attention_layer_norm=False).qk_layernorm is False
         assert self._provider(attention_layer_norm=True).qk_layernorm is True
+
+
+class TestModelConfigBridge:
+    def test_preserves_builder_dtype_and_architecture_fields(self):
+        config = LLaDA15Bridge().model_config_bridge(DummyHFPretrained(_make_hf_config()))
+
+        assert config.transformer.params_dtype is torch.bfloat16
+        assert config.transformer.autocast_dtype is torch.bfloat16
+        assert config.transformer.bf16 is True
+        assert config.transformer.hidden_size == 4096
+        assert config.transformer.num_layers == 32
+        assert config.transformer.num_query_groups == 32
+        assert config.vocab_size == 126464
 
 
 class TestMappingRegistry:

--- a/tests/unit_tests/diffusion/model/nemotron_labs_diffusion/conversion/test_nemotron_labs_diffusion_bridge.py
+++ b/tests/unit_tests/diffusion/model/nemotron_labs_diffusion/conversion/test_nemotron_labs_diffusion_bridge.py
@@ -235,6 +235,27 @@ class TestNemotronLabsDiffusionBridgeModelConfig:
         assert transformer.fp16 is False
         assert config.scatter_embedding_sequence_parallel is False
 
+    def test_vlm_weight_tying_uses_top_level_config(self):
+        text_config = types.SimpleNamespace(
+            hidden_size=1024,
+            intermediate_size=4096,
+            num_hidden_layers=8,
+            num_attention_heads=8,
+            num_key_value_heads=4,
+            head_dim=128,
+            vocab_size=32000,
+            max_position_embeddings=4096,
+            rms_norm_eps=1e-5,
+            tie_word_embeddings=True,
+            rope_parameters={"rope_theta": 10000.0},
+        )
+        hf_config = types.SimpleNamespace(text_config=text_config, tie_word_embeddings=False)
+        hf_config.to_dict = lambda: {"text_config": dict(vars(text_config))}
+
+        config = NemotronLabsDiffusionBridge().model_config_bridge(DummyHFPretrained(hf_config))
+
+        assert config.share_embeddings_and_output_weights is False
+
 
 class TestNemotronLabsDiffusionBridgeMappingRegistryVLM:
     """Tests for the VLM-format mapping registry (HF keys use language_model.* prefix)."""

--- a/tests/unit_tests/diffusion/model/nemotron_labs_diffusion/conversion/test_nemotron_labs_diffusion_bridge.py
+++ b/tests/unit_tests/diffusion/model/nemotron_labs_diffusion/conversion/test_nemotron_labs_diffusion_bridge.py
@@ -17,6 +17,8 @@
 import types
 
 import pytest
+import torch
+import torch.nn.functional as F
 
 from megatron.bridge.diffusion.conversion.nemotron_labs_diffusion.nemotron_labs_diffusion_bridge import (
     NemotronLabsDiffusionBridge,
@@ -200,6 +202,38 @@ class TestNemotronLabsDiffusionBridgeProviderBridge:
         # SimpleNamespace doesn't have text_config, getattr falls back to hf_config itself
         provider = bridge.provider_bridge(hf)
         assert provider.hidden_size == 768
+
+
+class TestNemotronLabsDiffusionBridgeModelConfig:
+    """Tests for the provider-neutral model-config mapping."""
+
+    def test_preserves_legacy_transformer_defaults(self):
+        text_config = types.SimpleNamespace(
+            hidden_size=1024,
+            intermediate_size=4096,
+            num_hidden_layers=8,
+            num_attention_heads=8,
+            num_key_value_heads=4,
+            head_dim=128,
+            vocab_size=32000,
+            max_position_embeddings=4096,
+            rms_norm_eps=1e-5,
+            tie_word_embeddings=False,
+            rope_parameters={"rope_theta": 10000.0},
+        )
+        hf_config = types.SimpleNamespace(text_config=text_config)
+        hf_config.to_dict = lambda: {"text_config": dict(vars(text_config))}
+
+        config = NemotronLabsDiffusionBridge().model_config_bridge(DummyHFPretrained(hf_config))
+        transformer = config.transformer
+
+        assert transformer.activation_func is F.silu
+        assert transformer.hidden_dropout == 0.0
+        assert transformer.attention_dropout == 0.0
+        assert transformer.params_dtype is torch.bfloat16
+        assert transformer.bf16 is True
+        assert transformer.fp16 is False
+        assert config.scatter_embedding_sequence_parallel is False
 
 
 class TestNemotronLabsDiffusionBridgeMappingRegistryVLM:

--- a/tests/unit_tests/diffusion/model/nemotron_labs_diffusion/test_nemotron_labs_diffusion_attention.py
+++ b/tests/unit_tests/diffusion/model/nemotron_labs_diffusion/test_nemotron_labs_diffusion_attention.py
@@ -300,6 +300,26 @@ class TestMinistral3RotaryEmbedding:
 
 
 class TestNemotronLabsDiffusionAttentionInit:
+    def test_block_size_falls_back_to_legacy_config_field(self):
+        cfg = _make_config(block_size=7)
+        from megatron.bridge.diffusion.models.common.nemotron_labs_diffusion_attention import (
+            NemotronLabsDiffusionAttention,
+        )
+
+        with patch(
+            "megatron.bridge.diffusion.models.common.nemotron_labs_diffusion_attention.compute_block_mask",
+            return_value=MagicMock(),
+        ) as compute_mask:
+            NemotronLabsDiffusionAttention(
+                cfg,
+                1,
+                AttnMaskType.causal,
+                "self",
+                pg_collection=_make_pg_collection(),
+            )
+
+        compute_mask.assert_called_once_with(block_size=7, max_seq_length=cfg.seq_length)
+
     def test_softmax_scale_computed_correctly(self):
         head_dim = 8
         attn = _make_attention(head_dim=head_dim)

--- a/tests/unit_tests/diffusion/model/test_model_configs.py
+++ b/tests/unit_tests/diffusion/model/test_model_configs.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+import ast
+from pathlib import Path
+
+import pytest
+from megatron.core.transformer import TransformerConfig
+
+from megatron.bridge.diffusion.models.flux.model_config import FluxModelBuilder, FluxModelConfig
+from megatron.bridge.diffusion.models.llada15.model_config import LLaDA15ModelConfig
+from megatron.bridge.diffusion.models.nemotron_labs_diffusion.model_config import NemotronLabsDiffusionModelConfig
+from megatron.bridge.diffusion.models.wan.model_config import WanModelBuilder, WanModelConfig
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "config_class",
+    [FluxModelConfig, WanModelConfig, LLaDA15ModelConfig, NemotronLabsDiffusionModelConfig],
+)
+def test_diffusion_model_configs_roundtrip_with_exact_mcore_transformer(config_class):
+    transformer = TransformerConfig(num_layers=2, hidden_size=16, num_attention_heads=2)
+    config = config_class(transformer=transformer, vocab_size=32)
+
+    restored = config_class.from_dict(config.as_dict())
+
+    assert type(restored.transformer) is TransformerConfig
+    assert restored.get_builder_cls() is config.get_builder_cls()
+    assert restored.as_dict() == config.as_dict()
+
+
+@pytest.mark.unit
+def test_diffusion_model_config_modules_are_provider_neutral():
+    repository_root = Path(__file__).parents[4]
+    modules = [
+        "src/megatron/bridge/diffusion/models/flux/model_config.py",
+        "src/megatron/bridge/diffusion/models/wan/model_config.py",
+        "src/megatron/bridge/diffusion/models/llada15/model_config.py",
+        "src/megatron/bridge/diffusion/models/nemotron_labs_diffusion/model_config.py",
+        "src/megatron/bridge/diffusion/models/flux/__init__.py",
+        "src/megatron/bridge/diffusion/models/llada15/__init__.py",
+        "src/megatron/bridge/diffusion/models/nemotron_labs_diffusion/__init__.py",
+    ]
+
+    for module in modules:
+        tree = ast.parse((repository_root / module).read_text())
+        top_level_imports = [
+            node for node in tree.body if isinstance(node, ast.ImportFrom) and node.module is not None
+        ]
+        assert all("provider" not in node.module for node in top_level_imports)
+
+
+@pytest.mark.unit
+def test_nemotron_labs_diffusion_recipes_do_not_import_model_providers():
+    repository_root = Path(__file__).parents[4]
+    recipe_root = repository_root / "src/megatron/bridge/diffusion/recipes/nemotron_labs_diffusion"
+
+    violations = []
+    for path in recipe_root.rglob("*.py"):
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ImportFrom) or node.module is None:
+                continue
+            if ".models." in node.module and "provider" in node.module:
+                violations.append(f"{path.name}:{node.lineno}:{node.module}")
+
+    assert not violations, "Model providers remain in official diffusion recipes: " + ", ".join(violations)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("config_class", "builder_class", "target"),
+    [
+        (FluxModelConfig, FluxModelBuilder, "megatron.bridge.diffusion.models.flux.model_config.Flux"),
+        (WanModelConfig, WanModelBuilder, "megatron.bridge.diffusion.models.wan.model_config.WanModel"),
+    ],
+)
+def test_custom_diffusion_builders_pass_exact_transformer_and_outer_config(
+    monkeypatch, config_class, builder_class, target
+):
+    transformer = TransformerConfig(num_layers=2, hidden_size=16, num_attention_heads=2)
+    config = config_class(transformer=transformer, vocab_size=32)
+    captured = {}
+
+    def fake_model(transformer_config=None, *args, **kwargs):
+        captured["transformer"] = kwargs.pop("config", transformer_config)
+        captured["architecture_config"] = kwargs["architecture_config"]
+        return object()
+
+    monkeypatch.setattr(target, fake_model)
+    builder_class(config).build_model(object(), pre_process=True, post_process=True)
+
+    assert type(captured["transformer"]) is TransformerConfig
+    assert captured["architecture_config"] is config

--- a/tests/unit_tests/diffusion/model/test_model_configs.py
+++ b/tests/unit_tests/diffusion/model/test_model_configs.py
@@ -68,14 +68,44 @@ def test_nemotron_labs_diffusion_recipes_do_not_import_model_providers():
 
 @pytest.mark.unit
 @pytest.mark.parametrize(
-    ("config_class", "builder_class", "target"),
+    ("config_class", "builder_class", "target", "expected_architecture"),
     [
-        (FluxModelConfig, FluxModelBuilder, "megatron.bridge.diffusion.models.flux.model_config.Flux"),
-        (WanModelConfig, WanModelBuilder, "megatron.bridge.diffusion.models.wan.model_config.WanModel"),
+        (
+            FluxModelConfig,
+            FluxModelBuilder,
+            "megatron.bridge.diffusion.models.flux.model_config.Flux",
+            {
+                "num_joint_layers": 19,
+                "num_single_layers": 38,
+                "in_channels": 64,
+                "context_dim": 4096,
+                "model_channels": 256,
+                "axes_dims_rope": [16, 56, 56],
+                "patch_size": 1,
+                "guidance_embed": False,
+                "vec_in_dim": 768,
+            },
+        ),
+        (
+            WanModelConfig,
+            WanModelBuilder,
+            "megatron.bridge.diffusion.models.wan.model_config.WanModel",
+            {
+                "crossattn_emb_size": 1536,
+                "in_channels": 16,
+                "out_channels": 16,
+                "patch_spatial": 2,
+                "patch_temporal": 1,
+                "freq_dim": 256,
+                "text_dim": 4096,
+                "layernorm_across_heads": True,
+                "qkv_format": "thd",
+            },
+        ),
     ],
 )
-def test_custom_diffusion_builders_pass_exact_transformer_and_outer_config(
-    monkeypatch, config_class, builder_class, target
+def test_custom_diffusion_builders_pass_exact_transformer_and_explicit_architecture(
+    monkeypatch, config_class, builder_class, target, expected_architecture
 ):
     transformer = TransformerConfig(num_layers=2, hidden_size=16, num_attention_heads=2)
     config = config_class(transformer=transformer, vocab_size=32)
@@ -83,11 +113,12 @@ def test_custom_diffusion_builders_pass_exact_transformer_and_outer_config(
 
     def fake_model(transformer_config=None, *args, **kwargs):
         captured["transformer"] = kwargs.pop("config", transformer_config)
-        captured["architecture_config"] = kwargs["architecture_config"]
+        captured["architecture"] = {name: kwargs[name] for name in expected_architecture}
+        assert "architecture_config" not in kwargs
         return object()
 
     monkeypatch.setattr(target, fake_model)
     builder_class(config).build_model(object(), pre_process=True, post_process=True)
 
     assert type(captured["transformer"]) is TransformerConfig
-    assert captured["architecture_config"] is config
+    assert captured["architecture"] == expected_architecture

--- a/tests/unit_tests/diffusion/model/wan/conversion/test_wan_bridge.py
+++ b/tests/unit_tests/diffusion/model/wan/conversion/test_wan_bridge.py
@@ -81,6 +81,26 @@ def test_provider_bridge_constructs_provider_with_expected_fields():
     assert provider.attention_dropout == 0
 
 
+def test_model_config_bridge_preserves_wan_architecture_fields():
+    class DummyHF:
+        def __init__(self, cfg):
+            self.config = cfg
+
+    cfg = _make_cfg()
+    config = wan_bridge_module.WanBridge().model_config_bridge(DummyHF(cfg))
+
+    assert config.transformer.hidden_size == cfg.num_attention_heads * cfg.attention_head_dim
+    assert config.transformer.num_layers == cfg.num_layers
+    assert config.transformer.ffn_hidden_size == cfg.ffn_dim
+    assert config.crossattn_emb_size == config.transformer.hidden_size
+    assert config.in_channels == cfg.in_channels
+    assert config.out_channels == cfg.out_channels
+    assert config.patch_temporal == cfg.patch_size[0]
+    assert config.patch_spatial == cfg.patch_size[1]
+    assert config.freq_dim == cfg.freq_dim
+    assert config.text_dim == cfg.text_dim
+
+
 def test_mapping_registry_registers_module_types_and_builds_mappings(monkeypatch):
     calls_register_module_type = []
 

--- a/tests/unit_tests/diffusion/model/wan/test_wan_model_misc.py
+++ b/tests/unit_tests/diffusion/model/wan/test_wan_model_misc.py
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
+
 import torch
 
-from megatron.bridge.diffusion.models.wan.wan_model import sinusoidal_embedding_1d
+from megatron.bridge.diffusion.models.flux.flux_model import Flux
+from megatron.bridge.diffusion.models.wan.wan_model import WanModel, _build_wan_layer_spec, sinusoidal_embedding_1d
 
 
 def test_sinusoidal_embedding_1d_shape_and_dtype():
@@ -23,3 +26,27 @@ def test_sinusoidal_embedding_1d_shape_and_dtype():
     emb = sinusoidal_embedding_1d(dim, pos)
     assert emb.shape == (pos.shape[0], dim)
     assert emb.dtype == torch.float32
+
+
+def test_diffusion_model_constructor_positional_prefix_is_compatible():
+    config = object()
+
+    flux_bound = inspect.signature(Flux).bind(config, False, False, True, False)
+    wan_bound = inspect.signature(WanModel).bind(config, False, False, True, False)
+
+    assert flux_bound.arguments["pre_process"] is False
+    assert flux_bound.arguments["post_process"] is False
+    assert wan_bound.arguments["pre_process"] is False
+    assert wan_bound.arguments["post_process"] is False
+
+
+def test_wan_custom_layer_spec_factory_remains_zero_argument():
+    sentinel = object()
+    calls = []
+
+    def custom_factory():
+        calls.append(True)
+        return sentinel
+
+    assert _build_wan_layer_spec(custom_factory, layernorm_across_heads=True) is sentinel
+    assert calls == [True]

--- a/tests/unit_tests/diffusion/model/wan/test_wan_step.py
+++ b/tests/unit_tests/diffusion/model/wan/test_wan_step.py
@@ -15,13 +15,27 @@
 import pytest
 import torch
 
-from megatron.bridge.diffusion.models.wan.wan_step import WanForwardStep, wan_data_step
+import megatron.bridge.diffusion.models.wan.wan_step as wan_step_module
+from megatron.bridge.diffusion.models.wan.wan_step import WanForwardStep, _get_qkv_format, wan_data_step
 
 
 class _DummyIter:
     def __init__(self, batch):
         # mimic attribute used inside wan_data_step
         self.iterable = [batch]
+
+
+class _Wrapper:
+    def __init__(self, module):
+        self.module = module
+
+
+def test_wan_qkv_format_comes_from_unwrapped_runtime_model(monkeypatch):
+    model = type("WanRuntime", (), {"qkv_format": "thd", "config": object()})()
+    wrapper = _Wrapper(model)
+    monkeypatch.setattr(wan_step_module, "unwrap_model", lambda candidate: candidate.module)
+
+    assert _get_qkv_format(wrapper) == "thd"
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="wan_data_step moves tensors to CUDA")

--- a/tests/unit_tests/diffusion/recipes/flux/test_flux_recipe.py
+++ b/tests/unit_tests/diffusion/recipes/flux/test_flux_recipe.py
@@ -18,7 +18,7 @@ from types import SimpleNamespace
 import pytest
 
 from megatron.bridge.diffusion.data.flux.flux_energon_datamodule import FluxDatasetConfig
-from megatron.bridge.diffusion.models.flux.flux_provider import FluxProvider
+from megatron.bridge.diffusion.models.flux.model_config import FluxModelConfig
 from megatron.bridge.diffusion.recipes.flux.flux import flux_12b_pretrain_config, flux_12b_sft_config
 from megatron.bridge.training.config import ConfigContainer
 
@@ -31,7 +31,7 @@ _flux_recipe_mod = importlib.import_module("megatron.bridge.diffusion.recipes.fl
 
 
 def _fake_flux_diffusers_config() -> SimpleNamespace:
-    """Shape expected by FluxBridge.provider_bridge; values match FLUX.1-dev / recipe defaults."""
+    """Shape expected by FluxBridge.model_config_bridge; values match FLUX.1-dev defaults."""
     return SimpleNamespace(
         num_attention_heads=24,
         attention_head_dim=128,
@@ -74,7 +74,7 @@ class TestPretrainConfig:
         config = flux_12b_pretrain_config()
 
         assert isinstance(config, ConfigContainer)
-        assert isinstance(config.model, FluxProvider)
+        assert isinstance(config.model, FluxModelConfig)
         assert isinstance(config.dataset, FluxDatasetConfig)
         assert config.dataset.path is None  # default: mock/synthetic data
 

--- a/tests/unit_tests/diffusion/recipes/nemotron_labs_diffusion/test_ar_to_dlm_recipe.py
+++ b/tests/unit_tests/diffusion/recipes/nemotron_labs_diffusion/test_ar_to_dlm_recipe.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+import pytest
+from megatron.core.transformer import TransformerConfig
+
+from megatron.bridge.diffusion.models.nemotron_labs_diffusion.model_config import (
+    NemotronLabsDiffusionModelConfig,
+)
+from megatron.bridge.diffusion.recipes.nemotron_labs_diffusion import ar_to_dlm
+
+
+pytestmark = pytest.mark.unit
+
+
+def _model_config() -> NemotronLabsDiffusionModelConfig:
+    return NemotronLabsDiffusionModelConfig(
+        transformer=TransformerConfig(num_layers=1, hidden_size=16, num_attention_heads=2),
+        vocab_size=32,
+        block_size=23,
+        hf_config={"model_type": "test-diffusion"},
+    )
+
+
+@pytest.mark.parametrize(
+    ("recipe", "tensor_parallel_size"),
+    [
+        (ar_to_dlm.nemotron_labs_diffusion_3b_pretrain_config, 1),
+        (ar_to_dlm.nemotron_labs_diffusion_8b_pretrain_config, 4),
+        (ar_to_dlm.nemotron_labs_diffusion_14b_pretrain_config, 8),
+    ],
+)
+def test_size_recipe_uses_copied_model_config_without_loading_hf(monkeypatch, recipe, tensor_parallel_size):
+    source = _model_config()
+    monkeypatch.setattr(
+        ar_to_dlm.PreTrainedCausalLM,
+        "from_pretrained",
+        lambda *args, **kwargs: pytest.fail("custom model_config must not load Hugging Face"),
+    )
+
+    config = recipe(model_config=source)
+
+    assert config.model is not source
+    assert isinstance(config.model, NemotronLabsDiffusionModelConfig)
+    assert config.model.block_size == 23
+    assert config.model.hf_config == {"model_type": "test-diffusion"}
+    assert config.model.tensor_model_parallel_size == tensor_parallel_size
+    assert source.tensor_model_parallel_size == 1
+    assert source.seq_length == 1024
+
+
+@pytest.mark.parametrize(
+    "recipe",
+    [
+        ar_to_dlm.nemotron_labs_diffusion_3b_pretrain_config,
+        ar_to_dlm.nemotron_labs_diffusion_8b_pretrain_config,
+        ar_to_dlm.nemotron_labs_diffusion_14b_pretrain_config,
+    ],
+)
+def test_size_recipe_rejects_explicit_hf_path_with_model_config(recipe):
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        recipe(model_config=_model_config(), hf_path="org/model")

--- a/tests/unit_tests/examples/test_provider_free_examples.py
+++ b/tests/unit_tests/examples/test_provider_free_examples.py
@@ -30,9 +30,6 @@ NIGHTLY_DOCS_ROOT = DOCS_ROOT / "fern" / "versions" / "nightly" / "pages"
 # Remove entries as these integrations gain standalone ModelConfig/ModelBuilder
 # support or no longer require a persistent provider-based HF loading hook.
 TEMPORARY_FALLBACKS = {
-    "to_megatron_model": {
-        Path("models/llada/llada15/convert_llada15_hf_to_megatron.py"),
-    },
     "to_megatron_provider": {
         Path("distillation/llama/distill_llama32_3b-1b.py"),
         Path("megatron_mimo/qwen35_vl/finetune_qwen35_vl.py"),

--- a/tests/unit_tests/models/test_provider_free_primary_consumers.py
+++ b/tests/unit_tests/models/test_provider_free_primary_consumers.py
@@ -27,6 +27,7 @@ REPO_ROOT = SRC_ROOT.parents[2]
 FUNCTIONAL_ROOT = REPO_ROOT / "tests" / "functional_tests"
 PRIMARY_CONSUMER_ROOTS = (
     SRC_ROOT / "recipes",
+    SRC_ROOT / "diffusion" / "recipes",
     SRC_ROOT / "inference",
 )
 FORBIDDEN_CALLS = {"provider_bridge", "to_megatron_provider"}

--- a/tests/unit_tests/models/test_registered_bridge_builder_audit.py
+++ b/tests/unit_tests/models/test_registered_bridge_builder_audit.py
@@ -25,7 +25,7 @@ from megatron.training.models.base import ModelBuilder, ModelConfig
 pytestmark = pytest.mark.unit
 
 SRC_ROOT = Path(__file__).parents[3] / "src"
-BRIDGE_ROOT = SRC_ROOT / "megatron" / "bridge" / "models"
+BRIDGE_ROOT = SRC_ROOT / "megatron" / "bridge"
 
 # Every registered bridge must be named here. Adding a registration without
 # adding its builder/config contract to the audit is intentionally a test failure.
@@ -38,6 +38,7 @@ REGISTERED_BRIDGE_CONFIGS: dict[str, tuple[str, ...]] = {
     "Ernie45VLBridge": ("megatron.bridge.models.ernie_vl.model_config.Ernie45VLModelConfig",),
     "Exaone4Bridge": ("megatron.bridge.models.exaone.model_config.Exaone4ModelConfig",),
     "FalconH1Bridge": ("megatron.bridge.models.falcon_h1.model_config.FalconH1ModelConfig",),
+    "FluxBridge": ("megatron.bridge.diffusion.models.flux.model_config.FluxModelConfig",),
     "GLM45Bridge": ("megatron.bridge.models.glm.model_config.GLM45ModelConfig",),
     "GLM45VBridge": ("megatron.bridge.models.glm_vl.model_config.GLM45VModelConfig",),
     "GLM47FlashBridge": ("megatron.bridge.models.glm.model_config.GLM47FlashModelConfig",),
@@ -57,6 +58,7 @@ REGISTERED_BRIDGE_CONFIGS: dict[str, tuple[str, ...]] = {
     "GemmaBridge": ("megatron.bridge.models.gemma.model_config.GemmaModelConfig",),
     "KimiK2Bridge": ("megatron.bridge.models.kimi.model_config.KimiK2ModelConfig",),
     "KimiK25VLBridge": ("megatron.bridge.models.kimi_vl.model_config.KimiK25VLModelConfig",),
+    "LLaDA15Bridge": ("megatron.bridge.diffusion.models.llada15.model_config.LLaDA15ModelConfig",),
     "LlamaBridge": ("megatron.bridge.models.gpt.model_config.BridgeGPTModelConfig",),
     "LlamaNemotronBridge": ("megatron.bridge.models.llama_nemotron.model_config.LlamaNemotronModelConfig",),
     "MiMoV2FlashBridge": ("megatron.bridge.models.mimo_v2_flash.model_config.MiMoV2FlashModelConfig",),
@@ -66,6 +68,9 @@ REGISTERED_BRIDGE_CONFIGS: dict[str, tuple[str, ...]] = {
     "MistralBridge": ("megatron.bridge.models.mistral.model_config.MistralModelConfig",),
     "NemotronBridge": ("megatron.bridge.models.gpt.model_config.BridgeGPTModelConfig",),
     "NemotronHBridge": ("megatron.bridge.models.nemotronh.model_config.NemotronHModelConfig",),
+    "NemotronLabsDiffusionBridge": (
+        "megatron.bridge.diffusion.models.nemotron_labs_diffusion.model_config.NemotronLabsDiffusionModelConfig",
+    ),
     "NemotronOmniBridge": ("megatron.bridge.models.nemotron_omni.model_config.NemotronOmniModelConfig",),
     "NemotronVLBridge": ("megatron.bridge.models.nemotron_vl.model_config.NemotronVLModelConfig",),
     "OlMoEBridge": ("megatron.bridge.models.olmoe.model_config.OlMoEModelConfig",),
@@ -88,6 +93,7 @@ REGISTERED_BRIDGE_CONFIGS: dict[str, tuple[str, ...]] = {
     "SarvamMoEBridge": ("megatron.bridge.models.sarvam.model_config.SarvamMoEModelConfig",),
     "Step35Bridge": ("megatron.bridge.models.stepfun.step35_bridge.Step35ModelConfig",),
     "Step37Bridge": ("megatron.bridge.models.stepfun.step37_model_config.Step37ModelConfig",),
+    "WanBridge": ("megatron.bridge.diffusion.models.wan.model_config.WanModelConfig",),
 }
 
 # Keep the registration source expression explicit as part of the manifest. This
@@ -102,6 +108,7 @@ REGISTERED_BRIDGE_ARCHITECTURES: dict[str, str] = {
     "Ernie45VLBridge": "_ERNIE45_VL_MOE_HF_CLASS_NAME",
     "Exaone4Bridge": "'Exaone4ForCausalLM'",
     "FalconH1Bridge": "'FalconH1ForCausalLM'",
+    "FluxBridge": "FluxTransformer2DModel",
     "GLM45Bridge": "Glm4MoeForCausalLM",
     "GLM45VBridge": "Glm4vMoeForConditionalGeneration",
     "GLM47FlashBridge": "'Glm4MoeLiteForCausalLM'",
@@ -115,6 +122,7 @@ REGISTERED_BRIDGE_ARCHITECTURES: dict[str, str] = {
     "GemmaBridge": "GemmaForCausalLM",
     "KimiK25VLBridge": "'KimiK25ForConditionalGeneration'",
     "KimiK2Bridge": "'KimiK2ForCausalLM'",
+    "LLaDA15Bridge": "'LLaDAModelLM'",
     "LlamaBridge": "LlamaForCausalLM",
     "LlamaNemotronBridge": "'DeciLMForCausalLM'",
     "MiMoV2FlashBridge": "'MiMoV2FlashForCausalLM'",
@@ -124,6 +132,7 @@ REGISTERED_BRIDGE_ARCHITECTURES: dict[str, str] = {
     "MistralBridge": "MistralForCausalLM",
     "NemotronBridge": "NemotronForCausalLM",
     "NemotronHBridge": "'NemotronHForCausalLM'",
+    "NemotronLabsDiffusionBridge": "'NemotronLabsDiffusionModel'",
     "NemotronOmniBridge": "'NemotronH_Nano_Omni_Reasoning_V3'",
     "NemotronVLBridge": "'NemotronH_Nano_VL_V2'",
     "OlMoEBridge": "OlmoeForCausalLM",
@@ -146,6 +155,7 @@ REGISTERED_BRIDGE_ARCHITECTURES: dict[str, str] = {
     "SarvamMoEBridge": "'SarvamMoEForCausalLM'",
     "Step35Bridge": "'Step3p5ForCausalLM'",
     "Step37Bridge": "'Step3p7ForConditionalGeneration'",
+    "WanBridge": "WanTransformer3DModel",
 }
 
 REGISTRATION_SOURCE_ALIASES: dict[str, str] = {


### PR DESCRIPTION
## Summary

- migrate Flux, LLaDA 1.5, Nemotron Labs Diffusion, and Wan bridges to serializable ModelConfig plus standalone ModelBuilder contracts
- move official diffusion recipes off model-provider construction paths
- preserve exact legacy transformer defaults and compatibility behavior, including Flux openai_gelu and Nemotron block sizing
- extend registered-bridge and provider-free consumer audits to diffusion

## Stack

- Base: #4545
- This PR contains only diffusion-specific migration changes and tests.

## Validation

- uvx pre-commit run --all-files
- two independent subagent review passes completed; all confirmed findings fixed
- EOS targeted unit tests are running
