### PR TITLE
[model] fix: restore quantized HF export streaming

### DIFF
--- a/src/megatron/bridge/models/conversion/quant_bridge.py
+++ b/src/megatron/bridge/models/conversion/quant_bridge.py
@@ -59,7 +59,7 @@ class MegatronQuantizationBridge:
         megatron_to_hf_tasks = conversion_tasks
         unwrapped_model = unwrap_model(megatron_model)[0]
         model_config = unwrapped_model.config
-        embeddings_are_tied = self._share_embeddings_and_output_weights(model_config, unwrapped_model)
+        embeddings_are_tied = self._share_embeddings_and_output_weights(model_config)
 
         hf_state_dict: Mapping[str, torch.Tensor] = hf_pretrained.state if hasattr(hf_pretrained, "state") else {}
 

--- a/tests/unit_tests/quantization/test_quant_bridge.py
+++ b/tests/unit_tests/quantization/test_quant_bridge.py
@@ -12,12 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+import types
 from unittest.mock import patch
 
 import pytest
 import torch
 from megatron.core.transformer.transformer_config import TransformerConfig
 
+from megatron.bridge.models.conversion import quant_bridge as quant_bridge_module
 from megatron.bridge.models.conversion.param_mapping import (
     AutoMapping,
     ColumnParallelMapping,
@@ -27,6 +30,7 @@ from megatron.bridge.models.conversion.param_mapping import (
     RowParallelMapping,
     merge_qkv_weights,
 )
+from megatron.bridge.models.conversion.quant_bridge import MegatronQuantizationBridge
 
 
 def scaled_fp8_blockwise(
@@ -161,6 +165,42 @@ class MockModule(torch.nn.Module):
 
 def dummy_quantization_checker(param_name):
     return True
+
+
+def test_quantized_stream_uses_model_config_for_tied_embeddings(monkeypatch):
+    model_bridge_module = types.ModuleType("megatron.bridge.models.conversion.model_bridge")
+    model_bridge_module.HFWeightTuple = tuple
+    monkeypatch.setitem(
+        sys.modules,
+        "megatron.bridge.models.conversion.model_bridge",
+        model_bridge_module,
+    )
+
+    model_config = object()
+    model = types.SimpleNamespace(config=model_config)
+    seen_configs = []
+
+    bridge = MegatronQuantizationBridge()
+    monkeypatch.setattr(
+        bridge,
+        "_share_embeddings_and_output_weights",
+        lambda config: seen_configs.append(config) or False,
+        raising=False,
+    )
+    monkeypatch.setattr(bridge, "_with_progress_tracking", lambda tasks, *_args: tasks, raising=False)
+    monkeypatch.setattr(quant_bridge_module, "unwrap_model", lambda _models: [model])
+
+    exported = bridge.stream_weights_megatron_to_hf_quant(
+        model,
+        types.SimpleNamespace(),
+        quantization_checker=lambda _name: False,
+        quant_fn=lambda weight, _block_size: (weight, torch.ones(1)),
+        conversion_tasks=[],
+        show_progress=False,
+    )
+
+    assert list(exported) == []
+    assert seen_configs == [model_config]
 
 
 class TestColumnParallelMappingQuant:


### PR DESCRIPTION
## What does this PR do?

Restore the public `AutoBridge.export_hf_weights_quant()` streaming path.

Any valid invocation currently raises on first generator iteration, before a
conversion task or quantization callback can run. This blocks the supported
quantize-before-gather workflow introduced for downstream training/RL weight sync.

Related API-tracking context: #4103.

## Root cause

The quantized stream passed both the model config and unwrapped model to
`_share_embeddings_and_output_weights()`, but that helper accepts only the model
config. Python therefore raised:

```text
TypeError: ... takes 1 positional argument but 2 were given
```

The ordinary HF export path already uses the correct one-argument contract.

## Fix

Pass only `model_config`, matching the helper definition and ordinary export.
Add a focused stream-level regression test that forces generator iteration with
valid empty conversion tasks and verifies the exact config object passed to the
tied-embedding helper.

## Validation

Fail before, pass after:

```bash
PYTHONPATH=<CPU-import-shim>:src:3rdparty/Megatron-LM \
  uv run --no-sync python -m pytest --confcutdir=tests/unit_tests/quantization \
  tests/unit_tests/quantization/test_quant_bridge.py::test_quantized_stream_uses_model_config_for_tied_embeddings -q
```

- Before: `1 failed` at `quant_bridge.py:62` with the claimed `TypeError`.
- After: `1 passed`.

Adjacent quantized mappings:

```bash
PYTHONPATH=<CPU-import-shim>:src:3rdparty/Megatron-LM \
  uv run --no-sync python -m pytest --confcutdir=tests/unit_tests/quantization \
  tests/unit_tests/quantization/test_quant_bridge.py -k 'not QKV' -q
```

- `9 passed, 1 deselected`.
- The deselected QKV case is GPU-only. This fix is in stream orchestration before
  mapping or collective work and does not change GPU/distributed behavior.

Additional checks:

```text
git diff --check                              passed
uv run --no-sync pre-commit run --all-files  passed
```

## Scope

No mapping, quantization algorithm, tensor layout, public signature, dependency,
workflow, or MCore code is changed.
