### PR TITLE
fix(model): resolve Gemma 4 architecture bugs

### DIFF
--- a/examples/models/gemma/gemma4/parity_check_e4b.py
+++ b/examples/models/gemma/gemma4/parity_check_e4b.py
@@ -69,7 +69,6 @@ from megatron.training import print_rank_0
 SEQ = 16
 BATCH = 1
 FULL_VOCAB = 262144
-LOGIT_SOFTCAP = 30.0
 
 # Audio-mode constants (based on audio_tower checkpoint analysis)
 AUDIO_MEL_BINS = 128  # mel-spectrogram frequency bins
@@ -367,19 +366,18 @@ def _forward_audio(model, input_ids_audio, audio_features):
 
 
 # ---------------------------------------------------------------------------
-# Logit gathering + softcapping
+# Logit gathering
 # ---------------------------------------------------------------------------
 
 
-def _gather_and_cap(logits, mpu):
-    """All-gather TP vocab shards, trim to FULL_VOCAB, apply softcapping."""
+def _gather_logits(logits, mpu):
+    """All-gather TP vocab shards and trim to FULL_VOCAB."""
     tp = mpu.get_tensor_model_parallel_world_size()
     if tp > 1:
         parts = [torch.zeros_like(logits) for _ in range(tp)]
         dist.all_gather(parts, logits.contiguous(), group=mpu.get_tensor_model_parallel_group())
         logits = torch.cat(parts, dim=-1)
-    raw = logits[..., :FULL_VOCAB].cpu().float()
-    return torch.tanh(raw / LOGIT_SOFTCAP) * LOGIT_SOFTCAP
+    return logits[..., :FULL_VOCAB].cpu().float()
 
 
 # ---------------------------------------------------------------------------
@@ -556,7 +554,6 @@ def _report(mode, megatron_logits, hf_logits, atol, seq_len=None):
 
     print_rank_0(f"\n{'=' * 70}")
     print_rank_0(f"  Parity [{mode.upper()}]: {mode_labels[mode]}")
-    print_rank_0(f"  (Megatron logits softcapped at {LOGIT_SOFTCAP} before comparison)")
     print_rank_0(f"  seq={seq_len}  batch={BATCH}  vocab={FULL_VOCAB}")
     print_rank_0(f"  max |diff|  : {max_diff:.6f}  (atol={atol})")
     print_rank_0(f"  mean |diff| : {mean_diff:.6f}")
@@ -630,7 +627,7 @@ def main():
     else:
         logits = _forward_audio(model, input_ids_audio, audio_features)
 
-    megatron_logits = _gather_and_cap(logits, mpu)
+    megatron_logits = _gather_logits(logits, mpu)
 
     del model, models, logits
     torch.cuda.empty_cache()

--- a/src/megatron/bridge/models/gemma/gemma4_bridge.py
+++ b/src/megatron/bridge/models/gemma/gemma4_bridge.py
@@ -177,6 +177,7 @@ class Gemma4Bridge(MegatronModelBridge):
             full_attention_rope_base=full_rope.get("rope_theta", 1000000.0),
             full_attention_rope_partial_factor=full_rope.get("partial_rotary_factor", 0.25),
             num_kv_shared_layers=getattr(hf_config, "num_kv_shared_layers", 0),
+            use_double_wide_mlp=getattr(hf_config, "use_double_wide_mlp", False),
             per_layer_embed_vocab_size=getattr(hf_config, "vocab_size_per_layer_input", hf_config.vocab_size),
             per_layer_embed_dim=getattr(hf_config, "hidden_size_per_layer_input", 256),
             final_logit_softcapping=getattr(hf_config, "final_logit_softcapping", None),
@@ -245,34 +246,6 @@ class Gemma4Bridge(MegatronModelBridge):
             if hf_name not in hf_state_dict:
                 continue
 
-            if hf_name.endswith("router.proj.weight"):
-                layer_match = re.search(r"layers\.(\d+)\.", hf_name)
-                if layer_match:
-                    layer_idx = layer_match.group(1)
-                    prefix = hf_name.rsplit("layers.", 1)[0]
-                    scale_key = f"{prefix}layers.{layer_idx}.router.scale"
-                    ln2_key = f"{prefix}layers.{layer_idx}.pre_feedforward_layernorm_2.weight"
-                    if scale_key in hf_state_dict and ln2_key in hf_state_dict:
-                        router_scale = hf_state_dict[scale_key].float().to(tensor.device)
-                        ln2_weight = hf_state_dict[ln2_key].float().to(tensor.device)
-                        hidden_size = tensor.shape[-1]
-                        scalar_root_size = hidden_size**-0.5
-                        fusion_factor = router_scale * scalar_root_size / ln2_weight
-                        tensor = (tensor.float() / fusion_factor.unsqueeze(0)).to(tensor.dtype)
-
-            elif hf_name.endswith(("mlp.gate_proj.weight", "mlp.up_proj.weight")) and "experts" not in hf_name:
-                layer_match = re.search(r"layers\.(\d+)\.", hf_name)
-                if layer_match:
-                    layer_idx = layer_match.group(1)
-                    prefix = hf_name.rsplit("layers.", 1)[0]
-                    pffl_key = f"{prefix}layers.{layer_idx}.pre_feedforward_layernorm.weight"
-                    pffl2_key = f"{prefix}layers.{layer_idx}.pre_feedforward_layernorm_2.weight"
-                    if pffl_key in hf_state_dict and pffl2_key in hf_state_dict:
-                        w_pffl = hf_state_dict[pffl_key].float().to(tensor.device)
-                        w_pffl2 = hf_state_dict[pffl2_key].float().to(tensor.device)
-                        correction = w_pffl / w_pffl2
-                        tensor = (tensor.float() / correction.unsqueeze(0)).to(tensor.dtype)
-
             result[hf_name] = tensor
 
         return result
@@ -319,55 +292,7 @@ class Gemma4Bridge(MegatronModelBridge):
                         hf_weights[role] = hf_state_dict[name]
                 return hf_weights
 
-        if isinstance(hf_param, dict) and "gate" in hf_param:
-            gate_name = hf_param["gate"]
-            if "mlp.gate_proj" in gate_name:
-                return self._fuse_shared_expert_prenorm(hf_param, hf_state_dict)
-
-        if isinstance(hf_param, str) and hf_param.endswith("router.proj.weight"):
-            return self._fuse_router_weight(hf_param, hf_state_dict)
-
         return super().maybe_modify_loaded_hf_weight(hf_param, hf_state_dict)
-
-    def _fuse_router_weight(self, hf_param: str, hf_state_dict: Mapping[str, torch.Tensor]) -> torch.Tensor:
-        proj_weight = hf_state_dict[hf_param]
-        layer_match = re.search(r"layers\.(\d+)\.", hf_param)
-        if layer_match is None:
-            return proj_weight
-        layer_idx = layer_match.group(1)
-        scale_key = f"model.layers.{layer_idx}.router.scale"
-        ln2_key = f"model.layers.{layer_idx}.pre_feedforward_layernorm_2.weight"
-        if scale_key not in hf_state_dict or ln2_key not in hf_state_dict:
-            return proj_weight
-        router_scale = hf_state_dict[scale_key].float()
-        ln2_weight = hf_state_dict[ln2_key].float()
-        hidden_size = proj_weight.shape[-1]
-        scalar_root_size = hidden_size**-0.5
-        fusion_factor = router_scale * scalar_root_size / ln2_weight
-        fused_weight = proj_weight.float() * fusion_factor.unsqueeze(0)
-        return fused_weight.to(proj_weight.dtype)
-
-    def _fuse_shared_expert_prenorm(
-        self, hf_param: dict[str, str], hf_state_dict: Mapping[str, torch.Tensor]
-    ) -> dict[str, torch.Tensor]:
-        gate_name = hf_param["gate"]
-        layer_match = re.search(r"layers\.(\d+)\.", gate_name)
-        if layer_match is None:
-            return {role: hf_state_dict[name] for role, name in hf_param.items()}
-        layer_idx = layer_match.group(1)
-        pffl_key = f"model.layers.{layer_idx}.pre_feedforward_layernorm.weight"
-        pffl2_key = f"model.layers.{layer_idx}.pre_feedforward_layernorm_2.weight"
-        if pffl_key not in hf_state_dict or pffl2_key not in hf_state_dict:
-            return {role: hf_state_dict[name] for role, name in hf_param.items()}
-        w_pffl = hf_state_dict[pffl_key].float()
-        w_pffl2 = hf_state_dict[pffl2_key].float()
-        correction = w_pffl / w_pffl2
-        hf_weights = {}
-        for role, name in hf_param.items():
-            weight = hf_state_dict[name]
-            fused = weight.float() * correction.unsqueeze(0)
-            hf_weights[role] = fused.to(weight.dtype)
-        return hf_weights
 
     def mapping_registry(self) -> MegatronMappingRegistry:
         if self._is_dense_config():
@@ -451,7 +376,7 @@ class Gemma4Bridge(MegatronModelBridge):
             ),
             "decoder.layers.*.pre_mlp_layernorm.weight": "model.layers.*.pre_feedforward_layernorm_2.weight",
             "decoder.layers.*.mlp.shared_experts.linear_fc2.weight": "model.layers.*.mlp.down_proj.weight",
-            "decoder.layers.*.mlp.shared_experts.linear_fc2.post_layernorm.weight": (
+            "decoder.layers.*.mlp.post_shared_expert_layernorm.weight": (
                 "model.layers.*.post_feedforward_layernorm_1.weight"
             ),
             "decoder.layers.*.mlp.router.weight": "model.layers.*.router.proj.weight",

--- a/src/megatron/bridge/models/gemma/gemma4_bridge.py
+++ b/src/megatron/bridge/models/gemma/gemma4_bridge.py
@@ -159,6 +159,8 @@ class Gemma4Bridge(MegatronModelBridge):
         if layer_types is not None:
             layer_types = [layer_type == "sliding_attention" for layer_type in layer_types]
 
+        sliding_window = getattr(hf_config, "sliding_window", 512)
+
         return Gemma4DenseProvider(
             num_layers=hf_config.num_hidden_layers,
             hidden_size=hf_config.hidden_size,
@@ -172,12 +174,14 @@ class Gemma4Bridge(MegatronModelBridge):
             vocab_size=hf_config.vocab_size,
             normalization="RMSNorm",
             layernorm_epsilon=hf_config.rms_norm_eps,
+            window_size=(sliding_window - 1, 0),
             window_attn_skip_freq=layer_types if layer_types is not None else 6,
             sliding_window_rope_base=sliding_rope.get("rope_theta", 10000.0),
             full_attention_rope_base=full_rope.get("rope_theta", 1000000.0),
             full_attention_rope_partial_factor=full_rope.get("partial_rotary_factor", 0.25),
             num_kv_shared_layers=getattr(hf_config, "num_kv_shared_layers", 0),
             use_double_wide_mlp=getattr(hf_config, "use_double_wide_mlp", False),
+            attention_k_eq_v=getattr(hf_config, "attention_k_eq_v", False),
             per_layer_embed_vocab_size=getattr(hf_config, "vocab_size_per_layer_input", hf_config.vocab_size),
             per_layer_embed_dim=getattr(hf_config, "hidden_size_per_layer_input", 256),
             final_logit_softcapping=getattr(hf_config, "final_logit_softcapping", None),
@@ -202,6 +206,7 @@ class Gemma4Bridge(MegatronModelBridge):
 
         provider.global_head_dim = getattr(hf_config, "global_head_dim", 512)
         provider.num_global_key_value_heads = getattr(hf_config, "num_global_key_value_heads", 2)
+        provider.attention_k_eq_v = getattr(hf_config, "attention_k_eq_v", False)
 
         rope_params = getattr(hf_config, "rope_parameters", {})
         if isinstance(rope_params, dict):
@@ -231,9 +236,30 @@ class Gemma4Bridge(MegatronModelBridge):
 
     @classmethod
     def megatron_to_hf_config(cls, provider: Gemma4ModelProvider | Gemma4DenseProvider) -> dict:
-        """Convert a Gemma 4 provider config back to Hugging Face config."""
+        """Preserve Gemma 4 architecture fields affected by provider conversion."""
         hf_config = super().megatron_to_hf_config(provider)
-        hf_config["final_logit_softcapping"] = provider.final_logit_softcapping
+        is_moe = provider.num_moe_experts is not None
+        window_size = provider.window_size
+        hf_config.update(
+            {
+                "attention_k_eq_v": provider.attention_k_eq_v,
+                "enable_moe_block": is_moe,
+                "final_logit_softcapping": provider.final_logit_softcapping,
+                "num_kv_shared_layers": getattr(provider, "num_kv_shared_layers", 0),
+                "sliding_window": window_size[0] + 1 if isinstance(window_size, tuple) else window_size,
+                "use_double_wide_mlp": getattr(provider, "use_double_wide_mlp", False),
+            }
+        )
+        if is_moe:
+            hf_config.update(
+                {
+                    "intermediate_size": provider.moe_shared_expert_intermediate_size,
+                    "moe_intermediate_size": provider.moe_ffn_hidden_size,
+                    "num_experts": provider.num_moe_experts,
+                    "top_k_experts": provider.moe_router_topk,
+                }
+            )
+            hf_config.pop("num_experts_per_tok", None)
         return hf_config
 
     def maybe_modify_converted_hf_weight(self, task, converted_weights_dict, hf_state_dict):
@@ -417,7 +443,7 @@ class Gemma4Bridge(MegatronModelBridge):
                     hf_param="model.layers.*.router.scale",
                 ),
                 ReplicatedMapping(
-                    megatron_param="decoder.layers.*.pffl_weight",
+                    megatron_param="decoder.layers.*.pre_shared_expert_layernorm.weight",
                     hf_param="model.layers.*.pre_feedforward_layernorm.weight",
                 ),
                 ReplicatedMapping(

--- a/src/megatron/bridge/models/gemma/gemma4_bridge.py
+++ b/src/megatron/bridge/models/gemma/gemma4_bridge.py
@@ -94,6 +94,62 @@ def _infer_attn_pattern(layer_types: list[str]) -> tuple[int, int]:
     return (len(layer_types), 0)
 
 
+def _layer_types_from_provider(provider: Gemma4ModelProvider | Gemma4DenseProvider) -> list[str]:
+    """Reconstruct the Hugging Face per-layer attention pattern."""
+    if isinstance(provider, Gemma4DenseProvider):
+        pattern = provider.window_attn_skip_freq
+    else:
+        pattern = provider.interleaved_attn_pattern
+
+    if isinstance(pattern, list):
+        layer_types = [
+            value if isinstance(value, str) else "sliding_attention" if bool(value) else "full_attention"
+            for value in pattern
+        ]
+    elif isinstance(pattern, tuple) and len(pattern) == 2:
+        sliding_count, full_count = pattern
+        cycle = ["sliding_attention"] * sliding_count + ["full_attention"] * full_count
+        layer_types = [cycle[index % len(cycle)] for index in range(provider.num_layers)] if cycle else []
+    elif isinstance(pattern, int) and pattern > 0:
+        layer_types = [
+            "sliding_attention" if layer_number % pattern else "full_attention"
+            for layer_number in range(1, provider.num_layers + 1)
+        ]
+    else:
+        layer_types = ["full_attention"] * provider.num_layers
+
+    if layer_types:
+        layer_types[-1] = "full_attention"
+    return layer_types
+
+
+def _rope_parameters_from_provider(provider: Gemma4ModelProvider | Gemma4DenseProvider) -> dict[str, dict]:
+    """Reconstruct Gemma 4's dual local/global RoPE configuration."""
+    if isinstance(provider, Gemma4DenseProvider):
+        local_base = provider.sliding_window_rope_base
+        global_base = provider.full_attention_rope_base
+        global_partial_factor = provider.full_attention_rope_partial_factor
+    else:
+        rotary_base = provider.rotary_base
+        if isinstance(rotary_base, tuple):
+            local_base, global_base = rotary_base
+        else:
+            local_base = global_base = rotary_base
+        global_partial_factor = provider.global_rotary_percent
+
+    return {
+        "full_attention": {
+            "partial_rotary_factor": global_partial_factor,
+            "rope_theta": global_base,
+            "rope_type": "proportional",
+        },
+        "sliding_attention": {
+            "rope_theta": local_base,
+            "rope_type": "default",
+        },
+    }
+
+
 # ---------------------------------------------------------------------------
 # Gemma4Bridge — text-only CausalLM bridge (MoE and Dense)
 # ---------------------------------------------------------------------------
@@ -238,6 +294,11 @@ class Gemma4Bridge(MegatronModelBridge):
     def megatron_to_hf_config(cls, provider: Gemma4ModelProvider | Gemma4DenseProvider) -> dict:
         """Preserve Gemma 4 architecture fields affected by provider conversion."""
         hf_config = super().megatron_to_hf_config(provider)
+        dtype = hf_config.pop("torch_dtype", None)
+        if dtype is not None:
+            hf_config["dtype"] = dtype
+        hf_config.pop("partial_rotary_factor", None)
+        hf_config.pop("rope_theta", None)
         is_moe = provider.num_moe_experts is not None
         window_size = provider.window_size
         hf_config.update(
@@ -245,9 +306,17 @@ class Gemma4Bridge(MegatronModelBridge):
                 "attention_k_eq_v": provider.attention_k_eq_v,
                 "enable_moe_block": is_moe,
                 "final_logit_softcapping": provider.final_logit_softcapping,
+                "global_head_dim": (provider.global_head_dim if is_moe else provider.global_kv_channels),
+                "hidden_size_per_layer_input": getattr(provider, "per_layer_embed_dim", 0),
+                "layer_types": _layer_types_from_provider(provider),
                 "num_kv_shared_layers": getattr(provider, "num_kv_shared_layers", 0),
+                "num_global_key_value_heads": (
+                    provider.num_global_key_value_heads if is_moe else provider.num_global_query_groups
+                ),
+                "rope_parameters": _rope_parameters_from_provider(provider),
                 "sliding_window": window_size[0] + 1 if isinstance(window_size, tuple) else window_size,
                 "use_double_wide_mlp": getattr(provider, "use_double_wide_mlp", False),
+                "vocab_size_per_layer_input": getattr(provider, "per_layer_embed_vocab_size", provider.vocab_size),
             }
         )
         if is_moe:

--- a/src/megatron/bridge/models/gemma/gemma4_provider.py
+++ b/src/megatron/bridge/models/gemma/gemma4_provider.py
@@ -143,6 +143,7 @@ class Gemma4DenseProvider(GPTModelProvider):
     full_attention_rope_base: float = 1000000.0
     full_attention_rope_partial_factor: float = 0.25
     num_kv_shared_layers: int = 18
+    use_double_wide_mlp: bool = False
     per_layer_embed_vocab_size: int = 262144
     per_layer_embed_dim: int = 256
     final_logit_softcapping: float | None = 30.0

--- a/src/megatron/bridge/models/gemma/gemma4_provider.py
+++ b/src/megatron/bridge/models/gemma/gemma4_provider.py
@@ -14,7 +14,7 @@
 
 """Gemma 4 text-only model providers.
 
-Gemma4DenseProvider: Dense (E4B, ~3.8B) — builds GPTModel with local spec,
+Gemma4DenseProvider: Dense (E2B, E4B, and 31B) — builds GPTModel with local spec,
     dual RoPE, PLE, and shared KV.
 Gemma4ModelProvider: MoE (26B-A4B and similar) — extends GPTModelProvider
     with TE-based layer spec, dual RoPE, and softcapped output layer.

--- a/src/megatron/bridge/models/gemma/gemma4_provider.py
+++ b/src/megatron/bridge/models/gemma/gemma4_provider.py
@@ -46,6 +46,33 @@ from megatron.bridge.models.gemma.modules import extend_instance
 from megatron.bridge.models.gpt_provider import GPTModelProvider
 
 
+def _validate_gemma4_moe_orchestration(provider: GPTModelProvider) -> None:
+    """Reject MCore execution modes bypassed by Gemma 4's custom MoE forward."""
+    unsupported = []
+    if provider.transformer_impl == "inference_optimized":
+        unsupported.append("transformer_impl='inference_optimized'")
+    if provider.cuda_graph_impl != "none":
+        unsupported.append(f"cuda_graph_impl={provider.cuda_graph_impl!r}")
+    if provider.moe_shared_expert_overlap:
+        unsupported.append("moe_shared_expert_overlap=True")
+    if provider.mlp_chunks_for_prefill > 1:
+        unsupported.append("mlp_chunks_for_prefill > 1")
+    if provider.mlp_chunks_for_training > 1:
+        unsupported.append("mlp_chunks_for_training > 1")
+    if provider.inference_fuse_tp_communication:
+        unsupported.append("inference_fuse_tp_communication=True")
+    recompute_modules = set(provider.recompute_modules or [])
+    if provider.recompute_granularity == "selective" and "layernorm" in recompute_modules:
+        unsupported.append("selective layernorm recompute")
+    offload_modules = set(provider.offload_modules or [])
+    if provider.fine_grained_activation_offloading and "mlp_norm" in offload_modules:
+        unsupported.append("MLP norm activation offloading")
+    if unsupported:
+        raise ValueError(
+            "Gemma 4 MoE's separate router/shared/routed inputs do not yet support: " + ", ".join(unsupported)
+        )
+
+
 def _install_gemma4_dense_load_state_aliases(model: torch.nn.Module) -> None:
     """Translate Gemma4 Dense checkpoint attention aliases before load_state_dict.
 
@@ -90,13 +117,13 @@ def _install_gemma4_dense_load_state_aliases(model: torch.nn.Module) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Dense (E4B) provider
+# Dense provider
 # ---------------------------------------------------------------------------
 
 
 @dataclass
 class Gemma4DenseProvider(GPTModelProvider):
-    """Gemma-4 Dense (3.8B) model provider for clean Megatron-Core.
+    """Gemma 4 dense E2B, E4B, and 31B provider for clean Megatron-Core.
 
     All Gemma4-specific settings are encoded here as dataclass fields so that
     no Gemma4-specific CLI arguments are required.
@@ -139,6 +166,7 @@ class Gemma4DenseProvider(GPTModelProvider):
 
     global_kv_channels: int = 512
     num_global_query_groups: int = 2
+    attention_k_eq_v: bool = False
     sliding_window_rope_base: float = 10000.0
     full_attention_rope_base: float = 1000000.0
     full_attention_rope_partial_factor: float = 0.25
@@ -298,6 +326,10 @@ class Gemma4ModelProvider(GPTModelProvider):
     fp16: bool = False
     params_dtype: torch.dtype = torch.bfloat16
     autocast_dtype: torch.dtype = torch.bfloat16
+
+    def finalize(self) -> None:
+        _validate_gemma4_moe_orchestration(self)
+        super().finalize()
 
     def provide(self, pre_process=None, post_process=None, vp_stage=None) -> "MCoreGPTModel":
         """Configure and instantiate a Megatron Core Gemma 4 MoE model."""

--- a/src/megatron/bridge/models/gemma/gemma4_provider.py
+++ b/src/megatron/bridge/models/gemma/gemma4_provider.py
@@ -181,6 +181,8 @@ class Gemma4DenseProvider(GPTModelProvider):
     moe_ffn_hidden_size: Optional[int] = None
 
     def finalize(self) -> None:
+        if self.use_double_wide_mlp:
+            self.hetereogenous_dist_checkpoint = True
         super().finalize()
         self._gemma4_dense_finalized = True
 

--- a/src/megatron/bridge/models/gemma/modeling_gemma4.py
+++ b/src/megatron/bridge/models/gemma/modeling_gemma4.py
@@ -95,6 +95,11 @@ def _gemma4_rms_norm(hidden_states: Tensor, weight: Tensor | None, eps: float) -
     return normed_output.type_as(hidden_states)
 
 
+def _mark_sequence_parallel_parameter(parameter: nn.Parameter, config: TransformerConfig) -> None:
+    """Mark replicated parameters whose gradients span sequence-parallel shards."""
+    setattr(parameter, "sequence_parallel", bool(getattr(config, "sequence_parallel", False)))
+
+
 class Gemma4RMSNorm(nn.Module):
     """HF Gemma4-compatible RMSNorm.
 
@@ -118,6 +123,7 @@ class Gemma4RMSNorm(nn.Module):
         self.with_scale = with_scale
         if with_scale:
             self.weight = nn.Parameter(torch.ones(hidden_size, dtype=getattr(config, "params_dtype", torch.float32)))
+            _mark_sequence_parallel_parameter(self.weight, config)
         self.eps = eps
 
     def forward(self, hidden_states: Tensor) -> Tensor:
@@ -129,7 +135,12 @@ RMSNorm = Gemma4RMSNorm
 
 
 class Gemma4DenseMLP(MLP):
-    """Dense MLP that permits Gemma 4's layer-specific FFN widths."""
+    """Keep both MCore projections on Gemma 4's layer-specific FFN width.
+
+    MCore's FC1 accepts an explicit width, while FC2 reads it from the config.
+    Gemma 4 E2B doubles the final shared layers, so a shallow config copy keeps
+    both projections consistent without replacing MCore's optimized kernels.
+    """
 
     def __init__(
         self,
@@ -1263,7 +1274,11 @@ class Gemma4TransformerLayer(TransformerLayer):
     ) -> None:
         super().__init__(config=config, submodules=submodules, layer_number=layer_number, **kwargs)
         self.register_buffer("layer_scalar", torch.ones(1, dtype=config.params_dtype))
-        self.pffl_weight = nn.Parameter(torch.ones(config.hidden_size, dtype=config.params_dtype))
+        self.pre_shared_expert_layernorm = Gemma4RMSNorm(
+            config,
+            config.hidden_size,
+            eps=config.layernorm_epsilon,
+        )
         self.post_ffn_layernorm = Gemma4RMSNorm(config, config.hidden_size, eps=config.layernorm_epsilon)
 
     def _forward_mlp(
@@ -1282,7 +1297,7 @@ class Gemma4TransformerLayer(TransformerLayer):
         )
         shared_expert_input = _gemma4_rms_norm(
             residual,
-            self.pffl_weight,
+            self.pre_shared_expert_layernorm.weight,
             self.config.layernorm_epsilon,
         )
         mlp_output_with_bias = self.mlp.forward_with_separate_inputs(
@@ -1322,6 +1337,8 @@ class Gemma4TopKRouter(TopKRouter):
         super().__init__(config=config, **kwargs)
         self.per_expert_scale = nn.Parameter(torch.ones(config.num_moe_experts, dtype=config.params_dtype))
         self.scale = nn.Parameter(torch.ones(config.hidden_size, dtype=config.params_dtype))
+        _mark_sequence_parallel_parameter(self.per_expert_scale, config)
+        _mark_sequence_parallel_parameter(self.scale, config)
         self.scalar_root_size = config.hidden_size**-0.5
 
     def gating(self, input: Tensor) -> Tensor:

--- a/src/megatron/bridge/models/gemma/modeling_gemma4.py
+++ b/src/megatron/bridge/models/gemma/modeling_gemma4.py
@@ -49,7 +49,7 @@ from megatron.core.transformer.attention import SelfAttention, SelfAttentionSubm
 from megatron.core.transformer.enums import AttnMaskType
 from megatron.core.transformer.identity_op import IdentityOp
 from megatron.core.transformer.mlp import MLP, MLPSubmodules
-from megatron.core.transformer.moe.moe_layer import MoELayer
+from megatron.core.transformer.moe.moe_layer import MoELayer, te_checkpoint
 from megatron.core.transformer.moe.router import TopKRouter
 from megatron.core.transformer.spec_utils import ModuleSpec, get_submodules
 from megatron.core.transformer.transformer_config import TransformerConfig
@@ -1398,6 +1398,16 @@ class Gemma4MoELayer(MoELayer):
             return output, mlp_bias
 
         if self.moe_layer_recompute and self.training:
+            if self.config.fp8 or self.config.fp4:
+                return te_checkpoint(
+                    custom_forward,
+                    False,
+                    tensor_parallel.random.get_cuda_rng_tracker,
+                    self.tp_group,
+                    expert_input,
+                    shared_expert_input,
+                    router_input,
+                )
             return tensor_parallel.checkpoint(
                 custom_forward,
                 False,
@@ -1570,14 +1580,54 @@ class Gemma4SelfAttention(SelfAttention):
 
         return _fix(state_dict)
 
+    def _get_tied_query_key_value_tensors(
+        self,
+        hidden_states: Tensor,
+        key_value_states: Tensor | None = None,
+    ) -> tuple[Tensor, Tensor, Tensor]:
+        """Return independently normalized K and V from Gemma 4's shared raw projection."""
+        mixed_qkv, split_arg_list = super().get_query_key_value_tensors(
+            hidden_states,
+            key_value_states,
+            output_gate=False,
+            split_qkv=False,
+        )
+        query, raw_key, _value = torch.split(mixed_qkv, split_arg_list, dim=3)
+        key = raw_key
+
+        query = query.reshape(
+            query.size(0),
+            query.size(1),
+            -1,
+            self.hidden_size_per_attention_head,
+        )
+        if self.config.num_query_groups < self.world_size:
+            idx = get_pg_rank(self.pg_collection.tp) % (self.world_size // self.config.num_query_groups)
+            size = self.num_attention_heads_per_partition // (self.world_size // self.config.num_query_groups)
+            query = query[:, :, idx * size : (idx + 1) * size, :]
+
+        if self.q_layernorm is not None:
+            query = apply_module(self.q_layernorm)(query)
+        if self.k_layernorm is not None:
+            key = apply_module(self.k_layernorm)(key)
+        if self.config.test_mode:
+            self.run_realtime_tests()
+
+        return query, key, raw_key
+
     def get_query_key_value_tensors(self, hidden_states, key_value_states=None, **kwargs):
         """Override to apply v_norm and enforce K=V tying for global attention."""
+        if getattr(self, "_tied_kv", False) and kwargs.get("split_qkv", True) and not kwargs.get("output_gate", False):
+            query, key, value = self._get_tied_query_key_value_tensors(hidden_states, key_value_states)
+            v_float = value.float()
+            rms = v_float.pow(2).mean(-1, keepdim=True).add(self._v_norm_eps).sqrt()
+            value = (v_float / rms).to(value.dtype)
+            return query, key, value
+
         result = super().get_query_key_value_tensors(hidden_states, key_value_states, **kwargs)
         if len(result) < 3:
             return result
         query, key, value = result[0], result[1], result[2]
-        if getattr(self, "_tied_kv", False):
-            value = key
         v_float = value.float()
         rms = v_float.pow(2).mean(-1, keepdim=True).add(self._v_norm_eps).sqrt()
         value = (v_float / rms).to(value.dtype)

--- a/src/megatron/bridge/models/gemma/modeling_gemma4.py
+++ b/src/megatron/bridge/models/gemma/modeling_gemma4.py
@@ -32,13 +32,13 @@ import inspect
 import types
 import weakref
 from dataclasses import dataclass
-from functools import lru_cache
+from functools import lru_cache, partial
 from typing import TYPE_CHECKING, Optional, Tuple
 
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from megatron.core import parallel_state
+from megatron.core import parallel_state, tensor_parallel
 from megatron.core.fusions.fused_bias_dropout import get_bias_dropout_add
 from megatron.core.inference.contexts import BaseInferenceContext
 from megatron.core.models.backends import LocalSpecProvider
@@ -51,7 +51,7 @@ from megatron.core.transformer.identity_op import IdentityOp
 from megatron.core.transformer.mlp import MLP, MLPSubmodules
 from megatron.core.transformer.moe.moe_layer import MoELayer
 from megatron.core.transformer.moe.router import TopKRouter
-from megatron.core.transformer.spec_utils import ModuleSpec
+from megatron.core.transformer.spec_utils import ModuleSpec, get_submodules
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.transformer.transformer_layer import (
     LayerNormBuilder,
@@ -84,6 +84,17 @@ TEDotProductAttention, _ = safe_import_from("megatron.core.extensions.transforme
 # ---------------------------------------------------------------------------
 
 
+def _gemma4_rms_norm(hidden_states: Tensor, weight: Tensor | None, eps: float) -> Tensor:
+    """Apply the exact RMSNorm expression used by Hugging Face Gemma 4."""
+    normed_output = hidden_states.float() * torch.pow(
+        hidden_states.float().pow(2).mean(-1, keepdim=True) + eps,
+        -0.5,
+    )
+    if weight is not None:
+        normed_output = normed_output * weight.float()
+    return normed_output.type_as(hidden_states)
+
+
 class Gemma4RMSNorm(nn.Module):
     """HF Gemma4-compatible RMSNorm.
 
@@ -106,20 +117,46 @@ class Gemma4RMSNorm(nn.Module):
         super().__init__()
         self.with_scale = with_scale
         if with_scale:
-            self.weight = nn.Parameter(torch.ones(hidden_size))
+            self.weight = nn.Parameter(torch.ones(hidden_size, dtype=getattr(config, "params_dtype", torch.float32)))
         self.eps = eps
 
     def forward(self, hidden_states: Tensor) -> Tensor:
-        normed_output = hidden_states.float() * torch.pow(
-            hidden_states.float().pow(2).mean(-1, keepdim=True) + self.eps,
-            -0.5,
-        )
-        if self.with_scale:
-            normed_output = normed_output * self.weight.float()
-        return normed_output.type_as(hidden_states)
+        weight = self.weight if self.with_scale else None
+        return _gemma4_rms_norm(hidden_states, weight, self.eps)
 
 
 RMSNorm = Gemma4RMSNorm
+
+
+class Gemma4DenseMLP(MLP):
+    """Dense MLP that permits Gemma 4's layer-specific FFN widths."""
+
+    def __init__(
+        self,
+        config: TransformerConfig,
+        submodules: MLPSubmodules,
+        ffn_hidden_size: int | None = None,
+        **kwargs: object,
+    ) -> None:
+        ffn_hidden_size = config.ffn_hidden_size if ffn_hidden_size is None else ffn_hidden_size
+        layer_config = copy.copy(config)
+        layer_config.ffn_hidden_size = ffn_hidden_size
+        super().__init__(
+            config=layer_config,
+            submodules=submodules,
+            ffn_hidden_size=ffn_hidden_size,
+            **kwargs,
+        )
+
+
+def _gemma4_dense_ffn_hidden_size(config: TransformerConfig, layer_number: int) -> int:
+    """Return the HF FFN width for a one-indexed dense Gemma 4 layer."""
+    base_width = int(config.ffn_hidden_size)
+    first_shared_layer = int(config.num_layers) - int(getattr(config, "num_kv_shared_layers", 0))
+    is_shared_layer = first_shared_layer > 0 and layer_number - 1 >= first_shared_layer
+    if getattr(config, "use_double_wide_mlp", False) and is_shared_layer:
+        return 2 * base_width
+    return base_width
 
 
 # ---------------------------------------------------------------------------
@@ -483,8 +520,16 @@ class Gemma4DenseTransformerLayer(TransformerLayer):
         config: TransformerConfig,
         submodules: Gemma4DenseTransformerLayerSubmodules,
         layer_number: int = 1,
-        **kwargs,
-    ):
+        **kwargs: object,
+    ) -> None:
+        submodules = copy.deepcopy(submodules)
+        mlp_submodules = get_submodules(submodules.mlp)
+        ffn_hidden_size = _gemma4_dense_ffn_hidden_size(config, layer_number)
+        submodules.mlp = partial(
+            Gemma4DenseMLP.as_mlp_submodule,
+            submodules=mlp_submodules,
+            ffn_hidden_size=ffn_hidden_size,
+        )
         super().__init__(config, submodules, layer_number=layer_number, **kwargs)
 
         self.post_self_attn_layernorm = submodules.post_self_attn_layernorm(
@@ -1209,19 +1254,50 @@ def _install_ple_forward(model: "torch.nn.Module") -> None:
 class Gemma4TransformerLayer(TransformerLayer):
     """Gemma 4 MoE transformer layer with per-layer output scaling and extra post-norms."""
 
-    def __init__(self, config, submodules, layer_number=1, **kwargs):
+    def __init__(
+        self,
+        config: TransformerConfig,
+        submodules: TransformerLayerSubmodules,
+        layer_number: int = 1,
+        **kwargs: object,
+    ) -> None:
         super().__init__(config=config, submodules=submodules, layer_number=layer_number, **kwargs)
         self.register_buffer("layer_scalar", torch.ones(1, dtype=config.params_dtype))
-        self.register_buffer("pffl_weight", torch.ones(config.hidden_size, dtype=config.params_dtype))
+        self.pffl_weight = nn.Parameter(torch.ones(config.hidden_size, dtype=config.params_dtype))
+        self.post_ffn_layernorm = Gemma4RMSNorm(config, config.hidden_size, eps=config.layernorm_epsilon)
 
-        NormImpl = TENorm if HAVE_TE else torch.nn.Identity
-        self.post_ffn_layernorm = NormImpl(
-            config=config,
-            hidden_size=config.hidden_size,
-            eps=config.layernorm_epsilon,
+    def _forward_mlp(
+        self,
+        hidden_states: Tensor,
+        inference_context: BaseInferenceContext | None = None,
+        padding_mask: Tensor | None = None,
+    ) -> Tensor:
+        """Run HF's separate shared-expert, routed-expert, and router inputs."""
+        del inference_context
+        residual = hidden_states.float() if self.config.fp32_residual_connection else hidden_states
+        expert_input = _gemma4_rms_norm(
+            residual,
+            self.pre_mlp_layernorm.weight,
+            self.config.layernorm_epsilon,
         )
+        shared_expert_input = _gemma4_rms_norm(
+            residual,
+            self.pffl_weight,
+            self.config.layernorm_epsilon,
+        )
+        mlp_output_with_bias = self.mlp.forward_with_separate_inputs(
+            expert_input,
+            shared_expert_input,
+            residual,
+            padding_mask=padding_mask,
+        )
+        return self._forward_post_mlp(mlp_output_with_bias, residual)
 
-    def _forward_post_mlp(self, mlp_output_with_bias, residual):
+    def _forward_post_mlp(
+        self,
+        mlp_output_with_bias: tuple[Tensor, Tensor | None],
+        residual: Tensor,
+    ) -> Tensor:
         from megatron.core.utils import make_viewless_tensor
 
         mlp_out = mlp_output_with_bias[0]
@@ -1242,19 +1318,26 @@ class Gemma4TransformerLayer(TransformerLayer):
 class Gemma4TopKRouter(TopKRouter):
     """Gemma 4 MoE router with per-expert scaling."""
 
-    def __init__(self, config, **kwargs):
+    def __init__(self, config: TransformerConfig, **kwargs: object) -> None:
         super().__init__(config=config, **kwargs)
-        self.register_buffer(
-            "per_expert_scale",
-            torch.ones(config.num_moe_experts, dtype=config.params_dtype),
-        )
-        self.register_buffer(
-            "scale",
-            torch.ones(config.hidden_size, dtype=config.params_dtype),
-        )
+        self.per_expert_scale = nn.Parameter(torch.ones(config.num_moe_experts, dtype=config.params_dtype))
+        self.scale = nn.Parameter(torch.ones(config.hidden_size, dtype=config.params_dtype))
+        self.scalar_root_size = config.hidden_size**-0.5
 
-    def routing(self, logits, padding_mask=None, input_ids=None):
-        routing_probs, routing_map = super().routing(logits, padding_mask=padding_mask, input_ids=input_ids)
+    def gating(self, input: Tensor) -> Tensor:
+        """Apply HF's scaleless RMSNorm and learned router scale before projection."""
+        input = _gemma4_rms_norm(input, None, self.config.layernorm_epsilon)
+        input = input * self.scale * self.scalar_root_size
+        return super().gating(input)
+
+    def routing(
+        self,
+        logits: Tensor,
+        padding_mask: Tensor | None = None,
+        input_ids: Tensor | None = None,
+    ) -> tuple[Tensor, Tensor | None]:
+        del input_ids
+        routing_probs, routing_map = super().routing(logits, padding_mask=padding_mask)
         if routing_map is not None:
             prob_sums = routing_probs.sum(dim=-1, keepdim=True).clamp(min=1e-20)
             routing_probs = routing_probs / prob_sums
@@ -1265,21 +1348,49 @@ class Gemma4TopKRouter(TopKRouter):
 class Gemma4MoELayer(MoELayer):
     """Gemma 4 MoE layer with post-routed-expert and post-shared-expert normalization."""
 
-    def __init__(self, config, submodules, **kwargs):
+    def __init__(self, config: TransformerConfig, submodules: object, **kwargs: object) -> None:
         super().__init__(config=config, submodules=submodules, **kwargs)
-        NormImpl = TENorm if HAVE_TE else torch.nn.Identity
-        self.post_moe_layernorm = NormImpl(
-            config=config,
-            hidden_size=config.hidden_size,
-            eps=config.layernorm_epsilon,
-        )
-        self.post_shared_expert_layernorm = NormImpl(
-            config=config,
-            hidden_size=config.hidden_size,
-            eps=config.layernorm_epsilon,
-        )
+        self.post_moe_layernorm = Gemma4RMSNorm(config, config.hidden_size, eps=config.layernorm_epsilon)
+        self.post_shared_expert_layernorm = Gemma4RMSNorm(config, config.hidden_size, eps=config.layernorm_epsilon)
 
-    def postprocess(self, output, shared_expert_output):
+    def forward_with_separate_inputs(
+        self,
+        expert_input: Tensor,
+        shared_expert_input: Tensor,
+        router_input: Tensor,
+        padding_mask: Tensor | None = None,
+    ) -> tuple[Tensor, Tensor | None]:
+        """Run the MoE using the three independently normalized HF inputs."""
+        if self.shared_expert_overlap:
+            raise NotImplementedError("Gemma 4 separate shared-expert normalization requires overlap to be disabled")
+        if padding_mask is not None:
+            padding_mask = padding_mask.transpose(0, 1).bool()
+
+        def custom_forward(
+            expert_input: Tensor,
+            shared_expert_input: Tensor,
+            router_input: Tensor,
+        ) -> tuple[Tensor, Tensor | None]:
+            shared_expert_output = self.shared_experts_compute(shared_expert_input)
+            probs, routing_map = self.route(router_input, padding_mask)
+            dispatched_input, probs = self.preprocess(expert_input, probs, routing_map)
+            dispatched_input, probs = self.dispatch(dispatched_input, probs)
+            output, mlp_bias = self.routed_experts_compute(dispatched_input, probs)
+            output = self.combine(output)
+            output = self.postprocess(output, shared_expert_output)
+            return output, mlp_bias
+
+        if self.moe_layer_recompute and self.training:
+            return tensor_parallel.checkpoint(
+                custom_forward,
+                False,
+                expert_input,
+                shared_expert_input,
+                router_input,
+            )
+        return custom_forward(expert_input, shared_expert_input, router_input)
+
+    def postprocess(self, output: Tensor, shared_expert_output: Tensor | None) -> Tensor:
         output = self.token_dispatcher.combine_postprocess(output)
         if self.config.moe_latent_size:
             output, _ = self.fc2_latent_proj(output)
@@ -1352,6 +1463,12 @@ def _gemma4_block_spec(config, use_transformer_engine=True, **kwargs):
             mlp_spec.module = Gemma4MoELayer
             if hasattr(mlp_spec, "submodules") and mlp_spec.submodules is not None:
                 mlp_spec.submodules.router = Gemma4TopKRouter
+        elif isinstance(mlp_spec, partial) and isinstance(mlp_spec.func, type) and issubclass(mlp_spec.func, MoELayer):
+            mlp_kwargs = dict(mlp_spec.keywords or {})
+            mlp_submodules = copy.deepcopy(mlp_kwargs["submodules"])
+            mlp_submodules.router = Gemma4TopKRouter
+            mlp_kwargs["submodules"] = mlp_submodules
+            layer_spec.submodules.mlp = partial(Gemma4MoELayer, *mlp_spec.args, **mlp_kwargs)
 
     return block_spec
 

--- a/src/megatron/bridge/models/gemma/modeling_gemma4.py
+++ b/src/megatron/bridge/models/gemma/modeling_gemma4.py
@@ -15,7 +15,7 @@
 """
 Gemma 4 Dense and MoE layer specs, attention, positional embeddings, and helpers.
 
-Dense (E4B) layer specification:
+Dense (E2B, E4B, and 31B) layer specification:
 - 4-norm transformer structure (input, post-attn, pre-MLP, post-MLP)
 - Dual RoPE (sliding θ=10000, global θ=1000000 with partial rotation)
 - Per-Layer Embeddings (PLE)
@@ -1353,6 +1353,7 @@ class Gemma4TopKRouter(TopKRouter):
         padding_mask: Tensor | None = None,
         input_ids: Tensor | None = None,
     ) -> tuple[Tensor, Tensor | None]:
+        # Token identities do not affect Gemma 4 routing; retain the argument for compatibility with existing callers.
         del input_ids
         routing_probs, routing_map = super().routing(logits, padding_mask=padding_mask)
         if routing_map is not None:

--- a/src/megatron/bridge/models/gemma_vl/gemma4_vl_bridge.py
+++ b/src/megatron/bridge/models/gemma_vl/gemma4_vl_bridge.py
@@ -296,7 +296,7 @@ class Gemma4VLBridge(Gemma4Bridge):
                     hf_param="model.language_model.layers.*.router.scale",
                 ),
                 ReplicatedMapping(
-                    megatron_param="language_model.decoder.layers.*.pffl_weight",
+                    megatron_param="language_model.decoder.layers.*.pre_shared_expert_layernorm.weight",
                     hf_param="model.language_model.layers.*.pre_feedforward_layernorm.weight",
                 ),
                 ReplicatedMapping(

--- a/src/megatron/bridge/models/gemma_vl/gemma4_vl_bridge.py
+++ b/src/megatron/bridge/models/gemma_vl/gemma4_vl_bridge.py
@@ -28,8 +28,6 @@ Usage::
 """
 
 import os
-import re
-from typing import Mapping
 
 import torch
 
@@ -195,50 +193,6 @@ class Gemma4VLBridge(Gemma4Bridge):
     def _hf_layer_prefix(self) -> str:
         """VLM text weights live under ``model.language_model.*``."""
         return "model.language_model."
-
-    def _fuse_router_weight(self, hf_param: str, hf_state_dict: Mapping[str, torch.Tensor]) -> torch.Tensor:
-        """Fuse router preprocessing — VLM prefix-aware version."""
-        proj_weight = hf_state_dict[hf_param]
-        layer_match = re.search(r"layers\.(\d+)\.", hf_param)
-        if layer_match is None:
-            return proj_weight
-        layer_idx = layer_match.group(1)
-        prefix = hf_param.rsplit("layers.", 1)[0]
-        scale_key = f"{prefix}layers.{layer_idx}.router.scale"
-        ln2_key = f"{prefix}layers.{layer_idx}.pre_feedforward_layernorm_2.weight"
-        if scale_key not in hf_state_dict or ln2_key not in hf_state_dict:
-            return proj_weight
-        router_scale = hf_state_dict[scale_key].float()
-        ln2_weight = hf_state_dict[ln2_key].float()
-        hidden_size = proj_weight.shape[-1]
-        scalar_root_size = hidden_size**-0.5
-        fusion_factor = router_scale * scalar_root_size / ln2_weight
-        fused_weight = proj_weight.float() * fusion_factor.unsqueeze(0)
-        return fused_weight.to(proj_weight.dtype)
-
-    def _fuse_shared_expert_prenorm(
-        self, hf_param: dict[str, str], hf_state_dict: Mapping[str, torch.Tensor]
-    ) -> dict[str, torch.Tensor]:
-        """Fuse pre-norm correction — VLM prefix-aware version."""
-        gate_name = hf_param["gate"]
-        layer_match = re.search(r"layers\.(\d+)\.", gate_name)
-        if layer_match is None:
-            return {role: hf_state_dict[name] for role, name in hf_param.items()}
-        layer_idx = layer_match.group(1)
-        prefix = gate_name.rsplit("layers.", 1)[0]
-        pffl_key = f"{prefix}layers.{layer_idx}.pre_feedforward_layernorm.weight"
-        pffl2_key = f"{prefix}layers.{layer_idx}.pre_feedforward_layernorm_2.weight"
-        if pffl_key not in hf_state_dict or pffl2_key not in hf_state_dict:
-            return {role: hf_state_dict[name] for role, name in hf_param.items()}
-        w_pffl = hf_state_dict[pffl_key].float()
-        w_pffl2 = hf_state_dict[pffl2_key].float()
-        correction = w_pffl / w_pffl2
-        hf_weights = {}
-        for role, name in hf_param.items():
-            weight = hf_state_dict[name]
-            fused = weight.float() * correction.unsqueeze(0)
-            hf_weights[role] = fused.to(weight.dtype)
-        return hf_weights
 
     def mapping_registry(self) -> MegatronMappingRegistry:
         """Dispatch to Dense or MoE VLM mappings."""

--- a/src/megatron/bridge/models/gemma_vl/gemma4_vl_bridge.py
+++ b/src/megatron/bridge/models/gemma_vl/gemma4_vl_bridge.py
@@ -28,6 +28,7 @@ Usage::
 """
 
 import os
+from dataclasses import asdict, is_dataclass
 
 import torch
 
@@ -151,12 +152,45 @@ class Gemma4VLBridge(Gemma4Bridge):
         return provider
 
     @classmethod
-    def megatron_to_hf_config(cls, provider: Gemma4VLModelProvider | Gemma4DenseVLProvider) -> dict:
+    def megatron_to_hf_config(
+        cls,
+        provider: Gemma4VLModelProvider | Gemma4DenseVLProvider | Gemma4DenseProvider,
+    ) -> dict:
         """Convert a Gemma 4 VL provider config back to Hugging Face config."""
-        hf_config = super().megatron_to_hf_config(provider)
-        final_logit_softcapping = hf_config.pop("final_logit_softcapping")
-        hf_config.setdefault("text_config", {})["final_logit_softcapping"] = final_logit_softcapping
-        return hf_config
+        text_config = super().megatron_to_hf_config(provider)
+        text_config.pop("architectures", None)
+        text_config["model_type"] = "gemma4_text"
+
+        if not isinstance(provider, (Gemma4VLModelProvider, Gemma4DenseVLProvider)):
+            text_config["architectures"] = ["Gemma4ForCausalLM"]
+            return text_config
+
+        def config_to_dict(config) -> dict | None:
+            if config is None:
+                return None
+            if isinstance(config, dict):
+                return dict(config)
+            if hasattr(config, "to_dict"):
+                return config.to_dict()
+            if is_dataclass(config):
+                return asdict(config)
+            return {name: value for name, value in vars(config).items() if not name.startswith("_")}
+
+        return {
+            "architectures": ["Gemma4ForConditionalGeneration"],
+            "audio_config": config_to_dict(provider.audio_config),
+            "audio_token_id": provider.audio_token_id,
+            "bos_token_id": provider.bos_token_id,
+            "dtype": text_config["dtype"],
+            "eos_token_id": provider.eos_token_id,
+            "image_token_id": provider.image_token_id,
+            "model_type": "gemma4",
+            "text_config": text_config,
+            "tie_word_embeddings": provider.share_embeddings_and_output_weights,
+            "video_token_id": provider.video_token_id,
+            "vision_config": config_to_dict(provider.vision_config),
+            "vision_soft_tokens_per_image": provider.vision_soft_tokens_per_image,
+        }
 
     def _conversion_mode(self) -> str:
         mode = getattr(self, "gemma4_conversion_mode", None) or os.environ.get("GEMMA4_CONVERSION_MODE", "auto")

--- a/tests/functional_tests/test_groups/recipes/test_gemma4_vl_recipes_finetune.py
+++ b/tests/functional_tests/test_groups/recipes/test_gemma4_vl_recipes_finetune.py
@@ -37,9 +37,10 @@ from tests.functional_tests.test_groups.recipes.utils import run_pretrain_vl_rec
 # - num_moe_experts=4:         reduce from 128 → 4 (critical for memory)
 # - interleaved_attn_pattern:  (1,1) → layer 1 sliding, layer 2 global;
 #                              ensures Gemma4SelfAttention global path is covered
-# - expert/tensor/pipeline:    all-1 for single-node simplicity
+# - expert/pipeline:           1 for single-node simplicity
+# - tensor parallel:           2 to exercise sequence-parallel gradient synchronization
 _SMALL_MODEL_OVERRIDES = {
-    "tensor_model_parallel_size": 1,
+    "tensor_model_parallel_size": 2,
     "pipeline_model_parallel_size": 1,
     "expert_model_parallel_size": 1,
     "num_layers": 2,

--- a/tests/unit_tests/models/gemma/test_gemma4_bridge.py
+++ b/tests/unit_tests/models/gemma/test_gemma4_bridge.py
@@ -286,12 +286,18 @@ class TestGemma4BridgeConfigExport:
         assert config["enable_moe_block"] is False
         assert config["sliding_window"] == 1024
         assert config["attention_k_eq_v"] is True
+        assert config["dtype"] == "bfloat16"
+        assert config["global_head_dim"] == provider.global_kv_channels
+        assert config["layer_types"][:6] == ["sliding_attention"] * 5 + ["full_attention"]
+        assert config["num_global_key_value_heads"] == provider.num_global_query_groups
         assert config["num_kv_shared_layers"] == 20
+        assert config["rope_parameters"]["full_attention"]["partial_rotary_factor"] == 0.25
         assert config["use_double_wide_mlp"] is True
 
     def test_moe_architecture_fields(self):
         provider = Gemma4ModelProvider(
             attention_k_eq_v=True,
+            num_layers=6,
             num_moe_experts=128,
             moe_router_topk=8,
             moe_ffn_hidden_size=704,
@@ -302,6 +308,9 @@ class TestGemma4BridgeConfigExport:
 
         assert config["enable_moe_block"] is True
         assert config["attention_k_eq_v"] is True
+        assert config["dtype"] == "bfloat16"
+        assert config["layer_types"][:6] == ["sliding_attention"] * 5 + ["full_attention"]
+        assert config["num_global_key_value_heads"] == provider.num_global_key_value_heads
         assert config["num_experts"] == 128
         assert config["top_k_experts"] == 8
         assert config["moe_intermediate_size"] == 704

--- a/tests/unit_tests/models/gemma/test_gemma4_bridge.py
+++ b/tests/unit_tests/models/gemma/test_gemma4_bridge.py
@@ -48,6 +48,7 @@ def mock_hf_config_moe():
     cfg.head_dim = 256
     cfg.global_head_dim = 512
     cfg.num_global_key_value_heads = 2
+    cfg.attention_k_eq_v = True
     cfg.initializer_range = 0.02
     cfg.rms_norm_eps = 1e-6
     cfg.vocab_size = 262144
@@ -80,6 +81,7 @@ def mock_hf_config_dense():
     cfg.head_dim = 256
     cfg.global_head_dim = 512
     cfg.num_global_key_value_heads = 2
+    cfg.attention_k_eq_v = True
     cfg.initializer_range = 0.02
     cfg.rms_norm_eps = 1e-6
     cfg.vocab_size = 262144
@@ -190,6 +192,7 @@ class TestGemma4BridgeProviderBridgeMoE:
         assert p.global_head_dim == 512
         assert p.num_global_key_value_heads == 2
         assert p.global_rotary_percent == 0.25
+        assert p.attention_k_eq_v is True
 
     def test_interleaved_attn_pattern(self, bridge, mock_pretrained_moe):
         assert bridge.provider_bridge(mock_pretrained_moe).interleaved_attn_pattern == (5, 1)
@@ -261,6 +264,49 @@ class TestGemma4DenseArchitectureConfig:
 
         assert provider.use_double_wide_mlp is True
         assert provider.num_kv_shared_layers == 20
+
+    def test_dense_attention_config(self, bridge, mock_pretrained_dense):
+        provider = bridge.provider_bridge(mock_pretrained_dense)
+
+        assert provider.window_size == (1023, 0)
+        assert provider.attention_k_eq_v is True
+
+
+class TestGemma4BridgeConfigExport:
+    def test_dense_architecture_fields(self):
+        provider = Gemma4DenseProvider(
+            window_size=(1023, 0),
+            attention_k_eq_v=True,
+            num_kv_shared_layers=20,
+            use_double_wide_mlp=True,
+        )
+
+        config = Gemma4Bridge.megatron_to_hf_config(provider)
+
+        assert config["enable_moe_block"] is False
+        assert config["sliding_window"] == 1024
+        assert config["attention_k_eq_v"] is True
+        assert config["num_kv_shared_layers"] == 20
+        assert config["use_double_wide_mlp"] is True
+
+    def test_moe_architecture_fields(self):
+        provider = Gemma4ModelProvider(
+            attention_k_eq_v=True,
+            num_moe_experts=128,
+            moe_router_topk=8,
+            moe_ffn_hidden_size=704,
+            moe_shared_expert_intermediate_size=2112,
+        )
+
+        config = Gemma4Bridge.megatron_to_hf_config(provider)
+
+        assert config["enable_moe_block"] is True
+        assert config["attention_k_eq_v"] is True
+        assert config["num_experts"] == 128
+        assert config["top_k_experts"] == 8
+        assert config["moe_intermediate_size"] == 704
+        assert config["intermediate_size"] == 2112
+
 
 # ===========================================================================
 # _infer_attn_pattern helper
@@ -514,6 +560,11 @@ class TestGemma4BridgeMappingRegistry:
     def test_has_shared_expert_mapping(self, bridge):
         names = self._collect_names(bridge.mapping_registry())
         assert any("shared_experts" in n for n in names)
+
+    def test_has_direct_pre_shared_expert_norm_mapping(self, bridge):
+        names = self._collect_names(bridge.mapping_registry())
+        assert "decoder.layers.*.pre_shared_expert_layernorm.weight" in names
+        assert "model.layers.*.pre_feedforward_layernorm.weight" in names
 
     def test_has_post_moe_layernorm(self, bridge):
         names = self._collect_names(bridge.mapping_registry())

--- a/tests/unit_tests/models/gemma/test_gemma4_bridge.py
+++ b/tests/unit_tests/models/gemma/test_gemma4_bridge.py
@@ -92,6 +92,8 @@ def mock_hf_config_dense():
     cfg.hidden_act = "gelu_pytorch_tanh"
     cfg.torch_dtype = "bfloat16"
     cfg.enable_moe_block = False
+    cfg.use_double_wide_mlp = True
+    cfg.num_kv_shared_layers = 20
     cfg.num_experts = 256
     cfg.top_k_experts = 16
     cfg.layer_types = ["sliding_attention"] * 5 + ["full_attention"] + ["sliding_attention"] * 5 + ["full_attention"]
@@ -252,6 +254,14 @@ def test_megatron_to_hf_config_preserves_final_logit_softcapping(provider_cls):
     assert Gemma4Bridge.megatron_to_hf_config(provider)["final_logit_softcapping"] == 17.0
 
 
+class TestGemma4DenseArchitectureConfig:
+    def test_double_wide_mlp_config(self, bridge, mock_pretrained_dense):
+        """E2B shared-KV layers require twice the base FFN width."""
+        provider = bridge.provider_bridge(mock_pretrained_dense)
+
+        assert provider.use_double_wide_mlp is True
+        assert provider.num_kv_shared_layers == 20
+
 # ===========================================================================
 # _infer_attn_pattern helper
 # ===========================================================================
@@ -352,36 +362,30 @@ class TestMaybeModifyLoadedHFWeight:
         result = bridge.maybe_modify_loaded_hf_weight(hf_param, sd)
         assert result is not None
 
-    def test_router_weight_fusion(self, bridge):
-        hidden = 8
-        sd = self._make_sd(hidden=hidden)
+    def test_router_weight_passthrough(self, bridge):
+        sd = self._make_sd(hidden=8)
         hf_param = "model.layers.0.router.proj.weight"
+
         result = bridge.maybe_modify_loaded_hf_weight(hf_param, sd)
-        assert isinstance(result, torch.Tensor)
-        assert result.shape == sd[hf_param].shape
-        expected_factor = 1.0 * (hidden**-0.5) / 2.0
-        expected = (sd[hf_param].float() * expected_factor).to(sd[hf_param].dtype)
-        torch.testing.assert_close(result, expected)
+
+        torch.testing.assert_close(result, sd[hf_param], rtol=0, atol=0)
 
     def test_router_fusion_missing_keys_passthrough(self, bridge):
         sd = {"model.layers.0.router.proj.weight": torch.randn(4, 8)}
         result = bridge.maybe_modify_loaded_hf_weight("model.layers.0.router.proj.weight", sd)
         torch.testing.assert_close(result, sd["model.layers.0.router.proj.weight"])
 
-    def test_shared_expert_prenorm_fusion(self, bridge):
-        hidden = 8
-        sd = self._make_sd(hidden=hidden)
+    def test_shared_expert_weights_passthrough(self, bridge):
+        sd = self._make_sd(hidden=8)
         hf_param = {
             "gate": "model.layers.0.mlp.gate_proj.weight",
             "up": "model.layers.0.mlp.up_proj.weight",
         }
+
         result = bridge.maybe_modify_loaded_hf_weight(hf_param, sd)
-        assert isinstance(result, dict)
-        correction = 3.0 / 2.0
-        expected = (sd["model.layers.0.mlp.gate_proj.weight"].float() * correction).to(
-            sd["model.layers.0.mlp.gate_proj.weight"].dtype
-        )
-        torch.testing.assert_close(result["gate"], expected)
+
+        torch.testing.assert_close(result["gate"], sd[hf_param["gate"]], rtol=0, atol=0)
+        torch.testing.assert_close(result["up"], sd[hf_param["up"]], rtol=0, atol=0)
 
     def test_shared_expert_fusion_missing_keys_passthrough(self, bridge):
         sd = {
@@ -420,34 +424,30 @@ class TestMaybeModifyConvertedHFWeight:
         assert "model.layers.0.self_attn.v_proj.weight" not in result
         assert "model.layers.0.self_attn.q_proj.weight" in result
 
-    def test_router_weight_unfusion(self, bridge):
-        hidden = 8
-        ref_sd = self._make_ref_sd(hidden=hidden)
-        factor = 1.0 * (hidden**-0.5) / 2.0
-        fused = (ref_sd["model.layers.0.router.proj.weight"].float() * factor).to(
-            ref_sd["model.layers.0.router.proj.weight"].dtype
-        )
-        result = bridge.maybe_modify_converted_hf_weight(None, {"model.layers.0.router.proj.weight": fused}, ref_sd)
+    def test_router_weight_export_passthrough(self, bridge):
+        ref_sd = self._make_ref_sd(hidden=8)
+        converted = {"model.layers.0.router.proj.weight": torch.randn(4, 8)}
+
+        result = bridge.maybe_modify_converted_hf_weight(None, converted, ref_sd)
+
         torch.testing.assert_close(
             result["model.layers.0.router.proj.weight"],
-            ref_sd["model.layers.0.router.proj.weight"],
-            atol=1e-5,
-            rtol=1e-5,
+            converted["model.layers.0.router.proj.weight"],
+            rtol=0,
+            atol=0,
         )
 
-    def test_shared_expert_gate_unfusion(self, bridge):
-        hidden = 8
-        ref_sd = self._make_ref_sd(hidden=hidden)
-        correction = 3.0 / 2.0
-        fused = (ref_sd["model.layers.0.mlp.gate_proj.weight"].float() * correction).to(
-            ref_sd["model.layers.0.mlp.gate_proj.weight"].dtype
-        )
-        result = bridge.maybe_modify_converted_hf_weight(None, {"model.layers.0.mlp.gate_proj.weight": fused}, ref_sd)
+    def test_shared_expert_weight_export_passthrough(self, bridge):
+        ref_sd = self._make_ref_sd(hidden=8)
+        converted = {"model.layers.0.mlp.gate_proj.weight": torch.randn(16, 8)}
+
+        result = bridge.maybe_modify_converted_hf_weight(None, converted, ref_sd)
+
         torch.testing.assert_close(
             result["model.layers.0.mlp.gate_proj.weight"],
-            ref_sd["model.layers.0.mlp.gate_proj.weight"],
-            atol=1e-5,
-            rtol=1e-5,
+            converted["model.layers.0.mlp.gate_proj.weight"],
+            rtol=0,
+            atol=0,
         )
 
     def test_empty_hf_state_dict_passthrough(self, bridge):

--- a/tests/unit_tests/models/gemma/test_gemma4_modeling.py
+++ b/tests/unit_tests/models/gemma/test_gemma4_modeling.py
@@ -22,6 +22,7 @@ from types import SimpleNamespace
 
 import pytest
 import torch
+from megatron.core import tensor_parallel
 
 from megatron.bridge.models.gemma.modeling_gemma4 import (
     Gemma4DenseMLP,
@@ -735,33 +736,50 @@ class TestGemma4SelfAttention:
 
         assert out is expected
 
-    def test_get_query_key_value_tensors_ties_and_normalizes_value(self, monkeypatch):
-        query = torch.ones(2, 1, 1, 2)
-        key = torch.full_like(query, 3.0)
-        value = torch.full_like(query, 5.0)
-        extra = torch.full_like(query, 7.0)
+    def test_get_query_key_value_tensors_normalizes_tied_value_from_raw_key(self, monkeypatch):
+        query = torch.tensor([[[[1.0, 2.0]]]])
+        raw_key = torch.tensor([[[[3.0, 4.0]]]])
+        unused_value = torch.tensor([[[[5.0, 6.0]]]])
+        mixed_qkv = torch.cat((query, raw_key, unused_value), dim=-1)
 
-        def fake_get_qkv(self, hidden_states, key_value_states=None, **kwargs):
-            del self, hidden_states, key_value_states, kwargs
-            return query, key, value, extra
+        def fake_get_qkv(self, hidden_states, key_value_states=None, output_gate=False, split_qkv=True):
+            del self, hidden_states, key_value_states
+            assert output_gate is False
+            assert split_qkv is False
+            return mixed_qkv, [2, 2, 2]
 
         monkeypatch.setattr(
             "megatron.bridge.models.gemma.modeling_gemma4.SelfAttention.get_query_key_value_tensors",
             fake_get_qkv,
         )
         attn = self._make_attention(layer_number=2)
+        attn.config.num_query_groups = 1
+        attn.config.test_mode = False
+        attn.hidden_size_per_attention_head = 2
+        attn.world_size = 1
+
+        class ScaleKey(torch.nn.Module):
+            def forward(self, tensor):
+                return tensor * torch.tensor([2.0, 1.0])
+
+        object.__setattr__(attn, "q_layernorm", torch.nn.Identity())
+        object.__setattr__(attn, "k_layernorm", ScaleKey())
         attn._tied_kv = True
         attn._v_norm_eps = 1e-6
 
-        out_query, out_key, out_value, out_extra = Gemma4SelfAttention.get_query_key_value_tensors(
+        out_query, out_key, out_value = Gemma4SelfAttention.get_query_key_value_tensors(
             attn,
             torch.zeros(1),
         )
 
-        assert out_query is query
-        assert out_key is key
-        assert out_extra is extra
-        torch.testing.assert_close(out_value, torch.ones_like(key))
+        torch.testing.assert_close(out_query, query)
+        torch.testing.assert_close(out_key, raw_key * torch.tensor([2.0, 1.0]))
+        expected_value = raw_key / torch.sqrt(raw_key.pow(2).mean(-1, keepdim=True) + 1e-6)
+        torch.testing.assert_close(out_value, expected_value)
+        assert not torch.allclose(
+            out_value,
+            out_key / torch.sqrt(out_key.pow(2).mean(-1, keepdim=True) + 1e-6),
+        )
 
     def test_forward_selects_local_mask_and_rotary_embedding(self, monkeypatch):
         calls = {}
@@ -1949,6 +1967,50 @@ class TestGemma4MoEHelpers:
         out = Gemma4MoELayer.postprocess(layer, output, shared)
 
         torch.testing.assert_close(out, torch.full_like(output, 21.0))
+
+    @pytest.mark.parametrize(("fp8", "fp4"), [(True, False), (False, True)])
+    def test_moe_layer_recompute_uses_te_checkpoint_for_quantized_training(self, monkeypatch, fp8, fp4):
+        calls = []
+
+        def fake_te_checkpoint(function, distribute_saved_activations, get_rng_tracker, tp_group, *args):
+            calls.append((distribute_saved_activations, get_rng_tracker, tp_group))
+            return function(*args)
+
+        def fail_tensor_parallel_checkpoint(*args, **kwargs):
+            del args, kwargs
+            raise AssertionError("quantized MoE recompute must use TE checkpointing")
+
+        monkeypatch.setattr("megatron.bridge.models.gemma.modeling_gemma4.te_checkpoint", fake_te_checkpoint)
+        monkeypatch.setattr(tensor_parallel, "checkpoint", fail_tensor_parallel_checkpoint)
+
+        layer = object.__new__(Gemma4MoELayer)
+        torch.nn.Module.__init__(layer)
+        layer.shared_expert_overlap = False
+        layer.moe_layer_recompute = True
+        layer.train()
+        layer.config = SimpleNamespace(fp8=fp8, fp4=fp4)
+        layer.tp_group = "tp-group"
+        layer.shared_experts_compute = lambda tensor: tensor + 1.0
+        layer.route = lambda tensor, padding_mask: (tensor, padding_mask)
+        layer.preprocess = lambda tensor, probs, routing_map: (tensor + probs, routing_map)
+        layer.dispatch = lambda tensor, probs: (tensor, probs)
+        layer.routed_experts_compute = lambda tensor, probs: (tensor + 1.0, None)
+        layer.combine = lambda tensor: tensor
+        layer.postprocess = lambda output, shared: output + shared
+        expert_input = torch.tensor(1.0)
+        shared_input = torch.tensor(2.0)
+        router_input = torch.tensor(3.0)
+
+        output, bias = Gemma4MoELayer.forward_with_separate_inputs(
+            layer,
+            expert_input,
+            shared_input,
+            router_input,
+        )
+
+        assert bias is None
+        torch.testing.assert_close(output, torch.tensor(8.0))
+        assert calls == [(False, tensor_parallel.random.get_cuda_rng_tracker, "tp-group")]
 
     def test_install_tied_kv_marks_only_global_attention_layers(self):
         local_attn = SimpleNamespace()

--- a/tests/unit_tests/models/gemma/test_gemma4_modeling.py
+++ b/tests/unit_tests/models/gemma/test_gemma4_modeling.py
@@ -1968,20 +1968,29 @@ class TestGemma4MoEHelpers:
 
         torch.testing.assert_close(out, torch.full_like(output, 21.0))
 
-    @pytest.mark.parametrize(("fp8", "fp4"), [(True, False), (False, True)])
-    def test_moe_layer_recompute_uses_te_checkpoint_for_quantized_training(self, monkeypatch, fp8, fp4):
+    @pytest.mark.parametrize(
+        ("fp8", "fp4", "expected_checkpoint"),
+        [
+            pytest.param(False, False, "tensor_parallel", id="bf16"),
+            pytest.param(True, False, "te", id="fp8"),
+            pytest.param(False, True, "te", id="fp4"),
+        ],
+    )
+    def test_moe_layer_recompute_uses_expected_checkpoint_for_training(
+        self, monkeypatch, fp8, fp4, expected_checkpoint
+    ):
         calls = []
 
         def fake_te_checkpoint(function, distribute_saved_activations, get_rng_tracker, tp_group, *args):
-            calls.append((distribute_saved_activations, get_rng_tracker, tp_group))
+            calls.append(("te", distribute_saved_activations, get_rng_tracker, tp_group))
             return function(*args)
 
-        def fail_tensor_parallel_checkpoint(*args, **kwargs):
-            del args, kwargs
-            raise AssertionError("quantized MoE recompute must use TE checkpointing")
+        def fake_tensor_parallel_checkpoint(function, distribute_saved_activations, *args):
+            calls.append(("tensor_parallel", distribute_saved_activations))
+            return function(*args)
 
         monkeypatch.setattr("megatron.bridge.models.gemma.modeling_gemma4.te_checkpoint", fake_te_checkpoint)
-        monkeypatch.setattr(tensor_parallel, "checkpoint", fail_tensor_parallel_checkpoint)
+        monkeypatch.setattr(tensor_parallel, "checkpoint", fake_tensor_parallel_checkpoint)
 
         layer = object.__new__(Gemma4MoELayer)
         torch.nn.Module.__init__(layer)
@@ -2010,7 +2019,10 @@ class TestGemma4MoEHelpers:
 
         assert bias is None
         torch.testing.assert_close(output, torch.tensor(8.0))
-        assert calls == [(False, tensor_parallel.random.get_cuda_rng_tracker, "tp-group")]
+        if expected_checkpoint == "te":
+            assert calls == [("te", False, tensor_parallel.random.get_cuda_rng_tracker, "tp-group")]
+        else:
+            assert calls == [("tensor_parallel", False)]
 
     def test_install_tied_kv_marks_only_global_attention_layers(self):
         local_attn = SimpleNamespace()

--- a/tests/unit_tests/models/gemma/test_gemma4_modeling.py
+++ b/tests/unit_tests/models/gemma/test_gemma4_modeling.py
@@ -17,12 +17,14 @@
 import types
 import weakref
 from contextlib import nullcontext
+from functools import partial
 from types import SimpleNamespace
 
 import pytest
 import torch
 
 from megatron.bridge.models.gemma.modeling_gemma4 import (
+    Gemma4DenseMLP,
     Gemma4DenseRotaryEmbedding,
     Gemma4DenseSelfAttention,
     Gemma4DenseTransformerLayer,
@@ -89,6 +91,14 @@ class TestGemma4RMSNorm:
 
         assert not hasattr(norm, "weight")
 
+    def test_weight_uses_model_parameter_dtype(self):
+        norm = Gemma4RMSNorm(
+            _config(params_dtype=torch.bfloat16),
+            hidden_size=2,
+        )
+
+        assert norm.weight.dtype is torch.bfloat16
+
 
 class TestGemma4MoE:
     def test_router_returns_normalized_topk_weights(self):
@@ -149,6 +159,38 @@ class TestGemma4LayerSpec:
         assert layer_spec.submodules.self_attention.module is Gemma4DenseSelfAttention
         assert layer_spec.submodules.post_self_attn_layernorm is Gemma4RMSNorm
         assert layer_spec.submodules.post_mlp_layernorm is Gemma4RMSNorm
+
+    def test_double_wide_mlp_only_applies_to_shared_kv_layers(self, monkeypatch):
+        mlp_builders = []
+
+        def fake_layer_init(self, config, submodules, layer_number=1, **kwargs):
+            del kwargs
+            torch.nn.Module.__init__(self)
+            self.config = config
+            self.layer_number = layer_number
+            mlp_builders.append(submodules.mlp)
+
+        monkeypatch.setattr(
+            "megatron.bridge.models.gemma.modeling_gemma4.TransformerLayer.__init__",
+            fake_layer_init,
+        )
+        config = _config(
+            hidden_size=4,
+            ffn_hidden_size=6,
+            num_layers=4,
+            num_kv_shared_layers=2,
+            use_double_wide_mlp=True,
+            per_layer_embed_dim=0,
+            enable_moe_block=False,
+        )
+
+        Gemma4DenseTransformerLayer(config, get_gemma4_layer_spec().submodules, layer_number=2)
+        Gemma4DenseTransformerLayer(config, get_gemma4_layer_spec().submodules, layer_number=3)
+
+        assert mlp_builders[0].func.__self__ is Gemma4DenseMLP
+        assert mlp_builders[0].keywords["ffn_hidden_size"] == 6
+        assert mlp_builders[1].func.__self__ is Gemma4DenseMLP
+        assert mlp_builders[1].keywords["ffn_hidden_size"] == 12
 
 
 class TestGemma4DenseSelfAttention:
@@ -1637,6 +1679,46 @@ class TestGemma4PLEHelpers:
 
 
 class TestGemma4MoEHelpers:
+    def test_topk_router_scale_state_is_trainable(self, monkeypatch):
+        def fake_router_init(self, config, **kwargs):
+            del kwargs
+            torch.nn.Module.__init__(self)
+            self.config = config
+
+        monkeypatch.setattr(
+            "megatron.bridge.models.gemma.modeling_gemma4.TopKRouter.__init__",
+            fake_router_init,
+        )
+        router = Gemma4TopKRouter(
+            _config(
+                num_moe_experts=3,
+                params_dtype=torch.bfloat16,
+            )
+        )
+
+        assert isinstance(router.scale, torch.nn.Parameter)
+        assert isinstance(router.per_expert_scale, torch.nn.Parameter)
+        assert router.scale.dtype is torch.bfloat16
+        assert router.per_expert_scale.dtype is torch.bfloat16
+
+    def test_transformer_moe_norm_state_is_trainable(self, monkeypatch):
+        def fake_layer_init(self, config, submodules, layer_number=1, **kwargs):
+            del submodules, layer_number, kwargs
+            torch.nn.Module.__init__(self)
+            self.config = config
+
+        monkeypatch.setattr(
+            "megatron.bridge.models.gemma.modeling_gemma4.TransformerLayer.__init__",
+            fake_layer_init,
+        )
+        layer = Gemma4TransformerLayer(
+            _config(params_dtype=torch.bfloat16),
+            submodules=SimpleNamespace(),
+        )
+
+        assert isinstance(layer.pffl_weight, torch.nn.Parameter)
+        assert isinstance(layer.post_ffn_layernorm.weight, torch.nn.Parameter)
+
     def test_gemma4_block_spec_patches_attention_layer_and_moe_modules(self, monkeypatch):
         from megatron.core.transformer.attention import SelfAttention
         from megatron.core.transformer.moe.moe_layer import MoELayer
@@ -1672,6 +1754,27 @@ class TestGemma4MoEHelpers:
         assert attn_submodules.linear_proj != "old_proj"
         assert layer_spec.submodules.mlp.module is Gemma4MoELayer
         assert mlp_submodules.router is Gemma4TopKRouter
+
+    def test_gemma4_block_spec_patches_partial_moe_builder(self, monkeypatch):
+        from megatron.core.transformer.moe.moe_layer import MoELayer, MoESubmodules
+
+        mlp_submodules = MoESubmodules(experts=object(), shared_experts=object())
+        layer_spec = SimpleNamespace(
+            module=object,
+            submodules=SimpleNamespace(
+                self_attention=SimpleNamespace(module=object, submodules=None),
+                mlp=partial(MoELayer, submodules=mlp_submodules),
+            ),
+        )
+        monkeypatch.setattr(
+            "megatron.bridge.models.gemma.modeling_gemma4.get_gpt_decoder_block_spec",
+            lambda *args, **kwargs: SimpleNamespace(layer_specs=[layer_spec]),
+        )
+
+        _gemma4_block_spec("config", use_transformer_engine=True)
+
+        assert layer_spec.submodules.mlp.func is Gemma4MoELayer
+        assert layer_spec.submodules.mlp.keywords["submodules"].router is Gemma4TopKRouter
 
     def test_gemma4_block_spec_skips_te_projection_patch_when_disabled(self, monkeypatch):
         from megatron.core.transformer.attention import SelfAttention
@@ -1725,6 +1828,61 @@ class TestGemma4MoEHelpers:
         assert out_map is routing_map
         torch.testing.assert_close(out_probs[0], torch.tensor([0.4, 1.2, 0.0]))
         torch.testing.assert_close(out_probs[1], torch.tensor([0.5, 1.0, 0.0]))
+
+    def test_topk_router_gating_applies_hf_norm_and_scale(self, monkeypatch):
+        captured = []
+
+        def fake_gating(self, hidden_states):
+            del self
+            captured.append(hidden_states)
+            return hidden_states
+
+        monkeypatch.setattr("megatron.bridge.models.gemma.modeling_gemma4.TopKRouter.gating", fake_gating)
+        router = object.__new__(Gemma4TopKRouter)
+        torch.nn.Module.__init__(router)
+        router.config = SimpleNamespace(layernorm_epsilon=1e-6)
+        router.scale = torch.nn.Parameter(torch.tensor([2.0, 3.0]))
+        router.scalar_root_size = 2**-0.5
+        hidden_states = torch.tensor([[3.0, 4.0]])
+
+        output = Gemma4TopKRouter.gating(router, hidden_states)
+
+        normed = hidden_states * torch.pow(hidden_states.pow(2).mean(-1, keepdim=True) + 1e-6, -0.5)
+        expected = normed * router.scale * router.scalar_root_size
+        torch.testing.assert_close(output, expected)
+        torch.testing.assert_close(captured[0], expected)
+
+    def test_transformer_layer_uses_separate_moe_inputs(self):
+        calls = []
+
+        class FakeMoE:
+            def forward_with_separate_inputs(self, expert, shared, router, padding_mask=None):
+                calls.append((expert, shared, router, padding_mask))
+                return torch.zeros_like(expert), None
+
+        layer = SimpleNamespace(
+            config=SimpleNamespace(fp32_residual_connection=False, layernorm_epsilon=1e-6),
+            pre_mlp_layernorm=SimpleNamespace(weight=torch.tensor([2.0, 2.0])),
+            pffl_weight=torch.tensor([3.0, 3.0]),
+            mlp=FakeMoE(),
+            _forward_post_mlp=lambda output, residual: (output, residual),
+        )
+        hidden_states = torch.tensor([[[3.0, 4.0]]])
+
+        output, residual = Gemma4TransformerLayer._forward_mlp(
+            layer,
+            hidden_states,
+            padding_mask=torch.tensor([[True]]),
+        )
+
+        base = hidden_states * torch.pow(hidden_states.pow(2).mean(-1, keepdim=True) + 1e-6, -0.5)
+        expert, shared, router, padding_mask = calls[0]
+        torch.testing.assert_close(expert, base * 2.0)
+        torch.testing.assert_close(shared, base * 3.0)
+        torch.testing.assert_close(router, hidden_states)
+        torch.testing.assert_close(output[0], torch.zeros_like(hidden_states))
+        torch.testing.assert_close(residual, hidden_states)
+        torch.testing.assert_close(padding_mask, torch.tensor([[True]]))
 
     def test_topk_router_routing_keeps_probs_when_map_missing(self, monkeypatch):
         routing_probs = torch.ones(2, 3)

--- a/tests/unit_tests/models/gemma/test_gemma4_modeling.py
+++ b/tests/unit_tests/models/gemma/test_gemma4_modeling.py
@@ -99,6 +99,14 @@ class TestGemma4RMSNorm:
 
         assert norm.weight.dtype is torch.bfloat16
 
+    def test_weight_is_marked_for_sequence_parallel_reduction(self):
+        norm = Gemma4RMSNorm(
+            _config(params_dtype=torch.bfloat16, sequence_parallel=True),
+            hidden_size=2,
+        )
+
+        assert norm.weight.sequence_parallel is True
+
 
 class TestGemma4MoE:
     def test_router_returns_normalized_topk_weights(self):
@@ -191,6 +199,25 @@ class TestGemma4LayerSpec:
         assert mlp_builders[0].keywords["ffn_hidden_size"] == 6
         assert mlp_builders[1].func.__self__ is Gemma4DenseMLP
         assert mlp_builders[1].keywords["ffn_hidden_size"] == 12
+
+    def test_dense_mlp_sets_width_on_layer_config_and_constructor(self, monkeypatch):
+        captured = {}
+
+        def fake_mlp_init(self, config, submodules, ffn_hidden_size=None, **kwargs):
+            del submodules, kwargs
+            torch.nn.Module.__init__(self)
+            captured["config"] = config
+            captured["ffn_hidden_size"] = ffn_hidden_size
+
+        monkeypatch.setattr("megatron.bridge.models.gemma.modeling_gemma4.MLP.__init__", fake_mlp_init)
+        config = _config(ffn_hidden_size=6)
+
+        Gemma4DenseMLP(config, submodules=SimpleNamespace(), ffn_hidden_size=12)
+
+        assert captured["config"] is not config
+        assert config.ffn_hidden_size == 6
+        assert captured["config"].ffn_hidden_size == 12
+        assert captured["ffn_hidden_size"] == 12
 
 
 class TestGemma4DenseSelfAttention:
@@ -1693,6 +1720,7 @@ class TestGemma4MoEHelpers:
             _config(
                 num_moe_experts=3,
                 params_dtype=torch.bfloat16,
+                sequence_parallel=True,
             )
         )
 
@@ -1700,6 +1728,8 @@ class TestGemma4MoEHelpers:
         assert isinstance(router.per_expert_scale, torch.nn.Parameter)
         assert router.scale.dtype is torch.bfloat16
         assert router.per_expert_scale.dtype is torch.bfloat16
+        assert router.scale.sequence_parallel is True
+        assert router.per_expert_scale.sequence_parallel is True
 
     def test_transformer_moe_norm_state_is_trainable(self, monkeypatch):
         def fake_layer_init(self, config, submodules, layer_number=1, **kwargs):
@@ -1712,12 +1742,14 @@ class TestGemma4MoEHelpers:
             fake_layer_init,
         )
         layer = Gemma4TransformerLayer(
-            _config(params_dtype=torch.bfloat16),
+            _config(params_dtype=torch.bfloat16, sequence_parallel=True),
             submodules=SimpleNamespace(),
         )
 
-        assert isinstance(layer.pffl_weight, torch.nn.Parameter)
+        assert isinstance(layer.pre_shared_expert_layernorm.weight, torch.nn.Parameter)
         assert isinstance(layer.post_ffn_layernorm.weight, torch.nn.Parameter)
+        assert layer.pre_shared_expert_layernorm.weight.sequence_parallel is True
+        assert layer.post_ffn_layernorm.weight.sequence_parallel is True
 
     def test_gemma4_block_spec_patches_attention_layer_and_moe_modules(self, monkeypatch):
         from megatron.core.transformer.attention import SelfAttention
@@ -1863,7 +1895,7 @@ class TestGemma4MoEHelpers:
         layer = SimpleNamespace(
             config=SimpleNamespace(fp32_residual_connection=False, layernorm_epsilon=1e-6),
             pre_mlp_layernorm=SimpleNamespace(weight=torch.tensor([2.0, 2.0])),
-            pffl_weight=torch.tensor([3.0, 3.0]),
+            pre_shared_expert_layernorm=SimpleNamespace(weight=torch.tensor([3.0, 3.0])),
             mlp=FakeMoE(),
             _forward_post_mlp=lambda output, residual: (output, residual),
         )

--- a/tests/unit_tests/models/gemma/test_gemma4_provider.py
+++ b/tests/unit_tests/models/gemma/test_gemma4_provider.py
@@ -65,7 +65,7 @@ def _build_dense_model(provider, model):
 
 
 class TestGemma4DenseProviderDefaults:
-    """Config-level checks for the Dense E4B text provider."""
+    """Config-level checks for Gemma 4 dense text providers."""
 
     @pytest.fixture
     def provider(self):
@@ -82,6 +82,7 @@ class TestGemma4DenseProviderDefaults:
             ("kv_channels", 256),
             ("global_kv_channels", 512),
             ("num_global_query_groups", 2),
+            ("attention_k_eq_v", False),
             ("seq_length", 131_072),
             ("vocab_size", 262_143),
             ("make_vocab_size_divisible_by", 128),
@@ -381,6 +382,26 @@ class TestGemma4ModelProviderDefaults:
         assert provider.fp16 is False
         assert provider.params_dtype == torch.bfloat16
         assert provider.autocast_dtype == torch.bfloat16
+
+    @pytest.mark.parametrize(
+        "provider",
+        [
+            Gemma4ModelProvider(transformer_impl="inference_optimized"),
+            Gemma4ModelProvider(cuda_graph_impl="transformer_engine"),
+            Gemma4ModelProvider(moe_shared_expert_overlap=True),
+            Gemma4ModelProvider(mlp_chunks_for_prefill=2),
+            Gemma4ModelProvider(mlp_chunks_for_training=2),
+            Gemma4ModelProvider(inference_fuse_tp_communication=True),
+            Gemma4ModelProvider(recompute_granularity="selective", recompute_modules=["layernorm"]),
+            Gemma4ModelProvider(
+                fine_grained_activation_offloading=True,
+                offload_modules=["mlp_norm"],
+            ),
+        ],
+    )
+    def test_finalize_rejects_unsupported_custom_moe_orchestration(self, provider):
+        with pytest.raises(ValueError, match="Gemma 4 MoE"):
+            provider.finalize()
 
     def test_provide_restores_dual_rotary_base(self, provider):
         mock_model = Mock()

--- a/tests/unit_tests/models/gemma/test_gemma4_provider.py
+++ b/tests/unit_tests/models/gemma/test_gemma4_provider.py
@@ -93,6 +93,7 @@ class TestGemma4DenseProviderDefaults:
             ("full_attention_rope_base", 1_000_000.0),
             ("full_attention_rope_partial_factor", 0.25),
             ("num_kv_shared_layers", 18),
+            ("use_double_wide_mlp", False),
             ("per_layer_embed_vocab_size", 262_144),
             ("per_layer_embed_dim", 256),
             ("final_logit_softcapping", 30.0),

--- a/tests/unit_tests/models/gemma/test_gemma4_provider.py
+++ b/tests/unit_tests/models/gemma/test_gemma4_provider.py
@@ -120,6 +120,13 @@ class TestGemma4DenseProviderDefaults:
         provider.finalize()
         assert provider._gemma4_dense_finalized is True
 
+    def test_finalize_marks_double_wide_layers_as_heterogeneous_for_checkpointing(self):
+        provider = Gemma4DenseProvider(use_double_wide_mlp=True)
+
+        provider.finalize()
+
+        assert provider.hetereogenous_dist_checkpoint is True
+
     def test_provide_rejects_pipeline_parallel(self, provider):
         provider.pipeline_model_parallel_size = 2
         with pytest.raises(NotImplementedError, match="PP=1"):
@@ -209,6 +216,79 @@ class TestGemma4DenseLoadStateAliases:
         _install_gemma4_dense_load_state_aliases(model)
         _install_gemma4_dense_load_state_aliases(model)
         assert model._gemma4_dense_load_state_aliases_installed is True
+
+
+class TestGemma4DenseDistributedCheckpoint:
+    """Exercise a real heterogeneous E2B model checkpoint on CPU."""
+
+    def test_double_wide_mlp_checkpoint_roundtrip(self, tmp_path):
+        from megatron.core import parallel_state
+        from megatron.core.dist_checkpointing import load, save
+
+        rendezvous = tmp_path / "dist_init"
+        checkpoint_dir = tmp_path / "checkpoint"
+        checkpoint_dir.mkdir()
+        torch.distributed.init_process_group(
+            "gloo",
+            init_method=f"file://{rendezvous}",
+            rank=0,
+            world_size=1,
+        )
+        parallel_state.initialize_model_parallel()
+
+        def make_provider():
+            return Gemma4DenseProvider(
+                num_layers=4,
+                hidden_size=8,
+                ffn_hidden_size=16,
+                num_attention_heads=2,
+                num_query_groups=1,
+                kv_channels=4,
+                global_kv_channels=4,
+                num_global_query_groups=1,
+                seq_length=8,
+                vocab_size=32,
+                make_vocab_size_divisible_by=1,
+                window_size=(3, 0),
+                window_attn_skip_freq=[True, False, True, False],
+                num_kv_shared_layers=2,
+                use_double_wide_mlp=True,
+                per_layer_embed_vocab_size=32,
+                per_layer_embed_dim=0,
+                bf16=False,
+                params_dtype=torch.float32,
+                autocast_dtype=torch.float32,
+                use_cpu_initialization=True,
+            )
+
+        try:
+            with (
+                patch(
+                    "megatron.bridge.models.gemma.gemma4_provider.Gemma4DenseRotaryEmbedding",
+                    return_value=None,
+                ),
+                patch("torch.cuda.current_device", return_value="cpu"),
+                patch("torch.cuda.synchronize"),
+            ):
+                source = make_provider().provide()
+                source_state = {
+                    name: tensor.detach().clone()
+                    for name, tensor in source.state_dict().items()
+                    if torch.is_tensor(tensor)
+                }
+                save(source.sharded_state_dict(), checkpoint_dir, async_sharded_save=False)
+
+                destination = make_provider().provide()
+                loaded_state = load(destination.sharded_state_dict(), checkpoint_dir)
+                destination.load_state_dict(loaded_state, strict=False)
+
+            fc1_shapes = [tuple(layer.mlp.linear_fc1.weight.shape) for layer in source.decoder.layers]
+            assert fc1_shapes == [(32, 8), (32, 8), (64, 8), (64, 8)]
+            for name, expected in source_state.items():
+                torch.testing.assert_close(destination.state_dict()[name], expected)
+        finally:
+            parallel_state.destroy_model_parallel()
+            torch.distributed.destroy_process_group()
 
 
 class TestGemma4PLEBlockThreading:

--- a/tests/unit_tests/models/gemma_vl/test_gemma4_vl_bridge.py
+++ b/tests/unit_tests/models/gemma_vl/test_gemma4_vl_bridge.py
@@ -71,6 +71,7 @@ def mock_hf_config_causal_moe():
     cfg.head_dim = 256
     cfg.global_head_dim = 512
     cfg.num_global_key_value_heads = 2
+    cfg.attention_k_eq_v = True
     cfg.initializer_range = 0.02
     cfg.rms_norm_eps = 1e-6
     cfg.vocab_size = 262144
@@ -103,6 +104,7 @@ def mock_hf_config_causal_dense():
     cfg.head_dim = 256
     cfg.global_head_dim = 512
     cfg.num_global_key_value_heads = 2
+    cfg.attention_k_eq_v = True
     cfg.initializer_range = 0.02
     cfg.rms_norm_eps = 1e-6
     cfg.vocab_size = 262144
@@ -158,6 +160,7 @@ def mock_text_config_moe():
     config.head_dim = 256
     config.global_head_dim = 512
     config.num_global_key_value_heads = 2
+    config.attention_k_eq_v = True
     config.initializer_range = 0.02
     config.rms_norm_eps = 1e-6
     config.vocab_size = 262144
@@ -192,6 +195,7 @@ def mock_text_config_dense():
     config.head_dim = 256
     config.global_head_dim = 512
     config.num_global_key_value_heads = 2
+    config.attention_k_eq_v = True
     config.initializer_range = 0.02
     config.rms_norm_eps = 1e-6
     config.vocab_size = 262144
@@ -331,6 +335,7 @@ class TestGemma4BridgeProviderBridgeMoE:
         assert p.global_head_dim == 512
         assert p.num_global_key_value_heads == 2
         assert p.global_rotary_percent == 0.25
+        assert p.attention_k_eq_v is True
 
     def test_interleaved_attn_pattern(self, causal_bridge, mock_causal_pretrained):
         assert causal_bridge.provider_bridge(mock_causal_pretrained).interleaved_attn_pattern == (5, 1)
@@ -692,6 +697,7 @@ class TestGemma4VLBridgeProviderBridgeMoE:
         assert p.moe_ffn_hidden_size == 704
         assert p.moe_shared_expert_intermediate_size == 2112
         assert p.moe_layer_freq == 1
+        assert p.attention_k_eq_v is True
 
     def test_softmax_scale_is_one(self, bridge, mock_hf_pretrained_moe):
         assert bridge.provider_bridge(mock_hf_pretrained_moe).softmax_scale == 1.0
@@ -821,6 +827,12 @@ class TestGemma4VLBridgeMappingRegistry:
         bridge.hf_config = mock_hf_config_moe
         names = self._collect_names(bridge.mapping_registry())
         assert any("post_shared_expert_layernorm" in n for n in names)
+
+    def test_has_direct_pre_shared_expert_norm_mapping(self, bridge, mock_hf_config_moe):
+        bridge.hf_config = mock_hf_config_moe
+        names = self._collect_names(bridge.mapping_registry())
+        assert "language_model.decoder.layers.*.pre_shared_expert_layernorm.weight" in names
+        assert "model.language_model.layers.*.pre_feedforward_layernorm.weight" in names
 
     def test_moe_registry_has_no_duplicate_non_layernorm_hf_targets(self, bridge, mock_hf_config_moe):
         bridge.hf_config = mock_hf_config_moe

--- a/tests/unit_tests/models/gemma_vl/test_gemma4_vl_bridge.py
+++ b/tests/unit_tests/models/gemma_vl/test_gemma4_vl_bridge.py
@@ -443,36 +443,30 @@ class TestMaybeModifyLoadedHFWeightCausal:
         result = causal_bridge.maybe_modify_loaded_hf_weight(hf_param, sd)
         assert result is not None
 
-    def test_router_weight_fusion(self, causal_bridge):
-        hidden = 8
-        sd = self._make_sd(hidden=hidden)
+    def test_router_weight_passthrough(self, causal_bridge):
+        sd = self._make_sd(hidden=8)
         hf_param = "model.layers.0.router.proj.weight"
+
         result = causal_bridge.maybe_modify_loaded_hf_weight(hf_param, sd)
-        assert isinstance(result, torch.Tensor)
-        assert result.shape == sd[hf_param].shape
-        expected_factor = 1.0 * (hidden**-0.5) / 2.0
-        expected = (sd[hf_param].float() * expected_factor).to(sd[hf_param].dtype)
-        torch.testing.assert_close(result, expected)
+
+        torch.testing.assert_close(result, sd[hf_param], rtol=0, atol=0)
 
     def test_router_fusion_missing_keys_passthrough(self, causal_bridge):
         sd = {"model.layers.0.router.proj.weight": torch.randn(4, 8)}
         result = causal_bridge.maybe_modify_loaded_hf_weight("model.layers.0.router.proj.weight", sd)
         torch.testing.assert_close(result, sd["model.layers.0.router.proj.weight"])
 
-    def test_shared_expert_prenorm_fusion(self, causal_bridge):
-        hidden = 8
-        sd = self._make_sd(hidden=hidden)
+    def test_shared_expert_weights_passthrough(self, causal_bridge):
+        sd = self._make_sd(hidden=8)
         hf_param = {
             "gate": "model.layers.0.mlp.gate_proj.weight",
             "up": "model.layers.0.mlp.up_proj.weight",
         }
+
         result = causal_bridge.maybe_modify_loaded_hf_weight(hf_param, sd)
-        assert isinstance(result, dict)
-        correction = 3.0 / 2.0
-        expected = (sd["model.layers.0.mlp.gate_proj.weight"].float() * correction).to(
-            sd["model.layers.0.mlp.gate_proj.weight"].dtype
-        )
-        torch.testing.assert_close(result["gate"], expected)
+
+        torch.testing.assert_close(result["gate"], sd[hf_param["gate"]], rtol=0, atol=0)
+        torch.testing.assert_close(result["up"], sd[hf_param["up"]], rtol=0, atol=0)
 
     def test_shared_expert_fusion_missing_keys_passthrough(self, causal_bridge):
         sd = {
@@ -508,38 +502,38 @@ class TestMaybeModifyConvertedHFWeightCausal:
         assert "model.layers.0.self_attn.v_proj.weight" not in result
         assert "model.layers.0.self_attn.q_proj.weight" in result
 
-    def test_router_weight_unfusion(self, causal_bridge):
-        hidden = 8
-        ref_sd = self._make_ref_sd(hidden=hidden)
-        factor = 1.0 * (hidden**-0.5) / 2.0
-        fused = (ref_sd["model.layers.0.router.proj.weight"].float() * factor).to(
-            ref_sd["model.layers.0.router.proj.weight"].dtype
-        )
+    def test_router_weight_export_passthrough(self, causal_bridge):
+        ref_sd = self._make_ref_sd(hidden=8)
+        converted = {"model.layers.0.router.proj.weight": torch.randn(4, 8)}
+
         result = causal_bridge.maybe_modify_converted_hf_weight(
-            None, {"model.layers.0.router.proj.weight": fused}, ref_sd
-        )
-        torch.testing.assert_close(
-            result["model.layers.0.router.proj.weight"],
-            ref_sd["model.layers.0.router.proj.weight"],
-            atol=1e-5,
-            rtol=1e-5,
+            None,
+            converted,
+            ref_sd,
         )
 
-    def test_shared_expert_gate_unfusion(self, causal_bridge):
-        hidden = 8
-        ref_sd = self._make_ref_sd(hidden=hidden)
-        correction = 3.0 / 2.0
-        fused = (ref_sd["model.layers.0.mlp.gate_proj.weight"].float() * correction).to(
-            ref_sd["model.layers.0.mlp.gate_proj.weight"].dtype
+        torch.testing.assert_close(
+            result["model.layers.0.router.proj.weight"],
+            converted["model.layers.0.router.proj.weight"],
+            rtol=0,
+            atol=0,
         )
+
+    def test_shared_expert_weight_export_passthrough(self, causal_bridge):
+        ref_sd = self._make_ref_sd(hidden=8)
+        converted = {"model.layers.0.mlp.gate_proj.weight": torch.randn(16, 8)}
+
         result = causal_bridge.maybe_modify_converted_hf_weight(
-            None, {"model.layers.0.mlp.gate_proj.weight": fused}, ref_sd
+            None,
+            converted,
+            ref_sd,
         )
+
         torch.testing.assert_close(
             result["model.layers.0.mlp.gate_proj.weight"],
-            ref_sd["model.layers.0.mlp.gate_proj.weight"],
-            atol=1e-5,
-            rtol=1e-5,
+            converted["model.layers.0.mlp.gate_proj.weight"],
+            rtol=0,
+            atol=0,
         )
 
     def test_empty_hf_state_dict_passthrough(self, causal_bridge):

--- a/tests/unit_tests/models/gemma_vl/test_gemma4_vl_bridge.py
+++ b/tests/unit_tests/models/gemma_vl/test_gemma4_vl_bridge.py
@@ -761,6 +761,81 @@ def test_megatron_to_hf_config_nests_final_logit_softcapping(provider_cls):
     assert hf_config["text_config"]["final_logit_softcapping"] == 17.0
 
 
+def test_megatron_to_hf_config_nests_dense_architecture_fields():
+    provider = Gemma4DenseVLProvider(
+        attention_k_eq_v=True,
+        final_logit_softcapping=17.0,
+        num_kv_shared_layers=20,
+        use_double_wide_mlp=True,
+        vision_config={"hidden_size": 1152},
+        audio_config={"hidden_size": 512},
+        eos_token_id=[1, 106],
+        window_size=(511, 0),
+    )
+
+    hf_config = Gemma4VLBridge.megatron_to_hf_config(provider)
+
+    expected = {
+        "attention_k_eq_v": True,
+        "enable_moe_block": False,
+        "final_logit_softcapping": 17.0,
+        "num_kv_shared_layers": 20,
+        "sliding_window": 512,
+        "use_double_wide_mlp": True,
+    }
+    assert {name: hf_config["text_config"][name] for name in expected} == expected
+    assert not set(expected).intersection(hf_config)
+    assert hf_config["architectures"] == ["Gemma4ForConditionalGeneration"]
+    assert hf_config["model_type"] == "gemma4"
+    assert hf_config["text_config"]["model_type"] == "gemma4_text"
+    assert hf_config["text_config"]["num_hidden_layers"] == provider.num_layers
+    assert hf_config["vision_config"] == {"hidden_size": 1152}
+    assert hf_config["audio_config"] == {"hidden_size": 512}
+    assert hf_config["eos_token_id"] == [1, 106]
+
+
+def test_megatron_to_hf_config_nests_moe_architecture_fields():
+    provider = Gemma4VLModelProvider(
+        attention_k_eq_v=True,
+        final_logit_softcapping=19.0,
+        moe_ffn_hidden_size=704,
+        moe_router_topk=8,
+        moe_shared_expert_intermediate_size=2112,
+        num_layers=6,
+        num_moe_experts=128,
+        window_size=1024,
+    )
+
+    hf_config = Gemma4VLBridge.megatron_to_hf_config(provider)
+
+    expected = {
+        "attention_k_eq_v": True,
+        "enable_moe_block": True,
+        "final_logit_softcapping": 19.0,
+        "intermediate_size": 2112,
+        "moe_intermediate_size": 704,
+        "num_experts": 128,
+        "num_kv_shared_layers": 0,
+        "sliding_window": 1024,
+        "top_k_experts": 8,
+        "use_double_wide_mlp": False,
+    }
+    assert {name: hf_config["text_config"][name] for name in expected} == expected
+    assert not set(expected).intersection(hf_config)
+    assert hf_config["text_config"]["layer_types"][:6] == ["sliding_attention"] * 5 + ["full_attention"]
+
+
+def test_megatron_to_hf_config_keeps_vl_text_mode_flat():
+    provider = Gemma4DenseProvider(final_logit_softcapping=23.0)
+
+    hf_config = Gemma4VLBridge.megatron_to_hf_config(provider)
+
+    assert "text_config" not in hf_config
+    assert hf_config["architectures"] == ["Gemma4ForCausalLM"]
+    assert hf_config["model_type"] == "gemma4_text"
+    assert hf_config["final_logit_softcapping"] == 23.0
+
+
 class TestGemma4VLBridgeMappingRegistry:
     def _collect_names(self, registry):
         names = []


### PR DESCRIPTION
## What changed

This PR contains the Gemma 4 architecture/conversion bugs discovered while investigating #4610. The focused dense-softcap fix has merged separately in #4645.

1. **E2B heterogeneous FFNs**
   - preserves `use_double_wide_mlp`
   - allocates double-wide FC1 and FC2 only in the final shared-KV layers
   - keeps the existing optimized MCore MLP kernels; `Gemma4DenseMLP` only provides the correct per-layer config width
   - marks double-wide models as heterogeneous for distributed checkpointing; a real narrow/wide save/load roundtrip is covered in tests
2. **26B-A4B MoE state and runtime graph**
   - handles current MCore's `partial(MoELayer, ...)` builder
   - directly maps trainable router scale/projection, per-expert scale, and pre/post-FFN norms
   - removes the prior lossy BF16 router/shared-prenorm fusion and its inverse
   - runs Hugging Face's distinct router, shared-expert, and routed-expert inputs while retaining MCore expert dispatch, grouped experts, auxiliary loss, and MoE recompute
   - preserves MCore's TE checkpoint path for FP8/FP4 whole-MoE recompute
   - shares the raw K projection with V before applying their independent HF normalizations on `attention_k_eq_v` layers
3. **31B dense attention config**
   - maps `sliding_window` into MCore's inclusive window tuple
   - preserves `attention_k_eq_v` for full-attention layers
4. **Training and execution safety**
   - marks new replicated norm/router parameters for sequence-parallel gradient synchronization
   - changes the functional SFT smoke to TP=2
   - rejects MCore orchestration modes bypassed by the custom MoE forward instead of silently accepting incorrect behavior
5. **Complete config export fidelity**
   - reconstructs official dense and MoE `Gemma4Config` nesting, while retaining flat `Gemma4TextConfig` for text mode
   - preserves dtype, layer pattern, local/global RoPE, head geometry, shared-KV/double-wide/window/K=V fields, PLE fields, MoE count/top-k/width, vision/audio configs, special tokens, and official model types
6. **Parity tooling**
   - removes the parity script's manual second softcap now that the model output layer applies it

Related to #4610. The issue-closing final-logit-softcap fix is merged via #4645.

## Why the fusion code is removed

The old implementation approximated Hugging Face's three-input MoE graph by folding router scale divided by pre-FFN norm-2 into the router projection and folding pre-FFN norm-1 divided by norm-2 into shared-expert weights. That workaround was lossy in BF16, omitted 120 trainable tensors from 26B export, and did not reproduce the training graph. The replacement stores and applies the original parameters directly; the code was removed rather than relocated.

## Validation environment

- `nvcr.io/nvidia/nemo:26.06`, Python 3.12, Transformers 5.8.1
- base `45186600a`; MCore `0823c731ed7d793aef047b6a64f2dbbf32bf6e2c`
- 2x RTX 6000 Ada 48 GiB
- roundtrip seed 1234; parity seed 4610; deterministic BF16 eval, TF32 disabled

Pinned official checkpoints:

- `google/gemma-4-E2B-it@70af34e20bd4b7a91f0de6b22675850c43922a03`
- `google/gemma-4-E4B-it@fee6332c1abaafb77f6f9624236c63aa2f1d0187`
- `google/gemma-4-26B-A4B-it@20da991ab4afab98e8f910c4a2e8f4fbefc404ad`
- `google/gemma-4-31B-it@3548789868c5356dbf307c98e6f609007b82b3eb`

### HF -> MCore -> HF state correspondence

Full `GEMMA4_CONVERSION_MODE=auto` / `Gemma4VLBridge` roundtrips (the final review fixes do not change weight mappings):

| Variant | TP/EP | Exact tensors | Compared elements | Missing/extra | Dtype mismatch | Error |
|---|---:|---:|---:|---:|---:|---:|
| E2B | 1/1 | 2,011/2,011 | 5,123,178,979 | 0/0 | 0 | exactly 0 |
| E4B | 1/1 | 2,130/2,130 | 7,996,157,418 | 0/0 | 0 | exactly 0 |
| 26B-A4B | 1/2 | 1,013/1,013 | 25,805,936,206 | 0/0 | 0 | exactly 0 |
| 31B | 2/1 | 1,188/1,188 | 31,273,088,876 | 0/0 | 0 | exactly 0 |

The separate dense text/LLM path is also bitwise exact for every language tensor: E2B 600 tensors / 4,647,449,891 elements, E4B 719 / 7,518,069,034, and 31B 832 / 30,697,345,340. Its omitted source keys are exactly the expected vision/audio/projector tensors.

### HF logit and generation parity

These end-to-end results were measured with this architecture fix combined with #4645's final softcap. Both pre-softcap and final post-softcap logits were captured for short/long prompts and an 8x output-head saturation control. All short/long final argmaxes agree, and the saturation cases prove exactly one cap.

| Variant | Short post max/mean abs | Long post max/mean abs | 8x post max/mean abs | Greedy new IDs |
|---|---:|---:|---:|---:|
| E2B | 0.375 / 0.005325 | 0.5 / 0.1183 | 0 / 0 | 8/8 exact |
| E4B | 0.5 / 0.05957 | 0.625 / 0.2076 | 2.5625 / 0.000411 | 8/8 exact |
| 26B-A4B | 2.1875 / 0.2029 | 7.84375 / 0.7178 | 3.25 / 2.00e-5 | 8/8 exact |
| 31B | 0.6875 / 0.1157 | 0.828125 / 0.06829 | 2.4375 / 0.006614 | 8/8 exact |

The corrected 26B K=V normalization changes greedy agreement from the first 3/8 tokens to exact 8/8. Residual BF16 fused-kernel drift later moves a few close router decisions and is amplified by sparse routing; the post-softcap logits are not claimed to be exact.

### Config and distributed-checkpoint fidelity

- all seven supported official Auto/VL and text combinations reconstruct with zero architecture-field mismatch and exact vision/audio config dictionaries
- a real four-layer E2B model with narrow and double-wide FFNs saves to MCore distributed checkpoint, loads into a new model, and matches every tensor exactly
- behavioral tests distinguish HF's `VNorm(raw_K)` from the incorrect `VNorm(KNorm(raw_K))`
- FP8 and FP4 tests require TE checkpoint dispatch and fail if the ordinary tensor-parallel checkpoint path is selected

### Focused tests and quality gates

- focused Gemma 4 bridge/model/provider/VL suite: `311 passed`
- TP=2 + sequence-parallel, 2-layer/4-expert Gemma 4 VL SFT: 10/10 iterations, 80 samples, grad norm 39.938, zero skipped/NaN iterations; validation and test completed
- `uv run pre-commit run --all-files`
- `git diff --check`

Exact state roundtrip is necessary but not sufficient: it does not exercise model construction, graph placement, router APIs, nonlinear output config, gradient synchronization, or generation. The construction, forward/parity, TP=2 training, and saturation checks above cover those separate failure classes.

## Deliberately out of scope

To keep this bug-fix PR reviewable, the separable audio-input plumbing, heterogeneous FLOP reporting, and selectable Transformer Engine RMSNorm backend/recipe defaults are not included. They remain preserved in the development backup for focused follow-ups.
