### PR TITLE
fix(perf): copy PreemptionPlugin into launcher to drop megatron import

### DIFF
--- a/scripts/performance/perf_plugins.py
+++ b/scripts/performance/perf_plugins.py
@@ -655,3 +655,71 @@ class PyTorchProfilerPlugin(Plugin):
             logger.info(f"{self.__class__.__name__} added CLI overrides: {', '.join(cli_overrides)}")
         else:
             raise NotImplementedError("PyTorchProfilerPlugin is only supported for run.Script tasks")
+
+
+@dataclass
+class PreemptionPluginScriptArgs:
+    """Arguments for PreemptionPlugin to pass to run.Script."""
+
+    enable_exit_handler: bool
+    enable_exit_handler_for_data_loader: bool
+
+
+def _default_preemption_converter(args: PreemptionPluginScriptArgs) -> List[str]:
+    """Default converter for PreemptionPlugin that generates hydra-style overrides."""
+    return [
+        f"train.exit_signal_handler={str(args.enable_exit_handler)}",
+        f"train.exit_signal_handler_for_dataloader={str(args.enable_exit_handler_for_data_loader)}",
+    ]
+
+
+@dataclass(kw_only=True)
+class PreemptionPlugin(Plugin):
+    """A plugin for setting up preemption handling and signals.
+
+    Args:
+        preempt_time (int): The time, in seconds, before the task's time limit at which the executor
+                             will send a SIGTERM preemption signal. This allows tasks to be gracefully
+                             stopped before reaching their time limit, reducing waste and
+                             promoting fair resource usage. The default value is 60 seconds (1 minute).
+                             This is only supported for ``run.SlurmExecutor``.
+        enable_exit_handler (bool): Whether to enable the exit signal handler in training config.
+        enable_exit_handler_for_data_loader (bool): Whether to enable the exit signal handler for data loader.
+        script_args_converter_fn (Optional[Callable]): A function that takes PreemptionPluginScriptArgs
+                                                        and returns a list of CLI arguments. If not provided,
+                                                        uses the default hydra-style converter.
+    """
+
+    preempt_time: int = 60
+    enable_exit_handler: bool = True
+    enable_exit_handler_for_data_loader: bool = False
+    script_args_converter_fn: Optional[Callable[[PreemptionPluginScriptArgs], List[str]]] = None
+
+    def setup(self, task: Union["run.Partial", "run.Script"], executor: "run.Executor"):
+        """Set up the preemption plugin."""
+        if isinstance(task, Script):
+            # For run.Script, append CLI overrides to the script arguments
+            if self.enable_exit_handler:
+                # Create args dataclass
+                script_args = PreemptionPluginScriptArgs(
+                    enable_exit_handler=self.enable_exit_handler,
+                    enable_exit_handler_for_data_loader=self.enable_exit_handler_for_data_loader,
+                )
+
+                # Use custom converter or default
+                converter = self.script_args_converter_fn or _default_preemption_converter
+                cli_overrides = converter(script_args)
+
+                task.args.extend(cli_overrides)
+                logger.info(f"{self.__class__.__name__} added CLI overrides: {', '.join(cli_overrides)}")
+        else:
+            raise NotImplementedError("PreemptionPlugin is only supported for run.Script tasks")
+
+        # Apply signal configuration for both task types when using SlurmExecutor
+        if isinstance(executor, SlurmExecutor):
+            # Sends a SIGTERM self.preempt_time seconds before hitting time limit
+            logger.info(
+                f"{self.__class__.__name__} will send a SIGTERM {self.preempt_time} seconds before the "
+                "job's time limit for your Slurm executor."
+            )
+            executor.signal = f"TERM@{self.preempt_time}"

--- a/scripts/performance/setup_experiment.py
+++ b/scripts/performance/setup_experiment.py
@@ -46,13 +46,10 @@ try:
 except (ImportError, ModuleNotFoundError):
     HAVE_WANDB = False
 
-from megatron.bridge.recipes.run_plugins import PreemptionPlugin
-
-
 try:
-    from perf_plugins import NsysPlugin, PerfEnvPlugin, PyTorchProfilerPlugin
+    from perf_plugins import NsysPlugin, PerfEnvPlugin, PreemptionPlugin, PyTorchProfilerPlugin
 except (ImportError, ModuleNotFoundError):
-    from .perf_plugins import NsysPlugin, PerfEnvPlugin, PyTorchProfilerPlugin
+    from .perf_plugins import NsysPlugin, PerfEnvPlugin, PreemptionPlugin, PyTorchProfilerPlugin
 
 SCRIPT_DIR = Path(__file__).parent.resolve()
 ENTRYPOINT_PERFORMANCE = "run_script.py"


### PR DESCRIPTION
## Background / motivation

- The perf launcher `scripts/performance/setup_experiment.py` runs on a submit node that has **no torch/cuda/`megatron`** — it only builds the nemo-run experiment and hands it to Slurm. The actual training runs later, inside the container, where `megatron` *is* available.
- Its module-level `from megatron.bridge.recipes.run_plugins import PreemptionPlugin` pulled in the whole `megatron` stack at **import time**, failing before any training started:

  ```
  File ".../scripts/performance/setup_experiment.py", line 49, in <module>
      from megatron.bridge.recipes.run_plugins import PreemptionPlugin
  ModuleNotFoundError: No module named 'megatron'
  ```

  Observed on `wan_1_3b_8gpu_gb200` (nemo-ci `main`, job `359638586`).
- Every *other* launcher plugin — `NsysPlugin`, `PerfEnvPlugin`, `PyTorchProfilerPlugin` (in `perf_plugins.py`) and `FaultTolerancePlugin` (in `resiliency_plugins.py`) — is already a **local copy** of its `run_plugins.py` counterpart, precisely so the launcher does not need Megatron-Bridge installed. `PreemptionPlugin` was the one that was missed.

## What changed

- Copy `PreemptionPlugin` (+ `PreemptionPluginScriptArgs` + `_default_preemption_converter`) from `megatron/bridge/recipes/run_plugins.py` into `scripts/performance/perf_plugins.py`.
- Import `PreemptionPlugin` from the local `perf_plugins` in `setup_experiment.py` instead of `megatron.bridge`.

## Details

- `perf_plugins.py` already carries the header *"copy from megatron/bridge/recipes/run_plugins.py … cloned to not require installing Megatron-Bridge to run the perf scripts."* This change just completes that mirror.
- The copy drops the upstream `HAVE_NEMO_RUN` guard to match the local file style (`perf_plugins.py` imports `nemo_run`/`Script`/`SlurmExecutor` unconditionally at the top).
- No new import-time `megatron` dependency is introduced: `perf_plugins.py` needs only `nemo_run` + `utils.utils`, and `utils.utils`'s `megatron.bridge` imports are all lazy (function-local). The CI trace confirms this — `utils.utils` imported cleanly before the crash at line 49.

```mermaid
flowchart LR
    subgraph launcher["Submit node (no torch/cuda/megatron)"]
        SE["setup_experiment.py"] -->|before| MB["megatron.bridge.recipes.run_plugins<br/>ModuleNotFoundError ❌"]
        SE -->|after| PP["perf_plugins.PreemptionPlugin ✅"]
    end
    SE --> SLURM["Slurm"] --> trainer["Trainer container<br/>(megatron available)"]
```

## Tested

- `python -m py_compile` on both files — OK.
- `ruff@0.9.9 check` / `check --select I` / `format --check` on both files — all pass.
- Grep confirms `setup_experiment.py` has **no** remaining module-level `megatron` import; the `PreemptionPlugin(...)` call site (long-convergence path) is unchanged.
