### PR TITLE
[inference] fix: Honor configured Qwen VLM visual token IDs

### DIFF
--- a/src/megatron/bridge/inference/vlm/vlm_inference_controller.py
+++ b/src/megatron/bridge/inference/vlm/vlm_inference_controller.py
@@ -95,16 +95,18 @@ class QwenVLTextGenerationController(VLMTextGenerationController):
 
     def __init__(self, inference_wrapped_model, tokenizer, image_processor, processor):
         super().__init__(inference_wrapped_model, tokenizer, image_processor)
+        vision_start_token_id = tokenizer.convert_tokens_to_ids("<|vision_start|>")
+        image_token_id = tokenizer.convert_tokens_to_ids("<|image_pad|>")
 
         class QwenVLTokenizer(TokenizerWrapper):
             # pylint: disable=C0115,C0116
             def detokenize(self, tokens):
                 new_tokens = []
                 for token in tokens:
-                    if token == 151652:
+                    if token == vision_start_token_id:
                         new_tokens.append(token)
-                        new_tokens.append(151655)
-                    elif token != 151655:
+                        new_tokens.append(image_token_id)
+                    elif token != image_token_id:
                         new_tokens.append(token)
                 return self._tokenizer.decode(new_tokens, skip_special_tokens=False)
 

--- a/tests/unit_tests/inference/vlm/test_vlm_inference_controller.py
+++ b/tests/unit_tests/inference/vlm/test_vlm_inference_controller.py
@@ -200,6 +200,10 @@ class TestQwenVLTextGenerationController:
         """
         mock_processor = MagicMock()
         mock_inference_model = MagicMock()
+        mock_tokenizer.convert_tokens_to_ids.side_effect = {
+            "<|vision_start|>": 151652,
+            "<|image_pad|>": 151655,
+        }.__getitem__
 
         # Patch the direct parent's __init__ to avoid complex initialization chain
         with patch.object(VLMTextGenerationController, "__init__", return_value=None):
@@ -231,3 +235,54 @@ class TestQwenVLTextGenerationController:
             controller.tokenizer.detokenize([1, 2, 3])
             call_args = mock_tokenizer.decode.call_args[0][0]
             assert call_args == [1, 2, 3], "Regular tokens should pass through"
+
+    @pytest.mark.parametrize(
+        ("vision_start_token_id", "image_token_id"),
+        [(151652, 151655), (200001, 200004)],
+        ids=["canonical", "configured"],
+    )
+    def test_detokenize_preserves_prompt_length_for_configured_visual_tokens(
+        self,
+        mock_tokenizer,
+        mock_image_processor,
+        vision_start_token_id,
+        image_token_id,
+    ):
+        """Keep MCore's generated-text character slice aligned with the original prompt."""
+        vision_end_token_id = image_token_id - 1
+        question_token_id = 7
+        answer_token_id = 8
+        token_text = {
+            vision_start_token_id: "<|vision_start|>",
+            vision_end_token_id: "<|vision_end|>",
+            image_token_id: "<|image_pad|>",
+            question_token_id: "Question",
+            answer_token_id: "Answer",
+        }
+        mock_tokenizer.convert_tokens_to_ids.side_effect = {
+            "<|vision_start|>": vision_start_token_id,
+            "<|image_pad|>": image_token_id,
+        }.__getitem__
+        mock_tokenizer.decode.side_effect = lambda tokens, **_: "".join(token_text[token] for token in tokens)
+
+        with patch.object(VLMTextGenerationController, "__init__", return_value=None):
+            controller = QwenVLTextGenerationController(
+                MagicMock(),
+                mock_tokenizer,
+                mock_image_processor,
+                MagicMock(),
+            )
+
+        prompt = "<|vision_start|><|image_pad|><|vision_end|>Question"
+        expanded_prompt_and_answer = [
+            vision_start_token_id,
+            image_token_id,
+            image_token_id,
+            image_token_id,
+            vision_end_token_id,
+            question_token_id,
+            answer_token_id,
+        ]
+        text = controller.tokenizer.detokenize(expanded_prompt_and_answer)
+
+        assert text[len(prompt) :] == "Answer"


### PR DESCRIPTION
## Problem

Qwen VLM inference collapses processor-expanded image-placeholder runs before
MCore derives `generated_text` by slicing the decoded text at the original
prompt length. That collapse hardcoded the canonical Qwen token IDs even though
the Qwen2.5-VL and Qwen3-VL bridges preserve configured visual token IDs.

For an aligned Qwen tokenizer/config with remapped visual tokens, inference
could produce correct answer tokens but return `generated_text` contaminated
with image-placeholder and prompt residue.

## Root cause and fix

The model and processor use the configured visual IDs, while the controller's
detokenizer recognized only `151652` and `151655`.

The controller now resolves `<|vision_start|>` and `<|image_pad|>` through the
supplied tokenizer and uses those IDs for the existing placeholder-collapse
logic. Canonical Qwen behavior is unchanged.

## Regression evidence

Before the production edit, the configured-ID case failed for the claimed
character-slice mismatch while the canonical control passed:

```text
uv run --no-project --python 3.12 --with pytest --with torch --with numpy \
  python -m pytest --confcutdir=tests/unit_tests/inference/vlm \
  'tests/unit_tests/inference/vlm/test_vlm_inference_controller.py::TestQwenVLTextGenerationController::test_detokenize_preserves_prompt_length_for_configured_visual_tokens' -q

1 failed, 1 passed
```

After the fix, the unchanged regression passed:

```text
2 passed
```

Adjacent validation:

```text
uv run --no-project --python 3.12 --with pytest --with torch --with numpy --with pillow \
  python -m pytest --confcutdir=tests/unit_tests/inference/vlm \
  tests/unit_tests/inference/vlm/test_vlm_inference_controller.py \
  tests/unit_tests/inference/vlm/test_qwenvl_inference_wrapper.py \
  tests/unit_tests/inference/vlm/test_vlm_engine.py \
  -k 'not requested_seed' -q

25 passed, 1 deselected
```

The deselected test is CUDA-only sampling-RNG coverage unrelated to
detokenization. `git diff --check` and all all-files pre-commit hooks passed.

## Scope

This change is limited to Qwen2.5-VL/Qwen3-VL result detokenization and its
CPU-verifiable contract test. It does not change model math, checkpoint
conversion, public APIs, dependencies, CI, or MCore source, and it does not
claim full-suite, model-quality, convergence, performance, or GPU validation.

