### PR TITLE
[inference] fix: Seed VLM sampling generator

### DIFF
--- a/src/megatron/bridge/inference/vlm/vlm_engine.py
+++ b/src/megatron/bridge/inference/vlm/vlm_engine.py
@@ -18,6 +18,7 @@ import torch
 from megatron.core.inference.engines.static_engine import StaticInferenceEngine
 from megatron.core.inference.inference_request import InferenceRequest
 from megatron.core.inference.sampling_params import SamplingParams
+from megatron.core.inference.text_generation_controllers.text_generation_controller import TextGenerationController
 from PIL.Image import Image
 
 from ._mcore_compat import InferenceMode
@@ -25,6 +26,23 @@ from ._mcore_compat import InferenceMode
 
 class VLMEngine(StaticInferenceEngine):
     """VLM inference engine extending MCoreEngine with image support."""
+
+    def __init__(
+        self,
+        text_generation_controller: TextGenerationController,
+        max_batch_size: int | None = None,
+        random_seed: int | None = None,
+        legacy: bool = False,
+        buffer_size_gb: float | None = 40,
+    ) -> None:
+        super().__init__(
+            text_generation_controller=text_generation_controller,
+            max_batch_size=max_batch_size,
+            random_seed=random_seed,
+            legacy=legacy,
+            buffer_size_gb=buffer_size_gb,
+        )
+        self._sampling_random_seed = random_seed
 
     # pylint: disable=C0115,C0116
     def generate(
@@ -40,6 +58,8 @@ class VLMEngine(StaticInferenceEngine):
 
             if self.random_seed:
                 torch.random.manual_seed(self.random_seed)
+            if self._sampling_random_seed is not None:
+                self.controller.sampling_rng.manual_seed(self._sampling_random_seed)
 
             if images is not None and len(images) != len(prompts):
                 raise ValueError(f"Number of images ({len(images)}) must match number of prompts ({len(prompts)})")

--- a/tests/unit_tests/inference/vlm/test_vlm_engine.py
+++ b/tests/unit_tests/inference/vlm/test_vlm_engine.py
@@ -14,6 +14,7 @@
 
 from unittest.mock import MagicMock
 
+import torch
 from megatron.core.inference.contexts import StaticInferenceContext
 
 from megatron.bridge.inference.vlm._mcore_compat import InferenceMode
@@ -47,3 +48,45 @@ class TestVLMEngine:
             assert not InferenceMode.is_active()
         finally:
             InferenceMode.unset_active()
+
+    def test_generate_uses_requested_seed_for_sampling(self):
+        def sample_tokens(random_seed):
+            InferenceMode.unset_active()
+            mock_controller = MagicMock()
+            mock_controller.tokenize_prompt.return_value = ([1, 2, 3], "image_dict")
+            mock_controller.inference_wrapped_model.inference_context = StaticInferenceContext(
+                max_batch_size=128, max_sequence_length=8192
+            )
+            mock_controller.inference_wrapped_model.inference_wrapper_config = MagicMock(inference_max_requests=128)
+            mock_controller.sampling_rng = torch.Generator(device="cuda")
+            mock_controller.sampling_rng.manual_seed(42)
+
+            try:
+                engine = VLMEngine(mock_controller, max_batch_size=4, random_seed=random_seed)
+                engine.scheduler = MagicMock()
+                engine.scheduler.add_request.return_value = "req_id"
+
+                def run_engine():
+                    probabilities = torch.full((2,), 0.5, device="cuda")
+                    sampled_tokens = torch.multinomial(
+                        probabilities,
+                        num_samples=16,
+                        replacement=True,
+                        generator=mock_controller.sampling_rng,
+                    )
+                    engine.scheduler.completed_request_pool = {"req_id": sampled_tokens.cpu().tolist()}
+
+                engine.run_engine = run_engine
+                return engine.generate(["prompt"], ["image"])
+            finally:
+                InferenceMode.unset_active()
+
+        first_sample = sample_tokens(random_seed=17)
+        replayed_sample = sample_tokens(random_seed=17)
+        different_sample = sample_tokens(random_seed=23)
+        default_sample = sample_tokens(random_seed=None)
+        config_seed_sample = sample_tokens(random_seed=42)
+
+        assert first_sample == replayed_sample
+        assert first_sample != different_sample
+        assert default_sample == config_seed_sample


### PR DESCRIPTION
## What changed

The public VLM generation path forwarded `random_seed` to `VLMEngine`, but the engine only reseeded PyTorch's global RNG. Megatron-Core performs stochastic token selection with the controller-owned `sampling_rng`, so distinct explicit seeds silently selected the same sampling stream.

This change reseeds the controller sampling generator at the existing VLM generation seed boundary. It also adds a regression that checks the user-visible contract: the same seed replays the same stochastic token sequence, while different seeds select different sequences.

## Supported trigger and impact

This affects Qwen VLM generation through `megatron.bridge.inference.vlm.base.generate` when stochastic sampling is enabled. Before this change, explicit `random_seed` values did not control the generator that sampled output tokens, preventing callers from selecting or replaying the requested stochastic stream.

## Validation

The unchanged regression failed on the audited base because seeds 17 and 23 returned the identical 16-token sample:

```text
uv run --no-sync python -m pytest tests/unit_tests/inference/vlm/test_vlm_engine.py::TestVLMEngine::test_generate_uses_requested_seed_for_sampling -q
# before: 1 failed
# after: 1 passed
```

Focused adjacent coverage:

```text
uv run --no-sync python -m pytest tests/unit_tests/inference/vlm -q
# 34 passed

uv run --no-sync pre-commit run --all-files
# passed
```

## Scope

- No checkpoint, model-weight, or greedy-sampling behavior changes.
- No dependency, lockfile, workflow, public conversion API, or Megatron-Core submodule changes.
- Explicit seeds, including zero, control sampling. Omitting the seed preserves the existing model-configured sampling stream.
- The full test suite was not run.
