### PR TITLE
perf(ckpt): avoid quadratic HF shard completion scans

### DIFF
--- a/src/megatron/bridge/models/hf_pretrained/state.py
+++ b/src/megatron/bridge/models/hf_pretrained/state.py
@@ -819,6 +819,7 @@ class SafeTensorsStateSource(StateSource):
             filename_to_keys_map[filename].add(key)
 
         files_to_save = dict(filename_to_keys_map)
+        remaining_keys_by_file = {filename: set(keys) for filename, keys in files_to_save.items()}
         buffered_tensors = {}
         all_yielded_keys = set()
         all_saved_keys = set()
@@ -837,24 +838,32 @@ class SafeTensorsStateSource(StateSource):
 
             buffered_tensors[name] = tensor
 
-            # Check if any file is complete and can be saved.
-            # Iterate over a copy of keys since we might modify the dict.
-            for filename in list(files_to_save.keys()):
+            # Update only the shard containing this tensor. Scanning every shard
+            # for every yielded tensor becomes prohibitively expensive for models
+            # with tens of thousands of tensors.
+            filename = key_to_filename_map[name]
+            remaining_keys = remaining_keys_by_file.get(filename)
+            if remaining_keys is None:
+                # The shard was already saved. Preserve the previous duplicate-key
+                # behavior by leaving the tensor buffered for final reporting.
+                continue
+
+            remaining_keys.discard(name)
+            if not remaining_keys:
                 keys_for_file = files_to_save[filename]
-                if keys_for_file.issubset(buffered_tensors.keys()):
-                    # This shard is complete, save it.
-                    tensors_to_save = {key: buffered_tensors[key] for key in keys_for_file}
+                tensors_to_save = {key: buffered_tensors[key] for key in keys_for_file}
 
-                    output_file_path = _resolve_output_shard_path(output_path, filename)
-                    output_file_path.parent.mkdir(parents=True, exist_ok=True)
-                    save_file(tensors_to_save, output_file_path)
+                output_file_path = _resolve_output_shard_path(output_path, filename)
+                output_file_path.parent.mkdir(parents=True, exist_ok=True)
+                save_file(tensors_to_save, output_file_path)
 
-                    # Free memory by removing saved tensors from the buffer.
-                    for key in keys_for_file:
-                        del buffered_tensors[key]
+                # Free memory by removing saved tensors from the buffer.
+                for key in keys_for_file:
+                    del buffered_tensors[key]
 
-                    all_saved_keys.update(keys_for_file)
-                    del files_to_save[filename]
+                all_saved_keys.update(keys_for_file)
+                del files_to_save[filename]
+                del remaining_keys_by_file[filename]
 
         # --- Final Reporting ---
         if files_to_save:
@@ -867,8 +876,8 @@ class SafeTensorsStateSource(StateSource):
                     "Warning: The following files are different from the source because the generator did not yield all "
                     "of their tensors. However they are still saved because strict=False."
                 )
-            for filename, keys_for_file in files_to_save.items():
-                missing_for_file = keys_for_file - all_yielded_keys
+            for filename in files_to_save:
+                missing_for_file = remaining_keys_by_file[filename]
                 if missing_for_file:
                     print(f"  - {filename}: missing {len(missing_for_file)} tensors:")
                     for key in sorted(list(missing_for_file)):

--- a/tests/unit_tests/models/test_hf_pretrained_state.py
+++ b/tests/unit_tests/models/test_hf_pretrained_state.py
@@ -13,11 +13,15 @@
 # limitations under the License.
 
 import json
+from collections import defaultdict
+from collections.abc import Iterable, Iterator
+from pathlib import Path
 
 import pytest
 import torch
 from safetensors import safe_open
 
+from megatron.bridge.models.hf_pretrained import state as state_module
 from megatron.bridge.models.hf_pretrained.state import SafeTensorsStateSource, _resolve_output_shard_path
 
 
@@ -102,3 +106,51 @@ def test_save_generator_strict_false_writes_nested_partial_shard(tmp_path) -> No
 
     index_data = json.loads((output_path / "model.safetensors.index.json").read_text(encoding="utf-8"))
     assert index_data["weight_map"] == {"model.present": shard_filename}
+
+
+def test_save_generator_writes_shard_as_soon_as_its_remaining_keys_arrive(tmp_path, monkeypatch) -> None:
+    class _SubsetForbiddenSet(set[str]):
+        def issubset(self, _other: Iterable[object]) -> bool:
+            raise AssertionError("save_generator must not scan shard subsets for each yielded tensor")
+
+    def tracking_defaultdict(_default_factory: object) -> defaultdict[str, _SubsetForbiddenSet]:
+        return defaultdict(_SubsetForbiddenSet)
+
+    first_shard = "model-00001-of-00002.safetensors"
+    second_shard = "model-00002-of-00002.safetensors"
+    _write_safetensors_index(
+        tmp_path,
+        {
+            "model.first.weight": first_shard,
+            "model.first.bias": first_shard,
+            "model.second.weight": second_shard,
+            "model.second.bias": second_shard,
+        },
+    )
+    source = SafeTensorsStateSource(tmp_path)
+    saved_shards: list[tuple[str, set[str]]] = []
+
+    def record_save(tensors: dict[str, torch.Tensor], output_file: str | Path) -> None:
+        saved_shards.append((str(output_file), set(tensors)))
+
+    monkeypatch.setattr(state_module, "defaultdict", tracking_defaultdict)
+    monkeypatch.setattr("safetensors.torch.save_file", record_save)
+
+    def tensors() -> Iterator[tuple[str, torch.Tensor]]:
+        yield "model.first.weight", torch.ones(1)
+        assert saved_shards == []
+
+        yield "model.second.weight", torch.full((1,), 2.0)
+        assert saved_shards == []
+
+        yield "model.first.bias", torch.zeros(1)
+        assert saved_shards == [(str(tmp_path / "output" / first_shard), {"model.first.weight", "model.first.bias"})]
+
+        yield "model.second.bias", torch.full((1,), 3.0)
+
+    source.save_generator(tensors(), tmp_path / "output")
+
+    assert saved_shards == [
+        (str(tmp_path / "output" / first_shard), {"model.first.weight", "model.first.bias"}),
+        (str(tmp_path / "output" / second_shard), {"model.second.weight", "model.second.bias"}),
+    ]


### PR DESCRIPTION
# What does this PR do ?

Replace the quadratic Hugging Face shard-completion scan with per-shard remaining-key tracking during streaming safetensors export.

This fixes the dominant CPU bottleneck observed in NVBug 6328900 for MiniMax-M2 HF checkpoint export. The source index contains FP8 scale keys that are intentionally absent from the BF16 export, leaving 124 shards pending until the final partial-shard flush. The previous implementation checked every pending shard against the growing global tensor buffer after every yielded tensor, producing roughly six million `set.issubset(dict_keys)` calls for this model.

# Changelog

- Track the remaining expected keys independently for each source shard.
- Update only the shard that owns the newly yielded tensor instead of scanning every pending shard.
- Preserve strict-mode, partial-shard, duplicate-key, and output-index behavior.
- Add a regression test that interleaves two shards and fails if the old `issubset()` scan is used.

# Validation

All NVBug reproductions and validation used exactly `nvcr.io/nvidian/nemo:26.06.01.rc0`.

| Metric | Stock rc0 | Patched rc0 |
|---|---:|---:|
| 2-node / 16-H100 application step | 53m12s | 15m13s |
| Rank-0 `save_hf_pretrained` | 2,675.175s | 403.369s |
| Rank-0 generator traversal | approximately 40m by shard timing | 145.099s |
| Output | 125 shards / 48,239 keys | 125 shards / 48,239 keys |
| Safetensor bytes | 457,385,910,976 | 457,385,910,976 |

- Full MiniMax-M2 TP2/PP1/EP8 run: Slurm `13532453`, completed `0:0`; application step 15m13s.
- Exact output-header validation: Slurm `13532893`, completed `0:0`; all 48,239 index keys matched all 48,239 shard-header keys across 125 referenced shards.
- Post-review focused unit validation: Slurm `13534982`, 11 passed; ruff and format checks passed.
- Full `uv run pre-commit run --all-files`: Slurm `13534983`, all hooks passed.

Peak writer memory remains approximately 426 GiB because source-only FP8 scale keys still keep 124 BF16 output shards incomplete until the final flush. That incremental-release improvement is separate from this PR's CPU-complexity fix.

The controlled performance run retained a 60-minute process-group timeout for direct comparison with the baseline. Its measured save/barrier durations are below 600 seconds, but this PR does not change timeout policy and does not claim a direct default-timeout validation.

# GitHub Actions CI

CI should run through the standard copy-pr-bot workflow for the signed commit.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] Added the necessary unit regression test.
- [x] Evaluated documentation impact; no user-facing API or configuration changes require documentation.
- [x] This PR does not affect optional-install components.

# Additional Information

- NVIDIA internal tracking: NVBug 6328900.
