### PR TITLE
fix: scatter Qwen3-VL text-model embeddings under SP for standalone LM forwards

### DIFF
--- a/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/text_model.py
+++ b/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/text_model.py
@@ -142,6 +142,9 @@ class Qwen3VLGPTModel(GPTModel):
         # `_preprocess` can optionally return an extra fused cos/sin buffer (for
         # flash decode). Match the upstream GPTModel handling to avoid unpack
         # errors when six values are returned.
+        # Standalone LM forwards (e.g. language-model distillation) embed internally; the VLM
+        # outer model otherwise supplies pre-scattered merged embeddings via decoder_input.
+        _embeddings_provided = decoder_input is not None
         preproc_output = self._preprocess(
             input_ids=input_ids,
             position_ids=position_ids,
@@ -157,6 +160,15 @@ class Qwen3VLGPTModel(GPTModel):
             rotary_pos_sin,
             sequence_len_offset,
         ) = preproc_output[:5]
+
+        # The embedding is built with scatter_embedding_sequence_parallel=False (the VLM outer
+        # model scatters the merged vision+text embeddings for SP). For a standalone LM forward
+        # under sequence parallelism, scatter the internally-embedded sequence here so the
+        # decoder/output shapes are correct (otherwise the output-side gather doubles the seq).
+        if not _embeddings_provided and self.pre_process and self.config.sequence_parallel:
+            decoder_input = tensor_parallel.scatter_to_sequence_parallel_region(
+                decoder_input, group=self.pg_collection.tp
+            )
 
         # Run decoder.
         hidden_states = self.decoder(


### PR DESCRIPTION
## What

Fix a sequence-parallel bug in the Qwen3-VL text model that breaks **standalone language-model forwards** (e.g. distilling only the LM tower of a VLM) under tensor + sequence parallelism.

## Why

`Qwen3VLModel` builds its text model with `scatter_embedding_sequence_parallel=False` because the outer VLM model manually scatters the **merged vision+text** embeddings for sequence parallelism (`modelling_qwen3_vl/model.py`).

When the language model is run **on its own** — no outer VLM, e.g. ModelOpt language-model distillation of a VLM — that manual scatter is bypassed. Under SP the embeddings therefore stay unscattered, the decoder runs the **full** sequence on every TP rank, and the output-side sequence-parallel gather then **doubles** the sequence length.

This surfaces downstream as a `TP_size × seq_length` vs `seq_length` shape mismatch. Concretely, ModelOpt VLM language-model distillation at TP=2 + SP fails in the KD loss-mask step:

```
RuntimeError: The size of tensor a (32) must match the size of tensor b (16) at non-singleton dimension 0
```

(32 = TP_size(2) × seq_length(16).) Plain TP (no SP) works; the plain LM path works; only the standalone-VLM-LM + SP combination is affected.

## Fix

In `Qwen3VLTextModel.forward`, when no external `decoder_input` is provided (i.e. the LM embeds internally) and sequence parallelism is enabled, scatter the internally-embedded sequence — mirroring the existing MTP-path scatter a few lines below. The normal VLM forward (which passes pre-scattered `decoder_input` from the outer model) is unaffected.

```python
if not _embeddings_provided and self.pre_process and self.config.sequence_parallel:
    decoder_input = tensor_parallel.scatter_to_sequence_parallel_region(
        decoder_input, group=self.pg_collection.tp
    )
```

## Testing

Validated on `nvcr.io/nvidia/nemo:26.06`: Qwen3.5-VL language-model distillation at **TP=2 + SP** passes with this change (previously failed at the loss-mask step). Single-GPU and TP-without-SP were already passing and remain so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
