### PR TITLE
fix(recipe): stop enabling cuDNN norm by default

### DIFF
--- a/src/megatron/bridge/recipes/utils/environment_utils.py
+++ b/src/megatron/bridge/recipes/utils/environment_utils.py
@@ -25,9 +25,6 @@ COMMON_RECIPE_ENV_VARS: dict[str, str | int | float | bool] = {
     "NCCL_GRAPH_REGISTER": 0,
     # Recipe baselines do not enable NCCL user buffers by default.
     "NCCL_NVLS_ENABLE": 0,
-    # Use cuDNN LayerNorm for the common Transformer Engine baseline.
-    "NVTE_NORM_BWD_USE_CUDNN": 1,
-    "NVTE_NORM_FWD_USE_CUDNN": 1,
     # Let long-running training jobs grow allocator segments when needed.
     "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True",
     # Keep NCCL stream handling consistent across all hardware recipes.

--- a/tests/unit_tests/recipes/test_recipe_environment_defaults.py
+++ b/tests/unit_tests/recipes/test_recipe_environment_defaults.py
@@ -91,8 +91,6 @@ def test_common_recipe_environment_is_small_and_universal():
     assert COMMON_RECIPE_ENV_VARS == {
         "NCCL_GRAPH_REGISTER": 0,
         "NCCL_NVLS_ENABLE": 0,
-        "NVTE_NORM_BWD_USE_CUDNN": 1,
-        "NVTE_NORM_FWD_USE_CUDNN": 1,
         "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True",
         "TORCH_NCCL_AVOID_RECORD_STREAMS": 1,
         "TORCH_NCCL_HIGH_PRIORITY": 1,


### PR DESCRIPTION
# What does this PR do?

Stop common H100 library recipes from selecting Transformer Engine's cuDNN norm backend by default.

The defaults were introduced by #4682 and caused a severe Qwen3.5-VL regression with real MedPix inputs. Performance recipes that explicitly opt into the cuDNN norm backend keep their measured settings.

# Changelog

- Remove `NVTE_NORM_FWD_USE_CUDNN=1` and `NVTE_NORM_BWD_USE_CUDNN=1` from `COMMON_RECIPE_ENV_VARS`.
- Update the common recipe environment unit-test expectation.

# Performance evidence

Measured on 2 nodes / 16 H100 GPUs with a Qwen3.5-VL 0.8B proxy, real MedPix data, sequence length 512, MBS 4, and GBS 64:

| Configuration | Mean of final 4 iterations |
| --- | ---: |
| Old Bridge with the same new MCore revision | 214.3 ms |
| New Bridge defaults | 871.9 ms |
| New Bridge, remove only the FWD cuDNN norm default | 620.8 ms |
| New Bridge, remove only the BWD cuDNN norm default | 432.8 ms |
| New Bridge, remove both norm defaults and retain all other common env settings | 211.6 ms |

The vision forward path increased from about 33 ms to 237-250 ms with the forward cuDNN norm default. Removing both norm defaults restored the old Bridge throughput.

MedPix shuffle order, CPU/GPU padding, the MCore revision, attention changes, MRoPE changes, and `linear_attention_freq` were independently tested and did not explain the regression.

# GitHub Actions CI

The PR is ready for CI.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] Updated the focused unit test.
- [x] No documentation changes are required; this restores the previous runtime default.
- [x] This change does not affect an optional-install component.

Validation:

- `uv run python -m pytest tests/unit_tests/recipes/test_recipe_environment_defaults.py` — 6 passed.
- `uv run pre-commit run --all-files` — passed.

# Additional Information

The two regressing settings remain available for explicit use in performance recipes and user launch environments.
