### PR TITLE
fix(training): pass training_log optional args by keyword to avoid misbinding

### DIFF
--- a/src/megatron/bridge/training/train.py
+++ b/src/megatron/bridge/training/train.py
@@ -610,7 +610,8 @@ def train(
                 global_state,
                 history_wct,
                 model,
-                log_max_attention_logit,
+                pg_collection=pg_collection,
+                log_max_attention_logit=log_max_attention_logit,
                 loaded_iteration=start_iteration,
                 # training_log recomputes seqlen/FLOPS from the (log-step) accumulators
                 # itself; pass None so it uses that path (the per-step seqlen_sum is no

--- a/src/megatron/bridge/training/utils/train_utils.py
+++ b/src/megatron/bridge/training/utils/train_utils.py
@@ -673,6 +673,7 @@ def training_log(
     global_state: GlobalState,
     history_wct: list,
     model: list[MegatronModule],
+    *,
     pg_collection: Optional[Any] = None,
     log_max_attention_logit: Optional[float] = None,
     loaded_iteration: int = 0,

--- a/tests/unit_tests/training/utils/test_train_utils.py
+++ b/tests/unit_tests/training/utils/test_train_utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
 import math
 import random
 import time
@@ -418,6 +419,73 @@ class TestTrainingLog:
         # Verify tensorboard logging was called
         mock_global_state.tensorboard_logger.add_scalar.assert_called()
         mock_global_state.timers.write.assert_called()
+
+    @mock.patch("megatron.bridge.training.utils.train_utils.get_num_microbatches")
+    @mock.patch("megatron.bridge.training.utils.train_utils.reduce_max_stat_across_model_parallel_group")
+    @mock.patch("megatron.bridge.training.utils.train_utils.get_world_size_safe")
+    @mock.patch("megatron.bridge.training.utils.train_utils.print_rank_last")
+    @mock.patch("megatron.bridge.training.utils.train_utils.report_runtime")
+    @mock.patch("megatron.bridge.training.utils.train_utils.report_throughput")
+    @mock.patch("megatron.bridge.training.utils.train_utils.report_l2_norm_grad")
+    def test_max_attention_logit_logged(
+        self,
+        mock_report_l2_norm_grad,
+        mock_report_throughput,
+        mock_report_runtime,
+        mock_print_rank_last,
+        mock_get_world_size,
+        mock_reduce_lr,
+        mock_get_microbatches,
+        mock_config,
+        mock_global_state,
+        loss_dict,
+    ):
+        """max-attention-logit must reach the writers when a value is provided (qk_clip path)."""
+        total_loss_dict = self.get_fresh_total_loss_dict()
+
+        mock_report_l2_norm_grad.return_value = {}
+        mock_report_throughput.return_value = {}
+        mock_report_runtime.return_value = {}
+        mock_get_microbatches.return_value = 8
+        mock_reduce_lr.return_value = 1e-4
+        mock_get_world_size.return_value = 32
+
+        mock_global_state.train_state.step = 100
+        mock_config.logger.tensorboard_log_interval = 10
+
+        training_log(
+            loss_dict=loss_dict,
+            total_loss_dict=total_loss_dict,
+            learning_rate=1e-4,
+            decoupled_learning_rate=None,
+            loss_scale=1024.0,
+            report_memory_flag=False,
+            skipped_iter=0,
+            grad_norm=2.5,
+            params_norm=15.2,
+            num_zeros_in_grad=0,
+            config=mock_config,
+            global_state=mock_global_state,
+            history_wct=None,
+            model=None,
+            log_max_attention_logit=12.5,
+        )
+
+        mock_global_state.tensorboard_logger.add_scalar.assert_any_call("max-attention-logit", 12.5, 100)
+        wandb_metric_calls = [
+            call for call in mock_global_state.wandb_logger.log.call_args_list if "max-attention-logit" in call.args[0]
+        ]
+        assert wandb_metric_calls, "max-attention-logit was not logged to wandb"
+
+    def test_optional_params_are_keyword_only(self):
+        """Optional params must stay keyword-only so a positional call cannot bind to the wrong slot.
+
+        Regression guard: log_max_attention_logit used to be passed as the 15th positional
+        argument in train.py, silently binding to pg_collection instead.
+        """
+        sig = inspect.signature(training_log)
+        for name in ("pg_collection", "log_max_attention_logit", "loaded_iteration", "seq_length"):
+            assert sig.parameters[name].kind is inspect.Parameter.KEYWORD_ONLY
 
     @mock.patch("megatron.bridge.training.utils.train_utils.get_num_microbatches")
     @mock.patch("megatron.bridge.training.utils.train_utils.reduce_max_stat_across_model_parallel_group")


### PR DESCRIPTION
## What does this PR do?

`train.py` passed `log_max_attention_logit` as the 15th positional argument of `training_log`, but the 15th parameter of `training_log` is `pg_collection`. The value therefore bound to the wrong slot:

- With `qk_clip` enabled, `clip_qk()` returns a float, which landed in `pg_collection`. The `pg_collection or get_pg_collection(model)` guard keeps a truthy float, so the first logging step crashes with `AttributeError: 'float' object has no attribute 'mp'` at `reduce_max_stat_across_model_parallel_group(..., mp_group=pg_collection.mp)`.
- Without `qk_clip`, the misbinding is masked (`None or get_pg_collection(model)` recovers), but the real `log_max_attention_logit` parameter always stays `None`, so the `max-attention-logit` metric is silently never written to TensorBoard/W&B/MLflow.

The sibling caller in `train_megatron_mimo.py` already passes everything by keyword and is unaffected.

## Changes

- Pass `pg_collection` and `log_max_attention_logit` by keyword at the `train.py` call site. Passing the in-scope `pg_collection` also removes a per-iteration `get_pg_collection(model)` recomputation inside `training_log`.
- Make the optional parameters of `training_log` keyword-only (`*` separator) so any future positional call fails immediately with a `TypeError` instead of misbinding.
- Add unit tests: the `max-attention-logit` metric reaches the writers when a value is provided, and a signature guard asserting the optional parameters stay keyword-only.

## Before submitting

- [x] Did you read the contributor guideline?
- [x] Did you write any new necessary tests?
