### PR TITLE
[diffusion, data] fix: pad WAN context for CP

### DIFF
--- a/src/megatron/bridge/diffusion/data/wan/wan_taskencoder.py
+++ b/src/megatron/bridge/diffusion/data/wan/wan_taskencoder.py
@@ -130,6 +130,7 @@ class WanTaskEncoder(DiffusionTaskEncoderWithSequencePacking):
         if seq_len_q < seq_len_q_padded:
             video_latent = F.pad(video_latent, (0, 0, 0, seq_len_q_padded - seq_len_q))
             loss_mask = F.pad(loss_mask, (0, seq_len_q_padded - seq_len_q))
+        if seq_len_kv < seq_len_kv_padded:
             context_embeddings = F.pad(context_embeddings, (0, 0, 0, seq_len_kv_padded - seq_len_kv))
 
         ### Note: shape of sample's values

--- a/tests/unit_tests/diffusion/data/wan/test_wan_taskencoder.py
+++ b/tests/unit_tests/diffusion/data/wan/test_wan_taskencoder.py
@@ -101,6 +101,37 @@ def test_encode_sample_no_context_parallel(monkeypatch):
     assert out.__subflavors__ == sample["__subflavors__"]
 
 
+def test_batch_context_matches_padded_kv_length_with_cp(monkeypatch):
+    monkeypatch.setattr(parallel_state, "get_context_parallel_world_size", lambda: 3, raising=False)
+
+    from megatron.energon.task_encoder.base import WorkerConfig
+
+    class _FakeWorkerCfg:
+        def worker_seed(self):
+            return 789
+
+        active_worker_sample_index = 0
+
+    monkeypatch.setattr(WorkerConfig, "active_worker_config", _FakeWorkerCfg(), raising=False)
+
+    encoder = WanTaskEncoder(seq_length=43008, patch_temporal=1, patch_spatial=2, packing_buffer_size=200)
+    encoded = encoder.encode_sample(
+        {
+            "__key__": "k",
+            "__restore_key__": "rk",
+            "__subflavors__": [],
+            "json": {"meta": 1},
+            "pth": torch.randn(16, 1, 4, 6),
+            "pickle": torch.randn(226, 4096),
+        }
+    )
+    batch = encoder.batch([encoded])
+
+    assert encoded.seq_len_q.item() == 6
+    assert encoded.seq_len_q_padded.item() == 6
+    assert batch["context_embeddings"].shape[0] == batch["seq_len_kv_padded"].sum().item()
+
+
 def test_batch_with_packing_buffer_size(monkeypatch):
     # Force CP world size 1
     monkeypatch.setattr(parallel_state, "get_context_parallel_world_size", lambda: 1, raising=False)


### PR DESCRIPTION
## What does this PR do?

Fix WAN real-data training when context parallelism requires KV padding but the video query sequence is already aligned.

With `model.context_parallel_size=3` and THD QKV format, WAN pads its fixed 512-token text context metadata to 516 tokens. For a video whose patch count is already divisible by six, the query-padding branch did not run, so the actual context tensor stayed at 512 rows while cross-attention advertised a padded endpoint of 516. Transformer Engine then receives inconsistent THD partition metadata and fails before the first training step.

## Root cause and fix

`WanTaskEncoder.encode_sample` coupled context padding to the query-padding condition. Q and KV lengths are independent, so query alignment does not imply KV alignment.

The fix gives KV/context padding its own length guard. It does not change aligned inputs or WAN model behavior.

## Regression evidence

Run in the project development container:

```bash
uv run --no-sync python -m pytest tests/unit_tests/diffusion/data/wan/test_wan_taskencoder.py::test_batch_context_matches_padded_kv_length_with_cp -q
```

- Before the production fix: failed with `assert 512 == 516`.
- After the fix: `1 passed`.

Focused adjacent validation:

```bash
uv run --no-sync python -m pytest \
  tests/unit_tests/diffusion/data/wan/test_wan_taskencoder.py \
  tests/unit_tests/diffusion/data/wan/test_wan_mock_datamodule.py \
  tests/unit_tests/diffusion/data/wan/test_wan_energon_datamodule.py \
  tests/unit_tests/diffusion/model/wan/flow_matching/test_flow_matching_pipeline_wan.py \
  tests/unit_tests/diffusion/model/wan/test_wan_step.py -q
```

Result: `13 passed, 1 skipped`. The skipped test is the existing CUDA-only `wan_data_step` check in the CPU validation container.

```bash
git diff --check
uv run --no-sync pre-commit run --all-files
```

Both passed; all configured pre-commit hooks were green.

## Scope

This changes only WAN task-encoder KV padding and adds one focused unit regression. It does not modify dependencies, workflows, public APIs, Megatron-Core, checkpoint formats, or model math. No full-suite, GPU training, convergence, quality, or performance claim is made.
