### PR TITLE
fix(performance): synchronize sequence length override

### DIFF
--- a/scripts/performance/README.md
+++ b/scripts/performance/README.md
@@ -103,7 +103,7 @@ uv run python scripts/performance/setup_experiment.py \
 - `-ms/--max_steps`: Maximum number of training steps.
 - `-gb/--global_batch_size`: Override global batch size.
 - `-mb/--micro_batch_size`: Override micro-batch size.
-- `-sl/--seq_length`: Sequence length.
+- `-sl/--seq_length`: Override model sequence length and the LLM dataset sequence length.
 
 ##### Optimizer arguments
 

--- a/scripts/performance/utils/overrides.py
+++ b/scripts/performance/utils/overrides.py
@@ -378,6 +378,10 @@ def set_user_overrides(recipe: ConfigContainer, args: argparse.Namespace) -> Con
         recipe.tokenizer = TokenizerConfig(
             tokenizer_type="SentencePieceTokenizer", tokenizer_model=args.tokenizer_model
         )
+
+    if args.seq_length is not None:
+        recipe.model.seq_length = args.seq_length
+
     # Create dataset configuration based on type
     if args.data == "mock":
         if args.domain == "llm":
@@ -385,7 +389,7 @@ def set_user_overrides(recipe: ConfigContainer, args: argparse.Namespace) -> Con
             # For vlm models, use the default dataset configuration in model recipe,
             # becuase preprocess of dataset is different for each vlm model.
             recipe.dataset = create_mock_dataset_config(
-                seq_length=args.seq_length or recipe.model.seq_length,
+                seq_length=recipe.model.seq_length,
                 num_workers=recipe.dataset.num_workers,
                 pin_memory=recipe.dataset.pin_memory,
                 persistent_workers=recipe.dataset.persistent_workers,
@@ -395,7 +399,7 @@ def set_user_overrides(recipe: ConfigContainer, args: argparse.Namespace) -> Con
             raise ValueError("--dataset-paths and --index-mapping-dir are required for rp2 dataset")
         recipe.dataset = create_rp2_dataset_config(
             dataset_paths=args.dataset_paths,
-            seq_length=recipe.dataset.sequence_length,
+            seq_length=args.seq_length if args.seq_length is not None else recipe.dataset.sequence_length,
             index_mapping_dir=args.index_mapping_dir,
             num_workers=recipe.dataset.num_workers,
             pin_memory=recipe.dataset.pin_memory,
@@ -405,7 +409,7 @@ def set_user_overrides(recipe: ConfigContainer, args: argparse.Namespace) -> Con
         if not args.c4_root:
             raise ValueError("--c4_root is required for c4 dataset")
         recipe.dataset = create_c4_dataset_config(
-            seq_length=recipe.dataset.sequence_length,
+            seq_length=args.seq_length if args.seq_length is not None else recipe.dataset.sequence_length,
             c4_root=args.c4_root,
             train_shards=tuple(args.c4_train_shards),
             index_mapping_dir=args.index_mapping_dir,
@@ -420,7 +424,7 @@ def set_user_overrides(recipe: ConfigContainer, args: argparse.Namespace) -> Con
         pad_seq_to_mult = cp_size * 2 if cp_size > 1 else 1
         recipe.dataset = create_squad_dataset_config(
             dataset_root=args.dataset_root,
-            seq_length=args.seq_length or recipe.model.seq_length,
+            seq_length=recipe.model.seq_length,
             packed=False,
             pad_seq_to_mult=pad_seq_to_mult,
             num_workers=recipe.dataset.num_workers,
@@ -434,7 +438,7 @@ def set_user_overrides(recipe: ConfigContainer, args: argparse.Namespace) -> Con
         pad_seq_to_mult = cp_size * 2 if cp_size > 1 else 1
         recipe.dataset = create_squad_dataset_config(
             dataset_root=args.dataset_root,
-            seq_length=args.seq_length or recipe.model.seq_length,
+            seq_length=recipe.model.seq_length,
             packed=True,
             pad_seq_to_mult=pad_seq_to_mult,
             num_workers=recipe.dataset.num_workers,

--- a/tests/unit_tests/scripts/performance/test_user_overrides.py
+++ b/tests/unit_tests/scripts/performance/test_user_overrides.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for performance-script user overrides."""
+
+import sys
+from pathlib import Path
+
+
+_PERF_SCRIPTS_DIR = Path(__file__).resolve().parents[4] / "scripts" / "performance"
+if str(_PERF_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_PERF_SCRIPTS_DIR))
+
+from argument_parser import parse_cli_args
+from utils.overrides import set_user_overrides
+
+from megatron.bridge.recipes.gpt.h100.vanilla_gpt import vanilla_gpt_pretrain_1gpu_h100_bf16_config
+
+
+def _parse_args(tmp_path: Path, *extra_args: str):
+    parser = parse_cli_args()
+    args, unknown = parser.parse_known_args(
+        [
+            "--model_family_name",
+            "gpt",
+            "--model_recipe_name",
+            "vanilla_gpt",
+            "--num_gpus",
+            "1",
+            "--gpu",
+            "h100",
+            "--save_config_filepath",
+            str(tmp_path / "ConfigContainer.yaml"),
+            *extra_args,
+        ]
+    )
+    assert unknown == []
+    return args
+
+
+def test_seq_length_updates_model_and_mock_dataset(tmp_path):
+    recipe = vanilla_gpt_pretrain_1gpu_h100_bf16_config()
+
+    updated = set_user_overrides(recipe, _parse_args(tmp_path, "--seq_length", "128"))
+
+    assert updated.model.seq_length == 128
+    assert updated.dataset.sequence_length == 128


### PR DESCRIPTION
## What does this PR do?

Fixes the performance CLI sequence-length override exposed by a small training smoke:

- `--seq_length` now updates both `model.seq_length` and the selected LLM dataset sequence length
- mock, RP2, C4, and SQuAD dataset construction receives the explicit override
- dataset-specific sequence defaults remain unchanged when the user does not provide an override
- the performance README documents the dual model/dataset behavior

This PR does not change `--num_layers` handling.

## Testing

- 2×H100 mock-data E2E using only `--seq_length 128` for sequence length: one training iteration; exit 0
- sequence-length override, plugin, config-dump, executor, and offline-mode tests: 11 passed
- regression test uses a local vanilla GPT config and requires no network or model token
- pre-commit, Ruff, format, and `git diff --check`
