### PR TITLE
fix(model): align Gemma 4 MoE global RoPE with Hugging Face

### DIFF
--- a/src/megatron/bridge/models/gemma/modeling_gemma4.py
+++ b/src/megatron/bridge/models/gemma/modeling_gemma4.py
@@ -1744,15 +1744,21 @@ class Gemma4RotaryEmbedding(RotaryEmbedding):
         super().__init__(
             kv_channels=global_kv_channels,
             rotary_base=rotary_base,
-            rotary_percent=global_rotary_percent,
+            rotary_percent=1.0,
             **global_kwargs,
         )
 
-        dim = int(global_kv_channels * global_rotary_percent)
+        # HF proportional RoPE rotates pairs across the full attention head. Represent the
+        # partial rotation with zero-frequency pairs instead of shortening the rotary width.
+        rope_angles = int(global_rotary_percent * global_kv_channels // 2)
+        nope_angles = global_kv_channels // 2 - rope_angles
         device = self.inv_freq.device
-        self.inv_freq = 1.0 / (
-            rotary_base ** (torch.arange(0, dim, 2, dtype=torch.float32, device=device) / global_kv_channels)
+        rotated = 1.0 / (
+            rotary_base
+            ** (torch.arange(0, 2 * rope_angles, 2, dtype=torch.float32, device=device) / global_kv_channels)
         )
+        non_rotated = torch.zeros(nope_angles, dtype=torch.float32, device=device)
+        self.inv_freq = torch.cat([rotated, non_rotated], dim=0)
 
         self.rope_local = RotaryEmbedding(
             rotary_base=rotary_base_local,

--- a/tests/unit_tests/models/gemma/test_gemma4_modeling.py
+++ b/tests/unit_tests/models/gemma/test_gemma4_modeling.py
@@ -23,6 +23,7 @@ from types import SimpleNamespace
 import pytest
 import torch
 from megatron.core import tensor_parallel
+from megatron.core.models.common.embeddings.rotary_pos_embedding import apply_rotary_pos_emb
 
 from megatron.bridge.models.gemma.modeling_gemma4 import (
     Gemma4DenseMLP,
@@ -896,8 +897,44 @@ class TestGemma4RotaryEmbeddings:
             use_cpu_initialization=True,
         )
 
-        assert rotary.inv_freq.numel() == 2
+        assert rotary.inv_freq.numel() == 8
+        expected_rotated = 1.0 / (1_000_000 ** (torch.arange(0, 4, 2, dtype=torch.float32) / 16))
+        torch.testing.assert_close(rotary.inv_freq[:2], expected_rotated)
+        torch.testing.assert_close(rotary.inv_freq[2:], torch.zeros(6))
         assert rotary.rope_local.inv_freq.numel() == 4
+
+    def test_moe_global_rotary_matches_hf_proportional_coordinate_layout(self):
+        head_dim = 16
+        partial_rotary_factor = 0.25
+        rotary_base = 1_000_000
+        position = 3
+        rotary = Gemma4RotaryEmbedding(
+            kv_channels=8,
+            rotary_percent=1.0,
+            rotary_base=rotary_base,
+            rotary_base_local=10_000,
+            global_kv_channels=head_dim,
+            global_rotary_percent=partial_rotary_factor,
+            use_cpu_initialization=True,
+        )
+
+        hidden_states = torch.arange(1, head_dim + 1, dtype=torch.float32).view(1, 1, 1, head_dim)
+        freqs = rotary.get_freqs_non_repeated(1, offset=position)
+        freqs = torch.cat((freqs, freqs), dim=-1)[:, None, None, :]
+        config = SimpleNamespace(apply_rope_fusion=False, rotary_interleaved=False)
+        actual = apply_rotary_pos_emb(hidden_states, freqs, config, cp_group=object())
+
+        expected = hidden_states.clone()
+        rope_angles = int(partial_rotary_factor * head_dim // 2)
+        angles = position / (rotary_base ** (torch.arange(0, 2 * rope_angles, 2, dtype=torch.float32) / head_dim))
+        cos = torch.cos(angles)
+        sin = torch.sin(angles)
+        left = hidden_states[..., :rope_angles]
+        right = hidden_states[..., head_dim // 2 : head_dim // 2 + rope_angles]
+        expected[..., :rope_angles] = left * cos - right * sin
+        expected[..., head_dim // 2 : head_dim // 2 + rope_angles] = right * cos + left * sin
+
+        torch.testing.assert_close(actual, expected)
 
     def test_dense_rotary_forwards_to_sliding_and_full_rope(self):
         class FakeRope:


### PR DESCRIPTION
# What does this PR do ?

Align Gemma 4 MoE global-attention RoPE with the Hugging Face proportional partial-RoPE layout.

For a 512-wide global attention head with a 0.25 partial factor, Hugging Face keeps a full 256-entry frequency vector, uses 64 non-zero frequencies, and rotates coordinate pairs across the two 256-wide half-heads. The existing Bridge implementation shortened the rotary width to 128 dimensions, which instead paired coordinates inside that prefix.

This change keeps the full head as the rotary width and represents the non-rotary coordinates with zero frequencies. Their cosine/sine values become 1/0, so those coordinate pairs pass through unchanged while the active pairs match Hugging Face.

## Attribution

This is a current-main adaptation of the original investigation and patch by @Zhichenzzz:

- https://github.com/radixark/Megatron-Bridge/commit/be3e2566ca23e2542a08a7e1ee8cec7644a31dfd
- https://github.com/radixark/Megatron-Bridge/pull/7

The original downstream validation reported the first global-layer attention difference improving from 11.6% to 1.55%. That GPU result belongs to the original contribution and was not re-run as part of this adaptation.

# Changelog

- Build Gemma 4 MoE global RoPE at the full attention-head width.
- Zero-pad the inactive proportional-RoPE frequencies instead of reducing `rotary_percent`.
- Update the existing rotary construction test.
- Add a direct numerical test for Hugging Face's cross-half coordinate pairing.

# GitHub Actions CI

Please run the focused Gemma unit coverage in CI. The repository's full runtime dependency set cannot be resolved on the local macOS arm64 host because `nvidia-resiliency-ext` is Linux-only.

Local checks:

- `uv run --no-project --with pre-commit pre-commit run --all-files` — passed
- `git diff --check` — passed
- Python compilation of both changed files — passed

Targeted CI command:

- `uv run python -m pytest tests/unit_tests/models/gemma/test_gemma4_modeling.py -k RotaryEmbeddings -v`

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation? (No user-facing documentation change is needed.)
- [x] Does the PR affect components that are optional to install? (No.)

# Additional Information

- No public API or checkpoint mapping changes.
- No dependency, recipe, CI workflow, or Megatron-LM submodule changes.
