### PR TITLE
[do not merge] backport Qwen3.5 and Nemotron 3 Nano pretraining to r0.5.0

### DIFF
--- a/docs/models/qwen/qwen35-vl.md
+++ b/docs/models/qwen/qwen35-vl.md
@@ -52,6 +52,27 @@ Please upgrade to `transformers` >= 5.2.0 in order to use the Qwen 3.5 models.
 
 For checkpoint conversion, inference, finetuning recipes, and step-by-step training guides, see the [Qwen 3.5 Examples](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/examples/models/qwen/qwen35_vl/README.md).
 
+### Text-only pretraining
+
+The Qwen3.5 35B-A3B recipe can pretrain only the language-model component of
+the unified model. It derives the registered language-model provider from the
+nested Hugging Face `text_config`; no vision model, projection, processor, or
+multimodal dataset is created.
+
+```python
+from megatron.bridge.recipes.qwen import qwen35_35b_a3b_pretrain_config
+
+config = qwen35_35b_a3b_pretrain_config()
+```
+
+The canonical alias selects the eight-GPU GB200 BF16 library recipe,
+`qwen35_35b_a3b_pretrain_8gpu_gb200_bf16_config`. It uses the Qwen3.5-VL GB200
+topology and applicable performance settings while retaining library-recipe
+training, evaluation, logging, checkpointing, and correctness defaults. The
+text-only recipe uses learned routing and fixed-length text batches; it does
+not create or freeze any vision components. Set `config.dataset.blend` (or
+`config.dataset.data_path`) to use a prepared Megatron indexed text dataset.
+
 ## Hugging Face Model Cards
 
 - Qwen3.5 0.8B: https://huggingface.co/Qwen/Qwen3.5-0.8B

--- a/docs/models/qwen/qwen35-vl.md
+++ b/docs/models/qwen/qwen35-vl.md
@@ -54,24 +54,26 @@ For checkpoint conversion, inference, finetuning recipes, and step-by-step train
 
 ### Text-only pretraining
 
-The Qwen3.5 35B-A3B recipe can pretrain only the language-model component of
-the unified model. It derives the registered language-model provider from the
-nested Hugging Face `text_config`; no vision model, projection, processor, or
-multimodal dataset is created.
+The Qwen3.5 9B and 35B-A3B recipes can pretrain only the language-model
+component of the unified models. They derive the registered language-model
+provider from the nested Hugging Face `text_config`; no vision model,
+projection, processor, or multimodal dataset is created.
 
 ```python
-from megatron.bridge.recipes.qwen import qwen35_35b_a3b_pretrain_config
+from megatron.bridge.recipes.qwen import qwen35_9b_pretrain_config
 
-config = qwen35_35b_a3b_pretrain_config()
+config = qwen35_9b_pretrain_config()
 ```
 
-The canonical alias selects the eight-GPU GB200 BF16 library recipe,
-`qwen35_35b_a3b_pretrain_8gpu_gb200_bf16_config`. It uses the Qwen3.5-VL GB200
-topology and applicable performance settings while retaining library-recipe
-training, evaluation, logging, checkpointing, and correctness defaults. The
-text-only recipe uses learned routing and fixed-length text batches; it does
-not create or freeze any vision components. Set `config.dataset.blend` (or
-`config.dataset.data_path`) to use a prepared Megatron indexed text dataset.
+The canonical aliases select eight-GPU GB200 BF16 library recipes. The dense
+9B recipe, `qwen35_9b_pretrain_8gpu_gb200_bf16_config`, uses the same data
+parallel topology as the Llama 3 8B GB200 performance recipe, with
+module-scoped CUDA graphs so library correctness checks remain enabled. The MoE recipe,
+`qwen35_35b_a3b_pretrain_8gpu_gb200_bf16_config`, uses the applicable Qwen3.5-VL
+GB200 HybridEP settings with learned routing. Both retain library-recipe
+training, evaluation, logging, checkpointing, and correctness defaults. Set
+`config.dataset.blend` (or `config.dataset.data_path`) to use a prepared
+Megatron indexed text dataset.
 
 ## Hugging Face Model Cards
 

--- a/src/megatron/bridge/recipes/nemotronh/__init__.py
+++ b/src/megatron/bridge/recipes/nemotronh/__init__.py
@@ -14,6 +14,10 @@
 
 # Nemotron Nano v2 models
 # Nemotron 3 Nano models
+from megatron.bridge.recipes.nemotronh.gb200 import (
+    nemotron_3_nano_gb200_pretrain_config,
+    nemotron_3_nano_pretrain_8gpu_gb200_bf16_config,
+)
 from megatron.bridge.recipes.nemotronh.nemotron_3_nano import (
     nemotron_3_nano_peft_config,
     nemotron_3_nano_pretrain_config,
@@ -82,6 +86,8 @@ __all__ = [
     "nemotron_3_nano_pretrain_config",
     "nemotron_3_nano_sft_config",
     "nemotron_3_nano_peft_config",
+    "nemotron_3_nano_gb200_pretrain_config",
+    "nemotron_3_nano_pretrain_8gpu_gb200_bf16_config",
     # Nemotron 3 Super models
     "nemotron_3_super_pretrain_config",
     "nemotron_3_super_sft_config",

--- a/src/megatron/bridge/recipes/nemotronh/gb200/__init__.py
+++ b/src/megatron/bridge/recipes/nemotronh/gb200/__init__.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from megatron.bridge.recipes.nemotronh.gb200.nemotron_3_nano import (
+    nemotron_3_nano_gb200_pretrain_config,
+    nemotron_3_nano_pretrain_8gpu_gb200_bf16_config,
+)
+
+
+__all__ = [
+    "nemotron_3_nano_gb200_pretrain_config",
+    "nemotron_3_nano_pretrain_8gpu_gb200_bf16_config",
+]

--- a/src/megatron/bridge/recipes/nemotronh/gb200/nemotron_3_nano.py
+++ b/src/megatron/bridge/recipes/nemotronh/gb200/nemotron_3_nano.py
@@ -16,6 +16,7 @@
 
 from megatron.bridge.recipes.nemotronh.nemotron_3_nano import nemotron_3_nano_pretrain_config
 from megatron.bridge.training.config import ConfigContainer
+from megatron.bridge.training.mixed_precision import get_mixed_precision_config
 from megatron.bridge.utils.cuda_graph import set_cuda_graph_modules
 
 
@@ -56,6 +57,18 @@ def nemotron_3_nano_pretrain_8gpu_gb200_bf16_config() -> ConfigContainer:
     cfg.model.cuda_graph_warmup_steps = 3
     cfg.model.use_te_rng_tracker = True
     cfg.rng.te_rng_tracker = True
+
+    # Retain performance-recipe parity. Nemotron 3 Nano uses no positional
+    # embeddings, so this remains a no-op unless the architecture changes.
+    cfg.model.apply_rope_fusion = True
+    cfg.model.cross_entropy_fusion_impl = "native"
+    cfg.rerun_state_machine.check_for_nan_in_loss = False
+    cfg.ddp.check_for_nan_in_grad = False
+
+    # Keep BF16 compute while reducing gradients in BF16 instead of FP32.
+    cfg.mixed_precision = get_mixed_precision_config(cfg.mixed_precision)
+    cfg.mixed_precision.grad_reduce_in_fp32 = False
+    cfg.ddp.grad_reduce_in_fp32 = False
 
     # TP communication overlap requires TP > 1 and sequence parallelism.
     if cfg.comm_overlap is not None:

--- a/src/megatron/bridge/recipes/nemotronh/gb200/nemotron_3_nano.py
+++ b/src/megatron/bridge/recipes/nemotronh/gb200/nemotron_3_nano.py
@@ -16,7 +16,7 @@
 
 from megatron.bridge.recipes.nemotronh.nemotron_3_nano import nemotron_3_nano_pretrain_config
 from megatron.bridge.training.config import ConfigContainer
-from megatron.bridge.utils.cuda_graph import clear_cuda_graph_modules
+from megatron.bridge.utils.cuda_graph import set_cuda_graph_modules
 
 
 def nemotron_3_nano_pretrain_8gpu_gb200_bf16_config() -> ConfigContainer:
@@ -50,12 +50,12 @@ def nemotron_3_nano_pretrain_8gpu_gb200_bf16_config() -> ConfigContainer:
     cfg.model.moe_shared_expert_overlap = False
     cfg.model.moe_router_force_load_balancing = False
 
-    # The scoped graph configuration exceeds memory at the library recipe's
-    # MBS2, so retain the validated eager execution path.
-    cfg.model.cuda_graph_impl = "none"
-    clear_cuda_graph_modules(cfg.model)
-    cfg.model.use_te_rng_tracker = False
-    cfg.rng.te_rng_tracker = False
+    # Match the validated GB200 performance recipe's TE-scoped graph set.
+    cfg.model.cuda_graph_impl = "transformer_engine"
+    set_cuda_graph_modules(cfg.model, ["attn", "mamba", "moe_router", "moe_preprocess"])
+    cfg.model.cuda_graph_warmup_steps = 3
+    cfg.model.use_te_rng_tracker = True
+    cfg.rng.te_rng_tracker = True
 
     # TP communication overlap requires TP > 1 and sequence parallelism.
     if cfg.comm_overlap is not None:

--- a/src/megatron/bridge/recipes/nemotronh/gb200/nemotron_3_nano.py
+++ b/src/megatron/bridge/recipes/nemotronh/gb200/nemotron_3_nano.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""GB200 pretraining recipe for Nemotron 3 Nano."""
+
+from megatron.bridge.recipes.nemotronh.nemotron_3_nano import nemotron_3_nano_pretrain_config
+from megatron.bridge.training.config import ConfigContainer
+from megatron.bridge.utils.cuda_graph import clear_cuda_graph_modules
+
+
+def nemotron_3_nano_pretrain_8gpu_gb200_bf16_config() -> ConfigContainer:
+    """Return the Nemotron 3 Nano BF16 pretraining config for eight GB200 GPUs.
+
+    The release-branch recipe retains the established optimizer, scheduler,
+    routing, and BF16 contracts. It applies the validated GB200 TP1/EP8
+    HybridEP topology and uses a 4,096-token sequence length for the paired
+    NeMo-CI convergence workload.
+
+    Returns:
+        GB200 BF16 pretraining configuration.
+    """
+    cfg = nemotron_3_nano_pretrain_config()
+
+    cfg.model.seq_length = 4096
+    cfg.dataset.seq_length = 4096
+
+    cfg.model.tensor_model_parallel_size = 1
+    cfg.model.pipeline_model_parallel_size = 1
+    cfg.model.virtual_pipeline_model_parallel_size = None
+    cfg.model.context_parallel_size = 1
+    cfg.model.sequence_parallel = False
+    cfg.model.expert_tensor_parallel_size = 1
+    cfg.model.expert_model_parallel_size = 8
+
+    cfg.model.moe_token_dispatcher_type = "flex"
+    cfg.model.moe_flex_dispatcher_backend = "hybridep"
+    # r0.5.0 uses this field for the HybridEP communication SM budget.
+    cfg.model.moe_hybridep_num_sms = 16
+    cfg.model.moe_shared_expert_overlap = False
+    cfg.model.moe_router_force_load_balancing = False
+
+    # The scoped graph configuration exceeds memory at the library recipe's
+    # MBS2, so retain the validated eager execution path.
+    cfg.model.cuda_graph_impl = "none"
+    clear_cuda_graph_modules(cfg.model)
+    cfg.model.use_te_rng_tracker = False
+    cfg.rng.te_rng_tracker = False
+
+    # TP communication overlap requires TP > 1 and sequence parallelism.
+    if cfg.comm_overlap is not None:
+        cfg.comm_overlap.tp_comm_overlap = False
+
+    return cfg
+
+
+# NeMo-CI appends ``_pretrain_config`` to MODEL_RECIPE_NAME. This explicit
+# alias lets the GB200 release case select the hardware recipe without changing
+# the legacy ``nemotron_3_nano_pretrain_config`` default.
+nemotron_3_nano_gb200_pretrain_config = nemotron_3_nano_pretrain_8gpu_gb200_bf16_config
+
+
+__all__ = [
+    "nemotron_3_nano_gb200_pretrain_config",
+    "nemotron_3_nano_pretrain_8gpu_gb200_bf16_config",
+]

--- a/src/megatron/bridge/recipes/qwen/__init__.py
+++ b/src/megatron/bridge/recipes/qwen/__init__.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Qwen3.5 GB200 models
+from .gb200.qwen35 import qwen35_35b_a3b_pretrain_8gpu_gb200_bf16_config
+
 # Qwen2 models
 from .qwen2 import (
     qwen2_1p5b_peft_config,
@@ -87,6 +90,9 @@ from .qwen3_next import (
     qwen3_next_80b_a3b_sft_config,
 )
 
+# Qwen3.5 text models
+from .qwen35 import qwen35_35b_a3b_pretrain_config
+
 
 __all__ = [
     # Qwen2 models
@@ -153,4 +159,7 @@ __all__ = [
     "qwen3_next_80b_a3b_pretrain_config",
     "qwen3_next_80b_a3b_sft_config",
     "qwen3_next_80b_a3b_peft_config",
+    # Qwen3.5 text models
+    "qwen35_35b_a3b_pretrain_config",
+    "qwen35_35b_a3b_pretrain_8gpu_gb200_bf16_config",
 ]

--- a/src/megatron/bridge/recipes/qwen/__init__.py
+++ b/src/megatron/bridge/recipes/qwen/__init__.py
@@ -13,7 +13,10 @@
 # limitations under the License.
 
 # Qwen3.5 GB200 models
-from .gb200.qwen35 import qwen35_35b_a3b_pretrain_8gpu_gb200_bf16_config
+from .gb200.qwen35 import (
+    qwen35_9b_pretrain_8gpu_gb200_bf16_config,
+    qwen35_35b_a3b_pretrain_8gpu_gb200_bf16_config,
+)
 
 # Qwen2 models
 from .qwen2 import (
@@ -91,7 +94,7 @@ from .qwen3_next import (
 )
 
 # Qwen3.5 text models
-from .qwen35 import qwen35_35b_a3b_pretrain_config
+from .qwen35 import qwen35_9b_pretrain_config, qwen35_35b_a3b_pretrain_config
 
 
 __all__ = [
@@ -160,6 +163,8 @@ __all__ = [
     "qwen3_next_80b_a3b_sft_config",
     "qwen3_next_80b_a3b_peft_config",
     # Qwen3.5 text models
+    "qwen35_9b_pretrain_config",
+    "qwen35_9b_pretrain_8gpu_gb200_bf16_config",
     "qwen35_35b_a3b_pretrain_config",
     "qwen35_35b_a3b_pretrain_8gpu_gb200_bf16_config",
 ]

--- a/src/megatron/bridge/recipes/qwen/gb200/__init__.py
+++ b/src/megatron/bridge/recipes/qwen/gb200/__init__.py
@@ -12,7 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from megatron.bridge.recipes.qwen.gb200.qwen35 import qwen35_35b_a3b_pretrain_8gpu_gb200_bf16_config
+from megatron.bridge.recipes.qwen.gb200.qwen35 import (
+    qwen35_9b_pretrain_8gpu_gb200_bf16_config,
+    qwen35_35b_a3b_pretrain_8gpu_gb200_bf16_config,
+)
 
 
-__all__ = ["qwen35_35b_a3b_pretrain_8gpu_gb200_bf16_config"]
+__all__ = [
+    "qwen35_9b_pretrain_8gpu_gb200_bf16_config",
+    "qwen35_35b_a3b_pretrain_8gpu_gb200_bf16_config",
+]

--- a/src/megatron/bridge/recipes/qwen/gb200/__init__.py
+++ b/src/megatron/bridge/recipes/qwen/gb200/__init__.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from megatron.bridge.recipes.qwen.gb200.qwen35 import qwen35_35b_a3b_pretrain_8gpu_gb200_bf16_config
+
+
+__all__ = ["qwen35_35b_a3b_pretrain_8gpu_gb200_bf16_config"]

--- a/src/megatron/bridge/recipes/qwen/gb200/qwen35.py
+++ b/src/megatron/bridge/recipes/qwen/gb200/qwen35.py
@@ -24,6 +24,7 @@ from megatron.bridge.models.gpt_provider import GPTModelProvider
 from megatron.bridge.recipes.common import _pretrain_common
 from megatron.bridge.training.comm_overlap import CommOverlapConfig
 from megatron.bridge.training.config import ConfigContainer
+from megatron.bridge.training.mixed_precision import bf16_mixed
 
 
 _QWEN35_9B_BASE = "Qwen/Qwen3.5-9B-Base"
@@ -78,9 +79,8 @@ def qwen35_9b_pretrain_8gpu_gb200_bf16_config() -> ConfigContainer:
     cfg.model.fine_grained_activation_offloading = False
     cfg.model.offload_modules = None
 
-    # Capture the dense attention and MLP modules while retaining the library
-    # recipe's loss-NaN rerun check. Full-iteration capture, as used by the
-    # Llama performance recipe, is incompatible with that correctness check.
+    # Capture the dense attention and MLP modules. Keep cross entropy on the
+    # native fused path validated by the 64-GPU GB200 performance run.
     cfg.model.cuda_graph_impl = "transformer_engine"
     cfg.model.cuda_graph_scope = None
     cfg.model.cuda_graph_modules = ["attn", "mlp"]
@@ -94,11 +94,16 @@ def qwen35_9b_pretrain_8gpu_gb200_bf16_config() -> ConfigContainer:
     cfg.optimizer.exp_avg_dtype = torch.float32
     cfg.optimizer.exp_avg_sq_dtype = torch.float32
 
+    cfg.mixed_precision = bf16_mixed()
+    cfg.mixed_precision.grad_reduce_in_fp32 = False
+
     cfg.ddp.overlap_grad_reduce = True
     cfg.ddp.overlap_param_gather = True
-    cfg.ddp.check_for_nan_in_grad = True
+    cfg.ddp.grad_reduce_in_fp32 = False
+    cfg.ddp.check_for_nan_in_grad = False
     cfg.ddp.use_distributed_optimizer = True
     cfg.ddp.use_megatron_fsdp = False
+    cfg.rerun_state_machine.check_for_nan_in_loss = False
 
     cfg.comm_overlap = CommOverlapConfig(tp_comm_overlap=False)
     return cfg

--- a/src/megatron/bridge/recipes/qwen/gb200/qwen35.py
+++ b/src/megatron/bridge/recipes/qwen/gb200/qwen35.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""GB200 text-only pretraining recipe for Qwen3.5 MoE."""
+
+from __future__ import annotations
+
+import torch
+from transformers import AutoConfig
+
+from megatron.bridge import AutoBridge
+from megatron.bridge.models.gpt_provider import GPTModelProvider
+from megatron.bridge.models.hybrid.hybrid_provider import HybridModelProvider
+from megatron.bridge.recipes.common import _pretrain_common
+from megatron.bridge.training.comm_overlap import CommOverlapConfig
+from megatron.bridge.training.config import ConfigContainer
+
+
+_QWEN35_35B_A3B_BASE = "Qwen/Qwen3.5-35B-A3B-Base"
+
+
+def _qwen35_35b_a3b_text_provider() -> GPTModelProvider | HybridModelProvider:
+    """Build the language-model provider from the unified Qwen3.5 config."""
+    text_config = AutoConfig.from_pretrained(_QWEN35_35B_A3B_BASE).text_config
+    # The nested text config intentionally omits ``architectures``. AutoBridge
+    # needs it to select the registered causal-LM bridge instead of the VLM.
+    text_config.architectures = ["Qwen3_5MoeForCausalLM"]
+    return AutoBridge.from_hf_config(text_config).to_megatron_provider(load_weights=False)
+
+
+def qwen35_35b_a3b_pretrain_8gpu_gb200_bf16_config() -> ConfigContainer:
+    """Return a text-only Qwen3.5-35B-A3B pretraining config for eight GB200 GPUs."""
+    cfg = _pretrain_common()
+
+    cfg.model = _qwen35_35b_a3b_text_provider()
+    cfg.tokenizer.tokenizer_model = _QWEN35_35B_A3B_BASE
+    cfg.dataset.seq_length = 4096
+    cfg.dataset.blend = None
+    cfg.dataset.num_workers = 8
+
+    # Match the Qwen3.5-VL GB200 topology while training only the text model.
+    cfg.model.tensor_model_parallel_size = 1
+    cfg.model.pipeline_model_parallel_size = 1
+    cfg.model.pipeline_model_parallel_layout = None
+    cfg.model.pipeline_dtype = torch.bfloat16
+    cfg.model.virtual_pipeline_model_parallel_size = None
+    cfg.model.context_parallel_size = 1
+    cfg.model.expert_model_parallel_size = 8
+    cfg.model.expert_tensor_parallel_size = 1
+    cfg.model.sequence_parallel = False
+    cfg.model.seq_length = 4096
+    cfg.model.init_method_std = 0.02
+    cfg.train.global_batch_size = 512
+    # MBS4 is suitable for force-balanced throughput benchmarking, but OOMs
+    # with learned routing. MBS1 was validated with real RP2 data on GB200.
+    cfg.train.micro_batch_size = 1
+
+    cfg.model.transformer_impl = "transformer_engine"
+    cfg.model.bias_activation_fusion = True
+    cfg.model.moe_router_fusion = True
+    cfg.model.moe_permute_fusion = True
+    cfg.model.moe_grouped_gemm = True
+    cfg.model.cross_entropy_loss_fusion = True
+    # Keep the library-safe native implementation instead of the performance
+    # harness's TE cross-entropy path, which currently warns about stability.
+    cfg.model.cross_entropy_fusion_impl = "native"
+    cfg.model.apply_rope_fusion = True
+
+    cfg.model.recompute_granularity = None
+    cfg.model.recompute_method = None
+    cfg.model.recompute_num_layers = None
+    cfg.model.recompute_modules = None
+    cfg.model.fine_grained_activation_offloading = False
+    cfg.model.offload_modules = None
+
+    # Fixed-length text batches can use the scopes that the VLM recipe must
+    # disable for variable-length multimodal inputs.
+    cfg.model.cuda_graph_impl = "transformer_engine"
+    cfg.model.cuda_graph_scope = None
+    cfg.model.cuda_graph_modules = ["attn", "moe_router", "moe_preprocess"]
+    cfg.model.cuda_graph_warmup_steps = 3
+    cfg.model.use_te_rng_tracker = True
+    cfg.rng.te_rng_tracker = True
+
+    cfg.model.moe_token_dispatcher_type = "flex"
+    cfg.model.moe_flex_dispatcher_backend = "hybridep"
+    cfg.model.moe_flex_dispatcher_num_sms = 32
+    cfg.model.moe_hybridep_num_sms = None
+    cfg.model.moe_shared_expert_overlap = False
+    cfg.model.moe_router_force_load_balancing = False
+    cfg.model.moe_router_padding_for_fp8 = False
+
+    cfg.optimizer.use_precision_aware_optimizer = False
+    cfg.optimizer.main_grads_dtype = torch.float32
+    cfg.optimizer.main_params_dtype = torch.float32
+    cfg.optimizer.exp_avg_dtype = torch.float32
+    cfg.optimizer.exp_avg_sq_dtype = torch.float32
+    cfg.optimizer.overlap_param_gather_with_optimizer_step = False
+
+    cfg.ddp.overlap_grad_reduce = False
+    cfg.ddp.overlap_param_gather = False
+    cfg.ddp.check_for_nan_in_grad = True
+    cfg.ddp.use_distributed_optimizer = True
+    cfg.ddp.use_megatron_fsdp = False
+
+    cfg.comm_overlap = CommOverlapConfig(
+        tp_comm_overlap=True,
+        overlap_grad_reduce=False,
+        overlap_param_gather=False,
+    )
+    return cfg

--- a/src/megatron/bridge/recipes/qwen/gb200/qwen35.py
+++ b/src/megatron/bridge/recipes/qwen/gb200/qwen35.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""GB200 text-only pretraining recipe for Qwen3.5 MoE."""
+"""GB200 text-only pretraining recipes for Qwen3.5 dense and MoE models."""
 
 from __future__ import annotations
 
@@ -27,23 +27,89 @@ from megatron.bridge.training.comm_overlap import CommOverlapConfig
 from megatron.bridge.training.config import ConfigContainer
 
 
+_QWEN35_9B_BASE = "Qwen/Qwen3.5-9B-Base"
 _QWEN35_35B_A3B_BASE = "Qwen/Qwen3.5-35B-A3B-Base"
 
 
-def _qwen35_35b_a3b_text_provider() -> GPTModelProvider | HybridModelProvider:
-    """Build the language-model provider from the unified Qwen3.5 config."""
-    text_config = AutoConfig.from_pretrained(_QWEN35_35B_A3B_BASE).text_config
+def _qwen35_text_provider(model_id: str, architecture: str) -> GPTModelProvider | HybridModelProvider:
+    """Build a language-model provider from a unified Qwen3.5 config."""
+    text_config = AutoConfig.from_pretrained(model_id).text_config
     # The nested text config intentionally omits ``architectures``. AutoBridge
     # needs it to select the registered causal-LM bridge instead of the VLM.
-    text_config.architectures = ["Qwen3_5MoeForCausalLM"]
+    text_config.architectures = [architecture]
     return AutoBridge.from_hf_config(text_config).to_megatron_provider(load_weights=False)
+
+
+def qwen35_9b_pretrain_8gpu_gb200_bf16_config() -> ConfigContainer:
+    """Return a text-only Qwen3.5-9B pretraining config for eight GB200 GPUs."""
+    cfg = _pretrain_common()
+
+    cfg.model = _qwen35_text_provider(_QWEN35_9B_BASE, "Qwen3_5ForCausalLM")
+    cfg.tokenizer.tokenizer_model = _QWEN35_9B_BASE
+    cfg.dataset.seq_length = 4096
+    cfg.dataset.blend = None
+    cfg.dataset.num_workers = 8
+
+    # Follow the Llama 3 8B GB200 topology: keep model parallelism at one and
+    # use all eight GPUs for data parallelism.
+    cfg.model.tensor_model_parallel_size = 1
+    cfg.model.pipeline_model_parallel_size = 1
+    cfg.model.pipeline_model_parallel_layout = None
+    cfg.model.pipeline_dtype = torch.bfloat16
+    cfg.model.virtual_pipeline_model_parallel_size = None
+    cfg.model.context_parallel_size = 1
+    cfg.model.expert_model_parallel_size = 1
+    cfg.model.expert_tensor_parallel_size = 1
+    cfg.model.sequence_parallel = False
+    cfg.model.seq_length = 4096
+    cfg.model.init_method_std = 0.02
+    cfg.train.global_batch_size = 128
+    cfg.train.micro_batch_size = 2
+
+    cfg.model.transformer_impl = "transformer_engine"
+    cfg.model.bias_activation_fusion = True
+    cfg.model.cross_entropy_loss_fusion = True
+    cfg.model.cross_entropy_fusion_impl = "native"
+    cfg.model.apply_rope_fusion = True
+
+    cfg.model.recompute_granularity = None
+    cfg.model.recompute_method = None
+    cfg.model.recompute_num_layers = None
+    cfg.model.recompute_modules = None
+    cfg.model.fine_grained_activation_offloading = False
+    cfg.model.offload_modules = None
+
+    # Capture the dense attention and MLP modules while retaining the library
+    # recipe's loss-NaN rerun check. Full-iteration capture, as used by the
+    # Llama performance recipe, is incompatible with that correctness check.
+    cfg.model.cuda_graph_impl = "transformer_engine"
+    cfg.model.cuda_graph_scope = None
+    cfg.model.cuda_graph_modules = ["attn", "mlp"]
+    cfg.model.cuda_graph_warmup_steps = 3
+    cfg.model.use_te_rng_tracker = True
+    cfg.rng.te_rng_tracker = True
+
+    cfg.optimizer.use_precision_aware_optimizer = False
+    cfg.optimizer.main_grads_dtype = torch.float32
+    cfg.optimizer.main_params_dtype = torch.float32
+    cfg.optimizer.exp_avg_dtype = torch.float32
+    cfg.optimizer.exp_avg_sq_dtype = torch.float32
+
+    cfg.ddp.overlap_grad_reduce = True
+    cfg.ddp.overlap_param_gather = True
+    cfg.ddp.check_for_nan_in_grad = True
+    cfg.ddp.use_distributed_optimizer = True
+    cfg.ddp.use_megatron_fsdp = False
+
+    cfg.comm_overlap = CommOverlapConfig(tp_comm_overlap=False)
+    return cfg
 
 
 def qwen35_35b_a3b_pretrain_8gpu_gb200_bf16_config() -> ConfigContainer:
     """Return a text-only Qwen3.5-35B-A3B pretraining config for eight GB200 GPUs."""
     cfg = _pretrain_common()
 
-    cfg.model = _qwen35_35b_a3b_text_provider()
+    cfg.model = _qwen35_text_provider(_QWEN35_35B_A3B_BASE, "Qwen3_5MoeForCausalLM")
     cfg.tokenizer.tokenizer_model = _QWEN35_35B_A3B_BASE
     cfg.dataset.seq_length = 4096
     cfg.dataset.blend = None

--- a/src/megatron/bridge/recipes/qwen/gb200/qwen35.py
+++ b/src/megatron/bridge/recipes/qwen/gb200/qwen35.py
@@ -21,7 +21,6 @@ from transformers import AutoConfig
 
 from megatron.bridge import AutoBridge
 from megatron.bridge.models.gpt_provider import GPTModelProvider
-from megatron.bridge.models.hybrid.hybrid_provider import HybridModelProvider
 from megatron.bridge.recipes.common import _pretrain_common
 from megatron.bridge.training.comm_overlap import CommOverlapConfig
 from megatron.bridge.training.config import ConfigContainer
@@ -31,7 +30,7 @@ _QWEN35_9B_BASE = "Qwen/Qwen3.5-9B-Base"
 _QWEN35_35B_A3B_BASE = "Qwen/Qwen3.5-35B-A3B-Base"
 
 
-def _qwen35_text_provider(model_id: str, architecture: str) -> GPTModelProvider | HybridModelProvider:
+def _qwen35_text_provider(model_id: str, architecture: str) -> GPTModelProvider:
     """Build a language-model provider from a unified Qwen3.5 config."""
     text_config = AutoConfig.from_pretrained(model_id).text_config
     # The nested text config intentionally omits ``architectures``. AutoBridge

--- a/src/megatron/bridge/recipes/qwen/gb200/qwen35.py
+++ b/src/megatron/bridge/recipes/qwen/gb200/qwen35.py
@@ -160,8 +160,7 @@ def qwen35_35b_a3b_pretrain_8gpu_gb200_bf16_config() -> ConfigContainer:
 
     cfg.model.moe_token_dispatcher_type = "flex"
     cfg.model.moe_flex_dispatcher_backend = "hybridep"
-    cfg.model.moe_flex_dispatcher_num_sms = 32
-    cfg.model.moe_hybridep_num_sms = None
+    cfg.model.moe_hybridep_num_sms = 32
     cfg.model.moe_shared_expert_overlap = False
     cfg.model.moe_router_force_load_balancing = False
     cfg.model.moe_router_padding_for_fp8 = False

--- a/src/megatron/bridge/recipes/qwen/qwen35.py
+++ b/src/megatron/bridge/recipes/qwen/qwen35.py
@@ -17,8 +17,11 @@
 from __future__ import annotations
 
 from megatron.bridge.recipes.qwen.gb200.qwen35 import (
+    qwen35_9b_pretrain_8gpu_gb200_bf16_config as qwen35_9b_pretrain_config,
+)
+from megatron.bridge.recipes.qwen.gb200.qwen35 import (
     qwen35_35b_a3b_pretrain_8gpu_gb200_bf16_config as qwen35_35b_a3b_pretrain_config,
 )
 
 
-__all__ = ["qwen35_35b_a3b_pretrain_config"]
+__all__ = ["qwen35_9b_pretrain_config", "qwen35_35b_a3b_pretrain_config"]

--- a/src/megatron/bridge/recipes/qwen/qwen35.py
+++ b/src/megatron/bridge/recipes/qwen/qwen35.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ruff: noqa: F401
+"""Compatibility alias for the canonical Qwen3.5 text recipe."""
+
+from __future__ import annotations
+
+from megatron.bridge.recipes.qwen.gb200.qwen35 import (
+    qwen35_35b_a3b_pretrain_8gpu_gb200_bf16_config as qwen35_35b_a3b_pretrain_config,
+)
+
+
+__all__ = ["qwen35_35b_a3b_pretrain_config"]

--- a/tests/unit_tests/recipes/nemotronh/test_nemotron_3_nano_gb200.py
+++ b/tests/unit_tests/recipes/nemotronh/test_nemotron_3_nano_gb200.py
@@ -23,7 +23,7 @@ from megatron.bridge.recipes.nemotronh import (
 )
 from megatron.bridge.training import config as training_config
 from megatron.bridge.training.config import ConfigContainer
-from megatron.bridge.training.mixed_precision import get_mixed_precision_config
+from megatron.bridge.training.mixed_precision import MixedPrecisionConfig
 from megatron.bridge.utils.cuda_graph import cuda_graph_module_names
 
 
@@ -56,6 +56,14 @@ def test_nemotron_3_nano_gb200_pretrain_config() -> None:
     assert config.model.cuda_graph_warmup_steps == 3
     assert config.model.use_te_rng_tracker is True
     assert config.rng.te_rng_tracker is True
+    assert config.model.apply_rope_fusion is True
+    assert config.model.cross_entropy_fusion_impl == "native"
+    assert config.rerun_state_machine.check_for_nan_in_loss is False
+    assert config.ddp.check_for_nan_in_grad is False
+    assert isinstance(config.mixed_precision, MixedPrecisionConfig)
+    assert config.mixed_precision.bf16 is True
+    assert config.mixed_precision.grad_reduce_in_fp32 is False
+    assert config.ddp.grad_reduce_in_fp32 is False
     assert config.comm_overlap is not None
     assert config.comm_overlap.tp_comm_overlap is False
 
@@ -74,7 +82,10 @@ def test_nemotron_3_nano_gb200_retains_training_contract() -> None:
     assert config.optimizer.main_params_dtype == torch.float32
     assert config.optimizer.exp_avg_dtype == torch.float32
     assert config.optimizer.exp_avg_sq_dtype == torch.float32
-    assert config.mixed_precision == "bf16_mixed"
+    assert isinstance(config.mixed_precision, MixedPrecisionConfig)
+    assert config.mixed_precision.bf16 is True
+    assert config.mixed_precision.fp8 is None
+    assert config.mixed_precision.grad_reduce_in_fp32 is False
 
     assert config.model.moe_router_load_balancing_type == "seq_aux_loss"
     assert config.model.moe_aux_loss_coeff == 0.0001
@@ -83,7 +94,10 @@ def test_nemotron_3_nano_gb200_retains_training_contract() -> None:
     assert config.model.moe_router_padding_for_fp8 is False
     assert config.model.cross_entropy_loss_fusion is True
     assert config.model.cross_entropy_fusion_impl == "native"
-    assert config.ddp.check_for_nan_in_grad is True
+    assert config.model.apply_rope_fusion is True
+    assert config.rerun_state_machine.check_for_nan_in_loss is False
+    assert config.ddp.check_for_nan_in_grad is False
+    assert config.ddp.grad_reduce_in_fp32 is False
     assert config.ddp.use_distributed_optimizer is True
 
 
@@ -95,18 +109,17 @@ def test_nemotron_3_nano_gb200_aliases_are_discoverable() -> None:
 
 
 def test_nemotron_3_nano_gb200_validates_with_nemo_ci_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The 64-GPU release overrides should finalize without changing recipe topology."""
+    """The 64-GPU runtime update should preserve topology and precision contracts."""
     config = nemotron_3_nano_gb200_pretrain_config()
     config.train.global_batch_size = 512
     config.train.micro_batch_size = 2
-    config.mixed_precision = get_mixed_precision_config(config.mixed_precision)
 
     monkeypatch.setattr(training_config, "get_world_size_safe", lambda: 64)
     # The real release run performs this capability check on GB200. Unit
     # finalization only verifies the combined configuration contract.
     monkeypatch.setattr(training_config, "validate_flex_dispatcher_backend", lambda _model: None)
 
-    config.validate()
+    training_config.runtime_config_update(config)
 
     assert config.data_parallel_size == 64
     assert config.train.global_batch_size == 512
@@ -115,3 +128,14 @@ def test_nemotron_3_nano_gb200_validates_with_nemo_ci_overrides(monkeypatch: pyt
     assert config.dataset.seq_length == 4096
     assert config.validation.eval_global_batch_size == 512
     assert config.validation.eval_micro_batch_size == 2
+    assert config.model.bf16 is True
+    assert config.model.params_dtype == torch.bfloat16
+    assert config.ddp.grad_reduce_in_fp32 is False
+    assert config.optimizer.main_grads_dtype == torch.float32
+    assert config.optimizer.main_params_dtype == torch.float32
+    assert config.optimizer.exp_avg_dtype == torch.float32
+    assert config.optimizer.exp_avg_sq_dtype == torch.float32
+    assert config.model.moe_flex_dispatcher_backend == "hybridep"
+    assert config.model.moe_hybridep_num_sms == 16
+    assert config.model.cuda_graph_impl == "transformer_engine"
+    assert cuda_graph_module_names(config.model) == ["attn", "mamba", "moe_router", "moe_preprocess"]

--- a/tests/unit_tests/recipes/nemotronh/test_nemotron_3_nano_gb200.py
+++ b/tests/unit_tests/recipes/nemotronh/test_nemotron_3_nano_gb200.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+import megatron.bridge.recipes as recipes
+from megatron.bridge.models.mamba.mamba_provider import MambaModelProvider
+from megatron.bridge.recipes.nemotronh import (
+    nemotron_3_nano_gb200_pretrain_config,
+    nemotron_3_nano_pretrain_8gpu_gb200_bf16_config,
+)
+from megatron.bridge.training import config as training_config
+from megatron.bridge.training.config import ConfigContainer
+from megatron.bridge.training.mixed_precision import get_mixed_precision_config
+from megatron.bridge.utils.cuda_graph import cuda_graph_module_names
+
+
+def test_nemotron_3_nano_gb200_pretrain_config() -> None:
+    """The release backport should expose the validated GB200 execution contract."""
+    config = nemotron_3_nano_pretrain_8gpu_gb200_bf16_config()
+
+    assert isinstance(config, ConfigContainer)
+    assert isinstance(config.model, MambaModelProvider)
+
+    assert config.model.seq_length == 4096
+    assert config.dataset.seq_length == 4096
+    assert config.model.tensor_model_parallel_size == 1
+    assert config.model.pipeline_model_parallel_size == 1
+    assert config.model.virtual_pipeline_model_parallel_size is None
+    assert config.model.context_parallel_size == 1
+    assert config.model.sequence_parallel is False
+    assert config.model.expert_tensor_parallel_size == 1
+    assert config.model.expert_model_parallel_size == 8
+
+    assert config.model.moe_token_dispatcher_type == "flex"
+    assert config.model.moe_flex_dispatcher_backend == "hybridep"
+    assert config.model.moe_hybridep_num_sms == 16
+    assert not hasattr(config.model, "moe_flex_dispatcher_num_sms")
+    assert config.model.moe_shared_expert_overlap is False
+    assert config.model.moe_router_force_load_balancing is False
+
+    assert config.model.cuda_graph_impl == "none"
+    assert cuda_graph_module_names(config.model) == []
+    assert config.model.use_te_rng_tracker is False
+    assert config.rng.te_rng_tracker is False
+    assert config.comm_overlap is not None
+    assert config.comm_overlap.tp_comm_overlap is False
+
+
+def test_nemotron_3_nano_gb200_retains_training_contract() -> None:
+    """The GB200 wrapper must not import convergence-sensitive perf settings."""
+    config = nemotron_3_nano_pretrain_8gpu_gb200_bf16_config()
+
+    assert config.train.train_iters == 39735
+    assert config.train.global_batch_size == 3072
+    assert config.train.micro_batch_size == 2
+    assert config.optimizer.lr == 1.6e-3
+    assert config.optimizer.min_lr == 1.6e-5
+    assert config.scheduler.lr_warmup_iters == 333
+    assert config.optimizer.main_grads_dtype == torch.float32
+    assert config.optimizer.main_params_dtype == torch.float32
+    assert config.optimizer.exp_avg_dtype == torch.float32
+    assert config.optimizer.exp_avg_sq_dtype == torch.float32
+    assert config.mixed_precision == "bf16_mixed"
+
+    assert config.model.moe_router_load_balancing_type == "seq_aux_loss"
+    assert config.model.moe_aux_loss_coeff == 0.0001
+    assert config.model.moe_router_topk == 6
+    assert config.model.moe_router_force_load_balancing is False
+    assert config.model.moe_router_padding_for_fp8 is False
+    assert config.model.cross_entropy_loss_fusion is True
+    assert config.model.cross_entropy_fusion_impl == "native"
+    assert config.ddp.check_for_nan_in_grad is True
+    assert config.ddp.use_distributed_optimizer is True
+
+
+def test_nemotron_3_nano_gb200_aliases_are_discoverable() -> None:
+    """Direct users and NeMo-CI should both resolve the GB200 recipe."""
+    assert nemotron_3_nano_gb200_pretrain_config is nemotron_3_nano_pretrain_8gpu_gb200_bf16_config
+    assert recipes.nemotron_3_nano_gb200_pretrain_config is nemotron_3_nano_pretrain_8gpu_gb200_bf16_config
+    assert recipes.nemotron_3_nano_pretrain_8gpu_gb200_bf16_config is (nemotron_3_nano_pretrain_8gpu_gb200_bf16_config)
+
+
+def test_nemotron_3_nano_gb200_validates_with_nemo_ci_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The 64-GPU release overrides should finalize without changing recipe topology."""
+    config = nemotron_3_nano_gb200_pretrain_config()
+    config.train.global_batch_size = 512
+    config.train.micro_batch_size = 2
+    config.mixed_precision = get_mixed_precision_config(config.mixed_precision)
+
+    monkeypatch.setattr(training_config, "get_world_size_safe", lambda: 64)
+    # The real release run performs this capability check on GB200. Unit
+    # finalization only verifies the combined configuration contract.
+    monkeypatch.setattr(training_config, "validate_flex_dispatcher_backend", lambda _model: None)
+
+    config.validate()
+
+    assert config.data_parallel_size == 64
+    assert config.train.global_batch_size == 512
+    assert config.train.micro_batch_size == 2
+    assert config.model.seq_length == 4096
+    assert config.dataset.seq_length == 4096
+    assert config.validation.eval_global_batch_size == 512
+    assert config.validation.eval_micro_batch_size == 2

--- a/tests/unit_tests/recipes/nemotronh/test_nemotron_3_nano_gb200.py
+++ b/tests/unit_tests/recipes/nemotronh/test_nemotron_3_nano_gb200.py
@@ -51,10 +51,11 @@ def test_nemotron_3_nano_gb200_pretrain_config() -> None:
     assert config.model.moe_shared_expert_overlap is False
     assert config.model.moe_router_force_load_balancing is False
 
-    assert config.model.cuda_graph_impl == "none"
-    assert cuda_graph_module_names(config.model) == []
-    assert config.model.use_te_rng_tracker is False
-    assert config.rng.te_rng_tracker is False
+    assert config.model.cuda_graph_impl == "transformer_engine"
+    assert cuda_graph_module_names(config.model) == ["attn", "mamba", "moe_router", "moe_preprocess"]
+    assert config.model.cuda_graph_warmup_steps == 3
+    assert config.model.use_te_rng_tracker is True
+    assert config.rng.te_rng_tracker is True
     assert config.comm_overlap is not None
     assert config.comm_overlap.tp_comm_overlap is False
 

--- a/tests/unit_tests/recipes/qwen/test_qwen35_recipes.py
+++ b/tests/unit_tests/recipes/qwen/test_qwen35_recipes.py
@@ -92,8 +92,6 @@ def test_qwen35_text_recipe_uses_nested_language_model_config(
     assert cfg.rng.te_rng_tracker is True
     assert cfg.model.apply_rope_fusion is True
     assert cfg.model.cross_entropy_fusion_impl == "native"
-    assert cfg.ddp.grad_reduce_in_fp32 is True
-    assert cfg.ddp.check_for_nan_in_grad is True
     assert cfg.dataset.mmap_bin_files is True
 
     if recipe_name == "qwen35_9b_pretrain_8gpu_gb200_bf16_config":
@@ -103,7 +101,10 @@ def test_qwen35_text_recipe_uses_nested_language_model_config(
         assert cfg.model.cuda_graph_impl == "transformer_engine"
         assert cfg.model.cuda_graph_scope is None
         assert cfg.model.cuda_graph_modules == ["attn", "mlp"]
-        assert cfg.rerun_state_machine.check_for_nan_in_loss is True
+        assert cfg.mixed_precision.grad_reduce_in_fp32 is False
+        assert cfg.ddp.grad_reduce_in_fp32 is False
+        assert cfg.ddp.check_for_nan_in_grad is False
+        assert cfg.rerun_state_machine.check_for_nan_in_loss is False
         assert cfg.ddp.overlap_grad_reduce is True
         assert cfg.ddp.overlap_param_gather is True
         assert cfg.comm_overlap.tp_comm_overlap is False
@@ -119,9 +120,11 @@ def test_qwen35_text_recipe_uses_nested_language_model_config(
         assert cfg.model.cuda_graph_impl == "transformer_engine"
         assert cfg.model.cuda_graph_scope is None
         assert cfg.model.cuda_graph_modules == ["attn", "moe_router", "moe_preprocess"]
+        assert cfg.ddp.grad_reduce_in_fp32 is True
+        assert cfg.ddp.check_for_nan_in_grad is True
 
 
-def test_qwen35_9b_recipe_validates_with_library_correctness_checks(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_qwen35_9b_recipe_validates_with_gb200_performance_settings(monkeypatch: pytest.MonkeyPatch) -> None:
     """The dense scoped-graph recipe must pass combined config and provider validation."""
     text_config = SimpleNamespace(architectures=None)
     provider = GPTModelProvider(
@@ -152,4 +155,4 @@ def test_qwen35_9b_recipe_validates_with_library_correctness_checks(monkeypatch:
 
     assert text_config.architectures == ["Qwen3_5ForCausalLM"]
     assert cuda_graph_module_names(cfg.model) == ["attn", "mlp"]
-    assert cfg.rerun_state_machine.check_for_nan_in_loss is True
+    assert cfg.rerun_state_machine.check_for_nan_in_loss is False

--- a/tests/unit_tests/recipes/qwen/test_qwen35_recipes.py
+++ b/tests/unit_tests/recipes/qwen/test_qwen35_recipes.py
@@ -1,0 +1,84 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import pytest
+
+from megatron.bridge.recipes.qwen.gb200 import qwen35 as qwen35_recipe
+from megatron.bridge.training.config import ConfigContainer
+
+
+class _FakeProvider(SimpleNamespace):
+    def finalize(self) -> None:
+        return None
+
+
+class _FakeBridge:
+    def __init__(self, provider: _FakeProvider):
+        self.provider = provider
+
+    def to_megatron_provider(self, load_weights: bool = False) -> _FakeProvider:
+        assert load_weights is False
+        return self.provider
+
+
+def test_qwen35_text_recipe_uses_nested_language_model_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The text recipe must select the causal-LM bridge, not the VLM bridge."""
+    text_config = SimpleNamespace(architectures=None)
+    provider = _FakeProvider(num_moe_experts=None)
+    captured = {}
+
+    def fake_from_pretrained(model_id: str):
+        captured["model_id"] = model_id
+        return SimpleNamespace(text_config=text_config)
+
+    def fake_from_hf_config(config):
+        captured["text_config"] = config
+        return _FakeBridge(provider)
+
+    monkeypatch.setattr(qwen35_recipe.AutoConfig, "from_pretrained", fake_from_pretrained)
+    monkeypatch.setattr(qwen35_recipe.AutoBridge, "from_hf_config", fake_from_hf_config)
+
+    cfg = qwen35_recipe.qwen35_35b_a3b_pretrain_8gpu_gb200_bf16_config()
+
+    assert isinstance(cfg, ConfigContainer)
+    assert captured["model_id"] == "Qwen/Qwen3.5-35B-A3B-Base"
+    assert captured["text_config"] is text_config
+    assert text_config.architectures == ["Qwen3_5MoeForCausalLM"]
+    assert cfg.model is provider
+    assert cfg.tokenizer.tokenizer_model == "Qwen/Qwen3.5-35B-A3B-Base"
+    assert cfg.dataset.seq_length == 4096
+    assert cfg.model.tensor_model_parallel_size == 1
+    assert cfg.model.pipeline_model_parallel_size == 1
+    assert cfg.model.expert_model_parallel_size == 8
+    assert cfg.model.expert_tensor_parallel_size == 1
+    assert cfg.model.sequence_parallel is False
+    assert cfg.train.global_batch_size == 512
+    assert cfg.train.micro_batch_size == 1
+    assert cfg.model.recompute_granularity is None
+    assert cfg.model.moe_token_dispatcher_type == "flex"
+    assert cfg.model.moe_flex_dispatcher_backend == "hybridep"
+    assert cfg.model.moe_flex_dispatcher_num_sms == 32
+    assert cfg.model.moe_router_force_load_balancing is False
+    assert cfg.model.cuda_graph_impl == "transformer_engine"
+    assert cfg.model.cuda_graph_scope is None
+    assert cfg.model.cuda_graph_modules == ["attn", "moe_router", "moe_preprocess"]
+    assert cfg.model.use_te_rng_tracker is True
+    assert cfg.rng.te_rng_tracker is True
+    assert cfg.model.apply_rope_fusion is True
+    assert cfg.model.cross_entropy_fusion_impl == "native"
+    assert cfg.ddp.grad_reduce_in_fp32 is True
+    assert cfg.ddp.check_for_nan_in_grad is True
+    assert cfg.dataset.mmap_bin_files is True

--- a/tests/unit_tests/recipes/qwen/test_qwen35_recipes.py
+++ b/tests/unit_tests/recipes/qwen/test_qwen35_recipes.py
@@ -16,8 +16,11 @@ from types import SimpleNamespace
 
 import pytest
 
+from megatron.bridge.models.gpt_provider import GPTModelProvider
 from megatron.bridge.recipes.qwen.gb200 import qwen35 as qwen35_recipe
 from megatron.bridge.training.config import ConfigContainer
+from megatron.bridge.training.mixed_precision import get_mixed_precision_config
+from megatron.bridge.utils.cuda_graph import cuda_graph_module_names
 
 
 class _FakeProvider(SimpleNamespace):
@@ -34,8 +37,28 @@ class _FakeBridge:
         return self.provider
 
 
-def test_qwen35_text_recipe_uses_nested_language_model_config(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The text recipe must select the causal-LM bridge, not the VLM bridge."""
+@pytest.mark.parametrize(
+    ("recipe_name", "model_id", "architecture"),
+    [
+        (
+            "qwen35_9b_pretrain_8gpu_gb200_bf16_config",
+            "Qwen/Qwen3.5-9B-Base",
+            "Qwen3_5ForCausalLM",
+        ),
+        (
+            "qwen35_35b_a3b_pretrain_8gpu_gb200_bf16_config",
+            "Qwen/Qwen3.5-35B-A3B-Base",
+            "Qwen3_5MoeForCausalLM",
+        ),
+    ],
+)
+def test_qwen35_text_recipe_uses_nested_language_model_config(
+    monkeypatch: pytest.MonkeyPatch,
+    recipe_name: str,
+    model_id: str,
+    architecture: str,
+) -> None:
+    """Text recipes must select the causal-LM bridge, not the VLM bridge."""
     text_config = SimpleNamespace(architectures=None)
     provider = _FakeProvider(num_moe_experts=None)
     captured = {}
@@ -51,30 +74,20 @@ def test_qwen35_text_recipe_uses_nested_language_model_config(monkeypatch: pytes
     monkeypatch.setattr(qwen35_recipe.AutoConfig, "from_pretrained", fake_from_pretrained)
     monkeypatch.setattr(qwen35_recipe.AutoBridge, "from_hf_config", fake_from_hf_config)
 
-    cfg = qwen35_recipe.qwen35_35b_a3b_pretrain_8gpu_gb200_bf16_config()
+    cfg = getattr(qwen35_recipe, recipe_name)()
 
     assert isinstance(cfg, ConfigContainer)
-    assert captured["model_id"] == "Qwen/Qwen3.5-35B-A3B-Base"
+    assert captured["model_id"] == model_id
     assert captured["text_config"] is text_config
-    assert text_config.architectures == ["Qwen3_5MoeForCausalLM"]
+    assert text_config.architectures == [architecture]
     assert cfg.model is provider
-    assert cfg.tokenizer.tokenizer_model == "Qwen/Qwen3.5-35B-A3B-Base"
+    assert cfg.tokenizer.tokenizer_model == model_id
     assert cfg.dataset.seq_length == 4096
     assert cfg.model.tensor_model_parallel_size == 1
     assert cfg.model.pipeline_model_parallel_size == 1
-    assert cfg.model.expert_model_parallel_size == 8
     assert cfg.model.expert_tensor_parallel_size == 1
     assert cfg.model.sequence_parallel is False
-    assert cfg.train.global_batch_size == 512
-    assert cfg.train.micro_batch_size == 1
     assert cfg.model.recompute_granularity is None
-    assert cfg.model.moe_token_dispatcher_type == "flex"
-    assert cfg.model.moe_flex_dispatcher_backend == "hybridep"
-    assert cfg.model.moe_flex_dispatcher_num_sms == 32
-    assert cfg.model.moe_router_force_load_balancing is False
-    assert cfg.model.cuda_graph_impl == "transformer_engine"
-    assert cfg.model.cuda_graph_scope is None
-    assert cfg.model.cuda_graph_modules == ["attn", "moe_router", "moe_preprocess"]
     assert cfg.model.use_te_rng_tracker is True
     assert cfg.rng.te_rng_tracker is True
     assert cfg.model.apply_rope_fusion is True
@@ -82,3 +95,60 @@ def test_qwen35_text_recipe_uses_nested_language_model_config(monkeypatch: pytes
     assert cfg.ddp.grad_reduce_in_fp32 is True
     assert cfg.ddp.check_for_nan_in_grad is True
     assert cfg.dataset.mmap_bin_files is True
+
+    if recipe_name == "qwen35_9b_pretrain_8gpu_gb200_bf16_config":
+        assert cfg.model.expert_model_parallel_size == 1
+        assert cfg.train.global_batch_size == 128
+        assert cfg.train.micro_batch_size == 2
+        assert cfg.model.cuda_graph_impl == "transformer_engine"
+        assert cfg.model.cuda_graph_scope is None
+        assert cfg.model.cuda_graph_modules == ["attn", "mlp"]
+        assert cfg.rerun_state_machine.check_for_nan_in_loss is True
+        assert cfg.ddp.overlap_grad_reduce is True
+        assert cfg.ddp.overlap_param_gather is True
+        assert cfg.comm_overlap.tp_comm_overlap is False
+    else:
+        assert cfg.model.expert_model_parallel_size == 8
+        assert cfg.train.global_batch_size == 512
+        assert cfg.train.micro_batch_size == 1
+        assert cfg.model.moe_token_dispatcher_type == "flex"
+        assert cfg.model.moe_flex_dispatcher_backend == "hybridep"
+        assert cfg.model.moe_flex_dispatcher_num_sms == 32
+        assert cfg.model.moe_router_force_load_balancing is False
+        assert cfg.model.cuda_graph_impl == "transformer_engine"
+        assert cfg.model.cuda_graph_scope is None
+        assert cfg.model.cuda_graph_modules == ["attn", "moe_router", "moe_preprocess"]
+
+
+def test_qwen35_9b_recipe_validates_with_library_correctness_checks(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The dense scoped-graph recipe must pass combined config and provider validation."""
+    text_config = SimpleNamespace(architectures=None)
+    provider = GPTModelProvider(
+        num_layers=2,
+        hidden_size=128,
+        num_attention_heads=4,
+        num_query_groups=4,
+        ffn_hidden_size=512,
+        kv_channels=32,
+        vocab_size=128,
+        seq_length=4096,
+    )
+
+    monkeypatch.setattr(
+        qwen35_recipe.AutoConfig,
+        "from_pretrained",
+        lambda _model_id: SimpleNamespace(text_config=text_config),
+    )
+    monkeypatch.setattr(
+        qwen35_recipe.AutoBridge,
+        "from_hf_config",
+        lambda _config: _FakeBridge(provider),
+    )
+
+    cfg = qwen35_recipe.qwen35_9b_pretrain_8gpu_gb200_bf16_config()
+    cfg.mixed_precision = get_mixed_precision_config(cfg.mixed_precision)
+    cfg.validate()
+
+    assert text_config.architectures == ["Qwen3_5ForCausalLM"]
+    assert cuda_graph_module_names(cfg.model) == ["attn", "mlp"]
+    assert cfg.rerun_state_machine.check_for_nan_in_loss is True

--- a/tests/unit_tests/recipes/qwen/test_qwen35_recipes.py
+++ b/tests/unit_tests/recipes/qwen/test_qwen35_recipes.py
@@ -113,7 +113,8 @@ def test_qwen35_text_recipe_uses_nested_language_model_config(
         assert cfg.train.micro_batch_size == 1
         assert cfg.model.moe_token_dispatcher_type == "flex"
         assert cfg.model.moe_flex_dispatcher_backend == "hybridep"
-        assert cfg.model.moe_flex_dispatcher_num_sms == 32
+        assert cfg.model.moe_hybridep_num_sms == 32
+        assert not hasattr(cfg.model, "moe_flex_dispatcher_num_sms")
         assert cfg.model.moe_router_force_load_balancing is False
         assert cfg.model.cuda_graph_impl == "transformer_engine"
         assert cfg.model.cuda_graph_scope is None

--- a/tests/unit_tests/recipes/test_qwen_recipes.py
+++ b/tests/unit_tests/recipes/test_qwen_recipes.py
@@ -69,6 +69,26 @@ class _FakeBridge:
         # Ignore hf_path; return a bridge that yields a fake provider
         return _FakeBridge()
 
+    @staticmethod
+    def from_hf_config(hf_config):
+        # Ignore hf_config; return a bridge that yields a fake provider
+        return _FakeBridge()
+
+
+class _FakeTextConfig:
+    architectures = None
+
+
+class _FakeRootConfig:
+    text_config = _FakeTextConfig()
+
+
+class _FakeAutoConfig:
+    @staticmethod
+    def from_pretrained(hf_path: str):
+        # Ignore hf_path; return a unified config with a nested text config.
+        return _FakeRootConfig()
+
 
 def _assert_basic_config(cfg):
     from megatron.bridge.training.config import ConfigContainer
@@ -102,6 +122,8 @@ def test_each_qwen_recipe_builds_config(recipe_func: Callable, monkeypatch: pyte
     module_name = recipe_func.__module__
     mod = importlib.import_module(module_name)
     monkeypatch.setattr(mod, "AutoBridge", _FakeBridge)
+    if hasattr(mod, "AutoConfig"):
+        monkeypatch.setattr(mod, "AutoConfig", _FakeAutoConfig)
 
     overrides = _safe_overrides_for(recipe_func.__name__)
 
@@ -135,7 +157,12 @@ def test_each_qwen_recipe_builds_config(recipe_func: Callable, monkeypatch: pyte
     assert getattr(cfg.model, "tensor_model_parallel_size", 1) >= 1
     assert getattr(cfg.model, "pipeline_model_parallel_size", 1) >= 1
 
-    if "qwen3" in recipe_name and "pretrain" in recipe_name and "next" not in recipe_name:
+    if (
+        "qwen3" in recipe_name
+        and "pretrain" in recipe_name
+        and "next" not in recipe_name
+        and "qwen35" not in recipe_name
+    ):
         assert cfg.model.cross_entropy_fusion_impl == "te"
 
     # SFT and PEFT-specific assertions


### PR DESCRIPTION
## What changed

Backports the Qwen3.5 text-only and Nemotron 3 Nano GB200 library pretraining recipes onto `r0.5.0` for NeMo 26.06 convergence validation.

### Qwen3.5

- adds Qwen3.5 9B and 35B-A3B GB200 library recipes from #4854
- exposes canonical `qwen35_9b_pretrain_config` and `qwen35_35b_a3b_pretrain_config` aliases
- adapts the provider annotation and HybridEP SM field to the older release layout

### Nemotron 3 Nano

- adds `nemotron_3_nano_pretrain_8gpu_gb200_bf16_config` and the NeMo-CI selector alias `nemotron_3_nano_gb200_pretrain_config`
- fixes model and dataset sequence length at 4096
- uses the validated GB200 topology: TP1, PP1, CP1, EP8, ETP1, sequence parallelism off
- enables the release HybridEP path with `moe_hybridep_num_sms=16`
- keeps eager execution because scoped CUDA graphs exceed memory at the library recipe MBS2
- explicitly keeps forced router load balancing disabled
- retains the release library optimizer, LR schedule, learned routing policy and coefficient, token semantics, BF16/FP32 optimizer-state contract, GBS3072, and MBS2

NeMo-CI should select this recipe with `MODEL_RECIPE_NAME=nemotron_3_nano_gb200`. The shared release template then deliberately overrides only the convergence-run controls to 48,000 steps, sequence length 4096, and GBS512; the model case overrides GPU count to 64 and MBS to 2.

## Why

NeMo-CI needs a reviewable release-branch SHA for the paired Qwen3.5 9B and Nemotron 3 Nano 100B-token, 64-GPU DGX Cloud GB200 convergence candidates against the 26.06 container. This does not replace the corresponding main-targeting recipe work.

## Validation

- 92 focused Qwen/Nemotron recipe and discovery tests passed in `nvcr.io/nvidian/nemo:26.06.01.rc2` with release-pinned Megatron-Core `458c8d0e`
- public `scripts/performance/run_recipe.py` dry-run resolved `nemotron_3_nano_gb200` with the exact 64-GPU NeMo-CI overlay: GBS512, MBS2, sequence length 4096, and 48,000 steps
- the resolved Nemotron config confirms TP1/PP1/CP1/EP8/ETP1, HybridEP, eager execution, and force balancing disabled
- all-file pre-commit and `git diff --check` passed
- the same GB200 Nemotron execution recipe completed the corrected 100-step public-entry hardware gate on 8 GB200 GPUs as Lyris job `2382796`: 100/100, finite loss and grad norm, zero skipped/NaN iterations, checkpoint and validation/test complete
- Qwen3.5 9B previously completed 100 real-RP2 steps on 8 GB200 GPUs as Lyris job `2378268`, W&B `hvdq6oa3`

## Active convergence run

The corrected Qwen-only NeMo-CI overlay root `58144288` is pinned to Qwen head `dd81e664e` and is unaffected by this Nemotron addition. A Nemotron launch must use current PR head `987244934` and `MODEL_RECIPE_NAME=nemotron_3_nano_gb200`.
