### PR TITLE
[ckpt] fix: Dispatch MIMO loads through checkpoint manager

### DIFF
--- a/src/megatron/bridge/training/setup_megatron_mimo.py
+++ b/src/megatron/bridge/training/setup_megatron_mimo.py
@@ -20,7 +20,7 @@ import torch.distributed as dist
 from megatron.core.pipeline_parallel.multimodule_communicator import MultiModulePipelineCommunicator
 from megatron.core.utils import get_model_config
 
-from megatron.bridge.training.checkpointing import CheckpointManager, create_checkpoint_manager, load_checkpoint
+from megatron.bridge.training.checkpointing import CheckpointLoadContext, CheckpointManager, create_checkpoint_manager
 from megatron.bridge.training.megatron_mimo_parallel_utils import (
     build_pg_collection_for_schedule,
     get_active_module_pg,
@@ -259,7 +259,7 @@ def setup_megatron_mimo(
     # ``parallel_state`` globals from this rank's pg_collection.
     active_module_name, local_pg_collection = get_active_module_pg(megatron_mimo_infra)
 
-    # Initialize checkpoint manager (owns checkpointing_context internally).
+    # Initialize checkpoint manager.
     checkpoint_manager = create_checkpoint_manager(cfg.checkpoint)
 
     # Load checkpoint if one exists (persistent, pretrained, or non-persistent).
@@ -280,14 +280,15 @@ def setup_megatron_mimo(
     if should_load:
         timers = global_state.timers
         timers("load-checkpoint", log_level=0).start(barrier=True)
-        load_checkpoint(
-            global_state,
-            model=[model],
-            optimizer=optimizer,
-            opt_param_scheduler=first_scheduler,
-            checkpointing_context=checkpoint_manager.checkpointing_context,
-            pg_collection=local_pg_collection,
-            module_name=active_module_name,
+        checkpoint_manager.load(
+            CheckpointLoadContext(
+                state=global_state,
+                model=[model],
+                optimizer=optimizer,
+                opt_param_scheduler=first_scheduler,
+                pg_collection=local_pg_collection,
+                module_name=active_module_name,
+            )
         )
         timers("load-checkpoint").stop(barrier=True)
         timers.log(["load-checkpoint"])

--- a/tests/unit_tests/training/megatron_mimo/test_megatron_mimo_checkpointing.py
+++ b/tests/unit_tests/training/megatron_mimo/test_megatron_mimo_checkpointing.py
@@ -1099,7 +1099,7 @@ class TestSetupMegatronMIMOCheckpointLoading:
         "megatron.core.parallel_state._DATA_PARALLEL_GROUP_WITH_CP",
     ]
 
-    def _run_setup(self, *, load_path=None, checkpoint_exists_return=False):
+    def _run_setup(self, *, load_path=None, checkpoint_exists_return=False, checkpoint_manager=None):
         """Run setup_megatron_mimo with mocks, return dict of mock handles."""
         from megatron.bridge.training.setup_megatron_mimo import setup_megatron_mimo
 
@@ -1172,11 +1172,11 @@ class TestSetupMegatronMIMOCheckpointLoading:
                     return_value=checkpoint_exists_return,
                 )
             )
-            m_load = stack.enter_context(patch("megatron.bridge.training.setup_megatron_mimo.load_checkpoint"))
             m_create_mgr = stack.enter_context(
                 patch("megatron.bridge.training.setup_megatron_mimo.create_checkpoint_manager")
             )
-            m_create_mgr.return_value = MagicMock(checkpointing_context={"ctx": True})
+            checkpoint_manager = checkpoint_manager or MagicMock()
+            m_create_mgr.return_value = checkpoint_manager
 
             stack.enter_context(
                 patch("megatron.core.models.mimo.optimizer.get_mimo_optimizer", return_value=mock_optimizer)
@@ -1196,7 +1196,7 @@ class TestSetupMegatronMIMOCheckpointLoading:
 
             result = setup_megatron_mimo(state=state)
 
-            mocks["load_checkpoint"] = m_load
+            mocks["checkpoint_manager"] = checkpoint_manager
             mocks["checkpoint_exists"] = m_ckpt_exists
             mocks["result"] = result
 
@@ -1204,27 +1204,54 @@ class TestSetupMegatronMIMOCheckpointLoading:
 
     def test_load_invoked_when_persistent_checkpoint_exists(self):
         mocks = self._run_setup(load_path="/tmp/ckpt", checkpoint_exists_return=True)
-        mocks["load_checkpoint"].assert_called_once()
+        mocks["checkpoint_manager"].load.assert_called_once()
+
+    def test_load_dispatches_through_custom_checkpoint_manager(self):
+        class CustomCheckpointManager:
+            def __init__(self):
+                self.load_context = None
+
+            def save(self, ctx, callback_manager):
+                pass
+
+            def load(self, ctx):
+                self.load_context = ctx
+                return (0, 0)
+
+            def finalize_async_saves(self, state, blocking=False, terminate=False):
+                pass
+
+        checkpoint_manager = CustomCheckpointManager()
+
+        self._run_setup(
+            load_path="/tmp/ckpt",
+            checkpoint_exists_return=True,
+            checkpoint_manager=checkpoint_manager,
+        )
+
+        assert checkpoint_manager.load_context is not None
+        assert checkpoint_manager.load_context.pg_collection is not None
+        assert checkpoint_manager.load_context.module_name == "language"
 
     def test_load_not_invoked_when_no_checkpoint(self):
         mocks = self._run_setup(load_path=None, checkpoint_exists_return=False)
-        mocks["load_checkpoint"].assert_not_called()
+        mocks["checkpoint_manager"].load.assert_not_called()
 
     def test_load_passes_model_as_list(self):
         mocks = self._run_setup(load_path="/tmp/ckpt", checkpoint_exists_return=True)
-        _, kwargs = mocks["load_checkpoint"].call_args
-        assert isinstance(kwargs["model"], list)
-        assert len(kwargs["model"]) == 1
+        context = mocks["checkpoint_manager"].load.call_args.args[0]
+        assert isinstance(context.model, list)
+        assert len(context.model) == 1
 
     def test_load_passes_pg_collection(self):
         mocks = self._run_setup(load_path="/tmp/ckpt", checkpoint_exists_return=True)
-        _, kwargs = mocks["load_checkpoint"].call_args
-        assert kwargs["pg_collection"] is not None
+        context = mocks["checkpoint_manager"].load.call_args.args[0]
+        assert context.pg_collection is not None
 
     def test_load_passes_module_name(self):
         mocks = self._run_setup(load_path="/tmp/ckpt", checkpoint_exists_return=True)
-        _, kwargs = mocks["load_checkpoint"].call_args
-        assert kwargs["module_name"] == "language"
+        context = mocks["checkpoint_manager"].load.call_args.args[0]
+        assert context.module_name == "language"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# What does this PR do?

Route MegatronMIMO checkpoint resumes through the configured public checkpoint-manager contract.

## Supported trigger and impact

When a MegatronMIMO training configuration sets `checkpoint.custom_manager_class` and a persistent, pretrained, or non-persistent checkpoint is detected, setup creates the custom manager but reads `checkpointing_context`, a private property implemented only by `DefaultCheckpointManager`, before calling the built-in loader.

A manager that implements exactly the public `CheckpointManager` protocol therefore crashes with `AttributeError`. A custom manager that happens to expose the private property still has its `load()` implementation silently bypassed. Custom save and async-finalization already dispatch through the manager, so resume behavior is asymmetric.

## Root cause and fix

The standard setup path packages checkpoint state in `CheckpointLoadContext` and calls `checkpoint_manager.load()`, but the MegatronMIMO sibling path retained a direct call to the free loader.

This change uses the same public manager boundary in MegatronMIMO while preserving its model list, optimizer, first scheduler, rank-local process-group collection, and active module name. `DefaultCheckpointManager.load()` delegates to the existing free loader, preserving default behavior.

# Changelog

- Dispatch MegatronMIMO resume through `CheckpointManager.load()`.
- Add a protocol-only custom-manager regression test and update adjacent setup assertions to verify the public context contract.

# Validation

Fail-before on unmodified `origin/main` (`88a2ba2b02a9af83a0652ff268cb981495dc3d59`):

```bash
uv run --no-sync python -m pytest \
  tests/unit_tests/training/megatron_mimo/test_megatron_mimo_checkpointing.py::TestSetupMegatronMIMOCheckpointLoading::test_load_dispatches_through_custom_checkpoint_manager \
  -q
```

Result: `1 failed` at the private-property access with `AttributeError: 'CustomCheckpointManager' object has no attribute 'checkpointing_context'`.

The unchanged regression after the fix: `1 passed`.

Focused and adjacent coverage:

```bash
uv run --no-sync python -m pytest \
  tests/unit_tests/training/test_setup.py \
  tests/unit_tests/training/test_checkpointing.py::TestCheckpointManager \
  tests/unit_tests/training/megatron_mimo/test_megatron_mimo_checkpointing.py::TestSetupMegatronMIMOCheckpointLoading \
  -q
```

Result: `41 passed`.

Additional gates:

- `git diff --check` — passed
- `uv run --no-sync pre-commit run --all-files` — all hooks passed

# Scope limitations

This does not change checkpoint source detection, formats, save behavior, the standard training path, public API signatures, dependencies, or CI workflows. The regression targets the manager-dispatch contract and does not claim GPU, convergence, performance, or full-suite validation.

# Before this PR is ready for review

- [x] Read and followed the contributor guidelines.
- [x] Added the focused regression test.
- [x] Documentation changes are not necessary because the public contract is unchanged.
- [x] No optional-install component behavior is changed.

# Additional information

No duplicate issue or PR was found for this root cause.
