### PR TITLE
feat(recipe): add Qwen3 30B GB200 MXFP8 verification

### DIFF
--- a/examples/model_verification_cards/qwen3-30b-a3b/card.yaml
+++ b/examples/model_verification_cards/qwen3-30b-a3b/card.yaml
@@ -20,7 +20,8 @@ verification_index:
     H100:
       verified: [pretrain, sft, sft_export_inference, sft_long_context, peft, checkpoint_resume]
     GB200:
-      unverified: [pretrain, sft, sft_export_inference, sft_long_context, peft, checkpoint_resume]
+      verified: [pretrain]
+      unverified: [sft, sft_export_inference, sft_long_context, peft, checkpoint_resume]
   performance:
     H100: verified
 model:
@@ -29,7 +30,7 @@ model:
   architecture: Qwen3MoeForCausalLM
   min_transformers_version: "5.8.1"
 verification_environment:
-  base_container: nvcr.io/nvidia/pytorch:26.04-py3
+  base_container: nvcr.io/nvidia/nemo:26.06
   bridge_commit: aabb29d0ed15fc7ed881f0538352c6bd2d2fd52d  # pragma: allowlist secret
 
 items:
@@ -175,6 +176,54 @@ items:
         moe_preprocess remain active. Loss is finite from 12.41145 to 6.139116
         with no skipped or NaN iterations, all four metrics are recorded, and
         complete iter_0000050 and iter_0000100 checkpoints are saved.
+
+    GB200:
+      status: verified
+      precision: fp8_mx
+      bridge_commit: ee8fcd73faee4a7e5369116469cc939d44f33911  # pragma: allowlist secret
+      enabled_features:
+        cuda_graph:
+          implementation: transformer_engine
+          scopes: [moe_router, moe_preprocess]
+        moe_dispatcher: hybridep
+      command: >
+        ./scripts/training/train.sh --nodes 2 --gpus-per-node 4
+        --recipe qwen3_30b_a3b_pretrain_8gpu_gb200_fp8mx_functional_config
+        --mode pretrain --dataset megatron-indexed --seq_length 4096
+        --max_steps 100 --lr 3e-4 --min_lr 3e-5 --warmup_iters 40
+        'dataset.blend=[["work/data/rp2/head_01"],null]'
+        dataset.path_to_cache=work/cache/qwen3-30b-a3b/rp2
+        tokenizer.tokenizer_type=SentencePieceTokenizer
+        tokenizer.tokenizer_model=work/data/rp2/tokenizer.model
+        scheduler.lr_decay_iters=100
+        model.moe_router_force_load_balancing=false
+        ddp.check_for_nan_in_grad=true ddp.check_for_large_grads=true
+        rerun_state_machine.check_for_nan_in_loss=true
+        checkpoint.load=null checkpoint.save_optim=true checkpoint.save_rng=true
+        checkpoint.load_optim=true checkpoint.load_rng=true checkpoint.finetune=false
+        validation.eval_iters=0 validation.eval_interval=0
+        dataset.random_seed=1234 dataset.num_workers=8 rng.seed=1234
+        dist.distributed_timeout_minutes=30
+        --save_dir work/model-verification/qwen3-30b-a3b/pretrain-mxfp8-gb200-reference-v2-checkpoints
+        --save_interval 50 logger.log_interval=1 logger.log_throughput=true
+        logger.tensorboard_dir=null
+      last_verified: 2026-07-23
+      metrics:
+        initial_loss: 12.41293
+        final_loss: 6.134433
+        last_10_steps_step_time_ms_avg: 14709.940
+        last_10_steps_model_tflops_per_gpu_avg: 418.070
+      expected_result: >
+        On 8x GB200, this support-verification workload completes exactly 100
+        bounded RP2 optimizer steps with TP1/PP1/CP1/EP8/ETP1, DP8, SP off,
+        GBS/MBS 512/4, and 16-way gradient accumulation. MXFP8 compute, natural
+        routing, HybridEP, Transformer Engine CUDA graphs for moe_router and
+        moe_preprocess, communication overlap, functional safety checks, and
+        BF16 parameter all-gather remain active. Loss is finite from 12.41293
+        to 6.134433 with no skipped or NaN iterations, all four metrics are
+        recorded, and complete eight-shard iter_0000050 and iter_0000100
+        checkpoints are saved. Timing and throughput are support sanity checks,
+        not cross-model convergence or tuned performance claims.
 
   sft:
     H100:

--- a/examples/model_verification_cards/qwen3-30b-a3b/card.yaml
+++ b/examples/model_verification_cards/qwen3-30b-a3b/card.yaml
@@ -180,7 +180,7 @@ items:
     GB200:
       status: verified
       precision: fp8_mx
-      bridge_commit: ee8fcd73faee4a7e5369116469cc939d44f33911  # pragma: allowlist secret
+      bridge_commit: bf09638e1a3b426605f5f9ae651af4d4fb33830b  # pragma: allowlist secret
       enabled_features:
         cuda_graph:
           implementation: transformer_engine
@@ -204,23 +204,23 @@ items:
         validation.eval_iters=0 validation.eval_interval=0
         dataset.random_seed=1234 dataset.num_workers=8 rng.seed=1234
         dist.distributed_timeout_minutes=30
-        --save_dir work/model-verification/qwen3-30b-a3b/pretrain-mxfp8-gb200-reference-v2-checkpoints
+        --save_dir work/model-verification/qwen3-30b-a3b/pretrain-mxfp8-gb200-reference-checkpoints
         --save_interval 50 logger.log_interval=1 logger.log_throughput=true
         logger.tensorboard_dir=null
       last_verified: 2026-07-23
       metrics:
         initial_loss: 12.41293
-        final_loss: 6.134433
-        last_10_steps_step_time_ms_avg: 14709.940
-        last_10_steps_model_tflops_per_gpu_avg: 418.070
+        final_loss: 6.106341
+        last_10_steps_step_time_ms_avg: 12394.990
+        last_10_steps_model_tflops_per_gpu_avg: 486.580
       expected_result: >
         On 8x GB200, this support-verification workload completes exactly 100
         bounded RP2 optimizer steps with TP1/PP1/CP1/EP8/ETP1, DP8, SP off,
         GBS/MBS 512/4, and 16-way gradient accumulation. MXFP8 compute, natural
         routing, HybridEP, Transformer Engine CUDA graphs for moe_router and
         moe_preprocess, communication overlap, functional safety checks, and
-        BF16 parameter all-gather remain active. Loss is finite from 12.41293
-        to 6.134433 with no skipped or NaN iterations, all four metrics are
+        MXFP8 parameter all-gather remain active. Loss is finite from 12.41293
+        to 6.106341 with no skipped or NaN iterations, all four metrics are
         recorded, and complete eight-shard iter_0000050 and iter_0000100
         checkpoints are saved. Timing and throughput are support sanity checks,
         not cross-model convergence or tuned performance claims.

--- a/examples/model_verification_cards/qwen3-30b-a3b/card.yaml
+++ b/examples/model_verification_cards/qwen3-30b-a3b/card.yaml
@@ -3,9 +3,10 @@
 
 title: qwen3_30b_a3b
 summary: >
-  Performance scope: only pretrain_performance.H100 uses the tuned canonical
-  performance recipe; timing and throughput metrics from functional training
-  items remain sanity checks rather than optimized performance results.
+  Performance scope: pretrain_performance.H100 and pretrain_performance.GB200
+  use tuned canonical performance recipes; timing and throughput metrics from
+  functional training items remain sanity checks rather than optimized
+  performance results.
   Qwen3-30B-A3B support verification covers conversion, inference, and training.
 verification_index:
   model_level:
@@ -20,10 +21,11 @@ verification_index:
     H100:
       verified: [pretrain, sft, sft_export_inference, sft_long_context, peft, checkpoint_resume]
     GB200:
-      verified: [pretrain]
-      unverified: [sft, sft_export_inference, sft_long_context, peft, checkpoint_resume]
+      verified: [pretrain, checkpoint_resume]
+      unverified: [sft, sft_export_inference, sft_long_context, peft]
   performance:
     H100: verified
+    GB200: verified
 model:
   hf_id: Qwen/Qwen3-30B-A3B
   hf_revision: ad44e777bcd18fa416d9da3bd8f70d33ebb85d39  # pragma: allowlist secret
@@ -180,7 +182,7 @@ items:
     GB200:
       status: verified
       precision: fp8_mx
-      bridge_commit: bf09638e1a3b426605f5f9ae651af4d4fb33830b  # pragma: allowlist secret
+      bridge_commit: 487f563983f00b190a1a8322d663f317ad8e611c  # pragma: allowlist secret
       enabled_features:
         cuda_graph:
           implementation: transformer_engine
@@ -210,9 +212,9 @@ items:
       last_verified: 2026-07-23
       metrics:
         initial_loss: 12.41293
-        final_loss: 6.106341
-        last_10_steps_step_time_ms_avg: 12394.990
-        last_10_steps_model_tflops_per_gpu_avg: 486.580
+        final_loss: 6.183484
+        last_10_steps_step_time_ms_avg: 12362.340
+        last_10_steps_model_tflops_per_gpu_avg: 487.880
       expected_result: >
         On 8x GB200, this support-verification workload completes exactly 100
         bounded RP2 optimizer steps with TP1/PP1/CP1/EP8/ETP1, DP8, SP off,
@@ -220,7 +222,7 @@ items:
         routing, HybridEP, Transformer Engine CUDA graphs for moe_router and
         moe_preprocess, communication overlap, functional safety checks, and
         MXFP8 parameter all-gather remain active. Loss is finite from 12.41293
-        to 6.106341 with no skipped or NaN iterations, all four metrics are
+        to 6.183484 with no skipped or NaN iterations, all four metrics are
         recorded, and complete eight-shard iter_0000050 and iter_0000100
         checkpoints are saved. Timing and throughput are support sanity checks,
         not cross-model convergence or tuned performance claims.
@@ -445,6 +447,58 @@ items:
         6.145390 differs from reference 6.139116 by 0.102197%, within the declared
         one-percent gate, so both sentinels match and all four metrics are recorded.
 
+    GB200:
+      status: verified
+      precision: fp8_mx
+      bridge_commit: 487f563983f00b190a1a8322d663f317ad8e611c  # pragma: allowlist secret
+      depends_on: pretrain
+      command: >
+        ./scripts/training/train.sh --nodes 2 --gpus-per-node 4
+        --recipe qwen3_30b_a3b_pretrain_8gpu_gb200_fp8mx_functional_config
+        --mode pretrain --dataset megatron-indexed --seq_length 4096
+        --max_steps 100 --lr 3e-4 --min_lr 3e-5 --warmup_iters 40
+        'dataset.blend=[["work/data/rp2/head_01"],null]'
+        dataset.path_to_cache=work/cache/qwen3-30b-a3b/rp2
+        tokenizer.tokenizer_type=SentencePieceTokenizer
+        tokenizer.tokenizer_model=work/data/rp2/tokenizer.model
+        scheduler.lr_decay_iters=100
+        model.moe_router_force_load_balancing=false
+        ddp.check_for_nan_in_grad=true ddp.check_for_large_grads=true
+        rerun_state_machine.check_for_nan_in_loss=true
+        checkpoint.save_optim=true checkpoint.save_rng=true
+        checkpoint.load_optim=true checkpoint.load_rng=true checkpoint.finetune=false
+        validation.eval_iters=0 validation.eval_interval=0
+        dataset.random_seed=1234 dataset.num_workers=8 rng.seed=1234
+        dist.distributed_timeout_minutes=30
+        --load_dir work/model-verification/qwen3-30b-a3b/pretrain-mxfp8-gb200-reference-checkpoints
+        --save_dir work/model-verification/qwen3-30b-a3b/pretrain-mxfp8-gb200-resumed-checkpoints
+        --save_interval 50 checkpoint.ckpt_step=50
+        train.empty_unused_memory_level=2
+        logger.log_interval=1 logger.log_throughput=true
+        logger.tensorboard_dir=null
+      last_verified: 2026-07-23
+      metrics:
+        initial_loss: 6.774675
+        final_loss: 6.187264
+        last_10_steps_step_time_ms_avg: 18694.970
+        last_10_steps_model_tflops_per_gpu_avg: 322.620
+      resume_comparison:
+        reference_item: pretrain
+        sentinel_steps: [51, 100]
+        loss_relative_tolerance: 1.0e-2
+        loss_absolute_tolerance: 1.0e-6
+        sentinels_match: true
+      expected_result: >
+        The command restores optimizer, scheduler, data-order, and RNG state
+        from iter_0000050, keeps the MXFP8 forward pre-hook active before the
+        first resumed forward pass, begins at step 51, and finishes at step 100
+        in a distinct resumed root with finite losses and no skipped or NaN
+        iterations. Step-51 loss 6.774675 matches the uninterrupted reference
+        exactly; step-100 loss 6.187264 differs from reference 6.183484 by
+        0.061131%, within the declared one-percent gate. Both sentinels match,
+        all four metrics are recorded, and a complete iter_0000100 checkpoint
+        is saved.
+
   pretrain_performance:
     H100:
       status: verified
@@ -467,3 +521,24 @@ items:
         layers with moe_router and moe_preprocess scopes. Over steps 41-50, the
         run averages at most 27 seconds per step and at least 225 model
         TFLOP/s/GPU, while peak allocated memory remains below 65 GiB/GPU.
+
+    GB200:
+      status: verified
+      precision: fp8_mx
+      bridge_commit: 6e1b47893e3c174e74a97fb1730c9f58387ab882  # pragma: allowlist secret
+      command: >
+        ./scripts/training/train.sh --nodes 2 --gpus-per-node 4
+        --recipe qwen3_30b_a3b_pretrain_8gpu_gb200_fp8mx_config --max_steps 50
+      last_verified: 2026-07-23
+      metrics:
+        initial_loss: 12.347540
+        final_loss: 8.112733
+        last_10_steps_step_time_ms_avg: 6501.120
+        last_10_steps_model_tflops_per_gpu_avg: 927.680
+      expected_result: >
+        On two nodes with 8x GB200, the exact mock-data performance recipe
+        completes exactly 50 steps with finite losses, no skipped or NaN
+        iterations, and all four metrics recorded. The benchmark uses forced
+        load balancing, HybridEP, MXFP8, and full-iteration CUDA graphs. Over
+        steps 41-50, the run averages at most 7 seconds per step and at least
+        900 model TFLOP/s/GPU.

--- a/src/megatron/bridge/recipes/qwen/__init__.py
+++ b/src/megatron/bridge/recipes/qwen/__init__.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Qwen3 GB200 models
+from .gb200.qwen3_moe import qwen3_30b_a3b_pretrain_8gpu_gb200_fp8mx_functional_config
+
 # Qwen3.5 GB200 models
 from .gb200.qwen35 import (
     qwen35_text_9b_pretrain_8gpu_gb200_bf16_config,
@@ -155,6 +158,7 @@ __all__ = [
     "qwen3_32b_peft_config",
     # Qwen3 MoE models
     "qwen3_30b_a3b_pretrain_config",
+    "qwen3_30b_a3b_pretrain_8gpu_gb200_fp8mx_functional_config",
     "qwen3_30b_a3b_sft_config",
     "qwen3_30b_a3b_peft_config",
     "qwen3_235b_a22b_pretrain_config",

--- a/src/megatron/bridge/recipes/qwen/gb200/__init__.py
+++ b/src/megatron/bridge/recipes/qwen/gb200/__init__.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from megatron.bridge.recipes.qwen.gb200.qwen3_moe import (
+    qwen3_30b_a3b_pretrain_8gpu_gb200_fp8mx_functional_config,
+)
 from megatron.bridge.recipes.qwen.gb200.qwen35 import (
     qwen35_text_9b_pretrain_8gpu_gb200_bf16_config,
     qwen35_text_35b_a3b_pretrain_8gpu_gb200_bf16_config,
@@ -19,6 +22,7 @@ from megatron.bridge.recipes.qwen.gb200.qwen35 import (
 
 
 __all__ = [
+    "qwen3_30b_a3b_pretrain_8gpu_gb200_fp8mx_functional_config",
     "qwen35_text_9b_pretrain_8gpu_gb200_bf16_config",
     "qwen35_text_35b_a3b_pretrain_8gpu_gb200_bf16_config",
 ]

--- a/src/megatron/bridge/recipes/qwen/gb200/qwen3_moe.py
+++ b/src/megatron/bridge/recipes/qwen/gb200/qwen3_moe.py
@@ -28,16 +28,18 @@ from megatron.bridge.training.mixed_precision import bf16_with_mxfp8_mixed
 def qwen3_30b_a3b_pretrain_8gpu_gb200_fp8mx_functional_config() -> ConfigContainer:
     """Return a checkpointable Qwen3-30B-A3B MXFP8 pretraining config for eight GB200 GPUs.
 
-    The Blackwell topology, precision, dispatcher, overlap, kernels, batch
-    sizes, and environment follow the corresponding flat performance recipe.
-    Functional verification keeps natural routing and safety checks enabled,
-    runs 100 optimizer steps, and uses scoped Transformer Engine CUDA graphs
-    because full-iteration graphs are incompatible with loss-NaN checking.
+    The Blackwell topology, compute precision, dispatcher, overlap, kernels,
+    batch sizes, and environment follow the corresponding flat performance
+    recipe. Functional verification keeps natural routing and safety checks
+    enabled, runs 100 optimizer steps, and uses BF16 parameter all-gather so
+    checkpoints resume without an MXFP8 grad-buffer restaging transient.
     """
     cfg = qwen3_30b_a3b_pretrain_16gpu_h100_bf16_config()
 
     # Precision and eight-GPU GB200 topology.
     cfg.mixed_precision = bf16_with_mxfp8_mixed()
+    cfg.mixed_precision.fp8_param_gather = False
+    cfg.mixed_precision.reuse_grad_buf_for_mxfp8_param_ag = False
     cfg.mixed_precision.grad_reduce_in_fp32 = False
     cfg.optimizer.use_precision_aware_optimizer = False
     cfg.model.tensor_model_parallel_size = 1

--- a/src/megatron/bridge/recipes/qwen/gb200/qwen3_moe.py
+++ b/src/megatron/bridge/recipes/qwen/gb200/qwen3_moe.py
@@ -31,8 +31,8 @@ def qwen3_30b_a3b_pretrain_8gpu_gb200_fp8mx_functional_config() -> ConfigContain
     The Blackwell topology, compute precision, dispatcher, overlap, kernels,
     batch sizes, and environment follow the corresponding flat performance
     recipe. Functional verification keeps natural routing and safety checks
-    enabled, runs 100 optimizer steps, and uses BF16 parameter all-gather so
-    checkpoints resume without an MXFP8 grad-buffer restaging transient.
+    enabled, runs 100 optimizer steps, and uses BF16 parameter all-gather
+    while retaining MXFP8 forward and backward compute.
     """
     cfg = qwen3_30b_a3b_pretrain_16gpu_h100_bf16_config()
 

--- a/src/megatron/bridge/recipes/qwen/gb200/qwen3_moe.py
+++ b/src/megatron/bridge/recipes/qwen/gb200/qwen3_moe.py
@@ -31,15 +31,12 @@ def qwen3_30b_a3b_pretrain_8gpu_gb200_fp8mx_functional_config() -> ConfigContain
     The Blackwell topology, compute precision, dispatcher, overlap, kernels,
     batch sizes, and environment follow the corresponding flat performance
     recipe. Functional verification keeps natural routing and safety checks
-    enabled, runs 100 optimizer steps, and uses BF16 parameter all-gather
-    while retaining MXFP8 forward and backward compute.
+    enabled and runs 100 optimizer steps with MXFP8 parameter all-gather.
     """
     cfg = qwen3_30b_a3b_pretrain_16gpu_h100_bf16_config()
 
     # Precision and eight-GPU GB200 topology.
     cfg.mixed_precision = bf16_with_mxfp8_mixed()
-    cfg.mixed_precision.fp8_param_gather = False
-    cfg.mixed_precision.reuse_grad_buf_for_mxfp8_param_ag = False
     cfg.mixed_precision.grad_reduce_in_fp32 = False
     cfg.optimizer.use_precision_aware_optimizer = False
     cfg.model.tensor_model_parallel_size = 1

--- a/src/megatron/bridge/recipes/qwen/gb200/qwen3_moe.py
+++ b/src/megatron/bridge/recipes/qwen/gb200/qwen3_moe.py
@@ -1,0 +1,101 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""GB200 functional recipes for Qwen3 MoE models."""
+
+from __future__ import annotations
+
+from megatron.bridge.recipes.qwen.h100.qwen3_moe import (
+    qwen3_30b_a3b_pretrain_16gpu_h100_bf16_config,
+)
+from megatron.bridge.recipes.utils.environment_utils import COMMON_RECIPE_ENV_VARS
+from megatron.bridge.training.comm_overlap import CommOverlapConfig
+from megatron.bridge.training.config import ConfigContainer
+from megatron.bridge.training.mixed_precision import bf16_with_mxfp8_mixed
+
+
+def qwen3_30b_a3b_pretrain_8gpu_gb200_fp8mx_functional_config() -> ConfigContainer:
+    """Return a checkpointable Qwen3-30B-A3B MXFP8 pretraining config for eight GB200 GPUs.
+
+    The Blackwell topology, precision, dispatcher, overlap, kernels, batch
+    sizes, and environment follow the corresponding flat performance recipe.
+    Functional verification keeps natural routing and safety checks enabled,
+    runs 100 optimizer steps, and uses scoped Transformer Engine CUDA graphs
+    because full-iteration graphs are incompatible with loss-NaN checking.
+    """
+    cfg = qwen3_30b_a3b_pretrain_16gpu_h100_bf16_config()
+
+    # Precision and eight-GPU GB200 topology.
+    cfg.mixed_precision = bf16_with_mxfp8_mixed()
+    cfg.mixed_precision.grad_reduce_in_fp32 = False
+    cfg.optimizer.use_precision_aware_optimizer = False
+    cfg.model.tensor_model_parallel_size = 1
+    cfg.model.pipeline_model_parallel_size = 1
+    cfg.model.context_parallel_size = 1
+    cfg.model.virtual_pipeline_model_parallel_size = None
+    cfg.model.expert_model_parallel_size = 8
+    cfg.model.expert_tensor_parallel_size = 1
+    cfg.model.sequence_parallel = False
+    cfg.train.global_batch_size = 512
+    cfg.train.micro_batch_size = 4
+
+    # HybridEP and Blackwell overlap settings from the performance recipe.
+    cfg.model.moe_flex_dispatcher_backend = "hybridep"
+    cfg.model.moe_token_dispatcher_type = "flex"
+    cfg.model.moe_hybridep_num_sms = 32
+    cfg.model.moe_hybridep_num_sms_preprocessing = 32
+    cfg.model.moe_shared_expert_overlap = False
+    cfg.model.moe_router_force_load_balancing = False
+    cfg.model.high_priority_a2a_comm_stream = True
+    cfg.model.use_transformer_engine_op_fuser = True
+    cfg.model.moe_mlp_glu_interleave_size = 32
+    cfg.mixed_precision.fp8_dot_product_attention = True
+    cfg.comm_overlap = CommOverlapConfig(
+        tp_comm_overlap=True,
+        overlap_moe_expert_parallel_comm=True,
+        delay_wgrad_compute=True,
+    )
+
+    # Scoped graphs remain compatible with the functional safety contract.
+    cfg.model.cuda_graph_impl = "transformer_engine"
+    cfg.model.cuda_graph_scope = ["moe_router", "moe_preprocess"]
+    cfg.rng.te_rng_tracker = True
+    cfg.model.use_te_rng_tracker = True
+
+    cfg.ddp.grad_reduce_in_fp32 = False
+    cfg.ddp.check_for_nan_in_grad = True
+    cfg.ddp.check_for_large_grads = True
+    cfg.rerun_state_machine.check_for_nan_in_loss = True
+    cfg.validation.eval_iters = 0
+    cfg.validation.eval_interval = 0
+    cfg.logger.log_interval = 1
+    cfg.logger.tensorboard_dir = None
+
+    cfg.env_vars = {
+        **COMMON_RECIPE_ENV_VARS,
+        "CUDA_DEVICE_MAX_CONNECTIONS": 32,
+        "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True",
+        "NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN": 8,
+        "NUM_OF_TOKENS_PER_CHUNK_COMBINE_API": 128,
+        "NVLINK_DOMAIN_SIZE": 72,
+        "USE_MNNVL": 1,
+        "CUDNNFE_CLUSTER_OVERLAP_MARGIN": 8,
+        "NVTE_BWD_LAYERNORM_SM_MARGIN": 20,
+        "NVTE_CUTEDSL_FUSED_GROUPED_MLP": 1,
+        "NVTE_FWD_LAYERNORM_SM_MARGIN": 20,
+    }
+    return cfg
+
+
+__all__ = ["qwen3_30b_a3b_pretrain_8gpu_gb200_fp8mx_functional_config"]

--- a/src/megatron/bridge/training/train.py
+++ b/src/megatron/bridge/training/train.py
@@ -358,16 +358,20 @@ def train(
             ),
         )
 
-    # Disable forward pre-hook to start training to ensure that errors in checkpoint loading
-    # or random initialization don't propagate to all ranks in first all-gather (which is a
-    # no-op if things work correctly).
+    # Keep the forward pre-hook enabled for MXFP8 resume so parameter gathering
+    # and MXFP8 staging match an uninterrupted iteration. Other runs retain the
+    # first-iteration validation path below.
     if should_toggle_forward_pre_hook:
-        disable_forward_pre_hook(model, param_sync=False)
-        # Also remove param_sync_func temporarily so that sync calls made in
-        # `forward_backward_func` are no-ops.
         param_sync_func = model_config.param_sync_func
-        model_config.param_sync_func = None
-        pre_hook_enabled = False
+        is_mxfp8_resume = start_iteration > 0 and str(model_config.fp8_recipe).lower().endswith("mxfp8")
+        if not is_mxfp8_resume:
+            disable_forward_pre_hook(model, param_sync=False)
+            # Also remove param_sync_func temporarily so that sync calls made in
+            # `forward_backward_func` are no-ops.
+            model_config.param_sync_func = None
+            pre_hook_enabled = False
+        else:
+            pre_hook_enabled = True
 
     # Run training iterations till done.
     while global_state.train_state.step < train_config.train_iters:
@@ -537,7 +541,7 @@ def train(
                 # Enable forward pre-hook after training step has successfully run. All subsequent
                 # forward passes will use the forward pre-hook / `param_sync_func` in
                 # `forward_backward_func`.
-                if should_toggle_forward_pre_hook:
+                if should_toggle_forward_pre_hook and not pre_hook_enabled:
                     enable_forward_pre_hook(model)
                     model_config.param_sync_func = param_sync_func
                     pre_hook_enabled = True
@@ -1607,7 +1611,7 @@ def _handle_mxfp8_param_buffer_copy(
 
     However, we should skip this on the first iteration when forward_pre_hook is disabled,
     because:
-    1. The first iteration's params are already in param.data (from init or checkpoint).
+    1. A fresh run's first-iteration params are already in param.data from initialization.
     2. Without forward_pre_hook, finish_param_sync() won't be called to zero the grad buffer,
        so the main grads will be polluted by the main params.
 

--- a/tests/unit_tests/recipes/test_qwen_recipes.py
+++ b/tests/unit_tests/recipes/test_qwen_recipes.py
@@ -640,60 +640,6 @@ def test_qwen3_30b_a3b_pretrain_defaults(monkeypatch: pytest.MonkeyPatch):
     assert cfg.comm_overlap.tp_comm_overlap is True
 
 
-def test_qwen3_30b_a3b_gb200_mxfp8_functional_defaults(monkeypatch: pytest.MonkeyPatch):
-    """Test the checkpointable GB200 MXFP8 support-verification contract."""
-    from megatron.bridge.recipes.qwen import qwen3_30b_a3b_pretrain_8gpu_gb200_fp8mx_functional_config
-
-    mod = importlib.import_module("megatron.bridge.recipes.qwen.qwen3_moe")
-    patch_recipe_module_global(monkeypatch, mod, "AutoBridge", _FakeBridge)
-
-    cfg = qwen3_30b_a3b_pretrain_8gpu_gb200_fp8mx_functional_config()
-
-    _assert_basic_config(cfg)
-    assert cfg.model.tensor_model_parallel_size == 1
-    assert cfg.model.pipeline_model_parallel_size == 1
-    assert cfg.model.context_parallel_size == 1
-    assert cfg.model.expert_model_parallel_size == 8
-    assert cfg.model.expert_tensor_parallel_size == 1
-    assert cfg.model.sequence_parallel is False
-    assert cfg.train.train_iters == 100
-    assert cfg.train.global_batch_size == 512
-    assert cfg.train.micro_batch_size == 4
-    assert cfg.model.moe_flex_dispatcher_backend == "hybridep"
-    assert cfg.model.moe_token_dispatcher_type == "flex"
-    assert cfg.model.moe_hybridep_num_sms == 32
-    assert cfg.model.moe_hybridep_num_sms_preprocessing == 32
-    assert cfg.model.moe_router_force_load_balancing is False
-    assert cfg.model.high_priority_a2a_comm_stream is True
-    assert cfg.model.use_transformer_engine_op_fuser is True
-    assert cfg.model.moe_mlp_glu_interleave_size == 32
-    assert cfg.model.cuda_graph_impl == "transformer_engine"
-    assert cfg.model.cuda_graph_scope == ["moe_router", "moe_preprocess"]
-    assert cfg.model.use_te_rng_tracker is True
-    assert cfg.rng.te_rng_tracker is True
-    assert cfg.mixed_precision.bf16 is True
-    assert cfg.mixed_precision.fp8 == "e4m3"
-    assert cfg.mixed_precision.fp8_recipe == "mxfp8"
-    assert cfg.mixed_precision.fp8_param_gather is True
-    assert cfg.mixed_precision.reuse_grad_buf_for_mxfp8_param_ag is True
-    assert cfg.mixed_precision.fp8_dot_product_attention is True
-    assert cfg.mixed_precision.grad_reduce_in_fp32 is False
-    assert cfg.optimizer.use_precision_aware_optimizer is False
-    assert cfg.ddp.grad_reduce_in_fp32 is False
-    assert cfg.ddp.check_for_nan_in_grad is True
-    assert cfg.ddp.check_for_large_grads is True
-    assert cfg.rerun_state_machine.check_for_nan_in_loss is True
-    assert cfg.validation.eval_iters == 0
-    assert cfg.validation.eval_interval == 0
-    assert cfg.checkpoint.save_interval == 50
-    assert cfg.checkpoint.load is None
-    assert cfg.comm_overlap.tp_comm_overlap is True
-    assert cfg.comm_overlap.overlap_moe_expert_parallel_comm is True
-    assert cfg.comm_overlap.delay_wgrad_compute is True
-    assert cfg.env_vars["NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN"] == 8
-    assert cfg.env_vars["NVTE_CUTEDSL_FUSED_GROUPED_MLP"] == 1
-
-
 def test_qwen3_30b_a3b_bf16_perf_recipe_uses_default_functional_config(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/tests/unit_tests/recipes/test_qwen_recipes.py
+++ b/tests/unit_tests/recipes/test_qwen_recipes.py
@@ -674,8 +674,8 @@ def test_qwen3_30b_a3b_gb200_mxfp8_functional_defaults(monkeypatch: pytest.Monke
     assert cfg.mixed_precision.bf16 is True
     assert cfg.mixed_precision.fp8 == "e4m3"
     assert cfg.mixed_precision.fp8_recipe == "mxfp8"
-    assert cfg.mixed_precision.fp8_param_gather is False
-    assert cfg.mixed_precision.reuse_grad_buf_for_mxfp8_param_ag is False
+    assert cfg.mixed_precision.fp8_param_gather is True
+    assert cfg.mixed_precision.reuse_grad_buf_for_mxfp8_param_ag is True
     assert cfg.mixed_precision.fp8_dot_product_attention is True
     assert cfg.mixed_precision.grad_reduce_in_fp32 is False
     assert cfg.optimizer.use_precision_aware_optimizer is False

--- a/tests/unit_tests/recipes/test_qwen_recipes.py
+++ b/tests/unit_tests/recipes/test_qwen_recipes.py
@@ -640,6 +640,59 @@ def test_qwen3_30b_a3b_pretrain_defaults(monkeypatch: pytest.MonkeyPatch):
     assert cfg.comm_overlap.tp_comm_overlap is True
 
 
+def test_qwen3_30b_a3b_gb200_mxfp8_functional_defaults(monkeypatch: pytest.MonkeyPatch):
+    """Test the checkpointable GB200 MXFP8 support-verification contract."""
+    from megatron.bridge.recipes.qwen import qwen3_30b_a3b_pretrain_8gpu_gb200_fp8mx_functional_config
+
+    mod = importlib.import_module("megatron.bridge.recipes.qwen.qwen3_moe")
+    patch_recipe_module_global(monkeypatch, mod, "AutoBridge", _FakeBridge)
+
+    cfg = qwen3_30b_a3b_pretrain_8gpu_gb200_fp8mx_functional_config()
+
+    _assert_basic_config(cfg)
+    assert cfg.model.tensor_model_parallel_size == 1
+    assert cfg.model.pipeline_model_parallel_size == 1
+    assert cfg.model.context_parallel_size == 1
+    assert cfg.model.expert_model_parallel_size == 8
+    assert cfg.model.expert_tensor_parallel_size == 1
+    assert cfg.model.sequence_parallel is False
+    assert cfg.train.train_iters == 100
+    assert cfg.train.global_batch_size == 512
+    assert cfg.train.micro_batch_size == 4
+    assert cfg.model.moe_flex_dispatcher_backend == "hybridep"
+    assert cfg.model.moe_token_dispatcher_type == "flex"
+    assert cfg.model.moe_hybridep_num_sms == 32
+    assert cfg.model.moe_hybridep_num_sms_preprocessing == 32
+    assert cfg.model.moe_router_force_load_balancing is False
+    assert cfg.model.high_priority_a2a_comm_stream is True
+    assert cfg.model.use_transformer_engine_op_fuser is True
+    assert cfg.model.moe_mlp_glu_interleave_size == 32
+    assert cfg.model.cuda_graph_impl == "transformer_engine"
+    assert cfg.model.cuda_graph_scope == ["moe_router", "moe_preprocess"]
+    assert cfg.model.use_te_rng_tracker is True
+    assert cfg.rng.te_rng_tracker is True
+    assert cfg.mixed_precision.bf16 is True
+    assert cfg.mixed_precision.fp8 == "e4m3"
+    assert cfg.mixed_precision.fp8_recipe == "mxfp8"
+    assert cfg.mixed_precision.fp8_param_gather is True
+    assert cfg.mixed_precision.fp8_dot_product_attention is True
+    assert cfg.mixed_precision.grad_reduce_in_fp32 is False
+    assert cfg.optimizer.use_precision_aware_optimizer is False
+    assert cfg.ddp.grad_reduce_in_fp32 is False
+    assert cfg.ddp.check_for_nan_in_grad is True
+    assert cfg.ddp.check_for_large_grads is True
+    assert cfg.rerun_state_machine.check_for_nan_in_loss is True
+    assert cfg.validation.eval_iters == 0
+    assert cfg.validation.eval_interval == 0
+    assert cfg.checkpoint.save_interval == 50
+    assert cfg.checkpoint.load is None
+    assert cfg.comm_overlap.tp_comm_overlap is True
+    assert cfg.comm_overlap.overlap_moe_expert_parallel_comm is True
+    assert cfg.comm_overlap.delay_wgrad_compute is True
+    assert cfg.env_vars["NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN"] == 8
+    assert cfg.env_vars["NVTE_CUTEDSL_FUSED_GROUPED_MLP"] == 1
+
+
 def test_qwen3_30b_a3b_bf16_perf_recipe_uses_default_functional_config(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/tests/unit_tests/recipes/test_qwen_recipes.py
+++ b/tests/unit_tests/recipes/test_qwen_recipes.py
@@ -674,7 +674,8 @@ def test_qwen3_30b_a3b_gb200_mxfp8_functional_defaults(monkeypatch: pytest.Monke
     assert cfg.mixed_precision.bf16 is True
     assert cfg.mixed_precision.fp8 == "e4m3"
     assert cfg.mixed_precision.fp8_recipe == "mxfp8"
-    assert cfg.mixed_precision.fp8_param_gather is True
+    assert cfg.mixed_precision.fp8_param_gather is False
+    assert cfg.mixed_precision.reuse_grad_buf_for_mxfp8_param_ag is False
     assert cfg.mixed_precision.fp8_dot_product_attention is True
     assert cfg.mixed_precision.grad_reduce_in_fp32 is False
     assert cfg.optimizer.use_precision_aware_optimizer is False


### PR DESCRIPTION
# What does this PR do ?

Adds a checkpointable Qwen3-30B-A3B MXFP8 functional pretraining recipe for 8x GB200, records the canonical GB200 performance result, and fixes MXFP8 checkpoint-resume parity.

# Changelog

- Add and export `qwen3_30b_a3b_pretrain_8gpu_gb200_fp8mx_functional_config`.
- Preserve the GB200 performance recipe's MXFP8, EP8, HybridEP, overlap, kernel, and environment stack while restoring natural routing, safety checks, deterministic real-data training, and checkpoint saving.
- Keep the forward pre-hook enabled on MXFP8 resume so parameter gathering and MXFP8 staging match an uninterrupted iteration; pure BF16/fresh runs retain the existing first-iteration validation path.
- Add `pretrain_performance.GB200` evidence from the canonical mock-data, forced-balance, full-iteration CUDA-graph recipe.
- Verify GB200 MXFP8 pretrain and checkpoint resume on the same Bridge commit.

The resume mismatch came from disabling the distributed-optimizer forward pre-hook on the first iteration of every process, including a resumed process. The uninterrupted step 51 used the normal gather/staging path, while resumed step 51 skipped it, producing the earlier 12.32% loss spike. With the scoped MXFP8 fix, resumed step 51 matches the uninterrupted reference exactly.

# GitHub Actions CI

Local validation:

- `uv run --no-project --python 3.12 --with pyyaml python skills/create-model-verification-card/scripts/validate_card.py examples/model_verification_cards/qwen3-30b-a3b/card.yaml`
- `uvx pre-commit run --all-files`
- Canonical 8x GB200 performance run: 50/50 steps, 6,501.12 ms and 927.68 model TFLOP/s/GPU over steps 41-50, zero skipped/NaN iterations
- Clean same-commit 8x GB200 functional reference: 100/100 steps, finite loss 12.412930 -> 6.183484, 12,362.34 ms and 487.88 model TFLOP/s/GPU over steps 91-100, zero skipped/NaN iterations, complete step-50 and step-100 checkpoints
- Clean same-commit resume: step-51 loss 6.774675 matches the uninterrupted reference exactly; step-100 loss 6.187264 differs from reference 6.183484 by 0.061131%, within the 1% gate; zero skipped/NaN iterations and a complete step-100 checkpoint

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed Contributor guidelines
- [x] No new unit test requested; covered by the 8x GB200 verification runs
- [x] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install? No
  - [x] Reviewer: Does the PR have correct import guards for all optional libraries? Not applicable

# Additional Information

- Internal pretrain evidence: MB-968
- Internal resume evidence: MB-969
