### PR TITLE
build(deps): provide transformer-engine metadata so uv lock skips its source build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,6 +157,30 @@ name = "flash-mla"
 version = "1.0.0+b7643bd"
 requires-dist = []
 
+# transformer-engine is a git dep marked no-build-isolation, so uv builds it FROM SOURCE purely to read
+# its metadata at lock time — a cold nvcc/ninja compile that runs tens of minutes and stalled the nightly
+# mcore bump (CI-Events-Workflows#746). Provide its metadata so the resolver skips that build, exactly as
+# the flash-mla block above. Mirrors what uv extracted into uv.lock for this pinned commit: version =
+# VERSION.txt (2.17.0) + uv's git-hash local segment; requires-dist = build_tools/pytorch.install_requirements()
+# ∪ the base setup_requirements() (setup.py). The pytorch/core_cu13 extras are no-ops on the self-contained
+# source build (its extras_require is {"test": ...}), declared so `transformer-engine[pytorch,core_cu13]`
+# resolves without a build. Bump version + requires-dist together whenever the TE pin (override-dependencies
+# above) changes — an out-of-date entry sends uv back to building TE.
+[[tool.uv.dependency-metadata]]
+name = "transformer-engine"
+version = "2.17.0+2e559f06"
+requires-dist = [
+    "einops",
+    "importlib-metadata>=1.0",
+    "nvdlfw-inspect",
+    "onnx",
+    "onnxscript",
+    "packaging",
+    "pydantic",
+    "torch>=2.1",
+]
+provides-extras = ["core-cu13", "pytorch"]
+
 [tool.uv.sources]
 megatron-core = { path = "3rdparty/Megatron-LM/", editable = true }
 nvidia-modelopt = { index = "nvidia" }

--- a/uv.lock
+++ b/uv.lock
@@ -33,6 +33,12 @@ overrides = [
 name = "flash-mla"
 version = "1.0.0+b7643bd"
 
+[[manifest.dependency-metadata]]
+name = "transformer-engine"
+version = "2.17.0+2e559f06"
+requires-dist = ["einops", "importlib-metadata>=1.0", "nvdlfw-inspect", "onnx", "onnxscript", "packaging", "pydantic", "torch>=2.1"]
+provides-extras = ["core-cu13", "pytorch"]
+
 [[package]]
 name = "absl-py"
 version = "2.5.0"


### PR DESCRIPTION
## Background / motivation

- `transformer-engine` is pinned as a **git dependency** (`override-dependencies`) and marked **`no-build-isolation`**, with **no** `[[tool.uv.dependency-metadata]]` entry — unlike its sibling `flash-mla`, which has one.
- So `uv lock` has to **build TE from source just to read its metadata**: a cold `nvcc`/`ninja` compile that runs **tens of minutes**. It stalled the nightly Megatron-Core bump — the lock job sat silent for 16+ min after `Updated TransformerEngine.git` and was cancelled, opening no PRs (NVIDIA-NeMo/CI-Events-Workflows#746).

## What changed

- Add a `[[tool.uv.dependency-metadata]]` override for `transformer-engine`, mirroring the existing `flash-mla` one, so the resolver uses provided metadata instead of building it at lock time.

## Details

```toml
# pyproject.toml (excerpt)
[[tool.uv.dependency-metadata]]
name = "transformer-engine"
version = "2.17.0+2e559f06"
requires-dist = [
    "einops", "importlib-metadata>=1.0", "nvdlfw-inspect", "onnx",
    "onnxscript", "packaging", "pydantic", "torch>=2.1",
]
provides-extras = ["core-cu13", "pytorch"]
```

- The metadata is **not guessed** — it mirrors exactly what uv already extracted into `uv.lock` for the pinned commit `2e559f0`:
  - `version` = `build_tools/VERSION.txt` (`2.17.0`) + uv's git-hash local segment (`+2e559f06`).
  - `requires-dist` = `build_tools/pytorch.install_requirements()` ∪ the base `setup_requirements()` (`setup.py`) = the 8 deps in the lock's TE block.
  - `provides-extras` = the extras `transformer-engine[pytorch,core_cu13]` requests; they are no-ops on the self-contained source build (its `extras_require` is `{"test": ...}`), declared so the request resolves without a build.
- **Resolution is unchanged.** The only `uv.lock` delta is uv recording the override in `[[manifest.dependency-metadata]]` — every package block is byte-identical. Regenerated with the **CI-pinned uv 0.7.2** (`docker/Dockerfile.ci`) so the lock `revision` stays `2` (uv 0.11.x would bump it to 3 and break `uv sync --locked` under 0.7.2).
- **Lock-time only.** The override affects `uv lock` metadata extraction, not installation — `uv sync --locked` still builds/installs TE exactly as before.

### Maintenance note

`version` (git-hash local segment) and `requires-dist` are pinned to the current TE commit. **Bump both whenever the TE pin (`override-dependencies`) changes** — an out-of-date entry silently sends uv back to building TE. The in-file comment says the same.

## Tested

- `uv lock` (uv 0.7.2) — **resolved 348 packages in ~1.5s, no TE build** (vs. the multi-minute build before). Diff is only the `[[manifest.dependency-metadata]]` entry; `revision` stays `2`.
- `uv lock --locked` — **exit 0** (lock consistent with `pyproject.toml`; the check CI's `uv sync --locked` relies on).
- Cross-checked the metadata against TE's own `build_tools/pytorch.install_requirements()` + `setup.py setup_requirements()` at commit `2e559f0`, and against the resolved `transformer-engine` block already in `uv.lock`.

```mermaid
flowchart LR
  subgraph before["Before"]
    A["uv lock --upgrade"] --> B["build TE from source<br/>(nvcc/ninja, 10-40+ min)"] --> C["read metadata"]
  end
  subgraph after["After"]
    D["uv lock --upgrade"] --> E["read [[dependency-metadata]]<br/>(~seconds)"]
  end
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
