### PR TITLE
feat(recipe): add DeepSeek-V4-Pro GB300 performance recipe

### DIFF
--- a/scripts/performance/configs/deepseek/__init__.py
+++ b/scripts/performance/configs/deepseek/__init__.py
@@ -13,6 +13,10 @@ if HAVE_MEGATRON_BRIDGE:
         deepseek_v3_pretrain_config_gb300,
         deepseek_v3_pretrain_config_h100,
         deepseek_v3_pretrain_config_vr200,
+        deepseek_v4_pro_pretrain_config_gb200,
+        deepseek_v4_pro_pretrain_config_gb300,
+        deepseek_v4_pro_proxy_pretrain_config_gb200,
+        deepseek_v4_pro_proxy_pretrain_config_gb300,
     )
 
 from .deepseek_workload_base_configs import (
@@ -68,10 +72,19 @@ from .deepseek_workload_base_configs import (
     DEEPSEEK_V3_PRETRAIN_CONFIG_VR200_FP8_MX_V2,
     DEEPSEEK_V3_PRETRAIN_CONFIG_VR200_NVFP4_V1,
     DEEPSEEK_V3_PRETRAIN_CONFIG_VR200_NVFP4_V2,
+    DEEPSEEK_V4_PRO_PRETRAIN_CONFIG_GB200_FP8_MX_V1,
+    DEEPSEEK_V4_PRO_PRETRAIN_CONFIG_GB300_FP8_MX_V1,
+    DEEPSEEK_V4_PRO_PROXY_PRETRAIN_CONFIG_GB200_FP8_MX_V1,
+    DEEPSEEK_V4_PRO_PROXY_PRETRAIN_CONFIG_GB300_FP8_MX_V1,
 )
 
 
 __all__ = [
+    # DeepSeek V4 Pro (MXFP8)
+    "DEEPSEEK_V4_PRO_PRETRAIN_CONFIG_GB300_FP8_MX_V1",
+    "DEEPSEEK_V4_PRO_PRETRAIN_CONFIG_GB200_FP8_MX_V1",
+    "DEEPSEEK_V4_PRO_PROXY_PRETRAIN_CONFIG_GB200_FP8_MX_V1",
+    "DEEPSEEK_V4_PRO_PROXY_PRETRAIN_CONFIG_GB300_FP8_MX_V1",
     # V1 (GBS=2048 for Blackwell, GBS=8192 for H100)
     "DEEPSEEK_V3_PRETRAIN_CONFIG_B300_BF16_V1",
     "DEEPSEEK_V3_PRETRAIN_CONFIG_B300_FP8_CS_V1",
@@ -139,5 +152,9 @@ if HAVE_MEGATRON_BRIDGE:
             "deepseek_v3_pretrain_config_b200",
             "deepseek_v3_pretrain_config_h100",
             "deepseek_v3_pretrain_config_vr200",
+            "deepseek_v4_pro_pretrain_config_gb200",
+            "deepseek_v4_pro_pretrain_config_gb300",
+            "deepseek_v4_pro_proxy_pretrain_config_gb200",
+            "deepseek_v4_pro_proxy_pretrain_config_gb300",
         ]
     )

--- a/scripts/performance/configs/deepseek/__init__.py
+++ b/scripts/performance/configs/deepseek/__init__.py
@@ -17,6 +17,7 @@ if HAVE_MEGATRON_BRIDGE:
         deepseek_v4_pro_pretrain_config_gb300,
         deepseek_v4_pro_proxy_pretrain_config_gb200,
         deepseek_v4_pro_proxy_pretrain_config_gb300,
+        deepseek_v4_pro_proxy_pp2_pretrain_config_gb200,
     )
 
 from .deepseek_workload_base_configs import (
@@ -76,6 +77,8 @@ from .deepseek_workload_base_configs import (
     DEEPSEEK_V4_PRO_PRETRAIN_CONFIG_GB300_FP8_MX_V1,
     DEEPSEEK_V4_PRO_PROXY_PRETRAIN_CONFIG_GB200_FP8_MX_V1,
     DEEPSEEK_V4_PRO_PROXY_PRETRAIN_CONFIG_GB300_FP8_MX_V1,
+    DEEPSEEK_V4_PRO_PROXY_PP2_PRETRAIN_CONFIG_GB200_FP8_MX_V1,
+    DEEPSEEK_V4_PRO_PROXY_PP2_PRETRAIN_CONFIG_GB300_FP8_MX_V1,
 )
 
 
@@ -85,6 +88,8 @@ __all__ = [
     "DEEPSEEK_V4_PRO_PRETRAIN_CONFIG_GB200_FP8_MX_V1",
     "DEEPSEEK_V4_PRO_PROXY_PRETRAIN_CONFIG_GB200_FP8_MX_V1",
     "DEEPSEEK_V4_PRO_PROXY_PRETRAIN_CONFIG_GB300_FP8_MX_V1",
+    "DEEPSEEK_V4_PRO_PROXY_PP2_PRETRAIN_CONFIG_GB200_FP8_MX_V1",
+    "DEEPSEEK_V4_PRO_PROXY_PP2_PRETRAIN_CONFIG_GB300_FP8_MX_V1",
     # V1 (GBS=2048 for Blackwell, GBS=8192 for H100)
     "DEEPSEEK_V3_PRETRAIN_CONFIG_B300_BF16_V1",
     "DEEPSEEK_V3_PRETRAIN_CONFIG_B300_FP8_CS_V1",
@@ -156,5 +161,6 @@ if HAVE_MEGATRON_BRIDGE:
             "deepseek_v4_pro_pretrain_config_gb300",
             "deepseek_v4_pro_proxy_pretrain_config_gb200",
             "deepseek_v4_pro_proxy_pretrain_config_gb300",
+            "deepseek_v4_pro_proxy_pp2_pretrain_config_gb200",
         ]
     )

--- a/scripts/performance/configs/deepseek/__init__.py
+++ b/scripts/performance/configs/deepseek/__init__.py
@@ -13,11 +13,7 @@ if HAVE_MEGATRON_BRIDGE:
         deepseek_v3_pretrain_config_gb300,
         deepseek_v3_pretrain_config_h100,
         deepseek_v3_pretrain_config_vr200,
-        deepseek_v4_pro_pretrain_config_gb200,
         deepseek_v4_pro_pretrain_config_gb300,
-        deepseek_v4_pro_proxy_pretrain_config_gb200,
-        deepseek_v4_pro_proxy_pretrain_config_gb300,
-        deepseek_v4_pro_proxy_pp2_pretrain_config_gb200,
     )
 
 from .deepseek_workload_base_configs import (
@@ -73,23 +69,13 @@ from .deepseek_workload_base_configs import (
     DEEPSEEK_V3_PRETRAIN_CONFIG_VR200_FP8_MX_V2,
     DEEPSEEK_V3_PRETRAIN_CONFIG_VR200_NVFP4_V1,
     DEEPSEEK_V3_PRETRAIN_CONFIG_VR200_NVFP4_V2,
-    DEEPSEEK_V4_PRO_PRETRAIN_CONFIG_GB200_FP8_MX_V1,
     DEEPSEEK_V4_PRO_PRETRAIN_CONFIG_GB300_FP8_MX_V1,
-    DEEPSEEK_V4_PRO_PROXY_PRETRAIN_CONFIG_GB200_FP8_MX_V1,
-    DEEPSEEK_V4_PRO_PROXY_PRETRAIN_CONFIG_GB300_FP8_MX_V1,
-    DEEPSEEK_V4_PRO_PROXY_PP2_PRETRAIN_CONFIG_GB200_FP8_MX_V1,
-    DEEPSEEK_V4_PRO_PROXY_PP2_PRETRAIN_CONFIG_GB300_FP8_MX_V1,
 )
 
 
 __all__ = [
     # DeepSeek V4 Pro (MXFP8)
     "DEEPSEEK_V4_PRO_PRETRAIN_CONFIG_GB300_FP8_MX_V1",
-    "DEEPSEEK_V4_PRO_PRETRAIN_CONFIG_GB200_FP8_MX_V1",
-    "DEEPSEEK_V4_PRO_PROXY_PRETRAIN_CONFIG_GB200_FP8_MX_V1",
-    "DEEPSEEK_V4_PRO_PROXY_PRETRAIN_CONFIG_GB300_FP8_MX_V1",
-    "DEEPSEEK_V4_PRO_PROXY_PP2_PRETRAIN_CONFIG_GB200_FP8_MX_V1",
-    "DEEPSEEK_V4_PRO_PROXY_PP2_PRETRAIN_CONFIG_GB300_FP8_MX_V1",
     # V1 (GBS=2048 for Blackwell, GBS=8192 for H100)
     "DEEPSEEK_V3_PRETRAIN_CONFIG_B300_BF16_V1",
     "DEEPSEEK_V3_PRETRAIN_CONFIG_B300_FP8_CS_V1",
@@ -157,10 +143,6 @@ if HAVE_MEGATRON_BRIDGE:
             "deepseek_v3_pretrain_config_b200",
             "deepseek_v3_pretrain_config_h100",
             "deepseek_v3_pretrain_config_vr200",
-            "deepseek_v4_pro_pretrain_config_gb200",
             "deepseek_v4_pro_pretrain_config_gb300",
-            "deepseek_v4_pro_proxy_pretrain_config_gb200",
-            "deepseek_v4_pro_proxy_pretrain_config_gb300",
-            "deepseek_v4_pro_proxy_pp2_pretrain_config_gb200",
         ]
     )

--- a/scripts/performance/configs/deepseek/deepseek_llm_pretrain.py
+++ b/scripts/performance/configs/deepseek/deepseek_llm_pretrain.py
@@ -14,6 +14,7 @@
 
 import logging
 
+import torch
 from utils.overrides import set_workload_base_configs
 from utils.precision import get_precision_config
 from utils.utils import get_workload_base_config
@@ -324,6 +325,41 @@ def set_deepseek_v4_pro_common_configs(cfg: ConfigContainer) -> None:
     # cuteDSL fused grouped-MLP interleave (clamped SwiGLU fusion path).
     cfg.model.moe_mlp_glu_interleave_size = 32
 
+    # Native global MXFP8 (matching the MLM reference), overriding the lib mxfp8 config's
+    # eval-oriented choices. The lib bundles a per-layer "kitchen" quant_recipe
+    # (TEQuantizationParams, MXFP8-train/BF16-eval) with fp8_param_gather=False; that exists
+    # only for DSv4 MTP/validation BF16 eval, which a perf benchmark (eval_iters=0) doesn't
+    # use. Perf wants standard TE MXFP8 with fp8 param gather ON (perf-optimal, = MLM).
+    cfg.model.quant_recipe = None
+    cfg.mixed_precision.fp8_param_gather = True
+    cfg.mixed_precision.reuse_grad_buf_for_mxfp8_param_ag = True
+
+    # Train the DSA/CSA indexer, matching the MLM reference. The lib's DSv4-Flash
+    # recipe zeroes the indexer auxiliary loss (eval-leaning, same commit as the
+    # kitchen quant_recipe above), which leaves the sparse-token selector without a
+    # direct training signal. A faithful pretraining mirror keeps it on.
+    cfg.model.dsa_indexer_loss_coeff = 0.01
+    cfg.model.dsa_indexer_use_sparse_loss = True
+
+    # No CPU (pinned host) paged-stash spill buffer, matching the MLM reference
+    # (cpu factor 0.0; cuda factor stays 1.2). set_full_iter_cg_configs defaults
+    # this to 1.0, which mirrors the multi-tens-of-GB stash working set into
+    # page-locked host RAM per rank -- with 4 ranks/GB300 node that blows the
+    # host cgroup (OOM-killed at iter 2). The 1.2x HBM buffer holds the stash alone.
+    cfg.model.moe_paged_stash_buffer_size_factor_cpu = 0.0
+
+    # Log GPU memory every log_interval steps (mirrors MLM's --log-memory-interval),
+    # so steady-state peak memory is captured. MBridge's flag-gated report otherwise
+    # stops after iter 2, which under full-iter CG undercounts the post-capture peak.
+    cfg.logger.log_memory_interval = cfg.logger.log_interval
+
+    # BF16 precision-aware optimizer master gradients, matching the MLM reference.
+    # The lib forces main_grads_dtype=fp32 (deepseek_v4.py); MLM uses bf16. With the
+    # precision-aware optimizer (enabled here) bf16 master grads are valid and halve
+    # the master-grad buffer. grad_reduce_in_fp32 (the DDP reduce path) is already
+    # False above -- this is the separate optimizer-side knob.
+    cfg.optimizer.main_grads_dtype = torch.bfloat16
+
     # MCore's TransformerConfig.__post_init__ does set(self.offload_modules);
     # keep it an empty list (not None) when fine-grained offloading is off. The
     # full-Pro builder overrides this with the real offload module list.
@@ -429,3 +465,63 @@ def deepseek_v4_pro_proxy_pretrain_config_gb300(
     return _deepseek_v4_pro_pretrain_config(
         gpu="gb300", precision=precision, config_variant=config_variant, proxy=True
     )
+
+
+# Multi-stage debug proxy: PP2/VPP4 + MTP, 15 layers. Used to reproduce the full-Pro
+# scaling-mode crash at small scale (the PP1 proxy with MTP runs fine, so the trigger
+# needs a multi-stage pipeline + interleaved schedule + MTP on a non-first stage).
+_DEEPSEEK_V4_PRO_PROXY_PP2_NUM_LAYERS = 13
+
+
+def deepseek_v4_pro_proxy_pp2_pretrain_config_gb200(
+    precision: str = "fp8_mx", mock: bool = True, config_variant: str = "v1"
+) -> ConfigContainer:
+    """GB200, 15-layer DeepSeek-V4-Pro proxy with PP2/VPP4 + MTP (MXFP8, 128 GPUs).
+
+    Multi-stage debug variant: mimics the full Pro's pipeline + interleaved schedule +
+    MTP-on-last-stage at small scale. EP64 (like full Pro) -> PP2*EP64 = 128 GPUs.
+    15 transformer layers over 8 virtual stages (PP2*VPP4); last stage = "tmL" (1 layer
+    + MTP + loss). num_layers / CSA ratios / MTP / pp_layout are set HERE in Python (not
+    via Hydra overrides, which mis-parse the layout DSL into a single element).
+    """
+    if precision != "fp8_mx":
+        raise NotImplementedError(
+            "DeepSeek-V4-Pro performance configs currently support precision='fp8_mx' "
+            f"(MXFP8) only; got {precision!r}."
+        )
+    base_cfg = get_workload_base_config(
+        model_family_name="deepseek",
+        model_recipe_name="deepseek_v4_pro_proxy_pp2",
+        gpu="gb200",
+        compute_dtype=precision.upper(),
+        task="pretrain",
+        config_variant=config_variant,
+    )
+
+    cfg = deepseek_v4_pro_pretrain_mxfp8_config()
+
+    cfg.model.pipeline_model_parallel_size = base_cfg.pipeline_model_parallel_size
+    cfg.model.virtual_pipeline_model_parallel_size = base_cfg.virtual_pipeline_model_parallel_size
+    cfg.model.expert_model_parallel_size = base_cfg.expert_model_parallel_size
+    cfg.model.moe_flex_dispatcher_backend = base_cfg.moe_flex_dispatcher_backend
+
+    # 15 layers, KEEP MTP=1 (mimic full Pro). Truncate the bridge-derived per-layer lists:
+    # csa_compress_ratios -> first 15 (real) + [0] (MTP slot) = 16 == num_layers + mtp;
+    # moe_layer_freq -> first 15 (all-MoE).
+    n = _DEEPSEEK_V4_PRO_PROXY_PP2_NUM_LAYERS
+    cfg.model.num_layers = n
+    cfg.model.mtp_num_layers = 1
+    cfg.model.csa_compress_ratios = list(cfg.model.csa_compress_ratios)[:n] + [0]
+    if isinstance(cfg.model.moe_layer_freq, list):
+        cfg.model.moe_layer_freq = cfg.model.moe_layer_freq[:n]
+
+    # pp_layout string from the workload base config, set in Python (mcore parses the DSL).
+    cfg.model.pipeline_model_parallel_layout = base_cfg.pp_layout
+
+    set_workload_base_configs(cfg, base_cfg)
+    if is_full_iteration_cuda_graph(cfg.model):
+        set_full_iter_cg_configs(cfg)
+    set_deepseek_v4_pro_common_configs(cfg)
+
+    cfg.comm_overlap.overlap_grad_reduce = True
+    return cfg

--- a/scripts/performance/configs/deepseek/deepseek_llm_pretrain.py
+++ b/scripts/performance/configs/deepseek/deepseek_llm_pretrain.py
@@ -27,7 +27,6 @@ from megatron.bridge.recipes.deepseek.deepseek_v3 import (
 )
 from megatron.bridge.recipes.deepseek.deepseek_v4 import (
     deepseek_v4_pro_pretrain_mxfp8_config,
-    set_deepseek_v4_pipeline_model_parallel_layout,
 )
 from megatron.bridge.training.config import ConfigContainer
 from megatron.bridge.utils.cuda_graph import is_full_iteration_cuda_graph
@@ -294,19 +293,11 @@ def deepseek_v3_pretrain_config_h100(
     return cfg
 
 
-# Number of decoder layers in the DeepSeek-V4-Pro proxy. The proxy is a
-# pipeclean stand-in for the full 61-layer Pro model: it keeps every production
-# Pro hyperparameter (experts, MLA LoRA ranks, hash routing, SwiGLU clamp,
-# DSA/mHC) but shrinks the layer count so it fits on a single NVL72 domain.
-_DEEPSEEK_V4_PRO_PROXY_NUM_LAYERS = 8
-
-
 def set_deepseek_v4_pro_common_configs(cfg: ConfigContainer) -> None:
-    """Set the performance knobs shared by full DeepSeek-V4-Pro and its proxy.
+    """Set the full-scale DeepSeek-V4-Pro performance knobs.
 
-    Reproduces the validated full-iteration CUDA-graph + fused-DSA recipe
-    (calibrated ~917 TFLOP/s/GPU on the 8L proxy, GB200). Call AFTER
-    ``set_workload_base_configs``/``set_full_iter_cg_configs`` so these win over
+    Call after ``set_workload_base_configs``/``set_full_iter_cg_configs`` so
+    these settings win over
     ``_set_common_perf_overrides`` (which forces the TE op fuser off and the
     cross-entropy fusion impl back to ``te``).
     """
@@ -334,10 +325,10 @@ def set_deepseek_v4_pro_common_configs(cfg: ConfigContainer) -> None:
     cfg.mixed_precision.fp8_param_gather = True
     cfg.mixed_precision.reuse_grad_buf_for_mxfp8_param_ag = True
 
-    # Train the DSA/CSA indexer, matching the MLM reference. The lib's DSv4-Flash
-    # recipe zeroes the indexer auxiliary loss (eval-leaning, same commit as the
-    # kitchen quant_recipe above), which leaves the sparse-token selector without a
-    # direct training signal. A faithful pretraining mirror keeps it on.
+    # Train the DSA/CSA indexer, matching the MLM reference. The library recipe
+    # zeroes the indexer auxiliary loss for evaluation-oriented use, which leaves
+    # the sparse-token selector without a direct training signal. A faithful
+    # performance configuration keeps it on.
     cfg.model.dsa_indexer_loss_coeff = 0.01
     cfg.model.dsa_indexer_use_sparse_loss = True
 
@@ -348,11 +339,6 @@ def set_deepseek_v4_pro_common_configs(cfg: ConfigContainer) -> None:
     # host cgroup (OOM-killed at iter 2). The 1.2x HBM buffer holds the stash alone.
     cfg.model.moe_paged_stash_buffer_size_factor_cpu = 0.0
 
-    # Log GPU memory every log_interval steps (mirrors MLM's --log-memory-interval),
-    # so steady-state peak memory is captured. MBridge's flag-gated report otherwise
-    # stops after iter 2, which under full-iter CG undercounts the post-capture peak.
-    cfg.logger.log_memory_interval = cfg.logger.log_interval
-
     # BF16 precision-aware optimizer master gradients, matching the MLM reference.
     # The lib forces main_grads_dtype=fp32 (deepseek_v4.py); MLM uses bf16. With the
     # precision-aware optimizer (enabled here) bf16 master grads are valid and halve
@@ -360,139 +346,25 @@ def set_deepseek_v4_pro_common_configs(cfg: ConfigContainer) -> None:
     # False above -- this is the separate optimizer-side knob.
     cfg.optimizer.main_grads_dtype = torch.bfloat16
 
-    # MCore's TransformerConfig.__post_init__ does set(self.offload_modules);
-    # keep it an empty list (not None) when fine-grained offloading is off. The
-    # full-Pro builder overrides this with the real offload module list.
-    cfg.model.fine_grained_activation_offloading = False
-    cfg.model.offload_modules = []
-
     cfg.dist.enable_megatron_core_experimental = True
     cfg.mixed_precision.grad_reduce_in_fp32 = False
     cfg.ddp.grad_reduce_in_fp32 = False
 
 
-def _deepseek_v4_pro_pretrain_config(gpu: str, precision: str, config_variant: str, *, proxy: bool) -> ConfigContainer:
-    """Build a DeepSeek-V4-Pro (or 8L proxy) performance config for ``gpu``."""
-    if precision != "fp8_mx":
-        raise NotImplementedError(
-            "DeepSeek-V4-Pro performance configs currently support precision='fp8_mx' "
-            f"(MXFP8) only; got {precision!r}."
-        )
-
-    model_recipe_name = "deepseek_v4_pro_proxy" if proxy else "deepseek_v4_pro"
-    base_cfg = get_workload_base_config(
-        model_family_name="deepseek",
-        model_recipe_name=model_recipe_name,
-        gpu=gpu,
-        compute_dtype=precision.upper(),
-        task="pretrain",
-        config_variant=config_variant,
-    )
-
-    cfg = deepseek_v4_pro_pretrain_mxfp8_config()
-
-    # Pre-apply parallelism so the pipeline-layout helper sees the right PP/VPP.
-    cfg.model.pipeline_model_parallel_size = base_cfg.pipeline_model_parallel_size
-    cfg.model.virtual_pipeline_model_parallel_size = base_cfg.virtual_pipeline_model_parallel_size
-    cfg.model.expert_model_parallel_size = base_cfg.expert_model_parallel_size
-    cfg.model.moe_flex_dispatcher_backend = base_cfg.moe_flex_dispatcher_backend
-
-    if proxy:
-        # Shrink the 61L Pro to an 8L proxy: drop MTP and truncate the per-layer
-        # lists the bridge derives from num_hidden_layers=61 to the proxy length.
-        # csa_compress_ratios is 62 (61 layers + 1 MTP); moe_layer_freq is 61
-        # (all-MoE). Both must equal num_layers after the override.
-        n = _DEEPSEEK_V4_PRO_PROXY_NUM_LAYERS
-        cfg.model.num_layers = n
-        cfg.model.mtp_num_layers = None
-        cfg.model.csa_compress_ratios = list(cfg.model.csa_compress_ratios)[:n]
-        if isinstance(cfg.model.moe_layer_freq, list):
-            cfg.model.moe_layer_freq = cfg.model.moe_layer_freq[:n]
-
-    if base_cfg.pp_layout:
-        cfg.model.pipeline_model_parallel_layout = base_cfg.pp_layout
-    else:
-        set_deepseek_v4_pipeline_model_parallel_layout(cfg.model)
-
-    set_workload_base_configs(cfg, base_cfg)
-    if is_full_iteration_cuda_graph(cfg.model):
-        set_full_iter_cg_configs(cfg)
-    set_deepseek_v4_pro_common_configs(cfg)
-
-    if not proxy:
-        # Full Pro: fine-grained activation offloading of attention activations
-        # (matches the validated 61L GB300 full-iter-CG run).
-        cfg.model.fine_grained_activation_offloading = True
-        cfg.model.offload_modules = ["core_attn", "attn_proj"]
-        cfg.model.fine_grained_offloading_max_inflight_offloads = 2
-
-    cfg.comm_overlap.overlap_grad_reduce = True
-
-    return cfg
-
-
-def deepseek_v4_pro_pretrain_config_gb200(
-    precision: str = "fp8_mx", mock: bool = True, config_variant: str = "v1"
-) -> ConfigContainer:
-    """GB200, full 61-layer DeepSeek-V4-Pro perf config (MXFP8)."""
-    return _deepseek_v4_pro_pretrain_config(
-        gpu="gb200", precision=precision, config_variant=config_variant, proxy=False
-    )
-
-
 def deepseek_v4_pro_pretrain_config_gb300(
     precision: str = "fp8_mx", mock: bool = True, config_variant: str = "v1"
 ) -> ConfigContainer:
-    """GB300, full 61-layer DeepSeek-V4-Pro perf config (MXFP8)."""
-    return _deepseek_v4_pro_pretrain_config(
-        gpu="gb300", precision=precision, config_variant=config_variant, proxy=False
-    )
-
-
-def deepseek_v4_pro_proxy_pretrain_config_gb200(
-    precision: str = "fp8_mx", mock: bool = True, config_variant: str = "v1"
-) -> ConfigContainer:
-    """GB200, 8-layer DeepSeek-V4-Pro proxy perf config (MXFP8, pipeclean)."""
-    return _deepseek_v4_pro_pretrain_config(
-        gpu="gb200", precision=precision, config_variant=config_variant, proxy=True
-    )
-
-
-def deepseek_v4_pro_proxy_pretrain_config_gb300(
-    precision: str = "fp8_mx", mock: bool = True, config_variant: str = "v1"
-) -> ConfigContainer:
-    """GB300, 8-layer DeepSeek-V4-Pro proxy perf config (MXFP8, pipeclean)."""
-    return _deepseek_v4_pro_pretrain_config(
-        gpu="gb300", precision=precision, config_variant=config_variant, proxy=True
-    )
-
-
-# Multi-stage debug proxy: PP2/VPP4 + MTP, 15 layers. Used to reproduce the full-Pro
-# scaling-mode crash at small scale (the PP1 proxy with MTP runs fine, so the trigger
-# needs a multi-stage pipeline + interleaved schedule + MTP on a non-first stage).
-_DEEPSEEK_V4_PRO_PROXY_PP2_NUM_LAYERS = 13
-
-
-def deepseek_v4_pro_proxy_pp2_pretrain_config_gb200(
-    precision: str = "fp8_mx", mock: bool = True, config_variant: str = "v1"
-) -> ConfigContainer:
-    """GB200, 15-layer DeepSeek-V4-Pro proxy with PP2/VPP4 + MTP (MXFP8, 128 GPUs).
-
-    Multi-stage debug variant: mimics the full Pro's pipeline + interleaved schedule +
-    MTP-on-last-stage at small scale. EP64 (like full Pro) -> PP2*EP64 = 128 GPUs.
-    15 transformer layers over 8 virtual stages (PP2*VPP4); last stage = "tmL" (1 layer
-    + MTP + loss). num_layers / CSA ratios / MTP / pp_layout are set HERE in Python (not
-    via Hydra overrides, which mis-parse the layout DSL into a single element).
-    """
+    """Build the full 61-layer DeepSeek-V4-Pro GB300 performance config."""
     if precision != "fp8_mx":
         raise NotImplementedError(
             "DeepSeek-V4-Pro performance configs currently support precision='fp8_mx' "
             f"(MXFP8) only; got {precision!r}."
         )
+
     base_cfg = get_workload_base_config(
         model_family_name="deepseek",
-        model_recipe_name="deepseek_v4_pro_proxy_pp2",
-        gpu="gb200",
+        model_recipe_name="deepseek_v4_pro",
+        gpu="gb300",
         compute_dtype=precision.upper(),
         task="pretrain",
         config_variant=config_variant,
@@ -500,22 +372,12 @@ def deepseek_v4_pro_proxy_pp2_pretrain_config_gb200(
 
     cfg = deepseek_v4_pro_pretrain_mxfp8_config()
 
+    # Pre-apply the validated full-scale parallelism before common overrides.
     cfg.model.pipeline_model_parallel_size = base_cfg.pipeline_model_parallel_size
     cfg.model.virtual_pipeline_model_parallel_size = base_cfg.virtual_pipeline_model_parallel_size
     cfg.model.expert_model_parallel_size = base_cfg.expert_model_parallel_size
     cfg.model.moe_flex_dispatcher_backend = base_cfg.moe_flex_dispatcher_backend
 
-    # 15 layers, KEEP MTP=1 (mimic full Pro). Truncate the bridge-derived per-layer lists:
-    # csa_compress_ratios -> first 15 (real) + [0] (MTP slot) = 16 == num_layers + mtp;
-    # moe_layer_freq -> first 15 (all-MoE).
-    n = _DEEPSEEK_V4_PRO_PROXY_PP2_NUM_LAYERS
-    cfg.model.num_layers = n
-    cfg.model.mtp_num_layers = 1
-    cfg.model.csa_compress_ratios = list(cfg.model.csa_compress_ratios)[:n] + [0]
-    if isinstance(cfg.model.moe_layer_freq, list):
-        cfg.model.moe_layer_freq = cfg.model.moe_layer_freq[:n]
-
-    # pp_layout string from the workload base config, set in Python (mcore parses the DSL).
     cfg.model.pipeline_model_parallel_layout = base_cfg.pp_layout
 
     set_workload_base_configs(cfg, base_cfg)
@@ -523,5 +385,12 @@ def deepseek_v4_pro_proxy_pp2_pretrain_config_gb200(
         set_full_iter_cg_configs(cfg)
     set_deepseek_v4_pro_common_configs(cfg)
 
+    # Fine-grained activation offloading of attention activations matches the
+    # validated full-scale GB300 run.
+    cfg.model.fine_grained_activation_offloading = True
+    cfg.model.offload_modules = ["core_attn", "attn_proj"]
+    cfg.model.fine_grained_offloading_max_inflight_offloads = 2
+
     cfg.comm_overlap.overlap_grad_reduce = True
+
     return cfg

--- a/scripts/performance/configs/deepseek/deepseek_llm_pretrain.py
+++ b/scripts/performance/configs/deepseek/deepseek_llm_pretrain.py
@@ -24,6 +24,10 @@ from megatron.bridge.recipes.deepseek.deepseek_v3 import (
 from megatron.bridge.recipes.deepseek.deepseek_v3 import (
     set_deepseek_v3_pipeline_model_parallel_layout,
 )
+from megatron.bridge.recipes.deepseek.deepseek_v4 import (
+    deepseek_v4_pro_pretrain_mxfp8_config,
+    set_deepseek_v4_pipeline_model_parallel_layout,
+)
 from megatron.bridge.training.config import ConfigContainer
 from megatron.bridge.utils.cuda_graph import is_full_iteration_cuda_graph
 
@@ -287,3 +291,141 @@ def deepseek_v3_pretrain_config_h100(
     cfg.comm_overlap.overlap_grad_reduce = False
 
     return cfg
+
+
+# Number of decoder layers in the DeepSeek-V4-Pro proxy. The proxy is a
+# pipeclean stand-in for the full 61-layer Pro model: it keeps every production
+# Pro hyperparameter (experts, MLA LoRA ranks, hash routing, SwiGLU clamp,
+# DSA/mHC) but shrinks the layer count so it fits on a single NVL72 domain.
+_DEEPSEEK_V4_PRO_PROXY_NUM_LAYERS = 8
+
+
+def set_deepseek_v4_pro_common_configs(cfg: ConfigContainer) -> None:
+    """Set the performance knobs shared by full DeepSeek-V4-Pro and its proxy.
+
+    Reproduces the validated full-iteration CUDA-graph + fused-DSA recipe
+    (calibrated ~917 TFLOP/s/GPU on the 8L proxy, GB200). Call AFTER
+    ``set_workload_base_configs``/``set_full_iter_cg_configs`` so these win over
+    ``_set_common_perf_overrides`` (which forces the TE op fuser off and the
+    cross-entropy fusion impl back to ``te``).
+    """
+    cfg.model.moe_router_force_load_balancing = True
+
+    # Fused DSA sparse attention (FlashMLA forward + cuDNN DSA backward) — the
+    # dominant perf lever over the unfused PyTorch DSA path.
+    cfg.model.apply_dsa_kernel_fusion = True
+
+    # TE op fuser + native cross-entropy fusion (dev backbone disables the "te"
+    # cross-entropy fusion path for DSv4).
+    cfg.model.use_transformer_engine_op_fuser = True
+    cfg.model.cross_entropy_loss_fusion = True
+    cfg.model.cross_entropy_fusion_impl = "native"
+
+    # cuteDSL fused grouped-MLP interleave (clamped SwiGLU fusion path).
+    cfg.model.moe_mlp_glu_interleave_size = 32
+
+    # MCore's TransformerConfig.__post_init__ does set(self.offload_modules);
+    # keep it an empty list (not None) when fine-grained offloading is off. The
+    # full-Pro builder overrides this with the real offload module list.
+    cfg.model.fine_grained_activation_offloading = False
+    cfg.model.offload_modules = []
+
+    cfg.dist.enable_megatron_core_experimental = True
+    cfg.mixed_precision.grad_reduce_in_fp32 = False
+    cfg.ddp.grad_reduce_in_fp32 = False
+
+
+def _deepseek_v4_pro_pretrain_config(gpu: str, precision: str, config_variant: str, *, proxy: bool) -> ConfigContainer:
+    """Build a DeepSeek-V4-Pro (or 8L proxy) performance config for ``gpu``."""
+    if precision != "fp8_mx":
+        raise NotImplementedError(
+            "DeepSeek-V4-Pro performance configs currently support precision='fp8_mx' "
+            f"(MXFP8) only; got {precision!r}."
+        )
+
+    model_recipe_name = "deepseek_v4_pro_proxy" if proxy else "deepseek_v4_pro"
+    base_cfg = get_workload_base_config(
+        model_family_name="deepseek",
+        model_recipe_name=model_recipe_name,
+        gpu=gpu,
+        compute_dtype=precision.upper(),
+        task="pretrain",
+        config_variant=config_variant,
+    )
+
+    cfg = deepseek_v4_pro_pretrain_mxfp8_config()
+
+    # Pre-apply parallelism so the pipeline-layout helper sees the right PP/VPP.
+    cfg.model.pipeline_model_parallel_size = base_cfg.pipeline_model_parallel_size
+    cfg.model.virtual_pipeline_model_parallel_size = base_cfg.virtual_pipeline_model_parallel_size
+    cfg.model.expert_model_parallel_size = base_cfg.expert_model_parallel_size
+    cfg.model.moe_flex_dispatcher_backend = base_cfg.moe_flex_dispatcher_backend
+
+    if proxy:
+        # Shrink the 61L Pro to an 8L proxy: drop MTP and truncate the per-layer
+        # lists the bridge derives from num_hidden_layers=61 to the proxy length.
+        # csa_compress_ratios is 62 (61 layers + 1 MTP); moe_layer_freq is 61
+        # (all-MoE). Both must equal num_layers after the override.
+        n = _DEEPSEEK_V4_PRO_PROXY_NUM_LAYERS
+        cfg.model.num_layers = n
+        cfg.model.mtp_num_layers = None
+        cfg.model.csa_compress_ratios = list(cfg.model.csa_compress_ratios)[:n]
+        if isinstance(cfg.model.moe_layer_freq, list):
+            cfg.model.moe_layer_freq = cfg.model.moe_layer_freq[:n]
+
+    if base_cfg.pp_layout:
+        cfg.model.pipeline_model_parallel_layout = base_cfg.pp_layout
+    else:
+        set_deepseek_v4_pipeline_model_parallel_layout(cfg.model)
+
+    set_workload_base_configs(cfg, base_cfg)
+    if is_full_iteration_cuda_graph(cfg.model):
+        set_full_iter_cg_configs(cfg)
+    set_deepseek_v4_pro_common_configs(cfg)
+
+    if not proxy:
+        # Full Pro: fine-grained activation offloading of attention activations
+        # (matches the validated 61L GB300 full-iter-CG run).
+        cfg.model.fine_grained_activation_offloading = True
+        cfg.model.offload_modules = ["core_attn", "attn_proj"]
+        cfg.model.fine_grained_offloading_max_inflight_offloads = 2
+
+    cfg.comm_overlap.overlap_grad_reduce = True
+
+    return cfg
+
+
+def deepseek_v4_pro_pretrain_config_gb200(
+    precision: str = "fp8_mx", mock: bool = True, config_variant: str = "v1"
+) -> ConfigContainer:
+    """GB200, full 61-layer DeepSeek-V4-Pro perf config (MXFP8)."""
+    return _deepseek_v4_pro_pretrain_config(
+        gpu="gb200", precision=precision, config_variant=config_variant, proxy=False
+    )
+
+
+def deepseek_v4_pro_pretrain_config_gb300(
+    precision: str = "fp8_mx", mock: bool = True, config_variant: str = "v1"
+) -> ConfigContainer:
+    """GB300, full 61-layer DeepSeek-V4-Pro perf config (MXFP8)."""
+    return _deepseek_v4_pro_pretrain_config(
+        gpu="gb300", precision=precision, config_variant=config_variant, proxy=False
+    )
+
+
+def deepseek_v4_pro_proxy_pretrain_config_gb200(
+    precision: str = "fp8_mx", mock: bool = True, config_variant: str = "v1"
+) -> ConfigContainer:
+    """GB200, 8-layer DeepSeek-V4-Pro proxy perf config (MXFP8, pipeclean)."""
+    return _deepseek_v4_pro_pretrain_config(
+        gpu="gb200", precision=precision, config_variant=config_variant, proxy=True
+    )
+
+
+def deepseek_v4_pro_proxy_pretrain_config_gb300(
+    precision: str = "fp8_mx", mock: bool = True, config_variant: str = "v1"
+) -> ConfigContainer:
+    """GB300, 8-layer DeepSeek-V4-Pro proxy perf config (MXFP8, pipeclean)."""
+    return _deepseek_v4_pro_pretrain_config(
+        gpu="gb300", precision=precision, config_variant=config_variant, proxy=True
+    )

--- a/scripts/performance/configs/deepseek/deepseek_workload_base_configs.py
+++ b/scripts/performance/configs/deepseek/deepseek_workload_base_configs.py
@@ -394,6 +394,23 @@ DEEPSEEK_V4_PRO_PROXY_PRETRAIN_CONFIG_GB200_FP8_MX_V1 = replace(
 )
 DEEPSEEK_V4_PRO_PROXY_PRETRAIN_CONFIG_GB300_FP8_MX_V1 = DEEPSEEK_V4_PRO_PROXY_PRETRAIN_CONFIG_GB200_FP8_MX_V1
 
+# Multi-stage proxy (PP2/VPP4 + MTP) for reproducing the full-Pro scaling-mode crash
+# at small scale. 15 transformer layers over 8 virtual stages (PP2*VPP4); last stage =
+# "tmL" (1 layer + MTP + loss), leaner for perf. EP64 mimics full Pro, so this needs
+# PP2*EP64 = 128 GPUs.
+DEEPSEEK_V4_PRO_PROXY_PP2_PRETRAIN_CONFIG_GB200_FP8_MX_V1 = replace(
+    BASE_DEEPSEEK_V4_PRO_CONFIG,
+    num_gpus=128,
+    micro_batch_size=1,
+    global_batch_size=2048,
+    pipeline_model_parallel_size=2,
+    virtual_pipeline_model_parallel_size=2,
+    expert_model_parallel_size=64,
+    pp_layout="Et*4|t*4|t*4|tmL",
+    recompute_modules=[],
+)
+DEEPSEEK_V4_PRO_PROXY_PP2_PRETRAIN_CONFIG_GB300_FP8_MX_V1 = DEEPSEEK_V4_PRO_PROXY_PP2_PRETRAIN_CONFIG_GB200_FP8_MX_V1
+
 
 __all__ = [
     # DeepSeek V4 Pro (MXFP8)
@@ -401,6 +418,8 @@ __all__ = [
     "DEEPSEEK_V4_PRO_PRETRAIN_CONFIG_GB200_FP8_MX_V1",
     "DEEPSEEK_V4_PRO_PROXY_PRETRAIN_CONFIG_GB200_FP8_MX_V1",
     "DEEPSEEK_V4_PRO_PROXY_PRETRAIN_CONFIG_GB300_FP8_MX_V1",
+    "DEEPSEEK_V4_PRO_PROXY_PP2_PRETRAIN_CONFIG_GB200_FP8_MX_V1",
+    "DEEPSEEK_V4_PRO_PROXY_PP2_PRETRAIN_CONFIG_GB300_FP8_MX_V1",
     # V1 (original GBS settings)
     "DEEPSEEK_V3_PRETRAIN_CONFIG_GB300_BF16_V1",
     "DEEPSEEK_V3_PRETRAIN_CONFIG_GB300_FP8_CS_V1",

--- a/scripts/performance/configs/deepseek/deepseek_workload_base_configs.py
+++ b/scripts/performance/configs/deepseek/deepseek_workload_base_configs.py
@@ -348,12 +348,10 @@ DEEPSEEK_V3_PRETRAIN_CONFIG_GB300_FP8_MX_GBS15360 = replace(
 # =============================================================================
 # DeepSeek V4 Pro Pretrain (MXFP8, full-iteration CUDA graph + fused DSA)
 #
-# Full Pro is the 61-layer production model. The proxy shrinks it to 8 layers
-# for single-NVL72-domain pipecleans. Layer count / CSA compress ratios / MTP
-# are overridden in the perf builder (deepseek_llm_pretrain.py), not here -
-# WorkloadBaseConfig has no num_layers field. Mirrors the dsv3 FP8_MX full-iter
-# pattern: cuda_graph_impl="full_iteration" + cutedsl_fused_grouped_mlp=True
-# auto-plumb the cuteDSL/CG env vars via perf_plugins.
+# Full Pro is the 61-layer production model. This configuration mirrors the
+# DeepSeek-V3 FP8_MX full-iteration pattern: full-iteration CUDA graphs and the
+# cuteDSL fused grouped MLP automatically plumb the required environment via
+# the performance plugins.
 # =============================================================================
 
 BASE_DEEPSEEK_V4_PRO_CONFIG = WorkloadBaseConfig(
@@ -377,49 +375,9 @@ DEEPSEEK_V4_PRO_PRETRAIN_CONFIG_GB300_FP8_MX_V1 = replace(
     pp_layout="Et*4|(tttt|)*14tmL",
     recompute_modules=["mla_up_proj", "mhc"],
 )
-DEEPSEEK_V4_PRO_PRETRAIN_CONFIG_GB200_FP8_MX_V1 = DEEPSEEK_V4_PRO_PRETRAIN_CONFIG_GB300_FP8_MX_V1
-
-# 8-layer proxy: TP=1, PP=1, EP=64 on 64 GPUs (one NVL72 domain), GBS=2048,
-# no recompute (everything fits under full-iteration CUDA graph).
-DEEPSEEK_V4_PRO_PROXY_PRETRAIN_CONFIG_GB200_FP8_MX_V1 = replace(
-    BASE_DEEPSEEK_V4_PRO_CONFIG,
-    num_gpus=64,
-    micro_batch_size=1,
-    global_batch_size=2048,
-    pipeline_model_parallel_size=1,
-    virtual_pipeline_model_parallel_size=None,
-    expert_model_parallel_size=64,
-    pp_layout=None,
-    recompute_modules=[],
-)
-DEEPSEEK_V4_PRO_PROXY_PRETRAIN_CONFIG_GB300_FP8_MX_V1 = DEEPSEEK_V4_PRO_PROXY_PRETRAIN_CONFIG_GB200_FP8_MX_V1
-
-# Multi-stage proxy (PP2/VPP4 + MTP) for reproducing the full-Pro scaling-mode crash
-# at small scale. 15 transformer layers over 8 virtual stages (PP2*VPP4); last stage =
-# "tmL" (1 layer + MTP + loss), leaner for perf. EP64 mimics full Pro, so this needs
-# PP2*EP64 = 128 GPUs.
-DEEPSEEK_V4_PRO_PROXY_PP2_PRETRAIN_CONFIG_GB200_FP8_MX_V1 = replace(
-    BASE_DEEPSEEK_V4_PRO_CONFIG,
-    num_gpus=128,
-    micro_batch_size=1,
-    global_batch_size=2048,
-    pipeline_model_parallel_size=2,
-    virtual_pipeline_model_parallel_size=2,
-    expert_model_parallel_size=64,
-    pp_layout="Et*4|t*4|t*4|tmL",
-    recompute_modules=[],
-)
-DEEPSEEK_V4_PRO_PROXY_PP2_PRETRAIN_CONFIG_GB300_FP8_MX_V1 = DEEPSEEK_V4_PRO_PROXY_PP2_PRETRAIN_CONFIG_GB200_FP8_MX_V1
-
-
 __all__ = [
     # DeepSeek V4 Pro (MXFP8)
     "DEEPSEEK_V4_PRO_PRETRAIN_CONFIG_GB300_FP8_MX_V1",
-    "DEEPSEEK_V4_PRO_PRETRAIN_CONFIG_GB200_FP8_MX_V1",
-    "DEEPSEEK_V4_PRO_PROXY_PRETRAIN_CONFIG_GB200_FP8_MX_V1",
-    "DEEPSEEK_V4_PRO_PROXY_PRETRAIN_CONFIG_GB300_FP8_MX_V1",
-    "DEEPSEEK_V4_PRO_PROXY_PP2_PRETRAIN_CONFIG_GB200_FP8_MX_V1",
-    "DEEPSEEK_V4_PRO_PROXY_PP2_PRETRAIN_CONFIG_GB300_FP8_MX_V1",
     # V1 (original GBS settings)
     "DEEPSEEK_V3_PRETRAIN_CONFIG_GB300_BF16_V1",
     "DEEPSEEK_V3_PRETRAIN_CONFIG_GB300_FP8_CS_V1",

--- a/scripts/performance/configs/deepseek/deepseek_workload_base_configs.py
+++ b/scripts/performance/configs/deepseek/deepseek_workload_base_configs.py
@@ -357,21 +357,21 @@ DEEPSEEK_V3_PRETRAIN_CONFIG_GB300_FP8_MX_GBS15360 = replace(
 BASE_DEEPSEEK_V4_PRO_CONFIG = WorkloadBaseConfig(
     expert_tensor_parallel_size=1,
     moe_flex_dispatcher_backend="hybridep",
-    moe_a2a_overlap=False,
-    cuda_graph_impl="full_iteration",
-    cuda_graph_scope=[],
-    cutedsl_fused_grouped_mlp=True,
+    num_gpus=256,
+    micro_batch_size=1,
+    global_batch_size=4096,
 )
 
 # Full 61-layer Pro: TP=1, PP=4, VPP=4, EP=64 on 256 GPUs, GBS=4096.
 DEEPSEEK_V4_PRO_PRETRAIN_CONFIG_GB300_FP8_MX_V1 = replace(
     BASE_DEEPSEEK_V4_PRO_CONFIG,
-    num_gpus=256,
-    micro_batch_size=1,
-    global_batch_size=4096,
     pipeline_model_parallel_size=4,
     virtual_pipeline_model_parallel_size=4,
     expert_model_parallel_size=64,
+    moe_a2a_overlap=False,
+    cuda_graph_impl="full_iteration",
+    cuda_graph_scope=[],
+    cutedsl_fused_grouped_mlp=True,
     pp_layout="Et*4|(tttt|)*14tmL",
     recompute_modules=["mla_up_proj", "mhc"],
 )

--- a/scripts/performance/configs/deepseek/deepseek_workload_base_configs.py
+++ b/scripts/performance/configs/deepseek/deepseek_workload_base_configs.py
@@ -345,7 +345,62 @@ DEEPSEEK_V3_PRETRAIN_CONFIG_GB300_FP8_MX_GBS15360 = replace(
 )
 
 
+# =============================================================================
+# DeepSeek V4 Pro Pretrain (MXFP8, full-iteration CUDA graph + fused DSA)
+#
+# Full Pro is the 61-layer production model. The proxy shrinks it to 8 layers
+# for single-NVL72-domain pipecleans. Layer count / CSA compress ratios / MTP
+# are overridden in the perf builder (deepseek_llm_pretrain.py), not here -
+# WorkloadBaseConfig has no num_layers field. Mirrors the dsv3 FP8_MX full-iter
+# pattern: cuda_graph_impl="full_iteration" + cutedsl_fused_grouped_mlp=True
+# auto-plumb the cuteDSL/CG env vars via perf_plugins.
+# =============================================================================
+
+BASE_DEEPSEEK_V4_PRO_CONFIG = WorkloadBaseConfig(
+    expert_tensor_parallel_size=1,
+    moe_flex_dispatcher_backend="hybridep",
+    moe_a2a_overlap=False,
+    cuda_graph_impl="full_iteration",
+    cuda_graph_scope=[],
+    cutedsl_fused_grouped_mlp=True,
+)
+
+# Full 61-layer Pro: TP=1, PP=4, VPP=4, EP=64 on 256 GPUs, GBS=4096.
+DEEPSEEK_V4_PRO_PRETRAIN_CONFIG_GB300_FP8_MX_V1 = replace(
+    BASE_DEEPSEEK_V4_PRO_CONFIG,
+    num_gpus=256,
+    micro_batch_size=1,
+    global_batch_size=4096,
+    pipeline_model_parallel_size=4,
+    virtual_pipeline_model_parallel_size=4,
+    expert_model_parallel_size=64,
+    pp_layout="Et*4|(tttt|)*14tmL",
+    recompute_modules=["mla_up_proj", "mhc"],
+)
+DEEPSEEK_V4_PRO_PRETRAIN_CONFIG_GB200_FP8_MX_V1 = DEEPSEEK_V4_PRO_PRETRAIN_CONFIG_GB300_FP8_MX_V1
+
+# 8-layer proxy: TP=1, PP=1, EP=64 on 64 GPUs (one NVL72 domain), GBS=2048,
+# no recompute (everything fits under full-iteration CUDA graph).
+DEEPSEEK_V4_PRO_PROXY_PRETRAIN_CONFIG_GB200_FP8_MX_V1 = replace(
+    BASE_DEEPSEEK_V4_PRO_CONFIG,
+    num_gpus=64,
+    micro_batch_size=1,
+    global_batch_size=2048,
+    pipeline_model_parallel_size=1,
+    virtual_pipeline_model_parallel_size=None,
+    expert_model_parallel_size=64,
+    pp_layout=None,
+    recompute_modules=[],
+)
+DEEPSEEK_V4_PRO_PROXY_PRETRAIN_CONFIG_GB300_FP8_MX_V1 = DEEPSEEK_V4_PRO_PROXY_PRETRAIN_CONFIG_GB200_FP8_MX_V1
+
+
 __all__ = [
+    # DeepSeek V4 Pro (MXFP8)
+    "DEEPSEEK_V4_PRO_PRETRAIN_CONFIG_GB300_FP8_MX_V1",
+    "DEEPSEEK_V4_PRO_PRETRAIN_CONFIG_GB200_FP8_MX_V1",
+    "DEEPSEEK_V4_PRO_PROXY_PRETRAIN_CONFIG_GB200_FP8_MX_V1",
+    "DEEPSEEK_V4_PRO_PROXY_PRETRAIN_CONFIG_GB300_FP8_MX_V1",
     # V1 (original GBS settings)
     "DEEPSEEK_V3_PRETRAIN_CONFIG_GB300_BF16_V1",
     "DEEPSEEK_V3_PRETRAIN_CONFIG_GB300_FP8_CS_V1",

--- a/src/megatron/bridge/recipes/deepseek/__init__.py
+++ b/src/megatron/bridge/recipes/deepseek/__init__.py
@@ -38,6 +38,8 @@ from .deepseek_v4 import (
     deepseek_v4_flash_pretrain_muon_config,
     deepseek_v4_flash_pretrain_mxfp8_config,
     deepseek_v4_flash_sft_config,
+    deepseek_v4_pro_pretrain_config,
+    deepseek_v4_pro_pretrain_mxfp8_config,
     set_deepseek_v4_pipeline_model_parallel_layout,
 )
 
@@ -56,5 +58,7 @@ __all__ = [
     "deepseek_v4_flash_pretrain_muon_config",
     "deepseek_v4_flash_sft_config",
     "deepseek_v4_flash_no_mtp_sft_config",
+    "deepseek_v4_pro_pretrain_config",
+    "deepseek_v4_pro_pretrain_mxfp8_config",
     "set_deepseek_v4_pipeline_model_parallel_layout",
 ]

--- a/src/megatron/bridge/recipes/deepseek/deepseek_v4.py
+++ b/src/megatron/bridge/recipes/deepseek/deepseek_v4.py
@@ -277,6 +277,167 @@ def deepseek_v4_flash_pretrain_muon_config() -> ConfigContainer:
     return cfg
 
 
+def deepseek_v4_pro_pretrain_config() -> ConfigContainer:
+    """Return the DeepSeek-V4-Pro Blackwell pre-training base config.
+
+    Full 61-layer Pro model. Architecture (layer count, experts, MLA LoRA ranks,
+    CSA/DSA compress ratios, hash-routing layers, SwiGLU clamp, MTP) is derived
+    from the ``deepseek-ai/DeepSeek-V4-Pro`` HF config by the bridge. Recommended
+    Blackwell baseline: TP=1, PP=4, EP=8, CP=1. The performance layer overrides
+    parallelism (e.g. EP=64) and enables full-iteration CUDA graphs / fused DSA.
+    """
+    use_fused_mhc = deepseek_v4_supports_blackwell_fused_kernels()
+    cfg = _pretrain_common()
+    cfg.model = AutoBridge.from_hf_pretrained(
+        "deepseek-ai/DeepSeek-V4-Pro", trust_remote_code=True
+    ).to_megatron_provider(load_weights=False)
+
+    cfg.model.tensor_model_parallel_size = 1
+    cfg.model.pipeline_model_parallel_size = 4
+    cfg.model.pipeline_dtype = torch.bfloat16
+    cfg.model.virtual_pipeline_model_parallel_size = None
+    cfg.model.context_parallel_size = 1
+    cfg.model.expert_model_parallel_size = 8
+    cfg.model.expert_tensor_parallel_size = 1
+    cfg.model.sequence_parallel = False
+    cfg.model.seq_length = 4096
+    cfg.model.params_dtype = torch.bfloat16
+
+    cfg.model.account_for_embedding_in_pipeline_split = False
+    cfg.model.account_for_loss_in_pipeline_split = False
+    cfg.model.num_layers_in_first_pipeline_stage = None
+    cfg.model.num_layers_in_last_pipeline_stage = None
+    set_deepseek_v4_pipeline_model_parallel_layout(cfg.model)
+
+    cfg.model.transformer_impl = "transformer_engine"
+    cfg.model.attention_backend = None
+    cfg.model.apply_dsa_kernel_fusion = False
+    cfg.model.apply_rope_fusion = True
+    cfg.model.use_fused_mhc = use_fused_mhc
+    cfg.model.dsa_indexer_loss_coeff = 0.0
+    cfg.model.dsa_indexer_use_sparse_loss = False
+
+    cfg.model.moe_token_dispatcher_type = "alltoall"
+    cfg.model.moe_aux_loss_coeff = 0.0
+    cfg.model.moe_router_force_load_balancing = False
+    cfg.model.cross_entropy_loss_fusion = True
+    cfg.model.cross_entropy_fusion_impl = "te"
+
+    cfg.model.recompute_granularity = "selective"
+    cfg.model.recompute_modules = ["moe_act", "mhc"]
+    cfg.model.recompute_method = None
+    cfg.model.recompute_num_layers = None
+    cfg.model.fine_grained_activation_offloading = False
+    cfg.model.offload_modules = None
+    cfg.model.cuda_graph_impl = "none"
+    cfg.model.cuda_graph_scope = "full"
+    cfg.model.cuda_graph_warmup_steps = 3
+
+    cfg.tokenizer.tokenizer_type = "NullTokenizer"
+    cfg.tokenizer.tokenizer_model = None
+    cfg.tokenizer.vocab_size = cfg.model.vocab_size
+    cfg.tokenizer.make_vocab_size_divisible_by = cfg.model.make_vocab_size_divisible_by
+    cfg.tokenizer.tensor_model_parallel_size = cfg.model.tensor_model_parallel_size
+    cfg.tokenizer.rank = 0
+
+    cfg.dataset.blend = None
+    cfg.dataset.blend_per_split = None
+    cfg.dataset.seq_length = 4096
+    cfg.dataset.num_workers = 8
+    cfg.dataset.skip_getting_attention_mask_from_dataset = True
+    cfg.dataset.dataloader_type = "single"
+
+    cfg.train.train_iters = 1_000_000
+    cfg.train.global_batch_size = 128
+    cfg.train.micro_batch_size = 1
+    cfg.train.manual_gc = True
+    cfg.train.manual_gc_interval = 5
+    cfg.train.manual_gc_eval = 5
+    cfg.validation.eval_interval = 2000
+    cfg.validation.eval_iters = 32
+
+    cfg.logger.log_interval = 10
+    cfg.checkpoint.save_interval = 2000
+    cfg.checkpoint.async_save = False
+    cfg.dist.enable_megatron_core_experimental = True
+
+    cfg.comm_overlap = CommOverlapConfig(tp_comm_overlap=False)
+    cfg.comm_overlap.delay_wgrad_compute = False
+    cfg.comm_overlap.overlap_moe_expert_parallel_comm = False
+
+    cfg.ddp.check_for_nan_in_grad = True
+    cfg.ddp.use_megatron_fsdp = False
+    return cfg
+
+
+def deepseek_v4_pro_pretrain_mxfp8_config() -> ConfigContainer:
+    """Return the DeepSeek-V4-Pro Adam + MXFP8 pre-training config."""
+    cfg = deepseek_v4_pro_pretrain_config()
+
+    cfg.model.tensor_model_parallel_size = 1
+    cfg.model.pipeline_model_parallel_size = 4
+    cfg.model.virtual_pipeline_model_parallel_size = None
+    cfg.model.context_parallel_size = 1
+    cfg.model.expert_model_parallel_size = 8
+    cfg.model.expert_tensor_parallel_size = 1
+    cfg.model.sequence_parallel = False
+    cfg.model.seq_length = 4096
+    cfg.dataset.seq_length = 4096
+    cfg.train.train_iters = 1_000_000
+    cfg.train.global_batch_size = 128
+    cfg.train.micro_batch_size = 1
+    use_fused_mhc = deepseek_v4_supports_blackwell_fused_kernels()
+    cfg.model.apply_dsa_kernel_fusion = False
+    cfg.model.apply_rope_fusion = True
+    cfg.model.use_fused_mhc = use_fused_mhc
+    cfg.model.dsa_indexer_loss_coeff = 0.0
+    cfg.model.dsa_indexer_use_sparse_loss = False
+    cfg.model.moe_token_dispatcher_type = "alltoall"
+    cfg.model.recompute_granularity = "selective"
+    cfg.model.recompute_modules = ["moe_act", "mhc"]
+    set_deepseek_v4_pipeline_model_parallel_layout(cfg.model)
+
+    opt_cfg, scheduler_cfg = distributed_fused_adam_with_cosine_annealing(
+        lr_warmup_iters=2000,
+        lr_decay_iters=cfg.train.train_iters,
+        max_lr=2.7e-4,
+        min_lr=2.7e-5,
+        weight_decay=0.1,
+        clip_grad=1.0,
+    )
+    opt_cfg.use_precision_aware_optimizer = True
+    opt_cfg.main_grads_dtype = torch.float32
+    opt_cfg.main_params_dtype = torch.float32
+    opt_cfg.exp_avg_dtype = torch.bfloat16
+    opt_cfg.exp_avg_sq_dtype = torch.bfloat16
+    opt_cfg.adam_beta1 = 0.9
+    opt_cfg.adam_beta2 = 0.95
+    opt_cfg.adam_eps = 1e-20
+
+    scheduler_cfg.start_weight_decay = 0.1
+    scheduler_cfg.end_weight_decay = 0.1
+    scheduler_cfg.weight_decay_incr_style = "constant"
+
+    cfg.optimizer = opt_cfg
+    cfg.scheduler = scheduler_cfg
+    cfg.ddp.use_distributed_optimizer = True
+    cfg.ddp.overlap_param_gather = True
+    cfg.ddp.overlap_grad_reduce = True
+    cfg.ddp.grad_reduce_in_fp32 = True
+    cfg.ddp.average_in_collective = True
+    cfg.ddp.data_parallel_sharding_strategy = "optim_grads_params"
+    cfg.mixed_precision = bf16_with_mxfp8_mixed()
+    # MCore uses a layer's training quantization recipe during eval unless an
+    # evaluation_recipe is provided. Keep DSv4 MTP/validation eval in BF16
+    # while training TE linears with MXFP8.
+    cfg.mixed_precision.fp8_param_gather = False
+    cfg.mixed_precision.reuse_grad_buf_for_mxfp8_param_ag = False
+    cfg.model.moe_router_padding_for_fp8 = True
+    cfg.model.mtp_eval_in_bf16 = True
+    cfg.model.quant_recipe = _deepseek_v4_mxfp8_quant_recipe()
+    return cfg
+
+
 # ---------------------------------------------------------------------------
 # Supervised fine-tuning (SFT)
 # ---------------------------------------------------------------------------

--- a/src/megatron/bridge/training/utils/train_utils.py
+++ b/src/megatron/bridge/training/utils/train_utils.py
@@ -1236,6 +1236,15 @@ def training_log(
                 # Make sure the memory after the second iteration is reported
                 # to include optimizer state memory.
                 report_memory_flag = False
+        if logger_config.log_memory_interval is not None and iteration % logger_config.log_memory_interval == 0:
+            # Per-interval memory report (mirrors mcore's --log-memory-interval),
+            # independent of report_memory_flag, so steady-state memory is logged
+            # beyond the first two iterations (the flag-gated block stops after iter 2).
+            memory_string = f"(after {iteration} iterations) memory (GB)"
+            for metric, value in report_memory(logger_config.memory_keys).items():
+                memory_string += f" | {metric}: {value}"
+            if torch.distributed.get_rank(group=pg_collection.dp) == 0:
+                print("[Rank {}] {}".format(torch.distributed.get_rank(), memory_string), flush=True)
         timers.log(timers_to_log, normalizer=logger_config.log_interval)
 
     return report_memory_flag

--- a/src/megatron/bridge/training/utils/train_utils.py
+++ b/src/megatron/bridge/training/utils/train_utils.py
@@ -1236,15 +1236,6 @@ def training_log(
                 # Make sure the memory after the second iteration is reported
                 # to include optimizer state memory.
                 report_memory_flag = False
-        if logger_config.log_memory_interval is not None and iteration % logger_config.log_memory_interval == 0:
-            # Per-interval memory report (mirrors mcore's --log-memory-interval),
-            # independent of report_memory_flag, so steady-state memory is logged
-            # beyond the first two iterations (the flag-gated block stops after iter 2).
-            memory_string = f"(after {iteration} iterations) memory (GB)"
-            for metric, value in report_memory(logger_config.memory_keys).items():
-                memory_string += f" | {metric}: {value}"
-            if torch.distributed.get_rank(group=pg_collection.dp) == 0:
-                print("[Rank {}] {}".format(torch.distributed.get_rank(), memory_string), flush=True)
         timers.log(timers_to_log, normalizer=logger_config.log_interval)
 
     return report_memory_flag


### PR DESCRIPTION
## What changed

- add the full 61-layer DeepSeek-V4-Pro pretraining recipe
- add the Adam + MXFP8 configuration used by the performance recipe
- add the validated 256-GPU GB300 performance configuration
- enable the full-scale performance settings used by the reference run, including fused DSA, full-iteration CUDA graphs, cuteDSL grouped MLP, MXFP8 parameter gather, and fine-grained activation offloading

## Scope

This PR intentionally includes only the validated full-scale GB300 recipe. GB200 aliases, reduced-layer proxy recipes, Rubin configurations, and cluster-specific submission scripts are excluded.

## Validation

- validated on 256 GB300 GPUs for 40 iterations at approximately 21.5 seconds per iteration
- approximately 996 calibrated TFLOP/s/GPU versus 967 for the MCore-direct reference
- repository pre-commit hooks pass
- Python compilation and `git diff --check` pass

## Dependencies

The recipe uses the DeepSeek-V4 model support already present on the `r0.5.0` branch and requires the corresponding Megatron-Core DeepSeek-V4 performance capabilities in the runtime environment.
