### PR TITLE
[diffusion] fix: Encode Wan T5 prompts on CPU

### DIFF
--- a/src/megatron/bridge/diffusion/models/wan/flow_matching/flow_inference_pipeline.py
+++ b/src/megatron/bridge/diffusion/models/wan/flow_matching/flow_inference_pipeline.py
@@ -384,8 +384,8 @@ class FlowInferencePipeline:  # noqa: D101
                 if offload_model:
                     self.text_encoder.cpu()
             else:
-                context = self.text_encoder([prompt], torch.device("cpu"))[0].to(self.device)
-                context_null = self.text_encoder([n_prompt], torch.device("cpu"))[0].to(self.device)
+                context = _encode_text(self.tokenizer, self.text_encoder, "cpu", prompt).to(self.device)
+                context_null = _encode_text(self.tokenizer, self.text_encoder, "cpu", n_prompt).to(self.device)
             context_lens.append(context_max_len)  # all samples have the same context_max_len
             contexts.append(context)
             contexts_null.append(context_null)

--- a/tests/unit_tests/diffusion/model/wan/flow_matching/test_flow_inference_pipeline.py
+++ b/tests/unit_tests/diffusion/model/wan/flow_matching/test_flow_inference_pipeline.py
@@ -18,6 +18,7 @@ from unittest.mock import MagicMock
 
 import pytest
 import torch
+from transformers import UMT5Config, UMT5EncoderModel
 
 from megatron.bridge.diffusion.models.wan.flow_matching.flow_inference_pipeline import (
     FlowInferencePipeline,
@@ -614,4 +615,30 @@ class TestGenerate:
             seed=42,
             offload_model=False,
         )
+        assert isinstance(result, torch.Tensor)
+
+    def test_generate_with_t5_cpu(self, pipeline_for_generate):
+        pip = pipeline_for_generate
+        pip.t5_cpu = True
+        pip.text_encoder = UMT5EncoderModel(
+            UMT5Config(
+                vocab_size=32,
+                d_model=32,
+                d_kv=8,
+                d_ff=64,
+                num_layers=1,
+                num_heads=4,
+                dropout_rate=0.0,
+            )
+        )
+
+        result = pip.generate(
+            prompts=["a cat"],
+            sizes=[(16, 16)],
+            frame_nums=[5],
+            sampling_steps=2,
+            seed=42,
+            offload_model=False,
+        )
+
         assert isinstance(result, torch.Tensor)


### PR DESCRIPTION
## What

Wan text-to-video inference crashes before sampling when users select the public `--t5_cpu` option. The flag reaches `FlowInferencePipeline`, which constructs a raw Hugging Face `UMT5EncoderModel`, but the CPU branch invokes it with the obsolete wrapper form `text_encoder([prompt], device)`. Transformers binds the prompt list as `input_ids` and fails at `input_ids.size()`.

## Fix

Reuse the existing `_encode_text` adapter on CPU for both positive and negative prompts, then move only the resulting embeddings to the DiT device. This preserves the intended memory-saving behavior without changing the default GPU text-encoder path.

A focused regression uses a tiny real `UMT5EncoderModel` through the public `generate(..., t5_cpu=True)` contract.

## Verification

Fail-before on unmodified `main`:

```bash
uv run --no-sync python -m pytest tests/unit_tests/diffusion/model/wan/flow_matching/test_flow_inference_pipeline.py::TestGenerate::test_generate_with_t5_cpu -vv --tb=short
```

Result: `1 failed` with `AttributeError: list object has no attribute size` at the UMT5 input path.

Pass-after with the unchanged regression:

```bash
uv run --no-sync python -m pytest tests/unit_tests/diffusion/model/wan/flow_matching/test_flow_inference_pipeline.py::TestGenerate::test_generate_with_t5_cpu -q
```

Result: `1 passed`.

Adjacent units:

```bash
uv run --no-sync python -m pytest \
  tests/unit_tests/diffusion/model/wan/flow_matching/test_flow_inference_pipeline.py \
  tests/unit_tests/diffusion/model/wan/inference/test_inference_init.py \
  tests/unit_tests/diffusion/model/wan/inference/test_inference_utils.py \
  -q -k "not test_generate_offload_model"
```

Result: `37 passed, 1 skipped, 1 deselected`. The deselected existing case requires CUDA synchronization; this CPU text-encoding fix does not alter CUDA execution.

```bash
git diff --check
uv run --no-sync pre-commit run --all-files
```

Both passed.

## Scope

This change only repairs the supported single-GPU Wan `--t5_cpu` path. It does not enable parallel Wan inference, alter model/checkpoint formats, add dependencies, or change public signatures.