### PR TITLE
fix(training): align GDN MTP FLOPs with decoder layout

### DIFF
--- a/src/megatron/bridge/training/utils/flop_utils.py
+++ b/src/megatron/bridge/training/utils/flop_utils.py
@@ -968,20 +968,21 @@ def num_floating_point_operations(
         # weighted sum of GDN and standard-attention per-layer costs.
         if experimental_attention_variant == "gated_delta_net":
             linear_attention_freq = cfg.model.linear_attention_freq
+            decoder_num_layers = cfg.model.num_layers
             if linear_attention_freq is None:
                 raise ValueError(
                     "linear_attention_freq must be set when experimental_attention_variant='gated_delta_net'"
                 )
             if isinstance(linear_attention_freq, int):
                 linear_attention_pattern = [
-                    0 if ((i + 1) % linear_attention_freq == 0) else 1 for i in range(num_layers)
+                    0 if ((i + 1) % linear_attention_freq == 0) else 1 for i in range(decoder_num_layers)
                 ]
             elif isinstance(linear_attention_freq, list):
                 linear_attention_pattern = linear_attention_freq
-                if len(linear_attention_pattern) != num_layers:
+                if len(linear_attention_pattern) != decoder_num_layers:
                     raise ValueError(
                         f"Invalid length of linear_attention_pattern: {len(linear_attention_pattern)}, "
-                        f"expected {num_layers}, "
+                        f"expected {decoder_num_layers}, "
                         f"current linear_attention_freq: {linear_attention_freq}"
                     )
             else:
@@ -989,7 +990,10 @@ def num_floating_point_operations(
                     f"linear_attention_freq must be int or list, got {type(linear_attention_freq).__name__}"
                 )
 
-            num_gdn_layers = sum(linear_attention_pattern)
+            # MTP construction reuses the final decoder layer spec, so each MTP
+            # layer has the same attention type as the final decoder layer.
+            last_layer_is_gdn = linear_attention_pattern[-1] if linear_attention_pattern else 0
+            num_gdn_layers = sum(linear_attention_pattern) + last_layer_is_gdn * mtp_num_layers
             num_standard_attn_layers = num_layers - num_gdn_layers
 
             standard_self_attn_per_layer = self_attn_term / num_layers if num_layers > 0 else 0

--- a/tests/unit_tests/training/utils/test_flop_utils.py
+++ b/tests/unit_tests/training/utils/test_flop_utils.py
@@ -791,6 +791,54 @@ class TestGDNLayerFlops:
             "List [1,1,0,1,1,0,1,1] should produce the same FLOPs as int freq=3 (equivalent 6/2 split)"
         )
 
+    @pytest.mark.parametrize("linear_attention_freq", [4, [1, 1, 1, 0]])
+    def test_gdn_mtp_repeats_last_decoder_attention(self, linear_attention_freq):
+        """MTP should reuse the final decoder layer's standard-attention spec."""
+        batch_size = 1
+        hidden_size = 128
+        seq_length = 32
+        ffn_hidden_size = 256
+        num_attention_heads = 4
+        num_query_groups = 2
+        kv_channels = 32
+        vocab_size = 1024
+        model_overrides = {
+            "num_layers": 4,
+            "hidden_size": hidden_size,
+            "seq_length": seq_length,
+            "ffn_hidden_size": ffn_hidden_size,
+            "num_attention_heads": num_attention_heads,
+            "num_query_groups": num_query_groups,
+            "kv_channels": kv_channels,
+            "vocab_size": vocab_size,
+            "gated_linear_unit": False,
+            "linear_attention_freq": linear_attention_freq,
+        }
+        base_cfg = MockConfigContainer(model=self._qwen35_27b_config(**model_overrides))
+        mtp_cfg = MockConfigContainer(model=self._qwen35_27b_config(**model_overrides, mtp_num_layers=1))
+
+        query_projection_size = kv_channels * num_attention_heads
+        key_value_projection_size = kv_channels * num_query_groups
+        dense_mlp = 3 * 2 * hidden_size * (ffn_hidden_size * 2)
+        standard_attention = (
+            3
+            * 2
+            * (
+                hidden_size * (query_projection_size + 2 * key_value_projection_size)
+                + query_projection_size * hidden_size
+                + query_projection_size * seq_length
+            )
+        )
+        mtp_aux = 3 * 2 * (3 * hidden_size + 2 * hidden_size**2)
+        extra_logits = 3 * 2 * hidden_size * vocab_size
+        expected_delta = batch_size * seq_length * (dense_mlp + standard_attention + mtp_aux + extra_logits)
+
+        actual_delta = num_floating_point_operations(mtp_cfg, batch_size=batch_size) - num_floating_point_operations(
+            base_cfg, batch_size=batch_size
+        )
+
+        assert actual_delta == pytest.approx(expected_delta)
+
     def test_gdn_exact_self_attn_term(self):
         """Verify the GDN self_attn_term matches the expected formula from Megatron-LM."""
         batch_size = 1

--- a/tests/unit_tests/training/utils/test_flop_utils.py
+++ b/tests/unit_tests/training/utils/test_flop_utils.py
@@ -791,9 +791,17 @@ class TestGDNLayerFlops:
             "List [1,1,0,1,1,0,1,1] should produce the same FLOPs as int freq=3 (equivalent 6/2 split)"
         )
 
-    @pytest.mark.parametrize("linear_attention_freq", [4, [1, 1, 1, 0]])
-    def test_gdn_mtp_repeats_last_decoder_attention(self, linear_attention_freq):
-        """MTP should reuse the final decoder layer's standard-attention spec."""
+    @pytest.mark.parametrize(
+        ("linear_attention_freq", "last_layer_is_gdn"),
+        [
+            pytest.param(4, False, id="int-last-standard"),
+            pytest.param([1, 1, 1, 0], False, id="list-last-standard"),
+            pytest.param(3, True, id="int-last-gdn"),
+            pytest.param([1, 1, 0, 1], True, id="list-last-gdn"),
+        ],
+    )
+    def test_gdn_mtp_reuses_last_decoder_attention_type(self, linear_attention_freq, last_layer_is_gdn):
+        """Every MTP depth should reuse the final decoder layer's attention type."""
         batch_size = 1
         hidden_size = 128
         seq_length = 32
@@ -802,6 +810,12 @@ class TestGDNLayerFlops:
         num_query_groups = 2
         kv_channels = 32
         vocab_size = 1024
+        mtp_num_layers = 2
+        linear_key_head_dim = 16
+        linear_value_head_dim = 16
+        linear_num_key_heads = 4
+        linear_num_value_heads = 8
+        linear_conv_kernel_dim = 4
         model_overrides = {
             "num_layers": 4,
             "hidden_size": hidden_size,
@@ -813,9 +827,14 @@ class TestGDNLayerFlops:
             "vocab_size": vocab_size,
             "gated_linear_unit": False,
             "linear_attention_freq": linear_attention_freq,
+            "linear_key_head_dim": linear_key_head_dim,
+            "linear_value_head_dim": linear_value_head_dim,
+            "linear_num_key_heads": linear_num_key_heads,
+            "linear_num_value_heads": linear_num_value_heads,
+            "linear_conv_kernel_dim": linear_conv_kernel_dim,
         }
         base_cfg = MockConfigContainer(model=self._qwen35_27b_config(**model_overrides))
-        mtp_cfg = MockConfigContainer(model=self._qwen35_27b_config(**model_overrides, mtp_num_layers=1))
+        mtp_cfg = MockConfigContainer(model=self._qwen35_27b_config(**model_overrides, mtp_num_layers=mtp_num_layers))
 
         query_projection_size = kv_channels * num_attention_heads
         key_value_projection_size = kv_channels * num_query_groups
@@ -829,9 +848,24 @@ class TestGDNLayerFlops:
                 + query_projection_size * seq_length
             )
         )
+        qk_dim = linear_key_head_dim * linear_num_key_heads
+        v_dim = linear_value_head_dim * linear_num_value_heads
+        gdn_attention = (
+            3
+            * 2
+            * (
+                hidden_size * (2 * qk_dim + 2 * v_dim + 2 * linear_num_value_heads)
+                + linear_conv_kernel_dim * (2 * qk_dim + v_dim)
+                + linear_num_value_heads * linear_value_head_dim**2 * 4
+                + hidden_size * v_dim
+            )
+        )
         mtp_aux = 3 * 2 * (3 * hidden_size + 2 * hidden_size**2)
         extra_logits = 3 * 2 * hidden_size * vocab_size
-        expected_delta = batch_size * seq_length * (dense_mlp + standard_attention + mtp_aux + extra_logits)
+        last_attention = gdn_attention if last_layer_is_gdn else standard_attention
+        expected_delta = (
+            batch_size * seq_length * mtp_num_layers * (dense_mlp + last_attention + mtp_aux + extra_logits)
+        )
 
         actual_delta = num_floating_point_operations(mtp_cfg, batch_size=batch_size) - num_floating_point_operations(
             base_cfg, batch_size=batch_size


### PR DESCRIPTION
# What does this PR do ?

Fixes Gated DeltaNet FLOPs accounting when a decoder-only attention layout is combined with Multi-Token Prediction (MTP), unblocking the Qwen3.5-VL L1 recipe test on `main`.

# Changelog

- Generate and validate `linear_attention_freq` against decoder layers only; Hugging Face layer layouts do not include MTP layers.
- Account for every MTP layer using the final decoder layer's attention type, matching MCore's MTP block construction.
- Add a parameterized unit regression for integer/list layouts whose final decoder layer is either standard attention or GDN, with an exact FLOPs-delta assertion across two MTP depths.

# GitHub Actions CI

Validated in the repository container on EOS:

- PASS: `uv run python -m pytest tests/unit_tests/training/utils/test_flop_utils.py::TestGDNLayerFlops::test_gdn_mtp_reuses_last_decoder_attention_type -q` (`4 passed`)
- PASS: `uv run python -m pytest tests/unit_tests/training/utils/test_flop_utils.py::TestGDNLayerFlops -q` (`9 passed`)
- PASS: mutation check: removing the MTP GDN-layer term makes both final-GDN cases fail (`2 failed`), then both pass after restoring the implementation.
- PASS: 2-GPU H100 `TestQwen35VLFinetuneRecipes::test_sft_nothing_frozen` smoke train (`1 passed`, all 10 iterations plus validation/test evaluation)
- PASS: `uv run pre-commit run --all-files`

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] Added a unit regression covering the broken integer/list plus MTP paths.
- [x] No documentation update is needed; this restores existing internal FLOPs semantics.
- [x] The change does not affect optional-install components or import guards.

# Additional Information

- Regression introduced by #4790 (`2f69b067748a0842521a527b59ace55e18df7f44`): exact Hugging Face Qwen attention schedules became decoder-length lists.
- Last passing target job: https://github.com/NVIDIA-NeMo/Megatron-Bridge/actions/runs/29123303699/job/86496304191
- First failing target job at the bad commit: https://github.com/NVIDIA-NeMo/Megatron-Bridge/actions/runs/29135911454/job/86513808812
- #4821 reduced the functional-test list from 64 entries to 4, but Bridge FLOPs accounting still required 5 entries after adding `mtp_num_layers=1`.
- Current failing `main` job fixed by this PR: https://github.com/NVIDIA-NeMo/Megatron-Bridge/actions/runs/29176488641/job/86607551503
