### PR TITLE
fix(ckpt): honor CheckpointConfig.async_strategy on the sync save path (#4639)

### DIFF
--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -140,6 +140,38 @@ _DIRECT_ITERATION_DIR_SENTINEL = -2
 HF_WEIGHTS_SUBDIR = "hf"
 
 
+class SyncSaveWithConfiguredAsyncStrategy(TorchDistSaveShardedStrategy):
+    """torch_dist save strategy whose synchronous ``save`` honors ``CheckpointConfig.async_strategy``.
+
+    MCore's ``TorchDistSaveShardedStrategy.save`` hardcodes the deprecated ``mcore``
+    async-finalize path for synchronous saves, silently ignoring the configured
+    ``async_strategy``. Route the sync save through ``async_save`` with the configured
+    strategy followed by ``execute_sync`` so ``async_save=False`` saves (e.g.
+    ``AutoBridge.save_megatron_model``) use the same strategy as async ones (#4639).
+    """
+
+    def __init__(self, *args: Any, sync_async_strategy: str = "nvrx", **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.sync_async_strategy = sync_async_strategy
+
+    def save(self, sharded_state_dict: ShardedStateDict, checkpoint_dir: Path) -> None:
+        """Synchronously save using the configured async strategy's writer/finalize path."""
+        if (
+            self.sync_async_strategy == "mcore"
+            or "async_strategy" not in inspect.signature(self.async_save).parameters
+        ):
+            # "mcore" matches the built-in behavior; newer MCore branches removed the kwarg.
+            return super().save(sharded_state_dict, checkpoint_dir)
+        try:
+            async_request = self.async_save(
+                sharded_state_dict, checkpoint_dir, async_strategy=self.sync_async_strategy
+            )
+        except (ImportError, ModuleNotFoundError):
+            # Environment lacks the configured strategy's modules (e.g. no nvidia-resiliency-ext).
+            return super().save(sharded_state_dict, checkpoint_dir)
+        async_request.execute_sync()
+
+
 # ============================================================================
 # Checkpoint version and utilities
 # ============================================================================
@@ -1284,10 +1316,11 @@ def save_checkpoint(
             else:
                 validate_sharding_integrity = True
                 if ckpt_cfg.ckpt_format == "torch_dist":
-                    save_strategy = TorchDistSaveShardedStrategy(
+                    save_strategy = SyncSaveWithConfiguredAsyncStrategy(
                         "torch_dist",
                         1,
                         thread_count=ckpt_cfg.storage_writers_per_rank,
+                        sync_async_strategy=ckpt_cfg.async_strategy,
                     )
                 else:
                     save_strategy = get_default_save_sharded_strategy(ckpt_cfg.ckpt_format)

--- a/tests/unit_tests/training/test_checkpointing.py
+++ b/tests/unit_tests/training/test_checkpointing.py
@@ -16,7 +16,7 @@
 import os
 import tempfile
 from pathlib import Path
-from unittest.mock import Mock, mock_open, patch
+from unittest.mock import MagicMock, Mock, mock_open, patch
 
 import pytest
 import torch
@@ -4213,3 +4213,68 @@ class TestLayerWiseOptimizerCheckpointing:
         # Standard load_state_dict must be called; per-rank file loader must NOT be called.
         mock_layer_wise_optim.load_state_dict.assert_called_once_with(mock_state_dict["optimizer"])
         mock_layer_wise_optim.load_state_dict_from_file.assert_not_called()
+
+
+class TestSyncSaveWithConfiguredAsyncStrategy:
+    """Sync torch_dist saves must honor CheckpointConfig.async_strategy (#4639)."""
+
+    def _strategy(self, sync_async_strategy="nvrx"):
+        from megatron.bridge.training.checkpointing import SyncSaveWithConfiguredAsyncStrategy
+
+        return SyncSaveWithConfiguredAsyncStrategy(
+            "torch_dist", 1, thread_count=2, sync_async_strategy=sync_async_strategy
+        )
+
+    def test_save_routes_through_configured_async_strategy(self):
+        strategy = self._strategy("nvrx")
+        request = MagicMock()
+        received = {}
+
+        def fake_async_save(sharded_state_dict, checkpoint_dir, async_strategy="nvrx"):
+            received["async_strategy"] = async_strategy
+            return request
+
+        with patch.object(type(strategy), "async_save", staticmethod(fake_async_save)):
+            strategy.save({"a": 1}, "/tmp/ckpt")
+
+        assert received["async_strategy"] == "nvrx"
+        request.execute_sync.assert_called_once_with()
+
+    def test_save_mcore_strategy_uses_builtin_save(self):
+        from megatron.core.dist_checkpointing.strategies.torch import TorchDistSaveShardedStrategy
+
+        strategy = self._strategy("mcore")
+        with patch.object(TorchDistSaveShardedStrategy, "save", autospec=True) as base_save:
+            strategy.save({"a": 1}, "/tmp/ckpt")
+        base_save.assert_called_once()
+
+    def test_save_falls_back_when_strategy_modules_missing(self):
+        from megatron.core.dist_checkpointing.strategies.torch import TorchDistSaveShardedStrategy
+
+        strategy = self._strategy("nvrx")
+
+        def raising_async_save(sharded_state_dict, checkpoint_dir, async_strategy="nvrx"):
+            raise ImportError("nvidia-resiliency-ext not installed")
+
+        with (
+            patch.object(type(strategy), "async_save", staticmethod(raising_async_save)),
+            patch.object(TorchDistSaveShardedStrategy, "save", autospec=True) as base_save,
+        ):
+            strategy.save({"a": 1}, "/tmp/ckpt")
+        base_save.assert_called_once()
+
+    def test_save_falls_back_when_kwarg_unsupported(self):
+        """Newer MCore branches removed the async_strategy kwarg from async_save."""
+        from megatron.core.dist_checkpointing.strategies.torch import TorchDistSaveShardedStrategy
+
+        strategy = self._strategy("nvrx")
+
+        def no_kwarg_async_save(sharded_state_dict, checkpoint_dir):
+            raise AssertionError("should not be called: sync fallback must use built-in save")
+
+        with (
+            patch.object(type(strategy), "async_save", staticmethod(no_kwarg_async_save)),
+            patch.object(TorchDistSaveShardedStrategy, "save", autospec=True) as base_save,
+        ):
+            strategy.save({"a": 1}, "/tmp/ckpt")
+        base_save.assert_called_once()


### PR DESCRIPTION
## What does this PR do?

Fixes #4639.

`CheckpointConfig.async_strategy` (default `"nvrx"`) is plumbed into `dist_checkpointing.save(...)`, but has no effect when `async_save=False`: MCore's sync path calls `TorchDistSaveShardedStrategy.save()`, which internally hardcodes `async_strategy="mcore"` — the deprecated finalize path that can crash with `TypeError: cannot pickle code objects` in `gather_object(write_results)`. Since `save_megatron_model` sets `async_save=False` unconditionally, every HF→Megatron conversion runs through that deprecated path, which forced the monkey-patch workaround in NVIDIA-NeMo/RL#2989.

## Fix

Implements option **(a)** from the issue at the MB layer: a `SyncSaveWithConfiguredAsyncStrategy` subclass of `TorchDistSaveShardedStrategy` whose `save()` routes through `async_save(..., async_strategy=<configured>).execute_sync()`. The torch_dist construction site in `save_checkpoint` now instantiates it with `sync_async_strategy=ckpt_cfg.async_strategy`.

Fallbacks to the built-in `save()` (unchanged behavior) when:
- `async_strategy="mcore"` is explicitly configured,
- the installed MCore's `async_save` no longer accepts the `async_strategy` kwarg (dev branch),
- the configured strategy's modules are missing (`ImportError`, e.g. no `nvidia-resiliency-ext`).

Async saves (`async_save=True`) are untouched — `dist_checkpointing.save` never calls `strategy.save()` on that path.

## Tests

Added `TestSyncSaveWithConfiguredAsyncStrategy` in `tests/unit_tests/training/test_checkpointing.py` covering: nvrx routing + `execute_sync`, explicit mcore passthrough, ImportError fallback, and missing-kwarg fallback.

## Changelog

- fix(ckpt): sync torch_dist saves now honor `CheckpointConfig.async_strategy` instead of the deprecated hardcoded `mcore` path