### PR TITLE
[docs] fix: Align async inference examples with Bridge CLI

### DIFF
--- a/examples/inference/README.md
+++ b/examples/inference/README.md
@@ -82,19 +82,15 @@ launching, such as `WORKSPACE`, `HF_MODEL_ID`, `MEGATRON_MODEL_PATH`,
 
 ## Concurrent Async Generation
 
-`scripts/inference/async_text_generation.py` is intentionally direct
-MCore-style. It does not use `AutoBridge`; pass normal Megatron
-training/inference arguments such as `--load`, tokenizer args, model provider,
-and parallelism settings.
+`scripts/inference/async_text_generation.py` uses the same Bridge/AutoBridge
+model loading and shared inference arguments as the synchronous entrypoint.
 
 ```bash
-bash examples/inference/run_async_text_generation.sh --nproc 8 \
-  --load /path/to/megatron/checkpoint \
-  --tokenizer-type HuggingFaceTokenizer \
-  --tokenizer-model Qwen/Qwen2.5-1.5B \
-  --model-provider gpt \
-  --bf16 \
-  --prompts "Megatron async inference is" "Concurrent generation is"
+bash examples/inference/run_async_text_generation.sh --nproc 1 \
+  --hf_model_path Qwen/Qwen2.5-1.5B \
+  --dtype bf16 \
+  --prompt "Megatron async inference is" \
+  --prompt "Concurrent generation is"
 ```
 
 The async example uses `MegatronAsyncLLM` in coordinator mode and submits
@@ -102,16 +98,13 @@ multiple prompts concurrently from the primary rank.
 
 ## OpenAI-Compatible Server
 
-`scripts/inference/openai_server.py` is also direct MCore-style and uses
-`MegatronAsyncLLM.serve(...)`.
+`scripts/inference/openai_server.py` uses the Bridge/AutoBridge model-loading
+arguments and serves requests through `MegatronAsyncLLM.serve(...)`.
 
 ```bash
-bash examples/inference/run_openai_server.sh --nproc 8 \
-  --load /path/to/megatron/checkpoint \
-  --tokenizer-type HuggingFaceTokenizer \
-  --tokenizer-model Qwen/Qwen2.5-1.5B \
-  --model-provider gpt \
-  --bf16 \
+bash examples/inference/run_openai_server.sh --nproc 1 \
+  --hf_model_path Qwen/Qwen2.5-1.5B \
+  --dtype bf16 \
   --host 0.0.0.0 \
   --port 5000
 ```

--- a/examples/inference/run_async_text_generation.sh
+++ b/examples/inference/run_async_text_generation.sh
@@ -17,18 +17,16 @@ set -euo pipefail
 
 usage() {
     cat <<'USAGE'
-Run direct MCore-style concurrent async text generation.
+Run Bridge/AutoBridge-backed concurrent async text generation.
 
 Example:
-  examples/inference/run_async_text_generation.sh --nproc 8 \
-    --load /path/to/megatron/checkpoint \
-    --tokenizer-type HuggingFaceTokenizer \
-    --tokenizer-model Qwen/Qwen2.5-1.5B \
-    --model-provider gpt \
-    --bf16 \
-    --prompts "Megatron async inference is" "Concurrent generation is"
+  examples/inference/run_async_text_generation.sh --nproc 1 \
+    --hf_model_path Qwen/Qwen2.5-1.5B \
+    --dtype bf16 \
+    --prompt "Megatron async inference is" \
+    --prompt "Concurrent generation is"
 
-Pass Megatron training/inference arguments after --nproc.
+Pass scripts/inference/async_text_generation.py arguments after --nproc.
 USAGE
 }
 

--- a/examples/inference/run_openai_server.sh
+++ b/examples/inference/run_openai_server.sh
@@ -17,19 +17,16 @@ set -euo pipefail
 
 usage() {
     cat <<'USAGE'
-Run a direct MCore-style OpenAI-compatible inference server.
+Run a Bridge/AutoBridge-backed OpenAI-compatible inference server.
 
 Example:
-  examples/inference/run_openai_server.sh --nproc 8 \
-    --load /path/to/megatron/checkpoint \
-    --tokenizer-type HuggingFaceTokenizer \
-    --tokenizer-model Qwen/Qwen2.5-1.5B \
-    --model-provider gpt \
-    --bf16 \
+  examples/inference/run_openai_server.sh --nproc 1 \
+    --hf_model_path Qwen/Qwen2.5-1.5B \
+    --dtype bf16 \
     --host 0.0.0.0 \
     --port 5000
 
-Pass Megatron training/inference/server arguments after --nproc.
+Pass scripts/inference/openai_server.py arguments after --nproc.
 USAGE
 }
 


### PR DESCRIPTION
# What does this PR do ?

Aligns the public async text-generation and OpenAI server examples with the Bridge/AutoBridge CLI their entrypoints now use.

The published commands still passed the old Megatron reference-layer options (`--load`, tokenizer/provider flags, `--bf16`, and `--prompts`). The launch wrappers forward those options unchanged, while the current scripts use strict Bridge parsers, so both documented workflows exited in argparse before loading a model.

# Changelog

- Describe async generation and the server as Bridge/AutoBridge entrypoints.
- Replace removed model-loading and precision options with `--hf_model_path` and `--dtype bf16`.
- Use repeatable singular `--prompt` in the async example.
- Keep both wrapper `--help` examples synchronized with the README commands.

# Root cause and fix

PR #4475 migrated `scripts/inference/async_text_generation.py` and `scripts/inference/openai_server.py` from the Megatron reference-layer parser to the shared Bridge parser. The public README and wrapper help added earlier were not migrated with those entrypoints.

This patch changes only the three stale documentation/help surfaces. It does not add compatibility aliases or alter the current CLI, model loading, or inference runtime.

# Validation

A standalone deterministic contract reproducer reads the published README/help options and the actual parser `add_argument` definitions.

```text
uv run --no-project python reproduce_cli_contract.py .

Before: exit 1; async and server README/help each reported the obsolete options as unsupported.
After:  exit 0; all published async/server options are accepted by their current parsers.
```

Additional checks:

```text
bash -n examples/inference/run_async_text_generation.sh examples/inference/run_openai_server.sh
bash examples/inference/run_async_text_generation.sh --help
bash examples/inference/run_openai_server.sh --help
git diff --check
uv run --no-sync pre-commit run --all-files
```

All passed. No GPU, model execution, performance, convergence, or full test-suite validation is claimed; the changed boundary is documentation and executable shell help only.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] Added the focused deterministic contract reproduction needed for this bug audit; no repository test file is needed for the documentation-only patch.
- [x] Updated the affected documentation and executable help text.
- [x] Confirmed this does not affect optional-install components.

# Additional Information

No existing issue or open PR was found for this root cause.
