### PR TITLE
build(deps): pin flash-mla to FlashMLA nv_dev ToT (b7643bd)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,13 +149,13 @@ url = "https://pypi.nvidia.com"
 # resolver does not have to build it at lock time. Pin matches 3rdparty/Megatron-LM.
 [[tool.uv.dependency-metadata]]
 name = "flash-mla"
-version = "1.0.0+9edee0c"
+version = "1.0.0+b7643bd"
 requires-dist = []
 
 [tool.uv.sources]
 megatron-core = { path = "3rdparty/Megatron-LM/", editable = true }
 nvidia-modelopt = { index = "nvidia" }
-flash_mla = { git = "https://github.com/deepseek-ai/FlashMLA", rev = "9edee0c022cd0938148a18e334203b0aab43aa19" }
+flash_mla = { git = "https://github.com/deepseek-ai/FlashMLA", rev = "nv_dev" }
 
 [project.optional-dependencies]
 recipes = [

--- a/uv.lock
+++ b/uv.lock
@@ -28,7 +28,7 @@ overrides = [
 
 [[manifest.dependency-metadata]]
 name = "flash-mla"
-version = "1.0.0+9edee0c"
+version = "1.0.0+b7643bd"
 
 [[package]]
 name = "absl-py"
@@ -1107,8 +1107,8 @@ wheels = [
 
 [[package]]
 name = "flash-mla"
-version = "1.0.0+9edee0c"
-source = { git = "https://github.com/deepseek-ai/FlashMLA?rev=9edee0c022cd0938148a18e334203b0aab43aa19#9edee0c022cd0938148a18e334203b0aab43aa19" }
+version = "1.0.0+b7643bd"
+source = { git = "https://github.com/deepseek-ai/FlashMLA?rev=nv_dev#b7643bd54521f563b839b98289b5cd048c062ba2" }
 
 [[package]]
 name = "flashinfer-cubin"
@@ -2245,7 +2245,7 @@ docs = [
     { name = "sphinx-copybutton", specifier = ">=0.5.2" },
     { name = "sphinxcontrib-mermaid" },
 ]
-no-pypi-wheels = [{ name = "flash-mla", git = "https://github.com/deepseek-ai/FlashMLA?rev=9edee0c022cd0938148a18e334203b0aab43aa19" }]
+no-pypi-wheels = [{ name = "flash-mla", git = "https://github.com/deepseek-ai/FlashMLA?rev=nv_dev" }]
 test = [
     { name = "click" },
     { name = "coverage", specifier = ">=7.8.1" },


### PR DESCRIPTION
## Background / motivation

- Release-branch cherry-pick of #4670 onto `r0.5.0`.
- The NeMo-FW release container (`nvcr.io/nvidian/nemo:26.06.01.rc0`) pins Megatron-Bridge at an `r0.5.0` commit, and builds **flash-mla** from the April-2025 FlashMLA commit `9edee0c` instead of the `nv_dev` ToT `b7643bd` (2026-04-30).
- Root cause: MB re-declares `flash_mla` in its **own** root `pyproject.toml` (uv ignores a path-dependency's `[tool.uv.sources]`, so the `3rdparty/Megatron-LM` submodule's `nv_dev` pin never propagates). That copy drifted to `9edee0c`; since the image resolves `flash_mla` from the root via `uv sync --locked`, the stale pin wins.

## What changed

- `pyproject.toml`: `flash_mla` `rev` `9edee0c…` → `nv_dev`; metadata label `1.0.0+9edee0c` → `1.0.0+b7643bd`.
- `uv.lock`: `flash-mla` entry refreshed to `rev=nv_dev#b7643bd54521f563b839b98289b5cd048c062ba2` (manifest metadata, `[[package]]` source, `no-pypi-wheels` group).

## Follow-up

- After merge, bump `MEGATRON_BRIDGE_REF` on the `nemo-ci` `r26.06` branch (`dl/joc/nemo-ci`, `.gitlab/workflows/ci_build_vars.yml`) to an `r0.5.0` commit that includes this fix, so the next `26.06.01` RC container builds flash-mla from `nv_dev`.

## Tested

- Cherry-pick applied cleanly onto `r0.5.0`; lock diff scoped to `flash-mla` only, no residual `9edee0c`.
- `nv_dev` ToT `b7643bd…` verified via `git ls-remote`; lock consistency validated by CI (`uv sync --locked`).
