### PR TITLE
[training] fix: resume global non-persistent checkpoints

### DIFF
--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -145,6 +145,19 @@ HF_WEIGHTS_SUBDIR = "hf"
 # ============================================================================
 
 
+def _has_global_non_persistent_checkpoint(load_dir: str | None, ckpt_cfg: CheckpointConfig) -> bool:
+    """Return whether the configured global non-persistent checkpoint source exists."""
+    if ckpt_cfg.non_persistent_ckpt_type != "global":
+        return False
+
+    non_persistent_global_dir = (
+        ckpt_cfg.non_persistent_global_ckpt_dir
+        if ckpt_cfg.non_persistent_global_ckpt_dir or load_dir is None
+        else os.path.join(load_dir, _NON_PERSISTENT_CKPT_SUBDIR)
+    )
+    return checkpoint_exists(non_persistent_global_dir)
+
+
 def set_checkpoint_version(value: float) -> None:
     """Set the global checkpoint version number.
 
@@ -2172,7 +2185,12 @@ def load_checkpoint(
 
     # Finetuning directories
     pretrained_dir = cfg.checkpoint.pretrained_checkpoint
-    if pretrained_dir is not None and not (checkpoint_exists(load_dir) or is_hf_checkpoint_dir(load_dir)):
+    has_resume_checkpoint = (
+        checkpoint_exists(load_dir)
+        or is_hf_checkpoint_dir(load_dir)
+        or _has_global_non_persistent_checkpoint(load_dir, cfg.checkpoint)
+    )
+    if pretrained_dir is not None and not has_resume_checkpoint:
         print_rank_0(
             f"Checkpoint file not found in load directory {load_dir}. "
             f"Attempting to finetune with checkpoint in {pretrained_dir}"

--- a/src/megatron/bridge/training/setup.py
+++ b/src/megatron/bridge/training/setup.py
@@ -40,6 +40,7 @@ from megatron.bridge.training.callbacks import CallbackContext, CallbackManager,
 from megatron.bridge.training.checkpointing import (
     CheckpointLoadContext,
     CheckpointManager,
+    _has_global_non_persistent_checkpoint,
     _load_checkpoint_from_path,
     create_checkpoint_manager,
 )
@@ -107,11 +108,15 @@ def _should_load_checkpoint(cfg: ConfigContainer, checkpoint_manager: Checkpoint
         "local_checkpoint_manager" in checkpointing_context
         and checkpointing_context["local_checkpoint_manager"].find_latest() != -1
     )
+    has_global_non_persistent_checkpoint = _has_global_non_persistent_checkpoint(
+        cfg.checkpoint.load, cfg.checkpoint
+    )
 
     if cfg.peft is not None:
-        return cfg.checkpoint.load is not None and (
+        load_checkpoint_exists = cfg.checkpoint.load is not None and (
             checkpoint_exists(cfg.checkpoint.load) or is_hf_checkpoint_dir(cfg.checkpoint.load)
         )
+        return load_checkpoint_exists or has_global_non_persistent_checkpoint
 
     load_checkpoint_exists = cfg.checkpoint.load is not None and (
         checkpoint_exists(cfg.checkpoint.load) or is_hf_checkpoint_dir(cfg.checkpoint.load)
@@ -120,7 +125,12 @@ def _should_load_checkpoint(cfg: ConfigContainer, checkpoint_manager: Checkpoint
         checkpoint_exists(cfg.checkpoint.pretrained_checkpoint)
         or is_hf_checkpoint_dir(cfg.checkpoint.pretrained_checkpoint)
     )
-    should_load_checkpoint = load_checkpoint_exists or has_pretrained_checkpoint or has_local_checkpoint
+    should_load_checkpoint = (
+        load_checkpoint_exists
+        or has_pretrained_checkpoint
+        or has_local_checkpoint
+        or has_global_non_persistent_checkpoint
+    )
 
     if cfg._checkpoint_load_required and not should_load_checkpoint:
         raise FileNotFoundError(

--- a/tests/unit_tests/training/test_setup.py
+++ b/tests/unit_tests/training/test_setup.py
@@ -22,6 +22,7 @@ from megatron.bridge.data.builders import GPTSFTDatasetConfig
 from megatron.bridge.models.gpt.gpt_builder import GPTModelConfig
 from megatron.bridge.models.gpt_provider import GPTModelProvider
 from megatron.bridge.models.transformer_config import TransformerConfig
+from megatron.bridge.training.checkpointing import load_checkpoint
 from megatron.bridge.training.setup import (
     _bind_dataset_provider_context,
     _build_distributed_model,
@@ -45,10 +46,24 @@ def _make_gpt_model_config(**kwargs):
     return GPTModelConfig(**defaults)
 
 
-def _make_checkpoint_source_config(*, load, pretrained_checkpoint=None, required=True):
+def _make_checkpoint_source_config(
+    *,
+    load,
+    pretrained_checkpoint=None,
+    required=True,
+    non_persistent_ckpt_type=None,
+    non_persistent_global_ckpt_dir=None,
+    peft=None,
+):
     return SimpleNamespace(
-        checkpoint=SimpleNamespace(load=load, pretrained_checkpoint=pretrained_checkpoint),
-        peft=None,
+        checkpoint=SimpleNamespace(
+            load=load,
+            pretrained_checkpoint=pretrained_checkpoint,
+            non_persistent_ckpt_type=non_persistent_ckpt_type,
+            non_persistent_global_ckpt_dir=non_persistent_global_ckpt_dir,
+            finetune=False,
+        ),
+        peft=peft,
         _checkpoint_load_required=required,
     )
 
@@ -93,6 +108,41 @@ class TestShouldLoadCheckpoint:
         checkpoint_manager = SimpleNamespace(checkpointing_context={"local_checkpoint_manager": local_manager})
 
         assert _should_load_checkpoint(cfg, checkpoint_manager) is True
+
+    def test_global_non_persistent_checkpoint_reaches_checkpoint_loader(self, tmp_path):
+        load_dir = tmp_path / "checkpoints"
+        non_persistent_dir = load_dir / "non_persistent"
+        non_persistent_dir.mkdir(parents=True)
+        (non_persistent_dir / "latest_train_state.pt").touch()
+        cfg = _make_checkpoint_source_config(
+            load=str(load_dir),
+            required=False,
+            non_persistent_ckpt_type="global",
+        )
+        checkpoint_manager = SimpleNamespace(checkpointing_context={})
+
+        assert _should_load_checkpoint(cfg, checkpoint_manager) is True
+
+    @patch("megatron.bridge.training.checkpointing._load_checkpoint_from_path", return_value=(12, 0))
+    def test_peft_resume_prefers_global_non_persistent_checkpoint(self, mock_load, tmp_path):
+        load_dir = tmp_path / "checkpoints"
+        non_persistent_dir = load_dir / "non_persistent"
+        non_persistent_dir.mkdir(parents=True)
+        (non_persistent_dir / "latest_train_state.pt").touch()
+        pretrained_dir = tmp_path / "pretrained"
+        pretrained_dir.mkdir()
+        (pretrained_dir / "latest_train_state.pt").touch()
+        cfg = _make_checkpoint_source_config(
+            load=str(load_dir),
+            pretrained_checkpoint=str(pretrained_dir),
+            non_persistent_ckpt_type="global",
+            peft=object(),
+        )
+
+        load_checkpoint(SimpleNamespace(cfg=cfg), [], None, None)
+
+        assert mock_load.call_args.args[0] == str(load_dir)
+        assert cfg.checkpoint.finetune is False
 
     @patch("megatron.bridge.training.setup.checkpoint_exists", return_value=False)
     def test_hf_load_reaches_checkpoint_loader_for_targeted_error(self, _mock_exists):


### PR DESCRIPTION
## Problem

When global non-persistent checkpointing is enabled, Bridge saves recovery state under either the configured non-persistent directory or `<load>/non_persistent`. The standard setup checkpoint-source gate checked the persistent root, pretrained source, and local checkpoint manager, but not that global non-persistent source.

After a restart before the first persistent save, setup therefore skipped `CheckpointManager.load` and silently restarted training from step/sample zero. For finetuning and PEFT, the downstream loader could additionally redirect the same global-only resume to `pretrained_checkpoint`, losing optimizer, scheduler, RNG, and train-state recovery.

## Fix

Add one shared predicate whose global non-persistent directory semantics match the checkpoint loader. Use it both when setup decides whether to invoke the manager and when checkpoint loading decides whether to fall back to a pretrained source.

The change is limited to global non-persistent source discovery; persistent, Hugging Face, local non-persistent, and pretrained loading behavior is otherwise unchanged.

## Validation

Fail before:

```text
uv run python -m pytest tests/unit_tests/training/test_setup.py::TestShouldLoadCheckpoint::test_global_non_persistent_checkpoint_reaches_checkpoint_loader -q --tb=short
1 failed: setup returned False for a valid nested global non-persistent tracker
```

The PEFT routing control also failed before the downstream fix because it selected the pretrained directory instead of the configured resume directory.

Pass after:

```text
uv run python -m pytest tests/unit_tests/training/test_setup.py::TestShouldLoadCheckpoint::test_global_non_persistent_checkpoint_reaches_checkpoint_loader tests/unit_tests/training/test_setup.py::TestShouldLoadCheckpoint::test_peft_resume_prefers_global_non_persistent_checkpoint -q --tb=short
2 passed
```

Focused and adjacent:

```text
uv run python -m pytest tests/unit_tests/training/test_setup.py tests/unit_tests/training/test_checkpointing.py::TestNonPersistentCheckpoints <six focused checkpoint_exists selectors> -q --tb=short
28 passed
```

```text
uv run pre-commit run --all-files
Passed

git diff --check
Passed
```

This is a deterministic CPU source-selection defect; no GPU/distributed execution, full-suite, convergence, performance, or model-quality validation was performed.
