### PR TITLE
fix(perf): reinstate aws-ofi-nccl EFA plugin for EKS

### DIFF
--- a/docker/Dockerfile.fw_base
+++ b/docker/Dockerfile.fw_base
@@ -100,6 +100,7 @@ ARG REINSTALL_NCCL
 ARG NCCL_VERSION
 ARG REINSTALL_CUBLAS
 ARG CUBLAS_VERSION
+ARG AWS_OFI_NCCL_VERSION=v1.17.3
 
 RUN --mount=type=bind,source=docker/common/install_nsys.sh,target=/opt/install_nsys.sh \
     --mount=type=bind,source=docker/common/install_cudnn.sh,target=/opt/install_cudnn.sh \
@@ -117,6 +118,20 @@ RUN --mount=type=bind,source=docker/common/install_nsys.sh,target=/opt/install_n
     if [ $REINSTALL_CUBLAS = "True" ]; then \
     bash /opt/install_cublas.sh --CUBLAS_VER=$CUBLAS_VERSION; \
     fi
+
+##############################################################################
+##
+## Reinstall the aws-ofi-nccl EFA plugin
+##
+## NVIDIA PyTorch >= 26.06 dropped aws-ofi-nccl and defaults
+## NCCL_NET_PLUGIN=spcx (HPCX Spectrum-X), which cannot drive EFA -> NCCL falls
+## back to TCP sockets on AWS. Rebuild the plugin against the reinstalled NCCL and
+## the image's libfabric so EFA jobs keep their fabric. Selection stays per-CSP in
+## the launcher (EKSEnvPlugin pins NCCL_NET_PLUGIN for AWS).
+##############################################################################
+
+RUN --mount=type=bind,source=docker/common/install_aws_ofi_nccl.sh,target=/opt/install_aws_ofi_nccl.sh \
+    bash /opt/install_aws_ofi_nccl.sh --AWS_OFI_NCCL_VER=$AWS_OFI_NCCL_VERSION
 
 ##############################################################################
 ##

--- a/docker/Dockerfile.fw_base
+++ b/docker/Dockerfile.fw_base
@@ -100,7 +100,6 @@ ARG REINSTALL_NCCL
 ARG NCCL_VERSION
 ARG REINSTALL_CUBLAS
 ARG CUBLAS_VERSION
-ARG AWS_OFI_NCCL_VERSION=v1.17.3
 
 RUN --mount=type=bind,source=docker/common/install_nsys.sh,target=/opt/install_nsys.sh \
     --mount=type=bind,source=docker/common/install_cudnn.sh,target=/opt/install_cudnn.sh \
@@ -121,20 +120,6 @@ RUN --mount=type=bind,source=docker/common/install_nsys.sh,target=/opt/install_n
 
 ##############################################################################
 ##
-## Reinstall the aws-ofi-nccl EFA plugin
-##
-## NVIDIA PyTorch >= 26.06 dropped aws-ofi-nccl and defaults
-## NCCL_NET_PLUGIN=spcx (HPCX Spectrum-X), which cannot drive EFA -> NCCL falls
-## back to TCP sockets on AWS. Rebuild the plugin against the reinstalled NCCL and
-## the image's libfabric so EFA jobs keep their fabric. Selection stays per-CSP in
-## the launcher (EKSEnvPlugin pins NCCL_NET_PLUGIN for AWS).
-##############################################################################
-
-RUN --mount=type=bind,source=docker/common/install_aws_ofi_nccl.sh,target=/opt/install_aws_ofi_nccl.sh \
-    bash /opt/install_aws_ofi_nccl.sh --AWS_OFI_NCCL_VER=$AWS_OFI_NCCL_VERSION
-
-##############################################################################
-##
 ## Install vLLM
 ##
 ##############################################################################
@@ -146,6 +131,23 @@ RUN --mount=type=bind,from=vllm_wheel,source=/src/vllm/,target=/tmp/vllm/ \
     pushd /usr/local/lib/python3.12/dist-packages/vllm && \
     patch -p1 < /opt/vllm.patch && \
     popd
+
+##############################################################################
+##
+## Reinstall the aws-ofi-nccl EFA plugin
+##
+## NVIDIA PyTorch >= 26.06 dropped aws-ofi-nccl and defaults
+## NCCL_NET_PLUGIN=spcx (HPCX Spectrum-X), which cannot drive EFA -> NCCL falls
+## back to TCP sockets on AWS. Rebuild the plugin against the reinstalled NCCL and
+## the image's libfabric so EFA jobs keep their fabric. Selection stays per-CSP in
+## the launcher (EKSEnvPlugin pins NCCL_NET_PLUGIN for AWS). Kept last so it does
+## not invalidate the CUDA-toolkit or vLLM layer caches.
+##############################################################################
+
+ARG AWS_OFI_NCCL_VERSION=v1.17.3
+
+RUN --mount=type=bind,source=docker/common/install_aws_ofi_nccl.sh,target=/opt/install_aws_ofi_nccl.sh \
+    bash /opt/install_aws_ofi_nccl.sh --AWS_OFI_NCCL_VER=$AWS_OFI_NCCL_VERSION
 
 ##############################################################################
 ##

--- a/docker/common/install_aws_ofi_nccl.sh
+++ b/docker/common/install_aws_ofi_nccl.sh
@@ -1,0 +1,71 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/bin/bash
+
+# Build and install the aws-ofi-nccl NCCL network plugin (the NCCL <-> libfabric
+# bridge that lets NCCL run over AWS EFA).
+#
+# Why this exists: the NVIDIA PyTorch >= 26.06 base image dropped aws-ofi-nccl
+# and now defaults NCCL_NET_PLUGIN=spcx (HPCX Spectrum-X). On an EFA fabric the
+# Spectrum-X plugin cannot drive the NICs, so NCCL cannot use EFA. The
+# EFA/libfabric userspace is still in the image (/opt/amazon/efa) and the base even
+# keeps a dangling /etc/ld.so.conf.d/aws-ofi-nccl.conf -> /opt/amazon/ofi-nccl/lib,
+# so we only need to rebuild the plugin and drop it back into that same prefix.
+
+set -euo pipefail
+
+AWS_OFI_NCCL_VER="v1.17.3"
+
+for i in "$@"; do
+    case $i in
+        --AWS_OFI_NCCL_VER=?*) AWS_OFI_NCCL_VER="${i#*=}";;
+        *) ;;
+    esac
+    shift
+done
+
+PREFIX="/opt/amazon/ofi-nccl"
+SRC_DIR="$(mktemp -d)"
+
+apt-get update
+apt-get install -y --no-install-recommends \
+    git ca-certificates build-essential autoconf automake libtool libhwloc-dev
+apt-get clean
+rm -rf /var/lib/apt/lists/*
+
+git clone --depth 1 --branch "${AWS_OFI_NCCL_VER}" \
+    https://github.com/aws/aws-ofi-nccl.git "${SRC_DIR}"
+
+pushd "${SRC_DIR}"
+./autogen.sh
+# libfabric ships under /opt/amazon/efa; NCCL headers/lib come from libnccl-dev in
+# the system prefix (/usr). --enable-platform-aws pulls in the EFA tunings.
+./configure \
+    --prefix="${PREFIX}" \
+    --with-libfabric=/opt/amazon/efa \
+    --with-cuda=/usr/local/cuda \
+    --with-nccl=/usr \
+    --enable-platform-aws \
+    --disable-tests
+make -j"$(nproc)"
+make install
+popd
+
+# Revive the ldconfig entry the base image left behind so a bare `libnccl-net.so`
+# lookup can also resolve here; EKSEnvPlugin still pins the absolute path.
+echo "${PREFIX}/lib" > /etc/ld.so.conf.d/aws-ofi-nccl.conf
+ldconfig
+
+rm -rf "${SRC_DIR}"

--- a/scripts/performance/utils/csp_plugins.py
+++ b/scripts/performance/utils/csp_plugins.py
@@ -34,6 +34,14 @@ from nemo_run import Plugin
 from nemo_run.core.execution.kubeflow import KubeflowExecutor
 
 
+# Absolute path to the aws-ofi-nccl EFA net plugin in the FW image (installed by
+# docker/common/install_aws_ofi_nccl.sh). NVIDIA PyTorch >= 26.06 base images drop
+# aws-ofi-nccl and default NCCL_NET_PLUGIN=spcx (HPCX Spectrum-X), which cannot
+# drive EFA. Pinning the absolute path forces NCCL back onto aws-ofi and is
+# unambiguous (the image also ships HPCX libnccl-net.so on the ldconfig path).
+AWS_OFI_NCCL_NET_PLUGIN = "/opt/amazon/ofi-nccl/lib/libnccl-net.so"
+
+
 @dataclass(kw_only=True)
 class EKSEnvPlugin(Plugin):
     """AWS EKS (EFA) fabric.
@@ -41,9 +49,9 @@ class EKSEnvPlugin(Plugin):
     Selecting this plugin means the job runs on an EFA-equipped EKS cluster, so
     EFA is enabled unconditionally: the pod requests EFA devices, runs
     privileged with the host RDMA device nodes mounted, and NCCL uses the
-    aws-ofi / libfabric EFA provider. NCCL discovers the aws-ofi plugin and
-    libfabric via the image's ldconfig (``/etc/ld.so.conf.d``), so no
-    ``LD_LIBRARY_PATH`` override is needed.
+    aws-ofi / libfabric EFA provider. The plugin pins ``NCCL_NET_PLUGIN`` to the
+    aws-ofi net plugin because newer base images default it to ``spcx`` (HPCX
+    Spectrum-X), which cannot drive EFA and silently degrades NCCL to TCP.
 
     Attributes:
         efa_device_count: ``vpc.amazonaws.com/efa`` devices requested per node.
@@ -58,9 +66,11 @@ class EKSEnvPlugin(Plugin):
         efa = {"vpc.amazonaws.com/efa": str(self.efa_device_count)}
         executor.extra_resource_requests = {**executor.extra_resource_requests, **efa}
         executor.extra_resource_limits = {**executor.extra_resource_limits, **efa}
-        # libfabric EFA provider; NCCL loads the aws-ofi net plugin from ldconfig.
+        # libfabric EFA provider + the aws-ofi net plugin (overriding the base
+        # image's spcx default, which does not speak EFA).
         executor.env_vars.setdefault("FI_PROVIDER", "efa")
         executor.env_vars.setdefault("FI_EFA_USE_HUGE_PAGE", "0")
+        executor.env_vars.setdefault("NCCL_NET_PLUGIN", AWS_OFI_NCCL_NET_PLUGIN)
         # EFA requires a privileged container and the host /dev/infiniband nodes.
         security_context = {**executor.container_kwargs.get("securityContext", {}), "privileged": True}
         executor.container_kwargs = {**executor.container_kwargs, "securityContext": security_context}

--- a/tests/unit_tests/scripts/performance/test_csp_plugins.py
+++ b/tests/unit_tests/scripts/performance/test_csp_plugins.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for scripts/performance/utils/csp_plugins.py — CSP fabric plugins."""
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+# scripts/performance is not an installed package; add it to sys.path so we can
+# import ``utils.csp_plugins`` the same way the scripts themselves do.
+_PERF_SCRIPTS_DIR = Path(__file__).resolve().parents[4] / "scripts" / "performance"
+if str(_PERF_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_PERF_SCRIPTS_DIR))
+
+try:
+    import nemo_run  # noqa: F401
+    from nemo_run.core.execution.kubeflow import KubeflowExecutor
+
+    HAS_NEMO_RUN = True
+except ImportError:
+    HAS_NEMO_RUN = False
+
+if HAS_NEMO_RUN:
+    from utils.csp_plugins import AWS_OFI_NCCL_NET_PLUGIN, EKSEnvPlugin, GKEEnvPlugin
+
+
+@pytest.mark.skipif(not HAS_NEMO_RUN, reason="nemo_run not installed")
+def test_eks_plugin_pins_aws_ofi_and_enables_efa():
+    """The EFA plugin must pin the aws-ofi net plugin and request EFA fabric."""
+    executor = KubeflowExecutor()
+
+    EKSEnvPlugin().setup(task=None, executor=executor)
+
+    assert executor.env_vars["NCCL_NET_PLUGIN"] == AWS_OFI_NCCL_NET_PLUGIN
+    assert executor.env_vars["FI_PROVIDER"] == "efa"
+    assert executor.env_vars["FI_EFA_USE_HUGE_PAGE"] == "0"
+    assert executor.extra_resource_requests["vpc.amazonaws.com/efa"] == "32"
+    assert executor.extra_resource_limits["vpc.amazonaws.com/efa"] == "32"
+    assert executor.container_kwargs["securityContext"]["privileged"] is True
+    assert any(volume.get("name") == "rdma-dev" for volume in executor.volumes)
+
+
+@pytest.mark.skipif(not HAS_NEMO_RUN, reason="nemo_run not installed")
+def test_eks_plugin_respects_preset_net_plugin():
+    """A recipe/user override of NCCL_NET_PLUGIN must win over the aws-ofi default."""
+    executor = KubeflowExecutor(env_vars={"NCCL_NET_PLUGIN": "/custom/libnccl-net.so"})
+
+    EKSEnvPlugin().setup(task=None, executor=executor)
+
+    assert executor.env_vars["NCCL_NET_PLUGIN"] == "/custom/libnccl-net.so"
+
+
+@pytest.mark.skipif(not HAS_NEMO_RUN, reason="nemo_run not installed")
+def test_eks_plugin_is_noop_off_kubeflow():
+    """Selecting EKS on a non-Kubeflow executor must not mutate it."""
+    executor = SimpleNamespace()
+
+    EKSEnvPlugin().setup(task=None, executor=executor)
+
+    assert not hasattr(executor, "env_vars")
+
+
+@pytest.mark.skipif(not HAS_NEMO_RUN, reason="nemo_run not installed")
+def test_gke_plugin_never_sets_net_plugin_and_selects_gib():
+    """GKE fabric attaches gIB and must never touch the aws-ofi NCCL_NET_PLUGIN."""
+    executor = KubeflowExecutor()
+
+    GKEEnvPlugin(rdma_networks=["rdma-0", "rdma-1"]).setup(task=None, executor=executor)
+
+    assert "NCCL_NET_PLUGIN" not in executor.env_vars
+    assert executor.env_vars["NCCL_NET"] == "gIB"
+    assert "networking.gke.io/interfaces" in executor.pod_annotations
+
+
+@pytest.mark.skipif(not HAS_NEMO_RUN, reason="nemo_run not installed")
+def test_gke_plugin_is_noop_without_networks():
+    """A single-block GKE run (no RDMA networks) must not alter fabric env."""
+    executor = KubeflowExecutor()
+
+    GKEEnvPlugin().setup(task=None, executor=executor)
+
+    assert "NCCL_NET" not in executor.env_vars
+    assert "NCCL_NET_PLUGIN" not in executor.env_vars


### PR DESCRIPTION
## Background

The NVIDIA PyTorch base image no longer ships the **aws-ofi-nccl** plugin (the
NCCL ⇆ libfabric bridge for AWS EFA) and now defaults `NCCL_NET_PLUGIN=spcx`
(HPCX Spectrum-X). The EFA/libfabric userspace is still present in the image
(`/opt/amazon/efa`), but without the `aws-ofi-nccl` `libnccl-net.so`, NCCL cannot
run over EFA on EKS. The base even leaves a dangling
`/etc/ld.so.conf.d/aws-ofi-nccl.conf → /opt/amazon/ofi-nccl/lib`.

This restores the plugin and selects it for AWS jobs.

## What changed

- **Image build** rebuilds `aws-ofi-nccl` from source (public
  `github.com/aws/aws-ofi-nccl`, pinned `v1.17.3`) against the reinstalled NCCL and
  the image's libfabric, installing it into `/opt/amazon/ofi-nccl` — the prefix the
  leftover `aws-ofi-nccl.conf` already registers.
- **Launcher** pins `NCCL_NET_PLUGIN` to that plugin for AWS jobs, overriding the
  base image's `spcx` default. GCP is untouched (still selects gIB).

## Details

- `docker/common/install_aws_ofi_nccl.sh` — clones + builds the plugin
  (`--with-libfabric=/opt/amazon/efa --with-cuda=/usr/local/cuda --with-nccl=/usr
  --enable-platform-aws`), installs to `/opt/amazon/ofi-nccl`, refreshes the
  ldconfig entry, `ldconfig`. Version pinned via `--AWS_OFI_NCCL_VER`.
- `docker/Dockerfile.fw_base` — new `ARG AWS_OFI_NCCL_VERSION=v1.17.3`; runs the
  script in `fw_toolkit_builder` right after `install_nccl.sh`, so the plugin links
  against the reinstalled NCCL.
- `scripts/performance/utils/csp_plugins.py` — `EKSEnvPlugin` now
  `setdefault`s `NCCL_NET_PLUGIN=/opt/amazon/ofi-nccl/lib/libnccl-net.so` (absolute
  path — the image also ships an HPCX `libnccl-net.so`, so a bare soname is
  ambiguous). A recipe/user override still wins. `GKEEnvPlugin` unchanged.
- `tests/unit_tests/scripts/performance/test_csp_plugins.py` — new coverage for
  both CSP plugins (previously untested).

## Tested

- `pytest tests/unit_tests/scripts/performance/test_csp_plugins.py` — asserts the
  EKS plugin pins aws-ofi + EFA, respects a pre-set override, and no-ops off
  Kubeflow; the GKE plugin never sets `NCCL_NET_PLUGIN`.
- Image build is validated by CI (requires the FW build + registry).
