### PR TITLE
fix(model): map router expert_bias in DeepSeek-family common mapping list

### DIFF
--- a/src/megatron/bridge/models/deepseek/common.py
+++ b/src/megatron/bridge/models/deepseek/common.py
@@ -44,6 +44,7 @@ def get_common_mapping_list(hf_config=None) -> list:
         "decoder.layers.*.mlp.linear_fc2.weight": "model.layers.*.mlp.down_proj.weight",
         # MoE
         "decoder.layers.*.mlp.router.weight": "model.layers.*.mlp.gate.weight",
+        "decoder.layers.*.mlp.router.expert_bias": "model.layers.*.mlp.gate.e_score_correction_bias",
         "decoder.layers.*.mlp.experts.linear_fc2.weight*": "model.layers.*.mlp.experts.*.down_proj.weight",
         "decoder.layers.*.mlp.experts.local_experts.*.linear_fc2.weight": "model.layers.*.mlp.experts.*.down_proj.weight",
         "decoder.layers.*.mlp.shared_experts.linear_fc2.weight": "model.layers.*.mlp.shared_experts.down_proj.weight",
@@ -125,10 +126,6 @@ def get_common_mapping_list(hf_config=None) -> list:
                         AutoMapping(
                             megatron_param=f"mtp.layers.{mtp_layer}.final_layernorm.weight",
                             hf_param=f"model.layers.{mtp_layer + num_transformer_layers}.shared_head.norm.weight",
-                        ),
-                        AutoMapping(
-                            megatron_param=f"mtp.layers.{mtp_layer}.mtp_model_layer.mlp.router.expert_bias",
-                            hf_param=f"model.layers.{mtp_layer + num_transformer_layers}.mlp.gate.e_score_correction_bias",
                         ),
                     ]
                 )

--- a/src/megatron/bridge/models/deepseek/deepseek_v3_bridge.py
+++ b/src/megatron/bridge/models/deepseek/deepseek_v3_bridge.py
@@ -22,7 +22,6 @@ from megatron.core.models.gpt.gpt_model import GPTModel
 from megatron.bridge.models.conversion import quantization_utils
 from megatron.bridge.models.conversion.mapping_registry import MegatronMappingRegistry
 from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge, WeightConversionTask
-from megatron.bridge.models.conversion.param_mapping import AutoMapping
 from megatron.bridge.models.conversion.transformers_compat import rope_theta_from_hf
 from megatron.bridge.models.deepseek.common import get_common_mapping_list
 from megatron.bridge.models.hf_pretrained.causal_lm import PreTrainedCausalLM
@@ -129,12 +128,6 @@ class DeepSeekV3Bridge(MegatronModelBridge):
 
     def mapping_registry(self) -> MegatronMappingRegistry:
         mapping_list = get_common_mapping_list(hf_config=self.hf_config)
-        mapping_list.append(
-            AutoMapping(
-                megatron_param="decoder.layers.*.mlp.router.expert_bias",
-                hf_param="model.layers.*.mlp.gate.e_score_correction_bias",
-            )
-        )
         return MegatronMappingRegistry(*mapping_list)
 
     def maybe_modify_loaded_hf_weight(

--- a/src/megatron/bridge/models/glm/glm47_flash_bridge.py
+++ b/src/megatron/bridge/models/glm/glm47_flash_bridge.py
@@ -32,7 +32,6 @@ from megatron.core.models.gpt.gpt_model import GPTModel
 
 from megatron.bridge.models.conversion.mapping_registry import MegatronMappingRegistry
 from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge
-from megatron.bridge.models.conversion.param_mapping import AutoMapping
 from megatron.bridge.models.deepseek.common import get_common_mapping_list
 from megatron.bridge.models.hf_pretrained.causal_lm import PreTrainedCausalLM
 from megatron.bridge.models.mla_provider import MLAModelProvider
@@ -111,10 +110,4 @@ class GLM47FlashBridge(MegatronModelBridge):
     def mapping_registry(self) -> MegatronMappingRegistry:
         hf_config = getattr(self, "hf_config", None)
         mapping_list = get_common_mapping_list(hf_config=hf_config)
-        mapping_list.append(
-            AutoMapping(
-                megatron_param="decoder.layers.*.mlp.router.expert_bias",
-                hf_param="model.layers.*.mlp.gate.e_score_correction_bias",
-            )
-        )
         return MegatronMappingRegistry(*mapping_list)

--- a/src/megatron/bridge/models/kimi_vl/kimi_k25_vl_bridge.py
+++ b/src/megatron/bridge/models/kimi_vl/kimi_k25_vl_bridge.py
@@ -235,12 +235,6 @@ class KimiK25VLBridge(MegatronModelBridge):
 
     def mapping_registry(self) -> MegatronMappingRegistry:
         mapping_list = get_common_mapping_list()
-        param_mappings = {
-            "decoder.layers.*.mlp.router.expert_bias": "model.layers.*.mlp.gate.e_score_correction_bias",
-        }
-
-        for megatron_param, hf_param in param_mappings.items():
-            mapping_list.append(AutoMapping(megatron_param=megatron_param, hf_param=hf_param))
 
         # In HF Kimi K2.5 VL models, the language component is nested under
         # "language_model.model" instead of just "model", so we need to add the prefix.

--- a/tests/unit_tests/models/deepseek/test_deepseek_bridges.py
+++ b/tests/unit_tests/models/deepseek/test_deepseek_bridges.py
@@ -16,13 +16,16 @@
 Unit tests for DeepSeek bridges.
 """
 
+from types import SimpleNamespace
 from unittest.mock import Mock
 
 import pytest
 import torch
 from transformers import GenerationConfig
 
+from megatron.bridge.models.conversion.mapping_registry import MegatronMappingRegistry
 from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge, WeightConversionTask
+from megatron.bridge.models.deepseek.common import get_common_mapping_list
 from megatron.bridge.models.deepseek.deepseek_v2_bridge import DeepSeekV2Bridge
 from megatron.bridge.models.deepseek.deepseek_v3_bridge import DeepSeekV3Bridge, _dequant_fp8_blockwise
 from megatron.bridge.models.hf_pretrained.causal_lm import PreTrainedCausalLM
@@ -471,3 +474,31 @@ class TestDeepSeekV3MaybeModifyLoadedHFWeight:
         assert torch.all(result["gate"] == 2.0)
         # Non-FP8 entries pass through unchanged.
         assert result["up"] is w2
+
+
+class TestCommonMappingExpertBias:
+    """Router expert_bias coverage in the shared DeepSeek-family mapping list (issue #4199)."""
+
+    def test_decoder_expert_bias_in_common_list(self):
+        """The common list must map router expert_bias for the main decoder layers."""
+        registry = MegatronMappingRegistry(*get_common_mapping_list())
+        mapping = registry.megatron_to_hf_lookup("decoder.layers.5.mlp.router.expert_bias")
+        assert mapping is not None
+        assert mapping.hf_param == "model.layers.5.mlp.gate.e_score_correction_bias"
+
+    def test_mtp_expert_bias_still_generated(self):
+        """The MTP loop must still emit the expert_bias mapping for MTP layers."""
+        hf_config = SimpleNamespace(num_nextn_predict_layers=1, num_hidden_layers=61)
+        registry = MegatronMappingRegistry(*get_common_mapping_list(hf_config=hf_config))
+        mapping = registry.megatron_to_hf_lookup("mtp.layers.0.mtp_model_layer.mlp.router.expert_bias")
+        assert mapping is not None
+        assert mapping.hf_param == "model.layers.61.mlp.gate.e_score_correction_bias"
+
+    def test_v3_bridge_resolves_expert_bias(self):
+        """DeepSeekV3Bridge must keep resolving expert_bias via the common list."""
+        bridge = DeepSeekV3Bridge()
+        bridge.hf_config = SimpleNamespace(num_nextn_predict_layers=0)
+        registry = bridge.mapping_registry()
+        mapping = registry.megatron_to_hf_lookup("decoder.layers.0.mlp.router.expert_bias")
+        assert mapping is not None
+        assert mapping.hf_param == "model.layers.0.mlp.gate.e_score_correction_bias"

--- a/tests/unit_tests/models/kimi/test_kimi_bridge.py
+++ b/tests/unit_tests/models/kimi/test_kimi_bridge.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from megatron.bridge.models.kimi.kimi_bridge import KimiK2Bridge
+
+
+@pytest.fixture
+def kimi_registry():
+    """Mapping registry of a bare Kimi K2 bridge."""
+    return KimiK2Bridge().mapping_registry()
+
+
+class TestKimiK2BridgeMappingRegistry:
+    """Mapping-registry checks for the Kimi K2 bridge."""
+
+    def test_expert_bias_mapping_present(self, kimi_registry):
+        """Kimi K2 enables moe_router_enable_expert_bias, so the router expert_bias
+        must map to the HF gate.e_score_correction_bias key.
+
+        Regression test for the mapping being absent from the DeepSeek common
+        mapping list (https://github.com/NVIDIA-NeMo/Megatron-Bridge/issues/4199):
+        without it, expert_bias stayed at its zero init after HF conversion and
+        top-k routing diverged from the HF checkpoint.
+        """
+        mapping = kimi_registry.megatron_to_hf_lookup("decoder.layers.3.mlp.router.expert_bias")
+        assert mapping is not None
+        assert mapping.hf_param == "model.layers.3.mlp.gate.e_score_correction_bias"
+
+    def test_expert_bias_reverse_lookup(self, kimi_registry):
+        """The HF-side key must resolve back to the Megatron router expert_bias."""
+        mapping = kimi_registry.hf_to_megatron_lookup("model.layers.7.mlp.gate.e_score_correction_bias")
+        assert mapping is not None
+        assert mapping.megatron_param == "decoder.layers.7.mlp.router.expert_bias"


### PR DESCRIPTION
## What does this PR do?

Fixes #4199

The DeepSeek-family shared mapping list (`get_common_mapping_list`) mapped `router.expert_bias <-> gate.e_score_correction_bias` only for MTP layers, not for the main decoder layers. Any bridge that consumes the common list and enables `moe_router_enable_expert_bias` therefore converted HF checkpoints with the router bias left at its zero init.

Kimi K2 was affected directly: `KimiK2Bridge` sets `moe_router_enable_expert_bias = True` but never appended the mapping itself, so after HF-to-Megatron conversion its noaux-tc top-k routing diverged from the HF checkpoint. DeepSeekV3, GLM-4.7-Flash, and Kimi K2.5 VL each carried a private copy of the same `AutoMapping` append to work around the gap.

## Changes

- Add `decoder.layers.*.mlp.router.expert_bias -> model.layers.*.mlp.gate.e_score_correction_bias` to the `param_mappings` dict in `models/deepseek/common.py`. The MTP generation loop derives the MTP variant from the same entry, so the previously hand-written MTP `AutoMapping` is removed (it generated an identical mapping).
- Drop the now-redundant per-bridge appends in `deepseek_v3_bridge.py`, `glm47_flash_bridge.py`, and `kimi_k25_vl_bridge.py`.
- Families without the bias (for example DeepSeek-V2) simply never match the wildcard, the same established pattern as the coexisting MLA and non-MLA query mappings in the same dict.

## Tests

- New: common-list lookup resolves decoder `expert_bias` in both directions for Kimi K2, and the MTP variant is still generated.
- Existing assertions in `test_glm47_flash_bridge.py` and `test_kimi_k25_vl_bridge.py` keep passing since the common list now supplies identical wildcard entries.

## Before submitting

- [x] Did you read the contributor guideline?
- [x] Did you write any new necessary tests?
