### PR TITLE
fix(model): shard MiMo-V2 conversion experts with ETP

### DIFF
--- a/examples/models/mimo_v2_flash/README.md
+++ b/examples/models/mimo_v2_flash/README.md
@@ -6,16 +6,24 @@ The HF checkpoint depends on custom modeling code, so all commands below pass `-
 
 ## Hardware Requirements
 
-MiMo-V2-Flash requires **at least 2 nodes (16 GPUs)** for inference and conversion. The full FP8 checkpoint cannot fit on a single 8-GPU node because:
+MiMo-V2-Flash requires **at least 2 nodes (16 GPUs)** for inference and conversion. Although the source checkpoint is FP8, conversion dequantizes its weights to BF16 before loading them into Megatron. The 47 MoE layers contain about 302.8B expert parameters, or about 605.6 GB in BF16, so the parallel layout must shard the target expert weights with enough headroom for the rest of the model and communication workspaces.
 
-- TEGroupedMLP workspace is proportional to `num_experts / EP`; with EP=8 on 1 node, workspace alone OOMs.
-- TP does **not** reduce expert memory — increase EP instead.
+- With `EP=8, ETP=1`, each rank holds about 75.7 GB of BF16 expert parameters before dense parameters and communication workspaces, leaving insufficient memory headroom.
+- Dense TP does **not** reduce expert memory when `ETP=1`. Set expert tensor parallelism (`--etp`) to shard each expert's matrices when using TP, or combine PP and EP so each rank holds fewer MoE layers/experts.
 - Context parallelism is **not** supported (TE backends refuse CP + learnable softmax on SWA layers).
 - TP size must be ≤ `min(num_key_value_heads, swa_num_key_value_heads)`.
 
+The conversion sweep uses layouts that keep dequantized expert parameters near 37.85 GB per GPU:
+
+| TP | PP | EP | ETP |
+|----|----|----|-----|
+| 2  | 1  | 8  | 2   |
+| 1  | 2  | 8  | 1   |
+| 2  | 2  | 4  | 2   |
+
 ## Checkpoint Conversion
 
-[slurm_conversion.sh](slurm_conversion.sh) sweeps multiple TP/PP/EP configs to verify HF ↔ Megatron round-trip conversion.
+[slurm_conversion.sh](slurm_conversion.sh) sweeps multiple TP/PP/EP/ETP configs to verify HF ↔ Megatron round-trip conversion.
 
 ### Setup
 
@@ -44,7 +52,7 @@ detected")` on any mismatch (which the wrapper turns into an `ERROR`
 line and a non-zero exit). A successful run ends with:
 
 ```
-[OK] Config 3: TP=2, PP=2, EP=4 passed
+[OK] Config 3: TP=2, PP=2, EP=4, ETP=2 passed
 
 ======================================
 All 3 configs passed

--- a/examples/models/mimo_v2_flash/slurm_conversion.sh
+++ b/examples/models/mimo_v2_flash/slurm_conversion.sh
@@ -17,11 +17,12 @@
 # MiMo-V2-Flash Conversion Round-Trip Verification (Multi-Node via Slurm)
 #
 # MiMo-V2-Flash (Hybrid attention + MoE: 256 experts, top-8, FP8 ~310GB).
-# The full model OOMs on a single 8-GPU node — minimum 2 nodes (16 GPUs)
-# with EP >= 8. Context parallelism is not supported. TP must be
-# <= min(num_key_value_heads, swa_num_key_value_heads).
+# The FP8 source weights are dequantized to BF16 during conversion. The full
+# model therefore OOMs on a single 8-GPU node — use at least 2 nodes (16 GPUs)
+# and shard expert weights with EP and ETP. Context parallelism is not
+# supported. TP must be <= min(num_key_value_heads, swa_num_key_value_heads).
 #
-# Sweeps multiple parallelism configs (TP,PP,EP) to verify HF <-> Megatron
+# Sweeps multiple parallelism configs (TP,PP,EP,ETP) to verify HF <-> Megatron
 # round-trip conversion. Each config runs sequentially.
 #
 # Usage:
@@ -52,12 +53,14 @@ WORKDIR="/opt/Megatron-Bridge"
 # export HF_HOME="/path/to/shared/HF_HOME"
 # export UV_CACHE_DIR="/path/to/shared/uv_cache"
 
-# ── Parallelism configs: "TP,PP,EP" per entry ────────────────────────────
-# TP*PP*EP must equal total GPUs (NODES * GPUS_PER_NODE).
+# ── Parallelism configs: "TP,PP,EP,ETP" per entry ────────────────────────
+# TP*PP and ETP*EP*PP must each divide total GPUs (NODES * GPUS_PER_NODE).
 # EP must divide 256 (number of experts).
+# Dense TP does not shard expert weights; ETP does. Keep ETP=TP for TP>1 in
+# this sweep so each rank holds about 38 GB of dequantized expert weights.
 # TP must be <= min(num_key_value_heads, swa_num_key_value_heads) = 4.
 # Context parallelism is not supported.
-PARALLELISM_CONFIGS=("2,1,8" "1,2,8" "2,2,4")
+PARALLELISM_CONFIGS=("2,1,8,2" "1,2,8,1" "2,2,4,2")
 
 # ── Model ─────────────────────────────────────────────────────────────────
 MODEL_NAME=MiMo-V2-Flash
@@ -91,19 +94,19 @@ fi
 
 CONFIG_INDEX=0
 for CONFIG in "${PARALLELISM_CONFIGS[@]}"; do
-    IFS=',' read -r TP PP EP <<< "$CONFIG"
+    IFS=',' read -r TP PP EP ETP <<< "$CONFIG"
     CONFIG_INDEX=$((CONFIG_INDEX + 1))
 
     echo ""
     echo "======================================"
-    echo "Config $CONFIG_INDEX/${#PARALLELISM_CONFIGS[@]}: TP=$TP, PP=$PP, EP=$EP"
+    echo "Config $CONFIG_INDEX/${#PARALLELISM_CONFIGS[@]}: TP=$TP, PP=$PP, EP=$EP, ETP=$ETP"
     echo "======================================"
 
     # Sync dependencies once per node, then run the roundtrip
     CMD="if [ \"\$SLURM_LOCALID\" -eq 0 ]; then uv sync; else sleep 10; fi && "
     CMD="${CMD}uv run --no-sync python examples/conversion/hf_megatron_roundtrip_multi_gpu.py"
     CMD="$CMD --hf-model-id $HF_MODEL_ID"
-    CMD="$CMD --tp $TP --pp $PP --ep $EP"
+    CMD="$CMD --tp $TP --pp $PP --ep $EP --etp $ETP"
     CMD="$CMD --trust-remote-code"
 
     echo "Executing: $CMD"
@@ -111,10 +114,10 @@ for CONFIG in "${PARALLELISM_CONFIGS[@]}"; do
     $SRUN_CMD bash -c "cd $WORKDIR && $CMD"
     RUN_EXIT=$?
     if [ $RUN_EXIT -ne 0 ]; then
-        echo "ERROR: Config TP=$TP, PP=$PP, EP=$EP failed (exit $RUN_EXIT)"
+        echo "ERROR: Config TP=$TP, PP=$PP, EP=$EP, ETP=$ETP failed (exit $RUN_EXIT)"
         exit $RUN_EXIT
     fi
-    echo "[OK] Config $CONFIG_INDEX: TP=$TP, PP=$PP, EP=$EP passed"
+    echo "[OK] Config $CONFIG_INDEX: TP=$TP, PP=$PP, EP=$EP, ETP=$ETP passed"
 done
 
 echo ""

--- a/tests/functional_tests/test_groups/models/mimo_v2_flash/test_mimo_v2_flash_conversion.py
+++ b/tests/functional_tests/test_groups/models/mimo_v2_flash/test_mimo_v2_flash_conversion.py
@@ -222,15 +222,18 @@ class TestMiMoV2FlashConversion:
 
     @pytest.mark.run_only_on("GPU")
     @pytest.mark.parametrize(
-        "tp,pp,ep,test_name",
+        "tp,pp,ep,etp,test_name",
         [
-            (2, 1, 1, "TP"),
-            (1, 2, 1, "PP"),
-            (1, 1, 2, "EP"),
+            (2, 1, 1, 1, "TP"),
+            (1, 2, 1, 1, "PP"),
+            (1, 1, 2, 1, "EP"),
+            (1, 1, 1, 2, "ETP"),
         ],
     )
-    def test_mimo_v2_flash_conversion_parallelism(self, mimo_v2_flash_toy_model_path, tmp_path, tp, pp, ep, test_name):
-        """Round-trip conversion (HF → Megatron → HF) under TP / PP / EP."""
+    def test_mimo_v2_flash_conversion_parallelism(
+        self, mimo_v2_flash_toy_model_path, tmp_path, tp, pp, ep, etp, test_name
+    ):
+        """Round-trip conversion (HF → Megatron → HF) under TP / PP / EP / ETP."""
         test_output_dir = tmp_path / f"mimo_v2_flash_{test_name}"
         test_output_dir.mkdir(exist_ok=True)
 
@@ -258,6 +261,8 @@ class TestMiMoV2FlashConversion:
             str(pp),
             "--ep",
             str(ep),
+            "--etp",
+            str(etp),
             "--trust-remote-code",
         ]
 
@@ -267,6 +272,8 @@ class TestMiMoV2FlashConversion:
             print(f"STDOUT: {result.stdout}")
             print(f"STDERR: {result.stderr}")
             pytest.fail(f"MiMo-V2-Flash {test_name} conversion failed with return code {result.returncode}")
+
+        assert f"Expert tensor parallel size: {etp}" in result.stdout
 
         model_name = Path(mimo_v2_flash_toy_model_path).name
         converted_dir = test_output_dir / model_name


### PR DESCRIPTION
## Summary

- make expert tensor parallelism explicit in the MiMo-V2-Flash conversion sweep
- document why the FP8 source checkpoint needs additional expert sharding after conversion dequantizes weights to BF16
- add an isolated TP=1/ETP=2 round-trip regression case and assert the effective ETP setting

The unchanged example on `main` used implicit `ETP=1`. With the full `XiaomiMiMo/MiMo-V2-Flash` checkpoint on 2 nodes / 16 H100 80GB GPUs, each rank had about 75.7 GB of BF16 expert parameters before dense parameters and communication workspace. The failure surfaced while broadcasting the first replicated parameter (`model.norm.weight`, shape 4096, BF16, about 8 KiB), when each rank already had about 82.62 GB allocated and only about 357 MB free. No complete expert tensor was being materialized or broadcast; the documented parallel layout lacked memory headroom.

The corrected sweep keeps expert parameters near 37.85 GB per GPU:

- TP=2, PP=1, EP=8, ETP=2
- TP=1, PP=2, EP=8, ETP=1
- TP=2, PP=2, EP=4, ETP=2

Related: NVBug 6270147

## Validation

Base revisions:

- Megatron Bridge: `b7b4e11b054e73fa3cfc52e5df14cd6b4d50e02e`
- Megatron Core: `0823c731ed7d793aef047b6a64f2dbbf32bf6e2c`

Real-model validation on 2 nodes / 16 H100 80GB GPUs:

- reproduced the unchanged TP=2/PP=1/EP=8/ETP=1 conversion OOM with the full public checkpoint
- completed the full HF -> Megatron -> HF round-trip comparison and checkpoint save for all three corrected layouts above
- completed unchanged real-model text generation with TP=1/PP=1/EP=16 and 100 requested new tokens

Focused validation:

- `uv run python -m pytest tests/unit_tests/models/mimo_v2_flash/test_mimo_v2_flash_bridge.py -v` (26 passed)
- focused 2-GPU MiMo-V2-Flash TP/PP/EP/ETP functional round trips (4 passed)
- `uv run pre-commit run --all-files` (passed)
