### PR TITLE
fix(training): pass process groups in RL integration guide

### DIFF
--- a/docs/bridge-rl-integration.md
+++ b/docs/bridge-rl-integration.md
@@ -155,7 +155,7 @@ from megatron.bridge.training.state import GlobalState
 # Minimal bootstrap
 state = GlobalState()
 state.cfg = megatron_cfg
-initialize_megatron(cfg=megatron_cfg)
+pg_collection = initialize_megatron(cfg=megatron_cfg)
 set_jit_fusion_options(megatron_cfg.model, megatron_cfg.train.micro_batch_size)
 
 ckpt_ctx = init_checkpointing_context(megatron_cfg.checkpoint)
@@ -165,6 +165,7 @@ model_list = get_model(
     use_torch_fsdp2=megatron_cfg.dist.use_torch_fsdp2,
     overlap_param_gather_with_optimizer_step=megatron_cfg.optimizer.overlap_param_gather_with_optimizer_step,
     data_parallel_random_init=megatron_cfg.rng.data_parallel_random_init,
+    pg_collection=pg_collection,
 )
 optimizer, scheduler = setup_optimizer(
     optimizer_config=megatron_cfg.optimizer,
@@ -440,11 +441,12 @@ class MegatronBridgeAdapter:
         from megatron.bridge.training.initialize import initialize_megatron, set_jit_fusion_options
         from megatron.bridge.models.model_provider import get_model
         from megatron.bridge.training.optim import setup_optimizer
-        initialize_megatron(cfg=self.megatron_cfg)
+        self.pg_collection = initialize_megatron(cfg=self.megatron_cfg)
         set_jit_fusion_options(self.megatron_cfg.model, self.megatron_cfg.train.micro_batch_size)
         self.model_list = get_model(self.megatron_cfg.model, self.megatron_cfg.ddp,
                                     use_torch_fsdp2=self.megatron_cfg.dist.use_torch_fsdp2,
-                                    overlap_param_gather_with_optimizer_step=self.megatron_cfg.optimizer.overlap_param_gather_with_optimizer_step)
+                                    overlap_param_gather_with_optimizer_step=self.megatron_cfg.optimizer.overlap_param_gather_with_optimizer_step,
+                                    pg_collection=self.pg_collection)
         self.model = self.model_list[0]
         self.optimizer, self.scheduler = setup_optimizer(self.megatron_cfg.optimizer, self.megatron_cfg.scheduler, self.model_list,
                                                          use_gloo_process_groups=self.megatron_cfg.dist.use_gloo_process_groups)

--- a/tests/unit_tests/doc_consistency/test_readme_consistency.py
+++ b/tests/unit_tests/doc_consistency/test_readme_consistency.py
@@ -34,6 +34,8 @@ TRAINING_README = REPO_ROOT / "scripts" / "training" / "README.md"
 DATASET_UTILS = REPO_ROOT / "src" / "megatron" / "bridge" / "recipes" / "utils" / "dataset_utils.py"
 LLAMA_README = REPO_ROOT / "tutorials" / "recipes" / "llama" / "README.md"
 DCLM_README = REPO_ROOT / "tutorials" / "data" / "dclm" / "README.md"
+RL_INTEGRATION_DOC = REPO_ROOT / "docs" / "bridge-rl-integration.md"
+MODEL_PROVIDER = REPO_ROOT / "src" / "megatron" / "bridge" / "models" / "model_provider.py"
 GEMMA3_VL_README = REPO_ROOT / "examples" / "models" / "gemma" / "gemma3_vl" / "README.md"
 GEMMA3_VL_RECIPES = RECIPES_DIR / "gemma3_vl" / "gemma3_vl.py"
 RUN_RECIPE = REPO_ROOT / "scripts" / "training" / "run_recipe.py"
@@ -193,6 +195,46 @@ def test_hf_path_flag_documented_if_implemented():
     if '"--hf_path"' not in _read(RUN_RECIPE):
         return  # flag not implemented — nothing to document
     assert "--hf_path" in _read(TRAINING_README), "--hf_path is implemented but not documented in README"
+
+
+def test_rl_integration_get_model_calls_supply_required_keyword_only_arguments():
+    """RL integration snippets must satisfy get_model's required keyword-only contract."""
+    provider_tree = ast.parse(_read(MODEL_PROVIDER), filename=str(MODEL_PROVIDER))
+    get_model_def = next(
+        node for node in provider_tree.body if isinstance(node, ast.FunctionDef) and node.name == "get_model"
+    )
+    required_keywords = {
+        arg.arg
+        for arg, default in zip(get_model_def.args.kwonlyargs, get_model_def.args.kw_defaults)
+        if default is None
+    }
+    assert required_keywords, "get_model has no required keyword-only arguments — update this contract test"
+
+    text = _read(RL_INTEGRATION_DOC)
+    documented_calls: list[tuple[int, set[str]]] = []
+    for match in re.finditer(r"```python\n(?P<code>.*?)```", text, re.DOTALL):
+        code = match.group("code")
+        if "get_model(" not in code:
+            continue
+        tree = ast.parse(code, filename=str(RL_INTEGRATION_DOC))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            function_name = getattr(node.func, "id", None) or getattr(node.func, "attr", None)
+            if function_name != "get_model":
+                continue
+            source_line = text.count("\n", 0, match.start("code")) + node.lineno
+            documented_calls.append(
+                (source_line, {keyword.arg for keyword in node.keywords if keyword.arg is not None})
+            )
+
+    assert len(documented_calls) == 2, f"expected two RL integration get_model calls, found {documented_calls}"
+    missing = {
+        source_line: sorted(required_keywords - supplied_keywords)
+        for source_line, supplied_keywords in documented_calls
+        if required_keywords - supplied_keywords
+    }
+    assert not missing, f"RL integration get_model calls omit required keyword-only arguments: {missing}"
 
 
 def test_model_examples_use_current_run_recipe_arguments():


### PR DESCRIPTION
## What does this PR do?

Fixes both model-construction snippets in the public RL integration guide.

The guide initialized Megatron and then called `get_model()` without its required keyword-only `pg_collection`. Any otherwise-valid user following either snippet reached:

```text
TypeError: get_model() missing 1 required keyword-only argument: 'pg_collection'
```

This happens during Python argument binding, before model construction, so optimizer and checkpoint setup cannot begin.

## Root cause

`initialize_megatron()` returns the process-group collection created for the eager initialization path, including the ordinary MPU collection or the decentralized HyperCommGrid collection. The guide discarded that return value after `get_model()` made `pg_collection` required.

The maintained executable training paths already preserve and pass this object, but both guide snippets had drifted from the current API.

## Fix

Capture the collection returned by `initialize_megatron()` and pass that same object to `get_model()` in both the minimal bootstrap and adapter skeleton.

A stdlib doc-consistency regression derives required keyword-only arguments from the current `get_model` definition, parses the guide Python fences, and checks both documented calls.

Related context: #4294 and #4515.

## Validation

Fail before on unmodified `fc704f7809f84461c6e2cbf476acb28c4a5654c0`:

```text
uv run --active --no-sync python tests/unit_tests/doc_consistency/test_readme_consistency.py
```

Result: 14 passed, 1 failed. Both guide calls were reported missing `pg_collection` at source lines 162 and 445.

Pass after, including 14 adjacent doc-consistency controls:

```text
uv run --no-project --with pytest python -m pytest -p no:cacheprovider --confcutdir=tests/unit_tests/doc_consistency tests/unit_tests/doc_consistency/test_readme_consistency.py
```

Result: 15 passed.

Additional checks:

```text
git diff --check
uv run --no-project --with 'pre-commit==3.6.2' pre-commit run --all-files
```

Result: passed; every pre-commit hook passed.

## Scope

This PR changes only the RL guide and a stdlib documentation-contract test. It does not change public APIs, runtime model code, dependencies, workflows, or the Megatron-Core submodule. No GPU, convergence, model-quality, or performance validation is claimed; the reproduced failure is deterministic Python signature binding before GPU model execution.
