### PR TITLE
[inference] fix: respect prompt file truncation limit

### DIFF
--- a/src/megatron/bridge/inference/text_generation.py
+++ b/src/megatron/bridge/inference/text_generation.py
@@ -99,14 +99,16 @@ def load_prompts(
     """Collect prompts from explicit args and/or a line-oriented (optionally JSONL) file."""
     collected = list(prompts or [])
     if prompt_file:
+        file_prompts_collected = 0
         with Path(prompt_file).open("r", encoding="utf-8") as handle:
             for line in handle:
                 raw_prompt = line.rstrip("\n")
                 if not raw_prompt:
                     continue
-                collected.append(_get_prompt_from_json_line(raw_prompt) or raw_prompt)
-                if prompt_file_num_truncate is not None and len(collected) >= prompt_file_num_truncate:
+                if prompt_file_num_truncate is not None and file_prompts_collected >= prompt_file_num_truncate:
                     break
+                collected.append(_get_prompt_from_json_line(raw_prompt) or raw_prompt)
+                file_prompts_collected += 1
     if not collected:
         collected = list(default_prompts)
     return collected

--- a/tests/unit_tests/scripts/test_text_generation.py
+++ b/tests/unit_tests/scripts/test_text_generation.py
@@ -270,6 +270,17 @@ def test_load_prompts_from_file_with_jsonl_and_truncate(text_generation, tmp_pat
     assert text_generation.load_prompts(None, str(prompt_file), 2, ["d"]) == ["json prompt", "raw prompt"]
 
 
+def test_load_prompts_truncates_only_file_prompts(text_generation, tmp_path):
+    prompt_file = tmp_path / "prompts.txt"
+    prompt_file.write_text("file-1\nfile-2\nfile-3\n", encoding="utf-8")
+
+    assert text_generation.load_prompts(["explicit"], str(prompt_file), 2, ["default"]) == [
+        "explicit",
+        "file-1",
+        "file-2",
+    ]
+
+
 def test_validate_sequence_length(text_generation):
     # fits -> no raise
     text_generation.validate_sequence_length(longest_prompt_tokens=100, num_new_tokens=28, max_seq_length=4096)


### PR DESCRIPTION
## Summary

- keep `--prompt-file-num-truncate` scoped to prompts read from `--prompt_file`
- preserve explicit prompts when both supported prompt sources are combined
- add a focused regression for the mixed-source path

## Supported trigger and impact

Both synchronous and asynchronous generation accept `--prompt`, `--prompt_file`, and `--prompt-file-num-truncate`. With one explicit prompt, a file containing at least two rows, and a file limit of two, the loader returned only the explicit prompt and the first file row.

That silently dropped requested generation inputs and could produce incomplete batch or evaluation output without an error.

## Root cause

`load_prompts` initializes its result with explicit prompts, but used the combined result length to enforce the file-only limit. Explicit prompts therefore consumed file quota. The fix tracks accepted nonblank file prompts independently.

## Regression evidence

Fail-before on `82b47ab85b3a05185476a6df297d15e75d5a8f3a`:

```text
uv run --no-sync python -m pytest --confcutdir=tests/unit_tests/scripts \
  tests/unit_tests/scripts/test_text_generation.py::test_load_prompts_truncates_only_file_prompts -q
# 1 failed: ['explicit', 'file-1'] != ['explicit', 'file-1', 'file-2']
```

Pass-after:

```text
uv run --no-sync python -m pytest --confcutdir=tests/unit_tests/scripts \
  tests/unit_tests/scripts/test_text_generation.py::test_load_prompts_truncates_only_file_prompts -q
# 1 passed
```

Adjacent validation:

```text
uv run --no-sync python -m pytest --confcutdir=tests/unit_tests/scripts \
  tests/unit_tests/scripts/test_text_generation.py -q
# 12 passed

git diff --check
# passed

uv run --no-sync pre-commit run --all-files
# all hooks passed
```

## Scope

This changes only shared prompt collection and its unit coverage. It does not alter model loading, tokenizer behavior, inference engines, parallelism, dependencies, or public API signatures. No full-suite, GPU inference, convergence, model-quality, or performance validation was run.