### PR TITLE
[ckpt] fix: select newest global recovery root

### DIFF
--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -149,17 +149,29 @@ DATALOADER_STATE_SUBDIR = "energon"
 # ============================================================================
 
 
+def _get_global_non_persistent_checkpoint_dirs(
+    load_dir: str | None,
+    ckpt_cfg: CheckpointConfig,
+) -> tuple[str, ...]:
+    """Return the configured global non-persistent checkpoint sources."""
+    if ckpt_cfg.non_persistent_global_ckpt_dir:
+        return (ckpt_cfg.non_persistent_global_ckpt_dir,)
+
+    checkpoint_dirs = []
+    for checkpoint_root in (getattr(ckpt_cfg, "save", None), load_dir):
+        if isinstance(checkpoint_root, str) and checkpoint_root:
+            checkpoint_dir = os.path.join(checkpoint_root, _NON_PERSISTENT_CKPT_SUBDIR)
+            if checkpoint_dir not in checkpoint_dirs:
+                checkpoint_dirs.append(checkpoint_dir)
+    return tuple(checkpoint_dirs)
+
+
 def _has_global_non_persistent_checkpoint(load_dir: str | None, ckpt_cfg: CheckpointConfig) -> bool:
     """Return whether the configured global non-persistent checkpoint source exists."""
     if ckpt_cfg.non_persistent_ckpt_type != "global":
         return False
 
-    non_persistent_global_dir = (
-        ckpt_cfg.non_persistent_global_ckpt_dir
-        if ckpt_cfg.non_persistent_global_ckpt_dir or load_dir is None
-        else os.path.join(load_dir, _NON_PERSISTENT_CKPT_SUBDIR)
-    )
-    return checkpoint_exists(non_persistent_global_dir)
+    return any(checkpoint_exists(path) for path in _get_global_non_persistent_checkpoint_dirs(load_dir, ckpt_cfg))
 
 
 def set_checkpoint_version(value: float) -> None:
@@ -3524,14 +3536,18 @@ def _load_base_checkpoint(
             raise NotImplementedError(f"Checkpoint format {ckpt_format} not supported")
 
     # Try to load non-persistent checkpoint first
-    non_persistent_global_dir = (
-        ckpt_cfg.non_persistent_global_ckpt_dir
-        if ckpt_cfg.non_persistent_global_ckpt_dir or load_dir is None
-        else os.path.join(load_dir, _NON_PERSISTENT_CKPT_SUBDIR)
-    )
-    non_persistent_iteration = _get_non_persistent_iteration(
-        non_persistent_global_dir, ckpt_cfg.non_persistent_ckpt_type, checkpointing_context
-    )
+    non_persistent_global_dir = ""
+    non_persistent_iteration = -1
+    if ckpt_cfg.non_persistent_ckpt_type == "global":
+        for candidate_dir in _get_global_non_persistent_checkpoint_dirs(load_dir, ckpt_cfg):
+            candidate_iteration = _get_non_persistent_iteration(candidate_dir, "global", checkpointing_context)
+            if candidate_iteration > non_persistent_iteration:
+                non_persistent_global_dir = candidate_dir
+                non_persistent_iteration = candidate_iteration
+    else:
+        non_persistent_iteration = _get_non_persistent_iteration(
+            non_persistent_global_dir, ckpt_cfg.non_persistent_ckpt_type, checkpointing_context
+        )
 
     tracker_filename = "because load directory is not defined"
     if load_dir is not None:
@@ -3541,8 +3557,15 @@ def _load_base_checkpoint(
 
     if non_persistent_iteration != -1:  # there is a non-persistent checkpoint
         if non_persistent_iteration >= iteration:
-            # Non-persistent (global and local) state is written under checkpoint.save, already the root.
-            _record_dataloader_state_dir(checkpointing_context, ckpt_cfg.save)
+            dataloader_checkpoint_root = ckpt_cfg.save
+            if (
+                ckpt_cfg.non_persistent_ckpt_type == "global"
+                and not ckpt_cfg.non_persistent_global_ckpt_dir
+                and load_dir is not None
+                and non_persistent_global_dir == os.path.join(load_dir, _NON_PERSISTENT_CKPT_SUBDIR)
+            ):
+                dataloader_checkpoint_root = load_dir
+            _record_dataloader_state_dir(checkpointing_context, dataloader_checkpoint_root)
             return _load_non_persistent_base_checkpoint(
                 non_persistent_global_dir,
                 ckpt_cfg,

--- a/tests/unit_tests/training/test_checkpointing.py
+++ b/tests/unit_tests/training/test_checkpointing.py
@@ -35,6 +35,7 @@ from megatron.bridge.training.checkpointing import (
     _extract_megatron_lm_args_from_state_dict,
     _get_checkpoint_format,
     _get_non_persistent_iteration,
+    _has_global_non_persistent_checkpoint,
     _load_base_checkpoint,
     _load_checkpoint_from_path,
     _load_hf_pretrained_checkpoint,
@@ -1930,6 +1931,116 @@ class TestLoadBaseCheckpoint:
         mock_pg.tp.rank.return_value = 0
         mock_pg.tp.size.return_value = 1
         return mock_pg
+
+    def test_global_non_persistent_checkpoint_is_found_under_distinct_save_dir(self, tmp_path):
+        """An unchanged restart discovers the non-persistent checkpoint written under save."""
+        load_dir = tmp_path / "input"
+        save_dir = tmp_path / "output"
+        non_persistent_dir = save_dir / "non_persistent"
+        non_persistent_dir.mkdir(parents=True)
+        (non_persistent_dir / "latest_train_state.pt").touch()
+
+        ckpt_cfg = Mock(spec=CheckpointConfig)
+        ckpt_cfg.save = str(save_dir)
+        ckpt_cfg.non_persistent_ckpt_type = "global"
+        ckpt_cfg.non_persistent_global_ckpt_dir = None
+
+        assert _has_global_non_persistent_checkpoint(str(load_dir), ckpt_cfg)
+
+    @patch("megatron.bridge.training.checkpointing._load_global_dist_base_checkpoint")
+    @patch("megatron.bridge.training.checkpointing._get_checkpoint_format", return_value="torch_dist")
+    @patch("megatron.bridge.training.checkpointing._load_non_persistent_base_checkpoint")
+    @patch("megatron.bridge.training.checkpointing._resolve_checkpoint_iteration", return_value=(100, False))
+    def test_newer_global_non_persistent_checkpoint_is_loaded_from_distinct_save_dir(
+        self,
+        _mock_resolve,
+        mock_load_non_persistent,
+        _mock_get_format,
+        mock_load_persistent,
+        tmp_path,
+        base_config,
+        mock_pg_collection,
+    ):
+        """A restart prefers the newer recovery point written under checkpoint.save."""
+        load_dir = tmp_path / "input"
+        save_dir = tmp_path / "output"
+        non_persistent_dir = save_dir / "non_persistent"
+        non_persistent_dir.mkdir(parents=True)
+        torch.save(
+            TrainState(step=200).state_dict(),
+            get_checkpoint_train_state_filename(str(non_persistent_dir), prefix="latest"),
+        )
+
+        base_config.save = str(save_dir)
+        base_config.ckpt_format = "torch_dist"
+        base_config.non_persistent_ckpt_type = "global"
+        base_config.non_persistent_global_ckpt_dir = None
+        expected = ({"model": "newer"}, str(non_persistent_dir / "iter_0000200"), False, CheckpointType.GLOBAL)
+        mock_load_non_persistent.return_value = expected
+
+        checkpointing_context = {}
+        result = _load_base_checkpoint(
+            str(load_dir),
+            base_config,
+            checkpointing_context=checkpointing_context,
+            pg_collection=mock_pg_collection,
+        )
+
+        assert result == expected
+        assert mock_load_non_persistent.call_args.args[0] == str(non_persistent_dir)
+        assert mock_load_non_persistent.call_args.args[4] == 200
+        assert checkpointing_context["dataloader_state_dir"] == str(save_dir / DATALOADER_STATE_SUBDIR)
+        mock_load_persistent.assert_not_called()
+
+    @patch("megatron.bridge.training.checkpointing._load_non_persistent_base_checkpoint")
+    @patch("megatron.bridge.training.checkpointing._resolve_checkpoint_iteration", return_value=(50, False))
+    def test_newer_global_non_persistent_checkpoint_under_load_remains_available(
+        self,
+        _mock_resolve,
+        mock_load_non_persistent,
+        tmp_path,
+        base_config,
+        mock_pg_collection,
+    ):
+        """A distinct empty save root does not hide a newer recovery point under load."""
+        load_dir = tmp_path / "input"
+        save_dir = tmp_path / "output"
+        load_non_persistent_dir = load_dir / "non_persistent"
+        save_non_persistent_dir = save_dir / "non_persistent"
+        load_non_persistent_dir.mkdir(parents=True)
+        save_non_persistent_dir.mkdir(parents=True)
+        torch.save(
+            TrainState(step=200).state_dict(),
+            get_checkpoint_train_state_filename(str(load_non_persistent_dir), prefix="latest"),
+        )
+        torch.save(
+            TrainState(step=100).state_dict(),
+            get_checkpoint_train_state_filename(str(save_non_persistent_dir), prefix="latest"),
+        )
+
+        base_config.save = str(save_dir)
+        base_config.non_persistent_ckpt_type = "global"
+        base_config.non_persistent_global_ckpt_dir = None
+        expected = (
+            {"model": "newer"},
+            str(load_non_persistent_dir / "iter_0000200"),
+            False,
+            CheckpointType.GLOBAL,
+        )
+        mock_load_non_persistent.return_value = expected
+
+        checkpointing_context = {}
+        result = _load_base_checkpoint(
+            str(load_dir),
+            base_config,
+            checkpointing_context=checkpointing_context,
+            pg_collection=mock_pg_collection,
+        )
+
+        assert result == expected
+        assert mock_load_non_persistent.call_args.args[0] == str(load_non_persistent_dir)
+        assert mock_load_non_persistent.call_args.args[4] == 200
+        assert checkpointing_context["dataloader_state_dir"] == str(load_dir / DATALOADER_STATE_SUBDIR)
 
     @patch("megatron.bridge.training.checkpointing._get_non_persistent_iteration")
     @patch("megatron.bridge.training.checkpointing.file_exists")


### PR DESCRIPTION
## Problem

A supported restart can configure distinct `checkpoint.load` and `checkpoint.save` roots with global non-persistent checkpointing and no explicit `non_persistent_global_ckpt_dir`. Global recovery state is written under `{checkpoint.save}/non_persistent`, but both setup reachability and the base loader searched only `{checkpoint.load}/non_persistent`.

After the current run saves a newer recovery point under the output root, an unchanged restart can therefore miss it and roll back to an older persistent or stale non-persistent checkpoint under the input root, losing training progress.

## Fix

Preserve explicit global non-persistent directory behavior. For the default layout, inspect the deduplicated save-root and load-root candidates, select the highest recorded iteration, and align default Energon state restoration with the root that supplied the selected model checkpoint.

A negative control keeps a newer load-root recovery point eligible when the distinct save root contains an older one.

The closest related change is #4900, which made same-root global non-persistent checkpoints reachable but did not cover distinct load/save roots.

## Validation

Fail before on the unmodified base (`fc704f7809f84461c6e2cbf476acb28c4a5654c0`):

```text
uv run python -m pytest \
  tests/unit_tests/training/test_checkpointing.py::TestLoadBaseCheckpoint::test_global_non_persistent_checkpoint_is_found_under_distinct_save_dir \
  tests/unit_tests/training/test_checkpointing.py::TestLoadBaseCheckpoint::test_newer_global_non_persistent_checkpoint_is_loaded_from_distinct_save_dir \
  -q --tb=short
```

Result: `2 failed`. The probe returned false, and the loader reported the missing tracker under the input root before loading persistent iteration 100 instead of the newer non-persistent iteration 200.

Pass after, including the load-root negative control:

```text
uv run python -m pytest \
  tests/unit_tests/training/test_checkpointing.py::TestLoadBaseCheckpoint::test_global_non_persistent_checkpoint_is_found_under_distinct_save_dir \
  tests/unit_tests/training/test_checkpointing.py::TestLoadBaseCheckpoint::test_newer_global_non_persistent_checkpoint_is_loaded_from_distinct_save_dir \
  tests/unit_tests/training/test_checkpointing.py::TestLoadBaseCheckpoint::test_newer_global_non_persistent_checkpoint_under_load_remains_available \
  -q --tb=short
```

Result: `3 passed`.

Focused adjacent coverage:

```text
uv run python -m pytest \
  tests/unit_tests/training/test_checkpointing.py::TestNonPersistentCheckpoints \
  tests/unit_tests/training/test_checkpointing.py::TestLoadBaseCheckpoint \
  tests/unit_tests/training/test_setup.py::TestShouldLoadCheckpoint \
  -q --tb=short
```

Result: `23 passed`.

```text
git diff --check
uv run pre-commit run --all-files
```

Result: passed.

## Scope

This is a deterministic CPU checkpoint source-selection fix. No dependency, CI workflow, public API signature, Megatron-Core, distributed execution, GPU behavior, convergence, performance, model-quality, or full-suite validation is included.