### PR TITLE
DSV4: Making compress_rope_theta priotitzed than rope_scaling->rope_theta

### DIFF
--- a/src/megatron/bridge/models/deepseek/deepseek_v4_bridge.py
+++ b/src/megatron/bridge/models/deepseek/deepseek_v4_bridge.py
@@ -436,7 +436,7 @@ class DeepSeekV4Bridge(MegatronModelBridge):
             compress_rope_params = rope_params
         provider.rotary_base = float(main_rope_params.get("rope_theta", hf_config.rope_theta))  # 10000
         provider.csa_compress_rotary_base = float(
-            compress_rope_params.get("rope_theta", getattr(hf_config, "compress_rope_theta", provider.rotary_base))
+            getattr(hf_config, "compress_rope_theta", compress_rope_params.get("rope_theta", provider.rotary_base))
         )  # 160000
         provider.rotary_scaling_factor = float(compress_rope_params["factor"])  # 16
         provider.original_max_position_embeddings = int(

--- a/tests/unit_tests/models/deepseek/test_deepseek_v4_bridge.py
+++ b/tests/unit_tests/models/deepseek/test_deepseek_v4_bridge.py
@@ -71,7 +71,7 @@ def _deepseek_v4_hf_config():
         o_lora_rank=1024,
         rope_theta=10000,
         compress_rope_theta=160000,
-        rope_scaling={"factor": 16, "original_max_position_embeddings": 65536},
+        rope_scaling={"factor": 16, "original_max_position_embeddings": 65536, "rope_theta": 10000},
         num_hidden_layers=4,
         num_nextn_predict_layers=1,
         num_hash_layers=3,
@@ -403,6 +403,7 @@ class TestDeepSeekV4RotaryPercent:
             out = bridge.provider_bridge(hf_pretrained)
 
         assert out.rotary_percent == 1.0
+        assert out.csa_compress_rotary_base == 160000
 
 
 class TestDeepSeekV4HardwareDefaults:


### PR DESCRIPTION
# What does this PR do ?

Making compress_rope_theta priotitzed than rope_scaling->rope_theta

# Changelog

  1. The raw `config.json` has top-level rope_theta=10000, top-level compress_rope_theta=160000, and no nested rope_theta under rope_scaling.
  2. vLLM’s patch_rope_parameters() detects Transformers >=5.0 and calls config.standardize_rope_params().
  3. That normalization inserts the generic rope_theta=10000 into rope_parameters/rope_scaling.
  4. If we gave the normalized nested value priority, compressed layers incorrectly received 10000, so fix this.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [X] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [X] Did you write any new necessary tests?
- [X] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
