### PR TITLE
chore: Update vllm patch for 0.24.0

### DIFF
--- a/docker/patches/vllm.patch
+++ b/docker/patches/vllm.patch
@@ -1,12 +1,12 @@
 diff --git a/utils/torch_utils.py b/utils/torch_utils.py
-index 1eb9306ed..0e0008aab 100644
+index 9269fbb44..77693bfd6 100644
 --- a/utils/torch_utils.py
 +++ b/utils/torch_utils.py
-@@ -788,6 +788,9 @@ def is_torch_equal_or_newer(target: str) -> bool:
+@@ -828,6 +828,9 @@ def is_torch_equal_or_newer(target: str) -> bool:
      Returns:
          Whether the condition meets.
      """
-+    if target == "2.12.0.dev":
++    if target == "2.13.0.dev":
 +        return False
 +
      try:


### PR DESCRIPTION
# What does this PR do ?

chore: Update vllm patch for 0.24.0

We should not merge until base image uses pytorch 26.06 and vllm 0.24.0

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
