### PR TITLE
build(docker): make nvshmem reinstall optional in Dockerfile.ci

### DIFF
--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -18,6 +18,7 @@ WORKDIR /opt/Megatron-Bridge
 
 ARG INSTALL_DEEPEP=True
 ARG DEEPEP_COMMIT=34152ae28f80bcc3ee38d7a12cb2ad87cfd4ea72
+ARG REINSTALL_NVSHMEM=True
 
 ENV PATH="/opt/venv/bin:/opt/venv/bin:/root/.local/bin:$PATH" \
     UV_PROJECT_ENVIRONMENT=/opt/venv \
@@ -59,10 +60,12 @@ RUN --mount=type=bind,source=docker/patches/deepep.patch,target=/opt/deepep.patc
         git fetch origin $DEEPEP_COMMIT && \
         git checkout FETCH_HEAD && \
         patch -p1 < /opt/deepep.patch && \
-        pip install --no-cache-dir nvidia-nvshmem-cu13==3.6.5 && \
-        # Create symlink for libnvshmem_host.so (required for DeepEP fabric handle operations)
-        NVSHMEM_LIB_PATH=$(pip show nvidia-nvshmem-cu13 | grep "Location:" | cut -d' ' -f2)/nvidia/nvshmem/lib && \
-        ln -sf ${NVSHMEM_LIB_PATH}/libnvshmem_host.so.3 ${NVSHMEM_LIB_PATH}/libnvshmem_host.so && \
+        if [ "$REINSTALL_NVSHMEM" = "True" ]; then \
+            pip install --no-cache-dir nvidia-nvshmem-cu13==3.6.5 && \
+            # Create symlink for libnvshmem_host.so (required for DeepEP fabric handle operations)
+            NVSHMEM_LIB_PATH=$(pip show nvidia-nvshmem-cu13 | grep "Location:" | cut -d' ' -f2)/nvidia/nvshmem/lib && \
+            ln -sf ${NVSHMEM_LIB_PATH}/libnvshmem_host.so.3 ${NVSHMEM_LIB_PATH}/libnvshmem_host.so; \
+        fi && \
         apt-get update && \
         apt-get install -y --no-install-recommends libnvidia-ml-dev && \
         TORCH_CUDA_ARCH_LIST="9.0 10.0 12.0" pip install --no-cache-dir --no-build-isolation -v . && \

--- a/docker/README.md
+++ b/docker/README.md
@@ -139,6 +139,7 @@ docker build \
 | `BASE_IMAGE` | Base container; set to the fw-base image when building the full stack |
 | `INSTALL_DEEPEP` | Set to `True` to build and install DeepEP and nvshmem |
 | `DEEPEP_COMMIT` | DeepEP git commit SHA |
+| `REINSTALL_NVSHMEM` | Set to `True` to reinstall nvshmem (`nvidia-nvshmem-cu13`) over the base image version; only applied when `INSTALL_DEEPEP=True` |
 | `MCORE_TRIGGERED_TESTING` | Skip uv lockfile check for cross-version Megatron-LM testing |
 | `UV_CACHE_PRUNE_ARGS` | Extra arguments for `uv cache prune` |
 


### PR DESCRIPTION
# What does this PR do ?

 Add REINSTALL_NVSHMEM build arg (default True) gating the pip install of nvidia-nvshmem-cu13 and libnvshmem_host.so symlink inside the INSTALL_DEEPEP block, so users can opt out and rely on the base image's nvshmem.

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
