### PR TITLE
[data] fix: accept decoded Nemotron video inputs

### DIFF
--- a/src/megatron/bridge/models/nemotron_vl/data/collate_fn.py
+++ b/src/megatron/bridge/models/nemotron_vl/data/collate_fn.py
@@ -87,26 +87,28 @@ def nemotron_nano_v2_vl_collate_fn(
         video_nframe_max = -1
 
         for example in examples:
-            video_path = example["conversation"][0]["content"][0]["path"]
-            image_urls, metadata = maybe_path_or_url_to_data_urls(
-                video_path,
-                fps=max(0, int(video_fps)),
-                nframe=max(0, int(video_nframe)),
-                nframe_max=int(video_nframe_max),
-            )
-            frames.append([pil_image_from_base64(image_url) for image_url in image_urls])
+            video_part = example["conversation"][0]["content"][0]
+            video_payload = video_part.get("video")
+            metadata = None
+            if video_payload is not None and not isinstance(video_payload, str):
+                frames.append(video_payload)
+            else:
+                video_path = video_payload if isinstance(video_payload, str) else video_part["path"]
+                image_urls, metadata = maybe_path_or_url_to_data_urls(
+                    video_path,
+                    fps=max(0, int(video_fps)),
+                    nframe=max(0, int(video_nframe)),
+                    nframe_max=int(video_nframe_max),
+                )
+                frames.append([pil_image_from_base64(image_url) for image_url in image_urls])
 
         prompt = processor.apply_chat_template(
             [example["conversation"] for example in examples],
             tokenize=False,
             **shared_chat_template_kwargs_from_examples(examples),
         )
-        batch = processor(
-            text=prompt,
-            videos=frames,
-            videos_kwargs={"video_metadata": metadata},
-            return_tensors="pt",
-        )
+        processor_kwargs = {"videos_kwargs": {"video_metadata": metadata}} if metadata is not None else {}
+        batch = processor(text=prompt, videos=frames, return_tensors="pt", **processor_kwargs)
     else:
         # Ensure a pad_token is set so padding can produce uniform-length tensors.
         if processor.tokenizer.pad_token is None:

--- a/tests/unit_tests/data/energon/test_hf_task_encoder.py
+++ b/tests/unit_tests/data/energon/test_hf_task_encoder.py
@@ -338,6 +338,82 @@ class TestHFTaskEncoderBatch(unittest.TestCase):
             encoder.batch([sample])
 
 
+def test_nemotron_vl_registry_accepts_decoded_energon_video(monkeypatch):
+    from megatron.bridge.models.nemotron_vl import nemotron_vl_utils
+    from megatron.bridge.models.nemotron_vl.data import collate_fn as nemotron_vl_collate
+
+    class _Tokenizer:
+        pad_token = "<pad>"
+        pad_token_id = 0
+        eos_token = "<eos>"
+        eos_token_id = 1
+
+        def convert_tokens_to_ids(self, token):
+            return {"<video>": 9, "<image>": 10}[token]
+
+    class NemotronNanoVLV2Processor:
+        def __init__(self):
+            self.tokenizer = _Tokenizer()
+            self.video_payloads = None
+
+        def apply_chat_template(self, conversations, **kwargs):
+            del conversations, kwargs
+            return ["rendered prompt"]
+
+        def __call__(self, *, videos, **kwargs):
+            del kwargs
+            self.video_payloads = videos
+            return {
+                "input_ids": torch.tensor([[1, 2, 3]]),
+                "num_patches": torch.tensor([1]),
+                "pixel_values_videos": torch.ones(1, 3, 2, 2),
+            }
+
+    monkeypatch.setattr(
+        nemotron_vl_collate,
+        "extract_skipped_token_ids",
+        lambda processor: torch.empty(0, dtype=torch.long),
+    )
+    monkeypatch.setattr(
+        nemotron_vl_collate,
+        "_nemotron_vl_assistant_mask_boundary_config",
+        lambda processor: None,
+    )
+    monkeypatch.setattr(
+        nemotron_vl_collate,
+        "build_assistant_loss_mask",
+        lambda example, input_ids, *args, **kwargs: torch.zeros_like(input_ids, dtype=torch.float32),
+    )
+    monkeypatch.setattr(
+        nemotron_vl_utils,
+        "adjust_image_tokens",
+        lambda batch, *args, **kwargs: batch,
+    )
+
+    processor = NemotronNanoVLV2Processor()
+    encoder = HFTaskEncoder(processor=processor, seq_length=128)
+    sample = _make_chatml_sample(
+        conversation=json.dumps(
+            [
+                {
+                    "role": "user",
+                    "content": [{"type": "video"}, {"type": "text", "text": "Describe the video."}],
+                },
+                {"role": "assistant", "content": "A moving square."},
+            ]
+        ),
+        videos=[[torch.ones(3, 2, 2)]],
+    )
+
+    encoded = encoder.encode_sample(sample)
+    decoded_frames = encoded.example["conversation"][0]["content"][0]["video"]
+    batch = encoder.batch([encoded])
+
+    assert isinstance(batch, HFEnergonBatch)
+    assert processor.video_payloads is not None
+    assert processor.video_payloads[0][0] is decoded_frames[0]
+
+
 class TestHFTaskEncoderEncodeBatch(unittest.TestCase):
     def test_encode_batch(self):
         processor = _make_processor()


### PR DESCRIPTION
## What

Allow the Nemotron Nano V2 VL collator to consume decoded video frames emitted
by the generic Energon task encoder.

## Why

`HFEnergonTaskEncoderConfig` supports Hugging Face processors through the
generic `HFTaskEncoder`, whose collator registry maps
`NemotronNanoVLV2Processor` to `nemotron_nano_v2_vl_collate_fn`.

Energon decodes video media before collation, and the shared normalization path
represents it as:

```python
{"type": "video", "video": [decoded_frames]}
```

The Nemotron collator instead unconditionally read `content["path"]`, so a
supported Nemotron + Energon video batch failed with `KeyError: 'path'` before
the processor ran.

## Fix

Pass already-decoded non-string `video` payloads directly to the processor.
String-valued `video` payloads and the legacy `path` form continue through the
existing path/URL decoder, including video metadata when available.

## Validation

Fail-before on unmodified `main`:

```text
uv run --no-sync python -m pytest tests/unit_tests/data/energon/test_hf_task_encoder.py -k nemotron_vl_registry_accepts_decoded_energon_video -q
1 failed, 14 deselected
```

Pass-after with the unchanged regression:

```text
uv run --no-sync python -m pytest tests/unit_tests/data/energon/test_hf_task_encoder.py -k nemotron_vl_registry_accepts_decoded_energon_video -q
1 passed, 14 deselected
```

Focused and adjacent coverage:

```text
uv run --no-sync python -m pytest tests/unit_tests/data/energon/test_hf_task_encoder.py tests/unit_tests/data/test_conversation_processing.py tests/unit_tests/data/collators/test_model_collators.py::test_nemotron_vl_video_collate_rejects_in_batch_packing tests/unit_tests/data/collators/test_model_collators.py::test_nemotron_vl_collate_uses_each_rows_flat_image_tile_counts tests/unit_tests/data/sources/test_hf_adapters.py::test_llava_video_adapter_normalizes_turns -q
76 passed
```

```text
git diff --check
passed

uv run --no-sync pre-commit run --all-files
passed
```

Scope is limited to the CPU-side media handoff. This does not change packing,
model execution, checkpointing, or public API signatures.
