### PR TITLE
ci(nemo-rl): add weekly Megatron GRPO smoke

### DIFF
--- a/.github/workflows/nemo-rl-e2e-weekly.yml
+++ b/.github/workflows/nemo-rl-e2e-weekly.yml
@@ -1,0 +1,108 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: NeMo-RL Megatron e2e (weekly)
+
+on:
+  schedule:
+    - cron: "0 7 * * 1" # Mondays 07:00 UTC, after the weekly verl workflow.
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  grpo-qwen3-8b-base-megatron-lora:
+    name: GRPO Qwen3 8B LoRA (Megatron)
+    runs-on: nemo-ci-gcp-gpu-x8
+    timeout-minutes: 60
+    env:
+      CONTAINER: nemo_rl_${{ github.run_id }}
+      HF_DATASETS_CACHE: /home/TestData/nemo-rl/hf_datasets_cache
+      HF_HOME: /home/TestData/nemo-rl/hf_home
+      NEMO_RL_IMAGE: us-east4-docker.pkg.dev/nv-projdgxchipp-20260113193621/rl/rl:28921487402
+      NEMO_RL_REF: 3b04247b78c69ed4c447204aad0d1e3215b0a083 # pragma: allowlist secret
+      TEST_DATA_PATH: ${{ vars.DEFAULT_TEST_DATA_PATH }}
+    steps:
+      - name: Checkout Megatron-Bridge
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          submodules: recursive
+
+      - name: Checkout pinned NeMo-RL
+        shell: bash -x -e -u -o pipefail {0}
+        run: |
+          rm -rf "${RUNNER_TEMP}/nemo-rl"
+          git init "${RUNNER_TEMP}/nemo-rl"
+          git -C "${RUNNER_TEMP}/nemo-rl" remote add origin https://github.com/NVIDIA-NeMo/RL.git
+          git -C "${RUNNER_TEMP}/nemo-rl" fetch --depth=1 origin "$NEMO_RL_REF"
+          git -C "${RUNNER_TEMP}/nemo-rl" checkout --detach FETCH_HEAD
+          test "$(git -C "${RUNNER_TEMP}/nemo-rl" rev-parse HEAD)" = "$NEMO_RL_REF"
+
+      - name: Start pinned NeMo-RL container
+        shell: bash -x -e -u -o pipefail {0}
+        run: |
+          docker rm -f "$CONTAINER" || true
+          docker pull "$NEMO_RL_IMAGE"
+          docker run \
+            --rm -d \
+            --name "$CONTAINER" \
+            --runtime=nvidia --gpus all \
+            --shm-size=64g \
+            --env HF_DATASETS_CACHE \
+            --env HF_HOME \
+            --env WANDB_MODE=disabled \
+            --volume "${TEST_DATA_PATH}:/home/TestData" \
+            --volume "${GITHUB_WORKSPACE}:/opt/Megatron-Bridge" \
+            --volume "${RUNNER_TEMP}/nemo-rl:/opt/nemo-rl" \
+            --workdir /opt/nemo-rl \
+            "$NEMO_RL_IMAGE" \
+            sleep 3900
+
+      - name: Run NeMo-RL GRPO smoke
+        shell: bash -x -e -u -o pipefail {0}
+        run: |
+          docker exec \
+            --env BRIDGE_ROOT=/opt/Megatron-Bridge \
+            --env EXPECTED_BRIDGE_SHA="$GITHUB_SHA" \
+            --env EXPECTED_NEMO_RL_SHA="$NEMO_RL_REF" \
+            --env NEMO_RL_ROOT=/opt/nemo-rl \
+            "$CONTAINER" \
+            bash /opt/Megatron-Bridge/.github/workflows/nemo_rl_ci/run_grpo_qwen3_8b_lora.sh
+
+      - name: Cleanup container
+        if: always()
+        shell: bash
+        run: docker rm -f "$CONTAINER" || true
+
+  notify:
+    needs: [grpo-qwen3-8b-base-megatron-lora]
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack on failure
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_CI_CHANNEL_WEBHOOK }}
+          SLACK_WEBHOOK_ADMIN: <!subteam^${{ secrets.SLACK_TEAM_GROUP_ID }}>
+        run: |
+          curl -X POST \
+            -H 'Content-type: application/json' \
+            --data "{\"text\":\":rotating_light: <https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}|NeMo-RL Megatron e2e (weekly)> failed. Please review.\n\ncc ${SLACK_WEBHOOK_ADMIN}\"}" \
+            "$SLACK_WEBHOOK"

--- a/.github/workflows/nemo_rl_ci/README.md
+++ b/.github/workflows/nemo_rl_ci/README.md
@@ -1,0 +1,63 @@
+# NeMo-RL Megatron weekly CI
+
+This directory runs an existing NeMo-RL suite against the Megatron-Bridge and
+Megatron-Core revisions checked out by this repository's weekly workflow. The
+initial smoke is
+`tests/test_suites/llm/grpo-qwen3-8b-base-1n8g-megatron-lora.sh` from NeMo-RL.
+It runs 20 GRPO steps and retains the upstream convergence, numerical-error,
+reward, and step-time assertions.
+
+## Candidate inventory
+
+| NeMo-RL suite | Workload | Resources | Steps / suite limit | Main caches and dependencies |
+| --- | --- | --- | --- | --- |
+| `grpo-qwen3-8b-base-1n8g-megatron-lora.sh` | Qwen3-8B-Base GRPO, Megatron LoRA, vLLM rollout | 1 node, 8 GPUs | 20 / 40 min | Qwen3-8B-Base, OpenMathInstruct-2, Ray, vLLM, Bridge/MCore worker environment |
+| `sft-llama3.1-8b-1n8g-megatron-lora.sh` | Llama-3.1-8B SFT, Megatron LoRA | 1 node, 8 GPUs | 50 / 30 min | Gated Llama model/tokenizer, Tulu 3 SFT mixture, Ray, Bridge/MCore worker environment |
+| `grpo-llama3.2-1b-instruct-1n8g-megatron.sh` | Llama-3.2-1B GRPO, full Megatron policy, vLLM rollout | 1 node, 8 GPUs | 500 / 180 min | Gated Llama model/tokenizer, OpenMathInstruct-2, Ray, vLLM, Bridge/MCore worker environment |
+
+The Qwen3 test is selected because it is the shortest public-model candidate
+that exercises the actual RL path: generation, reward calculation, policy
+optimization, and weight synchronization with a Megatron policy.
+
+## Pinned environment and version injection
+
+The workflow pins both the NeMo-RL source SHA and the immutable CI image tag
+built for that SHA. It reuses that image instead of building a new container on
+every weekly run. Models and datasets use the runner's shared Hugging Face cache;
+missing public assets may populate that cache on the first run.
+
+NeMo-RL normally freezes separate actor environments. Setting only the driver
+checkout is therefore insufficient and can silently test the Bridge package
+baked into the image. The runner takes the narrower source-override path:
+
+1. Mount the current Megatron-Bridge checkout and its checked-out MCore
+   submodule into the pinned NeMo-RL container.
+2. Put their source roots first in `PYTHONPATH`, which NeMo-RL propagates into
+   Ray actor runtime environments.
+3. Before training, invoke NeMo-RL's Megatron policy-worker interpreter and
+   require `megatron.bridge` and `megatron.core` to resolve under those mounted
+   roots.
+4. Print and verify the full NeMo-RL, Bridge, and MCore Git SHAs in the run log.
+
+This avoids the much slower `NRL_FORCE_REBUILD_VENVS=true` path while proving
+that the frozen Megatron worker environment imports the checkout under test.
+The job also requires step 20 unconditionally before repeating the upstream
+metric assertions, closing the suite script's conditional-assertion gap.
+
+## Adding a test
+
+Prefer an existing, bounded NeMo-RL suite with explicit end-of-run metrics. Add
+a small wrapper beside `run_grpo_qwen3_8b_lora.sh`, pin a compatible NeMo-RL
+revision and image, and give the test its own single-node 8-GPU workflow job.
+The wrapper must:
+
+- verify the mounted Bridge and MCore import paths with the actual policy-worker
+  interpreter;
+- record the three full repository SHAs;
+- disable external experiment logging;
+- assert the expected final step independently of conditional upstream checks;
+- preserve the upstream metric assertions; and
+- remove only its own output and checkpoints on exit.
+
+Keep the workflow schedule-only plus manual dispatch, use the shared model/data
+cache, and retain the failure notification job.

--- a/.github/workflows/nemo_rl_ci/run_grpo_qwen3_8b_lora.sh
+++ b/.github/workflows/nemo_rl_ci/run_grpo_qwen3_8b_lora.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -euo pipefail
+
+: "${BRIDGE_ROOT:?Set BRIDGE_ROOT to the mounted Megatron-Bridge checkout}"
+: "${NEMO_RL_ROOT:?Set NEMO_RL_ROOT to the pinned NeMo-RL checkout}"
+: "${EXPECTED_BRIDGE_SHA:?Set EXPECTED_BRIDGE_SHA to the tested Bridge commit}"
+: "${EXPECTED_NEMO_RL_SHA:?Set EXPECTED_NEMO_RL_SHA to the pinned NeMo-RL commit}"
+
+MCORE_ROOT="${BRIDGE_ROOT}/3rdparty/Megatron-LM"
+POLICY_PYTHON=/usr/local/bin/python-MegatronPolicyWorker
+SUITE=grpo-qwen3-8b-base-1n8g-megatron-lora
+SUITE_DIR="${NEMO_RL_ROOT}/tests/test_suites/llm"
+OUTPUT_DIR="${SUITE_DIR}/${SUITE}"
+METRICS="${OUTPUT_DIR}/metrics.json"
+
+bridge_sha=$(git -C "$BRIDGE_ROOT" rev-parse HEAD)
+mcore_sha=$(git -C "$MCORE_ROOT" rev-parse HEAD)
+nemo_rl_sha=$(git -C "$NEMO_RL_ROOT" rev-parse HEAD)
+expected_mcore_sha=$(git -C "$BRIDGE_ROOT" ls-tree HEAD 3rdparty/Megatron-LM | awk '{print $3}')
+
+test "$bridge_sha" = "$EXPECTED_BRIDGE_SHA"
+test "$mcore_sha" = "$expected_mcore_sha"
+test "$nemo_rl_sha" = "$EXPECTED_NEMO_RL_SHA"
+test -x "$POLICY_PYTHON"
+
+echo "Megatron-Bridge SHA: ${bridge_sha}"
+echo "Megatron-Core SHA: ${mcore_sha}"
+echo "NeMo-RL SHA: ${nemo_rl_sha}"
+echo "Version injection: mounted checkout through PYTHONPATH (worker venv rebuild disabled)"
+
+export NRL_FORCE_REBUILD_VENVS=false
+export PYTHONPATH="${BRIDGE_ROOT}/src:${MCORE_ROOT}:${NEMO_RL_ROOT}${PYTHONPATH:+:${PYTHONPATH}}"
+export UV_NO_SYNC=1
+export WANDB_MODE=disabled
+
+BRIDGE_ROOT="$BRIDGE_ROOT" MCORE_ROOT="$MCORE_ROOT" "$POLICY_PYTHON" - <<'PY'
+import os
+from pathlib import Path
+
+import megatron.bridge
+import megatron.core
+
+
+def assert_from_checkout(module_file: str, checkout_root: str) -> Path:
+    resolved = Path(module_file).resolve()
+    resolved.relative_to(Path(checkout_root).resolve())
+    return resolved
+
+
+bridge_file = assert_from_checkout(megatron.bridge.__file__, os.environ["BRIDGE_ROOT"])
+mcore_file = assert_from_checkout(megatron.core.__file__, os.environ["MCORE_ROOT"])
+print(f"Megatron policy worker Bridge import: {bridge_file}")
+print(f"Megatron policy worker MCore import: {mcore_file}")
+PY
+
+rm -rf "$OUTPUT_DIR"
+cleanup() {
+    rm -rf "$OUTPUT_DIR"
+}
+trap cleanup EXIT
+
+start_seconds=$SECONDS
+cd "$NEMO_RL_ROOT"
+bash "${SUITE_DIR}/${SUITE}.sh" logger.wandb_enabled=false
+runtime_seconds=$((SECONDS - start_seconds))
+
+test -s "$METRICS"
+last_step=$(jq -er '.["train/loss"] | keys | map(tonumber) | max' "$METRICS")
+if ((last_step < 20)); then
+    echo "NeMo-RL suite ended at step ${last_step}; expected step 20" >&2
+    exit 1
+fi
+
+# The upstream suite conditionally checks these only after step 20. Re-run them
+# after the unconditional step assertion so an incomplete run cannot pass.
+uv run --no-sync tests/check_metrics.py "$METRICS" \
+    'mean(data["train/gen_kl_error"], 20) < 0.002' \
+    'data["train/gen_kl_error"]["20"] < 0.002' \
+    'max(data["train/reward"]) > 0.35' \
+    'mean(data["timing/train/total_step_time"], 2) < 80'
+
+jq '{
+    final_step: (."train/loss" | keys | map(tonumber) | max),
+    final_gen_kl_error: ."train/gen_kl_error"."20",
+    max_reward: (."train/reward" | to_entries | map(.value) | max),
+    final_step_time_seconds: (."timing/train/total_step_time" | to_entries | max_by(.key | tonumber) | .value)
+}' "$METRICS"
+echo "NeMo-RL suite runtime: ${runtime_seconds} seconds"


### PR DESCRIPTION
## Summary

- add a schedule/manual-dispatch weekly 8-GPU NeMo-RL job for the existing Qwen3-8B GRPO Megatron LoRA suite
- pin the NeMo-RL source and matching prebuilt image, then inject and verify the current Bridge checkout and its MCore gitlink in the actual Megatron policy-worker environment
- require step 20 and repeat all upstream numerical, reward, and timing assertions so incomplete runs cannot pass
- document candidate selection, cache requirements, version injection, and how to add another smoke

## Verification

- Single-node 8xH100 cluster run: passed 20/20 steps using Bridge `b65283465cd06dcde1827c6b1e54ccd34195140b`, MCore `0823c731ed7d793aef047b6a64f2dbbf32bf6e2c`, and NeMo-RL `3b04247b78c69ed4c447204aad0d1e3215b0a083`
- All upstream checks passed: mean/final generation KL `0.000917`, max reward `0.433594`, mean step time `49.61s`; validation accuracy at step 20 was `0.367188`
- Suite runtime: 1,232 seconds; total allocation elapsed: 23:04
- `bash -n .github/workflows/nemo_rl_ci/run_grpo_qwen3_8b_lora.sh`
- workflow structure and internal-path/literal-secret scans
- `uv run pre-commit run --all-files`
- independent workflow/security and failure-behavior review

The workflow intentionally has only `schedule` and `workflow_dispatch` triggers. Because this is a new workflow, the exact GitHub runner/registry/cache path cannot be manually dispatched until the workflow exists on the default branch; the pinned container, selected suite, checkout injection, worker imports, and assertions were verified on the cluster before opening this PR.