### PR TITLE
Migrate Qwen VL models to HybridModel

### DIFF
--- a/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/model.py
+++ b/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/model.py
@@ -31,7 +31,7 @@ from transformers.models.qwen3_vl.configuration_qwen3_vl import Qwen3VLConfig as
 
 from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.attention import Qwen3VLSelfAttention
 from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.rope import get_rope_index
-from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.text_model import Qwen3VLGPTModel
+from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.text_model import Qwen3VLHybridModel
 from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.transformer_config import (
     Qwen3VLTransformerConfig,
     get_vision_model_config,
@@ -123,9 +123,6 @@ class Qwen3VLModel(MegatronModule):
     ) -> None:
         super().__init__(config=language_transformer_config)
 
-        if hasattr(language_transformer_layer_spec, "submodules"):
-            language_transformer_layer_spec.submodules.self_attention.module = Qwen3VLSelfAttention
-
         self.vision_transformer_config = vision_transformer_config
         self.pre_process = pre_process
         self.post_process = post_process
@@ -203,13 +200,15 @@ class Qwen3VLModel(MegatronModule):
                 pg_collection=pg_collection,
             )
         if self.add_decoder:
-            self.language_model = Qwen3VLGPTModel(
+            if mtp_block_spec is not None:
+                raise ValueError("Qwen3 multimodal HybridModel does not accept a separate MTP block spec.")
+            self.language_model = Qwen3VLHybridModel(
                 config=language_transformer_config,
-                transformer_layer_spec=language_transformer_layer_spec,
+                hybrid_stack_spec=language_transformer_layer_spec,
                 vocab_size=language_transformer_config.vocab_size,
                 max_sequence_length=language_transformer_config.language_max_sequence_length,
+                hybrid_layer_pattern=language_transformer_config.hybrid_layer_pattern,
                 parallel_output=parallel_output,
-                position_embedding_type="mrope",
                 rotary_percent=language_transformer_config.rotary_percent,
                 pre_process=self.pre_process,
                 post_process=self.post_process,
@@ -217,16 +216,15 @@ class Qwen3VLModel(MegatronModule):
                 fp16_lm_cross_entropy=language_transformer_config.fp16_lm_cross_entropy,
                 share_embeddings_and_output_weights=language_transformer_config.share_embeddings_and_output_weights,
                 scatter_embedding_sequence_parallel=False,
-                mtp_block_spec=mtp_block_spec,
                 vp_stage=vp_stage,
                 pg_collection=pg_collection,
             )
             if pre_process:
                 deepstack_indexes = getattr(vision_transformer_config, "deepstack_visual_indexes", [])
-                assert len(deepstack_indexes) <= len(self.language_model.decoder.layers), (
+                logical_layers = len(self.language_model.decoder.layers) // 2
+                assert len(deepstack_indexes) <= logical_layers, (
                     "the deepstack_visual_embeds should on the first pp-stage of language model",
-                    f"got {len(deepstack_indexes)} deepstack_visual_indexes, "
-                    f" {len(self.language_model.decoder.layers)} language model layers",
+                    f"got {len(deepstack_indexes)} deepstack_visual_indexes,  {logical_layers} language model layers",
                 )
 
             self.share_embeddings_and_output_weights = self.language_model.share_embeddings_and_output_weights

--- a/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/rope.py
+++ b/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/rope.py
@@ -139,6 +139,22 @@ class Qwen3VLMultimodalRotaryEmbedding(nn.Module):
         self.mrope_section = [24, 20, 20]
         assert cp_group is not None, "cp_group is required"
         self.cp_group = cp_group
+        self._position_ids_context: torch.Tensor | None = None
+        self._mrope_section_context: List[int] | None = None
+
+    def set_forward_context(
+        self,
+        position_ids: torch.Tensor,
+        mrope_section: List[int] | None,
+    ) -> None:
+        """Set explicit positions for HybridModel's standard RoPE call path."""
+        self._position_ids_context = position_ids
+        self._mrope_section_context = mrope_section
+
+    def clear_forward_context(self) -> None:
+        """Release references to per-forward position tensors."""
+        self._position_ids_context = None
+        self._mrope_section_context = None
 
     def apply_interleaved_mrope(self, freqs, mrope_section):
         """Apply interleaved MRoPE to 3D rotary embeddings.
@@ -159,8 +175,8 @@ class Qwen3VLMultimodalRotaryEmbedding(nn.Module):
 
     def forward(
         self,
-        position_ids: torch.Tensor,
-        mrope_section: List[int] | None,
+        position_ids: torch.Tensor | int,
+        mrope_section: List[int] | None = None,
         packed_seq_params: Optional[PackedSeqParams] = None,
         **kwargs,
     ) -> Tensor:
@@ -174,6 +190,12 @@ class Qwen3VLMultimodalRotaryEmbedding(nn.Module):
         Returns:
             Tensor: Embeddings after applying RoPE.
         """
+        if not isinstance(position_ids, torch.Tensor):
+            if self._position_ids_context is None:
+                raise RuntimeError("Qwen mRoPE positions must be set before HybridModel forward.")
+            position_ids = self._position_ids_context
+            mrope_section = self._mrope_section_context
+
         if position_ids.ndim == 2:
             position_ids = position_ids[None, ...].expand(3, position_ids.shape[0], -1)
         # Use fp32 for position indices to avoid precision loss when inv_freq is bf16.

--- a/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/text_model.py
+++ b/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/text_model.py
@@ -18,20 +18,32 @@ Copied from https://github.com/Thaurun/mbridge/blob/4462d1e284626d2ed9d3e3e
 3e5a40f2ee42a2c74/mbridge/models/qwen3_vl/gpt_model.py
 """
 
+from contextlib import nullcontext
+from copy import deepcopy
 from dataclasses import replace
 from typing import Literal, Optional
 
 import torch
 from megatron.core import tensor_parallel
 from megatron.core.dist_checkpointing.mapping import ShardedStateDict
+from megatron.core.enums import Fp8Recipe
+from megatron.core.fp4_utils import get_fp4_context
+from megatron.core.fp8_utils import get_fp8_context
 from megatron.core.inference.contexts import BaseInferenceContext
+from megatron.core.inference.utils import InferenceMode
 from megatron.core.models.gpt.gpt_model import GPTModel
+from megatron.core.models.hybrid.hybrid_block import HybridStack
+from megatron.core.models.hybrid.hybrid_layer_allocation import Symbols
+from megatron.core.models.hybrid.hybrid_model import HybridModel
 from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.transformer.spec_utils import ModuleSpec
-from megatron.core.utils import deprecate_inference_params
+from megatron.core.transformer.transformer_layer import TransformerLayer
+from megatron.core.utils import WrappedTensor, deprecate_inference_params, make_viewless_tensor
 from torch import Tensor
 
+from megatron.bridge.models.hybrid.hybrid_provider import get_default_hybrid_stack_spec
+from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.attention import Qwen3VLSelfAttention
 from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.rope import Qwen3VLMultimodalRotaryEmbedding
 from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.transformer_block import Qwen3VLTransformerBlock
 from megatron.bridge.models.transformer_config import TransformerConfig
@@ -257,3 +269,398 @@ class Qwen3VLGPTModel(GPTModel):
             del self.__dict__["embedding"]
 
         return result
+
+
+class Qwen3VLHybridStack(HybridStack):
+    """Hybrid stack that injects Qwen DeepStack embeddings after logical blocks."""
+
+    def set_multimodal_context(
+        self,
+        visual_pos_masks: torch.Tensor | None,
+        deepstack_visual_embeds: list[torch.Tensor] | None,
+    ) -> None:
+        """Set per-forward multimodal inputs consumed by :meth:`forward`."""
+        self._qwen_visual_pos_masks = visual_pos_masks
+        self._qwen_deepstack_visual_embeds = deepstack_visual_embeds
+
+    def clear_multimodal_context(self) -> None:
+        """Release references to per-forward multimodal tensors."""
+        self._qwen_visual_pos_masks = None
+        self._qwen_deepstack_visual_embeds = None
+
+    @staticmethod
+    def _deepstack_process(
+        hidden_states: Tensor,
+        visual_pos_masks: torch.Tensor,
+        visual_embeds: torch.Tensor,
+    ) -> Tensor:
+        hidden_states = hidden_states.transpose(0, 1).contiguous()
+        hidden_states[visual_pos_masks, :] = hidden_states[visual_pos_masks, :].clone() + visual_embeds
+        return hidden_states.transpose(0, 1).contiguous()
+
+    def _maybe_add_deepstack_embedding(
+        self,
+        hidden_states: Tensor,
+        local_layer_idx: int,
+        visual_pos_masks: torch.Tensor,
+        deepstack_visual_embeds: tuple[torch.Tensor, ...],
+    ) -> Tensor:
+        if self.layer_type_list[local_layer_idx] not in {Symbols.MLP, Symbols.MOE}:
+            return hidden_states
+        logical_layer_idx = (self.layers[local_layer_idx].layer_number - 1) // 2
+        if logical_layer_idx >= len(deepstack_visual_embeds):
+            return hidden_states
+        hidden_states = self._deepstack_process(
+            hidden_states,
+            visual_pos_masks,
+            deepstack_visual_embeds[logical_layer_idx],
+        )
+        return make_viewless_tensor(
+            inp=hidden_states,
+            requires_grad=hidden_states.requires_grad,
+            keep_graph=True,
+        )
+
+    def _checkpointed_forward_with_deepstack(
+        self,
+        hidden_states: Tensor,
+        attention_mask: Tensor,
+        rotary_pos_emb: Tensor,
+        packed_seq_params: PackedSeqParams | None,
+        padding_mask: Tensor | None,
+        visual_pos_masks: torch.Tensor,
+        deepstack_visual_embeds: tuple[torch.Tensor, ...],
+    ) -> Tensor:
+        use_inner_quantization_context = bool(
+            (self.config.fp8 and self.config.fp8_recipe != Fp8Recipe.delayed) or self.config.fp4
+        )
+
+        def custom(start: int, end: int):
+            def custom_forward(
+                hidden_states,
+                attention_mask,
+                rotary_pos_emb,
+                padding_mask,
+                visual_pos_masks,
+                *visual_embeds,
+            ):
+                for local_layer_idx in range(start, end):
+                    layer = self.layers[local_layer_idx]
+                    if use_inner_quantization_context and self.config.fp8:
+                        quantization_context = get_fp8_context(self.config, layer.layer_number - 1)
+                    elif use_inner_quantization_context and self.config.fp4:
+                        quantization_context = get_fp4_context(self.config, layer.layer_number - 1)
+                    else:
+                        quantization_context = nullcontext()
+
+                    with quantization_context:
+                        if isinstance(layer, TransformerLayer):
+                            hidden_states, _ = layer(
+                                hidden_states=hidden_states,
+                                attention_mask=attention_mask,
+                                rotary_pos_emb=rotary_pos_emb,
+                                inference_context=None,
+                                packed_seq_params=packed_seq_params,
+                                padding_mask=padding_mask,
+                            )
+                        else:
+                            hidden_states = layer(
+                                hidden_states=hidden_states,
+                                attention_mask=attention_mask,
+                                inference_context=None,
+                                packed_seq_params=packed_seq_params,
+                            )
+                    if isinstance(hidden_states, tuple):
+                        hidden_states = hidden_states[0]
+                    hidden_states = self._maybe_add_deepstack_embedding(
+                        hidden_states,
+                        local_layer_idx,
+                        visual_pos_masks,
+                        visual_embeds,
+                    )
+                return hidden_states
+
+            return custom_forward
+
+        def run_chunk(start: int, end: int, use_checkpoint: bool) -> None:
+            nonlocal hidden_states
+            forward_func = custom(start, end)
+            args = (
+                hidden_states,
+                attention_mask,
+                rotary_pos_emb,
+                padding_mask,
+                visual_pos_masks,
+                *deepstack_visual_embeds,
+            )
+            if use_checkpoint:
+                if self.config.fp8 or self.config.fp4:
+                    from megatron.core.extensions.transformer_engine import te_checkpoint
+
+                    hidden_states = te_checkpoint(
+                        forward_func,
+                        self.config.distribute_saved_activations,
+                        tensor_parallel.random.get_cuda_rng_tracker,
+                        self.pg_collection.tp,
+                        *args,
+                    )
+                else:
+                    hidden_states = tensor_parallel.checkpoint(
+                        forward_func,
+                        self.config.distribute_saved_activations,
+                        *args,
+                    )
+            else:
+                hidden_states = forward_func(*args)
+
+        if self.config.recompute_method == "uniform":
+            layer_idx = 0
+            while layer_idx < self.num_layers_per_pipeline_rank:
+                chunk_end = min(
+                    layer_idx + self.config.recompute_num_layers,
+                    self.num_layers_per_pipeline_rank,
+                )
+                run_chunk(layer_idx, chunk_end, True)
+                layer_idx = chunk_end
+        elif self.config.recompute_method == "block":
+            recompute_skip_num_layers = 0
+            for layer_idx in range(self.num_layers_per_pipeline_rank):
+                if (self.config.fp8 or self.config.fp4) and not hidden_states.requires_grad:
+                    recompute_skip_num_layers += 1
+                use_checkpoint = (
+                    recompute_skip_num_layers
+                    <= layer_idx
+                    < self.config.recompute_num_layers + recompute_skip_num_layers
+                )
+                run_chunk(layer_idx, layer_idx + 1, use_checkpoint)
+        else:
+            raise ValueError(f"Unsupported recompute method: {self.config.recompute_method}")
+
+        return hidden_states
+
+    def forward(
+        self,
+        hidden_states: Tensor | WrappedTensor,
+        attention_mask: Tensor,
+        inference_context: BaseInferenceContext | None = None,
+        rotary_pos_emb: Tensor | None = None,
+        *,
+        inference_params: BaseInferenceContext | None = None,
+        packed_seq_params: PackedSeqParams | None = None,
+        padding_mask: Tensor | None = None,
+    ) -> Tensor:
+        """Run the Hybrid stack with mRoPE and optional DeepStack injection."""
+        visual_pos_masks = getattr(self, "_qwen_visual_pos_masks", None)
+        deepstack_visual_embeds = tuple(getattr(self, "_qwen_deepstack_visual_embeds", None) or ())
+        if not deepstack_visual_embeds:
+            return super().forward(
+                hidden_states=hidden_states,
+                attention_mask=attention_mask,
+                inference_context=inference_context,
+                rotary_pos_emb=rotary_pos_emb,
+                inference_params=inference_params,
+                packed_seq_params=packed_seq_params,
+                padding_mask=padding_mask,
+            )
+
+        if not self.pre_process:
+            raise ValueError("DeepStack embeddings must be consumed on the first language pipeline stage.")
+        if visual_pos_masks is None:
+            raise ValueError("visual_pos_masks is required when DeepStack embeddings are provided.")
+
+        inference_context = deprecate_inference_params(inference_context, inference_params)
+        if isinstance(hidden_states, WrappedTensor):
+            hidden_states = hidden_states.unwrap()
+        if inference_context and inference_context.is_static_batching():
+            inference_context.max_seqlen = inference_context.max_sequence_length
+            inference_context.seqlen_offset = inference_context.sequence_len_offset
+
+        if (
+            (self.config.cuda_graph_impl == "local" or self.config.flash_decode)
+            and inference_context
+            and inference_context.is_static_batching()
+            and InferenceMode.is_active()
+        ):
+            current_batch_size = hidden_states.shape[1]
+            sequence_len_offset = torch.tensor(
+                [inference_context.sequence_len_offset] * current_batch_size,
+                dtype=torch.int32,
+                device="cuda",
+            )
+        else:
+            sequence_len_offset = None
+
+        use_outer_fp8_context = self.config.fp8 and self.config.fp8_recipe == Fp8Recipe.delayed
+        outer_fp8_context = get_fp8_context(self.config) if use_outer_fp8_context else nullcontext()
+        with outer_fp8_context:
+            if self.config.recompute_granularity == "full" and self.training:
+                hidden_states = self._checkpointed_forward_with_deepstack(
+                    hidden_states,
+                    attention_mask,
+                    rotary_pos_emb,
+                    packed_seq_params,
+                    padding_mask,
+                    visual_pos_masks,
+                    deepstack_visual_embeds,
+                )
+            else:
+                for local_layer_idx, layer in enumerate(self.layers):
+                    if self.config.fp8 and self.config.fp8_recipe != Fp8Recipe.delayed:
+                        quantization_context = get_fp8_context(self.config, layer.layer_number - 1)
+                    elif self.config.fp4:
+                        quantization_context = get_fp4_context(self.config, layer.layer_number - 1)
+                    else:
+                        quantization_context = nullcontext()
+                    with quantization_context:
+                        if isinstance(layer, TransformerLayer):
+                            hidden_states, _ = layer(
+                                hidden_states=hidden_states,
+                                attention_mask=attention_mask,
+                                inference_context=inference_context,
+                                rotary_pos_emb=rotary_pos_emb,
+                                sequence_len_offset=sequence_len_offset,
+                                packed_seq_params=packed_seq_params,
+                                padding_mask=padding_mask,
+                            )
+                        else:
+                            hidden_states = layer(
+                                hidden_states=hidden_states,
+                                attention_mask=attention_mask,
+                                inference_context=inference_context,
+                                packed_seq_params=packed_seq_params,
+                            )
+                    if isinstance(hidden_states, tuple):
+                        hidden_states = hidden_states[0]
+                    hidden_states = self._maybe_add_deepstack_embedding(
+                        hidden_states,
+                        local_layer_idx,
+                        visual_pos_masks,
+                        deepstack_visual_embeds,
+                    )
+
+        if self.post_process and self.post_layer_norm:
+            hidden_states = self.final_norm(hidden_states)
+        return make_viewless_tensor(
+            inp=hidden_states,
+            requires_grad=hidden_states.requires_grad,
+            keep_graph=True,
+        )
+
+
+def get_qwen3_vl_hybrid_stack_spec(config: TransformerConfig) -> ModuleSpec:
+    """Return the default Hybrid stack with Qwen's absolute mRoPE attention."""
+    stack_spec = deepcopy(get_default_hybrid_stack_spec(config))
+    stack_spec.module = Qwen3VLHybridStack
+    stack_spec.submodules.attention_layer.submodules.self_attention.module = Qwen3VLSelfAttention
+    return stack_spec
+
+
+class Qwen3VLHybridModel(HybridModel):
+    """Qwen3-VL language model implemented on top of HybridModel."""
+
+    def __init__(
+        self,
+        config: TransformerConfig,
+        hybrid_stack_spec: ModuleSpec,
+        vocab_size: int,
+        max_sequence_length: int,
+        hybrid_layer_pattern: str,
+        pre_process: bool = True,
+        post_process: bool = True,
+        fp16_lm_cross_entropy: bool = False,
+        parallel_output: bool = True,
+        share_embeddings_and_output_weights: bool = False,
+        rotary_percent: float = 1.0,
+        rotary_base: int = 10000,
+        scatter_embedding_sequence_parallel: bool = False,
+        seq_len_interpolation_factor: float | None = None,
+        vp_stage: int | None = None,
+        pg_collection: ProcessGroupCollection | None = None,
+    ) -> None:
+        super().__init__(
+            config=config,
+            hybrid_stack_spec=hybrid_stack_spec,
+            vocab_size=vocab_size,
+            max_sequence_length=max_sequence_length,
+            hybrid_layer_pattern=hybrid_layer_pattern,
+            pre_process=pre_process,
+            post_process=post_process,
+            fp16_lm_cross_entropy=fp16_lm_cross_entropy,
+            parallel_output=parallel_output,
+            share_embeddings_and_output_weights=share_embeddings_and_output_weights,
+            position_embedding_type="none",
+            rotary_percent=rotary_percent,
+            rotary_base=rotary_base,
+            scatter_embedding_sequence_parallel=scatter_embedding_sequence_parallel,
+            seq_len_interpolation_factor=seq_len_interpolation_factor,
+            vp_stage=vp_stage,
+            pg_collection=pg_collection,
+        )
+        self.position_embedding_type = "mrope"
+        self.rotary_pos_emb = Qwen3VLMultimodalRotaryEmbedding(
+            kv_channels=self.config.kv_channels,
+            rotary_percent=rotary_percent,
+            rotary_interleaved=self.config.rotary_interleaved,
+            seq_len_interpolation_factor=seq_len_interpolation_factor,
+            rotary_base=rotary_base,
+            cp_group=self.pg_collection.cp,
+        )
+        self.mrope_section = self.config.mrope_section
+        if self.mrope_section is None:
+            raise ValueError("mrope_section must be configured for Qwen3 multimodal models.")
+
+    def forward(
+        self,
+        input_ids: Tensor,
+        position_ids: Tensor,
+        attention_mask: Tensor,
+        decoder_input: Tensor | None = None,
+        labels: Tensor | None = None,
+        inference_context: BaseInferenceContext | None = None,
+        packed_seq_params: PackedSeqParams | None = None,
+        extra_block_kwargs: dict | None = None,
+        runtime_gather_output: bool | None = None,
+        *,
+        inference_params: BaseInferenceContext | None = None,
+        loss_mask: Tensor | None = None,
+        visual_pos_masks: torch.Tensor | None = None,
+        deepstack_visual_embeds: list[torch.Tensor] | None = None,
+        **kwargs,
+    ) -> Tensor:
+        """Run HybridModel with explicit multimodal positions and DeepStack inputs."""
+        if position_ids is None:
+            raise ValueError("Qwen3 multimodal HybridModel requires explicit position_ids.")
+        extra_block_kwargs = dict(extra_block_kwargs or {})
+        padding_mask = extra_block_kwargs.pop("padding_mask", None)
+        if extra_block_kwargs or kwargs:
+            unexpected = sorted(set(extra_block_kwargs) | set(kwargs))
+            raise TypeError(f"Unexpected Qwen3 multimodal language-model arguments: {unexpected}")
+
+        self.rotary_pos_emb.set_forward_context(
+            position_ids,
+            self.mrope_section,
+        )
+        self.decoder.set_multimodal_context(
+            visual_pos_masks,
+            deepstack_visual_embeds,
+        )
+        position_embedding_type = self.position_embedding_type
+        self.position_embedding_type = "rope"
+        try:
+            return super().forward(
+                input_ids=input_ids,
+                position_ids=position_ids,
+                attention_mask=attention_mask,
+                decoder_input=decoder_input,
+                labels=labels,
+                inference_context=inference_context,
+                runtime_gather_output=runtime_gather_output,
+                inference_params=inference_params,
+                loss_mask=loss_mask,
+                packed_seq_params=packed_seq_params,
+                padding_mask=padding_mask,
+            )
+        finally:
+            self.position_embedding_type = position_embedding_type
+            self.rotary_pos_emb.clear_forward_context()
+            self.decoder.clear_multimodal_context()

--- a/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/transformer_config.py
+++ b/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/transformer_config.py
@@ -43,6 +43,7 @@ class Qwen3VLTransformerConfig(TransformerConfig):
     share_embeddings_and_output_weights: bool = False
     rotary_percent: float = 1.0
     rotary_base: float = 10000
+    hybrid_layer_pattern: str | None = None
 
     # Multimodal rope section for [temporal, height, width] dimensions
     mrope_section: List[int] = field(default_factory=lambda: [24, 20, 20])

--- a/src/megatron/bridge/models/qwen_vl/qwen35_vl_bridge.py
+++ b/src/megatron/bridge/models/qwen_vl/qwen35_vl_bridge.py
@@ -32,6 +32,7 @@ This module provides two bridges:
 import logging
 
 import torch
+from megatron.core.models.hybrid.hybrid_layer_allocation import Symbols
 
 from megatron.bridge.models.conversion.mapping_registry import MegatronMappingRegistry
 from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge
@@ -40,6 +41,7 @@ from megatron.bridge.models.conversion.param_mapping import (
     ConcatenatedQKVMapping,
     ReplicatedMapping,
 )
+from megatron.bridge.models.conversion.transformers_compat import full_attention_interval_from_hf
 from megatron.bridge.models.conversion.utils import moe_experts_stored_packed
 from megatron.bridge.models.hf_pretrained.causal_lm import PreTrainedCausalLM
 from megatron.bridge.models.qwen.qwen35_bridge import (
@@ -47,6 +49,10 @@ from megatron.bridge.models.qwen.qwen35_bridge import (
     Qwen35MoEBridge,
     _apply_qwen35_common_config,
     _apply_qwen35_moe_config,
+)
+from megatron.bridge.models.qwen.qwen_hybrid import (
+    configure_qwen_hybrid_layers,
+    qwen_logical_layer_count,
 )
 from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.model import Qwen3VLModel
 from megatron.bridge.models.qwen_vl.qwen35_vl_provider import (
@@ -164,6 +170,15 @@ class Qwen35VLMoEBridge(MegatronModelBridge):
         >>> provider = bridge.to_megatron_provider()
     """
 
+    @classmethod
+    def megatron_to_hf_config(cls, provider) -> dict:
+        """Restore the logical Qwen layer count when exporting HybridModel config."""
+        hf_config = super().megatron_to_hf_config(provider)
+        logical_layer_count = qwen_logical_layer_count(provider.hybrid_layer_pattern)
+        if logical_layer_count is not None:
+            hf_config["num_hidden_layers"] = logical_layer_count
+        return hf_config
+
     def provider_bridge(self, hf_pretrained: PreTrainedCausalLM) -> Qwen35VLMoEModelProvider:
         """
         Create a Qwen35VLMoEModelProvider from a HuggingFace pretrained model.
@@ -212,6 +227,13 @@ class Qwen35VLMoEBridge(MegatronModelBridge):
         # With partial_rotary_factor=0.25 and head_dim=256, rotary_dim=64,
         # so each pair needs 32 dims total → sections [11, 11, 10].
         provider.mrope_section = getattr(text_config, "rope_scaling", {}).get("mrope_section", [11, 11, 10])
+        configure_qwen_hybrid_layers(
+            provider,
+            num_logical_layers=text_config.num_hidden_layers,
+            mlp_symbols=Symbols.MOE,
+            linear_attention_freq=provider.linear_attention_freq,
+            mtp_mlp_symbol=Symbols.MOE,
+        )
 
         return provider
 
@@ -256,7 +278,11 @@ class Qwen35VLMoEBridge(MegatronModelBridge):
         mapping_list = []
         mapping_list.extend(
             Qwen35MoEBridge._get_moe_lm_mappings(
-                hf_prefix="model.language_model.", megatron_prefix="language_model.", experts_packed=experts_packed
+                self.hf_config.text_config.num_hidden_layers,
+                full_attention_interval_from_hf(self.hf_config.text_config),
+                hf_prefix="model.language_model.",
+                megatron_prefix="language_model.",
+                experts_packed=experts_packed,
             )
         )
         mapping_list.extend(
@@ -299,6 +325,15 @@ class Qwen35VLBridge(MegatronModelBridge):
 
     mimo_source_prefixes = {"language": "language_model.", "images": "vision_model."}
 
+    @classmethod
+    def megatron_to_hf_config(cls, provider) -> dict:
+        """Restore the logical Qwen layer count when exporting HybridModel config."""
+        hf_config = super().megatron_to_hf_config(provider)
+        logical_layer_count = qwen_logical_layer_count(provider.hybrid_layer_pattern)
+        if logical_layer_count is not None:
+            hf_config["num_hidden_layers"] = logical_layer_count
+        return hf_config
+
     def provider_bridge(self, hf_pretrained: PreTrainedCausalLM) -> Qwen35VLModelProvider:
         """Create a Qwen35VLModelProvider from a HuggingFace pretrained model."""
         hf_config = hf_pretrained.config
@@ -330,6 +365,13 @@ class Qwen35VLBridge(MegatronModelBridge):
         provider.image_token_id = getattr(hf_config, "image_token_id", 248056)
         provider.video_token_id = getattr(hf_config, "video_token_id", 248057)
         provider.mrope_section = getattr(text_config, "rope_scaling", {}).get("mrope_section", [11, 11, 10])
+        configure_qwen_hybrid_layers(
+            provider,
+            num_logical_layers=text_config.num_hidden_layers,
+            mlp_symbols=Symbols.MLP,
+            linear_attention_freq=provider.linear_attention_freq,
+            mtp_mlp_symbol=Symbols.MLP,
+        )
 
         return provider
 
@@ -346,7 +388,12 @@ class Qwen35VLBridge(MegatronModelBridge):
         mapping_list = []
 
         mapping_list.extend(
-            Qwen35Bridge._get_dense_lm_mappings(hf_prefix="model.language_model.", megatron_prefix="language_model.")
+            Qwen35Bridge._get_dense_lm_mappings(
+                self.hf_config.text_config.num_hidden_layers,
+                full_attention_interval_from_hf(self.hf_config.text_config),
+                hf_prefix="model.language_model.",
+                megatron_prefix="language_model.",
+            )
         )
         mapping_list.extend(Qwen35Bridge._get_dense_mtp_mappings(megatron_prefix="language_model."))
         mapping_list.extend(_get_vision_mappings())

--- a/src/megatron/bridge/models/qwen_vl/qwen35_vl_provider.py
+++ b/src/megatron/bridge/models/qwen_vl/qwen35_vl_provider.py
@@ -12,40 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Qwen3.5 VL Model Provider configurations for Megatron-Core.
-
-Qwen3.5 is a family of vision-language models that combine:
-- A hybrid Gated DeltaNet (GDN) + Gated Attention language model (like Qwen3-Next)
-- A vision encoder (similar to Qwen3-VL)
-- Dense MLP or Mixture of Experts (MoE) with shared experts
-
-This module provides two model providers:
-
-- ``Qwen35VLModelProvider``: Dense variant (e.g., Qwen3.5-27B)
-  Reference: https://huggingface.co/Qwen/Qwen3.5-27B
-
-- ``Qwen35VLMoEModelProvider``: MoE variant (e.g., Qwen3.5-397B-A17B)
-  Reference: https://huggingface.co/Qwen/Qwen3.5-397B-A17B
-"""
-
-from __future__ import annotations
+"""HybridModel providers for dense and MoE Qwen3.5 vision-language models."""
 
 from dataclasses import dataclass, field
-from typing import Any, Callable, ClassVar, List, Optional
+from typing import Any, ClassVar
 
 import transformers
-from megatron.core.models.gpt import GPTModel as MCoreGPTModel
-from megatron.core.models.gpt.experimental_attention_variant_module_specs import (
-    get_transformer_block_with_experimental_attention_variant_spec,
-)
+from megatron.core.extensions.transformer_engine import TEColumnParallelLinear, TENorm, TERowParallelLinear
+from megatron.core.models.hybrid.hybrid_layer_allocation import Symbols
+from megatron.core.models.vision.vit_layer_specs import get_vit_layer_with_transformer_engine_spec
 from megatron.core.transformer.spec_utils import ModuleSpec
-from megatron.core.transformer.transformer_block import TransformerBlockSubmodules
 from packaging.version import Version as PkgVersion
+
+from megatron.bridge.models.qwen.qwen_hybrid import configure_qwen_hybrid_layers
+from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.attention import Qwen3VLSelfAttention
+from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.text_model import Qwen3VLHybridModel
+from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.transformer_config import get_vision_model_config
+from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.utils import PatchMergerSubmodules
+from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.vision_model import Qwen3VLVisionModel
+from megatron.bridge.models.qwen_vl.qwen3_vl_provider import Qwen3VLModelProvider, Qwen3VLMoEModelProvider
 
 
 _TRANSFORMERS_HAS_QWEN3_5_MOE = PkgVersion(transformers.__version__) >= PkgVersion("5.2.0")
-
 if _TRANSFORMERS_HAS_QWEN3_5_MOE:
     from transformers.models.qwen3_5_moe.configuration_qwen3_5_moe import Qwen3_5MoeVisionConfig
 else:
@@ -59,254 +47,141 @@ except ImportError:
     _TRANSFORMERS_HAS_QWEN3_5 = False
     Qwen3_5VisionConfig = None  # type: ignore[assignment,misc]
 
-from megatron.core.extensions.transformer_engine import (
-    TEColumnParallelLinear,
-    TENorm,
-    TERowParallelLinear,
-)
-from megatron.core.models.vision.vit_layer_specs import get_vit_layer_with_transformer_engine_spec
-
-from megatron.bridge.models.gpt_provider import GPTModelProvider
-from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.attention import Qwen3VLSelfAttention
-from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.model import Qwen3VLModel
-from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.text_model import Qwen3VLGPTModel
-from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.transformer_config import get_vision_model_config
-from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.utils import PatchMergerSubmodules
-from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.vision_model import Qwen3VLVisionModel
-
 
 _QWEN_VISUAL_ENCODER_KEY = "qwen_visual"
 _IMAGES_MODALITY_KEY = "images"
 
 
 def _check_qwen3_5_available() -> None:
-    """Raise a clear error if transformers doesn't have qwen3_5 (dense) support."""
     if not _TRANSFORMERS_HAS_QWEN3_5:
-        raise ImportError(
-            f"Qwen3.5 VL (dense) requires transformers with qwen3_5 model support, "
-            f"but found {transformers.__version__}. "
-            "Please upgrade: pip install --upgrade transformers"
-        )
+        raise ImportError(f"Qwen3.5 VL requires transformers support, but found {transformers.__version__}.")
 
 
 def _check_qwen3_5_moe_available() -> None:
-    """Raise a clear error if transformers doesn't have qwen3_5_moe support."""
     if not _TRANSFORMERS_HAS_QWEN3_5_MOE:
-        raise ImportError(
-            f"Qwen3.5 VL (MoE) requires transformers >= 5.2.0, but found {transformers.__version__}. "
-            "Please upgrade: pip install --upgrade transformers"
+        raise ImportError(f"Qwen3.5 VL MoE requires transformers >= 5.2.0, but found {transformers.__version__}.")
+
+
+class _Qwen35VLMIMOAPI:
+    """MIMO construction helpers shared by dense and MoE providers."""
+
+    @property
+    def special_token_ids(self) -> dict[str, int]:
+        """Return the token ID associated with the image modality."""
+        return {_IMAGES_MODALITY_KEY: self.image_token_id}
+
+    def build_language_spec(self, vp_stage: int | None = None, pp_rank: int | None = None) -> ModuleSpec:
+        """Build the Qwen multimodal Hybrid stack spec."""
+        del vp_stage, pp_rank
+        return self._resolve_hybrid_stack_spec()
+
+    def build_mtp_spec(self, vp_stage: int | None = None) -> None:
+        """Return no separate MTP spec because HybridModel carries it in the stack spec."""
+        del vp_stage
+        return None
+
+    def build_vision_encoder_spec(self) -> ModuleSpec:
+        """Build the Qwen3.5 vision encoder spec used by MIMO."""
+        return _qwen35_build_vision_encoder_spec(self)
+
+    def build_language_model_spec(self, pp_rank: int | None = 0) -> ModuleSpec:
+        """Build the standalone Hybrid language-model spec used by MIMO."""
+        self._ensure_hybrid_pattern()
+        return ModuleSpec(
+            module=Qwen3VLHybridModel,
+            params={
+                "config": self,
+                "hybrid_stack_spec": self.build_language_spec(pp_rank=pp_rank),
+                "vocab_size": self.vocab_size,
+                "max_sequence_length": self.language_max_sequence_length,
+                "hybrid_layer_pattern": self.hybrid_layer_pattern,
+                "fp16_lm_cross_entropy": self.fp16_lm_cross_entropy,
+                "parallel_output": True,
+                "share_embeddings_and_output_weights": self.share_embeddings_and_output_weights,
+                "rotary_percent": self.rotary_percent,
+                "rotary_base": self.rotary_base,
+                "scatter_embedding_sequence_parallel": False,
+            },
         )
 
 
 @dataclass
-class Qwen35VLModelProvider(GPTModelProvider):
-    """
-    Model provider for Qwen3.5 VL Dense (Vision-Language) Models.
-
-    Qwen3.5 dense combines a hybrid GDN (Gated DeltaNet) + Gated Attention language
-    model architecture with a vision encoder (similar to Qwen3-VL) and a standard
-    dense MLP (no Mixture of Experts).
-
-    Key Architecture Details (27B):
-    - 64 layers: 16 groups x (3 GDN + 1 Attention)
-    - Hidden dim: 5120, Intermediate dim: 17408
-    - GDN: 16 QK heads, 48 V heads, head_dim=128
-    - Gated Attention: 24 Q heads, 4 KV heads, head_dim=256
-    - Vision: depth=27, hidden=1152, no deepstack
-    - mRoPE with sections [11, 11, 10], rope_theta=10,000,000
-    - partial_rotary_factor=0.25
-    """
+class Qwen35VLModelProvider(_Qwen35VLMIMOAPI, Qwen3VLModelProvider):
+    """HybridModel provider for dense Qwen3.5 vision-language models."""
 
     modality_keys: ClassVar[dict[str, str]] = {_IMAGES_MODALITY_KEY: _QWEN_VISUAL_ENCODER_KEY}
-
-    # =========================================================================
-    # Hybrid Architecture (Qwen3-Next style)
-    # =========================================================================
-    transformer_layer_spec: ModuleSpec | Callable[["GPTModelProvider"], ModuleSpec] = (
-        get_transformer_block_with_experimental_attention_variant_spec
-    )
+    vision_config: Any = field(default=None)
     layernorm_zero_centered_gamma: bool = True
     attention_output_gate: bool = True
     experimental_attention_variant: str = "gated_delta_net"
     linear_attention_freq: int | list[int] = 4
-
-    # --- Gated DeltaNet (GDN) parameters ---
     linear_conv_kernel_dim: int = 4
     linear_key_head_dim: int = 128
     linear_value_head_dim: int = 128
     linear_num_key_heads: int = 16
     linear_num_value_heads: int = 48
-
-    # =========================================================================
-    # Common LLM parameters
-    # =========================================================================
-    normalization: str = "RMSNorm"
     gated_linear_unit: bool = True
     add_bias_linear: bool = False
     add_qkv_bias: bool = False
-    qk_layernorm: bool = True
     kv_channels: int | None = 256
     num_query_groups: int = 4
-    hidden_dropout: float = 0.0
-    attention_dropout: float = 0.0
-    attention_softmax_in_fp32: bool = True
     rotary_base: float = 10000000.0
     rotary_percent: float = 0.25
     seq_length: int = 262144
-
-    # =========================================================================
-    # VL-specific parameters
-    # =========================================================================
-    vision_config: Any = field(default=None)
-    position_embedding_type: str = "mrope"
-    mrope_section: List[int] = field(default_factory=lambda: [11, 11, 10])
-    apply_rotary_pos_emb_in_fp32: bool = False
-
+    mrope_section: list[int] = field(default_factory=lambda: [11, 11, 10])
     image_token_id: int = 248056
     video_token_id: int = 248057
     vision_start_token_id: int = 248053
     vision_end_token_id: int = 248054
     bos_token_id: int = 248045
     eos_token_id: int = 248044
-
-    spatial_merge_size: int = 2
-    temporal_patch_size: int = 2
-    patch_size: int = 16
-    language_max_sequence_length: int = 2048
-    scatter_embedding_sequence_parallel: bool = False
-
-    # =========================================================================
-    # Freeze options for fine-tuning
-    # =========================================================================
-    freeze_language_model: bool = False
-    freeze_vision_model: bool = False
-    freeze_vision_projection: bool = False
-
-    # =========================================================================
-    # Performance
-    # =========================================================================
-    bias_activation_fusion: bool = True
-    use_hf_vision_model: bool = False
-    vision_dp_when_cp: bool = False
+    deepstack_visual_indexes: list[int] = field(default_factory=list)
     hetereogenous_dist_checkpoint: bool = True
 
-    mtp_num_layers: Optional[int] = None
-
-    @property
-    def special_token_ids(self) -> dict[str, int]:
-        """Return modality token ids."""
-        return {_IMAGES_MODALITY_KEY: self.image_token_id}
-
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         _check_qwen3_5_available()
         if self.vision_config is None:
             self.vision_config = Qwen3_5VisionConfig()
         super().__post_init__()
 
-    def finalize(self) -> None:
-        if (self.context_parallel_size or 1) > 1:
-            self.calculate_per_token_loss = True
-        super().finalize()
-
-    def build_language_spec(
-        self, vp_stage: Optional[int] = None, pp_rank: Optional[int] = None
-    ) -> TransformerBlockSubmodules | ModuleSpec:
-        """Build the language transformer-block spec."""
-        return _qwen35_build_language_block_spec(self, vp_stage, pp_rank)
-
-    def build_mtp_spec(self, vp_stage: Optional[int] = None) -> Optional[TransformerBlockSubmodules | ModuleSpec]:
-        """Build the MTP block spec."""
-        return _qwen35_build_mtp_block_spec(self, vp_stage)
-
-    def build_vision_encoder_spec(self) -> ModuleSpec:
-        """Build the vision encoder spec."""
-        return _qwen35_build_vision_encoder_spec(self)
-
-    def build_language_model_spec(self, pp_rank: Optional[int] = 0) -> ModuleSpec:
-        """Build the language model spec."""
-        return _qwen35_build_language_model_spec(self, pp_rank=pp_rank)
-
-    def provide(self, pre_process=None, post_process=None, vp_stage=None) -> Qwen3VLModel:
-        """Provide a Qwen3.5 VL dense model instance with vision and language components."""
-        language_transformer_config = self
-        hf_vision_config = self.vision_config
-        hf_vision_config.torch_dtype = self.params_dtype
-
-        block_spec = self.build_language_spec(vp_stage=vp_stage)
-        mtp_spec = self.build_mtp_spec(vp_stage=vp_stage)
-
-        model = Qwen3VLModel(
-            language_transformer_config=language_transformer_config,
-            language_transformer_layer_spec=block_spec,
-            vision_transformer_config=hf_vision_config,
-            pre_process=pre_process,
-            post_process=post_process,
-            pg_collection=self._pg_collection,
-            mtp_block_spec=mtp_spec,
-            vp_stage=vp_stage,
-        )
-
-        if self.freeze_language_model or self.freeze_vision_model or self.freeze_vision_projection:
-            model.freeze(
-                freeze_language_model=self.freeze_language_model,
-                freeze_vision_model=self.freeze_vision_model,
-                freeze_vision_projection=self.freeze_vision_projection,
+    def _ensure_hybrid_pattern(self) -> None:
+        if self.hybrid_layer_pattern is None:
+            if self.num_layers is None:
+                raise ValueError("num_layers must be configured for Qwen3.5 VL")
+            configure_qwen_hybrid_layers(
+                self,
+                num_logical_layers=self.num_layers,
+                mlp_symbols=Symbols.MLP,
+                linear_attention_freq=self.linear_attention_freq,
+                mtp_mlp_symbol=Symbols.MLP,
             )
 
-        return model
+    def finalize(self) -> None:
+        self._ensure_hybrid_pattern()
+        super().finalize()
 
-    def provide_language_model(self, pre_process=None, post_process=None, vp_stage=None) -> MCoreGPTModel:
-        """Provide just the language model component without vision."""
-        return GPTModelProvider.provide(self, pre_process=pre_process, post_process=post_process, vp_stage=vp_stage)
+    def provide(self, pre_process=None, post_process=None, vp_stage=None):
+        self._ensure_hybrid_pattern()
+        return super().provide(pre_process, post_process, vp_stage)
 
 
 @dataclass
-class Qwen35VLMoEModelProvider(GPTModelProvider):
-    """
-    Model provider for Qwen 3.5 VL (Vision-Language) Models.
-
-    Qwen 3.5 combines a hybrid GDN (Gated DeltaNet) + Gated Attention language model
-    architecture (like Qwen3-Next) with a vision encoder (similar to Qwen3-VL) and
-    Mixture of Experts (MoE) with shared experts.
-
-    Key Architecture Details (397B-A17B):
-    - 60 layers: 15 groups × (3 GDN-MoE + 1 Attention-MoE)
-    - Hidden dim: 4096, Token Embedding: 248320
-    - GDN: 16 QK heads, 64 V heads, head_dim=128
-    - Gated Attention: 32 Q heads, 2 KV heads, head_dim=256
-    - MoE: 512 experts, 10 routed + 1 shared, expert dim=1024
-    - mRoPE with sections [11, 11, 10], rope_theta=10,000,000
-    - partial_rotary_factor=0.25
-
-    Note: num_query_groups corresponds to num_key_value_heads in HF config (for
-    standard Gated Attention layers). GDN layers have separate head counts.
-    """
+class Qwen35VLMoEModelProvider(_Qwen35VLMIMOAPI, Qwen3VLMoEModelProvider):
+    """HybridModel provider for MoE Qwen3.5 and Qwen3.6 vision-language models."""
 
     modality_keys: ClassVar[dict[str, str]] = {_IMAGES_MODALITY_KEY: _QWEN_VISUAL_ENCODER_KEY}
-
-    # =========================================================================
-    # Hybrid Architecture (Qwen3-Next style)
-    # =========================================================================
-    transformer_layer_spec: ModuleSpec | Callable[["GPTModelProvider"], ModuleSpec] = (
-        get_transformer_block_with_experimental_attention_variant_spec
-    )
+    vision_config: Any = field(default=None)
     layernorm_zero_centered_gamma: bool = True
     attention_output_gate: bool = True
     experimental_attention_variant: str = "gated_delta_net"
-    linear_attention_freq: int | list[int] = 4  # 1 standard attention per 4 layers
-
-    # --- Gated DeltaNet (GDN) parameters ---
+    linear_attention_freq: int | list[int] = 4
     linear_conv_kernel_dim: int = 4
     linear_key_head_dim: int = 128
     linear_value_head_dim: int = 128
     linear_num_key_heads: int = 16
-    linear_num_value_heads: int = 64  # 64 V heads for GDN in 397B model
-
-    # =========================================================================
-    # MoE parameters
-    # =========================================================================
+    linear_num_value_heads: int = 64
     num_moe_experts: int = 512
-    moe_router_topk: int = 10  # 10 routed experts per token
+    moe_router_topk: int = 10
     moe_shared_expert_gate: bool = True
     moe_router_dtype: str = "fp32"
     moe_router_load_balancing_type: str = "global_aux_loss"
@@ -315,207 +190,64 @@ class Qwen35VLMoEModelProvider(GPTModelProvider):
     moe_token_dispatcher_type: str = "alltoall"
     moe_permute_fusion: bool = True
     moe_aux_loss_coeff: float = 1e-3
-
-    # =========================================================================
-    # Common LLM parameters
-    # =========================================================================
-    normalization: str = "RMSNorm"
     gated_linear_unit: bool = True
     add_bias_linear: bool = False
     add_qkv_bias: bool = False
-    qk_layernorm: bool = True
-    kv_channels: int | None = 256  # head_dim for standard Gated Attention
-    num_query_groups: int = 2  # KV heads for standard Gated Attention
-    hidden_dropout: float = 0.0
-    attention_dropout: float = 0.0
-    attention_softmax_in_fp32: bool = True
-    rotary_base: float = 10000000.0  # rope_theta from HF config
-    rotary_percent: float = 0.25  # partial_rotary_factor from HF config
-    seq_length: int = 262144  # 262K native context length
-
-    # =========================================================================
-    # VL-specific parameters
-    # =========================================================================
-
-    vision_config: Any = field(default=None)
-
-    # Position embedding: Qwen3.5 uses multimodal rope (mRoPE)
-    position_embedding_type: str = "mrope"
-    # Qwen3.5 mRoPE section is [11, 11, 10] (different from Qwen3-VL's [24, 20, 20])
-    # because partial_rotary_factor=0.25, so RoPE dim = 256*0.25 = 64, with sections [11,11,10]
-    # for [temporal, height, width] summing to 32 (half of 64 rotary dim).
-    mrope_section: List[int] = field(default_factory=lambda: [11, 11, 10])
-    apply_rotary_pos_emb_in_fp32: bool = False
-
-    # Vision-Language token IDs
+    kv_channels: int | None = 256
+    num_query_groups: int = 2
+    rotary_base: float = 10000000.0
+    rotary_percent: float = 0.25
+    seq_length: int = 262144
+    mrope_section: list[int] = field(default_factory=lambda: [11, 11, 10])
     image_token_id: int = 248056
     video_token_id: int = 248057
     vision_start_token_id: int = 248053
     vision_end_token_id: int = 248054
     bos_token_id: int = 248045
     eos_token_id: int = 248046
-
-    # Vision model settings
-    spatial_merge_size: int = 2
-    temporal_patch_size: int = 2
-    patch_size: int = 16
-    language_max_sequence_length: int = 2048
-
-    scatter_embedding_sequence_parallel: bool = False
-
-    # =========================================================================
-    # Freeze options for fine-tuning
-    # =========================================================================
-    freeze_language_model: bool = False
-    freeze_vision_model: bool = False
-    freeze_vision_projection: bool = False
-
-    # =========================================================================
-    # Performance
-    # =========================================================================
-    bias_activation_fusion: bool = True
-    use_hf_vision_model: bool = False
-    vision_dp_when_cp: bool = False
-
-    # Heterogeneous dist checkpoint (needed for hybrid architecture)
+    deepstack_visual_indexes: list[int] = field(default_factory=list)
     hetereogenous_dist_checkpoint: bool = True
 
-    mtp_num_layers: Optional[int] = None
-
-    @property
-    def special_token_ids(self) -> dict[str, int]:
-        """Return modality token ids."""
-        return {_IMAGES_MODALITY_KEY: self.image_token_id}
-
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         _check_qwen3_5_moe_available()
         if self.vision_config is None:
             self.vision_config = Qwen3_5MoeVisionConfig()
         super().__post_init__()
 
-    def finalize(self) -> None:
-        if (self.context_parallel_size or 1) > 1:
-            self.calculate_per_token_loss = True
-        super().finalize()
-
-    def build_language_spec(
-        self, vp_stage: Optional[int] = None, pp_rank: Optional[int] = None
-    ) -> TransformerBlockSubmodules | ModuleSpec:
-        """Build the language transformer-block spec."""
-        return _qwen35_build_language_block_spec(self, vp_stage, pp_rank)
-
-    def build_mtp_spec(self, vp_stage: Optional[int] = None) -> Optional[TransformerBlockSubmodules | ModuleSpec]:
-        """Build the MTP block spec (or ``None`` when MTP is disabled)."""
-        return _qwen35_build_mtp_block_spec(self, vp_stage)
-
-    def build_vision_encoder_spec(self) -> ModuleSpec:
-        """Build the vision encoder spec."""
-        return _qwen35_build_vision_encoder_spec(self)
-
-    def build_language_model_spec(self, pp_rank: Optional[int] = 0) -> ModuleSpec:
-        """Build the language model spec."""
-        return _qwen35_build_language_model_spec(self, pp_rank=pp_rank)
-
-    def provide(self, pre_process=None, post_process=None, vp_stage=None) -> Qwen3VLModel:
-        """Provide a Qwen3.5 VL model instance with vision and language components."""
-        language_transformer_config = self
-        hf_vision_config = self.vision_config
-        hf_vision_config.torch_dtype = self.params_dtype
-
-        block_spec = self.build_language_spec(vp_stage=vp_stage)
-        mtp_spec = self.build_mtp_spec(vp_stage=vp_stage)
-
-        model = Qwen3VLModel(
-            language_transformer_config=language_transformer_config,
-            language_transformer_layer_spec=block_spec,
-            vision_transformer_config=hf_vision_config,
-            pre_process=pre_process,
-            post_process=post_process,
-            pg_collection=self._pg_collection,
-            mtp_block_spec=mtp_spec,
-            vp_stage=vp_stage,
-        )
-
-        # Apply freeze options if any are enabled for fine-tuning
-        if self.freeze_language_model or self.freeze_vision_model or self.freeze_vision_projection:
-            model.freeze(
-                freeze_language_model=self.freeze_language_model,
-                freeze_vision_model=self.freeze_vision_model,
-                freeze_vision_projection=self.freeze_vision_projection,
+    def _ensure_hybrid_pattern(self) -> None:
+        if self.hybrid_layer_pattern is None:
+            if self.num_layers is None:
+                raise ValueError("num_layers must be configured for Qwen3.5 VL MoE")
+            configure_qwen_hybrid_layers(
+                self,
+                num_logical_layers=self.num_layers,
+                mlp_symbols=Symbols.MOE,
+                linear_attention_freq=self.linear_attention_freq,
+                mtp_mlp_symbol=Symbols.MOE,
             )
 
-        return model
+    def finalize(self) -> None:
+        self._ensure_hybrid_pattern()
+        super().finalize()
 
-    def provide_language_model(self, pre_process=None, post_process=None, vp_stage=None) -> MCoreGPTModel:
-        """Provide just the language model component without vision."""
-        return GPTModelProvider.provide(self, pre_process=pre_process, post_process=post_process, vp_stage=vp_stage)
-
-
-def _qwen35_build_language_block_spec(
-    provider: GPTModelProvider,
-    vp_stage: Optional[int],
-    pp_rank: Optional[int] = None,
-) -> TransformerBlockSubmodules | ModuleSpec:
-    """Build the language transformer-block spec."""
-    block_spec = get_transformer_block_with_experimental_attention_variant_spec(
-        provider,
-        vp_stage=vp_stage,
-        pp_rank=pp_rank,
-    )
-    _patch_standard_attention_specs(block_spec, Qwen3VLSelfAttention)
-    return block_spec
+    def provide(self, pre_process=None, post_process=None, vp_stage=None):
+        self._ensure_hybrid_pattern()
+        return super().provide(pre_process, post_process, vp_stage)
 
 
-def _qwen35_build_mtp_block_spec(
-    provider: GPTModelProvider,
-    vp_stage: Optional[int],
-) -> Optional[TransformerBlockSubmodules | ModuleSpec]:
-    """Build the MTP block spec."""
-    from megatron.bridge.models.gpt_provider import mtp_block_spec
-
-    mtp_spec = mtp_block_spec(provider, vp_stage=vp_stage)
-    _patch_standard_attention_specs(mtp_spec, Qwen3VLSelfAttention)
-    return mtp_spec
-
-
-def _qwen35_build_language_model_spec(provider: GPTModelProvider, pp_rank: Optional[int] = 0) -> ModuleSpec:
-    """Build the Qwen3VL language model spec."""
-    return ModuleSpec(
-        module=Qwen3VLGPTModel,
-        params={
-            "config": provider,
-            "transformer_layer_spec": provider.build_language_spec(pp_rank=pp_rank),
-            "vocab_size": provider.vocab_size,
-            "max_sequence_length": provider.language_max_sequence_length,
-            "fp16_lm_cross_entropy": provider.fp16_lm_cross_entropy,
-            "parallel_output": True,
-            "share_embeddings_and_output_weights": provider.share_embeddings_and_output_weights,
-            "position_embedding_type": "mrope",
-            "rotary_percent": provider.rotary_percent,
-            "rotary_base": provider.rotary_base,
-            "scatter_embedding_sequence_parallel": False,
-            "mtp_block_spec": None,
-        },
-    )
-
-
-def _qwen35_build_vision_encoder_spec(provider: GPTModelProvider) -> ModuleSpec:
-    """Build the Qwen3VL vision encoder spec."""
+def _qwen35_build_vision_encoder_spec(provider) -> ModuleSpec:
     if getattr(provider, "use_hf_vision_model", False):
         raise ValueError("use_hf_vision_model is not supported for Qwen3VLVisionModel")
-
-    vision_transformer_layer_spec = get_vit_layer_with_transformer_engine_spec()
-    vision_transformer_layer_spec.submodules.self_attention.module = Qwen3VLSelfAttention
-
-    megatron_vision_transformer_config = get_vision_model_config(provider.vision_config, megatron_config=provider)
-    megatron_vision_transformer_config.pipeline_model_parallel_size = 1
-    megatron_vision_transformer_config.first_pipeline_num_layers = None
-
+    vision_layer_spec = get_vit_layer_with_transformer_engine_spec()
+    vision_layer_spec.submodules.self_attention.module = Qwen3VLSelfAttention
+    vision_config = get_vision_model_config(provider.vision_config, megatron_config=provider)
+    vision_config.pipeline_model_parallel_size = 1
+    vision_config.first_pipeline_num_layers = None
     return ModuleSpec(
         module=Qwen3VLVisionModel,
         params={
-            "transformer_config": megatron_vision_transformer_config,
-            "transformer_layer_spec": vision_transformer_layer_spec,
+            "transformer_config": vision_config,
+            "transformer_layer_spec": vision_layer_spec,
             "patch_merger_spec": PatchMergerSubmodules(
                 patch_norm=TENorm,
                 linear_fc1=TEColumnParallelLinear,
@@ -525,55 +257,3 @@ def _qwen35_build_vision_encoder_spec(provider: GPTModelProvider) -> ModuleSpec:
             "post_process": True,
         },
     )
-
-
-def _patch_standard_attention_specs(
-    block_spec: Optional[TransformerBlockSubmodules | ModuleSpec],
-    attention_cls,
-) -> None:
-    """Selectively replace standard self-attention specs with ``attention_cls``.
-
-    This handles both the main decoder block spec and the nested TransformerLayer
-    spec stored inside MTP block specs.
-
-    In a hybrid block spec, each layer spec has a different self_attention submodule:
-    - Standard attention layers have a ``SelfAttention``-like module.
-    - GDN layers have a ``GatedDeltaNet``-like module.
-
-    This function patches only the standard attention layers with *attention_cls*
-    (e.g. ``Qwen3VLSelfAttention`` for mRoPE support), leaving GDN layers unchanged.
-
-    Detection heuristic: GDN layer specs have ``GatedDeltaNet`` (or similar) as the
-    self_attention module, which does NOT have a ``linear_qkv`` submodule. Standard
-    attention specs DO have ``linear_qkv``. We use this to distinguish them.
-    """
-    from megatron.core.transformer.attention import SelfAttention
-
-    if block_spec is None:
-        return
-
-    if hasattr(block_spec, "layer_specs"):
-        for layer_spec in block_spec.layer_specs:
-            _patch_standard_attention_specs(layer_spec, attention_cls)
-        return
-
-    if not isinstance(block_spec, ModuleSpec):
-        return
-
-    submodules = getattr(block_spec, "submodules", None)
-    if submodules is None:
-        return
-
-    if hasattr(submodules, "mtp_model_layer"):
-        _patch_standard_attention_specs(submodules.mtp_model_layer, attention_cls)
-
-    if not hasattr(submodules, "self_attention"):
-        return
-
-    attn_spec = submodules.self_attention
-    # Standard attention specs use SelfAttention (or a subclass) as the module.
-    # and have linear_qkv in their submodules. GDN specs use GatedDeltaNet.
-    if attn_spec.module is SelfAttention or (
-        isinstance(attn_spec.module, type) and issubclass(attn_spec.module, SelfAttention)
-    ):
-        attn_spec.module = attention_cls

--- a/src/megatron/bridge/models/qwen_vl/qwen3_vl_bridge.py
+++ b/src/megatron/bridge/models/qwen_vl/qwen3_vl_bridge.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import torch
+from megatron.core.models.hybrid.hybrid_layer_allocation import Symbols
 from transformers import Qwen3VLForConditionalGeneration, Qwen3VLMoeForConditionalGeneration
 
 from megatron.bridge.models.conversion.mapping_registry import MegatronMappingRegistry
@@ -28,8 +29,129 @@ from megatron.bridge.models.conversion.transformers_compat import rope_theta_fro
 from megatron.bridge.models.conversion.utils import moe_experts_stored_packed
 from megatron.bridge.models.hf_pretrained.causal_lm import PreTrainedCausalLM
 from megatron.bridge.models.qwen.qwen35_bridge import _moe_routed_expert_mappings
+from megatron.bridge.models.qwen.qwen_hybrid import (
+    configure_qwen_hybrid_layers,
+    qwen_logical_layer_count,
+    qwen_moe_layer_symbols,
+    qwen_physical_layer_indices,
+)
 from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.model import Qwen3VLModel
 from megatron.bridge.models.qwen_vl.qwen3_vl_provider import Qwen3VLModelProvider, Qwen3VLMoEModelProvider
+
+
+def _vision_mappings() -> list:
+    direct_mappings = {
+        "vision_model.decoder.layers.*.self_attention.linear_proj.weight": "model.visual.blocks.*.attn.proj.weight",
+        "vision_model.decoder.layers.*.self_attention.linear_proj.bias": "model.visual.blocks.*.attn.proj.bias",
+        "vision_model.decoder.layers.*.mlp.linear_fc1.weight": "model.visual.blocks.*.mlp.linear_fc1.weight",
+        "vision_model.decoder.layers.*.mlp.linear_fc1.bias": "model.visual.blocks.*.mlp.linear_fc1.bias",
+        "vision_model.decoder.layers.*.mlp.linear_fc2.weight": "model.visual.blocks.*.mlp.linear_fc2.weight",
+        "vision_model.decoder.layers.*.mlp.linear_fc2.bias": "model.visual.blocks.*.mlp.linear_fc2.bias",
+        "vision_model.decoder.layers.*.self_attention.linear_qkv.layer_norm_weight": "model.visual.blocks.*.norm1.weight",
+        "vision_model.decoder.layers.*.self_attention.linear_qkv.layer_norm_bias": "model.visual.blocks.*.norm1.bias",
+        "vision_model.decoder.layers.*.mlp.linear_fc1.layer_norm_weight": "model.visual.blocks.*.norm2.weight",
+        "vision_model.decoder.layers.*.mlp.linear_fc1.layer_norm_bias": "model.visual.blocks.*.norm2.bias",
+        "vision_model.decoder.deepstack_merger_list.*.patch_norm.weight": "model.visual.deepstack_merger_list.*.norm.weight",
+        "vision_model.decoder.deepstack_merger_list.*.patch_norm.bias": "model.visual.deepstack_merger_list.*.norm.bias",
+        "vision_model.decoder.deepstack_merger_list.*.linear_fc1.weight": "model.visual.deepstack_merger_list.*.linear_fc1.weight",
+        "vision_model.decoder.deepstack_merger_list.*.linear_fc1.bias": "model.visual.deepstack_merger_list.*.linear_fc1.bias",
+        "vision_model.decoder.deepstack_merger_list.*.linear_fc2.weight": "model.visual.deepstack_merger_list.*.linear_fc2.weight",
+        "vision_model.decoder.deepstack_merger_list.*.linear_fc2.bias": "model.visual.deepstack_merger_list.*.linear_fc2.bias",
+        "vision_model.merger.patch_norm.**": "model.visual.merger.norm.**",
+        "vision_model.merger.linear_fc1.weight": "model.visual.merger.linear_fc1.weight",
+        "vision_model.merger.linear_fc1.bias": "model.visual.merger.linear_fc1.bias",
+        "vision_model.merger.linear_fc2.weight": "model.visual.merger.linear_fc2.weight",
+        "vision_model.merger.linear_fc2.bias": "model.visual.merger.linear_fc2.bias",
+    }
+    mappings = [AutoMapping(k, v) for k, v in direct_mappings.items()]
+    mappings.extend(
+        [
+            ConcatenatedQKVMapping(
+                "vision_model.decoder.layers.*.self_attention.linear_qkv.weight",
+                "model.visual.blocks.*.attn.qkv.weight",
+            ),
+            ConcatenatedQKVMapping(
+                "vision_model.decoder.layers.*.self_attention.linear_qkv.bias",
+                "model.visual.blocks.*.attn.qkv.bias",
+            ),
+            ReplicatedMapping("vision_model.patch_embed.proj.**", "model.visual.patch_embed.proj.**"),
+            ReplicatedMapping("vision_model.pos_embed.weight", "model.visual.pos_embed.weight"),
+        ]
+    )
+    return mappings
+
+
+def _attention_mappings(logical_layer_idx: int, attention_layer_idx: int) -> list:
+    hf_layer = f"model.language_model.layers.{logical_layer_idx}"
+    attention_layer = f"language_model.decoder.layers.{attention_layer_idx}.self_attention"
+    return [
+        AutoMapping(f"{attention_layer}.linear_qkv.layer_norm_weight", f"{hf_layer}.input_layernorm.weight"),
+        AutoMapping(f"{attention_layer}.linear_proj.weight", f"{hf_layer}.self_attn.o_proj.weight"),
+        AutoMapping(f"{attention_layer}.q_layernorm.weight", f"{hf_layer}.self_attn.q_norm.weight"),
+        AutoMapping(f"{attention_layer}.k_layernorm.weight", f"{hf_layer}.self_attn.k_norm.weight"),
+        QKVMapping(
+            megatron_param=f"{attention_layer}.linear_qkv.weight",
+            q=f"{hf_layer}.self_attn.q_proj.weight",
+            k=f"{hf_layer}.self_attn.k_proj.weight",
+            v=f"{hf_layer}.self_attn.v_proj.weight",
+        ),
+        QKVMapping(
+            megatron_param=f"{attention_layer}.linear_qkv.bias",
+            q=f"{hf_layer}.self_attn.q_proj.bias",
+            k=f"{hf_layer}.self_attn.k_proj.bias",
+            v=f"{hf_layer}.self_attn.v_proj.bias",
+        ),
+    ]
+
+
+def _dense_mlp_mappings(logical_layer_idx: int, mlp_layer_idx: int) -> list:
+    hf_layer = f"model.language_model.layers.{logical_layer_idx}"
+    mlp_layer = f"language_model.decoder.layers.{mlp_layer_idx}.mlp"
+    return [
+        AutoMapping(f"{mlp_layer}.linear_fc1.layer_norm_weight", f"{hf_layer}.post_attention_layernorm.weight"),
+        AutoMapping(f"{mlp_layer}.linear_fc2.weight", f"{hf_layer}.mlp.down_proj.weight"),
+        GatedMLPMapping(
+            megatron_param=f"{mlp_layer}.linear_fc1.weight",
+            gate=f"{hf_layer}.mlp.gate_proj.weight",
+            up=f"{hf_layer}.mlp.up_proj.weight",
+        ),
+    ]
+
+
+def _moe_mlp_mappings(logical_layer_idx: int, moe_layer_idx: int, *, experts_packed: bool) -> list:
+    hf_layer = f"model.language_model.layers.{logical_layer_idx}"
+    moe_layer = f"language_model.decoder.layers.{moe_layer_idx}"
+    return [
+        AutoMapping(f"{moe_layer}.pre_mlp_layernorm.weight", f"{hf_layer}.post_attention_layernorm.weight"),
+        AutoMapping(f"{moe_layer}.mlp.router.weight", f"{hf_layer}.mlp.gate.weight"),
+        *_moe_routed_expert_mappings(
+            hf_layer,
+            moe_layer,
+            experts_packed,
+            transpose_on_export=True,
+        ),
+    ]
+
+
+class _Qwen3VLBridgeMixin:
+    @classmethod
+    def megatron_to_hf_config(cls, provider) -> dict:
+        hf_config = super().megatron_to_hf_config(provider)
+        logical_layer_count = qwen_logical_layer_count(provider.hybrid_layer_pattern)
+        if logical_layer_count is not None:
+            hf_config["num_hidden_layers"] = logical_layer_count
+        return hf_config
+
+    @staticmethod
+    def _base_language_mappings() -> list:
+        return [
+            AutoMapping(
+                "language_model.embedding.word_embeddings.weight",
+                "model.language_model.embed_tokens.weight",
+            ),
+            AutoMapping("language_model.output_layer.weight", "lm_head.weight"),
+            AutoMapping("language_model.decoder.final_norm.weight", "model.language_model.norm.weight"),
+        ]
 
 
 @MegatronModelBridge.register_bridge(
@@ -38,48 +160,17 @@ from megatron.bridge.models.qwen_vl.qwen3_vl_provider import Qwen3VLModelProvide
     provider=Qwen3VLModelProvider,
     model_type="qwen3_vl",
 )
-class Qwen3VLBridge(MegatronModelBridge):
-    """
-    Megatron Bridge for Qwen3-VL Conditional Generation.
-
-    This bridge handles the conversion between HuggingFace Qwen3VLForConditionalGeneration
-    and Megatron-Core Qwen3VLModel formats, including weight mappings and
-    configuration translation for vision-language models.
-
-    The weight mappings are based on the yan-mbridge implementation which defines:
-    - Vision model direct mappings
-    - Vision attention layer mappings
-    - Vision MLP layer mappings
-    - Language model mappings
-    - Deepstack visual merger mappings
-
-    Example:
-        >>> from megatron.bridge import AutoBridge
-        >>> bridge = AutoBridge.from_hf_pretrained("Qwen/Qwen3-VL-8B-Instruct")
-        >>> provider = bridge.to_megatron_provider()
-    """
+class Qwen3VLBridge(_Qwen3VLBridgeMixin, MegatronModelBridge):
+    """Megatron Bridge for dense Qwen3-VL conditional generation."""
 
     def provider_bridge(self, hf_pretrained: PreTrainedCausalLM) -> Qwen3VLModelProvider:
-        """
-        Create a Qwen3VLModelProvider from a HuggingFace pretrained model.
-
-        Args:
-            hf_pretrained: HuggingFace pretrained VLM model
-
-        Returns:
-            Qwen3VLModelProvider configured with the HF model's parameters
-        """
         hf_config = hf_pretrained.config
         text_config = hf_config.text_config
-
         provider_kwargs = self.hf_config_to_provider_kwargs(text_config)
-
         vision_config = hf_config.vision_config
         vision_config.torch_dtype = provider_kwargs.get("params_dtype", torch.float32)
-
         provider = Qwen3VLModelProvider(**provider_kwargs)
 
-        # Qwen3-specific settings
         provider.normalization = "RMSNorm"
         provider.gated_linear_unit = True
         provider.add_qkv_bias = text_config.attention_bias
@@ -87,12 +178,7 @@ class Qwen3VLBridge(MegatronModelBridge):
         provider.qk_layernorm = True
         provider.hidden_dropout = 0.0
         provider.rotary_base = rope_theta_from_hf(text_config)
-
-        # For VLMs, tie_word_embeddings lives on the top-level config, not text_config.
-        # text_config inherits PretrainedConfig's default of True which is wrong.
         provider.share_embeddings_and_output_weights = getattr(hf_config, "tie_word_embeddings", False)
-
-        # VL-specific overrides
         provider.position_embedding_type = "mrope"
         provider.vision_config = vision_config
         provider.hf_text_config = text_config
@@ -105,97 +191,22 @@ class Qwen3VLBridge(MegatronModelBridge):
         provider.video_token_id = getattr(hf_config, "video_token_id", 151656)
         rope_cfg = getattr(text_config, "rope_parameters", None) or getattr(text_config, "rope_scaling", {})
         provider.mrope_section = rope_cfg.get("mrope_section", [24, 20, 20])
-
+        configure_qwen_hybrid_layers(
+            provider,
+            num_logical_layers=text_config.num_hidden_layers,
+            mlp_symbols=Symbols.MLP,
+            mtp_mlp_symbol=Symbols.MLP,
+        )
         return provider
 
     def mapping_registry(self) -> MegatronMappingRegistry:
-        param_mappings = {
-            "language_model.embedding.word_embeddings.weight": "model.language_model.embed_tokens.weight",
-            "language_model.output_layer.weight": "lm_head.weight",
-            "language_model.decoder.final_layernorm.weight": "model.language_model.norm.weight",
-            "language_model.decoder.layers.*.self_attention.linear_qkv.layer_norm_weight": "model.language_model.layers.*.input_layernorm.weight",
-            "language_model.decoder.layers.*.mlp.linear_fc1.layer_norm_weight": "model.language_model.layers.*.post_attention_layernorm.weight",
-            "language_model.decoder.layers.*.self_attention.linear_proj.weight": "model.language_model.layers.*.self_attn.o_proj.weight",
-            "language_model.decoder.layers.*.mlp.linear_fc2.weight": "model.language_model.layers.*.mlp.down_proj.weight",
-            "language_model.decoder.layers.*.self_attention.q_layernorm.weight": "model.language_model.layers.*.self_attn.q_norm.weight",
-            "language_model.decoder.layers.*.self_attention.k_layernorm.weight": "model.language_model.layers.*.self_attn.k_norm.weight",
-            # vision module attn
-            "vision_model.decoder.layers.*.self_attention.linear_proj.weight": "model.visual.blocks.*.attn.proj.weight",
-            "vision_model.decoder.layers.*.self_attention.linear_proj.bias": "model.visual.blocks.*.attn.proj.bias",
-            # vision module mlp
-            "vision_model.decoder.layers.*.mlp.linear_fc1.weight": "model.visual.blocks.*.mlp.linear_fc1.weight",
-            "vision_model.decoder.layers.*.mlp.linear_fc1.bias": "model.visual.blocks.*.mlp.linear_fc1.bias",
-            "vision_model.decoder.layers.*.mlp.linear_fc2.weight": "model.visual.blocks.*.mlp.linear_fc2.weight",
-            "vision_model.decoder.layers.*.mlp.linear_fc2.bias": "model.visual.blocks.*.mlp.linear_fc2.bias",
-            # vision module norm
-            "vision_model.decoder.layers.*.self_attention.linear_qkv.layer_norm_weight": "model.visual.blocks.*.norm1.weight",
-            "vision_model.decoder.layers.*.self_attention.linear_qkv.layer_norm_bias": "model.visual.blocks.*.norm1.bias",
-            "vision_model.decoder.layers.*.mlp.linear_fc1.layer_norm_weight": "model.visual.blocks.*.norm2.weight",
-            "vision_model.decoder.layers.*.mlp.linear_fc1.layer_norm_bias": "model.visual.blocks.*.norm2.bias",
-            # # vision module deepstack merger
-            "vision_model.decoder.deepstack_merger_list.*.patch_norm.weight": "model.visual.deepstack_merger_list.*.norm.weight",
-            "vision_model.decoder.deepstack_merger_list.*.patch_norm.bias": "model.visual.deepstack_merger_list.*.norm.bias",
-            "vision_model.decoder.deepstack_merger_list.*.linear_fc1.weight": "model.visual.deepstack_merger_list.*.linear_fc1.weight",
-            "vision_model.decoder.deepstack_merger_list.*.linear_fc1.bias": "model.visual.deepstack_merger_list.*.linear_fc1.bias",
-            "vision_model.decoder.deepstack_merger_list.*.linear_fc2.weight": "model.visual.deepstack_merger_list.*.linear_fc2.weight",
-            "vision_model.decoder.deepstack_merger_list.*.linear_fc2.bias": "model.visual.deepstack_merger_list.*.linear_fc2.bias",
-            # vision module merger
-            "vision_model.merger.patch_norm.**": "model.visual.merger.norm.**",
-            "vision_model.merger.linear_fc1.weight": "model.visual.merger.linear_fc1.weight",
-            "vision_model.merger.linear_fc1.bias": "model.visual.merger.linear_fc1.bias",
-            "vision_model.merger.linear_fc2.weight": "model.visual.merger.linear_fc2.weight",
-            "vision_model.merger.linear_fc2.bias": "model.visual.merger.linear_fc2.bias",
-        }
-
-        mapping_list = []
-
-        # Convert simple 1:1 mappings to AutoMapping objects
-        for megatron_param, hf_param in param_mappings.items():
-            mapping_list.append(AutoMapping(megatron_param=megatron_param, hf_param=hf_param))
-
-        # Add special mappings that require parameter transformation
-        mapping_list.extend(
-            [
-                # QKV mapping: Combine separate Q, K, V matrices into single QKV matrix
-                QKVMapping(
-                    megatron_param="language_model.decoder.layers.*.self_attention.linear_qkv.weight",
-                    q="model.language_model.layers.*.self_attn.q_proj.weight",
-                    k="model.language_model.layers.*.self_attn.k_proj.weight",
-                    v="model.language_model.layers.*.self_attn.v_proj.weight",
-                ),
-                # QKV bias mapping (if attention_bias is True)
-                QKVMapping(
-                    megatron_param="language_model.decoder.layers.*.self_attention.linear_qkv.bias",
-                    q="model.language_model.layers.*.self_attn.q_proj.bias",
-                    k="model.language_model.layers.*.self_attn.k_proj.bias",
-                    v="model.language_model.layers.*.self_attn.v_proj.bias",
-                ),
-                # Gated MLP: Combine gate and up projection matrices into single FC1 matrix
-                GatedMLPMapping(
-                    megatron_param="language_model.decoder.layers.*.mlp.linear_fc1.weight",
-                    gate="model.language_model.layers.*.mlp.gate_proj.weight",
-                    up="model.language_model.layers.*.mlp.up_proj.weight",
-                ),
-                ConcatenatedQKVMapping(
-                    megatron_param="vision_model.decoder.layers.*.self_attention.linear_qkv.weight",
-                    hf_param="model.visual.blocks.*.attn.qkv.weight",
-                ),
-                ConcatenatedQKVMapping(
-                    megatron_param="vision_model.decoder.layers.*.self_attention.linear_qkv.bias",
-                    hf_param="model.visual.blocks.*.attn.qkv.bias",
-                ),
-                ReplicatedMapping(
-                    megatron_param="vision_model.patch_embed.proj.**",
-                    hf_param="model.visual.patch_embed.proj.**",
-                ),
-                ReplicatedMapping(
-                    megatron_param="vision_model.pos_embed.weight",
-                    hf_param="model.visual.pos_embed.weight",
-                ),
-            ]
-        )
-
-        return MegatronMappingRegistry(*mapping_list)
+        mappings = self._base_language_mappings()
+        for logical_layer_idx in range(self.hf_config.text_config.num_hidden_layers):
+            attention_layer_idx, mlp_layer_idx = qwen_physical_layer_indices(logical_layer_idx)
+            mappings.extend(_attention_mappings(logical_layer_idx, attention_layer_idx))
+            mappings.extend(_dense_mlp_mappings(logical_layer_idx, mlp_layer_idx))
+        mappings.extend(_vision_mappings())
+        return MegatronMappingRegistry(*mappings)
 
 
 @MegatronModelBridge.register_bridge(
@@ -204,41 +215,17 @@ class Qwen3VLBridge(MegatronModelBridge):
     provider=Qwen3VLMoEModelProvider,
     model_type="qwen3_vl_moe",
 )
-class Qwen3VLMoEBridge(MegatronModelBridge):
-    """
-    Megatron Bridge for Qwen3-VL MoE (Mixture of Experts) Conditional Generation.
-
-    This bridge handles the conversion between HuggingFace Qwen3VLMoEForConditionalGeneration
-    and Megatron-Core Qwen3VL MoE model formats, including weight mappings and
-    configuration translation for vision-language MoE models.
-
-    The weight mappings handle:
-    - Vision model weights (same as dense model)
-    - Language model MoE layers with expert routing
-    - Shared embeddings and output layers
-    - QK layernorm specific to Qwen3 architecture
-
-    This bridge works with any Qwen3VL MoE model size and automatically extracts
-    the MoE configuration from the HuggingFace model.
-
-    Example:
-        >>> from megatron.bridge import AutoBridge
-        >>> bridge = AutoBridge.from_hf_pretrained("Qwen/Qwen3-VL-30B-A3B-Instruct")
-        >>> provider = bridge.to_megatron_provider()
-    """
+class Qwen3VLMoEBridge(_Qwen3VLBridgeMixin, MegatronModelBridge):
+    """Megatron Bridge for Qwen3-VL MoE conditional generation."""
 
     def provider_bridge(self, hf_pretrained: PreTrainedCausalLM) -> Qwen3VLMoEModelProvider:
         hf_config = hf_pretrained.config
         text_config = hf_config.text_config
-
         provider_kwargs = self.hf_config_to_provider_kwargs(text_config)
-
         vision_config = hf_config.vision_config
         vision_config.torch_dtype = provider_kwargs.get("params_dtype", torch.float32)
-
         provider = Qwen3VLMoEModelProvider(**provider_kwargs)
 
-        # Qwen3 MoE-specific settings
         provider.normalization = "RMSNorm"
         provider.gated_linear_unit = True
         provider.add_qkv_bias = text_config.attention_bias
@@ -246,11 +233,7 @@ class Qwen3VLMoEBridge(MegatronModelBridge):
         provider.qk_layernorm = True
         provider.hidden_dropout = 0.0
         provider.rotary_base = rope_theta_from_hf(text_config)
-
-        # For VLMs, tie_word_embeddings lives on the top-level config, not text_config.
         provider.share_embeddings_and_output_weights = getattr(hf_config, "tie_word_embeddings", False)
-
-        # MoE specific parameters
         provider.moe_ffn_hidden_size = text_config.moe_intermediate_size
         provider.num_moe_experts = text_config.num_experts
         provider.moe_router_topk = text_config.num_experts_per_tok
@@ -262,13 +245,13 @@ class Qwen3VLMoEBridge(MegatronModelBridge):
         provider.moe_router_pre_softmax = False
         provider.moe_token_dispatcher_type = "alltoall"
         provider.moe_permute_fusion = True
-
-        # VL-specific overrides
         provider.position_embedding_type = "mrope"
         provider.vision_config = vision_config
         provider.hf_text_config = text_config
         provider.head_dim = getattr(
-            text_config, "head_dim", text_config.hidden_size // text_config.num_attention_heads
+            text_config,
+            "head_dim",
+            text_config.hidden_size // text_config.num_attention_heads,
         )
         provider.bos_token_id = getattr(text_config, "bos_token_id", 151643)
         provider.eos_token_id = getattr(text_config, "eos_token_id", 151645)
@@ -278,122 +261,43 @@ class Qwen3VLMoEBridge(MegatronModelBridge):
         provider.video_token_id = getattr(hf_config, "video_token_id", 151656)
         rope_cfg = getattr(text_config, "rope_parameters", None) or getattr(text_config, "rope_scaling", {})
         provider.mrope_section = rope_cfg.get("mrope_section", [24, 20, 20])
-
+        mlp_symbols = qwen_moe_layer_symbols(
+            text_config.num_hidden_layers,
+            decoder_sparse_step=provider.decoder_sparse_step,
+            mlp_only_layers=provider.mlp_only_layers,
+        )
+        configure_qwen_hybrid_layers(
+            provider,
+            num_logical_layers=text_config.num_hidden_layers,
+            mlp_symbols=mlp_symbols,
+            mtp_mlp_symbol=Symbols.MOE,
+        )
         return provider
 
     def mapping_registry(self) -> MegatronMappingRegistry:
-        """
-        Return MegatronMappingRegistry containing parameter mappings for MoE models.
-
-        The MoE mappings include:
-        1. Standard language model mappings (embeddings, layer norms, output)
-        2. Vision model mappings (same as dense model)
-        3. QKV mappings with QK layernorm
-        4. MoE-specific mappings:
-           - Router weights for expert selection
-           - Expert MLPs (multiple experts per layer)
-           - Pre-MLP layernorm
-        5. Deepstack visual merger mappings
-
-        Returns:
-            MegatronMappingRegistry with all MoE parameter mappings
-        """
-        # Language model direct mappings (same as dense model)
-        param_mappings = {
-            # Embeddings and output layers
-            "language_model.embedding.word_embeddings.weight": "model.language_model.embed_tokens.weight",
-            "language_model.output_layer.weight": "lm_head.weight",
-            "language_model.decoder.final_layernorm.weight": "model.language_model.norm.weight",
-            # Layer normalization for attention (TE format - fused into linear)
-            "language_model.decoder.layers.*.self_attention.linear_qkv.layer_norm_weight": "model.language_model.layers.*.input_layernorm.weight",
-            # Layer normalization (non-TE/quantization format - separate modules)
-            "language_model.decoder.layers.*.input_layernorm.weight": "model.language_model.layers.*.input_layernorm.weight",
-            # MoE-specific: pre-MLP layernorm (already in non-TE format for MoE)
-            "language_model.decoder.layers.*.pre_mlp_layernorm.weight": "model.language_model.layers.*.post_attention_layernorm.weight",
-            # Attention output projection
-            "language_model.decoder.layers.*.self_attention.linear_proj.weight": "model.language_model.layers.*.self_attn.o_proj.weight",
-            # QK layernorm weights (Qwen3 specific)
-            "language_model.decoder.layers.*.self_attention.q_layernorm.weight": "model.language_model.layers.*.self_attn.q_norm.weight",
-            "language_model.decoder.layers.*.self_attention.k_layernorm.weight": "model.language_model.layers.*.self_attn.k_norm.weight",
-            # MoE router weights
-            "language_model.decoder.layers.*.mlp.router.weight": "model.language_model.layers.*.mlp.gate.weight",
-            # vision module attn
-            "vision_model.decoder.layers.*.self_attention.linear_proj.weight": "model.visual.blocks.*.attn.proj.weight",
-            "vision_model.decoder.layers.*.self_attention.linear_proj.bias": "model.visual.blocks.*.attn.proj.bias",
-            # vision module mlp
-            "vision_model.decoder.layers.*.mlp.linear_fc1.weight": "model.visual.blocks.*.mlp.linear_fc1.weight",
-            "vision_model.decoder.layers.*.mlp.linear_fc1.bias": "model.visual.blocks.*.mlp.linear_fc1.bias",
-            "vision_model.decoder.layers.*.mlp.linear_fc2.weight": "model.visual.blocks.*.mlp.linear_fc2.weight",
-            "vision_model.decoder.layers.*.mlp.linear_fc2.bias": "model.visual.blocks.*.mlp.linear_fc2.bias",
-            # vision module norm
-            "vision_model.decoder.layers.*.self_attention.linear_qkv.layer_norm_weight": "model.visual.blocks.*.norm1.weight",
-            "vision_model.decoder.layers.*.self_attention.linear_qkv.layer_norm_bias": "model.visual.blocks.*.norm1.bias",
-            "vision_model.decoder.layers.*.mlp.linear_fc1.layer_norm_weight": "model.visual.blocks.*.norm2.weight",
-            "vision_model.decoder.layers.*.mlp.linear_fc1.layer_norm_bias": "model.visual.blocks.*.norm2.bias",
-            # # vision module deepstack merger
-            "vision_model.decoder.deepstack_merger_list.*.patch_norm.weight": "model.visual.deepstack_merger_list.*.norm.weight",
-            "vision_model.decoder.deepstack_merger_list.*.patch_norm.bias": "model.visual.deepstack_merger_list.*.norm.bias",
-            "vision_model.decoder.deepstack_merger_list.*.linear_fc1.weight": "model.visual.deepstack_merger_list.*.linear_fc1.weight",
-            "vision_model.decoder.deepstack_merger_list.*.linear_fc1.bias": "model.visual.deepstack_merger_list.*.linear_fc1.bias",
-            "vision_model.decoder.deepstack_merger_list.*.linear_fc2.weight": "model.visual.deepstack_merger_list.*.linear_fc2.weight",
-            "vision_model.decoder.deepstack_merger_list.*.linear_fc2.bias": "model.visual.deepstack_merger_list.*.linear_fc2.bias",
-            # vision module merger
-            "vision_model.merger.patch_norm.**": "model.visual.merger.norm.**",
-            "vision_model.merger.linear_fc1.weight": "model.visual.merger.linear_fc1.weight",
-            "vision_model.merger.linear_fc1.bias": "model.visual.merger.linear_fc1.bias",
-            "vision_model.merger.linear_fc2.weight": "model.visual.merger.linear_fc2.weight",
-            "vision_model.merger.linear_fc2.bias": "model.visual.merger.linear_fc2.bias",
-        }
-
-        mapping_list = []
-
-        # Convert simple 1:1 mappings to AutoMapping objects
-        for megatron_param, hf_param in param_mappings.items():
-            mapping_list.append(AutoMapping(megatron_param=megatron_param, hf_param=hf_param))
-
-        # Add special mappings that require parameter transformation
-        mapping_list.extend(
-            [
-                # QKV mapping: Combine separate Q, K, V matrices
-                QKVMapping(
-                    megatron_param="language_model.decoder.layers.*.self_attention.linear_qkv.weight",
-                    q="model.language_model.layers.*.self_attn.q_proj.weight",
-                    k="model.language_model.layers.*.self_attn.k_proj.weight",
-                    v="model.language_model.layers.*.self_attn.v_proj.weight",
-                ),
-                # QKV bias mapping (if attention_bias is True)
-                QKVMapping(
-                    megatron_param="language_model.decoder.layers.*.self_attention.linear_qkv.bias",
-                    q="model.language_model.layers.*.self_attn.q_proj.bias",
-                    k="model.language_model.layers.*.self_attn.k_proj.bias",
-                    v="model.language_model.layers.*.self_attn.v_proj.bias",
-                ),
-                # MoE routed-expert MLPs (grouped GEMM + SequentialMLP layouts). Fused vs per-expert
-                # HF mappings are selected from the checkpoint so HF->Megatron->HF round-trips.
-                *_moe_routed_expert_mappings(
-                    "model.language_model.",
-                    "language_model.",
-                    moe_experts_stored_packed(getattr(self, "hf_pretrained", None), "model.language_model.layers."),
-                    transpose_on_export=True,
-                ),
-                # QKV mapping for vision model
-                ConcatenatedQKVMapping(
-                    megatron_param="vision_model.decoder.layers.*.self_attention.linear_qkv.weight",
-                    hf_param="model.visual.blocks.*.attn.qkv.weight",
-                ),
-                ConcatenatedQKVMapping(
-                    megatron_param="vision_model.decoder.layers.*.self_attention.linear_qkv.bias",
-                    hf_param="model.visual.blocks.*.attn.qkv.bias",
-                ),
-                ReplicatedMapping(  # These patch_embed are conv, we need to use ReplicatedMapping
-                    megatron_param="vision_model.patch_embed.proj.**",
-                    hf_param="model.visual.patch_embed.proj.**",
-                ),
-                ReplicatedMapping(
-                    megatron_param="vision_model.pos_embed.weight",
-                    hf_param="model.visual.pos_embed.weight",
-                ),
-            ]
+        text_config = self.hf_config.text_config
+        mlp_symbols = qwen_moe_layer_symbols(
+            text_config.num_hidden_layers,
+            decoder_sparse_step=getattr(text_config, "decoder_sparse_step", 1),
+            mlp_only_layers=getattr(text_config, "mlp_only_layers", []),
         )
-
-        return MegatronMappingRegistry(*mapping_list)
+        experts_packed = moe_experts_stored_packed(
+            getattr(self, "hf_pretrained", None),
+            "model.language_model.layers.",
+        )
+        mappings = self._base_language_mappings()
+        for logical_layer_idx, mlp_symbol in enumerate(mlp_symbols):
+            attention_layer_idx, mlp_layer_idx = qwen_physical_layer_indices(logical_layer_idx)
+            mappings.extend(_attention_mappings(logical_layer_idx, attention_layer_idx))
+            if mlp_symbol == Symbols.MOE:
+                mappings.extend(
+                    _moe_mlp_mappings(
+                        logical_layer_idx,
+                        mlp_layer_idx,
+                        experts_packed=experts_packed,
+                    )
+                )
+            else:
+                mappings.extend(_dense_mlp_mappings(logical_layer_idx, mlp_layer_idx))
+        mappings.extend(_vision_mappings())
+        return MegatronMappingRegistry(*mappings)

--- a/src/megatron/bridge/models/qwen_vl/qwen3_vl_provider.py
+++ b/src/megatron/bridge/models/qwen_vl/qwen3_vl_provider.py
@@ -21,15 +21,24 @@ Reference: https://huggingface.co/Qwen/Qwen3-VL-30B-A3B-Instruct
 """
 
 from dataclasses import dataclass, field
-from typing import List, Optional
+from typing import Callable, List, Optional
 
-from megatron.core.models.gpt import GPTModel as MCoreGPTModel
-from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_with_transformer_engine_spec
+from megatron.core.models.hybrid.hybrid_layer_allocation import Symbols
+from megatron.core.transformer.spec_utils import ModuleSpec
 from transformers.models.qwen3_vl.configuration_qwen3_vl import Qwen3VLTextConfig, Qwen3VLVisionConfig
 from transformers.models.qwen3_vl_moe.configuration_qwen3_vl_moe import Qwen3VLMoeTextConfig
 
-from megatron.bridge.models.gpt_provider import GPTModelProvider
+from megatron.bridge.models.hybrid.hybrid_provider import HybridModelProvider
+from megatron.bridge.models.qwen.qwen_hybrid import (
+    QwenHybridModelProvider,
+    configure_qwen_hybrid_layers,
+    qwen_moe_layer_symbols,
+)
 from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.model import Qwen3VLModel
+from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.text_model import (
+    Qwen3VLHybridModel,
+    get_qwen3_vl_hybrid_stack_spec,
+)
 
 
 @dataclass
@@ -48,7 +57,7 @@ class DistTrainConfig:
 
 
 @dataclass
-class Qwen3VLModelProvider(GPTModelProvider):
+class Qwen3VLModelProvider(QwenHybridModelProvider):
     """
     Base model provider for Qwen 3 VL Models.
     Inherits language model configuration from Qwen3ModelProvider.
@@ -133,8 +142,19 @@ class Qwen3VLModelProvider(GPTModelProvider):
     # Maximum sequence length for vision encoder CUDA graphs (must accommodate largest input)
     # If None, calculated from num_position_embeddings / spatial_merge_size^2
     max_vision_cuda_graph_seq_length: Optional[int] = None
+    mtp_num_layers: Optional[int] = None
+    hybrid_stack_spec: ModuleSpec | Callable = get_qwen3_vl_hybrid_stack_spec
 
     def finalize(self) -> None:
+        if self.hybrid_layer_pattern is None:
+            if self.num_layers is None:
+                raise ValueError("num_layers must be configured for Qwen3-VL")
+            configure_qwen_hybrid_layers(
+                self,
+                num_logical_layers=self.num_layers,
+                mlp_symbols=Symbols.MLP,
+                mtp_mlp_symbol=Symbols.MLP,
+            )
         if (self.context_parallel_size or 1) > 1:
             self.calculate_per_token_loss = True
         super().finalize()
@@ -144,13 +164,7 @@ class Qwen3VLModelProvider(GPTModelProvider):
         language_transformer_config = self
         hf_vision_config = self.vision_config
 
-        # Spec for the Qwen3VLTransformerLayer
-        language_transformer_layer_spec = get_gpt_layer_with_transformer_engine_spec(
-            num_experts=None,
-            moe_grouped_gemm=False,
-            qk_layernorm=self.qk_layernorm,
-            fp8=False,
-        )
+        language_transformer_layer_spec = self._resolve_hybrid_stack_spec()
 
         model = Qwen3VLModel(
             language_transformer_config=language_transformer_config,
@@ -173,18 +187,17 @@ class Qwen3VLModelProvider(GPTModelProvider):
 
         return model
 
-    def provide_language_model(self, pre_process=None, post_process=None, vp_stage=None) -> MCoreGPTModel:
+    def provide_language_model(self, pre_process=None, post_process=None, vp_stage=None) -> Qwen3VLHybridModel:
         """Provide just the language model component without vision."""
-        # Use GPTModelProvider's provide method to create standard language model
-        return GPTModelProvider.provide(self, pre_process=pre_process, post_process=post_process, vp_stage=vp_stage)
+        return _provide_qwen3_vl_language_model(self, pre_process, post_process, vp_stage)
 
 
 @dataclass
-class Qwen3VLMoEModelProvider(GPTModelProvider):
+class Qwen3VLMoEModelProvider(QwenHybridModelProvider):
     """
     Base model provider for Qwen 3 VL MoE (Mixture of Experts) Models.
 
-    This provider inherits directly from GPTModelProvider following the
+    This provider inherits directly from HybridModelProvider following the
     provider_bridge refactoring pattern. It includes:
     - Qwen3 MoE-specific LLM defaults (RMSNorm, gated linear unit, QK layernorm, MoE config)
     - VL-specific configurations (vision_config, token IDs, mrope)
@@ -298,8 +311,23 @@ class Qwen3VLMoEModelProvider(GPTModelProvider):
     vision_cuda_graph_scope: List[str] = field(default_factory=list)
     # Maximum sequence length for vision encoder CUDA graphs (must accommodate largest input)
     max_vision_cuda_graph_seq_length: Optional[int] = None
+    mtp_num_layers: Optional[int] = None
+    hybrid_stack_spec: ModuleSpec | Callable = get_qwen3_vl_hybrid_stack_spec
 
     def finalize(self) -> None:
+        if self.hybrid_layer_pattern is None:
+            if self.num_layers is None:
+                raise ValueError("num_layers must be configured for Qwen3-VL MoE")
+            configure_qwen_hybrid_layers(
+                self,
+                num_logical_layers=self.num_layers,
+                mlp_symbols=qwen_moe_layer_symbols(
+                    self.num_layers,
+                    decoder_sparse_step=self.decoder_sparse_step,
+                    mlp_only_layers=self.mlp_only_layers,
+                ),
+                mtp_mlp_symbol=Symbols.MOE,
+            )
         if (self.context_parallel_size or 1) > 1:
             self.calculate_per_token_loss = True
         if self.tensor_model_parallel_size > 1:
@@ -311,12 +339,7 @@ class Qwen3VLMoEModelProvider(GPTModelProvider):
         language_transformer_config = self
         hf_vision_config = self.vision_config
 
-        language_transformer_layer_spec = get_gpt_layer_with_transformer_engine_spec(
-            num_experts=self.num_moe_experts,
-            moe_grouped_gemm=True,
-            qk_layernorm=self.qk_layernorm,
-            fp8=False,
-        )
+        language_transformer_layer_spec = self._resolve_hybrid_stack_spec()
 
         # Reuse Qwen3VLModel for MoE model but replace the language model with MoE language model
         model = Qwen3VLModel(
@@ -340,7 +363,48 @@ class Qwen3VLMoEModelProvider(GPTModelProvider):
 
         return model
 
-    def provide_language_model(self, pre_process=None, post_process=None, vp_stage=None) -> MCoreGPTModel:
+    def provide_language_model(self, pre_process=None, post_process=None, vp_stage=None) -> Qwen3VLHybridModel:
         """Provide just the language MoE model component without vision."""
-        # Use GPTModelProvider's provide method to create standard MoE language model
-        return GPTModelProvider.provide(self, pre_process=pre_process, post_process=post_process, vp_stage=vp_stage)
+        return _provide_qwen3_vl_language_model(self, pre_process, post_process, vp_stage)
+
+
+def _provide_qwen3_vl_language_model(
+    provider: HybridModelProvider,
+    pre_process: bool | None,
+    post_process: bool | None,
+    vp_stage: int | None,
+) -> Qwen3VLHybridModel:
+    """Construct the Qwen multimodal Hybrid language decoder without the vision encoder."""
+    from megatron.core.pipeline_parallel.utils import is_pp_first_stage, is_pp_last_stage
+
+    from megatron.bridge.utils.vocab_utils import calculate_padded_vocab_size
+
+    if vp_stage is not None or provider.virtual_pipeline_model_parallel_size is not None:
+        raise ValueError("Virtual pipeline parallelism is not supported by HybridModel.")
+    if provider.vocab_size is None or provider.hybrid_layer_pattern is None:
+        raise ValueError("vocab_size and hybrid_layer_pattern must be configured before model construction.")
+    vocab_size = provider.vocab_size
+    if provider.should_pad_vocab:
+        vocab_size = calculate_padded_vocab_size(
+            vocab_size,
+            provider.make_vocab_size_divisible_by,
+            provider.tensor_model_parallel_size,
+        )
+    pre_process = pre_process if pre_process is not None else is_pp_first_stage(provider._pg_collection.pp)
+    post_process = post_process if post_process is not None else is_pp_last_stage(provider._pg_collection.pp)
+    return Qwen3VLHybridModel(
+        config=provider,
+        hybrid_stack_spec=provider._resolve_hybrid_stack_spec(),
+        vocab_size=vocab_size,
+        max_sequence_length=provider.language_max_sequence_length,
+        hybrid_layer_pattern=provider.hybrid_layer_pattern,
+        pre_process=pre_process,
+        post_process=post_process,
+        fp16_lm_cross_entropy=provider.fp16_lm_cross_entropy,
+        parallel_output=provider.parallel_output,
+        share_embeddings_and_output_weights=provider.share_embeddings_and_output_weights,
+        rotary_percent=provider.rotary_percent,
+        rotary_base=provider.rotary_base,
+        scatter_embedding_sequence_parallel=False,
+        pg_collection=provider._pg_collection,
+    )

--- a/src/megatron/bridge/models/qwen_vl/qwen3_vl_step.py
+++ b/src/megatron/bridge/models/qwen_vl/qwen3_vl_step.py
@@ -17,9 +17,9 @@ from functools import partial
 from typing import Any, Iterable
 
 import torch
-from megatron.core.models.gpt import GPTModel
 from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.pipeline_parallel.utils import is_pp_first_stage, is_pp_last_stage
+from megatron.core.transformer import MegatronModule
 from megatron.core.utils import get_batch_on_this_cp_rank, get_model_config
 
 from megatron.bridge.training.config import ConfigContainer
@@ -213,7 +213,7 @@ def _pad_and_pack_qwen3_vl_step(
 def forward_step(
     state: GlobalState,
     data_iterator: Iterable,
-    model: GPTModel,
+    model: MegatronModule,
     return_schedule_plan: bool = False,
 ) -> tuple[torch.Tensor, partial]:
     """Forward training step.
@@ -221,7 +221,7 @@ def forward_step(
     Args:
         state: Global state for the run
         data_iterator: Input data iterator
-        model: The GPT Model
+        model: The Qwen3-VL model
         return_schedule_plan (bool): Whether to return the schedule plan instead of the output tensor
 
     Returns:

--- a/tests/functional_tests/test_groups/recipes/test_qwen35_vl_recipes_finetune.py
+++ b/tests/functional_tests/test_groups/recipes/test_qwen35_vl_recipes_finetune.py
@@ -35,7 +35,11 @@ pytestmark = pytest.mark.integration
 
 
 _TP2_PP1 = {"tensor_model_parallel_size": 2, "pipeline_model_parallel_size": 1}
-_TINY_MODEL = {"num_layers": 4, "linear_attention_freq": [1, 1, 1, 0]}
+_TINY_MODEL = {
+    "num_layers": 8,
+    "hybrid_layer_pattern": "G-G-G-*-",
+    "linear_attention_freq": [1, 1, 1, 0],
+}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/functional_tests/test_groups/recipes/test_qwen35_vl_recipes_pretrain.py
+++ b/tests/functional_tests/test_groups/recipes/test_qwen35_vl_recipes_pretrain.py
@@ -33,7 +33,11 @@ from tests.functional_tests.test_groups.recipes.utils import run_pretrain_vl_rec
 pytestmark = pytest.mark.integration
 
 _TP2_PP1 = {"tensor_model_parallel_size": 2, "pipeline_model_parallel_size": 1}
-_TINY_MODEL = {"num_layers": 4, "linear_attention_freq": [1, 1, 1, 0]}
+_TINY_MODEL = {
+    "num_layers": 8,
+    "hybrid_layer_pattern": "G-G-G-*-",
+    "linear_attention_freq": [1, 1, 1, 0],
+}
 
 QWEN35_VL_PRETRAIN_RECIPES = [
     (

--- a/tests/functional_tests/test_groups/recipes/test_qwen3_vl_recipes_finetune.py
+++ b/tests/functional_tests/test_groups/recipes/test_qwen3_vl_recipes_finetune.py
@@ -32,6 +32,13 @@ from megatron.bridge.recipes.qwen_vl.qwen3_vl import qwen3_vl_8b_sft_config
 from tests.functional_tests.test_groups.recipes.utils import run_pretrain_vl_recipe_test
 
 
+_TINY_MODEL = {
+    "num_layers": 8,
+    "hybrid_layer_pattern": "*-*-*-*-",
+    "deepstack_visual_indexes": [0, 1, 2],
+}
+
+
 # Variants that route through the Qwen3-VL-specific forward step (``qwen3_vl_step``).
 # Covers the step function used by the examples / ``run_recipe.py --step_func qwen3_vl_step``,
 # which is otherwise only exercised by the DistTrain smoke test that requires 8 GPUs.
@@ -46,7 +53,7 @@ QWEN3_VL_FINETUNE_RECIPES = [
         qwen3_vl_8b_sft_config,
         "qwen3_vl_8b_sft_qwen3_vl_step",
         {"tensor_model_parallel_size": 2, "pipeline_model_parallel_size": 1},
-        {"num_layers": 4, "deepstack_visual_indexes": [0, 1, 2]},
+        _TINY_MODEL,
     ),
     (
         qwen3_vl_8b_sft_config,
@@ -56,11 +63,10 @@ QWEN3_VL_FINETUNE_RECIPES = [
             "pipeline_model_parallel_size": 1,
         },
         {
+            **_TINY_MODEL,
             "freeze_language_model": False,
             "freeze_vision_model": False,
             "freeze_vision_projection": False,
-            "num_layers": 4,
-            "deepstack_visual_indexes": [0, 1, 2],
             "recompute_granularity": "full",
             "recompute_method": "uniform",
             "recompute_num_layers": 1,
@@ -73,10 +79,7 @@ QWEN3_VL_FINETUNE_RECIPES = [
             "tensor_model_parallel_size": 2,
             "pipeline_model_parallel_size": 1,
         },
-        {
-            "num_layers": 4,
-            "deepstack_visual_indexes": [0, 1, 2],
-        },
+        _TINY_MODEL,
     ),
 ]
 

--- a/tests/functional_tests/test_groups/recipes/test_qwen3_vl_recipes_pretrain.py
+++ b/tests/functional_tests/test_groups/recipes/test_qwen3_vl_recipes_pretrain.py
@@ -33,7 +33,11 @@ from tests.functional_tests.test_groups.recipes.utils import run_pretrain_vl_rec
 pytestmark = pytest.mark.integration
 
 _TP2_PP1 = {"tensor_model_parallel_size": 2, "pipeline_model_parallel_size": 1}
-_TINY_MODEL = {"num_layers": 4, "deepstack_visual_indexes": [0, 1, 2]}
+_TINY_MODEL = {
+    "num_layers": 8,
+    "hybrid_layer_pattern": "*-*-*-*-",
+    "deepstack_visual_indexes": [0, 1, 2],
+}
 
 QWEN3_VL_PRETRAIN_RECIPES = [
     (

--- a/tests/unit_tests/models/megatron_mimo/test_qwen35_vl_provider.py
+++ b/tests/unit_tests/models/megatron_mimo/test_qwen35_vl_provider.py
@@ -12,7 +12,7 @@ from megatron.bridge.models.megatron_mimo.megatron_mimo_config import (
     ModuleParallelismConfig,
 )
 from megatron.bridge.models.megatron_mimo.megatron_mimo_provider import MegatronMIMOProvider
-from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.text_model import Qwen3VLGPTModel
+from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.text_model import Qwen3VLHybridModel
 from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.vision_model import Qwen3VLVisionModel
 from megatron.bridge.models.qwen_vl.qwen35_vl_provider import _TRANSFORMERS_HAS_QWEN3_5, Qwen35VLModelProvider
 from megatron.bridge.training.config import ConfigContainer
@@ -58,20 +58,20 @@ class TestQwen35VLProviderMIMOAPI:
         spec = provider.build_language_model_spec()
 
         assert isinstance(spec, ModuleSpec)
-        assert spec.module is Qwen3VLGPTModel
+        assert spec.module is Qwen3VLHybridModel
 
         params = spec.params
         assert params is not None
         assert params["config"] is provider
-        assert params["transformer_layer_spec"] is sentinel_block_spec
+        assert params["hybrid_stack_spec"] is sentinel_block_spec
+        assert params["hybrid_layer_pattern"] == "G-G-G-*-" * 16
         assert params["vocab_size"] == provider.vocab_size
         assert params["max_sequence_length"] == provider.language_max_sequence_length
-        assert params["position_embedding_type"] == "mrope"
         assert params["rotary_percent"] == provider.rotary_percent
         assert params["rotary_base"] == provider.rotary_base
-        assert params["mtp_block_spec"] is None
         assert params["parallel_output"] is True
         assert params["scatter_embedding_sequence_parallel"] is False
+        assert provider.num_layers == 128
         assert "pg_collection" not in params
         assert "pre_process" not in params
         assert "post_process" not in params

--- a/tests/unit_tests/models/qwen_vl/modelling_qwen3_vl/test_model.py
+++ b/tests/unit_tests/models/qwen_vl/modelling_qwen3_vl/test_model.py
@@ -30,7 +30,6 @@ import torch
 import torch.distributed as dist
 import torch.nn.functional as F
 from megatron.core import parallel_state
-from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_with_transformer_engine_spec
 from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
@@ -38,6 +37,7 @@ from PIL import Image
 from transformers import AutoProcessor, Qwen3VLMoeConfig
 
 from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.model import Qwen3VLModel
+from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.text_model import get_qwen3_vl_hybrid_stack_spec
 from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.transformer_config import Qwen3VLTransformerConfig
 from megatron.bridge.models.qwen_vl.qwen3_vl_provider import DistTrainConfig
 
@@ -143,7 +143,7 @@ class TestQwen3VLModel:
         """
         return Qwen3VLTransformerConfig(
             # Use actual model dimensions from HF config
-            num_layers=4,  # Reduced for testing (actual: hf_config.text_config.num_hidden_layers)
+            num_layers=8,  # Four logical blocks, each represented by attention and MLP layers.
             hidden_size=hf_config.text_config.hidden_size,  # Must match vision output: 2048
             num_attention_heads=hf_config.text_config.num_attention_heads,
             num_query_groups=hf_config.text_config.num_key_value_heads,
@@ -182,22 +182,17 @@ class TestQwen3VLModel:
             use_cpu_initialization=True,
             hidden_dropout=0.0,
             attention_dropout=hf_config.text_config.attention_dropout,
+            hybrid_layer_pattern="*-*-*-*-",
         )
 
     @staticmethod
-    def get_language_model_layer_spec():
-        """Create a GPT layer spec for the language model.
+    def get_language_model_layer_spec(config):
+        """Create a Hybrid stack spec for the language model.
 
         Returns:
             ModuleSpec: Layer specification for transformer layers.
         """
-        language_model_layer_spec = get_gpt_layer_with_transformer_engine_spec(
-            num_experts=None,  # No MoE for basic test
-            moe_grouped_gemm=False,
-            qk_layernorm=False,
-            fp8=False,
-        )
-        return language_model_layer_spec
+        return get_qwen3_vl_hybrid_stack_spec(config)
 
     @staticmethod
     def get_data_batch(processor, random_image):
@@ -275,7 +270,7 @@ class TestQwen3VLModel:
 
         vision_transformer_config = self.get_vision_transformer_config(hf_config)
         language_transformer_config = self.get_language_transformer_config(hf_config)
-        language_model_layer_spec = self.get_language_model_layer_spec()
+        language_model_layer_spec = self.get_language_model_layer_spec(language_transformer_config)
 
         model = Qwen3VLModel(
             vision_transformer_config=vision_transformer_config,
@@ -314,7 +309,7 @@ class TestQwen3VLModel:
 
         vision_transformer_config = self.get_vision_transformer_config(hf_config)
         language_transformer_config = self.get_language_transformer_config(hf_config)
-        language_model_layer_spec = self.get_language_model_layer_spec()
+        language_model_layer_spec = self.get_language_model_layer_spec(language_transformer_config)
 
         # Test with add_decoder=True
         model = Qwen3VLModel(
@@ -361,7 +356,7 @@ class TestQwen3VLModel:
 
         vision_transformer_config = self.get_vision_transformer_config(hf_config)
         language_transformer_config = self.get_language_transformer_config(hf_config)
-        language_model_layer_spec = self.get_language_model_layer_spec()
+        language_model_layer_spec = self.get_language_model_layer_spec(language_transformer_config)
 
         # Test with pre_process=True
         model_pre = Qwen3VLModel(
@@ -428,7 +423,7 @@ class TestQwen3VLModel:
         vision_transformer_config = self.get_vision_transformer_config(hf_config)
         language_transformer_config = self.get_language_transformer_config(hf_config)
         self._attach_dist_train(language_transformer_config, vision_to_llm_dp_ratio=1)
-        language_model_layer_spec = self.get_language_model_layer_spec()
+        language_model_layer_spec = self.get_language_model_layer_spec(language_transformer_config)
 
         model = Qwen3VLModel(
             language_transformer_config=language_transformer_config,
@@ -474,7 +469,7 @@ class TestQwen3VLModel:
         vision_transformer_config = self.get_vision_transformer_config(hf_config)
         language_transformer_config = self.get_language_transformer_config(hf_config)
         self._attach_dist_train(language_transformer_config, vision_to_llm_dp_ratio=1)
-        language_model_layer_spec = self.get_language_model_layer_spec()
+        language_model_layer_spec = self.get_language_model_layer_spec(language_transformer_config)
 
         encoder = Qwen3VLModel(
             language_transformer_config=language_transformer_config,
@@ -821,7 +816,7 @@ class TestQwen3VLModel:
 
         vision_transformer_config = self.get_vision_transformer_config(hf_config)
         language_transformer_config = self.get_language_transformer_config(hf_config)
-        language_model_layer_spec = self.get_language_model_layer_spec()
+        language_model_layer_spec = self.get_language_model_layer_spec(language_transformer_config)
 
         model = Qwen3VLModel(
             language_transformer_config=language_transformer_config,
@@ -868,7 +863,7 @@ class TestQwen3VLModel:
         model = Qwen3VLModel(
             vision_transformer_config=self.get_vision_transformer_config(hf_config),
             language_transformer_config=language_transformer_config,
-            language_transformer_layer_spec=self.get_language_model_layer_spec(),
+            language_transformer_layer_spec=self.get_language_model_layer_spec(language_transformer_config),
             parallel_output=True,
             pre_process=True,
             post_process=True,
@@ -897,7 +892,7 @@ class TestQwen3VLModel:
         model = Qwen3VLModel(
             vision_transformer_config=self.get_vision_transformer_config(hf_config),
             language_transformer_config=language_transformer_config,
-            language_transformer_layer_spec=self.get_language_model_layer_spec(),
+            language_transformer_layer_spec=self.get_language_model_layer_spec(language_transformer_config),
             parallel_output=True,
             pre_process=True,
             post_process=True,

--- a/tests/unit_tests/models/qwen_vl/test_qwen35_vl_bridge.py
+++ b/tests/unit_tests/models/qwen_vl/test_qwen35_vl_bridge.py
@@ -124,6 +124,17 @@ def _make_mock_pretrained(text_config, vision_config, tie_word_embeddings=False)
     return pretrained
 
 
+@pytest.fixture(autouse=True)
+def _set_bridge_hf_configs():
+    previous_dense = Qwen35VLBridge.hf_config
+    previous_moe = Qwen35VLMoEBridge.hf_config
+    Qwen35VLBridge.hf_config = SimpleNamespace(text_config=_make_dense_text_config())
+    Qwen35VLMoEBridge.hf_config = SimpleNamespace(text_config=_make_moe_text_config())
+    yield
+    Qwen35VLBridge.hf_config = previous_dense
+    Qwen35VLMoEBridge.hf_config = previous_moe
+
+
 # =====================================================================
 # Tests for Qwen35VLBridge (Dense)
 # =====================================================================
@@ -155,7 +166,8 @@ class TestQwen35VLBridgeProviderBridge:
 
     def test_provider_bridge_basic_config(self, bridge, mock_pretrained):
         provider = bridge.provider_bridge(mock_pretrained)
-        assert provider.num_layers == 64
+        assert provider.num_layers == 128
+        assert provider.hybrid_layer_pattern == "G-G-G-*-" * 16
         assert provider.hidden_size == 5120
         assert provider.ffn_hidden_size == 17408
         assert provider.num_attention_heads == 24
@@ -308,7 +320,8 @@ class TestQwen35VLMoEBridgeProviderBridge:
 
     def test_provider_bridge_basic_config(self, bridge, mock_pretrained):
         provider = bridge.provider_bridge(mock_pretrained)
-        assert provider.num_layers == 60
+        assert provider.num_layers == 120
+        assert provider.hybrid_layer_pattern == "GEGEGE*E" * 15
         assert provider.hidden_size == 4096
         assert provider.num_attention_heads == 32
         assert provider.num_query_groups == 2

--- a/tests/unit_tests/models/qwen_vl/test_qwen35_vl_provider.py
+++ b/tests/unit_tests/models/qwen_vl/test_qwen35_vl_provider.py
@@ -12,21 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from types import SimpleNamespace
-from unittest.mock import Mock
-
 import pytest
-from megatron.core.transformer.attention import SelfAttention
 from megatron.core.transformer.spec_utils import ModuleSpec
 
-from megatron.bridge.models.gpt_provider import GPTModelProvider
+from megatron.bridge.models.hybrid.hybrid_provider import HybridModelProvider
 from megatron.bridge.models.qwen_vl.qwen35_vl_provider import (
     _TRANSFORMERS_HAS_QWEN3_5,
     _TRANSFORMERS_HAS_QWEN3_5_MOE,
-    Qwen3VLSelfAttention,
     Qwen35VLModelProvider,
     Qwen35VLMoEModelProvider,
-    _patch_standard_attention_specs,
 )
 
 
@@ -141,8 +135,8 @@ class TestQwen35VLModelProvider:
         )
         assert isinstance(provider.vision_config, Qwen3_5VisionConfig)
 
-    def test_inherits_from_gpt_provider(self):
-        assert issubclass(Qwen35VLModelProvider, GPTModelProvider)
+    def test_inherits_from_hybrid_provider(self):
+        assert issubclass(Qwen35VLModelProvider, HybridModelProvider)
 
     def test_provide_methods_exist(self):
         provider = Qwen35VLModelProvider(
@@ -178,6 +172,18 @@ class TestQwen35VLModelProvider:
         )
         assert provider.mtp_num_layers is None
         assert provider.build_mtp_spec(vp_stage=None) is None
+
+    def test_recipe_mtp_override_uses_hybrid_mtp_pattern(self):
+        provider = Qwen35VLModelProvider(
+            num_layers=4,
+            hidden_size=5120,
+            num_attention_heads=24,
+        )
+        provider.mtp_num_layers = 1
+
+        provider.finalize()
+
+        assert provider.hybrid_layer_pattern == "G-G-G-*-/*-"
 
     def test_build_vision_encoder_spec_shape(self):
         """The vision encoder spec must slot into MIMO's modality_submodules_spec.
@@ -221,16 +227,6 @@ class TestQwen35VLModelProvider:
         # Vision PP must be flattened to 1 so MIMO heterogeneous parallelism is honored.
         assert params["transformer_config"].pipeline_model_parallel_size == 1
         assert params["transformer_config"].first_pipeline_num_layers is None
-
-    def test_patch_standard_attention_specs_recurses_into_mtp_specs(self):
-        attn_spec = ModuleSpec(module=SelfAttention, submodules=SimpleNamespace())
-        mtp_model_layer = ModuleSpec(module=object, submodules=SimpleNamespace(self_attention=attn_spec))
-        mtp_layer = ModuleSpec(module=object, submodules=SimpleNamespace(mtp_model_layer=mtp_model_layer))
-        mtp_block = SimpleNamespace(layer_specs=[mtp_layer])
-
-        _patch_standard_attention_specs(mtp_block, Qwen3VLSelfAttention)
-
-        assert mtp_model_layer.submodules.self_attention.module is Qwen3VLSelfAttention
 
 
 @pytest.mark.skipif(not _TRANSFORMERS_HAS_QWEN3_5_MOE, reason="transformers does not have qwen3_5_moe support")
@@ -294,8 +290,8 @@ class TestQwen35VLMoEModelProvider:
         assert provider.bos_token_id == 248045
         assert provider.eos_token_id == 248046
 
-    def test_inherits_from_gpt_provider(self):
-        assert issubclass(Qwen35VLMoEModelProvider, GPTModelProvider)
+    def test_inherits_from_hybrid_provider(self):
+        assert issubclass(Qwen35VLMoEModelProvider, HybridModelProvider)
 
     def test_mimo_spec_builders_exist(self):
         """U2: MoE provider also exposes build_language_spec / build_mtp_spec / build_vision_module."""
@@ -330,47 +326,14 @@ class TestQwen35VLMoEModelProvider:
         )
         assert isinstance(provider.vision_config, Qwen3_5MoeVisionConfig)
 
-    def test_provide_patches_mtp_attention_spec(self, monkeypatch):
-        block_attn_spec = ModuleSpec(module=SelfAttention, submodules=SimpleNamespace())
-        mtp_attn_spec = ModuleSpec(module=SelfAttention, submodules=SimpleNamespace())
-        block_spec = SimpleNamespace(
-            layer_specs=[ModuleSpec(module=object, submodules=SimpleNamespace(self_attention=block_attn_spec))]
-        )
-        mtp_spec = SimpleNamespace(
-            layer_specs=[
-                ModuleSpec(
-                    module=object,
-                    submodules=SimpleNamespace(
-                        mtp_model_layer=ModuleSpec(
-                            module=object,
-                            submodules=SimpleNamespace(self_attention=mtp_attn_spec),
-                        )
-                    ),
-                )
-            ]
-        )
-        model_ctor = Mock(return_value=Mock())
-
-        monkeypatch.setattr(
-            "megatron.bridge.models.qwen_vl.qwen35_vl_provider.get_transformer_block_with_experimental_attention_variant_spec",
-            lambda *args, **kwargs: block_spec,
-        )
-        monkeypatch.setattr("megatron.bridge.models.gpt_provider.mtp_block_spec", lambda *args, **kwargs: mtp_spec)
-        monkeypatch.setattr("megatron.bridge.models.qwen_vl.qwen35_vl_provider.Qwen3VLModel", model_ctor)
-
+    def test_finalize_configures_hybrid_pattern(self):
         provider = Qwen35VLMoEModelProvider(
-            num_layers=60,
+            num_layers=4,
             hidden_size=4096,
             num_attention_heads=32,
-            mtp_num_layers=1,
         )
-        provider.provide()
+        provider.finalize()
 
-        kwargs = model_ctor.call_args.kwargs
-        assert kwargs["language_transformer_layer_spec"].layer_specs[0].submodules.self_attention.module is (
-            Qwen3VLSelfAttention
-        )
-        assert (
-            kwargs["mtp_block_spec"].layer_specs[0].submodules.mtp_model_layer.submodules.self_attention.module
-            is Qwen3VLSelfAttention
-        )
+        assert provider.num_layers == 8
+        assert provider.hybrid_layer_pattern == "GEGEGE*E"
+        assert provider.mtp_num_layers is None

--- a/tests/unit_tests/models/qwen_vl/test_qwen3_vl_bridge.py
+++ b/tests/unit_tests/models/qwen_vl/test_qwen3_vl_bridge.py
@@ -1,0 +1,121 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import torch
+from transformers import Qwen3VLVisionConfig
+
+from megatron.bridge.models.hf_pretrained.causal_lm import PreTrainedCausalLM
+from megatron.bridge.models.qwen_vl.qwen3_vl_bridge import Qwen3VLBridge, Qwen3VLMoEBridge
+from megatron.bridge.models.qwen_vl.qwen3_vl_provider import Qwen3VLModelProvider, Qwen3VLMoEModelProvider
+
+
+def _text_config(*, moe: bool = False):
+    config = SimpleNamespace(
+        num_hidden_layers=2,
+        hidden_size=128,
+        intermediate_size=256,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=32,
+        vocab_size=1024,
+        max_position_embeddings=512,
+        rms_norm_eps=1e-6,
+        initializer_range=0.02,
+        attention_dropout=0.0,
+        attention_bias=False,
+        hidden_act="silu",
+        tie_word_embeddings=False,
+        rope_theta=5_000_000.0,
+        rope_scaling={"mrope_section": [4, 6, 6]},
+        num_nextn_predict_layers=None,
+        torch_dtype=torch.bfloat16,
+        bos_token_id=1,
+        eos_token_id=2,
+    )
+    if moe:
+        config.moe_intermediate_size = 64
+        config.num_experts = 8
+        config.num_experts_per_tok = 2
+        config.decoder_sparse_step = 1
+        config.mlp_only_layers = [0]
+    return config
+
+
+def _pretrained(text_config):
+    pretrained = Mock(spec=PreTrainedCausalLM)
+    pretrained.config = SimpleNamespace(
+        text_config=text_config,
+        vision_config=Qwen3VLVisionConfig(depth=2, hidden_size=32, num_heads=4),
+        tie_word_embeddings=False,
+        vision_start_token_id=3,
+        vision_end_token_id=4,
+        image_token_id=5,
+        video_token_id=6,
+    )
+    return pretrained
+
+
+def _mapping_names(bridge) -> list[str]:
+    names = []
+    for mapping in bridge.mapping_registry().mappings:
+        megatron_param = getattr(mapping, "megatron_param", None)
+        if megatron_param is not None:
+            names.append(str(megatron_param))
+    return names
+
+
+def test_dense_provider_uses_two_physical_layers_per_block():
+    provider = Qwen3VLBridge().provider_bridge(_pretrained(_text_config()))
+
+    assert isinstance(provider, Qwen3VLModelProvider)
+    assert provider.num_layers == 4
+    assert provider.hybrid_layer_pattern == "*-*-"
+
+
+def test_moe_provider_preserves_dense_layer_placement():
+    provider = Qwen3VLMoEBridge().provider_bridge(_pretrained(_text_config(moe=True)))
+
+    assert isinstance(provider, Qwen3VLMoEModelProvider)
+    assert provider.num_layers == 4
+    assert provider.hybrid_layer_pattern == "*-*E"
+
+
+def test_dense_mappings_use_physical_attention_and_mlp_indices():
+    previous = Qwen3VLBridge.hf_config
+    Qwen3VLBridge.hf_config = SimpleNamespace(text_config=_text_config())
+    try:
+        names = _mapping_names(Qwen3VLBridge())
+    finally:
+        Qwen3VLBridge.hf_config = previous
+
+    assert "language_model.decoder.layers.0.self_attention.linear_qkv.weight" in names
+    assert "language_model.decoder.layers.1.mlp.linear_fc1.weight" in names
+    assert "language_model.decoder.layers.2.self_attention.linear_qkv.weight" in names
+    assert "language_model.decoder.layers.3.mlp.linear_fc1.weight" in names
+    assert "language_model.decoder.final_norm.weight" in names
+
+
+def test_moe_mappings_use_mlp_symbol_for_each_logical_layer():
+    previous = Qwen3VLMoEBridge.hf_config
+    Qwen3VLMoEBridge.hf_config = SimpleNamespace(text_config=_text_config(moe=True))
+    try:
+        names = _mapping_names(Qwen3VLMoEBridge())
+    finally:
+        Qwen3VLMoEBridge.hf_config = previous
+
+    assert "language_model.decoder.layers.1.mlp.linear_fc1.weight" in names
+    assert "language_model.decoder.layers.3.mlp.router.weight" in names

--- a/tests/unit_tests/models/qwen_vl/test_qwen3_vl_hybrid.py
+++ b/tests/unit_tests/models/qwen_vl/test_qwen3_vl_hybrid.py
@@ -1,0 +1,152 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import torch
+from megatron.core.models.hybrid.hybrid_layer_allocation import Symbols
+from megatron.core.models.hybrid.hybrid_model import HybridModel
+
+from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.attention import Qwen3VLSelfAttention
+from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.rope import Qwen3VLMultimodalRotaryEmbedding
+from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.text_model import (
+    Qwen3VLHybridModel,
+    Qwen3VLHybridStack,
+    get_qwen3_vl_hybrid_stack_spec,
+)
+
+
+def test_hybrid_stack_spec_uses_qwen_attention():
+    config = SimpleNamespace(transformer_impl="transformer_engine", restore_modelopt_state=False)
+
+    spec = get_qwen3_vl_hybrid_stack_spec(config)
+
+    assert spec.module is Qwen3VLHybridStack
+    assert spec.submodules.attention_layer.submodules.self_attention.module is Qwen3VLSelfAttention
+
+
+def test_deepstack_embedding_is_added_after_logical_mlp_layer():
+    stack = Qwen3VLHybridStack.__new__(Qwen3VLHybridStack)
+    torch.nn.Module.__init__(stack)
+    stack.layer_type_list = [Symbols.ATTENTION, Symbols.MLP]
+    attention_layer = torch.nn.Identity()
+    attention_layer.layer_number = 1
+    mlp_layer = torch.nn.Identity()
+    mlp_layer.layer_number = 2
+    stack.layers = torch.nn.ModuleList([attention_layer, mlp_layer])
+    hidden_states = torch.zeros(3, 1, 2)
+    visual_pos_masks = torch.tensor([[False, True, False]])
+    visual_embeds = (torch.tensor([[2.0, 3.0]]),)
+
+    after_attention = stack._maybe_add_deepstack_embedding(
+        hidden_states,
+        0,
+        visual_pos_masks,
+        visual_embeds,
+    )
+    after_mlp = stack._maybe_add_deepstack_embedding(
+        hidden_states,
+        1,
+        visual_pos_masks,
+        visual_embeds,
+    )
+
+    torch.testing.assert_close(after_attention, hidden_states)
+    torch.testing.assert_close(after_mlp[1, 0], visual_embeds[0][0])
+
+
+def test_multimodal_context_does_not_replace_hybrid_rotary_embedding():
+    stack = Qwen3VLHybridStack.__new__(Qwen3VLHybridStack)
+    torch.nn.Module.__init__(stack)
+    visual_pos_masks = torch.tensor([[True]])
+    deepstack_visual_embeds = [torch.ones(1, 2)]
+    stack.set_multimodal_context(visual_pos_masks, deepstack_visual_embeds)
+
+    assert not hasattr(stack, "_qwen_rotary_pos_emb")
+    assert stack._qwen_visual_pos_masks is visual_pos_masks
+    assert stack._qwen_deepstack_visual_embeds is deepstack_visual_embeds
+    stack.clear_multimodal_context()
+    assert stack._qwen_visual_pos_masks is None
+    assert stack._qwen_deepstack_visual_embeds is None
+
+
+def test_mrope_adapter_uses_explicit_positions_for_hybrid_call():
+    rope = Qwen3VLMultimodalRotaryEmbedding.__new__(Qwen3VLMultimodalRotaryEmbedding)
+    torch.nn.Module.__init__(rope)
+    rope.inv_freq = torch.ones(4)
+    rope.rotary_interleaved = False
+    rope.seq_len_interpolation_factor = None
+    rope.mrope_section = [1, 1, 2]
+    rope.is_thd_format = False
+    rope.cp_group = SimpleNamespace(size=lambda: 1)
+    rope._position_ids_context = None
+    rope._mrope_section_context = None
+    position_ids = torch.tensor([[[0, 1]], [[0, 2]], [[0, 3]]])
+    rope.set_forward_context(position_ids, [1, 1, 2])
+
+    expected = rope(position_ids, [1, 1, 2])
+    actual = rope(3, packed_seq=False)
+
+    torch.testing.assert_close(actual, expected)
+
+
+def test_hybrid_model_temporarily_enables_rope_path_for_parent_forward(monkeypatch):
+    class _Rotary(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.context = None
+
+        def set_forward_context(self, *context):
+            self.context = context
+
+        def clear_forward_context(self):
+            self.context = None
+
+    class _Decoder(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.context = None
+
+        def set_multimodal_context(self, *context):
+            self.context = context
+
+        def clear_multimodal_context(self):
+            self.context = None
+
+    model = Qwen3VLHybridModel.__new__(Qwen3VLHybridModel)
+    torch.nn.Module.__init__(model)
+    model.position_embedding_type = "mrope"
+    model.mrope_section = [1, 1, 2]
+    model.rotary_pos_emb = _Rotary()
+    model.decoder = _Decoder()
+    observed = {}
+
+    def _parent_forward(instance, **kwargs):
+        observed["position_embedding_type"] = instance.position_embedding_type
+        return kwargs["decoder_input"]
+
+    monkeypatch.setattr(HybridModel, "forward", _parent_forward)
+    decoder_input = torch.randn(2, 1, 4)
+    result = model.forward(
+        input_ids=torch.ones(1, 2, dtype=torch.long),
+        position_ids=torch.zeros(3, 1, 2, dtype=torch.long),
+        attention_mask=None,
+        decoder_input=decoder_input,
+    )
+
+    assert result is decoder_input
+    assert observed["position_embedding_type"] == "rope"
+    assert model.position_embedding_type == "mrope"
+    assert model.rotary_pos_emb.context is None
+    assert model.decoder.context is None


### PR DESCRIPTION
## Summary

- migrate dense and MoE Qwen3-VL models to `HybridModel`
- migrate the full official dense and MoE Qwen3.5 multimodal checkpoints on the shared Hybrid language runtime from #4836
- update multimodal model construction, RoPE, conversion mappings, and recipe integration
- add focused provider, bridge, model, and recipe coverage

## Models modified

Qwen3-VL checkpoints using `Qwen3VLForConditionalGeneration` or `Qwen3VLMoeForConditionalGeneration`:

- `Qwen/Qwen3-VL-8B-Instruct`
- `Qwen/Qwen3-VL-30B-A3B-Instruct`
- `Qwen/Qwen3-VL-235B-A22B-Instruct`

Official dense Qwen3.5 multimodal checkpoints using `Qwen3_5ForConditionalGeneration`:

- `Qwen/Qwen3.5-0.8B`
- `Qwen/Qwen3.5-2B`
- `Qwen/Qwen3.5-4B`
- `Qwen/Qwen3.5-9B`
- `Qwen/Qwen3.5-27B`

Official MoE Qwen3.5 multimodal checkpoints using `Qwen3_5MoeForConditionalGeneration`:

- `Qwen/Qwen3.5-35B-A3B`
- `Qwen/Qwen3.5-122B-A10B`
- `Qwen/Qwen3.5-397B-A17B`

Each official Qwen3.5 repository above has a top-level multimodal configuration containing a nested `qwen3_5_text` or `qwen3_5_moe_text` decoder. PR #4836 migrates those reusable decoder architectures; this PR owns the public checkpoint IDs and migrates their top-level conditional-generation wrappers, vision models, prefixed conversion mappings, and recipes.

## Stack

This is PR 3 of 4. Merge the stack in order:

1. #4747 - Qwen3 dense and MoE
2. #4836 - Qwen3-Next and Qwen3.5 text
3. #4837 - Qwen3-VL and Qwen3.5-VL
4. #4838 - Qwen3-ASR and Qwen3-Omni

## Validation

- `uv run --no-project --with pre-commit pre-commit run --all-files`
- The complete four-PR stack is tree-identical to the original #4747 implementation.
