### PR TITLE
feat(training): add NVFP4 training callback with FP8 healing (r0.5.0)

### DIFF
--- a/docs/training/mixed-precision.md
+++ b/docs/training/mixed-precision.md
@@ -137,6 +137,60 @@ from megatron.bridge.recipes.llama import llama3_8b_low_precision_pretrain_confi
 cfg = llama3_8b_low_precision_pretrain_config("bf16_with_nvfp4_mixed")
 ```
 
+### FP8 Healing
+
+NVFP4 training can leave an accuracy gap at the end of training. The *FP8 healing*
+technique closes it: run most training steps in NVFP4, then switch the quantization
+recipe to FP8 for the final steps. Megatron Bridge ships this as
+{py:class}`bridge.training.nvfp4_healing.NVFP4HealingCallback`, the technique used in
+NVIDIA's MLPerf Llama-2 70B LoRA submission.
+
+The callback composes with the NVFP4 recipe — configure `bf16_with_nvfp4_mixed` as usual
+and attach the callback:
+
+```python
+from megatron.bridge.training.finetune import finetune
+from megatron.bridge.training.nvfp4_healing import NVFP4HealingCallback, NVFP4HealingConfig
+
+cfg.mixed_precision = "bf16_with_nvfp4_mixed"
+healing = NVFP4HealingCallback(
+    NVFP4HealingConfig(
+        healing_iter=350,          # steps 0..349 run NVFP4, steps 350+ run FP8
+        healing_recipe="mxfp8",    # or "delayed" (DelayedScaling)
+        pre_quantize_base_weights=True,  # PEFT/frozen base weights only
+    )
+)
+finetune(cfg, forward_step, callbacks=[healing])
+```
+
+#### NVFP4 Healing Configuration Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `healing_iter` | `int` | required | Number of NVFP4 steps; steps at index >= `healing_iter` run in FP8 |
+| `healing_recipe` | `str` | required | `"delayed"` (Transformer Engine `DelayedScaling`) or `"mxfp8"` (`MXFP8BlockScaling`, Blackwell only) |
+| `pre_quantize_base_weights` | `bool` | `False` | Replace frozen base weights with NVFP4 tensors at startup and stash FP8 copies for healing. Requires frozen base weights (PEFT/LoRA) |
+| `store_quantized_params_on_gpu` | `bool` | `False` | Keep the FP8 stash on GPU instead of pinned host memory |
+| `fp8_amax_history_len` | `int` | `1024` | `DelayedScaling` amax history length |
+| `fp8_amax_compute_algo` | `str` | `"max"` | `DelayedScaling` amax compute algorithm |
+| `reduce_amax` | `bool` | `True` | `DelayedScaling` amax reduction |
+| `reset_cuda_graph_warmup` | `bool` | `False` | Re-run CUDA-graph warmup steps after healing before re-capture |
+
+Layer-structure settings (`first_last_layers_bf16`, `num_layers_at_start_in_bf16`,
+`num_layers_at_end_in_bf16`, `fp8_dot_product_attention`,
+`use_transformer_engine_op_fuser`) are read from the model config at runtime and must
+not be duplicated in the healing config.
+
+Constraints:
+
+- The NVFP4 phase requires Blackwell-generation GPUs and Transformer Engine >= 2.7.0;
+  `"mxfp8"` healing also requires Blackwell, while `"delayed"` healing runs on Hopper-class
+  hardware too.
+- `pre_quantize_base_weights=True` requires the quantized base weights to be frozen
+  (e.g. LoRA fine-tuning); the callback raises an error if it finds trainable target weights.
+- Full-iteration CUDA graphs are reset at the healing step so they re-capture with the
+  FP8 recipe.
+
 NVFP4 is related to FP8 in that both use Transformer Engine low-precision kernels and BF16 fallback for non-quantized state, but the configuration knobs are separate. Use FP8 recipes on Hopper or Blackwell when FP8 is the target precision; use NVFP4 recipes on Blackwell when the model and hardware have been validated for 4-bit training.
 
 ## Available Mixed Precision Recipes

--- a/src/megatron/bridge/training/nvfp4_healing.py
+++ b/src/megatron/bridge/training/nvfp4_healing.py
@@ -1,0 +1,162 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""NVFP4 training with FP8 healing.
+
+This module provides :class:`NVFP4HealingCallback`, which implements the FP8-healing
+technique for NVFP4 training: run most training steps in NVFP4 (see the
+``bf16_with_nvfp4_mixed`` recipe in ``megatron.bridge.training.mixed_precision``), then
+switch the quantization recipe to FP8 at a configurable step so the final phase of
+training "heals" model quality. This is the technique used in NVIDIA's MLPerf
+Llama-2 70B LoRA submission.
+
+Optionally, when base weights are frozen (PEFT/LoRA), the callback pre-quantizes them:
+NVFP4 tensors replace the BF16 weights on device for the NVFP4 phase (saving memory),
+while FP8 copies are stashed in pinned host memory (or on device) and swapped in when
+healing starts.
+
+The recipe switch works by replacing ``megatron.core.fp4_utils.get_fp4_recipe`` with a
+function returning the FP8 healing recipe. Megatron-Core resolves that function at call
+time, so the change takes effect on the next forward pass (and on CUDA-graph re-capture,
+which the callback triggers by resetting ``FullCudaGraphWrapper`` state). The original
+function is restored in ``on_train_end``. ``config.fp4`` stays truthy throughout, so the
+model keeps using the same quantization autocast code path it was built with.
+
+Example:
+    ```python
+    from megatron.bridge.training.nvfp4_healing import NVFP4HealingCallback, NVFP4HealingConfig
+
+    cfg.mixed_precision = "bf16_with_nvfp4_mixed"
+    healing = NVFP4HealingCallback(
+        NVFP4HealingConfig(
+            healing_iter=350,
+            healing_recipe="mxfp8",
+            pre_quantize_base_weights=True,
+        )
+    )
+    finetune(cfg, forward_step, callbacks=[healing])
+    ```
+"""
+
+from __future__ import annotations
+
+import gc
+import logging
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import torch
+
+from megatron.bridge.training.callbacks import Callback, CallbackContext
+from megatron.bridge.utils.common_utils import print_rank_0
+
+
+if TYPE_CHECKING:
+    from megatron.core.transformer.transformer_config import TransformerConfig
+
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+VALID_HEALING_RECIPES: tuple[str, ...] = ("delayed", "mxfp8")
+
+
+@dataclass(kw_only=True)
+class NVFP4HealingConfig:
+    """Configuration for :class:`NVFP4HealingCallback`.
+
+    Attributes:
+        healing_iter: Number of training steps to run in NVFP4 before switching to FP8.
+            Steps with index >= ``healing_iter`` (0-based) run with the FP8 healing
+            recipe. Must be >= 1.
+        healing_recipe: FP8 recipe used for healing. ``"delayed"`` selects Transformer
+            Engine ``DelayedScaling``; ``"mxfp8"`` selects ``MXFP8BlockScaling``
+            (Blackwell only). Naming matches ``MixedPrecisionConfig.fp8_recipe``.
+        pre_quantize_base_weights: Pre-quantize base weights of Transformer Engine
+            ``Linear``/``LayerNormLinear`` modules at startup: NVFP4 replaces the
+            weights on device, FP8 copies are stashed for healing. Requires the target
+            weights to be frozen (e.g. PEFT/LoRA fine-tuning).
+        store_quantized_params_on_gpu: Keep the stashed FP8 weights on GPU instead of
+            pinned host memory (trades GPU memory for a zero-copy healing switch).
+        fp8_amax_history_len: ``DelayedScaling`` amax history length.
+        fp8_amax_compute_algo: ``DelayedScaling`` amax compute algorithm.
+        reduce_amax: ``DelayedScaling`` amax reduction across the amax group.
+        reset_cuda_graph_warmup: After healing, also reset the CUDA-graph warmup
+            counters so warmup steps run again before graph re-capture.
+    """
+
+    healing_iter: int
+    healing_recipe: str
+    pre_quantize_base_weights: bool = False
+    store_quantized_params_on_gpu: bool = False
+    fp8_amax_history_len: int = 1024
+    fp8_amax_compute_algo: str = "max"
+    reduce_amax: bool = True
+    reset_cuda_graph_warmup: bool = False
+
+    def __post_init__(self) -> None:
+        """Validate field values."""
+        if self.healing_recipe not in VALID_HEALING_RECIPES:
+            raise ValueError(f"healing_recipe must be one of {VALID_HEALING_RECIPES}, got {self.healing_recipe!r}")
+        if self.healing_iter < 1:
+            raise ValueError(f"healing_iter must be >= 1, got {self.healing_iter}")
+
+
+def _require_te() -> None:
+    """Raise a descriptive error if Transformer Engine with NVFP4 support is unavailable."""
+    from megatron.core.utils import is_te_min_version
+
+    try:
+        import transformer_engine  # noqa: F401
+    except ImportError as err:
+        raise RuntimeError(
+            "NVFP4 healing requires Transformer Engine >= 2.7.0.dev0, which is not installed."
+        ) from err
+    if not is_te_min_version("2.7.0.dev0"):
+        raise RuntimeError("NVFP4 healing requires Transformer Engine >= 2.7.0.dev0 for NVFP4BlockScaling support.")
+
+
+def _unwrap_model_chunk(chunk: torch.nn.Module) -> torch.nn.Module:
+    """Unwrap DDP/Float16Module-style wrappers by following ``.module`` attributes."""
+    current = chunk
+    while True:
+        child = getattr(current, "module", None)
+        if child is None:
+            return current
+        current = child
+
+
+class NVFP4HealingCallback(Callback):
+    """Training callback implementing NVFP4 training with FP8 healing.
+
+    See the module docstring for the technique overview and a usage example. The
+    callback overrides three events:
+
+    - ``on_data_init_start``: optional base-weight pre-quantization.
+    - ``on_train_step_end``: applies the healing switch once, at ``healing_iter``.
+    - ``on_train_end``: restores the original Megatron-Core FP4 recipe function.
+    """
+
+    def __init__(self, config: NVFP4HealingConfig) -> None:
+        """Initialize the callback with a validated config."""
+        self.config = config
+        self._healed: bool = False
+        self._patched: bool = False
+        self._original_get_fp4_recipe: Any = None
+        self._fp8_stash: list[Any] = []
+
+    @property
+    def healed(self) -> bool:
+        """Whether the FP8 healing switch has been applied."""
+        return self._healed

--- a/src/megatron/bridge/training/nvfp4_healing.py
+++ b/src/megatron/bridge/training/nvfp4_healing.py
@@ -55,7 +55,7 @@ import gc
 import logging
 from collections.abc import Iterator
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import torch
 
@@ -120,9 +120,7 @@ def _require_te() -> None:
     try:
         import transformer_engine  # noqa: F401
     except ImportError as err:
-        raise RuntimeError(
-            "NVFP4 healing requires Transformer Engine >= 2.7.0.dev0, which is not installed."
-        ) from err
+        raise RuntimeError("NVFP4 healing requires Transformer Engine >= 2.7.0.dev0, which is not installed.") from err
     if not is_te_min_version("2.7.0.dev0"):
         raise RuntimeError("NVFP4 healing requires Transformer Engine >= 2.7.0.dev0 for NVFP4BlockScaling support.")
 
@@ -302,7 +300,7 @@ class NVFP4HealingCallback(Callback):
         count = 0
         with torch.no_grad():
             for _, module in self._iter_quantizable_modules(model):
-                weight = module.weight
+                weight: Any = module.weight
                 if weight.requires_grad:
                     raise ValueError(
                         "pre_quantize_base_weights=True requires frozen base weights "
@@ -340,9 +338,9 @@ class NVFP4HealingCallback(Callback):
             )
         model_config = self._get_model_config(model)
         device = torch.cuda.current_device()
-        transfer_stream = torch.cuda.Stream()
+        transfer_stream = torch.cuda.Stream()  # type: ignore[no-untyped-call]
         swaps: list[tuple[torch.nn.Module, Any, Any]] = []
-        fuser_layers: dict[int, torch.nn.Module] = {}
+        fuser_layers: dict[int, Any] = {}
 
         with torch.no_grad():
             # Batch all H2D transfers on a dedicated stream, synchronize once, then swap
@@ -377,14 +375,16 @@ class NVFP4HealingCallback(Callback):
     @staticmethod
     def _get_model_config(model: list[torch.nn.Module]) -> TransformerConfig:
         """Return the Megatron-Core ``TransformerConfig`` of the (unwrapped) first chunk."""
-        return _unwrap_model_chunk(model[0]).config
+        unwrapped: Any = _unwrap_model_chunk(model[0])
+        return cast("TransformerConfig", unwrapped.config)
 
     @staticmethod
     def _is_target_module(module: torch.nn.Module) -> bool:
         """Whether ``module`` is a quantizable Transformer Engine linear with a weight."""
         import transformer_engine.pytorch as te
 
-        return isinstance(module, (te.Linear, te.LayerNormLinear)) and getattr(module, "weight", None) is not None
+        is_te_linear = bool(isinstance(module, (te.Linear, te.LayerNormLinear)))
+        return is_te_linear and getattr(module, "weight", None) is not None
 
     @staticmethod
     def _keep_layer_in_bf16(global_layer_idx: int, model_config: TransformerConfig) -> bool:
@@ -393,7 +393,7 @@ class NVFP4HealingCallback(Callback):
             return False
         if global_layer_idx < model_config.num_layers_at_start_in_bf16:
             return True
-        return global_layer_idx >= model_config.num_layers - model_config.num_layers_at_end_in_bf16
+        return bool(global_layer_idx >= model_config.num_layers - model_config.num_layers_at_end_in_bf16)
 
     def _iter_quantizable_modules(
         self, model: list[torch.nn.Module]
@@ -406,7 +406,7 @@ class NVFP4HealingCallback(Callback):
         """
         model_config = self._get_model_config(model)
         for chunk in model:
-            unwrapped = _unwrap_model_chunk(chunk)
+            unwrapped: Any = _unwrap_model_chunk(chunk)
             try:
                 layers = unwrapped.decoder.layers
             except AttributeError as err:

--- a/src/megatron/bridge/training/nvfp4_healing.py
+++ b/src/megatron/bridge/training/nvfp4_healing.py
@@ -160,3 +160,38 @@ class NVFP4HealingCallback(Callback):
     def healed(self) -> bool:
         """Whether the FP8 healing switch has been applied."""
         return self._healed
+
+    # ------------------------------------------------------------------ hooks
+
+    def on_data_init_start(self, context: CallbackContext) -> None:
+        """Pre-quantize frozen base weights if ``pre_quantize_base_weights`` is set."""
+        if not self.config.pre_quantize_base_weights:
+            return
+        gc.collect()
+        torch.cuda.empty_cache()
+        self._pre_quantize(context.model)
+
+    def on_train_step_end(self, context: CallbackContext) -> None:
+        """Apply the FP8 healing switch once, when ``healing_iter`` is reached."""
+        if self._healed:
+            return
+        if context.state.train_state.step + 1 != self.config.healing_iter:
+            return
+        print_rank_0(f"NVFP4 healing: switching to FP8 ('{self.config.healing_recipe}') recipe...")
+        self._apply_healing(context)
+        self._healed = True
+
+    def on_train_end(self, context: CallbackContext) -> None:
+        """Restore the original Megatron-Core FP4 recipe function."""
+        self._restore_fp4_recipe()
+
+    # ---------------------------------------------------------------- healing
+
+    def _apply_healing(self, context: CallbackContext) -> None:
+        raise NotImplementedError  # implemented in a later task
+
+    def _restore_fp4_recipe(self) -> None:
+        raise NotImplementedError  # implemented in a later task
+
+    def _pre_quantize(self, model: list[torch.nn.Module]) -> None:
+        raise NotImplementedError  # implemented in a later task

--- a/src/megatron/bridge/training/nvfp4_healing.py
+++ b/src/megatron/bridge/training/nvfp4_healing.py
@@ -226,5 +226,21 @@ class NVFP4HealingCallback(Callback):
         fp4_utils.get_fp4_recipe = self._original_get_fp4_recipe
         self._patched = False
 
+    def _reset_cuda_graphs(self) -> None:
+        """Clear captured full-iteration CUDA graphs so they re-capture with the new recipe."""
+        if torch.distributed.is_initialized():
+            torch.distributed.barrier()
+        try:
+            from megatron.core.full_cuda_graph import FullCudaGraphWrapper
+        except ImportError:
+            return
+        if not hasattr(FullCudaGraphWrapper, "cuda_graph"):
+            return
+        for stage in ("training", "validation"):
+            FullCudaGraphWrapper.cuda_graph[stage] = None
+            FullCudaGraphWrapper.result[stage] = None
+            if self.config.reset_cuda_graph_warmup:
+                FullCudaGraphWrapper.curr_iteration[stage] = 0
+
     def _pre_quantize(self, model: list[torch.nn.Module]) -> None:
         raise NotImplementedError  # implemented in a later task

--- a/src/megatron/bridge/training/nvfp4_healing.py
+++ b/src/megatron/bridge/training/nvfp4_healing.py
@@ -188,7 +188,15 @@ class NVFP4HealingCallback(Callback):
     # ---------------------------------------------------------------- healing
 
     def _apply_healing(self, context: CallbackContext) -> None:
-        raise NotImplementedError  # implemented in a later task
+        """Switch training to the FP8 healing recipe (and pre-quantized FP8 weights)."""
+        model = context.model
+        model_config = self._get_model_config(model)
+        self._reset_cuda_graphs()
+        if self.config.pre_quantize_base_weights:
+            if not self._fp8_stash:
+                raise RuntimeError("FP8 healing weight stash is empty; pre-quantization did not run.")
+            self._swap_in_fp8_weights(model)
+        self._patch_fp4_recipe(self._build_healing_recipe(model_config))
 
     def _build_healing_recipe(self, model_config: TransformerConfig) -> Any:
         """Construct the FP8 recipe object used for the healing phase."""
@@ -309,6 +317,60 @@ class NVFP4HealingCallback(Callback):
                 setattr(module, "weight", torch.nn.Parameter(nvfp4_param, requires_grad=False))
                 count += 1
         print_rank_0(f"NVFP4 healing: pre-quantized {count} weights (NVFP4 on device, FP8 stashed).")
+
+    # ------------------------------------------------------------ weight swap
+
+    def _move_stash_entry_to_device(self, weight: Any, device: Any) -> None:
+        """Asynchronously move a stashed quantized tensor's storages to ``device``."""
+        if self.config.healing_recipe == "mxfp8":
+            weight._rowwise_data = weight._rowwise_data.to(device, non_blocking=True)
+            weight._columnwise_data = weight._columnwise_data.to(device, non_blocking=True)
+        else:
+            weight._data = weight._data.to(device, non_blocking=True)
+            if getattr(weight, "_transpose", None) is not None:
+                weight._transpose = weight._transpose.to(device, non_blocking=True)
+
+    def _swap_in_fp8_weights(self, model: list[torch.nn.Module]) -> None:
+        """Replace pre-quantized NVFP4 weights with the stashed FP8 weights."""
+        modules = list(self._iter_quantizable_modules(model))
+        if len(modules) != len(self._fp8_stash):
+            raise RuntimeError(
+                f"FP8 weight stash size ({len(self._fp8_stash)}) does not match the quantizable module "
+                f"count ({len(modules)}); the model structure changed after pre-quantization."
+            )
+        model_config = self._get_model_config(model)
+        device = torch.cuda.current_device()
+        transfer_stream = torch.cuda.Stream()
+        swaps: list[tuple[torch.nn.Module, Any, Any]] = []
+        fuser_layers: dict[int, torch.nn.Module] = {}
+
+        with torch.no_grad():
+            # Batch all H2D transfers on a dedicated stream, synchronize once, then swap
+            # pointers - avoids per-weight synchronization stalls.
+            with torch.cuda.stream(transfer_stream):
+                for (layer, module), new_weight in zip(modules, self._fp8_stash):
+                    if not self.config.store_quantized_params_on_gpu:
+                        self._move_stash_entry_to_device(new_weight, device)
+                    swaps.append((module, module.weight, new_weight))
+                    if model_config.use_transformer_engine_op_fuser:
+                        fuser_layers[id(layer)] = layer
+            transfer_stream.synchronize()
+
+            for module, old_weight, new_weight in swaps:
+                setattr(module, "weight", torch.nn.Parameter(new_weight, requires_grad=False))
+                if hasattr(old_weight, "clear"):
+                    old_weight.clear()
+
+            for layer in fuser_layers.values():
+                layer.mlp._fused_impl = (layer.mlp._make_fused_impl(),)
+                layer.self_attention.linear_proj._fused_branches = (
+                    layer.self_attention.linear_proj._make_fused_branches()
+                )
+                layer.self_attention.linear_qkv._fused_branches = (
+                    layer.self_attention.linear_qkv._make_fused_branches()
+                )
+
+        self._fp8_stash = []
 
     # ------------------------------------------------------------- traversal
 

--- a/src/megatron/bridge/training/nvfp4_healing.py
+++ b/src/megatron/bridge/training/nvfp4_healing.py
@@ -190,8 +190,41 @@ class NVFP4HealingCallback(Callback):
     def _apply_healing(self, context: CallbackContext) -> None:
         raise NotImplementedError  # implemented in a later task
 
+    def _build_healing_recipe(self, model_config: TransformerConfig) -> Any:
+        """Construct the FP8 recipe object used for the healing phase."""
+        _require_te()
+        from transformer_engine.common.recipe import DelayedScaling, MXFP8BlockScaling
+
+        if self.config.healing_recipe == "delayed":
+            return DelayedScaling(
+                amax_history_len=self.config.fp8_amax_history_len,
+                amax_compute_algo=self.config.fp8_amax_compute_algo,
+                reduce_amax=self.config.reduce_amax,
+                fp8_dpa=model_config.fp8_dot_product_attention,
+            )
+        return MXFP8BlockScaling()
+
+    def _patch_fp4_recipe(self, recipe: Any) -> None:
+        """Make ``megatron.core.fp4_utils.get_fp4_recipe`` return ``recipe``."""
+        import megatron.core.fp4_utils as fp4_utils
+
+        if not self._patched:
+            self._original_get_fp4_recipe = fp4_utils.get_fp4_recipe
+            self._patched = True
+
+        def healing_get_fp4_recipe(config: Any) -> Any:
+            return recipe
+
+        fp4_utils.get_fp4_recipe = healing_get_fp4_recipe
+
     def _restore_fp4_recipe(self) -> None:
-        raise NotImplementedError  # implemented in a later task
+        """Restore the original ``get_fp4_recipe`` if it was patched."""
+        if not self._patched:
+            return
+        import megatron.core.fp4_utils as fp4_utils
+
+        fp4_utils.get_fp4_recipe = self._original_get_fp4_recipe
+        self._patched = False
 
     def _pre_quantize(self, model: list[torch.nn.Module]) -> None:
         raise NotImplementedError  # implemented in a later task

--- a/src/megatron/bridge/training/nvfp4_healing.py
+++ b/src/megatron/bridge/training/nvfp4_healing.py
@@ -242,8 +242,73 @@ class NVFP4HealingCallback(Callback):
             if self.config.reset_cuda_graph_warmup:
                 FullCudaGraphWrapper.curr_iteration[stage] = 0
 
+    # ------------------------------------------------------- pre-quantization
+
+    def _build_quantizers(self) -> tuple[Any, Any]:
+        """Build the NVFP4 quantizer and the FP8 quantizer matching ``healing_recipe``."""
+        _require_te()
+        import transformer_engine_torch as tex
+        from transformer_engine.pytorch.tensor.float8_tensor import Float8Quantizer
+        from transformer_engine.pytorch.tensor.mxfp8_tensor import MXFP8Quantizer
+        from transformer_engine.pytorch.tensor.nvfp4_tensor import NVFP4Quantizer
+
+        nvfp4_quantizer = NVFP4Quantizer()
+        if self.config.healing_recipe == "delayed":
+            device = torch.cuda.current_device()
+            fp8_quantizer = Float8Quantizer(
+                scale=torch.ones(1, dtype=torch.float32, device=device),
+                amax=torch.zeros(1, dtype=torch.float32, device=device),
+                fp8_dtype=tex.DType.kFloat8E4M3,
+            )
+        else:
+            fp8_quantizer = MXFP8Quantizer(tex.DType.kFloat8E4M3)
+        return nvfp4_quantizer, fp8_quantizer
+
+    def _validate_quantized(self, qparam: Any, kind: str) -> None:
+        """Check that a quantized tensor carries the storages its kind requires."""
+        if kind in ("nvfp4", "mxfp8"):
+            if qparam._rowwise_data is None or qparam._columnwise_data is None:
+                raise RuntimeError(f"Quantized '{kind}' tensor is missing rowwise/columnwise data.")
+        else:
+            if qparam._data is None:
+                raise RuntimeError("Quantized FP8 tensor is missing data.")
+
+    def _stash_fp8_copy(self, qparam: Any) -> None:
+        """Clone a quantized FP8 tensor and stash it (pinned host memory by default)."""
+        qparam = qparam.clone()
+        if not self.config.store_quantized_params_on_gpu:
+            # Pinned host memory enables fast async H2D transfer at healing time.
+            if self.config.healing_recipe == "mxfp8":
+                qparam._rowwise_data = qparam._rowwise_data.cpu().pin_memory()
+                qparam._columnwise_data = qparam._columnwise_data.cpu().pin_memory()
+            else:
+                qparam._data = qparam._data.cpu().pin_memory()
+                if getattr(qparam, "_transpose", None) is not None:
+                    qparam._transpose = qparam._transpose.cpu().pin_memory()
+        self._fp8_stash.append(qparam)
+
     def _pre_quantize(self, model: list[torch.nn.Module]) -> None:
-        raise NotImplementedError  # implemented in a later task
+        """Replace frozen base weights with NVFP4 tensors and stash FP8 copies for healing."""
+        nvfp4_quantizer, fp8_quantizer = self._build_quantizers()
+        fp8_kind = self.config.healing_recipe
+        count = 0
+        with torch.no_grad():
+            for _, module in self._iter_quantizable_modules(model):
+                weight = module.weight
+                if weight.requires_grad:
+                    raise ValueError(
+                        "pre_quantize_base_weights=True requires frozen base weights "
+                        f"(e.g. PEFT/LoRA fine-tuning); found a trainable weight on {type(module).__name__}."
+                    )
+                fp8_param = fp8_quantizer(weight.detach())
+                self._validate_quantized(fp8_param, fp8_kind)
+                self._stash_fp8_copy(fp8_param)
+
+                nvfp4_param = nvfp4_quantizer(weight.detach())
+                self._validate_quantized(nvfp4_param, "nvfp4")
+                setattr(module, "weight", torch.nn.Parameter(nvfp4_param, requires_grad=False))
+                count += 1
+        print_rank_0(f"NVFP4 healing: pre-quantized {count} weights (NVFP4 on device, FP8 stashed).")
 
     # ------------------------------------------------------------- traversal
 

--- a/src/megatron/bridge/training/nvfp4_healing.py
+++ b/src/megatron/bridge/training/nvfp4_healing.py
@@ -244,3 +244,53 @@ class NVFP4HealingCallback(Callback):
 
     def _pre_quantize(self, model: list[torch.nn.Module]) -> None:
         raise NotImplementedError  # implemented in a later task
+
+    # ------------------------------------------------------------- traversal
+
+    @staticmethod
+    def _get_model_config(model: list[torch.nn.Module]) -> TransformerConfig:
+        """Return the Megatron-Core ``TransformerConfig`` of the (unwrapped) first chunk."""
+        return _unwrap_model_chunk(model[0]).config
+
+    @staticmethod
+    def _is_target_module(module: torch.nn.Module) -> bool:
+        """Whether ``module`` is a quantizable Transformer Engine linear with a weight."""
+        import transformer_engine.pytorch as te
+
+        return isinstance(module, (te.Linear, te.LayerNormLinear)) and getattr(module, "weight", None) is not None
+
+    @staticmethod
+    def _keep_layer_in_bf16(global_layer_idx: int, model_config: TransformerConfig) -> bool:
+        """Mirror Megatron-Core's first/last-layers-in-BF16 selection (see ``get_fp4_context``)."""
+        if not model_config.first_last_layers_bf16:
+            return False
+        if global_layer_idx < model_config.num_layers_at_start_in_bf16:
+            return True
+        return global_layer_idx >= model_config.num_layers - model_config.num_layers_at_end_in_bf16
+
+    def _iter_quantizable_modules(
+        self, model: list[torch.nn.Module]
+    ) -> Iterator[tuple[torch.nn.Module, torch.nn.Module]]:
+        """Yield ``(layer, module)`` for every quantizable TE linear, in deterministic order.
+
+        Iterates all model chunks (virtual pipeline stages) and uses each layer's global
+        ``layer_number`` (1-based) so BF16 first/last-layer selection is correct under
+        pipeline parallelism. Layers Megatron-Core keeps in BF16 are skipped.
+        """
+        model_config = self._get_model_config(model)
+        for chunk in model:
+            unwrapped = _unwrap_model_chunk(chunk)
+            try:
+                layers = unwrapped.decoder.layers
+            except AttributeError as err:
+                raise RuntimeError(
+                    "NVFP4HealingCallback requires a Megatron-Core GPT-style model exposing "
+                    f"`decoder.layers`; got {type(unwrapped).__name__}."
+                ) from err
+            for local_idx, layer in enumerate(layers):
+                global_idx = getattr(layer, "layer_number", local_idx + 1) - 1
+                if self._keep_layer_in_bf16(global_idx, model_config):
+                    continue
+                for _, module in layer.named_modules():
+                    if self._is_target_module(module):
+                        yield layer, module

--- a/tests/unit_tests/training/test_nvfp4_healing.py
+++ b/tests/unit_tests/training/test_nvfp4_healing.py
@@ -14,6 +14,9 @@
 
 """Unit tests for the NVFP4 FP8-healing callback."""
 
+import contextlib
+import sys
+import types
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
@@ -404,3 +407,184 @@ class TestHookRegistration:
         assert manager.has_callbacks("on_train_end")
         assert not manager.has_callbacks("on_train_start")
         assert not manager.has_callbacks("on_train_step_start")
+
+
+class TestRequireTE:
+    def test_raises_when_te_version_too_old(self, monkeypatch):
+        import megatron.core.utils as mcu
+
+        from megatron.bridge.training.nvfp4_healing import _require_te
+
+        monkeypatch.setattr(mcu, "is_te_min_version", lambda v: False)
+        with pytest.raises(RuntimeError, match="Transformer Engine"):
+            _require_te()
+
+
+class TestOnDataInitStart:
+    def test_prequantizes_when_enabled(self):
+        cb = NVFP4HealingCallback(make_config(pre_quantize_base_weights=True))
+        ctx = Mock()
+        ctx.model = [make_fake_chunk([1])]
+        with patch.object(cb, "_pre_quantize") as pre_quantize, patch("torch.cuda.empty_cache"):
+            cb.on_data_init_start(ctx)
+            pre_quantize.assert_called_once_with(ctx.model)
+
+
+class TestResetCudaGraphsFallbacks:
+    def test_missing_module_is_noop(self, monkeypatch):
+        import builtins
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "megatron.core.full_cuda_graph":
+                raise ImportError("simulated")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        cb = NVFP4HealingCallback(make_config())
+        cb._reset_cuda_graphs()  # returns cleanly
+
+    def test_missing_attr_is_noop(self, monkeypatch):
+        from megatron.core.full_cuda_graph import FullCudaGraphWrapper
+
+        monkeypatch.delattr(FullCudaGraphWrapper, "cuda_graph", raising=False)
+        cb = NVFP4HealingCallback(make_config())
+        cb._reset_cuda_graphs()  # returns cleanly
+
+
+def _inject_fake_te_quantizers(monkeypatch):
+    """Inject fake Transformer Engine quantizer modules so _build_quantizers runs CPU-only."""
+    tex = types.ModuleType("transformer_engine_torch")
+    tex.DType = types.SimpleNamespace(kFloat8E4M3="e4m3")
+    f8 = types.ModuleType("transformer_engine.pytorch.tensor.float8_tensor")
+    f8.Float8Quantizer = lambda **kwargs: ("float8", kwargs)
+    mx = types.ModuleType("transformer_engine.pytorch.tensor.mxfp8_tensor")
+    mx.MXFP8Quantizer = lambda dtype: ("mxfp8", dtype)
+    nv = types.ModuleType("transformer_engine.pytorch.tensor.nvfp4_tensor")
+    nv.NVFP4Quantizer = lambda: "nvfp4"
+    monkeypatch.setitem(sys.modules, "transformer_engine_torch", tex)
+    monkeypatch.setitem(sys.modules, "transformer_engine.pytorch.tensor.float8_tensor", f8)
+    monkeypatch.setitem(sys.modules, "transformer_engine.pytorch.tensor.mxfp8_tensor", mx)
+    monkeypatch.setitem(sys.modules, "transformer_engine.pytorch.tensor.nvfp4_tensor", nv)
+
+
+class TestBuildQuantizers:
+    def test_delayed_builds_float8_quantizer(self, monkeypatch):
+        import megatron.bridge.training.nvfp4_healing as mod
+
+        monkeypatch.setattr(mod, "_require_te", lambda: None)
+        monkeypatch.setattr(torch.cuda, "current_device", lambda: "cpu")
+        _inject_fake_te_quantizers(monkeypatch)
+
+        cb = NVFP4HealingCallback(make_config(healing_recipe="delayed"))
+        nvfp4_q, fp8_q = cb._build_quantizers()
+        assert nvfp4_q == "nvfp4"
+        assert fp8_q[0] == "float8"
+        assert fp8_q[1]["fp8_dtype"] == "e4m3"
+
+    def test_mxfp8_builds_mxfp8_quantizer(self, monkeypatch):
+        import megatron.bridge.training.nvfp4_healing as mod
+
+        monkeypatch.setattr(mod, "_require_te", lambda: None)
+        monkeypatch.setattr(torch.cuda, "current_device", lambda: "cpu")
+        _inject_fake_te_quantizers(monkeypatch)
+
+        cb = NVFP4HealingCallback(make_config(healing_recipe="mxfp8"))
+        nvfp4_q, fp8_q = cb._build_quantizers()
+        assert nvfp4_q == "nvfp4"
+        assert fp8_q == ("mxfp8", "e4m3")
+
+
+class FakeStorage:
+    """Fake quantized storage tracking cpu()/pin_memory()/to() calls."""
+
+    def __init__(self):
+        self.pinned = False
+        self.moved_to = None
+
+    def cpu(self):
+        return self
+
+    def pin_memory(self):
+        self.pinned = True
+        return self
+
+    def to(self, device, non_blocking):
+        self.moved_to = (device, non_blocking)
+        return self
+
+
+class TestStashFP8CopyPinned:
+    def test_mxfp8_pins_rowwise_and_columnwise(self):
+        cb = NVFP4HealingCallback(make_config(healing_recipe="mxfp8", store_quantized_params_on_gpu=False))
+        q = SimpleNamespace(_rowwise_data=FakeStorage(), _columnwise_data=FakeStorage())
+        q.clone = lambda: q
+        cb._stash_fp8_copy(q)
+        assert cb._fp8_stash == [q]
+        assert q._rowwise_data.pinned and q._columnwise_data.pinned
+
+    def test_delayed_pins_data_and_transpose(self):
+        cb = NVFP4HealingCallback(make_config(healing_recipe="delayed", store_quantized_params_on_gpu=False))
+        q = SimpleNamespace(_data=FakeStorage(), _transpose=FakeStorage())
+        q.clone = lambda: q
+        cb._stash_fp8_copy(q)
+        assert q._data.pinned and q._transpose.pinned
+
+
+class TestMoveStashEntryToDevice:
+    def test_mxfp8_moves_rowwise_and_columnwise(self):
+        cb = NVFP4HealingCallback(make_config(healing_recipe="mxfp8"))
+        w = SimpleNamespace(_rowwise_data=FakeStorage(), _columnwise_data=FakeStorage())
+        cb._move_stash_entry_to_device(w, "cuda:0")
+        assert w._rowwise_data.moved_to == ("cuda:0", True)
+        assert w._columnwise_data.moved_to == ("cuda:0", True)
+
+    def test_delayed_moves_data_and_transpose(self):
+        cb = NVFP4HealingCallback(make_config(healing_recipe="delayed"))
+        w = SimpleNamespace(_data=FakeStorage(), _transpose=FakeStorage())
+        cb._move_stash_entry_to_device(w, "cuda:0")
+        assert w._data.moved_to == ("cuda:0", True)
+        assert w._transpose.moved_to == ("cuda:0", True)
+
+
+class TestIsTargetModule:
+    def test_true_for_te_linear_with_weight_false_otherwise(self, monkeypatch):
+        import transformer_engine.pytorch as te
+
+        class Linear(torch.nn.Module):
+            pass
+
+        class LayerNormLinear(torch.nn.Module):
+            pass
+
+        monkeypatch.setattr(te, "Linear", Linear, raising=False)
+        monkeypatch.setattr(te, "LayerNormLinear", LayerNormLinear, raising=False)
+
+        target = Linear()
+        target.weight = torch.zeros(1)
+        assert NVFP4HealingCallback._is_target_module(target) is True
+        assert NVFP4HealingCallback._is_target_module(torch.nn.Linear(2, 2)) is False
+
+
+class TestSwapInFP8WeightsMocked:
+    def test_swaps_stashed_weights_and_clears_stash(self, monkeypatch):
+        model = [make_fake_chunk([1, 2])]  # two Linear modules, op_fuser disabled
+        cb = NVFP4HealingCallback(make_config(pre_quantize_base_weights=True, store_quantized_params_on_gpu=True))
+        cb._fp8_stash = [torch.ones(2, 2), torch.ones(2, 2)]
+
+        class FakeStream:
+            def synchronize(self):
+                self.synced = True
+
+        monkeypatch.setattr(torch.cuda, "current_device", lambda: "cpu")
+        monkeypatch.setattr(torch.cuda, "Stream", lambda: FakeStream())
+        monkeypatch.setattr(torch.cuda, "stream", lambda stream: contextlib.nullcontext())
+
+        with patch_target_module():
+            cb._swap_in_fp8_weights(model)
+
+        assert cb._fp8_stash == []
+        for layer in model[0].decoder.layers:
+            assert torch.all(layer.linear.weight == 1)
+            assert layer.linear.weight.requires_grad is False

--- a/tests/unit_tests/training/test_nvfp4_healing.py
+++ b/tests/unit_tests/training/test_nvfp4_healing.py
@@ -197,6 +197,91 @@ class TestCudaGraphReset:
         assert FullCudaGraphWrapper.curr_iteration == {"training": 0, "validation": 0}
 
 
+class FakeLayer(torch.nn.Module):
+    def __init__(self, layer_number):
+        super().__init__()
+        self.layer_number = layer_number
+        self.linear = torch.nn.Linear(4, 4)
+
+
+def make_fake_chunk(layer_numbers, num_layers=None, first_last_bf16=False, start_bf16=0, end_bf16=0, op_fuser=False):
+    layers = torch.nn.ModuleList([FakeLayer(n) for n in layer_numbers])
+    config = SimpleNamespace(
+        num_layers=num_layers if num_layers is not None else len(layer_numbers),
+        first_last_layers_bf16=first_last_bf16,
+        num_layers_at_start_in_bf16=start_bf16,
+        num_layers_at_end_in_bf16=end_bf16,
+        use_transformer_engine_op_fuser=op_fuser,
+        fp8_dot_product_attention=False,
+    )
+    return SimpleNamespace(decoder=SimpleNamespace(layers=layers), config=config)
+
+
+def linear_is_target(module):
+    return isinstance(module, torch.nn.Linear)
+
+
+def patch_target_module():
+    return patch.object(NVFP4HealingCallback, "_is_target_module", staticmethod(linear_is_target))
+
+
+class TestUnwrapModelChunk:
+    def test_returns_object_without_module_attr(self):
+        chunk = make_fake_chunk([1])
+        assert _unwrap_model_chunk(chunk) is chunk
+
+    def test_follows_nested_module_chain(self):
+        inner = make_fake_chunk([1])
+        wrapped = SimpleNamespace(module=SimpleNamespace(module=inner))
+        assert _unwrap_model_chunk(wrapped) is inner
+
+
+class TestLayerIteration:
+    def test_yields_all_target_modules(self):
+        model = [make_fake_chunk([1, 2, 3])]
+        cb = NVFP4HealingCallback(make_config())
+        with patch_target_module():
+            found = list(cb._iter_quantizable_modules(model))
+        assert len(found) == 3
+        assert all(isinstance(m, torch.nn.Linear) for _, m in found)
+
+    def test_skips_first_and_last_bf16_layers(self):
+        model = [make_fake_chunk([1, 2, 3, 4], first_last_bf16=True, start_bf16=1, end_bf16=1)]
+        cb = NVFP4HealingCallback(make_config())
+        with patch_target_module():
+            found = list(cb._iter_quantizable_modules(model))
+        assert {layer.layer_number for layer, _ in found} == {2, 3}
+
+    def test_bf16_skip_ignored_when_flag_off(self):
+        model = [make_fake_chunk([1, 2, 3, 4], first_last_bf16=False, start_bf16=1, end_bf16=1)]
+        cb = NVFP4HealingCallback(make_config())
+        with patch_target_module():
+            found = list(cb._iter_quantizable_modules(model))
+        assert len(found) == 4
+
+    def test_pipeline_rank_uses_global_layer_numbers(self):
+        # Simulates the last PP rank holding global layers 3..4 of a 4-layer model
+        # with the final layer kept in BF16.
+        model = [make_fake_chunk([3, 4], num_layers=4, first_last_bf16=True, start_bf16=1, end_bf16=1)]
+        cb = NVFP4HealingCallback(make_config())
+        with patch_target_module():
+            found = list(cb._iter_quantizable_modules(model))
+        assert {layer.layer_number for layer, _ in found} == {3}
+
+    def test_iterates_across_virtual_pipeline_chunks(self):
+        chunk_a = make_fake_chunk([1, 2], num_layers=4)
+        chunk_b = make_fake_chunk([3, 4], num_layers=4)
+        cb = NVFP4HealingCallback(make_config())
+        with patch_target_module():
+            found = list(cb._iter_quantizable_modules([chunk_a, chunk_b]))
+        assert [layer.layer_number for layer, _ in found] == [1, 2, 3, 4]
+
+    def test_unsupported_model_structure_raises(self):
+        cb = NVFP4HealingCallback(make_config())
+        with pytest.raises(RuntimeError, match="decoder.layers"):
+            list(cb._iter_quantizable_modules([SimpleNamespace(config=SimpleNamespace())]))
+
+
 class TestHookRegistration:
     def test_registers_expected_hooks(self):
         manager = CallbackManager()

--- a/tests/unit_tests/training/test_nvfp4_healing.py
+++ b/tests/unit_tests/training/test_nvfp4_healing.py
@@ -94,6 +94,81 @@ class TestHealingTrigger:
             assert cb.healed is False
 
 
+def _has_te_with_nvfp4():
+    """True when a real Transformer Engine >= 2.7.0.dev0 is importable (same gate as production)."""
+    try:
+        import transformer_engine  # noqa: F401
+
+        from megatron.core.utils import is_te_min_version
+
+        return is_te_min_version("2.7.0.dev0")
+    except Exception:
+        return False
+
+
+requires_te = pytest.mark.skipif(not _has_te_with_nvfp4(), reason="requires Transformer Engine >= 2.7.0.dev0")
+
+
+class TestRecipePatchAndRestore:
+    def test_patch_replaces_and_on_train_end_restores(self):
+        import megatron.core.fp4_utils as fp4_utils
+
+        original = fp4_utils.get_fp4_recipe
+        cb = NVFP4HealingCallback(make_config())
+        sentinel = object()
+        try:
+            cb._patch_fp4_recipe(sentinel)
+            assert fp4_utils.get_fp4_recipe(Mock()) is sentinel
+            cb.on_train_end(Mock())
+            assert fp4_utils.get_fp4_recipe is original
+        finally:
+            fp4_utils.get_fp4_recipe = original
+
+    def test_double_patch_keeps_true_original(self):
+        import megatron.core.fp4_utils as fp4_utils
+
+        original = fp4_utils.get_fp4_recipe
+        cb = NVFP4HealingCallback(make_config())
+        try:
+            cb._patch_fp4_recipe(object())
+            cb._patch_fp4_recipe(object())
+            cb._restore_fp4_recipe()
+            assert fp4_utils.get_fp4_recipe is original
+        finally:
+            fp4_utils.get_fp4_recipe = original
+
+    def test_restore_without_patch_is_noop(self):
+        import megatron.core.fp4_utils as fp4_utils
+
+        original = fp4_utils.get_fp4_recipe
+        cb = NVFP4HealingCallback(make_config())
+        cb.on_train_end(Mock())
+        assert fp4_utils.get_fp4_recipe is original
+
+
+class TestHealingRecipeConstruction:
+    @requires_te
+    def test_delayed_recipe_fields(self):
+        from transformer_engine.common.recipe import DelayedScaling
+
+        cb = NVFP4HealingCallback(
+            make_config(healing_recipe="delayed", fp8_amax_history_len=16, fp8_amax_compute_algo="max")
+        )
+        model_config = SimpleNamespace(fp8_dot_product_attention=False)
+        recipe = cb._build_healing_recipe(model_config)
+        assert isinstance(recipe, DelayedScaling)
+        assert recipe.amax_history_len == 16
+        assert recipe.amax_compute_algo == "max"
+
+    @requires_te
+    def test_mxfp8_recipe(self):
+        from transformer_engine.common.recipe import MXFP8BlockScaling
+
+        cb = NVFP4HealingCallback(make_config(healing_recipe="mxfp8"))
+        recipe = cb._build_healing_recipe(SimpleNamespace(fp8_dot_product_attention=False))
+        assert isinstance(recipe, MXFP8BlockScaling)
+
+
 class TestHookRegistration:
     def test_registers_expected_hooks(self):
         manager = CallbackManager()

--- a/tests/unit_tests/training/test_nvfp4_healing.py
+++ b/tests/unit_tests/training/test_nvfp4_healing.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the NVFP4 FP8-healing callback."""
+
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+import torch
+
+from megatron.bridge.training.callbacks import CallbackManager
+from megatron.bridge.training.nvfp4_healing import (
+    VALID_HEALING_RECIPES,
+    NVFP4HealingCallback,
+    NVFP4HealingConfig,
+    _unwrap_model_chunk,
+)
+
+
+def make_config(**overrides):
+    defaults = {"healing_iter": 3, "healing_recipe": "delayed"}
+    defaults.update(overrides)
+    return NVFP4HealingConfig(**defaults)
+
+
+class TestNVFP4HealingConfig:
+    def test_valid_config_defaults(self):
+        cfg = make_config()
+        assert cfg.healing_iter == 3
+        assert cfg.healing_recipe == "delayed"
+        assert cfg.pre_quantize_base_weights is False
+        assert cfg.store_quantized_params_on_gpu is False
+        assert cfg.fp8_amax_history_len == 1024
+        assert cfg.fp8_amax_compute_algo == "max"
+        assert cfg.reduce_amax is True
+        assert cfg.reset_cuda_graph_warmup is False
+
+    def test_mxfp8_recipe_accepted(self):
+        assert make_config(healing_recipe="mxfp8").healing_recipe == "mxfp8"
+
+    def test_valid_recipes_constant(self):
+        assert VALID_HEALING_RECIPES == ("delayed", "mxfp8")
+
+    def test_invalid_recipe_raises(self):
+        with pytest.raises(ValueError, match="healing_recipe"):
+            make_config(healing_recipe="FP8_DS")
+
+    def test_invalid_healing_iter_raises(self):
+        with pytest.raises(ValueError, match="healing_iter"):
+            make_config(healing_iter=0)

--- a/tests/unit_tests/training/test_nvfp4_healing.py
+++ b/tests/unit_tests/training/test_nvfp4_healing.py
@@ -282,6 +282,65 @@ class TestLayerIteration:
             list(cb._iter_quantizable_modules([SimpleNamespace(config=SimpleNamespace())]))
 
 
+class TestPreQuantization:
+    def test_rejects_trainable_weights(self):
+        model = [make_fake_chunk([1])]
+        cb = NVFP4HealingCallback(make_config(pre_quantize_base_weights=True))
+        with (
+            patch_target_module(),
+            patch.object(cb, "_build_quantizers", return_value=(Mock(), Mock())),
+        ):
+            with pytest.raises(ValueError, match="frozen"):
+                cb._pre_quantize(model)
+
+    def test_stashes_fp8_and_replaces_weights_with_nvfp4(self):
+        model = [make_fake_chunk([1, 2])]
+        for layer in model[0].decoder.layers:
+            layer.linear.weight.requires_grad_(False)
+        cb = NVFP4HealingCallback(make_config(pre_quantize_base_weights=True, store_quantized_params_on_gpu=True))
+        fake_nvfp4 = Mock(side_effect=lambda w: torch.zeros_like(w))
+        fake_fp8 = Mock(side_effect=lambda w: torch.ones_like(w))
+        with (
+            patch_target_module(),
+            patch.object(cb, "_build_quantizers", return_value=(fake_nvfp4, fake_fp8)),
+            patch.object(cb, "_validate_quantized"),
+        ):
+            cb._pre_quantize(model)
+
+        assert len(cb._fp8_stash) == 2
+        assert all(torch.all(stashed == 1) for stashed in cb._fp8_stash)
+        for layer in model[0].decoder.layers:
+            weight = layer.linear.weight
+            assert isinstance(weight, torch.nn.Parameter)
+            assert weight.requires_grad is False
+            assert torch.all(weight == 0)
+
+    def test_on_data_init_start_noop_without_flag(self):
+        cb = NVFP4HealingCallback(make_config(pre_quantize_base_weights=False))
+        ctx = Mock()
+        with patch.object(cb, "_pre_quantize") as pre_quantize:
+            cb.on_data_init_start(ctx)
+            pre_quantize.assert_not_called()
+
+
+class TestValidateQuantized:
+    def test_nvfp4_missing_storage_raises(self):
+        cb = NVFP4HealingCallback(make_config())
+        bad = SimpleNamespace(_rowwise_data=None, _columnwise_data=torch.zeros(1))
+        with pytest.raises(RuntimeError, match="rowwise"):
+            cb._validate_quantized(bad, "nvfp4")
+
+    def test_delayed_missing_data_raises(self):
+        cb = NVFP4HealingCallback(make_config())
+        with pytest.raises(RuntimeError, match="data"):
+            cb._validate_quantized(SimpleNamespace(_data=None), "delayed")
+
+    def test_valid_tensors_pass(self):
+        cb = NVFP4HealingCallback(make_config())
+        cb._validate_quantized(SimpleNamespace(_rowwise_data=torch.zeros(1), _columnwise_data=torch.zeros(1)), "mxfp8")
+        cb._validate_quantized(SimpleNamespace(_data=torch.zeros(1)), "delayed")
+
+
 class TestHookRegistration:
     def test_registers_expected_hooks(self):
         manager = CallbackManager()

--- a/tests/unit_tests/training/test_nvfp4_healing.py
+++ b/tests/unit_tests/training/test_nvfp4_healing.py
@@ -60,3 +60,46 @@ class TestNVFP4HealingConfig:
     def test_invalid_healing_iter_raises(self):
         with pytest.raises(ValueError, match="healing_iter"):
             make_config(healing_iter=0)
+
+
+def make_context(step):
+    ctx = Mock()
+    ctx.state.train_state.step = step
+    return ctx
+
+
+class TestHealingTrigger:
+    def test_fires_exactly_at_healing_iter(self):
+        cb = NVFP4HealingCallback(make_config(healing_iter=3))
+        with patch.object(cb, "_apply_healing") as apply:
+            cb.on_train_step_end(make_context(step=1))  # step+1 == 2 != 3
+            apply.assert_not_called()
+            assert cb.healed is False
+            cb.on_train_step_end(make_context(step=2))  # step+1 == 3
+            apply.assert_called_once()
+            assert cb.healed is True
+
+    def test_fires_only_once(self):
+        cb = NVFP4HealingCallback(make_config(healing_iter=1))
+        with patch.object(cb, "_apply_healing") as apply:
+            cb.on_train_step_end(make_context(step=0))
+            cb.on_train_step_end(make_context(step=0))
+            assert apply.call_count == 1
+
+    def test_does_not_fire_past_healing_iter(self):
+        cb = NVFP4HealingCallback(make_config(healing_iter=2))
+        with patch.object(cb, "_apply_healing") as apply:
+            cb.on_train_step_end(make_context(step=5))
+            apply.assert_not_called()
+            assert cb.healed is False
+
+
+class TestHookRegistration:
+    def test_registers_expected_hooks(self):
+        manager = CallbackManager()
+        manager.add(NVFP4HealingCallback(make_config()))
+        assert manager.has_callbacks("on_data_init_start")
+        assert manager.has_callbacks("on_train_step_end")
+        assert manager.has_callbacks("on_train_end")
+        assert not manager.has_callbacks("on_train_start")
+        assert not manager.has_callbacks("on_train_step_start")

--- a/tests/unit_tests/training/test_nvfp4_healing.py
+++ b/tests/unit_tests/training/test_nvfp4_healing.py
@@ -98,7 +98,6 @@ def _has_te_with_nvfp4():
     """True when a real Transformer Engine >= 2.7.0.dev0 is importable (same gate as production)."""
     try:
         import transformer_engine  # noqa: F401
-
         from megatron.core.utils import is_te_min_version
 
         return is_te_min_version("2.7.0.dev0")

--- a/tests/unit_tests/training/test_nvfp4_healing.py
+++ b/tests/unit_tests/training/test_nvfp4_healing.py
@@ -341,6 +341,61 @@ class TestValidateQuantized:
         cb._validate_quantized(SimpleNamespace(_data=torch.zeros(1)), "delayed")
 
 
+class TestApplyHealing:
+    def test_missing_stash_raises_when_prequantize_configured(self):
+        cb = NVFP4HealingCallback(make_config(pre_quantize_base_weights=True))
+        ctx = make_context(step=2)
+        ctx.model = [make_fake_chunk([1])]
+        with (
+            patch.object(cb, "_reset_cuda_graphs"),
+            patch.object(cb, "_swap_in_fp8_weights"),
+            patch.object(cb, "_build_healing_recipe", return_value=object()),
+            patch.object(cb, "_patch_fp4_recipe"),
+        ):
+            with pytest.raises(RuntimeError, match="stash"):
+                cb._apply_healing(ctx)
+
+    def test_healing_order_with_prequantized_weights(self):
+        cb = NVFP4HealingCallback(make_config(pre_quantize_base_weights=True))
+        cb._fp8_stash = [object()]
+        ctx = make_context(step=2)
+        ctx.model = [make_fake_chunk([1])]
+        call_order = []
+        recipe = object()
+        with (
+            patch.object(cb, "_reset_cuda_graphs", side_effect=lambda: call_order.append("reset")),
+            patch.object(cb, "_swap_in_fp8_weights", side_effect=lambda m: call_order.append("swap")),
+            patch.object(cb, "_build_healing_recipe", return_value=recipe),
+            patch.object(cb, "_patch_fp4_recipe", side_effect=lambda r: call_order.append("patch")),
+        ):
+            cb._apply_healing(ctx)
+        assert call_order == ["reset", "swap", "patch"]
+
+    def test_recipe_switch_only_without_prequantize(self):
+        cb = NVFP4HealingCallback(make_config(pre_quantize_base_weights=False))
+        ctx = make_context(step=2)
+        ctx.model = [make_fake_chunk([1])]
+        with (
+            patch.object(cb, "_reset_cuda_graphs"),
+            patch.object(cb, "_swap_in_fp8_weights") as swap,
+            patch.object(cb, "_build_healing_recipe", return_value=object()),
+            patch.object(cb, "_patch_fp4_recipe") as patch_recipe,
+        ):
+            cb._apply_healing(ctx)
+        swap.assert_not_called()
+        patch_recipe.assert_called_once()
+
+
+class TestSwapInFP8Weights:
+    def test_stash_count_mismatch_raises(self):
+        model = [make_fake_chunk([1, 2])]
+        cb = NVFP4HealingCallback(make_config(pre_quantize_base_weights=True))
+        cb._fp8_stash = [object()]  # 1 stash entry vs 2 modules
+        with patch_target_module():
+            with pytest.raises(RuntimeError, match="stash"):
+                cb._swap_in_fp8_weights(model)
+
+
 class TestHookRegistration:
     def test_registers_expected_hooks(self):
         manager = CallbackManager()

--- a/tests/unit_tests/training/test_nvfp4_healing.py
+++ b/tests/unit_tests/training/test_nvfp4_healing.py
@@ -169,6 +169,34 @@ class TestHealingRecipeConstruction:
         assert isinstance(recipe, MXFP8BlockScaling)
 
 
+class TestCudaGraphReset:
+    def test_resets_graph_and_result_state(self, monkeypatch):
+        from megatron.core.full_cuda_graph import FullCudaGraphWrapper
+
+        monkeypatch.setattr(FullCudaGraphWrapper, "cuda_graph", {"training": "g", "validation": "g"}, raising=False)
+        monkeypatch.setattr(FullCudaGraphWrapper, "result", {"training": "r", "validation": "r"}, raising=False)
+        monkeypatch.setattr(FullCudaGraphWrapper, "curr_iteration", {"training": 5, "validation": 4}, raising=False)
+
+        cb = NVFP4HealingCallback(make_config())
+        cb._reset_cuda_graphs()
+
+        assert FullCudaGraphWrapper.cuda_graph == {"training": None, "validation": None}
+        assert FullCudaGraphWrapper.result == {"training": None, "validation": None}
+        assert FullCudaGraphWrapper.curr_iteration == {"training": 5, "validation": 4}
+
+    def test_reset_warmup_counters_when_configured(self, monkeypatch):
+        from megatron.core.full_cuda_graph import FullCudaGraphWrapper
+
+        monkeypatch.setattr(FullCudaGraphWrapper, "cuda_graph", {"training": "g", "validation": "g"}, raising=False)
+        monkeypatch.setattr(FullCudaGraphWrapper, "result", {"training": "r", "validation": "r"}, raising=False)
+        monkeypatch.setattr(FullCudaGraphWrapper, "curr_iteration", {"training": 5, "validation": 4}, raising=False)
+
+        cb = NVFP4HealingCallback(make_config(reset_cuda_graph_warmup=True))
+        cb._reset_cuda_graphs()
+
+        assert FullCudaGraphWrapper.curr_iteration == {"training": 0, "validation": 0}
+
+
 class TestHookRegistration:
     def test_registers_expected_hooks(self):
         manager = CallbackManager()


### PR DESCRIPTION
## What does this PR do?

Backport of #5023 to `r0.5.0` for the NeMo 26.06.01 / MLPerf integration target.

Adds `NVFP4HealingCallback` — NVFP4 training with FP8 healing (`src/megatron/bridge/training/nvfp4_healing.py`): train most steps in NVFP4 (existing `bf16_with_nvfp4_mixed` recipe), then at `healing_iter` switch the quantization recipe to FP8 (`DelayedScaling` or `MXFP8BlockScaling`) to recover accuracy in the final phase. For frozen base weights (PEFT/LoRA), optionally pre-quantizes them at startup: NVFP4 on device for training, FP8 copies stashed in pinned host memory and swapped in at healing time. Upstreams the callback used in NVIDIA's MLPerf Llama-2 70B LoRA submission.

Clean cherry-pick of the 10 feature/test/docs commits from #5023 (the since-removed GB200 functional test commits are excluded). Unit tests pass against this branch's Megatron-LM pin (44 passed, 2 TE-version-gated skips that run in CI containers).

Note: with NVFP4-stored params (`fp4_param_gather=True`, as set by `bf16_with_nvfp4_mixed`), the healing switch requires `pre_quantize_base_weights=True` — Transformer Engine enforces weight/recipe correspondence.

The same feature remains open against `main` in #5023 for 26.08.

🤖 Generated with [Claude Code](https://claude.com/claude-code)