### PR TITLE
fix(inference): reject pipeline parallelism in QwenVLInferenceWrapper

### DIFF
--- a/src/megatron/bridge/inference/vlm/qwenvl_inference_wrapper.py
+++ b/src/megatron/bridge/inference/vlm/qwenvl_inference_wrapper.py
@@ -40,6 +40,32 @@ class QwenVLInferenceWrapper(AbstractModelInferenceWrapper):
     def __init__(self, model, inference_context=None):
         super().__init__(model, inference_context=inference_context)
 
+    def run_one_forward_step(self, inference_input: Dict[str, Any], recv_buffer_seq_len: Optional[int] = None):
+        """Run a single forward pass, rejecting pipeline parallelism.
+
+        This wrapper only implements the tensor-parallel / no-pipeline path
+        (``forward_pass_without_pipeline_parallel``), whose inputs are keyed on
+        ``input_ids`` and include the multimodal tensors (``pixel_values`` /
+        ``image_grid_thw``). The base-class pipeline path instead reads
+        ``inference_input["tokens"]`` and drops those multimodal inputs, so it cannot
+        run this VLM. Fail fast with a clear error instead of raising a cryptic
+        ``KeyError: 'tokens'`` deep inside the pipeline path.
+
+        Args:
+            inference_input: The prepared model inputs for the current context window.
+            recv_buffer_seq_len: Optional pipeline recv-buffer sequence length (unused here).
+
+        Returns:
+            The output logits from the tensor-parallel forward pass.
+        """
+        if getattr(self.config, "pipeline_model_parallel_size", 1) > 1:
+            raise NotImplementedError(
+                "QwenVLInferenceWrapper does not support pipeline parallelism "
+                "(pipeline_model_parallel_size > 1); run VLM inference with "
+                "pipeline_model_parallel_size=1."
+            )
+        return super().run_one_forward_step(inference_input, recv_buffer_seq_len)
+
     def prep_inference_input(
         self,
         prompts_tokens: torch.Tensor,

--- a/tests/unit_tests/inference/vlm/test_qwenvl_inference_wrapper.py
+++ b/tests/unit_tests/inference/vlm/test_qwenvl_inference_wrapper.py
@@ -128,3 +128,28 @@ class TestQwenVLInferenceWrapper:
             runtime_gather_output=True,
         )
         assert result.equal(torch.tensor([[[0.1, 0.9]]]))
+
+    def test_run_one_forward_step_rejects_pipeline_parallel(self, wrapper):
+        # The base pipeline path reads inference_input["tokens"] (absent here, only
+        # "input_ids" is provided) and drops the multimodal inputs, so PP must be rejected
+        # with a clear error rather than a cryptic KeyError.
+        wrapper.config = MagicMock()
+        wrapper.config.pipeline_model_parallel_size = 2
+
+        with pytest.raises(NotImplementedError, match="pipeline parallelism"):
+            wrapper.run_one_forward_step({"input_ids": torch.tensor([[1, 2, 3]])})
+
+    def test_run_one_forward_step_delegates_without_pipeline_parallel(self, wrapper):
+        wrapper.config = MagicMock()
+        wrapper.config.pipeline_model_parallel_size = 1
+        inference_input = {"input_ids": torch.tensor([[1, 2, 3]])}
+
+        with patch(
+            "megatron.core.inference.model_inference_wrappers.abstract_model_inference_wrapper."
+            "AbstractModelInferenceWrapper.run_one_forward_step",
+            return_value="logits",
+        ) as mock_super:
+            result = wrapper.run_one_forward_step(inference_input)
+
+        mock_super.assert_called_once_with(inference_input, None)
+        assert result == "logits"


### PR DESCRIPTION
## What

`setup_model_and_tokenizer` for VLM inference accepts a `pp` (pipeline) argument, but `QwenVLInferenceWrapper` only implements the tensor-parallel / no-pipeline forward path (`forward_pass_without_pipeline_parallel`), whose inputs are keyed on `"input_ids"` and carry the multimodal tensors (`pixel_values` / `image_grid_thw`).

When `pipeline_model_parallel_size > 1`, the base `run_one_forward_step` takes the pipeline branch:

```python
# AbstractModelInferenceWrapper.run_one_forward_step (PP branch)
tokens = inference_input["tokens"]   # <- this wrapper only provides "input_ids"
```

so decoding dies with a cryptic `KeyError: 'tokens'`. That path also reads only `tokens`/`position_ids`/`attention_mask` and calls the model positionally, dropping the multimodal inputs entirely — so it cannot run the VLM correctly even if the key existed.

## Fix

Override `run_one_forward_step` to fail fast with a clear `NotImplementedError` when `pipeline_model_parallel_size > 1`, and delegate to the base implementation otherwise. This turns a confusing mid-generation `KeyError` into an explicit, actionable message. (Full PP support for the VLM path would additionally require threading the multimodal inputs through the pipeline forward, which is out of scope here.)

## Test

Added:
- `test_run_one_forward_step_rejects_pipeline_parallel` — asserts `NotImplementedError` when `pipeline_model_parallel_size = 2`.
- `test_run_one_forward_step_delegates_without_pipeline_parallel` — asserts delegation to the base method when `= 1`.

## Notes

Local unit-test execution isn't possible on this machine (megatron.core / CUDA deps); ruff check and format pass.