### PR TITLE
Migrate Qwen3-Next and Qwen3.5 models to HybridModel

### DIFF
--- a/src/megatron/bridge/models/hybrid/hybrid_provider.py
+++ b/src/megatron/bridge/models/hybrid/hybrid_provider.py
@@ -179,9 +179,13 @@ class HybridModelProvider(TransformerConfig, ModelProviderMixin[MCoreHybridModel
             self.hybrid_override_pattern = None
             used_hybrid_override_pattern = True
 
-        # Combine hybrid_layer_pattern (main decoder) with mtp_hybrid_override_pattern
-        # into a single unified pattern that MCore HybridModel can parse.
-        if self.hybrid_layer_pattern is not None and self.mtp_hybrid_override_pattern:
+        # Combine the main and MTP patterns only when MTP is enabled. Providers may
+        # predeclare an MTP override before a recipe sets mtp_num_layers.
+        if (
+            self.hybrid_layer_pattern is not None
+            and self.mtp_hybrid_override_pattern
+            and (self.mtp_num_layers or self.mtp_use_repeated_layer)
+        ):
             sep = Symbols.MTP_SEPARATOR
             main_pattern = self.hybrid_layer_pattern.split(sep)[0]
             # When mtp_use_repeated_layer=True, the shared MTP layer always exists

--- a/src/megatron/bridge/models/qwen/qwen35_bridge.py
+++ b/src/megatron/bridge/models/qwen/qwen35_bridge.py
@@ -13,15 +13,13 @@
 # limitations under the License.
 
 import torch
-from megatron.core.models.gpt.experimental_attention_variant_module_specs import (
-    get_transformer_block_with_experimental_attention_variant_spec,
-)
-from megatron.core.models.gpt.gpt_model import GPTModel
+from megatron.core.models.hybrid.hybrid_layer_allocation import Symbols
+from megatron.core.models.hybrid.hybrid_model import HybridModel
 from transformers import Qwen3_5ForCausalLM, Qwen3_5MoeForCausalLM
 
 from megatron.bridge.models.conversion.mapping_registry import MegatronMappingRegistry
 from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge
-from megatron.bridge.models.conversion.param_mapping import (  # noqa: F401
+from megatron.bridge.models.conversion.param_mapping import (
     AutoMapping,
     FusedExpertMapping,
     FusedGatedExpertMapping,
@@ -34,21 +32,18 @@ from megatron.bridge.models.conversion.param_mapping import (  # noqa: F401
 )
 from megatron.bridge.models.conversion.transformers_compat import full_attention_interval_from_hf
 from megatron.bridge.models.conversion.utils import moe_experts_stored_packed
-from megatron.bridge.models.gpt_provider import GPTModelProvider
+from megatron.bridge.models.hybrid.hybrid_provider import HybridModelProvider
+from megatron.bridge.models.qwen.qwen_hybrid import (
+    QwenHybridModelProvider,
+    configure_qwen_hybrid_layers,
+    qwen_attention_symbols,
+    qwen_logical_layer_count,
+    qwen_physical_layer_indices,
+)
 
 
-def _apply_qwen35_common_config(provider: GPTModelProvider, text_config) -> None:
-    """Apply Qwen3.5 common LM configuration to a Megatron provider.
-
-    Covers settings shared by both dense and MoE variants:
-    normalization, GDN hybrid architecture, and MTP.
-
-    Args:
-        provider: GPTModelProvider (or subclass) to configure.
-        text_config: HuggingFace config object (or text_config for VLMs)
-            so that language-model fields are read from the correct level.
-    """
-    # --- Common Qwen3 LLM settings ---
+def _apply_qwen35_common_config(provider: HybridModelProvider, text_config) -> None:
+    """Apply configuration shared by dense and MoE Qwen3.5 language models."""
     provider.normalization = "RMSNorm"
     provider.gated_linear_unit = True
     provider.add_qkv_bias = getattr(text_config, "attention_bias", False)
@@ -56,40 +51,24 @@ def _apply_qwen35_common_config(provider: GPTModelProvider, text_config) -> None
     provider.qk_layernorm = True
     provider.hidden_dropout = 0.0
 
-    # --- Qwen3-Next hybrid architecture settings ---
     provider.layernorm_zero_centered_gamma = True
     provider.attention_output_gate = True
     provider.experimental_attention_variant = "gated_delta_net"
-    # full_attention_interval defines how often standard attention appears:
-    # e.g., 4 means every 4th layer is standard attention (3 GDN + 1 Attn)
     provider.linear_attention_freq = full_attention_interval_from_hf(text_config)
     provider.linear_num_value_heads = getattr(text_config, "linear_num_value_heads", 32)
     provider.rotary_percent = getattr(text_config, "rope_parameters", {}).get("partial_rotary_factor", 0.25)
-
-    # --- GDN (Gated DeltaNet) specific parameters ---
     provider.linear_conv_kernel_dim = getattr(text_config, "linear_conv_kernel_dim", 4)
     provider.linear_key_head_dim = getattr(text_config, "linear_key_head_dim", 128)
     provider.linear_value_head_dim = getattr(text_config, "linear_value_head_dim", 128)
     provider.linear_num_key_heads = getattr(text_config, "linear_num_key_heads", 16)
 
-    # --- MTP (Multi-Token Prediction) ---
     if provider.mtp_num_layers:
         provider.mtp_loss_scaling_factor = 0.1
 
 
-def _apply_qwen35_moe_config(provider: GPTModelProvider, text_config) -> None:
-    """Apply Qwen3.5 MoE-specific configuration to a Megatron provider.
-
-    Calls _apply_qwen35_common_config first, then adds MoE parameters.
-
-    Args:
-        provider: GPTModelProvider (or subclass) to configure.
-        text_config: HuggingFace config object (or text_config for VLMs)
-            so that language-model fields are read from the correct level.
-    """
+def _apply_qwen35_moe_config(provider: HybridModelProvider, text_config) -> None:
+    """Apply Qwen3.5 MoE configuration in addition to the common settings."""
     _apply_qwen35_common_config(provider, text_config)
-
-    # --- MoE specific parameters ---
     provider.moe_ffn_hidden_size = getattr(text_config, "moe_intermediate_size", 1024)
     provider.num_moe_experts = getattr(text_config, "num_experts", 512)
     provider.moe_router_topk = getattr(text_config, "num_experts_per_tok", 10)
@@ -102,558 +81,409 @@ def _apply_qwen35_moe_config(provider: GPTModelProvider, text_config) -> None:
     provider.moe_permute_fusion = True
 
 
-def _moe_routed_expert_mappings(hf_prefix, megatron_prefix, experts_packed, transpose_on_export=False):
-    """Routed-expert mappings for a MoE decoder, for both the grouped-GEMM and SequentialMLP layouts.
-
-    ``experts_packed`` selects fused HF tensors (``experts.gate_up_proj`` / ``experts.down_proj``)
-    vs per-expert (``experts.<i>.gate_proj`` / ``up_proj`` / ``down_proj``), matching the checkpoint so
-    HF->Megatron->HF round-trips. ``transpose_on_export`` applies to the fused mappings (e.g. Qwen3-VL).
-    """
-    grouped_fc1 = f"{megatron_prefix}decoder.layers.*.mlp.experts.linear_fc1.weight*"
-    grouped_fc2 = f"{megatron_prefix}decoder.layers.*.mlp.experts.linear_fc2.weight*"
-    seq_fc1 = f"{megatron_prefix}decoder.layers.*.mlp.experts.local_experts.*.linear_fc1.weight"
-    seq_fc2 = f"{megatron_prefix}decoder.layers.*.mlp.experts.local_experts.*.linear_fc2.weight"
-    if experts_packed:
-        gate_up = f"{hf_prefix}layers.*.mlp.experts.gate_up_proj"
-        down = f"{hf_prefix}layers.*.mlp.experts.down_proj"
-        return [
-            FusedGatedExpertMapping(
-                megatron_param=grouped_fc1, hf_param=gate_up, transpose_on_export=transpose_on_export
-            ),
-            FusedExpertMapping(megatron_param=grouped_fc2, hf_param=down, transpose_on_export=transpose_on_export),
-            FusedGatedExpertMapping(megatron_param=seq_fc1, hf_param=gate_up, transpose_on_export=transpose_on_export),
-            FusedExpertMapping(megatron_param=seq_fc2, hf_param=down, transpose_on_export=transpose_on_export),
-        ]
-    gate = f"{hf_prefix}layers.*.mlp.experts.*.gate_proj.weight"
-    up = f"{hf_prefix}layers.*.mlp.experts.*.up_proj.weight"
-    down = f"{hf_prefix}layers.*.mlp.experts.*.down_proj.weight"
+def _base_lm_mappings(hf_prefix: str, megatron_prefix: str) -> list:
     return [
-        GatedMLPMapping(megatron_param=grouped_fc1, gate=gate, up=up),
-        AutoMapping(megatron_param=grouped_fc2, hf_param=down),
-        GatedMLPMapping(megatron_param=seq_fc1, gate=gate, up=up),
-        AutoMapping(megatron_param=seq_fc2, hf_param=down),
+        AutoMapping(f"{megatron_prefix}embedding.word_embeddings.weight", f"{hf_prefix}embed_tokens.weight"),
+        AutoMapping(f"{megatron_prefix}output_layer.weight", "lm_head.weight"),
+        AutoMapping(f"{megatron_prefix}decoder.final_norm.weight", f"{hf_prefix}norm.weight"),
     ]
 
 
-@MegatronModelBridge.register_bridge(source=Qwen3_5MoeForCausalLM, target=GPTModel, model_type="qwen3_5_moe_text")
-class Qwen35MoEBridge(MegatronModelBridge):
-    """
-    Megatron Bridge for Qwen3.5 Language Model (MoE variant).
+def _qwen35_attention_mappings(
+    logical_layer_idx: int,
+    attention_layer_idx: int,
+    attention_symbol: str,
+    *,
+    hf_prefix: str,
+    megatron_prefix: str,
+) -> list:
+    hf_layer = f"{hf_prefix}layers.{logical_layer_idx}"
+    attention_layer = f"{megatron_prefix}decoder.layers.{attention_layer_idx}.self_attention"
+    if attention_symbol == Symbols.ATTENTION:
+        return [
+            AutoMapping(f"{attention_layer}.linear_qkv.layer_norm_weight", f"{hf_layer}.input_layernorm.weight"),
+            AutoMapping(f"{attention_layer}.q_layernorm.weight", f"{hf_layer}.self_attn.q_norm.weight"),
+            AutoMapping(f"{attention_layer}.k_layernorm.weight", f"{hf_layer}.self_attn.k_norm.weight"),
+            AutoMapping(f"{attention_layer}.linear_proj.weight", f"{hf_layer}.self_attn.o_proj.weight"),
+            QKVMapping(
+                megatron_param=f"{attention_layer}.linear_qkv.weight",
+                q=f"{hf_layer}.self_attn.q_proj.weight",
+                k=f"{hf_layer}.self_attn.k_proj.weight",
+                v=f"{hf_layer}.self_attn.v_proj.weight",
+            ),
+        ]
 
-    This bridge handles the conversion between HuggingFace Qwen3.5 language
-    model and Megatron-Core Qwen3.5 Model formats, including weight mappings and
-    configuration translation for the hybrid GDN+Attention LM architecture.
+    return [
+        AutoMapping(f"{attention_layer}.in_proj.layer_norm_weight", f"{hf_layer}.input_layernorm.weight"),
+        AutoMapping(f"{attention_layer}.out_proj.weight", f"{hf_layer}.linear_attn.out_proj.weight"),
+        AutoMapping(f"{attention_layer}.A_log", f"{hf_layer}.linear_attn.A_log"),
+        AutoMapping(f"{attention_layer}.dt_bias", f"{hf_layer}.linear_attn.dt_bias"),
+        GDNConv1dMapping(
+            megatron_param=f"{attention_layer}.conv1d.weight",
+            hf_param=f"{hf_layer}.linear_attn.conv1d.weight",
+        ),
+        GDNLinearMappingSeparate(
+            megatron_param=f"{attention_layer}.in_proj.weight",
+            qkv=f"{hf_layer}.linear_attn.in_proj_qkv.weight",
+            z=f"{hf_layer}.linear_attn.in_proj_z.weight",
+            b=f"{hf_layer}.linear_attn.in_proj_b.weight",
+            a=f"{hf_layer}.linear_attn.in_proj_a.weight",
+        ),
+        RMSNorm2ZeroCenteredRMSNormMapping(
+            f"{attention_layer}.out_norm.weight",
+            f"{hf_layer}.linear_attn.norm.weight",
+        ),
+    ]
 
-    The weight mappings handle:
-    - Language model hybrid layers (GDN + standard attention)
-    - MoE layers with routed and shared experts
-    - QK layernorm, zero-centered RMSNorm for GDN output norm
 
-    Architecture: 15 × (3 × (GDN → MoE) + 1 × (Attention → MoE)) = 60 layers
+def _dense_layer_mappings(
+    logical_layer_idx: int,
+    mlp_layer_idx: int,
+    *,
+    hf_prefix: str,
+    megatron_prefix: str,
+) -> list:
+    hf_layer = f"{hf_prefix}layers.{logical_layer_idx}"
+    mlp_layer = f"{megatron_prefix}decoder.layers.{mlp_layer_idx}.mlp"
+    return [
+        AutoMapping(f"{mlp_layer}.linear_fc1.layer_norm_weight", f"{hf_layer}.post_attention_layernorm.weight"),
+        AutoMapping(f"{mlp_layer}.linear_fc2.weight", f"{hf_layer}.mlp.down_proj.weight"),
+        GatedMLPMapping(
+            megatron_param=f"{mlp_layer}.linear_fc1.weight",
+            gate=f"{hf_layer}.mlp.gate_proj.weight",
+            up=f"{hf_layer}.mlp.up_proj.weight",
+        ),
+    ]
 
-    The VL variant (Qwen35VLMoEBridge) reuses the provider settings and LM
-    mapping logic via the module-level helpers and static mapping methods.
 
-    Example:
-        >>> from transformers import AutoModelForCausalLM, AutoTokenizer
-        >>> model = AutoModelForCausalLM.from_pretrained("Qwen/Qwen3.5-397B-A17B")
-        >>> model.save_pretrained("./Qwen3.5-397B-A17B-LM")
-        >>> tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3.5-397B-A17B")
-        >>> tokenizer.save_pretrained("./Qwen3.5-397B-A17B")
-        >>> from megatron.bridge import AutoBridge
-        >>> bridge = AutoBridge.from_hf_pretrained("./Qwen3.5-397B-A17B")
-        >>> provider = bridge.to_megatron_provider()
-    """
+def _moe_layer_mappings(
+    logical_layer_idx: int,
+    moe_layer_idx: int,
+    *,
+    hf_prefix: str,
+    megatron_prefix: str,
+    experts_packed: bool,
+) -> list:
+    hf_layer = f"{hf_prefix}layers.{logical_layer_idx}"
+    moe_layer = f"{megatron_prefix}decoder.layers.{moe_layer_idx}"
+    return [
+        AutoMapping(f"{moe_layer}.mlp.router.weight", f"{hf_layer}.mlp.gate.weight"),
+        AutoMapping(f"{moe_layer}.pre_mlp_layernorm.weight", f"{hf_layer}.post_attention_layernorm.weight"),
+        *_moe_routed_expert_mappings(hf_layer, moe_layer, experts_packed),
+        GatedMLPMapping(
+            megatron_param=f"{moe_layer}.mlp.shared_experts.linear_fc1.weight",
+            gate=f"{hf_layer}.mlp.shared_expert.gate_proj.weight",
+            up=f"{hf_layer}.mlp.shared_expert.up_proj.weight",
+        ),
+        AutoMapping(
+            f"{moe_layer}.mlp.shared_experts.linear_fc2.weight",
+            f"{hf_layer}.mlp.shared_expert.down_proj.weight",
+        ),
+        ReplicatedMapping(
+            f"{moe_layer}.mlp.shared_experts.gate_weight",
+            f"{hf_layer}.mlp.shared_expert_gate.weight",
+        ),
+    ]
+
+
+def _moe_routed_expert_mappings(
+    hf_layer: str,
+    moe_layer: str,
+    experts_packed: bool,
+    *,
+    transpose_on_export: bool = False,
+) -> list:
+    """Map grouped and sequential routed experts to the checkpoint's storage layout."""
+    grouped_fc1 = f"{moe_layer}.mlp.experts.linear_fc1.weight*"
+    grouped_fc2 = f"{moe_layer}.mlp.experts.linear_fc2.weight*"
+    sequential_fc1 = f"{moe_layer}.mlp.experts.local_experts.*.linear_fc1.weight"
+    sequential_fc2 = f"{moe_layer}.mlp.experts.local_experts.*.linear_fc2.weight"
+    if experts_packed:
+        gate_up = f"{hf_layer}.mlp.experts.gate_up_proj"
+        down = f"{hf_layer}.mlp.experts.down_proj"
+        return [
+            FusedGatedExpertMapping(
+                megatron_param=grouped_fc1,
+                hf_param=gate_up,
+                transpose_on_export=transpose_on_export,
+            ),
+            FusedExpertMapping(
+                megatron_param=grouped_fc2,
+                hf_param=down,
+                transpose_on_export=transpose_on_export,
+            ),
+            FusedGatedExpertMapping(
+                megatron_param=sequential_fc1,
+                hf_param=gate_up,
+                transpose_on_export=transpose_on_export,
+            ),
+            FusedExpertMapping(
+                megatron_param=sequential_fc2,
+                hf_param=down,
+                transpose_on_export=transpose_on_export,
+            ),
+        ]
+
+    gate = f"{hf_layer}.mlp.experts.*.gate_proj.weight"
+    up = f"{hf_layer}.mlp.experts.*.up_proj.weight"
+    down = f"{hf_layer}.mlp.experts.*.down_proj.weight"
+    return [
+        GatedMLPMapping(megatron_param=grouped_fc1, gate=gate, up=up),
+        AutoMapping(megatron_param=grouped_fc2, hf_param=down),
+        GatedMLPMapping(megatron_param=sequential_fc1, gate=gate, up=up),
+        AutoMapping(megatron_param=sequential_fc2, hf_param=down),
+    ]
+
+
+def _mtp_common_mappings(megatron_prefix: str) -> list:
+    attention_layer = f"{megatron_prefix}mtp.layers.0.mtp_model_layer.layers.0.self_attention"
+    return [
+        AutoMapping(f"{megatron_prefix}mtp.layers.0.eh_proj.weight", "mtp.fc.weight"),
+        AutoMapping(f"{megatron_prefix}mtp.layers.0.enorm.weight", "mtp.pre_fc_norm_embedding.weight"),
+        AutoMapping(f"{megatron_prefix}mtp.layers.0.hnorm.weight", "mtp.pre_fc_norm_hidden.weight"),
+        AutoMapping(f"{megatron_prefix}mtp.layers.0.final_layernorm.weight", "mtp.norm.weight"),
+        AutoMapping(f"{attention_layer}.linear_qkv.layer_norm_weight", "mtp.layers.0.input_layernorm.weight"),
+        AutoMapping(f"{attention_layer}.q_layernorm.weight", "mtp.layers.0.self_attn.q_norm.weight"),
+        AutoMapping(f"{attention_layer}.k_layernorm.weight", "mtp.layers.0.self_attn.k_norm.weight"),
+        AutoMapping(f"{attention_layer}.linear_proj.weight", "mtp.layers.0.self_attn.o_proj.weight"),
+        QKVMapping(
+            megatron_param=f"{megatron_prefix}mtp.layers.*.mtp_model_layer.layers.0.self_attention.linear_qkv.weight",
+            q="mtp.layers.*.self_attn.q_proj.weight",
+            k="mtp.layers.*.self_attn.k_proj.weight",
+            v="mtp.layers.*.self_attn.v_proj.weight",
+        ),
+    ]
+
+
+class _Qwen35HybridBridgeMixin:
+    @classmethod
+    def megatron_to_hf_config(cls, provider) -> dict:
+        hf_config = super().megatron_to_hf_config(provider)
+        logical_layer_count = qwen_logical_layer_count(provider.hybrid_layer_pattern)
+        if logical_layer_count is not None:
+            hf_config["num_hidden_layers"] = logical_layer_count
+        return hf_config
+
+
+@MegatronModelBridge.register_bridge(
+    source=Qwen3_5MoeForCausalLM,
+    target=HybridModel,
+    provider=QwenHybridModelProvider,
+    model_type="qwen3_5_moe_text",
+)
+class Qwen35MoEBridge(_Qwen35HybridBridgeMixin, MegatronModelBridge):
+    """Megatron Bridge for the MoE Qwen3.5 and Qwen3.6 language models."""
 
     @staticmethod
-    def _get_moe_lm_mappings(hf_prefix="model.", megatron_prefix="", experts_packed=False):
-        """Get language model parameter mappings for MoE Qwen3.5.
-
-        Args:
-            hf_prefix: Prefix for HF param names in safetensors. Use "model.layers.*"
-                for LM and "model.language_model.layers.*" for VL models.
-            megatron_prefix: Prefix for Megatron param names. Use "" for LM
-                (default) and "language_model." for VL models.
-            experts_packed: Whether the routed experts are stored fused (``experts.gate_up_proj`` /
-                ``down_proj``) rather than per-expert (``experts.<i>.gate_proj`` / ``up_proj`` /
-                ``down_proj``). Selected from the checkpoint layout by ``mapping_registry``.
-
-        Returns:
-            List of mapping objects for the MoE LM portion.
-        """
-
-        # =====================================================================
-        # Simple 1:1 parameter mappings
-        # =====================================================================
-        param_mappings = {
-            # =================================================================
-            # Language Model: Embeddings and output
-            # =================================================================
-            f"{megatron_prefix}embedding.word_embeddings.weight": f"{hf_prefix}embed_tokens.weight",
-            f"{megatron_prefix}output_layer.weight": "lm_head.weight",
-            f"{megatron_prefix}decoder.final_layernorm.weight": f"{hf_prefix}norm.weight",
-            # =================================================================
-            # Language Model: MoE router
-            # =================================================================
-            f"{megatron_prefix}decoder.layers.*.mlp.router.weight": f"{hf_prefix}layers.*.mlp.gate.weight",
-            f"{megatron_prefix}decoder.layers.*.pre_mlp_layernorm.weight": f"{hf_prefix}layers.*.post_attention_layernorm.weight",
-            # =================================================================
-            # Language Model: Standard attention layers (Gated Attention)
-            # These mappings apply to layers where standard attention is used
-            # (every 4th layer in the 15 × (3 GDN + 1 Attn) pattern)
-            # =================================================================
-            f"{megatron_prefix}decoder.layers.*.self_attention.linear_qkv.layer_norm_weight": f"{hf_prefix}layers.*.input_layernorm.weight",
-            f"{megatron_prefix}decoder.layers.*.self_attention.q_layernorm.weight": f"{hf_prefix}layers.*.self_attn.q_norm.weight",
-            f"{megatron_prefix}decoder.layers.*.self_attention.k_layernorm.weight": f"{hf_prefix}layers.*.self_attn.k_norm.weight",
-            f"{megatron_prefix}decoder.layers.*.self_attention.linear_proj.weight": f"{hf_prefix}layers.*.self_attn.o_proj.weight",
-            # =================================================================
-            # Language Model: Linear attention (Gated DeltaNet) layers
-            # These mappings apply to layers where GDN is used
-            # (3 out of every 4 layers)
-            # =================================================================
-            f"{megatron_prefix}decoder.layers.*.self_attention.in_proj.layer_norm_weight": f"{hf_prefix}layers.*.input_layernorm.weight",
-            f"{megatron_prefix}decoder.layers.*.self_attention.out_proj.weight": f"{hf_prefix}layers.*.linear_attn.out_proj.weight",
-            f"{megatron_prefix}decoder.layers.*.self_attention.A_log": f"{hf_prefix}layers.*.linear_attn.A_log",
-            f"{megatron_prefix}decoder.layers.*.self_attention.dt_bias": f"{hf_prefix}layers.*.linear_attn.dt_bias",
-        }
-
-        mapping_list = []
-
-        # Convert simple 1:1 mappings to AutoMapping objects
-        for megatron_param, hf_param in param_mappings.items():
-            mapping_list.append(AutoMapping(megatron_param=megatron_param, hf_param=hf_param))
-
-        # Register module types for GDN and shared expert (needed for AutoMapping detection)
+    def _get_moe_lm_mappings(
+        num_layers: int = 1,
+        linear_attention_freq: int | list[int] = 1,
+        hf_prefix: str = "model.",
+        megatron_prefix: str = "",
+        experts_packed: bool = False,
+    ) -> list:
+        mappings = _base_lm_mappings(hf_prefix, megatron_prefix)
+        attention_symbols = qwen_attention_symbols(num_layers, linear_attention_freq)
+        for logical_layer_idx, attention_symbol in enumerate(attention_symbols):
+            attention_layer_idx, moe_layer_idx = qwen_physical_layer_indices(logical_layer_idx)
+            mappings.extend(
+                _qwen35_attention_mappings(
+                    logical_layer_idx,
+                    attention_layer_idx,
+                    attention_symbol,
+                    hf_prefix=hf_prefix,
+                    megatron_prefix=megatron_prefix,
+                )
+            )
+            mappings.extend(
+                _moe_layer_mappings(
+                    logical_layer_idx,
+                    moe_layer_idx,
+                    hf_prefix=hf_prefix,
+                    megatron_prefix=megatron_prefix,
+                    experts_packed=experts_packed,
+                )
+            )
         AutoMapping.register_module_type("SharedExpertMLP", "column")
         AutoMapping.register_module_type("GatedDeltaNet", "column")
-
-        # =====================================================================
-        # Special mappings requiring parameter transformation
-        # =====================================================================
-        mapping_list.extend(
-            [
-                # =============================================================
-                # Language Model: Standard Attention QKV
-                # Combines separate Q, K, V matrices into single QKV matrix
-                # =============================================================
-                QKVMapping(
-                    megatron_param=f"{megatron_prefix}decoder.layers.*.self_attention.linear_qkv.weight",
-                    q=f"{hf_prefix}layers.*.self_attn.q_proj.weight",
-                    k=f"{hf_prefix}layers.*.self_attn.k_proj.weight",
-                    v=f"{hf_prefix}layers.*.self_attn.v_proj.weight",
-                ),
-                # =============================================================
-                # Language Model: GDN (Gated DeltaNet) specific mappings
-                # =============================================================
-                # GDN Conv1d: depthwise causal convolution
-                GDNConv1dMapping(
-                    megatron_param=f"{megatron_prefix}decoder.layers.*.self_attention.conv1d.weight",
-                    hf_param=f"{hf_prefix}layers.*.linear_attn.conv1d.weight",
-                ),
-                # GDN Input Projection: Qwen3.5 stores 4 separate weight tensors
-                # (in_proj_qkv, in_proj_z, in_proj_b, in_proj_a) instead of the
-                # 2 fused tensors (in_proj_qkvz, in_proj_ba) used by Qwen3-Next.
-                GDNLinearMappingSeparate(
-                    megatron_param=f"{megatron_prefix}decoder.layers.*.self_attention.in_proj.weight",
-                    qkv=f"{hf_prefix}layers.*.linear_attn.in_proj_qkv.weight",
-                    z=f"{hf_prefix}layers.*.linear_attn.in_proj_z.weight",
-                    b=f"{hf_prefix}layers.*.linear_attn.in_proj_b.weight",
-                    a=f"{hf_prefix}layers.*.linear_attn.in_proj_a.weight",
-                ),
-                # GDN Output Norm: zero-centered RMSNorm conversion
-                # Qwen3-Next uses standard RMSNorm initialized to ones for output norm,
-                # while Megatron uses zero-centered RMSNorm, so we subtract 1 during conversion.
-                RMSNorm2ZeroCenteredRMSNormMapping(
-                    f"{megatron_prefix}decoder.layers.*.self_attention.out_norm.weight",
-                    f"{hf_prefix}layers.*.linear_attn.norm.weight",
-                ),
-                # =============================================================
-                # Language Model: MoE routed-expert MLPs. Covers both the grouped-GEMM
-                # (experts.linear_fc*.weight*) and SequentialMLP (experts.local_experts.*.linear_fc*)
-                # Megatron layouts, selecting fused vs per-expert HF mappings from the checkpoint.
-                # =============================================================
-                *_moe_routed_expert_mappings(hf_prefix, megatron_prefix, experts_packed),
-                # =============================================================
-                # Language Model: Shared Expert MLPs
-                # =============================================================
-                GatedMLPMapping(
-                    megatron_param=f"{megatron_prefix}decoder.layers.*.mlp.shared_experts.linear_fc1.weight",
-                    gate=f"{hf_prefix}layers.*.mlp.shared_expert.gate_proj.weight",
-                    up=f"{hf_prefix}layers.*.mlp.shared_expert.up_proj.weight",
-                ),
-                AutoMapping(
-                    megatron_param=f"{megatron_prefix}decoder.layers.*.mlp.shared_experts.linear_fc2.weight",
-                    hf_param=f"{hf_prefix}layers.*.mlp.shared_expert.down_proj.weight",
-                ),
-                # Shared expert gate weight (replicated across TP ranks)
-                ReplicatedMapping(
-                    megatron_param=f"{megatron_prefix}decoder.layers.*.mlp.shared_experts.gate_weight",
-                    hf_param=f"{hf_prefix}layers.*.mlp.shared_expert_gate.weight",
-                ),
-            ]
-        )
-
-        return mapping_list
+        return mappings
 
     @staticmethod
-    def _get_moe_mtp_mappings(megatron_prefix: str = "", mtp_experts_packed: bool = False):
-        """Get MTP parameter mappings for MoE Qwen3.5.
-
-        Args:
-            megatron_prefix: Prefix for Megatron param names. Use "" for LM and
-                "language_model." for VL models.
-            mtp_experts_packed: Whether the MTP experts are packed.
-                Qwen3.5 stores per-expert
-                (mtp.layers.0.mlp.experts.{i}.gate_proj.weight),
-                whereas Qwen3.6 stores packed
-                (mtp.layers.0.mlp.experts.gate_up_proj).
-
-        Returns:
-            List of mapping objects for the MoE MTP portion.
-        """
-        mapping_list = []
-
-        # =================================================================
-        # MTP (Multi-Token Prediction) mappings
-        # MTP uses standard attention (not GDN) and standard per-expert
-        # MoE format (unlike the fused gate_up_proj in main decoder).
-        # Megatron VL prefix: language_model.mtp.*
-        # Megatron LM prefix: mtp.* (LM)
-        # HF prefix: mtp.* (top-level, not under model.language_model.)
-        # =================================================================
-        mtp_param_mappings = {
-            f"{megatron_prefix}mtp.layers.0.eh_proj.weight": "mtp.fc.weight",
-            f"{megatron_prefix}mtp.layers.0.enorm.weight": "mtp.pre_fc_norm_embedding.weight",
-            f"{megatron_prefix}mtp.layers.0.hnorm.weight": "mtp.pre_fc_norm_hidden.weight",
-            f"{megatron_prefix}mtp.layers.0.final_layernorm.weight": "mtp.norm.weight",
-            f"{megatron_prefix}mtp.layers.0.mtp_model_layer.mlp.router.weight": "mtp.layers.0.mlp.gate.weight",
-            f"{megatron_prefix}mtp.layers.0.mtp_model_layer.pre_mlp_layernorm.weight": "mtp.layers.0.post_attention_layernorm.weight",
-            f"{megatron_prefix}mtp.layers.0.mtp_model_layer.self_attention.linear_qkv.layer_norm_weight": "mtp.layers.0.input_layernorm.weight",
-            f"{megatron_prefix}mtp.layers.0.mtp_model_layer.self_attention.q_layernorm.weight": "mtp.layers.0.self_attn.q_norm.weight",
-            f"{megatron_prefix}mtp.layers.0.mtp_model_layer.self_attention.k_layernorm.weight": "mtp.layers.0.self_attn.k_norm.weight",
-            f"{megatron_prefix}mtp.layers.0.mtp_model_layer.self_attention.linear_proj.weight": "mtp.layers.0.self_attn.o_proj.weight",
-        }
-
-        for megatron_param, hf_param in mtp_param_mappings.items():
-            mapping_list.append(AutoMapping(megatron_param=megatron_param, hf_param=hf_param))
-
-        mapping_list.extend(
+    def _get_moe_mtp_mappings(megatron_prefix: str = "", mtp_experts_packed: bool = False) -> list:
+        mappings = _mtp_common_mappings(megatron_prefix)
+        moe_layer = f"{megatron_prefix}mtp.layers.0.mtp_model_layer.layers.1"
+        mappings.extend(
             [
-                QKVMapping(
-                    megatron_param=f"{megatron_prefix}mtp.layers.*.mtp_model_layer.self_attention.linear_qkv.weight",
-                    q="mtp.layers.*.self_attn.q_proj.weight",
-                    k="mtp.layers.*.self_attn.k_proj.weight",
-                    v="mtp.layers.*.self_attn.v_proj.weight",
+                AutoMapping(f"{moe_layer}.mlp.router.weight", "mtp.layers.0.mlp.gate.weight"),
+                AutoMapping(
+                    f"{moe_layer}.pre_mlp_layernorm.weight",
+                    "mtp.layers.0.post_attention_layernorm.weight",
                 ),
                 GatedMLPMapping(
-                    megatron_param=f"{megatron_prefix}mtp.layers.*.mtp_model_layer.mlp.shared_experts.linear_fc1.weight",
-                    gate="mtp.layers.*.mlp.shared_expert.gate_proj.weight",
-                    up="mtp.layers.*.mlp.shared_expert.up_proj.weight",
+                    megatron_param=f"{moe_layer}.mlp.shared_experts.linear_fc1.weight",
+                    gate="mtp.layers.0.mlp.shared_expert.gate_proj.weight",
+                    up="mtp.layers.0.mlp.shared_expert.up_proj.weight",
                 ),
                 AutoMapping(
-                    megatron_param=f"{megatron_prefix}mtp.layers.*.mtp_model_layer.mlp.shared_experts.linear_fc2.weight",
-                    hf_param="mtp.layers.*.mlp.shared_expert.down_proj.weight",
+                    f"{moe_layer}.mlp.shared_experts.linear_fc2.weight",
+                    "mtp.layers.0.mlp.shared_expert.down_proj.weight",
                 ),
                 ReplicatedMapping(
-                    megatron_param=f"{megatron_prefix}mtp.layers.0.mtp_model_layer.mlp.shared_experts.gate_weight",
-                    hf_param="mtp.layers.0.mlp.shared_expert_gate.weight",
+                    f"{moe_layer}.mlp.shared_experts.gate_weight",
+                    "mtp.layers.0.mlp.shared_expert_gate.weight",
                 ),
             ]
         )
-
         if mtp_experts_packed:
-            # Qwen3.6: packed format (same as main decoder)
-            mapping_list.extend(
+            mappings.extend(
                 [
                     FusedGatedExpertMapping(
-                        megatron_param=f"{megatron_prefix}mtp.layers.*.mtp_model_layer.mlp.experts.linear_fc1.weight*",
-                        hf_param="mtp.layers.*.mlp.experts.gate_up_proj",
+                        megatron_param=f"{moe_layer}.mlp.experts.linear_fc1.weight*",
+                        hf_param="mtp.layers.0.mlp.experts.gate_up_proj",
                     ),
                     FusedExpertMapping(
-                        megatron_param=f"{megatron_prefix}mtp.layers.*.mtp_model_layer.mlp.experts.linear_fc2.weight*",
-                        hf_param="mtp.layers.*.mlp.experts.down_proj",
+                        megatron_param=f"{moe_layer}.mlp.experts.linear_fc2.weight*",
+                        hf_param="mtp.layers.0.mlp.experts.down_proj",
                     ),
                 ]
             )
         else:
-            # Qwen3.5: per-expert format (current behavior)
-            mapping_list.extend(
+            mappings.extend(
                 [
                     GatedMLPMapping(
-                        megatron_param=f"{megatron_prefix}mtp.layers.*.mtp_model_layer.mlp.experts.linear_fc1.weight*",
-                        gate="mtp.layers.*.mlp.experts.*.gate_proj.weight",
-                        up="mtp.layers.*.mlp.experts.*.up_proj.weight",
+                        megatron_param=f"{moe_layer}.mlp.experts.linear_fc1.weight*",
+                        gate="mtp.layers.0.mlp.experts.*.gate_proj.weight",
+                        up="mtp.layers.0.mlp.experts.*.up_proj.weight",
                     ),
                     AutoMapping(
-                        megatron_param=f"{megatron_prefix}mtp.layers.*.mtp_model_layer.mlp.experts.linear_fc2.weight*",
-                        hf_param="mtp.layers.*.mlp.experts.*.down_proj.weight",
+                        f"{moe_layer}.mlp.experts.linear_fc2.weight*",
+                        "mtp.layers.0.mlp.experts.*.down_proj.weight",
                     ),
                 ]
             )
-
-        return mapping_list
+        return mappings
 
     def provider_bridge(self, hf_pretrained):
-        """Convert HuggingFace Qwen3.5 text model config to GPTModelProvider."""
+        """Convert a Hugging Face Qwen3.5 MoE config to HybridModelProvider."""
         provider = super().provider_bridge(hf_pretrained)
         hf_config = hf_pretrained.config
-
-        # --- LM-specific parameters ---
         _apply_qwen35_moe_config(provider, hf_config)
-
-        # --- LM-specific overrides ---
         provider.position_embedding_type = "rope"
         provider.autocast_dtype = torch.bfloat16
         provider.share_embeddings_and_output_weights = getattr(hf_config, "tie_word_embeddings", False)
         provider.bos_token_id = getattr(hf_config, "bos_token_id", 248045)
         provider.eos_token_id = getattr(hf_config, "eos_token_id", 248046)
-        provider.transformer_layer_spec = get_transformer_block_with_experimental_attention_variant_spec
-
-        # Heterogeneous checkpointing for mixed attention layers
         provider.hetereogenous_dist_checkpoint = True
-
+        configure_qwen_hybrid_layers(
+            provider,
+            num_logical_layers=hf_config.num_hidden_layers,
+            mlp_symbols=Symbols.MOE,
+            linear_attention_freq=provider.linear_attention_freq,
+            mtp_mlp_symbol=Symbols.MOE,
+        )
         return provider
 
     def mapping_registry(self) -> MegatronMappingRegistry:
-        """
-        Return MegatronMappingRegistry containing parameter mappings for Qwen3.5 LM.
-
-        Combines:
-        - Standard attention: QKV, output projection, QK layernorm
-        - Linear attention (GDN): in_proj, out_proj, conv1d, A_log, dt_bias, out_norm
-        - MoE: router, routed expert MLPs, shared expert MLPs, shared expert gate
-        - Embeddings, output layer, final layernorm
-
-        Naming Convention:
-        - Megatron language model params are prefixed with "decoder."
-        - HF language model params are prefixed with "model.layers.*"
-
-        Returns:
-            MegatronMappingRegistry with all parameter mappings
-        """
-        # Detect MTP MoE expert weight format: Qwen3.5 stores per-expert
-        # (mtp.layers.0.mlp.experts.{i}.gate_proj.weight), Qwen3.6 stores packed
-        # (mtp.layers.0.mlp.experts.gate_up_proj). Same architecture string,
-        # different storage — must inspect HF keys.
         mtp_experts_packed = False
         hf_pretrained = getattr(self, "hf_pretrained", None)
         if hasattr(hf_pretrained, "state") and hasattr(hf_pretrained.state, "source"):
             hf_keys = set(hf_pretrained.state.source.get_all_keys())
-            if "mtp.layers.0.mlp.experts.gate_up_proj" in hf_keys:
-                mtp_experts_packed = True
+            mtp_experts_packed = "mtp.layers.0.mlp.experts.gate_up_proj" in hf_keys
         experts_packed = moe_experts_stored_packed(hf_pretrained, "model.layers.")
 
-        mapping_list = []
-
-        mapping_list.extend(self._get_moe_lm_mappings(megatron_prefix="", experts_packed=experts_packed))
-        mapping_list.extend(self._get_moe_mtp_mappings(megatron_prefix="", mtp_experts_packed=mtp_experts_packed))
-        return MegatronMappingRegistry(*mapping_list)
-
-
-@MegatronModelBridge.register_bridge(source=Qwen3_5ForCausalLM, target=GPTModel, model_type="qwen3_5_text")
-class Qwen35Bridge(MegatronModelBridge):
-    """
-    Megatron Bridge for Qwen3.5 Dense Language Model.
-
-    This bridge handles the conversion between HuggingFace Qwen3.5 language
-    model and Megatron-Core Qwen3.5 Model formats, including weight mappings and
-    configuration translation for the hybrid GDN+Attention LM architecture.
-
-    The weight mappings handle:
-    - Language model hybrid layers (GDN + standard attention)
-    - Dense MLP with gated SiLU activation (fused pre-MLP layernorm)
-    - QK layernorm, zero-centered RMSNorm for GDN output norm
-
-    Architecture (27B): 16 × (3 × GDN + 1 × Attention) = 64 layers
-
-    This class also serves as the base for Qwen35VLBridge (vision-language
-    variant), which reuses the common provider settings and LM mapping logic
-    via the static helper methods.
-
-    Example:
-        >>> from transformers import AutoModelForCausalLM, AutoTokenizer
-        >>> model = AutoModelForCausalLM.from_pretrained("Qwen/Qwen3.5-27B")
-        >>> model.save_pretrained("./Qwen3.5-27B-LM")
-        >>> tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3.5-27B")
-        >>> tokenizer.save_pretrained("./Qwen3.5-27B-LM")
-        >>> from megatron.bridge import AutoBridge
-        >>> bridge = AutoBridge.from_hf_pretrained("./Qwen3.5-27B-LM")
-        >>> provider = bridge.to_megatron_provider()
-    """
-
-    @staticmethod
-    def _get_dense_lm_mappings(hf_prefix="model.", megatron_prefix=""):
-        """Get language model parameter mappings for dense (non-MoE) Qwen3.5.
-
-        Args:
-            hf_prefix: Prefix for HF param names in safetensors. Use "model.layers.*"
-                for LM and "model.language_model.layers.*" for VL models.
-            megatron_prefix: Prefix for Megatron param names. Use "" for LM
-                (default) and "language_model." for VL models.
-
-        Returns:
-            List of mapping objects for the dense LM portion.
-        """
-        param_mappings = {
-            # =================================================================
-            # Language Model: Embeddings and output
-            # =================================================================
-            f"{megatron_prefix}embedding.word_embeddings.weight": f"{hf_prefix}embed_tokens.weight",
-            f"{megatron_prefix}output_layer.weight": "lm_head.weight",
-            f"{megatron_prefix}decoder.final_layernorm.weight": f"{hf_prefix}norm.weight",
-            # =================================================================
-            # Language Model: Dense MLP (pre-MLP layernorm fused into linear_fc1)
-            # =================================================================
-            f"{megatron_prefix}decoder.layers.*.mlp.linear_fc1.layer_norm_weight": f"{hf_prefix}layers.*.post_attention_layernorm.weight",
-            f"{megatron_prefix}decoder.layers.*.mlp.linear_fc2.weight": f"{hf_prefix}layers.*.mlp.down_proj.weight",
-            # =================================================================
-            # Language Model: Standard attention layers (Gated Attention)
-            # =================================================================
-            f"{megatron_prefix}decoder.layers.*.self_attention.linear_qkv.layer_norm_weight": f"{hf_prefix}layers.*.input_layernorm.weight",
-            f"{megatron_prefix}decoder.layers.*.self_attention.q_layernorm.weight": f"{hf_prefix}layers.*.self_attn.q_norm.weight",
-            f"{megatron_prefix}decoder.layers.*.self_attention.k_layernorm.weight": f"{hf_prefix}layers.*.self_attn.k_norm.weight",
-            f"{megatron_prefix}decoder.layers.*.self_attention.linear_proj.weight": f"{hf_prefix}layers.*.self_attn.o_proj.weight",
-            # =================================================================
-            # Language Model: Linear attention (Gated DeltaNet) layers
-            # =================================================================
-            f"{megatron_prefix}decoder.layers.*.self_attention.in_proj.layer_norm_weight": f"{hf_prefix}layers.*.input_layernorm.weight",
-            f"{megatron_prefix}decoder.layers.*.self_attention.out_proj.weight": f"{hf_prefix}layers.*.linear_attn.out_proj.weight",
-            f"{megatron_prefix}decoder.layers.*.self_attention.A_log": f"{hf_prefix}layers.*.linear_attn.A_log",
-            f"{megatron_prefix}decoder.layers.*.self_attention.dt_bias": f"{hf_prefix}layers.*.linear_attn.dt_bias",
-        }
-
-        mapping_list = []
-        for megatron_param, hf_param in param_mappings.items():
-            mapping_list.append(AutoMapping(megatron_param=megatron_param, hf_param=hf_param))
-
-        AutoMapping.register_module_type("GatedDeltaNet", "column")
-
-        mapping_list.extend(
-            [
-                # =============================================================
-                # Language Model: Standard Attention QKV
-                # =============================================================
-                QKVMapping(
-                    megatron_param=f"{megatron_prefix}decoder.layers.*.self_attention.linear_qkv.weight",
-                    q=f"{hf_prefix}layers.*.self_attn.q_proj.weight",
-                    k=f"{hf_prefix}layers.*.self_attn.k_proj.weight",
-                    v=f"{hf_prefix}layers.*.self_attn.v_proj.weight",
-                ),
-                # =============================================================
-                # Language Model: Dense MLP (gated: gate_proj + up_proj → linear_fc1)
-                # =============================================================
-                GatedMLPMapping(
-                    megatron_param=f"{megatron_prefix}decoder.layers.*.mlp.linear_fc1.weight",
-                    gate=f"{hf_prefix}layers.*.mlp.gate_proj.weight",
-                    up=f"{hf_prefix}layers.*.mlp.up_proj.weight",
-                ),
-                # =============================================================
-                # Language Model: GDN (Gated DeltaNet) specific mappings
-                # =============================================================
-                GDNConv1dMapping(
-                    megatron_param=f"{megatron_prefix}decoder.layers.*.self_attention.conv1d.weight",
-                    hf_param=f"{hf_prefix}layers.*.linear_attn.conv1d.weight",
-                ),
-                GDNLinearMappingSeparate(
-                    megatron_param=f"{megatron_prefix}decoder.layers.*.self_attention.in_proj.weight",
-                    qkv=f"{hf_prefix}layers.*.linear_attn.in_proj_qkv.weight",
-                    z=f"{hf_prefix}layers.*.linear_attn.in_proj_z.weight",
-                    b=f"{hf_prefix}layers.*.linear_attn.in_proj_b.weight",
-                    a=f"{hf_prefix}layers.*.linear_attn.in_proj_a.weight",
-                ),
-                RMSNorm2ZeroCenteredRMSNormMapping(
-                    f"{megatron_prefix}decoder.layers.*.self_attention.out_norm.weight",
-                    f"{hf_prefix}layers.*.linear_attn.norm.weight",
-                ),
-            ]
+        mappings = self._get_moe_lm_mappings(
+            self.hf_config.num_hidden_layers,
+            full_attention_interval_from_hf(self.hf_config),
+            experts_packed=experts_packed,
         )
+        mappings.extend(self._get_moe_mtp_mappings(mtp_experts_packed=mtp_experts_packed))
+        return MegatronMappingRegistry(*mappings)
 
-        return mapping_list
+
+@MegatronModelBridge.register_bridge(
+    source=Qwen3_5ForCausalLM,
+    target=HybridModel,
+    provider=QwenHybridModelProvider,
+    model_type="qwen3_5_text",
+)
+class Qwen35Bridge(_Qwen35HybridBridgeMixin, MegatronModelBridge):
+    """Megatron Bridge for dense Qwen3.5 language models."""
 
     @staticmethod
-    def _get_dense_mtp_mappings(megatron_prefix=""):
-        """Get MTP (Multi-Token Prediction) parameter mappings for dense Qwen3.5.
+    def _get_dense_lm_mappings(
+        num_layers: int,
+        linear_attention_freq: int | list[int],
+        hf_prefix: str = "model.",
+        megatron_prefix: str = "",
+    ) -> list:
+        mappings = _base_lm_mappings(hf_prefix, megatron_prefix)
+        attention_symbols = qwen_attention_symbols(num_layers, linear_attention_freq)
+        for logical_layer_idx, attention_symbol in enumerate(attention_symbols):
+            attention_layer_idx, mlp_layer_idx = qwen_physical_layer_indices(logical_layer_idx)
+            mappings.extend(
+                _qwen35_attention_mappings(
+                    logical_layer_idx,
+                    attention_layer_idx,
+                    attention_symbol,
+                    hf_prefix=hf_prefix,
+                    megatron_prefix=megatron_prefix,
+                )
+            )
+            mappings.extend(
+                _dense_layer_mappings(
+                    logical_layer_idx,
+                    mlp_layer_idx,
+                    hf_prefix=hf_prefix,
+                    megatron_prefix=megatron_prefix,
+                )
+            )
+        AutoMapping.register_module_type("GatedDeltaNet", "column")
+        return mappings
 
-        Args:
-            megatron_prefix: Prefix for Megatron param names. Use "" for LM and
-                "language_model." for VL models.
-
-        Returns:
-            List of mapping objects for the MTP portion.
-        """
-        mapping_list = []
-
-        # =================================================================
-        # MTP (Multi-Token Prediction) mappings
-        # MTP uses standard attention (not GDN) and dense MLP.
-        # Megatron VL prefix: language_model.mtp.*
-        # Megatron ML prefix: mtp.*
-        # HF prefix: mtp.* (top-level, not under model.language_model.)
-        # =================================================================
-        mtp_param_mappings = {
-            f"{megatron_prefix}mtp.layers.0.eh_proj.weight": "mtp.fc.weight",
-            f"{megatron_prefix}mtp.layers.0.enorm.weight": "mtp.pre_fc_norm_embedding.weight",
-            f"{megatron_prefix}mtp.layers.0.hnorm.weight": "mtp.pre_fc_norm_hidden.weight",
-            f"{megatron_prefix}mtp.layers.0.final_layernorm.weight": "mtp.norm.weight",
-            f"{megatron_prefix}mtp.layers.0.mtp_model_layer.mlp.linear_fc1.layer_norm_weight": "mtp.layers.0.post_attention_layernorm.weight",
-            f"{megatron_prefix}mtp.layers.0.mtp_model_layer.mlp.linear_fc2.weight": "mtp.layers.0.mlp.down_proj.weight",
-            f"{megatron_prefix}mtp.layers.0.mtp_model_layer.self_attention.linear_qkv.layer_norm_weight": "mtp.layers.0.input_layernorm.weight",
-            f"{megatron_prefix}mtp.layers.0.mtp_model_layer.self_attention.q_layernorm.weight": "mtp.layers.0.self_attn.q_norm.weight",
-            f"{megatron_prefix}mtp.layers.0.mtp_model_layer.self_attention.k_layernorm.weight": "mtp.layers.0.self_attn.k_norm.weight",
-            f"{megatron_prefix}mtp.layers.0.mtp_model_layer.self_attention.linear_proj.weight": "mtp.layers.0.self_attn.o_proj.weight",
-        }
-        for megatron_param, hf_param in mtp_param_mappings.items():
-            mapping_list.append(AutoMapping(megatron_param=megatron_param, hf_param=hf_param))
-
-        mapping_list.extend(
+    @staticmethod
+    def _get_dense_mtp_mappings(megatron_prefix: str = "") -> list:
+        mappings = _mtp_common_mappings(megatron_prefix)
+        mlp_layer = f"{megatron_prefix}mtp.layers.0.mtp_model_layer.layers.1.mlp"
+        mappings.extend(
             [
-                QKVMapping(
-                    megatron_param=f"{megatron_prefix}mtp.layers.*.mtp_model_layer.self_attention.linear_qkv.weight",
-                    q="mtp.layers.*.self_attn.q_proj.weight",
-                    k="mtp.layers.*.self_attn.k_proj.weight",
-                    v="mtp.layers.*.self_attn.v_proj.weight",
+                AutoMapping(
+                    f"{mlp_layer}.linear_fc1.layer_norm_weight",
+                    "mtp.layers.0.post_attention_layernorm.weight",
                 ),
+                AutoMapping(f"{mlp_layer}.linear_fc2.weight", "mtp.layers.0.mlp.down_proj.weight"),
                 GatedMLPMapping(
-                    megatron_param=f"{megatron_prefix}mtp.layers.0.mtp_model_layer.mlp.linear_fc1.weight",
+                    megatron_param=f"{mlp_layer}.linear_fc1.weight",
                     gate="mtp.layers.0.mlp.gate_proj.weight",
                     up="mtp.layers.0.mlp.up_proj.weight",
                 ),
             ]
         )
-
-        return mapping_list
+        return mappings
 
     def provider_bridge(self, hf_pretrained):
-        """Convert HuggingFace Qwen3.5 text model config to GPTModelProvider."""
+        """Convert a Hugging Face dense Qwen3.5 config to HybridModelProvider."""
         provider = super().provider_bridge(hf_pretrained)
         hf_config = hf_pretrained.config
-
-        # --- LM-specific parameters ---
         _apply_qwen35_common_config(provider, hf_config)
-
-        # --- LM-specific overrides ---
         provider.position_embedding_type = "rope"
         provider.autocast_dtype = torch.bfloat16
         provider.share_embeddings_and_output_weights = getattr(hf_config, "tie_word_embeddings", False)
         provider.bos_token_id = getattr(hf_config, "bos_token_id", 248045)
         provider.eos_token_id = getattr(hf_config, "eos_token_id", 248046)
-        provider.transformer_layer_spec = get_transformer_block_with_experimental_attention_variant_spec
-        # Heterogeneous checkpointing for mixed attention layers
         provider.hetereogenous_dist_checkpoint = True
-
+        configure_qwen_hybrid_layers(
+            provider,
+            num_logical_layers=hf_config.num_hidden_layers,
+            mlp_symbols=Symbols.MLP,
+            linear_attention_freq=provider.linear_attention_freq,
+            mtp_mlp_symbol=Symbols.MLP,
+        )
         return provider
 
     def mapping_registry(self) -> MegatronMappingRegistry:
-        """
-        Return MegatronMappingRegistry for Qwen3.5 dense ML model.
-
-        Key differences from the MoE variant:
-        - Dense MLP: gate_proj + up_proj fused into linear_fc1, down_proj as linear_fc2
-        - Pre-MLP layernorm fused into mlp.linear_fc1 (not a separate pre_mlp_layernorm)
-        - No MoE router, routed expert MLPs, or shared expert mappings
-        """
-        mapping_list = []
-
-        mapping_list.extend(self._get_dense_lm_mappings(megatron_prefix=""))
-        mapping_list.extend(self._get_dense_mtp_mappings(megatron_prefix=""))
-        return MegatronMappingRegistry(*mapping_list)
+        mappings = self._get_dense_lm_mappings(
+            self.hf_config.num_hidden_layers,
+            full_attention_interval_from_hf(self.hf_config),
+        )
+        mappings.extend(self._get_dense_mtp_mappings())
+        return MegatronMappingRegistry(*mappings)

--- a/src/megatron/bridge/models/qwen/qwen3_bridge.py
+++ b/src/megatron/bridge/models/qwen/qwen3_bridge.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 import torch
-from megatron.core.models.gpt.gpt_model import GPTModel
+from megatron.core.models.hybrid.hybrid_layer_allocation import Symbols
+from megatron.core.models.hybrid.hybrid_model import HybridModel
 from transformers import Qwen3ForCausalLM
 
 from megatron.bridge.models.conversion.mapping_registry import MegatronMappingRegistry
@@ -23,15 +24,26 @@ from megatron.bridge.models.conversion.param_mapping import (
     GatedMLPMapping,
     QKVMapping,
 )
+from megatron.bridge.models.qwen.qwen_hybrid import (
+    QwenHybridModelProvider,
+    configure_qwen_hybrid_layers,
+    qwen_logical_layer_count,
+    qwen_physical_layer_indices,
+)
 
 
-@MegatronModelBridge.register_bridge(source=Qwen3ForCausalLM, target=GPTModel, model_type="qwen3")
+@MegatronModelBridge.register_bridge(
+    source=Qwen3ForCausalLM,
+    target=HybridModel,
+    provider=QwenHybridModelProvider,
+    model_type="qwen3",
+)
 class Qwen3Bridge(MegatronModelBridge):
     """
     Megatron Bridge for Qwen3 Causal LM.
 
     This bridge handles the conversion between HuggingFace Qwen3ForCausalLM
-    and Megatron-Core GPTModel formats. Qwen3 differs from Qwen2 by using
+    and Megatron-Core HybridModel formats. Qwen3 differs from Qwen2 by using
     QK layernorm and no QKV bias.
 
     Example:
@@ -40,9 +52,19 @@ class Qwen3Bridge(MegatronModelBridge):
         >>> provider = bridge.to_megatron_provider()
     """
 
+    @classmethod
+    def megatron_to_hf_config(cls, provider) -> dict:
+        """Convert a Hybrid Qwen3 provider to a Hugging Face config dictionary."""
+        hf_config = super().megatron_to_hf_config(provider)
+        logical_layer_count = qwen_logical_layer_count(provider.hybrid_layer_pattern)
+        if logical_layer_count is not None:
+            hf_config["num_hidden_layers"] = logical_layer_count
+        return hf_config
+
     def provider_bridge(self, hf_pretrained):
-        """Convert HuggingFace Qwen3 config to GPTModelProvider."""
+        """Convert a Hugging Face Qwen3 config to HybridModelProvider."""
         provider = super().provider_bridge(hf_pretrained)
+        hf_config = hf_pretrained.config
 
         provider.normalization = "RMSNorm"
         provider.gated_linear_unit = True
@@ -51,6 +73,14 @@ class Qwen3Bridge(MegatronModelBridge):
         provider.hidden_dropout = 0.0
         provider.qk_layernorm = True  # Qwen3 uses QK layernorm
         provider.autocast_dtype = torch.bfloat16
+        provider.share_embeddings_and_output_weights = getattr(hf_config, "tie_word_embeddings", True)
+
+        configure_qwen_hybrid_layers(
+            provider,
+            num_logical_layers=hf_config.num_hidden_layers,
+            mlp_symbols=Symbols.MLP,
+            mtp_mlp_symbol=Symbols.MLP,
+        )
 
         return provider
 
@@ -65,67 +95,85 @@ class Qwen3Bridge(MegatronModelBridge):
         The fused QKV matrix is handled by :class:`QKVMapping` and the gated
         MLP gate+up projection by :class:`GatedMLPMapping`.
         """
-        # Dictionary maps Megatron parameter names -> HF parameter names
-        # Supports wildcard (*) patterns for layer-specific parameters
         param_mappings = {
             # Embedding and output
             "embedding.word_embeddings.weight": "model.embed_tokens.weight",
             "output_layer.weight": "lm_head.weight",
-            "decoder.final_layernorm.weight": "model.norm.weight",
-            # Decoder layer attention norms and projections
-            "decoder.layers.*.self_attention.linear_qkv.layer_norm_weight": "model.layers.*.input_layernorm.weight",
-            "decoder.layers.*.mlp.linear_fc1.layer_norm_weight": "model.layers.*.post_attention_layernorm.weight",
-            "decoder.layers.*.self_attention.q_layernorm.weight": "model.layers.*.self_attn.q_norm.weight",  # Qwen3 specific
-            "decoder.layers.*.self_attention.k_layernorm.weight": "model.layers.*.self_attn.k_norm.weight",  # Qwen3 specific
-            "decoder.layers.*.self_attention.linear_proj.weight": "model.layers.*.self_attn.o_proj.weight",
-            "decoder.layers.*.mlp.linear_fc2.weight": "model.layers.*.mlp.down_proj.weight",
+            "decoder.final_norm.weight": "model.norm.weight",
             # MTP projection and norms (used when mtp_num_layers >= 1)
             "mtp.layers.0.eh_proj.weight": "mtp.fc.weight",
             "mtp.layers.0.enorm.weight": "mtp.pre_fc_norm_embedding.weight",
             "mtp.layers.0.hnorm.weight": "mtp.pre_fc_norm_hidden.weight",
             "mtp.layers.0.final_layernorm.weight": "mtp.norm.weight",
             # MTP transformer layer attention
-            "mtp.layers.0.mtp_model_layer.self_attention.linear_qkv.layer_norm_weight": "mtp.layers.0.input_layernorm.weight",
-            "mtp.layers.0.mtp_model_layer.self_attention.q_layernorm.weight": "mtp.layers.0.self_attn.q_norm.weight",
-            "mtp.layers.0.mtp_model_layer.self_attention.k_layernorm.weight": "mtp.layers.0.self_attn.k_norm.weight",
-            "mtp.layers.0.mtp_model_layer.self_attention.linear_proj.weight": "mtp.layers.0.self_attn.o_proj.weight",
+            "mtp.layers.0.mtp_model_layer.layers.0.self_attention.linear_qkv.layer_norm_weight": "mtp.layers.0.input_layernorm.weight",
+            "mtp.layers.0.mtp_model_layer.layers.0.self_attention.q_layernorm.weight": "mtp.layers.0.self_attn.q_norm.weight",
+            "mtp.layers.0.mtp_model_layer.layers.0.self_attention.k_layernorm.weight": "mtp.layers.0.self_attn.k_norm.weight",
+            "mtp.layers.0.mtp_model_layer.layers.0.self_attention.linear_proj.weight": "mtp.layers.0.self_attn.o_proj.weight",
             # MTP transformer layer MLP
-            "mtp.layers.0.mtp_model_layer.mlp.linear_fc1.layer_norm_weight": "mtp.layers.0.post_attention_layernorm.weight",
-            "mtp.layers.0.mtp_model_layer.mlp.linear_fc2.weight": "mtp.layers.0.mlp.down_proj.weight",
+            "mtp.layers.0.mtp_model_layer.layers.1.mlp.linear_fc1.layer_norm_weight": "mtp.layers.0.post_attention_layernorm.weight",
+            "mtp.layers.0.mtp_model_layer.layers.1.mlp.linear_fc2.weight": "mtp.layers.0.mlp.down_proj.weight",
         }
 
-        mapping_list = []
-        # Convert each dictionary entry to AutoMapping(megatron_param, hf_param)
-        for megatron_param, hf_param in param_mappings.items():
-            mapping_list.append(AutoMapping(megatron_param=megatron_param, hf_param=hf_param))
+        mapping_list = [AutoMapping(megatron_param=k, hf_param=v) for k, v in param_mappings.items()]
 
-        # Add special mappings that require parameter concatenation/transformation
+        for logical_layer_idx in range(self.hf_config.num_hidden_layers):
+            attention_layer_idx, mlp_layer_idx = qwen_physical_layer_indices(logical_layer_idx)
+            hf_layer = f"model.layers.{logical_layer_idx}"
+            attention_layer = f"decoder.layers.{attention_layer_idx}.self_attention"
+            mlp_layer = f"decoder.layers.{mlp_layer_idx}.mlp"
+            mapping_list.extend(
+                [
+                    AutoMapping(
+                        megatron_param=f"{attention_layer}.linear_qkv.layer_norm_weight",
+                        hf_param=f"{hf_layer}.input_layernorm.weight",
+                    ),
+                    AutoMapping(
+                        megatron_param=f"{attention_layer}.q_layernorm.weight",
+                        hf_param=f"{hf_layer}.self_attn.q_norm.weight",
+                    ),
+                    AutoMapping(
+                        megatron_param=f"{attention_layer}.k_layernorm.weight",
+                        hf_param=f"{hf_layer}.self_attn.k_norm.weight",
+                    ),
+                    AutoMapping(
+                        megatron_param=f"{attention_layer}.linear_proj.weight",
+                        hf_param=f"{hf_layer}.self_attn.o_proj.weight",
+                    ),
+                    AutoMapping(
+                        megatron_param=f"{mlp_layer}.linear_fc1.layer_norm_weight",
+                        hf_param=f"{hf_layer}.post_attention_layernorm.weight",
+                    ),
+                    AutoMapping(
+                        megatron_param=f"{mlp_layer}.linear_fc2.weight",
+                        hf_param=f"{hf_layer}.mlp.down_proj.weight",
+                    ),
+                    QKVMapping(
+                        megatron_param=f"{attention_layer}.linear_qkv.weight",
+                        q=f"{hf_layer}.self_attn.q_proj.weight",
+                        k=f"{hf_layer}.self_attn.k_proj.weight",
+                        v=f"{hf_layer}.self_attn.v_proj.weight",
+                    ),
+                    GatedMLPMapping(
+                        megatron_param=f"{mlp_layer}.linear_fc1.weight",
+                        gate=f"{hf_layer}.mlp.gate_proj.weight",
+                        up=f"{hf_layer}.mlp.up_proj.weight",
+                    ),
+                ]
+            )
+
         mapping_list.extend(
             [
-                # QKV: Combine separate Q, K, V matrices into single QKV matrix
-                # Note: Qwen3 does NOT have bias in QKV projections (unlike Qwen2)
-                QKVMapping(
-                    megatron_param="decoder.layers.*.self_attention.linear_qkv.weight",
-                    q="model.layers.*.self_attn.q_proj.weight",
-                    k="model.layers.*.self_attn.k_proj.weight",
-                    v="model.layers.*.self_attn.v_proj.weight",
-                ),
-                # Gated MLP: Combine gate and up projection matrices into single FC1 matrix
-                GatedMLPMapping(
-                    megatron_param="decoder.layers.*.mlp.linear_fc1.weight",
-                    gate="model.layers.*.mlp.gate_proj.weight",
-                    up="model.layers.*.mlp.up_proj.weight",
-                ),
                 # MTP QKV: same split/merge as decoder layers
                 QKVMapping(
-                    megatron_param="mtp.layers.*.mtp_model_layer.self_attention.linear_qkv.weight",
+                    megatron_param="mtp.layers.*.mtp_model_layer.layers.0.self_attention.linear_qkv.weight",
                     q="mtp.layers.*.self_attn.q_proj.weight",
                     k="mtp.layers.*.self_attn.k_proj.weight",
                     v="mtp.layers.*.self_attn.v_proj.weight",
                 ),
                 # MTP Gated MLP
                 GatedMLPMapping(
-                    megatron_param="mtp.layers.0.mtp_model_layer.mlp.linear_fc1.weight",
+                    megatron_param="mtp.layers.0.mtp_model_layer.layers.1.mlp.linear_fc1.weight",
                     gate="mtp.layers.0.mlp.gate_proj.weight",
                     up="mtp.layers.0.mlp.up_proj.weight",
                 ),

--- a/src/megatron/bridge/models/qwen/qwen3_moe_bridge.py
+++ b/src/megatron/bridge/models/qwen/qwen3_moe_bridge.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 import torch
-from megatron.core.models.gpt.gpt_model import GPTModel
+from megatron.core.models.hybrid.hybrid_layer_allocation import Symbols
+from megatron.core.models.hybrid.hybrid_model import HybridModel
 from transformers import Qwen3MoeForCausalLM
 
 from megatron.bridge.models.conversion.mapping_registry import MegatronMappingRegistry
@@ -23,15 +24,26 @@ from megatron.bridge.models.conversion.param_mapping import (
     GatedMLPMapping,
     QKVMapping,
 )
+from megatron.bridge.models.qwen.qwen_hybrid import (
+    QwenHybridModelProvider,
+    configure_qwen_hybrid_layers,
+    qwen_logical_layer_count,
+    qwen_physical_layer_indices,
+)
 
 
-@MegatronModelBridge.register_bridge(source=Qwen3MoeForCausalLM, target=GPTModel, model_type="qwen3_moe")
+@MegatronModelBridge.register_bridge(
+    source=Qwen3MoeForCausalLM,
+    target=HybridModel,
+    provider=QwenHybridModelProvider,
+    model_type="qwen3_moe",
+)
 class Qwen3MoEBridge(MegatronModelBridge):
     """
     Megatron Bridge for Qwen3 MoE Causal LM.
 
     This bridge handles the conversion between HuggingFace Qwen3MoeForCausalLM
-    and Megatron-Core GPTModel formats. Qwen3 MoE models use mixture of experts
+    and Megatron-Core HybridModel formats. Qwen3 MoE models use mixture of experts
     architecture with QK layernorm.
 
     Example:
@@ -44,13 +56,17 @@ class Qwen3MoEBridge(MegatronModelBridge):
     def megatron_to_hf_config(cls, provider) -> dict:
         """Convert Megatron provider config to HuggingFace Qwen3MoeConfig dict."""
         hf_config = super().megatron_to_hf_config(provider)
+        logical_layer_count = qwen_logical_layer_count(provider.hybrid_layer_pattern)
+        if logical_layer_count is not None:
+            hf_config["num_hidden_layers"] = logical_layer_count
         hf_config["decoder_sparse_step"] = 1  # All layers are MoE in Qwen3 MoE
         hf_config["norm_topk_prob"] = False  # Qwen3 MoE does not normalize top-k probs
         return hf_config
 
     def provider_bridge(self, hf_pretrained):
-        """Convert HuggingFace Qwen3 MoE config to GPTModelProvider."""
+        """Convert a Hugging Face Qwen3 MoE config to HybridModelProvider."""
         provider = super().provider_bridge(hf_pretrained)
+        hf_config = hf_pretrained.config
 
         provider.normalization = "RMSNorm"
         provider.gated_linear_unit = True
@@ -66,6 +82,14 @@ class Qwen3MoEBridge(MegatronModelBridge):
         provider.moe_router_pre_softmax = False
         provider.moe_token_dispatcher_type = "alltoall"
         provider.moe_permute_fusion = True
+        provider.share_embeddings_and_output_weights = getattr(hf_config, "tie_word_embeddings", True)
+
+        configure_qwen_hybrid_layers(
+            provider,
+            num_logical_layers=hf_config.num_hidden_layers,
+            mlp_symbols=Symbols.MOE,
+            mtp_mlp_symbol=Symbols.MOE,
+        )
 
         return provider
 
@@ -73,57 +97,70 @@ class Qwen3MoEBridge(MegatronModelBridge):
         # Return MegatronMappingRegistry containing parameter mappings from Megatron to HF format
         # First create simple 1:1 parameter mappings using a dictionary for readability
 
-        # Dictionary maps Megatron parameter names -> HF parameter names
-        # Supports wildcard (*) patterns for layer-specific parameters
         param_mappings = {
             "embedding.word_embeddings.weight": "model.embed_tokens.weight",
             "output_layer.weight": "lm_head.weight",
-            "decoder.final_layernorm.weight": "model.norm.weight",
-            "decoder.layers.*.self_attention.linear_qkv.layer_norm_weight": "model.layers.*.input_layernorm.weight",
-            "decoder.layers.*.mlp.router.weight": "model.layers.*.mlp.gate.weight",
-            "decoder.layers.*.pre_mlp_layernorm.weight": "model.layers.*.post_attention_layernorm.weight",
-            "decoder.layers.*.self_attention.q_layernorm.weight": "model.layers.*.self_attn.q_norm.weight",
-            "decoder.layers.*.self_attention.k_layernorm.weight": "model.layers.*.self_attn.k_norm.weight",
-            "decoder.layers.*.self_attention.linear_proj.weight": "model.layers.*.self_attn.o_proj.weight",
+            "decoder.final_norm.weight": "model.norm.weight",
         }
 
-        mapping_list = []
-        # Convert each dictionary entry to AutoMapping(megatron_param, hf_param)
-        for megatron_param, hf_param in param_mappings.items():
-            mapping_list.append(AutoMapping(megatron_param=megatron_param, hf_param=hf_param))
+        mapping_list = [AutoMapping(megatron_param=k, hf_param=v) for k, v in param_mappings.items()]
 
-        # Add special mappings that require parameter concatenation/transformation
-        mapping_list.extend(
-            [
-                # QKV: Combine separate Q, K, V matrices into single QKV matrix
-                # Note: Qwen3 MoE does NOT have bias in QKV projections
-                QKVMapping(
-                    megatron_param="decoder.layers.*.self_attention.linear_qkv.weight",
-                    q="model.layers.*.self_attn.q_proj.weight",
-                    k="model.layers.*.self_attn.k_proj.weight",
-                    v="model.layers.*.self_attn.v_proj.weight",
-                ),
-                # Expert mappings for TEGroupedMLP
-                GatedMLPMapping(
-                    megatron_param="decoder.layers.*.mlp.experts.linear_fc1.weight*",
-                    gate="model.layers.*.mlp.experts.*.gate_proj.weight",
-                    up="model.layers.*.mlp.experts.*.up_proj.weight",
-                ),
-                AutoMapping(
-                    megatron_param="decoder.layers.*.mlp.experts.linear_fc2.weight*",
-                    hf_param="model.layers.*.mlp.experts.*.down_proj.weight",
-                ),
-                # Expert mappings for SequentialMLP (used by quantization)
-                GatedMLPMapping(
-                    megatron_param="decoder.layers.*.mlp.experts.local_experts.*.linear_fc1.weight",
-                    gate="model.layers.*.mlp.experts.*.gate_proj.weight",
-                    up="model.layers.*.mlp.experts.*.up_proj.weight",
-                ),
-                AutoMapping(
-                    megatron_param="decoder.layers.*.mlp.experts.local_experts.*.linear_fc2.weight",
-                    hf_param="model.layers.*.mlp.experts.*.down_proj.weight",
-                ),
-            ]
-        )
+        for logical_layer_idx in range(self.hf_config.num_hidden_layers):
+            attention_layer_idx, moe_layer_idx = qwen_physical_layer_indices(logical_layer_idx)
+            hf_layer = f"model.layers.{logical_layer_idx}"
+            attention_layer = f"decoder.layers.{attention_layer_idx}.self_attention"
+            moe_layer = f"decoder.layers.{moe_layer_idx}"
+            mapping_list.extend(
+                [
+                    AutoMapping(
+                        megatron_param=f"{attention_layer}.linear_qkv.layer_norm_weight",
+                        hf_param=f"{hf_layer}.input_layernorm.weight",
+                    ),
+                    AutoMapping(
+                        megatron_param=f"{attention_layer}.q_layernorm.weight",
+                        hf_param=f"{hf_layer}.self_attn.q_norm.weight",
+                    ),
+                    AutoMapping(
+                        megatron_param=f"{attention_layer}.k_layernorm.weight",
+                        hf_param=f"{hf_layer}.self_attn.k_norm.weight",
+                    ),
+                    AutoMapping(
+                        megatron_param=f"{attention_layer}.linear_proj.weight",
+                        hf_param=f"{hf_layer}.self_attn.o_proj.weight",
+                    ),
+                    AutoMapping(
+                        megatron_param=f"{moe_layer}.pre_mlp_layernorm.weight",
+                        hf_param=f"{hf_layer}.post_attention_layernorm.weight",
+                    ),
+                    AutoMapping(
+                        megatron_param=f"{moe_layer}.mlp.router.weight",
+                        hf_param=f"{hf_layer}.mlp.gate.weight",
+                    ),
+                    QKVMapping(
+                        megatron_param=f"{attention_layer}.linear_qkv.weight",
+                        q=f"{hf_layer}.self_attn.q_proj.weight",
+                        k=f"{hf_layer}.self_attn.k_proj.weight",
+                        v=f"{hf_layer}.self_attn.v_proj.weight",
+                    ),
+                    GatedMLPMapping(
+                        megatron_param=f"{moe_layer}.mlp.experts.linear_fc1.weight*",
+                        gate=f"{hf_layer}.mlp.experts.*.gate_proj.weight",
+                        up=f"{hf_layer}.mlp.experts.*.up_proj.weight",
+                    ),
+                    AutoMapping(
+                        megatron_param=f"{moe_layer}.mlp.experts.linear_fc2.weight*",
+                        hf_param=f"{hf_layer}.mlp.experts.*.down_proj.weight",
+                    ),
+                    GatedMLPMapping(
+                        megatron_param=f"{moe_layer}.mlp.experts.local_experts.*.linear_fc1.weight",
+                        gate=f"{hf_layer}.mlp.experts.*.gate_proj.weight",
+                        up=f"{hf_layer}.mlp.experts.*.up_proj.weight",
+                    ),
+                    AutoMapping(
+                        megatron_param=f"{moe_layer}.mlp.experts.local_experts.*.linear_fc2.weight",
+                        hf_param=f"{hf_layer}.mlp.experts.*.down_proj.weight",
+                    ),
+                ]
+            )
 
         return MegatronMappingRegistry(*mapping_list)

--- a/src/megatron/bridge/models/qwen/qwen3_next_bridge.py
+++ b/src/megatron/bridge/models/qwen/qwen3_next_bridge.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,15 +13,13 @@
 # limitations under the License.
 
 import torch
-from megatron.core.models.gpt.experimental_attention_variant_module_specs import (
-    get_transformer_block_with_experimental_attention_variant_spec,
-)
-from megatron.core.models.gpt.gpt_model import GPTModel
+from megatron.core.models.hybrid.hybrid_layer_allocation import Symbols
+from megatron.core.models.hybrid.hybrid_model import HybridModel
 from transformers import Qwen3NextForCausalLM
 
 from megatron.bridge.models.conversion.mapping_registry import MegatronMappingRegistry
 from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge
-from megatron.bridge.models.conversion.param_mapping import (  # noqa: F401
+from megatron.bridge.models.conversion.param_mapping import (
     AutoMapping,
     GatedMLPMapping,
     GDNConv1dMapping,
@@ -31,30 +29,38 @@ from megatron.bridge.models.conversion.param_mapping import (  # noqa: F401
     RMSNorm2ZeroCenteredRMSNormMapping,
 )
 from megatron.bridge.models.conversion.transformers_compat import full_attention_interval_from_hf
+from megatron.bridge.models.qwen.qwen_hybrid import (
+    QwenHybridModelProvider,
+    configure_qwen_hybrid_layers,
+    qwen_attention_symbols,
+    qwen_logical_layer_count,
+    qwen_physical_layer_indices,
+)
 
 
-@MegatronModelBridge.register_bridge(source=Qwen3NextForCausalLM, target=GPTModel, model_type="qwen3_next")
+@MegatronModelBridge.register_bridge(
+    source=Qwen3NextForCausalLM,
+    target=HybridModel,
+    provider=QwenHybridModelProvider,
+    model_type="qwen3_next",
+)
 class Qwen3NextBridge(MegatronModelBridge):
-    """
-    Megatron Bridge for Qwen3-Next Causal LM.
+    """Megatron Bridge for Qwen3-Next Causal LM."""
 
-    This bridge handles the conversion between HuggingFace Qwen3NextForCausalLM
-    and Megatron-Core GPTModel formats. Qwen3-Next uses a hybrid architecture
-    combining gated delta net linear attention with standard softmax attention,
-    mixture of experts with shared experts, and zero-centered RMSNorm.
-
-    Example:
-        >>> from megatron.bridge import AutoBridge
-        >>> bridge = AutoBridge.from_hf_pretrained("Qwen/Qwen3-Next-80B-A3B-Instruct")
-        >>> provider = bridge.to_megatron_provider()
-    """
+    @classmethod
+    def megatron_to_hf_config(cls, provider) -> dict:
+        """Convert a Hybrid Qwen3-Next provider to a Hugging Face config dictionary."""
+        hf_config = super().megatron_to_hf_config(provider)
+        logical_layer_count = qwen_logical_layer_count(provider.hybrid_layer_pattern)
+        if logical_layer_count is not None:
+            hf_config["num_hidden_layers"] = logical_layer_count
+        return hf_config
 
     def provider_bridge(self, hf_pretrained):
-        """Convert HuggingFace Qwen3-Next config to GPTModelProvider."""
+        """Convert a Hugging Face Qwen3-Next config to HybridModelProvider."""
         provider = super().provider_bridge(hf_pretrained)
         hf_config = hf_pretrained.config
 
-        # Standard GPT settings (shared with Qwen3 MoE)
         provider.normalization = "RMSNorm"
         provider.gated_linear_unit = True
         provider.position_embedding_type = "rope"
@@ -65,7 +71,6 @@ class Qwen3NextBridge(MegatronModelBridge):
         provider.autocast_dtype = torch.bfloat16
         provider.share_embeddings_and_output_weights = getattr(hf_config, "tie_word_embeddings", False)
 
-        # MoE settings
         provider.moe_grouped_gemm = True
         provider.moe_router_load_balancing_type = "global_aux_loss"
         provider.moe_aux_loss_coeff = 1e-3
@@ -76,12 +81,8 @@ class Qwen3NextBridge(MegatronModelBridge):
         provider.moe_router_dtype = "fp32"
         provider.moe_shared_expert_intermediate_size = hf_config.shared_expert_intermediate_size
 
-        # Qwen3-Next: zero-centered RMSNorm and gated attention
         provider.layernorm_zero_centered_gamma = True
         provider.attention_output_gate = True
-
-        # Qwen3-Next: hybrid gated delta net + standard attention
-        provider.transformer_layer_spec = get_transformer_block_with_experimental_attention_variant_spec
         provider.experimental_attention_variant = "gated_delta_net"
         provider.linear_attention_freq = full_attention_interval_from_hf(hf_config)
         provider.linear_conv_kernel_dim = hf_config.linear_conv_kernel_dim
@@ -89,161 +90,160 @@ class Qwen3NextBridge(MegatronModelBridge):
         provider.linear_value_head_dim = hf_config.linear_value_head_dim
         provider.linear_num_key_heads = hf_config.linear_num_key_heads
         provider.linear_num_value_heads = hf_config.linear_num_value_heads
-
-        # Heterogeneous checkpointing for mixed attention layers
         provider.hetereogenous_dist_checkpoint = True
+
+        configure_qwen_hybrid_layers(
+            provider,
+            num_logical_layers=hf_config.num_hidden_layers,
+            mlp_symbols=Symbols.MOE,
+            linear_attention_freq=provider.linear_attention_freq,
+            mtp_mlp_symbol=Symbols.MOE,
+        )
 
         return provider
 
     def mapping_registry(self) -> MegatronMappingRegistry:
-        # Return MegatronMappingRegistry containing parameter mappings from Megatron to HF format
-        # First create simple 1:1 parameter mappings using a dictionary for readability
+        """Return explicit logical-to-physical parameter mappings for Qwen3-Next."""
+        mapping_list = [
+            AutoMapping("embedding.word_embeddings.weight", "model.embed_tokens.weight"),
+            AutoMapping("output_layer.weight", "lm_head.weight"),
+            AutoMapping("decoder.final_norm.weight", "model.norm.weight"),
+        ]
 
-        # Dictionary maps Megatron parameter names -> HF parameter names
-        # Supports wildcard (*) patterns for layer-specific parameters
-        param_mappings = {
-            # Embedding and output
-            "embedding.word_embeddings.weight": "model.embed_tokens.weight",
-            "output_layer.weight": "lm_head.weight",
-            "decoder.final_layernorm.weight": "model.norm.weight",
-            # MoE
-            "decoder.layers.*.mlp.router.weight": "model.layers.*.mlp.gate.weight",
-            "decoder.layers.*.pre_mlp_layernorm.weight": "model.layers.*.post_attention_layernorm.weight",
-            # Standard attention
-            "decoder.layers.*.self_attention.linear_qkv.layer_norm_weight": "model.layers.*.input_layernorm.weight",
-            "decoder.layers.*.self_attention.q_layernorm.weight": "model.layers.*.self_attn.q_norm.weight",
-            "decoder.layers.*.self_attention.k_layernorm.weight": "model.layers.*.self_attn.k_norm.weight",
-            "decoder.layers.*.self_attention.linear_proj.weight": "model.layers.*.self_attn.o_proj.weight",
-            # Linear attention
-            "decoder.layers.*.self_attention.in_proj.layer_norm_weight": "model.layers.*.input_layernorm.weight",
-            "decoder.layers.*.self_attention.out_proj.weight": "model.layers.*.linear_attn.out_proj.weight",
-            "decoder.layers.*.self_attention.A_log": "model.layers.*.linear_attn.A_log",
-            "decoder.layers.*.self_attention.dt_bias": "model.layers.*.linear_attn.dt_bias",
-            # MTP projection and norms
-            "mtp.layers.0.eh_proj.weight": "mtp.fc.weight",
-            "mtp.layers.0.enorm.weight": "mtp.pre_fc_norm_embedding.weight",
-            "mtp.layers.0.hnorm.weight": "mtp.pre_fc_norm_hidden.weight",
-            "mtp.layers.0.final_layernorm.weight": "mtp.norm.weight",
-            # MTP MoE
-            "mtp.layers.0.mtp_model_layer.mlp.router.weight": "mtp.layers.0.mlp.gate.weight",
-            "mtp.layers.0.mtp_model_layer.pre_mlp_layernorm.weight": "mtp.layers.0.post_attention_layernorm.weight",
-            # MTP standard attention
-            "mtp.layers.0.mtp_model_layer.self_attention.linear_qkv.layer_norm_weight": "mtp.layers.0.input_layernorm.weight",
-            "mtp.layers.0.mtp_model_layer.self_attention.q_layernorm.weight": "mtp.layers.0.self_attn.q_norm.weight",
-            "mtp.layers.0.mtp_model_layer.self_attention.k_layernorm.weight": "mtp.layers.0.self_attn.k_norm.weight",
-            "mtp.layers.0.mtp_model_layer.self_attention.linear_proj.weight": "mtp.layers.0.self_attn.o_proj.weight",
-        }
-
-        mapping_list = []
-        # Convert each dictionary entry to AutoMapping(megatron_param, hf_param)
-        for megatron_param, hf_param in param_mappings.items():
-            mapping_list.append(AutoMapping(megatron_param=megatron_param, hf_param=hf_param))
         AutoMapping.register_module_type("SharedExpertMLP", "column")
         AutoMapping.register_module_type("GatedDeltaNet", "column")
 
-        # Add special mappings that require parameter concatenation/transformation
-        mapping_list.extend(
-            [
-                # QKV: Combine separate Q, K, V matrices into single QKV matrix
-                # Note: Qwen3 MoE does NOT have bias in QKV projections
-                QKVMapping(
-                    megatron_param="decoder.layers.*.self_attention.linear_qkv.weight",
-                    q="model.layers.*.self_attn.q_proj.weight",
-                    k="model.layers.*.self_attn.k_proj.weight",
-                    v="model.layers.*.self_attn.v_proj.weight",
-                ),
-                QKVMapping(
-                    megatron_param="mtp.layers.*.mtp_model_layer.self_attention.linear_qkv.weight",
-                    q="mtp.layers.*.self_attn.q_proj.weight",
-                    k="mtp.layers.*.self_attn.k_proj.weight",
-                    v="mtp.layers.*.self_attn.v_proj.weight",
-                ),
-                # GDNLinear: Combine separate QKVZ_proj and BA_proj into single in_proj for GDN
-                # Note: Qwen3-Next does NOT have bias in the input linear projections
-                GDNConv1dMapping(
-                    megatron_param="decoder.layers.*.self_attention.conv1d.weight",
-                    hf_param="model.layers.*.linear_attn.conv1d.weight",
-                ),
-                GDNLinearMapping(
-                    megatron_param="decoder.layers.*.self_attention.in_proj.weight",
-                    qkvz="model.layers.*.linear_attn.in_proj_qkvz.weight",
-                    ba="model.layers.*.linear_attn.in_proj_ba.weight",
-                ),
-                # Gated MLP of experts
-                GatedMLPMapping(
-                    megatron_param="decoder.layers.*.mlp.experts.linear_fc1.weight*",
-                    gate="model.layers.*.mlp.experts.*.gate_proj.weight",
-                    up="model.layers.*.mlp.experts.*.up_proj.weight",
-                ),
-                AutoMapping(
-                    megatron_param="decoder.layers.*.mlp.experts.linear_fc2.weight*",
-                    hf_param="model.layers.*.mlp.experts.*.down_proj.weight",
-                ),
-                # Sequential (non-grouped) experts (e.g. ModelOpt pruning).
-                GatedMLPMapping(
-                    megatron_param="decoder.layers.*.mlp.experts.local_experts.*.linear_fc1.weight",
-                    gate="model.layers.*.mlp.experts.*.gate_proj.weight",
-                    up="model.layers.*.mlp.experts.*.up_proj.weight",
-                ),
-                AutoMapping(
-                    megatron_param="decoder.layers.*.mlp.experts.local_experts.*.linear_fc2.weight",
-                    hf_param="model.layers.*.mlp.experts.*.down_proj.weight",
-                ),
-                GatedMLPMapping(
-                    megatron_param="mtp.layers.*.mtp_model_layer.mlp.experts.linear_fc1.weight*",
-                    gate="mtp.layers.*.mlp.experts.*.gate_proj.weight",
-                    up="mtp.layers.*.mlp.experts.*.up_proj.weight",
-                ),
-                AutoMapping(
-                    megatron_param="mtp.layers.*.mtp_model_layer.mlp.experts.linear_fc2.weight*",
-                    hf_param="mtp.layers.*.mlp.experts.*.down_proj.weight",
-                ),
-                # Sequential (non-grouped) MTP experts (e.g. ModelOpt pruning).
-                GatedMLPMapping(
-                    megatron_param="mtp.layers.*.mtp_model_layer.mlp.experts.local_experts.*.linear_fc1.weight",
-                    gate="mtp.layers.*.mlp.experts.*.gate_proj.weight",
-                    up="mtp.layers.*.mlp.experts.*.up_proj.weight",
-                ),
-                AutoMapping(
-                    megatron_param="mtp.layers.*.mtp_model_layer.mlp.experts.local_experts.*.linear_fc2.weight",
-                    hf_param="mtp.layers.*.mlp.experts.*.down_proj.weight",
-                ),
-                # Gated MLP of shared expert
-                GatedMLPMapping(
-                    megatron_param="decoder.layers.*.mlp.shared_experts.linear_fc1.weight",
-                    gate="model.layers.*.mlp.shared_expert.gate_proj.weight",
-                    up="model.layers.*.mlp.shared_expert.up_proj.weight",
-                ),
-                AutoMapping(
-                    megatron_param="decoder.layers.*.mlp.shared_experts.linear_fc2.weight",
-                    hf_param="model.layers.*.mlp.shared_expert.down_proj.weight",
-                ),
-                GatedMLPMapping(
-                    megatron_param="mtp.layers.*.mtp_model_layer.mlp.shared_experts.linear_fc1.weight",
-                    gate="mtp.layers.*.mlp.shared_expert.gate_proj.weight",
-                    up="mtp.layers.*.mlp.shared_expert.up_proj.weight",
-                ),
-                AutoMapping(
-                    megatron_param="mtp.layers.*.mtp_model_layer.mlp.shared_experts.linear_fc2.weight",
-                    hf_param="mtp.layers.*.mlp.shared_expert.down_proj.weight",
-                ),
-                # Shared expert gate
-                ReplicatedMapping(
-                    megatron_param="decoder.layers.*.mlp.shared_experts.gate_weight",
-                    hf_param="model.layers.*.mlp.shared_expert_gate.weight",
-                ),
-                ReplicatedMapping(
-                    megatron_param="mtp.layers.0.mtp_model_layer.mlp.shared_experts.gate_weight",
-                    hf_param="mtp.layers.0.mlp.shared_expert_gate.weight",
-                ),
-                # Qwen3-Next implements the output norm as a standard RMSNorm while initializing weight to ones,
-                # while other norms are regular zero-centered RMSNorms.
-                # To correctly load the output norm weight, we need to subtract 1 from it.
-                RMSNorm2ZeroCenteredRMSNormMapping(
-                    "decoder.layers.*.self_attention.out_norm.weight",
-                    "model.layers.*.linear_attn.norm.weight",
-                ),
-            ]
+        num_layers = self.hf_config.num_hidden_layers
+        attention_symbols = qwen_attention_symbols(
+            num_layers,
+            full_attention_interval_from_hf(self.hf_config),
         )
+        for logical_layer_idx, attention_symbol in enumerate(attention_symbols):
+            attention_layer_idx, moe_layer_idx = qwen_physical_layer_indices(logical_layer_idx)
+            hf_layer = f"model.layers.{logical_layer_idx}"
+            attention_layer = f"decoder.layers.{attention_layer_idx}.self_attention"
+            moe_layer = f"decoder.layers.{moe_layer_idx}"
 
+            if attention_symbol == Symbols.ATTENTION:
+                mapping_list.extend(
+                    [
+                        AutoMapping(
+                            f"{attention_layer}.linear_qkv.layer_norm_weight",
+                            f"{hf_layer}.input_layernorm.weight",
+                        ),
+                        AutoMapping(
+                            f"{attention_layer}.q_layernorm.weight",
+                            f"{hf_layer}.self_attn.q_norm.weight",
+                        ),
+                        AutoMapping(
+                            f"{attention_layer}.k_layernorm.weight",
+                            f"{hf_layer}.self_attn.k_norm.weight",
+                        ),
+                        AutoMapping(
+                            f"{attention_layer}.linear_proj.weight",
+                            f"{hf_layer}.self_attn.o_proj.weight",
+                        ),
+                        QKVMapping(
+                            megatron_param=f"{attention_layer}.linear_qkv.weight",
+                            q=f"{hf_layer}.self_attn.q_proj.weight",
+                            k=f"{hf_layer}.self_attn.k_proj.weight",
+                            v=f"{hf_layer}.self_attn.v_proj.weight",
+                        ),
+                    ]
+                )
+            else:
+                mapping_list.extend(
+                    [
+                        AutoMapping(
+                            f"{attention_layer}.in_proj.layer_norm_weight",
+                            f"{hf_layer}.input_layernorm.weight",
+                        ),
+                        AutoMapping(f"{attention_layer}.out_proj.weight", f"{hf_layer}.linear_attn.out_proj.weight"),
+                        AutoMapping(f"{attention_layer}.A_log", f"{hf_layer}.linear_attn.A_log"),
+                        AutoMapping(f"{attention_layer}.dt_bias", f"{hf_layer}.linear_attn.dt_bias"),
+                        GDNConv1dMapping(
+                            megatron_param=f"{attention_layer}.conv1d.weight",
+                            hf_param=f"{hf_layer}.linear_attn.conv1d.weight",
+                        ),
+                        GDNLinearMapping(
+                            megatron_param=f"{attention_layer}.in_proj.weight",
+                            qkvz=f"{hf_layer}.linear_attn.in_proj_qkvz.weight",
+                            ba=f"{hf_layer}.linear_attn.in_proj_ba.weight",
+                        ),
+                        RMSNorm2ZeroCenteredRMSNormMapping(
+                            f"{attention_layer}.out_norm.weight",
+                            f"{hf_layer}.linear_attn.norm.weight",
+                        ),
+                    ]
+                )
+
+            mapping_list.extend(self._moe_layer_mappings(moe_layer, hf_layer))
+
+        mapping_list.extend(self._mtp_mappings())
         return MegatronMappingRegistry(*mapping_list)
+
+    @staticmethod
+    def _moe_layer_mappings(megatron_layer: str, hf_layer: str) -> list:
+        """Build mappings for one Qwen3-Next MoE physical layer."""
+        return [
+            AutoMapping(f"{megatron_layer}.mlp.router.weight", f"{hf_layer}.mlp.gate.weight"),
+            AutoMapping(
+                f"{megatron_layer}.pre_mlp_layernorm.weight",
+                f"{hf_layer}.post_attention_layernorm.weight",
+            ),
+            GatedMLPMapping(
+                megatron_param=f"{megatron_layer}.mlp.experts.linear_fc1.weight*",
+                gate=f"{hf_layer}.mlp.experts.*.gate_proj.weight",
+                up=f"{hf_layer}.mlp.experts.*.up_proj.weight",
+            ),
+            AutoMapping(
+                f"{megatron_layer}.mlp.experts.linear_fc2.weight*",
+                f"{hf_layer}.mlp.experts.*.down_proj.weight",
+            ),
+            GatedMLPMapping(
+                megatron_param=f"{megatron_layer}.mlp.experts.local_experts.*.linear_fc1.weight",
+                gate=f"{hf_layer}.mlp.experts.*.gate_proj.weight",
+                up=f"{hf_layer}.mlp.experts.*.up_proj.weight",
+            ),
+            AutoMapping(
+                f"{megatron_layer}.mlp.experts.local_experts.*.linear_fc2.weight",
+                f"{hf_layer}.mlp.experts.*.down_proj.weight",
+            ),
+            GatedMLPMapping(
+                megatron_param=f"{megatron_layer}.mlp.shared_experts.linear_fc1.weight",
+                gate=f"{hf_layer}.mlp.shared_expert.gate_proj.weight",
+                up=f"{hf_layer}.mlp.shared_expert.up_proj.weight",
+            ),
+            AutoMapping(
+                f"{megatron_layer}.mlp.shared_experts.linear_fc2.weight",
+                f"{hf_layer}.mlp.shared_expert.down_proj.weight",
+            ),
+            ReplicatedMapping(
+                f"{megatron_layer}.mlp.shared_experts.gate_weight",
+                f"{hf_layer}.mlp.shared_expert_gate.weight",
+            ),
+        ]
+
+    @staticmethod
+    def _mtp_mappings() -> list:
+        """Build mappings for the optional two-layer Hybrid MTP block."""
+        attention_layer = "mtp.layers.0.mtp_model_layer.layers.0.self_attention"
+        moe_layer = "mtp.layers.0.mtp_model_layer.layers.1"
+        mappings = [
+            AutoMapping("mtp.layers.0.eh_proj.weight", "mtp.fc.weight"),
+            AutoMapping("mtp.layers.0.enorm.weight", "mtp.pre_fc_norm_embedding.weight"),
+            AutoMapping("mtp.layers.0.hnorm.weight", "mtp.pre_fc_norm_hidden.weight"),
+            AutoMapping("mtp.layers.0.final_layernorm.weight", "mtp.norm.weight"),
+            AutoMapping(f"{attention_layer}.linear_qkv.layer_norm_weight", "mtp.layers.0.input_layernorm.weight"),
+            AutoMapping(f"{attention_layer}.q_layernorm.weight", "mtp.layers.0.self_attn.q_norm.weight"),
+            AutoMapping(f"{attention_layer}.k_layernorm.weight", "mtp.layers.0.self_attn.k_norm.weight"),
+            AutoMapping(f"{attention_layer}.linear_proj.weight", "mtp.layers.0.self_attn.o_proj.weight"),
+            QKVMapping(
+                megatron_param="mtp.layers.*.mtp_model_layer.layers.0.self_attention.linear_qkv.weight",
+                q="mtp.layers.*.self_attn.q_proj.weight",
+                k="mtp.layers.*.self_attn.k_proj.weight",
+                v="mtp.layers.*.self_attn.v_proj.weight",
+            ),
+        ]
+        mappings.extend(Qwen3NextBridge._moe_layer_mappings(moe_layer, "mtp.layers.0"))
+        return mappings

--- a/src/megatron/bridge/models/qwen/qwen_hybrid.py
+++ b/src/megatron/bridge/models/qwen/qwen_hybrid.py
@@ -1,0 +1,220 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared HybridModel layout helpers for Qwen3 and newer models."""
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from megatron.core.models.hybrid.hybrid_layer_allocation import Symbols
+
+from megatron.bridge.models.hybrid.hybrid_provider import HybridModelProvider
+
+
+def qwen_pipeline_layer_pattern(
+    hybrid_layer_pattern: str,
+    pipeline_model_parallel_size: int,
+    *,
+    account_for_embedding: bool = False,
+    account_for_loss: bool = False,
+) -> str:
+    """Split a Qwen Hybrid pattern across PP stages without separating logical blocks."""
+    if pipeline_model_parallel_size <= 0:
+        raise ValueError("pipeline_model_parallel_size must be positive")
+
+    main_pattern, separator, mtp_pattern = hybrid_layer_pattern.partition(Symbols.MTP_SEPARATOR)
+    if Symbols.PIPE in main_pattern:
+        segment_count = main_pattern.count(Symbols.PIPE) + 1
+        if segment_count != pipeline_model_parallel_size:
+            raise ValueError(
+                f"Qwen hybrid_layer_pattern defines {segment_count} pipeline segments, "
+                f"but pipeline_model_parallel_size is {pipeline_model_parallel_size}."
+            )
+        return hybrid_layer_pattern
+    if pipeline_model_parallel_size == 1:
+        return hybrid_layer_pattern
+    if len(main_pattern) % 2:
+        raise ValueError("Qwen Hybrid patterns must contain two physical layers per logical block.")
+
+    logical_blocks = [main_pattern[index : index + 2] for index in range(0, len(main_pattern), 2)]
+    attention_symbols = {Symbols.ATTENTION, Symbols.GDN}
+    mlp_symbols = {Symbols.MLP, Symbols.MOE}
+    invalid_blocks = [
+        block for block in logical_blocks if block[0] not in attention_symbols or block[1] not in mlp_symbols
+    ]
+    if invalid_blocks:
+        raise ValueError(f"Unsupported Qwen logical blocks in hybrid_layer_pattern: {invalid_blocks}")
+
+    total_pipeline_units = len(logical_blocks) + int(account_for_embedding) + int(account_for_loss)
+    units_per_stage, extra_units = divmod(total_pipeline_units, pipeline_model_parallel_size)
+    logical_blocks_per_stage = [
+        units_per_stage + int(stage_index < extra_units) for stage_index in range(pipeline_model_parallel_size)
+    ]
+    logical_blocks_per_stage[0] -= int(account_for_embedding)
+    logical_blocks_per_stage[-1] -= int(account_for_loss)
+    if any(count <= 0 for count in logical_blocks_per_stage):
+        raise ValueError(
+            "Every pipeline stage must receive at least one Qwen logical block after embedding/loss balancing."
+        )
+
+    segments = []
+    block_offset = 0
+    for block_count in logical_blocks_per_stage:
+        segments.append("".join(logical_blocks[block_offset : block_offset + block_count]))
+        block_offset += block_count
+    if block_offset != len(logical_blocks):
+        raise RuntimeError("Failed to assign every Qwen logical block to a pipeline stage.")
+
+    segmented_pattern = Symbols.PIPE.join(segments)
+    return segmented_pattern + (separator + mtp_pattern if separator else "")
+
+
+@dataclass
+class QwenHybridModelProvider(HybridModelProvider):
+    """HybridModel provider that keeps each Qwen logical block on one PP stage."""
+
+    def finalize(self) -> None:
+        if (
+            self.hybrid_layer_pattern is not None
+            and self.pipeline_model_parallel_size > 1
+            and self.pipeline_model_parallel_layout is None
+            and self.num_layers_in_first_pipeline_stage is None
+            and self.num_layers_in_last_pipeline_stage is None
+        ):
+            segmented_pattern = qwen_pipeline_layer_pattern(
+                self.hybrid_layer_pattern,
+                self.pipeline_model_parallel_size,
+                account_for_embedding=bool(self.account_for_embedding_in_pipeline_split),
+                account_for_loss=bool(self.account_for_loss_in_pipeline_split),
+            )
+            if segmented_pattern != self.hybrid_layer_pattern:
+                self.hybrid_layer_pattern = segmented_pattern
+                # The explicit segments already include embedding/loss-aware balancing.
+                self.account_for_embedding_in_pipeline_split = False
+                self.account_for_loss_in_pipeline_split = False
+        super().finalize()
+
+
+def qwen_attention_symbols(
+    num_layers: int,
+    linear_attention_freq: int | Sequence[int] | None = None,
+) -> list[str]:
+    """Translate a logical Qwen attention schedule to HybridModel symbols."""
+    if linear_attention_freq is None:
+        return [Symbols.ATTENTION] * num_layers
+
+    if isinstance(linear_attention_freq, int):
+        if linear_attention_freq <= 0:
+            raise ValueError("linear_attention_freq must be positive")
+        return [
+            Symbols.ATTENTION if (layer_idx + 1) % linear_attention_freq == 0 else Symbols.GDN
+            for layer_idx in range(num_layers)
+        ]
+
+    linear_attention_pattern = list(linear_attention_freq)
+    if len(linear_attention_pattern) != num_layers:
+        raise ValueError(
+            "linear_attention_freq has "
+            f"{len(linear_attention_pattern)} entries, but num_hidden_layers is {num_layers}."
+        )
+    invalid_values = sorted(set(linear_attention_pattern) - {0, 1})
+    if invalid_values:
+        raise ValueError(f"Unsupported linear attention pattern values: {invalid_values}. Expected only 0 or 1.")
+    return [Symbols.GDN if is_linear else Symbols.ATTENTION for is_linear in linear_attention_pattern]
+
+
+def qwen_hybrid_layer_pattern(
+    num_layers: int,
+    *,
+    mlp_symbols: str | Sequence[str],
+    linear_attention_freq: int | Sequence[int] | None = None,
+) -> str:
+    """Build a two-physical-layer HybridModel pattern for each logical Qwen block."""
+    if isinstance(mlp_symbols, str):
+        mlp_pattern = [mlp_symbols] * num_layers
+    else:
+        mlp_pattern = list(mlp_symbols)
+        if len(mlp_pattern) != num_layers:
+            raise ValueError(f"MLP pattern has {len(mlp_pattern)} entries, but num_hidden_layers is {num_layers}.")
+
+    invalid_symbols = sorted(set(mlp_pattern) - {Symbols.MLP, Symbols.MOE})
+    if invalid_symbols:
+        raise ValueError(
+            f"Unsupported Qwen MLP symbols: {invalid_symbols}. Expected '{Symbols.MLP}' or '{Symbols.MOE}'."
+        )
+
+    attention_pattern = qwen_attention_symbols(num_layers, linear_attention_freq)
+    return "".join(
+        attention_symbol + mlp_symbol for attention_symbol, mlp_symbol in zip(attention_pattern, mlp_pattern)
+    )
+
+
+def qwen_moe_layer_symbols(
+    num_layers: int,
+    *,
+    decoder_sparse_step: int = 1,
+    mlp_only_layers: Sequence[int] = (),
+) -> list[str]:
+    """Translate Hugging Face Qwen MoE placement fields to Hybrid symbols."""
+    if decoder_sparse_step <= 0:
+        raise ValueError("decoder_sparse_step must be positive")
+    dense_layers = set(mlp_only_layers)
+    invalid_layers = sorted(layer_idx for layer_idx in dense_layers if not 0 <= layer_idx < num_layers)
+    if invalid_layers:
+        raise ValueError(f"mlp_only_layers contains out-of-range indices: {invalid_layers}")
+    return [
+        Symbols.MOE
+        if logical_layer_idx not in dense_layers and (logical_layer_idx + 1) % decoder_sparse_step == 0
+        else Symbols.MLP
+        for logical_layer_idx in range(num_layers)
+    ]
+
+
+def configure_qwen_hybrid_layers(
+    provider: HybridModelProvider,
+    *,
+    num_logical_layers: int,
+    mlp_symbols: str | Sequence[str],
+    linear_attention_freq: int | Sequence[int] | None = None,
+    mtp_mlp_symbol: str | None = None,
+) -> None:
+    """Configure main and optional MTP physical layer patterns on a Qwen provider."""
+    provider.hybrid_layer_pattern = qwen_hybrid_layer_pattern(
+        num_logical_layers,
+        mlp_symbols=mlp_symbols,
+        linear_attention_freq=linear_attention_freq,
+    )
+    provider.num_layers = len(provider.hybrid_layer_pattern)
+
+    if mtp_mlp_symbol is not None:
+        if mtp_mlp_symbol not in {Symbols.MLP, Symbols.MOE}:
+            raise ValueError(
+                f"Unsupported Qwen MTP MLP symbol: {mtp_mlp_symbol}. Expected '{Symbols.MLP}' or '{Symbols.MOE}'."
+            )
+        provider.mtp_hybrid_override_pattern = Symbols.ATTENTION + mtp_mlp_symbol
+
+
+def qwen_logical_layer_count(hybrid_layer_pattern: str | None) -> int | None:
+    """Return the number of logical Qwen blocks encoded by a HybridModel pattern."""
+    if not hybrid_layer_pattern:
+        return None
+    main_pattern = hybrid_layer_pattern.split(Symbols.MTP_SEPARATOR)[0].replace(Symbols.PIPE, "")
+    attention_symbols = {Symbols.ATTENTION, Symbols.GDN}
+    return sum(symbol in attention_symbols for symbol in main_pattern)
+
+
+def qwen_physical_layer_indices(logical_layer_idx: int) -> tuple[int, int]:
+    """Return attention and MLP/MoE physical indices for one logical Qwen block."""
+    attention_layer_idx = 2 * logical_layer_idx
+    return attention_layer_idx, attention_layer_idx + 1

--- a/tests/functional_tests/test_groups/recipes/test_qwen_recipes_pretrain.py
+++ b/tests/functional_tests/test_groups/recipes/test_qwen_recipes_pretrain.py
@@ -28,7 +28,7 @@ from tests.functional_tests.test_groups.recipes.utils import run_pretrain_recipe
 QWEN_PRETRAIN_RECIPES = [
     # (config_func, name, parallelism_overrides, model_overrides)
     (qwen25_500m_config, "qwen25_500m", {}, {"num_layers": 2}),
-    (qwen3_600m_config, "qwen3_600m", {}, {"num_layers": 2}),
+    (qwen3_600m_config, "qwen3_600m", {}, {"num_layers": 4, "hybrid_layer_pattern": "*-*-"}),
 ]
 
 

--- a/tests/unit_tests/models/qwen/test_qwen35_bridge.py
+++ b/tests/unit_tests/models/qwen/test_qwen35_bridge.py
@@ -16,14 +16,15 @@
 Unit tests for Qwen3.5 bridge functionality.
 """
 
+from types import SimpleNamespace
 from unittest.mock import Mock
 
 import pytest
 import torch
 
 from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge
-from megatron.bridge.models.gpt_provider import GPTModelProvider
 from megatron.bridge.models.hf_pretrained.causal_lm import PreTrainedCausalLM
+from megatron.bridge.models.hybrid.hybrid_provider import HybridModelProvider
 from megatron.bridge.models.qwen.qwen35_bridge import Qwen35Bridge, Qwen35MoEBridge
 
 
@@ -38,6 +39,18 @@ _NULL_ATTRS = (
     "num_nextn_predict_layers",
     "mtp_num_hidden_layers",
 )
+
+
+@pytest.fixture(autouse=True)
+def _set_bridge_hf_configs():
+    config = SimpleNamespace(num_hidden_layers=4, full_attention_interval=4)
+    previous_dense = Qwen35Bridge.hf_config
+    previous_moe = Qwen35MoEBridge.hf_config
+    Qwen35Bridge.hf_config = config
+    Qwen35MoEBridge.hf_config = config
+    yield
+    Qwen35Bridge.hf_config = previous_dense
+    Qwen35MoEBridge.hf_config = previous_moe
 
 
 class TestQwen35DenseBridge:
@@ -105,8 +118,9 @@ class TestQwen35DenseBridge:
 
         result = bridge.provider_bridge(mock_pretrained_qwen3_5)
 
-        assert isinstance(result, GPTModelProvider)
-        assert result.num_layers == mock_qwen3_5_config.num_hidden_layers
+        assert isinstance(result, HybridModelProvider)
+        assert result.num_layers == 2 * mock_qwen3_5_config.num_hidden_layers
+        assert result.hybrid_layer_pattern == "G-G-G-*-" * 16
         assert result.hidden_size == mock_qwen3_5_config.hidden_size
         assert result.num_attention_heads == mock_qwen3_5_config.num_attention_heads
         assert result.seq_length == mock_qwen3_5_config.max_position_embeddings
@@ -143,7 +157,7 @@ class TestQwen35DenseBridge:
             assert result.linear_attention_freq == mock_qwen3_5_config.full_attention_interval
         else:
             assert isinstance(result.linear_attention_freq, list)
-            for i in range(result.num_layers):
+            for i in range(mock_qwen3_5_config.num_hidden_layers):
                 if (i + 1) % mock_qwen3_5_config.full_attention_interval == 0:
                     assert result.linear_attention_freq[i] == 0
                 else:
@@ -257,7 +271,7 @@ class TestQwen35DenseBridge:
         bridge = Qwen35Bridge()
         result = bridge.provider_bridge(mock_pretrained)
 
-        assert result.num_layers == 64
+        assert result.num_layers == 128
         assert result.hidden_size == 5120
         assert result.num_attention_heads == 24
         assert result.ffn_hidden_size == 17408
@@ -304,7 +318,7 @@ class TestQwen35DenseBridge:
 
         # Should have layer norm mappings
         assert "model.norm.weight" in hf_params
-        assert "decoder.final_layernorm.weight" in megatron_params
+        assert "decoder.final_norm.weight" in megatron_params
 
     def test_mapping_registry_mtp_mapping(self):
         """Test that mapping_registry contains MTP mapping."""
@@ -461,8 +475,9 @@ class TestQwen35MoEBridge:
 
         result = bridge.provider_bridge(mock_pretrained_qwen3_5_moe)
 
-        assert isinstance(result, GPTModelProvider)
-        assert result.num_layers == mock_qwen3_5_moe_config.num_hidden_layers
+        assert isinstance(result, HybridModelProvider)
+        assert result.num_layers == 2 * mock_qwen3_5_moe_config.num_hidden_layers
+        assert result.hybrid_layer_pattern == "GEGEGE*E" * 15
         assert result.hidden_size == mock_qwen3_5_moe_config.hidden_size
         assert result.num_attention_heads == mock_qwen3_5_moe_config.num_attention_heads
         assert result.seq_length == mock_qwen3_5_moe_config.max_position_embeddings
@@ -610,7 +625,7 @@ class TestQwen35MoEBridge:
         bridge = Qwen35MoEBridge()
         result = bridge.provider_bridge(mock_pretrained)
 
-        assert result.num_layers == 60
+        assert result.num_layers == 120
         assert result.hidden_size == 4096
         assert result.num_attention_heads == 32
         assert result.moe_ffn_hidden_size == 1024
@@ -653,7 +668,7 @@ class TestQwen35MoEBridge:
         assert "output_layer.weight" in megatron_params
 
         assert "model.norm.weight" in hf_params
-        assert "decoder.final_layernorm.weight" in megatron_params
+        assert "decoder.final_norm.weight" in megatron_params
 
     def test_mapping_registry_mtp_mapping(self):
         """Test that mapping_registry contains MTP mapping."""
@@ -735,10 +750,10 @@ class TestQwen35MoEBridge:
 
         # Check for MoE router mapping
         hf_params = [mapping.hf_param for mapping in auto_mappings]
-        assert "model.layers.*.mlp.gate.weight" in hf_params
+        assert "model.layers.0.mlp.gate.weight" in hf_params
         # shared_expert_gate is represented via ReplicatedMapping in bridge
         replicated_hf_params = [mapping.hf_param for mapping in replicated_mappings]
-        assert "model.layers.*.mlp.shared_expert_gate.weight" in replicated_hf_params
+        assert "model.layers.0.mlp.shared_expert_gate.weight" in replicated_hf_params
 
         # Routed-expert mappings exist for both the grouped-GEMM (experts.linear_fc*.weight*) and
         # SequentialMLP (local_experts.*.linear_fc*) layouts. Their fused-vs-per-expert form depends

--- a/tests/unit_tests/models/qwen/test_qwen3_bridge.py
+++ b/tests/unit_tests/models/qwen/test_qwen3_bridge.py
@@ -14,6 +14,7 @@
 
 import tempfile
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import pytest
@@ -23,9 +24,18 @@ from transformers import Qwen2Config, Qwen3ForCausalLM
 from megatron.bridge.models import AutoBridge
 from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge
 from megatron.bridge.models.conversion.transformers_compat import rope_theta_from_hf
-from megatron.bridge.models.gpt_provider import GPTModelProvider
 from megatron.bridge.models.hf_pretrained.causal_lm import PreTrainedCausalLM
+from megatron.bridge.models.hybrid.hybrid_provider import HybridModelProvider
 from megatron.bridge.models.qwen.qwen3_bridge import Qwen3Bridge
+
+
+@pytest.fixture(autouse=True)
+def _set_bridge_hf_config():
+    """Give explicit mapping tests a small logical Qwen layer count."""
+    previous = Qwen3Bridge.hf_config
+    Qwen3Bridge.hf_config = SimpleNamespace(num_hidden_layers=2)
+    yield
+    Qwen3Bridge.hf_config = previous
 
 
 class TestMegatronQwen3Bridge:
@@ -93,11 +103,11 @@ class TestMegatronQwen3Bridge:
         # Call provider_bridge
         result = bridge.provider_bridge(mock_pretrained_qwen3)
 
-        # Check that it returns a GPTModelProvider instance (after refactoring)
-        assert isinstance(result, GPTModelProvider)
+        assert isinstance(result, HybridModelProvider)
 
         # Check basic configuration mapping
-        assert result.num_layers == qwen3_config.num_hidden_layers
+        assert result.num_layers == 2 * qwen3_config.num_hidden_layers
+        assert result.hybrid_layer_pattern == "*-" * qwen3_config.num_hidden_layers
         assert result.hidden_size == qwen3_config.hidden_size
         assert result.num_attention_heads == qwen3_config.num_attention_heads
         assert result.seq_length == qwen3_config.max_position_embeddings
@@ -200,8 +210,7 @@ class TestMegatronQwen3Bridge:
         # Pass model only
         result = bridge.provider_bridge(mock_pretrained_qwen3)
 
-        # Just verify that we got a valid GPTModelProvider
-        assert isinstance(result, GPTModelProvider)
+        assert isinstance(result, HybridModelProvider)
 
     def test_provider_bridge_without_tie_embeddings(self, qwen3_config):
         """Test provider_bridge when tie_word_embeddings is not present."""
@@ -393,7 +402,7 @@ class TestAutoBridgeIntegration:
                     "megatron.bridge.models.conversion.auto_bridge.model_bridge.get_model_bridge"
                 ) as mock_get_bridge:
                     mock_bridge = Mock()
-                    mock_provider = Mock(spec=GPTModelProvider)
+                    mock_provider = Mock(spec=HybridModelProvider)
                     mock_bridge.provider_bridge.return_value = mock_provider
                     mock_get_bridge.return_value = mock_bridge
 
@@ -483,28 +492,28 @@ class TestQwen3BridgeParameterMapping:
         bridge = Qwen3Bridge()
         mapping_registry = bridge.mapping_registry()
 
-        # This test verifies that the mapping registry was created
-        # The actual parameter mappings are tested in integration tests
-        assert mapping_registry is not None
+        mapping = mapping_registry.megatron_to_hf_lookup("decoder.layers.0.self_attention.q_layernorm.weight")
+        assert mapping is not None
+        assert mapping.hf_param == "model.layers.0.self_attn.q_norm.weight"
 
     def test_qwen3_qk_norm_mapping_difference(self):
         """Test that Qwen3 bridge includes QK norm mappings not present in Qwen2."""
         bridge = Qwen3Bridge()
         mapping_registry = bridge.mapping_registry()
 
-        # Qwen3 should have QK norm mappings
-        # This is implicitly tested by the bridge's mapping_registry method
-        # which includes the QK norm parameter mappings
-        assert mapping_registry is not None
+        attention_mapping = mapping_registry.megatron_to_hf_lookup(
+            "decoder.layers.0.self_attention.k_layernorm.weight"
+        )
+        mlp_mapping = mapping_registry.megatron_to_hf_lookup("decoder.layers.1.mlp.linear_fc2.weight")
+        assert attention_mapping.hf_param == "model.layers.0.self_attn.k_norm.weight"
+        assert mlp_mapping.hf_param == "model.layers.0.mlp.down_proj.weight"
 
     def test_qwen3_no_qkv_bias_mapping(self):
         """Test that Qwen3 bridge doesn't include QKV bias mappings."""
         bridge = Qwen3Bridge()
         mapping_registry = bridge.mapping_registry()
 
-        # Qwen3 doesn't have QKV bias, unlike Qwen2
-        # This is reflected in the QKVMapping not including bias terms
-        assert mapping_registry is not None
+        assert mapping_registry.megatron_to_hf_lookup("decoder.layers.0.self_attention.linear_qkv.bias") is None
 
 
 class TestQwen3BridgeMTPMapping:
@@ -525,15 +534,15 @@ class TestQwen3BridgeMTPMapping:
         "mtp.layers.0.enorm.weight",
         "mtp.layers.0.hnorm.weight",
         "mtp.layers.0.final_layernorm.weight",
-        "mtp.layers.0.mtp_model_layer.self_attention.linear_qkv.layer_norm_weight",
-        "mtp.layers.0.mtp_model_layer.self_attention.q_layernorm.weight",
-        "mtp.layers.0.mtp_model_layer.self_attention.k_layernorm.weight",
-        "mtp.layers.0.mtp_model_layer.self_attention.linear_proj.weight",
+        "mtp.layers.0.mtp_model_layer.layers.0.self_attention.linear_qkv.layer_norm_weight",
+        "mtp.layers.0.mtp_model_layer.layers.0.self_attention.q_layernorm.weight",
+        "mtp.layers.0.mtp_model_layer.layers.0.self_attention.k_layernorm.weight",
+        "mtp.layers.0.mtp_model_layer.layers.0.self_attention.linear_proj.weight",
         # QKVMapping stores a wildcard pattern, not a concrete layer index
-        "mtp.layers.*.mtp_model_layer.self_attention.linear_qkv.weight",
-        "mtp.layers.0.mtp_model_layer.mlp.linear_fc1.layer_norm_weight",
-        "mtp.layers.0.mtp_model_layer.mlp.linear_fc1.weight",
-        "mtp.layers.0.mtp_model_layer.mlp.linear_fc2.weight",
+        "mtp.layers.*.mtp_model_layer.layers.0.self_attention.linear_qkv.weight",
+        "mtp.layers.0.mtp_model_layer.layers.1.mlp.linear_fc1.layer_norm_weight",
+        "mtp.layers.0.mtp_model_layer.layers.1.mlp.linear_fc1.weight",
+        "mtp.layers.0.mtp_model_layer.layers.1.mlp.linear_fc2.weight",
     )
 
     def _get_all_megatron_params(self, mapping_registry):

--- a/tests/unit_tests/models/qwen/test_qwen3_moe_bridge.py
+++ b/tests/unit_tests/models/qwen/test_qwen3_moe_bridge.py
@@ -16,15 +16,24 @@
 Unit tests for Qwen3 MoE bridge functionality.
 """
 
+from types import SimpleNamespace
 from unittest.mock import Mock
 
 import pytest
 import torch
 
 from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge
-from megatron.bridge.models.gpt_provider import GPTModelProvider
 from megatron.bridge.models.hf_pretrained.causal_lm import PreTrainedCausalLM
+from megatron.bridge.models.hybrid.hybrid_provider import HybridModelProvider
 from megatron.bridge.models.qwen.qwen3_moe_bridge import Qwen3MoEBridge
+
+
+@pytest.fixture(autouse=True)
+def _set_bridge_hf_config():
+    previous = Qwen3MoEBridge.hf_config
+    Qwen3MoEBridge.hf_config = SimpleNamespace(num_hidden_layers=2)
+    yield
+    Qwen3MoEBridge.hf_config = previous
 
 
 class TestQwen3MoEBridge:
@@ -122,11 +131,11 @@ class TestQwen3MoEBridge:
         # Call provider_bridge
         result = bridge.provider_bridge(mock_pretrained_qwen3_moe)
 
-        # Check that it returns a GPTModelProvider instance (after refactoring)
-        assert isinstance(result, GPTModelProvider)
+        assert isinstance(result, HybridModelProvider)
 
         # Check basic configuration mapping
-        assert result.num_layers == mock_qwen3_moe_config.num_hidden_layers
+        assert result.num_layers == 2 * mock_qwen3_moe_config.num_hidden_layers
+        assert result.hybrid_layer_pattern == "*E" * mock_qwen3_moe_config.num_hidden_layers
         assert result.hidden_size == mock_qwen3_moe_config.hidden_size
         assert result.num_attention_heads == mock_qwen3_moe_config.num_attention_heads
         assert result.seq_length == mock_qwen3_moe_config.max_position_embeddings
@@ -257,7 +266,7 @@ class TestQwen3MoEBridge:
         bridge = Qwen3MoEBridge()
         result = bridge.provider_bridge(mock_pretrained)
 
-        # GPTModelProvider defaults share_embeddings_and_output_weights to True
+        # Preserve the historical default when the HF field is absent.
         assert result.share_embeddings_and_output_weights is True
 
     def test_provider_bridge_235b_config(self, qwen3_moe_235b_config_dict):
@@ -273,7 +282,7 @@ class TestQwen3MoEBridge:
         result = bridge.provider_bridge(mock_pretrained)
 
         # Check 235B-specific configuration
-        assert result.num_layers == 94
+        assert result.num_layers == 188
         assert result.hidden_size == 4096
         assert result.num_attention_heads == 64
         assert result.ffn_hidden_size == 12288
@@ -318,7 +327,7 @@ class TestQwen3MoEBridge:
 
         # Should have layer norm mappings
         assert "model.norm.weight" in hf_params
-        assert "decoder.final_layernorm.weight" in megatron_params
+        assert "decoder.final_norm.weight" in megatron_params
 
     def test_mapping_registry_qkv_mapping(self):
         """Test that mapping_registry contains QKV mapping."""
@@ -353,7 +362,7 @@ class TestQwen3MoEBridge:
 
         # Check for MoE router mapping
         hf_params = [mapping.hf_param for mapping in auto_mappings]
-        assert "model.layers.*.mlp.gate.weight" in hf_params
+        assert "model.layers.0.mlp.gate.weight" in hf_params
 
         # Check for expert mappings in GatedMLPMapping
         assert len(gated_mlp_mappings) > 0

--- a/tests/unit_tests/models/qwen/test_qwen3_next_bridge.py
+++ b/tests/unit_tests/models/qwen/test_qwen3_next_bridge.py
@@ -16,15 +16,24 @@
 Unit tests for Qwen3 Next bridge functionality.
 """
 
+from types import SimpleNamespace
 from unittest.mock import Mock
 
 import pytest
 import torch
 
 from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge
-from megatron.bridge.models.gpt_provider import GPTModelProvider
 from megatron.bridge.models.hf_pretrained.causal_lm import PreTrainedCausalLM
+from megatron.bridge.models.hybrid.hybrid_provider import HybridModelProvider
 from megatron.bridge.models.qwen.qwen3_next_bridge import Qwen3NextBridge
+
+
+@pytest.fixture(autouse=True)
+def _set_bridge_hf_config():
+    previous = Qwen3NextBridge.hf_config
+    Qwen3NextBridge.hf_config = SimpleNamespace(num_hidden_layers=4, full_attention_interval=4)
+    yield
+    Qwen3NextBridge.hf_config = previous
 
 
 class TestQwen3NextBridge:
@@ -121,11 +130,11 @@ class TestQwen3NextBridge:
         # Call provider_bridge
         result = bridge.provider_bridge(mock_pretrained_qwen3_next)
 
-        # Check that it returns a GPTModelProvider instance (not a model-specific subclass)
-        assert isinstance(result, GPTModelProvider)
+        assert isinstance(result, HybridModelProvider)
 
         # Check basic configuration mapping
-        assert result.num_layers == mock_qwen3_next_config.num_hidden_layers
+        assert result.num_layers == 2 * mock_qwen3_next_config.num_hidden_layers
+        assert result.hybrid_layer_pattern == "GEGEGE*E" * 12
         assert result.hidden_size == mock_qwen3_next_config.hidden_size
         assert result.num_attention_heads == mock_qwen3_next_config.num_attention_heads
         assert result.seq_length == mock_qwen3_next_config.max_position_embeddings
@@ -165,7 +174,7 @@ class TestQwen3NextBridge:
             assert result.linear_attention_freq == mock_qwen3_next_config.full_attention_interval
         else:
             assert isinstance(result.linear_attention_freq, list)
-            for i in range(result.num_layers):
+            for i in range(mock_qwen3_next_config.num_hidden_layers):
                 if (i + 1) % mock_qwen3_next_config.full_attention_interval == 0:
                     assert result.linear_attention_freq[i] == 0
                 else:
@@ -357,7 +366,7 @@ class TestQwen3NextBridge:
         result = bridge.provider_bridge(mock_pretrained)
 
         # Check 80B-A3B-specific configuration
-        assert result.num_layers == 48
+        assert result.num_layers == 96
         assert result.hidden_size == 2048
         assert result.num_attention_heads == 16
         assert result.ffn_hidden_size == 5120
@@ -404,7 +413,7 @@ class TestQwen3NextBridge:
 
         # Should have layer norm mappings
         assert "model.norm.weight" in hf_params
-        assert "decoder.final_layernorm.weight" in megatron_params
+        assert "decoder.final_norm.weight" in megatron_params
 
     def test_mapping_registry_mtp_mapping(self):
         """Test that mapping_registry contains MTP mapping."""
@@ -485,10 +494,10 @@ class TestQwen3NextBridge:
 
         # Check for MoE router mapping
         hf_params = [mapping.hf_param for mapping in auto_mappings]
-        assert "model.layers.*.mlp.gate.weight" in hf_params
+        assert "model.layers.0.mlp.gate.weight" in hf_params
         # shared_expert_gate is represented via ReplicatedMapping in bridge
         replicated_hf_params = [mapping.hf_param for mapping in replicated_mappings]
-        assert "model.layers.*.mlp.shared_expert_gate.weight" in replicated_hf_params
+        assert "model.layers.0.mlp.shared_expert_gate.weight" in replicated_hf_params
 
         # Check for expert mappings in GatedMLPMapping
         assert len(gated_mlp_mappings) > 0

--- a/tests/unit_tests/models/qwen/test_qwen_hybrid.py
+++ b/tests/unit_tests/models/qwen/test_qwen_hybrid.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from megatron.core.models.hybrid.hybrid_layer_allocation import Symbols
+
+from megatron.bridge.models.qwen.qwen_hybrid import (
+    QwenHybridModelProvider,
+    configure_qwen_hybrid_layers,
+    qwen_pipeline_layer_pattern,
+)
+
+
+def _provider() -> QwenHybridModelProvider:
+    return QwenHybridModelProvider(
+        num_layers=2,
+        hidden_size=128,
+        ffn_hidden_size=256,
+        num_attention_heads=4,
+        bf16=False,
+    )
+
+
+def test_mtp_pattern_is_deferred_when_mtp_is_disabled():
+    provider = _provider()
+    configure_qwen_hybrid_layers(
+        provider,
+        num_logical_layers=2,
+        mlp_symbols=Symbols.MLP,
+        mtp_mlp_symbol=Symbols.MLP,
+    )
+
+    provider.finalize()
+
+    assert provider.hybrid_layer_pattern == "*-*-"
+    assert provider.mtp_hybrid_override_pattern == "*-"
+
+
+def test_mtp_pattern_honors_recipe_override_set_after_conversion():
+    provider = _provider()
+    configure_qwen_hybrid_layers(
+        provider,
+        num_logical_layers=2,
+        mlp_symbols=Symbols.MLP,
+        mtp_mlp_symbol=Symbols.MLP,
+    )
+    provider.mtp_num_layers = 1
+
+    provider.finalize()
+
+    assert provider.hybrid_layer_pattern == "*-*-/*-"
+    assert provider.num_layers == 4
+
+
+def test_pipeline_segmentation_preserves_logical_blocks_and_embedding_loss_balance():
+    provider = QwenHybridModelProvider(
+        num_layers=94,
+        hidden_size=128,
+        ffn_hidden_size=256,
+        num_attention_heads=4,
+        pipeline_model_parallel_size=16,
+        account_for_embedding_in_pipeline_split=True,
+        account_for_loss_in_pipeline_split=True,
+        bf16=False,
+    )
+    configure_qwen_hybrid_layers(
+        provider,
+        num_logical_layers=94,
+        mlp_symbols=Symbols.MOE,
+    )
+
+    provider.finalize()
+
+    segments = provider.hybrid_layer_pattern.split(Symbols.PIPE)
+    assert [len(segment) for segment in segments] == [10] + [12] * 14 + [10]
+    assert all(segment == "*E" * (len(segment) // 2) for segment in segments)
+    assert provider.num_layers == 188
+    assert provider.account_for_embedding_in_pipeline_split is False
+    assert provider.account_for_loss_in_pipeline_split is False
+
+
+def test_pipeline_segmentation_rejects_stale_explicit_segments():
+    with pytest.raises(ValueError, match="defines 2 pipeline segments"):
+        qwen_pipeline_layer_pattern("*-*-|*-*-", pipeline_model_parallel_size=1)


### PR DESCRIPTION
## Summary

- migrate Qwen3-Next to `HybridModel`
- migrate the reusable dense and MoE Qwen3.5 text-decoder architectures to `HybridModel`
- share Gated DeltaNet/full-attention schedule translation and logical-to-physical layer mappings
- update focused bridge tests for both model families

## Models modified

Qwen3-Next checkpoint using `Qwen3NextForCausalLM`:

- `Qwen/Qwen3-Next-80B-A3B-Instruct`

Qwen3.5 text-decoder architectures:

- `qwen3_5_text` using `Qwen3_5ForCausalLM`
- `qwen3_5_moe_text` using `Qwen3_5MoeForCausalLM`

These are reusable language-decoder architectures, not separate public Qwen3.5 checkpoint repositories. They appear as the nested `text_config` inside the official `Qwen/Qwen3.5-*` multimodal checkpoints. This PR migrates those decoder bridges and provides language-layer mapping helpers reused by the full multimodal bridges.

The official `Qwen/Qwen3.5-*` checkpoint repositories, their top-level conditional-generation wrappers, vision models, and end-to-end conversion paths are modified in #4837.

## Stack

This is PR 2 of 4. Merge the stack in order:

1. #4747 - Qwen3 dense and MoE
2. #4836 - Qwen3-Next and Qwen3.5 text
3. #4837 - Qwen3-VL and Qwen3.5-VL
4. #4838 - Qwen3-ASR and Qwen3-Omni

## Validation

- `uv run --no-project --with pre-commit pre-commit run --all-files`
- The complete four-PR stack is tree-identical to the original #4747 implementation.
