### PR TITLE
fix(perf): support natural MoE router loads

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,7 +129,7 @@ override-dependencies = [
     "torch; sys_platform == 'never'",
     "torchvision; sys_platform == 'never'",
     "triton; sys_platform == 'never'",
-    "transformer-engine @ git+https://github.com/NVIDIA/TransformerEngine.git@d64bc14dc87eb658ab98839e4b7687595ee53e2d",
+    "transformer-engine @ git+https://github.com/NVIDIA/TransformerEngine.git@b9d690e042b1c4e455214e7dab65d6d3512c05d6",
     "mlflow>=3.9.0",                                        # To address CVE-2025-15031
     "cachetools>=5.0.0",
     "cryptography>=43.0.0,<47",

--- a/src/megatron/bridge/perf_recipes/deepseek/common.py
+++ b/src/megatron/bridge/perf_recipes/deepseek/common.py
@@ -32,7 +32,7 @@ def _deepseek_v3_common(cfg: ConfigContainer) -> None:
     cfg.model.moe_router_fusion = True
     cfg.model.recompute_granularity = "selective"
     cfg.dist.enable_megatron_core_experimental = True
-    cfg.model.moe_router_force_load_balancing = True
+    cfg.model.moe_router_force_load_balancing = False
 
 
 def _enable_deepseek_full_iteration_mxfp8(

--- a/src/megatron/bridge/perf_recipes/gpt_oss/b200/gpt_oss.py
+++ b/src/megatron/bridge/perf_recipes/gpt_oss/b200/gpt_oss.py
@@ -26,7 +26,7 @@ def gpt_oss_120b_pretrain_64gpu_b200_bf16_config() -> ConfigContainer:
     cfg = gpt_oss_120b_pretrain_config()
     cfg.mixed_precision = _perf_precision("bf16")
     cfg.model.moe_router_fusion = True
-    cfg.model.moe_router_force_load_balancing = True
+    cfg.model.moe_router_force_load_balancing = False
 
     cfg.model.tensor_model_parallel_size = 1
     cfg.model.pipeline_model_parallel_size = 1
@@ -47,7 +47,7 @@ def gpt_oss_120b_pretrain_64gpu_b200_fp8mx_config() -> ConfigContainer:
     cfg = gpt_oss_120b_pretrain_config()
     cfg.mixed_precision = _perf_precision("fp8_mx")
     cfg.model.moe_router_fusion = True
-    cfg.model.moe_router_force_load_balancing = True
+    cfg.model.moe_router_force_load_balancing = False
 
     cfg.model.tensor_model_parallel_size = 1
     cfg.model.pipeline_model_parallel_size = 1

--- a/src/megatron/bridge/perf_recipes/gpt_oss/b300/gpt_oss.py
+++ b/src/megatron/bridge/perf_recipes/gpt_oss/b300/gpt_oss.py
@@ -134,7 +134,7 @@ def gpt_oss_120b_pretrain_64gpu_b300_bf16_config() -> ConfigContainer:
     cfg = gpt_oss_120b_pretrain_config()
     cfg.mixed_precision = _perf_precision("bf16")
     cfg.model.moe_router_fusion = True
-    cfg.model.moe_router_force_load_balancing = True
+    cfg.model.moe_router_force_load_balancing = False
 
     cfg.model.tensor_model_parallel_size = 1
     cfg.model.pipeline_model_parallel_size = 1
@@ -159,7 +159,7 @@ def gpt_oss_120b_pretrain_64gpu_b300_fp8mx_config() -> ConfigContainer:
     cfg = gpt_oss_120b_pretrain_config()
     cfg.mixed_precision = _perf_precision("fp8_mx")
     cfg.model.moe_router_fusion = True
-    cfg.model.moe_router_force_load_balancing = True
+    cfg.model.moe_router_force_load_balancing = False
 
     cfg.model.tensor_model_parallel_size = 1
     cfg.model.pipeline_model_parallel_size = 1

--- a/src/megatron/bridge/perf_recipes/gpt_oss/gb200/gpt_oss.py
+++ b/src/megatron/bridge/perf_recipes/gpt_oss/gb200/gpt_oss.py
@@ -111,7 +111,7 @@ def gpt_oss_120b_pretrain_64gpu_gb200_bf16_config() -> ConfigContainer:
     cfg = gpt_oss_120b_pretrain_config()
     cfg.mixed_precision = _perf_precision("bf16")
     cfg.model.moe_router_fusion = True
-    cfg.model.moe_router_force_load_balancing = True
+    cfg.model.moe_router_force_load_balancing = False
 
     cfg.model.tensor_model_parallel_size = 1
     cfg.model.pipeline_model_parallel_size = 1
@@ -136,7 +136,7 @@ def gpt_oss_120b_pretrain_64gpu_gb200_fp8mx_config() -> ConfigContainer:
     cfg = gpt_oss_120b_pretrain_config()
     cfg.mixed_precision = _perf_precision("fp8_mx")
     cfg.model.moe_router_fusion = True
-    cfg.model.moe_router_force_load_balancing = True
+    cfg.model.moe_router_force_load_balancing = False
 
     cfg.model.tensor_model_parallel_size = 1
     cfg.model.pipeline_model_parallel_size = 1

--- a/src/megatron/bridge/perf_recipes/gpt_oss/gb300/gpt_oss.py
+++ b/src/megatron/bridge/perf_recipes/gpt_oss/gb300/gpt_oss.py
@@ -110,7 +110,7 @@ def gpt_oss_120b_pretrain_64gpu_gb300_bf16_config() -> ConfigContainer:
     cfg = gpt_oss_120b_pretrain_config()
     cfg.mixed_precision = _perf_precision("bf16")
     cfg.model.moe_router_fusion = True
-    cfg.model.moe_router_force_load_balancing = True
+    cfg.model.moe_router_force_load_balancing = False
 
     cfg.model.tensor_model_parallel_size = 1
     cfg.model.pipeline_model_parallel_size = 1
@@ -131,7 +131,7 @@ def gpt_oss_120b_pretrain_64gpu_gb300_fp8mx_config() -> ConfigContainer:
     cfg = gpt_oss_120b_pretrain_config()
     cfg.mixed_precision = _perf_precision("fp8_mx")
     cfg.model.moe_router_fusion = True
-    cfg.model.moe_router_force_load_balancing = True
+    cfg.model.moe_router_force_load_balancing = False
 
     cfg.model.tensor_model_parallel_size = 1
     cfg.model.pipeline_model_parallel_size = 1

--- a/src/megatron/bridge/perf_recipes/gpt_oss/h100/gpt_oss.py
+++ b/src/megatron/bridge/perf_recipes/gpt_oss/h100/gpt_oss.py
@@ -26,7 +26,7 @@ def gpt_oss_120b_pretrain_64gpu_h100_bf16_config() -> ConfigContainer:
     cfg = gpt_oss_120b_pretrain_config()
     cfg.mixed_precision = _perf_precision("bf16")
     cfg.model.moe_router_fusion = True
-    cfg.model.moe_router_force_load_balancing = True
+    cfg.model.moe_router_force_load_balancing = False
 
     cfg.model.tensor_model_parallel_size = 1
     cfg.model.pipeline_model_parallel_size = 4
@@ -47,7 +47,7 @@ def gpt_oss_120b_pretrain_64gpu_h100_fp8cs_config() -> ConfigContainer:
     cfg = gpt_oss_120b_pretrain_config()
     cfg.mixed_precision = _perf_precision("fp8_cs")
     cfg.model.moe_router_fusion = True
-    cfg.model.moe_router_force_load_balancing = True
+    cfg.model.moe_router_force_load_balancing = False
 
     cfg.model.tensor_model_parallel_size = 1
     cfg.model.pipeline_model_parallel_size = 4

--- a/src/megatron/bridge/perf_recipes/nemotronh/b200/nemotronh.py
+++ b/src/megatron/bridge/perf_recipes/nemotronh/b200/nemotronh.py
@@ -147,7 +147,7 @@ def nemotron_3_nano_pretrain_8gpu_b200_bf16_config() -> ConfigContainer:
     cfg.train.micro_batch_size = 2
 
     cfg.model.moe_flex_dispatcher_backend = "hybridep"
-    cfg.model.moe_router_force_load_balancing = True
+    cfg.model.moe_router_force_load_balancing = False
 
     cfg.model.cuda_graph_impl = "transformer_engine"
     cfg.model.cuda_graph_scope = ["attn", "mamba", "moe_router", "moe_preprocess"]
@@ -174,7 +174,7 @@ def nemotron_3_nano_pretrain_8gpu_b200_fp8mx_config() -> ConfigContainer:
     cfg.train.micro_batch_size = 2
 
     cfg.model.moe_flex_dispatcher_backend = "hybridep"
-    cfg.model.moe_router_force_load_balancing = True
+    cfg.model.moe_router_force_load_balancing = False
 
     cfg.model.cuda_graph_impl = "transformer_engine"
     cfg.model.cuda_graph_scope = ["attn", "mamba", "moe_router", "moe_preprocess"]
@@ -201,7 +201,7 @@ def nemotron_3_nano_pretrain_8gpu_b200_nvfp4_config() -> ConfigContainer:
     cfg.train.micro_batch_size = 2
 
     cfg.model.moe_flex_dispatcher_backend = "hybridep"
-    cfg.model.moe_router_force_load_balancing = True
+    cfg.model.moe_router_force_load_balancing = False
 
     cfg.model.cuda_graph_impl = "transformer_engine"
     cfg.model.cuda_graph_scope = ["attn", "mamba", "moe_router", "moe_preprocess"]

--- a/src/megatron/bridge/perf_recipes/nemotronh/b300/nemotronh.py
+++ b/src/megatron/bridge/perf_recipes/nemotronh/b300/nemotronh.py
@@ -147,7 +147,7 @@ def nemotron_3_nano_pretrain_8gpu_b300_bf16_config() -> ConfigContainer:
     cfg.train.micro_batch_size = 4
 
     cfg.model.moe_flex_dispatcher_backend = "hybridep"
-    cfg.model.moe_router_force_load_balancing = True
+    cfg.model.moe_router_force_load_balancing = False
 
     cfg.model.cuda_graph_impl = "transformer_engine"
     cfg.model.cuda_graph_scope = ["attn", "mamba", "moe_router", "moe_preprocess"]
@@ -174,7 +174,7 @@ def nemotron_3_nano_pretrain_8gpu_b300_fp8mx_config() -> ConfigContainer:
     cfg.train.micro_batch_size = 4
 
     cfg.model.moe_flex_dispatcher_backend = "hybridep"
-    cfg.model.moe_router_force_load_balancing = True
+    cfg.model.moe_router_force_load_balancing = False
 
     cfg.model.cuda_graph_impl = "transformer_engine"
     cfg.model.cuda_graph_scope = ["attn", "mamba", "moe_router", "moe_preprocess"]
@@ -201,7 +201,7 @@ def nemotron_3_nano_pretrain_8gpu_b300_nvfp4_config() -> ConfigContainer:
     cfg.train.micro_batch_size = 4
 
     cfg.model.moe_flex_dispatcher_backend = "hybridep"
-    cfg.model.moe_router_force_load_balancing = True
+    cfg.model.moe_router_force_load_balancing = False
 
     cfg.model.cuda_graph_impl = "transformer_engine"
     cfg.model.cuda_graph_scope = ["attn", "mamba", "moe_router", "moe_preprocess"]

--- a/src/megatron/bridge/perf_recipes/nemotronh/common.py
+++ b/src/megatron/bridge/perf_recipes/nemotronh/common.py
@@ -47,7 +47,7 @@ def _apply_nemotron_3_super_perf_defaults(cfg: ConfigContainer) -> None:
     cfg.mixed_precision.grad_reduce_in_fp32 = False
     cfg.ddp.grad_reduce_in_fp32 = False
 
-    cfg.model.moe_router_force_load_balancing = True
+    cfg.model.moe_router_force_load_balancing = False
     cfg.checkpoint.async_save = False
 
     _benchmark_common(cfg)

--- a/src/megatron/bridge/perf_recipes/nemotronh/gb200/nemotronh.py
+++ b/src/megatron/bridge/perf_recipes/nemotronh/gb200/nemotronh.py
@@ -143,7 +143,7 @@ def nemotron_3_nano_pretrain_8gpu_gb200_bf16_config() -> ConfigContainer:
     cfg.train.micro_batch_size = 2
 
     cfg.model.moe_flex_dispatcher_backend = "hybridep"
-    cfg.model.moe_router_force_load_balancing = True
+    cfg.model.moe_router_force_load_balancing = False
 
     cfg.model.cuda_graph_impl = "transformer_engine"
     cfg.model.cuda_graph_scope = ["attn", "mamba", "moe_router", "moe_preprocess"]
@@ -170,7 +170,7 @@ def nemotron_3_nano_pretrain_8gpu_gb200_fp8mx_config() -> ConfigContainer:
     cfg.train.micro_batch_size = 2
 
     cfg.model.moe_flex_dispatcher_backend = "hybridep"
-    cfg.model.moe_router_force_load_balancing = True
+    cfg.model.moe_router_force_load_balancing = False
 
     cfg.model.cuda_graph_impl = "transformer_engine"
     cfg.model.cuda_graph_scope = ["attn", "mamba", "moe_router", "moe_preprocess"]
@@ -197,7 +197,7 @@ def nemotron_3_nano_pretrain_8gpu_gb200_nvfp4_config() -> ConfigContainer:
     cfg.train.micro_batch_size = 2
 
     cfg.model.moe_flex_dispatcher_backend = "hybridep"
-    cfg.model.moe_router_force_load_balancing = True
+    cfg.model.moe_router_force_load_balancing = False
 
     cfg.model.cuda_graph_impl = "transformer_engine"
     cfg.model.cuda_graph_scope = ["attn", "mamba", "moe_router", "moe_preprocess"]

--- a/src/megatron/bridge/perf_recipes/nemotronh/gb300/nemotronh.py
+++ b/src/megatron/bridge/perf_recipes/nemotronh/gb300/nemotronh.py
@@ -144,7 +144,7 @@ def nemotron_3_nano_pretrain_8gpu_gb300_bf16_config() -> ConfigContainer:
     cfg.train.micro_batch_size = 4
 
     cfg.model.moe_flex_dispatcher_backend = "hybridep"
-    cfg.model.moe_router_force_load_balancing = True
+    cfg.model.moe_router_force_load_balancing = False
 
     cfg.model.cuda_graph_impl = "transformer_engine"
     cfg.model.cuda_graph_scope = ["attn", "mamba", "moe_router", "moe_preprocess"]
@@ -171,7 +171,7 @@ def nemotron_3_nano_pretrain_8gpu_gb300_fp8mx_config() -> ConfigContainer:
     cfg.train.micro_batch_size = 4
 
     cfg.model.moe_flex_dispatcher_backend = "hybridep"
-    cfg.model.moe_router_force_load_balancing = True
+    cfg.model.moe_router_force_load_balancing = False
 
     cfg.model.cuda_graph_impl = "transformer_engine"
     cfg.model.cuda_graph_scope = ["attn", "mamba", "moe_router", "moe_preprocess"]
@@ -198,7 +198,7 @@ def nemotron_3_nano_pretrain_8gpu_gb300_nvfp4_config() -> ConfigContainer:
     cfg.train.micro_batch_size = 4
 
     cfg.model.moe_flex_dispatcher_backend = "hybridep"
-    cfg.model.moe_router_force_load_balancing = True
+    cfg.model.moe_router_force_load_balancing = False
 
     cfg.model.cuda_graph_impl = "transformer_engine"
     cfg.model.cuda_graph_scope = ["attn", "mamba", "moe_router", "moe_preprocess"]

--- a/src/megatron/bridge/perf_recipes/nemotronh/h100/nemotronh.py
+++ b/src/megatron/bridge/perf_recipes/nemotronh/h100/nemotronh.py
@@ -57,7 +57,7 @@ def nemotron_3_nano_pretrain_16gpu_h100_bf16_config() -> ConfigContainer:
     cfg.train.global_batch_size = 1024
     cfg.train.micro_batch_size = 1
 
-    cfg.model.moe_router_force_load_balancing = True
+    cfg.model.moe_router_force_load_balancing = False
 
     cfg.model.cuda_graph_impl = "transformer_engine"
     cfg.model.cuda_graph_scope = ["attn", "mamba"]
@@ -86,7 +86,7 @@ def nemotron_3_nano_pretrain_16gpu_h100_fp8cs_config() -> ConfigContainer:
     cfg.train.global_batch_size = 1024
     cfg.train.micro_batch_size = 1
 
-    cfg.model.moe_router_force_load_balancing = True
+    cfg.model.moe_router_force_load_balancing = False
 
     cfg.model.cuda_graph_impl = "transformer_engine"
     cfg.model.cuda_graph_scope = ["mamba"]

--- a/src/megatron/bridge/perf_recipes/qwen/b200/qwen3_moe.py
+++ b/src/megatron/bridge/perf_recipes/qwen/b200/qwen3_moe.py
@@ -136,7 +136,7 @@ def qwen3_30b_a3b_pretrain_8gpu_b200_bf16_config() -> ConfigContainer:
     cfg.model.moe_router_fusion = True
     cfg.model.seq_length = 4096
     cfg.dataset.seq_length = 4096
-    cfg.model.moe_router_force_load_balancing = True
+    cfg.model.moe_router_force_load_balancing = False
 
     cfg.model.tensor_model_parallel_size = 1
     cfg.model.pipeline_model_parallel_size = 1
@@ -170,7 +170,7 @@ def qwen3_30b_a3b_pretrain_8gpu_b200_fp8cs_config() -> ConfigContainer:
     cfg.model.moe_router_fusion = True
     cfg.model.seq_length = 4096
     cfg.dataset.seq_length = 4096
-    cfg.model.moe_router_force_load_balancing = True
+    cfg.model.moe_router_force_load_balancing = False
 
     cfg.model.tensor_model_parallel_size = 1
     cfg.model.pipeline_model_parallel_size = 1
@@ -204,7 +204,7 @@ def qwen3_30b_a3b_pretrain_8gpu_b200_fp8mx_config() -> ConfigContainer:
     cfg.model.moe_router_fusion = True
     cfg.model.seq_length = 4096
     cfg.dataset.seq_length = 4096
-    cfg.model.moe_router_force_load_balancing = True
+    cfg.model.moe_router_force_load_balancing = False
 
     cfg.model.tensor_model_parallel_size = 1
     cfg.model.pipeline_model_parallel_size = 1

--- a/src/megatron/bridge/perf_recipes/qwen/b300/qwen3_moe.py
+++ b/src/megatron/bridge/perf_recipes/qwen/b300/qwen3_moe.py
@@ -132,7 +132,7 @@ def qwen3_30b_a3b_pretrain_8gpu_b300_bf16_config() -> ConfigContainer:
     cfg.model.moe_router_fusion = True
     cfg.model.seq_length = 4096
     cfg.dataset.seq_length = 4096
-    cfg.model.moe_router_force_load_balancing = True
+    cfg.model.moe_router_force_load_balancing = False
 
     cfg.model.tensor_model_parallel_size = 1
     cfg.model.pipeline_model_parallel_size = 1
@@ -166,7 +166,7 @@ def qwen3_30b_a3b_pretrain_8gpu_b300_fp8cs_config() -> ConfigContainer:
     cfg.model.moe_router_fusion = True
     cfg.model.seq_length = 4096
     cfg.dataset.seq_length = 4096
-    cfg.model.moe_router_force_load_balancing = True
+    cfg.model.moe_router_force_load_balancing = False
 
     cfg.model.tensor_model_parallel_size = 1
     cfg.model.pipeline_model_parallel_size = 1
@@ -200,7 +200,7 @@ def qwen3_30b_a3b_pretrain_8gpu_b300_fp8mx_config() -> ConfigContainer:
     cfg.model.moe_router_fusion = True
     cfg.model.seq_length = 4096
     cfg.dataset.seq_length = 4096
-    cfg.model.moe_router_force_load_balancing = True
+    cfg.model.moe_router_force_load_balancing = False
 
     cfg.model.tensor_model_parallel_size = 1
     cfg.model.pipeline_model_parallel_size = 1

--- a/src/megatron/bridge/perf_recipes/qwen/common.py
+++ b/src/megatron/bridge/perf_recipes/qwen/common.py
@@ -33,19 +33,10 @@ def _with_global_batch_size(cfg: ConfigContainer, global_batch_size: int) -> Con
     return cfg
 
 
-def _enable_hybridep_full_iteration_mxfp8(cfg: ConfigContainer) -> None:
-    cfg.model.cuda_graph_impl = "full_iteration"
-    cfg.model.cuda_graph_scope = []
+def _enable_hybridep_mxfp8_common(cfg: ConfigContainer) -> None:
+    """Apply settings shared by partial and full-iteration MXFP8 recipes."""
     cfg.rng.te_rng_tracker = True
     cfg.model.use_te_rng_tracker = True
-
-    cfg.model.offload_modules = []
-    cfg.model.moe_pad_experts_for_cuda_graph_inference = True
-    cfg.model.moe_paged_stash = True
-    cfg.model.moe_expert_rank_capacity_factor = 1.5
-    cfg.model.moe_paged_stash_buffer_size_factor_cuda = 1.2
-    cfg.model.moe_paged_stash_buffer_size_factor_cpu = 1.0
-
     cfg.model.moe_shared_expert_overlap = False
     cfg.model.high_priority_a2a_comm_stream = True
     cfg.model.use_transformer_engine_op_fuser = True
@@ -58,3 +49,24 @@ def _enable_hybridep_full_iteration_mxfp8(cfg: ConfigContainer) -> None:
         overlap_moe_expert_parallel_comm=True,
         delay_wgrad_compute=True,
     )
+
+
+def _enable_hybridep_partial_mxfp8(cfg: ConfigContainer) -> None:
+    """Use TE module graphs without full-iteration-only paged-stash settings."""
+    cfg.model.cuda_graph_impl = "transformer_engine"
+    cfg.model.cuda_graph_scope = ["attn", "moe_router", "moe_preprocess"]
+    _enable_hybridep_mxfp8_common(cfg)
+
+
+def _enable_hybridep_full_iteration_mxfp8(cfg: ConfigContainer) -> None:
+    cfg.model.cuda_graph_impl = "full_iteration"
+    cfg.model.cuda_graph_scope = []
+
+    cfg.model.offload_modules = []
+    cfg.model.moe_pad_experts_for_cuda_graph_inference = True
+    cfg.model.moe_paged_stash = True
+    cfg.model.moe_expert_rank_capacity_factor = 1.5
+    cfg.model.moe_paged_stash_buffer_size_factor_cuda = 1.2
+    cfg.model.moe_paged_stash_buffer_size_factor_cpu = 1.0
+
+    _enable_hybridep_mxfp8_common(cfg)

--- a/src/megatron/bridge/perf_recipes/qwen/gb200/qwen3_moe.py
+++ b/src/megatron/bridge/perf_recipes/qwen/gb200/qwen3_moe.py
@@ -137,7 +137,7 @@ def qwen3_30b_a3b_pretrain_8gpu_gb200_bf16_config() -> ConfigContainer:
     cfg.model.moe_router_fusion = True
     cfg.model.seq_length = 4096
     cfg.dataset.seq_length = 4096
-    cfg.model.moe_router_force_load_balancing = True
+    cfg.model.moe_router_force_load_balancing = False
 
     cfg.model.tensor_model_parallel_size = 1
     cfg.model.pipeline_model_parallel_size = 1
@@ -171,7 +171,7 @@ def qwen3_30b_a3b_pretrain_8gpu_gb200_fp8cs_config() -> ConfigContainer:
     cfg.model.moe_router_fusion = True
     cfg.model.seq_length = 4096
     cfg.dataset.seq_length = 4096
-    cfg.model.moe_router_force_load_balancing = True
+    cfg.model.moe_router_force_load_balancing = False
 
     cfg.model.tensor_model_parallel_size = 1
     cfg.model.pipeline_model_parallel_size = 1
@@ -205,7 +205,7 @@ def qwen3_30b_a3b_pretrain_8gpu_gb200_fp8mx_config() -> ConfigContainer:
     cfg.model.moe_router_fusion = True
     cfg.model.seq_length = 4096
     cfg.dataset.seq_length = 4096
-    cfg.model.moe_router_force_load_balancing = True
+    cfg.model.moe_router_force_load_balancing = False
 
     cfg.model.tensor_model_parallel_size = 1
     cfg.model.pipeline_model_parallel_size = 1

--- a/src/megatron/bridge/perf_recipes/qwen/gb200/qwen3_moe.py
+++ b/src/megatron/bridge/perf_recipes/qwen/gb200/qwen3_moe.py
@@ -18,6 +18,7 @@ from megatron.bridge.perf_recipes.qwen.common import (
     ConfigContainer,
     _benchmark_common,
     _enable_hybridep_full_iteration_mxfp8,
+    _enable_hybridep_partial_mxfp8,
     _perf_precision,
     _with_global_batch_size,
     qwen3_30b_a3b_pretrain_config,
@@ -220,7 +221,10 @@ def qwen3_30b_a3b_pretrain_8gpu_gb200_fp8mx_config() -> ConfigContainer:
     cfg.model.moe_token_dispatcher_type = "flex"
 
     _benchmark_common(cfg)
-    _enable_hybridep_full_iteration_mxfp8(cfg)
+    # Natural routing makes expert token shapes dynamic. Keep this measured GB200
+    # fix targeted; sibling GPU presets retain full-iteration graphs until they
+    # are validated independently on their own topology.
+    _enable_hybridep_partial_mxfp8(cfg)
     return cfg
 
 

--- a/src/megatron/bridge/perf_recipes/qwen/gb300/qwen3_moe.py
+++ b/src/megatron/bridge/perf_recipes/qwen/gb300/qwen3_moe.py
@@ -136,7 +136,7 @@ def qwen3_30b_a3b_pretrain_8gpu_gb300_bf16_config() -> ConfigContainer:
     cfg.model.moe_router_fusion = True
     cfg.model.seq_length = 4096
     cfg.dataset.seq_length = 4096
-    cfg.model.moe_router_force_load_balancing = True
+    cfg.model.moe_router_force_load_balancing = False
 
     cfg.model.tensor_model_parallel_size = 1
     cfg.model.pipeline_model_parallel_size = 1
@@ -170,7 +170,7 @@ def qwen3_30b_a3b_pretrain_8gpu_gb300_fp8cs_config() -> ConfigContainer:
     cfg.model.moe_router_fusion = True
     cfg.model.seq_length = 4096
     cfg.dataset.seq_length = 4096
-    cfg.model.moe_router_force_load_balancing = True
+    cfg.model.moe_router_force_load_balancing = False
 
     cfg.model.tensor_model_parallel_size = 1
     cfg.model.pipeline_model_parallel_size = 1
@@ -204,7 +204,7 @@ def qwen3_30b_a3b_pretrain_8gpu_gb300_fp8mx_config() -> ConfigContainer:
     cfg.model.moe_router_fusion = True
     cfg.model.seq_length = 4096
     cfg.dataset.seq_length = 4096
-    cfg.model.moe_router_force_load_balancing = True
+    cfg.model.moe_router_force_load_balancing = False
 
     cfg.model.tensor_model_parallel_size = 1
     cfg.model.pipeline_model_parallel_size = 1

--- a/src/megatron/bridge/perf_recipes/qwen/h100/qwen3_moe.py
+++ b/src/megatron/bridge/perf_recipes/qwen/h100/qwen3_moe.py
@@ -37,7 +37,7 @@ def qwen3_30b_a3b_pretrain_16gpu_h100_bf16_config() -> ConfigContainer:
     cfg.model.moe_router_fusion = True
     cfg.model.seq_length = 4096
     cfg.dataset.seq_length = 4096
-    cfg.model.moe_router_force_load_balancing = True
+    cfg.model.moe_router_force_load_balancing = False
 
     cfg.model.tensor_model_parallel_size = 1
     cfg.model.pipeline_model_parallel_size = 1
@@ -72,7 +72,7 @@ def qwen3_30b_a3b_pretrain_16gpu_h100_fp8cs_config() -> ConfigContainer:
     cfg.model.moe_router_fusion = True
     cfg.model.seq_length = 4096
     cfg.dataset.seq_length = 4096
-    cfg.model.moe_router_force_load_balancing = True
+    cfg.model.moe_router_force_load_balancing = False
 
     cfg.model.tensor_model_parallel_size = 1
     cfg.model.pipeline_model_parallel_size = 1

--- a/tests/unit_tests/recipes/test_moe_perf_recipes.py
+++ b/tests/unit_tests/recipes/test_moe_perf_recipes.py
@@ -1,0 +1,110 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib
+
+import pytest
+
+from megatron.bridge.perf_recipes.deepseek.gb200.deepseek_v3 import (
+    deepseek_v3_pretrain_256gpu_gb200_fp8mx_config,
+)
+from megatron.bridge.perf_recipes.gpt_oss.gb200.gpt_oss import (
+    gpt_oss_120b_pretrain_64gpu_gb200_fp8mx_config,
+)
+from megatron.bridge.perf_recipes.qwen.gb200.qwen3_moe import (
+    qwen3_30b_a3b_pretrain_8gpu_gb200_fp8mx_config,
+    qwen3_235b_a22b_pretrain_64gpu_gb200_fp8mx_config,
+)
+from tests.unit_tests.recipes.recipe_test_utils import patch_recipe_module_global
+
+
+class _FakeModelCfg:
+    """Minimal model provider for Qwen and DeepSeek recipe construction."""
+
+    def __init__(self):
+        self.apply_rope_fusion = False
+        self.context_parallel_size = 1
+        self.cross_entropy_fusion_impl = "native"
+        self.make_vocab_size_divisible_by = 128
+        self.moe_expert_rank_capacity_factor = None
+        self.moe_pad_experts_for_cuda_graph_inference = False
+        self.moe_paged_stash = False
+        self.num_moe_experts = 0
+        self.rotary_base = 10000.0
+        self.vocab_size = 1024
+
+    def finalize(self):
+        return None
+
+
+class _FakeBridge:
+    @staticmethod
+    def from_hf_pretrained(hf_path: str, **kwargs):
+        return _FakeBridge()
+
+    def to_megatron_provider(self, load_weights: bool = False):
+        return _FakeModelCfg()
+
+
+@pytest.fixture(autouse=True)
+def _patch_hf_bridges(monkeypatch: pytest.MonkeyPatch):
+    """Keep perf-recipe tests independent of the HF cache and network."""
+    for module_name in (
+        "megatron.bridge.recipes.deepseek.deepseek_v3",
+        "megatron.bridge.recipes.gpt_oss.h100.gpt_oss",
+        "megatron.bridge.recipes.qwen.qwen3_moe",
+    ):
+        module = importlib.import_module(module_name)
+        patch_recipe_module_global(monkeypatch, module, "AutoBridge", _FakeBridge)
+
+
+@pytest.mark.parametrize(
+    "recipe",
+    [
+        deepseek_v3_pretrain_256gpu_gb200_fp8mx_config,
+        gpt_oss_120b_pretrain_64gpu_gb200_fp8mx_config,
+        qwen3_30b_a3b_pretrain_8gpu_gb200_fp8mx_config,
+    ],
+)
+def test_moe_perf_recipes_use_natural_router_loads(recipe):
+    cfg = recipe()
+
+    assert cfg.model.moe_router_force_load_balancing is False
+    assert cfg.model.use_transformer_engine_op_fuser is True
+
+
+def test_qwen3_30b_gb200_natural_routing_avoids_full_iteration_graphs():
+    cfg = qwen3_30b_a3b_pretrain_8gpu_gb200_fp8mx_config()
+
+    assert cfg.model.cuda_graph_impl == "transformer_engine"
+    assert cfg.model.cuda_graph_scope == ["attn", "moe_router", "moe_preprocess"]
+    assert cfg.model.moe_paged_stash is False
+    assert cfg.model.moe_pad_experts_for_cuda_graph_inference is False
+    assert cfg.model.moe_expert_rank_capacity_factor is None
+
+
+def test_qwen3_existing_full_iteration_graph_settings_are_preserved():
+    cfg = qwen3_235b_a22b_pretrain_64gpu_gb200_fp8mx_config()
+
+    assert cfg.model.cuda_graph_impl == "full_iteration"
+    assert cfg.model.cuda_graph_scope == []
+    assert cfg.model.moe_paged_stash is True
+    assert cfg.model.moe_pad_experts_for_cuda_graph_inference is True
+    assert cfg.model.moe_expert_rank_capacity_factor == 1.5
+    assert cfg.rng.te_rng_tracker is True
+    assert cfg.model.use_te_rng_tracker is True
+    assert cfg.model.use_transformer_engine_op_fuser is True
+    assert cfg.comm_overlap.tp_comm_overlap is True
+    assert cfg.comm_overlap.overlap_moe_expert_parallel_comm is True
+    assert cfg.comm_overlap.delay_wgrad_compute is True

--- a/uv.lock
+++ b/uv.lock
@@ -22,7 +22,7 @@ overrides = [
     { name = "onnx", marker = "python_full_version < '3.13'", specifier = ">=1.21.0" },
     { name = "torch", marker = "sys_platform == 'never'" },
     { name = "torchvision", marker = "sys_platform == 'never'" },
-    { name = "transformer-engine", git = "https://github.com/NVIDIA/TransformerEngine.git?rev=d64bc14dc87eb658ab98839e4b7687595ee53e2d" },
+    { name = "transformer-engine", git = "https://github.com/NVIDIA/TransformerEngine.git?rev=b9d690e042b1c4e455214e7dab65d6d3512c05d6" },
     { name = "triton", marker = "sys_platform == 'never'" },
     { name = "urllib3", specifier = ">=2.6.3" },
 ]
@@ -4854,8 +4854,8 @@ wheels = [
 
 [[package]]
 name = "transformer-engine"
-version = "2.16.0+d64bc14d"
-source = { git = "https://github.com/NVIDIA/TransformerEngine.git?rev=d64bc14dc87eb658ab98839e4b7687595ee53e2d#d64bc14dc87eb658ab98839e4b7687595ee53e2d" }
+version = "2.16.0+b9d690e0"
+source = { git = "https://github.com/NVIDIA/TransformerEngine.git?rev=b9d690e042b1c4e455214e7dab65d6d3512c05d6#b9d690e042b1c4e455214e7dab65d6d3512c05d6" }
 dependencies = [
     { name = "einops" },
     { name = "importlib-metadata" },


### PR DESCRIPTION
# What does this PR do?

Use natural MoE router loads in the affected performance recipes and keep the Qwen3 30B 8-GPU GB200 MXFP8 path functional under dynamic expert token shapes.

# Changelog

- disable forced router load balancing in the targeted MoE performance recipes
- pin Transformer Engine to the compatible grouped-MLP pointer implementation
- use Transformer Engine module graphs for Qwen3 30B GB200 MXFP8 instead of full-iteration paged-stash assumptions
- add offline recipe regression tests and preserve coverage for existing full-iteration recipes

# Validation

- `uv lock --check`
- Ruff lint and formatting checks
- 50/50 distributed training iterations completed with zero skipped or NaN iterations
- no grouped-MLP pointer error, OOM, or NCCL watchdog
- convergence and memory validation passed
- the matching CI performance baseline is being updated separately because forced and natural routing are different workloads
- full GitHub CI was manually requested and is awaiting runner vetting

# Before ready for review

- [x] Added regression tests
- [x] Updated dependency lock data
- [ ] Full GitHub CI completed
