### PR TITLE
perf(conversion): reduce GPU import and export memory

### DIFF
--- a/scripts/conversion/README.md
+++ b/scripts/conversion/README.md
@@ -70,6 +70,23 @@ For export, add `--hf-path`. Distributed Hugging Face saving is enabled by
 default for the GPU backend to avoid gathering the full model on rank zero.
 Use `--no-distributed-save` only when the model fits comfortably on rank zero.
 
+GPU import uses the faster checkpoint save path by default. For models that
+would otherwise run out of GPU memory while saving the imported checkpoint,
+add `--low-memory-save`. This releases model shards as they are saved, but can
+increase conversion time, so enable it only when the default path does not fit:
+
+```bash
+./scripts/conversion/convert.sh import \
+  --executor slurm \
+  --device gpu \
+  --nodes 1 \
+  --gpus-per-node 8 \
+  --hf-model MODEL \
+  --megatron-path /workspace/models/large-model \
+  --tp 1 --pp 1 --ep 8 --etp 1 \
+  --low-memory-save
+```
+
 No cluster-specific `srun` flags are added by default. If the target cluster
 requires extra flags, repeat `--srun-arg=ARG`. For example, a Pyxis/Enroot
 cluster may use:

--- a/scripts/conversion/arguments.py
+++ b/scripts/conversion/arguments.py
@@ -246,6 +246,11 @@ Examples:
         allow_abbrev=False,
     )
     _add_common_conversion_arguments(import_parser, include_execution=include_execution)
+    import_parser.add_argument(
+        "--low-memory-save",
+        action="store_true",
+        help="Reduce peak GPU memory while saving large imported checkpoints at the cost of additional runtime.",
+    )
 
     export_parser = subparsers.add_parser(
         "export",
@@ -348,7 +353,10 @@ def conversion_worker_args(args: argparse.Namespace) -> list[str]:
     if args.distributed_timeout_minutes is not None:
         worker_args.extend(["--distributed-timeout-minutes", str(args.distributed_timeout_minutes)])
 
-    if args.command == "export":
+    if args.command == "import":
+        if args.low_memory_save:
+            worker_args.append("--low-memory-save")
+    else:
         worker_args.extend(["--hf-path", args.hf_path])
         if args.no_progress:
             worker_args.append("--no-progress")

--- a/scripts/conversion/arguments.py
+++ b/scripts/conversion/arguments.py
@@ -356,7 +356,7 @@ def conversion_worker_args(args: argparse.Namespace) -> list[str]:
     if args.command == "import":
         if args.low_memory_save:
             worker_args.append("--low-memory-save")
-    else:
+    elif args.command == "export":
         worker_args.extend(["--hf-path", args.hf_path])
         if args.no_progress:
             worker_args.append("--no-progress")

--- a/scripts/conversion/gpu_backend.py
+++ b/scripts/conversion/gpu_backend.py
@@ -267,6 +267,7 @@ def import_checkpoint(
     etp: int,
     torch_dtype: str,
     trust_remote_code: bool,
+    low_memory_save: bool,
     distributed_timeout_minutes: int | None,
     overwrite: bool,
 ) -> None:
@@ -282,6 +283,7 @@ def import_checkpoint(
         etp: Expert tensor parallelism size.
         torch_dtype: Weight dtype name.
         trust_remote_code: Allow custom Hugging Face repository code.
+        low_memory_save: Reduce peak GPU memory while saving the imported checkpoint.
         distributed_timeout_minutes: Process-group timeout in minutes.
         overwrite: Delete a non-empty destination before conversion.
     """
@@ -310,7 +312,7 @@ def import_checkpoint(
         megatron_path,
         hf_tokenizer_path=hf_model,
         hf_tokenizer_kwargs=_hf_tokenizer_kwargs(bridge, trust_remote_code=trust_remote_code),
-        low_memory_save=True,
+        low_memory_save=low_memory_save,
     )
     print_rank_0(f"GPU import complete: {megatron_path}")
 

--- a/scripts/conversion/gpu_backend.py
+++ b/scripts/conversion/gpu_backend.py
@@ -310,6 +310,7 @@ def import_checkpoint(
         megatron_path,
         hf_tokenizer_path=hf_model,
         hf_tokenizer_kwargs=_hf_tokenizer_kwargs(bridge, trust_remote_code=trust_remote_code),
+        low_memory_save=True,
     )
     print_rank_0(f"GPU import complete: {megatron_path}")
 

--- a/scripts/conversion/run_conversion.py
+++ b/scripts/conversion/run_conversion.py
@@ -41,6 +41,8 @@ def _validate_args(args: argparse.Namespace) -> None:
         raise ValueError("--distributed-timeout-minutes must be at least 1.")
     if args.device == "cpu" and any(getattr(args, name) != 1 for name in ("tp", "pp", "ep", "etp")):
         raise ValueError("CPU conversion requires TP=PP=EP=ETP=1.")
+    if args.command == "import" and args.device == "cpu" and args.low_memory_save:
+        raise ValueError("--low-memory-save is only supported by the GPU backend.")
     if args.command == "export":
         if args.save_every_n_ranks < 1:
             raise ValueError("--save-every-n-ranks must be at least 1.")
@@ -72,6 +74,7 @@ def _run_import(args: argparse.Namespace) -> None:
         pp=args.pp,
         ep=args.ep,
         etp=args.etp,
+        low_memory_save=args.low_memory_save,
         distributed_timeout_minutes=args.distributed_timeout_minutes,
     )
 

--- a/scripts/conversion/setup_conversion.py
+++ b/scripts/conversion/setup_conversion.py
@@ -94,6 +94,8 @@ def _validate_args(args: argparse.Namespace) -> None:
 
     if args.command == "roundtrip" and args.device != "gpu":
         raise ValueError("Round-trip validation requires the GPU backend.")
+    if args.command == "import" and args.device == "cpu" and args.low_memory_save:
+        raise ValueError("--low-memory-save is only supported by the GPU backend.")
 
     if args.device == "cpu":
         if args.nodes != 1:

--- a/src/megatron/bridge/models/conversion/auto_bridge.py
+++ b/src/megatron/bridge/models/conversion/auto_bridge.py
@@ -1346,6 +1346,8 @@ class AutoBridge(Generic[MegatronModelT]):
         cls,
         hf_model_id: str | Path,
         megatron_path: str | Path,
+        *,
+        low_memory_save: bool = False,
         **kwargs,
     ) -> None:
         """
@@ -1360,6 +1362,8 @@ class AutoBridge(Generic[MegatronModelT]):
             hf_model_id: HuggingFace model ID or path to model directory
                 Examples: "meta-llama/Meta-Llama-3-8B", "./my_model"
             megatron_path: Directory path where the Megatron checkpoint will be saved
+            low_memory_save: Reduce peak memory while saving the Megatron checkpoint.
+                This destroys the converted model during save and can increase runtime.
             **kwargs: Additional arguments passed to from_hf_pretrained
                 Common options include:
                 - torch_dtype: Model precision (torch.float16, torch.bfloat16)
@@ -1379,7 +1383,8 @@ class AutoBridge(Generic[MegatronModelT]):
             ...     "meta-llama/Meta-Llama-3-8B",
             ...     "./megatron_checkpoints/llama3_8b",
             ...     torch_dtype=torch.float16,
-            ...     device_map="auto"
+            ...     device_map="auto",
+            ...     low_memory_save=True
             ... )
         """
         # Load the HuggingFace model
@@ -1404,7 +1409,7 @@ class AutoBridge(Generic[MegatronModelT]):
             megatron_path,
             hf_tokenizer_path=hf_model_id,
             hf_tokenizer_kwargs=hf_tokenizer_kwargs,
-            low_memory_save=True,
+            low_memory_save=low_memory_save,
         )
 
     def export_ckpt(

--- a/src/megatron/bridge/models/hf_pretrained/state.py
+++ b/src/megatron/bridge/models/hf_pretrained/state.py
@@ -967,36 +967,29 @@ class SafeTensorsStateSource(StateSource):
                 torch.distributed.barrier()
             return
 
-        all_expected_keys: Set[str] = set(key_to_filename_map.keys())
-        all_yielded_keys = set()
         filename_to_keys_map: Dict[str, Set[str]] = defaultdict(set)
-        for key, fname in key_to_filename_map.items():
-            filename_to_keys_map[fname].add(key)
-
-        all_filenames = sorted(filename_to_keys_map.keys())
+        if is_saver_rank:
+            for key, fname in key_to_filename_map.items():
+                filename_to_keys_map[fname].add(key)
+            all_filenames = sorted(filename_to_keys_map)
+        else:
+            all_filenames = []
 
         # Distribute files among saver ranks (one per node)
         if is_saver_rank:
             assigned_filenames = [fname for idx, fname in enumerate(all_filenames) if idx % num_savers == saver_index]
             assigned_filenames_set = set(assigned_filenames)
-            assigned_expected_keys: Set[str] = (
-                set().union(*(filename_to_keys_map[fname] for fname in assigned_filenames))
-                if assigned_filenames
-                else set()
-            )
         else:
             assigned_filenames = []
             assigned_filenames_set = set()
-            assigned_expected_keys = set()
 
+        files_to_save = {fname: filename_to_keys_map[fname] for fname in assigned_filenames}
+        remaining_keys_by_file = {fname: set(keys) for fname, keys in files_to_save.items()}
         buffered_tensors: Dict[str, torch.Tensor] = {}
-        actually_saved_keys: Set[str] = set()
         local_saved_tensor_bytes = 0
 
         for name, tensor in generator:
-            all_yielded_keys.add(name)
-
-            if name not in all_expected_keys:
+            if name not in key_to_filename_map:
                 if strict:
                     raise KeyError(
                         f"Tensor '{name}' from generator not found in the original model structure. "
@@ -1012,41 +1005,84 @@ class SafeTensorsStateSource(StateSource):
                     continue
                 buffered_tensors[name] = tensor
 
-        if is_saver_rank:
-            missing_keys = assigned_expected_keys - set(buffered_tensors.keys())
-            if missing_keys:
-                missing_keys_sorted = sorted(missing_keys)
-                missing_preview = ", ".join(missing_keys_sorted[:20])
-                missing_suffix = ""
-                if len(missing_keys_sorted) > 20:
-                    missing_suffix = f", ... (+{len(missing_keys_sorted) - 20} more)"
-                print(
-                    f"Rank {rank}: Missing {len(missing_keys_sorted)} tensors for keys: "
-                    f"{missing_preview}{missing_suffix}",
-                    flush=True,
-                )
-
-            for fname in assigned_filenames:
-                keys_for_file = filename_to_keys_map[fname]
-                tensors_to_save = {k: buffered_tensors[k] for k in keys_for_file if k in buffered_tensors}
-                if not tensors_to_save:
+                remaining_keys = remaining_keys_by_file.get(fname)
+                if remaining_keys is None:
+                    # The shard was already saved. Preserve the existing
+                    # duplicate-key behavior by ignoring the repeated tensor.
+                    del buffered_tensors[name]
                     continue
-                output_file_path = _resolve_output_shard_path(output_path, fname)
-                output_file_path.parent.mkdir(parents=True, exist_ok=True)
-                save_file(tensors_to_save, output_file_path)
-                actually_saved_keys.update(tensors_to_save.keys())
-                local_saved_tensor_bytes += sum(
-                    tensor.numel() * tensor.element_size() for tensor in tensors_to_save.values()
-                )
+
+                remaining_keys.discard(name)
+                if not remaining_keys:
+                    keys_for_file = files_to_save[fname]
+                    tensors_to_save = {key: buffered_tensors[key] for key in keys_for_file}
+                    output_file_path = _resolve_output_shard_path(output_path, fname)
+                    output_file_path.parent.mkdir(parents=True, exist_ok=True)
+                    save_file(tensors_to_save, output_file_path)
+                    local_saved_tensor_bytes += sum(
+                        saved_tensor.numel() * saved_tensor.element_size() for saved_tensor in tensors_to_save.values()
+                    )
+
+                    for key in keys_for_file:
+                        del buffered_tensors[key]
+                    del tensors_to_save
+                    del files_to_save[fname]
+                    del remaining_keys_by_file[fname]
+
+        missing_keys = set().union(*remaining_keys_by_file.values()) if remaining_keys_by_file else set()
+        if is_saver_rank and missing_keys:
+            missing_keys_sorted = sorted(missing_keys)
+            missing_preview = ", ".join(missing_keys_sorted[:20])
+            missing_suffix = ""
+            if len(missing_keys_sorted) > 20:
+                missing_suffix = f", ... (+{len(missing_keys_sorted) - 20} more)"
+            print(
+                f"Rank {rank}: Missing {len(missing_keys_sorted)} tensors for keys: {missing_preview}{missing_suffix}",
+                flush=True,
+            )
+
+        if is_saver_rank and not strict:
+            for fname in list(files_to_save):
+                keys_for_file = files_to_save[fname]
+                tensors_to_save = {key: buffered_tensors[key] for key in keys_for_file if key in buffered_tensors}
+                if tensors_to_save:
+                    output_file_path = _resolve_output_shard_path(output_path, fname)
+                    output_file_path.parent.mkdir(parents=True, exist_ok=True)
+                    save_file(tensors_to_save, output_file_path)
+                    local_saved_tensor_bytes += sum(
+                        saved_tensor.numel() * saved_tensor.element_size() for saved_tensor in tensors_to_save.values()
+                    )
+                    for key in tensors_to_save:
+                        del buffered_tensors[key]
+                    del tensors_to_save
+
+        if buffered_tensors:
+            print(
+                f"Rank {rank}: Warning: {len(buffered_tensors)} tensors were yielded but not saved because their "
+                "corresponding file shards were incomplete.",
+                flush=True,
+            )
+
+        # In strict mode an incomplete shard is not written, so every key in
+        # that shard is unsaved. In non-strict mode partial shards are written
+        # and only keys not yielded by the generator remain unsaved.
+        if strict:
+            local_unsaved_keys = set().union(*files_to_save.values()) if files_to_save else set()
+        else:
+            local_unsaved_keys = missing_keys
+
+        if is_saver_rank and local_unsaved_keys and strict:
+            keys_sorted = sorted(local_unsaved_keys)
+            preview = ", ".join(keys_sorted[:20])
+            suffix = f", ... (+{len(keys_sorted) - 20} more)" if len(keys_sorted) > 20 else ""
+            print(
+                f"Rank {rank}: Error: {len(keys_sorted)} tensors not written: {preview}{suffix}",
+                flush=True,
+            )
 
         # Strict-mode check: ensure all expected tensors were written. Aggregate
         # per-rank missing counts so all ranks raise consistently (avoids hangs
         # on the trailing barriers).
-        if is_saver_rank:
-            local_unsaved_keys = assigned_expected_keys - actually_saved_keys
-        else:
-            local_unsaved_keys = set()
-
         if is_distributed:
             gathered_save_status: list[tuple[int, int] | None] = [None] * world_size
             torch.distributed.all_gather_object(
@@ -1060,14 +1096,6 @@ class SafeTensorsStateSource(StateSource):
             total_saved_tensor_bytes = local_saved_tensor_bytes
 
         if total_unsaved_count and strict:
-            if local_unsaved_keys:
-                keys_sorted = sorted(local_unsaved_keys)
-                preview = ", ".join(keys_sorted[:20])
-                suffix = f", ... (+{len(keys_sorted) - 20} more)" if len(keys_sorted) > 20 else ""
-                print(
-                    f"Rank {rank}: Error: {len(keys_sorted)} tensors not written: {preview}{suffix}",
-                    flush=True,
-                )
             raise RuntimeError(
                 f"{total_unsaved_count} tensors from the original checkpoint were not written. "
                 "Re-run with strict=False to save the partial checkpoint instead of failing."
@@ -1092,7 +1120,15 @@ class SafeTensorsStateSource(StateSource):
             else:
                 all_saved_keys_aggregated = set()
         else:
-            all_saved_keys_aggregated = actually_saved_keys
+            from safetensors import safe_open
+
+            all_saved_keys_aggregated = set()
+            for fname in all_filenames:
+                file_path = _resolve_output_shard_path(output_path, fname)
+                if not file_path.exists():
+                    continue
+                with safe_open(file_path, framework="pt", device="cpu") as f:
+                    all_saved_keys_aggregated.update(f.keys())
 
         if rank == 0:
             original_index_file = self.path / "model.safetensors.index.json"

--- a/src/megatron/bridge/models/hf_pretrained/state.py
+++ b/src/megatron/bridge/models/hf_pretrained/state.py
@@ -967,11 +967,8 @@ class SafeTensorsStateSource(StateSource):
                 torch.distributed.barrier()
             return
 
-        filename_to_keys_map: Dict[str, Set[str]] = defaultdict(set)
         if is_saver_rank:
-            for key, fname in key_to_filename_map.items():
-                filename_to_keys_map[fname].add(key)
-            all_filenames = sorted(filename_to_keys_map)
+            all_filenames = sorted(set(key_to_filename_map.values()))
         else:
             all_filenames = []
 
@@ -982,6 +979,12 @@ class SafeTensorsStateSource(StateSource):
         else:
             assigned_filenames = []
             assigned_filenames_set = set()
+
+        filename_to_keys_map: Dict[str, Set[str]] = defaultdict(set)
+        if is_saver_rank:
+            for key, fname in key_to_filename_map.items():
+                if fname in assigned_filenames_set:
+                    filename_to_keys_map[fname].add(key)
 
         files_to_save = {fname: filename_to_keys_map[fname] for fname in assigned_filenames}
         remaining_keys_by_file = {fname: set(keys) for fname, keys in files_to_save.items()}

--- a/src/megatron/bridge/models/hf_pretrained/state.py
+++ b/src/megatron/bridge/models/hf_pretrained/state.py
@@ -990,6 +990,33 @@ class SafeTensorsStateSource(StateSource):
         remaining_keys_by_file = {fname: set(keys) for fname, keys in files_to_save.items()}
         buffered_tensors: Dict[str, torch.Tensor] = {}
         local_saved_tensor_bytes = 0
+        local_saved_filenames: Set[str] = set()
+        local_export_error: str | None = None
+
+        def write_shard(fname: str, tensors_to_save: Dict[str, torch.Tensor]) -> bool:
+            """Write one shard while deferring saver-local failures until the generator is drained."""
+            nonlocal local_export_error, local_saved_tensor_bytes
+
+            output_file_path: Path | None = None
+            try:
+                output_file_path = _resolve_output_shard_path(output_path, fname)
+                output_file_path.parent.mkdir(parents=True, exist_ok=True)
+                save_file(tensors_to_save, output_file_path)
+            except Exception as error:
+                local_export_error = f"Rank {rank} failed to write shard '{fname}': {type(error).__name__}: {error}"
+                if output_file_path is not None:
+                    try:
+                        output_file_path.unlink(missing_ok=True)
+                    except OSError:
+                        pass
+                buffered_tensors.clear()
+                return False
+
+            local_saved_filenames.add(fname)
+            local_saved_tensor_bytes += sum(
+                saved_tensor.numel() * saved_tensor.element_size() for saved_tensor in tensors_to_save.values()
+            )
+            return True
 
         for name, tensor in generator:
             if name not in key_to_filename_map:
@@ -1006,31 +1033,30 @@ class SafeTensorsStateSource(StateSource):
                 fname = key_to_filename_map[name]
                 if fname not in assigned_filenames_set:
                     continue
-                buffered_tensors[name] = tensor
 
                 remaining_keys = remaining_keys_by_file.get(fname)
-                if remaining_keys is None:
-                    # The shard was already saved. Preserve the existing
-                    # duplicate-key behavior by ignoring the repeated tensor.
-                    del buffered_tensors[name]
+                if local_export_error is not None:
+                    continue
+                if remaining_keys is None or name not in remaining_keys:
+                    duplicate_message = f"Duplicate tensor '{name}' from generator."
+                    if strict:
+                        local_export_error = f"Rank {rank}: {duplicate_message}"
+                        buffered_tensors.clear()
+                    else:
+                        print(f"{duplicate_message} Skipping.", flush=True)
                     continue
 
+                buffered_tensors[name] = tensor
                 remaining_keys.discard(name)
                 if not remaining_keys:
                     keys_for_file = files_to_save[fname]
                     tensors_to_save = {key: buffered_tensors[key] for key in keys_for_file}
-                    output_file_path = _resolve_output_shard_path(output_path, fname)
-                    output_file_path.parent.mkdir(parents=True, exist_ok=True)
-                    save_file(tensors_to_save, output_file_path)
-                    local_saved_tensor_bytes += sum(
-                        saved_tensor.numel() * saved_tensor.element_size() for saved_tensor in tensors_to_save.values()
-                    )
-
-                    for key in keys_for_file:
-                        del buffered_tensors[key]
+                    if write_shard(fname, tensors_to_save):
+                        for key in keys_for_file:
+                            del buffered_tensors[key]
+                        del files_to_save[fname]
+                        del remaining_keys_by_file[fname]
                     del tensors_to_save
-                    del files_to_save[fname]
-                    del remaining_keys_by_file[fname]
 
         missing_keys = set().union(*remaining_keys_by_file.values()) if remaining_keys_by_file else set()
         if is_saver_rank and missing_keys:
@@ -1044,20 +1070,17 @@ class SafeTensorsStateSource(StateSource):
                 flush=True,
             )
 
-        if is_saver_rank and not strict:
+        if is_saver_rank and not strict and local_export_error is None:
             for fname in list(files_to_save):
                 keys_for_file = files_to_save[fname]
                 tensors_to_save = {key: buffered_tensors[key] for key in keys_for_file if key in buffered_tensors}
                 if tensors_to_save:
-                    output_file_path = _resolve_output_shard_path(output_path, fname)
-                    output_file_path.parent.mkdir(parents=True, exist_ok=True)
-                    save_file(tensors_to_save, output_file_path)
-                    local_saved_tensor_bytes += sum(
-                        saved_tensor.numel() * saved_tensor.element_size() for saved_tensor in tensors_to_save.values()
-                    )
-                    for key in tensors_to_save:
-                        del buffered_tensors[key]
+                    if write_shard(fname, tensors_to_save):
+                        for key in tensors_to_save:
+                            del buffered_tensors[key]
                     del tensors_to_save
+                    if local_export_error is not None:
+                        break
 
         if buffered_tensors:
             print(
@@ -1087,16 +1110,32 @@ class SafeTensorsStateSource(StateSource):
         # per-rank missing counts so all ranks raise consistently (avoids hangs
         # on the trailing barriers).
         if is_distributed:
-            gathered_save_status: list[tuple[int, int] | None] = [None] * world_size
+            gathered_save_status: list[tuple[int, int, str | None, tuple[str, ...]] | None] = [None] * world_size
             torch.distributed.all_gather_object(
                 gathered_save_status,
-                (len(local_unsaved_keys), local_saved_tensor_bytes),
+                (
+                    len(local_unsaved_keys),
+                    local_saved_tensor_bytes,
+                    local_export_error,
+                    tuple(sorted(local_saved_filenames)),
+                ),
             )
             total_unsaved_count = sum(status[0] for status in gathered_save_status if status is not None)
             total_saved_tensor_bytes = sum(status[1] for status in gathered_save_status if status is not None)
+            export_errors = [status[2] for status in gathered_save_status if status is not None and status[2]]
+            saved_filenames_aggregated = {
+                fname for status in gathered_save_status if status is not None for fname in status[3]
+            }
         else:
             total_unsaved_count = len(local_unsaved_keys)
             total_saved_tensor_bytes = local_saved_tensor_bytes
+            export_errors = [local_export_error] if local_export_error else []
+            saved_filenames_aggregated = local_saved_filenames
+
+        if export_errors:
+            raise RuntimeError(
+                "Checkpoint export failed after all ranks drained the tensor generator: " + "; ".join(export_errors)
+            )
 
         if total_unsaved_count and strict:
             raise RuntimeError(
@@ -1114,7 +1153,7 @@ class SafeTensorsStateSource(StateSource):
                 from safetensors import safe_open
 
                 all_saved_keys_aggregated = set()
-                for fname in all_filenames:
+                for fname in sorted(saved_filenames_aggregated):
                     file_path = _resolve_output_shard_path(output_path, fname)
                     if not file_path.exists():
                         continue
@@ -1126,7 +1165,7 @@ class SafeTensorsStateSource(StateSource):
             from safetensors import safe_open
 
             all_saved_keys_aggregated = set()
-            for fname in all_filenames:
+            for fname in sorted(saved_filenames_aggregated):
                 file_path = _resolve_output_shard_path(output_path, fname)
                 if not file_path.exists():
                     continue

--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -15,6 +15,7 @@
 """Input/output checkpointing."""
 
 import contextlib
+import gc
 import os
 import random
 import shutil
@@ -2248,6 +2249,16 @@ def _load_model_weights_from_checkpoint(
             if model_key not in state_dict:
                 continue
             _load_model_state_dict(model[i], state_dict[model_key], strict)
+
+    # The loaded state dict can own checkpoint staging tensors distinct from
+    # the model parameters. Release both state-dict structures before the
+    # synchronization below so cached allocations cannot starve NCCL or the
+    # conversion collectives that follow.
+    del state_dict
+    del sharded_state_dict
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
 
     if torch.distributed.is_initialized():
         torch.distributed.barrier()

--- a/tests/unit_tests/conversion/launcher/test_arguments.py
+++ b/tests/unit_tests/conversion/launcher/test_arguments.py
@@ -43,6 +43,7 @@ def test_cpu_local_import_defaults():
     assert args.device == "cpu"
     assert args.srun_args == []
     assert (args.tp, args.pp, args.ep, args.etp) == (1, 1, 1, 1)
+    assert args.low_memory_save is False
 
 
 def test_srun_args_are_repeatable():
@@ -203,6 +204,27 @@ def test_import_worker_args_forward_hf_revision():
     worker_args = module.conversion_worker_args(args)
 
     assert worker_args[worker_args.index("--hf-revision") + 1] == "0123456789abcdef"
+    assert "--low-memory-save" not in worker_args
+
+
+def test_import_worker_args_forward_low_memory_save():
+    module = _load_arguments_module()
+    args = module.build_parser(include_execution=True).parse_args(
+        [
+            "import",
+            "--device",
+            "gpu",
+            "--hf-model",
+            "hf/model",
+            "--megatron-path",
+            "/checkpoint",
+            "--low-memory-save",
+        ]
+    )
+
+    worker_args = module.conversion_worker_args(args)
+
+    assert "--low-memory-save" in worker_args
 
 
 def test_roundtrip_worker_parser_accepts_serialized_args():

--- a/tests/unit_tests/conversion/launcher/test_gpu_backend.py
+++ b/tests/unit_tests/conversion/launcher/test_gpu_backend.py
@@ -168,7 +168,7 @@ class TestImportHfToMegatron:
 
         save_call = next(call for call in calls if call[0] == "save_megatron_model")
         assert save_call[1] == (["megatron-model"], "/ckpt")
-        assert "low_memory_save" not in save_call[2]
+        assert save_call[2]["low_memory_save"] is True
         assert save_call[2]["hf_tokenizer_path"] == "hf"
         assert save_call[2]["hf_tokenizer_kwargs"] == {
             "padding_side": "left",

--- a/tests/unit_tests/conversion/launcher/test_gpu_backend.py
+++ b/tests/unit_tests/conversion/launcher/test_gpu_backend.py
@@ -123,7 +123,8 @@ class _FakeHfPretrained:
 
 
 class TestImportHfToMegatron:
-    def test_import_saves_megatron_checkpoint_with_tokenizer_metadata(self, cli, monkeypatch):
+    @pytest.mark.parametrize("low_memory_save", [False, True])
+    def test_import_saves_megatron_checkpoint_with_tokenizer_metadata(self, cli, monkeypatch, low_memory_save):
         calls = []
         prepared_outputs = []
 
@@ -162,13 +163,14 @@ class TestImportHfToMegatron:
             etp=1,
             torch_dtype="bfloat16",
             trust_remote_code=True,
+            low_memory_save=low_memory_save,
             distributed_timeout_minutes=None,
             overwrite=False,
         )
 
         save_call = next(call for call in calls if call[0] == "save_megatron_model")
         assert save_call[1] == (["megatron-model"], "/ckpt")
-        assert save_call[2]["low_memory_save"] is True
+        assert save_call[2]["low_memory_save"] is low_memory_save
         assert save_call[2]["hf_tokenizer_path"] == "hf"
         assert save_call[2]["hf_tokenizer_kwargs"] == {
             "padding_side": "left",

--- a/tests/unit_tests/conversion/launcher/test_run_conversion.py
+++ b/tests/unit_tests/conversion/launcher/test_run_conversion.py
@@ -91,6 +91,45 @@ def test_cpu_import_dispatches_to_cpu_backend():
     ]
 
 
+def test_gpu_import_forwards_low_memory_save():
+    module, _, gpu_backend = _load_run_conversion_module()
+    calls = []
+    gpu_backend.import_checkpoint = lambda **kwargs: calls.append(kwargs)
+
+    module.main(
+        [
+            "import",
+            "--device",
+            "gpu",
+            "--hf-model",
+            "hf/model",
+            "--megatron-path",
+            "/checkpoint",
+            "--low-memory-save",
+        ]
+    )
+
+    assert calls[0]["low_memory_save"] is True
+
+
+def test_cpu_import_rejects_low_memory_save():
+    module, _, _ = _load_run_conversion_module()
+
+    with pytest.raises(ValueError, match="only supported by the GPU backend"):
+        module.main(
+            [
+                "import",
+                "--device",
+                "cpu",
+                "--hf-model",
+                "hf/model",
+                "--megatron-path",
+                "/checkpoint",
+                "--low-memory-save",
+            ]
+        )
+
+
 def test_cpu_import_forwards_hf_revision_without_replacing_model_id(monkeypatch):
     module, cpu_backend, _ = _load_run_conversion_module()
     calls = []

--- a/tests/unit_tests/conversion/launcher/test_setup_conversion.py
+++ b/tests/unit_tests/conversion/launcher/test_setup_conversion.py
@@ -110,6 +110,14 @@ def test_cpu_backend_rejects_distributed_parallelism():
         module._validate_args(args)
 
 
+def test_cpu_backend_rejects_low_memory_save():
+    module = _load_setup_conversion_module()
+    args = _parse(module, "--low-memory-save")
+
+    with pytest.raises(ValueError, match="only supported by the GPU backend"):
+        module._validate_args(args)
+
+
 def test_local_executor_rejects_detach():
     module = _load_setup_conversion_module()
     args = _parse(module, "--detach")

--- a/tests/unit_tests/models/test_auto_bridge.py
+++ b/tests/unit_tests/models/test_auto_bridge.py
@@ -1541,7 +1541,7 @@ class TestAutoBridge:
             "./megatron_checkpoint",
             hf_tokenizer_path="meta-llama/Meta-Llama-3-8B",
             hf_tokenizer_kwargs=mock_bridge._model_bridge.get_hf_tokenizer_kwargs(),
-            low_memory_save=True,
+            low_memory_save=False,
         )
 
     @patch.object(AutoBridge, "save_megatron_model")
@@ -1580,6 +1580,39 @@ class TestAutoBridge:
             "./megatron_checkpoint",
             hf_tokenizer_path="./local_model",
             hf_tokenizer_kwargs={"revision": "0123456789abcdef"},  # pragma: allowlist secret
+            low_memory_save=False,
+        )
+
+    @patch.object(AutoBridge, "save_megatron_model")
+    @patch.object(AutoBridge, "to_megatron_model")
+    @patch.object(AutoBridge, "from_hf_pretrained")
+    def test_import_ckpt_with_low_memory_save(
+        self, mock_from_hf_pretrained, mock_to_megatron_model, mock_save_megatron_model
+    ):
+        """Test import_ckpt low-memory save forwarding."""
+        mock_bridge = Mock(spec=AutoBridge)
+        mock_from_hf_pretrained.return_value = mock_bridge
+        mock_megatron_model = [Mock()]
+        mock_bridge.to_megatron_model.return_value = mock_megatron_model
+        mock_bridge.save_megatron_model = Mock()
+        mock_bridge._model_bridge.get_hf_tokenizer_kwargs.return_value = {}
+
+        AutoBridge.import_ckpt(
+            "meta-llama/Meta-Llama-3-8B",
+            "./megatron_checkpoint",
+            low_memory_save=True,
+            torch_dtype=torch.bfloat16,
+        )
+
+        mock_from_hf_pretrained.assert_called_once_with(
+            "meta-llama/Meta-Llama-3-8B",
+            torch_dtype=torch.bfloat16,
+        )
+        mock_bridge.save_megatron_model.assert_called_once_with(
+            mock_megatron_model,
+            "./megatron_checkpoint",
+            hf_tokenizer_path="meta-llama/Meta-Llama-3-8B",
+            hf_tokenizer_kwargs={},
             low_memory_save=True,
         )
 

--- a/tests/unit_tests/models/test_hf_pretrained_state.py
+++ b/tests/unit_tests/models/test_hf_pretrained_state.py
@@ -20,6 +20,7 @@ from pathlib import Path
 import pytest
 import torch
 from safetensors import safe_open
+from safetensors.torch import save_file
 
 from megatron.bridge.models.hf_pretrained import state as state_module
 from megatron.bridge.models.hf_pretrained.state import SafeTensorsStateSource, _resolve_output_shard_path
@@ -34,6 +35,19 @@ def _write_safetensors_index(tmp_path, weight_map: dict[str, str], metadata: dic
     if metadata is not None:
         index["metadata"] = metadata
     index_file.write_text(json.dumps(index), encoding="utf-8")
+
+
+def _mock_single_rank_distributed(monkeypatch) -> None:
+    monkeypatch.setattr(torch.distributed, "is_available", lambda: True)
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: True)
+    monkeypatch.setattr(torch.distributed, "get_world_size", lambda: 1)
+    monkeypatch.setattr(torch.distributed, "get_rank", lambda: 0)
+    monkeypatch.setattr(torch.distributed, "barrier", lambda: None)
+
+    def gather_rank_zero(output: list[object | None], value: object) -> None:
+        output[0] = value
+
+    monkeypatch.setattr(torch.distributed, "all_gather_object", gather_rank_zero)
 
 
 @pytest.mark.parametrize(
@@ -211,16 +225,7 @@ def test_distributed_save_generator_writes_shard_before_generator_is_exhausted(t
     source = SafeTensorsStateSource(tmp_path)
     saved_shards: list[tuple[str, set[str]]] = []
 
-    monkeypatch.setattr(torch.distributed, "is_available", lambda: True)
-    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: True)
-    monkeypatch.setattr(torch.distributed, "get_world_size", lambda: 1)
-    monkeypatch.setattr(torch.distributed, "get_rank", lambda: 0)
-    monkeypatch.setattr(torch.distributed, "barrier", lambda: None)
-
-    def gather_rank_zero(output: list[object | None], value: object) -> None:
-        output[0] = value
-
-    monkeypatch.setattr(torch.distributed, "all_gather_object", gather_rank_zero)
+    _mock_single_rank_distributed(monkeypatch)
 
     def record_save(tensors: dict[str, torch.Tensor], output_file: str | Path) -> None:
         saved_shards.append((str(output_file), set(tensors)))
@@ -245,3 +250,308 @@ def test_distributed_save_generator_writes_shard_before_generator_is_exhausted(t
         (str(tmp_path / "output" / first_shard), {"model.first.weight", "model.first.bias"}),
         (str(tmp_path / "output" / second_shard), {"model.second.weight", "model.second.bias"}),
     ]
+
+
+def test_distributed_save_strict_rejects_incomplete_multi_key_shard(tmp_path, monkeypatch) -> None:
+    shard_filename = "model-00001-of-00001.safetensors"
+    _write_safetensors_index(
+        tmp_path,
+        {
+            "model.present": shard_filename,
+            "model.missing": shard_filename,
+        },
+    )
+    source = SafeTensorsStateSource(tmp_path)
+    output_path = tmp_path / "output"
+    _mock_single_rank_distributed(monkeypatch)
+
+    with pytest.raises(RuntimeError, match="2 tensors from the original checkpoint were not written"):
+        source.save_generator(
+            iter([("model.present", torch.ones(1))]),
+            output_path,
+            distributed_save=True,
+        )
+
+    assert not (output_path / shard_filename).exists()
+    assert not (output_path / "model.safetensors.index.json").exists()
+
+
+def test_distributed_save_non_strict_writes_partial_shard_and_index(tmp_path, monkeypatch) -> None:
+    shard_filename = "model-00001-of-00001.safetensors"
+    _write_safetensors_index(
+        tmp_path,
+        {
+            "model.present": shard_filename,
+            "model.missing": shard_filename,
+        },
+        metadata={"format": "pt", "total_size": 1},
+    )
+    source = SafeTensorsStateSource(tmp_path)
+    output_path = tmp_path / "output"
+    _mock_single_rank_distributed(monkeypatch)
+
+    source.save_generator(
+        iter([("model.present", torch.ones(2))]),
+        output_path,
+        strict=False,
+        distributed_save=True,
+    )
+
+    with safe_open(output_path / shard_filename, framework="pt", device="cpu") as shard:
+        assert set(shard.keys()) == {"model.present"}
+        torch.testing.assert_close(shard.get_tensor("model.present"), torch.ones(2))
+
+    index_data = json.loads((output_path / "model.safetensors.index.json").read_text(encoding="utf-8"))
+    assert index_data == {
+        "metadata": {"format": "pt", "total_size": 8},
+        "weight_map": {"model.present": shard_filename},
+    }
+
+
+def test_distributed_save_strict_rejects_extra_generator_key(tmp_path, monkeypatch) -> None:
+    shard_filename = "model-00001-of-00001.safetensors"
+    _write_safetensors_index(tmp_path, {"model.expected": shard_filename})
+    source = SafeTensorsStateSource(tmp_path)
+    output_path = tmp_path / "output"
+    _mock_single_rank_distributed(monkeypatch)
+
+    with pytest.raises(KeyError, match="model.extra"):
+        source.save_generator(
+            iter([("model.extra", torch.ones(1))]),
+            output_path,
+            distributed_save=True,
+        )
+
+    assert not (output_path / shard_filename).exists()
+    assert not (output_path / "model.safetensors.index.json").exists()
+
+
+def test_distributed_save_non_strict_skips_extra_generator_key(tmp_path, monkeypatch, capsys) -> None:
+    shard_filename = "model-00001-of-00001.safetensors"
+    _write_safetensors_index(tmp_path, {"model.expected": shard_filename})
+    source = SafeTensorsStateSource(tmp_path)
+    output_path = tmp_path / "output"
+    _mock_single_rank_distributed(monkeypatch)
+
+    source.save_generator(
+        iter(
+            [
+                ("model.extra", torch.zeros(1)),
+                ("model.expected", torch.ones(1)),
+            ]
+        ),
+        output_path,
+        strict=False,
+        distributed_save=True,
+    )
+
+    assert "tensor 'model.extra' from generator not found in original model structure" in capsys.readouterr().out
+    with safe_open(output_path / shard_filename, framework="pt", device="cpu") as shard:
+        assert set(shard.keys()) == {"model.expected"}
+    index_data = json.loads((output_path / "model.safetensors.index.json").read_text(encoding="utf-8"))
+    assert index_data["weight_map"] == {"model.expected": shard_filename}
+
+
+def test_distributed_save_index_excludes_stale_shard_not_written_by_current_export(tmp_path, monkeypatch) -> None:
+    first_shard = "model-00001-of-00002.safetensors"
+    stale_shard = "model-00002-of-00002.safetensors"
+    _write_safetensors_index(
+        tmp_path,
+        {
+            "model.current": first_shard,
+            "model.stale": stale_shard,
+        },
+    )
+    source = SafeTensorsStateSource(tmp_path)
+    output_path = tmp_path / "output"
+    output_path.mkdir()
+    save_file({"model.stale": torch.zeros(1)}, output_path / stale_shard)
+    _mock_single_rank_distributed(monkeypatch)
+
+    source.save_generator(
+        iter([("model.current", torch.ones(1))]),
+        output_path,
+        strict=False,
+        distributed_save=True,
+    )
+
+    index_data = json.loads((output_path / "model.safetensors.index.json").read_text(encoding="utf-8"))
+    assert index_data == {
+        "metadata": {"total_size": 4},
+        "weight_map": {"model.current": first_shard},
+    }
+
+
+def test_distributed_save_drains_generator_before_reporting_saver_write_failure(tmp_path, monkeypatch) -> None:
+    first_shard = "model-00001-of-00002.safetensors"
+    second_shard = "model-00002-of-00002.safetensors"
+    _write_safetensors_index(
+        tmp_path,
+        {
+            "model.first.weight": first_shard,
+            "model.first.bias": first_shard,
+            "model.second.weight": second_shard,
+            "model.second.bias": second_shard,
+        },
+    )
+    source = SafeTensorsStateSource(tmp_path)
+    generator_exhausted = False
+    save_attempts = 0
+    _mock_single_rank_distributed(monkeypatch)
+
+    def fail_save(_tensors: dict[str, torch.Tensor], _output_file: str | Path) -> None:
+        nonlocal save_attempts
+        save_attempts += 1
+        raise OSError("disk full")
+
+    monkeypatch.setattr("safetensors.torch.save_file", fail_save)
+
+    def tensors() -> Iterator[tuple[str, torch.Tensor]]:
+        nonlocal generator_exhausted
+        yield "model.first.weight", torch.ones(1)
+        yield "model.first.bias", torch.zeros(1)
+        yield "model.second.weight", torch.full((1,), 2.0)
+        yield "model.second.bias", torch.full((1,), 3.0)
+        generator_exhausted = True
+
+    with pytest.raises(RuntimeError, match="disk full"):
+        source.save_generator(tensors(), tmp_path / "output", distributed_save=True)
+
+    assert generator_exhausted
+    assert save_attempts == 1
+
+
+@pytest.mark.parametrize("duplicate_after_shard_completion", [False, True])
+def test_distributed_save_strict_rejects_duplicate_key_deterministically(
+    tmp_path,
+    monkeypatch,
+    duplicate_after_shard_completion: bool,
+) -> None:
+    shard_filename = "model-00001-of-00001.safetensors"
+    _write_safetensors_index(
+        tmp_path,
+        {
+            "model.weight": shard_filename,
+            "model.bias": shard_filename,
+        },
+    )
+    source = SafeTensorsStateSource(tmp_path)
+    _mock_single_rank_distributed(monkeypatch)
+
+    if duplicate_after_shard_completion:
+        tensors = [
+            ("model.weight", torch.ones(1)),
+            ("model.bias", torch.zeros(1)),
+            ("model.weight", torch.full((1,), 2.0)),
+        ]
+    else:
+        tensors = [
+            ("model.weight", torch.ones(1)),
+            ("model.weight", torch.full((1,), 2.0)),
+            ("model.bias", torch.zeros(1)),
+        ]
+
+    with pytest.raises(RuntimeError, match="Duplicate tensor 'model.weight'"):
+        source.save_generator(iter(tensors), tmp_path / "output", distributed_save=True)
+
+
+@pytest.mark.parametrize("duplicate_after_shard_completion", [False, True])
+def test_distributed_save_non_strict_skips_duplicate_key_deterministically(
+    tmp_path,
+    monkeypatch,
+    capsys,
+    duplicate_after_shard_completion: bool,
+) -> None:
+    shard_filename = "model-00001-of-00001.safetensors"
+    _write_safetensors_index(
+        tmp_path,
+        {
+            "model.weight": shard_filename,
+            "model.bias": shard_filename,
+        },
+    )
+    source = SafeTensorsStateSource(tmp_path)
+    output_path = tmp_path / "output"
+    _mock_single_rank_distributed(monkeypatch)
+
+    if duplicate_after_shard_completion:
+        tensors = [
+            ("model.weight", torch.ones(1)),
+            ("model.bias", torch.zeros(1)),
+            ("model.weight", torch.full((1,), 2.0)),
+        ]
+    else:
+        tensors = [
+            ("model.weight", torch.ones(1)),
+            ("model.weight", torch.full((1,), 2.0)),
+            ("model.bias", torch.zeros(1)),
+        ]
+
+    source.save_generator(iter(tensors), output_path, strict=False, distributed_save=True)
+
+    assert "Duplicate tensor 'model.weight' from generator. Skipping." in capsys.readouterr().out
+    with safe_open(output_path / shard_filename, framework="pt", device="cpu") as shard:
+        torch.testing.assert_close(shard.get_tensor("model.weight"), torch.ones(1))
+
+
+def test_distributed_save_multiple_savers_write_only_assigned_shards_and_build_complete_index(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    first_shard = "model-00001-of-00002.safetensors"
+    second_shard = "model-00002-of-00002.safetensors"
+    _write_safetensors_index(
+        tmp_path,
+        {
+            "model.first": first_shard,
+            "model.second": second_shard,
+        },
+    )
+    source = SafeTensorsStateSource(tmp_path)
+    output_path = tmp_path / "output"
+    current_rank = 2
+    rank_statuses: dict[int, object] = {}
+
+    monkeypatch.setattr(torch.distributed, "is_available", lambda: True)
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: True)
+    monkeypatch.setattr(torch.distributed, "get_world_size", lambda: 4)
+    monkeypatch.setattr(torch.distributed, "get_rank", lambda: current_rank)
+    monkeypatch.setattr(torch.distributed, "barrier", lambda: None)
+
+    def gather_available_rank_statuses(output: list[object | None], value: object) -> None:
+        rank_statuses[current_rank] = value
+        for rank, status in rank_statuses.items():
+            output[rank] = status
+
+    monkeypatch.setattr(torch.distributed, "all_gather_object", gather_available_rank_statuses)
+
+    tensors = [
+        ("model.first", torch.ones(1)),
+        ("model.second", torch.full((1,), 2.0)),
+    ]
+    source.save_generator(
+        iter(tensors),
+        output_path,
+        distributed_save=True,
+        save_every_n_ranks=2,
+    )
+    assert not (output_path / first_shard).exists()
+    assert (output_path / second_shard).exists()
+
+    current_rank = 0
+    source.save_generator(
+        iter(tensors),
+        output_path,
+        distributed_save=True,
+        save_every_n_ranks=2,
+    )
+
+    assert (output_path / first_shard).exists()
+    index_data = json.loads((output_path / "model.safetensors.index.json").read_text(encoding="utf-8"))
+    assert index_data == {
+        "metadata": {"total_size": 8},
+        "weight_map": {
+            "model.first": first_shard,
+            "model.second": second_shard,
+        },
+    }

--- a/tests/unit_tests/models/test_hf_pretrained_state.py
+++ b/tests/unit_tests/models/test_hf_pretrained_state.py
@@ -194,3 +194,54 @@ def test_save_generator_writes_shard_as_soon_as_its_remaining_keys_arrive(tmp_pa
         (str(tmp_path / "output" / first_shard), {"model.first.weight", "model.first.bias"}),
         (str(tmp_path / "output" / second_shard), {"model.second.weight", "model.second.bias"}),
     ]
+
+
+def test_distributed_save_generator_writes_shard_before_generator_is_exhausted(tmp_path, monkeypatch) -> None:
+    first_shard = "model-00001-of-00002.safetensors"
+    second_shard = "model-00002-of-00002.safetensors"
+    _write_safetensors_index(
+        tmp_path,
+        {
+            "model.first.weight": first_shard,
+            "model.first.bias": first_shard,
+            "model.second.weight": second_shard,
+            "model.second.bias": second_shard,
+        },
+    )
+    source = SafeTensorsStateSource(tmp_path)
+    saved_shards: list[tuple[str, set[str]]] = []
+
+    monkeypatch.setattr(torch.distributed, "is_available", lambda: True)
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: True)
+    monkeypatch.setattr(torch.distributed, "get_world_size", lambda: 1)
+    monkeypatch.setattr(torch.distributed, "get_rank", lambda: 0)
+    monkeypatch.setattr(torch.distributed, "barrier", lambda: None)
+
+    def gather_rank_zero(output: list[object | None], value: object) -> None:
+        output[0] = value
+
+    monkeypatch.setattr(torch.distributed, "all_gather_object", gather_rank_zero)
+
+    def record_save(tensors: dict[str, torch.Tensor], output_file: str | Path) -> None:
+        saved_shards.append((str(output_file), set(tensors)))
+
+    monkeypatch.setattr("safetensors.torch.save_file", record_save)
+
+    def tensors() -> Iterator[tuple[str, torch.Tensor]]:
+        yield "model.first.weight", torch.ones(1)
+        assert saved_shards == []
+
+        yield "model.second.weight", torch.full((1,), 2.0)
+        assert saved_shards == []
+
+        yield "model.first.bias", torch.zeros(1)
+        assert saved_shards == [(str(tmp_path / "output" / first_shard), {"model.first.weight", "model.first.bias"})]
+
+        yield "model.second.bias", torch.full((1,), 3.0)
+
+    source.save_generator(tensors(), tmp_path / "output", distributed_save=True)
+
+    assert saved_shards == [
+        (str(tmp_path / "output" / first_shard), {"model.first.weight", "model.first.bias"}),
+        (str(tmp_path / "output" / second_shard), {"model.second.weight", "model.second.bias"}),
+    ]

--- a/tests/unit_tests/training/test_checkpointing.py
+++ b/tests/unit_tests/training/test_checkpointing.py
@@ -2428,13 +2428,18 @@ class TestLoadModelWeightsFromCheckpoint:
         # Call the function
         from megatron.bridge.training.checkpointing import _load_model_weights_from_checkpoint
 
-        _load_model_weights_from_checkpoint(
-            checkpoint_path="/test/checkpoint",
-            model=mock_model,
-            fully_parallel_load=False,
-            dist_ckpt_strictness="assume_ok_unexpected",
-            strict=True,
-        )
+        with (
+            patch("megatron.bridge.training.checkpointing.gc.collect") as mock_gc_collect,
+            patch("megatron.bridge.training.checkpointing.torch.cuda.is_available", return_value=True),
+            patch("megatron.bridge.training.checkpointing.torch.cuda.empty_cache") as mock_empty_cache,
+        ):
+            _load_model_weights_from_checkpoint(
+                checkpoint_path="/test/checkpoint",
+                model=mock_model,
+                fully_parallel_load=False,
+                dist_ckpt_strictness="assume_ok_unexpected",
+                strict=True,
+            )
 
         # Verify calls
         mock_dist_ckpt.load_common_state_dict.assert_called_once_with("/test/checkpoint")
@@ -2445,6 +2450,8 @@ class TestLoadModelWeightsFromCheckpoint:
         assert call_args[0][1] == {"metadata": mock_metadata}
         mock_strategy_cls.assert_called_once_with()
         mock_load_state_dict.assert_called_once_with(mock_model[0], mock_full_state_dict["model"], True)
+        mock_gc_collect.assert_called_once_with()
+        mock_empty_cache.assert_called_once_with()
 
     @patch("megatron.bridge.training.checkpointing.delete_extra_state")
     @patch("megatron.bridge.training.checkpointing.dist_checkpointing")


### PR DESCRIPTION
# What does this PR do?

Bounds checkpoint-conversion memory in both directions:

- Distributed Hugging Face export writes each assigned safetensors shard as soon as all of its tensors arrive, instead of buffering every assigned shard until conversion finishes.
- Distributed-checkpoint loading releases staging structures and cached CUDA allocations before post-load synchronization and export collectives.
- GPU Hugging Face import exposes `--low-memory-save` for checkpoints that do not fit with the default saver. The faster save path remains the default.

# Changelog

- Stream completed safetensors shards to disk and release their tensor buffers immediately.
- Avoid per-rank duplicate sets of every expected and yielded Hugging Face key.
- Build reverse shard metadata only for shards assigned to the local saver rank.
- Release DCP staging references and cached CUDA memory after model loading.
- Drain the tensor generator after saver-local write failures, then aggregate and raise the error consistently across ranks.
- Build the output index only from shards written by the current export, excluding stale files from prior attempts.
- Reject duplicate keys deterministically in strict mode and warn/skip them in non-strict mode.
- Add an opt-in GPU import flag:

  ```bash
  ./scripts/conversion/convert.sh import ... --low-memory-save
  ```

- Wire the same default and opt-in behavior through `AutoBridge.import_ckpt()` without forwarding the option to the Hugging Face loader.
- Reject `--low-memory-save` on CPU and document its memory/runtime trade-off.
- Add focused unit coverage for streaming, failure handling, load cleanup, CLI propagation, CPU validation, and both GPU import save modes.

# Validation

## Unit and static checks

- Streaming/load-cleanup suite: 201 passed in the NeMo 26.06 Linux container.
- Conversion launcher/backend suite after adding the flag: 58 passed in the NeMo 26.06 Linux container.
- AutoBridge import/save focused suite: 11 passed in the NeMo 26.06 Linux container.
- `pre-commit run --all-files`: passed.

## Qwen3-30B-A3B controlled A/B

One exclusive node with 8x H100 80GB, BF16, TP4/PP2/EP4/ETP1. Each pair used the same warmed source or Megatron checkpoint and the same physical node. Both exports used distributed save.

| Measurement | Base | Memory-efficient | Change |
| --- | ---: | ---: | ---: |
| Import wall time | 166.946s | 206.752s | +23.84% |
| Export inner wall time | 104.282s | 130.100s | +24.76% |
| Import peak device memory | 13,881 MiB | 13,223 MiB | -4.74% |
| Export peak device memory | 18,199 MiB | 14,705 MiB | -19.20% |
| Import task MaxRSS | 2,616,860 KiB | 2,632,204 KiB | +0.59% |
| Export task MaxRSS | 10,307,780 KiB | 6,231,304 KiB | -39.55% |

The import result is why low-memory Megatron save is opt-in: Qwen3-30B-A3B pays 23.84% more wall time for a 658 MiB device-memory reduction and no host-memory reduction. Large models that need the extra headroom can enable `--low-memory-save`; other imports keep the faster default.

Streaming export remains the GPU distributed-save implementation because it reduces peak device memory by 3,494 MiB and task MaxRSS by 39.55%. It trades approximately 25% additional wall time for that headroom in this I/O-bound run.

Both imports reloaded successfully. The source, base export, and fixed export matched exactly across all 18,867 tensors, and all 16 safetensors shards plus the index were byte-identical. Both exports strictly reloaded as `Qwen3MoeForCausalLM`.

## One-node GB200 export A/B

Kimi K3 four-layer proxy, one node / 4x GB200, BF16, TP1/PP1/EP4/ETP1. Both exports used the same 176GB Megatron distributed checkpoint.

| Measurement | Base | Fixed |
| --- | ---: | ---: |
| Post-DCP allocated HBM / rank | 51.71 GiB | 51.71 GiB |
| Post-DCP reserved HBM / rank | 80.69 GiB | 51.73 GiB |
| DCP-load peak allocated HBM / rank | 80.67 GiB | 80.67 GiB |
| First safetensors shard persisted | 144.9s | 24.4s |
| Max host RSS / rank | 21.91 GiB | 21.29 GiB |

The fix releases 28.96 GiB of cached HBM per rank after DCP load and persists the first output shard 120.5s earlier. It does not reduce the DCP-load instantaneous peak; eliminating that peak requires a separate load-in-place change.

The fixed exporter wrote shards progressively at 24.4s, 70.5s, 114.7s, and 118.7s. The base exporter wrote no shard until 144.9s. End-to-end proxy wall time was 149.9s base versus 166.4s fixed, so this PR makes no export-throughput improvement claim.

All 7 safetensors shards plus the index were byte-identical between base and fixed, covering 58,482,941,904 serialized bytes and 16,402 tensors.

## One-node GB200 opt-in import roundtrip

The same proxy imported with `--low-memory-save` in 5:15 and persisted a 176GB distributed checkpoint without OOM. Exporting that checkpoint with the streaming saver completed in 3:53.

All 7 safetensors shards plus the index were byte-identical to an export from the default-save import, again covering 58,482,941,904 serialized bytes. This comparison isolates the save-mode change; it does not claim bitwise reversibility against the published MXFP4 source, whose expert weights are dequantized to BF16 during import.

# GitHub Actions CI

CI is requested for final commit `f2fc200316370e31d0ad33b27df0ea97cc49c432`.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] Added targeted unit tests.
- [x] Completed one-node Qwen3-30B-A3B timing, memory, reload, and exact parity A/B.
- [x] Completed one-node GB200 export A/B and exact output parity.
- [x] Completed one-node GB200 opt-in import and roundtrip parity.
- [x] No dependency changes; the AutoBridge option is a backwards-compatible keyword-only addition.

# Additional Information

Observed while validating a large MoE conversion: the prior distributed saver deferred all weight-shard writes until generator exhaustion, and retained checkpoint-load cache left too little headroom for later NCCL collectives.