### PR TITLE
fix(flops): use parquet packed dataset for LoRA SQuAD FLOP accounting

### DIFF
--- a/src/megatron/bridge/data/datasets/packing_utils.py
+++ b/src/megatron/bridge/data/datasets/packing_utils.py
@@ -351,8 +351,18 @@ def calculate_avg_seqlen(
     Raises:
         ValueError: If no rows remain after applying drop_remainder, or if no sequences are found.
     """
-    with open(dataset_file, "rb") as f:
-        data = safe_load_npy(f.read())
+    if str(dataset_file).lower().endswith((".parquet", ".pq")):
+        import pyarrow.parquet as pq
+
+        table = pq.read_table(dataset_file, columns=["input_ids", "seq_start_id"])
+        ids, starts = table.column("input_ids"), table.column("seq_start_id")
+        data = [
+            {"input_ids": ids[i].as_py(), "seq_start_id": starts[i].as_py()}
+            for i in range(table.num_rows)
+        ]
+    else:
+        with open(dataset_file, "rb") as f:
+            data = safe_load_npy(f.read())
 
     total_len_accum = 0
     seqlen_sq_accum = 0

--- a/src/megatron/bridge/training/utils/flop_utils.py
+++ b/src/megatron/bridge/training/utils/flop_utils.py
@@ -24,6 +24,25 @@ from megatron.bridge.utils.vocab_utils import calculate_padded_vocab_size
 _lora_seq_stats_cache: dict = {}
 
 
+def _packed_data_exists(path: str | None) -> bool:
+    """Return True if a packed dataset file exists, for both parquet and npy formats.
+
+    Parquet specs may be a single file, a glob, or a directory, so they are validated
+    via the packed-parquet resolver rather than a bare ``Path.exists()`` check (which
+    would fail for globs/directories and silently disable LoRA-aware FLOP accounting).
+    """
+    if not path:
+        return False
+    if str(path).lower().endswith((".parquet", ".pq")):
+        try:
+            from megatron.bridge.data.datasets.packed_parquet import resolve_packed_parquet_paths
+
+            return len(resolve_packed_parquet_paths(path)) > 0
+        except Exception:
+            return False
+    return Path(path).exists()
+
+
 def vit_flops(
     cfg: ConfigContainer,
     batch_size: int,
@@ -366,10 +385,13 @@ def num_floating_point_operations(
             dataset_root = getattr(cfg.dataset, "dataset_root", None)
             seq_size = getattr(packed_specs, "packed_sequence_size", None)
             if dataset_root is not None and seq_size is not None:
-                matches = sorted(Path(dataset_root).glob(f"packed/*/training_{seq_size}.npy"))
+                # Prefer the current parquet format; fall back to the deprecated .npy.
+                matches = sorted(Path(dataset_root).glob(f"packed/*/training_{seq_size}.idx.parquet"))
+                if not matches:
+                    matches = sorted(Path(dataset_root).glob(f"packed/*/training_{seq_size}.npy"))
                 if matches:
                     packed_data_path = str(matches[0])
-        if is_lora and is_squad and is_llama3_70b and packed_data_path is not None and Path(packed_data_path).exists():
+        if is_lora and is_squad and is_llama3_70b and _packed_data_exists(packed_data_path):
             gbs = cfg.train.global_batch_size
             seq_len = cfg.model.seq_length
             cache_key = (packed_data_path, gbs, seq_len)


### PR DESCRIPTION
## Summary
Backport to `r0.5.0`. The LoRA-aware FLOP branch in `flop_utils.py` only detected
the deprecated `.npy` packed dataset. Offline packing now emits `.parquet`, so the
detection silently failed and the code fell through to full-model **6ND** FLOP
accounting instead of the LoRA-aware (~4ND) path. This over-counted TFLOPS/GPU for
LoRA Llama-3-70B SQuAD runs (~1770 reported vs the true ~1150), while environments
still shipping a pre-staged `.npy` dataset reported correctly — producing a
confusing, environment-dependent discrepancy for the same config.

## Changes
- **`training/utils/flop_utils.py`**
  - Glob prefers the current `training_{seq}.idx.parquet`, falling back to the
    deprecated `training_{seq}.npy`.
  - New `_packed_data_exists()` helper validates parquet specs (single file, glob,
    or directory) via `resolve_packed_parquet_paths` (imported from
    `data/datasets/packed_parquet`) instead of a bare `Path.exists()`.
- **`data/datasets/packing_utils.py`**
  - `calculate_avg_seqlen()` gains a format-aware loader: reads parquet via
    `pyarrow` (columns `input_ids`, `seq_start_id`); `.npy` still uses
    `safe_load_npy`.

## Test plan
- [ ] LoRA Llama-3-70B SQuAD run reports parquet-based (~4ND) TFLOPS/GPU
- [ ] Legacy `.npy` datasets still load and produce identical stats
- [ ] Non-LoRA / non-SQuAD paths are unaffected