### PR TITLE
 feat(conversion): enable Qwen3.5 MoE MIMO round trips

### DIFF
--- a/examples/megatron_mimo/qwen35_vl/conversion.sh
+++ b/examples/megatron_mimo/qwen35_vl/conversion.sh
@@ -18,15 +18,19 @@
 # Wraps the generic, model-agnostic CLI at
 #   examples/conversion/convert_megatron_mimo.py
 # with Qwen3.5-VL defaults: two MIMO components (`language` + `images`)
-# whose names must match the route table declared by the registered
-# Qwen3.5-VL MIMO adapter
-# (src/megatron/bridge/models/megatron_mimo/conversion/adapters/qwen35_vl.py).
+# whose names must match the route table derived from the Qwen3.5-VL bridge's
+# `mimo_source_prefixes` and the provider's `modality_keys`
+# (src/megatron/bridge/models/qwen_vl/qwen35_vl_bridge.py).
 #
 # Usage:
 #   bash examples/megatron_mimo/qwen35_vl/conversion.sh
 #
 # Override defaults via environment variables, e.g.:
 #   MODEL_NAME=Qwen3.5-27B LANGUAGE_TP=4 VISION_TP=1 \
+#     bash examples/megatron_mimo/qwen35_vl/conversion.sh
+#
+# MoE variants need expert parallelism, e.g.:
+#   MODEL_NAME=Qwen3.5-35B-A3B LANGUAGE_DP=4 LANGUAGE_EP=4 VISION_TP=1 \
 #     bash examples/megatron_mimo/qwen35_vl/conversion.sh
 #
 # Mirrors the non-MIMO Qwen3.5-VL entry point at
@@ -38,16 +42,18 @@ set -xeuo pipefail
 # Workspace directory for checkpoints and results.
 WORKSPACE=${WORKSPACE:-/workspace}
 
-# Supported dense Qwen3.5-VL variants. MoE variants
-# (Qwen3.5-35B-A3B / 122B-A10B / 397B-A17B) are out of v1 scope.
+# Supported Qwen3.5-VL variants: dense plus the MoE variants.
 MODEL_NAME=${MODEL_NAME:-Qwen3.5-0.8B}
 
 case "${MODEL_NAME}" in
     Qwen3.5-0.8B|Qwen3.5-2B|Qwen3.5-4B|Qwen3.5-9B|Qwen3.5-27B)
         ;;
+    Qwen3.5-35B-A3B|Qwen3.5-122B-A10B|Qwen3.5-397B-A17B)
+        ;;
     *)
         echo "Unsupported MODEL_NAME=${MODEL_NAME}." \
-             "MIMO v1 supports dense variants only: Qwen3.5-{0.8B,2B,4B,9B,27B}."
+             "Supported: dense Qwen3.5-{0.8B,2B,4B,9B,27B} and MoE" \
+             "Qwen3.5-{35B-A3B,122B-A10B,397B-A17B}."
         exit 1
         ;;
 esac
@@ -60,6 +66,12 @@ LANGUAGE_TP=${LANGUAGE_TP:-1}
 VISION_TP=${VISION_TP:-1}
 LANGUAGE_DP=${LANGUAGE_DP:-1}
 VISION_DP=${VISION_DP:-1}
+# Expert parallelism for the language component. MoE variants need EP > 1:
+# with EP=1 every language rank holds a full copy of the expert weights, which
+# does not fit for the MoE sizes. Encoder components must stay dense (EP=1),
+# and the config requires LANGUAGE_TP * LANGUAGE_DP to be divisible by
+# LANGUAGE_EP, so scale DP with EP (e.g. LANGUAGE_EP=4 with LANGUAGE_DP=4).
+LANGUAGE_EP=${LANGUAGE_EP:-1}
 LANGUAGE_RANK_OFFSET=${LANGUAGE_RANK_OFFSET:-0}
 VISION_RANK_OFFSET=${VISION_RANK_OFFSET:-$((LANGUAGE_RANK_OFFSET + LANGUAGE_TP * LANGUAGE_DP))}
 
@@ -78,7 +90,7 @@ uv run python -m torch.distributed.run --nproc_per_node="${NPROC_PER_NODE}" \
     examples/conversion/convert_megatron_mimo.py import \
         --hf-model "Qwen/${MODEL_NAME}" \
         --megatron-path "${MEGATRON_PATH}" \
-        --component "language=tp=${LANGUAGE_TP},dp=${LANGUAGE_DP},rank_offset=${LANGUAGE_RANK_OFFSET}" \
+        --component "language=tp=${LANGUAGE_TP},dp=${LANGUAGE_DP},ep=${LANGUAGE_EP},rank_offset=${LANGUAGE_RANK_OFFSET}" \
         --component "images=tp=${VISION_TP},dp=${VISION_DP},rank_offset=${VISION_RANK_OFFSET}" \
         --torch-dtype "${TORCH_DTYPE}"
 
@@ -90,6 +102,6 @@ uv run python -m torch.distributed.run --nproc_per_node="${NPROC_PER_NODE}" \
         --hf-model "Qwen/${MODEL_NAME}" \
         --megatron-path "${MEGATRON_PATH}" \
         --hf-path "${HF_PATH}" \
-        --component "language=tp=${LANGUAGE_TP},dp=${LANGUAGE_DP},rank_offset=${LANGUAGE_RANK_OFFSET}" \
+        --component "language=tp=${LANGUAGE_TP},dp=${LANGUAGE_DP},ep=${LANGUAGE_EP},rank_offset=${LANGUAGE_RANK_OFFSET}" \
         --component "images=tp=${VISION_TP},dp=${VISION_DP},rank_offset=${VISION_RANK_OFFSET}" \
         --torch-dtype "${TORCH_DTYPE}"

--- a/src/megatron/bridge/models/conversion/model_bridge.py
+++ b/src/megatron/bridge/models/conversion/model_bridge.py
@@ -952,7 +952,11 @@ class MegatronModelBridge(
         """
         from megatron.bridge.utils.common_utils import extract_expert_number_from_param
 
-        ep_size = parallel_state.get_expert_model_parallel_world_size()
+        # Use the mapping's process group rather than the global parallel-state
+        # singleton. Decentralized callers such as MegatronMIMO install
+        # route-local groups directly on mappings, while MCore's cached global EP
+        # world size may still describe another component.
+        ep_size = task.mapping.ep_size
         num_experts = model_config.num_moe_experts
         experts_per_rank = num_experts // ep_size
 

--- a/src/megatron/bridge/models/megatron_mimo/conversion/orchestrator.py
+++ b/src/megatron/bridge/models/megatron_mimo/conversion/orchestrator.py
@@ -30,7 +30,12 @@ import torch.nn as nn
 from megatron.core.transformer.module import MegatronModule
 from transformers.configuration_utils import PretrainedConfig
 
-from megatron.bridge.models.conversion.auto_bridge import AutoBridge
+from megatron.bridge.models.conversion.auto_bridge import (
+    MTP_CONFIG_FIELDS,
+    AutoBridge,
+    _model_omits_mtp,
+    _mtp_source_key_prefixes,
+)
 from megatron.bridge.models.conversion.mapping_registry import MegatronMappingRegistry
 from megatron.bridge.models.conversion.model_bridge import HFWeightTuple
 from megatron.bridge.models.hf_pretrained.causal_lm import PreTrainedCausalLM
@@ -279,13 +284,32 @@ def build_route_local_registry(
     return MegatronMappingRegistry(*stripped)
 
 
+def bind_hf_source_to_bridge(source_bridge: "MegatronModelBridge", hf_pretrained: Any) -> None:
+    """Attach the HF source to a bridge before its mapping registry is built.
+
+    ``MegatronModelBridge.mapping_registry()`` may inspect the checkpoint itself —
+    for example to detect whether MoE experts are stored fused or per-expert — and
+    falls back to no-checkpoint defaults when nothing is attached. The standard
+    conversion entry points bind ``hf_pretrained`` / ``hf_config`` before consulting
+    the registry, but MIMO builds route-local registries eagerly in
+    :func:`make_route_local_bridge`, so it must bind first or every route silently
+    inherits the wrong mappings.
+    """
+    source_bridge.hf_pretrained = hf_pretrained
+    source_bridge.hf_config = hf_pretrained.config if hasattr(hf_pretrained, "config") else hf_pretrained
+
+
 def make_route_local_bridge(
     source_bridge: "MegatronModelBridge",
     route: MIMOComponent,
     *,
     route_local_registry: MegatronMappingRegistry | None = None,
 ) -> "MegatronModelBridge":
-    """Clone a source bridge and override its registry for one route."""
+    """Clone a source bridge and override its registry for one route.
+
+    Callers must bind the HF source with :func:`bind_hf_source_to_bridge` first when
+    the registry is checkpoint-dependent.
+    """
     if route_local_registry is None:
         route_local_registry = build_route_local_registry(source_bridge.mapping_registry(), route)
 
@@ -513,6 +537,7 @@ class MegatronMIMOBridge(AutoBridge):
         mimo_model = self._coerce_mimo_model(megatron_model)
         infra = self._require_infra(infra)
         hf_pretrained = self._resolve_hf_pretrained(hf_path)
+        bind_hf_source_to_bridge(self._model_bridge, hf_pretrained)
 
         tasks: list[MIMOConversionTask] = []
         for route, pg_collection in _iter_active_routes(self.routes, infra.pg_collections):
@@ -808,6 +833,8 @@ def import_hf_to_megatron_mimo(
     active route with a prefix-stripped registry and the route's
     pg_collection. Returns ``mimo_model`` for convenience.
     """
+    bind_hf_source_to_bridge(source_bridge, hf_pretrained)
+
     for route, pg_collection in _iter_active_routes(routes, pg_collections):
         submodule = mimo_model.get_submodule(route.target_module_path)
         wrapped = make_route_local_bridge(source_bridge, route)
@@ -849,6 +876,8 @@ def export_megatron_mimo_to_hf(
     Megatron-side ``megatron_param`` is prefix-stripped, so routes produce
     disjoint subsets of the HF state dict.
     """
+    bind_hf_source_to_bridge(source_bridge, hf_pretrained)
+
     for route, pg_collection in _iter_active_routes(routes, pg_collections):
         submodule = mimo_model.get_submodule(route.target_module_path)
         wrapped = make_route_local_bridge(source_bridge, route)
@@ -892,18 +921,23 @@ def save_hf_pretrained_mimo(
             "pre-safetensors checkpoints are not supported."
         )
 
+    standard_provider = bridge._require_provider().standard_provider
+    mtp_disabled = _model_omits_mtp(standard_provider)
     output_path = Path(path)
     if dist.is_initialized():
         if dist.get_rank() == 0:
-            _copy_hf_artifacts(bridge, output_path, source_path=source_path)
+            _copy_hf_artifacts(bridge, output_path, source_path=source_path, disable_mtp=mtp_disabled)
     else:
-        _copy_hf_artifacts(bridge, output_path, source_path=source_path)
+        _copy_hf_artifacts(bridge, output_path, source_path=source_path, disable_mtp=mtp_disabled)
 
     if dist.is_initialized():
         dist.barrier()
 
     state_source = bridge.hf_pretrained.state.source
     assert isinstance(state_source, SafeTensorsStateSource), "checked above"
+    ignored_source_key_prefixes = (
+        _mtp_source_key_prefixes(state_source, bridge.hf_pretrained.config, standard_provider) if mtp_disabled else ()
+    ) or None
     state_source.save_generator(
         _stream_mimo_weights_to_rank0(
             source_bridge=bridge._model_bridge,
@@ -915,6 +949,7 @@ def save_hf_pretrained_mimo(
         ),
         output_path,
         strict=strict,
+        ignored_source_key_prefixes=ignored_source_key_prefixes,
     )
 
     if dist.is_initialized():
@@ -929,14 +964,50 @@ def _copy_hf_artifacts(
     output_path: Path,
     *,
     source_path: Optional[Union[str, Path]] = None,
+    disable_mtp: bool = False,
 ) -> None:
     output_path.mkdir(parents=True, exist_ok=True)
     additional_files = getattr(bridge._model_bridge, "ADDITIONAL_FILE_PATTERNS", None) or None
-    bridge.hf_pretrained.save_artifacts(
-        output_path,
-        original_source_path=source_path,
-        additional_files=additional_files,
-    )
+    with _temporarily_disable_hf_mtp(bridge.hf_pretrained.config, enabled=disable_mtp):
+        bridge.hf_pretrained.save_artifacts(
+            output_path,
+            original_source_path=source_path,
+            additional_files=additional_files,
+        )
+
+
+@contextlib.contextmanager
+def _temporarily_disable_hf_mtp(config: Any, *, enabled: bool) -> Iterator[None]:
+    """Save a config consistent with MIMO's intentionally omitted MTP route."""
+    if not enabled:
+        yield
+        return
+
+    mutations: list[tuple[Any, str, Any]] = []
+    configs = [config]
+    text_config = config.get("text_config") if isinstance(config, dict) else getattr(config, "text_config", None)
+    if text_config is not None:
+        configs.append(text_config)
+
+    for current in configs:
+        for field in MTP_CONFIG_FIELDS:
+            if isinstance(current, dict):
+                if field not in current:
+                    continue
+                mutations.append((current, field, current[field]))
+                current[field] = 0
+            elif field in getattr(current, "__dict__", {}):
+                mutations.append((current, field, getattr(current, field)))
+                setattr(current, field, 0)
+
+    try:
+        yield
+    finally:
+        for current, field, value in mutations:
+            if isinstance(current, dict):
+                current[field] = value
+            else:
+                setattr(current, field, value)
 
 
 def _stream_mimo_weights_to_rank0(

--- a/src/megatron/bridge/models/megatron_mimo/megatron_mimo_provider.py
+++ b/src/megatron/bridge/models/megatron_mimo/megatron_mimo_provider.py
@@ -163,6 +163,7 @@ class MegatronMIMOProvider(ModelProviderMixin[MimoModel]):
         self._sync_standard_provider_language_parallelism()
 
         # MIMO conversion does not import/export MTP routes yet.
+        # TODO: Remove this override once Megatron-LM's MegatronMIMO path supports MTP.
         if hasattr(standard_provider, "mtp_num_layers"):
             setattr(standard_provider, "mtp_num_layers", None)
 

--- a/src/megatron/bridge/models/qwen_vl/qwen35_vl_bridge.py
+++ b/src/megatron/bridge/models/qwen_vl/qwen35_vl_bridge.py
@@ -164,6 +164,8 @@ class Qwen35VLMoEBridge(MegatronModelBridge):
         >>> provider = bridge.to_megatron_provider()
     """
 
+    mimo_source_prefixes = {"language": "language_model.", "images": "vision_model."}
+
     def provider_bridge(self, hf_pretrained: PreTrainedCausalLM) -> Qwen35VLMoEModelProvider:
         """
         Create a Qwen35VLMoEModelProvider from a HuggingFace pretrained model.

--- a/tests/unit_tests/models/megatron_mimo/conversion/test_orchestrator.py
+++ b/tests/unit_tests/models/megatron_mimo/conversion/test_orchestrator.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from collections import namedtuple
+from types import SimpleNamespace
 from unittest.mock import Mock
 
 import pytest
@@ -516,6 +517,38 @@ def test_save_hf_pretrained_mimo_rejects_non_safetensors_source(tmp_path):
 
     with pytest.raises(ValueError, match="safetensors"):
         orchestrator_module.save_hf_pretrained_mimo(bridge, _FakeMimoModel(), [], {}, tmp_path)
+
+
+def test_save_hf_pretrained_mimo_disables_and_ignores_omitted_mtp(monkeypatch, tmp_path):
+    from megatron.bridge.models.hf_pretrained.state import SafeTensorsStateSource
+
+    text_config = SimpleNamespace(mtp_num_hidden_layers=1, num_hidden_layers=40)
+    config = SimpleNamespace(text_config=text_config)
+    saved_mtp_values = []
+
+    hf_pretrained = Mock()
+    hf_pretrained.config = config
+    hf_pretrained.save_artifacts.side_effect = lambda *args, **kwargs: saved_mtp_values.append(
+        text_config.mtp_num_hidden_layers
+    )
+    state_source = Mock(spec=SafeTensorsStateSource)
+    state_source.has_glob.side_effect = lambda pattern: pattern == "mtp.*"
+    hf_pretrained.state.source = state_source
+
+    standard_provider = SimpleNamespace(mtp_num_layers=None)
+    bridge = Mock()
+    bridge.hf_pretrained = hf_pretrained
+    bridge._model_bridge = Mock(ADDITIONAL_FILE_PATTERNS=None)
+    bridge._require_provider.return_value = SimpleNamespace(standard_provider=standard_provider)
+
+    monkeypatch.setattr(orchestrator_module.dist, "is_initialized", lambda: False)
+    monkeypatch.setattr(orchestrator_module, "_stream_mimo_weights_to_rank0", lambda **kwargs: iter(()))
+
+    orchestrator_module.save_hf_pretrained_mimo(bridge, _FakeMimoModel(), [], {}, tmp_path)
+
+    assert saved_mtp_values == [0]
+    assert text_config.mtp_num_hidden_layers == 1
+    assert state_source.save_generator.call_args.kwargs["ignored_source_key_prefixes"] == ("mtp.",)
 
 
 def test_copy_hf_artifacts_forwards_additional_file_patterns(tmp_path):

--- a/tests/unit_tests/models/megatron_mimo/conversion/test_qwen35_vl_default_conversion.py
+++ b/tests/unit_tests/models/megatron_mimo/conversion/test_qwen35_vl_default_conversion.py
@@ -31,8 +31,13 @@ from megatron.bridge.models.megatron_mimo.megatron_mimo_config import (
     ModuleParallelismConfig,
 )
 from megatron.bridge.models.megatron_mimo.megatron_mimo_provider import MegatronMIMOProvider
-from megatron.bridge.models.qwen_vl.qwen35_vl_bridge import Qwen35VLBridge
-from megatron.bridge.models.qwen_vl.qwen35_vl_provider import _TRANSFORMERS_HAS_QWEN3_5, Qwen35VLModelProvider
+from megatron.bridge.models.qwen_vl.qwen35_vl_bridge import Qwen35VLBridge, Qwen35VLMoEBridge
+from megatron.bridge.models.qwen_vl.qwen35_vl_provider import (
+    _TRANSFORMERS_HAS_QWEN3_5,
+    _TRANSFORMERS_HAS_QWEN3_5_MOE,
+    Qwen35VLModelProvider,
+    Qwen35VLMoEModelProvider,
+)
 
 
 pytestmark = pytest.mark.skipif(not _TRANSFORMERS_HAS_QWEN3_5, reason="transformers does not have qwen3_5 support")
@@ -74,20 +79,36 @@ def _patch_language_spec(monkeypatch, language_provider: Qwen35VLModelProvider) 
     )
 
 
-def _get_qwen35_conversion_spec():
+def _make_moe_language_provider() -> Qwen35VLMoEModelProvider:
+    """Small Qwen35VLMoEModelProvider; see ``_make_language_provider`` for the vision-config note."""
+    provider = Qwen35VLMoEModelProvider(
+        num_layers=4,
+        hidden_size=256,
+        num_attention_heads=8,
+        vocab_size=128,
+        num_moe_experts=8,
+        moe_router_topk=2,
+        moe_ffn_hidden_size=128,
+    )
+    provider.vision_config.deepstack_visual_indexes = []
+    return provider
+
+
+def _get_qwen35_conversion_spec(bridge_cls: type = Qwen35VLBridge):
     _reset_registry_for_tests()
-    return get_mimo_conversion_spec(Qwen35VLBridge)
+    return get_mimo_conversion_spec(bridge_cls)
 
 
 def _run_qwen35_conversion_spec(
     monkeypatch,
-    language_provider: Qwen35VLModelProvider,
+    language_provider: Qwen35VLModelProvider | Qwen35VLMoEModelProvider,
     parallelism_config: MegatronMIMOParallelismConfig,
+    bridge_cls: type = Qwen35VLBridge,
 ) -> tuple[MegatronMIMOProvider, list[MIMOComponent], Qwen35VLBridge, object]:
-    source_bridge = Qwen35VLBridge()
+    source_bridge = bridge_cls()
     monkeypatch.setattr(source_bridge, "provider_bridge", MagicMock(return_value=language_provider))
     hf_pretrained = object()
-    provider, routes = _get_qwen35_conversion_spec()(source_bridge, hf_pretrained, parallelism_config)
+    provider, routes = _get_qwen35_conversion_spec(bridge_cls)(source_bridge, hf_pretrained, parallelism_config)
     return provider, routes, source_bridge, hf_pretrained
 
 
@@ -164,3 +185,90 @@ class TestQwen35VLDefaultMIMOConversion:
         _, routes, _, _ = _run_qwen35_conversion_spec(monkeypatch, language_provider, parallelism_config)
 
         validate_route_table(routes, parallelism_config=parallelism_config)
+
+
+@pytest.mark.skipif(not _TRANSFORMERS_HAS_QWEN3_5_MOE, reason="transformers does not have qwen3_5_moe support")
+class TestQwen35VLMoEDefaultMIMOConversion:
+    """MoE variants resolve the same default MIMO conversion spec as the dense bridge.
+
+    The MoE mapping registry uses the same Megatron-side ``language_model.`` /
+    ``vision_model.`` prefixes as the dense one, so declaring
+    ``mimo_source_prefixes`` is all that is needed to reach the default route
+    builder — no MoE-specific conversion spec.
+    """
+
+    def test_default_conversion_spec_available_for_moe_bridge(self):
+        conversion_spec = _get_qwen35_conversion_spec(Qwen35VLMoEBridge)
+
+        assert callable(conversion_spec)
+        assert supports_mimo_conversion(Qwen35VLMoEBridge)
+
+    def test_returns_provider_and_routes(self, monkeypatch):
+        language_provider = _make_moe_language_provider()
+        _patch_language_spec(monkeypatch, language_provider)
+        parallelism_config = _make_parallelism_config()
+
+        provider, routes, source_bridge, hf_pretrained = _run_qwen35_conversion_spec(
+            monkeypatch,
+            language_provider,
+            parallelism_config,
+            bridge_cls=Qwen35VLMoEBridge,
+        )
+
+        source_bridge.provider_bridge.assert_called_once_with(hf_pretrained)
+        assert isinstance(provider, MegatronMIMOProvider)
+        assert provider.language_model_spec.params["config"] is language_provider
+        assert provider.megatron_mimo_parallelism_config is parallelism_config
+        assert len(routes) == 2
+
+    def test_route_table_contents(self, monkeypatch):
+        """MoE routes must resolve to the same prefixes/targets as the dense bridge."""
+        language_provider = _make_moe_language_provider()
+        _patch_language_spec(monkeypatch, language_provider)
+        _, routes, _, _ = _run_qwen35_conversion_spec(
+            monkeypatch,
+            language_provider,
+            _make_parallelism_config(),
+            bridge_cls=Qwen35VLMoEBridge,
+        )
+
+        names = {route.name: route for route in routes}
+        assert set(names.keys()) == {"language", "images"}
+
+        assert names["language"].source_prefix == "language_model."
+        assert names["language"].target_module_path == "language_model"
+
+        assert names["images"].source_prefix == "vision_model."
+        assert names["images"].target_module_path == "modality_submodules.images.encoders.qwen_visual"
+
+    def test_forces_mtp_off(self, monkeypatch):
+        """MoE variants ship MTP layers; MIMO conversion does not import/export them."""
+        language_provider = _make_moe_language_provider()
+        _patch_language_spec(monkeypatch, language_provider)
+        language_provider.mtp_num_layers = 1
+
+        _run_qwen35_conversion_spec(
+            monkeypatch,
+            language_provider,
+            _make_parallelism_config(),
+            bridge_cls=Qwen35VLMoEBridge,
+        )
+
+        assert language_provider.mtp_num_layers is None
+
+    def test_route_table_validates_against_parallelism_config(self, monkeypatch):
+        parallelism_config = _make_parallelism_config()
+        language_provider = _make_moe_language_provider()
+        _patch_language_spec(monkeypatch, language_provider)
+        provider, routes, _, _ = _run_qwen35_conversion_spec(
+            monkeypatch,
+            language_provider,
+            parallelism_config,
+            bridge_cls=Qwen35VLMoEBridge,
+        )
+
+        validate_route_table(
+            routes,
+            parallelism_config=parallelism_config,
+            modality_submodules_spec=provider.modality_submodules_spec,
+        )

--- a/tests/unit_tests/models/stepfun/test_step35_bridge.py
+++ b/tests/unit_tests/models/stepfun/test_step35_bridge.py
@@ -742,7 +742,7 @@ class TestStackedExpertGatedMLPMapping:
     def test_grouped_export_accumulates_gate_and_up_separately(self, mock_ep_size):
         mock_ep_size.return_value = 1
         model_config = SimpleNamespace(num_moe_experts=2)
-        mapping = SimpleNamespace(is_grouped_export=True)
+        mapping = SimpleNamespace(is_grouped_export=True, ep_size=1)
         buffers = {}
 
         task0 = SimpleNamespace(

--- a/tests/unit_tests/models/test_model_bridge.py
+++ b/tests/unit_tests/models/test_model_bridge.py
@@ -233,6 +233,7 @@ def test_stream_weights_megatron_to_hf_transforms_grouped_tensor_once_after_accu
     class GroupedMapping:
         is_grouped_export = True
         group_key = "hf.grouped"
+        ep_size = 1
 
         def megatron_to_hf(self, weight, module):
             return {self.group_key: weight}
@@ -283,6 +284,43 @@ def test_stream_weights_megatron_to_hf_transforms_grouped_tensor_once_after_accu
         "hf.grouped.scale",
         "hf.grouped.scale_2",
     ]
+
+
+def test_grouped_export_uses_mapping_local_ep_size(monkeypatch):
+    monkeypatch.setattr(
+        "megatron.bridge.models.conversion.model_bridge.parallel_state.get_expert_model_parallel_world_size",
+        lambda: 1,
+    )
+    mapping = SimpleNamespace(is_grouped_export=True, ep_size=2)
+    model_config = SimpleNamespace(num_moe_experts=4)
+    buffers = {}
+
+    first = MegatronModelBridge._accumulate_grouped_export(
+        None,
+        SimpleNamespace(
+            mapping=mapping,
+            param_name="decoder.layers.0.mlp.experts.linear_fc2.weight0",
+        ),
+        {"hf.grouped": torch.tensor([[0.0], [2.0]])},
+        model_config,
+        buffers,
+        {},
+    )
+    second = MegatronModelBridge._accumulate_grouped_export(
+        None,
+        SimpleNamespace(
+            mapping=mapping,
+            param_name="decoder.layers.0.mlp.experts.linear_fc2.weight1",
+        ),
+        {"hf.grouped": torch.tensor([[1.0], [3.0]])},
+        model_config,
+        buffers,
+        {},
+    )
+
+    assert first is None
+    torch.testing.assert_close(second["hf.grouped"], torch.tensor([[0.0], [1.0], [2.0], [3.0]]))
+    assert buffers == {}
 
 
 def test_stream_weights_megatron_to_hf_finalizes_exported_tensors_before_cpu(monkeypatch):

--- a/tests/unit_tests/models/test_model_bridge_lora.py
+++ b/tests/unit_tests/models/test_model_bridge_lora.py
@@ -2003,6 +2003,7 @@ def test_stream_weights_megatron_to_hf_merges_grouped_expert_adapters(monkeypatc
     class GroupedMapping:
         is_grouped_export = True
         group_key = "hf.experts.down_proj"
+        ep_size = 1
 
         def megatron_to_hf(self, weight, module):
             return {self.group_key: torch.zeros(2, 2)}
@@ -2085,6 +2086,7 @@ def test_stream_weights_megatron_to_hf_merges_grouped_expert_adapters_before_tra
     class GroupedMapping:
         is_grouped_export = True
         group_key = "hf.experts.down_proj"
+        ep_size = 1
         transpose_on_export = True
 
         def megatron_to_hf(self, weight, module):


### PR DESCRIPTION
Bind the HF source before resolving checkpoint-dependent mappings and use route-local expert parallelism when accumulating grouped expert exports.

Save an MTP-disabled HF configuration when MIMO omits MTP weights, and add Qwen3.5 MoE route, EP wrapper, and regression coverage.