### PR TITLE
[ckpt] fix: align ModelOpt checkpoint selection

### DIFF
--- a/examples/models/nemotron/nemotron_3/super/qat_nemotron_3_super.py
+++ b/examples/models/nemotron/nemotron_3/super/qat_nemotron_3_super.py
@@ -83,7 +83,8 @@ def main() -> None:
 
     # Check for ModelOpt state
     checkpoint_to_check = cfg.checkpoint.pretrained_checkpoint or cfg.checkpoint.load
-    if checkpoint_to_check and has_modelopt_state(checkpoint_to_check):
+    ckpt_step = None if cfg.checkpoint.pretrained_checkpoint else cfg.checkpoint.ckpt_step
+    if checkpoint_to_check and has_modelopt_state(checkpoint_to_check, ckpt_step=ckpt_step):
         cfg.model.restore_modelopt_state = True
         # ModelOpt quantization does not support gradient accumulation fusion
         cfg.model.gradient_accumulation_fusion = False

--- a/examples/quantization/pretrain_quantized_llama3_8b.py
+++ b/examples/quantization/pretrain_quantized_llama3_8b.py
@@ -195,7 +195,8 @@ def main() -> None:
 
     # Check for ModelOpt state
     checkpoint_to_check = cfg.checkpoint.pretrained_checkpoint or cfg.checkpoint.load
-    if checkpoint_to_check and has_modelopt_state(checkpoint_to_check):
+    ckpt_step = None if cfg.checkpoint.pretrained_checkpoint else cfg.checkpoint.ckpt_step
+    if checkpoint_to_check and has_modelopt_state(checkpoint_to_check, ckpt_step=ckpt_step):
         cfg.model.restore_modelopt_state = True
 
     # Display final configuration

--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -1259,6 +1259,9 @@ class ConfigContainer(Container):
                 "Gradient accumulation fusion is not supported with ModelOpt/Quantized models. "
                 "Please set model.gradient_accumulation_fusion=False"
             )
+            from megatron.bridge.training.post_training.checkpointing import _validate_modelopt_checkpointing
+
+            _validate_modelopt_checkpointing(self.checkpoint.non_persistent_ckpt_type)
 
         # Checkpoint
         self._validate_hf_checkpoint_export_source()

--- a/src/megatron/bridge/training/post_training/checkpointing.py
+++ b/src/megatron/bridge/training/post_training/checkpointing.py
@@ -28,10 +28,31 @@ from megatron.core.transformer.module import MegatronModule
 from megatron.core.utils import unwrap_model
 
 
-def _get_modelopt_checkpoint_path(checkpoint_path: str) -> str:
-    """Get the path to use for ModelOpt operations (handles iteration directories)."""
+def _validate_modelopt_checkpointing(non_persistent_ckpt_type: str | None) -> None:
+    """Reject checkpoint sources whose ModelOpt state cannot be selected consistently."""
+    if non_persistent_ckpt_type is not None:
+        raise ValueError(
+            "ModelOpt checkpoint restoration is not supported with non-persistent checkpoint loading. "
+            "Set checkpoint.non_persistent_ckpt_type=None."
+        )
+
+
+def _get_modelopt_checkpoint_path(checkpoint_path: str, ckpt_step: int | None = None) -> str:
+    """Get the checkpoint iteration path to use for ModelOpt operations."""
     if not checkpoint_path or not os.path.isdir(checkpoint_path):
         return checkpoint_path
+
+    from megatron.bridge.training.checkpointing import (
+        _DIRECT_ITERATION_DIR_SENTINEL,
+        _resolve_checkpoint_iteration,
+    )
+    from megatron.bridge.training.utils.checkpoint_utils import get_checkpoint_name
+
+    iteration, release = _resolve_checkpoint_iteration(checkpoint_path, ckpt_step)
+    if iteration == _DIRECT_ITERATION_DIR_SENTINEL:
+        return checkpoint_path
+    if iteration >= 0 or release:
+        return get_checkpoint_name(checkpoint_path, iteration, release)
 
     # Check for iter_* folders
     try:
@@ -68,19 +89,20 @@ def _get_modelopt_checkpoint_path(checkpoint_path: str) -> str:
     return checkpoint_path  # No iteration dirs, use root
 
 
-def has_modelopt_state(checkpoint_path: str) -> bool:
+def has_modelopt_state(checkpoint_path: str, ckpt_step: int | None = None) -> bool:
     """Check if ModelOpt state exists inside the checkpoint path.
 
     Checks for modelopt_state in iteration directories (iter_*) or root directory.
     NOTE: Ignores distillation state which is deprecated and unused.
 
     Args:
-        checkpoint_path: Path to the checkpoint directory
+        checkpoint_path: Path to the checkpoint directory.
+        ckpt_step: Specific checkpoint iteration selected for native loading.
 
     Returns:
         True if modelopt_state folder exists and contains nontrivial state, else False.
     """
-    modelopt_checkpoint_path = _get_modelopt_checkpoint_path(checkpoint_path)
+    modelopt_checkpoint_path = _get_modelopt_checkpoint_path(checkpoint_path, ckpt_step)
     modelopt_state_path = os.path.join(modelopt_checkpoint_path, "modelopt_state")
     if not os.path.isdir(modelopt_state_path):
         return False
@@ -94,12 +116,17 @@ def has_modelopt_state(checkpoint_path: str) -> bool:
     return len(modes) > 0
 
 
-def load_modelopt_state(model: list[MegatronModule], checkpoint_path: str) -> None:
+def load_modelopt_state(
+    model: list[MegatronModule],
+    checkpoint_path: str,
+    ckpt_step: int | None = None,
+) -> None:
     """Load modelopt_state from a checkpoint.
     Args:
         model: The model to load the modelopt_state into
-        checkpoint_path: Path to the checkpoint directory
+        checkpoint_path: Path to the checkpoint directory.
+        ckpt_step: Specific checkpoint iteration selected for native loading.
     """
-    modelopt_checkpoint_path = _get_modelopt_checkpoint_path(checkpoint_path)
+    modelopt_checkpoint_path = _get_modelopt_checkpoint_path(checkpoint_path, ckpt_step)
     unwrapped_model = unwrap_model(model)
     restore_sharded_modelopt_state(unwrapped_model, modelopt_checkpoint_path)

--- a/src/megatron/bridge/training/setup.py
+++ b/src/megatron/bridge/training/setup.py
@@ -288,15 +288,19 @@ def setup(
             # Check which checkpoint path has modelopt state
             if cfg.checkpoint.pretrained_checkpoint and has_modelopt_state(cfg.checkpoint.pretrained_checkpoint):
                 checkpoint_path = cfg.checkpoint.pretrained_checkpoint
-            elif cfg.checkpoint.load and has_modelopt_state(cfg.checkpoint.load):
+                ckpt_step = None
+            elif cfg.checkpoint.load and has_modelopt_state(
+                cfg.checkpoint.load, ckpt_step=cfg.checkpoint.ckpt_step
+            ):
                 checkpoint_path = cfg.checkpoint.load
+                ckpt_step = cfg.checkpoint.ckpt_step
             else:
                 raise RuntimeError(
                     f"No modelopt_state found in pretrained_checkpoint={cfg.checkpoint.pretrained_checkpoint} "
                     f"or load={cfg.checkpoint.load}"
                 )
 
-            load_modelopt_state(model, checkpoint_path)
+            load_modelopt_state(model, checkpoint_path, ckpt_step=ckpt_step)
             return model
 
         _register_pre_wrap_hook(cfg.model, modelopt_pre_wrap_hook)

--- a/tests/unit_tests/training/post_training/test_checkpointing.py
+++ b/tests/unit_tests/training/post_training/test_checkpointing.py
@@ -23,6 +23,7 @@ from megatron.core.dist_checkpointing.strategies.common import COMMON_STATE_FNAM
 
 from megatron.bridge.training.post_training.checkpointing import (
     _get_modelopt_checkpoint_path,
+    _validate_modelopt_checkpointing,
     has_modelopt_state,
     load_modelopt_state,
 )
@@ -117,6 +118,36 @@ class TestGetModeloptCheckpointPath:
                 result = _get_modelopt_checkpoint_path(str(checkpoint_path))
                 assert result == str(iter_folder_200)
                 assert mock_load.call_count == 3
+
+    def test_returns_tracked_iter_folder_before_higher_iter(self):
+        """Test that ModelOpt state follows the checkpoint selected by the native tracker."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            checkpoint_path = Path(temp_dir)
+            iter_folder_100 = checkpoint_path / "iter_0000100"
+            iter_folder_200 = checkpoint_path / "iter_0000200"
+            iter_folder_100.mkdir()
+            iter_folder_200.mkdir()
+            (checkpoint_path / "latest_checkpointed_iteration.txt").write_text("100", encoding="utf-8")
+
+            with patch("megatron.core.dist_checkpointing.load_common_state_dict") as mock_load:
+                mock_load.side_effect = lambda path: {"iteration": 100 if path == str(iter_folder_100) else 200}
+
+                result = _get_modelopt_checkpoint_path(str(checkpoint_path))
+
+            assert result == str(iter_folder_100)
+
+    def test_explicit_step_overrides_higher_iter(self):
+        """Test that ModelOpt state follows the explicit native checkpoint step."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            checkpoint_path = Path(temp_dir)
+            iter_folder_100 = checkpoint_path / "iter_0000100"
+            iter_folder_200 = checkpoint_path / "iter_0000200"
+            iter_folder_100.mkdir()
+            iter_folder_200.mkdir()
+
+            result = _get_modelopt_checkpoint_path(str(checkpoint_path), ckpt_step=100)
+
+            assert result == str(iter_folder_100)
 
     def test_handles_exception_during_state_dict_load(self):
         """Test that it skips checkpoints that fail to load and continues."""
@@ -273,6 +304,19 @@ class TestGetModeloptCheckpointPath:
 
 class TestPostTrainingCheckpointUtilities:
     """Test utility functions for post-training checkpoint management."""
+
+    @pytest.mark.parametrize("non_persistent_ckpt_type", ["global", "local"])
+    def test_rejects_non_persistent_modelopt_restore(self, non_persistent_ckpt_type):
+        """Test that ModelOpt restoration rejects ambiguous non-persistent checkpoint loading."""
+        with pytest.raises(
+            ValueError,
+            match="ModelOpt checkpoint restoration is not supported with non-persistent checkpoint loading",
+        ):
+            _validate_modelopt_checkpointing(non_persistent_ckpt_type)
+
+    def test_allows_persistent_modelopt_restore(self):
+        """Test that persistent ModelOpt restoration remains supported."""
+        _validate_modelopt_checkpointing(None)
 
     @pytest.mark.parametrize(
         "checkpoint_path,modelopt_exists,expected",


### PR DESCRIPTION
## Summary

Keep ModelOpt transformation state on the same checkpoint iteration as native model, optimizer, RNG, and train-state loading.

## Supported trigger and impact

A quantized/QAT checkpoint root can contain multiple `iter_*` directories while the native tracker or `checkpoint.ckpt_step` selects a non-maximum iteration. Bridge previously restored ModelOpt state from the numerically greatest directory, then loaded native state from the tracked/requested directory. This could construct incompatible transformed modules, fail state loading, or apply transformation metadata from the wrong training step.

## Root cause and fix

`training/post_training/checkpointing.py` maintained an independent maximum-iteration scan instead of using the native checkpoint resolver.

The patch:

- reuses native direct-directory, explicit-step, Bridge-tracker, and legacy-tracker selection;
- propagates `ckpt_step` through setup and the two QAT entry points;
- preserves the existing scan fallback for roots without tracker metadata;
- rejects ModelOpt restoration with non-persistent loading, whose later source selection cannot currently be aligned safely.

## Regression evidence

- Fail before: the focused tracker regression selected `iter_0000200` for ModelOpt while the native tracker selected `iter_0000100` (1 failed).
- Pass after: the unchanged tracker contract reproducer exits 0; explicit `ckpt_step` also selects the requested iteration.
- Focused and adjacent unit file: 39 passed.

Validation commands (the pytest command used a local CPU optional-import harness; no checkpoint selection behavior was mocked):

```text
uv run --no-project --python 3.12 --with pytest==8.3.5 python -m pytest --confcutdir=tests/unit_tests/training/post_training tests/unit_tests/training/post_training/test_checkpointing.py -q
uv run pre-commit run --all-files
git diff --check
```

All passed.

## Scope

This validates checkpoint-source selection and focused CPU contracts. It does not claim GPU training, convergence, performance, or full-suite validation. ModelOpt plus non-persistent checkpoint loading is now rejected explicitly rather than mixing state sources.
