### PR TITLE
fix(training): restore SFT cache and MoE overlap compatibility

### DIFF
--- a/src/megatron/bridge/recipes/utils/dataset_utils.py
+++ b/src/megatron/bridge/recipes/utils/dataset_utils.py
@@ -112,6 +112,15 @@ def _text_hf_dataset_config(
     )
 
 
+def _legacy_compatible_prompt_completion_preprocessing() -> PromptCompletionSFTPreprocessingConfig:
+    """Accept legacy input/output materializations and canonical adapter rows."""
+    return PromptCompletionSFTPreprocessingConfig(
+        prompt_column="input",
+        completion_column="output",
+        separator=" ",
+    )
+
+
 def default_squad_config(
     seq_length: int, enable_offline_packing: bool = True, pad_seq_to_mult: int = 1
 ) -> GPTSFTDatasetConfig:
@@ -133,12 +142,7 @@ def default_squad_config(
 
     return _text_hf_dataset_config(
         source=HFDatasetSourceConfig(dataset_name="squad"),
-        # Preserve compatibility with SQuAD datasets materialized before the
-        # semantic adapter switched from input/output to prompt/completion.
-        # Canonical prompt/completion rows are still accepted by normalization.
-        preprocessing=PromptCompletionSFTPreprocessingConfig(
-            prompt_column="input", completion_column="output", separator=" "
-        ),
+        preprocessing=_legacy_compatible_prompt_completion_preprocessing(),
         seq_length=seq_length,
         enable_offline_packing=enable_offline_packing,
         offline_packing_specs=offline_packing_specs,
@@ -169,7 +173,7 @@ def default_openmathinstruct2_config(
 
     return _text_hf_dataset_config(
         source=HFDatasetSourceConfig(dataset_name="openmathinstruct2"),
-        preprocessing=PromptCompletionSFTPreprocessingConfig(separator=" "),
+        preprocessing=_legacy_compatible_prompt_completion_preprocessing(),
         seq_length=seq_length,
         enable_offline_packing=enable_offline_packing,
         offline_packing_specs=offline_packing_specs,
@@ -199,7 +203,7 @@ def default_gsm8k_config(
 
     return _text_hf_dataset_config(
         source=HFDatasetSourceConfig(dataset_name="gsm8k"),
-        preprocessing=PromptCompletionSFTPreprocessingConfig(separator=" "),
+        preprocessing=_legacy_compatible_prompt_completion_preprocessing(),
         test_source=HFDatasetSourceConfig(dataset_name="gsm8k", split="test"),
         do_validation=False,
         do_test=True,

--- a/src/megatron/bridge/recipes/utils/dataset_utils.py
+++ b/src/megatron/bridge/recipes/utils/dataset_utils.py
@@ -133,7 +133,12 @@ def default_squad_config(
 
     return _text_hf_dataset_config(
         source=HFDatasetSourceConfig(dataset_name="squad"),
-        preprocessing=PromptCompletionSFTPreprocessingConfig(separator=" "),
+        # Preserve compatibility with SQuAD datasets materialized before the
+        # semantic adapter switched from input/output to prompt/completion.
+        # Canonical prompt/completion rows are still accepted by normalization.
+        preprocessing=PromptCompletionSFTPreprocessingConfig(
+            prompt_column="input", completion_column="output", separator=" "
+        ),
         seq_length=seq_length,
         enable_offline_packing=enable_offline_packing,
         offline_packing_specs=offline_packing_specs,

--- a/src/megatron/bridge/recipes/utils/dataset_utils.py
+++ b/src/megatron/bridge/recipes/utils/dataset_utils.py
@@ -112,15 +112,6 @@ def _text_hf_dataset_config(
     )
 
 
-def _legacy_compatible_prompt_completion_preprocessing() -> PromptCompletionSFTPreprocessingConfig:
-    """Accept legacy input/output materializations and canonical adapter rows."""
-    return PromptCompletionSFTPreprocessingConfig(
-        prompt_column="input",
-        completion_column="output",
-        separator=" ",
-    )
-
-
 def default_squad_config(
     seq_length: int, enable_offline_packing: bool = True, pad_seq_to_mult: int = 1
 ) -> GPTSFTDatasetConfig:
@@ -142,7 +133,11 @@ def default_squad_config(
 
     return _text_hf_dataset_config(
         source=HFDatasetSourceConfig(dataset_name="squad"),
-        preprocessing=_legacy_compatible_prompt_completion_preprocessing(),
+        preprocessing=PromptCompletionSFTPreprocessingConfig(
+            prompt_column="input",
+            completion_column="output",
+            separator=" ",
+        ),
         seq_length=seq_length,
         enable_offline_packing=enable_offline_packing,
         offline_packing_specs=offline_packing_specs,
@@ -173,7 +168,11 @@ def default_openmathinstruct2_config(
 
     return _text_hf_dataset_config(
         source=HFDatasetSourceConfig(dataset_name="openmathinstruct2"),
-        preprocessing=_legacy_compatible_prompt_completion_preprocessing(),
+        preprocessing=PromptCompletionSFTPreprocessingConfig(
+            prompt_column="input",
+            completion_column="output",
+            separator=" ",
+        ),
         seq_length=seq_length,
         enable_offline_packing=enable_offline_packing,
         offline_packing_specs=offline_packing_specs,
@@ -203,7 +202,11 @@ def default_gsm8k_config(
 
     return _text_hf_dataset_config(
         source=HFDatasetSourceConfig(dataset_name="gsm8k"),
-        preprocessing=_legacy_compatible_prompt_completion_preprocessing(),
+        preprocessing=PromptCompletionSFTPreprocessingConfig(
+            prompt_column="input",
+            completion_column="output",
+            separator=" ",
+        ),
         test_source=HFDatasetSourceConfig(dataset_name="gsm8k", split="test"),
         do_validation=False,
         do_test=True,

--- a/src/megatron/bridge/training/comm_overlap.py
+++ b/src/megatron/bridge/training/comm_overlap.py
@@ -500,8 +500,8 @@ class CommOverlapConfig:
             assert not model_cfg.moe_shared_expert_overlap, (
                 "disable moe_shared_expert_overlap when enabling overlap_moe_expert_parallel_comm"
             )
-            assert model_cfg.mtp_num_layers is None or model_cfg.mtp_num_layers == 1, (
-                "MTP layernum only supports 1 when enabling overlap_moe_expert_parallel_comm."
+            assert model_cfg.mtp_num_layers in (None, 0, 1), (
+                "MTP supports at most one layer when enabling overlap_moe_expert_parallel_comm."
             )
 
         if self.user_comm_overlap_cfg.delay_wgrad_compute is True:

--- a/tests/unit_tests/recipes/utils/test_sft_dataset_utils.py
+++ b/tests/unit_tests/recipes/utils/test_sft_dataset_utils.py
@@ -187,20 +187,6 @@ class TestDefaultSquadConfig:
         assert cfg.preprocessing.completion_column == "output"
         assert cfg.preprocessing.separator == " "
 
-    @pytest.mark.parametrize(
-        ("row", "expected_metadata"),
-        [
-            ({"input": "question", "output": "answer", "id": 7}, {"id": 7}),
-            ({"prompt": "question", "completion": "answer"}, {}),
-        ],
-    )
-    def test_normalizes_legacy_and_canonical_rows(self, row, expected_metadata):
-        cfg = default_squad_config(seq_length=512)
-
-        normalized = normalize_sft_example(row, cfg.preprocessing)
-
-        assert normalized == {"input": "question", "output": "answer", **expected_metadata}
-
     def test_enable_offline_packing_creates_packing_specs(self):
         cfg = default_squad_config(seq_length=512, enable_offline_packing=True)
         assert cfg.enable_offline_packing is True
@@ -221,8 +207,15 @@ class TestConfigDifferences:
         )
         for cfg in configs:
             assert isinstance(cfg.preprocessing, PromptCompletionSFTPreprocessingConfig)
+            assert cfg.preprocessing.prompt_column == "input"
+            assert cfg.preprocessing.completion_column == "output"
             assert cfg.preprocessing.separator == " "
             assert cfg.preprocessing.loss_mode == "completion"
+
+            legacy = normalize_sft_example({"input": "question", "output": "answer", "id": 7}, cfg.preprocessing)
+            canonical = normalize_sft_example({"prompt": "question", "completion": "answer"}, cfg.preprocessing)
+            assert legacy == {"input": "question", "output": "answer", "id": 7}
+            assert canonical == {"input": "question", "output": "answer"}
 
     def test_different_default_seq_lengths(self):
         omi2 = default_openmathinstruct2_config()

--- a/tests/unit_tests/recipes/utils/test_sft_dataset_utils.py
+++ b/tests/unit_tests/recipes/utils/test_sft_dataset_utils.py
@@ -21,6 +21,7 @@ from megatron.bridge.data.builders import (
     GPTSFTDatasetConfig,
     PromptCompletionSFTPreprocessingConfig,
 )
+from megatron.bridge.data.sft_processing import normalize_sft_example
 from megatron.bridge.recipes.utils.dataset_utils import (
     default_gsm8k_config,
     default_openmathinstruct2_config,
@@ -182,7 +183,23 @@ class TestDefaultSquadConfig:
         assert cfg.do_validation is True
         assert cfg.do_test is False
         assert isinstance(cfg.preprocessing, PromptCompletionSFTPreprocessingConfig)
+        assert cfg.preprocessing.prompt_column == "input"
+        assert cfg.preprocessing.completion_column == "output"
         assert cfg.preprocessing.separator == " "
+
+    @pytest.mark.parametrize(
+        ("row", "expected_metadata"),
+        [
+            ({"input": "question", "output": "answer", "id": 7}, {"id": 7}),
+            ({"prompt": "question", "completion": "answer"}, {}),
+        ],
+    )
+    def test_normalizes_legacy_and_canonical_rows(self, row, expected_metadata):
+        cfg = default_squad_config(seq_length=512)
+
+        normalized = normalize_sft_example(row, cfg.preprocessing)
+
+        assert normalized == {"input": "question", "output": "answer", **expected_metadata}
 
     def test_enable_offline_packing_creates_packing_specs(self):
         cfg = default_squad_config(seq_length=512, enable_offline_packing=True)

--- a/tests/unit_tests/training/test_comm_overlap.py
+++ b/tests/unit_tests/training/test_comm_overlap.py
@@ -511,7 +511,8 @@ class TestMegatronCommOverlapConfig:
         for key in filtered_keys:
             assert key not in model_cfg.tp_comm_overlap_cfg
 
-    def test_moe_ep_overlap_config_validation(self):
+    @pytest.mark.parametrize("mtp_num_layers", [None, 0, 1])
+    def test_moe_ep_overlap_config_validation(self, mtp_num_layers):
         comm_cfg = CommOverlapConfig(
             tp_comm_overlap=False,
             data_parallel_size=1,
@@ -534,7 +535,7 @@ class TestMegatronCommOverlapConfig:
             recompute_method=None,
             recompute_num_layers=None,
             moe_shared_expert_overlap=False,
-            mtp_num_layers=None,
+            mtp_num_layers=mtp_num_layers,
             add_bias_linear=False,
         )
 
@@ -544,6 +545,39 @@ class TestMegatronCommOverlapConfig:
             result = comm_cfg._get_model_comm_overlap_cfgs(model_cfg, ddp_cfg)
 
         assert result.overlap_moe_expert_parallel_comm is True
+
+    def test_moe_ep_overlap_rejects_multiple_mtp_layers(self):
+        comm_cfg = CommOverlapConfig(
+            tp_comm_overlap=False,
+            data_parallel_size=1,
+            overlap_moe_expert_parallel_comm=True,
+        )
+        comm_cfg.finalize()
+
+        model_cfg = create_gpt_config(
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=1,
+            virtual_pipeline_model_parallel_size=None,
+            sequence_parallel=False,
+            expert_model_parallel_size=2,
+            num_moe_experts=2,
+            moe_token_dispatcher_type="alltoall",
+            bf16=True,
+            fp16=False,
+            recompute_granularity=None,
+            recompute_method=None,
+            recompute_num_layers=None,
+            moe_shared_expert_overlap=False,
+            mtp_num_layers=2,
+            add_bias_linear=False,
+        )
+        ddp_cfg = DistributedDataParallelConfig(use_distributed_optimizer=False)
+
+        with (
+            patch("megatron.bridge.training.comm_overlap.is_torch_min_version", return_value=True),
+            pytest.raises(AssertionError, match="at most one layer"),
+        ):
+            comm_cfg._get_model_comm_overlap_cfgs(model_cfg, ddp_cfg)
 
     def test_delay_wgrad_config_validation(self):
         """delay_wgrad_compute passes when TE and EP overlap conditions are met."""


### PR DESCRIPTION
## Summary

- keep the built-in SQuAD, GSM8K, and OpenMathInstruct-2 finetuning recipes compatible with legacy `input`/`output` materializations while continuing to accept canonical `prompt`/`completion` rows
- allow `mtp_num_layers=0` (MTP disabled) with MoE expert-parallel communication overlap
- add regression coverage for both schema variants and the supported MTP layer-count values

## Background

A nightly functional run exposed two Bridge regressions:

1. SFT and LoRA recipes failed while reading an existing SQuAD materialization because the configured schema expected `prompt`/`completion`, while older materializations use `input`/`output`. The same compatibility requirement applies to GSM8K and OpenMathInstruct-2 materializations produced by their former processors.
2. GPT-OSS recipes failed overlap validation because the hybrid model provider represents disabled MTP as `0`, but validation accepted only `None` or `1`.

The later optional CUDA-stub import seen in one failure report occurred after the primary overlap assertion. This PR intentionally does not change MCore or optional backend import behavior.

## Validation

- `uv run --no-sync --active pre-commit run --all-files`
- Python byte-compilation of the changed source and tests
- added focused unit tests for legacy/canonical SQuAD, GSM8K, and OpenMathInstruct-2 normalization and MTP values `None`, `0`, `1`, and `2`

The focused pytest run could not collect locally because the host CUDA driver is older than the installed PyTorch CUDA runtime. PR CI is the authoritative test run.
