### PR TITLE
[data] fix: preserve explicit fixed padding

### DIFF
--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -1130,7 +1130,7 @@ class ConfigContainer(Container):
                 getattr(self.model, "pipeline_model_parallel_size", 1) > 1
                 or getattr(self.model, "expert_model_parallel_size", 1) > 1
             )
-            self.dataset.pad_to_max_length = requires_fixed_seq_len
+            self.dataset.pad_to_max_length = self.dataset.pad_to_max_length or requires_fixed_seq_len
 
         cp_size = getattr(self.model, "context_parallel_size", 1)
         eval_cp_size = self.dist.eval_context_parallel_size

--- a/tests/unit_tests/training/test_config.py
+++ b/tests/unit_tests/training/test_config.py
@@ -1105,6 +1105,27 @@ class TestConfigContainerValidation:
         finally:
             restore_get_world_size_safe(og_ws, cfg_mod)
 
+    def test_direct_hf_preserves_explicit_fixed_length_padding(self, monkeypatch):
+        """Test explicit fixed-length padding remains enabled without PP or EP."""
+        gpt_model_cfg = create_test_gpt_config(
+            pipeline_model_parallel_size=1,
+            expert_model_parallel_size=1,
+        )
+        dataset_cfg = create_test_direct_hf_sft_dataset_config(sequence_length=512)
+        dataset_cfg.pad_to_max_length = True
+
+        container, og_ws, cfg_mod = create_test_config_container(
+            world_size_override=1,
+            model_config=gpt_model_cfg,
+            dataset_config_override=dataset_cfg,
+        )
+
+        try:
+            container.validate()
+            assert dataset_cfg.pad_to_max_length is True
+        finally:
+            restore_get_world_size_safe(og_ws, cfg_mod)
+
     def test_direct_hf_seq_length_must_support_cp_and_sp_collate_slicing(self, monkeypatch):
         """Test the sequence cap cannot undo CP/SP-safe collate padding."""
         gpt_model_cfg = create_test_gpt_config(


### PR DESCRIPTION
## What changed

Preserve an explicit `DirectHFSFTDatasetConfig.pad_to_max_length=True` choice when pipeline and expert parallelism are both one.

Combined config validation previously replaced the public dataset field with `PP > 1 or EP > 1`. On the supported single-stage Direct-HF SFT path, that silently changed an explicit fixed-padding request to dynamic, batch-relative padding before the provider built the dataset and bound its collator.

The fix ORs the existing choice with the parallelism requirement: PP or EP can still force fixed padding, while their absence no longer disables a user request.

## User impact

Users who explicitly request fixed `seq_length` batches can otherwise receive batch-dependent tensor widths. This defeats the documented fixed-padding mode and can break shape-sensitive training workflows.

Related context: #4143 documents fixed padding as a valid working mode for shape-sensitive SFT, but it does not cover this configuration overwrite.

## Validation

Fail-before and pass-after used the same focused regression test:

```text
uv run --active --no-sync python -m pytest tests/unit_tests/training/test_config.py::TestConfigContainerValidation::test_direct_hf_preserves_explicit_fixed_length_padding -q
```

- Before: `1 failed`; validation changed explicit `True` to `False`.
- After: `1 passed`.

Adjacent Direct-HF config and builder coverage:

```text
uv run --active --no-sync python -m pytest tests/unit_tests/training/test_config.py -k direct_hf tests/unit_tests/data/builders/test_direct_hf_sft.py -q
```

- `36 passed, 210 deselected`.

Additional gates:

```text
git diff --check
uv run --active --no-sync pre-commit run --all-files
```

- Both passed.

## Scope

- No dependency, lockfile, CI workflow, public API signature, or Megatron-Core change.
- No full-suite, convergence, model-quality, or performance claim.
- The change only preserves explicit fixed padding; automatic PP/EP fixed-padding behavior remains covered and unchanged.
