### PR TITLE
fix(diffusion): construct Wan pipeline stages

### DIFF
--- a/src/megatron/bridge/diffusion/models/wan/wan_model.py
+++ b/src/megatron/bridge/diffusion/models/wan/wan_model.py
@@ -167,15 +167,12 @@ class WanModel(VisionModule):
 
         # set attributes "average_gradients_across_tp_domain" for nn.Parameter objects
         # this is used for gradient averaging across TP domain with sequence parallelism
-        self._mark_trainable_params_for_tp_grad_avg(
-            [
-                self.patch_embedding,
-                self.text_embedding,
-                self.time_embedder,
-                self.time_proj,
-                self.head,
-            ]
-        )
+        tp_grad_avg_modules = [self.text_embedding, self.time_embedder, self.time_proj]
+        if self.pre_process:
+            tp_grad_avg_modules.append(self.patch_embedding)
+        if self.post_process:
+            tp_grad_avg_modules.append(self.head)
+        self._mark_trainable_params_for_tp_grad_avg(tp_grad_avg_modules)
 
     def forward(
         self,

--- a/tests/unit_tests/diffusion/model/wan/test_wan_provider.py
+++ b/tests/unit_tests/diffusion/model/wan/test_wan_provider.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 import torch
 import torch.nn as nn
 from megatron.core import parallel_state
@@ -21,10 +22,19 @@ from megatron.bridge.diffusion.models.wan.wan_model import WanModel
 from megatron.bridge.diffusion.models.wan.wan_provider import WanModelProvider
 
 
-def test_wan_model_provider_provide_returns_model(monkeypatch):
+@pytest.mark.parametrize(
+    ("is_first_stage", "is_last_stage"),
+    [
+        pytest.param(True, True, id="single-stage"),
+        pytest.param(True, False, id="first-stage"),
+        pytest.param(False, False, id="middle-stage"),
+        pytest.param(False, True, id="last-stage"),
+    ],
+)
+def test_wan_model_provider_constructs_pipeline_stage(monkeypatch, is_first_stage, is_last_stage):
     # Force pipeline stage booleans to avoid dependency on initialized model parallel
-    monkeypatch.setattr(parallel_state, "is_pipeline_first_stage", lambda: True, raising=False)
-    monkeypatch.setattr(parallel_state, "is_pipeline_last_stage", lambda: True, raising=False)
+    monkeypatch.setattr(parallel_state, "is_pipeline_first_stage", lambda: is_first_stage, raising=False)
+    monkeypatch.setattr(parallel_state, "is_pipeline_last_stage", lambda: is_last_stage, raising=False)
     # Avoid querying uninitialized PP groups
     monkeypatch.setattr(parallel_state, "get_pipeline_model_parallel_world_size", lambda: 1, raising=False)
 
@@ -78,6 +88,8 @@ def test_wan_model_provider_provide_returns_model(monkeypatch):
     provider.num_query_groups = provider.num_attention_heads
     model = provider.provide()
     assert isinstance(model, WanModel)
+    assert hasattr(model, "patch_embedding") is is_first_stage
+    assert hasattr(model, "head") is is_last_stage
     # Sanity check key config properties were plumbed
     assert model.config.hidden_size == 64
     assert model.config.num_attention_heads == 4


### PR DESCRIPTION
## Summary

- construct Wan first, middle, and last pipeline stages without dereferencing absent stage-local modules
- preserve TP gradient marking for shared conditioning modules and the modules owned by each stage
- extend the provider regression test across all four stage ownership combinations

## Supported trigger and impact

Wan training configs and the public inference CLI accept pipeline parallel sizes greater than one. During PP=2 model construction, the first rank omitted `head` and the last rank omitted `patch_embedding`, but `WanModel.__init__` unconditionally accessed both while assembling the TP-gradient-marking list. Both ranks therefore crashed before scheduling or checkpoint loading completed.

## Fix

Build the marking list from shared modules, then append `patch_embedding` and `head` only on the stages that own them. This keeps PP=1 behavior unchanged and does not alter model ownership or forward semantics.

## Validation

- Exact-base focused test: failed before with missing `head`; passed after the fix
- `uv run --no-sync python -m pytest tests/unit_tests/diffusion/model/wan/test_wan_provider.py tests/unit_tests/diffusion/model/wan/test_wan_model_misc.py tests/unit_tests/diffusion/model/wan/flow_matching/test_flow_inference_pipeline.py::TestSetupModelFromCheckpoint -q` — 9 passed
- Two-process PP=2 construction reproducer with pinned MCore — base failed on missing `head`/`patch_embedding`; fixed branch exited 0
- `git diff --check` — passed
- `uv run --no-sync pre-commit run --all-files` — passed

## Scope

This change is limited to ordinary Wan stage construction. It does not change public APIs, forward computation, checkpoint formats, or separate virtual-pipeline flag handling.