### PR TITLE
[data] fix: make CORD target selection deterministic

### DIFF
--- a/src/megatron/bridge/data/sources/hf_adapters.py
+++ b/src/megatron/bridge/data/sources/hf_adapters.py
@@ -16,7 +16,6 @@
 
 import io
 import json
-import random
 import re
 from collections.abc import Callable, Iterable, Mapping
 from pathlib import Path
@@ -164,7 +163,9 @@ def _cord_v2_adapter(example: Mapping[str, Any], kwargs: Mapping[str, Any]) -> d
         gt_jsons = ground_truth["gt_parses"]
     else:
         gt_jsons = [ground_truth["gt_parse"]]
-    text = json2token(random.choice(gt_jsons), sort_json_key=True)
+    # Dataset adaptation runs independently on pipeline stages and after RNG
+    # restoration, so target selection must not depend on process-global state.
+    text = json2token(gt_jsons[0], sort_json_key=True)
     prompt = str(kwargs.get("prompt", "Describe this image."))
     return {
         "conversation": [

--- a/tests/unit_tests/data/sources/test_hf_adapters.py
+++ b/tests/unit_tests/data/sources/test_hf_adapters.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
 
 import json
+import random
 from types import SimpleNamespace
 
 import pytest
@@ -75,6 +76,20 @@ def test_cord_adapter_supports_plural_and_singular_ground_truth(ground_truth):
 
     assert adapted[0]["conversation"][0]["content"][0]["type"] == "image"
     assert adapted[0]["conversation"][1]["role"] == "assistant"
+
+
+def test_cord_adapter_multiple_ground_truths_is_independent_of_global_rng():
+    row = {
+        "image": SimpleNamespace(),
+        "ground_truth": json.dumps({"gt_parses": [{"name": "first"}, {"name": "second"}]}),
+    }
+
+    random.seed(42)
+    first_adaptation = adapt_hf_dataset([row], adapter_name="cord_v2")
+    random.seed(142)
+    second_adaptation = adapt_hf_dataset([row], adapter_name="cord_v2")
+
+    assert first_adaptation == second_adaptation
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What does this PR do?

Makes CORD v2 target adaptation deterministic when a supported custom Hugging Face dataset row supplies multiple `gt_parses` entries.

The adapter previously selected a target with process-global `random.choice`. Dataset adaptation runs independently on pipeline stages, whose Python RNG seeds differ, and can also run after checkpoint RNG restoration. With pipeline parallelism, the first stage could therefore tokenize one parse while the last stage constructed labels from another parse, silently changing the training target. Rebuilding after resume could likewise select a different target.

The adapter now consistently uses the first accepted parse. This preserves support for singular `gt_parse` and plural `gt_parses` rows without coupling dataset semantics to process-global RNG state.

## Testing

Fail-before / pass-after regression:

```text
uv run --active --no-sync python -m pytest --confcutdir=tests/unit_tests/data tests/unit_tests/data/sources/test_hf_adapters.py::test_cord_adapter_multiple_ground_truths_is_independent_of_global_rng -q

Before: 1 failed (the two RNG seeds selected different targets)
After:  1 passed
```

Adjacent data tests:

```text
uv run --active --no-sync python -m pytest --confcutdir=tests/unit_tests/data tests/unit_tests/data/test_token_utils.py tests/unit_tests/data/sources/test_hf.py tests/unit_tests/data/sources/test_hf_adapters.py tests/unit_tests/data/builders/test_direct_hf_sft.py tests/unit_tests/data/datasets/test_direct_sft.py tests/unit_tests/data/collators/test_sft.py

92 passed
```

Two-process distributed reproducer using the real adapter:

```text
uv run --no-sync python -m torch.distributed.run --standalone --nproc_per_node=2 reproduce_cord_pp_targets.py

Before: failed; 2 ranks produced 2 distinct targets
After:  passed; 2 ranks produced 1 shared target
```

Additional checks:

```text
git diff --check
uv run --active --no-sync pre-commit run --all-files
```

Both passed.

## Scope

This change is limited to CORD-schema rows with multiple accepted ground-truth parses. It does not claim full-suite, convergence, model-quality, or performance validation.
