### PR TITLE
[training, ckpt] fix: Clean up failed MegatronMIMO pretraining

### DIFF
--- a/src/megatron/bridge/training/pretrain_megatron_mimo.py
+++ b/src/megatron/bridge/training/pretrain_megatron_mimo.py
@@ -30,7 +30,7 @@ from typing import Callable, Optional
 import torch.distributed as dist
 
 from megatron.bridge.training.config import ConfigContainer, megatron_mimo_runtime_config_update
-from megatron.bridge.training.pretrain import _maybe_destroy_process_group
+from megatron.bridge.training.pretrain import _cleanup_after_pretrain_failure, _maybe_destroy_process_group
 from megatron.bridge.training.setup_megatron_mimo import setup_megatron_mimo
 from megatron.bridge.training.state import GlobalState
 from megatron.bridge.training.train import _finish_train
@@ -75,33 +75,37 @@ def pretrain_megatron_mimo(
     state = global_state if global_state is not None else GlobalState()
     state.cfg = cfg
 
-    # Setup: model, optimizer, schedulers, MPU bridging, checkpoint load, data iterators.
-    setup_output = setup_megatron_mimo(
-        state=state,
-        build_data_iterators_fn=build_data_iterators_fn,
-    )
+    try:
+        # Setup: model, optimizer, schedulers, MPU bridging, checkpoint load, data iterators.
+        setup_output = setup_megatron_mimo(
+            state=state,
+            build_data_iterators_fn=build_data_iterators_fn,
+        )
 
-    logger.info(f"Rank {dist.get_rank()}: Starting training loop")
+        logger.info(f"Rank {dist.get_rank()}: Starting training loop")
 
-    # Run training loop
-    train_megatron_mimo(
-        forward_step_func=forward_step_func,
-        model=setup_output.model,
-        optimizer=setup_output.optimizer,
-        schedulers=setup_output.schedulers,
-        train_data_iterator=setup_output.train_data_iterator,
-        valid_data_iterator=setup_output.valid_data_iterator,
-        global_state=setup_output.global_state,
-        megatron_mimo_infra=setup_output.megatron_mimo_infra,
-        multimodule_communicator=setup_output.multimodule_communicator,
-        checkpoint_manager=setup_output.checkpoint_manager,
-        multimodule_pg_collection=setup_output.multimodule_pg_collection,
-        module_to_grid_tuple=setup_output.module_to_grid_tuple,
-    )
+        # Run training loop
+        train_megatron_mimo(
+            forward_step_func=forward_step_func,
+            model=setup_output.model,
+            optimizer=setup_output.optimizer,
+            schedulers=setup_output.schedulers,
+            train_data_iterator=setup_output.train_data_iterator,
+            valid_data_iterator=setup_output.valid_data_iterator,
+            global_state=setup_output.global_state,
+            megatron_mimo_infra=setup_output.megatron_mimo_infra,
+            multimodule_communicator=setup_output.multimodule_communicator,
+            checkpoint_manager=setup_output.checkpoint_manager,
+            multimodule_pg_collection=setup_output.multimodule_pg_collection,
+            module_to_grid_tuple=setup_output.module_to_grid_tuple,
+        )
 
-    # Post-training cleanup: finalize async saves, shut down NVRx/FT, flush
-    # loggers, destroy GlobalState (which calls destroy_model_parallel internally).
-    _finish_train(setup_output.global_state, setup_output.checkpoint_manager)
+        # Post-training cleanup: finalize async saves, shut down NVRx/FT, flush
+        # loggers, destroy GlobalState (which calls destroy_model_parallel internally).
+        _finish_train(setup_output.global_state, setup_output.checkpoint_manager)
+    except BaseException:
+        _cleanup_after_pretrain_failure(state, should_destroy_process_group)
+        raise
 
     _maybe_destroy_process_group(should_destroy_process_group)
 

--- a/tests/unit_tests/training/megatron_mimo/test_pretrain_megatron_mimo.py
+++ b/tests/unit_tests/training/megatron_mimo/test_pretrain_megatron_mimo.py
@@ -258,6 +258,38 @@ def test_pretrain_megatron_mimo_calls_setup_and_train(
     mock_finish.assert_called_once()
 
 
+def test_pretrain_megatron_mimo_aborts_async_state_after_failure():
+    """pretrain_megatron_mimo should clean up async and Megatron state after a failure."""
+    from megatron.bridge.training.pretrain_megatron_mimo import pretrain_megatron_mimo
+
+    cfg = _make_cfg()
+    state = MagicMock()
+    async_calls_queue = MagicMock()
+    state._async_calls_queue = async_calls_queue
+    failure = RuntimeError("training failed")
+
+    with (
+        patch("megatron.bridge.training.pretrain_megatron_mimo.dist") as mock_dist,
+        patch("megatron.bridge.training.pretrain_megatron_mimo.megatron_mimo_runtime_config_update"),
+        patch("megatron.bridge.training.pretrain_megatron_mimo.setup_megatron_mimo", side_effect=failure),
+        patch("megatron.bridge.training.pretrain.destroy_global_state") as mock_destroy_global_state,
+        patch("megatron.core.dist_checkpointing.strategies.filesystem_async._results_queue", None),
+        pytest.raises(RuntimeError, match="training failed") as exc_info,
+    ):
+        mock_dist.is_initialized.return_value = True
+        pretrain_megatron_mimo(
+            cfg=cfg,
+            forward_step_func=MagicMock(),
+            build_data_iterators_fn=MagicMock(),
+            global_state=state,
+        )
+
+    assert exc_info.value is failure
+    async_calls_queue.close.assert_called_once_with(abort=True)
+    assert state._async_calls_queue is None
+    mock_destroy_global_state.assert_called_once()
+
+
 def test_finish_train_calls_cleanup():
     """_finish_train should finalize async saves, shut down NVRx/FT, and flush loggers."""
     from megatron.bridge.training.train import _finish_train


### PR DESCRIPTION
## Summary

Clean up framework-owned async checkpoint and Megatron state when the public
MegatronMIMO pretraining entry point propagates an exception.

## Supported trigger and impact

With `checkpoint.async_save=True` and the persistent MCore worker,
`setup_megatron_mimo()` initializes async checkpoint state before later setup
and user iterator work. The training loop can also schedule a checkpoint before
a later supported forward, evaluation, logging, or training boundary raises.

Previously, `pretrain_megatron_mimo()` performed cleanup only on successful
completion. If a caller caught the public exception and retried in the same
process, a fresh queue restarted at request zero while the old class-owned
persistent caller still held the abandoned completion. That completion could
prematurely run the retry checkpoint's finalizers before its new payload was
durable.

## Root cause and fix

Standard pretraining already delegates exceptional cleanup to
`_cleanup_after_pretrain_failure()`, which aborts the async queue, clears MCore
results ownership, destroys Megatron globals, and preserves caller-owned
distributed state. The mirrored MegatronMIMO entry point did not use that
exceptional owner.

The MIMO setup, training, and normal-finish sequence is now enclosed in the same
`BaseException` cleanup contract, with the original exception re-raised. No
public signature, configuration, dependency, workflow, or MCore change is
involved.

## Validation

Exact current-base fail-before:

```text
uv run --active --no-sync python -m pytest \
  tests/unit_tests/training/megatron_mimo/test_pretrain_megatron_mimo.py::test_pretrain_megatron_mimo_aborts_async_state_after_failure \
  -q
```

Unmodified production result: `1 failed` because `close(abort=True)` had zero
calls. Patched result: passed.

Focused and adjacent tests:

```text
uv run --active --no-sync python -m pytest \
  tests/unit_tests/training/megatron_mimo/test_pretrain_megatron_mimo.py \
  tests/unit_tests/training/test_pretrain.py::TestPretrainProcessGroupOwnership \
  -q
```

Result: `12 passed`.

Two-rank same-process retry reproducer:

```text
uv run --active --no-sync python -m torch.distributed.run \
  --standalone --nproc_per_node=2 \
  reproduce_mimo_async_retry_stale_completion.py <fresh-output-dir>
```

- Unmodified source: both ranks failed because retry request zero was finalized
  from the abandoned session's completion.
- Patched source: exited successfully; no premature finalization occurred.

```text
git diff --check
uv run --active --no-sync pre-commit run --all-files
```

Result: passed.

## Scope

This validates exceptional cleanup and same-process retry for MegatronMIMO with
the persistent MCore async-save path. The viable MIMO path uses a caller-owned
default process group, which remains intact. This does not claim full-suite,
convergence, performance, or model-quality validation.
