### PR TITLE
Migrate GLM-5 family to HybridModel

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Megatron Bridge provides out-of-the-box bridges and training recipes for a wide 
 | **Ernie** | [Ernie 4.5 MoE](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/src/megatron/bridge/models/ernie), [Ernie 4.5 VL MoE](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/src/megatron/bridge/models/ernie_vl) |
 | [**Falcon**](docs/models/falcon/index.md) | Falcon H1 |
 | [**Gemma**](docs/models/gemma/index.md) | Gemma / Gemma 2, Gemma 3, Gemma 3-VL, Gemma 4 (26B-A4B MoE / 31B dense), Gemma 4-VL (26B-A4B MoE) |
-| [**GLM**](docs/models/glm/index.md) | GLM-4.5 / 4.7 / 4.7-Flash, GLM-4.5V, GLM-5 / 5.1 |
+| [**GLM**](docs/models/glm/index.md) | GLM-4.5 / 4.7 / 4.7-Flash, GLM-4.5V, GLM-5 / 5.1 / 5.2 |
 | [**GPT-OSS**](docs/models/gpt_oss/index.md) | GPT-oss |
 | [**Kimi**](docs/models/kimi/index.md) | Kimi K2, Kimi-K2.5-VL |
 | [**Llama**](docs/models/llama/index.md) | Llama 2, Llama 3 / 3.1 / 3.2 / 3.3 |

--- a/docs/fern/versions/nightly.yml
+++ b/docs/fern/versions/nightly.yml
@@ -68,7 +68,7 @@ navigation:
       path: ./nightly/pages/models/glm/glm-45v.mdx
     - page: GLM-4.7 and GLM-4.7-Flash
       path: ./nightly/pages/models/glm/glm47.mdx
-    - page: GLM-5 and GLM-5.1
+    - page: GLM-5, GLM-5.1, and GLM-5.2
       path: ./nightly/pages/models/glm/glm5.mdx
     section: GLM
   - contents:

--- a/docs/fern/versions/nightly/pages/index.mdx
+++ b/docs/fern/versions/nightly/pages/index.mdx
@@ -209,7 +209,7 @@ Megatron Bridge provides out-of-the-box bridges and training recipes for a wide 
 | [**DeepSeek**](docs/models/deepseek/index.md) | DeepSeek V2 / V2 Lite, DeepSeek V3, DeepSeek V4 |
 | [**Falcon**](docs/models/falcon/index.md) | Falcon H1 |
 | [**Gemma**](docs/models/gemma/index.md) | Gemma / Gemma 2, Gemma 3, Gemma 3-VL, Gemma 4-VL (26B-A4B MoE) |
-| [**GLM**](docs/models/glm/index.md) | GLM-4.5 / 4.7 / 4.7-Flash, GLM-4.5V, GLM-5 / 5.1 |
+| [**GLM**](docs/models/glm/index.md) | GLM-4.5 / 4.7 / 4.7-Flash, GLM-4.5V, GLM-5 / 5.1 / 5.2 |
 | [**GPT-OSS**](docs/models/gpt_oss/index.md) | GPT-oss |
 | [**Kimi**](docs/models/kimi/index.md) | Kimi K2, Kimi-K2.5-VL |
 | [**Llama**](docs/models/llama/index.md) | Llama 2, Llama 3 / 3.1 / 3.2 / 3.3 |

--- a/docs/fern/versions/nightly/pages/models/README.mdx
+++ b/docs/fern/versions/nightly/pages/models/README.mdx
@@ -12,7 +12,7 @@ Megatron Bridge conversion, training recipe links, and model-specific notes.
 | **DeepSeek** | [DeepSeek V2](deepseek/deepseek-v2.md), [DeepSeek V3](deepseek/deepseek-v3.md), [DeepSeek V4](deepseek/deepseek-v4.md) |
 | **Falcon** | [Falcon H1](falcon/falcon-h1.md) |
 | **Gemma** | [Gemma](gemma/gemma.md), [Gemma 2](gemma/gemma2.md), [Gemma 3](gemma/gemma3.md), [Gemma 3 VL](gemma/gemma3-vl.md), [Gemma 4 VL](gemma/gemma4-vl.md) |
-| **GLM** | [GLM 4.5](glm/glm45.md), [GLM-4.5V](glm/glm-45v.md), [GLM-4.7 / 4.7-Flash](glm/glm47.md), [GLM-5 / 5.1](glm/glm5.md) |
+| **GLM** | [GLM 4.5](glm/glm45.md), [GLM-4.5V](glm/glm-45v.md), [GLM-4.7 / 4.7-Flash](glm/glm47.md), [GLM-5 / 5.1 / 5.2](glm/glm5.md) |
 | **GPT-OSS** | [GPT OSS](gpt_oss/gpt-oss.md) |
 | **Kimi** | [Kimi K2](kimi/kimi-k2.md), [Kimi-K2.5-VL](kimi/kimi-k25-vl.md) |
 | **Llama** | [Llama 2](llama/llama2.md), [Llama 3](llama/llama3.md) |

--- a/docs/fern/versions/nightly/pages/models/glm/glm5.mdx
+++ b/docs/fern/versions/nightly/pages/models/glm/glm5.mdx
@@ -1,6 +1,6 @@
-# GLM-5 and GLM-5.1
+# GLM-5, GLM-5.1, and GLM-5.2
 
-[GLM-5](https://huggingface.co/zai-org/GLM-5) and [GLM-5.1](https://huggingface.co/zai-org/GLM-5.1) are large sparse MoE language models with Multi-Latent Attention and Dynamic Sparse Attention. Megatron Bridge supports both checkpoints through the shared `GLM5Bridge`.
+[GLM-5](https://huggingface.co/zai-org/GLM-5), [GLM-5.1](https://huggingface.co/zai-org/GLM-5.1), and [GLM-5.2](https://huggingface.co/zai-org/GLM-5.2) are large sparse MoE language models with Multi-Latent Attention and Dynamic Sparse Attention. Megatron Bridge supports all three checkpoints through the shared `GLM5Bridge`.
 
 ## Supported Variants
 
@@ -8,19 +8,23 @@
 |---------|-----------------|-------|
 | GLM-5 | `zai-org/GLM-5` | MoE + MLA + DSA architecture |
 | GLM-5.1 | `zai-org/GLM-5.1` | Same architecture and mapping shape as GLM-5 |
+| GLM-5.2 | `zai-org/GLM-5.2` | Adds DSA IndexShare between selected logical layers |
 
 ## Architecture Notes
 
-- `GlmMoeDsaForCausalLM` architecture with 78 transformer layers.
+- `GlmMoeDsaForCausalLM` architecture with 78 logical transformer blocks.
+- Each logical block is represented by two `HybridModel` layers: `D-` for dense blocks and `DE` for MoE blocks. The standard 3-dense/75-MoE layout therefore has 156 physical layers.
 - First 3 layers are dense; remaining layers use MoE.
 - 256 routed experts with top-8 routing and one shared expert per MoE layer.
 - Uses MLA plus DSA indexer parameters (`index_head_dim`, `index_n_heads`, `index_topk`).
+- GLM-5.2 IndexShare is translated from the logical `indexer_types` schedule. Pipeline boundaries are placed only before DSA layers that compute their own indexer output.
 - Requires `transformers &gt;= 5.2.0`.
-- DSA requires the `fast-hadamard-transform` CUDA extension and MCore support for the DSA experimental attention variant.
+- DSA requires the `fast-hadamard-transform` CUDA extension.
+- BF16 checkpoint conversion is supported. FP8 checkpoints and MTP execution are not currently supported.
 
 ## Examples
 
-For conversion, inference, dependency notes, hardware requirements, and MCore patch requirements, see the [GLM-5 examples README](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/examples/models/glm/glm5/README.md).
+For conversion, inference, dependency notes, and hardware requirements, see the [GLM-5 examples README](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/examples/models/glm/glm5/README.md).
 
 ## Related Implementation
 

--- a/docs/fern/versions/nightly/pages/models/glm/index.mdx
+++ b/docs/fern/versions/nightly/pages/models/glm/index.mdx
@@ -7,4 +7,4 @@ GLM model documentation is organized by model variant.
 | GLM 4.5 | [glm45.md](glm45.md) |
 | GLM-4.5V | [glm-45v.md](glm-45v.md) |
 | GLM-4.7 / 4.7-Flash | [glm47.md](glm47.md) |
-| GLM-5 / 5.1 | [glm5.md](glm5.md) |
+| GLM-5 / 5.1 / 5.2 | [glm5.md](glm5.md) |

--- a/docs/models/README.md
+++ b/docs/models/README.md
@@ -12,7 +12,7 @@ Megatron Bridge conversion, training recipe links, and model-specific notes.
 | **DeepSeek** | [DeepSeek V2](deepseek/deepseek-v2.md), [DeepSeek V3](deepseek/deepseek-v3.md), [DeepSeek V4](deepseek/deepseek-v4.md) |
 | **Falcon** | [Falcon H1](falcon/falcon-h1.md) |
 | **Gemma** | [Gemma](gemma/gemma.md), [Gemma 2](gemma/gemma2.md), [Gemma 3](gemma/gemma3.md), [Gemma 3 VL](gemma/gemma3-vl.md), [Gemma 4 VL](gemma/gemma4-vl.md) |
-| **GLM** | [GLM 4.5](glm/glm45.md), [GLM-4.5V](glm/glm-45v.md), [GLM-4.7 / 4.7-Flash](glm/glm47.md), [GLM-5 / 5.1](glm/glm5.md) |
+| **GLM** | [GLM 4.5](glm/glm45.md), [GLM-4.5V](glm/glm-45v.md), [GLM-4.7 / 4.7-Flash](glm/glm47.md), [GLM-5 / 5.1 / 5.2](glm/glm5.md) |
 | **GPT-OSS** | [GPT OSS](gpt_oss/gpt-oss.md) |
 | **Kimi** | [Kimi K2](kimi/kimi-k2.md), [Kimi-K2.5-VL](kimi/kimi-k25-vl.md) |
 | **Llama** | [Llama 2](llama/llama2.md), [Llama 3](llama/llama3.md) |

--- a/docs/models/glm/glm5.md
+++ b/docs/models/glm/glm5.md
@@ -1,6 +1,6 @@
-# GLM-5 and GLM-5.1
+# GLM-5, GLM-5.1, and GLM-5.2
 
-[GLM-5](https://huggingface.co/zai-org/GLM-5) and [GLM-5.1](https://huggingface.co/zai-org/GLM-5.1) are large sparse MoE language models with Multi-Latent Attention and Dynamic Sparse Attention. Megatron Bridge supports both checkpoints through the shared `GLM5Bridge`.
+[GLM-5](https://huggingface.co/zai-org/GLM-5), [GLM-5.1](https://huggingface.co/zai-org/GLM-5.1), and [GLM-5.2](https://huggingface.co/zai-org/GLM-5.2) are large sparse MoE language models with Multi-Latent Attention and Dynamic Sparse Attention. Megatron Bridge supports all three checkpoints through the shared `GLM5Bridge`.
 
 ## Supported Variants
 
@@ -8,22 +8,25 @@
 |---------|-----------------|-------|
 | GLM-5 | `zai-org/GLM-5` | MoE + MLA + DSA architecture |
 | GLM-5.1 | `zai-org/GLM-5.1` | Same architecture and mapping shape as GLM-5 |
+| GLM-5.2 | `zai-org/GLM-5.2` | Adds DSA IndexShare between selected logical layers |
 
 ## Architecture Notes
 
-- `GlmMoeDsaForCausalLM` architecture with 78 transformer layers.
+- `GlmMoeDsaForCausalLM` architecture with 78 logical transformer blocks.
+- Each logical block is represented by two `HybridModel` layers: `D-` for dense blocks and `DE` for MoE blocks. The standard 3-dense/75-MoE layout therefore has 156 physical layers.
 - First 3 layers are dense; remaining layers use MoE.
 - 256 routed experts with top-8 routing and one shared expert per MoE layer.
 - Uses MLA plus DSA indexer parameters (`index_head_dim`, `index_n_heads`, `index_topk`).
+- GLM-5.2 IndexShare is translated from the logical `indexer_types` schedule. Pipeline boundaries are placed only before DSA layers that compute their own indexer output.
 - Requires `transformers >= 5.2.0`.
-- DSA requires the `fast-hadamard-transform` CUDA extension and MCore support for the DSA experimental attention variant.
+- DSA requires the `fast-hadamard-transform` CUDA extension.
+- BF16 checkpoint conversion is supported. FP8 checkpoints and MTP execution are not currently supported.
 
 ## Examples
 
-For conversion, inference, dependency notes, hardware requirements, and MCore patch requirements, see the [GLM-5 examples README](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/examples/models/glm/glm5/README.md).
+For conversion, inference, dependency notes, and hardware requirements, see the [GLM-5 examples README](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/examples/models/glm/glm5/README.md).
 
 ## Related Implementation
 
 - Bridge implementation: [`src/megatron/bridge/models/glm_moe_dsa/glm5_bridge.py`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/src/megatron/bridge/models/glm_moe_dsa/glm5_bridge.py)
 - Examples: [`examples/models/glm/glm5`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/examples/models/glm/glm5)
-

--- a/docs/models/glm/index.md
+++ b/docs/models/glm/index.md
@@ -16,4 +16,4 @@ glm5.md
 | GLM 4.5 | [glm45.md](glm45.md) |
 | GLM-4.5V | [glm-45v.md](glm-45v.md) |
 | GLM-4.7 / 4.7-Flash | [glm47.md](glm47.md) |
-| GLM-5 / 5.1 | [glm5.md](glm5.md) |
+| GLM-5 / 5.1 / 5.2 | [glm5.md](glm5.md) |

--- a/examples/models/glm/glm5/README.md
+++ b/examples/models/glm/glm5/README.md
@@ -1,20 +1,22 @@
-# GLM-5 / GLM-5.1 Examples
+# GLM-5 / GLM-5.1 / GLM-5.2 Examples
 
-Scripts for the GLM-5 family — [GLM-5](https://huggingface.co/zai-org/GLM-5) (`zai-org/GLM-5`) and [GLM-5.1](https://huggingface.co/zai-org/GLM-5.1) (`zai-org/GLM-5.1`) — large sparse MoE models with Multi-Latent Attention (MLA) and Dynamic Sparse Attention (DSA).
+Scripts for the GLM-5 family: [GLM-5](https://huggingface.co/zai-org/GLM-5) (`zai-org/GLM-5`), [GLM-5.1](https://huggingface.co/zai-org/GLM-5.1) (`zai-org/GLM-5.1`), and [GLM-5.2](https://huggingface.co/zai-org/GLM-5.2) (`zai-org/GLM-5.2`). These are large sparse MoE models with Multi-Latent Attention (MLA) and Dynamic Sparse Attention (DSA).
 
-GLM-5 and GLM-5.1 share the `GlmMoeDsaForCausalLM` architecture and identical MoE / MLA / DSA dimensions, so the same `GLM5Bridge` handles both. To run the GLM-5.1 checkpoint, replace `zai-org/GLM-5` with `zai-org/GLM-5.1` (or set `MODEL_NAME=GLM-5.1` in the slurm scripts).
+All three variants share the `GlmMoeDsaForCausalLM` architecture and use the same `GLM5Bridge`. Set `MODEL_NAME` to select the checkpoint in the Slurm scripts.
 
 | Property | Value |
 |---|---|
-| HF model IDs | `zai-org/GLM-5`, `zai-org/GLM-5.1` |
+| HF model IDs | `zai-org/GLM-5`, `zai-org/GLM-5.1`, `zai-org/GLM-5.2` |
 | Architecture | MoE + MLA + DSA (`GlmMoeDsaForCausalLM`) |
-| Layers | 78 transformer (first 3 dense, rest MoE) |
+| Layers | 78 logical blocks; 156 physical Hybrid layers (first 3 MLPs dense, rest MoE) |
 | Routed experts | 256, top-8 per token |
 | Shared experts | 1 per MoE layer |
-| Total params | ~800B+ (BF16) |
+| Total params | ~750-800B (BF16, variant-dependent) |
 | Active params | ~60B per token |
 
 **Requirements:** `transformers >= 5.2.0`, `fast-hadamard-transform` (CUDA extension, required by DSA)
+
+The bridge represents each logical block as a `D-` dense pair or `DE` MoE pair in `HybridModel`. GLM-5.2 IndexShare is derived from `indexer_types`; when PP is enabled, stage boundaries are automatically moved to full-indexer DSA layers so shared indexer output never crosses stages. BF16 checkpoint conversion is supported; FP8 checkpoints and MTP execution are outside the current scope.
 
 ## Hardware Requirements
 
@@ -24,17 +26,6 @@ Full-model conversion and inference in BF16 requires **at least 8 nodes (64 GPUs
 - TP does **not** reduce expert memory — increase EP instead.
 - Minimum recommended: `TP=2, EP=32, PP=1` (64 GPUs, 8 nodes).
 - `TP=1, EP=64` works for conversion but may cause empty-dispatch issues during autoregressive inference with single-token batches. Use `TP >= 2` for inference.
-
-### Pre-requisites
-
-Install `fast-hadamard-transform` (required by the DSA attention variant) into the project venv from a GPU node:
-
-```bash
-pip install --target=.venv/lib/python3.12/site-packages --no-deps --no-build-isolation \
-    git+https://github.com/Dao-AILab/fast-hadamard-transform.git
-```
-
-The PyPI source distribution is incomplete; install from the git repo.
 
 ## Inference (Megatron)
 
@@ -77,14 +68,7 @@ Both scripts resolve the HF model from the local cache to avoid `snapshot_downlo
 |---|---|
 | `CONTAINER_IMAGE` | Path to Singularity/SquashFS container image |
 | `BRIDGE_PATH` | Megatron-Bridge checkout on shared storage (bind-mounted as `/opt/Megatron-Bridge`) |
-| `HF_HOME` | HuggingFace cache directory (must contain the downloaded `zai-org/GLM-5` or `zai-org/GLM-5.1` model) |
+| `HF_HOME` | HuggingFace cache directory containing the selected `zai-org/GLM-5` family checkpoint |
 | `HF_TOKEN` | HuggingFace access token (for gated model access) |
-| `MODEL_NAME` | HF model name without the `zai-org/` prefix; defaults to `GLM-5`. Set to `GLM-5.1` to run the 5.1 checkpoint. |
+| `MODEL_NAME` | HF model name without the `zai-org/` prefix; defaults to `GLM-5`. Supported values include `GLM-5`, `GLM-5.1`, and `GLM-5.2`. |
 | `OUTPUT_DIR` | Conversion output directory (conversion script only) |
-
-## MCore Patches Required
-
-The DSA attention variant requires two patches to `megatron/core/models/gpt/experimental_attention_variant_module_specs.py`:
-
-1. **DSA dispatch:** Add `elif config.experimental_attention_variant == "dsa"` to `get_experimental_attention_variant_module_spec` to call `get_dsa_module_spec_for_backend`.
-2. **MLA metainfo:** Add `metainfo={"fuse_input_layernorm": False}` to the `MLASelfAttention` `ModuleSpec` in `get_dsa_module_spec_for_backend`.

--- a/examples/models/glm/glm5/slurm_conversion.sh
+++ b/examples/models/glm/glm5/slurm_conversion.sh
@@ -14,11 +14,11 @@
 # limitations under the License.
 
 # ==============================================================================
-# GLM-5 / GLM-5.1 Conversion Round-Trip Verification (Multi-Node via Slurm)
+# GLM-5 / GLM-5.1 / GLM-5.2 Conversion Round-Trip Verification (Multi-Node via Slurm)
 #
-# GLM-5 and GLM-5.1 share the same GlmMoeDsaForCausalLM architecture
-# (MoE + MLA + DSA: 256 routed experts, top-8, ~800B+ params, BF16),
-# so this script handles both. Set MODEL_NAME=GLM-5.1 to run the 5.1 checkpoint.
+# The GLM-5 family shares the same GlmMoeDsaForCausalLM architecture
+# (MoE + MLA + DSA: 256 routed experts, top-8, ~750-800B params, BF16),
+# so this script handles GLM-5, GLM-5.1, and GLM-5.2.
 #
 # The full model requires multi-node — minimum 8 nodes (64 GPUs) with
 # EP >= 32.  TP does NOT reduce expert memory — increase EP instead.
@@ -31,6 +31,7 @@
 #   3. Submit:
 #        sbatch examples/models/glm/glm5/slurm_conversion.sh                  # GLM-5
 #        MODEL_NAME=GLM-5.1 sbatch examples/models/glm/glm5/slurm_conversion.sh
+#        MODEL_NAME=GLM-5.2 sbatch examples/models/glm/glm5/slurm_conversion.sh
 # ==============================================================================
 
 #SBATCH --job-name=glm5-roundtrip
@@ -61,7 +62,7 @@ WORKDIR="/opt/Megatron-Bridge"
 PARALLELISM_CONFIGS=("2,1,32")
 
 # ── Model ─────────────────────────────────────────────────────────────────
-# MODEL_NAME selects between GLM-5 and GLM-5.1 (same architecture).
+# MODEL_NAME selects a GLM-5-family checkpoint.
 MODEL_NAME="${MODEL_NAME:-GLM-5}"
 HF_MODEL_ID=zai-org/$MODEL_NAME
 

--- a/examples/models/glm/glm5/slurm_inference.sh
+++ b/examples/models/glm/glm5/slurm_inference.sh
@@ -14,11 +14,11 @@
 # limitations under the License.
 
 # ==============================================================================
-# GLM-5 / GLM-5.1 Multi-Node Inference (Slurm)
+# GLM-5 / GLM-5.1 / GLM-5.2 Multi-Node Inference (Slurm)
 #
-# GLM-5 and GLM-5.1 share the same GlmMoeDsaForCausalLM architecture
-# (MoE + MLA + DSA: 256 routed experts, top-8, ~800B+ params, BF16),
-# so this script handles both. Set MODEL_NAME=GLM-5.1 to run the 5.1 checkpoint.
+# The GLM-5 family shares the same GlmMoeDsaForCausalLM architecture
+# (MoE + MLA + DSA: 256 routed experts, top-8, ~750-800B params, BF16),
+# so this script handles GLM-5, GLM-5.1, and GLM-5.2.
 #
 # Full model requires 8 nodes (64 GPUs) minimum.
 # TP does NOT reduce expert memory — increase EP instead.
@@ -35,6 +35,7 @@
 # Usage:
 #   sbatch examples/models/glm/glm5/slurm_inference.sh                  # GLM-5
 #   MODEL_NAME=GLM-5.1 sbatch examples/models/glm/glm5/slurm_inference.sh
+#   MODEL_NAME=GLM-5.2 sbatch examples/models/glm/glm5/slurm_inference.sh
 # ==============================================================================
 
 #SBATCH --job-name=glm5-infer
@@ -59,7 +60,7 @@ export HF_HOME="${HF_HOME:?Set HF_HOME to your HuggingFace cache directory}"
 export UV_CACHE_DIR="${UV_CACHE_DIR:-/tmp/uv_cache}"
 
 # ── Model / Parallelism ──────────────────────────────────────────────────
-# MODEL_NAME selects between GLM-5 and GLM-5.1 (same architecture).
+# MODEL_NAME selects a GLM-5-family checkpoint.
 MODEL_NAME="${MODEL_NAME:-GLM-5}"
 # Use the direct local snapshot path to avoid 64 processes calling
 # snapshot_download simultaneously (causes Lustre race conditions).

--- a/src/megatron/bridge/models/conversion/model_bridge.py
+++ b/src/megatron/bridge/models/conversion/model_bridge.py
@@ -548,9 +548,9 @@ class MegatronModelBridge(
 
         # Handle rope scaling: extract params from rope_scaling dict
         # HF configs use either "type" or "rope_type" key for the scaling type
-        from megatron.bridge.models.mla_provider import MLAModelProvider
+        from megatron.bridge.models.transformer_config import MLATransformerConfig
 
-        is_mla_provider = self.PROVIDER_CLASS is not None and issubclass(self.PROVIDER_CLASS, MLAModelProvider)
+        is_mla_provider = self.PROVIDER_CLASS is not None and issubclass(self.PROVIDER_CLASS, MLATransformerConfig)
         rope_scaling = getattr(hf_config, "rope_scaling", None)
 
         rope_type = None
@@ -630,7 +630,7 @@ class MegatronModelBridge(
             ModelProviderTarget: A configured model provider instance
         """
         from megatron.bridge.models.gpt_provider import GPTModelProvider
-        from megatron.bridge.models.mla_provider import MLAModelProvider
+        from megatron.bridge.models.transformer_config import MLATransformerConfig
 
         hf_config = hf_pretrained.config
 
@@ -641,7 +641,7 @@ class MegatronModelBridge(
 
         # Use specified provider class, defaulting to GPTModelProvider
         provider_class = self.PROVIDER_CLASS if self.PROVIDER_CLASS is not None else GPTModelProvider
-        is_mla_provider = issubclass(provider_class, MLAModelProvider)
+        is_mla_provider = issubclass(provider_class, MLATransformerConfig)
         # Filter kwargs to only fields the provider dataclass accepts, so that MLA-only None
         # values (q_lora_rank, kv_lora_rank, …) are silently dropped for non-MLA providers
         # while still being passed through for MLA providers that declare them as fields.

--- a/src/megatron/bridge/models/glm_moe_dsa/glm5_bridge.py
+++ b/src/megatron/bridge/models/glm_moe_dsa/glm5_bridge.py
@@ -12,9 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
+from copy import deepcopy
 
-from megatron.core.models.gpt.gpt_model import GPTModel
+import torch
+from megatron.core.models.hybrid.hybrid_layer_allocation import Symbols
+from megatron.core.models.hybrid.hybrid_model import HybridModel
+from megatron.core.transformer import ModuleSpec
+from megatron.core.transformer.experimental_attention_variant.dsa import is_dsa_skip_topk_layer
+from torch import nn
 from transformers import GlmMoeDsaForCausalLM
 
 from megatron.bridge.models.conversion.mapping_registry import MegatronMappingRegistry
@@ -24,24 +29,137 @@ from megatron.bridge.models.conversion.param_mapping import (
     GatedMLPMapping,
     QKVMapping,
 )
+from megatron.bridge.models.glm_moe_dsa.glm5_provider import GLM5ModelProvider
 from megatron.bridge.models.hf_pretrained.causal_lm import PreTrainedCausalLM
-from megatron.bridge.models.mla_provider import MLAModelProvider
+from megatron.bridge.models.hybrid.hybrid_provider import get_default_hybrid_stack_spec
 
 
-logger = logging.getLogger(__name__)
+def glm5_hybrid_stack_spec(config: GLM5ModelProvider) -> ModuleSpec:
+    """Return the selected Hybrid stack with GLM's MLA query and KV norms."""
+    stack_spec = deepcopy(get_default_hybrid_stack_spec(config))
+    dsa_submodules = stack_spec.submodules.dsa_layer.submodules
+    native_norm = dsa_submodules.input_layernorm
+    attention_submodules = dsa_submodules.self_attention.submodules
+    attention_submodules.q_layernorm = native_norm
+    attention_submodules.kv_layernorm = native_norm
+    return stack_spec
+
+
+def _get_mlp_layer_types(hf_config) -> list[str]:
+    """Return and validate the logical GLM MLP layer types."""
+    num_layers = hf_config.num_hidden_layers
+    layer_types = getattr(hf_config, "mlp_layer_types", None)
+    if layer_types is None:
+        first_k_dense = getattr(hf_config, "first_k_dense_replace", min(3, num_layers))
+        layer_types = ["dense"] * first_k_dense + ["sparse"] * (num_layers - first_k_dense)
+    else:
+        layer_types = list(layer_types)
+
+    if len(layer_types) != num_layers:
+        raise ValueError(f"mlp_layer_types has {len(layer_types)} entries, but num_hidden_layers is {num_layers}.")
+    invalid_types = sorted(set(layer_types) - {"dense", "sparse"})
+    if invalid_types:
+        raise ValueError(f"Unsupported GLM MLP layer types: {invalid_types}. Expected 'dense' or 'sparse'.")
+    return layer_types
+
+
+def _indexer_types_for_schedule(num_layers: int, *, topk_freq: int, skip_topk_offset: int) -> list[str]:
+    """Build an HF-style logical IndexShare schedule from MCore parameters."""
+    return [
+        "shared" if is_dsa_skip_topk_layer(layer_number, skip_topk_offset, topk_freq) else "full"
+        for layer_number in range(1, num_layers + 1)
+    ]
+
+
+def _get_index_share_schedule(hf_config) -> tuple[int, int]:
+    """Derive and validate the logical IndexShare frequency and offset."""
+    num_layers = hf_config.num_hidden_layers
+    indexer_types = getattr(hf_config, "indexer_types", None)
+    if indexer_types is None:
+        raise ValueError("GLM IndexShare conversion requires indexer_types in the Hugging Face config.")
+    indexer_types = list(indexer_types)
+    if len(indexer_types) != num_layers:
+        raise ValueError(f"indexer_types has {len(indexer_types)} entries, but num_hidden_layers is {num_layers}.")
+    invalid_types = sorted(set(indexer_types) - {"full", "shared"})
+    if invalid_types:
+        raise ValueError(f"Unsupported GLM indexer types: {invalid_types}. Expected 'full' or 'shared'.")
+
+    if all(indexer_type == "full" for indexer_type in indexer_types):
+        return 1, 0
+
+    configured_freq = getattr(hf_config, "index_topk_freq", None)
+    configured_offset = getattr(hf_config, "index_skip_topk_offset", None)
+    if configured_freq is not None and configured_offset is not None:
+        configured_schedule = _indexer_types_for_schedule(
+            num_layers,
+            topk_freq=configured_freq,
+            skip_topk_offset=configured_offset,
+        )
+        if configured_schedule != indexer_types:
+            raise ValueError(
+                "indexer_types does not match index_topk_freq/index_skip_topk_offset: "
+                f"expected {configured_schedule}, got {indexer_types}."
+            )
+        return configured_freq, configured_offset
+
+    candidates = [
+        (topk_freq, skip_topk_offset)
+        for topk_freq in range(2, num_layers + 1)
+        for skip_topk_offset in range(num_layers + 1)
+        if _indexer_types_for_schedule(
+            num_layers,
+            topk_freq=topk_freq,
+            skip_topk_offset=skip_topk_offset,
+        )
+        == indexer_types
+    ]
+    if configured_freq is not None:
+        candidates = [candidate for candidate in candidates if candidate[0] == configured_freq]
+    if configured_offset is not None:
+        candidates = [candidate for candidate in candidates if candidate[1] == configured_offset]
+    if not candidates:
+        raise ValueError(
+            f"indexer_types cannot be represented by MCore's periodic DSA IndexShare schedule: {indexer_types}."
+        )
+
+    # Prefer the widest matching period when a short config ends before the next full indexer.
+    return max(candidates, key=lambda candidate: (candidate[0], -candidate[1]))
+
+
+class _GLM5IndexShareMapping(AutoMapping):
+    """Export a live MCore indexer to its source and shared HF layers."""
+
+    def __init__(self, megatron_param: str, hf_param: str, shared_hf_params: tuple[str, ...] = ()):
+        super().__init__(megatron_param=megatron_param, hf_param=hf_param)
+        self.shared_hf_params = shared_hf_params
+
+    def megatron_to_hf(
+        self,
+        megatron_weights: torch.Tensor | None,
+        megatron_module: nn.Module | None,
+    ) -> dict[str, torch.Tensor]:
+        """Copy the computing indexer's weight to HF's unused shared modules."""
+        result = super().megatron_to_hf(megatron_weights, megatron_module)
+        if result:
+            source_weight = result[self.hf_param]
+            result.update({hf_param: source_weight.clone() for hf_param in self.shared_hf_params})
+        return result
 
 
 @MegatronModelBridge.register_bridge(
-    source=GlmMoeDsaForCausalLM, target=GPTModel, provider=MLAModelProvider, model_type="glm_moe_dsa"
+    source=GlmMoeDsaForCausalLM,
+    target=HybridModel,
+    provider=GLM5ModelProvider,
+    model_type="glm_moe_dsa",
 )
 class GLM5Bridge(MegatronModelBridge):
     """
-    Megatron Bridge for GLM-5 / GLM-5.1 (MoE + MLA + DSA).
+    Megatron Bridge for GLM-5 / GLM-5.1 / GLM-5.2 (MoE + MLA + DSA).
 
     This bridge handles conversion between HuggingFace GlmMoeDsaForCausalLM
-    and Megatron-Core GPTModel formats. GLM-5 and GLM-5.1 share the same
-    architecture and configuration shape, so both ``zai-org/GLM-5`` and
-    ``zai-org/GLM-5.1`` are auto-detected through this bridge.
+    and Megatron-Core HybridModel formats. The GLM-5 family shares the same
+    architecture and configuration shape, so all variants are auto-detected
+    through this bridge.
 
     The architecture uses Multi-Latent Attention (MLA), Dynamic Sparse Attention
     (DSA) indexer layers, and Mixture-of-Experts (MoE).
@@ -53,19 +171,10 @@ class GLM5Bridge(MegatronModelBridge):
         >>> provider = bridge.to_megatron_provider()
     """
 
-    def provider_bridge(self, hf_pretrained: PreTrainedCausalLM) -> MLAModelProvider:
+    def provider_bridge(self, hf_pretrained: PreTrainedCausalLM) -> GLM5ModelProvider:
+        """Convert a Hugging Face GLM-5-family config to a Hybrid MLA provider."""
         provider = super().provider_bridge(hf_pretrained)
         hf_config = hf_pretrained.config
-
-        # Use experimental-attention spec for DSA
-        try:
-            from megatron.core.models.gpt.experimental_attention_variant_module_specs import (
-                get_transformer_block_with_experimental_attention_variant_spec,
-            )
-
-            provider.transformer_layer_spec = get_transformer_block_with_experimental_attention_variant_spec
-        except (ImportError, ModuleNotFoundError):
-            logger.warning("DSA spec not available; falling back to standard GPT decoder block spec.")
 
         provider.normalization = "RMSNorm"
         provider.gated_linear_unit = True
@@ -73,6 +182,7 @@ class GLM5Bridge(MegatronModelBridge):
         provider.share_embeddings_and_output_weights = False
         provider.qk_layernorm = True
         provider.multi_latent_attention = True
+        provider.sequence_parallel = True
 
         # Disable MTP (Multi-Token Prediction) by default
         # HF config has num_nextn_predict_layers=1
@@ -93,10 +203,15 @@ class GLM5Bridge(MegatronModelBridge):
 
         provider.make_vocab_size_divisible_by = 1280
 
-        # GLM5-specific: computed fields not in CONFIG_MAPPING
-        provider.moe_layer_freq = [0] * hf_config.first_k_dense_replace + [1] * (
-            hf_config.num_hidden_layers - hf_config.first_k_dense_replace
+        mlp_layer_types = _get_mlp_layer_types(hf_config)
+        provider.hybrid_layer_pattern = "".join(
+            Symbols.DS_ATTENTION + (Symbols.MLP if layer_type == "dense" else Symbols.MOE)
+            for layer_type in mlp_layer_types
         )
+        provider.num_layers = len(provider.hybrid_layer_pattern)
+        provider.moe_layer_freq = [int(layer_type == Symbols.MOE) for layer_type in provider.hybrid_layer_pattern]
+        provider.hybrid_stack_spec = glm5_hybrid_stack_spec
+
         provider.moe_shared_expert_intermediate_size = hf_config.moe_intermediate_size * hf_config.n_shared_experts
 
         # GLM5-specific: rotary_base is nested in rope_parameters
@@ -105,6 +220,10 @@ class GLM5Bridge(MegatronModelBridge):
         provider.rotary_scaling_factor = 1.0
         provider.mscale = 1.0
         provider.mscale_all_dim = 1.0
+        # Transformers ignores the legacy interleave fields and applies split-half RoPE.
+        provider.rotary_interleaved = False
+        provider.dsa_indexer_rope_interleaved = False
+        provider.apply_rope_fusion = False
 
         # DSA indexer params
         provider.experimental_attention_variant = "dsa"
@@ -114,10 +233,186 @@ class GLM5Bridge(MegatronModelBridge):
         provider.dsa_indexer_loss_coeff = 0.001
         provider.dsa_indexer_use_sparse_loss = True
 
+        logical_freq, logical_offset = _get_index_share_schedule(hf_config)
+        provider.dsa_indexer_topk_freq = 2 * logical_freq
+        provider.dsa_indexer_skip_topk_offset = 2 * max(logical_offset, 1) - 1
+
         return provider
 
+    @classmethod
+    def megatron_to_hf_config(cls, provider) -> dict:
+        """Restore the logical GLM layer count when exporting a Hybrid model."""
+        hf_config = super().megatron_to_hf_config(provider)
+        hybrid_layer_pattern = getattr(provider, "hybrid_layer_pattern", None)
+        if hybrid_layer_pattern:
+            main_pattern = hybrid_layer_pattern.split(Symbols.MTP_SEPARATOR)[0]
+            hf_config["num_hidden_layers"] = main_pattern.count(Symbols.DS_ATTENTION)
+        return hf_config
+
     def mapping_registry(self) -> MegatronMappingRegistry:
-        param_mappings = {
+        """Return explicit logical-to-physical GLM parameter mappings."""
+        hf_config = self.hf_config
+        _get_index_share_schedule(hf_config)
+        indexer_types = list(hf_config.indexer_types)
+        index_share_groups: dict[int, list[int]] = {}
+        source_layer_idx = None
+        for layer_idx, indexer_type in enumerate(indexer_types):
+            if indexer_type == "full":
+                source_layer_idx = layer_idx
+                index_share_groups[source_layer_idx] = []
+            elif source_layer_idx is None:
+                raise ValueError("The first GLM indexer layer must be 'full'.")
+            else:
+                index_share_groups[source_layer_idx].append(layer_idx)
+
+        mapping_list = [
+            AutoMapping(
+                megatron_param="embedding.word_embeddings.weight",
+                hf_param="model.embed_tokens.weight",
+            ),
+            AutoMapping(megatron_param="decoder.final_norm.weight", hf_param="model.norm.weight"),
+            AutoMapping(megatron_param="output_layer.weight", hf_param="lm_head.weight"),
+        ]
+
+        for hf_layer_idx, mlp_layer_type in enumerate(_get_mlp_layer_types(hf_config)):
+            dsa_layer_idx = 2 * hf_layer_idx
+            ffn_layer_idx = dsa_layer_idx + 1
+            hf_layer = f"model.layers.{hf_layer_idx}"
+            dsa_layer = f"decoder.layers.{dsa_layer_idx}"
+            ffn_layer = f"decoder.layers.{ffn_layer_idx}"
+
+            mapping_list.extend(
+                [
+                    AutoMapping(
+                        megatron_param=f"{dsa_layer}.input_layernorm.weight",
+                        hf_param=f"{hf_layer}.input_layernorm.weight",
+                    ),
+                    AutoMapping(
+                        megatron_param=f"{dsa_layer}.self_attention.linear_proj.weight",
+                        hf_param=f"{hf_layer}.self_attn.o_proj.weight",
+                    ),
+                    AutoMapping(
+                        megatron_param=f"{dsa_layer}.self_attention.linear_q_down_proj.weight",
+                        hf_param=f"{hf_layer}.self_attn.q_a_proj.weight",
+                    ),
+                    AutoMapping(
+                        megatron_param=f"{dsa_layer}.self_attention.linear_q_up_proj.weight",
+                        hf_param=f"{hf_layer}.self_attn.q_b_proj.weight",
+                    ),
+                    AutoMapping(
+                        megatron_param=f"{dsa_layer}.self_attention.q_layernorm.weight",
+                        hf_param=f"{hf_layer}.self_attn.q_a_layernorm.weight",
+                    ),
+                    AutoMapping(
+                        megatron_param=f"{dsa_layer}.self_attention.linear_kv_down_proj.weight",
+                        hf_param=f"{hf_layer}.self_attn.kv_a_proj_with_mqa.weight",
+                    ),
+                    AutoMapping(
+                        megatron_param=f"{dsa_layer}.self_attention.linear_kv_up_proj.weight",
+                        hf_param=f"{hf_layer}.self_attn.kv_b_proj.weight",
+                    ),
+                    AutoMapping(
+                        megatron_param=f"{dsa_layer}.self_attention.kv_layernorm.weight",
+                        hf_param=f"{hf_layer}.self_attn.kv_a_layernorm.weight",
+                    ),
+                    AutoMapping(
+                        megatron_param=f"{dsa_layer}.self_attention.linear_q_proj.weight",
+                        hf_param=f"{hf_layer}.self_attn.q_proj.weight",
+                    ),
+                ]
+            )
+
+            if indexer_types[hf_layer_idx] == "full":
+                shared_layer_indices = index_share_groups[hf_layer_idx]
+                indexer_mappings = {
+                    "linear_wq_b.weight": "wq_b.weight",
+                    "linear_wk.weight": "wk.weight",
+                    "k_norm.weight": "k_norm.weight",
+                    "k_norm.bias": "k_norm.bias",
+                    "linear_weights_proj.weight": "weights_proj.weight",
+                }
+                for megatron_suffix, hf_suffix in indexer_mappings.items():
+                    mapping_list.append(
+                        _GLM5IndexShareMapping(
+                            megatron_param=(f"{dsa_layer}.self_attention.core_attention.indexer.{megatron_suffix}"),
+                            hf_param=f"{hf_layer}.self_attn.indexer.{hf_suffix}",
+                            shared_hf_params=tuple(
+                                f"model.layers.{shared_idx}.self_attn.indexer.{hf_suffix}"
+                                for shared_idx in shared_layer_indices
+                            ),
+                        )
+                    )
+
+            if mlp_layer_type == "dense":
+                mapping_list.extend(
+                    [
+                        AutoMapping(
+                            megatron_param=f"{ffn_layer}.mlp.linear_fc1.layer_norm_weight",
+                            hf_param=f"{hf_layer}.post_attention_layernorm.weight",
+                        ),
+                        AutoMapping(
+                            megatron_param=f"{ffn_layer}.mlp.linear_fc2.weight",
+                            hf_param=f"{hf_layer}.mlp.down_proj.weight",
+                        ),
+                        GatedMLPMapping(
+                            megatron_param=f"{ffn_layer}.mlp.linear_fc1.weight",
+                            gate=f"{hf_layer}.mlp.gate_proj.weight",
+                            up=f"{hf_layer}.mlp.up_proj.weight",
+                        ),
+                    ]
+                )
+                continue
+
+            mapping_list.extend(
+                [
+                    AutoMapping(
+                        megatron_param=f"{ffn_layer}.pre_mlp_layernorm.weight",
+                        hf_param=f"{hf_layer}.post_attention_layernorm.weight",
+                    ),
+                    AutoMapping(
+                        megatron_param=f"{ffn_layer}.mlp.router.weight",
+                        hf_param=f"{hf_layer}.mlp.gate.weight",
+                    ),
+                    AutoMapping(
+                        megatron_param=f"{ffn_layer}.mlp.router.expert_bias",
+                        hf_param=f"{hf_layer}.mlp.gate.e_score_correction_bias",
+                    ),
+                    AutoMapping(
+                        megatron_param=f"{ffn_layer}.mlp.shared_experts.router.weight",
+                        hf_param=f"{hf_layer}.mlp.shared_experts.gate.weight",
+                    ),
+                    AutoMapping(
+                        megatron_param=f"{ffn_layer}.mlp.shared_experts.linear_fc2.weight",
+                        hf_param=f"{hf_layer}.mlp.shared_experts.down_proj.weight",
+                    ),
+                    GatedMLPMapping(
+                        megatron_param=f"{ffn_layer}.mlp.shared_experts.linear_fc1.weight",
+                        gate=f"{hf_layer}.mlp.shared_experts.gate_proj.weight",
+                        up=f"{hf_layer}.mlp.shared_experts.up_proj.weight",
+                    ),
+                    AutoMapping(
+                        megatron_param=f"{ffn_layer}.mlp.experts.linear_fc2.weight*",
+                        hf_param=f"{hf_layer}.mlp.experts.*.down_proj.weight",
+                    ),
+                    AutoMapping(
+                        megatron_param=f"{ffn_layer}.mlp.experts.local_experts.*.linear_fc2.weight",
+                        hf_param=f"{hf_layer}.mlp.experts.*.down_proj.weight",
+                    ),
+                    GatedMLPMapping(
+                        megatron_param=f"{ffn_layer}.mlp.experts.linear_fc1.weight*",
+                        gate=f"{hf_layer}.mlp.experts.*.gate_proj.weight",
+                        up=f"{hf_layer}.mlp.experts.*.up_proj.weight",
+                    ),
+                    GatedMLPMapping(
+                        megatron_param=f"{ffn_layer}.mlp.experts.local_experts.*.linear_fc1.weight",
+                        gate=f"{hf_layer}.mlp.experts.*.gate_proj.weight",
+                        up=f"{hf_layer}.mlp.experts.*.up_proj.weight",
+                    ),
+                ]
+            )
+
+        # MTP execution remains disabled, but keep the existing conversion registrations.
+        mtp_param_mappings = {
             # Embed
             "embedding.word_embeddings.weight": "model.embed_tokens.weight",
             # LM Head
@@ -161,56 +456,7 @@ class GLM5Bridge(MegatronModelBridge):
             "decoder.layers.*.mlp.experts.local_experts.*.linear_fc2.weight": "model.layers.*.mlp.experts.*.down_proj.weight",
         }
 
-        mapping_list = [AutoMapping(megatron_param=k, hf_param=v) for k, v in param_mappings.items()]
-
-        # Attention (non-MLA fallback: combined QKV)
-        mapping_list.extend(
-            [
-                QKVMapping(
-                    megatron_param="decoder.layers.*.self_attention.linear_qkv.weight",
-                    q="model.layers.*.self_attn.q_proj.weight",
-                    k="model.layers.*.self_attn.k_proj.weight",
-                    v="model.layers.*.self_attn.v_proj.weight",
-                ),
-                QKVMapping(
-                    megatron_param="decoder.layers.*.self_attention.linear_qkv.bias",
-                    q="model.layers.*.self_attn.q_proj.bias",
-                    k="model.layers.*.self_attn.k_proj.bias",
-                    v="model.layers.*.self_attn.v_proj.bias",
-                ),
-                # Dense MLP gate+up → fc1
-                GatedMLPMapping(
-                    megatron_param="decoder.layers.*.mlp.linear_fc1.weight",
-                    gate="model.layers.*.mlp.gate_proj.weight",
-                    up="model.layers.*.mlp.up_proj.weight",
-                ),
-                # Shared expert gate+up → fc1
-                GatedMLPMapping(
-                    megatron_param="decoder.layers.*.mlp.shared_experts.linear_fc1.weight",
-                    gate="model.layers.*.mlp.shared_experts.gate_proj.weight",
-                    up="model.layers.*.mlp.shared_experts.up_proj.weight",
-                ),
-            ]
-        )
-
-        # MoE expert weights (per-expert format: experts.N.gate_proj / up_proj)
-        mapping_list.extend(
-            [
-                GatedMLPMapping(
-                    megatron_param="decoder.layers.*.mlp.experts.linear_fc1.weight*",
-                    gate="model.layers.*.mlp.experts.*.gate_proj.weight",
-                    up="model.layers.*.mlp.experts.*.up_proj.weight",
-                ),
-                GatedMLPMapping(
-                    megatron_param="decoder.layers.*.mlp.experts.local_experts.*.linear_fc1.weight",
-                    gate="model.layers.*.mlp.experts.*.gate_proj.weight",
-                    up="model.layers.*.mlp.experts.*.up_proj.weight",
-                ),
-            ]
-        )
-
-        hf_config = self.hf_config
-        num_mtp_layers = getattr(hf_config, "num_nextn_predict_layers", 0)
+        num_mtp_layers = getattr(hf_config, "num_nextn_predict_layers", 0) or 0
         num_transformer_layers = hf_config.num_hidden_layers
         for mtp_layer in range(num_mtp_layers):
             # MTP specific mappings
@@ -236,7 +482,7 @@ class GLM5Bridge(MegatronModelBridge):
             )
 
             for layer_prefix in ("transformer_layer", "mtp_model_layer"):
-                for megatron_param, hf_param in param_mappings.items():
+                for megatron_param, hf_param in mtp_param_mappings.items():
                     megatron_param = (
                         megatron_param.replace(".*", f".*.{layer_prefix}", 1)
                         .replace("decoder", "mtp")

--- a/src/megatron/bridge/models/glm_moe_dsa/glm5_provider.py
+++ b/src/megatron/bridge/models/glm_moe_dsa/glm5_provider.py
@@ -14,7 +14,7 @@
 
 """GLM5 uses HybridMLAModelProvider through this compatibility alias."""
 
-from megatron.bridge.models.mla_provider import HybridMLAModelProvider as GLM5ModelProvider  # noqa: F401
+from megatron.bridge.models.hybrid_mla_provider import HybridMLAModelProvider as GLM5ModelProvider  # noqa: F401
 
 
 __all__ = ["GLM5ModelProvider"]

--- a/src/megatron/bridge/models/glm_moe_dsa/glm5_provider.py
+++ b/src/megatron/bridge/models/glm_moe_dsa/glm5_provider.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""GLM5 uses MLAModelProvider directly. This module is kept for import compatibility."""
+"""GLM5 uses HybridMLAModelProvider through this compatibility alias."""
 
-from megatron.bridge.models.mla_provider import MLAModelProvider as GLM5ModelProvider  # noqa: F401
+from megatron.bridge.models.mla_provider import HybridMLAModelProvider as GLM5ModelProvider  # noqa: F401
 
 
 __all__ = ["GLM5ModelProvider"]

--- a/src/megatron/bridge/models/hybrid_mla_provider.py
+++ b/src/megatron/bridge/models/hybrid_mla_provider.py
@@ -1,0 +1,148 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Hybrid model provider for Multi-Latent Attention."""
+
+from dataclasses import dataclass
+
+from megatron.core.models.hybrid.hybrid_layer_allocation import Symbols
+from megatron.core.transformer.experimental_attention_variant.dsa import (
+    is_dsa_skip_topk_layer,
+    source_dsa_compute_layer,
+)
+
+from megatron.bridge.models.hybrid.hybrid_provider import HybridModelProvider
+from megatron.bridge.models.transformer_config import MLATransformerConfig
+
+
+def _validate_dsa_pipeline_segments(main_pattern: str, *, topk_freq: int, skip_topk_offset: int) -> None:
+    """Ensure shared DSA indexers never reference a previous pipeline stage."""
+    layer_offset = 0
+    for segment_idx, segment in enumerate(main_pattern.split(Symbols.PIPE)):
+        if segment_idx > 0 and (not segment or segment[0] != Symbols.DS_ATTENTION):
+            raise ValueError(
+                "Hybrid MLA pipeline separators must be placed before DSA layers "
+                "so attention and FFN physical layers stay together."
+            )
+        for local_idx, layer_type in enumerate(segment):
+            layer_number = layer_offset + local_idx + 1
+            if layer_type != Symbols.DS_ATTENTION or not is_dsa_skip_topk_layer(
+                layer_number, skip_topk_offset, topk_freq
+            ):
+                continue
+            source_layer = source_dsa_compute_layer(layer_number, skip_topk_offset, topk_freq)
+            if source_layer <= layer_offset:
+                raise ValueError(
+                    "Hybrid MLA pipeline segments cannot split DSA IndexShare groups: "
+                    f"layer {layer_number} reuses indexer output from layer {source_layer}, "
+                    "which is on a previous pipeline stage."
+                )
+        layer_offset += len(segment)
+
+
+def _add_dsa_pipeline_separators(
+    pattern: str,
+    *,
+    pipeline_model_parallel_size: int,
+    topk_freq: int,
+    skip_topk_offset: int,
+) -> str:
+    """Add balanced pipeline separators before full-indexer DSA layers."""
+    main_pattern, separator, mtp_pattern = pattern.partition(Symbols.MTP_SEPARATOR)
+    if Symbols.DS_ATTENTION not in main_pattern or pipeline_model_parallel_size <= 1:
+        return pattern
+
+    if Symbols.PIPE in main_pattern:
+        num_segments = main_pattern.count(Symbols.PIPE) + 1
+        if num_segments != pipeline_model_parallel_size:
+            raise ValueError(
+                f"hybrid_layer_pattern defines {num_segments} pipeline segments, but "
+                f"pipeline_model_parallel_size is {pipeline_model_parallel_size}."
+            )
+        _validate_dsa_pipeline_segments(
+            main_pattern,
+            topk_freq=topk_freq,
+            skip_topk_offset=skip_topk_offset,
+        )
+        return pattern
+
+    candidate_boundaries = [
+        layer_idx
+        for layer_idx, layer_type in enumerate(main_pattern)
+        if layer_idx > 0
+        and layer_type == Symbols.DS_ATTENTION
+        and not is_dsa_skip_topk_layer(layer_idx + 1, skip_topk_offset, topk_freq)
+    ]
+    required_boundaries = pipeline_model_parallel_size - 1
+    if len(candidate_boundaries) < required_boundaries:
+        raise ValueError(
+            "Cannot split Hybrid MLA layers across pipeline stages without crossing a DSA "
+            f"IndexShare group: found {len(candidate_boundaries)} valid boundaries for "
+            f"pipeline_model_parallel_size={pipeline_model_parallel_size}."
+        )
+
+    selected_boundaries = []
+    candidate_start = 0
+    for stage_idx in range(1, pipeline_model_parallel_size):
+        remaining_boundaries = pipeline_model_parallel_size - stage_idx - 1
+        choices = candidate_boundaries[candidate_start : len(candidate_boundaries) - remaining_boundaries]
+        target = len(main_pattern) * stage_idx / pipeline_model_parallel_size
+        boundary = min(choices, key=lambda candidate: (abs(candidate - target), candidate))
+        selected_boundaries.append(boundary)
+        candidate_start = candidate_boundaries.index(boundary, candidate_start) + 1
+
+    boundaries = set(selected_boundaries)
+    segmented_pattern = "".join(
+        (Symbols.PIPE if layer_idx in boundaries else "") + layer_type
+        for layer_idx, layer_type in enumerate(main_pattern)
+    )
+    _validate_dsa_pipeline_segments(
+        segmented_pattern,
+        topk_freq=topk_freq,
+        skip_topk_offset=skip_topk_offset,
+    )
+    return segmented_pattern + (separator + mtp_pattern if separator else "")
+
+
+@dataclass
+class HybridMLAModelProvider(HybridModelProvider, MLATransformerConfig):
+    """Provider for Hybrid models using Multi-Latent Attention."""
+
+    def finalize(self) -> None:
+        """Finalize the provider after adding DSA-safe pipeline segments."""
+        pattern_attr = "hybrid_layer_pattern"
+        pattern = self.hybrid_layer_pattern
+        if pattern is None and self.hybrid_override_pattern is not None:
+            pattern_attr = "hybrid_override_pattern"
+            pattern = self.hybrid_override_pattern
+
+        main_pattern = pattern.split(Symbols.MTP_SEPARATOR)[0] if pattern is not None else ""
+        if Symbols.DS_ATTENTION in main_pattern and self.pipeline_model_parallel_size > 1:
+            if (
+                self.num_layers_in_first_pipeline_stage is not None
+                or self.num_layers_in_last_pipeline_stage is not None
+            ):
+                raise ValueError(
+                    "Hybrid MLA derives pipeline stages from hybrid_layer_pattern; "
+                    "num_layers_in_first_pipeline_stage and num_layers_in_last_pipeline_stage are unsupported."
+                )
+            pattern = _add_dsa_pipeline_separators(
+                pattern,
+                pipeline_model_parallel_size=self.pipeline_model_parallel_size,
+                topk_freq=self.dsa_indexer_topk_freq or 1,
+                skip_topk_offset=self.dsa_indexer_skip_topk_offset or 0,
+            )
+            setattr(self, pattern_attr, pattern)
+
+        super().finalize()

--- a/src/megatron/bridge/models/mla_provider.py
+++ b/src/megatron/bridge/models/mla_provider.py
@@ -12,15 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""MLA (Multi-Latent Attention) Model Provider.
+"""MLA (Multi-Latent Attention) model providers.
 
-This module provides a minimal provider for models using Multi-Latent Attention,
-such as DeepSeek V2/V3 and Kimi K2.
+This module provides GPT and Hybrid model providers for models using
+Multi-Latent Attention.
 """
 
 from dataclasses import dataclass
 
+from megatron.core.models.hybrid.hybrid_layer_allocation import Symbols
+from megatron.core.transformer.experimental_attention_variant.dsa import (
+    is_dsa_skip_topk_layer,
+    source_dsa_compute_layer,
+)
+
 from megatron.bridge.models.gpt_provider import GPTModelProvider
+from megatron.bridge.models.hybrid.hybrid_provider import HybridModelProvider
 from megatron.bridge.models.transformer_config import MLATransformerConfig
 
 
@@ -42,3 +49,125 @@ class MLAModelProvider(MLATransformerConfig, GPTModelProvider):
     """
 
     pass
+
+
+def _validate_dsa_pipeline_segments(main_pattern: str, *, topk_freq: int, skip_topk_offset: int) -> None:
+    """Ensure shared DSA indexers never reference a previous pipeline stage."""
+    layer_offset = 0
+    for segment_idx, segment in enumerate(main_pattern.split(Symbols.PIPE)):
+        if segment_idx > 0 and (not segment or segment[0] != Symbols.DS_ATTENTION):
+            raise ValueError(
+                "Hybrid MLA pipeline separators must be placed before DSA layers "
+                "so attention and FFN physical layers stay together."
+            )
+        for local_idx, layer_type in enumerate(segment):
+            layer_number = layer_offset + local_idx + 1
+            if layer_type != Symbols.DS_ATTENTION or not is_dsa_skip_topk_layer(
+                layer_number, skip_topk_offset, topk_freq
+            ):
+                continue
+            source_layer = source_dsa_compute_layer(layer_number, skip_topk_offset, topk_freq)
+            if source_layer <= layer_offset:
+                raise ValueError(
+                    "Hybrid MLA pipeline segments cannot split DSA IndexShare groups: "
+                    f"layer {layer_number} reuses indexer output from layer {source_layer}, "
+                    "which is on a previous pipeline stage."
+                )
+        layer_offset += len(segment)
+
+
+def _add_dsa_pipeline_separators(
+    pattern: str,
+    *,
+    pipeline_model_parallel_size: int,
+    topk_freq: int,
+    skip_topk_offset: int,
+) -> str:
+    """Add balanced pipeline separators before full-indexer DSA layers."""
+    main_pattern, separator, mtp_pattern = pattern.partition(Symbols.MTP_SEPARATOR)
+    if Symbols.DS_ATTENTION not in main_pattern or pipeline_model_parallel_size <= 1:
+        return pattern
+
+    if Symbols.PIPE in main_pattern:
+        num_segments = main_pattern.count(Symbols.PIPE) + 1
+        if num_segments != pipeline_model_parallel_size:
+            raise ValueError(
+                f"hybrid_layer_pattern defines {num_segments} pipeline segments, but "
+                f"pipeline_model_parallel_size is {pipeline_model_parallel_size}."
+            )
+        _validate_dsa_pipeline_segments(
+            main_pattern,
+            topk_freq=topk_freq,
+            skip_topk_offset=skip_topk_offset,
+        )
+        return pattern
+
+    candidate_boundaries = [
+        layer_idx
+        for layer_idx, layer_type in enumerate(main_pattern)
+        if layer_idx > 0
+        and layer_type == Symbols.DS_ATTENTION
+        and not is_dsa_skip_topk_layer(layer_idx + 1, skip_topk_offset, topk_freq)
+    ]
+    required_boundaries = pipeline_model_parallel_size - 1
+    if len(candidate_boundaries) < required_boundaries:
+        raise ValueError(
+            "Cannot split Hybrid MLA layers across pipeline stages without crossing a DSA "
+            f"IndexShare group: found {len(candidate_boundaries)} valid boundaries for "
+            f"pipeline_model_parallel_size={pipeline_model_parallel_size}."
+        )
+
+    selected_boundaries = []
+    candidate_start = 0
+    for stage_idx in range(1, pipeline_model_parallel_size):
+        remaining_boundaries = pipeline_model_parallel_size - stage_idx - 1
+        choices = candidate_boundaries[candidate_start : len(candidate_boundaries) - remaining_boundaries]
+        target = len(main_pattern) * stage_idx / pipeline_model_parallel_size
+        boundary = min(choices, key=lambda candidate: (abs(candidate - target), candidate))
+        selected_boundaries.append(boundary)
+        candidate_start = candidate_boundaries.index(boundary, candidate_start) + 1
+
+    boundaries = set(selected_boundaries)
+    segmented_pattern = "".join(
+        (Symbols.PIPE if layer_idx in boundaries else "") + layer_type
+        for layer_idx, layer_type in enumerate(main_pattern)
+    )
+    _validate_dsa_pipeline_segments(
+        segmented_pattern,
+        topk_freq=topk_freq,
+        skip_topk_offset=skip_topk_offset,
+    )
+    return segmented_pattern + (separator + mtp_pattern if separator else "")
+
+
+@dataclass
+class HybridMLAModelProvider(HybridModelProvider, MLATransformerConfig):
+    """Provider for Hybrid models using Multi-Latent Attention."""
+
+    def finalize(self) -> None:
+        """Finalize the provider after adding DSA-safe pipeline segments."""
+        pattern_attr = "hybrid_layer_pattern"
+        pattern = self.hybrid_layer_pattern
+        if pattern is None and self.hybrid_override_pattern is not None:
+            pattern_attr = "hybrid_override_pattern"
+            pattern = self.hybrid_override_pattern
+
+        main_pattern = pattern.split(Symbols.MTP_SEPARATOR)[0] if pattern is not None else ""
+        if Symbols.DS_ATTENTION in main_pattern and self.pipeline_model_parallel_size > 1:
+            if (
+                self.num_layers_in_first_pipeline_stage is not None
+                or self.num_layers_in_last_pipeline_stage is not None
+            ):
+                raise ValueError(
+                    "Hybrid MLA derives pipeline stages from hybrid_layer_pattern; "
+                    "num_layers_in_first_pipeline_stage and num_layers_in_last_pipeline_stage are unsupported."
+                )
+            pattern = _add_dsa_pipeline_separators(
+                pattern,
+                pipeline_model_parallel_size=self.pipeline_model_parallel_size,
+                topk_freq=self.dsa_indexer_topk_freq or 1,
+                skip_topk_offset=self.dsa_indexer_skip_topk_offset or 0,
+            )
+            setattr(self, pattern_attr, pattern)
+
+        super().finalize()

--- a/src/megatron/bridge/models/mla_provider.py
+++ b/src/megatron/bridge/models/mla_provider.py
@@ -12,22 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""MLA (Multi-Latent Attention) model providers.
-
-This module provides GPT and Hybrid model providers for models using
-Multi-Latent Attention.
-"""
+"""GPT model provider for Multi-Latent Attention."""
 
 from dataclasses import dataclass
 
-from megatron.core.models.hybrid.hybrid_layer_allocation import Symbols
-from megatron.core.transformer.experimental_attention_variant.dsa import (
-    is_dsa_skip_topk_layer,
-    source_dsa_compute_layer,
-)
-
 from megatron.bridge.models.gpt_provider import GPTModelProvider
-from megatron.bridge.models.hybrid.hybrid_provider import HybridModelProvider
 from megatron.bridge.models.transformer_config import MLATransformerConfig
 
 
@@ -49,125 +38,3 @@ class MLAModelProvider(MLATransformerConfig, GPTModelProvider):
     """
 
     pass
-
-
-def _validate_dsa_pipeline_segments(main_pattern: str, *, topk_freq: int, skip_topk_offset: int) -> None:
-    """Ensure shared DSA indexers never reference a previous pipeline stage."""
-    layer_offset = 0
-    for segment_idx, segment in enumerate(main_pattern.split(Symbols.PIPE)):
-        if segment_idx > 0 and (not segment or segment[0] != Symbols.DS_ATTENTION):
-            raise ValueError(
-                "Hybrid MLA pipeline separators must be placed before DSA layers "
-                "so attention and FFN physical layers stay together."
-            )
-        for local_idx, layer_type in enumerate(segment):
-            layer_number = layer_offset + local_idx + 1
-            if layer_type != Symbols.DS_ATTENTION or not is_dsa_skip_topk_layer(
-                layer_number, skip_topk_offset, topk_freq
-            ):
-                continue
-            source_layer = source_dsa_compute_layer(layer_number, skip_topk_offset, topk_freq)
-            if source_layer <= layer_offset:
-                raise ValueError(
-                    "Hybrid MLA pipeline segments cannot split DSA IndexShare groups: "
-                    f"layer {layer_number} reuses indexer output from layer {source_layer}, "
-                    "which is on a previous pipeline stage."
-                )
-        layer_offset += len(segment)
-
-
-def _add_dsa_pipeline_separators(
-    pattern: str,
-    *,
-    pipeline_model_parallel_size: int,
-    topk_freq: int,
-    skip_topk_offset: int,
-) -> str:
-    """Add balanced pipeline separators before full-indexer DSA layers."""
-    main_pattern, separator, mtp_pattern = pattern.partition(Symbols.MTP_SEPARATOR)
-    if Symbols.DS_ATTENTION not in main_pattern or pipeline_model_parallel_size <= 1:
-        return pattern
-
-    if Symbols.PIPE in main_pattern:
-        num_segments = main_pattern.count(Symbols.PIPE) + 1
-        if num_segments != pipeline_model_parallel_size:
-            raise ValueError(
-                f"hybrid_layer_pattern defines {num_segments} pipeline segments, but "
-                f"pipeline_model_parallel_size is {pipeline_model_parallel_size}."
-            )
-        _validate_dsa_pipeline_segments(
-            main_pattern,
-            topk_freq=topk_freq,
-            skip_topk_offset=skip_topk_offset,
-        )
-        return pattern
-
-    candidate_boundaries = [
-        layer_idx
-        for layer_idx, layer_type in enumerate(main_pattern)
-        if layer_idx > 0
-        and layer_type == Symbols.DS_ATTENTION
-        and not is_dsa_skip_topk_layer(layer_idx + 1, skip_topk_offset, topk_freq)
-    ]
-    required_boundaries = pipeline_model_parallel_size - 1
-    if len(candidate_boundaries) < required_boundaries:
-        raise ValueError(
-            "Cannot split Hybrid MLA layers across pipeline stages without crossing a DSA "
-            f"IndexShare group: found {len(candidate_boundaries)} valid boundaries for "
-            f"pipeline_model_parallel_size={pipeline_model_parallel_size}."
-        )
-
-    selected_boundaries = []
-    candidate_start = 0
-    for stage_idx in range(1, pipeline_model_parallel_size):
-        remaining_boundaries = pipeline_model_parallel_size - stage_idx - 1
-        choices = candidate_boundaries[candidate_start : len(candidate_boundaries) - remaining_boundaries]
-        target = len(main_pattern) * stage_idx / pipeline_model_parallel_size
-        boundary = min(choices, key=lambda candidate: (abs(candidate - target), candidate))
-        selected_boundaries.append(boundary)
-        candidate_start = candidate_boundaries.index(boundary, candidate_start) + 1
-
-    boundaries = set(selected_boundaries)
-    segmented_pattern = "".join(
-        (Symbols.PIPE if layer_idx in boundaries else "") + layer_type
-        for layer_idx, layer_type in enumerate(main_pattern)
-    )
-    _validate_dsa_pipeline_segments(
-        segmented_pattern,
-        topk_freq=topk_freq,
-        skip_topk_offset=skip_topk_offset,
-    )
-    return segmented_pattern + (separator + mtp_pattern if separator else "")
-
-
-@dataclass
-class HybridMLAModelProvider(HybridModelProvider, MLATransformerConfig):
-    """Provider for Hybrid models using Multi-Latent Attention."""
-
-    def finalize(self) -> None:
-        """Finalize the provider after adding DSA-safe pipeline segments."""
-        pattern_attr = "hybrid_layer_pattern"
-        pattern = self.hybrid_layer_pattern
-        if pattern is None and self.hybrid_override_pattern is not None:
-            pattern_attr = "hybrid_override_pattern"
-            pattern = self.hybrid_override_pattern
-
-        main_pattern = pattern.split(Symbols.MTP_SEPARATOR)[0] if pattern is not None else ""
-        if Symbols.DS_ATTENTION in main_pattern and self.pipeline_model_parallel_size > 1:
-            if (
-                self.num_layers_in_first_pipeline_stage is not None
-                or self.num_layers_in_last_pipeline_stage is not None
-            ):
-                raise ValueError(
-                    "Hybrid MLA derives pipeline stages from hybrid_layer_pattern; "
-                    "num_layers_in_first_pipeline_stage and num_layers_in_last_pipeline_stage are unsupported."
-                )
-            pattern = _add_dsa_pipeline_separators(
-                pattern,
-                pipeline_model_parallel_size=self.pipeline_model_parallel_size,
-                topk_freq=self.dsa_indexer_topk_freq or 1,
-                skip_topk_offset=self.dsa_indexer_skip_topk_offset or 0,
-            )
-            setattr(self, pattern_attr, pattern)
-
-        super().finalize()

--- a/src/megatron/bridge/training/utils/flop_utils.py
+++ b/src/megatron/bridge/training/utils/flop_utils.py
@@ -354,12 +354,13 @@ def num_floating_point_operations(
         return cfg.model._get_num_floating_point_operations(batch_size)
 
     def calculate_layer_counts():
-        """Calculate the number of attention, Mamba, MLP, MoE, and GDN layers."""
+        """Calculate the number of attention, DSA, Mamba, MLP, MoE, and GDN layers."""
         hybrid_pattern = getattr(cfg.model, "hybrid_layer_pattern", None)
         if hybrid_pattern:
             layer_counts = get_hybrid_layer_counts(hybrid_pattern)
             return (
                 layer_counts[Symbols.ATTENTION],
+                layer_counts[Symbols.DS_ATTENTION],
                 layer_counts[Symbols.MAMBA],
                 layer_counts[Symbols.MLP],
                 layer_counts[Symbols.MOE],
@@ -369,9 +370,10 @@ def num_floating_point_operations(
         num_attn_layers = round(cfg.model.num_layers * getattr(cfg.model, "hybrid_attention_ratio", 0))
         num_mlp_layers = round(cfg.model.num_layers * getattr(cfg.model, "hybrid_mlp_ratio", 0))
         num_mamba_layers = cfg.model.num_layers - num_attn_layers - num_mlp_layers
+        num_dsa_layers = 0
         num_moe_layers = 0
         num_gdn_layers = 0
-        return num_attn_layers, num_mamba_layers, num_mlp_layers, num_moe_layers, num_gdn_layers
+        return num_attn_layers, num_dsa_layers, num_mamba_layers, num_mlp_layers, num_moe_layers, num_gdn_layers
 
     def mlp_layer_flops(batch_size, seq_len, hidden_size, expansion=4.0, swiglu=False):
         """Calculate FLOPs for an MLP layer."""
@@ -420,6 +422,38 @@ def num_floating_point_operations(
         return (
             4 * batch_size * seq_len * hidden_size * p * (hidden_size + (hidden_size * (g / num_heads)))
             + 2 * batch_size * seq_len * hidden_size * p * core_seq
+        )
+
+    def mla_attn_layer_flops(
+        batch_size,
+        seq_len,
+        hidden_size,
+        num_heads,
+        q_lora_rank=None,
+        kv_lora_rank=0,
+        qk_head_dim=64,
+        qk_pos_emb_head_dim=0,
+        v_head_dim=64,
+        core_attn_seq_factor=None,
+    ):
+        """Calculate FLOPs for one MLA attention layer."""
+        core_seq = seq_len if core_attn_seq_factor is None else core_attn_seq_factor
+        if q_lora_rank is None:
+            q_term = hidden_size * num_heads * (qk_head_dim + qk_pos_emb_head_dim)
+        else:
+            q_term = q_lora_rank * (hidden_size + num_heads * (qk_head_dim + qk_pos_emb_head_dim) + 1)
+        return (
+            2
+            * batch_size
+            * seq_len
+            * (
+                q_term
+                + kv_lora_rank * (hidden_size + num_heads * (qk_head_dim + v_head_dim) + 1)
+                + hidden_size * qk_pos_emb_head_dim
+                + num_heads * v_head_dim * hidden_size
+                + core_seq * num_heads * (qk_head_dim + qk_pos_emb_head_dim) / 2
+                + core_seq * num_heads * v_head_dim / 2
+            )
         )
 
     def calculate_swa_context():
@@ -524,6 +558,7 @@ def num_floating_point_operations(
         seq_len,
         hidden_size,
         num_attn_layers,
+        num_dsa_layers,
         num_mamba_layers,
         num_mlp_layers,
         num_moe_layers,
@@ -535,6 +570,11 @@ def num_floating_point_operations(
         num_attn_heads=32,
         gqa_groups=8,
         kv_channels=None,
+        q_lora_rank=None,
+        kv_lora_rank=0,
+        qk_head_dim=64,
+        qk_pos_emb_head_dim=0,
+        v_head_dim=64,
         mlp_expansion=4.0,
         swiglu=False,
         moe_latent_size=None,
@@ -577,9 +617,23 @@ def num_floating_point_operations(
                 core_attn_seq_factor=2 * swa_context,
             )
 
+        dsa_attn_flops = num_dsa_layers * mla_attn_layer_flops(
+            batch_size,
+            seq_len,
+            hidden_size,
+            num_attn_heads,
+            q_lora_rank,
+            kv_lora_rank,
+            qk_head_dim,
+            qk_pos_emb_head_dim,
+            v_head_dim,
+            core_attn_seq_factor,
+        )
+
         flops_fwd = (
             full_attn_flops
             + swa_attn_flops
+            + dsa_attn_flops
             + num_mlp_layers * mlp_layer_flops(batch_size, seq_len, hidden_size, mlp_expansion, swiglu)
             + num_mamba_layers
             * mamba_layer_flops(
@@ -828,49 +882,20 @@ def num_floating_point_operations(
                 self_attn_term += 3 * 2 * (sparse_attn_term + main_compressor_term + indexer_term)
             else:
                 ## MLA
-                if not hasattr(cfg.model, "q_lora_rank") or cfg.model.q_lora_rank is None:
-                    q_term = (
-                        cfg.model.hidden_size
-                        * cfg.model.num_attention_heads
-                        * (getattr(cfg.model, "qk_head_dim", 64) + getattr(cfg.model, "qk_pos_emb_head_dim", 0))
-                    )
-                else:
-                    q_term = cfg.model.q_lora_rank * (
-                        cfg.model.hidden_size
-                        + cfg.model.num_attention_heads
-                        * (getattr(cfg.model, "qk_head_dim", 64) + getattr(cfg.model, "qk_pos_emb_head_dim", 0))
-                        + 1
-                    )
                 self_attn_term = (
                     3
-                    * 2  # fwd(1) + bwd(2) *FMA
                     * num_layers
-                    * (
-                        ## q lora + rope + q norm
-                        q_term
-                        ## kv lora + rope + kv norm
-                        + getattr(cfg.model, "kv_lora_rank", 0)
-                        * (
-                            cfg.model.hidden_size
-                            + cfg.model.num_attention_heads
-                            * (getattr(cfg.model, "qk_head_dim", 64) + getattr(cfg.model, "v_head_dim", 64))
-                            + 1
-                        )
-                        + cfg.model.hidden_size * getattr(cfg.model, "qk_pos_emb_head_dim", 0)
-                        ## o proj
-                        + (cfg.model.num_attention_heads * getattr(cfg.model, "v_head_dim", 64))
-                        * cfg.model.hidden_size
-                        ## core attn
-                        + core_attn_seq_factor
-                        * (
-                            cfg.model.num_attention_heads
-                            * (getattr(cfg.model, "qk_head_dim", 64) + getattr(cfg.model, "qk_pos_emb_head_dim", 0))
-                        )
-                        / 2
-                        + core_attn_seq_factor
-                        * cfg.model.num_attention_heads
-                        * getattr(cfg.model, "v_head_dim", 64)
-                        / 2
+                    * mla_attn_layer_flops(
+                        batch_size=1,
+                        seq_len=1,
+                        hidden_size=cfg.model.hidden_size,
+                        num_heads=cfg.model.num_attention_heads,
+                        q_lora_rank=getattr(cfg.model, "q_lora_rank", None),
+                        kv_lora_rank=getattr(cfg.model, "kv_lora_rank", 0),
+                        qk_head_dim=getattr(cfg.model, "qk_head_dim", 64),
+                        qk_pos_emb_head_dim=getattr(cfg.model, "qk_pos_emb_head_dim", 0),
+                        v_head_dim=getattr(cfg.model, "v_head_dim", 64),
+                        core_attn_seq_factor=core_attn_seq_factor,
                     )
                 )
 
@@ -1057,7 +1082,14 @@ def num_floating_point_operations(
     # a physical hybrid pattern is sufficient to select hybrid accounting.
     if getattr(cfg.model, "is_hybrid_model", False) or getattr(cfg.model, "hybrid_layer_pattern", None):
         # Calculate the number of each type of layer.
-        num_attn_layers, num_mamba_layers, num_mlp_layers, num_moe_layers, num_gdn_layers = calculate_layer_counts()
+        (
+            num_attn_layers,
+            num_dsa_layers,
+            num_mamba_layers,
+            num_mlp_layers,
+            num_moe_layers,
+            num_gdn_layers,
+        ) = calculate_layer_counts()
         mtp_num_layers = getattr(cfg.model, "mtp_num_layers", None)
         if mtp_num_layers is None:
             # When using unified hybrid patterns, infer MTP depth count from the pattern.
@@ -1085,6 +1117,7 @@ def num_floating_point_operations(
             seq_len=effective_seq_length,
             hidden_size=cfg.model.hidden_size,
             num_attn_layers=num_attn_layers,
+            num_dsa_layers=num_dsa_layers,
             num_mamba_layers=num_mamba_layers,
             num_mlp_layers=num_mlp_layers,
             num_moe_layers=num_moe_layers,
@@ -1096,6 +1129,11 @@ def num_floating_point_operations(
             num_attn_heads=cfg.model.num_attention_heads,
             gqa_groups=num_query_groups,
             kv_channels=getattr(cfg.model, "kv_channels", None),
+            q_lora_rank=getattr(cfg.model, "q_lora_rank", None),
+            kv_lora_rank=getattr(cfg.model, "kv_lora_rank", 0),
+            qk_head_dim=getattr(cfg.model, "qk_head_dim", 64),
+            qk_pos_emb_head_dim=getattr(cfg.model, "qk_pos_emb_head_dim", 0),
+            v_head_dim=getattr(cfg.model, "v_head_dim", 64),
             mlp_expansion=cfg.model.ffn_hidden_size / cfg.model.hidden_size,
             swiglu=getattr(cfg.model, "gated_linear_unit", False),
             moe_latent_size=getattr(cfg.model, "moe_latent_size", None),

--- a/tests/functional_tests/test_groups/models/glm_moe_dsa/test_glm5_conversion.py
+++ b/tests/functional_tests/test_groups/models/glm_moe_dsa/test_glm5_conversion.py
@@ -31,11 +31,10 @@ HF_GLM5_TOY_MODEL_CONFIG = {
     "hidden_size": 1024,
     "intermediate_size": 2048,
     "moe_intermediate_size": 256,
-    "num_hidden_layers": 2,
+    "num_hidden_layers": 4,
     # ---- Attention ----
     "num_attention_heads": 16,
-    "num_key_value_heads": 4,
-    "head_dim": 64,
+    "num_key_value_heads": 16,
     "qk_head_dim": 128,
     "qk_nope_head_dim": 96,
     "qk_rope_head_dim": 32,
@@ -45,6 +44,7 @@ HF_GLM5_TOY_MODEL_CONFIG = {
     "index_n_heads": 8,
     "index_topk": 256,
     "indexer_rope_interleave": True,
+    "indexer_types": ["full", "full", "full", "shared"],
     # ---- LoRA ranks ----
     "q_lora_rank": 256,
     "kv_lora_rank": 128,
@@ -60,7 +60,7 @@ HF_GLM5_TOY_MODEL_CONFIG = {
     "routed_scaling_factor": 2.5,
     "scoring_func": "sigmoid",
     "topk_method": "noaux_tc",
-    "mlp_layer_types": ["dense", "sparse"],
+    "mlp_layer_types": ["dense", "sparse", "sparse", "sparse"],
     # ---- Position encoding ----
     "max_position_embeddings": 8192,
     "rope_interleave": True,
@@ -106,6 +106,11 @@ def _create_glm5_toy_model(model_dir: Path) -> None:
     from transformers import GlmMoeDsaForCausalLM
 
     model = GlmMoeDsaForCausalLM(config)
+
+    # Shared indexer modules are serialized by HF but unused at runtime. MCore
+    # stores only the source indexer, so make the dead HF copies deterministic.
+    source_indexer = model.model.layers[2].self_attn.indexer
+    model.model.layers[3].self_attn.indexer.load_state_dict(source_indexer.state_dict())
 
     model = model.bfloat16()
     for k, v in model.named_buffers():
@@ -189,10 +194,11 @@ class TestGLM5Conversion:
 
         assert hasattr(model, "model")
         assert hasattr(model.model, "layers")
-        assert len(model.model.layers) == 2
+        assert len(model.model.layers) == 4
 
-        second_layer = model.model.layers[1]
-        assert hasattr(second_layer, "mlp")
+        fourth_layer = model.model.layers[3]
+        assert hasattr(fourth_layer, "mlp")
+        assert fourth_layer.self_attn.skip_topk is True
 
     @pytest.mark.run_only_on("GPU")
     @pytest.mark.parametrize(

--- a/tests/unit_tests/models/glm_moe_dsa/test_glm5_bridge.py
+++ b/tests/unit_tests/models/glm_moe_dsa/test_glm5_bridge.py
@@ -15,11 +15,23 @@
 """Unit tests for the GLM-5 MoE DSA bridge."""
 
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
+import torch
+from megatron.core.models.hybrid.hybrid_layer_allocation import Symbols
+from megatron.core.transformer.identity_op import IdentityOp
 
+from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge
 from megatron.bridge.models.conversion.param_mapping import AutoMapping, GatedMLPMapping, QKVMapping
-from megatron.bridge.models.glm_moe_dsa.glm5_bridge import GLM5Bridge
+from megatron.bridge.models.glm_moe_dsa.glm5_bridge import (
+    GLM5Bridge,
+    _GLM5IndexShareMapping,
+    _indexer_types_for_schedule,
+    glm5_hybrid_stack_spec,
+)
+from megatron.bridge.models.glm_moe_dsa.glm5_provider import GLM5ModelProvider
+from megatron.bridge.models.mla_provider import HybridMLAModelProvider
 
 
 pytestmark = pytest.mark.unit
@@ -29,36 +41,252 @@ pytestmark = pytest.mark.unit
 def glm5_bridge() -> GLM5Bridge:
     """Create a GLM-5 bridge with only the config fields read by mapping_registry."""
     bridge = GLM5Bridge()
-    bridge.hf_config = SimpleNamespace(num_hidden_layers=4, num_nextn_predict_layers=1)
+    bridge.hf_config = SimpleNamespace(
+        num_hidden_layers=4,
+        num_nextn_predict_layers=1,
+        mlp_layer_types=["dense", "sparse", "sparse", "sparse"],
+        indexer_types=["full", "full", "full", "shared"],
+        index_topk_freq=4,
+        index_skip_topk_offset=3,
+    )
     return bridge
+
+
+def _hf_config(
+    *,
+    num_hidden_layers: int = 4,
+    mlp_layer_types: list[str] | None = None,
+    indexer_types: list[str] | None = None,
+) -> SimpleNamespace:
+    if mlp_layer_types is None:
+        mlp_layer_types = ["dense", "sparse", "sparse", "sparse"][:num_hidden_layers]
+    if indexer_types is None:
+        indexer_types = ["full"] * num_hidden_layers
+    return SimpleNamespace(
+        num_hidden_layers=num_hidden_layers,
+        hidden_size=64,
+        intermediate_size=128,
+        moe_intermediate_size=32,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        head_dim=16,
+        q_lora_rank=16,
+        kv_lora_rank=8,
+        qk_nope_head_dim=12,
+        qk_rope_head_dim=4,
+        v_head_dim=16,
+        n_routed_experts=8,
+        n_shared_experts=1,
+        num_experts_per_tok=2,
+        n_group=1,
+        topk_group=1,
+        routed_scaling_factor=2.5,
+        max_position_embeddings=1024,
+        rms_norm_eps=1e-5,
+        initializer_range=0.02,
+        attention_dropout=0.0,
+        tie_word_embeddings=False,
+        attention_bias=False,
+        vocab_size=128,
+        hidden_act="silu",
+        torch_dtype=torch.bfloat16,
+        rope_parameters={"rope_theta": 1_000_000, "rope_type": "default"},
+        rope_scaling=None,
+        mlp_layer_types=mlp_layer_types,
+        index_head_dim=16,
+        index_n_heads=4,
+        index_topk=32,
+        indexer_types=indexer_types,
+        num_nextn_predict_layers=1,
+    )
+
+
+def _provider_from_config(hf_config: SimpleNamespace) -> GLM5ModelProvider:
+    bridge = GLM5Bridge()
+    return bridge.provider_bridge(SimpleNamespace(config=hf_config))
 
 
 def _mapping_by_megatron_param(bridge: GLM5Bridge) -> dict[str, object]:
     return {mapping.megatron_param: mapping for mapping in bridge.mapping_registry()}
 
 
+def test_glm5_uses_hybrid_mla_provider() -> None:
+    """The compatibility provider is the shared Hybrid MLA provider."""
+    assert GLM5Bridge.PROVIDER_CLASS is GLM5ModelProvider
+    assert GLM5ModelProvider is HybridMLAModelProvider
+
+    provider = _provider_from_config(_hf_config())
+    assert isinstance(provider, HybridMLAModelProvider)
+    assert provider.q_lora_rank == 16
+    assert provider.kv_lora_rank == 8
+
+
+def test_shared_config_conversion_detects_hybrid_mla_provider() -> None:
+    """Hybrid MLA providers use MLA's direct YaRN config field names."""
+    hf_config = _hf_config()
+    hf_config.rope_scaling = {
+        "rope_type": "yarn",
+        "factor": 2.0,
+        "mscale": 0.7,
+    }
+
+    provider_kwargs = GLM5Bridge().hf_config_to_provider_kwargs(hf_config)
+
+    assert provider_kwargs["_mla_rope_params"] == {
+        "rotary_scaling_factor": 2.0,
+        "mscale": 0.7,
+    }
+    assert "yarn_rotary_scaling_factor" not in provider_kwargs
+
+
+def test_glm5_stack_uses_native_norm_for_dsa_q_and_kv() -> None:
+    """GLM DSA uses the selected Hybrid stack's norm for both MLA latent paths."""
+    stack_spec = glm5_hybrid_stack_spec(GLM5ModelProvider())
+    dsa_submodules = stack_spec.submodules.dsa_layer.submodules
+    attention_submodules = dsa_submodules.self_attention.submodules
+
+    assert attention_submodules.q_layernorm is dsa_submodules.input_layernorm
+    assert attention_submodules.kv_layernorm is dsa_submodules.input_layernorm
+    assert attention_submodules.q_layernorm is not IdentityOp
+
+
+def test_glm5_provider_translates_logical_layers_to_hybrid_pattern() -> None:
+    """Dense and sparse logical blocks become D-/DE physical pairs."""
+    provider = _provider_from_config(_hf_config())
+
+    assert provider.hybrid_layer_pattern == "D-DEDEDE"
+    assert provider.num_layers == 8
+    assert provider.moe_layer_freq == [0, 0, 0, 1, 0, 1, 0, 1]
+    assert provider.mtp_num_layers is None
+    assert provider.sequence_parallel is True
+    assert provider.rotary_interleaved is False
+    assert provider.dsa_indexer_rope_interleaved is False
+    assert provider.apply_rope_fusion is False
+
+
+def test_glm5_provider_falls_back_to_first_k_dense_replace() -> None:
+    """Legacy GLM configs without mlp_layer_types retain their dense prefix."""
+    hf_config = _hf_config()
+    hf_config.mlp_layer_types = None
+    hf_config.first_k_dense_replace = 2
+
+    provider = _provider_from_config(hf_config)
+
+    assert provider.hybrid_layer_pattern == "D-D-DEDE"
+
+
+def test_glm52_provider_has_156_physical_layers() -> None:
+    """The official GLM-5.2 layout has 78 DSA, 3 dense, and 75 MoE layers."""
+    num_logical_layers = 78
+    hf_config = _hf_config(
+        num_hidden_layers=num_logical_layers,
+        mlp_layer_types=["dense"] * 3 + ["sparse"] * 75,
+        indexer_types=_indexer_types_for_schedule(
+            num_logical_layers,
+            topk_freq=4,
+            skip_topk_offset=3,
+        ),
+    )
+    hf_config.index_topk_freq = 4
+    hf_config.index_skip_topk_offset = 3
+
+    provider = _provider_from_config(hf_config)
+
+    assert provider.num_layers == 156
+    assert provider.hybrid_layer_pattern.count(Symbols.DS_ATTENTION) == 78
+    assert provider.hybrid_layer_pattern.count(Symbols.MLP) == 3
+    assert provider.hybrid_layer_pattern.count(Symbols.MOE) == 75
+    assert provider.dsa_indexer_topk_freq == 8
+    assert provider.dsa_indexer_skip_topk_offset == 5
+
+
+def test_glm5_provider_rejects_non_periodic_indexshare() -> None:
+    """Hybrid DSA cannot represent an arbitrary explicit IndexShare pattern."""
+    hf_config = _hf_config(indexer_types=["full", "shared", "full", "shared"])
+    hf_config.index_topk_freq = 4
+    hf_config.index_skip_topk_offset = 3
+
+    with pytest.raises(ValueError, match="does not match"):
+        _provider_from_config(hf_config)
+
+
+def test_glm5_export_restores_logical_layer_count() -> None:
+    """HF export counts DSA layers rather than physical Hybrid layers."""
+    provider = _provider_from_config(_hf_config())
+    provider.hybrid_layer_pattern = "D-DE|DEDE"
+
+    with patch.object(MegatronModelBridge, "megatron_to_hf_config", return_value={}):
+        hf_config = GLM5Bridge.megatron_to_hf_config(provider)
+
+    assert hf_config["num_hidden_layers"] == 4
+
+
+def test_mapping_registry_maps_logical_layers_to_physical_pairs(glm5_bridge: GLM5Bridge) -> None:
+    """Logical GLM layer indices map to their DSA and FFN physical layers."""
+    mappings = _mapping_by_megatron_param(glm5_bridge)
+
+    assert mappings["decoder.layers.0.input_layernorm.weight"].hf_param == ("model.layers.0.input_layernorm.weight")
+    assert mappings["decoder.layers.1.mlp.linear_fc2.weight"].hf_param == ("model.layers.0.mlp.down_proj.weight")
+    assert mappings["decoder.layers.6.self_attention.linear_proj.weight"].hf_param == (
+        "model.layers.3.self_attn.o_proj.weight"
+    )
+    assert mappings["decoder.layers.7.mlp.router.weight"].hf_param == "model.layers.3.mlp.gate.weight"
+    assert mappings["decoder.final_norm.weight"].hf_param == "model.norm.weight"
+
+
+def test_mapping_registry_exports_indexshare_weights_from_source_layer(glm5_bridge: GLM5Bridge) -> None:
+    """A live MCore indexer supplies both its full and shared HF modules."""
+    mappings = _mapping_by_megatron_param(glm5_bridge)
+
+    source_mapping = mappings["decoder.layers.4.self_attention.core_attention.indexer.linear_wq_b.weight"]
+    assert source_mapping.hf_param == "model.layers.2.self_attn.indexer.wq_b.weight"
+    assert source_mapping.shared_hf_params == ("model.layers.3.self_attn.indexer.wq_b.weight",)
+    assert "decoder.layers.6.self_attention.core_attention.indexer.linear_wq_b.weight" not in mappings
+
+
+def test_indexshare_export_copies_shared_hf_weights() -> None:
+    """Shared HF indexer weights have equal values without aliasing source storage."""
+    source_weight = torch.ones(2)
+    mapping = _GLM5IndexShareMapping(
+        megatron_param="decoder.indexer.weight",
+        hf_param="model.source.indexer.weight",
+        shared_hf_params=("model.shared.indexer.weight",),
+    )
+
+    with patch.object(
+        AutoMapping,
+        "megatron_to_hf",
+        return_value={"model.source.indexer.weight": source_weight},
+    ):
+        result = mapping.megatron_to_hf(None, None)
+
+    shared_weight = result["model.shared.indexer.weight"]
+    assert torch.equal(shared_weight, source_weight)
+    assert shared_weight.data_ptr() != source_weight.data_ptr()
+
+
 def test_mapping_registry_includes_grouped_and_local_expert_fc2_paths(glm5_bridge: GLM5Bridge) -> None:
     """GLM-5 MoE export supports both packed and local-expert down-projection names."""
     mappings = _mapping_by_megatron_param(glm5_bridge)
 
-    grouped_mapping = mappings["decoder.layers.*.mlp.experts.linear_fc2.weight*"]
+    grouped_mapping = mappings["decoder.layers.3.mlp.experts.linear_fc2.weight*"]
     assert isinstance(grouped_mapping, AutoMapping)
-    assert grouped_mapping.hf_param == "model.layers.*.mlp.experts.*.down_proj.weight"
+    assert grouped_mapping.hf_param == "model.layers.1.mlp.experts.*.down_proj.weight"
 
-    local_expert_mapping = mappings["decoder.layers.*.mlp.experts.local_experts.*.linear_fc2.weight"]
+    local_expert_mapping = mappings["decoder.layers.3.mlp.experts.local_experts.*.linear_fc2.weight"]
     assert isinstance(local_expert_mapping, AutoMapping)
-    assert local_expert_mapping.hf_param == "model.layers.*.mlp.experts.*.down_proj.weight"
+    assert local_expert_mapping.hf_param == "model.layers.1.mlp.experts.*.down_proj.weight"
 
     registry = glm5_bridge.mapping_registry()
-    grouped_lookup = registry.megatron_to_hf_lookup("decoder.layers.2.mlp.experts.linear_fc2.weight3")
+    grouped_lookup = registry.megatron_to_hf_lookup("decoder.layers.3.mlp.experts.linear_fc2.weight3")
     assert grouped_lookup is not None
-    assert grouped_lookup.hf_param == "model.layers.2.mlp.experts.3.down_proj.weight"
+    assert grouped_lookup.hf_param == "model.layers.1.mlp.experts.3.down_proj.weight"
 
     local_expert_lookup = registry.megatron_to_hf_lookup(
-        "decoder.layers.2.mlp.experts.local_experts.3.linear_fc2.weight"
+        "decoder.layers.3.mlp.experts.local_experts.3.linear_fc2.weight"
     )
     assert local_expert_lookup is not None
-    assert local_expert_lookup.hf_param == "model.layers.2.mlp.experts.3.down_proj.weight"
+    assert local_expert_lookup.hf_param == "model.layers.1.mlp.experts.3.down_proj.weight"
 
 
 @pytest.mark.parametrize("layer_prefix", ["transformer_layer", "mtp_model_layer"])
@@ -131,6 +359,24 @@ def test_mapping_registry_includes_mtp_standalone_weights(glm5_bridge: GLM5Bridg
 def test_mapping_registry_omits_mtp_mappings_without_nextn_layers() -> None:
     """No MTP mappings are registered when the HF config has no MTP layers."""
     bridge = GLM5Bridge()
-    bridge.hf_config = SimpleNamespace(num_hidden_layers=4, num_nextn_predict_layers=0)
+    bridge.hf_config = SimpleNamespace(
+        num_hidden_layers=4,
+        num_nextn_predict_layers=0,
+        mlp_layer_types=["dense", "sparse", "sparse", "sparse"],
+        indexer_types=["full"] * 4,
+    )
+
+    assert all(not mapping.megatron_param.startswith("mtp.") for mapping in bridge.mapping_registry())
+
+
+def test_mapping_registry_omits_mtp_mappings_when_nextn_layers_are_disabled() -> None:
+    """An exported config uses None to represent disabled runtime MTP."""
+    bridge = GLM5Bridge()
+    bridge.hf_config = SimpleNamespace(
+        num_hidden_layers=4,
+        num_nextn_predict_layers=None,
+        mlp_layer_types=["dense", "sparse", "sparse", "sparse"],
+        indexer_types=["full"] * 4,
+    )
 
     assert all(not mapping.megatron_param.startswith("mtp.") for mapping in bridge.mapping_registry())

--- a/tests/unit_tests/models/glm_moe_dsa/test_glm5_bridge.py
+++ b/tests/unit_tests/models/glm_moe_dsa/test_glm5_bridge.py
@@ -31,7 +31,7 @@ from megatron.bridge.models.glm_moe_dsa.glm5_bridge import (
     glm5_hybrid_stack_spec,
 )
 from megatron.bridge.models.glm_moe_dsa.glm5_provider import GLM5ModelProvider
-from megatron.bridge.models.mla_provider import HybridMLAModelProvider
+from megatron.bridge.models.hybrid_mla_provider import HybridMLAModelProvider
 
 
 pytestmark = pytest.mark.unit

--- a/tests/unit_tests/models/test_hybrid_mla_provider.py
+++ b/tests/unit_tests/models/test_hybrid_mla_provider.py
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Unit tests for shared MLA model providers."""
+"""Unit tests for the Hybrid MLA model provider."""
 
 from unittest.mock import patch
 
 import pytest
 
 from megatron.bridge.models.hybrid.hybrid_provider import HybridModelProvider
-from megatron.bridge.models.mla_provider import HybridMLAModelProvider
+from megatron.bridge.models.hybrid_mla_provider import HybridMLAModelProvider
 from megatron.bridge.models.transformer_config import MLATransformerConfig
 
 

--- a/tests/unit_tests/models/test_mla_provider.py
+++ b/tests/unit_tests/models/test_mla_provider.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for shared MLA model providers."""
+
+from unittest.mock import patch
+
+import pytest
+
+from megatron.bridge.models.hybrid.hybrid_provider import HybridModelProvider
+from megatron.bridge.models.mla_provider import HybridMLAModelProvider
+from megatron.bridge.models.transformer_config import MLATransformerConfig
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_hybrid_mla_provider_inherits_hybrid_and_mla_configs() -> None:
+    """Hybrid MLA exposes both the Hybrid provider and MLA config fields."""
+    assert issubclass(HybridMLAModelProvider, HybridModelProvider)
+    assert issubclass(HybridMLAModelProvider, MLATransformerConfig)
+
+    provider = HybridMLAModelProvider(q_lora_rank=16, kv_lora_rank=8)
+    assert provider.q_lora_rank == 16
+    assert provider.kv_lora_rank == 8
+
+
+def test_hybrid_mla_provider_adds_balanced_indexshare_safe_pipeline_segments() -> None:
+    """Pipeline boundaries keep logical pairs and IndexShare groups together."""
+    provider = HybridMLAModelProvider(
+        num_layers=8,
+        hybrid_layer_pattern="D-DEDEDE",
+        pipeline_model_parallel_size=2,
+        dsa_indexer_topk_freq=8,
+        dsa_indexer_skip_topk_offset=5,
+    )
+
+    with patch.object(HybridModelProvider, "finalize") as base_finalize:
+        provider.finalize()
+
+    assert provider.hybrid_layer_pattern == "D-DE|DEDE"
+    base_finalize.assert_called_once_with()
+
+
+def test_hybrid_mla_provider_rejects_cross_stage_indexshare() -> None:
+    """An explicit boundary cannot place a shared indexer on a new stage."""
+    provider = HybridMLAModelProvider(
+        num_layers=8,
+        hybrid_layer_pattern="D-DEDE|DE",
+        pipeline_model_parallel_size=2,
+        dsa_indexer_topk_freq=8,
+        dsa_indexer_skip_topk_offset=5,
+    )
+
+    with patch.object(HybridModelProvider, "finalize"), pytest.raises(
+        ValueError, match="cannot split DSA IndexShare groups"
+    ):
+        provider.finalize()
+
+
+def test_hybrid_mla_provider_rejects_split_logical_pair() -> None:
+    """An explicit boundary cannot separate a DSA layer from its FFN."""
+    provider = HybridMLAModelProvider(
+        num_layers=8,
+        hybrid_layer_pattern="D|-DEDEDE",
+        pipeline_model_parallel_size=2,
+        dsa_indexer_topk_freq=8,
+        dsa_indexer_skip_topk_offset=5,
+    )
+
+    with patch.object(HybridModelProvider, "finalize"), pytest.raises(ValueError, match="before DSA layers"):
+        provider.finalize()
+
+
+def test_hybrid_mla_provider_rejects_pipeline_layout_without_enough_full_indexers() -> None:
+    """Every pipeline stage after the first must begin with a full indexer."""
+    provider = HybridMLAModelProvider(
+        num_layers=8,
+        hybrid_layer_pattern="D-DEDEDE",
+        pipeline_model_parallel_size=4,
+        dsa_indexer_topk_freq=8,
+        dsa_indexer_skip_topk_offset=5,
+    )
+
+    with patch.object(HybridModelProvider, "finalize"), pytest.raises(ValueError, match="valid boundaries"):
+        provider.finalize()

--- a/tests/unit_tests/training/utils/test_flop_utils.py
+++ b/tests/unit_tests/training/utils/test_flop_utils.py
@@ -599,6 +599,72 @@ class TestHybridTransformerParity:
 
         assert hybrid_flops == pytest.approx(transformer_flops)
 
+    def test_mla_dsa_physical_pattern_matches_transformer(self):
+        """A DSA+MLP physical stack should match the equivalent MLA transformer."""
+        batch_size = 2
+        mla_config = self._base_config(
+            multi_latent_attention=True,
+            q_lora_rank=128,
+            kv_lora_rank=64,
+            qk_head_dim=48,
+            qk_pos_emb_head_dim=16,
+            v_head_dim=64,
+        )
+        transformer_cfg = MockConfigContainer(model=MockModelConfig(**mla_config))
+        hybrid_cfg = MockConfigContainer(
+            model=MockModelConfig(
+                **(
+                    mla_config
+                    | {
+                        "is_hybrid_model": True,
+                        "num_layers": 8,
+                        "hybrid_layer_pattern": "D-" * 4,
+                    }
+                )
+            )
+        )
+
+        transformer_flops = num_floating_point_operations(transformer_cfg, batch_size=batch_size)
+        hybrid_flops = num_floating_point_operations(hybrid_cfg, batch_size=batch_size)
+
+        assert hybrid_flops == pytest.approx(transformer_flops)
+
+    def test_mla_mixed_dsa_and_moe_physical_pattern_matches_transformer(self):
+        """GLM-style D-/DE physical layers should preserve the prior MLA+MoE estimate."""
+        batch_size = 2
+        mla_moe_config = self._base_config(
+            multi_latent_attention=True,
+            q_lora_rank=128,
+            kv_lora_rank=64,
+            qk_head_dim=48,
+            qk_pos_emb_head_dim=16,
+            v_head_dim=64,
+            num_moe_experts=8,
+            moe_layer_freq=[0, 1, 1, 1],
+            moe_router_topk=2,
+            moe_ffn_hidden_size=1024,
+            moe_shared_expert_intermediate_size=256,
+        )
+        transformer_cfg = MockConfigContainer(model=MockModelConfig(**mla_moe_config))
+        hybrid_cfg = MockConfigContainer(
+            model=MockModelConfig(
+                **(
+                    mla_moe_config
+                    | {
+                        "is_hybrid_model": True,
+                        "num_layers": 8,
+                        "hybrid_layer_pattern": "D-DEDEDE",
+                        "moe_layer_freq": [0, 0, 0, 1, 0, 1, 0, 1],
+                    }
+                )
+            )
+        )
+
+        transformer_flops = num_floating_point_operations(transformer_cfg, batch_size=batch_size)
+        hybrid_flops = num_floating_point_operations(hybrid_cfg, batch_size=batch_size)
+
+        assert hybrid_flops == pytest.approx(transformer_flops)
+
     def test_sliding_window_physical_pattern_matches_transformer(self):
         """Hybrid SWA counting should use physical layer positions in window_attn_skip_freq."""
         batch_size = 2


### PR DESCRIPTION
# What does this PR do ?

Migrating GLM-5 family from `GPTModel` to `HybridModel`.

This is part of the [effort](https://github.com/NVIDIA-NeMo/Megatron-Bridge/issues/4510) to deprecate all major open-source models to `HybridModel`.

## Testing
