### PR TITLE
[recipe] fix: propagate GPT-OSS pretraining failures

### DIFF
--- a/examples/models/gpt_oss/slurm_pretrain.sh
+++ b/examples/models/gpt_oss/slurm_pretrain.sh
@@ -157,6 +157,7 @@ fi
 # Run each parallelism config in sequence
 export CUDA_DEVICE_MAX_CONNECTIONS=1
 CONFIG_INDEX=0
+JOB_EXIT=0
 for CONFIG in "${PARALLELISM_CONFIGS[@]}"; do
     OLD_IFS=$IFS
     IFS=',' read -r TP PP EP CP SP <<< "$CONFIG"
@@ -203,9 +204,14 @@ for CONFIG in "${PARALLELISM_CONFIGS[@]}"; do
     RUN_EXIT=$?
     if [ $RUN_EXIT -ne 0 ]; then
         echo "ERROR: Config TP=$TP, PP=$PP, EP=$EP, SP=$SP, CP=$CP failed with exit code $RUN_EXIT"
+        JOB_EXIT=$RUN_EXIT
         continue
     fi
 done
+
+if [ $JOB_EXIT -ne 0 ]; then
+    exit $JOB_EXIT
+fi
 
 echo "======================================"
 echo "Job completed (all ${#PARALLELISM_CONFIGS[@]} configs)"

--- a/tests/unit_tests/examples/test_gpt_oss_slurm.py
+++ b/tests/unit_tests/examples/test_gpt_oss_slurm.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_gpt_oss_pretrain_reports_any_failed_config(tmp_path):
+    source = REPO_ROOT / "examples/models/gpt_oss/slurm_pretrain.sh"
+    configured_script = source.read_text().replace('CONTAINER_IMAGE=""', 'CONTAINER_IMAGE="test.sqsh"', 1)
+    launcher = tmp_path / source.name
+    launcher.write_text(configured_script)
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_srun = fake_bin / "srun"
+    fake_srun.write_text(
+        """#!/bin/bash
+count=$(cat "$SRUN_COUNT_FILE" 2>/dev/null || echo 0)
+count=$((count + 1))
+echo "$count" > "$SRUN_COUNT_FILE"
+if [ "$count" -eq 1 ]; then
+    exit 17
+fi
+exit 0
+"""
+    )
+    fake_srun.chmod(0o755)
+
+    count_file = tmp_path / "srun-count"
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{fake_bin}:{env['PATH']}",
+            "SRUN_COUNT_FILE": str(count_file),
+        }
+    )
+
+    result = subprocess.run(["bash", str(launcher)], cwd=tmp_path, capture_output=True, env=env, text=True)
+
+    assert count_file.read_text().strip() == "3"
+    assert result.returncode == 17
+    assert "failed with exit code 17" in result.stdout
+    assert "Job completed" not in result.stdout


### PR DESCRIPTION
## Summary

The documented GPT-OSS pretraining Slurm launcher continued after a failed parallelism configuration but discarded the nonzero `srun` status. After the loop it printed that all configurations completed and exited 0, so Slurm and automation could accept incomplete or wholly failed training as successful.

This change retains the failure status while preserving the launcher's documented behavior of attempting every configured parallelism setup, then exits nonzero before the success footer when any attempt failed.

## Regression coverage

The regression test uses a deterministic `srun` stub: the first of three configurations returns 17 and the remaining two succeed. It asserts that all three attempts still run, the launcher returns 17, logs the failure, and does not print the success footer.

Fail-before on unmodified production code:

```text
uv run python -m pytest tests/unit_tests/examples/test_gpt_oss_slurm.py -q
# 1 failed: expected 17, actual launcher status 0
```

Pass-after and adjacent validation:

```text
uv run python -m pytest tests/unit_tests/examples/test_gpt_oss_slurm.py tests/unit_tests/recipes/test_gpt_oss_recipes.py tests/unit_tests/recipes/test_all_recipe_factories.py -q
# 285 passed

bash -n examples/models/gpt_oss/slurm_pretrain.sh examples/models/gpt_oss/slurm_sft.sh examples/models/gpt_oss/slurm_peft.sh
git diff --check
uv run pre-commit run --all-files
# all passed
```

## Scope

This is limited to scheduler-visible Bash control flow in the GPT-OSS pretraining example. It does not change recipe defaults, training semantics, dependencies, CI, or public Python APIs. No GPU or convergence validation was performed or required for this shell status-propagation defect.