### PR TITLE
docs(data): clarify shared fine-tuning dataset storage

### DIFF
--- a/examples/models/gpt_oss/README.md
+++ b/examples/models/gpt_oss/README.md
@@ -81,6 +81,7 @@ Before training, ensure the following are configured:
 3. **Environment Variables**:
    - `HF_TOKEN`: to download models from HF Hub (if required)
    - `HF_HOME`: (optional) to avoid re-downloading models and datasets
+   - `NEMO_DATASETS_CACHE` or `NEMO_HOME`: for multi-node SFT/PEFT, point the default dataset root to shared storage mounted at the same path on every node
    - `WANDB_API_KEY`: (optional) to enable WandB logging
 
 All training scripts use SLURM for containerized multi-node training.
@@ -131,11 +132,22 @@ sbatch pack_data_job.sh   # pre-pack once; skipped automatically on subsequent r
 sbatch slurm_sft.sh
 ```
 
-Squad and other datasets that do not use packed sequences do not require this step.
+Dataset preparation runs only on global rank 0. This is safe when the prepared
+JSONL and packed files are visible at the same paths on every rank. Packing and
+training must therefore use the same shared dataset cache (or an explicitly
+configured shared `dataset_root`). Set `NEMO_DATASETS_CACHE` directly, or set
+`NEMO_HOME` to its parent cache directory. The default
+`/root/.cache/nemo/datasets` is container-local, so it is not suitable for
+multi-node jobs unless that directory is backed by a shared mount.
+
+Squad and other datasets that do not use packed sequences do not require the
+separate pre-pack job. Multi-node training still requires the JSONL prepared by
+global rank 0 to be visible at the same path on every rank.
 
 ### Parameter-Efficient Fine-Tuning (PEFT) with LoRA
 
-See the [slurm_peft.sh](slurm_peft.sh) script for LoRA fine-tuning. The recipe uses sequence packing by default.
+See the [slurm_peft.sh](slurm_peft.sh) script for LoRA fine-tuning. The recipe uses sequence packing by default,
+so multi-node jobs require the same shared dataset-cache configuration described above.
 
 ### Expected Training Dynamics
 We provide a [Weights & Biases report](https://api.wandb.ai/links/nvidia-nemo-fw-public/xs3rmk4t) for the expected loss curves and grad norms.

--- a/examples/models/gpt_oss/pack_data_job.sh
+++ b/examples/models/gpt_oss/pack_data_job.sh
@@ -45,9 +45,11 @@ CONTAINER_IMAGE=""
 CONTAINER_MOUNTS=""
 # CONTAINER_MOUNTS="/data:/data,/workspace:/workspace"
 
-# HuggingFace / NeMo cache directories (set to avoid re-downloading)
+# HuggingFace / NeMo cache directories. NEMO_DATASETS_CACHE, or the datasets
+# directory under NEMO_HOME, must match the shared path used by training.
 # export HF_HOME="/path/to/shared/HF_HOME"
 # export NEMO_HOME="/path/to/shared/NEMO_HOME"
+# export NEMO_DATASETS_CACHE="/path/to/shared/NEMO_DATASETS_CACHE"
 
 mkdir -p logs
 
@@ -55,6 +57,13 @@ if [ -z "$CONTAINER_IMAGE" ]; then
     echo "ERROR: CONTAINER_IMAGE must be set."
     exit 1
 fi
+
+EFFECTIVE_NEMO_DATASETS_CACHE="${NEMO_DATASETS_CACHE:-${NEMO_HOME:+${NEMO_HOME}/datasets}}"
+if [ -z "$EFFECTIVE_NEMO_DATASETS_CACHE" ]; then
+    echo "ERROR: NEMO_DATASETS_CACHE or NEMO_HOME must point to shared storage used by packing and training."
+    exit 1
+fi
+echo "NeMo datasets cache: $EFFECTIVE_NEMO_DATASETS_CACHE"
 
 SRUN_CMD="srun --mpi=pmix --container-image=$CONTAINER_IMAGE"
 if [ -n "$CONTAINER_MOUNTS" ]; then

--- a/examples/models/gpt_oss/slurm_peft.sh
+++ b/examples/models/gpt_oss/slurm_peft.sh
@@ -87,8 +87,11 @@ export NCCL_NVLS_ENABLE=0
 # Pre-sync once before submitting jobs: UV_CACHE_DIR=/path/to/cache uv sync
 # export UV_CACHE_DIR="/path/to/shared/uv_cache"
 
-# HuggingFace cache directory (recommended for shared filesystem)
+# HuggingFace / NeMo cache directories. Multi-node PEFT requires a shared
+# dataset cache so every node can read data prepared by global rank 0.
 # export HF_HOME="/path/to/shared/HF_HOME"
+# export NEMO_HOME="/path/to/shared/NEMO_HOME"
+# export NEMO_DATASETS_CACHE="/path/to/shared/NEMO_DATASETS_CACHE"
 
 # Authentication tokens (set these for your environment)
 # export HF_TOKEN="hf_your_token_here"
@@ -117,6 +120,12 @@ if [ -z "$CONTAINER_IMAGE" ]; then
     echo "ERROR: CONTAINER_IMAGE must be set. Please specify a valid container image."
     exit 1
 fi
+
+EFFECTIVE_NEMO_DATASETS_CACHE="${NEMO_DATASETS_CACHE:-${NEMO_HOME:+${NEMO_HOME}/datasets}}"
+if [ "${SLURM_JOB_NUM_NODES:-1}" -gt 1 ] && [ -z "$EFFECTIVE_NEMO_DATASETS_CACHE" ]; then
+    echo "WARNING: Multi-node PEFT requires shared dataset paths. Set NEMO_DATASETS_CACHE or NEMO_HOME unless the recipe uses an explicit shared dataset_root or packed path."
+fi
+echo "NeMo datasets cache: ${EFFECTIVE_NEMO_DATASETS_CACHE:-/root/.cache/nemo/datasets}"
 
 # Build srun command (shared across configs)
 SRUN_CMD="srun --mpi=pmix --container-image=$CONTAINER_IMAGE"

--- a/examples/models/gpt_oss/slurm_sft.sh
+++ b/examples/models/gpt_oss/slurm_sft.sh
@@ -117,9 +117,11 @@ export TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC=7200
 # Pre-sync once before submitting jobs: UV_CACHE_DIR=/path/to/cache uv sync
 # export UV_CACHE_DIR="/path/to/shared/uv_cache"
 
-# HuggingFace / NeMo cache directories (recommended for shared filesystem)
+# HuggingFace / NeMo cache directories. Multi-node SFT requires a shared dataset
+# cache so every node can read data prepared by global rank 0.
 # export HF_HOME="/path/to/shared/HF_HOME"
 # export NEMO_HOME="/path/to/shared/NEMO_HOME"
+# export NEMO_DATASETS_CACHE="/path/to/shared/NEMO_DATASETS_CACHE"
 
 # Authentication tokens (set these for your environment)
 # export HF_TOKEN="hf_your_token_here"
@@ -150,6 +152,12 @@ if [ -z "$CONTAINER_IMAGE" ]; then
     echo "ERROR: CONTAINER_IMAGE must be set. Please specify a valid container image."
     exit 1
 fi
+
+EFFECTIVE_NEMO_DATASETS_CACHE="${NEMO_DATASETS_CACHE:-${NEMO_HOME:+${NEMO_HOME}/datasets}}"
+if [ "${SLURM_JOB_NUM_NODES:-1}" -gt 1 ] && [ -z "$EFFECTIVE_NEMO_DATASETS_CACHE" ]; then
+    echo "WARNING: Multi-node SFT requires shared dataset paths. Set NEMO_DATASETS_CACHE or NEMO_HOME unless the recipe uses an explicit shared dataset_root or packed path."
+fi
+echo "NeMo datasets cache: ${EFFECTIVE_NEMO_DATASETS_CACHE:-/root/.cache/nemo/datasets}"
 
 # Build srun command (shared across configs)
 SRUN_CMD="srun --mpi=pmix --container-image=$CONTAINER_IMAGE"


### PR DESCRIPTION
# What does this PR do ?

Document the shared-storage contract for GPT-OSS multi-node fine-tuning and
make the example packing/training launchers report unsafe default-cache use.

This addresses the new multi-node symptom in NVBug 6181306. The original issue
in that bug was already fixed and is distinct from this dataset-visibility
failure.

# Changelog

- Explain that dataset preparation runs on global rank 0 and that prepared
  JSONL and packed files must be visible at the same paths on every rank.
- Require the standalone GPT-OSS packing job to use an explicit
  `NEMO_DATASETS_CACHE` or `NEMO_HOME`, then log the effective cache path.
- Warn from the multi-node SFT and PEFT examples when neither shared-cache
  variable is set, while allowing recipes with explicit shared dataset paths.
- Clarify that non-packed datasets skip only the standalone packing job; their
  rank-0-prepared JSONL still requires shared visibility.

No Megatron-Bridge runtime behavior is changed. In particular, this PR does not
add distributed path collectives or a `data_iterator is None` guard.

# GitHub Actions CI

Validation used the selected 26.06.01 RC container.

- All three changed shell launchers parsed, `git diff --check` passed, and
  `pre-commit run --all-files` passed.
- A controlled two-node / 16-rank main-branch A/B run established the storage
  contract: a node-0-only fixture reproduced the `NoneType` iterator failure on
  the second node, while the identical fixture under shared storage completed
  two training iterations successfully.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests? (No runtime behavior changed.)
- [x] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install? (No)
  - [x] Reviewer: Does the PR have correct import guards for all optional libraries? (Not applicable)

# Additional Information

The current GPT-OSS raw-data path has a separate chat-template failure because
the template lacks a `{% generation %}` block. The distributed regression used
a compatible prepacked fixture so that issue would not be conflated with NVBug
6181306. This PR does not change chat-template handling.

AI assistance: OpenAI Codex was used for investigation, implementation, testing,
and drafting; the author reviewed the final changes.
