### PR TITLE
fix(skill): require one inference run

### DIFF
--- a/skills/create-model-verification-card/SKILL.md
+++ b/skills/create-model-verification-card/SKILL.md
@@ -507,9 +507,10 @@ result. Private executor configuration stays outside the card.
   generation. Choose a prompt whose tokenized length is divisible by TP so the
   helper does not append padding before selecting the compared next-token
   position.
-- **Megatron inference:** Use deterministic greedy generation, specify an exact
-  token count, run twice, and record the literal completion including
-  whitespace.
+- **Megatron inference:** Disable sampling, run one deterministic greedy
+  generation with an exact token count, and record the literal completion
+  including whitespace. A second replay may help diagnose nondeterminism, but
+  it is not required verification evidence.
 - **Pretrain:** Use a bounded public dataset description and a stable schedule.
   Save a middle and final checkpoint when resume is in scope. For expensive
   workloads, a 100-step reference with checkpoints at steps 50 and 100 is a
@@ -520,11 +521,11 @@ result. Private executor configuration stays outside the card.
   decay. Use a public dataset name or preset, not its storage location. Save the
   final full-SFT checkpoint when export verification is in scope.
 - **SFT export and inference:** Depend on `sft`, export its final full-model
-  checkpoint to HF, reload the exported model with Transformers, and run greedy
-  generation twice. Store this item as an ordered `commands` list containing
-  exactly two strings: the synchronous Slurm export first and the `uv run` HF
-  inference second. Specify an exact new-token count and record the literal
-  byte-identical completion, including whitespace, in `expected_result`.
+  checkpoint to HF, reload the exported model with Transformers, and run one
+  deterministic greedy generation. Store this item as an ordered `commands`
+  list containing exactly two strings: the synchronous Slurm export first and
+  the `uv run` HF inference second. Specify an exact new-token count and record
+  the literal completion, including whitespace, in `expected_result`.
 - **Long-context SFT:** Verify sequence packing and CP together. Record CP only
   when its size is greater than one.
 - **Checkpoint resume:** Depend on `pretrain`; load its middle checkpoint

--- a/skills/create-model-verification-card/scripts/validate_card.py
+++ b/skills/create-model-verification-card/scripts/validate_card.py
@@ -1078,14 +1078,6 @@ def _validate_inference(
             )
         if len(prompts) == 1 and literal.strip() == prompts[0].strip():
             errors.append(f"{_pointer(*path, 'expected_result')}: literal completion must not repeat the prompt")
-    repeated = re.search(r"\b(?:twice|two\s+(?:independent\s+)?(?:runs|executions))\b", expected, re.IGNORECASE)
-    matched = re.search(
-        r"\b(?:byte[- ](?:for[- ])?byte|byte[- ]identical|identical|match(?:es|ed)?)\b", expected, re.IGNORECASE
-    )
-    if repeated is None or matched is None:
-        errors.append(
-            f"{_pointer(*path, 'expected_result')}: state that two independent runs produced byte-identical output"
-        )
     if re.search(r"\bdo[_-]sample(?:=|\s+)(?:true|1)\b", command, re.IGNORECASE):
         errors.append(f"{_pointer(*resolved_command_path)}: inference verification must be deterministic")
 

--- a/skills/create-model-verification-card/scripts/verify_hf_inference.py
+++ b/skills/create-model-verification-card/scripts/verify_hf_inference.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Verify deterministic, exact-length inference from an exported HF checkpoint."""
+"""Run greedy, exact-length inference from an exported HF checkpoint."""
 
 from __future__ import annotations
 
@@ -70,7 +70,7 @@ def _format_prompt(tokenizer: Any, prompt: str, *, chat_template: bool, disable_
 
 
 def main() -> int:
-    """Run two exact-length greedy generations and print their shared completion."""
+    """Run one exact-length greedy generation and print its completion."""
     args = _parse_args()
 
     import torch
@@ -97,27 +97,21 @@ def main() -> int:
     prompt_length = inputs["input_ids"].shape[1]
     pad_token_id = tokenizer.pad_token_id if tokenizer.pad_token_id is not None else tokenizer.eos_token_id
 
-    outputs = []
     with torch.inference_mode():
-        for _ in range(2):
-            outputs.append(
-                model.generate(
-                    **inputs,
-                    do_sample=False,
-                    min_new_tokens=args.max_new_tokens,
-                    max_new_tokens=args.max_new_tokens,
-                    pad_token_id=pad_token_id,
-                )
-            )
+        output = model.generate(
+            **inputs,
+            do_sample=False,
+            min_new_tokens=args.max_new_tokens,
+            max_new_tokens=args.max_new_tokens,
+            pad_token_id=pad_token_id,
+        )
 
     expected_length = prompt_length + args.max_new_tokens
-    if any(output.shape != (1, expected_length) for output in outputs):
-        lengths = [output.shape[1] - prompt_length for output in outputs]
-        raise RuntimeError(f"Expected exactly {args.max_new_tokens} generated tokens; observed {lengths}")
-    if not torch.equal(outputs[0], outputs[1]):
-        raise RuntimeError("Two greedy HF inference runs produced different token IDs")
+    if output.shape != (1, expected_length):
+        observed_length = output.shape[1] - prompt_length
+        raise RuntimeError(f"Expected exactly {args.max_new_tokens} generated tokens; observed {observed_length}")
 
-    completion_ids = outputs[0][0, prompt_length:].tolist()
+    completion_ids = output[0, prompt_length:].tolist()
     completion = tokenizer.decode(completion_ids, skip_special_tokens=True)
     LOG.info("HF completion (%d tokens): %s", args.max_new_tokens, json.dumps(completion, ensure_ascii=False))
     return 0


### PR DESCRIPTION
## Summary

- make one bounded deterministic greedy generation sufficient inference evidence
- keep a second replay as an optional nondeterminism diagnostic
- update the HF inference helper to call `generate()` once
- retain existing two-run card results as valid historical evidence

The two-command post-SFT flow is unchanged: one export command followed by one inference command.

## Testing

- validated the skill with `quick_validate.py`
- validated all five existing model verification cards
- verified a one-run result without `twice` or `byte-identical` language passes the card validator
- verified the HF helper calls `generate()` exactly once with a fake model
- `uv run --no-project --with pre-commit pre-commit run --all-files`
