### PR TITLE
fix(flops): use parquet packed dataset for LoRA SQuAD FLOP accounting

### DIFF
--- a/src/megatron/bridge/data/datasets/packing_utils.py
+++ b/src/megatron/bridge/data/datasets/packing_utils.py
@@ -336,7 +336,10 @@ def calculate_avg_seqlen(
     """Calculate average sequence length statistics from a packed dataset.
 
     Args:
-        dataset_file: Path to the .npy packed dataset file.
+        dataset_file: Path to the packed dataset. Either a legacy ``.npy`` file, or a
+            parquet spec (``.parquet`` / ``.pq``) which may be a single file, a glob
+            pattern, or a directory -- resolved via ``resolve_packed_parquet_paths``
+            so this matches the specs accepted by the FLOP-accounting existence gate.
         gbs: Global batch size used to determine how many rows to process.
         max_seq_len: Maximum sequence length (reserved for future use).
         drop_remainder: If True, drop rows that don't fill a complete batch.
@@ -351,10 +354,22 @@ def calculate_avg_seqlen(
     Raises:
         ValueError: If no rows remain after applying drop_remainder, or if no sequences are found.
     """
-    if str(dataset_file).lower().endswith((".parquet", ".pq")):
+    # Same predicate the packed-parquet loader (and flop_utils._packed_data_exists)
+    # uses, so the format detected here matches the spec accepted by the existence
+    # gate -- covers single file, glob pattern, and directory specs.
+    from megatron.bridge.data.datasets.packed_parquet import (
+        is_packed_parquet_spec,
+        resolve_packed_parquet_paths,
+    )
+
+    if is_packed_parquet_spec(dataset_file):
         import pyarrow.parquet as pq
 
-        table = pq.read_table(dataset_file, columns=["input_ids", "seq_start_id"])
+        # Resolve the spec (single file / glob / directory) to concrete shard paths
+        # before reading, so a glob/dir spec that passes the existence gate does not
+        # then crash pq.read_table (which cannot take a raw glob string).
+        shards = resolve_packed_parquet_paths(dataset_file)
+        table = pq.read_table(shards, columns=["input_ids", "seq_start_id"])
         ids, starts = table.column("input_ids"), table.column("seq_start_id")
         data = [
             {"input_ids": ids[i].as_py(), "seq_start_id": starts[i].as_py()}

--- a/src/megatron/bridge/data/datasets/packing_utils.py
+++ b/src/megatron/bridge/data/datasets/packing_utils.py
@@ -351,8 +351,18 @@ def calculate_avg_seqlen(
     Raises:
         ValueError: If no rows remain after applying drop_remainder, or if no sequences are found.
     """
-    with open(dataset_file, "rb") as f:
-        data = safe_load_npy(f.read())
+    if str(dataset_file).lower().endswith((".parquet", ".pq")):
+        import pyarrow.parquet as pq
+
+        table = pq.read_table(dataset_file, columns=["input_ids", "seq_start_id"])
+        ids, starts = table.column("input_ids"), table.column("seq_start_id")
+        data = [
+            {"input_ids": ids[i].as_py(), "seq_start_id": starts[i].as_py()}
+            for i in range(table.num_rows)
+        ]
+    else:
+        with open(dataset_file, "rb") as f:
+            data = safe_load_npy(f.read())
 
     total_len_accum = 0
     seqlen_sq_accum = 0

--- a/src/megatron/bridge/training/utils/flop_utils.py
+++ b/src/megatron/bridge/training/utils/flop_utils.py
@@ -27,19 +27,24 @@ _lora_seq_stats_cache: dict = {}
 def _packed_data_exists(path: str | None) -> bool:
     """Return True if a packed dataset file exists, for both parquet and npy formats.
 
-    Parquet specs may be a single file, a glob, or a directory, so they are validated
-    via the packed-parquet resolver rather than a bare ``Path.exists()`` check (which
-    would fail for globs/directories and silently disable LoRA-aware FLOP accounting).
+    Parquet specs may be a single file, a glob, or a directory, so they are detected
+    with ``is_packed_parquet_spec`` and validated via the packed-parquet resolver
+    rather than a bare ``Path.exists()`` check (which would fail for globs/directories
+    and silently disable LoRA-aware FLOP accounting). This mirrors the format detection
+    in ``calculate_avg_seqlen`` so a spec that passes this gate also reads correctly.
     """
     if not path:
         return False
-    if str(path).lower().endswith((".parquet", ".pq")):
-        try:
-            from megatron.bridge.data.datasets.packed_parquet import resolve_packed_parquet_paths
+    try:
+        from megatron.bridge.data.datasets.packed_parquet import (
+            is_packed_parquet_spec,
+            resolve_packed_parquet_paths,
+        )
 
+        if is_packed_parquet_spec(path):
             return len(resolve_packed_parquet_paths(path)) > 0
-        except Exception:
-            return False
+    except Exception:
+        return False
     return Path(path).exists()
 
 

--- a/src/megatron/bridge/training/utils/flop_utils.py
+++ b/src/megatron/bridge/training/utils/flop_utils.py
@@ -24,6 +24,25 @@ from megatron.bridge.utils.vocab_utils import calculate_padded_vocab_size
 _lora_seq_stats_cache: dict = {}
 
 
+def _packed_data_exists(path: str | None) -> bool:
+    """Return True if a packed dataset file exists, for both parquet and npy formats.
+
+    Parquet specs may be a single file, a glob, or a directory, so they are validated
+    via the packed-parquet resolver rather than a bare ``Path.exists()`` check (which
+    would fail for globs/directories and silently disable LoRA-aware FLOP accounting).
+    """
+    if not path:
+        return False
+    if str(path).lower().endswith((".parquet", ".pq")):
+        try:
+            from megatron.bridge.data.datasets.packed_parquet import resolve_packed_parquet_paths
+
+            return len(resolve_packed_parquet_paths(path)) > 0
+        except Exception:
+            return False
+    return Path(path).exists()
+
+
 def vit_flops(
     cfg: ConfigContainer,
     batch_size: int,
@@ -366,10 +385,13 @@ def num_floating_point_operations(
             dataset_root = getattr(cfg.dataset, "dataset_root", None)
             seq_size = getattr(packed_specs, "packed_sequence_size", None)
             if dataset_root is not None and seq_size is not None:
-                matches = sorted(Path(dataset_root).glob(f"packed/*/training_{seq_size}.npy"))
+                # Prefer the current parquet format; fall back to the deprecated .npy.
+                matches = sorted(Path(dataset_root).glob(f"packed/*/training_{seq_size}.idx.parquet"))
+                if not matches:
+                    matches = sorted(Path(dataset_root).glob(f"packed/*/training_{seq_size}.npy"))
                 if matches:
                     packed_data_path = str(matches[0])
-        if is_lora and is_squad and is_llama3_70b and packed_data_path is not None and Path(packed_data_path).exists():
+        if is_lora and is_squad and is_llama3_70b and _packed_data_exists(packed_data_path):
             gbs = cfg.train.global_batch_size
             seq_len = cfg.model.seq_length
             cache_key = (packed_data_path, gbs, seq_len)

--- a/tests/unit_tests/data/datasets/test_packing_utils.py
+++ b/tests/unit_tests/data/datasets/test_packing_utils.py
@@ -17,7 +17,11 @@ from typing import List
 import numpy as np
 import pytest
 
-from megatron.bridge.data.datasets.packing_utils import first_fit, first_fit_decreasing
+from megatron.bridge.data.datasets.packing_utils import (
+    calculate_avg_seqlen,
+    first_fit,
+    first_fit_decreasing,
+)
 
 
 def _first_fit_linear(seqlens: List[int], pack_size: int) -> List[List[int]]:
@@ -83,3 +87,73 @@ class TestSegmentTreeMatchesLinearScan:
         seqlens = list(np.random.randint(1, 2048, size=5000))
         pack_size = 2048
         assert first_fit(seqlens, pack_size) == _first_fit_linear(seqlens, pack_size)
+
+
+# ---------------------------------------------------------------------------
+# calculate_avg_seqlen: format-aware loader (npy + parquet single/glob/dir)
+# ---------------------------------------------------------------------------
+#
+# Two hand-crafted packed rows shared by every fixture below so all formats
+# must return the same stats:
+#   row A: seq_start_id=[0, 4], input_ids len 8 -> boundaries [0,4,8]
+#          per-seq token counts = [3, 3]  (each minus 1 EOS)
+#   row B: seq_start_id=[0],    input_ids len 5 -> boundaries [0,5]
+#          per-seq token counts = [4]
+# Aggregated over both rows (gbs=1, drop_remainder=True -> count=2):
+#   seq_count_accum   = 2 + 1              = 3
+#   total_len_accum   = (3+3) + 4          = 10
+#   seqlen_sq_accum   = (9+9) + 16         = 34
+# -> (count, total, sq_individual, sq_per_row) = (3/2, 10/2, 34/3, 34/2)
+_AVG_SEQLEN_ROWS = [
+    {"input_ids": list(range(8)), "seq_start_id": [0, 4]},
+    {"input_ids": list(range(5)), "seq_start_id": [0]},
+]
+_AVG_SEQLEN_EXPECTED = (3 / 2, 10 / 2, 34 / 3, 34 / 2)
+
+
+def _write_avg_seqlen_parquet(path, rows) -> None:
+    """Write the two columns calculate_avg_seqlen reads to a parquet shard."""
+    pa = pytest.importorskip("pyarrow")
+    pq = pytest.importorskip("pyarrow.parquet")
+    table = pa.table(
+        {
+            "input_ids": [r["input_ids"] for r in rows],
+            "seq_start_id": [r["seq_start_id"] for r in rows],
+        }
+    )
+    pq.write_table(table, str(path))
+
+
+class TestCalculateAvgSeqlen:
+    """calculate_avg_seqlen must load npy and parquet (single/glob/dir) identically."""
+
+    def _assert_expected(self, stats):
+        assert stats == pytest.approx(_AVG_SEQLEN_EXPECTED)
+
+    def test_npy_legacy(self, tmp_path):
+        path = tmp_path / "training_4096.npy"
+        np.save(path, np.array(_AVG_SEQLEN_ROWS, dtype=object))
+        stats = calculate_avg_seqlen(str(path), gbs=1, max_seq_len=8, drop_remainder=True)
+        self._assert_expected(stats)
+
+    def test_parquet_single_file(self, tmp_path):
+        path = tmp_path / "training_4096.idx.parquet"
+        _write_avg_seqlen_parquet(path, _AVG_SEQLEN_ROWS)
+        stats = calculate_avg_seqlen(str(path), gbs=1, max_seq_len=8, drop_remainder=True)
+        self._assert_expected(stats)
+
+    def test_parquet_glob_spec_matches_single_file(self, tmp_path):
+        """A glob spec (sharded parquet) must resolve+read, not crash -- guards the
+        _packed_data_exists vs calculate_avg_seqlen input-set consistency."""
+        _write_avg_seqlen_parquet(tmp_path / "shard_000.idx.parquet", _AVG_SEQLEN_ROWS[:1])
+        _write_avg_seqlen_parquet(tmp_path / "shard_001.idx.parquet", _AVG_SEQLEN_ROWS[1:])
+        glob_spec = str(tmp_path / "shard_*.idx.parquet")
+        stats = calculate_avg_seqlen(glob_spec, gbs=1, max_seq_len=8, drop_remainder=True)
+        self._assert_expected(stats)
+
+    def test_parquet_directory_spec(self, tmp_path):
+        """A directory spec is also accepted (globs *.parquet under the dir)."""
+        _write_avg_seqlen_parquet(tmp_path / "shard_000.idx.parquet", _AVG_SEQLEN_ROWS[:1])
+        _write_avg_seqlen_parquet(tmp_path / "shard_001.idx.parquet", _AVG_SEQLEN_ROWS[1:])
+        stats = calculate_avg_seqlen(str(tmp_path), gbs=1, max_seq_len=8, drop_remainder=True)
+        self._assert_expected(stats)


### PR DESCRIPTION
Backport to `llmb-r0.5.1`: LoRA Llama-3-70B SQuAD over-reports `MODEL_TFLOP/s/GPU` (~1755 vs ~1150) because `flop_utils.py` only detects the deprecated `.npy` packed dataset, while packing now emits `.parquet`, so it falls back to full-model 6ND accounting. This fix makes the resolver prefer `.idx.parquet` (fall back to `.npy`) and adds a parquet-aware seqlen loader — metrics-only, no step-time change.