### PR TITLE
fix(cuda_graph): preserve explicit empty cuda_graph_scope through the override chain

### DIFF
--- a/src/megatron/bridge/utils/cuda_graph.py
+++ b/src/megatron/bridge/utils/cuda_graph.py
@@ -87,9 +87,20 @@ def set_cuda_graph_modules(config: Any, modules: Any) -> None:
 
 
 def clear_cuda_graph_modules(config: Any) -> None:
-    """Clear per-layer CUDA graph modules using the active MCore API."""
+    """Clear per-layer CUDA graph modules using the active MCore API.
+
+    Clearing must leave ``cuda_graph_scope`` as an empty list rather than
+    ``None`` so that an explicit user request to disable per-layer capture
+    (e.g. ``model.cuda_graph_scope=[]`` alongside ``cuda_graph_impl=none``)
+    survives the override pipeline instead of being silently wiped to
+    ``None``. Both values are treated identically as "no graphs" by the
+    readers in this module, so preserving ``[]`` changes no behavior while
+    keeping the field consistent with what the caller set.
+    """
 
     set_cuda_graph_modules(config, [])
+    if hasattr(config, "cuda_graph_scope"):
+        config.cuda_graph_scope = []
 
 
 def set_full_iteration_cuda_graph(config: Any) -> None:

--- a/src/megatron/bridge/utils/cuda_graph.py
+++ b/src/megatron/bridge/utils/cuda_graph.py
@@ -81,7 +81,15 @@ def set_cuda_graph_modules(config: Any, modules: Any) -> None:
     if _supports_cuda_graph_modules(config):
         config.cuda_graph_modules = [_module_value(name) for name in module_names]
         if hasattr(config, "cuda_graph_scope"):
-            config.cuda_graph_scope = None
+            # Preserve an explicit empty scope as [] rather than wiping it to
+            # None. The new ``cuda_graph_modules`` API supersedes the legacy
+            # ``cuda_graph_scope`` list, so we must clear the legacy field to
+            # avoid double-counting scopes. But callers that explicitly disable
+            # CUDA graphs set ``cuda_graph_scope=[]`` and expect it to stay an
+            # empty list; collapsing it to None silently changes the effective
+            # config (see perf-script override precedence). Only the non-empty
+            # case needs the field neutralized.
+            config.cuda_graph_scope = [] if not module_names else None
     else:
         config.cuda_graph_scope = [CudaGraphScope[name] for name in module_names]
 


### PR DESCRIPTION
## Background
On `yuya/mb4583-cuda-graph-local-scope`, `tests/unit_tests/recipes/test_override_precedence.py::TestFullChainSanity::test_I_combined_overrides_end_to_end`
fails with `AssertionError: assert None == []` — an explicit `model.cuda_graph_scope=[]` override is dropped to `None` by the override chain.

## Root cause & fix
With `cuda_graph_impl=none`, the override chain clears modules via `set_cuda_graph_modules(config, [])`; in
`src/megatron/bridge/utils/cuda_graph.py` that path forced `cuda_graph_scope = None`, wiping an explicit empty scope. Fixed to preserve `[]`.

## Tested
Reproduced (FAIL) and verified (PASS) by running the exact test in `nvcr.io/nvidia/nemo:26.04` on the aws-h100 cluster:
```
Reproduce (failing branch): FAILED ... AssertionError: assert None == []
Verify (this fix):          1 passed in 3.17s
```
---
Opened on behalf of an automated implement-and-heal agent that **independently** derived how to run the test (vendored-submodule env), reproduced, fixed, and **verified it green on a real GPU cluster** before this PR. Draft for the branch owner's review.