### PR TITLE
[docs] fix: Include model verification skill in docs index

### DIFF
--- a/docs/skills-index.md
+++ b/docs/skills-index.md
@@ -27,6 +27,7 @@ skills/adding-model-support/llm-patterns
 skills/adding-model-support/vlm-patterns
 skills/adding-model-support/recipe-patterns
 skills/adding-model-support/tests-and-examples
+skills/create-model-verification-card/SKILL
 skills/verl-e2e-testing/SKILL
 skills/nemo-rl-e2e-testing/SKILL
 ```


### PR DESCRIPTION
## Summary

- include the model verification card skill in the Adding Model Support toctree
- fix the toc.not_included warning that broke the main docs build in Actions run 29927912446

## Testing

- uv run --only-group docs sphinx-build --fail-on-warning --builder html docs /tmp/mb-main-doc-toctree-html
- uv run --active --no-sync pre-commit run --all-files