### PR TITLE
[training] fix: Preserve flat Hugging Face configs

### DIFF
--- a/src/megatron/bridge/training/utils/config_utils.py
+++ b/src/megatron/bridge/training/utils/config_utils.py
@@ -101,10 +101,17 @@ class _ConfigContainerBase(_MCoreConfigContainerBase):
             result["_target_"] = f"{value.__class__.__module__}.{value.__class__.__qualname__}"
 
         if include_target and is_dataclass(value):
-            config_items = (
+            field_names = {field.name for field in dataclass_fields(value) if not field.name.startswith("_")}
+            config_items = [
                 (field.name, getattr(value, field.name))
                 for field in dataclass_fields(value)
                 if not field.name.startswith("_")
+            ]
+            # Runtime normalization may add self-aliases that are not constructor state.
+            config_items.extend(
+                (key, item)
+                for key, item in vars(value).items()
+                if not key.startswith("_") and key not in field_names and item is not value
             )
         else:
             config_items = ((key, item) for key, item in value.to_dict().items() if not key.startswith("_"))

--- a/tests/unit_tests/training/utils/test_flat_hf_config_serialization.py
+++ b/tests/unit_tests/training/utils/test_flat_hf_config_serialization.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+
+import pytest
+import yaml
+from transformers import PreTrainedConfig
+
+from megatron.bridge.training.utils.config_utils import _ConfigContainerBase
+from megatron.bridge.utils.instantiate_utils import InstantiationMode, register_allowed_target_prefix
+
+
+pytestmark = pytest.mark.unit
+
+register_allowed_target_prefix(f"{__name__}.")
+
+
+class FlatRemoteHFConfig(PreTrainedConfig):
+    """Minimal stand-in for a trust-remote-code config with dynamic fields."""
+
+    def __init__(
+        self,
+        hidden_size=768,
+        vision_config=None,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.hidden_size = hidden_size
+        self.vision_config = vision_config or {"hidden_size": 3584, "attn_sep": False}
+
+
+@dataclass
+class FlatRemoteHFConfigContainer(_ConfigContainerBase):
+    hf_config: FlatRemoteHFConfig
+
+
+def test_flat_remote_hf_config_yaml_roundtrip_preserves_dynamic_fields(tmp_path):
+    config = FlatRemoteHFConfigContainer(
+        hf_config=FlatRemoteHFConfig(
+            hidden_size=2560,
+            vision_config={"hidden_size": 1280, "attn_sep": True},
+        )
+    )
+    config.hf_config.text_config = config.hf_config
+    yaml_path = tmp_path / "run_config.yaml"
+    config.to_yaml(str(yaml_path))
+
+    serialized = yaml.safe_load(yaml_path.read_text())
+    assert serialized["hf_config"]["hidden_size"] == 2560
+    assert serialized["hf_config"]["vision_config"] == {"hidden_size": 1280, "attn_sep": True}
+    assert "text_config" not in serialized["hf_config"]
+
+    loaded = FlatRemoteHFConfigContainer.from_yaml(str(yaml_path), mode=InstantiationMode.STRICT)
+    assert isinstance(loaded.hf_config, FlatRemoteHFConfig)
+    assert loaded.hf_config.hidden_size == 2560
+    assert loaded.hf_config.vision_config == {"hidden_size": 1280, "attn_sep": True}
+
+    loaded.hf_config.text_config = loaded.hf_config
+    assert loaded.hf_config.text_config.hidden_size == 2560


### PR DESCRIPTION
## What changed

Flat trust-remote-code Hugging Face configs can declare architecture fields as
ordinary instance attributes. Transformers 5 also makes `PreTrainedConfig` a
dataclass, so Bridge's run-config serializer emitted only inherited dataclass
fields and silently dropped model-specific values.

This affects the supported checkpoint-only load path for flat ERNIE 4.5 VL
Thinking configs: a checkpoint's `run_config.yaml` can reconstruct language and
vision settings with incompatible defaults.

The serializer now preserves public instance attributes that are not dataclass
fields. It excludes a direct self-reference because ERNIE runtime normalization
adds `text_config = hf_config`; that alias is runtime state and would otherwise
recurse during YAML serialization.

## Validation

- Before the fix:
  `uv run --active --no-sync python -m pytest tests/unit_tests/training/utils/test_flat_hf_config_serialization.py -q`
  — `1 failed` with `KeyError: 'hidden_size'`.
- After the fix, focused plus adjacent serialization/config tests:
  `uv run --active --no-sync python -m pytest tests/unit_tests/training/utils/test_flat_hf_config_serialization.py tests/unit_tests/training/utils/test_hf_config_serialization.py tests/unit_tests/training/utils/test_quant_recipe_serialization.py tests/unit_tests/training/utils/test_config_utils.py -q`
  — `79 passed`.
- `uv run --active --no-sync pre-commit run --all-files` — passed.
- `git diff --check` — passed.

## Scope

This changes run-config serialization only. It does not change model weights,
conversion APIs, dependencies, CI workflows, or GPU/distributed execution.
