### PR TITLE
[model] fix: Gather Nemotron diffusion TP logits

### DIFF
--- a/src/megatron/bridge/diffusion/models/nemotron_labs_diffusion/inference_nemotron_labs_diffusion.py
+++ b/src/megatron/bridge/diffusion/models/nemotron_labs_diffusion/inference_nemotron_labs_diffusion.py
@@ -158,6 +158,7 @@ def _model_forward(model, input_ids):
         input_ids=input_ids,
         position_ids=position_ids,
         attention_mask=None,
+        runtime_gather_output=True,
     )
     logits = output if isinstance(output, torch.Tensor) else output[0]
     return logits
@@ -408,7 +409,7 @@ def tp_follower_loop(model):
             )
             seq_len = input_ids.shape[1]
             position_ids = torch.arange(seq_len, device=input_ids.device).unsqueeze(0).expand_as(input_ids)
-            model(input_ids=input_ids, position_ids=position_ids, attention_mask=None)
+            model(input_ids=input_ids, position_ids=position_ids, attention_mask=None, runtime_gather_output=True)
         elif cmd == _CMD_SET_INF_MODE_ON:
             for attn in _get_core_attentions(model):
                 attn.set_inference_mode(True)

--- a/tests/unit_tests/diffusion/model/nemotron_labs_diffusion/test_inference.py
+++ b/tests/unit_tests/diffusion/model/nemotron_labs_diffusion/test_inference.py
@@ -495,6 +495,27 @@ class TestGenerateAr:
         result, *_ = self._run_generate_ar(prompt_len=prompt_len, max_new_tokens=max_new_tokens)
         assert result.shape == (1, prompt_len + max_new_tokens)
 
+    def test_generate_ar_selects_from_full_vocab_with_parallel_output(self):
+        """TP generation selects the global maximum, not a rank-local vocabulary index."""
+        model, _ = _make_mock_model()
+        prompt = torch.zeros(1, 1, dtype=torch.long)
+
+        def fake_mcore_forward(*, input_ids, position_ids, attention_mask, runtime_gather_output=None):
+            del position_ids, attention_mask
+            vocab_size = 8 if runtime_gather_output else 4
+            logits = torch.zeros(input_ids.shape[0], input_ids.shape[1], vocab_size)
+            logits[:, :, 2] = 5.0
+            if runtime_gather_output:
+                logits[:, :, 6] = 10.0
+            return logits
+
+        model.side_effect = fake_mcore_forward
+
+        with patch(f"{_MODULE}._tp_send_cmd"):
+            result = generate_ar(model, prompt, max_new_tokens=1)
+
+        assert result[0, -1].item() == 6
+
     def test_generate_ar_with_temperature(self):
         """temperature > 0 uses multinomial sampling; output length is still correct."""
         torch.manual_seed(7)


### PR DESCRIPTION
## What

Gather full-vocabulary logits before Nemotron Labs diffusion AR or dLLM sampling under tensor parallelism.

## User impact

The documented Nemotron Labs inference path accepts `--tp > 1` and retains the model provider's `parallel_output=True` default. Before this change, each TP rank received only its local vocabulary shard, but AR and dLLM generation treated the shard's axis as global token IDs. The source rank could therefore emit only rank-local indices, while dLLM token selection and confidence scoring also ignored the other vocabulary partitions.

## Root cause

The custom inference helper calls pinned MCore `GPTModel.forward()` without `runtime_gather_output`. With `parallel_output=True`, MCore's column-parallel output layer returns `V / TP` logits per rank. Input-token broadcasts synchronize the next forward but cannot gather logits or translate local indices into global vocabulary IDs.

## Fix

Request `runtime_gather_output=True` on both the normal model forward and the mirrored TP follower forward. This keeps every rank in the required collective and gives AR/dLLM sampling full-vocabulary logits without changing model configuration or APIs.

## Validation

Fail-before / pass-after:

```text
uv run python -m pytest tests/unit_tests/diffusion/model/nemotron_labs_diffusion/test_inference.py::TestGenerateAr::test_generate_ar_selects_from_full_vocab_with_parallel_output -q --tb=short

Before: 1 failed — selected local token 2 instead of global token 6
After:  1 passed
```

Focused adjacent tests:

```text
uv run python -m pytest \
  tests/unit_tests/diffusion/model/nemotron_labs_diffusion/test_inference.py \
  tests/unit_tests/diffusion/model/nemotron_labs_diffusion/test_nemotron_labs_diffusion_attention.py \
  tests/unit_tests/diffusion/recipes/nemotron_labs_diffusion/test_nemotron_labs_diffusion_provider.py -q

114 passed
```

```text
git diff --check
uv run pre-commit run --all-files
```

Both passed.

## Scope

This changes only Nemotron Labs diffusion inference logit materialization. It does not change training, checkpoint weights, sampling algorithms, model/provider defaults, dependencies, CI, or the pinned MCore submodule. GPU model-quality or performance validation was not run; the regression exercises the explicit pinned-MCore sharded-vs-gathered output contract deterministically.
