### PR TITLE
build(deps): bump wandb to >=0.28.0 to clear CVE-2026-39821 in wandb-core

### DIFF
--- a/docker/Dockerfile.fw_final
+++ b/docker/Dockerfile.fw_final
@@ -88,7 +88,8 @@ RUN pip install "starlette==0.49.1" \
     "jupyterlab>=4.5.7" \
     "jupyter-server>=2.18.0" \
     "mistune>=3.2.1" \
-    "GitPython>=3.1.50" && \
+    "GitPython>=3.1.50" \
+    "wandb>=0.28.0" && \
     # Address CVE from transitive dependency
     pip uninstall -y opencv-python-headless nvidia-dali-cuda130
 
@@ -122,43 +123,10 @@ RUN JACKSON_VERSION=2.18.6 && \
     done && \
     rm -rf "${TMPDIR}"
 
-# Patch wandb-core: bump google.golang.org/grpc from 1.79.2 to 1.79.3 (CVE fix)
-ARG TARGETARCH
-RUN GRPC_VERSION=1.79.3 && \
-    GO_VERSION=1.26.1 && \
-    WANDB_VERSION=$(python3 -c "import wandb; print(wandb.__version__)") && \
-    WANDB_CORE_BIN=/opt/venv/lib/python3.12/site-packages/wandb/bin/wandb-core && \
-    curl -fsSL "https://dl.google.com/go/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz" | tar -C /tmp -xz && \
-    export PATH="/tmp/go/bin:$PATH" && \
-    export GOPATH=/tmp/gopath && \
-    git clone --depth 1 --branch "v${WANDB_VERSION}" https://github.com/wandb/wandb.git /tmp/wandb-src && \
-    cd /tmp/wandb-src/core && \
-    go get google.golang.org/grpc@v${GRPC_VERSION} && \
-    go mod tidy && \
-    go mod vendor && \
-    CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -trimpath -ldflags="-s -w" \
-        -o "${WANDB_CORE_BIN}" ./cmd/wandb-core/ && \
-    rm -rf /tmp/wandb-src /tmp/go /tmp/gopath
-
-# Patch wandb-core (dist-packages copy): bump github.com/go-git/go-git/v5 to 5.19.0 (CVE fix).
-# This stock upstream binary ships with go-git v5.17.2 and is a separate wandb install from the
-# /opt/venv copy rebuilt above, so it must be rebuilt against its own wandb version (resolved via
-# the system interpreter that owns dist-packages) to avoid a python/wandb-core version mismatch.
-RUN GO_GIT_VERSION=5.19.0 && \
-    GO_VERSION=1.26.1 && \
-    WANDB_VERSION=$(/usr/bin/python3 -c "import wandb; print(wandb.__version__)") && \
-    WANDB_CORE_BIN=/usr/local/lib/python3.12/dist-packages/wandb/bin/wandb-core && \
-    curl -fsSL "https://dl.google.com/go/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz" | tar -C /tmp -xz && \
-    export PATH="/tmp/go/bin:$PATH" && \
-    export GOPATH=/tmp/gopath && \
-    git clone --depth 1 --branch "v${WANDB_VERSION}" https://github.com/wandb/wandb.git /tmp/wandb-src && \
-    cd /tmp/wandb-src/core && \
-    go get github.com/go-git/go-git/v5@v${GO_GIT_VERSION} && \
-    go mod tidy && \
-    go mod vendor && \
-    CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -trimpath -ldflags="-s -w" \
-        -o "${WANDB_CORE_BIN}" ./cmd/wandb-core/ && \
-    rm -rf /tmp/wandb-src /tmp/go /tmp/gopath
+# wandb-core Go CVEs (golang.org/x/net CVE-2026-39821, google.golang.org/grpc, go-git/v5) are
+# cleared by shipping wandb>=0.28.0: its prebuilt wandb-core already vendors the patched versions
+# (x/net v0.56.0, grpc v1.81.1, go-git/v5 v5.19.1), so no from-source rebuild is needed. The
+# dist-packages copy is pinned in the pip block above; the /opt/venv copy via pyproject.toml.
 
 ##############################################################################
 ##

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ dependencies = [
     "tensorboard>=2.19.0",
     "typing-extensions",
     "rich",
-    "wandb>=0.25.0",
+    "wandb>=0.28.0",  # To address CVE-2026-39821 (golang.org/x/net >= v0.55.0 in wandb-core)
     "six>=1.17.0",
     "regex>=2024.11.6",
     "pyyaml>=6.0.2",

--- a/uv.lock
+++ b/uv.lock
@@ -2211,7 +2211,7 @@ requires-dist = [
     { name = "transformer-engine", extras = ["core-cu13", "pytorch"], marker = "extra == 'te'" },
     { name = "transformers", specifier = ">=5.8.1,<5.9.0" },
     { name = "typing-extensions" },
-    { name = "wandb", specifier = ">=0.25.0" },
+    { name = "wandb", specifier = ">=0.28.0" },
 ]
 provides-extras = ["recipes", "parquet", "tensor-inspect", "te", "ssm", "audio"]
 


### PR DESCRIPTION
### Background / motivation

- A vulnerability scan of the NeMo-FW `26.06.01.rc2` image flagged **CVE-2026-39821** (GHSA-w2q5-6q6x-x959 / GO-2026-5026) in `golang.org/x/net`, at `/usr/local/lib/python3.12/dist-packages/wandb/bin/wandb-core`.
- `golang.org/x/net` is **statically compiled into** the `wandb-core` Go binary the `wandb` wheel ships — not a pip-level dep, so it moves only with the `wandb` version.
- The fw_final image carries **two** wandb installs, and both must be `>=0.28.0`:
  - **`/opt/venv`** — governed by the lock (the vulnerable rc2 predated the bump; `r0.5.0` already resolves `0.28.0`).
  - **`/usr/local/.../dist-packages`** — a separate copy from the base image, still `0.27.2` (x/net `v0.54.0`) — this is the copy the finding is on, and it is **not** governed by the lock.

### What changed

- **`pyproject.toml` + `uv.lock`** — raise the `wandb` floor `>=0.25.0` → `>=0.28.0` (fixes the `/opt/venv` copy; makes the fix a hard constraint).
- **`docker/Dockerfile.fw_final`** — pin `wandb>=0.28.0` in the dist-packages CVE pip block (fixes the flagged dist-packages copy), and **remove the two from-source `wandb-core` rebuild blocks** — stock `0.28.0` already vendors the patched Go deps, so they are redundant.

### Details

wandb `0.28.0`'s `wandb-core` already vendors every module the rebuilds targeted, at/above their thresholds:

| module | old rebuild bumped to | wandb 0.28.0 | 
|---|---|---|
| `golang.org/x/net` | (n/a) | **v0.56.0** ✅ |
| `google.golang.org/grpc` | 1.79.3 | **v1.81.1** ✅ |
| `github.com/go-git/go-git/v5` | 5.19.0 | **v5.19.1** ✅ |

- So the rebuilds are not just redundant — block 1 would *downgrade* grpc `1.81.1 → 1.79.3`. Removing both also drops a fragile step (Go toolchain download + `wandb` clone + `go mod vendor`/build per arch). A breadcrumb comment records why no rebuild is needed.
- `uv.lock` resolution is unchanged (already `0.28.0`); the only lock delta is the recorded floor specifier.

### Tested

- `uv lock` regenerated inside the NeMo-FW `fw-base` CUDA container (uv 0.8.22, nvcc 13.3, torch `nv26.06`); `Resolved 347 packages`, exit 0.
- Verified in the base image that `/opt/venv`'s uv venv has no `pip` (bare `pip` → system → dist-packages), confirming the pip block targets the flagged copy.
- Confirmed wandb `0.28.0`'s `core/go.mod` vendors x/net v0.56.0 / grpc v1.81.1 / go-git v5.19.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
