### PR TITLE
fix(training): prevent VPP FLOPS metadata overcounting

### DIFF
--- a/src/megatron/bridge/models/qwen_omni/qwen3_omni_step.py
+++ b/src/megatron/bridge/models/qwen_omni/qwen3_omni_step.py
@@ -28,7 +28,7 @@ from megatron.core.utils import get_batch_on_this_cp_rank, get_model_config
 from megatron.bridge.training.losses import (
     create_masked_next_token_loss_function as _create_loss_function,
 )
-from megatron.bridge.training.utils.flop_utils import accumulate_flops_metadata
+from megatron.bridge.training.utils.flop_utils import accumulate_flops_metadata, get_model_chunk_vp_stage
 from megatron.bridge.training.utils.padding_utils import (
     pad_or_truncate_2d_to_len,
     pad_or_truncate_attn_to_len,
@@ -260,7 +260,12 @@ def forward_step(
             if grid is not None and grid.numel() > 0:
                 patches = grid.prod(dim=-1).sum()
                 num_vision_patches = patches if num_vision_patches is None else num_vision_patches + patches
-    accumulate_flops_metadata(state, tokens, num_vision_patches=num_vision_patches)
+    accumulate_flops_metadata(
+        state,
+        tokens,
+        vp_stage=get_model_chunk_vp_stage(model),
+        num_vision_patches=num_vision_patches,
+    )
 
     forward_args = {
         "input_ids": tokens,

--- a/src/megatron/bridge/models/qwen_vl/qwen3_vl_step.py
+++ b/src/megatron/bridge/models/qwen_vl/qwen3_vl_step.py
@@ -27,7 +27,7 @@ from megatron.bridge.training.losses import (
     create_masked_next_token_loss_function as _create_loss_function,
 )
 from megatron.bridge.training.state import GlobalState
-from megatron.bridge.training.utils.flop_utils import accumulate_flops_metadata
+from megatron.bridge.training.utils.flop_utils import accumulate_flops_metadata, get_model_chunk_vp_stage
 from megatron.bridge.training.utils.padding_utils import (
     pad_or_truncate_2d_to_len,
     pad_or_truncate_attn_to_len,
@@ -282,6 +282,7 @@ def forward_step(
     accumulate_flops_metadata(
         state,
         tokens,
+        vp_stage=get_model_chunk_vp_stage(model),
         cu_seqlens=getattr(packed_seq_params, "cu_seqlens_q", None) if packed_seq_params is not None else None,
         num_vision_patches=num_vision_patches,
     )

--- a/src/megatron/bridge/training/gpt_step.py
+++ b/src/megatron/bridge/training/gpt_step.py
@@ -29,7 +29,6 @@ from megatron.core.pipeline_parallel.utils import (
 from megatron.core.transformer.enums import LayerType
 from megatron.core.transformer.pipeline_parallel_layer_layout import PipelineParallelLayerLayout
 from megatron.core.utils import (
-    get_attr_wrapped_model,
     get_batch_on_this_cp_rank,
     get_model_config,
     get_pg_rank,
@@ -42,7 +41,7 @@ from megatron.bridge.training.config import ConfigContainer
 from megatron.bridge.training.losses import masked_next_token_loss
 from megatron.bridge.training.post_training.distillation import loss_func_kd
 from megatron.bridge.training.state import GlobalState
-from megatron.bridge.training.utils.flop_utils import accumulate_flops_metadata
+from megatron.bridge.training.utils.flop_utils import accumulate_flops_metadata, get_model_chunk_vp_stage
 from megatron.bridge.training.utils.packed_seq_utils import get_packed_seq_params
 from megatron.bridge.training.utils.pg_utils import get_pg_collection
 
@@ -171,15 +170,6 @@ def _current_stage_needs_mtp_inputs_from_layout(
         return is_last
 
     return _current_stage_has_mtp_from_layout(cfg, pg_collection=pg_collection, vp_stage=vp_stage)
-
-
-def _model_chunk_vp_stage(model: GPTModel) -> int | None:
-    """Return the virtual pipeline stage owned by the current model chunk."""
-    try:
-        vp_stage = get_attr_wrapped_model(model, "vp_stage", allow_none=False)
-    except RuntimeError:
-        return None
-    return vp_stage if isinstance(vp_stage, int) else None
 
 
 def _partition_packed_batch_for_cp(batch: dict[str, torch.Tensor], cp_size: int) -> dict[str, torch.Tensor]:
@@ -383,6 +373,7 @@ def _forward_step_common(
     config = get_model_config(model)
     pg_collection = get_pg_collection(model)
     use_mtp = (getattr(config, "mtp_num_layers", None) or 0) > 0
+    vp_stage = get_model_chunk_vp_stage(model)
 
     timers("batch-generator", log_level=2).start()
     with straggler_timer(bdata=True):
@@ -398,7 +389,7 @@ def _forward_step_common(
             state.cfg,
             use_mtp,
             pg_collection=pg_collection,
-            vp_stage=_model_chunk_vp_stage(model),
+            vp_stage=vp_stage,
         )
     timers("batch-generator").stop()
 
@@ -431,6 +422,7 @@ def _forward_step_common(
     accumulate_flops_metadata(
         state,
         tokens,
+        vp_stage=vp_stage,
         config_seq_len=getattr(config, "seq_length", None),
         cu_seqlens=cu_seqlens if cp_use_thd else None,
         cu_seqlens_argmin=cu_seqlens_argmin if cp_use_thd else None,

--- a/src/megatron/bridge/training/utils/flop_utils.py
+++ b/src/megatron/bridge/training/utils/flop_utils.py
@@ -20,6 +20,7 @@ from megatron.core.models.hybrid.hybrid_layer_allocation import (
     get_hybrid_layer_counts,
     parse_hybrid_pattern,
 )
+from megatron.core.utils import get_attr_wrapped_model
 
 from megatron.bridge.data.datasets.packing_utils import calculate_avg_seqlen
 from megatron.bridge.peft.lora import LoRA
@@ -28,6 +29,23 @@ from megatron.bridge.utils.vocab_utils import calculate_padded_vocab_size
 
 
 _lora_seq_stats_cache: dict = {}
+
+
+def get_model_chunk_vp_stage(model: torch.nn.Module) -> int | None:
+    """Return the virtual-pipeline stage assigned to a model chunk, if any.
+
+    Args:
+        model: Model chunk, possibly wrapped by mixed precision or DDP.
+
+    Returns:
+        The integer virtual-pipeline stage, or ``None`` for an unchunked model
+        or a model that does not expose the stage.
+    """
+    try:
+        vp_stage = get_attr_wrapped_model(model, "vp_stage", allow_none=False)
+    except RuntimeError:
+        return None
+    return vp_stage if isinstance(vp_stage, int) else None
 
 
 def _accumulator_to_int(value) -> int:
@@ -173,6 +191,7 @@ def accumulate_flops_metadata(
     state,
     tokens: torch.Tensor | None,
     *,
+    vp_stage: int | None = None,
     config_seq_len: int | None = None,
     cu_seqlens: torch.Tensor | None = None,
     cu_seqlens_argmin: torch.Tensor | None = None,
@@ -181,6 +200,11 @@ def accumulate_flops_metadata(
     num_vision_patches: int | torch.Tensor | None = None,
 ) -> None:
     """Accumulate per-microbatch FLOPS metadata onto ``state``.
+
+    Under interleaved pipeline parallelism, the forward step runs once per
+    virtual model chunk for the same logical data microbatch. Only virtual stage
+    0 contributes metadata so model chunking does not multiply the full-model
+    FLOPS estimate. ``None`` and ``0`` both represent the primary/only chunk.
 
     Writes three accumulators consumed by ``train.py`` at end of step:
 
@@ -211,7 +235,7 @@ def accumulate_flops_metadata(
     attention FLOPS by a large factor: actual attention work is Σᵢ sᵢ²,
     not (Σᵢ sᵢ)². Using ``cu_seqlens`` here closes that gap.
     """
-    if tokens is None:
+    if vp_stage not in (None, 0) or tokens is None:
         return
 
     mbs = tokens.shape[0]

--- a/src/megatron/bridge/training/vlm_step.py
+++ b/src/megatron/bridge/training/vlm_step.py
@@ -28,7 +28,7 @@ from megatron.bridge.training.losses import (
     create_masked_next_token_loss_function as _create_loss_function,
 )
 from megatron.bridge.training.state import GlobalState
-from megatron.bridge.training.utils.flop_utils import accumulate_flops_metadata
+from megatron.bridge.training.utils.flop_utils import accumulate_flops_metadata, get_model_chunk_vp_stage
 from megatron.bridge.training.utils.packed_seq_utils import get_packed_seq_params
 from megatron.bridge.training.utils.pg_utils import get_pg_collection
 
@@ -269,6 +269,7 @@ def forward_step(
     accumulate_flops_metadata(
         state,
         tokens,
+        vp_stage=get_model_chunk_vp_stage(model),
         cu_seqlens=cu_seqlens,
         cu_seqlens_unpadded=cu_seqlens_unpadded,
         num_vision_patches=num_vision_patches,

--- a/tests/unit_tests/training/test_gpt_step.py
+++ b/tests/unit_tests/training/test_gpt_step.py
@@ -548,6 +548,7 @@ class TestGetBatch:
         )
         state.timers = _NoopTimer()
         state.straggler_timer = _NoopTimer()
+        state._flops_seqlen_sum = 0
         config = type(
             "Config",
             (),
@@ -572,6 +573,7 @@ class TestGetBatch:
         assert torch.equal(inner_model.forward_kwargs["input_ids"], tokens)
         assert torch.equal(inner_model.forward_kwargs["position_ids"], position_ids)
         assert torch.equal(inner_model.forward_kwargs["labels"], labels)
+        assert state._flops_seqlen_sum == 0
 
     def test_forward_common_uses_model_chunk_vp_stage_instead_of_global_vpp_rank(self, monkeypatch):
         """The model chunk VP stage must override stale global VPP rank state."""

--- a/tests/unit_tests/training/utils/test_flop_utils.py
+++ b/tests/unit_tests/training/utils/test_flop_utils.py
@@ -2291,6 +2291,36 @@ class TestAccumulateFlopsMetadata:
         assert state._flops_seqlen_sum == 2 * 128
         assert state._flops_seqlen_sq_sum == (32**2 + 96**2) + (64**2 + 64**2)
 
+    @pytest.mark.parametrize("vp_size", [1, 2, 10])
+    def test_vpp_accumulates_each_logical_microbatch_once(self, vp_size):
+        # MCore's interleaved schedule calls forward_step once for every
+        # (logical microbatch, model chunk) pair. FLOPS metadata describes the
+        # data, not a model chunk, so only VP stage 0 may contribute it.
+        state = _State()
+        num_microbatches = 4
+        tokens = torch.zeros(1, 128)
+        cu_seqlens = torch.tensor([0, 32, 128])
+
+        for vp_stage in range(vp_size):
+            for _ in range(num_microbatches):
+                accumulate_flops_metadata(
+                    state,
+                    tokens,
+                    vp_stage=vp_stage,
+                    cu_seqlens=cu_seqlens,
+                    num_vision_patches=8,
+                )
+
+        seqlen_sum, seqlen_sq_sum, vision = resolve_global_flops_seqlen_stats(
+            state,
+            data_parallel_size=1,
+            vp_size=vp_size,
+            dp_group=None,
+        )
+        assert seqlen_sum == num_microbatches * 128
+        assert seqlen_sq_sum == num_microbatches * (32**2 + 96**2)
+        assert vision == num_microbatches * 8
+
     def test_tokens_none_is_noop(self):
         state = _State()
         accumulate_flops_metadata(state, None)


### PR DESCRIPTION
## Summary

- accumulate FLOPs sequence/vision metadata only on the primary virtual model chunk, so each logical data microbatch contributes exactly once
- preserve #4511's resolver behavior: do not blindly divide already-normalized metadata by VPP
- apply the same invariant to GPT, VLM, Qwen3-VL, and Qwen3-Omni step functions
- add VPP=1/2/10 regression coverage for dense token, THD attention, and vision metadata totals

## Regression

NeMo CI job [356425840](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/356425840) ran packed Llama 3 70B SFT with PP=8, VPP=10, CP=1, and DP=4. Stable iterations reported about 14,946 MODEL_TFLOP/s/GPU versus a 1,502.74 golden average (+894.59%, or 9.9459x) at unchanged ~1.14 s iteration time.

This regressed in #4511 (`fb039fd1`), which removed resolver-side division by VPP on the premise that the accumulators already represented one complete training step. That premise is path-dependent:

- dense GPT metadata can exist on only one boundary virtual chunk, so unconditional division undercounts it
- packed SFT exposes the same tokens and `cu_seqlens` on every virtual chunk, so the forward-step accumulator runs VPP times

MCore's interleaved schedule executes the forward step once for every `(logical microbatch, model chunk)` pair. `resolve_global_flops_seqlen_stats` runs once after the completed training step, and `training_log` consumes the cumulative per-step FLOPs delta once at each log boundary. Therefore neither resolver nor logging adds an independent VPP multiplier; they expose the per-chunk over-accumulation.

## Invariant and fix

FLOPs metadata describes the logical data microbatch, while VPP only partitions the full model into scheduled chunks. Each physical PP rank must accumulate each logical microbatch exactly once, independent of VPP size.

The accumulator now accepts the current model chunk's explicit `vp_stage`; stages other than `None`/`0` are no-ops. The stage is read through mixed-precision/DDP wrappers. This fixes packed VPP without assuming every path accumulates exactly VPP times or introducing integer division/truncation in the resolver.

Controlled schedule-table reproduction with four logical microbatches:

| VPP | forward-step calls | resolved token total before | resolved token total after |
| ---: | ---: | ---: | ---: |
| 1 | 4 | 32 (1x) | 32 (1x) |
| 2 | 8 | 64 (2x) | 32 (1x) |
| 10 | 40 | 320 (10x) | 32 (1x) |

## Validation

- `426 passed`: FLOPs, GPT step, training/logging/state, VLM, Qwen3-VL, Qwen3-Omni, and Llama performance recipe unit tests
- VPP=1/2/10 controlled reproduction in the NeMo 26.06 RC container
- `uv run --no-project -- pre-commit run --all-files`

The `--no-project` flag uses the RC container's pre-synced environment; a fresh host sync cannot install the pinned NRX wheel on the host's older manylinux baseline.

No user-facing configuration or checkpoint format changes.
