### PR TITLE
[doc, recipe] fix: correct Gemma3-VL recipe names

### DIFF
--- a/examples/models/gemma/gemma3_vl/README.md
+++ b/examples/models/gemma/gemma3_vl/README.md
@@ -85,9 +85,12 @@ The image is a table comparing the technical specifications of two
 
 - See: [bridge.recipes.gemma3_vl](../../../../docs/apidocs/bridge/bridge.recipes.gemma3_vl.md)
 - Available recipes:
-  - `gemma3_vl_4b_finetune_config`: Finetuning for 4B VL model with PEFT support
-  - `gemma3_vl_12b_finetune_config`: Finetuning for 12B VL model with PEFT support
-  - `gemma3_vl_27b_finetune_config`: Finetuning for 27B VL model with PEFT support
+  - `gemma3_vl_4b_sft_config`: Full-parameter SFT for the 4B VL model
+  - `gemma3_vl_4b_peft_config`: PEFT for the 4B VL model
+  - `gemma3_vl_12b_sft_config`: Full-parameter SFT for the 12B VL model
+  - `gemma3_vl_12b_peft_config`: PEFT for the 12B VL model
+  - `gemma3_vl_27b_sft_config`: Full-parameter SFT for the 27B VL model
+  - `gemma3_vl_27b_peft_config`: PEFT for the 27B VL model
 
 Before training, ensure the following environment variables are set:
 1. `SAVE_DIR`: checkpoint and log saving directory

--- a/tests/unit_tests/doc_consistency/test_readme_consistency.py
+++ b/tests/unit_tests/doc_consistency/test_readme_consistency.py
@@ -31,6 +31,8 @@ RECIPES_DIR = REPO_ROOT / "src" / "megatron" / "bridge" / "recipes"
 TRAINING_README = REPO_ROOT / "scripts" / "training" / "README.md"
 LLAMA_README = REPO_ROOT / "tutorials" / "recipes" / "llama" / "README.md"
 DCLM_README = REPO_ROOT / "tutorials" / "data" / "dclm" / "README.md"
+GEMMA3_VL_README = REPO_ROOT / "examples" / "models" / "gemma" / "gemma3_vl" / "README.md"
+GEMMA3_VL_RECIPES = RECIPES_DIR / "gemma3_vl" / "gemma3_vl.py"
 RUN_RECIPE = REPO_ROOT / "scripts" / "training" / "run_recipe.py"
 TRAINING_CONFIG = REPO_ROOT / "src" / "megatron" / "bridge" / "training" / "config.py"
 
@@ -55,6 +57,16 @@ def test_training_readme_recipes_exist():
     referenced = set(re.findall(r"--recipe\s+(\w+)", _read(TRAINING_README)))
     missing = sorted(r for r in referenced if r not in defined)
     assert not missing, f"README references nonexistent recipes: {missing}"
+
+
+def test_gemma3_vl_readme_recipes_are_exported():
+    """Every Gemma3-VL recipe advertised in its README is a launcher-visible alias."""
+    documented = set(re.findall(r"`(gemma3_vl_\w+_config)`", _read(GEMMA3_VL_README)))
+    assert documented, "no Gemma3-VL recipe configs documented"
+
+    exported = set(re.findall(r"as\s+(gemma3_vl_\w+_config)", _read(GEMMA3_VL_RECIPES)))
+    missing = sorted(documented - exported)
+    assert not missing, f"Gemma3-VL README references unexported recipes: {missing}"
 
 
 def test_llama_readme_conversion_path_exists():


### PR DESCRIPTION
## Problem

The Gemma3-VL example README advertises three `*_finetune_config` recipe names. Those aliases are not exported by `megatron.bridge.recipes`, so the supported `scripts/training/run_recipe.py --recipe ...` path rejects every documented name with `AttributeError` before training starts.

## Root cause

Gemma3-VL recipes were split into distinct SFT and PEFT aliases, but the README retained the former combined finetune names. The launcher performs a literal recipe-module lookup and has no compatibility rewrite for those stale names.

## Fix

List the six exported SFT/PEFT aliases and describe their modes. Add a doc-consistency regression test that checks every Gemma3-VL recipe name advertised in the README against the launcher-visible family aliases.

## Validation

Fail-before on the unmodified documentation:

- `uv run --no-sync python -m pytest tests/unit_tests/doc_consistency/test_readme_consistency.py -q`
- Result: `1 failed, 5 passed`; the failure identifies all three unexported documented names.

Pass-after and adjacent coverage:

- `uv run --no-sync python -m pytest tests/unit_tests/doc_consistency/test_readme_consistency.py::test_gemma3_vl_readme_recipes_are_exported tests/unit_tests/recipes/test_gemma3_vl_recipes.py -q`
- Result: `27 passed`.
- `uv run --no-sync python -m pytest tests/unit_tests/doc_consistency/test_readme_consistency.py -q`
- Result: `6 passed`.
- `uv run --no-sync pre-commit run --all-files`
- Result: all hooks passed.
- `git diff --check`
- Result: passed.

## Scope

This changes only the documented recipe names and their static consistency coverage. It does not change recipe implementations, launcher behavior, dependencies, conversion APIs, or CI workflows.