### PR TITLE
fix(cuda_graph): keep empty cuda_graph_scope as [] when clearing modules

### DIFF
--- a/src/megatron/bridge/utils/cuda_graph.py
+++ b/src/megatron/bridge/utils/cuda_graph.py
@@ -81,7 +81,12 @@ def set_cuda_graph_modules(config: Any, modules: Any) -> None:
     if _supports_cuda_graph_modules(config):
         config.cuda_graph_modules = [_module_value(name) for name in module_names]
         if hasattr(config, "cuda_graph_scope"):
-            config.cuda_graph_scope = None
+            # Keep the legacy ``cuda_graph_scope`` field consistent with the
+            # non-``cuda_graph_modules`` branch below: represent "no scopes" as
+            # an empty list rather than ``None`` so that clearing modules (e.g.
+            # the ``cuda_graph_impl="none"`` disable path, or an explicit
+            # ``cuda_graph_scope=[]`` override) leaves ``[]`` in place.
+            config.cuda_graph_scope = [] if not module_names else None
     else:
         config.cuda_graph_scope = [CudaGraphScope[name] for name in module_names]
 


### PR DESCRIPTION
## Background

On `yuya/mb4583-cuda-graph-local-scope`, the unit test
`tests/unit_tests/recipes/test_override_precedence.py::TestFullChainSanity::test_I_combined_overrides_end_to_end`
fails with `AssertionError: assert None == []` — an explicit `model.cuda_graph_scope=[]` override is
dropped to `None` by the override chain.

## Root cause & fix

`set_cuda_graph_modules()` in `src/megatron/bridge/utils/cuda_graph.py` unconditionally set
`config.cuda_graph_scope = None` when clearing per-layer modules. This makes it consistent with the
sibling branch by representing "no scopes" as `[]` when there are no modules, so an explicit empty
scope (or the disable path) survives as `[]`:

```python
config.cuda_graph_scope = [] if not module_names else None
```

## Tested

Reproduced (FAIL) and verified (PASS) by running the exact test in `nvcr.io/nvidia/nemo:26.04` on
the aws-h100 cluster, using the branch's `megatron.core` from the `3rdparty/Megatron-LM` submodule:

```
============================== 1 passed in 2.86s ===============================
```

---
Opened on behalf of an automated implement-and-heal agent that **independently** worked out how to
run the test (vendored-submodule env), reproduced the failure, authored this fix, and verified it
green on a real GPU cluster. Draft for the branch owner's review.