### PR TITLE
chore(skills): remove Open Plugin manifest (superseded)

### DIFF
--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,5 +1,0 @@
-{
-  "name": "megatron-bridge",
-  "description": "Megatron-Bridge repository skills (CI/CD, testing, dependency bumps, performance tuning, model onboarding, multi-node Slurm) for Regent agents working on this repo.",
-  "version": "0.1.0"
-}


### PR DESCRIPTION
Revert of #4892. The CI-Events Regent `plugin-oci-builder` now **generates** the Open Plugin manifest when it packages this repo's `skills/`, so the in-repo `.plugin/plugin.json` is no longer needed. No other change.