### PR TITLE
[model] fix: preserve Falcon H1 input scaling

### DIFF
--- a/src/megatron/bridge/models/falcon_h1/falconh1_bridge.py
+++ b/src/megatron/bridge/models/falcon_h1/falconh1_bridge.py
@@ -121,9 +121,8 @@ class FalconH1Bridge(MegatronModelBridge):
             "decoder.layers.*.mlp.linear_fc2.weight": "model.layers.*.feed_forward.down_proj.weight",
             # Attention output projection
             "decoder.layers.*.self_attention.linear_proj.weight": "model.layers.*.self_attn.o_proj.weight",
-            # Layer norms for TELayerNormColumnParallelLinear layers
-            "decoder.layers.*.mamba_mixer.in_proj.layer_norm_weight": "model.layers.*.input_layernorm.weight",
-            "decoder.layers.*.self_attention.linear_qkv.layer_norm_weight": "model.layers.*.input_layernorm.weight",
+            # Shared input norm for parallel Mamba and attention branches
+            "decoder.layers.*.norm.weight": "model.layers.*.input_layernorm.weight",
             "decoder.layers.*.mlp.linear_fc1.layer_norm_weight": "model.layers.*.pre_ff_layernorm.weight",
             "decoder.final_norm.weight": "model.final_layernorm.weight",
             # Embeddings and output

--- a/src/megatron/bridge/models/falcon_h1/modeling_falconh1/falconh1_layer_specs.py
+++ b/src/megatron/bridge/models/falcon_h1/modeling_falconh1/falconh1_layer_specs.py
@@ -1,7 +1,9 @@
 # Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
 from megatron.core.extensions.transformer_engine import (
+    TEColumnParallelLinear,
     TEDotProductAttention,
     TELayerNormColumnParallelLinear,
+    TENorm,
     TERowParallelLinear,
 )
 from megatron.core.fusions.fused_bias_dropout import get_bias_dropout_add
@@ -80,11 +82,12 @@ falconh1_stack_spec = ModuleSpec(
             module=FalconH1Layer,
             params={"attn_mask_type": AttnMaskType.causal},
             submodules=FalconH1Submodules(
+                norm=TENorm,
                 # SSM component - complete MambaMixer spec
                 mamba_mixer=ModuleSpec(
                     module=FalconH1MambaMixer,
                     submodules=MambaMixerSubmodules(
-                        in_proj=TELayerNormColumnParallelLinear,
+                        in_proj=TEColumnParallelLinear,
                         out_proj=TERowParallelLinear,
                     ),
                 ),
@@ -92,7 +95,7 @@ falconh1_stack_spec = ModuleSpec(
                 self_attention=ModuleSpec(
                     module=FalconH1SelfAttention,
                     submodules=SelfAttentionSubmodules(
-                        linear_qkv=TELayerNormColumnParallelLinear,
+                        linear_qkv=TEColumnParallelLinear,
                         core_attention=TEDotProductAttention,
                         linear_proj=TERowParallelLinear,
                     ),

--- a/tests/unit_tests/models/falcon_h1/test_falcon_h1_bridge.py
+++ b/tests/unit_tests/models/falcon_h1/test_falcon_h1_bridge.py
@@ -188,6 +188,7 @@ def test_megatron_to_hf_config_preserves_falcon_fields(falcon_h1_pretrained):
 def test_mapping_registry_contains_falcon_h1_weight_families():
     registry = FalconH1Bridge().mapping_registry()
     megatron_params = [str(mapping.megatron_param) for mapping in registry]
+    hf_params = [str(mapping.hf_param) for mapping in registry]
 
     assert "embedding.word_embeddings.weight" in megatron_params
     assert "output_layer.weight" in megatron_params
@@ -197,6 +198,10 @@ def test_mapping_registry_contains_falcon_h1_weight_families():
     assert "decoder.layers.*.mamba_mixer.conv1d_bias" in megatron_params
     assert "decoder.layers.*.mamba_mixer.conv1d.weight" in megatron_params
     assert "decoder.layers.*.mamba_mixer.conv1d.bias" in megatron_params
+    assert megatron_params.count("decoder.layers.*.norm.weight") == 1
+    assert hf_params.count("model.layers.*.input_layernorm.weight") == 1
+    assert "decoder.layers.*.mamba_mixer.in_proj.layer_norm_weight" not in megatron_params
+    assert "decoder.layers.*.self_attention.linear_qkv.layer_norm_weight" not in megatron_params
     assert "decoder.layers.*.self_attention.linear_qkv.weight" in megatron_params
     assert "decoder.layers.*.mlp.linear_fc1.weight" in megatron_params
     assert "decoder.layers.*.mlp.linear_fc2.weight" in megatron_params

--- a/tests/unit_tests/models/falcon_h1/test_falcon_h1_layers.py
+++ b/tests/unit_tests/models/falcon_h1/test_falcon_h1_layers.py
@@ -17,6 +17,11 @@ from unittest.mock import patch
 
 import pytest
 import torch
+from megatron.core.extensions.transformer_engine import (
+    TEColumnParallelLinear,
+    TELayerNormColumnParallelLinear,
+    TENorm,
+)
 
 from megatron.bridge.models.falcon_h1.modeling_falconh1.falconh1_layer import (
     FalconH1MambaMixer,
@@ -25,6 +30,7 @@ from megatron.bridge.models.falcon_h1.modeling_falconh1.falconh1_layer import (
     SelfAttention,
     _run_mamba_mixer_with_static_cache_namespace,
 )
+from megatron.bridge.models.falcon_h1.modeling_falconh1.falconh1_layer_specs import falconh1_stack_spec
 from megatron.bridge.models.falcon_h1.modeling_falconh1.falconh1_model import FalconH1Config
 
 
@@ -110,6 +116,15 @@ def test_self_attention_applies_key_multiplier():
     torch.testing.assert_close(scaled_query, query)
     torch.testing.assert_close(scaled_key, torch.tensor([6.0]))
     torch.testing.assert_close(scaled_value, value)
+
+
+def test_parallel_layer_normalizes_once_before_branch_input_multipliers():
+    submodules = falconh1_stack_spec.submodules.falconh1_layer.submodules
+
+    assert submodules.norm is TENorm
+    assert submodules.mamba_mixer.submodules.in_proj is TEColumnParallelLinear
+    assert submodules.self_attention.submodules.linear_qkv is TEColumnParallelLinear
+    assert submodules.mlp.submodules.linear_fc1 is TELayerNormColumnParallelLinear
 
 
 def test_static_mamba_cache_key_is_namespaced_when_layer_uses_attention():


### PR DESCRIPTION
## What changed

Falcon H1 parallel decoder layers now apply the checkpoint's shared input RMSNorm once, before the Mamba and attention branches. Their input projections use ordinary TE column-parallel linears, while the MLP keeps its existing fused pre-FF norm/linear.

The conversion mapping now imports and exports the single Hugging Face `input_layernorm` through the layer-level norm instead of duplicating it into two independently trainable branch parameters.

## Why

`tiiuae/Falcon-H1-0.5B-Instruct` sets `ssm_in_multiplier=1.25`. The supported Hugging Face implementation normalizes the decoder input and then applies that multiplier before Mamba's projection. Bridge previously multiplied the raw input before a fused RMSNorm+linear, which nearly canceled the 1.25 scale. It also created separate norm weights for Mamba and attention even though Falcon H1 defines one shared input norm, so training could make them diverge and HF export could not represent both values.

## Validation

Fail before / pass after:

```text
uv run --no-sync python -m pytest tests/unit_tests/models/falcon_h1/test_falcon_h1_layers.py::test_parallel_layer_normalizes_once_before_branch_input_multipliers -q
before: 1 failed (parallel layer norm was IdentityOp)
after:  1 passed
```

Adjacent tests:

```text
uv run --no-sync python -m pytest tests/unit_tests/models/falcon_h1/ -q
26 passed
```

The public 0.5B checkpoint also passed an exact HF→Megatron→HF round-trip: all 579 exported tensors matched with zero mismatches, the exported HF checkpoint reloaded, the next token matched, and logits cosine similarity was 0.999937.

```text
git diff --check
uv run --active --no-sync pre-commit run --all-files
```

Both passed.

## Scope

This changes only the default Falcon H1 layer spec and its input-norm weight mapping. No dependency, workflow, public API, or MCore changes are included.
