### PR TITLE
[misc] fix: Make standalone top-p sampling usable

### DIFF
--- a/src/megatron/bridge/inference/text_generation.py
+++ b/src/megatron/bridge/inference/text_generation.py
@@ -359,7 +359,7 @@ def build_inference_config(
 def build_sampling_params(
     *,
     temperature: float,
-    top_k: int,
+    top_k: int | None,
     top_p: float,
     return_log_probs: bool,
     skip_prompt_log_probs: bool,
@@ -369,6 +369,10 @@ def build_sampling_params(
     stop_words: list[str] | None,
 ) -> SamplingParams:
     """Build MCore ``SamplingParams`` from CLI-derived values."""
+    if top_k is None:
+        top_k = 0 if top_p > 0.0 else 1
+    if top_k > 0 and top_p > 0.0:
+        raise ValueError("--top_k and --top_p cannot both be positive.")
     return SamplingParams(
         temperature=temperature,
         top_k=top_k,
@@ -469,7 +473,12 @@ def add_sampling_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParse
     group.add_argument("--max_new_tokens", type=int, default=30, help="Maximum generated tokens per prompt.")
     group.add_argument("--temperature", type=float, default=1.0, help="Sampling temperature.")
     group.add_argument("--top_p", type=float, default=0.0, help="Top-p sampling.")
-    group.add_argument("--top_k", type=int, default=1, help="Top-k sampling.")
+    group.add_argument(
+        "--top_k",
+        type=int,
+        default=None,
+        help="Top-k sampling. Defaults to 1 unless --top_p is set.",
+    )
     group.add_argument("--return-log-probs", action="store_true", help="Return token log probabilities.")
     group.add_argument("--skip-prompt-log-probs", action="store_true", help="Skip prompt log probabilities.")
     group.add_argument("--top-n-logprobs", type=int, default=0, help="Return top-n logprobs.")

--- a/tests/unit_tests/scripts/test_text_generation.py
+++ b/tests/unit_tests/scripts/test_text_generation.py
@@ -23,6 +23,7 @@ from enum import Enum
 from pathlib import Path
 
 import pytest
+from megatron.core.inference.sampling.torch_sampling import TorchSampling
 
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -287,3 +288,64 @@ def test_validate_sequence_length(text_generation):
     # exceeds -> raise
     with pytest.raises(ValueError, match="Longest prompt plus generation needs"):
         text_generation.validate_sequence_length(longest_prompt_tokens=4090, num_new_tokens=30, max_seq_length=4096)
+
+
+def _parse_sampling_params(text_generation, cli_args):
+    parser = text_generation.argparse.ArgumentParser()
+    text_generation.add_sampling_args(parser)
+    args = parser.parse_args(cli_args)
+    return text_generation.build_sampling_params(
+        temperature=args.temperature,
+        top_k=args.top_k,
+        top_p=args.top_p,
+        return_log_probs=args.return_log_probs,
+        skip_prompt_log_probs=args.skip_prompt_log_probs,
+        num_tokens_to_generate=args.max_new_tokens,
+        termination_id=args.termination_id,
+        top_n_logprobs=args.top_n_logprobs,
+        stop_words=args.stop_words,
+    )
+
+
+def test_top_p_sampling_is_compatible_with_default_cli_values(text_generation):
+    params = _parse_sampling_params(text_generation, ["--top_p", "0.9"])
+    logits = text_generation.torch.tensor([[1.0, 2.0, 3.0]])
+
+    sampled = TorchSampling.sample_from_logits(
+        logits,
+        params.kwargs["temperature"],
+        params.kwargs["top_k"],
+        params.kwargs["top_p"],
+        generator=text_generation.torch.Generator().manual_seed(0),
+    )
+
+    assert params.kwargs["top_k"] == 0
+    assert sampled.shape == (1,)
+
+
+def test_default_sampling_remains_greedy(text_generation):
+    params = _parse_sampling_params(text_generation, [])
+    logits = text_generation.torch.tensor([[1.0, 2.0, 3.0]])
+
+    sampled = TorchSampling.sample_from_logits(
+        logits,
+        params.kwargs["temperature"],
+        params.kwargs["top_k"],
+        params.kwargs["top_p"],
+        generator=text_generation.torch.Generator().manual_seed(0),
+    )
+
+    assert params.kwargs["top_k"] == 1
+    assert sampled.item() == 2
+
+
+def test_top_p_sampling_accepts_explicitly_disabled_top_k(text_generation):
+    params = _parse_sampling_params(text_generation, ["--top_p", "0.9", "--top_k", "0"])
+
+    assert params.kwargs["top_k"] == 0
+    assert params.kwargs["top_p"] == 0.9
+
+
+def test_sampling_rejects_positive_top_p_and_top_k(text_generation):
+    with pytest.raises(ValueError, match="cannot both be positive"):
+        _parse_sampling_params(text_generation, ["--top_p", "0.9", "--top_k", "2"])


### PR DESCRIPTION
## Summary

The shared offline inference CLI advertises `--top_p`, but supplying it alone retained the active `--top_k=1` default. Sync dynamic, sync legacy-static, and async generation passed both positive values through `SamplingParams`; the pinned MCore torch sampler then raised `AssertionError: Cannot have top-p and top-k both greater than zero` after model/distributed initialization.

This change represents an omitted top-k as `None` and resolves it when constructing sampling parameters:

- default invocation remains greedy (`top_k=1`, `top_p=0.0`)
- standalone positive top-p disables top-k (`top_k=0`)
- explicit `top_k=0` with positive top-p remains supported
- explicitly positive top-k and top-p are rejected with `ValueError`

## Regression evidence

Before the production fix, the new contract test parsed only `--top_p 0.9`, invoked the real pinned MCore CPU torch sampler, and failed with:

```text
AssertionError: Cannot have top-p and top-k both greater than zero
```

After the fix, the unchanged test passes.

Validation:

```text
uv run --no-sync python -m pytest --confcutdir=tests/unit_tests/scripts tests/unit_tests/scripts/test_text_generation.py::test_top_p_sampling_is_compatible_with_default_cli_values -q
# 1 passed

uv run --no-sync python -m pytest --confcutdir=tests/unit_tests/scripts tests/unit_tests/scripts/test_text_generation.py -q
# 16 passed

uv run --no-sync pre-commit run --all-files
# all hooks passed

git diff --check
# passed
```

## Scope

The patch changes only the shared sampling argument/constructor helper and its focused unit tests. It does not change dependencies, lockfiles, workflows, the MCore submodule, server-side request sampling, or model code. No GPU, distributed, convergence, performance, or full-suite validation is claimed.