### PR TITLE
fix(checkpoint): preserve quantization recipe config

### DIFF
--- a/src/megatron/bridge/training/utils/checkpoint_utils.py
+++ b/src/megatron/bridge/training/utils/checkpoint_utils.py
@@ -505,7 +505,11 @@ def _sanitize_run_config_object(obj: Any) -> Any:
         target = obj.get("_target_")
         if isinstance(target, str) and target in _RUNTIME_ONLY_TARGETS:
             return None
-        if target == _RECIPE_CONFIG_TARGET and set(obj).issubset({"_target_", "_call_"}):
+        if (
+            target == _RECIPE_CONFIG_TARGET
+            and obj.get("_call_", True) is True
+            and set(obj).issubset({"_target_", "_call_"})
+        ):
             logger.warning(
                 "Ignoring a legacy quantization recipe whose state was not preserved in run_config.yaml. "
                 "The checkpoint can still be loaded, but the original per-module quantization settings "

--- a/src/megatron/bridge/training/utils/checkpoint_utils.py
+++ b/src/megatron/bridge/training/utils/checkpoint_utils.py
@@ -35,6 +35,7 @@ CONFIG_FILE = "run_config.yaml"
 
 logger = logging.getLogger(__name__)
 _RUNTIME_ONLY_TARGETS = frozenset({"megatron.core.timers.Timers"})
+_RECIPE_CONFIG_TARGET = "megatron.core.quantization.quant_config.RecipeConfig"
 
 
 def file_exists(path: str) -> bool:
@@ -503,6 +504,13 @@ def _sanitize_run_config_object(obj: Any) -> Any:
     if isinstance(obj, dict):
         target = obj.get("_target_")
         if isinstance(target, str) and target in _RUNTIME_ONLY_TARGETS:
+            return None
+        if target == _RECIPE_CONFIG_TARGET and set(obj).issubset({"_target_", "_call_"}):
+            logger.warning(
+                "Ignoring a legacy quantization recipe whose state was not preserved in run_config.yaml. "
+                "The checkpoint can still be loaded, but the original per-module quantization settings "
+                "must be supplied separately if they are needed."
+            )
             return None
         return {key: _sanitize_run_config_object(value) for key, value in obj.items()}
     if isinstance(obj, list):

--- a/src/megatron/bridge/training/utils/config_utils.py
+++ b/src/megatron/bridge/training/utils/config_utils.py
@@ -17,6 +17,7 @@ from dataclasses import fields as dataclass_fields
 from dataclasses import is_dataclass
 from typing import Any, Mapping
 
+from megatron.core.quantization.quant_config import GlobMatcher, RecipeConfig
 from megatron.training.config.container import ConfigContainerBase as _MCoreConfigContainerBase
 from megatron.training.config.utils import (
     _get_init_false_fields,  # noqa: F401
@@ -41,9 +42,33 @@ class _ConfigContainerBase(_MCoreConfigContainerBase):
 
     @classmethod
     def _convert_value_to_dict(cls, value: Any) -> Any:
+        if isinstance(value, RecipeConfig) and not hasattr(value, "to_cfg_dict"):
+            return cls._convert_recipe_config_to_dict(value)
         if isinstance(value, PreTrainedConfig) and not hasattr(value, "to_cfg_dict"):
             return cls._convert_pretrained_config_to_dict(value, include_target=True)
         return super()._convert_value_to_dict(value)
+
+    @classmethod
+    def _convert_recipe_config_to_dict(cls, value: RecipeConfig) -> dict[str, Any]:
+        """Convert an MCore quantization recipe to an instantiable mapping."""
+        serialized_matchers: list[dict[str, Any]] = []
+        for matcher in value.matchers:
+            if type(matcher) is not GlobMatcher:
+                matcher_type = f"{type(matcher).__module__}.{type(matcher).__qualname__}"
+                raise TypeError(f"Unsupported quantization recipe matcher type: {matcher_type}")
+            serialized_matchers.append(
+                {
+                    "_target_": f"{GlobMatcher.__module__}.{GlobMatcher.__qualname__}",
+                    "pattern": matcher.pattern,
+                    "config_key": matcher.config_key,
+                }
+            )
+
+        return {
+            "_target_": f"{RecipeConfig.__module__}.{RecipeConfig.__qualname__}",
+            "matchers": serialized_matchers,
+            "config_dict": cls._convert_value_to_dict(value.configs),
+        }
 
     @classmethod
     def _convert_pretrained_config_to_dict(

--- a/src/megatron/bridge/training/utils/config_utils.py
+++ b/src/megatron/bridge/training/utils/config_utils.py
@@ -17,7 +17,7 @@ from dataclasses import fields as dataclass_fields
 from dataclasses import is_dataclass
 from typing import Any, Mapping
 
-from megatron.core.quantization.quant_config import GlobMatcher, RecipeConfig
+from megatron.core.quantization.quant_config import GlobMatcher, Matcher, RecipeConfig
 from megatron.training.config.container import ConfigContainerBase as _MCoreConfigContainerBase
 from megatron.training.config.utils import (
     _get_init_false_fields,  # noqa: F401
@@ -43,6 +43,12 @@ class _ConfigContainerBase(_MCoreConfigContainerBase):
     @classmethod
     def _convert_value_to_dict(cls, value: Any) -> Any:
         if isinstance(value, RecipeConfig) and not hasattr(value, "to_cfg_dict"):
+            if type(value) is not RecipeConfig:
+                recipe_type = f"{type(value).__module__}.{type(value).__qualname__}"
+                raise TypeError(
+                    f"Unsupported quantization recipe type: {recipe_type}. "
+                    "RecipeConfig subclasses must implement to_cfg_dict()."
+                )
             return cls._convert_recipe_config_to_dict(value)
         if isinstance(value, PreTrainedConfig) and not hasattr(value, "to_cfg_dict"):
             return cls._convert_pretrained_config_to_dict(value, include_target=True)
@@ -53,22 +59,32 @@ class _ConfigContainerBase(_MCoreConfigContainerBase):
         """Convert an MCore quantization recipe to an instantiable mapping."""
         serialized_matchers: list[dict[str, Any]] = []
         for matcher in value.matchers:
-            if type(matcher) is not GlobMatcher:
-                matcher_type = f"{type(matcher).__module__}.{type(matcher).__qualname__}"
-                raise TypeError(f"Unsupported quantization recipe matcher type: {matcher_type}")
-            serialized_matchers.append(
-                {
-                    "_target_": f"{GlobMatcher.__module__}.{GlobMatcher.__qualname__}",
-                    "pattern": matcher.pattern,
-                    "config_key": matcher.config_key,
-                }
-            )
+            serialized_matchers.append(cls._convert_recipe_matcher_to_dict(matcher))
 
         return {
             "_target_": f"{RecipeConfig.__module__}.{RecipeConfig.__qualname__}",
             "matchers": serialized_matchers,
             "config_dict": cls._convert_value_to_dict(value.configs),
         }
+
+    @classmethod
+    def _convert_recipe_matcher_to_dict(cls, matcher: Matcher) -> dict[str, Any]:
+        """Convert a quantization recipe matcher to an instantiable mapping."""
+        if type(matcher) is GlobMatcher:
+            return {
+                "_target_": f"{GlobMatcher.__module__}.{GlobMatcher.__qualname__}",
+                "pattern": matcher.pattern,
+                "config_key": matcher.config_key,
+            }
+
+        serialized_matcher = super()._convert_value_to_dict(matcher)
+        if not isinstance(serialized_matcher, dict) or "_target_" not in serialized_matcher:
+            matcher_type = f"{type(matcher).__module__}.{type(matcher).__qualname__}"
+            raise TypeError(
+                f"Unsupported quantization recipe matcher type: {matcher_type}. "
+                "Custom matchers must be dataclasses or implement to_cfg_dict()."
+            )
+        return serialized_matcher
 
     @classmethod
     def _convert_pretrained_config_to_dict(

--- a/tests/unit_tests/training/utils/test_quant_recipe_serialization.py
+++ b/tests/unit_tests/training/utils/test_quant_recipe_serialization.py
@@ -6,7 +6,9 @@ from megatron.core.quantization.quant_config import GlobMatcher, MatchContext, M
 
 from megatron.bridge.models.gpt_provider import GPTModelProvider
 from megatron.bridge.training.model_load_save import load_model_config
+from megatron.bridge.training.utils.checkpoint_utils import read_run_config
 from megatron.bridge.training.utils.config_utils import _ConfigContainerBase
+from megatron.bridge.utils.instantiate_utils import instantiate, target_allowlist
 
 
 pytestmark = pytest.mark.unit
@@ -20,6 +22,35 @@ class _RunConfig(_ConfigContainerBase):
 class _UnsupportedMatcher(Matcher):
     def match(self, context: MatchContext) -> str | None:
         return None
+
+
+class _SerializableMatcher(Matcher):
+    def __init__(self, pattern: str, config_key: str):
+        self.pattern = pattern
+        self.config_key = config_key
+
+    def match(self, context: MatchContext) -> str | None:
+        return self.config_key if context.module_path == self.pattern else None
+
+    def to_cfg_dict(self) -> dict[str, str]:
+        return {
+            "_target_": "megatron.core.quantization.quant_config.GlobMatcher",
+            "pattern": self.pattern,
+            "config_key": self.config_key,
+        }
+
+
+@dataclass
+class SerializableDataclassMatcher(Matcher):
+    pattern: str
+    config_key: str
+
+    def match(self, context: MatchContext) -> str | None:
+        return self.config_key if context.module_path == self.pattern else None
+
+
+class _RecipeConfigSubclass(RecipeConfig):
+    pass
 
 
 def _quant_recipe() -> RecipeConfig:
@@ -91,14 +122,17 @@ def test_quant_recipe_round_trips_through_run_config(tmp_path) -> None:
     )
 
 
-def test_legacy_stateless_quant_recipe_is_ignored(tmp_path, caplog) -> None:
+@pytest.mark.parametrize("include_call_flag", [False, True])
+def test_legacy_stateless_quant_recipe_is_ignored(tmp_path, caplog, include_call_flag) -> None:
     run_config_path = tmp_path / "run_config.yaml"
     _RunConfig(model=_model_provider()).to_yaml(str(run_config_path))
     run_config = yaml.safe_load(run_config_path.read_text())
-    run_config["model"]["quant_recipe"] = {
-        "_call_": True,
+    legacy_recipe = {
         "_target_": "megatron.core.quantization.quant_config.RecipeConfig",
     }
+    if include_call_flag:
+        legacy_recipe["_call_"] = True
+    run_config["model"]["quant_recipe"] = legacy_recipe
     run_config_path.write_text(yaml.safe_dump(run_config))
 
     with caplog.at_level("WARNING"):
@@ -116,8 +150,60 @@ def test_unsupported_quant_recipe_matcher_fails_loudly() -> None:
         _ConfigContainerBase._convert_value_to_dict(recipe)
 
 
+def test_custom_serializable_matcher_uses_its_config_mapping() -> None:
+    recipe = RecipeConfig(
+        matchers=[_SerializableMatcher("decoder.layers.0.*", "custom")],
+        config_dict={"custom": {}},
+    )
+
+    serialized = _ConfigContainerBase._convert_value_to_dict(recipe)
+    restored = instantiate(serialized)
+
+    assert isinstance(restored.matchers[0], GlobMatcher)
+    assert restored.matchers[0].pattern == "decoder.layers.0.*"
+    assert restored.matchers[0].config_key == "custom"
+
+
+def test_dataclass_matcher_uses_base_config_serialization() -> None:
+    recipe = RecipeConfig(
+        matchers=[SerializableDataclassMatcher("decoder.layers.0.*", "custom")],
+        config_dict={"custom": {}},
+    )
+    serialized = _ConfigContainerBase._convert_value_to_dict(recipe)
+    matcher_target = serialized["matchers"][0]["_target_"]
+    target_allowlist.add_exact(matcher_target)
+    try:
+        restored = instantiate(serialized)
+    finally:
+        target_allowlist.remove_exact(matcher_target)
+
+    assert isinstance(restored.matchers[0], SerializableDataclassMatcher)
+    assert restored.matchers[0].pattern == "decoder.layers.0.*"
+    assert restored.matchers[0].config_key == "custom"
+
+
+def test_recipe_subclass_without_serializer_fails_loudly() -> None:
+    recipe = _RecipeConfigSubclass(matchers=[], config_dict={})
+
+    with pytest.raises(TypeError, match="RecipeConfig subclasses must implement to_cfg_dict"):
+        _ConfigContainerBase._convert_value_to_dict(recipe)
+
+
 def test_upstream_recipe_serializer_takes_precedence(monkeypatch) -> None:
     recipe = _quant_recipe()
     monkeypatch.setattr(recipe, "to_cfg_dict", lambda: {"serializer": "upstream"}, raising=False)
 
     assert _ConfigContainerBase._convert_value_to_dict(recipe) == {"serializer": "upstream"}
+
+
+def test_recipe_class_reference_is_not_treated_as_legacy_stub(tmp_path) -> None:
+    run_config_path = tmp_path / "run_config.yaml"
+    recipe_class_reference = {
+        "_target_": "megatron.core.quantization.quant_config.RecipeConfig",
+        "_call_": False,
+    }
+    run_config_path.write_text(yaml.safe_dump({"recipe_class": recipe_class_reference}))
+
+    loaded = read_run_config(str(run_config_path))
+
+    assert loaded["recipe_class"] == recipe_class_reference

--- a/tests/unit_tests/training/utils/test_quant_recipe_serialization.py
+++ b/tests/unit_tests/training/utils/test_quant_recipe_serialization.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from dataclasses import dataclass
 
 import pytest

--- a/tests/unit_tests/training/utils/test_quant_recipe_serialization.py
+++ b/tests/unit_tests/training/utils/test_quant_recipe_serialization.py
@@ -1,0 +1,123 @@
+from dataclasses import dataclass
+
+import pytest
+import yaml
+from megatron.core.quantization.quant_config import GlobMatcher, MatchContext, Matcher, RecipeConfig
+
+from megatron.bridge.models.gpt_provider import GPTModelProvider
+from megatron.bridge.training.model_load_save import load_model_config
+from megatron.bridge.training.utils.config_utils import _ConfigContainerBase
+
+
+pytestmark = pytest.mark.unit
+
+
+@dataclass
+class _RunConfig(_ConfigContainerBase):
+    model: GPTModelProvider
+
+
+class _UnsupportedMatcher(Matcher):
+    def match(self, context: MatchContext) -> str | None:
+        return None
+
+
+def _quant_recipe() -> RecipeConfig:
+    return RecipeConfig(
+        matchers=[
+            GlobMatcher("decoder.layers.0.*", "first_layer"),
+            GlobMatcher("*", "fallback"),
+        ],
+        config_dict={
+            "first_layer": {
+                "transformer_engine_config_type": "TEQuantizationParams",
+                "training_recipe": {"fp8_quantization_recipe": "mxfp8"},
+            },
+            "fallback": {
+                "transformer_engine_config_type": "TEQuantizationParams",
+                "training_recipe": {},
+            },
+        },
+    )
+
+
+def _model_provider() -> GPTModelProvider:
+    return GPTModelProvider(
+        num_layers=2,
+        hidden_size=128,
+        num_attention_heads=4,
+        quant_recipe=_quant_recipe(),
+    )
+
+
+def test_quant_recipe_round_trips_through_run_config(tmp_path) -> None:
+    run_config_path = tmp_path / "run_config.yaml"
+    _RunConfig(model=_model_provider()).to_yaml(str(run_config_path))
+
+    serialized = yaml.safe_load(run_config_path.read_text())
+    serialized_recipe = serialized["model"]["quant_recipe"]
+    assert serialized_recipe == {
+        "_target_": "megatron.core.quantization.quant_config.RecipeConfig",
+        "config_dict": _quant_recipe().configs,
+        "matchers": [
+            {
+                "_target_": "megatron.core.quantization.quant_config.GlobMatcher",
+                "config_key": "first_layer",
+                "pattern": "decoder.layers.0.*",
+            },
+            {
+                "_target_": "megatron.core.quantization.quant_config.GlobMatcher",
+                "config_key": "fallback",
+                "pattern": "*",
+            },
+        ],
+    }
+
+    loaded_model, mlm_args = load_model_config(str(tmp_path))
+    assert mlm_args is None
+    assert isinstance(loaded_model.quant_recipe, RecipeConfig)
+    assert loaded_model.quant_recipe.configs == _quant_recipe().configs
+    assert (
+        loaded_model.quant_recipe.match_to_config_key(
+            MatchContext(module_path="decoder.layers.0.self_attention.linear_qkv", layer_number=0)
+        )
+        == "first_layer"
+    )
+    assert (
+        loaded_model.quant_recipe.match_to_config_key(
+            MatchContext(module_path="decoder.layers.1.self_attention.linear_qkv", layer_number=1)
+        )
+        == "fallback"
+    )
+
+
+def test_legacy_stateless_quant_recipe_is_ignored(tmp_path, caplog) -> None:
+    run_config_path = tmp_path / "run_config.yaml"
+    _RunConfig(model=_model_provider()).to_yaml(str(run_config_path))
+    run_config = yaml.safe_load(run_config_path.read_text())
+    run_config["model"]["quant_recipe"] = {
+        "_call_": True,
+        "_target_": "megatron.core.quantization.quant_config.RecipeConfig",
+    }
+    run_config_path.write_text(yaml.safe_dump(run_config))
+
+    with caplog.at_level("WARNING"):
+        loaded_model, mlm_args = load_model_config(str(tmp_path))
+
+    assert mlm_args is None
+    assert loaded_model.quant_recipe is None
+    assert "legacy quantization recipe whose state was not preserved" in caplog.text
+
+
+def test_unsupported_quant_recipe_matcher_fails_loudly() -> None:
+    recipe = RecipeConfig(matchers=[_UnsupportedMatcher()], config_dict={})
+
+    with pytest.raises(TypeError, match="Unsupported quantization recipe matcher type"):
+        _ConfigContainerBase._convert_value_to_dict(recipe)
+
+
+def test_upstream_recipe_serializer_takes_precedence(monkeypatch) -> None:
+    recipe = _quant_recipe()
+    monkeypatch.setattr(recipe, "to_cfg_dict", lambda: {"serializer": "upstream"}, raising=False)
+
+    assert _ConfigContainerBase._convert_value_to_dict(recipe) == {"serializer": "upstream"}


### PR DESCRIPTION
## Summary

NVBug: 6419767

- preserve the complete MCore `RecipeConfig` state in `run_config.yaml`, including ordered matchers and quantization configs
- support serializable custom matchers and defer to a future upstream serializer
- load lossy legacy recipe stubs as `None` with a warning instead of failing checkpoint config reconstruction

## Root cause

`RecipeConfig` is a stateful, non-dataclass object without `to_cfg_dict()`. Existing serialization recorded only its class target and discarded the required `matchers` and `config_dict`, so loading tried to call `RecipeConfig()` without its required arguments.

## Compatibility

Existing affected checkpoints cannot recover the recipe state that was already discarded; they load with `quant_recipe=None`. Checkpoints saved with this change retain the full state and instantiate `RecipeConfig` and its matchers normally when loaded.
