### PR TITLE
[ckpt] fix: load legacy checkpoints without content metadata

### DIFF
--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -2641,6 +2641,8 @@ def _load_checkpoint_from_path(
             if not tp_pp_match:
                 print_rank_0("{}: Rerun state will be ignored".format(mismatch_msg))
 
+        if sharded_sd_metadata is None:
+            sharded_sd_metadata = {}
         sharded_sd_metadata["dp_cp_group"] = pg_collection.dp_cp
         optim_sd_kwargs = dict(metadata=sharded_sd_metadata, is_loading=True)
         model_sd_kwargs = dict(metadata=sharded_sd_metadata)

--- a/tests/unit_tests/training/test_checkpointing.py
+++ b/tests/unit_tests/training/test_checkpointing.py
@@ -2512,8 +2512,8 @@ class TestMegatronLMCompatibility:
         mock_pg_collection.dp_cp.rank.return_value = 0
         mock_get_pg_collection.return_value = mock_pg_collection
 
-        # Mock dist_checkpointing
-        mock_dist_ckpt.load_content_metadata.return_value = {}
+        # Legacy checkpoints predate content metadata in the common state.
+        mock_dist_ckpt.load_content_metadata.return_value = None
         mock_dist_ckpt.load.return_value = {}
 
         mock_rerun_machine.return_value.load_state_dict = Mock()


### PR DESCRIPTION
## Summary

- normalize missing torch-dist content metadata before attaching the runtime DP/CP process group;
- make the legacy Megatron-LM integration fixture match MCore's real missing-metadata contract.

## Bug and impact

Bridge explicitly supports loading legacy Megatron-LM torch-dist checkpoints through the legacy tracker, embedded argument extraction, and train-state fallback. Checkpoints created before content metadata was introduced do not contain that optional common-state field.

Pinned MCore returns `None` when content metadata is absent. For a supported legacy resume with a non-distributed optimizer (or with optimizer loading disabled), Bridge left the value as `None` and then assigned `sharded_sd_metadata["dp_cp_group"]`, raising `TypeError` before model loading began.

The fix normalizes absent metadata only after the existing distributed-optimizer fallback. That preserves reconstruction of the saved optimizer sharding type while allowing model and non-distributed optimizer scaffolds to load old checkpoints.

## Validation

The CPU-only commands below used a temporary import shim in `PYTHONPATH` to skip package-wide optional model/data registrations; the checkpoint loader and failing metadata boundary were not mocked by that shim.

Fail-before / pass-after:

```bash
uv run --no-project --python 3.12 \
  --with pytest==8.3.5 --with torch==2.9.1 --with numpy --with pyyaml \
  --with transformers --with safetensors --with nvidia-modelopt --with requests \
  --with tensorboard \
  python -m pytest --confcutdir=tests/unit_tests/training \
  tests/unit_tests/training/test_checkpointing.py::TestMegatronLMCompatibility::test_load_checkpoint_full_legacy_integration -q
```

- Base `b864189731ae15c5f891f5d543f638d2213348cc`: failed with `TypeError: 'NoneType' object does not support item assignment` at the DP/CP metadata attachment.
- Patched: 1 passed.

Adjacent legacy compatibility coverage:

```bash
uv run --no-project --python 3.12 \
  --with pytest==8.3.5 --with torch==2.9.1 --with numpy --with pyyaml \
  --with transformers --with safetensors --with nvidia-modelopt --with requests \
  --with tensorboard \
  python -m pytest --confcutdir=tests/unit_tests/training \
  tests/unit_tests/training/test_checkpointing.py::TestMegatronLMCompatibility -q
```

Result: 6 passed.

```bash
git diff --check
uv run --no-sync pre-commit run --all-files
```

Both passed.

## Scope

This is limited to torch-dist checkpoints whose optional content metadata is absent. New Bridge checkpoints, local checkpoints, FSDP-DTensor loading, and the existing distributed-optimizer metadata fallback are unchanged. No full-suite, GPU, distributed, convergence, model-quality, or performance validation was run.
