### PR TITLE
test(checkpoint): isolate local checkpoint scenarios

### DIFF
--- a/tests/functional_tests/launch_scripts/h100/active/L0_Launch_training_local_checkpointing.sh
+++ b/tests/functional_tests/launch_scripts/h100/active/L0_Launch_training_local_checkpointing.sh
@@ -18,9 +18,15 @@ set -xeuo pipefail
 
 export CUDA_VISIBLE_DEVICES="0,1"
 
-uv run python -m torch.distributed.run --nproc_per_node=2 --nnodes=1 -m coverage run \
-  --data-file=/opt/Megatron-Bridge/.coverage --source=/opt/Megatron-Bridge/ --parallel-mode \
-  -m pytest -o log_cli=true -o log_cli_level=INFO -v -s -x -m "not pleasefixme" --tb=short -rA \
-  tests/functional_tests/test_groups/training/test_local_checkpointing.py
+# Run each scenario in fresh workers so their test-owned WORLD and NCCL groups
+# are released at process exit instead of leaking into the next scenario.
+for test_case in \
+  "TestLocalCheckpointing::test_local_checkpoint_save_and_resume" \
+  "TestLocalCheckpointing::test_local_checkpoint_save_resume_with_most_recent_k"; do
+  uv run python -m torch.distributed.run --nproc_per_node=2 --nnodes=1 -m coverage run \
+    --data-file=/opt/Megatron-Bridge/.coverage --source=/opt/Megatron-Bridge/ --parallel-mode \
+    -m pytest -o log_cli=true -o log_cli_level=INFO -v -s -x -m "not pleasefixme" --tb=short -rA \
+    "tests/functional_tests/test_groups/training/test_local_checkpointing.py::${test_case}"
+done
 
 coverage combine -q


### PR DESCRIPTION
## Summary

- run the two H100 local-checkpoint scenarios in separate `torchrun` worker lifetimes
- release each test-owned WORLD process group and its NCCL subgroups at process exit
- keep the launcher active rather than quarantining the coverage as flaky

## Diagnosis

Both scenarios initialize the WORLD process group themselves. Megatron cleanup clears its subgroup references, but the enclosing pytest/torchrun process keeps PyTorch's NCCL groups alive for the next scenario. The intermittent second-case NaN is consistent with that leaked communicator state.

An in-process teardown experiment destroyed WORLD successfully, but attempting to reinitialize it in the same `torchrun` workers hung at rendezvous. Giving each scenario fresh workers provides deterministic cleanup without changing production distributed lifecycle ownership.

## Verification

- H100 Slurm job `13585791`: modified launcher passed 5 consecutive repetitions (10/10 isolated scenario runs, all RC=0)
- `bash -n tests/functional_tests/launch_scripts/h100/active/L0_Launch_training_local_checkpointing.sh`
- `uv run pre-commit run --all-files`

