### PR TITLE
[training] fix: require checkpoint source for finetuning

### DIFF
--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -1078,6 +1078,7 @@ class ConfigContainer(Container):
     mixed_precision: Optional[Union[MixedPrecisionConfig, str]] = None
     tensor_inspect: TensorInspectConfig | None = None
     inprocess_restart: Optional[InProcessRestartConfig] = None
+    _checkpoint_load_required: bool = field(default=False, init=False, repr=False)
 
     def get_data_parallel_size(self, world_size: int) -> int:
         """Calculate the data parallel size based on the model configuration."""

--- a/src/megatron/bridge/training/finetune.py
+++ b/src/megatron/bridge/training/finetune.py
@@ -50,4 +50,5 @@ def finetune(
     assert config.checkpoint.pretrained_checkpoint is not None or config.checkpoint.load is not None, (
         "Finetuning requires a loading from a pretrained checkpoint or resuming from a checkpoint"
     )
+    config._checkpoint_load_required = True
     return pretrain(config, forward_step_func, callbacks=callbacks)

--- a/src/megatron/bridge/training/setup.py
+++ b/src/megatron/bridge/training/setup.py
@@ -100,6 +100,36 @@ def _bind_dataset_provider_context(
     return provider
 
 
+def _should_load_checkpoint(cfg: ConfigContainer, checkpoint_manager: CheckpointManager) -> bool:
+    """Return whether setup has a checkpoint source to load."""
+    checkpointing_context = getattr(checkpoint_manager, "checkpointing_context", {})
+    has_local_checkpoint = (
+        "local_checkpoint_manager" in checkpointing_context
+        and checkpointing_context["local_checkpoint_manager"].find_latest() != -1
+    )
+
+    if cfg.peft is not None:
+        return cfg.checkpoint.load is not None and (
+            checkpoint_exists(cfg.checkpoint.load) or is_hf_checkpoint_dir(cfg.checkpoint.load)
+        )
+
+    load_checkpoint_exists = cfg.checkpoint.load is not None and (
+        checkpoint_exists(cfg.checkpoint.load) or is_hf_checkpoint_dir(cfg.checkpoint.load)
+    )
+    has_pretrained_checkpoint = cfg.checkpoint.pretrained_checkpoint is not None and (
+        checkpoint_exists(cfg.checkpoint.pretrained_checkpoint)
+        or is_hf_checkpoint_dir(cfg.checkpoint.pretrained_checkpoint)
+    )
+    should_load_checkpoint = load_checkpoint_exists or has_pretrained_checkpoint or has_local_checkpoint
+
+    if cfg._checkpoint_load_required and not should_load_checkpoint:
+        raise FileNotFoundError(
+            "Finetuning requires loading from an available pretrained checkpoint or resuming from a checkpoint"
+        )
+
+    return should_load_checkpoint
+
+
 def setup(
     state: GlobalState,
     train_valid_test_datasets_provider: Callable[..., tuple[Optional[Any], Optional[Any], Optional[Any]]],
@@ -291,39 +321,13 @@ def setup(
     timers("model-and-optimizer-setup").stop()
     barrier_and_log("after model, optimizer, and learning rate scheduler are built")
 
-    # Check if a local (non-persistent) checkpoint is available.  Local
-    # checkpoints are independent of global ones — they don't write
-    # latest_train_state.pt to load_dir, so checkpoint_exists() won't
-    # find them.
-    _ckpt_ctx = getattr(checkpoint_manager, "checkpointing_context", {})
-    has_local_checkpoint = (
-        "local_checkpoint_manager" in _ckpt_ctx and _ckpt_ctx["local_checkpoint_manager"].find_latest() != -1
-    )
-
     # For PEFT, the pretrained checkpoint is loaded in the pre-wrap hook
+    should_load_checkpoint = _should_load_checkpoint(cfg, checkpoint_manager)
     if cfg.peft is not None:
-        # HF full-model directories enter the load flow only to produce the
-        # targeted checkpoint.load error in checkpointing.
-        should_load_checkpoint = cfg.checkpoint.load is not None and (
-            checkpoint_exists(cfg.checkpoint.load) or is_hf_checkpoint_dir(cfg.checkpoint.load)
-        )
         if should_load_checkpoint:
             # The finetune toggle is explicitly set to True in order to avoid loading optimizer and RNG states
             # This is switched off here in order to load these states from the checkpoint
             cfg.checkpoint.finetune = False
-    else:
-        # ``checkpoint.load`` resumes from native Megatron checkpoints. ``pretrained_checkpoint``
-        # may also point at a HuggingFace full-model directory for initialization.
-        # HF directories are included in load detection only to route to the
-        # targeted checkpoint.load error in checkpointing.
-        load_checkpoint_exists = cfg.checkpoint.load is not None and (
-            checkpoint_exists(cfg.checkpoint.load) or is_hf_checkpoint_dir(cfg.checkpoint.load)
-        )
-        has_pretrained_checkpoint = cfg.checkpoint.pretrained_checkpoint is not None and (
-            checkpoint_exists(cfg.checkpoint.pretrained_checkpoint)
-            or is_hf_checkpoint_dir(cfg.checkpoint.pretrained_checkpoint)
-        )
-        should_load_checkpoint = load_checkpoint_exists or has_pretrained_checkpoint or has_local_checkpoint
 
     if should_load_checkpoint:
         timers("load-checkpoint", log_level=0).start(barrier=True)

--- a/tests/unit_tests/training/test_finetune.py
+++ b/tests/unit_tests/training/test_finetune.py
@@ -111,3 +111,27 @@ class TestFinetune:
                 mock_pretrain.assert_called_once_with(container, mock_forward_step_func, callbacks=None)
             finally:
                 restore_get_world_size_safe(og_ws, cfg_mod)
+
+    def test_finetune_requires_checkpoint_during_setup(self, tmp_path):
+        """Test that finetune marks its configured checkpoint as required."""
+        gpt_model_cfg = create_test_gpt_config()
+        checkpoint_cfg = create_test_checkpoint_config(
+            pretrained_checkpoint=None,
+            load=str(tmp_path / "missing-checkpoint"),
+        )
+
+        container, og_ws, cfg_mod = create_test_config_container(
+            world_size_override=1,
+            model_config=gpt_model_cfg,
+            checkpoint_config=checkpoint_cfg,
+        )
+        mock_forward_step_func = Mock()
+
+        with patch("megatron.bridge.training.finetune.pretrain") as mock_pretrain:
+            try:
+                assert container._checkpoint_load_required is False
+                finetune(container, mock_forward_step_func)
+                assert container._checkpoint_load_required is True
+                mock_pretrain.assert_called_once_with(container, mock_forward_step_func, callbacks=None)
+            finally:
+                restore_get_world_size_safe(og_ws, cfg_mod)

--- a/tests/unit_tests/training/test_setup.py
+++ b/tests/unit_tests/training/test_setup.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -23,6 +24,7 @@ from megatron.bridge.models.transformer_config import TransformerConfig
 from megatron.bridge.training.setup import (
     _build_distributed_model,
     _register_pre_wrap_hook,
+    _should_load_checkpoint,
     _validate_and_set_vocab_size,
     maybe_log_and_save_config,
 )
@@ -39,6 +41,56 @@ def _make_gpt_model_config(**kwargs):
     defaults = dict(transformer=_make_transformer(**tc_kwargs), vocab_size=32000)
     defaults.update(kwargs)
     return GPTModelConfig(**defaults)
+
+
+def _make_checkpoint_source_config(*, load, pretrained_checkpoint=None, required=True):
+    return SimpleNamespace(
+        checkpoint=SimpleNamespace(load=load, pretrained_checkpoint=pretrained_checkpoint),
+        peft=None,
+        _checkpoint_load_required=required,
+    )
+
+
+class TestShouldLoadCheckpoint:
+    """Tests for checkpoint source detection at setup time."""
+
+    @patch("megatron.bridge.training.setup.is_hf_checkpoint_dir", return_value=False)
+    @patch("megatron.bridge.training.setup.checkpoint_exists", return_value=False)
+    def test_required_checkpoint_must_exist(self, _mock_exists, _mock_is_hf):
+        cfg = _make_checkpoint_source_config(load="/missing/checkpoint")
+        checkpoint_manager = SimpleNamespace(checkpointing_context={})
+
+        with pytest.raises(FileNotFoundError, match="Finetuning requires loading from an available"):
+            _should_load_checkpoint(cfg, checkpoint_manager)
+
+    @patch("megatron.bridge.training.setup.is_hf_checkpoint_dir", return_value=False)
+    @patch("megatron.bridge.training.setup.checkpoint_exists", return_value=False)
+    def test_local_checkpoint_satisfies_required_source(self, _mock_exists, _mock_is_hf):
+        cfg = _make_checkpoint_source_config(load="/missing/global/checkpoint")
+        local_manager = Mock()
+        local_manager.find_latest.return_value = 12
+        checkpoint_manager = SimpleNamespace(checkpointing_context={"local_checkpoint_manager": local_manager})
+
+        assert _should_load_checkpoint(cfg, checkpoint_manager) is True
+
+    @patch("megatron.bridge.training.setup.checkpoint_exists", return_value=False)
+    def test_hf_load_reaches_checkpoint_loader_for_targeted_error(self, _mock_exists):
+        cfg = _make_checkpoint_source_config(load="/hf/full-model")
+        checkpoint_manager = SimpleNamespace(checkpointing_context={})
+
+        with patch(
+            "megatron.bridge.training.setup.is_hf_checkpoint_dir",
+            side_effect=lambda path: path == "/hf/full-model",
+        ):
+            assert _should_load_checkpoint(cfg, checkpoint_manager) is True
+
+    @patch("megatron.bridge.training.setup.is_hf_checkpoint_dir", return_value=False)
+    @patch("megatron.bridge.training.setup.checkpoint_exists", return_value=False)
+    def test_missing_checkpoint_remains_optional_for_pretraining(self, _mock_exists, _mock_is_hf):
+        cfg = _make_checkpoint_source_config(load="/missing/checkpoint", required=False)
+        checkpoint_manager = SimpleNamespace(checkpointing_context={})
+
+        assert _should_load_checkpoint(cfg, checkpoint_manager) is False
 
 
 class TestValidateAndSetVocabSize:


### PR DESCRIPTION
## Problem

The exported full-SFT recipes initialize model providers with `load_weights=False`, default `checkpoint.pretrained_checkpoint` to `None`, and point `checkpoint.load` at the output directory for auto-resume. On a fresh output directory, `finetune()` accepted the non-null path, while setup found no persistent, pretrained, or local checkpoint and continued with random model weights.

Supported trigger:

`run_recipe.py --recipe llama32_1b_sft_config --dataset llm-finetune` with the default fresh checkpoint output and no `checkpoint.pretrained_checkpoint`.

Impact: full SFT can silently train from random initialization instead of a base model.

## Root cause and fix

The entry check validated only that a path string was configured, before setup had enough information to distinguish available persistent, pretrained, Hugging Face, and non-persistent local sources.

`finetune()` now marks checkpoint loading as required through a private runtime-only config field. Setup enforces that requirement after checkpoint-manager creation, using the complete source predicate. This preserves local-only resume, PEFT base loading, Hugging Face initialization, the targeted error for Hugging Face directories supplied via `checkpoint.load`, and intentional random initialization through `pretrain()`.

## Verification

Fail-before deterministic CPU reproducer:

```bash
uv run --no-sync python reproduce_required_checkpoint_at_setup.py
```

On `a136b9027b68cd5f9ae7e38127eb98980e94e79e`: exit 1 with `BUG: missing SFT checkpoint reached setup without being required`.

The unchanged reproducer after the fix: exit 0; setup rejects the missing required source with `FileNotFoundError`.

Focused and adjacent tests:

```bash
uv run --no-sync python -m pytest \
  tests/unit_tests/training/test_finetune.py \
  tests/unit_tests/training/test_setup.py::TestShouldLoadCheckpoint \
  tests/unit_tests/training/test_checkpointing.py::TestLoadCheckpoint::test_load_checkpoint_rejects_hf_directory_for_resume_load \
  tests/unit_tests/training/utils/test_checkpoint_utils.py::TestCheckpointUtils::test_checkpoint_exists_with_valid_path \
  tests/unit_tests/training/utils/test_checkpoint_utils.py::TestCheckpointUtils::test_checkpoint_exists_with_missing_tracker_file \
  tests/unit_tests/training/utils/test_checkpoint_utils.py::TestCheckpointUtils::test_checkpoint_exists_with_missing_directory \
  tests/unit_tests/training/utils/test_checkpoint_utils.py::TestCheckpointUtils::test_checkpoint_exists_with_none_path \
  tests/unit_tests/training/utils/test_checkpoint_utils.py::TestCheckpointUtils::test_checkpoint_exists_with_iteration_directory \
  tests/unit_tests/training/utils/test_checkpoint_utils.py::TestCheckpointUtils::test_checkpoint_exists_prefers_iteration_dir_over_tracker -q
```

Result: 15 passed.

```bash
git diff --check
uv run --with pre-commit --no-sync pre-commit run --all-files
```

Result: passed; all hooks passed.

## Scope

This validates the CPU checkpoint-source decision and does not claim GPU, distributed, convergence, performance, or full-suite coverage. The test environment bypassed package-wide optional model registration only; the actual finetune, config, setup, checkpoint utilities, and pinned MCore code were exercised.