### PR TITLE
fix(training): align comm-overlap validation with Megatron-Core

### DIFF
--- a/src/megatron/bridge/training/comm_overlap.py
+++ b/src/megatron/bridge/training/comm_overlap.py
@@ -505,6 +505,11 @@ class CommOverlapConfig:
             assert model_cfg.recompute_num_layers is None, (
                 "recompute_num_layers must be None when enabling overlap_moe_expert_parallel_comm"
             )
+            # ``recompute_modules`` may still be None here (Megatron-Core normalizes it to
+            # ["core_attn"] in __post_init__, which runs after this pre-finalize check).
+            assert "moe" not in (model_cfg.recompute_modules or []), (
+                "disable moe in recompute_modules when enabling overlap_moe_expert_parallel_comm"
+            )
             assert not model_cfg.moe_shared_expert_overlap, (
                 "disable moe_shared_expert_overlap when enabling overlap_moe_expert_parallel_comm"
             )

--- a/src/megatron/bridge/training/comm_overlap.py
+++ b/src/megatron/bridge/training/comm_overlap.py
@@ -467,6 +467,14 @@ class CommOverlapConfig:
             f"model_cfg: {model_cfg} does not have overlap_moe_expert_parallel_comm"
         )
 
+        # NOTE: The checks below intentionally mirror the
+        # ``overlap_moe_expert_parallel_comm`` validation in Megatron-Core's
+        # ``TransformerConfig.__post_init__`` (megatron/core/transformer/transformer_config.py).
+        # They run earlier -- at comm-overlap setup, before model finalize -- to surface
+        # misconfigurations sooner and to keep this path unit-testable without a full model
+        # build (see tests/unit_tests/training/test_comm_overlap.py). Megatron-Core re-validates
+        # the same invariants at finalize and is the authoritative gate, so any change here must
+        # be kept in sync with the Megatron-Core copy (and vice versa) to avoid silent drift.
         if self.user_comm_overlap_cfg.overlap_moe_expert_parallel_comm is True:
             assert model_cfg.expert_model_parallel_size > 1, (
                 "overlap_moe_expert_parallel_comm is only supported when expert_model_parallel_size > 1"

--- a/tests/unit_tests/training/test_comm_overlap.py
+++ b/tests/unit_tests/training/test_comm_overlap.py
@@ -579,6 +579,40 @@ class TestMegatronCommOverlapConfig:
         ):
             comm_cfg._get_model_comm_overlap_cfgs(model_cfg, ddp_cfg)
 
+    def test_moe_ep_overlap_rejects_moe_in_recompute_modules(self):
+        comm_cfg = CommOverlapConfig(
+            tp_comm_overlap=False,
+            data_parallel_size=1,
+            overlap_moe_expert_parallel_comm=True,
+        )
+        comm_cfg.finalize()
+
+        model_cfg = create_gpt_config(
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=1,
+            virtual_pipeline_model_parallel_size=None,
+            sequence_parallel=False,
+            expert_model_parallel_size=2,
+            num_moe_experts=2,
+            moe_token_dispatcher_type="alltoall",
+            bf16=True,
+            fp16=False,
+            recompute_granularity="selective",
+            recompute_method=None,
+            recompute_num_layers=None,
+            recompute_modules=["moe"],
+            moe_shared_expert_overlap=False,
+            mtp_num_layers=None,
+            add_bias_linear=False,
+        )
+        ddp_cfg = DistributedDataParallelConfig(use_distributed_optimizer=False)
+
+        with (
+            patch("megatron.bridge.training.comm_overlap.is_torch_min_version", return_value=True),
+            pytest.raises(AssertionError, match="moe in recompute_modules"),
+        ):
+            comm_cfg._get_model_comm_overlap_cfgs(model_cfg, ddp_cfg)
+
     def test_delay_wgrad_config_validation(self):
         """delay_wgrad_compute passes when TE and EP overlap conditions are met."""
         comm_cfg = CommOverlapConfig(


### PR DESCRIPTION
## What

Bring the bridge's `overlap_moe_expert_parallel_comm` validation in `CommOverlapConfig._get_model_comm_overlap_cfgs` into line with Megatron-Core:

1. **Add the one missing check** — `"moe" not in recompute_modules` — that Megatron-Core enforces in `TransformerConfig.__post_init__` but the bridge did not, plus a unit test.
2. **Document the mirror** with a `NOTE` marking these asserts as a deliberate duplicate of Megatron-Core's, so future edits update both copies.

## Why

The bridge duplicates ~10 of the 11 `overlap_moe_expert_parallel_comm` checks from Megatron-Core's `__post_init__`. The duplication is intentional — the bridge copy runs earlier (at comm-overlap setup, before model finalize) and is unit-testable without a full model build (`tests/unit_tests/training/test_comm_overlap.py`). But the linkage was implicit, and the two copies **silently drifted**: the bridge relaxed the MTP-layer check to accept `mtp_num_layers=0` while Megatron-Core still rejected it, so configs that passed the bridge check still failed at model finalize.

This PR closes the remaining check gap and makes the mirror relationship explicit so it does not drift again.

## Changes

- `src/megatron/bridge/training/comm_overlap.py`
  - Add `assert "moe" not in (model_cfg.recompute_modules or [])`. The `or []` guard is required because this runs **before** Megatron-Core normalizes `recompute_modules` from `None` to `["core_attn"]` in `__post_init__`, so it can still be `None` here.
  - Add a `NOTE` cross-referencing Megatron-Core's `TransformerConfig.__post_init__` as the authoritative copy.
- `tests/unit_tests/training/test_comm_overlap.py`
  - Add `test_moe_ep_overlap_rejects_moe_in_recompute_modules`.

## Behavior note

This adds an **earlier** assertion: a config that puts `moe` in `recompute_modules` with EP comm overlap enabled now fails at comm-overlap setup instead of only at model finalize (it failed either way). No previously-valid config becomes invalid.

## Related / follow-ups

- Companion Megatron-Core change realigns the MTP check (allow `mtp_num_layers=0`): NVIDIA/Megatron-LM#5912.
- Remaining known asymmetry, intentionally **not** changed here: the bridge additionally checks `num_moe_experts > 1`, which Megatron-Core does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
