### PR TITLE
fix(conversion): reject source-dependent CPU export early

### DIFF
--- a/examples/model_verification_cards/minimax-m3-text-only/card.yaml
+++ b/examples/model_verification_cards/minimax-m3-text-only/card.yaml
@@ -1,37 +1,35 @@
 # Agent-readable model verification card.
 # status: unverified | verified | unsupported | not_applicable
 
-title: minimax_m3
+title: minimax_m3_text_only
 summary: >
   Performance disclaimer: this model has not been performance-tuned; reported
   timing and throughput metrics are sanity checks, not optimized performance
-  results. MiniMax-M3 verification covers the supported language-model backbone;
-  its vision, lightning-indexer, and MTP modules are outside the Bridge support
-  surface. A persisted 32-H100 BF16 HF-to-Megatron import and reload exactly
-  matched all 22,665 supported tensors and all 597 replicated state tensors
-  across the 32 EP ranks; 228 lightning-indexer tensors were intentionally
-  omitted. A MiniMax-M3-specific router cast now preserves the checkpoint's FP32
+  results. This is the MiniMax-M3 text-only verification card: every claim is
+  limited to the supported language-model backbone. Vision, projector,
+  lightning-indexer, and MTP behavior is outside the verification surface. A
+  persisted 32-H100 BF16 HF-to-Megatron import and reload exactly matched all
+  22,665 supported text tensors and all 597 replicated state tensors across the
+  32 EP ranks. A MiniMax-M3-specific router cast preserves the checkpoint's FP32
   gate computation when BF16 hidden states reach Transformer Engine. Two clean,
   independent 32-H100 Megatron executions reloaded the persisted checkpoint,
   completed exactly 64 greedy generation steps apiece, and produced
-  byte-identical decoded completions. At the inference commit, all 29 focused
-  MiniMax-M3 bridge tests and the repository pre-commit checks pass.
+  byte-identical decoded completions. Persisted Megatron-to-HF conversion remains
+  unverified until a strict source-overlay export and reload completes.
 verification_index:
   model_level:
     verified: [hf_to_megatron_gpu, inference]
-    unverified: [hf_to_megatron_cpu, manual_forward_pass]
-    unsupported: [megatron_to_hf_cpu, megatron_to_hf_gpu]
+    unverified: [hf_to_megatron_cpu, megatron_to_hf_gpu, manual_forward_pass]
+    unsupported: [megatron_to_hf_cpu]
   training:
     H100:
-      unverified: [pretrain, sft, sft_long_context, peft, checkpoint_resume]
-      unsupported: [sft_export_inference]
+      unverified: all
     GB200:
-      unverified: [pretrain, sft, sft_long_context, peft, checkpoint_resume]
-      unsupported: [sft_export_inference]
+      unverified: all
 model:
   hf_id: MiniMaxAI/MiniMax-M3
   hf_revision: 50942730318c7943fe83db7ec8e9f9177ecb1cf8  # pragma: allowlist secret
-  architecture: MiniMaxM3SparseForConditionalGeneration
+  architecture: MiniMaxM3SparseForCausalLM
   min_transformers_version: "5.8.1"
 verification_environment:
   base_container: nvcr.io/nvidia/pytorch:26.04-py3
@@ -56,7 +54,7 @@ items:
       ./scripts/conversion/convert.sh import --executor slurm --device gpu
       --nodes 4 --gpus-per-node 8 --hf-model MiniMaxAI/MiniMax-M3
       --hf-revision 50942730318c7943fe83db7ec8e9f9177ecb1cf8
-      --megatron-path work/model-verification/minimax-m3/imported-megatron
+      --megatron-path work/model-verification/minimax-m3-text-only/imported-megatron
       --torch-dtype bfloat16 --tp 1 --pp 1 --ep 32 --etp 1
       --trust-remote-code
     last_verified: 2026-07-21
@@ -75,19 +73,22 @@ items:
     command: null
     last_verified: null
     expected_result: >
-      Standalone Hugging Face export is intentionally unsupported because the
-      Bridge converts only the language backbone and omits the checkpoint's
-      vision tower, projector, lightning indexer, and multimodal configuration.
+      The current single-process config-only CPU exporter cannot provide the
+      pinned source checkpoint required to preserve MiniMax-M3's unbridged
+      tensors. Use the distributed GPU source-overlay path for persisted export.
 
   megatron_to_hf_gpu:
-    status: unsupported
-    precision: null
+    status: unverified
+    precision: bf16
     command: null
     last_verified: null
     expected_result: >
-      Distributed standalone Hugging Face export is intentionally unsupported
-      because the Bridge cannot reconstruct the omitted multimodal modules and
-      configuration into a complete MiniMax-M3 checkpoint.
+      A pinned distributed source-overlay export must replace all 22,665
+      supported text tensors and preserve all 751 unbridged vision, projector,
+      patch-merge, and lightning-indexer tensors byte-for-byte. The persisted HF
+      artifact must contain exactly 23,416 indexed tensors, reload successfully,
+      and have zero missing, unexpected, shape, dtype, or value mismatches in a
+      strict supported-text audit.
 
   manual_forward_pass:
     status: unverified
@@ -108,7 +109,7 @@ items:
       uv run python examples/conversion/hf_to_megatron_generate_text.py
       --hf_model_path MiniMaxAI/MiniMax-M3
       --hf-revision 50942730318c7943fe83db7ec8e9f9177ecb1cf8
-      --megatron_model_path work/model-verification/minimax-m3/imported-megatron/iter_0000000
+      --megatron_model_path work/model-verification/minimax-m3-text-only/imported-megatron/iter_0000000
       --tp 1 --pp 1 --ep 32 --etp 1
       --prompt "Write a detailed 500-word explanation of why the sky appears blue."
       --max_new_tokens 64 --apply-chat-template --thinking-mode disabled
@@ -158,16 +159,16 @@ items:
         all four metrics, and a reloadable final checkpoint.
 
   sft_export_inference:
-    all:
-      status: unsupported
-      precision: null
+    H100:
+      status: unverified
+      precision: bf16
       depends_on: sft
       commands: null
       last_verified: null
       expected_result: >
-        Post-SFT Hugging Face export and native Hugging Face inference are
-        unsupported on every hardware target because standalone Hugging Face
-        export cannot reconstruct the complete multimodal checkpoint.
+        Export the verified H100 full-SFT checkpoint through the strict
+        source-overlay path, reload the resulting checkpoint with Transformers,
+        and require two greedy fixed-length text generations to be byte-identical.
 
   sft_long_context:
     H100:

--- a/examples/model_verification_cards/minimax-m3-text-only/card.yaml
+++ b/examples/model_verification_cards/minimax-m3-text-only/card.yaml
@@ -14,12 +14,17 @@ summary: >
   gate computation when BF16 hidden states reach Transformer Engine. Two clean,
   independent 32-H100 Megatron executions reloaded the persisted checkpoint,
   completed exactly 64 greedy generation steps apiece, and produced
-  byte-identical decoded completions. Persisted Megatron-to-HF conversion remains
-  unverified until a strict source-overlay export and reload completes.
+  byte-identical decoded completions. A persisted 32-H100 BF16 Megatron-to-HF
+  source-overlay export wrote exactly 23,416 indexed tensors
+  (854,172,958,720 bytes). A strict persisted-output audit matched all 22,665
+  mapped text tensors at exact shape, dtype, and expected value, including a
+  declared Megatron-side provenance sentinel, and preserved all 751 unbridged
+  tensors byte-for-byte. The exported config, tokenizer, processor, custom code,
+  and provider semantics matched the canonical pinned-source expectations.
 verification_index:
   model_level:
-    verified: [hf_to_megatron_gpu, inference]
-    unverified: [hf_to_megatron_cpu, megatron_to_hf_gpu, manual_forward_pass]
+    verified: [hf_to_megatron_gpu, megatron_to_hf_gpu, inference]
+    unverified: [hf_to_megatron_cpu, manual_forward_pass]
     unsupported: [megatron_to_hf_cpu]
   training:
     H100:
@@ -33,7 +38,7 @@ model:
   min_transformers_version: "5.8.1"
 verification_environment:
   base_container: nvcr.io/nvidia/pytorch:26.04-py3
-  bridge_commit: 58f72364644ea83f3c683a0cbe9fa6c0f9f3f525  # pragma: allowlist secret
+  bridge_commit: 2863ff4ca17d8fd0a848683ef9b8550acc6ee73c  # pragma: allowlist secret
 
 items:
   hf_to_megatron_cpu:
@@ -78,17 +83,32 @@ items:
       tensors. Use the distributed GPU source-overlay path for persisted export.
 
   megatron_to_hf_gpu:
-    status: unverified
+    status: verified
     precision: bf16
-    command: null
-    last_verified: null
+    command: >
+      ./scripts/conversion/convert.sh export --executor slurm --device gpu
+      --nodes 4 --gpus-per-node 8 --hf-model MiniMaxAI/MiniMax-M3
+      --hf-revision 50942730318c7943fe83db7ec8e9f9177ecb1cf8
+      --megatron-path work/model-verification/minimax-m3-text-only/imported-megatron/iter_0000000
+      --hf-path work/model-verification/minimax-m3-text-only/exported-hf
+      --torch-dtype bfloat16 --tp 1 --pp 1 --ep 32 --etp 1
+      --trust-remote-code --distributed-save --save-every-n-ranks 1
+      --distributed-timeout-minutes 120 --no-progress
+    last_verified: 2026-07-22
     expected_result: >
-      A pinned distributed source-overlay export must replace all 22,665
-      supported text tensors and preserve all 751 unbridged vision, projector,
-      patch-merge, and lightning-indexer tensors byte-for-byte. The persisted HF
-      artifact must contain exactly 23,416 indexed tensors, reload successfully,
-      and have zero missing, unexpected, shape, dtype, or value mismatches in a
-      strict supported-text audit.
+      The pinned 32-H100 BF16 source-overlay export wrote 59 safetensors shards
+      containing exactly 23,416 indexed tensors and 854,172,958,720 bytes. A
+      strict persisted-output audit matched all 22,665 mapped text tensors at
+      exact shape, dtype, and expected value: 22,664 were source-equal and the
+      declared final-layernorm provenance sentinel changed from source 1.125 to
+      exported 42.0. All 751 unbridged vision, projector, patch-merge, and
+      lightning-indexer tensors remained byte-identical. There were zero
+      duplicate, missing, unexpected, shard, index, shape, dtype, or value
+      mismatches. AutoBridge reconstructed the exact provider semantics, and the
+      config, tokenizer, processor, and custom-code artifacts matched the
+      canonical pinned-source save. This verifies persisted safetensors and
+      Bridge config/provider reopening, not native Transformers model
+      instantiation.
 
   manual_forward_pass:
     status: unverified

--- a/examples/model_verification_cards/minimax-m3/card.yaml
+++ b/examples/model_verification_cards/minimax-m3/card.yaml
@@ -10,16 +10,16 @@ summary: >
   surface. A persisted 32-H100 BF16 HF-to-Megatron import and reload exactly
   matched all 22,665 supported tensors and all 597 replicated state tensors
   across the 32 EP ranks; 228 lightning-indexer tensors were intentionally
-  omitted. Deterministic inference remains unverified: the first forward reached
-  an unsupported BF16-input/FP32-router-weight Transformer Engine general-GEMM
-  tuple, so no completion was produced and the second run did not start. At the
-  recorded Bridge commit, all 32 focused bridge, generation-helper, and
-  AutoBridge registration tests pass, and a pinned real-config and tokenizer
-  smoke resolves the recorded HF commit under Transformers 5.8.1.
+  omitted. A MiniMax-M3-specific router cast now preserves the checkpoint's FP32
+  gate computation when BF16 hidden states reach Transformer Engine. Two clean,
+  independent 32-H100 Megatron executions reloaded the persisted checkpoint,
+  completed exactly 64 greedy generation steps apiece, and produced
+  byte-identical decoded completions. At the inference commit, all 29 focused
+  MiniMax-M3 bridge tests and the repository pre-commit checks pass.
 verification_index:
   model_level:
-    verified: [hf_to_megatron_gpu]
-    unverified: [hf_to_megatron_cpu, manual_forward_pass, inference]
+    verified: [hf_to_megatron_gpu, inference]
+    unverified: [hf_to_megatron_cpu, manual_forward_pass]
     unsupported: [megatron_to_hf_cpu, megatron_to_hf_gpu]
   training:
     H100:
@@ -35,7 +35,7 @@ model:
   min_transformers_version: "5.8.1"
 verification_environment:
   base_container: nvcr.io/nvidia/pytorch:26.04-py3
-  bridge_commit: 52c521427a53d1d0a7a8c0b2d07c9860a4ed7f88  # pragma: allowlist secret
+  bridge_commit: 58f72364644ea83f3c683a0cbe9fa6c0f9f3f525  # pragma: allowlist secret
 
 items:
   hf_to_megatron_cpu:
@@ -51,6 +51,7 @@ items:
   hf_to_megatron_gpu:
     status: verified
     precision: bf16
+    bridge_commit: 52c521427a53d1d0a7a8c0b2d07c9860a4ed7f88  # pragma: allowlist secret
     command: >
       ./scripts/conversion/convert.sh import --executor slurm --device gpu
       --nodes 4 --gpus-per-node 8 --hf-model MiniMaxAI/MiniMax-M3
@@ -101,17 +102,25 @@ items:
       across the required H100 ranks.
 
   inference:
-    status: unverified
+    status: verified
     precision: bf16
-    command: null
-    last_verified: null
-    expected_result: >
-      The 2026-07-21 deterministic attempt stopped at the first forward when
-      BF16 router input and FP32 gate weights reached an unsupported Transformer
-      Engine general-GEMM tuple; no completion was produced and the second run
-      did not start. Verification still requires two independent greedy
-      Megatron executions to complete without missing-weight or forward errors
-      and produce byte-identical decoded fixed-length completions.
+    command: >
+      uv run python examples/conversion/hf_to_megatron_generate_text.py
+      --hf_model_path MiniMaxAI/MiniMax-M3
+      --hf-revision 50942730318c7943fe83db7ec8e9f9177ecb1cf8
+      --megatron_model_path work/model-verification/minimax-m3/imported-megatron/iter_0000000
+      --tp 1 --pp 1 --ep 32 --etp 1
+      --prompt "Write a detailed 500-word explanation of why the sky appears blue."
+      --max_new_tokens 64 --apply-chat-template --thinking-mode disabled
+      --trust-remote-code
+    last_verified: 2026-07-21
+    expected_result: |-
+      Two independent executions on 32 H100s reload the persisted checkpoint
+      in BF16, exit successfully with an exact 64-token greedy result, and
+      produce byte-identical UTF-8 output with no leading or trailing
+      whitespace. The literal completion is "# Why the Sky Appears Blue
+
+      The blue color of the sky is one of the most familiar sights in nature, yet the physics behind it involves a fascinating interplay of light, atmosphere, and human perception. The phenomenon is primarily explained by a process called **Rayleigh scattering**, named after the British physicist Lord Rayleigh,"
 
   pretrain:
     H100:

--- a/examples/model_verification_cards/minimax-m3/card.yaml
+++ b/examples/model_verification_cards/minimax-m3/card.yaml
@@ -1,0 +1,211 @@
+# Agent-readable model verification card.
+# status: unverified | verified | unsupported | not_applicable
+
+title: minimax_m3
+summary: >
+  Performance disclaimer: this model has not been performance-tuned; reported
+  timing and throughput metrics are sanity checks, not optimized performance
+  results. MiniMax-M3 verification covers the supported language-model backbone;
+  its vision, lightning-indexer, and MTP modules are outside the Bridge support
+  surface. Historical 32-H100 in-memory roundtrip and single-run generation
+  results are smoke evidence only and do not satisfy the current persisted-import
+  or deterministic-inference gates. At the recorded Bridge commit, all 32
+  focused bridge, generation-helper, and AutoBridge registration tests pass on
+  the recorded container environment; this sanity result does not promote a
+  real-checkpoint verification item. A pinned real-config and tokenizer smoke
+  also resolves the recorded HF commit under Transformers 5.8.1.
+verification_index:
+  model_level:
+    unverified: [hf_to_megatron_cpu, hf_to_megatron_gpu, manual_forward_pass, inference]
+    unsupported: [megatron_to_hf_cpu, megatron_to_hf_gpu]
+  training:
+    H100:
+      unverified: [pretrain, sft, sft_long_context, peft, checkpoint_resume]
+      unsupported: [sft_export_inference]
+    GB200:
+      unverified: [pretrain, sft, sft_long_context, peft, checkpoint_resume]
+      unsupported: [sft_export_inference]
+model:
+  hf_id: MiniMaxAI/MiniMax-M3
+  hf_revision: 50942730318c7943fe83db7ec8e9f9177ecb1cf8  # pragma: allowlist secret
+  architecture: MiniMaxM3SparseForConditionalGeneration
+  min_transformers_version: "5.8.1"
+verification_environment:
+  base_container: nvcr.io/nvidia/pytorch:26.04-py3
+  bridge_commit: 52c521427a53d1d0a7a8c0b2d07c9860a4ed7f88  # pragma: allowlist secret
+
+items:
+  hf_to_megatron_cpu:
+    status: unverified
+    precision: bf16
+    command: null
+    last_verified: null
+    expected_result: >
+      A pinned CPU import must exit successfully, persist iter_0000000, and
+      reload the complete supported language-model tensor set without missing,
+      unexpected, shape-mismatched, or value-mismatched tensors.
+
+  hf_to_megatron_gpu:
+    status: unverified
+    precision: bf16
+    command: >
+      ./scripts/conversion/convert.sh import --executor slurm --device gpu
+      --nodes 4 --gpus-per-node 8 --hf-model MiniMaxAI/MiniMax-M3
+      --hf-revision 50942730318c7943fe83db7ec8e9f9177ecb1cf8
+      --megatron-path work/model-verification/minimax-m3/imported-megatron
+      --torch-dtype bfloat16 --tp 1 --pp 1 --ep 32 --etp 1
+      --trust-remote-code
+    last_verified: null
+    expected_result: >
+      The pinned 32-H100 import must exit successfully, persist iter_0000000,
+      and reload at TP1/PP1/EP32/ETP1 with every supported language-model tensor
+      accounted for. An in-memory roundtrip alone does not satisfy this gate.
+
+  megatron_to_hf_cpu:
+    status: unsupported
+    precision: null
+    command: null
+    last_verified: null
+    expected_result: >
+      Standalone Hugging Face export is intentionally unsupported because the
+      Bridge converts only the language backbone and omits the checkpoint's
+      vision tower, projector, lightning indexer, and multimodal configuration.
+
+  megatron_to_hf_gpu:
+    status: unsupported
+    precision: null
+    command: null
+    last_verified: null
+    expected_result: >
+      Distributed standalone Hugging Face export is intentionally unsupported
+      because the Bridge cannot reconstruct the omitted multimodal modules and
+      configuration into a complete MiniMax-M3 checkpoint.
+
+  manual_forward_pass:
+    status: unverified
+    precision: bf16
+    command: null
+    last_verified: null
+    expected_result: >
+      Verification requires matching next-token predictions and cosine
+      similarity of at least 0.99 against the pinned Hugging Face revision, with
+      maximum and mean absolute logit differences reported as diagnostics. The
+      current helper cannot shard the approximately 809-GiB Hugging Face model
+      across the required H100 ranks.
+
+  inference:
+    status: unverified
+    precision: bf16
+    command: null
+    last_verified: null
+    expected_result: >
+      Two independent greedy Megatron executions against the pinned revision
+      must complete without missing-weight or forward errors and produce the
+      same exact token IDs and literal fixed-length completion.
+
+  pretrain:
+    H100:
+      status: unverified
+      precision: bf16
+      enabled_features: {}
+      command: null
+      last_verified: null
+      metrics:
+        initial_loss: null
+        final_loss: null
+        last_10_steps_step_time_ms_avg: null
+        last_10_steps_model_tflops_per_gpu_avg: null
+      expected_result: >
+        The public 256-H100 BF16 recipe must complete a bounded 100-step run
+        with finite loss, no skipped or NaN iterations, all four metrics, a
+        persisted post-setup configuration, and a reloadable final checkpoint.
+
+  sft:
+    H100:
+      status: unverified
+      precision: bf16
+      enabled_features:
+        sequence_packing: offline
+      command: null
+      last_verified: null
+      metrics:
+        initial_loss: null
+        final_loss: null
+        last_10_steps_step_time_ms_avg: null
+        last_10_steps_model_tflops_per_gpu_avg: null
+      expected_result: >
+        The public 128-H100 packed BF16 recipe must complete a pinned-data
+        100-step full-SFT run with finite loss, no skipped or NaN iterations,
+        all four metrics, and a reloadable final checkpoint.
+
+  sft_export_inference:
+    all:
+      status: unsupported
+      precision: null
+      depends_on: sft
+      commands: null
+      last_verified: null
+      expected_result: >
+        Post-SFT Hugging Face export and native Hugging Face inference are
+        unsupported on every hardware target because standalone Hugging Face
+        export cannot reconstruct the complete multimodal checkpoint.
+
+  sft_long_context:
+    H100:
+      status: unverified
+      precision: bf16
+      enabled_features:
+        sequence_packing: offline
+      command: null
+      last_verified: null
+      metrics:
+        initial_loss: null
+        final_loss: null
+        last_10_steps_step_time_ms_avg: null
+        last_10_steps_model_tflops_per_gpu_avg: null
+      expected_result: >
+        A dedicated packed long-context recipe must complete 100 steps with
+        context parallelism, finite loss, no skipped or NaN iterations, and all
+        four metrics. Beyond 2,048 tokens, Bridge uses full causal attention
+        instead of MiniMax-M3's lightning-indexer sparse attention.
+
+  peft:
+    H100:
+      status: unverified
+      precision: bf16
+      enabled_features: {}
+      command: null
+      last_verified: null
+      metrics:
+        initial_loss: null
+        final_loss: null
+        last_10_steps_step_time_ms_avg: null
+        last_10_steps_model_tflops_per_gpu_avg: null
+      expected_result: >
+        A MiniMax-M3 PEFT recipe with an audited adapter target set must complete
+        100 steps with finite loss, no skipped or NaN iterations, all four
+        metrics, and a reloadable adapter checkpoint.
+
+  checkpoint_resume:
+    H100:
+      status: unverified
+      precision: bf16
+      depends_on: pretrain
+      command: null
+      last_verified: null
+      metrics:
+        initial_loss: null
+        final_loss: null
+        last_10_steps_step_time_ms_avg: null
+        last_10_steps_model_tflops_per_gpu_avg: null
+      resume_comparison:
+        reference_item: pretrain
+        sentinel_steps: [51, 100]
+        loss_relative_tolerance: 1.0e-2
+        loss_absolute_tolerance: 1.0e-6
+        sentinels_match: null
+      expected_result: >
+        A direct continuation from the bounded pretrain run must restore model,
+        optimizer, scheduler, data-order, and RNG state, execute through the
+        reference final step, match declared sentinel losses within tolerance,
+        and save a reloadable checkpoint to a distinct output root.

--- a/examples/model_verification_cards/minimax-m3/card.yaml
+++ b/examples/model_verification_cards/minimax-m3/card.yaml
@@ -7,16 +7,19 @@ summary: >
   timing and throughput metrics are sanity checks, not optimized performance
   results. MiniMax-M3 verification covers the supported language-model backbone;
   its vision, lightning-indexer, and MTP modules are outside the Bridge support
-  surface. Historical 32-H100 in-memory roundtrip and single-run generation
-  results are smoke evidence only and do not satisfy the current persisted-import
-  or deterministic-inference gates. At the recorded Bridge commit, all 32
-  focused bridge, generation-helper, and AutoBridge registration tests pass on
-  the recorded container environment; this sanity result does not promote a
-  real-checkpoint verification item. A pinned real-config and tokenizer smoke
-  also resolves the recorded HF commit under Transformers 5.8.1.
+  surface. A persisted 32-H100 BF16 HF-to-Megatron import and reload exactly
+  matched all 22,665 supported tensors and all 597 replicated state tensors
+  across the 32 EP ranks; 228 lightning-indexer tensors were intentionally
+  omitted. Deterministic inference remains unverified: the first forward reached
+  an unsupported BF16-input/FP32-router-weight Transformer Engine general-GEMM
+  tuple, so no completion was produced and the second run did not start. At the
+  recorded Bridge commit, all 32 focused bridge, generation-helper, and
+  AutoBridge registration tests pass, and a pinned real-config and tokenizer
+  smoke resolves the recorded HF commit under Transformers 5.8.1.
 verification_index:
   model_level:
-    unverified: [hf_to_megatron_cpu, hf_to_megatron_gpu, manual_forward_pass, inference]
+    verified: [hf_to_megatron_gpu]
+    unverified: [hf_to_megatron_cpu, manual_forward_pass, inference]
     unsupported: [megatron_to_hf_cpu, megatron_to_hf_gpu]
   training:
     H100:
@@ -46,7 +49,7 @@ items:
       unexpected, shape-mismatched, or value-mismatched tensors.
 
   hf_to_megatron_gpu:
-    status: unverified
+    status: verified
     precision: bf16
     command: >
       ./scripts/conversion/convert.sh import --executor slurm --device gpu
@@ -55,11 +58,15 @@ items:
       --megatron-path work/model-verification/minimax-m3/imported-megatron
       --torch-dtype bfloat16 --tp 1 --pp 1 --ep 32 --etp 1
       --trust-remote-code
-    last_verified: null
+    last_verified: 2026-07-21
     expected_result: >
-      The pinned 32-H100 import must exit successfully, persist iter_0000000,
-      and reload at TP1/PP1/EP32/ETP1 with every supported language-model tensor
-      accounted for. An in-memory roundtrip alone does not satisfy this gate.
+      The pinned 32-H100 BF16 import exited successfully, persisted
+      iter_0000000, and reloaded at TP1/PP1/EP32/ETP1. A strict audit matched
+      exactly 22,665 of 22,665 supported language-model tensors with zero
+      duplicate, missing, unexpected, shape, dtype, or value mismatches. All
+      597 replicated state tensors matched exactly across the 32 EP ranks. The
+      228 lightning-indexer tensors were intentionally omitted from the
+      supported Bridge surface.
 
   megatron_to_hf_cpu:
     status: unsupported
@@ -99,9 +106,12 @@ items:
     command: null
     last_verified: null
     expected_result: >
-      Two independent greedy Megatron executions against the pinned revision
-      must complete without missing-weight or forward errors and produce the
-      same exact token IDs and literal fixed-length completion.
+      The 2026-07-21 deterministic attempt stopped at the first forward when
+      BF16 router input and FP32 gate weights reached an unsupported Transformer
+      Engine general-GEMM tuple; no completion was produced and the second run
+      did not start. Verification still requires two independent greedy
+      Megatron executions to complete without missing-weight or forward errors
+      and produce byte-identical decoded fixed-length completions.
 
   pretrain:
     H100:

--- a/scripts/conversion/cpu_backend.py
+++ b/scripts/conversion/cpu_backend.py
@@ -102,12 +102,17 @@ def export_checkpoint(
     if not checkpoint_path.exists():
         raise FileNotFoundError(f"Megatron checkpoint does not exist: {checkpoint_path}")
     config_path = _find_run_config(checkpoint_path)
-    prepare_output_directory(hf_path, overwrite=overwrite, source_paths=[megatron_path, hf_model])
 
     trusted = is_safe_repo(trust_remote_code=trust_remote_code, hf_path=hf_model)
     logger.info("CPU export: %s -> %s", megatron_path, hf_path)
     logger.info("Using Megatron run config: %s", config_path)
     bridge = AutoBridge.from_auto_config(megatron_path, hf_model, trust_remote_code=trusted)
+    if bridge._model_bridge.REQUIRES_HF_SOURCE_FOR_EXPORT:
+        raise NotImplementedError(
+            f"{type(bridge._model_bridge).__name__} export requires the original Hugging Face checkpoint; "
+            "the config-only CPU export path is not supported."
+        )
+    prepare_output_directory(hf_path, overwrite=overwrite, source_paths=[megatron_path, hf_model])
     try:
         bridge.export_ckpt(
             megatron_path=megatron_path,

--- a/scripts/conversion/cpu_backend.py
+++ b/scripts/conversion/cpu_backend.py
@@ -107,11 +107,6 @@ def export_checkpoint(
     logger.info("CPU export: %s -> %s", megatron_path, hf_path)
     logger.info("Using Megatron run config: %s", config_path)
     bridge = AutoBridge.from_auto_config(megatron_path, hf_model, trust_remote_code=trusted)
-    if bridge._model_bridge.REQUIRES_HF_SOURCE_FOR_EXPORT:
-        raise NotImplementedError(
-            f"{type(bridge._model_bridge).__name__} export requires the original Hugging Face checkpoint; "
-            "the config-only CPU export path is not supported."
-        )
     prepare_output_directory(hf_path, overwrite=overwrite, source_paths=[megatron_path, hf_model])
     try:
         bridge.export_ckpt(

--- a/scripts/conversion/cpu_backend.py
+++ b/scripts/conversion/cpu_backend.py
@@ -107,6 +107,11 @@ def export_checkpoint(
     logger.info("CPU export: %s -> %s", megatron_path, hf_path)
     logger.info("Using Megatron run config: %s", config_path)
     bridge = AutoBridge.from_auto_config(megatron_path, hf_model, trust_remote_code=trusted)
+    if bridge._model_bridge.REQUIRES_HF_SOURCE_FOR_EXPORT:
+        raise NotImplementedError(
+            f"{type(bridge._model_bridge).__name__} export requires the original Hugging Face checkpoint; "
+            "the config-only CPU export path is not supported."
+        )
     prepare_output_directory(hf_path, overwrite=overwrite, source_paths=[megatron_path, hf_model])
     try:
         bridge.export_ckpt(

--- a/src/megatron/bridge/models/conversion/auto_bridge.py
+++ b/src/megatron/bridge/models/conversion/auto_bridge.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import dataclasses
+import itertools
 import logging
 from collections.abc import Callable
 from contextlib import nullcontext
@@ -978,6 +979,11 @@ class AutoBridge(Generic[MegatronModelT]):
         if not isinstance(self.hf_pretrained, (*_PRETRAINED_WRAPPER_TYPES, PretrainedConfig)):
             raise ValueError("save_hf_pretrained requires a pretrained HuggingFace model or config.")
         is_config_only = isinstance(self.hf_pretrained, PretrainedConfig)
+        if model_bridge is not None and model_bridge.REQUIRES_HF_SOURCE_FOR_EXPORT and is_config_only:
+            raise NotImplementedError(
+                f"{type(model_bridge).__name__} export requires the original Hugging Face checkpoint; "
+                "the config-only CPU export path is not supported."
+            )
 
         def _save_artifacts():
             if is_config_only:
@@ -1098,6 +1104,14 @@ class AutoBridge(Generic[MegatronModelT]):
             merge_adapter_weights=merge_adapter_weights,
             weight_dtype=weight_dtype,
         )
+        passthrough_hook = getattr(type(bridge), "stream_hf_export_passthrough", None)
+        passthrough = (
+            passthrough_hook(bridge, self.hf_pretrained, cpu=True) if passthrough_hook is not None else iter(())
+        )
+        # Yield the small source-only set first. Source shards that mix mapped
+        # and passthrough tensors can then flush as mapped tensors arrive,
+        # instead of retaining the complete mapped backbone until the end.
+        generator = itertools.chain(passthrough, generator)
         model_instance = self._get_model_instance(model)
         quant_tensors = None
         # Import lazily so Bridge conversion modules can load before ModelOpt
@@ -1431,6 +1445,11 @@ class AutoBridge(Generic[MegatronModelT]):
             >>> from transformers import AutoModelForCausalLM
             >>> hf_model = AutoModelForCausalLM.from_pretrained("./hf_exports/my_model")
         """
+        if isinstance(self.hf_pretrained, PretrainedConfig) and self._model_bridge.REQUIRES_HF_SOURCE_FOR_EXPORT:
+            raise NotImplementedError(
+                f"{type(self._model_bridge).__name__} export requires the original Hugging Face checkpoint; "
+                "the config-only CPU export path is not supported."
+            )
         try:
             from megatron.bridge.training.model_load_save import temporary_distributed_context
         except ImportError:

--- a/src/megatron/bridge/models/conversion/auto_bridge.py
+++ b/src/megatron/bridge/models/conversion/auto_bridge.py
@@ -979,6 +979,14 @@ class AutoBridge(Generic[MegatronModelT]):
         if not isinstance(self.hf_pretrained, (*_PRETRAINED_WRAPPER_TYPES, PretrainedConfig)):
             raise ValueError("save_hf_pretrained requires a pretrained HuggingFace model or config.")
         is_config_only = isinstance(self.hf_pretrained, PretrainedConfig)
+        requires_hf_source = (
+            model_bridge is not None and getattr(type(model_bridge), "REQUIRES_HF_SOURCE_FOR_EXPORT", False) is True
+        )
+        if requires_hf_source and is_config_only:
+            raise NotImplementedError(
+                f"{type(model_bridge).__name__} export requires the original Hugging Face checkpoint; "
+                "the config-only CPU export path is not supported."
+            )
 
         def _save_artifacts():
             if is_config_only:
@@ -1440,6 +1448,11 @@ class AutoBridge(Generic[MegatronModelT]):
             >>> from transformers import AutoModelForCausalLM
             >>> hf_model = AutoModelForCausalLM.from_pretrained("./hf_exports/my_model")
         """
+        if isinstance(self.hf_pretrained, PretrainedConfig) and self._model_bridge.REQUIRES_HF_SOURCE_FOR_EXPORT:
+            raise NotImplementedError(
+                f"{type(self._model_bridge).__name__} export requires the original Hugging Face checkpoint; "
+                "the config-only CPU export path is not supported."
+            )
         try:
             from megatron.bridge.training.model_load_save import temporary_distributed_context
         except ImportError:

--- a/src/megatron/bridge/models/conversion/auto_bridge.py
+++ b/src/megatron/bridge/models/conversion/auto_bridge.py
@@ -979,7 +979,10 @@ class AutoBridge(Generic[MegatronModelT]):
         if not isinstance(self.hf_pretrained, (*_PRETRAINED_WRAPPER_TYPES, PretrainedConfig)):
             raise ValueError("save_hf_pretrained requires a pretrained HuggingFace model or config.")
         is_config_only = isinstance(self.hf_pretrained, PretrainedConfig)
-        if model_bridge is not None and model_bridge.REQUIRES_HF_SOURCE_FOR_EXPORT and is_config_only:
+        requires_hf_source = (
+            model_bridge is not None and getattr(type(model_bridge), "REQUIRES_HF_SOURCE_FOR_EXPORT", False) is True
+        )
+        if requires_hf_source and is_config_only:
             raise NotImplementedError(
                 f"{type(model_bridge).__name__} export requires the original Hugging Face checkpoint; "
                 "the config-only CPU export path is not supported."

--- a/src/megatron/bridge/models/conversion/auto_bridge.py
+++ b/src/megatron/bridge/models/conversion/auto_bridge.py
@@ -979,14 +979,6 @@ class AutoBridge(Generic[MegatronModelT]):
         if not isinstance(self.hf_pretrained, (*_PRETRAINED_WRAPPER_TYPES, PretrainedConfig)):
             raise ValueError("save_hf_pretrained requires a pretrained HuggingFace model or config.")
         is_config_only = isinstance(self.hf_pretrained, PretrainedConfig)
-        requires_hf_source = (
-            model_bridge is not None and getattr(type(model_bridge), "REQUIRES_HF_SOURCE_FOR_EXPORT", False) is True
-        )
-        if requires_hf_source and is_config_only:
-            raise NotImplementedError(
-                f"{type(model_bridge).__name__} export requires the original Hugging Face checkpoint; "
-                "the config-only CPU export path is not supported."
-            )
 
         def _save_artifacts():
             if is_config_only:
@@ -1448,11 +1440,6 @@ class AutoBridge(Generic[MegatronModelT]):
             >>> from transformers import AutoModelForCausalLM
             >>> hf_model = AutoModelForCausalLM.from_pretrained("./hf_exports/my_model")
         """
-        if isinstance(self.hf_pretrained, PretrainedConfig) and self._model_bridge.REQUIRES_HF_SOURCE_FOR_EXPORT:
-            raise NotImplementedError(
-                f"{type(self._model_bridge).__name__} export requires the original Hugging Face checkpoint; "
-                "the config-only CPU export path is not supported."
-            )
         try:
             from megatron.bridge.training.model_load_save import temporary_distributed_context
         except ImportError:

--- a/src/megatron/bridge/models/conversion/model_bridge.py
+++ b/src/megatron/bridge/models/conversion/model_bridge.py
@@ -416,6 +416,11 @@ class MegatronModelBridge(
 
     SUPPORTS_HF_PRETRAINED_EXPORT: ClassVar[bool] = True
 
+    # Composite bridges may require access to the original HF checkpoint during
+    # export so source-only components can be preserved. Such bridges cannot use
+    # the config-only CPU export path.
+    REQUIRES_HF_SOURCE_FOR_EXPORT: ClassVar[bool] = False
+
     # Provider class to instantiate in provider_bridge (set via @register_bridge decorator)
     # For MLA models, use DeepSeekModelProvider or similar; for standard GPT, use GPTModelProvider
     PROVIDER_CLASS = None  # Set by @register_bridge(provider=...) or defaults to GPTModelProvider
@@ -1220,6 +1225,31 @@ class MegatronModelBridge(
             if converted_weights is not None:
                 # Assert that vp_stage is not None for HF->Megatron tasks
                 yield MegatronWeightTuple(task.param_name, converted_weights, task.vp_stage)
+
+    def stream_hf_export_passthrough(
+        self,
+        hf_pretrained: HFPreTrained,
+        *,
+        cpu: bool = True,
+    ) -> Iterable[HFWeightTuple]:
+        """Yield source HF tensors that must be preserved during checkpoint save.
+
+        Most bridges convert every tensor represented by their Hugging Face
+        checkpoint and therefore return an empty iterator. A bridge that owns
+        only part of a composite checkpoint may override this hook to preserve
+        explicitly unsupported components byte-for-byte from the source
+        checkpoint while replacing the converted component.
+
+        Args:
+            hf_pretrained: Hugging Face wrapper that provides the source state.
+            cpu: Whether yielded tensors must be moved to CPU.
+
+        Returns:
+            An iterator of source tensors to append only when saving an HF
+            checkpoint. In-memory conversion APIs continue to expose converted
+            tensors only.
+        """
+        return iter(())
 
     @torch.no_grad()
     def stream_weights_megatron_to_hf(

--- a/src/megatron/bridge/models/conversion/model_bridge.py
+++ b/src/megatron/bridge/models/conversion/model_bridge.py
@@ -416,11 +416,6 @@ class MegatronModelBridge(
 
     SUPPORTS_HF_PRETRAINED_EXPORT: ClassVar[bool] = True
 
-    # Composite bridges may require access to the original HF checkpoint during
-    # export so source-only components can be preserved. Such bridges cannot use
-    # the config-only CPU export path.
-    REQUIRES_HF_SOURCE_FOR_EXPORT: ClassVar[bool] = False
-
     # Provider class to instantiate in provider_bridge (set via @register_bridge decorator)
     # For MLA models, use DeepSeekModelProvider or similar; for standard GPT, use GPTModelProvider
     PROVIDER_CLASS = None  # Set by @register_bridge(provider=...) or defaults to GPTModelProvider

--- a/src/megatron/bridge/models/conversion/model_bridge.py
+++ b/src/megatron/bridge/models/conversion/model_bridge.py
@@ -416,6 +416,11 @@ class MegatronModelBridge(
 
     SUPPORTS_HF_PRETRAINED_EXPORT: ClassVar[bool] = True
 
+    # Composite bridges may require access to the original HF checkpoint during
+    # export so source-only components can be preserved. Such bridges cannot use
+    # the config-only CPU export path.
+    REQUIRES_HF_SOURCE_FOR_EXPORT: ClassVar[bool] = False
+
     # Provider class to instantiate in provider_bridge (set via @register_bridge decorator)
     # For MLA models, use DeepSeekModelProvider or similar; for standard GPT, use GPTModelProvider
     PROVIDER_CLASS = None  # Set by @register_bridge(provider=...) or defaults to GPTModelProvider

--- a/src/megatron/bridge/models/minimax_m3/minimax_m3_bridge.py
+++ b/src/megatron/bridge/models/minimax_m3/minimax_m3_bridge.py
@@ -187,6 +187,15 @@ class MiniMaxM3Bridge(MegatronModelBridge):
     """
 
     REQUIRES_HF_SOURCE_FOR_EXPORT = True
+    # AutoTokenizer.save_pretrained() consolidates these artifacts. Preserve the
+    # pinned source files so the source-overlay checkpoint remains self-contained.
+    ADDITIONAL_FILE_PATTERNS = [
+        "added_tokens.json",
+        "merges.txt",
+        "special_tokens_map.json",
+        "tokenizer_config.json",
+        "vocab.json",
+    ]
 
     @classmethod
     def hf_to_megatron_activation(cls, hidden_act: str):

--- a/src/megatron/bridge/models/minimax_m3/minimax_m3_bridge.py
+++ b/src/megatron/bridge/models/minimax_m3/minimax_m3_bridge.py
@@ -14,6 +14,7 @@
 
 from dataclasses import dataclass, replace
 from functools import partial
+from typing import Iterable
 
 import torch
 from megatron.core.models.gpt.gpt_layer_specs import get_gpt_decoder_block_spec
@@ -24,7 +25,7 @@ from megatron.core.transformer.transformer_block import TransformerBlockSubmodul
 from megatron.core.transformer.transformer_config import TransformerConfig
 
 from megatron.bridge.models.conversion.mapping_registry import MegatronMappingRegistry
-from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge
+from megatron.bridge.models.conversion.model_bridge import HFWeightTuple, MegatronModelBridge
 from megatron.bridge.models.conversion.param_mapping import (
     AutoMapping,
     GatedMLPMapping,
@@ -173,10 +174,11 @@ class MiniMaxM3Bridge(MegatronModelBridge):
         - MTP (Multi-Token Prediction) modules are not mapped. The released
           checkpoint advertises ``num_nextn_predict_layers`` in its config but
           ships no ``mtp.*`` weights, so ``mtp_num_layers`` is forced to None.
-        - Standalone Hugging Face checkpoint export is not supported. The HF
-          checkpoint is multimodal, while this bridge maps only its
-          ``language_model.*`` tensors. In-memory HF-to-Megatron-to-HF weight
-          verification remains supported.
+        - Persisted Hugging Face export replaces the supported
+          ``language_model.*`` tensors and preserves the source checkpoint's
+          vision, projector, patch-merge, and lightning-indexer tensors
+          byte-for-byte. Those passthrough tensors remain outside the Bridge
+          verification surface.
 
     Example:
         >>> from megatron.bridge import AutoBridge
@@ -184,7 +186,7 @@ class MiniMaxM3Bridge(MegatronModelBridge):
         >>> provider = bridge.to_megatron_provider()
     """
 
-    SUPPORTS_HF_PRETRAINED_EXPORT = False
+    REQUIRES_HF_SOURCE_FOR_EXPORT = True
 
     @classmethod
     def hf_to_megatron_activation(cls, hidden_act: str):
@@ -313,12 +315,74 @@ class MiniMaxM3Bridge(MegatronModelBridge):
 
     @classmethod
     def megatron_to_hf_config(cls, provider: GPTModelProvider) -> dict:
-        """Reject standalone HF export until the full multimodal contract is mapped."""
-        raise NotImplementedError(
-            "MiniMax-M3 standalone Hugging Face export is not supported: the source checkpoint is multimodal, "
-            "but this bridge maps only language_model.* tensors. Use HF import, native Megatron checkpoints, "
-            "or in-memory round-trip verification."
+        """Convert the Megatron provider to MiniMax-M3's nested HF config."""
+        text_config = super().megatron_to_hf_config(provider)
+        torch_dtype = text_config.pop("torch_dtype")
+        text_config.pop("architectures", None)
+        text_config.pop("model_type", None)
+
+        # seq_length is a workload setting for the Megatron provider, whereas
+        # max_position_embeddings is an architecture limit. Omitting it here
+        # lets conform_config_to_reference preserve the pinned HF value.
+        text_config.pop("max_position_embeddings", None)
+        # The text-only provider intentionally disables MTP because the source
+        # checkpoint contains no mtp.* weights. Preserve the outer checkpoint's
+        # declaration rather than overwriting it with the provider's None.
+        text_config.pop("num_nextn_predict_layers", None)
+        text_config.pop("mtp_num_hidden_layers", None)
+        text_config.update(
+            {
+                "architectures": ["MiniMaxM3SparseForCausalLM"],
+                "intermediate_size": provider.moe_ffn_hidden_size,
+                "dense_intermediate_size": provider.ffn_hidden_size,
+                "shared_intermediate_size": provider.moe_shared_expert_intermediate_size,
+                "n_shared_experts": 1,
+                "head_dim": provider.kv_channels,
+                "hidden_act": "swigluoai",
+                "rotary_dim": round(provider.rotary_percent * provider.kv_channels),
+                "partial_rotary_factor": provider.rotary_percent,
+                "use_gemma_norm": provider.layernorm_zero_centered_gamma,
+                "use_qk_norm": provider.qk_layernorm,
+                "qk_norm_type": "per_head",
+                "num_local_experts": provider.num_moe_experts,
+                "num_experts_per_tok": provider.moe_router_topk,
+                "scoring_func": provider.moe_router_score_function,
+                "use_routing_bias": provider.moe_router_enable_expert_bias,
+                "routed_scaling_factor": provider.moe_router_topk_scaling_factor,
+                "router_aux_loss_coef": provider.moe_aux_loss_coeff,
+                "moe_layer_freq": provider.moe_layer_freq,
+                "swiglu_alpha": 1.702,
+                "swiglu_limit": provider.activation_func_clamp_value,
+            }
         )
+
+        return {
+            "architectures": ["MiniMaxM3SparseForConditionalGeneration"],
+            "model_type": "minimax_m3_vl",
+            "text_config": text_config,
+            "torch_dtype": torch_dtype,
+        }
+
+    def stream_hf_export_passthrough(
+        self,
+        hf_pretrained: PreTrainedCausalLM,
+        *,
+        cpu: bool = True,
+    ) -> Iterable[HFWeightTuple]:
+        """Preserve source tensors outside the converted text-backbone surface."""
+        if not hasattr(hf_pretrained, "state"):
+            raise NotImplementedError(
+                "MiniMax-M3 HF export requires the pinned source checkpoint so unbridged tensors can be preserved."
+            )
+
+        for name in hf_pretrained.state:
+            is_passthrough = name.startswith(("vision_tower.", "multi_modal_projector.", "patch_merge_mlp.")) or (
+                name.startswith("language_model.") and ".self_attn.index_" in name
+            )
+            if not is_passthrough:
+                continue
+            tensor = hf_pretrained.state[name].detach()
+            yield HFWeightTuple(name, tensor.cpu() if cpu else tensor)
 
     def mapping_registry(self) -> MegatronMappingRegistry:
         """Return the parameter mappings for the MiniMax-M3 language model.

--- a/src/megatron/bridge/models/minimax_m3/minimax_m3_bridge.py
+++ b/src/megatron/bridge/models/minimax_m3/minimax_m3_bridge.py
@@ -186,6 +186,7 @@ class MiniMaxM3Bridge(MegatronModelBridge):
         >>> provider = bridge.to_megatron_provider()
     """
 
+    REQUIRES_HF_SOURCE_FOR_EXPORT = True
     # AutoTokenizer.save_pretrained() consolidates these artifacts. Preserve the
     # pinned source files so the source-overlay checkpoint remains self-contained.
     ADDITIONAL_FILE_PATTERNS = [

--- a/src/megatron/bridge/models/minimax_m3/minimax_m3_bridge.py
+++ b/src/megatron/bridge/models/minimax_m3/minimax_m3_bridge.py
@@ -12,13 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from functools import partial
 
 import torch
 from megatron.core.models.gpt.gpt_layer_specs import get_gpt_decoder_block_spec
 from megatron.core.models.gpt.gpt_model import GPTModel
+from megatron.core.transformer.moe.moe_layer import MoELayer
 from megatron.core.transformer.moe.router import TopKRouter
+from megatron.core.transformer.transformer_block import TransformerBlockSubmodules
+from megatron.core.transformer.transformer_config import TransformerConfig
 
 from megatron.bridge.models.conversion.mapping_registry import MegatronMappingRegistry
 from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge
@@ -45,6 +48,50 @@ except ImportError:
     quick_gelu = torch.nn.functional.gelu
 
 
+class MiniMaxM3TopKRouter(TopKRouter):
+    """MiniMax-M3 router that computes its projection in the weight dtype."""
+
+    def gating(self, input: torch.Tensor) -> torch.Tensor:
+        """Match HF by widening router inputs to the FP32 router weight dtype."""
+        return super().gating(input.to(dtype=self.weight.dtype))
+
+
+def minimax_m3_block_spec(
+    config: TransformerConfig,
+    use_transformer_engine: bool = True,
+    normalization: str | None = None,
+    qk_l2_norm: bool | None = False,
+    vp_stage: int | None = None,
+    pp_rank: int | None = None,
+    **kwargs: object,
+) -> TransformerBlockSubmodules:
+    """Build a GPT block spec that uses MiniMax-M3's FP32 router projection."""
+    block_spec = get_gpt_decoder_block_spec(
+        config,
+        use_transformer_engine=use_transformer_engine,
+        normalization=normalization,
+        qk_l2_norm=qk_l2_norm,
+        vp_stage=vp_stage,
+        pp_rank=pp_rank,
+        **kwargs,
+    )
+
+    for layer_spec in block_spec.layer_specs:
+        mlp_spec = layer_spec.submodules.mlp
+        if isinstance(mlp_spec, partial) and isinstance(mlp_spec.func, type) and issubclass(mlp_spec.func, MoELayer):
+            mlp_kwargs = dict(mlp_spec.keywords or {})
+            mlp_submodules = mlp_kwargs["submodules"]
+            if mlp_submodules.router is not TopKRouter:
+                continue
+            mlp_kwargs["submodules"] = replace(mlp_submodules, router=MiniMaxM3TopKRouter)
+            layer_spec.submodules.mlp = partial(mlp_spec.func, *mlp_spec.args, **mlp_kwargs)
+
+    return block_spec
+
+
+AutoMapping.register_module_type("MiniMaxM3TopKRouter", "replicated")
+
+
 def _promote_router_weights_to_float32(model: list[torch.nn.Module]) -> list[torch.nn.Module]:
     """Keep MiniMax-M3 router parameters in FP32 for every load path.
 
@@ -67,9 +114,20 @@ class MiniMaxM3ModelProvider(GPTModelProvider):
     """GPT provider that preserves MiniMax-M3's FP32 router parameters."""
 
     def __post_init__(self) -> None:
-        """Install the router hook on fresh and deserialized providers."""
+        """Install MiniMax-M3 router behavior on fresh and deserialized providers."""
         super().__post_init__()
-        self.register_pre_wrap_hook(_promote_router_weights_to_float32, prepend=True)
+        layer_spec = self.transformer_layer_spec
+        if layer_spec is get_gpt_decoder_block_spec:
+            self.transformer_layer_spec = minimax_m3_block_spec
+        elif isinstance(layer_spec, partial) and layer_spec.func is get_gpt_decoder_block_spec:
+            self.transformer_layer_spec = partial(
+                minimax_m3_block_spec,
+                *layer_spec.args,
+                **(layer_spec.keywords or {}),
+            )
+
+        if not hasattr(self, "_pre_wrap_hooks") or _promote_router_weights_to_float32 not in self._pre_wrap_hooks:
+            self.register_pre_wrap_hook(_promote_router_weights_to_float32, prepend=True)
 
 
 @MegatronModelBridge.register_bridge(
@@ -154,7 +212,7 @@ class MiniMaxM3Bridge(MegatronModelBridge):
         provider = MiniMaxM3ModelProvider(**{k: v for k, v in provider_kwargs.items() if k in valid_fields})
 
         # Use decoder block spec to properly handle moe_layer_freq (mixed dense/MoE layers)
-        provider.transformer_layer_spec = partial(get_gpt_decoder_block_spec, use_transformer_engine=HAVE_TE)
+        provider.transformer_layer_spec = partial(minimax_m3_block_spec, use_transformer_engine=HAVE_TE)
 
         # Gemma-style RMSNorm: weights stored zero-centered, applied as x * (1 + w)
         provider.normalization = "RMSNorm"

--- a/src/megatron/bridge/models/minimax_m3/minimax_m3_bridge.py
+++ b/src/megatron/bridge/models/minimax_m3/minimax_m3_bridge.py
@@ -186,7 +186,6 @@ class MiniMaxM3Bridge(MegatronModelBridge):
         >>> provider = bridge.to_megatron_provider()
     """
 
-    REQUIRES_HF_SOURCE_FOR_EXPORT = True
     # AutoTokenizer.save_pretrained() consolidates these artifacts. Preserve the
     # pinned source files so the source-overlay checkpoint remains self-contained.
     ADDITIONAL_FILE_PATTERNS = [

--- a/tests/unit_tests/conversion/launcher/test_cpu_backend.py
+++ b/tests/unit_tests/conversion/launcher/test_cpu_backend.py
@@ -7,8 +7,6 @@ import sys
 import types
 from pathlib import Path
 
-import pytest
-
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
 SCRIPT_DIR = REPO_ROOT / "scripts" / "conversion"
@@ -79,34 +77,3 @@ def test_import_preserves_model_id_and_forwards_revision():
             },
         ),
     ]
-
-
-def test_export_requiring_hf_source_rejects_before_preparing_output(tmp_path):
-    module, calls = _load_cpu_backend()
-    checkpoint_path = tmp_path / "megatron"
-    checkpoint_path.mkdir()
-    (checkpoint_path / "run_config.yaml").write_text("model: {}\n")
-    export_called = False
-
-    class SourceOverlayBridge:
-        _model_bridge = types.SimpleNamespace(REQUIRES_HF_SOURCE_FOR_EXPORT=True)
-
-        def export_ckpt(self, **_kwargs):
-            nonlocal export_called
-            export_called = True
-
-    module.AutoBridge.from_auto_config = staticmethod(lambda *_args, **_kwargs: SourceOverlayBridge())
-
-    with pytest.raises(NotImplementedError, match="config-only CPU export path"):
-        module.export_checkpoint(
-            hf_model="hf/model",
-            megatron_path=str(checkpoint_path),
-            hf_path=str(tmp_path / "hf-output"),
-            show_progress=False,
-            strict=False,
-            trust_remote_code=True,
-            overwrite=False,
-        )
-
-    assert not export_called
-    assert not any(call[0] == "prepare_output_directory" for call in calls)

--- a/tests/unit_tests/conversion/launcher/test_cpu_backend.py
+++ b/tests/unit_tests/conversion/launcher/test_cpu_backend.py
@@ -7,6 +7,8 @@ import sys
 import types
 from pathlib import Path
 
+import pytest
+
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
 SCRIPT_DIR = REPO_ROOT / "scripts" / "conversion"
@@ -77,3 +79,34 @@ def test_import_preserves_model_id_and_forwards_revision():
             },
         ),
     ]
+
+
+def test_export_requiring_hf_source_rejects_before_preparing_output(tmp_path):
+    module, calls = _load_cpu_backend()
+    checkpoint_path = tmp_path / "megatron"
+    checkpoint_path.mkdir()
+    (checkpoint_path / "run_config.yaml").write_text("model: {}\n")
+    export_called = False
+
+    class SourceOverlayBridge:
+        _model_bridge = types.SimpleNamespace(REQUIRES_HF_SOURCE_FOR_EXPORT=True)
+
+        def export_ckpt(self, **_kwargs):
+            nonlocal export_called
+            export_called = True
+
+    module.AutoBridge.from_auto_config = staticmethod(lambda *_args, **_kwargs: SourceOverlayBridge())
+
+    with pytest.raises(NotImplementedError, match="config-only CPU export path"):
+        module.export_checkpoint(
+            hf_model="hf/model",
+            megatron_path=str(checkpoint_path),
+            hf_path=str(tmp_path / "hf-output"),
+            show_progress=False,
+            strict=False,
+            trust_remote_code=True,
+            overwrite=False,
+        )
+
+    assert not export_called
+    assert not any(call[0] == "prepare_output_directory" for call in calls)

--- a/tests/unit_tests/models/minimax_m3/test_minimax_m3_bridge.py
+++ b/tests/unit_tests/models/minimax_m3/test_minimax_m3_bridge.py
@@ -18,14 +18,13 @@ Unit tests for the MiniMax-M3 bridge.
 
 from functools import partial
 from types import SimpleNamespace
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
 import torch
 from megatron.core.models.gpt.gpt_layer_specs import get_gpt_decoder_block_spec
-from transformers import GenerationConfig, PretrainedConfig
+from transformers import GenerationConfig
 
-from megatron.bridge.models.conversion.auto_bridge import AutoBridge
 from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge
 from megatron.bridge.models.conversion.param_mapping import AutoMapping
 from megatron.bridge.models.conversion.utils import conform_config_to_reference
@@ -527,7 +526,6 @@ class TestMiniMaxM3Bridge:
 
     def test_hf_export_is_enabled_for_source_overlay(self):
         assert MiniMaxM3Bridge.SUPPORTS_HF_PRETRAINED_EXPORT is True
-        assert MiniMaxM3Bridge.REQUIRES_HF_SOURCE_FOR_EXPORT is True
 
     def test_hf_export_preserves_source_tokenizer_artifacts(self):
         assert MiniMaxM3Bridge.ADDITIONAL_FILE_PATTERNS == [
@@ -537,30 +535,6 @@ class TestMiniMaxM3Bridge:
             "tokenizer_config.json",
             "vocab.json",
         ]
-
-    def test_config_only_hf_export_rejects_before_creating_output(self, tmp_path):
-        hf_config = PretrainedConfig()
-        hf_config.architectures = ["MiniMaxM3SparseForConditionalGeneration"]
-        hf_config.model_type = "minimax_m3_vl"
-        auto_bridge = AutoBridge(hf_config)
-        output_path = tmp_path / "incomplete-hf-export"
-
-        with pytest.raises(NotImplementedError, match="original Hugging Face checkpoint"):
-            auto_bridge.save_hf_pretrained([], output_path)
-
-        assert not output_path.exists()
-
-    def test_config_only_export_ckpt_rejects_before_loading_megatron(self):
-        hf_config = PretrainedConfig()
-        hf_config.architectures = ["MiniMaxM3SparseForConditionalGeneration"]
-        hf_config.model_type = "minimax_m3_vl"
-        auto_bridge = AutoBridge(hf_config)
-
-        with patch.object(auto_bridge, "load_megatron_model") as load_megatron_model:
-            with pytest.raises(NotImplementedError, match="original Hugging Face checkpoint"):
-                auto_bridge.export_ckpt("/unused/megatron", "/unused/hf")
-
-        load_megatron_model.assert_not_called()
 
     def test_hf_export_passthrough_is_narrow_and_lossless(self):
         state = {

--- a/tests/unit_tests/models/minimax_m3/test_minimax_m3_bridge.py
+++ b/tests/unit_tests/models/minimax_m3/test_minimax_m3_bridge.py
@@ -529,6 +529,15 @@ class TestMiniMaxM3Bridge:
         assert MiniMaxM3Bridge.SUPPORTS_HF_PRETRAINED_EXPORT is True
         assert MiniMaxM3Bridge.REQUIRES_HF_SOURCE_FOR_EXPORT is True
 
+    def test_hf_export_preserves_source_tokenizer_artifacts(self):
+        assert MiniMaxM3Bridge.ADDITIONAL_FILE_PATTERNS == [
+            "added_tokens.json",
+            "merges.txt",
+            "special_tokens_map.json",
+            "tokenizer_config.json",
+            "vocab.json",
+        ]
+
     def test_config_only_hf_export_rejects_before_creating_output(self, tmp_path):
         hf_config = PretrainedConfig()
         hf_config.architectures = ["MiniMaxM3SparseForConditionalGeneration"]

--- a/tests/unit_tests/models/minimax_m3/test_minimax_m3_bridge.py
+++ b/tests/unit_tests/models/minimax_m3/test_minimax_m3_bridge.py
@@ -18,7 +18,7 @@ Unit tests for the MiniMax-M3 bridge.
 
 from functools import partial
 from types import SimpleNamespace
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 import torch
@@ -28,6 +28,7 @@ from transformers import GenerationConfig, PretrainedConfig
 from megatron.bridge.models.conversion.auto_bridge import AutoBridge
 from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge
 from megatron.bridge.models.conversion.param_mapping import AutoMapping
+from megatron.bridge.models.conversion.utils import conform_config_to_reference
 from megatron.bridge.models.hf_pretrained.causal_lm import PreTrainedCausalLM
 from megatron.bridge.models.minimax_m3.minimax_m3_bridge import (
     MiniMaxM3Bridge,
@@ -439,21 +440,130 @@ class TestMiniMaxM3Bridge:
                 assert "index_" not in str(p)
                 assert "vision_tower" not in str(p)
 
-    def test_megatron_to_hf_config_rejects_incomplete_multimodal_export(self, mock_pretrained):
+    def test_megatron_to_hf_config_builds_nested_text_config(self, mock_pretrained):
         bridge = MiniMaxM3Bridge()
         provider = bridge.provider_bridge(mock_pretrained)
+        config = MiniMaxM3Bridge.megatron_to_hf_config(provider)
 
-        with pytest.raises(NotImplementedError, match="multimodal"):
-            MiniMaxM3Bridge.megatron_to_hf_config(provider)
+        assert config["architectures"] == ["MiniMaxM3SparseForConditionalGeneration"]
+        assert config["model_type"] == "minimax_m3_vl"
+        assert config["torch_dtype"] == "bfloat16"
+        assert "vision_config" not in config
 
-    def test_public_hf_save_rejects_before_creating_output(self, tmp_path):
+        text_config = config["text_config"]
+        assert text_config["architectures"] == ["MiniMaxM3SparseForCausalLM"]
+        assert text_config["hidden_size"] == 64
+        assert text_config["intermediate_size"] == 32
+        assert text_config["dense_intermediate_size"] == 128
+        assert text_config["shared_intermediate_size"] == 32
+        assert text_config["head_dim"] == 16
+        assert text_config["rotary_dim"] == 8
+        assert text_config["hidden_act"] == "swigluoai"
+        assert text_config["moe_layer_freq"] == [0, 1, 1, 1]
+        assert text_config["scoring_func"] == "sigmoid"
+        assert text_config["use_routing_bias"] is True
+        assert text_config["use_gemma_norm"] is True
+        assert text_config["use_qk_norm"] is True
+        assert "max_position_embeddings" not in text_config
+        assert "num_nextn_predict_layers" not in text_config
+        assert "mtp_num_hidden_layers" not in text_config
+
+    def test_megatron_to_hf_config_preserves_source_mtp_declaration(self, mock_pretrained):
+        bridge = MiniMaxM3Bridge()
+        provider = bridge.provider_bridge(mock_pretrained)
+        exported = MiniMaxM3Bridge.megatron_to_hf_config(provider)
+        reference = {
+            "architectures": ["MiniMaxM3SparseForConditionalGeneration"],
+            "model_type": "minimax_m3_vl",
+            "text_config": {
+                **_MINIMAX_M3_TEXT_CONFIG,
+                "num_nextn_predict_layers": 1,
+            },
+        }
+
+        conformed = conform_config_to_reference(exported, reference)
+
+        assert conformed["text_config"]["num_nextn_predict_layers"] == 1
+
+    def test_megatron_to_hf_config_preserves_text_semantics(self, mock_pretrained):
+        bridge = MiniMaxM3Bridge()
+        original = bridge.provider_bridge(mock_pretrained)
+        exported = MiniMaxM3Bridge.megatron_to_hf_config(original)
+        roundtrip_pretrained = Mock(spec=PreTrainedCausalLM)
+        roundtrip_config = dict(exported)
+        roundtrip_config["text_config"] = SimpleNamespace(**exported["text_config"])
+        roundtrip_pretrained.config = SimpleNamespace(**roundtrip_config)
+        restored = bridge.provider_bridge(roundtrip_pretrained)
+
+        for field in (
+            "hidden_size",
+            "num_layers",
+            "num_attention_heads",
+            "num_query_groups",
+            "kv_channels",
+            "vocab_size",
+            "ffn_hidden_size",
+            "moe_ffn_hidden_size",
+            "num_moe_experts",
+            "moe_router_topk",
+            "moe_router_score_function",
+            "moe_router_enable_expert_bias",
+            "moe_router_topk_scaling_factor",
+            "moe_shared_expert_intermediate_size",
+            "moe_layer_freq",
+            "rotary_percent",
+            "layernorm_zero_centered_gamma",
+            "qk_layernorm",
+            "share_embeddings_and_output_weights",
+        ):
+            assert getattr(restored, field) == getattr(original, field)
+        assert restored.activation_func is quick_gelu
+        assert restored.activation_func_clamp_value == original.activation_func_clamp_value
+
+    def test_hf_export_is_enabled_for_source_overlay(self):
+        assert MiniMaxM3Bridge.SUPPORTS_HF_PRETRAINED_EXPORT is True
+        assert MiniMaxM3Bridge.REQUIRES_HF_SOURCE_FOR_EXPORT is True
+
+    def test_config_only_hf_export_rejects_before_creating_output(self, tmp_path):
         hf_config = PretrainedConfig()
         hf_config.architectures = ["MiniMaxM3SparseForConditionalGeneration"]
         hf_config.model_type = "minimax_m3_vl"
         auto_bridge = AutoBridge(hf_config)
         output_path = tmp_path / "incomplete-hf-export"
 
-        with pytest.raises(NotImplementedError, match="standalone Hugging Face"):
+        with pytest.raises(NotImplementedError, match="original Hugging Face checkpoint"):
             auto_bridge.save_hf_pretrained([], output_path)
 
         assert not output_path.exists()
+
+    def test_config_only_export_ckpt_rejects_before_loading_megatron(self):
+        hf_config = PretrainedConfig()
+        hf_config.architectures = ["MiniMaxM3SparseForConditionalGeneration"]
+        hf_config.model_type = "minimax_m3_vl"
+        auto_bridge = AutoBridge(hf_config)
+
+        with patch.object(auto_bridge, "load_megatron_model") as load_megatron_model:
+            with pytest.raises(NotImplementedError, match="original Hugging Face checkpoint"):
+                auto_bridge.export_ckpt("/unused/megatron", "/unused/hf")
+
+        load_megatron_model.assert_not_called()
+
+    def test_hf_export_passthrough_is_narrow_and_lossless(self):
+        state = {
+            "language_model.model.embed_tokens.weight": torch.randn(2, 2),
+            "language_model.model.layers.3.self_attn.index_q_proj.weight": torch.randn(2, 2),
+            "vision_tower.vision_model.embeddings.patch_embedding.weight": torch.randn(2, 2),
+            "multi_modal_projector.linear_1.weight": torch.randn(2, 2),
+            "patch_merge_mlp.linear_1.weight": torch.randn(2, 2),
+        }
+        hf_pretrained = SimpleNamespace(state=state)
+
+        passthrough = dict(MiniMaxM3Bridge().stream_hf_export_passthrough(hf_pretrained))
+
+        assert set(passthrough) == set(state) - {"language_model.model.embed_tokens.weight"}
+        for name, tensor in passthrough.items():
+            assert torch.equal(tensor, state[name])
+
+    def test_hf_export_passthrough_requires_source_checkpoint(self):
+        with pytest.raises(NotImplementedError, match="pinned source checkpoint"):
+            list(MiniMaxM3Bridge().stream_hf_export_passthrough(SimpleNamespace()))

--- a/tests/unit_tests/models/minimax_m3/test_minimax_m3_bridge.py
+++ b/tests/unit_tests/models/minimax_m3/test_minimax_m3_bridge.py
@@ -16,23 +16,30 @@
 Unit tests for the MiniMax-M3 bridge.
 """
 
+from functools import partial
+from types import SimpleNamespace
 from unittest.mock import Mock
 
 import pytest
 import torch
+from megatron.core.models.gpt.gpt_layer_specs import get_gpt_decoder_block_spec
 from transformers import GenerationConfig, PretrainedConfig
 
 from megatron.bridge.models.conversion.auto_bridge import AutoBridge
 from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge
+from megatron.bridge.models.conversion.param_mapping import AutoMapping
 from megatron.bridge.models.hf_pretrained.causal_lm import PreTrainedCausalLM
 from megatron.bridge.models.minimax_m3.minimax_m3_bridge import (
     MiniMaxM3Bridge,
     MiniMaxM3ModelProvider,
+    MiniMaxM3TopKRouter,
     TopKRouter,
     _promote_router_weights_to_float32,
+    minimax_m3_block_spec,
     quick_gelu,
 )
 from megatron.bridge.models.model_provider import _apply_mixed_precision_wrapper
+from megatron.bridge.utils.instantiate_utils import instantiate
 
 
 # Toy text-backbone config (mirrors the shape of MiniMaxAI/MiniMax-M3 text_config)
@@ -299,6 +306,115 @@ class TestMiniMaxM3Bridge:
 
         assert isinstance(provider, MiniMaxM3ModelProvider)
         assert provider._pre_wrap_hooks[0] is _promote_router_weights_to_float32
+        assert provider.transformer_layer_spec.func is minimax_m3_block_spec
+
+    def test_provider_upgrades_legacy_checkpoint_layer_spec_idempotently(self, mock_pretrained):
+        provider = MiniMaxM3Bridge().provider_bridge(mock_pretrained)
+        provider.transformer_layer_spec = partial(get_gpt_decoder_block_spec, use_transformer_engine=True)
+
+        provider.__post_init__()
+
+        assert provider.transformer_layer_spec.func is minimax_m3_block_spec
+        assert provider.transformer_layer_spec.keywords == {"use_transformer_engine": True}
+        assert provider._pre_wrap_hooks.count(_promote_router_weights_to_float32) == 1
+
+    def test_router_gating_casts_input_to_float32_weight_dtype(self, monkeypatch):
+        captured_inputs = []
+
+        def fake_gating(_router, hidden_states):
+            captured_inputs.append(hidden_states)
+            return hidden_states
+
+        monkeypatch.setattr(TopKRouter, "gating", fake_gating)
+        router = object.__new__(MiniMaxM3TopKRouter)
+        torch.nn.Module.__init__(router)
+        router.weight = torch.nn.Parameter(torch.randn(8, 64, dtype=torch.float32))
+        hidden_states = torch.randn(2, 3, 64, dtype=torch.bfloat16)
+
+        output = MiniMaxM3TopKRouter.gating(router, hidden_states)
+
+        assert captured_inputs[0].dtype == torch.float32
+        assert torch.equal(captured_inputs[0], hidden_states.float())
+        assert output is captured_inputs[0]
+        assert hidden_states.dtype == torch.bfloat16
+
+    def test_router_gating_does_not_copy_matching_dtype_input(self, monkeypatch):
+        captured_inputs = []
+
+        def fake_gating(_router, hidden_states):
+            captured_inputs.append(hidden_states)
+            return hidden_states
+
+        monkeypatch.setattr(TopKRouter, "gating", fake_gating)
+        router = object.__new__(MiniMaxM3TopKRouter)
+        torch.nn.Module.__init__(router)
+        router.weight = torch.nn.Parameter(torch.randn(8, 64, dtype=torch.float32))
+        hidden_states = torch.randn(2, 3, 64, dtype=torch.float32)
+
+        MiniMaxM3TopKRouter.gating(router, hidden_states)
+
+        assert captured_inputs[0] is hidden_states
+
+    def test_block_spec_installs_minimax_router_only_for_moe_layers(self, monkeypatch):
+        from megatron.core.transformer.moe.moe_layer import MoELayer, MoESubmodules
+
+        moe_submodules = MoESubmodules(experts=object())
+        moe_layer_spec = SimpleNamespace(submodules=SimpleNamespace(mlp=partial(MoELayer, submodules=moe_submodules)))
+        dense_mlp_spec = object()
+        dense_layer_spec = SimpleNamespace(submodules=SimpleNamespace(mlp=dense_mlp_spec))
+        block_spec = SimpleNamespace(layer_specs=[dense_layer_spec, moe_layer_spec])
+        calls = []
+
+        def fake_get_gpt_decoder_block_spec(config, use_transformer_engine=True, **kwargs):
+            calls.append((config, use_transformer_engine, kwargs))
+            return block_spec
+
+        monkeypatch.setattr(
+            "megatron.bridge.models.minimax_m3.minimax_m3_bridge.get_gpt_decoder_block_spec",
+            fake_get_gpt_decoder_block_spec,
+        )
+
+        output = minimax_m3_block_spec(
+            "config",
+            use_transformer_engine=True,
+            vp_stage=2,
+            pp_rank=1,
+            extra="value",
+        )
+
+        assert output is block_spec
+        assert calls == [
+            (
+                "config",
+                True,
+                {
+                    "normalization": None,
+                    "qk_l2_norm": False,
+                    "vp_stage": 2,
+                    "pp_rank": 1,
+                    "extra": "value",
+                },
+            )
+        ]
+        assert dense_layer_spec.submodules.mlp is dense_mlp_spec
+        assert moe_layer_spec.submodules.mlp.func is MoELayer
+        assert moe_layer_spec.submodules.mlp.keywords["submodules"].router is MiniMaxM3TopKRouter
+        assert moe_submodules.router is TopKRouter
+
+    def test_minimax_router_is_registered_as_replicated(self):
+        assert "MiniMaxM3TopKRouter" in AutoMapping._MODULE_TYPE_REGISTRY["replicated"]
+
+    def test_block_spec_serialized_target_can_be_instantiated(self):
+        layer_spec = instantiate(
+            {
+                "_target_": ("megatron.bridge.models.minimax_m3.minimax_m3_bridge.minimax_m3_block_spec"),
+                "_partial_": True,
+                "use_transformer_engine": True,
+            }
+        )
+
+        assert layer_spec.func is minimax_m3_block_spec
+        assert layer_spec.keywords == {"use_transformer_engine": True}
 
     def test_mapping_registry_uses_language_model_prefix(self):
         """All HF-side params must live under the multimodal language_model. prefix."""

--- a/tests/unit_tests/models/minimax_m3/test_minimax_m3_bridge.py
+++ b/tests/unit_tests/models/minimax_m3/test_minimax_m3_bridge.py
@@ -18,13 +18,14 @@ Unit tests for the MiniMax-M3 bridge.
 
 from functools import partial
 from types import SimpleNamespace
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 import torch
 from megatron.core.models.gpt.gpt_layer_specs import get_gpt_decoder_block_spec
-from transformers import GenerationConfig
+from transformers import GenerationConfig, PretrainedConfig
 
+from megatron.bridge.models.conversion.auto_bridge import AutoBridge
 from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge
 from megatron.bridge.models.conversion.param_mapping import AutoMapping
 from megatron.bridge.models.conversion.utils import conform_config_to_reference
@@ -526,6 +527,7 @@ class TestMiniMaxM3Bridge:
 
     def test_hf_export_is_enabled_for_source_overlay(self):
         assert MiniMaxM3Bridge.SUPPORTS_HF_PRETRAINED_EXPORT is True
+        assert MiniMaxM3Bridge.REQUIRES_HF_SOURCE_FOR_EXPORT is True
 
     def test_hf_export_preserves_source_tokenizer_artifacts(self):
         assert MiniMaxM3Bridge.ADDITIONAL_FILE_PATTERNS == [
@@ -535,6 +537,30 @@ class TestMiniMaxM3Bridge:
             "tokenizer_config.json",
             "vocab.json",
         ]
+
+    def test_config_only_hf_export_rejects_before_creating_output(self, tmp_path):
+        hf_config = PretrainedConfig()
+        hf_config.architectures = ["MiniMaxM3SparseForConditionalGeneration"]
+        hf_config.model_type = "minimax_m3_vl"
+        auto_bridge = AutoBridge(hf_config)
+        output_path = tmp_path / "incomplete-hf-export"
+
+        with pytest.raises(NotImplementedError, match="original Hugging Face checkpoint"):
+            auto_bridge.save_hf_pretrained([], output_path)
+
+        assert not output_path.exists()
+
+    def test_config_only_export_ckpt_rejects_before_loading_megatron(self):
+        hf_config = PretrainedConfig()
+        hf_config.architectures = ["MiniMaxM3SparseForConditionalGeneration"]
+        hf_config.model_type = "minimax_m3_vl"
+        auto_bridge = AutoBridge(hf_config)
+
+        with patch.object(auto_bridge, "load_megatron_model") as load_megatron_model:
+            with pytest.raises(NotImplementedError, match="original Hugging Face checkpoint"):
+                auto_bridge.export_ckpt("/unused/megatron", "/unused/hf")
+
+        load_megatron_model.assert_not_called()
 
     def test_hf_export_passthrough_is_narrow_and_lossless(self):
         state = {

--- a/tests/unit_tests/models/minimax_m3/test_minimax_m3_bridge.py
+++ b/tests/unit_tests/models/minimax_m3/test_minimax_m3_bridge.py
@@ -491,7 +491,12 @@ class TestMiniMaxM3Bridge:
         exported = MiniMaxM3Bridge.megatron_to_hf_config(original)
         roundtrip_pretrained = Mock(spec=PreTrainedCausalLM)
         roundtrip_config = dict(exported)
-        roundtrip_config["text_config"] = SimpleNamespace(**exported["text_config"])
+        # MiniMaxM3Config propagates the outer checkpoint dtype into its nested
+        # text config. Mirror that constructor behavior in this lightweight
+        # namespace round trip.
+        roundtrip_text_config = dict(exported["text_config"])
+        roundtrip_text_config["torch_dtype"] = exported["torch_dtype"]
+        roundtrip_config["text_config"] = SimpleNamespace(**roundtrip_text_config)
         roundtrip_pretrained.config = SimpleNamespace(**roundtrip_config)
         restored = bridge.provider_bridge(roundtrip_pretrained)
 

--- a/tests/unit_tests/models/test_auto_bridge.py
+++ b/tests/unit_tests/models/test_auto_bridge.py
@@ -329,6 +329,41 @@ class TestAutoBridge:
 
         assert source.save_generator_kwargs["ignored_source_key_prefixes"] is None
 
+    def test_save_hf_weights_prepends_bridge_passthrough_tensors(self, tmp_path):
+        """Composite bridges can preserve source-only tensors during HF save."""
+        source = _make_fake_source(present=set())
+        saved_pairs = []
+
+        def capture_generator(generator, _path, **_kwargs):
+            saved_pairs.extend(generator)
+
+        source.save_generator.side_effect = capture_generator
+        hf_pretrained = SimpleNamespace(
+            config=SimpleNamespace(),
+            state=SimpleNamespace(source=source),
+        )
+
+        class CompositeBridge:
+            def stream_weights_megatron_to_hf(self, *_args, **_kwargs):
+                return iter([("language.weight", torch.ones(1))])
+
+            def stream_hf_export_passthrough(self, *_args, **_kwargs):
+                return iter([("vision.weight", torch.zeros(1))])
+
+        bridge_obj = object.__new__(AutoBridge)
+        bridge_obj.hf_pretrained = hf_pretrained
+        composite_bridge = CompositeBridge()
+        model_instance = SimpleNamespace(config=SimpleNamespace(mtp_num_layers=1))
+
+        with (
+            patch.object(AutoBridge, "_model_bridge", new_callable=PropertyMock, return_value=composite_bridge),
+            patch.object(AutoBridge, "_get_model_instance", return_value=model_instance),
+            patch("modelopt.torch.quantization.utils.is_quantized", return_value=False),
+        ):
+            bridge_obj.save_hf_weights([Mock()], tmp_path, show_progress=False)
+
+        assert [name for name, _tensor in saved_pairs] == ["vision.weight", "language.weight"]
+
     def _run_save_hf_weights(self, source, tmp_path, *, mtp_num_layers):
         """Drive ``save_hf_weights`` with a stubbed bridge/model so the only
         behavior under test is the MTP prefix-resolution wiring.


### PR DESCRIPTION
## Summary

- add an explicit bridge capability for exports that require the original Hugging Face checkpoint
- reject config-only CPU export before preparing output or loading a Megatron checkpoint
- cover launcher and public AutoBridge failure paths

## Dependency

Stacked on #5002, which introduces the MiniMax-M3 source-overlay export that needs this capability.

## Testing

- `uv run python -m pytest --confcutdir=tests/unit_tests/conversion/launcher tests/unit_tests/conversion/launcher/test_cpu_backend.py -q` (2 passed)
- `uv run pre-commit run --all-files` (passed)