### PR TITLE
[recipe, docs] fix: Update DeepSeek V3 pretraining example

### DIFF
--- a/docs/fern/versions/nightly/pages/models/deepseek/deepseek-v3.mdx
+++ b/docs/fern/versions/nightly/pages/models/deepseek/deepseek-v3.mdx
@@ -115,18 +115,23 @@ See: [bridge.recipes.deepseek.deepseek_v3](../../apidocs/bridge/bridge.recipes.d
 ```python
 from megatron.bridge.recipes.deepseek import deepseek_v3_pretrain_config
 
-config = deepseek_v3_pretrain_config(
-    name="deepseek_v3_pretrain",
-    data_paths=["/path/to/dataset.nvjsonl"],
-    dir="/results/deepseek_v3",
-    train_iters=500_000,
-    global_batch_size=4096,
-    seq_length=4096,
-    # MTP configuration
-    mtp_num_layers=1,
-    mtp_loss_scaling_factor=0.1,
-    # Uses TP=2, PP=16, EP=64 (1024 GPUs, 128 nodes) automatically
-)
+config = deepseek_v3_pretrain_config()
+
+# Point to a preprocessed GPT dataset and choose output directories.
+config.dataset.blend = [["/path/to/dataset_text_document"], None]
+config.checkpoint.save = "/results/deepseek_v3/checkpoints"
+config.checkpoint.load = "/results/deepseek_v3/checkpoints"
+config.logger.tensorboard_dir = "/results/deepseek_v3/tb_logs"
+
+# Customize training values after constructing the parameterless recipe.
+config.train.train_iters = 500_000
+config.train.global_batch_size = 4096
+config.model.seq_length = 4096
+config.dataset.seq_length = 4096
+config.model.mtp_num_layers = 1
+config.model.mtp_loss_scaling_factor = 0.1
+
+# The recipe uses TP=2, PP=16, EP=64 (1024 GPUs, 128 nodes) automatically.
 ```
 
 To place the MTP layer in a standalone PP/VPP stage instead of colocating it with loss, rebuild the recipe layout:

--- a/docs/models/deepseek/deepseek-v3.md
+++ b/docs/models/deepseek/deepseek-v3.md
@@ -115,18 +115,23 @@ See: [bridge.recipes.deepseek.deepseek_v3](../../apidocs/bridge/bridge.recipes.d
 ```python
 from megatron.bridge.recipes.deepseek import deepseek_v3_pretrain_config
 
-config = deepseek_v3_pretrain_config(
-    name="deepseek_v3_pretrain",
-    data_paths=["/path/to/dataset.nvjsonl"],
-    dir="/results/deepseek_v3",
-    train_iters=500_000,
-    global_batch_size=4096,
-    seq_length=4096,
-    # MTP configuration
-    mtp_num_layers=1,
-    mtp_loss_scaling_factor=0.1,
-    # Uses TP=2, PP=16, EP=64 (1024 GPUs, 128 nodes) automatically
-)
+config = deepseek_v3_pretrain_config()
+
+# Point to a preprocessed GPT dataset and choose output directories.
+config.dataset.blend = [["/path/to/dataset_text_document"], None]
+config.checkpoint.save = "/results/deepseek_v3/checkpoints"
+config.checkpoint.load = "/results/deepseek_v3/checkpoints"
+config.logger.tensorboard_dir = "/results/deepseek_v3/tb_logs"
+
+# Customize training values after constructing the parameterless recipe.
+config.train.train_iters = 500_000
+config.train.global_batch_size = 4096
+config.model.seq_length = 4096
+config.dataset.seq_length = 4096
+config.model.mtp_num_layers = 1
+config.model.mtp_loss_scaling_factor = 0.1
+
+# The recipe uses TP=2, PP=16, EP=64 (1024 GPUs, 128 nodes) automatically.
 ```
 
 To place the MTP layer in a standalone PP/VPP stage instead of colocating it with loss, rebuild the recipe layout:


### PR DESCRIPTION
## Summary

Update the DeepSeek V3 pretraining example to use the current parameterless recipe API and hierarchical `ConfigContainer` overrides.

## Supported trigger and impact

Copying the Python example from the current DeepSeek V3 model guide fails before returning a config:

```text
TypeError: deepseek_v3_pretrain_1024gpu_h100_bf16_config() got an unexpected keyword argument 'name'
```

The public compatibility name now aliases a parameterless H100 recipe function. The canonical and nightly examples still passed the legacy `name`, `data_paths`, `dir`, and training keywords directly, so users could not construct the documented config or start training.

## Root cause and fix

The H100 recipe namespace refactor made library recipes parameterless, but the DeepSeek V3 model page and its Fern nightly mirror retained the former constructor contract.

The examples now:

- call the recipe without arguments;
- set the preprocessed GPT dataset prefix through `config.dataset.blend`;
- set checkpoint and TensorBoard output paths on their current sub-configs;
- set training and MTP values on their owning sub-configs; and
- keep `config.model.seq_length` and `config.dataset.seq_length` synchronized.

## Verification

Focused deterministic docs executor, unchanged before and after the fix:

```bash
uv run --active --no-sync python reproduce_documented_example.py \
  docs/models/deepseek/deepseek-v3.md
```

- Before: exit 1 on the unexpected `name` keyword, before model access.
- After: exit 0; the example returns a `ConfigContainer` with the documented dataset, output, iteration, batch, sequence, and MTP values.
- The same after-fix command against `docs/fern/versions/nightly/pages/models/deepseek/deepseek-v3.mdx` exits 0.

Adjacent tests:

```bash
uv run --active --no-sync python -m pytest \
  tests/unit_tests/recipes/test_deepseek_recipes.py -q
```

Result: 33 passed.

Additional gates:

```text
git diff --check                                           passed
uv run --active --no-sync pre-commit run --all-files       passed
```

## Scope

Documentation only. No recipe implementation, public API, dependency, workflow, generated lockfile, GPU behavior, convergence, or performance claim is changed. No GPU, distributed, or full-suite test was run.
