### PR TITLE
[ckpt] fix: restore RNG state when future saves disable it

### DIFF
--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -1913,7 +1913,8 @@ def generate_state_dict(
 
     # Optimizer stuff. During load, optimizer sharded-state scaffolding is
     # required even if the next checkpoint should not save optimizer state.
-    include_optimizer_state = ckpt_cfg.save_optim or bool((optim_sd_kwargs or {}).get("is_loading"))
+    is_loading = bool((optim_sd_kwargs or {}).get("is_loading"))
+    include_optimizer_state = ckpt_cfg.save_optim or is_loading
     if include_optimizer_state:
         if optimizer is not None and not getattr(optimizer, "is_stub_optimizer", False):
             if ckpt_cfg.ckpt_format == "torch_dist":
@@ -1935,7 +1936,7 @@ def generate_state_dict(
         state_dict["rerun_state_machine"] = rerun_state
 
     # RNG states.
-    if ckpt_cfg.save_rng:
+    if ckpt_cfg.save_rng or (is_loading and rng_state is not None):
         state_dict["rng_state"] = rng_state
 
     return state_dict

--- a/tests/unit_tests/training/test_checkpointing.py
+++ b/tests/unit_tests/training/test_checkpointing.py
@@ -3561,6 +3561,37 @@ class TestFSDPDTensorFunctionality:
         assert result["opt_param_scheduler"] == {"scheduler": "state"}
         mock_optimizer.sharded_state_dict.assert_called_once()
 
+    @pytest.mark.parametrize("ckpt_format", ["torch_dist", "fsdp_dtensor"])
+    @pytest.mark.parametrize(
+        "is_loading,has_rng_scaffold,expected_rng_state",
+        [(True, True, True), (True, False, False), (False, True, False)],
+    )
+    def test_generate_state_dict_includes_rng_scaffold_only_when_loading(
+        self, ckpt_format, is_loading, has_rng_scaffold, expected_rng_state
+    ):
+        """Load-time RNG scaffolding should not depend on save_rng."""
+        from megatron.bridge.training.checkpointing import generate_state_dict
+
+        mock_model = Mock()
+        mock_model.sharded_state_dict.return_value = {"test_param": torch.tensor([1.0])}
+        mock_model.state_dict_for_save_checkpoint.return_value = {"test_param": torch.tensor([1.0])}
+        mock_rng_state = Mock() if has_rng_scaffold else None
+        optim_sd_kwargs = {"is_loading": True} if is_loading else None
+
+        ckpt_cfg = CheckpointConfig(ckpt_format=ckpt_format, save_rng=False)
+        result = generate_state_dict(
+            ckpt_cfg=ckpt_cfg,
+            model=[mock_model],
+            optimizer=None,
+            opt_param_scheduler=None,
+            rng_state=mock_rng_state,
+            optim_sd_kwargs=optim_sd_kwargs,
+        )
+
+        assert ("rng_state" in result) is expected_rng_state
+        if expected_rng_state:
+            assert result["rng_state"] is mock_rng_state
+
 
 class TestCheckpointPathOverride:
     """Test checkpoint_path_override parameter in loading functions."""


### PR DESCRIPTION
## Summary

Restore RNG state when resuming a persistent checkpoint with `load_rng=True` while the new run uses `save_rng=False`.

## User impact and root cause

`load_rng` and `save_rng` are independent checkpoint controls. A supported run can restore RNG continuity from an existing checkpoint while omitting RNG state from future saves.

The load path created the required RNG sharded-state scaffold, but `generate_state_dict` retained it only when the new run's `save_rng` setting was enabled. Distributed checkpoint loading therefore could not populate the saved RNG state. Finalization then attempted the legacy RNG keys and terminated the resume path.

## Fix

Treat state-dictionary generation as a load when its existing `is_loading` metadata is set, and include RNG only when a real load scaffold is present. Normal saves with `save_rng=False` and loads with RNG restoration disabled continue to omit the key.

The regression matrix covers `torch_dist` and `fsdp_dtensor` with:

- load-time RNG scaffold present;
- load-time RNG scaffold absent;
- normal save with `save_rng=False`.

## Validation

Failing before the production fix:

```text
uv run python -m pytest tests/unit_tests/training/test_checkpointing.py -k 'test_generate_state_dict_includes_rng_scaffold_only_when_loading' -q
# 1 failed, 1 passed (the original torch_dist reproduction)
```

Passing after the fix and expanded backend/control coverage:

```text
uv run python -m pytest tests/unit_tests/training/test_checkpointing.py -k 'test_generate_state_dict_includes_rng_scaffold_only_when_loading' -q
# 6 passed

uv run python -m pytest tests/unit_tests/training/test_checkpointing.py -k 'RNGState or includes_optimizer_scaffold_when_loading or includes_rng_scaffold_only_when_loading or load_checkpoint_from_path' -q
# 11 passed

git diff --check
# passed

uv run pre-commit run --all-files
# passed
```

## Scope

This changes only checkpoint state-dictionary scaffold selection and its focused unit coverage. It does not change checkpoint configuration defaults, public APIs, dependencies, conversion behavior, or the pinned Megatron-Core revision.
