### PR TITLE
[training] fix: Close TensorBoard writer on restart

### DIFF
--- a/src/megatron/bridge/training/state.py
+++ b/src/megatron/bridge/training/state.py
@@ -490,6 +490,8 @@ class GlobalState:
                 setattr(model_config, callback_name, None)
         self._timers = None
         self._train_state = None
+        if self._tensorboard_logger is not None:
+            self._tensorboard_logger.close()
         self._tensorboard_logger = None
         self._wandb_logger = None
         self._mlflow_logger = None

--- a/tests/unit_tests/training/test_state.py
+++ b/tests/unit_tests/training/test_state.py
@@ -1022,6 +1022,17 @@ class TestGlobalState:
         assert state._async_calls_queue == mock_async_queue
         assert state.rank_monitor_client is not None
 
+    def test_reset_for_restart_closes_tensorboard_writer(self):
+        """Test reset_for_restart closes the attempt-scoped TensorBoard writer."""
+        state = GlobalState()
+        mock_writer = MagicMock()
+        state._tensorboard_logger = mock_writer
+
+        state.reset_for_restart()
+
+        mock_writer.close.assert_called_once_with()
+        assert state._tensorboard_logger is None
+
 
 class TestTimersWriteToMlflow:
     """Test suite for _timers_write_to_mlflow function."""


### PR DESCRIPTION
## What changed

Close an active TensorBoard `SummaryWriter` when `GlobalState` is reset for an in-process restart, before clearing the state reference.

## Supported trigger and impact

With documented experimental in-process restart enabled and `logger.tensorboard_dir` configured, setup materializes a TensorBoard writer. If training then raises a recoverable software exception, the NVRx finalizer reuses the same `GlobalState` for the next attempt.

Previously, restart cleanup only set `_tensorboard_logger` to `None`. PyTorch/TensorBoard requires an explicit `close()` to flush pending events, stop the background writer, and close the event file; the writer stack does not provide a destructor that supplies this lifecycle step. The retry could therefore create a second writer while the first worker remained live, losing buffered events and accumulating threads, queues, and file descriptors across recoveries.

## Root cause and fix

`GlobalState.reset_for_restart()` owned the writer reference but discarded it without running its close protocol. The minimal fix closes the existing writer at that ownership boundary, then preserves the existing lazy reinitialization behavior for the next attempt.

## Regression evidence

The focused lifecycle test was run unchanged before and after the production change:

```text
uv run --no-sync python -m pytest tests/unit_tests/training/test_state.py::TestGlobalState::test_reset_for_restart_closes_tensorboard_writer -q
```

- Unmodified base `ebce28fc7383a338694651d8a1fde3e67bde61c2`: exit 1; expected `close()` once, called 0 times.
- Fixed tree: 1 passed.

Focused and adjacent validation:

```text
uv run --no-sync python -m pytest \
  tests/unit_tests/training/test_state.py \
  tests/unit_tests/training/test_inprocess_restart.py \
  -q -k 'not test_pretrain_raises_error_when_process_group_initialized_with_inprocess_restart'
# 85 passed, 1 deselected

uv run --no-sync pre-commit run --all-files
# all hooks passed

git diff --check
# passed
```

The one deselected adjacent test imports optional Transformer Engine before exercising its process-group compatibility assertion; it is unrelated to the changed writer lifecycle.

## Scope

This validates attempt-scoped TensorBoard resource cleanup during in-process restart. It does not claim GPU/distributed, convergence, performance, or full-suite validation. No dependency, workflow, public API, submodule, or lockfile change is included.
