### PR TITLE
[model] fix: honor provider precision overrides

### DIFF
--- a/src/megatron/bridge/models/model_provider.py
+++ b/src/megatron/bridge/models/model_provider.py
@@ -617,10 +617,31 @@ def get_model(
         list[MegatronModule]: List of model modules. Contains multiple modules
             when using virtual pipeline parallelism, otherwise a single module
     """
-    if fp16:
+    if fp16 is True and bf16 is True:
+        raise ValueError("Only one of fp16 and bf16 can be enabled.")
+
+    if fp16 is not None:
         model_provider.fp16 = fp16
-    if bf16:
+    if bf16 is not None:
         model_provider.bf16 = bf16
+
+    # Enabling one precision mode overrides the provider's existing mode even
+    # when the caller omits the corresponding explicit False.
+    if fp16 is True and bf16 is None:
+        model_provider.bf16 = False
+    elif bf16 is True and fp16 is None:
+        model_provider.fp16 = False
+
+    if fp16 is not None or bf16 is not None:
+        if model_provider.fp16:
+            selected_dtype = torch.float16
+        elif model_provider.bf16:
+            selected_dtype = torch.bfloat16
+        else:
+            selected_dtype = torch.float32
+        for field_name in ("params_dtype", "pipeline_dtype", "autocast_dtype"):
+            if hasattr(model_provider, field_name):
+                setattr(model_provider, field_name, selected_dtype)
 
     model_provider.use_cpu_initialization = use_cpu_initialization if use_cpu_initialization else False
     if init_model_with_meta_device:

--- a/tests/unit_tests/models/test_model_instantiation.py
+++ b/tests/unit_tests/models/test_model_instantiation.py
@@ -14,6 +14,7 @@
 
 from unittest.mock import Mock, patch
 
+import pytest
 import torch
 from megatron.core.distributed import DistributedDataParallelConfig
 from megatron.core.enums import ModelType
@@ -444,6 +445,101 @@ class TestGetModel:
 
         # Assertions
         assert model_provider.fp16
+
+    @pytest.mark.parametrize(
+        ("initial_fp16", "initial_bf16", "fp16_override", "bf16_override", "expected_dtype"),
+        [
+            (True, False, False, True, torch.bfloat16),
+            (False, True, True, False, torch.float16),
+            (False, True, None, None, torch.bfloat16),
+            (True, False, False, False, torch.float32),
+            (True, False, False, None, torch.float32),
+            (False, True, None, False, torch.float32),
+        ],
+    )
+    @patch("megatron.bridge.models.model_provider._create_model")
+    @patch("megatron.bridge.models.model_provider._print_num_params")
+    @patch("megatron.bridge.models.model_provider.correct_amax_history_if_needed")
+    @patch("megatron.bridge.models.model_provider.get_model_config")
+    def test_get_model_applies_precision_switch_overrides(
+        self,
+        mock_get_model_config,
+        mock_fix_float8,
+        mock_print_params,
+        mock_create_model,
+        initial_fp16,
+        initial_bf16,
+        fp16_override,
+        bf16_override,
+        expected_dtype,
+    ):
+        """Test that explicit precision overrides replace the provider precision."""
+        model_provider = create_test_config()
+        initial_dtype = torch.float16 if initial_fp16 else torch.bfloat16
+        model_provider.fp16 = initial_fp16
+        model_provider.bf16 = initial_bf16
+        model_provider.params_dtype = initial_dtype
+        model_provider.pipeline_dtype = initial_dtype
+        model_provider.autocast_dtype = initial_dtype
+
+        model = MockMegatronModule(model_provider)
+        mock_create_model.return_value = [model]
+        mock_get_model_config.return_value = model_provider
+        mock_fix_float8.return_value = [model]
+        observed_precision = []
+
+        def record_precision(config, model_module):
+            observed_precision.append(
+                (
+                    config.fp16,
+                    config.bf16,
+                    config.params_dtype,
+                    config.pipeline_dtype,
+                    config.autocast_dtype,
+                )
+            )
+            return model_module
+
+        get_model(
+            model_provider,
+            DistributedDataParallelConfig(),
+            fp16=fp16_override,
+            bf16=bf16_override,
+            wrap_with_ddp=False,
+            use_cpu_initialization=True,
+            mixed_precision_wrapper=record_precision,
+            pg_collection=_PG(),
+        )
+
+        expected_precision = (
+            expected_dtype == torch.float16,
+            expected_dtype == torch.bfloat16,
+            expected_dtype,
+            expected_dtype,
+            expected_dtype,
+        )
+        assert (
+            model_provider.fp16,
+            model_provider.bf16,
+            model_provider.params_dtype,
+            model_provider.pipeline_dtype,
+            model_provider.autocast_dtype,
+        ) == expected_precision
+        assert observed_precision == ([] if expected_dtype == torch.float32 else [expected_precision])
+
+    @patch("megatron.bridge.models.model_provider._create_model")
+    def test_get_model_rejects_conflicting_precision_overrides(self, mock_create_model):
+        """Test that FP16 and BF16 cannot be enabled together."""
+        with pytest.raises(ValueError, match="Only one of fp16 and bf16"):
+            get_model(
+                MockModelProvider(),
+                DistributedDataParallelConfig(),
+                fp16=True,
+                bf16=True,
+                pg_collection=_PG(),
+            )
+
+        mock_create_model.assert_not_called()
 
     @patch("megatron.bridge.models.model_provider._create_model")
     @patch("megatron.bridge.models.model_provider._print_num_params")


### PR DESCRIPTION
## What does this PR do?

Honor the documented tri-state `fp16` and `bf16` construction overrides on the supported provider path.

`get_model()` previously applied these values only when truthy. Switching an FP16 provider to BF16 (or the reverse) therefore ignored the required explicit `False`, left both flags enabled, and retained stale allocation/pipeline dtypes. MCore could then construct or wrap the model in the old precision. Explicitly disabling mixed precision also left half-precision dtype fields behind.

The fix:

- preserves `None` as “keep the provider value” while honoring explicit `False`;
- makes an explicitly enabled precision replace the provider's existing mode;
- synchronizes parameter, pipeline, and autocast dtypes for FP16, BF16, and FP32;
- rejects simultaneous `fp16=True` and `bf16=True` before model creation.

## Testing

Fail-before on the unmodified base:

```text
uv run --active --no-sync --with torch==2.13.0 python -m pytest --confcutdir=tests/unit_tests/models tests/unit_tests/models/test_model_instantiation.py::TestGetModel::test_get_model_applies_precision_switch_overrides -q
# 2 failed, 1 passed
```

Pass-after, including switch, disable, omission, dtype synchronization, and conflict controls:

```text
uv run --active --no-sync --with torch==2.13.0 python -m pytest --confcutdir=tests/unit_tests/models tests/unit_tests/models/test_model_instantiation.py::TestGetModel::test_get_model_applies_precision_switch_overrides tests/unit_tests/models/test_model_instantiation.py::TestGetModel::test_get_model_rejects_conflicting_precision_overrides -q
# 7 passed
```

Focused adjacent provider boundary:

```text
uv run --active --no-sync --with torch==2.13.0 python -m pytest --confcutdir=tests/unit_tests/models tests/unit_tests/models/test_model_provider_mixin.py tests/unit_tests/models/test_model_instantiation.py::TestGetModel --deselect=tests/unit_tests/models/test_model_instantiation.py::TestGetModel::test_get_model_pre_wrap_hook -q
# 21 passed, 1 deselected
```

Additional checks:

```text
git diff --check
# passed

uv run --active --no-sync pre-commit run --all-files
# all applicable hooks passed
```

Scope is limited to the shared provider construction boundary and focused CPU contract tests. No public API signature, dependency, workflow, GPU behavior, convergence, performance, or full-suite validation is claimed.
