### PR TITLE
fix(ckpt): remove all non-persistent checkpoints when most_recent_k is 0

### DIFF
--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -1574,9 +1574,16 @@ def cleanup_old_non_persistent_checkpoint(
     sorted_iter_ckpts = sorted(iter_ckpts, key=lambda ckpt_name: int(ckpt_name.name[len(iter_prefix) :]))
     if not sorted_iter_ckpts:
         return
-    rm_iter_ckpts = sorted_iter_ckpts[:-leave_ckpt_num]
+    # `leave_ckpt_num == 0` means keep none: slice with `[:-0]` would be `[:0]` (empty),
+    # so nothing would be removed. Guard it explicitly to remove all instead.
+    if leave_ckpt_num > 0:
+        rm_iter_ckpts = sorted_iter_ckpts[:-leave_ckpt_num]
+        keep_iter_ckpts = sorted_iter_ckpts[-leave_ckpt_num:]
+    else:
+        rm_iter_ckpts = sorted_iter_ckpts
+        keep_iter_ckpts = []
     print_rank_0(f"Non-persistent checkpoints scheduled for removal: {rm_iter_ckpts}")
-    print_rank_0(f"Non-persistent checkpoints to be kept: {sorted_iter_ckpts[-leave_ckpt_num:]}")
+    print_rank_0(f"Non-persistent checkpoints to be kept: {keep_iter_ckpts}")
 
     def remove_iter_ckpts(_iter_ckpts):
         for ckpt in _iter_ckpts:

--- a/tests/unit_tests/training/test_checkpointing.py
+++ b/tests/unit_tests/training/test_checkpointing.py
@@ -1556,6 +1556,24 @@ class TestCleanupNonPersistentCheckpoints:
 
     @patch("torch.distributed.is_initialized")
     @patch("torch.distributed.get_rank")
+    @patch("shutil.rmtree")
+    def test_cleanup_old_non_persistent_checkpoint_leave_zero(self, mock_rmtree, mock_get_rank, mock_dist_init):
+        """leave_ckpt_num=0 should remove all checkpoints, not keep them (guards the [:-0] pitfall)."""
+        mock_dist_init.return_value = True
+        mock_get_rank.return_value = 0
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            save_dir = Path(temp_dir)
+            for name in ("iter_0001000", "iter_0002000", "iter_0003000"):
+                (save_dir / name).mkdir()
+
+            cleanup_old_non_persistent_checkpoint(str(save_dir), leave_ckpt_num=0, do_async=False)
+
+            # All three checkpoints must be scheduled for removal.
+            assert mock_rmtree.call_count == 3
+
+    @patch("torch.distributed.is_initialized")
+    @patch("torch.distributed.get_rank")
     def test_cleanup_old_non_persistent_checkpoint_retain_interval(self, mock_get_rank, mock_dist_init):
         """Test cleanup of old checkpoints."""
         mock_dist_init.return_value = True


### PR DESCRIPTION
## What

`cleanup_old_non_persistent_checkpoint` computes the checkpoints to delete with:

```python
rm_iter_ckpts = sorted_iter_ckpts[:-leave_ckpt_num]
```

The caller passes `leave_ckpt_num=ckpt_cfg.most_recent_k` and only guards `most_recent_k > -1`, so `0` is an accepted value meaning "keep zero most-recent checkpoints" (delete all). But with `leave_ckpt_num == 0`, Python evaluates `sorted_iter_ckpts[:-0]` as `sorted_iter_ckpts[:0]`, i.e. an empty list, so **nothing is ever removed** and non-persistent checkpoints accumulate unboundedly, the exact opposite of the intended behavior. The "to be kept" log line has the same `[-0:]` (whole list) pitfall.

## Fix

Guard the zero case explicitly: when `leave_ckpt_num <= 0`, schedule all checkpoints for removal and keep none.

## Test

Added `test_cleanup_old_non_persistent_checkpoint_leave_zero` asserting all checkpoints are removed when `leave_ckpt_num=0`.

## Notes

Local unit-test execution isn't possible on this machine (megatron.core / CUDA deps); ruff check and format pass. Happy to trigger CI on request.