### PR TITLE
ci: harden workflow-result gates against transient GitHub API errors

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -1041,22 +1041,38 @@ jobs:
         run: |
           # NOTE: `gh run view` must NOT be wrapped in `|| echo 0`. Doing so swallows
           # any failure (e.g. "failed to determine base repo" when git context is
-          # missing) and silently sets FAILED_JOBS=0, turning the summary green even
-          # when earlier jobs failed. GH_REPO makes `gh` independent of the local git
-          # repository, and `set -e -o pipefail` makes any failure here abort the job.
-          FAILED_JOBS=$(gh run view $GITHUB_RUN_ID --json jobs --jq '[.jobs[] | select(.status == "completed" and .conclusion != "success" and .conclusion != "skipped")] | length')
+          # missing, or a transient 5xx from the GitHub API) and silently sets
+          # FAILED_JOBS=0, turning the summary green even when earlier jobs failed.
+          # GH_REPO makes `gh` independent of the local git repository. We fetch the
+          # job list ONCE (fewer API calls => fewer chances to hit a transient error),
+          # retrying transient API errors, and fail closed (exit 1) if the API is still
+          # unreachable after all retries — a green summary must never rest on an
+          # unread API response.
+          JOBS_JSON=""
+          for attempt in 1 2 3 4 5; do
+            if JOBS_JSON=$(gh run view "$GITHUB_RUN_ID" --json jobs); then
+              break
+            fi
+            echo "::warning::gh run view --json jobs failed (attempt ${attempt}/5)"
+            JOBS_JSON=""
+            [ "$attempt" -lt 5 ] && sleep $((attempt * 5))
+          done
+          if [ -z "$JOBS_JSON" ]; then
+            echo "::error::gh run view --json jobs failed after 5 attempts; GitHub Actions API unreachable"
+            exit 1
+          fi
+
+          FAILED_JOBS=$(jq '[.jobs[] | select(.status == "completed" and .conclusion != "success" and .conclusion != "skipped")] | length' <<< "$JOBS_JSON")
 
           UNEXPECTED_SKIPS=0
           check_tier_skips() {
             local tier="$1" expect="$2"
             [ "$expect" != "true" ] && return
             local n
-            n=$(gh run view $GITHUB_RUN_ID --json jobs \
-              | jq --arg p "${tier}_" '[.jobs[] | select(.name | startswith($p)) | select(.conclusion == "skipped")] | length')
+            n=$(jq --arg p "${tier}_" '[.jobs[] | select(.name | startswith($p)) | select(.conclusion == "skipped")] | length' <<< "$JOBS_JSON")
             if [ "${n:-0}" -gt 0 ]; then
               echo "❌ Found $n unexpectedly skipped ${tier} job(s):"
-              gh run view $GITHUB_RUN_ID --json jobs \
-                | jq -r --arg p "${tier}_" '.jobs[] | select(.name | startswith($p)) | select(.conclusion == "skipped") | .name'
+              jq -r --arg p "${tier}_" '.jobs[] | select(.name | startswith($p)) | select(.conclusion == "skipped") | .name' <<< "$JOBS_JSON"
               UNEXPECTED_SKIPS=$((UNEXPECTED_SKIPS + n))
             fi
           }
@@ -1072,7 +1088,7 @@ jobs:
 
           if [ "${FAILED_JOBS:-0}" -gt 0 ]; then
             echo "❌ Found $FAILED_JOBS failed job(s):"
-            gh run view $GITHUB_RUN_ID --json jobs --jq '.jobs[] | select(.status == "completed" and .conclusion != "success" and .conclusion != "skipped") | .name'
+            jq -r '.jobs[] | select(.status == "completed" and .conclusion != "success" and .conclusion != "skipped") | .name' <<< "$JOBS_JSON"
           fi
 
           if [ "${FAILED_JOBS:-0}" -gt 0 ] || [ "${UNEXPECTED_SKIPS:-0}" -gt 0 ]; then

--- a/.github/workflows/copyright-check.yml
+++ b/.github/workflows/copyright-check.yml
@@ -44,8 +44,34 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Result
+        shell: bash -e -u -o pipefail {0}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          SKIPPING_IS_ALLOWED: ${{ needs.pre-flight.outputs.docs_only == 'true' || needs.pre-flight.outputs.is_deployment_workflow == 'true' }}
         run: |
-          FAILED_JOBS=$(gh run view $GITHUB_RUN_ID --json jobs --jq '[.jobs[] | select(.status == "completed" and .conclusion != "success")] | length') || echo 0
+          # NOTE: `gh run view` must NOT be wrapped in `|| echo 0`. Doing so swallows
+          # any failure (e.g. a missing GH_TOKEN, or a transient 5xx from the GitHub
+          # API) and silently sets FAILED_JOBS=0, turning the summary green even when
+          # earlier jobs failed. GH_TOKEN + GH_REPO authenticate `gh` and make it
+          # independent of the local git repository (this job has no checkout). We
+          # fetch the job list ONCE, retrying transient API errors, and fail closed
+          # (exit 1) if the API is still unreachable after all retries.
+          JOBS_JSON=""
+          for attempt in 1 2 3 4 5; do
+            if JOBS_JSON=$(gh run view "$GITHUB_RUN_ID" --json jobs); then
+              break
+            fi
+            echo "::warning::gh run view --json jobs failed (attempt ${attempt}/5)"
+            JOBS_JSON=""
+            [ "$attempt" -lt 5 ] && sleep $((attempt * 5))
+          done
+          if [ -z "$JOBS_JSON" ]; then
+            echo "::error::gh run view --json jobs failed after 5 attempts; GitHub Actions API unreachable"
+            exit 1
+          fi
+
+          FAILED_JOBS=$(jq '[.jobs[] | select(.status == "completed" and .conclusion != "success")] | length' <<< "$JOBS_JSON")
 
           if [ "${FAILED_JOBS:-0}" -eq 0 ] || [ "$SKIPPING_IS_ALLOWED" == "true" ]; then
               echo "✅ All previous jobs completed successfully"
@@ -53,6 +79,6 @@ jobs:
           else
               echo "❌ Found $FAILED_JOBS failed job(s)"
               # Show which jobs failed
-              gh run view $GITHUB_RUN_ID --json jobs --jq '.jobs[] | select(.status == "completed" and .conclusion != "success") | .name'
+              jq -r '.jobs[] | select(.status == "completed" and .conclusion != "success") | .name' <<< "$JOBS_JSON"
               exit 1
           fi

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -243,10 +243,27 @@ jobs:
         run: |
           # NOTE: `gh run view` must NOT be wrapped in `|| echo 0`. Doing so swallows
           # any failure (e.g. "failed to determine base repo" when git context is
-          # missing) and silently sets FAILED_JOBS=0, turning the summary green even
-          # when earlier jobs failed. GH_REPO makes `gh` independent of the local git
-          # repository, and `set -e -o pipefail` makes any failure here abort the job.
-          FAILED_JOBS=$(gh run view $GITHUB_RUN_ID --json jobs --jq '[.jobs[] | select(.status == "completed" and .conclusion != "success")] | length')
+          # missing, or a transient 5xx from the GitHub API) and silently sets
+          # FAILED_JOBS=0, turning the summary green even when earlier jobs failed.
+          # GH_REPO makes `gh` independent of the local git repository. We fetch the
+          # job list ONCE, retrying transient API errors, and fail closed (exit 1) if
+          # the API is still unreachable after all retries — a green summary must
+          # never rest on an unread API response.
+          JOBS_JSON=""
+          for attempt in 1 2 3 4 5; do
+            if JOBS_JSON=$(gh run view "$GITHUB_RUN_ID" --json jobs); then
+              break
+            fi
+            echo "::warning::gh run view --json jobs failed (attempt ${attempt}/5)"
+            JOBS_JSON=""
+            [ "$attempt" -lt 5 ] && sleep $((attempt * 5))
+          done
+          if [ -z "$JOBS_JSON" ]; then
+            echo "::error::gh run view --json jobs failed after 5 attempts; GitHub Actions API unreachable"
+            exit 1
+          fi
+
+          FAILED_JOBS=$(jq '[.jobs[] | select(.status == "completed" and .conclusion != "success")] | length' <<< "$JOBS_JSON")
 
           if [ "${FAILED_JOBS:-0}" -eq 0 ] || [ "$SKIPPING_IS_ALLOWED" == "true" ]; then
               echo "✅ All previous jobs completed successfully"
@@ -254,6 +271,6 @@ jobs:
           else
               echo "❌ Found $FAILED_JOBS failed job(s)"
               # Show which jobs failed
-              gh run view $GITHUB_RUN_ID --json jobs --jq '.jobs[] | select(.status == "completed" and .conclusion != "success") | .name'
+              jq -r '.jobs[] | select(.status == "completed" and .conclusion != "success") | .name' <<< "$JOBS_JSON"
               exit 1
           fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -120,13 +120,31 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          FAILED_JOBS=$(gh run view $GITHUB_RUN_ID --repo ${{ github.repository }} --json jobs --jq '[.jobs[] | select(.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "action_required")] | length')
+          # Fetch the job list ONCE, retrying transient GitHub API errors (5xx), and
+          # fail closed (exit 1) if the API is still unreachable after all retries.
+          # Never wrap this in `|| echo 0` — that silently sets FAILED_JOBS=0 and turns
+          # the summary green even when earlier jobs failed.
+          JOBS_JSON=""
+          for attempt in 1 2 3 4 5; do
+            if JOBS_JSON=$(gh run view "$GITHUB_RUN_ID" --repo "${{ github.repository }}" --json jobs); then
+              break
+            fi
+            echo "::warning::gh run view --json jobs failed (attempt ${attempt}/5)"
+            JOBS_JSON=""
+            [ "$attempt" -lt 5 ] && sleep $((attempt * 5))
+          done
+          if [ -z "$JOBS_JSON" ]; then
+            echo "::error::gh run view --json jobs failed after 5 attempts; GitHub Actions API unreachable"
+            exit 1
+          fi
+
+          FAILED_JOBS=$(jq '[.jobs[] | select(.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "action_required")] | length' <<< "$JOBS_JSON")
 
           if [ "${FAILED_JOBS:-0}" -eq 0 ]; then
               echo "✅ All previous jobs completed successfully"
               exit 0
           else
               echo "❌ Found $FAILED_JOBS failed job(s)"
-              gh run view $GITHUB_RUN_ID --repo ${{ github.repository }} --json jobs --jq '.jobs[] | select(.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "action_required") | .name'
+              jq -r '.jobs[] | select(.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "action_required") | .name' <<< "$JOBS_JSON"
               exit 1
           fi


### PR DESCRIPTION
## Background / motivation

The `Get workflow result` / summary **gate** jobs decide a run's overall
status by calling `gh run view --json jobs` and counting non-success jobs.
On **2026-07-07** GitHub had an incident — *"Actions and Codespaces APIs
experiencing partial failures"* (500-class errors on the REST API). A run
where **every test job passed** went red anyway: the gate's single, unretried
`gh run view` call hit a `502` and, under `set -e -o pipefail`, aborted the
job.

Investigating that surfaced a second, worse bug in the copyright gate.

Two distinct failure modes existed across four gates:

| Workflow | Guard today | Failure on API 5xx |
|----------|-------------|--------------------|
| `cicd-main.yml` (`Nemo_CICD_Test`) | `set -e`, no retry | **false RED** — green run flipped red |
| `install-test.yml` | `set -e`, no retry | **false RED** |
| `release.yaml` | `set -e`, no retry | **false RED** |
| `copyright-check.yml` | `\|\| echo 0`, **no `GH_TOKEN`** | **false GREEN** — see below |

`copyright-check-summary` never had `GH_TOKEN`, so `gh` fails auth on **every**
run; `|| echo 0` swallows the error and the gate reports success regardless of
whether copyright-check actually failed. It is currently a **no-op gate**.
Observed on a recent run:

```
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable.
✅ All previous jobs completed successfully
```

## What changed

Harden all four gates consistently against transient GitHub API errors while
preserving the existing rule that a gate must **never** silently go green:

- Fetch the job list **once** with a bounded retry loop (5 attempts, linear
  backoff) — fewer API calls *and* resilience to a transient `5xx`.
- Run every `jq` filter against the cached JSON instead of re-hitting the API.
- **Fail closed** (`exit 1`) if the API is still unreachable after all retries.
- `copyright-check.yml`: add `GH_TOKEN` + `GH_REPO` (this job has no checkout)
  and the `SKIPPING_IS_ALLOWED` env it already references, and drop
  `|| echo 0` — bringing it in line with `install-test.yml`.

## Details

The shared idiom (adapted per file for `--repo` / jq filters):

```bash
JOBS_JSON=""
for attempt in 1 2 3 4 5; do
  if JOBS_JSON=$(gh run view "$GITHUB_RUN_ID" --json jobs); then
    break
  fi
  echo "::warning::gh run view --json jobs failed (attempt ${attempt}/5)"
  JOBS_JSON=""
  [ "$attempt" -lt 5 ] && sleep $((attempt * 5))
done
if [ -z "$JOBS_JSON" ]; then
  echo "::error::gh run view --json jobs failed after 5 attempts; GitHub Actions API unreachable"
  exit 1
fi
FAILED_JOBS=$(jq '...' <<< "$JOBS_JSON")
```

Decision flow (unchanged happy path; the new branch is the retry/fail-closed):

```mermaid
flowchart TD
    A[gh run view --json jobs] -->|success| P[parse cached JSON with jq]
    A -->|5xx / auth error| R{attempt < 5?}
    R -->|yes| S[warn + backoff, retry] --> A
    R -->|no| F["::error:: fail closed (exit 1)"]
    P --> D{failed or unexpectedly-skipped jobs?}
    D -->|yes| RED[exit 1]
    D -->|no| GREEN[exit 0]
```

- `.github/workflows/cicd-main.yml` — `Nemo_CICD_Test`; collapses 4 API calls
  (count + 3 tier-skip lookups + failed-list) to 1 cached fetch.
- `.github/workflows/install-test.yml` — `Get workflow result`.
- `.github/workflows/release.yaml` — `release-summary` (keeps `--repo`).
- `.github/workflows/copyright-check.yml` — `copyright-check-summary`; also
  adds the missing auth env described above.

**Note:** a sustained multi-minute API outage still fails the gate closed by
design — re-run the gate job once GitHub recovers. The retry only absorbs
transient blips.

## Tested

- `actionlint` (with its `shellcheck` pass) — **0 findings** in any changed
  gate block; `cicd-main.yml`'s pre-existing findings are all unrelated and
  outside the edited step.
- `python -c 'yaml.safe_load(...)'` parses all four files; `git diff --check`
  clean.
- Logic validated with a mock `gh` under `bash -e -u -o pipefail`:
  - healthy API, all green → `exit 0`
  - healthy API, one real failure → detected, `exit 1` (not masked)
  - two transient `502`s then success → retries, `exit 0`
  - API permanently down → **fail closed**, `exit 1` (no false green)
