### PR TITLE
fix(perf): let nsys_extra_args override launcher defaults instead of …

### DIFF
--- a/scripts/performance/perf_plugins.py
+++ b/scripts/performance/perf_plugins.py
@@ -70,6 +70,43 @@ def _ensure_sqlite_nsys_export(nsys_extra_args: list[str]) -> list[str]:
     return nsys_extra_args + [NSYS_SQLITE_EXPORT_ARG]
 
 
+def _nsys_arg_name(arg: str) -> Optional[str]:
+    """Return the option name for a flag-like token (e.g. '--cuda-graph-trace'), else None."""
+    if not arg.startswith("-"):
+        return None
+    return arg.split("=", 1)[0]
+
+
+def _merge_nsys_extra_args(user_args: list[str], default_args: list[str]) -> list[str]:
+    """Merge user-provided nsys args over defaults, deduplicating by option name.
+
+    nemo_run seeds ``launcher.nsys_extra_args`` with defaults such as
+    ``--cuda-graph-trace=node``. Naively concatenating user args with these defaults
+    emits the same option twice (e.g. both ``--cuda-graph-trace=node`` and
+    ``--cuda-graph-trace=graph``), which nsys rejects. Here, any default whose option
+    name is also supplied by the user is dropped so the user value wins.
+
+    Both ``--flag=value`` and space-separated ``--flag value`` forms are handled.
+    """
+    user_names = {name for name in (_nsys_arg_name(arg) for arg in user_args) if name is not None}
+
+    retained_defaults: list[str] = []
+    skip_next = False
+    for index, arg in enumerate(default_args):
+        if skip_next:
+            skip_next = False
+            continue
+        name = _nsys_arg_name(arg)
+        if name is not None and name in user_names:
+            # Drop this default; also drop its space-separated value, if any.
+            if "=" not in arg and index + 1 < len(default_args) and not default_args[index + 1].startswith("-"):
+                skip_next = True
+            continue
+        retained_defaults.append(arg)
+
+    return user_args + retained_defaults
+
+
 @dataclass
 class NsysPluginScriptArgs:
     """Arguments for NsysPlugin to pass to run.Script."""
@@ -143,8 +180,9 @@ class NsysPlugin(Plugin):
         if self.nsys_extra_args is not None:
             # Get existing launcher extra args (nemo_run defaults)
             existing_extra_args = launcher.nsys_extra_args or []
-            # Combine user args with existing args (user args first for precedence)
-            launcher.nsys_extra_args = self.nsys_extra_args + existing_extra_args
+            # Merge, letting user args override any default sharing the same option
+            # name (e.g. --cuda-graph-trace) instead of emitting a duplicate flag.
+            launcher.nsys_extra_args = _merge_nsys_extra_args(self.nsys_extra_args, existing_extra_args)
             logger.info(f"Combined nsys_extra_args: {launcher.nsys_extra_args}")
 
         if self.export_sqlite:


### PR DESCRIPTION
# What does this PR do ?
Fixes `NsysPlugin` so user-supplied `--nsys_extra_args` override nemo_run launcher defaults instead of being concatenated with them, which caused nsys to fail when the same option appeared twice (e.g. `--cuda-graph-trace=node` and `--cuda-graph-trace=graph`).

# Changelog
- Add `_nsys_arg_name()` and `_merge_nsys_extra_args()` helpers in `scripts/performance/perf_plugins.py` to merge nsys CLI args by option name.
- Update `NsysPlugin.setup()` to call `_merge_nsys_extra_args()` instead of blindly concatenating `self.nsys_extra_args + existing_extra_args`.
- User-provided options now replace matching nemo_run defaults (e.g. `--cuda-graph-trace=graph` replaces the default `--cuda-graph-trace=node`); unrelated defaults are preserved.
- Supports both `--flag=value` and space-separated `--flag value` forms.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [x] Reviewer: Does the PR have correct import guards for all optional libraries?

# Additional Information
- **Motivation:** nemo_run's `Launcher` seeds `nsys_extra_args` with defaults including `--cuda-graph-trace=node`. Passing `--nsys_extra_args --cuda-graph-trace=graph` via the perf scripts previously produced both flags on the nsys command line, which nsys rejects.
- **Scope:** Change is limited to `scripts/performance/perf_plugins.py` (perf scripts copy of `NsysPlugin`).
- **Tests:** No new unit tests added. The perf-scripts copy has no existing test file for this module; happy to add a small test for `_merge_nsys_extra_args` if maintainers prefer.
- **Docs:** No doc update needed; behavior now matches the intended semantics of `--nsys_extra_args` (override, not duplicate).

- Related to # (issue)
https://github.com/NVIDIA-NeMo/Megatron-Bridge/pull/3311 
Unlike the above PR, this PR will allow to overide default nemo params and not related to specific nsys flags

