### PR TITLE
[training] fix: Create MIMO embedding groups in global order

### DIFF
--- a/src/megatron/bridge/models/megatron_mimo/megatron_mimo_builder.py
+++ b/src/megatron/bridge/models/megatron_mimo/megatron_mimo_builder.py
@@ -91,9 +91,9 @@ def build_hypercomm_grids(
 
 
 def populate_embedding_and_position_groups(
-    pp_group: dist.ProcessGroup,
+    pp_rank_groups: list[list[int]] | None,
 ) -> Tuple[Optional[dist.ProcessGroup], Optional[dist.ProcessGroup]]:
-    """Create embedding-related process groups from PP group ranks.
+    """Create embedding-related process groups from globally enumerated PP ranks.
 
     Following MCore semantics:
     - pos_embd_pg: Only rank 0 of PP (first stage) - for position embeddings
@@ -103,27 +103,36 @@ def populate_embedding_and_position_groups(
     Must be called on all ranks that could participate.
 
     Args:
-        pp_group: The pipeline parallel process group.
+        pp_rank_groups: Every pipeline-parallel rank group in global creation order.
 
     Returns:
-        Tuple of (pos_embd_pg, embd_pg). Returns (None, None) if pp_group is None.
+        Tuple of process groups for the current rank. Returns (None, None) when
+        no pipeline-parallel rank groups are provided.
     """
-    if pp_group is None:
+    if not pp_rank_groups:
         return None, None
 
-    pp_ranks = sorted(dist.get_process_group_ranks(pp_group))
+    current_rank = dist.get_rank()
+    local_pos_embd_pg = None
+    local_embd_pg = None
+    for pp_rank_group in pp_rank_groups:
+        pp_ranks = sorted(pp_rank_group)
 
-    # Position embeddings only on first PP stage
-    pos_embd_ranks = [pp_ranks[0]]
-    pos_embd_pg = dist.new_group(ranks=pos_embd_ranks)
+        # Every global rank must create every derived group in the same order.
+        pos_embd_ranks = [pp_ranks[0]]
+        pos_embd_pg = dist.new_group(ranks=pos_embd_ranks)
 
-    # Word embeddings on first and last PP stages (for tied embeddings)
-    embd_ranks = [pp_ranks[0]]
-    if len(pp_ranks) > 1 and pp_ranks[-1] != pp_ranks[0]:
-        embd_ranks.append(pp_ranks[-1])
-    embd_pg = dist.new_group(ranks=embd_ranks)
+        embd_ranks = [pp_ranks[0]]
+        if len(pp_ranks) > 1 and pp_ranks[-1] != pp_ranks[0]:
+            embd_ranks.append(pp_ranks[-1])
+        embd_pg = dist.new_group(ranks=embd_ranks)
 
-    return pos_embd_pg, embd_pg
+        if current_rank in pos_embd_ranks:
+            local_pos_embd_pg = pos_embd_pg
+        if current_rank in embd_ranks:
+            local_embd_pg = embd_pg
+
+    return local_pos_embd_pg, local_embd_pg
 
 
 def is_pp_first_stage(pp_group: Optional[dist.ProcessGroup]) -> bool:

--- a/src/megatron/bridge/models/megatron_mimo/megatron_mimo_provider.py
+++ b/src/megatron/bridge/models/megatron_mimo/megatron_mimo_provider.py
@@ -286,7 +286,7 @@ class MegatronMIMOProvider(ModelProviderMixin[MimoModel]):
 
             # dist.new_group() is a collective on the default PG — all ranks must
             # call it in the same global order regardless of module membership.
-            pos_embd_pg, embd_pg = populate_embedding_and_position_groups(pp_group)
+            pos_embd_pg, embd_pg = populate_embedding_and_position_groups(grid.get_rank_enum(["pp"]))
 
             # Only build a full PG collection for ranks that participate in this module.
             if grid.is_current_rank_in_grid():

--- a/tests/unit_tests/models/megatron_mimo/test_megatron_mimo_provider.py
+++ b/tests/unit_tests/models/megatron_mimo/test_megatron_mimo_provider.py
@@ -559,19 +559,20 @@ class TestMegatronMIMOInfra:
 class TestEmbeddingGroupHelpers:
     """Test cases for embedding group helper functions."""
 
+    @patch("torch.distributed.get_rank")
     @patch("torch.distributed.new_group")
-    @patch("torch.distributed.get_process_group_ranks")
-    def test_populate_embedding_groups_single_pp_rank(self, mock_get_ranks, mock_new_group):
+    def test_populate_embedding_groups_single_pp_rank(self, mock_new_group, mock_get_rank):
         """Test embedding groups with single PP rank (PP=1)."""
         from megatron.bridge.models.megatron_mimo.megatron_mimo_builder import (
             populate_embedding_and_position_groups,
         )
 
-        mock_pp_group = MagicMock()
-        mock_get_ranks.return_value = [0]  # Single PP rank
-        mock_new_group.return_value = MagicMock()
+        mock_get_rank.return_value = 0
+        mock_pos_embd = MagicMock()
+        mock_embd = MagicMock()
+        mock_new_group.side_effect = [mock_pos_embd, mock_embd]
 
-        populate_embedding_and_position_groups(mock_pp_group)
+        pos_embd_pg, embd_pg = populate_embedding_and_position_groups([[0]])
 
         # Should create groups for both position and word embeddings
         assert mock_new_group.call_count == 2
@@ -579,28 +580,33 @@ class TestEmbeddingGroupHelpers:
         calls = mock_new_group.call_args_list
         assert calls[0].kwargs["ranks"] == [0]
         assert calls[1].kwargs["ranks"] == [0]
+        assert pos_embd_pg is mock_pos_embd
+        assert embd_pg is mock_embd
 
+    @patch("torch.distributed.get_rank")
     @patch("torch.distributed.new_group")
-    @patch("torch.distributed.get_process_group_ranks")
-    def test_populate_embedding_groups_multiple_pp_ranks(self, mock_get_ranks, mock_new_group):
-        """Test embedding groups with multiple PP ranks (PP>1)."""
+    @patch("torch.distributed.get_process_group_ranks", return_value=[0, 4])
+    def test_populate_embedding_groups_multiple_pp_groups(self, _mock_get_ranks, mock_new_group, mock_get_rank):
+        """Test every PP subgroup is created in one global order."""
         from megatron.bridge.models.megatron_mimo.megatron_mimo_builder import (
             populate_embedding_and_position_groups,
         )
 
-        mock_pp_group = MagicMock()
-        mock_get_ranks.return_value = [0, 4, 8, 12]  # PP=4
-        mock_new_group.return_value = MagicMock()
+        mock_get_rank.return_value = 0
+        created_groups = [MagicMock() for _ in range(4)]
+        mock_new_group.side_effect = created_groups
 
-        populate_embedding_and_position_groups(mock_pp_group)
+        pos_embd_pg, embd_pg = populate_embedding_and_position_groups([[0, 4], [1, 5]])
 
-        # Should create two groups
-        assert mock_new_group.call_count == 2
+        # Every rank makes the same calls for every PP subgroup, not just its local subgroup.
+        assert mock_new_group.call_count == 4
         calls = mock_new_group.call_args_list
-        # pos_embd only on first rank
         assert calls[0].kwargs["ranks"] == [0]
-        # embd on first and last ranks
-        assert calls[1].kwargs["ranks"] == [0, 12]
+        assert calls[1].kwargs["ranks"] == [0, 4]
+        assert calls[2].kwargs["ranks"] == [1]
+        assert calls[3].kwargs["ranks"] == [1, 5]
+        assert pos_embd_pg is created_groups[0]
+        assert embd_pg is created_groups[1]
 
     def test_populate_embedding_groups_none_pp_group(self):
         """Test embedding groups with None PP group."""


### PR DESCRIPTION
## What changed

Create MIMO position-embedding and word-embedding process groups from the
HyperCommGrid's global PP-group enumeration, then retain the groups that apply
to the current rank.

## Bug and impact

`torch.distributed.new_group()` is collective over the default process group:
all ranks must create groups in the same global order. The MIMO provider instead
derived embedding groups from each rank's local PP group. With multiple PP
groups, ranks therefore used the same creation ordinal for different rank lists.

The shipped Qwen3.5-VL non-colocated SFT configuration reaches this path with
language TP=4, PP=2, and DP=2. A reduced four-rank PP=2/DP=2 reproducer showed
silent communicator cross-talk: logical groups `[0, 2]` and `[1, 3]` both
reduced to `5.0`, instead of their independent expected values `4.0` and `6.0`.

The fix creates each derived group for every globally enumerated PP subgroup in
stable order on every rank. PP=1 behavior and first/last-stage group ownership
remain unchanged.

## Validation

Fail-before on the unmodified base revision:

```text
uv run python -m torch.distributed.run --nproc_per_node=4 reproduce_mimo_embedding_groups.py --pipeline-parallel-size=1
PASS pp=1 dp=4

uv run python -m torch.distributed.run --nproc_per_node=4 reproduce_mimo_embedding_groups.py --pipeline-parallel-size=2
FAIL: [0, 2] reduced to 5.0, expected 4.0
FAIL: [1, 3] reduced to 5.0, expected 6.0
```

Pass-after with the unchanged reproducer:

```text
PASS pp=1 dp=4
PASS pp=2 dp=2
```

Focused and adjacent tests:

```text
uv run python -m pytest -q \
  tests/unit_tests/models/megatron_mimo/test_megatron_mimo_provider.py \
  tests/unit_tests/models/megatron_mimo/test_megatron_mimo_builder.py \
  tests/unit_tests/models/megatron_mimo/test_megatron_mimo_ddp.py \
  tests/unit_tests/training/megatron_mimo/test_megatron_mimo_config.py
63 passed

uv run pre-commit run --all-files
Passed

git diff --check
Passed
```

Scope is limited to MIMO-derived embedding process groups; no conversion APIs,
dependencies, CI workflows, or MCore sources are changed.
