### PR TITLE
[training] fix: Respect disabled exit signal handling

### DIFF
--- a/src/megatron/bridge/training/state.py
+++ b/src/megatron/bridge/training/state.py
@@ -464,7 +464,7 @@ class GlobalState:
 
     def _set_signal_handler(self) -> None:
         """Initializes the distributed signal handler based on the configuration."""
-        if self.cfg.train is not None:
+        if self.cfg.train is not None and self.cfg.train.exit_signal_handler:
             self._signal_handler = DistributedSignalHandler(self.cfg.train.exit_signal).__enter__()
 
     def reset_for_restart(self) -> None:

--- a/tests/unit_tests/training/test_pg_collection_wiring.py
+++ b/tests/unit_tests/training/test_pg_collection_wiring.py
@@ -39,6 +39,7 @@ def test_should_skip_iteration_uses_passed_pg_collection(monkeypatch):
         train=SimpleNamespace(
             iterations_to_skip={1},
             micro_batch_size=4,
+            exit_signal_handler=False,
             exit_signal=signal.SIGTERM,
         )
     )

--- a/tests/unit_tests/training/test_state.py
+++ b/tests/unit_tests/training/test_state.py
@@ -12,14 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import multiprocessing
 import os
 import signal
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
 
 from megatron.bridge.training.state import FaultToleranceState, GlobalState, TrainState
+
+
+def _send_sigterm_with_handler_disabled() -> None:
+    config = SimpleNamespace(
+        train=SimpleNamespace(
+            exit_signal_handler=False,
+            exit_signal=signal.SIGTERM,
+        )
+    )
+    state = GlobalState()
+    state.cfg = config
+    os.kill(os.getpid(), signal.SIGTERM)
 
 
 class TestTrainState:
@@ -696,6 +710,19 @@ class TestGlobalState:
 
             mock_dsh.assert_not_called()
             assert state._signal_handler is None
+
+    def test_disabled_signal_handler_does_not_intercept_sigterm(self):
+        """Disabling graceful signal handling preserves SIGTERM's default disposition."""
+        process = multiprocessing.get_context("fork").Process(target=_send_sigterm_with_handler_disabled)
+        process.start()
+        process.join(timeout=10)
+
+        if process.is_alive():
+            process.kill()
+            process.join()
+            pytest.fail("child process did not terminate after SIGTERM")
+
+        assert process.exitcode == -signal.SIGTERM
 
     @pytest.fixture
     def restore_sigterm_handler(self):

--- a/tests/unit_tests/training/test_state.py
+++ b/tests/unit_tests/training/test_state.py
@@ -25,6 +25,9 @@ from megatron.bridge.training.state import FaultToleranceState, GlobalState, Tra
 
 
 def _send_sigterm_with_handler_disabled() -> None:
+    # Forked test processes inherit the runner's signal disposition. Establish
+    # the baseline that the disabled Bridge setting must preserve explicitly.
+    signal.signal(signal.SIGTERM, signal.SIG_DFL)
     config = SimpleNamespace(
         train=SimpleNamespace(
             exit_signal_handler=False,


### PR DESCRIPTION
## Problem

`train.exit_signal_handler` defaults to `False`, but assigning the training
config to `GlobalState` still installed Bridge's SIGTERM trap unconditionally.
The trap only records a flag, while the training loop polls that flag only when
the option is enabled.

As a result, ordinary training with the documented/default disabled setting
could swallow an operator or scheduler SIGTERM, continue until a hard kill,
and lose work since the last periodic checkpoint.

## Root cause and fix

The config setter always called `_set_signal_handler()`, and
`_set_signal_handler()` checked only that `cfg.train` existed. Guard handler
installation with `cfg.train.exit_signal_handler` so the disabled setting
preserves the process's existing/default SIGTERM disposition.

The enabled graceful-checkpoint path is unchanged.

## Regression evidence

Focused regression, unchanged before and after:

```bash
uv run --no-sync python -m pytest \
  tests/unit_tests/training/test_state.py::TestGlobalState::test_disabled_signal_handler_does_not_intercept_sigterm \
  -q -p no:cacheprovider
```

- Before: `1 failed`; the child logged that it received SIGTERM and exited
  normally with code 0 instead of being terminated by SIGTERM.
- After: `1 passed`.

Adjacent signal/preemption coverage:

```bash
uv run --no-sync python -m pytest \
  tests/unit_tests/training/utils/test_sig_utils.py \
  tests/unit_tests/training/test_state.py \
  tests/unit_tests/training/test_train.py \
  tests/unit_tests/recipes/test_run_plugins.py \
  -k "signal or preemption" -q -p no:cacheprovider
```

Result: `17 passed, 137 deselected`.

Additional checks:

- `git diff --check` — passed
- `uv run --no-sync pre-commit run --all-files` — every hook passed

## Scope

This is a CPU-only signal-disposition regression. It does not change the
enabled save-on-SIGTERM flow, checkpoint implementation, distributed
collectives, dependencies, CI workflows, public API signatures, or
Megatron-Core.
