### PR TITLE
[model] fix: Preserve GLM-5 MTP layers during conversion

### DIFF
--- a/src/megatron/bridge/models/glm_moe_dsa/glm5_bridge.py
+++ b/src/megatron/bridge/models/glm_moe_dsa/glm5_bridge.py
@@ -74,10 +74,6 @@ class GLM5Bridge(MegatronModelBridge):
         provider.qk_layernorm = True
         provider.multi_latent_attention = True
 
-        # Disable MTP (Multi-Token Prediction) by default
-        # HF config has num_nextn_predict_layers=1
-        provider.mtp_num_layers = None
-
         provider.moe_grouped_gemm = True
         provider.moe_router_pre_softmax = True
         provider.moe_token_dispatcher_type = "alltoall"

--- a/tests/unit_tests/models/glm_moe_dsa/test_glm5_bridge.py
+++ b/tests/unit_tests/models/glm_moe_dsa/test_glm5_bridge.py
@@ -42,6 +42,7 @@ def _provider_from_hf_config(monkeypatch: pytest.MonkeyPatch, **config_overrides
     config = {
         "first_k_dense_replace": 3,
         "num_hidden_layers": 78,
+        "num_nextn_predict_layers": 1,
         "moe_intermediate_size": 2048,
         "n_shared_experts": 1,
         "rope_parameters": {"rope_theta": 1_000_000},
@@ -55,9 +56,16 @@ def _provider_from_hf_config(monkeypatch: pytest.MonkeyPatch, **config_overrides
     monkeypatch.setattr(
         MegatronModelBridge,
         "provider_bridge",
-        lambda _self, _hf_pretrained: SimpleNamespace(),
+        lambda _self, hf_pretrained: SimpleNamespace(mtp_num_layers=hf_pretrained.config.num_nextn_predict_layers),
     )
     return GLM5Bridge().provider_bridge(SimpleNamespace(config=SimpleNamespace(**config)))
+
+
+def test_provider_bridge_preserves_mtp_architecture_from_hf_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    """GLM-5 conversion preserves the MTP layers declared by the checkpoint config."""
+    provider = _provider_from_hf_config(monkeypatch)
+
+    assert provider.mtp_num_layers == 1
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What changed

Preserve the MTP layer count from released GLM-5-family Hugging Face configs during default AutoBridge conversion.

## User impact

GLM-5, GLM-5.1, and GLM-5.2 configs declare one next-token-prediction layer, and their checkpoints contain appended MTP tensors. The GLM-5 bridge was overwriting the generic `num_nextn_predict_layers -> mtp_num_layers` mapping with `None`. Megatron-Core therefore constructed no MTP destination parameters, leaving the existing MTP mappings unreachable and silently omitting that checkpoint state from non-strict conversion and round trips.

## Root cause and fix

The override was introduced before GLM-5 MTP parameter mappings were available and remained after those mappings were added. Remove only that stale override so the generic config bridge supplies the released layer count. Add a focused provider-contract regression test that fails with `None` before the fix and passes with `1` after it.

## Validation

- `uv run python -m pytest tests/unit_tests/models/glm_moe_dsa/test_glm5_bridge.py::test_provider_bridge_preserves_mtp_architecture_from_hf_config -q` — fails before (`None != 1`), passes after
- `uv run python -m pytest tests/unit_tests/models/glm_moe_dsa/test_glm5_bridge.py tests/unit_tests/models/test_autobridge_registration_matrix.py tests/unit_tests/recipes/test_glm5_perf_recipes.py -q` — 19 passed
- `git diff --check` — passed
- `uv run pre-commit run --all-files` — passed

## Scope

This changes only GLM-5-family provider configuration ownership and its unit coverage. It does not change public APIs, dependencies, CI workflows, the Megatron-Core submodule, or main-token inference semantics.