### PR TITLE
fix(training): validate cpu_offloading has something to offload (#2684)

### DIFF
--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -1243,6 +1243,7 @@ class ConfigContainer(Container):
         _validate_and_sync_distributed_optimizer_settings(self)
         _validate_mixed_precision_consistency(self)
         _validate_fine_grained_activation_offloading(self)
+        _validate_cpu_offloading(self)
 
         # CUDA graph scope validation: check_for_nan_in_loss must be disabled with full_iteration graph
         if is_full_iteration_cuda_graph(self.model):
@@ -1840,6 +1841,33 @@ def _validate_mixed_precision_consistency(config: ConfigContainer) -> None:
                 "model is using fp32 precision (model.bf16=False, model.fp16=False) and "
                 "use_precision_aware_optimizer=True."
             )
+
+
+def _validate_cpu_offloading(config: ConfigContainer) -> None:
+    """Fail fast when CPU offloading is enabled but nothing is selected to offload.
+
+    Without this, the misconfiguration only surfaces deep inside model construction as
+    Transformer Engine's "CPU Offloading is enabled while it is not mentioned what to
+    offload" ValueError, with no hint about which config knobs control it (#2684).
+
+    Args:
+        config: The configuration container to validate.
+
+    Raises:
+        ValueError: If cpu_offloading is enabled with both activation and weight
+            offloading disabled.
+    """
+    model_cfg = config.model
+    if not getattr(model_cfg, "cpu_offloading", False):
+        return
+    if not (
+        getattr(model_cfg, "cpu_offloading_activations", False) or getattr(model_cfg, "cpu_offloading_weights", False)
+    ):
+        raise ValueError(
+            "model.cpu_offloading is enabled but both model.cpu_offloading_activations and "
+            "model.cpu_offloading_weights are False, so there is nothing to offload. "
+            "Enable at least one of them, or set model.cpu_offloading=False to disable CPU offloading."
+        )
 
 
 def _validate_fine_grained_activation_offloading(config: ConfigContainer) -> None:

--- a/tests/unit_tests/training/test_config.py
+++ b/tests/unit_tests/training/test_config.py
@@ -3814,3 +3814,44 @@ class TestTokenizerConfig:
                 metadata_path=metadata_path,
                 random_arg=True,
             )
+
+
+class TestCpuOffloadingValidation:
+    """cpu_offloading with nothing selected to offload must fail fast with a clear error (#2684)."""
+
+    def _validate(self, **model_kwargs):
+        gpt_model_cfg = create_test_gpt_config(**model_kwargs)
+        container, og_ws, cfg_mod = create_test_config_container(world_size_override=1, model_config=gpt_model_cfg)
+        try:
+            container.validate()
+        finally:
+            restore_get_world_size_safe(og_ws, cfg_mod)
+
+    def test_offloading_with_nothing_to_offload_raises(self):
+        with pytest.raises(ValueError, match="nothing to offload"):
+            self._validate(
+                cpu_offloading=True,
+                cpu_offloading_activations=False,
+                cpu_offloading_weights=False,
+            )
+
+    def test_offloading_activations_only_passes(self):
+        self._validate(
+            cpu_offloading=True,
+            cpu_offloading_activations=True,
+            cpu_offloading_weights=False,
+        )
+
+    def test_offloading_weights_only_passes(self):
+        self._validate(
+            cpu_offloading=True,
+            cpu_offloading_activations=False,
+            cpu_offloading_weights=True,
+        )
+
+    def test_offloading_disabled_ignores_flags(self):
+        self._validate(
+            cpu_offloading=False,
+            cpu_offloading_activations=False,
+            cpu_offloading_weights=False,
+        )


### PR DESCRIPTION
## What does this PR do?

Fixes #2684.

Setting `cpu_offloading=True` with `cpu_offloading_activations=False` (and `cpu_offloading_weights` at its default `False`) crashes deep inside model construction (`TransformerBlock.__init__` → TE `get_cpu_offload_context`) with:

```
ValueError: CPU Offloading is enabled while it is not mentioned what to offload (weights/activations)
```

The traceback gives no hint which Megatron-Bridge config fields control this.

## Fix

Add `_validate_cpu_offloading()` to `ConfigContainer.validate()` (alongside the existing fine-grained-offloading validation): when `model.cpu_offloading` is enabled and both `model.cpu_offloading_activations` and `model.cpu_offloading_weights` are `False`, fail fast at config-validation time with an error naming the exact knobs to change.

No behavior change for valid configs.

## Tests

`TestCpuOffloadingValidation` in `tests/unit_tests/training/test_config.py`: raising case, activations-only, weights-only, and offloading-disabled passthrough.

## Changelog

- fix(training): fail fast with an actionable error when `cpu_offloading=True` but nothing is selected to offload