### PR TITLE
build(fw_final): retry jackson-core fetch on Maven throttling

### DIFF
--- a/docker/Dockerfile.fw_final
+++ b/docker/Dockerfile.fw_final
@@ -97,10 +97,14 @@ RUN pip install "starlette==0.49.1" \
 # The actual onnx Python package is managed above via pip/uv; this stale copy triggers CVE scanners.
 RUN rm -rf /opt/pytorch/pytorch/third_party/onnx
 
-# Patch jackson-core CVE inside Ray's bundled fat-jar (cannot upgrade Ray itself)
+# Patch jackson-core CVE inside Ray's bundled fat-jar (cannot upgrade Ray itself).
+# Maven Central throttles CI egress IPs (HTTP 429/503); --retry-on-http-error makes
+# wget retry those instead of aborting the build (wget ignores --tries for HTTP errors).
 RUN JACKSON_VERSION=2.18.6 && \
     TMPDIR=$(mktemp -d) && \
-    wget -q "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/${JACKSON_VERSION}/jackson-core-${JACKSON_VERSION}.jar" \
+    wget -nv --tries=5 --waitretry=10 --retry-connrefused \
+    --retry-on-http-error=429,500,502,503,504 \
+    "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/${JACKSON_VERSION}/jackson-core-${JACKSON_VERSION}.jar" \
     -O "${TMPDIR}/jackson-core-fixed.jar" && \
     unzip -q "${TMPDIR}/jackson-core-fixed.jar" -d "${TMPDIR}/jackson_fixed" && \
     apt-get update && apt-get install -y --no-install-recommends zip && apt-get clean && \


### PR DESCRIPTION
## Background

`build-NeMo-FW-final-sbsa` on nemo-ci `r26.06` (job `366020715`, project `dl/joc/nemo-ci`) failed at `Dockerfile.fw_final:101` with **exit code 8**.

- That layer patches the jackson-core CVE inside Ray's bundled `ray_dist.jar` by fetching the fixed jar from **Maven Central at build time**.
- Maven Central throttles CI egress IPs (HTTP **429/503**). `wget` **aborts on the first HTTP error** — `--tries` only retries *network-level* failures (connection refused / timeout), **not** HTTP error responses. So one transient throttle takes the whole build down.

## What changed

- Harden the `wget` in the jackson patch layer with `--retry-on-http-error=429,500,502,503,504` + `--tries=5 --waitretry=10 --retry-connrefused`.
- Switch `-q` → `-nv` so a genuine failure surfaces the HTTP status in the build log (the old `-q` is why the failing trace showed only "exit 8").

No dependency / CVE-posture change — the patch and versions are untouched. This is deliberately the release-safe fix (vs. `main`, which dropped the layer entirely).

## Details

- `docker/Dockerfile.fw_final` — only the `wget` invocation and the comment above the `RUN`.
- `--retry-on-http-error` is the load-bearing flag; it exists since wget 1.20, and the base image (Ubuntu 24.04) ships 1.21.4.

## Tested

`wget` ignores `--tries` for HTTP errors, so a bare retry bump would be a no-op — verified against a real 503:

```console
# A) --tries=4, NO --retry-on-http-error  → gives up on first 503 (exit 8)
$ wget --tries=4 -O /dev/null https://httpbin.org/status/503
HTTP request sent, awaiting response... 503 Service Temporarily Unavailable
ERROR 503: Service Temporarily Unavailable.

# B) + --retry-on-http-error=503            → actually retries
HTTP request sent... 503 ... Retrying.
HTTP request sent... 503 ... Retrying.
HTTP request sent... 503 ... Retrying.
```

The exact hardened command against the real artifact succeeds:

```console
$ wget -nv --tries=5 --waitretry=10 --retry-connrefused \
    --retry-on-http-error=429,500,502,503,504 \
    "https://repo1.maven.org/maven2/.../jackson-core-2.18.6.jar" -O jackson-core-fixed.jar
URL:.../jackson-core-2.18.6.jar [589904/589904] -> "jackson-core-fixed.jar" [1]   # exit 0, valid JAR
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
