### PR TITLE
[training, ckpt] fix: Resolve default in-process restart world size

### DIFF
--- a/src/megatron/bridge/training/inprocess_restart.py
+++ b/src/megatron/bridge/training/inprocess_restart.py
@@ -48,14 +48,18 @@ def inprocess_restart(train_fn: Callable, config: InProcessRestartConfig, global
     ):
         warnings.warn("Set TORCH_CPP_LOG_LEVEL=error to suppress c10d waitForInput timeout warning messages")
 
+    active_world_size = config.active_world_size
+    if active_world_size is None:
+        active_world_size = int(os.getenv("WORLD_SIZE", "1"))
+
     # Layers represents a configuration for a layer of branches at a certain
     # depth in a topology tree constructed by inprocess.rank_assignment.Tree.
     # First layer contains all ranks and it's the root of the topology tree,
     # the second optional layer groups ranks by nodes.
     layers = [
         inprocess.rank_assignment.Layer(
-            min_ranks=config.active_world_size,
-            max_ranks=config.active_world_size,
+            min_ranks=active_world_size,
+            max_ranks=active_world_size,
             flag=inprocess.rank_assignment.LayerFlag.RESERVE,
         )
     ]
@@ -89,7 +93,7 @@ def inprocess_restart(train_fn: Callable, config: InProcessRestartConfig, global
         finalize.append(inprocess.finalize.ThreadedFinalize(timeout=timedelta(seconds=10), fn=torch.cuda.empty_cache))
 
     initialize = inprocess.Compose(
-        inprocess.initialize.RetryController(min_world_size=config.active_world_size),
+        inprocess.initialize.RetryController(min_world_size=active_world_size),
         inprocess.nested_restarter.NestedRestarterHandlingCompleted(),
     )
 

--- a/tests/unit_tests/training/test_inprocess_restart.py
+++ b/tests/unit_tests/training/test_inprocess_restart.py
@@ -24,6 +24,30 @@ from megatron.bridge.training.state import GlobalState
 class TestInProcessRestart:
     """Test cases for the inprocess_restart function."""
 
+    def test_inprocess_restart_resolves_default_active_world_size(self):
+        """Test the documented WORLD_SIZE fallback for active ranks."""
+        from nvidia_resiliency_ext.inprocess.state import State
+
+        config = InProcessRestartConfig(enabled=True, granularity="rank", empty_cuda_cache=False)
+        mock_global_state = MagicMock(spec=GlobalState)
+
+        with (
+            patch.dict(os.environ, {"MASTER_PORT": "29500", "WORLD_SIZE": "4"}),
+            patch("megatron.bridge.training.inprocess_restart.warnings.warn"),
+            patch("nvidia_resiliency_ext.inprocess.Wrapper") as mock_wrapper,
+        ):
+            mock_wrapper.return_value.return_value = MagicMock()
+            inprocess_restart(MagicMock(), config, mock_global_state)
+
+        wrapper_kwargs = mock_wrapper.call_args.kwargs
+        retry_controller = wrapper_kwargs["initialize"].instances[0]
+        state = State(rank=0, world_size=4, active_rank=0, active_world_size=4).freeze()
+
+        assert retry_controller(state) is state
+        root_layer = wrapper_kwargs["rank_assignment"].layers[0]
+        assert root_layer.min_ranks == 4
+        assert root_layer.max_ranks == 4
+
     def test_inprocess_restart_basic_configuration(self):
         """Test inprocess_restart with basic configuration."""
         mock_train_fn = MagicMock()


### PR DESCRIPTION
## Problem

Enabling in-process restart with the documented default `active_world_size=None` crashes before training starts. The config promises to fall back to `WORLD_SIZE`, but Bridge passed `None` to both the NVRx root rank-assignment layer and `RetryController`. NVRx then compares an integer world size/rank count with `None` and raises `TypeError`.

This affects the supported `InProcessRestartConfig(enabled=True)` path whenever users do not explicitly repeat the launcher world size in the config.

## Fix

Resolve the active world size once from `WORLD_SIZE` (with the existing single-process fallback of `1`) and pass that integer to both NVRx consumers. Explicit `active_world_size` values are unchanged.

The regression test exercises the real NVRx `State`, `RetryController`, rank-assignment `Layer`, and `Tree`, while mocking only the outer process wrapper.

## Validation

- Unmodified-base deterministic contract reproducer: failed with `TypeError: '<' not supported between instances of 'int' and 'NoneType'` in `RetryController.__call__`.
- `uv run python -m pytest tests/unit_tests/training/test_inprocess_restart.py::TestInProcessRestart::test_inprocess_restart_resolves_default_active_world_size -q --tb=short` — 1 passed.
- `uv run python -m pytest tests/unit_tests/training/test_inprocess_restart.py -q --tb=short` — 18 passed.
- `uv run pre-commit run --all-files` — passed.
- `git diff --check` — passed.

## Scope

This changes wrapper-construction semantics only. No GPU/distributed execution, convergence, performance, or full-suite validation is claimed.
