### PR TITLE
[data] feat: Add Tulu 3 dataset preset and current validation evidence

### DIFF
--- a/scripts/training/README.md
+++ b/scripts/training/README.md
@@ -66,7 +66,7 @@ and loader settings; use `dataset.dataset_kwargs={...}` only for extra options c
 | `local-jsonl` | Source selector | sft/lora/dora | Local prompt-completion JSONL selected by `dataset.dataset_root` |
 | `local-vlm` | Source selector | sft/lora/dora | Local VLM JSON/JSONL selected through `dataset.source` overrides |
 | `squad` | Named preset | sft/lora/dora | Hugging Face SQuAD preset |
-| `tulu` | Named preset | sft/lora/dora | Ai2 Tulu 3 SFT mixture (`allenai/tulu-3-sft-mixture`) |
+| `tulu3` | Named preset | sft/lora/dora | Ai2 Tulu 3 SFT mixture (`allenai/tulu-3-sft-mixture`) |
 | `openmathinstruct2` | Named preset | sft/lora/dora | OpenMathInstruct-2 prompt/completion preset |
 | `openmathinstruct2-thinking` | Named preset | sft/lora/dora | OpenMathInstruct-2 analysis/final channel format |
 | `gsm8k` | Named preset | sft/lora/dora | GSM8K preset |
@@ -99,7 +99,7 @@ format: chain-of-thought goes to the analysis channel and the answer goes to the
 
 ### Tulu
 
-`tulu` uses the canonical current Tulu SFT dataset, `allenai/tulu-3-sft-mixture`. The preset reads its published
+`tulu3` uses the canonical current Tulu SFT dataset, `allenai/tulu-3-sft-mixture`. The preset reads its published
 `train` split and its native `messages` chat schema; it reserves 5% for validation by default. The mixture is licensed
 under ODC-BY-1.0, but individual subsets can carry additional terms, including non-commercial restrictions. Review the
 Hugging Face dataset card and its linked subset licenses before use.
@@ -107,7 +107,7 @@ Hugging Face dataset card and its linked subset licenses before use.
 ### Offline packing
 
 Offline packing is a text SFT option, not a dataset name. Set `dataset.enable_offline_packing=true` for `squad`, either
-OpenMathInstruct-2 format, `tulu`, `gsm8k`, or `local-jsonl`. The launcher aligns packed padding for the resolved CP/TP and
+OpenMathInstruct-2 format, `tulu3`, `gsm8k`, or `local-jsonl`. The launcher aligns packed padding for the resolved CP/TP and
 sequence-parallel configuration. Packed training requires `train.micro_batch_size=1`. The builder materializes packed
 data automatically, so a separate packing Slurm job is not required. The selected recipe/model must support packed THD
 sequences; for example, GLM-4.5 and Qwen3-Next recipes currently do not. On multiple nodes, keep the dataset cache on

--- a/scripts/training/README.md
+++ b/scripts/training/README.md
@@ -66,6 +66,7 @@ and loader settings; use `dataset.dataset_kwargs={...}` only for extra options c
 | `local-jsonl` | Source selector | sft/lora/dora | Local prompt-completion JSONL selected by `dataset.dataset_root` |
 | `local-vlm` | Source selector | sft/lora/dora | Local VLM JSON/JSONL selected through `dataset.source` overrides |
 | `squad` | Named preset | sft/lora/dora | Hugging Face SQuAD preset |
+| `tulu` | Named preset | sft/lora/dora | Ai2 Tulu 3 SFT mixture (`allenai/tulu-3-sft-mixture`) |
 | `openmathinstruct2` | Named preset | sft/lora/dora | OpenMathInstruct-2 prompt/completion preset |
 | `openmathinstruct2-thinking` | Named preset | sft/lora/dora | OpenMathInstruct-2 analysis/final channel format |
 | `gsm8k` | Named preset | sft/lora/dora | GSM8K preset |
@@ -96,10 +97,17 @@ The launcher does not infer the source corpus from the files. For one preprocess
 `openmathinstruct2` uses prompt/completion records. `openmathinstruct2-thinking` changes only the semantic output
 format: chain-of-thought goes to the analysis channel and the answer goes to the final channel.
 
+### Tulu
+
+`tulu` uses the canonical current Tulu SFT dataset, `allenai/tulu-3-sft-mixture`. The preset reads its published
+`train` split and its native `messages` chat schema; it reserves 5% for validation by default. The mixture is licensed
+under ODC-BY-1.0, but individual subsets can carry additional terms, including non-commercial restrictions. Review the
+Hugging Face dataset card and its linked subset licenses before use.
+
 ### Offline packing
 
 Offline packing is a text SFT option, not a dataset name. Set `dataset.enable_offline_packing=true` for `squad`, either
-OpenMathInstruct-2 format, `gsm8k`, or `local-jsonl`. The launcher aligns packed padding for the resolved CP/TP and
+OpenMathInstruct-2 format, `tulu`, `gsm8k`, or `local-jsonl`. The launcher aligns packed padding for the resolved CP/TP and
 sequence-parallel configuration. Packed training requires `train.micro_batch_size=1`. The builder materializes packed
 data automatically, so a separate packing Slurm job is not required. The selected recipe/model must support packed THD
 sequences; for example, GLM-4.5 and Qwen3-Next recipes currently do not. On multiple nodes, keep the dataset cache on

--- a/src/megatron/bridge/data/sources/hf.py
+++ b/src/megatron/bridge/data/sources/hf.py
@@ -200,7 +200,7 @@ _HF_DATASET_PRESETS: dict[str, _HFDatasetPreset] = {
         schema_adapter="squad",
         supported_splits=("train", "validation"),
     ),
-    "tulu": _HFDatasetPreset(
+    "tulu3": _HFDatasetPreset(
         path_or_dataset="allenai/tulu-3-sft-mixture",
         schema_adapter=None,
         supported_splits=("train",),

--- a/src/megatron/bridge/data/sources/hf.py
+++ b/src/megatron/bridge/data/sources/hf.py
@@ -131,7 +131,7 @@ class _HFDatasetPreset:
     """Resolved physical source metadata for a built-in dataset."""
 
     path_or_dataset: str
-    schema_adapter: str
+    schema_adapter: str | None
     split: str = "train"
     subset: str | list[str] | None = None
     load_kwargs: dict[str, Any] | None = None
@@ -199,6 +199,11 @@ _HF_DATASET_PRESETS: dict[str, _HFDatasetPreset] = {
         path_or_dataset="rajpurkar/squad",
         schema_adapter="squad",
         supported_splits=("train", "validation"),
+    ),
+    "tulu": _HFDatasetPreset(
+        path_or_dataset="allenai/tulu-3-sft-mixture",
+        schema_adapter=None,
+        supported_splits=("train",),
     ),
 }
 

--- a/src/megatron/bridge/recipes/utils/dataset_utils.py
+++ b/src/megatron/bridge/recipes/utils/dataset_utils.py
@@ -143,7 +143,7 @@ def default_squad_config(
     )
 
 
-def default_tulu_config(
+def default_tulu3_config(
     seq_length: int = 4096,
     enable_offline_packing: bool = False,
     pad_seq_to_mult: int = 1,
@@ -163,7 +163,7 @@ def default_tulu_config(
         offline_packing_specs = PackedSequenceSpecs(packed_sequence_size=seq_length, pad_seq_to_mult=pad_seq_to_mult)
 
     return _text_hf_dataset_config(
-        source=HFDatasetSourceConfig(dataset_name="tulu"),
+        source=HFDatasetSourceConfig(dataset_name="tulu3"),
         preprocessing=ChatSFTPreprocessingConfig(),
         seq_length=seq_length,
         enable_offline_packing=enable_offline_packing,
@@ -374,9 +374,9 @@ def _squad_dataset_config(config: ConfigContainer) -> GPTSFTDatasetConfig:
     return default_squad_config(seq_length=_resolve_seq_length(config), enable_offline_packing=False)
 
 
-def _tulu_dataset_config(config: ConfigContainer) -> GPTSFTDatasetConfig:
+def _tulu3_dataset_config(config: ConfigContainer) -> GPTSFTDatasetConfig:
     """Build the Tulu 3 chat SFT dataset preset."""
-    return default_tulu_config(seq_length=_resolve_seq_length(config))
+    return default_tulu3_config(seq_length=_resolve_seq_length(config))
 
 
 def _openmathinstruct2_dataset_config(config: ConfigContainer) -> GPTSFTDatasetConfig:
@@ -469,7 +469,7 @@ DATASET_PRESETS: dict[str, DatasetPreset] = {
     "mock": _mock_dataset_config,
     "megatron-indexed": _megatron_indexed_dataset_config,
     "squad": _squad_dataset_config,
-    "tulu": _tulu_dataset_config,
+    "tulu3": _tulu3_dataset_config,
     "openmathinstruct2": _openmathinstruct2_dataset_config,
     "openmathinstruct2-thinking": _openmathinstruct2_thinking_dataset_config,
     "gsm8k": _gsm8k_dataset_config,

--- a/src/megatron/bridge/recipes/utils/dataset_utils.py
+++ b/src/megatron/bridge/recipes/utils/dataset_utils.py
@@ -143,6 +143,36 @@ def default_squad_config(
     )
 
 
+def default_tulu_config(
+    seq_length: int = 4096,
+    enable_offline_packing: bool = False,
+    pad_seq_to_mult: int = 1,
+) -> GPTSFTDatasetConfig:
+    """Create the default Tulu 3 SFT mixture dataset configuration.
+
+    Args:
+        seq_length: Maximum sequence length.
+        enable_offline_packing: Whether to enable offline text SFT packing.
+        pad_seq_to_mult: Sequence-length multiple used by offline packing.
+
+    Returns:
+        A chat SFT configuration for ``allenai/tulu-3-sft-mixture``.
+    """
+    offline_packing_specs = None
+    if enable_offline_packing:
+        offline_packing_specs = PackedSequenceSpecs(packed_sequence_size=seq_length, pad_seq_to_mult=pad_seq_to_mult)
+
+    return _text_hf_dataset_config(
+        source=HFDatasetSourceConfig(dataset_name="tulu"),
+        preprocessing=ChatSFTPreprocessingConfig(),
+        seq_length=seq_length,
+        enable_offline_packing=enable_offline_packing,
+        offline_packing_specs=offline_packing_specs,
+        val_proportion=0.05,
+        num_workers=2,
+    )
+
+
 def default_openmathinstruct2_config(
     seq_length: int = 4096,
     enable_offline_packing: bool = False,
@@ -344,6 +374,11 @@ def _squad_dataset_config(config: ConfigContainer) -> GPTSFTDatasetConfig:
     return default_squad_config(seq_length=_resolve_seq_length(config), enable_offline_packing=False)
 
 
+def _tulu_dataset_config(config: ConfigContainer) -> GPTSFTDatasetConfig:
+    """Build the Tulu 3 chat SFT dataset preset."""
+    return default_tulu_config(seq_length=_resolve_seq_length(config))
+
+
 def _openmathinstruct2_dataset_config(config: ConfigContainer) -> GPTSFTDatasetConfig:
     """Build the OpenMathInstruct-2 prompt-completion preset."""
     return default_openmathinstruct2_config(seq_length=_resolve_seq_length(config))
@@ -434,6 +469,7 @@ DATASET_PRESETS: dict[str, DatasetPreset] = {
     "mock": _mock_dataset_config,
     "megatron-indexed": _megatron_indexed_dataset_config,
     "squad": _squad_dataset_config,
+    "tulu": _tulu_dataset_config,
     "openmathinstruct2": _openmathinstruct2_dataset_config,
     "openmathinstruct2-thinking": _openmathinstruct2_thinking_dataset_config,
     "gsm8k": _gsm8k_dataset_config,

--- a/tests/unit_tests/data/sources/test_hf.py
+++ b/tests/unit_tests/data/sources/test_hf.py
@@ -201,7 +201,7 @@ def test_named_source_uses_preset_split_and_adapter(monkeypatch):
     assert adapted[0]["original_answers"] == ["2"]
 
 
-def test_tulu_preset_uses_current_native_chat_dataset(monkeypatch):
+def test_tulu3_preset_uses_current_native_chat_dataset(monkeypatch):
     rows = [
         {
             "id": "example-1",
@@ -219,7 +219,7 @@ def test_tulu_preset_uses_current_native_chat_dataset(monkeypatch):
         return rows
 
     monkeypatch.setattr(source_module, "load_dataset", _load_dataset)
-    source = HFDatasetSourceConfig(dataset_name="tulu")
+    source = HFDatasetSourceConfig(dataset_name="tulu3")
 
     resolved = resolve_hf_dataset_source(source)
     adapted = load_and_adapt_hf_dataset(source)

--- a/tests/unit_tests/data/sources/test_hf.py
+++ b/tests/unit_tests/data/sources/test_hf.py
@@ -201,6 +201,36 @@ def test_named_source_uses_preset_split_and_adapter(monkeypatch):
     assert adapted[0]["original_answers"] == ["2"]
 
 
+def test_tulu_preset_uses_current_native_chat_dataset(monkeypatch):
+    rows = [
+        {
+            "id": "example-1",
+            "messages": [
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hi"},
+            ],
+            "source": "example-source",
+        }
+    ]
+    calls = []
+
+    def _load_dataset(path, *, split, **kwargs):
+        calls.append((path, split, kwargs))
+        return rows
+
+    monkeypatch.setattr(source_module, "load_dataset", _load_dataset)
+    source = HFDatasetSourceConfig(dataset_name="tulu")
+
+    resolved = resolve_hf_dataset_source(source)
+    adapted = load_and_adapt_hf_dataset(source)
+
+    assert resolved.path_or_dataset == "allenai/tulu-3-sft-mixture"
+    assert resolved.split == "train"
+    assert resolved.schema_adapter is None
+    assert calls == [("allenai/tulu-3-sft-mixture", "train", {})]
+    assert adapted == rows
+
+
 def test_load_and_adapt_composes_source_loader_and_adapter(monkeypatch):
     rows = [{"context": "ctx", "question": "q", "answers": {"text": ["a"]}}]
     monkeypatch.setattr(source_module, "load_hf_dataset_source", lambda source: rows)

--- a/tests/unit_tests/doc_consistency/test_readme_consistency.py
+++ b/tests/unit_tests/doc_consistency/test_readme_consistency.py
@@ -122,9 +122,10 @@ def test_training_readme_dataset_table_matches_public_presets():
     )
     assert isinstance(registry, ast.Dict)
     registered = {key.value for key in registry.keys if isinstance(key, ast.Constant) and isinstance(key.value, str)}
-    documented = set(re.findall(r"^\| `([^`]+)` \|", _read(TRAINING_README), re.MULTILINE))
+    documented = re.findall(r"^\| `([^`]+)` \|", _read(TRAINING_README), re.MULTILINE)
 
-    assert documented == registered
+    assert len(documented) == len(set(documented))
+    assert set(documented) == registered
     assert "allenai/tulu-3-sft-mixture" in _read(TRAINING_README)
 
 

--- a/tests/unit_tests/doc_consistency/test_readme_consistency.py
+++ b/tests/unit_tests/doc_consistency/test_readme_consistency.py
@@ -30,6 +30,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[3]
 RECIPES_DIR = REPO_ROOT / "src" / "megatron" / "bridge" / "recipes"
 TRAINING_README = REPO_ROOT / "scripts" / "training" / "README.md"
+DATASET_UTILS = REPO_ROOT / "src" / "megatron" / "bridge" / "recipes" / "utils" / "dataset_utils.py"
 LLAMA_README = REPO_ROOT / "tutorials" / "recipes" / "llama" / "README.md"
 DCLM_README = REPO_ROOT / "tutorials" / "data" / "dclm" / "README.md"
 GEMMA3_VL_README = REPO_ROOT / "examples" / "models" / "gemma" / "gemma3_vl" / "README.md"
@@ -107,6 +108,24 @@ def test_training_readme_recipes_exist():
     referenced = set(re.findall(r"--recipe\s+(\w+)", _read(TRAINING_README)))
     missing = sorted(r for r in referenced if r not in defined)
     assert not missing, f"README references nonexistent recipes: {missing}"
+
+
+def test_training_readme_dataset_table_matches_public_presets():
+    """Every public dataset preset is documented once in the launcher README."""
+    tree = ast.parse(_read(DATASET_UTILS), filename=str(DATASET_UTILS))
+    registry = next(
+        node.value
+        for node in tree.body
+        if isinstance(node, ast.AnnAssign)
+        and isinstance(node.target, ast.Name)
+        and node.target.id == "DATASET_PRESETS"
+    )
+    assert isinstance(registry, ast.Dict)
+    registered = {key.value for key in registry.keys if isinstance(key, ast.Constant) and isinstance(key.value, str)}
+    documented = set(re.findall(r"^\| `([^`]+)` \|", _read(TRAINING_README), re.MULTILINE))
+
+    assert documented == registered
+    assert "allenai/tulu-3-sft-mixture" in _read(TRAINING_README)
 
 
 def test_gemma3_vl_readme_recipes_are_exported():

--- a/tests/unit_tests/recipes/utils/test_dataset_utils.py
+++ b/tests/unit_tests/recipes/utils/test_dataset_utils.py
@@ -114,7 +114,7 @@ class TestDatasetPresets:
             "mock",
             "megatron-indexed",
             "squad",
-            "tulu",
+            "tulu3",
             "openmathinstruct2",
             "openmathinstruct2-thinking",
             "gsm8k",
@@ -156,7 +156,7 @@ class TestDatasetPresets:
         ("dataset_name", "source_name"),
         [
             ("squad", "squad"),
-            ("tulu", "tulu"),
+            ("tulu3", "tulu3"),
             ("openmathinstruct2", "openmathinstruct2"),
             ("openmathinstruct2-thinking", "openmathinstruct2_thinking"),
             ("gsm8k", "gsm8k"),
@@ -172,8 +172,8 @@ class TestDatasetPresets:
         assert dataset.enable_offline_packing is False
         assert dataset_train_mode(dataset) == "finetune"
 
-    def test_tulu_preset_allows_typed_config_overrides(self):
-        dataset = build_dataset_config(_make_config(model_seq_length=2048), "tulu")
+    def test_tulu3_preset_allows_typed_config_overrides(self):
+        dataset = build_dataset_config(_make_config(model_seq_length=2048), "tulu3")
 
         process_config_with_overrides(
             dataset,

--- a/tests/unit_tests/recipes/utils/test_dataset_utils.py
+++ b/tests/unit_tests/recipes/utils/test_dataset_utils.py
@@ -114,6 +114,7 @@ class TestDatasetPresets:
             "mock",
             "megatron-indexed",
             "squad",
+            "tulu",
             "openmathinstruct2",
             "openmathinstruct2-thinking",
             "gsm8k",
@@ -155,6 +156,7 @@ class TestDatasetPresets:
         ("dataset_name", "source_name"),
         [
             ("squad", "squad"),
+            ("tulu", "tulu"),
             ("openmathinstruct2", "openmathinstruct2"),
             ("openmathinstruct2-thinking", "openmathinstruct2_thinking"),
             ("gsm8k", "gsm8k"),
@@ -169,6 +171,21 @@ class TestDatasetPresets:
         assert dataset.seq_length == 2048
         assert dataset.enable_offline_packing is False
         assert dataset_train_mode(dataset) == "finetune"
+
+    def test_tulu_preset_allows_typed_config_overrides(self):
+        dataset = build_dataset_config(_make_config(model_seq_length=2048), "tulu")
+
+        process_config_with_overrides(
+            dataset,
+            cli_overrides=[
+                "max_train_samples=128",
+                "hf_validation_proportion=0.1",
+            ],
+        )
+
+        assert dataset.max_train_samples == 128
+        assert dataset.hf_validation_proportion == 0.1
+        dataset.validate()
 
     def test_local_jsonl_is_a_config_preset_with_direct_overrides(self):
         dataset = build_dataset_config(_make_config(model_seq_length=1024), "local-jsonl")

--- a/tests/unit_tests/recipes/utils/test_sft_dataset_utils.py
+++ b/tests/unit_tests/recipes/utils/test_sft_dataset_utils.py
@@ -26,7 +26,31 @@ from megatron.bridge.recipes.utils.dataset_utils import (
     default_openmathinstruct2_config,
     default_openmathinstruct2_thinking_config,
     default_squad_config,
+    default_tulu_config,
 )
+
+
+@pytest.mark.unit
+class TestDefaultTuluConfig:
+    def test_uses_native_chat_preset_with_validation_holdout(self):
+        cfg = default_tulu_config()
+
+        assert isinstance(cfg, GPTSFTDatasetConfig)
+        assert cfg.hf_dataset.dataset_name == "tulu"
+        assert cfg.hf_dataset.split is None
+        assert isinstance(cfg.preprocessing, ChatSFTPreprocessingConfig)
+        assert cfg.hf_validation_proportion == 0.05
+        assert cfg.do_validation is True
+        assert cfg.do_test is False
+
+    def test_custom_sequence_length_and_packing(self):
+        cfg = default_tulu_config(seq_length=8192, enable_offline_packing=True, pad_seq_to_mult=4)
+
+        assert cfg.seq_length == 8192
+        assert cfg.enable_offline_packing is True
+        assert cfg.offline_packing_specs is not None
+        assert cfg.offline_packing_specs.packed_sequence_size == 8192
+        assert cfg.offline_packing_specs.pad_seq_to_mult == 4
 
 
 @pytest.mark.unit

--- a/tests/unit_tests/recipes/utils/test_sft_dataset_utils.py
+++ b/tests/unit_tests/recipes/utils/test_sft_dataset_utils.py
@@ -26,17 +26,17 @@ from megatron.bridge.recipes.utils.dataset_utils import (
     default_openmathinstruct2_config,
     default_openmathinstruct2_thinking_config,
     default_squad_config,
-    default_tulu_config,
+    default_tulu3_config,
 )
 
 
 @pytest.mark.unit
-class TestDefaultTuluConfig:
+class TestDefaultTulu3Config:
     def test_uses_native_chat_preset_with_validation_holdout(self):
-        cfg = default_tulu_config()
+        cfg = default_tulu3_config()
 
         assert isinstance(cfg, GPTSFTDatasetConfig)
-        assert cfg.hf_dataset.dataset_name == "tulu"
+        assert cfg.hf_dataset.dataset_name == "tulu3"
         assert cfg.hf_dataset.split is None
         assert isinstance(cfg.preprocessing, ChatSFTPreprocessingConfig)
         assert cfg.hf_validation_proportion == 0.05
@@ -44,7 +44,7 @@ class TestDefaultTuluConfig:
         assert cfg.do_test is False
 
     def test_custom_sequence_length_and_packing(self):
-        cfg = default_tulu_config(seq_length=8192, enable_offline_packing=True, pad_seq_to_mult=4)
+        cfg = default_tulu3_config(seq_length=8192, enable_offline_packing=True, pad_seq_to_mult=4)
 
         assert cfg.seq_length == 8192
         assert cfg.enable_offline_packing is True

--- a/tests/unit_tests/scripts/training/test_run_recipe.py
+++ b/tests/unit_tests/scripts/training/test_run_recipe.py
@@ -63,7 +63,7 @@ def _load_module():
     dataset_names = {
         *pretraining_datasets,
         "squad",
-        "tulu",
+        "tulu3",
         "openmathinstruct2",
         "openmathinstruct2-thinking",
         "gsm8k",
@@ -234,12 +234,12 @@ def test_named_finetuning_dataset_maps_to_internal_config():
     handles.recipe_runner.apply_cli_overrides.assert_called_once_with(config, [])
 
 
-def test_tulu_dataset_is_listed_in_launcher_help():
+def test_tulu3_dataset_is_listed_in_launcher_help():
     module, _ = _load_module()
 
     help_text = module._build_parser().format_help()
 
-    assert "tulu" in help_text
+    assert "tulu3" in help_text
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/scripts/training/test_run_recipe.py
+++ b/tests/unit_tests/scripts/training/test_run_recipe.py
@@ -63,6 +63,7 @@ def _load_module():
     dataset_names = {
         *pretraining_datasets,
         "squad",
+        "tulu",
         "openmathinstruct2",
         "openmathinstruct2-thinking",
         "gsm8k",
@@ -231,6 +232,14 @@ def test_named_finetuning_dataset_maps_to_internal_config():
 
     handles.build_dataset_config.assert_called_once_with(config, "squad")
     handles.recipe_runner.apply_cli_overrides.assert_called_once_with(config, [])
+
+
+def test_tulu_dataset_is_listed_in_launcher_help():
+    module, _ = _load_module()
+
+    help_text = module._build_parser().format_help()
+
+    assert "tulu" in help_text
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# What does this PR do ?

Add a launcher-visible Tulu 3 dataset preset backed by the official Ai2 Tulu 3 SFT mixture.

# Changelog

- Resolve `tulu3` to `allenai/tulu-3-sft-mixture` and preserve its native `messages` chat schema.
- Build a chat SFT config with a deterministic 5% validation holdout and offline-packing support.
- Document launcher usage and mixed-license considerations.
- Cover source resolution, config validation and overrides, packing, launcher discovery, and documentation consistency.
- Reject duplicate dataset rows in the launcher documentation consistency check.

# Validation

- `uv run python -m pytest tests/unit_tests/data/sources/test_hf.py tests/unit_tests/recipes/utils/test_dataset_utils.py tests/unit_tests/recipes/utils/test_sft_dataset_utils.py tests/unit_tests/scripts/training/test_run_recipe.py tests/unit_tests/doc_consistency/test_readme_consistency.py -q` — 191 passed in the supported container.
- `uv run pre-commit run --all-files` — passed on the final diff.
- EOS real-data/real-model validation — Slurm job `5645984` completed with exit `0:0`:
  - Both cases used `Qwen/Qwen3-0.6B` weights, the `tulu3` preset, and the real `train[:256]` dataset slice, materialized as 243 training and 13 validation examples.
  - Non-packed: 2/2 training iterations completed with finite LM losses `1.898752` and `3.871898`; validation LM loss `1.802260`.
  - Offline-packed at sequence length 512: created 96 training and 6 validation packed rows; packing efficiency was 93.17% and 83.04%, respectively. 2/2 training iterations completed with finite LM losses `1.984679` and `2.300231`; validation LM loss `1.588419`.
  - Both cases reported zero skipped iterations and zero NaN iterations.
- Independent implementation review found no high-confidence actionable defects.
- Independent test audit found no blocking coverage gaps; its duplicate-row observation was addressed.

# Before this PR is ready for review

- [x] Read and followed the contributor guidelines.
- [x] Added focused unit tests.
- [x] Updated launcher documentation.
- [x] No optional-install components are affected.
- [x] Independent reviewer and tester audits complete.
- [x] Real dataset/model smoke tests passed with and without offline packing.
- [ ] CI results reviewed for the latest commit.
