### PR TITLE
[inference] fix: Preserve the Qwen VLM processor for generation

### DIFF
--- a/src/megatron/bridge/inference/vlm/base.py
+++ b/src/megatron/bridge/inference/vlm/base.py
@@ -117,6 +117,7 @@ def setup_model_and_tokenizer(
         inference_max_seq_length=inference_max_seq_length,
         inference_max_batch_size=inference_max_batch_size,
     )
+    inference_wrapped_model.processor = processor
 
     return inference_wrapped_model, processor
 
@@ -193,6 +194,8 @@ def generate(
     """
 
     if isinstance(wrapped_model, QwenVLInferenceWrapper):
+        if processor is None:
+            processor = getattr(wrapped_model, "processor", None)
         text_generation_controller = QwenVLTextGenerationController(
             inference_wrapped_model=wrapped_model,
             tokenizer=tokenizer,

--- a/src/megatron/bridge/inference/vlm/vlm_inference_controller.py
+++ b/src/megatron/bridge/inference/vlm/vlm_inference_controller.py
@@ -113,6 +113,11 @@ class QwenVLTextGenerationController(VLMTextGenerationController):
 
     def tokenize_prompt(self, prompt: str, image):
         """Tokenize with the HF processor (image + text; same idea as hf_to_megatron_generate_vlm)."""
+        if self.processor is None:
+            if image is not None:
+                raise ValueError("A processor is required for Qwen VLM image prompts.")
+            return self.tokenizer.tokenize(prompt), None
+
         if image is None:
             inputs = self.processor(text=[prompt], return_tensors="pt")
         else:

--- a/tests/unit_tests/inference/vlm/test_base.py
+++ b/tests/unit_tests/inference/vlm/test_base.py
@@ -112,6 +112,7 @@ class TestSetupModelAndTokenizer:
         # Verify return values
         assert result_model == mock_wrapped_model
         assert result_processor == mock_processor
+        assert result_model.processor is mock_processor
 
     @patch("megatron.bridge.inference.vlm.base.get_hf_model_id_from_checkpoint", return_value=None)
     @patch("megatron.bridge.inference.vlm.base.print_rank_0")
@@ -320,6 +321,64 @@ class TestSetupInferenceWrapper:
 
 class TestGenerate:
     """Tests for generate function."""
+
+    @patch("megatron.bridge.inference.vlm.base.VLMEngine")
+    def test_generate_qwen_uses_wrapped_processor_by_default(self, mock_engine, mock_tokenizer, mock_image_processor):
+        mock_wrapper = MagicMock(spec=QwenVLInferenceWrapper)
+        mock_processor = MagicMock()
+        mock_processor.return_value = {
+            "input_ids": torch.tensor([[1, 2, 3]]),
+            "pixel_values": torch.tensor([1]),
+            "image_grid_thw": torch.tensor([2]),
+        }
+        mock_wrapper.processor = mock_processor
+
+        def tokenize_first_prompt(*, prompts, images, sampling_params):
+            controller = mock_engine.call_args.kwargs["text_generation_controller"]
+            return controller.tokenize_prompt(prompts[0], images[0])
+
+        mock_engine.return_value.generate.side_effect = tokenize_first_prompt
+
+        with patch(
+            "megatron.bridge.inference.vlm.vlm_inference_controller.TextGenerationController.__init__",
+            return_value=None,
+        ):
+            result = generate(
+                wrapped_model=mock_wrapper,
+                tokenizer=mock_tokenizer,
+                image_processor=mock_image_processor,
+                prompts=["test"],
+                images=["image"],
+            )
+
+        assert result[0] == [1, 2, 3]
+        mock_processor.assert_called_once_with(text=["test"], images="image", padding=True, return_tensors="pt")
+
+    @patch("megatron.bridge.inference.vlm.base.VLMEngine")
+    def test_generate_qwen_text_only_without_processor(self, mock_engine, mock_tokenizer, mock_image_processor):
+        mock_wrapper = MagicMock(spec=QwenVLInferenceWrapper)
+
+        def tokenize_first_prompt(*, prompts, images, sampling_params):
+            controller = mock_engine.call_args.kwargs["text_generation_controller"]
+            image = images[0] if images is not None else None
+            return controller.tokenize_prompt(prompts[0], image)
+
+        mock_engine.return_value.generate.side_effect = tokenize_first_prompt
+
+        with patch(
+            "megatron.bridge.inference.vlm.vlm_inference_controller.TextGenerationController.__init__",
+            return_value=None,
+        ):
+            result = generate(
+                wrapped_model=mock_wrapper,
+                tokenizer=mock_tokenizer,
+                image_processor=mock_image_processor,
+                prompts=["test"],
+                images=None,
+            )
+
+        assert result == ([1, 2, 3], None)
+        mock_tokenizer.encode.assert_called_once_with("test", add_special_tokens=False)
 
     @patch("megatron.bridge.inference.vlm.base.VLMEngine")
     @patch("megatron.bridge.inference.vlm.base.QwenVLTextGenerationController")


### PR DESCRIPTION
## Problem

`generate()` declares its Qwen VLM `processor` argument optional, and `VLMEngine` supports text-only requests with `images=None`. However, the Qwen controller dereferenced the default `None` before model execution. Omitting the argument therefore crashed with `TypeError: 'NoneType' object is not callable`. The same omission also discarded a combined processor already created by `setup_model_and_tokenizer()`, breaking image prompts unless callers redundantly passed it again.

## Root cause and fix

The setup path returned the Hugging Face processor separately but did not retain it on the inference wrapper, while `generate()` forwarded only its explicit argument. This change:

- retains the setup-created processor on the wrapper;
- lets `generate()` recover it when the optional argument is omitted;
- falls back to tokenizer-only processing for direct text-only Qwen wrappers; and
- raises a clear error for image prompts only when no combined processor exists anywhere.

Explicit processors continue to take precedence.

## Verification

Fail-before on `origin/main`:

```text
uv run --active --no-sync python -m pytest tests/unit_tests/inference/vlm/test_base.py::TestGenerate::test_generate_qwen_uses_wrapped_processor_by_default -q
# 1 failed: QwenVLTextGenerationController called processor=None
```

Pass-after and adjacent coverage:

```text
uv run --active --no-sync python -m pytest tests/unit_tests/inference/vlm/ -q
# 36 passed

uv run --active --no-sync pre-commit run --all-files
# all hooks passed

git diff --check
# passed
```

Scope is limited to Qwen VLM processor ownership and prompt tokenization. No full-suite, convergence, model-quality, or performance validation was run.
