### PR TITLE
[ckpt] fix: ignore FSDP RNG after layout changes

### DIFF
--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -2864,6 +2864,20 @@ def _load_checkpoint_from_path(
                     return 0, 0
             checkpoint_name = get_checkpoint_name(load_dir, iteration, release)
 
+        tp_pp_match = True
+        run_config_filename = get_checkpoint_run_config_filename(checkpoint_name)
+        if file_exists(run_config_filename):
+            run_config = read_run_config(run_config_filename)
+            ckpt_tp_pp = (
+                run_config["model"]["tensor_model_parallel_size"],
+                run_config["model"]["pipeline_model_parallel_size"],
+            )
+            run_tp_pp = (
+                cfg.model.tensor_model_parallel_size,
+                cfg.model.pipeline_model_parallel_size,
+            )
+            tp_pp_match = ckpt_tp_pp == run_tp_pp
+
         reader = _get_filesystem_reader(checkpoint_name)
         try:
             state_dict_metadata = reader.read_metadata().state_dict_metadata
@@ -2880,9 +2894,15 @@ def _load_checkpoint_from_path(
                 gen_sd_rerun_state = get_rerun_state_machine().state_dict(
                     data_iterator=None, ckpt_format=ckpt_format, force=True
                 )
-            if cfg.checkpoint.load_rng:
+            if cfg.checkpoint.load_rng and tp_pp_match:
                 gen_sd_rng_state = get_rng_state(
                     cfg.rng.data_parallel_random_init, ckpt_format, pg_collection=pg_collection
+                )
+            elif cfg.checkpoint.load_rng:
+                ignore_rng_state = True
+                print_rank_0(
+                    f"(TP, PP) mismatch after resume ({run_tp_pp} vs {ckpt_tp_pp} from checkpoint): "
+                    "RNG state will be ignored"
                 )
             if cfg.checkpoint.load_optim:
                 gen_sd_optim = optimizer

--- a/tests/unit_tests/training/test_checkpointing.py
+++ b/tests/unit_tests/training/test_checkpointing.py
@@ -1484,6 +1484,58 @@ class TestLoadCheckpoint:
 
         mock_load_hf.assert_not_called()
 
+    def test_fsdp_layout_change_ignores_rng_state(self, load_checkpoint_fixtures):
+        """FSDP resharding must not partially restore TP/PP-keyed RNG state."""
+        cfg = load_checkpoint_fixtures["mock_cfg"]
+        cfg.checkpoint.ckpt_format = "fsdp_dtensor"
+        cfg.checkpoint.load_optim = False
+        cfg.model.tensor_model_parallel_size = 2
+        cfg.model.pipeline_model_parallel_size = 1
+        cfg.peft = None
+
+        pg_collection = Mock()
+        pg_collection.tp.size.return_value = 2
+        pg_collection.pp.size.return_value = 1
+
+        reader = Mock()
+        reader.read_metadata.return_value.state_dict_metadata = {}
+
+        with (
+            patch("megatron.bridge.training.checkpointing.is_hf_checkpoint_dir", return_value=False),
+            patch("megatron.bridge.training.checkpointing.is_checkpoint_iteration_directory", return_value=True),
+            patch("megatron.bridge.training.checkpointing.file_exists", return_value=True),
+            patch("megatron.bridge.training.checkpointing.read_run_config") as mock_read_run_config,
+            patch("megatron.bridge.training.checkpointing._get_filesystem_reader", return_value=reader),
+            patch("megatron.bridge.training.checkpointing.get_rng_state", return_value="fresh") as mock_get_rng_state,
+            patch(
+                "megatron.bridge.training.checkpointing.generate_state_dict", return_value={"model": {}}
+            ) as mock_generate,
+            patch(
+                "megatron.bridge.training.checkpointing._load_base_checkpoint",
+                return_value=(None, "", False, None),
+            ),
+        ):
+            mock_read_run_config.return_value = {
+                "model": {
+                    "tensor_model_parallel_size": 1,
+                    "pipeline_model_parallel_size": 1,
+                }
+            }
+
+            result = _load_checkpoint_from_path(
+                "/checkpoints/iter_0000003",
+                load_checkpoint_fixtures["mock_state"],
+                load_checkpoint_fixtures["mock_model"],
+                load_checkpoint_fixtures["mock_optimizer"],
+                load_checkpoint_fixtures["mock_scheduler"],
+                pg_collection=pg_collection,
+            )
+
+        assert result == (0, 0)
+        mock_read_run_config.assert_called_once_with("/checkpoints/iter_0000003/run_config.yaml")
+        mock_get_rng_state.assert_not_called()
+        assert mock_generate.call_args.kwargs["rng_state"] is None
+
     @patch("torch.distributed.is_initialized")
     @patch("megatron.bridge.training.checkpointing._build_auto_bridge_for_save")
     def test_load_hf_pretrained_checkpoint_initializes_from_hf_source(


### PR DESCRIPTION
## What changed

When an `fsdp_dtensor` checkpoint is resumed with a different tensor- or
pipeline-parallel layout, read the saved `run_config.yaml` and uniformly skip
RNG restoration. Model and optimizer DTensors remain eligible for resharding.

## Why

FSDP checkpoint RNG state is keyed by the saved TP/PP coordinates rather than
represented as a reshardable DTensor. A supported TP=1/PP=1 checkpoint resumed
as TP=2/PP=1 therefore left the newly introduced TP rank with a partial,
invalid RNG payload. Final checkpoint processing then crashed in
`numpy.random.set_state` instead of completing the documented resharded resume.
Even where the partial payload happened to deserialize, mixing saved and fresh
streams would violate consistent resume semantics.

The loader now applies the same policy used by other checkpoint formats:
TP/PP topology changes restore reshardable training state but start with fresh
RNG state on every rank.

## Validation

- Regression test, before:  
  `uv run python -m pytest tests/unit_tests/training/test_checkpointing.py::TestLoadCheckpoint::test_fsdp_layout_change_ignores_rng_state -q`  
  `1 failed` because the FSDP path never inspected the saved layout.
- Regression test, after: same command, `1 passed`.
- Adjacent checkpoint-loading tests:  
  `uv run python -m pytest tests/unit_tests/training/test_checkpointing.py::TestLoadCheckpoint -q`  
  `6 passed`.
- Two-process FSDP reproducer, TP=1/DP=2 save followed by TP=2/DP=1 load:
  before, the new TP rank crashed in `numpy.random.set_state`; after, both ranks
  retained consistent fresh RNG state and exited successfully.
- `git diff --check`
- `uv run pre-commit run --all-files`

## Scope

This does not change model or optimizer resharding, checkpoint schemas, or
public APIs. Validation was focused on checkpoint resume correctness; it does
not claim full-suite, convergence, performance, or model-quality coverage.
