### PR TITLE
[data] fix: Preserve Qwen2-Audio source sampling rates

### DIFF
--- a/src/megatron/bridge/models/qwen_audio/data/collate_fn.py
+++ b/src/megatron/bridge/models/qwen_audio/data/collate_fn.py
@@ -56,6 +56,8 @@ def qwen2_audio_collate_fn(
 
     texts = []
     audio_inputs = []
+    audio_sampling_rates = set()
+    has_audio_without_sampling_rate = False
     for example in examples:
         texts.append(
             processor.apply_chat_template(
@@ -67,11 +69,24 @@ def qwen2_audio_collate_fn(
         audio = example.get("audio")
         if audio is not None:
             if isinstance(audio, tuple):
-                audio_inputs.append(audio[0])  # (array, sr) -> array
+                audio_inputs.append(audio[0])
+                audio_sampling_rates.add(int(audio[1]))
             elif isinstance(audio, dict):
                 audio_inputs.append(audio["array"])
+                sampling_rate = audio.get("sampling_rate")
+                if sampling_rate is None:
+                    has_audio_without_sampling_rate = True
+                else:
+                    audio_sampling_rates.add(int(sampling_rate))
             else:
                 audio_inputs.append(audio)
+                has_audio_without_sampling_rate = True
+
+    if len(audio_sampling_rates) > 1:
+        raise ValueError("Qwen2-Audio batches require a single sampling rate.")
+    if audio_sampling_rates and has_audio_without_sampling_rate:
+        raise ValueError("Qwen2-Audio batches cannot mix audio with known and unknown sampling rates.")
+    audio_kwargs = {"sampling_rate": next(iter(audio_sampling_rates))} if audio_sampling_rates else {}
 
     tokenizer = getattr(processor, "tokenizer", processor)
 
@@ -84,6 +99,7 @@ def qwen2_audio_collate_fn(
             audio=audio_inputs if audio_inputs else None,
             return_tensors="pt",
             padding=True,
+            **audio_kwargs,
         )
     finally:
         if tokenizer is not None and saved_padding_side is not None:

--- a/tests/unit_tests/data/vlm_datasets/test_collate.py
+++ b/tests/unit_tests/data/vlm_datasets/test_collate.py
@@ -253,6 +253,182 @@ def test_qwen2_audio_collate_fn_uses_audio_inputs_key(monkeypatch):
     assert "feature_attention_mask" not in batch
 
 
+def test_qwen2_audio_collate_fn_forwards_source_sampling_rate(monkeypatch):
+    class _AudioProcessor:
+        class _Tok:
+            pad_token_id = 0
+            padding_side = "right"
+            added_tokens_decoder = {}
+
+            def __call__(self, text, add_special_tokens=False):  # noqa: ARG002
+                return {"input_ids": [1, 2]}
+
+        def __init__(self):
+            self.tokenizer = self._Tok()
+            self.sampling_rate = None
+
+        def apply_chat_template(self, conversation, tokenize=False, **kwargs):  # noqa: ARG002
+            return "dummy"
+
+        def __call__(
+            self,
+            text=None,
+            audio=None,
+            *,
+            sampling_rate,
+            return_tensors="pt",
+            padding=True,
+        ):
+            self.sampling_rate = sampling_rate
+            n = len(text)
+            return {
+                "input_ids": torch.tensor([[1, 2, 3]] * n),
+                "input_features": torch.randn(n, 80, 16),
+                "feature_attention_mask": torch.ones(n, 16),
+            }
+
+    monkeypatch.setattr(qwen_audio_collate, "gather_assistant_text_segments", lambda ex: ["dummy"])
+
+    processor = _AudioProcessor()
+    examples = [
+        {
+            "conversation": [{"role": "user", "content": [{"type": "text", "text": "transcribe"}]}],
+            "audio": (torch.zeros(8_000), 8_000),
+        }
+    ]
+
+    collate.qwen2_audio_collate_fn(examples, processor)
+
+    assert processor.sampling_rate == 8_000
+
+
+@pytest.mark.parametrize(
+    ("audio_values", "error"),
+    [
+        ([(torch.zeros(1), 8_000), (torch.zeros(1), 16_000)], "single sampling rate"),
+        ([(torch.zeros(1), 8_000), torch.zeros(1)], "known and unknown sampling rates"),
+    ],
+)
+def test_qwen2_audio_collate_fn_rejects_ambiguous_sampling_rates(audio_values, error):
+    class _AudioProcessor:
+        class _Tok:
+            pad_token_id = 0
+            padding_side = "right"
+            added_tokens_decoder = {}
+
+        def __init__(self):
+            self.tokenizer = self._Tok()
+
+        def apply_chat_template(self, conversation, tokenize=False, **kwargs):  # noqa: ARG002
+            return "dummy"
+
+        def __call__(self, **kwargs):  # noqa: ARG002
+            raise AssertionError("ambiguous audio rates must be rejected before processor invocation")
+
+    examples = [
+        {
+            "conversation": [{"role": "user", "content": [{"type": "text", "text": "transcribe"}]}],
+            "audio": audio,
+        }
+        for audio in audio_values
+    ]
+
+    with pytest.raises(ValueError, match=error):
+        collate.qwen2_audio_collate_fn(examples, _AudioProcessor())
+
+
+def test_qwen2_audio_collate_fn_preserves_raw_audio_compatibility(monkeypatch):
+    class _AudioProcessor:
+        class _Tok:
+            pad_token_id = 0
+            padding_side = "right"
+            added_tokens_decoder = {}
+
+            def __call__(self, text, add_special_tokens=False):  # noqa: ARG002
+                return {"input_ids": [1, 2]}
+
+        def __init__(self):
+            self.tokenizer = self._Tok()
+            self.sampling_rate = "unset"
+
+        def apply_chat_template(self, conversation, tokenize=False, **kwargs):  # noqa: ARG002
+            return "dummy"
+
+        def __call__(
+            self,
+            text=None,
+            audio=None,
+            *,
+            sampling_rate=None,
+            return_tensors="pt",
+            padding=True,
+        ):
+            self.sampling_rate = sampling_rate
+            n = len(text)
+            return {
+                "input_ids": torch.tensor([[1, 2, 3]] * n),
+                "input_features": torch.randn(n, 80, 16),
+                "feature_attention_mask": torch.ones(n, 16),
+            }
+
+    monkeypatch.setattr(qwen_audio_collate, "gather_assistant_text_segments", lambda ex: ["dummy"])
+
+    processor = _AudioProcessor()
+    examples = [
+        {
+            "conversation": [{"role": "user", "content": [{"type": "text", "text": "transcribe"}]}],
+            "audio": torch.zeros(8_000),
+        }
+    ]
+
+    collate.qwen2_audio_collate_fn(examples, processor)
+
+    assert processor.sampling_rate is None
+
+
+def test_qwen2_audio_collate_fn_rejects_non_native_whisper_sampling_rate():
+    from transformers import WhisperFeatureExtractor
+
+    class _AudioProcessor:
+        class _Tok:
+            pad_token_id = 0
+            padding_side = "right"
+            added_tokens_decoder = {}
+
+        def __init__(self):
+            self.tokenizer = self._Tok()
+            self.feature_extractor = WhisperFeatureExtractor()
+
+        def apply_chat_template(self, conversation, tokenize=False, **kwargs):  # noqa: ARG002
+            return "dummy"
+
+        def __call__(
+            self,
+            text=None,
+            audio=None,
+            *,
+            sampling_rate=None,
+            return_tensors="pt",
+            padding=True,
+        ):
+            return self.feature_extractor(
+                audio,
+                sampling_rate=sampling_rate,
+                return_attention_mask=True,
+                return_tensors=return_tensors,
+            )
+
+    examples = [
+        {
+            "conversation": [{"role": "user", "content": [{"type": "text", "text": "transcribe"}]}],
+            "audio": (torch.zeros(8_000).numpy(), 8_000),
+        }
+    ]
+
+    with pytest.raises(ValueError, match="8000"):
+        collate.qwen2_audio_collate_fn(examples, _AudioProcessor())
+
+
 def test_qwen2_audio_collate_fn_defers_packing_to_audio_step(monkeypatch):
     class _AudioProcessor:
         class _Tok:


### PR DESCRIPTION
## What changed

Preserve source sampling-rate metadata when Qwen2-Audio conversation batches
are sent to the Hugging Face processor. Batches containing different known
rates, or a mixture of known and unknown rates, now fail closed instead of
assigning one rate to every waveform. Raw waveform-only inputs retain their
previous default behavior.

## User impact

`make_default_audio_dataset` supports arbitrary Hugging Face audio/text
datasets, and the configurable Common Voice maker preserves each decoded
waveform's native rate. The Qwen2-Audio collator previously stripped that rate
before feature extraction. A non-16-kHz waveform could therefore be silently
interpreted at the Whisper extractor's 16-kHz rate, changing its duration and
features (for example, 8,000 samples at 8 kHz were treated as 0.5 seconds).

The stock recipe dataset is already 16 kHz and is unchanged.

## Root cause and fix

The maker-to-collator contract uses `(waveform, sampling_rate)`, but the
collator appended only tuple element zero. The fix collects tuple/dict rates,
validates that a processor batch has one unambiguous rate, and forwards that
rate through `Qwen2AudioProcessor` to `WhisperFeatureExtractor`.

This does not add resampling. Unsupported rates are explicitly rejected by the
pinned extractor instead of being silently reinterpreted.

## Verification

Fail before / pass after:

```text
uv run python -m pytest \
  tests/unit_tests/data/vlm_datasets/test_collate.py::test_qwen2_audio_collate_fn_forwards_source_sampling_rate -q

before: 1 failed — processor call omitted required `sampling_rate`
after:  1 passed
```

Focused and adjacent checks:

```text
uv run python -m pytest tests/unit_tests/data/vlm_datasets/test_collate.py -k qwen2_audio -q
# 7 passed, 45 deselected (Transformers 5.8.1)

uv run python -m pytest \
  tests/unit_tests/data/hf_datasets/test_makers.py::test_make_cv17_dataset \
  tests/unit_tests/data/hf_datasets/test_makers.py::test_make_default_audio_dataset_custom_text_column_keeps_spaces -q
# 2 passed

uv run pre-commit run --all-files
# passed
```

Coverage includes real Whisper rejection for maker-shaped 8-kHz input,
heterogeneous known-rate rejection, known/unknown-rate rejection, and raw-only
compatibility. This is a CPU data-contract fix; no model-quality, convergence,
performance, or full-suite validation is claimed.
