### PR TITLE
refactor(mimo): migrate MegatronMIMO to model builders

### DIFF
--- a/examples/megatron_mimo/llava/megatron_mimo_training_llava.py
+++ b/examples/megatron_mimo/llava/megatron_mimo_training_llava.py
@@ -592,7 +592,7 @@ def _wrap_iter(loader_iter, model_dtype=torch.bfloat16):
         yield batch
 
 
-def _build_data_iterators(cfg, _megatron_mimo_infra, *, train_state=None):
+def _build_data_iterators(cfg, megatron_mimo_infra, *, train_state=None):
     """Build data iterators compatible with setup_megatron_mimo's build_data_iterators_fn.
 
     Signature: (cfg, megatron_mimo_infra, *, train_state=None) -> (train_iter, valid_iter)
@@ -617,6 +617,7 @@ def _build_data_iterators(cfg, _megatron_mimo_infra, *, train_state=None):
         train_samples=max(train_samples, 10),  # min 10 samples
         valid_samples=valid_samples,
         test_samples=test_samples,
+        grids=megatron_mimo_infra.module_to_grid_map,
     )
 
     model_dtype = torch.bfloat16 if getattr(cfg.model, "bf16", True) else torch.float32

--- a/examples/megatron_mimo/llava/megatron_mimo_training_llava_audio.py
+++ b/examples/megatron_mimo/llava/megatron_mimo_training_llava_audio.py
@@ -536,7 +536,7 @@ def _wrap_iter(loader_iter, model_dtype=torch.bfloat16):
         yield batch
 
 
-def _build_data_iterators(cfg, _megatron_mimo_infra, *, train_state=None):
+def _build_data_iterators(cfg, megatron_mimo_infra, *, train_state=None):
     """Build data iterators compatible with setup_megatron_mimo's build_data_iterators_fn.
 
     Signature: (cfg, megatron_mimo_infra, *, train_state=None) -> (train_iter, valid_iter)
@@ -561,6 +561,7 @@ def _build_data_iterators(cfg, _megatron_mimo_infra, *, train_state=None):
         train_samples=max(train_samples, 10),  # min 10 samples
         valid_samples=valid_samples,
         test_samples=test_samples,
+        grids=megatron_mimo_infra.module_to_grid_map,
     )
 
     model_dtype = torch.bfloat16 if getattr(cfg.model, "bf16", True) else torch.float32

--- a/examples/megatron_mimo/qwen35_vl/finetune_qwen35_vl.py
+++ b/examples/megatron_mimo/qwen35_vl/finetune_qwen35_vl.py
@@ -792,16 +792,15 @@ def _wrap_iter_logging(
 
 
 def _make_build_data_iterators(spec: Qwen35MIMOHFSpec, args: argparse.Namespace):
-    def _build_data_iterators(cfg, _megatron_mimo_infra, *, train_state=None):
+    def _build_data_iterators(cfg, megatron_mimo_infra, *, train_state=None):
         if train_state is None:
             train_state = TrainState()
 
-        if cfg.model._grids is None:
-            raise ValueError("MegatronMIMOProvider._grids is None. Model must be built before data iterators.")
+        grids = megatron_mimo_infra.module_to_grid_map
 
         sampler_dp_rank, sampler_dp_size, needs_data = get_megatron_mimo_sampling_info(
             cfg.model.megatron_mimo_parallelism_config,
-            cfg.model._grids,
+            grids,
         )
         if not needs_data:
             return None, None

--- a/examples/megatron_mimo/qwen35_vl/finetune_qwen35_vl.py
+++ b/examples/megatron_mimo/qwen35_vl/finetune_qwen35_vl.py
@@ -54,11 +54,12 @@ from megatron.bridge.data.vlm_processing import (
     build_assistant_loss_mask,
     chat_template_kwargs_from_example,
 )
+from megatron.bridge.models.megatron_mimo.conversion import MegatronMIMOBridge
 from megatron.bridge.models.megatron_mimo.megatron_mimo_config import (
     MegatronMIMOParallelismConfig,
     ModuleParallelismConfig,
 )
-from megatron.bridge.models.megatron_mimo.megatron_mimo_provider import MegatronMIMOProvider
+from megatron.bridge.models.megatron_mimo.model_config import MegatronMIMOModelConfig
 from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.rope import get_rope_index
 from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.utils import reorganize_inputs
 from megatron.bridge.recipes.utils.optimizer_utils import distributed_fused_adam_with_cosine_annealing
@@ -238,8 +239,8 @@ def _grid_dim_rank(grid: Any, dim_name: str, default: int = 0) -> int:
     return int(grid.get_pg([dim_name]).rank())
 
 
-def _batch_spec_for_rank(cfg: Any) -> MIMOBatchSpec:
-    grids = getattr(cfg.model, "_grids", None)
+def _batch_spec_for_rank(cfg: Any, grids: dict[str, Any] | None = None) -> MIMOBatchSpec:
+    grids = grids or getattr(cfg.model, "_grids", None)
     if not grids:
         return MIMOBatchSpec()
 
@@ -322,39 +323,33 @@ def _validate_mimo_batch_sizes(
     return summaries
 
 
-def _build_mimo_provider(
+def _build_mimo_model_config(
     hf_config: object,
     parallelism_config: MegatronMIMOParallelismConfig,
     args: argparse.Namespace,
-) -> MegatronMIMOProvider:
-    bridge = AutoBridge.from_hf_config(hf_config)
-    # TODO: Remove this compatibility fallback when MegatronMIMOProvider can adapt
-    # directly from a builder-backed Qwen3.5-VL ModelConfig.
-    standard_provider = bridge.to_megatron_provider(load_weights=False)
-    standard_provider.seq_length = args.seq_length
-    if hasattr(standard_provider, "language_max_sequence_length"):
-        standard_provider.language_max_sequence_length = args.seq_length
-    standard_provider.bf16 = not args.fp32
-    standard_provider.fp16 = False
-    standard_provider.use_cpu_initialization = True
-    if hasattr(standard_provider, "mtp_num_layers"):
-        standard_provider.mtp_num_layers = None
-    if hasattr(standard_provider, "_enable_in_batch_packing"):
-        standard_provider._enable_in_batch_packing = False
+) -> MegatronMIMOModelConfig:
+    source_bridge = AutoBridge.from_hf_config(hf_config)
+    bridge = MegatronMIMOBridge.from_bridge(source_bridge, parallelism_config=parallelism_config)
+    model_config = bridge.get_model_config()
+    source_config = model_config.source_model_config
+    source_config.seq_length = args.seq_length
+    if hasattr(source_config, "language_max_sequence_length"):
+        source_config.language_max_sequence_length = args.seq_length
+    source_config.bf16 = not args.fp32
+    source_config.fp16 = False
+    source_config.use_cpu_initialization = True
+    if hasattr(source_config, "mtp_num_layers"):
+        source_config.mtp_num_layers = None
+    if hasattr(source_config, "_enable_in_batch_packing"):
+        source_config._enable_in_batch_packing = False
 
-    provider = MegatronMIMOProvider.from_standard_provider(
-        standard_provider=standard_provider,
-        megatron_mimo_parallelism_config=parallelism_config,
-    )
-    provider.use_cpu_initialization = True
-    provider.bf16 = not args.fp32
-    provider.fp16 = False
-    provider.freeze_language_model = args.freeze_llm
-    provider.freeze_modality_encoders = {"images": args.freeze_vision}
-    provider.freeze_modality_projections = {"images": args.freeze_projector}
-    if not hasattr(provider, "num_moe_experts"):
-        provider.num_moe_experts = None
-    return provider
+    model_config.use_cpu_initialization = True
+    model_config.bf16 = not args.fp32
+    model_config.fp16 = False
+    model_config.freeze_language_model = args.freeze_llm
+    model_config.freeze_modality_encoders = {"images": args.freeze_vision}
+    model_config.freeze_modality_projections = {"images": args.freeze_projector}
+    return model_config
 
 
 def _build_data_provider(args: argparse.Namespace) -> HFConversationDatasetProvider:
@@ -818,7 +813,7 @@ def _make_build_data_iterators(spec: Qwen35MIMOHFSpec, args: argparse.Namespace)
         base_collate = getattr(train_ds, "collate_fn", None)
         if base_collate is None:
             raise ValueError("HF conversation train dataset does not expose collate_fn.")
-        batch_spec = _batch_spec_for_rank(cfg)
+        batch_spec = _batch_spec_for_rank(cfg, grids)
         use_metadata_collate = not batch_spec.modality_inputs
         _log(
             f"mimo_batch_spec spec={batch_spec.describe()} collate={'metadata' if use_metadata_collate else 'visual'}"
@@ -899,7 +894,7 @@ def _build_checkpoint_config(args: argparse.Namespace) -> CheckpointConfig:
 
 
 def _register_converted_checkpoint_pre_wrap_hook(
-    model_provider: MegatronMIMOProvider,
+    model_config: MegatronMIMOModelConfig,
     checkpoint_path: str | None,
 ) -> None:
     if checkpoint_path is None:
@@ -909,11 +904,13 @@ def _register_converted_checkpoint_pre_wrap_hook(
         if len(model_list) != 1:
             raise ValueError(f"Expected a single MegatronMIMO model, got {len(model_list)} chunks.")
 
-        infra = model_provider.build_infra()
+        builder = model_config.get_builder_cls()(model_config)
+        builder.finalize()
+        infra = builder.build_infra()
         active_module_name, local_pg_collection = get_active_module_pg(infra)
         load_state = GlobalState()
         load_state.cfg = ConfigContainer(
-            model=model_provider,
+            model=model_config,
             train=None,
             optimizer=OptimizerConfig(use_distributed_optimizer=False),
             ddp=None,
@@ -948,12 +945,12 @@ def _register_converted_checkpoint_pre_wrap_hook(
         _log("converted MegatronMIMO checkpoint loaded before DDP wrap")
         return model_list
 
-    model_provider.register_pre_wrap_hook(_load_converted_checkpoint)
+    model_config.pre_wrap_hooks.append(_load_converted_checkpoint)
 
 
 def _build_config(
     *,
-    model_provider: MegatronMIMOProvider,
+    model_config: MegatronMIMOModelConfig,
     data_provider: HFConversationDatasetProvider,
     args: argparse.Namespace,
 ) -> ConfigContainer:
@@ -1008,7 +1005,7 @@ def _build_config(
             manual_gc_interval=100,
             manual_gc_eval=100,
         ),
-        model=model_provider,
+        model=model_config,
         optimizer=optimizer_cfg,
         scheduler=scheduler_cfg,
         dataset=data_provider,
@@ -1196,9 +1193,9 @@ def main() -> None:
         for summary in _validate_mimo_batch_sizes(parallelism_config, args):
             _log(f"batch contract: global_mbs={args.micro_batch_size}, {summary}")
 
-        _log("building Qwen3.5-VL MegatronMIMO provider")
-        model_provider = _build_mimo_provider(hf_config, parallelism_config, args)
-        _register_converted_checkpoint_pre_wrap_hook(model_provider, args.pretrained_checkpoint)
+        _log("building Qwen3.5-VL MegatronMIMO model config")
+        model_config = _build_mimo_model_config(hf_config, parallelism_config, args)
+        _register_converted_checkpoint_pre_wrap_hook(model_config, args.pretrained_checkpoint)
 
         _log(f"building HF conversation data provider: maker={args.dataset_maker}")
         data_provider = _build_data_provider(args)
@@ -1206,7 +1203,7 @@ def main() -> None:
         _log(f"pretrained checkpoint: {args.pretrained_checkpoint}")
         _log(f"checkpoint dir: {args.checkpoint_dir}")
         _log("building training config")
-        cfg = _build_config(model_provider=model_provider, data_provider=data_provider, args=args)
+        cfg = _build_config(model_config=model_config, data_provider=data_provider, args=args)
 
         _log("launching pretrain_megatron_mimo")
         pretrain_megatron_mimo(

--- a/src/megatron/bridge/data/loaders.py
+++ b/src/megatron/bridge/data/loaders.py
@@ -200,6 +200,7 @@ def build_train_valid_test_data_loaders(
     train_state: TrainState,
     build_train_valid_test_datasets_provider: Callable,
     dp_group: torch.distributed.ProcessGroup,
+    mimo_grids: Optional[dict] = None,
 ) -> tuple[Optional[DataLoader], Optional[DataLoader], Optional[DataLoader]]:
     """Build train, validation, and test data loaders.
 
@@ -210,6 +211,8 @@ def build_train_valid_test_data_loaders(
         cfg: The main configuration container.
         train_state: The current training state.
         build_train_valid_test_datasets_provider: A function to build the datasets.
+        mimo_grids: Runtime process grids from ``MegatronMIMOInfra`` when
+            ``cfg.model`` is a pure ``MegatronMIMOModelConfig``.
 
     Returns:
         A tuple (train_dataloader, valid_dataloader, test_dataloader).
@@ -217,8 +220,9 @@ def build_train_valid_test_data_loaders(
     # Check for MegatronMIMO path
     from megatron.bridge.data.megatron_mimo.base_provider import MegatronMIMODatasetProvider
     from megatron.bridge.models.megatron_mimo.megatron_mimo_provider import MegatronMIMOProvider
+    from megatron.bridge.models.megatron_mimo.model_config import MegatronMIMOModelConfig
 
-    if isinstance(cfg.model, MegatronMIMOProvider):
+    if isinstance(cfg.model, (MegatronMIMOModelConfig, MegatronMIMOProvider)):
         if not isinstance(cfg.dataset, MegatronMIMODatasetProvider):
             raise ValueError(
                 "MegatronMIMO models require cfg.dataset to be a MegatronMIMODatasetProvider. "
@@ -234,6 +238,7 @@ def build_train_valid_test_data_loaders(
             train_samples=train_samples,
             valid_samples=valid_samples,
             test_samples=test_samples,
+            grids=mimo_grids,
         )
 
         # Sync train_state flags across all ranks.
@@ -385,6 +390,7 @@ def build_train_valid_test_data_iterators(
     train_state: TrainState,
     build_train_valid_test_datasets_provider: Callable,
     dp_group: torch.distributed.ProcessGroup,
+    mimo_grids: Optional[dict] = None,
 ) -> tuple[Optional[RerunDataIterator], Optional[RerunDataIterator], Optional[RerunDataIterator]]:
     """Build train, validation, and test data iterators.
 
@@ -406,6 +412,7 @@ def build_train_valid_test_data_iterators(
         train_state=train_state,
         build_train_valid_test_datasets_provider=build_train_valid_test_datasets_provider,
         dp_group=dp_group,
+        mimo_grids=mimo_grids,
     )
 
     # Build iterators.
@@ -454,6 +461,7 @@ def setup_data_iterators(
     model_length: int,
     train_valid_test_datasets_provider: Callable,
     dp_group: torch.distributed.ProcessGroup,
+    mimo_grids: Optional[dict] = None,
 ) -> tuple[
     Union[Optional[RerunDataIterator], list[Optional[RerunDataIterator]]],
     Union[Optional[RerunDataIterator], list[Optional[RerunDataIterator]]],
@@ -481,6 +489,7 @@ def setup_data_iterators(
         train_state=train_state,
         build_train_valid_test_datasets_provider=train_valid_test_datasets_provider,
         dp_group=dp_group,
+        mimo_grids=mimo_grids,
     )
 
     return train_data_iterator, valid_data_iterator, test_data_iterator

--- a/src/megatron/bridge/data/megatron_mimo/loaders.py
+++ b/src/megatron/bridge/data/megatron_mimo/loaders.py
@@ -25,6 +25,7 @@ def build_megatron_mimo_data_loaders(
     train_samples: int,
     valid_samples: int,
     test_samples: int,
+    grids: Optional[dict] = None,
 ) -> Tuple[Optional[DataLoader], Optional[DataLoader], Optional[DataLoader]]:
     """Build MegatronMIMO data loaders with globally consistent sampling.
 
@@ -35,20 +36,24 @@ def build_megatron_mimo_data_loaders(
     Only ranks that need data (first/last PP stage) will get non-None loaders.
 
     Args:
-        cfg: Configuration container with MegatronMIMOProvider as cfg.model.
+        cfg: Configuration container with MegatronMIMOModelConfig or the legacy
+            MegatronMIMOProvider as cfg.model.
         train_state: Current training state.
         megatron_mimo_provider: MegatronMIMO dataset provider (e.g., MockMegatronMIMOProvider)
             with get_collate_fn() method.
         train_samples: Number of training samples.
         valid_samples: Number of validation samples.
         test_samples: Number of test samples.
+        grids: Process grids from the constructed MegatronMIMO infrastructure.
+            Legacy providers may instead expose these through ``_grids``.
 
     Returns:
         Tuple of (train_loader, valid_loader, test_loader).
         Returns (None, None, None) if this rank doesn't need data.
 
     Raises:
-        ValueError: If cfg.model is not MegatronMIMOProvider or megatron_mimo_parallelism_config is None.
+        ValueError: If cfg.model is not a supported MegatronMIMO config, its
+            parallelism config is missing, or no process grids are available.
 
     Example:
         >>> from megatron.bridge.data.megatron_mimo import MockMegatronMIMOProvider, build_megatron_mimo_data_loaders
@@ -65,16 +70,18 @@ def build_megatron_mimo_data_loaders(
         ... )
     """
     from megatron.bridge.models.megatron_mimo.megatron_mimo_provider import MegatronMIMOProvider
+    from megatron.bridge.models.megatron_mimo.model_config import MegatronMIMOModelConfig
 
-    if not isinstance(cfg.model, MegatronMIMOProvider):
-        raise ValueError("cfg.model must be MegatronMIMOProvider for MegatronMIMO data loading.")
+    if not isinstance(cfg.model, (MegatronMIMOModelConfig, MegatronMIMOProvider)):
+        raise ValueError("cfg.model must be a MegatronMIMO model config for data loading.")
 
     if cfg.model.megatron_mimo_parallelism_config is None:
         raise ValueError("megatron_mimo_parallelism_config must be set for MegatronMIMO data loading.")
 
-    if cfg.model._grids is None:
+    grids = grids or getattr(cfg.model, "_grids", None)
+    if grids is None:
         raise ValueError(
-            "MegatronMIMOProvider._grids is None. Ensure build_model() is called before building data loaders."
+            "MegatronMIMO grids are required. Pass grids from MegatronMIMOInfra after model construction."
         )
 
     # Validate that micro_batch_size is divisible by every module's DP size.
@@ -91,9 +98,6 @@ def build_megatron_mimo_data_loaders(
             )
 
     print_rank_0("> building MegatronMIMO train, validation, and test datasets ...")
-
-    # Use cached grids from build_model()
-    grids = cfg.model._grids
 
     sampler_dp_rank, sampler_dp_size, needs_data = get_megatron_mimo_sampling_info(
         cfg.model.megatron_mimo_parallelism_config, grids

--- a/src/megatron/bridge/models/megatron_mimo/__init__.py
+++ b/src/megatron/bridge/models/megatron_mimo/__init__.py
@@ -1,14 +1,14 @@
 # Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 
 from megatron.bridge.models.megatron_mimo.build_model import build_megatron_mimo_model
-from megatron.bridge.models.megatron_mimo.llava_provider import LlavaMegatronMIMOProvider
+from megatron.bridge.models.megatron_mimo.infra import MegatronMIMOInfra
 from megatron.bridge.models.megatron_mimo.megatron_mimo_config import (
     MegatronMIMOParallelismConfig,
     ModuleParallelismConfig,
 )
-from megatron.bridge.models.megatron_mimo.megatron_mimo_provider import (
-    MegatronMIMOInfra,
-    MegatronMIMOProvider,
+from megatron.bridge.models.megatron_mimo.model_config import (
+    MegatronMIMOModelBuilder,
+    MegatronMIMOModelConfig,
 )
 
 
@@ -17,6 +17,14 @@ def __getattr__(name: str):
         from megatron.bridge.models.megatron_mimo.conversion import MegatronMIMOBridge
 
         return MegatronMIMOBridge
+    if name == "LlavaMegatronMIMOProvider":
+        from megatron.bridge.models.megatron_mimo.llava_provider import LlavaMegatronMIMOProvider
+
+        return LlavaMegatronMIMOProvider
+    if name == "MegatronMIMOProvider":
+        from megatron.bridge.models.megatron_mimo import megatron_mimo_provider
+
+        return getattr(megatron_mimo_provider, name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
@@ -26,6 +34,8 @@ __all__ = [
     "MegatronMIMOInfra",
     "MegatronMIMOProvider",
     "MegatronMIMOParallelismConfig",
+    "MegatronMIMOModelBuilder",
+    "MegatronMIMOModelConfig",
     "ModuleParallelismConfig",
     "build_megatron_mimo_model",
 ]

--- a/src/megatron/bridge/models/megatron_mimo/build_model.py
+++ b/src/megatron/bridge/models/megatron_mimo/build_model.py
@@ -22,17 +22,16 @@ if TYPE_CHECKING:
     from megatron.core.distributed import DistributedDataParallelConfig
     from megatron.core.models.mimo import MimoModel
 
-    from megatron.bridge.models.megatron_mimo.megatron_mimo_provider import (
-        MegatronMIMOInfra,
-        MegatronMIMOProvider,
-    )
+    from megatron.bridge.models.megatron_mimo.infra import MegatronMIMOInfra
+    from megatron.bridge.models.megatron_mimo.megatron_mimo_provider import MegatronMIMOProvider
+    from megatron.bridge.models.megatron_mimo.model_config import MegatronMIMOModelConfig
 
 
 logger = logging.getLogger(__name__)
 
 
 def build_megatron_mimo_model(
-    provider: "MegatronMIMOProvider",
+    model_config: "MegatronMIMOModelConfig | MegatronMIMOProvider",
     *,
     ddp_config: Optional["DistributedDataParallelConfig"] = None,
     fp16: bool = False,
@@ -46,13 +45,20 @@ def build_megatron_mimo_model(
     Side effects: initialises Python/NumPy/torch/Megatron-Core RNG and sets
     ``parallel_state._*_GROUP`` globals from the rank-local pg_collection.
     """
+    from megatron.bridge.models.megatron_mimo.model_config import MegatronMIMOModelConfig
     from megatron.bridge.training.megatron_mimo_parallel_utils import (
         get_active_module_pg,
         validate_no_stub_ranks,
     )
 
-    if provider.megatron_mimo_parallelism_config is None:
-        raise ValueError("build_megatron_mimo_model requires provider.megatron_mimo_parallelism_config to be set.")
+    if isinstance(model_config, MegatronMIMOModelConfig):
+        builder = model_config.get_builder_cls()(model_config)
+        parallelism_config = model_config.megatron_mimo_parallelism_config
+    else:
+        builder = None
+        parallelism_config = model_config.megatron_mimo_parallelism_config
+    if parallelism_config is None:
+        raise ValueError("build_megatron_mimo_model requires heterogeneous parallelism config.")
 
     if not dist.is_initialized():
         raise RuntimeError(
@@ -61,8 +67,12 @@ def build_megatron_mimo_model(
         )
 
     logger.info("Rank %d: Building MIMO infra", dist.get_rank())
-    provider.finalize()
-    infra = provider.build_infra()
+    if builder is not None:
+        builder.finalize()
+        infra = builder.build_infra()
+    else:
+        model_config.finalize()
+        infra = model_config.build_infra()
 
     world_size = dist.get_world_size()
     validate_no_stub_ranks(infra.module_to_grid_map, world_size)
@@ -70,13 +80,23 @@ def build_megatron_mimo_model(
     _set_per_module_random_seeds(infra, seed=seed)
 
     logger.info("Rank %d: Building distributed MIMO model", dist.get_rank())
-    model_list = provider.provide_distributed_model(
-        ddp_config=ddp_config,
-        fp16=fp16,
-        bf16=bf16,
-        wrap_with_ddp=wrap_with_ddp,
-        data_parallel_random_init=data_parallel_random_init,
-    )
+    if builder is not None:
+        model_list = builder.build_distributed_models(
+            ddp_config=ddp_config,
+            fp16=fp16,
+            bf16=bf16,
+            wrap_with_ddp=wrap_with_ddp,
+            data_parallel_random_init=data_parallel_random_init,
+            infra=infra,
+        )
+    else:
+        model_list = model_config.provide_distributed_model(
+            ddp_config=ddp_config,
+            fp16=fp16,
+            bf16=bf16,
+            wrap_with_ddp=wrap_with_ddp,
+            data_parallel_random_init=data_parallel_random_init,
+        )
     mimo_model = model_list[0]
 
     active_module_name, local_pg_collection = get_active_module_pg(infra)

--- a/src/megatron/bridge/models/megatron_mimo/build_model.py
+++ b/src/megatron/bridge/models/megatron_mimo/build_model.py
@@ -2,14 +2,16 @@
 """Shared model-construction entry point for MegatronMIMO.
 
 Used by both ``setup_megatron_mimo`` (training) and the conversion CLI.
-Composes ``provider.finalize`` + ``build_infra`` + per-module RNG init +
-distributed-model build + ``parallel_state`` global bridge.
+Composes config finalization, infrastructure construction, per-module RNG
+initialization, distributed model construction, and the ``parallel_state`` bridge.
+Legacy providers remain supported as a deprecated compatibility path.
 """
 
 from __future__ import annotations
 
 import logging
 import random
+import warnings
 from typing import TYPE_CHECKING, Optional
 
 import numpy as np
@@ -34,11 +36,12 @@ def build_megatron_mimo_model(
     model_config: "MegatronMIMOModelConfig | MegatronMIMOProvider",
     *,
     ddp_config: Optional["DistributedDataParallelConfig"] = None,
-    fp16: bool = False,
-    bf16: bool = True,
+    fp16: bool | None = None,
+    bf16: bool | None = None,
     seed: int = 0,
     wrap_with_ddp: bool = True,
     data_parallel_random_init: bool = True,
+    infra: Optional["MegatronMIMOInfra"] = None,
 ) -> tuple["MimoModel", "MegatronMIMOInfra"]:
     """Build a distributed MegatronMIMO model and return ``(model, infra)``.
 
@@ -55,8 +58,18 @@ def build_megatron_mimo_model(
         builder = model_config.get_builder_cls()(model_config)
         parallelism_config = model_config.megatron_mimo_parallelism_config
     else:
+        from megatron.bridge.models.megatron_mimo.megatron_mimo_provider import (
+            _suppress_provider_build_deprecation_warnings,
+        )
+
         builder = None
         parallelism_config = model_config.megatron_mimo_parallelism_config
+        warnings.warn(
+            "Passing MegatronMIMOProvider to build_megatron_mimo_model() is deprecated. "
+            "Pass MegatronMIMOModelConfig instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
     if parallelism_config is None:
         raise ValueError("build_megatron_mimo_model requires heterogeneous parallelism config.")
 
@@ -68,11 +81,19 @@ def build_megatron_mimo_model(
 
     logger.info("Rank %d: Building MIMO infra", dist.get_rank())
     if builder is not None:
-        builder.finalize()
-        infra = builder.build_infra()
+        if infra is None:
+            builder.finalize()
+            infra = builder.build_infra()
+        else:
+            builder.infra = infra
     else:
+        if infra is not None:
+            raise ValueError("Explicit infra is only supported with MegatronMIMOModelConfig.")
         model_config.finalize()
-        infra = model_config.build_infra()
+        with _suppress_provider_build_deprecation_warnings():
+            infra = model_config.build_infra()
+
+    assert infra is not None
 
     world_size = dist.get_world_size()
     validate_no_stub_ranks(infra.module_to_grid_map, world_size)
@@ -90,13 +111,14 @@ def build_megatron_mimo_model(
             infra=infra,
         )
     else:
-        model_list = model_config.provide_distributed_model(
-            ddp_config=ddp_config,
-            fp16=fp16,
-            bf16=bf16,
-            wrap_with_ddp=wrap_with_ddp,
-            data_parallel_random_init=data_parallel_random_init,
-        )
+        with model_config._reuse_infra(infra), _suppress_provider_build_deprecation_warnings():
+            model_list = model_config.provide_distributed_model(
+                ddp_config=ddp_config,
+                fp16=fp16,
+                bf16=bf16,
+                wrap_with_ddp=wrap_with_ddp,
+                data_parallel_random_init=data_parallel_random_init,
+            )
     mimo_model = model_list[0]
 
     active_module_name, local_pg_collection = get_active_module_pg(infra)

--- a/src/megatron/bridge/models/megatron_mimo/conversion/mimo_model_io.py
+++ b/src/megatron/bridge/models/megatron_mimo/conversion/mimo_model_io.py
@@ -17,8 +17,9 @@
 from __future__ import annotations
 
 import logging
+from contextlib import contextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Iterator, Optional, Union
 
 from megatron.bridge.training.checkpointing import load_checkpoint, maybe_finalize_async_save, save_checkpoint
 from megatron.bridge.training.config import CheckpointConfig, ConfigContainer, LoggerConfig, OptimizerConfig
@@ -30,11 +31,10 @@ if TYPE_CHECKING:
     from megatron.core.distributed import DistributedDataParallelConfig
     from megatron.core.models.mimo import MimoModel
 
+    from megatron.bridge.models.megatron_mimo.infra import MegatronMIMOInfra
     from megatron.bridge.models.megatron_mimo.megatron_mimo_config import MegatronMIMOParallelismConfig
-    from megatron.bridge.models.megatron_mimo.megatron_mimo_provider import (
-        MegatronMIMOInfra,
-        MegatronMIMOProvider,
-    )
+    from megatron.bridge.models.megatron_mimo.megatron_mimo_provider import MegatronMIMOProvider
+    from megatron.bridge.models.megatron_mimo.model_config import MegatronMIMOModelConfig
 
 
 logger = logging.getLogger(__name__)
@@ -43,7 +43,7 @@ logger = logging.getLogger(__name__)
 def save_megatron_mimo_model(
     model: "MimoModel",
     infra: "MegatronMIMOInfra",
-    provider: "MegatronMIMOProvider",
+    provider: "MegatronMIMOModelConfig | MegatronMIMOProvider",
     path: Union[str, Path],
     *,
     hf_tokenizer_path: Optional[Union[str, Path]] = None,
@@ -55,12 +55,14 @@ def save_megatron_mimo_model(
     Args:
         model: Constructed ``MimoModel``.
         infra: ``MegatronMIMOInfra`` from model construction.
-        provider: Provider used to reconstruct the model on load.
+        provider: Pure model config used to reconstruct the model on load, or
+            a legacy provider retained for checkpoint compatibility.
         path: Directory to save the dist-checkpoint into.
         hf_tokenizer_path: Optional HF model ID or path for tokenizer assets.
         hf_tokenizer_kwargs: Optional kwargs for ``AutoTokenizer.from_pretrained``.
         ckpt_format: Checkpoint format. Default ``"torch_dist"``.
     """
+    checkpoint_model_config = provider
     tokenizer_config = None
     if hf_tokenizer_path is not None:
         from megatron.bridge.training.tokenizers.config import TokenizerConfig
@@ -75,7 +77,7 @@ def save_megatron_mimo_model(
 
     state = GlobalState()
     state.cfg = ConfigContainer(
-        model=provider,
+        model=checkpoint_model_config,
         train=None,
         optimizer=OptimizerConfig(use_distributed_optimizer=False),
         ddp=None,
@@ -108,11 +110,7 @@ def save_megatron_mimo_model(
         ckpt_format,
     )
 
-    # Derived ModuleSpec fields don't round-trip through yaml — snapshot,
-    # clear, then restore around the save.
-    _saved_derived = _snapshot_derived_spec_fields(provider)
-    try:
-        _clear_derived_spec_fields(provider)
+    with _checkpoint_serializable_model_config(checkpoint_model_config):
         state.initialize_async_checkpoint_worker()
         save_checkpoint(
             state=state,
@@ -125,8 +123,6 @@ def save_megatron_mimo_model(
             module_name=active_module_name,
         )
         maybe_finalize_async_save(state, state.cfg.checkpoint, blocking=True, terminate=True)
-    finally:
-        _restore_derived_spec_fields(provider, _saved_derived)
 
     if tokenizer_config is not None:
         from megatron.bridge.training.checkpointing import get_checkpoint_name, save_tokenizer_assets
@@ -146,7 +142,7 @@ def load_megatron_mimo_model(
     bf16: bool = True,
     wrap_with_ddp: bool = False,
     data_parallel_random_init: bool = False,
-) -> tuple["MimoModel", "MegatronMIMOInfra", "MegatronMIMOProvider"]:
+) -> tuple["MimoModel", "MegatronMIMOInfra", "MegatronMIMOModelConfig"]:
     """Load a MegatronMIMO model from a Megatron distributed-checkpoint.
 
     Args:
@@ -158,16 +154,16 @@ def load_megatron_mimo_model(
         data_parallel_random_init: Forwarded to ``build_megatron_mimo_model``.
 
     Returns:
-        ``(mimo_model, infra, provider)``.
+        ``(mimo_model, infra, model_config)``.
     """
     from megatron.bridge.training.model_load_save import load_model_config
 
     iter_path = _resolve_iter_folder(Path(path))
 
-    provider, _mlm_args = load_model_config(str(iter_path))
+    model_config, _mlm_args = load_model_config(str(iter_path))
 
     if parallelism_config is not None:
-        provider.megatron_mimo_parallelism_config = parallelism_config
+        model_config.megatron_mimo_parallelism_config = parallelism_config
 
     logger.info(
         "load_megatron_mimo_model: loading from %s (resolved iter=%s)",
@@ -178,7 +174,7 @@ def load_megatron_mimo_model(
     from megatron.bridge.models.megatron_mimo import build_megatron_mimo_model
 
     mimo_model, infra = build_megatron_mimo_model(
-        provider,
+        model_config,
         ddp_config=ddp_config,
         fp16=fp16,
         bf16=bf16,
@@ -190,7 +186,7 @@ def load_megatron_mimo_model(
 
     state = GlobalState()
     state.cfg = ConfigContainer(
-        model=provider,
+        model=model_config,
         train=None,
         optimizer=OptimizerConfig(use_distributed_optimizer=False),
         ddp=None,
@@ -236,11 +232,35 @@ def load_megatron_mimo_model(
         module_name=active_module_name,
     )
 
-    return mimo_model, infra, provider
+    return mimo_model, infra, model_config
+
+
+@contextmanager
+def _checkpoint_serializable_model_config(
+    model_config: "MegatronMIMOModelConfig | MegatronMIMOProvider",
+) -> Iterator[None]:
+    """Temporarily clear runtime-only fields from legacy providers.
+
+    Pure model configs contain only serializable construction inputs and require
+    no mutation. Legacy providers cache derived module specs and process grids,
+    which must be omitted from the YAML run config and restored after saving.
+    """
+    from megatron.bridge.models.megatron_mimo.megatron_mimo_provider import MegatronMIMOProvider
+
+    if not isinstance(model_config, MegatronMIMOProvider):
+        yield
+        return
+
+    saved = _snapshot_derived_spec_fields(model_config)
+    try:
+        _clear_derived_spec_fields(model_config)
+        yield
+    finally:
+        _restore_derived_spec_fields(model_config, saved)
 
 
 def _snapshot_derived_spec_fields(provider: "MegatronMIMOProvider") -> dict:
-    """Capture the provider's runtime-derived spec fields for restoration."""
+    """Capture a legacy provider's runtime-derived fields for restoration."""
     return {
         "language_model_spec": provider.language_model_spec,
         "modality_submodules_spec": provider.modality_submodules_spec,
@@ -250,7 +270,7 @@ def _snapshot_derived_spec_fields(provider: "MegatronMIMOProvider") -> dict:
 
 
 def _clear_derived_spec_fields(provider: "MegatronMIMOProvider") -> None:
-    """Reset derived spec fields so yaml serialisation captures only inputs."""
+    """Reset legacy runtime fields before YAML serialization."""
     provider.language_model_spec = None
     provider.modality_submodules_spec = {}
     provider.special_token_ids = {}
@@ -258,7 +278,7 @@ def _clear_derived_spec_fields(provider: "MegatronMIMOProvider") -> None:
 
 
 def _restore_derived_spec_fields(provider: "MegatronMIMOProvider", saved: dict) -> None:
-    """Restore derived spec fields after a save, leaving the provider usable."""
+    """Restore legacy runtime fields after checkpoint serialization."""
     provider.language_model_spec = saved["language_model_spec"]
     provider.modality_submodules_spec = saved["modality_submodules_spec"]
     provider.special_token_ids = saved["special_token_ids"]

--- a/src/megatron/bridge/models/megatron_mimo/conversion/mimo_model_io.py
+++ b/src/megatron/bridge/models/megatron_mimo/conversion/mimo_model_io.py
@@ -138,8 +138,8 @@ def load_megatron_mimo_model(
     *,
     parallelism_config: Optional["MegatronMIMOParallelismConfig"] = None,
     ddp_config: Optional["DistributedDataParallelConfig"] = None,
-    fp16: bool = False,
-    bf16: bool = True,
+    fp16: bool | None = None,
+    bf16: bool | None = None,
     wrap_with_ddp: bool = False,
     data_parallel_random_init: bool = False,
 ) -> tuple["MimoModel", "MegatronMIMOInfra", "MegatronMIMOModelConfig"]:
@@ -149,7 +149,8 @@ def load_megatron_mimo_model(
         path: Checkpoint parent directory or an ``iter_*`` directory.
         parallelism_config: Optional per-component parallelism override.
         ddp_config: DDP config forwarded to ``build_megatron_mimo_model``.
-        fp16 / bf16: Precision flags forwarded to model construction.
+        fp16 / bf16: Optional precision overrides forwarded to model construction.
+            When omitted, the serialized model config controls precision.
         wrap_with_ddp: Whether to DDP-wrap.
         data_parallel_random_init: Forwarded to ``build_megatron_mimo_model``.
 

--- a/src/megatron/bridge/models/megatron_mimo/conversion/orchestrator.py
+++ b/src/megatron/bridge/models/megatron_mimo/conversion/orchestrator.py
@@ -20,6 +20,7 @@ import contextlib
 import copy
 import logging
 import types
+import warnings
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Iterable, Iterator, Optional, Union
@@ -337,7 +338,6 @@ class MegatronMIMOBridge(AutoBridge):
         self.parallelism_config = parallelism_config
         self._source_bridge_override = source_bridge
         self._mimo_provider: Optional["MegatronMIMOProvider"] = None
-        self._mimo_model_config: Optional["MegatronMIMOModelConfig"] = None
         self._routes: Optional[list[MIMOComponent]] = None
         self._infra: Optional["MegatronMIMOInfra"] = None
 
@@ -389,7 +389,7 @@ class MegatronMIMOBridge(AutoBridge):
     def routes(self) -> list[MIMOComponent]:
         """Return the route table resolved for this source bridge."""
         if self._routes is None:
-            self.to_megatron_model_config(load_weights=False)
+            self.get_model_config()
         assert self._routes is not None
         return self._routes
 
@@ -407,44 +407,131 @@ class MegatronMIMOBridge(AutoBridge):
         hf_path: str | Path | None = None,
     ) -> "MegatronMIMOProvider":
         """Build the deprecated compatibility provider for this HF source."""
+        warnings.warn(
+            "MegatronMIMOBridge.to_megatron_mimo_provider() is deprecated. Use get_model_config(), "
+            "apply overrides, and call get_megatron_model() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if hf_path is not None:
             raise NotImplementedError("MegatronMIMOBridge.to_megatron_mimo_provider does not support hf_path yet.")
         if load_weights:
-            raise NotImplementedError("Use to_megatron_model(load_weights=True) for MegatronMIMO weight loading.")
+            raise NotImplementedError("Use get_megatron_model(load_weights=True) for MegatronMIMO weight loading.")
 
         if self._mimo_provider is not None and self._routes is not None:
             return self._mimo_provider
 
         source_bridge = self._model_bridge
-        provider = _build_default_mimo_provider(source_bridge, self.hf_pretrained, self.parallelism_config)
+        provider = _build_default_mimo_provider(source_bridge, self._provider_bridge_input, self.parallelism_config)
         if self._routes is None:
-            self.to_megatron_model_config(load_weights=False)
+            current_config = self._model_config
+            self.get_model_config()
+            self._model_config = current_config
         self._mimo_provider = provider
+        self._model_config = provider
         return provider
+
+    def get_model_config(self) -> "MegatronMIMOModelConfig":
+        """Resolve and register the pure MIMO model config and conversion routes."""
+        source_bridge = self._model_bridge
+        conversion_spec = get_mimo_conversion_spec(type(source_bridge))
+        model_config, routes = conversion_spec(source_bridge, self._provider_bridge_input, self.parallelism_config)
+        validate_route_table(routes, parallelism_config=self.parallelism_config)
+        self._model_config = model_config
+        self._routes = routes
+        return model_config
 
     def to_megatron_model_config(
         self,
         load_weights: bool = False,
         hf_path: str | Path | None = None,
     ) -> "MegatronMIMOModelConfig":
-        """Resolve and cache the pure MIMO model config and conversion routes."""
+        """Deprecated alias for :meth:`get_model_config`."""
+        warnings.warn(
+            "MegatronMIMOBridge.to_megatron_model_config() is deprecated. Use get_model_config() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if hf_path is not None:
             raise NotImplementedError("MegatronMIMO model config does not support hf_path yet.")
         if load_weights:
             raise NotImplementedError("MIMO weights are loaded after heterogeneous model construction.")
-        if self._mimo_model_config is not None and self._routes is not None:
-            return self._mimo_model_config
-        source_bridge = self._model_bridge
-        conversion_spec = get_mimo_conversion_spec(type(source_bridge))
-        model_config, routes = conversion_spec(source_bridge, self.hf_pretrained, self.parallelism_config)
-        validate_route_table(routes, parallelism_config=self.parallelism_config)
-        self._mimo_model_config = model_config
-        self._routes = routes
-        return model_config
+        return self.get_model_config()
 
     def validate_mimo_conversion_support(self) -> None:
         """Validate MIMO conversion support by resolving its pure model config."""
-        self.to_megatron_model_config(load_weights=False)
+        self.get_model_config()
+
+    def get_megatron_model(
+        self,
+        model_config: Optional["MegatronMIMOModelConfig"] = None,
+        *,
+        load_weights: bool = True,
+        hf_path: str | Path | None = None,
+        **kwargs,
+    ) -> list[MegatronModule]:
+        """Build MIMO and load routed HF weights before distributed wrapping."""
+        from megatron.bridge.models.megatron_mimo.model_config import MegatronMIMOModelConfig
+
+        current_config = self._model_config
+        if model_config is None:
+            if isinstance(current_config, MegatronMIMOModelConfig):
+                model_config = current_config
+            else:
+                model_config = self.get_model_config()
+                self._model_config = current_config
+
+        if self._routes is None:
+            source_bridge = self._model_bridge
+            conversion_spec = get_mimo_conversion_spec(type(source_bridge))
+            _, routes = conversion_spec(source_bridge, self._provider_bridge_input, self.parallelism_config)
+            validate_route_table(routes, parallelism_config=self.parallelism_config)
+            self._routes = routes
+
+        builder = model_config.get_builder_cls()(model_config)
+        builder.finalize()
+        infra = builder.build_infra()
+        original_hooks = model_config.pre_wrap_hooks
+        original_hook_values = list(original_hooks)
+        source_transformer = getattr(model_config.source_model_config, "transformer", None)
+        original_perform_initialization = (
+            source_transformer.perform_initialization if source_transformer is not None else None
+        )
+
+        try:
+            if load_weights:
+                hf_pretrained = self._resolve_hf_pretrained(hf_path)
+                if source_transformer is not None:
+                    source_transformer.perform_initialization = False
+
+                def _load_weights(models: list[MegatronModule]) -> list[MegatronModule]:
+                    import_hf_to_megatron_mimo(
+                        source_bridge=self._model_bridge,
+                        hf_pretrained=hf_pretrained,
+                        mimo_model=self._coerce_mimo_model(models),
+                        routes=self.routes,
+                        pg_collections=infra.pg_collections,
+                    )
+                    return models
+
+                original_hooks[:] = [_load_weights, *original_hook_values]
+
+            kwargs.setdefault("fp16", model_config.fp16)
+            kwargs.setdefault("bf16", model_config.bf16)
+            mimo_model, built_infra = self._build_mimo_model(
+                model_config,
+                infra=infra,
+                **kwargs,
+            )
+        finally:
+            if source_transformer is not None and original_perform_initialization is not None:
+                source_transformer.perform_initialization = original_perform_initialization
+            original_hooks[:] = original_hook_values
+            model_config.pre_wrap_hooks = original_hooks
+
+        self._model_config = model_config
+        self._infra = built_infra
+        return [mimo_model]
 
     def to_megatron_model(
         self,
@@ -452,12 +539,13 @@ class MegatronMIMOBridge(AutoBridge):
         hf_path: str | Path | None = None,
         **kwargs,
     ) -> list[MegatronModule]:
-        """Build a distributed MIMO model and optionally import HF weights."""
-        model_config = self.to_megatron_model_config(load_weights=False)
-        mimo_model = self.build_mimo_model(model_config=model_config, **kwargs)
-        if load_weights:
-            self.load_hf_weights(mimo_model, hf_path=hf_path)
-        return [mimo_model]
+        """Deprecated alias for :meth:`get_megatron_model`."""
+        warnings.warn(
+            "MegatronMIMOBridge.to_megatron_model() is deprecated. Use get_megatron_model() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.get_megatron_model(load_weights=load_weights, hf_path=hf_path, **kwargs)
 
     def build_mimo_model(
         self,
@@ -465,8 +553,8 @@ class MegatronMIMOBridge(AutoBridge):
         model_config: Optional["MegatronMIMOModelConfig"] = None,
         mimo_provider: Optional["MegatronMIMOProvider"] = None,
         ddp_config: Optional["DistributedDataParallelConfig"] = None,
-        fp16: bool = False,
-        bf16: bool = True,
+        fp16: bool | None = None,
+        bf16: bool | None = None,
         seed: int = 0,
         wrap_with_ddp: bool = True,
         data_parallel_random_init: bool = True,
@@ -476,30 +564,84 @@ class MegatronMIMOBridge(AutoBridge):
         ``mimo_provider`` is a deprecated compatibility alias for callers that
         still construct the legacy provider directly.
         """
-        from megatron.bridge.models.megatron_mimo import build_megatron_mimo_model
+        from megatron.bridge.models.megatron_mimo.model_config import MegatronMIMOModelConfig
 
         if model_config is not None and mimo_provider is not None:
             raise ValueError("model_config and mimo_provider are mutually exclusive.")
+        if mimo_provider is not None:
+            warnings.warn(
+                "build_mimo_model(mimo_provider=...) is deprecated. Pass model_config or call "
+                "get_megatron_model() instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         build_config = model_config if model_config is not None else mimo_provider
         if build_config is None:
-            model_config = self.to_megatron_model_config(load_weights=False)
+            current_config = self._model_config
+            if isinstance(current_config, MegatronMIMOModelConfig):
+                model_config = current_config
+            else:
+                model_config = self.get_model_config()
             build_config = model_config
-        mimo_model, infra = build_megatron_mimo_model(
-            build_config,
+        if mimo_provider is not None:
+            with warnings.catch_warnings():
+                warnings.filterwarnings(
+                    "ignore",
+                    message=r"^Passing MegatronMIMOProvider to build_megatron_mimo_model\(\) is deprecated\.",
+                    category=DeprecationWarning,
+                )
+                mimo_model, infra = self._build_mimo_model(
+                    build_config,
+                    ddp_config=ddp_config,
+                    fp16=fp16,
+                    bf16=bf16,
+                    seed=seed,
+                    wrap_with_ddp=wrap_with_ddp,
+                    data_parallel_random_init=data_parallel_random_init,
+                )
+        else:
+            mimo_model, infra = self._build_mimo_model(
+                build_config,
+                ddp_config=ddp_config,
+                fp16=fp16,
+                bf16=bf16,
+                seed=seed,
+                wrap_with_ddp=wrap_with_ddp,
+                data_parallel_random_init=data_parallel_random_init,
+            )
+        if mimo_provider is not None:
+            self._mimo_provider = mimo_provider
+            self._model_config = mimo_provider
+        else:
+            assert model_config is not None
+            self._model_config = model_config
+        self._infra = infra
+        return mimo_model
+
+    @staticmethod
+    def _build_mimo_model(
+        model_config: "MegatronMIMOModelConfig | MegatronMIMOProvider",
+        *,
+        ddp_config: Optional["DistributedDataParallelConfig"] = None,
+        fp16: bool | None = None,
+        bf16: bool | None = None,
+        seed: int = 0,
+        wrap_with_ddp: bool = True,
+        data_parallel_random_init: bool = True,
+        infra: Optional["MegatronMIMOInfra"] = None,
+    ) -> tuple["MimoModel", "MegatronMIMOInfra"]:
+        from megatron.bridge.models.megatron_mimo import build_megatron_mimo_model
+
+        return build_megatron_mimo_model(
+            model_config,
             ddp_config=ddp_config,
             fp16=fp16,
             bf16=bf16,
             seed=seed,
             wrap_with_ddp=wrap_with_ddp,
             data_parallel_random_init=data_parallel_random_init,
+            infra=infra,
         )
-        if mimo_provider is not None:
-            self._mimo_provider = mimo_provider
-        else:
-            assert model_config is not None
-            self._mimo_model_config = model_config
-        self._infra = infra
-        return mimo_model
 
     def load_hf_weights(
         self,
@@ -618,11 +760,23 @@ class MegatronMIMOBridge(AutoBridge):
             raise NotImplementedError("MegatronMIMO checkpoint save does not support low_memory_save.")
         if model_config is not None and mimo_provider is not None:
             raise ValueError("model_config and mimo_provider are mutually exclusive.")
+        if mimo_provider is not None:
+            warnings.warn(
+                "save_megatron_model(mimo_provider=...) is deprecated. Pass model_config or rely on the "
+                "bridge's current config instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         mimo_model = self._coerce_mimo_model(model)
         infra = self._require_infra(infra)
         checkpoint_config = model_config if model_config is not None else mimo_provider
         if checkpoint_config is None:
-            checkpoint_config = self._mimo_model_config or self._require_provider()
+            checkpoint_config = self._model_config
+        if checkpoint_config is None:
+            raise ValueError(
+                "No MegatronMIMO model config is registered. Call get_model_config(), get_megatron_model(), "
+                "or load_megatron_model() first, or pass model_config explicitly."
+            )
         save_megatron_mimo_model(
             mimo_model,
             infra,
@@ -638,8 +792,8 @@ class MegatronMIMOBridge(AutoBridge):
         *,
         parallelism_config: Optional["MegatronMIMOParallelismConfig"] = None,
         ddp_config: Optional["DistributedDataParallelConfig"] = None,
-        fp16: bool = False,
-        bf16: bool = True,
+        fp16: bool | None = None,
+        bf16: bool | None = None,
         wrap_with_ddp: bool = False,
         data_parallel_random_init: bool = False,
     ) -> "MimoModel":
@@ -655,7 +809,7 @@ class MegatronMIMOBridge(AutoBridge):
             wrap_with_ddp=wrap_with_ddp,
             data_parallel_random_init=data_parallel_random_init,
         )
-        self._mimo_model_config = model_config
+        self._model_config = model_config
         self._infra = infra
         return mimo_model
 
@@ -667,7 +821,7 @@ class MegatronMIMOBridge(AutoBridge):
         hf_tokenizer_kwargs: Optional[dict] = None,
     ) -> None:
         """Import HF weights and write a MegatronMIMO checkpoint."""
-        model = self.to_megatron_model(
+        model = self.get_megatron_model(
             load_weights=True,
             wrap_with_ddp=False,
             data_parallel_random_init=False,
@@ -729,9 +883,11 @@ class MegatronMIMOBridge(AutoBridge):
         return self._mimo_provider
 
     def _require_model_config(self) -> "MegatronMIMOModelConfig":
-        if self._mimo_model_config is None:
+        from megatron.bridge.models.megatron_mimo.model_config import MegatronMIMOModelConfig
+
+        if not isinstance(self._model_config, MegatronMIMOModelConfig):
             raise ValueError("MegatronMIMO model config is required. Build or resolve the model first.")
-        return self._mimo_model_config
+        return self._model_config
 
     @staticmethod
     def _coerce_mimo_model(model: "MimoModel" | list["MimoModel"]) -> "MimoModel":

--- a/src/megatron/bridge/models/megatron_mimo/conversion/orchestrator.py
+++ b/src/megatron/bridge/models/megatron_mimo/conversion/orchestrator.py
@@ -43,11 +43,12 @@ if TYPE_CHECKING:
 
     from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge, WeightConversionTask
     from megatron.bridge.models.conversion.param_mapping import MegatronParamMapping
+    from megatron.bridge.models.megatron_mimo.infra import MegatronMIMOInfra
     from megatron.bridge.models.megatron_mimo.megatron_mimo_config import MegatronMIMOParallelismConfig
     from megatron.bridge.models.megatron_mimo.megatron_mimo_provider import (
-        MegatronMIMOInfra,
         MegatronMIMOProvider,
     )
+    from megatron.bridge.models.megatron_mimo.model_config import MegatronMIMOModelConfig
 
 
 logger = logging.getLogger(__name__)
@@ -140,7 +141,7 @@ def _check_no_prefix_overlap(routes: list[MIMOComponent]) -> None:
 
 MIMOConversionSpecBuilder = Callable[
     ["MegatronModelBridge", Any, "MegatronMIMOParallelismConfig"],
-    tuple[Any, list[MIMOComponent]],
+    tuple["MegatronMIMOModelConfig", list[MIMOComponent]],
 ]
 
 
@@ -190,24 +191,40 @@ def _build_default_mimo_conversion_spec(
     source_bridge: "MegatronModelBridge",
     hf_pretrained: Any,
     parallelism_config: "MegatronMIMOParallelismConfig",
-) -> tuple["MegatronMIMOProvider", list[MIMOComponent]]:
-    """Build MIMO provider/routes from standard bridge/provider metadata."""
-    mimo_provider = _build_default_mimo_provider(source_bridge, hf_pretrained, parallelism_config)
-    standard_provider = mimo_provider.standard_provider
-    if standard_provider is None:
-        raise TypeError("Default MIMO conversion requires a standard_provider.")
-    return mimo_provider, _build_default_mimo_routes(source_bridge, standard_provider)
+) -> tuple["MegatronMIMOModelConfig", list[MIMOComponent]]:
+    """Build pure MIMO config/routes from the source bridge model config."""
+    from megatron.bridge.models.megatron_mimo.model_config import MegatronMIMOModelConfig
+
+    source_model_config = source_bridge.model_config_bridge(hf_pretrained)
+    modality_keys = getattr(source_bridge, "mimo_modality_keys", None)
+    language_spec_builder = getattr(source_bridge, "mimo_language_spec_builder", None)
+    modality_spec_builder = getattr(source_bridge, "mimo_modality_spec_builder", None)
+    special_token_fields = getattr(source_bridge, "mimo_special_token_fields", None)
+    if not modality_keys or not language_spec_builder or not modality_spec_builder or not special_token_fields:
+        raise TypeError("Default MIMO conversion requires source bridge MIMO modality/spec-builder metadata.")
+    special_token_ids = {
+        modality: int(getattr(source_model_config, field_name))
+        for modality, field_name in special_token_fields.items()
+    }
+    config = MegatronMIMOModelConfig(
+        source_model_config=source_model_config,
+        megatron_mimo_parallelism_config=parallelism_config,
+        language_spec_builder=language_spec_builder,
+        modality_spec_builder=modality_spec_builder,
+        modality_keys=dict(modality_keys),
+        special_token_ids=special_token_ids,
+    )
+    return config, _build_default_mimo_routes(source_bridge, config.modality_keys)
 
 
-def _build_default_mimo_routes(source_bridge: "MegatronModelBridge", standard_provider: object) -> list[MIMOComponent]:
+def _build_default_mimo_routes(
+    source_bridge: "MegatronModelBridge", modality_keys: dict[str, str]
+) -> list[MIMOComponent]:
     from megatron.core.models.mimo.config.role import MIMO_LANGUAGE_MODULE_KEY
 
     source_prefixes = getattr(source_bridge, "mimo_source_prefixes", None)
-    modality_keys = getattr(standard_provider, "modality_keys", None)
     if source_prefixes is None or modality_keys is None:
-        raise TypeError(
-            "Default MIMO conversion requires source_bridge.mimo_source_prefixes and standard_provider.modality_keys."
-        )
+        raise TypeError("Default MIMO conversion requires source and modality route metadata.")
 
     source_prefixes = dict(source_prefixes)
     modality_keys = dict(modality_keys)
@@ -320,6 +337,7 @@ class MegatronMIMOBridge(AutoBridge):
         self.parallelism_config = parallelism_config
         self._source_bridge_override = source_bridge
         self._mimo_provider: Optional["MegatronMIMOProvider"] = None
+        self._mimo_model_config: Optional["MegatronMIMOModelConfig"] = None
         self._routes: Optional[list[MIMOComponent]] = None
         self._infra: Optional["MegatronMIMOInfra"] = None
 
@@ -371,7 +389,7 @@ class MegatronMIMOBridge(AutoBridge):
     def routes(self) -> list[MIMOComponent]:
         """Return the route table resolved for this source bridge."""
         if self._routes is None:
-            self.to_megatron_mimo_provider(load_weights=False)
+            self.to_megatron_model_config(load_weights=False)
         assert self._routes is not None
         return self._routes
 
@@ -388,7 +406,7 @@ class MegatronMIMOBridge(AutoBridge):
         load_weights: bool = False,
         hf_path: str | Path | None = None,
     ) -> "MegatronMIMOProvider":
-        """Build the MIMO provider and route table for this HF source."""
+        """Build the deprecated compatibility provider for this HF source."""
         if hf_path is not None:
             raise NotImplementedError("MegatronMIMOBridge.to_megatron_mimo_provider does not support hf_path yet.")
         if load_weights:
@@ -398,20 +416,35 @@ class MegatronMIMOBridge(AutoBridge):
             return self._mimo_provider
 
         source_bridge = self._model_bridge
+        provider = _build_default_mimo_provider(source_bridge, self.hf_pretrained, self.parallelism_config)
+        if self._routes is None:
+            self.to_megatron_model_config(load_weights=False)
+        self._mimo_provider = provider
+        return provider
+
+    def to_megatron_model_config(
+        self,
+        load_weights: bool = False,
+        hf_path: str | Path | None = None,
+    ) -> "MegatronMIMOModelConfig":
+        """Resolve and cache the pure MIMO model config and conversion routes."""
+        if hf_path is not None:
+            raise NotImplementedError("MegatronMIMO model config does not support hf_path yet.")
+        if load_weights:
+            raise NotImplementedError("MIMO weights are loaded after heterogeneous model construction.")
+        if self._mimo_model_config is not None and self._routes is not None:
+            return self._mimo_model_config
+        source_bridge = self._model_bridge
         conversion_spec = get_mimo_conversion_spec(type(source_bridge))
-        mimo_provider, routes = conversion_spec(source_bridge, self.hf_pretrained, self.parallelism_config)
-        validate_route_table(
-            routes,
-            parallelism_config=self.parallelism_config,
-            modality_submodules_spec=mimo_provider.modality_submodules_spec,
-        )
-        self._mimo_provider = mimo_provider
+        model_config, routes = conversion_spec(source_bridge, self.hf_pretrained, self.parallelism_config)
+        validate_route_table(routes, parallelism_config=self.parallelism_config)
+        self._mimo_model_config = model_config
         self._routes = routes
-        return mimo_provider
+        return model_config
 
     def validate_mimo_conversion_support(self) -> None:
-        """Validate MIMO conversion support by resolving the real provider and routes."""
-        self.to_megatron_mimo_provider(load_weights=False)
+        """Validate MIMO conversion support by resolving its pure model config."""
+        self.to_megatron_model_config(load_weights=False)
 
     def to_megatron_model(
         self,
@@ -420,8 +453,8 @@ class MegatronMIMOBridge(AutoBridge):
         **kwargs,
     ) -> list[MegatronModule]:
         """Build a distributed MIMO model and optionally import HF weights."""
-        mimo_provider = self.to_megatron_mimo_provider(load_weights=False)
-        mimo_model = self.build_mimo_model(mimo_provider=mimo_provider, **kwargs)
+        model_config = self.to_megatron_model_config(load_weights=False)
+        mimo_model = self.build_mimo_model(model_config=model_config, **kwargs)
         if load_weights:
             self.load_hf_weights(mimo_model, hf_path=hf_path)
         return [mimo_model]
@@ -429,6 +462,7 @@ class MegatronMIMOBridge(AutoBridge):
     def build_mimo_model(
         self,
         *,
+        model_config: Optional["MegatronMIMOModelConfig"] = None,
         mimo_provider: Optional["MegatronMIMOProvider"] = None,
         ddp_config: Optional["DistributedDataParallelConfig"] = None,
         fp16: bool = False,
@@ -437,12 +471,21 @@ class MegatronMIMOBridge(AutoBridge):
         wrap_with_ddp: bool = True,
         data_parallel_random_init: bool = True,
     ) -> "MimoModel":
-        """Build the MIMO model and cache its infrastructure."""
+        """Build the MIMO model and cache its infrastructure.
+
+        ``mimo_provider`` is a deprecated compatibility alias for callers that
+        still construct the legacy provider directly.
+        """
         from megatron.bridge.models.megatron_mimo import build_megatron_mimo_model
 
-        mimo_provider = mimo_provider or self.to_megatron_mimo_provider(load_weights=False)
+        if model_config is not None and mimo_provider is not None:
+            raise ValueError("model_config and mimo_provider are mutually exclusive.")
+        build_config = model_config if model_config is not None else mimo_provider
+        if build_config is None:
+            model_config = self.to_megatron_model_config(load_weights=False)
+            build_config = model_config
         mimo_model, infra = build_megatron_mimo_model(
-            mimo_provider,
+            build_config,
             ddp_config=ddp_config,
             fp16=fp16,
             bf16=bf16,
@@ -450,7 +493,11 @@ class MegatronMIMOBridge(AutoBridge):
             wrap_with_ddp=wrap_with_ddp,
             data_parallel_random_init=data_parallel_random_init,
         )
-        self._mimo_provider = mimo_provider
+        if mimo_provider is not None:
+            self._mimo_provider = mimo_provider
+        else:
+            assert model_config is not None
+            self._mimo_model_config = model_config
         self._infra = infra
         return mimo_model
 
@@ -557,20 +604,29 @@ class MegatronMIMOBridge(AutoBridge):
         hf_tokenizer_kwargs: Optional[dict] = None,
         *,
         infra: Optional["MegatronMIMOInfra"] = None,
+        model_config: Optional["MegatronMIMOModelConfig"] = None,
         mimo_provider: Optional["MegatronMIMOProvider"] = None,
     ) -> None:
-        """Save a MegatronMIMO checkpoint."""
+        """Save a MegatronMIMO checkpoint.
+
+        ``mimo_provider`` is a deprecated compatibility alias for callers that
+        still save checkpoints from the legacy provider path.
+        """
         from megatron.bridge.models.megatron_mimo.conversion.mimo_model_io import save_megatron_mimo_model
 
         if low_memory_save:
             raise NotImplementedError("MegatronMIMO checkpoint save does not support low_memory_save.")
+        if model_config is not None and mimo_provider is not None:
+            raise ValueError("model_config and mimo_provider are mutually exclusive.")
         mimo_model = self._coerce_mimo_model(model)
         infra = self._require_infra(infra)
-        mimo_provider = mimo_provider or self._require_provider()
+        checkpoint_config = model_config if model_config is not None else mimo_provider
+        if checkpoint_config is None:
+            checkpoint_config = self._mimo_model_config or self._require_provider()
         save_megatron_mimo_model(
             mimo_model,
             infra,
-            mimo_provider,
+            checkpoint_config,
             path,
             hf_tokenizer_path=hf_tokenizer_path,
             hf_tokenizer_kwargs=hf_tokenizer_kwargs,
@@ -587,11 +643,10 @@ class MegatronMIMOBridge(AutoBridge):
         wrap_with_ddp: bool = False,
         data_parallel_random_init: bool = False,
     ) -> "MimoModel":
-        """Load a MegatronMIMO checkpoint and cache its provider/infra."""
+        """Load a MegatronMIMO checkpoint and cache its config/infra."""
         from megatron.bridge.models.megatron_mimo.conversion.mimo_model_io import load_megatron_mimo_model
 
-        self.to_megatron_mimo_provider(load_weights=False)
-        mimo_model, infra, mimo_provider = load_megatron_mimo_model(
+        mimo_model, infra, model_config = load_megatron_mimo_model(
             path,
             parallelism_config=parallelism_config or self.parallelism_config,
             ddp_config=ddp_config,
@@ -600,7 +655,7 @@ class MegatronMIMOBridge(AutoBridge):
             wrap_with_ddp=wrap_with_ddp,
             data_parallel_random_init=data_parallel_random_init,
         )
-        self._mimo_provider = mimo_provider
+        self._mimo_model_config = model_config
         self._infra = infra
         return mimo_model
 
@@ -672,6 +727,11 @@ class MegatronMIMOBridge(AutoBridge):
         if self._mimo_provider is None:
             raise ValueError("MegatronMIMO provider is required. Call to_megatron_mimo_provider() first.")
         return self._mimo_provider
+
+    def _require_model_config(self) -> "MegatronMIMOModelConfig":
+        if self._mimo_model_config is None:
+            raise ValueError("MegatronMIMO model config is required. Build or resolve the model first.")
+        return self._mimo_model_config
 
     @staticmethod
     def _coerce_mimo_model(model: "MimoModel" | list["MimoModel"]) -> "MimoModel":

--- a/src/megatron/bridge/models/megatron_mimo/infra.py
+++ b/src/megatron/bridge/models/megatron_mimo/infra.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Provider-neutral runtime infrastructure for heterogeneous MegatronMIMO models."""
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from megatron.core.process_groups_config import ProcessGroupCollection
+
+
+if TYPE_CHECKING:
+    from megatron.core.hyper_comm_grid import HyperCommGrid
+
+
+@dataclass
+class MegatronMIMOInfra:
+    """Runtime process-group infrastructure for a heterogeneous MIMO model."""
+
+    module_to_grid_map: dict[str, "HyperCommGrid"]
+    topology: dict[str, list[str]]
+    pg_collections: dict[str, ProcessGroupCollection | None]
+    participating_modules: list[str]
+    module_output_ndim: dict[str, int] = field(default_factory=dict)
+
+
+__all__ = ["MegatronMIMOInfra"]

--- a/src/megatron/bridge/models/megatron_mimo/megatron_mimo_ddp.py
+++ b/src/megatron/bridge/models/megatron_mimo/megatron_mimo_ddp.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 """DDP wrapping utilities for MegatronMIMO models.
 
-Called from the training layer after MegatronMIMOProvider.provide().
+Called by the MegatronMIMO model builder before training.
 
 Note: This module only supports DDP wrapping. FSDP is not yet implemented.
 """

--- a/src/megatron/bridge/models/megatron_mimo/megatron_mimo_provider.py
+++ b/src/megatron/bridge/models/megatron_mimo/megatron_mimo_provider.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
-"""MegatronMIMO Model Provider for heterogeneous multi-module training.
+"""Deprecated MegatronMIMO provider compatibility for heterogeneous training.
 
 This module provides MegatronMIMOProvider, which integrates with the standard
 ModelProviderMixin interface to enable multi-module models in the training loop.
@@ -14,8 +14,10 @@ from __future__ import annotations
 
 import copy
 import inspect
+import warnings
+from contextlib import contextmanager
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Callable, Dict, Iterator, List, Optional, Union
 
 import torch
 import torch.distributed as dist
@@ -44,12 +46,24 @@ if TYPE_CHECKING:
     from megatron.core.hyper_comm_grid import HyperCommGrid
 
 
+@contextmanager
+def _suppress_provider_build_deprecation_warnings() -> Iterator[None]:
+    """Suppress only nested warnings from legacy MIMO provider build methods."""
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=r"^MegatronMIMOProvider\.(build_infra|provide|provide_distributed_model)\(\) is deprecated\.",
+            category=DeprecationWarning,
+        )
+        yield
+
+
 @dataclass
 class MegatronMIMOProvider(ModelProviderMixin[MimoModel]):
-    """MegatronMIMO provider with heterogeneous parallelism support.
+    """Deprecated MegatronMIMO provider with heterogeneous parallelism support.
 
-    Integrates with the standard training loop via provide_distributed_model().
-    Use build_infra() to access MegatronMIMO-specific infrastructure (grids, topology, pg_collections).
+    New code should use ``MegatronMIMOModelConfig`` with
+    ``build_megatron_mimo_model()``. This class remains available for compatibility.
 
     This provider handles:
     - HyperCommGrid creation per module (heterogeneous parallelism)
@@ -74,9 +88,9 @@ class MegatronMIMOProvider(ModelProviderMixin[MimoModel]):
         ...     modality_submodules_spec={"clip_encoder": clip_spec},
         ...     megatron_mimo_parallelism_config=megatron_mimo_parallelism_config,
         ... )
-        >>> # For training loop integration:
+        >>> # Deprecated compatibility path:
         >>> model = provider.provide_distributed_model(ddp_config=ddp_config)
-        >>> # Or for manual usage:
+        >>> # Direct construction is also deprecated:
         >>> model = provider.provide()
         >>> infra = provider.build_infra()
     """
@@ -200,7 +214,7 @@ class MegatronMIMOProvider(ModelProviderMixin[MimoModel]):
         return build_language_model_spec(pp_rank=pp_rank)
 
     def build_infra(self) -> MegatronMIMOInfra:
-        """Build MegatronMIMO parallelism infrastructure.
+        """Build legacy MegatronMIMO provider infrastructure.
 
         This method builds HyperCommGrids, ProcessGroupCollections, and topology
         for MegatronMIMO's heterogeneous parallelism. It is idempotent and does not
@@ -213,6 +227,14 @@ class MegatronMIMOProvider(ModelProviderMixin[MimoModel]):
             MegatronMIMOInfra containing grids, topology, pg_collections,
             and the list of modules this rank participates in.
         """
+        self._warn_deprecated_build_api("build_infra")
+        reused_infra = getattr(self, "_reused_infra", None)
+        if reused_infra is not None:
+            return reused_infra
+        return self._build_infra()
+
+    def _build_infra(self) -> MegatronMIMOInfra:
+        """Build provider infrastructure without emitting a compatibility warning."""
         if self.megatron_mimo_parallelism_config is not None:
             grids = build_hypercomm_grids(self.megatron_mimo_parallelism_config)
             pg_collections = self._get_pg_collections_from_grids(grids)
@@ -362,6 +384,18 @@ class MegatronMIMOProvider(ModelProviderMixin[MimoModel]):
             ValueError: If language_model_spec is not set, or if this rank
                 doesn't participate in any module.
         """
+        self._warn_deprecated_build_api("provide")
+        return self._provide(pre_process=pre_process, post_process=post_process, vp_stage=vp_stage)
+
+    def _provide(
+        self,
+        pre_process: Optional[bool] = None,
+        post_process: Optional[bool] = None,
+        vp_stage: Optional[int] = None,
+        *,
+        infra: Optional[MegatronMIMOInfra] = None,
+    ) -> MimoModel:
+        """Build from the provider without emitting a compatibility warning."""
         if self.language_model_spec is None:
             raise ValueError(
                 "language_model_spec must be set before calling provide(). "
@@ -369,7 +403,11 @@ class MegatronMIMOProvider(ModelProviderMixin[MimoModel]):
             )
 
         # Build infrastructure
-        infra = self.build_infra()
+        if infra is None:
+            infra = getattr(self, "_reused_infra", None)
+            if infra is None:
+                with _suppress_provider_build_deprecation_warnings():
+                    infra = self.build_infra()
 
         # Inject pg_collection into language model spec
         language_spec = self.language_model_spec
@@ -413,6 +451,30 @@ class MegatronMIMOProvider(ModelProviderMixin[MimoModel]):
         self._apply_freezing(megatron_mimo_model)
 
         return megatron_mimo_model
+
+    @staticmethod
+    def _warn_deprecated_build_api(method_name: str) -> None:
+        """Warn that a legacy provider build entry point is deprecated."""
+        warnings.warn(
+            f"MegatronMIMOProvider.{method_name}() is deprecated. Pass a MegatronMIMOModelConfig "
+            "to build_megatron_mimo_model() instead.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+
+    @contextmanager
+    def _reuse_infra(self, infra: MegatronMIMOInfra) -> Iterator[None]:
+        """Reuse one infra instance across a nested legacy provider build."""
+        sentinel = object()
+        previous = getattr(self, "_reused_infra", sentinel)
+        object.__setattr__(self, "_reused_infra", infra)
+        try:
+            yield
+        finally:
+            if previous is sentinel:
+                delattr(self, "_reused_infra")
+            else:
+                object.__setattr__(self, "_reused_infra", previous)
 
     def provide_distributed_model(
         self,
@@ -475,6 +537,13 @@ class MegatronMIMOProvider(ModelProviderMixin[MimoModel]):
             ValueError: If this rank doesn't participate in any module
                 (indicates invalid parallelism configuration).
         """
+        warnings.warn(
+            "MegatronMIMOProvider.provide_distributed_model() is deprecated. Pass a MegatronMIMOModelConfig "
+            "to build_megatron_mimo_model(), or use MegatronMIMOBridge.get_megatron_model() for conversion.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         if wrap_with_ddp and ddp_config is None:
             raise ValueError("ddp_config is required when wrap_with_ddp is True")
 
@@ -487,10 +556,14 @@ class MegatronMIMOProvider(ModelProviderMixin[MimoModel]):
         self.finalize()
 
         # Build infrastructure
-        infra = self.build_infra()
+        infra = getattr(self, "_reused_infra", None)
+        if infra is None:
+            with _suppress_provider_build_deprecation_warnings():
+                infra = self.build_infra()
 
         # Get the model
-        model = self.provide()
+        with self._reuse_infra(infra), _suppress_provider_build_deprecation_warnings():
+            model = self.provide()
         model_list = [model]
 
         # Resolve hooks

--- a/src/megatron/bridge/models/megatron_mimo/megatron_mimo_provider.py
+++ b/src/megatron/bridge/models/megatron_mimo/megatron_mimo_provider.py
@@ -28,6 +28,7 @@ from megatron.core.transformer.module import MegatronModule
 from megatron.core.transformer.spec_utils import ModuleSpec
 from megatron.core.utils import get_model_config
 
+from megatron.bridge.models.megatron_mimo.infra import MegatronMIMOInfra
 from megatron.bridge.models.megatron_mimo.megatron_mimo_builder import (
     build_hypercomm_grids,
     is_pp_first_stage,
@@ -41,28 +42,6 @@ from megatron.bridge.models.model_provider import ModelProviderMixin
 
 if TYPE_CHECKING:
     from megatron.core.hyper_comm_grid import HyperCommGrid
-
-
-@dataclass
-class MegatronMIMOInfra:
-    """MegatronMIMO infrastructure metadata (separate from model).
-
-    This dataclass contains the parallelism infrastructure that MegatronMIMO builds,
-    separated from the model itself to maintain the standard provide() contract.
-
-    Attributes:
-        module_to_grid_map: Mapping of module names to their HyperCommGrids.
-        topology: DAG of module data flow (module_name -> list of downstream modules).
-        pg_collections: Mapping of module names to ProcessGroupCollections.
-            None for modules this rank doesn't participate in.
-        participating_modules: List of module names this rank participates in.
-    """
-
-    module_to_grid_map: Dict[str, "HyperCommGrid"]
-    topology: Dict[str, List[str]]
-    pg_collections: Dict[str, Optional[ProcessGroupCollection]]
-    participating_modules: List[str]
-    module_output_ndim: Dict[str, int] = field(default_factory=dict)
 
 
 @dataclass

--- a/src/megatron/bridge/models/megatron_mimo/model_config.py
+++ b/src/megatron/bridge/models/megatron_mimo/model_config.py
@@ -1,0 +1,378 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pure MegatronMIMO configuration and heterogeneous model builder."""
+
+from __future__ import annotations
+
+import copy
+import importlib
+from dataclasses import asdict, dataclass, field, replace
+from typing import Any, ClassVar
+
+import torch
+import torch.distributed as dist
+from megatron.core.distributed import DistributedDataParallelConfig
+from megatron.core.models.mimo import MimoModel
+from megatron.core.models.mimo.config.base_configs import MimoModelConfig
+from megatron.core.models.mimo.config.role import MIMO_LANGUAGE_MODULE_KEY
+from megatron.core.process_groups_config import ProcessGroupCollection
+from megatron.core.transformer.module import MegatronModule
+from megatron.core.transformer.spec_utils import ModuleSpec
+from megatron.core.utils import get_model_config
+from megatron.training.models.base import ModelBuilder, ModelConfig
+
+from megatron.bridge.models.megatron_mimo.infra import MegatronMIMOInfra
+from megatron.bridge.models.megatron_mimo.megatron_mimo_builder import (
+    build_hypercomm_grids,
+    is_pp_first_stage,
+    is_pp_last_stage,
+    populate_embedding_and_position_groups,
+)
+from megatron.bridge.models.megatron_mimo.megatron_mimo_config import (
+    MegatronMIMOParallelismConfig,
+    ModuleParallelismConfig,
+)
+from megatron.bridge.models.megatron_mimo.megatron_mimo_ddp import wrap_megatron_mimo_model_distributed
+
+
+@dataclass(kw_only=True)
+class MegatronMIMOModelConfig(ModelConfig):
+    """Serializable inputs for heterogeneous MegatronMIMO construction."""
+
+    builder: ClassVar[str] = "megatron.bridge.models.megatron_mimo.model_config.MegatronMIMOModelBuilder"
+    source_model_config: ModelConfig
+    megatron_mimo_parallelism_config: MegatronMIMOParallelismConfig
+    language_spec_builder: str
+    modality_spec_builder: str
+    modality_keys: dict[str, str]
+    special_token_ids: dict[str, int]
+    topology: dict[str, list[str]] | None = None
+    module_output_ndim: dict[str, int] | None = None
+    freeze_language_model: bool = False
+    freeze_modality_encoders: dict[str, bool] = field(default_factory=dict)
+    freeze_modality_projections: dict[str, bool] = field(default_factory=dict)
+    fp16: bool = False
+    bf16: bool = True
+    use_cpu_initialization: bool = False
+    init_model_with_meta_device: bool = False
+
+    def __post_init__(self) -> None:
+        """Restore parallelism dataclasses from YAML-compatible dictionaries."""
+        parallelism = self.megatron_mimo_parallelism_config
+        if isinstance(parallelism, dict):
+            module_parallelisms = parallelism.get("module_parallelisms")
+            if not isinstance(module_parallelisms, dict):
+                raise TypeError("MegatronMIMO parallelism config must define a module_parallelisms mapping.")
+            self.megatron_mimo_parallelism_config = MegatronMIMOParallelismConfig(
+                module_parallelisms={
+                    name: _restore_module_parallelism_config(module_config)
+                    for name, module_config in module_parallelisms.items()
+                },
+                special_token_ids=dict(parallelism.get("special_token_ids", {})),
+            )
+            return
+
+        parallelism.module_parallelisms = {
+            name: _restore_module_parallelism_config(module_config)
+            for name, module_config in parallelism.module_parallelisms.items()
+        }
+
+    def as_dict(self) -> dict[str, Any]:
+        """Serialize heterogeneous parallelism as YAML-safe primitive mappings."""
+        data = super().as_dict()
+        parallelism = self.megatron_mimo_parallelism_config
+        data["megatron_mimo_parallelism_config"] = {
+            "module_parallelisms": {
+                name: asdict(module_config) for name, module_config in parallelism.module_parallelisms.items()
+            },
+            "special_token_ids": dict(parallelism.special_token_ids),
+        }
+        return data
+
+
+def _restore_module_parallelism_config(
+    config: ModuleParallelismConfig | dict[str, Any],
+) -> ModuleParallelismConfig:
+    if isinstance(config, ModuleParallelismConfig):
+        return config
+    if not isinstance(config, dict):
+        raise TypeError(
+            "MegatronMIMO module parallelism entries must be ModuleParallelismConfig instances or mappings."
+        )
+    return ModuleParallelismConfig(**config)
+
+
+def _resolve_builder(path: str):
+    module_name, function_name = path.rsplit(".", 1)
+    return getattr(importlib.import_module(module_name), function_name)
+
+
+class MegatronMIMOModelBuilder(ModelBuilder[MimoModel, MegatronMIMOModelConfig]):
+    """Build MegatronMIMO models with per-module HyperCommGrid and DDP state."""
+
+    def __init__(self, model_config: MegatronMIMOModelConfig):
+        super().__init__(model_config)
+        self.infra: MegatronMIMOInfra | None = None
+
+    def finalize(self) -> None:
+        """Validate heterogeneous rank allocation against the distributed world."""
+        if not dist.is_initialized():
+            raise RuntimeError("MegatronMIMO requires torch.distributed to be initialized before construction.")
+        self._model_config.megatron_mimo_parallelism_config.finalize(dist.get_world_size())
+
+    def build_infra(self) -> MegatronMIMOInfra:
+        """Create per-module grids and process-group collections."""
+        config = self._model_config
+        grids = build_hypercomm_grids(config.megatron_mimo_parallelism_config)
+        pg_collections: dict[str, ProcessGroupCollection | None] = {}
+        for module_name, grid in grids.items():
+            pp_group = grid.get_pg(["pp"])
+            pos_embd_pg, embd_pg = populate_embedding_and_position_groups(pp_group)
+            if grid.is_current_rank_in_grid():
+                first_stage = is_pp_first_stage(pp_group)
+                last_stage = is_pp_last_stage(pp_group)
+                pg_collections[module_name] = ProcessGroupCollection(
+                    tp=grid.get_pg(["tp"]),
+                    dp=grid.get_pg(["dp"]),
+                    pp=pp_group,
+                    cp=grid.get_pg(["cp"]),
+                    ep=grid.get_pg(["ep"]),
+                    dp_cp=grid.get_pg(["dp", "cp"]),
+                    mp=grid.get_pg(["tp", "pp"]),
+                    tp_ep_pp=grid.get_pg(["tp", "ep", "pp"]),
+                    pos_embd=pos_embd_pg if first_stage else None,
+                    embd=embd_pg if first_stage or last_stage else None,
+                )
+            else:
+                pg_collections[module_name] = None
+
+        topology = config.topology or {
+            **{name: [MIMO_LANGUAGE_MODULE_KEY] for name in config.modality_keys},
+            MIMO_LANGUAGE_MODULE_KEY: [],
+        }
+        output_ndim = config.module_output_ndim or {
+            name: 3 if name == MIMO_LANGUAGE_MODULE_KEY else 2 for name in grids
+        }
+        self.infra = MegatronMIMOInfra(
+            module_to_grid_map=grids,
+            topology=topology,
+            pg_collections=pg_collections,
+            participating_modules=[name for name, pg in pg_collections.items() if pg is not None],
+            module_output_ndim=output_ndim,
+        )
+        return self.infra
+
+    @staticmethod
+    def _inject_language_pg(
+        spec: ModuleSpec,
+        pg_collection: ProcessGroupCollection,
+        *,
+        pre_process: bool,
+        post_process: bool,
+    ) -> ModuleSpec:
+        spec = copy.deepcopy(spec)
+        spec.params = dict(spec.params or {})
+        spec.params.update(
+            pg_collection=pg_collection,
+            pre_process=pre_process,
+            post_process=post_process,
+        )
+        return spec
+
+    @staticmethod
+    def _inject_modality_pg(spec: ModuleSpec, pg_collection: ProcessGroupCollection) -> ModuleSpec:
+        spec = copy.deepcopy(spec)
+        if spec.submodules and "encoders" in spec.submodules:
+            for encoder_spec in spec.submodules["encoders"].values():
+                encoder_spec.params = dict(encoder_spec.params or {})
+                encoder_spec.params["pg_collection"] = pg_collection
+                transformer = encoder_spec.params.get("transformer_config")
+                if transformer is not None and pg_collection.tp is not None:
+                    transformer.tensor_model_parallel_size = pg_collection.tp.size()
+        if spec.submodules and "input_projections" in spec.submodules:
+            for projection_spec in spec.submodules["input_projections"]:
+                if isinstance(projection_spec, ModuleSpec):
+                    projection_spec.params = dict(projection_spec.params or {})
+                    projection_spec.params.setdefault("tp_group", pg_collection.tp)
+        return spec
+
+    def build_model(
+        self,
+        pg_collection: ProcessGroupCollection | None = None,
+        pre_process: bool | None = None,
+        post_process: bool | None = None,
+        vp_stage: int | None = None,
+        *,
+        infra: MegatronMIMOInfra | None = None,
+    ) -> MimoModel:
+        """Build the rank-local MIMO module graph."""
+        del pg_collection, pre_process, post_process, vp_stage
+        config = self._model_config
+        infra = infra or self.infra or self.build_infra()
+        language_pg = infra.pg_collections.get(MIMO_LANGUAGE_MODULE_KEY)
+        language_pp_rank = 0
+        if language_pg is not None and language_pg.pp is not None:
+            language_pp_rank = dist.get_rank(group=language_pg.pp)
+        source_config = config.source_model_config
+        language_parallelism = config.megatron_mimo_parallelism_config.module_parallelisms[MIMO_LANGUAGE_MODULE_KEY]
+        source_transformer = replace(
+            source_config.transformer,
+            tensor_model_parallel_size=language_parallelism.tensor_model_parallel_size,
+            pipeline_model_parallel_size=language_parallelism.pipeline_model_parallel_size,
+            context_parallel_size=language_parallelism.context_parallel_size,
+            expert_tensor_parallel_size=language_parallelism.expert_tensor_parallel_size,
+            mtp_num_layers=None,
+        )
+        source_config = replace(source_config, transformer=source_transformer)
+        language_spec = _resolve_builder(config.language_spec_builder)(
+            source_config,
+            pp_rank=language_pp_rank,
+        )
+        if language_pg is not None:
+            language_spec = self._inject_language_pg(
+                language_spec,
+                language_pg,
+                pre_process=is_pp_first_stage(language_pg.pp),
+                post_process=is_pp_last_stage(language_pg.pp),
+            )
+
+        modality_specs = _resolve_builder(config.modality_spec_builder)(source_config)
+        for module_name, spec in tuple(modality_specs.items()):
+            module_pg = infra.pg_collections.get(module_name)
+            if module_pg is not None:
+                modality_specs[module_name] = self._inject_modality_pg(spec, module_pg)
+        _finalize_transformer_configs_in_specs(language_spec, modality_specs)
+        model = MimoModel(
+            MimoModelConfig(
+                language_model_spec=language_spec,
+                modality_submodules_spec=modality_specs,
+                special_token_ids=config.special_token_ids,
+                module_to_grid_map=infra.module_to_grid_map,
+            )
+        )
+        self._apply_freezing(model)
+        return model
+
+    def build_distributed_models(
+        self,
+        pg_collection: ProcessGroupCollection | None = None,
+        ddp_config: DistributedDataParallelConfig | None = None,
+        overlap_param_gather_with_optimizer_step: bool = False,
+        use_megatron_fsdp: bool = False,
+        use_torch_fsdp2: bool = False,
+        wrap_with_ddp: bool = True,
+        data_parallel_random_init: bool = True,
+        mixed_precision_wrapper: Any = None,
+        *,
+        fp16: bool | None = None,
+        bf16: bool | None = None,
+        infra: MegatronMIMOInfra | None = None,
+    ) -> list[MegatronModule]:
+        """Build, hook, cast, and independently DDP-wrap MIMO submodules."""
+        del pg_collection, overlap_param_gather_with_optimizer_step, data_parallel_random_init, mixed_precision_wrapper
+        if wrap_with_ddp and ddp_config is None:
+            raise ValueError("ddp_config is required when wrap_with_ddp is True")
+        if use_megatron_fsdp or use_torch_fsdp2:
+            raise NotImplementedError("MegatronMIMO supports heterogeneous DDP only; FSDP is not supported.")
+        config = self._model_config
+        infra = infra or self.infra or self.build_infra()
+        model_list: list[MegatronModule] = [self.build_model(infra=infra)]
+        for hook in config.pre_wrap_hooks:
+            result = hook(model_list)
+            if result is not None:
+                model_list = result
+        if not config.use_cpu_initialization and not config.init_model_with_meta_device:
+            model_list = [model.cuda(torch.cuda.current_device()) for model in model_list]
+        for model in model_list:
+            get_model_config(model).variable_seq_lengths = True
+        if fp16 if fp16 is not None else config.fp16:
+            model_list = [model.half() for model in model_list]
+        elif bf16 if bf16 is not None else config.bf16:
+            model_list = [model.bfloat16() for model in model_list]
+        for model in model_list:
+            self._move_frozen_params_to_device(model)
+        if wrap_with_ddp:
+            assert ddp_config is not None
+            model_list = [
+                wrap_megatron_mimo_model_distributed(
+                    megatron_mimo_model=model,
+                    ddp_config=ddp_config,
+                    megatron_mimo_parallelism_config=config.megatron_mimo_parallelism_config,
+                    grids=infra.module_to_grid_map,
+                    pg_collections=infra.pg_collections,
+                )
+                for model in model_list
+            ]
+        for hook in config.post_wrap_hooks:
+            result = hook(model_list)
+            if result is not None:
+                model_list = result
+        return model_list
+
+    def _apply_freezing(self, model: MimoModel) -> None:
+        config = self._model_config
+        if config.freeze_language_model and getattr(model, "language_model", None) is not None:
+            for parameter in model.language_model.parameters():
+                parameter.requires_grad = False
+        for modality, should_freeze in config.freeze_modality_encoders.items():
+            if should_freeze and modality in model.modality_submodules:
+                for parameter in model.modality_submodules[modality].encoders.parameters():
+                    parameter.requires_grad = False
+        for modality, should_freeze in config.freeze_modality_projections.items():
+            if should_freeze and modality in model.modality_submodules:
+                for parameter in model.modality_submodules[modality].input_projections.parameters():
+                    parameter.requires_grad = False
+
+    @staticmethod
+    def _move_frozen_params_to_device(model: torch.nn.Module) -> None:
+        if not torch.cuda.is_available():
+            return
+        device = torch.cuda.current_device()
+        for parameter in model.parameters():
+            if not parameter.requires_grad and parameter.device.type == "cpu":
+                parameter.data = parameter.data.to(device)
+        for buffer in model.buffers():
+            if buffer.device.type == "cpu":
+                buffer.data = buffer.data.to(device)
+
+
+def _finalize_transformer_configs_in_specs(
+    language_spec: ModuleSpec,
+    modality_specs: dict[str, ModuleSpec],
+) -> None:
+    """Finalize nested transformer configs embedded in module specifications."""
+    from megatron.core.transformer import TransformerConfig
+
+    def _finalize(spec: ModuleSpec | None) -> None:
+        if spec is None:
+            return
+        for value in (spec.params or {}).values():
+            if isinstance(value, TransformerConfig) and hasattr(value, "finalize"):
+                value.finalize()
+
+    _finalize(language_spec)
+    for modality_spec in modality_specs.values():
+        submodules = modality_spec.submodules or {}
+        for encoder_spec in (submodules.get("encoders") or {}).values():
+            _finalize(encoder_spec)
+        for projection_spec in submodules.get("input_projections") or []:
+            _finalize(projection_spec)
+        for projection_spec in submodules.get("output_projections") or []:
+            _finalize(projection_spec)
+        for decoder_spec in (submodules.get("decoders") or {}).values():
+            _finalize(decoder_spec)
+
+
+__all__ = ["MegatronMIMOInfra", "MegatronMIMOModelBuilder", "MegatronMIMOModelConfig"]

--- a/src/megatron/bridge/models/qwen_vl/model_config.py
+++ b/src/megatron/bridge/models/qwen_vl/model_config.py
@@ -327,3 +327,78 @@ __all__ = [
     "Qwen3VLModelBuilder",
     "Qwen3VLModelConfig",
 ]
+
+
+def build_qwen35_mimo_language_spec(config: Qwen35VLModelConfig, *, pp_rank: int = 0) -> ModuleSpec:
+    """Build the provider-free Qwen3.5 language ModuleSpec used by MIMO."""
+    from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.text_model import Qwen3VLGPTModel
+
+    transformer = _language_transformer(config)
+    block_spec = get_transformer_block_with_experimental_attention_variant_spec(
+        transformer,
+        pp_rank=pp_rank,
+    )
+    _patch_attention(block_spec)
+    return ModuleSpec(
+        module=Qwen3VLGPTModel,
+        params={
+            "config": transformer,
+            "transformer_layer_spec": block_spec,
+            "vocab_size": config.vocab_size,
+            "max_sequence_length": config.language_max_sequence_length,
+            "fp16_lm_cross_entropy": config.fp16_lm_cross_entropy,
+            "parallel_output": config.parallel_output,
+            "share_embeddings_and_output_weights": config.share_embeddings_and_output_weights,
+            "position_embedding_type": "mrope",
+            "rotary_percent": config.rotary_percent,
+            "rotary_base": config.rotary_base,
+            "scatter_embedding_sequence_parallel": False,
+            "mtp_block_spec": None,
+        },
+    )
+
+
+def build_qwen35_mimo_modality_specs(config: Qwen35VLModelConfig) -> dict[str, ModuleSpec]:
+    """Build provider-free Qwen3.5 vision modality specs used by MIMO."""
+    from megatron.core.extensions.transformer_engine import (
+        TEColumnParallelLinear,
+        TENorm,
+        TERowParallelLinear,
+    )
+    from megatron.core.models.mimo.submodules.vision import VisionModalitySubmodules
+    from megatron.core.models.vision.vit_layer_specs import get_vit_layer_with_transformer_engine_spec
+
+    from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.transformer_config import get_vision_model_config
+    from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.utils import PatchMergerSubmodules
+    from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.vision_model import Qwen3VLVisionModel
+
+    if config.use_hf_vision_model:
+        raise ValueError("use_hf_vision_model is not supported by MegatronMIMO")
+    transformer = _language_transformer(config)
+    vision_config = _vision_config_from_dict(config.vision_config, config.vision_config_target)
+    vision_layer_spec = get_vit_layer_with_transformer_engine_spec()
+    vision_layer_spec.submodules.self_attention.module = Qwen3VLSelfAttention
+    vision_transformer = get_vision_model_config(vision_config, megatron_config=transformer, exact_mcore=True)
+    vision_transformer.pipeline_model_parallel_size = 1
+    encoder_spec = ModuleSpec(
+        module=Qwen3VLVisionModel,
+        params={
+            "transformer_config": vision_transformer,
+            "vision_config": vision_config,
+            "transformer_layer_spec": vision_layer_spec,
+            "patch_merger_spec": PatchMergerSubmodules(
+                patch_norm=TENorm,
+                linear_fc1=TEColumnParallelLinear,
+                linear_fc2=TERowParallelLinear,
+            ),
+            "pre_process": True,
+            "post_process": True,
+        },
+    )
+    return {
+        "images": ModuleSpec(
+            module=VisionModalitySubmodules,
+            params={},
+            submodules={"encoders": {"qwen_visual": encoder_spec}, "input_projections": []},
+        )
+    }

--- a/src/megatron/bridge/models/qwen_vl/qwen35_vl_bridge.py
+++ b/src/megatron/bridge/models/qwen_vl/qwen35_vl_bridge.py
@@ -333,6 +333,10 @@ class Qwen35VLBridge(MegatronModelBridge):
     """
 
     mimo_source_prefixes = {"language": "language_model.", "images": "vision_model."}
+    mimo_modality_keys = {"images": "qwen_visual"}
+    mimo_special_token_fields = {"images": "image_token_id"}
+    mimo_language_spec_builder = "megatron.bridge.models.qwen_vl.model_config.build_qwen35_mimo_language_spec"
+    mimo_modality_spec_builder = "megatron.bridge.models.qwen_vl.model_config.build_qwen35_mimo_modality_specs"
 
     MODEL_CONFIG_CLASS = Qwen35VLModelConfig
 

--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -51,6 +51,7 @@ from megatron.bridge.models.gpt.gpt_builder import GPTModelConfig
 from megatron.bridge.models.hybrid.hybrid_builder import HybridModelConfig
 from megatron.bridge.models.hybrid.hybrid_provider import HybridModelProvider
 from megatron.bridge.models.megatron_mimo.megatron_mimo_provider import MegatronMIMOProvider
+from megatron.bridge.models.megatron_mimo.model_config import MegatronMIMOModelConfig
 from megatron.bridge.models.metadata import get_hf_model_id_from_model_config
 from megatron.bridge.peft.base import PEFT
 from megatron.bridge.training.comm_overlap import CommOverlapConfig
@@ -1055,6 +1056,7 @@ class ConfigContainer(Container):
         | T5ModelProvider
         | HybridModelProvider
         | MegatronMIMOProvider
+        | MegatronMIMOModelConfig
         | GPTModelConfig
         | HybridModelConfig
     )

--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -1809,8 +1809,8 @@ def megatron_mimo_runtime_config_update(cfg: ConfigContainer) -> None:
     """MegatronMIMO-equivalent of ``runtime_config_update``.
 
     The standard ``runtime_config_update`` cannot be used directly because it
-    accesses ``cfg.model`` attributes (``bf16``, ``tensor_model_parallel_size``,
-    ``cuda_graph_impl``, …) that do not exist on ``MegatronMIMOProvider``.
+    accesses global-model attributes (``tensor_model_parallel_size``,
+    ``cuda_graph_impl``, …) that do not apply to heterogeneous MegatronMIMO configs.
 
     This function cherry-picks the safe, model-agnostic parts:
 
@@ -1834,8 +1834,8 @@ def megatron_mimo_runtime_config_update(cfg: ConfigContainer) -> None:
     cfg.data_parallel_size = 1
 
     # Finalize sub-configs that don't depend on model construction order.
-    # NOTE: cfg.model.finalize() is NOT called here — it validates parallelism
-    # config and is called inside setup_megatron_mimo() right before build_infra().
+    # NOTE: cfg.model finalization is handled by the MegatronMIMO builder after
+    # runtime overrides have been applied.
     if hasattr(cfg.optimizer, "finalize"):
         cfg.optimizer.finalize()
     if hasattr(cfg.ddp, "finalize"):

--- a/src/megatron/bridge/training/megatron_mimo_parallel_utils.py
+++ b/src/megatron/bridge/training/megatron_mimo_parallel_utils.py
@@ -25,7 +25,7 @@ from megatron.core.distributed.finalize_model_grads import finalize_model_grads 
 from megatron.core.models.mimo import MimoModel
 from megatron.core.models.mimo.config.role import MIMO_LANGUAGE_MODULE_KEY
 
-from megatron.bridge.models.megatron_mimo.megatron_mimo_provider import MegatronMIMOInfra
+from megatron.bridge.models.megatron_mimo.infra import MegatronMIMOInfra
 
 
 if TYPE_CHECKING:

--- a/src/megatron/bridge/training/pretrain_megatron_mimo.py
+++ b/src/megatron/bridge/training/pretrain_megatron_mimo.py
@@ -54,9 +54,11 @@ def pretrain_megatron_mimo(
     3. Call train_megatron_mimo() with all components
 
     Args:
-        cfg: ConfigContainer with training configuration.  ``cfg.model`` must be
-            an ``MegatronMIMOProvider``.  ``cfg.optimizer`` (a ``BridgeOptimizerConfig``)
-            is used to create the ``MimoOptimizer`` and per-module LR schedulers.
+        cfg: ConfigContainer with training configuration. ``cfg.model`` should be
+            a ``MegatronMIMOModelConfig``; legacy ``MegatronMIMOProvider`` values
+            remain supported with a deprecation warning. ``cfg.optimizer`` (a
+            ``BridgeOptimizerConfig``) creates the ``MimoOptimizer`` and per-module
+            learning-rate schedulers.
         forward_step_func: Forward step function for training.
         build_data_iterators_fn: Function to build data iterators.
             Signature: (cfg, megatron_mimo_infra) -> (train_iter, valid_iter)

--- a/src/megatron/bridge/training/setup_megatron_mimo.py
+++ b/src/megatron/bridge/training/setup_megatron_mimo.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
     from megatron.core.optimizer.optimizer_param_scheduler import OptimizerParamScheduler
     from megatron.core.process_groups_config import MultiModuleProcessGroupCollection, ProcessGroupCollection
 
-    from megatron.bridge.models.megatron_mimo.megatron_mimo_provider import MegatronMIMOInfra
+    from megatron.bridge.models.megatron_mimo.infra import MegatronMIMOInfra
 
 
 logger = logging.getLogger(__name__)

--- a/src/megatron/bridge/training/setup_megatron_mimo.py
+++ b/src/megatron/bridge/training/setup_megatron_mimo.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 """MegatronMIMO-specific setup for heterogeneous multi-module training.
 
 This module provides the setup logic for MegatronMIMO training, mirroring the standard
@@ -115,7 +115,7 @@ def _update_megatron_mimo_model_config_funcs(
 
     assert model_config.variable_seq_lengths, (
         "variable_seq_lengths must be True for MegatronMIMO training. "
-        "This should be set by MegatronMIMOProvider.provide_distributed_model()."
+        "This should be set by the MegatronMIMO model builder."
     )
 
 
@@ -126,7 +126,7 @@ def setup_megatron_mimo(
     """MegatronMIMO-specific setup helper.
 
     This function sets up all components needed for MegatronMIMO training:
-    - Builds distributed model via ``cfg.model`` (an ``MegatronMIMOProvider``)
+    - Builds a distributed model from ``cfg.model`` (normally a ``MegatronMIMOModelConfig``)
     - Builds MegatronMIMO infrastructure (grids, topology, pg_collections)
     - Creates MultiModulePipelineCommunicator
     - Creates MimoOptimizer and per-module LR schedulers
@@ -135,9 +135,10 @@ def setup_megatron_mimo(
     - Validates configuration
 
     Args:
-        state: GlobalState with ``state.cfg`` already set.  ``state.cfg.model``
-            must be an ``MegatronMIMOProvider``.  ``state.cfg.optimizer`` is used to
-            create the optimizer.
+        state: GlobalState with ``state.cfg`` already set. ``state.cfg.model`` should
+            be a ``MegatronMIMOModelConfig``; legacy ``MegatronMIMOProvider`` values
+            remain supported with a deprecation warning. ``state.cfg.optimizer`` is
+            used to create the optimizer.
         build_data_iterators_fn: Optional function to build data iterators.
             Should have signature: (cfg, megatron_mimo_infra) -> (train_iter, valid_iter)
 
@@ -164,15 +165,15 @@ def setup_megatron_mimo(
 
     # Build the distributed MIMO model + infra. This single call replaces
     # the previously-inlined finalize / build_infra / validate-no-stub /
-    # set-per-module-seeds / provide_distributed_model / parallel_state-bridge
+    # set-per-module-seeds / distributed model build / parallel_state-bridge
     # sequence. The same helper is the entry point for the conversion CLI,
     # which is why it lives under ``models/megatron_mimo`` rather than
     # inside this training-setup module.
     from megatron.bridge.models.megatron_mimo import build_megatron_mimo_model
 
-    megatron_mimo_provider = cfg.model
+    model_config = cfg.model
     model, megatron_mimo_infra = build_megatron_mimo_model(
-        megatron_mimo_provider,
+        model_config,
         ddp_config=cfg.ddp,
         fp16=getattr(cfg.model, "fp16", False),
         bf16=getattr(cfg.model, "bf16", True),
@@ -217,7 +218,7 @@ def setup_megatron_mimo(
     if megatron_mimo_infra.module_to_grid_map:
         assert unwrapped_model.mimo_config.module_to_grid_map is not None, (
             "MimoModelConfig.module_to_grid_map must be set at model construction time. "
-            "Ensure MegatronMIMOProvider.provide() passes module_to_grid_map for MegatronMIMO parallelism."
+            "Ensure the MegatronMIMO model builder passes module_to_grid_map for heterogeneous parallelism."
         )
 
     logger.info(f"Rank {dist.get_rank()}: Creating MimoOptimizer")

--- a/src/megatron/bridge/training/train_megatron_mimo.py
+++ b/src/megatron/bridge/training/train_megatron_mimo.py
@@ -56,7 +56,7 @@ if TYPE_CHECKING:
     from megatron.core.pipeline_parallel.multimodule_communicator import MultiModulePipelineCommunicator
     from megatron.core.process_groups_config import MultiModuleProcessGroupCollection
 
-    from megatron.bridge.models.megatron_mimo.megatron_mimo_provider import MegatronMIMOInfra
+    from megatron.bridge.models.megatron_mimo.infra import MegatronMIMOInfra
 
 
 logger = logging.getLogger(__name__)

--- a/src/megatron/bridge/training/utils/theoretical_memory_utils.py
+++ b/src/megatron/bridge/training/utils/theoretical_memory_utils.py
@@ -307,12 +307,12 @@ def report_theoretical_memory(
         verbose (bool, optional): If True, passes verbosity flag to helper functions.
                                 Defaults to False.
     """
-    # Skip for MegatronMIMO: MegatronMIMOProvider is not a TransformerConfig, so it lacks
+    # Skip for MegatronMIMO: heterogeneous configs do not have one global set of
     # kv_channels/num_attention_heads/etc. needed for the calculation.
-    # (Other providers like GPTModelProvider inherit TransformerConfig and work fine.)
     from megatron.bridge.models.megatron_mimo.megatron_mimo_provider import MegatronMIMOProvider
+    from megatron.bridge.models.megatron_mimo.model_config import MegatronMIMOModelConfig
 
-    if isinstance(config.model, MegatronMIMOProvider):
+    if isinstance(config.model, (MegatronMIMOModelConfig, MegatronMIMOProvider)):
         return
 
     should_report_activation = config.model.sequence_parallel and config.model.recompute_granularity == "selective"

--- a/tests/functional_tests/test_groups/megatron_mimo/test_megatron_mimo_conversion.py
+++ b/tests/functional_tests/test_groups/megatron_mimo/test_megatron_mimo_conversion.py
@@ -16,9 +16,8 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import copy
 from pathlib import Path
-from typing import ClassVar
 
 import pytest
 import torch
@@ -26,11 +25,13 @@ import torch.distributed as dist
 from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_with_transformer_engine_spec
 from megatron.core.models.gpt.gpt_model import GPTModel
 from megatron.core.models.mimo.config.role import MIMO_LANGUAGE_MODULE_KEY
+from megatron.core.models.mimo.submodules.vision import VisionModalitySubmodules
 from megatron.core.models.vision.clip_vit_model import CLIPViTModel
 from megatron.core.models.vision.vit_layer_specs import get_vit_layer_with_transformer_engine_spec
 from megatron.core.transformer.spec_utils import ModuleSpec
 from megatron.core.transformer.transformer_config import TransformerConfig
 
+from megatron.bridge.models.gpt.model_config import BridgeGPTModelConfig
 from megatron.bridge.models.megatron_mimo import build_megatron_mimo_model
 from megatron.bridge.models.megatron_mimo.conversion.mimo_model_io import (
     load_megatron_mimo_model,
@@ -40,7 +41,7 @@ from megatron.bridge.models.megatron_mimo.megatron_mimo_config import (
     MegatronMIMOParallelismConfig,
     ModuleParallelismConfig,
 )
-from megatron.bridge.models.megatron_mimo.megatron_mimo_provider import MegatronMIMOProvider
+from megatron.bridge.models.megatron_mimo.model_config import MegatronMIMOModelConfig
 from megatron.bridge.utils.instantiate_utils import register_allowed_target_prefix
 from tests.functional_tests.utils import broadcast_path, initialize_distributed
 
@@ -49,57 +50,40 @@ _IMAGE_TOKEN_ID = 63
 register_allowed_target_prefix(f"{__name__}.")
 
 
-@dataclass
-class TinyStandardMIMOProvider:
-    """Tiny modality-aware provider used to test conversion-generated MIMO providers."""
+def build_tiny_language_spec(config: BridgeGPTModelConfig, pp_rank: int = 0) -> ModuleSpec:
+    """Build the tiny language module from a serializable source config."""
+    return ModuleSpec(
+        module=GPTModel,
+        params={
+            "config": copy.deepcopy(config.transformer),
+            "transformer_layer_spec": get_gpt_layer_with_transformer_engine_spec(),
+            "vocab_size": config.vocab_size,
+            "max_sequence_length": config.seq_length,
+            "pre_process": pp_rank == 0,
+            "post_process": True,
+        },
+    )
 
-    vocab_size: int = 64
-    hidden_size: int = 16
-    num_layers: int = 1
-    num_attention_heads: int = 4
-    seq_length: int = 16
-    image_size: int = 16
-    patch_dim: int = 8
-    modality_keys: ClassVar[dict[str, str]] = {"images": "clip"}
-    special_token_ids: ClassVar[dict[str, int]] = {"images": _IMAGE_TOKEN_ID}
 
-    def _transformer_config(self) -> TransformerConfig:
-        return TransformerConfig(
-            num_layers=self.num_layers,
-            hidden_size=self.hidden_size,
-            ffn_hidden_size=self.hidden_size * 4,
-            num_attention_heads=self.num_attention_heads,
-            bf16=True,
-            variable_seq_lengths=True,
-            moe_token_dispatcher_type="alltoall",
-            attention_dropout=0.0,
-            hidden_dropout=0.0,
+def build_tiny_modality_specs(config: BridgeGPTModelConfig) -> dict[str, ModuleSpec]:
+    """Build the tiny vision module from a serializable source config."""
+    vision_encoder = ModuleSpec(
+        module=CLIPViTModel,
+        params={
+            "transformer_config": copy.deepcopy(config.transformer),
+            "transformer_layer_spec": get_vit_layer_with_transformer_engine_spec(),
+            "patch_dim": 8,
+            "img_h": 16,
+            "img_w": 16,
+        },
+    )
+    return {
+        "images": ModuleSpec(
+            module=VisionModalitySubmodules,
+            params={},
+            submodules={"encoders": {"clip": vision_encoder}, "input_projections": []},
         )
-
-    def build_language_model_spec(self, pp_rank: int = 0) -> ModuleSpec:
-        return ModuleSpec(
-            module=GPTModel,
-            params={
-                "config": self._transformer_config(),
-                "transformer_layer_spec": get_gpt_layer_with_transformer_engine_spec(),
-                "vocab_size": self.vocab_size,
-                "max_sequence_length": self.seq_length,
-                "pre_process": pp_rank == 0,
-                "post_process": True,
-            },
-        )
-
-    def build_vision_encoder_spec(self) -> ModuleSpec:
-        return ModuleSpec(
-            module=CLIPViTModel,
-            params={
-                "transformer_config": self._transformer_config(),
-                "transformer_layer_spec": get_vit_layer_with_transformer_engine_spec(),
-                "patch_dim": self.patch_dim,
-                "img_h": self.image_size,
-                "img_w": self.image_size,
-            },
-        )
+    }
 
 
 def _parallelism_config() -> MegatronMIMOParallelismConfig:
@@ -121,10 +105,30 @@ def _parallelism_config() -> MegatronMIMOParallelismConfig:
     )
 
 
-def _mimo_provider() -> MegatronMIMOProvider:
-    return MegatronMIMOProvider.from_standard_provider(
-        standard_provider=TinyStandardMIMOProvider(),
+def _mimo_model_config() -> MegatronMIMOModelConfig:
+    source_config = BridgeGPTModelConfig(
+        transformer=TransformerConfig(
+            num_layers=1,
+            hidden_size=16,
+            ffn_hidden_size=64,
+            num_attention_heads=4,
+            bf16=True,
+            variable_seq_lengths=True,
+            moe_token_dispatcher_type="alltoall",
+            attention_dropout=0.0,
+            hidden_dropout=0.0,
+        ),
+        vocab_size=64,
+        make_vocab_size_divisible_by=1,
+        seq_length=16,
+    )
+    return MegatronMIMOModelConfig(
+        source_model_config=source_config,
         megatron_mimo_parallelism_config=_parallelism_config(),
+        language_spec_builder=f"{__name__}.build_tiny_language_spec",
+        modality_spec_builder=f"{__name__}.build_tiny_modality_specs",
+        modality_keys={"images": "clip"},
+        special_token_ids={"images": _IMAGE_TOKEN_ID},
     )
 
 
@@ -159,9 +163,9 @@ def test_megatron_mimo_conversion_checkpoint_save_load_roundtrip(tmp_path):
     checkpoint_path.mkdir(parents=True, exist_ok=True)
     dist.barrier()
 
-    provider = _mimo_provider()
+    model_config = _mimo_model_config()
     model, infra = build_megatron_mimo_model(
-        provider,
+        model_config,
         bf16=True,
         wrap_with_ddp=False,
         data_parallel_random_init=False,
@@ -170,10 +174,10 @@ def test_megatron_mimo_conversion_checkpoint_save_load_roundtrip(tmp_path):
     _fill_active_submodule(model, active_module)
     expected_sum = _active_parameter_sum(model, active_module)
 
-    save_megatron_mimo_model(model, infra, provider, checkpoint_path)
+    save_megatron_mimo_model(model, infra, model_config, checkpoint_path)
     dist.barrier()
 
-    loaded_model, loaded_infra, loaded_provider = load_megatron_mimo_model(
+    loaded_model, loaded_infra, loaded_config = load_megatron_mimo_model(
         checkpoint_path,
         parallelism_config=_parallelism_config(),
         bf16=True,
@@ -183,7 +187,8 @@ def test_megatron_mimo_conversion_checkpoint_save_load_roundtrip(tmp_path):
     loaded_active_module = loaded_infra.participating_modules[0]
 
     assert loaded_active_module == active_module
-    assert loaded_provider.standard_provider is not None
-    assert loaded_provider.language_model_spec is not None
-    assert loaded_provider.modality_submodules_spec
+    assert isinstance(loaded_config, MegatronMIMOModelConfig)
+    assert isinstance(loaded_config.source_model_config, BridgeGPTModelConfig)
+    assert loaded_config.language_spec_builder == f"{__name__}.build_tiny_language_spec"
+    assert loaded_config.modality_spec_builder == f"{__name__}.build_tiny_modality_specs"
     assert _active_parameter_sum(loaded_model, loaded_active_module) == pytest.approx(expected_sum)

--- a/tests/functional_tests/test_groups/megatron_mimo/test_pretrain_megatron_mimo.py
+++ b/tests/functional_tests/test_groups/megatron_mimo/test_pretrain_megatron_mimo.py
@@ -38,11 +38,12 @@ from megatron.core.transformer.spec_utils import ModuleSpec
 from megatron.core.transformer.transformer_config import TransformerConfig
 
 from megatron.bridge.data.megatron_mimo.mock_provider import MockMegatronMIMOProvider
+from megatron.bridge.models.gpt.model_config import BridgeGPTModelConfig
 from megatron.bridge.models.megatron_mimo.megatron_mimo_config import (
     MegatronMIMOParallelismConfig,
     ModuleParallelismConfig,
 )
-from megatron.bridge.models.megatron_mimo.megatron_mimo_provider import MegatronMIMOProvider
+from megatron.bridge.models.megatron_mimo.model_config import MegatronMIMOModelConfig
 from megatron.bridge.training.config import (
     CheckpointConfig,
     ConfigContainer,
@@ -153,6 +154,43 @@ def _build_model_specs(deterministic: bool = False):
     return language_model_spec, {"vision": vision_submodule_spec}, {"vision": _SPECIAL_TOKEN_ID}
 
 
+def _test_language_spec_builder(config: BridgeGPTModelConfig, *, pp_rank: int = 0) -> ModuleSpec:
+    """Build the tiny language spec from a serializable source config."""
+    del pp_rank
+    language_spec, _, _ = _build_model_specs(deterministic=not config.transformer.bf16)
+    language_spec.params = dict(language_spec.params or {})
+    language_spec.params["config"] = config.transformer
+    return language_spec
+
+
+def _test_modality_spec_builder(config: BridgeGPTModelConfig) -> dict[str, ModuleSpec]:
+    """Build the tiny vision specs from a serializable source config."""
+    _, modality_specs, _ = _build_model_specs(deterministic=not config.transformer.bf16)
+    return modality_specs
+
+
+def _build_mimo_model_config(
+    parallelism_config: MegatronMIMOParallelismConfig,
+    *,
+    deterministic: bool,
+) -> MegatronMIMOModelConfig:
+    source_config = BridgeGPTModelConfig(
+        transformer=_make_language_config(deterministic=deterministic),
+        vocab_size=_VOCAB_SIZE,
+        seq_length=_SEQ_LENGTH,
+    )
+    return MegatronMIMOModelConfig(
+        source_model_config=source_config,
+        megatron_mimo_parallelism_config=parallelism_config,
+        language_spec_builder=f"{__name__}._test_language_spec_builder",
+        modality_spec_builder=f"{__name__}._test_modality_spec_builder",
+        modality_keys={"vision": "vision"},
+        special_token_ids={"vision": _SPECIAL_TOKEN_ID},
+        topology={"vision": ["language"], "language": []},
+        bf16=not deterministic,
+    )
+
+
 # ── Data helpers ─────────────────────────────────────────────────────────────
 
 
@@ -245,13 +283,11 @@ def _build_data_iterators(cfg, megatron_mimo_infra, *, train_state=None):
         train_samples=max(train_samples, 100),
         valid_samples=0,
         test_samples=0,
+        grids=megatron_mimo_infra.module_to_grid_map,
     )
 
     # Match the vision encoder's compute dtype (fp32 under --deterministic, bf16 otherwise).
-    vision_cfg = (
-        cfg.model.modality_submodules_spec["vision"].submodules["encoders"]["clip"].params["transformer_config"]
-    )
-    vision_dtype = torch.bfloat16 if vision_cfg.bf16 else torch.float32
+    vision_dtype = torch.bfloat16 if cfg.model.source_model_config.transformer.bf16 else torch.float32
     train_iter = _wrap_iter(train_loader, vision_dtype=vision_dtype) if train_loader is not None else None
     return train_iter, None
 
@@ -264,21 +300,7 @@ def _build_config(
     train_iters: int = _TRAIN_ITERS,
     deterministic: bool = False,
 ) -> ConfigContainer:
-    language_model_spec, modality_submodules_spec, special_token_ids = _build_model_specs(deterministic=deterministic)
-
-    megatron_mimo_provider = MegatronMIMOProvider(
-        language_model_spec=language_model_spec,
-        modality_submodules_spec=modality_submodules_spec,
-        special_token_ids=special_token_ids,
-        megatron_mimo_parallelism_config=parallelism_config,
-        topology={"vision": ["language"], "language": []},
-        # MegatronMIMOProvider casts the whole model via .bfloat16() after build,
-        # overriding per-submodule TransformerConfig dtypes — flip it off in
-        # deterministic mode so the model stays fp32.
-        bf16=not deterministic,
-    )
-    if not hasattr(megatron_mimo_provider, "num_moe_experts"):
-        megatron_mimo_provider.num_moe_experts = None
+    model_config = _build_mimo_model_config(parallelism_config, deterministic=deterministic)
 
     train_cfg = TrainingConfig(
         micro_batch_size=1,
@@ -295,7 +317,7 @@ def _build_config(
 
     cfg = ConfigContainer(
         train=train_cfg,
-        model=megatron_mimo_provider,
+        model=model_config,
         optimizer=opt_config,
         scheduler=SchedulerConfig(start_weight_decay=0.0, end_weight_decay=0.0),
         dataset=_build_mock_data_provider(),
@@ -382,6 +404,7 @@ def _build_tracing_data_iterators(cfg, megatron_mimo_infra, *, train_state=None)
         train_samples=max(train_samples, 100),
         valid_samples=0,
         test_samples=0,
+        grids=megatron_mimo_infra.module_to_grid_map,
     )
     train_iter = _tracing_wrap_iter(train_loader) if train_loader is not None else None
     return train_iter, None
@@ -417,17 +440,7 @@ def _build_resume_config(
     Mirrors ``_build_config`` but wires the save/load directory into
     ``CheckpointConfig`` and uses the traceable mock data provider.
     """
-    language_model_spec, modality_submodules_spec, special_token_ids = _build_model_specs()
-
-    megatron_mimo_provider = MegatronMIMOProvider(
-        language_model_spec=language_model_spec,
-        modality_submodules_spec=modality_submodules_spec,
-        special_token_ids=special_token_ids,
-        megatron_mimo_parallelism_config=parallelism_config,
-        topology={"vision": ["language"], "language": []},
-    )
-    if not hasattr(megatron_mimo_provider, "num_moe_experts"):
-        megatron_mimo_provider.num_moe_experts = None
+    model_config = _build_mimo_model_config(parallelism_config, deterministic=False)
 
     train_cfg = TrainingConfig(
         micro_batch_size=1,
@@ -456,7 +469,7 @@ def _build_resume_config(
 
     return ConfigContainer(
         train=train_cfg,
-        model=megatron_mimo_provider,
+        model=model_config,
         optimizer=opt_config,
         scheduler=SchedulerConfig(start_weight_decay=0.0, end_weight_decay=0.0),
         dataset=_build_traceable_mock_provider(),
@@ -498,7 +511,7 @@ class TestMegatronMIMOTraining:
             pytest.skip(f"MegatronMIMO test requires exactly 2 GPUs, got {world_size}")
 
         # Monkey-patch: report_theoretical_memory crashes on MegatronMIMO models
-        # because cfg.model is MegatronMIMOProvider (no kv_channels).
+        # because heterogeneous MIMO configs do not have one global kv_channels value.
         import megatron.bridge.training.utils.train_utils as _tu
 
         _tu.report_theoretical_memory = lambda *a, **kw: None

--- a/tests/unit_tests/data/megatron_mimo/test_loaders.py
+++ b/tests/unit_tests/data/megatron_mimo/test_loaders.py
@@ -15,6 +15,11 @@ class FakeMegatronMIMOProvider:
         self._grids = grids
 
 
+class FakeMegatronMIMOModelConfig:
+    def __init__(self, megatron_mimo_parallelism_config):
+        self.megatron_mimo_parallelism_config = megatron_mimo_parallelism_config
+
+
 class FakeDataset:
     def __init__(self, size: int):
         self._size = size
@@ -48,6 +53,10 @@ def _patch_megatron_mimo_provider_class(monkeypatch):
         "megatron.bridge.models.megatron_mimo.megatron_mimo_provider.MegatronMIMOProvider",
         FakeMegatronMIMOProvider,
     )
+    monkeypatch.setattr(
+        "megatron.bridge.models.megatron_mimo.model_config.MegatronMIMOModelConfig",
+        FakeMegatronMIMOModelConfig,
+    )
 
 
 def test_build_megatron_mimo_data_loaders_raises_when_model_not_megatron_mimo(monkeypatch):
@@ -55,7 +64,7 @@ def test_build_megatron_mimo_data_loaders_raises_when_model_not_megatron_mimo(mo
     cfg = SimpleNamespace(model=object(), train=SimpleNamespace(micro_batch_size=2))
     provider = FakeProvider()
 
-    with pytest.raises(ValueError, match="cfg.model must be MegatronMIMOProvider"):
+    with pytest.raises(ValueError, match="MegatronMIMO model config"):
         build_megatron_mimo_data_loaders(
             cfg, train_state=None, megatron_mimo_provider=provider, train_samples=4, valid_samples=2, test_samples=2
         )
@@ -83,10 +92,35 @@ def test_build_megatron_mimo_data_loaders_raises_when_grids_missing(monkeypatch)
     )
     provider = FakeProvider()
 
-    with pytest.raises(ValueError, match="_grids is None"):
+    with pytest.raises(ValueError, match="Pass grids from MegatronMIMOInfra"):
         build_megatron_mimo_data_loaders(
             cfg, train_state=None, megatron_mimo_provider=provider, train_samples=4, valid_samples=2, test_samples=2
         )
+
+
+def test_build_megatron_mimo_data_loaders_accepts_model_config_with_explicit_grids(monkeypatch):
+    builder_calls = _patch_happy_path_dependencies(monkeypatch)
+    parallelism_config = SimpleNamespace(
+        module_parallelisms={"llm": SimpleNamespace(data_parallel_size=1)},
+    )
+    cfg = SimpleNamespace(
+        model=FakeMegatronMIMOModelConfig(parallelism_config),
+        train=SimpleNamespace(micro_batch_size=2),
+    )
+    grids = {"llm": object()}
+
+    loaders = build_megatron_mimo_data_loaders(
+        cfg,
+        train_state=SimpleNamespace(consumed_train_samples=0),
+        megatron_mimo_provider=FakeProvider(),
+        train_samples=4,
+        valid_samples=2,
+        test_samples=2,
+        grids=grids,
+    )
+
+    assert loaders == ("loader-1", "loader-2", "loader-3")
+    assert len(builder_calls) == 3
 
 
 def _patch_happy_path_dependencies(monkeypatch):

--- a/tests/unit_tests/examples/test_provider_free_examples.py
+++ b/tests/unit_tests/examples/test_provider_free_examples.py
@@ -35,7 +35,6 @@ TEMPORARY_FALLBACKS = {
     },
     "to_megatron_provider": {
         Path("distillation/llama/distill_llama32_3b-1b.py"),
-        Path("megatron_mimo/qwen35_vl/finetune_qwen35_vl.py"),
         Path("models/diffusion/inference_dllm.py"),
     },
     "provider_bridge": {
@@ -50,7 +49,6 @@ TEMPORARY_FALLBACKS = {
     "direct_model_provider_import": {
         Path("megatron_mimo/llava/megatron_mimo_training_llava.py"),
         Path("megatron_mimo/llava/megatron_mimo_training_llava_audio.py"),
-        Path("megatron_mimo/qwen35_vl/finetune_qwen35_vl.py"),
     },
 }
 

--- a/tests/unit_tests/models/megatron_mimo/conversion/test_mimo_model_io.py
+++ b/tests/unit_tests/models/megatron_mimo/conversion/test_mimo_model_io.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Compatibility tests for MegatronMIMO checkpoint model metadata."""
+
+import inspect
+from types import SimpleNamespace
+
+import pytest
+
+from megatron.bridge.models.megatron_mimo.conversion.mimo_model_io import (
+    _checkpoint_serializable_model_config,
+    save_megatron_mimo_model,
+)
+from megatron.bridge.models.megatron_mimo.megatron_mimo_provider import MegatronMIMOProvider
+
+
+@pytest.mark.unit
+def test_save_api_preserves_provider_keyword_name() -> None:
+    """Keep released keyword calls compatible while accepting pure configs."""
+    signature = inspect.signature(save_megatron_mimo_model)
+
+    assert "provider" in signature.parameters
+    assert "model_config" not in signature.parameters
+
+
+@pytest.mark.unit
+def test_legacy_provider_runtime_fields_are_restored_after_serialization() -> None:
+    """Legacy providers omit derived specs and grids only inside the save scope."""
+    language_spec = object()
+    modality_specs = {"images": object()}
+    special_token_ids = {"images": 7}
+    grids = {"language": object()}
+    provider = MegatronMIMOProvider(
+        language_model_spec=language_spec,
+        modality_submodules_spec=modality_specs,
+        special_token_ids=special_token_ids,
+    )
+    provider._grids = grids
+
+    with _checkpoint_serializable_model_config(provider):
+        assert provider.language_model_spec is None
+        assert provider.modality_submodules_spec == {}
+        assert provider.special_token_ids == {}
+        assert provider._grids is None
+
+    assert provider.language_model_spec is language_spec
+    assert provider.modality_submodules_spec is modality_specs
+    assert provider.special_token_ids is special_token_ids
+    assert provider._grids is grids
+
+
+@pytest.mark.unit
+def test_pure_model_config_is_not_mutated_for_checkpoint_serialization() -> None:
+    """Pure configs already contain only serialized inputs."""
+    model_config = SimpleNamespace(marker=object())
+
+    with _checkpoint_serializable_model_config(model_config):
+        assert model_config.marker is not None
+
+    assert model_config.marker is not None

--- a/tests/unit_tests/models/megatron_mimo/conversion/test_orchestrator.py
+++ b/tests/unit_tests/models/megatron_mimo/conversion/test_orchestrator.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
 from collections import namedtuple
 from unittest.mock import Mock
 
@@ -79,20 +80,16 @@ def test_register_mimo_conversion_spec_allows_same_function_reregistration():
 
 
 def test_default_mimo_routes_require_metadata_and_matching_keys():
-    with pytest.raises(TypeError, match="mimo_source_prefixes"):
-        orchestrator_module._build_default_mimo_routes(
-            source_bridge=object(),
-            standard_provider=type("Provider", (), {"modality_keys": {}})(),
-        )
+    with pytest.raises(TypeError, match="route metadata"):
+        orchestrator_module._build_default_mimo_routes(source_bridge=object(), modality_keys={})
 
     source_bridge = type(
         "Bridge",
         (),
         {"mimo_source_prefixes": {"language": "language_model.", "extra": "extra_model."}},
     )()
-    standard_provider = type("Provider", (), {"modality_keys": {"images": "clip"}})()
     with pytest.raises(ValueError, match="Missing"):
-        orchestrator_module._build_default_mimo_routes(source_bridge, standard_provider)
+        orchestrator_module._build_default_mimo_routes(source_bridge, {"images": "clip"})
 
 
 class _FakeMimoModel(nn.Module):
@@ -523,10 +520,17 @@ def test_copy_hf_artifacts_forwards_additional_file_patterns(tmp_path):
 class _FakeSourceBridgeForMIMOBridge:
     export_weight_dtype = "bf16"
 
+    def provider_bridge(self, hf_pretrained):
+        return _FakeProviderForMIMOBridge()
+
 
 class _FakeProviderForMIMOBridge:
     def __init__(self):
         self.modality_submodules_spec = {"images": object()}
+
+
+class _FakeModelConfigForMIMOBridge:
+    modality_keys = {"images": "fake"}
 
 
 class _FakeInfraForMIMOBridge:
@@ -564,7 +568,7 @@ def _ensure_fake_mimo_conversion_spec_registered() -> None:
 
     @register_mimo_conversion_spec(_FakeSourceBridgeForMIMOBridge)
     def _fake_mimo_conversion_spec(source_bridge, hf_pretrained, parallelism_config):
-        return _FakeProviderForMIMOBridge(), _bridge_routes()
+        return _FakeModelConfigForMIMOBridge(), _bridge_routes()
 
 
 def _mimo_bridge() -> MegatronMIMOBridge:
@@ -577,12 +581,26 @@ def _mimo_bridge() -> MegatronMIMOBridge:
 
 
 class TestMegatronMIMOBridge:
-    def test_to_megatron_mimo_provider_resolves_conversion_spec_and_routes(self):
+    def test_deprecated_provider_aliases_remain_in_public_signatures(self):
+        assert "mimo_provider" in inspect.signature(MegatronMIMOBridge.build_mimo_model).parameters
+        assert "mimo_provider" in inspect.signature(MegatronMIMOBridge.save_megatron_model).parameters
+
+    def test_to_megatron_model_config_resolves_conversion_spec_and_routes(self):
         bridge = _mimo_bridge()
+
+        model_config = bridge.to_megatron_model_config()
+
+        assert isinstance(model_config, _FakeModelConfigForMIMOBridge)
+        assert [route.name for route in bridge.routes] == ["language", "images"]
+
+    def test_to_megatron_mimo_provider_builds_deprecated_compatibility_provider(self, monkeypatch):
+        bridge = _mimo_bridge()
+        provider = _FakeProviderForMIMOBridge()
+        monkeypatch.setattr(orchestrator_module, "_build_default_mimo_provider", lambda *args: provider)
 
         mimo_provider = bridge.to_megatron_mimo_provider()
 
-        assert isinstance(mimo_provider, _FakeProviderForMIMOBridge)
+        assert mimo_provider is provider
         assert [route.name for route in bridge.routes] == ["language", "images"]
 
     def test_standard_provider_method_points_to_mimo_specific_name(self):
@@ -603,12 +621,16 @@ class TestMegatronMIMOBridge:
         with pytest.raises(NotImplementedError, match="load_weights"):
             bridge.to_megatron_mimo_provider(load_weights=True)
 
-    def test_to_megatron_mimo_provider_returns_cached_provider(self):
+    def test_to_megatron_mimo_provider_returns_cached_provider(self, monkeypatch):
         bridge = _mimo_bridge()
+        provider = _FakeProviderForMIMOBridge()
+        build_provider = Mock(return_value=provider)
+        monkeypatch.setattr(orchestrator_module, "_build_default_mimo_provider", build_provider)
 
         first = bridge.to_megatron_mimo_provider()
 
         assert bridge.to_megatron_mimo_provider() is first
+        build_provider.assert_called_once()
         bridge.validate_mimo_conversion_support()
 
     def test_from_bridge_copies_source_state(self):
@@ -637,7 +659,7 @@ class TestMegatronMIMOBridge:
         monkeypatch.setattr(orchestrator_module, "import_hf_to_megatron_mimo", fake_import_hf_to_megatron_mimo)
 
         bridge = _mimo_bridge()
-        bridge.to_megatron_mimo_provider()
+        bridge.to_megatron_model_config()
         bridge._infra = _FakeInfraForMIMOBridge()
         monkeypatch.setattr(bridge, "_resolve_hf_pretrained", lambda hf_path: "hf")
 
@@ -674,9 +696,30 @@ class TestMegatronMIMOBridge:
         assert calls[0][1]["wrap_with_ddp"] is False
         assert calls[1] == ("load", model, {"hf_path": "/hf"})
 
+    def test_build_mimo_model_routes_deprecated_provider_alias_and_caches(self, monkeypatch):
+        bridge = _mimo_bridge()
+        provider = _FakeProviderForMIMOBridge()
+        model = _FakeMimoModel()
+        infra = _FakeInfraForMIMOBridge()
+        calls = []
+
+        def fake_build(config, **kwargs):
+            calls.append((config, kwargs))
+            return model, infra
+
+        monkeypatch.setattr(megatron_mimo_module, "build_megatron_mimo_model", fake_build)
+
+        assert bridge.build_mimo_model(mimo_provider=provider, wrap_with_ddp=False) is model
+        assert calls[0][0] is provider
+        assert bridge._mimo_provider is provider
+        assert bridge._infra is infra
+
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            bridge.build_mimo_model(model_config=object(), mimo_provider=provider)
+
     def test_export_hf_weights_rejects_unimplemented_options(self):
         bridge = _mimo_bridge()
-        bridge.to_megatron_mimo_provider()
+        bridge.to_megatron_model_config()
         infra = _FakeInfraForMIMOBridge()
         model = _FakeMimoModel()
 
@@ -703,7 +746,7 @@ class TestMegatronMIMOBridge:
 
     def test_save_hf_pretrained_delegates(self, monkeypatch):
         bridge = _mimo_bridge()
-        bridge.to_megatron_mimo_provider()
+        bridge.to_megatron_model_config()
         bridge._infra = _FakeInfraForMIMOBridge()
         calls = []
 
@@ -731,6 +774,8 @@ class TestMegatronMIMOBridge:
             bridge._require_infra()
         with pytest.raises(ValueError, match="provider"):
             bridge._require_provider()
+        with pytest.raises(ValueError, match="model config"):
+            bridge._require_model_config()
         with pytest.raises(ValueError, match="single MimoModel"):
             bridge._coerce_mimo_model([model, model])
         with pytest.raises(ValueError, match="hf_path is required"):
@@ -757,7 +802,8 @@ class TestMegatronMIMOBridge:
 
     def test_require_provider_returns_cached_provider(self):
         bridge = _mimo_bridge()
-        provider = bridge.to_megatron_mimo_provider()
+        provider = _FakeProviderForMIMOBridge()
+        bridge._mimo_provider = provider
 
         assert bridge._require_provider() is provider
 
@@ -782,7 +828,7 @@ class TestMegatronMIMOBridge:
 
         bridge = _mimo_bridge()
         bridge._infra = _FakeInfraForMIMOBridge()
-        provider = object()
+        model_config = object()
         calls = []
 
         def fake_save_megatron_mimo_model(*args, **kwargs):
@@ -796,14 +842,34 @@ class TestMegatronMIMOBridge:
             "/ckpt",
             hf_tokenizer_path="/tok",
             hf_tokenizer_kwargs={"trust_remote_code": True},
-            mimo_provider=provider,
+            model_config=model_config,
         )
 
-        assert calls[0][0][:4] == (model, bridge._infra, provider, "/ckpt")
+        assert calls[0][0][:4] == (model, bridge._infra, model_config, "/ckpt")
         assert calls[0][1] == {
             "hf_tokenizer_path": "/tok",
             "hf_tokenizer_kwargs": {"trust_remote_code": True},
         }
+
+    def test_save_megatron_model_routes_deprecated_provider_alias(self, monkeypatch):
+        import megatron.bridge.models.megatron_mimo.conversion.mimo_model_io as mimo_model_io
+
+        bridge = _mimo_bridge()
+        bridge._infra = _FakeInfraForMIMOBridge()
+        provider = _FakeProviderForMIMOBridge()
+        calls = []
+        monkeypatch.setattr(
+            mimo_model_io,
+            "save_megatron_mimo_model",
+            lambda *args, **kwargs: calls.append((args, kwargs)),
+        )
+
+        model = _FakeMimoModel()
+        bridge.save_megatron_model(model, "/ckpt", mimo_provider=provider)
+
+        assert calls[0][0][:4] == (model, bridge._infra, provider, "/ckpt")
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            bridge.save_megatron_model(model, "/ckpt", model_config=object(), mimo_provider=provider)
 
     def test_load_megatron_model_delegates_and_caches(self, monkeypatch):
         import megatron.bridge.models.megatron_mimo.conversion.mimo_model_io as mimo_model_io
@@ -811,12 +877,12 @@ class TestMegatronMIMOBridge:
         bridge = _mimo_bridge()
         model = _FakeMimoModel()
         infra = _FakeInfraForMIMOBridge()
-        provider = _FakeProviderForMIMOBridge()
+        model_config = _FakeModelConfigForMIMOBridge()
         calls = []
 
         def fake_load_megatron_mimo_model(*args, **kwargs):
             calls.append((args, kwargs))
-            return model, infra, provider
+            return model, infra, model_config
 
         monkeypatch.setattr(mimo_model_io, "load_megatron_mimo_model", fake_load_megatron_mimo_model)
 
@@ -824,7 +890,7 @@ class TestMegatronMIMOBridge:
 
         assert returned is model
         assert bridge._infra is infra
-        assert bridge._mimo_provider is provider
+        assert bridge._mimo_model_config is model_config
         assert calls[0][0] == ("/ckpt",)
         assert calls[0][1]["parallelism_config"] == bridge.parallelism_config
         assert calls[0][1]["wrap_with_ddp"] is True

--- a/tests/unit_tests/models/megatron_mimo/conversion/test_orchestrator.py
+++ b/tests/unit_tests/models/megatron_mimo/conversion/test_orchestrator.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 import inspect
+import types
+import warnings
 from collections import namedtuple
 from unittest.mock import Mock
 
@@ -520,8 +522,15 @@ def test_copy_hf_artifacts_forwards_additional_file_patterns(tmp_path):
 class _FakeSourceBridgeForMIMOBridge:
     export_weight_dtype = "bf16"
 
+    def __init__(self):
+        self.model_config_inputs = []
+
     def provider_bridge(self, hf_pretrained):
         return _FakeProviderForMIMOBridge()
+
+    def model_config_bridge(self, hf_pretrained):
+        self.model_config_inputs.append(hf_pretrained)
+        return _FakeModelConfigForMIMOBridge()
 
 
 class _FakeProviderForMIMOBridge:
@@ -568,7 +577,7 @@ def _ensure_fake_mimo_conversion_spec_registered() -> None:
 
     @register_mimo_conversion_spec(_FakeSourceBridgeForMIMOBridge)
     def _fake_mimo_conversion_spec(source_bridge, hf_pretrained, parallelism_config):
-        return _FakeModelConfigForMIMOBridge(), _bridge_routes()
+        return source_bridge.model_config_bridge(hf_pretrained), _bridge_routes()
 
 
 def _mimo_bridge() -> MegatronMIMOBridge:
@@ -588,19 +597,32 @@ class TestMegatronMIMOBridge:
     def test_to_megatron_model_config_resolves_conversion_spec_and_routes(self):
         bridge = _mimo_bridge()
 
-        model_config = bridge.to_megatron_model_config()
+        with pytest.warns(DeprecationWarning, match="to_megatron_model_config"):
+            model_config = bridge.to_megatron_model_config()
 
         assert isinstance(model_config, _FakeModelConfigForMIMOBridge)
+        assert bridge._model_config is model_config
         assert [route.name for route in bridge.routes] == ["language", "images"]
+
+    def test_get_model_config_wraps_config_only_source_for_bridge_contract(self):
+        bridge = _mimo_bridge()
+        source_bridge = bridge._model_bridge
+
+        model_config = bridge.get_model_config()
+
+        assert isinstance(model_config, _FakeModelConfigForMIMOBridge)
+        assert source_bridge.model_config_inputs[0].config is bridge.hf_pretrained
 
     def test_to_megatron_mimo_provider_builds_deprecated_compatibility_provider(self, monkeypatch):
         bridge = _mimo_bridge()
         provider = _FakeProviderForMIMOBridge()
         monkeypatch.setattr(orchestrator_module, "_build_default_mimo_provider", lambda *args: provider)
 
-        mimo_provider = bridge.to_megatron_mimo_provider()
+        with pytest.warns(DeprecationWarning, match="to_megatron_mimo_provider"):
+            mimo_provider = bridge.to_megatron_mimo_provider()
 
         assert mimo_provider is provider
+        assert bridge._model_config is provider
         assert [route.name for route in bridge.routes] == ["language", "images"]
 
     def test_standard_provider_method_points_to_mimo_specific_name(self):
@@ -617,9 +639,11 @@ class TestMegatronMIMOBridge:
         with pytest.raises(NotImplementedError, match="config-only checkpoint export"):
             MegatronMIMOBridge.from_auto_config("/ckpt", "hf")
         with pytest.raises(NotImplementedError, match="hf_path"):
-            bridge.to_megatron_mimo_provider(hf_path="/hf")
+            with pytest.warns(DeprecationWarning, match="to_megatron_mimo_provider"):
+                bridge.to_megatron_mimo_provider(hf_path="/hf")
         with pytest.raises(NotImplementedError, match="load_weights"):
-            bridge.to_megatron_mimo_provider(load_weights=True)
+            with pytest.warns(DeprecationWarning, match="to_megatron_mimo_provider"):
+                bridge.to_megatron_mimo_provider(load_weights=True)
 
     def test_to_megatron_mimo_provider_returns_cached_provider(self, monkeypatch):
         bridge = _mimo_bridge()
@@ -627,9 +651,11 @@ class TestMegatronMIMOBridge:
         build_provider = Mock(return_value=provider)
         monkeypatch.setattr(orchestrator_module, "_build_default_mimo_provider", build_provider)
 
-        first = bridge.to_megatron_mimo_provider()
+        with pytest.warns(DeprecationWarning, match="to_megatron_mimo_provider"):
+            first = bridge.to_megatron_mimo_provider()
 
-        assert bridge.to_megatron_mimo_provider() is first
+        with pytest.warns(DeprecationWarning, match="to_megatron_mimo_provider"):
+            assert bridge.to_megatron_mimo_provider() is first
         build_provider.assert_called_once()
         bridge.validate_mimo_conversion_support()
 
@@ -675,26 +701,86 @@ class TestMegatronMIMOBridge:
         assert calls[0]["pg_collections"] == bridge._infra.pg_collections
         assert calls[0]["allowed_mismatched_params"] == ["ignored.*"]
 
-    def test_to_megatron_model_builds_and_optionally_loads(self, monkeypatch):
+    def test_to_megatron_model_delegates_to_canonical_builder_api(self, monkeypatch):
         bridge = _mimo_bridge()
         model = _FakeMimoModel()
-        calls = []
+        canonical = Mock(return_value=[model])
+        monkeypatch.setattr(bridge, "get_megatron_model", canonical)
 
-        def fake_build_mimo_model(**kwargs):
-            calls.append(("build", kwargs))
-            return model
+        with pytest.warns(DeprecationWarning, match="to_megatron_model"):
+            assert bridge.to_megatron_model(load_weights=True, hf_path="/hf", wrap_with_ddp=False) == [model]
 
-        def fake_load_hf_weights(model_arg, **kwargs):
-            calls.append(("load", model_arg, kwargs))
-            return model_arg
+        canonical.assert_called_once_with(load_weights=True, hf_path="/hf", wrap_with_ddp=False)
 
-        monkeypatch.setattr(bridge, "build_mimo_model", fake_build_mimo_model)
-        monkeypatch.setattr(bridge, "load_hf_weights", fake_load_hf_weights)
+    def test_get_megatron_model_loads_weights_before_wrapping_and_registers_on_success(self, monkeypatch):
+        bridge = _mimo_bridge()
+        bridge._routes = _bridge_routes()
+        previous_config = object()
+        bridge._model_config = previous_config
+        model = _FakeMimoModel()
+        infra = _FakeInfraForMIMOBridge()
+        transformer = types.SimpleNamespace(perform_initialization=True)
+        original_hook = Mock(side_effect=lambda models: models)
+        model_config = Mock()
+        model_config.source_model_config = types.SimpleNamespace(transformer=transformer)
+        model_config.pre_wrap_hooks = [original_hook]
+        model_config.fp16 = True
+        model_config.bf16 = False
+        builder = Mock()
+        builder.build_infra.return_value = infra
+        model_config.get_builder_cls.return_value = lambda config: builder
+        imported = []
 
-        assert bridge.to_megatron_model(load_weights=True, hf_path="/hf", wrap_with_ddp=False) == [model]
-        assert calls[0][0] == "build"
-        assert calls[0][1]["wrap_with_ddp"] is False
-        assert calls[1] == ("load", model, {"hf_path": "/hf"})
+        monkeypatch.setattr(bridge, "_resolve_hf_pretrained", lambda hf_path: "hf")
+        monkeypatch.setattr(
+            orchestrator_module,
+            "import_hf_to_megatron_mimo",
+            lambda **kwargs: imported.append(kwargs),
+        )
+
+        def fake_build(config, **kwargs):
+            assert kwargs["infra"] is infra
+            assert kwargs["fp16"] is True
+            assert kwargs["bf16"] is False
+            assert transformer.perform_initialization is False
+            assert config.pre_wrap_hooks[0] is not original_hook
+            models = [model]
+            for hook in config.pre_wrap_hooks:
+                models = hook(models)
+            return models[0], infra
+
+        monkeypatch.setattr(bridge, "_build_mimo_model", fake_build)
+
+        assert bridge.get_megatron_model(model_config, hf_path="/hf", wrap_with_ddp=True) == [model]
+
+        assert imported[0]["mimo_model"] is model
+        assert imported[0]["pg_collections"] is infra.pg_collections
+        assert bridge._model_config is model_config
+        assert bridge._infra is infra
+        assert transformer.perform_initialization is True
+        assert model_config.pre_wrap_hooks == [original_hook]
+        original_hook.assert_called_once_with([model])
+
+    def test_get_megatron_model_failure_preserves_current_config(self, monkeypatch):
+        bridge = _mimo_bridge()
+        bridge._routes = _bridge_routes()
+        previous_config = object()
+        bridge._model_config = previous_config
+        transformer = types.SimpleNamespace(perform_initialization=True)
+        model_config = Mock()
+        model_config.source_model_config = types.SimpleNamespace(transformer=transformer)
+        model_config.pre_wrap_hooks = []
+        builder = Mock()
+        builder.build_infra.return_value = _FakeInfraForMIMOBridge()
+        model_config.get_builder_cls.return_value = lambda config: builder
+        monkeypatch.setattr(bridge, "_build_mimo_model", Mock(side_effect=RuntimeError("build failed")))
+
+        with pytest.raises(RuntimeError, match="build failed"):
+            bridge.get_megatron_model(model_config, load_weights=False, wrap_with_ddp=False)
+
+        assert bridge._model_config is previous_config
+        assert transformer.perform_initialization is True
+        assert model_config.pre_wrap_hooks == []
 
     def test_build_mimo_model_routes_deprecated_provider_alias_and_caches(self, monkeypatch):
         bridge = _mimo_bridge()
@@ -704,12 +790,19 @@ class TestMegatronMIMOBridge:
         calls = []
 
         def fake_build(config, **kwargs):
+            warnings.warn(
+                "Passing MegatronMIMOProvider to build_megatron_mimo_model() is deprecated. "
+                "Pass MegatronMIMOModelConfig instead.",
+                DeprecationWarning,
+            )
             calls.append((config, kwargs))
             return model, infra
 
         monkeypatch.setattr(megatron_mimo_module, "build_megatron_mimo_model", fake_build)
 
-        assert bridge.build_mimo_model(mimo_provider=provider, wrap_with_ddp=False) is model
+        with pytest.warns(DeprecationWarning, match="mimo_provider") as caught_warnings:
+            assert bridge.build_mimo_model(mimo_provider=provider, wrap_with_ddp=False) is model
+        assert len(caught_warnings) == 1
         assert calls[0][0] is provider
         assert bridge._mimo_provider is provider
         assert bridge._infra is infra
@@ -865,7 +958,8 @@ class TestMegatronMIMOBridge:
         )
 
         model = _FakeMimoModel()
-        bridge.save_megatron_model(model, "/ckpt", mimo_provider=provider)
+        with pytest.warns(DeprecationWarning, match="mimo_provider"):
+            bridge.save_megatron_model(model, "/ckpt", mimo_provider=provider)
 
         assert calls[0][0][:4] == (model, bridge._infra, provider, "/ckpt")
         with pytest.raises(ValueError, match="mutually exclusive"):
@@ -890,7 +984,7 @@ class TestMegatronMIMOBridge:
 
         assert returned is model
         assert bridge._infra is infra
-        assert bridge._mimo_model_config is model_config
+        assert bridge._model_config is model_config
         assert calls[0][0] == ("/ckpt",)
         assert calls[0][1]["parallelism_config"] == bridge.parallelism_config
         assert calls[0][1]["wrap_with_ddp"] is True
@@ -903,8 +997,8 @@ class TestMegatronMIMOBridge:
 
         monkeypatch.setattr(
             bridge,
-            "to_megatron_model",
-            lambda **kwargs: calls.append(("to_megatron_model", kwargs)) or [model],
+            "get_megatron_model",
+            lambda **kwargs: calls.append(("get_megatron_model", kwargs)) or [model],
         )
         monkeypatch.setattr(
             bridge,
@@ -915,7 +1009,7 @@ class TestMegatronMIMOBridge:
         bridge.import_ckpt("/ckpt", hf_tokenizer_path="hf", hf_tokenizer_kwargs={"trust_remote_code": True})
 
         assert calls[0] == (
-            "to_megatron_model",
+            "get_megatron_model",
             {"load_weights": True, "wrap_with_ddp": False, "data_parallel_random_init": False},
         )
         assert calls[1] == (

--- a/tests/unit_tests/models/megatron_mimo/conversion/test_qwen35_vl_default_conversion.py
+++ b/tests/unit_tests/models/megatron_mimo/conversion/test_qwen35_vl_default_conversion.py
@@ -17,7 +17,6 @@
 from unittest.mock import MagicMock
 
 import pytest
-from megatron.core.transformer.spec_utils import ModuleSpec
 
 from megatron.bridge.models.megatron_mimo.conversion import (
     MIMOComponent,
@@ -30,9 +29,9 @@ from megatron.bridge.models.megatron_mimo.megatron_mimo_config import (
     MegatronMIMOParallelismConfig,
     ModuleParallelismConfig,
 )
-from megatron.bridge.models.megatron_mimo.megatron_mimo_provider import MegatronMIMOProvider
+from megatron.bridge.models.megatron_mimo.model_config import MegatronMIMOModelConfig
 from megatron.bridge.models.qwen_vl.qwen35_vl_bridge import Qwen35VLBridge
-from megatron.bridge.models.qwen_vl.qwen35_vl_provider import _TRANSFORMERS_HAS_QWEN3_5, Qwen35VLModelProvider
+from megatron.bridge.models.qwen_vl.qwen35_vl_provider import _TRANSFORMERS_HAS_QWEN3_5
 
 
 pytestmark = pytest.mark.skipif(not _TRANSFORMERS_HAS_QWEN3_5, reason="transformers does not have qwen3_5 support")
@@ -48,32 +47,6 @@ def _make_parallelism_config() -> MegatronMIMOParallelismConfig:
     )
 
 
-def _make_language_provider() -> Qwen35VLModelProvider:
-    """Small Qwen35VLModelProvider; ``deepstack_visual_indexes`` patched in.
-
-    Bare ``Qwen3_5VisionConfig()`` constructor lacks ``deepstack_visual_indexes``;
-    real loaded HF configs supply it (defaulted to empty). Setting it here so
-    the MIMO provider's eager ``_build_vision_modality_spec`` doesn't trip
-    inside ``get_vision_model_config``.
-    """
-    provider = Qwen35VLModelProvider(
-        num_layers=64,
-        hidden_size=5120,
-        num_attention_heads=24,
-        vocab_size=128,
-    )
-    provider.vision_config.deepstack_visual_indexes = []
-    return provider
-
-
-def _patch_language_spec(monkeypatch, language_provider: Qwen35VLModelProvider) -> None:
-    monkeypatch.setattr(
-        language_provider,
-        "build_language_spec",
-        lambda vp_stage=None, pp_rank=None: ModuleSpec(module=object),
-    )
-
-
 def _get_qwen35_conversion_spec():
     _reset_registry_for_tests()
     return get_mimo_conversion_spec(Qwen35VLBridge)
@@ -81,14 +54,15 @@ def _get_qwen35_conversion_spec():
 
 def _run_qwen35_conversion_spec(
     monkeypatch,
-    language_provider: Qwen35VLModelProvider,
     parallelism_config: MegatronMIMOParallelismConfig,
-) -> tuple[MegatronMIMOProvider, list[MIMOComponent], Qwen35VLBridge, object]:
+) -> tuple[MegatronMIMOModelConfig, list[MIMOComponent], Qwen35VLBridge, object]:
     source_bridge = Qwen35VLBridge()
-    monkeypatch.setattr(source_bridge, "provider_bridge", MagicMock(return_value=language_provider))
+    source_model_config = MagicMock(image_token_id=248056)
+    monkeypatch.setattr(source_bridge, "model_config_bridge", MagicMock(return_value=source_model_config))
+    monkeypatch.setattr(source_bridge, "provider_bridge", MagicMock(side_effect=AssertionError("provider path used")))
     hf_pretrained = object()
-    provider, routes = _get_qwen35_conversion_spec()(source_bridge, hf_pretrained, parallelism_config)
-    return provider, routes, source_bridge, hf_pretrained
+    config, routes = _get_qwen35_conversion_spec()(source_bridge, hf_pretrained, parallelism_config)
+    return config, routes, source_bridge, hf_pretrained
 
 
 class TestQwen35VLDefaultMIMOConversion:
@@ -98,35 +72,18 @@ class TestQwen35VLDefaultMIMOConversion:
         assert callable(conversion_spec)
         assert supports_mimo_conversion(Qwen35VLBridge)
 
-    def test_returns_provider_and_routes(self, monkeypatch):
-        language_provider = _make_language_provider()
-        _patch_language_spec(monkeypatch, language_provider)
+    def test_returns_config_and_routes(self, monkeypatch):
         parallelism_config = _make_parallelism_config()
 
-        provider, routes, source_bridge, hf_pretrained = _run_qwen35_conversion_spec(
-            monkeypatch,
-            language_provider,
-            parallelism_config,
-        )
+        config, routes, source_bridge, hf_pretrained = _run_qwen35_conversion_spec(monkeypatch, parallelism_config)
 
-        source_bridge.provider_bridge.assert_called_once_with(hf_pretrained)
-        assert isinstance(provider, MegatronMIMOProvider)
-        assert provider.language_model_spec.params["config"] is language_provider
-        assert provider.megatron_mimo_parallelism_config is parallelism_config
+        source_bridge.model_config_bridge.assert_called_once_with(hf_pretrained)
+        source_bridge.provider_bridge.assert_not_called()
+        assert isinstance(config, MegatronMIMOModelConfig)
+        assert config.megatron_mimo_parallelism_config is parallelism_config
 
         assert len(routes) == 2
         assert all(isinstance(r, MIMOComponent) for r in routes)
-
-    def test_forces_mtp_off(self, monkeypatch):
-        """MIMO conversion disables MTP for the standard provider."""
-        language_provider = _make_language_provider()
-        _patch_language_spec(monkeypatch, language_provider)
-        language_provider.mtp_num_layers = 4
-        parallelism_config = _make_parallelism_config()
-
-        provider, _, _, _ = _run_qwen35_conversion_spec(monkeypatch, language_provider, parallelism_config)
-        assert isinstance(provider, MegatronMIMOProvider)
-        assert language_provider.mtp_num_layers is None
 
     def test_route_table_contents(self, monkeypatch):
         """Routes match the parameter prefixes used by Qwen35VLBridge.mapping_registry.
@@ -137,9 +94,7 @@ class TestQwen35VLDefaultMIMOConversion:
           - ``mimo_model.language_model``
           - ``mimo_model.modality_submodules.images.encoders.qwen_visual``
         """
-        language_provider = _make_language_provider()
-        _patch_language_spec(monkeypatch, language_provider)
-        _, routes, _, _ = _run_qwen35_conversion_spec(monkeypatch, language_provider, _make_parallelism_config())
+        _, routes, _, _ = _run_qwen35_conversion_spec(monkeypatch, _make_parallelism_config())
 
         names = {route.name: route for route in routes}
         assert set(names.keys()) == {"language", "images"}
@@ -159,8 +114,6 @@ class TestQwen35VLDefaultMIMOConversion:
         routes without spurious "unmapped component" errors.
         """
         parallelism_config = _make_parallelism_config()
-        language_provider = _make_language_provider()
-        _patch_language_spec(monkeypatch, language_provider)
-        _, routes, _, _ = _run_qwen35_conversion_spec(monkeypatch, language_provider, parallelism_config)
+        _, routes, _, _ = _run_qwen35_conversion_spec(monkeypatch, parallelism_config)
 
         validate_route_table(routes, parallelism_config=parallelism_config)

--- a/tests/unit_tests/models/megatron_mimo/conversion/test_routes_and_registry.py
+++ b/tests/unit_tests/models/megatron_mimo/conversion/test_routes_and_registry.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from types import SimpleNamespace
+
 import pytest
 from megatron.core.transformer.spec_utils import ModuleSpec
 from transformers.configuration_utils import PretrainedConfig
@@ -30,7 +32,7 @@ from megatron.bridge.models.megatron_mimo.megatron_mimo_config import (
     MegatronMIMOParallelismConfig,
     ModuleParallelismConfig,
 )
-from megatron.bridge.models.megatron_mimo.megatron_mimo_provider import MegatronMIMOProvider
+from megatron.bridge.models.megatron_mimo.model_config import MegatronMIMOModelConfig
 
 
 def _two_component_config() -> MegatronMIMOParallelismConfig:
@@ -179,6 +181,14 @@ class _FakeSourceBridgeWithProvider:
 
 class _FakeSourceBridgeWithDefaultRoutes(_FakeSourceBridgeWithProvider):
     mimo_source_prefixes = {"language": "language_model.", "vision": "vision_model."}
+    mimo_modality_keys = {"vision": "fake_visual"}
+    mimo_special_token_fields = {"vision": "image_token_id"}
+    mimo_language_spec_builder = "tests.fake.language_spec"
+    mimo_modality_spec_builder = "tests.fake.modality_specs"
+
+    def model_config_bridge(self, hf_pretrained):
+        self.hf_pretrained = hf_pretrained
+        return SimpleNamespace(image_token_id=7)
 
 
 class TestConversionSpecRegistry:
@@ -224,14 +234,14 @@ class TestConversionSpecRegistry:
 
         source_bridge = _FakeSourceBridgeWithDefaultRoutes()
         hf_pretrained = object()
-        provider, route_table = get_mimo_conversion_spec(_FakeSourceBridgeWithDefaultRoutes)(
+        config, route_table = get_mimo_conversion_spec(_FakeSourceBridgeWithDefaultRoutes)(
             source_bridge,
             hf_pretrained,
             _two_component_config(),
         )
 
-        assert isinstance(provider, MegatronMIMOProvider)
-        assert provider.standard_provider is source_bridge.provider
+        assert isinstance(config, MegatronMIMOModelConfig)
+        assert config.special_token_ids == {"vision": 7}
         assert source_bridge.hf_pretrained is hf_pretrained
         assert route_table == [
             MIMOComponent("language", "language_model.", "language_model"),
@@ -245,7 +255,7 @@ class TestConversionSpecRegistry:
         with pytest.raises(KeyError, match="mimo_source_prefixes"):
             get_mimo_conversion_spec(_FakeBridgeA)
 
-    def test_validate_mimo_conversion_support_resolves_provider_and_routes(self):
+    def test_validate_mimo_conversion_support_resolves_config_and_routes(self):
         source_bridge = _FakeSourceBridgeWithDefaultRoutes()
         bridge = MegatronMIMOBridge(
             PretrainedConfig(),
@@ -255,7 +265,7 @@ class TestConversionSpecRegistry:
 
         bridge.validate_mimo_conversion_support()
 
-        assert isinstance(bridge.to_megatron_mimo_provider(load_weights=False), MegatronMIMOProvider)
+        assert isinstance(bridge.to_megatron_model_config(load_weights=False), MegatronMIMOModelConfig)
         assert bridge.routes == [
             MIMOComponent("language", "language_model.", "language_model"),
             MIMOComponent("vision", "vision_model.", "modality_submodules.vision.encoders.fake_visual"),

--- a/tests/unit_tests/models/megatron_mimo/test_example_data_callbacks.py
+++ b/tests/unit_tests/models/megatron_mimo/test_example_data_callbacks.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Static contracts for runtime-grid handoff in MegatronMIMO examples."""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+
+REPOSITORY_ROOT = Path(__file__).parents[4]
+EXAMPLE_PATHS = [
+    "examples/megatron_mimo/qwen35_vl/finetune_qwen35_vl.py",
+    "examples/megatron_mimo/llava/megatron_mimo_training_llava.py",
+    "examples/megatron_mimo/llava/megatron_mimo_training_llava_audio.py",
+]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("relative_path", EXAMPLE_PATHS)
+def test_mimo_example_data_callbacks_use_runtime_infra_grids(relative_path: str) -> None:
+    """Require example callbacks to use grids built outside the serializable config."""
+    tree = ast.parse((REPOSITORY_ROOT / relative_path).read_text())
+    callbacks = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == "_build_data_iterators"
+    ]
+
+    assert callbacks, f"No _build_data_iterators callback found in {relative_path}"
+    for callback in callbacks:
+        rendered = ast.unparse(callback)
+        assert "megatron_mimo_infra.module_to_grid_map" in rendered
+        assert "cfg.model._grids" not in rendered

--- a/tests/unit_tests/models/megatron_mimo/test_megatron_mimo_provider.py
+++ b/tests/unit_tests/models/megatron_mimo/test_megatron_mimo_provider.py
@@ -3,6 +3,7 @@
 
 from unittest.mock import MagicMock, Mock, patch
 
+import pytest
 from megatron.core.transformer.spec_utils import ModuleSpec
 
 from megatron.bridge.models.megatron_mimo import (
@@ -178,7 +179,10 @@ class TestMegatronMIMOProvider:
         mock_model_instance = MagicMock()
         mock_mimo_model.return_value = mock_model_instance
 
-        result = provider.provide()
+        with pytest.warns(DeprecationWarning, match=r"provide\(\) is deprecated") as warnings:
+            result = provider.provide()
+
+        assert len(warnings) == 1
 
         assert result == mock_model_instance
 
@@ -208,7 +212,10 @@ class TestMegatronMIMOProvider:
         language_spec = ModuleSpec(module=Mock, params={"config": Mock()})
         provider = MegatronMIMOProvider(language_model_spec=language_spec)
 
-        infra = provider.build_infra()
+        with pytest.warns(DeprecationWarning, match=r"build_infra\(\) is deprecated") as warnings:
+            infra = provider.build_infra()
+
+        assert len(warnings) == 1
 
         # Should return infrastructure with auto-derived topology
         assert isinstance(infra, MegatronMIMOInfra)
@@ -488,8 +495,6 @@ class TestMegatronMIMOProvider:
         language_spec = ModuleSpec(module=Mock, params={"config": Mock()})
         provider = MegatronMIMOProvider(language_model_spec=language_spec)
 
-        import pytest
-
         with pytest.raises(NotImplementedError, match="MegatronMIMO does not use global model parallelism"):
             provider.initialize_model_parallel(seed=42)
         with pytest.raises(NotImplementedError, match="MegatronMIMO does not use global model parallelism"):
@@ -522,10 +527,40 @@ class TestMegatronMIMOProvider:
         mock_get_config.return_value = mock_config
 
         # No parallelism config means no DDP wrapping needed
-        provider.provide_distributed_model(wrap_with_ddp=False)
+        with pytest.warns(DeprecationWarning, match=r"provide_distributed_model\(\) is deprecated") as warnings:
+            provider.provide_distributed_model(wrap_with_ddp=False)
+
+        assert len(warnings) == 1
 
         # Should have set variable_seq_lengths=True
         assert mock_config.variable_seq_lengths is True
+
+    @patch("megatron.bridge.models.megatron_mimo.megatron_mimo_provider.MimoModel")
+    @patch("megatron.bridge.models.megatron_mimo.megatron_mimo_provider.get_model_config")
+    def test_distributed_build_preserves_and_reuses_infra_override(self, mock_get_config, mock_mimo_model):
+        """Deprecated distributed builds call a subclass infra override only once."""
+        infra = MagicMock()
+        model = MagicMock()
+        calls = []
+
+        class OverrideProvider(MegatronMIMOProvider):
+            def build_infra(self):
+                calls.append("build_infra")
+                return infra
+
+        provider = OverrideProvider(
+            language_model_spec=ModuleSpec(module=Mock, params={"config": Mock()}),
+            bf16=False,
+        )
+        mock_mimo_model.return_value = model
+        mock_get_config.return_value = MagicMock(variable_seq_lengths=False)
+
+        with pytest.warns(DeprecationWarning, match=r"provide_distributed_model\(\) is deprecated") as warnings:
+            result = provider.provide_distributed_model(wrap_with_ddp=False)
+
+        assert len(warnings) == 1
+        assert result == [model]
+        assert calls == ["build_infra"]
 
 
 class TestMegatronMIMOInfra:

--- a/tests/unit_tests/models/megatron_mimo/test_model_config.py
+++ b/tests/unit_tests/models/megatron_mimo/test_model_config.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+import yaml
+from megatron.core.transformer import TransformerConfig
+from megatron.training.config.yaml_utils import safe_yaml_representers
+
+import megatron.bridge.models.megatron_mimo.model_config as model_config_module
+from megatron.bridge.models.common.base import ModelConfig
+from megatron.bridge.models.gpt.model_config import BridgeGPTModelConfig
+from megatron.bridge.models.megatron_mimo import MegatronMIMOInfra as PackageMegatronMIMOInfra
+from megatron.bridge.models.megatron_mimo.infra import MegatronMIMOInfra
+from megatron.bridge.models.megatron_mimo.megatron_mimo_config import (
+    MegatronMIMOParallelismConfig,
+    ModuleParallelismConfig,
+)
+from megatron.bridge.models.megatron_mimo.megatron_mimo_provider import (
+    MegatronMIMOInfra as ProviderMegatronMIMOInfra,
+)
+from megatron.bridge.models.megatron_mimo.model_config import (
+    MegatronMIMOInfra as ModelConfigMegatronMIMOInfra,
+)
+from megatron.bridge.models.megatron_mimo.model_config import (
+    MegatronMIMOModelBuilder,
+    MegatronMIMOModelConfig,
+)
+from megatron.bridge.models.model_provider import ModelProviderMixin
+from megatron.bridge.training.config import ConfigContainer
+
+
+def _model_config() -> MegatronMIMOModelConfig:
+    source = BridgeGPTModelConfig(
+        transformer=TransformerConfig(num_layers=1, hidden_size=8, num_attention_heads=1),
+        vocab_size=32,
+    )
+    parallelism = MegatronMIMOParallelismConfig(
+        module_parallelisms={
+            "language": ModuleParallelismConfig(data_parallel_size=1),
+            "images": ModuleParallelismConfig(data_parallel_size=1, rank_offset=1),
+        }
+    )
+    return MegatronMIMOModelConfig(
+        source_model_config=source,
+        megatron_mimo_parallelism_config=parallelism,
+        language_spec_builder="pkg.language_spec",
+        modality_spec_builder="pkg.modality_specs",
+        modality_keys={"images": "vision"},
+        special_token_ids={"images": 7},
+    )
+
+
+def test_infra_public_imports_resolve_to_one_shared_class() -> None:
+    assert PackageMegatronMIMOInfra is MegatronMIMOInfra
+    assert ProviderMegatronMIMOInfra is MegatronMIMOInfra
+    assert ModelConfigMegatronMIMOInfra is MegatronMIMOInfra
+
+
+def test_config_builder_returns_public_infra_class(monkeypatch) -> None:
+    monkeypatch.setattr(model_config_module, "build_hypercomm_grids", lambda _config: {})
+
+    infra = MegatronMIMOModelBuilder(_model_config()).build_infra()
+
+    assert type(infra) is MegatronMIMOInfra
+    assert isinstance(infra, PackageMegatronMIMOInfra)
+
+
+def test_model_config_roundtrip_is_provider_neutral() -> None:
+    config = _model_config()
+    serialized = config.as_dict()
+    restored = MegatronMIMOModelConfig.from_dict(serialized)
+
+    assert not isinstance(config, ModelProviderMixin)
+    assert restored.as_dict() == serialized
+    assert restored.special_token_ids == {"images": 7}
+
+
+def test_config_container_yaml_representation_restores_parallelism_dataclasses() -> None:
+    config = _model_config()
+    model_payload = ConfigContainer._convert_value_to_dict(config)
+    with safe_yaml_representers():
+        yaml_payload = yaml.safe_load(yaml.safe_dump({"model": model_payload}))
+
+    restored = ModelConfig.from_dict(yaml_payload["model"])
+
+    assert isinstance(restored, MegatronMIMOModelConfig)
+    assert isinstance(restored.megatron_mimo_parallelism_config, MegatronMIMOParallelismConfig)
+    assert all(
+        isinstance(module_config, ModuleParallelismConfig)
+        for module_config in restored.megatron_mimo_parallelism_config.module_parallelisms.values()
+    )
+    assert restored.megatron_mimo_parallelism_config.module_parallelisms["images"].rank_offset == 1
+    builder = MegatronMIMOModelBuilder(restored)
+    assert isinstance(
+        builder._model_config.megatron_mimo_parallelism_config.module_parallelisms["language"],
+        ModuleParallelismConfig,
+    )

--- a/tests/unit_tests/models/megatron_mimo/test_qwen35_vl_provider.py
+++ b/tests/unit_tests/models/megatron_mimo/test_qwen35_vl_provider.py
@@ -2,11 +2,9 @@
 """Unit tests for Qwen3.5-VL standard-provider MegatronMIMO hooks."""
 
 import pytest
-import yaml
 from megatron.core.models.mimo.submodules.vision import VisionModalitySubmodules
 from megatron.core.transformer.spec_utils import ModuleSpec
 
-from megatron.bridge.models.megatron_mimo.conversion.mimo_model_io import _clear_derived_spec_fields
 from megatron.bridge.models.megatron_mimo.megatron_mimo_config import (
     MegatronMIMOParallelismConfig,
     ModuleParallelismConfig,
@@ -15,9 +13,6 @@ from megatron.bridge.models.megatron_mimo.megatron_mimo_provider import Megatron
 from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.text_model import Qwen3VLGPTModel
 from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.vision_model import Qwen3VLVisionModel
 from megatron.bridge.models.qwen_vl.qwen35_vl_provider import _TRANSFORMERS_HAS_QWEN3_5, Qwen35VLModelProvider
-from megatron.bridge.training.config import ConfigContainer
-from megatron.bridge.utils.instantiate_utils import instantiate
-from megatron.bridge.utils.yaml_utils import safe_yaml_representers
 
 
 pytestmark = pytest.mark.skipif(not _TRANSFORMERS_HAS_QWEN3_5, reason="transformers does not have qwen3_5 support")
@@ -169,33 +164,6 @@ class TestMegatronMIMOProviderFactory:
         images_spec = provider.modality_submodules_spec["images"]
         assert images_spec.module is VisionModalitySubmodules
         assert list(images_spec.submodules["encoders"].keys()) == ["dummy_visual"]
-
-    def test_yaml_round_trip_rebuilds_specs_after_clear(self, tmp_path):
-        language_provider = _make_language_provider()
-        provider = MegatronMIMOProvider.from_standard_provider(
-            standard_provider=language_provider,
-            megatron_mimo_parallelism_config=_make_parallelism_config(),
-        )
-
-        _clear_derived_spec_fields(provider)
-        model_dict = ConfigContainer._convert_value_to_dict(provider)
-        assert model_dict["language_model_spec"] is None
-        assert model_dict["modality_submodules_spec"] == {}
-        assert model_dict["special_token_ids"] == {}
-        assert "standard_provider" in model_dict
-
-        yaml_path = tmp_path / "run_config.yaml"
-        with safe_yaml_representers():
-            yaml_path.write_text(yaml.safe_dump({"model": model_dict}))
-
-        loaded_dict = yaml.safe_load(yaml_path.read_text())
-        loaded_provider = instantiate(loaded_dict["model"])
-
-        assert isinstance(loaded_provider, MegatronMIMOProvider)
-        assert isinstance(loaded_provider.standard_provider, Qwen35VLModelProvider)
-        assert loaded_provider.language_model_spec is not None
-        assert loaded_provider.modality_submodules_spec
-        assert loaded_provider.special_token_ids == {"images": language_provider.image_token_id}
 
     def test_from_standard_provider_requires_language_model_spec_api(self):
         with pytest.raises(TypeError, match="build_language_model_spec"):

--- a/tests/unit_tests/models/qwen_vl/test_model_config.py
+++ b/tests/unit_tests/models/qwen_vl/test_model_config.py
@@ -24,6 +24,7 @@ from megatron.bridge.models.qwen_vl.model_config import (
     Qwen25VLModelConfig,
     Qwen35VLModelBuilder,
     Qwen35VLModelConfig,
+    build_qwen35_mimo_modality_specs,
 )
 from megatron.bridge.models.qwen_vl.qwen25_vl_bridge import Qwen25VLBridge
 
@@ -302,6 +303,49 @@ def test_qwen2_audio_builder_passes_outer_config_without_transformer_copy(monkey
     assert type(config.transformer) is TransformerConfig
     assert "audio_token_id" not in config.transformer.__dict__
     assert "pad_token_id" not in config.transformer.__dict__
+
+
+@pytest.mark.unit
+def test_qwen35_mimo_modality_spec_uses_exact_mcore_transformer(monkeypatch):
+    vision_config = SimpleNamespace(
+        depth=2,
+        hidden_size=16,
+        num_heads=2,
+        intermediate_size=32,
+        patch_size=2,
+        temporal_patch_size=2,
+        in_channels=3,
+        spatial_merge_size=2,
+        num_position_embeddings=16,
+        out_hidden_size=16,
+        deepstack_visual_indexes=[],
+    )
+    config = Qwen35VLModelConfig(
+        transformer=TransformerConfig(num_layers=2, hidden_size=16, num_attention_heads=2),
+        vocab_size=32,
+    )
+    monkeypatch.setattr(
+        "megatron.bridge.models.qwen_vl.model_config._vision_config_from_dict",
+        lambda *args: vision_config,
+    )
+
+    specs = build_qwen35_mimo_modality_specs(config)
+    encoder_spec = specs["images"].submodules["encoders"]["qwen_visual"]
+    transformer = encoder_spec.params["transformer_config"]
+
+    assert type(transformer) is TransformerConfig
+    assert encoder_spec.params["vision_config"] is vision_config
+    for family_field in (
+        "patch_size",
+        "temporal_patch_size",
+        "in_channels",
+        "spatial_merge_size",
+        "num_position_embeddings",
+        "out_hidden_size",
+        "deepstack_visual_indexes",
+        "apply_rotary_pos_emb_in_fp32",
+    ):
+        assert family_field not in transformer.__dict__
 
 
 @pytest.mark.unit

--- a/tests/unit_tests/training/utils/test_theoretical_memory_utils.py
+++ b/tests/unit_tests/training/utils/test_theoretical_memory_utils.py
@@ -68,10 +68,16 @@ def _make_config(**model_overrides):
 
 
 def _mock_megatron_mimo_provider(monkeypatch):
+    model_config_module_name = "megatron.bridge.models.megatron_mimo.model_config"
+    model_config_module = ModuleType(model_config_module_name)
+    model_config_module.MegatronMIMOModelConfig = type("MegatronMIMOModelConfig", (), {})
+    monkeypatch.setitem(sys.modules, model_config_module_name, model_config_module)
+
     module_name = "megatron.bridge.models.megatron_mimo.megatron_mimo_provider"
     module = ModuleType(module_name)
     module.MegatronMIMOProvider = type("MegatronMIMOProvider", (), {})
     monkeypatch.setitem(sys.modules, module_name, module)
+    return model_config_module.MegatronMIMOModelConfig, module.MegatronMIMOProvider
 
 
 @pytest.mark.unit
@@ -189,3 +195,14 @@ def test_report_theoretical_memory_uses_structured_estimate(monkeypatch, capsys)
     assert "Theoretical memory footprints: weight and optimizer=0.03 MB" in captured.out
     assert "activation=0.02 MB" in captured.out
     assert "total=0.05 MB" in captured.out
+
+
+@pytest.mark.unit
+def test_report_theoretical_memory_skips_builder_backed_mimo(monkeypatch, capsys):
+    model_config_class, _ = _mock_megatron_mimo_provider(monkeypatch)
+    config = _make_config()
+    config.model = model_config_class()
+
+    report_theoretical_memory(config, num_microbatches=4)
+
+    assert capsys.readouterr().out == ""


### PR DESCRIPTION
## Summary

- migrate MegatronMIMO construction, conversion, checkpoint IO, and data loading to serializable ModelConfig plus standalone ModelBuilder contracts
- retain deprecated provider compatibility paths and released keyword aliases
- use one provider-neutral MegatronMIMOInfra type across legacy and builder paths
- pass runtime process grids explicitly from setup infrastructure instead of storing them in serializable configs
- update Qwen3.5-VL MIMO spec builders and repository examples

## Stack

- Base: #4545
- This PR contains only MegatronMIMO-specific migration changes and tests. Xiaomi MiMo model families remain in the base PR.

## Validation

- uvx pre-commit run --all-files
- two independent subagent review passes completed; all confirmed findings fixed
- EOS: 628 targeted unit tests passed
- EOS: 2-GPU MegatronMIMO checkpoint save/load round-trip passed
