### PR TITLE
fix(model): make step35 layer-spec builder public so converted checkpoints load

### DIFF
--- a/src/megatron/bridge/models/stepfun/modelling_step37/transformer_block.py
+++ b/src/megatron/bridge/models/stepfun/modelling_step37/transformer_block.py
@@ -17,16 +17,16 @@
 Mirrors ``qwen_vl/modelling_qwen3_vl/transformer_block.py``: returns the
 per-layer ``TransformerLayerSubmodules`` spec consumed by Megatron's
 ``GPTModel``. Step3.7 reuses Step-3.5's hybrid full/sliding decoder layer
-(``_build_step35_layer_spec``) verbatim — the function lives in
+(``build_step35_layer_spec``) verbatim — the function lives in
 ``step35_bridge`` to keep all Step-3.5 spec-construction logic in one place.
 """
 
-from megatron.bridge.models.stepfun.step35_bridge import _build_step35_layer_spec
+from megatron.bridge.models.stepfun.step35_bridge import build_step35_layer_spec
 
 
 def get_step37_text_layer_spec(*args, **kwargs):
     """Return the Step-3.5 hybrid layer spec used as Step3.7's text decoder."""
-    return _build_step35_layer_spec(*args, **kwargs)
+    return build_step35_layer_spec(*args, **kwargs)
 
 
 __all__ = ["get_step37_text_layer_spec"]

--- a/src/megatron/bridge/models/stepfun/step35_bridge.py
+++ b/src/megatron/bridge/models/stepfun/step35_bridge.py
@@ -138,7 +138,7 @@ class _MTPDenseLayerSpecsList(list):
         return super().__getitem__(idx)
 
 
-def _build_step35_layer_spec(cfg, **kw):
+def build_step35_layer_spec(cfg, **kw):
     """Per-layer spec for Step3.5: dense for layers 0-2 and 45-47, MoE for 3-44.
 
     Also rewrites every main-decoder layer's ModuleSpec to use
@@ -347,11 +347,11 @@ class Step35Bridge(MegatronModelBridge):
                 if 0 <= idx < provider.num_layers:
                     moe_layer_freq[idx] = 1
             provider.moe_layer_freq = moe_layer_freq
-            # _build_step35_layer_spec reads moe_layer_freq to produce per-layer dense/MoE
+            # build_step35_layer_spec reads moe_layer_freq to produce per-layer dense/MoE
             # specs for the main decoder, and wraps layer_specs with _MTPDenseLayerSpecsList
             # so that get_gpt_mtp_block_spec_for_backend picks up a dense spec for MTP layers
             # (45-47 are not in moe_layers_enum).
-            provider.transformer_layer_spec = _build_step35_layer_spec
+            provider.transformer_layer_spec = build_step35_layer_spec
 
         return provider
 

--- a/src/megatron/bridge/models/stepfun/step37_bridge.py
+++ b/src/megatron/bridge/models/stepfun/step37_bridge.py
@@ -54,7 +54,7 @@ from megatron.bridge.models.stepfun.step35_bridge import (
     StackedExpertAutoMapping,
     StackedExpertGatedMLPMapping,
     Step35Bridge,
-    _build_step35_layer_spec,
+    build_step35_layer_spec,
 )
 from megatron.bridge.models.stepfun.step37_provider import Step37ModelProvider
 
@@ -278,7 +278,7 @@ class Step37Bridge(MegatronModelBridge):
                 if 0 <= idx < provider.num_layers:
                     moe_layer_freq[idx] = 1
             provider.moe_layer_freq = moe_layer_freq
-            provider.transformer_layer_spec = _build_step35_layer_spec
+            provider.transformer_layer_spec = build_step35_layer_spec
 
         # Per-layer hybrid full/sliding attention schedule.
         layer_types = getattr(text_config, "layer_types", None)

--- a/tests/unit_tests/models/stepfun/test_step35_bridge.py
+++ b/tests/unit_tests/models/stepfun/test_step35_bridge.py
@@ -35,8 +35,8 @@ from megatron.bridge.models.stepfun.step35_bridge import (
     Step35Bridge,
     Step35DecoderLayer,
     Step35SharedExpertMLP,
-    _build_step35_layer_spec,
     _MTPDenseLayerSpecsList,
+    build_step35_layer_spec,
 )
 
 
@@ -446,16 +446,27 @@ class TestStep35BridgeProviderBridge:
 
     def test_transformer_layer_spec_uses_custom_builder(self):
         _, p = self._run()
-        assert p.transformer_layer_spec is _build_step35_layer_spec
+        assert p.transformer_layer_spec is build_step35_layer_spec
+
+    def test_transformer_layer_spec_target_passes_checkpoint_load_validation(self):
+        """The serialized spec target must be loadable by the checkpoint instantiate path."""
+        from megatron.bridge.utils.instantiate_utils import _validate_target_prefix
+
+        _, p = self._run()
+        spec = p.transformer_layer_spec
+        target = f"{spec.__module__}.{spec.__qualname__}"
+        # Raises InstantiationException for private path segments — the exact
+        # gate that rejects a converted checkpoint's run_config on load.
+        _validate_target_prefix(target=target, full_key="transformer_layer_spec")
 
 
 # ---------------------------------------------------------------------------
-# _build_step35_layer_spec
+# build_step35_layer_spec
 # ---------------------------------------------------------------------------
 
 
 class TestBuildStep35LayerSpec:
-    """Cover the per-spec rewrite loop in ``_build_step35_layer_spec``.
+    """Cover the per-spec rewrite loop in ``build_step35_layer_spec``.
 
     Mocks out the two Megatron-Core spec builders so the test can run without
     a real backend, and feeds them a hand-rolled mix of MoE and dense layer
@@ -496,7 +507,7 @@ class TestBuildStep35LayerSpec:
                 return_value=fake_dense_mtp,
             ) as mock_dense,
         ):
-            out = _build_step35_layer_spec(cfg)
+            out = build_step35_layer_spec(cfg)
         return out, fake_dense_mtp, mock_block, mock_dense, cfg
 
     def test_moe_shared_experts_rebound_to_step35_shared_expert_mlp(self):

--- a/tests/unit_tests/models/stepfun/test_step37_bridge.py
+++ b/tests/unit_tests/models/stepfun/test_step37_bridge.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for Step37Bridge (Step3.7) layer-spec wiring."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from megatron.bridge.models.stepfun import step37_bridge as _step37_bridge_mod
+from megatron.bridge.models.stepfun.modelling_step37 import transformer_block as _step37_block_mod
+from megatron.bridge.models.stepfun.modelling_step37.transformer_block import get_step37_text_layer_spec
+from megatron.bridge.models.stepfun.step35_bridge import build_step35_layer_spec
+from megatron.bridge.models.stepfun.step37_bridge import Step37Bridge
+
+
+class _FakeProvider:
+    """Stand-in for `Step37ModelProvider`; empty `__dataclass_fields__` filters
+    away the CONFIG_MAPPING kwargs so no Megatron backend is needed."""
+
+    __dataclass_fields__ = {}
+
+    def __init__(self, **kwargs):
+        self.num_layers = 4
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+def _make_hf_config(**text_overrides) -> SimpleNamespace:
+    """Build a minimal Step3.7-shaped config: nested text_config + vision_config."""
+    text = dict(
+        num_hidden_layers=4,
+        torch_dtype="bfloat16",
+        moe_layers_enum="2,3",
+        layer_types=[
+            "full_attention",
+            "sliding_attention",
+            "full_attention",
+            "sliding_attention",
+        ],
+    )
+    text.update(text_overrides)
+    return SimpleNamespace(
+        text_config=SimpleNamespace(**text),
+        vision_config=SimpleNamespace(),
+    )
+
+
+class TestStep37BridgeProviderBridge:
+    """Verify the MoE-schedule branch of Step37Bridge.provider_bridge.
+
+    `Step37ModelProvider` is patched out so the test runs without a real
+    Megatron backend, mirroring the Step35Bridge unit tests.
+    """
+
+    def _run(self, **text_overrides):
+        hf_config = _make_hf_config(**text_overrides)
+        with patch.object(_step37_bridge_mod, "Step37ModelProvider", _FakeProvider):
+            return Step37Bridge().provider_bridge(SimpleNamespace(config=hf_config))
+
+    def test_moe_schedule_selects_public_layer_spec_builder(self):
+        p = self._run()
+        assert p.transformer_layer_spec is build_step35_layer_spec
+        assert p.moe_layer_freq == [0, 0, 1, 1]
+
+    def test_layer_spec_target_passes_checkpoint_load_validation(self):
+        """The serialized spec target must be loadable by the checkpoint instantiate path."""
+        from megatron.bridge.utils.instantiate_utils import _validate_target_prefix
+
+        p = self._run()
+        spec = p.transformer_layer_spec
+        target = f"{spec.__module__}.{spec.__qualname__}"
+        _validate_target_prefix(target=target, full_key="transformer_layer_spec")
+
+
+class TestGetStep37TextLayerSpec:
+    def test_delegates_to_step35_builder(self):
+        """Step3.7's text decoder spec is Step-3.5's hybrid layer spec, passed through verbatim."""
+        sentinel_cfg = object()
+        sentinel_out = object()
+        with patch.object(_step37_block_mod, "build_step35_layer_spec", return_value=sentinel_out) as builder:
+            out = get_step37_text_layer_spec(sentinel_cfg, num_experts=None)
+
+        builder.assert_called_once_with(sentinel_cfg, num_experts=None)
+        assert out is sentinel_out
+
+    def test_module_exposes_public_builder(self):
+        assert _step37_block_mod.build_step35_layer_spec is build_step35_layer_spec


### PR DESCRIPTION
## Summary

Step-3.5-Flash inference from a converted checkpoint fails: with #4686 applied, `examples/models/stepfun/step35/conversion.sh` succeeds, but `examples/models/stepfun/step35/inference.sh` (with `MEGATRON_MODEL_PATH` set) crashes on all ranks before generation:

```text
InstantiationException: Instantiation of
'megatron.bridge.models.stepfun.step35_bridge._build_step35_layer_spec'
is not allowed because private target path segments are not supported.
full_key: transformer_layer_spec
```

Root cause: the bridge assigns a private function as `transformer_layer_spec`; checkpoint save serializes its dotted path into `run_config`, and the checkpoint loader's target validation rejects private path segments. This blocks anything that loads a converted Step-3.5 checkpoint — inference, finetuning resume, and `test_step35_inference_sh`. Every other bridge uses public spec builders.

## Changes

- `src/megatron/bridge/models/stepfun/step35_bridge.py`: rename `_build_step35_layer_spec` → `build_step35_layer_spec` (public).
- `src/megatron/bridge/models/stepfun/step37_bridge.py`, `modelling_step37/transformer_block.py`: same rename at import/usage sites (Step-3.7 shares the builder).
- `tests/unit_tests/models/stepfun/test_step35_bridge.py`: new test asserting the serialized spec target (module.qualname, as checkpoint save produces it) passes the checkpoint loader's target validation.

No backward-compat shim: Step-3.5 conversion could not complete before #4686, so no existing checkpoints carry the private target.

## Verification

- Red-green (nvcr.io/nvidian/nemo:26.06.rc9): RED — on unpatched code the real validator raises `InstantiationException` on the serialized target; GREEN — full `test_step35_bridge.py` passes on the branch.
- E2E: converted `stepfun-ai/Step-3.5-Flash` (with #4686), then `inference.sh` with `MEGATRON_MODEL_PATH` loads the Megatron checkpoint and generates coherent text.

## Reference

- NVBug 6270246. Companion: #4686 (conversion produces the checkpoint; this PR makes it loadable for inference).