### PR TITLE
build: remove jackson-core CVE patch layer from fw_final image

### DIFF
--- a/docker/Dockerfile.fw_final
+++ b/docker/Dockerfile.fw_final
@@ -96,32 +96,6 @@ RUN pip install "starlette==0.49.1" \
 # The actual onnx Python package is managed above via pip/uv; this stale copy triggers CVE scanners.
 RUN rm -rf /opt/pytorch/pytorch/third_party/onnx
 
-# Patch jackson-core CVE inside Ray's bundled fat-jar (cannot upgrade Ray itself)
-RUN JACKSON_VERSION=2.18.6 && \
-    TMPDIR=$(mktemp -d) && \
-    wget -q "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/${JACKSON_VERSION}/jackson-core-${JACKSON_VERSION}.jar" \
-    -O "${TMPDIR}/jackson-core-fixed.jar" && \
-    unzip -q "${TMPDIR}/jackson-core-fixed.jar" -d "${TMPDIR}/jackson_fixed" && \
-    apt-get update && apt-get install -y --no-install-recommends zip && apt-get clean && \
-    for RAY_JAR in \
-    /usr/local/lib/python3.12/dist-packages/ray/jars/ray_dist.jar \
-    /opt/venv/lib/python3.12/site-packages/ray/jars/ray_dist.jar; \
-    do \
-    rm -rf "${TMPDIR}/ray_dist" && \
-    unzip -q "${RAY_JAR}" -d "${TMPDIR}/ray_dist" && \
-    find "${TMPDIR}/ray_dist" -type d -name "jackson" | while read JACKSON_DIR; do \
-        rm -rf "${JACKSON_DIR}/core"; \
-        cp -r "${TMPDIR}/jackson_fixed/com/fasterxml/jackson/core" "${JACKSON_DIR}/core"; \
-    done && \
-    find "${TMPDIR}/ray_dist/META-INF" -name "pom.properties" 2>/dev/null | \
-        xargs grep -l "jackson-core" 2>/dev/null | \
-        xargs -I{} sed -i "s/^version=.*/version=${JACKSON_VERSION}/" {} ; \
-    mv "${RAY_JAR}" "${RAY_JAR}.bak" && \
-    (cd "${TMPDIR}/ray_dist" && zip -qr "${RAY_JAR}" .) && \
-    rm -f "${RAY_JAR}.bak"; \
-    done && \
-    rm -rf "${TMPDIR}"
-
 # Patch wandb-core: bump google.golang.org/grpc from 1.79.2 to 1.79.3 (CVE fix)
 ARG TARGETARCH
 RUN GRPC_VERSION=1.79.3 && \


### PR DESCRIPTION
## Background / motivation

* The `docker/Dockerfile.fw_final` build has a layer that downloads `jackson-core` from Maven Central and repackages Ray's bundled `ray_dist.jar` to patch a jackson-core CVE (added in `09202a11d`, "cannot upgrade Ray itself").
* That layer depends on a live `wget https://repo1.maven.org/...` at build time. Maven Central throttles CI egress IPs, so the step intermittently fails with `wget` exit code 8 (server error) and takes down the whole `build-NeMo-FW-final` job — most recently observed in nemo-ci job `355640267`.

## What changed

* Remove the jackson-core patch `RUN` block entirely from `docker/Dockerfile.fw_final`.

## Details

* `docker/Dockerfile.fw_final` — deletes the 25-line patch layer (comment + `RUN`); the immediately adjacent onnx-cleanup and wandb-core CVE layers are untouched.
* No other file references jackson (`git grep -i jackson` is now empty); `docker/common/README.md` never documented it.

## Security note

* This **reintroduces the jackson-core CVE** in Ray's bundled fat-jar **if** Ray still ships a vulnerable `jackson-core` in `ray_dist.jar`. This removal was a deliberate maintainer decision to prioritize build reliability; if a scanner re-flags it, the follow-up is to bump the transitive Ray pin (or re-add the patch behind a retry/internal-mirror fetch).

## Tested

* `git grep -i jackson` → no matches after the change.
* PR CI exercises the full `Dockerfile.fw_final` build without the Maven Central dependency.
