### PR TITLE
fix(recipe): correct Qwen3.5-VL 122B H100 VPP

### DIFF
--- a/scripts/performance/configs/qwen_vl/qwen35_vl_workload_base_configs.py
+++ b/scripts/performance/configs/qwen_vl/qwen35_vl_workload_base_configs.py
@@ -267,7 +267,7 @@ QWEN35_VL_122B_A10B_PRETRAIN_CONFIG_H100_BF16 = replace(
     num_gpus=128,
     tensor_model_parallel_size=2,
     pipeline_model_parallel_size=8,
-    virtual_pipeline_model_parallel_size=4,
+    virtual_pipeline_model_parallel_size=2,
     expert_model_parallel_size=16,
     moe_a2a_overlap=True,
 )
@@ -278,7 +278,7 @@ QWEN35_VL_122B_A10B_PRETRAIN_CONFIG_H100_FP8_CS = replace(
     num_gpus=128,
     tensor_model_parallel_size=2,
     pipeline_model_parallel_size=8,
-    virtual_pipeline_model_parallel_size=4,
+    virtual_pipeline_model_parallel_size=2,
     expert_model_parallel_size=16,
     moe_a2a_overlap=True,
 )

--- a/src/megatron/bridge/perf_recipes/qwen_vl/h100/qwen35_vl.py
+++ b/src/megatron/bridge/perf_recipes/qwen_vl/h100/qwen35_vl.py
@@ -93,7 +93,7 @@ def qwen35_vl_35b_a3b_pretrain_16gpu_h100_fp8cs_config() -> ConfigContainer:
 
 
 def qwen35_vl_122b_a10b_pretrain_128gpu_h100_bf16_config() -> ConfigContainer:
-    """Qwen3.5-VL 122B-A10B pretrain: 128× H100, BF16, TP=2 PP=8 VP=4 EP=16."""
+    """Qwen3.5-VL 122B-A10B pretrain: 128× H100, BF16, TP=2 PP=8 VP=2 EP=16."""
     cfg = qwen35_vl_122b_a10b_pretrain_mock_config()
     cfg.mixed_precision = _perf_precision("bf16")
     _qwen35_vl_common(cfg)
@@ -101,7 +101,7 @@ def qwen35_vl_122b_a10b_pretrain_128gpu_h100_bf16_config() -> ConfigContainer:
     cfg.model.tensor_model_parallel_size = 2
     cfg.model.pipeline_model_parallel_size = 8
     cfg.model.context_parallel_size = 1
-    cfg.model.virtual_pipeline_model_parallel_size = 4
+    cfg.model.virtual_pipeline_model_parallel_size = 2
     cfg.model.expert_model_parallel_size = 16
     cfg.model.expert_tensor_parallel_size = 1
     cfg.model.sequence_parallel = True

--- a/tests/unit_tests/scripts/performance/test_qwen35_vl_workload_base_configs.py
+++ b/tests/unit_tests/scripts/performance/test_qwen35_vl_workload_base_configs.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for Qwen3.5-VL performance workload presets."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from megatron.bridge.perf_recipes.qwen_vl.h100.qwen35_vl import (
+    qwen35_vl_122b_a10b_pretrain_128gpu_h100_bf16_config,
+    qwen35_vl_122b_a10b_pretrain_128gpu_h100_fp8cs_config,
+)
+
+
+pytestmark = pytest.mark.unit
+
+_PERF_SCRIPTS_DIR = Path(__file__).resolve().parents[4] / "scripts" / "performance"
+if str(_PERF_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_PERF_SCRIPTS_DIR))
+
+from configs.qwen_vl.qwen35_vl_workload_base_configs import (  # noqa: E402
+    QWEN35_VL_122B_A10B_PRETRAIN_CONFIG_H100_BF16,
+    QWEN35_VL_122B_A10B_PRETRAIN_CONFIG_H100_FP8_CS,
+)
+
+
+@pytest.mark.parametrize(
+    ("legacy_config", "recipe_fn"),
+    [
+        (
+            QWEN35_VL_122B_A10B_PRETRAIN_CONFIG_H100_BF16,
+            qwen35_vl_122b_a10b_pretrain_128gpu_h100_bf16_config,
+        ),
+        (
+            QWEN35_VL_122B_A10B_PRETRAIN_CONFIG_H100_FP8_CS,
+            qwen35_vl_122b_a10b_pretrain_128gpu_h100_fp8cs_config,
+        ),
+    ],
+)
+def test_qwen35_vl_122b_h100_pipeline_layout(legacy_config, recipe_fn):
+    num_layers = 48
+    config = recipe_fn()
+    pp_size = config.model.pipeline_model_parallel_size
+    vp_size = config.model.virtual_pipeline_model_parallel_size
+
+    assert num_layers % pp_size == 0
+    assert vp_size is not None
+    assert (num_layers // pp_size) % vp_size == 0
+    assert pp_size == legacy_config.pipeline_model_parallel_size
+    assert vp_size == legacy_config.virtual_pipeline_model_parallel_size


### PR DESCRIPTION
## Summary

- change the canonical flat Qwen3.5-VL 122B H100 BF16/FP8 recipes from VPP4 to VPP2
- keep the legacy workload-base configurations synchronized during their deprecation window
- add a regression test covering canonical and legacy BF16/FP8 configurations

## Root cause

The H100 presets use 48 transformer layers with PP8, which assigns six layers to each pipeline rank. MCore requires the layers per pipeline rank to be divisible by the virtual pipeline size. VPP4 violates that requirement because `6 % 4 != 0`, so the model fails during construction.

VPP2 produces two three-layer virtual chunks while preserving the existing 128-GPU TP2/PP8/EP16 topology and keeping VPP enabled for expert-parallel communication overlap.

## Impact

Both the canonical `megatron.bridge.perf_recipes` path used by `run_script.py` and the legacy `scripts/performance/configs` compatibility path now produce a valid layout. Other hardware presets and model families are unchanged.

## Validation

- canonical/legacy BF16 and FP8 parity and divisibility test in `nvcr.io/nvidia/nemo:26.06`: 2 passed
- canonical `run_script.py --dryrun` for H100 BF16: passed, emitted VPP2
- canonical `run_script.py --dryrun` for H100 FP8 current scaling: passed, emitted VPP2
- `uv run pre-commit run --all-files`: passed

## Test scope

Blast radius is limited to the Qwen3.5-VL 122B H100 performance recipes and their legacy compatibility configs. L0/unit validation is sufficient; no CI tier label is requested.
