### PR TITLE
fix(recipe): enable VR in perf configs

### DIFF
--- a/scripts/performance/configs/gpt_oss/gpt_oss_llm_pretrain.py
+++ b/scripts/performance/configs/gpt_oss/gpt_oss_llm_pretrain.py
@@ -483,6 +483,12 @@ def gpt_oss_120b_pretrain_config_vr200(
     set_gpt_oss_common_configs(cfg)
     set_workload_base_configs(cfg, base_cfg)
 
+    if is_full_iteration_cuda_graph(cfg.model):
+        set_full_iter_cg_configs(cfg)
+
+    if cfg.mixed_precision.fp8_recipe == "mxfp8":
+        cfg.model.fp8_output_proj = True
+
     return cfg
 
 

--- a/scripts/performance/configs/qwen/qwen3_llm_pretrain.py
+++ b/scripts/performance/configs/qwen/qwen3_llm_pretrain.py
@@ -133,6 +133,8 @@ def qwen3_235b_a22b_pretrain_config_vr200(
 
     set_qwen3_common_configs(cfg)
     set_workload_base_configs(cfg, base_cfg)
+    if precision == "fp8_mx" and is_full_iteration_cuda_graph(cfg.model):
+        set_full_iter_cg_configs(cfg)
 
     return cfg
 
@@ -295,6 +297,8 @@ def qwen3_30b_a3b_pretrain_config_vr200(
 
     set_qwen3_common_configs(cfg)
     set_workload_base_configs(cfg, base_cfg)
+    if precision == "fp8_mx" and is_full_iteration_cuda_graph(cfg.model):
+        set_full_iter_cg_configs(cfg)
 
     return cfg
 

--- a/scripts/performance/perf_plugins.py
+++ b/scripts/performance/perf_plugins.py
@@ -325,7 +325,7 @@ class PerfEnvPlugin(Plugin):
                     # executor.env_vars["NCCL_NVLS_ENABLE"] = "1" # This causes OOM; worked fine with NeMo2 and 25.09
                     executor.env_vars["NCCL_CTA_POLICY"] = "1"
                     del_cudnn_ln = False
-        if gpu in ["gb200", "gb300"]:
+        if gpu in ["gb200", "gb300", "vr200"]:
             if model_family_name == "llama" and model_recipe_name == "llama3_70b" and train_task == "pretrain":
                 if compute_dtype == "bf16" or (compute_dtype == "fp8_cs"):
                     del_cudnn_ln = False
@@ -379,7 +379,7 @@ class PerfEnvPlugin(Plugin):
                 executor.env_vars["USE_MNNVL"] = "0"
                 executor.env_vars["NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN"] = "8" if ep_size > 8 else str(ep_size)
             else:
-                # GB200/GB300 use NVL72 topology
+                # GB200/GB300/VR200 use NVL72 topology
                 assert ep_size <= 72, "ep_size must be less than or equal to 72"
                 executor.env_vars["NVLINK_DOMAIN_SIZE"] = "72"
                 executor.env_vars["USE_MNNVL"] = "1"
@@ -527,7 +527,7 @@ class PerfEnvPlugin(Plugin):
             cp_size,
             moe_a2a_overlap=moe_a2a_overlap,
             moe_flex_dispatcher_backend=moe_flex_dispatcher_backend,
-            gpu_sm100_or_newer=self.gpu in ["b300", "b200", "gb200", "gb300"],
+            gpu_sm100_or_newer=self.gpu in ["b300", "b200", "gb200", "gb300", "vr200"],
         )
 
         # Set LayerNorm SM margin to support the overlap with LayerNorm kernel

--- a/scripts/performance/utils/executors.py
+++ b/scripts/performance/utils/executors.py
@@ -138,7 +138,7 @@ def slurm_executor(
     log_repo_status_cmd = "bash /opt/Megatron-Bridge/docker/common/print_sha.sh /nemo_run/configs/repo_status.json"
     custom_bash_cmds.append(log_repo_status_cmd)
 
-    numa_divisor = 2 if gpu.lower() in ["gb200", "gb300"] else 4
+    numa_divisor = 2 if gpu.lower() in ["gb200", "gb300", "vr200"] else 4
     numa_cmd = f"numactl --cpunodebind=$((SLURM_LOCALID/{numa_divisor})) --membind=$((SLURM_LOCALID/{numa_divisor}))"
     if gpu.lower() in ["b300"] and enable_pct_binding:
         numa_cmd += " -C $((SLURM_LOCALID * 16)),$((SLURM_LOCALID * 16 + 1))"


### PR DESCRIPTION
# What does this PR do ?

- Fixes few of the configs/settings for VR

# Changelog

- gpt_oss 120B / qwen3 235B & 30B: apply full-iteration CUDA-graph configs on VR200 (and mxfp8 fp8_output_proj for gpt_oss 120B)
- perf_plugins/executors: add vr200 to the GB200/GB300 platform lists (NVL72 topology, cuDNN LayerNorm, sm_100+ overlap, NUMA divisor)

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [x] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information