### PR TITLE
fix(model): apply final logit softcapping to Gemma 4 dense models

### DIFF
--- a/src/megatron/bridge/models/gemma/gemma4_bridge.py
+++ b/src/megatron/bridge/models/gemma/gemma4_bridge.py
@@ -179,6 +179,7 @@ class Gemma4Bridge(MegatronModelBridge):
             num_kv_shared_layers=getattr(hf_config, "num_kv_shared_layers", 0),
             per_layer_embed_vocab_size=getattr(hf_config, "vocab_size_per_layer_input", hf_config.vocab_size),
             per_layer_embed_dim=getattr(hf_config, "hidden_size_per_layer_input", 256),
+            final_logit_softcapping=getattr(hf_config, "final_logit_softcapping", None),
             bf16=True,
         )
 
@@ -226,6 +227,13 @@ class Gemma4Bridge(MegatronModelBridge):
         provider.make_vocab_size_divisible_by = 128
 
         return provider
+
+    @classmethod
+    def megatron_to_hf_config(cls, provider: Gemma4ModelProvider | Gemma4DenseProvider) -> dict:
+        """Convert a Gemma 4 provider config back to Hugging Face config."""
+        hf_config = super().megatron_to_hf_config(provider)
+        hf_config["final_logit_softcapping"] = provider.final_logit_softcapping
+        return hf_config
 
     def maybe_modify_converted_hf_weight(self, task, converted_weights_dict, hf_state_dict):
         """Un-fuse fused weights and drop synthesized keys on export."""

--- a/src/megatron/bridge/models/gemma/gemma4_provider.py
+++ b/src/megatron/bridge/models/gemma/gemma4_provider.py
@@ -145,6 +145,7 @@ class Gemma4DenseProvider(GPTModelProvider):
     num_kv_shared_layers: int = 18
     per_layer_embed_vocab_size: int = 262144
     per_layer_embed_dim: int = 256
+    final_logit_softcapping: float | None = 30.0
 
     num_moe_experts: Optional[int] = None
     moe_router_topk: Optional[int] = None
@@ -221,6 +222,13 @@ class Gemma4DenseProvider(GPTModelProvider):
         _install_ple_forward(model)
         _install_gemma4_dense_load_state_aliases(model)
 
+        if (
+            hasattr(model, "output_layer")
+            and self.final_logit_softcapping is not None
+            and not isinstance(model.output_layer, Gemma4OutputLayer)
+        ):
+            extend_instance(model.output_layer, Gemma4OutputLayer)
+
         return model
 
 
@@ -277,7 +285,7 @@ class Gemma4ModelProvider(GPTModelProvider):
     moe_permute_fusion: bool = True
     moe_layer_freq: int = 1
 
-    final_logit_softcapping: float = 30.0
+    final_logit_softcapping: float | None = 30.0
 
     flash_decode: bool = False
     transformer_layer_spec: Union[Callable, object] = field(
@@ -321,7 +329,11 @@ class Gemma4ModelProvider(GPTModelProvider):
             global_rotary_percent=self.global_rotary_percent,
         )
 
-        if hasattr(model, "output_layer") and self.final_logit_softcapping:
+        if (
+            hasattr(model, "output_layer")
+            and self.final_logit_softcapping is not None
+            and not isinstance(model.output_layer, Gemma4OutputLayer)
+        ):
             extend_instance(model.output_layer, Gemma4OutputLayer)
 
         if hasattr(model, "embedding") or hasattr(model, "output_layer"):

--- a/src/megatron/bridge/models/gemma_vl/gemma4_vl_bridge.py
+++ b/src/megatron/bridge/models/gemma_vl/gemma4_vl_bridge.py
@@ -152,6 +152,14 @@ class Gemma4VLBridge(Gemma4Bridge):
 
         return provider
 
+    @classmethod
+    def megatron_to_hf_config(cls, provider: Gemma4VLModelProvider | Gemma4DenseVLProvider) -> dict:
+        """Convert a Gemma 4 VL provider config back to Hugging Face config."""
+        hf_config = super().megatron_to_hf_config(provider)
+        final_logit_softcapping = hf_config.pop("final_logit_softcapping")
+        hf_config.setdefault("text_config", {})["final_logit_softcapping"] = final_logit_softcapping
+        return hf_config
+
     def _conversion_mode(self) -> str:
         mode = getattr(self, "gemma4_conversion_mode", None) or os.environ.get("GEMMA4_CONVERSION_MODE", "auto")
         mode = mode.lower()

--- a/tests/unit_tests/models/gemma/test_gemma4_bridge.py
+++ b/tests/unit_tests/models/gemma/test_gemma4_bridge.py
@@ -237,6 +237,20 @@ class TestGemma4BridgeProviderBridgeDense:
     def test_does_not_return_moe_provider(self, bridge, mock_pretrained_dense):
         assert not isinstance(bridge.provider_bridge(mock_pretrained_dense), Gemma4ModelProvider)
 
+    def test_logit_softcapping(self, bridge, mock_pretrained_dense):
+        """Dense providers must preserve HF's final-logit softcap configuration."""
+        assert bridge.provider_bridge(mock_pretrained_dense).final_logit_softcapping == 30.0
+
+    def test_missing_logit_softcapping_disables_it(self, bridge, mock_pretrained_dense):
+        del mock_pretrained_dense.config.final_logit_softcapping
+        assert bridge.provider_bridge(mock_pretrained_dense).final_logit_softcapping is None
+
+
+@pytest.mark.parametrize("provider_cls", [Gemma4DenseProvider, Gemma4ModelProvider])
+def test_megatron_to_hf_config_preserves_final_logit_softcapping(provider_cls):
+    provider = provider_cls(final_logit_softcapping=17.0)
+    assert Gemma4Bridge.megatron_to_hf_config(provider)["final_logit_softcapping"] == 17.0
+
 
 # ===========================================================================
 # _infer_attn_pattern helper

--- a/tests/unit_tests/models/gemma/test_gemma4_provider.py
+++ b/tests/unit_tests/models/gemma/test_gemma4_provider.py
@@ -27,11 +27,41 @@ from megatron.bridge.models.gemma.gemma4_provider import (
     _install_gemma4_dense_load_state_aliases,
 )
 from megatron.bridge.models.gemma.modeling_gemma4 import (
+    Gemma4OutputLayer,
     _gemma4_checkpointed_forward,
     _install_tied_kv,
     _patch_ple_block_threading,
 )
+from megatron.bridge.models.gemma.modules import extend_instance
 from megatron.bridge.models.gpt_provider import GPTModelProvider
+
+
+class _IdentityOutputLayer(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.config = config
+
+    def forward(self, hidden_states, *args, **kwargs):
+        return hidden_states, None
+
+
+class _ModelWithOutputLayer(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.output_layer = _IdentityOutputLayer(config)
+
+
+def _build_dense_model(provider, model):
+    provider._gemma4_dense_finalized = True
+    with (
+        patch("megatron.core.models.gpt.GPTModel", return_value=model),
+        patch("megatron.bridge.models.gemma.gemma4_provider.Gemma4DenseRotaryEmbedding"),
+        patch("megatron.bridge.models.gemma.gemma4_provider._attach_ple_modules"),
+        patch("megatron.bridge.models.gemma.gemma4_provider.wire_gemma4_kv_sharing"),
+        patch("megatron.bridge.models.gemma.gemma4_provider._install_ple_forward"),
+        patch("megatron.bridge.models.gemma.gemma4_provider._install_gemma4_dense_load_state_aliases"),
+    ):
+        return provider.build()
 
 
 class TestGemma4DenseProviderDefaults:
@@ -65,6 +95,7 @@ class TestGemma4DenseProviderDefaults:
             ("num_kv_shared_layers", 18),
             ("per_layer_embed_vocab_size", 262_144),
             ("per_layer_embed_dim", 256),
+            ("final_logit_softcapping", 30.0),
             ("num_moe_experts", None),
             ("moe_router_topk", None),
             ("moe_ffn_hidden_size", None),
@@ -95,6 +126,38 @@ class TestGemma4DenseProviderDefaults:
     def test_provide_rejects_virtual_pipeline_stage(self, provider):
         with pytest.raises(NotImplementedError, match="PP=1"):
             provider.provide(vp_stage=0)
+
+    def test_build_applies_final_logit_softcapping_once(self, provider):
+        """Dense output must match HF's single tanh softcap in the saturation regime."""
+        built = _build_dense_model(provider, _ModelWithOutputLayer(provider))
+
+        raw_logits = torch.tensor([[-120.0, -30.0, 0.0, 30.0, 120.0]])
+        logits, bias = built.output_layer(raw_logits)
+        expected_once = 30.0 * torch.tanh(raw_logits / 30.0)
+        expected_twice = 30.0 * torch.tanh(expected_once / 30.0)
+
+        assert isinstance(built.output_layer, Gemma4OutputLayer)
+        torch.testing.assert_close(logits, expected_once)
+        assert not torch.allclose(logits, expected_twice)
+        assert bias is None
+
+    def test_build_does_not_double_softcap_existing_output_layer(self, provider):
+        model = _ModelWithOutputLayer(provider)
+        extend_instance(model.output_layer, Gemma4OutputLayer)
+        built = _build_dense_model(provider, model)
+
+        raw_logits = torch.tensor([[-120.0, 120.0]])
+        logits, _ = built.output_layer(raw_logits)
+        torch.testing.assert_close(logits, 30.0 * torch.tanh(raw_logits / 30.0))
+
+    def test_build_leaves_output_uncapped_when_disabled(self, provider):
+        provider.final_logit_softcapping = None
+        built = _build_dense_model(provider, _ModelWithOutputLayer(provider))
+
+        raw_logits = torch.tensor([[-120.0, 120.0]])
+        logits, _ = built.output_layer(raw_logits)
+        assert not isinstance(built.output_layer, Gemma4OutputLayer)
+        torch.testing.assert_close(logits, raw_logits)
 
 
 class TestGemma4DenseLoadStateAliases:
@@ -342,6 +405,22 @@ class TestGemma4ModelProviderDefaults:
                 provider.provide(pre_process=True, post_process=True)
 
         assert provider.rotary_base == (10_000, 1_000_000)
+
+    def test_provide_does_not_double_softcap_existing_output_layer(self, provider):
+        model = _ModelWithOutputLayer(provider)
+        extend_instance(model.output_layer, Gemma4OutputLayer)
+        model.setup_embeddings_and_output_layer = Mock()
+
+        with (
+            patch.object(GPTModelProvider, "provide", return_value=model),
+            patch("megatron.bridge.models.gemma.gemma4_provider.Gemma4RotaryEmbedding"),
+            patch("megatron.bridge.models.gemma.gemma4_provider._install_tied_kv"),
+        ):
+            built = provider.provide(pre_process=True, post_process=True)
+
+        raw_logits = torch.tensor([[-120.0, 120.0]])
+        logits, _ = built.output_layer(raw_logits)
+        torch.testing.assert_close(logits, 30.0 * torch.tanh(raw_logits / 30.0))
 
 
 class TestInstallTiedKV:

--- a/tests/unit_tests/models/gemma_vl/test_gemma4_vl_bridge.py
+++ b/tests/unit_tests/models/gemma_vl/test_gemma4_vl_bridge.py
@@ -743,11 +743,23 @@ class TestGemma4VLBridgeProviderBridgeDense:
     def test_returns_dense_vl_provider(self, bridge, mock_hf_pretrained_dense):
         assert isinstance(bridge.provider_bridge(mock_hf_pretrained_dense), Gemma4DenseVLProvider)
 
+    def test_preserves_logit_softcapping(self, bridge, mock_hf_pretrained_dense):
+        assert bridge.provider_bridge(mock_hf_pretrained_dense).final_logit_softcapping == 30.0
+
     def test_text_mode_returns_text_provider(self, bridge, mock_hf_pretrained_dense, monkeypatch):
         monkeypatch.setenv("GEMMA4_CONVERSION_MODE", "text")
         p = bridge.provider_bridge(mock_hf_pretrained_dense)
         assert isinstance(p, Gemma4DenseProvider)
         assert not isinstance(p, Gemma4DenseVLProvider)
+
+
+@pytest.mark.parametrize("provider_cls", [Gemma4DenseVLProvider, Gemma4VLModelProvider])
+def test_megatron_to_hf_config_nests_final_logit_softcapping(provider_cls):
+    provider = provider_cls(final_logit_softcapping=17.0)
+    hf_config = Gemma4VLBridge.megatron_to_hf_config(provider)
+
+    assert "final_logit_softcapping" not in hf_config
+    assert hf_config["text_config"]["final_logit_softcapping"] == 17.0
 
 
 class TestGemma4VLBridgeMappingRegistry:


### PR DESCRIPTION
## What changed

Gemma 4 dense models now preserve Hugging Face's `final_logit_softcapping` value and apply exactly one final `scale * tanh(logits / scale)` operation after the LM head. The behavior is shared by the flat text and nested VL providers and exports, and installation is idempotent so an inherited/custom output layer cannot be capped twice.

This is the focused fix for the bug reported in #4610. The independently discovered E2B heterogeneous-FFN and 26B-A4B MoE conversion/runtime corrections are split into a separate follow-up PR.

Fixes #4610

## Root cause

PR #4148 added the existing `Gemma4OutputLayer` softcap only to the MoE provider. The dense provider dropped the config field and never installed that output behavior. Weight roundtrips could still be exact because softcapping is a config/runtime operation, and greedy IDs could still match because positive-scale `tanh` is monotonic and preserves argmax ordering.

## Validation

- `nvcr.io/nvidia/nemo:26.06`, Python 3.12, Transformers 5.8.1
- focused bridge/provider/VL unit tests: `213 passed`
- controlled logits drive values well beyond the cap and distinguish zero, one, and two applications
- disabled/missing caps, dense text/VL config propagation and export, and idempotent dense/MoE construction are covered
- `uv run pre-commit run --all-files`

Pinned official checkpoints used for the original reproduction and post-fix controlled parity:

- `google/gemma-4-E2B-it@70af34e20bd4b7a91f0de6b22675850c43922a03`
- `google/gemma-4-E4B-it@fee6332c1abaafb77f6f9624236c63aa2f1d0187`
- `google/gemma-4-26B-A4B-it@20da991ab4afab98e8f910c4a2e8f4fbefc404ad`
- `google/gemma-4-31B-it@3548789868c5356dbf307c98e6f609007b82b3eb`

For the 8x output-head saturation control, dense post-softcap HF-vs-MCore max/mean absolute errors changed from E2B `1114/624.874` to `0/0` (real head isolation), E4B `586/253.087` to `2.5625/0.000411`, and 31B `430/103.032` to `2.4375/0.006614`. E4B and 31B full-model greedy outputs remained exactly equal. The existing 26B-A4B MoE path still applies a single cap: its runtime is within max `0.122` of a single cap of its own raw logits and is clearly separated from a double cap.

The residual dense maxima are BF16 fused-GEMM accumulation differences: layerwise comparison localizes them before the output operation, exact-head isolation removes them, and an FP32 E4B control reduces final raw-logit max error to `1.221e-4`.
