### PR TITLE
[models] fix: preserve Ministral 3 export dimensions

### DIFF
--- a/src/megatron/bridge/models/ministral3/ministral3_bridge.py
+++ b/src/megatron/bridge/models/ministral3/ministral3_bridge.py
@@ -104,6 +104,15 @@ class Ministral3Bridge(MegatronModelBridge):
 
         return provider
 
+    @classmethod
+    def megatron_to_hf_config(cls, provider: Ministral3ModelProvider) -> dict[str, object]:
+        """Convert a Ministral 3 provider to its nested HuggingFace config layout."""
+        text_config = super().megatron_to_hf_config(provider)
+        top_level_keys = ("architectures", "model_type", "tie_word_embeddings")
+        hf_config = {key: text_config.pop(key) for key in top_level_keys if key in text_config}
+        hf_config["text_config"] = text_config
+        return hf_config
+
     def mapping_registry(self) -> MegatronMappingRegistry:
         """
         Return MegatronMappingRegistry containing parameter mappings for VL models.

--- a/src/megatron/bridge/models/ministral3/ministral3_bridge.py
+++ b/src/megatron/bridge/models/ministral3/ministral3_bridge.py
@@ -92,14 +92,23 @@ class Ministral3Bridge(MegatronModelBridge):
 
         # Ministral 3 has separate text_config and vision_config
         text_config = getattr(hf_config, "text_config", hf_config)
+        params_dtype = self.dtype_from_hf(hf_config, default=torch.float32)
         provider = Ministral3ModelProvider(
             hidden_size=text_config.hidden_size,
             ffn_hidden_size=text_config.intermediate_size,
             num_layers=text_config.num_hidden_layers,
-            share_embeddings_and_output_weights=getattr(text_config, "tie_word_embeddings", False),
+            num_attention_heads=text_config.num_attention_heads,
+            num_query_groups=text_config.num_key_value_heads,
+            kv_channels=text_config.head_dim,
+            seq_length=text_config.max_position_embeddings,
+            share_embeddings_and_output_weights=getattr(hf_config, "tie_word_embeddings", False),
             rotary_base=text_config.rope_parameters["rope_theta"],
             vocab_size=text_config.vocab_size,
+            params_dtype=params_dtype,
+            fp16=params_dtype == torch.float16,
+            bf16=params_dtype == torch.bfloat16,
             hf_config=hf_config,
+            image_token_id=getattr(hf_config, "image_token_index", 10),
         )
 
         return provider
@@ -110,6 +119,8 @@ class Ministral3Bridge(MegatronModelBridge):
         text_config = super().megatron_to_hf_config(provider)
         top_level_keys = ("architectures", "model_type", "tie_word_embeddings")
         hf_config = {key: text_config.pop(key) for key in top_level_keys if key in text_config}
+        if "torch_dtype" in text_config:
+            hf_config["dtype"] = text_config.pop("torch_dtype")
         hf_config["text_config"] = text_config
         return hf_config
 
@@ -233,7 +244,7 @@ if HAS_MISTRAL3 and Mistral3ForConditionalGeneration is not None:
     # Dynamically register the bridge with Ministral3Model as target
     try:
         Ministral3Bridge = MegatronModelBridge.register_bridge(
-            source=Mistral3ForConditionalGeneration, target=Ministral3Model
+            source=Mistral3ForConditionalGeneration, target=Ministral3Model, model_type="mistral3"
         )(Ministral3Bridge)
     except Exception:
         # If registration fails, the bridge will still work manually

--- a/tests/unit_tests/models/ministral3/test_ministral3_bridge.py
+++ b/tests/unit_tests/models/ministral3/test_ministral3_bridge.py
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
+import torch
 from transformers import Mistral3Config
 
+from megatron.bridge import AutoBridge
 from megatron.bridge.models.conversion.mapping_registry import MegatronMappingRegistry
-from megatron.bridge.models.conversion.utils import conform_config_to_reference
 from megatron.bridge.models.hf_pretrained.vlm import PreTrainedVLM
 from megatron.bridge.models.ministral3.ministral3_bridge import Ministral3Bridge
 from megatron.bridge.models.ministral3.ministral3_provider import Ministral3ModelProvider
@@ -33,6 +34,8 @@ def mock_text_config():
     config.intermediate_size = 9216
     config.num_attention_heads = 32
     config.num_key_value_heads = 8
+    config.head_dim = 96
+    config.max_position_embeddings = 262144
     config.vocab_size = 131072
     config.rope_parameters = {
         "rope_theta": 1000000,
@@ -62,9 +65,11 @@ def mock_hf_config(mock_text_config, mock_vision_config):
     config = Mock()
     config.text_config = mock_text_config
     config.vision_config = mock_vision_config
+    config.tie_word_embeddings = True
+    config.torch_dtype = torch.bfloat16
 
     # VL-specific token IDs
-    config.image_token_id = 10
+    config.image_token_index = 10
 
     return config
 
@@ -131,12 +136,12 @@ class TestMinistral3BridgeProviderBridge:
     def test_provider_bridge_tie_word_embeddings(self, ministral3_bridge, mock_hf_pretrained):
         """Test provider_bridge handles tie_word_embeddings correctly."""
         # Test with tie_word_embeddings=True
-        mock_hf_pretrained.config.text_config.tie_word_embeddings = True
+        mock_hf_pretrained.config.tie_word_embeddings = True
         provider = ministral3_bridge.provider_bridge(mock_hf_pretrained)
         assert provider.share_embeddings_and_output_weights is True
 
         # Test with tie_word_embeddings=False
-        mock_hf_pretrained.config.text_config.tie_word_embeddings = False
+        mock_hf_pretrained.config.tie_word_embeddings = False
         provider = ministral3_bridge.provider_bridge(mock_hf_pretrained)
         assert provider.share_embeddings_and_output_weights is False
 
@@ -309,11 +314,18 @@ class TestMinistral3BridgeEdgeCases:
         text_config.num_hidden_layers = 26
         text_config.hidden_size = 3072
         text_config.intermediate_size = 9216
+        text_config.num_attention_heads = 32
+        text_config.num_key_value_heads = 8
+        text_config.head_dim = 96
+        text_config.max_position_embeddings = 262144
         text_config.vocab_size = 131072
         text_config.rope_parameters = {"rope_theta": 1000000}
         text_config.tie_word_embeddings = False
 
         minimal_config.text_config = text_config
+        minimal_config.tie_word_embeddings = False
+        minimal_config.torch_dtype = torch.bfloat16
+        minimal_config.image_token_index = 10
         minimal_pretrained.config = minimal_config
 
         provider = ministral3_bridge.provider_bridge(minimal_pretrained)
@@ -402,18 +414,25 @@ class TestMinistral3BridgeCompatibility:
         assert provider.ffn_hidden_size == 16384
         assert provider.rotary_base == 1000000000.0
 
-    def test_auto_config_export_uses_checkpoint_text_dimensions(self, ministral3_bridge):
-        """Test resized checkpoints replace the reference model's nested text dimensions."""
-        reference_config = Mistral3Config(
+    def test_provider_bridge_uses_composite_config_contract(self, ministral3_bridge):
+        """Test the real composite config maps text dimensions and top-level fields."""
+        hf_config = Mistral3Config(
+            architectures=["Mistral3ForConditionalGeneration"],
+            dtype="float16",
+            image_token_index=42,
+            tie_word_embeddings=False,
             text_config={
-                "hidden_size": 512,
-                "intermediate_size": 1536,
-                "num_hidden_layers": 4,
-                "num_attention_heads": 8,
+                "model_type": "ministral3",
+                "hidden_size": 256,
+                "intermediate_size": 768,
+                "num_hidden_layers": 2,
+                "num_attention_heads": 4,
                 "num_key_value_heads": 2,
                 "head_dim": 64,
-                "vocab_size": 32768,
+                "max_position_embeddings": 4096,
+                "vocab_size": 16384,
                 "rope_parameters": {"rope_type": "default", "rope_theta": 1000000.0},
+                "tie_word_embeddings": True,
             },
             vision_config={
                 "hidden_size": 128,
@@ -424,47 +443,143 @@ class TestMinistral3BridgeCompatibility:
                 "image_size": 28,
             },
         )
-        checkpoint_provider = Ministral3ModelProvider(
-            hidden_size=256,
-            ffn_hidden_size=768,
-            num_layers=2,
-            num_attention_heads=4,
-            num_query_groups=2,
-            kv_channels=64,
-            vocab_size=16384,
-            hf_config=reference_config,
-        )
+        hf_pretrained = Mock(spec=PreTrainedVLM)
+        hf_pretrained.config = hf_config
 
-        checkpoint_config = ministral3_bridge.megatron_to_hf_config(checkpoint_provider)
-        synthesized_config = Mistral3Config(
-            **conform_config_to_reference(checkpoint_config, reference_config.to_dict())
+        provider = ministral3_bridge.provider_bridge(hf_pretrained)
+
+        assert provider.hidden_size == hf_config.text_config.hidden_size
+        assert provider.ffn_hidden_size == hf_config.text_config.intermediate_size
+        assert provider.num_layers == hf_config.text_config.num_hidden_layers
+        assert provider.num_attention_heads == hf_config.text_config.num_attention_heads
+        assert provider.num_query_groups == hf_config.text_config.num_key_value_heads
+        assert provider.kv_channels == hf_config.text_config.head_dim
+        assert provider.seq_length == hf_config.text_config.max_position_embeddings
+        assert provider.vocab_size == hf_config.text_config.vocab_size
+        assert provider.share_embeddings_and_output_weights is hf_config.tie_word_embeddings
+        assert provider.params_dtype == torch.float16
+        assert provider.fp16 is True
+        assert provider.bf16 is False
+        assert provider.image_token_id == hf_config.image_token_index
+        assert provider.hf_config is hf_config
+
+    def test_auto_config_export_preserves_composite_config_semantics(self, ministral3_bridge, tmp_path):
+        """Test the production auto-config path synthesizes a valid composite config."""
+        checkpoint_config = Mistral3Config(
+            architectures=["Mistral3ForConditionalGeneration"],
+            dtype="bfloat16",
+            tie_word_embeddings=False,
+            text_config={
+                "model_type": "ministral3",
+                "hidden_size": 256,
+                "intermediate_size": 768,
+                "num_hidden_layers": 2,
+                "num_attention_heads": 4,
+                "num_key_value_heads": 2,
+                "head_dim": 64,
+                "max_position_embeddings": 4096,
+                "vocab_size": 16384,
+                "rope_parameters": {"rope_type": "default", "rope_theta": 1000000.0},
+                "tie_word_embeddings": True,
+            },
+            vision_config={
+                "hidden_size": 128,
+                "intermediate_size": 256,
+                "num_hidden_layers": 2,
+                "num_attention_heads": 4,
+                "head_dim": 32,
+                "patch_size": 14,
+                "image_size": 28,
+            },
         )
+        checkpoint_pretrained = Mock(spec=PreTrainedVLM)
+        checkpoint_pretrained.config = checkpoint_config
+        checkpoint_provider = ministral3_bridge.provider_bridge(checkpoint_pretrained)
+
+        reference_config = Mistral3Config(
+            architectures=["Mistral3ForConditionalGeneration"],
+            dtype="float16",
+            image_token_index=99,
+            multimodal_projector_bias=True,
+            projector_hidden_act="silu",
+            spatial_merge_size=4,
+            tie_word_embeddings=True,
+            vision_feature_layer=-2,
+            text_config={
+                "model_type": "ministral3",
+                "hidden_size": 512,
+                "intermediate_size": 1536,
+                "num_hidden_layers": 4,
+                "num_attention_heads": 8,
+                "num_key_value_heads": 2,
+                "head_dim": 64,
+                "max_position_embeddings": 8192,
+                "vocab_size": 32768,
+                "rope_parameters": {"rope_type": "default", "rope_theta": 2000000.0},
+                "sliding_window": 2048,
+                "tie_word_embeddings": True,
+                "use_cache": False,
+            },
+            vision_config={
+                "hidden_size": 192,
+                "intermediate_size": 384,
+                "num_hidden_layers": 3,
+                "num_attention_heads": 6,
+                "head_dim": 32,
+                "patch_size": 16,
+                "image_size": 32,
+            },
+        )
+        reference_rope_parameters = dict(reference_config.text_config.rope_parameters)
+        reference_vision_config = reference_config.vision_config.to_dict()
+
+        checkpoint_dir = tmp_path / "checkpoint"
+        checkpoint_dir.mkdir()
+        (checkpoint_dir / "run_config.yaml").write_text("model: {}\n")
+
+        with (
+            patch("transformers.AutoConfig.from_pretrained", return_value=reference_config),
+            patch(
+                "megatron.bridge.training.model_load_save.load_model_config",
+                return_value=(checkpoint_provider, None),
+            ),
+        ):
+            auto_bridge = AutoBridge.from_auto_config(str(checkpoint_dir), "mistralai/reference")
+
+        synthesized_config = auto_bridge.hf_pretrained
+        assert isinstance(synthesized_config, Mistral3Config)
 
         assert synthesized_config.text_config.hidden_size == checkpoint_provider.hidden_size
         assert synthesized_config.text_config.intermediate_size == checkpoint_provider.ffn_hidden_size
         assert synthesized_config.text_config.num_hidden_layers == checkpoint_provider.num_layers
         assert synthesized_config.text_config.num_attention_heads == checkpoint_provider.num_attention_heads
         assert synthesized_config.text_config.num_key_value_heads == checkpoint_provider.num_query_groups
+        assert synthesized_config.text_config.head_dim == checkpoint_provider.kv_channels
+        assert synthesized_config.text_config.max_position_embeddings == checkpoint_provider.seq_length
         assert synthesized_config.text_config.vocab_size == checkpoint_provider.vocab_size
 
-    def test_auto_config_export_preserves_checkpoint_embedding_tying(self, ministral3_bridge):
-        """Test nested config synthesis preserves the checkpoint's top-level tying contract."""
-        reference_config = Mistral3Config(tie_word_embeddings=False)
-        checkpoint_provider = Ministral3ModelProvider(
-            hidden_size=256,
-            ffn_hidden_size=768,
-            num_layers=2,
-            num_attention_heads=4,
-            num_query_groups=2,
-            kv_channels=64,
-            vocab_size=16384,
-            share_embeddings_and_output_weights=True,
-            hf_config=reference_config,
-        )
-
-        checkpoint_config = ministral3_bridge.megatron_to_hf_config(checkpoint_provider)
-        synthesized_config = Mistral3Config(
-            **conform_config_to_reference(checkpoint_config, reference_config.to_dict())
-        )
-
+        assert synthesized_config.architectures == ["Mistral3ForConditionalGeneration"]
+        assert synthesized_config.model_type == "mistral3"
         assert synthesized_config.tie_word_embeddings is checkpoint_provider.share_embeddings_and_output_weights
+        assert synthesized_config.dtype == checkpoint_provider.params_dtype
+
+        assert synthesized_config.image_token_index == reference_config.image_token_index
+        assert synthesized_config.multimodal_projector_bias is reference_config.multimodal_projector_bias
+        assert synthesized_config.projector_hidden_act == reference_config.projector_hidden_act
+        assert synthesized_config.spatial_merge_size == reference_config.spatial_merge_size
+        assert synthesized_config.vision_feature_layer == reference_config.vision_feature_layer
+        assert synthesized_config.text_config.model_type == reference_config.text_config.model_type
+        assert synthesized_config.text_config.rope_parameters == reference_rope_parameters
+        assert synthesized_config.text_config.sliding_window == reference_config.text_config.sliding_window
+        assert synthesized_config.text_config.tie_word_embeddings is reference_config.text_config.tie_word_embeddings
+        assert synthesized_config.text_config.use_cache is reference_config.text_config.use_cache
+        assert synthesized_config.vision_config.to_dict() == reference_vision_config
+
+        synthesized_provider = auto_bridge.to_megatron_provider(load_weights=False)
+        assert synthesized_provider.num_attention_heads == checkpoint_provider.num_attention_heads
+        assert synthesized_provider.num_query_groups == checkpoint_provider.num_query_groups
+        assert synthesized_provider.kv_channels == checkpoint_provider.kv_channels
+        assert synthesized_provider.share_embeddings_and_output_weights is False
+        assert synthesized_provider.params_dtype == torch.bfloat16
+        assert synthesized_provider.fp16 is False
+        assert synthesized_provider.bf16 is True

--- a/tests/unit_tests/models/ministral3/test_ministral3_bridge.py
+++ b/tests/unit_tests/models/ministral3/test_ministral3_bridge.py
@@ -15,8 +15,10 @@
 from unittest.mock import Mock
 
 import pytest
+from transformers import Mistral3Config
 
 from megatron.bridge.models.conversion.mapping_registry import MegatronMappingRegistry
+from megatron.bridge.models.conversion.utils import conform_config_to_reference
 from megatron.bridge.models.hf_pretrained.vlm import PreTrainedVLM
 from megatron.bridge.models.ministral3.ministral3_bridge import Ministral3Bridge
 from megatron.bridge.models.ministral3.ministral3_provider import Ministral3ModelProvider
@@ -399,3 +401,70 @@ class TestMinistral3BridgeCompatibility:
         assert provider.hidden_size == 5120
         assert provider.ffn_hidden_size == 16384
         assert provider.rotary_base == 1000000000.0
+
+    def test_auto_config_export_uses_checkpoint_text_dimensions(self, ministral3_bridge):
+        """Test resized checkpoints replace the reference model's nested text dimensions."""
+        reference_config = Mistral3Config(
+            text_config={
+                "hidden_size": 512,
+                "intermediate_size": 1536,
+                "num_hidden_layers": 4,
+                "num_attention_heads": 8,
+                "num_key_value_heads": 2,
+                "head_dim": 64,
+                "vocab_size": 32768,
+                "rope_parameters": {"rope_type": "default", "rope_theta": 1000000.0},
+            },
+            vision_config={
+                "hidden_size": 128,
+                "intermediate_size": 256,
+                "num_hidden_layers": 2,
+                "num_attention_heads": 4,
+                "patch_size": 14,
+                "image_size": 28,
+            },
+        )
+        checkpoint_provider = Ministral3ModelProvider(
+            hidden_size=256,
+            ffn_hidden_size=768,
+            num_layers=2,
+            num_attention_heads=4,
+            num_query_groups=2,
+            kv_channels=64,
+            vocab_size=16384,
+            hf_config=reference_config,
+        )
+
+        checkpoint_config = ministral3_bridge.megatron_to_hf_config(checkpoint_provider)
+        synthesized_config = Mistral3Config(
+            **conform_config_to_reference(checkpoint_config, reference_config.to_dict())
+        )
+
+        assert synthesized_config.text_config.hidden_size == checkpoint_provider.hidden_size
+        assert synthesized_config.text_config.intermediate_size == checkpoint_provider.ffn_hidden_size
+        assert synthesized_config.text_config.num_hidden_layers == checkpoint_provider.num_layers
+        assert synthesized_config.text_config.num_attention_heads == checkpoint_provider.num_attention_heads
+        assert synthesized_config.text_config.num_key_value_heads == checkpoint_provider.num_query_groups
+        assert synthesized_config.text_config.vocab_size == checkpoint_provider.vocab_size
+
+    def test_auto_config_export_preserves_checkpoint_embedding_tying(self, ministral3_bridge):
+        """Test nested config synthesis preserves the checkpoint's top-level tying contract."""
+        reference_config = Mistral3Config(tie_word_embeddings=False)
+        checkpoint_provider = Ministral3ModelProvider(
+            hidden_size=256,
+            ffn_hidden_size=768,
+            num_layers=2,
+            num_attention_heads=4,
+            num_query_groups=2,
+            kv_channels=64,
+            vocab_size=16384,
+            share_embeddings_and_output_weights=True,
+            hf_config=reference_config,
+        )
+
+        checkpoint_config = ministral3_bridge.megatron_to_hf_config(checkpoint_provider)
+        synthesized_config = Mistral3Config(
+            **conform_config_to_reference(checkpoint_config, reference_config.to_dict())
+        )
+
+        assert synthesized_config.tie_word_embeddings is checkpoint_provider.share_embeddings_and_output_weights


### PR DESCRIPTION
## Summary

- emit checkpoint-derived Ministral 3 language settings under `text_config`
- preserve the Hugging Face top-level architecture, model type, and embedding-tying fields
- cover both resized text dimensions and the existing top-level tying contract

## Supported trigger and impact

`AutoBridge.from_auto_config()` supports exporting custom-small and pruned
checkpoints relative to a Hugging Face reference configuration. For Ministral 3,
the generic reverse mapping emitted checkpoint dimensions as flat keys, while
`Mistral3Config` stores those dimensions under `text_config`.

When a checkpoint's hidden size, FFN size, layer/head counts, or vocabulary
differs from the reference, recursive config conformance discarded the flat
checkpoint values and retained the reference's nested dimensions. Export could
therefore write checkpoint-shaped tensors with an incompatible `config.json`,
causing size mismatches when Transformers loads the result.

## Root cause and fix

The generic converter cannot infer family-specific nesting, and
`conform_config_to_reference()` intentionally merges only matching key paths.
This adds the reverse-config override at the Ministral 3 bridge boundary, where
the nested Hugging Face schema is known. The patch does not change parameter
mapping or conversion APIs.

## Validation

Fail before (unmodified base):

```text
uv run --no-project --no-cache --no-managed-python --no-python-downloads --python /usr/bin/python3 python -m pytest tests/unit_tests/models/ministral3/test_ministral3_bridge.py::TestMinistral3BridgeCompatibility::test_auto_config_export_uses_checkpoint_text_dimensions -q
```

Result: `1 failed`; the synthesized hidden size remained the reference value
(`512`) instead of the checkpoint value (`256`).

Pass after, including the top-level embedding-tying control:

```text
uv run --no-project --no-cache --no-managed-python --no-python-downloads --python /usr/bin/python3 python -m pytest tests/unit_tests/models/ministral3/test_ministral3_bridge.py::TestMinistral3BridgeCompatibility::test_auto_config_export_uses_checkpoint_text_dimensions tests/unit_tests/models/ministral3/test_ministral3_bridge.py::TestMinistral3BridgeCompatibility::test_auto_config_export_preserves_checkpoint_embedding_tying -q
```

Result: `2 passed`.

Adjacent validation:

```text
uv run --no-project --no-cache --no-managed-python --no-python-downloads --python /usr/bin/python3 python -m pytest tests/unit_tests/models/ministral3/test_ministral3_bridge.py tests/unit_tests/models/ministral3/test_ministral3_provider.py tests/unit_tests/models/qwen3_asr/test_qwen3_asr_config.py -q
```

Result: `48 passed`.

Static validation:

```text
git diff --check
uv run --no-project --no-cache --no-managed-python --no-python-downloads --python /host-venv/bin/python3 pre-commit run --all-files
```

Result: passed; all pre-commit hooks passed.

## Scope

This is limited to Ministral 3 export-time Hugging Face config synthesis. No
training, distributed, checkpoint tensor, model-quality, convergence, or
performance validation is claimed.
