### PR TITLE
fix(conversion): detect tied embeddings by Megatron param name, not hard-coded HF name

### DIFF
--- a/src/megatron/bridge/models/conversion/model_bridge.py
+++ b/src/megatron/bridge/models/conversion/model_bridge.py
@@ -1391,9 +1391,16 @@ class MegatronModelBridge(
                     else:
                         hf_name = hf_name[:suffix_pos] + ".base_layer" + hf_name[suffix_pos:]
 
-                # Handle tied embeddings case
-                # TODO(yuya): fix this hard coded naming
-                if embeddings_are_tied and hf_name == "model.embed_tokens.weight":
+                # Handle tied embeddings case. Detect via the Megatron-side param
+                # name, which is consistently "...embedding.word_embeddings.weight"
+                # across every bridge (see _should_skip_mtp_duplicate_embedding_export
+                # above for the same convention), rather than the HF-side name: that
+                # varies per bridge, e.g. "model.embed_tokens.weight" for plain LLMs
+                # vs. "model.language_model.embed_tokens.weight" for VLM bridges like
+                # qwen3_vl/qwen35/gemma3_vl/glm_45v/etc. The literal HF-name match
+                # this replaced silently skipped lm_head.weight export for all of
+                # those when embeddings are tied.
+                if embeddings_are_tied and task.global_param_name.endswith("embedding.word_embeddings.weight"):
                     emit_lm_head = isinstance(hf_pretrained, PretrainedConfig)
                     if hasattr(hf_pretrained, "state") and hasattr(hf_pretrained.state, "source"):
                         expected_keys = hf_pretrained.state.source.get_all_keys()

--- a/tests/unit_tests/models/test_model_bridge.py
+++ b/tests/unit_tests/models/test_model_bridge.py
@@ -413,3 +413,61 @@ def test_stream_weights_megatron_to_hf_transforms_tied_aliases_independently(mon
         "lm_head.weight.scale",
     ]
     assert weights[0].weight.data_ptr() != weights[2].weight.data_ptr()
+
+
+def test_stream_weights_megatron_to_hf_emits_lm_head_for_nested_vlm_embedding_name(monkeypatch):
+    # Regression test: VLM bridges (qwen3_vl, qwen35, gemma3_vl, glm_45v, etc.)
+    # map the tied embedding to a nested HF name like
+    # "model.language_model.embed_tokens.weight" rather than the plain-LLM
+    # "model.embed_tokens.weight". The tied-embedding branch must still detect
+    # this and re-emit lm_head.weight, not just the plain-LLM naming.
+    bridge = DummyBridge()
+    source_tensor = torch.ones(2, 2, requires_grad=True)
+
+    class EmbeddingMapping:
+        def megatron_to_hf(self, weight, module):
+            return {"model.language_model.embed_tokens.weight": weight}
+
+    task = WeightConversionTask(
+        param_name="language_model.embedding.word_embeddings.weight",
+        global_param_name="language_model.embedding.word_embeddings.weight",
+        mapping=EmbeddingMapping(),
+        pp_rank=0,
+        vp_stage=0,
+        megatron_module=None,
+        param_weight=source_tensor,
+    )
+
+    _patch_stream_weights_megatron_to_hf_basics(monkeypatch)
+    monkeypatch.setattr(
+        DummyBridge,
+        "_share_embeddings_and_output_weights",
+        lambda self, *_args, **_kwargs: True,
+    )
+    hf_pretrained = SimpleNamespace(
+        state=SimpleNamespace(
+            source=SimpleNamespace(
+                get_all_keys=lambda: [
+                    "model.language_model.embed_tokens.weight",
+                    "lm_head.weight",
+                ]
+            )
+        )
+    )
+
+    weights = list(
+        bridge.stream_weights_megatron_to_hf(
+            [Mock()],
+            hf_pretrained,
+            cpu=True,
+            show_progress=False,
+            conversion_tasks=[task],
+            merge_adapter_weights=False,
+        )
+    )
+
+    assert [weight.param_name for weight in weights] == [
+        "model.language_model.embed_tokens.weight",
+        "lm_head.weight",
+    ]
+    assert weights[0].weight.data_ptr() != weights[1].weight.data_ptr()


### PR DESCRIPTION
## What changed

`stream_weights_megatron_to_hf`'s tied-embedding branch (`model_bridge.py`, with the existing `# TODO(yuya): fix this hard coded naming` comment on it) decides whether to re-emit a duplicate `lm_head.weight` during HF export by checking `hf_name == "model.embed_tokens.weight"`. This re-emission is necessary because `build_conversion_tasks` unconditionally drops the Megatron `output_layer.weight` task whenever embeddings are tied, so the tied-embedding branch is the only place that can still produce `lm_head.weight` in the output.

That literal string only matches the plain-LLM naming convention. At least ten bridges map the tied embedding to a differently-prefixed HF name instead, e.g.:
- `qwen_vl/qwen3_vl_bridge.py`, `glm_vl/glm_45v_bridge.py`, `gemma_vl/gemma4_vl_bridge.py`: `"model.language_model.embed_tokens.weight"`
- `gemma_vl/gemma3_vl_bridge.py`: `"language_model.model.embed_tokens.weight"` (different prefix order)
- plus `qwen/qwen35_bridge.py`, `qwen_omni/*`, `qwen_audio/qwen2_audio_bridge.py`, `qwen3_asr/qwen3_asr_bridge.py`, `nemotron_vl/nemotron_vl_bridge.py`, `ministral3/ministral3_bridge.py`

For any of these with `tie_word_embeddings=True` (a real, common config, e.g. the smaller dense Qwen VL variants), export falls into the generic `else` branch: the embedding tensor is emitted once under its own name, and `lm_head.weight` is silently never emitted, even if the source checkpoint had it. No error, no warning, just a missing key in the exported HF checkpoint.

## Fix

Detect the tied embedding task via `task.global_param_name.endswith("embedding.word_embeddings.weight")` instead of matching the HF-side name. This is the same convention the file already uses a few hundred lines up, in `_should_skip_mtp_duplicate_embedding_export`. I grepped every bridge under `models/` for its Megatron-side embedding key and confirmed this holds everywhere (`embedding.word_embeddings.weight` for plain LLMs, `language_model.embedding.word_embeddings.weight` or similar for VLMs), so the new condition is a strict superset of the old one and plain-LLM behavior is unchanged.

## Verification

Added `test_stream_weights_megatron_to_hf_emits_lm_head_for_nested_vlm_embedding_name`, mirroring the existing `test_stream_weights_megatron_to_hf_transforms_tied_aliases_independently` but with a VLM-style nested HF name (`"model.language_model.embed_tokens.weight"`), to cover the case the old code missed.

I could not run the test suite in my environment: importing `megatron.core` pulls in `triton`, which has no Windows wheel available. I traced the exact control flow by hand and dry-ran the old vs. new condition against the real Megatron-side/HF-side name pairs from three representative bridges (plain LLM, qwen3_vl-style VLM, gemma3_vl's differently-ordered prefix) to confirm the logic, but this needs a real CI run to confirm the test itself passes.