### PR TITLE
feat(training): add ValidationConfig.eval_at_start for step-0 baseline eval (#3996)

### DIFF
--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -38,10 +38,11 @@ from megatron.training.config import DistributedInitConfig as MTrainDistributedI
 from megatron.training.config import LoggerConfig as MTrainLoggerConfig
 from megatron.training.config import ProfilingConfig as MTrainProfilingConfig
 from megatron.training.config import RerunStateMachineConfig as MTrainRerunStateMachineConfig
-from megatron.training.config import RNGConfig, ValidationConfig
+from megatron.training.config import RNGConfig
 from megatron.training.config import SchedulerConfig as MTrainSchedulerConfig
 from megatron.training.config import StragglerDetectionConfig as MTrainStragglerDetectionConfig
 from megatron.training.config import TrainingConfig as MTrainTrainingConfig
+from megatron.training.config import ValidationConfig as MTrainValidationConfig
 
 from megatron.bridge.data.base import (
     DataloaderConfig,
@@ -409,6 +410,16 @@ class SchedulerConfig(MTrainSchedulerConfig):
                 f"Cannot specify lr_warmup_fraction={self.lr_warmup_fraction} with lr_warmup_iters={self.lr_warmup_iters} or lr_warmup_samples={self.lr_warmup_samples}. "
                 f"Use either lr_warmup_fraction OR lr_warmup_iters OR lr_warmup_samples."
             )
+
+
+@dataclass(kw_only=True)
+class ValidationConfig(MTrainValidationConfig):
+    """Bridge validation settings, extending the MCore training ValidationConfig."""
+
+    eval_at_start: bool = False
+    """Run one validation pass before the first training step (step-0 eval). Provides the
+    baseline metric that anchors training curves. Skipped when resuming from a checkpoint
+    (step > 0) or when validation is disabled."""
 
 
 @dataclass(kw_only=True)

--- a/src/megatron/bridge/training/train.py
+++ b/src/megatron/bridge/training/train.py
@@ -351,6 +351,35 @@ def train(
         model_config.param_sync_func = None
         pre_hook_enabled = False
 
+    # Optional step-0 validation pass: establishes the baseline metric before any
+    # optimizer step (#3996). Skipped on resume/in-process restart (step > 0).
+    if (
+        getattr(val_config, "eval_at_start", False)
+        and global_state.train_state.do_valid
+        and global_state.train_state.step == 0
+    ):
+        timers("interval-time").stop()
+        if train_config.manual_gc and train_config.manual_gc_eval:
+            gc.collect()
+        timers("eval-time", log_level=0).start(barrier=True)
+        evaluate_and_print_results(
+            global_state,
+            f"iteration {global_state.train_state.step}",
+            forward_step_func,
+            valid_data_iterator,
+            model,
+            model_config,
+            verbose=False,
+            write_to_tensorboard=True,
+            process_non_loss_data_func=process_non_loss_data_func,
+            non_loss_data_func=non_loss_data_func,
+            callback_manager=callback_manager,
+        )
+        timers("eval-time").stop()
+        if train_config.manual_gc and train_config.manual_gc_eval:
+            gc.collect(generation=0)
+        timers("interval-time", log_level=0).start(barrier=True)
+
     # Run training iterations till done.
     while global_state.train_state.step < train_config.train_iters:
         # Handle profiling for this step

--- a/tests/unit_tests/training/test_config.py
+++ b/tests/unit_tests/training/test_config.py
@@ -3814,3 +3814,30 @@ class TestTokenizerConfig:
                 metadata_path=metadata_path,
                 random_arg=True,
             )
+
+
+class TestValidationConfigEvalAtStart:
+    """Bridge ValidationConfig adds eval_at_start for a step-0 baseline eval (#3996)."""
+
+    def test_default_disabled(self):
+        cfg = ValidationConfig()
+        assert cfg.eval_at_start is False
+
+    def test_enable(self):
+        cfg = ValidationConfig(eval_at_start=True)
+        assert cfg.eval_at_start is True
+
+    def test_inherits_mcore_fields(self):
+        cfg = ValidationConfig(eval_iters=10, eval_interval=50, eval_at_start=True)
+        assert cfg.eval_iters == 10
+        assert cfg.eval_interval == 50
+
+    def test_deprecated_sync_ignores_eval_at_start(self, recwarn):
+        """The TrainingConfig->ValidationConfig deprecation sync must not warn for eval_at_start."""
+        gpt_model_cfg = create_test_gpt_config()
+        container, og_ws, cfg_mod = create_test_config_container(world_size_override=1, model_config=gpt_model_cfg)
+        try:
+            container.validate()
+        finally:
+            restore_get_world_size_safe(og_ws, cfg_mod)
+        assert not any("eval_at_start" in str(w.message) for w in recwarn.list)


### PR DESCRIPTION
## What does this PR do?

Fixes #3996 (maintainer-approved ask: https://github.com/NVIDIA-NeMo/Megatron-Bridge/issues/3996#issuecomment).

There is currently no way to run a validation pass *before* the training loop starts: the only `evaluate_and_print_results` call site inside `train()` is gated on `step % eval_interval == 0` evaluated after the step increment, so the first eval lands at `step == eval_interval`. Long runs lose the baseline number that anchors W&B/TensorBoard plots, and short smoke runs may never eval at all.

## Implementation

As suggested in the issue, the toggle lives in the validation config and the eval runs inside `train()` where all required args are in scope:

- **`ValidationConfig.eval_at_start: bool = False`** — added on a new Bridge `ValidationConfig` subclass of the MCore training `ValidationConfig` (same pattern as `TrainingConfig`/`SchedulerConfig`/`TokenizerConfig`). All existing imports from `megatron.bridge.training.config` transparently pick up the subclass; configs constructed from the upstream class still work (`getattr(..., False)` guard).
- **`train()`**: immediately before the training loop, when `eval_at_start` is set, `do_valid` is true, and `step == 0`, run exactly one validation pass with the same val iterator, `eval-time`/`interval-time` timer handling, `manual_gc_eval` behavior, and callback wiring as the in-loop eval. Forward pre-hooks are still disabled at this point in `train()`, matching the in-loop eval's requirement.
- **Resume-safe**: `step > 0` (checkpoint resume, `inprocess_restart` re-entries) skips the step-0 eval for free, as the issue requested.

## Tests

`TestValidationConfigEvalAtStart` in `tests/unit_tests/training/test_config.py`: default-off, enable, MCore field inheritance, and no spurious deprecation warning from the TrainingConfig→ValidationConfig sync loop.

## Changelog

- feat(training): `ValidationConfig.eval_at_start` runs one validation pass before the first training step