### PR TITLE
feat(recipes): add standalone NeMoDiag V0 workloads

### DIFF
--- a/scripts/performance/argument_parser.py
+++ b/scripts/performance/argument_parser.py
@@ -511,6 +511,13 @@ def parse_cli_args():
         default=None,
     )
     slurm_args.add_argument(
+        "--custom_post_bash_cmds",
+        nargs="*",
+        action="append",
+        help="List of bash commands to execute after the main command",
+        default=None,
+    )
+    slurm_args.add_argument(
         "--gres",
         type=str,
         help="Slurm generic resources to request (e.g., 'gpu:4').",

--- a/scripts/performance/perf_plugins.py
+++ b/scripts/performance/perf_plugins.py
@@ -294,6 +294,8 @@ class PerfEnvPlugin(Plugin):
         """Set model-specific environment variables"""
         if model_family_name in ["deepseek"]:
             executor.env_vars["NVTE_ALLOW_NONDETERMINISTIC_ALGO"] = "0"
+        if model_family_name == "nemodiag":
+            executor.env_vars["NVTE_ALLOW_NONDETERMINISTIC_ALGO"] = "0"
 
         if workload_base_config.cuda_graph_impl == "full_iteration" or (
             workload_base_config.cuda_graph_impl == "local"
@@ -333,6 +335,9 @@ class PerfEnvPlugin(Plugin):
                 if compute_dtype == "fp8_cs":
                     del_cudnn_ln = False
             if model_family_name == "deepseek":
+                if compute_dtype == "fp8_mx":
+                    del_cudnn_ln = False
+            if model_family_name == "nemodiag":
                 if compute_dtype == "fp8_mx":
                     del_cudnn_ln = False
             if model_family_name == "kimi":

--- a/scripts/performance/setup_experiment.py
+++ b/scripts/performance/setup_experiment.py
@@ -19,6 +19,7 @@ import json
 import logging
 import os
 import re
+import shlex
 import sys
 import tempfile
 import time
@@ -114,8 +115,10 @@ def _build_nemorun_script(
     args: List[str],
     kubeflow_namespace: Optional[str],
     custom_env_vars: Dict[str, str],
+    custom_bash_cmds: Optional[List[List[str]]] = None,
+    custom_post_bash_cmds: Optional[List[List[str]]] = None,
 ) -> run.Script:
-    """Build the rank-local task and apply optional Kubeflow NUMA binding."""
+    """Build a rank-local task with optional Kubeflow NUMA binding and hooks."""
     task = run.Script(
         path=script_path,
         entrypoint="python",
@@ -124,8 +127,52 @@ def _build_nemorun_script(
     )
     if kubeflow_namespace and _kubeflow_numa_binding_enabled(custom_env_vars):
         logger.info("Enabling per-rank GPU-local NUMA binding for Kubeflow torchrun workers")
-        return _kubeflow_numa_binding_script(task)
+        task = _kubeflow_numa_binding_script(task)
+    if kubeflow_namespace and (custom_bash_cmds or custom_post_bash_cmds):
+        task = _script_with_hooks(task, custom_bash_cmds, custom_post_bash_cmds)
     return task
+
+
+def _shell_join_commands(commands: Optional[List[List[str]]]) -> str:
+    """Render repeated command-token lists as one shell command sequence."""
+    if not commands:
+        return ":"
+    return " ; ".join(shlex.join(command) for command in commands)
+
+
+def _script_with_hooks(
+    script: run.Script,
+    custom_bash_cmds: Optional[List[List[str]]],
+    custom_post_bash_cmds: Optional[List[List[str]]],
+) -> run.Script:
+    """Wrap a script with pre/post hooks while preserving its training exit code."""
+    pre_cmds = _shell_join_commands(custom_bash_cmds)
+    post_cmds = _shell_join_commands(custom_post_bash_cmds)
+    training_cmd = shlex.join(script.to_command(with_entrypoint=True))
+    wrapped_cmd = f"""
+set -euo pipefail
+
+set +e
+bash -c {shlex.quote(f"{pre_cmds} ; {training_cmd}")}
+TRAIN_RC="$?"
+set -e
+
+export NEMO_RUN_TRAINING_EXIT_CODE="${{TRAIN_RC}}"
+POST_RC=0
+bash -c {shlex.quote(post_cmds)} || POST_RC="$?"
+
+if [ "${{TRAIN_RC}}" -ne 0 ]; then
+    exit "${{TRAIN_RC}}"
+fi
+exit "${{POST_RC}}"
+"""
+    return run.Script(
+        path="-lc",
+        entrypoint="bash",
+        args=[wrapped_cmd],
+        env=script.env.copy(),
+        metadata=script.metadata.copy(),
+    )
 
 
 def _build_csp_plugin(csp: str) -> Any:
@@ -478,6 +525,7 @@ def main(
     custom_env_vars: Dict[str, str],
     custom_srun_args: List[str],
     custom_bash_cmds: List[List[str]],
+    custom_post_bash_cmds: List[List[str]],
     nccl_ub: bool,
     pretrained_checkpoint: Optional[str],
     save_dir: Optional[str],
@@ -681,6 +729,7 @@ def main(
             custom_env_vars=custom_env_vars,
             custom_srun_args=custom_srun_args,
             custom_bash_cmds=custom_bash_cmds,
+            custom_post_bash_cmds=custom_post_bash_cmds,
             gres=gres,
             hf_token=hf_token,
             offline=offline,
@@ -761,6 +810,8 @@ def main(
         args=_filter_run_script_args(sys.argv[1:]),
         kubeflow_namespace=kubeflow_namespace,
         custom_env_vars=custom_env_vars,
+        custom_bash_cmds=custom_bash_cmds,
+        custom_post_bash_cmds=custom_post_bash_cmds,
     )
 
     logger.info("Will launch the following command with Nemo-Run: %s", " ".join(nemorun_script.to_command()))
@@ -1043,6 +1094,7 @@ if __name__ == "__main__":
         custom_env_vars=custom_env_vars,
         custom_srun_args=args.custom_srun_args,
         custom_bash_cmds=args.custom_bash_cmds,
+        custom_post_bash_cmds=args.custom_post_bash_cmds,
         nccl_ub=args.nccl_ub,
         pretrained_checkpoint=args.pretrained_checkpoint,
         save_dir=args.save_dir,

--- a/scripts/performance/utils/executors.py
+++ b/scripts/performance/utils/executors.py
@@ -81,7 +81,19 @@ INLINE_TEMPLATE = r"""
 set -euo pipefail
 
 # NOTE: DO NOT change the single quotes to double quotes.
+set +e
 bash -c '{{ pre_cmds }} {{ command }}'
+TRAIN_RC="$?"
+set -e
+
+export NEMO_RUN_TRAINING_EXIT_CODE="${TRAIN_RC}"
+POST_RC=0
+bash -c '{{ post_cmds }}' || POST_RC="$?"
+
+if [ "${TRAIN_RC}" -ne 0 ]; then
+    exit "${TRAIN_RC}"
+fi
+exit "${POST_RC}"
 """
 
 PERF_ENV_VARS = {
@@ -116,6 +128,7 @@ def slurm_executor(
     wandb_key: str = None,
     network: str = None,
     custom_bash_cmds: List[List[str]] = None,
+    custom_post_bash_cmds: List[List[str]] = None,
     additional_slurm_params: Dict[str, Any] = None,
     gres: Optional[str] = None,
     packager: str = "git",
@@ -133,6 +146,7 @@ def slurm_executor(
                 #SBATCH --constraint=gpu
     """
     custom_bash_cmds = [] if custom_bash_cmds is None else [" ".join(cmd) for cmd in custom_bash_cmds]
+    custom_post_bash_cmds = [] if custom_post_bash_cmds is None else [" ".join(cmd) for cmd in custom_post_bash_cmds]
     mounts = []
     # Explicitly request GPU resources to ensure proper allocation
     # Without --gres=gpu:N, some clusters only allocate 1 GPU regardless of ntasks_per_node
@@ -194,7 +208,10 @@ def slurm_executor(
 
     launcher = SlurmTemplate(
         template_inline=INLINE_TEMPLATE,
-        template_vars={"pre_cmds": " ; ".join(custom_bash_cmds)},
+        template_vars={
+            "pre_cmds": " ; ".join(custom_bash_cmds),
+            "post_cmds": " ; ".join(custom_post_bash_cmds) or ":",
+        },
     )
 
     executor = run.SlurmExecutor(

--- a/scripts/performance/utils/overrides.py
+++ b/scripts/performance/utils/overrides.py
@@ -19,6 +19,7 @@ from typing import List, Optional
 
 from omegaconf import OmegaConf
 
+from megatron.bridge.perf_recipes.nemodiag.common import set_nemodiag_v0_pipeline_model_parallel_layout
 from megatron.bridge.recipes.deepseek.deepseek_v3 import set_deepseek_v3_pipeline_model_parallel_layout
 from megatron.bridge.recipes.kimi.kimi_k2 import _get_kimi_k2_pipeline_layout
 from megatron.bridge.recipes.utils.determinism_utils import apply_determinism_overrides
@@ -493,6 +494,10 @@ def set_user_overrides(recipe: ConfigContainer, args: argparse.Namespace) -> Con
         pp_size is not None or vp_size != -1 or pipeline_model_parallel_layout is not None
     ):
         set_deepseek_v3_pipeline_model_parallel_layout(recipe.model, layout=pipeline_model_parallel_layout)
+    if model_recipe_name == "nemodiag_v0" and (
+        pp_size is not None or vp_size != -1 or pipeline_model_parallel_layout is not None
+    ):
+        set_nemodiag_v0_pipeline_model_parallel_layout(recipe.model, layout=pipeline_model_parallel_layout)
     if model_recipe_name == "kimi_k2":
         if pp_size is not None or vp_size != -1:
             if not isinstance(recipe.model.pipeline_model_parallel_layout, str):

--- a/src/megatron/bridge/perf_recipes/nemodiag/__init__.py
+++ b/src/megatron/bridge/perf_recipes/nemodiag/__init__.py
@@ -1,0 +1,16 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from megatron.bridge.perf_recipes.nemodiag.gb300.nemodiag_v0 import *  # noqa: F403
+from megatron.bridge.perf_recipes.nemodiag.gb300.nemodiag_v0 import __all__

--- a/src/megatron/bridge/perf_recipes/nemodiag/common.py
+++ b/src/megatron/bridge/perf_recipes/nemodiag/common.py
@@ -1,0 +1,250 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Standalone model and performance defaults for NeMoDiag V0."""
+
+from functools import partial
+
+import torch
+import torch.nn.functional as F
+from megatron.core.models.gpt.gpt_layer_specs import get_gpt_decoder_block_spec
+
+from megatron.bridge.models.mla_provider import MLAModelProvider
+from megatron.bridge.perf_recipes._common import (
+    _benchmark_common,
+    _enable_overlap_param_gather_with_optimizer_step,
+    _perf_precision,
+)
+from megatron.bridge.recipes.common import _pretrain_common
+from megatron.bridge.recipes.utils.tokenizer_utils import DEFAULT_NULL_TOKENIZER_VOCAB_SIZE
+from megatron.bridge.training.comm_overlap import CommOverlapConfig
+from megatron.bridge.training.config import ConfigContainer
+from megatron.bridge.training.mixed_precision import MixedPrecisionConfig
+
+
+NEMODIAG_V0_PIPELINE_LAYOUT = "Et*4|(t*4|)*6t*3mL"
+
+
+def set_nemodiag_v0_pipeline_model_parallel_layout(
+    model_cfg: MLAModelProvider, layout: str | list[list[str]] | None = None
+) -> None:
+    """Set the supported NeMoDiag V0 pipeline layout.
+
+    An explicit layout always wins. The default test topology uses PP=2 and
+    VP=4; other topologies leave automatic layer placement enabled.
+    """
+    if layout is not None:
+        model_cfg.pipeline_model_parallel_layout = layout
+        return
+
+    pp_size = model_cfg.pipeline_model_parallel_size or 1
+    vp_size = model_cfg.virtual_pipeline_model_parallel_size or 1
+    model_cfg.pipeline_model_parallel_layout = NEMODIAG_V0_PIPELINE_LAYOUT if (pp_size, vp_size) == (2, 4) else None
+
+
+def nemodiag_v0_pretrain_config() -> ConfigContainer:
+    """Build the standalone synthetic model used by NeMoDiag V0 tests."""
+    cfg = _pretrain_common()
+
+    cfg.model = MLAModelProvider(
+        # Synthetic test architecture.
+        num_layers=31,
+        hidden_size=7168,
+        ffn_hidden_size=18432,
+        num_attention_heads=128,
+        num_query_groups=128,
+        vocab_size=129280,
+        layernorm_epsilon=1e-6,
+        init_method_std=0.006,
+        attention_dropout=0.0,
+        hidden_dropout=0.0,
+        activation_func=F.silu,
+        normalization="RMSNorm",
+        gated_linear_unit=True,
+        add_bias_linear=False,
+        add_qkv_bias=False,
+        share_embeddings_and_output_weights=False,
+        qk_layernorm=True,
+        multi_latent_attention=True,
+        q_lora_rank=1536,
+        kv_lora_rank=512,
+        qk_head_dim=128,
+        qk_pos_emb_head_dim=64,
+        v_head_dim=128,
+        position_embedding_type="rope",
+        rotary_base=10000.0,
+        rotary_scaling_factor=40,
+        original_max_position_embeddings=4096,
+        beta_fast=32,
+        beta_slow=1,
+        mscale=1.0,
+        mscale_all_dim=1.0,
+        # Synthetic MoE shape and routing.
+        num_moe_experts=144,
+        moe_ffn_hidden_size=2048,
+        moe_shared_expert_intermediate_size=2048,
+        moe_layer_freq=[0, 0, 0] + [1] * 28,
+        moe_router_topk=8,
+        moe_router_num_groups=8,
+        moe_router_group_topk=4,
+        moe_router_topk_scaling_factor=2.5,
+        moe_router_pre_softmax=True,
+        moe_router_load_balancing_type="seq_aux_loss",
+        moe_router_score_function="sigmoid",
+        moe_router_enable_expert_bias=True,
+        moe_router_bias_update_rate=1e-3,
+        moe_router_dtype="fp32",
+        moe_aux_loss_coeff=0.0001,
+        moe_grouped_gemm=True,
+        moe_permute_fusion=True,
+        moe_token_dispatcher_type="flex",
+        moe_flex_dispatcher_backend="hybridep",
+        moe_hybridep_num_sms=16,
+        moe_shared_expert_overlap=False,
+        # Model implementation and fusions.
+        transformer_layer_spec=partial(get_gpt_decoder_block_spec, use_transformer_engine=True),
+        transformer_impl="transformer_engine",
+        apply_rope_fusion=False,
+        gradient_accumulation_fusion=True,
+        bias_activation_fusion=True,
+        bias_dropout_fusion=True,
+        cross_entropy_fusion_impl="te",
+        cross_entropy_loss_fusion=True,
+        masked_softmax_fusion=True,
+        persist_layer_norm=True,
+        attention_softmax_in_fp32=False,
+        make_vocab_size_divisible_by=1280,
+        # NeMoDiag V0 topology.
+        tensor_model_parallel_size=1,
+        pipeline_model_parallel_size=2,
+        pipeline_dtype=torch.bfloat16,
+        virtual_pipeline_model_parallel_size=4,
+        context_parallel_size=1,
+        expert_model_parallel_size=36,
+        expert_tensor_parallel_size=1,
+        sequence_parallel=False,
+        seq_length=4096,
+        account_for_embedding_in_pipeline_split=False,
+        account_for_loss_in_pipeline_split=False,
+        mtp_num_layers=1,
+        mtp_loss_scaling_factor=0.1,
+        bf16=True,
+        params_dtype=torch.bfloat16,
+        recompute_granularity=None,
+        recompute_modules=None,
+        recompute_method=None,
+        recompute_num_layers=None,
+        fine_grained_activation_offloading=False,
+        offload_modules=[],
+        cuda_graph_impl="none",
+        cuda_graph_scope=[],
+        cuda_graph_warmup_steps=3,
+        attention_backend=None,
+        moe_router_padding_for_fp8=False,
+    )
+    set_nemodiag_v0_pipeline_model_parallel_layout(cfg.model)
+
+    # Runtime identity is intentionally self-contained and does not download a tokenizer.
+    cfg.tokenizer.tokenizer_type = "NullTokenizer"
+    cfg.tokenizer.tokenizer_model = None
+    cfg.tokenizer.vocab_size = DEFAULT_NULL_TOKENIZER_VOCAB_SIZE
+    cfg.dataset.blend = None
+    cfg.dataset.num_workers = 8
+    cfg.dataset.seq_length = cfg.model.seq_length
+
+    cfg.train.train_iters = 1_000_000
+    cfg.train.global_batch_size = 1152
+    cfg.train.micro_batch_size = 1
+    cfg.train.manual_gc = True
+    cfg.train.manual_gc_interval = 5
+    cfg.train.manual_gc_eval = 5
+    cfg.validation.eval_interval = 2000
+    cfg.scheduler.lr_warmup_iters = 2000
+
+    cfg.mixed_precision = MixedPrecisionConfig(
+        bf16=True,
+        params_dtype=torch.bfloat16,
+        pipeline_dtype=torch.bfloat16,
+        autocast_enabled=False,
+        grad_reduce_in_fp32=False,
+    )
+    cfg.optimizer.use_precision_aware_optimizer = True
+    cfg.optimizer.main_params_dtype = torch.float32
+    cfg.optimizer.main_grads_dtype = torch.bfloat16
+    cfg.optimizer.exp_avg_dtype = torch.bfloat16
+    cfg.optimizer.exp_avg_sq_dtype = torch.bfloat16
+
+    cfg.comm_overlap = CommOverlapConfig(tp_comm_overlap=False)
+    cfg.comm_overlap.delay_wgrad_compute = False
+    cfg.comm_overlap.overlap_moe_expert_parallel_comm = False
+    cfg.comm_overlap.overlap_grad_reduce = True
+
+    cfg.checkpoint.save_interval = 2000
+    cfg.checkpoint.async_save = False
+    cfg.ddp.overlap_grad_reduce = True
+    cfg.ddp.overlap_param_gather = True
+    cfg.ddp.check_for_nan_in_grad = True
+    cfg.ddp.use_distributed_optimizer = True
+    cfg.ddp.use_megatron_fsdp = False
+    cfg.ddp.grad_reduce_in_fp32 = False
+    cfg.ddp.data_parallel_sharding_strategy = "no_shard"
+
+    return cfg
+
+
+def _nemodiag_v0_common(cfg: ConfigContainer) -> None:
+    """Apply precision-independent NeMoDiag benchmark settings."""
+    cfg.dataset.seq_length = cfg.model.seq_length
+    cfg.model.moe_router_fusion = True
+    cfg.model.recompute_granularity = "selective"
+    cfg.model.moe_router_force_load_balancing = True
+    cfg.dist.enable_megatron_core_experimental = True
+
+
+def _enable_nemodiag_full_iteration_mxfp8(
+    cfg: ConfigContainer,
+    *,
+    fp8_dot_product_attention: bool = False,
+    fp8_output_proj: bool = False,
+) -> None:
+    """Apply full-iteration MXFP8 and HybridEP settings."""
+    cfg.model.cuda_graph_impl = "full_iteration"
+    cfg.model.cuda_graph_scope = []
+    cfg.model.high_priority_a2a_comm_stream = True
+    cfg.model.moe_expert_rank_capacity_factor = 1.5
+    cfg.model.moe_hybridep_num_sms_preprocessing = 32
+    cfg.model.moe_mlp_glu_interleave_size = 32
+    cfg.model.moe_pad_experts_for_cuda_graph_inference = True
+    cfg.model.moe_paged_stash = True
+    cfg.model.moe_paged_stash_buffer_size_factor_cpu = 1.0
+    cfg.model.moe_paged_stash_buffer_size_factor_cuda = 1.2
+    cfg.model.use_transformer_engine_op_fuser = True
+    cfg.model.fp8_output_proj = fp8_output_proj
+    cfg.model.use_te_rng_tracker = True
+    cfg.rng.te_rng_tracker = True
+
+    cfg.mixed_precision.fp8_dot_product_attention = fp8_dot_product_attention
+    cfg.comm_overlap.delay_wgrad_compute = True
+    cfg.comm_overlap.overlap_moe_expert_parallel_comm = True
+
+
+__all__ = [
+    "NEMODIAG_V0_PIPELINE_LAYOUT",
+    "_benchmark_common",
+    "_enable_nemodiag_full_iteration_mxfp8",
+    "_enable_overlap_param_gather_with_optimizer_step",
+    "_nemodiag_v0_common",
+    "_perf_precision",
+    "nemodiag_v0_pretrain_config",
+    "set_nemodiag_v0_pipeline_model_parallel_layout",
+]

--- a/src/megatron/bridge/perf_recipes/nemodiag/gb300/__init__.py
+++ b/src/megatron/bridge/perf_recipes/nemodiag/gb300/__init__.py
@@ -1,0 +1,16 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from megatron.bridge.perf_recipes.nemodiag.gb300.nemodiag_v0 import *  # noqa: F403
+from megatron.bridge.perf_recipes.nemodiag.gb300.nemodiag_v0 import __all__

--- a/src/megatron/bridge/perf_recipes/nemodiag/gb300/nemodiag_v0.py
+++ b/src/megatron/bridge/perf_recipes/nemodiag/gb300/nemodiag_v0.py
@@ -1,0 +1,115 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""GB300 performance recipes for NeMoDiag V0."""
+
+from megatron.bridge.perf_recipes.nemodiag.common import (
+    _benchmark_common,
+    _enable_nemodiag_full_iteration_mxfp8,
+    _enable_overlap_param_gather_with_optimizer_step,
+    _nemodiag_v0_common,
+    _perf_precision,
+    nemodiag_v0_pretrain_config,
+)
+from megatron.bridge.training.config import ConfigContainer
+
+
+def _nemodiag_v0_gb300_config(*, precision: str, global_batch_size: int) -> ConfigContainer:
+    cfg = nemodiag_v0_pretrain_config()
+    cfg.mixed_precision = _perf_precision(precision)
+    cfg.train.global_batch_size = global_batch_size
+    _nemodiag_v0_common(cfg)
+
+    if precision == "bf16":
+        cfg.train.micro_batch_size = 1
+        cfg.model.recompute_modules = ["moe_act"]
+        cfg.model.cuda_graph_impl = "transformer_engine"
+        cfg.model.cuda_graph_scope = ["attn", "moe_router", "moe_preprocess"]
+        _benchmark_common(cfg)
+        _enable_overlap_param_gather_with_optimizer_step(cfg)
+    elif precision == "fp8_mx":
+        cfg.train.micro_batch_size = 1
+        cfg.model.recompute_modules = []
+        _benchmark_common(cfg)
+        _enable_nemodiag_full_iteration_mxfp8(
+            cfg,
+            fp8_dot_product_attention=True,
+            fp8_output_proj=True,
+        )
+    elif precision == "nvfp4":
+        cfg.train.micro_batch_size = 2
+        cfg.model.recompute_modules = ["mla_up_proj"]
+        cfg.model.cuda_graph_scope = []
+        _benchmark_common(cfg)
+    else:
+        raise ValueError(f"Unsupported NeMoDiag V0 precision: {precision}")
+
+    return cfg
+
+
+def nemodiag_v0_pretrain_72gpu_gb300_bf16_perf72_e144_config() -> ConfigContainer:
+    """NeMoDiag V0: 72 GB300 GPUs, BF16."""
+    return _nemodiag_v0_gb300_config(precision="bf16", global_batch_size=1152)
+
+
+def nemodiag_v0_pretrain_144gpu_gb300_bf16_perf72_e144_config() -> ConfigContainer:
+    """NeMoDiag V0: 144 GB300 GPUs, BF16."""
+    return _nemodiag_v0_gb300_config(precision="bf16", global_batch_size=2304)
+
+
+def nemodiag_v0_pretrain_288gpu_gb300_bf16_perf72_e144_config() -> ConfigContainer:
+    """NeMoDiag V0: 288 GB300 GPUs, BF16."""
+    return _nemodiag_v0_gb300_config(precision="bf16", global_batch_size=4608)
+
+
+def nemodiag_v0_pretrain_72gpu_gb300_fp8mx_perf72_e144_config() -> ConfigContainer:
+    """NeMoDiag V0: 72 GB300 GPUs, MXFP8."""
+    return _nemodiag_v0_gb300_config(precision="fp8_mx", global_batch_size=1152)
+
+
+def nemodiag_v0_pretrain_144gpu_gb300_fp8mx_perf72_e144_config() -> ConfigContainer:
+    """NeMoDiag V0: 144 GB300 GPUs, MXFP8."""
+    return _nemodiag_v0_gb300_config(precision="fp8_mx", global_batch_size=2304)
+
+
+def nemodiag_v0_pretrain_288gpu_gb300_fp8mx_perf72_e144_config() -> ConfigContainer:
+    """NeMoDiag V0: 288 GB300 GPUs, MXFP8."""
+    return _nemodiag_v0_gb300_config(precision="fp8_mx", global_batch_size=4608)
+
+
+def nemodiag_v0_pretrain_72gpu_gb300_nvfp4_perf72_e144_config() -> ConfigContainer:
+    """NeMoDiag V0: 72 GB300 GPUs, NVFP4."""
+    return _nemodiag_v0_gb300_config(precision="nvfp4", global_batch_size=1152)
+
+
+def nemodiag_v0_pretrain_144gpu_gb300_nvfp4_perf72_e144_config() -> ConfigContainer:
+    """NeMoDiag V0: 144 GB300 GPUs, NVFP4."""
+    return _nemodiag_v0_gb300_config(precision="nvfp4", global_batch_size=2304)
+
+
+def nemodiag_v0_pretrain_288gpu_gb300_nvfp4_perf72_e144_config() -> ConfigContainer:
+    """NeMoDiag V0: 288 GB300 GPUs, NVFP4."""
+    return _nemodiag_v0_gb300_config(precision="nvfp4", global_batch_size=4608)
+
+
+__all__ = [
+    "nemodiag_v0_pretrain_72gpu_gb300_bf16_perf72_e144_config",
+    "nemodiag_v0_pretrain_72gpu_gb300_fp8mx_perf72_e144_config",
+    "nemodiag_v0_pretrain_72gpu_gb300_nvfp4_perf72_e144_config",
+    "nemodiag_v0_pretrain_144gpu_gb300_bf16_perf72_e144_config",
+    "nemodiag_v0_pretrain_144gpu_gb300_fp8mx_perf72_e144_config",
+    "nemodiag_v0_pretrain_144gpu_gb300_nvfp4_perf72_e144_config",
+    "nemodiag_v0_pretrain_288gpu_gb300_bf16_perf72_e144_config",
+    "nemodiag_v0_pretrain_288gpu_gb300_fp8mx_perf72_e144_config",
+    "nemodiag_v0_pretrain_288gpu_gb300_nvfp4_perf72_e144_config",
+]

--- a/tests/unit_tests/recipes/test_nemodiag_perf_recipes.py
+++ b/tests/unit_tests/recipes/test_nemodiag_perf_recipes.py
@@ -1,0 +1,149 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the standalone NeMoDiag V0 performance recipes."""
+
+import inspect
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from megatron.bridge.models.mla_provider import MLAModelProvider
+from megatron.bridge.perf_recipes.nemodiag.common import NEMODIAG_V0_PIPELINE_LAYOUT
+from megatron.bridge.perf_recipes.nemodiag.gb300.nemodiag_v0 import (
+    nemodiag_v0_pretrain_72gpu_gb300_bf16_perf72_e144_config,
+    nemodiag_v0_pretrain_72gpu_gb300_fp8mx_perf72_e144_config,
+    nemodiag_v0_pretrain_72gpu_gb300_nvfp4_perf72_e144_config,
+    nemodiag_v0_pretrain_144gpu_gb300_bf16_perf72_e144_config,
+    nemodiag_v0_pretrain_144gpu_gb300_fp8mx_perf72_e144_config,
+    nemodiag_v0_pretrain_144gpu_gb300_nvfp4_perf72_e144_config,
+    nemodiag_v0_pretrain_288gpu_gb300_bf16_perf72_e144_config,
+    nemodiag_v0_pretrain_288gpu_gb300_fp8mx_perf72_e144_config,
+    nemodiag_v0_pretrain_288gpu_gb300_nvfp4_perf72_e144_config,
+)
+from megatron.bridge.training.config import ConfigContainer
+
+
+_RECIPE_CASES = [
+    (nemodiag_v0_pretrain_72gpu_gb300_bf16_perf72_e144_config, 72, "bf16", 1152, 1, ["moe_act"]),
+    (nemodiag_v0_pretrain_144gpu_gb300_bf16_perf72_e144_config, 144, "bf16", 2304, 1, ["moe_act"]),
+    (nemodiag_v0_pretrain_288gpu_gb300_bf16_perf72_e144_config, 288, "bf16", 4608, 1, ["moe_act"]),
+    (nemodiag_v0_pretrain_72gpu_gb300_fp8mx_perf72_e144_config, 72, "fp8_mx", 1152, 1, []),
+    (nemodiag_v0_pretrain_144gpu_gb300_fp8mx_perf72_e144_config, 144, "fp8_mx", 2304, 1, []),
+    (nemodiag_v0_pretrain_288gpu_gb300_fp8mx_perf72_e144_config, 288, "fp8_mx", 4608, 1, []),
+    (nemodiag_v0_pretrain_72gpu_gb300_nvfp4_perf72_e144_config, 72, "nvfp4", 1152, 2, ["mla_up_proj"]),
+    (nemodiag_v0_pretrain_144gpu_gb300_nvfp4_perf72_e144_config, 144, "nvfp4", 2304, 2, ["mla_up_proj"]),
+    (nemodiag_v0_pretrain_288gpu_gb300_nvfp4_perf72_e144_config, 288, "nvfp4", 4608, 2, ["mla_up_proj"]),
+]
+
+
+@pytest.mark.parametrize("recipe_fn,num_gpus,precision,gbs,mbs,recompute_modules", _RECIPE_CASES)
+def test_nemodiag_v0_recipe_is_standalone_and_fixed(
+    recipe_fn,
+    num_gpus: int,
+    precision: str,
+    gbs: int,
+    mbs: int,
+    recompute_modules: list[str],
+):
+    assert not inspect.signature(recipe_fn).parameters
+
+    cfg = recipe_fn()
+
+    assert isinstance(cfg, ConfigContainer)
+    assert isinstance(cfg.model, MLAModelProvider)
+    assert cfg.model.hf_model_id is None
+    assert cfg.tokenizer.tokenizer_type == "NullTokenizer"
+    assert cfg.tokenizer.tokenizer_model is None
+    assert cfg.train.global_batch_size == gbs
+    assert cfg.train.global_batch_size / num_gpus == 16
+    assert cfg.train.micro_batch_size == mbs
+    assert cfg.model.recompute_modules == recompute_modules
+
+    assert cfg.model.num_layers == 31
+    assert cfg.model.num_moe_experts == 144
+    assert cfg.model.moe_layer_freq == [0, 0, 0] + [1] * 28
+    assert cfg.model.tensor_model_parallel_size == 1
+    assert cfg.model.pipeline_model_parallel_size == 2
+    assert cfg.model.virtual_pipeline_model_parallel_size == 4
+    assert cfg.model.context_parallel_size == 1
+    assert cfg.model.expert_model_parallel_size == 36
+    assert cfg.model.expert_tensor_parallel_size == 1
+    assert cfg.model.pipeline_model_parallel_layout == NEMODIAG_V0_PIPELINE_LAYOUT
+
+    if precision == "bf16":
+        assert cfg.mixed_precision.fp8 is None
+        assert cfg.model.cuda_graph_impl == "transformer_engine"
+    elif precision == "fp8_mx":
+        assert cfg.mixed_precision.fp8_recipe == "mxfp8"
+        assert cfg.model.cuda_graph_impl == "full_iteration"
+        assert cfg.mixed_precision.fp8_dot_product_attention is True
+        assert cfg.model.fp8_output_proj is True
+    else:
+        assert cfg.mixed_precision.fp4 == "e2m1"
+        assert cfg.mixed_precision.fp4_recipe == "nvfp4"
+        assert cfg.model.cuda_graph_impl == "none"
+
+
+@pytest.mark.parametrize("recipe_fn,num_gpus,precision,unused_gbs,unused_mbs,unused_recompute", _RECIPE_CASES)
+def test_nemodiag_v0_recipe_is_discoverable(
+    recipe_fn,
+    num_gpus: int,
+    precision: str,
+    unused_gbs: int,
+    unused_mbs: int,
+    unused_recompute: list[str],
+):
+    scripts_dir = Path(__file__).resolve().parents[3] / "scripts" / "performance"
+    sys.path.insert(0, str(scripts_dir))
+    try:
+        from utils.utils import get_perf_recipe_by_name
+
+        discovered = get_perf_recipe_by_name(
+            model_recipe_name="nemodiag_v0",
+            task="pretrain",
+            num_gpus=num_gpus,
+            gpu="gb300",
+            precision=precision,
+            config_variant="perf72_e144",
+        )
+    finally:
+        sys.path.remove(str(scripts_dir))
+
+    assert isinstance(discovered, ConfigContainer)
+    assert type(discovered.model) is MLAModelProvider
+    assert discovered.train.global_batch_size == recipe_fn().train.global_batch_size
+
+
+@pytest.mark.parametrize(
+    "recipe_fn",
+    [
+        nemodiag_v0_pretrain_72gpu_gb300_bf16_perf72_e144_config,
+        nemodiag_v0_pretrain_72gpu_gb300_fp8mx_perf72_e144_config,
+        nemodiag_v0_pretrain_72gpu_gb300_nvfp4_perf72_e144_config,
+    ],
+)
+def test_nemodiag_v0_recipe_validates_for_gb300(recipe_fn, monkeypatch: pytest.MonkeyPatch):
+    import megatron.bridge.training.config as config_module
+    import megatron.bridge.training.flex_dispatcher_backend as flex_backend_module
+
+    monkeypatch.setattr(config_module, "get_world_size_safe", lambda: 72)
+    monkeypatch.setattr(
+        flex_backend_module.torch.cuda,
+        "get_device_properties",
+        lambda unused_device: SimpleNamespace(major=10, name="NVIDIA GB300"),
+    )
+
+    config_module.runtime_config_update(recipe_fn())

--- a/tests/unit_tests/scripts/performance/test_executors.py
+++ b/tests/unit_tests/scripts/performance/test_executors.py
@@ -34,8 +34,10 @@ except ImportError:
     HAS_NEMO_RUN = False
 
 if HAS_NEMO_RUN:
+    from argument_parser import parse_cli_args
     from setup_experiment import _build_nemorun_script
     from utils.executors import (
+        INLINE_TEMPLATE,
         KUBEFLOW_NUMA_BINDING_ENV,
         PERF_ENV_VARS,
         _kubeflow_numa_binding_enabled,
@@ -137,3 +139,78 @@ def test_kubeflow_numa_binding_is_disabled_by_default():
     """Normal Kubeflow jobs must retain the unmodified Torchrun launcher."""
     assert not _kubeflow_numa_binding_enabled({})
     assert not _kubeflow_numa_binding_enabled({KUBEFLOW_NUMA_BINDING_ENV: "0"})
+
+
+@pytest.mark.skipif(not HAS_NEMO_RUN, reason="nemo_run not installed")
+def test_parser_accepts_repeatable_post_hooks():
+    args = parse_cli_args().parse_args(
+        [
+            "--model_family_name",
+            "llama",
+            "--model_recipe_name",
+            "llama3_8b",
+            "--num_gpus",
+            "8",
+            "--gpu",
+            "h100",
+            "--custom_post_bash_cmds",
+            "echo",
+            "post-one",
+            "--custom_post_bash_cmds",
+            "echo",
+            "post-two",
+        ]
+    )
+
+    assert args.custom_post_bash_cmds == [["echo", "post-one"], ["echo", "post-two"]]
+
+
+@pytest.mark.skipif(not HAS_NEMO_RUN, reason="nemo_run not installed")
+def test_slurm_executor_preserves_training_status_and_defaults_to_noop_post_hook(tmp_path):
+    executor = slurm_executor(
+        gpu="h100",
+        account="test",
+        partition="test",
+        log_dir=str(tmp_path),
+        nodes=1,
+        num_gpus_per_node=8,
+    )
+
+    assert executor.launcher.template_vars["post_cmds"] == ":"
+    assert "NEMO_RUN_TRAINING_EXIT_CODE" in INLINE_TEMPLATE
+    assert 'exit "${TRAIN_RC}"' in INLINE_TEMPLATE
+
+
+@pytest.mark.skipif(not HAS_NEMO_RUN, reason="nemo_run not installed")
+def test_slurm_executor_renders_custom_post_hooks(tmp_path):
+    executor = slurm_executor(
+        gpu="h100",
+        account="test",
+        partition="test",
+        log_dir=str(tmp_path),
+        nodes=1,
+        num_gpus_per_node=8,
+        custom_post_bash_cmds=[["echo", "first"], ["echo", "second"]],
+    )
+
+    assert executor.launcher.template_vars["post_cmds"] == "echo first ; echo second"
+
+
+@pytest.mark.skipif(not HAS_NEMO_RUN, reason="nemo_run not installed")
+def test_kubeflow_script_wraps_pre_and_post_hooks():
+    task = _build_nemorun_script(
+        script_path="/opt/Megatron-Bridge/scripts/performance/run_script.py",
+        script_dir="/opt/Megatron-Bridge/scripts/performance",
+        args=["--max_steps", "10"],
+        kubeflow_namespace="nemo-ci",
+        custom_env_vars={},
+        custom_bash_cmds=[["bash", "/hooks/pre.sh"]],
+        custom_post_bash_cmds=[["bash", "/hooks/post.sh"]],
+    )
+
+    wrapped = task.args[0]
+    assert task.entrypoint == "bash"
+    assert "bash /hooks/pre.sh" in wrapped
+    assert "bash /hooks/post.sh" in wrapped
+    assert "NEMO_RUN_TRAINING_EXIT_CODE" in wrapped
+    assert 'exit "${TRAIN_RC}"' in wrapped

--- a/tests/unit_tests/scripts/performance/test_perf_plugins.py
+++ b/tests/unit_tests/scripts/performance/test_perf_plugins.py
@@ -36,6 +36,7 @@ pytestmark = pytest.mark.skipif(not HAS_NEMO_RUN, reason="nemo_run not installed
 
 if HAS_NEMO_RUN:
     from perf_plugins import PerfEnvPlugin
+    from utils.utils import WorkloadBaseConfig
 
 
 def test_set_determinism_env_vars_writes_three_keys():
@@ -55,3 +56,33 @@ def test_set_determinism_env_vars_writes_three_keys():
     assert executor.env_vars["NCCL_ALGO"] == "Ring"
     assert executor.env_vars["NVTE_ALLOW_NONDETERMINISTIC_ALGO"] == "0"
     assert executor.env_vars["CUBLAS_WORKSPACE_CONFIG"] == ":4096:8"
+
+
+def test_nemodiag_mxfp8_environment_preserves_determinism_and_cudnn_layernorm():
+    plugin = PerfEnvPlugin(
+        model_family_name="nemodiag",
+        model_recipe_name="nemodiag_v0",
+        gpu="gb300",
+        compute_dtype="fp8_mx",
+        train_task="pretrain",
+    )
+    executor = MagicMock()
+    executor.env_vars = {
+        "NVTE_NORM_FWD_USE_CUDNN": "1",
+        "NVTE_NORM_BWD_USE_CUDNN": "1",
+    }
+
+    plugin._set_model_specific_environment_variables(
+        MagicMock(),
+        executor,
+        WorkloadBaseConfig(),
+        model_family_name="nemodiag",
+        model_recipe_name="nemodiag_v0",
+        gpu="gb300",
+        compute_dtype="fp8_mx",
+        train_task="pretrain",
+    )
+
+    assert executor.env_vars["NVTE_ALLOW_NONDETERMINISTIC_ALGO"] == "0"
+    assert executor.env_vars["NVTE_NORM_FWD_USE_CUDNN"] == "1"
+    assert executor.env_vars["NVTE_NORM_BWD_USE_CUDNN"] == "1"


### PR DESCRIPTION
# What does this PR do ?

Adds a standalone NeMoDiag V0 synthetic performance recipe and the launcher hooks required by ClusterDiag, without resolving NeMoDiag through another model recipe or HF model identity.

# Changelog

- Add explicit MLAModelProvider-based NeMoDiag V0 recipes for 72, 144, and 288 GB300 GPUs in BF16, MXFP8, and NVFP4.
- Keep runtime tokenizer configuration self-contained with NullTokenizer and no HF model ID.
- Add independent NeMoDiag pipeline-layout and performance environment handling.
- Add Slurm and Kubeflow post-run hooks that preserve the training exit code.
- Add recipe discovery, runtime validation, launcher hook, and environment regression tests.

# GitHub Actions CI

Related unit tests: 48 passed in the project container. Full pre-commit: passed. The functional test module could not start locally because its session fixture requires GH_TOKEN to download test assets.

# Before your PR is Ready for review

- [x] Read and followed the contributor guidelines.
- [x] Added necessary tests.
- [x] No documentation change is required; the ClusterDiag-facing documentation is in the companion PR.
- [x] This does not add a new optional dependency.

# Additional Information

Companion nemo-clusterdiag PR will mount branch yuya/nemodiag-v0-standalone and neutralize profile, data, cache, fixture, and documentation naming.