### PR TITLE
[ckpt] fix: Clear saved pipeline layout for single-rank load

### DIFF
--- a/src/megatron/bridge/training/model_load_save.py
+++ b/src/megatron/bridge/training/model_load_save.py
@@ -485,6 +485,11 @@ def load_megatron_model(
             if hasattr(model_cfg, key) and value is not None:
                 setattr(model_cfg, key, value)
 
+    # A saved flexible layout describes PP/VPP stage ownership. It must not be
+    # reinterpreted as virtual pipeline chunks after collapsing to one rank.
+    if model_cfg.pipeline_model_parallel_size == 1 and model_cfg.virtual_pipeline_model_parallel_size is None:
+        model_cfg.pipeline_model_parallel_layout = None
+
     # Flex dispatcher requires TPxEP > 1; fall back to allgather for single-rank export
     if getattr(model_cfg, "moe_token_dispatcher_type", None) == "flex":
         tp = getattr(model_cfg, "tensor_model_parallel_size", 1)

--- a/tests/unit_tests/training/test_model_load_save.py
+++ b/tests/unit_tests/training/test_model_load_save.py
@@ -273,6 +273,38 @@ class TestLoadMegatronModel:
 
         assert loaded_provider.pipeline_model_parallel_layout == expected_layout
 
+    @pytest.mark.parametrize(
+        "pipeline_layout",
+        [None, [["embedding", "decoder"], ["decoder", "loss"]]],
+        ids=["plain", "flexible"],
+    )
+    @patch("megatron.bridge.training.model_load_save.build_and_load_model")
+    @patch("megatron.bridge.training.model_load_save.load_model_config")
+    def test_default_load_builds_all_layers_on_one_rank(
+        self, mock_load_model_config, mock_build_and_load_model, pipeline_layout
+    ):
+        """Verify default loading removes saved pipeline-stage ownership."""
+        provider = GPTModelProvider(
+            num_layers=2,
+            hidden_size=16,
+            num_attention_heads=2,
+            pipeline_model_parallel_size=2,
+            pipeline_model_parallel_layout=pipeline_layout,
+        )
+        mock_load_model_config.return_value = (provider, None)
+
+        def _built_layer_count(checkpoint_path, model_cfg, *args):
+            model_cfg.finalize()
+            if model_cfg.pipeline_model_parallel_layout is None:
+                return model_cfg.num_layers
+            return model_cfg.pipeline_model_parallel_layout.get_num_layers_to_build(vp_stage=None, pp_rank=0)
+
+        mock_build_and_load_model.side_effect = _built_layer_count
+
+        built_layer_count = load_megatron_model("/ckpt")
+
+        assert built_layer_count == provider.num_layers
+
     @patch("megatron.bridge.training.model_load_save.temporary_distributed_context")
     @patch("megatron.bridge.training.checkpointing._load_model_weights_from_checkpoint")
     @patch("megatron.bridge.utils.instantiate_utils.instantiate")


### PR DESCRIPTION
## Problem

Loading a supported checkpoint with a saved flexible pipeline layout through
the default `AutoBridge.load_megatron_model()` path can silently construct only
the first layout segment's decoder layers.

The loader collapses PP/VPP to one rank for its default path but preserved the
saved topology-specific layout. During later config finalization, that list is
reinterpreted as virtual pipeline chunks. Model construction creates one chunk
without a virtual-stage index, so only virtual segment zero is selected. Since
checkpoint loading requests only the constructed model state and permits
unexpected checkpoint entries, later decoder layers can be omitted without a
load error.

## Fix

Clear the saved flexible layout after overrides only when the final requested
topology is PP=1 and VPP is disabled. Multi-rank override paths continue to
retain their saved or explicitly supplied layouts.

## Validation

- Before the fix, the unchanged parameterized regression passed the plain
  control and failed the flexible-layout case: one of two decoder layers was
  selected.
- After the fix, the same regression passed both cases: `2 passed`.
- `uv run --active --no-sync python -m pytest tests/unit_tests/training/test_model_load_save.py -q`
  -> `56 passed`.
- `uv run --active --no-sync python -m pytest tests/unit_tests/models/test_auto_bridge.py -k load_megatron_model -q`
  -> `4 passed, 72 deselected`.
- `git diff --check` -> passed.
- `uv run --active --no-sync pre-commit run --all-files` -> every hook passed.

## Scope

This changes only default one-rank model loading when VPP is disabled. It does
not change distributed loading, conversion APIs, checkpoint formats, or
multi-rank flexible-layout behavior. No full-suite, model-quality, convergence,
or performance validation was run.
