### PR TITLE
[model] fix: Honor plain export dtype for Kimi K2.5

### DIFF
--- a/src/megatron/bridge/models/kimi_vl/kimi_k25_vl_bridge.py
+++ b/src/megatron/bridge/models/kimi_vl/kimi_k25_vl_bridge.py
@@ -184,6 +184,9 @@ class KimiK25VLBridge(MegatronModelBridge):
         hf_state_dict: Mapping[str, torch.Tensor],
     ) -> Dict[str, torch.Tensor]:
         """Re-quantize converted expert weights to INT4 format."""
+        if task.weight_dtype is not None:
+            return converted_weights_dict
+
         result = {}
         for fqn, tensor in converted_weights_dict.items():
             if self._is_quantized_expert_key(fqn):

--- a/tests/unit_tests/models/kimi_vl/test_kimi_k25_vl_bridge.py
+++ b/tests/unit_tests/models/kimi_vl/test_kimi_k25_vl_bridge.py
@@ -316,6 +316,49 @@ class TestKimiK25VLBridgeWeightConversion:
         assert kimi_bridge._is_quantized_expert_key("model.layers.5.self_attn.q_proj.weight") is False
         assert kimi_bridge._is_quantized_expert_key("model.embed_tokens.weight") is False
 
+    def test_plain_export_dtype_skips_int4_requantization(self, kimi_bridge):
+        """An explicit plain export dtype must preserve routed expert weights."""
+        from megatron.bridge.models.conversion.model_bridge import WeightConversionTask
+
+        task = WeightConversionTask(
+            param_name="decoder.layers.5.mlp.experts.linear_fc1.weight0",
+            global_param_name="decoder.layers.5.mlp.experts.linear_fc1.weight0",
+            mapping=Mock(),
+            weight_dtype=torch.bfloat16,
+        )
+        weight_key = "language_model.model.layers.5.mlp.experts.0.gate_proj.weight"
+        weight = torch.ones((2, 32), dtype=torch.float32)
+
+        result = kimi_bridge.maybe_modify_converted_hf_weight(task, {weight_key: weight}, {})
+
+        assert set(result) == {weight_key}
+        assert result[weight_key] is weight
+
+    def test_default_export_requantizes_routed_expert_weights(self, kimi_bridge):
+        """Default export should continue recreating Kimi's INT4 source layout."""
+        from megatron.bridge.models.conversion.model_bridge import WeightConversionTask
+
+        task = WeightConversionTask(
+            param_name="decoder.layers.5.mlp.experts.linear_fc1.weight0",
+            global_param_name="decoder.layers.5.mlp.experts.linear_fc1.weight0",
+            mapping=Mock(),
+        )
+        weight_key = "language_model.model.layers.5.mlp.experts.0.gate_proj.weight"
+
+        result = kimi_bridge.maybe_modify_converted_hf_weight(
+            task,
+            {weight_key: torch.ones((2, 32), dtype=torch.bfloat16)},
+            {},
+        )
+
+        base_key = weight_key.removesuffix(".weight")
+        assert set(result) == {
+            f"{base_key}.weight_packed",
+            f"{base_key}.weight_scale",
+            f"{base_key}.weight_shape",
+        }
+        assert result[f"{base_key}.weight_packed"].dtype == torch.int32
+
     @patch("megatron.bridge.models.kimi_vl.kimi_k25_vl_bridge.dequantize_int4")
     def test_load_and_dequantize_uses_source_tensor_device(self, mock_dequantize, kimi_bridge):
         """Quantized loads should dequantize on the source tensor device."""


### PR DESCRIPTION
# What does this PR do ?

Honor an explicit plain export dtype for Kimi K2.5 routed expert weights instead of silently recreating the source INT4 layout.

# Changelog

- Return converted floating-point expert weights unchanged when `WeightConversionTask.weight_dtype` requests a plain export.
- Preserve the existing Kimi INT4 requantization path when no export dtype is requested.
- Add regression and negative-control coverage for both contracts.

# Root cause and impact

`AutoBridge.export_hf_weights(..., weight_dtype=...)` propagates the requested dtype through `WeightConversionTask`. Kimi K2.5 then unconditionally ran its family export hook and replaced routed expert `.weight` tensors with `.weight_packed`, `.weight_scale`, and `.weight_shape`. Because the generic cast only casts floating tensors, the result remained packed INT4 and violated the documented plain-export contract. This affects supported Kimi K2.5 exports that request a floating dtype for exact SFT or inference parity.

The fix checks the task contract at the Kimi ownership boundary before family-specific requantization. Default quantized exports are unchanged.

# Verification

Fail-before on unmodified `origin/main` at `1523d2f08fc79c2914bc4c4ab81d7fd6e587a38e`:

```text
uv run --no-sync python -m pytest --confcutdir=tests/unit_tests/models/kimi_vl tests/unit_tests/models/kimi_vl/test_kimi_k25_vl_bridge.py::TestKimiK25VLBridgeWeightConversion::test_plain_export_dtype_skips_int4_requantization -q
1 failed: expected the plain .weight key; received weight_packed, weight_scale, and weight_shape
```

Pass-after regression plus default-export negative control:

```text
uv run --no-sync python -m pytest --confcutdir=tests/unit_tests/models/kimi_vl tests/unit_tests/models/kimi_vl/test_kimi_k25_vl_bridge.py::TestKimiK25VLBridgeWeightConversion::test_plain_export_dtype_skips_int4_requantization tests/unit_tests/models/kimi_vl/test_kimi_k25_vl_bridge.py::TestKimiK25VLBridgeWeightConversion::test_default_export_requantizes_routed_expert_weights -q
2 passed
```

Adjacent validation:

```text
uv run --no-sync python -m pytest --confcutdir=tests/unit_tests/models/kimi_vl tests/unit_tests/models/kimi_vl/test_kimi_k25_vl_bridge.py tests/unit_tests/models/test_quantization_utils.py -q
47 passed
git diff --check
passed
uv run --no-sync pre-commit run --all-files
passed all hooks
```

# Scope

This is limited to Kimi K2.5 routed-expert post-conversion handling. It does not change default quantized export behavior, public APIs, dependencies, workflows, or MCore. No GPU, distributed, full-suite, convergence, quality, or performance validation was run because this contract is deterministic in the CPU-side export hook.

# Before your PR is "Ready for review"

- [x] Read and followed the contributor guidelines.
- [x] Added focused regression coverage.
- [x] No documentation update is needed; this restores the existing documented export contract.
- [x] No optional-install component behavior is changed.