### PR TITLE
[ckpt] fix: Preserve finalized checkpoint during async overlap

### DIFF
--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -1595,7 +1595,10 @@ def save_checkpoint(
 
         def cleanup_old_checkpoints_finalize_fn() -> None:
             cleanup_old_non_persistent_checkpoint(
-                save_dir, leave_ckpt_num=ckpt_cfg.most_recent_k, do_async=ckpt_cfg.async_save
+                save_dir,
+                leave_ckpt_num=ckpt_cfg.most_recent_k,
+                do_async=ckpt_cfg.async_save,
+                max_iteration=checkpoint_step,
             )
 
         assert async_save_request is not None

--- a/tests/unit_tests/training/test_checkpointing.py
+++ b/tests/unit_tests/training/test_checkpointing.py
@@ -713,6 +713,8 @@ class TestSaveCheckpoint:
     def test_async_retention_keeps_tracker_checkpoint_until_finalize(self, tmp_path, save_checkpoint_fixtures):
         """The tracker-selected checkpoint must survive until its async replacement is durable."""
         old_checkpoint = tmp_path / "iter_0000500"
+        current_checkpoint = tmp_path / "iter_0001000"
+        future_incomplete_checkpoint = tmp_path / "iter_0001500"
         old_checkpoint.mkdir()
         torch.save({"step": torch.tensor(500)}, old_checkpoint / "train_state.pt")
         latest_train_state = tmp_path / "latest_train_state.pt"
@@ -743,7 +745,7 @@ class TestSaveCheckpoint:
         async_request.add_finalize_fn.side_effect = add_finalize_fn
 
         def start_async_save(*args, **kwargs):
-            (tmp_path / "iter_0001000").mkdir(exist_ok=True)
+            current_checkpoint.mkdir(exist_ok=True)
             return async_request
 
         def run_cleanup_immediately(*, target, args):
@@ -793,12 +795,17 @@ class TestSaveCheckpoint:
 
             assert call_order == ["register_cleanup", "schedule"]
             assert old_checkpoint.is_dir()
+            assert current_checkpoint.is_dir()
             assert torch.load(latest_train_state, weights_only=True)["step"].item() == 500
 
+            # A later save can create its directory before this request finalizes.
+            future_incomplete_checkpoint.mkdir()
             for finalize_fn in finalize_fns:
                 finalize_fn()
 
         assert not old_checkpoint.exists()
+        assert current_checkpoint.is_dir()
+        assert future_incomplete_checkpoint.is_dir()
         assert torch.load(latest_train_state, weights_only=True)["step"].item() == 1000
 
     @pytest.mark.parametrize("most_recent_k", [0, 1])


### PR DESCRIPTION
## Problem

Ordinary persistent async checkpoint retention can delete the checkpoint it has just made durable when a later save is already in flight.

A supported configuration with `async_save=True`, `most_recent_k=1`, and a save cadence shorter than storage latency can enqueue step 1000 and then create the step-1500 directory before step 1000 finalizes. Step-1000 finalization advances the tracker, but retention scans every visible `iter_*` directory, keeps incomplete step 1500 as numerically newest, and deletes the tracker-selected step 1000. A crash, preemption, or failed later writer then leaves no tracker-selected durable resume point.

## Root cause and fix

The ordinary persistent retention finalizer did not pass its finalized request step to the shared cleanup helper. Global non-persistent overlap already uses that upper bound.

Pass `max_iteration=checkpoint_step` from the ordinary persistent finalizer as well. This limits retention selection to checkpoints known durable at that finalization boundary while leaving the later in-flight directory untouched.

## Regression evidence

The focused contract extends the existing async-retention test with a visible later in-flight directory.

Before the fix:

```text
Non-persistent checkpoints scheduled for removal: [iter_0000500, iter_0001000]
Non-persistent checkpoints to be kept: [iter_0001500]
AssertionError: tracker-selected iter_0001000 no longer exists
```

After the fix:

```bash
uv run python -m pytest \
  tests/unit_tests/training/test_checkpointing.py::TestSaveCheckpoint::test_async_retention_keeps_tracker_checkpoint_until_finalize \
  -q
```

Result: `1 passed`.

Focused adjacent coverage:

```bash
uv run python -m pytest \
  tests/unit_tests/training/test_checkpointing.py::TestSaveCheckpoint \
  tests/unit_tests/training/test_checkpointing.py::TestCleanupNonPersistentCheckpoints \
  tests/unit_tests/training/test_checkpointing.py::TestCheckpointManager::test_default_checkpoint_manager_finalize_async_saves \
  -q
```

Result: `16 passed`.

Also passed:

- `git diff --check`
- `uv run pre-commit run --all-files`

## Scope

This changes only ordinary persistent async retention selection. It does not change checkpoint payload formats, tracker ordering, global non-persistent behavior, local checkpoint-manager cleanup, synchronous retention, model numerics, dependencies, or public APIs. No full-suite, GPU, convergence, model-quality, or performance validation is claimed.
