### PR TITLE
[ckpt] fix: Follow tracker when loading MIMO config

### DIFF
--- a/src/megatron/bridge/models/megatron_mimo/conversion/mimo_model_io.py
+++ b/src/megatron/bridge/models/megatron_mimo/conversion/mimo_model_io.py
@@ -266,21 +266,21 @@ def _restore_derived_spec_fields(provider: "MegatronMIMOProvider", saved: dict) 
 
 
 def _resolve_iter_folder(path: Path) -> Path:
-    """Resolve ``path`` to an ``iter_*`` folder, or pick the latest under it."""
-    if path.name.startswith("iter_"):
+    """Resolve ``path`` to the checkpoint iteration selected for loading."""
+    from megatron.bridge.training.checkpointing import (
+        _DIRECT_ITERATION_DIR_SENTINEL,
+        _resolve_checkpoint_iteration,
+    )
+    from megatron.bridge.training.utils.checkpoint_utils import get_checkpoint_name
+
+    iteration, release = _resolve_checkpoint_iteration(str(path), None)
+    if iteration == _DIRECT_ITERATION_DIR_SENTINEL:
         return path
 
-    iter_folders = [f for f in path.iterdir() if f.is_dir() and f.name.startswith("iter_")]
-    if not iter_folders:
-        raise FileNotFoundError(
-            f"No iter_* folder found under {path}; expected either a MIMO "
-            f"dist-checkpoint parent directory or an iter folder directly."
-        )
+    if iteration >= 0 or release:
+        return Path(get_checkpoint_name(str(path), iteration, release))
 
-    def _iter_number(folder: Path) -> int:
-        try:
-            return int(folder.name.removeprefix("iter_"))
-        except ValueError:
-            return -1
-
-    return max(iter_folders, key=_iter_number)
+    raise FileNotFoundError(
+        f"No checkpoint tracker found under {path}; expected either a MIMO "
+        f"dist-checkpoint parent directory or an iter folder directly."
+    )

--- a/tests/unit_tests/models/megatron_mimo/conversion/test_mimo_model_io.py
+++ b/tests/unit_tests/models/megatron_mimo/conversion/test_mimo_model_io.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+import pytest
+
+from megatron.bridge.models.megatron_mimo.conversion.mimo_model_io import load_megatron_mimo_model
+
+
+@pytest.mark.unit
+def test_parent_load_uses_tracker_selected_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Provider config should come from the same durable iteration as weights."""
+    durable_iteration = tmp_path / "iter_0000010"
+    durable_iteration.mkdir()
+    (durable_iteration / "run_config.yaml").touch()
+    (tmp_path / "latest_checkpointed_iteration.txt").write_text("10", encoding="utf-8")
+
+    # Async save creates its iteration directory before finalization updates the
+    # tracker and writes run_config.yaml. An interrupted save can leave it behind.
+    (tmp_path / "iter_0000020").mkdir()
+
+    selected_config_path: Path | None = None
+
+    class StopAfterConfigSelection(Exception):
+        pass
+
+    def record_config_path(checkpoint_path: str) -> None:
+        nonlocal selected_config_path
+        selected_config_path = Path(checkpoint_path)
+        raise StopAfterConfigSelection
+
+    monkeypatch.setattr(
+        "megatron.bridge.training.model_load_save.load_model_config",
+        record_config_path,
+    )
+
+    with pytest.raises(StopAfterConfigSelection):
+        load_megatron_mimo_model(tmp_path)
+
+    assert selected_config_path == durable_iteration


### PR DESCRIPTION
## What changed

MegatronMIMO parent-directory loads now resolve provider configuration through the same checkpoint tracker used for weight loading.

## User impact and trigger

The documented MIMO export path accepts a checkpoint parent directory. Async checkpoint save creates a new `iter_*` directory before finalization writes `run_config.yaml` and advances the tracker. If a save is interrupted in that window, the parent can contain a higher incomplete iteration while its tracker still points to the last durable checkpoint.

Previously, MIMO config loading chose the numerically highest directory, while shared weight loading followed the tracker. Export could therefore fail on the incomplete directory or combine stale config with weights from a different iteration.

## Root cause and fix

`_resolve_iter_folder()` duplicated checkpoint selection using numeric directory order. It now reuses the shared `_resolve_checkpoint_iteration()` contract and `get_checkpoint_name()`, preserving direct iteration and release paths while keeping provider config and weights on the same selected checkpoint.

## Regression evidence

Fail before:

`uv run python -m pytest tests/unit_tests/models/megatron_mimo/conversion/test_mimo_model_io.py -q`

Result: 1 failed. The tracker selected `iter_0000010`, but config loading selected incomplete `iter_0000020`.

Pass after and adjacent checks:

`uv run python -m pytest tests/unit_tests/models/megatron_mimo/conversion/test_mimo_model_io.py tests/unit_tests/models/megatron_mimo/conversion/test_orchestrator.py tests/unit_tests/training/test_checkpointing.py::TestCheckpointIterationResolution -q`

Result: 55 passed.

`uv run pre-commit run --all-files`

Result: all hooks passed.

## Scope

No dependency, lockfile, workflow, public API signature, or Megatron-Core submodule change.