### PR TITLE
[model] fix: Restore callable Mamba stack specs

### DIFF
--- a/src/megatron/bridge/models/mamba/mamba_builder.py
+++ b/src/megatron/bridge/models/mamba/mamba_builder.py
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
 from dataclasses import dataclass
-from typing import Any, ClassVar
+from typing import Any, Callable, ClassVar
 
+from megatron.core.models.hybrid.hybrid_model import HybridModel
+from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.transformer import ModuleSpec
 
 from megatron.bridge.models.hybrid.hybrid_builder import (
@@ -31,7 +34,7 @@ class MambaModelConfig(HybridModelConfig):
     """Backward-compatible wrapper around :class:`HybridModelConfig`."""
 
     builder: ClassVar[str] = "megatron.bridge.models.mamba.MambaModelBuilder"
-    mamba_stack_spec: ModuleSpec | None = None
+    mamba_stack_spec: ModuleSpec | Callable[[], ModuleSpec] | Callable[["MambaModelConfig"], ModuleSpec] | None = None
 
     def __post_init__(self) -> None:
         """Normalize the deprecated Mamba stack-spec field to the Hybrid field."""
@@ -57,6 +60,39 @@ class MambaModelConfig(HybridModelConfig):
 
 class MambaModelBuilder(HybridModelBuilder):
     """Backward-compatible wrapper around :class:`HybridModelBuilder`."""
+
+    def build_model(
+        self,
+        pg_collection: ProcessGroupCollection,
+        pre_process: bool | None = None,
+        post_process: bool | None = None,
+        vp_stage: int | None = None,
+    ) -> HybridModel:
+        """Build a Hybrid model while resolving legacy Mamba stack-spec factories.
+
+        Args:
+            pg_collection: Process groups used to construct the model.
+            pre_process: Whether to include input processing on this stage.
+            post_process: Whether to include output processing on this stage.
+            vp_stage: Virtual pipeline stage to construct.
+
+        Returns:
+            The constructed Hybrid model.
+        """
+        stack_spec = self._model_config.hybrid_stack_spec
+        if stack_spec is None or isinstance(stack_spec, ModuleSpec):
+            return super().build_model(pg_collection, pre_process, post_process, vp_stage)
+
+        if len(inspect.signature(stack_spec).parameters) > 0:
+            resolved_stack_spec = stack_spec(self._model_config)
+        else:
+            resolved_stack_spec = stack_spec()
+
+        self._model_config.hybrid_stack_spec = resolved_stack_spec
+        try:
+            return super().build_model(pg_collection, pre_process, post_process, vp_stage)
+        finally:
+            self._model_config.hybrid_stack_spec = stack_spec
 
 
 def transformer_engine_mamba_stack_spec() -> ModuleSpec:

--- a/tests/unit_tests/models/mamba/test_mamba_builder.py
+++ b/tests/unit_tests/models/mamba/test_mamba_builder.py
@@ -61,6 +61,38 @@ class TestMambaModelBuilderCompatibility:
         assert config.mamba_stack_spec is None
         assert mock_model.call_args.kwargs["hybrid_stack_spec"] is module_spec
 
+    @pytest.mark.parametrize("factory_uses_config", [False, True])
+    @patch("megatron.training.models.hybrid.HybridModel")
+    def test_mamba_stack_spec_factory_maps_to_hybrid_model_kwarg(self, mock_model, factory_uses_config):
+        module_spec = ModuleSpec(module=object)
+        factory_calls = []
+
+        if factory_uses_config:
+
+            def stack_spec_factory(config):
+                factory_calls.append(config)
+                return module_spec
+
+        else:
+
+            def stack_spec_factory():
+                factory_calls.append(None)
+                return module_spec
+
+        config = MambaModelConfig(
+            transformer=_make_transformer(),
+            vocab_size=32000,
+            mamba_stack_spec=stack_spec_factory,
+        )
+        builder = MambaModelBuilder(config)
+        pg = Mock()
+        pg.pp = Mock()
+
+        builder.build_model(pg, pre_process=True, post_process=True)
+
+        assert factory_calls == [config if factory_uses_config else None]
+        assert mock_model.call_args.kwargs["hybrid_stack_spec"] is module_spec
+
     def test_rejects_hybrid_and_mamba_stack_spec_together(self):
         module_spec = ModuleSpec(module=object)
 


### PR DESCRIPTION
## What changed

Restore callable `mamba_stack_spec` support in the backward-compatible
`MambaModelBuilder`.

After the Mamba-to-Hybrid refactor, `MambaModelConfig` still accepted and
migrated legacy stack-spec factories, but the inherited Hybrid builder passed
the factory itself to MCore as `hybrid_stack_spec`. Neither the historical
zero-argument factory nor the config-argument factory was invoked, so a
supported legacy configuration could reach model construction with a function
where a `ModuleSpec` was required.

The Mamba compatibility builder now:

- resolves both historical factory signatures before delegating to the Hybrid
  builder;
- preserves direct `ModuleSpec` and `None` behavior;
- restores the config's original factory after construction.

## User impact

Users constructing a Mamba model with
`MambaModelConfig(mamba_stack_spec=<callable>)` can again use both supported
factory signatures. Direct `ModuleSpec` configurations are unchanged.

## Verification

The unchanged parameterized regression was first run against
`cd76e0c56b0e72337ac991a372f481512c614792` with unmodified production code:

```bash
uv run --active --no-sync --with torch==2.13.0 python -m pytest \
  --confcutdir=tests/unit_tests/models/mamba \
  tests/unit_tests/models/mamba/test_mamba_builder.py::TestMambaModelBuilderCompatibility::test_mamba_stack_spec_factory_maps_to_hybrid_model_kwarg -q
```

Result before: `2 failed` because neither factory was called.

Result after: `2 passed`.

Focused and adjacent verification:

```bash
uv run --active --no-sync --with torch==2.13.0 python -m pytest \
  --confcutdir=tests/unit_tests/models \
  tests/unit_tests/models/mamba/test_mamba_builder.py \
  tests/unit_tests/models/mamba/test_mamba_provider.py \
  tests/unit_tests/models/hybrid/test_hybrid_builder.py -q
```

Result: `33 passed`.

```bash
git diff --check
uv run pre-commit run --all-files
```

Result: passed; all applicable pre-commit hooks passed.

## Scope

This is a CPU-level builder contract fix and focused regression test. No
dependency, workflow, public conversion API, checkpoint-format, or upstream
MCore change is included. No full-suite, GPU, model-quality, convergence, or
performance validation is claimed.
