### PR TITLE
build(deps): pin flash-mla to FlashMLA nv_dev ToT (b7643bd)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,13 +150,13 @@ url = "https://pypi.nvidia.com"
 # resolver does not have to build it at lock time. Pin matches 3rdparty/Megatron-LM.
 [[tool.uv.dependency-metadata]]
 name = "flash-mla"
-version = "1.0.0+9edee0c"
+version = "1.0.0+b7643bd"
 requires-dist = []
 
 [tool.uv.sources]
 megatron-core = { path = "3rdparty/Megatron-LM/", editable = true }
 nvidia-modelopt = { index = "nvidia" }
-flash_mla = { git = "https://github.com/deepseek-ai/FlashMLA", rev = "9edee0c022cd0938148a18e334203b0aab43aa19" }
+flash_mla = { git = "https://github.com/deepseek-ai/FlashMLA", rev = "nv_dev" }
 
 [project.optional-dependencies]
 recipes = [

--- a/uv.lock
+++ b/uv.lock
@@ -28,7 +28,7 @@ overrides = [
 
 [[manifest.dependency-metadata]]
 name = "flash-mla"
-version = "1.0.0+9edee0c"
+version = "1.0.0+b7643bd"
 
 [[package]]
 name = "absl-py"
@@ -1108,8 +1108,8 @@ wheels = [
 
 [[package]]
 name = "flash-mla"
-version = "1.0.0+9edee0c"
-source = { git = "https://github.com/deepseek-ai/FlashMLA?rev=9edee0c022cd0938148a18e334203b0aab43aa19#9edee0c022cd0938148a18e334203b0aab43aa19" }
+version = "1.0.0+b7643bd"
+source = { git = "https://github.com/deepseek-ai/FlashMLA?rev=nv_dev#b7643bd54521f563b839b98289b5cd048c062ba2" }
 
 [[package]]
 name = "flashinfer-cubin"
@@ -2245,7 +2245,7 @@ docs = [
     { name = "sphinx-copybutton", specifier = ">=0.5.2" },
     { name = "sphinxcontrib-mermaid" },
 ]
-no-pypi-wheels = [{ name = "flash-mla", git = "https://github.com/deepseek-ai/FlashMLA?rev=9edee0c022cd0938148a18e334203b0aab43aa19" }]
+no-pypi-wheels = [{ name = "flash-mla", git = "https://github.com/deepseek-ai/FlashMLA?rev=nv_dev" }]
 test = [
     { name = "click" },
     { name = "coverage", specifier = ">=7.8.1" },


### PR DESCRIPTION
## Background / motivation

- The NeMo-FW release container (`nvcr.io/nvidian/nemo:26.06.01.rc0`) builds **flash-mla** from the April-2025 FlashMLA commit `9edee0c` — intended to be the `nv_dev` branch ToT `b7643bd` (2026-04-30).
- Root cause is **here**: Megatron-Bridge re-declares the `flash_mla` git source in its **own** root `pyproject.toml`, because uv does **not** honor a path-dependency's `[tool.uv.sources]` — so the `3rdparty/Megatron-LM` submodule pin never propagates. That copy drifted to `9edee0c` while Megatron-LM already moved to `nv_dev`.
- The release image resolves `flash_mla` from this root `pyproject.toml` via `uv sync --locked`, so **MB's stale pin wins** and the container shipped the old FlashMLA even though MCore was on `nv_dev`.

## What changed

- `pyproject.toml`: `flash_mla` source `rev` `9edee0c…` → `nv_dev`; `[[tool.uv.dependency-metadata]]` label `1.0.0+9edee0c` → `1.0.0+b7643bd`.
- `uv.lock`: refreshed the `flash-mla` entry (manifest metadata, `[[package]]` source, and the `no-pypi-wheels` group source) to `rev=nv_dev#b7643bd54521f563b839b98289b5cd048c062ba2`.

## Details

- The pin now again matches `3rdparty/Megatron-LM` (`[tool.uv.sources] flash_mla → rev "nv_dev"`), keeping the comment above the declaration honest.
- `flash-mla` has pre-declared metadata (`requires-dist = []`) and ships no wheel, so its lock footprint is git-source-only — the lock delta is exactly the four `flash-mla` lines, no other dependency touched.
- Resolved SHA `b7643bd54521f563b839b98289b5cd048c062ba2` verified via `git ls-remote https://github.com/deepseek-ai/FlashMLA refs/heads/nv_dev`.

```mermaid
flowchart TD
    C["release container build<br/>uv sync --locked"] --> MBroot["MB root pyproject.toml<br/>[tool.uv.sources] flash_mla"]
    C -. "path dep sources ignored by uv" .-> SUB["3rdparty/Megatron-LM<br/>flash_mla = rev nv_dev ✅"]
    MBroot -->|before| OLD["FlashMLA 9edee0c<br/>Apr 2025 ❌"]
    MBroot -->|after this PR| NEW["FlashMLA nv_dev<br/>b7643bd ✅"]
```

## Tested

- `git ls-remote` confirms `nv_dev` ToT = `b7643bd…`.
- Lock diff scoped to `flash-mla` only; no residual `9edee0c` in `pyproject.toml`/`uv.lock`.
- Lock consistency (`uv sync --locked`) is validated by CI on this PR (local relock needs `nvcc` for TE/fast-hadamard-transform metadata; the `flash-mla` delta is deterministic — static pre-declared version + `ls-remote`-verified resolved SHA — matching uv's `?rev=<branch>#<sha>` format as used for `emerging-optimizers`).
