### PR TITLE
fix(data): normalize ShareGPT role aliases

### DIFF
--- a/src/megatron/bridge/data/conversation_processing.py
+++ b/src/megatron/bridge/data/conversation_processing.py
@@ -32,6 +32,7 @@ from megatron.bridge.training.utils.visual_inputs import GenericVisualInputs
 
 
 CHATML_ASSISTANT_ROLE = "assistant"
+_LEGACY_CHAT_ROLE_ALIASES = {"human": "user", "gpt": CHATML_ASSISTANT_ROLE}
 
 
 @dataclass(frozen=True)
@@ -494,7 +495,8 @@ def normalize_chat_conversation(
             normalized.append(turn)
             continue
         if "from" in turn and "value" in turn:
-            normalized.append({"role": str(turn["from"]).lower(), "content": turn["value"]})
+            role = str(turn["from"]).lower()
+            normalized.append({"role": _LEGACY_CHAT_ROLE_ALIASES.get(role, role), "content": turn["value"]})
             continue
         raise ValueError("Chat turns must contain role/content or legacy from/value fields.")
 

--- a/tests/unit_tests/data/test_conversation_processing.py
+++ b/tests/unit_tests/data/test_conversation_processing.py
@@ -611,6 +611,21 @@ def test_shared_chat_preprocessing_supports_all_declared_conversation_columns(co
     assert normalize_chat_conversation(row) == turns
 
 
+def test_shared_chat_preprocessing_normalizes_sharegpt_roles_before_templating():
+    tokenized = tokenize_chat_example(
+        {
+            "conversations": [
+                {"from": "human", "value": "question"},
+                {"from": "gpt", "value": "answer"},
+            ]
+        },
+        _LlamaPreprocessingTokenizer(),
+    )
+
+    assert [turn["role"] for turn in tokenized.conversation] == ["user", "assistant"]
+    assert tokenized.assistant_mask.any()
+
+
 def test_ultrachat_style_row_has_matching_gpt_sft_and_direct_hf_collation():
     tokenizer = _LlamaPreprocessingTokenizer()
     row = {


### PR DESCRIPTION
## Summary

Normalize the conventional ShareGPT role aliases `human` and `gpt` to
processor-facing `user` and `assistant` roles before applying a Hugging Face
chat template.

## User impact

The documented Direct-HF and HF-materialized GPT SFT paths accept legacy
`conversations` rows with `from`/`value` turns. A conventional ShareGPT row
such as:

```json
{"conversations": [{"from": "human", "value": "Question"}, {"from": "gpt", "value": "Answer"}]}
```

was normalized to roles `human`/`gpt` and passed unchanged to the selected
instruction model's chat template. Strict templates reject those roles;
permissive templates can render no recognized assistant span, leaving
assistant-only training with no usable loss mask. The sibling Energon path
already canonicalizes the same aliases.

## Root cause and fix

`normalize_chat_conversation()` converted legacy field names and lowercased
the role, but did not translate the two conventional ShareGPT aliases. The
fix maps only legacy `from`/`value` turns:

- `human` to `user`
- `gpt` to `assistant`

Already canonical `role`/`content` messages and other custom legacy role
values are unchanged.

## Regression evidence

The focused test reaches the processor-facing chat-template boundary and
asserts both canonical roles and a nonempty assistant mask.

Fail before:

```text
uv run --active --no-sync python -m pytest \
  --confcutdir=tests/unit_tests/data \
  tests/unit_tests/data/test_conversation_processing.py::test_shared_chat_preprocessing_normalizes_sharegpt_roles_before_templating \
  -q -p no:cacheprovider
```

Result: `1 failed`; the template received `['human', 'gpt']` instead of
`['user', 'assistant']`.

Pass after: the unchanged command completed with `1 passed`.

Focused adjacent validation:

```text
uv run --active --no-sync python -m pytest \
  --confcutdir=tests/unit_tests/data \
  tests/unit_tests/data/test_sft_processing.py \
  tests/unit_tests/data/test_conversation_processing.py \
  tests/unit_tests/data/builders/test_direct_hf_sft.py \
  tests/unit_tests/data/builders/test_gpt_sft_config.py \
  tests/unit_tests/data/collators/test_sft.py \
  tests/unit_tests/data/datasets/test_chat_template.py \
  tests/unit_tests/data/energon/test_task_encoder_utils.py \
  -q -p no:cacheprovider
```

Result: `221 passed`.

Additional gates:

- `git diff --check`: passed
- `uv run --active --no-sync pre-commit run --all-files`: passed

## Scope

This change is limited to deterministic CPU schema normalization before
batching or training. It does not change public signatures, dependencies,
CI workflows, canonical OpenAI-style messages, or model-specific templates.
No GPU, distributed, convergence, performance, or full-suite validation is
claimed.
