### PR TITLE
fix(model): restore DeepSeek V3 sequence auxiliary loss

### DIFF
--- a/src/megatron/bridge/models/deepseek/deepseek_v3_bridge.py
+++ b/src/megatron/bridge/models/deepseek/deepseek_v3_bridge.py
@@ -66,6 +66,9 @@ class DeepSeekV3Bridge(MegatronModelBridge):
         provider.moe_router_pre_softmax = True
         provider.moe_token_dispatcher_type = "alltoall"
         provider.moe_router_load_balancing_type = "seq_aux_loss"
+        # The released V3 configs omit this training-only hyperparameter, but V3 uses a
+        # small complementary sequence-wise loss alongside expert-bias load balancing.
+        provider.moe_aux_loss_coeff = getattr(hf_config, "aux_loss_alpha", 0.0001)
         provider.moe_shared_expert_overlap = True
         provider.moe_router_score_function = "sigmoid"
         provider.moe_router_enable_expert_bias = True

--- a/tests/unit_tests/models/deepseek/test_deepseek_bridges.py
+++ b/tests/unit_tests/models/deepseek/test_deepseek_bridges.py
@@ -92,7 +92,6 @@ class TestDeepSeekV3Bridge:
             "tie_word_embeddings": False,
             "topk_group": 4,
             "topk_method": "noaux_tc",
-            "aux_loss_alpha": 0.0001,
             "torch_dtype": "bfloat16",
             "transformers_version": "4.33.1",
             "use_cache": True,
@@ -125,7 +124,7 @@ class TestDeepSeekV3Bridge:
         assert provider.vocab_size == mock_pretrained_v3.config.vocab_size
         assert provider.layernorm_epsilon == mock_pretrained_v3.config.rms_norm_eps
         assert provider.rotary_base == mock_pretrained_v3.config.rope_theta
-        assert provider.moe_aux_loss_coeff == mock_pretrained_v3.config.aux_loss_alpha
+        assert provider.moe_aux_loss_coeff == 0.0001
         # dtype mapping
         assert provider.bf16 is True
         assert provider.params_dtype == torch.bfloat16


### PR DESCRIPTION
## What

Restore DeepSeek V3's complementary sequence-wise auxiliary loss when the Hugging Face config omits the training-only `aux_loss_alpha` field.

- Default `moe_aux_loss_coeff` to `0.0001` for released DeepSeek V3 configs.
- Continue honoring an explicit `aux_loss_alpha` from custom configs.
- Make the unit fixture match the released `DeepSeek-V3` / `DeepSeek-V3-Base` config shape, where the field is absent.

## Why

#4909 removed the previous hard-coded `0.0001` under the assumption that the value would be config-derived. The unit fixture contained `aux_loss_alpha`, but the released Hugging Face configs do not, so the effective value fell to MCore's default `0`.

DeepSeek V3 mainly uses expert-bias load balancing, but its [technical report](https://arxiv.org/abs/2412.19437) also specifies a complementary sequence-wise balance loss with an extremely small coefficient to prevent extreme per-sequence expert imbalance. With coefficient 0, MCore skips that loss and gradient entirely.

## Controlled 256-GPU H100 A/B

All probes use the same TP/PP/CP/EP `2/8/1/32`, GBS/MBS `512/1`, sequence length 4096, dataset, image, and environment unless the named axis is changed.

| Probe | Changed axis | Steps 36–50 mean | Avg TFLOPS/GPU | Result |
| --- | --- | ---: | ---: | --- |
| Last good ([W&B](https://wandb.ai/nvidia/megatron-bridge-ci-short-convergence/runs/w8tuoeic)) | reference | 26.855 s | 79.79 | pass |
| First bad ([W&B](https://wandb.ai/nvidia/megatron-bridge-ci-short-convergence/runs/8seg2sng)) | post-#4909 config/source | 31.750 s | 67.13 | perf fail |
| Last-good MCore on first-bad image/Bridge ([job](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/377486462), [W&B](https://wandb.ai/nvidia/megatron-bridge-ci-short-convergence/runs/da0gji0b)) | MCore only | 31.629 s | 67.38 | perf fail; MCore ruled out |
| Restore only `moe_aux_loss_coeff=0.0001` ([job](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/377525901), [W&B](https://wandb.ai/nvidia/megatron-bridge-ci-short-convergence/runs/0jpe3kzz)) | aux coefficient only | **26.715 s** | **80.16** | **performance, convergence, and memory pass** |

The bad/MCore-pin runs stay near 31.6–32.0 s as training progresses. Restoring the coefficient makes `seq_load_balancing_loss` converge from 1.50 toward 1.03 and restores the 24–30 s iteration regime. This locates the slowdown in evolving MoE expert balance / HybridEP dispatch and expert-tail work rather than a fixed startup, environment, or MCore regression.

The controlled fix is +2.31% versus the 78.35 golden TFLOPS/GPU, within the ±10% gate.

## Audit

I audited model bridges that select an auxiliary-loss routing type without setting a coefficient locally:

- DeepSeek V2: released config contains `aux_loss_alpha=0.001`; generic mapping is effective.
- Qwen3.5: released config contains `router_aux_loss_coef=0.001`; generic mapping is effective.
- GLM5: released config omits the coefficient, but the bridge was introduced on the expert-bias/no-aux path; it was not regressed by #4909 and should be evaluated separately if its training recipe requires a complementary sequence loss.
- DeepSeek V3/V3-Base: confirmed affected; released configs omit the field and #4909 removed the fallback.

No second model is confirmed to have the same cleanup regression.

## Validation

- 256-GPU H100 controlled A/B: **performance, convergence, and memory passed**.
- `pre-commit run --files ...`: passed all hooks.
- `git diff --check`: passed.
- Focused local pytest could not import the current repository from this host because Transformer Engine is not installed; repository CI is enabled for the signed-off commit.
