### PR TITLE
ci: add weekly verl e2e test suite

### DIFF
--- a/.github/workflows/verl-e2e-weekly.yml
+++ b/.github/workflows/verl-e2e-weekly.yml
@@ -27,10 +27,6 @@ on:
         required: false
         type: string
         default: main
-  # TEMPORARY (revert before merge): smoke-test on the copy-pr-bot mirror branch
-  push:
-    branches:
-      - "pull-request/[0-9]+"
 
 concurrency:
   group: ${{ github.workflow }}
@@ -53,8 +49,7 @@ jobs:
         shell: bash -x -e -u -o pipefail {0}
         env:
           RUNNER_PREFIX: ${{ vars.DEFAULT_RUNNER_PREFIX }}
-          # TEMPORARY (revert before merge): restrict the PR smoke-test to the cheapest script
-          SINGLE: ${{ github.event.inputs.script || (startsWith(github.ref, 'refs/heads/pull-request/') && 'run_megatron_qwen3' || '') }}
+          SINGLE: ${{ github.event.inputs.script }}
         run: |
           get_header() {
             grep -m1 "^# $1=" "$2" | cut -d= -f2

--- a/.github/workflows/verl-e2e-weekly.yml
+++ b/.github/workflows/verl-e2e-weekly.yml
@@ -1,0 +1,156 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: verl e2e (weekly)
+
+on:
+  schedule:
+    - cron: "0 6 * * 1" # Mondays 06:00 UTC
+  workflow_dispatch:
+    inputs:
+      script:
+        description: "Run a single script (basename without .sh); empty = all run_*.sh"
+        required: false
+        type: string
+      verl_ref:
+        description: "verl git ref to check out"
+        required: false
+        type: string
+        default: main
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  discover:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.scan.outputs.matrix }}
+      has_scripts: ${{ steps.scan.outputs.has_scripts }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Scan verl_ci/run_*.sh into a matrix
+        id: scan
+        shell: bash -x -e -u -o pipefail {0}
+        env:
+          RUNNER_PREFIX: ${{ vars.DEFAULT_RUNNER_PREFIX }}
+          SINGLE: ${{ github.event.inputs.script }}
+        run: |
+          get_header() {
+            grep -m1 "^# $1=" "$2" | cut -d= -f2
+          }
+
+          entries=""
+          for f in .github/workflows/verl_ci/run_*.sh; do
+            [ -f "$f" ] || continue
+            name=$(basename "$f" .sh)
+            if [ -n "${SINGLE:-}" ] && [ "$name" != "$SINGLE" ]; then
+              continue
+            fi
+            timeout=$(get_header CI_TIMEOUT "$f"); timeout=${timeout:-60}
+            gpu_count=$(get_header GPU_COUNT "$f"); gpu_count=${gpu_count:-8}
+            # shellcheck disable=SC2001 # regex quantifier not expressible via ${var//}
+            runner=$(echo "${RUNNER_PREFIX}" | sed "s/gpu-x[0-9]*/gpu-${gpu_count}/")
+            entries="${entries}{\"script\":\"${name}\",\"timeout\":${timeout},\"runner\":\"${runner}\"},"
+          done
+
+          matrix="{\"include\":[${entries%,}]}"
+          echo "matrix=${matrix}" | tee -a "$GITHUB_OUTPUT"
+          if [ -n "$entries" ]; then
+            echo "has_scripts=true" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "has_scripts=false" | tee -a "$GITHUB_OUTPUT"
+          fi
+
+  verl-e2e:
+    needs: [discover]
+    if: needs.discover.outputs.has_scripts == 'true'
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix: ${{ fromJSON(needs.discover.outputs.matrix) }}
+    runs-on: ${{ matrix.runner }}
+    name: ${{ matrix.script }}
+    timeout-minutes: ${{ matrix.timeout }}
+    env:
+      CONTAINER: verl_${{ github.run_id }}_${{ matrix.script }}
+      VERL_IMAGE: ${{ vars.DEFAULT_CONTAINER_REGISTRY }}/dockerhub/verlai/verl:vllm020.dev1
+      VERL_REF: ${{ github.event.inputs.verl_ref || 'main' }}
+      TEST_DATA_PATH: ${{ vars.DEFAULT_TEST_DATA_PATH }}
+      VERL_DATA_ROOT: /home/TestData/verl_ci
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Start verl container
+        shell: bash -x -e -u -o pipefail {0}
+        run: |
+          docker rm -f "$CONTAINER" || true
+          docker run \
+            --rm -d \
+            --name "$CONTAINER" \
+            --runtime=nvidia --gpus all \
+            --shm-size=64g \
+            --env HF_HUB_OFFLINE=1 \
+            --env VERL_DATA_ROOT="$VERL_DATA_ROOT" \
+            --volume "${TEST_DATA_PATH}:/home/TestData" \
+            --volume "${GITHUB_WORKSPACE}:/opt/Megatron-Bridge" \
+            --workdir /workspace \
+            "$VERL_IMAGE" \
+            bash -c "sleep $(( ${{ matrix.timeout }} * 60 + 300 ))"
+
+      - name: Run ${{ matrix.script }}
+        shell: bash -x -e -u -o pipefail {0}
+        run: |
+          docker exec \
+            -e SCRIPT_PATH="/opt/Megatron-Bridge/.github/workflows/verl_ci/${{ matrix.script }}.sh" \
+            -e VERL_REF="$VERL_REF" \
+            -e VERL_DATA_ROOT="$VERL_DATA_ROOT" \
+            "$CONTAINER" bash -euxo pipefail -c '
+              export HOME=/tmp/verl_home
+              mkdir -p "$HOME"
+              # Reproduce verl runner layout: $HOME/models/<org>/<name> + $HOME/models/hf_data/gsm8k
+              ln -sfn "$VERL_DATA_ROOT/models" "$HOME/models"
+              git clone https://github.com/verl-project/verl.git /workspace/verl
+              cd /workspace/verl
+              git checkout "$VERL_REF"
+              git rev-parse HEAD
+              bash "$SCRIPT_PATH"
+            '
+
+      - name: Cleanup container
+        if: always()
+        shell: bash
+        run: docker rm -f "$CONTAINER" || true
+
+  notify:
+    needs: [discover, verl-e2e]
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack on failure
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_CI_CHANNEL_WEBHOOK }}
+          SLACK_WEBHOOK_ADMIN: <!subteam^${{ secrets.SLACK_TEAM_GROUP_ID }}>
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          curl -X POST \
+            -H 'Content-type: application/json' \
+            --data "{\"text\":\":rotating_light: <https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}|verl e2e (weekly)> has failing leg(s). Please review.\n\ncc ${SLACK_WEBHOOK_ADMIN}\"}" \
+            "$SLACK_WEBHOOK"

--- a/.github/workflows/verl-e2e-weekly.yml
+++ b/.github/workflows/verl-e2e-weekly.yml
@@ -27,6 +27,10 @@ on:
         required: false
         type: string
         default: main
+  # TEMPORARY (revert before merge): smoke-test on the copy-pr-bot mirror branch
+  push:
+    branches:
+      - "pull-request/[0-9]+"
 
 concurrency:
   group: ${{ github.workflow }}
@@ -49,7 +53,8 @@ jobs:
         shell: bash -x -e -u -o pipefail {0}
         env:
           RUNNER_PREFIX: ${{ vars.DEFAULT_RUNNER_PREFIX }}
-          SINGLE: ${{ github.event.inputs.script }}
+          # TEMPORARY (revert before merge): restrict the PR smoke-test to the cheapest script
+          SINGLE: ${{ github.event.inputs.script || (startsWith(github.ref, 'refs/heads/pull-request/') && 'run_megatron_qwen3' || '') }}
         run: |
           get_header() {
             grep -m1 "^# $1=" "$2" | cut -d= -f2
@@ -65,7 +70,7 @@ jobs:
             timeout=$(get_header CI_TIMEOUT "$f"); timeout=${timeout:-60}
             gpu_count=$(get_header GPU_COUNT "$f"); gpu_count=${gpu_count:-8}
             # shellcheck disable=SC2001 # regex quantifier not expressible via ${var//}
-            runner=$(echo "${RUNNER_PREFIX}" | sed "s/gpu-x[0-9]*/gpu-${gpu_count}/")
+            runner=$(echo "${RUNNER_PREFIX}" | sed "s/gpu-x[0-9]*/gpu-x${gpu_count}/")
             entries="${entries}{\"script\":\"${name}\",\"timeout\":${timeout},\"runner\":\"${runner}\"},"
           done
 

--- a/.github/workflows/verl_ci/README.md
+++ b/.github/workflows/verl_ci/README.md
@@ -1,0 +1,116 @@
+# Megatron-Bridge vLLM PPO CI suites
+
+This directory provides standalone entry points for three jobs currently defined
+across
+[`e2e_ppo_trainer_megatron_vllm.yml`](https://github.com/verl-project/verl/blob/main/.github/workflows/e2e_ppo_trainer_megatron_vllm.yml)
+and
+[`e2e_ppo_trainer_megatron_vllm_2.yml`](https://github.com/verl-project/verl/blob/main/.github/workflows/e2e_ppo_trainer_megatron_vllm_2.yml).
+The existing verl source files and workflows do not need to be changed to use them.
+Only variants using the official NVIDIA NeMo Megatron-Bridge backend are included.
+
+| Existing CI job | Included Megatron-Bridge variants | Standalone entry point |
+| --- | --- | --- |
+| `e2e_ppo_trainer_megatron-deepseek` | LoRA, save and resume | `bash run_megatron_deepseek.sh` |
+| `e2e_ppo_trainer_megatron-qwen3` | Dense | `bash run_megatron_qwen3.sh` |
+| `e2e_ppo_trainer_megatron-moe-expert-parallel` | MoE EP=4, FP8 rollout, and LoRA EP=2 | `bash run_megatron_moe_expert_parallel.sh` |
+
+Each script reproduces the relevant Megatron-Bridge command order from its original
+job: dependency installation, GSM8K preprocessing, selected training variants,
+checkpoint boundaries, and final checkpoint cleanup. Every training invocation
+uses `USE_MBRIDGE=True` and `VANILLA_MBRIDGE=False`, directly or through an
+explicit shared environment array. Run a script from the verl repository root in
+an isolated CI job. Do not run multiple scripts concurrently in the same checkout,
+Python environment, home directory, or set of GPUs.
+
+## Runner requirements
+
+- One Linux node with 8 NVIDIA L20 GPUs for each active script. The shared trainer
+  config uses one node and 8 GPUs, and the expert-parallel topology consumes all 8.
+- A 60-minute timeout per script, matching the existing jobs.
+- The tested container image:
+  `verl-ci-cn-beijing.cr.volces.com/verlai/verl:vllm020.dev1`. Its preinstalled
+  CUDA, Python, PyTorch, vLLM, Ray, Megatron build dependencies, and system
+  libraries are part of the test environment. Several installs use `--no-deps`,
+  so a generic CUDA image is not an equivalent replacement.
+- An NVIDIA host driver compatible with the image, NCCL peer communication across
+  all 8 GPUs, enough host RAM and shared memory for CPU offload, and usable local
+  loopback ports for Ray.
+- A pip-writable Python environment plus writable repository root, `${HOME}`,
+  `/tmp`, and enough storage for package/model caches, datasets, generated dummy
+  models, and checkpoints. The workflows do not define numeric CPU, RAM, disk, or
+  shared-memory minima; use the existing `L20x8` runner profile as the baseline.
+- A checkout with full history (`fetch-depth: 0`). All commands must run from the
+  repository root because requirements, configs, launchers, and `checkpoints/` use
+  repository-relative paths.
+
+## Preloaded models and data
+
+The shared trainer script does not download models. Preload the public snapshots
+at these exact paths:
+
+```text
+${HOME}/models/deepseek-ai/deepseek-coder-1.3b-instruct
+${HOME}/models/Qwen/Qwen3-0.6B
+${HOME}/models/Qwen/Qwen3-30B-A3B-Instruct-2507
+${HOME}/models/Skywork/Skywork-Reward-V2-Llama-3.2-1B
+```
+
+The MoE suite creates a dummy model, but still needs the Qwen3-30B snapshot for
+tokenizer and base artifacts. Start with no stale
+`${HOME}/dummy_models/Qwen/Qwen3-30B-A3B-Instruct-2507` directory, or validate that
+it was generated from the current dummy-model config. All three suites enable the
+Skywork reward model.
+
+Make the raw GSM8K dataset loadable from `${HOME}/models/hf_data/gsm8k`. Each
+script preprocesses it to:
+
+```text
+${HOME}/data/gsm8k/train.parquet
+${HOME}/data/gsm8k/test.parquet
+```
+
+## Network and environment
+
+The runner must be able to pull the tested image and reach its Python package index
+and GitHub. The scripts install Megatron-Bridge and Megatron-LM at run time.
+Because the requirements files and the ModelOpt lower bound are not all immutable
+pins, retain the exact image and capture `pip3 list` when investigating a
+reproducibility failure.
+
+No external service container is needed. Ray runs inside the job, and every
+training invocation first stops any previous local Ray runtime.
+
+The DeepSeek script preserves checkpoints between its Megatron-Bridge LoRA
+save/resume phases. DeepSeek and Qwen3 remove stale checkpoints before their
+retained variants; MoE retains the workflow's cleanup boundary before its LoRA
+variant. Every script has an exit trap that removes the repository-local
+`checkpoints/` directory after success or failure. No artifacts are uploaded, so
+a zero script exit status is the CI pass condition.
+
+## Preflight checklist
+
+Before starting a CI job, verify:
+
+- exactly 8 CUDA devices are visible;
+- every required model and raw-data path is readable;
+- the workspace, Python environment, `${HOME}/data`, `${HOME}/dummy_models`, and
+  `/tmp` are writable;
+- `python3`, `pip3`, `git`, and `ray` are available; and
+- localhost traffic and NCCL communication are not routed through the proxy.
+
+## NVIDIA CI integration
+
+These scripts are discovered and run weekly by
+[`.github/workflows/verl-e2e-weekly.yml`](../verl-e2e-weekly.yml). That workflow
+globs every `run_*.sh` in this directory into a parallel matrix (one 8-GPU job per
+script), so adding a new `run_*.sh` here is picked up automatically with no
+workflow edit. The workflow reads two tuning headers from each script:
+
+- `# CI_TIMEOUT=<minutes>` — per-leg `timeout-minutes` (default 60).
+- `# GPU_COUNT=<n>` — selects the N-GPU runner label (default 8).
+
+In NVIDIA CI the L20x8 runner profile above is served by an 8×H100 node, and the
+verl image is mirrored into the internal ECR registry. Required models and the raw
+GSM8K dataset are pre-staged into the shared test-data volume, so each leg runs
+offline (`HF_HUB_OFFLINE=1`); the workflow reproduces the `${HOME}/models` and
+`${HOME}/models/hf_data/gsm8k` layout above via symlinks before invoking a script.

--- a/.github/workflows/verl_ci/run_megatron_deepseek.sh
+++ b/.github/workflows/verl_ci/run_megatron_deepseek.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# CI_TIMEOUT=60
+# GPU_COUNT=8
+set -xeuo pipefail
+
+readonly TRAINER_SCRIPT="tests/special_e2e/run_ppo_trainer_megatron.sh"
+readonly MODEL_NAME="deepseek-ai/deepseek-coder-1.3b-instruct"
+
+cleanup() {
+    rm -rf checkpoints
+}
+trap cleanup EXIT
+
+## Use our checkout
+pip3 install git+https://github.com/NVIDIA-NeMo/Megatron-Bridge.git@main --no-deps --no-build-isolation
+pip3 install git+https://github.com/NVIDIA/Megatron-LM.git@main --no-deps --no-build-isolation
+pip3 install "nvidia-modelopt[torch]>=0.37.0"
+## cd to verl checkout root
+pip3 install -r requirements-test.txt
+pip3 install -r requirements.txt
+pip3 install --no-deps -e .
+pip3 install math-verify
+
+python3 examples/data_preprocess/gsm8k.py --local_dataset_path "${HOME}/models/hf_data/gsm8k"
+
+cleanup
+
+ray stop --force
+ALL_OFFLOAD=True \
+SAVE_FREQ=1 \
+MODEL_ID="${MODEL_NAME}" \
+COMMON_PP=4 \
+LORA_RANK=8 \
+COMMON_VPP=null \
+COMMON_CP=1 \
+USE_MBRIDGE=True \
+VANILLA_MBRIDGE=False \
+VALUE_VANILLA_MBRIDGE=False \
+USE_DIST_CKPT=False \
+bash "${TRAINER_SCRIPT}"
+
+ray stop --force
+RESUME_MODE=auto \
+MODEL_ID="${MODEL_NAME}" \
+TOTAL_TRAIN_STEPS=2 \
+SAVE_FREQ=1 \
+COMMON_PP=4 \
+LORA_RANK=8 \
+COMMON_VPP=null \
+COMMON_CP=1 \
+USE_MBRIDGE=True \
+VANILLA_MBRIDGE=False \
+VALUE_VANILLA_MBRIDGE=False \
+USE_DIST_CKPT=False \
+bash "${TRAINER_SCRIPT}"

--- a/.github/workflows/verl_ci/run_megatron_moe_expert_parallel.sh
+++ b/.github/workflows/verl_ci/run_megatron_moe_expert_parallel.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# CI_TIMEOUT=60
+# GPU_COUNT=8
+set -xeuo pipefail
+
+readonly TRAINER_SCRIPT="tests/special_e2e/run_ppo_trainer_megatron.sh"
+
+cleanup() {
+    rm -rf checkpoints
+}
+trap cleanup EXIT
+
+## Use our checkout
+pip3 install git+https://github.com/NVIDIA-NeMo/Megatron-Bridge.git@main --no-deps --no-build-isolation
+pip3 install git+https://github.com/NVIDIA/Megatron-LM.git@main --no-deps --no-build-isolation
+pip3 install "nvidia-modelopt[torch]>=0.37.0"
+## cd to verl checkout root
+pip3 install -r requirements-test.txt
+pip3 install -r requirements.txt
+pip3 install --no-deps -e .
+pip3 install math-verify
+
+python3 examples/data_preprocess/gsm8k.py --local_dataset_path "${HOME}/models/hf_data/gsm8k"
+
+cleanup
+
+common_env=(
+    ADV_ESTIMATOR=grpo
+    USE_DUMMY_MODEL=True
+    DUMMY_MODEL_CONFIG_PATH=tests/special_e2e/ppo_trainer/expert_parallel/qwen2moe_minimal.json
+    PPO_MAX_TOKEN_LEN=1024
+    FWD_MAX_TOKEN_LEN=1024
+    MAX_PROMPT_LENGTH=512
+    MAX_RESPONSE_LENGTH=512
+    MODEL_ID=Qwen/Qwen3-30B-A3B-Instruct-2507
+    USE_MBRIDGE=True
+    VANILLA_MBRIDGE=False
+    VALUE_VANILLA_MBRIDGE=False
+    COMMON_PP=2
+    COMMON_VPP=null
+    COMMON_CP=1
+    COMMON_TP=4
+    COMMON_ETP=1
+    USE_DIST_CKPT=False
+    ALL_OFFLOAD=True
+    SKIP_SAVE_HF_MODEL=1
+)
+
+ray stop --force
+env "${common_env[@]}" \
+    COMMON_EP=4 \
+    INFER_TP=8 \
+    bash "${TRAINER_SCRIPT}"
+
+ray stop --force
+env "${common_env[@]}" \
+    COMMON_EP=4 \
+    INFER_TP=2 \
+    ROLLOUT_QUANTIZATION=fp8 \
+    bash "${TRAINER_SCRIPT}"
+
+cleanup
+
+ray stop --force
+env "${common_env[@]}" \
+    LORA_RANK=8 \
+    CRITIC_LORA_RANK=8 \
+    COMMON_EP=2 \
+    INFER_TP=8 \
+    LORA_MERGE=True \
+    bash "${TRAINER_SCRIPT}"

--- a/.github/workflows/verl_ci/run_megatron_qwen3.sh
+++ b/.github/workflows/verl_ci/run_megatron_qwen3.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# CI_TIMEOUT=60
+# GPU_COUNT=8
+set -xeuo pipefail
+
+readonly TRAINER_SCRIPT="tests/special_e2e/run_ppo_trainer_megatron.sh"
+
+cleanup() {
+    rm -rf checkpoints
+}
+trap cleanup EXIT
+
+## Use our checkout
+pip3 install git+https://github.com/NVIDIA-NeMo/Megatron-Bridge.git@main --no-deps --no-build-isolation
+pip3 install git+https://github.com/NVIDIA/Megatron-LM.git@main --no-deps --no-build-isolation
+pip3 install "nvidia-modelopt[torch]>=0.37.0"
+## cd to verl checkout root
+pip3 install -r requirements-test.txt
+pip3 install -r requirements.txt
+pip3 install --no-deps -e .
+pip3 install math-verify
+
+python3 examples/data_preprocess/gsm8k.py --local_dataset_path "${HOME}/models/hf_data/gsm8k"
+
+cleanup
+
+ray stop --force
+ALL_OFFLOAD=False \
+USE_MBRIDGE=True \
+VANILLA_MBRIDGE=False \
+USE_MEGATRON_FSDP=True \
+TOTAL_TRAIN_STEPS=2 \
+MODEL_ID=Qwen/Qwen3-0.6B \
+COMMON_PP=1 \
+COMMON_VPP=null \
+COMMON_CP=1 \
+COMMON_TP=1 \
+INFER_TP=1 \
+bash "${TRAINER_SCRIPT}" \
+    ++actor_rollout_ref.actor.megatron.override_transformer_config.gradient_accumulation_fusion=False \
+    ++actor_rollout_ref.ref.megatron.override_transformer_config.gradient_accumulation_fusion=False \
+    ++critic.megatron.override_transformer_config.gradient_accumulation_fusion=False


### PR DESCRIPTION
## Background / motivation

- verl's Megatron backend is validated upstream by `e2e_ppo_trainer_megatron_vllm*.yml`, but nothing in this repo catches a Megatron-Bridge change that breaks verl's PPO loop.
- Ports the three Megatron-Bridge-backend suites from [HollowMan6@`825f2ef`](https://github.com/HollowMan6/Megatron-Bridge/commit/825f2ef74f678df5a251781ec8e877a596867ad6) and runs them **weekly** against Bridge `main` + MCore `main`.
- Kept **out of `cicd-main.yml`** — the environment is entirely different (verl's container, a verl checkout, 8 GPUs, verl's model layout), so it does not fit the `megatron-bridge:*` / `test-template` path.

## What changed

- `.github/workflows/verl_ci/` — the three `run_*.sh` (verbatim from upstream) + `README.md`, plus `# CI_TIMEOUT=60` / `# GPU_COUNT=8` tuning headers and copyright headers.
- `.github/workflows/verl-e2e-weekly.yml` — new standalone workflow: dynamic discovery → parallel matrix → Slack-on-failure.

## Details

- **Dynamic matrix** — the `discover` job globs `verl_ci/run_*.sh` into a JSON matrix (reusing `cicd-main.yml`'s `generate-test-matrix` glob + `# CI_TIMEOUT`/`# GPU_COUNT` header convention). **Add a new `run_*.sh` and it is picked up automatically — no workflow edit.**
- **Per-leg run** (`runs-on: nemo-ci-aws-gpu-8`, one leg per script, `fail-fast: false`): `docker run` verl's image, then a workflow-owned preamble reproduces verl's runner layout (`HOME=/tmp/verl_home`, `ln -s $VERL_DATA_ROOT/models $HOME/models`), clones verl, and runs the unmodified script. The committed scripts stay verbatim; all env adaptation lives in the workflow.
- **Container** — pulled from the internal ECR **DockerHub pull-through cache** (`…/dockerhub/verlai/verl:vllm020.dev1`), which uses authenticated DockerHub creds (no rate limits) and auto-refreshes. Verified end-to-end: the ECR repo now serves the image (amd64, matches the H100 runners).
- **Models/data** — the 4 public snapshots + raw GSM8K are staged into the shared test-data volume (`nemo-fw/TestData/verl_ci/models/…`) via the standard Internal-Developer upload pipeline, so each leg runs offline (`HF_HUB_OFFLINE=1`).
- **Notification** — `notify` job (`if: failure()`) posts to the CI Slack channel and `@`-tags the team usergroup (same curl+webhook pattern as `cicd-approve-test-queue.yml`).
- **Triggers** — `schedule` (Mondays 06:00 UTC) + `workflow_dispatch` (optional single-`script` input, overridable `verl_ref`). Does **not** run on PRs, so this PR burns no GPU time.

```mermaid
flowchart TD
    cron["schedule: weekly<br/>+ workflow_dispatch"] --> disc["discover (ubuntu)<br/>glob verl_ci/run_*.sh<br/>→ matrix + runner + timeout"]
    disc -->|"matrix, fail-fast:false"| leg["verl-e2e (per script)<br/>runs-on: nemo-ci-aws-gpu-8"]
    leg --> drun["docker run verl ECR image<br/>--gpus all, mount TestData,<br/>HF_HUB_OFFLINE=1"]
    drun --> prep["prep: HOME + symlink models,<br/>clone verl-project/verl"]
    prep --> run["docker exec: bash run_&lt;name&gt;.sh"]
    run --> notify["notify (if: failure())<br/>Slack → CI channel + @team"]
```

## Tested

- `actionlint .github/workflows/verl-e2e-weekly.yml` → clean.
- `shellcheck -S error verl_ci/run_*.sh` → clean; `bash -n` on each → OK; script bodies byte-identical to upstream `825f2ef`.
- Discover glob dry-run → 3 legs, `runner=nemo-ci-aws-gpu-8`, `timeout=60`; single-`script` filter verified.
- ECR pull-through verified: `skopeo inspect docker://…/dockerhub/verlai/verl:vllm020.dev1` returns the manifest and the `dockerhub/verlai/verl` repo was created + populated in ECR.

## Follow-ups before the first green run

- [ ] Confirm a live 8×H100 runner answers to `nemo-ci-aws-gpu-8` (no current script uses `GPU_COUNT`).
- [ ] Land the Internal-Developer test-data PR staging `verl_ci/` models + GSM8K.
- [ ] After a first successful manual `workflow_dispatch`, pin `verl_ref` to the validated verl SHA.
- Scripts were tuned for 8×L20 (48 GB); 8×H100 (80 GB) is larger, so first run confirms no L20-specific assumptions.
