### PR TITLE
build: isolate uv cache by PyTorch ABI

### DIFF
--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -86,6 +86,11 @@ ARG UV_CACHE_PRUNE_ARGS
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     --mount=type=cache,target=/root/.cache/uv \
+    # Wheels for no-build-isolation packages are tied to the base image's PyTorch C++ ABI. Scope
+    # the cache to the exact PyTorch, CUDA, and C++ ABI combination to prevent cross-base reuse.
+    TORCH_ABI_CACHE_KEY=$(uv run --no-project --active python -W ignore::FutureWarning -c \
+        'import torch; print(f"{torch.__version__}-{torch.version.cuda}-{int(torch._C._GLIBCXX_USE_CXX11_ABI)}")') && \
+    export UV_CACHE_DIR="/root/.cache/uv/torch-${TORCH_ABI_CACHE_KEY}" && \
     export MAMBA_FORCE_BUILD=TRUE CAUSAL_CONV1D_FORCE_BUILD=TRUE && \
     # flash-mla (Megatron-LM's no_pypi_wheels group) has no PyPI wheel and is built from source by
     # the uv sync below. Point the compilers at the CCCL/libcu++ headers (under cccl/ in this base
@@ -105,6 +110,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         uv sync --locked --only-group build && \
         uv sync --link-mode copy --locked --all-extras --all-groups --no-group diffusion; \
     fi && \
+    # Fail the image build if the extension cannot resolve symbols from the base image's PyTorch.
+    uv run --no-sync python -c "import torch, causal_conv1d_cuda" && \
     # Create symlink for tilelang's libcudart_stub.so to the actual libcudart.so
     # Otherwise, the stub will be called in some cases and fail
     ln -sf "$(ldconfig -p | awk '/libcudart\.so\.[0-9]+ /{print $NF; exit}')" /opt/venv/lib/python3.12/site-packages/tilelang/lib/libcudart_stub.so && \


### PR DESCRIPTION
# What does this PR do ?

Prevent PyTorch C++ extensions from being restored from a uv build cache populated by a different base-image PyTorch ABI.

# Changelog

- Scope the Docker build's uv cache to the exact PyTorch version, CUDA version, and C++ ABI combination.
- Import `causal_conv1d_cuda` after dependency installation so unresolved PyTorch symbols fail during the image build instead of at training startup.

# GitHub Actions CI

Please run CI for commit `f9d11ead4`.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] Added the necessary build-time regression check.
- [x] Documentation changes are not necessary; this fixes internal image build caching.
- [x] The affected `causal-conv1d` dependency is optional for package users but installed in the all-extras CI image.
  - [x] No Python import guard changes are needed; the new import is confined to the all-extras Docker build.

# Additional Information

The issue was reproduced with `causal-conv1d==1.6.2.post1` loading against PyTorch `2.13.0a0+8145d630e8.nv26.06`: the cached extension referenced `c10::impl::cow::materialize_cow_storage`, which the runtime libraries did not export. Rebuilding the same package from source against that exact PyTorch build made the import pass.

Validation:

- `docker build --check -f docker/Dockerfile.ci --target megatron_bridge .`
- Clean source rebuild and import of `causal_conv1d_cuda` against the affected PyTorch build
- `uv run pre-commit run --all-files` inside the Megatron-Bridge container
