### PR TITLE
[ckpt] fix: defer async retention until finalization

### DIFF
--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -1527,6 +1527,17 @@ def save_checkpoint(
         else:
             fire_callback()
 
+    # Do not remove the tracker-selected checkpoint until its async replacement is durable.
+    if ckpt_cfg.async_save and ckpt_cfg.most_recent_k > -1 and ckpt_type != CheckpointType.LOCAL:
+
+        def cleanup_old_checkpoints_finalize_fn() -> None:
+            cleanup_old_non_persistent_checkpoint(
+                save_dir, leave_ckpt_num=ckpt_cfg.most_recent_k, do_async=ckpt_cfg.async_save
+            )
+
+        assert async_save_request is not None
+        async_save_request.add_finalize_fn(cleanup_old_checkpoints_finalize_fn)
+
     if ckpt_cfg.async_save:
         schedule_async_save(state, async_save_request)
         print_rank_0(f"  scheduled an async checkpoint save at iteration {train_state.step:7d} to {save_dir}")
@@ -1538,12 +1549,10 @@ def save_checkpoint(
 
     fault_tolerance.on_checkpointing_end(global_state=state, is_async_finalization=False)
 
-    # keep only last k checkpoints
+    # Keep synchronous cleanup after the fault-tolerance checkpointing section.
     # Skip for LOCAL checkpoints — LocalCheckpointManager manages its own cleanup.
-    if ckpt_cfg.most_recent_k > -1 and ckpt_type != CheckpointType.LOCAL:
-        cleanup_old_non_persistent_checkpoint(
-            save_dir, leave_ckpt_num=ckpt_cfg.most_recent_k, do_async=ckpt_cfg.async_save
-        )
+    if not ckpt_cfg.async_save and ckpt_cfg.most_recent_k > -1 and ckpt_type != CheckpointType.LOCAL:
+        cleanup_old_non_persistent_checkpoint(save_dir, leave_ckpt_num=ckpt_cfg.most_recent_k, do_async=False)
 
     # Wait so everyone is done (not necessary)
     if torch.distributed.is_initialized():

--- a/tests/unit_tests/training/test_checkpointing.py
+++ b/tests/unit_tests/training/test_checkpointing.py
@@ -688,6 +688,97 @@ class TestSaveCheckpoint:
         written_content = "".join([str(call[0][0]) for call in write_calls if len(call[0]) > 0])
         assert "1000" in written_content, f"Expected '1000' in written content, got: {written_content}"
 
+    def test_async_retention_keeps_tracker_checkpoint_until_finalize(self, tmp_path, save_checkpoint_fixtures):
+        """The tracker-selected checkpoint must survive until its async replacement is durable."""
+        old_checkpoint = tmp_path / "iter_0000500"
+        old_checkpoint.mkdir()
+        torch.save({"step": torch.tensor(500)}, old_checkpoint / "train_state.pt")
+        latest_train_state = tmp_path / "latest_train_state.pt"
+        torch.save({"step": torch.tensor(500)}, latest_train_state)
+
+        state = save_checkpoint_fixtures["mock_state"]
+        state.cfg.checkpoint.save = str(tmp_path)
+        state.cfg.checkpoint.async_save = True
+        state.cfg.checkpoint.most_recent_k = 1
+        state.wandb_logger = Mock()
+
+        pg_collection = Mock()
+        pg_collection.expt_dp.rank.return_value = 0
+        pg_collection.tp.rank.return_value = 0
+        pg_collection.tp.size.return_value = 1
+        pg_collection.pp.rank.return_value = 0
+        pg_collection.pp.size.return_value = 1
+
+        finalize_fns = []
+        call_order = []
+        async_request = Mock()
+
+        def add_finalize_fn(finalize_fn):
+            finalize_fns.append(finalize_fn)
+            if finalize_fn.__name__ == "cleanup_old_checkpoints_finalize_fn":
+                call_order.append("register_cleanup")
+
+        async_request.add_finalize_fn.side_effect = add_finalize_fn
+
+        def start_async_save(*args, **kwargs):
+            (tmp_path / "iter_0001000").mkdir(exist_ok=True)
+            return async_request
+
+        def run_cleanup_immediately(*, target, args):
+            thread = Mock()
+            thread.start.side_effect = lambda: target(*args)
+            return thread
+
+        with (
+            patch("megatron.bridge.training.checkpointing.dist_checkpointing.save", side_effect=start_async_save),
+            patch("megatron.bridge.training.checkpointing.get_default_save_sharded_strategy", return_value=Mock()),
+            patch("megatron.bridge.training.checkpointing.get_pg_collection", return_value=pg_collection),
+            patch("megatron.bridge.training.checkpointing.get_rng_state", return_value=Mock()),
+            patch("megatron.bridge.training.checkpointing.get_rerun_state_machine") as mock_rerun,
+            patch("megatron.bridge.training.checkpointing._get_model_glu_interleave_sizes", return_value=(None, None)),
+            patch(
+                "megatron.bridge.training.checkpointing.generate_state_dict",
+                return_value={"model": {"weight": Mock()}},
+            ),
+            patch(
+                "megatron.bridge.training.checkpointing.unwrap_model",
+                return_value=save_checkpoint_fixtures["mock_model"],
+            ),
+            patch("megatron.bridge.training.checkpointing.save_sharded_modelopt_state"),
+            patch("megatron.bridge.training.checkpointing.maybe_save_dataloader_state"),
+            patch(
+                "megatron.bridge.training.checkpointing.schedule_async_save",
+                side_effect=lambda *args, **kwargs: call_order.append("schedule"),
+            ),
+            patch("megatron.bridge.training.checkpointing.fault_tolerance"),
+            patch("megatron.bridge.training.checkpointing.is_empty_async_queue", return_value=True),
+            patch("megatron.bridge.training.checkpointing.get_rank_safe", return_value=0),
+            patch("megatron.bridge.training.checkpointing.is_last_rank", return_value=False),
+            patch("megatron.bridge.training.checkpointing.threading.Thread", side_effect=run_cleanup_immediately),
+            patch("torch.distributed.is_initialized", return_value=True),
+            patch("torch.distributed.get_rank", return_value=0),
+            patch("torch.distributed.barrier"),
+        ):
+            mock_rerun.return_value.state_dict.return_value = {}
+            save_checkpoint(
+                state,
+                save_checkpoint_fixtures["mock_model"],
+                save_checkpoint_fixtures["mock_optimizer"],
+                save_checkpoint_fixtures["mock_scheduler"],
+                1000000,
+                checkpointing_context={},
+            )
+
+            assert call_order == ["register_cleanup", "schedule"]
+            assert old_checkpoint.is_dir()
+            assert torch.load(latest_train_state, weights_only=True)["step"].item() == 500
+
+            for finalize_fn in finalize_fns:
+                finalize_fn()
+
+        assert not old_checkpoint.exists()
+        assert torch.load(latest_train_state, weights_only=True)["step"].item() == 1000
+
     @patch("megatron.bridge.training.checkpointing.wandb_utils")
     @patch("megatron.bridge.training.checkpointing.is_last_rank")
     @patch("builtins.open", new_callable=mock_open)


### PR DESCRIPTION
## Problem

With `async_save=True` and `most_recent_k=1`, starting a new persistent save can
delete the only complete checkpoint before its replacement is durable.

The new `iter_*` directory exists as soon as the async save is prepared, but its
shards, completeness metadata, and Bridge tracker updates are still pending. The
retention pass previously ran immediately after scheduling, kept that numerically
newest incomplete directory, and removed the older checkpoint still selected by
`latest_train_state.pt`. A crash, preemption, or racing resume in that window has no
complete tracker-selected checkpoint to load.

## Fix

Register async retention as a save finalizer before the request is scheduled. It now
runs after payload, tracker, barrier, and user finalizers. Synchronous retention stays
in its original post-fault-tolerance location, and local checkpoint retention remains
owned by the local checkpoint manager.

## Regression evidence

The focused test creates a complete step-500 checkpoint and tracker, starts a blocked
async step-1000 replacement, and makes cleanup deterministic.

- Before the fix: **1 failed** because step 500 was removed before finalization while
  the tracker still selected it.
- After the fix: **1 passed**; step 500 survives until finalizers run, the tracker then
  advances to step 1000, and only then is step 500 removed.
- The test also asserts retention is registered before scheduling freezes the async
  request.

```text
uv run python -m pytest \
  tests/unit_tests/training/test_checkpointing.py::TestSaveCheckpoint::test_async_retention_keeps_tracker_checkpoint_until_finalize -q
```

Adjacent verification:

```text
uv run python -m pytest \
  tests/unit_tests/training/test_checkpointing.py::TestSaveCheckpoint \
  tests/unit_tests/training/test_checkpointing.py::TestCleanupNonPersistentCheckpoints \
  tests/unit_tests/training/test_checkpointing.py::TestCheckpointManager::test_default_checkpoint_manager_finalize_async_saves -q
```

- **11 passed** across synchronous save, async scheduling, HF/PEFT sidecars,
  retention cleanup, and manager finalization.
- `git diff --check` passed.
- `uv run pre-commit run --all-files` passed.

## Scope

This changes only host-side async retention ordering. It does not change checkpoint
payload formats, synchronous retention semantics, local checkpoint cleanup, model
numerics, or public APIs. No full-suite, GPU, convergence, or performance validation
is claimed.
