### PR TITLE
fix(misc): restore five-shot MMLU evaluation

### DIFF
--- a/examples/evaluation/eval.sh
+++ b/examples/evaluation/eval.sh
@@ -1,97 +1,32 @@
-# Unset SLURM/PMI/PMIX env vars to prevent MPI initialization issues
-for i in $(env | grep ^SLURM_ | cut -d"=" -f 1); do unset -v $i; done
-for i in $(env | grep ^PMI_ | cut -d"=" -f 1); do unset -v $i; done
-for i in $(env | grep ^PMIX_ | cut -d"=" -f 1); do unset -v $i; done
+#!/usr/bin/env bash
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-OUTPUT_DIR=$1
-PARALLELISM=$2
+set -euo pipefail
 
-# Install missing dependency for lm-evaluation-harness
-uv pip install math_verify --quiet
+# Unset scheduler variables before starting local evaluation processes. Leaving
+# these set can make MPI-aware dependencies try to join the parent allocation.
+for prefix in SLURM_ PMI_ PMIX_; do
+    while IFS= read -r variable_name; do
+        unset -v "${variable_name}"
+    done < <(compgen -A variable "${prefix}" || true)
+done
 
-cat << EVAL_EOF > _temp_eval_script.py
-import subprocess
-import time
+cleanup() {
+    ray stop --force >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
 
-from nemo_evaluator.api.api_dataclasses import (
-    ApiEndpoint,
-    ConfigParams,
-    EvaluationConfig,
-    EvaluationTarget,
-)
-from nemo_evaluator.api import check_endpoint, evaluate
-
-# Configuration
-endpoint_url = "http://0.0.0.0:8000/v1/completions/"
-endpoint_type = "completions"
-model_id = "megatron_model"
-eval_task = "mmlu"
-limit_samples = 100
-parallelism = $PARALLELISM
-request_timeout = 1000
-temperature = None
-top_p = None
-top_k = None
-# Use local filesystem to avoid NFS SQLite lock contention on GCP (NFSv3).
-# lm-eval's --use_cache writes a SQLite WAL that requires POSIX locks which
-# are extremely slow over NFS, causing minutes-long stalls between batches.
-pvc_output_dir = "/$OUTPUT_DIR/results/"
-output_dir = "/tmp/eval_results/"
-
-# Check server readiness
-server_ready = check_endpoint(
-    endpoint_url=endpoint_url,
-    endpoint_type=endpoint_type,
-    model_name=model_id,
-)
-if not server_ready:
-    raise RuntimeError(
-        "Server is not ready to accept requests. Check the deployment logs for errors."
-    )
-
-# Build configs
-api_endpoint = ApiEndpoint(
-    url=endpoint_url,
-    type=endpoint_type,
-    model_id=model_id,
-)
-target_cfg = EvaluationTarget(api_endpoint=api_endpoint)
-eval_params = ConfigParams(
-    limit_samples=limit_samples,
-    parallelism=parallelism,
-    request_timeout=request_timeout,
-    temperature=temperature,
-    top_p=top_p,
-)
-eval_cfg = EvaluationConfig(
-    type=eval_task,
-    params=eval_params,
-    output_dir=output_dir,
-)
-
-if __name__ == "__main__":
-    # Run evaluation
-    result = evaluate(target_cfg=target_cfg, eval_cfg=eval_cfg)
-
-    # Copy results from local tmp to PVC output dir (lm_cache stays in /tmp)
-    import os, shutil
-    os.makedirs(pvc_output_dir, exist_ok=True)
-    for item in os.listdir(output_dir):
-        if item == "lm_cache_rank0.db":
-            continue  # skip large SQLite cache
-        src = os.path.join(output_dir, item)
-        dst = os.path.join(pvc_output_dir, item)
-        if os.path.isdir(src):
-            shutil.copytree(src, dst, dirs_exist_ok=True)
-        else:
-            shutil.copy2(src, dst)
-    print(f"Results copied to {pvc_output_dir}")
-
-    # Shutdown Ray server
-    print("Evaluation completed. Shutting down Ray server...")
-    subprocess.run(["ray", "stop", "--force"], check=False, timeout=30)
-    print("Ray server shutdown command sent.")
-    time.sleep(5)
-EVAL_EOF
-
-uv run --active --no-sync python _temp_eval_script.py
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+uv run --active --no-sync python "${script_dir}/run_lm_eval.py" "$@"

--- a/examples/evaluation/launch_evaluation_pipeline.py
+++ b/examples/evaluation/launch_evaluation_pipeline.py
@@ -21,12 +21,14 @@ Parse arguments early to catch unknown args before other libraries
 
 import logging
 import os
+import shlex
 import signal
 import sys
 import time
+import uuid
 from dataclasses import dataclass
+from pathlib import Path
 
-import yaml
 from nemo_run.core.execution.slurm import SlurmJobDetails
 from nemo_run.run.ray.job import RayJob
 
@@ -41,9 +43,11 @@ except (ImportError, ModuleNotFoundError):
 
 try:
     from argument_parser import parse_cli_args
+    from run_lm_eval import iter_evaluation_metrics, load_evaluation_results
     from utils.executors import kuberay_executor, slurm_executor
 except (ImportError, ModuleNotFoundError):
     from .argument_parser import parse_cli_args
+    from .run_lm_eval import iter_evaluation_metrics, load_evaluation_results
     from .utils.executors import kuberay_executor, slurm_executor
 
 logging.basicConfig(level=logging.DEBUG)
@@ -110,17 +114,33 @@ def main(args):
         name="demo-slurm-ray-deploy",
         executor=executor,
     )
+    evaluation_run_id = uuid.uuid4().hex
+    deploy_command = shlex.join(
+        [
+            "bash",
+            "/opt/Megatron-Bridge/examples/evaluation/deploy.sh",
+            args.megatron_checkpoint,
+            str(args.num_replicas),
+            str(args.num_gpus),
+        ]
+    )
+    eval_command = shlex.join(
+        [
+            "bash",
+            "/opt/Megatron-Bridge/examples/evaluation/eval.sh",
+            args.output_dir,
+            str(args.parallelism),
+            "--run-id",
+            evaluation_run_id,
+        ]
+    )
+    shell_script = f"""set -euo pipefail
+{deploy_command} 2>&1 | tee -a deploy.log &
+sleep 120
+{eval_command} 2>&1 | tee -a eval.log
+"""
     job.start(
-        command=f"""
-        bash /opt/Megatron-Bridge/examples/evaluation/deploy.sh \
-            {args.megatron_checkpoint} \
-            {args.num_replicas} \
-            {args.num_gpus}| tee -a deploy.log & \
-        sleep 120; \
-        bash /opt/Megatron-Bridge/examples/evaluation/eval.sh \
-            {args.output_dir} \
-            {args.parallelism} | tee -a eval.log
-        """,
+        command=shlex.join(["bash", "-c", shell_script]),
         workdir=None,
     )
 
@@ -139,9 +159,9 @@ def main(args):
     job.logs(follow=True, timeout=10 * 60 * 60)
     job.stop()
 
-    with open(os.path.join(args.output_dir, "results", "results.yml"), "r") as f:
-        results = yaml.safe_load(f)
+    results_path, results = load_evaluation_results(Path(args.output_dir), evaluation_run_id)
 
+    logger.info("Results file: %s", results_path)
     logger.info("Results: %s", results)
 
     if HAVE_WANDB and args.wandb_key:
@@ -152,9 +172,10 @@ def main(args):
             filters={"display_name": args.wandb_experiment_name},
         )
 
+        run_id = None
         if runs:
             run_id = runs[0].id
-            print(f"Found run with ID: {run_id}")
+            logger.info("Found run with ID: %s", run_id)
 
         wandb_run = wandb.init(
             project=args.wandb_project_name,
@@ -164,21 +185,18 @@ def main(args):
         )
         artifact = wandb.Artifact(name="evaluation_results", type="evaluation_results")
         artifact.add_file(
-            local_path=os.path.join(args.output_dir, "results", "results.yml"),
-            name="results.yml",
+            local_path=str(results_path),
+            name=results_path.name,
         )
         wandb_run.log_artifact(artifact)
 
-        for category in ["tasks", "groups"]:
-            for task_or_group_name, result in results["results"][category].items():
-                for metric_name, metric_result in result["metrics"].items():
-                    field_key = f"{category.rstrip('s')}/{task_or_group_name}/{metric_name}"
-                    wandb_run.log(
-                        {
-                            f"{field_key}/value": metric_result["scores"][metric_name]["value"],
-                            f"{field_key}/stderr": metric_result["scores"][metric_name]["stats"]["stderr"],
-                        }
-                    )
+        category_names = {"results": "task", "groups": "group"}
+        for category, entry_name, metric_name, value, stderr in iter_evaluation_metrics(results):
+            field_key = f"{category_names[category]}/{entry_name}/{metric_name}"
+            metrics = {f"{field_key}/value": value}
+            if stderr is not None:
+                metrics[f"{field_key}/stderr"] = stderr
+            wandb_run.log(metrics)
 
         wandb_run.finish()
 

--- a/examples/evaluation/run_lm_eval.py
+++ b/examples/evaluation/run_lm_eval.py
@@ -1,0 +1,265 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Run the legacy five-shot MMLU evaluation against a deployed endpoint."""
+
+from __future__ import annotations
+
+import argparse
+import http.client
+import json
+import logging
+import re
+import shutil
+import subprocess
+import tempfile
+import time
+import uuid
+from collections.abc import Iterator, Sequence
+from http import HTTPStatus
+from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit
+
+
+logger = logging.getLogger(__name__)
+
+_ENDPOINT_URL = "http://0.0.0.0:8000/v1/completions/"
+_MODEL_ID = "megatron_model"
+_MMLU_TASK = "mmlu_str"
+_NUM_FEWSHOT = 5
+_LIMIT_SAMPLES = 100.0
+_REQUEST_TIMEOUT = 1000
+_TEMPERATURE = 1e-7
+_TOP_P = 0.9999999
+_MAX_RETRIES = 5
+_READINESS_MAX_ATTEMPTS = 600
+_READINESS_RETRY_INTERVAL = 2.0
+_READINESS_REQUEST_TIMEOUT = float(_REQUEST_TIMEOUT)
+_RUN_ID_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.-]*")
+
+EvaluationMetric = tuple[str, str, str, float, float | None]
+
+
+def _parse_run_id(value: str) -> str:
+    if value in {".", ".."} or _RUN_ID_PATTERN.fullmatch(value) is None:
+        raise argparse.ArgumentTypeError(
+            "run-id must contain only letters, numbers, periods, underscores, and hyphens"
+        )
+    return value
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse evaluation arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("output_dir", type=Path, help="Directory in which to store evaluation results")
+    parser.add_argument("parallelism", type=int, help="Number of concurrent requests sent to the endpoint")
+    parser.add_argument(
+        "--run-id",
+        type=_parse_run_id,
+        default=uuid.uuid4().hex,
+        help="Unique identifier used to isolate this run's results",
+    )
+    parser.add_argument("--endpoint-url", default=_ENDPOINT_URL, help="Full OpenAI-compatible completions URL")
+    parser.add_argument("--eval-task", default=_MMLU_TASK, help="lm-eval task or task group")
+    parser.add_argument(
+        "--limit-samples",
+        type=float,
+        default=_LIMIT_SAMPLES,
+        help="Maximum samples per task; values below one select a fraction",
+    )
+    args = parser.parse_args(argv)
+    if args.parallelism < 1:
+        parser.error("parallelism must be at least 1")
+    if args.limit_samples <= 0:
+        parser.error("limit-samples must be positive")
+    return args
+
+
+def wait_for_endpoint(
+    endpoint_url: str,
+    *,
+    model_id: str = _MODEL_ID,
+    max_attempts: int = _READINESS_MAX_ATTEMPTS,
+    retry_interval: float = _READINESS_RETRY_INTERVAL,
+    request_timeout: float = _READINESS_REQUEST_TIMEOUT,
+) -> None:
+    """Wait until an OpenAI-compatible completions endpoint accepts a request."""
+    if max_attempts < 1:
+        raise ValueError("max_attempts must be at least 1")
+    if retry_interval < 0:
+        raise ValueError("retry_interval must be non-negative")
+    if request_timeout <= 0:
+        raise ValueError("request_timeout must be positive")
+
+    parsed_url = urlsplit(endpoint_url)
+    if parsed_url.scheme not in {"http", "https"} or parsed_url.hostname is None:
+        raise ValueError(f"Unsupported endpoint URL: {endpoint_url}")
+    connection_type = http.client.HTTPSConnection if parsed_url.scheme == "https" else http.client.HTTPConnection
+    request_target = urlunsplit(("", "", parsed_url.path or "/", parsed_url.query, ""))
+    request_body = json.dumps({"model": model_id, "max_tokens": 1, "prompt": "hello, my name is"})
+    request_headers = {"Accept": "application/json", "Content-Type": "application/json"}
+
+    for attempt in range(1, max_attempts + 1):
+        connection = connection_type(parsed_url.hostname, parsed_url.port, timeout=request_timeout)
+        try:
+            connection.request("POST", request_target, body=request_body, headers=request_headers)
+            response = connection.getresponse()
+            response.read()
+            if response.status == HTTPStatus.OK:
+                logger.info("Endpoint is ready after %d attempt(s)", attempt)
+                return
+            logger.info("Endpoint readiness attempt %d/%d returned HTTP %d", attempt, max_attempts, response.status)
+        except (OSError, http.client.HTTPException) as error:
+            logger.info("Endpoint readiness attempt %d/%d failed: %s", attempt, max_attempts, error)
+        finally:
+            connection.close()
+
+        if attempt < max_attempts:
+            time.sleep(retry_interval)
+
+    raise RuntimeError(f"Endpoint did not become ready after {max_attempts} attempts: {endpoint_url}")
+
+
+def build_lm_eval_command(
+    *,
+    parallelism: int,
+    output_dir: Path,
+    endpoint_url: str = _ENDPOINT_URL,
+    eval_task: str = _MMLU_TASK,
+    limit_samples: float = _LIMIT_SAMPLES,
+) -> list[str]:
+    """Build the command matching the legacy NeMo Evaluator MMLU configuration."""
+    model_args = ",".join(
+        [
+            f"base_url={endpoint_url}",
+            f"model={_MODEL_ID}",
+            "tokenized_requests=False",
+            "tokenizer_backend=None",
+            f"num_concurrent={parallelism}",
+            f"timeout={_REQUEST_TIMEOUT}",
+            f"max_retries={_MAX_RETRIES}",
+            "stream=False",
+        ]
+    )
+    return [
+        "lm-eval",
+        "--tasks",
+        eval_task,
+        "--num_fewshot",
+        str(_NUM_FEWSHOT),
+        "--model",
+        "local-completions",
+        "--model_args",
+        model_args,
+        "--log_samples",
+        "--output_path",
+        str(output_dir),
+        "--use_cache",
+        str(output_dir / "lm_cache"),
+        "--limit",
+        str(int(limit_samples) if limit_samples.is_integer() else limit_samples),
+        "--trust_remote_code",
+        f"--gen_kwargs=temperature={_TEMPERATURE},top_p={_TOP_P}",
+    ]
+
+
+def copy_evaluation_results(source_dir: Path, destination_dir: Path) -> None:
+    """Copy evaluation artifacts while leaving the local SQLite cache behind."""
+    destination_dir.mkdir(parents=True, exist_ok=True)
+    for source in source_dir.iterdir():
+        if source.name.startswith("lm_cache"):
+            continue
+        destination = destination_dir / source.name
+        if source.is_dir():
+            shutil.copytree(source, destination, dirs_exist_ok=True)
+        else:
+            shutil.copy2(source, destination)
+
+
+def find_latest_results_file(output_dir: Path, run_id: str) -> Path:
+    """Find the lm-eval aggregate results file for one isolated run."""
+    run_results_dir = output_dir / "results" / _parse_run_id(run_id)
+    candidates = list(run_results_dir.rglob("results_*.json"))
+    if not candidates:
+        raise FileNotFoundError(f"No lm-eval results file found under {run_results_dir}")
+    return max(candidates, key=lambda path: (path.stat().st_mtime_ns, str(path)))
+
+
+def load_evaluation_results(output_dir: Path, run_id: str) -> tuple[Path, dict[str, object]]:
+    """Load the aggregate results for one isolated evaluation run."""
+    results_path = find_latest_results_file(output_dir, run_id)
+    with results_path.open(encoding="utf-8") as results_file:
+        results = json.load(results_file)
+    if not isinstance(results, dict):
+        raise ValueError(f"Expected an object in {results_path}")
+    return results_path, results
+
+
+def iter_evaluation_metrics(results: dict[str, object]) -> Iterator[EvaluationMetric]:
+    """Yield numeric task and group metrics from an lm-eval result object."""
+    groups = results.get("groups")
+    group_names = set(groups) if isinstance(groups, dict) else set()
+    for category in ("results", "groups"):
+        entries = results.get(category)
+        if not isinstance(entries, dict):
+            continue
+        for entry_name, entry in entries.items():
+            if not isinstance(entry_name, str) or not isinstance(entry, dict):
+                continue
+            if category == "results" and entry_name in group_names:
+                continue
+            for metric_key, value in entry.items():
+                if not isinstance(metric_key, str) or isinstance(value, bool) or not isinstance(value, (int, float)):
+                    continue
+                metric_name, separator, filter_name = metric_key.partition(",")
+                if metric_name.endswith("_stderr"):
+                    continue
+                stderr_key = f"{metric_name}_stderr,{filter_name}" if separator else f"{metric_name}_stderr"
+                stderr_value = entry.get(stderr_key)
+                stderr = (
+                    float(stderr_value)
+                    if isinstance(stderr_value, (int, float)) and not isinstance(stderr_value, bool)
+                    else None
+                )
+                reported_metric_name = (
+                    f"{metric_name}__{filter_name}" if separator and filter_name != "none" else metric_name
+                )
+                yield category, entry_name, reported_metric_name, float(value), stderr
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    """Run five-shot MMLU and persist all non-cache artifacts."""
+    args = parse_args(argv)
+    results_dir = args.output_dir / "results" / args.run_id
+    if results_dir.exists():
+        raise FileExistsError(f"Refusing to mix evaluation artifacts into existing run directory: {results_dir}")
+    wait_for_endpoint(args.endpoint_url)
+    with tempfile.TemporaryDirectory(prefix="megatron-bridge-eval-") as temporary_dir:
+        local_output_dir = Path(temporary_dir)
+        command = build_lm_eval_command(
+            parallelism=args.parallelism,
+            output_dir=local_output_dir,
+            endpoint_url=args.endpoint_url,
+            eval_task=args.eval_task,
+            limit_samples=args.limit_samples,
+        )
+        logger.info("Running five-shot lm-eval task %s against %s", args.eval_task, args.endpoint_url)
+        subprocess.run(command, check=True)
+        copy_evaluation_results(local_output_dir, results_dir)
+    logger.info("Results for run %s copied to %s", args.run_id, results_dir)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    main()

--- a/tests/unit_tests/evaluation/test_run_lm_eval.py
+++ b/tests/unit_tests/evaluation/test_run_lm_eval.py
@@ -1,0 +1,133 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+
+
+_MODULE_PATH = Path(__file__).parents[3] / "examples" / "evaluation" / "run_lm_eval.py"
+_SPEC = importlib.util.spec_from_file_location("run_lm_eval", _MODULE_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+run_lm_eval = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(run_lm_eval)
+
+
+@pytest.mark.unit
+def test_build_lm_eval_command_preserves_legacy_mmlu_configuration(tmp_path: Path) -> None:
+    command = run_lm_eval.build_lm_eval_command(parallelism=4, output_dir=tmp_path)
+
+    assert command[command.index("--tasks") + 1] == "mmlu_str"
+    assert command[command.index("--num_fewshot") + 1] == "5"
+    assert command[command.index("--limit") + 1] == "100"
+    assert command[command.index("--model") + 1] == "local-completions"
+    model_args = command[command.index("--model_args") + 1]
+    assert "base_url=http://0.0.0.0:8000/v1/completions/" in model_args
+    assert "model=megatron_model" in model_args
+    assert "num_concurrent=4" in model_args
+    assert "timeout=1000" in model_args
+    assert "--gen_kwargs=temperature=1e-07,top_p=0.9999999" in command
+
+
+@pytest.mark.unit
+def test_copy_evaluation_results_excludes_lm_cache(tmp_path: Path) -> None:
+    source_dir = tmp_path / "source"
+    destination_dir = tmp_path / "destination"
+    model_dir = source_dir / "megatron_model"
+    model_dir.mkdir(parents=True)
+    (model_dir / "results_2026-01-01.json").write_text("{}", encoding="utf-8")
+    (source_dir / "lm_cache_rank0.db").write_text("cache", encoding="utf-8")
+
+    run_lm_eval.copy_evaluation_results(source_dir, destination_dir)
+
+    assert (destination_dir / "megatron_model" / "results_2026-01-01.json").is_file()
+    assert not (destination_dir / "lm_cache_rank0.db").exists()
+
+
+@pytest.mark.unit
+def test_wait_for_endpoint_retries_until_server_is_ready() -> None:
+    assert run_lm_eval._READINESS_REQUEST_TIMEOUT == run_lm_eval._REQUEST_TIMEOUT
+
+    class DelayedReadinessHandler(BaseHTTPRequestHandler):
+        attempts = 0
+
+        def do_POST(self) -> None:  # noqa: N802
+            type(self).attempts += 1
+            content_length = int(self.headers["Content-Length"])
+            payload = json.loads(self.rfile.read(content_length))
+            assert payload == {"model": "megatron_model", "max_tokens": 1, "prompt": "hello, my name is"}
+            status = 200 if type(self).attempts >= 3 else 503
+            self.send_response(status)
+            self.end_headers()
+
+        def log_message(self, _format: str, *args: object) -> None:
+            del args
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), DelayedReadinessHandler)
+    server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+    server_thread.start()
+    try:
+        run_lm_eval.wait_for_endpoint(
+            f"http://127.0.0.1:{server.server_port}/v1/completions/",
+            max_attempts=5,
+            retry_interval=0.01,
+            request_timeout=1,
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+        server_thread.join()
+
+    assert DelayedReadinessHandler.attempts == 3
+
+
+@pytest.mark.unit
+def test_load_evaluation_results_is_scoped_to_run_id(tmp_path: Path) -> None:
+    current_results_dir = tmp_path / "results" / "current-run" / "megatron_model"
+    stale_results_dir = tmp_path / "results" / "stale-run" / "megatron_model"
+    current_results_dir.mkdir(parents=True)
+    stale_results_dir.mkdir(parents=True)
+    current = current_results_dir / "results_current.json"
+    stale = stale_results_dir / "results_stale.json"
+    current.write_text(json.dumps({"marker": "current"}), encoding="utf-8")
+    stale.write_text(json.dumps({"marker": "stale"}), encoding="utf-8")
+
+    results_path, results = run_lm_eval.load_evaluation_results(tmp_path, "current-run")
+
+    assert results_path == current
+    assert results == {"marker": "current"}
+
+
+@pytest.mark.unit
+def test_iter_evaluation_metrics_reads_task_and_group_scores() -> None:
+    results = {
+        "results": {
+            "mmlu_str": {"exact_match,none": 0.8, "exact_match_stderr,none": 0.02},
+            "mmlu_str_abstract_algebra": {
+                "alias": "abstract algebra",
+                "exact_match,strict-match": 0.75,
+                "exact_match_stderr,strict-match": 0.1,
+            },
+        },
+        "groups": {"mmlu_str": {"exact_match,none": 0.8, "exact_match_stderr,none": "N/A"}},
+    }
+
+    assert list(run_lm_eval.iter_evaluation_metrics(results)) == [
+        ("results", "mmlu_str_abstract_algebra", "exact_match__strict-match", 0.75, 0.1),
+        ("groups", "mmlu_str", "exact_match", 0.8, None),
+    ]


### PR DESCRIPTION
# What does this PR do ?

Restores the Megatron endpoint evaluation example after the NeMo Evaluator Python API removal while preserving its historical five-shot MMLU behavior.

# Changelog

- Run the shipped lm-evaluation-harness directly with the legacy MMLU task, five-shot prompts, request settings, and per-task sample limit.
- Poll the completions endpoint through model startup and isolate each run's result artifacts.
- Propagate deployment/evaluation pipeline failures and load only the current run's JSON results.
- Preserve task/group metric normalization for Weights & Biases.
- Add focused unit coverage for command compatibility, delayed readiness, result isolation, cache exclusion, and metric normalization.

# GitHub Actions CI

Local verification completed:

- Five focused unit tests pass in the 26.08 RC environment.
- Full pre-commit passes.
- A deployed Megatron checkpoint completed a five-shot MMLU request through the real completions endpoint.
- The complete 57-subject MMLU group retained five-shot configuration, and the same fixed path passed a controlled 26.06 comparison.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed Contributor guidelines.
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation? No documentation change is needed; the example behavior is restored in place.
- [x] Does the PR affect components that are optional to install? No new dependency or optional import is added.

# Additional Information

Fixes NVBug 6462837.

Root cause: the NeMo Evaluator upgrade removed the legacy `nemo_evaluator.api` package used by `eval.sh`, while the underlying lm-evaluation-harness remained available. This change invokes that harness directly instead of recreating the removed API and keeps the prior five-shot logic.

This PR intentionally targets `main` without a release label because the mapped `r0.6.0` label does not yet exist.

AI-assisted development: this change was developed with Codex and independently reviewed by a separate agent.
