### PR TITLE
[recipe] fix: Correct Ministral 3 SFT learning rates

### DIFF
--- a/src/megatron/bridge/recipes/ministral3/h100/ministral3.py
+++ b/src/megatron/bridge/recipes/ministral3/h100/ministral3.py
@@ -94,8 +94,8 @@ def ministral3_3b_sft_1gpu_h100_bf16_config() -> ConfigContainer:
     opt_cfg, scheduler_cfg = distributed_fused_adam_with_cosine_annealing(
         lr_warmup_iters=10,
         lr_decay_iters=50,
-        max_lr=0.00005,
-        min_lr=0.000005,
+        max_lr=0.000005,
+        min_lr=0.0000005,
     )
     cfg.optimizer = opt_cfg
     cfg.scheduler = scheduler_cfg
@@ -209,8 +209,8 @@ def ministral3_8b_sft_2gpu_h100_bf16_config() -> ConfigContainer:
     opt_cfg, scheduler_cfg = distributed_fused_adam_with_cosine_annealing(
         lr_warmup_iters=10,
         lr_decay_iters=50,
-        max_lr=0.00005,
-        min_lr=0.000005,
+        max_lr=0.000005,
+        min_lr=0.0000005,
     )
     cfg.optimizer = opt_cfg
     cfg.scheduler = scheduler_cfg
@@ -324,8 +324,8 @@ def ministral3_14b_sft_4gpu_h100_bf16_config() -> ConfigContainer:
     opt_cfg, scheduler_cfg = distributed_fused_adam_with_cosine_annealing(
         lr_warmup_iters=10,
         lr_decay_iters=50,
-        max_lr=0.00005,
-        min_lr=0.000005,
+        max_lr=0.000005,
+        min_lr=0.0000005,
     )
     cfg.optimizer = opt_cfg
     cfg.scheduler = scheduler_cfg

--- a/tests/unit_tests/recipes/test_ministral3_recipes.py
+++ b/tests/unit_tests/recipes/test_ministral3_recipes.py
@@ -125,6 +125,19 @@ def test_each_ministral3_sft_recipe_builds_config(recipe_func: Callable, monkeyp
     assert cfg.peft is None
 
 
+@pytest.mark.parametrize("recipe_func", _MINISTRAL3_SFT_FUNCS)
+def test_each_ministral3_sft_recipe_uses_recommended_learning_rate(
+    recipe_func: Callable, monkeypatch: pytest.MonkeyPatch
+):
+    """Test that each Ministral3 full-SFT recipe uses its recommended learning-rate range."""
+    patch_recipe_module_global(monkeypatch, _ministral3_module, "AutoBridge", _FakeAutoBridge)
+
+    cfg = recipe_func()
+
+    assert cfg.optimizer.lr == pytest.approx(5e-6)
+    assert cfg.optimizer.min_lr == pytest.approx(5e-7)
+
+
 @pytest.mark.parametrize("recipe_func", _MINISTRAL3_PEFT_FUNCS)
 def test_each_ministral3_peft_recipe_builds_config(recipe_func: Callable, monkeypatch: pytest.MonkeyPatch):
     """Test that each Ministral3 PEFT recipe function builds a valid configuration."""


### PR DESCRIPTION
## What does this PR do?

Correct the default optimizer schedule for all three supported Ministral 3 full-SFT recipes. The factories declared and documented a `5e-6` peak learning rate, but configured `5e-5`; the scheduler therefore warmed to a value 10× above the maintained recommendation whenever users selected a public SFT recipe without an optimizer override.

The patch changes the 3B, 8B, and 14B full-SFT factories to a `5e-6` peak and preserves their existing 10:1 peak-to-floor ratio with a `5e-7` floor. It adds a parametrized regression covering all three public recipe factories.

Related model-support tracker: #1601.

## Root cause

The parameterless VLM recipe refactor hard-coded the peak and floor one decimal place above the prior full-SFT values while retaining the `LR=5e-6` recipe contract. `distributed_fused_adam_with_cosine_annealing` assigns `max_lr` directly to `OptimizerConfig.lr`, and Bridge passes that value to the optimizer scheduler as its maximum; no later configuration step corrected it.

## Validation

Fail-before contract reproducer on unmodified `fc704f7809f84461c6e2cbf476acb28c4a5654c0`:

```text
MB_SOURCE_ROOT=<unmodified-base> uv run --no-project --python 3.12 python reproduce_ministral_sft_lr.py
```

Result: exit 1. All three factories returned `(5e-5, 5e-6)` instead of `(5e-6, 5e-7)`.

The unchanged reproducer against this branch exited 0 and returned `(5e-6, 5e-7)` for all three factories.

Focused regression:

```text
uv run --no-sync python -m pytest tests/unit_tests/recipes/test_ministral3_recipes.py -k recommended_learning_rate -q
```

Result: `3 passed, 25 deselected`.

Adjacent recipe tests:

```text
uv run --no-sync python -m pytest tests/unit_tests/recipes/test_ministral3_recipes.py -q
```

Result: `28 passed`.

Static checks:

```text
git diff --check
uv run pre-commit run --all-files
```

Result: passed; all pre-commit hooks passed.

## Scope

- No dependency, lockfile, workflow, public API, or Megatron-Core changes.
- The maintained example shell launcher explicitly overrides learning rates, so it is unaffected; the bug is in the public recipe defaults.
- No GPU, convergence, model-quality, performance, or full-suite validation is claimed.
