### PR TITLE
fix(perf): wire PreemptionPlugin for long-convergence runs

### DIFF
--- a/scripts/performance/argument_parser.py
+++ b/scripts/performance/argument_parser.py
@@ -441,6 +441,19 @@ def parse_cli_args():
         default="00:30:00",
     )
     slurm_args.add_argument(
+        "--preempt_time",
+        type=int,
+        help=" ".join(
+            [
+                "For long-convergence runs only: seconds before the Slurm time limit at which to send",
+                "SIGTERM so the training loop can save a checkpoint and exit gracefully before the hard",
+                "walltime kill, letting the next slice resume from it. Must exceed the checkpoint flush",
+                "time. Defaults to 60.",
+            ]
+        ),
+        default=60,
+    )
+    slurm_args.add_argument(
         "-gn",
         "--gpus_per_node",
         type=int,

--- a/scripts/performance/setup_experiment.py
+++ b/scripts/performance/setup_experiment.py
@@ -46,6 +46,9 @@ try:
 except (ImportError, ModuleNotFoundError):
     HAVE_WANDB = False
 
+from megatron.bridge.recipes.run_plugins import PreemptionPlugin
+
+
 try:
     from perf_plugins import NsysPlugin, PerfEnvPlugin, PyTorchProfilerPlugin
 except (ImportError, ModuleNotFoundError):
@@ -452,6 +455,7 @@ def main(
     save_dir: Optional[str],
     num_gpus: int,
     is_long_convergence_run: bool,
+    preempt_time: int,
     additional_slurm_params: Optional[Dict[str, Any]],
     enable_pct_binding: bool,
     golden_values_path: str,
@@ -660,6 +664,15 @@ def main(
         )
 
     plugins = []
+
+    # Long-convergence runs are split across walltime slices and resume from the last
+    # checkpoint each slice. Without a preemption signal, Slurm hard-kills the slice at
+    # the time limit before a checkpoint is written, so no progress persists and the
+    # resume loop stalls. The PreemptionPlugin sends SIGTERM `preempt_time` seconds
+    # before the limit and enables the training exit handler, so each slice saves and
+    # exits gracefully and the next slice resumes from it (inert off Slurm).
+    if is_long_convergence_run:
+        plugins.append(PreemptionPlugin(preempt_time=preempt_time, enable_exit_handler=True))
 
     # CSP fabric plugins (Kubeflow only; inert on Slurm via their isinstance guard):
     # aws -> EKSEnvPlugin (EFA), gcp -> GKEEnvPlugin (gIB). Networking/fabric only;
@@ -1006,6 +1019,7 @@ if __name__ == "__main__":
         save_dir=args.save_dir,
         num_gpus=args.num_gpus,
         is_long_convergence_run=args.is_long_convergence_run,
+        preempt_time=args.preempt_time,
         additional_slurm_params=args.additional_slurm_params,
         enable_pct_binding=args.enable_pct_binding,
         golden_values_path=args.golden_values_path,


### PR DESCRIPTION
# fix(perf): wire PreemptionPlugin for long-convergence runs

## Background / motivation

- Long-convergence perf runs (`--is_long_convergence_run`) are **split across Slurm walltime slices**: the launcher (`setup_experiment.py`) runs an outer resubmit loop — launch a slice, let Slurm cancel it at `TIME_LIMIT`, resume from the last checkpoint, relaunch — until `MAX_STEPS` is reached.
- This only works if **each slice persists its progress before it dies**. It didn't: the launcher never enabled a preemption signal, so Slurm **hard-killed** each slice at the time limit (`*** CANCELLED … DUE TO TIME LIMIT ***`) with no graceful save. The only checkpoints written were the periodic `save_interval` ones.
- When a slice completes fewer than `save_interval` steps (short walltime + startup/ckpt-load overhead), it **never crosses the next save boundary** → no new checkpoint → the next slice resumes from the *same* iteration. Net progress = 0. The forward-progress guard in the loop then correctly detects the stall, burns the `max_retries` budget, and raises `Megatron-Bridge CI test job failed`.
- Observed on the `wan_1_3b_text2image` 128-GPU H100 long-convergence nightly (short per-slice walltime, `save_interval=10`).

The graceful-preemption mechanism already exists in the library (`PreemptionPlugin` → `train.exit_signal_handler` → save-on-SIGTERM in `training/train.py`); it was simply **never wired into the performance launcher**.

## What changed

- `setup_experiment.py`: append `PreemptionPlugin(preempt_time=…, enable_exit_handler=True)` to the plugin list when `is_long_convergence_run`.
- `argument_parser.py`: new `--preempt_time` (int seconds, default `60`) to size the SIGTERM lead time.

## Details

- `PreemptionPlugin` (`src/megatron/bridge/recipes/run_plugins.py`) does two things for a Slurm `run.Script` task:
  - sets `executor.signal = "TERM@{preempt_time}"` → Slurm sends **SIGTERM `preempt_time`s before** the walltime;
  - injects `train.exit_signal_handler=True` → the training loop (`training/train.py`) catches SIGTERM, **saves a checkpoint at the current iteration**, and exits cleanly (`save_checkpoint_and_time(...)` then `"exiting program after receiving SIGTERM."`).
- Gated on `is_long_convergence_run`; the plugin is **inert off Slurm** (the `executor.signal` step is `SlurmExecutor`-only via its own `isinstance` guard), so single-slice runs are unaffected.
- `--preempt_time` **must exceed the checkpoint flush time** for the model/topology, and it eats into each slice's training budget — hence configurable rather than hard-coded (60s default matches the plugin default; bump for larger dist-checkpoints).

```mermaid
flowchart LR
    subgraph before["Before — hard kill, no save"]
        A1[train slice] --> A2[SLURM hard-kill\nat TIME_LIMIT]
        A2 --> A3[no ckpt written\nif slice < save_interval]
        A3 --> A4[resume from same iter\n→ stall → raise]
        A4 --> A1
    end
    subgraph after["After — SIGTERM save"]
        B1[train slice] --> B2[SIGTERM\npreempt_time before limit]
        B2 --> B3[exit_signal_handler:\nsave ckpt + exit]
        B3 --> B4[resume from new iter\n→ progress]
        B4 -->|until MAX_STEPS| B1
    end
```

Example — a long-convergence perf run now graceful-saves each slice:

```sh
# scripts/performance/setup_experiment.py (excerpt)
python -m scripts.performance.setup_experiment \
    ... \
    --is_long_convergence_run \
    --time_limit 00:15:00 \
    --preempt_time 120        # SIGTERM 2 min before the 15 min walltime → save + resume
```

## Tested

- `ruff@0.9.9 format` + `ruff check` — clean on both files (import sort auto-fixed).
- `python -m py_compile` — both files parse.
- Verified the SIGTERM path **saves** (not just exits): `training/train.py` calls `save_checkpoint_and_time(...)` under `if state.cfg.train.exit_signal_handler and any(signal_handler.signals_received())` when `checkpoint.save` is set.
- **Pending:** a live Slurm long-convergence slice run to confirm each slice emits `"exiting program after receiving SIGTERM."` and the next slice resumes from the newly-saved iteration (rather than the periodic `save_interval` checkpoint). Marking this PR draft until that runs.

## Notes

- This is the launcher-side fix. The `save_interval` vs slice-length race and the opaque no-progress raise in the resubmit loop are separate follow-ups; with preemption-save wired, per-slice persistence no longer depends on `save_interval` landing inside the walltime window.
