### PR TITLE
fix(model): correct Qwen3-VL vision_dp_when_cp CP gradient and avoid 0-image-rank hang

### DIFF
--- a/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/model.py
+++ b/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/model.py
@@ -513,10 +513,15 @@ class Qwen3VLModel(MegatronModule):
                             grid_thw=vision_grid_thw,
                         )
                 else:
+                    # A rank may receive 0 images (num_images < cp_size). Its 0-length placeholders
+                    # (vision_embeds and each deepstack tensor) must be created with
+                    # requires_grad=True so that backward runs on every CP rank and the cp_group
+                    # collective in AllGatherVisionEmbeddings.backward stays symmetric.
                     vision_embeds = torch.zeros(
                         (0, self.config.hidden_size),
                         device=vision_data.device,
                         dtype=torch.bfloat16,
+                        requires_grad=True,
                     )
                     deepstack_feature_lists = []
                     for _ in self.vision_transformer_config.deepstack_visual_indexes:
@@ -525,19 +530,20 @@ class Qwen3VLModel(MegatronModule):
                                 (0, self.language_model.config.hidden_size),
                                 device=vision_data.device,
                                 dtype=torch.bfloat16,
+                                requires_grad=True,
                             )
                         )
                 if cp_size > 1 and self.config.vision_dp_when_cp:
                     vision_embeds = AllGatherVisionEmbeddings.apply(
                         vision_embeds,
                         seqlen_on_cp_ranks,
-                        cp_group=self.pg_collection.cp,
+                        self.pg_collection.cp,
                     )
                     for i in range(len(deepstack_feature_lists)):
                         deepstack_feature_lists[i] = AllGatherVisionEmbeddings.apply(
                             deepstack_feature_lists[i],
                             seqlen_on_cp_ranks,
-                            cp_group=self.pg_collection.cp,
+                            self.pg_collection.cp,
                         )
 
             combined_embeddings = self.language_model.embedding(

--- a/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/utils.py
+++ b/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/utils.py
@@ -663,6 +663,7 @@ class AllGatherVisionEmbeddings(torch.autograd.Function):
             outputs.append(o)
         torch.distributed.all_gather(outputs, input, group=cp_group)
         ctx.cp_rank = torch.distributed.get_rank(group=cp_group)
+        ctx.cp_group = cp_group
         ctx.save_for_backward(*seqlens_on_cp_ranks)
 
         output = torch.cat(outputs, dim=0)
@@ -677,6 +678,8 @@ class AllGatherVisionEmbeddings(torch.autograd.Function):
         seqlens_on_cp_ranks = ctx.saved_tensors
         start_idx = torch.cat(seqlens_on_cp_ranks[:cp_rank]).sum() if cp_rank != 0 else 0
         end_idx = start_idx + seqlens_on_cp_ranks[cp_rank].sum()
+        grad_output = grad_output.contiguous()
+        torch.distributed.all_reduce(grad_output, group=ctx.cp_group)
         grad_output = grad_output[start_idx:end_idx]
         return grad_output, None, None
 

--- a/tests/unit_tests/models/qwen_vl/modelling_qwen3_vl/test_utils.py
+++ b/tests/unit_tests/models/qwen_vl/modelling_qwen3_vl/test_utils.py
@@ -480,6 +480,91 @@ class TestQwen3VLUtils:
 
         self.destroy_parallel_state()
 
+    @pytest.mark.skipif(
+        not torch.cuda.is_available() or int(os.environ.get("WORLD_SIZE", "1")) < 2,
+        reason="Requires at least 2 GPUs",
+    )
+    def test_allgather_vision_embeddings_backward_reduce_scatter(self):
+        """Backward must reduce-scatter: grad w.r.t. input is the CP-summed gradient sliced
+        to this rank's range, not just this rank's local slice.
+
+        Each rank drives a *rank-dependent* upstream gradient on the shared gathered output
+        (weight = cp_rank + 1). The correct gradient for every rank is therefore the same
+        row-weighted tensor scaled by S = sum_r (r + 1), sliced to the rank's own range. The
+        buggy local-slice-only backward would instead yield the per-rank weight, which differs
+        across ranks and misses the cross-rank contributions.
+        """
+        cp_size = 2
+        self._setup_parallel_state(tp_size=1, cp_size=cp_size)
+        cp_group = parallel_state.get_context_parallel_group()
+        cp_rank = parallel_state.get_context_parallel_rank()
+
+        local_seqlen = 3
+        hidden_size = 8
+        device = torch.cuda.current_device()
+        seqlens_on_cp_ranks = [torch.tensor([local_seqlen], dtype=torch.long, device=device) for _ in range(cp_size)]
+        total = local_seqlen * cp_size
+
+        input_ = torch.randn(local_seqlen, hidden_size, dtype=torch.float, device=device, requires_grad=True)
+        output = AllGatherVisionEmbeddings.apply(input_, seqlens_on_cp_ranks, cp_group)
+
+        # Row weight varies along the gathered sequence so the test also exercises the slice offset.
+        row = (torch.arange(total, device=device, dtype=torch.float) + 1.0).unsqueeze(1)  # (total, 1)
+        rank_weight = float(cp_rank + 1)
+        loss = (output * (row * rank_weight)).sum()
+        loss.backward()
+
+        s = sum(r + 1 for r in range(cp_size))  # 3 for cp_size=2
+        start = cp_rank * local_seqlen
+        expected = (row[start : start + local_seqlen] * s).expand(local_seqlen, hidden_size)
+        assert input_.grad is not None
+        torch.testing.assert_close(input_.grad, expected)
+
+        self.destroy_parallel_state()
+
+    @pytest.mark.skipif(
+        not torch.cuda.is_available() or int(os.environ.get("WORLD_SIZE", "1")) < 2,
+        reason="Requires at least 2 GPUs",
+    )
+    def test_allgather_vision_embeddings_empty_rank(self):
+        """A CP rank with 0 tokens (num_images < cp_size) must still participate in the
+        backward all_reduce so the collective stays symmetric and does not hang.
+
+        The empty rank supplies a 0-length input with requires_grad=True (mirroring the model's
+        placeholder), so autograd invokes the backward -- and thus the cp_group all_reduce -- on
+        every rank. The rank that owns the tokens must receive the CP-summed gradient.
+        """
+        cp_size = 2
+        self._setup_parallel_state(tp_size=1, cp_size=cp_size)
+        cp_group = parallel_state.get_context_parallel_group()
+        cp_rank = parallel_state.get_context_parallel_rank()
+
+        owner_seqlen = 4
+        hidden_size = 8
+        device = torch.cuda.current_device()
+        # Only rank 0 owns tokens; rank 1 is the empty (0-image) rank.
+        seqlens_on_cp_ranks = [
+            torch.tensor([owner_seqlen], dtype=torch.long, device=device),
+            torch.tensor([0], dtype=torch.long, device=device),
+        ]
+        local_seqlen = owner_seqlen if cp_rank == 0 else 0
+
+        input_ = torch.zeros(local_seqlen, hidden_size, dtype=torch.float, device=device, requires_grad=True)
+        output = AllGatherVisionEmbeddings.apply(input_, seqlens_on_cp_ranks, cp_group)
+        assert output.shape == (owner_seqlen, hidden_size)
+
+        # Rank-dependent upstream gradient again, so the owner rank must see the CP-summed grad.
+        rank_weight = float(cp_rank + 1)
+        (output * rank_weight).sum().backward()
+
+        assert input_.grad is not None
+        assert input_.grad.shape == (local_seqlen, hidden_size)
+        if cp_rank == 0:
+            s = sum(r + 1 for r in range(cp_size))  # 3
+            torch.testing.assert_close(input_.grad, torch.full((owner_seqlen, hidden_size), float(s), device=device))
+
+        self.destroy_parallel_state()
+
     def test_split_deepstack_embs_no_tp(self):
         """Test split_deepstack_embs with tp_size=1."""
         visual_pos_masks = torch.tensor([[True, False, True], [False, True, False]])


### PR DESCRIPTION

# What does this PR do ?

Fixes three bugs that break Qwen3-VL training with context parallelism when `vision_dp_when_cp=True`: the vision-embedding all-gather is entered with a `TypeError`, its backward silently drops cross-rank gradient contributions to the vision encoder, and CP ranks that receive 0 images cause an NCCL hang once the backward collective is fixed.

We have been running this fix in our internal production VLM training (multi-node, context parallelism with `vision_dp_when_cp` enabled): long runs train stably, and downstream evaluation scores improved after applying the fix — consistent with the vision encoder finally receiving the complete gradient.

<img width="2700" height="1520" alt="image" src="https://github.com/user-attachments/assets/54be5513-fe4e-4539-a2f9-e9c61a90bb1e" />


```text
Under vision_dp_when_cp the rank that ENCODES an image's tokens is not the rank
that PROCESSES them in the LLM: the fused text+vision sequence is sharded across
CP ranks in the usual zigzag pattern (rank r takes sequence chunks r and
2*cp_size-1-r), so each rank's backward produces gradient only for the rows
sitting on its own sequence shard. Printing the nonzero-row mask of grad_output
in a real CP=2 training step (one image, all of its tokens encoded by rank 0):

  grad_output on rank 0:   111111...1000000...0
  grad_output on rank 1:   000000...0111111...1   ← exactly complementary

BEFORE (no all_reduce — each rank slices its local grad):
  rank 0 keeps only its 1-rows; every 0-row of its image's gradient stays zero
  → vision grad does not flow
  rank 1 (0 images, no-grad placeholder) never runs backward at all

AFTER (all_reduce, then slice = reduce-scatter):
  the masks sum to 111111...1 — every rank holds the full gradient and slices
  out its own tokens → complete gradient ✓
  a 0-image rank joins the collective with a 0-length grad → no hang ✓
```

# Changelog

- `modelling_qwen3_vl/model.py`: call `AllGatherVisionEmbeddings.apply` with positional arguments — `torch.autograd.Function.apply` does not accept keyword arguments, so the previous `cp_group=...` call raised `TypeError: apply() takes no keyword arguments` as soon as the `vision_dp_when_cp` CP path was entered.
- `modelling_qwen3_vl/utils.py`: implement the correct backward of the all-gather (a reduce-scatter). The forward all-gathers each rank's vision embeddings to every CP rank, and the fused text+vision sequence is then sharded across CP ranks, so the gradient for one rank's vision tokens can be produced on any rank. The backward now `all_reduce`s `grad_output` over the CP group before slicing out the local range; previously each rank kept only its local slice and the cross-rank contributions were silently dropped (incomplete vision-encoder gradients). `forward` stashes `ctx.cp_group` for this.
- `modelling_qwen3_vl/model.py`: create the 0-image placeholder tensors (`vision_embeds` and each deepstack feature) with `requires_grad=True`. When `num_images < cp_size` a CP rank receives 0 images; with a no-grad placeholder, autograd skips the `Function` backward on that rank, the `all_reduce` above is never issued there, and the remaining ranks hang in the collective. The 0-length placeholders contribute nothing to the forward output.
- `tests/unit_tests/.../test_utils.py`: add two distributed unit tests (2-GPU, follow the file's existing `WORLD_SIZE>=2` pattern):
  - `test_allgather_vision_embeddings_backward_reduce_scatter` — asserts the gradient **value** is the CP-summed gradient sliced to the rank's range (the pre-existing test only checked `grad is not None`, which the buggy backward also passes).
  - `test_allgather_vision_embeddings_empty_rank` — a 0-token rank participates in the backward collective (no hang) and the token-owning rank receives the CP-summed gradient.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation? (bug fix — no doc changes needed)
- [ ] Does the PR affect components that are optional to install? (No)

# Additional Information

Verified beyond the unit tests: a mock-data Qwen3-VL pretrain (tiny 4-layer model, `MockVLMConversationProvider`) with `context_parallel_size=8`, `vision_dp_when_cp=True` on 8×A100 runs 10/10 iterations with no hang and decreasing loss (9.34 → 7.82); 0-image ranks occur naturally in every batch at CP=8. Without this fix the same setup either raises the `apply()` `TypeError` or, with only the reduce-scatter applied, hangs at the first backward.



Signed-off-by: Yoonsik Kim <yoonsik.kim90@navercorp.com>
Signed-off-by: Kayeon Song <kayeon.song@navercorp.com>
Signed-off-by: Chanwoo Park <chanwoo.park98@navercorp.com>