### PR TITLE
fix(model): use tanh-approximate GELU for Gemma-1 bridge

### DIFF
--- a/src/megatron/bridge/models/gemma/gemma_bridge.py
+++ b/src/megatron/bridge/models/gemma/gemma_bridge.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from megatron.core.activations import fast_gelu
 from megatron.core.models.gpt.gpt_model import GPTModel
 from megatron.core.transformer.enums import AttnBackend
 from transformers import GemmaForCausalLM
@@ -61,7 +62,11 @@ class GemmaBridge(MegatronModelBridge):
         provider = super().provider_bridge(hf_pretrained)
 
         provider.normalization = "RMSNorm"
-        provider.activation_func = self.hf_to_megatron_activation("gelu")
+        # Gemma uses tanh-approximate GELU (HF `gelu_pytorch_tanh`). The gemma-1 HF config
+        # carries the legacy `hidden_act="gelu"` field, but the model runs the tanh approximation
+        # (matching GemmaModelProvider's fast_gelu default and Gemma2Bridge). Mapping the literal
+        # "gelu" to exact GELU here would silently use the wrong activation.
+        provider.activation_func = fast_gelu
         provider.gated_linear_unit = True
         provider.add_bias_linear = False
         provider.attention_dropout = 0.0

--- a/tests/unit_tests/models/gemma/test_gemma_bridge.py
+++ b/tests/unit_tests/models/gemma/test_gemma_bridge.py
@@ -18,6 +18,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 import torch
+from megatron.core.activations import fast_gelu
 from transformers import GemmaConfig, GemmaForCausalLM, GenerationConfig
 
 from megatron.bridge.models import AutoBridge
@@ -156,6 +157,8 @@ class TestMegatronGemmaBridge:
         assert result.num_attention_heads == gemma_2b_config.num_attention_heads
         assert result.seq_length == gemma_2b_config.max_position_embeddings
         assert result.rotary_base == gemma_2b_config.rope_parameters["rope_theta"]
+        # Gemma runs tanh-approximate GELU (fast_gelu), despite the legacy hidden_act="gelu".
+        assert result.activation_func is fast_gelu
 
     def test_provider_bridge_basic_7b(self, mock_pretrained_gemma_7b, gemma_7b_config):
         """Test basic provider_bridge functionality for Gemma 7B."""


### PR DESCRIPTION
## What

`GemmaBridge.provider_bridge` set the activation function to exact GELU:

```python
provider.activation_func = self.hf_to_megatron_activation("gelu")  # -> F.gelu (exact)
```

But Gemma runs **tanh-approximate** GELU (HF `gelu_pytorch_tanh`). The gemma-1 HF config carries the legacy `hidden_act="gelu"` field, yet:

- `GemmaModelProvider` **defaults** to `fast_gelu` (tanh approximation)
- `Gemma2Bridge` hardcodes `fast_gelu` for exactly this reason
- `Gemma3`/`Gemma4` providers all default to `fast_gelu`

Only the gemma-1 bridge overrode the provider default back to exact GELU. Running exact GELU on weights trained with the tanh approximation produces slightly wrong activations and logits.

## Fix

Map the gemma-1 activation to `fast_gelu`, matching `Gemma2Bridge`, the provider default, and the actual model semantics.

## Test

Extended `test_provider_bridge_basic_2b` to assert the bridged provider's `activation_func is fast_gelu`.

## Notes

Local unit-test execution isn't possible on this machine (megatron.core / CUDA deps); ruff check and format pass.