### PR TITLE
docs(recipe): fix DeepSeek V2 pretraining examples

### DIFF
--- a/docs/fern/versions/nightly/pages/models/deepseek/deepseek-v2.mdx
+++ b/docs/fern/versions/nightly/pages/models/deepseek/deepseek-v2.mdx
@@ -108,15 +108,16 @@ See: [bridge.recipes.deepseek.deepseek_v2](../../apidocs/bridge/bridge.recipes.d
 ```python
 from megatron.bridge.recipes.deepseek import deepseek_v2_lite_pretrain_config
 
-config = deepseek_v2_lite_pretrain_config(
-    name="deepseek_v2_lite_pretrain",
-    data_paths=["/path/to/dataset.nvjsonl"],
-    dir="/results/deepseek_v2_lite",
-    train_iters=500_000,
-    global_batch_size=512,
-    seq_length=4096,
-    # Uses TP=1, PP=1, EP=8 (8 GPUs) automatically
-)
+config = deepseek_v2_lite_pretrain_config()
+config.dataset.blend = [["/path/to/dataset_text_document"], None]
+config.checkpoint.save = "/results/deepseek_v2_lite/checkpoints"
+config.checkpoint.load = "/results/deepseek_v2_lite/checkpoints"
+config.logger.tensorboard_dir = "/results/deepseek_v2_lite/tb_logs"
+config.train.train_iters = 500_000
+config.train.global_batch_size = 512
+config.model.seq_length = 4096
+config.dataset.seq_length = 4096
+# Uses TP=1, PP=1, EP=8 (8 GPUs) automatically
 ```
 
 #### DeepSeek-V2 (236B)
@@ -124,15 +125,16 @@ config = deepseek_v2_lite_pretrain_config(
 ```python
 from megatron.bridge.recipes.deepseek import deepseek_v2_pretrain_config
 
-config = deepseek_v2_pretrain_config(
-    name="deepseek_v2_pretrain",
-    data_paths=["/path/to/dataset.nvjsonl"],
-    dir="/results/deepseek_v2",
-    train_iters=500_000,
-    global_batch_size=512,
-    seq_length=4096,
-    # Uses TP=1, PP=4, EP=32 (128 GPUs) automatically
-)
+config = deepseek_v2_pretrain_config()
+config.dataset.blend = [["/path/to/dataset_text_document"], None]
+config.checkpoint.save = "/results/deepseek_v2/checkpoints"
+config.checkpoint.load = "/results/deepseek_v2/checkpoints"
+config.logger.tensorboard_dir = "/results/deepseek_v2/tb_logs"
+config.train.train_iters = 500_000
+config.train.global_batch_size = 512
+config.model.seq_length = 4096
+config.dataset.seq_length = 4096
+# Uses TP=1, PP=4, EP=32 (128 GPUs) automatically
 ```
 
 ### Finetuning Recipes

--- a/docs/models/deepseek/deepseek-v2.md
+++ b/docs/models/deepseek/deepseek-v2.md
@@ -108,15 +108,16 @@ See: [bridge.recipes.deepseek.deepseek_v2](../../apidocs/bridge/bridge.recipes.d
 ```python
 from megatron.bridge.recipes.deepseek import deepseek_v2_lite_pretrain_config
 
-config = deepseek_v2_lite_pretrain_config(
-    name="deepseek_v2_lite_pretrain",
-    data_paths=["/path/to/dataset.nvjsonl"],
-    dir="/results/deepseek_v2_lite",
-    train_iters=500_000,
-    global_batch_size=512,
-    seq_length=4096,
-    # Uses TP=1, PP=1, EP=8 (8 GPUs) automatically
-)
+config = deepseek_v2_lite_pretrain_config()
+config.dataset.blend = [["/path/to/dataset_text_document"], None]
+config.checkpoint.save = "/results/deepseek_v2_lite/checkpoints"
+config.checkpoint.load = "/results/deepseek_v2_lite/checkpoints"
+config.logger.tensorboard_dir = "/results/deepseek_v2_lite/tb_logs"
+config.train.train_iters = 500_000
+config.train.global_batch_size = 512
+config.model.seq_length = 4096
+config.dataset.seq_length = 4096
+# Uses TP=1, PP=1, EP=8 (8 GPUs) automatically
 ```
 
 #### DeepSeek-V2 (236B)
@@ -124,15 +125,16 @@ config = deepseek_v2_lite_pretrain_config(
 ```python
 from megatron.bridge.recipes.deepseek import deepseek_v2_pretrain_config
 
-config = deepseek_v2_pretrain_config(
-    name="deepseek_v2_pretrain",
-    data_paths=["/path/to/dataset.nvjsonl"],
-    dir="/results/deepseek_v2",
-    train_iters=500_000,
-    global_batch_size=512,
-    seq_length=4096,
-    # Uses TP=1, PP=4, EP=32 (128 GPUs) automatically
-)
+config = deepseek_v2_pretrain_config()
+config.dataset.blend = [["/path/to/dataset_text_document"], None]
+config.checkpoint.save = "/results/deepseek_v2/checkpoints"
+config.checkpoint.load = "/results/deepseek_v2/checkpoints"
+config.logger.tensorboard_dir = "/results/deepseek_v2/tb_logs"
+config.train.train_iters = 500_000
+config.train.global_batch_size = 512
+config.model.seq_length = 4096
+config.dataset.seq_length = 4096
+# Uses TP=1, PP=4, EP=32 (128 GPUs) automatically
 ```
 
 ### Finetuning Recipes
@@ -158,4 +160,3 @@ Finetuning recipes for DeepSeek V2 models are not currently available.
 - Recipe usage: [Recipe usage](../../recipe-usage.md)
 - Customizing the training recipe configuration: [Configuration overview](../../training/config-container-overview.md)
 - Training entry points: [Entry points](../../training/entry-points.md)
-


### PR DESCRIPTION
## Summary

Update the DeepSeek V2 and V2-Lite pretraining examples to use the current parameterless recipe API and hierarchical `ConfigContainer` overrides.

## Supported trigger and impact

Copying either Python example from the current DeepSeek V2 model guide fails before returning a config:

```text
TypeError: deepseek_v2_lite_pretrain_8gpu_h100_bf16_config() got an unexpected keyword argument 'name'
```

Both public compatibility names now alias parameterless H100 recipe functions. The examples still passed legacy `name`, `data_paths`, `dir`, and training keywords directly, so users could not construct the documented config or start training.

## Root cause and fix

The H100 recipe namespace refactor made library recipes parameterless, but the DeepSeek V2 model page and its Fern nightly mirror retained the former constructor contract.

The examples now:

- call each recipe without arguments;
- set the preprocessed GPT dataset prefix through `config.dataset.blend`;
- set checkpoint and TensorBoard output paths on their current sub-configs;
- set training values under `config.train`; and
- keep `config.model.seq_length` and `config.dataset.seq_length` synchronized.

## Verification

Focused deterministic docs executor, unchanged before and after the fix:

```bash
docker run --rm \
  -e PYTHONPATH=/workdir/src:/workdir/3rdparty/Megatron-LM \
  -v "$PWD":/workdir -v /tmp/docs-repro:/repro:ro -w /workdir \
  megatron-bridge:latest \
  uv run --active --no-sync python /repro/reproduce_documented_examples.py \
  docs/models/deepseek/deepseek-v2.md
```

- Before: exit 1 on the unexpected `name` keyword, before model access.
- After: exit 0; both examples return `ConfigContainer` objects with the documented dataset, output, iteration, batch, and sequence values.
- The same after-fix command against `docs/fern/versions/nightly/pages/models/deepseek/deepseek-v2.mdx` exits 0.

Adjacent tests:

```bash
docker run --rm -v "$PWD":/workdir -w /workdir megatron-bridge:latest \
  uv run --active --no-sync python -m pytest \
  tests/unit_tests/recipes/test_deepseek_recipes.py -q
```

Result: 33 passed.

Additional gates:

```text
git diff --check                                  passed
uv run pre-commit run --all-files                passed
```

## Scope

Documentation only. No recipe implementation, public API, dependency, workflow, generated lockfile, GPU behavior, convergence, or performance claim is changed.
