### PR TITLE
[data] fix: honor seed during offline packing

### DIFF
--- a/src/megatron/bridge/data/packing/offline.py
+++ b/src/megatron/bridge/data/packing/offline.py
@@ -267,8 +267,13 @@ def prepare_gpt_sft_packed_data(
     )
     sequences, histogram = create_hist(dataset, max_seq_length)
 
-    assignments, packing_metadata = create_packing_strategy(histogram, packed_sequence_size, packing_algorithm)
-    output_data = fill_packing_strategy(assignments, sequences, packed_sequence_size, tokenizer.eos_id)
+    random_state = np.random.get_state()
+    np.random.seed(seed)
+    try:
+        assignments, packing_metadata = create_packing_strategy(histogram, packed_sequence_size, packing_algorithm)
+        output_data = fill_packing_strategy(assignments, sequences, packed_sequence_size, tokenizer.eos_id)
+    finally:
+        np.random.set_state(random_state)
 
     # save output data
     output_path_str = str(output_path)

--- a/tests/unit_tests/data/packing/test_offline.py
+++ b/tests/unit_tests/data/packing/test_offline.py
@@ -15,6 +15,7 @@
 from pathlib import Path
 from types import SimpleNamespace
 
+import numpy as np
 import pytest
 import torch
 
@@ -22,11 +23,56 @@ from megatron.bridge.data.packing.offline import (
     _init_shared_dataset_worker,
     _materialize_dataset_items,
     _pre_pad_data_point,
+    prepare_gpt_sft_packed_data,
     tokenize_dataset,
 )
 
 
 PAD_ID = 0
+
+
+def test_configured_seed_controls_offline_packing(monkeypatch):
+    """Identical input and configured seed must produce identical packed rows."""
+
+    class TinyDataset:
+        tokenizer = SimpleNamespace(eod=PAD_ID)
+        pad_seq_length_to_mult = 1
+
+        def __init__(self):
+            runtime_lengths = (6, 6, 4, 4)
+            self.items = [
+                {
+                    "input_ids": [sample_id * 10 + token_id for token_id in range(runtime_length + 1)],
+                    "loss_mask": [True] * (runtime_length + 1),
+                }
+                for sample_id, runtime_length in enumerate(runtime_lengths)
+            ]
+
+        def __len__(self):
+            return len(self.items)
+
+        def __getitem__(self, index):
+            return self.items[index]
+
+    def prepare_with_ambient_seed(ambient_seed):
+        packed_outputs = []
+        np.random.seed(ambient_seed)
+        monkeypatch.setattr(np, "save", lambda _, rows: packed_outputs.append(rows))
+        prepare_gpt_sft_packed_data(
+            input_path=Path("unused.jsonl"),
+            output_path=Path("unused.npy"),
+            output_metadata_path=None,
+            packed_sequence_size=10,
+            tokenizer=SimpleNamespace(eos_id=PAD_ID),
+            max_seq_length=10,
+            seed=777,
+            packing_algorithm="first_fit_shuffle",
+            num_tokenizer_workers=1,
+            dataset_builder=lambda *args, **kwargs: TinyDataset(),
+        )
+        return packed_outputs[0]
+
+    assert prepare_with_ambient_seed(0) == prepare_with_ambient_seed(4)
 
 
 def test_pre_pad_data_point_chat_tensors_do_not_raise():


### PR DESCRIPTION
## What does this PR do?

Offline GPT SFT packing now uses the configured dataset seed for both randomized packing steps. Previously, `first_fit_shuffle` and the same-length permutation consumed ambient NumPy state, so identical inputs and `seed=777` could produce different groupings and even different packed-row counts depending on unrelated earlier NumPy calls. That makes offline-packed training and the cached artifact non-reproducible through supported builder and standalone-script paths.

Related context: #4351 expects deterministic seed-driven index preparation but does not fix this offline-packing path.

## Root cause and fix

`prepare_gpt_sft_packed_data` passed `seed` into dataset tokenization but not into the module-global NumPy draws used by `create_packing_strategy` and `fill_packing_strategy`.

The fix snapshots NumPy's global state, seeds the two packing operations with the configured value, and restores the caller's state in a `finally` block. This keeps the existing APIs and packing algorithms unchanged.

## Validation

The new regression test runs identical input and configured seed under two different ambient NumPy states.

- Before the fix: `uv run python -m pytest tests/unit_tests/data/packing/test_offline.py::test_configured_seed_controls_offline_packing -q` — **failed**; one run produced 2 packed rows and the other produced 3.
- After the fix: the same command — **1 passed**.
- Adjacent tests: `uv run python -m pytest tests/unit_tests/data/packing/test_algorithms.py tests/unit_tests/data/packing/test_offline.py tests/unit_tests/data/builders/test_gpt_sft_config.py tests/unit_tests/data/builders/test_gpt_sft_builder.py tests/unit_tests/scripts/test_prepare_gpt_sft_packed_data.py -q` — **67 passed**.
- `git diff --check` — passed.
- `uv run pre-commit run --all-files` — passed.

## Scope

This changes only CPU-side offline GPT SFT materialization. It does not change public APIs, packing algorithms, GPU/distributed execution, or make claims about model quality, convergence, or performance.
