### PR TITLE
fix(training): abort async checkpoints after pretrain failure

### DIFF
--- a/src/megatron/bridge/training/pretrain.py
+++ b/src/megatron/bridge/training/pretrain.py
@@ -198,14 +198,37 @@ def _pretrain(
         _finish_train(state, checkpoint_manager)
     except BaseException:
         if inprocess_call_wrapper is None:
-            _cleanup_after_pretrain_failure(should_destroy_process_group)
+            _cleanup_after_pretrain_failure(state, should_destroy_process_group)
         raise
 
     _maybe_destroy_process_group(should_destroy_process_group)
 
 
-def _cleanup_after_pretrain_failure(should_destroy_process_group: bool) -> None:
+def _abort_async_checkpoint_worker(state: GlobalState) -> None:
+    """Abort async checkpoint state before distributed teardown."""
+    try:
+        async_calls_queue = state._async_calls_queue
+        if async_calls_queue is not None:
+            async_calls_queue.close(abort=True)
+    finally:
+        state._async_calls_queue = None
+
+        from megatron.core.dist_checkpointing.strategies import filesystem_async
+
+        if filesystem_async._results_queue is not None:
+            try:
+                filesystem_async._results_queue._manager.shutdown()
+            finally:
+                filesystem_async._results_queue = None
+
+
+def _cleanup_after_pretrain_failure(state: GlobalState, should_destroy_process_group: bool) -> None:
     """Clean up framework-owned state after ordinary pretrain execution fails."""
+    try:
+        _abort_async_checkpoint_worker(state)
+    except Exception:
+        logger.exception("Failed to abort async checkpointing after pretrain failure")
+
     try:
         destroy_global_state()
     except Exception:

--- a/tests/unit_tests/training/test_pretrain.py
+++ b/tests/unit_tests/training/test_pretrain.py
@@ -90,6 +90,33 @@ class TestPretrainProcessGroupOwnership:
         mock_dist.barrier.assert_not_called()
         mock_dist.destroy_process_group.assert_called_once_with()
 
+    def test_framework_owned_async_worker_is_aborted_before_process_group_destroyed(self):
+        """Test failed setup aborts its async checkpoint worker before distributed cleanup."""
+        state = MagicMock()
+        async_queue = MagicMock()
+        cleanup_order = []
+
+        def setup_then_fail(*_args, **_kwargs):
+            state._async_calls_queue = async_queue
+            raise RuntimeError("setup failed after async worker initialization")
+
+        async_queue.close.side_effect = lambda *, abort: cleanup_order.append(("async_queue", abort))
+
+        with (
+            patch("megatron.bridge.training.pretrain.dist") as mock_dist,
+            patch("megatron.bridge.training.pretrain.destroy_global_state"),
+            patch("megatron.bridge.training.pretrain.get_dataset_provider"),
+            patch("megatron.bridge.training.pretrain.setup", side_effect=setup_then_fail),
+        ):
+            mock_dist.is_initialized.side_effect = [False, True]
+            mock_dist.destroy_process_group.side_effect = lambda: cleanup_order.append(("process_group", None))
+
+            with pytest.raises(RuntimeError, match="setup failed after async worker initialization"):
+                _pretrain(state, MagicMock())
+
+        assert cleanup_order == [("async_queue", True), ("process_group", None)]
+        assert state._async_calls_queue is None
+
     def test_caller_owned_process_group_is_preserved_when_setup_raises(self):
         """Test Bridge preserves a process group that existed before setup."""
         state = MagicMock()


### PR DESCRIPTION
## Summary

Abort framework-owned async checkpoint state before ordinary failed-pretrain
cleanup destroys Megatron and distributed state.

## Supported trigger and impact

With `checkpoint.async_save=True`, the MCore persistent worker can still have a
completed request awaiting finalization when standard, non-IPR `pretrain()`
raises. If the caller catches that public exception and retries training in the
same process, the fresh queue starts again at call index zero while the old
persistent completion state survives. The abandoned completion can therefore
prematurely finalize the retry's first checkpoint before its new payload is
durable.

## Root cause and fix

Ordinary `_pretrain()` failure cleanup destroyed Megatron globals and the
framework-owned process group, but did not abort its async queue or clear the
canonical MCore results queue. The exceptional path now:

1. aborts the async queue,
2. detaches it from `GlobalState`,
3. shuts down and clears MCore results ownership, then
4. continues the existing best-effort global/process-group cleanup.

This mirrors the established in-process-restart cleanup contract and preserves
caller-owned process groups.

## Validation

Fail-before/pass-after two-rank reproducer:

```text
uv run --active --no-sync python -m torch.distributed.run --standalone \
  --nproc_per_node=2 reproduce_async_retry_stale_completion.py <output-dir>
```

- Unmodified `origin/main`: failed on both ranks because retry request zero was
  finalized from the abandoned session's completion.
- Patched source: exited successfully; no premature finalization occurred.

Focused and adjacent tests:

```text
uv run --active --no-sync python -m pytest \
  tests/unit_tests/training/test_pretrain.py \
  tests/unit_tests/training/test_inprocess_restart.py::TestAbortCheckpoint \
  tests/unit_tests/training/test_state.py::TestGlobalState::test_initialize_async_checkpoint_worker_enabled \
  tests/unit_tests/training/test_state.py::TestGlobalState::test_initialize_async_checkpoint_worker_disabled \
  tests/unit_tests/training/test_state.py::TestGlobalState::test_async_calls_queue_property \
  tests/unit_tests/training/test_checkpointing.py::TestSaveCheckpoint::test_async_retention_keeps_tracker_checkpoint_until_finalize \
  tests/unit_tests/training/test_checkpointing.py::TestCheckpointManager::test_default_checkpoint_manager_finalize_async_saves \
  -q
```

Result: `17 passed`.

```text
git diff --check
uv run pre-commit run --all-files
```

Result: passed.

## Scope

This validates exceptional cleanup and same-process retry for the persistent
MCore async-save path. It does not claim full-suite, convergence, performance,
or model-quality validation.
