### PR TITLE
test(ckpt): isolate conversion launcher utility imports

### DIFF
--- a/tests/unit_tests/conversion/launcher/test_run_conversion.py
+++ b/tests/unit_tests/conversion/launcher/test_run_conversion.py
@@ -31,9 +31,10 @@ SCRIPT_DIR = REPO_ROOT / "scripts" / "conversion"
 def _load_run_conversion_module():
     cpu_backend = types.ModuleType("cpu_backend")
     gpu_backend = types.ModuleType("gpu_backend")
-    previous_modules = {name: sys.modules.get(name) for name in ("cpu_backend", "gpu_backend", "arguments")}
+    previous_modules = {name: sys.modules.get(name) for name in ("cpu_backend", "gpu_backend", "arguments", "utils")}
     sys.modules["cpu_backend"] = cpu_backend
     sys.modules["gpu_backend"] = gpu_backend
+    sys.modules.pop("utils", None)
     sys.path.insert(0, str(SCRIPT_DIR))
     try:
         spec = importlib.util.spec_from_file_location(
@@ -50,6 +51,15 @@ def _load_run_conversion_module():
             else:
                 sys.modules[name] = previous
     return module, cpu_backend, gpu_backend
+
+
+def test_loader_restores_preexisting_utils_module(monkeypatch):
+    preexisting_utils = types.ModuleType("utils")
+    monkeypatch.setitem(sys.modules, "utils", preexisting_utils)
+
+    _load_run_conversion_module()
+
+    assert sys.modules["utils"] is preexisting_utils
 
 
 def test_cpu_import_dispatches_to_cpu_backend():


### PR DESCRIPTION
# What does this PR do ?

Fix the main-branch core unit-test failure caused by the conversion launcher test leaking its top-level `utils` module into the shared pytest process.

# Changelog

- Save and remove any pre-existing `utils` module before dynamically loading `scripts/conversion/run_conversion.py`.
- Restore the exact previous module state after the dynamic import completes.
- Add a regression test proving a pre-existing same-name module is preserved.

# Root Cause

PR #4909 added `from utils import resolve_hf_commit_revision, resolve_hf_model_revision` to `scripts/conversion/run_conversion.py`. The unit-test loader prepends `scripts/conversion` to `sys.path`, so that import caches `scripts/conversion/utils.py` as the top-level module `utils`. The loader restored its other temporary modules but not `utils`. Later, `test_override_precedence.py` imported `utils.utils` and `utils.overrides` from `scripts/performance`; Python reused the leaked plain module and raised `ModuleNotFoundError: 'utils' is not a package` for 15 tests.

Failing main run: https://github.com/NVIDIA-NeMo/Megatron-Bridge/actions/runs/29876906382/job/88790258314

# GitHub Actions CI

Focused validation:

- `test_run_conversion.py`: 9 passed in a lightweight isolated environment.
- `uvx pre-commit run --all-files`: all hooks passed.
- Ruff lint, Ruff format check, and `git diff --check`: passed.

`uv run pre-commit run --all-files` cannot resolve the complete project environment on macOS ARM because `nvidia-resiliency-ext==0.6.0` only publishes Linux wheels; the same repository hooks were therefore run with `uvx pre-commit`.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] Added a focused regression test.
- [x] Documentation is not required for this test-isolation fix.
- [x] Optional-install components are unaffected.

# Additional Information

- Regression introduced by #4909.