### PR TITLE
feat(recipes): add DeepSeek V4 64K THD GB300 recipe

### DIFF
--- a/scripts/performance/setup_experiment.py
+++ b/scripts/performance/setup_experiment.py
@@ -155,10 +155,11 @@ def _build_nemorun_script(
 ) -> run.Script:
     """Build the rank-local task and apply optional Kubeflow NUMA binding."""
     in_container_repo_root = Path(script_dir).parents[1]
+    base_pythonpath = custom_env_vars.get("PYTHONPATH", "$PYTHONPATH")
     task = run.Script(
         path=script_path,
         entrypoint="python",
-        env={"PYTHONPATH": f"{script_dir}:{in_container_repo_root / 'src'}:$PYTHONPATH"},
+        env={"PYTHONPATH": f"{script_dir}:{in_container_repo_root / 'src'}:{base_pythonpath}"},
         args=args,
     )
     if kubeflow_namespace and _kubeflow_numa_binding_enabled(custom_env_vars):

--- a/scripts/performance/utils/overrides.py
+++ b/scripts/performance/utils/overrides.py
@@ -23,7 +23,7 @@ from megatron.bridge.recipes.deepseek.deepseek_v3 import set_deepseek_v3_pipelin
 from megatron.bridge.recipes.kimi.kimi_k2 import _get_kimi_k2_pipeline_layout
 from megatron.bridge.recipes.utils.determinism_utils import apply_determinism_overrides
 from megatron.bridge.training.comm_overlap import *
-from megatron.bridge.training.config import ConfigContainer, TokenizerConfig
+from megatron.bridge.training.config import ConfigContainer, MockVarlenDatasetConfig, TokenizerConfig
 from megatron.bridge.training.flex_dispatcher_backend import apply_flex_dispatcher_backend
 from megatron.bridge.training.utils.moe_token_drop import apply_moe_token_drop
 from megatron.bridge.training.utils.omegaconf_utils import (
@@ -510,10 +510,11 @@ def set_user_overrides(recipe: ConfigContainer, args: argparse.Namespace) -> Con
 
     # Create dataset configuration based on type
     if args.data == "mock":
-        if args.domain == "llm":
+        if args.domain == "llm" and not isinstance(recipe.dataset, MockVarlenDatasetConfig):
             # Override the dataset configuration for LLM models.
             # For vlm models, use the default dataset configuration in model recipe,
-            # becuase preprocess of dataset is different for each vlm model.
+            # because preprocessing is different for each VLM model. Preserve
+            # specialized mock datasets, such as the variable-length THD dataset.
             recipe.dataset = create_mock_dataset_config(
                 seq_length=recipe.model.seq_length,
                 num_workers=recipe.dataset.num_workers,

--- a/src/megatron/bridge/data/loaders.py
+++ b/src/megatron/bridge/data/loaders.py
@@ -22,7 +22,7 @@ from torch.utils.data import DataLoader
 
 from megatron.bridge.data.builders import GPTSFTDatasetConfig
 from megatron.bridge.data.samplers import build_pretraining_data_loader
-from megatron.bridge.training.config import ConfigContainer, GPTDatasetConfig
+from megatron.bridge.training.config import ConfigContainer, GPTDatasetConfig, MockVarlenDatasetConfig
 from megatron.bridge.training.state import TrainState
 from megatron.bridge.training.utils.sig_utils import DistributedSignalHandler
 from megatron.bridge.utils.common_utils import print_rank_0
@@ -104,6 +104,20 @@ def cyclic_iter(iter: Iterable) -> Iterator:
     while True:
         for x in iter:
             yield x
+
+
+def _identity_collate(batch: list[Any]) -> list[Any]:
+    """Keep variable-length samples as a list for MCore's packing scheduler."""
+    return batch
+
+
+def _get_collate_fn(dataset: Any, cfg: ConfigContainer) -> Callable | None:
+    """Resolve the dataset collate function for a Bridge data loader."""
+    if hasattr(dataset, "collate_fn"):
+        return dataset.collate_fn
+    if isinstance(cfg.dataset, MockVarlenDatasetConfig):
+        return _identity_collate
+    return None
 
 
 def get_train_valid_test_num_samples(cfg: ConfigContainer) -> tuple[int, int, int]:
@@ -326,7 +340,7 @@ def build_train_valid_test_data_loaders(
         cfg.dataset.num_workers,
         cfg.dataset.data_sharding,
         worker_init_fn=maybe_worker_init_fn,
-        collate_fn=train_ds.collate_fn if hasattr(train_ds, "collate_fn") else None,
+        collate_fn=_get_collate_fn(train_ds, cfg),
         pin_memory=cfg.dataset.pin_memory,
         persistent_workers=cfg.dataset.persistent_workers,
         data_parallel_rank=dp_rank,
@@ -354,7 +368,7 @@ def build_train_valid_test_data_loaders(
             cfg.dataset.num_workers,
             cfg.dataset.data_sharding,
             worker_init_fn=maybe_worker_init_fn,
-            collate_fn=valid_ds.collate_fn if hasattr(valid_ds, "collate_fn") else None,
+            collate_fn=_get_collate_fn(valid_ds, cfg),
             pin_memory=cfg.dataset.pin_memory,
             persistent_workers=cfg.dataset.persistent_workers,
             data_parallel_rank=eval_dp_rank,
@@ -372,7 +386,7 @@ def build_train_valid_test_data_loaders(
             cfg.dataset.num_workers,
             cfg.dataset.data_sharding,
             worker_init_fn=maybe_worker_init_fn,
-            collate_fn=valid_ds.collate_fn if hasattr(valid_ds, "collate_fn") else None,
+            collate_fn=_get_collate_fn(valid_ds, cfg),
             pin_memory=cfg.dataset.pin_memory,
             persistent_workers=cfg.dataset.persistent_workers,
             data_parallel_rank=eval_dp_rank,
@@ -390,7 +404,7 @@ def build_train_valid_test_data_loaders(
             cfg.dataset.num_workers,
             cfg.dataset.data_sharding,
             worker_init_fn=maybe_worker_init_fn,
-            collate_fn=test_ds.collate_fn if hasattr(test_ds, "collate_fn") else None,
+            collate_fn=_get_collate_fn(test_ds, cfg),
             pin_memory=cfg.dataset.pin_memory,
             persistent_workers=cfg.dataset.persistent_workers,
             data_parallel_rank=eval_dp_rank,

--- a/src/megatron/bridge/data/utils.py
+++ b/src/megatron/bridge/data/utils.py
@@ -35,27 +35,45 @@ from megatron.bridge.data.builders.mock_vlm_sft import (
     mock_vlm_sft_train_valid_test_datasets_provider,
 )
 from megatron.bridge.data.datasets.fim_dataset import GPTFIMDataset
-from megatron.bridge.training.config import GPTDatasetConfig, GPTFIMDatasetConfig, MockGPTDatasetConfig
+from megatron.bridge.training.config import (
+    GPTDatasetConfig,
+    GPTFIMDatasetConfig,
+    MockGPTDatasetConfig,
+    MockVarlenDatasetConfig,
+)
 from megatron.bridge.training.tokenizers.tokenizer import MegatronTokenizer
 from megatron.bridge.utils.common_utils import print_rank_0
 
 
-def is_dataset_built_on_rank(pg_collection: ProcessGroupCollection) -> bool:
+def is_dataset_built_on_rank(
+    pg_collection: ProcessGroupCollection, *, include_middle_pipeline_stages: bool = False
+) -> bool:
     """Determines whether the dataset should be built on the current rank.
 
     Datasets are typically built only on the first and last pipeline stages
     and the first tensor parallel rank to save memory and avoid redundancy.
+    Sequence-packing schedulers additionally require metadata on middle
+    pipeline stages, so those datasets are built on TP rank zero of every
+    pipeline stage.
+
+    Args:
+        pg_collection: Model-parallel process groups for the current rank.
+        include_middle_pipeline_stages: Build on every pipeline stage when
+            true, while still restricting construction to TP rank zero.
 
     Returns:
         True if the dataset should be built on the current rank, False otherwise.
     """
-    return (is_pp_first_stage(pg_collection.pp) or is_pp_last_stage(pg_collection.pp)) and (
-        pg_collection.tp.rank() == 0
+    pipeline_stage_owns_data = include_middle_pipeline_stages or (
+        is_pp_first_stage(pg_collection.pp) or is_pp_last_stage(pg_collection.pp)
     )
+    return pipeline_stage_owns_data and pg_collection.tp.rank() == 0
 
 
 def pretrain_train_valid_test_datasets_provider(
-    train_val_test_num_samples: list[int], dataset_config: BlendedMegatronDatasetConfig
+    train_val_test_num_samples: list[int],
+    dataset_config: BlendedMegatronDatasetConfig,
+    pg_collection: ProcessGroupCollection | None = None,
 ) -> tuple[GPTDataset, GPTDataset, GPTDataset]:
     """Build pretraining train, validation, and test datasets.
 
@@ -70,7 +88,16 @@ def pretrain_train_valid_test_datasets_provider(
         A tuple containing the train, validation, and test datasets.
     """
 
-    if dataset_config.mock:
+    if isinstance(dataset_config, MockVarlenDatasetConfig):
+        try:
+            from megatron.training.datasets.varlen_dataset import MockVarlenDataset
+        except ImportError as error:
+            raise RuntimeError(
+                "MockVarlenDatasetConfig requires a Megatron-Core version that provides "
+                "megatron.training.datasets.varlen_dataset.MockVarlenDataset."
+            ) from error
+        dataset_type = MockVarlenDataset
+    elif dataset_config.mock:
         dataset_type = MockGPTDataset
     elif hasattr(dataset_config, "fim_data"):
         dataset_type = GPTFIMDataset
@@ -79,9 +106,17 @@ def pretrain_train_valid_test_datasets_provider(
 
     print_rank_0("> building train, validation, and test datasets for GPT ...")
 
-    # Build the dataset on all ranks for TP-replicated loading
+    if isinstance(dataset_config, MockVarlenDatasetConfig):
+        if pg_collection is None:
+            raise ValueError("MockVarlenDatasetConfig requires pg_collection to select TP-rank dataset ownership.")
+        is_dataset_built = lambda: is_dataset_built_on_rank(  # noqa: E731
+            pg_collection, include_middle_pipeline_stages=True
+        )
+    else:
+        is_dataset_built = lambda: True  # noqa: E731
+
     train_ds, valid_ds, test_ds = BlendedMegatronDatasetBuilder(
-        dataset_type, train_val_test_num_samples, lambda: True, dataset_config
+        dataset_type, train_val_test_num_samples, is_dataset_built, dataset_config
     ).build()
 
     print_rank_0("> finished creating GPT datasets ...")

--- a/src/megatron/bridge/perf_recipes/deepseek/__init__.py
+++ b/src/megatron/bridge/perf_recipes/deepseek/__init__.py
@@ -32,6 +32,7 @@ from megatron.bridge.perf_recipes.deepseek.gb300.deepseek_v3 import (
     deepseek_v3_pretrain_256gpu_gb300_nvfp4_config,
 )
 from megatron.bridge.perf_recipes.deepseek.gb300.deepseek_v4 import (
+    deepseek_v4_pro_pretrain_64gpu_gb300_fp8mx_config,
     deepseek_v4_pro_pretrain_256gpu_gb300_fp8mx_config,
 )
 from megatron.bridge.perf_recipes.deepseek.h100.deepseek_v3 import (

--- a/src/megatron/bridge/perf_recipes/deepseek/gb300/deepseek_v4.py
+++ b/src/megatron/bridge/perf_recipes/deepseek/gb300/deepseek_v4.py
@@ -223,81 +223,32 @@ def deepseek_v4_pro_pretrain_64gpu_gb300_fp8mx_config() -> ConfigContainer:
 
 
 def deepseek_v4_pro_pretrain_256gpu_gb300_fp8mx_config() -> ConfigContainer:
-    """DeepSeek V4 Pro pretrain: 256× GB300, MXFP8, dev Megatron-Core required."""
-    cfg = deepseek_v4_pro_pretrain_32gpu_gb300_fp8mx_config()
+    """DeepSeek V4 Pro full model: 64K THD/CP training on 256 GB300 GPUs."""
+    cfg = deepseek_v4_pro_pretrain_64gpu_gb300_fp8mx_config()
 
-    cfg.model.tensor_model_parallel_size = 1
+    cfg.model.num_layers = 61
+    cfg.model.moe_layer_freq = [1] * cfg.model.num_layers
+    cfg.model.csa_compress_ratios = [128, 128, 4, *([128, 4] * 29), 0]
+    cfg.model.moe_n_hash_layers = 3
+    cfg.model.activation_func_clamp_value = 10.0
     cfg.model.pipeline_model_parallel_size = 4
     cfg.model.virtual_pipeline_model_parallel_size = 4
-    cfg.model.context_parallel_size = 1
-    cfg.model.expert_model_parallel_size = 64
-    cfg.model.expert_tensor_parallel_size = 1
-    cfg.model.sequence_parallel = False
-    cfg.train.global_batch_size = 4096
-    cfg.train.micro_batch_size = 1
-
-    cfg.model.moe_flex_dispatcher_backend = "hybridep"
-    cfg.model.moe_token_dispatcher_type = "flex"
-    cfg.model.moe_shared_expert_overlap = False
-    cfg.model.pipeline_model_parallel_layout = "Et*4|(tttt|)*14tmL"
+    cfg.model.pipeline_model_parallel_layout = "Et*4|(t*4|)*14tmL"
     cfg.model.recompute_granularity = "selective"
     cfg.model.recompute_modules = ["mla_up_proj", "mhc"]
-
-    _benchmark_common(cfg, cross_entropy_impl="native")
-
-    cfg.model.cuda_graph_impl = "full_iteration"
-    cfg.model.cuda_graph_scope = []
-    cfg.model.cuda_graph_warmup_steps = 3
-    cfg.model.use_te_rng_tracker = True
-    cfg.rng.te_rng_tracker = True
-
-    cfg.model.moe_pad_experts_for_cuda_graph_inference = True
-    cfg.model.moe_paged_stash = True
-    cfg.model.moe_expert_rank_capacity_factor = 1.5
-    cfg.model.moe_paged_stash_buffer_size_factor_cuda = 1.2
-    cfg.model.moe_paged_stash_buffer_size_factor_cpu = 0.0
-
-    cfg.model.moe_router_force_load_balancing = True
-    cfg.model.apply_dsa_kernel_fusion = True
-    cfg.model.use_transformer_engine_op_fuser = True
-    cfg.model.cross_entropy_loss_fusion = True
-    cfg.model.cross_entropy_fusion_impl = "native"
-    cfg.model.moe_mlp_glu_interleave_size = 32
-
-    cfg.model.quant_recipe = None
-    cfg.mixed_precision.fp8_param_gather = True
-    cfg.mixed_precision.reuse_grad_buf_for_mxfp8_param_ag = True
-    cfg.mixed_precision.grad_reduce_in_fp32 = False
-
-    cfg.model.dsa_indexer_loss_coeff = 0.01
-    cfg.model.dsa_indexer_use_sparse_loss = True
-
-    cfg.optimizer.main_grads_dtype = torch.bfloat16
-    cfg.dist.enable_megatron_core_experimental = True
-    cfg.ddp.grad_reduce_in_fp32 = False
 
     cfg.model.fine_grained_activation_offloading = True
     cfg.model.offload_modules = ["core_attn", "attn_proj"]
     cfg.model.fine_grained_offloading_max_inflight_offloads = 2
-    cfg.comm_overlap.overlap_grad_reduce = True
-
-    cfg.env_vars = {
-        **COMMON_PERF_ENV_VARS,
-        "CUDA_DEVICE_MAX_CONNECTIONS": 32,
-        "NCCL_GRAPH_REGISTER": 0,
-        "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True,graph_capture_record_stream_reuse:True",
-        "TORCH_NCCL_AVOID_RECORD_STREAMS": 0,
-        "NCCL_NVLS_ENABLE": 0,
-        "NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN": 64,
-        "NUM_OF_TOKENS_PER_CHUNK_COMBINE_API": 128,
-        "NVLINK_DOMAIN_SIZE": 72,
-        "USE_MNNVL": 1,
-        "NVTE_BWD_LAYERNORM_SM_MARGIN": 20,
-        "NVTE_CPU_OFFLOAD_V1": 1,
-        "NVTE_CUTEDSL_FUSED_GROUPED_MLP": 1,
-        "NVTE_FWD_LAYERNORM_SM_MARGIN": 20,
-        "NVTE_NORM_BWD_USE_CUDNN": 1,
-        "NVTE_NORM_FWD_USE_CUDNN": 1,
-        "NVTE_ALLOW_NONDETERMINISTIC_ALGO": 0,
-    }
+    cfg.env_vars.update(
+        {
+            "CUDA_DEVICE_MAX_CONNECTIONS": 32,
+            "NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN": 64,
+            "NVLINK_DOMAIN_SIZE": 72,
+            "USE_MNNVL": 1,
+            "NVTE_BWD_LAYERNORM_SM_MARGIN": 20,
+            "NVTE_CPU_OFFLOAD_V1": 1,
+            "NVTE_FWD_LAYERNORM_SM_MARGIN": 20,
+        }
+    )
     return cfg

--- a/src/megatron/bridge/perf_recipes/deepseek/gb300/deepseek_v4.py
+++ b/src/megatron/bridge/perf_recipes/deepseek/gb300/deepseek_v4.py
@@ -166,15 +166,7 @@ def deepseek_v4_pro_pretrain_64gpu_gb300_fp8mx_config() -> ConfigContainer:
 
     _benchmark_common(cfg, cross_entropy_impl="native")
 
-    # Restore the sample-based schedule after applying the benchmark defaults.
-    cfg.train.train_iters = None
-    cfg.train.train_samples = 585_937_500
-    cfg.scheduler.lr_decay_iters = None
-    cfg.scheduler.lr_decay_samples = 584_765_624
-    cfg.scheduler.lr_warmup_iters = 0
-    cfg.scheduler.lr_warmup_samples = 1_536_000
     cfg.model.use_transformer_engine_op_fuser = True
-    cfg.train.exit_interval = 30
     cfg.train.manual_gc_interval = 10
     cfg.model.cuda_graph_impl = "transformer_engine"
     cfg.model.cuda_graph_scope = ["attn", "moe_router", "moe_preprocess"]

--- a/src/megatron/bridge/perf_recipes/deepseek/gb300/deepseek_v4.py
+++ b/src/megatron/bridge/perf_recipes/deepseek/gb300/deepseek_v4.py
@@ -129,7 +129,7 @@ def deepseek_v4_pro_pretrain_64gpu_gb300_fp8mx_config() -> ConfigContainer:
     cfg.model.offload_modules = []
 
     opt_cfg, scheduler_cfg = distributed_muon_with_cosine_annealing(
-        muon_momentum=0.9,
+        muon_momentum=0.95,
         muon_use_nesterov=False,
         muon_scale_mode="spectral",
         muon_fp32_matmul_prec="medium",
@@ -137,10 +137,10 @@ def deepseek_v4_pro_pretrain_64gpu_gb300_fp8mx_config() -> ConfigContainer:
         muon_tp_mode="blockwise",
         muon_extra_scale_factor=1.0,
         muon_scalar_optimizer="adam",
-        lr_warmup_iters=10,
+        lr_warmup_iters=0,
         lr_decay_iters=50,
-        max_lr=3.9e-6,
-        min_lr=3.9e-7,
+        max_lr=2e-4,
+        min_lr=2e-5,
         weight_decay=0.1,
         clip_grad=1.0,
     )
@@ -151,13 +151,13 @@ def deepseek_v4_pro_pretrain_64gpu_gb300_fp8mx_config() -> ConfigContainer:
     opt_cfg.overlap_param_gather = True
     opt_cfg.muon_coefficient_type = "quintic"
     opt_cfg.adam_beta1 = 0.9
-    opt_cfg.adam_beta2 = 0.95
+    opt_cfg.adam_beta2 = 0.999
     opt_cfg.main_grads_dtype = torch.float32
     opt_cfg.main_params_dtype = torch.float32
     opt_cfg.exp_avg_dtype = torch.float32
     opt_cfg.exp_avg_sq_dtype = torch.float32
     opt_cfg.use_precision_aware_optimizer = False
-    scheduler_cfg.lr_warmup_init = 3.9e-7
+    scheduler_cfg.lr_warmup_init = 2e-5
     scheduler_cfg.start_weight_decay = 0.1
     scheduler_cfg.end_weight_decay = 0.1
 

--- a/src/megatron/bridge/perf_recipes/deepseek/gb300/deepseek_v4.py
+++ b/src/megatron/bridge/perf_recipes/deepseek/gb300/deepseek_v4.py
@@ -197,7 +197,7 @@ def deepseek_v4_pro_pretrain_64gpu_gb300_fp8mx_config() -> ConfigContainer:
     cfg.comm_overlap.overlap_param_gather = True
     cfg.comm_overlap.overlap_moe_expert_parallel_comm = False
     cfg.comm_overlap.delay_wgrad_compute = False
-    cfg.optimizer.optimizer_offload_fraction = 1.0
+    cfg.optimizer.optimizer_offload_fraction = 0.0
     cfg.optimizer.barrier_with_L1_time = True
 
     cfg.env_vars = {

--- a/src/megatron/bridge/perf_recipes/deepseek/gb300/deepseek_v4.py
+++ b/src/megatron/bridge/perf_recipes/deepseek/gb300/deepseek_v4.py
@@ -20,7 +20,206 @@ from megatron.bridge.perf_recipes.environment import COMMON_PERF_ENV_VARS
 from megatron.bridge.recipes.deepseek.gb300.deepseek_v4 import (
     deepseek_v4_pro_pretrain_32gpu_gb300_fp8mx_config,
 )
-from megatron.bridge.training.config import ConfigContainer
+from megatron.bridge.recipes.utils.optimizer_utils import distributed_muon_with_cosine_annealing
+from megatron.bridge.training.config import ConfigContainer, MockVarlenDatasetConfig
+
+
+def deepseek_v4_pro_pretrain_64gpu_gb300_fp8mx_config() -> ConfigContainer:
+    """DeepSeek V4 Pro proxy: 64K THD/CP training on 64 GB300 GPUs with MXFP8."""
+    cfg = deepseek_v4_pro_pretrain_32gpu_gb300_fp8mx_config()
+
+    cfg.model.num_layers = 15
+    cfg.model.moe_layer_freq = [1] * cfg.model.num_layers
+    cfg.model.num_moe_experts = 384
+    cfg.model.tensor_model_parallel_size = 1
+    cfg.model.pipeline_model_parallel_size = 1
+    cfg.model.virtual_pipeline_model_parallel_size = None
+    cfg.model.pipeline_model_parallel_layout = None
+    cfg.model.context_parallel_size = 16
+    cfg.model.expert_model_parallel_size = 64
+    cfg.model.expert_tensor_parallel_size = 1
+    cfg.model.sequence_parallel = False
+
+    cfg.model.seq_length = 65_536
+    cfg.model.max_position_embeddings = 65_536
+    cfg.model.original_max_position_embeddings = 4096
+    cfg.model.vocab_size = 129_280
+    cfg.model.actual_vocab_size = 129_280
+    cfg.model.make_vocab_size_divisible_by = 3232
+    cfg.model.q_lora_rank = 1536
+    cfg.model.o_groups = 16
+    cfg.model.o_lora_rank = 1024
+    cfg.model.csa_compress_ratios = [128, 128, 4, *([128, 4] * 6), 0]
+    cfg.model.csa_compress_rotary_base = 40_000.0
+    cfg.model.csa_window_size = 128
+    cfg.model.rotary_scaling_factor = 4.0
+    cfg.model.dsa_indexer_n_heads = 64
+    cfg.model.dsa_indexer_head_dim = 128
+    cfg.model.moe_n_hash_layers = 0
+    cfg.model.mtp_num_layers = 1
+    cfg.model.mtp_loss_scaling_factor = 0.1
+    cfg.tokenizer.vocab_size = 129_280
+    cfg.tokenizer.make_vocab_size_divisible_by = 3232
+    cfg.tokenizer.tensor_model_parallel_size = 1
+
+    cfg.dataset = MockVarlenDatasetConfig(
+        random_seed=1234,
+        reset_attention_mask=False,
+        reset_position_ids=False,
+        eod_mask_loss=False,
+        seq_length=65_536,
+        num_dataset_builder_threads=1,
+        split="99,1,0",
+        data_sharding=True,
+        dataloader_type="single",
+        num_workers=0,
+        skip_getting_attention_mask_from_dataset=True,
+        data_parallel_size=4,
+        context_parallel_size=16,
+        sequence_parallel_size=0,
+        varlen_mock_dataset_config_json=(
+            '{"mode":"distribution","type":"lognormal","format":"thd",'
+            '"min_seq_len":65534,"max_seq_len":65534,"mean_seq_len":65534,'
+            '"lognormal_sigma":1.1}'
+        ),
+    )
+    cfg.train.global_batch_size = 256
+    cfg.train.micro_batch_size = 1
+
+    cfg.model.sequence_packing_scheduler = "dp_balanced"
+    cfg.model.max_seqlen_per_dp_cp_rank = 4096
+    cfg.model.pad_packed_seq_alignment = "max"
+    cfg.model.thd_max_packed_sequences = 8
+    cfg.model.cp_partition_mode = "contiguous"
+    cfg.model.calculate_per_token_loss = True
+
+    cfg.model.moe_flex_dispatcher_backend = "hybridep"
+    cfg.model.moe_token_dispatcher_type = "flex"
+    cfg.model.moe_hybridep_num_sms = 32
+    cfg.model.moe_shared_expert_overlap = False
+    cfg.model.moe_grouped_gemm = True
+    cfg.model.moe_permute_fusion = True
+    cfg.model.moe_router_force_load_balancing = True
+    cfg.model.moe_router_load_balancing_type = "seq_aux_loss"
+    cfg.model.moe_aux_loss_coeff = 1.0e-4
+    cfg.model.moe_router_topk_scaling_factor = 2.5
+    cfg.model.moe_router_score_function = "sqrtsoftplus"
+    cfg.model.moe_router_enable_expert_bias = True
+    cfg.model.moe_router_bias_update_rate = 1.0e-3
+    cfg.model.moe_router_dtype = "fp32"
+    cfg.model.moe_router_fusion = True
+    cfg.model.moe_expert_rank_capacity_factor = 1.5
+    cfg.model.moe_pad_experts_for_cuda_graph_inference = True
+    cfg.model.moe_paged_stash = False
+    cfg.model.moe_router_padding_for_fp8 = False
+    cfg.model.moe_router_padding_for_quantization = True
+    cfg.model.moe_mlp_glu_interleave_size = 32
+    cfg.model.activation_func_clamp_value = None
+
+    cfg.model.apply_dsa_kernel_fusion = True
+    cfg.model.dsa_indexer_topk = 1024
+    cfg.model.dsa_indexer_loss_coeff = 0.01
+    cfg.model.dsa_indexer_use_sparse_loss = True
+    cfg.model.use_fused_mhc = True
+    cfg.model.cross_entropy_loss_fusion = True
+    cfg.model.cross_entropy_fusion_impl = "native"
+    cfg.model.recompute_granularity = "selective"
+    cfg.model.recompute_modules = ["mla_up_proj", "mhc"]
+    cfg.model.fine_grained_activation_offloading = False
+    cfg.model.offload_modules = []
+
+    opt_cfg, scheduler_cfg = distributed_muon_with_cosine_annealing(
+        muon_momentum=0.9,
+        muon_use_nesterov=False,
+        muon_scale_mode="spectral",
+        muon_fp32_matmul_prec="medium",
+        muon_num_ns_steps=5,
+        muon_tp_mode="blockwise",
+        muon_extra_scale_factor=1.0,
+        muon_scalar_optimizer="adam",
+        lr_warmup_iters=10,
+        lr_decay_iters=50,
+        max_lr=3.9e-6,
+        min_lr=3.9e-7,
+        weight_decay=0.1,
+        clip_grad=1.0,
+    )
+    opt_cfg.optimizer = "muon"
+    opt_cfg.use_distributed_optimizer = False
+    opt_cfg.use_layer_wise_distributed_optimizer = True
+    opt_cfg.use_layer_wise_param_layout = False
+    opt_cfg.overlap_param_gather = True
+    opt_cfg.muon_coefficient_type = "quintic"
+    opt_cfg.adam_beta1 = 0.9
+    opt_cfg.adam_beta2 = 0.95
+    opt_cfg.main_grads_dtype = torch.float32
+    opt_cfg.main_params_dtype = torch.float32
+    opt_cfg.exp_avg_dtype = torch.float32
+    opt_cfg.exp_avg_sq_dtype = torch.float32
+    opt_cfg.use_precision_aware_optimizer = False
+    scheduler_cfg.lr_warmup_init = 3.9e-7
+    scheduler_cfg.start_weight_decay = 0.1
+    scheduler_cfg.end_weight_decay = 0.1
+
+    cfg.optimizer = opt_cfg
+    cfg.scheduler = scheduler_cfg
+
+    _benchmark_common(cfg, cross_entropy_impl="native")
+
+    # Restore the sample-based schedule after applying the benchmark defaults.
+    cfg.train.train_iters = None
+    cfg.train.train_samples = 585_937_500
+    cfg.scheduler.lr_decay_iters = None
+    cfg.scheduler.lr_decay_samples = 584_765_624
+    cfg.scheduler.lr_warmup_iters = 0
+    cfg.scheduler.lr_warmup_samples = 1_536_000
+    cfg.model.use_transformer_engine_op_fuser = True
+    cfg.train.exit_interval = 30
+    cfg.train.manual_gc_interval = 10
+    cfg.model.cuda_graph_impl = "transformer_engine"
+    cfg.model.cuda_graph_scope = ["attn", "moe_router", "moe_preprocess"]
+    cfg.model.cuda_graph_warmup_steps = 1
+    cfg.model.use_te_rng_tracker = True
+    cfg.rng.te_rng_tracker = True
+    cfg.model.quant_recipe = None
+
+    cfg.mixed_precision.fp8_param_gather = True
+    cfg.mixed_precision.reuse_grad_buf_for_mxfp8_param_ag = True
+    cfg.mixed_precision.grad_reduce_in_fp32 = True
+    cfg.ddp.use_distributed_optimizer = True
+    cfg.ddp.overlap_param_gather = True
+    cfg.ddp.overlap_grad_reduce = True
+    cfg.ddp.grad_reduce_in_fp32 = True
+    cfg.ddp.check_for_nan_in_grad = True
+    cfg.ddp.average_in_collective = False
+    cfg.ddp.data_parallel_sharding_strategy = "optim_grads_params"
+    cfg.comm_overlap.overlap_grad_reduce = True
+    cfg.comm_overlap.overlap_param_gather = True
+    cfg.comm_overlap.overlap_moe_expert_parallel_comm = False
+    cfg.comm_overlap.delay_wgrad_compute = False
+    cfg.optimizer.optimizer_offload_fraction = 1.0
+    cfg.optimizer.barrier_with_L1_time = True
+
+    cfg.env_vars = {
+        **COMMON_PERF_ENV_VARS,
+        "NCCL_BUFFSIZE": 4_194_304,
+        "NCCL_GRAPH_REGISTER": 0,
+        "NCCL_NET_GDR_C2C": 1,
+        "NCCL_NET_GDR_LEVEL": "PHB",
+        "NCCL_NVLS_ENABLE": 0,
+        "NUM_OF_TOKENS_PER_CHUNK_COMBINE_API": 128,
+        "NVTE_ALLOW_NONDETERMINISTIC_ALGO": 1,
+        "NVTE_BWD_LAYERNORM_SM_MARGIN": 0,
+        "NVTE_CPU_OFFLOAD_V1": 0,
+        "NVTE_CUTEDSL_FUSED_GROUPED_MLP": 1,
+        "NVTE_FUSED_ATTN": 1,
+        "NVTE_FWD_LAYERNORM_SM_MARGIN": 0,
+        "NVTE_NORM_BWD_USE_CUDNN": 1,
+        "NVTE_NORM_FWD_USE_CUDNN": 1,
+        "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True,graph_capture_record_stream_reuse:True",
+        "TORCH_NCCL_AVOID_RECORD_STREAMS": 0,
+    }
+    return cfg
 
 
 def deepseek_v4_pro_pretrain_256gpu_gb300_fp8mx_config() -> ConfigContainer:

--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -387,6 +387,33 @@ class MockGPTDatasetConfig(GPTDatasetConfig):
         return super().finalize()
 
 
+@dataclass
+class MockVarlenDatasetConfig(MockGPTDatasetConfig):
+    """Configuration for MCore's mock variable-length THD dataset.
+
+    This dataset emits one unpacked variable-length sample at a time. A
+    Megatron-Core sequence-packing scheduler packs those samples into THD
+    microbatches at training time.
+    """
+
+    varlen_mock_dataset_config_json: str | None = None
+    """JSON string or path describing the mock sequence-length distribution."""
+
+    varlen_sbhd_validation: bool = False
+    """Whether to emit the fixed-width SBHD validation format instead of THD."""
+
+    def __init__(
+        self,
+        seq_length: int,
+        varlen_mock_dataset_config_json: str | None = None,
+        varlen_sbhd_validation: bool = False,
+        **kwargs,
+    ):
+        super().__init__(seq_length=seq_length, **kwargs)
+        self.varlen_mock_dataset_config_json = varlen_mock_dataset_config_json
+        self.varlen_sbhd_validation = varlen_sbhd_validation
+
+
 @dataclass(kw_only=True)
 class SchedulerConfig(MTrainSchedulerConfig):
     """Configuration settings for the learning rate scheduler and weight decay."""
@@ -1913,15 +1940,20 @@ def _validate_and_sync_distributed_optimizer_settings(config: ConfigContainer) -
 
     This function ensures that distributed optimizer settings are consistent across
     DDP and optimizer configurations. If either setting is enabled, both will be
-    enabled to maintain consistency.
+    enabled to maintain consistency. Decoupled layer-wise optimizers are the one
+    intentional exception: DDP uses distributed parameter and gradient buffers,
+    while the conventional distributed optimizer remains disabled.
 
     Args:
         config: The configuration container to validate and potentially modify.
     """
     ddp_setting = config.ddp.use_distributed_optimizer
     optimizer_setting = config.optimizer.use_distributed_optimizer
+    uses_decoupled_layer_wise_optimizer = (
+        config.optimizer.use_layer_wise_distributed_optimizer and ddp_setting and not optimizer_setting
+    )
 
-    if ddp_setting or optimizer_setting:
+    if not uses_decoupled_layer_wise_optimizer and (ddp_setting or optimizer_setting):
         if ddp_setting != optimizer_setting:
             warn_rank_0(
                 f"Distributed optimizer settings were not in sync: "

--- a/src/megatron/bridge/training/gpt_step.py
+++ b/src/megatron/bridge/training/gpt_step.py
@@ -20,6 +20,7 @@ import modelopt.torch.distill as mtd
 import torch
 from megatron.core import parallel_state
 from megatron.core.models.gpt import GPTModel
+from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.pipeline_parallel.utils import (
     is_pp_first_stage,
     is_pp_last_stage,
@@ -285,7 +286,8 @@ def get_batch(
     torch.Tensor,
     torch.Tensor,
     torch.Tensor,
-    dict[str, _PackedMetadataValue] | None,
+    dict[str, _PackedMetadataValue] | PackedSeqParams | None,
+    torch.Tensor | None,
 ]:
     """Generate a batch.
 
@@ -297,7 +299,8 @@ def get_batch(
 
     Returns:
         tuple of tensors containing tokens, labels, loss_mask, attention_mask,
-        position_ids, and optional packed-sequence metadata.
+        position_ids, optional packed-sequence metadata, and an optional
+        padding mask.
     """
     # Determine pipeline stage role via process group collection
     model_cfg = getattr(cfg, "model", None)
@@ -313,8 +316,30 @@ def get_batch(
     include_mtp_inputs = use_mtp and _current_stage_needs_mtp_inputs_from_layout(
         cfg, pg_collection=pg_collection, is_last=is_last, vp_stage=vp_stage
     )
+
+    if getattr(model_cfg, "sequence_packing_scheduler", None) is not None:
+        try:
+            from megatron.core.datasets.data_schedule import get_batch_on_this_rank_for_sequence_packing
+        except ImportError as error:
+            raise RuntimeError(
+                "Sequence-packing schedulers require a Megatron-Core version that provides "
+                "get_batch_on_this_rank_for_sequence_packing."
+            ) from error
+
+        tokens, labels, loss_mask, attention_mask, position_ids, packed_seq_params, padding_mask = (
+            get_batch_on_this_rank_for_sequence_packing(
+                data_iterator,
+                vpp_size=vp_size,
+                mtp_on_this_rank=include_mtp_inputs,
+                vp_stage=vp_stage,
+                pg_collection=pg_collection,
+                config=model_cfg,
+            )
+        )
+        return tokens, labels, loss_mask, attention_mask, position_ids, packed_seq_params, padding_mask
+
     if is_middle and not include_full_batch_fields and not include_mtp_inputs:
-        return None, None, None, None, None, None
+        return None, None, None, None, None, None, None
 
     batch = get_batch_from_iterator(
         data_iterator,
@@ -344,6 +369,7 @@ def get_batch(
         ),  # Attention_mask is optional for pre-training as a casual mask is generated automatically.
         batch["position_ids"],
         _packed_metadata_for_forward(batch),
+        None,
     )
 
 
@@ -378,6 +404,7 @@ def _forward_step_common(
             attention_mask,
             position_ids,
             packed_seq_metadata,
+            padding_mask,
         ) = get_batch(
             data_iterator,
             state.cfg,
@@ -402,7 +429,7 @@ def _forward_step_common(
     cu_seqlens_argmin = None
     cu_seqlens_unpadded = None
     cu_seqlens_unpadded_argmin = None
-    if packed_seq_metadata is not None:
+    if isinstance(packed_seq_metadata, dict):
         if packed_seq_metadata.get("cu_seqlens_q") is not None:
             cu_seqlens_q = packed_seq_metadata.get("cu_seqlens_q")
             cu_seqlens_q_padded = packed_seq_metadata.get("cu_seqlens_q_padded")
@@ -432,7 +459,7 @@ def _forward_step_common(
     }
 
     # Add packed sequence support
-    if packed_seq_metadata is not None:
+    if isinstance(packed_seq_metadata, dict):
         # total_tokens drives seq_idx computation in PackedSeqParams.__post_init__,
         # which is only needed for Mamba/hybrid SSM layers. Skip it for pure
         # transformer models to avoid per-step CUDA overhead.
@@ -444,6 +471,10 @@ def _forward_step_common(
             else:
                 packed_seq_metadata["total_tokens"] = getattr(config, "seq_length", None)
         forward_args["packed_seq_params"] = get_packed_seq_params(packed_seq_metadata)
+    elif packed_seq_metadata is not None:
+        forward_args["packed_seq_params"] = packed_seq_metadata
+    if padding_mask is not None:
+        forward_args["padding_mask"] = padding_mask
 
     with straggler_timer:
         if return_schedule_plan:

--- a/src/megatron/bridge/training/setup.py
+++ b/src/megatron/bridge/training/setup.py
@@ -28,7 +28,7 @@ from megatron.core.optimizer_param_scheduler import OptimizerParamScheduler
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.rerun_state_machine import RerunDataIterator
 from megatron.core.transformer import MegatronModule
-from megatron.training.models.base import ModelConfig
+from megatron.training.models.base import ModelConfig, compose_hooks
 
 from megatron.bridge.data.loaders import build_train_valid_test_datasets_for_num_epochs, setup_data_iterators
 from megatron.bridge.models.gpt.gpt_builder import GPTModelConfig
@@ -113,9 +113,7 @@ def _should_load_checkpoint(cfg: ConfigContainer, checkpoint_manager: Checkpoint
         "local_checkpoint_manager" in checkpointing_context
         and checkpointing_context["local_checkpoint_manager"].find_latest() != -1
     )
-    has_global_non_persistent_checkpoint = _has_global_non_persistent_checkpoint(
-        cfg.checkpoint.load, cfg.checkpoint
-    )
+    has_global_non_persistent_checkpoint = _has_global_non_persistent_checkpoint(cfg.checkpoint.load, cfg.checkpoint)
 
     if cfg.peft is not None:
         load_checkpoint_exists = cfg.checkpoint.load is not None and (
@@ -313,9 +311,7 @@ def setup(
                 checkpoint_path = cfg.checkpoint.pretrained_checkpoint
                 ckpt_step = None
             else:
-                raise RuntimeError(
-                    "No checkpoint source is available for ModelOpt state restoration"
-                )
+                raise RuntimeError("No checkpoint source is available for ModelOpt state restoration")
 
             if not has_modelopt_state(checkpoint_path, ckpt_step=ckpt_step):
                 raise RuntimeError(f"No modelopt_state found in selected checkpoint={checkpoint_path}")
@@ -475,12 +471,97 @@ def _register_pre_wrap_hook(model_cfg: ModelConfig | ModelProviderMixin, hook):
         model_cfg.register_pre_wrap_hook(hook)
 
 
+def _wrap_model_chunks_with_layer_wise_ddp(
+    cfg: ConfigContainer,
+    model: list[MegatronModule],
+    pg_collection: ProcessGroupCollection,
+) -> list[MegatronModule]:
+    """Wrap prepared model chunks with MCore's layer-wise optimizer DDP layout."""
+    from megatron.training.training import resolve_ddp_bucket_size, wrap_model_chunks_with_ddp
+
+    if cfg.dist.use_megatron_fsdp or cfg.dist.use_torch_fsdp2:
+        raise ValueError("Layer-wise distributed optimizer is only supported with Megatron DDP")
+
+    num_parameters = sum(sum(parameter.nelement() for parameter in model_chunk.parameters()) for model_chunk in model)
+    cfg.ddp.bucket_size = resolve_ddp_bucket_size(
+        cfg.ddp,
+        pg_collection.dp_cp,
+        cfg.ddp.overlap_grad_reduce,
+        num_parameters,
+    )
+
+    disable_bucketing_per_chunk = [
+        (chunk_idx > 0) or cfg.optimizer.overlap_param_gather_with_optimizer_step for chunk_idx in range(len(model))
+    ]
+    pp_rank = pg_collection.pp.rank()
+    bucket_sizes = [
+        None if (disable_bucketing or pp_rank > 0) else cfg.ddp.bucket_size
+        for disable_bucketing in disable_bucketing_per_chunk
+    ]
+
+    ddp_stream = torch.cuda.Stream()
+    ddp_stream.wait_stream(torch.cuda.current_stream())
+    cfg.ddp.use_layer_wise_param_layout = cfg.optimizer.use_layer_wise_param_layout
+    wrap_kwargs = {
+        "use_layer_wise_distributed_optimizer": True,
+        "pg_collection": pg_collection if cfg.dist.use_decentralized_pg else None,
+        "bucket_sizes": bucket_sizes,
+        "disable_bucketing_per_chunk": disable_bucketing_per_chunk,
+    }
+    # Support MCore versions that expose this setting as a helper argument.
+    if "use_layer_wise_param_layout" in inspect.signature(wrap_model_chunks_with_ddp).parameters:
+        wrap_kwargs["use_layer_wise_param_layout"] = cfg.optimizer.use_layer_wise_param_layout
+    transformer_config = cfg.model.transformer if isinstance(cfg.model, ModelConfig) else cfg.model
+    with torch.cuda.stream(ddp_stream):
+        model = wrap_model_chunks_with_ddp(
+            model,
+            transformer_config,
+            cfg.ddp,
+            **wrap_kwargs,
+        )
+    torch.cuda.current_stream().wait_stream(ddp_stream)
+
+    if cfg.rng.data_parallel_random_init:
+        for model_chunk in model:
+            model_chunk.broadcast_params()
+
+    return model
+
+
 def _build_distributed_model(cfg: ConfigContainer, pg_collection: ProcessGroupCollection) -> list[MegatronModule]:
     """Build distributed model from either ModelConfig or ModelProviderMixin."""
     model_config = cfg.model
     if isinstance(model_config, ModelConfig):
         builder_cls = model_config.get_builder_cls()
         builder = builder_cls(model_config)
+        if cfg.optimizer.use_layer_wise_distributed_optimizer:
+            # ModelBuilder's default DDP path computes a conventional distributed-
+            # optimizer layout. Build through mixed precision without DDP, then use
+            # the same layer-wise DDP wrapper as MCore's direct training entrypoint.
+            post_wrap_hooks = list(model_config.post_wrap_hooks)
+            model_config.post_wrap_hooks.clear()
+            try:
+                model = builder.build_distributed_models(
+                    pg_collection=pg_collection,
+                    ddp_config=cfg.ddp,
+                    overlap_param_gather_with_optimizer_step=cfg.optimizer.overlap_param_gather_with_optimizer_step,
+                    use_megatron_fsdp=False,
+                    use_torch_fsdp2=False,
+                    wrap_with_ddp=False,
+                    data_parallel_random_init=False,
+                )
+            finally:
+                model_config.post_wrap_hooks.extend(post_wrap_hooks)
+
+            model = _wrap_model_chunks_with_layer_wise_ddp(cfg, model, pg_collection)
+            post_wrap_hook = compose_hooks(post_wrap_hooks)
+            hooked_model = post_wrap_hook(model)
+            if hooked_model is not None:
+                model = hooked_model
+            else:
+                logging.getLogger(__name__).warning("Final post wrap hook returned None, skipping post wrap hooks.")
+            return model
+
         return builder.build_distributed_models(
             pg_collection=pg_collection,
             ddp_config=cfg.ddp,
@@ -490,14 +571,36 @@ def _build_distributed_model(cfg: ConfigContainer, pg_collection: ProcessGroupCo
             data_parallel_random_init=cfg.rng.data_parallel_random_init,
         )
     else:
-        return model_config.provide_distributed_model(
+        if not cfg.optimizer.use_layer_wise_distributed_optimizer:
+            return model_config.provide_distributed_model(
+                ddp_config=cfg.ddp,
+                use_megatron_fsdp=cfg.dist.use_megatron_fsdp,
+                use_torch_fsdp2=cfg.dist.use_torch_fsdp2,
+                overlap_param_gather_with_optimizer_step=cfg.optimizer.overlap_param_gather_with_optimizer_step,
+                data_parallel_random_init=cfg.rng.data_parallel_random_init,
+                pg_collection=pg_collection,
+            )
+
+        # The deprecated provider path has the same conventional-DDP limitation
+        # as ModelBuilder. Override its post hook with an identity until after
+        # the layer-wise DDP wrapper has been applied.
+        post_wrap_hook = model_config.post_wrap_hook
+        model = model_config.provide_distributed_model(
             ddp_config=cfg.ddp,
-            use_megatron_fsdp=cfg.dist.use_megatron_fsdp,
-            use_torch_fsdp2=cfg.dist.use_torch_fsdp2,
+            use_megatron_fsdp=False,
+            use_torch_fsdp2=False,
             overlap_param_gather_with_optimizer_step=cfg.optimizer.overlap_param_gather_with_optimizer_step,
-            data_parallel_random_init=cfg.rng.data_parallel_random_init,
+            wrap_with_ddp=False,
+            data_parallel_random_init=False,
+            post_wrap_hook=lambda model: model,
             pg_collection=pg_collection,
         )
+        model = _wrap_model_chunks_with_layer_wise_ddp(cfg, model, pg_collection)
+        if post_wrap_hook is not None:
+            hooked_model = post_wrap_hook(model)
+            if hooked_model is not None:
+                model = hooked_model
+        return model
 
 
 def _update_model_config_funcs(

--- a/src/megatron/bridge/training/train.py
+++ b/src/megatron/bridge/training/train.py
@@ -256,6 +256,7 @@ def train(
         config.ddp.use_megatron_fsdp,
         config.optimizer.use_distributed_optimizer,
         config.ddp.overlap_param_gather,
+        config.optimizer.use_layer_wise_distributed_optimizer,
     )
     # Also, check weight hash across DP replicas to be very pedantic.
     if train_config.check_weight_hash_across_dp_replicas_interval is not None:
@@ -807,6 +808,29 @@ def train(
         )
 
 
+def _wrap_sequence_packing_data_iterator(
+    data_iterator,
+    model_config,
+    num_microbatches: int,
+    pg_collection: ProcessGroupCollection,
+):
+    """Run MCore's per-global-batch THD sequence-packing scheduler."""
+    try:
+        from megatron.core.datasets.data_schedule import wrap_data_iterator
+    except ImportError as error:
+        raise RuntimeError(
+            "Sequence-packing schedulers require a Megatron-Core version that provides "
+            "megatron.core.datasets.data_schedule.wrap_data_iterator."
+        ) from error
+
+    return wrap_data_iterator(
+        data_iterator,
+        model_config,
+        num_microbatches,
+        pg_collection=pg_collection,
+    )
+
+
 @nvtx_decorator()
 def train_step(
     forward_step_func: ForwardStepCallable,
@@ -849,7 +873,11 @@ def train_step(
     optim_config = cfg.optimizer
 
     rerun_state_machine = get_rerun_state_machine()
-    while rerun_state_machine.should_run_forward_backward(data_iterator):
+    packed_data_iterator = None
+    packed_num_microbatches = None
+    has_wrapped_data_iterator = False
+    rerun_data_iterator = data_iterator
+    while rerun_state_machine.should_run_forward_backward(rerun_data_iterator):
         # Set grad to zero.
         for model_chunk in model:
             model_chunk.zero_grad_buffer()
@@ -887,6 +915,25 @@ def train_step(
                 data_iterator=forward_backward_data_iterator,
             )
 
+        num_microbatches = get_num_microbatches()
+        if getattr(model_config, "sequence_packing_scheduler", None) is not None:
+            if not has_wrapped_data_iterator:
+                (
+                    packed_data_iterator,
+                    packed_num_microbatches,
+                    _seqlen_sum_this_global_batch,
+                    _seqlen_squared_sum_this_global_batch,
+                ) = _wrap_sequence_packing_data_iterator(
+                    forward_backward_data_iterator,
+                    model_config,
+                    num_microbatches,
+                    pg_collection,
+                )
+                has_wrapped_data_iterator = True
+                rerun_data_iterator = packed_data_iterator
+            forward_backward_data_iterator = packed_data_iterator
+            num_microbatches = packed_num_microbatches
+
         # [ModelOpt]: Pipeline-parallel Distillation stacks student and teacher tensors
         if not cfg.dist.use_decentralized_pg:
             adjust_tensor_shapes_fn = get_tensor_shapes_adjust_fn_for_distillation(
@@ -903,7 +950,7 @@ def train_step(
             forward_step_func=forward_step_func,
             data_iterator=forward_backward_data_iterator,
             model=model,
-            num_microbatches=get_num_microbatches(),
+            num_microbatches=num_microbatches,
             seq_length=seq_length,
             micro_batch_size=train_config.micro_batch_size,
             decoder_seq_length=seq_length,
@@ -1096,7 +1143,10 @@ def maybe_run_manual_gc(manual_gc_enabled: bool, manual_gc_interval: int, iterat
 
 
 def should_disable_forward_pre_hook(
-    use_megatron_fsdp: bool, use_distributed_optimizer: bool, overlap_param_gather: bool
+    use_megatron_fsdp: bool,
+    use_distributed_optimizer: bool,
+    overlap_param_gather: bool,
+    use_layer_wise_distributed_optimizer: bool = False,
 ) -> bool:
     """Determine if forward pre-hooks should be disabled during checkpointing.
 
@@ -1107,6 +1157,8 @@ def should_disable_forward_pre_hook(
         use_megatron_fsdp: Whether Megatron FSDP is enabled.
         use_distributed_optimizer: Whether distributed optimizer is enabled.
         overlap_param_gather: Whether parameter gathering is overlapped.
+        use_layer_wise_distributed_optimizer: Whether the layer-wise distributed
+            optimizer is enabled.
 
     Returns:
         True if forward pre-hooks should be disabled, False otherwise.
@@ -1115,7 +1167,8 @@ def should_disable_forward_pre_hook(
         This is needed to prevent autograd issues during checkpoint saving
         when using distributed optimizer with parameter gathering overlap.
     """
-    return not use_megatron_fsdp and use_distributed_optimizer and overlap_param_gather
+    uses_distributed_optimizer = use_distributed_optimizer or use_layer_wise_distributed_optimizer
+    return not use_megatron_fsdp and uses_distributed_optimizer and overlap_param_gather
 
 
 def enable_forward_pre_hook(model: list[DDP]) -> None:
@@ -1303,6 +1356,7 @@ def save_checkpoint_and_time(
         state.cfg.ddp.use_megatron_fsdp,
         state.cfg.optimizer.use_distributed_optimizer,
         state.cfg.ddp.overlap_param_gather,
+        state.cfg.optimizer.use_layer_wise_distributed_optimizer,
     )
     if should_force_param_sync:
         force_param_sync(model, optimizer=optimizer)

--- a/src/megatron/bridge/training/utils/train_utils.py
+++ b/src/megatron/bridge/training/utils/train_utils.py
@@ -28,6 +28,7 @@ import torch.nn as nn
 from megatron.core import tensor_parallel
 from megatron.core.num_microbatches_calculator import get_num_microbatches
 from megatron.core.tensor_parallel import param_is_not_tensor_parallel_duplicate
+from megatron.core.transformer.experimental_attention_variant.dsa import DSAIndexerLossLoggingHelper
 from megatron.core.transformer.module import MegatronModule
 from megatron.core.transformer.moe.moe_utils import track_moe_metrics
 from megatron.core.transformer.multi_token_prediction import MTPLossLoggingHelper
@@ -1101,10 +1102,26 @@ def training_log(
             pg_collection=pg_collection,
         )
     if getattr(config.model, "mtp_num_layers", None) is not None:
-        mtp_loss_scale = 1 / get_num_microbatches()
+        # MCore already normalizes the reduced MTP metric by token count across
+        # ranks and microbatches.
+        mtp_loss_scale = 1.0
         mtp_metric_writer = _build_moe_metric_writer(writer, comet_logger, mlflow_logger)
         MTPLossLoggingHelper.track_mtp_metrics(
             mtp_loss_scale, iteration, mtp_metric_writer, wandb_writer, total_loss_dict
+        )
+
+    if (getattr(config.model, "dsa_indexer_loss_coeff", None) or 0) > 0:
+        indexer_loss_scale = 1 / get_num_microbatches()
+        indexer_metric_writer = _build_moe_metric_writer(writer, comet_logger, mlflow_logger)
+        DSAIndexerLossLoggingHelper.track_indexer_metrics(
+            loss_scale=indexer_loss_scale,
+            iteration=iteration,
+            writer=indexer_metric_writer,
+            wandb_writer=wandb_writer,
+            total_loss_dict=total_loss_dict,
+            num_layers=getattr(config.model, "num_layers", 0) + (getattr(config.model, "mtp_num_layers", None) or 0),
+            csa_compress_ratios=getattr(config.model, "csa_compress_ratios", None),
+            preserve_groups=getattr(config.model, "cuda_graph_impl", "none") != "none",
         )
 
     if iteration % logger_config.log_interval == 0:

--- a/tests/unit_tests/data/test_varlen_sequence_packing.py
+++ b/tests/unit_tests/data/test_varlen_sequence_packing.py
@@ -1,0 +1,60 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from megatron.bridge.data import utils as data_utils
+from megatron.bridge.data.loaders import _get_collate_fn
+from megatron.bridge.training.config import MockVarlenDatasetConfig
+
+
+pytestmark = pytest.mark.unit
+
+
+def _mock_varlen_config() -> MockVarlenDatasetConfig:
+    return MockVarlenDatasetConfig(
+        random_seed=1234,
+        reset_attention_mask=False,
+        reset_position_ids=False,
+        eod_mask_loss=False,
+        seq_length=65_536,
+        varlen_mock_dataset_config_json=(
+            '{"mode":"distribution","type":"lognormal","format":"thd",'
+            '"min_seq_len":65534,"max_seq_len":65534,"mean_seq_len":65534,'
+            '"lognormal_sigma":1.1}'
+        ),
+    )
+
+
+def test_mock_varlen_loader_preserves_samples_as_a_list() -> None:
+    cfg = SimpleNamespace(dataset=_mock_varlen_config())
+    collate_fn = _get_collate_fn(object(), cfg)
+    samples = [{"tokens": object()}, {"tokens": object()}]
+
+    assert collate_fn is not None
+    assert collate_fn(samples) is samples
+
+
+def test_mock_varlen_provider_builds_tp_zero_dataset_on_every_pp_stage(monkeypatch) -> None:
+    varlen_dataset = pytest.importorskip("megatron.training.datasets.varlen_dataset")
+    builder = Mock()
+    builder.return_value.build.return_value = ("train", "valid", "test")
+    owns_dataset = Mock(return_value=True)
+    monkeypatch.setattr(data_utils, "BlendedMegatronDatasetBuilder", builder)
+    monkeypatch.setattr(data_utils, "is_dataset_built_on_rank", owns_dataset)
+    pg_collection = object()
+    dataset_config = _mock_varlen_config()
+
+    result = data_utils.pretrain_train_valid_test_datasets_provider(
+        [256, 0, 0],
+        dataset_config,
+        pg_collection=pg_collection,
+    )
+
+    assert result == ("train", "valid", "test")
+    dataset_type, sample_counts, rank_predicate, captured_config = builder.call_args.args
+    assert dataset_type is varlen_dataset.MockVarlenDataset
+    assert sample_counts == [256, 0, 0]
+    assert captured_config is dataset_config
+    assert rank_predicate() is True
+    owns_dataset.assert_called_once_with(pg_collection, include_middle_pipeline_stages=True)

--- a/tests/unit_tests/recipes/test_deepseek_v4_64k_perf_recipe.py
+++ b/tests/unit_tests/recipes/test_deepseek_v4_64k_perf_recipe.py
@@ -5,6 +5,7 @@ import torch
 
 from megatron.bridge.perf_recipes.deepseek import (
     deepseek_v4_pro_pretrain_64gpu_gb300_fp8mx_config,
+    deepseek_v4_pro_pretrain_256gpu_gb300_fp8mx_config,
 )
 from megatron.bridge.training.config import MockVarlenDatasetConfig
 from tests.unit_tests.recipes.recipe_test_utils import patch_recipe_construction_dependencies
@@ -97,3 +98,41 @@ def test_deepseek_v4_pro_64k_thd_recipe() -> None:
     assert cfg.model.apply_dsa_kernel_fusion is True
     assert cfg.model.use_transformer_engine_op_fuser is True
     assert cfg.model.recompute_modules == ["mla_up_proj", "mhc"]
+
+
+def test_deepseek_v4_pro_full_model_uses_64k_thd_recipe() -> None:
+    cfg = deepseek_v4_pro_pretrain_256gpu_gb300_fp8mx_config()
+
+    assert cfg.model.num_layers == 61
+    assert cfg.model.moe_layer_freq == [1] * 61
+    assert cfg.model.csa_compress_ratios == [128, 128, 4, *([128, 4] * 29), 0]
+    assert cfg.model.moe_n_hash_layers == 3
+    assert cfg.model.activation_func_clamp_value == 10.0
+    assert cfg.model.tensor_model_parallel_size == 1
+    assert cfg.model.pipeline_model_parallel_size == 4
+    assert cfg.model.virtual_pipeline_model_parallel_size == 4
+    assert cfg.model.context_parallel_size == 16
+    assert cfg.model.expert_model_parallel_size == 64
+    assert cfg.model.pipeline_model_parallel_layout == "Et*4|(t*4|)*14tmL"
+
+    assert cfg.model.seq_length == 65_536
+    assert isinstance(cfg.dataset, MockVarlenDatasetConfig)
+    assert cfg.dataset.seq_length == 65_536
+    assert cfg.dataset.context_parallel_size == 16
+    assert cfg.dataset.data_parallel_size == 4
+    assert cfg.model.sequence_packing_scheduler == "dp_balanced"
+    assert cfg.model.max_seqlen_per_dp_cp_rank == 4096
+    assert cfg.train.global_batch_size == 256
+    assert cfg.train.micro_batch_size == 1
+
+    assert cfg.model.cuda_graph_impl == "transformer_engine"
+    assert cfg.model.cuda_graph_scope == ["attn", "moe_router", "moe_preprocess"]
+    assert cfg.model.moe_paged_stash is False
+    assert cfg.model.fine_grained_activation_offloading is True
+    assert cfg.model.offload_modules == ["core_attn", "attn_proj"]
+    assert cfg.model.fine_grained_offloading_max_inflight_offloads == 2
+    assert cfg.model.recompute_modules == ["mla_up_proj", "mhc"]
+    assert cfg.optimizer.optimizer == "muon"
+    assert cfg.optimizer.use_layer_wise_distributed_optimizer is True
+    assert cfg.env_vars["NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN"] == 64
+    assert cfg.env_vars["NVTE_CPU_OFFLOAD_V1"] == 1

--- a/tests/unit_tests/recipes/test_deepseek_v4_64k_perf_recipe.py
+++ b/tests/unit_tests/recipes/test_deepseek_v4_64k_perf_recipe.py
@@ -58,10 +58,10 @@ def test_deepseek_v4_pro_64k_thd_recipe() -> None:
     assert varlen_config["mean_seq_len"] == 65_534
 
     assert cfg.train.global_batch_size == 256
-    assert cfg.train.train_iters is None
-    assert cfg.train.train_samples == 585_937_500
+    assert cfg.train.train_iters == 50
+    assert cfg.train.train_samples is None
     assert cfg.train.micro_batch_size == 1
-    assert cfg.train.exit_interval == 30
+    assert cfg.train.exit_interval is None
     assert cfg.train.manual_gc_interval == 10
     assert cfg.model.cuda_graph_impl == "transformer_engine"
     assert cfg.model.cuda_graph_scope == ["attn", "moe_router", "moe_preprocess"]
@@ -76,10 +76,10 @@ def test_deepseek_v4_pro_64k_thd_recipe() -> None:
     assert cfg.optimizer.overlap_param_gather is True
     assert cfg.optimizer.optimizer_offload_fraction == 0.0
     assert cfg.optimizer.barrier_with_L1_time is True
-    assert cfg.scheduler.lr_decay_iters is None
-    assert cfg.scheduler.lr_decay_samples == 584_765_624
-    assert cfg.scheduler.lr_warmup_iters == 0
-    assert cfg.scheduler.lr_warmup_samples == 1_536_000
+    assert cfg.scheduler.lr_decay_iters == 50
+    assert cfg.scheduler.lr_decay_samples is None
+    assert cfg.scheduler.lr_warmup_iters == 10
+    assert cfg.scheduler.lr_warmup_samples == 0
     assert cfg.optimizer.muon_momentum == 0.9
     assert cfg.optimizer.muon_nesterov is False
     assert cfg.optimizer.main_grads_dtype == torch.float32

--- a/tests/unit_tests/recipes/test_deepseek_v4_64k_perf_recipe.py
+++ b/tests/unit_tests/recipes/test_deepseek_v4_64k_perf_recipe.py
@@ -1,0 +1,99 @@
+import json
+
+import pytest
+import torch
+
+from megatron.bridge.perf_recipes.deepseek import (
+    deepseek_v4_pro_pretrain_64gpu_gb300_fp8mx_config,
+)
+from megatron.bridge.training.config import MockVarlenDatasetConfig
+from tests.unit_tests.recipes.recipe_test_utils import patch_recipe_construction_dependencies
+
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def _keep_recipe_construction_offline(monkeypatch: pytest.MonkeyPatch) -> None:
+    patch_recipe_construction_dependencies(monkeypatch)
+
+
+def test_deepseek_v4_pro_64k_thd_recipe() -> None:
+    cfg = deepseek_v4_pro_pretrain_64gpu_gb300_fp8mx_config()
+
+    assert cfg.model.num_layers == 15
+    assert cfg.model.num_moe_experts == 384
+    assert cfg.model.tensor_model_parallel_size == 1
+    assert cfg.model.pipeline_model_parallel_size == 1
+    assert cfg.model.virtual_pipeline_model_parallel_size is None
+    assert cfg.model.context_parallel_size == 16
+    assert cfg.model.expert_model_parallel_size == 64
+    assert cfg.model.expert_tensor_parallel_size == 1
+    assert cfg.model.sequence_parallel is False
+
+    assert cfg.model.seq_length == 65_536
+    assert cfg.model.max_position_embeddings == 65_536
+    assert cfg.model.vocab_size == 129_280
+    assert cfg.model.actual_vocab_size == 129_280
+    assert cfg.model.q_lora_rank == 1536
+    assert cfg.model.o_groups == 16
+    assert cfg.model.o_lora_rank == 1024
+    assert cfg.model.csa_compress_ratios == [128, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 0]
+    assert cfg.model.sequence_packing_scheduler == "dp_balanced"
+    assert cfg.model.max_seqlen_per_dp_cp_rank == 4096
+    assert cfg.model.pad_packed_seq_alignment == "max"
+    assert cfg.model.thd_max_packed_sequences == 8
+    assert cfg.model.cp_partition_mode == "contiguous"
+    assert cfg.model.calculate_per_token_loss is True
+
+    assert isinstance(cfg.dataset, MockVarlenDatasetConfig)
+    assert cfg.dataset.seq_length == 65_536
+    assert cfg.dataset.context_parallel_size == 16
+    assert cfg.dataset.data_parallel_size == 4
+    varlen_config = json.loads(cfg.dataset.varlen_mock_dataset_config_json)
+    assert varlen_config["format"] == "thd"
+    assert varlen_config["min_seq_len"] == 65_534
+    assert varlen_config["max_seq_len"] == 65_534
+    assert varlen_config["mean_seq_len"] == 65_534
+
+    assert cfg.train.global_batch_size == 256
+    assert cfg.train.train_iters is None
+    assert cfg.train.train_samples == 585_937_500
+    assert cfg.train.micro_batch_size == 1
+    assert cfg.train.exit_interval == 30
+    assert cfg.train.manual_gc_interval == 10
+    assert cfg.model.cuda_graph_impl == "transformer_engine"
+    assert cfg.model.cuda_graph_scope == ["attn", "moe_router", "moe_preprocess"]
+    assert cfg.model.cuda_graph_warmup_steps == 1
+    assert cfg.model.fine_grained_activation_offloading is False
+    assert cfg.model.moe_paged_stash is False
+
+    assert cfg.optimizer.optimizer == "muon"
+    assert cfg.optimizer.use_distributed_optimizer is False
+    assert cfg.optimizer.use_layer_wise_distributed_optimizer is True
+    assert cfg.optimizer.use_layer_wise_param_layout is False
+    assert cfg.optimizer.overlap_param_gather is True
+    assert cfg.optimizer.optimizer_offload_fraction == 1.0
+    assert cfg.optimizer.barrier_with_L1_time is True
+    assert cfg.scheduler.lr_decay_iters is None
+    assert cfg.scheduler.lr_decay_samples == 584_765_624
+    assert cfg.scheduler.lr_warmup_iters == 0
+    assert cfg.scheduler.lr_warmup_samples == 1_536_000
+    assert cfg.optimizer.muon_momentum == 0.9
+    assert cfg.optimizer.muon_nesterov is False
+    assert cfg.optimizer.main_grads_dtype == torch.float32
+    assert cfg.optimizer.main_params_dtype == torch.float32
+    assert cfg.optimizer.exp_avg_dtype == torch.float32
+    assert cfg.optimizer.exp_avg_sq_dtype == torch.float32
+    assert cfg.ddp.use_distributed_optimizer is True
+    assert cfg.ddp.check_for_nan_in_grad is True
+    assert cfg.ddp.average_in_collective is False
+    assert cfg.comm_overlap.overlap_param_gather is True
+
+    assert cfg.model.moe_flex_dispatcher_backend == "hybridep"
+    assert cfg.model.moe_token_dispatcher_type == "flex"
+    assert cfg.model.moe_router_force_load_balancing is True
+    assert cfg.model.moe_pad_experts_for_cuda_graph_inference is True
+    assert cfg.model.apply_dsa_kernel_fusion is True
+    assert cfg.model.use_transformer_engine_op_fuser is True
+    assert cfg.model.recompute_modules == ["mla_up_proj", "mhc"]

--- a/tests/unit_tests/recipes/test_deepseek_v4_64k_perf_recipe.py
+++ b/tests/unit_tests/recipes/test_deepseek_v4_64k_perf_recipe.py
@@ -74,7 +74,7 @@ def test_deepseek_v4_pro_64k_thd_recipe() -> None:
     assert cfg.optimizer.use_layer_wise_distributed_optimizer is True
     assert cfg.optimizer.use_layer_wise_param_layout is False
     assert cfg.optimizer.overlap_param_gather is True
-    assert cfg.optimizer.optimizer_offload_fraction == 1.0
+    assert cfg.optimizer.optimizer_offload_fraction == 0.0
     assert cfg.optimizer.barrier_with_L1_time is True
     assert cfg.scheduler.lr_decay_iters is None
     assert cfg.scheduler.lr_decay_samples == 584_765_624
@@ -134,5 +134,7 @@ def test_deepseek_v4_pro_full_model_uses_64k_thd_recipe() -> None:
     assert cfg.model.recompute_modules == ["mla_up_proj", "mhc"]
     assert cfg.optimizer.optimizer == "muon"
     assert cfg.optimizer.use_layer_wise_distributed_optimizer is True
+    assert cfg.optimizer.optimizer_cpu_offload is False
+    assert cfg.optimizer.optimizer_offload_fraction == 0.0
     assert cfg.env_vars["NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN"] == 64
     assert cfg.env_vars["NVTE_CPU_OFFLOAD_V1"] == 1

--- a/tests/unit_tests/recipes/test_r050_perf_recipe_ports.py
+++ b/tests/unit_tests/recipes/test_r050_perf_recipe_ports.py
@@ -15,13 +15,11 @@
 """Regression tests for performance recipes manually ported from r0.5.0."""
 
 import pytest
-import torch
 
 from megatron.bridge.perf_recipes.deepseek import (
     deepseek_v3_pretrain_256gpu_b300_fp8mx_config,
     deepseek_v3_pretrain_256gpu_gb200_fp8mx_large_scale_config,
     deepseek_v3_pretrain_256gpu_gb300_fp8mx_large_scale_config,
-    deepseek_v4_pro_pretrain_256gpu_gb300_fp8mx_config,
 )
 from megatron.bridge.perf_recipes.qwen import (
     qwen3_30b_a3b_pretrain_8gpu_b200_fp8mx_config,
@@ -137,49 +135,3 @@ def test_deepseek_v3_b300_mxfp8_preserves_r050_hybridep_settings() -> None:
     cfg = deepseek_v3_pretrain_256gpu_b300_fp8mx_config()
 
     _assert_full_iteration_hybridep_mxfp8(cfg)
-
-
-def test_deepseek_v4_pro_gb300_matches_r050_performance_config() -> None:
-    cfg = deepseek_v4_pro_pretrain_256gpu_gb300_fp8mx_config()
-
-    assert cfg.train.global_batch_size == 4096
-    assert cfg.train.micro_batch_size == 1
-    assert cfg.model.tensor_model_parallel_size == 1
-    assert cfg.model.pipeline_model_parallel_size == 4
-    assert cfg.model.virtual_pipeline_model_parallel_size == 4
-    assert cfg.model.context_parallel_size == 1
-    assert cfg.model.expert_model_parallel_size == 64
-    assert cfg.model.expert_tensor_parallel_size == 1
-    assert cfg.model.pipeline_model_parallel_layout == "Et*4|(tttt|)*14tmL"
-    assert cfg.model.recompute_modules == ["mla_up_proj", "mhc"]
-    assert cfg.model.moe_flex_dispatcher_backend == "hybridep"
-    assert cfg.model.moe_token_dispatcher_type == "flex"
-    assert cfg.model.moe_shared_expert_overlap is False
-
-    assert cfg.model.cuda_graph_impl == "full_iteration"
-    assert cfg.model.cuda_graph_scope == []
-    assert cfg.model.moe_pad_experts_for_cuda_graph_inference is True
-    assert cfg.model.moe_paged_stash is True
-    assert cfg.model.moe_expert_rank_capacity_factor == 1.5
-    assert cfg.model.moe_paged_stash_buffer_size_factor_cuda == 1.2
-    assert cfg.model.moe_paged_stash_buffer_size_factor_cpu == 0.0
-
-    assert cfg.model.apply_dsa_kernel_fusion is True
-    assert cfg.model.use_transformer_engine_op_fuser is True
-    assert cfg.model.cross_entropy_fusion_impl == "native"
-    assert cfg.model.moe_mlp_glu_interleave_size == 32
-    assert cfg.model.quant_recipe is None
-    assert cfg.mixed_precision.fp8_param_gather is True
-    assert cfg.mixed_precision.reuse_grad_buf_for_mxfp8_param_ag is True
-    assert cfg.model.dsa_indexer_loss_coeff == 0.01
-    assert cfg.model.dsa_indexer_use_sparse_loss is True
-    assert cfg.optimizer.main_grads_dtype == torch.bfloat16
-    assert cfg.mixed_precision.grad_reduce_in_fp32 is False
-    assert cfg.ddp.grad_reduce_in_fp32 is False
-
-    assert cfg.model.fine_grained_activation_offloading is True
-    assert cfg.model.offload_modules == ["core_attn", "attn_proj"]
-    assert cfg.model.fine_grained_offloading_max_inflight_offloads == 2
-    assert cfg.comm_overlap.overlap_grad_reduce is True
-    assert cfg.comm_overlap.overlap_moe_expert_parallel_comm is False
-    assert cfg.comm_overlap.delay_wgrad_compute is False

--- a/tests/unit_tests/scripts/performance/test_executors.py
+++ b/tests/unit_tests/scripts/performance/test_executors.py
@@ -147,6 +147,25 @@ def test_build_nemorun_script_wraps_only_enabled_kubeflow_tasks():
 
 
 @pytest.mark.skipif(not HAS_NEMO_RUN, reason="nemo_run not installed")
+def test_build_nemorun_script_preserves_custom_pythonpath():
+    task = _build_nemorun_script(
+        script_path="/opt/Megatron-Bridge/scripts/performance/run_recipe.py",
+        script_dir="/opt/Megatron-Bridge/scripts/performance",
+        args=[],
+        kubeflow_namespace=None,
+        custom_env_vars={"PYTHONPATH": "/workspace/Megatron-LM"},
+    )
+
+    assert task.env == {
+        "PYTHONPATH": (
+            "/opt/Megatron-Bridge/scripts/performance:"
+            "/opt/Megatron-Bridge/src:"
+            "/workspace/Megatron-LM"
+        )
+    }
+
+
+@pytest.mark.skipif(not HAS_NEMO_RUN, reason="nemo_run not installed")
 def test_kubeflow_numa_binding_is_disabled_by_default():
     """Normal Kubeflow jobs must retain the unmodified Torchrun launcher."""
     assert not _kubeflow_numa_binding_enabled({})

--- a/tests/unit_tests/scripts/performance/test_user_overrides.py
+++ b/tests/unit_tests/scripts/performance/test_user_overrides.py
@@ -26,6 +26,7 @@ from argument_parser import parse_cli_args
 from utils.overrides import set_user_overrides
 
 from megatron.bridge.recipes.gpt.h100.vanilla_gpt import vanilla_gpt_pretrain_1gpu_h100_bf16_config
+from megatron.bridge.training.config import MockVarlenDatasetConfig
 
 
 def _parse_args(tmp_path: Path, *extra_args: str):
@@ -56,3 +57,22 @@ def test_seq_length_updates_model_and_mock_dataset(tmp_path):
 
     assert updated.model.seq_length == 128
     assert updated.dataset.seq_length == 128
+
+
+def test_default_mock_data_preserves_recipe_varlen_dataset(tmp_path):
+    recipe = vanilla_gpt_pretrain_1gpu_h100_bf16_config()
+    varlen_config = '{"format": "thd", "min_seq_len": 126, "max_seq_len": 126}'
+    varlen_dataset = MockVarlenDatasetConfig(
+        seq_length=128,
+        varlen_mock_dataset_config_json=varlen_config,
+        num_workers=recipe.dataset.num_workers,
+        pin_memory=recipe.dataset.pin_memory,
+        persistent_workers=recipe.dataset.persistent_workers,
+    )
+    recipe.dataset = varlen_dataset
+
+    updated = set_user_overrides(recipe, _parse_args(tmp_path))
+
+    assert updated.dataset is varlen_dataset
+    assert isinstance(updated.dataset, MockVarlenDatasetConfig)
+    assert updated.dataset.varlen_mock_dataset_config_json == varlen_config

--- a/tests/unit_tests/training/test_config.py
+++ b/tests/unit_tests/training/test_config.py
@@ -3413,6 +3413,29 @@ class TestRuntimeConfigUpdate:
 class TestDistributedOptimizerValidation:
     """Tests for the _validate_and_sync_distributed_optimizer_settings function."""
 
+    @patch("megatron.bridge.training.config.warn_rank_0")
+    def test_decoupled_layer_wise_optimizer_preserves_split_ddp_setting(self, mock_warn_rank_0):
+        """Layer-wise Muon uses distributed DDP buffers without the conventional distributed optimizer."""
+        container, og_ws, cfg_mod = create_test_config_container(
+            world_size_override=1,
+            model_config=create_test_gpt_config(),
+            ddp_config=create_test_ddp_config(use_distributed_optimizer=True),
+            optimizer_config=create_test_optimizer_config(
+                use_distributed_optimizer=False,
+                use_layer_wise_distributed_optimizer=True,
+                use_layer_wise_param_layout=False,
+            ),
+        )
+
+        try:
+            _validate_and_sync_distributed_optimizer_settings(container)
+
+            assert container.ddp.use_distributed_optimizer is True
+            assert container.optimizer.use_distributed_optimizer is False
+            mock_warn_rank_0.assert_not_called()
+        finally:
+            restore_get_world_size_safe(og_ws, cfg_mod)
+
     @pytest.mark.parametrize(
         "ddp_setting, optimizer_setting, expected_final_state, should_print_message, expected_message_parts",
         [

--- a/tests/unit_tests/training/test_gpt_step.py
+++ b/tests/unit_tests/training/test_gpt_step.py
@@ -88,6 +88,7 @@ def _make_cfg(
     pipeline_model_parallel_size=1,
     virtual_pipeline_model_parallel_size=None,
     mtp_num_layers=0,
+    sequence_packing_scheduler=None,
 ):
     cfg = type("Cfg", (), {})()
     cfg.dataset = type(
@@ -107,6 +108,7 @@ def _make_cfg(
             "pipeline_model_parallel_size": pipeline_model_parallel_size,
             "virtual_pipeline_model_parallel_size": virtual_pipeline_model_parallel_size,
             "mtp_num_layers": mtp_num_layers,
+            "sequence_packing_scheduler": sequence_packing_scheduler,
         },
     )()
     return cfg
@@ -165,6 +167,39 @@ class _VpStageWrapper:
 
 class TestGetBatch:
     """Tests for the get_batch helper."""
+
+    def test_sequence_packing_scheduler_uses_mcore_thd_batch_path(self, monkeypatch):
+        packed_seq_params = Mock(spec=PackedSeqParams)
+        expected = (
+            torch.tensor([[1, 2]]),
+            torch.tensor([[2, 3]]),
+            torch.ones(1, 2),
+            None,
+            torch.tensor([[0, 1]]),
+            packed_seq_params,
+            torch.ones(1, 2, dtype=torch.bool),
+        )
+        mcore_get_batch = Mock(return_value=expected)
+        monkeypatch.setattr(
+            "megatron.core.datasets.data_schedule.get_batch_on_this_rank_for_sequence_packing",
+            mcore_get_batch,
+        )
+
+        cfg = _make_cfg(sequence_packing_scheduler="dp_balanced")
+        pg_collection = _MockPGCollection()
+        data_iterator = MagicMock()
+
+        result = get_batch(data_iterator, cfg, use_mtp=False, pg_collection=pg_collection)
+
+        assert result == expected
+        mcore_get_batch.assert_called_once_with(
+            data_iterator,
+            vpp_size=None,
+            mtp_on_this_rank=False,
+            vp_stage=None,
+            pg_collection=pg_collection,
+            config=cfg.model,
+        )
 
     @pytest.mark.parametrize("metadata_key", ["cu_seqlens_q", "cu_seqlens"])
     def test_packed_cp_partition_rejects_multiple_physical_thd_rows(self, metadata_key):
@@ -319,6 +354,7 @@ class TestGetBatch:
             attention_mask,
             position_ids,
             packed_seq_metadata,
+            padding_mask,
         ) = get_batch(
             _Iterator(batch),
             _make_cfg(enable_offline_packing=True, offline_packing_specs=object()),
@@ -332,6 +368,7 @@ class TestGetBatch:
         assert torch.equal(attention_mask, batch["attention_mask"])
         assert torch.equal(position_ids, batch["position_ids"])
         assert packed_seq_metadata is not None
+        assert padding_mask is None
         assert torch.equal(packed_seq_metadata["cu_seqlens_q"], cu_seqlens_q)
         assert torch.equal(packed_seq_metadata["cu_seqlens_kv"], cu_seqlens_kv)
         assert torch.equal(packed_seq_metadata["cu_seqlens_q_padded"], cu_seqlens_q_padded)
@@ -353,7 +390,7 @@ class TestGetBatch:
             pg_collection=_MockPGCollection(),
         )
 
-        assert result == (None, None, None, None, None, None)
+        assert result == (None, None, None, None, None, None, None)
         data_iterator.__next__.assert_not_called()
 
     def test_middle_pp_stage_without_mtp_keeps_fast_path_when_mtp_enabled(self, monkeypatch):
@@ -373,7 +410,7 @@ class TestGetBatch:
             pg_collection=_MockPGCollection(pp_rank=1, pp_size=4),
         )
 
-        assert result == (None, None, None, None, None, None)
+        assert result == (None, None, None, None, None, None, None)
         data_iterator.__next__.assert_not_called()
 
     def test_standalone_mtp_middle_pp_stage_loads_tokens_and_position_ids(self, monkeypatch):
@@ -408,6 +445,7 @@ class TestGetBatch:
             out_attention_mask,
             out_position_ids,
             packed_seq_metadata,
+            padding_mask,
         ) = get_batch(
             _Iterator(batch),
             _make_cfg(
@@ -425,6 +463,7 @@ class TestGetBatch:
         assert out_attention_mask is None
         assert torch.equal(out_position_ids, position_ids)
         assert packed_seq_metadata is None
+        assert padding_mask is None
 
     def test_standalone_mtp_loss_stage_skips_mtp_inputs(self, monkeypatch):
         """The loss-only final PP stage does not load token ids for standalone MTP."""
@@ -639,6 +678,7 @@ class TestGetBatch:
                 None,
                 position_ids,
                 packed_seq_metadata,
+                None,
             ),
         )
         get_packed_seq_params_mock = Mock(return_value=sentinel_packed_seq_params)
@@ -658,6 +698,60 @@ class TestGetBatch:
         get_packed_seq_params_mock.assert_called_once_with(packed_seq_metadata)
         assert "cu_seqlens" not in get_packed_seq_params_mock.call_args.args[0]
         assert "cu_seqlens_argmin" not in get_packed_seq_params_mock.call_args.args[0]
+
+    def test_forward_common_passes_mcore_sequence_packing_params_directly(self, monkeypatch):
+        """Scheduler-produced PackedSeqParams must bypass Bridge metadata conversion."""
+        tokens = torch.tensor([[1, 2, 3, 4]])
+        labels = torch.tensor([[2, 3, 4, 5]])
+        loss_mask = torch.ones(1, 4)
+        position_ids = torch.arange(4).unsqueeze(0)
+        packed_seq_params = PackedSeqParams(qkv_format="thd")
+        padding_mask = torch.tensor([[False, False, False, True]])
+        model = Mock(return_value=torch.tensor(1.0))
+        state = Mock()
+        state.cfg = _make_cfg(sequence_packing_scheduler="dp_balanced")
+        state.timers = _NoopTimer()
+        state.straggler_timer = _NoopTimer()
+        config = type(
+            "Config",
+            (),
+            {
+                "is_hybrid_model": False,
+                "mtp_num_layers": 0,
+                "overlap_moe_expert_parallel_comm": False,
+            },
+        )()
+
+        monkeypatch.setattr("megatron.bridge.training.gpt_step.get_model_config", lambda model: config)
+        monkeypatch.setattr("megatron.bridge.training.gpt_step.get_pg_collection", lambda model: _MockPGCollection())
+        monkeypatch.setattr(
+            "megatron.bridge.training.gpt_step.get_batch",
+            lambda data_iterator, cfg, use_mtp, *, pg_collection, vp_stage=None: (
+                tokens,
+                labels,
+                loss_mask,
+                None,
+                position_ids,
+                packed_seq_params,
+                padding_mask,
+            ),
+        )
+        get_packed_seq_params_mock = Mock()
+        monkeypatch.setattr("megatron.bridge.training.gpt_step.get_packed_seq_params", get_packed_seq_params_mock)
+
+        output, returned_loss_mask = _forward_step_common(state, _Iterator({}), model)
+
+        assert torch.equal(output, torch.tensor(1.0))
+        assert torch.equal(returned_loss_mask, loss_mask)
+        model.assert_called_once_with(
+            input_ids=tokens,
+            position_ids=position_ids,
+            attention_mask=None,
+            labels=labels,
+            packed_seq_params=packed_seq_params,
+            padding_mask=padding_mask,
+        )
+        get_packed_seq_params_mock.assert_not_called()
 
 
 class _FakePackedPartitioner:

--- a/tests/unit_tests/training/test_setup.py
+++ b/tests/unit_tests/training/test_setup.py
@@ -30,6 +30,7 @@ from megatron.bridge.training.setup import (
     _should_load_checkpoint,
     _update_model_config_funcs,
     _validate_and_set_vocab_size,
+    _wrap_model_chunks_with_layer_wise_ddp,
     maybe_log_and_save_config,
 )
 from megatron.bridge.training.state import GlobalState
@@ -303,8 +304,10 @@ class TestBuildDistributedModel:
         cfg.model = model_cfg
         cfg.ddp = MagicMock()
         cfg.optimizer.overlap_param_gather_with_optimizer_step = False
+        cfg.optimizer.use_layer_wise_distributed_optimizer = False
         cfg.dist.use_megatron_fsdp = False
         cfg.dist.use_torch_fsdp2 = False
+        cfg.dist.use_decentralized_pg = False
         cfg.rng.data_parallel_random_init = False
         return cfg, model_cfg
 
@@ -326,6 +329,41 @@ class TestBuildDistributedModel:
         mock_builder.build_distributed_models.assert_called_once()
         assert result == mock_dist_model
 
+    @patch("megatron.bridge.training.setup._wrap_model_chunks_with_layer_wise_ddp")
+    def test_build_with_layer_wise_ddp_optimizer(self, mock_layer_wise_wrap):
+        """Layer-wise Muon must not reuse ModelBuilder's conventional DDP layout."""
+        cfg, model_cfg = self._make_cfg_with_model_config()
+        cfg.optimizer.use_layer_wise_distributed_optimizer = True
+
+        post_wrap_hook = MagicMock(side_effect=lambda model: [*model, "post-wrapped"])
+        model_cfg.post_wrap_hooks.append(post_wrap_hook)
+
+        mock_builder_cls = MagicMock()
+        mock_builder = MagicMock()
+        mock_builder_cls.return_value = mock_builder
+        prepared_model = [MagicMock()]
+        layer_wise_model = [MagicMock()]
+        mock_builder.build_distributed_models.return_value = prepared_model
+        mock_layer_wise_wrap.return_value = layer_wise_model
+
+        pg_collection = MagicMock()
+        with patch.object(type(model_cfg), "get_builder_cls", return_value=mock_builder_cls):
+            result = _build_distributed_model(cfg, pg_collection)
+
+        mock_builder.build_distributed_models.assert_called_once_with(
+            pg_collection=pg_collection,
+            ddp_config=cfg.ddp,
+            overlap_param_gather_with_optimizer_step=False,
+            use_megatron_fsdp=False,
+            use_torch_fsdp2=False,
+            wrap_with_ddp=False,
+            data_parallel_random_init=False,
+        )
+        mock_layer_wise_wrap.assert_called_once_with(cfg, prepared_model, pg_collection)
+        post_wrap_hook.assert_called_once_with(layer_wise_model)
+        assert model_cfg.post_wrap_hooks == [post_wrap_hook]
+        assert result == [*layer_wise_model, "post-wrapped"]
+
     def test_build_with_provider(self):
         """Test that provide_distributed_model is called for providers."""
         mock_provider = MagicMock()
@@ -339,6 +377,7 @@ class TestBuildDistributedModel:
         cfg.model = mock_provider
         cfg.ddp = MagicMock()
         cfg.optimizer.overlap_param_gather_with_optimizer_step = False
+        cfg.optimizer.use_layer_wise_distributed_optimizer = False
         cfg.dist.use_megatron_fsdp = False
         cfg.dist.use_torch_fsdp2 = False
         cfg.rng.data_parallel_random_init = False
@@ -347,6 +386,106 @@ class TestBuildDistributedModel:
 
         mock_provider.provide_distributed_model.assert_called_once()
         assert result == mock_dist_model
+
+    @patch("megatron.bridge.training.setup._wrap_model_chunks_with_layer_wise_ddp")
+    def test_build_provider_with_layer_wise_ddp_optimizer(self, mock_layer_wise_wrap):
+        """Provider models must also bypass their conventional DDP wrapper for layer-wise Muon."""
+        mock_provider = MagicMock()
+        mock_provider.__class__ = type("FakeProvider", (), {})
+        post_wrap_hook = MagicMock(side_effect=lambda model: [*model, "post-wrapped"])
+        mock_provider.post_wrap_hook = post_wrap_hook
+
+        prepared_model = [MagicMock()]
+        layer_wise_model = [MagicMock()]
+        mock_provider.provide_distributed_model.return_value = prepared_model
+        mock_layer_wise_wrap.return_value = layer_wise_model
+
+        cfg = MagicMock()
+        cfg.model = mock_provider
+        cfg.ddp = MagicMock()
+        cfg.optimizer.overlap_param_gather_with_optimizer_step = False
+        cfg.optimizer.use_layer_wise_distributed_optimizer = True
+        cfg.dist.use_megatron_fsdp = False
+        cfg.dist.use_torch_fsdp2 = False
+        cfg.rng.data_parallel_random_init = False
+        pg_collection = MagicMock()
+
+        result = _build_distributed_model(cfg, pg_collection)
+
+        mock_provider.provide_distributed_model.assert_called_once()
+        provider_kwargs = mock_provider.provide_distributed_model.call_args.kwargs
+        assert provider_kwargs["wrap_with_ddp"] is False
+        assert provider_kwargs["data_parallel_random_init"] is False
+        assert provider_kwargs["use_megatron_fsdp"] is False
+        assert provider_kwargs["use_torch_fsdp2"] is False
+        assert provider_kwargs["post_wrap_hook"](prepared_model) is prepared_model
+        mock_layer_wise_wrap.assert_called_once_with(cfg, prepared_model, pg_collection)
+        post_wrap_hook.assert_called_once_with(layer_wise_model)
+        assert result == [*layer_wise_model, "post-wrapped"]
+
+
+def test_wrap_model_chunks_with_layer_wise_ddp_uses_mcore_layout_and_broadcasts():
+    """The MBridge adapter must preserve MCore's layer-wise DDP arguments and ordering."""
+    first_chunk = MagicMock()
+    first_chunk.parameters.return_value = [SimpleNamespace(nelement=lambda: 3)]
+    second_chunk = MagicMock()
+    second_chunk.parameters.return_value = [SimpleNamespace(nelement=lambda: 5)]
+    wrapped_chunks = [MagicMock(), MagicMock()]
+
+    cfg = SimpleNamespace(
+        model=SimpleNamespace(transformer=MagicMock()),
+        ddp=SimpleNamespace(bucket_size=None, overlap_grad_reduce=True),
+        optimizer=SimpleNamespace(
+            overlap_param_gather_with_optimizer_step=False,
+            use_layer_wise_param_layout=False,
+        ),
+        dist=SimpleNamespace(
+            use_megatron_fsdp=False,
+            use_torch_fsdp2=False,
+            use_decentralized_pg=True,
+        ),
+        rng=SimpleNamespace(data_parallel_random_init=True),
+    )
+    pg_collection = MagicMock()
+    pg_collection.pp.rank.return_value = 0
+    ddp_stream = MagicMock()
+    current_stream = MagicMock()
+
+    with (
+        patch(
+            "megatron.training.training.resolve_ddp_bucket_size",
+            return_value=123,
+        ) as mock_resolve_bucket_size,
+        patch(
+            "megatron.training.training.wrap_model_chunks_with_ddp",
+            return_value=wrapped_chunks,
+        ) as mock_wrap,
+        patch("megatron.bridge.training.setup.torch.cuda.Stream", return_value=ddp_stream),
+        patch("megatron.bridge.training.setup.torch.cuda.current_stream", return_value=current_stream),
+        patch("megatron.bridge.training.setup.torch.cuda.stream"),
+    ):
+        result = _wrap_model_chunks_with_layer_wise_ddp(
+            cfg,
+            [first_chunk, second_chunk],
+            pg_collection,
+        )
+
+    mock_resolve_bucket_size.assert_called_once_with(cfg.ddp, pg_collection.dp_cp, True, 8)
+    mock_wrap.assert_called_once_with(
+        [first_chunk, second_chunk],
+        cfg.model,
+        cfg.ddp,
+        use_layer_wise_distributed_optimizer=True,
+        pg_collection=pg_collection,
+        bucket_sizes=[123, None],
+        disable_bucketing_per_chunk=[False, True],
+    )
+    assert cfg.ddp.use_layer_wise_param_layout is False
+    ddp_stream.wait_stream.assert_called_once_with(current_stream)
+    current_stream.wait_stream.assert_called_once_with(ddp_stream)
+    for wrapped_chunk in wrapped_chunks:
+        wrapped_chunk.broadcast_params.assert_called_once_with()
+    assert result == wrapped_chunks
 
 
 def test_restart_rebinds_overlap_callbacks_to_rebuilt_model():

--- a/tests/unit_tests/training/test_train.py
+++ b/tests/unit_tests/training/test_train.py
@@ -27,6 +27,7 @@ from megatron.bridge.training.train import (
     _handle_mxfp8_param_buffer_copy,
     _maybe_register_fsdp_buffers,
     _should_skip_and_handle_iteration,
+    _wrap_sequence_packing_data_iterator,
     checkpoint_and_decide_exit,
     force_param_sync,
     maybe_check_weight_hash_across_dp_replicas,
@@ -40,6 +41,26 @@ from megatron.bridge.training.utils.train_utils import maybe_inject_state
 
 
 pytestmark = pytest.mark.unit
+
+
+def test_wrap_sequence_packing_data_iterator_delegates_to_mcore(monkeypatch):
+    expected = (iter(()), 8, 1024.0, 4096.0)
+    mcore_wrap = Mock(return_value=expected)
+    monkeypatch.setattr("megatron.core.datasets.data_schedule.wrap_data_iterator", mcore_wrap)
+
+    data_iterator = iter(())
+    model_config = SimpleNamespace(sequence_packing_scheduler="dp_balanced")
+    pg_collection = Mock()
+
+    result = _wrap_sequence_packing_data_iterator(data_iterator, model_config, 4, pg_collection)
+
+    assert result == expected
+    mcore_wrap.assert_called_once_with(
+        data_iterator,
+        model_config,
+        4,
+        pg_collection=pg_collection,
+    )
 
 
 class TestFSDPRegistration:
@@ -440,6 +461,16 @@ class TestShouldDisableForwardPreHook:
             use_megatron_fsdp=False, use_distributed_optimizer=False, overlap_param_gather=True
         )
         assert result is False
+
+    def test_disable_with_layer_wise_distributed_optimizer_and_overlap(self):
+        """Muon's layer-wise distributed optimizer needs the same first-iteration guard."""
+        result = should_disable_forward_pre_hook(
+            use_megatron_fsdp=False,
+            use_distributed_optimizer=False,
+            overlap_param_gather=True,
+            use_layer_wise_distributed_optimizer=True,
+        )
+        assert result is True
 
     def test_keep_enabled_without_overlap_param_gather(self):
         """Test that pre-hook stays enabled when not overlapping parameter gathering."""

--- a/tests/unit_tests/training/utils/test_train_utils.py
+++ b/tests/unit_tests/training/utils/test_train_utils.py
@@ -1456,8 +1456,79 @@ class TestTrainingLog:
             model=None,
         )
 
-        # Verify MTP tracking was called
-        mock_mtp_helper.track_mtp_metrics.assert_called_once()
+        # The tracker is already token-normalized across ranks and microbatches.
+        mock_mtp_helper.track_mtp_metrics.assert_called_once_with(
+            1.0,
+            mock_global_state.train_state.step,
+            mock.ANY,
+            mock_global_state.wandb_logger,
+            total_loss_dict,
+        )
+
+    @mock.patch("megatron.bridge.training.utils.train_utils.get_num_microbatches")
+    @mock.patch("megatron.bridge.training.utils.train_utils.reduce_max_stat_across_model_parallel_group")
+    @mock.patch("megatron.bridge.training.utils.train_utils.get_world_size_safe")
+    @mock.patch("megatron.bridge.training.utils.train_utils.print_rank_last")
+    @mock.patch("megatron.bridge.training.utils.train_utils.DSAIndexerLossLoggingHelper")
+    @mock.patch("megatron.bridge.training.utils.train_utils.report_runtime")
+    @mock.patch("megatron.bridge.training.utils.train_utils.report_throughput")
+    @mock.patch("megatron.bridge.training.utils.train_utils.report_l2_norm_grad")
+    def test_dsa_indexer_logging(
+        self,
+        mock_report_l2_norm_grad,
+        mock_report_throughput,
+        mock_report_runtime,
+        mock_indexer_helper,
+        mock_print_rank_last,
+        mock_get_world_size,
+        mock_reduce_lr,
+        mock_get_microbatches,
+        mock_config,
+        mock_global_state,
+        loss_dict,
+    ):
+        """Test sparse DSA indexer loss logging when enabled."""
+        total_loss_dict = self.get_fresh_total_loss_dict()
+        mock_report_l2_norm_grad.return_value = {}
+        mock_report_throughput.return_value = {}
+        mock_report_runtime.return_value = {}
+        mock_get_microbatches.return_value = 8
+        mock_reduce_lr.return_value = 1e-4
+        mock_get_world_size.return_value = 32
+        mock_config.model.num_moe_experts = None
+        mock_config.model.mtp_num_layers = None
+        mock_config.model.dsa_indexer_loss_coeff = 0.01
+        mock_config.model.num_layers = 3
+        mock_config.model.csa_compress_ratios = [128, 128, 4]
+        mock_config.model.cuda_graph_impl = "none"
+
+        training_log(
+            loss_dict=loss_dict,
+            total_loss_dict=total_loss_dict,
+            learning_rate=1e-4,
+            decoupled_learning_rate=None,
+            loss_scale=1024.0,
+            report_memory_flag=False,
+            skipped_iter=0,
+            grad_norm=2.5,
+            params_norm=15.2,
+            num_zeros_in_grad=0,
+            config=mock_config,
+            global_state=mock_global_state,
+            history_wct=None,
+            model=None,
+        )
+
+        mock_indexer_helper.track_indexer_metrics.assert_called_once_with(
+            loss_scale=0.125,
+            iteration=mock_global_state.train_state.step,
+            writer=mock.ANY,
+            wandb_writer=mock_global_state.wandb_logger,
+            total_loss_dict=total_loss_dict,
+            num_layers=3,
+            csa_compress_ratios=[128, 128, 4],
+            preserve_groups=False,
+        )
 
     @mock.patch("megatron.bridge.training.utils.train_utils.get_num_microbatches")
     @mock.patch("megatron.bridge.training.utils.train_utils.reduce_max_stat_across_model_parallel_group")


### PR DESCRIPTION
# What does this PR do ?

Adds a 64-GPU GB300 DeepSeek V4 Pro proxy recipe for 64K THD sequence packing with context parallelism, plus the MBridge integration needed to run it.

# Changelog

- Add the 15-layer proxy recipe with CP16, EP64, DP4, DSA/MTP, MXFP8, partial CUDA graphs, and layer-wise Muon.
- Scale the existing 256-GPU entry point to the 61-layer 64K THD full model with PP4/VPP4, activation offloading, and selective recompute.
- Wire MCore's mock variable-length dataset and per-global-batch THD packing scheduler through MBridge.
- Add layer-wise Muon DDP setup and MTP/DSA metric handling.
- Add unit coverage for the recipe and shared integration paths.

# GitHub Actions CI

- `pre-commit run --all-files`: passed.
- Local unit/functional tests were not run because the development host is macOS; GitHub CI will provide test coverage.
- The finalized 256-GPU recipe dry-run completed on Lyris as job `2533728`.
- Validated on 64 GB300 GPUs (Lyris job `2532436`): 30 completed iterations at 64K THD, CP16/EP64/DP4, no skipped or NaN iterations, no paged-stashing rerun, ~29.7 s steady-state iteration time, and peak memory within 1% of reference job `2518258`.
- The cluster validation used `nvcr.io/nvidian/nemo:26.08.rc3` rebuilt with DeepEP `1.2.1+1b8f467`; the unmodified rc3 DeepEP triggers the known false-overflow/paged-stashing rerun.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

# Additional Information

The recipe requires a Megatron-Core revision that provides the variable-length mock dataset and sequence-packing scheduler APIs.
