### PR TITLE
[inference] fix: Handle variable-length VLM batches

### DIFF
--- a/src/megatron/bridge/inference/vlm/vlm_engine.py
+++ b/src/megatron/bridge/inference/vlm/vlm_engine.py
@@ -55,6 +55,7 @@ class VLMEngine(StaticInferenceEngine):
         InferenceMode.set_active()
         try:
             request_ids: List[str] = []
+            prepared_requests = []
 
             if self.random_seed:
                 torch.random.manual_seed(self.random_seed)
@@ -68,7 +69,14 @@ class VLMEngine(StaticInferenceEngine):
                 prompt = prompts[i]
                 image = images[i] if images is not None else None
                 prompt_tokens, image_dict = self.controller.tokenize_prompt(prompt, image)
+                prepared_requests.append((prompt, prompt_tokens, image_dict))
 
+            prompt_lengths = {len(prompt_tokens) for _, prompt_tokens, _ in prepared_requests}
+            serialize_requests = len(prompt_lengths) > 1 and any(
+                image_dict is not None for _, _, image_dict in prepared_requests
+            )
+
+            for prompt, prompt_tokens, image_dict in prepared_requests:
                 # Reuse encoder_prompt from scheduler to pass image
                 request_id = self.scheduler.add_request(
                     prompt=prompt,
@@ -77,8 +85,11 @@ class VLMEngine(StaticInferenceEngine):
                     sampling_params=sampling_params,
                 )
                 request_ids.append(request_id)
+                if serialize_requests:
+                    self.run_engine()
 
-            self.run_engine()
+            if not serialize_requests:
+                self.run_engine()
 
             result: List[InferenceRequest] = [
                 self.scheduler.completed_request_pool[request_id] for request_id in request_ids

--- a/tests/unit_tests/inference/vlm/test_vlm_engine.py
+++ b/tests/unit_tests/inference/vlm/test_vlm_engine.py
@@ -40,12 +40,65 @@ class TestVLMEngine:
             engine.scheduler.completed_request_pool = {"req_id": "result"}
             engine.run_engine = MagicMock()
 
-            results = engine.generate(["prompt"], ["image"])
+            results = engine.generate(["prompt 1", "prompt 2"], ["image 1", "image 2"])
 
-            assert results == ["result"]
-            engine.scheduler.add_request.assert_called()
-            engine.run_engine.assert_called()
+            assert results == ["result", "result"]
+            assert engine.scheduler.add_request.call_count == 2
+            engine.run_engine.assert_called_once()
             assert not InferenceMode.is_active()
+        finally:
+            InferenceMode.unset_active()
+
+    def test_generate_keeps_variable_length_visual_contexts_consistent(self):
+        InferenceMode.unset_active()
+        mock_controller = MagicMock()
+        mock_controller.tokenize_prompt.side_effect = [
+            ([1], None),
+            ([10, 11, 151655, 151655], {"pixel_values": "complete-image"}),
+        ]
+        mock_controller.inference_wrapped_model.inference_context = StaticInferenceContext(
+            max_batch_size=4, max_sequence_length=8192
+        )
+        mock_controller.inference_wrapped_model.inference_wrapper_config = MagicMock(inference_max_requests=4)
+
+        try:
+            engine = VLMEngine(mock_controller, max_batch_size=4, legacy=True)
+            pending_requests = {}
+            completed_requests = {}
+
+            def add_request(*, prompt, prompt_tokens, encoder_prompt, sampling_params):
+                request_id = str(len(pending_requests) + len(completed_requests))
+                pending_requests[request_id] = {
+                    "prompt": prompt,
+                    "prompt_tokens": prompt_tokens,
+                    "encoder_prompt": encoder_prompt,
+                }
+                return request_id
+
+            engine.scheduler = MagicMock()
+            engine.scheduler.add_request.side_effect = add_request
+            engine.scheduler.completed_request_pool = completed_requests
+
+            def run_engine():
+                first_context_length = min(len(request["prompt_tokens"]) for request in pending_requests.values())
+                inconsistent_requests = [
+                    request
+                    for request in pending_requests.values()
+                    if request["encoder_prompt"] is not None and len(request["prompt_tokens"]) > first_context_length
+                ]
+                assert not inconsistent_requests, (
+                    "a truncated first context window would receive the complete visual payload"
+                )
+                completed_requests.update(
+                    {request_id: request["prompt"] for request_id, request in pending_requests.items()}
+                )
+                pending_requests.clear()
+
+            engine.run_engine = run_engine
+
+            results = engine.generate(["short", "long image prompt"], [None, "image"])
+
+            assert results == ["short", "long image prompt"]
         finally:
             InferenceMode.unset_active()
 


### PR DESCRIPTION
## Problem

`generate()` accepts batched VLM requests, including a mix of text-only and
image requests. When those prompts have different token lengths, MCore begins
the first context window at the shortest prompt length. Bridge slices every
request's token IDs to that boundary but still forwards each image request's
complete visual tensors.

For a longer Qwen-VL image request, the first model call therefore receives
fewer image placeholders than visual features. Qwen2.5-VL rejects that
cardinality mismatch; Qwen3-VL fails when assigning the visual embeddings.

## Fix

Prepare the requests before scheduling them and serialize only batches that:

- contain visual inputs; and
- contain more than one prompt length.

Text-only batches and equal-length visual batches continue to run together.
Results remain in input order.

## Validation

Regression selector:

```text
uv run python -m pytest --confcutdir=tests/unit_tests/inference/vlm tests/unit_tests/inference/vlm/test_vlm_engine.py::TestVLMEngine::test_generate_keeps_variable_length_visual_contexts_consistent -q
```

- Unmodified base: `1 failed` with
  `a truncated first context window would receive the complete visual payload`.
- Fixed code: `1 passed`.
- The fixed regression also passed in the project's approved GPU validation
  container: `1 passed`.

Focused and adjacent tests:

```text
uv run python -m pytest --confcutdir=tests/unit_tests/inference/vlm tests/unit_tests/inference/vlm/test_vlm_engine.py tests/unit_tests/inference/vlm/test_vlm_inference_controller.py tests/unit_tests/inference/vlm/test_qwenvl_inference_wrapper.py -k 'not requested_seed' -q
```

Result: `23 passed, 1 deselected`. The deselected test covers CUDA sampling RNG,
not VLM request batching.

Additional checks:

- `git diff --check`: passed.
- `pre-commit run --all-files`: all hooks passed.

## Scope

This change does not alter tokenization, model math, checkpoint conversion, or
the MCore scheduler. It does not claim full-suite, convergence, model-quality,
or performance validation. It intentionally preserves batching for text-only
and equal-length visual requests.
