### PR TITLE
[training, ckpt] fix: Reset MCore async queue during restart

### DIFF
--- a/src/megatron/bridge/training/inprocess_restart.py
+++ b/src/megatron/bridge/training/inprocess_restart.py
@@ -102,13 +102,13 @@ def inprocess_restart(train_fn: Callable, config: InProcessRestartConfig, global
                     async_calls_queue.close(abort=True)
                     global_state._async_calls_queue = None
 
-                from megatron.core.dist_checkpointing.strategies.filesystem_async import _results_queue
+                from megatron.core.dist_checkpointing.strategies import filesystem_async
 
-                global _results_queue
-
-                if _results_queue is not None:
-                    _results_queue._manager.shutdown()
-                    del _results_queue
+                if filesystem_async._results_queue is not None:
+                    try:
+                        filesystem_async._results_queue._manager.shutdown()
+                    finally:
+                        filesystem_async._results_queue = None
 
             except Exception:
                 pass

--- a/tests/unit_tests/training/test_inprocess_restart.py
+++ b/tests/unit_tests/training/test_inprocess_restart.py
@@ -379,6 +379,52 @@ class TestInProcessRestart:
 class TestAbortCheckpoint:
     """Test cases for the AbortCheckpoint class functionality."""
 
+    def test_abort_checkpoint_resets_mcore_results_queue(self):
+        """Test AbortCheckpoint resets MCore's queue owner for a retry."""
+        from megatron.core.dist_checkpointing.strategies import filesystem_async
+
+        mock_config = MagicMock(spec=InProcessRestartConfig)
+        mock_config.active_world_size = 1
+        mock_config.granularity = "rank"
+        mock_config.empty_cuda_cache = False
+        mock_config.max_rank_faults = None
+        mock_config.monitor_process_logdir = None
+        mock_config.heartbeat_interval = 30.0
+        mock_config.heartbeat_timeout = 60.0
+        mock_config.barrier_timeout = 120.0
+        mock_config.completion_timeout = 120.0
+        mock_config.monitor_process_interval = 1.0
+        mock_config.monitor_thread_interval = 1.0
+        mock_config.last_call_wait = 1.0
+        mock_config.soft_timeout = 60.0
+        mock_config.hard_timeout = 90.0
+        mock_config.termination_grace_time = 1.0
+        mock_global_state = MagicMock(spec=GlobalState)
+        mock_global_state.async_calls_queue = None
+        mock_results_queue = MagicMock()
+        filesystem_async._results_queue = mock_results_queue
+
+        try:
+            with (
+                patch.dict(os.environ, {"MASTER_PORT": "29500"}),
+                patch("megatron.bridge.training.inprocess_restart.warnings.warn"),
+                patch("nvidia_resiliency_ext.inprocess.Wrapper") as mock_wrapper,
+            ):
+                mock_wrapper.return_value.return_value = MagicMock()
+                inprocess_restart(MagicMock(), mock_config, mock_global_state)
+                abort = mock_wrapper.call_args.kwargs["abort"]
+                abort_checkpoint = next(
+                    instance for instance in abort.instances if type(instance).__name__ == "AbortCheckpoint"
+                )
+
+                frozen_state = MagicMock()
+                assert abort_checkpoint(frozen_state) is frozen_state
+
+            mock_results_queue._manager.shutdown.assert_called_once_with()
+            assert filesystem_async._results_queue is None
+        finally:
+            filesystem_async._results_queue = None
+
     def test_abort_checkpoint_with_async_calls_queue(self):
         """Test AbortCheckpoint when async_calls_queue exists."""
         mock_global_state = MagicMock(spec=GlobalState)


### PR DESCRIPTION
## Summary

- Reset the MCore async-results queue at its owning module during an in-process restart abort.
- Guarantee the canonical queue binding is cleared even if manager shutdown raises.
- Add focused regression coverage that invokes the production abort component.

## Problem

With in-process restart enabled alongside `torch_dist` asynchronous checkpointing, the explicit `mcore` async strategy, and the persistent checkpoint worker, a recoverable restart could break the next checkpoint. The abort path imported the queue by value, shut down its manager, and deleted only Bridge's local alias. MCore retained a non-`None` binding to the dead proxy, so its next queue lookup reused an unusable manager instead of creating a fresh queue.

## Fix

Operate on the `filesystem_async` module that owns the queue and set its canonical `_results_queue` binding to `None` in a `finally` block. The NVRx checkpoint strategy is unchanged.

## Validation

- The regression fails on the unmodified base because the production abort leaves MCore's canonical owner bound, and passes with this fix.
- `uv run python -m pytest tests/unit_tests/training/test_inprocess_restart.py tests/unit_tests/training/test_state.py::TestGlobalState::test_initialize_async_checkpoint_worker_enabled tests/unit_tests/training/test_state.py::TestGlobalState::test_initialize_async_checkpoint_worker_disabled -q` — 19 passed.
- A two-rank NCCL lifecycle reproducer completed a real async save/reload before abort. Before the fix it failed at the stale canonical-owner invariant; after the fix it created a distinct queue and completed a second async save/reload.
- `git diff --check` — passed.
- `uv run pre-commit run --all-files` — passed.

## Scope

No public API, configuration default, dependency, CI workflow, or Megatron-Core source change. This patch affects only the explicit MCore async checkpoint strategy during in-process restart; the NVRx path is untouched.
