### PR TITLE
[recipe] fix: Propagate Gemma 4 VL Slurm failures

### DIFF
--- a/examples/models/gemma/gemma4_vl/slurm_peft.sh
+++ b/examples/models/gemma/gemma4_vl/slurm_peft.sh
@@ -131,7 +131,9 @@ if [ -n "$CONTAINER_MOUNTS" ]; then
 fi
 
 $SRUN_CMD bash -c "$CMD"
+RUN_EXIT=$?
 
 echo "======================================"
-echo "Training job finished. EXIT=$?"
+echo "Training job finished. EXIT=$RUN_EXIT"
 echo "======================================"
+exit $RUN_EXIT

--- a/examples/models/gemma/gemma4_vl/slurm_sft.sh
+++ b/examples/models/gemma/gemma4_vl/slurm_sft.sh
@@ -139,7 +139,9 @@ if [ -n "$CONTAINER_MOUNTS" ]; then
 fi
 
 $SRUN_CMD bash -c "$CMD"
+RUN_EXIT=$?
 
 echo "======================================"
-echo "Training job finished. EXIT=$?"
+echo "Training job finished. EXIT=$RUN_EXIT"
 echo "======================================"
+exit $RUN_EXIT

--- a/tests/unit_tests/examples/test_gemma4_vl_slurm.py
+++ b/tests/unit_tests/examples/test_gemma4_vl_slurm.py
@@ -1,0 +1,45 @@
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+GEMMA4_VL_EXAMPLES = REPO_ROOT / "examples" / "models" / "gemma" / "gemma4_vl"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("script_name", ["slurm_sft.sh", "slurm_peft.sh"])
+def test_gemma4_vl_slurm_wrappers_propagate_training_failure(tmp_path: Path, script_name: str) -> None:
+    """The batch script must report and return a failed training step."""
+    scontrol = tmp_path / "scontrol"
+    scontrol.write_text("#!/bin/bash\necho localhost\n")
+    scontrol.chmod(0o755)
+
+    srun = tmp_path / "srun"
+    srun.write_text("#!/bin/bash\nexit 42\n")
+    srun.chmod(0o755)
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "CONTAINER_IMAGE": "fake.sqsh",
+            "PATH": f"{tmp_path}:{env['PATH']}",
+            "SLURM_JOB_ID": "1234",
+            "SLURM_JOB_NODELIST": "localhost",
+            "SLURM_JOB_NUM_NODES": "1",
+            "SLURM_NTASKS": "8",
+        }
+    )
+
+    result = subprocess.run(
+        ["bash", str(GEMMA4_VL_EXAMPLES / script_name)],
+        capture_output=True,
+        check=False,
+        env=env,
+        text=True,
+    )
+
+    assert "Training job finished. EXIT=42" in result.stdout
+    assert result.returncode == 42


### PR DESCRIPTION
## Summary

The README-documented Gemma 4 VL SFT and PEFT Slurm wrappers reported and returned success whenever their synchronous `srun` training step returned a normal nonzero status. That can make a failed multi-GPU training job look successful to Slurm automation and allow dependent jobs to consume a missing or partial checkpoint.

## Root cause

Both wrappers ran a separator `echo` before reading `$?`. Bash therefore expanded `$?` as the separator's zero status, and the final successful `echo` also made the batch script exit zero.

## Fix

- Capture `srun`'s status immediately in `RUN_EXIT`.
- Report the captured status and explicitly exit with it in both SFT and PEFT wrappers.
- Add a parametrized black-box unit test that executes the real wrappers with a stub `srun` returning 42.

## Validation

- Regression before fix: `uv run --no-project --python /usr/bin/python3 python -m pytest --confcutdir=tests/unit_tests/examples tests/unit_tests/examples/test_gemma4_vl_slurm.py -q` — 2 failed; both wrappers printed `EXIT=0` instead of `EXIT=42`.
- Same unchanged regression after fix — 2 passed.
- `bash -n examples/models/gemma/gemma4_vl/slurm_sft.sh examples/models/gemma/gemma4_vl/slurm_peft.sh` — passed.
- `git diff --check` — passed.
- `uv run --no-project --python /usr/bin/python3 pre-commit run --all-files` — all applicable hooks passed.

## Scope

This changes only parent-shell exit-status propagation in the two Gemma 4 VL Slurm wrappers. It does not change recipe values, training semantics, Slurm resource requests, model code, or checkpoint behavior. No GPU/full-suite/convergence/performance validation was run or claimed because the defect is deterministic Bash status handling after synchronous `srun`.
