### PR TITLE
test(data): cover collate import boundaries

### DIFF
--- a/tests/unit_tests/data/vlm_datasets/test_imports.py
+++ b/tests/unit_tests/data/vlm_datasets/test_imports.py
@@ -21,49 +21,52 @@ import pytest
 pytestmark = pytest.mark.unit
 
 
-def test_direct_qwen_vl_collate_import_has_no_vlm_dataset_cycle():
+COLLATE_REGISTRY_MODULE = "megatron.bridge.data.vlm_datasets.collate"
+LIGHTWEIGHT_COLLATE_MODULES = [
+    "megatron.bridge.data.vlm_datasets.collate_utils",
+    "megatron.bridge.models.gemma_vl.data.collate_fn",
+    "megatron.bridge.models.glm_vl.data.collate_fn",
+    "megatron.bridge.models.kimi_vl.data.collate_fn",
+    "megatron.bridge.models.ministral3.data.collate_fn",
+    "megatron.bridge.models.nemotron_omni.data.collate_fn",
+    "megatron.bridge.models.nemotron_vl.data.collate_fn",
+    "megatron.bridge.models.qwen_audio.data.collate_fn",
+    "megatron.bridge.models.qwen_vl.data.collate_fn",
+]
+
+
+def _assert_subprocess_succeeds(code: str) -> None:
     result = subprocess.run(
-        [sys.executable, "-c", "import megatron.bridge.models.qwen_vl.data.collate_fn"],
+        [sys.executable, "-c", code],
         capture_output=True,
         text=True,
+        timeout=180,
         check=False,
     )
 
-    assert result.returncode == 0, result.stderr
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+@pytest.mark.parametrize("module_name", LIGHTWEIGHT_COLLATE_MODULES)
+def test_direct_collate_module_import_does_not_load_registry(module_name):
+    _assert_subprocess_succeeds(
+        "import importlib; "
+        "import sys; "
+        f"importlib.import_module({module_name!r}); "
+        f"assert {COLLATE_REGISTRY_MODULE!r} not in sys.modules"
+    )
 
 
 def test_vlm_datasets_package_import_does_not_load_collate_registry():
-    result = subprocess.run(
-        [
-            sys.executable,
-            "-c",
-            (
-                "import sys; "
-                "import megatron.bridge.data.vlm_datasets; "
-                "assert 'megatron.bridge.data.vlm_datasets.collate' not in sys.modules"
-            ),
-        ],
-        capture_output=True,
-        text=True,
-        check=False,
+    _assert_subprocess_succeeds(
+        "import sys; "
+        "import megatron.bridge.data.vlm_datasets; "
+        "assert 'megatron.bridge.data.vlm_datasets.collate' not in sys.modules"
     )
-
-    assert result.returncode == 0, result.stderr
 
 
 def test_vlm_datasets_collate_registry_remains_available_from_explicit_module():
-    result = subprocess.run(
-        [
-            sys.executable,
-            "-c",
-            (
-                "from megatron.bridge.data.vlm_datasets.collate import COLLATE_FNS, qwen2_5_collate_fn; "
-                "assert COLLATE_FNS['Qwen2_5_VLProcessor'] is qwen2_5_collate_fn"
-            ),
-        ],
-        capture_output=True,
-        text=True,
-        check=False,
+    _assert_subprocess_succeeds(
+        "from megatron.bridge.data.vlm_datasets.collate import COLLATE_FNS, qwen2_5_collate_fn; "
+        "assert COLLATE_FNS['Qwen2_5_VLProcessor'] is qwen2_5_collate_fn"
     )
-
-    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- Track the collate import-boundary P0 from [MB-587](https://linear.app/nvidia/issue/MB-587/report-unit-test-strategy-audit-for-earlier-contract-coverage).
- Replace the narrow Qwen-only subprocess check with fresh-process coverage for `collate_utils` and all eight model collator modules.
- Assert direct collator imports do not eagerly load the global VLM collate registry, while explicit registry import remains available.
- Bound every subprocess with a focused timeout and preserve stderr/stdout diagnostics for import-cycle failures.

## Cleanup
- Supersedes the narrow Qwen-only test added with #4528; the merged import-cycle fix itself remains valid.
- No behavior tests were removed.

## Validation
- `uv run --active --no-sync pre-commit run --all-files`
- Standard project container: `uv run --no-sync python -m pytest tests/unit_tests/data/vlm_datasets/test_imports.py -q` -> `11 passed`
- `git diff --check`

## Review
- Two independent review rounds completed; final round reported no findings.