### PR TITLE
test(recipes): stop pinning exact recipe count in env invariant

### DIFF
--- a/tests/unit_tests/recipes/test_recipe_environment_defaults.py
+++ b/tests/unit_tests/recipes/test_recipe_environment_defaults.py
@@ -123,7 +123,7 @@ def test_every_supported_hardware_recipe_declares_its_environment_inline():
             )
             assert isinstance(node.body[assignment_index + 1], ast.Return)
 
-    assert len(supported) == 259
+    assert supported, "no canonical h100 recipes discovered (glob or naming convention broke?)"
     assert unsupported == ["qwen/h100/qwen3_next.py:qwen3_next_80b_a3b_peft_1gpu_h100_bf16_config"]
 
 


### PR DESCRIPTION
## What

Changes the tail of `test_every_supported_hardware_recipe_declares_its_environment_inline` from an exact count to a truthiness check:

```python
-    assert len(supported) == 259
+    assert supported, "no canonical h100 recipes discovered — did the glob or naming convention break?"
```

## Why

`assert len(supported) == N` forced a magic-number bump on **every** recipe addition and is a merge-conflict magnet between concurrent recipe PRs — while adding no coverage. The real enforcement (every canonical h100 recipe declares `cfg.env_vars` inline) runs *inside the loop* via `_explicit_environment`, on every recipe the glob finds, independent of the count.

The only thing the exact count actually protected was the whole test silently going **vacuous** — if the discovery glob (`*/h100/*.py`) or the `_CANONICAL_RECIPE_NAME` convention ever breaks and matches zero functions, the loop runs zero times and every per-recipe assert passes trivially. `assert supported` preserves that anti-vacuity guarantee with none of the per-recipe friction.

## Follow-up to

#5056 (which removed the redundant `len(recipes)` and the `hybrid_ep_count` magic number from the sibling test). This removes the last remaining brittle count in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)