### PR TITLE
Add CLI configurability of num_moe_experts

### DIFF
--- a/scripts/performance/argument_parser.py
+++ b/scripts/performance/argument_parser.py
@@ -241,6 +241,13 @@ def parse_cli_args():
         default=None,
     )
     parser.add_argument(
+        "--num_moe_experts",
+        type=int,
+        help="Number of experts to use for the experiment. Defaults to None.",
+        required=False,
+        default=None,
+    )
+    parser.add_argument(
         "--pipeline_model_parallel_layout",
         type=str,
         help="Pipeline model parallel layout to use for the experiment. Defaults to None.",

--- a/scripts/performance/utils/overrides.py
+++ b/scripts/performance/utils/overrides.py
@@ -450,6 +450,8 @@ def set_user_overrides(recipe: ConfigContainer, args: argparse.Namespace) -> Con
         if args.num_layers is not None:
             recipe.model.num_layers = args.num_layers
         recipe.model.moe_layer_freq = [0] * num_dense_layers + [1] * (recipe.model.num_layers - num_dense_layers)
+    if args.num_moe_experts is not None:
+        recipe.model.num_moe_experts = args.num_moe_experts
     if args.pipeline_model_parallel_layout is not None:
         recipe.model.pipeline_model_parallel_layout = args.pipeline_model_parallel_layout
 


### PR DESCRIPTION
This PR adds `num_moe_experts` as a CLI configuration, which is required for DeepSeek-V3 proxy models running on 72×N GPUs.