### PR TITLE
[training, data] fix: align eval CP data ownership

### DIFF
--- a/examples/training_features/decentralized_pg/pretrain_qwen3_eval_cp.py
+++ b/examples/training_features/decentralized_pg/pretrain_qwen3_eval_cp.py
@@ -488,6 +488,7 @@ def main() -> None:
         model_length=len(model),
         train_valid_test_datasets_provider=dataset_provider,
         dp_group=train_pgs.dp,  # train iterator sharded by train DP
+        eval_dp_group=eval_pgs.dp,
     )
 
     # =========================================================================

--- a/src/megatron/bridge/data/loaders.py
+++ b/src/megatron/bridge/data/loaders.py
@@ -201,6 +201,8 @@ def build_train_valid_test_data_loaders(
     train_state: TrainState,
     build_train_valid_test_datasets_provider: Callable,
     dp_group: torch.distributed.ProcessGroup,
+    *,
+    eval_dp_group: torch.distributed.ProcessGroup | None = None,
 ) -> tuple[Optional[DataLoader], Optional[DataLoader], Optional[DataLoader]]:
     """Build train, validation, and test data loaders.
 
@@ -211,6 +213,9 @@ def build_train_valid_test_data_loaders(
         cfg: The main configuration container.
         train_state: The current training state.
         build_train_valid_test_datasets_provider: A function to build the datasets.
+        dp_group: Data-parallel group used to shard the training dataset.
+        eval_dp_group: Optional data-parallel group used to shard validation and test datasets.
+            Defaults to ``dp_group``.
 
     Returns:
         A tuple (train_dataloader, valid_dataloader, test_dataloader).
@@ -284,9 +289,13 @@ def build_train_valid_test_data_loaders(
 
     maybe_worker_init_fn = worker_init_fn if cfg.train.exit_signal_handler_for_dataloader else None
 
-    # Resolve DP rank/size from provided data-parallel process group
+    # Resolve train and eval DP ownership from their respective process groups.
     dp_rank = torch.distributed.get_rank(group=dp_group)
     dp_size = torch.distributed.get_world_size(group=dp_group)
+    if eval_dp_group is None:
+        eval_dp_group = dp_group
+    eval_dp_rank = torch.distributed.get_rank(group=eval_dp_group)
+    eval_dp_size = torch.distributed.get_world_size(group=eval_dp_group)
 
     # Build dataloders.
     train_dataloader = build_pretraining_data_loader(
@@ -327,8 +336,8 @@ def build_train_valid_test_data_loaders(
             collate_fn=valid_ds.collate_fn if hasattr(valid_ds, "collate_fn") else None,
             pin_memory=cfg.dataset.pin_memory,
             persistent_workers=cfg.dataset.persistent_workers,
-            data_parallel_rank=dp_rank,
-            data_parallel_size=dp_size,
+            data_parallel_rank=eval_dp_rank,
+            data_parallel_size=eval_dp_size,
             global_batch_size=eval_gbs,
         )
     elif cfg.validation.eval_iters > 0:
@@ -344,8 +353,8 @@ def build_train_valid_test_data_loaders(
             collate_fn=valid_ds.collate_fn if hasattr(valid_ds, "collate_fn") else None,
             pin_memory=cfg.dataset.pin_memory,
             persistent_workers=cfg.dataset.persistent_workers,
-            data_parallel_rank=dp_rank,
-            data_parallel_size=dp_size,
+            data_parallel_rank=eval_dp_rank,
+            data_parallel_size=eval_dp_size,
             global_batch_size=eval_gbs,
         )
 
@@ -361,8 +370,8 @@ def build_train_valid_test_data_loaders(
             collate_fn=test_ds.collate_fn if hasattr(test_ds, "collate_fn") else None,
             pin_memory=cfg.dataset.pin_memory,
             persistent_workers=cfg.dataset.persistent_workers,
-            data_parallel_rank=dp_rank,
-            data_parallel_size=dp_size,
+            data_parallel_rank=eval_dp_rank,
+            data_parallel_size=eval_dp_size,
             global_batch_size=eval_gbs,
         )
 
@@ -386,6 +395,8 @@ def build_train_valid_test_data_iterators(
     train_state: TrainState,
     build_train_valid_test_datasets_provider: Callable,
     dp_group: torch.distributed.ProcessGroup,
+    *,
+    eval_dp_group: torch.distributed.ProcessGroup | None = None,
 ) -> tuple[Optional[RerunDataIterator], Optional[RerunDataIterator], Optional[RerunDataIterator]]:
     """Build train, validation, and test data iterators.
 
@@ -396,6 +407,8 @@ def build_train_valid_test_data_iterators(
         cfg: The main configuration container.
         train_state: The current training state.
         build_train_valid_test_datasets_provider: A function to build the datasets.
+        dp_group: Data-parallel group used to shard the training dataset.
+        eval_dp_group: Optional data-parallel group used to shard validation and test datasets.
 
     Returns:
         A tuple (train_data_iterator, valid_data_iterator, test_data_iterator).
@@ -407,6 +420,7 @@ def build_train_valid_test_data_iterators(
         train_state=train_state,
         build_train_valid_test_datasets_provider=build_train_valid_test_datasets_provider,
         dp_group=dp_group,
+        eval_dp_group=eval_dp_group,
     )
 
     # Build iterators.
@@ -455,6 +469,8 @@ def setup_data_iterators(
     model_length: int,
     train_valid_test_datasets_provider: Callable,
     dp_group: torch.distributed.ProcessGroup,
+    *,
+    eval_dp_group: torch.distributed.ProcessGroup | None = None,
 ) -> tuple[
     Union[Optional[RerunDataIterator], list[Optional[RerunDataIterator]]],
     Union[Optional[RerunDataIterator], list[Optional[RerunDataIterator]]],
@@ -471,6 +487,8 @@ def setup_data_iterators(
         train_state: The current training state.
         model_length: The number of model chunks (used for virtual pipeline parallelism).
         train_valid_test_datasets_provider: A function to build the datasets.
+        dp_group: Data-parallel group used to shard the training dataset.
+        eval_dp_group: Optional data-parallel group used to shard validation and test datasets.
 
     Returns:
         A tuple (train_data_iterator, valid_data_iterator, test_data_iterator).
@@ -482,6 +500,7 @@ def setup_data_iterators(
         train_state=train_state,
         build_train_valid_test_datasets_provider=train_valid_test_datasets_provider,
         dp_group=dp_group,
+        eval_dp_group=eval_dp_group,
     )
 
     return train_data_iterator, valid_data_iterator, test_data_iterator

--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -1208,12 +1208,31 @@ class ConfigContainer(Container):
             )
             self.validation.eval_micro_batch_size = self.train.micro_batch_size
 
-        # Eval batch size divisibility check
-        eval_dp_product = self.validation.eval_micro_batch_size * self.data_parallel_size
+        # Eval batch size divisibility check. Eval-time CP changes the DP degree,
+        # so validation batch semantics must use the eval layout rather than the
+        # training layout stored in ``self.data_parallel_size``.
+        eval_data_parallel_size = self.data_parallel_size
+        if self.dist.eval_context_parallel_size is not None:
+            model_cfg = self.model
+            eval_world_size = get_world_size_safe()
+            if hasattr(model_cfg, "dist_train") and getattr(model_cfg.dist_train, "use_dist_train", False) is True:
+                eval_world_size = model_cfg.dist_train.language_world_size
+            eval_model_parallel_size = (
+                model_cfg.tensor_model_parallel_size
+                * model_cfg.pipeline_model_parallel_size
+                * self.dist.eval_context_parallel_size
+            )
+            assert eval_world_size % eval_model_parallel_size == 0, (
+                f"world size ({eval_world_size}) is not divisible by eval model parallel size "
+                f"({eval_model_parallel_size})"
+            )
+            eval_data_parallel_size = eval_world_size // eval_model_parallel_size
+
+        eval_dp_product = self.validation.eval_micro_batch_size * eval_data_parallel_size
         assert self.validation.eval_global_batch_size % eval_dp_product == 0, (
             f"eval_global_batch_size ({self.validation.eval_global_batch_size}) must be divisible by "
-            f"eval_micro_batch_size * data_parallel_size ({self.validation.eval_micro_batch_size} * "
-            f"{self.data_parallel_size} = {eval_dp_product})"
+            f"eval_micro_batch_size * eval_data_parallel_size ({self.validation.eval_micro_batch_size} * "
+            f"{eval_data_parallel_size} = {eval_dp_product})"
         )
 
         # Megatron-FSDP and Torch FSDP2 are mutually-exclusive.

--- a/src/megatron/bridge/training/eval.py
+++ b/src/megatron/bridge/training/eval.py
@@ -131,15 +131,18 @@ def evaluate(
 
     total_loss_dict = {}
 
-    # make validation batch size independent from training batch size
-    eval_batch_size = state.cfg.validation.eval_global_batch_size
-    eval_micro_batch_size = state.cfg.validation.eval_micro_batch_size
-    eval_num_microbatches = eval_batch_size // (eval_micro_batch_size * state.cfg.data_parallel_size)
-
     # Determine if this is a multimodule evaluation (MegatronMIMO)
     is_multimodule = isinstance(pg_collection, MultiModuleProcessGroupCollection) or isinstance(
         p2p_communicator, MultiModulePipelineCommunicator
     )
+
+    # make validation batch size independent from training batch size
+    eval_batch_size = state.cfg.validation.eval_global_batch_size
+    eval_micro_batch_size = state.cfg.validation.eval_micro_batch_size
+    # MegatronMIMO has heterogeneous per-module DP groups and intentionally owns
+    # global-batch accounting through the container-level DP size.
+    eval_data_parallel_size = state.cfg.data_parallel_size if is_multimodule else pg_collection.dp.size()
+    eval_num_microbatches = eval_batch_size // (eval_micro_batch_size * eval_data_parallel_size)
 
     if is_multimodule and not isinstance(p2p_communicator, MultiModulePipelineCommunicator):
         raise ValueError(

--- a/src/megatron/bridge/training/setup.py
+++ b/src/megatron/bridge/training/setup.py
@@ -396,6 +396,7 @@ def setup(
         model_length=len(model),
         train_valid_test_datasets_provider=train_valid_test_datasets_provider,
         dp_group=pg_collection.dp,
+        eval_dp_group=state._eval_pgs.dp if state._eval_pgs is not None else None,
     )
     timers("train/valid/test-data-iterators-setup").stop()
     barrier_and_log("after dataloaders are built")

--- a/tests/functional_tests/test_groups/data/test_loaders.py
+++ b/tests/functional_tests/test_groups/data/test_loaders.py
@@ -299,6 +299,42 @@ class TestDataLoaders:
         assert valid_dataloader is None
         assert test_dataloader is None
 
+    @mock.patch("torch.distributed.broadcast")
+    @mock.patch("torch.distributed.get_world_size")
+    @mock.patch("torch.distributed.get_rank")
+    @mock.patch("megatron.bridge.data.loaders.build_pretraining_data_loader", return_value=object())
+    @mock.patch("megatron.bridge.data.loaders.build_train_valid_test_datasets")
+    def test_build_train_valid_test_data_loaders_uses_eval_dp_group(
+        self, mock_build_datasets, mock_build_loader, mock_get_rank, mock_get_world_size, _mock_broadcast
+    ):
+        cfg = create_simple_test_config()
+        train_ds = mock.MagicMock()
+        train_ds.__len__.return_value = cfg.train.global_batch_size
+        valid_ds = mock.MagicMock()
+        test_ds = mock.MagicMock()
+        mock_build_datasets.return_value = (train_ds, valid_ds, test_ds)
+        train_dp_group = object()
+        eval_dp_group = object()
+
+        mock_get_rank.side_effect = lambda *, group: 1 if group is train_dp_group else 0
+        mock_get_world_size.side_effect = lambda *, group: 2 if group is train_dp_group else 1
+
+        build_train_valid_test_data_loaders(
+            cfg=cfg,
+            train_state=TrainState(),
+            build_train_valid_test_datasets_provider=mock.Mock(),
+            dp_group=train_dp_group,
+            eval_dp_group=eval_dp_group,
+        )
+
+        train_call, valid_call, test_call = mock_build_loader.call_args_list
+        assert train_call.kwargs["data_parallel_rank"] == 1
+        assert train_call.kwargs["data_parallel_size"] == 2
+        assert valid_call.kwargs["data_parallel_rank"] == 0
+        assert valid_call.kwargs["data_parallel_size"] == 1
+        assert test_call.kwargs["data_parallel_rank"] == 0
+        assert test_call.kwargs["data_parallel_size"] == 1
+
 
 class TestSampleBasedDataLoaders:
     """Tests for sample-based training data loader functionality."""

--- a/tests/unit_tests/training/test_config.py
+++ b/tests/unit_tests/training/test_config.py
@@ -1946,6 +1946,26 @@ class TestEvalBatchSizeConfig:
         finally:
             restore_get_world_size_safe(og_ws, cfg_mod)
 
+    def test_eval_batch_size_divisibility_uses_eval_data_parallel_size(self, monkeypatch):
+        """Eval-time CP changes the DP degree that owns validation batches."""
+        gpt_model_cfg = create_test_gpt_config()
+        train_cfg = create_test_training_config(global_batch_size=8, micro_batch_size=1)
+        val_cfg = ValidationConfig(eval_global_batch_size=2, eval_micro_batch_size=1)
+        container, og_ws, cfg_mod = create_test_config_container(
+            world_size_override=4,
+            model_config=gpt_model_cfg,
+            train_config=train_cfg,
+            validation_config=val_cfg,
+        )
+        container.dist.use_decentralized_pg = True
+        container.dist.use_gloo_process_groups = False
+        container.dist.eval_context_parallel_size = 2
+
+        try:
+            container.validate()
+        finally:
+            restore_get_world_size_safe(og_ws, cfg_mod)
+
     def test_eval_default_divisibility_check_fails(self, monkeypatch):
         """Even with defaults from training, the divisibility check should catch mismatches."""
         gpt_model_cfg = create_test_gpt_config()

--- a/tests/unit_tests/training/test_eval.py
+++ b/tests/unit_tests/training/test_eval.py
@@ -81,6 +81,7 @@ def _make_evaluate_state(*, eval_iters, exit_duration_in_mins=None):
 def _run_evaluate(*, state, model, callback_manager, is_test=False, timelimit_hit=False):
     pg_collection = SimpleNamespace(
         pp=SimpleNamespace(size=lambda: 1),
+        dp=SimpleNamespace(size=lambda: 1),
         dp_cp=object(),
     )
     rerun_state_machine = MagicMock()
@@ -221,3 +222,87 @@ def test_evaluate_timelimit_fires_start_but_not_end_callback():
 
     assert result == (None, None, True)
     assert observed == [("on_eval_start", False)]
+
+
+def test_evaluate_uses_injected_eval_data_parallel_size_for_microbatches():
+    """An injected eval process-group layout owns eval global-batch semantics."""
+    state = _make_evaluate_state(eval_iters=1)
+    state.cfg.validation.eval_global_batch_size = 4
+    state.cfg.validation.eval_micro_batch_size = 1
+    state.cfg.data_parallel_size = 2
+    model = _ModeTrackingModel()
+    forward_backward_func = MagicMock(return_value=[{}])
+    rerun_state_machine = MagicMock()
+    eval_pg_collection = SimpleNamespace(
+        pp=SimpleNamespace(size=lambda: 1),
+        dp=SimpleNamespace(size=lambda: 1),
+        dp_cp=object(),
+    )
+
+    with (
+        patch("megatron.bridge.training.eval.prepare_forward_step_func", return_value=MagicMock()),
+        patch("megatron.bridge.training.eval.get_model_config", return_value=SimpleNamespace()),
+        patch("megatron.bridge.training.eval.get_rerun_state_machine", return_value=rerun_state_machine),
+        patch("megatron.bridge.training.eval.is_full_iteration_cuda_graph", return_value=False),
+        patch("megatron.bridge.training.eval.get_forward_backward_func", return_value=forward_backward_func),
+        patch("megatron.bridge.training.eval.is_pp_last_stage", return_value=False),
+        patch("megatron.bridge.training.eval.fault_tolerance.on_eval_step_start"),
+        patch("megatron.bridge.training.eval.fault_tolerance.on_eval_step_end"),
+    ):
+        evaluate(
+            state=state,
+            forward_step_func=MagicMock(),
+            data_iterator=object(),
+            model=[model],
+            process_non_loss_data_func=None,
+            config=SimpleNamespace(timers=state.timers),
+            p2p_communicator=MagicMock(),
+            pg_collection=eval_pg_collection,
+        )
+
+    assert forward_backward_func.call_args.kwargs["num_microbatches"] == 4
+
+
+def test_evaluate_preserves_multimodule_data_parallel_accounting():
+    """MegatronMIMO collections do not expose one shared DP process group."""
+
+    class MultimodulePGCollection:
+        pass
+
+    class MultimoduleCommunicator:
+        is_pp_last_stage = False
+
+    state = _make_evaluate_state(eval_iters=1)
+    state.cfg.validation.eval_global_batch_size = 4
+    state.cfg.validation.eval_micro_batch_size = 1
+    state.cfg.data_parallel_size = 2
+    model = _ModeTrackingModel()
+    forward_backward_func = MagicMock(return_value=[{}])
+    rerun_state_machine = MagicMock()
+
+    with (
+        patch("megatron.bridge.training.eval.MultiModuleProcessGroupCollection", MultimodulePGCollection),
+        patch("megatron.bridge.training.eval.MultiModulePipelineCommunicator", MultimoduleCommunicator),
+        patch("megatron.bridge.training.eval.prepare_forward_step_func", return_value=MagicMock()),
+        patch("megatron.bridge.training.eval.get_model_config", return_value=SimpleNamespace()),
+        patch("megatron.bridge.training.eval.get_rerun_state_machine", return_value=rerun_state_machine),
+        patch("megatron.bridge.training.eval.is_full_iteration_cuda_graph", return_value=False),
+        patch(
+            "megatron.core.pipeline_parallel.schedules.forward_backward_pipelining_without_interleaving",
+            forward_backward_func,
+        ),
+        patch("megatron.bridge.training.eval.fault_tolerance.on_eval_step_start"),
+        patch("megatron.bridge.training.eval.fault_tolerance.on_eval_step_end"),
+    ):
+        evaluate(
+            state=state,
+            forward_step_func=MagicMock(),
+            data_iterator=object(),
+            model=[model],
+            process_non_loss_data_func=None,
+            config=SimpleNamespace(timers=state.timers),
+            p2p_communicator=MultimoduleCommunicator(),
+            pg_collection=MultimodulePGCollection(),
+        )
+
+    assert forward_backward_func.call_args.kwargs["num_microbatches"] == 2


### PR DESCRIPTION
## Summary

When decentralized process groups use a different context-parallel degree for evaluation than training, the data-parallel degree changes too. Bridge still sharded validation/test data and computed eval microbatches with the training DP degree. Eval-CP peers could therefore consume different logical samples, producing finite but invalid validation loss.

## Root cause and fix

- Thread the eval DP group from `GlobalState._eval_pgs` through iterator construction.
- Use eval DP rank/size for validation and test samplers while preserving training DP ownership for training data.
- Validate eval batch divisibility with the eval CP-derived DP degree.
- Compute standard evaluation microbatches from the injected process-group collection's DP size.
- Preserve MegatronMIMO's container-level batch accounting because its module DP groups are heterogeneous.
- Wire the eval-CP showcase to the eval DP group.

## Regression evidence

Fail before:

- `test_evaluate_uses_injected_eval_data_parallel_size_for_microbatches`: scheduled 2 microbatches instead of 4.
- A deterministic two-rank reproducer showed eval-CP peers receiving sample IDs `[0, 1]` instead of the same logical sample.

Pass after:

- `uv run --active --no-sync python -m pytest tests/unit_tests/training/test_eval.py -q --tb=short` — 7 passed.
- `uv run --active --no-sync python -m pytest tests/unit_tests/training/test_config.py::TestEvalBatchSizeConfig -q --tb=short` — 16 passed.
- `uv run --active --no-sync python -m pytest tests/functional_tests/test_groups/data/test_loaders.py::TestDataLoaders::test_build_train_valid_test_data_loaders_specialized_dispatch_updates_flags tests/functional_tests/test_groups/data/test_loaders.py::TestDataLoaders::test_build_train_valid_test_data_loaders_allows_none_train_dataset tests/functional_tests/test_groups/data/test_loaders.py::TestDataLoaders::test_build_train_valid_test_data_loaders_uses_eval_dp_group --confcutdir=tests/functional_tests/test_groups/data -q --tb=short` — 3 passed.
- `uv run --active --no-sync python -m torch.distributed.run --standalone --nproc_per_node=2 reproduce_eval_cp_sample_ownership.py` — passed.
- `uv run --active --no-sync pre-commit run --all-files` — passed.
- `git diff --check` — passed.

## Scope

This fixes the supported decentralized-PG eval-CP path and standard Bridge-built validation/test iterators. It does not add eval-time CP to MegatronMIMO or change its heterogeneous batch semantics. The full test suite was not run.
