### PR TITLE
[training] fix: Run eval callbacks in evaluation mode

### DIFF
--- a/src/megatron/bridge/training/eval.py
+++ b/src/megatron/bridge/training/eval.py
@@ -93,6 +93,8 @@ def evaluate(
             - timelimit_hit: Boolean indicating if the time limit was reached.
     """
     # Determine callback event names based on whether this is test or eval
+    start_event = "on_test_start" if is_test else "on_eval_start"
+    end_event = "on_test_end" if is_test else "on_eval_end"
     step_start_event = "on_test_step_start" if is_test else "on_eval_step_start"
     step_end_event = "on_test_step_end" if is_test else "on_eval_step_end"
     # Prepare forward_step_func (check signature and inject state if needed)
@@ -105,6 +107,16 @@ def evaluate(
     # Turn on evaluation mode which disables dropout.
     for model_module in model:
         model_module.eval()
+
+    if should_fire(callback_manager, start_event):
+        callback_manager.fire(
+            start_event,
+            CallbackContext(
+                state=state,
+                model=model,
+                user_state=callback_manager.user_state,
+            ),
+        )
 
     # Retrieve process group collection and model config from the model
     # Use injected pg_collection if provided, otherwise extract from model
@@ -343,10 +355,6 @@ def evaluate(
                 pg_collection=pg_collection,
             )
 
-    # Move model back to the train mode.
-    for model_module in model:
-        model_module.train()
-
     for key in total_loss_dict:
         numerator, denominator = total_loss_dict[key]
         total_loss_dict[key] = numerator / denominator
@@ -355,6 +363,21 @@ def evaluate(
     timers.log(["evaluate"])
 
     rerun_state_machine.set_mode(rerun_mode)
+
+    if should_fire(callback_manager, end_event):
+        callback_manager.fire(
+            end_event,
+            CallbackContext(
+                state=state,
+                model=model,
+                user_state=callback_manager.user_state,
+                total_loss_dict=total_loss_dict,
+            ),
+        )
+
+    # Move model back to the train mode.
+    for model_module in model:
+        model_module.train()
 
     return total_loss_dict, collected_non_loss_data, False
 
@@ -400,10 +423,6 @@ def evaluate_and_print_results(
         Optional[dict[str, torch.Tensor]]: The averaged evaluation loss dictionary, or
         None if evaluation exited early due to a configured time limit.
     """
-    # Determine callback event names based on whether this is test or eval
-    start_event = "on_test_start" if is_test else "on_eval_start"
-    end_event = "on_test_end" if is_test else "on_eval_end"
-
     if write_to_tensorboard:
         writer = state.tensorboard_logger
     else:
@@ -412,16 +431,6 @@ def evaluate_and_print_results(
     wandb_writer = state.wandb_logger
     mlflow_writer = state.mlflow_logger
     comet_logger = state.comet_logger
-
-    if should_fire(callback_manager, start_event):
-        callback_manager.fire(
-            start_event,
-            CallbackContext(
-                state=state,
-                model=model,
-                user_state=callback_manager.user_state,
-            ),
-        )
 
     total_loss_dict, collected_non_loss_data, timelimit = evaluate(
         state,
@@ -489,16 +498,5 @@ def evaluate_and_print_results(
     print_rank_last("-" * length)
     print_rank_last(string)
     print_rank_last("-" * length)
-
-    if should_fire(callback_manager, end_event):
-        callback_manager.fire(
-            end_event,
-            CallbackContext(
-                state=state,
-                model=model,
-                user_state=callback_manager.user_state,
-                total_loss_dict=total_loss_dict,
-            ),
-        )
 
     return total_loss_dict

--- a/tests/functional_tests/test_groups/training/test_callbacks.py
+++ b/tests/functional_tests/test_groups/training/test_callbacks.py
@@ -59,6 +59,7 @@ class TrackingCallback(Callback):
                 "has_grad_norm": context.grad_norm is not None,
                 "has_skipped_iter": context.skipped_iter is not None,
                 "has_total_loss_dict": context.total_loss_dict is not None,
+                "model_in_training_mode": any(model.training for model in context.model),
             }
         )
 
@@ -351,6 +352,14 @@ class TestCallbacksEndToEnd:
 
         for snapshot in tracking_callback.get_snapshots_for_event("on_test_end"):
             assert snapshot["has_total_loss_dict"], "on_test_end missing total_loss_dict"
+
+        for event_name in ["on_eval_start", "on_eval_end", "on_test_start", "on_test_end"]:
+            for snapshot in tracking_callback.get_snapshots_for_event(event_name):
+                assert not snapshot["model_in_training_mode"], f"{event_name} must run in evaluation mode"
+
+        for event_name in training_events:
+            for snapshot in tracking_callback.get_snapshots_for_event(event_name):
+                assert snapshot["model_in_training_mode"], f"{event_name} must run in training mode"
 
         # Verify user_state persistence (UserStateCallback)
         assert user_state_callback.final_count == train_iters, (

--- a/tests/unit_tests/training/test_eval.py
+++ b/tests/unit_tests/training/test_eval.py
@@ -18,7 +18,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 import torch
 
-from megatron.bridge.training.eval import evaluate_and_print_results
+from megatron.bridge.training.callbacks import CallbackManager
+from megatron.bridge.training.eval import evaluate, evaluate_and_print_results
 
 
 pytestmark = pytest.mark.unit
@@ -34,12 +35,91 @@ def _make_state():
     )
 
 
+class _ModeTrackingModel:
+    def __init__(self):
+        self.training = True
+
+    def eval(self):
+        self.training = False
+
+    def train(self):
+        self.training = True
+
+
+def _make_evaluate_state(*, eval_iters, exit_duration_in_mins=None):
+    timer = MagicMock()
+    timers = MagicMock(return_value=timer)
+    timers.log = MagicMock()
+    return SimpleNamespace(
+        timers=timers,
+        start_time=0.0,
+        train_state=SimpleNamespace(consumed_valid_samples=0),
+        cfg=SimpleNamespace(
+            validation=SimpleNamespace(
+                eval_global_batch_size=1,
+                eval_micro_batch_size=1,
+                eval_iters=eval_iters,
+            ),
+            data_parallel_size=1,
+            model=SimpleNamespace(
+                seq_length=1,
+                virtual_pipeline_model_parallel_size=None,
+                moe_expert_rank_capacity_factor=None,
+            ),
+            dist=SimpleNamespace(use_decentralized_pg=True),
+            optimizer=SimpleNamespace(reuse_grad_buf_for_mxfp8_param_ag=False),
+            ddp=SimpleNamespace(overlap_param_gather=False),
+            dataset=SimpleNamespace(dataloader_type="single"),
+            train=SimpleNamespace(
+                empty_unused_memory_level=0,
+                exit_duration_in_mins=exit_duration_in_mins,
+            ),
+        ),
+    )
+
+
+def _run_evaluate(*, state, model, callback_manager, is_test=False, timelimit_hit=False):
+    pg_collection = SimpleNamespace(
+        pp=SimpleNamespace(size=lambda: 1),
+        dp_cp=object(),
+    )
+    rerun_state_machine = MagicMock()
+    done_cuda = MagicMock()
+    done_cuda.item.return_value = int(timelimit_hit)
+
+    with (
+        patch("megatron.bridge.training.eval.prepare_forward_step_func", return_value=MagicMock()),
+        patch("megatron.bridge.training.eval.get_pg_collection", return_value=pg_collection),
+        patch("megatron.bridge.training.eval.get_model_config", return_value=SimpleNamespace()),
+        patch("megatron.bridge.training.eval.get_rerun_state_machine", return_value=rerun_state_machine),
+        patch("megatron.bridge.training.eval.is_full_iteration_cuda_graph", return_value=False),
+        patch("megatron.bridge.training.eval.get_forward_backward_func", return_value=MagicMock(return_value=[{}])),
+        patch("megatron.bridge.training.eval.is_pp_last_stage", return_value=False),
+        patch("megatron.bridge.training.eval.fault_tolerance.on_eval_step_start"),
+        patch("megatron.bridge.training.eval.fault_tolerance.on_eval_step_end"),
+        patch("megatron.bridge.training.eval.time.time", return_value=120.0),
+        patch("megatron.bridge.training.eval.torch.tensor", return_value=done_cuda),
+        patch("megatron.bridge.training.eval.torch.distributed.all_reduce"),
+    ):
+        return evaluate(
+            state=state,
+            forward_step_func=MagicMock(),
+            data_iterator=object(),
+            model=[model],
+            process_non_loss_data_func=None,
+            config=SimpleNamespace(timers=state.timers),
+            p2p_communicator=MagicMock(),
+            callback_manager=callback_manager,
+            is_test=is_test,
+        )
+
+
 @patch("megatron.bridge.training.eval.print_rank_last")
-@patch("megatron.bridge.training.eval.should_fire", return_value=False)
 @patch("megatron.bridge.training.eval.evaluate")
-def test_evaluate_and_print_results_returns_loss_dict(mock_evaluate, mock_should_fire, mock_print_rank_last):
+def test_evaluate_and_print_results_returns_loss_dict(mock_evaluate, mock_print_rank_last):
     losses = {"lm loss": torch.tensor(1.0)}
     mock_evaluate.return_value = (losses, None, False)
+    callback_manager = CallbackManager()
 
     result = evaluate_and_print_results(
         state=_make_state(),
@@ -49,22 +129,22 @@ def test_evaluate_and_print_results_returns_loss_dict(mock_evaluate, mock_should
         model=[MagicMock()],
         config=SimpleNamespace(),
         write_to_tensorboard=False,
+        callback_manager=callback_manager,
     )
 
     assert result is losses
-    assert mock_should_fire.called
+    assert mock_evaluate.call_args.kwargs["callback_manager"] is callback_manager
     assert mock_print_rank_last.called
 
 
 @patch("megatron.bridge.training.eval.print_rank_last")
-@patch("megatron.bridge.training.eval.should_fire", return_value=False)
 @patch("megatron.bridge.training.eval.evaluate")
 def test_evaluate_and_print_results_returns_none_on_timelimit(
     mock_evaluate,
-    mock_should_fire,
     mock_print_rank_last,
 ):
     mock_evaluate.return_value = (None, None, True)
+    callback_manager = CallbackManager()
 
     result = evaluate_and_print_results(
         state=_make_state(),
@@ -74,8 +154,70 @@ def test_evaluate_and_print_results_returns_none_on_timelimit(
         model=[MagicMock()],
         config=SimpleNamespace(),
         write_to_tensorboard=False,
+        callback_manager=callback_manager,
     )
 
     assert result is None
-    assert mock_should_fire.called
+    assert mock_evaluate.call_args.kwargs["callback_manager"] is callback_manager
     mock_print_rank_last.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("is_test", "start_event", "end_event"),
+    [
+        (False, "on_eval_start", "on_eval_end"),
+        (True, "on_test_start", "on_test_end"),
+    ],
+)
+def test_evaluate_fires_lifecycle_callbacks_in_eval_mode(is_test, start_event, end_event):
+    state = _make_evaluate_state(eval_iters=0)
+    model = _ModeTrackingModel()
+    callback_manager = CallbackManager()
+    observed = []
+    callback_manager.register(
+        start_event,
+        lambda context: observed.append((start_event, context.model[0].training, context.total_loss_dict)),
+    )
+    callback_manager.register(
+        end_event,
+        lambda context: observed.append((end_event, context.model[0].training, context.total_loss_dict)),
+    )
+
+    result = _run_evaluate(
+        state=state,
+        model=model,
+        callback_manager=callback_manager,
+        is_test=is_test,
+    )
+
+    assert result == ({}, None, False)
+    assert observed == [
+        (start_event, False, None),
+        (end_event, False, {}),
+    ]
+    assert model.training
+
+
+def test_evaluate_timelimit_fires_start_but_not_end_callback():
+    state = _make_evaluate_state(eval_iters=1, exit_duration_in_mins=1)
+    model = _ModeTrackingModel()
+    callback_manager = CallbackManager()
+    observed = []
+    callback_manager.register(
+        "on_eval_start",
+        lambda context: observed.append(("on_eval_start", context.model[0].training)),
+    )
+    callback_manager.register(
+        "on_eval_end",
+        lambda context: observed.append(("on_eval_end", context.model[0].training)),
+    )
+
+    result = _run_evaluate(
+        state=state,
+        model=model,
+        callback_manager=callback_manager,
+        timelimit_hit=True,
+    )
+
+    assert result == (None, None, True)
+    assert observed == [("on_eval_start", False)]


### PR DESCRIPTION
## What does this PR do?

Runs validation and test lifecycle callbacks while model chunks are actually in evaluation mode.

### Supported trigger and impact

Any `pretrain()` run that registers `on_eval_start`, `on_eval_end`, `on_test_start`, or `on_test_end` reaches this path during interval validation or final validation/test. The public callback contract says start hooks run after `model.eval()` and end hooks run before `model.train()`.

Previously, start hooks fired before `evaluate()` switched modes, while end hooks fired after `evaluate()` restored training mode. Callback inference or dropout-sensitive work therefore ran with training semantics, and `module.training` contradicted the documented lifecycle contract.

### Root cause and fix

Lifecycle hooks were owned by `evaluate_and_print_results()`, but the model-mode transitions are owned by `evaluate()`. This moves only the four lifecycle hook calls next to those transitions:

- start hooks fire immediately after all model chunks enter eval mode;
- end hooks fire after loss aggregation and before model chunks return to train mode.

Eval/test event selection, per-step hooks, reduced `total_loss_dict`, and the existing time-limit return behavior are preserved.

### Regression evidence

A deterministic CPU contract reproducer loaded and executed the real `evaluate_and_print_results()` and `evaluate()` functions with zero eval iterations:

```text
MB_WORKTREE=<checkout> uv run --no-project python <contract-reproducer>
```

- Base: exit 1 — `eval lifecycle modes were [('start', True), ('end', True)]`
- Fixed: exit 0 — `eval/test lifecycle callbacks observed evaluation mode`

The existing functional callback test now asserts evaluation mode for all validation/test lifecycle hooks and training mode for training hooks as a negative control.

Validation:

```text
uv run --no-project --with pytest python -m pytest --confcutdir=tests/unit_tests/training -p callback_loader tests/unit_tests/training/test_callbacks.py -q
# 42 passed

git diff --check
# passed

uv run --no-project --with pre-commit pre-commit run --all-files
# all hooks passed
```

### Scope

No checkpoint, training-step accounting, model conversion, dependency, workflow, public signature, or MCore code changes are included. The GPU functional test was not run locally; the ordering defect was exercised with the deterministic CPU harness. No full-suite, convergence, performance, or model-quality validation is claimed.
