### PR TITLE
fix(recipe): preserve Llama low-precision compatibility

### DIFF
--- a/src/megatron/bridge/recipes/llama/llama3.py
+++ b/src/megatron/bridge/recipes/llama/llama3.py
@@ -16,6 +16,8 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from megatron.bridge.recipes.llama.h100.llama3 import (
     llama3_8b_peft_1gpu_h100_bf16_config as llama3_8b_peft_config,
 )
@@ -23,7 +25,13 @@ from megatron.bridge.recipes.llama.h100.llama3 import (
     llama3_8b_pretrain_2gpu_h100_bf16_config as llama3_8b_pretrain_config,
 )
 from megatron.bridge.recipes.llama.h100.llama3 import (
-    llama3_8b_pretrain_2gpu_h100_fp8cs_config as llama3_8b_low_precision_pretrain_config,
+    llama3_8b_pretrain_2gpu_h100_fp8cs_config as _llama3_8b_pretrain_2gpu_h100_fp8cs_config,
+)
+from megatron.bridge.recipes.llama.h100.llama3 import (
+    llama3_8b_pretrain_2gpu_h100_fp8mx_config as _llama3_8b_pretrain_2gpu_h100_fp8mx_config,
+)
+from megatron.bridge.recipes.llama.h100.llama3 import (
+    llama3_8b_pretrain_2gpu_h100_nvfp4_config as _llama3_8b_pretrain_2gpu_h100_nvfp4_config,
 )
 from megatron.bridge.recipes.llama.h100.llama3 import (
     llama3_8b_pretrain_16gpu_h100_bf16_16k_config as llama3_8b_16k_pretrain_config,
@@ -103,6 +111,36 @@ from megatron.bridge.recipes.llama.h100.llama3 import (
 from megatron.bridge.recipes.llama.h100.llama3 import (
     llama32_3b_sft_1gpu_h100_bf16_config as llama32_3b_sft_config,
 )
+
+
+if TYPE_CHECKING:
+    from megatron.bridge.training.config import ConfigContainer
+
+
+def llama3_8b_low_precision_pretrain_config(
+    mixed_precision_recipe: str = "bf16_with_fp8_current_scaling_mixed",
+) -> "ConfigContainer":
+    """Return a low-precision Llama 3 8B pre-training config.
+
+    Args:
+        mixed_precision_recipe: Low-precision recipe to use.
+
+    Returns:
+        Llama 3 8B pre-training configuration.
+
+    Raises:
+        ValueError: If ``mixed_precision_recipe`` is not supported.
+    """
+    recipes = {
+        "bf16_with_fp8_current_scaling_mixed": _llama3_8b_pretrain_2gpu_h100_fp8cs_config,
+        "bf16_with_mxfp8_mixed": _llama3_8b_pretrain_2gpu_h100_fp8mx_config,
+        "bf16_with_nvfp4_mixed": _llama3_8b_pretrain_2gpu_h100_nvfp4_config,
+    }
+    try:
+        recipe = recipes[mixed_precision_recipe]
+    except KeyError as error:
+        raise ValueError(f"Unsupported low-precision recipe: {mixed_precision_recipe}") from error
+    return recipe()
 
 
 __all__ = [

--- a/tests/unit_tests/recipes/test_llama_recipe_compatibility.py
+++ b/tests/unit_tests/recipes/test_llama_recipe_compatibility.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import ast
+import importlib.util
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+_CANONICAL_MODULE_NAME = "megatron.bridge.recipes.llama.h100.llama3"
+_COMPATIBILITY_MODULE_PATH = (
+    Path(__file__).parents[3] / "src" / "megatron" / "bridge" / "recipes" / "llama" / "llama3.py"
+)
+_LOW_PRECISION_RECIPES = (
+    ("bf16_with_fp8_current_scaling_mixed", "fp8cs"),
+    ("bf16_with_mxfp8_mixed", "fp8mx"),
+    ("bf16_with_nvfp4_mixed", "nvfp4"),
+)
+_RECIPE_ENV_VARS = {"NVTE_FUSED_ATTN": "1"}
+
+
+def _load_compatibility_module(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
+    source = _COMPATIBILITY_MODULE_PATH.read_text()
+    syntax_tree = ast.parse(source)
+    canonical_module = ModuleType(_CANONICAL_MODULE_NAME)
+
+    def _canonical_recipe() -> str:
+        return "canonical"
+
+    for node in ast.walk(syntax_tree):
+        if isinstance(node, ast.ImportFrom) and node.module == _CANONICAL_MODULE_NAME:
+            for imported_name in node.names:
+                setattr(canonical_module, imported_name.name, _canonical_recipe)
+
+    def _low_precision_recipe(name: str) -> Callable[[], dict[str, object]]:
+        def _recipe() -> dict[str, object]:
+            return {"name": name, "env_vars": _RECIPE_ENV_VARS}
+
+        return _recipe
+
+    canonical_module.llama3_8b_pretrain_2gpu_h100_fp8cs_config = _low_precision_recipe("fp8cs")
+    canonical_module.llama3_8b_pretrain_2gpu_h100_fp8mx_config = _low_precision_recipe("fp8mx")
+    canonical_module.llama3_8b_pretrain_2gpu_h100_nvfp4_config = _low_precision_recipe("nvfp4")
+    monkeypatch.setitem(sys.modules, _CANONICAL_MODULE_NAME, canonical_module)
+
+    spec = importlib.util.spec_from_file_location("llama3_compatibility_under_test", _COMPATIBILITY_MODULE_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    compatibility_module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(compatibility_module)
+    return compatibility_module
+
+
+@pytest.mark.parametrize(("mixed_precision_recipe", "expected_name"), _LOW_PRECISION_RECIPES)
+def test_llama3_8b_low_precision_legacy_alias_preserves_selector(
+    monkeypatch: pytest.MonkeyPatch, mixed_precision_recipe: str, expected_name: str
+) -> None:
+    compatibility_module = _load_compatibility_module(monkeypatch)
+
+    config = compatibility_module.llama3_8b_low_precision_pretrain_config(
+        mixed_precision_recipe=mixed_precision_recipe
+    )
+
+    assert config == {"name": expected_name, "env_vars": _RECIPE_ENV_VARS}
+
+
+def test_llama3_8b_low_precision_legacy_alias_preserves_parameterless_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    compatibility_module = _load_compatibility_module(monkeypatch)
+
+    config = compatibility_module.llama3_8b_low_precision_pretrain_config()
+
+    assert config == {"name": "fp8cs", "env_vars": _RECIPE_ENV_VARS}
+
+
+def test_unrelated_llama3_legacy_alias_remains_parameterless(monkeypatch: pytest.MonkeyPatch) -> None:
+    compatibility_module = _load_compatibility_module(monkeypatch)
+
+    assert compatibility_module.llama3_8b_pretrain_config() == "canonical"


### PR DESCRIPTION
## Summary

- preserve legacy Llama 3 8B low-precision selector calls
- retain the current parameterless FP8 current-scaling default
- route through canonical FP8CS, MXFP8, and NVFP4 builders so recipe environment settings remain intact

## User impact and root cause

The public compatibility name previously accepted a mixed_precision_recipe selector. After the hardware recipe reorganization, that name directly referenced the zero-argument FP8 current-scaling builder. Supported legacy calls such as:

    llama3_8b_low_precision_pretrain_config("bf16_with_mxfp8_mixed")

therefore raised TypeError, and MXFP8 or NVFP4 could no longer be selected through the compatibility API.

This change replaces the direct alias with a small compatibility dispatcher. Calling it without an argument retains the current FP8 current-scaling behavior; all three supported selector values call their canonical public H100 builders.

## Validation

Fail-before on unmodified main:

    uv run --no-project --python 3.12 --with pytest python -m pytest --confcutdir=tests/unit_tests/recipes tests/unit_tests/recipes/test_llama_recipe_compatibility.py -q

Result: 3 failed, 2 passed. All selector cases failed with unexpected mixed_precision_recipe; parameterless controls passed.

Pass-after with this change:

    uv run --no-project --python 3.12 --with pytest python -m pytest --confcutdir=tests/unit_tests/recipes tests/unit_tests/recipes/test_llama_recipe_compatibility.py -q

Result: 5 passed.

Additional checks:

    git diff --check
    uv run --no-project --python 3.12 --with pre-commit==3.6.0 pre-commit run --all-files

Result: passed; all pre-commit hooks passed.

## Scope

This only restores compatibility routing. It does not change canonical recipe defaults, precision configuration, training semantics, or hardware sizing.