### PR TITLE
fix(training): allow local CUDA graphs for inference scopes

### DIFF
--- a/src/megatron/bridge/utils/cuda_graph.py
+++ b/src/megatron/bridge/utils/cuda_graph.py
@@ -138,8 +138,12 @@ def validate_cuda_graph_configuration(config: Any, *, config_name: str = "model"
         clear_cuda_graph_modules(config)
         return
 
-    if cuda_graph_impl == "local" and not is_full_iteration_cuda_graph(config):
-        graph_modules = cuda_graph_module_names(config)
+    graph_modules = cuda_graph_module_names(config)
+    inference_scopes = _member_names(getattr(config, "inference_cuda_graph_scope", None))
+    is_local_inference_graph = (
+        cuda_graph_impl == "local" and not graph_modules and bool(inference_scopes & {"layer", "block"})
+    )
+    if cuda_graph_impl == "local" and not is_full_iteration_cuda_graph(config) and not is_local_inference_graph:
         modules_msg = f" with scopes {graph_modules}" if graph_modules else ""
         raise ValueError(
             f'Megatron Bridge supports {config_name}.cuda_graph_impl="local" only for '

--- a/tests/unit_tests/training/test_config.py
+++ b/tests/unit_tests/training/test_config.py
@@ -1603,6 +1603,47 @@ class TestConfigContainerValidation:
         finally:
             restore_get_world_size_safe(og_ws, cfg_mod)
 
+    @pytest.mark.parametrize("inference_scope", ["layer", "block"])
+    def test_cuda_graph_local_inference_scope_allows_validation(self, inference_scope, monkeypatch):
+        """Test that MCore local inference graphs are not rejected as training scopes."""
+        gpt_model_cfg = create_test_gpt_config(
+            cuda_graph_impl="local",
+            inference_cuda_graph_scope=inference_scope,
+            use_te_rng_tracker=True,
+        )
+
+        container, og_ws, cfg_mod = create_test_config_container(
+            world_size_override=1,
+            model_config=gpt_model_cfg,
+        )
+
+        try:
+            container.validate()
+            assert container.model.cuda_graph_impl == "local"
+            assert container.model.inference_cuda_graph_scope.name == inference_scope
+        finally:
+            restore_get_world_size_safe(og_ws, cfg_mod)
+
+    def test_cuda_graph_local_inference_scope_rejects_training_modules(self, monkeypatch):
+        """Test that an inference scope does not bypass local training-scope validation."""
+        gpt_model_cfg = create_test_gpt_config(
+            cuda_graph_impl="local",
+            inference_cuda_graph_scope="block",
+            use_te_rng_tracker=True,
+        )
+        set_cuda_graph_modules(gpt_model_cfg, ["mlp"])
+
+        container, og_ws, cfg_mod = create_test_config_container(
+            world_size_override=1,
+            model_config=gpt_model_cfg,
+        )
+
+        try:
+            with pytest.raises(ValueError, match='cuda_graph_impl="local"'):
+                container.validate()
+        finally:
+            restore_get_world_size_safe(og_ws, cfg_mod)
+
     @pytest.mark.parametrize("graph_modules", [["mlp"], ["moe_router"]])
     def test_cuda_graph_local_scoped_modules_raise_clear_error(self, graph_modules, monkeypatch):
         """Test that Bridge rejects local scoped graphs before MCore layer construction."""


### PR DESCRIPTION
# What does this PR do ?

Allow local CUDA graphs for inference scopes

# Changelog

Allow MCore local CUDA graphs when constructing models configured for inference with:

- `cuda_graph_impl="local"`
- `inference_cuda_graph_scope="layer"` or `"block"`
- no explicit training CUDA graph modules

The existing Bridge validation rejected every non-full-iteration `local` configuration. This also rejected valid inference configurations, even though MCore requires the local implementation for layer- and block-scoped inference CUDA graphs.

The validation still rejects unsupported explicit local training scopes such as `mlp` and `moe_router`, preserving the existing training-side guard.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [X] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [X] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
