### PR TITLE
[model] fix: preserve Step KV cache amax mappings

### DIFF
--- a/src/megatron/bridge/models/conversion/quant_mapping.py
+++ b/src/megatron/bridge/models/conversion/quant_mapping.py
@@ -16,7 +16,12 @@ import re
 
 import torch
 
-from megatron.bridge.models.conversion.param_mapping import MegatronParamMapping, QKVMapping, ReplicatedMapping
+from megatron.bridge.models.conversion.param_mapping import (
+    MegatronParamMapping,
+    QKVGMapping,
+    QKVMapping,
+    ReplicatedMapping,
+)
 
 
 class AmaxMapping(ReplicatedMapping):
@@ -277,7 +282,7 @@ def derive_kv_bmm_amax_map(mappings: list[MegatronParamMapping]) -> list[Megatro
     derived_mappings = []
 
     for mapping in mappings:
-        if not isinstance(mapping, QKVMapping):
+        if not isinstance(mapping, (QKVGMapping, QKVMapping)):
             continue
         if mapping.allow_hf_name_mismatch:
             # Shared/tied-KV bridges may intentionally omit an HF projection.

--- a/tests/unit_tests/models/test_quant_mapping.py
+++ b/tests/unit_tests/models/test_quant_mapping.py
@@ -25,6 +25,7 @@ from megatron.bridge.models.conversion.param_mapping import (
     AutoMapping,
     ConcatenatedQKVMapping,
     GatedMLPMapping,
+    QKVGMapping,
     QKVMapping,
     ReplicatedMapping,
 )
@@ -115,6 +116,28 @@ class TestDeriveKvBmmAmaxMap:
             ),
         ]
         assert all(isinstance(mapping, AmaxMapping) for mapping in result)
+
+    def test_derives_kv_bmm_amax_mappings_from_step_qkvg_mapping(self):
+        mapping = QKVGMapping(
+            megatron_param="decoder.layers.*.self_attention.linear_qkv.weight",
+            q="model.layers.*.self_attn.q_proj.weight",
+            k="model.layers.*.self_attn.k_proj.weight",
+            v="model.layers.*.self_attn.v_proj.weight",
+            g="model.layers.*.self_attn.g_proj.weight",
+        )
+
+        result = derive_kv_bmm_amax_map([mapping])
+
+        assert [(m.megatron_param, m.hf_param) for m in result] == [
+            (
+                "decoder.layers.*.self_attention.core_attention.k_bmm_quantizer._amax",
+                "model.layers.*.self_attn.k_bmm_quantizer._amax",
+            ),
+            (
+                "decoder.layers.*.self_attention.core_attention.v_bmm_quantizer._amax",
+                "model.layers.*.self_attn.v_bmm_quantizer._amax",
+            ),
+        ]
 
     def test_preserves_wildcards_and_language_model_prefixes(self):
         mapping = QKVMapping(


### PR DESCRIPTION
## Summary

- derive ModelOpt K/V BMM amax mappings for `QKVGMapping` as well as `QKVMapping`
- preserve calibrated KV-cache state when exporting Step-3.5/3.7 QARL checkpoints
- add focused regression coverage for the production Step QKVG naming contract

## Problem

Step-3.5 and Step-3.7 use `QKVGMapping` for their main attention projections. ModelOpt's supported Step configuration enables persistent K/V BMM quantizer `_amax` buffers, but Bridge derived those semantic mappings only from `QKVMapping`. As a result, conversion-task lookup skipped the Step K/V buffers and `modelopt_weights.pt` omitted their calibrated state.

## Fix

Treat `QKVGMapping` as an eligible fused attention mapping in the existing K/V BMM derivation. The existing q/k/v parent validation and draft/MTP exclusions remain unchanged; the extra gate projection is not exported as a cache quantizer.

## Validation

Fail before / pass after:

```text
uv run python -m pytest tests/unit_tests/models/test_quant_mapping.py::TestDeriveKvBmmAmaxMap::test_derives_kv_bmm_amax_mappings_from_step_qkvg_mapping -q
before: 1 failed (derived mapping list was empty)
after:  1 passed
```

Adjacent coverage:

```text
uv run python -m pytest tests/unit_tests/models/test_quant_mapping.py tests/unit_tests/models/stepfun/test_step35_bridge.py tests/unit_tests/models/stepfun/test_step35_provider.py -q
135 passed
```

```text
git diff --check
passed

uv run pre-commit run --all-files
passed
```

## Scope

This changes only semantic mapping derivation and unit coverage. It does not change QKVG tensor layout, quantizer numerics, draft/MTP exclusions, distributed collectives, model quality, convergence, or performance.

