### PR TITLE
fix(data): handle packed SFT preparation edge cases

### DIFF
--- a/scripts/training/pack_sft_data.py
+++ b/scripts/training/pack_sft_data.py
@@ -57,6 +57,12 @@ def main() -> None:
         "--packed-val-data-path", default=None, help="Optional output path for packed validation data."
     )
     parser.add_argument("--packed-metadata-path", default=None, help="Optional output path for packing metadata.")
+    parser.add_argument(
+        "--num-tokenizer-workers",
+        type=int,
+        default=1,
+        help="Tokenizer worker processes. Values less than or equal to 1 run serially (default: 1).",
+    )
     args = parser.parse_args()
 
     import megatron.bridge.recipes as all_recipes
@@ -94,15 +100,11 @@ def main() -> None:
     if offline_packing_specs is None:
         sys.exit(f"Error: recipe '{args.recipe}' has no offline packing specs.")
 
-    # Cap tokenizer workers to avoid /dev/shm OOM from multiprocessing shared memory.
-    # Default is -1 (all CPUs) which exhausts /dev/shm even on CPU nodes.
-    # Use 1 worker so serial materialization avoids multiprocessing shared memory
-    # (see packed_sequence._materialize_dataset_items).
-    offline_packing_specs.num_tokenizer_workers = 1
+    offline_packing_specs.num_tokenizer_workers = args.num_tokenizer_workers
 
     print(f"Recipe:   {args.recipe}")
     print(f"Seq len:  {offline_packing_specs.packed_sequence_size}")
-    print(f"Workers:  {offline_packing_specs.num_tokenizer_workers} (single-threaded, no /dev/shm)")
+    print(f"Workers:  {offline_packing_specs.num_tokenizer_workers}")
     print()
 
     print("Building tokenizer...")

--- a/src/megatron/bridge/data/datasets/packed_sequence.py
+++ b/src/megatron/bridge/data/datasets/packed_sequence.py
@@ -13,12 +13,14 @@
 # limitations under the License.
 import json
 import logging
+import resource
 import warnings
 from dataclasses import dataclass
 from multiprocessing import Pool
 from pathlib import Path
 
 import numpy as np
+import torch
 from megatron.core.msc_utils import MultiStorageClientFeature
 from tqdm import tqdm
 
@@ -48,8 +50,31 @@ def _init_shared_dataset_worker(dataset):
 def _materialize_dataset_items(dataset, num_workers):
     if num_workers <= 1:
         return np.array([dataset[i] for i in tqdm(range(len(dataset)))])
-    with Pool(num_workers, initializer=_init_shared_dataset_worker, initargs=(dataset,)) as pool:
-        return np.array(list(tqdm(pool.imap(_get_shared_dataset_item, range(len(dataset))), total=len(dataset))))
+
+    # File-backed tensor sharing avoids one descriptor per returned tensor; the pool still needs descriptors.
+    previous_sharing_strategy = torch.multiprocessing.get_sharing_strategy()
+    torch.multiprocessing.set_sharing_strategy("file_system")
+
+    previous_nofile_limit = None
+    try:
+        soft_limit, hard_limit = resource.getrlimit(resource.RLIMIT_NOFILE)
+        if soft_limit != hard_limit:
+            resource.setrlimit(resource.RLIMIT_NOFILE, (hard_limit, hard_limit))
+            previous_nofile_limit = (soft_limit, hard_limit)
+    except (ValueError, OSError) as error:
+        logger.warning("Unable to raise the file-descriptor limit for tokenizer workers: %s", error)
+
+    try:
+        with Pool(num_workers, initializer=_init_shared_dataset_worker, initargs=(dataset,)) as pool:
+            items = tqdm(pool.imap(_get_shared_dataset_item, range(len(dataset))), total=len(dataset))
+            return np.array(list(items))
+    finally:
+        if previous_nofile_limit is not None:
+            try:
+                resource.setrlimit(resource.RLIMIT_NOFILE, previous_nofile_limit)
+            except (ValueError, OSError) as error:
+                logger.warning("Unable to restore the file-descriptor limit after tokenization: %s", error)
+        torch.multiprocessing.set_sharing_strategy(previous_sharing_strategy)
 
 
 def _pre_pad_data_point(data: dict, max_seq_length: int, max_length_to_pad: int, pad_id: int) -> None:
@@ -77,16 +102,19 @@ def _pre_pad_data_point(data: dict, max_seq_length: int, max_length_to_pad: int,
         val = data[key]
         # _chat_preprocess returns torch tensors / numpy arrays; normalize to a plain list.
         val = val.tolist() if hasattr(val, "tolist") else list(val)
-        if len(val) <= max_length_to_pad:
+        sequence_length = len(val)
+        if sequence_length <= max_length_to_pad:
             # input_ids are truncated by 1 for labels; add 1 extra pad token
-            val = val + [pad_value] * (max_length_to_pad - len(val) + 1)
-        elif len(val) > max_seq_length:
-            logger.info(
-                "Sequence length %d is larger than max_seq_length %d; truncating for packing.",
-                len(val),
-                max_seq_length,
-            )
-            val = val[:max_seq_length]
+            val = val + [pad_value] * (max_length_to_pad - sequence_length + 1)
+        else:
+            if sequence_length > max_seq_length:
+                logger.info(
+                    "Sequence length %d exceeds max_seq_length %d; truncating for packing.",
+                    sequence_length,
+                    max_seq_length,
+                )
+            # Keep the runtime segment length (stored length minus one) at the divisible pad target.
+            val = val[:max_length_to_pad] + [pad_value]
         data[key] = val
     return
 
@@ -113,6 +141,8 @@ def tokenize_dataset(
             Can include 'chat', 'use_hf_tokenizer_chat_template', 'tool_schemas', etc.
         pad_seq_to_mult (int | None): Optional multiple to pad each sequence to during packing
             preparation (e.g., set to 2 * context_parallel_size for THD CP).
+        num_tokenizer_workers: Number of worker processes used to materialize tokenized samples.
+            Values less than or equal to 1 run serially.
 
     Returns:
         np.ndarray: A NumPy array containing the tokenized data.
@@ -153,15 +183,26 @@ def tokenize_dataset(
     pad_id = dataset.tokenizer.eod
     pad_seq_length_to_mult = dataset.pad_seq_length_to_mult
     max_seq_length = dataset.max_seq_length
+
+    max_pad_cap = None
+    if pad_seq_to_mult > 1:
+        # Stored samples need one extra token for next-token labels, so cap the divisible runtime length below the pack.
+        max_pad_cap = ((max_seq_length - 1) // pad_seq_length_to_mult) * pad_seq_length_to_mult
+        if max_pad_cap == 0:
+            raise ValueError(
+                f"max_seq_length ({max_seq_length}) must be greater than the effective padding multiple "
+                f"({pad_seq_length_to_mult})."
+            )
+
     dataset = _materialize_dataset_items(dataset, num_tokenizer_workers)
 
-    if pad_seq_to_mult > 1:
+    if max_pad_cap is not None:
 
         def ceil_to_nearest(n, m):
             return (n + m - 1) // m * m
 
         for data in dataset:
-            max_length_to_pad = min(max_seq_length, ceil_to_nearest(len(data["input_ids"]), pad_seq_length_to_mult))
+            max_length_to_pad = min(max_pad_cap, ceil_to_nearest(len(data["input_ids"]), pad_seq_length_to_mult))
             _pre_pad_data_point(data, max_seq_length, max_length_to_pad, pad_id)
 
     return dataset
@@ -197,6 +238,8 @@ def prepare_packed_sequence_data(
             Enables packing with chat templates, tool schemas, etc.
         pad_seq_to_mult (int | None): Optional multiple to pad each sequence to during packing
             preparation (e.g., set to 2 * context_parallel_size for THD CP).
+        num_tokenizer_workers: Number of worker processes used to materialize tokenized samples.
+            Values less than or equal to 1 run serially.
 
     Returns:
         None: Saves the packed sequence data to the specified output path.

--- a/src/megatron/bridge/data/datasets/packing_utils.py
+++ b/src/megatron/bridge/data/datasets/packing_utils.py
@@ -154,6 +154,7 @@ def create_hist(dataset: np.array, truncate_seq_len: int) -> Tuple[Dict[int, Lis
 
     sequences = collections.defaultdict(list)
     counts = [0] * (truncate_seq_len + 1)
+    num_skipped = 0
 
     for item_dict in dataset:
         # Minus 1 here to account for the fact that transformer input and label
@@ -162,8 +163,18 @@ def create_hist(dataset: np.array, truncate_seq_len: int) -> Tuple[Dict[int, Lis
         # (this way the tokens are aligned for next token prediction).
         # We want pack size to be the length of the actual input and label, hence minus 1.
         seq_len = len(item_dict["input_ids"]) - 1
+        if seq_len > truncate_seq_len:
+            num_skipped += 1
+            continue
         sequences[seq_len].append(item_dict)
         counts[seq_len] += 1
+
+    if num_skipped:
+        logger.warning(
+            "Skipped %d sequences longer than the maximum packed sequence length %d",
+            num_skipped,
+            truncate_seq_len,
+        )
 
     logger.debug("Histogram of sequence lengths")
     logger.debug(counts)

--- a/tests/unit_tests/data/datasets/test_packed_sequence.py
+++ b/tests/unit_tests/data/datasets/test_packed_sequence.py
@@ -12,9 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
 import torch
 
-from megatron.bridge.data.datasets.packed_sequence import _materialize_dataset_items, _pre_pad_data_point
+from megatron.bridge.data.datasets.packed_sequence import (
+    _init_shared_dataset_worker,
+    _materialize_dataset_items,
+    _pre_pad_data_point,
+    tokenize_dataset,
+)
 
 
 PAD_ID = 0
@@ -64,13 +73,90 @@ def test_pre_pad_data_point_non_chat_lists_still_work():
     assert "loss_mask" not in data
 
 
-def test_pre_pad_data_point_truncates_overlong():
-    """Sequences longer than max_seq_length are truncated."""
+def test_pre_pad_data_point_truncates_overlong_to_target_plus_one():
+    """Overlong sequences retain a CP-divisible runtime length after truncation."""
     data = {"input_ids": list(range(20)), "loss_mask": [1] * 20}
     _pre_pad_data_point(data, max_seq_length=16, max_length_to_pad=8, pad_id=PAD_ID)
 
-    assert len(data["input_ids"]) == 16
-    assert len(data["loss_mask"]) == 16
+    assert len(data["input_ids"]) == 9
+    assert len(data["loss_mask"]) == len(data["input_ids"])
+    assert (len(data["input_ids"]) - 1) % 8 == 0
+    assert data["input_ids"][-1] == PAD_ID
+
+
+def test_pre_pad_data_point_near_pack_size_trims_to_target_plus_one():
+    """Near-pack-size sequences retain a CP-divisible runtime length without overflowing."""
+    data = {"input_ids": list(range(12)), "loss_mask": [1] * 12}
+    _pre_pad_data_point(data, max_seq_length=16, max_length_to_pad=8, pad_id=PAD_ID)
+
+    assert len(data["input_ids"]) == 9
+    assert len(data["loss_mask"]) == len(data["input_ids"])
+    assert (len(data["input_ids"]) - 1) % 8 == 0
+    assert data["input_ids"][-1] == PAD_ID
+
+
+def test_tokenize_dataset_caps_padding_target_below_pack_size(monkeypatch):
+    """CP padding should keep boundary and overlong samples within the divisible target."""
+
+    class TinyDataset:
+        tokenizer = SimpleNamespace(eod=PAD_ID)
+        pad_seq_length_to_mult = 8
+        max_seq_length = 20
+
+        def __init__(self):
+            self.items = [{"input_ids": list(range(length))} for length in (16, 17, 20, 21)]
+
+        def __len__(self):
+            return len(self.items)
+
+        def __getitem__(self, index):
+            return self.items[index]
+
+    monkeypatch.setattr(
+        "megatron.bridge.data.datasets.packed_sequence.create_sft_dataset", lambda **kwargs: TinyDataset()
+    )
+
+    dataset = tokenize_dataset(
+        Path("unused.jsonl"),
+        tokenizer=object(),
+        max_seq_length=20,
+        seed=123,
+        pad_seq_to_mult=8,
+        num_tokenizer_workers=1,
+    )
+
+    assert [len(item["input_ids"]) for item in dataset] == [17, 17, 17, 17]
+    assert all((len(item["input_ids"]) - 1) % 8 == 0 for item in dataset)
+    assert all(len(item["input_ids"]) <= 20 for item in dataset)
+
+
+def test_tokenize_dataset_rejects_padding_multiple_without_positive_target(monkeypatch):
+    """Padding must not silently reduce every sample to a zero-token runtime segment."""
+
+    class TinyDataset:
+        tokenizer = SimpleNamespace(eod=PAD_ID)
+        pad_seq_length_to_mult = 8
+        max_seq_length = 8
+
+        def __len__(self):
+            return 1
+
+        def __getitem__(self, index):
+            raise AssertionError("invalid padding should fail before materializing samples")
+
+    monkeypatch.setattr(
+        "megatron.bridge.data.datasets.packed_sequence.create_sft_dataset", lambda **kwargs: TinyDataset()
+    )
+
+    with pytest.raises(ValueError, match="must be greater than the effective padding multiple"):
+        tokenize_dataset(
+            Path("unused.jsonl"),
+            tokenizer=object(),
+            max_seq_length=8,
+            seed=123,
+            pad_seq_to_mult=8,
+            num_tokenizer_workers=1,
+        )
 
 
 def test_materialize_dataset_items_uses_serial_path_for_non_positive_workers(monkeypatch):
@@ -90,3 +176,54 @@ def test_materialize_dataset_items_uses_serial_path_for_non_positive_workers(mon
 
     assert _materialize_dataset_items(TinyDataset(), -1).tolist() == [10, 11, 12]
     assert _materialize_dataset_items(TinyDataset(), 0).tolist() == [10, 11, 12]
+
+
+@pytest.mark.parametrize("pool_fails", [False, True])
+def test_materialize_dataset_items_configures_and_restores_worker_resources(monkeypatch, pool_fails):
+    """The multiprocessing path should use file-backed tensor sharing only while its pool runs."""
+
+    class TinyDataset:
+        def __len__(self):
+            return 2
+
+        def __getitem__(self, index):
+            return index + 20
+
+    pool_calls = []
+
+    class FakePool:
+        def __init__(self, num_workers, *, initializer, initargs):
+            pool_calls.append((num_workers, initializer, initargs))
+            initializer(*initargs)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            return False
+
+        def imap(self, function, indexes):
+            if pool_fails:
+                raise RuntimeError("worker failure")
+            return map(function, indexes)
+
+    sharing_strategy_calls = []
+    nofile_limit_calls = []
+    monkeypatch.setattr("megatron.bridge.data.datasets.packed_sequence.Pool", FakePool)
+    monkeypatch.setattr(torch.multiprocessing, "get_sharing_strategy", lambda: "file_descriptor")
+    monkeypatch.setattr(torch.multiprocessing, "set_sharing_strategy", sharing_strategy_calls.append)
+    monkeypatch.setattr("megatron.bridge.data.datasets.packed_sequence.resource.getrlimit", lambda _: (256, 4096))
+    monkeypatch.setattr(
+        "megatron.bridge.data.datasets.packed_sequence.resource.setrlimit",
+        lambda _, limits: nofile_limit_calls.append(limits),
+    )
+
+    dataset = TinyDataset()
+    if pool_fails:
+        with pytest.raises(RuntimeError, match="worker failure"):
+            _materialize_dataset_items(dataset, 2)
+    else:
+        assert _materialize_dataset_items(dataset, 2).tolist() == [20, 21]
+    assert sharing_strategy_calls == ["file_system", "file_descriptor"]
+    assert nofile_limit_calls == [(4096, 4096), (256, 4096)]
+    assert pool_calls == [(2, _init_shared_dataset_worker, (dataset,))]

--- a/tests/unit_tests/data/datasets/test_packing_utils.py
+++ b/tests/unit_tests/data/datasets/test_packing_utils.py
@@ -12,12 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 from typing import List
 
 import numpy as np
 import pytest
 
-from megatron.bridge.data.datasets.packing_utils import first_fit, first_fit_decreasing
+from megatron.bridge.data.datasets.packing_utils import create_hist, first_fit, first_fit_decreasing
 
 
 def _first_fit_linear(seqlens: List[int], pack_size: int) -> List[List[int]]:
@@ -59,6 +60,21 @@ class TestFirstFitPacking:
         result = first_fit(seqlens, pack_size)
         for bin_contents in result:
             assert sum(bin_contents) <= pack_size
+
+
+def test_create_hist_skips_oversize_sequences(caplog):
+    """Oversize samples should be skipped without changing in-range histogram entries."""
+    in_range = {"input_ids": [1, 2, 3, 4]}
+    oversize = {"input_ids": [1, 2, 3, 4, 5]}
+    dataset = np.array([in_range, oversize], dtype=object)
+
+    with caplog.at_level(logging.WARNING):
+        sequences, histogram = create_hist(dataset, truncate_seq_len=3)
+
+    assert histogram == [0, 0, 0, 1]
+    assert sequences[3] == [in_range]
+    assert 4 not in sequences
+    assert "Skipped 1 sequences longer than the maximum packed sequence length 3" in caplog.text
 
 
 class TestSegmentTreeMatchesLinearScan:

--- a/tests/unit_tests/scripts/test_pack_sft_data.py
+++ b/tests/unit_tests/scripts/test_pack_sft_data.py
@@ -58,14 +58,17 @@ class _RecipeConfig:
 
 
 class _FinetuningDatasetBuilder:
+    instances = []
     pack_metadata = Path("default-pack-metadata.json")
 
     def __init__(self, *, tokenizer: object, **kwargs: object) -> None:
         self.tokenizer = tokenizer
         self.kwargs = kwargs
+        self.prepare_packed_data_called = False
+        self.instances.append(self)
 
     def prepare_packed_data(self) -> None:
-        raise AssertionError("explicit pack-path tests should not call prepare_packed_data")
+        self.prepare_packed_data_called = True
 
 
 def _load_module():
@@ -81,6 +84,7 @@ def _load_module():
 
 
 def _install_pack_sft_stubs(monkeypatch: pytest.MonkeyPatch, recipe_fn) -> Mock:
+    _FinetuningDatasetBuilder.instances.clear()
     megatron = sys.modules.get("megatron", types.ModuleType("megatron"))
     bridge = types.ModuleType("megatron.bridge")
     data = types.ModuleType("megatron.bridge.data")
@@ -160,7 +164,10 @@ def test_pack_sft_data_rejects_unsupported_hf_path(monkeypatch):
     assert str(exc_info.value) == "Error: recipe 'unit_recipe' does not accept an 'hf_path' parameter."
 
 
-def test_pack_sft_data_forwards_supported_overrides_and_explicit_paths(monkeypatch, tmp_path):
+@pytest.mark.parametrize(("worker_args", "expected_workers"), [([], 1), (["--num-tokenizer-workers", "8"], 8)])
+def test_pack_sft_data_forwards_supported_overrides_and_explicit_paths(
+    monkeypatch, tmp_path, worker_args, expected_workers
+):
     module = _load_module()
     recipe_calls = []
 
@@ -184,6 +191,7 @@ def test_pack_sft_data_forwards_supported_overrides_and_explicit_paths(monkeypat
             "4096",
             "--hf-path",
             "nvidia/unit",
+            *worker_args,
             "--train-input-path",
             str(train_input),
             "--packed-train-data-path",
@@ -203,4 +211,25 @@ def test_pack_sft_data_forwards_supported_overrides_and_explicit_paths(monkeypat
     assert kwargs["output_metadata_path"] == metadata_output
     assert kwargs["packed_sequence_size"] == 2048
     assert kwargs["max_seq_length"] == 4096
-    assert kwargs["num_tokenizer_workers"] == 1
+    assert kwargs["num_tokenizer_workers"] == expected_workers
+
+
+def test_pack_sft_data_forwards_worker_count_to_default_builder(monkeypatch):
+    module = _load_module()
+
+    def unit_recipe():
+        return _RecipeConfig()
+
+    _install_pack_sft_stubs(monkeypatch, unit_recipe)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["pack_sft_data.py", "--recipe", "unit_recipe", "--num-tokenizer-workers", "8"],
+    )
+
+    module.main()
+
+    assert len(_FinetuningDatasetBuilder.instances) == 1
+    builder = _FinetuningDatasetBuilder.instances[0]
+    assert builder.kwargs["offline_packing_specs"].num_tokenizer_workers == 8
+    assert builder.prepare_packed_data_called


### PR DESCRIPTION
## Summary

This is an org-owned migration and cleanup of fork PR #4598 for the still-unaddressed packed SFT preparation items in #4593 §2.3–§2.5.

- Keep near-pack-size and overlong stored samples within the pack while making their runtime lengths divisible by the effective THD/CP padding multiple.
- Reject padding configurations that cannot produce a positive runtime segment.
- Skip and report oversize samples in `create_hist` instead of indexing beyond the histogram.
- Use file-backed tensor sharing and a temporary file-descriptor limit increase around multi-worker tokenization, restoring both settings afterward.
- Replace the `PACK_NUM_WORKERS` environment behavior from #4598 with an explicit `--num-tokenizer-workers` argument and a conservative default of 1, addressing the maintainer inline comment.

Areas already handled on `main` remain out of scope, as described in #4598.

## Validation

- `uvx ruff check` on all six changed files — passed
- `uvx ruff format --check` on all six changed files — passed
- `uv run --active --no-sync pre-commit run --all-files` — passed
- `uv run --active --no-sync python -m pytest --confcutdir=tests/unit_tests/scripts tests/unit_tests/scripts/test_pack_sft_data.py -q` — 5 passed
- The focused packed-sequence and packing-utils pytest files were attempted with the standard project command, but this host cannot install `nvidia-resiliency-ext==0.6.0`: available wheels require `manylinux_2_39`, while the host is `manylinux_2_31_x86_64`. Those tests are included for CI.

No training E2E verification was run for this migrated branch.

## Residual risk

The multiprocessing mitigation is intended for the supported Linux default-fork path. A non-default `spawn` context would not inherit the parent's torch sharing strategy and was not validated here.
