### PR TITLE
fix(data): retry packed-Parquet resolution with metadata refresh after prep barrier (#4207)

### DIFF
--- a/src/megatron/bridge/data/builders/gpt_sft.py
+++ b/src/megatron/bridge/data/builders/gpt_sft.py
@@ -34,6 +34,7 @@ from megatron.bridge.data.packing import PackedSequenceSpecs
 from megatron.bridge.data.packing.paths import (
     is_packed_parquet_spec,
     resolve_packed_parquet_paths,
+    resolve_packed_parquet_paths_with_refresh,
 )
 from megatron.bridge.data.sft_processing import (
     ChatSFTPreprocessingConfig,
@@ -436,7 +437,9 @@ def build_gpt_sft_split(
     path_str = str(path)
     if is_packed_parquet_spec(path_str):
         try:
-            path_exists = bool(resolve_packed_parquet_paths(path_str))
+            # Retry with directory-metadata refresh: on shared filesystems a non-producer
+            # node can transiently see zero files right after rank 0 wrote them (#4207).
+            path_exists = bool(resolve_packed_parquet_paths_with_refresh(path_str))
         except ValueError:
             path_exists = False
     elif MultiStorageClientFeature.is_enabled():

--- a/src/megatron/bridge/data/packing/paths.py
+++ b/src/megatron/bridge/data/packing/paths.py
@@ -15,10 +15,15 @@
 """Path detection and resolution for packed Parquet artifacts."""
 
 import glob
+import logging
 import os
+import time
 from pathlib import Path
 
 from megatron.core.msc_utils import MultiStorageClientFeature
+
+
+logger = logging.getLogger(__name__)
 
 
 def is_packed_parquet_file(path) -> bool:
@@ -212,3 +217,65 @@ def resolve_packed_parquet_paths(spec: str | Path) -> list[str]:
         ValueError: If no matching files are found.
     """
     return _resolve_parquet_paths(str(spec))
+
+
+def _refresh_directory_metadata(spec: str) -> None:
+    """Force a directory listing so shared-filesystem clients drop stale negative entries."""
+    base = spec.split("*", 1)[0]
+    directory = base if os.path.isdir(base) else os.path.dirname(base)
+    try:
+        os.listdir(directory or ".")
+    except OSError:
+        pass
+
+
+def resolve_packed_parquet_paths_with_refresh(
+    spec: str | Path,
+    *,
+    max_attempts: int = 5,
+    backoff_s: float = 2.0,
+) -> list[str]:
+    """Resolve a packed parquet spec, retrying with directory-metadata refresh on empty results.
+
+    On shared filesystems (e.g. Lustre, NFS) a ``torch.distributed.barrier()`` guarantees the
+    producer rank *finished writing*, but not that other nodes' filesystem clients refreshed
+    their directory metadata. A non-producer node can therefore transiently resolve zero files
+    for a packed Parquet artifact that rank 0 just wrote (#4207). Retry resolution a bounded
+    number of times, forcing a parent-directory listing between attempts.
+
+    Args:
+        spec: Path specification (file, glob pattern, or directory).
+        max_attempts: Maximum number of resolution attempts.
+        backoff_s: Base sleep between attempts; attempt ``i`` sleeps ``backoff_s * i``.
+
+    Returns:
+        Sorted list of resolved file paths.
+
+    Raises:
+        ValueError: If no matching files are found after all attempts.
+    """
+    spec_str = str(spec)
+    last_error: ValueError | None = None
+    for attempt in range(1, max_attempts + 1):
+        try:
+            resolved = _resolve_parquet_paths(spec_str)
+        except ValueError as exc:
+            resolved = []
+            last_error = exc
+        if resolved:
+            return resolved
+        if attempt < max_attempts:
+            logger.warning(
+                "Packed Parquet spec %s resolved to no files (attempt %d/%d); "
+                "refreshing directory metadata and retrying — this can happen on shared "
+                "filesystems right after another node wrote the artifact.",
+                spec_str,
+                attempt,
+                max_attempts,
+            )
+            _refresh_directory_metadata(spec_str)
+            time.sleep(backoff_s * attempt)
+
+    if last_error is not None:
+        raise last_error
+    return []

--- a/tests/unit_tests/data/packing/test_paths.py
+++ b/tests/unit_tests/data/packing/test_paths.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for packed Parquet path resolution with shared-filesystem retry (#4207)."""
+
+import pytest
+
+from megatron.bridge.data.packing import paths as paths_mod
+from megatron.bridge.data.packing.paths import (
+    _refresh_directory_metadata,
+    resolve_packed_parquet_paths_with_refresh,
+)
+
+
+class TestResolvePackedParquetPathsWithRefresh:
+    def test_resolves_existing_file_without_retry(self, tmp_path, monkeypatch):
+        shard = tmp_path / "data.idx.parquet"
+        shard.touch()
+        sleeps = []
+        monkeypatch.setattr(paths_mod.time, "sleep", sleeps.append)
+
+        resolved = resolve_packed_parquet_paths_with_refresh(str(shard))
+
+        assert resolved == [str(shard)]
+        assert sleeps == []
+
+    def test_retries_until_files_become_visible(self, tmp_path, monkeypatch):
+        """Simulates a shared-filesystem client that sees the file only on a later attempt."""
+        shard = tmp_path / "data.idx.parquet"
+        attempts = []
+        sleeps = []
+        monkeypatch.setattr(paths_mod.time, "sleep", sleeps.append)
+
+        real_resolve = paths_mod._resolve_parquet_paths
+
+        def delayed_resolve(spec):
+            attempts.append(spec)
+            if len(attempts) == 3:
+                shard.touch()
+            return real_resolve(spec)
+
+        monkeypatch.setattr(paths_mod, "_resolve_parquet_paths", delayed_resolve)
+
+        resolved = resolve_packed_parquet_paths_with_refresh(str(shard), max_attempts=5, backoff_s=1.0)
+
+        assert resolved == [str(shard)]
+        assert len(attempts) == 3
+        # slept after the two failed attempts, with linear backoff
+        assert sleeps == [1.0, 2.0]
+
+    def test_raises_after_exhausting_attempts(self, tmp_path, monkeypatch):
+        missing = tmp_path / "missing.idx.parquet"
+        sleeps = []
+        monkeypatch.setattr(paths_mod.time, "sleep", sleeps.append)
+
+        with pytest.raises(ValueError, match="not found"):
+            resolve_packed_parquet_paths_with_refresh(str(missing), max_attempts=3, backoff_s=0.5)
+
+        assert len(sleeps) == 2  # no sleep after the final attempt
+
+    def test_directory_spec_retries_on_empty_directory(self, tmp_path, monkeypatch):
+        sleeps = []
+        monkeypatch.setattr(paths_mod.time, "sleep", sleeps.append)
+
+        with pytest.raises(ValueError, match="No Parquet files found"):
+            resolve_packed_parquet_paths_with_refresh(str(tmp_path), max_attempts=2, backoff_s=0.1)
+
+        assert len(sleeps) == 1
+
+
+class TestRefreshDirectoryMetadata:
+    def test_refresh_existing_directory(self, tmp_path):
+        _refresh_directory_metadata(str(tmp_path / "shard_*.parquet"))
+
+    def test_refresh_missing_directory_is_noop(self, tmp_path):
+        _refresh_directory_metadata(str(tmp_path / "nope" / "shard_*.parquet"))


### PR DESCRIPTION
## What does this PR do?

Fixes #4207.

Multi-node finetuning with packed-sequence datasets intermittently crashes at iteration 0 with `TypeError: 'NoneType' object is not an iterator` on an entire non-rank-0 node. Root cause (as analyzed in the issue): `FinetuningDatasetBuilder.build()` prepares the packed Parquet on rank 0, all ranks pass a `torch.distributed.barrier()`, then every rank resolves the packed-Parquet path. On a shared filesystem (e.g. Lustre) the barrier guarantees the producer *finished writing* but not that other nodes' filesystem clients refreshed their directory metadata — a non-producer node can still observe a stale negative directory entry, resolve zero files, and silently build a `None` dataset → `None` iterator → crash.

## Fix

- New `resolve_packed_parquet_paths_with_refresh()` in `data/packing/paths.py`: retries resolution up to 5 times, forcing a parent-directory listing (`os.listdir`) between attempts with linear backoff, and logs each retry. Raises the last resolution error if all attempts fail (unchanged failure semantics).
- `build_gpt_sft_split()` (the post-barrier consumer path) now uses the retrying resolver for packed-Parquet specs.
- The rank-0 pre-preparation check (`_packed_path_exists`) intentionally keeps the single-attempt resolver — a missing artifact there is the expected signal to produce it, and retrying would delay preparation.

No behavior change when files resolve on the first attempt (no sleeps, same results).

## Tests

New `tests/unit_tests/data/packing/test_paths.py`: immediate resolution without retry, delayed visibility resolved on a later attempt (backoff sequence asserted), exhaustion raising `ValueError`, empty-directory retry, and metadata-refresh no-op on missing directories.

## Changelog

- fix(data): packed-Parquet resolution retries with directory-metadata refresh to tolerate shared-filesystem visibility lag after the dataset-prep barrier