### PR TITLE
fix(training): account for rampup_batch_size in scheduler step calculation (#2609)

### DIFF
--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -1459,6 +1459,54 @@ class ConfigContainer(Container):
         )
         self._calculate_scheduler_steps()
 
+    def _get_consumed_samples_for_iterations(self, iterations: int) -> int:
+        """Return the number of samples consumed after ``iterations``, honoring batch-size ramp-up.
+
+        Mirrors the ramp-up behavior of
+        ``megatron.core.num_microbatches_calculator.RampupBatchsizeNumMicroBatchesCalculator`` so
+        scheduler sample counts line up with the iterations actually trained (#2609).
+        """
+        if iterations <= 0:
+            return 0
+
+        global_batch_size = self.train.global_batch_size
+        rampup_batch_size = self.train.rampup_batch_size
+        if rampup_batch_size is None:
+            return iterations * global_batch_size
+
+        assert len(rampup_batch_size) == 3, (
+            "expected rampup_batch_size format: [<start batch size>, <batch size increment>, <ramp-up samples>]"
+        )
+        start_batch_size = int(rampup_batch_size[0])
+        batch_size_increment = int(rampup_batch_size[1])
+        rampup_samples = int(rampup_batch_size[2])
+
+        diff_batch_size = global_batch_size - start_batch_size
+        assert diff_batch_size >= 0, (
+            "expected global batch size to be greater than or equal to start batch size, "
+            f"got {global_batch_size} and {start_batch_size}"
+        )
+        assert batch_size_increment > 0, f"expected a positive batch size increment, got {batch_size_increment}"
+        assert diff_batch_size % batch_size_increment == 0, (
+            f"expected global batch size interval ({diff_batch_size}) to be divisible by global batch "
+            f"size increment ({batch_size_increment})"
+        )
+
+        num_increments = diff_batch_size // batch_size_increment
+        if num_increments == 0:
+            return iterations * global_batch_size
+        rampup_samples_per_increment = rampup_samples / num_increments
+
+        consumed_samples = 0
+        iterations_done = 0
+        while iterations_done < iterations and consumed_samples < rampup_samples:
+            steps = int(consumed_samples / rampup_samples_per_increment)
+            current_batch_size = min(start_batch_size + steps * batch_size_increment, global_batch_size)
+            consumed_samples += current_batch_size
+            iterations_done += 1
+
+        return consumed_samples + (iterations - iterations_done) * global_batch_size
+
     def _calculate_scheduler_steps(self) -> None:
         """Calculate scheduler steps for both iteration-based and sample-based training."""
         is_sample_based = self.train.train_samples is not None
@@ -1483,16 +1531,24 @@ class ConfigContainer(Container):
                 self.scheduler.lr_decay_iters = self.train.train_iters
             if self.scheduler.lr_wsd_decay_iters is None and self.scheduler.lr_decay_style == "WSD":
                 self.scheduler.lr_wsd_decay_iters = self.scheduler.lr_decay_iters
-            self.scheduler.lr_decay_steps = self.scheduler.lr_decay_iters * self.train.global_batch_size
-            self.scheduler.wd_incr_steps = self.train.train_iters * self.train.global_batch_size
+            self.scheduler.lr_decay_steps = self._get_consumed_samples_for_iterations(self.scheduler.lr_decay_iters)
+            self.scheduler.wd_incr_steps = self._get_consumed_samples_for_iterations(self.train.train_iters)
 
             if self.scheduler.lr_wsd_decay_iters is not None:
-                self.scheduler.wsd_decay_steps = self.scheduler.lr_wsd_decay_iters * self.train.global_batch_size
+                # WSD decay covers the LAST lr_wsd_decay_iters iterations of the decay horizon,
+                # so measure the sample span between those two iteration marks (#2609).
+                self.scheduler.wsd_decay_steps = self.scheduler.lr_decay_steps - (
+                    self._get_consumed_samples_for_iterations(
+                        self.scheduler.lr_decay_iters - self.scheduler.lr_wsd_decay_iters
+                    )
+                )
 
             if self.scheduler.lr_warmup_fraction is not None:
                 self.scheduler.lr_warmup_steps = self.scheduler.lr_warmup_fraction * self.scheduler.lr_decay_steps
             else:
-                self.scheduler.lr_warmup_steps = self.scheduler.lr_warmup_iters * self.train.global_batch_size
+                self.scheduler.lr_warmup_steps = self._get_consumed_samples_for_iterations(
+                    self.scheduler.lr_warmup_iters
+                )
 
         # Enforce the Megatron Core invariant: lr_warmup_steps must be < lr_decay_steps.
         # This can be violated when train_iters is small (e.g. smoke runs) while

--- a/tests/unit_tests/training/test_config.py
+++ b/tests/unit_tests/training/test_config.py
@@ -3814,3 +3814,71 @@ class TestTokenizerConfig:
                 metadata_path=metadata_path,
                 random_arg=True,
             )
+
+
+class TestSchedulerStepsWithRampupBatchSize:
+    """Scheduler sample counts must honor rampup_batch_size (#2609)."""
+
+    def _validated_container(self, train_cfg, sched_cfg):
+        gpt_model_cfg = create_test_gpt_config()
+        container, og_ws, cfg_mod = create_test_config_container(
+            world_size_override=1, model_config=gpt_model_cfg, train_config=train_cfg, scheduler_config=sched_cfg
+        )
+        try:
+            container.validate()
+        finally:
+            restore_get_world_size_safe(og_ws, cfg_mod)
+        return container
+
+    def test_consumed_samples_no_rampup_matches_product(self):
+        train_cfg = create_test_training_config(train_iters=100, global_batch_size=16)
+        sched_cfg = create_test_scheduler_config()
+        container = self._validated_container(train_cfg, sched_cfg)
+        assert container._get_consumed_samples_for_iterations(100) == 100 * 16
+        assert container._get_consumed_samples_for_iterations(0) == 0
+
+    def test_consumed_samples_with_rampup(self):
+        # rampup [8, 8, 160]: 20 iterations at batch size 8, then batch size 16.
+        train_cfg = create_test_training_config(train_iters=100, global_batch_size=16, rampup_batch_size=[8, 8, 160])
+        sched_cfg = create_test_scheduler_config()
+        container = self._validated_container(train_cfg, sched_cfg)
+        assert container._get_consumed_samples_for_iterations(10) == 80
+        assert container._get_consumed_samples_for_iterations(20) == 160
+        assert container._get_consumed_samples_for_iterations(100) == 160 + 80 * 16
+
+    def test_consumed_samples_rampup_start_equals_global(self):
+        train_cfg = create_test_training_config(train_iters=50, global_batch_size=16, rampup_batch_size=[16, 8, 160])
+        sched_cfg = create_test_scheduler_config()
+        container = self._validated_container(train_cfg, sched_cfg)
+        assert container._get_consumed_samples_for_iterations(50) == 50 * 16
+
+    def test_wsd_schedule_with_rampup(self):
+        """Reproduces the #2609 example: warmup ends at iter 10 and WSD decay spans the last 20 iters."""
+        train_cfg = create_test_training_config(train_iters=100, global_batch_size=16, rampup_batch_size=[8, 8, 160])
+        sched_cfg = create_test_scheduler_config(
+            lr_decay_style="WSD",
+            lr_wsd_decay_style="linear",
+            lr_warmup_iters=10,
+            lr_wsd_decay_iters=20,
+        )
+        container = self._validated_container(train_cfg, sched_cfg)
+
+        # 20 ramp iterations at batch 8 consume 160 samples; the remaining 80 iterations consume 80*16.
+        assert container.scheduler.lr_warmup_steps == 80  # ends exactly at iteration 10
+        assert container.scheduler.lr_decay_steps == 1440
+        assert container.scheduler.wd_incr_steps == 1440
+        # Decay covers the last 20 iterations: consumed(100) - consumed(80) = 1440 - 1120.
+        assert container.scheduler.wsd_decay_steps == 320
+
+    def test_warmup_and_decay_without_rampup_unchanged(self):
+        train_cfg = create_test_training_config(train_iters=100, global_batch_size=16)
+        sched_cfg = create_test_scheduler_config(
+            lr_decay_style="WSD",
+            lr_wsd_decay_style="linear",
+            lr_warmup_iters=10,
+            lr_wsd_decay_iters=20,
+        )
+        container = self._validated_container(train_cfg, sched_cfg)
+        assert container.scheduler.lr_warmup_steps == 10 * 16
+        assert container.scheduler.lr_decay_steps == 100 * 16
+        assert container.scheduler.wsd_decay_steps == 20 * 16


### PR DESCRIPTION
## What does this PR do?

Fixes #2609.

`ConfigContainer._calculate_scheduler_steps()` converts iteration-based scheduler settings to sample counts as `iters * global_batch_size`. With `rampup_batch_size` enabled the early iterations consume fewer samples, so:

- LR warmup lasts longer (in iterations) than `lr_warmup_iters`
- decay starts and ends later than configured
- for `lr_decay_style=WSD` (decay anchored to the end) the decay never completes — it stops partway, exactly as shown in the issue's plot

## Fix

Add `_get_consumed_samples_for_iterations(iterations)`, mirroring `megatron.core.num_microbatches_calculator.RampupBatchsizeNumMicroBatchesCalculator` (same assertions and batch-size stepping), and use it in the iteration-based branch for:

- `lr_decay_steps = consumed(lr_decay_iters)`
- `wd_incr_steps = consumed(train_iters)`
- `lr_warmup_steps = consumed(lr_warmup_iters)`
- `wsd_decay_steps = consumed(lr_decay_iters) - consumed(lr_decay_iters - lr_wsd_decay_iters)` — the WSD decay window covers the *last* `lr_wsd_decay_iters` iterations, so it must be measured as the sample span between those two iteration marks

Without `rampup_batch_size` every value is unchanged (`consumed(n) == n * global_batch_size`).

With the issue's example (`train_iters=100`, `gbs=16`, `rampup=[8,8,160]`, `lr_warmup_iters=10`, `lr_wsd_decay_iters=20`): warmup now ends exactly at iteration 10 (80 samples), and WSD decay spans iterations 80→100 and reaches its end value at the final iteration.

## Tests

Added `TestSchedulerStepsWithRampupBatchSize` in `tests/unit_tests/training/test_config.py`: consumed-samples math (no ramp / ramp / start==global), the full WSD example from the issue, and a no-ramp regression check.

## Changelog

- fix(training): scheduler warmup/decay/WSD sample counts now honor `rampup_batch_size`