### PR TITLE
fix(data): honor --packed_sequence for llm-finetune-preloaded

### DIFF
--- a/src/megatron/bridge/recipes/utils/dataset_utils.py
+++ b/src/megatron/bridge/recipes/utils/dataset_utils.py
@@ -26,6 +26,7 @@ from megatron.bridge.data.builders import (
 )
 from megatron.bridge.data.energon.energon_provider import EnergonProvider
 from megatron.bridge.data.loaders import get_blend_and_blend_per_split
+from megatron.bridge.data.packing import PackedSequenceSpecs
 from megatron.bridge.data.vlm_datasets.preloaded_provider import PreloadedVLMConversationProvider
 from megatron.bridge.recipes.utils.finetune_utils import (
     default_gsm8k_config,
@@ -226,6 +227,14 @@ def apply_dataset_override(
             raise ValueError(
                 "llm-finetune-preloaded requires dataset.dataset_root=<path> to select the local JSONL source."
             )
+        offline_packing_specs = None
+        dataset_kwargs = None
+        if packed_sequence:
+            offline_packing_specs = PackedSequenceSpecs(
+                packed_sequence_size=resolved_seq_length,
+                pad_seq_to_mult=1,
+            )
+            dataset_kwargs = {"pad_to_max_length": True}
         config.dataset = GPTSFTDatasetConfig(
             seq_length=resolved_seq_length,
             dataset_root=dataset_root,
@@ -236,6 +245,9 @@ def apply_dataset_override(
             ),
             dataloader_type="batch",
             seed=5678,
+            enable_offline_packing=packed_sequence,
+            offline_packing_specs=offline_packing_specs,
+            dataset_kwargs=dataset_kwargs,
         )
 
     elif dataset_type == "vlm-energon":

--- a/tests/unit_tests/recipes/utils/test_dataset_utils.py
+++ b/tests/unit_tests/recipes/utils/test_dataset_utils.py
@@ -382,12 +382,51 @@ class TestApplyDatasetOverride:
         assert result.dataset.dataloader_type == "batch"
         assert "dataset.dataset_root=/data/sft" not in overrides
         assert "train.train_iters=10" in overrides
+        # Packing must stay disabled unless explicitly requested.
+        assert result.dataset.enable_offline_packing is False
+        assert result.dataset.offline_packing_specs is None
 
     def test_llm_finetune_preloaded_requires_local_source(self):
         config = _make_mock_config()
 
         with pytest.raises(ValueError, match="requires dataset.dataset_root"):
             apply_dataset_override(config, "llm-finetune-preloaded", seq_length=2048)
+
+    def test_llm_finetune_preloaded_honors_packed_sequence(self):
+        from megatron.bridge.data.builders import GPTSFTDatasetConfig
+
+        config = _make_mock_config()
+        overrides = ["dataset.dataset_root=/data/sft"]
+        result = apply_dataset_override(
+            config,
+            "llm-finetune-preloaded",
+            packed_sequence=True,
+            seq_length=16384,
+            cli_overrides=overrides,
+        )
+        assert isinstance(result.dataset, GPTSFTDatasetConfig)
+        assert result.dataset.enable_offline_packing is True
+        assert result.dataset.offline_packing_specs is not None
+        assert result.dataset.offline_packing_specs.packed_sequence_size == 16384
+        assert result.dataset.offline_packing_specs.pad_seq_to_mult == 1
+        assert result.dataset.dataset_kwargs == {"pad_to_max_length": True}
+
+    def test_llm_finetune_preloaded_packed_false_leaves_packing_disabled(self):
+        from megatron.bridge.data.builders import GPTSFTDatasetConfig
+
+        config = _make_mock_config()
+        overrides = ["dataset.dataset_root=/data/sft"]
+        result = apply_dataset_override(
+            config,
+            "llm-finetune-preloaded",
+            packed_sequence=False,
+            seq_length=2048,
+            cli_overrides=overrides,
+        )
+        assert isinstance(result.dataset, GPTSFTDatasetConfig)
+        assert result.dataset.enable_offline_packing is False
+        assert result.dataset.offline_packing_specs is None
+        assert result.dataset.dataset_kwargs is None
 
     # -- VLM energon ----------------------------------------------------------
 


### PR DESCRIPTION
## What & why

`apply_dataset_override` accepts a `packed_sequence` flag, but the
`llm-finetune-preloaded` branch built `GPTSFTDatasetConfig` without forwarding it.
So `--packed_sequence` was silently dropped on the preloaded path — runs trained
unpacked at meaningfully lower real-token throughput, with no error or warning.
The `llm-finetune` preset branch already wired packing correctly; this closes the
gap for the preloaded branch.

Closes #4830.

## Change

When `packed_sequence` is requested for `llm-finetune-preloaded`, forward it into
`GPTSFTDatasetConfig`, mirroring the `llm-finetune` preset:

- `enable_offline_packing=packed_sequence`
- `offline_packing_specs=PackedSequenceSpecs(packed_sequence_size=<resolved seq_length>, pad_seq_to_mult=1)`
- `dataset_kwargs={"pad_to_max_length": True}`

With `packed_sequence` unset, behavior is unchanged (packing stays disabled).
No public API change.

## Testing

Added unit tests in `tests/unit_tests/recipes/utils/test_dataset_utils.py`:

- `test_llm_finetune_preloaded_honors_packed_sequence` — packing enabled, specs
  sized to the resolved `seq_length`, `pad_to_max_length` set.
- `test_llm_finetune_preloaded_packed_false_leaves_packing_disabled` — flag-off
  path leaves packing disabled.
- Hardened the existing preloaded test to assert packing defaults off.

Verified in a NeMo 25.09 GPU container: the four preloaded/packed cases pass.

cc @yaoyu-33 