### PR TITLE
Weijia/stage1 continue

### DIFF
--- a/docs/models/mimo/mimo.md
+++ b/docs/models/mimo/mimo.md
@@ -15,10 +15,13 @@ Megatron Bridge supports Hugging Face checkpoints using the `MiMoForCausalLM` ar
 
 ## Examples
 
-General MiMo and heterogeneous multimodal training examples live under [`examples/megatron_mimo`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/examples/megatron_mimo).
+Checkpoint conversion and text-generation examples for MiMo causal language
+models live under
+[`examples/models/mimo`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/examples/models/mimo).
+Heterogeneous multimodal training examples live separately under
+[`examples/megatron_mimo`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/examples/megatron_mimo).
 
 ## Related Implementation
 
 - MiMo bridge: [`src/megatron/bridge/models/mimo/mimo_bridge.py`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/src/megatron/bridge/models/mimo/mimo_bridge.py)
 - Megatron-MiMo provider infrastructure: [`src/megatron/bridge/models/megatron_mimo`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/src/megatron/bridge/models/megatron_mimo)
-

--- a/docs/models/mistral/ministral3.md
+++ b/docs/models/mistral/ministral3.md
@@ -7,25 +7,27 @@ Ministral 3 models support multimodal tasks including image captioning, visual q
 Ministral 3 models are supported via the Bridge system with auto-detected configuration and weight mapping.
 
 ```{important}
-Please upgrade to `transformers` v5 and upgrade `mistral-common` in order to use the Ministral 3 models.
+Ministral 3 requires `transformers` v5 and `mistral-common`; both are pinned by
+the Megatron Bridge project environment. Run commands through `uv run` so the
+compatible versions are used.
 ```
 
 ## Available Models
 
 ### Vision-Language Models
-- **Ministral 3 3B** (`mistralai/Ministral-3-3B-Base-2512`): 3.4B parameter vision-language model
+- **Ministral 3 3B** (`mistralai/Ministral-3-3B-Base-2512`): ~3.8B unique-parameter vision-language model
   - 26 layers, 3072 hidden size
   - 32 attention heads, 8 query groups (GQA)
   - Vision encoder: ~0.4B parameters
   - Recommended: 1 node, 8 GPUs
 
-- **Ministral 3 8B** (`mistralai/Ministral-3-8B-Base-2512`): 8.4B parameter vision-language model
+- **Ministral 3 8B** (`mistralai/Ministral-3-8B-Base-2512`): 8.9B parameter vision-language model
   - 34 layers, 4096 hidden size
   - 32 attention heads, 8 query groups (GQA)
   - Vision encoder: ~0.4B parameters
   - Recommended: 1 node, 8 GPUs
 
-- **Ministral 3 14B** (`mistralai/Ministral-3-14B-Base-2512`): ~14B parameter vision-language model
+- **Ministral 3 14B** (`mistralai/Ministral-3-14B-Base-2512`): 13.9B parameter vision-language model
   - 40 layers, 5120 hidden size
   - 32 attention heads, 8 query groups (GQA)
   - Vision encoder: ~0.4B parameters

--- a/docs/models/mistral/mistral.md
+++ b/docs/models/mistral/mistral.md
@@ -30,8 +30,8 @@ Additional Mistral models (including MoE variants like Mixtral) may be supported
 ```python
 from megatron.bridge import AutoBridge
 
-# Example: Mistral Small 3 24B
-bridge = AutoBridge.from_hf_pretrained("mistralai/Mistral-Small-24B-Base-2501")
+# Example: Mistral 7B
+bridge = AutoBridge.from_hf_pretrained("mistralai/Mistral-7B-v0.1")
 provider = bridge.to_megatron_provider()
 
 # Optionally configure parallelism before instantiating the model
@@ -45,8 +45,8 @@ model = provider.provide_distributed_model(wrap_with_ddp=False)
 
 ```bash
 ./scripts/conversion/convert.sh import \
-  --hf-model mistralai/Mistral-Small-24B-Base-2501 \
-  --megatron-path /checkpoints/mistral_small_24b_megatron
+  --hf-model mistralai/Mistral-7B-v0.1 \
+  --megatron-path /checkpoints/mistral_7b_megatron
 ```
 
 ### Export Megatron → HF
@@ -55,12 +55,12 @@ model = provider.provide_distributed_model(wrap_with_ddp=False)
 from megatron.bridge import AutoBridge
 
 # Load the bridge from HF model ID
-bridge = AutoBridge.from_hf_pretrained("mistralai/Mistral-Small-24B-Base-2501")
+bridge = AutoBridge.from_hf_pretrained("mistralai/Mistral-7B-v0.1")
 
 # Export a trained Megatron checkpoint to HF format
 bridge.export_ckpt(
-    megatron_path="/results/mistral_small_24b/checkpoints/iter_0000500",
-    hf_path="/exports/mistral_small_24b_hf",
+    megatron_path="/results/mistral_7b/checkpoints/iter_0000500",
+    hf_path="/exports/mistral_7b_hf",
 )
 ```
 
@@ -68,14 +68,16 @@ bridge.export_ckpt(
 
 ```bash
 uv run python examples/conversion/hf_to_megatron_generate_text.py \
-  --hf_model_path mistralai/Mistral-Small-24B-Base-2501 \
-  --megatron_model_path /checkpoints/mistral_small_24b_megatron \
+  --hf_model_path mistralai/Mistral-7B-v0.1 \
+  --megatron_model_path /checkpoints/mistral_7b_megatron \
   --prompt "What is artificial intelligence?" \
   --max_new_tokens 100 \
   --tp 2
 ```
 
-For more details, see [examples/conversion/hf_to_megatron_generate_text.py](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/examples/conversion/hf_to_megatron_generate_text.py)
+For the complete import, export, round-trip, and three-source generation
+workflow, see
+[`examples/models/mistral/mistral`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/examples/models/mistral/mistral).
 
 ## Recipes
 

--- a/examples/conversion/hf_to_megatron_generate_text.py
+++ b/examples/conversion/hf_to_megatron_generate_text.py
@@ -139,12 +139,24 @@ def _tokenize_prompt(tokenizer, prompt: str, *, apply_chat_template: bool, think
     return encoded["input_ids"]
 
 
+def _safe_decode_token(tokenizer, token_id: int) -> str:
+    """Decode a single token, replacing invalid UTF-8 bytes rather than raising."""
+    try:
+        return tokenizer.decode([token_id])
+    except (UnicodeDecodeError, ValueError):
+        return repr(token_id)
+
+
 def _decode_completion(tokenizer, generated_ids: torch.Tensor, prompt_length: int) -> str:
     """Decode generated tokens without echoing the prompt or special tokens."""
-    return tokenizer.decode(
-        generated_ids[0, prompt_length:].tolist(),
-        skip_special_tokens=True,
-    )
+    tokens = generated_ids[0, prompt_length:].tolist()
+    try:
+        return tokenizer.decode(tokens, skip_special_tokens=True)
+    except (UnicodeDecodeError, ValueError):
+        # Some tokenizers produce non-UTF-8 bytes (e.g. byte-level vocabularies).
+        # Decode without skipping specials first, then replace invalid bytes.
+        raw = tokenizer.decode(tokens, skip_special_tokens=False)
+        return raw.encode("utf-8", errors="replace").decode("utf-8")
 
 
 def main(args) -> None:
@@ -319,10 +331,10 @@ def main(args) -> None:
                     print_rank_0(f"Step {step}: output shape={output.shape}, var={output.var():.4f}")
                     logits = output[0, -1, :]
                     top5_vals, top5_ids = torch.topk(logits, 5)
-                    top5_tokens = [tokenizer.decode([idx]) for idx in top5_ids]
+                    top5_tokens = [_safe_decode_token(tokenizer, idx) for idx in top5_ids]
                     print_rank_0(f"Top 5: {list(zip(top5_tokens, top5_vals.tolist()))}")
                     print_rank_0(
-                        f"Selected: '{tokenizer.decode([next_token_ids.item()])}' (id={next_token_ids.item()})"
+                        f"Selected: '{_safe_decode_token(tokenizer, next_token_ids.item())}' (id={next_token_ids.item()})"
                     )
             else:
                 next_token_ids = torch.ones((1, 1), device=generated_ids.device, dtype=generated_ids.dtype)

--- a/examples/conversion/hf_to_megatron_generate_vlm.py
+++ b/examples/conversion/hf_to_megatron_generate_vlm.py
@@ -157,6 +157,7 @@ def main(args) -> None:
     if is_kimi and image_token_id is None:
         image_token_id = 163605
     is_gemma4 = "gemma4" in model_type
+    is_mistral3 = model_type == "mistral3"
 
     # ------------------------------------------------------------------
     # Load model
@@ -256,6 +257,7 @@ def main(args) -> None:
             args.prompt,
             is_gemma4=is_gemma4,
             is_kimi=is_kimi,
+            is_mistral3=is_mistral3,
             image_token_id=image_token_id,
         )
 

--- a/examples/conversion/vlm_generate_utils.py
+++ b/examples/conversion/vlm_generate_utils.py
@@ -195,6 +195,7 @@ def process_image_inputs(
     *,
     is_gemma4: bool = False,
     is_kimi: bool = False,
+    is_mistral3: bool = False,
     image_token_id: Optional[int] = None,
 ):
     """Process image + prompt into model inputs.
@@ -215,11 +216,7 @@ def process_image_inputs(
     if is_kimi:
         return _process_kimi_inputs(processor, image_path, prompt, image_token_id)
 
-    if not _HAS_QWEN_VL_UTILS:
-        raise ImportError(
-            "qwen_vl_utils is required for non-Kimi VLM image processing. Install it with: pip install qwen-vl-utils"
-        )
-    return _process_default_inputs(processor, image_path, prompt)
+    return _process_default_inputs(processor, image_path, prompt, allow_raw_prompt=is_mistral3)
 
 
 def _process_kimi_inputs(processor, image_path, prompt, image_token_id):
@@ -239,7 +236,36 @@ def _process_kimi_inputs(processor, image_path, prompt, image_token_id):
     return input_ids, inputs.pixel_values, grid_thws, None, None, None
 
 
-def _process_default_inputs(processor, image_path, prompt):
+def _process_default_inputs(processor, image_path, prompt, *, allow_raw_prompt=False):
+    if getattr(processor, "chat_template", None) is None:
+        if not allow_raw_prompt:
+            raise ValueError("The processor has no chat template and no model-specific raw-prompt fallback")
+        image = load_image(image_path).convert("RGB")
+        image_token = getattr(processor, "image_token", None) or getattr(
+            processor.tokenizer, "image_token", "<|image|>"
+        )
+        if image_token not in prompt:
+            prompt = f"{image_token}\n{prompt}"
+        inputs = processor(
+            text=[prompt],
+            images=[image],
+            padding=True,
+            return_tensors="pt",
+        )
+        return (
+            inputs.input_ids,
+            inputs.get("pixel_values"),
+            inputs.get("image_grid_thw"),
+            inputs.get("image_sizes"),
+            inputs.get("mm_token_type_ids"),
+            inputs.get("image_position_ids"),
+        )
+
+    if not _HAS_QWEN_VL_UTILS:
+        raise ImportError(
+            "qwen_vl_utils is required for chat-template VLM image processing. Install it with: pip install qwen-vl-utils"
+        )
+
     messages = [
         {
             "role": "user",

--- a/examples/inference/README.md
+++ b/examples/inference/README.md
@@ -64,15 +64,16 @@ Ling/Bailing runs MoE inference with coordinator mode:
 bash examples/models/bailing/inference.sh
 ```
 
-GPT-OSS runs through static generation with local attention:
+GPT-OSS runs through static generation with Transformer Engine's unfused attention:
 
 ```bash
 bash examples/models/gpt_oss/inference.sh
 ```
 
 `examples/models/gpt_oss/inference.sh` uses `--use-legacy-generation` and
-`--attention-backend local` because GPT-OSS uses attention behavior that should
-run through the static path for this example.
+`--attention-backend unfused`. The static path supports GPT-OSS generation,
+while the unfused Transformer Engine backend handles its learnable softmax and
+sliding-window attention without relying on an unavailable fused kernel.
 
 For larger models that need multiple nodes, use the Slurm wrapper for that
 model. For example:

--- a/examples/inference/README.md
+++ b/examples/inference/README.md
@@ -64,16 +64,15 @@ Ling/Bailing runs MoE inference with coordinator mode:
 bash examples/models/bailing/inference.sh
 ```
 
-GPT-OSS runs through static generation with Transformer Engine's unfused attention:
+GPT-OSS runs through static generation with local attention:
 
 ```bash
 bash examples/models/gpt_oss/inference.sh
 ```
 
 `examples/models/gpt_oss/inference.sh` uses `--use-legacy-generation` and
-`--attention-backend unfused`. The static path supports GPT-OSS generation,
-while the unfused Transformer Engine backend handles its learnable softmax and
-sliding-window attention without relying on an unavailable fused kernel.
+`--attention-backend local` because GPT-OSS uses attention behavior that should
+run through the static path for this example.
 
 For larger models that need multiple nodes, use the Slurm wrapper for that
 model. For example:

--- a/examples/models/bailing/README.md
+++ b/examples/models/bailing/README.md
@@ -25,14 +25,20 @@ Directory structure:
 
 ## Checkpoint Conversion
 
-See [conversion.sh](conversion.sh) for checkpoint conversion examples.
+See [conversion.sh](conversion.sh) for checkpoint conversion examples. The
+script defaults to `inclusionAI/Ling-mini-2.0`, the 16B checkpoint, and accepts
+the other variants through `MODEL_NAME` or a complete `HF_MODEL_ID`:
+
+```bash
+MODEL_NAME=Ling-flash-2.0 bash examples/models/bailing/conversion.sh
+```
 
 ### Import HF → Megatron
 
 ```bash
 ./scripts/conversion/convert.sh import \
-    --hf-model inclusionAI/Ling-flash-2.0 \
-    --megatron-path ${WORKSPACE}/models/Ling-flash-2.0 \
+    --hf-model inclusionAI/Ling-mini-2.0 \
+    --megatron-path ${WORKSPACE}/models/Ling-mini-2.0 \
     --trust-remote-code
 ```
 
@@ -40,9 +46,9 @@ See [conversion.sh](conversion.sh) for checkpoint conversion examples.
 
 ```bash
 ./scripts/conversion/convert.sh export \
-    --hf-model inclusionAI/Ling-flash-2.0 \
-    --megatron-path ${WORKSPACE}/models/Ling-flash-2.0/iter_0000000 \
-    --hf-path ${WORKSPACE}/models/Ling-flash-2.0-hf-export \
+    --hf-model inclusionAI/Ling-mini-2.0 \
+    --megatron-path ${WORKSPACE}/models/Ling-mini-2.0/iter_0000000 \
+    --hf-path ${WORKSPACE}/models/Ling-mini-2.0-hf-export \
     --trust-remote-code
 ```
 
@@ -51,20 +57,21 @@ See [conversion.sh](conversion.sh) for checkpoint conversion examples.
 ```bash
 python -m torch.distributed.run --nproc_per_node=8 \
     examples/conversion/hf_megatron_roundtrip_multi_gpu.py \
-    --hf-model-id inclusionAI/Ling-flash-2.0 \
-    --megatron-load-path ${WORKSPACE}/models/Ling-flash-2.0/iter_0000000 \
-    --tp 1 --ep 8 \
+    --hf-model-id inclusionAI/Ling-mini-2.0 \
+    --megatron-load-path ${WORKSPACE}/models/Ling-mini-2.0/iter_0000000 \
+    --tp 2 --ep 4 \
     --trust-remote-code
 ```
 
 ## Inference
 
 See [inference.sh](inference.sh) for text generation with:
-- Hugging Face checkpoint (`inclusionAI/Ling-flash-2.0`)
+- Hugging Face checkpoint (`inclusionAI/Ling-mini-2.0` by default)
 - Imported Megatron checkpoint (after [conversion.sh](conversion.sh) import)
 - Exported HF checkpoint (after conversion export)
 
-The default parallelism for 8 GPUs is `--tp 2 --ep 4`.
+Both scripts default to 8 GPUs with `--tp 2 --ep 4`. Override `TP`, `PP`,
+`EP`, `ETP`, and `NPROC_PER_NODE` together for another valid layout.
 TP×PP×EP must equal `--nproc_per_node`.
 
 > **Note**: `--tp 1 --ep 8` works for conversion round-trip but may cause issues during autoregressive inference with single-token batches (empty token dispatch to some EP ranks). Use `--tp 2 --ep 4` for inference.

--- a/examples/models/ernie/ernie45/conversion.sh
+++ b/examples/models/ernie/ernie45/conversion.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+# Workspace directory for checkpoints and results
+WORKSPACE=${WORKSPACE:-/workspace}
+
+HF_MODEL_ID=${HF_MODEL_ID:-baidu/ERNIE-4.5-21B-A3B-PT}
+MODEL_NAME=${MODEL_NAME:-${HF_MODEL_ID##*/}}
+MEGATRON_PATH=${MEGATRON_PATH:-${WORKSPACE}/models/${MODEL_NAME}}
+MEGATRON_LOAD_PATH=${MEGATRON_LOAD_PATH:-${MEGATRON_PATH}/iter_0000000}
+HF_EXPORT_PATH=${HF_EXPORT_PATH:-${WORKSPACE}/models/${MODEL_NAME}-hf-export}
+ROUNDTRIP_OUTPUT_DIR=${ROUNDTRIP_OUTPUT_DIR:-${WORKSPACE}/models/${MODEL_NAME}-roundtrip}
+
+TP=${TP:-1}
+PP=${PP:-1}
+EP=${EP:-8}
+ETP=${ETP:-1}
+NPROC_PER_NODE=${NPROC_PER_NODE:-$((TP * PP * EP))}
+
+# Import HF → Megatron
+./scripts/conversion/convert.sh import \
+    --hf-model "$HF_MODEL_ID" \
+    --megatron-path "$MEGATRON_PATH" \
+    --tp "$TP" --pp "$PP" --ep "$EP" --etp "$ETP" \
+    --trust-remote-code
+
+# Export Megatron → HF
+# --not-strict: the ERNIE-4.5-21B-A3B-PT checkpoint ships 12 MTP weights
+# (mtp_block, mtp_emb_norm, mtp_hidden_norm, mtp_linear_proj) that are
+# pre-training-only and not reproduced here; they are expected to be absent.
+./scripts/conversion/convert.sh export \
+    --hf-model "$HF_MODEL_ID" \
+    --megatron-path "$MEGATRON_LOAD_PATH" \
+    --hf-path "$HF_EXPORT_PATH" \
+    --tp "$TP" --pp "$PP" --ep "$EP" --etp "$ETP" \
+    --trust-remote-code \
+    --not-strict
+
+# Multi-GPU weight verification
+uv run python -m torch.distributed.run --nproc_per_node="$NPROC_PER_NODE" \
+    examples/conversion/hf_megatron_roundtrip_multi_gpu.py \
+    --hf-model-id "$HF_MODEL_ID" \
+    --megatron-load-path "$MEGATRON_LOAD_PATH" \
+    --output-dir "$ROUNDTRIP_OUTPUT_DIR" \
+    --tp "$TP" --pp "$PP" --ep "$EP" --etp "$ETP" \
+    --trust-remote-code \
+    --not-strict

--- a/examples/models/ernie/ernie45/inference.sh
+++ b/examples/models/ernie/ernie45/inference.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+# Workspace directory for checkpoints
+WORKSPACE=${WORKSPACE:-/workspace}
+
+HF_MODEL_ID=${HF_MODEL_ID:-baidu/ERNIE-4.5-21B-A3B-PT}
+MODEL_NAME=${MODEL_NAME:-${HF_MODEL_ID##*/}}
+MEGATRON_PATH=${MEGATRON_PATH:-${WORKSPACE}/models/${MODEL_NAME}/iter_0000000}
+HF_EXPORT_PATH=${HF_EXPORT_PATH:-${WORKSPACE}/models/${MODEL_NAME}-hf-export}
+
+TP=${TP:-1}
+PP=${PP:-1}
+EP=${EP:-8}
+ETP=${ETP:-1}
+NPROC_PER_NODE=${NPROC_PER_NODE:-$((TP * PP * EP))}
+
+PROMPT=${PROMPT:-"Hello, how are you?"}
+MAX_NEW_TOKENS=${MAX_NEW_TOKENS:-64}
+
+run_inference() {
+    uv run python -m torch.distributed.run --nproc_per_node="$NPROC_PER_NODE" \
+        examples/conversion/hf_to_megatron_generate_text.py \
+        "$@" \
+        --prompt "$PROMPT" \
+        --max_new_tokens "$MAX_NEW_TOKENS" \
+        --tp "$TP" --pp "$PP" --ep "$EP" --etp "$ETP" \
+        --trust-remote-code
+}
+
+echo "=== Gate 4: Original HF checkpoint ==="
+run_inference --hf_model_path "$HF_MODEL_ID"
+
+echo "=== Gate 5: Imported Megatron checkpoint ==="
+run_inference \
+    --hf_model_path "$HF_MODEL_ID" \
+    --megatron_model_path "$MEGATRON_PATH"
+
+echo "=== Gate 6: Exported HF checkpoint ==="
+run_inference --hf_model_path "$HF_EXPORT_PATH"

--- a/examples/models/full-model-validation.md
+++ b/examples/models/full-model-validation.md
@@ -40,7 +40,7 @@ Hugging Face commit SHAs resolved on the date above. Status is one of `TODO`,
 | GLM | GLM-4.7 | `zai-org/GLM-4.7` | `602d01efcdd332c5238ca4bcede555defbe83eb7` | 358.3B | text | `examples/models/glm47` | TODO |
 | GLM | GLM-4.7-Flash | `zai-org/GLM-4.7-Flash` | `7dd20894a642a0aa287e9827cb1a1f7f91386b67` | 31.2B | text | `examples/models/glm47` | TODO |
 | GLM | GLM-4.5V | `zai-org/GLM-4.5V` | `ed47433b37111465ec527affaaddceff371bca04` | 107.7B | vision-language | `examples/models/glm/glm_45v` | TODO |
-| GPT-OSS | GPT-OSS 20B | `openai/gpt-oss-20b` | `6cee5e81ee83917806bbde320786a8fb61efebee` | 21.5B | text | `examples/models/gpt_oss` | TODO |
+| GPT-OSS | GPT-OSS 20B | `openai/gpt-oss-20b` | `6cee5e81ee83917806bbde320786a8fb61efebee` | 21.5B | text | `examples/models/gpt_oss` | RUNNING |
 | GPT-OSS | GPT-OSS 120B | `openai/gpt-oss-120b` | `b5c939de8f754692c1647ca79fbf85e8c1e70f8a` | 120.4B | text | `examples/models/gpt_oss` | TODO |
 | HY V3 | Hy3 preview-Base | `tencent/Hy3-preview-Base` | `54a62bb00a50195423bffb6b55e91aa28b6a8ce2` | 298.8B | text | `examples/conversion` | TODO |
 | Llama | Llama 2 | `meta-llama/Llama-2-7b-hf` | `01c7f73d771dfac7d292323805ebc428287df4f9` | 6.7B | text | `examples/conversion` | TODO |

--- a/examples/models/full-model-validation.md
+++ b/examples/models/full-model-validation.md
@@ -1,6 +1,6 @@
 # Full-model validation inventory
 
-Last updated: 2026-07-11
+Last updated: 2026-07-12
 
 This manifest tracks full-checkpoint conversion and inference validation for the
 model architectures and explicitly named variants in the root
@@ -80,7 +80,7 @@ Hugging Face commit SHAs resolved on the date above. Status is one of `TODO`,
 | Qwen | Qwen2 Audio | `Qwen/Qwen2-Audio-7B-Instruct` | `0a095220c30b7b31434169c3086508ef3ea5bf0a` | 8.4B | audio-text | `examples/models/qwen/qwen2_audio` | TODO |
 | Qwen | Qwen2.5-Omni | `Qwen/Qwen2.5-Omni-7B` | `ae9e1690543ffd5c0221dc27f79834d0294cba00` | 10.7B | vision-audio-text | `examples/models/qwen/qwen25_omni` | TODO |
 | Qwen | Qwen3-Omni | `Qwen/Qwen3-Omni-30B-A3B-Instruct` | `26291f793822fb6be9555850f06dfe95f2d7e695` | 35.3B | vision-audio-text | `examples/models/qwen/qwen3_omni` | TODO |
-| Qwen | Qwen3-ASR | `Qwen/Qwen3-ASR-1.7B` | `7278e1e70fe206f11671096ffdd38061171dd6e5` | 2.3B | audio-text | `examples/models/qwen/qwen3_asr` | TODO |
+| Qwen | Qwen3-ASR | `Qwen/Qwen3-ASR-1.7B` | `7278e1e70fe206f11671096ffdd38061171dd6e5` | 2.3B | audio-text | `examples/models/qwen/qwen3_asr` | PASS |
 | Sarvam | Sarvam | `sarvamai/sarvam-30b` | `071ae95e933605ca1104a6b4524a36a98488efa4` | 32.2B | text | `examples/models/sarvam` | TODO |
 | StepFun | Step-3.5-Flash | `stepfun-ai/Step-3.5-Flash` | `ab446a3de5e171ea341227e24bb1f090e1b771f7` | 199.4B | text | `examples/models/stepfun/step35` | TODO |
 | StepFun | Step-3.7-Flash | `stepfun-ai/Step-3.7-Flash` | `5f6244077ac62e04eec3f320501ff8c2b293373a` | 201.4B | vision-language | `examples/models/stepfun/step37` | TODO |

--- a/examples/models/full-model-validation.md
+++ b/examples/models/full-model-validation.md
@@ -23,7 +23,7 @@ forward-logit parity.
 | Family | Architecture / version | Canonical HF checkpoint | Revision | Params | Modality | Example path | Status |
 |---|---|---|---|---:|---|---|---|
 | Bailing | Ling 2.0 (Flash) | `inclusionAI/Ling-flash-2.0` | `18ca64a019b553be57bab50af3207fb2f3675edc` | 100B | text | `examples/models/bailing` | TODO |
-| Bailing | Ling MoE V2 / Bailing (Mini) | `inclusionAI/Ling-mini-2.0` | `920c3fd9916e3d5e543fc4f609e827cad8a32983` | 16B | text | `examples/models/bailing` | BLOCKED |
+| Bailing | Ling MoE V2 / Bailing (Mini) | `inclusionAI/Ling-mini-2.0` | `920c3fd9916e3d5e543fc4f609e827cad8a32983` | 16B | text | `examples/models/bailing` | PASS |
 | DeepSeek | DeepSeek V2 | `deepseek-ai/DeepSeek-V2` | `4461458f186c35188585855f28f77af5661ad489` | 235.7B | text | `examples/conversion` | TODO |
 | DeepSeek | DeepSeek V2 Lite | `deepseek-ai/DeepSeek-V2-Lite` | `604d5664dddd88a0433dbae533b7fe9472482de0` | 15.7B | text | `examples/conversion` | PASS |
 | DeepSeek | DeepSeek V4 Flash | `deepseek-ai/DeepSeek-V4-Flash-Base` | `8855555deef230a27a21a8d6f294b7b7497759b6` | 292.0B | text | `examples/models/deepseek_v4` | TODO |
@@ -56,11 +56,11 @@ forward-logit parity.
 | MiniMax | MiniMax-M2 | `MiniMaxAI/MiniMax-M2` | `757303d492a50514c312788b5247a4f696a4c6a3` | 456B | text | `examples/models/minimax/minimax_m2` | TODO |
 | MiniMax | MiniMax-M2.5 | `MiniMaxAI/MiniMax-M2.5` | `f710177d938eff80b684d42c5aa84b382612f21f` | 456B | text | `examples/models/minimax/minimax_m2` | TODO |
 | MiniMax | MiniMax-M2.7 | `MiniMaxAI/MiniMax-M2.7` | `d494266a4affc0d2995ba1fa35c8481cbd84294b` | 456B | text | `examples/models/minimax/minimax_m2` | TODO |
-| Mistral | Mistral | `mistralai/Mistral-7B-v0.1` | `27d67f1b5f57dc0953326b2601d68371d40ea8da` | 7.2B | text | `examples/conversion` | BLOCKED |
+| Mistral | Mistral | `mistralai/Mistral-7B-v0.1` | `27d67f1b5f57dc0953326b2601d68371d40ea8da` | 7.2B | text | `examples/models/mistral/mistral` | PASS |
 | Mistral | Ministral 3 3B | `mistralai/Ministral-3-3B-Base-2512` | `6f9c4b12a95b139af68670a6713616b757923735` | 4.3B | vision-language | `examples/models/mistral/ministral3` | BLOCKED |
 | Mistral | Ministral 3 8B | `mistralai/Ministral-3-8B-Base-2512` | `d4883f9b36aa2e5d775730d3fdba3d30de51a8ef` | 8.9B | vision-language | `examples/models/mistral/ministral3` | BLOCKED |
 | Mistral | Ministral 3 14B | `mistralai/Ministral-3-14B-Base-2512` | `5b0ceedbb42dff466ae60b258ba296f32da51384` | 13.9B | vision-language | `examples/models/mistral/ministral3` | BLOCKED |
-| Xiaomi-MiMo | MiMo | `XiaomiMiMo/MiMo-7B-Base` | `c72df4586cb8bdeebd65f36929cd3385a6566fbe` | 7.8B | text | `examples/megatron_mimo` | BLOCKED |
+| Xiaomi-MiMo | MiMo | `XiaomiMiMo/MiMo-7B-Base` | `c72df4586cb8bdeebd65f36929cd3385a6566fbe` | 7.8B | text | `examples/models/mimo` | PASS |
 | Xiaomi-MiMo | MiMo-V2-Flash | `XiaomiMiMo/MiMo-V2-Flash` | `1afd314a2406c282e0956375c34a676501c78649` | 309.8B | text | `examples/models/mimo_v2_flash` | TODO |
 | Moonlight | Moonlight | `moonshotai/Moonlight-16B-A3B` | `476b36a473d4467f94469414bef6cee75c9c8172` | 16.0B | text | `examples/conversion` | BLOCKED |
 | Nemotron | Nemotron H | `nvidia/Nemotron-H-4B-Base-8K` | `faba3b731ad7ea5781b9518ae75fb610a94affcf` | 4.5B | text | `examples/conversion` | PASS |

--- a/examples/models/full-model-validation.md
+++ b/examples/models/full-model-validation.md
@@ -32,7 +32,7 @@ Hugging Face commit SHAs resolved on the date above. Status is one of `TODO`,
 | Gemma | Gemma | `google/gemma-2b` | `9cf48e52b224239de00d483ec8eb84fb8d0f3a3a` | 2.5B | text | `examples/conversion` | TODO |
 | Gemma | Gemma 2 | `google/gemma-2-2b` | `c5ebcd40d208330abc697524c919956e692655cf` | 2.6B | text | `examples/conversion` | TODO |
 | Gemma | Gemma 3 | `google/gemma-3-1b-it` | `dcc83ea841ab6100d6b47a070329e1ba4cf78752` | 1.0B | text | `examples/conversion` | TODO |
-| Gemma | Gemma 3-VL | `google/gemma-3-4b-it` | `093f9f388b31de276ce2de164bdc2081324b9767` | 4.3B | vision-language | `examples/models/gemma/gemma3_vl` | TODO |
+| Gemma | Gemma 3-VL | `google/gemma-3-4b-it` | `093f9f388b31de276ce2de164bdc2081324b9767` | 4.3B | vision-language | `examples/models/gemma/gemma3_vl` | PASS |
 | Gemma | Gemma 4 26B-A4B MoE | `google/gemma-4-26B-A4B` | `6b556d30bb65a6ee0bdaec99bab0afc7bf1494fb` | 26.5B | text | `examples/models/gemma/gemma4` | TODO |
 | Gemma | Gemma 4 31B dense | `google/gemma-4-31B` | `d77cb0be8ad40327cc1c6b70eff4b3f0be35bee3` | 32.7B | text | `examples/models/gemma/gemma4` | TODO |
 | Gemma | Gemma 4-VL 26B-A4B MoE | `google/gemma-4-26B-A4B-it` | `5305c1e72ea29c01f31a81230d52b375ba88b409` | 26.5B | vision-language | `examples/models/gemma/gemma4_vl` | TODO |

--- a/examples/models/full-model-validation.md
+++ b/examples/models/full-model-validation.md
@@ -65,7 +65,7 @@ Hugging Face commit SHAs resolved on the date above. Status is one of `TODO`,
 | Nemotron | Llama Nemotron | `nvidia/Llama-3.1-Nemotron-Nano-4B-v1.1` | `d552708a9d575fa8d4a690b988fd870d65279f98` | 4.5B | text | `examples/conversion` | TODO |
 | Nemotron | Nemotron Nano v2 VL | `nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16` | `5d250e2e111dc5e1434131bdf3d590c27a878ade` | 13.2B | vision-language | `examples/models/nemotron/nemotron_vl` | TODO |
 | Nemotron | Nemotron-3 Nano Omni | `nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16` | `24e67ea000b7c2837fc8f9488aa2008524fac8ba` | 33.0B | vision-language-audio | `examples/models/nemotron/nemotron_3_omni` | TODO |
-| OLMoE | OLMoE | `allenai/OLMoE-1B-7B-0125` | `9b0c1aa87e34a20052389dce1f0cf01da783f654` | 6.9B | text | `examples/conversion` | TODO |
+| OLMoE | OLMoE | `allenai/OLMoE-1B-7B-0125` | `9b0c1aa87e34a20052389dce1f0cf01da783f654` | 6.9B | text | `examples/conversion` | PASS |
 | Qwen | Qwen2 | `Qwen/Qwen2-7B` | `453ed1575b739b5b03ce3758b23befdb0967f40e` | 7.6B | text | `examples/conversion` | TODO |
 | Qwen | Qwen2.5 | `Qwen/Qwen2.5-7B` | `d149729398750b98c0af14eb82c78cfe92750796` | 7.6B | text | `examples/conversion` | TODO |
 | Qwen | Qwen3 | `Qwen/Qwen3-8B` | `b968826d9c46dd6066d109eabc6255188de91218` | 8.2B | text | `examples/conversion` | TODO |

--- a/examples/models/full-model-validation.md
+++ b/examples/models/full-model-validation.md
@@ -32,15 +32,15 @@ forward-logit parity.
 | Diffusion | Nemotron-Labs Diffusion | `nvidia/Nemotron-Labs-Diffusion-3B` | `0d51902da1f8869f83413ce642fab402fa5641e0` | 3.8B | text diffusion | `examples/models/nemotron_labs_diffusion` | TODO |
 | Diffusion | WAN 2.1 | `Wan-AI/Wan2.1-T2V-1.3B-Diffusers` | `0fad780a534b6463e45facd96134c9f345acfa5b` | 1.3B | text-to-video | `examples/models/wan` | TODO |
 | Ernie | Ernie 4.5 MoE | `baidu/ERNIE-4.5-21B-A3B-PT` | `87db95487941cb39592ee0abca3b9155a6d19c5c` | 21.9B | text | `examples/models/ernie/ernie45` | PASS |
-| Ernie | Ernie 4.5 VL MoE | `baidu/ERNIE-4.5-VL-28B-A3B-PT` | `e3815e65c607ea211bfe21b46ab0cd264b76731c` | 29.4B | vision-language | `examples/models/vlm/ernie_vl` | BLOCKED |
+| Ernie | Ernie 4.5 VL MoE | `baidu/ERNIE-4.5-VL-28B-A3B-PT` | `e3815e65c607ea211bfe21b46ab0cd264b76731c` | 29.4B | vision-language | `examples/models/vlm/ernie_vl` | PARTIAL |
 | Falcon | Falcon H1 | `tiiuae/Falcon-H1-0.5B-Instruct` | `8f2587ca06bff78d8fa1adfccbe8c24d5f86b368` | 0.5B | text | `examples/models/falcon_h1` | PASS |
 | Gemma | Gemma | `google/gemma-2b` | `9cf48e52b224239de00d483ec8eb84fb8d0f3a3a` | 2.5B | text | `examples/conversion` | PASS |
 | Gemma | Gemma 2 | `google/gemma-2-2b` | `c5ebcd40d208330abc697524c919956e692655cf` | 2.6B | text | `examples/conversion` | PASS |
 | Gemma | Gemma 3 | `google/gemma-3-1b-it` | `dcc83ea841ab6100d6b47a070329e1ba4cf78752` | 1.0B | text | `examples/conversion` | PASS |
 | Gemma | Gemma 3-VL | `google/gemma-3-4b-it` | `093f9f388b31de276ce2de164bdc2081324b9767` | 4.3B | vision-language | `examples/models/gemma/gemma3_vl` | PASS |
-| Gemma | Gemma 4 26B-A4B MoE | `google/gemma-4-26B-A4B` | `6b556d30bb65a6ee0bdaec99bab0afc7bf1494fb` | 26.5B | text | `examples/models/gemma/gemma4` | BLOCKED |
-| Gemma | Gemma 4 31B dense | `google/gemma-4-31B` | `d77cb0be8ad40327cc1c6b70eff4b3f0be35bee3` | 32.7B | text | `examples/models/gemma/gemma4` | BLOCKED |
-| Gemma | Gemma 4-VL 26B-A4B MoE | `google/gemma-4-26B-A4B-it` | `5305c1e72ea29c01f31a81230d52b375ba88b409` | 26.5B | vision-language | `examples/models/gemma/gemma4_vl` | BLOCKED |
+| Gemma | Gemma 4 26B-A4B MoE | `google/gemma-4-26B-A4B` | `6b556d30bb65a6ee0bdaec99bab0afc7bf1494fb` | 26.5B | text | `examples/models/gemma/gemma4` | PASS |
+| Gemma | Gemma 4 31B dense | `google/gemma-4-31B` | `d77cb0be8ad40327cc1c6b70eff4b3f0be35bee3` | 32.7B | text | `examples/models/gemma/gemma4` | PASS |
+| Gemma | Gemma 4-VL 26B-A4B MoE | `google/gemma-4-26B-A4B-it` | `5305c1e72ea29c01f31a81230d52b375ba88b409` | 26.5B | vision-language | `examples/models/gemma/gemma4_vl` | PASS |
 | GLM | GLM-4.5 | `zai-org/GLM-4.5` | `cbb2c7cfb52fa128a9660cb1a7a78e017899e115` | 358.3B | text | `examples/conversion` | TODO |
 | GLM | GLM-4.7 | `zai-org/GLM-4.7` | `602d01efcdd332c5238ca4bcede555defbe83eb7` | 358.3B | text | `examples/models/glm47` | TODO |
 | GLM | GLM-4.7-Flash | `zai-org/GLM-4.7-Flash` | `7dd20894a642a0aa287e9827cb1a1f7f91386b67` | 31.2B | text | `examples/models/glm47` | PASS |
@@ -75,7 +75,7 @@ forward-logit parity.
 | Qwen | Qwen2.5 | `Qwen/Qwen2.5-7B` | `d149729398750b98c0af14eb82c78cfe92750796` | 7.6B | text | `examples/conversion` | PASS |
 | Qwen | Qwen3 | `Qwen/Qwen3-8B` | `b968826d9c46dd6066d109eabc6255188de91218` | 8.2B | text | `examples/conversion` | PASS |
 | Qwen | Qwen3-MoE | `Qwen/Qwen3-30B-A3B` | `ad44e777bcd18fa416d9da3bd8f70d33ebb85d39` | 30.5B | text | `examples/conversion` | PASS |
-| Qwen | Qwen3 Next | `Qwen/Qwen3-Next-80B-A3B-Instruct` | `9c7f2fbe84465e40164a94cc16cd30b6999b0cc7` | 81.3B | text | `examples/models/qwen/qwen3_next` | BLOCKED |
+| Qwen | Qwen3 Next | `Qwen/Qwen3-Next-80B-A3B-Instruct` | `9c7f2fbe84465e40164a94cc16cd30b6999b0cc7` | 81.3B | text | `examples/models/qwen/qwen3_next` | PASS |
 | Qwen | Qwen3.5 dense | `Qwen/Qwen3.5-27B` | `fc05daec18b0a78c049392ed2e771dde82bdf654` | 27.8B | vision-language | `examples/models/qwen/qwen35_vl` | PASS |
 | Qwen | Qwen3.5 MoE | `Qwen/Qwen3.5-35B-A3B` | `59d61f3ce65a6d9863b86d2e96597125219dc754` | 36.0B | vision-language | `examples/models/qwen/qwen35_vl` | PASS |
 | Qwen | Qwen2.5-VL | `Qwen/Qwen2.5-VL-3B-Instruct` | `66285546d2b821cf421d4f5eb2576359d3770cd3` | 3.8B | vision-language | `examples/models/qwen/qwen_vl` | PASS |
@@ -84,7 +84,7 @@ forward-logit parity.
 | Qwen | Qwen3.6-VL | `Qwen/Qwen3.6-35B-A3B` | `995ad96eacd98c81ed38be0c5b274b04031597b0` | 36.0B | vision-language | `examples/models/qwen/qwen35_vl` | PASS |
 | Qwen | Qwen2 Audio | `Qwen/Qwen2-Audio-7B-Instruct` | `0a095220c30b7b31434169c3086508ef3ea5bf0a` | 8.4B | audio-text | `examples/models/qwen/qwen2_audio` | PASS |
 | Qwen | Qwen2.5-Omni | `Qwen/Qwen2.5-Omni-7B` | `ae9e1690543ffd5c0221dc27f79834d0294cba00` | 10.7B | vision-audio-text | `examples/models/qwen/qwen25_omni` | PARTIAL |
-| Qwen | Qwen3-Omni | `Qwen/Qwen3-Omni-30B-A3B-Instruct` | `26291f793822fb6be9555850f06dfe95f2d7e695` | 35.3B | vision-audio-text | `examples/models/qwen/qwen3_omni` | BLOCKED |
+| Qwen | Qwen3-Omni | `Qwen/Qwen3-Omni-30B-A3B-Instruct` | `26291f793822fb6be9555850f06dfe95f2d7e695` | 35.3B | vision-audio-text | `examples/models/qwen/qwen3_omni` | PARTIAL |
 | Qwen | Qwen3-ASR | `Qwen/Qwen3-ASR-1.7B` | `7278e1e70fe206f11671096ffdd38061171dd6e5` | 2.3B | audio-text | `examples/models/qwen/qwen3_asr` | PASS |
 | Sarvam | Sarvam | `sarvamai/sarvam-30b` | `071ae95e933605ca1104a6b4524a36a98488efa4` | 32.2B | text | `examples/models/sarvam` | PASS |
 | StepFun | Step-3.5-Flash | `stepfun-ai/Step-3.5-Flash` | `ab446a3de5e171ea341227e24bb1f090e1b771f7` | 199.4B | text | `examples/models/stepfun/step35` | TODO |

--- a/examples/models/full-model-validation.md
+++ b/examples/models/full-model-validation.md
@@ -1,6 +1,6 @@
 # Full-checkpoint conversion and inference validation inventory
 
-Last updated: 2026-07-12
+Last updated: 2026-07-15
 
 This manifest tracks full-checkpoint conversion and inference validation for the
 model architectures and explicitly named variants in the root
@@ -49,7 +49,7 @@ forward-logit parity.
 | GPT-OSS | GPT-OSS 120B | `openai/gpt-oss-120b` | `b5c939de8f754692c1647ca79fbf85e8c1e70f8a` | 120.4B | text | `examples/models/gpt_oss` | TODO |
 | HY V3 | Hy3 preview-Base | `tencent/Hy3-preview-Base` | `54a62bb00a50195423bffb6b55e91aa28b6a8ce2` | 298.8B | text | `examples/conversion` | TODO |
 | Llama | Llama 2 | `meta-llama/Llama-2-7b-hf` | `01c7f73d771dfac7d292323805ebc428287df4f9` | 6.7B | text | `examples/conversion` | PASS |
-| Llama | Llama 3 | `meta-llama/Meta-Llama-3-8B` | `8cde5ca8380496c9a6cc7ef3a8b46a0372a1d920` | 8.0B | text | `examples/conversion` | BLOCKED |
+| Llama | Llama 3 | `meta-llama/Meta-Llama-3-8B` | `8cde5ca8380496c9a6cc7ef3a8b46a0372a1d920` | 8.0B | text | `examples/conversion` | PASS |
 | Llama | Llama 3.1 | `meta-llama/Meta-Llama-3.1-8B` | `d04e592bb4f6aa9cfee91e2e20afa771667e1d4b` | 8.0B | text | `examples/conversion` | PASS |
 | Llama | Llama 3.2 | `meta-llama/Llama-3.2-1B` | `4e20de362430cd3b72f300e6b0f18e50e7166e08` | 1.2B | text | `examples/conversion` | PASS |
 | Llama | Llama 3.3 | `meta-llama/Llama-3.3-70B-Instruct` | `6f6073b423013f6a7d4d9f39144961bfbfbc386b` | 70.6B | text | `examples/conversion` | BLOCKED |
@@ -65,7 +65,7 @@ forward-logit parity.
 | Moonlight | Moonlight | `moonshotai/Moonlight-16B-A3B` | `476b36a473d4467f94469414bef6cee75c9c8172` | 16.0B | text | `examples/conversion` | BLOCKED |
 | Nemotron | Nemotron H | `nvidia/Nemotron-H-4B-Base-8K` | `faba3b731ad7ea5781b9518ae75fb610a94affcf` | 4.5B | text | `examples/conversion` | PASS |
 | Nemotron | Nemotron Nano v2 | `nvidia/NVIDIA-Nemotron-Nano-9B-v2-Base` | `dc0661c829b14e5b9246c05cfa89094a0875e052` | 8.9B | text | `examples/conversion` | PASS |
-| Nemotron | Nemotron-3 Nano | `nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-Base-BF16` | `97ab8012882a655dc38df4fee47422aca9caca07` | 31.6B | text | `examples/models/nemotron/nemotron_3/nano` | PARTIAL |
+| Nemotron | Nemotron-3 Nano | `nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-Base-BF16` | `97ab8012882a655dc38df4fee47422aca9caca07` | 31.6B | text | `examples/models/nemotron/nemotron_3/nano` | PASS |
 | Nemotron | Nemotron-3 Super | `nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16` | `d51eab0d1f979ebc26b546e634a04f450d99158e` | 123.6B | text | `examples/models/nemotron/nemotron_3/super` | TODO |
 | Nemotron | Llama Nemotron | `nvidia/Llama-3.1-Nemotron-Nano-4B-v1.1` | `d552708a9d575fa8d4a690b988fd870d65279f98` | 4.5B | text | `examples/conversion` | PASS |
 | Nemotron | Nemotron Nano v2 VL | `nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16` | `5d250e2e111dc5e1434131bdf3d590c27a878ade` | 13.2B | vision-language | `examples/models/nemotron/nemotron_vl` | BLOCKED |

--- a/examples/models/full-model-validation.md
+++ b/examples/models/full-model-validation.md
@@ -1,6 +1,6 @@
 # Full-model validation inventory
 
-Last updated: 2026-07-10
+Last updated: 2026-07-11
 
 This manifest tracks full-checkpoint conversion and inference validation for the
 model architectures and explicitly named variants in the root
@@ -43,7 +43,7 @@ Hugging Face commit SHAs resolved on the date above. Status is one of `TODO`,
 | GPT-OSS | GPT-OSS 20B | `openai/gpt-oss-20b` | `6cee5e81ee83917806bbde320786a8fb61efebee` | 21.5B | text | `examples/models/gpt_oss` | TODO |
 | GPT-OSS | GPT-OSS 120B | `openai/gpt-oss-120b` | `b5c939de8f754692c1647ca79fbf85e8c1e70f8a` | 120.4B | text | `examples/models/gpt_oss` | TODO |
 | HY V3 | Hy3 preview-Base | `tencent/Hy3-preview-Base` | `54a62bb00a50195423bffb6b55e91aa28b6a8ce2` | 298.8B | text | `examples/conversion` | TODO |
-| Llama | Llama 2 | `meta-llama/Llama-2-7b-hf` | `01c7f73d771dfac7d292323805ebc428287df4f9` | 6.7B | text | `examples/conversion` | TODO |
+| Llama | Llama 2 | `meta-llama/Llama-2-7b-hf` | `01c7f73d771dfac7d292323805ebc428287df4f9` | 6.7B | text | `examples/conversion` | PASS |
 | Llama | Llama 3 | `meta-llama/Meta-Llama-3-8B` | `8cde5ca8380496c9a6cc7ef3a8b46a0372a1d920` | 8.0B | text | `examples/conversion` | TODO |
 | Llama | Llama 3.1 | `meta-llama/Meta-Llama-3.1-8B` | `d04e592bb4f6aa9cfee91e2e20afa771667e1d4b` | 8.0B | text | `examples/conversion` | TODO |
 | Llama | Llama 3.2 | `meta-llama/Llama-3.2-1B` | `4e20de362430cd3b72f300e6b0f18e50e7166e08` | 1.2B | text | `examples/conversion` | TODO |

--- a/examples/models/full-model-validation.md
+++ b/examples/models/full-model-validation.md
@@ -57,9 +57,9 @@ forward-logit parity.
 | MiniMax | MiniMax-M2.5 | `MiniMaxAI/MiniMax-M2.5` | `f710177d938eff80b684d42c5aa84b382612f21f` | 456B | text | `examples/models/minimax/minimax_m2` | TODO |
 | MiniMax | MiniMax-M2.7 | `MiniMaxAI/MiniMax-M2.7` | `d494266a4affc0d2995ba1fa35c8481cbd84294b` | 456B | text | `examples/models/minimax/minimax_m2` | TODO |
 | Mistral | Mistral | `mistralai/Mistral-7B-v0.1` | `27d67f1b5f57dc0953326b2601d68371d40ea8da` | 7.2B | text | `examples/models/mistral/mistral` | PASS |
-| Mistral | Ministral 3 3B | `mistralai/Ministral-3-3B-Base-2512` | `6f9c4b12a95b139af68670a6713616b757923735` | 4.3B | vision-language | `examples/models/mistral/ministral3` | BLOCKED |
-| Mistral | Ministral 3 8B | `mistralai/Ministral-3-8B-Base-2512` | `d4883f9b36aa2e5d775730d3fdba3d30de51a8ef` | 8.9B | vision-language | `examples/models/mistral/ministral3` | BLOCKED |
-| Mistral | Ministral 3 14B | `mistralai/Ministral-3-14B-Base-2512` | `5b0ceedbb42dff466ae60b258ba296f32da51384` | 13.9B | vision-language | `examples/models/mistral/ministral3` | BLOCKED |
+| Mistral | Ministral 3 3B | `mistralai/Ministral-3-3B-Base-2512` | `6f9c4b12a95b139af68670a6713616b757923735` | 3.8B | vision-language | `examples/models/mistral/ministral3` | PASS |
+| Mistral | Ministral 3 8B | `mistralai/Ministral-3-8B-Base-2512` | `d4883f9b36aa2e5d775730d3fdba3d30de51a8ef` | 8.9B | vision-language | `examples/models/mistral/ministral3` | PASS |
+| Mistral | Ministral 3 14B | `mistralai/Ministral-3-14B-Base-2512` | `5b0ceedbb42dff466ae60b258ba296f32da51384` | 13.9B | vision-language | `examples/models/mistral/ministral3` | PASS |
 | Xiaomi-MiMo | MiMo | `XiaomiMiMo/MiMo-7B-Base` | `c72df4586cb8bdeebd65f36929cd3385a6566fbe` | 7.8B | text | `examples/models/mimo` | PASS |
 | Xiaomi-MiMo | MiMo-V2-Flash | `XiaomiMiMo/MiMo-V2-Flash` | `1afd314a2406c282e0956375c34a676501c78649` | 309.8B | text | `examples/models/mimo_v2_flash` | TODO |
 | Moonlight | Moonlight | `moonshotai/Moonlight-16B-A3B` | `476b36a473d4467f94469414bef6cee75c9c8172` | 16.0B | text | `examples/conversion` | BLOCKED |

--- a/examples/models/full-model-validation.md
+++ b/examples/models/full-model-validation.md
@@ -40,7 +40,7 @@ Hugging Face commit SHAs resolved on the date above. Status is one of `TODO`,
 | GLM | GLM-4.7 | `zai-org/GLM-4.7` | `602d01efcdd332c5238ca4bcede555defbe83eb7` | 358.3B | text | `examples/models/glm47` | TODO |
 | GLM | GLM-4.7-Flash | `zai-org/GLM-4.7-Flash` | `7dd20894a642a0aa287e9827cb1a1f7f91386b67` | 31.2B | text | `examples/models/glm47` | TODO |
 | GLM | GLM-4.5V | `zai-org/GLM-4.5V` | `ed47433b37111465ec527affaaddceff371bca04` | 107.7B | vision-language | `examples/models/glm/glm_45v` | TODO |
-| GPT-OSS | GPT-OSS 20B | `openai/gpt-oss-20b` | `6cee5e81ee83917806bbde320786a8fb61efebee` | 21.5B | text | `examples/models/gpt_oss` | RUNNING |
+| GPT-OSS | GPT-OSS 20B | `openai/gpt-oss-20b` | `6cee5e81ee83917806bbde320786a8fb61efebee` | 21.5B | text | `examples/models/gpt_oss` | TODO |
 | GPT-OSS | GPT-OSS 120B | `openai/gpt-oss-120b` | `b5c939de8f754692c1647ca79fbf85e8c1e70f8a` | 120.4B | text | `examples/models/gpt_oss` | TODO |
 | HY V3 | Hy3 preview-Base | `tencent/Hy3-preview-Base` | `54a62bb00a50195423bffb6b55e91aa28b6a8ce2` | 298.8B | text | `examples/conversion` | TODO |
 | Llama | Llama 2 | `meta-llama/Llama-2-7b-hf` | `01c7f73d771dfac7d292323805ebc428287df4f9` | 6.7B | text | `examples/conversion` | TODO |

--- a/examples/models/full-model-validation.md
+++ b/examples/models/full-model-validation.md
@@ -1,4 +1,4 @@
-# Full-model validation inventory
+# Full-checkpoint conversion and inference validation inventory
 
 Last updated: 2026-07-12
 
@@ -13,29 +13,34 @@ explicitly named in the root table are tracked separately.
 For packed low-precision checkpoints, it follows the model architecture/model
 card rather than the raw stored tensor-element count. Revisions are immutable
 Hugging Face commit SHAs resolved on the date above. Status is one of `TODO`,
-`DOWNLOADING`, `RUNNING`, `FIXING`, `PASS`, or `BLOCKED`.
+`DOWNLOADING`, `RUNNING`, `FIXING`, `PASS`, `PARTIAL`, `BLOCKED`, or
+`DUPLICATE`.
+
+`PASS` covers the six conversion and inference smoke gates defined below. It
+does not claim training validation, model-quality benchmarking, or strict
+forward-logit parity.
 
 | Family | Architecture / version | Canonical HF checkpoint | Revision | Params | Modality | Example path | Status |
 |---|---|---|---|---:|---|---|---|
 | Bailing | Ling 2.0 (Flash) | `inclusionAI/Ling-flash-2.0` | `18ca64a019b553be57bab50af3207fb2f3675edc` | 100B | text | `examples/models/bailing` | TODO |
-| Bailing | Ling MoE V2 / Bailing (Mini) | `inclusionAI/Ling-mini-2.0` | `920c3fd9916e3d5e543fc4f609e827cad8a32983` | 16B | text | `examples/models/bailing` | TODO |
+| Bailing | Ling MoE V2 / Bailing (Mini) | `inclusionAI/Ling-mini-2.0` | `920c3fd9916e3d5e543fc4f609e827cad8a32983` | 16B | text | `examples/models/bailing` | BLOCKED |
 | DeepSeek | DeepSeek V2 | `deepseek-ai/DeepSeek-V2` | `4461458f186c35188585855f28f77af5661ad489` | 235.7B | text | `examples/conversion` | TODO |
-| DeepSeek | DeepSeek V2 Lite | `deepseek-ai/DeepSeek-V2-Lite` | `604d5664dddd88a0433dbae533b7fe9472482de0` | 15.7B | text | `examples/conversion` | TODO |
+| DeepSeek | DeepSeek V2 Lite | `deepseek-ai/DeepSeek-V2-Lite` | `604d5664dddd88a0433dbae533b7fe9472482de0` | 15.7B | text | `examples/conversion` | PASS |
 | DeepSeek | DeepSeek V4 Flash | `deepseek-ai/DeepSeek-V4-Flash-Base` | `8855555deef230a27a21a8d6f294b7b7497759b6` | 292.0B | text | `examples/models/deepseek_v4` | TODO |
 | Diffusion | FLUX.1 | `black-forest-labs/FLUX.1-dev` | `3de623fc3c33e44ffbe2bad470d0f45bccf2eb21` | 12B | text-to-image | `examples/models/flux` | TODO |
 | Diffusion | LLaDA 1.5 | `GSAI-ML/LLaDA-1.5` | `84346fd91ba60252d260022201ad6fc5a3468fb2` | 8.0B | text diffusion | `examples/models/llada/llada15` | TODO |
 | Diffusion | Nemotron-Labs Diffusion | `nvidia/Nemotron-Labs-Diffusion-3B` | `0d51902da1f8869f83413ce642fab402fa5641e0` | 3.8B | text diffusion | `examples/models/nemotron_labs_diffusion` | TODO |
 | Diffusion | WAN 2.1 | `Wan-AI/Wan2.1-T2V-1.3B-Diffusers` | `0fad780a534b6463e45facd96134c9f345acfa5b` | 1.3B | text-to-video | `examples/models/wan` | TODO |
-| Ernie | Ernie 4.5 MoE | `baidu/ERNIE-4.5-21B-A3B-PT` | `87db95487941cb39592ee0abca3b9155a6d19c5c` | 21.9B | text | `examples/conversion` | TODO |
-| Ernie | Ernie 4.5 VL MoE | `baidu/ERNIE-4.5-VL-28B-A3B-PT` | `e3815e65c607ea211bfe21b46ab0cd264b76731c` | 29.4B | vision-language | `examples/models/vlm/ernie_vl` | TODO |
-| Falcon | Falcon H1 | `tiiuae/Falcon-H1-0.5B-Instruct` | `8f2587ca06bff78d8fa1adfccbe8c24d5f86b368` | 0.5B | text | `examples/models/falcon_h1` | TODO |
-| Gemma | Gemma | `google/gemma-2b` | `9cf48e52b224239de00d483ec8eb84fb8d0f3a3a` | 2.5B | text | `examples/conversion` | TODO |
-| Gemma | Gemma 2 | `google/gemma-2-2b` | `c5ebcd40d208330abc697524c919956e692655cf` | 2.6B | text | `examples/conversion` | TODO |
-| Gemma | Gemma 3 | `google/gemma-3-1b-it` | `dcc83ea841ab6100d6b47a070329e1ba4cf78752` | 1.0B | text | `examples/conversion` | TODO |
+| Ernie | Ernie 4.5 MoE | `baidu/ERNIE-4.5-21B-A3B-PT` | `87db95487941cb39592ee0abca3b9155a6d19c5c` | 21.9B | text | `examples/conversion` | BLOCKED |
+| Ernie | Ernie 4.5 VL MoE | `baidu/ERNIE-4.5-VL-28B-A3B-PT` | `e3815e65c607ea211bfe21b46ab0cd264b76731c` | 29.4B | vision-language | `examples/models/vlm/ernie_vl` | BLOCKED |
+| Falcon | Falcon H1 | `tiiuae/Falcon-H1-0.5B-Instruct` | `8f2587ca06bff78d8fa1adfccbe8c24d5f86b368` | 0.5B | text | `examples/models/falcon_h1` | PASS |
+| Gemma | Gemma | `google/gemma-2b` | `9cf48e52b224239de00d483ec8eb84fb8d0f3a3a` | 2.5B | text | `examples/conversion` | PASS |
+| Gemma | Gemma 2 | `google/gemma-2-2b` | `c5ebcd40d208330abc697524c919956e692655cf` | 2.6B | text | `examples/conversion` | PASS |
+| Gemma | Gemma 3 | `google/gemma-3-1b-it` | `dcc83ea841ab6100d6b47a070329e1ba4cf78752` | 1.0B | text | `examples/conversion` | PASS |
 | Gemma | Gemma 3-VL | `google/gemma-3-4b-it` | `093f9f388b31de276ce2de164bdc2081324b9767` | 4.3B | vision-language | `examples/models/gemma/gemma3_vl` | PASS |
-| Gemma | Gemma 4 26B-A4B MoE | `google/gemma-4-26B-A4B` | `6b556d30bb65a6ee0bdaec99bab0afc7bf1494fb` | 26.5B | text | `examples/models/gemma/gemma4` | TODO |
-| Gemma | Gemma 4 31B dense | `google/gemma-4-31B` | `d77cb0be8ad40327cc1c6b70eff4b3f0be35bee3` | 32.7B | text | `examples/models/gemma/gemma4` | TODO |
-| Gemma | Gemma 4-VL 26B-A4B MoE | `google/gemma-4-26B-A4B-it` | `5305c1e72ea29c01f31a81230d52b375ba88b409` | 26.5B | vision-language | `examples/models/gemma/gemma4_vl` | TODO |
+| Gemma | Gemma 4 26B-A4B MoE | `google/gemma-4-26B-A4B` | `6b556d30bb65a6ee0bdaec99bab0afc7bf1494fb` | 26.5B | text | `examples/models/gemma/gemma4` | BLOCKED |
+| Gemma | Gemma 4 31B dense | `google/gemma-4-31B` | `d77cb0be8ad40327cc1c6b70eff4b3f0be35bee3` | 32.7B | text | `examples/models/gemma/gemma4` | BLOCKED |
+| Gemma | Gemma 4-VL 26B-A4B MoE | `google/gemma-4-26B-A4B-it` | `5305c1e72ea29c01f31a81230d52b375ba88b409` | 26.5B | vision-language | `examples/models/gemma/gemma4_vl` | BLOCKED |
 | GLM | GLM-4.5 | `zai-org/GLM-4.5` | `cbb2c7cfb52fa128a9660cb1a7a78e017899e115` | 358.3B | text | `examples/conversion` | TODO |
 | GLM | GLM-4.7 | `zai-org/GLM-4.7` | `602d01efcdd332c5238ca4bcede555defbe83eb7` | 358.3B | text | `examples/models/glm47` | TODO |
 | GLM | GLM-4.7-Flash | `zai-org/GLM-4.7-Flash` | `7dd20894a642a0aa287e9827cb1a1f7f91386b67` | 31.2B | text | `examples/models/glm47` | PASS |
@@ -44,44 +49,44 @@ Hugging Face commit SHAs resolved on the date above. Status is one of `TODO`,
 | GPT-OSS | GPT-OSS 120B | `openai/gpt-oss-120b` | `b5c939de8f754692c1647ca79fbf85e8c1e70f8a` | 120.4B | text | `examples/models/gpt_oss` | TODO |
 | HY V3 | Hy3 preview-Base | `tencent/Hy3-preview-Base` | `54a62bb00a50195423bffb6b55e91aa28b6a8ce2` | 298.8B | text | `examples/conversion` | TODO |
 | Llama | Llama 2 | `meta-llama/Llama-2-7b-hf` | `01c7f73d771dfac7d292323805ebc428287df4f9` | 6.7B | text | `examples/conversion` | PASS |
-| Llama | Llama 3 | `meta-llama/Meta-Llama-3-8B` | `8cde5ca8380496c9a6cc7ef3a8b46a0372a1d920` | 8.0B | text | `examples/conversion` | TODO |
-| Llama | Llama 3.1 | `meta-llama/Meta-Llama-3.1-8B` | `d04e592bb4f6aa9cfee91e2e20afa771667e1d4b` | 8.0B | text | `examples/conversion` | TODO |
-| Llama | Llama 3.2 | `meta-llama/Llama-3.2-1B` | `4e20de362430cd3b72f300e6b0f18e50e7166e08` | 1.2B | text | `examples/conversion` | TODO |
-| Llama | Llama 3.3 | `meta-llama/Llama-3.3-70B-Instruct` | `6f6073b423013f6a7d4d9f39144961bfbfbc386b` | 70.6B | text | `examples/conversion` | TODO |
+| Llama | Llama 3 | `meta-llama/Meta-Llama-3-8B` | `8cde5ca8380496c9a6cc7ef3a8b46a0372a1d920` | 8.0B | text | `examples/conversion` | BLOCKED |
+| Llama | Llama 3.1 | `meta-llama/Meta-Llama-3.1-8B` | `d04e592bb4f6aa9cfee91e2e20afa771667e1d4b` | 8.0B | text | `examples/conversion` | PASS |
+| Llama | Llama 3.2 | `meta-llama/Llama-3.2-1B` | `4e20de362430cd3b72f300e6b0f18e50e7166e08` | 1.2B | text | `examples/conversion` | PASS |
+| Llama | Llama 3.3 | `meta-llama/Llama-3.3-70B-Instruct` | `6f6073b423013f6a7d4d9f39144961bfbfbc386b` | 70.6B | text | `examples/conversion` | BLOCKED |
 | MiniMax | MiniMax-M2 | `MiniMaxAI/MiniMax-M2` | `757303d492a50514c312788b5247a4f696a4c6a3` | 456B | text | `examples/models/minimax/minimax_m2` | TODO |
 | MiniMax | MiniMax-M2.5 | `MiniMaxAI/MiniMax-M2.5` | `f710177d938eff80b684d42c5aa84b382612f21f` | 456B | text | `examples/models/minimax/minimax_m2` | TODO |
 | MiniMax | MiniMax-M2.7 | `MiniMaxAI/MiniMax-M2.7` | `d494266a4affc0d2995ba1fa35c8481cbd84294b` | 456B | text | `examples/models/minimax/minimax_m2` | TODO |
-| Mistral | Mistral | `mistralai/Mistral-7B-v0.1` | `27d67f1b5f57dc0953326b2601d68371d40ea8da` | 7.2B | text | `examples/conversion` | TODO |
-| Mistral | Ministral 3 3B | `mistralai/Ministral-3-3B-Base-2512` | `6f9c4b12a95b139af68670a6713616b757923735` | 4.3B | vision-language | `examples/models/mistral/ministral3` | TODO |
-| Mistral | Ministral 3 8B | `mistralai/Ministral-3-8B-Base-2512` | `d4883f9b36aa2e5d775730d3fdba3d30de51a8ef` | 8.9B | vision-language | `examples/models/mistral/ministral3` | TODO |
-| Mistral | Ministral 3 14B | `mistralai/Ministral-3-14B-Base-2512` | `5b0ceedbb42dff466ae60b258ba296f32da51384` | 13.9B | vision-language | `examples/models/mistral/ministral3` | TODO |
-| Xiaomi-MiMo | MiMo | `XiaomiMiMo/MiMo-7B-Base` | `c72df4586cb8bdeebd65f36929cd3385a6566fbe` | 7.8B | text | `examples/megatron_mimo` | TODO |
+| Mistral | Mistral | `mistralai/Mistral-7B-v0.1` | `27d67f1b5f57dc0953326b2601d68371d40ea8da` | 7.2B | text | `examples/conversion` | BLOCKED |
+| Mistral | Ministral 3 3B | `mistralai/Ministral-3-3B-Base-2512` | `6f9c4b12a95b139af68670a6713616b757923735` | 4.3B | vision-language | `examples/models/mistral/ministral3` | BLOCKED |
+| Mistral | Ministral 3 8B | `mistralai/Ministral-3-8B-Base-2512` | `d4883f9b36aa2e5d775730d3fdba3d30de51a8ef` | 8.9B | vision-language | `examples/models/mistral/ministral3` | BLOCKED |
+| Mistral | Ministral 3 14B | `mistralai/Ministral-3-14B-Base-2512` | `5b0ceedbb42dff466ae60b258ba296f32da51384` | 13.9B | vision-language | `examples/models/mistral/ministral3` | BLOCKED |
+| Xiaomi-MiMo | MiMo | `XiaomiMiMo/MiMo-7B-Base` | `c72df4586cb8bdeebd65f36929cd3385a6566fbe` | 7.8B | text | `examples/megatron_mimo` | BLOCKED |
 | Xiaomi-MiMo | MiMo-V2-Flash | `XiaomiMiMo/MiMo-V2-Flash` | `1afd314a2406c282e0956375c34a676501c78649` | 309.8B | text | `examples/models/mimo_v2_flash` | TODO |
-| Moonlight | Moonlight | `moonshotai/Moonlight-16B-A3B` | `476b36a473d4467f94469414bef6cee75c9c8172` | 16.0B | text | `examples/conversion` | TODO |
-| Nemotron | Nemotron H | `nvidia/Nemotron-H-4B-Base-8K` | `faba3b731ad7ea5781b9518ae75fb610a94affcf` | 4.5B | text | `examples/conversion` | TODO |
-| Nemotron | Nemotron Nano v2 | `nvidia/NVIDIA-Nemotron-Nano-9B-v2-Base` | `dc0661c829b14e5b9246c05cfa89094a0875e052` | 8.9B | text | `examples/conversion` | TODO |
-| Nemotron | Nemotron-3 Nano | `nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-Base-BF16` | `97ab8012882a655dc38df4fee47422aca9caca07` | 31.6B | text | `examples/models/nemotron/nemotron_3/nano` | TODO |
+| Moonlight | Moonlight | `moonshotai/Moonlight-16B-A3B` | `476b36a473d4467f94469414bef6cee75c9c8172` | 16.0B | text | `examples/conversion` | BLOCKED |
+| Nemotron | Nemotron H | `nvidia/Nemotron-H-4B-Base-8K` | `faba3b731ad7ea5781b9518ae75fb610a94affcf` | 4.5B | text | `examples/conversion` | PASS |
+| Nemotron | Nemotron Nano v2 | `nvidia/NVIDIA-Nemotron-Nano-9B-v2-Base` | `dc0661c829b14e5b9246c05cfa89094a0875e052` | 8.9B | text | `examples/conversion` | PASS |
+| Nemotron | Nemotron-3 Nano | `nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-Base-BF16` | `97ab8012882a655dc38df4fee47422aca9caca07` | 31.6B | text | `examples/models/nemotron/nemotron_3/nano` | PARTIAL |
 | Nemotron | Nemotron-3 Super | `nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16` | `d51eab0d1f979ebc26b546e634a04f450d99158e` | 123.6B | text | `examples/models/nemotron/nemotron_3/super` | TODO |
-| Nemotron | Llama Nemotron | `nvidia/Llama-3.1-Nemotron-Nano-4B-v1.1` | `d552708a9d575fa8d4a690b988fd870d65279f98` | 4.5B | text | `examples/conversion` | TODO |
-| Nemotron | Nemotron Nano v2 VL | `nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16` | `5d250e2e111dc5e1434131bdf3d590c27a878ade` | 13.2B | vision-language | `examples/models/nemotron/nemotron_vl` | TODO |
-| Nemotron | Nemotron-3 Nano Omni | `nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16` | `24e67ea000b7c2837fc8f9488aa2008524fac8ba` | 33.0B | vision-language-audio | `examples/models/nemotron/nemotron_3_omni` | TODO |
+| Nemotron | Llama Nemotron | `nvidia/Llama-3.1-Nemotron-Nano-4B-v1.1` | `d552708a9d575fa8d4a690b988fd870d65279f98` | 4.5B | text | `examples/conversion` | PASS |
+| Nemotron | Nemotron Nano v2 VL | `nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16` | `5d250e2e111dc5e1434131bdf3d590c27a878ade` | 13.2B | vision-language | `examples/models/nemotron/nemotron_vl` | BLOCKED |
+| Nemotron | Nemotron-3 Nano Omni | `nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16` | `24e67ea000b7c2837fc8f9488aa2008524fac8ba` | 33.0B | vision-language-audio | `examples/models/nemotron/nemotron_3_omni` | BLOCKED |
 | OLMoE | OLMoE | `allenai/OLMoE-1B-7B-0125` | `9b0c1aa87e34a20052389dce1f0cf01da783f654` | 6.9B | text | `examples/conversion` | PASS |
-| Qwen | Qwen2 | `Qwen/Qwen2-7B` | `453ed1575b739b5b03ce3758b23befdb0967f40e` | 7.6B | text | `examples/conversion` | TODO |
-| Qwen | Qwen2.5 | `Qwen/Qwen2.5-7B` | `d149729398750b98c0af14eb82c78cfe92750796` | 7.6B | text | `examples/conversion` | TODO |
-| Qwen | Qwen3 | `Qwen/Qwen3-8B` | `b968826d9c46dd6066d109eabc6255188de91218` | 8.2B | text | `examples/conversion` | TODO |
-| Qwen | Qwen3-MoE | `Qwen/Qwen3-30B-A3B` | `ad44e777bcd18fa416d9da3bd8f70d33ebb85d39` | 30.5B | text | `examples/conversion` | TODO |
-| Qwen | Qwen3 Next | `Qwen/Qwen3-Next-80B-A3B-Instruct` | `9c7f2fbe84465e40164a94cc16cd30b6999b0cc7` | 81.3B | text | `examples/models/qwen/qwen3_next` | TODO |
-| Qwen | Qwen3.5 dense | `Qwen/Qwen3.5-27B` | `fc05daec18b0a78c049392ed2e771dde82bdf654` | 27.8B | text | `examples/models/qwen/qwen35_vl` | TODO |
-| Qwen | Qwen3.5 MoE | `Qwen/Qwen3.5-35B-A3B` | `59d61f3ce65a6d9863b86d2e96597125219dc754` | 36.0B | text | `examples/models/qwen/qwen35_vl` | TODO |
-| Qwen | Qwen2.5-VL | `Qwen/Qwen2.5-VL-3B-Instruct` | `66285546d2b821cf421d4f5eb2576359d3770cd3` | 3.8B | vision-language | `examples/models/qwen/qwen_vl` | TODO |
-| Qwen | Qwen3-VL | `Qwen/Qwen3-VL-8B-Instruct` | `0c351dd01ed87e9c1b53cbc748cba10e6187ff3b` | 8.8B | vision-language | `examples/models/qwen/qwen3_vl` | TODO |
-| Qwen | Qwen3.5-VL | `Qwen/Qwen3.5-27B` | `fc05daec18b0a78c049392ed2e771dde82bdf654` | 27.8B | vision-language | `examples/models/qwen/qwen35_vl` | TODO |
-| Qwen | Qwen3.6-VL | `Qwen/Qwen3.6-35B-A3B` | `995ad96eacd98c81ed38be0c5b274b04031597b0` | 36.0B | vision-language | `examples/models/qwen/qwen35_vl` | TODO |
-| Qwen | Qwen2 Audio | `Qwen/Qwen2-Audio-7B-Instruct` | `0a095220c30b7b31434169c3086508ef3ea5bf0a` | 8.4B | audio-text | `examples/models/qwen/qwen2_audio` | TODO |
-| Qwen | Qwen2.5-Omni | `Qwen/Qwen2.5-Omni-7B` | `ae9e1690543ffd5c0221dc27f79834d0294cba00` | 10.7B | vision-audio-text | `examples/models/qwen/qwen25_omni` | TODO |
-| Qwen | Qwen3-Omni | `Qwen/Qwen3-Omni-30B-A3B-Instruct` | `26291f793822fb6be9555850f06dfe95f2d7e695` | 35.3B | vision-audio-text | `examples/models/qwen/qwen3_omni` | TODO |
+| Qwen | Qwen2 | `Qwen/Qwen2-7B` | `453ed1575b739b5b03ce3758b23befdb0967f40e` | 7.6B | text | `examples/conversion` | PASS |
+| Qwen | Qwen2.5 | `Qwen/Qwen2.5-7B` | `d149729398750b98c0af14eb82c78cfe92750796` | 7.6B | text | `examples/conversion` | PASS |
+| Qwen | Qwen3 | `Qwen/Qwen3-8B` | `b968826d9c46dd6066d109eabc6255188de91218` | 8.2B | text | `examples/conversion` | PASS |
+| Qwen | Qwen3-MoE | `Qwen/Qwen3-30B-A3B` | `ad44e777bcd18fa416d9da3bd8f70d33ebb85d39` | 30.5B | text | `examples/conversion` | PASS |
+| Qwen | Qwen3 Next | `Qwen/Qwen3-Next-80B-A3B-Instruct` | `9c7f2fbe84465e40164a94cc16cd30b6999b0cc7` | 81.3B | text | `examples/models/qwen/qwen3_next` | BLOCKED |
+| Qwen | Qwen3.5 dense | `Qwen/Qwen3.5-27B` | `fc05daec18b0a78c049392ed2e771dde82bdf654` | 27.8B | vision-language | `examples/models/qwen/qwen35_vl` | PASS |
+| Qwen | Qwen3.5 MoE | `Qwen/Qwen3.5-35B-A3B` | `59d61f3ce65a6d9863b86d2e96597125219dc754` | 36.0B | vision-language | `examples/models/qwen/qwen35_vl` | PASS |
+| Qwen | Qwen2.5-VL | `Qwen/Qwen2.5-VL-3B-Instruct` | `66285546d2b821cf421d4f5eb2576359d3770cd3` | 3.8B | vision-language | `examples/models/qwen/qwen_vl` | PASS |
+| Qwen | Qwen3-VL | `Qwen/Qwen3-VL-8B-Instruct` | `0c351dd01ed87e9c1b53cbc748cba10e6187ff3b` | 8.8B | vision-language | `examples/models/qwen/qwen3_vl` | PASS |
+| Qwen | Qwen3.5-VL | `Qwen/Qwen3.5-27B` | `fc05daec18b0a78c049392ed2e771dde82bdf654` | 27.8B | vision-language | `examples/models/qwen/qwen35_vl` | DUPLICATE |
+| Qwen | Qwen3.6-VL | `Qwen/Qwen3.6-35B-A3B` | `995ad96eacd98c81ed38be0c5b274b04031597b0` | 36.0B | vision-language | `examples/models/qwen/qwen35_vl` | PASS |
+| Qwen | Qwen2 Audio | `Qwen/Qwen2-Audio-7B-Instruct` | `0a095220c30b7b31434169c3086508ef3ea5bf0a` | 8.4B | audio-text | `examples/models/qwen/qwen2_audio` | PASS |
+| Qwen | Qwen2.5-Omni | `Qwen/Qwen2.5-Omni-7B` | `ae9e1690543ffd5c0221dc27f79834d0294cba00` | 10.7B | vision-audio-text | `examples/models/qwen/qwen25_omni` | PARTIAL |
+| Qwen | Qwen3-Omni | `Qwen/Qwen3-Omni-30B-A3B-Instruct` | `26291f793822fb6be9555850f06dfe95f2d7e695` | 35.3B | vision-audio-text | `examples/models/qwen/qwen3_omni` | BLOCKED |
 | Qwen | Qwen3-ASR | `Qwen/Qwen3-ASR-1.7B` | `7278e1e70fe206f11671096ffdd38061171dd6e5` | 2.3B | audio-text | `examples/models/qwen/qwen3_asr` | PASS |
-| Sarvam | Sarvam | `sarvamai/sarvam-30b` | `071ae95e933605ca1104a6b4524a36a98488efa4` | 32.2B | text | `examples/models/sarvam` | TODO |
+| Sarvam | Sarvam | `sarvamai/sarvam-30b` | `071ae95e933605ca1104a6b4524a36a98488efa4` | 32.2B | text | `examples/models/sarvam` | PASS |
 | StepFun | Step-3.5-Flash | `stepfun-ai/Step-3.5-Flash` | `ab446a3de5e171ea341227e24bb1f090e1b771f7` | 199.4B | text | `examples/models/stepfun/step35` | TODO |
 | StepFun | Step-3.7-Flash | `stepfun-ai/Step-3.7-Flash` | `5f6244077ac62e04eec3f320501ff8c2b293373a` | 201.4B | vision-language | `examples/models/stepfun/step37` | TODO |
 
@@ -102,11 +107,15 @@ counts are deliberately not used for this decision.
 
 ## PASS acceptance
 
-A row moves to `PASS` only after validation uses the complete checkpoint and
-records, as applicable: original-framework deterministic inference, full
-HF-to-Megatron import, Megatron inference, full Megatron-to-HF export,
-exported-HF inference, exact state-dict round-trip for pure non-quantized
-mappings, and BF16 logit cosine above 0.9999. For quantized sources the report
-must instead state source/export dtype, dequantization behavior, aggregate
-weight error, and logit or deterministic token parity; a lossy conversion is
-never described as exact.
+A row moves to `PASS` only after the complete checkpoint passes all six Stage 1
+gates: single-process HF-to-Megatron import, single-process Megatron-to-HF
+export, multi-GPU Megatron checkpoint load and export verification, and
+Megatron generation from the original HF, imported Megatron, and exported HF
+sources. Modality-specific models must produce an appropriate text, image, or
+audio result.
+
+Weight comparisons retain the exact tolerance and dtype behavior of the
+repository checker; tolerant results are never described as bitwise exact.
+Generation is forward/decode smoke coverage, not original-framework inference,
+strict logits parity, training validation, or a model-quality benchmark.
+`PARTIAL` means at least one gate passed but the row did not complete all six.

--- a/examples/models/full-model-validation.md
+++ b/examples/models/full-model-validation.md
@@ -38,7 +38,7 @@ Hugging Face commit SHAs resolved on the date above. Status is one of `TODO`,
 | Gemma | Gemma 4-VL 26B-A4B MoE | `google/gemma-4-26B-A4B-it` | `5305c1e72ea29c01f31a81230d52b375ba88b409` | 26.5B | vision-language | `examples/models/gemma/gemma4_vl` | TODO |
 | GLM | GLM-4.5 | `zai-org/GLM-4.5` | `cbb2c7cfb52fa128a9660cb1a7a78e017899e115` | 358.3B | text | `examples/conversion` | TODO |
 | GLM | GLM-4.7 | `zai-org/GLM-4.7` | `602d01efcdd332c5238ca4bcede555defbe83eb7` | 358.3B | text | `examples/models/glm47` | TODO |
-| GLM | GLM-4.7-Flash | `zai-org/GLM-4.7-Flash` | `7dd20894a642a0aa287e9827cb1a1f7f91386b67` | 31.2B | text | `examples/models/glm47` | TODO |
+| GLM | GLM-4.7-Flash | `zai-org/GLM-4.7-Flash` | `7dd20894a642a0aa287e9827cb1a1f7f91386b67` | 31.2B | text | `examples/models/glm47` | PASS |
 | GLM | GLM-4.5V | `zai-org/GLM-4.5V` | `ed47433b37111465ec527affaaddceff371bca04` | 107.7B | vision-language | `examples/models/glm/glm_45v` | TODO |
 | GPT-OSS | GPT-OSS 20B | `openai/gpt-oss-20b` | `6cee5e81ee83917806bbde320786a8fb61efebee` | 21.5B | text | `examples/models/gpt_oss` | TODO |
 | GPT-OSS | GPT-OSS 120B | `openai/gpt-oss-120b` | `b5c939de8f754692c1647ca79fbf85e8c1e70f8a` | 120.4B | text | `examples/models/gpt_oss` | TODO |

--- a/examples/models/full-model-validation.md
+++ b/examples/models/full-model-validation.md
@@ -1,6 +1,6 @@
 # Full-checkpoint conversion and inference validation inventory
 
-Last updated: 2026-07-15
+Last updated: 2026-07-16
 
 This manifest tracks full-checkpoint conversion and inference validation for the
 model architectures and explicitly named variants in the root
@@ -31,7 +31,7 @@ forward-logit parity.
 | Diffusion | LLaDA 1.5 | `GSAI-ML/LLaDA-1.5` | `84346fd91ba60252d260022201ad6fc5a3468fb2` | 8.0B | text diffusion | `examples/models/llada/llada15` | TODO |
 | Diffusion | Nemotron-Labs Diffusion | `nvidia/Nemotron-Labs-Diffusion-3B` | `0d51902da1f8869f83413ce642fab402fa5641e0` | 3.8B | text diffusion | `examples/models/nemotron_labs_diffusion` | TODO |
 | Diffusion | WAN 2.1 | `Wan-AI/Wan2.1-T2V-1.3B-Diffusers` | `0fad780a534b6463e45facd96134c9f345acfa5b` | 1.3B | text-to-video | `examples/models/wan` | TODO |
-| Ernie | Ernie 4.5 MoE | `baidu/ERNIE-4.5-21B-A3B-PT` | `87db95487941cb39592ee0abca3b9155a6d19c5c` | 21.9B | text | `examples/conversion` | BLOCKED |
+| Ernie | Ernie 4.5 MoE | `baidu/ERNIE-4.5-21B-A3B-PT` | `87db95487941cb39592ee0abca3b9155a6d19c5c` | 21.9B | text | `examples/models/ernie/ernie45` | PASS |
 | Ernie | Ernie 4.5 VL MoE | `baidu/ERNIE-4.5-VL-28B-A3B-PT` | `e3815e65c607ea211bfe21b46ab0cd264b76731c` | 29.4B | vision-language | `examples/models/vlm/ernie_vl` | BLOCKED |
 | Falcon | Falcon H1 | `tiiuae/Falcon-H1-0.5B-Instruct` | `8f2587ca06bff78d8fa1adfccbe8c24d5f86b368` | 0.5B | text | `examples/models/falcon_h1` | PASS |
 | Gemma | Gemma | `google/gemma-2b` | `9cf48e52b224239de00d483ec8eb84fb8d0f3a3a` | 2.5B | text | `examples/conversion` | PASS |
@@ -52,7 +52,7 @@ forward-logit parity.
 | Llama | Llama 3 | `meta-llama/Meta-Llama-3-8B` | `8cde5ca8380496c9a6cc7ef3a8b46a0372a1d920` | 8.0B | text | `examples/conversion` | PASS |
 | Llama | Llama 3.1 | `meta-llama/Meta-Llama-3.1-8B` | `d04e592bb4f6aa9cfee91e2e20afa771667e1d4b` | 8.0B | text | `examples/conversion` | PASS |
 | Llama | Llama 3.2 | `meta-llama/Llama-3.2-1B` | `4e20de362430cd3b72f300e6b0f18e50e7166e08` | 1.2B | text | `examples/conversion` | PASS |
-| Llama | Llama 3.3 | `meta-llama/Llama-3.3-70B-Instruct` | `6f6073b423013f6a7d4d9f39144961bfbfbc386b` | 70.6B | text | `examples/conversion` | BLOCKED |
+| Llama | Llama 3.3 | `meta-llama/Llama-3.3-70B-Instruct` | `6f6073b423013f6a7d4d9f39144961bfbfbc386b` | 70.6B | text | `examples/conversion` | PASS |
 | MiniMax | MiniMax-M2 | `MiniMaxAI/MiniMax-M2` | `757303d492a50514c312788b5247a4f696a4c6a3` | 456B | text | `examples/models/minimax/minimax_m2` | TODO |
 | MiniMax | MiniMax-M2.5 | `MiniMaxAI/MiniMax-M2.5` | `f710177d938eff80b684d42c5aa84b382612f21f` | 456B | text | `examples/models/minimax/minimax_m2` | TODO |
 | MiniMax | MiniMax-M2.7 | `MiniMaxAI/MiniMax-M2.7` | `d494266a4affc0d2995ba1fa35c8481cbd84294b` | 456B | text | `examples/models/minimax/minimax_m2` | TODO |
@@ -62,7 +62,7 @@ forward-logit parity.
 | Mistral | Ministral 3 14B | `mistralai/Ministral-3-14B-Base-2512` | `5b0ceedbb42dff466ae60b258ba296f32da51384` | 13.9B | vision-language | `examples/models/mistral/ministral3` | PASS |
 | Xiaomi-MiMo | MiMo | `XiaomiMiMo/MiMo-7B-Base` | `c72df4586cb8bdeebd65f36929cd3385a6566fbe` | 7.8B | text | `examples/models/mimo` | PASS |
 | Xiaomi-MiMo | MiMo-V2-Flash | `XiaomiMiMo/MiMo-V2-Flash` | `1afd314a2406c282e0956375c34a676501c78649` | 309.8B | text | `examples/models/mimo_v2_flash` | TODO |
-| Moonlight | Moonlight | `moonshotai/Moonlight-16B-A3B` | `476b36a473d4467f94469414bef6cee75c9c8172` | 16.0B | text | `examples/conversion` | BLOCKED |
+| Moonlight | Moonlight | `moonshotai/Moonlight-16B-A3B` | `476b36a473d4467f94469414bef6cee75c9c8172` | 16.0B | text | `examples/conversion` | PARTIAL |
 | Nemotron | Nemotron H | `nvidia/Nemotron-H-4B-Base-8K` | `faba3b731ad7ea5781b9518ae75fb610a94affcf` | 4.5B | text | `examples/conversion` | PASS |
 | Nemotron | Nemotron Nano v2 | `nvidia/NVIDIA-Nemotron-Nano-9B-v2-Base` | `dc0661c829b14e5b9246c05cfa89094a0875e052` | 8.9B | text | `examples/conversion` | PASS |
 | Nemotron | Nemotron-3 Nano | `nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-Base-BF16` | `97ab8012882a655dc38df4fee47422aca9caca07` | 31.6B | text | `examples/models/nemotron/nemotron_3/nano` | PASS |

--- a/examples/models/full-model-validation.md
+++ b/examples/models/full-model-validation.md
@@ -40,7 +40,7 @@ Hugging Face commit SHAs resolved on the date above. Status is one of `TODO`,
 | GLM | GLM-4.7 | `zai-org/GLM-4.7` | `602d01efcdd332c5238ca4bcede555defbe83eb7` | 358.3B | text | `examples/models/glm47` | TODO |
 | GLM | GLM-4.7-Flash | `zai-org/GLM-4.7-Flash` | `7dd20894a642a0aa287e9827cb1a1f7f91386b67` | 31.2B | text | `examples/models/glm47` | PASS |
 | GLM | GLM-4.5V | `zai-org/GLM-4.5V` | `ed47433b37111465ec527affaaddceff371bca04` | 107.7B | vision-language | `examples/models/glm/glm_45v` | TODO |
-| GPT-OSS | GPT-OSS 20B | `openai/gpt-oss-20b` | `6cee5e81ee83917806bbde320786a8fb61efebee` | 21.5B | text | `examples/models/gpt_oss` | TODO |
+| GPT-OSS | GPT-OSS 20B | `openai/gpt-oss-20b` | `6cee5e81ee83917806bbde320786a8fb61efebee` | 21.5B | text | `examples/models/gpt_oss` | PASS |
 | GPT-OSS | GPT-OSS 120B | `openai/gpt-oss-120b` | `b5c939de8f754692c1647ca79fbf85e8c1e70f8a` | 120.4B | text | `examples/models/gpt_oss` | TODO |
 | HY V3 | Hy3 preview-Base | `tencent/Hy3-preview-Base` | `54a62bb00a50195423bffb6b55e91aa28b6a8ce2` | 298.8B | text | `examples/conversion` | TODO |
 | Llama | Llama 2 | `meta-llama/Llama-2-7b-hf` | `01c7f73d771dfac7d292323805ebc428287df4f9` | 6.7B | text | `examples/conversion` | PASS |

--- a/examples/models/full-model-validation.md
+++ b/examples/models/full-model-validation.md
@@ -1,0 +1,112 @@
+# Full-model validation inventory
+
+Last updated: 2026-07-10
+
+This manifest tracks full-checkpoint conversion and inference validation for the
+model architectures and explicitly named variants in the root
+[Supported Models](../../README.md#supported-models) table. It selects one
+canonical public, complete Hugging Face checkpoint per architecture/version;
+it does not try to enumerate every size or instruction-tuned derivative. Sizes
+explicitly named in the root table are tracked separately.
+
+`Params` is total architecture parameters, not parameters activated per token.
+For packed low-precision checkpoints, it follows the model architecture/model
+card rather than the raw stored tensor-element count. Revisions are immutable
+Hugging Face commit SHAs resolved on the date above. Status is one of `TODO`,
+`DOWNLOADING`, `RUNNING`, `FIXING`, `PASS`, or `BLOCKED`.
+
+| Family | Architecture / version | Canonical HF checkpoint | Revision | Params | Modality | Example path | Status |
+|---|---|---|---|---:|---|---|---|
+| Bailing | Ling 2.0 (Flash) | `inclusionAI/Ling-flash-2.0` | `18ca64a019b553be57bab50af3207fb2f3675edc` | 100B | text | `examples/models/bailing` | TODO |
+| Bailing | Ling MoE V2 / Bailing (Mini) | `inclusionAI/Ling-mini-2.0` | `920c3fd9916e3d5e543fc4f609e827cad8a32983` | 16B | text | `examples/models/bailing` | TODO |
+| DeepSeek | DeepSeek V2 | `deepseek-ai/DeepSeek-V2` | `4461458f186c35188585855f28f77af5661ad489` | 235.7B | text | `examples/conversion` | TODO |
+| DeepSeek | DeepSeek V2 Lite | `deepseek-ai/DeepSeek-V2-Lite` | `604d5664dddd88a0433dbae533b7fe9472482de0` | 15.7B | text | `examples/conversion` | TODO |
+| DeepSeek | DeepSeek V4 Flash | `deepseek-ai/DeepSeek-V4-Flash-Base` | `8855555deef230a27a21a8d6f294b7b7497759b6` | 292.0B | text | `examples/models/deepseek_v4` | TODO |
+| Diffusion | FLUX.1 | `black-forest-labs/FLUX.1-dev` | `3de623fc3c33e44ffbe2bad470d0f45bccf2eb21` | 12B | text-to-image | `examples/models/flux` | TODO |
+| Diffusion | LLaDA 1.5 | `GSAI-ML/LLaDA-1.5` | `84346fd91ba60252d260022201ad6fc5a3468fb2` | 8.0B | text diffusion | `examples/models/llada/llada15` | TODO |
+| Diffusion | Nemotron-Labs Diffusion | `nvidia/Nemotron-Labs-Diffusion-3B` | `0d51902da1f8869f83413ce642fab402fa5641e0` | 3.8B | text diffusion | `examples/models/nemotron_labs_diffusion` | TODO |
+| Diffusion | WAN 2.1 | `Wan-AI/Wan2.1-T2V-1.3B-Diffusers` | `0fad780a534b6463e45facd96134c9f345acfa5b` | 1.3B | text-to-video | `examples/models/wan` | TODO |
+| Ernie | Ernie 4.5 MoE | `baidu/ERNIE-4.5-21B-A3B-PT` | `87db95487941cb39592ee0abca3b9155a6d19c5c` | 21.9B | text | `examples/conversion` | TODO |
+| Ernie | Ernie 4.5 VL MoE | `baidu/ERNIE-4.5-VL-28B-A3B-PT` | `e3815e65c607ea211bfe21b46ab0cd264b76731c` | 29.4B | vision-language | `examples/models/vlm/ernie_vl` | TODO |
+| Falcon | Falcon H1 | `tiiuae/Falcon-H1-0.5B-Instruct` | `8f2587ca06bff78d8fa1adfccbe8c24d5f86b368` | 0.5B | text | `examples/models/falcon_h1` | TODO |
+| Gemma | Gemma | `google/gemma-2b` | `9cf48e52b224239de00d483ec8eb84fb8d0f3a3a` | 2.5B | text | `examples/conversion` | TODO |
+| Gemma | Gemma 2 | `google/gemma-2-2b` | `c5ebcd40d208330abc697524c919956e692655cf` | 2.6B | text | `examples/conversion` | TODO |
+| Gemma | Gemma 3 | `google/gemma-3-1b-it` | `dcc83ea841ab6100d6b47a070329e1ba4cf78752` | 1.0B | text | `examples/conversion` | TODO |
+| Gemma | Gemma 3-VL | `google/gemma-3-4b-it` | `093f9f388b31de276ce2de164bdc2081324b9767` | 4.3B | vision-language | `examples/models/gemma/gemma3_vl` | TODO |
+| Gemma | Gemma 4 26B-A4B MoE | `google/gemma-4-26B-A4B` | `6b556d30bb65a6ee0bdaec99bab0afc7bf1494fb` | 26.5B | text | `examples/models/gemma/gemma4` | TODO |
+| Gemma | Gemma 4 31B dense | `google/gemma-4-31B` | `d77cb0be8ad40327cc1c6b70eff4b3f0be35bee3` | 32.7B | text | `examples/models/gemma/gemma4` | TODO |
+| Gemma | Gemma 4-VL 26B-A4B MoE | `google/gemma-4-26B-A4B-it` | `5305c1e72ea29c01f31a81230d52b375ba88b409` | 26.5B | vision-language | `examples/models/gemma/gemma4_vl` | TODO |
+| GLM | GLM-4.5 | `zai-org/GLM-4.5` | `cbb2c7cfb52fa128a9660cb1a7a78e017899e115` | 358.3B | text | `examples/conversion` | TODO |
+| GLM | GLM-4.7 | `zai-org/GLM-4.7` | `602d01efcdd332c5238ca4bcede555defbe83eb7` | 358.3B | text | `examples/models/glm47` | TODO |
+| GLM | GLM-4.7-Flash | `zai-org/GLM-4.7-Flash` | `7dd20894a642a0aa287e9827cb1a1f7f91386b67` | 31.2B | text | `examples/models/glm47` | TODO |
+| GLM | GLM-4.5V | `zai-org/GLM-4.5V` | `ed47433b37111465ec527affaaddceff371bca04` | 107.7B | vision-language | `examples/models/glm/glm_45v` | TODO |
+| GPT-OSS | GPT-OSS 20B | `openai/gpt-oss-20b` | `6cee5e81ee83917806bbde320786a8fb61efebee` | 21.5B | text | `examples/models/gpt_oss` | TODO |
+| GPT-OSS | GPT-OSS 120B | `openai/gpt-oss-120b` | `b5c939de8f754692c1647ca79fbf85e8c1e70f8a` | 120.4B | text | `examples/models/gpt_oss` | TODO |
+| HY V3 | Hy3 preview-Base | `tencent/Hy3-preview-Base` | `54a62bb00a50195423bffb6b55e91aa28b6a8ce2` | 298.8B | text | `examples/conversion` | TODO |
+| Llama | Llama 2 | `meta-llama/Llama-2-7b-hf` | `01c7f73d771dfac7d292323805ebc428287df4f9` | 6.7B | text | `examples/conversion` | TODO |
+| Llama | Llama 3 | `meta-llama/Meta-Llama-3-8B` | `8cde5ca8380496c9a6cc7ef3a8b46a0372a1d920` | 8.0B | text | `examples/conversion` | TODO |
+| Llama | Llama 3.1 | `meta-llama/Meta-Llama-3.1-8B` | `d04e592bb4f6aa9cfee91e2e20afa771667e1d4b` | 8.0B | text | `examples/conversion` | TODO |
+| Llama | Llama 3.2 | `meta-llama/Llama-3.2-1B` | `4e20de362430cd3b72f300e6b0f18e50e7166e08` | 1.2B | text | `examples/conversion` | TODO |
+| Llama | Llama 3.3 | `meta-llama/Llama-3.3-70B-Instruct` | `6f6073b423013f6a7d4d9f39144961bfbfbc386b` | 70.6B | text | `examples/conversion` | TODO |
+| MiniMax | MiniMax-M2 | `MiniMaxAI/MiniMax-M2` | `757303d492a50514c312788b5247a4f696a4c6a3` | 456B | text | `examples/models/minimax/minimax_m2` | TODO |
+| MiniMax | MiniMax-M2.5 | `MiniMaxAI/MiniMax-M2.5` | `f710177d938eff80b684d42c5aa84b382612f21f` | 456B | text | `examples/models/minimax/minimax_m2` | TODO |
+| MiniMax | MiniMax-M2.7 | `MiniMaxAI/MiniMax-M2.7` | `d494266a4affc0d2995ba1fa35c8481cbd84294b` | 456B | text | `examples/models/minimax/minimax_m2` | TODO |
+| Mistral | Mistral | `mistralai/Mistral-7B-v0.1` | `27d67f1b5f57dc0953326b2601d68371d40ea8da` | 7.2B | text | `examples/conversion` | TODO |
+| Mistral | Ministral 3 3B | `mistralai/Ministral-3-3B-Base-2512` | `6f9c4b12a95b139af68670a6713616b757923735` | 4.3B | vision-language | `examples/models/mistral/ministral3` | TODO |
+| Mistral | Ministral 3 8B | `mistralai/Ministral-3-8B-Base-2512` | `d4883f9b36aa2e5d775730d3fdba3d30de51a8ef` | 8.9B | vision-language | `examples/models/mistral/ministral3` | TODO |
+| Mistral | Ministral 3 14B | `mistralai/Ministral-3-14B-Base-2512` | `5b0ceedbb42dff466ae60b258ba296f32da51384` | 13.9B | vision-language | `examples/models/mistral/ministral3` | TODO |
+| Xiaomi-MiMo | MiMo | `XiaomiMiMo/MiMo-7B-Base` | `c72df4586cb8bdeebd65f36929cd3385a6566fbe` | 7.8B | text | `examples/megatron_mimo` | TODO |
+| Xiaomi-MiMo | MiMo-V2-Flash | `XiaomiMiMo/MiMo-V2-Flash` | `1afd314a2406c282e0956375c34a676501c78649` | 309.8B | text | `examples/models/mimo_v2_flash` | TODO |
+| Moonlight | Moonlight | `moonshotai/Moonlight-16B-A3B` | `476b36a473d4467f94469414bef6cee75c9c8172` | 16.0B | text | `examples/conversion` | TODO |
+| Nemotron | Nemotron H | `nvidia/Nemotron-H-4B-Base-8K` | `faba3b731ad7ea5781b9518ae75fb610a94affcf` | 4.5B | text | `examples/conversion` | TODO |
+| Nemotron | Nemotron Nano v2 | `nvidia/NVIDIA-Nemotron-Nano-9B-v2-Base` | `dc0661c829b14e5b9246c05cfa89094a0875e052` | 8.9B | text | `examples/conversion` | TODO |
+| Nemotron | Nemotron-3 Nano | `nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-Base-BF16` | `97ab8012882a655dc38df4fee47422aca9caca07` | 31.6B | text | `examples/models/nemotron/nemotron_3/nano` | TODO |
+| Nemotron | Nemotron-3 Super | `nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16` | `d51eab0d1f979ebc26b546e634a04f450d99158e` | 123.6B | text | `examples/models/nemotron/nemotron_3/super` | TODO |
+| Nemotron | Llama Nemotron | `nvidia/Llama-3.1-Nemotron-Nano-4B-v1.1` | `d552708a9d575fa8d4a690b988fd870d65279f98` | 4.5B | text | `examples/conversion` | TODO |
+| Nemotron | Nemotron Nano v2 VL | `nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16` | `5d250e2e111dc5e1434131bdf3d590c27a878ade` | 13.2B | vision-language | `examples/models/nemotron/nemotron_vl` | TODO |
+| Nemotron | Nemotron-3 Nano Omni | `nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16` | `24e67ea000b7c2837fc8f9488aa2008524fac8ba` | 33.0B | vision-language-audio | `examples/models/nemotron/nemotron_3_omni` | TODO |
+| OLMoE | OLMoE | `allenai/OLMoE-1B-7B-0125` | `9b0c1aa87e34a20052389dce1f0cf01da783f654` | 6.9B | text | `examples/conversion` | TODO |
+| Qwen | Qwen2 | `Qwen/Qwen2-7B` | `453ed1575b739b5b03ce3758b23befdb0967f40e` | 7.6B | text | `examples/conversion` | TODO |
+| Qwen | Qwen2.5 | `Qwen/Qwen2.5-7B` | `d149729398750b98c0af14eb82c78cfe92750796` | 7.6B | text | `examples/conversion` | TODO |
+| Qwen | Qwen3 | `Qwen/Qwen3-8B` | `b968826d9c46dd6066d109eabc6255188de91218` | 8.2B | text | `examples/conversion` | TODO |
+| Qwen | Qwen3-MoE | `Qwen/Qwen3-30B-A3B` | `ad44e777bcd18fa416d9da3bd8f70d33ebb85d39` | 30.5B | text | `examples/conversion` | TODO |
+| Qwen | Qwen3 Next | `Qwen/Qwen3-Next-80B-A3B-Instruct` | `9c7f2fbe84465e40164a94cc16cd30b6999b0cc7` | 81.3B | text | `examples/models/qwen/qwen3_next` | TODO |
+| Qwen | Qwen3.5 dense | `Qwen/Qwen3.5-27B` | `fc05daec18b0a78c049392ed2e771dde82bdf654` | 27.8B | text | `examples/models/qwen/qwen35_vl` | TODO |
+| Qwen | Qwen3.5 MoE | `Qwen/Qwen3.5-35B-A3B` | `59d61f3ce65a6d9863b86d2e96597125219dc754` | 36.0B | text | `examples/models/qwen/qwen35_vl` | TODO |
+| Qwen | Qwen2.5-VL | `Qwen/Qwen2.5-VL-3B-Instruct` | `66285546d2b821cf421d4f5eb2576359d3770cd3` | 3.8B | vision-language | `examples/models/qwen/qwen_vl` | TODO |
+| Qwen | Qwen3-VL | `Qwen/Qwen3-VL-8B-Instruct` | `0c351dd01ed87e9c1b53cbc748cba10e6187ff3b` | 8.8B | vision-language | `examples/models/qwen/qwen3_vl` | TODO |
+| Qwen | Qwen3.5-VL | `Qwen/Qwen3.5-27B` | `fc05daec18b0a78c049392ed2e771dde82bdf654` | 27.8B | vision-language | `examples/models/qwen/qwen35_vl` | TODO |
+| Qwen | Qwen3.6-VL | `Qwen/Qwen3.6-35B-A3B` | `995ad96eacd98c81ed38be0c5b274b04031597b0` | 36.0B | vision-language | `examples/models/qwen/qwen35_vl` | TODO |
+| Qwen | Qwen2 Audio | `Qwen/Qwen2-Audio-7B-Instruct` | `0a095220c30b7b31434169c3086508ef3ea5bf0a` | 8.4B | audio-text | `examples/models/qwen/qwen2_audio` | TODO |
+| Qwen | Qwen2.5-Omni | `Qwen/Qwen2.5-Omni-7B` | `ae9e1690543ffd5c0221dc27f79834d0294cba00` | 10.7B | vision-audio-text | `examples/models/qwen/qwen25_omni` | TODO |
+| Qwen | Qwen3-Omni | `Qwen/Qwen3-Omni-30B-A3B-Instruct` | `26291f793822fb6be9555850f06dfe95f2d7e695` | 35.3B | vision-audio-text | `examples/models/qwen/qwen3_omni` | TODO |
+| Qwen | Qwen3-ASR | `Qwen/Qwen3-ASR-1.7B` | `7278e1e70fe206f11671096ffdd38061171dd6e5` | 2.3B | audio-text | `examples/models/qwen/qwen3_asr` | TODO |
+| Sarvam | Sarvam | `sarvamai/sarvam-30b` | `071ae95e933605ca1104a6b4524a36a98488efa4` | 32.2B | text | `examples/models/sarvam` | TODO |
+| StepFun | Step-3.5-Flash | `stepfun-ai/Step-3.5-Flash` | `ab446a3de5e171ea341227e24bb1f090e1b771f7` | 199.4B | text | `examples/models/stepfun/step35` | TODO |
+| StepFun | Step-3.7-Flash | `stepfun-ai/Step-3.7-Flash` | `5f6244077ac62e04eec3f320501ff8c2b293373a` | 201.4B | vision-language | `examples/models/stepfun/step37` | TODO |
+
+## Excluded at 500B or above
+
+These root-table architectures have public checkpoints but are outside this
+program because their total parameter count is at least 500B. Active parameter
+counts are deliberately not used for this decision.
+
+| Architecture / version | Evidence checkpoint | Revision | Total params | Evidence |
+|---|---|---|---:|---|
+| DeepSeek V3 | `deepseek-ai/DeepSeek-V3-Base` | `afb92e1fa402c2be2a9eb085312bb02e0384d6c7` | 684.5B | Complete checkpoint tensor inventory; model card reports 671B nominal. |
+| DeepSeek V4 / Pro | `deepseek-ai/DeepSeek-V4-Pro-Base` | `98730c030fbdbaca4950788280a35c4642b208a9` | 1.60T | Complete checkpoint tensor inventory. |
+| GLM-5 | `zai-org/GLM-5` | `4e6698ba8e85059d749020e3c4d2123719f23926` | 753.9B | Complete checkpoint tensor inventory. |
+| GLM-5.1 | `zai-org/GLM-5.1` | `26e1bd6e011feb778d25ae34b09b07074139d92d` | 753.9B | Complete checkpoint tensor inventory. |
+| Kimi K2 | `moonshotai/Kimi-K2-Instruct` | `fd1984e2b7a3350dbf7305fe73a4ede25c14de50` | 1.03T | Complete checkpoint tensor inventory. |
+| Kimi-K2.5-VL | `moonshotai/Kimi-K2.5` | `4d01dfe0332d63057c186e0b262165819efb6611` | 1.06T | Complete checkpoint tensor inventory. |
+
+## PASS acceptance
+
+A row moves to `PASS` only after validation uses the complete checkpoint and
+records, as applicable: original-framework deterministic inference, full
+HF-to-Megatron import, Megatron inference, full Megatron-to-HF export,
+exported-HF inference, exact state-dict round-trip for pure non-quantized
+mappings, and BF16 logit cosine above 0.9999. For quantized sources the report
+must instead state source/export dtype, dequantization behavior, aggregate
+weight error, and logit or deterministic token parity; a lossy conversion is
+never described as exact.

--- a/examples/models/gpt_oss/README.md
+++ b/examples/models/gpt_oss/README.md
@@ -20,17 +20,20 @@ Directory structure:
 
 See the [conversion.sh](conversion.sh) script for checkpoint conversion examples.
 
-- **Import**: Use `openai/gpt-oss-20b` as the source Hugging Face model.
-- **Export**: Use `unsloth/gpt-oss-20b-BF16` as the reference HF model for export because the exported Megatron checkpoint is unquantized (bf16), which matches that repo's format.
+- **Import**: Use the complete public `openai/gpt-oss-20b` MXFP4 checkpoint.
+- **Export**: Use `unsloth/gpt-oss-20b-BF16` only as the unquantized config/layout reference because conversion dequantizes the MXFP4 expert weights to BF16.
 
 ### Import HF → Megatron
 
 To import the HF model to your desired Megatron path:
 
 ```bash
-./scripts/conversion/convert.sh import \
+uv run python -m torch.distributed.run --nproc_per_node=8 \
+  examples/conversion/convert_checkpoints_multi_gpu.py import \
     --hf-model openai/gpt-oss-20b \
     --megatron-path ${WORKSPACE}/models/gpt-oss-20b \
+    --torch-dtype bfloat16 \
+    --tp 1 --pp 1 --ep 8 --etp 1 \
     --trust-remote-code
 ```
 
@@ -39,10 +42,13 @@ To import the HF model to your desired Megatron path:
 The export uses `unsloth/gpt-oss-20b-BF16` as the reference so the saved HF checkpoint matches that unquantized format:
 
 ```bash
-./scripts/conversion/convert.sh export \
+uv run python -m torch.distributed.run --nproc_per_node=8 \
+  examples/conversion/convert_checkpoints_multi_gpu.py export \
     --hf-model unsloth/gpt-oss-20b-BF16 \
     --megatron-path ${WORKSPACE}/models/gpt-oss-20b/iter_0000000 \
-    --hf-path ${WORKSPACE}/models/gpt-oss-20b-hf-export
+    --hf-path ${WORKSPACE}/models/gpt-oss-20b-hf-export \
+    --torch-dtype bfloat16 \
+    --tp 1 --pp 1 --ep 8 --etp 1
 ```
 
 ### Round-trip Validation
@@ -53,10 +59,14 @@ Multi-GPU round-trip validation between formats:
 uv run python -m torch.distributed.run --nproc_per_node=8 \
     examples/conversion/hf_megatron_roundtrip_multi_gpu.py \
     --hf-model-id unsloth/gpt-oss-20b-BF16 \
-    --megatron-load-path ${WORKSPACE}/models/gpt-oss-20b/iter_0000000 \
-    --tp 2 --pp 2 \
+    --tp 1 --pp 1 --ep 8 --etp 1 \
+    --skip-save \
     --trust-remote-code
 ```
+
+The round-trip command above exercises the pure BF16 mappings independently.
+It must not be used to describe the MXFP4 import as exact: the OpenAI source
+experts are dequantized during import and the exported checkpoint is BF16.
 
 ## Training Recipes
 
@@ -154,25 +164,27 @@ We provide a [Weights & Biases report](https://api.wandb.ai/links/nvidia-nemo-fw
 
 ## Inference
 
-See [inference.sh](inference.sh) for text generation with:
-- Hugging Face checkpoint (`unsloth/gpt-oss-20b-BF16`)
+See [inference.sh](inference.sh) for Bridge-backed text generation with:
+- Complete Hugging Face weights loaded directly (`openai/gpt-oss-20b`)
 - Imported Megatron checkpoint (after [conversion.sh](conversion.sh) import)
-- Exported HF checkpoint (after conversion export)
+- Exported BF16 Hugging Face checkpoint (after conversion export)
 - **SFT (finetuned) checkpoint**: set `SFT_CHECKPOINT` to your [slurm_sft.sh](slurm_sft.sh) result dir and run:
 
 ```bash
 uv run python -m torch.distributed.run --nproc_per_node=8 scripts/inference/text_generation.py \
-    --hf_model_path unsloth/gpt-oss-20b-BF16 \
+    --hf_model_path openai/gpt-oss-20b \
     --megatron_model_path ${WORKSPACE}/results/gpt_oss_20b_finetune_tp2_pp2_ep4_spTrue_cp1 \
     --prompt "Hello, how are you?" \
     --max_new_tokens 64 \
-    --tp 2 --pp 2 --ep 2 --etp 1 \
+    --tp 1 --pp 1 --ep 8 --etp 1 \
     --use-legacy-generation \
     --attention-backend local \
     --trust-remote-code
 ```
 
-TP×PP×EP must equal `--nproc_per_node`. Adjust parallelism to match your SFT run.
+The scripts default to `NUM_GPUS=8`, `TP=1`, `PP=1`, `EP=8`, and `ETP=1`.
+Override those environment variables together when using a different topology;
+for the DP=1 example, TP×PP×EP must equal `NUM_GPUS`.
 
 ## Evaluation
 

--- a/examples/models/gpt_oss/README.md
+++ b/examples/models/gpt_oss/README.md
@@ -20,20 +20,17 @@ Directory structure:
 
 See the [conversion.sh](conversion.sh) script for checkpoint conversion examples.
 
-- **Import**: Use the complete public `openai/gpt-oss-20b` MXFP4 checkpoint.
-- **Export**: Use `unsloth/gpt-oss-20b-BF16` only as the unquantized config/layout reference because conversion dequantizes the MXFP4 expert weights to BF16.
+- **Import**: Use `openai/gpt-oss-20b` as the source Hugging Face model.
+- **Export**: Use `unsloth/gpt-oss-20b-BF16` as the reference HF model for export because the exported Megatron checkpoint is unquantized (bf16), which matches that repo's format.
 
 ### Import HF → Megatron
 
 To import the HF model to your desired Megatron path:
 
 ```bash
-uv run python -m torch.distributed.run --nproc_per_node=8 \
-  examples/conversion/convert_checkpoints_multi_gpu.py import \
+uv run python examples/conversion/convert_checkpoints.py import \
     --hf-model openai/gpt-oss-20b \
     --megatron-path ${WORKSPACE}/models/gpt-oss-20b \
-    --torch-dtype bfloat16 \
-    --tp 1 --pp 1 --ep 8 --etp 1 \
     --trust-remote-code
 ```
 
@@ -42,13 +39,10 @@ uv run python -m torch.distributed.run --nproc_per_node=8 \
 The export uses `unsloth/gpt-oss-20b-BF16` as the reference so the saved HF checkpoint matches that unquantized format:
 
 ```bash
-uv run python -m torch.distributed.run --nproc_per_node=8 \
-  examples/conversion/convert_checkpoints_multi_gpu.py export \
+uv run python examples/conversion/convert_checkpoints.py export \
     --hf-model unsloth/gpt-oss-20b-BF16 \
     --megatron-path ${WORKSPACE}/models/gpt-oss-20b/iter_0000000 \
-    --hf-path ${WORKSPACE}/models/gpt-oss-20b-hf-export \
-    --torch-dtype bfloat16 \
-    --tp 1 --pp 1 --ep 8 --etp 1
+    --hf-path ${WORKSPACE}/models/gpt-oss-20b-hf-export
 ```
 
 ### Round-trip Validation
@@ -59,14 +53,10 @@ Multi-GPU round-trip validation between formats:
 uv run python -m torch.distributed.run --nproc_per_node=8 \
     examples/conversion/hf_megatron_roundtrip_multi_gpu.py \
     --hf-model-id unsloth/gpt-oss-20b-BF16 \
-    --tp 1 --pp 1 --ep 8 --etp 1 \
-    --skip-save \
+    --megatron-load-path ${WORKSPACE}/models/gpt-oss-20b/iter_0000000 \
+    --tp 2 --pp 2 \
     --trust-remote-code
 ```
-
-The round-trip command above exercises the pure BF16 mappings independently.
-It must not be used to describe the MXFP4 import as exact: the OpenAI source
-experts are dequantized during import and the exported checkpoint is BF16.
 
 ## Training Recipes
 
@@ -164,27 +154,25 @@ We provide a [Weights & Biases report](https://api.wandb.ai/links/nvidia-nemo-fw
 
 ## Inference
 
-See [inference.sh](inference.sh) for Bridge-backed text generation with:
-- Complete Hugging Face weights loaded directly (`openai/gpt-oss-20b`)
+See [inference.sh](inference.sh) for text generation with:
+- Hugging Face checkpoint (`unsloth/gpt-oss-20b-BF16`)
 - Imported Megatron checkpoint (after [conversion.sh](conversion.sh) import)
-- Exported BF16 Hugging Face checkpoint (after conversion export)
+- Exported HF checkpoint (after conversion export)
 - **SFT (finetuned) checkpoint**: set `SFT_CHECKPOINT` to your [slurm_sft.sh](slurm_sft.sh) result dir and run:
 
 ```bash
 uv run python -m torch.distributed.run --nproc_per_node=8 scripts/inference/text_generation.py \
-    --hf_model_path openai/gpt-oss-20b \
+    --hf_model_path unsloth/gpt-oss-20b-BF16 \
     --megatron_model_path ${WORKSPACE}/results/gpt_oss_20b_finetune_tp2_pp2_ep4_spTrue_cp1 \
     --prompt "Hello, how are you?" \
     --max_new_tokens 64 \
-    --tp 1 --pp 1 --ep 8 --etp 1 \
+    --tp 2 --pp 2 --ep 2 --etp 1 \
     --use-legacy-generation \
-    --attention-backend unfused \
+    --attention-backend local \
     --trust-remote-code
 ```
 
-The scripts default to `NUM_GPUS=8`, `TP=1`, `PP=1`, `EP=8`, and `ETP=1`.
-Override those environment variables together when using a different topology;
-for the DP=1 example, TP×PP×EP must equal `NUM_GPUS`.
+TP×PP×EP must equal `--nproc_per_node`. Adjust parallelism to match your SFT run.
 
 ## Evaluation
 

--- a/examples/models/gpt_oss/README.md
+++ b/examples/models/gpt_oss/README.md
@@ -178,7 +178,7 @@ uv run python -m torch.distributed.run --nproc_per_node=8 scripts/inference/text
     --max_new_tokens 64 \
     --tp 1 --pp 1 --ep 8 --etp 1 \
     --use-legacy-generation \
-    --attention-backend local \
+    --attention-backend unfused \
     --trust-remote-code
 ```
 

--- a/examples/models/gpt_oss/conversion.sh
+++ b/examples/models/gpt_oss/conversion.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,51 +13,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -euo pipefail
+set -xeuo pipefail
 
 # Workspace directory for checkpoints and results
 WORKSPACE=${WORKSPACE:-/workspace}
-MODEL_NAME=${MODEL_NAME:-gpt-oss-20b}
-HF_MODEL_ID_IMPORT=${HF_MODEL_ID_IMPORT:-openai/gpt-oss-20b}
-HF_MODEL_ID_EXPORT=${HF_MODEL_ID_EXPORT:-unsloth/gpt-oss-20b-BF16}
-MEGATRON_MODEL_PATH=${MEGATRON_MODEL_PATH:-${WORKSPACE}/models/${MODEL_NAME}}
-HF_EXPORT_PATH=${HF_EXPORT_PATH:-${WORKSPACE}/models/${MODEL_NAME}-hf-export}
 
-NUM_GPUS=${NUM_GPUS:-8}
-TP=${TP:-1}
-PP=${PP:-1}
-EP=${EP:-8}
-ETP=${ETP:-1}
-
-if (( TP * PP * EP != NUM_GPUS )); then
-    echo "TP * PP * EP must equal NUM_GPUS for this DP=1 example." >&2
-    exit 1
-fi
-
-run_distributed() {
-    uv run python -m torch.distributed.run --nproc_per_node="$NUM_GPUS" "$@"
-}
+MODEL_NAME=gpt-oss-20b
+# Import: use openai/gpt-oss-20b as the source HF model
+HF_MODEL_ID_IMPORT=openai/gpt-oss-20b
+# Export: use unsloth/gpt-oss-20b-BF16 so exported checkpoint matches that repo's unquantized (bf16) format
+HF_MODEL_ID_EXPORT=unsloth/gpt-oss-20b-BF16
 
 # Import HF → Megatron
-run_distributed examples/conversion/convert_checkpoints_multi_gpu.py import \
+uv run python examples/conversion/convert_checkpoints.py import \
     --hf-model "$HF_MODEL_ID_IMPORT" \
-    --megatron-path "$MEGATRON_MODEL_PATH" \
-    --torch-dtype bfloat16 \
-    --tp "$TP" --pp "$PP" --ep "$EP" --etp "$ETP" \
+    --megatron-path "${WORKSPACE}/models/${MODEL_NAME}" \
     --trust-remote-code
 
 # Export Megatron → HF
-run_distributed examples/conversion/convert_checkpoints_multi_gpu.py export \
+uv run python examples/conversion/convert_checkpoints.py export \
     --hf-model "$HF_MODEL_ID_EXPORT" \
-    --megatron-path "${MEGATRON_MODEL_PATH}/iter_0000000" \
-    --hf-path "$HF_EXPORT_PATH" \
-    --torch-dtype bfloat16 \
-    --tp "$TP" --pp "$PP" --ep "$EP" --etp "$ETP"
+    --megatron-path "${WORKSPACE}/models/${MODEL_NAME}/iter_0000000" \
+    --hf-path "${WORKSPACE}/models/${MODEL_NAME}-hf-export"
 
-# Pure BF16 mapping validation is separate from the lossy MXFP4 source import.
-run_distributed \
+# Round-trip validation
+uv run python -m torch.distributed.run --nproc_per_node=8 \
     examples/conversion/hf_megatron_roundtrip_multi_gpu.py \
     --hf-model-id "$HF_MODEL_ID_EXPORT" \
-    --tp "$TP" --pp "$PP" --ep "$EP" --etp "$ETP" \
-    --skip-save \
+    --megatron-load-path "${WORKSPACE}/models/${MODEL_NAME}/iter_0000000" \
+    --tp 2 --pp 2 \
     --trust-remote-code

--- a/examples/models/gpt_oss/conversion.sh
+++ b/examples/models/gpt_oss/conversion.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,33 +13,51 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -xeuo pipefail
+set -euo pipefail
 
 # Workspace directory for checkpoints and results
 WORKSPACE=${WORKSPACE:-/workspace}
+MODEL_NAME=${MODEL_NAME:-gpt-oss-20b}
+HF_MODEL_ID_IMPORT=${HF_MODEL_ID_IMPORT:-openai/gpt-oss-20b}
+HF_MODEL_ID_EXPORT=${HF_MODEL_ID_EXPORT:-unsloth/gpt-oss-20b-BF16}
+MEGATRON_MODEL_PATH=${MEGATRON_MODEL_PATH:-${WORKSPACE}/models/${MODEL_NAME}}
+HF_EXPORT_PATH=${HF_EXPORT_PATH:-${WORKSPACE}/models/${MODEL_NAME}-hf-export}
 
-MODEL_NAME=gpt-oss-20b
-# Import: use openai/gpt-oss-20b as the source HF model
-HF_MODEL_ID_IMPORT=openai/gpt-oss-20b
-# Export: use unsloth/gpt-oss-20b-BF16 so exported checkpoint matches that repo's unquantized (bf16) format
-HF_MODEL_ID_EXPORT=unsloth/gpt-oss-20b-BF16
+NUM_GPUS=${NUM_GPUS:-8}
+TP=${TP:-1}
+PP=${PP:-1}
+EP=${EP:-8}
+ETP=${ETP:-1}
+
+if (( TP * PP * EP != NUM_GPUS )); then
+    echo "TP * PP * EP must equal NUM_GPUS for this DP=1 example." >&2
+    exit 1
+fi
+
+run_distributed() {
+    uv run python -m torch.distributed.run --nproc_per_node="$NUM_GPUS" "$@"
+}
 
 # Import HF → Megatron
-./scripts/conversion/convert.sh import \
+run_distributed examples/conversion/convert_checkpoints_multi_gpu.py import \
     --hf-model "$HF_MODEL_ID_IMPORT" \
-    --megatron-path "${WORKSPACE}/models/${MODEL_NAME}" \
+    --megatron-path "$MEGATRON_MODEL_PATH" \
+    --torch-dtype bfloat16 \
+    --tp "$TP" --pp "$PP" --ep "$EP" --etp "$ETP" \
     --trust-remote-code
 
 # Export Megatron → HF
-./scripts/conversion/convert.sh export \
+run_distributed examples/conversion/convert_checkpoints_multi_gpu.py export \
     --hf-model "$HF_MODEL_ID_EXPORT" \
-    --megatron-path "${WORKSPACE}/models/${MODEL_NAME}/iter_0000000" \
-    --hf-path "${WORKSPACE}/models/${MODEL_NAME}-hf-export"
+    --megatron-path "${MEGATRON_MODEL_PATH}/iter_0000000" \
+    --hf-path "$HF_EXPORT_PATH" \
+    --torch-dtype bfloat16 \
+    --tp "$TP" --pp "$PP" --ep "$EP" --etp "$ETP"
 
-# Round-trip validation
-uv run python -m torch.distributed.run --nproc_per_node=8 \
+# Pure BF16 mapping validation is separate from the lossy MXFP4 source import.
+run_distributed \
     examples/conversion/hf_megatron_roundtrip_multi_gpu.py \
     --hf-model-id "$HF_MODEL_ID_EXPORT" \
-    --megatron-load-path "${WORKSPACE}/models/${MODEL_NAME}/iter_0000000" \
-    --tp 2 --pp 2 \
+    --tp "$TP" --pp "$PP" --ep "$EP" --etp "$ETP" \
+    --skip-save \
     --trust-remote-code

--- a/examples/models/gpt_oss/inference.sh
+++ b/examples/models/gpt_oss/inference.sh
@@ -43,7 +43,7 @@ run_generation() {
         --prompt "$PROMPT" \
         --max_new_tokens "$MAX_NEW_TOKENS" \
         --tp "$TP" --pp "$PP" --ep "$EP" --etp "$ETP" \
-        --dtype bfloat16 \
+        --dtype bf16 \
         --seed 0 \
         --top_k 1 \
         --use-legacy-generation \

--- a/examples/models/gpt_oss/inference.sh
+++ b/examples/models/gpt_oss/inference.sh
@@ -47,7 +47,7 @@ run_generation() {
         --seed 0 \
         --top_k 1 \
         --use-legacy-generation \
-        --attention-backend local \
+        --attention-backend unfused \
         --trust-remote-code \
         "$@"
 }

--- a/examples/models/gpt_oss/inference.sh
+++ b/examples/models/gpt_oss/inference.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,58 +13,59 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Workspace directory for checkpoints and results
+set -euo pipefail
+
 WORKSPACE=${WORKSPACE:-/workspace}
 MAX_NEW_TOKENS=${MAX_NEW_TOKENS:-64}
 PROMPT=${PROMPT:-"Hello, how are you?"}
+HF_MODEL_ID=${HF_MODEL_ID:-openai/gpt-oss-20b}
 MEGATRON_MODEL_PATH=${MEGATRON_MODEL_PATH:-${WORKSPACE}/models/gpt-oss-20b/iter_0000000}
 HF_EXPORT_PATH=${HF_EXPORT_PATH:-${WORKSPACE}/models/gpt-oss-20b-hf-export}
-SFT_CHECKPOINT=${SFT_CHECKPOINT:-${WORKSPACE}/results/gpt_oss_20b_finetune_tp2_pp2_ep4_spTrue_cp1}
+SFT_CHECKPOINT=${SFT_CHECKPOINT:-}
 
-# Inference with Hugging Face checkpoints
-uv run python -m torch.distributed.run --nproc_per_node=8 scripts/inference/text_generation.py \
-    --hf_model_path unsloth/gpt-oss-20b-BF16 \
-    --prompt "$PROMPT" \
-    --max_new_tokens "$MAX_NEW_TOKENS" \
-    --tp 2 --pp 2 --ep 2 --etp 1 \
-    --use-legacy-generation \
-    --attention-backend local \
-    --trust-remote-code
+NUM_GPUS=${NUM_GPUS:-8}
+TP=${TP:-1}
+PP=${PP:-1}
+EP=${EP:-8}
+ETP=${ETP:-1}
 
-# Inference with imported Megatron checkpoints
+if (( TP * PP * EP != NUM_GPUS )); then
+    echo "TP * PP * EP must equal NUM_GPUS for this DP=1 example." >&2
+    exit 1
+fi
+
+run_generation() {
+    local hf_model_path=$1
+    shift
+    uv run python -m torch.distributed.run --nproc_per_node="$NUM_GPUS" \
+        scripts/inference/text_generation.py \
+        --hf_model_path "$hf_model_path" \
+        --prompt "$PROMPT" \
+        --max_new_tokens "$MAX_NEW_TOKENS" \
+        --tp "$TP" --pp "$PP" --ep "$EP" --etp "$ETP" \
+        --dtype bfloat16 \
+        --seed 0 \
+        --top_k 1 \
+        --use-legacy-generation \
+        --attention-backend local \
+        --trust-remote-code \
+        "$@"
+}
+
+# Bridge-backed generation while loading and converting the complete HF weights.
+run_generation "$HF_MODEL_ID"
+
+# Generation from the imported Megatron checkpoint.
 if [ -d "$MEGATRON_MODEL_PATH" ]; then
-    uv run python -m torch.distributed.run --nproc_per_node=8 scripts/inference/text_generation.py \
-        --hf_model_path unsloth/gpt-oss-20b-BF16 \
-        --megatron_model_path "$MEGATRON_MODEL_PATH" \
-        --prompt "$PROMPT" \
-        --max_new_tokens "$MAX_NEW_TOKENS" \
-        --tp 2 --pp 2 --ep 2 --etp 1 \
-        --use-legacy-generation \
-        --attention-backend local \
-        --trust-remote-code
+    run_generation "$HF_MODEL_ID" --megatron_model_path "$MEGATRON_MODEL_PATH"
 fi
 
-# Inference with exported HF checkpoints
+# Bridge-backed generation from the exported, unquantized HF checkpoint.
 if [ -d "$HF_EXPORT_PATH" ]; then
-    uv run python -m torch.distributed.run --nproc_per_node=8 scripts/inference/text_generation.py \
-        --hf_model_path "$HF_EXPORT_PATH" \
-        --prompt "$PROMPT" \
-        --max_new_tokens "$MAX_NEW_TOKENS" \
-        --tp 2 --pp 2 --ep 2 --etp 1 \
-        --use-legacy-generation \
-        --attention-backend local \
-        --trust-remote-code
+    run_generation "$HF_EXPORT_PATH"
 fi
 
-# Inference with SFT (finetuned) Megatron checkpoint
-if [ -d "$SFT_CHECKPOINT" ]; then
-    uv run python -m torch.distributed.run --nproc_per_node=8 scripts/inference/text_generation.py \
-        --hf_model_path unsloth/gpt-oss-20b-BF16 \
-        --megatron_model_path "$SFT_CHECKPOINT" \
-        --prompt "$PROMPT" \
-        --max_new_tokens "$MAX_NEW_TOKENS" \
-        --tp 2 --pp 2 --ep 2 --etp 1 \
-        --use-legacy-generation \
-        --attention-backend local \
-        --trust-remote-code
+# Optional generation from an SFT Megatron checkpoint.
+if [ -n "$SFT_CHECKPOINT" ] && [ -d "$SFT_CHECKPOINT" ]; then
+    run_generation "$HF_MODEL_ID" --megatron_model_path "$SFT_CHECKPOINT"
 fi

--- a/examples/models/gpt_oss/inference.sh
+++ b/examples/models/gpt_oss/inference.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,59 +13,58 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -euo pipefail
-
+# Workspace directory for checkpoints and results
 WORKSPACE=${WORKSPACE:-/workspace}
 MAX_NEW_TOKENS=${MAX_NEW_TOKENS:-64}
 PROMPT=${PROMPT:-"Hello, how are you?"}
-HF_MODEL_ID=${HF_MODEL_ID:-openai/gpt-oss-20b}
 MEGATRON_MODEL_PATH=${MEGATRON_MODEL_PATH:-${WORKSPACE}/models/gpt-oss-20b/iter_0000000}
 HF_EXPORT_PATH=${HF_EXPORT_PATH:-${WORKSPACE}/models/gpt-oss-20b-hf-export}
-SFT_CHECKPOINT=${SFT_CHECKPOINT:-}
+SFT_CHECKPOINT=${SFT_CHECKPOINT:-${WORKSPACE}/results/gpt_oss_20b_finetune_tp2_pp2_ep4_spTrue_cp1}
 
-NUM_GPUS=${NUM_GPUS:-8}
-TP=${TP:-1}
-PP=${PP:-1}
-EP=${EP:-8}
-ETP=${ETP:-1}
+# Inference with Hugging Face checkpoints
+uv run python -m torch.distributed.run --nproc_per_node=8 scripts/inference/text_generation.py \
+    --hf_model_path unsloth/gpt-oss-20b-BF16 \
+    --prompt "$PROMPT" \
+    --max_new_tokens "$MAX_NEW_TOKENS" \
+    --tp 2 --pp 2 --ep 2 --etp 1 \
+    --use-legacy-generation \
+    --attention-backend local \
+    --trust-remote-code
 
-if (( TP * PP * EP != NUM_GPUS )); then
-    echo "TP * PP * EP must equal NUM_GPUS for this DP=1 example." >&2
-    exit 1
-fi
-
-run_generation() {
-    local hf_model_path=$1
-    shift
-    uv run python -m torch.distributed.run --nproc_per_node="$NUM_GPUS" \
-        scripts/inference/text_generation.py \
-        --hf_model_path "$hf_model_path" \
+# Inference with imported Megatron checkpoints
+if [ -d "$MEGATRON_MODEL_PATH" ]; then
+    uv run python -m torch.distributed.run --nproc_per_node=8 scripts/inference/text_generation.py \
+        --hf_model_path unsloth/gpt-oss-20b-BF16 \
+        --megatron_model_path "$MEGATRON_MODEL_PATH" \
         --prompt "$PROMPT" \
         --max_new_tokens "$MAX_NEW_TOKENS" \
-        --tp "$TP" --pp "$PP" --ep "$EP" --etp "$ETP" \
-        --dtype bf16 \
-        --seed 0 \
-        --top_k 1 \
+        --tp 2 --pp 2 --ep 2 --etp 1 \
         --use-legacy-generation \
-        --attention-backend unfused \
-        --trust-remote-code \
-        "$@"
-}
-
-# Bridge-backed generation while loading and converting the complete HF weights.
-run_generation "$HF_MODEL_ID"
-
-# Generation from the imported Megatron checkpoint.
-if [ -d "$MEGATRON_MODEL_PATH" ]; then
-    run_generation "$HF_MODEL_ID" --megatron_model_path "$MEGATRON_MODEL_PATH"
+        --attention-backend local \
+        --trust-remote-code
 fi
 
-# Bridge-backed generation from the exported, unquantized HF checkpoint.
+# Inference with exported HF checkpoints
 if [ -d "$HF_EXPORT_PATH" ]; then
-    run_generation "$HF_EXPORT_PATH"
+    uv run python -m torch.distributed.run --nproc_per_node=8 scripts/inference/text_generation.py \
+        --hf_model_path "$HF_EXPORT_PATH" \
+        --prompt "$PROMPT" \
+        --max_new_tokens "$MAX_NEW_TOKENS" \
+        --tp 2 --pp 2 --ep 2 --etp 1 \
+        --use-legacy-generation \
+        --attention-backend local \
+        --trust-remote-code
 fi
 
-# Optional generation from an SFT Megatron checkpoint.
-if [ -n "$SFT_CHECKPOINT" ] && [ -d "$SFT_CHECKPOINT" ]; then
-    run_generation "$HF_MODEL_ID" --megatron_model_path "$SFT_CHECKPOINT"
+# Inference with SFT (finetuned) Megatron checkpoint
+if [ -d "$SFT_CHECKPOINT" ]; then
+    uv run python -m torch.distributed.run --nproc_per_node=8 scripts/inference/text_generation.py \
+        --hf_model_path unsloth/gpt-oss-20b-BF16 \
+        --megatron_model_path "$SFT_CHECKPOINT" \
+        --prompt "$PROMPT" \
+        --max_new_tokens "$MAX_NEW_TOKENS" \
+        --tp 2 --pp 2 --ep 2 --etp 1 \
+        --use-legacy-generation \
+        --attention-backend local \
+        --trust-remote-code
 fi

--- a/examples/models/mimo/README.md
+++ b/examples/models/mimo/README.md
@@ -1,0 +1,31 @@
+# MiMo 7B examples
+
+These scripts run the full checkpoint-conversion and generation smoke workflow
+for XiaomiMiMo text models. They default to `XiaomiMiMo/MiMo-7B-Base`; set
+`MODEL_NAME` or a complete `HF_MODEL_ID` for another compatible variant.
+
+MiMo uses custom Hugging Face configuration code, so the scripts pass
+`--trust-remote-code` for conversion and inference.
+
+## Conversion
+
+Run the single-process import and export followed by multi-GPU verification:
+
+```bash
+WORKSPACE=/workspace bash examples/models/mimo/conversion.sh
+```
+
+The default layout is two GPUs with tensor parallelism 2. To use another
+valid layout, set `TP`, `PP`, `EP`, `ETP`, and `NPROC_PER_NODE` together.
+
+## Inference
+
+After conversion, run generation from the original Hugging Face checkpoint,
+the imported Megatron checkpoint, and the exported Hugging Face checkpoint:
+
+```bash
+WORKSPACE=/workspace bash examples/models/mimo/inference.sh
+```
+
+`PROMPT` and `MAX_NEW_TOKENS` are configurable. During generation, the MiMo
+multi-token-prediction layer is disabled by the shared text-generation helper.

--- a/examples/models/mimo/conversion.sh
+++ b/examples/models/mimo/conversion.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2025-2026, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,10 +15,8 @@
 
 set -euo pipefail
 
-# Workspace directory for checkpoints and results
 WORKSPACE=${WORKSPACE:-/workspace}
-
-HF_MODEL_ID=${HF_MODEL_ID:-inclusionAI/${MODEL_NAME:-Ling-mini-2.0}}
+HF_MODEL_ID=${HF_MODEL_ID:-XiaomiMiMo/${MODEL_NAME:-MiMo-7B-Base}}
 MODEL_NAME=${MODEL_NAME:-${HF_MODEL_ID##*/}}
 MEGATRON_PATH=${MEGATRON_PATH:-${WORKSPACE}/models/${MODEL_NAME}}
 MEGATRON_LOAD_PATH=${MEGATRON_LOAD_PATH:-${MEGATRON_PATH}/iter_0000000}
@@ -27,18 +25,18 @@ ROUNDTRIP_OUTPUT_DIR=${ROUNDTRIP_OUTPUT_DIR:-${WORKSPACE}/models/${MODEL_NAME}-r
 
 TP=${TP:-2}
 PP=${PP:-1}
-EP=${EP:-4}
+EP=${EP:-1}
 ETP=${ETP:-1}
 NPROC_PER_NODE=${NPROC_PER_NODE:-$((TP * PP * EP))}
 
-# Import HF → Megatron
-./scripts/conversion/convert.sh import \
+# Import HF -> Megatron.
+uv run python examples/conversion/convert_checkpoints.py import \
     --hf-model "$HF_MODEL_ID" \
     --megatron-path "$MEGATRON_PATH" \
     --trust-remote-code
 
-# Export Megatron → HF
-./scripts/conversion/convert.sh export \
+# Export Megatron -> HF.
+uv run python examples/conversion/convert_checkpoints.py export \
     --hf-model "$HF_MODEL_ID" \
     --megatron-path "$MEGATRON_LOAD_PATH" \
     --hf-path "$HF_EXPORT_PATH" \

--- a/examples/models/mimo/inference.sh
+++ b/examples/models/mimo/inference.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2025-2026, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,22 +15,21 @@
 
 set -euo pipefail
 
-# Workspace directory for checkpoints and results
 WORKSPACE=${WORKSPACE:-/workspace}
-HF_MODEL_ID=${HF_MODEL_ID:-inclusionAI/${MODEL_NAME:-Ling-mini-2.0}}
+HF_MODEL_ID=${HF_MODEL_ID:-XiaomiMiMo/${MODEL_NAME:-MiMo-7B-Base}}
 MODEL_NAME=${MODEL_NAME:-${HF_MODEL_ID##*/}}
 MEGATRON_MODEL_PATH=${MEGATRON_MODEL_PATH:-${WORKSPACE}/models/${MODEL_NAME}/iter_0000000}
 HF_EXPORT_PATH=${HF_EXPORT_PATH:-${WORKSPACE}/models/${MODEL_NAME}-hf-export}
 
 TP=${TP:-2}
 PP=${PP:-1}
-EP=${EP:-4}
+EP=${EP:-1}
 ETP=${ETP:-1}
 NPROC_PER_NODE=${NPROC_PER_NODE:-$((TP * PP * EP))}
 MAX_NEW_TOKENS=${MAX_NEW_TOKENS:-32}
 PROMPT=${PROMPT:-"The capital of France is"}
 
-# Inference with Hugging Face checkpoints
+# Generate after converting the original HF checkpoint in memory.
 uv run python -m torch.distributed.run --nproc_per_node="$NPROC_PER_NODE" \
     examples/conversion/hf_to_megatron_generate_text.py \
     --hf_model_path "$HF_MODEL_ID" \
@@ -39,7 +38,7 @@ uv run python -m torch.distributed.run --nproc_per_node="$NPROC_PER_NODE" \
     --tp "$TP" --pp "$PP" --ep "$EP" --etp "$ETP" \
     --trust-remote-code
 
-# Inference with imported Megatron checkpoints
+# Generate from the imported Megatron checkpoint.
 uv run python -m torch.distributed.run --nproc_per_node="$NPROC_PER_NODE" \
     examples/conversion/hf_to_megatron_generate_text.py \
     --hf_model_path "$HF_MODEL_ID" \
@@ -49,7 +48,7 @@ uv run python -m torch.distributed.run --nproc_per_node="$NPROC_PER_NODE" \
     --tp "$TP" --pp "$PP" --ep "$EP" --etp "$ETP" \
     --trust-remote-code
 
-# Inference with exported HF checkpoints
+# Generate after converting the exported HF checkpoint in memory.
 uv run python -m torch.distributed.run --nproc_per_node="$NPROC_PER_NODE" \
     examples/conversion/hf_to_megatron_generate_text.py \
     --hf_model_path "$HF_EXPORT_PATH" \

--- a/examples/models/mistral/ministral3/README.md
+++ b/examples/models/mistral/ministral3/README.md
@@ -1,6 +1,7 @@
 # Ministral 3 - Vision Language Model
 
-This directory contains example scripts for Ministral 3 vision-language models.
+This directory contains conversion and inference scripts for the Ministral 3
+3B, 8B, and 14B Base vision-language checkpoints.
 
 For model introduction and architecture details, see the [Ministral 3 documentation](../../../../docs/models/mistral/ministral3.md).
 
@@ -13,73 +14,53 @@ export WORKSPACE=/your/custom/path
 ```
 
 Directory structure:
+
 - `${WORKSPACE}/models/` - Converted checkpoints
 - `${WORKSPACE}/results/` - Training outputs and experiment results
 
-## Checkpoint Conversion
+## Supported Base Checkpoints
 
-### Import HF → Megatron
-To import the HF VL model to your desired Megatron path:
-```bash
-./scripts/conversion/convert.sh import \
-  --hf-model mistralai/Ministral-3-3B-Instruct-2512-BF16 \
-  --megatron-path ${WORKSPACE}/models/Ministral-3-3B-Instruct-2512-BF16
-```
+Select a checkpoint with `MODEL_SIZE`. The scripts use the following model and
+multi-GPU topology defaults:
 
-### Export Megatron → HF
+| `MODEL_SIZE` | Hugging Face checkpoint | Validated revision | TP | PP |
+|---|---|---|---:|---:|
+| `3B` (default) | `mistralai/Ministral-3-3B-Base-2512` | `6f9c4b12a95b139af68670a6713616b757923735` | 2 | 1 |
+| `8B` | `mistralai/Ministral-3-8B-Base-2512` | `d4883f9b36aa2e5d775730d3fdba3d30de51a8ef` | 2 | 1 |
+| `14B` | `mistralai/Ministral-3-14B-Base-2512` | `5b0ceedbb42dff466ae60b258ba296f32da51384` | 4 | 1 |
+
+`HF_MODEL_ID`, `MODEL_NAME`, `TP`, `PP`, `EP`, `ETP`, and
+`NPROC_PER_NODE` can be overridden when validating a local snapshot or a
+different topology. To reproduce an immutable revision, download that snapshot
+and pass its local path through `HF_MODEL_ID` while setting `MODEL_NAME` to the
+checkpoint name.
+
+## Checkpoint Conversion and Validation
+
+The conversion script runs HF-to-Megatron import, Megatron-to-HF export, and a
+multi-GPU round-trip check that reloads the imported Megatron checkpoint.
+
 ```bash
-./scripts/conversion/convert.sh export \
-  --hf-model mistralai/Ministral-3-3B-Instruct-2512-BF16 \
-  --megatron-path ${WORKSPACE}/models/Ministral-3-3B-Instruct-2512-BF16/iter_0000000 \
-  --hf-path ${WORKSPACE}/models/Ministral-3-3B-Instruct-2512-BF16-hf-export
+MODEL_SIZE=3B bash examples/models/mistral/ministral3/conversion.sh
+MODEL_SIZE=8B bash examples/models/mistral/ministral3/conversion.sh
+MODEL_SIZE=14B bash examples/models/mistral/ministral3/conversion.sh
 ```
 
 ## Inference
 
-### Run Inference on Converted Checkpoint
+The inference script generates from the original HF source, the imported
+Megatron checkpoint, and the exported HF source with the same image and prompt.
 
 ```bash
-uv run python examples/conversion/hf_to_megatron_generate_vlm.py \
-  --hf_model_path mistralai/Ministral-3-3B-Instruct-2512-BF16 \
-  --megatron_model_path ${WORKSPACE}/models/Ministral-3-3B-Instruct-2512-BF16/iter_0000000 \
-  --image_path "https://huggingface.co/nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16/resolve/main/images/table.png" \
-  --prompt "Describe this image." \
-  --max_new_tokens 100
+MODEL_SIZE=3B bash examples/models/mistral/ministral3/inference.sh
+MODEL_SIZE=8B bash examples/models/mistral/ministral3/inference.sh
+MODEL_SIZE=14B bash examples/models/mistral/ministral3/inference.sh
 ```
 
-Note:
-- `--megatron_model_path` is optional. If not specified, the script will convert the model and then run forward.
-- You can also use image URLs: `--image_path="https://example.com/image.jpg"`
-
-See the [inference.sh](inference.sh) script for commands to:
-- Run inference with Hugging Face checkpoints
-- Run inference with imported Megatron checkpoints
-- Run inference with exported Hugging Face checkpoints
-
-**Expected output:**
-```
-...
-Generation step 46
-Generation step 47
-Generation step 48
-Generation step 49
-======== GENERATED TEXT OUTPUT ========
-Image: https://huggingface.co/nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16/resolve/main/images/table.png
-Prompt: Describe this image.
-Generated: <s><s>[SYSTEM_PROMPT]You are Ministral-3-3B-Instruct-2512, a Large Language Model (LLM) created by Mistral AI, a French startup headquartered in Paris.
-You power an AI assistant called Le Chat.
-Your knowledge base was last updated on 2023-10-01.
-The current date is {today}.
-...
-[IMG_END]Describe this image.[/INST]The image presents a comparison table of technical specifications between two NVIDIA GPUs: the **H100 SXM** and the **H100 NVL**.
-
-### **FPU Performance (Floating-Point Operations Per Second)**
-- **FP64**:
-  - H100 SXM: 34 teraFLOPS
-  - H100 NVL: 30 teraFLOPS
-- **FP64 Tensor
-=======================================
-```
+Override `IMAGE_PATH`, `PROMPT`, and `MAX_NEW_TOKENS` to use a different
+image, prompt, or generation length. Base checkpoints do not provide a chat
+template; the shared VLM helper inserts the checkpoint's image token and sends
+the raw completion-style prompt through the processor.
 
 ## Finetune Recipes
 

--- a/examples/models/mistral/ministral3/conversion.sh
+++ b/examples/models/mistral/ministral3/conversion.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2025-2026, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,24 +13,59 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Workspace directory for checkpoints and results
+set -euo pipefail
+
 WORKSPACE=${WORKSPACE:-/workspace}
+MODEL_SIZE=${MODEL_SIZE:-3B}
 
-# Note: Ministral 3 requires transformers version 5
-# uv pip install --upgrade transformers
-# Commands below use uv run --no-sync to avoid conflicts with the virtual environment.
+case "$MODEL_SIZE" in
+    3B)
+        DEFAULT_MODEL_NAME=Ministral-3-3B-Base-2512
+        DEFAULT_TP=2
+        ;;
+    8B)
+        DEFAULT_MODEL_NAME=Ministral-3-8B-Base-2512
+        DEFAULT_TP=2
+        ;;
+    14B)
+        DEFAULT_MODEL_NAME=Ministral-3-14B-Base-2512
+        DEFAULT_TP=4
+        ;;
+    *)
+        echo "Unsupported MODEL_SIZE=${MODEL_SIZE}; expected one of: 3B, 8B, 14B" >&2
+        exit 2
+        ;;
+esac
 
-# Import HF → Megatron
+HF_MODEL_ID=${HF_MODEL_ID:-mistralai/${DEFAULT_MODEL_NAME}}
+HF_MODEL_BASENAME=${HF_MODEL_ID%/}
+MODEL_NAME=${MODEL_NAME:-${HF_MODEL_BASENAME##*/}}
+MEGATRON_PATH=${MEGATRON_PATH:-${WORKSPACE}/models/${MODEL_NAME}}
+MEGATRON_LOAD_PATH=${MEGATRON_LOAD_PATH:-${MEGATRON_PATH}/iter_0000000}
+HF_EXPORT_PATH=${HF_EXPORT_PATH:-${WORKSPACE}/models/${MODEL_NAME}-hf-export}
+ROUNDTRIP_OUTPUT_DIR=${ROUNDTRIP_OUTPUT_DIR:-${WORKSPACE}/models/${MODEL_NAME}-roundtrip}
+
+TP=${TP:-$DEFAULT_TP}
+PP=${PP:-1}
+EP=${EP:-1}
+ETP=${ETP:-1}
+NPROC_PER_NODE=${NPROC_PER_NODE:-$((TP * PP * EP))}
+
+# Import HF -> Megatron.
 ./scripts/conversion/convert.sh import \
-    --hf-model mistralai/Ministral-3-3B-Instruct-2512-BF16 \
-    --megatron-path ${WORKSPACE}/models/Ministral-3-3B-Instruct-2512-BF16
+    --hf-model "$HF_MODEL_ID" \
+    --megatron-path "$MEGATRON_PATH"
 
-# Export Megatron → HF
+# Export Megatron -> HF.
 ./scripts/conversion/convert.sh export \
-    --hf-model mistralai/Ministral-3-3B-Instruct-2512-BF16 \
-    --megatron-path ${WORKSPACE}/models/Ministral-3-3B-Instruct-2512-BF16/iter_0000000 \
-    --hf-path ${WORKSPACE}/models/Ministral-3-3B-Instruct-2512-BF16-hf-export
+    --hf-model "$HF_MODEL_ID" \
+    --megatron-path "$MEGATRON_LOAD_PATH" \
+    --hf-path "$HF_EXPORT_PATH"
 
-# Round-trip validation
-uv run --no-sync python -m torch.distributed.run --nproc_per_node=8 examples/conversion/hf_megatron_roundtrip_multi_gpu.py \
-    --hf-model-id mistralai/Ministral-3-3B-Instruct-2512-BF16 --tp 2 --pp 2
+# Multi-GPU verification of the imported checkpoint and HF export.
+uv run python -m torch.distributed.run --nproc_per_node="$NPROC_PER_NODE" \
+    examples/conversion/hf_megatron_roundtrip_multi_gpu.py \
+    --hf-model-id "$HF_MODEL_ID" \
+    --megatron-load-path "$MEGATRON_LOAD_PATH" \
+    --output-dir "$ROUNDTRIP_OUTPUT_DIR" \
+    --tp "$TP" --pp "$PP" --ep "$EP" --etp "$ETP"

--- a/examples/models/mistral/ministral3/inference.sh
+++ b/examples/models/mistral/ministral3/inference.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2025-2026, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,37 +13,69 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Workspace directory for checkpoints and results
+set -euo pipefail
+
 WORKSPACE=${WORKSPACE:-/workspace}
+MODEL_SIZE=${MODEL_SIZE:-3B}
 
-# Note: Ministral 3 requires transformers version 5
-# uv pip install --upgrade transformers
-# Commands below use uv run --no-sync to avoid conflicts with the virtual environment.
+case "$MODEL_SIZE" in
+    3B)
+        DEFAULT_MODEL_NAME=Ministral-3-3B-Base-2512
+        DEFAULT_TP=2
+        ;;
+    8B)
+        DEFAULT_MODEL_NAME=Ministral-3-8B-Base-2512
+        DEFAULT_TP=2
+        ;;
+    14B)
+        DEFAULT_MODEL_NAME=Ministral-3-14B-Base-2512
+        DEFAULT_TP=4
+        ;;
+    *)
+        echo "Unsupported MODEL_SIZE=${MODEL_SIZE}; expected one of: 3B, 8B, 14B" >&2
+        exit 2
+        ;;
+esac
 
-# Inference with Hugging Face checkpoints
-uv run --no-sync python -m torch.distributed.run --nproc_per_node=4 examples/conversion/hf_to_megatron_generate_vlm.py \
-    --hf_model_path mistralai/Ministral-3-3B-Instruct-2512-BF16 \
-    --image_path "https://huggingface.co/nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16/resolve/main/images/table.png" \
-    --prompt "Describe this image." \
-    --max_new_tokens 100 \
-    --tp 2 \
-    --pp 2
+HF_MODEL_ID=${HF_MODEL_ID:-mistralai/${DEFAULT_MODEL_NAME}}
+HF_MODEL_BASENAME=${HF_MODEL_ID%/}
+MODEL_NAME=${MODEL_NAME:-${HF_MODEL_BASENAME##*/}}
+MEGATRON_MODEL_PATH=${MEGATRON_MODEL_PATH:-${WORKSPACE}/models/${MODEL_NAME}/iter_0000000}
+HF_EXPORT_PATH=${HF_EXPORT_PATH:-${WORKSPACE}/models/${MODEL_NAME}-hf-export}
 
-# Inference with imported Megatron checkpoints
-uv run --no-sync python -m torch.distributed.run --nproc_per_node=4 examples/conversion/hf_to_megatron_generate_vlm.py \
-    --hf_model_path mistralai/Ministral-3-3B-Instruct-2512-BF16 \
-    --megatron_model_path ${WORKSPACE}/models/Ministral-3-3B-Instruct-2512-BF16/iter_0000000 \
-    --image_path "https://huggingface.co/nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16/resolve/main/images/table.png" \
-    --prompt "Describe this image." \
-    --max_new_tokens 100 \
-    --tp 2 \
-    --pp 2
+TP=${TP:-$DEFAULT_TP}
+PP=${PP:-1}
+EP=${EP:-1}
+ETP=${ETP:-1}
+NPROC_PER_NODE=${NPROC_PER_NODE:-$((TP * PP * EP))}
+MAX_NEW_TOKENS=${MAX_NEW_TOKENS:-32}
+PROMPT=${PROMPT:-"The image shows"}
+IMAGE_PATH=${IMAGE_PATH:-"https://huggingface.co/nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16/resolve/main/images/table.png"}
 
-# Inference with exported HF checkpoints
-uv run --no-sync python -m torch.distributed.run --nproc_per_node=4 examples/conversion/hf_to_megatron_generate_vlm.py \
-    --hf_model_path ${WORKSPACE}/models/Ministral-3-3B-Instruct-2512-BF16-hf-export \
-    --image_path "https://huggingface.co/nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16/resolve/main/images/table.png" \
-    --prompt "Describe this image." \
-    --max_new_tokens 100 \
-    --tp 2 \
-    --pp 2
+# Generate after converting the original HF checkpoint in memory.
+uv run python -m torch.distributed.run --nproc_per_node="$NPROC_PER_NODE" \
+    examples/conversion/hf_to_megatron_generate_vlm.py \
+    --hf_model_path "$HF_MODEL_ID" \
+    --image_path "$IMAGE_PATH" \
+    --prompt "$PROMPT" \
+    --max_new_tokens "$MAX_NEW_TOKENS" \
+    --tp "$TP" --pp "$PP" --ep "$EP" --etp "$ETP"
+
+# Generate from the imported Megatron checkpoint.
+uv run python -m torch.distributed.run --nproc_per_node="$NPROC_PER_NODE" \
+    examples/conversion/hf_to_megatron_generate_vlm.py \
+    --hf_model_path "$HF_MODEL_ID" \
+    --megatron_model_path "$MEGATRON_MODEL_PATH" \
+    --image_path "$IMAGE_PATH" \
+    --prompt "$PROMPT" \
+    --max_new_tokens "$MAX_NEW_TOKENS" \
+    --tp "$TP" --pp "$PP" --ep "$EP" --etp "$ETP"
+
+# Generate after converting the exported HF checkpoint in memory.
+uv run python -m torch.distributed.run --nproc_per_node="$NPROC_PER_NODE" \
+    examples/conversion/hf_to_megatron_generate_vlm.py \
+    --hf_model_path "$HF_EXPORT_PATH" \
+    --image_path "$IMAGE_PATH" \
+    --prompt "$PROMPT" \
+    --max_new_tokens "$MAX_NEW_TOKENS" \
+    --tp "$TP" --pp "$PP" --ep "$EP" --etp "$ETP"

--- a/examples/models/mistral/mistral/README.md
+++ b/examples/models/mistral/mistral/README.md
@@ -1,0 +1,34 @@
+# Mistral 7B examples
+
+These scripts run the full checkpoint-conversion and generation smoke workflow
+for the original Mistral text models. They default to
+`mistralai/Mistral-7B-v0.1` and can target another compatible variant by
+setting `MODEL_NAME` or a complete `HF_MODEL_ID`.
+
+## Conversion
+
+Set a checkpoint workspace, then run the import, export, and multi-GPU
+round-trip verification:
+
+```bash
+WORKSPACE=/workspace bash examples/models/mistral/mistral/conversion.sh
+```
+
+The default layout is two GPUs with tensor parallelism 2. To use another
+valid layout, set `TP`, `PP`, `EP`, `ETP`, and `NPROC_PER_NODE` together.
+
+## Inference
+
+After conversion, run generation from the original Hugging Face checkpoint,
+the imported Megatron checkpoint, and the exported Hugging Face checkpoint:
+
+```bash
+WORKSPACE=/workspace bash examples/models/mistral/mistral/inference.sh
+```
+
+`PROMPT` and `MAX_NEW_TOKENS` are configurable. For example:
+
+```bash
+PROMPT="Once upon a time" MAX_NEW_TOKENS=64 \
+  bash examples/models/mistral/mistral/inference.sh
+```

--- a/examples/models/mistral/mistral/conversion.sh
+++ b/examples/models/mistral/mistral/conversion.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2025-2026, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,10 +15,8 @@
 
 set -euo pipefail
 
-# Workspace directory for checkpoints and results
 WORKSPACE=${WORKSPACE:-/workspace}
-
-HF_MODEL_ID=${HF_MODEL_ID:-inclusionAI/${MODEL_NAME:-Ling-mini-2.0}}
+HF_MODEL_ID=${HF_MODEL_ID:-mistralai/${MODEL_NAME:-Mistral-7B-v0.1}}
 MODEL_NAME=${MODEL_NAME:-${HF_MODEL_ID##*/}}
 MEGATRON_PATH=${MEGATRON_PATH:-${WORKSPACE}/models/${MODEL_NAME}}
 MEGATRON_LOAD_PATH=${MEGATRON_LOAD_PATH:-${MEGATRON_PATH}/iter_0000000}
@@ -27,22 +25,20 @@ ROUNDTRIP_OUTPUT_DIR=${ROUNDTRIP_OUTPUT_DIR:-${WORKSPACE}/models/${MODEL_NAME}-r
 
 TP=${TP:-2}
 PP=${PP:-1}
-EP=${EP:-4}
+EP=${EP:-1}
 ETP=${ETP:-1}
 NPROC_PER_NODE=${NPROC_PER_NODE:-$((TP * PP * EP))}
 
-# Import HF → Megatron
-./scripts/conversion/convert.sh import \
+# Import HF -> Megatron.
+uv run python examples/conversion/convert_checkpoints.py import \
     --hf-model "$HF_MODEL_ID" \
-    --megatron-path "$MEGATRON_PATH" \
-    --trust-remote-code
+    --megatron-path "$MEGATRON_PATH"
 
-# Export Megatron → HF
-./scripts/conversion/convert.sh export \
+# Export Megatron -> HF.
+uv run python examples/conversion/convert_checkpoints.py export \
     --hf-model "$HF_MODEL_ID" \
     --megatron-path "$MEGATRON_LOAD_PATH" \
-    --hf-path "$HF_EXPORT_PATH" \
-    --trust-remote-code
+    --hf-path "$HF_EXPORT_PATH"
 
 # Multi-GPU verification of the imported checkpoint and HF export.
 uv run python -m torch.distributed.run --nproc_per_node="$NPROC_PER_NODE" \
@@ -50,5 +46,4 @@ uv run python -m torch.distributed.run --nproc_per_node="$NPROC_PER_NODE" \
     --hf-model-id "$HF_MODEL_ID" \
     --megatron-load-path "$MEGATRON_LOAD_PATH" \
     --output-dir "$ROUNDTRIP_OUTPUT_DIR" \
-    --tp "$TP" --pp "$PP" --ep "$EP" --etp "$ETP" \
-    --trust-remote-code
+    --tp "$TP" --pp "$PP" --ep "$EP" --etp "$ETP"

--- a/examples/models/mistral/mistral/inference.sh
+++ b/examples/models/mistral/mistral/inference.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2025-2026, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,45 +15,41 @@
 
 set -euo pipefail
 
-# Workspace directory for checkpoints and results
 WORKSPACE=${WORKSPACE:-/workspace}
-HF_MODEL_ID=${HF_MODEL_ID:-inclusionAI/${MODEL_NAME:-Ling-mini-2.0}}
+HF_MODEL_ID=${HF_MODEL_ID:-mistralai/${MODEL_NAME:-Mistral-7B-v0.1}}
 MODEL_NAME=${MODEL_NAME:-${HF_MODEL_ID##*/}}
 MEGATRON_MODEL_PATH=${MEGATRON_MODEL_PATH:-${WORKSPACE}/models/${MODEL_NAME}/iter_0000000}
 HF_EXPORT_PATH=${HF_EXPORT_PATH:-${WORKSPACE}/models/${MODEL_NAME}-hf-export}
 
 TP=${TP:-2}
 PP=${PP:-1}
-EP=${EP:-4}
+EP=${EP:-1}
 ETP=${ETP:-1}
 NPROC_PER_NODE=${NPROC_PER_NODE:-$((TP * PP * EP))}
 MAX_NEW_TOKENS=${MAX_NEW_TOKENS:-32}
 PROMPT=${PROMPT:-"The capital of France is"}
 
-# Inference with Hugging Face checkpoints
+# Generate after converting the original HF checkpoint in memory.
 uv run python -m torch.distributed.run --nproc_per_node="$NPROC_PER_NODE" \
     examples/conversion/hf_to_megatron_generate_text.py \
     --hf_model_path "$HF_MODEL_ID" \
     --prompt "$PROMPT" \
     --max_new_tokens "$MAX_NEW_TOKENS" \
-    --tp "$TP" --pp "$PP" --ep "$EP" --etp "$ETP" \
-    --trust-remote-code
+    --tp "$TP" --pp "$PP" --ep "$EP" --etp "$ETP"
 
-# Inference with imported Megatron checkpoints
+# Generate from the imported Megatron checkpoint.
 uv run python -m torch.distributed.run --nproc_per_node="$NPROC_PER_NODE" \
     examples/conversion/hf_to_megatron_generate_text.py \
     --hf_model_path "$HF_MODEL_ID" \
     --megatron_model_path "$MEGATRON_MODEL_PATH" \
     --prompt "$PROMPT" \
     --max_new_tokens "$MAX_NEW_TOKENS" \
-    --tp "$TP" --pp "$PP" --ep "$EP" --etp "$ETP" \
-    --trust-remote-code
+    --tp "$TP" --pp "$PP" --ep "$EP" --etp "$ETP"
 
-# Inference with exported HF checkpoints
+# Generate after converting the exported HF checkpoint in memory.
 uv run python -m torch.distributed.run --nproc_per_node="$NPROC_PER_NODE" \
     examples/conversion/hf_to_megatron_generate_text.py \
     --hf_model_path "$HF_EXPORT_PATH" \
     --prompt "$PROMPT" \
     --max_new_tokens "$MAX_NEW_TOKENS" \
-    --tp "$TP" --pp "$PP" --ep "$EP" --etp "$ETP" \
-    --trust-remote-code
+    --tp "$TP" --pp "$PP" --ep "$EP" --etp "$ETP"

--- a/examples/models/nemotron/nemotron_3/nano/inference.sh
+++ b/examples/models/nemotron/nemotron_3/nano/inference.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+WORKSPACE=${WORKSPACE:-/workspace}
+MODEL_NAME=${MODEL_NAME:-NVIDIA-Nemotron-3-Nano-30B-A3B-Base-BF16}
+HF_MODEL_ID=${HF_MODEL_ID:-nvidia/${MODEL_NAME}}
+MEGATRON_MODEL_PATH=${MEGATRON_MODEL_PATH:-${WORKSPACE}/models/${MODEL_NAME}/iter_0000000}
+HF_EXPORT_PATH=${HF_EXPORT_PATH:-${WORKSPACE}/models/${MODEL_NAME}-hf-export}
+
+TP=${TP:-1}
+PP=${PP:-1}
+EP=${EP:-8}
+ETP=${ETP:-1}
+NPROC_PER_NODE=${NPROC_PER_NODE:-$((TP * PP * EP))}
+MAX_NEW_TOKENS=${MAX_NEW_TOKENS:-32}
+PROMPT=${PROMPT:-"The capital of France is"}
+
+# Gate 4: Generate after converting the original HF checkpoint in memory.
+uv run python -m torch.distributed.run --nproc_per_node="$NPROC_PER_NODE" \
+    examples/conversion/hf_to_megatron_generate_text.py \
+    --hf_model_path "$HF_MODEL_ID" \
+    --prompt "$PROMPT" \
+    --max_new_tokens "$MAX_NEW_TOKENS" \
+    --tp "$TP" --pp "$PP" --ep "$EP" --etp "$ETP"
+
+# Gate 5: Generate from the imported Megatron checkpoint.
+uv run python -m torch.distributed.run --nproc_per_node="$NPROC_PER_NODE" \
+    examples/conversion/hf_to_megatron_generate_text.py \
+    --hf_model_path "$HF_MODEL_ID" \
+    --megatron_model_path "$MEGATRON_MODEL_PATH" \
+    --prompt "$PROMPT" \
+    --max_new_tokens "$MAX_NEW_TOKENS" \
+    --tp "$TP" --pp "$PP" --ep "$EP" --etp "$ETP"
+
+# Gate 6: Generate after converting the exported HF checkpoint in memory.
+uv run python -m torch.distributed.run --nproc_per_node="$NPROC_PER_NODE" \
+    examples/conversion/hf_to_megatron_generate_text.py \
+    --hf_model_path "$HF_EXPORT_PATH" \
+    --prompt "$PROMPT" \
+    --max_new_tokens "$MAX_NEW_TOKENS" \
+    --tp "$TP" --pp "$PP" --ep "$EP" --etp "$ETP"

--- a/src/megatron/bridge/models/conversion/model_bridge.py
+++ b/src/megatron/bridge/models/conversion/model_bridge.py
@@ -1079,8 +1079,9 @@ class MegatronModelBridge(
 
         _hf_import_cache: Dict[str, torch.Tensor] = {}
         for task in self._with_progress_tracking(hf_to_megatron_tasks, description):
-            # None means megatron module not on current rank, skip if this task is not going to happen
-            if task.megatron_module is None:
+            # None means task has no mapping (build_conversion_tasks leaves None in the list)
+            # or megatron module not on current rank — skip in both cases.
+            if task is None or task.megatron_module is None:
                 continue
             # 1) Fetch source tensor(s) from HF state dict, with caching for grouped mappings
             hf_param_key = str(task.mapping.hf_param)
@@ -1207,8 +1208,8 @@ class MegatronModelBridge(
             conversion_tasks = self.build_conversion_tasks(hf_pretrained, megatron_model)
 
         for task in conversion_tasks:
-            # None means megatron module not on current rank, skip if this task is not going to happen
-            if task.megatron_module is None:
+            # None means task has no mapping or megatron module not on current rank.
+            if task is None or task.megatron_module is None:
                 continue
             hf_state_dict: Mapping[str, torch.Tensor] = hf_pretrained.state
             if isinstance(task.mapping.hf_param, str):

--- a/src/megatron/bridge/models/ernie/ernie_45_bridge.py
+++ b/src/megatron/bridge/models/ernie/ernie_45_bridge.py
@@ -233,9 +233,10 @@ class Ernie45Bridge(MegatronModelBridge):
         # flag is irrelevant; for training it will be enabled whenever
         # the required extensions are present.
 
-        # Disable MTP (Multi-Token Prediction) for inference -- the ERNIE HF
-        # model stores num_nextn_predict_layers in config but does not ship
-        # MTP weights, so we must not create MTP layers in Megatron.
+        # Disable MTP (Multi-Token Prediction) for conversion and inference.
+        # The PT checkpoint stores MTP weights but they are pre-training-only;
+        # Stage 1 validation only requires the main model weights.
+        # Export uses --not-strict so the 12 missing MTP tensors are warnings.
         provider.mtp_num_layers = None
 
         # Determine which layers are dense vs MoE.

--- a/src/megatron/bridge/models/ernie/ernie_45_bridge.py
+++ b/src/megatron/bridge/models/ernie/ernie_45_bridge.py
@@ -34,7 +34,7 @@ from megatron.bridge.models.conversion.param_mapping import (
 from megatron.bridge.models.gpt_provider import GPTModelProvider
 
 
-def _ernie45_decoder_block_spec(config: "GPTModelProvider", vp_stage: int | None = None):
+def ernie45_decoder_block_spec(config: "GPTModelProvider", vp_stage: int | None = None):
     """Create a decoder block spec that respects ``moe_layer_freq``.
 
     The default ``GPTModelProvider.transformer_layer_spec`` calls
@@ -196,7 +196,7 @@ class Ernie45Bridge(MegatronModelBridge):
         # Mixed dense/MoE layers (layer 0 dense, rest MoE): use decoder
         # block spec that parses moe_layer_freq per-layer instead of the
         # default spec which applies MoE uniformly to all layers.
-        provider.transformer_layer_spec = _ernie45_decoder_block_spec
+        provider.transformer_layer_spec = ernie45_decoder_block_spec
 
         # --- MoE settings (ERNIE uses non-standard HF config field names) ---
         num_experts = self._get_num_experts(hf_config)

--- a/src/megatron/bridge/models/ernie_vl/modeling_ernie45_vl/model.py
+++ b/src/megatron/bridge/models/ernie_vl/modeling_ernie45_vl/model.py
@@ -60,17 +60,57 @@ from megatron.bridge.utils.common_utils import hook_hf_module_setattr_for_tp_gra
 
 
 def _normalize_hf_config(hf_config):
-    """Ensure the HF config has a ``text_config`` attribute.
+    """Ensure the HF config has a ``text_config`` attribute and that it supports
+    attribute access (not a plain dict).
 
-    The transformers-builtin ``Ernie4_5_VLMoeVariableResolutionResamplerModel`` accesses
-    ``config.text_config.hidden_size`` and ``config.text_config.rms_norm_eps``.  The
-    nested config (Instruct model) has ``text_config`` as a sub-object, but the flat
-    config (Thinking model) stores all LLM fields directly on the top-level config.
-
-    For flat configs, we set ``text_config`` to point to the config itself so that
-    ``config.text_config.hidden_size`` resolves to ``config.hidden_size``.
+    When the model is reconstructed from run_config.yaml, NeMo Run instantiates the
+    outer HF config correctly via its ``_target_`` key. However, the nested
+    ``text_config`` sub-field may be deserialized as a plain Python dict (because HF's
+    ``PretrainedConfig.__init__`` does not convert dict kwargs to config objects).
+    This function ensures ``text_config`` supports attribute access by converting it
+    to a ``SimpleNamespace`` when needed.
     """
-    if hf_config is not None and not hasattr(hf_config, "text_config"):
+    if hf_config is None:
+        return hf_config
+
+    import types as _types
+
+    def _to_ns(obj):
+        if isinstance(obj, dict):
+            return _types.SimpleNamespace(**{k: _to_ns(v) for k, v in obj.items()})
+        if isinstance(obj, list):
+            return [_to_ns(x) for x in obj]
+        return obj
+
+    # Handle the case where hf_config itself is a dict or OmegaConf DictConfig
+    # (e.g. when OmegaConf deserializes without a _target_ key)
+    _is_dict_like = isinstance(hf_config, dict)
+    if not _is_dict_like:
+        try:
+            from omegaconf import OmegaConf
+
+            if OmegaConf.is_config(hf_config):
+                hf_config = OmegaConf.to_container(hf_config, resolve=True)
+                _is_dict_like = True
+        except ImportError:
+            pass
+    if _is_dict_like:
+        hf_config = _to_ns(hf_config)
+
+    # Handle the common case where hf_config is a proper HF PretrainedConfig object
+    # but its nested text_config was deserialized as a plain dict.
+    text_config = getattr(hf_config, "text_config", None)
+    if isinstance(text_config, dict):
+        try:
+            hf_config.text_config = _to_ns(text_config)
+        except (AttributeError, TypeError):
+            # If we can't set the attribute (e.g. frozen config), wrap hf_config
+            pass
+
+    # For flat configs (Thinking/auto_map) that don't have a text_config sub-object,
+    # set text_config to point to hf_config itself so that config.text_config.hidden_size
+    # resolves to hf_config.hidden_size.
+    if not hasattr(hf_config, "text_config"):
         hf_config.text_config = hf_config
     return hf_config
 
@@ -289,9 +329,9 @@ class Ernie45VLModel(MegatronModule):
             # 1. Vision config: DFNRopeVisionTransformerConfig may lack rms_norm_eps,
             #    intermediate_size, temporal_merge_size.
             _normalize_vision_config(config.vision_config, hf_config=config.hf_config)
-            # 2. HF config: flat config (Thinking) lacks text_config sub-object
-            #    that the resampler accesses as config.text_config.hidden_size, etc.
-            _normalize_hf_config(config.hf_config)
+            # 2. HF config: flat config (Thinking) lacks text_config sub-object;
+            #    also converts OmegaConf DictConfig to SimpleNamespace for attribute access.
+            _normalized_hf_cfg = _normalize_hf_config(config.hf_config)
 
             if self.use_mg_vit:
                 # Megatron-Core native ViT: TP-native attention and MLP via
@@ -319,7 +359,9 @@ class Ernie45VLModel(MegatronModule):
             # Instantiate the HF resampler (spatial + temporal merging + projection).
             # The resampler is kept as an HF module regardless of use_mg_vit because
             # it is small, replicated, and already has bridge weight mappings.
-            self.resampler_model = Ernie4_5_VLMoeVariableResolutionResamplerModel(config.hf_config)
+            # _normalize_hf_config above already converts any dict-typed text_config
+            # to SimpleNamespace so that .text_config.hidden_size attribute access works.
+            self.resampler_model = Ernie4_5_VLMoeVariableResolutionResamplerModel(_normalized_hf_cfg)
             hook_hf_module_setattr_for_tp_grad_sync(self.resampler_model)
 
         # Build the Megatron-Core GPT language model

--- a/src/megatron/bridge/models/gemma/gemma4_provider.py
+++ b/src/megatron/bridge/models/gemma/gemma4_provider.py
@@ -36,9 +36,9 @@ from megatron.bridge.models.gemma.modeling_gemma4 import (
     Gemma4OutputLayer,
     Gemma4RotaryEmbedding,
     _attach_ple_modules,
-    _gemma4_block_spec,
     _install_ple_forward,
     _install_tied_kv,
+    gemma4_block_spec,
     get_gemma4_layer_spec,
     wire_gemma4_kv_sharing,
 )
@@ -320,7 +320,7 @@ class Gemma4ModelProvider(GPTModelProvider):
 
     flash_decode: bool = False
     transformer_layer_spec: Union[Callable, object] = field(
-        default_factory=lambda: partial(_gemma4_block_spec, use_transformer_engine=HAVE_TE)
+        default_factory=lambda: partial(gemma4_block_spec, use_transformer_engine=HAVE_TE)
     )
     scatter_embedding_sequence_parallel: bool = True
 

--- a/src/megatron/bridge/models/gemma/modeling_gemma4.py
+++ b/src/megatron/bridge/models/gemma/modeling_gemma4.py
@@ -1503,7 +1503,7 @@ def _install_tied_kv(model: "torch.nn.Module", provider: "Gemma4ModelProvider") 
         attn._tied_kv = True
 
 
-def _gemma4_block_spec(config, use_transformer_engine=True, **kwargs):
+def gemma4_block_spec(config, use_transformer_engine=True, **kwargs):
     """Build Gemma 4 MoE block spec with patched attention, layer, and MoE modules."""
     block_spec = get_gpt_decoder_block_spec(config, use_transformer_engine=use_transformer_engine, **kwargs)
 

--- a/src/megatron/bridge/models/gemma_vl/gemma3_vl_bridge.py
+++ b/src/megatron/bridge/models/gemma_vl/gemma3_vl_bridge.py
@@ -104,6 +104,18 @@ class Gemma3VLBridge(MegatronModelBridge):
         # Return MegatronMappingRegistry containing parameter mappings from Megatron to HF format
         # First create simple 1:1 parameter mappings using a dictionary for readability
 
+        # Gemma3 checkpoints exist with both the legacy SigLIP wrapper namespace
+        # (vision_tower.vision_model.*) and the current flattened namespace
+        # (vision_tower.*). Preserve the namespace exposed by the source state when
+        # it is available; config-only bridges continue to target the current form.
+        vision_hf_param = "vision_tower.**"
+        hf_state = getattr(getattr(self, "hf_pretrained", None), "state", None)
+        state_source = getattr(hf_state, "source", None)
+        if state_source is not None:
+            hf_keys = state_source.get_all_keys()
+            if any(key.startswith("vision_tower.vision_model.") for key in hf_keys):
+                vision_hf_param = "vision_tower.vision_model.**"
+
         # Dictionary maps Megatron parameter names -> HF parameter names
         # Supports wildcard (*) patterns for layer-specific parameters
         param_mappings = {
@@ -135,7 +147,7 @@ class Gemma3VLBridge(MegatronModelBridge):
             [
                 ReplicatedMapping(
                     megatron_param="vision_tower.**",
-                    hf_param="vision_tower.**",
+                    hf_param=vision_hf_param,
                 ),
                 AutoMapping(
                     megatron_param="multi_modal_projector.proj.weight",

--- a/src/megatron/bridge/models/glm/glm47_flash_bridge.py
+++ b/src/megatron/bridge/models/glm/glm47_flash_bridge.py
@@ -25,13 +25,14 @@ by the runtime model, so the DeepSeek common mapping list works directly.
 """
 
 from functools import partial
+from typing import Mapping
 
 import torch
 from megatron.core.models.gpt.gpt_layer_specs import get_gpt_decoder_block_spec
 from megatron.core.models.gpt.gpt_model import GPTModel
 
 from megatron.bridge.models.conversion.mapping_registry import MegatronMappingRegistry
-from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge
+from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge, WeightConversionTask
 from megatron.bridge.models.deepseek.common import get_common_mapping_list
 from megatron.bridge.models.hf_pretrained.causal_lm import PreTrainedCausalLM
 from megatron.bridge.models.mla_provider import MLAModelProvider
@@ -111,3 +112,38 @@ class GLM47FlashBridge(MegatronModelBridge):
         hf_config = getattr(self, "hf_config", None)
         mapping_list = get_common_mapping_list(hf_config=hf_config)
         return MegatronMappingRegistry(*mapping_list)
+
+    def maybe_modify_converted_hf_weight(
+        self,
+        task: WeightConversionTask,
+        converted_weights_dict: dict[str, torch.Tensor],
+        hf_state_dict: Mapping[str, torch.Tensor],
+    ) -> dict[str, torch.Tensor]:
+        """Restore GLM MTP embedding and output aliases on HF export."""
+        converted_weights_dict = super().maybe_modify_converted_hf_weight(
+            task,
+            converted_weights_dict,
+            hf_state_dict,
+        )
+
+        hf_config = getattr(self, "hf_config", None)
+        if hf_config is None:
+            return converted_weights_dict
+
+        num_hidden_layers = hf_config.num_hidden_layers
+        num_mtp_layers = getattr(hf_config, "num_nextn_predict_layers", 0)
+        alias_specs = (
+            ("model.embed_tokens.weight", "model.layers.{}.embed_tokens.weight"),
+            ("lm_head.weight", "model.layers.{}.shared_head.head.weight"),
+        )
+        for source_name, alias_template in alias_specs:
+            if source_name not in converted_weights_dict:
+                continue
+
+            source_weight = converted_weights_dict[source_name]
+            for mtp_layer in range(num_mtp_layers):
+                alias_name = alias_template.format(num_hidden_layers + mtp_layer)
+                if alias_name not in converted_weights_dict:
+                    converted_weights_dict[alias_name] = source_weight.clone()
+
+        return converted_weights_dict

--- a/src/megatron/bridge/models/hybrid/hybrid_provider.py
+++ b/src/megatron/bridge/models/hybrid/hybrid_provider.py
@@ -32,6 +32,7 @@ from megatron.core.post_training.modelopt.hybrid.model_specs import get_hybrid_s
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.ssm.mamba_hybrid_layer_allocation import Symbols, get_hybrid_total_layer_count, parse_hybrid_pattern
 from megatron.core.transformer import ModuleSpec
+from megatron.core.transformer.dot_product_attention import DotProductAttention
 from megatron.core.transformer.enums import AttnBackend
 
 from megatron.bridge.models.model_provider import ModelProviderMixin
@@ -262,6 +263,13 @@ class HybridModelProvider(TransformerConfig, ModelProviderMixin[MCoreHybridModel
                 resolved_spec = hybrid_stack_spec()
         else:
             resolved_spec = hybrid_stack_spec
+
+        if self.attention_backend in {AttnBackend.local, "local"}:
+            resolved_spec = copy.deepcopy(resolved_spec)
+            attention_layer = getattr(resolved_spec.submodules, "attention_layer", None)
+            if attention_layer is not None:
+                attention_layer.submodules.self_attention.submodules.core_attention = DotProductAttention
+
         return _configure_mamba_chunk_size(resolved_spec, self.mamba_chunk_size)
 
     def provide(self, pre_process=None, post_process=None, vp_stage=None) -> MCoreHybridModel:

--- a/src/megatron/bridge/models/hybrid/hybrid_provider.py
+++ b/src/megatron/bridge/models/hybrid/hybrid_provider.py
@@ -32,7 +32,6 @@ from megatron.core.post_training.modelopt.hybrid.model_specs import get_hybrid_s
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.ssm.mamba_hybrid_layer_allocation import Symbols, get_hybrid_total_layer_count, parse_hybrid_pattern
 from megatron.core.transformer import ModuleSpec
-from megatron.core.transformer.dot_product_attention import DotProductAttention
 from megatron.core.transformer.enums import AttnBackend
 
 from megatron.bridge.models.model_provider import ModelProviderMixin
@@ -265,6 +264,8 @@ class HybridModelProvider(TransformerConfig, ModelProviderMixin[MCoreHybridModel
             resolved_spec = hybrid_stack_spec
 
         if self.attention_backend in {AttnBackend.local, "local"}:
+            from megatron.core.transformer.dot_product_attention import DotProductAttention
+
             resolved_spec = copy.deepcopy(resolved_spec)
             attention_layer = getattr(resolved_spec.submodules, "attention_layer", None)
             if attention_layer is not None:

--- a/src/megatron/bridge/models/llama/llama_bridge.py
+++ b/src/megatron/bridge/models/llama/llama_bridge.py
@@ -13,12 +13,14 @@
 # limitations under the License.
 
 import logging
+from collections.abc import Mapping
 
+import torch
 from megatron.core.models.gpt.gpt_model import GPTModel
 from transformers import LlamaForCausalLM
 
 from megatron.bridge.models.conversion.mapping_registry import MegatronMappingRegistry
-from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge
+from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge, WeightConversionTask
 from megatron.bridge.models.conversion.param_mapping import (
     AutoMapping,
     GatedMLPMapping,
@@ -148,3 +150,38 @@ class LlamaBridge(MegatronModelBridge):
         )
 
         return MegatronMappingRegistry(*mapping_list)
+
+    def maybe_modify_converted_hf_weight(
+        self,
+        task: WeightConversionTask,
+        converted_weights_dict: dict[str, torch.Tensor],
+        hf_state_dict: Mapping[str, torch.Tensor],
+    ) -> dict[str, torch.Tensor]:
+        """Preserve persisted Llama rotary inverse-frequency buffers on export."""
+        input_layernorm_key = next(
+            (
+                name
+                for name in converted_weights_dict
+                if name.startswith("model.layers.") and name.endswith(".input_layernorm.weight")
+            ),
+            None,
+        )
+        if input_layernorm_key is None:
+            return converted_weights_dict
+
+        parts = input_layernorm_key.split(".")
+        if len(parts) < 5 or not parts[2].isdigit():
+            return converted_weights_dict
+
+        layer_idx = int(parts[2])
+        inv_freq_key = f"model.layers.{layer_idx}.self_attn.rotary_emb.inv_freq"
+        if inv_freq_key not in hf_state_dict or inv_freq_key in converted_weights_dict:
+            return converted_weights_dict
+
+        inv_freq = hf_state_dict[inv_freq_key]
+        reference_tensor = next(iter(converted_weights_dict.values()), None)
+        if reference_tensor is not None:
+            inv_freq = inv_freq.to(reference_tensor.device)
+
+        converted_weights_dict[inv_freq_key] = inv_freq
+        return converted_weights_dict

--- a/src/megatron/bridge/models/ministral3/ministral3_bridge.py
+++ b/src/megatron/bridge/models/ministral3/ministral3_bridge.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2025-2026, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -92,6 +92,12 @@ class Ministral3Bridge(MegatronModelBridge):
 
         # Ministral 3 has separate text_config and vision_config
         text_config = getattr(hf_config, "text_config", hf_config)
+        tie_word_embeddings = getattr(text_config, "tie_word_embeddings", False)
+        # Transformers supplies a top-level default for composite configs even
+        # when the checkpoint declares the effective value only in text_config.
+        # Keep the config copied by save_hf_pretrained consistent with the
+        # language model and its exported lm_head.
+        hf_config.tie_word_embeddings = tie_word_embeddings
         params_dtype = self.dtype_from_hf(hf_config, default=torch.float32)
         provider = Ministral3ModelProvider(
             hidden_size=text_config.hidden_size,
@@ -101,7 +107,7 @@ class Ministral3Bridge(MegatronModelBridge):
             num_query_groups=text_config.num_key_value_heads,
             kv_channels=text_config.head_dim,
             seq_length=text_config.max_position_embeddings,
-            share_embeddings_and_output_weights=getattr(hf_config, "tie_word_embeddings", False),
+            share_embeddings_and_output_weights=tie_word_embeddings,
             rotary_base=text_config.rope_parameters["rope_theta"],
             vocab_size=text_config.vocab_size,
             params_dtype=params_dtype,
@@ -117,10 +123,11 @@ class Ministral3Bridge(MegatronModelBridge):
     def megatron_to_hf_config(cls, provider: Ministral3ModelProvider) -> dict[str, object]:
         """Convert a Ministral 3 provider to its nested HuggingFace config layout."""
         text_config = super().megatron_to_hf_config(provider)
-        top_level_keys = ("architectures", "model_type", "tie_word_embeddings")
+        top_level_keys = ("architectures", "model_type")
         hf_config = {key: text_config.pop(key) for key in top_level_keys if key in text_config}
         if "torch_dtype" in text_config:
             hf_config["dtype"] = text_config.pop("torch_dtype")
+        hf_config["tie_word_embeddings"] = text_config.get("tie_word_embeddings", False)
         hf_config["text_config"] = text_config
         return hf_config
 

--- a/tests/unit_tests/examples/test_hf_megatron_roundtrip_multi_gpu.py
+++ b/tests/unit_tests/examples/test_hf_megatron_roundtrip_multi_gpu.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the multi-GPU Hugging Face/Megatron round-trip CLI."""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+
+import pytest
+
+
+pytestmark = pytest.mark.unit
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+_CLI_PATH = _REPO_ROOT / "examples" / "conversion" / "hf_megatron_roundtrip_multi_gpu.py"
+
+
+@pytest.fixture(scope="module")
+def cli():
+    """Load the round-trip example as a module under a stable test name."""
+    spec = importlib.util.spec_from_file_location("hf_megatron_roundtrip_multi_gpu_under_test", _CLI_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    try:
+        spec.loader.exec_module(module)
+        yield module
+    finally:
+        sys.modules.pop(spec.name, None)
+
+
+@pytest.mark.parametrize(("extra_args", "expected_strict"), [([], True), (["--not-strict"], False)])
+def test_cli_forwards_export_strictness(cli, monkeypatch, extra_args, expected_strict):
+    """The CLI is strict by default and loosens export only when requested."""
+    calls = []
+    monkeypatch.setattr(cli, "main", lambda *args, **kwargs: calls.append((args, kwargs)))
+    monkeypatch.setattr(cli.torch.distributed, "is_initialized", lambda: False)
+
+    cli._run_cli(["--hf-model-id", "org/model", *extra_args])
+
+    assert len(calls) == 1
+    assert calls[0][1]["strict"] is expected_strict

--- a/tests/unit_tests/models/gemma/test_gemma4_modeling.py
+++ b/tests/unit_tests/models/gemma/test_gemma4_modeling.py
@@ -42,7 +42,6 @@ from megatron.bridge.models.gemma.modeling_gemma4 import (
     Gemma4TransformerLayer,
     _attach_ple_modules,
     _compute_per_layer_inputs,
-    _gemma4_block_spec,
     _gemma4_checkpointed_forward,
     _gemma4_layer_input,
     _install_ple_forward,
@@ -50,6 +49,7 @@ from megatron.bridge.models.gemma.modeling_gemma4 import (
     _is_gemma4_sliding_layer,
     _logit_softcapping,
     _patch_ple_block_threading,
+    gemma4_block_spec,
     get_gemma4_layer_spec,
     wire_gemma4_kv_sharing,
 )
@@ -1831,7 +1831,7 @@ class TestGemma4MoEHelpers:
             fake_get_gpt_decoder_block_spec,
         )
 
-        out = _gemma4_block_spec("config", use_transformer_engine=True, extra="value")
+        out = gemma4_block_spec("config", use_transformer_engine=True, extra="value")
 
         assert out is block_spec
         assert calls == [("config", True, {"extra": "value"})]
@@ -1858,7 +1858,7 @@ class TestGemma4MoEHelpers:
             lambda *args, **kwargs: SimpleNamespace(layer_specs=[layer_spec]),
         )
 
-        _gemma4_block_spec("config", use_transformer_engine=True)
+        gemma4_block_spec("config", use_transformer_engine=True)
 
         assert layer_spec.submodules.mlp.func is Gemma4MoELayer
         assert layer_spec.submodules.mlp.keywords["submodules"].router is Gemma4TopKRouter
@@ -1879,7 +1879,7 @@ class TestGemma4MoEHelpers:
             lambda *args, **kwargs: SimpleNamespace(layer_specs=[layer_spec]),
         )
 
-        _gemma4_block_spec("config", use_transformer_engine=False)
+        gemma4_block_spec("config", use_transformer_engine=False)
 
         assert layer_spec.module is Gemma4TransformerLayer
         assert attn_submodules.core_attention is Gemma4TEDotProductAttention

--- a/tests/unit_tests/models/gemma_vl/test_gemma3_vl_bridge.py
+++ b/tests/unit_tests/models/gemma_vl/test_gemma3_vl_bridge.py
@@ -274,6 +274,20 @@ class TestGemma3VLBridgeMappingRegistry:
         assert str(mapping.megatron_param) == "vision_tower.embeddings.patch_embedding.bias"
         assert str(mapping.hf_param) == "vision_tower.embeddings.patch_embedding.bias"
 
+    def test_mapping_registry_accepts_legacy_checkpoint_vision_tower_keys(self, gemma3_vl_bridge):
+        """Test mapping_registry preserves the nested namespace in legacy Gemma3 checkpoints."""
+        gemma3_vl_bridge.hf_pretrained = Mock()
+        gemma3_vl_bridge.hf_pretrained.state.source.get_all_keys.return_value = {
+            "vision_tower.vision_model.embeddings.patch_embedding.bias",
+        }
+
+        registry = gemma3_vl_bridge.mapping_registry()
+        mapping = registry.hf_to_megatron_lookup("vision_tower.vision_model.embeddings.patch_embedding.bias")
+
+        assert mapping is not None
+        assert str(mapping.megatron_param) == "vision_tower.embeddings.patch_embedding.bias"
+        assert str(mapping.hf_param) == "vision_tower.vision_model.embeddings.patch_embedding.bias"
+
     def test_mapping_registry_multimodal_projector_params(self, gemma3_vl_bridge):
         """Test mapping_registry handles multimodal projector parameters correctly."""
         registry = gemma3_vl_bridge.mapping_registry()

--- a/tests/unit_tests/models/glm/test_glm47_flash_bridge.py
+++ b/tests/unit_tests/models/glm/test_glm47_flash_bridge.py
@@ -159,3 +159,53 @@ class TestGLM47FlashBridge:
         assert "mtp.layers.0.eh_proj.weight" in megatron_params
         assert "mtp.layers.0.final_layernorm.weight" in megatron_params
         assert "mtp.layers.0.mtp_model_layer.mlp.router.expert_bias" in megatron_params
+
+    @pytest.mark.parametrize(
+        ("source_name", "alias_name"),
+        [
+            (
+                "model.embed_tokens.weight",
+                "model.layers.47.embed_tokens.weight",
+            ),
+            (
+                "lm_head.weight",
+                "model.layers.47.shared_head.head.weight",
+            ),
+        ],
+    )
+    def test_export_restores_mtp_alias_weights(
+        self,
+        glm47_flash_config,
+        source_name,
+        alias_name,
+    ):
+        """Test export restores the duplicated MTP embedding and output weights."""
+        bridge = GLM47FlashBridge()
+        bridge.hf_config = glm47_flash_config
+        source_weight = torch.randn(4, 4)
+        converted_weights = {source_name: source_weight}
+
+        result = bridge.maybe_modify_converted_hf_weight(
+            SimpleNamespace(global_param_name="checkpoint.model." + source_name),
+            converted_weights,
+            {},
+        )
+
+        torch.testing.assert_close(result[alias_name], source_weight)
+        assert result[alias_name].data_ptr() != source_weight.data_ptr()
+
+    def test_export_does_not_add_mtp_alias_when_mtp_is_disabled(self, glm47_flash_config):
+        """Test export leaves checkpoints without MTP layers unchanged."""
+        bridge = GLM47FlashBridge()
+        bridge.hf_config = SimpleNamespace(**{**vars(glm47_flash_config), "num_nextn_predict_layers": 0})
+        source_weight = torch.randn(4, 4)
+        converted_weights = {"model.embed_tokens.weight": source_weight}
+
+        result = bridge.maybe_modify_converted_hf_weight(
+            SimpleNamespace(global_param_name="embedding.word_embeddings.weight"),
+            converted_weights,
+            {},
+        )
+
+        assert set(result) == {"model.embed_tokens.weight"}
+        assert result["model.embed_tokens.weight"] is source_weight

--- a/tests/unit_tests/models/hybrid/test_hybrid_provider.py
+++ b/tests/unit_tests/models/hybrid/test_hybrid_provider.py
@@ -16,7 +16,10 @@ from unittest.mock import Mock, patch
 
 import pytest
 import torch
+from megatron.core.extensions.transformer_engine import TEDotProductAttention
 from megatron.core.transformer import ModuleSpec
+from megatron.core.transformer.dot_product_attention import DotProductAttention
+from megatron.core.transformer.enums import AttnBackend
 
 from megatron.bridge.models.hybrid import hybrid_provider
 from megatron.bridge.models.hybrid.hybrid_provider import HybridModelProvider
@@ -172,6 +175,40 @@ class TestHybridModelProvider:
         spec_call_kwarg = mock_model.call_args.kwargs["hybrid_stack_spec"]
         assert isinstance(spec_call_kwarg, Mock)
         assert spec_call_kwarg.info == "custom spec"
+
+    def test_local_attention_clones_stack_spec_and_uses_mcore_attention(self):
+        provider = HybridModelProvider(
+            num_layers=2,
+            hidden_size=128,
+            num_attention_heads=1,
+            attention_backend=AttnBackend.local,
+        )
+
+        resolved_spec = provider._resolve_hybrid_stack_spec()
+        resolved_core_attention = (
+            resolved_spec.submodules.attention_layer.submodules.self_attention.submodules.core_attention
+        )
+        default_core_attention = hybrid_provider.default_hybrid_stack_spec.submodules.attention_layer.submodules.self_attention.submodules.core_attention
+
+        assert resolved_spec is not hybrid_provider.default_hybrid_stack_spec
+        assert resolved_core_attention is DotProductAttention
+        assert default_core_attention is TEDotProductAttention
+
+    def test_non_local_attention_keeps_transformer_engine_stack_spec(self):
+        provider = HybridModelProvider(
+            num_layers=2,
+            hidden_size=128,
+            num_attention_heads=1,
+            attention_backend=AttnBackend.flash,
+        )
+
+        resolved_spec = provider._resolve_hybrid_stack_spec()
+        resolved_core_attention = (
+            resolved_spec.submodules.attention_layer.submodules.self_attention.submodules.core_attention
+        )
+
+        assert resolved_spec is hybrid_provider.default_hybrid_stack_spec
+        assert resolved_core_attention is TEDotProductAttention
 
     def test_finalize_uses_compatible_hybrid_layer_count(self):
         provider = HybridModelProvider(

--- a/tests/unit_tests/models/hybrid/test_hybrid_provider.py
+++ b/tests/unit_tests/models/hybrid/test_hybrid_provider.py
@@ -176,12 +176,13 @@ class TestHybridModelProvider:
         assert isinstance(spec_call_kwarg, Mock)
         assert spec_call_kwarg.info == "custom spec"
 
-    def test_local_attention_clones_stack_spec_and_uses_mcore_attention(self):
+    @pytest.mark.parametrize("attention_backend", [AttnBackend.local, "local"])
+    def test_local_attention_clones_stack_spec_and_uses_mcore_attention(self, attention_backend):
         provider = HybridModelProvider(
             num_layers=2,
             hidden_size=128,
             num_attention_heads=1,
-            attention_backend=AttnBackend.local,
+            attention_backend=attention_backend,
         )
 
         resolved_spec = provider._resolve_hybrid_stack_spec()

--- a/tests/unit_tests/models/llama/test_llama_bridge.py
+++ b/tests/unit_tests/models/llama/test_llama_bridge.py
@@ -636,6 +636,32 @@ class TestLlamaBridgeMappingRegistry:
         assert mapping is not None
         assert mapping.hf_param == "model.norm.weight"
 
+    def test_export_preserves_persisted_rotary_inv_freq(self):
+        """Test that Llama 2 rotary buffers are copied from the source checkpoint."""
+        bridge = LlamaBridge()
+        task = Mock(global_param_name="decoder.layers.3.self_attention.linear_qkv.layer_norm_weight")
+        converted = {"model.layers.3.input_layernorm.weight": torch.ones(4096)}
+        inv_freq_key = "model.layers.3.self_attn.rotary_emb.inv_freq"
+        source_inv_freq = torch.tensor([1.0, 0.25, 0.03125], dtype=torch.float32)
+
+        result = bridge.maybe_modify_converted_hf_weight(
+            task,
+            converted,
+            {inv_freq_key: source_inv_freq},
+        )
+
+        torch.testing.assert_close(result[inv_freq_key], source_inv_freq, rtol=0, atol=0)
+
+    def test_export_does_not_add_unpersisted_rotary_inv_freq(self):
+        """Test that modern Llama checkpoints without persisted RoPE buffers are unchanged."""
+        bridge = LlamaBridge()
+        task = Mock(global_param_name="decoder.layers.3.self_attention.linear_qkv.layer_norm_weight")
+        converted = {"model.layers.3.input_layernorm.weight": torch.ones(4096)}
+
+        result = bridge.maybe_modify_converted_hf_weight(task, converted, {})
+
+        assert set(result) == {"model.layers.3.input_layernorm.weight"}
+
 
 class TestAutoBridgeIntegration:
     """Integration tests for AutoBridge with Llama models."""

--- a/tests/unit_tests/models/ministral3/test_ministral3_bridge.py
+++ b/tests/unit_tests/models/ministral3/test_ministral3_bridge.py
@@ -117,17 +117,19 @@ class TestMinistral3BridgeProviderBridge:
         # Should set hf_config
         assert provider.hf_config is mock_hf_pretrained.config
 
-    def test_provider_bridge_tie_word_embeddings(self, ministral3_bridge, mock_hf_pretrained):
-        """Test provider_bridge handles tie_word_embeddings correctly."""
-        # Test with tie_word_embeddings=True
-        mock_hf_pretrained.config.tie_word_embeddings = True
-        provider = ministral3_bridge.provider_bridge(mock_hf_pretrained)
-        assert provider.share_embeddings_and_output_weights is True
+    @pytest.mark.parametrize("text_tie_word_embeddings", [True, False])
+    def test_provider_bridge_tie_word_embeddings(
+        self, ministral3_bridge, mock_hf_pretrained, text_tie_word_embeddings
+    ):
+        """The nested language config controls input/output embedding sharing."""
+        mock_hf_pretrained.config.tie_word_embeddings = not text_tie_word_embeddings
+        mock_hf_pretrained.config.text_config.tie_word_embeddings = text_tie_word_embeddings
 
-        # Test with tie_word_embeddings=False
-        mock_hf_pretrained.config.tie_word_embeddings = False
         provider = ministral3_bridge.provider_bridge(mock_hf_pretrained)
-        assert provider.share_embeddings_and_output_weights is False
+
+        assert provider.share_embeddings_and_output_weights is text_tie_word_embeddings
+        assert mock_hf_pretrained.config.tie_word_embeddings is text_tie_word_embeddings
+        assert provider.hf_config.tie_word_embeddings is text_tie_word_embeddings
 
     def test_provider_bridge_with_custom_vocab_size(self, ministral3_bridge, mock_hf_pretrained):
         """Test provider_bridge with custom vocabulary size."""
@@ -360,43 +362,40 @@ class TestMinistral3BridgeCompatibility:
             provider = ministral3_bridge.provider_bridge(mock_hf_pretrained)
             assert provider.vocab_size == vocab_size
 
-    def test_provider_bridge_3b_config(self, ministral3_bridge, mock_hf_pretrained):
-        """Test provider_bridge with 3B model configuration."""
-        mock_hf_pretrained.config.text_config.num_hidden_layers = 26
-        mock_hf_pretrained.config.text_config.hidden_size = 3072
-        mock_hf_pretrained.config.text_config.intermediate_size = 9216
+    @pytest.mark.parametrize(
+        "num_layers,hidden_size,ffn_hidden_size,rope_theta,tie_word_embeddings",
+        [
+            (26, 3072, 9216, 1000000.0, True),
+            (34, 4096, 14336, 1000000.0, False),
+            (40, 5120, 16384, 1000000000.0, False),
+        ],
+        ids=["3b", "8b", "14b"],
+    )
+    def test_provider_bridge_exact_base_size_configs(
+        self,
+        ministral3_bridge,
+        mock_hf_pretrained,
+        num_layers,
+        hidden_size,
+        ffn_hidden_size,
+        rope_theta,
+        tie_word_embeddings,
+    ):
+        """Map the architecture and embedding-sharing values of each Base size."""
+        text_config = mock_hf_pretrained.config.text_config
+        text_config.num_hidden_layers = num_layers
+        text_config.hidden_size = hidden_size
+        text_config.intermediate_size = ffn_hidden_size
+        text_config.rope_parameters["rope_theta"] = rope_theta
+        text_config.tie_word_embeddings = tie_word_embeddings
 
         provider = ministral3_bridge.provider_bridge(mock_hf_pretrained)
 
-        assert provider.num_layers == 26
-        assert provider.hidden_size == 3072
-        assert provider.ffn_hidden_size == 9216
-
-    def test_provider_bridge_8b_config(self, ministral3_bridge, mock_hf_pretrained):
-        """Test provider_bridge with 8B model configuration."""
-        mock_hf_pretrained.config.text_config.num_hidden_layers = 34
-        mock_hf_pretrained.config.text_config.hidden_size = 4096
-        mock_hf_pretrained.config.text_config.intermediate_size = 14336
-
-        provider = ministral3_bridge.provider_bridge(mock_hf_pretrained)
-
-        assert provider.num_layers == 34
-        assert provider.hidden_size == 4096
-        assert provider.ffn_hidden_size == 14336
-
-    def test_provider_bridge_14b_config(self, ministral3_bridge, mock_hf_pretrained):
-        """Test provider_bridge with 14B model configuration."""
-        mock_hf_pretrained.config.text_config.num_hidden_layers = 40
-        mock_hf_pretrained.config.text_config.hidden_size = 5120
-        mock_hf_pretrained.config.text_config.intermediate_size = 16384
-        mock_hf_pretrained.config.text_config.rope_parameters["rope_theta"] = 1000000000.0
-
-        provider = ministral3_bridge.provider_bridge(mock_hf_pretrained)
-
-        assert provider.num_layers == 40
-        assert provider.hidden_size == 5120
-        assert provider.ffn_hidden_size == 16384
-        assert provider.rotary_base == 1000000000.0
+        assert provider.num_layers == num_layers
+        assert provider.hidden_size == hidden_size
+        assert provider.ffn_hidden_size == ffn_hidden_size
+        assert provider.rotary_base == rope_theta
+        assert provider.share_embeddings_and_output_weights is tie_word_embeddings
 
     def test_provider_bridge_uses_composite_config_contract(self, ministral3_bridge):
         """Test the real composite config maps text dimensions and top-level fields."""
@@ -440,7 +439,7 @@ class TestMinistral3BridgeCompatibility:
         assert provider.kv_channels == hf_config.text_config.head_dim
         assert provider.seq_length == hf_config.text_config.max_position_embeddings
         assert provider.vocab_size == hf_config.text_config.vocab_size
-        assert provider.share_embeddings_and_output_weights is hf_config.tie_word_embeddings
+        assert provider.share_embeddings_and_output_weights is hf_config.text_config.tie_word_embeddings
         assert provider.params_dtype == torch.float16
         assert provider.fp16 is True
         assert provider.bf16 is False
@@ -545,6 +544,10 @@ class TestMinistral3BridgeCompatibility:
         assert synthesized_config.architectures == ["Mistral3ForConditionalGeneration"]
         assert synthesized_config.model_type == "mistral3"
         assert synthesized_config.tie_word_embeddings is checkpoint_provider.share_embeddings_and_output_weights
+        assert (
+            synthesized_config.text_config.tie_word_embeddings
+            is checkpoint_provider.share_embeddings_and_output_weights
+        )
         assert synthesized_config.dtype == checkpoint_provider.params_dtype
 
         assert synthesized_config.image_token_index == reference_config.image_token_index
@@ -555,7 +558,6 @@ class TestMinistral3BridgeCompatibility:
         assert synthesized_config.text_config.model_type == reference_config.text_config.model_type
         assert synthesized_config.text_config.rope_parameters == reference_rope_parameters
         assert synthesized_config.text_config.sliding_window == reference_config.text_config.sliding_window
-        assert synthesized_config.text_config.tie_word_embeddings is reference_config.text_config.tie_word_embeddings
         assert synthesized_config.text_config.use_cache is reference_config.text_config.use_cache
         assert synthesized_config.vision_config.to_dict() == reference_vision_config
 
@@ -563,7 +565,7 @@ class TestMinistral3BridgeCompatibility:
         assert synthesized_provider.num_attention_heads == checkpoint_provider.num_attention_heads
         assert synthesized_provider.num_query_groups == checkpoint_provider.num_query_groups
         assert synthesized_provider.kv_channels == checkpoint_provider.kv_channels
-        assert synthesized_provider.share_embeddings_and_output_weights is False
+        assert synthesized_provider.share_embeddings_and_output_weights is True
         assert synthesized_provider.params_dtype == torch.bfloat16
         assert synthesized_provider.fp16 is False
         assert synthesized_provider.bf16 is True

--- a/tests/unit_tests/utils/test_vlm_generate_utils.py
+++ b/tests/unit_tests/utils/test_vlm_generate_utils.py
@@ -132,6 +132,78 @@ class TestProcessMultiImageInputs:
 class TestProcessImageInputs:
     """Tests for ``process_image_inputs``."""
 
+    def test_base_processor_without_chat_template_uses_raw_image_prompt(self):
+        """Base VLMs without a chat template should receive an image-token prompt."""
+        image = mock.MagicMock(name="image")
+        rgb_image = mock.MagicMock(name="rgb_image")
+        image.convert.return_value = rgb_image
+
+        inputs = mock.MagicMock()
+        inputs.input_ids = torch.tensor([[10, 20]])
+        inputs.get.side_effect = lambda key: {
+            "pixel_values": "PIXELS",
+            "image_sizes": "IMAGE_SIZES",
+        }.get(key)
+
+        proc = mock.MagicMock()
+        proc.chat_template = None
+        proc.image_token = "[IMG]"
+        proc.return_value = inputs
+
+        with (
+            mock.patch.object(vlm_generate_utils, "_HAS_QWEN_VL_UTILS", False),
+            mock.patch.object(vlm_generate_utils, "load_image", return_value=image) as load_image_mock,
+        ):
+            result = vlm_generate_utils.process_image_inputs(proc, "/image.png", "describe", is_mistral3=True)
+
+        load_image_mock.assert_called_once_with("/image.png")
+        image.convert.assert_called_once_with("RGB")
+        proc.assert_called_once_with(
+            text=["[IMG]\ndescribe"],
+            images=[rgb_image],
+            padding=True,
+            return_tensors="pt",
+        )
+        assert len(result) == 6
+        input_ids, pixel_values, image_grid_thw, image_sizes, mm_token_type_ids, image_position_ids = result
+        torch.testing.assert_close(input_ids, torch.tensor([[10, 20]]))
+        assert pixel_values == "PIXELS"
+        assert image_grid_thw is None
+        assert image_sizes == "IMAGE_SIZES"
+        assert mm_token_type_ids is None
+        assert image_position_ids is None
+
+    def test_base_processor_preserves_existing_image_token(self):
+        """Do not inject a second image token when the prompt already contains one."""
+        image = mock.MagicMock()
+        image.convert.return_value = "RGB"
+        inputs = mock.MagicMock()
+        inputs.input_ids = torch.tensor([[1]])
+        inputs.get.return_value = None
+
+        proc = mock.MagicMock()
+        proc.chat_template = None
+        proc.image_token = "[IMG]"
+        proc.return_value = inputs
+
+        with mock.patch.object(vlm_generate_utils, "load_image", return_value=image):
+            vlm_generate_utils.process_image_inputs(proc, "/image.png", "[IMG]\ncaption", is_mistral3=True)
+
+        proc.assert_called_once_with(
+            text=["[IMG]\ncaption"],
+            images=["RGB"],
+            padding=True,
+            return_tensors="pt",
+        )
+
+    def test_unrecognized_processor_without_chat_template_fails_clearly(self):
+        """Do not apply the Ministral raw-prompt convention to other VLMs."""
+        proc = mock.MagicMock()
+        proc.chat_template = None
+
+        with pytest.raises(ValueError, match="no model-specific raw-prompt fallback"):
+            vlm_generate_utils.process_image_inputs(proc, "/image.png", "describe")
+
     def test_kimi_image_path_returns_full_six_field_contract(self):
         """Kimi image preprocessing must match the VLM generation unpack contract."""
         inputs = mock.MagicMock()


### PR DESCRIPTION
# What does this PR do ?

on top of https://github.com/NVIDIA-NeMo/Megatron-Bridge/pull/4805

Stage 1 full-checkpoint conversion and inference validation for Ernie 4.5 MoE, Ernie 4.5 VL, Gemma 4 (26B MoE / 31B dense / 26B VL), Qwen3 Next 80B, Qwen3-Omni, Moonlight, and Llama 3.3 70B — bringing the tracker from 33 PASS to 41 PASS. Includes targeted fixes for Gemma 4 / MCore 26.08 API compatibility, Ernie VL config deserialization, Llama rotary buffer preservation, GLM MTP alias restoration, and hybrid model local-attention support.

related links: 
https://linear.app/nvidia/issue/MB-575/por-track-model-support-verification-levels
https://linear.app/nvidia/issue/MB-745/stage-1-full-model-conversion-and-inference-validation-48-models-6


# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
