### PR TITLE
docs(recipe): fix Gemma 2 checkpoint overrides

### DIFF
--- a/docs/fern/versions/nightly/pages/models/gemma/gemma2.mdx
+++ b/docs/fern/versions/nightly/pages/models/gemma/gemma2.mdx
@@ -167,7 +167,7 @@ config = gemma2_27b_pretrain_config(
 #### Gemma 2 2B
 ```bash
 uv run python -m torch.distributed.run --nproc-per-node=8 scripts/training/run_recipe.py \
---pretrained-checkpoint /models/gemma-2-2b \
+checkpoint.pretrained_checkpoint=/models/gemma-2-2b \
 --recipe gemma2_2b_sft_config \
 train.global_batch_size=64 \
 train.train_iters=1000 \
@@ -189,7 +189,7 @@ config = gemma2_2b_sft_config(
 #### Gemma 2 9B
 ```bash
 uv run python -m torch.distributed.run --nproc-per-node=8 scripts/training/run_recipe.py \
---pretrained-checkpoint /models/gemma-2-9b \
+checkpoint.pretrained_checkpoint=/models/gemma-2-9b \
 --recipe gemma2_9b_sft_config \
 train.global_batch_size=64 \
 train.train_iters=1000 \
@@ -199,7 +199,7 @@ checkpoint.save=$SAVE_DIR/gemma2_9b_finetune
 #### Gemma 2 27B
 ```bash
 uv run python -m torch.distributed.run --nproc-per-node=16 scripts/training/run_recipe.py \
---pretrained-checkpoint /models/gemma-2-27b \
+checkpoint.pretrained_checkpoint=/models/gemma-2-27b \
 --recipe gemma2_27b_sft_config \
 train.global_batch_size=64 \
 train.train_iters=1000 \
@@ -211,7 +211,7 @@ checkpoint.save=$SAVE_DIR/gemma2_27b_finetune
 #### Gemma 2 2B
 ```bash
 uv run python -m torch.distributed.run --nproc-per-node=8 scripts/training/run_recipe.py \
---pretrained-checkpoint /models/gemma-2-2b \
+checkpoint.pretrained_checkpoint=/models/gemma-2-2b \
 --recipe gemma2_2b_peft_config \
 --peft_scheme lora \
 train.global_batch_size=128 \

--- a/docs/models/gemma/gemma2.md
+++ b/docs/models/gemma/gemma2.md
@@ -167,7 +167,7 @@ config = gemma2_27b_pretrain_config(
 #### Gemma 2 2B
 ```bash
 uv run python -m torch.distributed.run --nproc-per-node=8 scripts/training/run_recipe.py \
---pretrained-checkpoint /models/gemma-2-2b \
+checkpoint.pretrained_checkpoint=/models/gemma-2-2b \
 --recipe gemma2_2b_sft_config \
 train.global_batch_size=64 \
 train.train_iters=1000 \
@@ -189,7 +189,7 @@ config = gemma2_2b_sft_config(
 #### Gemma 2 9B
 ```bash
 uv run python -m torch.distributed.run --nproc-per-node=8 scripts/training/run_recipe.py \
---pretrained-checkpoint /models/gemma-2-9b \
+checkpoint.pretrained_checkpoint=/models/gemma-2-9b \
 --recipe gemma2_9b_sft_config \
 train.global_batch_size=64 \
 train.train_iters=1000 \
@@ -199,7 +199,7 @@ checkpoint.save=$SAVE_DIR/gemma2_9b_finetune
 #### Gemma 2 27B
 ```bash
 uv run python -m torch.distributed.run --nproc-per-node=16 scripts/training/run_recipe.py \
---pretrained-checkpoint /models/gemma-2-27b \
+checkpoint.pretrained_checkpoint=/models/gemma-2-27b \
 --recipe gemma2_27b_sft_config \
 train.global_batch_size=64 \
 train.train_iters=1000 \
@@ -211,7 +211,7 @@ checkpoint.save=$SAVE_DIR/gemma2_27b_finetune
 #### Gemma 2 2B
 ```bash
 uv run python -m torch.distributed.run --nproc-per-node=8 scripts/training/run_recipe.py \
---pretrained-checkpoint /models/gemma-2-2b \
+checkpoint.pretrained_checkpoint=/models/gemma-2-2b \
 --recipe gemma2_2b_peft_config \
 --peft_scheme lora \
 train.global_batch_size=128 \
@@ -287,4 +287,3 @@ config = gemma2_27b_peft_config(
 - Recipe usage: [Recipe usage](../../recipe-usage.md)
 - Customizing the training recipe configuration: [Configuration overview](../../training/config-container-overview.md)
 - Training entry points: [Entry points](../../training/entry-points.md)
-


### PR DESCRIPTION
## What does this PR do?

Fix the Gemma 2 SFT and PEFT launch examples so their pretrained-checkpoint paths use the Hydra override syntax accepted by `scripts/training/run_recipe.py`.

## User impact

Copying any documented Gemma 2 SFT command, or the documented 2B PEFT command, currently exits before training. The runner does not define `--pretrained-checkpoint`; it forwards that token to Hydra, which rejects it with `LexerNoViableAltException`.

## Root cause and fix

The examples used a legacy two-token CLI option:

```text
--pretrained-checkpoint /models/gemma-2-2b
```

The generic recipe runner accepts unknown arguments only as Hydra overrides. The examples now target the existing checkpoint field directly:

```text
checkpoint.pretrained_checkpoint=/models/gemma-2-2b
```

The canonical Gemma 2 page and its nightly Fern mirror are updated together.

## Validation

Fail before:

```bash
uv run python -c 'from hydra.core.override_parser.overrides_parser import OverridesParser; OverridesParser.create().parse_overrides(overrides=["--pretrained-checkpoint", "/models/gemma-2-2b"])'
```

Result: exit 1, `OverrideParseException: LexerNoViableAltException: --pretrained-checkpoint`.

Pass after:

```bash
uv run python -c 'from hydra.core.override_parser.overrides_parser import OverridesParser; OverridesParser.create().parse_overrides(overrides=["checkpoint.pretrained_checkpoint=/models/gemma-2-2b"])'
```

Result: exit 0. An unchanged focused reproducer extracted and parsed all four checkpoint arguments from both edited pages: 8 validated.

Adjacent checks:

```bash
uv run python -m pytest tests/unit_tests/recipes/gemma/test_gemma2_recipes.py -q
uv run python -m pytest tests/unit_tests/doc_consistency/test_readme_consistency.py -q
uv run python -m pytest tests/unit_tests/training/utils/test_omegaconf_utils.py::TestParseHydraOverrides -q
git diff --check
uv run pre-commit run --all-files
```

Results: 30 passed; 5 passed; 4 passed; diff check passed; all pre-commit hooks passed.

## Scope

Documentation only. This does not change recipe, parser, checkpoint, or training runtime behavior, and does not claim GPU, convergence, or performance validation.
