### PR TITLE
[docs, recipe] fix: Update Qwen2 recipe examples

### DIFF
--- a/docs/fern/versions/nightly/pages/models/qwen/qwen.mdx
+++ b/docs/fern/versions/nightly/pages/models/qwen/qwen.mdx
@@ -515,15 +515,15 @@ uv run python examples/conversion/hf_to_megatron_generate_text.py \
 ```python
 from megatron.bridge.recipes.qwen import qwen25_7b_pretrain_config
 
-config = qwen25_7b_pretrain_config(
-    name="qwen25_7b_pretrain",
-    data_paths=["/path/to/dataset.nvjsonl"],
-    dir="/results/qwen25_7b",
-    train_iters=500_000,
-    global_batch_size=2048,
-    seq_length=4096,
-    # Uses TP=2, PP=1 (16 GPUs) automatically
-)
+config = qwen25_7b_pretrain_config()
+config.dataset.data_path = "/path/to/dataset_text_document"
+config.checkpoint.save = "/results/qwen25_7b/checkpoints"
+config.logger.tensorboard_dir = "/results/qwen25_7b/tb_logs"
+config.train.train_iters = 500_000
+config.train.global_batch_size = 2048
+config.model.seq_length = 4096
+config.dataset.seq_length = 4096
+# Uses TP=2, PP=1 (2 model-parallel GPUs); additional GPUs become data parallel
 ```
 
 #### Finetuning Examples
@@ -533,14 +533,13 @@ config = qwen25_7b_pretrain_config(
 ```python
 from megatron.bridge.recipes.qwen import qwen25_7b_sft_config
 
-config = qwen25_7b_sft_config(
-    name="qwen25_7b_full_sft",
-    pretrained_checkpoint="/results/qwen25_7b/checkpoints/iter_0500000",
-    train_iters=1000,
-    global_batch_size=64,
-    finetune_lr=5e-6,
-    # Uses TP=2, PP=1 (16 GPUs) automatically
-)
+config = qwen25_7b_sft_config()
+config.checkpoint.pretrained_checkpoint = "/results/qwen25_7b/checkpoints/iter_0500000"
+config.train.train_iters = 1000
+config.train.global_batch_size = 64
+config.scheduler.lr_decay_iters = 1000
+config.optimizer.lr = 5e-6
+# Uses TP=2, PP=1 (2 model-parallel GPUs); additional GPUs become data parallel
 ```
 
 **LoRA Finetuning (7B):**
@@ -548,15 +547,13 @@ config = qwen25_7b_sft_config(
 ```python
 from megatron.bridge.recipes.qwen import qwen25_7b_peft_config
 
-config = qwen25_7b_peft_config(
-    name="qwen25_7b_lora",
-    pretrained_checkpoint="/results/qwen25_7b/checkpoints/iter_0500000",
-    peft_scheme="lora",  # or "dora"
-    train_iters=1000,
-    global_batch_size=128,
-    finetune_lr=1e-4,
-    # Uses TP=1, PP=1 (8 GPUs) automatically
-)
+config = qwen25_7b_peft_config(peft_scheme="lora")  # or "dora"
+config.checkpoint.pretrained_checkpoint = "/results/qwen25_7b/checkpoints/iter_0500000"
+config.train.train_iters = 1000
+config.train.global_batch_size = 128
+config.scheduler.lr_decay_iters = 1000
+config.optimizer.lr = 1e-4
+# Uses TP=1, PP=1 (1 model-parallel GPU); additional GPUs become data parallel
 ```
 
 ### Hugging Face Model Cards

--- a/docs/models/qwen/qwen.md
+++ b/docs/models/qwen/qwen.md
@@ -515,15 +515,15 @@ uv run python examples/conversion/hf_to_megatron_generate_text.py \
 ```python
 from megatron.bridge.recipes.qwen import qwen25_7b_pretrain_config
 
-config = qwen25_7b_pretrain_config(
-    name="qwen25_7b_pretrain",
-    data_paths=["/path/to/dataset.nvjsonl"],
-    dir="/results/qwen25_7b",
-    train_iters=500_000,
-    global_batch_size=2048,
-    seq_length=4096,
-    # Uses TP=2, PP=1 (16 GPUs) automatically
-)
+config = qwen25_7b_pretrain_config()
+config.dataset.data_path = "/path/to/dataset_text_document"
+config.checkpoint.save = "/results/qwen25_7b/checkpoints"
+config.logger.tensorboard_dir = "/results/qwen25_7b/tb_logs"
+config.train.train_iters = 500_000
+config.train.global_batch_size = 2048
+config.model.seq_length = 4096
+config.dataset.seq_length = 4096
+# Uses TP=2, PP=1 (2 model-parallel GPUs); additional GPUs become data parallel
 ```
 
 #### Finetuning Examples
@@ -533,14 +533,13 @@ config = qwen25_7b_pretrain_config(
 ```python
 from megatron.bridge.recipes.qwen import qwen25_7b_sft_config
 
-config = qwen25_7b_sft_config(
-    name="qwen25_7b_full_sft",
-    pretrained_checkpoint="/results/qwen25_7b/checkpoints/iter_0500000",
-    train_iters=1000,
-    global_batch_size=64,
-    finetune_lr=5e-6,
-    # Uses TP=2, PP=1 (16 GPUs) automatically
-)
+config = qwen25_7b_sft_config()
+config.checkpoint.pretrained_checkpoint = "/results/qwen25_7b/checkpoints/iter_0500000"
+config.train.train_iters = 1000
+config.train.global_batch_size = 64
+config.scheduler.lr_decay_iters = 1000
+config.optimizer.lr = 5e-6
+# Uses TP=2, PP=1 (2 model-parallel GPUs); additional GPUs become data parallel
 ```
 
 **LoRA Finetuning (7B):**
@@ -548,15 +547,13 @@ config = qwen25_7b_sft_config(
 ```python
 from megatron.bridge.recipes.qwen import qwen25_7b_peft_config
 
-config = qwen25_7b_peft_config(
-    name="qwen25_7b_lora",
-    pretrained_checkpoint="/results/qwen25_7b/checkpoints/iter_0500000",
-    peft_scheme="lora",  # or "dora"
-    train_iters=1000,
-    global_batch_size=128,
-    finetune_lr=1e-4,
-    # Uses TP=1, PP=1 (8 GPUs) automatically
-)
+config = qwen25_7b_peft_config(peft_scheme="lora")  # or "dora"
+config.checkpoint.pretrained_checkpoint = "/results/qwen25_7b/checkpoints/iter_0500000"
+config.train.train_iters = 1000
+config.train.global_batch_size = 128
+config.scheduler.lr_decay_iters = 1000
+config.optimizer.lr = 1e-4
+# Uses TP=1, PP=1 (1 model-parallel GPU); additional GPUs become data parallel
 ```
 
 ### Hugging Face Model Cards

--- a/tests/unit_tests/doc_consistency/test_readme_consistency.py
+++ b/tests/unit_tests/doc_consistency/test_readme_consistency.py
@@ -53,10 +53,6 @@ QWEN25_VL_DOCS = (
     REPO_ROOT / "docs" / "models" / "qwen" / "qwen2.5-vl.md",
     REPO_ROOT / "docs" / "fern" / "versions" / "nightly" / "pages" / "models" / "qwen" / "qwen2.5-vl.mdx",
 )
-QWEN2_DOCS = (
-    REPO_ROOT / "docs" / "models" / "qwen" / "qwen.md",
-    REPO_ROOT / "docs" / "fern" / "versions" / "nightly" / "pages" / "models" / "qwen" / "qwen.mdx",
-)
 VALOR_TUTORIAL = REPO_ROOT / "tutorials" / "data" / "valor32k-avqa" / "data-preparation.md"
 SPHINX_TUTORIAL_LINK_DOCS = (
     REPO_ROOT / "docs" / "training" / "data-preparation.md",
@@ -314,32 +310,6 @@ def test_multimodal_model_docs_use_current_launchers_and_conversion_flags():
     assert "--megatron-path /checkpoints/nemotron_omni" in valor
     assert "--hf_path" not in valor
     assert "--output_dir /checkpoints/nemotron_omni" not in valor
-
-
-def test_qwen2_recipe_examples_use_current_factory_api():
-    """Qwen2 recipe examples must call factories with their supported keywords."""
-    expected_keywords = {
-        "qwen25_7b_pretrain_config": set(),
-        "qwen25_7b_sft_config": set(),
-        "qwen25_7b_peft_config": {"peft_scheme"},
-    }
-    for path in QWEN2_DOCS:
-        qwen2_docs = _read(path).split("## Qwen2 / Qwen2.5", 1)[1]
-        examples = qwen2_docs.split("#### Pre-training Example", 1)[1].split("### Hugging Face Model Cards", 1)[0]
-        assert examples.count("config.optimizer.lr =") == 2
-        assert examples.count("config.scheduler.lr_decay_iters = 1000") == 2
-        assert "config.scheduler.max_lr" not in examples
-        calls: dict[str, list[set[str | None]]] = {name: [] for name in expected_keywords}
-        for code in re.findall(r"```python\n(.*?)```", examples, re.DOTALL):
-            tree = ast.parse(code, filename=str(path))
-            for node in ast.walk(tree):
-                if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id in calls:
-                    calls[node.func.id].append({keyword.arg for keyword in node.keywords})
-
-        for name, allowed_keywords in expected_keywords.items():
-            assert calls[name] == [allowed_keywords], (
-                f"{path.relative_to(REPO_ROOT)} calls {name} with unsupported keywords: {calls[name]}"
-            )
 
 
 def test_sphinx_docs_link_out_of_tree_tutorials_as_urls():

--- a/tests/unit_tests/doc_consistency/test_readme_consistency.py
+++ b/tests/unit_tests/doc_consistency/test_readme_consistency.py
@@ -53,6 +53,10 @@ QWEN25_VL_DOCS = (
     REPO_ROOT / "docs" / "models" / "qwen" / "qwen2.5-vl.md",
     REPO_ROOT / "docs" / "fern" / "versions" / "nightly" / "pages" / "models" / "qwen" / "qwen2.5-vl.mdx",
 )
+QWEN2_DOCS = (
+    REPO_ROOT / "docs" / "models" / "qwen" / "qwen.md",
+    REPO_ROOT / "docs" / "fern" / "versions" / "nightly" / "pages" / "models" / "qwen" / "qwen.mdx",
+)
 VALOR_TUTORIAL = REPO_ROOT / "tutorials" / "data" / "valor32k-avqa" / "data-preparation.md"
 SPHINX_TUTORIAL_LINK_DOCS = (
     REPO_ROOT / "docs" / "training" / "data-preparation.md",
@@ -310,6 +314,32 @@ def test_multimodal_model_docs_use_current_launchers_and_conversion_flags():
     assert "--megatron-path /checkpoints/nemotron_omni" in valor
     assert "--hf_path" not in valor
     assert "--output_dir /checkpoints/nemotron_omni" not in valor
+
+
+def test_qwen2_recipe_examples_use_current_factory_api():
+    """Qwen2 recipe examples must call factories with their supported keywords."""
+    expected_keywords = {
+        "qwen25_7b_pretrain_config": set(),
+        "qwen25_7b_sft_config": set(),
+        "qwen25_7b_peft_config": {"peft_scheme"},
+    }
+    for path in QWEN2_DOCS:
+        qwen2_docs = _read(path).split("## Qwen2 / Qwen2.5", 1)[1]
+        examples = qwen2_docs.split("#### Pre-training Example", 1)[1].split("### Hugging Face Model Cards", 1)[0]
+        assert examples.count("config.optimizer.lr =") == 2
+        assert examples.count("config.scheduler.lr_decay_iters = 1000") == 2
+        assert "config.scheduler.max_lr" not in examples
+        calls: dict[str, list[set[str | None]]] = {name: [] for name in expected_keywords}
+        for code in re.findall(r"```python\n(.*?)```", examples, re.DOTALL):
+            tree = ast.parse(code, filename=str(path))
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id in calls:
+                    calls[node.func.id].append({keyword.arg for keyword in node.keywords})
+
+        for name, allowed_keywords in expected_keywords.items():
+            assert calls[name] == [allowed_keywords], (
+                f"{path.relative_to(REPO_ROOT)} calls {name} with unsupported keywords: {calls[name]}"
+            )
 
 
 def test_sphinx_docs_link_out_of_tree_tutorials_as_urls():


### PR DESCRIPTION
## Problem

The published Qwen2/Qwen2.5 pretraining, SFT, and PEFT examples pass legacy keyword overrides directly to recipe factories. The public aliases now resolve to canonical signatures `()`, `()`, and `(peft_scheme=...)`, so every example raises `TypeError` before constructing a configuration.

## Root cause

The examples retained the old `**user_kwargs` calling convention after the recipes moved to parameterless factories plus nested `ConfigContainer` overrides. Existing recipe tests use the current calling convention and did not execute these documentation blocks.

## Fix

- Call each factory with its supported signature.
- Express the documented overrides through their owning nested configs.
- Keep `scheduler.lr_decay_iters` aligned when overriding `train.train_iters` for SFT and PEFT.
- Correct the example comments to distinguish model-parallel GPU count from optional data parallelism.
- Add a stdlib-only contract test covering both current/nightly documentation mirrors, factory keywords, and LR/scheduler ownership.

## Validation

Fail before:

```text
uv run --no-sync python tests/unit_tests/doc_consistency/test_readme_consistency.py
14/15 passed; qwen25_7b_pretrain_config was called with unsupported name, data_paths, dir, train_iters, global_batch_size, and seq_length keywords.
```

Pass after:

```text
uv run --no-sync python tests/unit_tests/doc_consistency/test_readme_consistency.py
15/15 passed

git diff --check
passed

UV_PROJECT_ENVIRONMENT=<existing-dev-environment> uv run --no-sync pre-commit run --all-files
passed
```

## Scope

This changes documentation and its focused contract test only. It does not change recipe implementations, defaults, public APIs, dependencies, CI workflows, or the broader topology table. No GPU or convergence validation was performed.
