### PR TITLE
fix(training): preserve timer samples across logging backends

### DIFF
--- a/src/megatron/bridge/training/utils/train_utils.py
+++ b/src/megatron/bridge/training/utils/train_utils.py
@@ -821,14 +821,21 @@ def training_log(
     # Tensorboard values.
     # Timer requires all the ranks to call.
     if logger_config.log_timers_to_tensorboard and (iteration % logger_config.tensorboard_log_interval == 0):
-        reset_in_tb = False if hasattr(timers, "write_to_wandb") else True
-        timers.write(timers_to_log, writer, iteration, normalizer=total_iterations, reset=reset_in_tb)
-        if hasattr(timers, "write_to_wandb"):
-            timers.write_to_wandb(timers_to_log, wandb_writer, iteration, normalizer=total_iterations, reset=True)
-        if hasattr(timers, "write_to_mlflow"):
-            timers.write_to_mlflow(timers_to_log, mlflow_logger, iteration, normalizer=total_iterations, reset=True)
-        if hasattr(timers, "write_to_comet"):
-            timers.write_to_comet(timers_to_log, comet_logger, iteration, normalizer=total_iterations, reset=True)
+        timer_backends = [
+            (getattr(timers, "write_to_wandb", None), wandb_writer),
+            (getattr(timers, "write_to_mlflow", None), mlflow_logger),
+            (getattr(timers, "write_to_comet", None), comet_logger),
+        ]
+        timer_backends = [(write_fn, backend) for write_fn, backend in timer_backends if write_fn is not None]
+        timers.write(timers_to_log, writer, iteration, normalizer=total_iterations, reset=not timer_backends)
+        for index, (write_fn, backend) in enumerate(timer_backends):
+            write_fn(
+                timers_to_log,
+                backend,
+                iteration,
+                normalizer=total_iterations,
+                reset=index == len(timer_backends) - 1,
+            )
 
     if config.profiling and config.profiling.record_memory_history and iteration == config.profiling.profile_step_end:
         rank = get_rank_safe()

--- a/tests/unit_tests/training/utils/test_train_utils.py
+++ b/tests/unit_tests/training/utils/test_train_utils.py
@@ -19,7 +19,7 @@ import time
 import unittest.mock as mock
 from dataclasses import dataclass
 from functools import partial
-from types import SimpleNamespace
+from types import MethodType, SimpleNamespace
 
 import numpy as np
 import pytest
@@ -469,6 +469,83 @@ class TestTrainingLog:
 
         comet_logger.log_metrics.assert_any_call({"learning-rate": 1e-4}, step=1)
         comet_logger.log_metrics.assert_any_call({"batch-size": 64}, step=1)
+
+    def test_detailed_timers_reach_all_enabled_backends(self, monkeypatch, mock_config, mock_global_state):
+        """Detailed timer samples are shared by every enabled logging backend."""
+        from megatron.bridge.training.state import (
+            _timers_write_to_comet,
+            _timers_write_to_mlflow,
+            _timers_write_to_wandb,
+        )
+
+        class StatefulTimers:
+            def __init__(self):
+                self.samples = {"forward-backward": (4.0, 6.0)}
+
+            def _get_global_min_max_time(self, names, reset, barrier, normalizer):
+                samples = {name: self.samples[name] for name in names if name in self.samples}
+                if reset:
+                    self.samples.clear()
+                return samples
+
+            def write(self, names, writer, iteration, normalizer=1.0, reset=True, barrier=False):
+                self._get_global_min_max_time(names, reset, barrier, normalizer)
+
+        timers = StatefulTimers()
+        timers.write_to_wandb = MethodType(_timers_write_to_wandb, timers)
+        timers.write_to_mlflow = MethodType(_timers_write_to_mlflow, timers)
+        timers.write_to_comet = MethodType(_timers_write_to_comet, timers)
+
+        monkeypatch.setattr(
+            "megatron.bridge.training.utils.train_utils.get_num_microbatches",
+            lambda: 8,
+            raising=True,
+        )
+        monkeypatch.setattr(
+            "megatron.bridge.training.utils.train_utils.reduce_max_stat_across_model_parallel_group",
+            lambda value, mp_group: value,
+            raising=True,
+        )
+
+        mock_config.logger.tensorboard_log_interval = 1
+        mock_config.logger.log_interval = 5
+        mock_config.logger.timing_log_level = 1
+        mock_config.logger.log_throughput_to_tensorboard = False
+        mock_config.logger.log_memory_to_tensorboard = False
+        mock_config.logger.log_runtime_to_tensorboard = False
+        mock_config.logger.log_l2_norm_grad_to_tensorboard = False
+        mock_config.logger.log_loss_scale_to_tensorboard = False
+        mock_config.logger.log_world_size_to_tensorboard = False
+
+        mock_global_state.train_state.step = 1
+        mock_global_state.timers = timers
+        mock_global_state.tensorboard_logger = None
+        mock_global_state.wandb_logger = None
+        mlflow_logger = mock.MagicMock()
+        comet_logger = mock.MagicMock()
+        mock_global_state.mlflow_logger = mlflow_logger
+        mock_global_state.comet_logger = comet_logger
+
+        training_log(
+            loss_dict={},
+            total_loss_dict={},
+            learning_rate=1e-4,
+            decoupled_learning_rate=None,
+            loss_scale=1024.0,
+            report_memory_flag=False,
+            skipped_iter=0,
+            grad_norm=None,
+            params_norm=None,
+            num_zeros_in_grad=None,
+            config=mock_config,
+            global_state=mock_global_state,
+            history_wct=[],
+            model=None,
+        )
+
+        mlflow_logger.log_metrics.assert_any_call({"forward-backward-time": 6.0}, step=1)
+        comet_logger.log_metrics.assert_any_call({"forward-backward-time": 6.0}, step=1)
+        assert timers.samples == {}
 
     @mock.patch("megatron.bridge.training.utils.train_utils.get_num_microbatches")
     @mock.patch("megatron.bridge.training.utils.train_utils.reduce_max_stat_across_model_parallel_group")


### PR DESCRIPTION
## What changed

Detailed training timers are stored in one shared Megatron-Core timer set. Bridge previously read that set for TensorBoard without resetting, then invoked the always-bound W&B, MLflow, and Comet timer writers in order with `reset=True` for each. The W&B slot therefore consumed the interval even when W&B was disabled, leaving MLflow and Comet with empty or near-zero detailed timer values.

The timer fanout now reads non-destructively for every available backend except the last one, which resets the interval exactly once. This preserves the same all-rank call order while allowing each enabled backend to receive the same completed sample.

## Supported trigger and impact

This affects ordinary training with:

- `log_timers_to_tensorboard=True`
- `timing_log_level=1` or `2`
- MLflow and/or Comet enabled

W&B does not need to be enabled. Training itself continues, but documented detailed metrics such as `forward-backward-time` and `optimizer-time` are silently absent or wrong in later logging backends.

Related logging-integration context: #2652.

## Regression evidence

The regression test binds the real Bridge timer-backend helpers to one stateful timer sample, disables W&B, enables MLflow and Comet, and asserts both later backends receive the same sample before it is cleared.

Fail before:

```bash
uv run --no-sync python -m pytest tests/unit_tests/training/utils/test_train_utils.py::TestTrainingLog::test_detailed_timers_reach_all_enabled_backends -q
```

Result: `1 failed`; MLflow received `{}` instead of `{"forward-backward-time": 6.0}`.

Pass after: the unchanged command reports `1 passed`.

Adjacent validation:

```bash
uv run --no-sync python -m pytest \
  tests/unit_tests/training/utils/test_train_utils.py::TestTrainingLog::test_detailed_timers_reach_all_enabled_backends \
  tests/unit_tests/training/utils/test_train_utils.py::TestTrainingLog::test_comet_only_logs_general_training_scalars \
  tests/unit_tests/training/test_state.py::TestGlobalState::test_timers_property_lazy_initialization \
  tests/unit_tests/training/test_state.py::TestGlobalState::test_timers_property_has_write_to_mlflow \
  tests/unit_tests/training/test_state.py::TestTimersWriteToMlflow \
  tests/unit_tests/training/test_state.py::TestCometLoggerProperty::test_timers_property_has_write_to_comet \
  tests/unit_tests/training/test_state.py::TestTimersWriteToComet -q
```

Result: `17 passed`.

Additional checks:

```bash
git diff --check
uv run --no-sync pre-commit run --all-files
```

Both passed; every applicable pre-commit hook passed.

## Scope

This changes timer telemetry fanout only. It does not change model computation, optimizer behavior, public APIs, dependencies, CI configuration, or the pinned Megatron-Core revision. Validation is a deterministic CPU contract test plus adjacent unit tests; no full-suite, model-quality, convergence, performance, or live tracking-service validation is claimed.
