### PR TITLE
fix(conversion): resolve tied output aliases from parameter mappings

### DIFF
--- a/src/megatron/bridge/models/conversion/model_bridge.py
+++ b/src/megatron/bridge/models/conversion/model_bridge.py
@@ -1287,6 +1287,9 @@ class MegatronModelBridge(
             megatron_model = [megatron_model]
 
         unwrapped_model_list = unwrap_model(megatron_model)
+        self.hf_pretrained = hf_pretrained
+        self.hf_config = hf_pretrained.config if hasattr(hf_pretrained, "config") else hf_pretrained
+
         # Use provided conversion tasks or build them
         if conversion_tasks is None:
             conversion_tasks = self.build_conversion_tasks(
@@ -1310,6 +1313,7 @@ class MegatronModelBridge(
         unwrapped_model = unwrapped_model_list[0]
         model_config = unwrapped_model.config
         embeddings_are_tied = self._share_embeddings_and_output_weights(model_config)
+        tied_mapping_registry = self.mapping_registry() if embeddings_are_tied else None
 
         hf_state_dict: Mapping[str, torch.Tensor] = hf_pretrained.state if hasattr(hf_pretrained, "state") else {}
 
@@ -1383,6 +1387,10 @@ class MegatronModelBridge(
 
             converted_weights_dict = self._cast_export_weight_dtype(converted_weights_dict, task.weight_dtype)
 
+            tied_output_hf_name = None
+            if tied_mapping_registry is not None:
+                tied_output_hf_name = self._get_tied_output_hf_name(task, tied_mapping_registry)
+
             for hf_name, tensor in converted_weights_dict.items():
                 if not merge_adapter_weights and "to_wrap.weight" in task.global_param_name:
                     suffix_pos = hf_name.rfind(".")
@@ -1391,28 +1399,28 @@ class MegatronModelBridge(
                     else:
                         hf_name = hf_name[:suffix_pos] + ".base_layer" + hf_name[suffix_pos:]
 
-                # Handle tied embeddings case
-                # TODO(yuya): fix this hard coded naming
-                if embeddings_are_tied and hf_name == "model.embed_tokens.weight":
-                    emit_lm_head = isinstance(hf_pretrained, PretrainedConfig)
+                if tied_output_hf_name is not None and hf_name == task.mapping.hf_param:
+                    emit_output_weight = isinstance(hf_pretrained, PretrainedConfig)
                     if hasattr(hf_pretrained, "state") and hasattr(hf_pretrained.state, "source"):
                         expected_keys = hf_pretrained.state.source.get_all_keys()
-                        emit_lm_head = "lm_head.weight" in expected_keys
+                        emit_output_weight = tied_output_hf_name in expected_keys
 
                     yield from HFWeightTuple(hf_name, tensor).iter_finalized(
                         export_hook=task.export_hook,
                         cpu=cpu,
                     )
-                    if emit_lm_head:
-                        yield from HFWeightTuple("lm_head.weight", tensor).iter_finalized(
+                    if emit_output_weight:
+                        yield from HFWeightTuple(tied_output_hf_name, tensor).iter_finalized(
                             export_hook=task.export_hook,
                             cpu=cpu,
                             clone_identity_output=True,
                         )
-                elif embeddings_are_tied and hf_name == "lm_head.weight":
+                elif embeddings_are_tied and (
+                    task.global_param_name.endswith("output_layer.weight") or hf_name == tied_output_hf_name
+                ):
                     # This should not happen when embeddings are tied - assert error
                     raise ValueError(
-                        "Encountered lm_head.weight when embeddings are tied. This indicates a mapping error."
+                        f"Encountered {hf_name} when embeddings are tied. This indicates a mapping error."
                     )
                 else:
                     # Regular case - yield the tensor normally
@@ -1608,6 +1616,34 @@ class MegatronModelBridge(
 
         inner_model = getattr(model_chunk, "language_model", model_chunk)
         return bool(getattr(inner_model, "mtp_process", False))
+
+    def _get_tied_output_hf_name(
+        self,
+        task: WeightConversionTask,
+        mapping_registry: MegatronMappingRegistry,
+    ) -> str | None:
+        """Resolve the HF output-weight alias for a tied embedding task."""
+        embedding_suffix = "embedding.word_embeddings.weight"
+        if not task.global_param_name.endswith(embedding_suffix):
+            return None
+        if not isinstance(task.mapping.hf_param, str):
+            raise ValueError(
+                "Expected tied embedding mapping to resolve to one HuggingFace parameter, "
+                f"got {task.mapping.hf_param!r}."
+            )
+
+        megatron_prefix = task.global_param_name[: -len(embedding_suffix)]
+        output_mapping = mapping_registry.megatron_to_hf_lookup(f"{megatron_prefix}output_layer.weight")
+        if output_mapping is None:
+            return None
+        if not isinstance(output_mapping.hf_param, str):
+            raise ValueError(
+                "Expected tied output-layer mapping to resolve to one HuggingFace parameter, "
+                f"got {output_mapping.hf_param!r}."
+            )
+        if output_mapping.hf_param == task.mapping.hf_param:
+            return None
+        return output_mapping.hf_param
 
     def build_conversion_tasks(
         self,

--- a/tests/unit_tests/models/test_model_bridge.py
+++ b/tests/unit_tests/models/test_model_bridge.py
@@ -16,10 +16,12 @@ from dataclasses import replace
 from types import SimpleNamespace
 from unittest.mock import Mock
 
+import pytest
 import torch
 
 from megatron.bridge.models.conversion.mapping_registry import MegatronMappingRegistry
 from megatron.bridge.models.conversion.model_bridge import HFWeightTuple, MegatronModelBridge, WeightConversionTask
+from megatron.bridge.models.conversion.param_mapping import AutoMapping
 
 
 class DummyBridge(MegatronModelBridge):
@@ -350,17 +352,45 @@ def test_stream_weights_megatron_to_hf_finalizes_exported_tensors_before_cpu(mon
         assert events.index(("finalize", label)) < events.index(("cpu", label))
 
 
-def test_stream_weights_megatron_to_hf_transforms_tied_aliases_independently(monkeypatch):
+@pytest.mark.parametrize(
+    ("megatron_prefix", "embedding_name", "output_name"),
+    [
+        ("", "model.embed_tokens.weight", "lm_head.weight"),
+        ("thinker.language_model.", "thinker.model.embed_tokens.weight", "thinker.lm_head.weight"),
+        ("language_model.", "model.language_model.embed_tokens.weight", "lm_head.weight"),
+        ("language_model.", "language_model.model.embed_tokens.weight", "language_model.lm_head.weight"),
+        (
+            "llava_model.language_model.",
+            "language_model.backbone.embeddings.weight",
+            "language_model.lm_head.weight",
+        ),
+    ],
+    ids=[
+        "plain-llm",
+        "component-prefix",
+        "nested-embedding-root-head",
+        "nested-language-model",
+        "nonstandard-embedding-name",
+    ],
+)
+def test_stream_weights_megatron_to_hf_transforms_tied_aliases_independently(
+    monkeypatch,
+    megatron_prefix,
+    embedding_name,
+    output_name,
+):
     bridge = DummyBridge()
     source_tensor = torch.ones(2, 2, requires_grad=True)
 
     class EmbeddingMapping:
+        hf_param = embedding_name
+
         def megatron_to_hf(self, weight, module):
-            return {"model.embed_tokens.weight": weight}
+            return {embedding_name: weight}
 
     task = WeightConversionTask(
-        param_name="embedding.word_embeddings.weight",
-        global_param_name="embedding.word_embeddings.weight",
+        param_name=f"{megatron_prefix}embedding.word_embeddings.weight",
+        global_param_name=f"{megatron_prefix}embedding.word_embeddings.weight",
         mapping=EmbeddingMapping(),
         pp_rank=0,
         vp_stage=0,
@@ -383,12 +413,19 @@ def test_stream_weights_megatron_to_hf_transforms_tied_aliases_independently(mon
         "_share_embeddings_and_output_weights",
         lambda self, *_args, **_kwargs: True,
     )
+    monkeypatch.setattr(
+        DummyBridge,
+        "mapping_registry",
+        lambda self: MegatronMappingRegistry(
+            AutoMapping(f"{megatron_prefix}output_layer.weight", output_name),
+        ),
+    )
     hf_pretrained = SimpleNamespace(
         state=SimpleNamespace(
             source=SimpleNamespace(
                 get_all_keys=lambda: [
-                    "model.embed_tokens.weight",
-                    "lm_head.weight",
+                    embedding_name,
+                    output_name,
                 ]
             )
         )
@@ -405,11 +442,64 @@ def test_stream_weights_megatron_to_hf_transforms_tied_aliases_independently(mon
         )
     )
 
-    assert transform_calls == ["model.embed_tokens.weight", "lm_head.weight"]
+    assert transform_calls == [embedding_name, output_name]
     assert [weight.param_name for weight in weights] == [
-        "model.embed_tokens.weight.packed",
-        "model.embed_tokens.weight.scale",
-        "lm_head.weight.packed",
-        "lm_head.weight.scale",
+        f"{embedding_name}.packed",
+        f"{embedding_name}.scale",
+        f"{output_name}.packed",
+        f"{output_name}.scale",
     ]
     assert weights[0].weight.data_ptr() != weights[2].weight.data_ptr()
+
+
+@pytest.mark.parametrize("has_output_mapping", [False, True], ids=["no-output-mapping", "output-not-in-source"])
+def test_stream_weights_megatron_to_hf_does_not_invent_tied_output_alias(monkeypatch, has_output_mapping):
+    bridge = DummyBridge()
+    embedding_name = "model.embed_tokens.weight"
+
+    class EmbeddingMapping:
+        hf_param = embedding_name
+
+        def megatron_to_hf(self, weight, module):
+            return {embedding_name: weight}
+
+    task = WeightConversionTask(
+        param_name="embedding.word_embeddings.weight",
+        global_param_name="embedding.word_embeddings.weight",
+        mapping=EmbeddingMapping(),
+        pp_rank=0,
+        vp_stage=0,
+        megatron_module=None,
+        param_weight=torch.ones(2, 2),
+    )
+
+    _patch_stream_weights_megatron_to_hf_basics(monkeypatch)
+    monkeypatch.setattr(
+        DummyBridge,
+        "_share_embeddings_and_output_weights",
+        lambda self, *_args, **_kwargs: True,
+    )
+    output_mappings = [AutoMapping("output_layer.weight", "lm_head.weight")] if has_output_mapping else []
+    monkeypatch.setattr(
+        DummyBridge,
+        "mapping_registry",
+        lambda self: MegatronMappingRegistry(*output_mappings),
+    )
+    hf_pretrained = SimpleNamespace(
+        state=SimpleNamespace(
+            source=SimpleNamespace(get_all_keys=lambda: [embedding_name]),
+        )
+    )
+
+    weights = list(
+        bridge.stream_weights_megatron_to_hf(
+            [Mock()],
+            hf_pretrained,
+            cpu=True,
+            show_progress=False,
+            conversion_tasks=[task],
+            merge_adapter_weights=False,
+        )
+    )
+
+    assert [weight.param_name for weight in weights] == [embedding_name]


### PR DESCRIPTION
## Summary

- extract the tied-embedding export fix from #4805 into a focused change
- identify tied embeddings by their Megatron parameter name and resolve the corresponding HF output alias through the bridge mapping registry
- preserve component-prefixed, nested-language-model, root-head, and nonstandard HF naming schemes without inventing aliases that are absent from the source checkpoint

This also covers the nested VLM naming problem reported in #4883. Thanks to @ErenAta16 for identifying that additional failure mode.

## Tests

- `uv run --no-sync pre-commit run --all-files`
- `git diff --check`
- targeted unit-test collection was attempted locally, but macOS ARM cannot install the pinned Linux-only `nvidia-resiliency-ext`/Triton runtime; Linux CI is required for the actual pytest run

## Scope

Only the `model_bridge.py` fix and its unit tests were extracted. The unrelated validation-document and generation-config changes from the original #4805 commit are intentionally excluded.
