### PR TITLE
[data] fix: Handle Qwen3-Next custom chat data

### DIFF
--- a/examples/models/qwen/qwen3_next/finetune_qwen3_next_80b_a3b.py
+++ b/examples/models/qwen/qwen3_next/finetune_qwen3_next_80b_a3b.py
@@ -49,7 +49,7 @@ from typing import Tuple
 
 from omegaconf import OmegaConf
 
-from megatron.bridge.data.builders import GPTSFTDatasetConfig, HFDatasetSourceConfig
+from megatron.bridge.data.builders import ChatSFTPreprocessingConfig, GPTSFTDatasetConfig, HFDatasetSourceConfig
 from megatron.bridge.recipes.qwen.qwen3_next import qwen3_next_80b_a3b_sft_config
 from megatron.bridge.training.config import ConfigContainer
 from megatron.bridge.training.pretrain import pretrain
@@ -78,6 +78,7 @@ def _replace_with_custom_data_path(config: ConfigContainer, data_path: str) -> N
         ),
         hf_validation_dataset=None,
         hf_test_dataset=None,
+        preprocessing=ChatSFTPreprocessingConfig(),
     )
 
 

--- a/tests/unit_tests/examples/test_qwen3_next_finetune.py
+++ b/tests/unit_tests/examples/test_qwen3_next_finetune.py
@@ -1,13 +1,19 @@
 # Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
 
 import importlib.util
+import json
 import pathlib
 import sys
 from types import SimpleNamespace
 
 import pytest
 
-from megatron.bridge.data.builders import GPTSFTDatasetConfig, HFDatasetSourceConfig
+import megatron.bridge.data.builders.gpt_sft as gpt_sft_builder
+from megatron.bridge.data.builders import (
+    GPTSFTDatasetConfig,
+    HFDatasetSourceConfig,
+    PromptCompletionSFTPreprocessingConfig,
+)
 
 
 pytestmark = pytest.mark.unit
@@ -45,5 +51,47 @@ def test_data_path_replaces_named_source_with_custom_json_source():
         assert config.dataset.hf_dataset.load_kwargs == {"data_files": "/data/custom.jsonl"}
         assert config.dataset.dataset_kwargs is None
         assert config.dataset.hf_validation_proportion == 0.1
+    finally:
+        sys.modules.pop(name, None)
+
+
+def test_data_path_materializes_advertised_messages_schema(monkeypatch, tmp_path):
+    name = "qwen3_next_finetune_messages_data"
+    try:
+        module = _load_example_module(name)
+        config = SimpleNamespace(
+            dataset=GPTSFTDatasetConfig(
+                seq_length=2048,
+                hf_dataset=HFDatasetSourceConfig(dataset_name="squad"),
+                hf_validation_proportion=0.1,
+                do_test=False,
+                preprocessing=PromptCompletionSFTPreprocessingConfig(
+                    prompt_column="input",
+                    completion_column="output",
+                    separator=" ",
+                ),
+            )
+        )
+        messages_rows = [
+            {
+                "id": index,
+                "messages": [
+                    {"role": "user", "content": f"Question {index}"},
+                    {"role": "assistant", "content": f"Answer {index}"},
+                ],
+            }
+            for index in range(10)
+        ]
+        monkeypatch.setattr(gpt_sft_builder, "load_and_adapt_hf_dataset", lambda _: messages_rows)
+
+        module._replace_with_custom_data_path(config, "/data/custom.jsonl")
+        gpt_sft_builder.materialize_hf_dataset(config.dataset, tmp_path)
+
+        materialized_rows = []
+        for split in ("training", "validation"):
+            with (tmp_path / f"{split}.jsonl").open(encoding="utf-8") as input_file:
+                materialized_rows.extend(json.loads(line) for line in input_file)
+        assert len(materialized_rows) == len(messages_rows)
+        assert all("conversation" in row and "messages" not in row for row in materialized_rows)
     finally:
         sys.modules.pop(name, None)


### PR DESCRIPTION
## Problem

The Qwen3-Next finetuning launcher advertises structured `conversation` and `messages` JSONL for `--data-path`. The shipped SFT recipe starts from SQuAD and explicitly configures prompt/completion preprocessing. Replacing only the data source preserved that incompatible preprocessing, so the advertised custom schema failed during data materialization before training.

## Fix

Select `ChatSFTPreprocessingConfig` when the launcher replaces the recipe source with a custom JSON/JSONL path. This keeps the default named SQuAD recipe unchanged and applies the schema contract only at the custom-path boundary.

The regression test uses the inherited SQuAD preprocessing state, supplies representative `messages` rows, runs real normalization/splitting/materialization, and verifies canonical `conversation` output.

## Validation

Fail-before on unmodified `main`:

- `uv run --active --no-sync python -m pytest -q --confcutdir=tests/unit_tests/examples tests/unit_tests/examples/test_qwen3_next_finetune.py`
- Result: 1 passed, 1 failed with `Prompt-completion preprocessing requires paired text columns; structured conversations require ChatSFTPreprocessingConfig.`

Pass-after:

- Same command: 2 passed.
- `uv run --active --no-sync python -m pytest -q --confcutdir=tests/unit_tests/data tests/unit_tests/data/test_sft_processing.py tests/unit_tests/data/sources/test_hf.py tests/unit_tests/data/builders/test_gpt_sft_config.py tests/unit_tests/data/builders/test_direct_hf_sft.py`: 114 passed.
- `git diff --check`: passed.
- `uv run --active --no-sync pre-commit run --all-files`: passed.

## Scope

This changes only the Qwen3-Next example launcher custom-data path. The default SQuAD source and other recipes are unchanged. The failure is deterministic CPU-side preprocessing before dataset construction, so no GPU or training-loop validation was required.