### PR TITLE
[model] fix: propagate Wan virtual pipeline stages

### DIFF
--- a/src/megatron/bridge/diffusion/models/wan/wan_layer_spec.py
+++ b/src/megatron/bridge/diffusion/models/wan/wan_layer_spec.py
@@ -111,7 +111,11 @@ class WanLayerWithAdaLN(TransformerLayer):
         # Replace any submodules that will have CP disabled and build them manually later after TransformerLayer init.
         # modified_submods = _replace_no_cp_submodules(submodules)
         super().__init__(
-            config=config, submodules=submodules, layer_number=layer_number, hidden_dropout=hidden_dropout
+            config=config,
+            submodules=submodules,
+            layer_number=layer_number,
+            hidden_dropout=hidden_dropout,
+            vp_stage=vp_stage,
         )
 
         # TODO (pmannan): Override Cross Attention to disable CP.

--- a/src/megatron/bridge/diffusion/models/wan/wan_model.py
+++ b/src/megatron/bridge/diffusion/models/wan/wan_model.py
@@ -98,6 +98,7 @@ class WanModel(VisionModule):
         fp16_lm_cross_entropy: bool = False,
         parallel_output: bool = True,
         transformer_decoder_layer_spec=WanLayerWithAdaLNspec,
+        vp_stage: Optional[int] = None,
         **kwargs,
     ):
         super(WanModel, self).__init__(config=config)
@@ -159,6 +160,7 @@ class WanModel(VisionModule):
             pre_process=self.pre_process,
             post_process=self.post_process,
             post_layer_norm=False,
+            vp_stage=vp_stage,
         )
 
         # output head

--- a/src/megatron/bridge/diffusion/models/wan/wan_provider.py
+++ b/src/megatron/bridge/diffusion/models/wan/wan_provider.py
@@ -84,8 +84,9 @@ class WanModelProvider(TransformerConfig, ModelProviderMixin[VisionModule]):  # 
 
         return model(
             self,
-            pre_process=parallel_state.is_pipeline_first_stage(),
-            post_process=parallel_state.is_pipeline_last_stage(),
+            pre_process=parallel_state.is_pipeline_first_stage() if pre_process is None else pre_process,
+            post_process=parallel_state.is_pipeline_last_stage() if post_process is None else post_process,
             fp16_lm_cross_entropy=self.fp16_lm_cross_entropy,
             parallel_output=self.parallel_output,
+            vp_stage=vp_stage,
         )

--- a/tests/unit_tests/diffusion/model/wan/test_wan_layer_spec.py
+++ b/tests/unit_tests/diffusion/model/wan/test_wan_layer_spec.py
@@ -12,7 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from megatron.bridge.diffusion.models.wan.wan_layer_spec import get_wan_block_with_transformer_engine_spec
+import torch.nn as nn
+from megatron.core.transformer.transformer_layer import TransformerLayer
+
+import megatron.bridge.diffusion.models.wan.wan_layer_spec as wan_layer_spec
+from megatron.bridge.diffusion.models.wan.wan_layer_spec import (
+    WanLayerWithAdaLN,
+    WanWithAdaLNSubmodules,
+    get_wan_block_with_transformer_engine_spec,
+)
 
 
 def test_get_wan_block_with_transformer_engine_spec_basic():
@@ -24,3 +32,36 @@ def test_get_wan_block_with_transformer_engine_spec_basic():
     # Expected submodule fields exist
     for name in ["norm1", "norm2", "norm3", "full_self_attention", "cross_attention", "mlp"]:
         assert hasattr(sub, name), f"Missing submodule {name}"
+
+
+def test_wan_layer_forwards_virtual_pipeline_stage(monkeypatch):
+    captured = {}
+
+    def fake_transformer_layer_init(
+        self,
+        *,
+        config,
+        submodules,
+        layer_number,
+        hidden_dropout,
+        pg_collection=None,
+        vp_stage=None,
+    ):
+        nn.Module.__init__(self)
+        self.config = config
+        self.cross_attention = nn.Identity()
+        self.mlp = nn.Identity()
+        captured["vp_stage"] = vp_stage
+
+    monkeypatch.setattr(TransformerLayer, "__init__", fake_transformer_layer_init)
+    monkeypatch.setattr(wan_layer_spec, "build_module", lambda *args, **kwargs: nn.Identity())
+    monkeypatch.setattr(wan_layer_spec, "WanAdaLN", lambda config: nn.Identity())
+
+    config = type(
+        "Config",
+        (),
+        {"hidden_size": 8, "layernorm_epsilon": 1e-6, "sequence_parallel": False},
+    )()
+    WanLayerWithAdaLN(config=config, submodules=WanWithAdaLNSubmodules(), vp_stage=1)
+
+    assert captured["vp_stage"] == 1

--- a/tests/unit_tests/diffusion/model/wan/test_wan_provider.py
+++ b/tests/unit_tests/diffusion/model/wan/test_wan_provider.py
@@ -34,6 +34,7 @@ def test_wan_model_provider_provide_returns_model(monkeypatch):
         def __init__(self, *args, **kwargs):
             super().__init__()
             self.input_tensor = None
+            self.vp_stage = kwargs.get("vp_stage")
 
         def set_input_tensor(self, input_tensor):
             self.input_tensor = input_tensor
@@ -44,7 +45,7 @@ def test_wan_model_provider_provide_returns_model(monkeypatch):
     monkeypatch.setattr(wan_model_module, "TransformerBlock", DummyTransformerBlock, raising=False)
 
     provider = WanModelProvider(
-        num_layers=2,  # keep small
+        num_layers=4,  # keep small and divisible across PP=2, VPP=2
         hidden_size=64,
         ffn_hidden_size=128,
         num_attention_heads=4,
@@ -72,12 +73,15 @@ def test_wan_model_provider_provide_returns_model(monkeypatch):
         freq_dim=16,
         text_len=32,
         text_dim=64,
+        pipeline_model_parallel_size=2,
+        virtual_pipeline_model_parallel_size=2,
     )
     # Ensure config supplies fields expected by core attention
     provider.kv_channels = provider.hidden_size // provider.num_attention_heads
     provider.num_query_groups = provider.num_attention_heads
-    model = provider.provide()
+    model = provider.provide(pre_process=True, post_process=True, vp_stage=1)
     assert isinstance(model, WanModel)
+    assert model.decoder.vp_stage == 1
     # Sanity check key config properties were plumbed
     assert model.config.hidden_size == 64
     assert model.config.num_attention_heads == 4


### PR DESCRIPTION
## What changed

Wan virtual pipeline parallelism accepted and validated `virtual_pipeline_model_parallel_size`, but dropped the `vp_stage` supplied by Bridge at two constructor boundaries. With PP=2/VPP=2, MCore therefore received `None` while calculating virtual-stage layer offsets and aborted model initialization.

This patch:

- honors the explicit `pre_process` and `post_process` values supplied by Bridge's model factory;
- forwards `vp_stage` from `WanModelProvider` through `WanModel` into `TransformerBlock`;
- forwards the same stage from the block into the Wan transformer-layer superclass.

## User impact

A supported Wan configuration with PP>1 and VPP enabled could not initialize, even when its layer count satisfied Wan's divisibility validation. Training or inference stopped before the first iteration.

## Regression evidence

The unchanged focused tests failed on the base revision because both downstream boundaries observed `vp_stage=None`, then passed with this patch:

```text
uv run --no-sync python -m pytest \
  tests/unit_tests/diffusion/model/wan/test_wan_provider.py::test_wan_model_provider_provide_returns_model \
  tests/unit_tests/diffusion/model/wan/test_wan_layer_spec.py::test_wan_layer_forwards_virtual_pipeline_stage -q

base: 2 failed
patch: 2 passed
```

Adjacent validation:

```text
uv run --no-sync python -m pytest \
  tests/unit_tests/diffusion/model/wan/test_wan_provider.py \
  tests/unit_tests/diffusion/model/wan/test_wan_layer_spec.py \
  tests/unit_tests/diffusion/model/wan/test_wan_model_misc.py -q
# 4 passed

CUDA_VISIBLE_DEVICES=0,1 uv run --no-sync python -m torch.distributed.run \
  --nproc_per_node=2 <focused Wan PP=2/VPP=2 constructor reproducer>
# passed: both virtual-stage blocks constructed on both PP ranks

uv run --no-sync pre-commit run --all-files
# passed

git diff --check
# passed
```

## Scope

This validates stage ownership and real PP=2/VPP=2 block construction. It does not claim full Wan training, convergence, performance, or generation validation. The separate stage-local patch/head construction issue is already addressed by #4823 and is not bundled here.
