### PR TITLE
fix(ckpt): backport config-only artifact preservation to r0.5.0

### DIFF
--- a/src/megatron/bridge/models/conversion/auto_bridge.py
+++ b/src/megatron/bridge/models/conversion/auto_bridge.py
@@ -45,7 +45,6 @@ from megatron.bridge.models.conversion.model_bridge import (
 )
 from megatron.bridge.models.conversion.utils import get_causal_lm_class_name_via_auto_map
 from megatron.bridge.models.gpt_provider import GPTModelProvider
-from megatron.bridge.models.hf_pretrained.base import PreTrainedBase
 from megatron.bridge.models.hf_pretrained.causal_lm import PreTrainedCausalLM, _ConfigOnlyPretrainedShim
 from megatron.bridge.models.hf_pretrained.safe_config_loader import safe_load_config_with_retry
 from megatron.bridge.models.hf_pretrained.state import SafeTensorsStateSource
@@ -800,40 +799,33 @@ class AutoBridge(Generic[MegatronModelT]):
 
         def _save_artifacts():
             if is_config_only:
-                import json
+                artifact_source_path = self.hf_model_id or source_path
+                if artifact_source_path is not None:
+                    model_bridge_instance = self._model_bridge
+                    artifact_kwargs = {}
+                    if hasattr(model_bridge_instance, "get_hf_tokenizer_kwargs"):
+                        artifact_kwargs.update(model_bridge_instance.get_hf_tokenizer_kwargs() or {})
+                    artifact_kwargs["trust_remote_code"] = self.trust_remote_code
 
-                # Config-only path: write config.json and optionally download modeling files from Hub.
-                Path(path).mkdir(parents=True, exist_ok=True)
-                config_dict = self.hf_pretrained.to_dict()
-                if not self.trust_remote_code:
-                    config_dict.pop("auto_map", None)
-                with open(Path(path) / "config.json", "w") as _f:
-                    json.dump(config_dict, _f, indent=2, sort_keys=True, allow_nan=True)
+                    # This wrapper loads artifacts lazily; model weights are never materialized here.
+                    artifact_source = PreTrainedCausalLM.from_pretrained(artifact_source_path, **artifact_kwargs)
+                    artifact_source.config = self.hf_pretrained
+                    additional_files = getattr(model_bridge_instance, "ADDITIONAL_FILE_PATTERNS", None) or None
+                    artifact_source.save_artifacts(
+                        path,
+                        original_source_path=source_path,
+                        additional_files=additional_files,
+                    )
+                else:
+                    import json
 
-                # Download custom modeling files only when the export is meant to preserve remote code.
-                hub_repo = self.hf_model_id
-                if hub_repo and self.trust_remote_code:
-                    try:
-                        from huggingface_hub import hf_hub_download, list_repo_files
-
-                        repo_files = list_repo_files(hub_repo)
-                        py_files = [f for f in repo_files if f.endswith(".py")]
-                        for py_file in py_files:
-                            hf_hub_download(
-                                repo_id=hub_repo,
-                                filename=py_file,
-                                local_dir=path,
-                            )
-                    except Exception as exc:
-                        logger.warning(
-                            "Could not download modeling files from %s: %s. "
-                            "This is expected for models that use standard transformers "
-                            "modeling classes and do not define custom .py files.",
-                            hub_repo,
-                            exc,
-                        )
-                    finally:
-                        PreTrainedBase._cleanup_hf_local_dir_cache(Path(path))
+                    # A bridge built directly from a config has no reference artifacts to preserve.
+                    Path(path).mkdir(parents=True, exist_ok=True)
+                    config_dict = self.hf_pretrained.to_dict()
+                    if not self.trust_remote_code:
+                        config_dict.pop("auto_map", None)
+                    with open(Path(path) / "config.json", "w") as _f:
+                        json.dump(config_dict, _f, indent=2, sort_keys=True, allow_nan=True)
 
             else:
                 # Get bridge-level ADDITIONAL_FILE_PATTERNS if configured

--- a/tests/unit_tests/models/test_auto_bridge.py
+++ b/tests/unit_tests/models/test_auto_bridge.py
@@ -22,7 +22,15 @@ from unittest.mock import Mock, PropertyMock, patch
 
 import pytest
 import torch
-from transformers import LlamaConfig
+from tokenizers import Tokenizer, models, pre_tokenizers
+from transformers import (
+    AutoProcessor,
+    AutoTokenizer,
+    CLIPImageProcessor,
+    LlamaConfig,
+    LlavaProcessor,
+    PreTrainedTokenizerFast,
+)
 from transformers.configuration_utils import PretrainedConfig
 
 from megatron.bridge.models.conversion.auto_bridge import (
@@ -43,6 +51,31 @@ def create_mock_pretrained_causal_lm():
             pass  # Skip actual initialization
 
     return MockPreTrainedCausalLM()
+
+
+def _save_minimal_fast_tokenizer(path: Path) -> PreTrainedTokenizerFast:
+    backend = Tokenizer(
+        models.WordLevel(
+            {
+                "<unk>": 0,
+                "<bos>": 1,
+                "<eos>": 2,
+                "<pad>": 3,
+                "hello": 4,
+            },
+            unk_token="<unk>",
+        )
+    )
+    backend.pre_tokenizer = pre_tokenizers.Whitespace()
+    tokenizer = PreTrainedTokenizerFast(
+        tokenizer_object=backend,
+        unk_token="<unk>",
+        bos_token="<bos>",
+        eos_token="<eos>",
+        pad_token="<pad>",
+    )
+    tokenizer.save_pretrained(path)
+    return tokenizer
 
 
 class TestAutoBridge:
@@ -691,18 +724,104 @@ class TestAutoBridge:
     @patch("torch.distributed.is_initialized", return_value=False)
     @patch("torch.distributed.is_available", return_value=False)
     def test_save_hf_pretrained_config_only(self, _mock_dist_avail, _mock_dist_init, tmp_path):
-        """Config-only save writes config.json, calls save_hf_weights, and tolerates missing hub files."""
+        """Config-only save without a reference writes config.json and calls save_hf_weights."""
         bridge = AutoBridge(PretrainedConfig())
-        bridge.hf_model_id = "some-org/some-model"
 
         with patch.object(AutoBridge, "save_hf_weights") as mock_save_hf_weights:
-            with patch("huggingface_hub.list_repo_files", return_value=["config.json", "README.md"]):
-                with patch("huggingface_hub.hf_hub_download") as mock_download:
-                    bridge.save_hf_pretrained([Mock()], str(tmp_path))
+            bridge.save_hf_pretrained([Mock()], str(tmp_path))
 
         assert (tmp_path / "config.json").exists()
-        mock_download.assert_not_called()
         mock_save_hf_weights.assert_called_once()
+
+    @pytest.mark.parametrize("artifact_source", ["hf_model_id", "source_path"])
+    @patch("torch.distributed.is_initialized", return_value=False)
+    @patch("torch.distributed.is_available", return_value=False)
+    def test_save_hf_pretrained_config_only_saves_reference_artifacts(
+        self, _mock_dist_avail, _mock_dist_init, tmp_path, artifact_source
+    ):
+        """Config-only save preserves processor artifacts without loading reference weights."""
+        source_path = tmp_path / "source"
+        output_path = tmp_path / "output"
+        source_path.mkdir()
+
+        source_config = LlamaConfig(
+            architectures=["LlamaForCausalLM"],
+            max_position_embeddings=2048,
+            vocab_size=5,
+        )
+        source_config.save_pretrained(source_path)
+        tokenizer = _save_minimal_fast_tokenizer(source_path)
+        processor = LlavaProcessor(image_processor=CLIPImageProcessor(), tokenizer=tokenizer)
+        processor.save_pretrained(source_path)
+
+        synthesized_config = LlamaConfig(
+            architectures=["LlamaForCausalLM"],
+            max_position_embeddings=4096,
+            vocab_size=5,
+        )
+        bridge = AutoBridge(synthesized_config)
+        save_kwargs = {}
+        if artifact_source == "hf_model_id":
+            bridge.hf_model_id = str(source_path)
+        else:
+            save_kwargs["source_path"] = source_path
+
+        with patch(
+            "megatron.bridge.models.hf_pretrained.causal_lm.AutoModelForCausalLM.from_pretrained"
+        ) as mock_load_weights:
+            with patch.object(AutoBridge, "save_hf_weights") as mock_save_hf_weights:
+                bridge.save_hf_pretrained([Mock()], output_path, **save_kwargs)
+
+        exported_tokenizer = AutoTokenizer.from_pretrained(output_path, local_files_only=True)
+        exported_processor = AutoProcessor.from_pretrained(output_path, local_files_only=True)
+        assert exported_tokenizer("hello")["input_ids"] == [4]
+        assert isinstance(exported_processor, LlavaProcessor)
+        assert (output_path / "tokenizer.json").is_file()
+        assert (output_path / "processor_config.json").is_file()
+        assert json.loads((output_path / "config.json").read_text())["max_position_embeddings"] == 4096
+        mock_load_weights.assert_not_called()
+        mock_save_hf_weights.assert_called_once()
+
+    @patch("torch.distributed.is_initialized", return_value=False)
+    @patch("torch.distributed.is_available", return_value=False)
+    def test_save_hf_pretrained_config_only_uses_reference_artifact_saver(self, _mock_dist_avail, _mock_dist_init):
+        """Config-only save delegates all artifacts and model-specific options to the lazy HF wrapper."""
+        config = LlamaConfig(architectures=["LlamaForCausalLM"])
+        bridge = AutoBridge(config)
+        bridge.hf_model_id = "some-org/some-model"
+
+        mock_artifact_source = Mock(spec=PreTrainedCausalLM)
+        mock_model_bridge = Mock(ADDITIONAL_FILE_PATTERNS=["chat_template.jinja"])
+        mock_model_bridge.get_hf_tokenizer_kwargs.return_value = {"use_fast": True}
+
+        with patch.object(
+            type(bridge),
+            "_model_bridge",
+            PropertyMock(return_value=mock_model_bridge),
+        ):
+            with patch.object(
+                PreTrainedCausalLM,
+                "from_pretrained",
+                return_value=mock_artifact_source,
+            ) as mock_from_pretrained:
+                with patch.object(AutoBridge, "save_hf_weights"):
+                    bridge.save_hf_pretrained(
+                        [Mock()],
+                        "./output_dir",
+                        source_path="./custom_files",
+                    )
+
+        mock_from_pretrained.assert_called_once_with(
+            "some-org/some-model",
+            use_fast=True,
+            trust_remote_code=False,
+        )
+        assert mock_artifact_source.config is config
+        mock_artifact_source.save_artifacts.assert_called_once_with(
+            "./output_dir",
+            original_source_path="./custom_files",
+            additional_files=["chat_template.jinja"],
+        )
 
     @patch("torch.distributed.is_initialized", return_value=False)
     @patch("torch.distributed.is_available", return_value=False)
@@ -710,21 +829,18 @@ class TestAutoBridge:
         self, _mock_dist_avail, _mock_dist_init, tmp_path
     ):
         """Config-only save omits stale remote-code metadata when remote code is not preserved."""
-        config = PretrainedConfig()
+        config = LlamaConfig(architectures=["LlamaForCausalLM"])
         config.auto_map = {
             "AutoConfig": "configuration_custom.CustomConfig",
             "AutoModelForCausalLM": "modeling_custom.CustomForCausalLM",
         }
         bridge = AutoBridge(config)
-        bridge.hf_model_id = "some-org/some-model"
 
         with patch.object(AutoBridge, "save_hf_weights"):
-            with patch("huggingface_hub.list_repo_files") as mock_list_repo_files:
-                bridge.save_hf_pretrained([Mock()], str(tmp_path))
+            bridge.save_hf_pretrained([Mock()], str(tmp_path))
 
         saved_config = json.loads((tmp_path / "config.json").read_text())
         assert "auto_map" not in saved_config
-        mock_list_repo_files.assert_not_called()
 
     @patch("torch.distributed.is_initialized", return_value=False)
     @patch("torch.distributed.is_available", return_value=False)
@@ -732,40 +848,38 @@ class TestAutoBridge:
         self, _mock_dist_avail, _mock_dist_init, tmp_path
     ):
         """Config-only save keeps auto_map and copies code when remote code is preserved."""
-        config = PretrainedConfig()
+        source_path = tmp_path / "source"
+        output_path = tmp_path / "output"
+        source_path.mkdir()
+        _save_minimal_fast_tokenizer(source_path)
+        (source_path / "modeling_custom.py").write_text("# custom modeling code\n")
+
+        config = LlamaConfig(architectures=["LlamaForCausalLM"])
         config.auto_map = {
             "AutoConfig": "configuration_custom.CustomConfig",
             "AutoModelForCausalLM": "modeling_custom.CustomForCausalLM",
         }
         bridge = AutoBridge(config)
-        bridge.hf_model_id = "some-org/some-model"
+        bridge.hf_model_id = str(source_path)
         bridge.trust_remote_code = True
 
-        def fake_hf_hub_download(repo_id, filename, local_dir):
-            del repo_id
-            local_dir = Path(local_dir)
-            (local_dir / filename).write_text("# custom modeling code")
-            metadata_dir = local_dir / ".cache" / "huggingface" / "download"
-            metadata_dir.mkdir(parents=True)
-            (metadata_dir / f"{filename}.metadata").write_text("metadata")
+        mock_model_bridge = Mock(ADDITIONAL_FILE_PATTERNS=None)
+        mock_model_bridge.get_hf_tokenizer_kwargs.return_value = {}
+        with patch.object(
+            type(bridge),
+            "_model_bridge",
+            PropertyMock(return_value=mock_model_bridge),
+        ):
+            with patch.object(AutoBridge, "save_hf_weights"):
+                bridge.save_hf_pretrained([Mock()], output_path)
 
-        with patch.object(AutoBridge, "save_hf_weights"):
-            with patch("huggingface_hub.list_repo_files", return_value=["modeling_custom.py", "README.md"]):
-                with patch("huggingface_hub.hf_hub_download", side_effect=fake_hf_hub_download) as mock_download:
-                    bridge.save_hf_pretrained([Mock()], str(tmp_path))
-
-        saved_config = json.loads((tmp_path / "config.json").read_text())
+        saved_config = json.loads((output_path / "config.json").read_text())
         assert saved_config["auto_map"] == {
             "AutoConfig": "configuration_custom.CustomConfig",
             "AutoModelForCausalLM": "modeling_custom.CustomForCausalLM",
         }
-        assert (tmp_path / "modeling_custom.py").exists()
-        assert not (tmp_path / ".cache").exists()
-        mock_download.assert_called_once_with(
-            repo_id="some-org/some-model",
-            filename="modeling_custom.py",
-            local_dir=str(tmp_path),
-        )
+        assert (output_path / "modeling_custom.py").exists()
+        assert not (output_path / ".cache").exists()
 
     @patch("torch.distributed.get_rank", return_value=1)
     @patch("torch.distributed.is_initialized", return_value=True)


### PR DESCRIPTION
## Summary

Manual backport of #4687 to `r0.5.0`.

NVBug: 6328612

This preserves tokenizer, processor, image-processor, generation-config, custom-code, and model-specific additional artifacts when a config-only bridge exports Hugging Face weights. It reuses the existing lazy artifact saver, keeps the synthesized export config authoritative, and does not materialize model weights.

The backport intentionally contains only the #4687 changes in:

- `src/megatron/bridge/models/conversion/auto_bridge.py`
- `tests/unit_tests/models/test_auto_bridge.py`

It does not include the unrelated #4688 checkpoint-serialization changes or other main-only conversion behavior.

## Why the automatic cherry-pick was not clean

After #4687 merged as squash commit `5d6ca9a7de5028480aae976427f21334d77bea31`, the service account created `cherry-pick-4687-r0.5.0` at the unchanged release tip `49bdb3b9169efee51f7fe79d17e7d39a259f8132`, but no backport PR was opened.

Reproducing the operation with:

```text
git cherry-pick -x 5d6ca9a7de5028480aae976427f21334d77bea31
```

produces two content conflicts:

1. `auto_bridge.py` import block
   - Main commit `8a34622655951e44e1847796d9b2a0ce647999ee` (#4719) reformatted the causal-LM import and changed the config-only shim's inheritance/type structure after `r0.5.0` diverged.
   - #4687 removes `PreTrainedBase` because replacing the manual config-only artifact path removes its final use in `auto_bridge.py`.
   - `r0.5.0` already has compatible `PreTrainedCausalLM.from_pretrained()` and `save_artifacts()` APIs. The resolution deletes the unused base import while retaining the release branch's one-line causal-LM import. This conflict is textual; no #4719 API behavior is required or included.

2. `test_auto_bridge.py` helper insertion point
   - Main-only commit `d17190fa4d2d023b9b2531c8d449ddb21c13b908` (#4189) inserted `_make_fake_source` immediately after `create_mock_pretrained_causal_lm()`.
   - #4687 inserts `_save_minimal_fast_tokenizer` in that same gap, before the main-only helper.
   - `r0.5.0` does not contain #4189, so the shared insertion point creates a modify/delete conflict. The resolution keeps only #4687's tokenizer helper and does not import #4189 tests or behavior. This conflict is also textual.

## Validation

- `git diff --check origin/r0.5.0..HEAD`
- `uv run --no-project --with pre-commit pre-commit run --all-files`
- Exact image: `nvcr.io/nvidian/nemo:26.06.01.rc0`
  - NVIDIA build ID `350500683`
  - image SHA-256 `8fa8b3b5dca40ac69c6c0d307e6834c1d3ca848be2d9400b821149512c5fc581`
  - CPU-only Slurm job `13655860`, completed `0:0`
  - complete `tests/unit_tests/models/test_auto_bridge.py`: `63 passed`
  - config-only artifact subset: `6 passed, 57 deselected`
  - full pre-commit: all hooks passed
- Fresh independent review of the complete backport diff and conflict resolution: no actionable findings.

## Blast radius

The change is limited to the config-only Hugging Face artifact-save path and its unit coverage. It does not alter weight mappings, model providers, public signatures, training, or dependencies. Focused unit coverage and the converter L0 CI surface are sufficient; no L1/L2 expansion is requested.
