### PR TITLE
test(recipes): drop brittle count asserts from recipe env invariants

### DIFF
--- a/tests/unit_tests/recipes/test_recipe_environment_defaults.py
+++ b/tests/unit_tests/recipes/test_recipe_environment_defaults.py
@@ -129,14 +129,12 @@ def test_every_supported_hardware_recipe_declares_its_environment_inline():
 
 def test_explicit_recipe_environment_invariants():
     recipes = list(_explicit_environments())
-    hybrid_ep_count = 0
     deepseek_v3_environment_recipe_names = set()
 
     for path, function_name, environment in recipes:
         hybrid_ep_names = environment.keys() & _HYBRID_EP_ENV_NAMES
         assert not hybrid_ep_names or hybrid_ep_names == _HYBRID_EP_ENV_NAMES
         if hybrid_ep_names:
-            hybrid_ep_count += 1
             assert environment["NVLINK_DOMAIN_SIZE"] == 8
             assert environment["USE_MNNVL"] == 0
             assert environment["NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN"] in {1, 8}
@@ -156,8 +154,6 @@ def test_explicit_recipe_environment_invariants():
                 assert environment["NVTE_FWD_LAYERNORM_SM_MARGIN"] == 20
                 assert environment["NVTE_BWD_LAYERNORM_SM_MARGIN"] == 20
 
-    assert len(recipes) == 259
-    assert hybrid_ep_count == 10
     assert deepseek_v3_environment_recipe_names == _DEEPSEEK_V3_ENVIRONMENT_RECIPE_NAMES
 
 


### PR DESCRIPTION
## What

Removes two snapshot count assertions at the end of `test_explicit_recipe_environment_invariants` in `tests/unit_tests/recipes/test_recipe_environment_defaults.py`:

- `assert len(recipes) == N` — **redundant** with `assert len(supported) == N` in the sibling `test_every_supported_hardware_recipe_declares_its_environment_inline`. Both iterate the identical canonical-recipe population (same name regex, same "has a return" filter), so this is a duplicate count guard.
- `assert hybrid_ep_count == N` — only pins the *size* of the hybrid-EP recipe population. The per-recipe value checks it sits next to (all-or-nothing hybrid-EP var set, `NVLINK_DOMAIN_SIZE == 8`, `USE_MNNVL == 0`, ranks `in {1, 8}`) are the real coverage and are unchanged.

The now-unused `hybrid_ep_count` counter is removed with it.

## Why

These magic-number counts force a manual bump on every recipe add/remove — unrelated to what the test actually validates — without adding coverage the surviving per-recipe invariants don't already provide. A recent example: adding the EXAONE recipes broke this test purely on the count, not on any real invariant.

## Unchanged

- The per-recipe hybrid-EP and deepseek layernorm-margin value asserts.
- The named-set check `deepseek_v3_environment_recipe_names == _DEEPSEEK_V3_ENVIRONMENT_RECIPE_NAMES`.
- The count guard `len(supported)` in the sibling test (still enforces every canonical recipe declares its env inline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)