### PR TITLE
perf(diffusion): use shared segment-tree first-fit for sequence packing

### DIFF
--- a/src/megatron/bridge/data/packing/algorithms.py
+++ b/src/megatron/bridge/data/packing/algorithms.py
@@ -16,7 +16,7 @@
 
 import collections
 import logging
-from typing import Dict, List, Tuple
+from typing import Dict, List, Sequence, Tuple, TypeVar
 
 import numpy as np
 from tqdm import tqdm
@@ -27,6 +27,8 @@ from megatron.bridge.utils.safe_pickle import safe_load_npy
 PACKING_ALGOS = ["first_fit_decreasing", "first_fit_shuffle"]
 
 logger = logging.getLogger(__name__)
+
+_ItemT = TypeVar("_ItemT")
 
 
 class _SegmentTree:
@@ -66,6 +68,57 @@ class _SegmentTree:
         return self._query(1, 0, self._n - 1, need)
 
 
+def first_fit_by_length(items: Sequence[_ItemT], item_lengths: Sequence[int], pack_size: int) -> list[list[_ItemT]]:
+    """
+    Packs arbitrary items into bins using First-Fit, driven by precomputed lengths.
+
+    A segment-tree index over per-bin remaining capacity makes each placement O(log N)
+    instead of a scan over every open bin, giving O(N log N) overall.
+
+    This is the shared core behind :func:`first_fit`. Callers that pack objects rather
+    than raw integers (for example diffusion samples keyed on padded query sequence
+    length) pass the lengths separately and get their original objects back in the bins.
+
+    Args:
+      items: The objects to pack, in the order they should be considered.
+      item_lengths: Length of each entry in `items`, in the same order.
+      pack_size: The maximum capacity of each bin.
+
+    Returns:
+      A list of lists, where each inner list represents a bin and contains the
+        items assigned to that bin.
+
+    Raises:
+      ValueError: If `items` and `item_lengths` do not have the same number of entries.
+    """
+    if len(items) != len(item_lengths):
+        raise ValueError(
+            f"items and item_lengths must have the same number of entries, got {len(items)} and {len(item_lengths)}"
+        )
+    if not items:
+        return []
+
+    n = len(items)
+    tree = _SegmentTree(n)
+    res: list[list[_ItemT]] = []
+    remaining: list[int] = []
+
+    for item, length in zip(items, item_lengths):
+        first_bin = tree.query_first_fit(length)
+        # An unopened bin still reads as 0 remaining capacity, so a zero-length item can
+        # match an index past the end of `res`; that case must open a bin, not index it.
+        if first_bin == -1 or first_bin >= len(res):
+            new_idx = len(res)
+            res.append([item])
+            remaining.append(pack_size - length)
+            tree.update(new_idx, remaining[new_idx])
+        else:
+            res[first_bin].append(item)
+            remaining[first_bin] -= length
+            tree.update(first_bin, remaining[first_bin])
+    return res
+
+
 def first_fit(seqlens: List[int], pack_size: int) -> List[List[int]]:
     """
     Packs sequences of varying lengths into bins using the First-Fit algorithm
@@ -79,26 +132,8 @@ def first_fit(seqlens: List[int], pack_size: int) -> List[List[int]]:
       A list of lists, where each inner list represents a bin and contains the
         lengths of the sequences assigned to that bin.
     """
-    if not seqlens:
-        return []
-
-    n = len(seqlens)
-    tree = _SegmentTree(n)
-    res = []
-    remaining = []
-
-    for s in seqlens:
-        first_bin = tree.query_first_fit(s)
-        if first_bin == -1 or first_bin >= len(res):
-            new_idx = len(res)
-            res.append([s])
-            remaining.append(pack_size - s)
-            tree.update(new_idx, remaining[new_idx])
-        else:
-            res[first_bin].append(s)
-            remaining[first_bin] -= s
-            tree.update(first_bin, remaining[first_bin])
-    return res
+    # The items being packed are themselves the lengths.
+    return first_fit_by_length(seqlens, seqlens, pack_size)
 
 
 def first_fit_decreasing(seqlens: List[int], pack_size: int) -> List[List[int]]:

--- a/src/megatron/bridge/data/packing/algorithms.py
+++ b/src/megatron/bridge/data/packing/algorithms.py
@@ -68,42 +68,54 @@ class _SegmentTree:
         return self._query(1, 0, self._n - 1, need)
 
 
-def first_fit_by_length(items: Sequence[_ItemT], item_lengths: Sequence[int], pack_size: int) -> list[list[_ItemT]]:
+def first_fit(
+    seqlens: Sequence[_ItemT],
+    pack_size: int,
+    *,
+    item_lengths: Sequence[int] | None = None,
+) -> list[list[_ItemT]]:
     """
-    Packs arbitrary items into bins using First-Fit, driven by precomputed lengths.
+    Packs sequences of varying lengths into bins using the First-Fit algorithm
+    with a segment-tree index for O(N log N) performance.
 
     A segment-tree index over per-bin remaining capacity makes each placement O(log N)
-    instead of a scan over every open bin, giving O(N log N) overall.
+    instead of a scan over every open bin.
 
-    This is the shared core behind :func:`first_fit`. Callers that pack objects rather
-    than raw integers (for example diffusion samples keyed on padded query sequence
-    length) pass the lengths separately and get their original objects back in the bins.
+    By default the entries of `seqlens` are themselves the lengths. Callers that pack
+    objects rather than raw integers (for example diffusion samples keyed on padded
+    query sequence length) pass `item_lengths` separately and get their original
+    objects back in the bins.
 
     Args:
-      items: The objects to pack, in the order they should be considered.
-      item_lengths: Length of each entry in `items`, in the same order.
+      seqlens: The entries to pack, in the order they should be considered. Integer
+        lengths unless `item_lengths` is given, in which case these may be any objects.
       pack_size: The maximum capacity of each bin.
+      item_lengths: Optional length of each entry in `seqlens`, in the same order. When
+        omitted, each entry is used as its own length.
 
     Returns:
       A list of lists, where each inner list represents a bin and contains the
-        items assigned to that bin.
+        entries assigned to that bin.
 
     Raises:
-      ValueError: If `items` and `item_lengths` do not have the same number of entries.
+      ValueError: If `item_lengths` is given and does not have the same number of
+        entries as `seqlens`.
     """
-    if len(items) != len(item_lengths):
+    lengths: Sequence[int] = seqlens if item_lengths is None else item_lengths  # type: ignore[assignment]
+    if item_lengths is not None and len(seqlens) != len(item_lengths):
         raise ValueError(
-            f"items and item_lengths must have the same number of entries, got {len(items)} and {len(item_lengths)}"
+            f"seqlens and item_lengths must have the same number of entries, "
+            f"got {len(seqlens)} and {len(item_lengths)}"
         )
-    if not items:
+    if not seqlens:
         return []
 
-    n = len(items)
+    n = len(seqlens)
     tree = _SegmentTree(n)
     res: list[list[_ItemT]] = []
     remaining: list[int] = []
 
-    for item, length in zip(items, item_lengths):
+    for item, length in zip(seqlens, lengths):
         first_bin = tree.query_first_fit(length)
         # An unopened bin still reads as 0 remaining capacity, so a zero-length item can
         # match an index past the end of `res`; that case must open a bin, not index it.
@@ -117,23 +129,6 @@ def first_fit_by_length(items: Sequence[_ItemT], item_lengths: Sequence[int], pa
             remaining[first_bin] -= length
             tree.update(first_bin, remaining[first_bin])
     return res
-
-
-def first_fit(seqlens: List[int], pack_size: int) -> List[List[int]]:
-    """
-    Packs sequences of varying lengths into bins using the First-Fit algorithm
-    with a segment-tree index for O(N log N) performance.
-
-    Args:
-      seqlens: A list of integers, representing the lengths of the sequences to be packed.
-      pack_size: The maximum capacity of each bin.
-
-    Returns:
-      A list of lists, where each inner list represents a bin and contains the
-        lengths of the sequences assigned to that bin.
-    """
-    # The items being packed are themselves the lengths.
-    return first_fit_by_length(seqlens, seqlens, pack_size)
 
 
 def first_fit_decreasing(seqlens: List[int], pack_size: int) -> List[List[int]]:

--- a/src/megatron/bridge/diffusion/data/common/sequence_packing_utils.py
+++ b/src/megatron/bridge/diffusion/data/common/sequence_packing_utils.py
@@ -13,7 +13,28 @@
 # limitations under the License.
 
 
-from typing import List
+from typing import Any, List
+
+from megatron.bridge.data.packing.algorithms import first_fit_by_length
+
+
+def packing_length(item: Any) -> int:
+    """
+    Returns the bin-packing length of an item.
+
+    Items are either plain sequence lengths or objects that report their length by
+    adding with an int -- `DiffusionSample` does this, returning its padded query
+    sequence length when one is set and its unpadded length otherwise. Going through
+    `0 + item` keeps this module free of a hard dependency on the sample type, and
+    matches the length the previous `sum(bin) + s` capacity check used.
+
+    Args:
+      item: A sequence length, or an object implementing `__radd__` against an int.
+
+    Returns:
+      The integer length used for bin-packing capacity accounting.
+    """
+    return 0 + item
 
 
 def find_first_bin_that_fits(bins: List[List[int]], s: int, bin_size: int) -> int:
@@ -38,22 +59,22 @@ def first_fit(seqlens: List[int], pack_size: int) -> List[List[int]]:
     """
     Packs sequences of varying lengths into bins using the First-Fit algorithm.
 
+    Delegates to the shared segment-tree implementation in
+    `megatron.bridge.data.packing.algorithms`, which places each item in O(log N)
+    rather than rescanning and re-summing every open bin. Bin assignments are
+    identical to the previous linear-scan implementation.
+
     Args:
-      seqlens: A list of integers, representing the lengths of the sequences to be packed.
+      seqlens: The sequences to pack. Entries are either integer lengths or objects
+        that report their length when added to an int (see `packing_length`); the
+        original entries are what end up in the returned bins.
       pack_size: The maximum capacity of each bin.
 
     Returns:
-      A list of lists, where each inner list represents a bin and contains the indices
-        of the sequences assigned to that bin.
+      A list of lists, where each inner list represents a bin and contains the
+        entries assigned to that bin.
     """
-    res = []
-    for s in seqlens:
-        first_bin = find_first_bin_that_fits(res, s, pack_size)
-        if first_bin == -1:  # open a new bin
-            res.append([s])
-        else:
-            res[first_bin].append(s)
-    return res
+    return first_fit_by_length(seqlens, [packing_length(item) for item in seqlens], pack_size)
 
 
 def first_fit_decreasing(seqlens: List[int], pack_size: int) -> List[List[int]]:

--- a/src/megatron/bridge/diffusion/data/common/sequence_packing_utils.py
+++ b/src/megatron/bridge/diffusion/data/common/sequence_packing_utils.py
@@ -15,7 +15,7 @@
 
 from typing import Any, List
 
-from megatron.bridge.data.packing.algorithms import first_fit_by_length
+from megatron.bridge.data.packing.algorithms import first_fit as _shared_first_fit
 
 
 def packing_length(item: Any) -> int:
@@ -74,7 +74,7 @@ def first_fit(seqlens: List[int], pack_size: int) -> List[List[int]]:
       A list of lists, where each inner list represents a bin and contains the
         entries assigned to that bin.
     """
-    return first_fit_by_length(seqlens, [packing_length(item) for item in seqlens], pack_size)
+    return _shared_first_fit(seqlens, pack_size, item_lengths=[packing_length(item) for item in seqlens])
 
 
 def first_fit_decreasing(seqlens: List[int], pack_size: int) -> List[List[int]]:

--- a/tests/unit_tests/data/packing/test_algorithms.py
+++ b/tests/unit_tests/data/packing/test_algorithms.py
@@ -174,3 +174,47 @@ class TestCalculateAvgSeqlen:
         _write_avg_seqlen_parquet(tmp_path / "shard_001.idx.parquet", _AVG_SEQLEN_ROWS[1:])
         stats = calculate_avg_seqlen(str(tmp_path), gbs=1, max_seq_len=8, drop_remainder=True)
         self._assert_expected(stats)
+
+
+class TestFirstFitItemLengths:
+    """first_fit can pack opaque objects when item_lengths is supplied.
+
+    This is the contract the diffusion task encoder relies on: it packs sample
+    objects keyed on padded query sequence length and needs the objects back.
+    """
+
+    def test_defaults_to_entries_as_their_own_lengths(self):
+        """Omitting item_lengths must behave exactly like passing seqlens twice."""
+        seqlens = [5, 3, 2, 7, 4]
+        assert first_fit(seqlens, 10) == first_fit(seqlens, 10, item_lengths=seqlens)
+
+    def test_packs_objects_and_returns_them(self):
+        items = ["a", "b", "c", "d"]
+        lengths = [5, 3, 2, 7]
+
+        result = first_fit(items, 10, item_lengths=lengths)
+
+        # Same bin structure as the equivalent integer packing, carrying the objects.
+        assert result == [["a", "b", "c"], ["d"]]
+
+    @pytest.mark.parametrize("seed", [0, 1, 2])
+    def test_object_packing_matches_integer_packing(self, seed):
+        """Bin structure must depend only on the lengths, not on what the items are."""
+        np.random.seed(seed)
+        lengths = [int(x) for x in np.random.randint(1, 2048, size=500)]
+        items = [object() for _ in lengths]
+
+        by_object = first_fit(items, 2048, item_lengths=lengths)
+        by_length = first_fit(lengths, 2048)
+
+        index = {id(o): i for i, o in enumerate(items)}
+        assert [[lengths[index[id(o)]] for o in b] for b in by_object] == by_length
+
+    def test_mismatched_lengths_raise(self):
+        with pytest.raises(ValueError, match="same number of entries"):
+            first_fit([1, 2, 3], 10, item_lengths=[1, 2])
+
+    def test_item_lengths_is_keyword_only(self):
+        """Guards against the lengths being passed positionally by mistake."""
+        with pytest.raises(TypeError):
+            first_fit([1, 2, 3], 10, [1, 2, 3])

--- a/tests/unit_tests/diffusion/data/common/test_sequence_packing_utils.py
+++ b/tests/unit_tests/diffusion/data/common/test_sequence_packing_utils.py
@@ -12,11 +12,61 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import random
+from typing import Any, List
+
+import pytest
+
 from megatron.bridge.diffusion.data.common.sequence_packing_utils import (
     find_first_bin_that_fits,
     first_fit,
     first_fit_decreasing,
+    packing_length,
 )
+
+
+def _linear_scan_first_fit(seqlens: List[Any], pack_size: int) -> List[List[Any]]:
+    """Reference: the original O(N^2) linear-scan first_fit, before the segment tree."""
+    res = []
+    for s in seqlens:
+        first_bin = find_first_bin_that_fits(res, s, pack_size)
+        if first_bin == -1:
+            res.append([s])
+        else:
+            res[first_bin].append(s)
+    return res
+
+
+class _LengthKeyedSample:
+    """Stand-in for DiffusionSample with the same __add__/__radd__/__lt__ contract.
+
+    first_fit is used by the diffusion task encoder to pack sample objects, not raw
+    integers, so the packing core must key on length while returning the objects
+    themselves. This mirrors that contract without pulling in torch or energon.
+    """
+
+    def __init__(self, seq_len: int, uid: int):
+        self.seq_len = seq_len
+        self.uid = uid
+
+    def __add__(self, other: Any) -> int:
+        if isinstance(other, _LengthKeyedSample):
+            return self.seq_len + other.seq_len
+        if isinstance(other, int):
+            return self.seq_len + other
+        raise NotImplementedError
+
+    def __radd__(self, other: Any) -> int:
+        if isinstance(other, int):
+            return self.seq_len + other
+        raise NotImplementedError
+
+    def __lt__(self, other: Any) -> bool:
+        if isinstance(other, _LengthKeyedSample):
+            return self.seq_len < other.seq_len
+        if isinstance(other, int):
+            return self.seq_len < other
+        raise NotImplementedError
 
 
 def test_find_first_bin_that_fits():
@@ -93,3 +143,85 @@ def test_first_fit_decreasing():
     assert result[0] == [7, 3], "First bin should contain [7, 3]"
     assert result[1] == [5, 4], "Second bin should contain [5, 4]"
     assert result[2] == [2], "Third bin should contain [2]"
+
+
+class TestSegmentTreeMatchesLinearScan:
+    """The segment-tree core must reproduce the original linear scan exactly.
+
+    first_fit is order- and identity-sensitive: the diffusion task encoder packs
+    sample objects and relies on which bin each one lands in, so "same bin count"
+    is not a strong enough guarantee. These compare full bin assignments.
+    """
+
+    @pytest.mark.parametrize("seed", range(10))
+    def test_matches_on_random_int_input(self, seed):
+        """Random integer lengths, including zero-length and oversized entries."""
+        rng = random.Random(seed)
+        pack_size = rng.choice([16, 128, 2048, 8192])
+        # Range exceeds pack_size so oversized items (own bin) are covered too.
+        seqlens = [rng.randint(0, pack_size + 200) for _ in range(rng.choice([1, 5, 50, 400]))]
+
+        assert first_fit(seqlens, pack_size) == _linear_scan_first_fit(seqlens, pack_size)
+        assert first_fit_decreasing(seqlens, pack_size) == _linear_scan_first_fit(
+            sorted(seqlens, reverse=True), pack_size
+        )
+
+    @pytest.mark.parametrize(
+        "seqlens,pack_size",
+        [
+            ([], 100),
+            ([0] * 10, 100),
+            ([0, 5, 0, 95, 0, 1], 100),
+            ([500], 100),
+            ([500, 600, 700], 100),
+            ([50, 50, 50, 50], 100),
+        ],
+        ids=["empty", "all-zero", "zero-mixed", "single-oversize", "all-oversize", "exact-fit"],
+    )
+    def test_matches_on_edge_cases(self, seqlens, pack_size):
+        """Zero-length items are the tricky case: an unopened bin also reads as 0 capacity."""
+        assert first_fit(seqlens, pack_size) == _linear_scan_first_fit(seqlens, pack_size)
+
+
+class TestPacksSampleObjects:
+    """first_fit must pack length-keyed objects, not just ints (diffusion task encoder path)."""
+
+    def _samples(self, lengths):
+        return [_LengthKeyedSample(length, uid) for uid, length in enumerate(lengths)]
+
+    def test_returns_original_objects(self):
+        samples = self._samples([5, 3, 2, 7, 4])
+        result = first_fit(samples, 10)
+
+        assert [[s.uid for s in b] for b in result] == [[0, 1, 2], [3], [4]]
+        assert all(isinstance(s, _LengthKeyedSample) for b in result for s in b)
+
+    @pytest.mark.parametrize("seed", range(10))
+    def test_matches_linear_scan_on_objects(self, seed):
+        rng = random.Random(1000 + seed)
+        pack_size = rng.choice([256, 4096, 8192])
+        samples = self._samples([rng.randint(0, pack_size // 2 + 50) for _ in range(rng.choice([1, 40, 300]))])
+
+        expected = _linear_scan_first_fit(samples, pack_size)
+        assert [[s.uid for s in b] for b in first_fit(samples, pack_size)] == [[s.uid for s in b] for b in expected]
+
+    def test_every_sample_placed_exactly_once(self):
+        rng = random.Random(7)
+        samples = self._samples([rng.randint(1, 2000) for _ in range(200)])
+
+        placed = sorted(s.uid for b in first_fit(samples, 4096) for s in b)
+        assert placed == sorted(s.uid for s in samples)
+
+    def test_bins_respect_capacity(self):
+        rng = random.Random(11)
+        pack_size = 4096
+        samples = self._samples([rng.randint(1, pack_size) for _ in range(200)])
+
+        for abin in first_fit(samples, pack_size):
+            assert sum(s.seq_len for s in abin) <= pack_size
+
+
+def test_packing_length_handles_ints_and_samples():
+    """packing_length is what keeps the module decoupled from DiffusionSample."""
+    assert packing_length(42) == 42
+    assert packing_length(_LengthKeyedSample(128, uid=0)) == 128


### PR DESCRIPTION
## What does this PR do?

Replace the linear-scan first-fit in the diffusion sequence packer with the segment-tree implementation already used by offline SFT packing. Bin assignments are unchanged.

`find_first_bin_that_fits()` scans every open bin and recomputes `sum(abin)` on each probe, so `first_fit()` is quadratic in the number of samples. `DiffusionTaskEncoder.select_samples_to_pack()` calls it once per packing buffer during training, so this cost recurs for the whole run rather than being paid once offline. `data/packing/algorithms.py` already carries an O(N log N) segment-tree first-fit, but it packs integers and returns integers, while the diffusion path packs `DiffusionSample` objects and needs those same objects back in the bins.

The fix:

- adds an optional keyword-only `item_lengths` to `first_fit()` in `data/packing/algorithms.py`, so capacity accounting can key on a supplied length while the original entries land in the bins;
- keeps `item_lengths=None` meaning "each entry is its own length", leaving existing two-argument calls untouched, including `create_packing_strategy()`, which resolves the packing function by name through `globals()` and calls it positionally;
- routes the diffusion `first_fit()` through that implementation instead of its own scan;
- resolves a sample's length with `0 + item`, preserving `DiffusionSample.__radd__` and its `seq_len_q_padded` over `seq_len_q` precedence without importing the sample type into the packing utils.

`find_first_bin_that_fits()` is no longer used by `first_fit()`, but it is public and separately tested, so it is left in place and can be removed in a follow-up.

## Testing

New coverage compares full bin assignments against the original linear scan rather than bin counts, since the task encoder depends on which bin each sample lands in. It covers randomized integer and object inputs, zero-length, oversized and exact-fit edge cases, object identity and conservation, and the `item_lengths` argument itself.

This checkout has an uninitialized `3rdparty/Megatron-LM` submodule, so `uv sync` fails and `megatron.core` cannot be imported. The packing tests were run against the real source files with `megatron.core` stubbed and `--noconftest`:

```text
tests/unit_tests/diffusion/data/common/test_sequence_packing_utils.py   33 passed
tests/unit_tests/data/packing/test_algorithms.py                        21 passed
tests/functional_tests/test_groups/data/packing/test_algorithms.py      17 passed
```

These are pure-CPU Python paths, but the runs under the project toolchain still need confirming:

```text
uv run pre-commit run --all-files
uv run python -m pytest tests/unit_tests/diffusion/data/common/test_sequence_packing_utils.py tests/unit_tests/data/packing/test_algorithms.py -q
```

`ruff check` and `ruff format` pass. `pre-commit` itself could not run here because its launcher is missing the `pre_commit` module, so `trailing-whitespace` and `end-of-file-fixer` were checked by hand on the changed files.

Packing time on uniformly drawn lengths with `pack_size=8192`:

```text
N=2000                  0.112s -> 0.011s
N=8000                  1.961s -> 0.057s
N=20000                13.425s -> 0.174s
N=8000 sample objects   8.878s -> 0.042s
```

The object case gains most because the previous code re-evaluated `sum(abin)` through `__radd__` on every probe.

## Scope

Limited to bin-packing order inside sequence packing. No existing signature changes incompatibly and no dependencies are added. No convergence, GPU behavior, at-scale performance, or full-suite validation is claimed.

CI needs `/ok to test <sha>` from an NVIDIA developer, since these commits are not GPG-signed.
