### PR TITLE
[test] fix: remove recipe inventory count assertions

### DIFF
--- a/tests/unit_tests/recipes/test_perf_recipe_environment.py
+++ b/tests/unit_tests/recipes/test_perf_recipe_environment.py
@@ -29,10 +29,6 @@ _CANONICAL_RECIPE_NAME = re.compile(
     r".+_(?:pretrain|sft|peft)_\d+gpu_[a-z0-9]+_(?:bf16|fp8cs|fp8mx|fp8sc|nvfp4)(?:_.+)?_config"
 )
 _RECIPE_ROOT = Path(__file__).resolve().parents[3] / "src" / "megatron" / "bridge" / "perf_recipes"
-# Deliberately lock the discovered public inventory; update this for intentional recipe additions or removals.
-_EXPECTED_FLAT_RECIPE_COUNT = 410
-_EXPECTED_DEEPSEEK_RECIPE_COUNT = 39
-_EXPECTED_DEEPSEEK_HYBRID_EP_RECIPE_COUNT = 37
 _INLINE_CORE_ENV_NAMES = {
     "CUDA_DEVICE_MAX_CONNECTIONS",
     "NCCL_NVLS_ENABLE",
@@ -128,7 +124,6 @@ def test_benchmark_common_preserves_legacy_manual_gc_defaults():
 
 
 def test_every_flat_recipe_builder_declares_its_environment_inline():
-    builders = []
     invalid = []
 
     for path in _RECIPE_ROOT.glob("*/*/*.py"):
@@ -136,11 +131,11 @@ def test_every_flat_recipe_builder_declares_its_environment_inline():
         for node in tree.body:
             if not isinstance(node, ast.FunctionDef) or _CANONICAL_RECIPE_NAME.fullmatch(node.name) is None:
                 continue
-            builders.append(f"{path.relative_to(_RECIPE_ROOT)}:{node.name}")
+            builder = f"{path.relative_to(_RECIPE_ROOT)}:{node.name}"
             try:
                 _explicit_environment(path, node.name)
             except AssertionError:
-                invalid.append(builders[-1])
+                invalid.append(builder)
             assert not any(
                 isinstance(decorator, ast.Call)
                 and isinstance(decorator.func, ast.Name)
@@ -148,17 +143,12 @@ def test_every_flat_recipe_builder_declares_its_environment_inline():
                 for decorator in node.decorator_list
             )
 
-    assert len(builders) == _EXPECTED_FLAT_RECIPE_COUNT
     assert not invalid
 
 
 def test_explicit_environment_invariants_across_all_flat_recipes():
     """Keep duplicated inline settings complete without deriving them at runtime."""
-    recipes = list(_explicit_environments())
-    deepseek_recipe_count = 0
-    deepseek_hybrid_ep_count = 0
-
-    for path, function_name, environment in recipes:
+    for path, function_name, environment in _explicit_environments():
         assert environment.keys() >= _INLINE_CORE_ENV_NAMES
 
         cudnn_names = {"NVTE_NORM_BWD_USE_CUDNN", "NVTE_NORM_FWD_USE_CUDNN"}
@@ -176,7 +166,6 @@ def test_explicit_environment_invariants_across_all_flat_recipes():
         if "_nvfp4" in function_name:
             assert environment["NVTE_USE_FAST_MATH"] == 1
         if path.parts[-3] == "deepseek":
-            deepseek_recipe_count += 1
             assert environment.keys().isdisjoint(_DEEPSEEK_NON_BASELINE_ENV_NAMES)
             assert environment["NVTE_FWD_LAYERNORM_SM_MARGIN"] == 20
             assert environment["NVTE_BWD_LAYERNORM_SM_MARGIN"] == 20
@@ -187,11 +176,6 @@ def test_explicit_environment_invariants_across_all_flat_recipes():
                 assert not hybrid_ep_names
             else:
                 assert hybrid_ep_names == _HYBRID_EP_ENV_NAMES
-                deepseek_hybrid_ep_count += 1
-
-    assert len(recipes) == _EXPECTED_FLAT_RECIPE_COUNT
-    assert deepseek_recipe_count == _EXPECTED_DEEPSEEK_RECIPE_COUNT
-    assert deepseek_hybrid_ep_count == _EXPECTED_DEEPSEEK_HYBRID_EP_RECIPE_COUNT
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/scripts/training/test_recipe_metadata.py
+++ b/tests/unit_tests/scripts/training/test_recipe_metadata.py
@@ -56,7 +56,6 @@ def test_every_flat_recipe_has_registered_family_and_metadata():
         if module.BENCHMARK_RECIPE_PATTERN.search(recipe_name)
     ]
 
-    assert len(recipes) > 300
     for recipe_name, owning_family in recipes:
         metadata = module.available_benchmark_recipe_metadata(recipe_name)
         assert metadata is not None
@@ -68,7 +67,6 @@ def test_every_exported_benchmark_name_has_canonical_metadata():
     recipe_names = module.benchmark_recipe_names()
     public_modes = {"pretrain": "pretrain", "sft": "sft", "peft": "lora"}
 
-    assert len(recipe_names) > 300
     for recipe_name in recipe_names:
         metadata = module.available_benchmark_recipe_metadata(recipe_name)
         assert metadata is not None


### PR DESCRIPTION
## What does this PR do?

Removes hard-coded recipe inventory count assertions from CI tests. The tests continue to discover recipes dynamically and validate every discovered recipe environment and metadata entry, without requiring unrelated count updates whenever recipes are added or removed.

This also removes the broad greater-than-300 recipe count guards from the training recipe metadata tests. A repository-wide scan found no other model or recipe inventory count assertions; semantic checks for model structure, mappings, parameters, and parallelism remain unchanged.

## Testing

- `uv run --active --no-sync pre-commit run --all-files` — passed
- Targeted pytest collection was attempted but the local environment has `nvidia-resiliency-ext` below the 0.6.0 minimum required by the pinned Megatron-Core, so collection stops before these tests execute. CI will run them in the supported environment.

Signed-off-by: Yu Yao <yuy@nvidia.com>