### PR TITLE
[ckpt] fix: preserve custom pipeline layouts in checkpoints

### DIFF
--- a/src/megatron/bridge/training/utils/config_utils.py
+++ b/src/megatron/bridge/training/utils/config_utils.py
@@ -18,6 +18,7 @@ from dataclasses import is_dataclass
 from typing import Any, Mapping
 
 from megatron.core.quantization.quant_config import GlobMatcher, Matcher, RecipeConfig
+from megatron.core.transformer.pipeline_parallel_layer_layout import PipelineParallelLayerLayout
 from megatron.training.config.container import ConfigContainerBase as _MCoreConfigContainerBase
 from megatron.training.config.utils import (
     _get_init_false_fields,  # noqa: F401
@@ -42,6 +43,8 @@ class _ConfigContainerBase(_MCoreConfigContainerBase):
 
     @classmethod
     def _convert_value_to_dict(cls, value: Any) -> Any:
+        if isinstance(value, PipelineParallelLayerLayout):
+            return cls._convert_value_to_dict(value.input_data)
         if isinstance(value, RecipeConfig) and not hasattr(value, "to_cfg_dict"):
             if type(value) is not RecipeConfig:
                 recipe_type = f"{type(value).__module__}.{type(value).__qualname__}"

--- a/tests/unit_tests/training/test_model_load_save.py
+++ b/tests/unit_tests/training/test_model_load_save.py
@@ -20,14 +20,17 @@ from unittest.mock import Mock, patch
 
 import pytest
 import torch
+from megatron.core.transformer.pipeline_parallel_layer_layout import PipelineParallelLayerLayout
 
 from megatron.bridge.models.gpt.gpt_builder import GPTModelConfig
+from megatron.bridge.models.gpt_provider import GPTModelProvider
 from megatron.bridge.models.model_provider import ModelProviderMixin
-from megatron.bridge.training.config import TokenizerConfig
+from megatron.bridge.training.config import ConfigContainer, TokenizerConfig
 from megatron.bridge.training.model_load_save import (
     dtype_from_hf,
     dtype_from_str,
     load_megatron_model,
+    load_model_config,
     load_tokenizer,
     megatron_cpu_init_context,
     save_megatron_model,
@@ -189,6 +192,32 @@ class TestTemporaryDistributedContext:
 
 class TestLoadMegatronModel:
     """Test load_megatron_model function."""
+
+    def test_load_model_config_preserves_finalized_pipeline_layout(self, tmp_path):
+        """Verify native checkpoints retain a finalized custom pipeline layout."""
+        provider = GPTModelProvider(num_layers=2, hidden_size=16, num_attention_heads=2)
+        provider.pipeline_model_parallel_size = 2
+        provider.pipeline_model_parallel_layout = [["embedding", "decoder"], ["decoder", "loss"]]
+        provider.finalize()
+
+        assert isinstance(provider.pipeline_model_parallel_layout, PipelineParallelLayerLayout)
+        expected_layout = provider.pipeline_model_parallel_layout.input_data
+
+        config = ConfigContainer(
+            model=provider,
+            train=None,
+            optimizer=None,
+            scheduler=None,
+            dataset=None,
+            logger=None,
+            tokenizer=None,
+            checkpoint=None,
+        )
+        config.to_yaml(str(tmp_path / "run_config.yaml"))
+
+        loaded_provider, _ = load_model_config(str(tmp_path))
+
+        assert loaded_provider.pipeline_model_parallel_layout == expected_layout
 
     @patch("megatron.bridge.training.model_load_save.temporary_distributed_context")
     @patch("megatron.bridge.training.checkpointing._load_model_weights_from_checkpoint")


### PR DESCRIPTION
## What

Preserve finalized custom pipeline layouts when Bridge serializes native checkpoint run configuration.

Closes the shared serialization root cause behind #2424. The model-specific fallback in #4306 remains compatible.

## User impact

A supported provider configured with an uneven PP, custom VPP, or standalone-MTP `pipeline_model_parallel_layout` is finalized before checkpoint save. Reloading that native checkpoint without separately reconstructing the layout currently drops it, which can make export/load fail or build a different pipeline partition.

## Root cause

Provider finalization converts a layout string/list into MCore `PipelineParallelLayerLayout`. Bridge's config serializer delegated this non-dataclass object to the generic YAML fallback, which wrote only a constructor stub and omitted its `input_data`. `load_model_config()` could not reconstruct that stub and replaced it with `None`.

## Fix

Serialize `PipelineParallelLayerLayout` through its original `input_data` at Bridge's shared config-conversion boundary. This preserves both string and list layouts without changing MCore or a public API.

The regression test finalizes a real two-stage `GPTModelProvider`, writes a real `ConfigContainer` YAML file, and reloads it through `load_model_config()`.

## Validation

Fail-before / pass-after:

```text
uv run python -m pytest tests/unit_tests/training/test_model_load_save.py::TestLoadMegatronModel::test_load_model_config_preserves_finalized_pipeline_layout -q

Before: 1 failed — loaded layout was None instead of the saved two-stage layout
After:  1 passed
```

Focused adjacent tests:

```text
uv run python -m pytest \
  tests/unit_tests/training/test_model_load_save.py \
  tests/unit_tests/training/utils/test_hf_config_serialization.py \
  tests/unit_tests/training/utils/test_quant_recipe_serialization.py \
  tests/unit_tests/training/test_gpt_step.py \
  -k 'not test_temporary_distributed_context_nccl' -q

95 passed, 1 deselected
```

The deselected test is an unrelated baseline-only CUDA availability assertion in the CPU validation environment.

```text
git diff --check
uv run pre-commit run --all-files
```

Both passed.

## Scope

This changes only run-config serialization for the existing MCore layout object. It does not change layout validation, pipeline execution, checkpoint weights, APIs, dependencies, CI, or the pinned MCore submodule. GPU execution was not required because the failure and fix are fully exercised at the deterministic config serialization/reload boundary.
