### PR TITLE
[data] fix: respect drop_last for iteration training

### DIFF
--- a/src/megatron/bridge/data/loaders.py
+++ b/src/megatron/bridge/data/loaders.py
@@ -268,7 +268,7 @@ def build_train_valid_test_data_loaders(
         cfg=cfg, build_train_valid_test_datasets_provider=build_train_valid_test_datasets_provider
     )
 
-    drop_last = cfg.train.num_epochs is None
+    drop_last = False if cfg.train.num_epochs is not None else cfg.dataset.drop_last
 
     # Check that the train dataset has at least one global batch of samples.
     if (

--- a/tests/functional_tests/test_groups/data/test_loaders.py
+++ b/tests/functional_tests/test_groups/data/test_loaders.py
@@ -335,6 +335,44 @@ class TestDataLoaders:
         assert test_call.kwargs["data_parallel_rank"] == 0
         assert test_call.kwargs["data_parallel_size"] == 1
 
+    @mock.patch("torch.distributed.broadcast")
+    @mock.patch("torch.distributed.get_world_size", return_value=1)
+    @mock.patch("torch.distributed.get_rank", return_value=0)
+    def test_iteration_based_loader_respects_drop_last_false(self, _mock_rank, _mock_world_size, _mock_broadcast):
+        class PaddingAwareDataset:
+            def __len__(self):
+                return 3
+
+            def __getitem__(self, index):
+                return index
+
+        cfg = create_simple_test_config()
+        cfg.train.global_batch_size = 4
+        cfg.validation.eval_iters = 0
+        cfg.dataset = GPTSFTDatasetConfig(
+            dataset_root="/tmp/dataset",
+            seq_length=512,
+            drop_last=False,
+            num_workers=0,
+            persistent_workers=False,
+        )
+        real_torch_tensor = torch.tensor
+
+        with mock.patch(
+            "megatron.bridge.data.loaders.torch.tensor",
+            side_effect=lambda data, *, dtype, device: real_torch_tensor(data, dtype=dtype),
+        ):
+            train_dataloader, _, _ = build_train_valid_test_data_loaders(
+                cfg=cfg,
+                train_state=TrainState(),
+                build_train_valid_test_datasets_provider=mock.Mock(return_value=(PaddingAwareDataset(), None, None)),
+                dp_group=object(),
+            )
+
+        batch = next(iter(train_dataloader)).tolist()
+        assert sorted(batch[:-1]) == [0, 1, 2]
+        assert batch[-1] == -1
+
 
 class TestSampleBasedDataLoaders:
     """Tests for sample-based training data loader functionality."""


### PR DESCRIPTION
## Summary

Honor `DataloaderConfig.drop_last` for iteration-based training data loaders.

## Bug

An iteration-based SFT configuration can explicitly set `drop_last=False`, but `build_train_valid_test_data_loaders()` replaces that setting with `True` whenever `num_epochs` is unset. A supported finite training dataset with 3 samples and global batch size 4 therefore raises `RuntimeError: Not enough train samples for a single global batch` instead of returning the sampler's padded partial batch. Larger non-divisible datasets silently discard their tail despite the explicit configuration.

The full path is dataset config -> standard train loader -> minimum-size guard -> `MegatronPretrainingBatchSampler`. The sampler already supports `drop_last=False` by padding the partial batch with `-1`; GPT-SFT handles those sentinels as autogenerated samples with zero loss mask.

## Fix

Use `cfg.dataset.drop_last` for iteration-based training while retaining the existing forced `False` policy for epoch-based training. This keeps the minimum-size guard and sampler on the same effective policy.

## Verification

The unchanged isolated reproducer failed against `878c698dc796d1e913db631dc46891d38385dedc` with the expected minimum-global-batch error and passed after the fix with the incomplete batch retained and padded.

Focused regression plus adjacent partial-batch sampler controls:

```bash
uv run --no-project python -m pytest --confcutdir=tests/functional_tests/test_groups/data -q \
  tests/functional_tests/test_groups/data/test_loaders.py::TestDataLoaders::test_iteration_based_loader_respects_drop_last_false \
  tests/functional_tests/test_groups/data/test_samplers.py::TestMegatronPretrainingBatchSampler::test_batch_sampler_incomplete_batch_drop_last_false \
  tests/functional_tests/test_groups/data/test_samplers.py::TestMegatronPretrainingBatchSampler::test_batch_sampler_incomplete_batch_with_padding \
  tests/functional_tests/test_groups/data/test_samplers.py::TestMegatronPretrainingBatchSampler::test_batch_sampler_drop_last_false_small_dataset_cycles_after_padding
```

Result: `4 passed`.

```bash
git diff --check
uv run --no-project pre-commit run --all-files
```

Both passed.

## Scope

This changes only standard iteration-based train-loader propagation. Epoch-based behavior remains unchanged. Evaluation/test partial-batch policy and cyclic/MIMO samplers are outside this PR.
