### PR TITLE
fix(model): default heterogeneous pipeline dtype

### DIFF
--- a/src/megatron/bridge/models/transformer_config.py
+++ b/src/megatron/bridge/models/transformer_config.py
@@ -254,6 +254,8 @@ class HeterogeneousTransformerConfig(TransformerConfig, MCoreHeterogeneousTransf
         It can be called multiple times safely.
         """
         _resolve_string_fields(self)
+        if self.pipeline_model_parallel_size > 1 and self.pipeline_dtype is None:
+            self.pipeline_dtype = self.params_dtype
         if self.sequence_parallel and self.tensor_model_parallel_size <= 1:
             self.sequence_parallel = False
         _set_moe_expert_tensor_parallel_default(self)

--- a/tests/unit_tests/models/test_transformer_config.py
+++ b/tests/unit_tests/models/test_transformer_config.py
@@ -14,6 +14,7 @@
 
 """Unit tests for megatron.bridge.models.transformer_config."""
 
+import json
 from unittest.mock import patch
 
 import pytest
@@ -255,6 +256,16 @@ class TestHeterogeneousTransformerConfigFinalize:
         defaults.update(kwargs)
         return HeterogeneousTransformerConfig(**defaults)
 
+    def _make_valid_hetero(self, **kwargs) -> HeterogeneousTransformerConfig:
+        block = {
+            "attention": {"no_op": False, "replace_with_linear": False, "num_query_groups": 4},
+            "mlp": {"no_op": False, "replace_with_linear": False, "ffn_hidden_size": 256},
+        }
+        return self._make_hetero(
+            heterogeneous_layers_config_encoded_json=json.dumps({"block_configs": [block, block]}),
+            **kwargs,
+        )
+
     def test_finalize_calls_mcore_hetero_post_init(self):
         cfg = self._make_hetero()
         with patch(_HETERO_FINALIZE_PATCH) as mock_post_init:
@@ -287,3 +298,25 @@ class TestHeterogeneousTransformerConfigFinalize:
         with patch(_HETERO_FINALIZE_PATCH):
             cfg.finalize()
         assert cfg.sequence_parallel is True
+
+    def test_pipeline_dtype_propagated_from_params_dtype_when_pp_gt1(self):
+        cfg = self._make_valid_hetero(
+            params_dtype=torch.bfloat16,
+            pipeline_dtype=None,
+            pipeline_model_parallel_size=2,
+        )
+
+        cfg.finalize()
+
+        assert cfg.pipeline_dtype is torch.bfloat16
+
+    def test_explicit_pipeline_dtype_is_preserved_when_pp_gt1(self):
+        cfg = self._make_valid_hetero(
+            params_dtype=torch.bfloat16,
+            pipeline_dtype=torch.float16,
+            pipeline_model_parallel_size=2,
+        )
+
+        cfg.finalize()
+
+        assert cfg.pipeline_dtype is torch.float16


### PR DESCRIPTION
## Summary

Default `pipeline_dtype` from `params_dtype` when finalizing a heterogeneous
transformer config with pipeline parallelism enabled.

The registered Llama-Nemotron heterogeneous provider defaults its parameter
precision to BF16. A caller using the documented provider override workflow
can set `pipeline_model_parallel_size=2` and then finalize the provider.
Unlike the standard and MLA finalizers, the heterogeneous finalizer did not
supply a pipeline dtype first, so Megatron-Core rejected the configuration:

```text
ValueError: When using pipeline parallelism, pipeline_dtype must be specified
```

## Root cause and fix

`HeterogeneousTransformerConfig.finalize()` reached Megatron-Core validation
without applying the Bridge-owned PP dtype default already used by the
standard and MLA config paths.

The fix applies that same invariant before heterogeneous validation and
preserves an explicitly configured pipeline dtype.

## Validation

Fail before the production fix:

```text
uv run --active --no-sync python -m pytest --confcutdir=tests/unit_tests/models tests/unit_tests/models/test_transformer_config.py -k 'TestHeterogeneousTransformerConfigFinalize and pipeline_dtype' -q
1 failed, 1 passed, 28 deselected
```

Pass after the fix, with the regression test unchanged:

```text
uv run --active --no-sync python -m pytest --confcutdir=tests/unit_tests/models tests/unit_tests/models/test_transformer_config.py -k 'TestHeterogeneousTransformerConfigFinalize and pipeline_dtype' -q
2 passed, 28 deselected
```

Focused adjacent module:

```text
uv run --active --no-sync python -m pytest --confcutdir=tests/unit_tests/models tests/unit_tests/models/test_transformer_config.py -q
30 passed
```

Additional checks:

```text
git diff --check
uv run --active --no-sync pre-commit run --all-files
```

Both passed.

## Scope

- Affects heterogeneous providers with PP greater than one when
  `pipeline_dtype` is not explicitly supplied.
- PP=1 and explicit pipeline dtypes are unchanged.
- This is a CPU configuration-contract regression test; it does not claim
  multi-GPU checkpoint, convergence, quality, or performance validation.
- No public API, dependency, CI workflow, or Megatron-Core source changes.
