### PR TITLE
[inference] fix: preserve batched Qwen VL visual inputs

### DIFF
--- a/src/megatron/bridge/inference/vlm/qwenvl_inference_wrapper.py
+++ b/src/megatron/bridge/inference/vlm/qwenvl_inference_wrapper.py
@@ -55,11 +55,48 @@ class QwenVLInferenceWrapper(AbstractModelInferenceWrapper):
         image_grid_thw = None
         mm_token_type_ids = None
 
-        if image_dict and image_dict[0] is not None:
-            image_dict = image_dict[0]
-            pixel_values = _to_cuda_optional(image_dict.get("pixel_values"))
-            image_grid_thw = _to_cuda_optional(image_dict.get("image_grid_thw"))
-            mm_token_type_ids = _to_cuda_optional(image_dict.get("mm_token_type_ids"))
+        if image_dict:
+            pixel_values_per_request = [
+                _to_cuda_optional(request.get("pixel_values")) for request in image_dict if request is not None
+            ]
+            pixel_values_per_request = [value for value in pixel_values_per_request if value is not None]
+            if pixel_values_per_request:
+                pixel_values = torch.cat(pixel_values_per_request, dim=0)
+
+            image_grids_per_request = [
+                _to_cuda_optional(request.get("image_grid_thw")) for request in image_dict if request is not None
+            ]
+            image_grids_per_request = [value for value in image_grids_per_request if value is not None]
+            if image_grids_per_request:
+                image_grid_thw = torch.cat(image_grids_per_request, dim=0)
+
+            mm_token_type_ids_per_request = [
+                _to_cuda_optional(request.get("mm_token_type_ids")) if request is not None else None
+                for request in image_dict
+            ]
+            mm_token_type_ids_template = next(
+                (value for value in mm_token_type_ids_per_request if value is not None), None
+            )
+            if mm_token_type_ids_template is not None:
+                padded_mm_token_type_ids = []
+                for value in mm_token_type_ids_per_request:
+                    if value is None:
+                        value = torch.zeros(
+                            1,
+                            seq_length,
+                            dtype=mm_token_type_ids_template.dtype,
+                            device=mm_token_type_ids_template.device,
+                        )
+                    elif value.size(1) < seq_length:
+                        pad = torch.zeros(
+                            value.size(0),
+                            seq_length - value.size(1),
+                            dtype=value.dtype,
+                            device=value.device,
+                        )
+                        value = torch.cat([value, pad], dim=-1)
+                    padded_mm_token_type_ids.append(value)
+                mm_token_type_ids = torch.cat(padded_mm_token_type_ids, dim=0)
 
         out: Dict[str, Any] = {
             "input_ids": prompts_tokens,
@@ -67,14 +104,6 @@ class QwenVLInferenceWrapper(AbstractModelInferenceWrapper):
             "image_grid_thw": image_grid_thw,
         }
         if mm_token_type_ids is not None:
-            if mm_token_type_ids.size(1) < seq_length:
-                pad = torch.zeros(
-                    mm_token_type_ids.size(0),
-                    seq_length - mm_token_type_ids.size(1),
-                    dtype=mm_token_type_ids.dtype,
-                    device=mm_token_type_ids.device,
-                )
-                mm_token_type_ids = torch.cat([mm_token_type_ids, pad], dim=-1)
             out["mm_token_type_ids"] = mm_token_type_ids
 
         out["position_ids"] = (

--- a/tests/unit_tests/inference/vlm/test_qwenvl_inference_wrapper.py
+++ b/tests/unit_tests/inference/vlm/test_qwenvl_inference_wrapper.py
@@ -62,6 +62,34 @@ class TestQwenVLInferenceWrapper:
         # Just verify it was set (not None)
         assert wrapper.inference_params is not None
 
+    def test_prep_inference_input_preserves_batched_visual_inputs(self, wrapper):
+        prompts_tokens = torch.tensor([[1, 2, 3], [4, 5, 6]])
+        first_pixel_values = torch.tensor([[1.0, 2.0]])
+        second_pixel_values = torch.tensor([[3.0, 4.0], [5.0, 6.0]])
+        first_grid = torch.tensor([[1, 1, 1]])
+        second_grid = torch.tensor([[1, 1, 2]])
+        image_dict = [
+            {
+                "pixel_values": first_pixel_values,
+                "image_grid_thw": first_grid,
+                "mm_token_type_ids": torch.tensor([[0, 1, 0]], dtype=torch.int32),
+            },
+            {
+                "pixel_values": second_pixel_values,
+                "image_grid_thw": second_grid,
+                "mm_token_type_ids": torch.tensor([[1, 1, 0]], dtype=torch.int32),
+            },
+        ]
+
+        with patch(
+            "megatron.bridge.inference.vlm.qwenvl_inference_wrapper._to_cuda_optional", side_effect=lambda x: x
+        ):
+            result = wrapper.prep_inference_input(prompts_tokens, image_dict)
+
+        assert result["pixel_values"].equal(torch.cat([first_pixel_values, second_pixel_values]))
+        assert result["image_grid_thw"].equal(torch.cat([first_grid, second_grid]))
+        assert result["mm_token_type_ids"].equal(torch.tensor([[0, 1, 0], [1, 1, 0]], dtype=torch.int32))
+
     def test_prep_inference_input_pads_mm_token_type_ids(self, wrapper):
         prompts_tokens = torch.tensor([[1, 2, 3, 4, 5]])
         pixel_values = torch.randn(1, 3, 224, 224)


### PR DESCRIPTION
## What

Preserve every active Qwen VL request's visual inputs when the static inference
engine batches more than one prompt.

## Supported trigger and impact

`generate()` accepts prompt/image lists and the default static inference context
admits up to four requests. With two or more distinct images, the prompt batch
contained every request but the wrapper forwarded visual tensors only for request
zero. Later requests could fail image-token cardinality checks or generate output
without their own visual grounding.

## Root cause

The engine stores each processed image dictionary on its request, and the
controller preserves the ordered dictionaries for the active batch. The Qwen VL
wrapper then unconditionally selected `image_dict[0]`, discarding
`pixel_values`, `image_grid_thw`, and `mm_token_type_ids` from all later requests.

## Fix

Concatenate per-request pixel and image-grid tensors at the wrapper's model-input
boundary. Build request-aligned multimodal token-type rows, padding shorter or
missing rows to the inference sequence length. Single-image and text-only inputs
retain their existing behavior.

## Verification

Focused regression:

```text
uv run python -m pytest tests/unit_tests/inference/vlm/test_qwenvl_inference_wrapper.py::TestQwenVLInferenceWrapper::test_prep_inference_input_preserves_batched_visual_inputs -q
```

- Before: `1 failed`; returned only request zero's pixel tensor.
- After: `1 passed`.

Adjacent inference tests:

```text
uv run python -m pytest tests/unit_tests/inference/vlm/test_qwenvl_inference_wrapper.py tests/unit_tests/inference/vlm/test_vlm_inference_controller.py tests/unit_tests/inference/vlm/test_vlm_engine.py -q
```

- Result: `20 passed`.

Additional checks:

- `git diff --check` — passed
- `uv run pre-commit run --all-files` — passed

## Scope

This change is limited to static Qwen2.5-VL/Qwen3-VL input assembly. It does not
claim pipeline-parallel support, full-suite coverage, end-to-end model-quality
validation, or performance validation.
