### PR TITLE
refactor(diffusion): reuse shared bin-packing algorithms for sequence packing

### DIFF
--- a/src/megatron/bridge/data/packing/algorithms.py
+++ b/src/megatron/bridge/data/packing/algorithms.py
@@ -131,21 +131,51 @@ def first_fit(
     return res
 
 
-def first_fit_decreasing(seqlens: List[int], pack_size: int) -> List[List[int]]:
+def first_fit_decreasing(
+    seqlens: Sequence[_ItemT],
+    pack_size: int,
+    *,
+    item_lengths: Sequence[int] | None = None,
+) -> list[list[_ItemT]]:
     """
     Packs sequences of varying lengths into bins using the First-Fit Decreasing algorithm.
 
     This is a variation of the First-Fit algorithm where the sequences are sorted by decreasing length before packing.
 
+    Like `first_fit`, callers that pack objects rather than raw integers (for example
+    diffusion samples keyed on padded query sequence length) pass `item_lengths`
+    separately: the entries are then ordered by those lengths, longest first, and the
+    original objects are what end up in the bins.
+
     Args:
-      seqlens: A list of integers, representing the lengths of the sequences to be packed.
+      seqlens: The entries to pack. Integer lengths unless `item_lengths` is given, in
+        which case these may be any objects.
       pack_size: The maximum capacity of each bin.
+      item_lengths: Optional length of each entry in `seqlens`, in the same order. When
+        omitted, each entry is used as its own length.
 
     Returns:
       A list of lists, similar to the output of the 'first_fit' function.
+
+    Raises:
+      ValueError: If `item_lengths` is given and does not have the same number of
+        entries as `seqlens`.
     """
-    sorted_seqlens = sorted(seqlens, reverse=True)
-    return first_fit(sorted_seqlens, pack_size)
+    if item_lengths is None:
+        return first_fit(sorted(seqlens, reverse=True), pack_size)
+    if len(seqlens) != len(item_lengths):
+        raise ValueError(
+            f"seqlens and item_lengths must have the same number of entries, "
+            f"got {len(seqlens)} and {len(item_lengths)}"
+        )
+    # Order entries by their supplied length, longest first, keeping each entry paired
+    # with its length. `sorted(..., reverse=True)` is stable, so entries of equal length
+    # keep their original relative order -- matching `sorted(items, reverse=True)` when
+    # the items compare by that same length.
+    order = sorted(range(len(seqlens)), key=lambda i: item_lengths[i], reverse=True)
+    sorted_items = [seqlens[i] for i in order]
+    sorted_lengths = [item_lengths[i] for i in order]
+    return first_fit(sorted_items, pack_size, item_lengths=sorted_lengths)
 
 
 def first_fit_shuffle(seqlens: List[int], pack_size: int) -> List[List[int]]:

--- a/src/megatron/bridge/diffusion/data/common/diffusion_task_encoder_with_sp.py
+++ b/src/megatron/bridge/diffusion/data/common/diffusion_task_encoder_with_sp.py
@@ -22,8 +22,9 @@ from megatron.energon.task_encoder.base import stateless
 from megatron.energon.task_encoder.cooking import Cooker, basic_sample_keys
 
 from megatron.bridge.data.energon.metadata import sample_metadata_kwargs
+from megatron.bridge.data.packing.algorithms import first_fit_decreasing
 from megatron.bridge.diffusion.data.common.diffusion_sample import DiffusionSample
-from megatron.bridge.diffusion.data.common.sequence_packing_utils import first_fit_decreasing
+from megatron.bridge.diffusion.data.common.sequence_packing_utils import packing_length
 
 
 @stateless
@@ -82,7 +83,9 @@ class DiffusionTaskEncoderWithSequencePacking(DefaultTaskEncoder, ABC):  # noqa:
         """
         Selects sequences to pack for mixed image-video training.
         """
-        results = first_fit_decreasing(samples, self.seq_length)
+        # Pack the live sample objects, keying capacity on each sample's (padded) query
+        # sequence length via the shared bin-packing algorithm used by LLM SFT packing.
+        results = first_fit_decreasing(samples, self.seq_length, item_lengths=[packing_length(s) for s in samples])
         random.shuffle(results)
         return results
 

--- a/src/megatron/bridge/diffusion/data/common/sequence_packing_utils.py
+++ b/src/megatron/bridge/diffusion/data/common/sequence_packing_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2024-2026, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,14 +13,18 @@
 # limitations under the License.
 
 
-from typing import Any, List
-
-from megatron.bridge.data.packing.algorithms import first_fit as _shared_first_fit
+from typing import Any
 
 
 def packing_length(item: Any) -> int:
     """
     Returns the bin-packing length of an item.
+
+    This is the only diffusion-specific piece of sequence packing: the bin-packing
+    algorithms themselves live in `megatron.bridge.data.packing.algorithms` and are
+    shared with LLM offline SFT packing. Diffusion packs live `DiffusionSample`
+    objects rather than integer lengths, so it computes each sample's length with
+    this adapter and passes the results as `item_lengths` to the shared packer.
 
     Items are either plain sequence lengths or objects that report their length by
     adding with an int -- `DiffusionSample` does this, returning its padded query
@@ -35,60 +39,3 @@ def packing_length(item: Any) -> int:
       The integer length used for bin-packing capacity accounting.
     """
     return 0 + item
-
-
-def find_first_bin_that_fits(bins: List[List[int]], s: int, bin_size: int) -> int:
-    """
-    Finds the first bin in a list of bins that has enough space to fit a sequence of size 's'.
-
-    Args:
-      bins: A list of lists, where each inner list represents a bin and contains the current elements in that bin.
-      s: The size of the sequence to be placed in a bin.
-      bin_size: The maximum capacity of each bin.
-
-    Returns:
-      The index of the first bin that can fit the sequence 's', or -1 if no such bin exists.
-    """
-    for i, abin in enumerate(bins):
-        if sum(abin) + s <= bin_size:
-            return i
-    return -1
-
-
-def first_fit(seqlens: List[int], pack_size: int) -> List[List[int]]:
-    """
-    Packs sequences of varying lengths into bins using the First-Fit algorithm.
-
-    Delegates to the shared segment-tree implementation in
-    `megatron.bridge.data.packing.algorithms`, which places each item in O(log N)
-    rather than rescanning and re-summing every open bin. Bin assignments are
-    identical to the previous linear-scan implementation.
-
-    Args:
-      seqlens: The sequences to pack. Entries are either integer lengths or objects
-        that report their length when added to an int (see `packing_length`); the
-        original entries are what end up in the returned bins.
-      pack_size: The maximum capacity of each bin.
-
-    Returns:
-      A list of lists, where each inner list represents a bin and contains the
-        entries assigned to that bin.
-    """
-    return _shared_first_fit(seqlens, pack_size, item_lengths=[packing_length(item) for item in seqlens])
-
-
-def first_fit_decreasing(seqlens: List[int], pack_size: int) -> List[List[int]]:
-    """
-    Packs sequences of varying lengths into bins using the First-Fit Decreasing algorithm.
-
-    This is a variation of the First-Fit algorithm where the sequences are sorted by decreasing length before packing.
-
-    Args:
-      seqlens: A list of integers, representing the lengths of the sequences to be packed.
-      pack_size: The maximum capacity of each bin.
-
-    Returns:
-      A list of lists, similar to the output of the 'first_fit' function.
-    """
-    sorted_seqlens = sorted(seqlens, reverse=True)
-    return first_fit(sorted_seqlens, pack_size)

--- a/src/megatron/bridge/diffusion/data/common/sequence_packing_utils.py
+++ b/src/megatron/bridge/diffusion/data/common/sequence_packing_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit_tests/data/packing/test_algorithms.py
+++ b/tests/unit_tests/data/packing/test_algorithms.py
@@ -45,6 +45,24 @@ def _first_fit_linear(seqlens: List[int], pack_size: int) -> List[List[int]]:
     return res
 
 
+def _first_fit_decreasing_linear_indices(lengths: list[int], pack_size: int) -> list[list[int]]:
+    """Reference first-fit-decreasing that retains each input item's identity."""
+    res: list[list[int]] = []
+    res_sums: list[int] = []
+    order = sorted(range(len(lengths)), key=lengths.__getitem__, reverse=True)
+    for item_index in order:
+        length = lengths[item_index]
+        for bin_index, current_sum in enumerate(res_sums):
+            if current_sum + length <= pack_size:
+                res[bin_index].append(item_index)
+                res_sums[bin_index] += length
+                break
+        else:
+            res.append([item_index])
+            res_sums.append(length)
+    return res
+
+
 class TestFirstFitPacking:
     """Test cases for first_fit bin-packing algorithm."""
 
@@ -243,6 +261,17 @@ class TestFirstFitDecreasingItemLengths:
         # then packs [d, b], [a, e], [c], carrying the original objects.
         assert result == [["d", "b"], ["a", "e"], ["c"]]
 
+    def test_equal_lengths_keep_input_identity_and_order(self):
+        """Stable sorting must not reorder opaque items with equal lengths."""
+        items = [object(), object(), object()]
+        lengths = [6, 6, 4]
+
+        result = first_fit_decreasing(items, 10, item_lengths=lengths)
+
+        assert result[0][0] is items[0]
+        assert result[0][1] is items[2]
+        assert result[1][0] is items[1]
+
     @pytest.mark.parametrize("seed", [0, 1, 2])
     def test_object_packing_matches_integer_packing(self, seed):
         """Bin structure must depend only on the lengths, not on what the items are."""
@@ -266,8 +295,30 @@ class TestFirstFitDecreasingItemLengths:
         by_object = first_fit_decreasing(items, 2048, item_lengths=lengths)
 
         index = {id(o): i for i, o in enumerate(items)}
-        packed_lengths = [[lengths[index[id(o)]] for o in b] for b in by_object]
-        assert packed_lengths == _first_fit_linear(sorted(lengths, reverse=True), 2048)
+        packed_indices = [[index[id(o)] for o in b] for b in by_object]
+        assert packed_indices == _first_fit_decreasing_linear_indices(lengths, 2048)
+
+    @pytest.mark.parametrize(
+        "lengths,pack_size",
+        [
+            ([], 100),
+            ([0] * 10, 100),
+            ([0, 5, 0, 95, 0, 1], 100),
+            ([500], 100),
+            ([500, 600, 700], 100),
+            ([50, 50, 50, 50], 100),
+        ],
+        ids=["empty", "all-zero", "zero-mixed", "single-oversize", "all-oversize", "exact-fit"],
+    )
+    def test_object_packing_matches_linear_scan_on_edge_cases(self, lengths, pack_size):
+        """Named edge cases must preserve exact object assignments."""
+        items = [object() for _ in lengths]
+
+        result = first_fit_decreasing(items, pack_size, item_lengths=lengths)
+
+        index = {id(item): i for i, item in enumerate(items)}
+        packed_indices = [[index[id(item)] for item in bin_items] for bin_items in result]
+        assert packed_indices == _first_fit_decreasing_linear_indices(lengths, pack_size)
 
     def test_mismatched_lengths_raise(self):
         with pytest.raises(ValueError, match="same number of entries"):

--- a/tests/unit_tests/data/packing/test_algorithms.py
+++ b/tests/unit_tests/data/packing/test_algorithms.py
@@ -218,3 +218,62 @@ class TestFirstFitItemLengths:
         """Guards against the lengths being passed positionally by mistake."""
         with pytest.raises(TypeError):
             first_fit([1, 2, 3], 10, [1, 2, 3])
+
+
+class TestFirstFitDecreasingItemLengths:
+    """first_fit_decreasing packs opaque objects when item_lengths is supplied.
+
+    This is the exact contract the diffusion task encoder relies on: it orders live
+    sample objects by (padded) query sequence length, longest first, and needs the
+    original objects back in the bins.
+    """
+
+    def test_defaults_to_entries_as_their_own_lengths(self):
+        """Omitting item_lengths must behave exactly like passing seqlens twice."""
+        seqlens = [5, 3, 2, 7, 4]
+        assert first_fit_decreasing(seqlens, 10) == first_fit_decreasing(seqlens, 10, item_lengths=seqlens)
+
+    def test_packs_objects_in_decreasing_length_order(self):
+        items = ["a", "b", "c", "d", "e"]
+        lengths = [5, 3, 2, 7, 4]
+
+        result = first_fit_decreasing(items, 10, item_lengths=lengths)
+
+        # Sorted by length desc -> d(7), a(5), e(4), b(3), c(2); first-fit-decreasing
+        # then packs [d, b], [a, e], [c], carrying the original objects.
+        assert result == [["d", "b"], ["a", "e"], ["c"]]
+
+    @pytest.mark.parametrize("seed", [0, 1, 2])
+    def test_object_packing_matches_integer_packing(self, seed):
+        """Bin structure must depend only on the lengths, not on what the items are."""
+        np.random.seed(seed)
+        lengths = [int(x) for x in np.random.randint(1, 2048, size=500)]
+        items = [object() for _ in lengths]
+
+        by_object = first_fit_decreasing(items, 2048, item_lengths=lengths)
+        by_length = first_fit_decreasing(lengths, 2048)
+
+        index = {id(o): i for i, o in enumerate(items)}
+        assert [[lengths[index[id(o)]] for o in b] for b in by_object] == by_length
+
+    @pytest.mark.parametrize("seed", [0, 1, 2])
+    def test_object_packing_matches_linear_scan_reference(self, seed):
+        """Assignments must match the original O(N^2) linear scan on the sorted order."""
+        np.random.seed(seed)
+        lengths = [int(x) for x in np.random.randint(0, 2248, size=400)]
+        items = [object() for _ in lengths]
+
+        by_object = first_fit_decreasing(items, 2048, item_lengths=lengths)
+
+        index = {id(o): i for i, o in enumerate(items)}
+        packed_lengths = [[lengths[index[id(o)]] for o in b] for b in by_object]
+        assert packed_lengths == _first_fit_linear(sorted(lengths, reverse=True), 2048)
+
+    def test_mismatched_lengths_raise(self):
+        with pytest.raises(ValueError, match="same number of entries"):
+            first_fit_decreasing([1, 2, 3], 10, item_lengths=[1, 2])
+
+    def test_item_lengths_is_keyword_only(self):
+        """Guards against the lengths being passed positionally by mistake."""
+        with pytest.raises(TypeError):
+            first_fit_decreasing([1, 2, 3], 10, [1, 2, 3])

--- a/tests/unit_tests/diffusion/data/common/test_diffusion_task_encoder.py
+++ b/tests/unit_tests/diffusion/data/common/test_diffusion_task_encoder.py
@@ -112,7 +112,7 @@ def test_select_samples_to_pack(monkeypatch):
 
     # Verify no bin exceeds seq_length
     for group in result:
-        total_seq_len = sum(sample.seq_len_q.item() for sample in group)
+        total_seq_len = sum(sample.seq_len_q_padded.item() for sample in group)
         assert total_seq_len <= encoder.seq_length, (
             f"Bin with total {total_seq_len} exceeds seq_length {encoder.seq_length}"
         )
@@ -120,8 +120,44 @@ def test_select_samples_to_pack(monkeypatch):
     # Verify that bins are non-empty
     assert all(len(group) > 0 for group in result), "No bin should be empty"
 
-    print(f"✓ Successfully packed {len(samples)} samples into {len(result)} bins")
-    print(f"  Bin sizes: {[sum(s.seq_len_q.item() for s in group) for group in result]}")
+
+def test_select_samples_to_pack_uses_padded_lengths_and_stable_identity(monkeypatch):
+    """The real selector must pack original samples by padded length with stable ties."""
+    _patch_worker_config(monkeypatch)
+
+    encoder = ConcreteDiffusionTaskEncoder(seq_length=16)
+    samples = [
+        create_diffusion_sample("sample_0", seq_len=6),
+        create_diffusion_sample("sample_1", seq_len=6),
+        create_diffusion_sample("sample_2", seq_len=4),
+    ]
+    samples[0].seq_len_q_padded = torch.tensor([10], dtype=torch.int32)
+    samples[1].seq_len_q_padded = torch.tensor([10], dtype=torch.int32)
+
+    result = encoder.select_samples_to_pack(samples)
+
+    bins_by_key = sorted([[sample.__key__ for sample in group] for group in result])
+    assert bins_by_key == [["sample_0", "sample_2"], ["sample_1"]]
+    by_key = {sample.__key__: sample for group in result for sample in group}
+    assert all(by_key[sample.__key__] is sample for sample in samples)
+    assert all(sum(sample.seq_len_q_padded.item() for sample in group) <= encoder.seq_length for group in result)
+
+
+def test_select_samples_to_pack_handles_empty_and_oversized_inputs(monkeypatch):
+    """The real selector must retain empty and one-item oversized-bin behavior."""
+    _patch_worker_config(monkeypatch)
+
+    encoder = ConcreteDiffusionTaskEncoder(seq_length=20)
+    assert encoder.select_samples_to_pack([]) == []
+
+    samples = [
+        create_diffusion_sample("oversized_0", seq_len=25),
+        create_diffusion_sample("oversized_1", seq_len=30),
+    ]
+    result = encoder.select_samples_to_pack(samples)
+
+    assert sorted([[sample.__key__ for sample in group] for group in result]) == [["oversized_0"], ["oversized_1"]]
+    assert {id(sample) for group in result for sample in group} == {id(sample) for sample in samples}
 
 
 def test_select_samples_to_pack_deterministic(monkeypatch):
@@ -206,7 +242,3 @@ def test_pack_selected_samples():
     assert packed_sample.latent_shape.shape[0] == 3, "latent_shape should have 3 rows"
     assert isinstance(packed_sample.video_metadata, list), "video_metadata should be a list"
     assert len(packed_sample.video_metadata) == 3, "video_metadata should have 3 elements"
-
-    print(f"✓ Successfully packed {len(samples_to_pack)} samples")
-    print(f"  Packed video shape: {packed_sample.video.shape}")
-    print(f"  Packed context embeddings shape: {packed_sample.context_embeddings.shape}")

--- a/tests/unit_tests/diffusion/data/common/test_sequence_packing_utils.py
+++ b/tests/unit_tests/diffusion/data/common/test_sequence_packing_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2024-2026, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,215 +13,111 @@
 # limitations under the License.
 
 import random
-from typing import Any, List
+from typing import Any
 
 import pytest
 
-from megatron.bridge.diffusion.data.common.sequence_packing_utils import (
-    find_first_bin_that_fits,
-    first_fit,
-    first_fit_decreasing,
-    packing_length,
-)
+from megatron.bridge.data.packing.algorithms import first_fit_decreasing
+from megatron.bridge.diffusion.data.common.sequence_packing_utils import packing_length
 
 
-def _linear_scan_first_fit(seqlens: List[Any], pack_size: int) -> List[List[Any]]:
-    """Reference: the original O(N^2) linear-scan first_fit, before the segment tree."""
+def _linear_scan_first_fit_decreasing(lengths, pack_size):
+    """Reference: the original O(N^2) linear-scan first-fit-decreasing the diffusion packer used."""
     res = []
-    for s in seqlens:
-        first_bin = find_first_bin_that_fits(res, s, pack_size)
-        if first_bin == -1:
+    for s in sorted(lengths, reverse=True):
+        placed = False
+        for abin in res:
+            if sum(abin) + s <= pack_size:
+                abin.append(s)
+                placed = True
+                break
+        if not placed:
             res.append([s])
-        else:
-            res[first_bin].append(s)
     return res
 
 
-class _LengthKeyedSample:
-    """Stand-in for DiffusionSample with the same __add__/__radd__/__lt__ contract.
+class _Sample:
+    """Stand-in for DiffusionSample's bin-packing contract.
 
-    first_fit is used by the diffusion task encoder to pack sample objects, not raw
-    integers, so the packing core must key on length while returning the objects
-    themselves. This mirrors that contract without pulling in torch or energon.
+    The diffusion task encoder packs live sample objects, keying capacity on the padded
+    query sequence length when one is set and the unpadded length otherwise (this mirrors
+    DiffusionSample.__radd__). This reproduces just that contract, without pulling in
+    torch or energon.
     """
 
-    def __init__(self, seq_len: int, uid: int):
-        self.seq_len = seq_len
+    def __init__(self, seq_len_q: int, *, seq_len_q_padded: int | None = None, uid: int = 0):
+        self.seq_len_q = seq_len_q
+        self.seq_len_q_padded = seq_len_q_padded
         self.uid = uid
-
-    def __add__(self, other: Any) -> int:
-        if isinstance(other, _LengthKeyedSample):
-            return self.seq_len + other.seq_len
-        if isinstance(other, int):
-            return self.seq_len + other
-        raise NotImplementedError
 
     def __radd__(self, other: Any) -> int:
         if isinstance(other, int):
-            return self.seq_len + other
+            return self.length + other
         raise NotImplementedError
 
-    def __lt__(self, other: Any) -> bool:
-        if isinstance(other, _LengthKeyedSample):
-            return self.seq_len < other.seq_len
-        if isinstance(other, int):
-            return self.seq_len < other
-        raise NotImplementedError
+    @property
+    def length(self) -> int:
+        return self.seq_len_q_padded if self.seq_len_q_padded is not None else self.seq_len_q
 
 
-def test_find_first_bin_that_fits():
-    """Test find_first_bin_that_fits function."""
-    # Test case: Find a bin that fits
-    bins = [[5, 3], [10], [2, 2, 2]]
-    s = 2
-    bin_size = 10
-    result = find_first_bin_that_fits(bins, s, bin_size)
-    assert result == 0, "Should return index 0 as first bin (5+3+2=10) fits"
-
-    # Test case: No bin fits
-    bins = [[8, 2], [9, 1], [10]]
-    s = 5
-    bin_size = 10
-    result = find_first_bin_that_fits(bins, s, bin_size)
-    assert result == -1, "Should return -1 as no bin can accommodate size 5"
-
-    # Test case: Empty bins list
-    bins = []
-    s = 5
-    bin_size = 10
-    result = find_first_bin_that_fits(bins, s, bin_size)
-    assert result == -1, "Should return -1 for empty bins list"
-
-    # Test case: First bin doesn't fit, but second does
-    bins = [[9], [5], [3]]
-    s = 4
-    bin_size = 10
-    result = find_first_bin_that_fits(bins, s, bin_size)
-    assert result == 1, "Should return index 1 as second bin (5+4=9) fits"
+def test_packing_length_handles_plain_ints():
+    assert packing_length(42) == 42
+    assert packing_length(0) == 0
 
 
-def test_first_fit():
-    """Test first_fit bin packing algorithm."""
-    # Test case: Simple packing scenario
-    seqlens = [5, 3, 2, 7, 4]
-    pack_size = 10
-    result = first_fit(seqlens, pack_size)
-
-    # Verify all sequences are packed
-    all_items = [item for bin in result for item in bin]
-    assert sum(all_items) == sum(seqlens), "Sum of all packed items should equal sum of input"
-
-    # Verify no bin exceeds pack_size
-    for bin in result:
-        assert sum(bin) <= pack_size, f"Bin {bin} exceeds pack_size {pack_size}"
-
-    # Verify expected packing: [5, 3, 2], [7], [4] (first-fit order)
-    assert len(result) == 3, "Should create 3 bins"
-    assert result[0] == [5, 3, 2], "First bin should contain [5, 3, 2]"
-    assert result[1] == [7], "Second bin should contain [7]"
-    assert result[2] == [4], "Third bin should contain [4]"
+def test_packing_length_prefers_padded_query_length():
+    """packing_length must match DiffusionSample: the padded length wins when it is set."""
+    assert packing_length(_Sample(100)) == 100
+    assert packing_length(_Sample(100, seq_len_q_padded=128)) == 128
 
 
-def test_first_fit_decreasing():
-    """Test first_fit_decreasing bin packing algorithm."""
-    # Test case: Same sequences as first_fit but sorted in decreasing order
-    seqlens = [5, 3, 2, 7, 4]
-    pack_size = 10
-    result = first_fit_decreasing(seqlens, pack_size)
+class TestDiffusionEncoderPacking:
+    """The diffusion task encoder call pattern: pack sample objects through the shared packer.
 
-    # Verify all sequences are packed
-    all_items = [item for bin in result for item in bin]
-    assert sum(all_items) == sum(seqlens), "Sum of all packed items should equal sum of input"
-
-    # Verify no bin exceeds pack_size
-    for bin in result:
-        assert sum(bin) <= pack_size, f"Bin {bin} exceeds pack_size {pack_size}"
-
-    # Verify expected packing: sorted [7, 5, 4, 3, 2] -> [7, 3], [5, 4, 2] (more efficient)
-    assert len(result) <= 3, "Should create at most 3 bins"
-    # First-fit-decreasing should pack: [7, 3], [5, 4], [2]
-    assert result[0] == [7, 3], "First bin should contain [7, 3]"
-    assert result[1] == [5, 4], "Second bin should contain [5, 4]"
-    assert result[2] == [2], "Third bin should contain [2]"
-
-
-class TestSegmentTreeMatchesLinearScan:
-    """The segment-tree core must reproduce the original linear scan exactly.
-
-    first_fit is order- and identity-sensitive: the diffusion task encoder packs
-    sample objects and relies on which bin each one lands in, so "same bin count"
-    is not a strong enough guarantee. These compare full bin assignments.
+    select_samples_to_pack() calls the shared first_fit_decreasing with item_lengths derived
+    from packing_length, so it is order- and identity-sensitive: it relies on which bin each
+    sample lands in. These assert full bin assignments and object identity, not just counts.
     """
 
+    def _pack(self, samples, pack_size):
+        return first_fit_decreasing(samples, pack_size, item_lengths=[packing_length(s) for s in samples])
+
+    def test_returns_original_sample_objects(self):
+        samples = [_Sample(length, uid=i) for i, length in enumerate([5, 3, 2, 7, 4])]
+        result = self._pack(samples, 10)
+
+        assert all(isinstance(s, _Sample) for b in result for s in b)
+        # Sorted desc -> 7,5,4,3,2 (uids 3,0,4,1,2); first-fit-decreasing packs
+        # [7,3],[5,4],[2] -> uids [[3,1],[0,4],[2]].
+        assert [[s.uid for s in b] for b in result] == [[3, 1], [0, 4], [2]]
+
+    def test_uses_padded_length_for_capacity(self):
+        """Padded length drives capacity: unpadded would pack two per bin, padded does not."""
+        samples = [_Sample(100, seq_len_q_padded=128, uid=i) for i in range(3)]
+        result = self._pack(samples, 200)
+        assert all(len(b) == 1 for b in result)
+
     @pytest.mark.parametrize("seed", range(10))
-    def test_matches_on_random_int_input(self, seed):
-        """Random integer lengths, including zero-length and oversized entries."""
+    def test_matches_linear_scan_reference(self, seed):
         rng = random.Random(seed)
-        pack_size = rng.choice([16, 128, 2048, 8192])
-        # Range exceeds pack_size so oversized items (own bin) are covered too.
-        seqlens = [rng.randint(0, pack_size + 200) for _ in range(rng.choice([1, 5, 50, 400]))]
-
-        assert first_fit(seqlens, pack_size) == _linear_scan_first_fit(seqlens, pack_size)
-        assert first_fit_decreasing(seqlens, pack_size) == _linear_scan_first_fit(
-            sorted(seqlens, reverse=True), pack_size
-        )
-
-    @pytest.mark.parametrize(
-        "seqlens,pack_size",
-        [
-            ([], 100),
-            ([0] * 10, 100),
-            ([0, 5, 0, 95, 0, 1], 100),
-            ([500], 100),
-            ([500, 600, 700], 100),
-            ([50, 50, 50, 50], 100),
-        ],
-        ids=["empty", "all-zero", "zero-mixed", "single-oversize", "all-oversize", "exact-fit"],
-    )
-    def test_matches_on_edge_cases(self, seqlens, pack_size):
-        """Zero-length items are the tricky case: an unopened bin also reads as 0 capacity."""
-        assert first_fit(seqlens, pack_size) == _linear_scan_first_fit(seqlens, pack_size)
-
-
-class TestPacksSampleObjects:
-    """first_fit must pack length-keyed objects, not just ints (diffusion task encoder path)."""
-
-    def _samples(self, lengths):
-        return [_LengthKeyedSample(length, uid) for uid, length in enumerate(lengths)]
-
-    def test_returns_original_objects(self):
-        samples = self._samples([5, 3, 2, 7, 4])
-        result = first_fit(samples, 10)
-
-        assert [[s.uid for s in b] for b in result] == [[0, 1, 2], [3], [4]]
-        assert all(isinstance(s, _LengthKeyedSample) for b in result for s in b)
-
-    @pytest.mark.parametrize("seed", range(10))
-    def test_matches_linear_scan_on_objects(self, seed):
-        rng = random.Random(1000 + seed)
         pack_size = rng.choice([256, 4096, 8192])
-        samples = self._samples([rng.randint(0, pack_size // 2 + 50) for _ in range(rng.choice([1, 40, 300]))])
+        lengths = [rng.randint(0, pack_size // 2 + 50) for _ in range(rng.choice([1, 40, 300]))]
+        samples = [_Sample(length, uid=i) for i, length in enumerate(lengths)]
 
-        expected = _linear_scan_first_fit(samples, pack_size)
-        assert [[s.uid for s in b] for b in first_fit(samples, pack_size)] == [[s.uid for s in b] for b in expected]
+        packed_lengths = [[s.length for s in b] for b in self._pack(samples, pack_size)]
+        assert packed_lengths == _linear_scan_first_fit_decreasing(lengths, pack_size)
 
     def test_every_sample_placed_exactly_once(self):
         rng = random.Random(7)
-        samples = self._samples([rng.randint(1, 2000) for _ in range(200)])
+        samples = [_Sample(rng.randint(1, 2000), uid=i) for i in range(200)]
 
-        placed = sorted(s.uid for b in first_fit(samples, 4096) for s in b)
-        assert placed == sorted(s.uid for s in samples)
+        placed = sorted(s.uid for b in self._pack(samples, 4096) for s in b)
+        assert placed == list(range(200))
 
     def test_bins_respect_capacity(self):
         rng = random.Random(11)
         pack_size = 4096
-        samples = self._samples([rng.randint(1, pack_size) for _ in range(200)])
+        samples = [_Sample(rng.randint(1, pack_size), uid=i) for i in range(200)]
 
-        for abin in first_fit(samples, pack_size):
-            assert sum(s.seq_len for s in abin) <= pack_size
-
-
-def test_packing_length_handles_ints_and_samples():
-    """packing_length is what keeps the module decoupled from DiffusionSample."""
-    assert packing_length(42) == 42
-    assert packing_length(_LengthKeyedSample(128, uid=0)) == 128
+        for abin in self._pack(samples, pack_size):
+            assert sum(s.length for s in abin) <= pack_size

--- a/tests/unit_tests/diffusion/data/common/test_sequence_packing_utils.py
+++ b/tests/unit_tests/diffusion/data/common/test_sequence_packing_utils.py
@@ -12,28 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import random
 from typing import Any
 
-import pytest
-
-from megatron.bridge.data.packing.algorithms import first_fit_decreasing
 from megatron.bridge.diffusion.data.common.sequence_packing_utils import packing_length
-
-
-def _linear_scan_first_fit_decreasing(lengths, pack_size):
-    """Reference: the original O(N^2) linear-scan first-fit-decreasing the diffusion packer used."""
-    res = []
-    for s in sorted(lengths, reverse=True):
-        placed = False
-        for abin in res:
-            if sum(abin) + s <= pack_size:
-                abin.append(s)
-                placed = True
-                break
-        if not placed:
-            res.append([s])
-    return res
 
 
 class _Sample:
@@ -45,10 +26,9 @@ class _Sample:
     torch or energon.
     """
 
-    def __init__(self, seq_len_q: int, *, seq_len_q_padded: int | None = None, uid: int = 0):
+    def __init__(self, seq_len_q: int, *, seq_len_q_padded: int | None = None):
         self.seq_len_q = seq_len_q
         self.seq_len_q_padded = seq_len_q_padded
-        self.uid = uid
 
     def __radd__(self, other: Any) -> int:
         if isinstance(other, int):
@@ -69,55 +49,3 @@ def test_packing_length_prefers_padded_query_length():
     """packing_length must match DiffusionSample: the padded length wins when it is set."""
     assert packing_length(_Sample(100)) == 100
     assert packing_length(_Sample(100, seq_len_q_padded=128)) == 128
-
-
-class TestDiffusionEncoderPacking:
-    """The diffusion task encoder call pattern: pack sample objects through the shared packer.
-
-    select_samples_to_pack() calls the shared first_fit_decreasing with item_lengths derived
-    from packing_length, so it is order- and identity-sensitive: it relies on which bin each
-    sample lands in. These assert full bin assignments and object identity, not just counts.
-    """
-
-    def _pack(self, samples, pack_size):
-        return first_fit_decreasing(samples, pack_size, item_lengths=[packing_length(s) for s in samples])
-
-    def test_returns_original_sample_objects(self):
-        samples = [_Sample(length, uid=i) for i, length in enumerate([5, 3, 2, 7, 4])]
-        result = self._pack(samples, 10)
-
-        assert all(isinstance(s, _Sample) for b in result for s in b)
-        # Sorted desc -> 7,5,4,3,2 (uids 3,0,4,1,2); first-fit-decreasing packs
-        # [7,3],[5,4],[2] -> uids [[3,1],[0,4],[2]].
-        assert [[s.uid for s in b] for b in result] == [[3, 1], [0, 4], [2]]
-
-    def test_uses_padded_length_for_capacity(self):
-        """Padded length drives capacity: unpadded would pack two per bin, padded does not."""
-        samples = [_Sample(100, seq_len_q_padded=128, uid=i) for i in range(3)]
-        result = self._pack(samples, 200)
-        assert all(len(b) == 1 for b in result)
-
-    @pytest.mark.parametrize("seed", range(10))
-    def test_matches_linear_scan_reference(self, seed):
-        rng = random.Random(seed)
-        pack_size = rng.choice([256, 4096, 8192])
-        lengths = [rng.randint(0, pack_size // 2 + 50) for _ in range(rng.choice([1, 40, 300]))]
-        samples = [_Sample(length, uid=i) for i, length in enumerate(lengths)]
-
-        packed_lengths = [[s.length for s in b] for b in self._pack(samples, pack_size)]
-        assert packed_lengths == _linear_scan_first_fit_decreasing(lengths, pack_size)
-
-    def test_every_sample_placed_exactly_once(self):
-        rng = random.Random(7)
-        samples = [_Sample(rng.randint(1, 2000), uid=i) for i in range(200)]
-
-        placed = sorted(s.uid for b in self._pack(samples, 4096) for s in b)
-        assert placed == list(range(200))
-
-    def test_bins_respect_capacity(self):
-        rng = random.Random(11)
-        pack_size = 4096
-        samples = [_Sample(rng.randint(1, pack_size), uid=i) for i in range(200)]
-
-        for abin in self._pack(samples, pack_size):
-            assert sum(s.length for s in abin) <= pack_size


### PR DESCRIPTION
## What does this PR do?

Follow-up to #5162. That PR shared `first_fit` between LLM offline SFT packing and diffusion, but the diffusion module `diffusion/data/common/sequence_packing_utils.py` was left carrying its own copies of `first_fit`, `first_fit_decreasing`, and a now-dead `find_first_bin_that_fits`. This removes that remaining duplication.

Diffusion packing differs from LLM offline packing in exactly one way: it packs live `DiffusionSample` **objects** during energon streaming, whereas LLM packing packs **integer lengths** offline into a materialized dataset. That difference is a data model, not an algorithm — so the algorithm should be shared and only a thin length adapter should stay diffusion-side.

The change:

- extends the shared `first_fit_decreasing` in `data/packing/algorithms.py` with the same keyword-only `item_lengths` argument `first_fit` already takes (from #5162), so it can order entries by a supplied length and return the original objects in the bins;
- keeps `item_lengths=None` meaning "each entry is its own length", so every existing integer caller (`create_packing_strategy`, `first_fit_shuffle`) is unchanged;
- routes `DiffusionTaskEncoderWithSequencePacking.select_samples_to_pack()` through the shared `first_fit_decreasing`, passing `item_lengths=[packing_length(s) for s in samples]`;
- reduces `diffusion/data/common/sequence_packing_utils.py` to its single diffusion-specific piece, `packing_length` (the `0 + item` adapter that reads `DiffusionSample.__radd__`), deleting the duplicated `first_fit`, `first_fit_decreasing`, and `find_first_bin_that_fits`.

**Bin assignments are unchanged.** The shared `first_fit_decreasing` sorts by length descending with a stable sort, which reproduces the old `sorted(samples, reverse=True)` ordering exactly (equal lengths keep original order), and `first_fit` itself is already verified equivalent to the linear scan in #5162.

## Testing

- `tests/unit_tests/data/packing/test_algorithms.py`: covers opaque-object packing, decreasing order, exact stable identity for equal lengths, object-vs-integer equivalence, randomized comparison against an independent O(N²) linear-scan reference, named empty/zero/oversized/exact-fit cases, length mismatch, and the keyword-only API.
- `tests/unit_tests/diffusion/data/common/test_sequence_packing_utils.py`: covers only the production unit that remains in that module, `packing_length`, including padded-over-unpadded precedence.
- `tests/unit_tests/diffusion/data/common/test_diffusion_task_encoder.py`: exercises the real `select_samples_to_pack()` entry point with real tensor-backed `DiffusionSample` objects. It verifies padded-length capacity, stable equal-length bin membership, original object identity, empty input, oversized samples, and deterministic outer-bin shuffling.

Verified in `nvcr.io/nvidia/nemo:26.06`:

```text
PYTHONPATH=src:3rdparty/Megatron-LM uv run --no-project python -m pytest -q \
  tests/unit_tests/data/packing/test_algorithms.py \
  tests/unit_tests/diffusion/data/common/test_sequence_packing_utils.py \
  tests/unit_tests/diffusion/data/common/test_diffusion_task_encoder.py
# 45 passed

uv run --no-project pre-commit run --all-files
# all hooks passed
```

An independent review identified and then rechecked the integration and edge-case coverage above; no actionable findings remain.

## Scope

Limited to which module owns the bin-packing algorithm. No public integer-caller signature changes incompatibly (`item_lengths` is optional and keyword-only), no dependencies added, no convergence/GPU/at-scale behavior claimed. `first_fit_shuffle` is left integer-only since no object caller needs it.

## Relationship

This is a direct follow-up to merged PR #5162.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
