### PR TITLE
feat(data): expose `shuffle` in DataloaderConfig

### DIFF
--- a/src/megatron/bridge/data/base.py
+++ b/src/megatron/bridge/data/base.py
@@ -43,8 +43,12 @@ class DataloaderConfig:
     drop_last: bool = True
     """Whether dataloaders drop the last incomplete batch."""
 
-    shuffle: bool = True
-    """Whether the global-batch sampler used by ``dataloader_type="batch"`` reshuffles samples each epoch."""
+    train_shuffle: bool = True
+    """Whether the training global-batch sampler reshuffles samples each epoch.
+
+    Only used when ``dataloader_type="batch"``. Validation and test samples are
+    never shuffled.
+    """
 
     persistent_workers: bool = True
     """Whether dataloader workers persist between iterations."""

--- a/src/megatron/bridge/data/base.py
+++ b/src/megatron/bridge/data/base.py
@@ -43,6 +43,9 @@ class DataloaderConfig:
     drop_last: bool = True
     """Whether dataloaders drop the last incomplete batch."""
 
+    shuffle: bool = True
+    """Whether the global-batch sampler used by ``dataloader_type="batch"`` reshuffles samples each epoch."""
+
     persistent_workers: bool = True
     """Whether dataloader workers persist between iterations."""
 

--- a/src/megatron/bridge/data/loaders.py
+++ b/src/megatron/bridge/data/loaders.py
@@ -334,6 +334,7 @@ def build_train_valid_test_data_loaders(
         global_batch_size=cfg.train.global_batch_size,
         drop_last=drop_last,
         seed=sampler_seed,
+        shuffle=cfg.dataset.shuffle,
     )
     eval_gbs = (
         cfg.validation.eval_global_batch_size
@@ -362,6 +363,7 @@ def build_train_valid_test_data_loaders(
             global_batch_size=eval_gbs,
             drop_last=not (isinstance(cfg.dataset, GPTSFTDatasetConfig) and cfg.dataset.dataloader_type == "batch"),
             seed=sampler_seed,
+            shuffle=cfg.dataset.shuffle,
         )
     elif cfg.validation.eval_iters > 0:
         val_dataloader_type = "cyclic" if isinstance(cfg.dataset, GPTDatasetConfig) else cfg.dataset.dataloader_type
@@ -381,6 +383,7 @@ def build_train_valid_test_data_loaders(
             global_batch_size=eval_gbs,
             drop_last=not (isinstance(cfg.dataset, GPTSFTDatasetConfig) and val_dataloader_type == "batch"),
             seed=sampler_seed,
+            shuffle=cfg.dataset.shuffle,
         )
 
     if cfg.validation.eval_iters > 0:
@@ -400,6 +403,7 @@ def build_train_valid_test_data_loaders(
             global_batch_size=eval_gbs,
             drop_last=not (isinstance(cfg.dataset, GPTSFTDatasetConfig) and cfg.dataset.dataloader_type == "batch"),
             seed=sampler_seed,
+            shuffle=cfg.dataset.shuffle,
         )
 
     # Flags to know if we need to do training/validation/testing.

--- a/src/megatron/bridge/data/loaders.py
+++ b/src/megatron/bridge/data/loaders.py
@@ -334,7 +334,7 @@ def build_train_valid_test_data_loaders(
         global_batch_size=cfg.train.global_batch_size,
         drop_last=drop_last,
         seed=sampler_seed,
-        shuffle=cfg.dataset.shuffle,
+        shuffle=cfg.dataset.train_shuffle,
     )
     eval_gbs = (
         cfg.validation.eval_global_batch_size
@@ -363,7 +363,7 @@ def build_train_valid_test_data_loaders(
             global_batch_size=eval_gbs,
             drop_last=not (isinstance(cfg.dataset, GPTSFTDatasetConfig) and cfg.dataset.dataloader_type == "batch"),
             seed=sampler_seed,
-            shuffle=cfg.dataset.shuffle,
+            shuffle=False,
         )
     elif cfg.validation.eval_iters > 0:
         val_dataloader_type = "cyclic" if isinstance(cfg.dataset, GPTDatasetConfig) else cfg.dataset.dataloader_type
@@ -383,7 +383,7 @@ def build_train_valid_test_data_loaders(
             global_batch_size=eval_gbs,
             drop_last=not (isinstance(cfg.dataset, GPTSFTDatasetConfig) and val_dataloader_type == "batch"),
             seed=sampler_seed,
-            shuffle=cfg.dataset.shuffle,
+            shuffle=False,
         )
 
     if cfg.validation.eval_iters > 0:
@@ -403,7 +403,7 @@ def build_train_valid_test_data_loaders(
             global_batch_size=eval_gbs,
             drop_last=not (isinstance(cfg.dataset, GPTSFTDatasetConfig) and cfg.dataset.dataloader_type == "batch"),
             seed=sampler_seed,
-            shuffle=cfg.dataset.shuffle,
+            shuffle=False,
         )
 
     # Flags to know if we need to do training/validation/testing.

--- a/src/megatron/bridge/data/samplers.py
+++ b/src/megatron/bridge/data/samplers.py
@@ -26,6 +26,7 @@ def build_pretraining_data_loader(
     drop_last: Optional[bool] = True,
     global_batch_size: Optional[int] = None,
     seed: int | None = None,
+    shuffle: bool = True,
 ) -> Optional[DataLoader]:
     """Build a dataloader for pretraining.
 
@@ -53,6 +54,8 @@ def build_pretraining_data_loader(
         seed: Explicit shuffle seed for the global-batch sampler. Supplying the
               dataset seed keeps pipeline stages on the same sample order even
               though their model RNG seeds differ.
+        shuffle: Whether the global-batch sampler reshuffles samples each epoch.
+                 Only used when dataloader_type is 'batch'.
 
     Returns:
         A PyTorch DataLoader instance, or the dataset itself if dataloader_type is
@@ -101,6 +104,7 @@ def build_pretraining_data_loader(
             data_parallel_size=data_parallel_size,
             drop_last=drop_last,
             pad_samples_to_global_batch_size=not drop_last,
+            shuffle=shuffle,
             seed=seed,
         )
     elif dataloader_type == "external":

--- a/tests/functional_tests/test_groups/data/test_loaders.py
+++ b/tests/functional_tests/test_groups/data/test_loaders.py
@@ -320,7 +320,7 @@ class TestDataLoaders:
                 dataset_root="/tmp/dataset",
                 seq_length=512,
                 seed=4321,
-                shuffle=False,
+                train_shuffle=False,
                 num_workers=0,
                 persistent_workers=False,
             )
@@ -356,14 +356,14 @@ class TestDataLoaders:
         assert train_call.kwargs["seed"] == expected_seed
         assert valid_call.kwargs["seed"] == expected_seed
         assert test_call.kwargs["seed"] == expected_seed
-        assert train_call.kwargs["shuffle"] is cfg.dataset.shuffle
-        assert valid_call.kwargs["shuffle"] is cfg.dataset.shuffle
-        assert test_call.kwargs["shuffle"] is cfg.dataset.shuffle
+        assert train_call.kwargs["shuffle"] is cfg.dataset.train_shuffle
+        assert valid_call.kwargs["shuffle"] is False
+        assert test_call.kwargs["shuffle"] is False
 
     @mock.patch("torch.distributed.broadcast")
     @mock.patch("torch.distributed.get_world_size", return_value=1)
     @mock.patch("torch.distributed.get_rank", return_value=0)
-    def test_gpt_sft_batch_eval_preserves_split_smaller_than_global_batch(
+    def test_gpt_sft_batch_eval_is_unshuffled_and_preserves_split_smaller_than_global_batch(
         self, _mock_rank, _mock_world_size, _mock_broadcast
     ):
         class PaddingAwareDataset:
@@ -404,8 +404,8 @@ class TestDataLoaders:
         test_batch = next(iter(test_dataloader))
         assert valid_batch.shape == (cfg.validation.eval_global_batch_size,)
         assert test_batch.shape == (cfg.validation.eval_global_batch_size,)
-        assert -1 in valid_batch
-        assert -1 in test_batch
+        assert valid_batch.tolist() == [0, 1, 2, -1]
+        assert test_batch.tolist() == [0, 1, 2, -1]
 
     @mock.patch("torch.distributed.broadcast")
     @mock.patch("torch.distributed.get_world_size", return_value=1)

--- a/tests/functional_tests/test_groups/data/test_loaders.py
+++ b/tests/functional_tests/test_groups/data/test_loaders.py
@@ -320,6 +320,7 @@ class TestDataLoaders:
                 dataset_root="/tmp/dataset",
                 seq_length=512,
                 seed=4321,
+                shuffle=False,
                 num_workers=0,
                 persistent_workers=False,
             )
@@ -355,6 +356,9 @@ class TestDataLoaders:
         assert train_call.kwargs["seed"] == expected_seed
         assert valid_call.kwargs["seed"] == expected_seed
         assert test_call.kwargs["seed"] == expected_seed
+        assert train_call.kwargs["shuffle"] is cfg.dataset.shuffle
+        assert valid_call.kwargs["shuffle"] is cfg.dataset.shuffle
+        assert test_call.kwargs["shuffle"] is cfg.dataset.shuffle
 
     @mock.patch("torch.distributed.broadcast")
     @mock.patch("torch.distributed.get_world_size", return_value=1)

--- a/tests/functional_tests/test_groups/data/test_samplers.py
+++ b/tests/functional_tests/test_groups/data/test_samplers.py
@@ -217,6 +217,7 @@ class TestMegatronPretrainingBatchSampler:
         assert sampler.micro_batch_size == 4
         assert sampler._global_batch_size == 16
         assert sampler.data_parallel_size == 2
+        assert sampler.shuffle is True
 
     def test_batch_sampler_length(self):
         """Test length calculation for batch sampler.
@@ -859,6 +860,23 @@ class TestBatchUtilities:
 
 class TestBatchDataloaderIntegration:
     """Integration tests for batch dataloader type."""
+
+    def test_build_batch_dataloader_propagates_shuffle(self):
+        """The loader builder must pass shuffle through to the batch sampler."""
+        dataloader = build_pretraining_data_loader(
+            dataset=list(range(16)),
+            consumed_samples=0,
+            dataloader_type="batch",
+            micro_batch_size=1,
+            num_workers=0,
+            data_sharding=False,
+            global_batch_size=4,
+            seed=1234,
+            shuffle=False,
+        )
+
+        assert dataloader.batch_sampler.shuffle is False
+        assert next(iter(dataloader.batch_sampler)) == [0, 1, 2, 3]
 
     def test_build_batch_dataloader_explicit_seed_is_independent_of_model_rng(self):
         """Pipeline-stage model seeds must not change the fine-tuning sample order."""

--- a/tests/unit_tests/data/builders/test_gpt_sft_config.py
+++ b/tests/unit_tests/data/builders/test_gpt_sft_config.py
@@ -59,6 +59,7 @@ def test_config_round_trip_is_declarative_and_serializable(tmp_path):
         hf_output_root=str(tmp_path),
         hf_validation_proportion=0.1,
         seed=5678,
+        shuffle=False,
         enable_offline_packing=True,
         offline_packing_specs=specs,
         do_test=False,
@@ -73,6 +74,7 @@ def test_config_round_trip_is_declarative_and_serializable(tmp_path):
     assert restored.offline_packing_specs.packed_sequence_size == 128
     assert restored.offline_packing_specs.max_single_sequence_length == 120
     assert isinstance(restored.preprocessing, PromptCompletionSFTPreprocessingConfig)
+    assert restored.shuffle is False
     assert "tokenizer" not in serialized
 
 

--- a/tests/unit_tests/data/builders/test_gpt_sft_config.py
+++ b/tests/unit_tests/data/builders/test_gpt_sft_config.py
@@ -59,7 +59,7 @@ def test_config_round_trip_is_declarative_and_serializable(tmp_path):
         hf_output_root=str(tmp_path),
         hf_validation_proportion=0.1,
         seed=5678,
-        shuffle=False,
+        train_shuffle=False,
         enable_offline_packing=True,
         offline_packing_specs=specs,
         do_test=False,
@@ -74,7 +74,7 @@ def test_config_round_trip_is_declarative_and_serializable(tmp_path):
     assert restored.offline_packing_specs.packed_sequence_size == 128
     assert restored.offline_packing_specs.max_single_sequence_length == 120
     assert isinstance(restored.preprocessing, PromptCompletionSFTPreprocessingConfig)
-    assert restored.shuffle is False
+    assert restored.train_shuffle is False
     assert "tokenizer" not in serialized
 
 


### PR DESCRIPTION
# What does this PR do ?

This PR exposes `shuffle` as an argument in the top-level dataset configuration API so it can be set in `MegatronPretrainingBatchSampler`. It was added in #4601 and it changed the convergence behavior of our Llama 2 70b LORA benchmark.

# Changelog

- Add `shuffle` to necessary config classes to expose it through `DataloaderConfig`.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.