### PR TITLE
feat(training): add VR200 memory clock lock

### DIFF
--- a/scripts/training/README.md
+++ b/scripts/training/README.md
@@ -254,6 +254,10 @@ target cluster. For example, a Pyxis/Enroot cluster may use:
 
 The `=` form is required when `ARG` begins with `-`.
 
+Use `-lmc FREQ`, `--peak-mem-clk FREQ`, or `--peak_mem_clk FREQ` to lock the GPU memory clock to a fixed frequency in
+MHz once per node before training. VR200 benchmark recipes default to `4752`; other recipes leave the memory clock
+unlocked. Pass `-lmc -1` to disable the VR200 default explicitly.
+
 The compact launcher does not add rank-command prefixes or extra sbatch parameters such as `segment`. Configure those
 through the target cluster integration, or use `scripts/performance/setup_experiment.py` when its compatibility NUMA
 and segment policies are required.

--- a/scripts/training/setup_experiment.py
+++ b/scripts/training/setup_experiment.py
@@ -20,6 +20,7 @@ import os
 import shlex
 import sys
 from pathlib import Path
+from typing import Any
 
 import nemo_run as run
 from nemo_run.config import get_nemorun_home
@@ -104,6 +105,18 @@ Arguments not owned by this launcher are forwarded unchanged to run_recipe.py.
         metavar="ARG",
         help="Additional cluster-specific argument passed to srun; may be repeated. Use --srun-arg=--flag.",
     )
+    execution.add_argument(
+        "-lmc",
+        "--peak-mem-clk",
+        "--peak_mem_clk",
+        type=int,
+        default=None,
+        dest="peak_mem_clk",
+        help=(
+            "Lock the GPU memory clock to a fixed frequency in MHz once per node. "
+            "Defaults to 4752 for VR200 benchmark recipes and is disabled otherwise; pass -1 to disable the default."
+        ),
+    )
     execution.add_argument("--experiment-name", help="NeMo-Run experiment name.")
     execution.add_argument(
         "--submission-dry-run",
@@ -181,6 +194,48 @@ def _task_environment() -> dict[str, str]:
     }
 
 
+def _resolve_peak_mem_clk(
+    requested_peak_mem_clk: int | None,
+    benchmark_metadata: BenchmarkRecipeMetadata | None,
+) -> int | None:
+    """Resolve the explicit memory clock or the VR200 benchmark default."""
+    if requested_peak_mem_clk == -1:
+        return None
+    if requested_peak_mem_clk is not None:
+        return requested_peak_mem_clk
+    if benchmark_metadata is not None and benchmark_metadata.hardware == "vr200":
+        return 4752
+    return None
+
+
+def _configure_slurm_peak_mem_clk(executor: Any, peak_mem_clk: int | None) -> None:
+    """Add a once-per-node GPU memory-clock lock to a Slurm executor."""
+    if peak_mem_clk is None:
+        return
+
+    command = "\n".join(
+        [
+            "",
+            "# Lock GPU memory clock",
+            " ".join(
+                [
+                    "srun",
+                    f"--ntasks={executor.nodes}",
+                    "--ntasks-per-node=1",
+                    "--output",
+                    os.path.join(executor.tunnel.job_dir, "peak_mem_clock.out"),
+                    "--error",
+                    os.path.join(executor.tunnel.job_dir, "peak_mem_clock.err"),
+                    "bash -c",
+                    shlex.quote(f"sudo nvidia-smi -lmc {peak_mem_clk},{peak_mem_clk}"),
+                ]
+            ),
+            "",
+        ]
+    )
+    executor.setup_lines = f"{executor.setup_lines or ''}{command}"
+
+
 def _build_executor(
     args: argparse.Namespace,
     env_names: list[str],
@@ -240,6 +295,8 @@ def main(argv: list[str] | None = None) -> None:
     mounts = _parse_mounts(args.mount)
     task_environment = _task_environment()
     executor = _build_executor(args, env_names, mounts, task_environment=task_environment)
+    peak_mem_clk = _resolve_peak_mem_clk(args.peak_mem_clk, benchmark_metadata)
+    _configure_slurm_peak_mem_clk(executor, peak_mem_clk)
 
     task = run.Script(
         path=str(CONTAINER_REPO_ROOT / "scripts/training/run_recipe.py"),

--- a/tests/unit_tests/scripts/training/test_setup_experiment.py
+++ b/tests/unit_tests/scripts/training/test_setup_experiment.py
@@ -212,6 +212,118 @@ def test_parser_consumes_repeatable_srun_args():
     assert training_args == ["--recipe", "gpt_oss_20b_pretrain_config"]
 
 
+@pytest.mark.parametrize("option", ["-lmc", "--peak-mem-clk", "--peak_mem_clk"])
+def test_parser_consumes_peak_mem_clk(option):
+    module = _load_setup_experiment_module()
+
+    args, training_args = module.parse_args(
+        [
+            option,
+            "2600",
+            "--recipe",
+            "gpt_oss_20b_pretrain_config",
+        ]
+    )
+
+    assert args.peak_mem_clk == 2600
+    assert training_args == ["--recipe", "gpt_oss_20b_pretrain_config"]
+
+
+@pytest.mark.parametrize(
+    ("requested_peak_mem_clk", "hardware", "expected"),
+    [
+        (None, "vr200", 4752),
+        (None, "h100", None),
+        (2600, "vr200", 2600),
+        (-1, "vr200", None),
+    ],
+)
+def test_peak_mem_clk_resolution(requested_peak_mem_clk, hardware, expected):
+    module = _load_setup_experiment_module()
+    metadata = types.SimpleNamespace(hardware=hardware)
+
+    assert module._resolve_peak_mem_clk(requested_peak_mem_clk, metadata) == expected
+
+
+def test_peak_mem_clk_resolution_without_benchmark_metadata():
+    module = _load_setup_experiment_module()
+
+    assert module._resolve_peak_mem_clk(None, None) is None
+    assert module._resolve_peak_mem_clk(2600, None) == 2600
+
+
+def test_peak_mem_clk_is_applied_once_per_slurm_node():
+    module = _load_setup_experiment_module()
+    executor = types.SimpleNamespace(
+        nodes=2,
+        tunnel=types.SimpleNamespace(job_dir="/job/dir"),
+        setup_lines="existing setup\n",
+    )
+
+    module._configure_slurm_peak_mem_clk(executor, 4752)
+
+    assert executor.setup_lines.startswith("existing setup\n")
+    assert "srun --ntasks=2 --ntasks-per-node=1 --output /job/dir/peak_mem_clock.out" in executor.setup_lines
+    assert "--error /job/dir/peak_mem_clock.err" in executor.setup_lines
+    assert "sudo nvidia-smi -lmc 4752,4752" in executor.setup_lines
+
+
+def test_main_applies_vr200_peak_mem_clk_default(monkeypatch):
+    module = _load_setup_experiment_module()
+    configured_clocks = []
+    sentinel_executor = object()
+
+    class _Script:
+        def __init__(self, **_kwargs):
+            pass
+
+    class _Experiment:
+        def __init__(self, _name):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            pass
+
+        def add(self, _task, *, executor, name):
+            assert executor is sentinel_executor
+            assert name == "training"
+
+        def dryrun(self):
+            pass
+
+    module.run.Script = _Script
+    module.run.Experiment = _Experiment
+    monkeypatch.setattr(module, "_build_executor", lambda *_args, **_kwargs: sentinel_executor)
+    monkeypatch.setattr(
+        module,
+        "_configure_slurm_peak_mem_clk",
+        lambda executor, peak_mem_clk: configured_clocks.append((executor, peak_mem_clk)),
+    )
+
+    module.main(
+        [
+            "--nodes",
+            "1",
+            "--gpus-per-node",
+            "8",
+            "--account",
+            "account",
+            "--partition",
+            "partition",
+            "--container-image",
+            "image.sqsh",
+            "--submission-dry-run",
+            "--recipe",
+            "qwen3_30b_a3b_pretrain_8gpu_vr200_bf16_config",
+        ]
+    )
+
+    assert configured_clocks == [(sentinel_executor, 4752)]
+
+
 def test_srun_args_reject_empty_values():
     module = _load_setup_experiment_module()
     args, _ = module.parse_args(["--srun-arg="])


### PR DESCRIPTION
## Summary

- mirror the GPU memory-clock control from #4920 into the compact scripts/training Slurm launcher
- default VR200 benchmark recipes to 4752 MHz, while allowing explicit overrides and -1 to disable
- run the lock once per node before training and keep launcher-only arguments out of run_recipe.py
- document the training CLI and cover parser, resolution, Slurm command, and main wiring

## Testing

- uv run python -m pytest tests/unit_tests/scripts/training/test_setup_experiment.py (45 passed)
- uv run pre-commit run --all-files