### PR TITLE
ci(coverage): exclude examples and scripts

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,7 @@
 comment: false
+ignore:
+  - "examples"
+  - "scripts"
 coverage:
   status:
     project: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -271,6 +271,8 @@ omit = [
     "/tmp/*",
     "/opt/Megatron-Bridge/tests/*",
     "/opt/Megatron-Bridge/*.py",
+    "examples/*",
+    "scripts/*",
     "*_ray.py",
 ]
 


### PR DESCRIPTION
## What does this PR do?

Exclude the repository's top-level `examples/` and `scripts/` directories from coverage calculations.

These directories contain runnable entry points, operational utilities, and illustrative code rather than the `megatron.bridge` library surface. Counting them in the project denominator makes library coverage harder to interpret; for example, Codecov currently reports `examples/` at 69.73% (1,504/2,157 lines).

The exclusion is applied in both places that affect reporting:

- coverage.py `run.omit`, so CI collection and local aggregate reports do not count the directories
- Codecov's top-level `ignore`, so Codecov skips them during upload processing

The patterns are anchored to the two top-level directories and do not exclude `tests/unit_tests/examples/` or `tests/unit_tests/scripts/`.

## Testing

- `uvx pre-commit run --all-files`
- Parsed `pyproject.toml` and `codecov.yml` and asserted both exclusion lists
- Synthetic coverage.py trace confirmed `src/` remains measured while top-level `examples/` and `scripts/` are omitted

`uv run pre-commit run --all-files` cannot resolve locally on macOS ARM because `nvidia-resiliency-ext==0.6.0` only publishes Linux wheels; the standalone pre-commit environment passes.
