### PR TITLE
[recipes] fix: Restore DeepSeek HSDP recipe environment

### DIFF
--- a/src/megatron/bridge/perf_recipes/deepseek/gb300/deepseek_v3.py
+++ b/src/megatron/bridge/perf_recipes/deepseek/gb300/deepseek_v3.py
@@ -344,6 +344,33 @@ def deepseek_v3_pretrain_128gpu_gb300_fp8mx_hsdp_config() -> ConfigContainer:
     cfg.mixed_precision.fp8_dot_product_attention = False
 
     cfg.model.moe_router_force_load_balancing = True
+    # Keep process settings next to the recipe so users can see the exact benchmark environment.
+    cfg.env_vars = {
+        **COMMON_PERF_ENV_VARS,
+        # CUDA stream scheduling for this model and parallel layout.
+        "CUDA_DEVICE_MAX_CONNECTIONS": 32,
+        # CUDA graph and allocator behavior for this recipe.
+        "NCCL_GRAPH_REGISTER": 0,
+        "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True,graph_capture_record_stream_reuse:True",
+        "TORCH_NCCL_AVOID_RECORD_STREAMS": 0,
+        # NCCL user-buffer and launch settings.
+        "NCCL_NVLS_ENABLE": 0,
+        # HybridEP topology for the target system.
+        "NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN": 32,
+        "NUM_OF_TOKENS_PER_CHUNK_COMBINE_API": 128,
+        "NVLINK_DOMAIN_SIZE": 72,
+        "USE_MNNVL": 1,
+        # Transformer Engine overlap settings for this model.
+        "NVTE_BWD_LAYERNORM_SM_MARGIN": 20,
+        "NVTE_CPU_OFFLOAD_V1": 1,
+        "NVTE_CUTEDSL_FUSED_GROUPED_MLP": 1,
+        "NVTE_FWD_LAYERNORM_SM_MARGIN": 20,
+        # Use cuDNN LayerNorm for this measured baseline.
+        "NVTE_NORM_BWD_USE_CUDNN": 1,
+        "NVTE_NORM_FWD_USE_CUDNN": 1,
+        # Keep DeepSeek kernel selection aligned with the measured baseline.
+        "NVTE_ALLOW_NONDETERMINISTIC_ALGO": 0,
+    }
     return cfg
 
 

--- a/tests/unit_tests/recipes/test_perf_recipe_environment.py
+++ b/tests/unit_tests/recipes/test_perf_recipe_environment.py
@@ -29,6 +29,10 @@ _CANONICAL_RECIPE_NAME = re.compile(
     r".+_(?:pretrain|sft|peft)_\d+gpu_[a-z0-9]+_(?:bf16|fp8cs|fp8mx|fp8sc|nvfp4)(?:_.+)?_config"
 )
 _RECIPE_ROOT = Path(__file__).resolve().parents[3] / "src" / "megatron" / "bridge" / "perf_recipes"
+# Deliberately lock the discovered public inventory; update this for intentional recipe additions or removals.
+_EXPECTED_FLAT_RECIPE_COUNT = 397
+_EXPECTED_DEEPSEEK_RECIPE_COUNT = 37
+_EXPECTED_DEEPSEEK_HYBRID_EP_RECIPE_COUNT = 35
 _INLINE_CORE_ENV_NAMES = {
     "CUDA_DEVICE_MAX_CONNECTIONS",
     "NCCL_NVLS_ENABLE",
@@ -144,7 +148,7 @@ def test_every_flat_recipe_builder_declares_its_environment_inline():
                 for decorator in node.decorator_list
             )
 
-    assert len(builders) == 396
+    assert len(builders) == _EXPECTED_FLAT_RECIPE_COUNT
     assert not invalid
 
 
@@ -185,9 +189,9 @@ def test_explicit_environment_invariants_across_all_flat_recipes():
                 assert hybrid_ep_names == _HYBRID_EP_ENV_NAMES
                 deepseek_hybrid_ep_count += 1
 
-    assert len(recipes) == 396
-    assert deepseek_recipe_count == 36
-    assert deepseek_hybrid_ep_count == 34
+    assert len(recipes) == _EXPECTED_FLAT_RECIPE_COUNT
+    assert deepseek_recipe_count == _EXPECTED_DEEPSEEK_RECIPE_COUNT
+    assert deepseek_hybrid_ep_count == _EXPECTED_DEEPSEEK_HYBRID_EP_RECIPE_COUNT
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What does this PR do?

Fixes the main-branch unit failures in [Launch_Unit_Tests_Core](https://github.com/NVIDIA-NeMo/Megatron-Bridge/actions/runs/29775987605/job/88466552646) by:

- restoring the inline process environment for the DeepSeek V3 128-GPU GB300 FP8-MX HSDP performance recipe;
- updating the intentionally locked recipe inventory to 397 total recipes, 37 DeepSeek recipes, and 35 HybridEP DeepSeek recipes;
- sharing named constants for those inventory expectations.

The HSDP recipe was added after the environment-variable migration was prepared, so its environment and the corresponding inventory increments were omitted during integration. The values here reproduce the previous performance launcher behavior for this recipe.

## Testing

- `uv run python -m pytest tests/unit_tests/recipes/test_perf_recipe_environment.py tests/unit_tests/scripts/performance/test_recipe_environment.py tests/unit_tests/recipes/test_deepseek_recipes.py -q` — 77 passed
- `uv run pre-commit run --all-files` — passed
- `git diff --check` — passed
