### PR TITLE
[model] fix: preserve Qwen hybrid attention schedules

### DIFF
--- a/src/megatron/bridge/models/conversion/transformers_compat.py
+++ b/src/megatron/bridge/models/conversion/transformers_compat.py
@@ -193,8 +193,8 @@ def rope_scaling_factor_from_hf(config, default: float = 1.0) -> float:
     return default
 
 
-def full_attention_interval_from_hf(config, default: int = 4) -> int:
-    """Extract the full-attention interval from a Qwen3-Next-style HuggingFace config.
+def full_attention_interval_from_hf(config, default: int = 4) -> int | list[int]:
+    """Extract the full-attention layout from a Qwen3-Next-style HuggingFace config.
 
     In transformers <5.5 the interval was stored directly as
     ``config.full_attention_interval``. In transformers >=5.5 the field was
@@ -208,16 +208,22 @@ def full_attention_interval_from_hf(config, default: int = 4) -> int:
         default: Value to return if neither layout is present.
 
     Returns:
-        int: The interval at which standard attention layers appear.
+        int | list[int]: The legacy interval or the exact per-layer pattern,
+        where 1 is linear attention and 0 is full attention.
+
+    Raises:
+        ValueError: If an explicit layer type is unsupported.
     """
+    layer_types = getattr(config, "layer_types", None)
+    if isinstance(layer_types, list) and layer_types:
+        supported_layer_types = {"linear_attention": 1, "full_attention": 0}
+        try:
+            return [supported_layer_types[layer_type] for layer_type in layer_types]
+        except KeyError as error:
+            raise ValueError(f"Unsupported attention layer type: {error.args[0]}") from error
+
     interval = getattr(config, "full_attention_interval", None)
     if interval is not None:
         return interval
-
-    layer_types = getattr(config, "layer_types", None)
-    if layer_types:
-        for i, layer_type in enumerate(layer_types):
-            if layer_type == "full_attention":
-                return i + 1
 
     return default

--- a/tests/unit_tests/models/qwen/test_qwen3_next_bridge.py
+++ b/tests/unit_tests/models/qwen/test_qwen3_next_bridge.py
@@ -177,6 +177,32 @@ class TestQwen3NextBridge:
         assert result.linear_num_value_heads == mock_qwen3_next_config.linear_num_value_heads
         assert result.experimental_attention_variant == "gated_delta_net"
 
+    @pytest.mark.parametrize(
+        ("layer_types", "expected_pattern"),
+        [
+            (["linear_attention"] * 4, [1, 1, 1, 1]),
+            (
+                ["linear_attention", "full_attention", "linear_attention", "linear_attention"],
+                [1, 0, 1, 1],
+            ),
+        ],
+    )
+    def test_provider_bridge_preserves_explicit_layer_types(
+        self,
+        mock_pretrained_qwen3_next,
+        mock_qwen3_next_config,
+        layer_types,
+        expected_pattern,
+    ):
+        """Explicit Hugging Face layer schedules must survive config conversion."""
+        mock_qwen3_next_config.num_hidden_layers = len(layer_types)
+        mock_qwen3_next_config.full_attention_interval = None
+        mock_qwen3_next_config.layer_types = layer_types
+
+        result = Qwen3NextBridge().provider_bridge(mock_pretrained_qwen3_next)
+
+        assert result.linear_attention_freq == expected_pattern
+
     def test_provider_bridge_mlp_config(self, mock_pretrained_qwen3_next, mock_qwen3_next_config):
         """Test MLP configuration mapping."""
         bridge = Qwen3NextBridge()


### PR DESCRIPTION
## What does this PR do?

Preserves explicit per-layer hybrid-attention schedules when converting Qwen3-Next and Qwen3.5 Hugging Face configs to Megatron providers.

## Supported trigger and impact

Transformers 5.8 accepts `layer_types` as an explicit per-layer list. Local or derived Qwen3-Next/Qwen3.5 checkpoints can therefore use non-periodic schedules, including all-linear attention.

Bridge previously reduced that list to the first full-attention position, or defaulted to interval 4 when no full-attention layer existed. Megatron then expanded the integer periodically. The resulting provider instantiated different attention modules from the Hugging Face model, so checkpoint conversion could encounter `linear_attn.*` weights where the Megatron model expected `self_attn.*`, or vice versa.

## Root cause and fix

`full_attention_interval_from_hf()` treated Transformers 5.x `layer_types` only as a source from which to reconstruct a legacy interval. That reconstruction is valid only for periodic schedules.

The helper now translates an explicit list directly to Megatron's exact per-layer representation (`1` for linear attention, `0` for full attention), with the same precedence Transformers gives `layer_types`. Legacy interval-only configs retain the existing integer path. Unsupported explicit layer names fail clearly.

## Validation

Fail-before on unmodified production code:

```text
uv run --no-sync python -m pytest tests/unit_tests/models/qwen/test_qwen3_next_bridge.py::TestQwen3NextBridge::test_provider_bridge_preserves_explicit_layer_types -q
2 failed
```

The all-linear case returned `4` instead of `[1, 1, 1, 1]`; the non-periodic case returned `2` instead of `[1, 0, 1, 1]`.

Pass-after with the unchanged regression:

```text
uv run --no-sync python -m pytest tests/unit_tests/models/qwen/test_qwen3_next_bridge.py::TestQwen3NextBridge::test_provider_bridge_preserves_explicit_layer_types -q
2 passed
```

Adjacent coverage:

```text
uv run --no-sync python -m pytest tests/unit_tests/models/qwen/test_qwen3_next_bridge.py tests/unit_tests/models/qwen/test_qwen35_bridge.py -q
61 passed

uv run --no-sync pre-commit run --all-files
Passed

git diff --check
Passed
```

An additional config-only probe with installed Transformers 5.8.1 verified both schedules for `Qwen3NextConfig`, `Qwen3_5TextConfig`, and `Qwen3_5MoeTextConfig`.

## Scope

This changes only deterministic CPU config translation and its unit regression. It does not change parameter mappings, checkpoint formats, dependencies, CI workflows, or MCore. No GPU, convergence, quality, or performance validation is claimed.
