### PR TITLE
ci: use NVIDIA inference for Claude review

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -44,11 +44,15 @@ jobs:
 
       - name: Run Claude Code Review
         uses: anthropics/claude-code-action@v1
+        env:
+          ANTHROPIC_BASE_URL: ${{ secrets.NVIDIA_INFERENCE_URL }}
+          CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
+          DISABLE_PROMPT_CACHING: "1"
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ secrets.NVIDIA_INFERENCE_KEY }}
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Read"
-            --model "claude-opus-4-6"
+            --model "${{ vars.CLAUDE_MODEL }}"
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
@@ -113,8 +117,9 @@ jobs:
 
   manual-review:
     if: github.event_name == 'issue_comment' && github.event.issue.pull_request != null && contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_claude_review.yml@v0.88.0
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_claude_review.yml@v1.7.0
     with:
+      model: ${{ vars.CLAUDE_MODEL }}
       prompt: |
         Mandatory workflow — never skip or reorder:
         1. Read the PR diff first.
@@ -174,4 +179,5 @@ jobs:
         mcp__github_inline_comment__create_inline_comment are optional —
         use them only for specific code suggestions.
     secrets:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      NVIDIA_INFERENCE_URL: ${{ secrets.NVIDIA_INFERENCE_URL }}
+      NVIDIA_INFERENCE_KEY: ${{ secrets.NVIDIA_INFERENCE_KEY }}


### PR DESCRIPTION
# What does this PR do ?

Updates the Claude review workflow to use the released FW-CI-templates `v1.7.0` NVIDIA inference configuration.

# Changelog

- Bump `_claude_review.yml` usage to `NVIDIA-NeMo/FW-CI-templates@v1.7.0`.
- Pass `vars.CLAUDE_MODEL`, `secrets.NVIDIA_INFERENCE_URL`, and `secrets.NVIDIA_INFERENCE_KEY`.
- Update the direct auto-review Claude action to use the NVIDIA inference endpoint/key and model variable.

# GitHub Actions CI

Workflow YAML was parsed locally; no product tests are needed for this CI-only change.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Did you write any new necessary tests? N/A.
- [x] Did you add or update any necessary documentation? N/A.

# Additional Information

- Linear: AUT-644