### PR TITLE
fix(training): count expert parameter norms with TP and EP

### DIFF
--- a/src/megatron/bridge/training/utils/train_utils.py
+++ b/src/megatron/bridge/training/utils/train_utils.py
@@ -325,23 +325,30 @@ def calc_params_l2_norm(
     params_data = []
     moe_params_data = []
     sharded_params_data = []
+    sharded_moe_params_data = []
     data_parallel_group = None
+    pg_collection = get_pg_collection(model)
 
     for model_chunk in model:
         for param in model_chunk.parameters():
             data_parallel_group = get_data_parallel_group_if_dtensor(param, data_parallel_group)
-            is_not_tp_duplicate = param_is_not_tensor_parallel_duplicate(param)
+            is_expert = not getattr(param, "allreduce", True)
+            is_not_tp_duplicate = param_is_not_tensor_parallel_duplicate(
+                param,
+                tp_group=pg_collection.tp,
+                expert_tp_group=pg_collection.expt_tp,
+            )
             if not is_not_tp_duplicate:
                 continue
             assert is_not_tp_duplicate
-            if not getattr(param, "allreduce", True):
+            if is_expert:
                 assert param_is_not_shared(param)
                 param = to_local_if_dtensor(param)
                 if model_config.bf16:
                     if not force_create_fp32_copy and hasattr(param, "main_param"):
                         if getattr(param, "main_param_sharded", False):
                             if param.main_param is not None:
-                                sharded_params_data.append(param.main_param)
+                                sharded_moe_params_data.append(param.main_param)
                         else:
                             main_param = param.main_param
                             moe_params_data.append(main_param if main_param is not None else param.data.float())
@@ -401,7 +408,6 @@ def calc_params_l2_norm(
         sharded_norm_2 = torch.zeros((1,), dtype=torch.float32, device="cuda")
     # Sum over all DP groups, including CP since distributed optimizer state is
     # sharded jointly over DP+CP.
-    pg_collection = get_pg_collection(model)
     torch.distributed.all_reduce(
         sharded_norm_2,
         op=torch.distributed.ReduceOp.SUM,
@@ -424,6 +430,25 @@ def calc_params_l2_norm(
     # See details in https://gitlab-master.nvidia.com/ADLR/megatron-lm/-/issues/409
     else:
         moe_norm_2 = torch.zeros_like(norm_2)
+
+    # Distributed optimizer shards expert main parameters over expert DP rather
+    # than regular DP, so reduce their contribution separately.
+    if len(sharded_moe_params_data) > 0:
+        sharded_moe_norm, _ = multi_tensor_applier(
+            multi_tensor_l2norm,
+            dummy_overflow_buf,
+            [sharded_moe_params_data],
+            False,  # no per-parameter norm.
+        )
+        sharded_moe_norm_2 = sharded_moe_norm * sharded_moe_norm
+    else:
+        sharded_moe_norm_2 = torch.zeros((1,), dtype=torch.float32, device="cuda")
+    torch.distributed.all_reduce(
+        sharded_moe_norm_2,
+        op=torch.distributed.ReduceOp.SUM,
+        group=pg_collection.expt_dp,
+    )
+    moe_norm_2 += sharded_moe_norm_2
 
     # Reduce norm across model parallel groups (dense and expert).
     # Dense params should sum across all model-parallel GPUs (tensor + pipeline).

--- a/src/megatron/bridge/training/utils/train_utils.py
+++ b/src/megatron/bridge/training/utils/train_utils.py
@@ -332,7 +332,8 @@ def calc_params_l2_norm(
     for model_chunk in model:
         for param in model_chunk.parameters():
             data_parallel_group = get_data_parallel_group_if_dtensor(param, data_parallel_group)
-            is_expert = not getattr(param, "allreduce", True)
+            # MCore uses allreduce=False to mark parameters that use expert-parallel process groups.
+            uses_expert_parallel_groups = not getattr(param, "allreduce", True)
             is_not_tp_duplicate = param_is_not_tensor_parallel_duplicate(
                 param,
                 tp_group=pg_collection.tp,
@@ -341,7 +342,7 @@ def calc_params_l2_norm(
             if not is_not_tp_duplicate:
                 continue
             assert is_not_tp_duplicate
-            if is_expert:
+            if uses_expert_parallel_groups:
                 assert param_is_not_shared(param)
                 param = to_local_if_dtensor(param)
                 if model_config.bf16:

--- a/tests/unit_tests/training/utils/test_train_utils.py
+++ b/tests/unit_tests/training/utils/test_train_utils.py
@@ -3023,6 +3023,43 @@ class TestCalcParamsL2Norm:
 
         assert actual_norm == pytest.approx(2.0)
 
+    def test_real_mcore_duplicate_filter_honors_expert_tp_group(self):
+        """Guard the Bridge<->MCore contract for expert-parameter duplicate filtering.
+
+        ``calc_params_l2_norm`` calls MCore's ``param_is_not_tensor_parallel_duplicate`` with an
+        ``expert_tp_group`` so that ``allreduce=False`` expert parameters de-duplicate over expert
+        tensor parallel instead of regular TP. Every other test in this class mocks that function,
+        so they would still pass against an MCore build that dropped the ``expert_tp_group`` kwarg --
+        silently undercounting expert parameter norms. Exercise the real function here so a pinned
+        MCore that regresses below this contract fails loudly (``TypeError`` or wrong result) rather
+        than degrading the training-log norm in production.
+        """
+        from megatron.core.tensor_parallel.layers import param_is_not_tensor_parallel_duplicate
+
+        assert "expert_tp_group" in inspect.signature(param_is_not_tensor_parallel_duplicate).parameters
+
+        class _RankGroup:
+            def __init__(self, rank):
+                self._rank = rank
+
+            def rank(self):
+                return self._rank
+
+        duplicate_regular_tp = _RankGroup(rank=1)  # would be dropped as a regular-TP duplicate
+        primary_expert_tp = _RankGroup(rank=0)  # but is the primary shard on expert TP
+
+        expert_param = SimpleNamespace(allreduce=False)
+        dense_param = SimpleNamespace(allreduce=True)
+
+        # Expert param must route through expert_tp_group (rank 0 -> kept), not regular TP (rank 1).
+        assert param_is_not_tensor_parallel_duplicate(
+            expert_param, tp_group=duplicate_regular_tp, expert_tp_group=primary_expert_tp
+        )
+        # Dense param still de-duplicates against the regular TP group (rank 1 -> dropped).
+        assert not param_is_not_tensor_parallel_duplicate(
+            dense_param, tp_group=duplicate_regular_tp, expert_tp_group=primary_expert_tp
+        )
+
     @mock.patch("megatron.bridge.training.utils.train_utils.calc_dtensor_params_l2_norm")
     def test_megatron_fsdp_path(self, mock_calc_dtensor_norm, mock_model_config_fp32):
         """Test calc_params_l2_norm with use_megatron_fsdp=True."""

--- a/tests/unit_tests/training/utils/test_train_utils.py
+++ b/tests/unit_tests/training/utils/test_train_utils.py
@@ -2508,7 +2508,10 @@ class TestCalcParamsL2Norm:
             def __init__(self):
                 # Minimal set of groups used by calc_params_l2_norm
                 self.dp_cp = object()
+                self.expt_dp = object()
+                self.expt_tp = object()
                 self.mp = object()
+                self.tp = object()
                 self.tp_ep_pp = object()
                 self.pp = object()
 
@@ -2519,11 +2522,13 @@ class TestCalcParamsL2Norm:
 
                 self.dp = _DP()
 
+        pg_collection = _PG()
         monkeypatch.setattr(
             "megatron.bridge.training.utils.train_utils.get_pg_collection",
-            lambda model: _PG(),
+            lambda model: pg_collection,
             raising=True,
         )
+        return pg_collection
 
     @pytest.fixture
     def simple_model(self):
@@ -2730,8 +2735,9 @@ class TestCalcParamsL2Norm:
         mock_is_not_tp_dup,
         mock_get_dp_group_if_dtensor,
         mock_model_config_bf16,
+        _patch_pg_collection,
     ):
-        """Test calc_params_l2_norm with sharded main params (distributed optimizer)."""
+        """Test dense sharded main params reduce over ordinary DP/CP."""
         model = torch.nn.Linear(5, 5, bias=False, dtype=torch.bfloat16).cuda()
 
         # Setup mocks
@@ -2748,7 +2754,14 @@ class TestCalcParamsL2Norm:
 
         result = calc_params_l2_norm(model, mock_model_config_bf16, force_create_fp32_copy=False)
 
-        # Should use sharded params path and call all_reduce
+        dense_sharded_reduce = next(
+            call for call in mock_all_reduce.call_args_list if call.kwargs["group"] is _patch_pg_collection.dp_cp
+        )
+        expert_sharded_reduce = next(
+            call for call in mock_all_reduce.call_args_list if call.kwargs["group"] is _patch_pg_collection.expt_dp
+        )
+        assert dense_sharded_reduce.args[0].item() == pytest.approx(13.0)
+        assert expert_sharded_reduce.args[0].item() == pytest.approx(0.0)
         assert isinstance(result, float)
         assert result > 0
 
@@ -2874,13 +2887,14 @@ class TestCalcParamsL2Norm:
 
     @mock.patch("megatron.bridge.training.utils.train_utils.get_data_parallel_group_if_dtensor")
     @mock.patch("megatron.bridge.training.utils.train_utils.param_is_not_tensor_parallel_duplicate")
-    def test_tp_duplicate_params(
+    def test_duplicate_filter_receives_tp_and_expert_tp_groups(
         self,
         mock_is_not_tp_dup,
         mock_get_dp_group_if_dtensor,
         mock_model_config_fp32,
+        _patch_pg_collection,
     ):
-        """Test calc_params_l2_norm skips TP duplicate parameters."""
+        """Test duplicate filtering receives both tensor-parallel groups."""
         model = torch.nn.Linear(5, 5, bias=False).cuda()
 
         # Setup mocks
@@ -2901,6 +2915,11 @@ class TestCalcParamsL2Norm:
 
             # Should be 0 since all params are TP duplicates
             assert result == pytest.approx(0.0, abs=1e-5)
+            mock_is_not_tp_dup.assert_called_once_with(
+                model.weight,
+                tp_group=_patch_pg_collection.tp,
+                expert_tp_group=_patch_pg_collection.expt_tp,
+            )
 
     @mock.patch("megatron.bridge.training.utils.train_utils.calc_dtensor_params_l2_norm")
     def test_megatron_fsdp_path(self, mock_calc_dtensor_norm, mock_model_config_fp32):
@@ -3225,12 +3244,9 @@ class TestCalcParamsL2Norm:
         mock_is_not_tp_dup,
         mock_get_dp_group_if_dtensor,
         mock_model_config_bf16,
+        _patch_pg_collection,
     ):
-        """Test calc_params_l2_norm with MoE params using sharded main_param (distributed optimizer).
-
-        When MoE params have main_param_sharded=True, they should be added to
-        sharded_params_data for proper all-reduce across DP groups.
-        """
+        """Test expert sharded main params reduce over expert DP."""
         model = torch.nn.Linear(5, 5, bias=False, dtype=torch.bfloat16).cuda()
 
         # Setup mocks
@@ -3248,7 +3264,14 @@ class TestCalcParamsL2Norm:
 
         result = calc_params_l2_norm(model, mock_model_config_bf16, force_create_fp32_copy=False)
 
-        # Should use sharded params path and call all_reduce
+        dense_sharded_reduce = next(
+            call for call in mock_all_reduce.call_args_list if call.kwargs["group"] is _patch_pg_collection.dp_cp
+        )
+        expert_sharded_reduce = next(
+            call for call in mock_all_reduce.call_args_list if call.kwargs["group"] is _patch_pg_collection.expt_dp
+        )
+        assert dense_sharded_reduce.args[0].item() == pytest.approx(0.0)
+        assert expert_sharded_reduce.args[0].item() == pytest.approx(13.0)
         assert isinstance(result, float)
         assert result > 0
 

--- a/tests/unit_tests/training/utils/test_train_utils.py
+++ b/tests/unit_tests/training/utils/test_train_utils.py
@@ -2921,6 +2921,55 @@ class TestCalcParamsL2Norm:
                 expert_tp_group=_patch_pg_collection.expt_tp,
             )
 
+    def test_moe_param_norm_counts_logical_parameter_when_tp_ranks_differ(
+        self,
+        monkeypatch,
+        mock_model_config_fp32,
+    ):
+        """Expert parameters use the expert-TP rank when it differs from regular TP."""
+
+        class _RankGroup:
+            def __init__(self, rank):
+                self._rank = rank
+
+            def rank(self):
+                return self._rank
+
+        class _MixedModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.dense = torch.nn.Parameter(torch.ones(4, device="cuda"))
+                self.expert = torch.nn.Parameter(torch.ones(4, device="cuda"))
+                self.expert.allreduce = False
+
+        regular_tp_group = _RankGroup(rank=1)
+        expert_tp_group = _RankGroup(rank=0)
+        reduce_group = _RankGroup(rank=0)
+        pg_collection = SimpleNamespace(
+            tp=regular_tp_group,
+            expt_tp=expert_tp_group,
+            dp_cp=reduce_group,
+            expt_dp=reduce_group,
+            mp=reduce_group,
+            tp_ep_pp=reduce_group,
+        )
+        monkeypatch.setattr(
+            "megatron.bridge.training.utils.train_utils.get_pg_collection",
+            lambda model: pg_collection,
+        )
+
+        with (
+            mock.patch(
+                "megatron.core.tensor_parallel.layers.get_tensor_model_parallel_rank",
+                return_value=regular_tp_group.rank(),
+            ),
+            mock.patch("torch.distributed.get_process_group_ranks", return_value=[0]),
+            mock.patch("torch.distributed.all_reduce"),
+        ):
+            actual_norm = calc_params_l2_norm(_MixedModel(), mock_model_config_fp32)
+
+        assert actual_norm == pytest.approx(2.0)
+
     @mock.patch("megatron.bridge.training.utils.train_utils.calc_dtensor_params_l2_norm")
     def test_megatron_fsdp_path(self, mock_calc_dtensor_norm, mock_model_config_fp32):
         """Test calc_params_l2_norm with use_megatron_fsdp=True."""

--- a/tests/unit_tests/training/utils/test_train_utils.py
+++ b/tests/unit_tests/training/utils/test_train_utils.py
@@ -2765,6 +2765,59 @@ class TestCalcParamsL2Norm:
         assert isinstance(result, float)
         assert result > 0
 
+    def test_bf16_sharded_dense_and_expert_norm_uses_matching_dp_groups(
+        self,
+        monkeypatch,
+        mock_model_config_bf16,
+        _patch_pg_collection,
+    ):
+        """Dense and expert optimizer shards contribute through their matching DP groups."""
+
+        class _DenseAndExpertModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.dense = torch.nn.Parameter(torch.ones(1, dtype=torch.bfloat16, device="cuda"))
+                self.expert = torch.nn.Parameter(torch.ones(1, dtype=torch.bfloat16, device="cuda"))
+                self.expert.allreduce = False
+
+                self.dense.main_param = torch.tensor([2.0], device="cuda")
+                self.dense.main_param_sharded = True
+                self.expert.main_param = torch.tensor([3.0], device="cuda")
+                self.expert.main_param_sharded = True
+
+        def fake_all_reduce(tensor, op, group):
+            del op
+            if group is _patch_pg_collection.dp_cp:
+                tensor.add_(12.0)
+            elif group is _patch_pg_collection.expt_dp:
+                tensor.add_(16.0)
+            elif group is not _patch_pg_collection.mp:
+                raise AssertionError("unexpected reduction group")
+
+        monkeypatch.setattr(
+            "megatron.bridge.training.utils.train_utils.get_data_parallel_group_if_dtensor",
+            lambda param, group: None,
+        )
+        monkeypatch.setattr(
+            "megatron.bridge.training.utils.train_utils.param_is_not_tensor_parallel_duplicate",
+            lambda param, **kwargs: True,
+        )
+        monkeypatch.setattr(
+            "megatron.bridge.training.utils.train_utils.to_local_if_dtensor",
+            lambda param: param,
+        )
+        monkeypatch.setattr("torch.distributed.get_process_group_ranks", lambda group: [0])
+        monkeypatch.setattr("torch.distributed.all_reduce", fake_all_reduce)
+
+        actual_norm = calc_params_l2_norm(
+            _DenseAndExpertModel(),
+            mock_model_config_bf16,
+            force_create_fp32_copy=False,
+        )
+
+        # Dense: 2**2 local + 12 remote over DP/CP. Expert: 3**2 local + 16 remote over expert DP.
+        assert actual_norm == pytest.approx(math.sqrt(41.0))
+
     @mock.patch("megatron.bridge.training.utils.train_utils.get_data_parallel_group_if_dtensor")
     @mock.patch("megatron.bridge.training.utils.train_utils.param_is_not_tensor_parallel_duplicate")
     @mock.patch("megatron.bridge.training.utils.train_utils.to_local_if_dtensor")


### PR DESCRIPTION
## Summary

- Pass the model-attached regular TP and expert-TP process groups to MCore's parameter-duplicate filter.
- Keep dense and expert distributed-optimizer main-parameter shards in separate norm buckets.
- Reduce dense shards over DP/CP and expert shards over expert DP.
- Add outcome-based regressions for logical expert-parameter counting and group-correct sharded norm aggregation.

## Root cause and impact

Bridge maintains an independent `calc_params_l2_norm` utility for parameter-norm reporting. It filtered every parameter with the regular tensor-parallel topology and accumulated all distributed-optimizer main-parameter shards over ordinary DP/CP.

For parameters with `allreduce=False`, duplicate filtering must use expert TP. Their sharded FP32 main parameters must likewise be reduced over expert DP. The old behavior could omit a logical expert parameter or aggregate its shard over the wrong domain, producing an undercounted parameter L2 norm in training logs.

## Why the Bridge diff differs from the final MCore diff

MCore #5916 originally implemented the same separate expert-sharded bucket in commit `2629ec4c3ae700d0fd67a4ef4399ad9e2d9c6461`. A later GTP refactor absorbed that bucket into MCore's generalized norm/reduction structure, so the final MCore PR diff is smaller.

Bridge still owns this independent training-log calculation and uses model-attached process groups (`pg_collection.tp`, `pg_collection.expt_tp`, `pg_collection.dp_cp`, and `pg_collection.expt_dp`) instead of MCore's global MPU accessors. Bridge already delegates optimizer gradient norm, clipping, and synchronization to MCore, so this PR does not duplicate any optimizer, TE, DDP, or grouped-linear code.

## Upstream status

NVIDIA/Megatron-LM#5916 is merged. The current Bridge `main` pin is its exact merge commit:

- `cd4afffa648426a959dc7cb1e24b5ce7d0c3ff54`

The previous upstream blocker is therefore resolved, and this PR does not change the MCore submodule pointer or dependency metadata.

## Test-first validation

Both contracts were executed against current Bridge `main` production code before applying this PR's implementation, using the same tests and the pinned MCore merge commit.

### RED: current main without the Bridge fix

- Logical expert parameter with regular TP rank 1 and expert-TP rank 0:
  - obtained `0.0`
  - expected `2.0`
- BF16 distributed-optimizer shards with deterministic group-aware reductions:
  - obtained `5.0`
  - expected `sqrt(41) = 6.403124...`
- Result: `2 failed`

### GREEN: same tests with the Bridge fix

- Exact same two nodes: `2 passed`
- Complete `TestCalcParamsL2Norm` class: `25 passed`
- `uv run pre-commit run --all-files`: passed
- `git diff --check`: passed

The sharded numeric test assigns independent remote contributions to DP/CP and expert DP and asserts the final norm, so it validates the observable result rather than only checking mocked call arguments.
