### PR TITLE
fix(diffusion): use generic fast tokenizer for FLUX CLIP

### DIFF
--- a/src/megatron/bridge/diffusion/models/flux/flow_matching/flux_inference_pipeline.py
+++ b/src/megatron/bridge/diffusion/models/flux/flow_matching/flux_inference_pipeline.py
@@ -403,7 +403,7 @@ class FluxInferencePipeline(nn.Module):
             clip_version: HuggingFace model ID or path for CLIP.
         """
         try:
-            from transformers import CLIPTextModel, CLIPTokenizer, T5EncoderModel, T5Tokenizer
+            from transformers import CLIPTextModel, PreTrainedTokenizerFast, T5EncoderModel, T5Tokenizer
 
             # Load T5
             t5_version = t5_version or "google/t5-v1_1-xxl"
@@ -414,7 +414,8 @@ class FluxInferencePipeline(nn.Module):
             # Load CLIP
             clip_version = clip_version or "openai/clip-vit-large-patch14"
             print(f"Loading CLIP encoder from {clip_version}...")
-            self.clip_tokenizer = CLIPTokenizer.from_pretrained("openai/clip-vit-large-patch14")
+            # Avoid rebuilding CLIP's post-processor through a version-sensitive model wrapper.
+            self.clip_tokenizer = PreTrainedTokenizerFast.from_pretrained("openai/clip-vit-large-patch14")
             self.clip_encoder = CLIPTextModel.from_pretrained(clip_version).to(self.device).eval()
 
             print("Text encoders loaded successfully")

--- a/tests/unit_tests/diffusion/model/flux/test_flux_pipeline.py
+++ b/tests/unit_tests/diffusion/model/flux/test_flux_pipeline.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from unittest.mock import MagicMock
+
 import numpy as np
 import pytest
 import torch
@@ -413,6 +415,39 @@ class TestFluxInferencePipelineIntegration:
         assert hasattr(pipeline, "scheduler")
         assert isinstance(pipeline.scheduler, FlowMatchEulerDiscreteScheduler)
         assert pipeline.scheduler.num_train_timesteps == 500
+
+    def test_load_text_encoders_uses_generic_fast_clip_tokenizer(self, monkeypatch):
+        """Test that CLIP tokenizer loading avoids the incompatible model wrapper."""
+        import transformers
+
+        mock_t5_tokenizer = MagicMock()
+        mock_fast_tokenizer = MagicMock()
+        mock_t5_encoder = MagicMock()
+        mock_clip_encoder = MagicMock()
+
+        monkeypatch.setattr(transformers.T5Tokenizer, "from_pretrained", MagicMock(return_value=mock_t5_tokenizer))
+        monkeypatch.setattr(transformers.T5EncoderModel, "from_pretrained", MagicMock(return_value=mock_t5_encoder))
+        monkeypatch.setattr(transformers.CLIPTextModel, "from_pretrained", MagicMock(return_value=mock_clip_encoder))
+        monkeypatch.setattr(
+            transformers.CLIPTokenizer,
+            "from_pretrained",
+            MagicMock(side_effect=TypeError("RobertaProcessing received an incompatible cls argument")),
+        )
+        monkeypatch.setattr(
+            transformers.PreTrainedTokenizerFast,
+            "from_pretrained",
+            MagicMock(return_value=mock_fast_tokenizer),
+        )
+
+        pipeline = FluxInferencePipeline.__new__(FluxInferencePipeline)
+        torch.nn.Module.__init__(pipeline)
+        pipeline.device = "cpu"
+
+        pipeline.load_text_encoders("t5-model", "clip-model")
+
+        transformers.PreTrainedTokenizerFast.from_pretrained.assert_called_once_with("openai/clip-vit-large-patch14")
+        transformers.CLIPTokenizer.from_pretrained.assert_not_called()
+        assert pipeline.clip_tokenizer is mock_fast_tokenizer
 
     def test_pack_unpack_latents_roundtrip(self):
         """Test that pack and unpack latents are inverse operations."""


### PR DESCRIPTION
# What does this PR do?

Fixes NVBug 6317367.

FLUX inference selected the model-specific CLIP tokenizer wrapper, which reconstructs the tokenizer post-processor with an argument unsupported by the resolved tokenizer backend. This changes only the tokenizer loader to use the serialized generic fast-tokenizer backend while preserving the existing canonical tokenizer source.

# Changelog

- Load the FLUX CLIP tokenizer through `PreTrainedTokenizerFast`.
- Preserve the canonical `openai/clip-vit-large-patch14` tokenizer source for custom or weights-only encoder checkpoints.
- Add a regression test that rejects the incompatible wrapper path.

# Validation

- Before: the release-validation reproducer raised `TypeError: RobertaProcessing.__new__() got an unexpected keyword argument 'cls'`.
- After: the same reproducer completed tokenizer loading and produced the expected CLIP token IDs.
- `uv run python -m pytest tests/unit_tests/diffusion/model/flux/test_flux_pipeline.py -q` — 34 passed.
- `uv run pre-commit run --all-files` — passed.
- `git diff --check` — passed.

Remote GitHub Actions CI is pending.

# AI assistance

This change was developed with Codex and independently reviewed in a separate Codex context. Reproduction and verification evidence was checked against the final signed commit.

# Before your PR is "Ready for review"

- [x] Read and followed the contributor guidelines.
- [x] Added the necessary regression test.
- [x] Documentation changes are not needed for this compatibility fix.
- [x] No optional dependency or import-guard behavior is changed.
