### PR TITLE
perf(recipe): overlap Qwen3 expert communication on H100

### DIFF
--- a/examples/model_verification_cards/qwen3-30b-a3b/card.yaml
+++ b/examples/model_verification_cards/qwen3-30b-a3b/card.yaml
@@ -504,13 +504,6 @@ items:
       status: verified
       precision: bf16
       bridge_commit: 8198fd9cd5a13c2650ae08e5dfca8d9d382db853  # pragma: allowlist secret
-      enabled_features:
-        cuda_graph:
-          implementation: transformer_engine
-          scopes: [moe_router, moe_preprocess]
-        moe_dispatcher: hybridep
-        expert_parallel_communication_overlap: true
-        delay_wgrad_compute: false
       command: >
         ./scripts/training/train.sh --nodes 2 --gpus-per-node 8
         --recipe qwen3_30b_a3b_pretrain_16gpu_h100_bf16_config --max_steps 50

--- a/examples/model_verification_cards/qwen3-30b-a3b/card.yaml
+++ b/examples/model_verification_cards/qwen3-30b-a3b/card.yaml
@@ -503,24 +503,33 @@ items:
     H100:
       status: verified
       precision: bf16
-      bridge_commit: 7160fd35c8f01f09d795e10f2057259d122c1e7e  # pragma: allowlist secret
+      bridge_commit: 8198fd9cd5a13c2650ae08e5dfca8d9d382db853  # pragma: allowlist secret
+      enabled_features:
+        cuda_graph:
+          implementation: transformer_engine
+          scopes: [moe_router, moe_preprocess]
+        moe_dispatcher: hybridep
+        expert_parallel_communication_overlap: true
+        delay_wgrad_compute: false
       command: >
         ./scripts/training/train.sh --nodes 2 --gpus-per-node 8
         --recipe qwen3_30b_a3b_pretrain_16gpu_h100_bf16_config --max_steps 50
-      last_verified: 2026-07-18
+      last_verified: 2026-07-25
       metrics:
         initial_loss: 12.34643
-        final_loss: 8.143753
-        last_10_steps_step_time_ms_avg: 25118.160
-        last_10_steps_model_tflops_per_gpu_avg: 240.110
+        final_loss: 8.145228
+        last_10_steps_step_time_ms_avg: 20992.030
+        last_10_steps_model_tflops_per_gpu_avg: 287.305
       expected_result: >
         On two nodes with 16x H100, the exact mock-data performance recipe
         completes exactly 50 steps with finite losses, no skipped or NaN
-        iterations, and all four metrics recorded. HybridEP is active and
-        Transformer Engine CUDA graph capture completes for all 48 graphable
-        layers with moe_router and moe_preprocess scopes. Over steps 41-50, the
-        run averages at most 27 seconds per step and at least 225 model
-        TFLOP/s/GPU, while peak allocated memory remains below 65 GiB/GPU.
+        iterations, and all four metrics recorded. HybridEP expert-parallel
+        communication overlap is active with delayed weight-gradient compute
+        disabled, and Transformer Engine CUDA graph capture completes for all
+        48 graphable layers with moe_router and moe_preprocess scopes. Over
+        steps 41-50, the run averages at most 21.55 seconds per step and at
+        least 280 model TFLOP/s/GPU, while peak allocated memory remains below
+        65 GiB/GPU.
 
     GB200:
       status: verified

--- a/skills/nemo-mbridge-perf-expert-parallel-overlap/SKILL.md
+++ b/skills/nemo-mbridge-perf-expert-parallel-overlap/SKILL.md
@@ -89,6 +89,42 @@ shape. It does not show a meaningful independent win from delayed wgrad, and it
 does not validate fused MoE permutation because that path was disabled for the
 runtime stack.
 
+## HybridEP Production-Shape Benchmark
+
+A 2026-07-25 controlled Qwen3 30B-A3B pretraining comparison validated plain
+EP overlap with the production HybridEP path:
+
+```text
+Hardware: 16×H100
+Precision: BF16
+Sequence: 4096
+Parallelism: TP1 / PP1 / CP1 / EP16
+Batch: MBS1 / GBS1024
+Routing: force balance
+Dispatcher: flex + HybridEP
+CUDA graph: Transformer Engine scopes moe_router + moe_preprocess
+Delayed wgrad: disabled
+```
+
+| Case | Steady window | Step time | Model TFLOPS/GPU |
+|---|---:|---:|---:|
+| overlap off | iterations 5-20 | 24.7138s | 244.039 |
+| overlap on, search run | iterations 5-20 | 21.0725s | 286.208 |
+| overlap on, independent validation | iterations 41-50 | 20.9920s | 287.305 |
+
+The independent run reduced step time by 15.059% and raised throughput by
+17.729% over the reproduced baseline. Loss was finite, skipped and NaN
+iterations remained zero, and rank-0 peak allocated memory was 62.166 GiB.
+
+A matched Nsight Systems comparison captured the same 463,348 rank-0 kernels
+per case. Enabling overlap increased communication concurrent with GEMM and
+attention from 9.079ms (0.11% of communication time) to 3,958.997ms (36.55%).
+GPU-active interval union fell from 22.821s to 21.221s.
+
+Use this as evidence for the mechanism, not as a universal speedup promise.
+The dispatcher, graph scopes, routing, parallelism, batch shape, and runtime
+were held fixed while only plain EP overlap changed.
+
 ## Enablement
 
 ### alltoall dispatcher
@@ -114,12 +150,16 @@ work and its extra compatibility constraints have been checked.
 from megatron.bridge.training.flex_dispatcher_backend import apply_flex_dispatcher_backend
 
 cfg.comm_overlap.overlap_moe_expert_parallel_comm = True
-cfg.comm_overlap.delay_wgrad_compute = True
+cfg.comm_overlap.delay_wgrad_compute = False
 cfg.model.moe_shared_expert_overlap = False
 
 apply_flex_dispatcher_backend(cfg.model, moe_flex_dispatcher_backend="deepep")
 # or: apply_flex_dispatcher_backend(cfg.model, moe_flex_dispatcher_backend="hybridep")
 ```
+
+Benchmark plain EP overlap first. Enable `delay_wgrad_compute=True` only as a
+separate follow-up A/B after its CUDA-graph and TE compatibility constraints
+are satisfied.
 
 ## Compatibility And Constraints
 
@@ -222,6 +262,22 @@ After a successful run with EP overlap:
 - Throughput improves or at least does not regress for the target workload
 - Loss trajectory matches baseline (overlap should not affect convergence)
 
+### Profile interpretation
+
+Use an unprofiled steady window for the throughput acceptance result. Use a
+matched profile to explain the mechanism:
+
+1. Keep the dispatcher, routing, graph scopes, batch shape, parallel layout,
+   and runtime fixed.
+2. Capture the same rank and steady iteration while toggling only plain EP
+   overlap.
+3. Build interval unions for communication and compute kernels, then measure
+   their intersection.
+4. Do not use summed kernel duration as wall time. Concurrent kernels can run
+   longer under SM or bandwidth contention even when exposed time decreases.
+5. Corroborate interval results with dispatch/combine NVTX ranges, final step
+   time, loss finiteness, skipped/NaN counts, and peak memory.
+
 ## Code Anchors
 
 ### Bridge overlap validation
@@ -287,6 +343,7 @@ def _set_moe_a2a_overlap_overrides(recipe, moe_a2a_overlap=False):
 | assert on attention bias | CUDA graph attn + delayed wgrad + bias | Check `add_bias_linear` / `add_qkv_bias` | Disable attention bias |
 | no throughput gain from flex dispatcher | `apply_flex_dispatcher_backend` not called | Check `moe_token_dispatcher_type` in logs | Call `apply_flex_dispatcher_backend(...)` |
 | DeepEP/HybridEP silently skipped | Unsupported GPU | Check warning logs | Run on Ampere/Hopper/Blackwell |
+| summed kernel time increases after overlap | Expected concurrency contention or a regression | Compare interval unions, comm/compute intersection, and unprofiled step time | Judge overlap from exposed wall time, not summed per-stream duration |
 
 ## Known Limitations
 
@@ -294,9 +351,9 @@ def _set_moe_a2a_overlap_overrides(recipe, moe_a2a_overlap=False):
   you must call `apply_flex_dispatcher_backend(...)`.
 - Public recipes are often conservative and leave MoE overlap disabled by
   default.
-- End-to-end throughput gains have not yet been measured in a controlled Bridge
-  experiment for every model family. Code validation is stronger than a single
-  universal performance claim.
+- Controlled end-to-end and profile evidence exists for one Qwen3 30B-A3B
+  HybridEP H100 shape; repeat the matched A/B before generalizing it to another
+  model, dispatcher, topology, precision, or batch shape.
 - MoE overlap and shared-expert overlap are mutually exclusive.
 - CUDA graph plus delayed wgrad is a multi-constraint path that requires
   careful TE version and scope validation.

--- a/skills/nemo-mbridge-perf-expert-parallel-overlap/card.yaml
+++ b/skills/nemo-mbridge-perf-expert-parallel-overlap/card.yaml
@@ -1,10 +1,12 @@
 title: expert_parallel_overlap
-validated_on: "2026-03-23"
+validated_on: "2026-07-25"
 summary: >
   Megatron-Bridge supports MoE expert-parallel communication overlap through
   overlap_moe_expert_parallel_comm, with optional delayed expert wgrad
   scheduling. The path depends on dispatcher choice (alltoall or flex),
-  expert parallelism degree, precision (BF16/FP16), and runtime support.
+  expert parallelism degree, precision (BF16/FP16), and runtime support. A
+  controlled Qwen3 30B-A3B HybridEP run on 16 H100 GPUs measured a 15.059%
+  step-time reduction from plain EP overlap.
 
 validation_status:
   moe_overlap_validation:
@@ -18,19 +20,23 @@ validation_status:
   cuda_graph_wgrad_interaction:
     - code_verified
   end_to_end_recipe_smoke:
-    - not_yet_tested
+    - measured
+  qwen3_30b_hybridep_h100:
+    - measured
+  matched_nsys_ab:
+    - measured
 
 training_dimensions:
   speed:
-    effect: "~10-20% faster step time (not yet measured in a controlled Bridge experiment)"
-    confidence: medium
+    effect: "15.059% faster step time and 17.729% higher throughput on the measured Qwen3 30B-A3B HybridEP H100 shape"
+    confidence: high_for_measured_shape
     rationale: >
       Hides expert dispatch/combine all-to-all under expert FFN compute.
       Benefit depends on EP degree and collective-to-compute ratio.
   memory:
-    effect: "neutral to slightly higher (not yet measured)"
+    effect: "62.166 GiB rank-0 peak allocated on the measured winner; baseline delta not isolated"
     confidence: medium
-    rationale: Overlap buffers may add minor memory pressure.
+    rationale: The winner stayed below the 65 GiB allocated-memory gate, but the profile A/B did not isolate a peak-memory delta.
   scale:
     effect: "positive at higher EP degrees (not yet measured)"
     confidence: medium
@@ -92,15 +98,20 @@ config_keys:
 
 recommended_path:
   comm_overlap.overlap_moe_expert_parallel_comm: true_for_moe_tuning
-  comm_overlap.delay_wgrad_compute: true_with_overlap
+  comm_overlap.delay_wgrad_compute: false_for_first_isolation
   model.moe_shared_expert_overlap: false_when_overlap_is_enabled
 
 expected_metric_change:
   - metric: step_time
     direction: down
-    magnitude: "~10-20% (not yet measured in Bridge)"
-    conditions: "MoE with alltoall or flex dispatcher, EP >= 4"
-    evidence: not_yet_measured
+    magnitude: "15.059% on measured Qwen3 30B-A3B shape"
+    conditions: "16×H100 BF16 seq4096 TP1 PP1 CP1 EP16 MBS1 GBS1024 force balance HybridEP"
+    evidence: measured
+  - metric: model_tflops_per_gpu
+    direction: up
+    magnitude: "17.729% (244.039 to 287.305)"
+    conditions: "same controlled Qwen3 30B-A3B shape"
+    evidence: measured
   - metric: peak_memory
     direction: up
     magnitude: "slight (not yet measured)"
@@ -110,7 +121,7 @@ expected_metric_change:
 minimal_example:
   config: |
     cfg.comm_overlap.overlap_moe_expert_parallel_comm = True
-    cfg.comm_overlap.delay_wgrad_compute = True
+    cfg.comm_overlap.delay_wgrad_compute = False
     cfg.model.moe_shared_expert_overlap = False
   command: |
     python scripts/performance/setup_experiment.py \
@@ -169,10 +180,13 @@ known_constraints:
 known_limitations:
   - Setting moe_flex_dispatcher_backend alone does not activate flex dispatch.
   - Public recipes are often conservative and leave MoE overlap disabled by default.
-  - End-to-end throughput gains not yet measured in a controlled Bridge experiment.
+  - The measured gain is specific to one Qwen3 30B-A3B HybridEP H100 shape.
+  - Summed per-stream kernel duration is not exposed wall time when kernels overlap.
 
 evidence:
   - docs/training/communication-overlap.md
+  - examples/model_verification_cards/qwen3-30b-a3b/card.yaml
+  - src/megatron/bridge/perf_recipes/qwen/h100/qwen3_moe.py
   - src/megatron/bridge/training/comm_overlap.py
   - src/megatron/bridge/training/flex_dispatcher_backend.py
   - src/megatron/bridge/training/config.py
@@ -181,6 +195,5 @@ evidence:
   - tests/unit_tests/training/test_deepep.py
 
 follow_up_validation:
-  - Measure end-to-end throughput gain for EP overlap on a representative MoE model.
   - Add a positive Bridge functional smoke test for overlap_moe_expert_parallel_comm.
-  - Validate flex dispatcher (DeepEP/HybridEP) throughput vs alltoall baseline.
+  - Repeat the matched A/B on another model family, dispatcher, and topology.

--- a/skills/nemo-mbridge-perf-moe-comm-overlap/SKILL.md
+++ b/skills/nemo-mbridge-perf-moe-comm-overlap/SKILL.md
@@ -55,7 +55,42 @@ You must also set `moe_token_dispatcher_type = "flex"`.
   attention or MoE-router work.
 - In practice, selective recompute is the safer pairing when overlap is enabled.
 
-## Measured Short-Run Caveat
+## Measured Evidence
+
+### HybridEP production-shape validation
+
+A 2026-07-25 controlled Qwen3 30B-A3B pretraining comparison used 16 H100
+GPUs, BF16, sequence length 4096, `TP=1`, `PP=1`, `CP=1`, `EP=16`,
+`MBS=1`, `GBS=1024`, forced-balanced routing, HybridEP, and Transformer
+Engine CUDA-graph scopes `moe_router` and `moe_preprocess`. The only
+performance change was plain EP overlap; delayed wgrad stayed disabled.
+
+| Case | Steady window | Step time | Model TFLOPS/GPU |
+|---|---:|---:|---:|
+| EP overlap off | iterations 5-20 | 24.7138s | 244.039 |
+| EP overlap on, search run | iterations 5-20 | 21.0725s | 286.208 |
+| EP overlap on, independent validation | iterations 41-50 | 20.9920s | 287.305 |
+
+The independent result reduced step time by 15.059% and increased throughput
+by 17.729% over the reproduced baseline. Loss remained finite, no iterations
+were skipped or NaN, and rank-0 peak allocated memory was 62.166 GiB.
+
+A same-method rank-0 Nsight Systems comparison captured 463,348 kernels in
+each case:
+
+| Profile metric | Overlap off | Overlap on |
+|---|---:|---:|
+| Communication concurrent with GEMM/attention | 9.079ms | 3,958.997ms |
+| Communication time hidden by compute | 0.11% | 36.55% |
+| GPU-active interval union | 22.821s | 21.221s |
+| HybridEP dispatch-with-permute NVTX | 4.253s | 1.767s |
+| HybridEP metadata-preprocess NVTX | 3.109s | 0.670s |
+
+This is direct evidence that the gain came from hiding exposed HybridEP
+dispatch/combine work, not from changing the dispatcher, routing, graph
+scopes, batch shape, or parallel layout.
+
+### Correctness-first alltoall smoke
 
 A 2026-05-18 current-main H100 x16 smoke on Qwen3 30B-A3B mock pretraining
 used `EP=16`, `alltoall`, global batch size 1024, CUDA graphs disabled, and
@@ -101,6 +136,11 @@ separate win, and it does not validate the fused permutation path. An earlier
    communication is already a visible slice of step time. It is not guaranteed
    to help every small or lightly loaded EP run.
 
+6. **Summed kernel time is not wall time**: concurrent kernels can run longer
+   because they contend for SMs or bandwidth, so overlap may increase summed
+   per-stream kernel duration while reducing the exposed interval union and
+   end-to-end step time.
+
 ## Verification
 
 Look for overlap-related log messages during initialization. The comm overlap
@@ -132,3 +172,15 @@ uv run python scripts/performance/run_script.py \
 If fused MoE permutation fails during bring-up, add
 `model.moe_permute_fusion=false` to separate overlap timing from runtime-stack
 validation, then retest with the matched production container.
+
+For performance validation, use an unprofiled steady window as the acceptance
+metric. Use a matched Nsight A/B to establish causality:
+
+1. Keep dispatcher, routing, CUDA graphs, batch shape, parallelism, and runtime
+   fixed.
+2. Toggle only `overlap_moe_expert_parallel_comm`; keep
+   `delay_wgrad_compute=false` for the first isolation.
+3. Compare communication and compute interval unions and their intersection,
+   not only summed kernel durations.
+4. Report steady step time, model TFLOPS/GPU, loss finiteness, skipped/NaN
+   iterations, and peak allocated memory.

--- a/skills/nemo-mbridge-perf-moe-comm-overlap/card.yaml
+++ b/skills/nemo-mbridge-perf-moe-comm-overlap/card.yaml
@@ -1,10 +1,11 @@
 title: moe_comm_overlap
-validated_on: "2026-03-15"
+validated_on: "2026-07-25"
 summary: >
   Megatron-Bridge supports MoE expert-parallel communication overlap through
   overlap_moe_expert_parallel_comm, with optional delayed expert wgrad
-  scheduling, but the path depends on dispatcher choice, expert parallelism,
-  precision, and runtime support.
+  scheduling. A controlled Qwen3 30B-A3B HybridEP run on 16 H100 GPUs measured
+  a 15.059% step-time reduction and 17.729% throughput increase from plain EP
+  overlap with delayed wgrad disabled.
 validation_status:
   moe_overlap_validation:
     - code_verified
@@ -13,7 +14,11 @@ validation_status:
   deepep_hybridep_helper_behavior:
     - code_verified
   end_to_end_recipe_smoke:
-    - unclear
+    - measured
+  qwen3_30b_hybridep_h100:
+    - measured
+  matched_nsys_ab:
+    - measured
 feature_meaning:
   moe_overlap: >
     Overlap of expert-parallel token dispatch communication with expert compute.
@@ -23,7 +28,33 @@ feature_meaning:
     Dispatcher mode used for DeepEP or HybridEP style backends.
 recommended_path:
   comm_overlap.overlap_moe_expert_parallel_comm: true_for_moe_tuning
+  comm_overlap.delay_wgrad_compute: false_for_first_isolation
   model.moe_shared_expert_overlap: false_when_overlap_is_enabled
+measured_result:
+  model: Qwen3 30B-A3B
+  hardware: "16×H100"
+  precision: BF16
+  shape: "seq4096 TP1 PP1 CP1 EP16 MBS1 GBS1024"
+  dispatcher: HybridEP
+  routing: force_balance
+  cuda_graph_scopes: "moe_router, moe_preprocess"
+  baseline_step_time_ms: 24713.800
+  baseline_model_tflops_per_gpu: 244.039
+  overlap_step_time_ms: 20992.030
+  overlap_model_tflops_per_gpu: 287.305
+  step_time_reduction_percent: 15.059
+  throughput_gain_percent: 17.729
+  rank0_peak_allocated_gib: 62.166
+  skipped_iterations: 0
+  nan_iterations: 0
+profile_result:
+  captured_kernels_per_case: 463348
+  comm_compute_overlap_off_ms: 9.079
+  comm_compute_overlap_on_ms: 3958.997
+  comm_hidden_off_percent: 0.11
+  comm_hidden_on_percent: 36.55
+  gpu_active_union_off_ms: 22820.667
+  gpu_active_union_on_ms: 21221.363
 known_constraints:
   - expert_model_parallel_size must be greater than 1.
   - num_moe_experts must be greater than 1.
@@ -33,9 +64,12 @@ known_constraints:
 known_limitations:
   - Setting moe_flex_dispatcher_backend alone does not activate flex dispatch.
   - Public recipes are often conservative and leave MoE overlap disabled by default.
-  - Repo evidence is stronger for validation logic than for end-to-end throughput gains.
+  - The measured gain is workload-specific and should not be generalized across model, dispatcher, topology, or batch changes.
+  - Summed per-stream kernel time is not a wall-time metric when kernels overlap.
 evidence:
   - docs/training/communication-overlap.md
+  - examples/model_verification_cards/qwen3-30b-a3b/card.yaml
+  - src/megatron/bridge/perf_recipes/qwen/h100/qwen3_moe.py
   - docs/parallelisms.md
   - src/megatron/bridge/training/comm_overlap.py
   - src/megatron/bridge/training/flex_dispatcher_backend.py
@@ -44,4 +78,4 @@ evidence:
   - tests/unit_tests/training/test_deepep.py
 follow_up_validation:
   - Add a positive Bridge functional smoke for overlap_moe_expert_parallel_comm.
-  - Add benchmark-backed guidance for at least one representative MoE family.
+  - Repeat the matched profile method on another model family and topology.

--- a/skills/nemo-mbridge-perf-moe-hardware-configs/SKILL.md
+++ b/skills/nemo-mbridge-perf-moe-hardware-configs/SKILL.md
@@ -14,7 +14,7 @@ Card: @skills/nemo-mbridge-perf-moe-hardware-configs/card.yaml
 
 | Platform | Typical MoE strategy | What usually matters most |
 |---|---|---|
-| H100 | DeepEP + stronger PP + moderate TP | communication overlap and PP efficiency |
+| H100 | DeepEP or HybridEP + explicit EP overlap | communication overlap, dispatcher/runtime compatibility, and PP efficiency |
 | B200 | DeepEP + MXFP8 + careful PP layout | container quality and tuned comm settings |
 | GB200 | HybridEP + partial CUDA graphs + CPU cleanup | host overhead, topology-aware dispatch, memory headroom |
 | GB300 | HybridEP + newer FP8 and kernel stack | same GB200 playbook, usually with a higher ceiling |
@@ -30,6 +30,7 @@ throughput caveats:
 | DSV3 | GB200/GB300 | HybridEP | TP=1, EP=64, PP=4, VPP=4 |
 | Qwen3 235B | H100 | DeepEP | TP=2, EP=32, PP=8, VPP=4 |
 | Qwen3 235B | GB200 | HybridEP | TP=1 or 2, EP=32-64, PP=4, VPP=unspecified |
+| Qwen3 30B | 16×H100 | HybridEP | TP=1, EP=16, PP=1, plain EP overlap |
 
 For Qwen3 235B on GB200, explicitly say `VPP=unspecified`; do not invent or
 extrapolate `VPP=12` unless a measured row provides it. Include TE-scoped CUDA
@@ -51,7 +52,7 @@ moves. Treat them as planning ranges, not exact promises.
 | DSV3, large-scale | GB300 | above the GB200 band, often mid-20s MFU | TP1, EP64, PP4, HybridEP |
 | Qwen3 235B | H100 | low-300s TFLOPS/GPU, around 30% MFU | TP2, EP32, PP8, DeepEP |
 | Qwen3 235B | GB200 | high-hundreds TFLOPS/GPU in tuned runs | TP1 or TP2, EP32-64, PP4, HybridEP |
-| Qwen3 30B | H100 | low-200s TFLOPS/GPU | TP1, EP8, PP1, DeepEP |
+| Qwen3 30B | H100 | high-200s TFLOPS/GPU on the validated 16-GPU shape | TP1, EP16, PP1, HybridEP + EP overlap |
 | Qwen3-Next 80B | GB200 | low-300s TFLOPS/GPU in BF16-class runs | TP1, EP32, PP2, HybridEP |
 
 ## Representative Config Families
@@ -104,6 +105,26 @@ CUDA Graph: attn + moe_router + moe_preprocess
 Recompute: moe_act, mlp, or norm depending on memory pressure
 Priority: balance throughput against memory headroom
 ```
+
+### Qwen3 30B-A3B on 16 H100
+
+```text
+Dispatcher: HybridEP
+TP=1  EP=16  PP=1  CP=1
+Precision: BF16
+Sequence: 4096
+Batch: MBS1 GBS1024
+Routing: force balance
+EP overlap: enabled
+Delayed wgrad: disabled
+CUDA Graph: moe_router + moe_preprocess
+Measured: 20.992s/step, 287.305 model TFLOPS/GPU over iterations 41-50
+Rank-0 peak allocated memory: 62.166 GiB
+```
+
+This shape improved 17.729% over its reproduced 244.039 TFLOPS/GPU baseline
+when only plain EP overlap changed. A matched Nsight A/B increased
+communication hidden by GEMM/attention from 0.11% to 36.55%.
 
 ### Qwen3-Next 80B on GB200
 
@@ -167,3 +188,8 @@ work, not as afterthoughts.
 
 5. **Force-balance routing is the safer benchmark default**: keep routing mode
    fixed when comparing hardware or dispatcher stacks.
+
+6. **Do not treat the dispatcher table as a hard platform rule**: HybridEP was
+   the validated winner for the 16×H100 Qwen3 30B shape, while DeepEP failed
+   bring-up in that matched runtime. Benchmark backend compatibility and
+   throughput in the production container.

--- a/skills/nemo-mbridge-perf-moe-hardware-configs/card.yaml
+++ b/skills/nemo-mbridge-perf-moe-hardware-configs/card.yaml
@@ -1,5 +1,5 @@
 title: moe_hardware_configs
-validated_on: "2026-04-01"
+validated_on: "2026-07-25"
 summary: >
   Best-known MoE training configurations per model family and hardware platform,
   with measured throughput, MFU, and parallelism settings. Covers DSV3, Qwen3,
@@ -22,6 +22,7 @@ validation_status:
     - measured
   qwen3_30b_h100:
     - measured
+    - profile_validated
   qwen3_next_80b_b200:
     - measured
   qwen3_next_80b_gb200:
@@ -155,6 +156,25 @@ best_configs:
     routing: force_balance
     recompute: full
 
+  qwen3_30b_h100_16:
+    model: "Qwen3 30B-A3B"
+    hardware: "16×H100"
+    precision: BF16
+    dispatcher: HybridEP
+    tflops: 287.305
+    step_time_ms: 20992.030
+    parallelism: "TP1 EP16 PP1 CP1"
+    sequence_length: 4096
+    batch: "MBS1 GBS1024"
+    routing: force_balance
+    ep_overlap: true
+    delay_wgrad_compute: false
+    cuda_graph: "moe_router, moe_preprocess"
+    rank0_peak_allocated_gib: 62.166
+    baseline_tflops: 244.039
+    throughput_gain_percent: 17.729
+    profile_comm_hidden_percent: "0.11 off, 36.55 on"
+
   qwen3_next_80b_gb200_64:
     model: "Qwen3-Next 80B-A3B"
     hardware: "64×GB200"
@@ -180,6 +200,8 @@ best_configs:
     note: "native CE, cutlass grouped gemm"
 
 optimization_patterns:
+  - name: ep_comm_overlap
+    impact: "+17.729% throughput on measured Qwen3 30B 16×H100 HybridEP shape"
   - name: force_balance_routing
     impact: "+5-10% MFU over dropless"
   - name: 1f1b_overlap
@@ -192,6 +214,8 @@ optimization_patterns:
     impact: "up to +15% from MBS sweep"
 
 evidence:
+  - "examples/model_verification_cards/qwen3-30b-a3b/card.yaml"
+  - "src/megatron/bridge/perf_recipes/qwen/h100/qwen3_moe.py"
   - "[MoE Perf] MCore Release Performance Tracker - DeepSeek-V3"
   - "[MoE Perf] MCore Release Performance Tracker - Qwen3"
   - "[MoE Perf] MCore Release Performance Tracker - Qwen3-Next"
@@ -199,6 +223,7 @@ evidence:
 
 known_limitations:
   - Container versions can cause significant performance regressions
+  - Dispatcher recommendations are starting points; the validated Qwen3 30B H100 winner used HybridEP rather than DeepEP
   - VPP must divide transformer layers evenly across PP stages
   - FP8 MFU numbers use higher peak FLOPS denominator than BF16
   - Configs are point-in-time measurements; mcore/TE updates may change results

--- a/skills/nemo-mbridge-perf-moe-optimization-workflow/SKILL.md
+++ b/skills/nemo-mbridge-perf-moe-optimization-workflow/SKILL.md
@@ -109,6 +109,26 @@ larger EP degree than the dense layers can tolerate.
 | Host overhead | GPU gaps, launch-bound traces, Python overhead | CUDA graphs, `--manual-gc`, higher MBS, CPU affinity tuning |
 | Compute | Low SM utilization after comm and host issues are addressed | grouped GEMM, fusion work, FP8, dispatcher-specific kernel tuning |
 
+### Profile overlap without misreading it
+
+Use unprofiled steady iterations for the acceptance metric and a matched
+profile for causal explanation:
+
+1. Change one overlap or dispatcher variable at a time; keep routing, graph
+   scopes, parallelism, batch shape, and runtime fixed.
+2. Build interval unions for communication kernels and compute kernels, then
+   measure their intersection to quantify hidden communication.
+3. Do not add kernel durations and call the result wall time. Concurrent
+   kernels may run longer because of SM or bandwidth contention even while the
+   exposed GPU-active union and end-to-end step time fall.
+4. Corroborate the trace with dispatch/combine NVTX ranges, steady step time,
+   model TFLOPS/GPU, loss finiteness, skipped/NaN counts, and peak memory.
+
+On a controlled 16×H100 Qwen3 30B-A3B HybridEP run, plain EP overlap increased
+communication hidden by GEMM/attention from 0.11% to 36.55%. The unprofiled
+step fell from 24.7138s to 20.9920s and throughput rose from 244.039 to 287.305
+model TFLOPS/GPU. `delay_wgrad_compute` remained disabled.
+
 ## Dispatcher And Overlap Guidance
 
 Use dispatcher choice as a bottleneck fix, not as the first tuning knob.
@@ -119,6 +139,10 @@ Use dispatcher choice as a bottleneck fix, not as the first tuning knob.
   strong default for H100 and B200 style deployments
 - `moe_token_dispatcher_type="flex"` + `moe_flex_dispatcher_backend="hybridep"`:
   strongest starting point on GB200 or GB300 NVL72 systems
+
+Treat these as starting points, not hard platform rules. HybridEP plus plain EP
+overlap was the measured winner for the 16×H100 Qwen3 30B-A3B shape. Benchmark
+backend compatibility and throughput in the target container.
 
 If the all-to-all path is visible in profiles, combine dispatcher tuning with:
 
@@ -177,3 +201,6 @@ Related references:
 5. **Parallel Folding is not optional at large scale**: once attention and expert
    layers want clearly different layouts, a single shared TP or EP plan becomes
    a tax on both.
+
+6. **Summed kernel time is not exposed time**: use interval unions and
+   communication/compute intersection when validating overlap.

--- a/skills/nemo-mbridge-perf-moe-optimization-workflow/card.yaml
+++ b/skills/nemo-mbridge-perf-moe-optimization-workflow/card.yaml
@@ -1,5 +1,5 @@
 title: moe_optimization_workflow
-validated_on: "2026-04-01"
+validated_on: "2026-07-25"
 summary: >
   Systematic 3-phase workflow for optimizing MoE training performance,
   distilled from the Megatron-Core MoE paper (arXiv:2603.07685). Covers
@@ -23,6 +23,10 @@ validation_status:
   cuda_graphs_moe:
     - documented
   dsv3_case_study:
+    - measured
+  qwen3_30b_h100_case_study:
+    - measured
+  overlap_profile_method:
     - measured
 
 core_concepts:
@@ -135,13 +139,36 @@ dsv3_case_study:
     tflops: 368
     dominant_bottleneck: "Communication (cross-node EP all-to-all)"
 
+qwen3_30b_h100_case_study:
+  hardware: "16×H100"
+  precision: BF16
+  parallelism: "TP1/PP1/CP1/EP16"
+  sequence_length: 4096
+  batch: "MBS1/GBS1024"
+  routing: force_balance
+  dispatcher: HybridEP
+  cuda_graph_scopes: "moe_router, moe_preprocess"
+  delayed_wgrad_compute: false
+  baseline_step_time_ms: 24713.800
+  overlap_step_time_ms: 20992.030
+  baseline_tflops: 244.039
+  overlap_tflops: 287.305
+  throughput_gain_percent: 17.729
+  profile_comm_hidden_off_percent: 0.11
+  profile_comm_hidden_on_percent: 36.55
+  dominant_bottleneck: "Exposed HybridEP dispatch/combine communication"
+
 key_lessons:
   - "Platform characteristics drive strategy, not just model architecture"
   - "Parallel Folding unlocks independent attention/MoE optimization"
   - "FP8 shifts bottleneck from memory/compute to CPU overhead"
   - "Optimization is iterative: solving one wall exposes another"
+  - "Use unprofiled steady timing for acceptance and matched profiles for causality"
+  - "Use interval unions and communication/compute intersection; summed concurrent kernel durations are not wall time"
 
 evidence:
   - "arXiv:2603.07685 — Scalable Training of MoE with Megatron Core"
   - "Megatron-Core v0.16 benchmarks"
   - "DSV3 and Qwen3-235B empirical results"
+  - "examples/model_verification_cards/qwen3-30b-a3b/card.yaml"
+  - "src/megatron/bridge/perf_recipes/qwen/h100/qwen3_moe.py"

--- a/src/megatron/bridge/perf_recipes/qwen/h100/qwen3_moe.py
+++ b/src/megatron/bridge/perf_recipes/qwen/h100/qwen3_moe.py
@@ -37,6 +37,8 @@ def qwen3_30b_a3b_pretrain_16gpu_h100_bf16_config() -> ConfigContainer:
     cfg = _qwen3_30b_a3b_default_pretrain_config()
     cfg.mixed_precision = _perf_precision("bf16")
     cfg.model.moe_router_force_load_balancing = True
+    cfg.comm_overlap.overlap_moe_expert_parallel_comm = True
+    cfg.comm_overlap.delay_wgrad_compute = False
 
     _benchmark_common(cfg)
     # Keep process settings next to the recipe so users can see the exact benchmark environment.

--- a/tests/unit_tests/recipes/test_qwen_recipes.py
+++ b/tests/unit_tests/recipes/test_qwen_recipes.py
@@ -666,6 +666,9 @@ def test_qwen3_30b_a3b_bf16_perf_recipe_uses_default_functional_config(
     assert perf_cfg.model.cuda_graph_impl == default_cfg.model.cuda_graph_impl
     assert perf_cfg.model.cuda_graph_scope == default_cfg.model.cuda_graph_scope
     assert perf_cfg.comm_overlap.tp_comm_overlap == default_cfg.comm_overlap.tp_comm_overlap
+    assert perf_cfg.comm_overlap.overlap_moe_expert_parallel_comm is True
+    assert default_cfg.comm_overlap.overlap_moe_expert_parallel_comm is None
+    assert perf_cfg.comm_overlap.delay_wgrad_compute is False
     assert perf_cfg.optimizer.use_precision_aware_optimizer == default_cfg.optimizer.use_precision_aware_optimizer
     assert perf_cfg.model.moe_router_force_load_balancing is True
     assert default_cfg.model.moe_router_force_load_balancing is False


### PR DESCRIPTION
# What does this PR do ?

Enable Megatron-Core expert-parallel communication overlap for the Qwen3 30B-A3B 16×H100 BF16 performance recipe, refresh its verified model-card result from 240.110 to 287.305 model TFLOPS/GPU, and capture the measured overlap/profile learnings in the performance skills.

# Changelog

- Enable `overlap_moe_expert_parallel_comm` for the Qwen3 30B-A3B H100 BF16 performance recipe.
- Keep `delay_wgrad_compute` disabled; controlled measurements showed plain EP overlap supplied the gain without delayed-weight-gradient scheduling.
- Add focused assertions that the performance recipe enables overlap without changing the default functional recipe.
- Update the H100 performance card with the independently validated 50-step result and a 280 TFLOPS/GPU acceptance gate.
- Update the MoE communication-overlap, EP-overlap, hardware-config, and optimization-workflow skills with the measured H100 configuration and matched Nsight A/B method.
- Document that overlap should be judged from unprofiled steady timing, interval unions, and communication/compute intersection—not summed concurrent kernel durations.

## Performance validation

Configuration: 16×H100, BF16, sequence length 4096, MBS/GBS 1/1024, TP1/PP1/CP1/EP16, mock data, forced load balancing, HybridEP, and Transformer Engine CUDA graph scopes `moe_router` + `moe_preprocess`.

| Result | Steps | Step time | Model TFLOPS/GPU |
|---|---:|---:|---:|
| Previous verification card | 41–50 | 25,118.160 ms | 240.110 |
| Reproduced baseline | 5–20 | 24,713.800 ms | 244.039 |
| Independent validation | 41–50 | **20,992.030 ms** | **287.305** |

The independent 50-step validation improves throughput by 19.656% over the previous card result and 17.729% over the reproduced baseline. Loss remained finite from 12.346430 to 8.145228, with zero skipped or NaN iterations. Rank-0 peak allocated memory was 62.166 GiB.

A same-method Nsight Systems A/B trace captured 463,348 rank-0 kernels in each case. Expert communication concurrent with GEMM/attention increased from 9.079 ms (0.11% of communication time) with overlap disabled to 3,958.997 ms (36.55%) with overlap enabled. GPU-active interval union fell from 22.821 s to 21.221 s.

# GitHub Actions CI

Local and targeted checks completed:

- [x] `uv run pre-commit run --all-files`
- [x] `uv run python -m pytest tests/unit_tests/recipes/test_qwen_recipes.py -k qwen3_30b_a3b_bf16_perf_recipe_uses_default_functional_config -q` (`1 passed, 86 deselected`)
- [x] Model-card YAML parse and `>=280` performance assertion
- [x] Four updated skill cards parsed as YAML; skill frontmatter names/descriptions and `<500`-line limits validated
- [x] Independent 50-step 16×H100 performance validation

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] Added the necessary focused regression test.
- [x] Updated the model verification card and relevant performance skills.
- [x] No optional-install component or dependency changes.

# Additional Information

- No public API changes.
- No dependency, CI workflow, or Megatron-Core submodule changes.
