### PR TITLE
docs(model): list verification index items explicitly

### DIFF
--- a/examples/model_verification_cards/moonlight-16b-a3b/card.yaml
+++ b/examples/model_verification_cards/moonlight-16b-a3b/card.yaml
@@ -9,12 +9,18 @@ summary: >
   and training.
 verification_index:
   model_level:
-    verified: all
+    verified:
+      - hf_to_megatron_cpu
+      - hf_to_megatron_gpu
+      - megatron_to_hf_cpu
+      - megatron_to_hf_gpu
+      - manual_forward_pass
+      - inference
   training:
     H100:
-      verified: all
+      verified: [pretrain, sft, sft_export_inference, sft_long_context, peft, checkpoint_resume]
     GB200:
-      unverified: all
+      unverified: [pretrain, sft, sft_export_inference, sft_long_context, peft, checkpoint_resume]
 model:
   hf_id: moonshotai/Moonlight-16B-A3B
   hf_revision: 476b36a473d4467f94469414bef6cee75c9c8172  # pragma: allowlist secret

--- a/examples/model_verification_cards/nemotron-3-nano-4b/card.yaml
+++ b/examples/model_verification_cards/nemotron-3-nano-4b/card.yaml
@@ -9,12 +9,18 @@ summary: >
   and training.
 verification_index:
   model_level:
-    verified: all
+    verified:
+      - hf_to_megatron_cpu
+      - hf_to_megatron_gpu
+      - megatron_to_hf_cpu
+      - megatron_to_hf_gpu
+      - manual_forward_pass
+      - inference
   training:
     H100:
-      verified: all
+      verified: [pretrain, sft, sft_export_inference, sft_long_context, peft, checkpoint_resume]
     GB200:
-      unverified: all
+      unverified: [pretrain, sft, sft_export_inference, sft_long_context, peft, checkpoint_resume]
 model:
   hf_id: nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16
   hf_revision: dfaf35de3e30f1867dd8dbc38a7fc9fb52d3914f  # pragma: allowlist secret

--- a/examples/model_verification_cards/qwen3-30b-a3b/card.yaml
+++ b/examples/model_verification_cards/qwen3-30b-a3b/card.yaml
@@ -9,12 +9,18 @@ summary: >
   Qwen3-30B-A3B support verification covers conversion, inference, and training.
 verification_index:
   model_level:
-    verified: all
+    verified:
+      - hf_to_megatron_cpu
+      - hf_to_megatron_gpu
+      - megatron_to_hf_cpu
+      - megatron_to_hf_gpu
+      - manual_forward_pass
+      - inference
   training:
     H100:
-      verified: all
+      verified: [pretrain, sft, sft_export_inference, sft_long_context, peft, checkpoint_resume]
     GB200:
-      unverified: all
+      unverified: [pretrain, sft, sft_export_inference, sft_long_context, peft, checkpoint_resume]
   performance:
     H100: verified
 model:

--- a/examples/model_verification_cards/qwen3-8b/card.yaml
+++ b/examples/model_verification_cards/qwen3-8b/card.yaml
@@ -14,12 +14,18 @@ summary: >
   training.
 verification_index:
   model_level:
-    verified: all
+    verified:
+      - hf_to_megatron_cpu
+      - hf_to_megatron_gpu
+      - megatron_to_hf_cpu
+      - megatron_to_hf_gpu
+      - manual_forward_pass
+      - inference
   training:
     H100:
-      verified: all
+      verified: [pretrain, sft, sft_export_inference, sft_long_context, peft, checkpoint_resume]
     GB200:
-      unverified: all
+      unverified: [pretrain, sft, sft_export_inference, sft_long_context, peft, checkpoint_resume]
 model:
   hf_id: Qwen/Qwen3-8B
   hf_revision: b968826d9c46dd6066d109eabc6255188de91218  # pragma: allowlist secret

--- a/skills/create-model-verification-card/SKILL.md
+++ b/skills/create-model-verification-card/SKILL.md
@@ -141,9 +141,10 @@ Group item names under the same four status names used by the detailed items.
 For an explicitly indexed hardware target with no corresponding item leaf,
 summarize the missing verification as `unverified`; do not add empty item
 leaves or placeholder commands merely to populate the index. Omit empty status
-buckets, so a hardware target with no verified training is written only as
-`unverified: all`, never as `verified: []`. Use the scalar `all` when every
-item in that scope has the same status; otherwise list the exact item names.
+buckets and always list every item name explicitly, even when every item in the
+scope has the same status. Never use the scalar `all` in `verification_index`:
+an explicit inventory makes it clear which existing items were assessed when
+new items are added later.
 
 For example, a card with partial H100 functional-training coverage and no
 GB200 functional-training verification uses:
@@ -151,13 +152,19 @@ GB200 functional-training verification uses:
 ```yaml
 verification_index:
   model_level:
-    verified: all
+    verified:
+      - hf_to_megatron_cpu
+      - hf_to_megatron_gpu
+      - megatron_to_hf_cpu
+      - megatron_to_hf_gpu
+      - manual_forward_pass
+      - inference
   training:
     H100:
       verified: [sft, sft_export_inference, sft_long_context, peft]
       unverified: [pretrain, checkpoint_resume]
     GB200:
-      unverified: all
+      unverified: [pretrain, sft, sft_export_inference, sft_long_context, peft, checkpoint_resume]
 ```
 
 When a canonical performance recipe exists, mirror only its concrete leaves:
@@ -594,8 +601,8 @@ an item verified merely to make validation pass.
   all four metrics for each verified training leaf; never record a private
   cluster name or retain the old `gpu_type` field.
 - Keep `verification_index` synchronized with `items`, omit empty status
-  buckets, and use `unverified: all` for an indexed hardware target with no
-  verified functional-training evidence.
+  buckets, list every item name explicitly, and never use the scalar `all` in
+  the index.
 - Audit the resolved convergence contract before each training run; align it
   with `qwen3_30b_a3b_convergence_v1` or record the exception and classify the
   result as support verification rather than cross-model convergence evidence.

--- a/skills/create-model-verification-card/scripts/validate_card.py
+++ b/skills/create-model-verification-card/scripts/validate_card.py
@@ -346,16 +346,15 @@ def _validate_index_status_buckets(
     scope_names = frozenset(scope)
     assignments: dict[str, str] = {}
     assignment_paths: dict[str, tuple[str, ...]] = {}
-    all_statuses: list[str] = []
     for status, members in buckets.items():
         if status not in STATUSES:
             continue
         bucket_path = (*path, status)
         if members == "all":
-            all_statuses.append(status)
+            errors.append(f"{_pointer(*bucket_path)}: list every item name explicitly; scalar all is not allowed")
             continue
         if not isinstance(members, list) or not members:
-            errors.append(f"{_pointer(*bucket_path)}: expected all or a non-empty item list")
+            errors.append(f"{_pointer(*bucket_path)}: expected a non-empty item list")
             continue
         for index, item_name in enumerate(members):
             item_path = (*bucket_path, str(index))
@@ -367,23 +366,6 @@ def _validate_index_status_buckets(
                 continue
             assignments[item_name] = status
             assignment_paths[item_name] = bucket_path
-
-    if all_statuses:
-        if len(buckets) != 1 or len(all_statuses) != 1:
-            errors.append(f"{_pointer(*path)}: all must be the only status bucket in its scope")
-        else:
-            status = all_statuses[0]
-            assignments = dict.fromkeys(scope, status)
-            assignment_paths = dict.fromkeys(scope, (*path, status))
-            if len(expected_statuses) == len(scope) and any(
-                expected_statuses[item_name] != status for item_name in scope
-            ):
-                errors.append(
-                    f"{_pointer(*path, status)}: all is allowed only when every detailed item in the scope "
-                    f"has status {status}"
-                )
-    elif len(assignments) == len(scope) and len(set(assignments.values())) == 1:
-        errors.append(f"{_pointer(*path)}: use scalar all when every item in the scope has the same status")
 
     missing_items = [item_name for item_name in scope if item_name not in assignments]
     if missing_items:


### PR DESCRIPTION
# What does this PR do ?

List every model-verification index item explicitly so a future inventory addition cannot be ambiguously covered by a stale scalar all entry.

# Changelog

- Expand the model-level, H100, and GB200 status buckets in all four verification cards.
- Update the model-verification-card skill to require explicit index inventories.
- Update the card validator to reject scalar all in verification index status buckets.

# GitHub Actions CI

Local checks completed as described below. Repository CI can run through the standard trusted-commit or /ok to test workflow.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests? No persistent test was needed; targeted positive and negative validator checks were run.
- [x] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install? No.
  - [x] Reviewer: Does the PR have correct import guards for all optional libraries? Not applicable.

# Testing

- All four model verification cards pass validate_card.py.
- A card using the old scalar all form is rejected by validate_card.py.
- All pre-commit hooks pass through an isolated uv environment on macOS.

# Additional Information

Follow-up to #5009.
