### PR TITLE
[training] fix: align ModelOpt restore with resume source

### DIFF
--- a/src/megatron/bridge/training/setup.py
+++ b/src/megatron/bridge/training/setup.py
@@ -300,20 +300,24 @@ def setup(
         def modelopt_pre_wrap_hook(model):
             from megatron.bridge.training.post_training.checkpointing import has_modelopt_state
 
-            # Check which checkpoint path has modelopt state
-            if cfg.checkpoint.pretrained_checkpoint and has_modelopt_state(cfg.checkpoint.pretrained_checkpoint):
-                checkpoint_path = cfg.checkpoint.pretrained_checkpoint
-                ckpt_step = None
-            elif cfg.checkpoint.load and has_modelopt_state(
-                cfg.checkpoint.load, ckpt_step=cfg.checkpoint.ckpt_step
-            ):
+            has_resume_checkpoint = cfg.checkpoint.load is not None and (
+                checkpoint_exists(cfg.checkpoint.load)
+                or is_hf_checkpoint_dir(cfg.checkpoint.load)
+                or _has_global_non_persistent_checkpoint(cfg.checkpoint.load, cfg.checkpoint)
+            )
+            if has_resume_checkpoint:
                 checkpoint_path = cfg.checkpoint.load
                 ckpt_step = cfg.checkpoint.ckpt_step
+            elif cfg.checkpoint.pretrained_checkpoint:
+                checkpoint_path = cfg.checkpoint.pretrained_checkpoint
+                ckpt_step = None
             else:
                 raise RuntimeError(
-                    f"No modelopt_state found in pretrained_checkpoint={cfg.checkpoint.pretrained_checkpoint} "
-                    f"or load={cfg.checkpoint.load}"
+                    "No checkpoint source is available for ModelOpt state restoration"
                 )
+
+            if not has_modelopt_state(checkpoint_path, ckpt_step=ckpt_step):
+                raise RuntimeError(f"No modelopt_state found in selected checkpoint={checkpoint_path}")
 
             load_modelopt_state(model, checkpoint_path, ckpt_step=ckpt_step)
             return model

--- a/tests/unit_tests/training/test_modelopt_setup.py
+++ b/tests/unit_tests/training/test_modelopt_setup.py
@@ -1,0 +1,109 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+import torch
+
+import megatron.bridge.training.setup as training_setup
+
+
+@pytest.mark.parametrize("resume_has_modelopt_state", [True, False])
+def test_modelopt_restore_prefers_native_resume_checkpoint(resume_has_modelopt_state):
+    class StopAfterHooksRegistered(Exception):
+        pass
+
+    cfg = SimpleNamespace(
+        checkpoint=SimpleNamespace(
+            load="/resume",
+            pretrained_checkpoint="/pretrained",
+            ckpt_step=17,
+            save=None,
+        ),
+        dataset=SimpleNamespace(),
+        dist=SimpleNamespace(enable_megatron_core_experimental=False, disable_jit_fuser=False),
+        ft=None,
+        logger=SimpleNamespace(
+            filter_warnings=False,
+            log_progress=False,
+            logging_level="INFO",
+            modules_to_filter=[],
+            set_level_for_all_loggers=False,
+        ),
+        model=SimpleNamespace(
+            fine_grained_activation_offloading=False,
+            restore_modelopt_state=True,
+            vocab_size=32,
+        ),
+        peft=None,
+        profiling=SimpleNamespace(),
+        tensor_inspect=SimpleNamespace(),
+        tokenizer=SimpleNamespace(),
+        train=SimpleNamespace(micro_batch_size=1, num_epochs=None),
+    )
+    timer = MagicMock()
+    state = SimpleNamespace(
+        cfg=cfg,
+        initialize_async_checkpoint_worker=Mock(),
+        start_time=0.0,
+        timers=Mock(return_value=timer),
+    )
+    hooks = []
+    start_time_tensor = Mock()
+    start_time_tensor.item.return_value = 0.0
+
+    with (
+        patch.multiple(
+            training_setup,
+            barrier_and_log=Mock(),
+            build_tokenizer=Mock(return_value=SimpleNamespace(vocab_size=32)),
+            create_checkpoint_manager=Mock(),
+            checkpoint_exists=Mock(return_value=True),
+            initialize_megatron=Mock(return_value=object()),
+            initialize_tensor_inspect_pre_model_initialization=Mock(),
+            maybe_log_and_save_config=Mock(),
+            print_rank_0=Mock(),
+            set_experimental_flag=Mock(),
+            set_jit_fusion_options=Mock(),
+            setup_logging=Mock(),
+            start_memory_history_recording=Mock(),
+            _build_distributed_model=Mock(side_effect=StopAfterHooksRegistered),
+            _register_pre_wrap_hook=Mock(side_effect=lambda _model, hook: hooks.append(hook)),
+        ),
+        patch.object(torch, "tensor", return_value=start_time_tensor),
+        patch.object(torch.distributed, "all_reduce"),
+        patch(
+            "megatron.bridge.training.post_training.checkpointing.has_modelopt_state",
+            side_effect=lambda checkpoint_path, **_kwargs: (
+                resume_has_modelopt_state if checkpoint_path == "/resume" else True
+            ),
+        ),
+        patch("megatron.bridge.training.post_training.checkpointing.load_modelopt_state") as mock_load_modelopt,
+    ):
+        with pytest.raises(StopAfterHooksRegistered):
+            training_setup.setup(state, Mock())
+
+        assert len(hooks) == 1
+        if resume_has_modelopt_state:
+            hooks[0]([])
+        else:
+            with pytest.raises(RuntimeError, match="No modelopt_state found in selected checkpoint=/resume"):
+                hooks[0]([])
+
+    if resume_has_modelopt_state:
+        mock_load_modelopt.assert_called_once_with([], "/resume", ckpt_step=17)
+    else:
+        mock_load_modelopt.assert_not_called()


### PR DESCRIPTION
## Summary

When QAT resumes with both `checkpoint.pretrained_checkpoint` and a valid `checkpoint.load`, native weights and optimizer state come from `checkpoint.load`. The ModelOpt pre-wrap hook instead preferred the pretrained checkpoint, so it could construct the model and optimizer from one ModelOpt schema before loading native state from another checkpoint.

The hook now uses the same resume-availability predicates as native checkpoint loading, selects the same authoritative source, and validates ModelOpt state only on that source. A valid resume without ModelOpt state raises instead of silently combining pretrained ModelOpt state with resume weights.

## Supported trigger and impact

The documented Nemotron QAT resume flow retains its quantized pretrained checkpoint while accepting `checkpoint.load` for resume. If those checkpoints differ in ModelOpt transformations, the old path could restore architecture and extra state from the pretrained source but load model and optimizer state from the resume source, causing schema/key failures or incorrect restored quantization state.

## Validation

Fail-before on `c0a200f685d3ee8969517f902f8b55059c6283c3`:

```text
uv run --active --no-sync python -m pytest --confcutdir=tests/unit_tests/training tests/unit_tests/training/test_modelopt_setup.py -q
2 failed
```

- ModelOpt-bearing resume: expected `/resume` at step 17; actual `/pretrained` with no step.
- Valid resume without ModelOpt state: expected a targeted error; actual fallback loaded pretrained ModelOpt state.

Pass-after and adjacent checks:

```text
uv run --active --no-sync python -m pytest --confcutdir=tests/unit_tests/training tests/unit_tests/training/test_modelopt_setup.py -q
2 passed

uv run --active --no-sync python -m pytest --confcutdir=tests/unit_tests/training tests/unit_tests/training/test_setup.py::TestShouldLoadCheckpoint::test_required_checkpoint_must_exist tests/unit_tests/training/test_setup.py::TestShouldLoadCheckpoint::test_local_checkpoint_satisfies_required_source -q
2 passed

git diff --check
passed

uv run pre-commit run --all-files
passed
```

## Scope

This changes only ModelOpt pre-wrap checkpoint-source selection and adds a focused CPU regression test. It does not add ModelOpt support for non-persistent checkpoints and does not claim full-suite, GPU, convergence, performance, or model-quality validation.
