### PR TITLE
fix(perf): read legacy SQuAD cache columns

### DIFF
--- a/scripts/performance/utils/datasets.py
+++ b/scripts/performance/utils/datasets.py
@@ -141,7 +141,11 @@ def create_squad_dataset_config(
         seed=5678,
         do_validation=True,
         do_test=False,
-        preprocessing=PromptCompletionSFTPreprocessingConfig(separator=" "),
+        preprocessing=PromptCompletionSFTPreprocessingConfig(
+            prompt_column="input",
+            completion_column="output",
+            separator=" ",
+        ),
         dataset_kwargs=dataset_kwargs,
         enable_offline_packing=packed,
         offline_packing_specs=offline_packing_specs,


### PR DESCRIPTION
## Summary

- configure the performance launcher SQuAD dataset to read legacy `input`/`output` materializations
- align `scripts/performance/utils/datasets.py` with the built-in SQuAD recipe fixed by PR 4882

## Background

The performance fine-tuning jobs tracked by [nemo-ci MR 2695](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/merge_requests/2695) reuse SQuAD JSONL materializations created by the former processor. Those rows use `input`/`output`.

[PR 4882](https://github.com/NVIDIA-NeMo/Megatron-Bridge/pull/4882) updated the built-in SQuAD recipe to select those legacy columns, but the separate performance helper still constructed `PromptCompletionSFTPreprocessingConfig` with its default `prompt`/`completion` columns. The pipeline therefore failed during offline packing with `Prompt-completion rows must contain the configured prompt/completion columns (prompt, completion)` even though it ran MBridge commit `d7c47a3a3`, which contains PR 4882.

## Validation

- `pre-commit run --all-files`