### PR TITLE
fix(model): enable attention output-gate fallback for step35 head-wis…

### DIFF
--- a/src/megatron/bridge/models/stepfun/step35_bridge.py
+++ b/src/megatron/bridge/models/stepfun/step35_bridge.py
@@ -239,14 +239,10 @@ class Step35Bridge(MegatronModelBridge):
         """
         provider = super().provider_bridge(hf_pretrained)
 
-        if (
-            getattr(provider, "head_wise_attn_gate", False)
-            and getattr(provider, "attention_output_gate", False)
-            and _mcore_supports_head_wise_attn_gate()
-        ):
+        if getattr(provider, "head_wise_attn_gate", False):
             # Native head-wise gates and the full-head output gate are mutually
-            # exclusive. Older MCore versions need the output-gate fallback.
-            provider.attention_output_gate = False
+            # exclusive; MCore without native support needs the output-gate fallback.
+            provider.attention_output_gate = not _mcore_supports_head_wise_attn_gate()
 
         hf_config = hf_pretrained.config
         mtp_layer_types = getattr(hf_config, "mtp_layer_types", None)

--- a/tests/unit_tests/models/stepfun/test_step35_bridge.py
+++ b/tests/unit_tests/models/stepfun/test_step35_bridge.py
@@ -277,6 +277,32 @@ class TestStep35BridgeProviderBridge:
         assert p.head_wise_attn_gate is True
         assert p.attention_output_gate is True
 
+    def test_head_wise_gate_without_native_support_enables_output_gate_fallback(self, monkeypatch):
+        """The published Step-3.5-Flash config carries no ``attention_output_gate``."""
+        monkeypatch.setattr(_step35_bridge_mod, "_mcore_supports_head_wise_attn_gate", lambda: False)
+        _, p = self._run(
+            hf_overrides={
+                "attention_output_gate": None,
+                "use_head_wise_attn_gate": True,
+            },
+        )
+
+        assert p.head_wise_attn_gate is True
+        assert p.attention_output_gate is True
+
+    def test_head_wise_gate_with_native_support_keeps_output_gate_off(self, monkeypatch):
+        """With native scalar gates, no fallback is enabled for the published config."""
+        monkeypatch.setattr(_step35_bridge_mod, "_mcore_supports_head_wise_attn_gate", lambda: True)
+        _, p = self._run(
+            hf_overrides={
+                "attention_output_gate": None,
+                "use_head_wise_attn_gate": True,
+            },
+        )
+
+        assert p.head_wise_attn_gate is True
+        assert p.attention_output_gate is False
+
     def test_attention_output_gate_preserved_without_head_wise_gate(self):
         _, p = self._run(
             hf_overrides={


### PR DESCRIPTION
## Summary

Step-3.5-Flash HF→Megatron conversion failed with a linear_qkv shape mismatch (Expected [10240, 4096], Got [10304, 4096]) at layer 0. The published config sets `use_head_wise_attn_gate` but no `attention_output_gate`, and the gate-mode block only ever disabled the output gate — the documented fallback for MCore without native head-wise gate support was never enabled, so the model was built without gate rows while QKVGMapping merged g_proj in.

## Changes

- `src/megatron/bridge/models/stepfun/step35_bridge.py`: the gate-mode block now sets `attention_output_gate = not _mcore_supports_head_wise_attn_gate()` whenever head-wise gates are requested (native support → off, as before; no native support → fallback on). Note this intentionally normalizes `attention_output_gate` to a bool whenever head-wise gates are requested.
- `tests/unit_tests/models/stepfun/test_step35_bridge.py`: two new tests covering both MCore-support branches with the published config shape (`attention_output_gate` absent). These pin the new behavior; the pre-existing gate tests remain the old-behavior guards.

## Verification

- Red-green (nvcr.io/nvidian/nemo:26.06.rc9): RED on unpatched source — exactly the new distributed test fails (2 failed, 46 passed); GREEN on the branch — 48/48.
- E2E: `examples/models/stepfun/step35/conversion.sh` completes the full stepfun-ai/Step-3.5-Flash conversion on the branch (checkpoint saved), past the previous crash point.

## Reference

- NVBug 6270246