### PR TITLE
fix(training): reset model callbacks during in-process restart

### DIFF
--- a/src/megatron/bridge/training/state.py
+++ b/src/megatron/bridge/training/state.py
@@ -478,6 +478,16 @@ class GlobalState:
         # The top-level tracker is overwritten after every checkpoint. A restart must
         # not reuse the iteration cached by an earlier invocation in this process.
         read_train_state.cache_clear()
+        if self.cfg is not None:
+            model_config = getattr(self.cfg.model, "transformer", self.cfg.model)
+            for callback_name in (
+                "finalize_model_grads_func",
+                "grad_scale_func",
+                "no_sync_func",
+                "grad_sync_func",
+                "param_sync_func",
+            ):
+                setattr(model_config, callback_name, None)
         self._timers = None
         self._train_state = None
         self._tensorboard_logger = None

--- a/tests/unit_tests/training/test_setup.py
+++ b/tests/unit_tests/training/test_setup.py
@@ -27,9 +27,11 @@ from megatron.bridge.training.setup import (
     _build_distributed_model,
     _register_pre_wrap_hook,
     _should_load_checkpoint,
+    _update_model_config_funcs,
     _validate_and_set_vocab_size,
     maybe_log_and_save_config,
 )
+from megatron.bridge.training.state import GlobalState
 
 
 def _make_transformer(**kwargs):
@@ -273,3 +275,35 @@ class TestBuildDistributedModel:
 
         mock_provider.provide_distributed_model.assert_called_once()
         assert result == mock_dist_model
+
+
+def test_restart_rebinds_overlap_callbacks_to_rebuilt_model():
+    """A restart must replace callbacks bound to the discarded model."""
+
+    class FakeDDP:
+        def no_sync(self):
+            pass
+
+        def start_grad_sync(self):
+            pass
+
+    model_config = _make_gpt_model_config()
+    transformer_config = model_config.transformer
+    ddp_config = SimpleNamespace(
+        overlap_grad_reduce=True,
+        overlap_param_gather=False,
+        align_param_gather=False,
+    )
+    first_model = FakeDDP()
+    rebuilt_model = FakeDDP()
+    state = GlobalState()
+    state._cfg = SimpleNamespace(model=model_config)
+
+    with patch("megatron.bridge.training.setup.DistributedDataParallel", FakeDDP):
+        _update_model_config_funcs([first_model], transformer_config, ddp_config, optimizer=None)
+        assert transformer_config.no_sync_func.__self__ is first_model
+
+        state.reset_for_restart()
+        _update_model_config_funcs([rebuilt_model], transformer_config, ddp_config, optimizer=None)
+
+    assert transformer_config.no_sync_func.__self__ is rebuilt_model


### PR DESCRIPTION
## What changed

Clear model-runtime synchronization callbacks when `GlobalState` is reset for
an in-process restart, then cover retry-time rebinding with a focused regression
test.

## Supported trigger and impact

With in-process restart enabled and `ddp.overlap_grad_reduce=True`, initial
setup stores methods bound to the current distributed model in the retained
transformer config. NVRx reuses that config after destroying the failed
runtime. Retry-time setup then reaches `_update_model_config_funcs()` with the
old `no_sync_func` still installed and raises before training can resume:

```text
AssertionError: When overlap_grad_reduce is True, config.no_sync_func must be None
```

The shipped in-process-restart functional configuration enables gradient
reduction overlap, so this is a supported recovery path rather than rejected
input.

## Root cause and fix

`GlobalState.reset_for_restart()` reset loggers, timers, train state, and signal
handling but retained the model, optimizer, and process-group callbacks stored
on the config. The fix clears the five setup-owned runtime callbacks at that
same ownership boundary. GPT and Hybrid wrapper configs target their nested
transformer config; legacy providers are handled directly.

## Regression evidence

The same two-rank real-DDP contract reproducer was run before and after the
production change (private infrastructure arguments omitted):

```text
srun --ntasks=2 <approved-container-args> \
  uv run --active --no-sync python distributed_restart_reproducer.py
```

- Unmodified base `3473d055a246be197b41c894479c1ba4d467a068`: exit 1; both ranks failed at the `no_sync_func is None` assertion.
- Fixed tree: exit 0; both ranks reset and rebound the real overlapped DDP callbacks without an assertion or traceback.

Focused and adjacent validation:

```text
uv run --active --no-sync python -m pytest \
  tests/unit_tests/training/test_setup.py \
  tests/unit_tests/training/test_state.py \
  tests/unit_tests/training/test_inprocess_restart.py \
  -q --tb=short
# 101 passed, 33 warnings

uv run --active --no-sync pre-commit run --all-files
# all hooks passed

git diff --check
# passed
```

## Scope

This validates retry-time callback ownership and rebinding for Megatron DDP
with gradient-reduction overlap. It does not claim full-suite, convergence,
performance, or Torch FSDP2 validation. No dependency, workflow, public API,
submodule, or lockfile changes are included.
