### PR TITLE
Remove FSDP's CUDA_DEVICE_MAX_CONNECTIONS>1 assertion.

### DIFF
--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -1097,9 +1097,6 @@ class ConfigContainer(Container):
             assert self.checkpoint.ckpt_format == "fsdp_dtensor", (
                 "Megatron-FSDP requires the fsdp_dtensor checkpointing format!"
             )
-        assert os.getenv("CUDA_DEVICE_MAX_CONNECTIONS") != "1", (
-            "FSDP requires CUDA_DEVICE_MAX_CONNECTIONS > 1 or unset."
-        )
         if self.ddp.nccl_ub:
             # Without manual registration, UBR is really slow.
             self.ddp.fsdp_manual_registration = True


### PR DESCRIPTION
# What does this PR do ?

Remove FSDP's CUDA_DEVICE_MAX_CONNECTIONS>1 assertion to allow strict queue ordering.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
- [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
