### PR TITLE
build(deps): pin fast-hadamard-transform to 1.1.0 (cherry-pick #4693)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,7 +138,8 @@ override-dependencies = [
     "langchain-core>=0.3.80",                               # To address CVE-2025-65106
     "onnx>=1.21.0; python_version < '3.13'",                # onnx<1.21 has missing lower bound on ml-dtypes, uses float4_e2m1fn (requires ml-dtypes>=0.5.0)
     "nvidia-cudnn-frontend==1.24.0",
-    "nvidia-cutlass-dsl[cu13]; sys_platform == 'never'"     # Rely on system site packages install
+    "nvidia-cutlass-dsl[cu13]; sys_platform == 'never'",    # Rely on system site packages install
+    "fast-hadamard-transform @ git+https://github.com/Dao-AILab/fast-hadamard-transform.git@v1.1.0"  # pin 1.1.0; PyPI sdist is incomplete, install from git tag (see DSv4/GLM-5 READMEs)
 ]
 
 [[tool.uv.index]]

--- a/uv.lock
+++ b/uv.lock
@@ -10,6 +10,7 @@ overrides = [
     { name = "av", marker = "sys_platform == 'never'" },
     { name = "cachetools", specifier = ">=5.0.0" },
     { name = "cryptography", specifier = ">=43.0.0,<47" },
+    { name = "fast-hadamard-transform", git = "https://github.com/Dao-AILab/fast-hadamard-transform.git?rev=v1.1.0" },
     { name = "imageio", marker = "sys_platform == 'never'" },
     { name = "imageio-ffmpeg", marker = "sys_platform == 'never'" },
     { name = "langchain", specifier = ">=0.3.28" },
@@ -1008,8 +1009,8 @@ wheels = [
 
 [[package]]
 name = "fast-hadamard-transform"
-version = "1.0.4.post1"
-source = { git = "https://github.com/Dao-AILab/fast-hadamard-transform.git?rev=f134af63deb2df17e1171a9ec1ea4a7d8604d5ca#f134af63deb2df17e1171a9ec1ea4a7d8604d5ca" }
+version = "1.1.0"
+source = { git = "https://github.com/Dao-AILab/fast-hadamard-transform.git?rev=v1.1.0#1cc807efbd6cc001df359822d60bf6052dd66859" }
 dependencies = [
     { name = "ninja" },
     { name = "packaging" },


### PR DESCRIPTION
## Background / motivation

- Cherry-picks the dependency-pin change from #4693 into `r0.5.0`.
- #4693 bundled two unrelated changes: a `fast-hadamard-transform` pin (`pyproject.toml` + `uv.lock`) and a `tests/unit_tests/training/test_train.py` fix. Only the pin is wanted on the release branch.

## What changed

- `pyproject.toml`: add `fast-hadamard-transform @ git+…@v1.1.0` override (+ trailing comma on the preceding `nvidia-cutlass-dsl` line).
- `uv.lock`: matching override entry + bump the resolved `fast-hadamard-transform` pin `1.0.4.post1` → `1.1.0`.

## Details

- Pin rationale (from #4693): PyPI sdist for `fast-hadamard-transform` is incomplete; install from the git tag (per DSv4 / GLM-5 READMEs).
- The `test_train.py` change from #4693 is **intentionally excluded**. It passes an `optimizer` positional arg to `maybe_check_weight_hash_across_dp_replicas(...)`, but that signature on `r0.5.0` (`src/megatron/bridge/training/train.py`) has **no `optimizer` parameter** — the optimizer arg only exists on `main`. Cherry-picking the test would break it on this branch.
- Supersedes the automated full-cherry-pick PR #4708, which carries that breaking test change.

## Tested

- Verified the `uv.lock` hunks apply against `r0.5.0`'s existing `fast-hadamard-transform` state (same rev `f134af63…` as `main` pre-change), so the pin pair is self-consistent.
- Lockfile consistency validated by CI.
