### PR TITLE
feat(model): add legacy mbridge compatibility facade

### DIFF
--- a/src/megatron/bridge/legacy/__init__.py
+++ b/src/megatron/bridge/legacy/__init__.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Namespaced compatibility APIs for legacy MBridge callers.
+
+The facade is the only convenience export. The compiler and migrated proof
+remain explicitly discoverable without broadening that facade::
+
+    from megatron.bridge.legacy.mapping_compiler import compile_legacy_mapping_registry
+    from megatron.bridge.legacy.qwen3_moe import Qwen3MoELegacyMapping
+"""
+
+from megatron.bridge.legacy.mbridge import AutoBridge
+
+
+__all__ = ["AutoBridge"]

--- a/src/megatron/bridge/legacy/mapping_compiler.py
+++ b/src/megatron/bridge/legacy/mapping_compiler.py
@@ -1,0 +1,290 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Compile declarative legacy weight maps into current mapping primitives."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping, Sequence
+from string import Formatter
+
+from megatron.bridge.models.conversion.mapping_registry import MegatronMappingRegistry
+from megatron.bridge.models.conversion.param_mapping import (
+    AutoMapping,
+    FusedExpertMapping,
+    FusedGatedExpertMapping,
+    GatedMLPMapping,
+    MegatronParamMapping,
+    QKVMapping,
+)
+
+
+_LAYER_FIELD = "layer_number"
+_EXPERT_FIELD = "expert_id"
+_ALLOWED_FIELDS = frozenset({_LAYER_FIELD, _EXPERT_FIELD})
+_GROUPED_EXPERT_RE = re.compile(r"(?P<prefix>.*\.mlp\.experts)\.linear_fc(?P<projection>[12])$")
+
+
+def compile_legacy_mapping_registry(
+    *,
+    direct_mapping: Mapping[str, str],
+    attention_mapping: Mapping[str, Sequence[str]],
+    mlp_mapping: Mapping[str, Sequence[str]],
+) -> MegatronMappingRegistry:
+    """Compile legacy mapping dictionaries into a current mapping registry.
+
+    Normalization rules:
+
+    - Direct names remain exact and cannot contain legacy placeholders.
+    - Attention and MLP keys are layer-local suffixes prefixed with
+      ``decoder.layers.*.``.
+    - ``{layer_number}`` becomes the layer wildcard ``*``.
+    - A bare layer-local ``...layernorm`` key gains its parameter suffix
+      ``.weight``.
+    - Grouped expert ``linear_fc1``/``linear_fc2`` keys become both TE grouped
+      ``weight*`` and sequential ``local_experts.*`` Megatron patterns.
+    - ``{expert_id}`` becomes the HF expert wildcard ``*``.
+    - One-to-one entries use ``AutoMapping``; three-way attention entries use
+      ``QKVMapping``; two-way MLP entries use ``GatedMLPMapping``; expert
+      entries without an HF expert placeholder use fused expert primitives.
+
+    Args:
+        direct_mapping: Exact Megatron-to-HF parameter names.
+        attention_mapping: Layer-local attention declarations.
+        mlp_mapping: Layer-local MLP and MoE declarations.
+
+    Returns:
+        A current Megatron mapping registry.
+
+    Raises:
+        ValueError: If a declaration is ambiguous, has invalid placeholders,
+            or normalizes to a duplicate Megatron pattern.
+        TypeError: If a dictionary has the wrong value shape.
+    """
+    compiled: list[MegatronParamMapping] = []
+    seen_megatron_patterns: set[str] = set()
+
+    for megatron_param, hf_param in direct_mapping.items():
+        _validate_clean_name(megatron_param, label="direct Megatron parameter")
+        _validate_clean_name(hf_param, label=f"direct HF target for {megatron_param!r}")
+        _validate_no_fields(megatron_param, label="direct Megatron parameter")
+        _validate_no_fields(hf_param, label=f"direct HF target for {megatron_param!r}")
+        _append_unique(
+            compiled,
+            seen_megatron_patterns,
+            AutoMapping(megatron_param=megatron_param, hf_param=hf_param),
+        )
+
+    for legacy_key, targets in attention_mapping.items():
+        for mapping in _compile_layer_entry("attention", legacy_key, targets):
+            _append_unique(compiled, seen_megatron_patterns, mapping)
+
+    for legacy_key, targets in mlp_mapping.items():
+        for mapping in _compile_layer_entry("mlp", legacy_key, targets):
+            _append_unique(compiled, seen_megatron_patterns, mapping)
+
+    return MegatronMappingRegistry(*compiled)
+
+
+def _compile_layer_entry(
+    category: str,
+    legacy_key: str,
+    targets: Sequence[str],
+) -> list[MegatronParamMapping]:
+    if isinstance(targets, (str, bytes)) or not isinstance(targets, Sequence):
+        raise TypeError(f"{category} mapping {legacy_key!r} must contain a sequence of HF targets.")
+    if not targets:
+        raise ValueError(f"{category} mapping {legacy_key!r} must contain at least one HF target.")
+    if any(not isinstance(target, str) for target in targets):
+        raise TypeError(f"{category} mapping {legacy_key!r} contains a non-string HF target.")
+
+    megatron_patterns, projection = _normalize_megatron_patterns(legacy_key)
+    hf_patterns = [_normalize_hf_pattern(target, legacy_key=legacy_key) for target in targets]
+    expert_fields = [_EXPERT_FIELD in _field_names(target) for target in targets]
+    is_expert = projection is not None
+
+    if any(expert_fields) and not is_expert:
+        raise ValueError(
+            f"{category} mapping {legacy_key!r} uses {{{_EXPERT_FIELD}}} but its Megatron key is not an expert "
+            "linear_fc1/linear_fc2 declaration."
+        )
+    if is_expert and any(expert_fields) and not all(expert_fields):
+        raise ValueError(
+            f"{category} mapping {legacy_key!r} mixes expert-specific and fused HF targets; "
+            f"either every target must use {{{_EXPERT_FIELD}}} or none may use it."
+        )
+
+    if category == "attention":
+        if is_expert:
+            raise ValueError(f"attention mapping {legacy_key!r} cannot declare expert projections.")
+        if len(hf_patterns) == 1:
+            return [AutoMapping(megatron_patterns[0], hf_patterns[0])]
+        if len(hf_patterns) == 3:
+            roles = _resolve_roles(
+                legacy_key=legacy_key,
+                category=category,
+                patterns=hf_patterns,
+                role_tokens={"q": ".q_proj.", "k": ".k_proj.", "v": ".v_proj."},
+            )
+            return [
+                QKVMapping(
+                    megatron_param=megatron_patterns[0],
+                    q=roles["q"],
+                    k=roles["k"],
+                    v=roles["v"],
+                )
+            ]
+        raise ValueError(
+            f"Ambiguous attention mapping {legacy_key!r}: expected one direct target or three Q/K/V targets, "
+            f"got {len(hf_patterns)}."
+        )
+
+    if category != "mlp":
+        raise ValueError(f"Unsupported legacy mapping category: {category!r}.")
+
+    if len(hf_patterns) == 1:
+        if is_expert and not expert_fields[0]:
+            mapping_type = FusedGatedExpertMapping if projection == "1" else FusedExpertMapping
+            return [mapping_type(megatron_param=pattern, hf_param=hf_patterns[0]) for pattern in megatron_patterns]
+        return [AutoMapping(pattern, hf_patterns[0]) for pattern in megatron_patterns]
+
+    if len(hf_patterns) == 2:
+        if is_expert and not all(expert_fields):
+            raise ValueError(
+                f"Ambiguous MLP mapping {legacy_key!r}: two fused HF expert tensors cannot be represented by one "
+                "current gated-expert primitive."
+            )
+        roles = _resolve_roles(
+            legacy_key=legacy_key,
+            category=category,
+            patterns=hf_patterns,
+            role_tokens={"gate": ".gate_proj.", "up": ".up_proj."},
+        )
+        return [
+            GatedMLPMapping(megatron_param=pattern, gate=roles["gate"], up=roles["up"])
+            for pattern in megatron_patterns
+        ]
+
+    raise ValueError(
+        f"Ambiguous MLP mapping {legacy_key!r}: expected one direct target or two gate/up targets, "
+        f"got {len(hf_patterns)}."
+    )
+
+
+def _normalize_megatron_patterns(legacy_key: str) -> tuple[list[str], str | None]:
+    _validate_clean_name(legacy_key, label="layer-local Megatron key")
+    _validate_no_fields(legacy_key, label="layer-local Megatron key")
+    if legacy_key.startswith("decoder.layers."):
+        raise ValueError(
+            f"Layer-local Megatron key {legacy_key!r} must be a suffix, not a pre-normalized decoder path."
+        )
+    if "*" in legacy_key:
+        raise ValueError(
+            f"Layer-local Megatron key {legacy_key!r} must not contain wildcards; "
+            "the compiler adds layer and expert wildcards."
+        )
+
+    normalized_key = legacy_key
+    if normalized_key.endswith("layernorm"):
+        normalized_key = f"{normalized_key}.weight"
+
+    grouped_expert_match = _GROUPED_EXPERT_RE.fullmatch(f"decoder.layers.*.{normalized_key}")
+    if grouped_expert_match is None:
+        return [f"decoder.layers.*.{normalized_key}"], None
+
+    projection = grouped_expert_match.group("projection")
+    grouped_prefix = grouped_expert_match.group("prefix")
+    grouped = f"{grouped_prefix}.linear_fc{projection}.weight*"
+    sequential = f"{grouped_prefix}.local_experts.*.linear_fc{projection}.weight"
+    return [grouped, sequential], projection
+
+
+def _normalize_hf_pattern(target: str, *, legacy_key: str) -> str:
+    _validate_clean_name(target, label=f"HF target for {legacy_key!r}")
+    fields = _field_names(target)
+    unknown_fields = sorted(fields - _ALLOWED_FIELDS)
+    if unknown_fields:
+        raise ValueError(
+            f"HF target {target!r} for {legacy_key!r} has unsupported placeholder(s): {unknown_fields}. "
+            f"Only {{{_LAYER_FIELD}}} and {{{_EXPERT_FIELD}}} are supported."
+        )
+    if target.count(f"{{{_LAYER_FIELD}}}") != 1:
+        raise ValueError(
+            f"HF target {target!r} for {legacy_key!r} must contain exactly one {{{_LAYER_FIELD}}} placeholder."
+        )
+    if target.count(f"{{{_EXPERT_FIELD}}}") > 1:
+        raise ValueError(
+            f"HF target {target!r} for {legacy_key!r} contains more than one {{{_EXPERT_FIELD}}} placeholder."
+        )
+    return target.replace(f"{{{_LAYER_FIELD}}}", "*").replace(f"{{{_EXPERT_FIELD}}}", "*")
+
+
+def _resolve_roles(
+    *,
+    legacy_key: str,
+    category: str,
+    patterns: Sequence[str],
+    role_tokens: Mapping[str, str],
+) -> dict[str, str]:
+    resolved: dict[str, str] = {}
+    for pattern in patterns:
+        matching_roles = [role for role, token in role_tokens.items() if token in pattern]
+        if len(matching_roles) != 1:
+            raise ValueError(
+                f"Ambiguous {category} mapping {legacy_key!r}: target {pattern!r} must identify exactly one of "
+                f"{sorted(role_tokens)}."
+            )
+        role = matching_roles[0]
+        if role in resolved:
+            raise ValueError(f"Ambiguous {category} mapping {legacy_key!r}: role {role!r} is declared more than once.")
+        resolved[role] = pattern
+
+    missing_roles = sorted(set(role_tokens) - set(resolved))
+    if missing_roles:
+        raise ValueError(f"Ambiguous {category} mapping {legacy_key!r}: missing role(s) {missing_roles}.")
+    return resolved
+
+
+def _field_names(value: str) -> set[str]:
+    try:
+        return {field_name for _, field_name, _, _ in Formatter().parse(value) if field_name is not None}
+    except ValueError as error:
+        raise ValueError(f"Invalid legacy placeholder syntax in {value!r}: {error}") from error
+
+
+def _validate_no_fields(value: str, *, label: str) -> None:
+    fields = sorted(_field_names(value))
+    if fields:
+        raise ValueError(f"{label} {value!r} cannot contain placeholder(s): {fields}.")
+
+
+def _validate_clean_name(value: object, *, label: str) -> None:
+    if not isinstance(value, str):
+        raise TypeError(f"{label} must be a string, got {type(value).__name__}.")
+    if not value or value != value.strip():
+        raise ValueError(f"{label} must be a non-empty name without surrounding whitespace, got {value!r}.")
+
+
+def _append_unique(
+    compiled: list[MegatronParamMapping],
+    seen_megatron_patterns: set[str],
+    mapping: MegatronParamMapping,
+) -> None:
+    if mapping.megatron_param in seen_megatron_patterns:
+        raise ValueError(
+            f"Ambiguous legacy declarations normalize to duplicate Megatron pattern {mapping.megatron_param!r}."
+        )
+    seen_megatron_patterns.add(mapping.megatron_param)
+    compiled.append(mapping)

--- a/src/megatron/bridge/legacy/mbridge.py
+++ b/src/megatron/bridge/legacy/mbridge.py
@@ -1,0 +1,215 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Thin legacy MBridge facade backed by the current conversion stack."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+from typing import Unpack, cast
+
+import torch
+from megatron.core.transformer.module import MegatronModule
+from transformers.configuration_utils import PretrainedConfig
+
+from megatron.bridge.models.conversion.auto_bridge import AutoBridge as CurrentAutoBridge
+from megatron.bridge.models.conversion.model_bridge import HFWeightTuple
+from megatron.bridge.models.model_provider import GetModelKwargs, ModelProviderMixin
+
+
+class AutoBridge:
+    """Compatibility facade for the bounded legacy MBridge API.
+
+    The facade keeps the legacy list-of-models contract while delegating model
+    construction, conversion, and saving to the current Megatron Bridge
+    implementation.
+    """
+
+    def __init__(
+        self,
+        bridge: CurrentAutoBridge[MegatronModule],
+        provider: ModelProviderMixin[MegatronModule],
+    ) -> None:
+        self._bridge = bridge
+        self._provider = provider
+
+    @classmethod
+    def from_config(cls, hf_config: PretrainedConfig, **provider_overrides: object) -> AutoBridge:
+        """Create the legacy facade from a Hugging Face configuration.
+
+        Args:
+            hf_config: Supported Hugging Face model configuration.
+            **provider_overrides: Current provider fields to override. The
+                legacy ``dtype`` keyword is accepted as an alias for the
+                provider precision fields.
+
+        Returns:
+            A facade wrapping the current :class:`AutoBridge`.
+
+        Raises:
+            AttributeError: If an override is not a real provider field.
+            TypeError: If ``dtype`` is not a ``torch.dtype``.
+        """
+        current_bridge = cast(
+            CurrentAutoBridge[MegatronModule],
+            CurrentAutoBridge.from_hf_config(hf_config),
+        )
+        provider = cast(
+            ModelProviderMixin[MegatronModule],
+            current_bridge.to_megatron_provider(load_weights=False),
+        )
+        facade = cls(current_bridge, provider)
+
+        overrides = dict(provider_overrides)
+        dtype = overrides.pop("dtype", None)
+        if dtype is not None and not isinstance(dtype, torch.dtype):
+            raise TypeError(f"dtype must be a torch.dtype, got {type(dtype).__name__}.")
+        facade._apply_provider_overrides(dtype=dtype, overrides=overrides)
+        return facade
+
+    def get_model(
+        self,
+        weight_path: str | Path | None = None,
+        **kwargs: Unpack[GetModelKwargs],
+    ) -> list[MegatronModule]:
+        """Build a list of Megatron model chunks and optionally load HF weights.
+
+        Args:
+            weight_path: Optional Hugging Face checkpoint path or model ID.
+            **kwargs: Current provider model-construction options.
+
+        Returns:
+            The legacy list of Megatron model chunks.
+        """
+        self._provider.finalize()
+        models = cast(list[MegatronModule], self._provider.provide_distributed_model(**kwargs))
+        if weight_path is not None:
+            self.load_weights(models, weight_path)
+        return models
+
+    def load_weights(
+        self,
+        models: list[MegatronModule],
+        weights_path: str | Path,
+        memory_efficient: bool = False,
+    ) -> None:
+        """Load Hugging Face weights into legacy-shaped model chunks.
+
+        Args:
+            models: List of Megatron model chunks.
+            weights_path: Hugging Face checkpoint path or model ID.
+            memory_efficient: Legacy loading mode. ``True`` is not representable
+                by the current API.
+
+        Raises:
+            NotImplementedError: If ``memory_efficient`` is enabled.
+            TypeError: If ``models`` is not a list.
+        """
+        self._require_model_list(models)
+        if memory_efficient:
+            raise NotImplementedError(
+                "memory_efficient=True is not representable by the current AutoBridge loading API. "
+                "Use memory_efficient=False; the current checkpoint source manages weight materialization."
+            )
+        self._bridge.load_hf_weights(models, hf_path=weights_path)
+
+    def export_weights(
+        self,
+        models: list[MegatronModule],
+        keep_stacked_experts: bool = True,
+    ) -> Iterable[HFWeightTuple]:
+        """Export legacy-shaped model chunks as Hugging Face weights.
+
+        Args:
+            models: List of Megatron model chunks.
+            keep_stacked_experts: Legacy expert-layout selector. The current API
+                supports only its source-native layout, represented by ``True``.
+
+        Returns:
+            An iterable of Hugging Face weight tuples.
+
+        Raises:
+            NotImplementedError: If separate expert output is requested.
+            TypeError: If ``models`` is not a list.
+        """
+        self._require_model_list(models)
+        if not keep_stacked_experts:
+            raise NotImplementedError(
+                "keep_stacked_experts=False is not representable by the current AutoBridge export API. "
+                "Use keep_stacked_experts=True to preserve the current bridge's source-native expert layout."
+            )
+        return self._bridge.export_hf_weights(models)
+
+    def save_weights(
+        self,
+        models: list[MegatronModule],
+        weights_path: str | Path,
+        memory_efficient: bool = False,
+    ) -> None:
+        """Save model chunks through the current Hugging Face save path.
+
+        Args:
+            models: List of Megatron model chunks.
+            weights_path: Output directory.
+            memory_efficient: Legacy save mode. ``True`` is not representable
+                by the current API.
+
+        Raises:
+            NotImplementedError: If ``memory_efficient`` is enabled.
+            TypeError: If ``models`` is not a list.
+        """
+        self._require_model_list(models)
+        if memory_efficient:
+            raise NotImplementedError(
+                "memory_efficient=True is not representable by the current AutoBridge save API. "
+                "Use memory_efficient=False; the current save path owns streaming and sharding."
+            )
+        self._bridge.save_hf_pretrained(models, weights_path)
+
+    def set_extra_args(self, **provider_overrides: object) -> None:
+        """Apply validated current-provider overrides and rebuild provider state.
+
+        Args:
+            **provider_overrides: Fields that already exist on the current
+                provider/config object.
+
+        Raises:
+            AttributeError: If any override is not a real provider field. No
+                overrides are applied when validation fails.
+        """
+        self._apply_provider_overrides(dtype=None, overrides=provider_overrides)
+
+    def _apply_provider_overrides(
+        self,
+        *,
+        dtype: torch.dtype | None,
+        overrides: Mapping[str, object],
+    ) -> None:
+        fields_to_validate = set(overrides)
+        if dtype is not None:
+            fields_to_validate.update(("params_dtype", "fp16", "bf16"))
+        unknown_fields = sorted(name for name in fields_to_validate if not hasattr(self._provider, name))
+        if unknown_fields:
+            formatted_fields = ", ".join(repr(name) for name in unknown_fields)
+            raise AttributeError(
+                f"{type(self._provider).__name__} has no provider/config field(s): {formatted_fields}. "
+                "Only existing current-provider fields can be passed to the legacy facade."
+            )
+        self._provider.apply_overrides_and_finalize(dtype=dtype, overrides=overrides)
+
+    @staticmethod
+    def _require_model_list(models: object) -> None:
+        if not isinstance(models, list):
+            raise TypeError("Legacy MBridge APIs require models to be provided as a list of model chunks.")

--- a/src/megatron/bridge/legacy/qwen3_moe.py
+++ b/src/megatron/bridge/legacy/qwen3_moe.py
@@ -21,7 +21,7 @@ from megatron.bridge.models.conversion.mapping_registry import MegatronMappingRe
 
 
 HF_MODEL_ID = "Qwen/Qwen3-30B-A3B"
-HF_REVISION = "ad44e777bcd18fa416d9da3bd8f70d33ebb85d39"
+HF_REVISION = "ad44e777bcd18fa416d9da3bd8f70d33ebb85d39"  # pragma: allowlist secret
 HF_ARCHITECTURE = "Qwen3MoeForCausalLM"
 MIN_TRANSFORMERS_VERSION = "5.8.1"
 

--- a/src/megatron/bridge/legacy/qwen3_moe.py
+++ b/src/megatron/bridge/legacy/qwen3_moe.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Legacy mapping declaration for the Qwen3 MoE migration proof."""
+
+from __future__ import annotations
+
+from megatron.bridge.legacy.mapping_compiler import compile_legacy_mapping_registry
+from megatron.bridge.models.conversion.mapping_registry import MegatronMappingRegistry
+
+
+HF_MODEL_ID = "Qwen/Qwen3-30B-A3B"
+HF_REVISION = "ad44e777bcd18fa416d9da3bd8f70d33ebb85d39"
+HF_ARCHITECTURE = "Qwen3MoeForCausalLM"
+MIN_TRANSFORMERS_VERSION = "5.8.1"
+
+
+class _Qwen2MoELegacyMappingDeclaration:
+    """Inheritance carrier for the legacy mappings reused by Qwen3 MoE.
+
+    The inherited declaration intentionally includes Qwen2 MoE QKV-bias and
+    shared-expert entries that are stale for the pinned Qwen3-30B-A3B proof
+    model. They exercise compilation only; semantic parity is asserted solely
+    for Qwen3's actual QKV weight, router, and grouped/sequential expert
+    parameters.
+    """
+
+    _DIRECT_MAPPING = {
+        "embedding.word_embeddings.weight": "model.embed_tokens.weight",
+        "decoder.final_layernorm.weight": "model.norm.weight",
+        "output_layer.weight": "lm_head.weight",
+    }
+    _ATTENTION_MAPPING = {
+        "self_attention.linear_proj.weight": ("model.layers.{layer_number}.self_attn.o_proj.weight",),
+        "self_attention.linear_qkv.layer_norm_weight": ("model.layers.{layer_number}.input_layernorm.weight",),
+        "self_attention.q_layernorm.weight": ("model.layers.{layer_number}.self_attn.q_norm.weight",),
+        "self_attention.k_layernorm.weight": ("model.layers.{layer_number}.self_attn.k_norm.weight",),
+        "self_attention.linear_qkv.weight": (
+            "model.layers.{layer_number}.self_attn.q_proj.weight",
+            "model.layers.{layer_number}.self_attn.k_proj.weight",
+            "model.layers.{layer_number}.self_attn.v_proj.weight",
+        ),
+        "self_attention.linear_qkv.bias": (
+            "model.layers.{layer_number}.self_attn.q_proj.bias",
+            "model.layers.{layer_number}.self_attn.k_proj.bias",
+            "model.layers.{layer_number}.self_attn.v_proj.bias",
+        ),
+    }
+    _MLP_MAPPING = {
+        "shared_experts.linear_fc1.weight": (
+            "model.layers.{layer_number}.mlp.shared_expert.gate_proj.weight",
+            "model.layers.{layer_number}.mlp.shared_expert.up_proj.weight",
+        ),
+        "pre_mlp_layernorm": ("model.layers.{layer_number}.post_attention_layernorm.weight",),
+        "shared_experts.linear_fc2.weight": ("model.layers.{layer_number}.mlp.shared_expert.down_proj.weight",),
+        "mlp.router.weight": ("model.layers.{layer_number}.mlp.gate.weight",),
+        "shared_experts.gate_weight": ("model.layers.{layer_number}.mlp.shared_expert_gate.weight",),
+        "mlp.experts.linear_fc1": (
+            "model.layers.{layer_number}.mlp.experts.{expert_id}.gate_proj.weight",
+            "model.layers.{layer_number}.mlp.experts.{expert_id}.up_proj.weight",
+        ),
+        "mlp.experts.linear_fc2": ("model.layers.{layer_number}.mlp.experts.{expert_id}.down_proj.weight",),
+    }
+
+
+class Qwen3MoELegacyMapping(_Qwen2MoELegacyMappingDeclaration):
+    """Compile the inherited legacy Qwen3 MoE mapping declaration.
+
+    This proof class is intentionally not registered with production bridge
+    dispatch. Production Qwen3 MoE conversion continues to use
+    ``Qwen3MoEBridge``. Its compiled registry retains stale inherited entries,
+    so it is not claimed to be fully equivalent to the production registry.
+    """
+
+    @classmethod
+    def mapping_registry(cls) -> MegatronMappingRegistry:
+        """Compile the inherited declaration into current mapping primitives."""
+        return compile_legacy_mapping_registry(
+            direct_mapping=cls._DIRECT_MAPPING,
+            attention_mapping=cls._ATTENTION_MAPPING,
+            mlp_mapping=cls._MLP_MAPPING,
+        )

--- a/src/megatron/bridge/models/conversion/utils.py
+++ b/src/megatron/bridge/models/conversion/utils.py
@@ -86,7 +86,7 @@ def weights_verification_table(bridge, megatron_model) -> Table:
     Returns a table comparing weights between a Hugging Face model and a Megatron-LM model.
 
     Args:
-        bridge (AutoBridge): The bridge object containing model information.
+        bridge (bridge.models.conversion.auto_bridge.AutoBridge): The bridge object containing model information.
         megatron_model: The Megatron-LM model instance.
 
     Returns:

--- a/tests/unit_tests/legacy/test_mapping_compiler.py
+++ b/tests/unit_tests/legacy/test_mapping_compiler.py
@@ -1,0 +1,356 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Normalization, ambiguity, and Qwen3 MoE parity tests for legacy maps."""
+
+from collections.abc import Mapping
+from typing import Any
+
+import pytest
+
+from megatron.bridge.legacy.mapping_compiler import compile_legacy_mapping_registry
+from megatron.bridge.legacy.qwen3_moe import (
+    HF_ARCHITECTURE,
+    HF_MODEL_ID,
+    HF_REVISION,
+    MIN_TRANSFORMERS_VERSION,
+    Qwen3MoELegacyMapping,
+)
+from megatron.bridge.models.conversion.mapping_registry import MegatronMappingRegistry
+from megatron.bridge.models.conversion.param_mapping import (
+    AutoMapping,
+    FusedExpertMapping,
+    FusedGatedExpertMapping,
+    GatedMLPMapping,
+    MegatronParamMapping,
+    QKVMapping,
+)
+from megatron.bridge.models.qwen.qwen3_moe_bridge import Qwen3MoEBridge
+
+
+def _mapping_by_pattern(
+    registry: MegatronMappingRegistry,
+    pattern: str,
+) -> MegatronParamMapping[Any]:
+    matches = [mapping for mapping in registry.mappings if mapping.megatron_param == pattern]
+    assert len(matches) == 1, f"Expected exactly one mapping for {pattern!r}, got {matches!r}."
+    return matches[0]
+
+
+def _assert_same_mapping_semantics(
+    compiled: MegatronMappingRegistry,
+    production: MegatronMappingRegistry,
+    pattern: str,
+) -> None:
+    compiled_mapping = _mapping_by_pattern(compiled, pattern)
+    production_mapping = _mapping_by_pattern(production, pattern)
+
+    assert type(compiled_mapping) is type(production_mapping)
+    assert compiled_mapping.hf_param == production_mapping.hf_param
+
+
+def test_dense_declarations_show_all_core_normalization_rules() -> None:
+    """Normalize exact, layer, layernorm, QKV, and gated-MLP declarations."""
+    registry = compile_legacy_mapping_registry(
+        direct_mapping={
+            "embedding.word_embeddings.weight": "model.embed_tokens.weight",
+        },
+        attention_mapping={
+            "self_attention.linear_proj.weight": ("model.layers.{layer_number}.self_attn.o_proj.weight",),
+            "self_attention.linear_qkv.weight": (
+                "model.layers.{layer_number}.self_attn.v_proj.weight",
+                "model.layers.{layer_number}.self_attn.q_proj.weight",
+                "model.layers.{layer_number}.self_attn.k_proj.weight",
+            ),
+        },
+        mlp_mapping={
+            "pre_mlp_layernorm": ("model.layers.{layer_number}.post_attention_layernorm.weight",),
+            "mlp.linear_fc1.weight": (
+                "model.layers.{layer_number}.mlp.up_proj.weight",
+                "model.layers.{layer_number}.mlp.gate_proj.weight",
+            ),
+        },
+    )
+
+    direct = _mapping_by_pattern(registry, "embedding.word_embeddings.weight")
+    projection = _mapping_by_pattern(registry, "decoder.layers.*.self_attention.linear_proj.weight")
+    qkv = _mapping_by_pattern(registry, "decoder.layers.*.self_attention.linear_qkv.weight")
+    layernorm = _mapping_by_pattern(registry, "decoder.layers.*.pre_mlp_layernorm.weight")
+    gated_mlp = _mapping_by_pattern(registry, "decoder.layers.*.mlp.linear_fc1.weight")
+
+    assert isinstance(direct, AutoMapping)
+    assert direct.hf_param == "model.embed_tokens.weight"
+    assert isinstance(projection, AutoMapping)
+    assert projection.hf_param == "model.layers.*.self_attn.o_proj.weight"
+    assert isinstance(qkv, QKVMapping)
+    assert qkv.hf_param == {
+        "q": "model.layers.*.self_attn.q_proj.weight",
+        "k": "model.layers.*.self_attn.k_proj.weight",
+        "v": "model.layers.*.self_attn.v_proj.weight",
+    }
+    assert isinstance(layernorm, AutoMapping)
+    assert layernorm.hf_param == "model.layers.*.post_attention_layernorm.weight"
+    assert isinstance(gated_mlp, GatedMLPMapping)
+    assert gated_mlp.hf_param == {
+        "gate": "model.layers.*.mlp.gate_proj.weight",
+        "up": "model.layers.*.mlp.up_proj.weight",
+    }
+
+
+def test_moe_expert_placeholder_compiles_grouped_and_sequential_patterns() -> None:
+    """Expand a single legacy expert declaration to both current MoE layouts."""
+    registry = compile_legacy_mapping_registry(
+        direct_mapping={},
+        attention_mapping={},
+        mlp_mapping={
+            "mlp.experts.linear_fc1": (
+                "model.layers.{layer_number}.mlp.experts.{expert_id}.gate_proj.weight",
+                "model.layers.{layer_number}.mlp.experts.{expert_id}.up_proj.weight",
+            ),
+            "mlp.experts.linear_fc2": ("model.layers.{layer_number}.mlp.experts.{expert_id}.down_proj.weight",),
+        },
+    )
+
+    grouped_fc1 = _mapping_by_pattern(registry, "decoder.layers.*.mlp.experts.linear_fc1.weight*")
+    sequential_fc1 = _mapping_by_pattern(
+        registry,
+        "decoder.layers.*.mlp.experts.local_experts.*.linear_fc1.weight",
+    )
+    grouped_fc2 = _mapping_by_pattern(registry, "decoder.layers.*.mlp.experts.linear_fc2.weight*")
+    sequential_fc2 = _mapping_by_pattern(
+        registry,
+        "decoder.layers.*.mlp.experts.local_experts.*.linear_fc2.weight",
+    )
+
+    for mapping in (grouped_fc1, sequential_fc1):
+        assert isinstance(mapping, GatedMLPMapping)
+        assert mapping.hf_param == {
+            "gate": "model.layers.*.mlp.experts.*.gate_proj.weight",
+            "up": "model.layers.*.mlp.experts.*.up_proj.weight",
+        }
+    for mapping in (grouped_fc2, sequential_fc2):
+        assert isinstance(mapping, AutoMapping)
+        assert mapping.hf_param == "model.layers.*.mlp.experts.*.down_proj.weight"
+
+
+def test_packed_hf_experts_use_fused_current_primitives() -> None:
+    """Compile packed HF expert tensors to fused expert primitives."""
+    registry = compile_legacy_mapping_registry(
+        direct_mapping={},
+        attention_mapping={},
+        mlp_mapping={
+            "mlp.experts.linear_fc1": ("model.layers.{layer_number}.mlp.experts.gate_up_proj",),
+            "mlp.experts.linear_fc2": ("model.layers.{layer_number}.mlp.experts.down_proj",),
+        },
+    )
+
+    for pattern in (
+        "decoder.layers.*.mlp.experts.linear_fc1.weight*",
+        "decoder.layers.*.mlp.experts.local_experts.*.linear_fc1.weight",
+    ):
+        assert isinstance(_mapping_by_pattern(registry, pattern), FusedGatedExpertMapping)
+    for pattern in (
+        "decoder.layers.*.mlp.experts.linear_fc2.weight*",
+        "decoder.layers.*.mlp.experts.local_experts.*.linear_fc2.weight",
+    ):
+        assert isinstance(_mapping_by_pattern(registry, pattern), FusedExpertMapping)
+
+
+@pytest.mark.parametrize(
+    ("category", "key", "targets", "message"),
+    (
+        (
+            "attention",
+            "self_attention.linear_qkv.weight",
+            (
+                "model.layers.{layer_number}.self_attn.q_proj.weight",
+                "model.layers.{layer_number}.self_attn.k_proj.weight",
+            ),
+            "expected one direct target or three Q/K/V targets",
+        ),
+        (
+            "attention",
+            "self_attention.linear_qkv.weight",
+            (
+                "model.layers.{layer_number}.self_attn.q_proj.weight",
+                "model.layers.{layer_number}.self_attn.q_proj.bias",
+                "model.layers.{layer_number}.self_attn.v_proj.weight",
+            ),
+            "role 'q' is declared more than once",
+        ),
+        (
+            "mlp",
+            "mlp.linear_fc1.weight",
+            (
+                "model.layers.{layer_number}.mlp.gate_proj.weight",
+                "model.layers.{layer_number}.mlp.gate_proj.bias",
+            ),
+            "role 'gate' is declared more than once",
+        ),
+        (
+            "mlp",
+            "mlp.experts.linear_fc1",
+            (
+                "model.layers.{layer_number}.mlp.experts.{expert_id}.gate_proj.weight",
+                "model.layers.{layer_number}.mlp.experts.up_proj.weight",
+            ),
+            "mixes expert-specific and fused HF targets",
+        ),
+        (
+            "mlp",
+            "mlp.linear_fc1.weight",
+            (
+                "model.layers.{layer_number}.mlp.proj_a.weight",
+                "model.layers.{layer_number}.mlp.proj_b.weight",
+            ),
+            "must identify exactly one",
+        ),
+    ),
+)
+def test_ambiguous_multi_target_declarations_fail_explicitly(
+    category: str,
+    key: str,
+    targets: tuple[str, ...],
+    message: str,
+) -> None:
+    """Make each unsupported grouping fail instead of guessing semantics."""
+    attention_mapping = {key: targets} if category == "attention" else {}
+    mlp_mapping = {key: targets} if category == "mlp" else {}
+
+    with pytest.raises(ValueError, match=message):
+        compile_legacy_mapping_registry(
+            direct_mapping={},
+            attention_mapping=attention_mapping,
+            mlp_mapping=mlp_mapping,
+        )
+
+
+@pytest.mark.parametrize(
+    ("direct_mapping", "attention_mapping", "mlp_mapping", "message"),
+    (
+        (
+            {"decoder.{layer_number}.weight": "model.weight"},
+            {},
+            {},
+            "cannot contain placeholder",
+        ),
+        (
+            {},
+            {
+                "decoder.layers.*.self_attention.linear_proj.weight": (
+                    "model.layers.{layer_number}.self_attn.o_proj.weight",
+                )
+            },
+            {},
+            "must be a suffix",
+        ),
+        (
+            {},
+            {"self_attention.linear_proj.weight": ("model.layers.{layer_number}.blocks.{block_number}.weight",)},
+            {},
+            "unsupported placeholder",
+        ),
+        (
+            {},
+            {"self_attention.linear_proj.weight": ("model.layers.0.self_attn.o_proj.weight",)},
+            {},
+            "must contain exactly one",
+        ),
+        (
+            {},
+            {"same.weight": ("model.layers.{layer_number}.attention.weight",)},
+            {"same.weight": ("model.layers.{layer_number}.mlp.weight",)},
+            "duplicate Megatron pattern",
+        ),
+    ),
+)
+def test_invalid_normalization_contracts_fail_explicitly(
+    direct_mapping: Mapping[str, str],
+    attention_mapping: Mapping[str, tuple[str, ...]],
+    mlp_mapping: Mapping[str, tuple[str, ...]],
+    message: str,
+) -> None:
+    """Reject placeholders, normalized input, and duplicate normalized output."""
+    with pytest.raises(ValueError, match=message):
+        compile_legacy_mapping_registry(
+            direct_mapping=direct_mapping,
+            attention_mapping=attention_mapping,
+            mlp_mapping=mlp_mapping,
+        )
+
+
+def test_string_layer_targets_are_rejected_as_wrong_shape() -> None:
+    """Do not treat a string as a sequence of one-character targets."""
+    with pytest.raises(TypeError, match="sequence of HF targets"):
+        compile_legacy_mapping_registry(
+            direct_mapping={},
+            attention_mapping={"self_attention.linear_proj.weight": "model.layers.{layer_number}.weight"},
+            mlp_mapping={},
+        )
+
+
+def test_qwen3_moe_inherits_legacy_qwen2_moe_declarations() -> None:
+    """Keep Qwen3 MoE as a declaration-only inheritance migration proof."""
+    assert "_DIRECT_MAPPING" not in Qwen3MoELegacyMapping.__dict__
+    assert "_ATTENTION_MAPPING" not in Qwen3MoELegacyMapping.__dict__
+    assert "_MLP_MAPPING" not in Qwen3MoELegacyMapping.__dict__
+
+
+def test_qwen3_moe_proof_metadata_is_exactly_pinned() -> None:
+    """Pin the migrated proof independently of historical card evidence."""
+    assert HF_MODEL_ID == "Qwen/Qwen3-30B-A3B"
+    assert HF_REVISION == "ad44e777bcd18fa416d9da3bd8f70d33ebb85d39"
+    assert HF_ARCHITECTURE == "Qwen3MoeForCausalLM"
+    assert MIN_TRANSFORMERS_VERSION == "5.8.1"
+
+
+def test_qwen3_moe_stale_inherited_entries_are_compiler_coverage_only() -> None:
+    """Exclude inherited QKV-bias/shared-expert entries from parity claims."""
+    assert "self_attention.linear_qkv.bias" in Qwen3MoELegacyMapping._ATTENTION_MAPPING
+    assert {
+        "shared_experts.linear_fc1.weight",
+        "shared_experts.linear_fc2.weight",
+        "shared_experts.gate_weight",
+    } < set(Qwen3MoELegacyMapping._MLP_MAPPING)
+
+    compiled_patterns = {mapping.megatron_param for mapping in Qwen3MoELegacyMapping.mapping_registry().mappings}
+    production_patterns = {mapping.megatron_param for mapping in Qwen3MoEBridge().mapping_registry().mappings}
+    stale_patterns = {
+        "decoder.layers.*.self_attention.linear_qkv.bias",
+        "decoder.layers.*.shared_experts.linear_fc1.weight",
+        "decoder.layers.*.shared_experts.linear_fc2.weight",
+        "decoder.layers.*.shared_experts.gate_weight",
+    }
+
+    assert stale_patterns <= compiled_patterns
+    assert stale_patterns.isdisjoint(production_patterns)
+
+
+@pytest.mark.parametrize(
+    "pattern",
+    (
+        "decoder.layers.*.self_attention.linear_qkv.weight",
+        "decoder.layers.*.mlp.router.weight",
+        "decoder.layers.*.mlp.experts.linear_fc1.weight*",
+        "decoder.layers.*.mlp.experts.linear_fc2.weight*",
+        "decoder.layers.*.mlp.experts.local_experts.*.linear_fc1.weight",
+        "decoder.layers.*.mlp.experts.local_experts.*.linear_fc2.weight",
+    ),
+)
+def test_qwen3_moe_compiler_matches_selected_production_parameter_semantics(pattern: str) -> None:
+    """Prove parity only for actual Qwen3 parameters in the selected set."""
+    compiled = Qwen3MoELegacyMapping.mapping_registry()
+    production = Qwen3MoEBridge().mapping_registry()
+
+    _assert_same_mapping_semantics(compiled, production, pattern)

--- a/tests/unit_tests/legacy/test_mapping_compiler.py
+++ b/tests/unit_tests/legacy/test_mapping_compiler.py
@@ -310,7 +310,7 @@ def test_qwen3_moe_inherits_legacy_qwen2_moe_declarations() -> None:
 def test_qwen3_moe_proof_metadata_is_exactly_pinned() -> None:
     """Pin the migrated proof independently of historical card evidence."""
     assert HF_MODEL_ID == "Qwen/Qwen3-30B-A3B"
-    assert HF_REVISION == "ad44e777bcd18fa416d9da3bd8f70d33ebb85d39"
+    assert HF_REVISION == "ad44e777bcd18fa416d9da3bd8f70d33ebb85d39"  # pragma: allowlist secret
     assert HF_ARCHITECTURE == "Qwen3MoeForCausalLM"
     assert MIN_TRANSFORMERS_VERSION == "5.8.1"
 

--- a/tests/unit_tests/legacy/test_mbridge.py
+++ b/tests/unit_tests/legacy/test_mbridge.py
@@ -1,0 +1,374 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Contract tests for the bounded legacy MBridge facade."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+import torch
+from transformers import PretrainedConfig, Qwen3MoeConfig
+
+from megatron.bridge.legacy import AutoBridge
+from megatron.bridge.models.qwen.qwen3_moe_bridge import Qwen3MoEBridge
+
+
+class _ProviderDouble:
+    """Provider double with an explicit, non-extensible field contract."""
+
+    tensor_model_parallel_size = 1
+    params_dtype = torch.float32
+    fp16 = False
+    bf16 = False
+
+    def __init__(self, models: list[object] | None = None) -> None:
+        self.models = models or []
+        self.apply_calls: list[tuple[torch.dtype | None, dict[str, object]]] = []
+        self.finalize_calls = 0
+        self.provide_calls: list[dict[str, object]] = []
+        self.events: list[str] = []
+
+    def apply_overrides_and_finalize(
+        self,
+        dtype: torch.dtype | None = None,
+        overrides: Mapping[str, object] | None = None,
+    ) -> _ProviderDouble:
+        """Record and apply the already-validated overrides."""
+        values = dict(overrides or {})
+        self.events.append("apply_overrides")
+        self.apply_calls.append((dtype, values))
+        if dtype is not None:
+            self.params_dtype = dtype
+            self.fp16 = dtype == torch.float16
+            self.bf16 = dtype == torch.bfloat16
+        for name, value in values.items():
+            setattr(self, name, value)
+        self.finalize()
+        return self
+
+    def finalize(self) -> None:
+        """Record finalization."""
+        self.events.append("finalize")
+        self.finalize_calls += 1
+
+    def provide_distributed_model(self, **kwargs: object) -> list[object]:
+        """Return the exact legacy model list."""
+        self.events.append("provide_distributed_model")
+        self.provide_calls.append(kwargs)
+        return self.models
+
+
+def _facade(
+    *,
+    models: list[object] | None = None,
+) -> tuple[AutoBridge, Mock, _ProviderDouble]:
+    current_bridge = Mock()
+    provider = _ProviderDouble(models)
+    return AutoBridge(current_bridge, provider), current_bridge, provider
+
+
+def test_public_facade_surface_is_exactly_six_methods() -> None:
+    """Keep the compatibility surface bounded to the owner-approved methods."""
+    public_callables = {
+        name
+        for name, value in AutoBridge.__dict__.items()
+        if not name.startswith("_") and (callable(value) or isinstance(value, classmethod))
+    }
+
+    assert public_callables == {
+        "export_weights",
+        "from_config",
+        "get_model",
+        "load_weights",
+        "save_weights",
+        "set_extra_args",
+    }
+
+
+def test_from_config_wraps_current_auto_bridge_and_applies_validated_overrides() -> None:
+    """Build the facade through current bridge/provider code."""
+    config = PretrainedConfig()
+    current_bridge = Mock()
+    provider = _ProviderDouble()
+    current_bridge.to_megatron_provider.return_value = provider
+
+    with patch(
+        "megatron.bridge.legacy.mbridge.CurrentAutoBridge.from_hf_config",
+        return_value=current_bridge,
+    ) as from_hf_config:
+        facade = AutoBridge.from_config(
+            config,
+            dtype=torch.bfloat16,
+            tensor_model_parallel_size=2,
+        )
+
+    assert isinstance(facade, AutoBridge)
+    assert facade._bridge is current_bridge
+    assert facade._provider is provider
+    from_hf_config.assert_called_once_with(config)
+    current_bridge.to_megatron_provider.assert_called_once_with(load_weights=False)
+    assert provider.apply_calls == [
+        (torch.bfloat16, {"tensor_model_parallel_size": 2}),
+    ]
+    assert provider.params_dtype is torch.bfloat16
+    assert provider.tensor_model_parallel_size == 2
+
+
+def test_from_config_migrates_qwen3_moe_through_current_provider() -> None:
+    """Select the production Qwen3 MoE bridge and preserve its key config."""
+    config = Qwen3MoeConfig(
+        architectures=["Qwen3MoeForCausalLM"],
+        vocab_size=151936,
+        hidden_size=2048,
+        intermediate_size=6144,
+        num_hidden_layers=48,
+        num_attention_heads=32,
+        num_key_value_heads=4,
+        head_dim=128,
+        max_position_embeddings=40960,
+        rms_norm_eps=1e-6,
+        rope_parameters={"rope_theta": 1_000_000.0, "rope_type": "default"},
+        decoder_sparse_step=1,
+        moe_intermediate_size=768,
+        num_experts_per_tok=8,
+        num_local_experts=128,
+        norm_topk_prob=True,
+        router_aux_loss_coef=1e-3,
+        mlp_only_layers=[],
+        attention_bias=False,
+        tie_word_embeddings=False,
+    )
+
+    facade = AutoBridge.from_config(config)
+
+    assert isinstance(facade._bridge._model_bridge, Qwen3MoEBridge)
+    assert facade._provider.num_layers == 48
+    assert facade._provider.num_moe_experts == 128
+    assert facade._provider.moe_router_topk == 8
+    assert facade._provider.add_qkv_bias is False
+    assert facade._provider.qk_layernorm is True
+
+
+def test_from_config_rejects_invalid_dtype_without_rebuilding_provider() -> None:
+    """Reject a non-torch dtype before provider finalization."""
+    config = PretrainedConfig()
+    current_bridge = Mock()
+    provider = _ProviderDouble()
+    current_bridge.to_megatron_provider.return_value = provider
+
+    with (
+        patch(
+            "megatron.bridge.legacy.mbridge.CurrentAutoBridge.from_hf_config",
+            return_value=current_bridge,
+        ),
+        pytest.raises(TypeError, match="dtype must be a torch.dtype"),
+    ):
+        AutoBridge.from_config(config, dtype="bfloat16")
+
+    assert provider.apply_calls == []
+    assert provider.finalize_calls == 0
+
+
+def test_set_extra_args_rejects_all_overrides_before_any_mutation() -> None:
+    """Prevent foreign attributes and partial updates on provider dataclasses."""
+    facade, _, provider = _facade()
+
+    with pytest.raises(AttributeError, match="'phantom_field'"):
+        facade.set_extra_args(
+            tensor_model_parallel_size=4,
+            phantom_field=True,
+        )
+
+    assert provider.tensor_model_parallel_size == 1
+    assert not hasattr(provider, "phantom_field")
+    assert provider.apply_calls == []
+    assert provider.finalize_calls == 0
+
+
+def test_set_extra_args_applies_existing_fields_and_rebuilds_provider() -> None:
+    """Apply valid provider fields through the current rebuild path."""
+    facade, _, provider = _facade()
+
+    assert facade.set_extra_args(tensor_model_parallel_size=4) is None
+
+    assert provider.tensor_model_parallel_size == 4
+    assert provider.apply_calls == [(None, {"tensor_model_parallel_size": 4})]
+    assert provider.finalize_calls == 1
+    assert provider.events == ["apply_overrides", "finalize"]
+
+
+def test_from_config_set_extra_args_get_model_finalization_order() -> None:
+    """Finalize each override phase before final model construction."""
+    config = PretrainedConfig()
+    models = [object()]
+    current_bridge = Mock()
+    provider = _ProviderDouble(models)
+    current_bridge.to_megatron_provider.return_value = provider
+
+    with patch(
+        "megatron.bridge.legacy.mbridge.CurrentAutoBridge.from_hf_config",
+        return_value=current_bridge,
+    ):
+        facade = AutoBridge.from_config(config, tensor_model_parallel_size=2)
+
+    facade.set_extra_args(tensor_model_parallel_size=4)
+    result = facade.get_model(wrap_with_ddp=False)
+
+    assert result is models
+    assert provider.tensor_model_parallel_size == 4
+    assert provider.finalize_calls == 3
+    assert provider.events == [
+        "apply_overrides",
+        "finalize",
+        "apply_overrides",
+        "finalize",
+        "finalize",
+        "provide_distributed_model",
+    ]
+
+
+def test_from_config_validates_dtype_backing_fields() -> None:
+    """Require dtype aliases to correspond to real provider/config fields."""
+
+    class _MissingDtypeFieldProvider:
+        fp16 = False
+        bf16 = False
+
+        def __init__(self) -> None:
+            self.apply_calls: list[object] = []
+
+        def apply_overrides_and_finalize(self, **kwargs: object) -> None:
+            self.apply_calls.append(kwargs)
+
+    config = PretrainedConfig()
+    current_bridge = Mock()
+    provider = _MissingDtypeFieldProvider()
+    current_bridge.to_megatron_provider.return_value = provider
+
+    with (
+        patch(
+            "megatron.bridge.legacy.mbridge.CurrentAutoBridge.from_hf_config",
+            return_value=current_bridge,
+        ),
+        pytest.raises(AttributeError, match="'params_dtype'"),
+    ):
+        AutoBridge.from_config(config, dtype=torch.bfloat16)
+
+    assert provider.apply_calls == []
+
+
+def test_get_model_preserves_list_shape_and_optionally_loads_weights() -> None:
+    """Return the provider's list unchanged and load into that same list."""
+    models = [object(), object()]
+    facade, _, provider = _facade(models=models)
+    weights_path = Path("/model")
+
+    with patch.object(facade, "load_weights") as load_weights:
+        result = facade.get_model(
+            weights_path,
+            wrap_with_ddp=False,
+            use_cpu_initialization=True,
+        )
+
+    assert result is models
+    assert provider.finalize_calls == 1
+    assert provider.provide_calls == [
+        {
+            "wrap_with_ddp": False,
+            "use_cpu_initialization": True,
+        }
+    ]
+    load_weights.assert_called_once_with(models, weights_path)
+
+
+@pytest.mark.parametrize("method_name", ("load_weights", "export_weights", "save_weights"))
+def test_weight_apis_require_legacy_list_shape(method_name: str) -> None:
+    """Reject a single model instead of silently changing legacy shape."""
+    facade, _, _ = _facade()
+    method = getattr(facade, method_name)
+
+    with pytest.raises(TypeError, match="list of model chunks"):
+        if method_name == "export_weights":
+            method(object())
+        else:
+            method(object(), "/weights")
+
+
+def test_load_weights_delegates_to_current_bridge() -> None:
+    """Delegate supported loading directly to current conversion code."""
+    models = [object()]
+    facade, current_bridge, _ = _facade()
+
+    assert facade.load_weights(models, "/weights") is None
+
+    current_bridge.load_hf_weights.assert_called_once_with(models, hf_path="/weights")
+
+
+def test_load_weights_rejects_unrepresentable_memory_efficient_mode() -> None:
+    """Fail actionably instead of ignoring legacy load semantics."""
+    models = [object()]
+    facade, current_bridge, _ = _facade()
+
+    with pytest.raises(NotImplementedError, match="memory_efficient=True.*not representable"):
+        facade.load_weights(models, "/weights", memory_efficient=True)
+
+    current_bridge.load_hf_weights.assert_not_called()
+
+
+def test_export_weights_delegates_and_preserves_iterable() -> None:
+    """Return the current bridge's export iterable without materializing it."""
+    models = [object()]
+    facade, current_bridge, _ = _facade()
+    exported = iter((("weight", torch.ones(1)),))
+    current_bridge.export_hf_weights.return_value = exported
+
+    assert facade.export_weights(models) is exported
+
+    current_bridge.export_hf_weights.assert_called_once_with(models)
+
+
+def test_export_weights_rejects_unrepresentable_expert_layout() -> None:
+    """Fail actionably instead of ignoring separate-expert output."""
+    models = [object()]
+    facade, current_bridge, _ = _facade()
+
+    with pytest.raises(NotImplementedError, match="keep_stacked_experts=False.*not representable"):
+        facade.export_weights(models, keep_stacked_experts=False)
+
+    current_bridge.export_hf_weights.assert_not_called()
+
+
+def test_save_weights_delegates_to_current_bridge() -> None:
+    """Delegate supported saving directly to current save code."""
+    models = [object()]
+    facade, current_bridge, _ = _facade()
+
+    assert facade.save_weights(models, "/output") is None
+
+    current_bridge.save_hf_pretrained.assert_called_once_with(models, "/output")
+
+
+def test_save_weights_rejects_unrepresentable_memory_efficient_mode() -> None:
+    """Fail actionably instead of ignoring legacy save semantics."""
+    models = [object()]
+    facade, current_bridge, _ = _facade()
+
+    with pytest.raises(NotImplementedError, match="memory_efficient=True.*not representable"):
+        facade.save_weights(models, "/output", memory_efficient=True)
+
+    current_bridge.save_hf_pretrained.assert_not_called()


### PR DESCRIPTION
## What

- add a namespaced `megatron.bridge.legacy.AutoBridge` facade for the bounded legacy API: `from_config`, `get_model`, `load_weights`, `export_weights`, `save_weights`, and `set_extra_args`
- delegate model construction and checkpoint operations to the current AutoBridge/provider stack, preserving the legacy list-of-model-chunks contract
- compile legacy `_DIRECT_MAPPING`, `_ATTENTION_MAPPING`, and `_MLP_MAPPING` declarations into `AutoMapping`, `QKVMapping`, `GatedMLPMapping`, `FusedExpertMapping`, and `FusedGatedExpertMapping`
- add a Qwen3-30B-A3B MoE migration proof, including TE grouped and sequential expert layouts, without replacing or re-registering the production Qwen3 bridge

## Compatibility boundaries

- unknown provider overrides fail atomically instead of creating phantom config fields
- unsupported legacy `memory_efficient=True` and `keep_stacked_experts=False` modes fail with actionable errors
- Qwen2-inherited QKV-bias/shared-expert declarations are compiler coverage only; production parity is claimed only for parameters present in Qwen3-30B-A3B
- the existing Qwen3 model verification card and production dispatch registration are unchanged

## Verification

- `uv run --no-project --with pre-commit pre-commit run --all-files`
- `uv run --no-project --python /opt/venv/bin/python python -m pytest tests/unit_tests/legacy -q` in `nvcr.io/nvidia/nemo:26.06.01` with the repository-pinned MCore: **41 passed**
- exact cached config check for `Qwen/Qwen3-30B-A3B@ad44e777bcd18fa416d9da3bd8f70d33ebb85d39` using Transformers 5.8.1
- `skills/create-model-verification-card/scripts/validate_card.py examples/model_verification_cards/qwen3-30b-a3b/card.yaml`
