### PR TITLE
[diffusion] fix: preserve LLaDA batch positions

### DIFF
--- a/examples/models/diffusion/inference_dllm.py
+++ b/examples/models/diffusion/inference_dllm.py
@@ -213,13 +213,13 @@ def parse_args():
     return p.parse_args()
 
 
-def _encode_prompts(tokenizer, prompts, use_chat_template):
+def _encode_prompts(tokenizer, prompts, use_chat_template, model):
     """Tokenize prompts, optionally wrapping each in the tokenizer's chat template.
 
-    Uses **right**-padding: Megatron applies RoPE by absolute sequence index and
-    ignores ``position_ids``, so the first real token must sit at index 0. Left-
-    padding would shift every prompt token's RoPE phase and corrupt generation.
-    The trailing pad positions are blocked by the key-padding mask in the loop.
+    LLaDA uses **left**-padding because Megatron applies RoPE by physical sequence
+    index. This shifts a short prompt and its generated suffix together, preserving
+    their relative positions; right-padding would insert a positional gap. Other
+    adapters retain their existing right-padding behavior.
     """
     if use_chat_template and getattr(tokenizer, "chat_template", None):
         texts = [
@@ -228,7 +228,8 @@ def _encode_prompts(tokenizer, prompts, use_chat_template):
         ]
     else:
         texts = prompts
-    return tokenizer(texts, return_tensors="pt", padding=True, padding_side="right")
+    padding_side = "left" if model == "llada15" else "right"
+    return tokenizer(texts, return_tensors="pt", padding=True, padding_side=padding_side)
 
 
 def main():
@@ -276,7 +277,12 @@ def main():
 
     model = adapter["load"](args)
 
-    inputs = _encode_prompts(tokenizer, args.prompts, use_chat_template=not args.no_chat_template)
+    inputs = _encode_prompts(
+        tokenizer,
+        args.prompts,
+        use_chat_template=not args.no_chat_template,
+        model=args.model,
+    )
     prompt_ids = inputs.input_ids.cuda()
     prompt_len = prompt_ids.shape[1]
 

--- a/tests/unit_tests/examples/test_inference_dllm.py
+++ b/tests/unit_tests/examples/test_inference_dllm.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the unified diffusion inference CLI."""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+_CLI_PATH = _REPO_ROOT / "examples" / "models" / "diffusion" / "inference_dllm.py"
+_PAD_TOKEN_ID = 0
+_PROMPT_TOKEN_IDS = {
+    "short": [11, 12],
+    "long": [21, 22, 23, 24],
+}
+
+
+@pytest.fixture(scope="module")
+def cli():
+    """Load the example CLI as a module under a stable test name."""
+    spec = importlib.util.spec_from_file_location("inference_dllm_under_test", _CLI_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    try:
+        spec.loader.exec_module(module)
+        yield module
+    finally:
+        sys.modules.pop(spec.name, None)
+
+
+class _FakeTokenizer:
+    chat_template = None
+
+    def __call__(self, texts, *, return_tensors, padding, padding_side):
+        assert return_tensors == "pt"
+        assert padding is True
+        width = max(len(_PROMPT_TOKEN_IDS[text]) for text in texts)
+        rows = []
+        for text in texts:
+            token_ids = _PROMPT_TOKEN_IDS[text]
+            pads = [_PAD_TOKEN_ID] * (width - len(token_ids))
+            rows.append(pads + token_ids if padding_side == "left" else token_ids + pads)
+        return SimpleNamespace(input_ids=rows)
+
+
+def _distance_from_last_prompt_token_to_generation(row):
+    last_prompt_index = max(index for index, token_id in enumerate(row) if token_id != _PAD_TOKEN_ID)
+    generation_start = len(row)
+    return generation_start - last_prompt_index
+
+
+def test_mixed_length_batch_preserves_prompt_to_generation_distance(cli):
+    tokenizer = _FakeTokenizer()
+    short_alone = cli._encode_prompts(tokenizer, ["short"], use_chat_template=False, model="llada15").input_ids[0]
+    batched = cli._encode_prompts(
+        tokenizer,
+        ["short", "long"],
+        use_chat_template=False,
+        model="llada15",
+    ).input_ids
+
+    standalone_distance = _distance_from_last_prompt_token_to_generation(short_alone)
+    assert standalone_distance == 1
+    assert _distance_from_last_prompt_token_to_generation(batched[0]) == standalone_distance
+    assert _distance_from_last_prompt_token_to_generation(batched[1]) == standalone_distance
+
+
+def test_nemotron_retains_right_padding(cli):
+    batched = cli._encode_prompts(
+        _FakeTokenizer(),
+        ["short", "long"],
+        use_chat_template=False,
+        model="nemotron_labs_diffusion",
+    ).input_ids
+
+    assert batched[0] == [11, 12, _PAD_TOKEN_ID, _PAD_TOKEN_ID]
+    assert batched[1] == _PROMPT_TOKEN_IDS["long"]


### PR DESCRIPTION
## Summary

- left-pad mixed-length prompts only for the unified LLaDA inference adapter
- preserve prompt-to-generation RoPE distances when a short prompt is batched with a longer peer
- retain existing right-padding behavior for Nemotron and cover it with a negative control

## Supported trigger and impact

Passing repeated, unequal-length `--prompts` to `examples/models/diffusion/inference_dllm.py` previously right-padded the LLaDA batch. The generated suffix always starts after the batch-wide prompt width, while the short row's real tokens stayed at positions starting from zero. Pinned MCore applies standard RoPE by physical sequence index, and the padding mask only blocks padded keys, so this inserted an artificial prompt-to-generation gap and silently made greedy output depend on the longer batch peer.

Left padding shifts the short prompt and its generated suffix together, preserving their relative RoPE distances. The existing key-padding mask continues to block the leading pad tokens. Padding selection is scoped to `llada15`; other adapters keep their previous layout.

## Validation

Fail before:

```text
uv run --no-sync python -m pytest tests/unit_tests/examples/test_inference_dllm.py -q
1 failed: short-row distance was 3 when batched versus 1 standalone
```

Pass after:

```text
uv run --no-sync python -m pytest tests/unit_tests/examples/test_inference_dllm.py -q
2 passed

uv run --no-sync python -m pytest \
  tests/unit_tests/examples/test_inference_dllm.py \
  tests/unit_tests/diffusion/model/llada15/test_inference.py \
  tests/unit_tests/diffusion/common/test_dllm.py -q
35 passed

uv run --no-sync pre-commit run --all-files
all hooks passed

git diff --check
passed
```

## Scope

This changes only unified-CLI prompt layout selection and its regression tests. It does not change model weights, the diffusion sampler, public API signatures, distributed behavior, dependencies, or existing Nemotron padding. No GPU, convergence, quality, or performance claim is made.
