### PR TITLE
fix(training): include Comet in logger presence gate

### DIFF
--- a/src/megatron/bridge/training/utils/train_utils.py
+++ b/src/megatron/bridge/training/utils/train_utils.py
@@ -718,7 +718,9 @@ def training_log(
     train_config = config.train
     pg_collection = pg_collection or get_pg_collection(model)
 
-    loggers_exist = writer is not None or wandb_writer is not None or mlflow_logger is not None
+    loggers_exist = (
+        writer is not None or wandb_writer is not None or mlflow_logger is not None or comet_logger is not None
+    )
 
     # Advanced, skipped, and Nan iterations.
     advanced_iters_key = "advanced iterations"

--- a/tests/unit_tests/training/utils/test_train_utils.py
+++ b/tests/unit_tests/training/utils/test_train_utils.py
@@ -420,6 +420,56 @@ class TestTrainingLog:
         mock_global_state.tensorboard_logger.add_scalar.assert_called()
         mock_global_state.timers.write.assert_called()
 
+    def test_comet_only_logs_general_training_scalars(self, monkeypatch, mock_config, mock_global_state):
+        """Comet does not require another backend to receive general training scalars."""
+        monkeypatch.setattr(
+            "megatron.bridge.training.utils.train_utils.get_num_microbatches",
+            lambda: 8,
+            raising=True,
+        )
+        monkeypatch.setattr(
+            "megatron.bridge.training.utils.train_utils.reduce_max_stat_across_model_parallel_group",
+            lambda value, mp_group: value,
+            raising=True,
+        )
+
+        mock_config.logger.tensorboard_log_interval = 1
+        mock_config.logger.log_interval = 5
+        mock_config.logger.log_timers_to_tensorboard = False
+        mock_config.logger.log_throughput_to_tensorboard = False
+        mock_config.logger.log_memory_to_tensorboard = False
+        mock_config.logger.log_runtime_to_tensorboard = False
+        mock_config.logger.log_l2_norm_grad_to_tensorboard = False
+        mock_config.logger.log_loss_scale_to_tensorboard = False
+        mock_config.logger.log_world_size_to_tensorboard = False
+
+        mock_global_state.train_state.step = 1
+        mock_global_state.tensorboard_logger = None
+        mock_global_state.wandb_logger = None
+        mock_global_state.mlflow_logger = None
+        comet_logger = mock.MagicMock()
+        mock_global_state.comet_logger = comet_logger
+
+        training_log(
+            loss_dict={},
+            total_loss_dict={},
+            learning_rate=1e-4,
+            decoupled_learning_rate=None,
+            loss_scale=1024.0,
+            report_memory_flag=False,
+            skipped_iter=0,
+            grad_norm=None,
+            params_norm=None,
+            num_zeros_in_grad=None,
+            config=mock_config,
+            global_state=mock_global_state,
+            history_wct=[],
+            model=None,
+        )
+
+        comet_logger.log_metrics.assert_any_call({"learning-rate": 1e-4}, step=1)
+        comet_logger.log_metrics.assert_any_call({"batch-size": 64}, step=1)
+
     @mock.patch("megatron.bridge.training.utils.train_utils.get_num_microbatches")
     @mock.patch("megatron.bridge.training.utils.train_utils.reduce_max_stat_across_model_parallel_group")
     @mock.patch("megatron.bridge.training.utils.train_utils.get_world_size_safe")
@@ -1644,6 +1694,7 @@ class TestTrainingLog:
         mock_global_state.tensorboard_logger = None
         mock_global_state.wandb_logger = None
         mock_global_state.mlflow_logger = None
+        mock_global_state.comet_logger = None
 
         # Set iteration to match logging intervals
         mock_global_state.train_state.step = 10


### PR DESCRIPTION
# What does this PR do?

Allow Comet-only training runs to receive the general scalar stream without requiring TensorBoard, W&B, or MLflow to be enabled.

# Supported trigger and impact

Configure `LoggerConfig` with `comet_project` and `comet_experiment_name` while leaving the other logging backends disabled, then run either the standard or MegatronMIMO training loop. The Comet experiment is created, but loss, learning rate, batch size, norms, and other general training scalars are silently omitted.

# Root cause and fix

`training_log()` retrieves `comet_logger` and contains Comet fan-out calls, but its shared `loggers_exist` gate counted only TensorBoard, W&B, and MLflow. This change includes Comet in that gate. It also updates the existing no-loggers test setup to explicitly disable Comet.

# Changelog

- Include Comet in the general logger-presence gate.
- Add a Comet-only regression test for learning-rate and batch-size emission.
- Preserve the no-loggers negative control.

# Validation

Fail-before on the unmodified base:

`uv run --no-sync python -m pytest tests/unit_tests/training/utils/test_train_utils.py::TestTrainingLog::test_comet_only_logs_general_training_scalars -q`

Result: `1 failed`; `comet_logger.log_metrics` had no calls.

Pass-after with the same regression test:

`uv run --no-sync python -m pytest tests/unit_tests/training/utils/test_train_utils.py::TestTrainingLog::test_comet_only_logs_general_training_scalars -q`

Result: `1 passed`.

Adjacent Comet configuration, state, timer, and checkpoint tests:

`uv run --no-sync python -m pytest tests/unit_tests/training/test_config.py::TestLoggerConfigFinalize tests/unit_tests/training/test_state.py::TestCometLoggerProperty tests/unit_tests/training/test_state.py::TestTimersWriteToComet tests/unit_tests/training/utils/test_comet_utils.py -q`

Result: `34 passed`.

Adjacent MoE/MTP fan-out tests:

`uv run --no-sync python -m pytest tests/unit_tests/training/utils/test_train_utils.py::TestMoeMetricFanoutWriter -q`

Result: `8 passed`.

`git diff --check` and `uv run --no-sync pre-commit run --all-files` passed.

# Scope limitations

This is a focused logger-gate fix. No public API, dependency, workflow, MCore, checkpoint, distributed, or model behavior changes are included. The full test suite, GPU integration, model quality, convergence, and performance were not run or claimed.