### PR TITLE
fix(data): retry packed-parquet resolution with NFS directory-metadata refresh (#4207)

### DIFF
--- a/src/megatron/bridge/data/builders/gpt_sft.py
+++ b/src/megatron/bridge/data/builders/gpt_sft.py
@@ -34,6 +34,7 @@ from megatron.bridge.data.packing import PackedSequenceSpecs
 from megatron.bridge.data.packing.paths import (
     is_packed_parquet_spec,
     resolve_packed_parquet_paths,
+    resolve_packed_parquet_paths_with_retry,
 )
 from megatron.bridge.data.sft_processing import (
     ChatSFTPreprocessingConfig,
@@ -436,7 +437,9 @@ def build_gpt_sft_split(
     path_str = str(path)
     if is_packed_parquet_spec(path_str):
         try:
-            path_exists = bool(resolve_packed_parquet_paths(path_str))
+            # Retry with directory-metadata refresh: on NFS filesystems a non-producer
+            # node can transiently see zero files right after rank 0 wrote them (#4207).
+            path_exists = bool(resolve_packed_parquet_paths_with_retry(path_str))
         except ValueError:
             path_exists = False
     elif MultiStorageClientFeature.is_enabled():

--- a/src/megatron/bridge/data/packing/paths.py
+++ b/src/megatron/bridge/data/packing/paths.py
@@ -15,10 +15,15 @@
 """Path detection and resolution for packed Parquet artifacts."""
 
 import glob
+import logging
 import os
+import time
 from pathlib import Path
 
 from megatron.core.msc_utils import MultiStorageClientFeature
+
+
+logger = logging.getLogger(__name__)
 
 
 def is_packed_parquet_file(path) -> bool:
@@ -212,3 +217,78 @@ def resolve_packed_parquet_paths(spec: str | Path) -> list[str]:
         ValueError: If no matching files are found.
     """
     return _resolve_parquet_paths(str(spec))
+
+
+def _refresh_directory_metadata(spec: str) -> None:
+    """Force a listdir on the nearest existing ancestor to bust stale NFS directory-cache entries.
+
+    On NFS filesystems (e.g. Isilon NFSv4.0) a node that did not write a
+    directory may cache a negative "not found" result for up to acdirmin
+    seconds (~30 s by default).  Calling os.listdir() on the nearest existing
+    ancestor forces the NFS client to issue GETATTR+READDIR to the server,
+    collapsing the negative-cache window within one RPC round-trip.
+    """
+    base = spec.split("*", 1)[0]
+    directory = Path(base if os.path.isdir(base) else os.path.dirname(base))
+    while True:
+        try:
+            os.listdir(directory)
+            return
+        except OSError:
+            parent = directory.parent
+            if parent == directory:
+                return
+            directory = parent
+
+
+def resolve_packed_parquet_paths_with_retry(
+    spec: str | Path,
+    *,
+    max_attempts: int = 10,
+    backoff_s: float = 1.0,
+) -> list[str]:
+    """Resolve packed parquet spec with NFS-aware retries and directory-metadata refresh.
+
+    On distributed NFS filesystems (e.g. Isilon NFSv4.0), a node that did not
+    write a directory may see stale cached metadata for ~30 s after rank 0 writes
+    it.  Issuing os.listdir() on the nearest existing ancestor forces a fresh
+    GETATTR/READDIR to the NFS server, collapsing the negative-cache window
+    within one retry cycle.  With max_attempts=10 and backoff_s=1.0 the total
+    budget is 1+2+...+9 = 45 s, comfortably above the measured 29 s window.
+    See NVIDIA-NeMo/Megatron-Bridge#4207.
+
+    Args:
+        spec: Path specification (file, glob pattern, or directory).
+        max_attempts: Maximum number of resolution attempts (default 10).
+        backoff_s: Base sleep duration in seconds; attempt N sleeps N*backoff_s (default 1.0).
+
+    Returns:
+        Sorted list of resolved file paths.
+
+    Raises:
+        ValueError: If no matching files are found after all attempts.
+    """
+    spec_str = str(spec)
+    last_error: ValueError | None = None
+    for attempt in range(1, max_attempts + 1):
+        try:
+            resolved = _resolve_parquet_paths(spec_str)
+        except ValueError as exc:
+            resolved = []
+            last_error = exc
+        if resolved:
+            if attempt > 1:
+                logger.warning("Packed Parquet spec %s resolved after %d attempt(s).", spec_str, attempt)
+            return resolved
+        if attempt < max_attempts:
+            logger.warning(
+                "Packed Parquet spec %s returned no files (attempt %d/%d); refreshing NFS directory metadata ...",
+                spec_str,
+                attempt,
+                max_attempts,
+            )
+            _refresh_directory_metadata(spec_str)
+            time.sleep(backoff_s * attempt)
+    if last_error is not None:
+        raise last_error
+    return []


### PR DESCRIPTION
## Problem

On multi-node finetuning runs against NFS filesystems (e.g. Isilon NFSv4.0), a
non-producer node can see stale directory metadata for ~30 s after rank 0 writes
packed Parquet files. `build_gpt_sft_split` calls `resolve_packed_parquet_paths`
once and returns `None` when zero files resolve, causing:

```
TypeError: 'NoneType' object is not an iterator
```

Root cause (measured directly on the affected cluster):
- `/jet/artifacts` is served by Isilon NFSv4.0 with different NFS heads per node
- Cross-node directory visibility lag: ~29 s, systematic across 20/20 rounds
- Matches the Linux NFS client attribute-cache TTL (`acdirmin ≈ 30 s`)

Note: the original issue mentions "e.g. Lustre" but this is not Lustre-specific —
any NFS filesystem with attribute caching can exhibit this behaviour.

## Fix

Two additions to `packing/paths.py`:

1. `_refresh_directory_metadata(spec)`: walks UP the path tree to the nearest
   existing ancestor and calls `os.listdir()`, forcing the NFS client to issue
   `GETATTR`+`READDIR` to the server and collapse the negative-cache window within
   one RPC round-trip.

2. `resolve_packed_parquet_paths_with_retry(spec, *, max_attempts=10, backoff_s=1.0)`:
   retries with metadata refresh on each miss. With linear back-off
   (1 s, 2 s, … 9 s), total budget = 45 s, safely above the measured ~29 s window.

`build_gpt_sft_split` now uses the retry-aware resolver.

## Verification

Tested on a 2-node GB200 NVL setup that had a 100% failure rate before this fix.
**5/5 runs passed** after applying the patch, across distinct node pairs.

## Credit

The original diagnosis and fix structure are from @lonexreb (#4207, PR #4798).
This PR addresses two issues identified in the original approach:

1. **`_refresh_directory_metadata` silent-fail on non-existent path**: the original
   returned immediately when the target path didn't exist yet, refreshing nothing.
   The tree-walk here continues to the nearest existing ancestor, so the refresh
   always reaches a real directory.

2. **Retry budget too short**: 5 attempts × ~4 s back-off ≈ 20 s was shorter than
   the measured ~29 s window. The new budget (45 s) has headroom.