### PR TITLE
[training] fix: allow W&B logging without checkpointing

### DIFF
--- a/src/megatron/bridge/training/state.py
+++ b/src/megatron/bridge/training/state.py
@@ -200,7 +200,9 @@ class GlobalState:
 
                 import wandb
 
-                save_dir = self.cfg.logger.wandb_save_dir or os.path.join(self.cfg.checkpoint.save, "wandb")
+                save_dir = self.cfg.logger.wandb_save_dir
+                if not save_dir:
+                    save_dir = os.path.join(self.cfg.checkpoint.save, "wandb") if self.cfg.checkpoint.save else None
 
                 config_dict = self.cfg.to_dict()
                 sanitized_config = json.loads(json.dumps(config_dict, default=safe_serialize))

--- a/tests/unit_tests/training/test_state.py
+++ b/tests/unit_tests/training/test_state.py
@@ -409,6 +409,42 @@ class TestGlobalState:
             assert logger == mock_wandb
             assert state._wandb_logger == mock_wandb
 
+    def test_wandb_logger_uses_default_dir_without_checkpointing(self):
+        """Test wandb logger without an explicit local or checkpoint directory."""
+        state = GlobalState()
+        mock_config = MagicMock()
+        mock_config.logger.wandb_project = "test_project"
+        mock_config.logger.wandb_exp_name = "test_experiment"
+        mock_config.logger.wandb_save_dir = None
+        mock_config.logger.wandb_entity = "test_entity"
+        mock_config.checkpoint.save = None
+        mock_config.to_dict.return_value = {"config": "data"}
+        state._cfg = mock_config
+
+        mock_wandb = MagicMock()
+
+        with (
+            patch("megatron.bridge.training.state.get_rank_safe", return_value=3),
+            patch("megatron.bridge.training.state.get_world_size_safe", return_value=4),
+            patch(
+                "builtins.__import__",
+                side_effect=lambda name, *args, **kwargs: (
+                    mock_wandb if name == "wandb" else __import__(name, *args, **kwargs)
+                ),
+            ),
+        ):
+            logger = state.wandb_logger
+
+            mock_wandb.init.assert_called_once_with(
+                dir=None,
+                name="test_experiment",
+                project="test_project",
+                config={"config": "data"},
+                entity="test_entity",
+            )
+            assert logger == mock_wandb
+            assert state._wandb_logger == mock_wandb
+
     def test_wandb_logger_property_missing_experiment_name(self):
         """Test wandb logger raises error when experiment name is empty."""
         state = GlobalState()


### PR DESCRIPTION
## What changed

Allow W&B logging to initialize when checkpoint saving is disabled and no explicit `logger.wandb_save_dir` is configured.

## User impact and trigger

`logger.wandb_save_dir` and `checkpoint.save` are both optional. A supported training configuration that enabled W&B with a project and experiment name, left `wandb_save_dir` unset, and disabled checkpoint saving crashed during setup on the last rank:

```text
TypeError: expected str, bytes or os.PathLike object, not NoneType
```

## Root cause

`GlobalState.wandb_logger` always derived a fallback with `os.path.join(checkpoint.save, "wandb")`. When both optional directories were unset, that expression received `None` before `wandb.init` could use its own default directory.

## Fix

Keep the explicit W&B directory when provided, keep the checkpoint-derived `wandb` directory when checkpoint saving is configured, and otherwise pass `dir=None` to W&B so its documented default applies.

## Validation

Fail before, pass after:

```bash
uv run --no-sync python -m pytest tests/unit_tests/training/test_state.py::TestGlobalState::test_wandb_logger_uses_default_dir_without_checkpointing -q
```

- Before: 1 failed at `os.path.join(None, "wandb")`.
- After: 1 passed.

Adjacent coverage:

```bash
uv run --no-sync python -m pytest tests/unit_tests/training/test_state.py -q
uv run --no-sync pre-commit run --all-files
git diff --check
```

- State/logger tests: 67 passed.
- Pre-commit: passed.
- Diff check: passed.

## Scope

This changes only W&B local-directory selection. Explicit W&B directories and checkpoint-derived directories retain their existing behavior. No GPU, distributed math, checkpoint format, dependency, CI workflow, or public API behavior was changed.
