### PR TITLE
fix(recipe): propagate GLM-4.5V Slurm failures

### DIFF
--- a/examples/models/glm/glm_45v/slurm_peft.sh
+++ b/examples/models/glm/glm_45v/slurm_peft.sh
@@ -161,7 +161,9 @@ if [ -n "$CONTAINER_MOUNTS" ]; then
 fi
 
 $SRUN_CMD bash -c "$CMD"
+RUN_EXIT=$?
 
 echo "======================================"
-echo "Job completed"
+echo "Training job finished. EXIT=$RUN_EXIT"
 echo "======================================"
+exit $RUN_EXIT

--- a/examples/models/glm/glm_45v/slurm_sft.sh
+++ b/examples/models/glm/glm_45v/slurm_sft.sh
@@ -159,7 +159,9 @@ if [ -n "$CONTAINER_MOUNTS" ]; then
 fi
 
 $SRUN_CMD bash -c "$CMD"
+RUN_EXIT=$?
 
 echo "======================================"
-echo "Job completed"
+echo "Training job finished. EXIT=$RUN_EXIT"
 echo "======================================"
+exit $RUN_EXIT

--- a/tests/unit_tests/examples/test_glm_45v_slurm.py
+++ b/tests/unit_tests/examples/test_glm_45v_slurm.py
@@ -1,0 +1,46 @@
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+GLM_45V_EXAMPLES = REPO_ROOT / "examples" / "models" / "glm" / "glm_45v"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("script_name", ["slurm_sft.sh", "slurm_peft.sh"])
+def test_glm_45v_slurm_wrappers_propagate_training_failure(tmp_path: Path, script_name: str) -> None:
+    """The batch script must return a failed synchronous training step."""
+    source_script = GLM_45V_EXAMPLES / script_name
+    configured_script = tmp_path / script_name
+    source = source_script.read_text()
+    configured = source.replace('CONTAINER_IMAGE=""', 'CONTAINER_IMAGE="fake.sqsh"', 1)
+    assert configured != source
+    configured_script.write_text(configured)
+
+    srun = tmp_path / "srun"
+    srun.write_text("#!/bin/bash\nexit 42\n")
+    srun.chmod(0o755)
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{tmp_path}:{env['PATH']}",
+            "SLURM_GPUS_PER_NODE": "8",
+            "SLURM_JOB_ID": "1234",
+            "SLURM_JOB_NUM_NODES": "1",
+        }
+    )
+
+    result = subprocess.run(
+        ["bash", str(configured_script)],
+        capture_output=True,
+        check=False,
+        cwd=tmp_path,
+        env=env,
+        text=True,
+    )
+
+    assert result.returncode == 42


### PR DESCRIPTION
## Summary

The README-documented GLM-4.5V SFT and PEFT Slurm wrappers returned success whenever their synchronous `srun` training step returned a normal nonzero status. This could make failed multi-node training jobs look successful to Slurm automation and allow dependent jobs to run after a missing or partial checkpoint.

## Root cause

Both wrappers ran three successful footer `echo` commands after `srun` without first saving its status. Bash therefore returned the final `echo` status (zero), not the training status.

## Fix

- Capture `srun`'s status immediately in `RUN_EXIT`.
- Report the captured status and explicitly exit with it in both SFT and PEFT wrappers.
- Add a parameterized black-box test that applies the documented container-image configuration to a temporary copy of each real wrapper and uses a fake `srun` returning 42.

## Validation

- Regression before fix: `uv run --no-project --python /usr/bin/python3 --with pytest python -m pytest --confcutdir=tests/unit_tests/examples tests/unit_tests/examples/test_glm_45v_slurm.py -q` — 2 failed; both wrappers returned 0 instead of 42.
- Same unchanged regression after fix — 2 passed.
- `bash -n examples/models/glm/glm_45v/slurm_sft.sh examples/models/glm/glm_45v/slurm_peft.sh` — passed.
- `git diff --check` — passed.
- `uv run --frozen --no-sync pre-commit run --all-files` — all hooks passed.

## Scope

This changes only parent-shell exit-status propagation in the two GLM-4.5V Slurm wrappers. It does not change recipe values, training semantics, resource requests, model code, or checkpoint behavior. No GPU, full-suite, convergence, or performance validation was run or claimed because the defect is deterministic Bash status handling after synchronous `srun`.
