### PR TITLE
fix(ckpt): select gemma4 dense mapping registry by hf_config and guard None conversion tasks

### DIFF
--- a/src/megatron/bridge/models/conversion/model_bridge.py
+++ b/src/megatron/bridge/models/conversion/model_bridge.py
@@ -1187,8 +1187,10 @@ class MegatronModelBridge(
             conversion_tasks = self.build_conversion_tasks(hf_pretrained, megatron_model)
 
         for task in conversion_tasks:
-            # None means megatron module not on current rank, skip if this task is not going to happen
-            if task.megatron_module is None:
+            # build_conversion_tasks returns List[None | WeightConversionTask]: a slot stays None
+            # when no mapping matched. A None megatron_module means the module is not on the current
+            # rank. Either way there is nothing to stream, so skip.
+            if task is None or task.megatron_module is None:
                 continue
             hf_state_dict: Mapping[str, torch.Tensor] = hf_pretrained.state
             if isinstance(task.mapping.hf_param, str):

--- a/src/megatron/bridge/models/conversion/model_bridge.py
+++ b/src/megatron/bridge/models/conversion/model_bridge.py
@@ -1057,8 +1057,10 @@ class MegatronModelBridge(
 
         _hf_import_cache: Dict[str, torch.Tensor] = {}
         for task in self._with_progress_tracking(hf_to_megatron_tasks, description):
-            # None means megatron module not on current rank, skip if this task is not going to happen
-            if task.megatron_module is None:
+            # build_conversion_tasks returns List[None | WeightConversionTask]: a slot stays None
+            # when no mapping matched for that param. A None megatron_module means the module is not
+            # on the current rank. Either way there is nothing to load, so skip.
+            if task is None or task.megatron_module is None:
                 continue
             # 1) Fetch source tensor(s) from HF state dict, with caching for grouped mappings
             hf_param_key = str(task.mapping.hf_param)

--- a/src/megatron/bridge/models/gemma/gemma4_bridge.py
+++ b/src/megatron/bridge/models/gemma/gemma4_bridge.py
@@ -340,7 +340,15 @@ class Gemma4Bridge(MegatronModelBridge):
         return hf_weights
 
     def mapping_registry(self) -> MegatronMappingRegistry:
-        if getattr(self, "_is_dense", False):
+        # `_is_dense` is set as a side effect of `provider_bridge()`. When `mapping_registry()` is
+        # reached without it having run on this instance (e.g. conversion-task building / export),
+        # fall back to the same signal `provider_bridge()` uses, so a dense model is never mapped
+        # with the MoE registry (which leaves dense params unmapped -> None tasks -> crash). NVBug 6367442.
+        is_dense = getattr(self, "_is_dense", None)
+        if is_dense is None:
+            hf_config = getattr(self, "hf_config", None)
+            is_dense = not getattr(hf_config, "enable_moe_block", False)
+        if is_dense:
             return self._dense_mapping_registry()
         return self._moe_mapping_registry()
 

--- a/tests/unit_tests/models/test_model_bridge_load_weights.py
+++ b/tests/unit_tests/models/test_model_bridge_load_weights.py
@@ -46,6 +46,9 @@ def _bridge_loading(monkeypatch, tasks):
     monkeypatch.setattr(bridge, "_with_progress_tracking", lambda iterable, description: iterable)
     # ``unwrap_model`` is module-level in model_bridge; pass the model list through unchanged.
     monkeypatch.setattr(model_bridge_mod, "unwrap_model", lambda m: m)
+    # After the task loop, load_weights broadcasts shared embeddings across ranks; stub it out so
+    # the test needs no distributed/parallel-state init (we are only exercising the task loop).
+    monkeypatch.setattr(bridge, "_broadcast_shared_embeddings", lambda models: None)
     return bridge
 
 

--- a/tests/unit_tests/models/test_model_bridge_load_weights.py
+++ b/tests/unit_tests/models/test_model_bridge_load_weights.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for None-task handling in ``load_weights_hf_to_megatron`` (NVBug 6367442).
+
+``build_conversion_tasks`` is typed ``List[None | WeightConversionTask]`` and intentionally
+leaves a slot as ``None`` when no mapping matches a parameter. The consuming loop in
+``load_weights_hf_to_megatron`` must skip such ``None`` slots; previously it accessed
+``task.megatron_module`` directly, raising
+``AttributeError: 'NoneType' object has no attribute 'megatron_module'`` during HF->Megatron
+weight loading (observed for Gemma4 dense conversion and inference).
+"""
+
+from types import SimpleNamespace
+
+import torch
+
+from megatron.bridge.models.conversion import model_bridge as model_bridge_mod
+from megatron.bridge.models.conversion.mapping_registry import MegatronMappingRegistry
+from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge
+
+
+class _DummyBridge(MegatronModelBridge):
+    def provider_bridge(self, hf_pretrained):  # pragma: no cover - not used in these tests
+        return None
+
+    def mapping_registry(self):  # pragma: no cover - not used in these tests
+        return MegatronMappingRegistry()
+
+
+def _bridge_loading(monkeypatch, tasks):
+    """Build a bridge whose ``build_conversion_tasks`` yields ``tasks`` with trivial plumbing."""
+    bridge = _DummyBridge()
+    monkeypatch.setattr(bridge, "build_conversion_tasks", lambda *a, **k: tasks)
+    monkeypatch.setattr(bridge, "_with_progress_tracking", lambda iterable, description: iterable)
+    # ``unwrap_model`` is module-level in model_bridge; pass the model list through unchanged.
+    monkeypatch.setattr(model_bridge_mod, "unwrap_model", lambda m: m)
+    return bridge
+
+
+def test_load_weights_skips_none_task(monkeypatch):
+    """A ``None`` task (no mapping matched) is skipped instead of dereferenced.
+
+    Before the fix this raised ``AttributeError: 'NoneType' object has no attribute
+    'megatron_module'``.
+    """
+    megatron_model = [torch.nn.Identity()]  # not FSDP -> FSDP branch skipped
+    # First slot is ``None`` (no mapping); second is a task whose module is not on this rank.
+    tasks = [None, SimpleNamespace(megatron_module=None)]
+    bridge = _bridge_loading(monkeypatch, tasks)
+    hf_pretrained = SimpleNamespace(model_name_or_path="dummy")  # no ``state`` -> empty state dict
+
+    result = bridge.load_weights_hf_to_megatron(hf_pretrained, megatron_model)
+
+    assert result is megatron_model  # completed without error; both slots skipped
+
+
+def test_load_weights_processes_real_task_after_none(monkeypatch):
+    """A real task following a ``None`` slot is still processed (the guard continues, not breaks)."""
+    megatron_model = [torch.nn.Identity()]
+    calls = []
+    mapping = SimpleNamespace(hf_param="hf.weight", is_grouped_export=False)
+    mapping.hf_to_megatron = lambda weights, module: calls.append("converted")
+    real_task = SimpleNamespace(megatron_module=object(), mapping=mapping, param_weight=None, param_name="p")
+    tasks = [None, real_task]
+    bridge = _bridge_loading(monkeypatch, tasks)
+    monkeypatch.setattr(
+        bridge,
+        "maybe_modify_loaded_hf_weight",
+        lambda hf_param, state_dict: calls.append("fetched") or torch.zeros(1),
+    )
+    hf_pretrained = SimpleNamespace(model_name_or_path="dummy")
+
+    bridge.load_weights_hf_to_megatron(hf_pretrained, megatron_model)
+
+    # The None slot was skipped first, then the real task's mapping was exercised.
+    assert calls == ["fetched", "converted"]


### PR DESCRIPTION
## Summary

Fixes NVBug 6367442: gemma4 dense (text-only) HF↔Megatron conversion selected the MoE parameter-mapping registry for dense models, producing unmapped params and crashing during weight loading.

## Changes

- src/megatron/bridge/models/gemma/gemma4_bridge.py:
  `mapping_registry()` falls back to `hf_config.enable_moe_block` when the stateful `_is_dense` flag is unset (MoE path unchanged).
- src/megatron/bridge/models/conversion/model_bridge.py:
  guard None conversion tasks in `_load_weights_hf_to_megatron` and `stream_weights_hf_to_megatron`.
- tests/unit_tests/models/test_model_bridge_load_weights.py:

  new red-green regression test.

## Verification
- Red-green: FAIL pre-fix, PASS after (nemo:26.06.rc9).
- Real roundtrip reproduced on origin/r0.5.0
  (RED: shape-mismatch crash) → GREEN on this branch:
  all tensors verified, HF ckpt written, 0 unmapped params.

## Reference
- NVBug 6367442