### PR TITLE
fix(model): use TP=1 for GLM-5 inference

### DIFF
--- a/examples/models/glm/glm5/README.md
+++ b/examples/models/glm/glm5/README.md
@@ -22,8 +22,8 @@ Full-model conversion and inference in BF16 requires **at least 8 nodes (64 GPUs
 
 - EP must divide 256 (number of routed experts). Valid: 1, 2, 4, 8, 16, 32, 64, 128, 256.
 - TP does **not** reduce expert memory — increase EP instead.
-- Minimum recommended: `TP=2, EP=32, PP=1` (64 GPUs, 8 nodes).
-- `TP=1, EP=64` works for conversion but may cause empty-dispatch issues during autoregressive inference with single-token batches. Use `TP >= 2` for inference.
+- Minimum recommended: `TP=1, PP=2, EP=32` (64 GPUs, 8 nodes). PP splits the 78 transformer layers evenly, with 39 layers per stage, and EP places 8 routed experts per GPU.
+- `TP=1, PP=1, EP=64` works for conversion but may cause empty-dispatch issues during autoregressive inference with single-token batches. Prefer `PP=2, EP=32` for inference on 64 GPUs.
 
 ### Pre-requisites
 
@@ -38,7 +38,7 @@ The PyPI source distribution is incomplete; install from the git repo.
 
 ## Inference (Megatron)
 
-[slurm_inference.sh](slurm_inference.sh) loads the HF checkpoint, converts to Megatron in-memory, and runs greedy text generation with `TP=2, EP=32` across 64 GPUs.
+[slurm_inference.sh](slurm_inference.sh) loads the HF checkpoint, converts to Megatron in-memory, and runs greedy text generation with `TP=1, PP=2, EP=32` across 64 GPUs. TP remains disabled because AbsorbedMLA requires sequence parallelism when `TP > 1`.
 
 ```bash
 sbatch examples/models/glm/glm5/slurm_inference.sh
@@ -68,7 +68,7 @@ export SLURM_ACCOUNT=your_account
 bash examples/models/glm/glm5/slurm_conversion.sh
 ```
 
-The script uses 8 nodes (64 GPUs) with `TP=2`, `PP=1`, and `EP=32`.
+The script uses 8 nodes (64 GPUs) with `TP=1`, `PP=2`, and `EP=32`.
 
 > **Note:** The round-trip verification step (comparing ~63K weight tensors on rank 0)
 > may hit Lustre I/O contention at this model scale. The HF→Megatron conversion

--- a/examples/models/glm/glm5/slurm_conversion.sh
+++ b/examples/models/glm/glm5/slurm_conversion.sh
@@ -14,6 +14,8 @@
 # limitations under the License.
 
 # GLM-5 round-trip verification on 8 Slurm nodes (64 GPUs).
+# TP=1 avoids the AbsorbedMLA sequence-parallel requirement for TP > 1;
+# PP=2 evenly splits the model's 78 transformer layers.
 # Run this wrapper from a Slurm login node; convert.sh submits one job and
 # waits for it by default.
 #
@@ -60,5 +62,5 @@ done
     "${ENV_ARGS[@]}" \
     --experiment-name glm5-roundtrip \
     --hf-model zai-org/GLM-5 \
-    --tp 2 --pp 1 --ep 32 --etp 1 \
+    --tp 1 --pp 2 --ep 32 --etp 1 \
     "$@"

--- a/examples/models/glm/glm5/slurm_inference.sh
+++ b/examples/models/glm/glm5/slurm_inference.sh
@@ -22,7 +22,9 @@
 #
 # Full model requires 8 nodes (64 GPUs) minimum.
 # TP does NOT reduce expert memory — increase EP instead.
-# Recommended: TP=2, EP=32, PP=1 (64 GPUs, 8 nodes).
+# Recommended: TP=1, EP=32, PP=2 (64 GPUs, 8 nodes).
+# PP=2 splits the 78 transformer layers evenly (39 per stage), while TP=1
+# avoids the AbsorbedMLA sequence-parallel requirement for TP > 1.
 #
 # Megatron inference engine support is not yet available for this architecture.
 # This launcher defaults to the older slow sanity-check generation path for now.
@@ -64,9 +66,9 @@ MODEL_NAME="${MODEL_NAME:-GLM-5}"
 # Use the direct local snapshot path to avoid 64 processes calling
 # snapshot_download simultaneously (causes Lustre race conditions).
 HF_MODEL_PATH="${HF_HOME}/hub/models--zai-org--${MODEL_NAME}/snapshots/$(ls ${HF_HOME}/hub/models--zai-org--${MODEL_NAME}/snapshots/ | head -1)"
-TP="${TP:-2}"
+TP="${TP:-1}"
 EP="${EP:-32}"
-PP="${PP:-1}"
+PP="${PP:-2}"
 
 PROMPT="${PROMPT:-What is artificial intelligence?}"
 MAX_NEW_TOKENS="${MAX_NEW_TOKENS:-100}"
@@ -76,6 +78,9 @@ export TORCH_NCCL_AVOID_RECORD_STREAMS=1
 export NCCL_NVLS_ENABLE=0
 export NCCL_DEBUG=WARN
 export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+export HF_HUB_OFFLINE=1
+export NCCL_TIMEOUT=1800000
+export WORKDIR HF_MODEL_PATH TP EP PP PROMPT MAX_NEW_TOKENS
 
 # ==============================================================================
 # Job Execution
@@ -90,40 +95,35 @@ echo "======================================"
 mkdir -p logs
 
 srun --mpi=pmix \
+  --export=HF_TOKEN,HF_HOME,UV_CACHE_DIR,NCCL_DEBUG,TORCH_NCCL_AVOID_RECORD_STREAMS,NCCL_NVLS_ENABLE,PYTORCH_CUDA_ALLOC_CONF,HF_HUB_OFFLINE,NCCL_TIMEOUT,WORKDIR,HF_MODEL_PATH,TP,EP,PP,PROMPT,MAX_NEW_TOKENS \
   --container-image="$CONTAINER_IMAGE" \
   --container-mounts="${BRIDGE_PATH}:${WORKDIR},${CONTAINER_MOUNTS}" \
+  --container-env=HF_TOKEN,HF_HOME,UV_CACHE_DIR,NCCL_DEBUG,TORCH_NCCL_AVOID_RECORD_STREAMS,NCCL_NVLS_ENABLE,PYTORCH_CUDA_ALLOC_CONF,HF_HUB_OFFLINE,NCCL_TIMEOUT,WORKDIR,HF_MODEL_PATH,TP,EP,PP,PROMPT,MAX_NEW_TOKENS \
   --no-container-mount-home \
-  bash -c "
-    export HF_TOKEN='$HF_TOKEN'
-    export HF_HOME='$HF_HOME'
-    export UV_CACHE_DIR='$UV_CACHE_DIR'
-    export NCCL_DEBUG=WARN
-    export TORCH_NCCL_AVOID_RECORD_STREAMS=1
-    export NCCL_NVLS_ENABLE=0
-    export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
-    export HF_HUB_OFFLINE=1
-    export NCCL_TIMEOUT=1800000
-    MASTER_ADDR=\$(python3 -c \"
+  bash -c '
+    MASTER_ADDR=$(python3 -c "
 import re, os
-s = os.environ.get('SLURM_NODELIST', '')
-m = re.match(r'([\w-]+)\[(\d+)', s)
-print(m.group(1) + m.group(2) if m else s.split(',')[0])
-\")
-    cd $WORKDIR
-    export PYTHONPATH=$WORKDIR/.venv/lib/python3.12/site-packages:\${PYTHONPATH:-}
+s = os.environ.get('"'"'SLURM_NODELIST'"'"', '"'"''"'"')
+m = re.match(r'"'"'([\w-]+)\[(\d+)'"'"', s)
+print(m.group(1) + m.group(2) if m else s.split('"'"','"'"')[0])
+")
+    cd "$WORKDIR"
+    export PYTHONPATH="$WORKDIR/.venv/lib/python3.12/site-packages:${PYTHONPATH:-}"
     uv run --no-sync python -m torch.distributed.run \
       --nproc_per_node=8 \
-      --nnodes=$SLURM_JOB_NUM_NODES \
-      --node_rank=\$SLURM_PROCID \
-      --master_addr=\$MASTER_ADDR \
+      --nnodes="$SLURM_JOB_NUM_NODES" \
+      --node_rank="$SLURM_PROCID" \
+      --master_addr="$MASTER_ADDR" \
       --master_port=29500 \
       examples/conversion/hf_to_megatron_generate_text.py \
-      --hf_model_path $HF_MODEL_PATH \
-      --prompt '$PROMPT' \
-      --max_new_tokens $MAX_NEW_TOKENS \
-      --tp $TP --ep $EP --pp $PP
-  "
+      --hf_model_path "$HF_MODEL_PATH" \
+      --prompt "$PROMPT" \
+      --max_new_tokens "$MAX_NEW_TOKENS" \
+      --tp "$TP" --ep "$EP" --pp "$PP"
+  '
+status=$?
 
 echo "======================================"
-echo "Inference completed (exit $?)"
+echo "Inference completed (exit $status)"
 echo "======================================"
+exit "$status"

--- a/tests/unit_tests/conversion/launcher/test_slurm_examples.py
+++ b/tests/unit_tests/conversion/launcher/test_slurm_examples.py
@@ -135,44 +135,6 @@ def test_slurm_conversion_readmes_use_login_node_wrappers():
         assert not re.search(r"sbatch[^\n]*slurm_conversion\.sh", contents), readme
 
 
-def test_glm5_inference_launcher_keeps_hf_token_out_of_process_arguments(tmp_path):
-    launcher = tmp_path / "srun"
-    launcher.write_text('#!/usr/bin/env bash\nprintf "CALL\\n"\nprintf "ARG=%s\\n" "$@"\nexit 7\n')
-    launcher.chmod(0o755)
-    snapshot = tmp_path / "hf-cache" / "hub" / "models--zai-org--GLM-5" / "snapshots" / "revision"
-    snapshot.mkdir(parents=True)
-    env = os.environ.copy()
-    env.update(
-        {
-            "BRIDGE_PATH": "/shared/Megatron-Bridge",
-            "CONTAINER_IMAGE": "/shared/container.sqsh",
-            "HF_HOME": str(tmp_path / "hf-cache"),
-            "HF_TOKEN": "sensitive-token-value",
-            "PATH": f"{tmp_path}:{env['PATH']}",
-            "SLURM_JOB_ID": "1234",
-            "SLURM_JOB_NUM_NODES": "8",
-        }
-    )
-
-    result = subprocess.run(
-        ["bash", str(REPO_ROOT / "examples/models/glm/glm5/slurm_inference.sh")],
-        capture_output=True,
-        cwd=tmp_path,
-        env=env,
-        text=True,
-    )
-
-    assert result.returncode == 7
-    (arguments,) = _parse_stub_calls(result.stdout)
-    assert "sensitive-token-value" not in result.stdout
-    assert all("sensitive-token-value" not in argument for argument in arguments)
-    assert "--export=ALL" not in arguments
-    assert any(argument.startswith("--export=") and "HF_TOKEN" in argument for argument in arguments)
-    assert any(argument.startswith("--container-env=") and "HF_TOKEN" in argument for argument in arguments)
-    assert "TP=1 PP=2 EP=32 (Total GPUs: 64)" in result.stdout
-    assert "Inference completed (exit 7)" in result.stdout
-
-
 @pytest.mark.parametrize(("relative_script", "expected"), WRAPPER_CASES)
 def test_slurm_conversion_wrapper_forwards_public_launcher_args(tmp_path, relative_script, expected):
     launcher = tmp_path / "convert.sh"

--- a/tests/unit_tests/conversion/launcher/test_slurm_examples.py
+++ b/tests/unit_tests/conversion/launcher/test_slurm_examples.py
@@ -30,7 +30,7 @@ WRAPPER_CASES = [
             "nodes": "8",
             "time": "01:00:00",
             "hf_model": "zai-org/GLM-5",
-            "config": ("2", "1", "32", "1"),
+            "config": ("1", "2", "32", "1"),
             "trust_remote_code": False,
         },
     ),
@@ -133,6 +133,44 @@ def test_slurm_conversion_readmes_use_login_node_wrappers():
         relative_script = script.relative_to(REPO_ROOT)
         assert f"bash {relative_script}" in contents, readme
         assert not re.search(r"sbatch[^\n]*slurm_conversion\.sh", contents), readme
+
+
+def test_glm5_inference_launcher_keeps_hf_token_out_of_process_arguments(tmp_path):
+    launcher = tmp_path / "srun"
+    launcher.write_text('#!/usr/bin/env bash\nprintf "CALL\\n"\nprintf "ARG=%s\\n" "$@"\nexit 7\n')
+    launcher.chmod(0o755)
+    snapshot = tmp_path / "hf-cache" / "hub" / "models--zai-org--GLM-5" / "snapshots" / "revision"
+    snapshot.mkdir(parents=True)
+    env = os.environ.copy()
+    env.update(
+        {
+            "BRIDGE_PATH": "/shared/Megatron-Bridge",
+            "CONTAINER_IMAGE": "/shared/container.sqsh",
+            "HF_HOME": str(tmp_path / "hf-cache"),
+            "HF_TOKEN": "sensitive-token-value",
+            "PATH": f"{tmp_path}:{env['PATH']}",
+            "SLURM_JOB_ID": "1234",
+            "SLURM_JOB_NUM_NODES": "8",
+        }
+    )
+
+    result = subprocess.run(
+        ["bash", str(REPO_ROOT / "examples/models/glm/glm5/slurm_inference.sh")],
+        capture_output=True,
+        cwd=tmp_path,
+        env=env,
+        text=True,
+    )
+
+    assert result.returncode == 7
+    (arguments,) = _parse_stub_calls(result.stdout)
+    assert "sensitive-token-value" not in result.stdout
+    assert all("sensitive-token-value" not in argument for argument in arguments)
+    assert "--export=ALL" not in arguments
+    assert any(argument.startswith("--export=") and "HF_TOKEN" in argument for argument in arguments)
+    assert any(argument.startswith("--container-env=") and "HF_TOKEN" in argument for argument in arguments)
+    assert "TP=1 PP=2 EP=32 (Total GPUs: 64)" in result.stdout
+    assert "Inference completed (exit 7)" in result.stdout
 
 
 @pytest.mark.parametrize(("relative_script", "expected"), WRAPPER_CASES)


### PR DESCRIPTION
# What does this PR do ?

Use a supported 64-GPU topology for GLM-5 conversion and inference by switching the example defaults from TP=2/PP=1/EP=32 to TP=1/PP=2/EP=32.

# Changelog

- Avoid the AbsorbedMLA sequence-parallel requirement by using TP=1.
- Split all 78 transformer layers evenly across two pipeline stages while retaining eight routed experts per GPU.
- Update the GLM-5 README, conversion wrapper, inference launcher, and launcher contract tests.
- Pass runtime variables through explicit Slurm and container allowlists, keep the Hugging Face token out of process arguments, and propagate inference failures from `srun`.

# GitHub Actions CI

- `uv run python -m pytest tests/unit_tests/models/glm_moe_dsa/test_glm5_bridge.py tests/unit_tests/conversion/launcher/test_slurm_examples.py -q` (18 passed)
- `uv run pre-commit run --all-files` (passed)
- Real GLM-5 checkpoint generation on 64 GPUs with TP=1/PP=2/EP=32 (20-token generation completed with coherent output)

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install? No; this PR changes no dependencies or optional imports.
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

# Additional Information

- Fixes an internally reported GLM-5 inference regression after the Megatron-Core update.
