### PR TITLE
[training] fix: Clean up failed pretrain sessions

### DIFF
--- a/src/megatron/bridge/training/pretrain.py
+++ b/src/megatron/bridge/training/pretrain.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+
 import torch.distributed as dist
 from nvidia_resiliency_ext.inprocess import CallWrapper
 
@@ -20,12 +22,16 @@ from megatron.bridge.training.callbacks import Callback, CallbackManager, normal
 from megatron.bridge.training.config import ConfigContainer, runtime_config_update
 from megatron.bridge.training.eval import evaluate_and_print_results
 from megatron.bridge.training.forward_step_func_types import ForwardStepCallable
+from megatron.bridge.training.initialize import destroy_global_state
 from megatron.bridge.training.setup import setup
 from megatron.bridge.training.state import GlobalState
 from megatron.bridge.training.train import _finish_train, train
 from megatron.bridge.training.utils.log_utils import barrier_and_log
 from megatron.bridge.utils.common_utils import print_rank_0
 from megatron.bridge.utils.decorators import experimental_fn
+
+
+logger = logging.getLogger(__name__)
 
 
 @experimental_fn
@@ -125,79 +131,100 @@ def _pretrain(
 
     config = state.cfg
     dataset_provider = get_dataset_provider(config.dataset)
-    setup_output = setup(state, dataset_provider, restart_store=store, callback_manager=callback_manager)
-    state = setup_output.state
-    model = setup_output.model
-    optimizer = setup_output.optimizer
-    scheduler = setup_output.scheduler
-    train_data_iterator = setup_output.train_data_iterator
-    valid_data_iterator = setup_output.valid_data_iterator
-    test_data_iterator = setup_output.test_data_iterator
-    checkpoint_manager = setup_output.checkpoint_manager
-    pg_collection = setup_output.pg_collection
+    try:
+        setup_output = setup(state, dataset_provider, restart_store=store, callback_manager=callback_manager)
+        state = setup_output.state
+        model = setup_output.model
+        optimizer = setup_output.optimizer
+        scheduler = setup_output.scheduler
+        train_data_iterator = setup_output.train_data_iterator
+        valid_data_iterator = setup_output.valid_data_iterator
+        test_data_iterator = setup_output.test_data_iterator
+        checkpoint_manager = setup_output.checkpoint_manager
+        pg_collection = setup_output.pg_collection
 
-    # TRAINING
-    if not config.validation.skip_train:
-        if state.train_state.do_train and config.train.train_iters > 0:
-            train(
-                forward_step_func,
-                model,
-                optimizer,
-                scheduler,
-                train_data_iterator,
-                valid_data_iterator,
+        # TRAINING
+        if not config.validation.skip_train:
+            if state.train_state.do_train and config.train.train_iters > 0:
+                train(
+                    forward_step_func,
+                    model,
+                    optimizer,
+                    scheduler,
+                    train_data_iterator,
+                    valid_data_iterator,
+                    state,
+                    checkpoint_manager,
+                    pg_collection,
+                    callback_manager=callback_manager,
+                )
+
+            barrier_and_log("after training is done")
+
+        else:
+            print_rank_0("skipping training ...")
+
+        iteration = state.train_state.step
+
+        # VALIDATION
+        if state.train_state.do_valid:
+            prefix = f"iteration {iteration} on validation set"
+            evaluate_and_print_results(
                 state,
-                checkpoint_manager,
-                pg_collection,
+                prefix,
+                forward_step_func,
+                valid_data_iterator,
+                model,
+                config.model,
+                verbose=True,
+                write_to_tensorboard=not config.validation.skip_train,
                 callback_manager=callback_manager,
             )
+        if state.train_state.do_test:
+            prefix = f"iteration {iteration} on test set"
+            evaluate_and_print_results(
+                state,
+                prefix,
+                forward_step_func,
+                test_data_iterator,
+                model,
+                config.model,
+                verbose=True,
+                write_to_tensorboard=not config.validation.skip_train,
+                callback_manager=callback_manager,
+                is_test=True,
+            )
 
-        barrier_and_log("after training is done")
+        _finish_train(state, checkpoint_manager)
+    except BaseException:
+        if inprocess_call_wrapper is None:
+            _cleanup_after_pretrain_failure(should_destroy_process_group)
+        raise
 
-    else:
-        print_rank_0("skipping training ...")
-
-    iteration = state.train_state.step
-
-    # VALIDATION
-    if state.train_state.do_valid:
-        prefix = f"iteration {iteration} on validation set"
-        evaluate_and_print_results(
-            state,
-            prefix,
-            forward_step_func,
-            valid_data_iterator,
-            model,
-            config.model,
-            verbose=True,
-            write_to_tensorboard=not config.validation.skip_train,
-            callback_manager=callback_manager,
-        )
-    if state.train_state.do_test:
-        prefix = f"iteration {iteration} on test set"
-        evaluate_and_print_results(
-            state,
-            prefix,
-            forward_step_func,
-            test_data_iterator,
-            model,
-            config.model,
-            verbose=True,
-            write_to_tensorboard=not config.validation.skip_train,
-            callback_manager=callback_manager,
-            is_test=True,
-        )
-
-    _finish_train(state, checkpoint_manager)
     _maybe_destroy_process_group(should_destroy_process_group)
 
 
-def _maybe_destroy_process_group(should_destroy: bool) -> None:
+def _cleanup_after_pretrain_failure(should_destroy_process_group: bool) -> None:
+    """Clean up framework-owned state after ordinary pretrain execution fails."""
+    try:
+        destroy_global_state()
+    except Exception:
+        logger.exception("Failed to destroy Megatron global state after pretrain failure")
+
+    try:
+        _maybe_destroy_process_group(should_destroy_process_group, synchronize=False)
+    except Exception:
+        logger.exception("Failed to destroy the process group after pretrain failure")
+
+
+def _maybe_destroy_process_group(should_destroy: bool, *, synchronize: bool = True) -> None:
     """Destroy the process group if it was created by this training session.
 
     Args:
         should_destroy: Whether the process group should be destroyed
+        synchronize: Whether to synchronize ranks before destruction
     """
     if should_destroy and dist.is_initialized():
-        dist.barrier()
+        if synchronize:
+            dist.barrier()
         dist.destroy_process_group()

--- a/tests/unit_tests/training/test_pretrain.py
+++ b/tests/unit_tests/training/test_pretrain.py
@@ -14,9 +14,11 @@
 
 """Unit tests for pretrain module process group cleanup."""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
-from megatron.bridge.training.pretrain import _maybe_destroy_process_group
+import pytest
+
+from megatron.bridge.training.pretrain import _maybe_destroy_process_group, _pretrain
 
 
 class TestDestroyProcessGroupIfNeeded:
@@ -59,5 +61,75 @@ class TestDestroyProcessGroupIfNeeded:
 
         _maybe_destroy_process_group(should_destroy=False)
 
+        mock_dist.barrier.assert_not_called()
+        mock_dist.destroy_process_group.assert_not_called()
+
+
+class TestPretrainProcessGroupOwnership:
+    """Test process group ownership across exceptional pretrain exits."""
+
+    def test_framework_owned_process_group_is_destroyed_when_setup_raises(self):
+        """Test Bridge destroys a process group initialized during failed setup."""
+        state = MagicMock()
+
+        with (
+            patch("megatron.bridge.training.pretrain.dist") as mock_dist,
+            patch("megatron.bridge.training.pretrain.destroy_global_state") as mock_destroy_global_state,
+            patch("megatron.bridge.training.pretrain.get_dataset_provider"),
+            patch(
+                "megatron.bridge.training.pretrain.setup",
+                side_effect=RuntimeError("setup failed after distributed initialization"),
+            ),
+        ):
+            mock_dist.is_initialized.side_effect = [False, True]
+
+            with pytest.raises(RuntimeError, match="setup failed after distributed initialization"):
+                _pretrain(state, MagicMock())
+
+        mock_destroy_global_state.assert_called_once_with()
+        mock_dist.barrier.assert_not_called()
+        mock_dist.destroy_process_group.assert_called_once_with()
+
+    def test_caller_owned_process_group_is_preserved_when_setup_raises(self):
+        """Test Bridge preserves a process group that existed before setup."""
+        state = MagicMock()
+
+        with (
+            patch("megatron.bridge.training.pretrain.dist") as mock_dist,
+            patch("megatron.bridge.training.pretrain.get_dataset_provider"),
+            patch("megatron.bridge.training.pretrain.setup", side_effect=RuntimeError("setup failed")),
+        ):
+            mock_dist.is_initialized.return_value = True
+
+            with pytest.raises(RuntimeError, match="setup failed"):
+                _pretrain(state, MagicMock())
+
+        mock_dist.destroy_process_group.assert_not_called()
+
+    def test_inprocess_restart_wrapper_retains_cleanup_ownership_when_setup_raises(self):
+        """Test NVRx retains cleanup ownership for wrapped pretrain failures."""
+        state = MagicMock()
+        store = MagicMock()
+        inprocess_call_wrapper = MagicMock()
+        inprocess_call_wrapper.iteration = 1
+
+        with (
+            patch("megatron.bridge.training.pretrain.dist") as mock_dist,
+            patch("megatron.bridge.training.pretrain.destroy_global_state") as mock_destroy_global_state,
+            patch("megatron.bridge.training.pretrain.get_dataset_provider"),
+            patch("megatron.bridge.training.pretrain.setup", side_effect=RuntimeError("setup failed")),
+        ):
+            mock_dist.is_initialized.return_value = False
+
+            with pytest.raises(RuntimeError, match="setup failed"):
+                _pretrain(
+                    state,
+                    MagicMock(),
+                    store=store,
+                    inprocess_call_wrapper=inprocess_call_wrapper,
+                )
+
+        mock_dist.PrefixStore.assert_called_once_with("1", store)
+        mock_destroy_global_state.assert_not_called()
         mock_dist.barrier.assert_not_called()
         mock_dist.destroy_process_group.assert_not_called()


### PR DESCRIPTION
## Problem

When the public `pretrain()` path initializes distributed and Megatron global state, an exception from setup, training, evaluation, checkpoint finalization, or a documented callback bypasses the success-only cleanup. If the caller catches that exception, the framework-created default process group and Megatron globals remain live, so a retry can reuse stale state, report an already-initialized group, leak resources, or hang.

Caller-created process groups are not affected by this ownership bug.

## Root cause

`_finish_train()` and `_maybe_destroy_process_group()` ran only after the full pretrain body completed successfully. The ordinary exception path had no corresponding cleanup, while the in-process-restart path has separate NVRx lifecycle ownership.

## Fix

- Clean Megatron global state when ordinary pretrain execution fails.
- Destroy the default process group only when this training session owned its initialization.
- Skip the distributed barrier during exceptional cleanup so a rank-local failure is not converted into a barrier hang.
- Preserve the original exception and leave in-process-restart cleanup under NVRx ownership.
- Add focused coverage for framework-owned and caller-owned groups, global cleanup, barrier omission, and the injected restart wrapper.

## Validation

Fail before the production fix:

```text
uv run --active --no-sync python -m pytest tests/unit_tests/training/test_pretrain.py -q
1 failed, 5 passed
AssertionError: Expected 'destroy_process_group' to be called once. Called 0 times.
```

The same deterministic one-rank Gloo reproducer also failed on the unmodified base because the framework-owned real process group remained initialized, then passed with the fix.

Pass after the fix and expanded regression coverage:

```text
uv run --no-sync python -m pytest tests/unit_tests/training/test_pretrain.py -q
7 passed
```

Adjacent lifecycle tests:

```text
uv run --no-sync python -m pytest tests/unit_tests/training/test_inprocess_restart.py tests/unit_tests/training/test_initialize.py -q
47 passed
```

Static checks:

```text
git diff --check
passed

uv run --active --no-sync pre-commit run --all-files
all hooks passed
```

## Scope

This changes only exceptional cleanup for ordinary `pretrain()` execution. Successful cleanup behavior, caller-owned process groups, and NVRx-managed in-process restart cleanup remain unchanged. No full-suite, convergence, performance, or multi-rank training claim is made.
