### PR TITLE
[training] fix: avoid duplicate MIMO evaluation timer

### DIFF
--- a/src/megatron/bridge/training/train_megatron_mimo.py
+++ b/src/megatron/bridge/training/train_megatron_mimo.py
@@ -401,7 +401,6 @@ def train_megatron_mimo(
         ):
             if train_config.manual_gc and train_config.manual_gc_eval:
                 gc.collect()
-            timers("evaluate", log_level=0).start(barrier=True)
             evaluate_and_print_results(
                 state=global_state,
                 prefix=f"iteration {train_state.step}",
@@ -414,7 +413,6 @@ def train_megatron_mimo(
                 p2p_communicator=multimodule_communicator,
                 pg_collection=multimodule_pg_collection,
             )
-            timers("evaluate").stop()
             if train_config.manual_gc and train_config.manual_gc_eval:
                 # Collect only objects created during eval (gen-0 is cheap).
                 gc.collect(generation=0)

--- a/tests/unit_tests/training/megatron_mimo/test_megatron_mimo_checkpointing.py
+++ b/tests/unit_tests/training/megatron_mimo/test_megatron_mimo_checkpointing.py
@@ -390,6 +390,67 @@ class TestNonColocatedGuard:
 
 
 # ---------------------------------------------------------------------------
+# Tests: evaluation timer ownership in train_megatron_mimo
+# ---------------------------------------------------------------------------
+
+
+def test_interval_evaluation_uses_evaluator_timer_ownership():
+    """Interval evaluation should let the shared evaluator own its timer."""
+    from megatron.core.timers import Timers
+
+    from megatron.bridge.training.train_megatron_mimo import train_megatron_mimo
+
+    state = _make_global_state(train_iters=1)
+    state.cfg.train.eval_interval = 1
+    state.timers = Timers(log_level=0, log_option="minmax")
+
+    infra = _make_megatron_mimo_infra()
+    checkpoint_manager = MagicMock()
+
+    def run_shared_evaluator(*_args, **_kwargs):
+        timer = state.timers("evaluate", log_level=0)
+        timer.start(barrier=True)
+        timer.stop()
+
+    with (
+        patch("torch.cuda.synchronize"),
+        patch("torch.distributed.barrier"),
+        patch("torch.distributed.get_rank", return_value=0),
+        patch("torch.distributed.get_world_size", return_value=1),
+        patch("megatron.bridge.training.train_megatron_mimo.get_num_microbatches", return_value=1),
+        patch("megatron.bridge.training.train_megatron_mimo.prepare_forward_step_func", return_value=Mock()),
+        patch("megatron.bridge.training.train_megatron_mimo.get_module_to_grid_tuple", return_value=[]),
+        patch(
+            "megatron.bridge.training.train_megatron_mimo.build_pg_collection_for_schedule",
+            return_value=Mock(spec=[]),
+        ),
+        patch(
+            "megatron.bridge.training.train_megatron_mimo.train_step_megatron_mimo",
+            return_value=({}, 0, 0.0, 0),
+        ),
+        patch(
+            "megatron.bridge.training.train_megatron_mimo.evaluate_and_print_results",
+            side_effect=run_shared_evaluator,
+        ) as mock_evaluate,
+        patch("megatron.bridge.training.train_megatron_mimo.checkpoint_and_decide_exit", return_value=False),
+    ):
+        train_megatron_mimo(
+            forward_step_func=Mock(),
+            model=Mock(),
+            optimizer=Mock(),
+            schedulers={},
+            train_data_iterator=iter([object()]),
+            valid_data_iterator=iter([object()]),
+            global_state=state,
+            megatron_mimo_infra=infra,
+            multimodule_communicator=Mock(),
+            checkpoint_manager=checkpoint_manager,
+        )
+
+    mock_evaluate.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
 # Tests: checkpoint_and_decide_exit integration in train_megatron_mimo
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

MIMO interval validation currently starts the shared `evaluate` timer in `train_megatron_mimo()` and then calls `evaluate_and_print_results()`, whose evaluator starts that same timer again. MCore timers are non-reentrant, so a supported run with a positive `eval_interval` and a validation iterator aborts at its first validation boundary with `AssertionError: timer has already been started`, before any validation forward pass.

This removes the redundant caller-side start/stop and leaves timer ownership with the shared evaluator. A focused regression uses the real pinned MCore timer registry through the one-step MIMO loop.

## Root cause and fix

- `train_megatron_mimo()` started `global_state.timers("evaluate")`.
- `evaluate()` immediately retrieved the identical named timer from the same registry and started it again.
- The second start violated MCore's timer invariant.
- The evaluator already owns starting, stopping, and logging this timer, so the caller-side wrapper was removed without changing evaluation behavior.

## Validation

Fail before the production fix:

```text
uv run --no-sync python -m pytest tests/unit_tests/training/megatron_mimo/test_megatron_mimo_checkpointing.py::test_interval_evaluation_uses_evaluator_timer_ownership -q
# 1 failed: AssertionError: timer has already been started
```

The unchanged regression after the fix:

```text
uv run --no-sync python -m pytest tests/unit_tests/training/megatron_mimo/test_megatron_mimo_checkpointing.py::test_interval_evaluation_uses_evaluator_timer_ownership -q
# 1 passed
```

Focused adjacent coverage:

```text
uv run --no-sync python -m pytest tests/unit_tests/training/megatron_mimo/test_megatron_mimo_checkpointing.py::TestNonColocatedGuard tests/unit_tests/training/megatron_mimo/test_megatron_mimo_checkpointing.py::test_interval_evaluation_uses_evaluator_timer_ownership tests/unit_tests/training/megatron_mimo/test_megatron_mimo_checkpointing.py::TestTrainMegatronMIMOCheckpointIntegration tests/unit_tests/training/test_eval.py -q
# 14 passed
```

Also passed:

```text
git diff --check
uv run --no-sync pre-commit run --all-files
```

## Scope

This is limited to MIMO interval-evaluation timer ownership. No full-suite, GPU/distributed, convergence, performance, or model-quality validation is claimed.
