### PR TITLE
[misc] fix: Preserve chat templates in inference tokenizer

### DIFF
--- a/src/megatron/bridge/inference/_tokenizer.py
+++ b/src/megatron/bridge/inference/_tokenizer.py
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Shared HuggingFace tokenizer adapter for MCore text generation.
+"""Shared HuggingFace tokenizer adapter for MCore text generation and serving.
 
 MCore's ``TextGenerationController`` expects a tokenizer exposing ``eod`` / ``bos`` /
 ``vocab_size`` attributes and ``tokenize`` / ``detokenize`` methods. This adapter wraps a
 HuggingFace tokenizer to that interface and is shared by the text-generation scripts and the
 VLM inference controllers (which previously each defined their own near-identical wrapper).
+MCore's OpenAI-compatible server additionally reads ``eos_id`` and, when available,
+``chat_template`` / ``apply_chat_template``.
 
 Behavior knobs let call sites preserve their historical semantics exactly:
 - ``set_pad_token``: default the pad token to EOS when unset (text generation).
@@ -47,8 +49,18 @@ class HFTokenizerAdapter:
         if set_pad_token and tokenizer.pad_token is None and tokenizer.eos_token is not None:
             tokenizer.pad_token = tokenizer.eos_token
         self.eod = tokenizer.eos_token_id
+        self.eos_id = tokenizer.eos_token_id
         self.bos = tokenizer.bos_token_id
         self.vocab_size = len(tokenizer) if expose_vocab_size else None
+
+    @property
+    def chat_template(self) -> object | None:
+        """Return the wrapped tokenizer's chat template, if one is configured."""
+        return getattr(self._tokenizer, "chat_template", None)
+
+    def apply_chat_template(self, conversation: object, **kwargs: object) -> object:
+        """Apply the wrapped tokenizer's chat template."""
+        return self._tokenizer.apply_chat_template(conversation, **kwargs)
 
     def tokenize(self, text: str) -> list[int]:
         """Tokenize text into token ids (no special tokens added)."""

--- a/tests/unit_tests/inference/test_tokenizer.py
+++ b/tests/unit_tests/inference/test_tokenizer.py
@@ -41,10 +41,24 @@ class _FakeTokenizer:
         return f"decoded({list(tokens)},sst={skip_special_tokens})"
 
 
+class _FakeChatTokenizer(_FakeTokenizer):
+    """HF tokenizer with the chat-template contract used by MCore's server."""
+
+    def __init__(self):
+        super().__init__()
+        self.chat_template = "{{ messages }}"
+        self.chat_template_calls = []
+
+    def apply_chat_template(self, messages, **kwargs):
+        self.chat_template_calls.append((messages, kwargs))
+        return [101, 102]
+
+
 def test_text_generation_defaults():
     tok = _FakeTokenizer()
     adapter = HFTokenizerAdapter(tok)
 
+    assert adapter.chat_template is None
     assert adapter.eod == 2
     assert adapter.bos == 1
     assert adapter.vocab_size == 32000
@@ -79,3 +93,29 @@ def test_force_skip_special_tokens_none_honors_caller():
     adapter = HFTokenizerAdapter(tok, force_skip_special_tokens=None)
     adapter.detokenize([65], skip_special_tokens=False)
     assert tok.decode_calls == [False]
+
+
+def test_openai_server_preserves_hf_chat_template_contract():
+    """The server adapter must expose an available HF chat template to MCore."""
+    tok = _FakeChatTokenizer()
+    adapter = HFTokenizerAdapter(tok)
+    messages = [{"role": "system", "content": "Be concise."}, {"role": "user", "content": "Hello"}]
+
+    assert adapter.chat_template == tok.chat_template
+    assert adapter.apply_chat_template(
+        messages,
+        tokenize=True,
+        add_generation_prompt=True,
+        tools=[{"type": "function"}],
+    ) == [101, 102]
+    assert adapter.eos_id == tok.eos_token_id
+    assert tok.chat_template_calls == [
+        (
+            messages,
+            {
+                "tokenize": True,
+                "add_generation_prompt": True,
+                "tools": [{"type": "function"}],
+            },
+        )
+    ]


### PR DESCRIPTION
## Problem

The documented OpenAI-compatible server always wraps its Hugging Face tokenizer
in `HFTokenizerAdapter`, but that adapter hides the tokenizer's
`chat_template` and `apply_chat_template` capabilities.

For a supported `/v1/chat/completions` request, MCore consequently takes its
template-less fallback and newline-joins only the message contents. The request
can succeed while silently losing roles, model control tokens, the assistant
generation prefix, tool formatting, and chat-template kwargs. Once templating
is exposed, assistant-history continuation also requires the `eos_id` alias.

Related user request: #1751.
This supersedes the author's self-closed, unmerged #4877 after revalidation on
the current `main`; GitHub would not reopen that PR after its head was refreshed.

## Root cause and fix

The Bridge adapter exposes the basic MCore text-generation tokenizer interface,
but not the additional tokenizer contract used by MCore's OpenAI chat endpoint.

This change keeps the ownership boundary at the adapter:

- expose the wrapped tokenizer's `chat_template`, returning `None` when absent;
- forward `apply_chat_template` and its kwargs unchanged;
- expose `eos_id` as the Hugging Face EOS token ID.

Tokenizers without a configured chat template still return `None`, so MCore's
existing raw-text fallback remains unchanged.

## Regression evidence

Before the production fix, the frozen regression failed as intended:

```text
uv run --no-project --python 3.12 --with pytest python -m pytest \
  --confcutdir=tests/unit_tests/inference \
  tests/unit_tests/inference/test_tokenizer.py::test_openai_server_preserves_hf_chat_template_contract -q

AttributeError: 'HFTokenizerAdapter' object has no attribute 'chat_template'
1 failed
```

After the fix, the same test passed unchanged:

```text
uv run --no-project --python 3.12 --with pytest python -m pytest \
  --confcutdir=tests/unit_tests/inference \
  tests/unit_tests/inference/test_tokenizer.py::test_openai_server_preserves_hf_chat_template_contract -q

1 passed
```

Adjacent validation:

```text
uv run --no-project --python 3.12 --with pytest python -m pytest \
  --confcutdir=tests/unit_tests/inference \
  tests/unit_tests/inference/test_tokenizer.py -q
# 4 passed

uv run --no-project --python 3.12 --with pytest --with torch --with numpy \
  python -m pytest --confcutdir=tests/unit_tests/scripts \
  tests/unit_tests/scripts/test_text_generation.py -q
# 16 passed

uv run --no-project --python 3.12 --with pre-commit==3.6.0 \
  pre-commit run --all-files
# all hooks passed

git diff --check
# passed
```

## Scope

This is a CPU-verifiable tokenizer-contract fix. It does not change generation
algorithms, model weights, conversion APIs, dependencies, CI, or MCore source,
and it does not claim model-quality, convergence, performance, or full-suite
validation.
