### PR TITLE
[training] fix: Forward NVRx CallWrapper through restart adapter

### DIFF
--- a/src/megatron/bridge/training/inprocess_restart.py
+++ b/src/megatron/bridge/training/inprocess_restart.py
@@ -157,14 +157,11 @@ def inprocess_restart(train_fn: Callable, config: InProcessRestartConfig, global
     #   Optional[CallWrapper] or CallWrapper after binding arguments
     # - Our _pretrain function expects the CallWrapper as a keyword argument named
     #   'inprocess_call_wrapper', but NVRx may pass it differently
-    # - This adapter ensures compatibility by extracting the CallWrapper and passing
-    #   it correctly to the actual training function
-    def _adapter(*args, **kwargs):
-        # Extract the injected CallWrapper from kwargs if NVRx placed it there
-        call_wrapper = kwargs.pop("inprocess_call_wrapper", None)
-
+    # - This adapter exposes the annotated parameter NVRx needs for injection and
+    #   passes it correctly to the actual training function
+    def _adapter(*args, inprocess_call_wrapper: Optional[inprocess.CallWrapper] = None, **kwargs):
         # Call the actual training function with the CallWrapper as expected keyword arg
-        result = train_fn(*args, inprocess_call_wrapper=call_wrapper, **kwargs)
+        result = train_fn(*args, inprocess_call_wrapper=inprocess_call_wrapper, **kwargs)
         return result
 
     new_train_fn = inprocess.Wrapper(

--- a/tests/unit_tests/training/test_inprocess_restart.py
+++ b/tests/unit_tests/training/test_inprocess_restart.py
@@ -553,6 +553,40 @@ class TestAbortCheckpoint:
 class TestAdapterFunction:
     """Test cases for the _adapter function behavior."""
 
+    def test_nvrx_injects_call_wrapper_into_adapter(self):
+        """Test that NVRx can inject its active CallWrapper into the adapter."""
+        from nvidia_resiliency_ext.inprocess import CallWrapper
+        from nvidia_resiliency_ext.inprocess.param_utils import substitute_param_value
+
+        mock_train_fn = MagicMock()
+        config = InProcessRestartConfig(enabled=True, granularity="rank", empty_cuda_cache=False)
+        mock_global_state = MagicMock(spec=GlobalState)
+
+        with (
+            patch.dict(os.environ, {"MASTER_PORT": "29500"}),
+            patch("megatron.bridge.training.inprocess_restart.warnings.warn"),
+            patch("nvidia_resiliency_ext.inprocess.Wrapper") as mock_wrapper,
+        ):
+            mock_wrapper.return_value.return_value = MagicMock()
+            inprocess_restart(mock_train_fn, config, mock_global_state)
+
+        adapter_fn = mock_wrapper.return_value.call_args.args[0]
+        mock_call_wrapper = MagicMock(spec=CallWrapper)
+        args, kwargs = substitute_param_value(
+            adapter_fn,
+            ("arg1",),
+            {"other_kwarg": "value"},
+            {CallWrapper: mock_call_wrapper},
+        )
+
+        adapter_fn(*args, **kwargs)
+
+        mock_train_fn.assert_called_once_with(
+            "arg1",
+            inprocess_call_wrapper=mock_call_wrapper,
+            other_kwarg="value",
+        )
+
     def test_adapter_function_behavior(self):
         """Test that the adapter function correctly handles CallWrapper extraction."""
         # We can't directly test the _adapter function since it's defined inside inprocess_restart,


### PR DESCRIPTION
## Problem

When `cfg.inprocess_restart.enabled=True`, NVIDIA Resiliency Extension injects
its active `CallWrapper` by inspecting the wrapped callable's annotations.
Bridge wraps `_pretrain` in an unannotated `*args, **kwargs` adapter, so NVRx
cannot inject the wrapper. The adapter always forwards `None`.

This makes the restart-attempt `PrefixStore` path unreachable and causes
failures to take Bridge's ordinary distributed-cleanup path instead of leaving
teardown to in-process restart. A fault can therefore reuse stale coordination
keys or race distributed teardown during recovery.

## Fix

Expose `inprocess_call_wrapper` as an annotated keyword-only adapter parameter
and forward it unchanged. This is a private adapter change; no public API or
configuration contract changes.

Add a focused regression test that runs NVRx v0.6.0's real
`substitute_param_value()` against the production adapter and verifies that the
active wrapper reaches the train function.

## Validation

Fail-before / pass-after:

```text
uv run python -m pytest tests/unit_tests/training/test_inprocess_restart.py::TestAdapterFunction::test_nvrx_injects_call_wrapper_into_adapter -q
```

- Before: failed because the train function received
  `inprocess_call_wrapper=None`.
- After: 1 passed.

A two-rank reproducer also exercised Bridge's production adapter through the
real NVRx wrapper:

```text
uv run python -m torch.distributed.run --standalone --nproc_per_node=2 ipr_wrapper_reproducer.py
```

- Before: both ranks reported that Bridge did not forward NVRx's active
  `CallWrapper`.
- After: completed successfully.

Adjacent and static checks:

```text
uv run python -m pytest tests/unit_tests/training/test_inprocess_restart.py -q
# 19 passed

uv run pre-commit run --all-files
# passed

git diff --check
# passed
```

Scope is limited to NVRx `CallWrapper` injection and its focused regression;
the full test suite and convergence/performance validation were not run.
