### PR TITLE
fix(model): honor plain export dtype for Kimi K2.5

### DIFF
--- a/src/megatron/bridge/models/kimi_vl/kimi_k25_vl_bridge.py
+++ b/src/megatron/bridge/models/kimi_vl/kimi_k25_vl_bridge.py
@@ -184,6 +184,9 @@ class KimiK25VLBridge(MegatronModelBridge):
         hf_state_dict: Mapping[str, torch.Tensor],
     ) -> Dict[str, torch.Tensor]:
         """Re-quantize converted expert weights to INT4 format."""
+        if task.weight_dtype is not None:
+            return converted_weights_dict
+
         result = {}
         for fqn, tensor in converted_weights_dict.items():
             if self._is_quantized_expert_key(fqn):

--- a/tests/unit_tests/models/kimi_vl/test_kimi_k25_vl_bridge.py
+++ b/tests/unit_tests/models/kimi_vl/test_kimi_k25_vl_bridge.py
@@ -301,6 +301,49 @@ class TestKimiK25VLBridgeWeightConversion:
         assert kimi_bridge._is_quantized_expert_key("model.layers.5.self_attn.q_proj.weight") is False
         assert kimi_bridge._is_quantized_expert_key("model.embed_tokens.weight") is False
 
+    def test_plain_export_dtype_skips_int4_requantization(self, kimi_bridge):
+        """An explicit plain export dtype must preserve routed expert weights."""
+        from megatron.bridge.models.conversion.model_bridge import WeightConversionTask
+
+        task = WeightConversionTask(
+            param_name="decoder.layers.5.mlp.experts.linear_fc1.weight0",
+            global_param_name="decoder.layers.5.mlp.experts.linear_fc1.weight0",
+            mapping=Mock(),
+            weight_dtype=torch.bfloat16,
+        )
+        weight_key = "language_model.model.layers.5.mlp.experts.0.gate_proj.weight"
+        weight = torch.ones((2, 32), dtype=torch.float32)
+
+        result = kimi_bridge.maybe_modify_converted_hf_weight(task, {weight_key: weight}, {})
+
+        assert set(result) == {weight_key}
+        assert result[weight_key] is weight
+
+    def test_default_export_requantizes_routed_expert_weights(self, kimi_bridge):
+        """Default export should continue recreating Kimi's INT4 source layout."""
+        from megatron.bridge.models.conversion.model_bridge import WeightConversionTask
+
+        task = WeightConversionTask(
+            param_name="decoder.layers.5.mlp.experts.linear_fc1.weight0",
+            global_param_name="decoder.layers.5.mlp.experts.linear_fc1.weight0",
+            mapping=Mock(),
+        )
+        weight_key = "language_model.model.layers.5.mlp.experts.0.gate_proj.weight"
+
+        result = kimi_bridge.maybe_modify_converted_hf_weight(
+            task,
+            {weight_key: torch.ones((2, 32), dtype=torch.bfloat16)},
+            {},
+        )
+
+        base_key = weight_key.removesuffix(".weight")
+        assert set(result) == {
+            f"{base_key}.weight_packed",
+            f"{base_key}.weight_scale",
+            f"{base_key}.weight_shape",
+        }
+        assert result[f"{base_key}.weight_packed"].dtype == torch.int32
+
     @patch("megatron.bridge.models.kimi_vl.kimi_k25_vl_bridge.dequantize_int4")
     def test_load_and_dequantize_uses_source_tensor_device(self, mock_dequantize, kimi_bridge):
         """Quantized loads should dequantize on the source tensor device."""


### PR DESCRIPTION
# What does this PR do ?

Honor the public plain-weight export contract for Kimi K2.5 when callers pass an explicit `weight_dtype` to `AutoBridge.export_hf_weights`.

Kimi K2.5's family hook currently re-quantizes routed-expert weights unconditionally. That replaces each converted plain `.weight` tensor with `weight_packed`, `weight_scale`, and `weight_shape` even when the caller explicitly requested a plain dtype. Because the generic dtype cast runs after the family hook, it cannot restore the removed plain key.

The fix lets the generic export path own explicit dtype conversion and retains the existing INT4 source-layout reconstruction when `weight_dtype` is omitted.

# Changelog

- Skip Kimi K2.5 INT4 re-quantization for explicit plain-dtype exports.
- Add a regression test for the explicit-dtype path.
- Add a negative control proving the default export still recreates the INT4 triplet.

# GitHub Actions CI

Fail-before on unmodified `ce3edde7e9cc528be400dfa007095f4e6103d575`:

```text
uv run --active --no-sync python -m pytest \
  tests/unit_tests/models/kimi_vl/test_kimi_k25_vl_bridge.py::TestKimiK25VLBridgeWeightConversion::test_plain_export_dtype_skips_int4_requantization -q
```

Result: `1 failed, 34 warnings`. The result contained the three INT4 checkpoint keys and omitted the requested plain `.weight` key.

Pass-after regression and default-layout negative control:

```text
uv run --active --no-sync python -m pytest \
  tests/unit_tests/models/kimi_vl/test_kimi_k25_vl_bridge.py::TestKimiK25VLBridgeWeightConversion::test_plain_export_dtype_skips_int4_requantization \
  tests/unit_tests/models/kimi_vl/test_kimi_k25_vl_bridge.py::TestKimiK25VLBridgeWeightConversion::test_default_export_requantizes_routed_expert_weights -q
```

Result: `2 passed, 34 warnings`.

Adjacent validation:

```text
uv run --active --no-sync python -m pytest \
  tests/unit_tests/models/kimi_vl/test_kimi_k25_vl_bridge.py \
  tests/unit_tests/models/kimi_vl/test_kimi_k25_vl_provider.py \
  tests/unit_tests/models/test_quantization_utils.py -q
```

Result: `54 passed, 34 warnings`.

Also passed:

```text
git diff --check
uv run --active --no-sync pre-commit run --all-files
```

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] Added focused regression coverage and a default-behavior negative control.
- [x] No documentation update is needed; the public export option is unchanged.
- [x] No optional dependency behavior is changed.

# Additional Information

Scope is limited to direct plain-dtype export behavior. This does not change default Kimi INT4 export, public APIs, dependencies, CI workflows, or Megatron-Core. It does not claim full-suite, model-quality, convergence, performance, or strict source-shard-map save validation.

Supersedes the closed, unmerged #4768 after reproducing the same root cause on current `main`.
