### PR TITLE
fix(training): default MoE expert tensor parallelism to one

### DIFF
--- a/src/megatron/bridge/models/transformer_config.py
+++ b/src/megatron/bridge/models/transformer_config.py
@@ -71,6 +71,17 @@ def _resolve_string_fields(config: MCoreTransformerConfig) -> None:
         config.pipeline_dtype = str_to_dtype(config.pipeline_dtype)
 
 
+def _set_moe_expert_tensor_parallel_default(config: MCoreTransformerConfig) -> None:
+    """Default expert tensor parallelism to one when expert parallelism is enabled.
+
+    Megatron Core resolves an unset expert tensor parallel size to the tensor model
+    parallel size. Bridge MoE configurations instead scale expert layers with expert
+    parallelism by default, while preserving explicit expert tensor parallel values.
+    """
+    if config.expert_tensor_parallel_size is None and config.expert_model_parallel_size > 1:
+        config.expert_tensor_parallel_size = 1
+
+
 @dataclass
 class TransformerConfig(MCoreTransformerConfig):
     """Megatron Core TransformerConfig with deferred post-init.
@@ -115,6 +126,7 @@ class TransformerConfig(MCoreTransformerConfig):
             self.pipeline_dtype = self.params_dtype
         if self.sequence_parallel and self.tensor_model_parallel_size <= 1:
             self.sequence_parallel = False
+        _set_moe_expert_tensor_parallel_default(self)
         MCoreTransformerConfig.__post_init__(self)
 
         # In-batch packing produces variable-length packed sequences across microbatches,
@@ -190,6 +202,7 @@ class MLATransformerConfig(TransformerConfig, MCoreMLATransformerConfig):
             self.pipeline_dtype = self.params_dtype
         if self.sequence_parallel and self.tensor_model_parallel_size <= 1:
             self.sequence_parallel = False
+        _set_moe_expert_tensor_parallel_default(self)
         MCoreMLATransformerConfig.__post_init__(self)
 
         if getattr(self, "_enable_in_batch_packing", False) and self.pipeline_model_parallel_size > 1:
@@ -243,6 +256,7 @@ class HeterogeneousTransformerConfig(TransformerConfig, MCoreHeterogeneousTransf
         _resolve_string_fields(self)
         if self.sequence_parallel and self.tensor_model_parallel_size <= 1:
             self.sequence_parallel = False
+        _set_moe_expert_tensor_parallel_default(self)
         MCoreHeterogeneousTransformerConfig.__post_init__(self)
 
     def get_config_for_layer(self, layer_number: int) -> MCoreTransformerConfig:

--- a/src/megatron/bridge/training/initialize.py
+++ b/src/megatron/bridge/training/initialize.py
@@ -48,7 +48,7 @@ from megatron.core.utils import (
 from megatron.bridge.models import GPTModelProvider, T5ModelProvider
 from megatron.bridge.models.gpt.gpt_builder import GPTModelConfig
 from megatron.bridge.models.hybrid.hybrid_builder import HybridModelConfig
-from megatron.bridge.models.transformer_config import TransformerConfig
+from megatron.bridge.models.transformer_config import TransformerConfig, _set_moe_expert_tensor_parallel_default
 from megatron.bridge.training.config import ConfigContainer, DistributedInitConfig, RerunStateMachineConfig, RNGConfig
 from megatron.bridge.training.utils.pg_utils import DistTrainProcessGroupCollection
 from megatron.bridge.utils.common_utils import (
@@ -408,6 +408,7 @@ def _create_pg_collection(
     save_grid: bool = False,
 ) -> ProcessGroupCollection:
     """Create all process groups via HyperCommGrid and return a ProcessGroupCollection."""
+    _set_moe_expert_tensor_parallel_default(model_config)
     hcp_sizes = getattr(model_config, "hierarchical_context_parallel_sizes", None)
     if hcp_sizes is not None:
         raise NotImplementedError(
@@ -699,6 +700,8 @@ def _initialize_distributed(
     use_inprocess_restart: bool = False,
 ) -> ProcessGroupCollection:
     """Initialize torch.distributed and core model parallel."""
+
+    _set_moe_expert_tensor_parallel_default(model_config)
 
     device_count = torch.cuda.device_count()
     if torch.distributed.is_initialized():

--- a/tests/unit_tests/models/test_transformer_config.py
+++ b/tests/unit_tests/models/test_transformer_config.py
@@ -21,6 +21,7 @@ import torch
 
 from megatron.bridge.models.transformer_config import (
     HeterogeneousTransformerConfig,
+    MLATransformerConfig,
     TransformerConfig,
     _resolve_string_fields,
 )
@@ -31,6 +32,7 @@ from megatron.bridge.models.transformer_config import (
 # ---------------------------------------------------------------------------
 
 _FINALIZE_PATCH = "megatron.bridge.models.transformer_config.MCoreTransformerConfig.__post_init__"
+_MLA_FINALIZE_PATCH = "megatron.bridge.models.transformer_config.MCoreMLATransformerConfig.__post_init__"
 _HETERO_FINALIZE_PATCH = "megatron.bridge.models.transformer_config.MCoreHeterogeneousTransformerConfig.__post_init__"
 
 
@@ -191,6 +193,53 @@ class TestTransformerConfigFinalize:
         with patch(_FINALIZE_PATCH):
             cfg.finalize()
         assert cfg.pipeline_dtype is None
+
+    def test_moe_unset_expert_tensor_parallel_size_defaults_to_one(self):
+        cfg = _make_config(
+            tensor_model_parallel_size=2,
+            expert_model_parallel_size=4,
+            expert_tensor_parallel_size=None,
+        )
+        with patch(_FINALIZE_PATCH):
+            cfg.finalize()
+        assert cfg.expert_tensor_parallel_size == 1
+
+    def test_moe_explicit_expert_tensor_parallel_size_is_preserved(self):
+        cfg = _make_config(
+            tensor_model_parallel_size=4,
+            expert_model_parallel_size=2,
+            expert_tensor_parallel_size=2,
+        )
+        with patch(_FINALIZE_PATCH):
+            cfg.finalize()
+        assert cfg.expert_tensor_parallel_size == 2
+
+    def test_dense_unset_expert_tensor_parallel_size_is_not_changed_by_bridge(self):
+        cfg = _make_config(
+            tensor_model_parallel_size=2,
+            expert_model_parallel_size=1,
+            expert_tensor_parallel_size=None,
+        )
+        with patch(_FINALIZE_PATCH):
+            cfg.finalize()
+        assert cfg.expert_tensor_parallel_size is None
+
+
+class TestMLATransformerConfigFinalize:
+    """Tests for MLATransformerConfig.finalize()."""
+
+    def test_moe_unset_expert_tensor_parallel_size_defaults_to_one(self):
+        cfg = MLATransformerConfig(
+            num_layers=2,
+            hidden_size=64,
+            num_attention_heads=4,
+            tensor_model_parallel_size=2,
+            expert_model_parallel_size=4,
+            expert_tensor_parallel_size=None,
+        )
+        with patch(_MLA_FINALIZE_PATCH):
+            cfg.finalize()
+        assert cfg.expert_tensor_parallel_size == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/recipes/test_glm45_recipes.py
+++ b/tests/unit_tests/recipes/test_glm45_recipes.py
@@ -56,7 +56,7 @@ class _FakeModelCfg:
         self.virtual_pipeline_model_parallel_size = None
         self.context_parallel_size = 1
         self.expert_model_parallel_size = 1
-        self.expert_tensor_parallel_size = 1
+        self.expert_tensor_parallel_size = None
         self.sequence_parallel = False
         self.seq_length = 64
         self.num_layers = 4
@@ -81,6 +81,9 @@ class _FakeModelCfg:
         self.vocab_size = 151552  # GLM vocab size
 
     def finalize(self):
+        from megatron.bridge.models.transformer_config import _set_moe_expert_tensor_parallel_default
+
+        _set_moe_expert_tensor_parallel_default(self)
         return None
 
 
@@ -334,6 +337,9 @@ def test_glm45_355b_full_sft_defaults(monkeypatch: pytest.MonkeyPatch):
     assert cfg.model.tensor_model_parallel_size == 2
     assert cfg.model.pipeline_model_parallel_size == 8
     assert cfg.model.expert_model_parallel_size == 16
+    assert cfg.model.expert_tensor_parallel_size is None
+    cfg.model.finalize()
+    assert cfg.model.expert_tensor_parallel_size == 1
     assert cfg.peft is None
 
 

--- a/tests/unit_tests/training/test_decentralized_pg.py
+++ b/tests/unit_tests/training/test_decentralized_pg.py
@@ -110,6 +110,42 @@ class TestCreatePgCollectionFunction:
         mock_hyper_grid.assert_called()
         call_kwargs = mock_hyper_grid.call_args[1]
         assert call_kwargs["shape"][0] == 2  # TP size
+        assert mock_model_config.expert_tensor_parallel_size is None
+        assert mock_hyper_grid.call_args_list[1].kwargs["shape"][0] == 2
+
+    @pytest.mark.parametrize(
+        ("expert_tensor_parallel_size", "expected_expert_shape"),
+        [(None, [1, 4, 2, 1]), (2, [2, 4, 1, 1])],
+    )
+    @patch("megatron.bridge.training.initialize.HyperCommGrid")
+    @patch("torch.distributed.get_world_size", return_value=8)
+    @patch("torch.distributed.new_subgroups_by_enumeration")
+    def test_create_pg_collection_with_expert_parallelism(
+        self,
+        mock_subgroups,
+        mock_world_size,
+        mock_hyper_grid,
+        expert_tensor_parallel_size,
+        expected_expert_shape,
+        mock_model_config,
+    ):
+        """Test Bridge's ETP default and explicit override in decentralized process groups."""
+        from megatron.bridge.training.initialize import _create_pg_collection
+
+        mock_model_config.tensor_model_parallel_size = 2
+        mock_model_config.expert_model_parallel_size = 4
+        mock_model_config.expert_tensor_parallel_size = expert_tensor_parallel_size
+
+        mock_grid_instance = MagicMock()
+        mock_grid_instance.create_pg.return_value = MagicMock()
+        mock_grid_instance._gen_rank_enum.return_value = [[0, 1, 2, 3, 4, 5, 6, 7]]
+        mock_hyper_grid.return_value = mock_grid_instance
+        mock_subgroups.return_value = (MagicMock(), [])
+
+        _create_pg_collection(mock_model_config, num_distributed_optimizer_instances=1)
+
+        assert mock_model_config.expert_tensor_parallel_size == (expert_tensor_parallel_size or 1)
+        assert mock_hyper_grid.call_args_list[1].kwargs["shape"] == expected_expert_shape
 
     @patch("megatron.bridge.training.initialize.HyperCommGrid")
     @patch("torch.distributed.get_world_size", return_value=8)
@@ -438,6 +474,10 @@ class TestInitializeDistributedBranching:
         # Verify the result is the pg_collection from _create_pg_collection
         assert result == mock_pg_collection
 
+    @pytest.mark.parametrize(
+        ("expert_tensor_parallel_size", "expected_expert_tensor_parallel_size"),
+        [(None, 1), (2, 2)],
+    )
     @patch("megatron.bridge.training.initialize.ProcessGroupCollection")
     @patch("megatron.bridge.training.initialize._create_pg_collection")
     @patch("megatron.bridge.training.initialize.parallel_state")
@@ -452,19 +492,21 @@ class TestInitializeDistributedBranching:
         mock_parallel_state,
         mock_create_pg_collection,
         mock_pg_collection_class,
+        expert_tensor_parallel_size,
+        expected_expert_tensor_parallel_size,
     ):
         """Test that _initialize_distributed uses mpu when use_decentralized_pg=False."""
         from megatron.bridge.training.initialize import _initialize_distributed
 
         mock_model_config = MagicMock()
-        mock_model_config.tensor_model_parallel_size = 1
+        mock_model_config.tensor_model_parallel_size = 2
         mock_model_config.pipeline_model_parallel_size = 1
         mock_model_config.context_parallel_size = 1
         mock_model_config.virtual_pipeline_model_parallel_size = None
         mock_model_config.pipeline_model_parallel_comm_backend = "nccl"
         mock_model_config.hierarchical_context_parallel_sizes = None
-        mock_model_config.expert_model_parallel_size = 1
-        mock_model_config.expert_tensor_parallel_size = None
+        mock_model_config.expert_model_parallel_size = 4
+        mock_model_config.expert_tensor_parallel_size = expert_tensor_parallel_size
 
         mock_dist_config = MagicMock()
         mock_dist_config.use_decentralized_pg = False
@@ -492,6 +534,10 @@ class TestInitializeDistributedBranching:
         mock_create_pg_collection.assert_not_called()
         # Verify parallel_state.initialize_model_parallel WAS called
         mock_parallel_state.initialize_model_parallel.assert_called_once()
+        assert (
+            mock_parallel_state.initialize_model_parallel.call_args.kwargs["expert_tensor_parallel_size"]
+            == expected_expert_tensor_parallel_size
+        )
 
 
 class TestSetupUsesDecentralizedPg:


### PR DESCRIPTION
# What does this PR do ?

Defaults expert tensor parallelism to 1 for Bridge configurations that enable expert model parallelism and leave ETP unset. Explicit ETP values are preserved, and EP=1/dense behavior continues to use the existing MCore default.

# Changelog

- Normalize unset ETP before Bridge transformer-config finalization calls MCore.
- Apply the same rule to standard and decentralized process-group initialization.
- Add focused coverage for unset and explicit ETP, dense behavior, MLA configs, decentralized expert grids, standard MPU setup, and an affected GLM-4.5 recipe.

# GitHub Actions CI

Focused validation completed in the standard project container:

- `uv run python -m pytest tests/unit_tests/models/test_transformer_config.py tests/unit_tests/training/test_decentralized_pg.py tests/unit_tests/recipes/test_glm45_recipes.py -q` — 84 passed.
- Focused `ruff check` and `ruff format --check` — passed.
- `uv run pre-commit run --all-files` — passed.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation? No documentation change is needed; this corrects default finalization for an existing configuration field.
- [x] Does the PR affect components that are optional to install? No.
  - [x] Reviewer: Does the PR have correct import guards for all optional libraries? Not applicable.

# Additional Information

Fixes #4007.
