### PR TITLE
[test] fix: repair Nemotron-H CI regressions

### DIFF
--- a/tests/functional_tests/test_groups/recipes/test_nemotronh_recipes_pretrain.py
+++ b/tests/functional_tests/test_groups/recipes/test_nemotronh_recipes_pretrain.py
@@ -36,6 +36,7 @@ NEMOTRON_3_NANO_PRETRAIN_RECIPES = [
             "num_moe_experts": 16,
             "moe_token_dispatcher_type": "alltoall",
             "moe_shared_expert_overlap": True,
+            "sequence_parallel": True,
         },
     ),
 ]

--- a/tests/unit_tests/models/nemotronh/test_nemotron_h_bridge.py
+++ b/tests/unit_tests/models/nemotronh/test_nemotron_h_bridge.py
@@ -368,14 +368,14 @@ class TestNemotronHBridge:
     @pytest.mark.parametrize("num_nextn_predict_layers", [None, 0])
     def test_provider_bridge_disables_mtp_naturally(
         self,
-        nemotron_nano_v2_config_dict,
+        active_nemotronh_config_dict,
         num_nextn_predict_layers,
     ):
         """HF configs without enabled MTP produce a normal non-MTP provider."""
         from types import SimpleNamespace
 
         config_dict = {
-            **nemotron_nano_v2_config_dict,
+            **active_nemotronh_config_dict,
             "n_routed_experts": 0,
             "mtp_hybrid_override_pattern": "*E",
             "keep_mtp_spec_in_bf16": True,
@@ -393,14 +393,14 @@ class TestNemotronHBridge:
         assert result.mtp_use_repeated_layer is False
         assert result.keep_mtp_spec_in_bf16 is False
 
-    def test_provider_bridge_rejects_incomplete_mtp_config(self, nemotron_nano_v2_config_dict):
+    def test_provider_bridge_rejects_incomplete_mtp_config(self, active_nemotronh_config_dict):
         """An enabled HF MTP config must describe its hybrid block."""
         from types import SimpleNamespace
 
         mock_pretrained = Mock(spec=PreTrainedCausalLM)
         mock_pretrained.config = SimpleNamespace(
             **{
-                **nemotron_nano_v2_config_dict,
+                **active_nemotronh_config_dict,
                 "n_routed_experts": 0,
                 "num_nextn_predict_layers": 1,
             }


### PR DESCRIPTION
## What changed

- update the remaining Nemotron-H MTP tests to use `active_nemotronh_config_dict`
- enable sequence parallelism in the Nemotron-3-Nano functional smoke when it overrides the recipe to TP=2

## Why

Two Nemotron-H jobs failed on main:

1. Core unit tests referenced the deleted `nemotron_nano_v2_config_dict` fixture after #5125 renamed the shared fixture.
2. The Nano functional smoke still overrides the recipe to TP=2 after #5035 changed the production recipe default to TP=1/SP=False. MoE with TP>1 requires sequence parallelism, so the test configuration was incomplete.

The production Nano recipe remains unchanged at its valid TP=1/SP=False default.

Failing jobs:

- https://github.com/NVIDIA-NeMo/Megatron-Bridge/actions/runs/30326815974/job/90174547300
- https://github.com/NVIDIA-NeMo/Megatron-Bridge/actions/runs/30326815974/job/90175706124

## Validation

- original failing MTP unit cases: 3 passed
- complete `test_nemotron_h_bridge.py`: 65 passed
- exact 2-GPU Nano functional smoke: 1 passed, including 10 training iterations, evaluation, checkpoint save, and checkpoint verification
- `uv run pre-commit run --all-files`: passed