### PR TITLE
Fix output layer not found with VPP > 1 when tie_word_embeddings

### DIFF
--- a/src/megatron/bridge/models/conversion/model_bridge.py
+++ b/src/megatron/bridge/models/conversion/model_bridge.py
@@ -1521,17 +1521,24 @@ class MegatronModelBridge(
         Args:
             megatron_model: Megatron model instance or list of model instances.
         """
-        unwrapped_model = unwrap_model(megatron_model)[0]
+        pp_group = _get_pp_group(megatron_model)
+        is_first_pp_stage = is_pp_first_stage(pp_group)
+        is_last_pp_stage = is_pp_last_stage(pp_group)
+
+        unwrapped_models = unwrap_model(megatron_model)
+        if not isinstance(unwrapped_models, list):
+            unwrapped_models = [unwrapped_models]
+        # VPP chunk 0 owns the input embedding; the final chunk owns the output layer.
+        unwrapped_model = unwrapped_models[-1] if is_last_pp_stage else unwrapped_models[0]
+
         # hack for vlm to work properly
         if hasattr(unwrapped_model, "language_model") and unwrapped_model.language_model is not None:
             unwrapped_model = unwrapped_model.language_model
         model_config = unwrapped_model.config
         share_embeddings = self._share_embeddings_and_output_weights(model_config)
 
-        # TODO(yuya): Fix for VPP, the vp stage needs to be passed in for stage checks
-        pp_group = _get_pp_group(megatron_model)
         if (share_embeddings and model_config.pipeline_model_parallel_size > 1) and (
-            is_pp_first_stage(pp_group) or is_pp_last_stage(pp_group)
+            is_first_pp_stage or is_last_pp_stage
         ):
             # Broadcast embeddings and output weights from rank 0 to embedding group
             embd_group = _get_embedding_group(megatron_model)

--- a/tests/unit_tests/models/test_model_bridge_lora.py
+++ b/tests/unit_tests/models/test_model_bridge_lora.py
@@ -18,6 +18,7 @@ from unittest.mock import Mock
 import pytest
 import torch
 
+import megatron.bridge.models.conversion.model_bridge as model_bridge_module
 from megatron.bridge.models.conversion.mapping_registry import MegatronMappingRegistry
 from megatron.bridge.models.conversion.model_bridge import (
     AdapterWeightConversionTask,
@@ -70,6 +71,87 @@ def _patch_parallel_state(monkeypatch):
         "megatron.bridge.models.conversion.peft_bridge.parallel_state.get_tensor_model_parallel_group",
         lambda: None,
     )
+
+
+def _patch_pipeline_state(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    is_first_stage: bool,
+    is_last_stage: bool,
+    rank: int,
+) -> tuple[object, Mock]:
+    pp_group = object()
+    embedding_group = object()
+    broadcast = Mock()
+
+    monkeypatch.setattr(model_bridge_module, "_get_pp_group", lambda _model: pp_group)
+    monkeypatch.setattr(model_bridge_module, "_get_embedding_group", lambda _model: embedding_group)
+    monkeypatch.setattr(model_bridge_module, "is_pp_first_stage", lambda _group: is_first_stage)
+    monkeypatch.setattr(model_bridge_module, "is_pp_last_stage", lambda _group: is_last_stage)
+    monkeypatch.setattr(torch.distributed, "get_process_group_ranks", lambda _group: [0, 1])
+    monkeypatch.setattr(torch.distributed, "get_rank", lambda: rank)
+    monkeypatch.setattr(torch.distributed, "broadcast", broadcast)
+
+    return embedding_group, broadcast
+
+
+def test_broadcast_shared_embeddings_uses_first_vpp_chunk_on_first_pp_stage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = SimpleNamespace(share_embeddings_and_output_weights=True, pipeline_model_parallel_size=2)
+    word_embeddings = torch.nn.Embedding(2, 3)
+    output_layer = torch.nn.Linear(3, 2, bias=False)
+    with torch.no_grad():
+        output_layer.weight.fill_(-1)
+
+    model_chunks = [
+        SimpleNamespace(config=config, embedding=SimpleNamespace(word_embeddings=word_embeddings)),
+        SimpleNamespace(config=config, output_layer=output_layer),
+    ]
+    embedding_group, broadcast = _patch_pipeline_state(
+        monkeypatch,
+        is_first_stage=True,
+        is_last_stage=False,
+        rank=0,
+    )
+
+    DummyBridge()._broadcast_shared_embeddings(model_chunks)
+
+    broadcast.assert_called_once()
+    broadcasted_weight = broadcast.call_args.args[0]
+    assert broadcasted_weight.data_ptr() == word_embeddings.weight.data_ptr()
+    assert broadcast.call_args.kwargs == {"src": 0, "group": embedding_group}
+    torch.testing.assert_close(output_layer.weight, torch.full_like(output_layer.weight, -1))
+
+
+def test_broadcast_shared_embeddings_uses_last_vpp_chunk_on_last_pp_stage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = SimpleNamespace(share_embeddings_and_output_weights=True, pipeline_model_parallel_size=2)
+    output_layer = torch.nn.Linear(3, 2, bias=False)
+    received_weight = torch.full_like(output_layer.weight, 4)
+    model_chunks = [
+        SimpleNamespace(config=config),
+        SimpleNamespace(config=config, output_layer=output_layer),
+    ]
+    embedding_group, broadcast = _patch_pipeline_state(
+        monkeypatch,
+        is_first_stage=False,
+        is_last_stage=True,
+        rank=1,
+    )
+
+    def receive_weight(tensor: torch.Tensor, *, src: int, group: object) -> None:
+        assert src == 0
+        assert group is embedding_group
+        tensor.copy_(received_weight)
+
+    broadcast.side_effect = receive_weight
+
+    DummyBridge()._broadcast_shared_embeddings(model_chunks)
+
+    broadcast.assert_called_once()
+    torch.testing.assert_close(output_layer.weight, received_weight)
 
 
 def test_merge_lora_adapter_weights_merges(monkeypatch):


### PR DESCRIPTION
# What does this PR do ?

Fix output layer not found with VPP > 1 when tie_word_embeddings

# Changelog

- Implement the TODO: the vp stage needs to be passed in for stage checks, as it can be that VPP chunk 0 owns the input embedding, the final chunk owns the output layer.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [X] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
