### PR TITLE
fix(perf): repair llama packing and golden evaluation

### DIFF
--- a/scripts/performance/utils/evaluate.py
+++ b/scripts/performance/utils/evaluate.py
@@ -654,6 +654,18 @@ def merge_golden_values(prior: Optional[Dict[str, Any]], segment: Dict[str, Any]
     return {**prior, **segment}
 
 
+def _unwrap_golden_values(values: Dict[str, Any]) -> Dict[str, Any]:
+    """Return the step mapping from a flat or snapshot-wrapped golden file."""
+    for snapshot_key in ("baseline", "current"):
+        if snapshot_key not in values:
+            continue
+        snapshot = values[snapshot_key]
+        if not isinstance(snapshot, dict):
+            raise ValueError(f"Golden values snapshot {snapshot_key!r} must be a mapping.")
+        return snapshot
+    return values
+
+
 def calc_convergence_and_performance(
     model_family_name: str,
     model_recipe_name: str,
@@ -773,9 +785,7 @@ def calc_convergence_and_performance(
     with open(expected_golden_values_path, "r") as f:
         expected_golden_values = json.load(f)
 
-    # Normalize: new format stores baseline data under a "baseline" key.
-    if "baseline" in expected_golden_values:
-        expected_golden_values = expected_golden_values["baseline"]
+    expected_golden_values = _unwrap_golden_values(expected_golden_values)
 
     steps = []
     golden_train_loss = {}

--- a/src/megatron/bridge/perf_recipes/llama/b200/llama3.py
+++ b/src/megatron/bridge/perf_recipes/llama/b200/llama3.py
@@ -262,7 +262,7 @@ def llama3_70b_lora_8gpu_b200_bf16_config() -> ConfigContainer:
 
     cfg.comm_overlap.tp_comm_overlap = False
 
-    cfg.dataset.packed_sequence_specs.pad_cu_seqlens = True
+    cfg.dataset.offline_packing_specs.pad_cu_seqlens = True
     cfg.dataset.dataset_kwargs = {"pad_to_max_length": True}
 
     _llama_benchmark_common(cfg)
@@ -296,7 +296,7 @@ def llama3_70b_lora_8gpu_b200_fp8cs_config() -> ConfigContainer:
 
     cfg.comm_overlap.tp_comm_overlap = False
 
-    cfg.dataset.packed_sequence_specs.pad_cu_seqlens = True
+    cfg.dataset.offline_packing_specs.pad_cu_seqlens = True
     cfg.dataset.dataset_kwargs = {"pad_to_max_length": True}
 
     _llama_benchmark_common(cfg)
@@ -330,7 +330,7 @@ def llama3_70b_lora_8gpu_b200_fp8mx_config() -> ConfigContainer:
 
     cfg.comm_overlap.tp_comm_overlap = False
 
-    cfg.dataset.packed_sequence_specs.pad_cu_seqlens = True
+    cfg.dataset.offline_packing_specs.pad_cu_seqlens = True
     cfg.dataset.dataset_kwargs = {"pad_to_max_length": True}
 
     _llama_benchmark_common(cfg)

--- a/src/megatron/bridge/perf_recipes/llama/b300/llama3.py
+++ b/src/megatron/bridge/perf_recipes/llama/b300/llama3.py
@@ -257,7 +257,7 @@ def llama3_70b_lora_8gpu_b300_bf16_config() -> ConfigContainer:
 
     cfg.comm_overlap.tp_comm_overlap = False
 
-    cfg.dataset.packed_sequence_specs.pad_cu_seqlens = True
+    cfg.dataset.offline_packing_specs.pad_cu_seqlens = True
     cfg.dataset.dataset_kwargs = {"pad_to_max_length": True}
 
     _llama_benchmark_common(cfg)
@@ -290,7 +290,7 @@ def llama3_70b_lora_8gpu_b300_fp8cs_config() -> ConfigContainer:
 
     cfg.comm_overlap.tp_comm_overlap = False
 
-    cfg.dataset.packed_sequence_specs.pad_cu_seqlens = True
+    cfg.dataset.offline_packing_specs.pad_cu_seqlens = True
     cfg.dataset.dataset_kwargs = {"pad_to_max_length": True}
 
     _llama_benchmark_common(cfg)
@@ -323,7 +323,7 @@ def llama3_70b_lora_8gpu_b300_fp8mx_config() -> ConfigContainer:
 
     cfg.comm_overlap.tp_comm_overlap = False
 
-    cfg.dataset.packed_sequence_specs.pad_cu_seqlens = True
+    cfg.dataset.offline_packing_specs.pad_cu_seqlens = True
     cfg.dataset.dataset_kwargs = {"pad_to_max_length": True}
 
     _llama_benchmark_common(cfg)

--- a/src/megatron/bridge/perf_recipes/llama/gb200/llama3.py
+++ b/src/megatron/bridge/perf_recipes/llama/gb200/llama3.py
@@ -267,7 +267,7 @@ def llama3_8b_sft_8gpu_gb200_bf16_config() -> ConfigContainer:
 
     cfg.model.seq_length = 16384
     cfg.dataset.seq_length = 16384
-    cfg.dataset.packed_sequence_specs.packed_sequence_size = 16384
+    cfg.dataset.offline_packing_specs.packed_sequence_size = 16384
     cfg.model.tensor_model_parallel_size = 1
     cfg.model.pipeline_model_parallel_size = 1
     cfg.model.context_parallel_size = 1
@@ -297,7 +297,7 @@ def llama3_8b_sft_8gpu_gb200_fp8cs_config() -> ConfigContainer:
 
     cfg.model.seq_length = 16384
     cfg.dataset.seq_length = 16384
-    cfg.dataset.packed_sequence_specs.packed_sequence_size = 16384
+    cfg.dataset.offline_packing_specs.packed_sequence_size = 16384
     cfg.model.tensor_model_parallel_size = 1
     cfg.model.pipeline_model_parallel_size = 1
     cfg.model.context_parallel_size = 1
@@ -395,7 +395,7 @@ def llama3_70b_lora_8gpu_gb200_bf16_config() -> ConfigContainer:
     cfg.peft.target_modules = ["linear_qkv"]
     cfg.model.seq_length = 2048
     cfg.dataset.seq_length = 2048
-    cfg.dataset.packed_sequence_specs.packed_sequence_size = 2048
+    cfg.dataset.offline_packing_specs.packed_sequence_size = 2048
     cfg.model.tensor_model_parallel_size = 1
     cfg.model.pipeline_model_parallel_size = 2
     cfg.model.context_parallel_size = 1
@@ -408,7 +408,7 @@ def llama3_70b_lora_8gpu_gb200_bf16_config() -> ConfigContainer:
 
     cfg.comm_overlap.tp_comm_overlap = False
 
-    cfg.dataset.packed_sequence_specs.pad_cu_seqlens = True
+    cfg.dataset.offline_packing_specs.pad_cu_seqlens = True
     cfg.dataset.dataset_kwargs = {"pad_to_max_length": True}
 
     _llama_benchmark_common(cfg)
@@ -443,7 +443,7 @@ def llama3_70b_lora_8gpu_gb200_fp8cs_config() -> ConfigContainer:
 
     cfg.comm_overlap.tp_comm_overlap = False
 
-    cfg.dataset.packed_sequence_specs.pad_cu_seqlens = True
+    cfg.dataset.offline_packing_specs.pad_cu_seqlens = True
     cfg.dataset.dataset_kwargs = {"pad_to_max_length": True}
 
     _llama_benchmark_common(cfg)
@@ -478,7 +478,7 @@ def llama3_70b_lora_8gpu_gb200_fp8mx_config() -> ConfigContainer:
 
     cfg.comm_overlap.tp_comm_overlap = False
 
-    cfg.dataset.packed_sequence_specs.pad_cu_seqlens = True
+    cfg.dataset.offline_packing_specs.pad_cu_seqlens = True
     cfg.dataset.dataset_kwargs = {"pad_to_max_length": True}
 
     _llama_benchmark_common(cfg)

--- a/src/megatron/bridge/perf_recipes/llama/gb300/llama3.py
+++ b/src/megatron/bridge/perf_recipes/llama/gb300/llama3.py
@@ -288,7 +288,7 @@ def llama3_70b_sft_32gpu_gb300_bf16_config() -> ConfigContainer:
     cfg.comm_overlap.defer_embedding_wgrad_compute = True
     cfg.comm_overlap.wgrad_deferral_limit = 22
 
-    cfg.dataset.packed_sequence_specs.pad_cu_seqlens = True
+    cfg.dataset.offline_packing_specs.pad_cu_seqlens = True
     cfg.dataset.dataset_kwargs = {"pad_to_max_length": True}
 
     _llama_benchmark_common(cfg)
@@ -324,7 +324,7 @@ def llama3_70b_sft_32gpu_gb300_fp8cs_config() -> ConfigContainer:
     cfg.comm_overlap.defer_embedding_wgrad_compute = True
     cfg.comm_overlap.wgrad_deferral_limit = 22
 
-    cfg.dataset.packed_sequence_specs.pad_cu_seqlens = True
+    cfg.dataset.offline_packing_specs.pad_cu_seqlens = True
     cfg.dataset.dataset_kwargs = {"pad_to_max_length": True}
 
     _llama_benchmark_common(cfg)
@@ -358,7 +358,7 @@ def llama3_70b_lora_8gpu_gb300_bf16_config() -> ConfigContainer:
 
     cfg.comm_overlap.tp_comm_overlap = False
 
-    cfg.dataset.packed_sequence_specs.pad_cu_seqlens = True
+    cfg.dataset.offline_packing_specs.pad_cu_seqlens = True
     cfg.dataset.dataset_kwargs = {"pad_to_max_length": True}
 
     _llama_benchmark_common(cfg)
@@ -392,7 +392,7 @@ def llama3_70b_lora_8gpu_gb300_fp8cs_config() -> ConfigContainer:
 
     cfg.comm_overlap.tp_comm_overlap = False
 
-    cfg.dataset.packed_sequence_specs.pad_cu_seqlens = True
+    cfg.dataset.offline_packing_specs.pad_cu_seqlens = True
     cfg.dataset.dataset_kwargs = {"pad_to_max_length": True}
 
     _llama_benchmark_common(cfg)
@@ -427,7 +427,7 @@ def llama3_70b_lora_8gpu_gb300_fp8mx_config() -> ConfigContainer:
 
     cfg.comm_overlap.tp_comm_overlap = False
 
-    cfg.dataset.packed_sequence_specs.pad_cu_seqlens = True
+    cfg.dataset.offline_packing_specs.pad_cu_seqlens = True
     cfg.dataset.dataset_kwargs = {"pad_to_max_length": True}
 
     _llama_benchmark_common(cfg)

--- a/src/megatron/bridge/perf_recipes/llama/h100/llama3.py
+++ b/src/megatron/bridge/perf_recipes/llama/h100/llama3.py
@@ -206,7 +206,7 @@ def llama3_70b_sft_32gpu_h100_bf16_config() -> ConfigContainer:
     cfg.comm_overlap.defer_embedding_wgrad_compute = True
     cfg.comm_overlap.wgrad_deferral_limit = 22
 
-    cfg.dataset.packed_sequence_specs.pad_cu_seqlens = False
+    cfg.dataset.offline_packing_specs.pad_cu_seqlens = False
     cfg.dataset.dataset_kwargs = {"pad_to_max_length": True}
 
     _llama_benchmark_common(cfg)
@@ -243,7 +243,7 @@ def llama3_70b_sft_32gpu_h100_fp8cs_config() -> ConfigContainer:
         wgrad_deferral_limit=22,
     )
 
-    cfg.dataset.packed_sequence_specs.pad_cu_seqlens = False
+    cfg.dataset.offline_packing_specs.pad_cu_seqlens = False
     cfg.dataset.dataset_kwargs = {"pad_to_max_length": True}
 
     _llama_benchmark_common(cfg)
@@ -279,7 +279,7 @@ def llama3_70b_lora_8gpu_h100_bf16_config() -> ConfigContainer:
 
     cfg.comm_overlap.tp_comm_overlap = False
 
-    cfg.dataset.packed_sequence_specs.pad_cu_seqlens = False
+    cfg.dataset.offline_packing_specs.pad_cu_seqlens = False
     cfg.dataset.dataset_kwargs = {"pad_to_max_length": True}
 
     _llama_benchmark_common(cfg)
@@ -311,7 +311,7 @@ def llama3_70b_lora_8gpu_h100_fp8cs_config() -> ConfigContainer:
 
     cfg.comm_overlap = CommOverlapConfig(tp_comm_overlap=True)
 
-    cfg.dataset.packed_sequence_specs.pad_cu_seqlens = False
+    cfg.dataset.offline_packing_specs.pad_cu_seqlens = False
     cfg.dataset.dataset_kwargs = {"pad_to_max_length": True}
 
     _llama_benchmark_common(cfg)

--- a/tests/unit_tests/recipes/test_llama_perf_recipes.py
+++ b/tests/unit_tests/recipes/test_llama_perf_recipes.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib
+import importlib.util
+import pkgutil
+from collections.abc import Callable
+
+import pytest
+
+from megatron.bridge.training.config import ConfigContainer
+
+
+def _finetune_perf_recipes() -> list[Callable[[], ConfigContainer]]:
+    recipes = []
+    llama_package = importlib.import_module("megatron.bridge.perf_recipes.llama")
+    for module_info in pkgutil.iter_modules(llama_package.__path__):
+        module_name = f"{llama_package.__name__}.{module_info.name}.llama3"
+        if not module_info.ispkg or importlib.util.find_spec(module_name) is None:
+            continue
+        module = importlib.import_module(module_name)
+        recipes.extend(
+            recipe
+            for name in dir(module)
+            if ("_sft_" in name or "_lora_" in name)
+            and name.endswith("_config")
+            and callable(recipe := getattr(module, name))
+            and recipe.__module__ == module_name
+        )
+    return recipes
+
+
+class _FakeModelCfg:
+    cross_entropy_fusion_impl = "te"
+    context_parallel_size = 1
+    use_te_rng_tracker = False
+
+    def finalize(self) -> None:
+        return None
+
+
+class _FakeBridge:
+    @staticmethod
+    def from_hf_pretrained(*args, **kwargs) -> "_FakeBridge":
+        return _FakeBridge()
+
+    def to_megatron_provider(self, load_weights: bool = False) -> _FakeModelCfg:
+        return _FakeModelCfg()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("recipe_func", _finetune_perf_recipes(), ids=lambda recipe: recipe.__name__)
+def test_llama3_finetune_perf_recipes_use_offline_packing_specs(
+    recipe_func: Callable[[], ConfigContainer], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    base_recipes = importlib.import_module("megatron.bridge.recipes.llama.llama3")
+    monkeypatch.setattr(base_recipes, "AutoBridge", _FakeBridge)
+
+    config = recipe_func()
+
+    assert config.dataset.offline_packing_specs is not None
+    assert config.dataset.enable_offline_packing is True
+    assert config.dataset.offline_packing_specs.packed_sequence_size == config.dataset.seq_length
+    assert not hasattr(config.dataset, "packed_sequence_specs")
+    assert config.dataset.dataset_kwargs["pad_to_max_length"] is True

--- a/tests/unit_tests/scripts/performance/test_evaluate.py
+++ b/tests/unit_tests/scripts/performance/test_evaluate.py
@@ -12,17 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for scripts/performance/utils/evaluate.py golden-value downsampling."""
+"""Tests for scripts/performance/utils/evaluate.py golden-value handling."""
 
+import json
 import sys
 from pathlib import Path
+
+import pytest
 
 
 _PERF_SCRIPTS_DIR = Path(__file__).resolve().parents[4] / "scripts" / "performance"
 if str(_PERF_SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(_PERF_SCRIPTS_DIR))
 
-from utils.evaluate import downsample_golden_values  # noqa: E402
+from utils import evaluate  # noqa: E402
+from utils.evaluate import _unwrap_golden_values, downsample_golden_values  # noqa: E402
 
 
 def _make_values(n_steps: int) -> dict:
@@ -34,6 +38,86 @@ def _make_values(n_steps: int) -> dict:
 
 def _step_keys(values: dict) -> list:
     return sorted((int(k) for k in values if k.lstrip("-").isdigit()))
+
+
+def test_unwrap_golden_values_supports_flat_and_snapshot_formats():
+    step_values = {"0": {"lm loss": 1.0}, "alloc": 2.0}
+
+    assert _unwrap_golden_values(step_values) is step_values
+    assert _unwrap_golden_values({"baseline": step_values}) is step_values
+    assert _unwrap_golden_values({"current": step_values}) is step_values
+
+
+def test_unwrap_golden_values_prefers_baseline_snapshot():
+    baseline = {"0": {"lm loss": 1.0}}
+    current = {"0": {"lm loss": 2.0}}
+
+    assert _unwrap_golden_values({"current": current, "baseline": baseline}) is baseline
+
+
+def test_calc_convergence_supports_current_snapshot_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    golden_path = tmp_path / "golden.json"
+    golden_path.write_text(
+        json.dumps(
+            {
+                "current": {
+                    "0": {
+                        "lm loss": 1.0,
+                        "elapsed time per iteration (ms)": 2.0,
+                        "GPU utilization": 3.0,
+                    },
+                    "alloc": 4.0,
+                    "max_alloc": 5.0,
+                    "max_reserved": 6.0,
+                }
+            }
+        )
+    )
+    metrics = {
+        "lm loss": {"0": 1.0},
+        "elapsed time per iteration (ms)": {"0": 2.0},
+        "GPU utilization": {"0": 3.0},
+        "grad norm": {"0": 0.5},
+        "alloc": 4.0,
+        "max_alloc": 5.0,
+        "max_reserved": 6.0,
+    }
+    monkeypatch.setattr(evaluate, "get_metrics_from_logfiles", lambda _paths, metric: metrics[metric])
+    monkeypatch.setattr(evaluate, "write_golden_values_to_disk", lambda **_kwargs: None)
+    monkeypatch.setattr(
+        evaluate,
+        "validate_convergence",
+        lambda **_kwargs: {"passed": True, "failed_metrics": [], "summary": ""},
+    )
+    monkeypatch.setattr(
+        evaluate,
+        "validate_performance",
+        lambda **_kwargs: {"passed": True, "failed_metrics": [], "summary": "", "metrics": {}},
+    )
+    monkeypatch.setattr(
+        evaluate,
+        "validate_memory",
+        lambda **_kwargs: {"passed": True, "failed_metrics": [], "summary": "", "metrics": {}},
+    )
+
+    passed, error_message, _current_values = evaluate.calc_convergence_and_performance(
+        model_family_name="llama",
+        model_recipe_name="llama3_8b",
+        assets_dir=str(tmp_path / "assets"),
+        log_paths=[],
+        loss_metric="lm loss",
+        timing_metric="elapsed time per iteration (ms)",
+        alloc_metric="alloc",
+        max_alloc_metric="max_alloc",
+        max_reserved_metric="max_reserved",
+        golden_values_path=str(golden_path),
+        convergence_config={},
+        performance_config={"eval_time_start_step": 0, "eval_time_end_step": 1},
+        memory_config={"memory_threshold": 0.1},
+    )
+
+    assert passed is True
+    assert error_message == ""
 
 
 def test_downsample_noop_when_under_cap():


### PR DESCRIPTION
# What does this PR do ?

Repairs two CI regressions in Llama finetuning performance recipe construction and convergence-golden evaluation.

# Changelog

- Update Llama SFT and LoRA performance recipes to use `offline_packing_specs`, matching the current HF SFT dataset provider API.
- Accept flat, `baseline`-wrapped, and `current`-wrapped convergence golden files.
- Add regression coverage that dynamically exercises every Llama SFT/LoRA performance recipe and tests a `current` snapshot through the evaluator file boundary.

# GitHub Actions CI

Targeted validation completed:

- `pre-commit run --all-files`
- Llama performance recipes plus evaluator tests: 34 passed
- Existing packed-sequence utility tests: 13 passed
- Existing packing-related training config tests: 16 passed
- Existing VLM packing tests: 15 passed

# Before your PR is "Ready for review"

- [x] Read and followed the contributor guidelines.
- [x] Added the necessary regression tests.
- [x] Documentation is not required for this configuration/evaluator fix.
- [x] This PR does not affect optional install components.

# Additional Information

A separately observed FP8 MX failure is already resolved on target `main` by #4536 and its Transformer Engine revision. This PR neither changes nor claims that fix.

Related to internal CI regressions; no public issue link.
