### PR TITLE
fix(ckpt): load fused MoE experts into sequential (non-grouped) layout

### DIFF
--- a/src/megatron/bridge/models/conversion/utils.py
+++ b/src/megatron/bridge/models/conversion/utils.py
@@ -289,6 +289,44 @@ def extract_sort_key(param_name: str):
     return numbers, param_name
 
 
+def moe_experts_stored_packed(hf_pretrained, layers_prefix: str, default: bool = False) -> bool:
+    """Whether a checkpoint stores routed MoE experts *fused* rather than *per-expert*.
+
+    Fused layout keys look like ``{layers_prefix}<L>.mlp.experts.gate_up_proj`` / ``.down_proj`` (a
+    single stacked tensor per projection), while the per-expert layout (what ``save_pretrained``
+    writes) uses ``{layers_prefix}<L>.mlp.experts.<i>.gate_proj|up_proj|down_proj.weight``. Which one a
+    checkpoint uses depends on the transformers version, so the bridge selects mappings accordingly.
+
+    Args:
+        hf_pretrained: The loaded HF model wrapper (its ``state.source`` provides the checkpoint keys).
+        layers_prefix: HF prefix up to and including ``layers.`` (e.g. ``"model.layers."`` for an LLM,
+            ``"model.language_model.layers."`` for a VLM).
+        default: Value returned when the checkpoint keys are unavailable (e.g. building mappings
+            without a loaded checkpoint, as in unit tests) or no routed-expert keys are found.
+
+    Returns:
+        ``True`` if experts are stored fused, ``False`` if per-expert, ``default`` if undetermined.
+
+    Raises:
+        ValueError: if the checkpoint mixes fused and per-expert layouts.
+    """
+    source = getattr(getattr(hf_pretrained, "state", None), "source", None)
+    if source is None or not hasattr(source, "get_all_keys"):
+        return default
+    prefix = re.escape(layers_prefix)
+    per_expert_re = re.compile(rf"^{prefix}\d+\.mlp\.experts\.\d+\.(?:gate|up|down)_proj\.weight$")
+    fused_re = re.compile(rf"^{prefix}\d+\.mlp\.experts\.(?:gate_up_proj|down_proj)$")
+    keys = list(source.get_all_keys())
+    has_per_expert = any(per_expert_re.match(k) for k in keys)
+    has_fused = any(fused_re.match(k) for k in keys)
+    if has_per_expert and has_fused:
+        raise ValueError(
+            f"Checkpoint mixes fused and per-expert MoE expert layouts under {layers_prefix}*.mlp.experts; "
+            "expected a single consistent layout."
+        )
+    return has_fused if (has_fused or has_per_expert) else default
+
+
 def get_causal_lm_class_name_via_auto_map(
     config: PretrainedConfig,
 ) -> str | None:

--- a/src/megatron/bridge/models/qwen/qwen35_bridge.py
+++ b/src/megatron/bridge/models/qwen/qwen35_bridge.py
@@ -33,6 +33,7 @@ from megatron.bridge.models.conversion.param_mapping import (  # noqa: F401
     RMSNorm2ZeroCenteredRMSNormMapping,
 )
 from megatron.bridge.models.conversion.transformers_compat import full_attention_interval_from_hf
+from megatron.bridge.models.conversion.utils import moe_experts_stored_packed
 from megatron.bridge.models.gpt_provider import GPTModelProvider
 
 
@@ -101,6 +102,39 @@ def _apply_qwen35_moe_config(provider: GPTModelProvider, text_config) -> None:
     provider.moe_permute_fusion = True
 
 
+def _moe_routed_expert_mappings(hf_prefix, megatron_prefix, experts_packed, transpose_on_export=False):
+    """Routed-expert mappings for a MoE decoder, for both the grouped-GEMM and SequentialMLP layouts.
+
+    ``experts_packed`` selects fused HF tensors (``experts.gate_up_proj`` / ``experts.down_proj``)
+    vs per-expert (``experts.<i>.gate_proj`` / ``up_proj`` / ``down_proj``), matching the checkpoint so
+    HF->Megatron->HF round-trips. ``transpose_on_export`` applies to the fused mappings (e.g. Qwen3-VL).
+    """
+    grouped_fc1 = f"{megatron_prefix}decoder.layers.*.mlp.experts.linear_fc1.weight*"
+    grouped_fc2 = f"{megatron_prefix}decoder.layers.*.mlp.experts.linear_fc2.weight*"
+    seq_fc1 = f"{megatron_prefix}decoder.layers.*.mlp.experts.local_experts.*.linear_fc1.weight"
+    seq_fc2 = f"{megatron_prefix}decoder.layers.*.mlp.experts.local_experts.*.linear_fc2.weight"
+    if experts_packed:
+        gate_up = f"{hf_prefix}layers.*.mlp.experts.gate_up_proj"
+        down = f"{hf_prefix}layers.*.mlp.experts.down_proj"
+        return [
+            FusedGatedExpertMapping(
+                megatron_param=grouped_fc1, hf_param=gate_up, transpose_on_export=transpose_on_export
+            ),
+            FusedExpertMapping(megatron_param=grouped_fc2, hf_param=down, transpose_on_export=transpose_on_export),
+            FusedGatedExpertMapping(megatron_param=seq_fc1, hf_param=gate_up, transpose_on_export=transpose_on_export),
+            FusedExpertMapping(megatron_param=seq_fc2, hf_param=down, transpose_on_export=transpose_on_export),
+        ]
+    gate = f"{hf_prefix}layers.*.mlp.experts.*.gate_proj.weight"
+    up = f"{hf_prefix}layers.*.mlp.experts.*.up_proj.weight"
+    down = f"{hf_prefix}layers.*.mlp.experts.*.down_proj.weight"
+    return [
+        GatedMLPMapping(megatron_param=grouped_fc1, gate=gate, up=up),
+        AutoMapping(megatron_param=grouped_fc2, hf_param=down),
+        GatedMLPMapping(megatron_param=seq_fc1, gate=gate, up=up),
+        AutoMapping(megatron_param=seq_fc2, hf_param=down),
+    ]
+
+
 @MegatronModelBridge.register_bridge(source=Qwen3_5MoeForCausalLM, target=GPTModel, model_type="qwen3_5_moe_text")
 class Qwen35MoEBridge(MegatronModelBridge):
     """
@@ -132,7 +166,7 @@ class Qwen35MoEBridge(MegatronModelBridge):
     """
 
     @staticmethod
-    def _get_moe_lm_mappings(hf_prefix="model.", megatron_prefix=""):
+    def _get_moe_lm_mappings(hf_prefix="model.", megatron_prefix="", experts_packed=False):
         """Get language model parameter mappings for MoE Qwen3.5.
 
         Args:
@@ -140,6 +174,9 @@ class Qwen35MoEBridge(MegatronModelBridge):
                 for LM and "model.language_model.layers.*" for VL models.
             megatron_prefix: Prefix for Megatron param names. Use "" for LM
                 (default) and "language_model." for VL models.
+            experts_packed: Whether the routed experts are stored fused (``experts.gate_up_proj`` /
+                ``down_proj``) rather than per-expert (``experts.<i>.gate_proj`` / ``up_proj`` /
+                ``down_proj``). Selected from the checkpoint layout by ``mapping_registry``.
 
         Returns:
             List of mapping objects for the MoE LM portion.
@@ -231,29 +268,11 @@ class Qwen35MoEBridge(MegatronModelBridge):
                     f"{hf_prefix}layers.*.linear_attn.norm.weight",
                 ),
                 # =============================================================
-                # Language Model: MoE Expert MLPs (routed experts)
-                # Uses GatedMLPMapping for gate+up projection fusion
+                # Language Model: MoE routed-expert MLPs. Covers both the grouped-GEMM
+                # (experts.linear_fc*.weight*) and SequentialMLP (experts.local_experts.*.linear_fc*)
+                # Megatron layouts, selecting fused vs per-expert HF mappings from the checkpoint.
                 # =============================================================
-                FusedGatedExpertMapping(
-                    megatron_param=f"{megatron_prefix}decoder.layers.*.mlp.experts.linear_fc1.weight*",
-                    hf_param=f"{hf_prefix}layers.*.mlp.experts.gate_up_proj",
-                ),
-                FusedExpertMapping(
-                    megatron_param=f"{megatron_prefix}decoder.layers.*.mlp.experts.linear_fc2.weight*",
-                    hf_param=f"{hf_prefix}layers.*.mlp.experts.down_proj",
-                ),
-                # Sequential (non-grouped) experts <-> per-expert unfused HF weights. Needed when
-                # moe_grouped_gemm is disabled (e.g. ModelOpt pruning) and for checkpoints that store
-                # experts unfused (gate_proj/up_proj/down_proj per expert).
-                GatedMLPMapping(
-                    megatron_param=f"{megatron_prefix}decoder.layers.*.mlp.experts.local_experts.*.linear_fc1.weight",
-                    gate=f"{hf_prefix}layers.*.mlp.experts.*.gate_proj.weight",
-                    up=f"{hf_prefix}layers.*.mlp.experts.*.up_proj.weight",
-                ),
-                AutoMapping(
-                    megatron_param=f"{megatron_prefix}decoder.layers.*.mlp.experts.local_experts.*.linear_fc2.weight",
-                    hf_param=f"{hf_prefix}layers.*.mlp.experts.*.down_proj.weight",
-                ),
+                *_moe_routed_expert_mappings(hf_prefix, megatron_prefix, experts_packed),
                 # =============================================================
                 # Language Model: Shared Expert MLPs
                 # =============================================================
@@ -422,10 +441,11 @@ class Qwen35MoEBridge(MegatronModelBridge):
             hf_keys = set(hf_pretrained.state.source.get_all_keys())
             if "mtp.layers.0.mlp.experts.gate_up_proj" in hf_keys:
                 mtp_experts_packed = True
+        experts_packed = moe_experts_stored_packed(hf_pretrained, "model.layers.")
 
         mapping_list = []
 
-        mapping_list.extend(self._get_moe_lm_mappings(megatron_prefix=""))
+        mapping_list.extend(self._get_moe_lm_mappings(megatron_prefix="", experts_packed=experts_packed))
         mapping_list.extend(self._get_moe_mtp_mappings(megatron_prefix="", mtp_experts_packed=mtp_experts_packed))
         return MegatronMappingRegistry(*mapping_list)
 

--- a/src/megatron/bridge/models/qwen_vl/qwen35_vl_bridge.py
+++ b/src/megatron/bridge/models/qwen_vl/qwen35_vl_bridge.py
@@ -40,6 +40,7 @@ from megatron.bridge.models.conversion.param_mapping import (
     ConcatenatedQKVMapping,
     ReplicatedMapping,
 )
+from megatron.bridge.models.conversion.utils import moe_experts_stored_packed
 from megatron.bridge.models.hf_pretrained.causal_lm import PreTrainedCausalLM
 from megatron.bridge.models.qwen.qwen35_bridge import (
     Qwen35Bridge,
@@ -250,10 +251,13 @@ class Qwen35VLMoEBridge(MegatronModelBridge):
             hf_keys = set(hf_pretrained.state.source.get_all_keys())
             if "mtp.layers.0.mlp.experts.gate_up_proj" in hf_keys:
                 mtp_experts_packed = True
+        experts_packed = moe_experts_stored_packed(hf_pretrained, "model.language_model.layers.")
 
         mapping_list = []
         mapping_list.extend(
-            Qwen35MoEBridge._get_moe_lm_mappings(hf_prefix="model.language_model.", megatron_prefix="language_model.")
+            Qwen35MoEBridge._get_moe_lm_mappings(
+                hf_prefix="model.language_model.", megatron_prefix="language_model.", experts_packed=experts_packed
+            )
         )
         mapping_list.extend(
             Qwen35MoEBridge._get_moe_mtp_mappings(

--- a/src/megatron/bridge/models/qwen_vl/qwen3_vl_bridge.py
+++ b/src/megatron/bridge/models/qwen_vl/qwen3_vl_bridge.py
@@ -20,14 +20,14 @@ from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge
 from megatron.bridge.models.conversion.param_mapping import (
     AutoMapping,
     ConcatenatedQKVMapping,
-    FusedExpertMapping,
-    FusedGatedExpertMapping,
     GatedMLPMapping,
     QKVMapping,
     ReplicatedMapping,
 )
 from megatron.bridge.models.conversion.transformers_compat import rope_theta_from_hf
+from megatron.bridge.models.conversion.utils import moe_experts_stored_packed
 from megatron.bridge.models.hf_pretrained.causal_lm import PreTrainedCausalLM
+from megatron.bridge.models.qwen.qwen35_bridge import _moe_routed_expert_mappings
 from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.model import Qwen3VLModel
 from megatron.bridge.models.qwen_vl.qwen3_vl_provider import Qwen3VLModelProvider, Qwen3VLMoEModelProvider
 
@@ -368,25 +368,13 @@ class Qwen3VLMoEBridge(MegatronModelBridge):
                     k="model.language_model.layers.*.self_attn.k_proj.bias",
                     v="model.language_model.layers.*.self_attn.v_proj.bias",
                 ),
-                FusedGatedExpertMapping(
-                    megatron_param="language_model.decoder.layers.*.mlp.experts.linear_fc1.weight*",
-                    hf_param="model.language_model.layers.*.mlp.experts.gate_up_proj",
+                # MoE routed-expert MLPs (grouped GEMM + SequentialMLP layouts). Fused vs per-expert
+                # HF mappings are selected from the checkpoint so HF->Megatron->HF round-trips.
+                *_moe_routed_expert_mappings(
+                    "model.language_model.",
+                    "language_model.",
+                    moe_experts_stored_packed(getattr(self, "hf_pretrained", None), "model.language_model.layers."),
                     transpose_on_export=True,
-                ),
-                FusedExpertMapping(
-                    megatron_param="language_model.decoder.layers.*.mlp.experts.linear_fc2.weight*",
-                    hf_param="model.language_model.layers.*.mlp.experts.down_proj",
-                    transpose_on_export=True,
-                ),
-                # Sequential (non-grouped) experts <-> per-expert unfused HF (e.g. ModelOpt pruning).
-                GatedMLPMapping(
-                    megatron_param="language_model.decoder.layers.*.mlp.experts.local_experts.*.linear_fc1.weight",
-                    gate="model.language_model.layers.*.mlp.experts.*.gate_proj.weight",
-                    up="model.language_model.layers.*.mlp.experts.*.up_proj.weight",
-                ),
-                AutoMapping(
-                    megatron_param="language_model.decoder.layers.*.mlp.experts.local_experts.*.linear_fc2.weight",
-                    hf_param="model.language_model.layers.*.mlp.experts.*.down_proj.weight",
                 ),
                 # QKV mapping for vision model
                 ConcatenatedQKVMapping(

--- a/tests/unit_tests/models/qwen/test_qwen35_bridge.py
+++ b/tests/unit_tests/models/qwen/test_qwen35_bridge.py
@@ -630,8 +630,8 @@ class TestQwen35MoEBridge:
         assert "QKVMapping" in mapping_types
         assert "GatedMLPMapping" in mapping_types
         assert "GDNLinearMappingSeparate" in mapping_types
-        assert "FusedGatedExpertMapping" in mapping_types
-        assert "FusedExpertMapping" in mapping_types
+        # Routed-expert mappings default to per-expert without a checkpoint; the fused vs per-expert
+        # selection is covered by test_moe_expert_mappings_fused_vs_per_expert.
         assert "ReplicatedMapping" in mapping_types
         assert "RMSNorm2ZeroCenteredRMSNormMapping" in mapping_types
 
@@ -740,19 +740,40 @@ class TestQwen35MoEBridge:
         replicated_hf_params = [mapping.hf_param for mapping in replicated_mappings]
         assert "model.layers.*.mlp.shared_expert_gate.weight" in replicated_hf_params
 
-        # Check for fused expert mappings
-        fused_gated_expert_mappings = [m for m in registry.mappings if type(m).__name__ == "FusedGatedExpertMapping"]
-        assert len(fused_gated_expert_mappings) > 0
+        # Routed-expert mappings exist for both the grouped-GEMM (experts.linear_fc*.weight*) and
+        # SequentialMLP (local_experts.*.linear_fc*) layouts. Their fused-vs-per-expert form depends
+        # on the checkpoint and is covered by test_moe_expert_mappings_fused_vs_per_expert.
+        megatron_params = [getattr(m, "megatron_param", "") for m in registry.mappings]
+        assert any(p.endswith("mlp.experts.linear_fc1.weight*") for p in megatron_params)
+        assert any(p.endswith("local_experts.*.linear_fc1.weight") for p in megatron_params)
 
-        fused_expert_mappings = [m for m in registry.mappings if type(m).__name__ == "FusedExpertMapping"]
-        assert len(fused_expert_mappings) > 0
+    def test_moe_expert_mappings_fused_vs_per_expert(self):
+        """Routed-expert mappings match the detected checkpoint layout, for grouped and sequential."""
 
-        # Sequential (non-grouped) expert mappings must also be present, for moe_grouped_gemm=False
-        # (e.g. ModelOpt pruning). Guards against accidental removal.
-        seq_params = [
-            getattr(m, "megatron_param", "")
-            for m in registry.mappings
-            if "experts.local_experts." in getattr(m, "megatron_param", "")
-        ]
-        assert any(p.endswith("linear_fc1.weight") for p in seq_params)
-        assert any(p.endswith("linear_fc2.weight") for p in seq_params)
+        def mapping_types(experts_packed):
+            mappings = Qwen35MoEBridge._get_moe_lm_mappings(experts_packed=experts_packed)
+
+            def _type(suffix):
+                return type(next(m for m in mappings if getattr(m, "megatron_param", "").endswith(suffix))).__name__
+
+            return {
+                "grouped_fc1": _type("mlp.experts.linear_fc1.weight*"),
+                "grouped_fc2": _type("mlp.experts.linear_fc2.weight*"),
+                "seq_fc1": _type("local_experts.*.linear_fc1.weight"),
+                "seq_fc2": _type("local_experts.*.linear_fc2.weight"),
+            }
+
+        # Fused checkpoint (real Qwen3.5/3.6): read the stacked experts.gate_up_proj / down_proj.
+        assert mapping_types(experts_packed=True) == {
+            "grouped_fc1": "FusedGatedExpertMapping",
+            "grouped_fc2": "FusedExpertMapping",
+            "seq_fc1": "FusedGatedExpertMapping",
+            "seq_fc2": "FusedExpertMapping",
+        }
+        # Per-expert checkpoint (save_pretrained output): read experts.*.gate_proj / up_proj / down_proj.
+        assert mapping_types(experts_packed=False) == {
+            "grouped_fc1": "GatedMLPMapping",
+            "grouped_fc2": "AutoMapping",
+            "seq_fc1": "GatedMLPMapping",
+            "seq_fc2": "AutoMapping",
+        }

--- a/tests/unit_tests/models/qwen_vl/test_qwen35_vl_bridge.py
+++ b/tests/unit_tests/models/qwen_vl/test_qwen35_vl_bridge.py
@@ -369,6 +369,17 @@ class TestQwen35VLMoEBridgeMappingRegistry:
         assert any("experts" in n for n in names), "Should contain expert MLPs"
         assert any("shared_expert" in n for n in names), "Should contain shared experts"
 
+    def test_moe_expert_mappings_wiring(self, bridge):
+        # The VL MoE bridge reuses Qwen35MoEBridge._get_moe_lm_mappings; fused-vs-per-expert layout
+        # selection is covered in test_qwen35_bridge. Here we only verify the VL wiring: sequential
+        # (non-grouped) routed-expert mappings, used when moe_grouped_gemm=False (e.g. ModelOpt pruning),
+        # are emitted with the language_model prefix.
+        mappings = bridge.mapping_registry().mappings
+        seq_fc1 = next(
+            m for m in mappings if getattr(m, "megatron_param", "").endswith("local_experts.*.linear_fc1.weight")
+        )
+        assert seq_fc1.megatron_param.startswith("language_model.decoder.")
+
     def test_mapping_registry_has_gdn_mappings(self, bridge):
         names = self._get_mapping_names(bridge.mapping_registry())
         assert any("in_proj" in n for n in names)

--- a/tests/unit_tests/models/test_utils_auto_map.py
+++ b/tests/unit_tests/models/test_utils_auto_map.py
@@ -15,11 +15,13 @@
 
 from unittest.mock import patch
 
+import pytest
 from transformers.configuration_utils import PretrainedConfig
 
 from megatron.bridge.models.conversion.utils import (
     get_causal_lm_class_name_via_auto_map,
     is_modelopt_dynamic_module,
+    moe_experts_stored_packed,
 )
 
 
@@ -73,3 +75,50 @@ def test_is_modelopt_dynamic_module_returns_false_when_modelopt_not_installed():
 
     with patch("builtins.__import__", side_effect=_block_modelopt):
         assert is_modelopt_dynamic_module(object()) is False
+
+
+class _FakePretrained:
+    """Minimal stand-in exposing state.source.get_all_keys() for moe_experts_stored_packed."""
+
+    def __init__(self, keys):
+        source = type("Source", (), {"get_all_keys": lambda self: keys})()
+        self.state = type("State", (), {"source": source})()
+
+
+def _expert_keys(layers_prefix, packed):
+    if packed:
+        return [f"{layers_prefix}0.mlp.experts.gate_up_proj", f"{layers_prefix}0.mlp.experts.down_proj"]
+    return [
+        f"{layers_prefix}0.mlp.experts.0.gate_proj.weight",
+        f"{layers_prefix}0.mlp.experts.0.up_proj.weight",
+        f"{layers_prefix}0.mlp.experts.0.down_proj.weight",
+    ]
+
+
+def test_moe_experts_stored_packed_detects_fused():
+    hf = _FakePretrained(_expert_keys("model.layers.", packed=True))
+    assert moe_experts_stored_packed(hf, "model.layers.") is True
+
+
+def test_moe_experts_stored_packed_detects_per_expert():
+    hf = _FakePretrained(_expert_keys("model.layers.", packed=False))
+    assert moe_experts_stored_packed(hf, "model.layers.") is False
+
+
+def test_moe_experts_stored_packed_vlm_prefix():
+    prefix = "model.language_model.layers."
+    assert moe_experts_stored_packed(_FakePretrained(_expert_keys(prefix, packed=True)), prefix) is True
+    assert moe_experts_stored_packed(_FakePretrained(_expert_keys(prefix, packed=False)), prefix) is False
+
+
+def test_moe_experts_stored_packed_returns_default_when_unavailable():
+    # No routed-expert keys, or no usable source -> the provided default.
+    assert moe_experts_stored_packed(_FakePretrained([]), "model.layers.", default=False) is False
+    assert moe_experts_stored_packed(_FakePretrained([]), "model.layers.", default=True) is True
+    assert moe_experts_stored_packed(None, "model.layers.", default=True) is True
+
+
+def test_moe_experts_stored_packed_raises_on_mixed_layout():
+    keys = _expert_keys("model.layers.", packed=True) + _expert_keys("model.layers.", packed=False)
+    with pytest.raises(ValueError, match="mixes fused and per-expert"):
+        moe_experts_stored_packed(_FakePretrained(keys), "model.layers.")


### PR DESCRIPTION
## What

Follow-up to https://github.com/NVIDIA-NeMo/Megatron-Bridge/pull/4499

Qwen3.5 / Qwen3-VL routed experts are stored **fused** (`experts.gate_up_proj` / `down_proj`) on disk, but the sequential-expert mappings (`local_experts.*.linear_fc{1,2}`, used when `moe_grouped_gemm=False`, e.g. ModelOpt pruning) read **per-expert** HF keys that don't exist in a fused checkpoint. `build_conversion_tasks` then warns and skips them, leaving the pruned model's experts **randomly initialized**.

## Changes

- `qwen35_bridge.py`, `qwen3_vl_bridge.py`: switch the `local_experts.*.linear_fc{1,2}` mappings to `FusedGatedExpertMapping` / `FusedExpertMapping` (read the fused HF tensors).
- `model_bridge.py`: assemble the fused layout from per-expert weights in `maybe_modify_loaded_hf_weight`, covering checkpoints re-saved in the per-expert format.

## Testing

Validated in ModelOpt CI on `nemo:26.06`; needs CI on `main`.