### PR TITLE
feat(training): enable THD online packing + CP for pretrain

### DIFF
--- a/src/megatron/bridge/training/gpt_step.py
+++ b/src/megatron/bridge/training/gpt_step.py
@@ -310,6 +310,46 @@ def get_batch(
         tuple of tensors containing tokens, labels, loss_mask, attention_mask,
         position_ids, and optional packed-sequence metadata.
     """
+    # Sequence packing (THD) + Context Parallel: when online packing is active AND CP>1,
+    # delegate to MCore's get_batch_on_this_rank_for_sequence_packing which handles both
+    # CP partitioning of the packed token sequence and THD metadata construction.
+    # For CP=1 with THD, the packed batch (cu_seqlens already set by wrap_data_iterator)
+    # flows through the standard get_batch_from_iterator path below without modification.
+    _cp_size = getattr(pg_collection, "cp", None)
+    _cp_size = _cp_size.size() if _cp_size is not None else 1
+    if getattr(cfg.model, "sequence_packing_scheduler", None) is not None and _cp_size > 1:
+        assert pg_collection.tp.size() == 1, (
+            "THD online packing + CP requires TP=1: Bridge gives all TP ranks a valid "
+            "data_iterator, but get_batch_on_this_rank_for_sequence_packing expects "
+            "data_iterator=None for non-TP-0 ranks."
+        )
+        from megatron.core.datasets.data_schedule import get_batch_on_this_rank_for_sequence_packing
+
+        mtp_on_this_rank = use_mtp and is_pp_last_stage(pg_collection.pp)
+        tokens, labels, loss_mask, _, position_ids, packed_seq_params, _ = get_batch_on_this_rank_for_sequence_packing(
+            data_iterator,
+            vpp_size=getattr(cfg.model, "virtual_pipeline_model_parallel_size", None),
+            mtp_on_this_rank=mtp_on_this_rank,
+            vp_stage=vp_stage,
+            config=cfg.model,
+            pg_collection=pg_collection,
+        )
+        # Map MCore PackedSeqParams into Bridge packed_seq_metadata dict.
+        packed_seq_metadata = None
+        if packed_seq_params is not None:
+            packed_seq_metadata = {
+                "cu_seqlens_q": getattr(packed_seq_params, "cu_seqlens_q", None),
+                "cu_seqlens_kv": getattr(packed_seq_params, "cu_seqlens_kv", None),
+                "cu_seqlens_q_padded": getattr(packed_seq_params, "cu_seqlens_q_padded", None),
+                "cu_seqlens_kv_padded": getattr(packed_seq_params, "cu_seqlens_kv_padded", None),
+                "max_seqlen_q": getattr(packed_seq_params, "max_seqlen_q", None),
+                "max_seqlen_kv": getattr(packed_seq_params, "max_seqlen_kv", None),
+                "cp_partition_mode": getattr(packed_seq_params, "cp_partition_mode", "contiguous"),
+                "cp_group": getattr(packed_seq_params, "cp_group", None),
+                "local_cp_size": getattr(packed_seq_params, "local_cp_size", None),
+            }
+        return tokens, labels, loss_mask, None, position_ids, packed_seq_metadata
+
     # Determine pipeline stage role via process group collection
     model_cfg = getattr(cfg, "model", None)
     vp_size = getattr(model_cfg, "virtual_pipeline_model_parallel_size", None)

--- a/src/megatron/bridge/training/train.py
+++ b/src/megatron/bridge/training/train.py
@@ -882,12 +882,38 @@ def train_step(
         else:
             adjust_tensor_shapes_fn = None
 
+        # Sequence packing (THD): wrap the data iterator for online sequence packing.
+        # Only entered when sequence_packing_scheduler is set (e.g. dp_balanced for CP+THD).
+        if getattr(model_config, "sequence_packing_scheduler", None) is not None:
+            from megatron.core.datasets.data_schedule import wrap_data_iterator
+
+            from megatron.bridge.training.utils.packed_seq_utils import SequencePackingIteratorWrapper
+
+            # Inject padded_seq_len so MCore's packing scheduler knows each sample's length.
+            assert not isinstance(forward_backward_data_iterator, list), (
+                "THD online packing does not support Virtual Pipeline Parallelism "
+                "(VPP produces a list of iterators; packing requires a single iterator)."
+            )
+            _pretrain_seq_len = model_config.seq_length
+            forward_backward_data_iterator = SequencePackingIteratorWrapper(
+                forward_backward_data_iterator, _pretrain_seq_len
+            )
+
+            (
+                forward_backward_data_iterator,
+                _fb_num_microbatches,
+                _seqlen_sum,
+                _seqlen_sq_sum,
+            ) = wrap_data_iterator(forward_backward_data_iterator, model_config, get_num_microbatches())
+        else:
+            _fb_num_microbatches = get_num_microbatches()
+
         # Forward pass.
         losses_reduced = forward_backward_func(
             forward_step_func=forward_step_func,
             data_iterator=forward_backward_data_iterator,
             model=model,
-            num_microbatches=get_num_microbatches(),
+            num_microbatches=_fb_num_microbatches,
             seq_length=seq_length,
             micro_batch_size=train_config.micro_batch_size,
             decoder_seq_length=seq_length,

--- a/src/megatron/bridge/training/utils/packed_seq_utils.py
+++ b/src/megatron/bridge/training/utils/packed_seq_utils.py
@@ -147,6 +147,9 @@ def get_packed_seq_params(batch: dict[str, PackedMetadataValue]) -> PackedSeqPar
             max_seqlen_kv=max_seqlen_kv if max_seqlen_kv is not None else max_seqlen_q,
             total_tokens=batch.get("total_tokens"),
             qkv_format="thd",
+            cp_partition_mode=batch.get("cp_partition_mode", "zigzag"),
+            cp_group=batch.get("cp_group"),
+            local_cp_size=batch.get("local_cp_size"),
         )
 
     cu_seqlens_padded = batch["cu_seqlens"].squeeze()
@@ -195,3 +198,32 @@ def get_packed_seq_params(batch: dict[str, PackedMetadataValue]) -> PackedSeqPar
             total_tokens=total_tokens,
             qkv_format="thd",
         )
+
+
+class SequencePackingIteratorWrapper:
+    """Wraps a fixed-length pretrain iterator to emit ``padded_seq_len`` and
+    ``original_seq_len`` required by MCore's online sequence-packing scheduler
+    (``wrap_data_iterator``).
+
+    Bridge's standard pretrain datasets (GPTDataset / DCLM) yield fixed-length
+    token tensors without sequence-boundary metadata.  The packing scheduler
+    needs ``padded_seq_len`` to know how long each sample is so it can pack
+    multiple samples into a single THD microbatch.  For fixed-length data every
+    sample is exactly ``seq_len`` tokens, so we inject that scalar.
+    """
+
+    def __init__(self, iterator, seq_len: int) -> None:
+        self._it = iterator
+        self._seq_len = seq_len
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        batch = next(self._it)
+        if "padded_seq_len" not in batch and "cu_seqlens" not in batch and "cu_seqlens_q" not in batch:
+            dev = torch.cuda.current_device()
+            sl = torch.tensor([self._seq_len], dtype=torch.int64, device=dev)
+            batch["padded_seq_len"] = sl
+            batch["original_seq_len"] = sl
+        return batch


### PR DESCRIPTION
Three changes to enable sequence_packing_scheduler=dp_balanced with CP>1 for standard pretrain (fixed-length) datasets in Bridge:

- train.py: SequencePackingIteratorWrapper injects padded_seq_len for MCore wrap_data_iterator; asserts no VPP; uses scheduler microbatch count
- gpt_step.py: CP>1 path delegates to get_batch_on_this_rank_for_sequence_packing for CP partitioning; CP=1+THD uses existing get_batch_from_iterator; TP=1 assert
- packed_seq_utils.py: SequencePackingIteratorWrapper class; CP fields in get_packed_seq_params (cp_partition_mode, cp_group, local_cp_size)

Limitations: TP=1 only, no VPP.

smoke run: https://wandb.ai/nvidia-nemo-fw-public/megatron-bridge-dsv4/runs/4bu6lrm2?nw=nwuserweijiachen

# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
