### PR TITLE
fix(misc): preserve nested Hugging Face config mappings

### DIFF
--- a/src/megatron/bridge/training/utils/config_utils.py
+++ b/src/megatron/bridge/training/utils/config_utils.py
@@ -13,9 +13,11 @@
 # limitations under the License.
 
 import logging
+from dataclasses import fields as dataclass_fields
+from dataclasses import is_dataclass
 from typing import Any, Mapping
 
-from megatron.training.config.container import ConfigContainerBase as _ConfigContainerBase  # noqa: F401
+from megatron.training.config.container import ConfigContainerBase as _MCoreConfigContainerBase
 from megatron.training.config.utils import (
     _get_init_false_fields,  # noqa: F401
     _resolve_target_class,  # noqa: F401
@@ -23,9 +25,59 @@ from megatron.training.config.utils import (
 from megatron.training.config.utils import (
     sanitize_dataclass_config as _sanitize_dataclass_config,
 )
+from transformers import PreTrainedConfig
 
 
 logger = logging.getLogger(__name__)
+
+
+class _ConfigContainerBase(_MCoreConfigContainerBase):
+    """Bridge config container that lets composite HF configs construct their children.
+
+    Nested ``PreTrainedConfig`` values are emitted as plain mappings because their
+    parent config owns child construction. Other dataclasses retain MCore's recursive
+    ``_target_`` serialization.
+    """
+
+    @classmethod
+    def _convert_value_to_dict(cls, value: Any) -> Any:
+        if isinstance(value, PreTrainedConfig) and not hasattr(value, "to_cfg_dict"):
+            return cls._convert_pretrained_config_to_dict(value, include_target=True)
+        return super()._convert_value_to_dict(value)
+
+    @classmethod
+    def _convert_pretrained_config_to_dict(
+        cls,
+        value: PreTrainedConfig,
+        *,
+        include_target: bool,
+    ) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        if include_target:
+            result["_target_"] = f"{value.__class__.__module__}.{value.__class__.__qualname__}"
+
+        if include_target and is_dataclass(value):
+            config_items = (
+                (field.name, getattr(value, field.name))
+                for field in dataclass_fields(value)
+                if not field.name.startswith("_")
+            )
+        else:
+            config_items = ((key, item) for key, item in value.to_dict().items() if not key.startswith("_"))
+
+        for key, item in config_items:
+            result[key] = cls._convert_pretrained_config_value_to_dict(item)
+        return result
+
+    @classmethod
+    def _convert_pretrained_config_value_to_dict(cls, value: Any) -> Any:
+        if isinstance(value, PreTrainedConfig):
+            return cls._convert_pretrained_config_to_dict(value, include_target=False)
+        if isinstance(value, (list, tuple)):
+            return [cls._convert_pretrained_config_value_to_dict(item) for item in value]
+        if isinstance(value, dict):
+            return {key: cls._convert_pretrained_config_value_to_dict(item) for key, item in value.items()}
+        return cls._convert_value_to_dict(value)
 
 
 def create_ddp_config(

--- a/tests/unit_tests/training/utils/test_hf_config_serialization.py
+++ b/tests/unit_tests/training/utils/test_hf_config_serialization.py
@@ -1,0 +1,168 @@
+from dataclasses import dataclass
+
+import pytest
+import yaml
+from transformers.models.llava.configuration_llava import LlavaConfig
+from transformers.models.mistral.configuration_mistral import MistralConfig
+from transformers.models.qwen3_omni_moe.configuration_qwen3_omni_moe import (
+    Qwen3OmniMoeTalkerCodePredictorConfig,
+    Qwen3OmniMoeTalkerConfig,
+    Qwen3OmniMoeTalkerTextConfig,
+)
+from transformers.models.siglip.configuration_siglip import SiglipVisionConfig
+
+from megatron.bridge.models.qwen_omni import Qwen3OmniModelProvider
+from megatron.bridge.recipes.common import _sft_common_vlm
+from megatron.bridge.training.config import ConfigContainer
+from megatron.bridge.training.utils.config_utils import _ConfigContainerBase
+from megatron.bridge.utils.instantiate_utils import InstantiationMode
+
+
+pytestmark = pytest.mark.unit
+
+
+def _code_predictor_config() -> dict[str, object]:
+    return {
+        "hidden_size": 1024,
+        "intermediate_size": 3072,
+        "num_hidden_layers": 5,
+        "num_attention_heads": 16,
+        "num_key_value_heads": 8,
+        "num_code_groups": 16,
+        "vocab_size": 2048,
+    }
+
+
+def _text_config() -> dict[str, object]:
+    return {
+        "hidden_size": 1024,
+        "intermediate_size": 2048,
+        "moe_intermediate_size": 384,
+        "num_hidden_layers": 20,
+        "num_attention_heads": 16,
+        "num_key_value_heads": 2,
+        "num_experts": 128,
+        "num_experts_per_tok": 6,
+        "vocab_size": 3072,
+    }
+
+
+def _talker_config() -> Qwen3OmniMoeTalkerConfig:
+    return Qwen3OmniMoeTalkerConfig(
+        code_predictor_config=_code_predictor_config(),
+        text_config=_text_config(),
+        thinker_hidden_size=2048,
+        num_code_groups=16,
+    )
+
+
+@dataclass
+class QwenTalkerConfigContainer(_ConfigContainerBase):
+    talker_config: Qwen3OmniMoeTalkerConfig
+
+
+@dataclass
+class LlavaConfigContainer(_ConfigContainerBase):
+    model_config: LlavaConfig
+
+
+@dataclass
+class RecursiveLeafConfig:
+    value: int
+
+
+@dataclass
+class RecursiveBranchConfig:
+    leaf: RecursiveLeafConfig
+
+
+@dataclass
+class RecursiveConfigContainer(_ConfigContainerBase):
+    branch: RecursiveBranchConfig
+
+
+@pytest.mark.parametrize("nested_as_dict", [False, True])
+def test_qwen_talker_config_yaml_roundtrip(tmp_path, nested_as_dict):
+    talker_config = _talker_config()
+    if nested_as_dict:
+        talker_config.code_predictor_config = _code_predictor_config()
+        talker_config.text_config = _text_config()
+
+    config = QwenTalkerConfigContainer(talker_config=talker_config)
+    yaml_path = tmp_path / "run_config.yaml"
+    config.to_yaml(str(yaml_path))
+
+    serialized = yaml.safe_load(yaml_path.read_text())
+    serialized_talker = serialized["talker_config"]
+    assert serialized_talker["_target_"].endswith(".Qwen3OmniMoeTalkerConfig")
+    assert "_target_" not in serialized_talker["code_predictor_config"]
+    assert "_target_" not in serialized_talker["text_config"]
+
+    loaded = QwenTalkerConfigContainer.from_yaml(str(yaml_path), mode=InstantiationMode.STRICT)
+    assert isinstance(loaded.talker_config, Qwen3OmniMoeTalkerConfig)
+    assert isinstance(loaded.talker_config.code_predictor_config, Qwen3OmniMoeTalkerCodePredictorConfig)
+    assert isinstance(loaded.talker_config.text_config, Qwen3OmniMoeTalkerTextConfig)
+    assert loaded.talker_config.code_predictor_config.num_hidden_layers == 5
+    assert loaded.talker_config.code_predictor_config.hidden_size == 1024
+    assert loaded.talker_config.text_config.num_hidden_layers == 20
+    assert loaded.talker_config.text_config.num_experts == 128
+
+
+def test_qwen_provider_config_container_yaml_roundtrip(tmp_path):
+    config = _sft_common_vlm()
+    config.model = Qwen3OmniModelProvider(
+        num_layers=2,
+        hidden_size=128,
+        num_attention_heads=4,
+        talker_config=_talker_config(),
+    )
+    yaml_path = tmp_path / "run_config.yaml"
+    config.to_yaml(str(yaml_path))
+
+    loaded = ConfigContainer.from_yaml(str(yaml_path), mode=InstantiationMode.STRICT)
+    assert isinstance(loaded.model, Qwen3OmniModelProvider)
+    assert isinstance(loaded.model.talker_config, Qwen3OmniMoeTalkerConfig)
+    assert isinstance(loaded.model.talker_config.code_predictor_config, Qwen3OmniMoeTalkerCodePredictorConfig)
+    assert isinstance(loaded.model.talker_config.text_config, Qwen3OmniMoeTalkerTextConfig)
+    assert loaded.model.talker_config.code_predictor_config.hidden_size == 1024
+    assert loaded.model.talker_config.text_config.num_experts == 128
+
+
+def test_other_composite_hf_config_yaml_roundtrip(tmp_path):
+    config = LlavaConfigContainer(
+        model_config=LlavaConfig(
+            vision_config=SiglipVisionConfig(hidden_size=768, num_attention_heads=12),
+            text_config=MistralConfig(hidden_size=1024, num_attention_heads=16, num_key_value_heads=8),
+        )
+    )
+    yaml_path = tmp_path / "run_config.yaml"
+    config.to_yaml(str(yaml_path))
+
+    serialized = yaml.safe_load(yaml_path.read_text())
+    assert serialized["model_config"]["_target_"].endswith(".LlavaConfig")
+    assert "_target_" not in serialized["model_config"]["vision_config"]
+    assert "_target_" not in serialized["model_config"]["text_config"]
+    assert serialized["model_config"]["vision_config"]["model_type"] == "siglip_vision_model"
+    assert serialized["model_config"]["text_config"]["model_type"] == "mistral"
+
+    loaded = LlavaConfigContainer.from_yaml(str(yaml_path), mode=InstantiationMode.STRICT)
+    assert isinstance(loaded.model_config, LlavaConfig)
+    assert isinstance(loaded.model_config.vision_config, SiglipVisionConfig)
+    assert isinstance(loaded.model_config.text_config, MistralConfig)
+    assert loaded.model_config.vision_config.hidden_size == 768
+    assert loaded.model_config.text_config.hidden_size == 1024
+
+
+def test_non_hf_nested_configs_remain_recursive(tmp_path):
+    config = RecursiveConfigContainer(branch=RecursiveBranchConfig(leaf=RecursiveLeafConfig(value=17)))
+    yaml_path = tmp_path / "run_config.yaml"
+    config.to_yaml(str(yaml_path))
+
+    serialized = yaml.safe_load(yaml_path.read_text())
+    assert serialized["branch"]["_target_"].endswith(".RecursiveBranchConfig")
+    assert serialized["branch"]["leaf"]["_target_"].endswith(".RecursiveLeafConfig")
+
+    loaded = RecursiveConfigContainer.from_yaml(str(yaml_path), mode=InstantiationMode.STRICT)
+    assert isinstance(loaded.branch, RecursiveBranchConfig)
+    assert isinstance(loaded.branch.leaf, RecursiveLeafConfig)
+    assert loaded.branch.leaf.value == 17

--- a/tests/unit_tests/training/utils/test_hf_config_serialization.py
+++ b/tests/unit_tests/training/utils/test_hf_config_serialization.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from dataclasses import dataclass
 
 import pytest


### PR DESCRIPTION
# What does this PR do?

Fixes recursive instantiation of nested Hugging Face configs when Megatron Bridge serializes a checkpoint `run_config.yaml`.

The parent `PreTrainedConfig` remains instantiable through `_target_`, while nested HF configs are emitted as plain mappings so the parent can construct its own children. Existing model-specific `to_cfg_dict()` hooks remain authoritative, and ordinary Bridge/MCore dataclasses keep recursive `_target_` behavior.

Fixes [#4616](https://github.com/NVIDIA-NeMo/Megatron-Bridge/issues/4616).

## Root cause

MCore recursively instantiated every nested `_target_` before invoking the parent Qwen3-Omni config. The parent then attempted to unpack an already-instantiated child as keyword arguments and failed:

```text
TypeError: Qwen3OmniMoeTalkerCodePredictorConfig() argument after ** must be a mapping,
not Qwen3OmniMoeTalkerCodePredictorConfig
```

## Config shape

Before, both the parent and children were independently targeted:

```yaml
talker_config:
  _target_: transformers.models.qwen3_omni_moe.configuration_qwen3_omni_moe.Qwen3OmniMoeTalkerConfig

  code_predictor_config:
    _target_: transformers.models.qwen3_omni_moe.configuration_qwen3_omni_moe.Qwen3OmniMoeTalkerCodePredictorConfig
    hidden_size: 1024
    num_hidden_layers: 5

  text_config:
    _target_: transformers.models.qwen3_omni_moe.configuration_qwen3_omni_moe.Qwen3OmniMoeTalkerTextConfig
    hidden_size: 1024
    num_hidden_layers: 20
```

After, only the parent is targeted. Nested mappings retain their HF `model_type` discriminator:

```yaml
talker_config:
  _target_: transformers.models.qwen3_omni_moe.configuration_qwen3_omni_moe.Qwen3OmniMoeTalkerConfig

  code_predictor_config:
    model_type: qwen3_omni_moe_talker_code_predictor
    hidden_size: 1024
    num_hidden_layers: 5

  text_config:
    model_type: qwen3_omni_moe_talker_text
    hidden_size: 1024
    num_hidden_layers: 20
```

# Changelog

- Add HF-aware Bridge config serialization without changing generic MCore instantiation.
- Preserve explicit `to_cfg_dict()` serializers such as Qwen3-ASR.
- Preserve dynamic nested HF child classes through canonical `model_type` mappings.
- Add Qwen3-Omni object/dictionary YAML round trips, a non-default Llava SigLIP/Mistral round trip, and a non-HF recursive control.

# Validation

- Real config-only round trip using `Qwen/Qwen3-Omni-30B-A3B-Instruct` revision `26291f793822fb6be9555850f06dfe95f2d7e695`.
- All five Qwen3-Omni nested configs retained exact `to_dict()` equality after load.
- 199 affected unit tests passed, including Qwen3-Omni and Qwen3-ASR.
- Pre-commit passed.
- Newly emitted YAML loaded successfully with the pre-fix Bridge loader.

# GitHub Actions CI

Not triggered locally.

# Before your PR is "Ready for review"

- [x] Read and followed the contributor guidelines.
- [x] Added regression and control tests.
- [x] Documentation changes are not required.
- [x] No optional-install component is affected.

# Additional Information

Already-generated Qwen3-Omni YAML containing recursive child `_target_` entries must be regenerated or repaired; this PR does not migrate invalid existing YAML. Checkpoint tensor files are unaffected.
