### PR TITLE
build(deps): upgrade Transformers to 5.12.1

### DIFF
--- a/.github/workflows/cache-hf-model.yml
+++ b/.github/workflows/cache-hf-model.yml
@@ -39,8 +39,23 @@ jobs:
 
       - name: Install dependencies
         run: |
-          TRANSFORMERS_VERSION=$(grep -E 'transformers[[:space:]]*[=><!~]+' ${GITHUB_WORKSPACE}/pyproject.toml | sed -E 's/.*transformers[[:space:]]*([=><!~]+)[[:space:]]*"?([0-9a-zA-Z\.\-\*]+)"?.*/\1\2/')
-          pip install torch "transformers${TRANSFORMERS_VERSION}" "huggingface_hub[cli]"
+          TRANSFORMERS_REQUIREMENT=$(
+            python - "${GITHUB_WORKSPACE}/pyproject.toml" <<'PY'
+          import re
+          import sys
+          import tomllib
+
+          with open(sys.argv[1], "rb") as pyproject:
+              dependencies = tomllib.load(pyproject)["project"]["dependencies"]
+
+          pattern = re.compile(r"^transformers(?:$|[\s\[<>=!~;@])", re.IGNORECASE)
+          requirement = next((item for item in dependencies if pattern.match(item)), None)
+          if requirement is None:
+              raise SystemExit("Transformers requirement not found in pyproject.toml")
+          sys.stdout.write(requirement)
+          PY
+          )
+          pip install torch "${TRANSFORMERS_REQUIREMENT}" "huggingface_hub[cli]"
 
       - name: Log in to HuggingFace
         env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ classifiers = [
     "Topic :: Utilities",
 ]
 dependencies = [
-    "transformers>=5.8.1,<5.9.0",
+    "transformers>=5.8,<=5.12.1",
     "mistral-common>=1.10.0",
     "peft>=0.18.1",
     "datasets>=2.20.0",

--- a/src/megatron/bridge/models/qwen_audio/modeling_qwen2_audio.py
+++ b/src/megatron/bridge/models/qwen_audio/modeling_qwen2_audio.py
@@ -41,17 +41,29 @@ if TYPE_CHECKING:
 # Import HuggingFace Qwen2Audio model classes with fallback
 try:
     from transformers import Qwen2AudioForConditionalGeneration
+    from transformers.models.qwen2_audio import modeling_qwen2_audio as hf_modeling_qwen2_audio
     from transformers.models.qwen2_audio.modeling_qwen2_audio import (
         Qwen2AudioEncoder,
         Qwen2AudioMultiModalProjector,
     )
 
+    HFQwen2AudioModel = getattr(hf_modeling_qwen2_audio, "Qwen2AudioModel", None)
     HAS_QWEN2_AUDIO = True
 except ImportError:
     Qwen2AudioForConditionalGeneration = None
     Qwen2AudioEncoder = None
     Qwen2AudioMultiModalProjector = None
+    HFQwen2AudioModel = None
     HAS_QWEN2_AUDIO = False
+
+
+_QWEN2_AUDIO_MERGE_METHOD = None
+if HAS_QWEN2_AUDIO:
+    _QWEN2_AUDIO_MERGE_METHOD = getattr(
+        Qwen2AudioForConditionalGeneration, "_merge_input_ids_with_audio_features", None
+    )
+    if _QWEN2_AUDIO_MERGE_METHOD is None and HFQwen2AudioModel is not None:
+        _QWEN2_AUDIO_MERGE_METHOD = getattr(HFQwen2AudioModel, "_merge_input_ids_with_audio_features", None)
 
 
 class Qwen2AudioModel(MegatronModule):
@@ -141,11 +153,9 @@ class Qwen2AudioModel(MegatronModule):
         self.share_embeddings_and_output_weights = config.share_embeddings_and_output_weights
         self.shared_embedding_or_output_weight = self.language_model.shared_embedding_or_output_weight
 
-        # Monkey-patch methods from HuggingFace Qwen2AudioForConditionalGeneration
-        if HAS_QWEN2_AUDIO and Qwen2AudioForConditionalGeneration is not None:
-            self._merge_input_ids_with_audio_features = types.MethodType(
-                Qwen2AudioForConditionalGeneration._merge_input_ids_with_audio_features, self
-            )
+        # Bind the merge method from the Hugging Face Qwen2-Audio implementation.
+        if _QWEN2_AUDIO_MERGE_METHOD is not None:
+            self._merge_input_ids_with_audio_features = types.MethodType(_QWEN2_AUDIO_MERGE_METHOD, self)
 
         # Store audio token id from config
         self.audio_token_id = getattr(config, "audio_token_id", 151646)

--- a/tests/functional_tests/test_groups/models/ministral3/test_ministral3_conversion.py
+++ b/tests/functional_tests/test_groups/models/ministral3/test_ministral3_conversion.py
@@ -18,6 +18,10 @@ from pathlib import Path
 
 import pytest
 import torch
+from tokenizers import Tokenizer
+from tokenizers.models import WordLevel
+from tokenizers.pre_tokenizers import Whitespace
+from transformers import PreTrainedTokenizerFast
 
 
 # Ministral 3 toy model configuration based on typical Ministral 3 structure
@@ -105,19 +109,19 @@ class TestMinistral3Conversion:
             print(f"Before save - {name}: {param.dtype}")
             break  # Just check the first parameter
 
-        # Create minimal tokenizer files
-        tokenizer_config = {
-            "tokenizer_class": "LlamaTokenizer",
-            "vocab_size": 32768,
-            "bos_token": "<s>",
-            "eos_token": "</s>",
-            "pad_token": "<pad>",
-            "unk_token": "<unk>",
-        }
-
         model_dir.mkdir(parents=True, exist_ok=True)
-        with open(model_dir / "tokenizer_config.json", "w") as f:
-            json.dump(tokenizer_config, f, indent=2)
+
+        # Save a valid tokenizer artifact so both Transformers 5.8 and 5.12 can reload it.
+        backend_tokenizer = Tokenizer(WordLevel({"<unk>": 0, "<s>": 1, "</s>": 2, "<pad>": 3}, unk_token="<unk>"))
+        backend_tokenizer.pre_tokenizer = Whitespace()
+        tokenizer = PreTrainedTokenizerFast(
+            tokenizer_object=backend_tokenizer,
+            unk_token="<unk>",
+            bos_token="<s>",
+            eos_token="</s>",
+            pad_token="<pad>",
+        )
+        tokenizer.save_pretrained(model_dir)
 
         # Save model and config to directory
         model.save_pretrained(model_dir, safe_serialization=True)

--- a/tests/unit_tests/models/qwen_audio/test_qwen2_audio_provider.py
+++ b/tests/unit_tests/models/qwen_audio/test_qwen2_audio_provider.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from megatron.bridge.models.qwen_audio import Qwen2AudioModelProvider
+from megatron.bridge.models.qwen_audio.modeling_qwen2_audio import _QWEN2_AUDIO_MERGE_METHOD
 
 
 class TestQwen2AudioModelProvider:
@@ -29,6 +30,10 @@ class TestQwen2AudioModelProvider:
         assert provider.num_layers == 32
         assert provider.hidden_size == 4096
         assert provider.num_attention_heads == 32
+
+    def test_hf_audio_merge_method_is_available(self):
+        """Test that the installed Transformers version exposes the audio merge helper."""
+        assert _QWEN2_AUDIO_MERGE_METHOD is not None
 
     def test_audio_specific_defaults(self):
         """Test Qwen2AudioModelProvider audio-specific default configuration."""

--- a/uv.lock
+++ b/uv.lock
@@ -2210,7 +2210,7 @@ requires-dist = [
     { name = "torch", specifier = ">=2.6.0" },
     { name = "tqdm", specifier = ">=4.67.1" },
     { name = "transformer-engine", extras = ["core-cu13", "pytorch"], marker = "extra == 'te'" },
-    { name = "transformers", specifier = ">=5.8.1,<5.9.0" },
+    { name = "transformers", specifier = ">=5.8,<=5.12.1" },
     { name = "typing-extensions" },
     { name = "wandb", specifier = ">=0.25.0" },
 ]
@@ -4869,7 +4869,7 @@ dependencies = [
 
 [[package]]
 name = "transformers"
-version = "5.8.1"
+version = "5.12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
@@ -4882,9 +4882,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e7/e6/4134ea2fbea322cddc7ffc94a0d8ee47fe32ce8e876b320cd37d88edfc4d/transformers-5.8.1.tar.gz", hash = "sha256:4dd5b6de4105725104d84fd6abd74b305f4debfc251b38c648ee5dd087cf543b", size = 8532019, upload-time = "2026-05-13T03:21:57.234Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/7c/8240f612819718100a9346dc28dea6a11370c3ca9c8c6eabadd3dea4ef29/transformers-5.12.1.tar.gz", hash = "sha256:679ee731c8225347889ad4fb3b2c926a62e9da3b7d284e9d12c791da7272466b", size = 8924054, upload-time = "2026-06-15T17:27:50.604Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/b1/8be7e7ef0b5200491312201918b6125ef9c9df9dd0f0240ccef9ac824e6b/transformers-5.8.1-py3-none-any.whl", hash = "sha256:5340fb95962162cdfdae5cc91d7f8fedd92ed75216c1154c5e1f590fcf56dd0e", size = 10632882, upload-time = "2026-05-13T03:21:52.876Z" },
+    { url = "https://files.pythonhosted.org/packages/df/56/bbd60dd8668055803bf8ba55a81f9b8a8b31497f620109a9671d26a2076d/transformers-5.12.1-py3-none-any.whl", hash = "sha256:2a5e109d2021265df7098ffbb738295acaf5ad256f12cbc586db2ea4dcbb1a8a", size = 11150587, upload-time = "2026-06-15T17:27:46.679Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- expand the declared Transformers compatibility range from `>=5.8.1,<5.9.0` to `>=5.8,<=5.12.1`
- regenerate `uv.lock` so Transformers resolves and pins exactly to 5.12.1
- support the Qwen2 Audio merge helper at its Transformers 5.8.1 and 5.12.1 locations
- replace the Ministral3 functional test's incomplete tokenizer stub with a valid tiny tokenizer artifact accepted by both supported endpoints
- preserve the complete Transformers compatibility range in the manually dispatched Hugging Face model-cache workflow

## Rationale

Transformers 5.12 provides native support needed by newer model paths, including native MiniMax M3 model execution. Megatron Bridge's existing MiniMax M3 checkpoint-conversion path did not import-fail on 5.8.1 because it registers the remote architecture by string, loads configuration lazily, and reads raw safetensor state without instantiating the native HF model class.

The first full CI run exposed two deterministic compatibility issues. Transformers 5.12.1 moved Qwen2 Audio's private merge helper from `Qwen2AudioForConditionalGeneration` to the inner `Qwen2AudioModel`; the two endpoint implementations are identical, so Bridge now selects the available location by capability rather than version. Transformers 5.12.1 also rejects the Ministral3 test's metadata-only tokenizer stub, so the fixture now saves a real tokenizer artifact. The unrelated Gemma1 BF16 tolerance failure reproduced previously under Transformers 5.8.1 and passed its authorized retry on PR #4772; this PR does not add a Gemma workaround.

The dependency audit found one live root constraint. MCore's optional Transformers uses are unversioned and therefore resolve through this root range. Historical release-version documentation and checkpoint metadata are not live constraints. The manually dispatched model-cache workflow previously kept only the first comparator from any Transformers requirement, so it could ignore the supported upper bound. It now parses `pyproject.toml` with Python 3.12 `tomllib` and passes the complete requirement unchanged to `pip`.

## Validation

- `uv lock --check`; exact lock resolution `transformers==5.12.1`
- locked sync and runtime assertion `transformers.__version__ == "5.12.1"`
- Transformers 5.12.1:
  - Qwen2 Audio unit directory: 33 passed
  - exact two-GPU Qwen2 Audio generation test that failed CI: passed
  - complete Ministral3 functional suite: 4 passed
- Transformers 5.8.1 compatibility endpoint:
  - Qwen2 Audio provider units: 13 passed
  - exact two-GPU Qwen2 Audio generation test: passed
  - Ministral3 toy artifact creation and TP roundtrip: passed
- original Transformers-sensitive coverage: 266 passed
- cache-workflow YAML parsing, extracted-step `bash -n`, and exact requirement assertion: `transformers>=5.8,<=5.12.1`
- `uv run pre-commit run --all-files`
- fresh independent review of the complete six-file diff and CI evidence: no actionable findings

## Full CI evidence

- [Initial run 29594927959](https://github.com/NVIDIA-NeMo/Megatron-Bridge/actions/runs/29594927959): diagnosed the Qwen2 Audio and Ministral3 upgrade regressions plus one unrelated Gemma1 flake.
- [Fixed-code run 29615573603](https://github.com/NVIDIA-NeMo/Megatron-Bridge/actions/runs/29615573603): both Qwen2 Audio shards, both Ministral3 shards, Gemma1, unit tests, imports, lint, container builds, and every GB200 shard passed. The only failing test shards were two AWS H100 runners with driver API 12080, which was too old for the container's PyTorch/CUDA stack; one failed when Transformer Engine could not initialize CUDA and the other when `torch.cuda.get_device_properties(0)` initialized CUDA. They were separate runners with the same infrastructure error and were not retried.

After rebasing onto current `main`, the final diff remains limited to six files and `uv lock --check`, `git diff --check`, workflow syntax checks, and all-files pre-commit pass.
