### PR TITLE
[ckpt] fix: Refresh tracker state across in-process restarts

### DIFF
--- a/src/megatron/bridge/training/state.py
+++ b/src/megatron/bridge/training/state.py
@@ -471,6 +471,11 @@ class GlobalState:
         This cleans up all stateful components that need to be reinitialized between restart iterations.
         The async calls queue for checkpointing is handled separately in aborting in order to clean up persistent workers.
         """
+        from megatron.bridge.training.utils.checkpoint_utils import read_train_state
+
+        # The top-level tracker is overwritten after every checkpoint. A restart must
+        # not reuse the iteration cached by an earlier invocation in this process.
+        read_train_state.cache_clear()
         self._timers = None
         self._train_state = None
         self._tensorboard_logger = None

--- a/tests/unit_tests/training/test_checkpointing.py
+++ b/tests/unit_tests/training/test_checkpointing.py
@@ -2827,6 +2827,21 @@ class TestGetTrainStateFromStateDict:
 class TestCheckpointIterationResolution:
     """Test checkpoint iteration resolution logic."""
 
+    def test_inprocess_restart_refreshes_mutable_bridge_tracker(self, tmp_path):
+        """Restart teardown must invalidate a cached tracker overwritten by a later save."""
+        from megatron.bridge.training.checkpointing import _resolve_checkpoint_iteration
+
+        tracker = get_checkpoint_train_state_filename(str(tmp_path), prefix="latest")
+        first_state = TrainState(step=5)
+        torch.save(first_state.state_dict(), tracker)
+        assert _resolve_checkpoint_iteration(str(tmp_path), None) == (5, False)
+
+        latest_state = TrainState(step=10)
+        torch.save(latest_state.state_dict(), tracker)
+        GlobalState().reset_for_restart()
+
+        assert _resolve_checkpoint_iteration(str(tmp_path), None) == (10, False)
+
     @patch("megatron.bridge.training.checkpointing.file_exists")
     @patch("megatron.bridge.training.checkpointing.read_train_state")
     def test_loads_from_bridge_tracker(self, mock_read_train_state, mock_file_exists):


### PR DESCRIPTION
## Problem

In-process restart retries the training function in the same interpreter. The ordinary resume path reads the mutable `latest_train_state.pt` tracker through a filename-keyed cache, but restart teardown did not invalidate that cache.

After one retry loads checkpoint N, training can publish checkpoint M at the same tracker path. A later retry would still select N. That silently rolls training back, or fails recovery when retention has already removed N.

## Root cause and fix

`read_train_state()` caches by path, while `GlobalState.reset_for_restart()` resets runtime state without clearing that process-global cache.

Clear the train-state reader cache at the all-rank restart boundary. This preserves caching during a training invocation and ensures every retry re-reads the latest tracker. A focused regression test overwrites the tracker between two resolutions and exercises production restart teardown.

## Validation

Fail-before / pass-after:

```text
uv run python -m pytest tests/unit_tests/training/test_checkpointing.py::TestCheckpointIterationResolution::test_inprocess_restart_refreshes_mutable_bridge_tracker -q
```

- Before: failed because the second resolution returned step 5 instead of step 10.
- After: 1 passed.

Adjacent unit coverage:

```text
uv run python -m pytest \
  tests/unit_tests/training/test_checkpointing.py \
  tests/unit_tests/training/test_state.py \
  tests/unit_tests/training/utils/test_checkpoint_utils.py -q
```

- 244 passed in the focused compatible environment; four unrelated environment-specific selectors were excluded.
- An approved container environment additionally passed 83 focused checkpoint/restart/state unit tests.

Two-rank integration:

```text
uv run ft_launcher \
  --rdzv_backend=c10d --rdzv_endpoint=127.0.0.1:29500 \
  --nnodes=1 --nproc-per-node=2 --max-restarts=3 \
  -m pytest -q -s -x -m "not pleasefixme" --tb=short \
  tests/functional_tests/test_groups/training/test_inprocess_restart.py::TestInProcessRestartIntegration::test_inprocess_restart_integration
```

- Passed on both ranks; launcher exited successfully.

Static checks:

```text
git diff --check
uv run pre-commit run --all-files
```

- Both passed.

## Scope

This changes only in-process restart teardown. It does not alter checkpoint serialization, tracker format, retention policy, or general NVRx retry behavior. The focused regression deterministically covers stale tracker selection; the existing two-rank functional selector validates the surrounding restart/training path without fault injection. The full test suite was not run.
