### PR TITLE
fix(model): preserve standalone conversion contracts

### DIFF
--- a/examples/conversion/hf_megatron_roundtrip_multi_gpu.py
+++ b/examples/conversion/hf_megatron_roundtrip_multi_gpu.py
@@ -265,7 +265,8 @@ def main(
             bridge.save_megatron_model(megatron_model, megatron_save_path)
 
 
-if __name__ == "__main__":
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments for the multi-GPU round-trip example."""
     parser = argparse.ArgumentParser(
         description="Convert between HuggingFace and Megatron-LM model formats on multiple GPUs"
     )
@@ -300,7 +301,12 @@ if __name__ == "__main__":
     )
     parser.add_argument("--atol", type=float, default=1e-1, help="Absolute tolerance for tensor comparison")
     parser.add_argument("--rtol", type=float, default=1e-5, help="Relative tolerance for tensor comparison")
-    args = parser.parse_args()
+    return parser.parse_args(argv)
+
+
+def _run_cli(argv: list[str] | None = None) -> None:
+    """Run the multi-GPU round-trip example from parsed CLI arguments."""
+    args = _parse_args(argv)
     main(
         args.hf_model_id,
         args.output_dir,
@@ -311,6 +317,7 @@ if __name__ == "__main__":
         args.megatron_save_path,
         args.megatron_load_path,
         args.trust_remote_code,
+        strict=not args.not_strict,
         skip_save=args.skip_save,
         atol=args.atol,
         rtol=args.rtol,
@@ -318,3 +325,7 @@ if __name__ == "__main__":
 
     if torch.distributed.is_initialized():
         torch.distributed.destroy_process_group()
+
+
+if __name__ == "__main__":
+    _run_cli()

--- a/examples/conversion/hf_to_megatron_generate_vlm.py
+++ b/examples/conversion/hf_to_megatron_generate_vlm.py
@@ -157,6 +157,7 @@ def main(args) -> None:
     if is_kimi and image_token_id is None:
         image_token_id = 163605
     is_gemma4 = "gemma4" in model_type
+    is_mistral3 = model_type == "mistral3"
 
     # ------------------------------------------------------------------
     # Load model
@@ -256,6 +257,7 @@ def main(args) -> None:
             args.prompt,
             is_gemma4=is_gemma4,
             is_kimi=is_kimi,
+            is_mistral3=is_mistral3,
             image_token_id=image_token_id,
         )
 

--- a/examples/conversion/vlm_generate_utils.py
+++ b/examples/conversion/vlm_generate_utils.py
@@ -195,6 +195,7 @@ def process_image_inputs(
     *,
     is_gemma4: bool = False,
     is_kimi: bool = False,
+    is_mistral3: bool = False,
     image_token_id: Optional[int] = None,
 ):
     """Process image + prompt into model inputs.
@@ -215,11 +216,7 @@ def process_image_inputs(
     if is_kimi:
         return _process_kimi_inputs(processor, image_path, prompt, image_token_id)
 
-    if not _HAS_QWEN_VL_UTILS:
-        raise ImportError(
-            "qwen_vl_utils is required for non-Kimi VLM image processing. Install it with: pip install qwen-vl-utils"
-        )
-    return _process_default_inputs(processor, image_path, prompt)
+    return _process_default_inputs(processor, image_path, prompt, allow_raw_prompt=is_mistral3)
 
 
 def _process_kimi_inputs(processor, image_path, prompt, image_token_id):
@@ -239,7 +236,36 @@ def _process_kimi_inputs(processor, image_path, prompt, image_token_id):
     return input_ids, inputs.pixel_values, grid_thws, None, None, None
 
 
-def _process_default_inputs(processor, image_path, prompt):
+def _process_default_inputs(processor, image_path, prompt, *, allow_raw_prompt=False):
+    if getattr(processor, "chat_template", None) is None:
+        if not allow_raw_prompt:
+            raise ValueError("The processor has no chat template and no model-specific raw-prompt fallback")
+        image = load_image(image_path).convert("RGB")
+        image_token = getattr(processor, "image_token", None) or getattr(
+            processor.tokenizer, "image_token", "<|image|>"
+        )
+        if image_token not in prompt:
+            prompt = f"{image_token}\n{prompt}"
+        inputs = processor(
+            text=[prompt],
+            images=[image],
+            padding=True,
+            return_tensors="pt",
+        )
+        return (
+            inputs.input_ids,
+            inputs.get("pixel_values"),
+            inputs.get("image_grid_thw"),
+            inputs.get("image_sizes"),
+            inputs.get("mm_token_type_ids"),
+            inputs.get("image_position_ids"),
+        )
+
+    if not _HAS_QWEN_VL_UTILS:
+        raise ImportError(
+            "qwen_vl_utils is required for chat-template VLM image processing. Install it with: pip install qwen-vl-utils"
+        )
+
     messages = [
         {
             "role": "user",

--- a/src/megatron/bridge/models/gemma_vl/gemma3_vl_bridge.py
+++ b/src/megatron/bridge/models/gemma_vl/gemma3_vl_bridge.py
@@ -104,6 +104,18 @@ class Gemma3VLBridge(MegatronModelBridge):
         # Return MegatronMappingRegistry containing parameter mappings from Megatron to HF format
         # First create simple 1:1 parameter mappings using a dictionary for readability
 
+        # Gemma3 checkpoints exist with both the legacy SigLIP wrapper namespace
+        # (vision_tower.vision_model.*) and the current flattened namespace
+        # (vision_tower.*). Preserve the namespace exposed by the source state when
+        # it is available; config-only bridges continue to target the current form.
+        vision_hf_param = "vision_tower.**"
+        hf_state = getattr(getattr(self, "hf_pretrained", None), "state", None)
+        state_source = getattr(hf_state, "source", None)
+        if state_source is not None:
+            hf_keys = state_source.get_all_keys()
+            if any(key.startswith("vision_tower.vision_model.") for key in hf_keys):
+                vision_hf_param = "vision_tower.vision_model.**"
+
         # Dictionary maps Megatron parameter names -> HF parameter names
         # Supports wildcard (*) patterns for layer-specific parameters
         param_mappings = {
@@ -135,7 +147,7 @@ class Gemma3VLBridge(MegatronModelBridge):
             [
                 ReplicatedMapping(
                     megatron_param="vision_tower.**",
-                    hf_param="vision_tower.**",
+                    hf_param=vision_hf_param,
                 ),
                 AutoMapping(
                     megatron_param="multi_modal_projector.proj.weight",

--- a/src/megatron/bridge/models/glm/glm47_flash_bridge.py
+++ b/src/megatron/bridge/models/glm/glm47_flash_bridge.py
@@ -25,13 +25,14 @@ by the runtime model, so the DeepSeek common mapping list works directly.
 """
 
 from functools import partial
+from typing import Mapping
 
 import torch
 from megatron.core.models.gpt.gpt_layer_specs import get_gpt_decoder_block_spec
 from megatron.core.models.gpt.gpt_model import GPTModel
 
 from megatron.bridge.models.conversion.mapping_registry import MegatronMappingRegistry
-from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge
+from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge, WeightConversionTask
 from megatron.bridge.models.deepseek.common import get_common_mapping_list
 from megatron.bridge.models.hf_pretrained.causal_lm import PreTrainedCausalLM
 from megatron.bridge.models.mla_provider import MLAModelProvider
@@ -111,3 +112,38 @@ class GLM47FlashBridge(MegatronModelBridge):
         hf_config = getattr(self, "hf_config", None)
         mapping_list = get_common_mapping_list(hf_config=hf_config)
         return MegatronMappingRegistry(*mapping_list)
+
+    def maybe_modify_converted_hf_weight(
+        self,
+        task: WeightConversionTask,
+        converted_weights_dict: dict[str, torch.Tensor],
+        hf_state_dict: Mapping[str, torch.Tensor],
+    ) -> dict[str, torch.Tensor]:
+        """Restore GLM MTP embedding and output aliases on HF export."""
+        converted_weights_dict = super().maybe_modify_converted_hf_weight(
+            task,
+            converted_weights_dict,
+            hf_state_dict,
+        )
+
+        hf_config = getattr(self, "hf_config", None)
+        if hf_config is None:
+            return converted_weights_dict
+
+        num_hidden_layers = hf_config.num_hidden_layers
+        num_mtp_layers = getattr(hf_config, "num_nextn_predict_layers", 0)
+        alias_specs = (
+            ("model.embed_tokens.weight", "model.layers.{}.embed_tokens.weight"),
+            ("lm_head.weight", "model.layers.{}.shared_head.head.weight"),
+        )
+        for source_name, alias_template in alias_specs:
+            if source_name not in converted_weights_dict:
+                continue
+
+            source_weight = converted_weights_dict[source_name]
+            for mtp_layer in range(num_mtp_layers):
+                alias_name = alias_template.format(num_hidden_layers + mtp_layer)
+                if alias_name not in converted_weights_dict:
+                    converted_weights_dict[alias_name] = source_weight.clone()
+
+        return converted_weights_dict

--- a/src/megatron/bridge/models/hf_pretrained/base.py
+++ b/src/megatron/bridge/models/hf_pretrained/base.py
@@ -211,7 +211,26 @@ class PreTrainedBase(ABC):
         for name in self.OPTIONAL_ARTIFACTS:
             artifact = getattr(self, name, None)
             if artifact is not None and hasattr(artifact, "save_pretrained"):
-                artifact.save_pretrained(save_path)
+                try:
+                    artifact.save_pretrained(save_path)
+                except ValueError:
+                    if name != "generation_config":
+                        raise
+
+                    source_path = original_source_path or getattr(self, "model_name_or_path", None)
+                    copied_files = []
+                    if source_path is not None:
+                        copied_files = self._copy_custom_modeling_files(
+                            source_path=source_path,
+                            target_path=save_path,
+                            file_patterns=["generation_config.json"],
+                        )
+                    if "generation_config.json" not in copied_files:
+                        raise
+                    logger.warning(
+                        "GenerationConfig.save_pretrained() rejected the source artifact; "
+                        "preserved the original generation_config.json instead."
+                    )
 
         # Download/copy additional files if specified
         if additional_files:

--- a/src/megatron/bridge/models/hybrid/hybrid_provider.py
+++ b/src/megatron/bridge/models/hybrid/hybrid_provider.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import inspect
 import logging
 import warnings
@@ -240,11 +241,21 @@ class HybridModelProvider(TransformerConfig, ModelProviderMixin[MCoreHybridModel
         """Resolve the configured Hybrid stack spec."""
         hybrid_stack_spec = self.hybrid_stack_spec
         if hybrid_stack_spec is None:
-            return get_default_hybrid_stack_spec(self)
-        if not isinstance(hybrid_stack_spec, ModuleSpec):
+            hybrid_stack_spec = get_default_hybrid_stack_spec(self)
+        elif not isinstance(hybrid_stack_spec, ModuleSpec):
             if len(inspect.signature(hybrid_stack_spec).parameters) > 0:
-                return hybrid_stack_spec(self)
-            return hybrid_stack_spec()
+                hybrid_stack_spec = hybrid_stack_spec(self)
+            else:
+                hybrid_stack_spec = hybrid_stack_spec()
+
+        if self.attention_backend in {AttnBackend.local, "local"}:
+            from megatron.core.transformer.dot_product_attention import DotProductAttention
+
+            hybrid_stack_spec = copy.deepcopy(hybrid_stack_spec)
+            attention_layer = getattr(hybrid_stack_spec.submodules, "attention_layer", None)
+            if attention_layer is not None:
+                attention_layer.submodules.self_attention.submodules.core_attention = DotProductAttention
+
         return hybrid_stack_spec
 
     def provide(self, pre_process=None, post_process=None, vp_stage=None) -> MCoreHybridModel:

--- a/src/megatron/bridge/models/llama/llama_bridge.py
+++ b/src/megatron/bridge/models/llama/llama_bridge.py
@@ -13,12 +13,14 @@
 # limitations under the License.
 
 import logging
+from collections.abc import Mapping
 
+import torch
 from megatron.core.models.gpt.gpt_model import GPTModel
 from transformers import LlamaForCausalLM
 
 from megatron.bridge.models.conversion.mapping_registry import MegatronMappingRegistry
-from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge
+from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge, WeightConversionTask
 from megatron.bridge.models.conversion.param_mapping import (
     AutoMapping,
     GatedMLPMapping,
@@ -148,3 +150,38 @@ class LlamaBridge(MegatronModelBridge):
         )
 
         return MegatronMappingRegistry(*mapping_list)
+
+    def maybe_modify_converted_hf_weight(
+        self,
+        task: WeightConversionTask,
+        converted_weights_dict: dict[str, torch.Tensor],
+        hf_state_dict: Mapping[str, torch.Tensor],
+    ) -> dict[str, torch.Tensor]:
+        """Preserve persisted Llama rotary inverse-frequency buffers on export."""
+        input_layernorm_key = next(
+            (
+                name
+                for name in converted_weights_dict
+                if name.startswith("model.layers.") and name.endswith(".input_layernorm.weight")
+            ),
+            None,
+        )
+        if input_layernorm_key is None:
+            return converted_weights_dict
+
+        parts = input_layernorm_key.split(".")
+        if len(parts) < 5 or not parts[2].isdigit():
+            return converted_weights_dict
+
+        layer_idx = int(parts[2])
+        inv_freq_key = f"model.layers.{layer_idx}.self_attn.rotary_emb.inv_freq"
+        if inv_freq_key not in hf_state_dict or inv_freq_key in converted_weights_dict:
+            return converted_weights_dict
+
+        inv_freq = hf_state_dict[inv_freq_key]
+        reference_tensor = next(iter(converted_weights_dict.values()), None)
+        if reference_tensor is not None:
+            inv_freq = inv_freq.to(reference_tensor.device)
+
+        converted_weights_dict[inv_freq_key] = inv_freq
+        return converted_weights_dict

--- a/src/megatron/bridge/models/ministral3/ministral3_bridge.py
+++ b/src/megatron/bridge/models/ministral3/ministral3_bridge.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2025-2026, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -92,6 +92,12 @@ class Ministral3Bridge(MegatronModelBridge):
 
         # Ministral 3 has separate text_config and vision_config
         text_config = getattr(hf_config, "text_config", hf_config)
+        tie_word_embeddings = getattr(text_config, "tie_word_embeddings", False)
+        # Transformers supplies a top-level default for composite configs even
+        # when the checkpoint declares the effective value only in text_config.
+        # Keep the config copied by save_hf_pretrained consistent with the
+        # language model and its exported lm_head.
+        hf_config.tie_word_embeddings = tie_word_embeddings
         params_dtype = self.dtype_from_hf(hf_config, default=torch.float32)
         provider = Ministral3ModelProvider(
             hidden_size=text_config.hidden_size,
@@ -101,7 +107,7 @@ class Ministral3Bridge(MegatronModelBridge):
             num_query_groups=text_config.num_key_value_heads,
             kv_channels=text_config.head_dim,
             seq_length=text_config.max_position_embeddings,
-            share_embeddings_and_output_weights=getattr(hf_config, "tie_word_embeddings", False),
+            share_embeddings_and_output_weights=tie_word_embeddings,
             rotary_base=text_config.rope_parameters["rope_theta"],
             vocab_size=text_config.vocab_size,
             params_dtype=params_dtype,
@@ -117,10 +123,11 @@ class Ministral3Bridge(MegatronModelBridge):
     def megatron_to_hf_config(cls, provider: Ministral3ModelProvider) -> dict[str, object]:
         """Convert a Ministral 3 provider to its nested HuggingFace config layout."""
         text_config = super().megatron_to_hf_config(provider)
-        top_level_keys = ("architectures", "model_type", "tie_word_embeddings")
+        top_level_keys = ("architectures", "model_type")
         hf_config = {key: text_config.pop(key) for key in top_level_keys if key in text_config}
         if "torch_dtype" in text_config:
             hf_config["dtype"] = text_config.pop("torch_dtype")
+        hf_config["tie_word_embeddings"] = text_config.get("tie_word_embeddings", False)
         hf_config["text_config"] = text_config
         return hf_config
 

--- a/tests/functional_tests/test_groups/models/gemma_vl/test_gemma4_vl_conversion.py
+++ b/tests/functional_tests/test_groups/models/gemma_vl/test_gemma4_vl_conversion.py
@@ -270,6 +270,7 @@ class TestGemma4VLConversion:
             str(pp),
             "--etp",
             str(etp),
+            "--not-strict",
         ]
 
         result = subprocess.run(
@@ -407,6 +408,7 @@ class TestGemma4DenseVLConversion:
             str(tp),
             "--pp",
             str(pp),
+            "--not-strict",
         ]
 
         result = subprocess.run(

--- a/tests/functional_tests/test_groups/models/nemotron_omni/test_nemotron_omni_conversion.py
+++ b/tests/functional_tests/test_groups/models/nemotron_omni/test_nemotron_omni_conversion.py
@@ -187,6 +187,7 @@ class TestNemotronOmniConversion:
             "--pp",
             pp,
             "--trust-remote-code",
+            "--not-strict",
         ]
 
         result = subprocess.run(

--- a/tests/unit_tests/examples/test_hf_megatron_roundtrip_multi_gpu.py
+++ b/tests/unit_tests/examples/test_hf_megatron_roundtrip_multi_gpu.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the multi-GPU Hugging Face/Megatron round-trip CLI."""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+
+import pytest
+
+
+pytestmark = pytest.mark.unit
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+_CLI_PATH = _REPO_ROOT / "examples" / "conversion" / "hf_megatron_roundtrip_multi_gpu.py"
+
+
+@pytest.fixture(scope="module")
+def cli():
+    """Load the round-trip example as a module under a stable test name."""
+    spec = importlib.util.spec_from_file_location("hf_megatron_roundtrip_multi_gpu_under_test", _CLI_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    try:
+        spec.loader.exec_module(module)
+        yield module
+    finally:
+        sys.modules.pop(spec.name, None)
+
+
+@pytest.mark.parametrize(("extra_args", "expected_strict"), [([], True), (["--not-strict"], False)])
+def test_cli_forwards_export_strictness(cli, monkeypatch, extra_args, expected_strict):
+    """The CLI is strict by default and loosens export only when requested."""
+    calls = []
+    monkeypatch.setattr(cli, "main", lambda *args, **kwargs: calls.append((args, kwargs)))
+    monkeypatch.setattr(cli.torch.distributed, "is_initialized", lambda: False)
+
+    cli._run_cli(["--hf-model-id", "org/model", *extra_args])
+
+    assert len(calls) == 1
+    assert calls[0][1]["strict"] is expected_strict

--- a/tests/unit_tests/models/gemma_vl/test_gemma3_vl_bridge.py
+++ b/tests/unit_tests/models/gemma_vl/test_gemma3_vl_bridge.py
@@ -274,6 +274,20 @@ class TestGemma3VLBridgeMappingRegistry:
         assert str(mapping.megatron_param) == "vision_tower.embeddings.patch_embedding.bias"
         assert str(mapping.hf_param) == "vision_tower.embeddings.patch_embedding.bias"
 
+    def test_mapping_registry_accepts_legacy_checkpoint_vision_tower_keys(self, gemma3_vl_bridge):
+        """Test mapping_registry preserves the nested namespace in legacy Gemma3 checkpoints."""
+        gemma3_vl_bridge.hf_pretrained = Mock()
+        gemma3_vl_bridge.hf_pretrained.state.source.get_all_keys.return_value = {
+            "vision_tower.vision_model.embeddings.patch_embedding.bias",
+        }
+
+        registry = gemma3_vl_bridge.mapping_registry()
+        mapping = registry.hf_to_megatron_lookup("vision_tower.vision_model.embeddings.patch_embedding.bias")
+
+        assert mapping is not None
+        assert str(mapping.megatron_param) == "vision_tower.embeddings.patch_embedding.bias"
+        assert str(mapping.hf_param) == "vision_tower.vision_model.embeddings.patch_embedding.bias"
+
     def test_mapping_registry_multimodal_projector_params(self, gemma3_vl_bridge):
         """Test mapping_registry handles multimodal projector parameters correctly."""
         registry = gemma3_vl_bridge.mapping_registry()

--- a/tests/unit_tests/models/glm/test_glm47_flash_bridge.py
+++ b/tests/unit_tests/models/glm/test_glm47_flash_bridge.py
@@ -159,3 +159,53 @@ class TestGLM47FlashBridge:
         assert "mtp.layers.0.eh_proj.weight" in megatron_params
         assert "mtp.layers.0.final_layernorm.weight" in megatron_params
         assert "mtp.layers.0.mtp_model_layer.mlp.router.expert_bias" in megatron_params
+
+    @pytest.mark.parametrize(
+        ("source_name", "alias_name"),
+        [
+            (
+                "model.embed_tokens.weight",
+                "model.layers.47.embed_tokens.weight",
+            ),
+            (
+                "lm_head.weight",
+                "model.layers.47.shared_head.head.weight",
+            ),
+        ],
+    )
+    def test_export_restores_mtp_alias_weights(
+        self,
+        glm47_flash_config,
+        source_name,
+        alias_name,
+    ):
+        """Test export restores the duplicated MTP embedding and output weights."""
+        bridge = GLM47FlashBridge()
+        bridge.hf_config = glm47_flash_config
+        source_weight = torch.randn(4, 4)
+        converted_weights = {source_name: source_weight}
+
+        result = bridge.maybe_modify_converted_hf_weight(
+            SimpleNamespace(global_param_name="checkpoint.model." + source_name),
+            converted_weights,
+            {},
+        )
+
+        torch.testing.assert_close(result[alias_name], source_weight)
+        assert result[alias_name].data_ptr() != source_weight.data_ptr()
+
+    def test_export_does_not_add_mtp_alias_when_mtp_is_disabled(self, glm47_flash_config):
+        """Test export leaves checkpoints without MTP layers unchanged."""
+        bridge = GLM47FlashBridge()
+        bridge.hf_config = SimpleNamespace(**{**vars(glm47_flash_config), "num_nextn_predict_layers": 0})
+        source_weight = torch.randn(4, 4)
+        converted_weights = {"model.embed_tokens.weight": source_weight}
+
+        result = bridge.maybe_modify_converted_hf_weight(
+            SimpleNamespace(global_param_name="embedding.word_embeddings.weight"),
+            converted_weights,
+            {},
+        )
+
+        assert set(result) == {"model.embed_tokens.weight"}
+        assert result["model.embed_tokens.weight"] is source_weight

--- a/tests/unit_tests/models/hf_pretrained/test_base.py
+++ b/tests/unit_tests/models/hf_pretrained/test_base.py
@@ -20,6 +20,7 @@ import tempfile
 from pathlib import Path
 from unittest.mock import Mock, patch
 
+import pytest
 from transformers.configuration_utils import PretrainedConfig
 
 
@@ -272,6 +273,42 @@ def test_save_artifacts_without_model_name_or_path():
         base.save_artifacts(target_dir)
 
         print("✅ test_save_artifacts_without_model_name_or_path passed")
+
+
+def test_save_artifacts_preserves_rejected_source_generation_config():
+    """Test invalid-but-loadable source generation metadata is preserved verbatim."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir)
+        source_dir = tmp_path / "source"
+        source_dir.mkdir()
+        source_generation_config = '{"do_sample": false, "temperature": 0.000001}\n'
+        (source_dir / "generation_config.json").write_text(source_generation_config)
+        target_dir = tmp_path / "target"
+
+        base = MockPreTrainedBase(model_name_or_path=str(source_dir))
+        base._config = Mock(save_pretrained=Mock())
+        base._generation_config = Mock()
+        base._generation_config.save_pretrained.side_effect = ValueError("invalid generation config")
+
+        base.save_artifacts(target_dir)
+
+        assert (target_dir / "generation_config.json").read_text() == source_generation_config
+
+
+def test_save_artifacts_reraises_generation_config_error_without_source_file():
+    """Test generation config save errors are not hidden without a source artifact."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir)
+        source_dir = tmp_path / "source"
+        source_dir.mkdir()
+
+        base = MockPreTrainedBase(model_name_or_path=str(source_dir))
+        base._config = Mock(save_pretrained=Mock())
+        base._generation_config = Mock()
+        base._generation_config.save_pretrained.side_effect = ValueError("invalid generation config")
+
+        with pytest.raises(ValueError, match="invalid generation config"):
+            base.save_artifacts(tmp_path / "target")
 
 
 def test_copy_handles_permission_errors():

--- a/tests/unit_tests/models/hybrid/test_hybrid_provider.py
+++ b/tests/unit_tests/models/hybrid/test_hybrid_provider.py
@@ -16,7 +16,10 @@ from unittest.mock import Mock, patch
 
 import pytest
 import torch
+from megatron.core.extensions.transformer_engine import TEDotProductAttention
 from megatron.core.transformer import ModuleSpec
+from megatron.core.transformer.dot_product_attention import DotProductAttention
+from megatron.core.transformer.enums import AttnBackend
 
 from megatron.bridge.models.hybrid import hybrid_provider
 from megatron.bridge.models.hybrid.hybrid_provider import HybridModelProvider
@@ -151,6 +154,41 @@ class TestHybridModelProvider:
         spec_call_kwarg = mock_model.call_args.kwargs["hybrid_stack_spec"]
         assert isinstance(spec_call_kwarg, Mock)
         assert spec_call_kwarg.info == "custom spec"
+
+    @pytest.mark.parametrize("attention_backend", [AttnBackend.local, "local"])
+    def test_local_attention_clones_stack_spec_and_uses_mcore_attention(self, attention_backend):
+        provider = HybridModelProvider(
+            num_layers=2,
+            hidden_size=128,
+            num_attention_heads=1,
+            attention_backend=attention_backend,
+        )
+
+        resolved_spec = provider._resolve_hybrid_stack_spec()
+        resolved_core_attention = (
+            resolved_spec.submodules.attention_layer.submodules.self_attention.submodules.core_attention
+        )
+        default_core_attention = hybrid_provider.default_hybrid_stack_spec.submodules.attention_layer.submodules.self_attention.submodules.core_attention
+
+        assert resolved_spec is not hybrid_provider.default_hybrid_stack_spec
+        assert resolved_core_attention is DotProductAttention
+        assert default_core_attention is TEDotProductAttention
+
+    def test_non_local_attention_keeps_transformer_engine_stack_spec(self):
+        provider = HybridModelProvider(
+            num_layers=2,
+            hidden_size=128,
+            num_attention_heads=1,
+            attention_backend=AttnBackend.flash,
+        )
+
+        resolved_spec = provider._resolve_hybrid_stack_spec()
+        resolved_core_attention = (
+            resolved_spec.submodules.attention_layer.submodules.self_attention.submodules.core_attention
+        )
+
+        assert resolved_spec is hybrid_provider.default_hybrid_stack_spec
+        assert resolved_core_attention is TEDotProductAttention
 
     def test_finalize_uses_compatible_hybrid_layer_count(self):
         provider = HybridModelProvider(

--- a/tests/unit_tests/models/llama/test_llama_bridge.py
+++ b/tests/unit_tests/models/llama/test_llama_bridge.py
@@ -636,6 +636,32 @@ class TestLlamaBridgeMappingRegistry:
         assert mapping is not None
         assert mapping.hf_param == "model.norm.weight"
 
+    def test_export_preserves_persisted_rotary_inv_freq(self):
+        """Test that Llama 2 rotary buffers are copied from the source checkpoint."""
+        bridge = LlamaBridge()
+        task = Mock(global_param_name="decoder.layers.3.self_attention.linear_qkv.layer_norm_weight")
+        converted = {"model.layers.3.input_layernorm.weight": torch.ones(4096)}
+        inv_freq_key = "model.layers.3.self_attn.rotary_emb.inv_freq"
+        source_inv_freq = torch.tensor([1.0, 0.25, 0.03125], dtype=torch.float32)
+
+        result = bridge.maybe_modify_converted_hf_weight(
+            task,
+            converted,
+            {inv_freq_key: source_inv_freq},
+        )
+
+        torch.testing.assert_close(result[inv_freq_key], source_inv_freq, rtol=0, atol=0)
+
+    def test_export_does_not_add_unpersisted_rotary_inv_freq(self):
+        """Test that modern Llama checkpoints without persisted RoPE buffers are unchanged."""
+        bridge = LlamaBridge()
+        task = Mock(global_param_name="decoder.layers.3.self_attention.linear_qkv.layer_norm_weight")
+        converted = {"model.layers.3.input_layernorm.weight": torch.ones(4096)}
+
+        result = bridge.maybe_modify_converted_hf_weight(task, converted, {})
+
+        assert set(result) == {"model.layers.3.input_layernorm.weight"}
+
 
 class TestAutoBridgeIntegration:
     """Integration tests for AutoBridge with Llama models."""

--- a/tests/unit_tests/models/ministral3/test_ministral3_bridge.py
+++ b/tests/unit_tests/models/ministral3/test_ministral3_bridge.py
@@ -117,17 +117,19 @@ class TestMinistral3BridgeProviderBridge:
         # Should set hf_config
         assert provider.hf_config is mock_hf_pretrained.config
 
-    def test_provider_bridge_tie_word_embeddings(self, ministral3_bridge, mock_hf_pretrained):
-        """Test provider_bridge handles tie_word_embeddings correctly."""
-        # Test with tie_word_embeddings=True
-        mock_hf_pretrained.config.tie_word_embeddings = True
-        provider = ministral3_bridge.provider_bridge(mock_hf_pretrained)
-        assert provider.share_embeddings_and_output_weights is True
+    @pytest.mark.parametrize("text_tie_word_embeddings", [True, False])
+    def test_provider_bridge_tie_word_embeddings(
+        self, ministral3_bridge, mock_hf_pretrained, text_tie_word_embeddings
+    ):
+        """The nested language config controls input/output embedding sharing."""
+        mock_hf_pretrained.config.tie_word_embeddings = not text_tie_word_embeddings
+        mock_hf_pretrained.config.text_config.tie_word_embeddings = text_tie_word_embeddings
 
-        # Test with tie_word_embeddings=False
-        mock_hf_pretrained.config.tie_word_embeddings = False
         provider = ministral3_bridge.provider_bridge(mock_hf_pretrained)
-        assert provider.share_embeddings_and_output_weights is False
+
+        assert provider.share_embeddings_and_output_weights is text_tie_word_embeddings
+        assert mock_hf_pretrained.config.tie_word_embeddings is text_tie_word_embeddings
+        assert provider.hf_config.tie_word_embeddings is text_tie_word_embeddings
 
     def test_provider_bridge_with_custom_vocab_size(self, ministral3_bridge, mock_hf_pretrained):
         """Test provider_bridge with custom vocabulary size."""
@@ -360,43 +362,40 @@ class TestMinistral3BridgeCompatibility:
             provider = ministral3_bridge.provider_bridge(mock_hf_pretrained)
             assert provider.vocab_size == vocab_size
 
-    def test_provider_bridge_3b_config(self, ministral3_bridge, mock_hf_pretrained):
-        """Test provider_bridge with 3B model configuration."""
-        mock_hf_pretrained.config.text_config.num_hidden_layers = 26
-        mock_hf_pretrained.config.text_config.hidden_size = 3072
-        mock_hf_pretrained.config.text_config.intermediate_size = 9216
+    @pytest.mark.parametrize(
+        "num_layers,hidden_size,ffn_hidden_size,rope_theta,tie_word_embeddings",
+        [
+            (26, 3072, 9216, 1000000.0, True),
+            (34, 4096, 14336, 1000000.0, False),
+            (40, 5120, 16384, 1000000000.0, False),
+        ],
+        ids=["3b", "8b", "14b"],
+    )
+    def test_provider_bridge_exact_base_size_configs(
+        self,
+        ministral3_bridge,
+        mock_hf_pretrained,
+        num_layers,
+        hidden_size,
+        ffn_hidden_size,
+        rope_theta,
+        tie_word_embeddings,
+    ):
+        """Map the architecture and embedding-sharing values of each Base size."""
+        text_config = mock_hf_pretrained.config.text_config
+        text_config.num_hidden_layers = num_layers
+        text_config.hidden_size = hidden_size
+        text_config.intermediate_size = ffn_hidden_size
+        text_config.rope_parameters["rope_theta"] = rope_theta
+        text_config.tie_word_embeddings = tie_word_embeddings
 
         provider = ministral3_bridge.provider_bridge(mock_hf_pretrained)
 
-        assert provider.num_layers == 26
-        assert provider.hidden_size == 3072
-        assert provider.ffn_hidden_size == 9216
-
-    def test_provider_bridge_8b_config(self, ministral3_bridge, mock_hf_pretrained):
-        """Test provider_bridge with 8B model configuration."""
-        mock_hf_pretrained.config.text_config.num_hidden_layers = 34
-        mock_hf_pretrained.config.text_config.hidden_size = 4096
-        mock_hf_pretrained.config.text_config.intermediate_size = 14336
-
-        provider = ministral3_bridge.provider_bridge(mock_hf_pretrained)
-
-        assert provider.num_layers == 34
-        assert provider.hidden_size == 4096
-        assert provider.ffn_hidden_size == 14336
-
-    def test_provider_bridge_14b_config(self, ministral3_bridge, mock_hf_pretrained):
-        """Test provider_bridge with 14B model configuration."""
-        mock_hf_pretrained.config.text_config.num_hidden_layers = 40
-        mock_hf_pretrained.config.text_config.hidden_size = 5120
-        mock_hf_pretrained.config.text_config.intermediate_size = 16384
-        mock_hf_pretrained.config.text_config.rope_parameters["rope_theta"] = 1000000000.0
-
-        provider = ministral3_bridge.provider_bridge(mock_hf_pretrained)
-
-        assert provider.num_layers == 40
-        assert provider.hidden_size == 5120
-        assert provider.ffn_hidden_size == 16384
-        assert provider.rotary_base == 1000000000.0
+        assert provider.num_layers == num_layers
+        assert provider.hidden_size == hidden_size
+        assert provider.ffn_hidden_size == ffn_hidden_size
+        assert provider.rotary_base == rope_theta
+        assert provider.share_embeddings_and_output_weights is tie_word_embeddings
 
     def test_provider_bridge_uses_composite_config_contract(self, ministral3_bridge):
         """Test the real composite config maps text dimensions and top-level fields."""
@@ -440,7 +439,7 @@ class TestMinistral3BridgeCompatibility:
         assert provider.kv_channels == hf_config.text_config.head_dim
         assert provider.seq_length == hf_config.text_config.max_position_embeddings
         assert provider.vocab_size == hf_config.text_config.vocab_size
-        assert provider.share_embeddings_and_output_weights is hf_config.tie_word_embeddings
+        assert provider.share_embeddings_and_output_weights is hf_config.text_config.tie_word_embeddings
         assert provider.params_dtype == torch.float16
         assert provider.fp16 is True
         assert provider.bf16 is False
@@ -545,6 +544,10 @@ class TestMinistral3BridgeCompatibility:
         assert synthesized_config.architectures == ["Mistral3ForConditionalGeneration"]
         assert synthesized_config.model_type == "mistral3"
         assert synthesized_config.tie_word_embeddings is checkpoint_provider.share_embeddings_and_output_weights
+        assert (
+            synthesized_config.text_config.tie_word_embeddings
+            is checkpoint_provider.share_embeddings_and_output_weights
+        )
         assert synthesized_config.dtype == checkpoint_provider.params_dtype
 
         assert synthesized_config.image_token_index == reference_config.image_token_index
@@ -555,7 +558,6 @@ class TestMinistral3BridgeCompatibility:
         assert synthesized_config.text_config.model_type == reference_config.text_config.model_type
         assert synthesized_config.text_config.rope_parameters == reference_rope_parameters
         assert synthesized_config.text_config.sliding_window == reference_config.text_config.sliding_window
-        assert synthesized_config.text_config.tie_word_embeddings is reference_config.text_config.tie_word_embeddings
         assert synthesized_config.text_config.use_cache is reference_config.text_config.use_cache
         assert synthesized_config.vision_config.to_dict() == reference_vision_config
 
@@ -563,7 +565,7 @@ class TestMinistral3BridgeCompatibility:
         assert synthesized_provider.num_attention_heads == checkpoint_provider.num_attention_heads
         assert synthesized_provider.num_query_groups == checkpoint_provider.num_query_groups
         assert synthesized_provider.kv_channels == checkpoint_provider.kv_channels
-        assert synthesized_provider.share_embeddings_and_output_weights is False
+        assert synthesized_provider.share_embeddings_and_output_weights is True
         assert synthesized_provider.params_dtype == torch.bfloat16
         assert synthesized_provider.fp16 is False
         assert synthesized_provider.bf16 is True

--- a/tests/unit_tests/utils/test_vlm_generate_utils.py
+++ b/tests/unit_tests/utils/test_vlm_generate_utils.py
@@ -132,6 +132,78 @@ class TestProcessMultiImageInputs:
 class TestProcessImageInputs:
     """Tests for ``process_image_inputs``."""
 
+    def test_base_processor_without_chat_template_uses_raw_image_prompt(self):
+        """Base VLMs without a chat template should receive an image-token prompt."""
+        image = mock.MagicMock(name="image")
+        rgb_image = mock.MagicMock(name="rgb_image")
+        image.convert.return_value = rgb_image
+
+        inputs = mock.MagicMock()
+        inputs.input_ids = torch.tensor([[10, 20]])
+        inputs.get.side_effect = lambda key: {
+            "pixel_values": "PIXELS",
+            "image_sizes": "IMAGE_SIZES",
+        }.get(key)
+
+        proc = mock.MagicMock()
+        proc.chat_template = None
+        proc.image_token = "[IMG]"
+        proc.return_value = inputs
+
+        with (
+            mock.patch.object(vlm_generate_utils, "_HAS_QWEN_VL_UTILS", False),
+            mock.patch.object(vlm_generate_utils, "load_image", return_value=image) as load_image_mock,
+        ):
+            result = vlm_generate_utils.process_image_inputs(proc, "/image.png", "describe", is_mistral3=True)
+
+        load_image_mock.assert_called_once_with("/image.png")
+        image.convert.assert_called_once_with("RGB")
+        proc.assert_called_once_with(
+            text=["[IMG]\ndescribe"],
+            images=[rgb_image],
+            padding=True,
+            return_tensors="pt",
+        )
+        assert len(result) == 6
+        input_ids, pixel_values, image_grid_thw, image_sizes, mm_token_type_ids, image_position_ids = result
+        torch.testing.assert_close(input_ids, torch.tensor([[10, 20]]))
+        assert pixel_values == "PIXELS"
+        assert image_grid_thw is None
+        assert image_sizes == "IMAGE_SIZES"
+        assert mm_token_type_ids is None
+        assert image_position_ids is None
+
+    def test_base_processor_preserves_existing_image_token(self):
+        """Do not inject a second image token when the prompt already contains one."""
+        image = mock.MagicMock()
+        image.convert.return_value = "RGB"
+        inputs = mock.MagicMock()
+        inputs.input_ids = torch.tensor([[1]])
+        inputs.get.return_value = None
+
+        proc = mock.MagicMock()
+        proc.chat_template = None
+        proc.image_token = "[IMG]"
+        proc.return_value = inputs
+
+        with mock.patch.object(vlm_generate_utils, "load_image", return_value=image):
+            vlm_generate_utils.process_image_inputs(proc, "/image.png", "[IMG]\ncaption", is_mistral3=True)
+
+        proc.assert_called_once_with(
+            text=["[IMG]\ncaption"],
+            images=["RGB"],
+            padding=True,
+            return_tensors="pt",
+        )
+
+    def test_unrecognized_processor_without_chat_template_fails_clearly(self):
+        """Do not apply the Ministral raw-prompt convention to other VLMs."""
+        proc = mock.MagicMock()
+        proc.chat_template = None
+
+        with pytest.raises(ValueError, match="no model-specific raw-prompt fallback"):
+            vlm_generate_utils.process_image_inputs(proc, "/image.png", "describe")
+
     def test_kimi_image_path_returns_full_six_field_contract(self):
         """Kimi image preprocessing must match the VLM generation unpack contract."""
         inputs = mock.MagicMock()


### PR DESCRIPTION
## Summary

- preserve persisted Llama rotary inverse-frequency buffers during HF export
- preserve Qwen3-ASR source `generation_config.json` when Transformers rejects the loaded artifact during save
- restore GLM-4.7-Flash MTP embedding and output aliases during HF export
- accept legacy Gemma3-VL `vision_tower.vision_model.*` checkpoint keys
- honor local attention for hybrid models without mutating the shared Transformer Engine stack spec
- align Ministral 3 Base tied-embedding semantics with its nested text config and support raw image prompts for Base processors without chat templates
- forward the multi-GPU round-trip CLI `--not-strict` option to export validation

These are the independently reviewable bug fixes extracted from #4805. The full-model inventory, validation-status documentation, bulk model workflows, and broad full-checkpoint conversion/inference/parity validation remain in #4805. This PR does not close or replace it.

## Verification

- `uv run --no-sync python -m pytest tests/unit_tests/examples/test_hf_megatron_roundtrip_multi_gpu.py tests/unit_tests/models/llama/test_llama_bridge.py tests/unit_tests/models/hf_pretrained/test_base.py tests/unit_tests/models/glm/test_glm47_flash_bridge.py tests/unit_tests/models/gemma_vl/test_gemma3_vl_bridge.py tests/unit_tests/models/hybrid/test_hybrid_provider.py tests/unit_tests/models/ministral3/test_ministral3_bridge.py tests/unit_tests/utils/test_vlm_generate_utils.py -q` — 140 passed in the CI-style container
- `uv run --no-sync pre-commit run --all-files` — passed
- `uv run --no-sync mypy --strict` on the nine changed source/example modules — reports 124 existing typing/import issues, primarily untyped Megatron-Core packages and pre-existing unannotated example helpers; no suppressions were added

No broad full-checkpoint job was run for this extraction; that validation intentionally remains tracked in #4805.

## CI follow-up

Exact-SHA run [29547648927](https://github.com/NVIDIA-NeMo/Megatron-Bridge/actions/runs/29547648927) exposed pre-existing partial-export expectations after the CLI began forwarding strictness:

- Gemma4 VL failed in `save_hf_pretrained(..., strict=True)`: `RuntimeError: 83 tensors from the original checkpoint were not written.`
- Nemotron Omni failed identically on H100 and GB200: `RuntimeError: 526 tensors from the original checkpoint were not written.` The incomplete shard reports the intentionally unmapped `vision_model.radio_model.summary_idxs`.
- Commit `ce14dd968d82567ded76c554dede0a518e424598` explicitly passes `--not-strict` from the known partial-roundtrip functional tests. Strict-by-default CLI behavior and model mappings remain unchanged.

Focused verification:

- `uv run --no-sync python -m pytest ... tests/unit_tests/examples/test_hf_megatron_roundtrip_multi_gpu.py` — 2 CLI tests passed; the four selected GPU cases were collected but skipped because the local CUDA 13 container cannot initialize against the workstation driver.
- `uv run --no-sync pre-commit run --all-files` — passed.
- Exact H100/GB200 verification passed in [run 29559267662](https://github.com/NVIDIA-NeMo/Megatron-Bridge/actions/runs/29559267662): [H100 Gemma4 VL](https://github.com/NVIDIA-NeMo/Megatron-Bridge/actions/runs/29559267662/job/87822527489), [H100 Nemotron Omni](https://github.com/NVIDIA-NeMo/Megatron-Bridge/actions/runs/29559267662/job/87822527491), and [GB200 Nemotron Omni](https://github.com/NVIDIA-NeMo/Megatron-Bridge/actions/runs/29559267662/job/87822526981). Broad full-model validation remains in #4805.