### PR TITLE
[model] fix: Preserve config-only Gemma 3 provider creation

### DIFF
--- a/src/megatron/bridge/models/gemma/gemma3_bridge.py
+++ b/src/megatron/bridge/models/gemma/gemma3_bridge.py
@@ -16,7 +16,7 @@ import math
 
 import torch
 from megatron.core.models.gpt.gpt_model import GPTModel
-from transformers import AutoConfig, Gemma3ForCausalLM
+from transformers import Gemma3ForCausalLM
 
 from megatron.bridge.models.conversion.mapping_registry import MegatronMappingRegistry
 from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge
@@ -55,11 +55,8 @@ class Gemma3ModelBridge(MegatronModelBridge):
         provider = super().provider_bridge(hf_pretrained)
         hf_config = hf_pretrained.config
 
-        # Precision config is stored in the VL Config
-        hf_vl_config = AutoConfig.from_pretrained(hf_pretrained._model_name_or_path)
-
-        # Override dtype from VL config (has precision info)
-        params_dtype = self.dtype_from_hf(hf_vl_config, default=torch.float32)
+        # Keep autocast dtype aligned with the supplied HF config.
+        params_dtype = self.dtype_from_hf(hf_config, default=torch.float32)
         provider.fp16 = params_dtype == torch.float16
         provider.bf16 = params_dtype == torch.bfloat16
         provider.params_dtype = params_dtype

--- a/tests/unit_tests/models/gemma/test_gemma3_bridge.py
+++ b/tests/unit_tests/models/gemma/test_gemma3_bridge.py
@@ -19,7 +19,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 import torch
-from transformers import Gemma3Config, Gemma3ForCausalLM, GenerationConfig
+from transformers import Gemma3Config, Gemma3ForCausalLM, Gemma3TextConfig, GenerationConfig
 
 from megatron.bridge.models import AutoBridge
 from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge
@@ -212,12 +212,8 @@ class TestMegatronGemma3Bridge:
         # Check that the class exists and has the expected base class
         assert issubclass(Gemma3ModelBridge, MegatronModelBridge)
 
-    @patch("megatron.bridge.models.gemma.gemma3_bridge.AutoConfig.from_pretrained")
-    def test_provider_bridge_basic_1b(self, mock_autoconfig, mock_pretrained_gemma3_1b, gemma3_1b_config):
+    def test_provider_bridge_basic_1b(self, mock_pretrained_gemma3_1b, gemma3_1b_config):
         """Test basic provider_bridge functionality for Gemma3 1B."""
-        # Mock the VL config loading
-        mock_autoconfig.return_value = gemma3_1b_config
-
         bridge = Gemma3ModelBridge()
 
         # Call provider_bridge
@@ -236,12 +232,8 @@ class TestMegatronGemma3Bridge:
             rope_theta_from_hf(gemma3_1b_config),
         )
 
-    @patch("megatron.bridge.models.gemma.gemma3_bridge.AutoConfig.from_pretrained")
-    def test_provider_bridge_basic_4b(self, mock_autoconfig, mock_pretrained_gemma3_4b, gemma3_4b_config):
+    def test_provider_bridge_basic_4b(self, mock_pretrained_gemma3_4b, gemma3_4b_config):
         """Test basic provider_bridge functionality for Gemma3 4B."""
-        # Mock the VL config loading
-        mock_autoconfig.return_value = gemma3_4b_config
-
         bridge = Gemma3ModelBridge()
 
         # Call provider_bridge
@@ -260,12 +252,8 @@ class TestMegatronGemma3Bridge:
             rope_theta_from_hf(gemma3_4b_config),
         )
 
-    @patch("megatron.bridge.models.gemma.gemma3_bridge.AutoConfig.from_pretrained")
-    def test_provider_bridge_basic_27b(self, mock_autoconfig, mock_pretrained_gemma3_27b, gemma3_27b_config):
+    def test_provider_bridge_basic_27b(self, mock_pretrained_gemma3_27b, gemma3_27b_config):
         """Test basic provider_bridge functionality for Gemma3 27B."""
-        # Mock the VL config loading
-        mock_autoconfig.return_value = gemma3_27b_config
-
         bridge = Gemma3ModelBridge()
 
         # Call provider_bridge
@@ -284,10 +272,8 @@ class TestMegatronGemma3Bridge:
             rope_theta_from_hf(gemma3_27b_config),
         )
 
-    @patch("megatron.bridge.models.gemma.gemma3_bridge.AutoConfig.from_pretrained")
-    def test_provider_bridge_vocabulary(self, mock_autoconfig, mock_pretrained_gemma3_1b, gemma3_1b_config):
+    def test_provider_bridge_vocabulary(self, mock_pretrained_gemma3_1b, gemma3_1b_config):
         """Test vocabulary size mapping."""
-        mock_autoconfig.return_value = gemma3_1b_config
         bridge = Gemma3ModelBridge()
 
         result = bridge.provider_bridge(mock_pretrained_gemma3_1b)
@@ -297,10 +283,8 @@ class TestMegatronGemma3Bridge:
         # Gemma3 uses tied embeddings by default
         assert result.share_embeddings_and_output_weights == True
 
-    @patch("megatron.bridge.models.gemma.gemma3_bridge.AutoConfig.from_pretrained")
-    def test_provider_bridge_attention_config(self, mock_autoconfig, mock_pretrained_gemma3_1b, gemma3_1b_config):
+    def test_provider_bridge_attention_config(self, mock_pretrained_gemma3_1b, gemma3_1b_config):
         """Test attention configuration mapping."""
-        mock_autoconfig.return_value = gemma3_1b_config
         bridge = Gemma3ModelBridge()
 
         result = bridge.provider_bridge(mock_pretrained_gemma3_1b)
@@ -310,10 +294,8 @@ class TestMegatronGemma3Bridge:
         assert result.num_query_groups == gemma3_1b_config.num_key_value_heads
         assert result.window_size == gemma3_1b_config.sliding_window
 
-    @patch("megatron.bridge.models.gemma.gemma3_bridge.AutoConfig.from_pretrained")
-    def test_provider_bridge_mlp_config(self, mock_autoconfig, mock_pretrained_gemma3_1b, gemma3_1b_config):
+    def test_provider_bridge_mlp_config(self, mock_pretrained_gemma3_1b, gemma3_1b_config):
         """Test MLP configuration mapping."""
-        mock_autoconfig.return_value = gemma3_1b_config
         bridge = Gemma3ModelBridge()
 
         result = bridge.provider_bridge(mock_pretrained_gemma3_1b)
@@ -322,10 +304,8 @@ class TestMegatronGemma3Bridge:
         assert result.ffn_hidden_size == gemma3_1b_config.intermediate_size
         assert result.gated_linear_unit == True  # Gemma3 uses gated MLP
 
-    @patch("megatron.bridge.models.gemma.gemma3_bridge.AutoConfig.from_pretrained")
-    def test_provider_bridge_normalization(self, mock_autoconfig, mock_pretrained_gemma3_1b, gemma3_1b_config):
+    def test_provider_bridge_normalization(self, mock_pretrained_gemma3_1b, gemma3_1b_config):
         """Test normalization configuration."""
-        mock_autoconfig.return_value = gemma3_1b_config
         bridge = Gemma3ModelBridge()
 
         result = bridge.provider_bridge(mock_pretrained_gemma3_1b)
@@ -333,10 +313,8 @@ class TestMegatronGemma3Bridge:
         # Check normalization settings
         assert result.layernorm_epsilon == gemma3_1b_config.rms_norm_eps
 
-    @patch("megatron.bridge.models.gemma.gemma3_bridge.AutoConfig.from_pretrained")
-    def test_provider_bridge_position_embedding(self, mock_autoconfig, mock_pretrained_gemma3_1b, gemma3_1b_config):
+    def test_provider_bridge_position_embedding(self, mock_pretrained_gemma3_1b, gemma3_1b_config):
         """Test position embedding configuration."""
-        mock_autoconfig.return_value = gemma3_1b_config
         bridge = Gemma3ModelBridge()
 
         result = bridge.provider_bridge(mock_pretrained_gemma3_1b)
@@ -347,12 +325,8 @@ class TestMegatronGemma3Bridge:
             rope_theta_from_hf(gemma3_1b_config),
         )
 
-    @patch("megatron.bridge.models.gemma.gemma3_bridge.AutoConfig.from_pretrained")
-    def test_provider_bridge_gemma3_specific_features(
-        self, mock_autoconfig, mock_pretrained_gemma3_1b, gemma3_1b_config
-    ):
+    def test_provider_bridge_gemma3_specific_features(self, mock_pretrained_gemma3_1b, gemma3_1b_config):
         """Test Gemma3-specific features."""
-        mock_autoconfig.return_value = gemma3_1b_config
         bridge = Gemma3ModelBridge()
 
         result = bridge.provider_bridge(mock_pretrained_gemma3_1b)
@@ -363,12 +337,8 @@ class TestMegatronGemma3Bridge:
         assert result.layernorm_zero_centered_gamma == True  # Gemma3-specific RMSNorm behavior
         assert result.softmax_scale == 1.0 / math.sqrt(gemma3_1b_config.query_pre_attn_scalar)
 
-    @patch("megatron.bridge.models.gemma.gemma3_bridge.AutoConfig.from_pretrained")
-    def test_provider_bridge_head_dim_calculation_1b(
-        self, mock_autoconfig, mock_pretrained_gemma3_1b, gemma3_1b_config
-    ):
+    def test_provider_bridge_head_dim_calculation_1b(self, mock_pretrained_gemma3_1b, gemma3_1b_config):
         """Test head dimension calculation for Gemma3 1B."""
-        mock_autoconfig.return_value = gemma3_1b_config
         bridge = Gemma3ModelBridge()
 
         result = bridge.provider_bridge(mock_pretrained_gemma3_1b)
@@ -378,12 +348,8 @@ class TestMegatronGemma3Bridge:
         # Verify this matches the HF config
         assert result.kv_channels == 256
 
-    @patch("megatron.bridge.models.gemma.gemma3_bridge.AutoConfig.from_pretrained")
-    def test_provider_bridge_head_dim_calculation_27b(
-        self, mock_autoconfig, mock_pretrained_gemma3_27b, gemma3_27b_config
-    ):
+    def test_provider_bridge_head_dim_calculation_27b(self, mock_pretrained_gemma3_27b, gemma3_27b_config):
         """Test head dimension calculation for Gemma3 27B."""
-        mock_autoconfig.return_value = gemma3_27b_config
         bridge = Gemma3ModelBridge()
 
         result = bridge.provider_bridge(mock_pretrained_gemma3_27b)
@@ -397,11 +363,8 @@ class TestMegatronGemma3Bridge:
         assert result.kv_channels != standard_calculation
         assert result.kv_channels == 128  # Correct value from HF config
 
-    @patch("megatron.bridge.models.gemma.gemma3_bridge.AutoConfig.from_pretrained")
-    def test_provider_bridge_dtype_handling(self, mock_autoconfig, gemma3_1b_config):
+    def test_provider_bridge_dtype_handling(self, gemma3_1b_config):
         """Test dtype handling in provider_bridge."""
-        mock_autoconfig.return_value = gemma3_1b_config
-
         # Create model with specific dtype - set it in the config
         mock_pretrained = Mock(spec=PreTrainedCausalLM)
         mock_pretrained.config = gemma3_1b_config
@@ -417,10 +380,8 @@ class TestMegatronGemma3Bridge:
         assert result.bf16 == True
         assert result.fp16 == False
 
-    @patch("megatron.bridge.models.gemma.gemma3_bridge.AutoConfig.from_pretrained")
-    def test_provider_bridge_rope_scaling_config(self, mock_autoconfig, mock_pretrained_gemma3_4b, gemma3_4b_config):
+    def test_provider_bridge_rope_scaling_config(self, mock_pretrained_gemma3_4b, gemma3_4b_config):
         """Test rope scaling configuration."""
-        mock_autoconfig.return_value = gemma3_4b_config
         bridge = Gemma3ModelBridge()
 
         result = bridge.provider_bridge(mock_pretrained_gemma3_4b)
@@ -429,10 +390,8 @@ class TestMegatronGemma3Bridge:
         assert result.rope_scaling_factor == gemma3_4b_config.rope_scaling["factor"]
         assert result.rope_scaling_factor == 8.0
 
-    @patch("megatron.bridge.models.gemma.gemma3_bridge.AutoConfig.from_pretrained")
-    def test_provider_bridge_no_rope_scaling(self, mock_autoconfig, mock_pretrained_gemma3_1b, gemma3_1b_config):
+    def test_provider_bridge_no_rope_scaling(self, mock_pretrained_gemma3_1b, gemma3_1b_config):
         """Test configuration without rope scaling."""
-        mock_autoconfig.return_value = gemma3_1b_config
         bridge = Gemma3ModelBridge()
 
         result = bridge.provider_bridge(mock_pretrained_gemma3_1b)
@@ -440,12 +399,8 @@ class TestMegatronGemma3Bridge:
         # 1B model has no rope scaling
         assert result.rope_scaling_factor == 1.0
 
-    @patch("megatron.bridge.models.gemma.gemma3_bridge.AutoConfig.from_pretrained")
-    def test_provider_bridge_query_pre_attn_scalar_variants(
-        self, mock_autoconfig, mock_pretrained_gemma3_27b, gemma3_27b_config
-    ):
+    def test_provider_bridge_query_pre_attn_scalar_variants(self, mock_pretrained_gemma3_27b, gemma3_27b_config):
         """Test query_pre_attn_scalar for 27B model which has different value."""
-        mock_autoconfig.return_value = gemma3_27b_config
         bridge = Gemma3ModelBridge()
 
         result = bridge.provider_bridge(mock_pretrained_gemma3_27b)
@@ -455,12 +410,10 @@ class TestMegatronGemma3Bridge:
         assert result.softmax_scale == expected_softmax_scale
         assert abs(result.softmax_scale - (1.0 / math.sqrt(168))) < 1e-6  # 168 for 27B model
 
-    @patch("megatron.bridge.models.gemma.gemma3_bridge.AutoConfig.from_pretrained")
     def test_megatron_to_hf_config_reconstructs_gemma3_special_fields(
-        self, mock_autoconfig, mock_pretrained_gemma3_4b, gemma3_4b_config
+        self, mock_pretrained_gemma3_4b, gemma3_4b_config
     ):
         """Test Gemma3 reverse export reconstructs rope and scaling fields."""
-        mock_autoconfig.return_value = gemma3_4b_config
         bridge = Gemma3ModelBridge()
 
         provider = bridge.provider_bridge(mock_pretrained_gemma3_4b)
@@ -472,12 +425,8 @@ class TestMegatronGemma3Bridge:
         assert hf_config["query_pre_attn_scalar"] == gemma3_4b_config.query_pre_attn_scalar
         assert hf_config["rope_scaling"] == {"factor": 8.0, "type": "linear"}
 
-    @patch("megatron.bridge.models.gemma.gemma3_bridge.AutoConfig.from_pretrained")
-    def test_megatron_to_hf_config_omits_rope_scaling_when_disabled(
-        self, mock_autoconfig, mock_pretrained_gemma3_1b, gemma3_1b_config
-    ):
+    def test_megatron_to_hf_config_omits_rope_scaling_when_disabled(self, mock_pretrained_gemma3_1b, gemma3_1b_config):
         """Test Gemma3 reverse export leaves rope_scaling unset when no scaling is active."""
-        mock_autoconfig.return_value = gemma3_1b_config
         bridge = Gemma3ModelBridge()
 
         provider = bridge.provider_bridge(mock_pretrained_gemma3_1b)
@@ -504,6 +453,19 @@ class TestMegatronGemma3Bridge:
 
 class TestAutoBridgeIntegration:
     """Integration tests for AutoBridge with Gemma3 models."""
+
+    def test_config_only_provider_uses_in_memory_config(self):
+        """Config-only provider construction does not require a model path."""
+        config = Gemma3TextConfig(
+            architectures=["Gemma3ForCausalLM"],
+            dtype="bfloat16",
+        )
+
+        provider = AutoBridge.from_hf_config(config).to_megatron_provider(load_weights=False)
+
+        assert isinstance(provider, Gemma3ModelProvider)
+        assert provider.hidden_size == config.hidden_size
+        assert provider.params_dtype == torch.bfloat16
 
     @pytest.fixture
     def gemma3_configs(self):


### PR DESCRIPTION
# What does this PR do?

Preserve config-only Gemma 3 provider construction by deriving precision from the supplied Hugging Face config instead of reloading it from a model path.

# Changelog

- Use the in-memory `Gemma3TextConfig` when setting provider precision fields.
- Add an unmocked regression for `AutoBridge.from_hf_config(...).to_megatron_provider(load_weights=False)`.
- Remove obsolete unit-test mocks for the eliminated config reload.

# Trigger and impact

A directly constructed `Gemma3TextConfig` has an empty `name_or_path`. The documented config-only AutoBridge path wraps that config and calls the Gemma 3 provider bridge before the weight-loading guard. Previously, the provider bridge called `AutoConfig.from_pretrained("")`, so random initialization and architecture introspection failed even with `load_weights=False`.

The fix keeps the existing `fp16`, `bf16`, `params_dtype`, and `autocast_dtype` behavior, but derives them from the config already supplied by the caller. The separate Gemma 3 VL bridge is unchanged.

# Validation

Fail-before on the unmodified base:

```text
uv run --frozen --no-sync python -m pytest tests/unit_tests/models/gemma/test_gemma3_bridge.py::TestAutoBridgeIntegration::test_config_only_provider_uses_in_memory_config -q
1 failed: AutoConfig.from_pretrained("") raised OSError for the empty repository/path identifier
```

Pass-after:

```text
uv run --frozen --no-sync python -m pytest tests/unit_tests/models/gemma/test_gemma3_bridge.py::TestAutoBridgeIntegration::test_config_only_provider_uses_in_memory_config -q
1 passed

uv run --frozen --no-sync python -m pytest tests/unit_tests/models/gemma/test_gemma3_bridge.py tests/unit_tests/models/test_auto_bridge.py -k "gemma3_bridge or from_hf_config_passes_causal_wrapper_to_vlm_provider_bridge" -q
23 passed, 75 deselected

git diff --check
passed

uv run --frozen --no-sync pre-commit run --all-files
passed
```

# Scope

This is a CPU-only config/provider construction fix. No GPU training, convergence, performance, full-suite, checkpoint, dependency, CI workflow, or public API validation is claimed.

# Before your PR is "Ready for review"

- [x] Read and followed the contributor guidelines.
- [x] Added the focused regression test.
- [x] No documentation change is necessary because this restores the existing documented contract.
- [x] No optional dependency behavior is changed.
