### PR TITLE
[model] fix: preserve linear Llama RoPE scaling

### DIFF
--- a/src/megatron/bridge/models/llama/llama_bridge.py
+++ b/src/megatron/bridge/models/llama/llama_bridge.py
@@ -50,7 +50,7 @@ class LlamaBridge(MegatronModelBridge):
         """Convert HuggingFace Llama config to Megatron GPTModelProvider.
 
         Uses base class implementation for common conversion, then sets
-        Llama-specific config and enables RoPE scaling for Llama 3.1/3.2 models.
+        Llama-specific config and preserves supported RoPE scaling.
 
         Args:
             hf_pretrained: HuggingFace PreTrainedCausalLM containing the Llama config
@@ -71,12 +71,16 @@ class LlamaBridge(MegatronModelBridge):
         provider.apply_rope_fusion = True
         provider.rotary_percent = 1.0
 
-        # Enable RoPE scaling for Llama 3.1/3.2 models via Megatron Core's built-in support
+        # Preserve supported RoPE scaling via Megatron Core's built-in implementations.
         hf_config = hf_pretrained.config
         hf_rope_scaling = getattr(hf_config, "rope_scaling", None)
-        if hf_rope_scaling is not None and hf_rope_scaling.get("rope_type") == "llama3":
-            provider.rope_scaling = True
-            provider.rope_scaling_factor = hf_rope_scaling.get("factor", 8.0)
+        if hf_rope_scaling:
+            rope_type = hf_rope_scaling.get("rope_type", hf_rope_scaling.get("type"))
+            if rope_type == "llama3":
+                provider.rope_scaling = True
+                provider.rope_scaling_factor = hf_rope_scaling.get("factor", 8.0)
+            elif rope_type == "linear":
+                provider.seq_len_interpolation_factor = hf_rope_scaling["factor"]
 
         return provider
 
@@ -84,7 +88,7 @@ class LlamaBridge(MegatronModelBridge):
     def megatron_to_hf_config(cls, provider: GPTModelProvider) -> dict:
         """Convert Megatron GPTModelProvider config to HuggingFace Llama config dict.
 
-        Uses base class implementation, then adds RoPE scaling for Llama 3.1/3.2.
+        Uses base class implementation, then adds supported Llama RoPE scaling.
 
         Args:
             provider: GPTModelProvider with Llama configuration
@@ -103,6 +107,11 @@ class LlamaBridge(MegatronModelBridge):
                 "low_freq_factor": 1.0,
                 "high_freq_factor": 4.0,
                 "original_max_position_embeddings": 8192,
+            }
+        elif provider.seq_len_interpolation_factor is not None:
+            hf_config["rope_scaling"] = {
+                "rope_type": "linear",
+                "factor": provider.seq_len_interpolation_factor,
             }
 
         return hf_config

--- a/tests/unit_tests/models/llama/test_llama_bridge.py
+++ b/tests/unit_tests/models/llama/test_llama_bridge.py
@@ -101,6 +101,26 @@ class TestLlamaBridgeConfigConverter:
         assert result.rope_scaling is True
         assert result.rope_scaling_factor == 32.0
 
+    def test_provider_bridge_preserves_linear_rope_scaling(self):
+        """Test that linear RoPE scaling is preserved in the Megatron provider."""
+        config = LlamaConfig(
+            architectures=["LlamaForCausalLM"],
+            hidden_size=64,
+            intermediate_size=128,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            max_position_embeddings=256,
+            vocab_size=128,
+            rope_scaling={"type": "linear", "factor": 8.0},
+        )
+
+        provider = AutoBridge.from_hf_config(config).to_megatron_provider(load_weights=False)
+
+        assert provider.position_embedding_type == "rope"
+        assert provider.seq_len_interpolation_factor == 8.0
+        assert provider.rope_scaling is False
+
     def test_provider_bridge_architecture_mapping(self, mock_pretrained_llama, llama_config):
         """Test that architecture parameters are correctly mapped from HF config."""
         bridge = LlamaBridge()
@@ -516,6 +536,26 @@ class TestLlamaBridgeMegatronToHFConfig:
         assert hf_config["rope_scaling"]["low_freq_factor"] == 1.0
         assert hf_config["rope_scaling"]["high_freq_factor"] == 4.0
         assert hf_config["rope_scaling"]["original_max_position_embeddings"] == 8192
+
+    def test_megatron_to_hf_config_with_linear_rope_scaling(self):
+        """Test Megatron to HF config conversion with linear RoPE scaling."""
+        provider = GPTModelProvider(
+            num_layers=2,
+            hidden_size=64,
+            ffn_hidden_size=128,
+            num_attention_heads=4,
+            num_query_groups=4,
+            seq_length=256,
+            vocab_size=128,
+            seq_len_interpolation_factor=8.0,
+        )
+
+        hf_config = LlamaBridge.megatron_to_hf_config(provider)
+
+        assert hf_config["rope_scaling"] == {
+            "rope_type": "linear",
+            "factor": 8.0,
+        }
 
 
 class TestLlamaBridgeMappingRegistry:


### PR DESCRIPTION
## Summary

Preserve linear RoPE scaling when converting Llama configurations between
Hugging Face and Megatron.

A supported `LlamaForCausalLM` configuration with
`rope_scaling={"type": "linear", "factor": 8.0}` is accepted by AutoBridge.
Previously, the Llama bridge handled only Llama-3 scaling, so the Megatron
provider kept `seq_len_interpolation_factor=None`. Megatron-Core consequently
used unscaled rotary positions, causing silent forward and training-semantic
divergence from the source model.

## Root cause and fix

`LlamaBridge.provider_bridge()` did not translate Hugging Face's linear scaling
contract into Megatron-Core's `seq_len_interpolation_factor`. The reverse config
synthesis also omitted the same state.

The patch maps linear scaling to the existing Megatron-Core interpolation field
and reconstructs the Hugging Face linear scaling dictionary on export. Existing
Llama-3 scaling behavior is unchanged.

## Validation

- Fail before:
  `uv run python -m pytest tests/unit_tests/models/llama/test_llama_bridge.py::TestLlamaBridgeConfigConverter::test_provider_bridge_preserves_linear_rope_scaling -q`
  failed because `seq_len_interpolation_factor` was `None`, expected `8.0`.
- Pass after: the focused forward and reverse linear-RoPE regression tests pass.
- Adjacent:
  `uv run python -m pytest tests/unit_tests/models/llama/test_llama_bridge.py -q`
  — 38 passed with the pinned Transformers 5.12.1.
- `git diff --check` — passed.
- `uv run pre-commit run --all-files` — passed.

## Scope

This change covers Llama linear RoPE scaling only. It does not add support for
other RoPE schemes, modify Megatron-Core, change public APIs, or claim GPU,
convergence, performance, or full-suite validation.
