### PR TITLE
cp: add sequential (non-grouped) MoE expert mappings (#4499)

### DIFF
--- a/src/megatron/bridge/models/deepseek/deepseek_v4_bridge.py
+++ b/src/megatron/bridge/models/deepseek/deepseek_v4_bridge.py
@@ -707,6 +707,16 @@ class DeepSeekV4Bridge(MegatronModelBridge):
                 "decoder.layers.*.mlp.experts.linear_fc2.weight*",
                 "layers.*.ffn.experts.*.w2.weight",
             ),
+            # Sequential (non-grouped) experts <-> per-expert HF (e.g. ModelOpt pruning).
+            GatedMLPMapping(
+                megatron_param="decoder.layers.*.mlp.experts.local_experts.*.linear_fc1.weight",
+                gate="layers.*.ffn.experts.*.w1.weight",
+                up="layers.*.ffn.experts.*.w3.weight",
+            ),
+            AutoMapping(
+                "decoder.layers.*.mlp.experts.local_experts.*.linear_fc2.weight",
+                "layers.*.ffn.experts.*.w2.weight",
+            ),
             # Shared expert MLP
             GatedMLPMapping(
                 megatron_param="decoder.layers.*.mlp.shared_experts.linear_fc1.weight",

--- a/src/megatron/bridge/models/qwen/qwen35_bridge.py
+++ b/src/megatron/bridge/models/qwen/qwen35_bridge.py
@@ -242,6 +242,18 @@ class Qwen35MoEBridge(MegatronModelBridge):
                     megatron_param=f"{megatron_prefix}decoder.layers.*.mlp.experts.linear_fc2.weight*",
                     hf_param=f"{hf_prefix}layers.*.mlp.experts.down_proj",
                 ),
+                # Sequential (non-grouped) experts <-> per-expert unfused HF weights. Needed when
+                # moe_grouped_gemm is disabled (e.g. ModelOpt pruning) and for checkpoints that store
+                # experts unfused (gate_proj/up_proj/down_proj per expert).
+                GatedMLPMapping(
+                    megatron_param=f"{megatron_prefix}decoder.layers.*.mlp.experts.local_experts.*.linear_fc1.weight",
+                    gate=f"{hf_prefix}layers.*.mlp.experts.*.gate_proj.weight",
+                    up=f"{hf_prefix}layers.*.mlp.experts.*.up_proj.weight",
+                ),
+                AutoMapping(
+                    megatron_param=f"{megatron_prefix}decoder.layers.*.mlp.experts.local_experts.*.linear_fc2.weight",
+                    hf_param=f"{hf_prefix}layers.*.mlp.experts.*.down_proj.weight",
+                ),
                 # =============================================================
                 # Language Model: Shared Expert MLPs
                 # =============================================================

--- a/src/megatron/bridge/models/qwen/qwen3_next_bridge.py
+++ b/src/megatron/bridge/models/qwen/qwen3_next_bridge.py
@@ -179,6 +179,16 @@ class Qwen3NextBridge(MegatronModelBridge):
                     megatron_param="decoder.layers.*.mlp.experts.linear_fc2.weight*",
                     hf_param="model.layers.*.mlp.experts.*.down_proj.weight",
                 ),
+                # Sequential (non-grouped) experts (e.g. ModelOpt pruning).
+                GatedMLPMapping(
+                    megatron_param="decoder.layers.*.mlp.experts.local_experts.*.linear_fc1.weight",
+                    gate="model.layers.*.mlp.experts.*.gate_proj.weight",
+                    up="model.layers.*.mlp.experts.*.up_proj.weight",
+                ),
+                AutoMapping(
+                    megatron_param="decoder.layers.*.mlp.experts.local_experts.*.linear_fc2.weight",
+                    hf_param="model.layers.*.mlp.experts.*.down_proj.weight",
+                ),
                 GatedMLPMapping(
                     megatron_param="mtp.layers.*.mtp_model_layer.mlp.experts.linear_fc1.weight*",
                     gate="mtp.layers.*.mlp.experts.*.gate_proj.weight",
@@ -186,6 +196,16 @@ class Qwen3NextBridge(MegatronModelBridge):
                 ),
                 AutoMapping(
                     megatron_param="mtp.layers.*.mtp_model_layer.mlp.experts.linear_fc2.weight*",
+                    hf_param="mtp.layers.*.mlp.experts.*.down_proj.weight",
+                ),
+                # Sequential (non-grouped) MTP experts (e.g. ModelOpt pruning).
+                GatedMLPMapping(
+                    megatron_param="mtp.layers.*.mtp_model_layer.mlp.experts.local_experts.*.linear_fc1.weight",
+                    gate="mtp.layers.*.mlp.experts.*.gate_proj.weight",
+                    up="mtp.layers.*.mlp.experts.*.up_proj.weight",
+                ),
+                AutoMapping(
+                    megatron_param="mtp.layers.*.mtp_model_layer.mlp.experts.local_experts.*.linear_fc2.weight",
                     hf_param="mtp.layers.*.mlp.experts.*.down_proj.weight",
                 ),
                 # Gated MLP of shared expert

--- a/src/megatron/bridge/models/qwen_vl/qwen3_vl_bridge.py
+++ b/src/megatron/bridge/models/qwen_vl/qwen3_vl_bridge.py
@@ -378,6 +378,16 @@ class Qwen3VLMoEBridge(MegatronModelBridge):
                     hf_param="model.language_model.layers.*.mlp.experts.down_proj",
                     transpose_on_export=True,
                 ),
+                # Sequential (non-grouped) experts <-> per-expert unfused HF (e.g. ModelOpt pruning).
+                GatedMLPMapping(
+                    megatron_param="language_model.decoder.layers.*.mlp.experts.local_experts.*.linear_fc1.weight",
+                    gate="model.language_model.layers.*.mlp.experts.*.gate_proj.weight",
+                    up="model.language_model.layers.*.mlp.experts.*.up_proj.weight",
+                ),
+                AutoMapping(
+                    megatron_param="language_model.decoder.layers.*.mlp.experts.local_experts.*.linear_fc2.weight",
+                    hf_param="model.language_model.layers.*.mlp.experts.*.down_proj.weight",
+                ),
                 # QKV mapping for vision model
                 ConcatenatedQKVMapping(
                     megatron_param="vision_model.decoder.layers.*.self_attention.linear_qkv.weight",

--- a/tests/unit_tests/models/deepseek/test_deepseek_v4_bridge.py
+++ b/tests/unit_tests/models/deepseek/test_deepseek_v4_bridge.py
@@ -310,6 +310,13 @@ class TestDeepSeekV4QuantizedExport:
         assert torch.equal(restored_mxfp4.float(), mxfp4_weight.float())
 
 
+def test_sequential_expert_mappings_present(bridge_with_mtp):
+    """Sequential (non-grouped) expert mappings exist for moe_grouped_gemm=False (ModelOpt pruning)."""
+    params = _by_megatron(bridge_with_mtp.mapping_registry())
+    assert "decoder.layers.*.mlp.experts.local_experts.*.linear_fc1.weight" in params
+    assert "decoder.layers.*.mlp.experts.local_experts.*.linear_fc2.weight" in params
+
+
 class TestDecoderHCHeadMappings:
     """The global decoder HC-head triplet must be replicated mappings."""
 

--- a/tests/unit_tests/models/qwen/test_qwen35_bridge.py
+++ b/tests/unit_tests/models/qwen/test_qwen35_bridge.py
@@ -746,3 +746,13 @@ class TestQwen35MoEBridge:
 
         fused_expert_mappings = [m for m in registry.mappings if type(m).__name__ == "FusedExpertMapping"]
         assert len(fused_expert_mappings) > 0
+
+        # Sequential (non-grouped) expert mappings must also be present, for moe_grouped_gemm=False
+        # (e.g. ModelOpt pruning). Guards against accidental removal.
+        seq_params = [
+            getattr(m, "megatron_param", "")
+            for m in registry.mappings
+            if "experts.local_experts." in getattr(m, "megatron_param", "")
+        ]
+        assert any(p.endswith("linear_fc1.weight") for p in seq_params)
+        assert any(p.endswith("linear_fc2.weight") for p in seq_params)

--- a/tests/unit_tests/models/qwen/test_qwen3_next_bridge.py
+++ b/tests/unit_tests/models/qwen/test_qwen3_next_bridge.py
@@ -474,3 +474,14 @@ class TestQwen3NextBridge:
             if "experts" in mapping.hf_param and "down_proj" in mapping.hf_param
         ]
         assert len(expert_down_params) > 0
+
+        # Sequential (non-grouped) expert mappings must be present for moe_grouped_gemm=False
+        # (e.g. ModelOpt pruning), for both the decoder and the MTP layers.
+        seq_params = [
+            getattr(m, "megatron_param", "")
+            for m in registry.mappings
+            if "experts.local_experts." in getattr(m, "megatron_param", "")
+        ]
+        assert any("decoder.layers" in p and p.endswith("linear_fc1.weight") for p in seq_params)
+        assert any("decoder.layers" in p and p.endswith("linear_fc2.weight") for p in seq_params)
+        assert any("mtp.layers" in p for p in seq_params)


### PR DESCRIPTION
## What

Cherry-pick of #4499 onto the `r0.5.0` release branch.

The MoE bridges only map **grouped** experts (`experts.linear_fc1/linear_fc2` with grouped GEMM). When grouped GEMM is disabled, experts use the **sequential** `SequentialMLP` layout (`experts.local_experts.*.linear_fc{1,2}.weight`), which had **no param mapping** — conversion then fails, e.g.:

```
No mapping found for ...experts.local_experts.0.linear_fc1.weight
AttributeError: 'NoneType' object has no attribute 'megatron_module'
```

This PR adds the sequential `local_experts.*` mappings **alongside** the existing grouped ones for:

- `Qwen35MoEBridge` (Qwen3.5-MoE)
- `Qwen3VLMoEBridge` (Qwen3.5-VL-MoE)
- `Qwen3NextBridge` (Qwen3-Next)
- `DeepSeekV4Bridge` (DeepSeek-V4)

## Why

[NVIDIA Model-Optimizer](https://github.com/NVIDIA/Model-Optimizer) Minitron pruning of these MoE models requires the sequential layout (`moe_grouped_gemm=False`), and currently can't load/save them through the bridge without these mappings.

## Cherry-pick details

Clean cherry-pick of squash commit `bf5163a` (#4499) from `main`. Content changes are identical to the original; only surrounding-context line numbers differ on `r0.5.0`.

## Type / area
feat · area:model
