### PR TITLE
fix(model): forward Qwen3-VL output processor hooks

### DIFF
--- a/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/text_model.py
+++ b/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/text_model.py
@@ -19,7 +19,7 @@ Copied from https://github.com/Thaurun/mbridge/blob/4462d1e284626d2ed9d3e3e
 """
 
 from dataclasses import replace
-from typing import Literal, Optional
+from typing import Any, Callable, Literal, Optional
 
 import torch
 from megatron.core import tensor_parallel
@@ -161,6 +161,8 @@ class Qwen3VLGPTModel(GPTModel):
         # args for deepstack
         visual_pos_masks: Optional[torch.Tensor] = None,
         deepstack_visual_embeds: Optional[list[torch.Tensor]] = None,
+        output_processor: Callable[..., Tensor] | None = None,
+        output_processor_context: Any | None = None,
     ) -> Tensor:
         """Forward function of the GPT Model This function passes the input tensors
         through the embedding layer, and then the decoeder and finally into the post
@@ -173,6 +175,10 @@ class Qwen3VLGPTModel(GPTModel):
         Args:
             runtime_gather_output (bool): Gather output at runtime. Default None means
                 `parallel_output` arg in the constructor will be used.
+            output_processor (Callable, optional): Custom postprocess hook forwarded to
+                the GPT model postprocessing path.
+            output_processor_context (Any, optional): User-defined context forwarded to
+                `output_processor`.
         """
 
         inference_context = deprecate_inference_params(inference_context, inference_params)
@@ -251,6 +257,8 @@ class Qwen3VLGPTModel(GPTModel):
             runtime_gather_output=runtime_gather_output,
             extra_block_kwargs=extra_block_kwargs,
             inference_context=inference_context,
+            output_processor=output_processor,
+            output_processor_context=output_processor_context,
         )
 
         if _shadow_embedding:

--- a/tests/unit_tests/models/qwen_vl/modelling_qwen3_vl/test_text_model_forward.py
+++ b/tests/unit_tests/models/qwen_vl/modelling_qwen3_vl/test_text_model_forward.py
@@ -84,6 +84,29 @@ def test_forward_accepts_extra_preprocess_output():
     assert dummy.postprocess_args["decoder_input"] is preproc[0]
 
 
+def test_forward_forwards_output_processor_hook():
+    """Forward accepts and passes output-processor arguments to postprocessing."""
+    dummy = _DummyModel()
+
+    def output_processor(**kwargs):
+        return kwargs
+
+    output_processor_context = object()
+
+    output = Qwen3VLGPTModel.forward(
+        dummy,
+        input_ids=torch.zeros((1, 4), dtype=torch.long),
+        position_ids=torch.zeros((1, 4), dtype=torch.long),
+        attention_mask=torch.ones((1, 4), dtype=torch.long),
+        output_processor=output_processor,
+        output_processor_context=output_processor_context,
+    )
+
+    assert output == "ok"
+    assert dummy.postprocess_args["output_processor"] is output_processor
+    assert dummy.postprocess_args["output_processor_context"] is output_processor_context
+
+
 def test_mtp_sequence_parallel_embedding_scatter_uses_tp_group(monkeypatch):
     """The MTP embedding wrapper must not fall back to global tensor-parallel state."""
     expected_group = object()


### PR DESCRIPTION
## Summary

- accept `output_processor` and `output_processor_context` in `Qwen3VLGPTModel.forward`
- forward both arguments to the inherited GPT model postprocessing path
- add a focused regression test for keyword acceptance and object-identity forwarding

Fixes #5031

## Tests

- `uv run --no-project --with pre-commit pre-commit run --all-files`
- `uv run --no-sync python -m compileall -q src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/text_model.py tests/unit_tests/models/qwen_vl/modelling_qwen3_vl/test_text_model_forward.py`
- Targeted pytest collection was attempted on macOS, but pinned Megatron-Core imports `triton`, which has no local macOS runtime; Linux CI will run the focused unit test.