### PR TITLE
[recipe,doc] fix: Update Qwen3 recipe examples

### DIFF
--- a/docs/fern/versions/nightly/pages/models/qwen/qwen.mdx
+++ b/docs/fern/versions/nightly/pages/models/qwen/qwen.mdx
@@ -364,30 +364,32 @@ uv run python examples/conversion/hf_to_megatron_generate_text.py \
 
 | Model | Mode | TP | PP | Total GPUs | Use Case |
 |-------|------|----|----|------------|----------|
-| **Qwen3 (0.6B-4B)** | Pretrain | 1 | 1 | 8 | Pre-training (single node) |
-| **Qwen3 (0.6B-4B)** | Full SFT | 1 | 1 | 8 | Full supervised finetuning |
-| **Qwen3 (0.6B-4B)** | LoRA/DoRA | 1 | 1 | 8 | PEFT finetuning (single node) |
-| **Qwen3 (8B-14B)** | Pretrain | 2 | 1 | 16 | Pre-training (2 nodes) |
-| **Qwen3 (8B-14B)** | Full SFT | 2 | 1 | 16 | Full supervised finetuning (2 nodes) |
-| **Qwen3 (8B-14B)** | LoRA/DoRA | 1 | 1 | 8 | PEFT finetuning (single node!) |
-| **Qwen3-32B** | Pretrain | 4 | 1 | 32 | Pre-training (4 nodes) |
-| **Qwen3-32B** | Full SFT | 4 | 1 | 32 | Full supervised finetuning (4 nodes) |
-| **Qwen3-32B** | LoRA/DoRA | 2 | 1 | 16 | PEFT finetuning (2 nodes) |
+| **Qwen3 0.6B-1.7B** | Pretrain / Full SFT / LoRA / DoRA | 1 | 1 | 1 | Single-GPU training |
+| **Qwen3 4B** | Pretrain / Full SFT | 2 | 1 | 2 | Two-GPU training |
+| **Qwen3 4B** | LoRA / DoRA | 1 | 1 | 1 | Single-GPU PEFT |
+| **Qwen3 8B** | Pretrain | 1 | 1 | 16 | Convergence recipe with DP=16 |
+| **Qwen3 8B** | Full SFT | 4 | 1 | 4 | Four-GPU full finetuning |
+| **Qwen3 8B** | LoRA / DoRA | 1 | 1 | 1 | Single-GPU PEFT |
+| **Qwen3 14B** | Pretrain / Full SFT | 8 | 1 | 8 | Single-node training |
+| **Qwen3 14B** | LoRA / DoRA | 1 | 1 | 1 | Single-GPU PEFT |
+| **Qwen3 32B** | Pretrain / Full SFT | 8 | 2 | 16 | Two-node training |
+| **Qwen3 32B** | LoRA / DoRA | 1 | 1 | 1 | Single-GPU PEFT |
 
 #### Pre-training Example
 
 ```python
 from megatron.bridge.recipes.qwen import qwen3_8b_pretrain_config
 
-config = qwen3_8b_pretrain_config(
-    name="qwen3_8b_pretrain",
-    data_paths=["/path/to/dataset.nvjsonl"],
-    dir="/results/qwen3_8b",
-    train_iters=500_000,
-    global_batch_size=2048,
-    seq_length=4096,
-    # Uses TP=2, PP=1 (16 GPUs) automatically
-)
+config = qwen3_8b_pretrain_config()
+config.dataset.data_path = "/path/to/dataset_text_document"
+config.checkpoint.save = "/results/qwen3_8b/checkpoints"
+config.logger.tensorboard_dir = "/results/qwen3_8b/tb_logs"
+config.train.train_iters = 500_000
+config.train.global_batch_size = 2048
+config.scheduler.lr_decay_iters = 500_000
+config.model.seq_length = 4096
+config.dataset.seq_length = 4096
+# Uses TP=1, PP=1 (1 model-parallel GPU); the remaining 15 GPUs are data parallel
 ```
 
 #### Finetuning Examples
@@ -397,14 +399,13 @@ config = qwen3_8b_pretrain_config(
 ```python
 from megatron.bridge.recipes.qwen import qwen3_8b_sft_config
 
-config = qwen3_8b_sft_config(
-    name="qwen3_8b_full_sft",
-    pretrained_checkpoint="/results/qwen3_8b/checkpoints/iter_0500000",
-    train_iters=1000,
-    global_batch_size=64,
-    finetune_lr=5e-6,
-    # Uses TP=2, PP=1 (16 GPUs) automatically
-)
+config = qwen3_8b_sft_config()
+config.checkpoint.pretrained_checkpoint = "/results/qwen3_8b/checkpoints/iter_0500000"
+config.train.train_iters = 1000
+config.train.global_batch_size = 64
+config.scheduler.lr_decay_iters = 1000
+config.optimizer.lr = 5e-6
+# Uses TP=4, PP=1 (4 model-parallel GPUs)
 ```
 
 **LoRA Finetuning (8B):**
@@ -412,15 +413,13 @@ config = qwen3_8b_sft_config(
 ```python
 from megatron.bridge.recipes.qwen import qwen3_8b_peft_config
 
-config = qwen3_8b_peft_config(
-    name="qwen3_8b_lora",
-    pretrained_checkpoint="/results/qwen3_8b/checkpoints/iter_0500000",
-    peft_scheme="lora",  # or "dora"
-    train_iters=1000,
-    global_batch_size=128,
-    finetune_lr=1e-4,
-    # Uses TP=1, PP=1 (8 GPUs) automatically
-)
+config = qwen3_8b_peft_config(peft_scheme="lora")  # or "dora"
+config.checkpoint.pretrained_checkpoint = "/results/qwen3_8b/checkpoints/iter_0500000"
+config.train.train_iters = 1000
+config.train.global_batch_size = 128
+config.scheduler.lr_decay_iters = 1000
+config.optimizer.lr = 1e-4
+# Uses TP=1, PP=1 (1 model-parallel GPU)
 ```
 
 ### Hugging Face Model Cards

--- a/docs/models/qwen/qwen.md
+++ b/docs/models/qwen/qwen.md
@@ -364,30 +364,32 @@ uv run python examples/conversion/hf_to_megatron_generate_text.py \
 
 | Model | Mode | TP | PP | Total GPUs | Use Case |
 |-------|------|----|----|------------|----------|
-| **Qwen3 (0.6B-4B)** | Pretrain | 1 | 1 | 8 | Pre-training (single node) |
-| **Qwen3 (0.6B-4B)** | Full SFT | 1 | 1 | 8 | Full supervised finetuning |
-| **Qwen3 (0.6B-4B)** | LoRA/DoRA | 1 | 1 | 8 | PEFT finetuning (single node) |
-| **Qwen3 (8B-14B)** | Pretrain | 2 | 1 | 16 | Pre-training (2 nodes) |
-| **Qwen3 (8B-14B)** | Full SFT | 2 | 1 | 16 | Full supervised finetuning (2 nodes) |
-| **Qwen3 (8B-14B)** | LoRA/DoRA | 1 | 1 | 8 | PEFT finetuning (single node!) |
-| **Qwen3-32B** | Pretrain | 4 | 1 | 32 | Pre-training (4 nodes) |
-| **Qwen3-32B** | Full SFT | 4 | 1 | 32 | Full supervised finetuning (4 nodes) |
-| **Qwen3-32B** | LoRA/DoRA | 2 | 1 | 16 | PEFT finetuning (2 nodes) |
+| **Qwen3 0.6B-1.7B** | Pretrain / Full SFT / LoRA / DoRA | 1 | 1 | 1 | Single-GPU training |
+| **Qwen3 4B** | Pretrain / Full SFT | 2 | 1 | 2 | Two-GPU training |
+| **Qwen3 4B** | LoRA / DoRA | 1 | 1 | 1 | Single-GPU PEFT |
+| **Qwen3 8B** | Pretrain | 1 | 1 | 16 | Convergence recipe with DP=16 |
+| **Qwen3 8B** | Full SFT | 4 | 1 | 4 | Four-GPU full finetuning |
+| **Qwen3 8B** | LoRA / DoRA | 1 | 1 | 1 | Single-GPU PEFT |
+| **Qwen3 14B** | Pretrain / Full SFT | 8 | 1 | 8 | Single-node training |
+| **Qwen3 14B** | LoRA / DoRA | 1 | 1 | 1 | Single-GPU PEFT |
+| **Qwen3 32B** | Pretrain / Full SFT | 8 | 2 | 16 | Two-node training |
+| **Qwen3 32B** | LoRA / DoRA | 1 | 1 | 1 | Single-GPU PEFT |
 
 #### Pre-training Example
 
 ```python
 from megatron.bridge.recipes.qwen import qwen3_8b_pretrain_config
 
-config = qwen3_8b_pretrain_config(
-    name="qwen3_8b_pretrain",
-    data_paths=["/path/to/dataset.nvjsonl"],
-    dir="/results/qwen3_8b",
-    train_iters=500_000,
-    global_batch_size=2048,
-    seq_length=4096,
-    # Uses TP=2, PP=1 (16 GPUs) automatically
-)
+config = qwen3_8b_pretrain_config()
+config.dataset.data_path = "/path/to/dataset_text_document"
+config.checkpoint.save = "/results/qwen3_8b/checkpoints"
+config.logger.tensorboard_dir = "/results/qwen3_8b/tb_logs"
+config.train.train_iters = 500_000
+config.train.global_batch_size = 2048
+config.scheduler.lr_decay_iters = 500_000
+config.model.seq_length = 4096
+config.dataset.seq_length = 4096
+# Uses TP=1, PP=1 (1 model-parallel GPU); the remaining 15 GPUs are data parallel
 ```
 
 #### Finetuning Examples
@@ -397,14 +399,13 @@ config = qwen3_8b_pretrain_config(
 ```python
 from megatron.bridge.recipes.qwen import qwen3_8b_sft_config
 
-config = qwen3_8b_sft_config(
-    name="qwen3_8b_full_sft",
-    pretrained_checkpoint="/results/qwen3_8b/checkpoints/iter_0500000",
-    train_iters=1000,
-    global_batch_size=64,
-    finetune_lr=5e-6,
-    # Uses TP=2, PP=1 (16 GPUs) automatically
-)
+config = qwen3_8b_sft_config()
+config.checkpoint.pretrained_checkpoint = "/results/qwen3_8b/checkpoints/iter_0500000"
+config.train.train_iters = 1000
+config.train.global_batch_size = 64
+config.scheduler.lr_decay_iters = 1000
+config.optimizer.lr = 5e-6
+# Uses TP=4, PP=1 (4 model-parallel GPUs)
 ```
 
 **LoRA Finetuning (8B):**
@@ -412,15 +413,13 @@ config = qwen3_8b_sft_config(
 ```python
 from megatron.bridge.recipes.qwen import qwen3_8b_peft_config
 
-config = qwen3_8b_peft_config(
-    name="qwen3_8b_lora",
-    pretrained_checkpoint="/results/qwen3_8b/checkpoints/iter_0500000",
-    peft_scheme="lora",  # or "dora"
-    train_iters=1000,
-    global_batch_size=128,
-    finetune_lr=1e-4,
-    # Uses TP=1, PP=1 (8 GPUs) automatically
-)
+config = qwen3_8b_peft_config(peft_scheme="lora")  # or "dora"
+config.checkpoint.pretrained_checkpoint = "/results/qwen3_8b/checkpoints/iter_0500000"
+config.train.train_iters = 1000
+config.train.global_batch_size = 128
+config.scheduler.lr_decay_iters = 1000
+config.optimizer.lr = 1e-4
+# Uses TP=1, PP=1 (1 model-parallel GPU)
 ```
 
 ### Hugging Face Model Cards

--- a/tests/unit_tests/doc_consistency/test_readme_consistency.py
+++ b/tests/unit_tests/doc_consistency/test_readme_consistency.py
@@ -53,6 +53,12 @@ QWEN25_VL_DOCS = (
     REPO_ROOT / "docs" / "models" / "qwen" / "qwen2.5-vl.md",
     REPO_ROOT / "docs" / "fern" / "versions" / "nightly" / "pages" / "models" / "qwen" / "qwen2.5-vl.mdx",
 )
+QWEN3_DOCS = (
+    REPO_ROOT / "docs" / "models" / "qwen" / "qwen.md",
+    REPO_ROOT / "docs" / "fern" / "versions" / "nightly" / "pages" / "models" / "qwen" / "qwen.mdx",
+)
+QWEN3_ALIASES = RECIPES_DIR / "qwen" / "qwen3.py"
+QWEN3_H100_RECIPES = RECIPES_DIR / "qwen" / "h100" / "qwen3.py"
 VALOR_TUTORIAL = REPO_ROOT / "tutorials" / "data" / "valor32k-avqa" / "data-preparation.md"
 SPHINX_TUTORIAL_LINK_DOCS = (
     REPO_ROOT / "docs" / "training" / "data-preparation.md",
@@ -310,6 +316,142 @@ def test_multimodal_model_docs_use_current_launchers_and_conversion_flags():
     assert "--megatron-path /checkpoints/nemotron_omni" in valor
     assert "--hf_path" not in valor
     assert "--output_dir /checkpoints/nemotron_omni" not in valor
+
+
+def test_qwen3_recipe_examples_use_current_factory_api():
+    """Qwen3 recipe examples must call factories with their supported keywords."""
+    assert _read(QWEN3_DOCS[0]) == _read(QWEN3_DOCS[1])
+    expected_keywords = {
+        "qwen3_8b_pretrain_config": set(),
+        "qwen3_8b_sft_config": set(),
+        "qwen3_8b_peft_config": {"peft_scheme"},
+    }
+    for path in QWEN3_DOCS:
+        qwen3_docs = _read(path).split("\n## Qwen3\n", 1)[1].split("## Qwen2 / Qwen2.5", 1)[0]
+        examples = qwen3_docs.split("#### Pre-training Example", 1)[1].split("### Hugging Face Model Cards", 1)[0]
+        calls: dict[str, list[set[str | None]]] = {name: [] for name in expected_keywords}
+        for code in re.findall(r"```python\n(.*?)```", examples, re.DOTALL):
+            tree = ast.parse(code, filename=str(path))
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id in calls:
+                    calls[node.func.id].append({keyword.arg for keyword in node.keywords})
+
+        for name, allowed_keywords in expected_keywords.items():
+            assert calls[name] == [allowed_keywords], (
+                f"{path.relative_to(REPO_ROOT)} calls {name} with unsupported keywords: {calls[name]}"
+            )
+
+        assert examples.count("config.optimizer.lr =") == 2
+        assert examples.count("config.scheduler.lr_decay_iters = 1000") == 2
+        assert "config.scheduler.max_lr" not in examples
+
+
+def test_qwen3_recipe_examples_match_source_signatures_and_nested_owners():
+    """Qwen3 examples must follow source signatures and nested config ownership."""
+    recipe_names = {
+        "qwen3_8b_pretrain_config",
+        "qwen3_8b_sft_config",
+        "qwen3_8b_peft_config",
+    }
+    alias_targets: dict[str, str] = {}
+    for node in ast.parse(_read(QWEN3_ALIASES), filename=str(QWEN3_ALIASES)).body:
+        if not isinstance(node, ast.ImportFrom):
+            continue
+        for imported_name in node.names:
+            if imported_name.asname in recipe_names:
+                alias_targets[imported_name.asname] = imported_name.name
+    assert set(alias_targets) == recipe_names
+
+    accepted_keywords: dict[str, set[str]] = {}
+    for node in ast.parse(_read(QWEN3_H100_RECIPES), filename=str(QWEN3_H100_RECIPES)).body:
+        if not isinstance(node, ast.FunctionDef) or node.name not in alias_targets.values():
+            continue
+        assert node.args.kwarg is None
+        accepted_keywords[node.name] = {
+            argument.arg for argument in (*node.args.posonlyargs, *node.args.args, *node.args.kwonlyargs)
+        }
+    assert set(accepted_keywords) == set(alias_targets.values())
+
+    qwen3_docs = _read(QWEN3_DOCS[0]).split("\n## Qwen3\n", 1)[1].split("## Qwen2 / Qwen2.5", 1)[0]
+    examples = qwen3_docs.split("#### Pre-training Example", 1)[1].split("### Hugging Face Model Cards", 1)[0]
+    assignments_by_recipe: dict[str, dict[str, object]] = {}
+    for code in re.findall(r"```python\n(.*?)```", examples, re.DOTALL):
+        tree = ast.parse(code, filename=str(QWEN3_DOCS[0]))
+        recipe_name = next(
+            (
+                node.value.func.id
+                for node in tree.body
+                if isinstance(node, ast.Assign)
+                and isinstance(node.value, ast.Call)
+                and isinstance(node.value.func, ast.Name)
+                and node.value.func.id in recipe_names
+            ),
+            None,
+        )
+        if recipe_name is None:
+            continue
+        factory_call = next(
+            node.value
+            for node in tree.body
+            if isinstance(node, ast.Assign)
+            and isinstance(node.value, ast.Call)
+            and isinstance(node.value.func, ast.Name)
+            and node.value.func.id == recipe_name
+        )
+        assert {keyword.arg for keyword in factory_call.keywords} <= accepted_keywords[alias_targets[recipe_name]]
+        assignments_by_recipe[recipe_name] = {
+            ast.unparse(node.targets[0]): ast.literal_eval(node.value)
+            for node in tree.body
+            if isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and ast.unparse(node.targets[0]).startswith("config.")
+        }
+
+    expected_owners = {
+        "qwen3_8b_pretrain_config": {
+            "config.dataset.data_path",
+            "config.checkpoint.save",
+            "config.logger.tensorboard_dir",
+            "config.train.train_iters",
+            "config.train.global_batch_size",
+            "config.scheduler.lr_decay_iters",
+            "config.model.seq_length",
+            "config.dataset.seq_length",
+        },
+        "qwen3_8b_sft_config": {
+            "config.checkpoint.pretrained_checkpoint",
+            "config.train.train_iters",
+            "config.train.global_batch_size",
+            "config.scheduler.lr_decay_iters",
+            "config.optimizer.lr",
+        },
+        "qwen3_8b_peft_config": {
+            "config.checkpoint.pretrained_checkpoint",
+            "config.train.train_iters",
+            "config.train.global_batch_size",
+            "config.scheduler.lr_decay_iters",
+            "config.optimizer.lr",
+        },
+    }
+    assert set(assignments_by_recipe) == recipe_names
+    for recipe_name, expected_fields in expected_owners.items():
+        assignments = assignments_by_recipe[recipe_name]
+        assert set(assignments) == expected_fields
+        assert assignments["config.scheduler.lr_decay_iters"] == assignments["config.train.train_iters"]
+
+    expected_topologies = {
+        "| **Qwen3 0.6B-1.7B** | Pretrain / Full SFT / LoRA / DoRA | 1 | 1 | 1 | Single-GPU training |",
+        "| **Qwen3 4B** | Pretrain / Full SFT | 2 | 1 | 2 | Two-GPU training |",
+        "| **Qwen3 4B** | LoRA / DoRA | 1 | 1 | 1 | Single-GPU PEFT |",
+        "| **Qwen3 8B** | Pretrain | 1 | 1 | 16 | Convergence recipe with DP=16 |",
+        "| **Qwen3 8B** | Full SFT | 4 | 1 | 4 | Four-GPU full finetuning |",
+        "| **Qwen3 8B** | LoRA / DoRA | 1 | 1 | 1 | Single-GPU PEFT |",
+        "| **Qwen3 14B** | Pretrain / Full SFT | 8 | 1 | 8 | Single-node training |",
+        "| **Qwen3 14B** | LoRA / DoRA | 1 | 1 | 1 | Single-GPU PEFT |",
+        "| **Qwen3 32B** | Pretrain / Full SFT | 8 | 2 | 16 | Two-node training |",
+        "| **Qwen3 32B** | LoRA / DoRA | 1 | 1 | 1 | Single-GPU PEFT |",
+    }
+    assert expected_topologies <= set(qwen3_docs.splitlines())
 
 
 def test_sphinx_docs_link_out_of_tree_tutorials_as_urls():


### PR DESCRIPTION
# What does this PR do ?

Fix the published dense Qwen3 pretraining, SFT, and PEFT examples so they use the current recipe factory and nested `ConfigContainer` APIs.

# Changelog

- Call parameterless pretraining/SFT factories without removed legacy keywords and pass only `peft_scheme` to the PEFT factory.
- Move dataset, checkpoint, training, scheduler, optimizer, logger, and sequence-length overrides to their owning nested configs.
- Keep scheduler decay aligned with the documented training length.
- Align the dense Qwen3 topology table and example comments with the current generic recipe aliases.
- Add a stdlib-only contract that checks both maintained documentation mirrors against the public aliases and canonical factory signatures.

# Bug and root cause

The maintained Qwen3 examples still used the old `**user_kwargs` factory contract. The current public aliases point directly to parameterless pretraining/SFT factories and a PEFT factory that accepts only `peft_scheme`, so copying any example raised `TypeError` before a configuration was constructed.

The regression also checks exact nested-field ownership, scheduler/train-step coherence, maintained-mirror equality, and the topology rows.

# Validation

Fail before:

```text
uv run --no-sync python tests/unit_tests/doc_consistency/test_readme_consistency.py
14/15 passed
AssertionError: docs/models/qwen/qwen.md calls qwen3_8b_pretrain_config
with unsupported keywords
```

Pass after:

```text
uv run --no-sync python tests/unit_tests/doc_consistency/test_readme_consistency.py
16/16 passed

git diff --check
passed

uv run --no-sync pre-commit run --all-files
all applicable hooks passed
```

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] Added focused regression coverage.
- [x] Updated both maintained documentation mirrors.
- [x] No optional dependency behavior is affected.

# Additional Information

This is limited to Qwen3 recipe documentation and its stdlib contract test. It does not change recipe implementations, public APIs, dependencies, CI workflows, or the Megatron-LM submodule. No GPU, convergence, model-quality, or performance validation was performed.

The adjacent Qwen2/Qwen2.5 stale examples were fixed separately in #5138.
