### PR TITLE
fix(qwen3-asr): preserve native auto registrations

### DIFF
--- a/src/megatron/bridge/models/qwen3_asr/hf_qwen3_asr/__init__.py
+++ b/src/megatron/bridge/models/qwen3_asr/hf_qwen3_asr/__init__.py
@@ -29,12 +29,22 @@
 # register the Auto classes ourselves below.
 
 from transformers import AutoConfig, AutoModel, AutoProcessor
+from transformers.models.auto.configuration_auto import CONFIG_MAPPING
 
 from .configuration_qwen3_asr import Qwen3ASRAudioEncoderConfig, Qwen3ASRConfig, Qwen3ASRThinkerConfig
 from .modeling_qwen3_asr import Qwen3ASRAudioEncoder, Qwen3ASRForConditionalGeneration
 from .processing_qwen3_asr import Qwen3ASRProcessor
 
 
-AutoConfig.register("qwen3_asr", Qwen3ASRConfig)
-AutoModel.register(Qwen3ASRConfig, Qwen3ASRForConditionalGeneration)
-AutoProcessor.register(Qwen3ASRConfig, Qwen3ASRProcessor)
+def _register_auto_classes(config_mapping=CONFIG_MAPPING) -> bool:
+    """Register vendored classes only when Transformers has no native Qwen3-ASR."""
+    if Qwen3ASRConfig.model_type in config_mapping:
+        return False
+
+    AutoConfig.register(Qwen3ASRConfig.model_type, Qwen3ASRConfig)
+    AutoModel.register(Qwen3ASRConfig, Qwen3ASRForConditionalGeneration)
+    AutoProcessor.register(Qwen3ASRConfig, Qwen3ASRProcessor)
+    return True
+
+
+_register_auto_classes()

--- a/tests/unit_tests/models/qwen3_asr/test_qwen3_asr_config.py
+++ b/tests/unit_tests/models/qwen3_asr/test_qwen3_asr_config.py
@@ -12,9 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from unittest.mock import patch
+
 import pytest
+from transformers import AutoConfig, AutoModel, AutoProcessor
 
 from megatron.bridge.models.conversion.utils import conform_config_to_reference
+from megatron.bridge.models.qwen3_asr.hf_qwen3_asr import (
+    Qwen3ASRForConditionalGeneration,
+    Qwen3ASRProcessor,
+    _register_auto_classes,
+)
 from megatron.bridge.models.qwen3_asr.hf_qwen3_asr.configuration_qwen3_asr import (
     Qwen3ASRConfig,
     Qwen3ASRThinkerConfig,
@@ -23,6 +31,34 @@ from megatron.bridge.training.config import ConfigContainer
 
 
 pytestmark = [pytest.mark.unit]
+
+
+def test_auto_classes_are_not_overridden_when_transformers_has_native_support():
+    with (
+        patch.object(AutoConfig, "register") as config_register,
+        patch.object(AutoModel, "register") as model_register,
+        patch.object(AutoProcessor, "register") as processor_register,
+    ):
+        registered = _register_auto_classes({Qwen3ASRConfig.model_type: object()})
+
+    assert registered is False
+    config_register.assert_not_called()
+    model_register.assert_not_called()
+    processor_register.assert_not_called()
+
+
+def test_auto_classes_are_registered_when_transformers_has_no_native_support():
+    with (
+        patch.object(AutoConfig, "register") as config_register,
+        patch.object(AutoModel, "register") as model_register,
+        patch.object(AutoProcessor, "register") as processor_register,
+    ):
+        registered = _register_auto_classes({})
+
+    assert registered is True
+    config_register.assert_called_once_with(Qwen3ASRConfig.model_type, Qwen3ASRConfig)
+    model_register.assert_called_once_with(Qwen3ASRConfig, Qwen3ASRForConditionalGeneration)
+    processor_register.assert_called_once_with(Qwen3ASRConfig, Qwen3ASRProcessor)
 
 
 def test_qwen3_asr_config_default_constructs_thinker_config():


### PR DESCRIPTION
## Summary

- register the vendored Qwen3-ASR Auto classes only when Transformers does not already provide the `qwen3_asr` model type
- preserve Transformers' native Qwen3-ASR registrations on newer releases
- add unit coverage for both the native-present and native-absent paths

## Motivation

`megatron.bridge` imports all model registrations eagerly. Transformers 5.13.1 now ships a native `qwen3_asr` config, so the unconditional vendored registration raises:

```
ValueError: 'qwen3_asr' is already used by a Transformers config, pick another name.
```

That prevents every Bridge consumer from importing, even when Qwen3-ASR is not selected. This is visible with the vLLM 0.25.1 base image, which ships Transformers 5.13.1.

Using `exist_ok=True` would replace the native global registration with Bridge's vendored schema. This change instead leaves the native registry untouched and retains the existing vendored fallback for Transformers releases without native Qwen3-ASR support.

This follows the import-safety goal in #4314: an unused model integration should not make `import megatron.bridge` fail.

## Validation

- `ruff format --check` and `ruff check` on the changed files
- focused registration unit tests: 2 passed
- Transformers 5.13.1 probe: `import megatron.bridge` succeeds and the native Qwen3-ASR config remains registered
- Transformers 5.8.1 probe: `import megatron.bridge` succeeds and the vendored Qwen3-ASR config is registered
