### PR TITLE
fix(cuda_graph): preserve explicit empty cuda_graph_scope as [] when clearing modules

### DIFF
--- a/src/megatron/bridge/utils/cuda_graph.py
+++ b/src/megatron/bridge/utils/cuda_graph.py
@@ -81,7 +81,12 @@ def set_cuda_graph_modules(config: Any, modules: Any) -> None:
     if _supports_cuda_graph_modules(config):
         config.cuda_graph_modules = [_module_value(name) for name in module_names]
         if hasattr(config, "cuda_graph_scope"):
-            config.cuda_graph_scope = None
+            # Clear the deprecated per-layer scope, but preserve the empty-list
+            # convention rather than dropping it to None. An explicit
+            # ``cuda_graph_scope=[]`` (e.g. from a Hydra/CLI override) means "no
+            # per-layer scope", and must survive the override chain as ``[]`` --
+            # replacing it with None loses that user intent.
+            config.cuda_graph_scope = []
     else:
         config.cuda_graph_scope = [CudaGraphScope[name] for name in module_names]
 


### PR DESCRIPTION
## Background

On this branch, the unit test
`tests/unit_tests/recipes/test_override_precedence.py::TestFullChainSanity::test_I_combined_overrides_end_to_end`
fails with `AssertionError: assert None == []` — an explicit `model.cuda_graph_scope=[]` override does
not survive the perf-script override chain (it is dropped to `None`).

## Root cause

`set_cuda_graph_modules()` in `src/megatron/bridge/utils/cuda_graph.py`, when clearing the per-layer
modules, set `config.cuda_graph_scope = None`. That destroys an explicit empty-list scope: a caller
passing `cuda_graph_scope=[]` (via a Hydra/CLI override) means "no per-layer scope", and that intent
must survive as `[]`, not become `None`.

## Fix

Preserve the empty-list convention — set `config.cuda_graph_scope = []` instead of `None` when
clearing modules (1 file, +6/-1).

## Tested

Reproduced and verified by running the exact test on the **aws-h100** cluster via a Kubeflow TrainJob
(`nvcr.io/nvidia/nemo:26.04`, with the branch's `megatron.core` from the `3rdparty/Megatron-LM`
submodule):

| Stage | Branch | Result |
|-------|--------|--------|
| Reproduce | `yuya/mb4583-cuda-graph-local-scope` | `1 failed` (`assert None == []`) |
| Verify | this fix | `1 passed` |

```
$ pytest tests/unit_tests/recipes/test_override_precedence.py::TestFullChainSanity::test_I_combined_overrides_end_to_end
============================== 1 passed in 2.83s ===============================
```

---
Opened on behalf of an automated implement-and-heal agent that reproduced the failure, authored the
fix, and verified it green on a real GPU cluster before this PR was raised. Draft for the branch
owner's review.