### PR TITLE
[peft] fix: support TE 2.17 grouped expert LoRA

### DIFF
--- a/src/megatron/bridge/peft/utils.py
+++ b/src/megatron/bridge/peft/utils.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
 import logging
 import math
 import re
 from dataclasses import dataclass, fields
+from functools import cache
 from importlib import import_module
 from importlib.metadata import version
 from pathlib import Path
@@ -84,6 +86,15 @@ HAVE_TE = all(
         HAVE_TE_ROW_GRP_LINEAR,
     )
 )
+
+
+@cache
+def _te_grouped_linear_uses_explicit_m_splits(
+    autograd_function: type[torch.autograd.Function],
+) -> bool:
+    """Return whether TE passes grouped-linear splits outside ``non_tensor_args``."""
+
+    return "m_splits" in inspect.signature(autograd_function.forward).parameters
 
 
 def _get_pg_collection_from_module(module: object | None) -> ProcessGroupCollection | None:
@@ -1983,8 +1994,7 @@ class GroupedExpertLinearAdapter(nn.Module):
                 grad_weight_quantizers,
                 grad_output_quantizers,
             ) = helper._get_quantizers()
-            non_tensor_args = (
-                m_splits,
+            common_non_tensor_args = (
                 helper.apply_bias,
                 None,
                 helper.fp8,
@@ -2001,26 +2011,27 @@ class GroupedExpertLinearAdapter(nn.Module):
                 helper.sequence_parallel,
                 helper.activation_dtype,
                 torch.is_grad_enabled(),
-                helper,
+                [None] * weight.shape[0],
+                False,
                 None,
                 helper.save_original_input,
                 False,
             )
             empty_biases = [x.new_empty(0) for _ in range(weight.shape[0])]
+            weights_and_biases = (*[weight[i] for i in range(weight.shape[0])], *empty_biases)
+            if _te_grouped_linear_uses_explicit_m_splits(TEPytorchGroupedLinearAutograd):
+                te_m_splits = torch.tensor(m_splits, dtype=torch.int64, device="cpu")
+                autograd_args = (x, te_m_splits, common_non_tensor_args, *weights_and_biases)
+            else:
+                non_tensor_args = (m_splits, *common_non_tensor_args)
+                autograd_args = (x, non_tensor_args, *weights_and_biases)
+
+            output: torch.Tensor
             if torch.is_grad_enabled():
-                return TEPytorchGroupedLinearAutograd.apply(
-                    x,
-                    non_tensor_args,
-                    *[weight[i] for i in range(weight.shape[0])],
-                    *empty_biases,
-                )
-            return TEPytorchGroupedLinearAutograd.forward(
-                None,
-                x,
-                non_tensor_args,
-                *[weight[i] for i in range(weight.shape[0])],
-                *empty_biases,
-            )
+                output, _ = TEPytorchGroupedLinearAutograd.apply(*autograd_args)
+            else:
+                output, _ = TEPytorchGroupedLinearAutograd.forward(None, *autograd_args)
+            return output
         finally:
             helper.end_forward()
 

--- a/src/megatron/bridge/peft/utils.py
+++ b/src/megatron/bridge/peft/utils.py
@@ -89,12 +89,14 @@ HAVE_TE = all(
 
 
 @cache
-def _te_grouped_linear_uses_explicit_m_splits(
+def _te_grouped_linear_api_features(
     autograd_function: type[torch.autograd.Function],
-) -> bool:
-    """Return whether TE passes grouped-linear splits outside ``non_tensor_args``."""
+) -> tuple[bool, bool]:
+    """Detect TE's private grouped-linear call contract from its signatures."""
 
-    return "m_splits" in inspect.signature(autograd_function.forward).parameters
+    uses_explicit_m_splits = "m_splits" in inspect.signature(autograd_function.forward).parameters
+    returns_workspaces = "_grad_workspaces" in inspect.signature(autograd_function.backward).parameters
+    return uses_explicit_m_splits, returns_workspaces
 
 
 def _get_pg_collection_from_module(module: object | None) -> ProcessGroupCollection | None:
@@ -2011,15 +2013,26 @@ class GroupedExpertLinearAdapter(nn.Module):
                 helper.sequence_parallel,
                 helper.activation_dtype,
                 torch.is_grad_enabled(),
-                [None] * weight.shape[0],
-                False,
-                None,
-                helper.save_original_input,
-                False,
             )
+            uses_explicit_m_splits, returns_workspaces = _te_grouped_linear_api_features(
+                TEPytorchGroupedLinearAutograd
+            )
+            # TE 2.15 replaced the module argument with workspace/cache fields and
+            # added the workspace list to the autograd function's output.
+            if returns_workspaces:
+                common_non_tensor_args += (
+                    [None] * weight.shape[0],
+                    False,
+                    None,
+                    helper.save_original_input,
+                    False,
+                )
+            else:
+                common_non_tensor_args += (helper, None, helper.save_original_input, False)
+
             empty_biases = [x.new_empty(0) for _ in range(weight.shape[0])]
             weights_and_biases = (*[weight[i] for i in range(weight.shape[0])], *empty_biases)
-            if _te_grouped_linear_uses_explicit_m_splits(TEPytorchGroupedLinearAutograd):
+            if uses_explicit_m_splits:
                 te_m_splits = torch.tensor(m_splits, dtype=torch.int64, device="cpu")
                 autograd_args = (x, te_m_splits, common_non_tensor_args, *weights_and_biases)
             else:
@@ -2028,10 +2041,13 @@ class GroupedExpertLinearAdapter(nn.Module):
 
             output: torch.Tensor
             if torch.is_grad_enabled():
-                output, _ = TEPytorchGroupedLinearAutograd.apply(*autograd_args)
+                autograd_output = TEPytorchGroupedLinearAutograd.apply(*autograd_args)
             else:
-                output, _ = TEPytorchGroupedLinearAutograd.forward(None, *autograd_args)
-            return output
+                autograd_output = TEPytorchGroupedLinearAutograd.forward(None, *autograd_args)
+            if returns_workspaces:
+                output, _ = autograd_output
+                return output
+            return autograd_output
         finally:
             helper.end_forward()
 

--- a/tests/unit_tests/peft/test_utils.py
+++ b/tests/unit_tests/peft/test_utils.py
@@ -1648,6 +1648,100 @@ class TestGroupedExpertLinearAdapter:
         assert mock_te_backend.call_args_list[0].kwargs["m_splits"] == [1, 2]
         assert mock_te_backend.call_args_list[1].kwargs["m_splits"] == [1, 2]
 
+    @pytest.mark.parametrize("te_version", ["2.16", "2.17"])
+    @pytest.mark.parametrize("grad_enabled", [False, True])
+    def test_grouped_expert_linear_adapter_matches_te_autograd_call_contract(self, te_version, grad_enabled):
+        """The private TE grouped-linear call should match both supported signatures."""
+        calls = []
+
+        class TE216GroupedLinearAutograd:
+            @staticmethod
+            def apply(inp, non_tensor_args, *weights_and_biases):
+                calls.append(("apply", inp, None, non_tensor_args, weights_and_biases))
+                return inp + 1, [None, None]
+
+            @staticmethod
+            def forward(ctx, inp, non_tensor_args, *weights_and_biases):
+                calls.append(("forward", inp, None, non_tensor_args, weights_and_biases))
+                return inp + 1, [None, None]
+
+        class TE217GroupedLinearAutograd:
+            @staticmethod
+            def apply(inp, m_splits, non_tensor_args, *weights_and_biases):
+                calls.append(("apply", inp, m_splits, non_tensor_args, weights_and_biases))
+                return inp + 1, [None, None]
+
+            @staticmethod
+            def forward(ctx, inp, m_splits, non_tensor_args, *weights_and_biases):
+                calls.append(("forward", inp, m_splits, non_tensor_args, weights_and_biases))
+                return inp + 1, [None, None]
+
+        autograd_cls = TE216GroupedLinearAutograd if te_version == "2.16" else TE217GroupedLinearAutograd
+        x = torch.arange(6, dtype=torch.float32).reshape(3, 2)
+        weight = torch.arange(8, dtype=torch.float32).reshape(2, 2, 2)
+        quantizers = tuple([None, None] for _ in range(6))
+        helper = SimpleNamespace(
+            activation_dtype=x.dtype,
+            apply_bias=False,
+            fp8=False,
+            fp8_calibration=False,
+            fuse_wgrad_accumulation=False,
+            save_original_input=False,
+            sequence_parallel=False,
+            wgrad_store=object(),
+            prepare_forward=Mock(return_value=x),
+            _get_quantizers=Mock(return_value=quantizers),
+            end_forward=Mock(),
+        )
+        adapter = GroupedExpertLinearAdapter(
+            in_features=2,
+            out_features=2,
+            dim=2,
+            num_local_experts=2,
+            base_linear_name="decoder.layers.0.mlp.experts.linear_fc2",
+            activation="identity",
+            input_is_parallel=False,
+            model_parallel_config=MockModelParallelConfig(),
+        )
+
+        with (
+            patch.object(adapter, "_get_te_grouped_linear_helper", return_value=helper),
+            patch("megatron.bridge.peft.utils.TEPytorchGroupedLinearAutograd", autograd_cls),
+            torch.set_grad_enabled(grad_enabled),
+        ):
+            output = adapter._forward_te_grouped_linear(x, weight=weight, m_splits=[1, 2])
+
+        torch.testing.assert_close(output, x + 1)
+        helper.prepare_forward.assert_called_once_with(x, num_gemms=2)
+        helper.end_forward.assert_called_once_with()
+        assert len(calls) == 1
+        call_kind, actual_input, explicit_m_splits, non_tensor_args, weights_and_biases = calls[0]
+        assert call_kind == ("apply" if grad_enabled else "forward")
+        assert actual_input is x
+
+        if te_version == "2.16":
+            assert explicit_m_splits is None
+            assert non_tensor_args[0] == [1, 2]
+            common_non_tensor_args = non_tensor_args[1:]
+        else:
+            assert explicit_m_splits.dtype == torch.int64
+            assert explicit_m_splits.device.type == "cpu"
+            assert explicit_m_splits.tolist() == [1, 2]
+            common_non_tensor_args = non_tensor_args
+
+        assert len(common_non_tensor_args) == 21
+        assert common_non_tensor_args[15] is grad_enabled
+        assert common_non_tensor_args[16] == [None, None]
+        assert common_non_tensor_args[17] is False
+        assert common_non_tensor_args[18] is None
+        assert common_non_tensor_args[19] is False
+        assert common_non_tensor_args[20] is False
+        assert len(weights_and_biases) == 4
+        torch.testing.assert_close(weights_and_biases[0], weight[0])
+        torch.testing.assert_close(weights_and_biases[1], weight[1])
+        assert weights_and_biases[2].numel() == 0
+        assert weights_and_biases[3].numel() == 0
+
     def test_grouped_expert_linear_adapter_requires_expert_tp_group_for_gather(self):
         """Per-expert LoRA should fail clearly when expert TP is configured without initialized groups."""
         config = MockModelParallelConfig()

--- a/tests/unit_tests/peft/test_utils.py
+++ b/tests/unit_tests/peft/test_utils.py
@@ -1648,51 +1648,10 @@ class TestGroupedExpertLinearAdapter:
         assert mock_te_backend.call_args_list[0].kwargs["m_splits"] == [1, 2]
         assert mock_te_backend.call_args_list[1].kwargs["m_splits"] == [1, 2]
 
-    @pytest.mark.parametrize("te_version", ["2.16", "2.17"])
-    @pytest.mark.parametrize("grad_enabled", [False, True])
-    def test_grouped_expert_linear_adapter_matches_te_autograd_call_contract(self, te_version, grad_enabled):
-        """The private TE grouped-linear call should match both supported signatures."""
-        calls = []
-
-        class TE216GroupedLinearAutograd:
-            @staticmethod
-            def apply(inp, non_tensor_args, *weights_and_biases):
-                calls.append(("apply", inp, None, non_tensor_args, weights_and_biases))
-                return inp + 1, [None, None]
-
-            @staticmethod
-            def forward(ctx, inp, non_tensor_args, *weights_and_biases):
-                calls.append(("forward", inp, None, non_tensor_args, weights_and_biases))
-                return inp + 1, [None, None]
-
-        class TE217GroupedLinearAutograd:
-            @staticmethod
-            def apply(inp, m_splits, non_tensor_args, *weights_and_biases):
-                calls.append(("apply", inp, m_splits, non_tensor_args, weights_and_biases))
-                return inp + 1, [None, None]
-
-            @staticmethod
-            def forward(ctx, inp, m_splits, non_tensor_args, *weights_and_biases):
-                calls.append(("forward", inp, m_splits, non_tensor_args, weights_and_biases))
-                return inp + 1, [None, None]
-
-        autograd_cls = TE216GroupedLinearAutograd if te_version == "2.16" else TE217GroupedLinearAutograd
-        x = torch.arange(6, dtype=torch.float32).reshape(3, 2)
-        weight = torch.arange(8, dtype=torch.float32).reshape(2, 2, 2)
-        quantizers = tuple([None, None] for _ in range(6))
-        helper = SimpleNamespace(
-            activation_dtype=x.dtype,
-            apply_bias=False,
-            fp8=False,
-            fp8_calibration=False,
-            fuse_wgrad_accumulation=False,
-            save_original_input=False,
-            sequence_parallel=False,
-            wgrad_store=object(),
-            prepare_forward=Mock(return_value=x),
-            _get_quantizers=Mock(return_value=quantizers),
-            end_forward=Mock(),
-        )
+    @pytest.mark.run_only_on("GPU")
+    def test_grouped_expert_linear_adapter_runs_te_grouped_linear(self):
+        """Per-expert LoRA should train and infer through a real TE grouped-linear helper."""
+        device = torch.device("cuda")
         adapter = GroupedExpertLinearAdapter(
             in_features=2,
             out_features=2,
@@ -1702,45 +1661,31 @@ class TestGroupedExpertLinearAdapter:
             activation="identity",
             input_is_parallel=False,
             model_parallel_config=MockModelParallelConfig(),
+            params_device=device,
+            params_dtype=torch.bfloat16,
         )
 
-        with (
-            patch.object(adapter, "_get_te_grouped_linear_helper", return_value=helper),
-            patch("megatron.bridge.peft.utils.TEPytorchGroupedLinearAutograd", autograd_cls),
-            torch.set_grad_enabled(grad_enabled),
-        ):
-            output = adapter._forward_te_grouped_linear(x, weight=weight, m_splits=[1, 2])
+        with torch.no_grad():
+            adapter.linear_in.weight[0].copy_(torch.eye(2, device=device, dtype=torch.bfloat16))
+            adapter.linear_out.weight[0].copy_(torch.eye(2, device=device, dtype=torch.bfloat16))
+            adapter.linear_in.weight[1].copy_(2 * torch.eye(2, device=device, dtype=torch.bfloat16))
+            adapter.linear_out.weight[1].copy_(torch.eye(2, device=device, dtype=torch.bfloat16))
 
-        torch.testing.assert_close(output, x + 1)
-        helper.prepare_forward.assert_called_once_with(x, num_gemms=2)
-        helper.end_forward.assert_called_once_with()
-        assert len(calls) == 1
-        call_kind, actual_input, explicit_m_splits, non_tensor_args, weights_and_biases = calls[0]
-        assert call_kind == ("apply" if grad_enabled else "forward")
-        assert actual_input is x
+        x = torch.tensor([[1, 2], [3, 4], [5, 6]], device=device, dtype=torch.bfloat16, requires_grad=True)
+        expected = torch.tensor([[1, 2], [6, 8], [10, 12]], device=device, dtype=torch.bfloat16)
 
-        if te_version == "2.16":
-            assert explicit_m_splits is None
-            assert non_tensor_args[0] == [1, 2]
-            common_non_tensor_args = non_tensor_args[1:]
-        else:
-            assert explicit_m_splits.dtype == torch.int64
-            assert explicit_m_splits.device.type == "cpu"
-            assert explicit_m_splits.tolist() == [1, 2]
-            common_non_tensor_args = non_tensor_args
+        output = adapter(x, [1, 2])
 
-        assert len(common_non_tensor_args) == 21
-        assert common_non_tensor_args[15] is grad_enabled
-        assert common_non_tensor_args[16] == [None, None]
-        assert common_non_tensor_args[17] is False
-        assert common_non_tensor_args[18] is None
-        assert common_non_tensor_args[19] is False
-        assert common_non_tensor_args[20] is False
-        assert len(weights_and_biases) == 4
-        torch.testing.assert_close(weights_and_biases[0], weight[0])
-        torch.testing.assert_close(weights_and_biases[1], weight[1])
-        assert weights_and_biases[2].numel() == 0
-        assert weights_and_biases[3].numel() == 0
+        torch.testing.assert_close(output, expected)
+        assert adapter._te_grouped_linear_helpers
+        output.float().sum().backward()
+        assert x.grad is not None
+        assert adapter.linear_in.weight.grad is not None
+        assert adapter.linear_out.weight.grad is not None
+
+        with torch.no_grad():
+            inference_output = adapter(x.detach(), [1, 2])
+        torch.testing.assert_close(inference_output, expected)
 
     def test_grouped_expert_linear_adapter_requires_expert_tp_group_for_gather(self):
         """Per-expert LoRA should fail clearly when expert TP is configured without initialized groups."""

--- a/tests/unit_tests/peft/test_utils.py
+++ b/tests/unit_tests/peft/test_utils.py
@@ -1649,8 +1649,8 @@ class TestGroupedExpertLinearAdapter:
         assert mock_te_backend.call_args_list[1].kwargs["m_splits"] == [1, 2]
 
     @pytest.mark.run_only_on("GPU")
-    def test_grouped_expert_linear_adapter_runs_te_grouped_linear(self):
-        """Per-expert LoRA should train and infer through a real TE grouped-linear helper."""
+    def test_grouped_expert_linear_adapter_training_and_inference(self):
+        """Per-expert LoRA should produce correct outputs and gradients."""
         device = torch.device("cuda")
         adapter = GroupedExpertLinearAdapter(
             in_features=2,
@@ -1677,7 +1677,6 @@ class TestGroupedExpertLinearAdapter:
         output = adapter(x, [1, 2])
 
         torch.testing.assert_close(output, expected)
-        assert adapter._te_grouped_linear_helpers
         output.float().sum().backward()
         assert x.grad is not None
         assert adapter.linear_in.weight.grad is not None


### PR DESCRIPTION
## What

- Make `GroupedExpertLinearAdapter` compatible with the Transformer Engine 2.14 through 2.17 private `_GroupedLinear` call layouts.
- Detect explicit split arguments and workspace outputs independently, then pass the matching non-tensor tuple and return only the output tensor.
- Add a behavioral CUDA regression that exercises normal adapter training, gradients, and no-grad inference while creating the real TE grouped-linear helper as a byproduct.

## Why

Transformer Engine 2.17 moved `m_splits` out of `non_tensor_args` into a dedicated `_GroupedLinear.forward` parameter. Megatron-Bridge called that private function using the older layout, which shifted every subsequent argument. The same unexercised path also omitted a TE 2.15/2.16 tuple field and propagated `(output, workspaces)` instead of the output tensor.

An independent review also caught that TE 2.14 uses a helper-module field and returns a bare tensor. The feature detection preserves that legacy contract while handling the workspace-based TE 2.15/2.16 contract and explicit-splits TE 2.17 contract.

This was discovered while validating the TE bump in #4696, but the fix is independent and can land before that bump.

## Validation

- `uv run python -m pytest tests/unit_tests/peft/test_utils.py` — 71 passed
- Real TE 2.16 CUDA grouped-linear adapter forward, backward, and no-grad inference — passed
- Exact TE 2.14 and 2.17 source contracts — inspected
- `uv run pre-commit run --all-files` — passed

The test runs against the TE version installed in CI rather than duplicating private signatures in test code, so it will naturally cover TE 2.17 when the dependency bump is applied.
