### PR TITLE
fix(training): pass only supported kwargs to get_batch_on_this_cp_rank (#3991)

### DIFF
--- a/src/megatron/bridge/training/gpt_step.py
+++ b/src/megatron/bridge/training/gpt_step.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
 import logging
-from functools import partial
-from typing import Iterable
+from functools import lru_cache, partial
+from typing import Callable, Iterable
 
 import modelopt.torch.distill as mtd
 import torch
@@ -56,6 +57,27 @@ _LEGACY_PACKED_SEQ_DEVICE_KEYS = ("cu_seqlens", "cu_seqlens_unpadded")
 _LEGACY_PACKED_SEQ_HOST_KEYS = ("cu_seqlens_argmin", "max_seqlen", "cu_seqlens_unpadded_argmin")
 _LEGACY_PACKED_SEQ_PARAM_KEYS = (*_LEGACY_PACKED_SEQ_DEVICE_KEYS, *_LEGACY_PACKED_SEQ_HOST_KEYS, "total_tokens")
 _PackedMetadataValue = torch.Tensor | int | None
+
+
+@lru_cache(maxsize=None)
+def _supported_kwargs(func: Callable) -> frozenset[str]:
+    """Return the parameter names accepted by ``func``."""
+    return frozenset(inspect.signature(func).parameters)
+
+
+def _slice_batch_on_this_cp_rank(batch: dict[str, torch.Tensor], cp_group) -> dict[str, torch.Tensor]:
+    """Call ``get_batch_on_this_cp_rank`` passing only the kwargs the installed Megatron-LM supports.
+
+    The ``is_hybrid_cp`` and ``cp_group`` kwargs exist on Megatron-LM main but not on
+    all branches (e.g. the ``dev`` branch), so pass them only when accepted (#3991).
+    """
+    supported = _supported_kwargs(get_batch_on_this_cp_rank)
+    kwargs = {}
+    if "is_hybrid_cp" in supported:
+        kwargs["is_hybrid_cp"] = False
+    if "cp_group" in supported:
+        kwargs["cp_group"] = cp_group
+    return get_batch_on_this_cp_rank(batch, **kwargs)
 
 
 def _trim_padded_cu_seqlens_for_cp(cu_seqlens: torch.Tensor, cu_seqlens_argmin: torch.Tensor | None) -> torch.Tensor:
@@ -339,7 +361,7 @@ def get_batch(
         batch = _partition_packed_batch_for_cp(batch, cp_size)
     else:
         # slice batch along sequence dimension for context parallelism
-        batch = get_batch_on_this_cp_rank(batch, is_hybrid_cp=False, cp_group=pg_collection.cp)
+        batch = _slice_batch_on_this_cp_rank(batch, cp_group=pg_collection.cp)
 
     return (
         batch["tokens"],

--- a/tests/unit_tests/training/test_gpt_step.py
+++ b/tests/unit_tests/training/test_gpt_step.py
@@ -26,6 +26,7 @@ from megatron.bridge.training.gpt_step import (
     _cu_seqlens_for_cp_partition,
     _forward_step_common,
     _partition_packed_batch_for_cp,
+    _slice_batch_on_this_cp_rank,
     get_batch,
     get_packed_seq_params,
 )
@@ -1126,3 +1127,52 @@ class TestCreateLossFunctionModelopt:
             assert torch.equal(loss_func.args[0], loss_mask)
             assert loss_func.keywords["check_for_nan_in_loss"] == False
             assert loss_func.keywords["check_for_spiky_loss"] == False
+
+
+class TestSliceBatchOnThisCpRank:
+    """Tests for _slice_batch_on_this_cp_rank kwarg compatibility across Megatron-LM branches (#3991)."""
+
+    def test_passes_kwargs_when_supported(self):
+        """Modern Megatron-LM main signature: is_hybrid_cp and cp_group are forwarded."""
+        received = {}
+
+        def modern(batch, is_hybrid_cp=True, cp_group=None):
+            received["is_hybrid_cp"] = is_hybrid_cp
+            received["cp_group"] = cp_group
+            return batch
+
+        sentinel_group = object()
+        batch = {"tokens": torch.zeros(1)}
+        with patch("megatron.bridge.training.gpt_step.get_batch_on_this_cp_rank", modern):
+            out = _slice_batch_on_this_cp_rank(batch, cp_group=sentinel_group)
+
+        assert out is batch
+        assert received == {"is_hybrid_cp": False, "cp_group": sentinel_group}
+
+    def test_omits_kwargs_when_unsupported(self):
+        """Megatron-LM dev-branch signature (batch only) must not receive unknown kwargs."""
+
+        def legacy(batch):
+            return batch
+
+        batch = {"tokens": torch.zeros(1)}
+        with patch("megatron.bridge.training.gpt_step.get_batch_on_this_cp_rank", legacy):
+            out = _slice_batch_on_this_cp_rank(batch, cp_group=object())
+
+        assert out is batch
+
+    def test_partial_signature_only_cp_group(self):
+        """A branch that accepts cp_group but not is_hybrid_cp gets only cp_group."""
+        received = {}
+
+        def partial_sig(batch, cp_group=None):
+            received["cp_group"] = cp_group
+            return batch
+
+        sentinel_group = object()
+        batch = {"tokens": torch.zeros(1)}
+        with patch("megatron.bridge.training.gpt_step.get_batch_on_this_cp_rank", partial_sig):
+            out = _slice_batch_on_this_cp_rank(batch, cp_group=sentinel_group)
+
+        assert out is batch
+        assert received == {"cp_group": sentinel_group}


### PR DESCRIPTION
## What does this PR do?

Fixes #3991.

`get_batch()` in `gpt_step.py` calls `megatron.core.utils.get_batch_on_this_cp_rank()` with `is_hybrid_cp=False, cp_group=...` unconditionally. Those kwargs exist on Megatron-LM `main` but not on all branches (e.g. the `dev` branch required for Step-3.5 training), so training fails at iteration 0 with:

```
TypeError: get_batch_on_this_cp_rank() got an unexpected keyword argument 'is_hybrid_cp'
```

## Fix

Add `_slice_batch_on_this_cp_rank()`, which inspects the installed function's signature once (`lru_cache`-ed per function object) and forwards only the kwargs it accepts:

- `is_hybrid_cp` / `cp_group` supported → passed as before (no behavior change on pinned MCore).
- Older/divergent signatures → kwargs omitted, positional `batch` only.

## Tests

Added `TestSliceBatchOnThisCpRank` in `tests/unit_tests/training/test_gpt_step.py` covering the modern signature, the legacy batch-only signature, and a partial (`cp_group`-only) signature.

## Changelog

- fix(training): tolerate Megatron-LM branches where `get_batch_on_this_cp_rank` lacks `is_hybrid_cp`/`cp_group` kwargs