### PR TITLE
[inference] fix: Honor VLM inference parameter dtype

### DIFF
--- a/src/megatron/bridge/inference/vlm/base.py
+++ b/src/megatron/bridge/inference/vlm/base.py
@@ -76,7 +76,10 @@ def setup_model_and_tokenizer(
     model_provider = bridge.to_megatron_provider(load_weights=False)
     model_provider.tensor_model_parallel_size = tp
     model_provider.pipeline_model_parallel_size = pp
-    model_provider.pipeline_dtype = torch.bfloat16
+    model_provider.params_dtype = params_dtype
+    model_provider.pipeline_dtype = params_dtype
+    model_provider.bf16 = params_dtype == torch.bfloat16
+    model_provider.fp16 = params_dtype == torch.float16
     model_provider.parallel_output = False
     model_provider.finalize()
     model_provider.initialize_model_parallel(seed=0)
@@ -86,7 +89,10 @@ def setup_model_and_tokenizer(
         mp_overrides={
             "tensor_model_parallel_size": tp,
             "pipeline_model_parallel_size": pp,
-            "pipeline_dtype": torch.bfloat16,
+            "params_dtype": params_dtype,
+            "pipeline_dtype": params_dtype,
+            "bf16": params_dtype == torch.bfloat16,
+            "fp16": params_dtype == torch.float16,
         },
         wrap_with_ddp=False,
     )
@@ -112,7 +118,7 @@ def setup_model_and_tokenizer(
     inference_wrapped_model = setup_inference_wrapper(
         model[0],
         processor.tokenizer,
-        params_dtype=torch.bfloat16,
+        params_dtype=params_dtype,
         inference_batch_times_seqlen_threshold=1000,
         inference_max_seq_length=inference_max_seq_length,
         inference_max_batch_size=inference_max_batch_size,

--- a/tests/unit_tests/inference/vlm/test_base.py
+++ b/tests/unit_tests/inference/vlm/test_base.py
@@ -113,6 +113,45 @@ class TestSetupModelAndTokenizer:
         assert result_model == mock_wrapped_model
         assert result_processor == mock_processor
 
+    @patch("megatron.bridge.inference.vlm.base.setup_inference_wrapper")
+    @patch("megatron.bridge.inference.vlm.base.AutoProcessor")
+    @patch("megatron.bridge.inference.vlm.base.AutoBridge")
+    @patch("megatron.bridge.inference.vlm.base.get_hf_model_id_from_checkpoint")
+    @patch("megatron.bridge.inference.vlm.base.is_safe_repo", return_value=False)
+    @patch("megatron.bridge.inference.vlm.base.print_rank_0")
+    def test_setup_model_and_tokenizer_propagates_params_dtype(
+        self,
+        mock_print_rank_0,
+        mock_is_safe_repo,
+        mock_get_hf_model_id,
+        mock_auto_bridge,
+        mock_auto_processor,
+        mock_setup_inference_wrapper,
+    ):
+        mock_get_hf_model_id.return_value = "Qwen/Qwen2.5-VL-3B"
+
+        mock_bridge = MagicMock()
+        mock_auto_bridge.from_hf_pretrained.return_value = mock_bridge
+        mock_model_provider = MagicMock()
+        mock_bridge.to_megatron_provider.return_value = mock_model_provider
+
+        mock_model = MagicMock()
+        mock_model.cuda.return_value = mock_model
+        mock_bridge.load_megatron_model.return_value = [mock_model]
+
+        mock_processor = MagicMock()
+        mock_processor.tokenizer.pad_token = "<|pad|>"
+        mock_auto_processor.from_pretrained.return_value = mock_processor
+
+        setup_model_and_tokenizer(
+            megatron_model_path="/path/to/checkpoint",
+            params_dtype=torch.float16,
+        )
+
+        assert mock_model_provider.pipeline_dtype == torch.float16
+        assert mock_bridge.load_megatron_model.call_args.kwargs["mp_overrides"]["pipeline_dtype"] == torch.float16
+        assert mock_setup_inference_wrapper.call_args.kwargs["params_dtype"] == torch.float16
+
     @patch("megatron.bridge.inference.vlm.base.get_hf_model_id_from_checkpoint", return_value=None)
     @patch("megatron.bridge.inference.vlm.base.print_rank_0")
     def test_setup_model_raises_without_hf_id(self, mock_print_rank_0, mock_get_hf_model_id):


### PR DESCRIPTION
## Summary

- honor the public VLM `params_dtype` argument during provider setup and Megatron checkpoint reconstruction
- keep `params_dtype`, `pipeline_dtype`, `bf16`, and `fp16` consistent before provider finalization
- pass the requested dtype into the final inference wrapper conversion
- add a focused regression for a non-default FP16 request

## Bug

`setup_model_and_tokenizer()` documents `params_dtype` as the model-parameter dtype, but the supported Qwen VLM checkpoint path hard-coded BF16 at every downstream boundary. For example, a caller requesting `torch.float16` received a BF16 provider configuration, BF16 checkpoint override, and BF16 final model conversion. The mismatch was silent and changed the requested numeric and hardware-compatibility contract.

## Fix

Propagate the requested dtype through the provider and checkpoint precision fields and into `setup_inference_wrapper()`. This follows the existing text-inference precision contract while leaving the BF16 default unchanged.

## Validation

Fail before:

```text
uv run --active --no-sync python -m pytest \
  tests/unit_tests/inference/vlm/test_base.py::TestSetupModelAndTokenizer::test_setup_model_and_tokenizer_propagates_params_dtype \
  -q
```

Result: `1 failed` because an explicit FP16 request observed `torch.bfloat16`.

Pass after:

```text
uv run --active --no-sync python -m pytest \
  tests/unit_tests/inference/vlm/test_base.py::TestSetupModelAndTokenizer::test_setup_model_and_tokenizer_propagates_params_dtype \
  -q
```

Result: `1 passed`.

Adjacent:

```text
uv run --active --no-sync python -m pytest tests/unit_tests/inference/vlm -q
```

Result: `38 passed`.

Static checks:

```text
git diff --check
uv run --active --no-sync pre-commit run --all-files
```

Both passed; every applicable pre-commit hook passed.

## Scope

This verifies configuration and dtype propagation through the public VLM setup path. It does not claim GPU kernel, model-quality, convergence, or performance validation. No dependency, lockfile, CI workflow, public signature, or Megatron-Core source is changed.
