### PR TITLE
feat(qwen-vl): add fused mRoPE

### DIFF
--- a/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/attention.py
+++ b/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/attention.py
@@ -28,7 +28,31 @@ from megatron.core.transformer.attention import (
 from megatron.core.transformer.dot_product_attention import DotProductAttention
 from torch import Tensor
 
-from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.rope import apply_rotary_pos_emb_absolute
+from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.rope import (
+    apply_rotary_pos_emb_absolute,
+    is_raw_mrope_freqs,
+    materialize_mrope_freqs,
+)
+
+
+def _get_packed_rotary_metadata(
+    packed_seq_params: PackedSeqParams | None,
+    *,
+    for_query: bool,
+) -> tuple[Tensor | None, int | None]:
+    """Return the padded-preferred cu-seqlens and matching max sequence length."""
+    if packed_seq_params is None:
+        return None, None
+    if for_query:
+        cu_seqlens = packed_seq_params.cu_seqlens_q_padded
+        if cu_seqlens is None:
+            cu_seqlens = packed_seq_params.cu_seqlens_q
+        return cu_seqlens, packed_seq_params.max_seqlen_q
+
+    cu_seqlens = packed_seq_params.cu_seqlens_kv_padded
+    if cu_seqlens is None:
+        cu_seqlens = packed_seq_params.cu_seqlens_kv
+    return cu_seqlens, packed_seq_params.max_seqlen_kv
 
 
 class Qwen3VLSelfAttention(SelfAttention):
@@ -114,6 +138,37 @@ class Qwen3VLSelfAttention(SelfAttention):
         else:
             assert rotary_pos_cos is None and rotary_pos_sin is None
 
+        # MCore inference mutates/slices the legacy sequence-first embedding
+        # layout before RoPE application. Materialize raw frequencies here so
+        # fused training support does not alter the inference contract.
+        if inference_context is not None and rotary_pos_emb is not None:
+            embeddings_are_tuple = isinstance(rotary_pos_emb, tuple)
+            raw_embeddings = rotary_pos_emb if embeddings_are_tuple else (rotary_pos_emb,)
+            if any(
+                is_raw_mrope_freqs(
+                    embedding,
+                    sequence_length=hidden_states.size(0),
+                    mrope_section=list(self.config.mrope_section),
+                )
+                for embedding in raw_embeddings
+            ):
+                materialized_embeddings = tuple(
+                    materialize_mrope_freqs(
+                        embedding,
+                        list(self.config.mrope_section),
+                        interleaved_mrope=bool(getattr(self.config, "mrope_interleaved", True)),
+                        rotary_interleaved=self.config.rotary_interleaved,
+                    )
+                    if is_raw_mrope_freqs(
+                        embedding,
+                        sequence_length=hidden_states.size(0),
+                        mrope_section=list(self.config.mrope_section),
+                    )
+                    else embedding
+                    for embedding in raw_embeddings
+                )
+                rotary_pos_emb = materialized_embeddings if embeddings_are_tuple else materialized_embeddings[0]
+
         # For self attention we just duplicate the rotary_pos_emb if it isn't already
         if rotary_pos_emb is not None and not isinstance(rotary_pos_emb, tuple):
             rotary_pos_emb = (rotary_pos_emb,) * 2
@@ -191,17 +246,8 @@ class Qwen3VLSelfAttention(SelfAttention):
         if rotary_pos_emb is not None and not self.config.flash_decode:
             q_pos_emb, k_pos_emb = rotary_pos_emb
 
-            if packed_seq_params is not None:
-                if packed_seq_params.cu_seqlens_q_padded is not None:
-                    cu_seqlens_q = packed_seq_params.cu_seqlens_q_padded
-                else:
-                    cu_seqlens_q = packed_seq_params.cu_seqlens_q
-                if packed_seq_params.cu_seqlens_kv_padded is not None:
-                    cu_seqlens_kv = packed_seq_params.cu_seqlens_kv_padded
-                else:
-                    cu_seqlens_kv = packed_seq_params.cu_seqlens_kv
-            else:
-                cu_seqlens_q = cu_seqlens_kv = None
+            cu_seqlens_q, max_seqlen_q = _get_packed_rotary_metadata(packed_seq_params, for_query=True)
+            cu_seqlens_kv, max_seqlen_kv = _get_packed_rotary_metadata(packed_seq_params, for_query=False)
 
             if q_pos_emb is not None:
                 # TODO VIJAY: simplify
@@ -211,6 +257,8 @@ class Qwen3VLSelfAttention(SelfAttention):
                         q_pos_emb,
                         config=self.config,
                         cu_seqlens=cu_seqlens_q,
+                        cp_group=self.pg_collection.cp,
+                        max_seqlen=max_seqlen_q,
                     )
                 else:
                     query = inference_context.apply_rotary_emb_query(
@@ -218,7 +266,7 @@ class Qwen3VLSelfAttention(SelfAttention):
                         q_pos_emb,
                         self.config,
                         cu_seqlens_q,
-                        self.model_comm_pgs.cp,
+                        self.pg_collection.cp,
                     )
             if k_pos_emb is not None:
                 key = apply_rotary_pos_emb_absolute(
@@ -226,6 +274,8 @@ class Qwen3VLSelfAttention(SelfAttention):
                     k_pos_emb,
                     config=self.config,
                     cu_seqlens=cu_seqlens_kv,
+                    cp_group=self.pg_collection.cp,
+                    max_seqlen=max_seqlen_kv,
                 )
 
             # TODO, can apply positional embedding to value_layer so it has

--- a/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/fused_mrope.py
+++ b/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/fused_mrope.py
@@ -1,0 +1,825 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Triton fused multimodal RoPE apply.
+
+Vendored from NVIDIA/Megatron-LM merge commit ``9304a25642`` (source blob
+``5ed245de1c32f03efecb543225f337389e845f07``). Keep local dispatch and
+fallback policy outside this file so upstream kernel fixes remain easy to port.
+
+The fused path consumes the raw three-axis mRoPE frequencies with shape
+``[3, batch, seq, rotary_dim / 2]`` and applies the rotation directly to a BSHD
+tensor. It supports both Qwen2-VL section-based mRoPE and Qwen3.5-VL
+stride-3 interleaved mRoPE layouts.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+from unittest.mock import MagicMock
+
+import torch
+from megatron.core.utils import null_decorator
+
+
+try:
+    import triton
+    import triton.language as tl
+
+    HAVE_TRITON = True
+except ImportError:
+    HAVE_TRITON = False
+
+if not HAVE_TRITON:
+    triton = MagicMock()
+    triton.jit = null_decorator
+    tl = MagicMock()
+
+
+def _smallest_power_of_2_at_least(x: int) -> int:
+    block = 1
+    while block < x:
+        block *= 2
+    return block
+
+
+def _expected_interleaved_mrope_section(half_rotary_dim: int) -> tuple[int, int, int]:
+    return ((half_rotary_dim + 2) // 3, (half_rotary_dim + 1) // 3, half_rotary_dim // 3)
+
+
+def _validate_mrope_section(
+    mrope_section: List[int], half_rotary_dim: int, interleaved_mrope: bool
+) -> tuple[int, int, int]:
+    assert len(mrope_section) == 3, f"mrope_section must have length 3, got {mrope_section}"
+
+    sec_t, sec_h, sec_w = (int(section) for section in mrope_section)
+    assert min(sec_t, sec_h, sec_w) >= 0, f"mrope_section values must be non-negative, got {mrope_section}"
+    assert half_rotary_dim > 0, "raw mRoPE rotary dim must be greater than 0"
+    assert sec_t + sec_h + sec_w == half_rotary_dim, (
+        f"mrope_section {mrope_section} must sum to rotary_dim / 2 = {half_rotary_dim}"
+    )
+    if interleaved_mrope:
+        expected = _expected_interleaved_mrope_section(half_rotary_dim)
+        assert (sec_t, sec_h, sec_w) == expected, (
+            f"interleaved mRoPE with rotary_dim / 2 = {half_rotary_dim} requires "
+            f"mrope_section {list(expected)}, got {mrope_section}"
+        )
+    return sec_t, sec_h, sec_w
+
+
+def _validate_mrope_inputs(
+    t: torch.Tensor, freqs: torch.Tensor, mrope_section: List[int], interleaved_mrope: bool
+) -> tuple[int, int, int, int, int, int, int, int]:
+    assert t.dim() == 4, f"t must have shape [seq, batch, heads, head_dim], got {t.shape}"
+    assert freqs.dim() == 4, f"raw mRoPE freqs must have shape [3, batch, seq, rotary_dim / 2], got {freqs.shape}"
+
+    seq, batch, heads, head_dim = t.shape
+    axes, freq_batch, freq_seq, half_rotary_dim = freqs.shape
+    assert axes == 3, f"raw mRoPE freqs first dimension must be 3, got {axes}"
+    assert freq_batch == batch and freq_seq == seq, (
+        f"freqs shape {tuple(freqs.shape)} is incompatible with t shape {tuple(t.shape)}"
+    )
+
+    sec_t, sec_h, sec_w = _validate_mrope_section(mrope_section, half_rotary_dim, interleaved_mrope)
+
+    rotary_dim = half_rotary_dim * 2
+    assert rotary_dim <= head_dim, f"raw mRoPE rotary dim {rotary_dim} exceeds input head dim {head_dim}"
+    return seq, batch, heads, head_dim, half_rotary_dim, sec_t, sec_h, sec_w
+
+
+def _validate_mrope_thd_inputs(
+    t: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    freqs: torch.Tensor,
+    mrope_section: List[int],
+    interleaved_mrope: bool,
+    cp_size: int,
+) -> tuple[int, int, int, int, int, int, int]:
+    assert t.dim() == 3, f"t must have shape [tokens, heads, head_dim], got {t.shape}"
+    assert freqs.dim() == 4, f"raw mRoPE freqs must have shape [3, 1, total_seqlen, rotary_dim / 2], got {freqs.shape}"
+    assert cu_seqlens.dim() == 1, f"cu_seqlens must be 1D, got {cu_seqlens.shape}"
+
+    tokens, heads, head_dim = t.shape
+    axes, freq_batch, freq_seq, half_rotary_dim = freqs.shape
+    assert axes == 3, f"raw mRoPE freqs first dimension must be 3, got {axes}"
+    assert freq_batch == 1, f"raw mRoPE THD freqs must have singleton batch dimension, got {freqs.shape}"
+    assert freq_seq == tokens * cp_size, (
+        "raw mRoPE THD freqs sequence length must match local tokens times cp_size, "
+        f"got freqs.shape[2]={freq_seq}, tokens={tokens}, cp_size={cp_size}"
+    )
+
+    sec_t, sec_h, sec_w = _validate_mrope_section(mrope_section, half_rotary_dim, interleaved_mrope)
+    rotary_dim = half_rotary_dim * 2
+    assert rotary_dim <= head_dim, f"raw mRoPE rotary dim {rotary_dim} exceeds input head dim {head_dim}"
+    return tokens, heads, head_dim, half_rotary_dim, sec_t, sec_h, sec_w
+
+
+def _fused_mrope_dtype_capability_reason(t: torch.Tensor, freqs: torch.Tensor) -> Optional[str]:
+    """Return why the input/freqs dtypes or CUDA compute capability are unsupported.
+
+    Returns None when both are fine. ``t`` is assumed to be a CUDA tensor (callers check
+    device placement first).
+    """
+    if freqs.dtype != torch.float32:
+        return f"raw mRoPE freqs must be float32, got {freqs.dtype}"
+    if t.dtype not in (torch.float16, torch.bfloat16, torch.float32):
+        return f"input dtype {t.dtype} is not supported"
+    try:
+        capability = torch.cuda.get_device_capability(t.device)
+    except RuntimeError as exc:
+        return f"could not query CUDA device capability: {exc}"
+    if capability < (7, 0):
+        return f"requires CUDA compute capability >= 7.0, got {capability[0]}.{capability[1]}"
+    if t.dtype == torch.bfloat16 and capability < (8, 0):
+        return f"requires CUDA compute capability >= 8.0 for bfloat16 inputs, got {capability[0]}.{capability[1]}"
+    return None
+
+
+def get_fused_mrope_unavailable_reason(
+    t: Optional[torch.Tensor] = None,
+    freqs: Optional[torch.Tensor] = None,
+    rotary_interleaved: bool = False,
+) -> Optional[str]:
+    """Return why fused mRoPE cannot run, or None when it is launchable."""
+    if not HAVE_TRITON:
+        return "Triton is not available"
+    if rotary_interleaved:
+        return "rotary_interleaved=True is not supported"
+    if t is None or freqs is None:
+        return None
+    if not t.is_cuda or not freqs.is_cuda:
+        return "Triton fused mRoPE requires CUDA tensors"
+    if t.device != freqs.device:
+        return f"Triton fused mRoPE requires t and freqs on the same device, got {t.device} and {freqs.device}"
+    reason = _fused_mrope_dtype_capability_reason(t, freqs)
+    if reason is not None:
+        return reason
+    if t.stride(-1) != 1:
+        return f"input head dimension must be contiguous, got stride {t.stride()}"
+    return None
+
+
+def get_fused_mrope_thd_unavailable_reason(
+    t: Optional[torch.Tensor] = None,
+    cu_seqlens: Optional[torch.Tensor] = None,
+    freqs: Optional[torch.Tensor] = None,
+    rotary_interleaved: bool = False,
+    cp_size: int = 1,
+    cp_rank: int = 0,
+) -> Optional[str]:
+    """Return why fused THD mRoPE cannot run, or None when it is launchable.
+
+    ``cu_seqlens`` is assumed to describe the padded layout used to partition
+    the THD tensor. In particular, every packed sub-sequence must be divisible
+    by ``cp_size`` when context parallelism is enabled. This function does not
+    inspect CUDA tensor values so availability checks remain free of host
+    synchronization.
+    """
+    if not HAVE_TRITON:
+        return "Triton is not available"
+    if rotary_interleaved:
+        return "rotary_interleaved=True is not supported"
+    if cp_size < 1:
+        return f"cp_size must be positive, got {cp_size}"
+    if cp_rank < 0 or cp_rank >= cp_size:
+        return f"cp_rank must be in [0, {cp_size}), got {cp_rank}"
+    if t is None or cu_seqlens is None or freqs is None:
+        return None
+    if t.dim() != 3:
+        return f"THD fused mRoPE expects t with shape [tokens, heads, head_dim], got {tuple(t.shape)}"
+    if freqs.dim() != 4:
+        return f"raw mRoPE THD freqs must have shape [3, 1, total_seqlen, rotary_dim / 2], got {tuple(freqs.shape)}"
+    if cu_seqlens.dim() != 1:
+        return f"cu_seqlens must be 1D, got {tuple(cu_seqlens.shape)}"
+    if not t.is_cuda or not freqs.is_cuda or not cu_seqlens.is_cuda:
+        return "Triton fused THD mRoPE requires CUDA tensors"
+    if t.device != freqs.device or t.device != cu_seqlens.device:
+        return (
+            "Triton fused THD mRoPE requires t, freqs, and cu_seqlens on the same device, "
+            f"got {t.device}, {freqs.device}, and {cu_seqlens.device}"
+        )
+    reason = _fused_mrope_dtype_capability_reason(t, freqs)
+    if reason is not None:
+        return reason
+    if cu_seqlens.dtype not in (torch.int32, torch.int64):
+        return f"cu_seqlens dtype {cu_seqlens.dtype} is not supported"
+    if t.stride(-1) != 1:
+        return f"input head dimension must be contiguous, got stride {t.stride()}"
+    if freqs.shape[0] != 3 or freqs.shape[1] != 1:
+        return f"raw mRoPE THD freqs must have shape [3, 1, total_seqlen, rotary_dim / 2], got {tuple(freqs.shape)}"
+    if cp_size > 1 and freqs.shape[2] % cp_size != 0:
+        return (
+            "raw mRoPE THD freqs sequence length must be divisible by context parallel size, "
+            f"got freqs.shape[2]={freqs.shape[2]}, cp_size={cp_size}"
+        )
+    if freqs.shape[2] != t.shape[0] * cp_size:
+        return (
+            "raw mRoPE THD freqs sequence length must match local tokens times cp_size, "
+            f"got freqs.shape[2]={freqs.shape[2]}, tokens={t.shape[0]}, cp_size={cp_size}"
+        )
+    return None
+
+
+def can_launch_fused_mrope(
+    t: Optional[torch.Tensor] = None,
+    freqs: Optional[torch.Tensor] = None,
+    rotary_interleaved: bool = False,
+) -> bool:
+    """Return whether the Triton fused mRoPE kernel can be launched."""
+    return get_fused_mrope_unavailable_reason(t, freqs, rotary_interleaved) is None
+
+
+def can_launch_fused_mrope_thd(
+    t: Optional[torch.Tensor] = None,
+    cu_seqlens: Optional[torch.Tensor] = None,
+    freqs: Optional[torch.Tensor] = None,
+    rotary_interleaved: bool = False,
+    cp_size: int = 1,
+    cp_rank: int = 0,
+) -> bool:
+    """Return whether the Triton fused THD mRoPE kernel can be launched."""
+    return (
+        get_fused_mrope_thd_unavailable_reason(
+            t,
+            cu_seqlens,
+            freqs,
+            rotary_interleaved=rotary_interleaved,
+            cp_size=cp_size,
+            cp_rank=cp_rank,
+        )
+        is None
+    )
+
+
+def mrope_freqs_to_rotary_emb(
+    freqs: torch.Tensor,
+    mrope_section: List[int],
+    interleaved_mrope: bool = False,
+    rotary_interleaved: bool = False,
+) -> torch.Tensor:
+    """Convert raw mRoPE freqs to the unfused RoPE embedding layout.
+
+    Args:
+        freqs: Raw mRoPE frequencies with shape ``[3, batch, seq, rotary_dim / 2]``.
+        mrope_section: Temporal, height, and width channel sections.
+        interleaved_mrope: Use Qwen3.5-VL stride-3 T/H/W layout when True. Use
+            Qwen2-VL section layout when False.
+        rotary_interleaved: Use adjacent-pair RoPE layout when True. This is
+            available for reference conversion; fused Triton currently supports
+            split-half layout only.
+
+    Returns:
+        Tensor with shape ``[seq, batch, 1, rotary_dim]``.
+    """
+    assert freqs.dim() == 4, f"raw mRoPE freqs must have shape [3, batch, seq, rotary_dim / 2], got {freqs.shape}"
+    assert freqs.size(0) == 3, f"raw mRoPE freqs first dimension must be 3, got {freqs.size(0)}"
+    assert len(mrope_section) == 3, f"mrope_section must have length 3, got {mrope_section}"
+
+    half_rotary_dim = freqs.size(-1)
+    sec_t, sec_h, sec_w = _validate_mrope_section(mrope_section, half_rotary_dim, interleaved_mrope)
+
+    if interleaved_mrope:
+        freqs_out = freqs[0].clone()
+        for dim_idx, offset in enumerate((1, 2), start=1):
+            length = int(mrope_section[dim_idx]) * 3
+            idx = slice(offset, length, 3)
+            freqs_out[..., idx] = freqs[dim_idx, ..., idx]
+        if rotary_interleaved:
+            batch = freqs_out.shape[0]
+            emb = torch.stack((freqs_out.reshape(batch, -1, 1), freqs_out.reshape(batch, -1, 1)), dim=-1)
+            emb = emb.view(batch, freqs_out.shape[1], -1)
+        else:
+            emb = torch.cat((freqs_out, freqs_out), dim=-1)
+    else:
+        if rotary_interleaved:
+            batch = freqs.shape[1]
+            emb = torch.stack((freqs.reshape(3, batch, -1, 1), freqs.reshape(3, batch, -1, 1)), dim=-1).view(
+                3, batch, freqs.shape[2], -1
+            )
+            mrope_section_doubled = list(mrope_section) * 2
+            emb = torch.cat(
+                [chunk[i % 3] for i, chunk in enumerate(emb.split(mrope_section_doubled, dim=-1))],
+                dim=-1,
+            )
+        else:
+            freqs_out = torch.empty_like(freqs[0])
+            freqs_out[..., :sec_t] = freqs[0, ..., :sec_t]
+            freqs_out[..., sec_t : sec_t + sec_h] = freqs[1, ..., sec_t : sec_t + sec_h]
+            freqs_out[..., sec_t + sec_h :] = freqs[2, ..., sec_t + sec_h :]
+            emb = torch.cat((freqs_out, freqs_out), dim=-1)
+    return emb[..., None, :].transpose(0, 1).contiguous()
+
+
+@triton.jit
+def _mrope_axis(
+    k,
+    SEC_T: tl.constexpr,
+    SEC_H: tl.constexpr,
+    SEC_W: tl.constexpr,
+    INTERLEAVED_MROPE: tl.constexpr,
+):
+    if INTERLEAVED_MROPE:
+        rem = k % 3
+        section_idx = k // 3
+        is_h = (rem == 1) & (section_idx < SEC_H)
+        is_w = (rem == 2) & (section_idx < SEC_W)
+        return tl.where(is_h, 1, tl.where(is_w, 2, 0))
+
+    is_h = (k >= SEC_T) & (k < (SEC_T + SEC_H))
+    is_w = k >= (SEC_T + SEC_H)
+    return tl.where(is_h, 1, tl.where(is_w, 2, 0))
+
+
+@triton.jit
+def _fused_mrope_kernel(
+    T,
+    FREQS,
+    OUT,
+    t_s_seq,
+    t_s_batch,
+    t_s_head,
+    t_s_dim,
+    f_s_axis,
+    f_s_batch,
+    f_s_seq,
+    f_s_dim,
+    o_s_seq,
+    o_s_batch,
+    o_s_head,
+    o_s_dim,
+    HALF_ROTARY_DIM: tl.constexpr,
+    PASS_DIM: tl.constexpr,
+    SEC_T: tl.constexpr,
+    SEC_H: tl.constexpr,
+    SEC_W: tl.constexpr,
+    INTERLEAVED_MROPE: tl.constexpr,
+    ROTARY_INTERLEAVED: tl.constexpr,
+    INVERSE: tl.constexpr,
+    FP32_COMPUTE: tl.constexpr,
+    BLOCK_HALF: tl.constexpr,
+    BLOCK_PASS: tl.constexpr,
+):
+    seq_idx = tl.program_id(0)
+    batch_idx = tl.program_id(1)
+    head_idx = tl.program_id(2)
+
+    k = tl.arange(0, BLOCK_HALF)
+    mask = k < HALF_ROTARY_DIM
+
+    axis = _mrope_axis(k, SEC_T, SEC_H, SEC_W, INTERLEAVED_MROPE)
+
+    # Pick the arithmetic dtype once: fp32 when fp32 accumulation is requested, otherwise the
+    # output dtype so intermediates round exactly like PyTorch's pointwise RoPE.
+    compute_ty = tl.float32 if FP32_COMPUTE else OUT.dtype.element_ty
+
+    freqs_offset = axis * f_s_axis + batch_idx * f_s_batch + seq_idx * f_s_seq + k * f_s_dim
+    freqs = tl.load(FREQS + freqs_offset, mask=mask, other=0.0)
+    cos_v = tl.cos(freqs).to(compute_ty)
+    sin_v = tl.sin(freqs).to(compute_ty)
+    if INVERSE:
+        sin_v = -sin_v
+
+    t_base = T + seq_idx * t_s_seq + batch_idx * t_s_batch + head_idx * t_s_head
+    out_base = OUT + seq_idx * o_s_seq + batch_idx * o_s_batch + head_idx * o_s_head
+
+    if ROTARY_INTERLEAVED:
+        lo_offset = (2 * k) * t_s_dim
+        hi_offset = (2 * k + 1) * t_s_dim
+        out_lo_offset = (2 * k) * o_s_dim
+        out_hi_offset = (2 * k + 1) * o_s_dim
+    else:
+        lo_offset = k * t_s_dim
+        hi_offset = (k + HALF_ROTARY_DIM) * t_s_dim
+        out_lo_offset = k * o_s_dim
+        out_hi_offset = (k + HALF_ROTARY_DIM) * o_s_dim
+
+    t_lo = tl.load(t_base + lo_offset, mask=mask, other=0.0).to(compute_ty)
+    t_hi = tl.load(t_base + hi_offset, mask=mask, other=0.0).to(compute_ty)
+
+    lo_cos = (t_lo * cos_v).to(compute_ty)
+    hi_sin = (t_hi * sin_v).to(compute_ty)
+    hi_cos = (t_hi * cos_v).to(compute_ty)
+    lo_sin = (t_lo * sin_v).to(compute_ty)
+
+    out_lo = (lo_cos - hi_sin).to(OUT.dtype.element_ty)
+    out_hi = (hi_cos + lo_sin).to(OUT.dtype.element_ty)
+
+    tl.store(out_base + out_lo_offset, out_lo, mask=mask)
+    tl.store(out_base + out_hi_offset, out_hi, mask=mask)
+
+    if PASS_DIM > 0:
+        pass_idx = tl.arange(0, BLOCK_PASS)
+        pass_mask = pass_idx < PASS_DIM
+        src_dim = 2 * HALF_ROTARY_DIM + pass_idx
+        pass_values = tl.load(t_base + src_dim * t_s_dim, mask=pass_mask, other=0.0)
+        tl.store(out_base + src_dim * o_s_dim, pass_values, mask=pass_mask)
+
+
+@triton.jit
+def _fused_mrope_thd_kernel(
+    T,
+    CU_SEQLENS,
+    FREQS,
+    OUT,
+    t_s_token,
+    t_s_head,
+    t_s_dim,
+    cu_s_idx,
+    f_s_axis,
+    f_s_seq,
+    f_s_dim,
+    o_s_token,
+    o_s_head,
+    o_s_dim,
+    NUM_SEQS,
+    HALF_ROTARY_DIM: tl.constexpr,
+    PASS_DIM: tl.constexpr,
+    SEC_T: tl.constexpr,
+    SEC_H: tl.constexpr,
+    SEC_W: tl.constexpr,
+    INTERLEAVED_MROPE: tl.constexpr,
+    ROTARY_INTERLEAVED: tl.constexpr,
+    INVERSE: tl.constexpr,
+    CP_SIZE: tl.constexpr,
+    CP_RANK: tl.constexpr,
+    FP32_COMPUTE: tl.constexpr,
+    BLOCK_HALF: tl.constexpr,
+    BLOCK_PASS: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+    head_idx = tl.program_id(1)
+
+    freq_seq_idx = token_idx
+    seq_i = 0
+    while seq_i < NUM_SEQS:
+        global_start = tl.load(CU_SEQLENS + seq_i * cu_s_idx)
+        global_end = tl.load(CU_SEQLENS + (seq_i + 1) * cu_s_idx)
+        local_start = global_start // CP_SIZE
+        local_end = global_end // CP_SIZE
+        in_seq = (token_idx >= local_start) & (token_idx < local_end)
+        local_offset = token_idx - local_start
+
+        if CP_SIZE > 1:
+            local_seq_len = local_end - local_start
+            first_cp_seg = (local_seq_len + 1) // 2
+            second_cp_seg = local_seq_len // 2
+            first_freq_idx = global_start + CP_RANK * first_cp_seg + local_offset
+            second_freq_idx = global_end - (CP_RANK + 1) * second_cp_seg + (local_offset - first_cp_seg)
+            seq_freq_idx = tl.where(local_offset < first_cp_seg, first_freq_idx, second_freq_idx)
+        else:
+            seq_freq_idx = global_start + local_offset
+
+        freq_seq_idx = tl.where(in_seq, seq_freq_idx, freq_seq_idx)
+        seq_i += 1
+
+    k = tl.arange(0, BLOCK_HALF)
+    mask = k < HALF_ROTARY_DIM
+    axis = _mrope_axis(k, SEC_T, SEC_H, SEC_W, INTERLEAVED_MROPE)
+
+    # Pick the arithmetic dtype once: fp32 when fp32 accumulation is requested, otherwise the
+    # output dtype so intermediates round exactly like PyTorch's pointwise RoPE.
+    compute_ty = tl.float32 if FP32_COMPUTE else OUT.dtype.element_ty
+
+    freqs_offset = axis * f_s_axis + freq_seq_idx * f_s_seq + k * f_s_dim
+    freqs = tl.load(FREQS + freqs_offset, mask=mask, other=0.0)
+    cos_v = tl.cos(freqs).to(compute_ty)
+    sin_v = tl.sin(freqs).to(compute_ty)
+    if INVERSE:
+        sin_v = -sin_v
+
+    t_base = T + token_idx * t_s_token + head_idx * t_s_head
+    out_base = OUT + token_idx * o_s_token + head_idx * o_s_head
+
+    if ROTARY_INTERLEAVED:
+        lo_offset = (2 * k) * t_s_dim
+        hi_offset = (2 * k + 1) * t_s_dim
+        out_lo_offset = (2 * k) * o_s_dim
+        out_hi_offset = (2 * k + 1) * o_s_dim
+    else:
+        lo_offset = k * t_s_dim
+        hi_offset = (k + HALF_ROTARY_DIM) * t_s_dim
+        out_lo_offset = k * o_s_dim
+        out_hi_offset = (k + HALF_ROTARY_DIM) * o_s_dim
+
+    t_lo = tl.load(t_base + lo_offset, mask=mask, other=0.0).to(compute_ty)
+    t_hi = tl.load(t_base + hi_offset, mask=mask, other=0.0).to(compute_ty)
+
+    lo_cos = (t_lo * cos_v).to(compute_ty)
+    hi_sin = (t_hi * sin_v).to(compute_ty)
+    hi_cos = (t_hi * cos_v).to(compute_ty)
+    lo_sin = (t_lo * sin_v).to(compute_ty)
+
+    out_lo = (lo_cos - hi_sin).to(OUT.dtype.element_ty)
+    out_hi = (hi_cos + lo_sin).to(OUT.dtype.element_ty)
+
+    tl.store(out_base + out_lo_offset, out_lo, mask=mask)
+    tl.store(out_base + out_hi_offset, out_hi, mask=mask)
+
+    if PASS_DIM > 0:
+        pass_idx = tl.arange(0, BLOCK_PASS)
+        pass_mask = pass_idx < PASS_DIM
+        src_dim = 2 * HALF_ROTARY_DIM + pass_idx
+        pass_values = tl.load(t_base + src_dim * t_s_dim, mask=pass_mask, other=0.0)
+        tl.store(out_base + src_dim * o_s_dim, pass_values, mask=pass_mask)
+
+
+def _launch_fused_mrope(
+    t: torch.Tensor,
+    freqs: torch.Tensor,
+    mrope_section: List[int],
+    interleaved_mrope: bool,
+    rotary_interleaved: bool,
+    inverse: bool,
+    fp32_compute: bool = False,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    unavailable_reason = get_fused_mrope_unavailable_reason(t, freqs, rotary_interleaved)
+    assert unavailable_reason is None, unavailable_reason
+
+    seq, batch, heads, head_dim, half_rotary_dim, sec_t, sec_h, sec_w = _validate_mrope_inputs(
+        t, freqs, mrope_section, interleaved_mrope
+    )
+
+    if out is None:
+        out = torch.empty_like(t)
+    else:
+        assert out.shape == t.shape and out.dtype == t.dtype
+        assert out.stride(-1) == 1, f"fused mRoPE requires output contiguous head dimension, got {out.stride()}"
+
+    block_half = _smallest_power_of_2_at_least(half_rotary_dim)
+    pass_dim = head_dim - (2 * half_rotary_dim)
+    block_pass = _smallest_power_of_2_at_least(max(pass_dim, 1))
+
+    grid = (seq, batch, heads)
+    _fused_mrope_kernel[grid](
+        t,
+        freqs,
+        out,
+        t.stride(0),
+        t.stride(1),
+        t.stride(2),
+        t.stride(3),
+        freqs.stride(0),
+        freqs.stride(1),
+        freqs.stride(2),
+        freqs.stride(3),
+        out.stride(0),
+        out.stride(1),
+        out.stride(2),
+        out.stride(3),
+        HALF_ROTARY_DIM=half_rotary_dim,
+        PASS_DIM=pass_dim,
+        SEC_T=sec_t,
+        SEC_H=sec_h,
+        SEC_W=sec_w,
+        INTERLEAVED_MROPE=interleaved_mrope,
+        ROTARY_INTERLEAVED=rotary_interleaved,
+        INVERSE=inverse,
+        FP32_COMPUTE=fp32_compute,
+        BLOCK_HALF=block_half,
+        BLOCK_PASS=block_pass,
+        num_warps=4,
+    )
+    return out
+
+
+def _launch_fused_mrope_thd(
+    t: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    freqs: torch.Tensor,
+    launch_metadata: tuple[int, int, int, int, int, int, int],
+    interleaved_mrope: bool,
+    rotary_interleaved: bool,
+    inverse: bool,
+    cp_size: int,
+    cp_rank: int,
+    fp32_compute: bool = False,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    tokens, heads, head_dim, half_rotary_dim, sec_t, sec_h, sec_w = launch_metadata
+
+    if out is None:
+        out = torch.empty_like(t)
+    else:
+        assert out.shape == t.shape and out.dtype == t.dtype
+        assert out.stride(-1) == 1, f"fused THD mRoPE requires output contiguous head dimension, got {out.stride()}"
+
+    block_half = _smallest_power_of_2_at_least(half_rotary_dim)
+    pass_dim = head_dim - (2 * half_rotary_dim)
+    block_pass = _smallest_power_of_2_at_least(max(pass_dim, 1))
+    num_seqs = cu_seqlens.numel() - 1
+
+    grid = (tokens, heads)
+    _fused_mrope_thd_kernel[grid](
+        t,
+        cu_seqlens,
+        freqs,
+        out,
+        t.stride(0),
+        t.stride(1),
+        t.stride(2),
+        cu_seqlens.stride(0),
+        freqs.stride(0),
+        freqs.stride(2),
+        freqs.stride(3),
+        out.stride(0),
+        out.stride(1),
+        out.stride(2),
+        num_seqs,
+        HALF_ROTARY_DIM=half_rotary_dim,
+        PASS_DIM=pass_dim,
+        SEC_T=sec_t,
+        SEC_H=sec_h,
+        SEC_W=sec_w,
+        INTERLEAVED_MROPE=interleaved_mrope,
+        ROTARY_INTERLEAVED=rotary_interleaved,
+        INVERSE=inverse,
+        CP_SIZE=cp_size,
+        CP_RANK=cp_rank,
+        FP32_COMPUTE=fp32_compute,
+        BLOCK_HALF=block_half,
+        BLOCK_PASS=block_pass,
+        num_warps=4,
+    )
+    return out
+
+
+class _FusedMRoPE(torch.autograd.Function):
+    """Autograd wrapper for fused mRoPE.
+
+    The raw frequency table is generated from position IDs and inverse frequencies,
+    so gradients are only propagated to the rotated tensor.
+    """
+
+    @staticmethod
+    def forward(ctx, t, freqs, mrope_section, interleaved_mrope, rotary_interleaved, fp32_compute):
+        """Apply fused mRoPE and save the raw frequencies for backward."""
+        assert not freqs.requires_grad, "fused mRoPE expects non-gradient raw frequency tensors"
+        ctx.mrope_section = tuple(int(section) for section in mrope_section)
+        ctx.interleaved_mrope = bool(interleaved_mrope)
+        ctx.rotary_interleaved = bool(rotary_interleaved)
+        ctx.fp32_compute = bool(fp32_compute)
+        ctx.save_for_backward(freqs)
+        return _launch_fused_mrope(
+            t,
+            freqs,
+            ctx.mrope_section,
+            ctx.interleaved_mrope,
+            ctx.rotary_interleaved,
+            inverse=False,
+            fp32_compute=ctx.fp32_compute,
+        )
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        """Apply inverse fused mRoPE to the output gradient."""
+        (freqs,) = ctx.saved_tensors
+        grad_input = _launch_fused_mrope(
+            grad_output.contiguous(),
+            freqs,
+            ctx.mrope_section,
+            ctx.interleaved_mrope,
+            ctx.rotary_interleaved,
+            inverse=True,
+            fp32_compute=ctx.fp32_compute,
+        )
+        return grad_input, None, None, None, None, None
+
+
+class _FusedMRoPETHD(torch.autograd.Function):
+    """Autograd wrapper for fused THD mRoPE."""
+
+    @staticmethod
+    def forward(
+        ctx,
+        t,
+        cu_seqlens,
+        freqs,
+        mrope_section,
+        interleaved_mrope,
+        rotary_interleaved,
+        cp_size,
+        cp_rank,
+        fp32_compute,
+    ):
+        """Apply fused THD mRoPE and save packed metadata for backward."""
+        assert not freqs.requires_grad, "fused THD mRoPE expects non-gradient raw frequency tensors"
+        mrope_section = tuple(int(section) for section in mrope_section)
+        ctx.interleaved_mrope = bool(interleaved_mrope)
+        ctx.rotary_interleaved = bool(rotary_interleaved)
+        ctx.cp_size = int(cp_size)
+        ctx.cp_rank = int(cp_rank)
+        ctx.fp32_compute = bool(fp32_compute)
+        ctx.launch_metadata = _validate_mrope_thd_inputs(
+            t, cu_seqlens, freqs, mrope_section, ctx.interleaved_mrope, ctx.cp_size
+        )
+        ctx.save_for_backward(cu_seqlens, freqs)
+        return _launch_fused_mrope_thd(
+            t,
+            cu_seqlens,
+            freqs,
+            ctx.launch_metadata,
+            ctx.interleaved_mrope,
+            ctx.rotary_interleaved,
+            inverse=False,
+            cp_size=ctx.cp_size,
+            cp_rank=ctx.cp_rank,
+            fp32_compute=ctx.fp32_compute,
+        )
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        """Apply inverse fused THD mRoPE to the output gradient."""
+        cu_seqlens, freqs = ctx.saved_tensors
+        grad_input = _launch_fused_mrope_thd(
+            grad_output.contiguous(),
+            cu_seqlens,
+            freqs,
+            ctx.launch_metadata,
+            ctx.interleaved_mrope,
+            ctx.rotary_interleaved,
+            inverse=True,
+            cp_size=ctx.cp_size,
+            cp_rank=ctx.cp_rank,
+            fp32_compute=ctx.fp32_compute,
+        )
+        return grad_input, None, None, None, None, None, None, None, None
+
+
+def fused_apply_mrope(
+    t: torch.Tensor,
+    freqs: torch.Tensor,
+    mrope_section: List[int],
+    interleaved_mrope: bool = False,
+    rotary_interleaved: bool = False,
+    fp32_compute: bool = False,
+) -> torch.Tensor:
+    """Apply multimodal RoPE with a fused Triton kernel.
+
+    Args:
+        t: Input tensor with shape ``[seq, batch, heads, head_dim]``.
+        freqs: Raw mRoPE frequencies with shape ``[3, batch, seq, rotary_dim / 2]``.
+        mrope_section: Temporal, height, and width channel sections.
+        interleaved_mrope: Use Qwen3.5-VL stride-3 T/H/W layout when True. Use
+            Qwen2-VL section layout when False.
+        rotary_interleaved: Must be False. The integrated fused mRoPE path
+            currently supports split-half RoPE layout.
+        fp32_compute: Apply the rotary math in fp32 and cast directly to output dtype.
+
+    Returns:
+        Rotated tensor with the same shape and dtype as ``t``.
+    """
+    return _FusedMRoPE.apply(t, freqs, mrope_section, interleaved_mrope, rotary_interleaved, fp32_compute)
+
+
+def fused_apply_mrope_thd(
+    t: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    freqs: torch.Tensor,
+    mrope_section: List[int],
+    interleaved_mrope: bool = False,
+    rotary_interleaved: bool = False,
+    cp_size: int = 1,
+    cp_rank: int = 0,
+    fp32_compute: bool = False,
+) -> torch.Tensor:
+    """Apply multimodal RoPE to THD-packed tensors with a fused Triton kernel.
+
+    Args:
+        t: Input tensor with shape ``[total_tokens, heads, head_dim]``.
+        cu_seqlens: Global cumulative sequence lengths for the padded packed
+            layout used to partition ``t``. With context parallelism, every
+            sub-sequence length must be divisible by ``cp_size``.
+        freqs: Raw mRoPE frequencies with shape ``[3, 1, total_seqlen, rotary_dim / 2]``.
+        mrope_section: Temporal, height, and width channel sections.
+        interleaved_mrope: Use Qwen3.5-VL stride-3 T/H/W layout when True.
+        rotary_interleaved: Must be False.
+        cp_size: Context parallel world size for THD token mapping.
+        cp_rank: Context parallel rank for THD token mapping.
+        fp32_compute: Apply the rotary math in fp32 and cast directly to output dtype.
+
+    Returns:
+        Rotated tensor with the same shape and dtype as ``t``.
+    """
+    return _FusedMRoPETHD.apply(
+        t,
+        cu_seqlens,
+        freqs,
+        mrope_section,
+        interleaved_mrope,
+        rotary_interleaved,
+        cp_size,
+        cp_rank,
+        fp32_compute,
+    )
+
+
+def is_fused_mrope_available() -> bool:
+    """Return whether the Triton mRoPE fusion can be used on this host.
+
+    This does not check tensor device, dtype, stride, or CUDA capability. Use
+    ``can_launch_fused_mrope`` or ``get_fused_mrope_unavailable_reason`` with
+    tensors before dispatching to the fused kernel.
+    """
+    if not torch.cuda.is_available():
+        return False
+    return can_launch_fused_mrope()

--- a/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/model.py
+++ b/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/model.py
@@ -857,7 +857,7 @@ class Qwen3VLModel(MegatronModule):
                     .permute(2, 0, 1)
                     .contiguous()
                 )
-            elif packed_cp_index is not None:
+            elif packed_cp_index is not None and not getattr(self.config, "apply_rope_fusion", False):
                 position_ids = _select_sequence(position_ids, packed_cp_index, seq_dim=2)
             attention_mask = None
             if self.language_model is not None:

--- a/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/rope.py
+++ b/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/rope.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+import warnings
 from typing import List, Optional
 
 import torch
@@ -28,8 +29,220 @@ from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.utils import deprecate_inference_params
 from torch import Tensor
 
+from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.fused_mrope import (
+    fused_apply_mrope,
+    fused_apply_mrope_thd,
+    get_fused_mrope_thd_unavailable_reason,
+    get_fused_mrope_unavailable_reason,
+)
 from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.transformer_config import Qwen3VLTransformerConfig
 from megatron.bridge.training.utils.packed_seq_utils import get_packed_seq_q_cu_seqlens
+
+
+_ROPE_FUSION_FALLBACK_WARNINGS: set[tuple[str, str]] = set()
+
+
+def is_raw_mrope_freqs(
+    freqs: torch.Tensor | None,
+    *,
+    sequence_length: int | None = None,
+    mrope_section: list[int] | None = None,
+) -> bool:
+    """Return whether ``freqs`` uses the raw T/H/W mRoPE layout.
+
+    ``sequence_length`` disambiguates raw ``[3, B, S, D/2]`` from a legacy
+    materialized embedding whose sequence length happens to be three.
+    """
+    is_raw_shape = isinstance(freqs, torch.Tensor) and freqs.dim() == 4 and freqs.size(0) == 3
+    if not is_raw_shape:
+        return False
+    if sequence_length is not None and freqs.size(2) != sequence_length:
+        return False
+    if mrope_section is not None and len(mrope_section) == 3:
+        # Materialized split-half RoPE doubles the raw frequency width.
+        return freqs.size(-1) != 2 * sum(int(value) for value in mrope_section)
+    return True
+
+
+def materialize_mrope_freqs(
+    freqs: torch.Tensor,
+    mrope_section: list[int],
+    *,
+    interleaved_mrope: bool,
+    rotary_interleaved: bool = False,
+) -> torch.Tensor:
+    """Convert raw T/H/W frequencies to Bridge's legacy unfused layout.
+
+    Unlike the fused Qwen3.5-VL kernel, this compatibility converter accepts
+    any valid stride-three section split used by existing Qwen3-VL providers.
+    """
+    if not is_raw_mrope_freqs(freqs):
+        raise ValueError(
+            f"Raw mRoPE frequencies must have shape [3, batch, seq, rotary_dim / 2], got {tuple(freqs.shape)}"
+        )
+    if len(mrope_section) != 3:
+        raise ValueError(f"mrope_section must contain T/H/W lengths, got {mrope_section}")
+
+    sec_t, sec_h, sec_w = (int(section) for section in mrope_section)
+    half_rotary_dim = freqs.size(-1)
+    if min(sec_t, sec_h, sec_w) < 0 or sec_t + sec_h + sec_w != half_rotary_dim:
+        raise ValueError(
+            f"mrope_section {mrope_section} must be non-negative and sum to rotary_dim / 2 = {half_rotary_dim}"
+        )
+
+    if interleaved_mrope:
+        freqs_out = freqs[0].clone()
+        for axis, offset in enumerate((1, 2), start=1):
+            idx = slice(offset, mrope_section[axis] * 3, 3)
+            freqs_out[..., idx] = freqs[axis, ..., idx]
+        if rotary_interleaved:
+            batch = freqs_out.size(0)
+            emb = torch.stack(
+                (freqs_out.reshape(batch, -1, 1), freqs_out.reshape(batch, -1, 1)),
+                dim=-1,
+            ).view(batch, freqs_out.size(1), -1)
+        else:
+            emb = torch.cat((freqs_out, freqs_out), dim=-1)
+    elif rotary_interleaved:
+        batch = freqs.size(1)
+        emb = torch.stack(
+            (freqs.reshape(3, batch, -1, 1), freqs.reshape(3, batch, -1, 1)),
+            dim=-1,
+        ).view(3, batch, freqs.size(2), -1)
+        doubled_sections = list(mrope_section) * 2
+        emb = torch.cat(
+            [chunk[index % 3] for index, chunk in enumerate(emb.split(doubled_sections, dim=-1))],
+            dim=-1,
+        )
+    else:
+        freqs_out = torch.empty_like(freqs[0])
+        freqs_out[..., :sec_t] = freqs[0, ..., :sec_t]
+        freqs_out[..., sec_t : sec_t + sec_h] = freqs[1, ..., sec_t : sec_t + sec_h]
+        freqs_out[..., sec_t + sec_h :] = freqs[2, ..., sec_t + sec_h :]
+        emb = torch.cat((freqs_out, freqs_out), dim=-1)
+
+    return emb[..., None, :].transpose(0, 1).contiguous()
+
+
+def _fused_section_unavailable_reason(
+    t: torch.Tensor,
+    freqs: torch.Tensor,
+    mrope_section: list[int],
+    *,
+    interleaved_mrope: bool,
+) -> str | None:
+    if len(mrope_section) != 3:
+        return f"mrope_section must contain three values, got {mrope_section}"
+    half_rotary_dim = freqs.size(-1)
+    section = tuple(int(value) for value in mrope_section)
+    if min(section) < 0 or sum(section) != half_rotary_dim:
+        return f"mrope_section {mrope_section} must sum to rotary_dim / 2 = {half_rotary_dim}"
+    if interleaved_mrope:
+        expected = (
+            (half_rotary_dim + 2) // 3,
+            (half_rotary_dim + 1) // 3,
+            half_rotary_dim // 3,
+        )
+        if section != expected:
+            return (
+                f"stride-three interleaved mRoPE requires section {list(expected)} "
+                f"for rotary_dim / 2 = {half_rotary_dim}, got {mrope_section}"
+            )
+    if 2 * half_rotary_dim > t.size(-1):
+        return f"raw mRoPE rotary dim {2 * half_rotary_dim} exceeds input head dim {t.size(-1)}"
+    return None
+
+
+def _warn_rope_fusion_fallback(layout: str, reason: str) -> None:
+    warning_key = (layout, reason)
+    if warning_key in _ROPE_FUSION_FALLBACK_WARNINGS:
+        return
+    warnings.warn(
+        f"Qwen-VL fused mRoPE is unavailable for {layout}: {reason}. Using the unfused implementation.",
+        UserWarning,
+        stacklevel=3,
+    )
+    _ROPE_FUSION_FALLBACK_WARNINGS.add(warning_key)
+
+
+def _get_cp_rank(
+    config: Qwen3VLTransformerConfig,
+    cp_group: torch.distributed.ProcessGroup | None,
+) -> tuple[int, int]:
+    cp_size = max(int(getattr(config, "context_parallel_size", 1)), 1)
+    if cp_size == 1:
+        return 1, 0
+    if cp_group is None:
+        raise ValueError("Qwen-VL packed mRoPE with context parallelism requires a CP group.")
+    if cp_group.size() != cp_size:
+        raise ValueError(f"CP group size {cp_group.size()} does not match config size {cp_size}.")
+    return cp_size, cp_group.rank()
+
+
+def _get_thd_cp_freq_indices(
+    cu_seqlens: torch.Tensor,
+    *,
+    cp_size: int,
+    cp_rank: int,
+    device: torch.device,
+) -> torch.Tensor:
+    """Build exact packed CP indices, including odd local sequence lengths."""
+    cu_seqlens_cpu = cu_seqlens.detach().cpu().tolist()
+    indices: list[int] = []
+    for global_start, global_end in zip(cu_seqlens_cpu[:-1], cu_seqlens_cpu[1:]):
+        global_length = global_end - global_start
+        if global_length % cp_size != 0:
+            raise ValueError(
+                f"Packed sequence length {global_length} must be divisible by context parallel size {cp_size}."
+            )
+        local_length = global_length // cp_size
+        first_length = (local_length + 1) // 2
+        second_length = local_length // 2
+        indices.extend(range(global_start + cp_rank * first_length, global_start + (cp_rank + 1) * first_length))
+        indices.extend(range(global_end - (cp_rank + 1) * second_length, global_end - cp_rank * second_length))
+    return torch.tensor(indices, dtype=torch.long, device=device)
+
+
+def _apply_unfused_raw_mrope(
+    t: torch.Tensor,
+    freqs: torch.Tensor,
+    config: Qwen3VLTransformerConfig,
+    *,
+    cu_seqlens: torch.Tensor | None,
+    cp_size: int,
+    cp_rank: int,
+    freqs_are_local: bool,
+) -> torch.Tensor:
+    materialized = materialize_mrope_freqs(
+        freqs,
+        list(config.mrope_section),
+        interleaved_mrope=bool(getattr(config, "mrope_interleaved", True)),
+        rotary_interleaved=config.rotary_interleaved,
+    )
+    if cu_seqlens is not None and not freqs_are_local:
+        indices = _get_thd_cp_freq_indices(
+            cu_seqlens,
+            cp_size=cp_size,
+            cp_rank=cp_rank,
+            device=materialized.device,
+        )
+        materialized = materialized.index_select(0, indices)
+
+    orig_dtype = t.dtype
+    compute_input = t.float() if config.apply_rotary_pos_emb_in_fp32 else t
+    if cu_seqlens is None:
+        result = _apply_rotary_pos_emb_bshd(
+            compute_input,
+            materialized,
+            rotary_interleaved=config.rotary_interleaved,
+        )
+    else:
+        result = _apply_rotary_pos_emb_bshd(
+            compute_input[:, None],
+            materialized,
+            rotary_interleaved=config.rotary_interleaved,
+        ).squeeze(1)
+    return result.to(orig_dtype) if config.apply_rotary_pos_emb_in_fp32 else result
 
 
 def _get_flat_packed_ranges(
@@ -120,6 +333,7 @@ class Qwen3VLMultimodalRotaryEmbedding(nn.Module):
         seq_len_interpolation_factor: Optional[float] = None,
         rotary_base: int = 10000,
         cp_group: torch.distributed.ProcessGroup = None,
+        return_raw_freqs: bool = False,
     ) -> None:
         super().__init__()
 
@@ -134,6 +348,7 @@ class Qwen3VLMultimodalRotaryEmbedding(nn.Module):
             rotary_base ** (torch.arange(0, dim, 2, dtype=torch.float32, device=torch.cuda.current_device()) / dim)
         )
         self.is_thd_format = False  # if is thd format, we do not need to split the rotary_pos_emb along CP
+        self.return_raw_freqs = return_raw_freqs
 
         # default mrope section is [24, 20, 20], if no mrope section is provided, use default mrope section
         self.mrope_section = [24, 20, 20]
@@ -150,7 +365,7 @@ class Qwen3VLMultimodalRotaryEmbedding(nn.Module):
         returns:
             x_t: (bs, seq_len, head_dim // 2)
         """
-        freqs_t = freqs[0]  # just overwrite the first dimension T
+        freqs_t = freqs[0].clone()  # overwrite a copy of the first dimension T
         for dim, offset in enumerate((1, 2), start=1):  # H, W
             length = mrope_section[dim] * 3
             idx = slice(offset, length, 3)
@@ -188,11 +403,13 @@ class Qwen3VLMultimodalRotaryEmbedding(nn.Module):
         seq_expanded = seq[:, :, None, :].float()
         # shape (3, bs, seq_length, dim)
         freqs = (inv_freq_expanded @ seq_expanded).transpose(2, 3)
-        if mrope_section is not None:
-            freqs = self.apply_interleaved_mrope(freqs, mrope_section)
-        else:
-            # if mrope_section is not provided, use default mrope section
-            freqs = self.apply_interleaved_mrope(freqs, self.mrope_section)
+        mrope_section = self.mrope_section if mrope_section is None else mrope_section
+        if self.return_raw_freqs:
+            if self.cp_group.size() > 1 and not self.is_thd_format:
+                freqs = get_pos_emb_on_this_cp_rank(freqs, 2, self.cp_group)
+            return freqs.contiguous()
+
+        freqs = self.apply_interleaved_mrope(freqs, mrope_section)
         emb = torch.cat((freqs, freqs), dim=-1)
 
         # shape (seq_length, bs, 1, 2 * dim)
@@ -457,30 +674,119 @@ def apply_rotary_pos_emb_absolute(
     freqs: Tensor,
     config: Qwen3VLTransformerConfig,
     cu_seqlens: Optional[Tensor] = None,
-):
-    """
-    Reroute to the appropriate apply_rotary_pos_emb function depending on
-    bshd (conventional) / thd (packed seq) format
+    *,
+    cp_group: torch.distributed.ProcessGroup | None = None,
+    max_seqlen: int | None = None,
+) -> Tensor:
+    """Apply Qwen-VL absolute mRoPE in BSHD or packed THD layout.
 
-    In Qwen3-VL, the shape of freqs is (seq_length, bs, 1, 2 * dim) instead of [max_seqlen, 1, 1, 2 * dim]
+    Raw ``[3, batch, seq, rotary_dim / 2]`` frequencies use the local Triton
+    kernel when requested and supported. Legacy materialized frequencies keep
+    the existing unfused behavior.
     """
-    # Fused RoPE (TE kernels) is not supported for Qwen3-VL / Qwen3.5-VL because:
-    # 1. This function uses per-token absolute freqs with shape (seq_len, bs, 1, 2*dim),
-    #    which differs from the standard mcore format (max_seqlen, 1, 1, 2*dim).
-    #    TE's fused_apply_rotary_pos_emb / fused_apply_rotary_pos_emb_thd expect the
-    #    standard format and would produce incorrect results with absolute freqs.
-    # 2. Qwen3VLSelfAttention calls this function directly, bypassing the mcore
-    #    apply_rotary_pos_emb() dispatcher that routes to fused kernels.
-    # 3. validate_rope_fusion_compatibility() already blocks fusion for mrope models
-    #    (position_embedding_type='mrope'), so provide() resets the flag to False.
-    #    This assert is a safety net in case the flag is forced on after provide().
-    assert not config.apply_rope_fusion, (
-        "apply_rope_fusion is not supported for Qwen3-VL / Qwen3.5-VL models. "
-        "This code path uses per-token absolute positional frequencies that are incompatible "
-        "with TE's fused RoPE kernels. Setting apply_rope_fusion=True would not actually "
-        "enable fusion (Qwen3VLSelfAttention bypasses the fused dispatch), but the flag "
-        "must remain False to avoid misleading configuration state."
-    )
+    del max_seqlen  # Propagated by attention for a stable packed call contract.
+
+    section = list(config.mrope_section)
+    cp_size_hint = max(int(getattr(config, "context_parallel_size", 1)), 1)
+    raw_sequence_lengths = {t.size(0), t.size(0) * cp_size_hint} if cu_seqlens is not None else {t.size(0)}
+    if is_raw_mrope_freqs(freqs, mrope_section=section) and freqs.size(2) in raw_sequence_lengths:
+        interleaved_mrope = bool(getattr(config, "mrope_interleaved", True))
+        section_reason = _fused_section_unavailable_reason(
+            t,
+            freqs,
+            section,
+            interleaved_mrope=interleaved_mrope,
+        )
+        cp_size, cp_rank = _get_cp_rank(config, cp_group)
+
+        if cu_seqlens is None:
+            if freqs.size(1) != t.size(1) or freqs.size(2) != t.size(0):
+                raise ValueError(
+                    "BSHD raw mRoPE frequencies must match input batch and sequence dimensions: "
+                    f"input={tuple(t.shape)}, freqs={tuple(freqs.shape)}"
+                )
+            reason = section_reason
+            if config.apply_rope_fusion and reason is None:
+                reason = get_fused_mrope_unavailable_reason(t, freqs, config.rotary_interleaved)
+            if config.apply_rope_fusion and reason is None:
+                return fused_apply_mrope(
+                    t,
+                    freqs,
+                    section,
+                    interleaved_mrope=interleaved_mrope,
+                    fp32_compute=config.apply_rotary_pos_emb_in_fp32,
+                )
+            if config.apply_rope_fusion:
+                _warn_rope_fusion_fallback("BSHD", reason)
+            return _apply_unfused_raw_mrope(
+                t,
+                freqs,
+                config,
+                cu_seqlens=None,
+                cp_size=1,
+                cp_rank=0,
+                freqs_are_local=True,
+            )
+
+        if t.dim() != 3:
+            raise ValueError(f"Packed THD input must have shape [tokens, heads, head_dim], got {tuple(t.shape)}")
+        if freqs.size(1) != 1:
+            raise ValueError(f"Packed THD raw mRoPE requires frequency batch size 1, got {freqs.size(1)}")
+
+        local_tokens = t.size(0)
+        global_tokens = local_tokens * cp_size
+        if freqs.size(2) == local_tokens:
+            freqs_are_local = True
+            launch_cp_size, launch_cp_rank = 1, 0
+            if cp_size > 1:
+                if bool(torch.any((cu_seqlens[1:] - cu_seqlens[:-1]) % cp_size).item()):
+                    raise ValueError("Each packed sequence length must be divisible by context parallel size.")
+                launch_cu_seqlens = torch.div(cu_seqlens, cp_size, rounding_mode="floor")
+            else:
+                launch_cu_seqlens = cu_seqlens
+        elif freqs.size(2) == global_tokens:
+            freqs_are_local = False
+            launch_cp_size, launch_cp_rank = cp_size, cp_rank
+            launch_cu_seqlens = cu_seqlens
+        else:
+            raise ValueError(
+                "Packed THD raw mRoPE frequency sequence length must be local or global: "
+                f"input tokens={local_tokens}, CP={cp_size}, freqs={freqs.size(2)}"
+            )
+
+        reason = section_reason
+        if config.apply_rope_fusion and reason is None:
+            reason = get_fused_mrope_thd_unavailable_reason(
+                t,
+                launch_cu_seqlens,
+                freqs,
+                config.rotary_interleaved,
+                cp_size=launch_cp_size,
+                cp_rank=launch_cp_rank,
+            )
+        if config.apply_rope_fusion and reason is None:
+            return fused_apply_mrope_thd(
+                t,
+                launch_cu_seqlens,
+                freqs,
+                section,
+                interleaved_mrope=interleaved_mrope,
+                cp_size=launch_cp_size,
+                cp_rank=launch_cp_rank,
+                fp32_compute=config.apply_rotary_pos_emb_in_fp32,
+            )
+        if config.apply_rope_fusion:
+            _warn_rope_fusion_fallback("THD", reason)
+        return _apply_unfused_raw_mrope(
+            t,
+            freqs,
+            config,
+            cu_seqlens=cu_seqlens,
+            cp_size=cp_size,
+            cp_rank=cp_rank,
+            freqs_are_local=freqs_are_local,
+        )
+
     orig_t_dtype = t.dtype
     if config.apply_rotary_pos_emb_in_fp32:
         t = t.float()

--- a/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/text_model.py
+++ b/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/text_model.py
@@ -109,6 +109,7 @@ class Qwen3VLGPTModel(GPTModel):
             seq_len_interpolation_factor=seq_len_interpolation_factor,
             rotary_base=rotary_base,
             cp_group=self.pg_collection.cp,
+            return_raw_freqs=bool(self.config.apply_rope_fusion),
         )
         self.mrope_section = self.config.mrope_section
         assert self.mrope_section is not None, (

--- a/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/transformer_config.py
+++ b/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/transformer_config.py
@@ -48,6 +48,7 @@ class Qwen3VLTransformerConfig(TransformerConfig):
 
     # Multimodal rope section for [temporal, height, width] dimensions
     mrope_section: List[int] = field(default_factory=lambda: [24, 20, 20])
+    mrope_interleaved: bool = True
     apply_rope_fusion: bool = False
 
     image_token_id: int = 151655
@@ -108,10 +109,13 @@ def get_vision_model_config(hf_config, megatron_config=None):
     # defensively with the same default (``modelling_qwen3_vl/model.py:193``).
     config.deepstack_visual_indexes = deepcopy(getattr(hf_config, "deepstack_visual_indexes", []))
 
-    config.apply_rope_fusion = False
     config.gated_linear_unit = False  # no gated
     config.activation_func = partial(F.gelu, approximate="tanh")  # hidden_act
     config.kv_channels = config.hidden_size // config.num_attention_heads
+    vision_axis_section = config.kv_channels // 4
+    config.mrope_section = [0, vision_axis_section, vision_axis_section]
+    config.mrope_interleaved = False
+    config.apply_rope_fusion = bool(getattr(megatron_config, "apply_rope_fusion", False))
     config.num_query_groups = config.num_attention_heads  # no GQA
     config.layernorm_zero_centered_gamma = False  # False
     config.apply_query_key_layer_scaling = False  # factor=math.sqrt(head_dim)

--- a/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/vision_model.py
+++ b/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/vision_model.py
@@ -25,6 +25,7 @@ from megatron.core.transformer.spec_utils import ModuleSpec
 from torch import nn
 from torch.nn import functional as F
 
+from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.rope import is_raw_mrope_freqs
 from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.transformer_block import Qwen3VLVisionTransformerBlock
 from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.transformer_config import Qwen3VLTransformerConfig
 from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.utils import (
@@ -44,7 +45,8 @@ def _maybe_pad_vision_sequence_for_cuda_graph(
 
     Args:
         hidden_states: ``[seq_len, hidden_size]``.
-        rotary_pos_emb: ``[seq_len, 1, 1, dim]`` (same layout as after ``reshape``/``repeat`` in :meth:`Qwen3VLVisionModel.forward`).
+        rotary_pos_emb: Legacy ``[seq_len, 1, 1, dim]`` embeddings or raw
+            ``[3, 1, seq_len, rotary_dim / 2]`` frequencies.
         seq_len: Current sequence length (must match tensor leading size).
         max_seq_len: Target length for CUDA graph capture.
 
@@ -62,7 +64,10 @@ def _maybe_pad_vision_sequence_for_cuda_graph(
     if seq_len < max_seq_len:
         pad_len = max_seq_len - seq_len
         hidden_states = F.pad(hidden_states, (0, 0, 0, pad_len), value=0.0)
-        rotary_pos_emb = F.pad(rotary_pos_emb, (0, 0, 0, 0, 0, 0, 0, pad_len), value=0.0)
+        if is_raw_mrope_freqs(rotary_pos_emb, sequence_length=seq_len):
+            rotary_pos_emb = F.pad(rotary_pos_emb, (0, 0, 0, pad_len), value=0.0)
+        else:
+            rotary_pos_emb = F.pad(rotary_pos_emb, (0, 0, 0, 0, 0, 0, 0, pad_len), value=0.0)
         seq_len = max_seq_len
     return hidden_states, rotary_pos_emb, seq_len
 
@@ -222,6 +227,17 @@ class Qwen3VLVisionModel(VisionModule):
 
         embeddings = freq_table[pos_ids]  # lookup rotary embeddings
         embeddings = embeddings.flatten(1)
+        if self.config.apply_rope_fusion:
+            section = list(self.config.mrope_section)
+            if section[0] != 0 or section[1] + section[2] != embeddings.size(-1):
+                raise ValueError(
+                    "Vision mRoPE section must be [0, height, width] and cover the raw frequency dimension, "
+                    f"got section={section}, frequency_dim={embeddings.size(-1)}"
+                )
+            raw_freqs = embeddings.new_zeros((3, 1, total_tokens, embeddings.size(-1)))
+            raw_freqs[1, 0, :, : section[1]] = embeddings[:, : section[1]]
+            raw_freqs[2, 0, :, section[1] :] = embeddings[:, section[1] :]
+            return raw_freqs
         return embeddings
 
     def fast_pos_embed_interpolate(self, grid_thw):
@@ -332,7 +348,8 @@ class Qwen3VLVisionModel(VisionModule):
         seq_len, _ = hidden_states.size()
 
         rotary_pos_emb = self.rot_pos_emb(grid_thw)
-        rotary_pos_emb = rotary_pos_emb.reshape(seq_len, 1, 1, -1).repeat(1, 1, 1, 2)
+        if not self.config.apply_rope_fusion:
+            rotary_pos_emb = rotary_pos_emb.reshape(seq_len, 1, 1, -1).repeat(1, 1, 1, 2)
 
         # Check if we need to pad for CUDA graphs
         use_cuda_graph_padding = self._uses_vision_cuda_graph()

--- a/src/megatron/bridge/perf_recipes/qwen_vl/common.py
+++ b/src/megatron/bridge/perf_recipes/qwen_vl/common.py
@@ -72,10 +72,9 @@ def _qwen35_vl_common(cfg: ConfigContainer) -> None:
 def _qwen35_vl_post(cfg: ConfigContainer) -> None:
     """VLM post-overrides that must run after ``_benchmark_common``.
 
-    Qwen3.5-VL disables RoPE fusion and CUDA graphs for VLM variable-length
-    inputs; these override the perf defaults that ``_benchmark_common`` sets.
+    Qwen3.5-VL keeps generic benchmark RoPE fusion opt-in and disables CUDA
+    graphs for VLM variable-length inputs.
     """
-    cfg.model.apply_rope_fusion = False
     cfg.model.cuda_graph_impl = "none"
     cfg.optimizer.overlap_param_gather = False
 

--- a/tests/unit_tests/models/qwen_vl/modelling_qwen3_vl/test_attention.py
+++ b/tests/unit_tests/models/qwen_vl/modelling_qwen3_vl/test_attention.py
@@ -19,18 +19,24 @@ Run with: uv run pytest tests/unit_tests/models/qwen_vl/modelling_qwen3_vl/test_
 
 import datetime
 import os
+from types import SimpleNamespace
 
 import pytest
 import torch
 import torch.distributed as dist
 from megatron.core import parallel_state
 from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_with_transformer_engine_spec
+from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer import TransformerConfig
 from megatron.core.transformer.attention import AttnMaskType
 
-from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.attention import Qwen3VLSelfAttention
+from megatron.bridge.models.qwen_vl.modelling_qwen3_vl import attention as qwen_attention
+from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.attention import (
+    Qwen3VLSelfAttention,
+    _get_packed_rotary_metadata,
+)
 
 
 class TestQwen3VLSelfAttention:
@@ -144,6 +150,126 @@ class TestQwen3VLSelfAttention:
 
         assert actual.shape == (2, 1, 2)
         torch.testing.assert_close(actual, expected)
+
+    def test_packed_rotary_metadata_propagates_q_and_kv_max_seqlen(self):
+        """Qwen's direct rotary call receives layout-specific padded metadata."""
+        q = torch.tensor([0, 5, 12], dtype=torch.int32)
+        kv = torch.tensor([0, 7, 16], dtype=torch.int32)
+        q_padded = torch.tensor([0, 8, 16], dtype=torch.int32)
+        kv_padded = torch.tensor([0, 10, 20], dtype=torch.int32)
+        packed = PackedSeqParams(
+            qkv_format="thd",
+            cu_seqlens_q=q,
+            cu_seqlens_kv=kv,
+            cu_seqlens_q_padded=q_padded,
+            cu_seqlens_kv_padded=kv_padded,
+            max_seqlen_q=8,
+            max_seqlen_kv=10,
+        )
+
+        actual_q, actual_max_q = _get_packed_rotary_metadata(packed, for_query=True)
+        actual_kv, actual_max_kv = _get_packed_rotary_metadata(packed, for_query=False)
+
+        assert actual_q is q_padded
+        assert actual_kv is kv_padded
+        assert actual_max_q == 8
+        assert actual_max_kv == 10
+
+    def test_inference_materializes_raw_mrope_and_propagates_q_k_metadata(self, monkeypatch):
+        """Static inference materializes raw mRoPE before cache adjustment and rotary calls."""
+        sequence_length = 4
+        hidden_size = 8
+        raw_freqs = torch.randn(3, 1, sequence_length, hidden_size // 2)
+        expected_freqs = qwen_attention.materialize_mrope_freqs(
+            raw_freqs,
+            [2, 1, 1],
+            interleaved_mrope=True,
+        )
+        cu_seqlens_q = torch.tensor([0, sequence_length], dtype=torch.int32)
+        cu_seqlens_kv = torch.tensor([0, sequence_length], dtype=torch.int32)
+        packed = PackedSeqParams(
+            qkv_format="thd",
+            cu_seqlens_q_padded=cu_seqlens_q,
+            cu_seqlens_kv_padded=cu_seqlens_kv,
+            max_seqlen_q=7,
+            max_seqlen_kv=11,
+        )
+        cp_group = object()
+        rotary_calls = []
+
+        def fake_apply_rotary(tensor, freqs, config, cu_seqlens=None, *, cp_group=None, max_seqlen=None):
+            rotary_calls.append((freqs, cu_seqlens, cp_group, max_seqlen))
+            return tensor
+
+        def adjust_key_value_for_inference(
+            inference_context,
+            query,
+            key,
+            value,
+            rotary_pos_emb,
+            rotary_pos_cos,
+            rotary_pos_sin,
+            sequence_len_offset,
+        ):
+            del (
+                inference_context,
+                rotary_pos_cos,
+                rotary_pos_sin,
+                sequence_len_offset,
+            )
+            assert isinstance(rotary_pos_emb, tuple)
+            assert len(rotary_pos_emb) == 2
+            torch.testing.assert_close(rotary_pos_emb[0], expected_freqs)
+            torch.testing.assert_close(rotary_pos_emb[1], expected_freqs)
+            return query, key, value, rotary_pos_emb, AttnMaskType.causal, None
+
+        monkeypatch.setattr(qwen_attention, "apply_rotary_pos_emb_absolute", fake_apply_rotary)
+        monkeypatch.setattr(qwen_attention, "nvtx_range_push", lambda **kwargs: None)
+        monkeypatch.setattr(qwen_attention, "nvtx_range_pop", lambda **kwargs: None)
+
+        query = torch.randn(sequence_length, 1, 1, hidden_size)
+        key = torch.randn_like(query)
+        value = torch.randn_like(query)
+        attention = SimpleNamespace(
+            config=SimpleNamespace(
+                no_rope_freq=None,
+                flash_decode=False,
+                mrope_section=[2, 1, 1],
+                mrope_interleaved=True,
+                rotary_interleaved=False,
+                attention_output_gate=False,
+            ),
+            layer_number=1,
+            training=False,
+            pg_collection=SimpleNamespace(cp=cp_group),
+            get_query_key_value_tensors=lambda hidden_states, key_value_states: (query, key, value),
+            _adjust_key_value_for_inference=adjust_key_value_for_inference,
+            core_attention=lambda query, key, value, attention_mask, **kwargs: query,
+            checkpoint_core_attention=False,
+            linear_proj=lambda context: (context, None),
+        )
+        inference_context = SimpleNamespace(
+            is_dynamic_batching=lambda: False,
+            is_decode_only=lambda: False,
+            is_static_batching=lambda: True,
+        )
+
+        output, bias = Qwen3VLSelfAttention.forward(
+            attention,
+            torch.randn(sequence_length, 1, hidden_size),
+            attention_mask=None,
+            inference_context=inference_context,
+            rotary_pos_emb=raw_freqs,
+            packed_seq_params=packed,
+        )
+
+        assert output.shape == (sequence_length, 1, hidden_size)
+        assert bias is None
+        assert len(rotary_calls) == 2
+        torch.testing.assert_close(rotary_calls[0][0], expected_freqs)
+        torch.testing.assert_close(rotary_calls[1][0], expected_freqs)
+        assert rotary_calls[0][1:] == (cu_seqlens_q, cp_group, 7)
+        assert rotary_calls[1][1:] == (cu_seqlens_kv, cp_group, 11)
 
     def run_self_attention(self, pg_collection):
         tensor_model_parallel_size = torch.distributed.get_world_size(pg_collection.tp)

--- a/tests/unit_tests/models/qwen_vl/modelling_qwen3_vl/test_fused_mrope.py
+++ b/tests/unit_tests/models/qwen_vl/modelling_qwen3_vl/test_fused_mrope.py
@@ -1,0 +1,573 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Parity and dispatch tests for the Bridge-owned Qwen-VL fused mRoPE path."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from megatron.core.models.common.embeddings.rope_utils import _apply_rotary_pos_emb_bshd
+
+from megatron.bridge.models.qwen_vl.modelling_qwen3_vl import fused_mrope
+from megatron.bridge.models.qwen_vl.modelling_qwen3_vl import rope as qwen_rope
+
+
+class FakeCPGroup:
+    """Minimal process-group contract used by the rotary dispatcher."""
+
+    def __init__(self, size: int = 1, rank: int = 0) -> None:
+        self._size = size
+        self._rank = rank
+
+    def size(self) -> int:
+        """Return the fake context-parallel size."""
+        return self._size
+
+    def rank(self) -> int:
+        """Return the fake context-parallel rank."""
+        return self._rank
+
+
+@pytest.fixture(autouse=True)
+def clear_fallback_warnings():
+    """Keep warn-once state isolated between tests."""
+    qwen_rope._ROPE_FUSION_FALLBACK_WARNINGS.clear()
+    yield
+    qwen_rope._ROPE_FUSION_FALLBACK_WARNINGS.clear()
+
+
+def _config(
+    *,
+    apply_rope_fusion: bool,
+    mrope_section: list[int],
+    mrope_interleaved: bool,
+    context_parallel_size: int = 1,
+    apply_rotary_pos_emb_in_fp32: bool = False,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        apply_rope_fusion=apply_rope_fusion,
+        mrope_section=mrope_section,
+        mrope_interleaved=mrope_interleaved,
+        rotary_interleaved=False,
+        context_parallel_size=context_parallel_size,
+        apply_rotary_pos_emb_in_fp32=apply_rotary_pos_emb_in_fp32,
+    )
+
+
+def _tolerances(dtype: torch.dtype) -> dict[str, float]:
+    if dtype == torch.bfloat16:
+        return {"rtol": 2.0e-2, "atol": 5.0e-2}
+    if dtype == torch.float16:
+        return {"rtol": 3.0e-3, "atol": 1.0e-2}
+    return {"rtol": 1.0e-6, "atol": 1.0e-6}
+
+
+def _cp_indices(cu_seqlens: list[int], cp_size: int, cp_rank: int) -> list[int]:
+    indices: list[int] = []
+    for start, end in zip(cu_seqlens[:-1], cu_seqlens[1:]):
+        local_length = (end - start) // cp_size
+        first_length = (local_length + 1) // 2
+        second_length = local_length // 2
+        indices.extend(range(start + cp_rank * first_length, start + (cp_rank + 1) * first_length))
+        indices.extend(range(end - (cp_rank + 1) * second_length, end - cp_rank * second_length))
+    return indices
+
+
+@pytest.mark.parametrize(
+    "section,interleaved",
+    [
+        ([11, 11, 10], True),
+        ([10, 11, 11], False),
+        ([24, 20, 20], True),
+        ([0, 16, 16], False),
+    ],
+)
+def test_materialize_raw_mrope_matches_manual_axis_selection(section, interleaved):
+    """Raw T/H/W frequencies reproduce the established materialized layout."""
+    half_rotary_dim = sum(section)
+    freqs = torch.stack(
+        [torch.full((1, 7, half_rotary_dim), float(axis + 1), dtype=torch.float32) for axis in range(3)]
+    )
+
+    actual = qwen_rope.materialize_mrope_freqs(
+        freqs,
+        section,
+        interleaved_mrope=interleaved,
+    )
+
+    if interleaved:
+        selected = freqs[0].clone()
+        selected[..., 1 : section[1] * 3 : 3] = freqs[1, ..., 1 : section[1] * 3 : 3]
+        selected[..., 2 : section[2] * 3 : 3] = freqs[2, ..., 2 : section[2] * 3 : 3]
+    else:
+        selected = torch.cat(
+            (
+                freqs[0, ..., : section[0]],
+                freqs[1, ..., section[0] : section[0] + section[1]],
+                freqs[2, ..., section[0] + section[1] :],
+            ),
+            dim=-1,
+        )
+    expected = torch.cat((selected, selected), dim=-1)[..., None, :].transpose(0, 1).contiguous()
+    torch.testing.assert_close(actual, expected)
+
+
+def test_triton_unavailable_falls_back_without_calling_fused(monkeypatch):
+    """A no-op or mocked fused API can never silently supply the output."""
+    generator = torch.Generator().manual_seed(1234)
+    t = torch.randn(9, 2, 3, 80, dtype=torch.float32, generator=generator)
+    freqs = torch.randn(3, 2, 9, 32, dtype=torch.float32, generator=generator)
+    section = [11, 11, 10]
+    config = _config(apply_rope_fusion=True, mrope_section=section, mrope_interleaved=True)
+
+    monkeypatch.setattr(qwen_rope, "get_fused_mrope_unavailable_reason", lambda *args, **kwargs: "no Triton")
+
+    def unexpected_fused_call(*args, **kwargs):
+        raise AssertionError("fused mRoPE must not be called after an unavailable result")
+
+    monkeypatch.setattr(qwen_rope, "fused_apply_mrope", unexpected_fused_call)
+    with pytest.warns(UserWarning, match="no Triton.*Using the unfused implementation"):
+        actual = qwen_rope.apply_rotary_pos_emb_absolute(t, freqs, config)
+
+    materialized = qwen_rope.materialize_mrope_freqs(freqs, section, interleaved_mrope=True)
+    expected = _apply_rotary_pos_emb_bshd(t, materialized, rotary_interleaved=False)
+    torch.testing.assert_close(actual, expected)
+
+
+def test_unsupported_interleaved_section_falls_back_before_availability_check(monkeypatch):
+    """Legacy Qwen3-VL sections remain correct when fusion is requested."""
+    generator = torch.Generator().manual_seed(2234)
+    t = torch.randn(6, 1, 2, 128, dtype=torch.float32, generator=generator)
+    freqs = torch.randn(3, 1, 6, 64, dtype=torch.float32, generator=generator)
+    section = [24, 20, 20]
+    config = _config(apply_rope_fusion=True, mrope_section=section, mrope_interleaved=True)
+
+    def unexpected_call(*args, **kwargs):
+        raise AssertionError("unsupported section must not reach fused availability or execution")
+
+    monkeypatch.setattr(qwen_rope, "get_fused_mrope_unavailable_reason", unexpected_call)
+    monkeypatch.setattr(qwen_rope, "fused_apply_mrope", unexpected_call)
+    with pytest.warns(UserWarning, match="stride-three interleaved mRoPE.*unfused"):
+        actual = qwen_rope.apply_rotary_pos_emb_absolute(t, freqs, config)
+
+    materialized = qwen_rope.materialize_mrope_freqs(freqs, section, interleaved_mrope=True)
+    expected = _apply_rotary_pos_emb_bshd(t, materialized, rotary_interleaved=False)
+    torch.testing.assert_close(actual, expected)
+
+
+def test_bshd_dispatch_selects_fused_raw_path(monkeypatch):
+    """Bridge dispatch passes raw frequencies and FP32 intent to Triton."""
+    t = torch.zeros(5, 1, 2, 64, dtype=torch.bfloat16)
+    freqs = torch.zeros(3, 1, 5, 32, dtype=torch.float32)
+    section = [11, 11, 10]
+    config = _config(
+        apply_rope_fusion=True,
+        mrope_section=section,
+        mrope_interleaved=True,
+        apply_rotary_pos_emb_in_fp32=True,
+    )
+    calls: dict[str, object] = {}
+
+    monkeypatch.setattr(qwen_rope, "get_fused_mrope_unavailable_reason", lambda *args, **kwargs: None)
+
+    def fake_fused(tensor, raw_freqs, raw_section, **kwargs):
+        calls.update(
+            tensor=tensor,
+            freqs=raw_freqs,
+            section=raw_section,
+            kwargs=kwargs,
+        )
+        return tensor + 1
+
+    monkeypatch.setattr(qwen_rope, "fused_apply_mrope", fake_fused)
+    actual = qwen_rope.apply_rotary_pos_emb_absolute(t, freqs, config, max_seqlen=5)
+
+    torch.testing.assert_close(actual, torch.ones_like(t))
+    assert calls["tensor"] is t
+    assert calls["freqs"] is freqs
+    assert calls["section"] == section
+    assert calls["kwargs"] == {"interleaved_mrope": True, "fp32_compute": True}
+
+
+def test_materialized_sequence_length_three_is_not_misclassified_as_raw(monkeypatch):
+    """Legacy ``[S=3, B, 1, D]`` remains unambiguous against the raw axis dimension."""
+    t = torch.randn(3, 1, 2, 80, dtype=torch.float32)
+    section = [11, 11, 10]
+    freqs = torch.randn(3, 1, 3, 32, dtype=torch.float32)
+    materialized = qwen_rope.materialize_mrope_freqs(freqs, section, interleaved_mrope=True)
+    config = _config(apply_rope_fusion=True, mrope_section=section, mrope_interleaved=True)
+
+    def unexpected_fused_call(*args, **kwargs):
+        raise AssertionError("materialized frequencies must stay on the established path")
+
+    monkeypatch.setattr(qwen_rope, "fused_apply_mrope", unexpected_fused_call)
+    actual = qwen_rope.apply_rotary_pos_emb_absolute(t, materialized, config)
+    expected = _apply_rotary_pos_emb_bshd(t, materialized, rotary_interleaved=False)
+    torch.testing.assert_close(actual, expected)
+
+
+@pytest.mark.parametrize("freqs_are_local", [False, True])
+def test_thd_dispatch_propagates_cp_mapping_and_local_cu_seqlens(monkeypatch, freqs_are_local):
+    """Packed dispatch distinguishes global fusion input from pre-sharded input."""
+    cp_group = FakeCPGroup(size=2, rank=1)
+    t = torch.zeros(12, 2, 64, dtype=torch.bfloat16)
+    global_freqs = torch.zeros(3, 1, 24, 32, dtype=torch.float32)
+    freqs = global_freqs[:, :, _cp_indices([0, 10, 24], 2, 1), :].contiguous() if freqs_are_local else global_freqs
+    cu_seqlens = torch.tensor([0, 10, 24], dtype=torch.int32)
+    section = [11, 11, 10]
+    config = _config(
+        apply_rope_fusion=True,
+        mrope_section=section,
+        mrope_interleaved=True,
+        context_parallel_size=2,
+    )
+    calls: dict[str, object] = {}
+
+    monkeypatch.setattr(qwen_rope, "get_fused_mrope_thd_unavailable_reason", lambda *args, **kwargs: None)
+
+    def fake_fused(tensor, launch_cu_seqlens, raw_freqs, raw_section, **kwargs):
+        calls.update(
+            tensor=tensor,
+            cu_seqlens=launch_cu_seqlens.clone(),
+            freqs=raw_freqs,
+            section=raw_section,
+            kwargs=kwargs,
+        )
+        return tensor + 1
+
+    monkeypatch.setattr(qwen_rope, "fused_apply_mrope_thd", fake_fused)
+    actual = qwen_rope.apply_rotary_pos_emb_absolute(
+        t,
+        freqs,
+        config,
+        cu_seqlens,
+        cp_group=cp_group,
+        max_seqlen=14,
+    )
+
+    torch.testing.assert_close(actual, torch.ones_like(t))
+    expected_cu = torch.tensor([0, 5, 12], dtype=torch.int32) if freqs_are_local else cu_seqlens
+    torch.testing.assert_close(calls["cu_seqlens"], expected_cu)
+    assert calls["freqs"] is freqs
+    assert calls["section"] == section
+    assert calls["kwargs"]["cp_size"] == (1 if freqs_are_local else 2)
+    assert calls["kwargs"]["cp_rank"] == (0 if freqs_are_local else 1)
+
+
+@pytest.mark.parametrize("cp_rank", [0, 1])
+def test_thd_unfused_fallback_supports_odd_local_sequence_lengths(monkeypatch, cp_rank):
+    """Fallback uses ceil/floor CP segments for odd local packed lengths."""
+    generator = torch.Generator().manual_seed(3234)
+    cp_group = FakeCPGroup(size=2, rank=cp_rank)
+    t = torch.randn(12, 2, 80, dtype=torch.float32, generator=generator)
+    freqs = torch.randn(3, 1, 24, 32, dtype=torch.float32, generator=generator)
+    cu_seqlens = torch.tensor([0, 10, 24], dtype=torch.int32)
+    section = [11, 11, 10]
+    config = _config(
+        apply_rope_fusion=True,
+        mrope_section=section,
+        mrope_interleaved=True,
+        context_parallel_size=2,
+    )
+
+    monkeypatch.setattr(
+        qwen_rope,
+        "get_fused_mrope_thd_unavailable_reason",
+        lambda *args, **kwargs: "unsupported test layout",
+    )
+    with pytest.warns(UserWarning, match="unsupported test layout.*unfused"):
+        actual = qwen_rope.apply_rotary_pos_emb_absolute(
+            t,
+            freqs,
+            config,
+            cu_seqlens,
+            cp_group=cp_group,
+            max_seqlen=14,
+        )
+
+    materialized = qwen_rope.materialize_mrope_freqs(freqs, section, interleaved_mrope=True)
+    indices = torch.tensor(_cp_indices(cu_seqlens.tolist(), 2, cp_rank), dtype=torch.long)
+    expected = _apply_rotary_pos_emb_bshd(
+        t[:, None],
+        materialized.index_select(0, indices),
+        rotary_interleaved=False,
+    ).squeeze(1)
+    torch.testing.assert_close(actual, expected)
+
+
+def test_real_unavailable_reason_on_cpu_never_calls_fused(monkeypatch):
+    """The vendored availability API produces a safe CPU fallback."""
+    t = torch.randn(4, 1, 2, 16)
+    freqs = torch.randn(3, 1, 4, 8)
+    section = [3, 3, 2]
+    config = _config(apply_rope_fusion=True, mrope_section=section, mrope_interleaved=True)
+
+    assert fused_mrope.get_fused_mrope_unavailable_reason(t, freqs) is not None
+
+    def unexpected_fused_call(*args, **kwargs):
+        raise AssertionError("CPU fallback must not call the fused API")
+
+    monkeypatch.setattr(qwen_rope, "fused_apply_mrope", unexpected_fused_call)
+    with pytest.warns(UserWarning, match="(CUDA tensors|Triton is not available).*unfused"):
+        actual = qwen_rope.apply_rotary_pos_emb_absolute(t, freqs, config)
+
+    materialized = qwen_rope.materialize_mrope_freqs(freqs, section, interleaved_mrope=True)
+    expected = _apply_rotary_pos_emb_bshd(t, materialized, rotary_interleaved=False)
+    torch.testing.assert_close(actual, expected)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_qwen35_rotary_embedding_returns_raw_without_materializing():
+    """The language embedding keeps global raw frequencies for packed CP."""
+    section = [11, 11, 10]
+    position_ids = torch.stack(
+        (
+            torch.arange(24, device="cuda"),
+            torch.arange(24, device="cuda") * 2,
+            torch.arange(24, device="cuda") * 3,
+        )
+    )[:, None, :]
+    rotary = qwen_rope.Qwen3VLMultimodalRotaryEmbedding(
+        kv_channels=256,
+        rotary_percent=0.25,
+        rotary_base=10_000_000,
+        cp_group=FakeCPGroup(size=2),
+        return_raw_freqs=True,
+    )
+    rotary.is_thd_format = True
+
+    raw_freqs = rotary(position_ids, section)
+    rotary.return_raw_freqs = False
+    materialized = rotary(position_ids, section)
+
+    assert raw_freqs.shape == (3, 1, 24, 32)
+    assert materialized.shape == (24, 1, 1, 64)
+    converted = qwen_rope.materialize_mrope_freqs(raw_freqs, section, interleaved_mrope=True)
+    torch.testing.assert_close(converted, materialized)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(not fused_mrope.is_fused_mrope_available(), reason="Triton fused mRoPE unavailable")
+@pytest.mark.parametrize("unsupported", ["input_dtype", "freq_dtype", "head_stride"])
+def test_unsupported_cuda_inputs_fall_back_without_calling_fused(monkeypatch, unsupported):
+    """Unsupported CUDA dtype and layout cases retain the unfused result."""
+    generator = torch.Generator(device="cuda").manual_seed(3734)
+    section = [11, 11, 10]
+    if unsupported == "input_dtype":
+        t = torch.randn(8, 1, 2, 80, dtype=torch.float64, device="cuda", generator=generator)
+    elif unsupported == "head_stride":
+        t = torch.randn(8, 1, 2, 160, dtype=torch.float32, device="cuda", generator=generator)[..., ::2]
+    else:
+        t = torch.randn(8, 1, 2, 80, dtype=torch.float32, device="cuda", generator=generator)
+    freqs = torch.randn(3, 1, 8, 32, dtype=torch.float32, device="cuda", generator=generator)
+    if unsupported == "freq_dtype":
+        freqs = freqs.half()
+    config = _config(apply_rope_fusion=True, mrope_section=section, mrope_interleaved=True)
+
+    def unexpected_fused_call(*args, **kwargs):
+        raise AssertionError("unsupported inputs must not call the fused kernel")
+
+    monkeypatch.setattr(qwen_rope, "fused_apply_mrope", unexpected_fused_call)
+    with pytest.warns(UserWarning, match="unavailable.*unfused"):
+        actual = qwen_rope.apply_rotary_pos_emb_absolute(t, freqs, config)
+
+    materialized = qwen_rope.materialize_mrope_freqs(freqs, section, interleaved_mrope=True)
+    expected = _apply_rotary_pos_emb_bshd(t, materialized, rotary_interleaved=False)
+    torch.testing.assert_close(actual, expected)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(not fused_mrope.is_fused_mrope_available(), reason="Triton fused mRoPE unavailable")
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+@pytest.mark.parametrize("layout", ["bshd", "thd"])
+def test_fused_dispatch_matches_unfused_forward_backward_cuda(dtype, layout, monkeypatch):
+    """Fused and unfused Qwen3.5-VL math match for both supported layouts."""
+    generator = torch.Generator(device="cuda").manual_seed(4234)
+    section = [11, 11, 10]
+    config = _config(apply_rope_fusion=True, mrope_section=section, mrope_interleaved=True)
+    if layout == "bshd":
+        t_ref = torch.randn(
+            32,
+            1,
+            3,
+            256,
+            dtype=dtype,
+            device="cuda",
+            generator=generator,
+            requires_grad=True,
+        )
+        freqs = torch.randn(3, 1, 32, 32, dtype=torch.float32, device="cuda", generator=generator)
+        cu_seqlens = None
+    else:
+        t_ref = torch.randn(
+            32,
+            3,
+            256,
+            dtype=dtype,
+            device="cuda",
+            generator=generator,
+            requires_grad=True,
+        )
+        freqs = torch.randn(3, 1, 32, 32, dtype=torch.float32, device="cuda", generator=generator)
+        cu_seqlens = torch.tensor([0, 12, 32], dtype=torch.int32, device="cuda")
+    t_fused = t_ref.detach().clone().requires_grad_(True)
+
+    materialized = qwen_rope.materialize_mrope_freqs(freqs, section, interleaved_mrope=True)
+    if layout == "bshd":
+        expected = _apply_rotary_pos_emb_bshd(t_ref, materialized, rotary_interleaved=False)
+        fused_name = "fused_apply_mrope"
+    else:
+        expected = _apply_rotary_pos_emb_bshd(
+            t_ref[:, None],
+            materialized,
+            rotary_interleaved=False,
+        ).squeeze(1)
+        fused_name = "fused_apply_mrope_thd"
+
+    fused_calls = 0
+    original_fused = getattr(qwen_rope, fused_name)
+
+    def wrapped_fused(*args, **kwargs):
+        nonlocal fused_calls
+        fused_calls += 1
+        return original_fused(*args, **kwargs)
+
+    monkeypatch.setattr(qwen_rope, fused_name, wrapped_fused)
+    actual = qwen_rope.apply_rotary_pos_emb_absolute(
+        t_fused,
+        freqs,
+        config,
+        cu_seqlens,
+        cp_group=FakeCPGroup(),
+        max_seqlen=20 if layout == "thd" else 32,
+    )
+
+    assert fused_calls == 1
+    tolerances = _tolerances(dtype)
+    torch.testing.assert_close(actual.float(), expected.float(), **tolerances)
+    grad = torch.randn_like(expected)
+    expected.backward(grad)
+    actual.backward(grad)
+    torch.testing.assert_close(t_fused.grad.float(), t_ref.grad.float(), **tolerances)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(not fused_mrope.is_fused_mrope_available(), reason="Triton fused mRoPE unavailable")
+@pytest.mark.parametrize("cp_rank", [0, 1])
+def test_fused_thd_cp_odd_local_lengths_match_manual_reference_cuda(cp_rank, monkeypatch):
+    """The Triton THD kernel maps odd local CP halves without gaps or overlap."""
+    generator = torch.Generator(device="cuda").manual_seed(5234)
+    section = [11, 11, 10]
+    cu_seqlens = torch.tensor([0, 10, 24], dtype=torch.int32, device="cuda")
+    t_ref = torch.randn(
+        12,
+        2,
+        256,
+        dtype=torch.bfloat16,
+        device="cuda",
+        generator=generator,
+        requires_grad=True,
+    )
+    t_fused = t_ref.detach().clone().requires_grad_(True)
+    freqs = torch.randn(3, 1, 24, 32, dtype=torch.float32, device="cuda", generator=generator)
+    config = _config(
+        apply_rope_fusion=True,
+        mrope_section=section,
+        mrope_interleaved=True,
+        context_parallel_size=2,
+    )
+    materialized = qwen_rope.materialize_mrope_freqs(freqs, section, interleaved_mrope=True)
+    indices = torch.tensor(_cp_indices([0, 10, 24], 2, cp_rank), dtype=torch.long, device="cuda")
+    expected = _apply_rotary_pos_emb_bshd(
+        t_ref[:, None],
+        materialized.index_select(0, indices),
+        rotary_interleaved=False,
+    ).squeeze(1)
+    fused_calls = 0
+    original_fused = qwen_rope.fused_apply_mrope_thd
+
+    def counted_fused(*args, **kwargs):
+        nonlocal fused_calls
+        fused_calls += 1
+        return original_fused(*args, **kwargs)
+
+    monkeypatch.setattr(qwen_rope, "fused_apply_mrope_thd", counted_fused)
+    actual = qwen_rope.apply_rotary_pos_emb_absolute(
+        t_fused,
+        freqs,
+        config,
+        cu_seqlens,
+        cp_group=FakeCPGroup(size=2, rank=cp_rank),
+        max_seqlen=14,
+    )
+
+    assert fused_calls == 1
+    tolerances = _tolerances(torch.bfloat16)
+    torch.testing.assert_close(actual.float(), expected.float(), **tolerances)
+    grad = torch.randn_like(expected)
+    expected.backward(grad)
+    actual.backward(grad)
+    torch.testing.assert_close(t_fused.grad.float(), t_ref.grad.float(), **tolerances)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(not fused_mrope.is_fused_mrope_available(), reason="Triton fused mRoPE unavailable")
+def test_vision_fp32_fused_thd_matches_explicit_float_compute_cuda(monkeypatch):
+    """Vision's BF16 inputs retain the established FP32 rotary math."""
+    generator = torch.Generator(device="cuda").manual_seed(6234)
+    tokens, heads, head_dim = 24, 2, 72
+    section = [0, 16, 16]
+    cu_seqlens = torch.tensor([0, 8, 24], dtype=torch.int32, device="cuda")
+    t_ref = torch.randn(
+        tokens,
+        heads,
+        head_dim,
+        dtype=torch.bfloat16,
+        device="cuda",
+        generator=generator,
+        requires_grad=True,
+    )
+    t_fused = t_ref.detach().clone().requires_grad_(True)
+    freqs = torch.randn(3, 1, tokens, 32, dtype=torch.float32, device="cuda", generator=generator)
+    config = _config(
+        apply_rope_fusion=True,
+        mrope_section=section,
+        mrope_interleaved=False,
+        apply_rotary_pos_emb_in_fp32=True,
+    )
+
+    materialized = qwen_rope.materialize_mrope_freqs(freqs, section, interleaved_mrope=False)
+    expected = (
+        _apply_rotary_pos_emb_bshd(
+            t_ref.float()[:, None],
+            materialized,
+            rotary_interleaved=False,
+        )
+        .squeeze(1)
+        .to(t_ref.dtype)
+    )
+    fused_calls = 0
+    original_fused = qwen_rope.fused_apply_mrope_thd
+
+    def counted_fused(*args, **kwargs):
+        nonlocal fused_calls
+        fused_calls += 1
+        return original_fused(*args, **kwargs)
+
+    monkeypatch.setattr(qwen_rope, "fused_apply_mrope_thd", counted_fused)
+    actual = qwen_rope.apply_rotary_pos_emb_absolute(
+        t_fused,
+        freqs,
+        config,
+        cu_seqlens,
+        cp_group=FakeCPGroup(),
+        max_seqlen=16,
+    )
+
+    assert fused_calls == 1
+    tolerances = _tolerances(torch.bfloat16)
+    torch.testing.assert_close(actual.float(), expected.float(), **tolerances)
+    grad = torch.randn_like(expected)
+    expected.backward(grad)
+    actual.backward(grad)
+    torch.testing.assert_close(t_fused.grad.float(), t_ref.grad.float(), **tolerances)

--- a/tests/unit_tests/models/qwen_vl/modelling_qwen3_vl/test_qwen3_vl_transformer_config.py
+++ b/tests/unit_tests/models/qwen_vl/modelling_qwen3_vl/test_qwen3_vl_transformer_config.py
@@ -152,3 +152,12 @@ class TestGetVisionModelConfigVisionCudaGraph:
         )
         with pytest.raises(KeyError):
             get_vision_model_config(_hf_config(), megatron)
+
+    def test_rope_fusion_propagates_with_vision_axis_sections(self):
+        """Vision maps row/column frequencies into raw sectioned mRoPE."""
+        cfg = get_vision_model_config(_hf_config(), _megatron_base(apply_rope_fusion=True))
+
+        assert cfg.apply_rope_fusion is True
+        assert cfg.mrope_section == [0, 4, 4]
+        assert cfg.mrope_interleaved is False
+        assert cfg.apply_rotary_pos_emb_in_fp32 is True

--- a/tests/unit_tests/models/qwen_vl/modelling_qwen3_vl/test_vision_model.py
+++ b/tests/unit_tests/models/qwen_vl/modelling_qwen3_vl/test_vision_model.py
@@ -18,6 +18,7 @@ import pytest
 import torch
 import torch.nn as nn
 
+from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.rope import materialize_mrope_freqs
 from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.transformer_config import Qwen3VLTransformerConfig
 from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.vision_model import (
     Qwen3VLVisionModel,
@@ -90,6 +91,23 @@ class TestMaybePadVisionSequenceForCudaGraph:
         rotary_pos_emb = torch.randn(seq_len, 1, 1, 4)
         with pytest.raises(ValueError, match="exceeds max_vision_cuda_graph_seq_length"):
             _maybe_pad_vision_sequence_for_cuda_graph(hidden_states, rotary_pos_emb, seq_len, max_seq_len)
+
+    def test_raw_mrope_padding_preserves_axis_layout(self):
+        seq_len, max_seq_len, hidden, half_rotary_dim = 3, 8, 4, 6
+        hidden_states = torch.ones(seq_len, hidden)
+        raw_freqs = torch.ones(3, 1, seq_len, half_rotary_dim)
+
+        _, padded_freqs, out_len = _maybe_pad_vision_sequence_for_cuda_graph(
+            hidden_states,
+            raw_freqs,
+            seq_len,
+            max_seq_len,
+        )
+
+        assert out_len == max_seq_len
+        assert padded_freqs.shape == (3, 1, max_seq_len, half_rotary_dim)
+        torch.testing.assert_close(padded_freqs[:, :, :seq_len], raw_freqs)
+        assert torch.count_nonzero(padded_freqs[:, :, seq_len:]) == 0
 
 
 class TestVisionForwardPackedAttentionSetup:
@@ -201,3 +219,33 @@ class TestQwen3VLVisionModelCudaGraphHelpers:
         m = _vision_model_shell(cfg)
         m.train()
         assert m._uses_vision_cuda_graph() is False
+
+    def test_rot_pos_emb_raw_layout_materializes_to_legacy_vision_rope(self):
+        """The fused vision path preserves the original row/column frequency math."""
+        cfg = _minimal_vision_config(
+            apply_rope_fusion=True,
+            mrope_section=[0, 4, 4],
+            mrope_interleaved=False,
+        )
+        model = _vision_model_shell(cfg)
+        model.spatial_merge_size = 2
+
+        def fake_rotary_embedding(max_hw):
+            positions = torch.arange(max_hw, dtype=torch.float32)[:, None]
+            dims = torch.arange(4, dtype=torch.float32)[None, :]
+            return positions + dims / 10
+
+        model.rotary_pos_emb = fake_rotary_embedding
+        grid_thw = torch.tensor([[1, 4, 4]], dtype=torch.long)
+
+        raw_freqs = model.rot_pos_emb(grid_thw)
+        materialized = materialize_mrope_freqs(
+            raw_freqs,
+            [0, 4, 4],
+            interleaved_mrope=False,
+        )
+
+        cfg.apply_rope_fusion = False
+        legacy = model.rot_pos_emb(grid_thw).reshape(16, 1, 1, -1).repeat(1, 1, 1, 2)
+        assert raw_freqs.shape == (3, 1, 16, 8)
+        torch.testing.assert_close(materialized, legacy)

--- a/tests/unit_tests/models/qwen_vl/test_qwen35_vl_provider.py
+++ b/tests/unit_tests/models/qwen_vl/test_qwen35_vl_provider.py
@@ -20,6 +20,7 @@ from megatron.core.transformer.attention import SelfAttention
 from megatron.core.transformer.spec_utils import ModuleSpec
 
 from megatron.bridge.models.gpt_provider import GPTModelProvider
+from megatron.bridge.models.qwen_vl import qwen35_vl_provider as provider_module
 from megatron.bridge.models.qwen_vl.qwen35_vl_provider import (
     _TRANSFORMERS_HAS_QWEN3_5,
     _TRANSFORMERS_HAS_QWEN3_5_MOE,
@@ -83,6 +84,31 @@ class TestQwen35VLModelProvider:
         assert provider.vision_end_token_id == 248054
         assert provider.bos_token_id == 248045
         assert provider.eos_token_id == 248044
+        assert provider.apply_rope_fusion is False
+
+    def test_direct_vlm_provider_preserves_explicit_rope_fusion(self, monkeypatch):
+        """The VLM provider bypass keeps Bridge-owned mRoPE fusion enabled."""
+        provider = Qwen35VLModelProvider(
+            num_layers=4,
+            hidden_size=512,
+            num_attention_heads=2,
+            apply_rope_fusion=True,
+        )
+        monkeypatch.setattr(provider, "build_language_spec", lambda **kwargs: object())
+        monkeypatch.setattr(provider, "build_mtp_spec", lambda **kwargs: None)
+        captured = {}
+
+        def fake_model(**kwargs):
+            captured.update(kwargs)
+            return object()
+
+        monkeypatch.setattr(provider_module, "Qwen3VLModel", fake_model)
+        model = provider.provide(pre_process=True, post_process=True)
+
+        assert model is not None
+        assert provider.apply_rope_fusion is True
+        assert captured["language_transformer_config"] is provider
+        assert captured["language_transformer_config"].apply_rope_fusion is True
 
     def test_common_llm_defaults(self):
         provider = Qwen35VLModelProvider(

--- a/tests/unit_tests/recipes/qwen_vl/test_qwen35_vl_recipes.py
+++ b/tests/unit_tests/recipes/qwen_vl/test_qwen35_vl_recipes.py
@@ -27,6 +27,7 @@ from typing import Callable
 import pytest
 import torch
 
+from megatron.bridge.perf_recipes.qwen_vl.common import _qwen35_vl_post
 from tests.unit_tests.recipes.recipe_test_utils import patch_recipe_module_global
 
 
@@ -231,6 +232,23 @@ def test_qwen35_vl_h100_module_has_no_parameterized_recipe_helpers():
     assert not hasattr(_qwen35_vl_h100_module, "_qwen35_vl_apply_common")
     assert not hasattr(_qwen35_vl_h100_module, "_qwen35_vl_apply_moe")
     assert not hasattr(_qwen35_vl_h100_module, "_qwen35_vl_enable_recompute")
+
+
+def test_qwen35_perf_post_keeps_generic_rope_fusion_enabled():
+    """Performance recipes no longer undo the benchmark fusion request."""
+    cfg = type(
+        "Cfg",
+        (),
+        {
+            "model": type("Model", (), {"apply_rope_fusion": True, "cuda_graph_impl": "local"})(),
+            "optimizer": type("Optimizer", (), {"overlap_param_gather": True})(),
+        },
+    )()
+
+    _qwen35_vl_post(cfg)
+
+    assert cfg.model.apply_rope_fusion is True
+    assert cfg.model.cuda_graph_impl == "none"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- vendor the upstream NVIDIA/Megatron-LM fused multimodal RoPE Triton kernel from [PR #5962](https://github.com/NVIDIA/Megatron-LM/pull/5962) (merge `9304a25642`, source blob `5ed245de1c32f03efecb543225f337389e845f07`)
- wire Bridge-owned Qwen3.5-VL language and vision paths to consume raw T/H/W frequencies and dispatch fused BSHD or packed THD forward/backward without pre-materializing the legacy embedding
- preserve the unfused implementation for disabled fusion, unavailable Triton, unsupported dtype/layout/section configurations, and the existing inference contract
- propagate padded query/key cu-seqlens, max sequence lengths, and the CP process group; preserve FP32 vision rotary compute and exact CP position mapping
- keep provider behavior backward compatible and stop Qwen3.5 performance recipes from overriding the explicit fusion opt-in

## Validation

Primary environment: `nvcr.io/nvidian/nemo:26.08.rc3` (`sha256:fe246df13b0b51fa9b16fb28ebde2bcc0f8f6fa16ea81e16196350f8b5d1ba61`), pinned Megatron-Core `cd4afffa648426a959dc7cb1e24b5ce7d0c3ff54`.

- focused fused/call-site/config/provider/recipe matrix: **195 passed**
- adjacent Qwen-VL, VLM-step, packed-sequence, and in-batch packing matrix: **297 passed, 9 skipped** (pre-existing environment gates)
- all-files pre-commit: **passed**
- `git diff --check`: **passed**
- independent complete-diff review: **no remaining actionable findings** after adding non-vacuous fused-call assertions and an attention-forward inference/metadata regression

CUDA tests cover FP16/BF16/FP32 BSHD and THD forward/backward parity, raw axis and interleaved section semantics, vision FP32 compute, fallback behavior, actual Triton call counts, and synthetic kernel-level odd-local CP indexing.

### H100 training evidence

Public candidate source was exercised in four sequential 10-step packed-THD jobs on two H100 80GB GPUs (job `14524438`), with identical source/data/seed/topology within each fused/unfused pair:

| Bounded real provider | Fusion | Final LM loss | Grad norm | Fused THD calls/rank |
|---|---:|---:|---:|---:|
| Qwen3.5-VL dense, four full-width layers, CP2 | off | 8.895203 | 9.559 | 0 |
| Qwen3.5-VL dense, four full-width layers, CP2 | on | 8.896544 | 9.594 | 4,176 |
| Qwen3.5-VL MoE, four full-width layers, EP2 | off | 8.508253 | 4.227 | 0 |
| Qwen3.5-VL MoE, four full-width layers, EP2 | on | 8.508933 | 4.218 | 2,088 |

All cases completed with finite validation/test losses and zero skipped or NaN iterations. Dense final loss differed by 0.015%; MoE differed by 0.008%.

### Synthetic fixed-shape full-model end-to-end H100 A/B

Job `14610816` ran the full 40-layer Qwen3.5-VL 35B-A3B BF16 model on 16 H100 80GB GPUs across two nodes. It used TP1/PP2/no-VPP/EP8, sequence length 4096, global batch 512, microbatch 1, unfrozen language and vision models, and fresh processes in counterbalanced off/on/on/off order. Every repeat discarded five warmup steps—including the approximately 316-second first-use compile—and measured 15 synchronized slowest-rank complete forward/backward/optimizer steps.

This run used the performance recipe's `MockVLMSFTDatasetConfig`, not a real dataset. Every synthetic example contained one generated 256×256 image, the fixed prompt `Describe this image.`, and padding to sequence length 4096. The result therefore isolates full-model compute and optimization at a fixed synthetic shape; it does not measure real-data loading or variation in image resolution, text length, packing, or multimodal composition. The real-MedPix follow-up requested during review is reported separately below.

The repository performance recipe required benchmark-only compatibility corrections shared by every A/B condition: VP12 is invalid for 40 layers at PP2; the Qwen3.5-VL wrapper lacks the schedule-plan API required by interleaved 1F1B; and the VPP-dependent EP A2A, delayed-wgrad, and optimizer-step parameter-gather overlaps were disabled. Precision-aware distributed Adam used BF16 moment tensors to fit the full model on 80GB GPUs. Model compute, source, seed, data, topology, precision, and all other settings were identical; only `apply_rope_fusion` changed.

| Run | Fusion | Mean step | Median | p05–p95 | Configured tokens/s | Peak allocated |
|---|---:|---:|---:|---:|---:|---:|
| `off_a` | off | 23.8358 s | 23.7815 s | 23.5275–24.1884 s | 87,983 | 58.8890 GiB |
| `on_a` | on | 22.4129 s | 22.3977 s | 22.2883–22.6096 s | 93,569 | 58.8266 GiB |
| `on_b` | on | 22.9126 s | 22.7359 s | 22.3492–23.8379 s | 91,528 | 58.8266 GiB |
| `off_b` | off | 23.8046 s | 23.7762 s | 23.4861–24.2176 s | 88,099 | 58.8890 GiB |
| **Pooled off (30 steps)** | off | **23.8202 s** | **23.7789 s** | **23.5275–24.1884 s** | **88,041** | **58.8890 GiB** |
| **Pooled on (30 steps)** | on | **22.6628 s** | **22.4703 s** | **22.3182–23.7906 s** | **92,537** | **58.8266 GiB** |

The pooled result is **1.0511x end-to-end speed**, **4.86% lower step time**, and **5.11% higher configured throughput**. Repeat-wise step-time reductions were 5.97% and 3.75%; corresponding throughput gains were 6.35% and 3.89%. Fusion reduced peak allocated memory by 63.9 MiB and peak reserved memory by 46.0 MiB.

All four 20-step runs completed with finite losses and zero skipped/nonfinite rank-steps. Controls recorded zero fused calls on every rank. Each fused repeat recorded 225,280 BSHD and 552,960 packed-THD calls across the 16 ranks. The exact signed PR source archive was `4049ee7b24c0eee598cd1738c5114330241f44df4f234ac15921408181b3f848`; the complete job log SHA-256 is `5ba75c7f4bcd7794c8b5d9b1b33343a53d882b0f3d162c0e5f165722fb808f06`.

### Real-MedPix full-model end-to-end H100 A/B

Job `14720921` reran the full 40-layer Qwen3.5-VL 35B-A3B BF16 model on 16 H100 80GB GPUs with the real `mmoukouba/MedPix-VQA` training split (17,420 image/question/answer rows), the Qwen3.5-VL processor, and `DirectHFSFTDatasetConfig`. The model used random-initialized weights because this is a performance comparison, not an accuracy result. The job used fresh processes in counterbalanced off/on/on/off order; each repeat excluded five complete warmup steps and measured 25 synchronized slowest-rank complete data-fetch/forward/backward/optimizer steps. This yields **50 measured steps per fusion condition**.

One-time dataset materialization and model/graph initialization were excluded, while per-step data fetching, collation, processor output consumption, vision/language forward, backward, and optimizer work were included. The PP2/EP8 training path pads the language sequence to the configured length 4096, so step time and samples/s are the primary end-to-end metrics rather than a claim about unpadded useful-token throughput. Real MedPix images and question/answer examples still exercised the direct-HF multimodal data and vision path.

The seed, full train split, model, source archive, TP1/PP2/no-VPP/EP8 topology, sequence length 4096, global batch 512, microbatch 1, BF16 precision, unfrozen language/vision models, BF16 Adam moments, and the same benchmark compatibility corrections were fixed. Only `apply_rope_fusion` changed.

| Run | Fusion | Mean step | Median | p05–p95 | Samples/s | Peak allocated |
|---|---:|---:|---:|---:|---:|---:|
| `off_a` | off | 24.2837 s | 24.2566 s | 24.0209–24.5509 s | 21.0841 | 60.6917 GiB |
| `on_a` | on | 23.8137 s | 23.7906 s | 23.6571–24.0899 s | 21.5003 | 60.5735 GiB |
| `on_b` | on | 23.7159 s | 23.7099 s | 23.4281–24.0060 s | 21.5889 | 60.5735 GiB |
| `off_b` | off | 23.7251 s | 23.6938 s | 23.4888–24.0597 s | 21.5805 | 60.6917 GiB |
| **Pooled off (50 steps)** | off | **24.0044 s** | **24.0403 s** | **23.4924–24.4915 s** | **21.3294** | **60.6917 GiB** |
| **Pooled on (50 steps)** | on | **23.7648 s** | **23.7649 s** | **23.4407–24.0899 s** | **21.5445** | **60.5735 GiB** |

The pooled real-data point estimate is **1.0101x end-to-end speed**, **0.998% lower step time**, and **1.008% higher samples/s**. The paired repeat reductions were 1.936% (`a`) and 0.039% (`b`), exposing run-order drift on the same scale as the effect; this should be interpreted as an approximately 1% point estimate for this topology, not as evidence that the isolated 2.45x operator speedup transfers directly to full-model training. Fusion reduced peak allocated memory by 121.0 MiB and peak reserved memory by 68.0 MiB.

All four cases completed `0:0` with finite losses and zero skipped/nonfinite rank-steps. Controls recorded zero fused calls on every rank. Each fused repeat recorded 337,920 BSHD and 829,440 packed-THD calls across the 16 ranks, with a nonzero fused counter on every rank. The exact PR-head source archive (`7065e06a4bf0d6df3e6295ee513aff25e4cf825e`) SHA-256 is `6941054d40cc472ba0a52513e3b62d629c52b8670b3863938477231fed570aaf`; the complete job log SHA-256 is `96d1115772ed644178941cdd6efb4e2631412f8b9fb6fc26f5c07402b630bb03`.

### MedPix loss-trajectory caveat

The real-MedPix run above is performance evidence, **not numerical-parity or convergence evidence**. A per-step audit found a reproducible fusion-dependent event at training iteration 7: the two fused repeats reported LM loss `15.1010` and `15.0322` with gradient norms `140.744` and `141.475`, while the two unfused repeats reported LM loss `10.4861` and `10.4623` with gradient norms `29.705` and `25.025`. The fused-versus-unfused LM-loss RMSE was `0.8824` and `0.9052` for the two paired runs, dominated by that iteration. All curves remained finite and decreased overall, but that health check is not sufficient to claim matching loss trajectories.

The benchmark is not a fixed-state comparison: it starts from random weights, the five timing warmups are real optimizer updates, Adam moments are BF16, the performance recipe forces random MoE router logits, and the selected Transformer Engine fused cross-entropy path emits known-stability warnings. Same-condition replicas also diverge later, so the existing log cannot attribute the iteration-7 difference uniquely to mRoPE. Independent re-review found no concrete axis, section, THD/CP mapping, backward, or dtype defect, but recommends a fixed-state real-MedPix crossover with identical batch/RNG state and no optimizer update, comparing post-RoPE Q/K, logits, native FP32 CE, and gradients. Until that replay is complete, the MedPix run must not be treated as correctness-parity evidence; the focused operator tests and bounded-provider training results remain the separate numerical evidence.

### Controlled H100 rotary-operator A/B

Job `14523680` used identical BF16 tensors, 24 heads, head dimension 256, 30 warmups, and 100 measured forward/backward iterations per condition on one H100 80GB. Instrumentation recorded 130 fused calls when enabled and zero when disabled.

| Layout | Fusion off | Fusion on | Change | Peak allocation |
|---|---:|---:|---:|---:|
| BSHD | 1.003 ms / 8.17M tok/s | 0.409 ms / 20.02M tok/s | 2.45x | 408 MiB → 288 MiB |
| packed THD, CP2 mapping | 0.543 ms / 7.54M tok/s | 0.266 ms / 15.41M tok/s | 2.04x | 204 MiB → 144 MiB |

These are isolated rotary forward/backward measurements, not full-model iteration-speed claims. The separately measured full-model point estimates are 1.0511x for the fixed-shape mock workload and 1.0101x for the 50-step-per-condition real-MedPix workload.

## Residual scope

- The 1.0511x full-model result uses fixed-shape synthetic samples. The separate 1.0101x point estimate uses real MedPix images/questions/answers and includes the per-step data path, but uses random-initialized weights, excludes one-time dataset materialization, and pads language compute to sequence length 4096 under PP2/EP8.
- The real-MedPix paired repeat reductions were 1.936% and 0.039%; additional randomized repetitions would be required to distinguish a stable approximately 1% gain from run-order drift more precisely.
- Full-model performance evidence uses the benchmark-only no-VPP/disabled-overlap/BF16-moment corrections described above; it should not be extrapolated unchanged to alternate interleaved, overlap, optimizer-state, or parallelism topologies.
- The dedicated packed CP2 and EP2 training evidence uses four real-width layers. The full 40-layer end-to-end benchmark separately exercises multi-node TP1/PP2/EP8 and both fused BSHD and THD paths.
- Odd-local CP mapping is validated directly at the kernel boundary; the pinned MCore/Transformer Engine production partitioner currently requires packed document lengths divisible by `2 * CP`, so that synthetic layout cannot reach the model call site.
- Full Qwen3-VL inference remains rejected by the model's pre-existing assertion. The new attention-level inference materialization branch is directly regression-tested, but full VLM inference is outside this change.
