### PR TITLE
fix(data): return None for Energon test split instead of aliasing validation

### DIFF
--- a/src/megatron/bridge/data/energon/energon_provider.py
+++ b/src/megatron/bridge/data/energon/energon_provider.py
@@ -69,8 +69,12 @@ class EnergonProvider(DatasetProvider):
             num_workers=self.num_workers,
             pg_collection=context.pg_collection,
         )
+        # EnergonMultiModalDataModule.test_dataloader() returns None (no distinct test split);
+        # honor that instead of aliasing the validation loader as a fake test set, which would
+        # otherwise report validation metrics as test metrics whenever eval_iters > 0.
+        test_dataloader = dataset.test_dataloader()
         return (
             iter(dataset.train_dataloader()),
             iter(dataset.val_dataloader()),
-            iter(dataset.val_dataloader()),
+            iter(test_dataloader) if test_dataloader is not None else None,
         )

--- a/tests/unit_tests/data/energon/test_energon_prodvider.py
+++ b/tests/unit_tests/data/energon/test_energon_prodvider.py
@@ -31,6 +31,8 @@ def _mock_datamodule(mock_datamodule_cls):
     mock_datamodule_cls.return_value = inst
     inst.train_dataloader.return_value = iter([])
     inst.val_dataloader.side_effect = lambda: iter([])
+    # Matches EnergonMultiModalDataModule: no distinct test split.
+    inst.test_dataloader.return_value = None
     return inst
 
 
@@ -65,6 +67,8 @@ class TestEnergonProvider:
         # So `val_dataloader()` is called twice.
         # We should make sure it returns a new iterable/iterator each time.
         mock_dataset_instance.val_dataloader.side_effect = lambda: iter([3, 4])
+        # No distinct test split: the datamodule returns None from test_dataloader().
+        mock_dataset_instance.test_dataloader.return_value = None
 
         mock_dataset_instance.seq_length = 2048
 
@@ -104,12 +108,14 @@ class TestEnergonProvider:
 
         # Check dataloader calls
         mock_dataset_instance.train_dataloader.assert_called_once()
-        assert mock_dataset_instance.val_dataloader.call_count == 2
+        mock_dataset_instance.val_dataloader.assert_called_once()
+        mock_dataset_instance.test_dataloader.assert_called_once()
 
         # Verify returned iterators
         assert list(train_iter) == [1, 2]
         assert list(val_iter) == [3, 4]
-        assert list(test_iter) == [3, 4]
+        # No test split -> None, so do_test stays False downstream (val is not reused as test).
+        assert test_iter is None
 
     # build_datasets() re-applies provider fields onto the eagerly-built task encoder so a
     # dataset.seq_length=... override reaches it before data loading.


### PR DESCRIPTION
## What

`EnergonProvider.build_datasets` returned the validation dataloader for **both** the validation and test slots:

```python
return (
    iter(dataset.train_dataloader()),
    iter(dataset.val_dataloader()),
    iter(dataset.val_dataloader()),   # <- test slot reuses validation
)
```

But `EnergonMultiModalDataModule.test_dataloader()` intentionally returns `None` and logs `"Multimodal dataloader test dataset split does not exist"` — there is no distinct test split.

Because a non-None test dataloader was returned, downstream:

```python
do_test = test_dataloader is not None and cfg.validation.eval_iters > 0
```

evaluates to `True`, so end-of-training test evaluation runs on the validation set and **reports validation metrics as test metrics**, hiding whether the model generalizes to a genuinely held-out split.

## Fix

Return `iter(dataset.test_dataloader())` if present, else `None` — honoring the datamodule's own contract. With `None`, `do_test` stays `False` and test evaluation is correctly skipped (the consumer in `data/loaders.py` already handles a `None` test dataloader).

## Test

Updated `test_init_and_build_datasets` to assert the test iterator is `None` and `test_dataloader()` is consulted; updated the shared mock helper to mirror the real datamodule (test split returns `None`).

## Notes

Local unit-test execution isn't possible on this machine (megatron.core / CUDA deps); ruff check and format pass.