### PR TITLE
fix(data): use Nemotron Ultra recipe defaults

### DIFF
--- a/examples/models/nemotron/nemotron_3/ultra/README.md
+++ b/examples/models/nemotron/nemotron_3/ultra/README.md
@@ -142,8 +142,11 @@ Pre-pack OpenMath data before training:
 sbatch pack_data_job.sh
 ```
 
-Use the same `SEQ_LENGTH`, `HF_MODEL_PATH`, and `NEMO_HOME` for packing and
-training. `NEMO_HOME` must point at a shared filesystem visible on all nodes.
+Packing uses the Hugging Face model and 4096-token sequence length defined by
+the recipe; `pack_data_job.sh` does not accept `HF_MODEL_PATH` or `SEQ_LENGTH`
+overrides. Keep the training launchers at those recipe defaults when consuming
+the packed artifacts. `NEMO_HOME` must be the same shared filesystem location
+for packing and training.
 
 ## Training
 

--- a/examples/models/nemotron/nemotron_3/ultra/pack_data_job.sh
+++ b/examples/models/nemotron/nemotron_3/ultra/pack_data_job.sh
@@ -27,14 +27,12 @@ set -euo pipefail
 CONTAINER_IMAGE=${CONTAINER_IMAGE:-}
 CONTAINER_MOUNTS=${CONTAINER_MOUNTS:-}
 WORKDIR=${WORKDIR:-/opt/Megatron-Bridge}
-HF_MODEL_PATH=${HF_MODEL_PATH:-nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16}
 RECIPE_NAME=${RECIPE_NAME:-nemotron_3_ultra_sft_openmathinstruct2_packed_config}
-SEQ_LENGTH=${SEQ_LENGTH:-4096}
 
 [ -n "${HF_HOME:-}" ] && export HF_HOME
 [ -n "${NEMO_HOME:-}" ] && export NEMO_HOME
 [ -n "${UV_CACHE_DIR:-}" ] && export UV_CACHE_DIR
-export WORKDIR HF_MODEL_PATH RECIPE_NAME SEQ_LENGTH
+export WORKDIR RECIPE_NAME
 
 if [ -z "$CONTAINER_IMAGE" ]; then
     echo "ERROR: CONTAINER_IMAGE must be set."
@@ -54,9 +52,7 @@ cd "$WORKDIR"
 export PYTHONPATH="$WORKDIR/src:$WORKDIR/3rdparty/Megatron-LM:${PYTHONPATH:-}"
 
 uv run --no-sync python scripts/training/prepare_gpt_sft_packed_data.py \
-    --recipe "$RECIPE_NAME" \
-    --seq-length "$SEQ_LENGTH" \
-    --hf-path "$HF_MODEL_PATH"
+    --recipe "$RECIPE_NAME"
 '
 
 echo PACK_DATA_DONE

--- a/tests/unit_tests/examples/test_nemotron_3_ultra_pack_data.py
+++ b/tests/unit_tests/examples/test_nemotron_3_ultra_pack_data.py
@@ -1,0 +1,80 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PACK_DATA_SCRIPT = REPO_ROOT / "examples/models/nemotron/nemotron_3/ultra/pack_data_job.sh"
+
+
+def test_nemotron_3_ultra_pack_data_uses_recipe_defaults(tmp_path: Path) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+
+    fake_srun = fake_bin / "srun"
+    fake_srun.write_text(
+        """#!/bin/bash
+while [[ "$1" == --* ]]; do
+    shift
+done
+exec "$@"
+"""
+    )
+    fake_srun.chmod(0o755)
+
+    fake_uv = fake_bin / "uv"
+    fake_uv.write_text(
+        """#!/bin/bash
+printf '%s\\n' "$@" > "$UV_ARGS_FILE"
+"""
+    )
+    fake_uv.chmod(0o755)
+
+    uv_args_file = tmp_path / "uv-args"
+    env = os.environ.copy()
+    env.update(
+        {
+            "CONTAINER_IMAGE": "test.sqsh",
+            "PATH": f"{fake_bin}:{env['PATH']}",
+            "UV_ARGS_FILE": str(uv_args_file),
+            "WORKDIR": str(tmp_path),
+        }
+    )
+
+    result = subprocess.run(
+        ["bash", str(PACK_DATA_SCRIPT)],
+        capture_output=True,
+        check=False,
+        cwd=tmp_path,
+        env=env,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "PACK_DATA_DONE"
+    assert uv_args_file.read_text().splitlines() == [
+        "run",
+        "--no-sync",
+        "python",
+        "scripts/training/prepare_gpt_sft_packed_data.py",
+        "--recipe",
+        "nemotron_3_ultra_sft_openmathinstruct2_packed_config",
+    ]


### PR DESCRIPTION
## Summary

- stop forwarding stale model-path and sequence-length overrides to the zero-argument Nemotron Ultra packed-SFT recipe
- document that packing uses the recipe-owned defaults and shares `NEMO_HOME` with training
- add a behavioral regression test for the launcher exact preparation command

NVBug 6497823

## Root cause

The H100 recipe namespace refactor made the Nemotron Ultra packed-SFT factory zero-argument, with the model ID and 4096-token length owned by the recipe. The older packing launcher continued passing both removed keyword overrides, so preparation failed during recipe-signature validation.

## Validation

- reproduced the unchanged launcher failure with the stock 26.08 RC2 workflow
- repeated the same real packing workflow after the fix: indexed 950,000 training and 50,000 validation examples, wrote both packed parquet artifacts, and reached `Done.` plus `PACK_DATA_DONE`
- `uv run python -m pytest tests/unit_tests/examples/test_nemotron_3_ultra_pack_data.py tests/unit_tests/scripts/test_prepare_gpt_sft_packed_data.py tests/unit_tests/recipes/nemotronh/test_nemotron_3_ultra.py` — 12 passed
- `bash -n examples/models/nemotron/nemotron_3/ultra/pack_data_job.sh`
- `uv run pre-commit run --all-files`
- `git diff --check`
- independent review completed on the exact final signed commit

This PR intentionally targets `main` only. The mapped 26.08 release label does not exist, so no release label or cherry-pick PR is available.

## AI assistance

This PR was authored by an AI coding agent under user direction and independently reviewed by a separate AI agent.
