### PR TITLE
fix(tests): prefer staged external fixtures

### DIFF
--- a/tests/functional_tests/fixture_utils.py
+++ b/tests/functional_tests/fixture_utils.py
@@ -20,6 +20,11 @@ DEFAULT_TEST_DATA_ROOT = Path("/home/TestData")
 TEST_DATA_ROOT_ENV = "NEMO_TEST_DATA_ROOT"
 
 
+def get_test_data_root() -> Path:
+    """Return the configured shared TestData root."""
+    return Path(os.environ.get(TEST_DATA_ROOT_ENV) or DEFAULT_TEST_DATA_ROOT)
+
+
 def resolve_test_data_file(relative_path: str | Path, fallback: str) -> str:
     """Resolve a staged TestData file before using its egress fallback.
 
@@ -30,6 +35,5 @@ def resolve_test_data_file(relative_path: str | Path, fallback: str) -> str:
     Returns:
         The staged file path when it exists, otherwise ``fallback``.
     """
-    test_data_root = Path(os.environ.get(TEST_DATA_ROOT_ENV) or DEFAULT_TEST_DATA_ROOT)
-    staged_path = test_data_root / relative_path
+    staged_path = get_test_data_root() / relative_path
     return str(staged_path) if staged_path.is_file() else fallback

--- a/tests/functional_tests/fixture_utils.py
+++ b/tests/functional_tests/fixture_utils.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from pathlib import Path
+
+
+DEFAULT_TEST_DATA_ROOT = Path("/home/TestData")
+TEST_DATA_ROOT_ENV = "NEMO_TEST_DATA_ROOT"
+
+
+def resolve_test_data_file(relative_path: str | Path, fallback: str) -> str:
+    """Resolve a staged TestData file before using its egress fallback.
+
+    Args:
+        relative_path: File path relative to the TestData root.
+        fallback: Value to use when the staged file is unavailable.
+
+    Returns:
+        The staged file path when it exists, otherwise ``fallback``.
+    """
+    test_data_root = Path(os.environ.get(TEST_DATA_ROOT_ENV) or DEFAULT_TEST_DATA_ROOT)
+    staged_path = test_data_root / relative_path
+    return str(staged_path) if staged_path.is_file() else fallback

--- a/tests/functional_tests/test_groups/converter/test_generate_vlm_from_hf.py
+++ b/tests/functional_tests/test_groups/converter/test_generate_vlm_from_hf.py
@@ -22,13 +22,19 @@ from pathlib import Path
 
 import pytest
 
+from tests.functional_tests.fixture_utils import resolve_test_data_file
+
 
 class TestGenerateVLMFromHF:
     @pytest.mark.run_only_on("GPU")
     def test_generate_vlm(self):
         """
-        Run distributed VLM generation on a small instruct model with an image URL.
+        Run distributed VLM generation on a small instruct model with an image fixture.
         """
+        image_path = resolve_test_data_file(
+            "megatron_bridge/assets/demo.jpeg",
+            "https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen-VL/assets/demo.jpeg",
+        )
         cmd = [
             "python",
             "-m",
@@ -45,7 +51,7 @@ class TestGenerateVLMFromHF:
             "--hf_model_path",
             "Qwen/Qwen2.5-VL-3B-Instruct",
             "--image_path",
-            "https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen-VL/assets/demo.jpeg",
+            image_path,
             "--prompt",
             "Describe this image.",
             "--tp",

--- a/tests/functional_tests/test_groups/data/download_unit_tests_dataset.py
+++ b/tests/functional_tests/test_groups/data/download_unit_tests_dataset.py
@@ -28,6 +28,54 @@ import click
 import requests
 from github import Github
 
+from tests.functional_tests.fixture_utils import get_test_data_root
+
+
+DEFAULT_REPO_NAME = "NVIDIA/Megatron-LM"
+STAGED_RELEASE_ASSETS = (
+    Path("megatron_bridge/release-assets/megatron-lm/v2.5/datasets.zip"),
+    Path("megatron_bridge/release-assets/megatron-lm/v2.5/tokenizers.zip"),
+)
+
+
+def extract_asset(asset_path: Path, assets_dir: Path) -> bool:
+    """Extract a release asset into the writable test data directory."""
+    try:
+        print(f"  Extracting {asset_path.name} to {assets_dir}...")
+
+        if asset_path.name.endswith(".zip"):
+            with zipfile.ZipFile(asset_path, "r") as zip_ref:
+                zip_ref.extractall(assets_dir)
+        elif asset_path.name.endswith((".tar.gz", ".tgz")):
+            with tarfile.open(asset_path, "r:gz") as tar_ref:
+                tar_ref.extractall(assets_dir)
+        elif asset_path.name.endswith(".tar"):
+            with tarfile.open(asset_path, "r") as tar_ref:
+                tar_ref.extractall(assets_dir)
+        else:
+            print(f"  Warning: Unknown file type for {asset_path.name}, skipping extraction")
+            return False
+
+        print(f"  Successfully extracted to {assets_dir}")
+        return True
+
+    except Exception as e:
+        print(f"  Error extracting {asset_path.name}: {e}")
+        return False
+
+
+def extract_staged_release_assets(repo_name: str, assets_dir: Path) -> bool:
+    """Extract staged Megatron-LM v2.5 assets when all of them are available."""
+    if repo_name != DEFAULT_REPO_NAME:
+        return False
+
+    staged_assets = tuple(get_test_data_root() / relative_path for relative_path in STAGED_RELEASE_ASSETS)
+    if not all(asset_path.is_file() for asset_path in staged_assets):
+        return False
+
+    print(f"Using staged release assets from {staged_assets[0].parent}")
+    return all(extract_asset(asset_path, assets_dir) for asset_path in staged_assets)
+
 
 def download_and_extract_asset(asset_url: str, asset_name: str, assets_dir: Path) -> bool:
     """
@@ -41,45 +89,29 @@ def download_and_extract_asset(asset_url: str, asset_name: str, assets_dir: Path
     Returns:
         bool: True if successful, False otherwise
     """
+    temp_file = assets_dir / asset_name
     try:
         # Download the asset
         print(f"  Downloading {asset_name}...")
-        response = requests.get(asset_url, stream=True)
+        response = requests.get(asset_url, stream=True, timeout=60)
         response.raise_for_status()
 
         # Save to temporary file
-        temp_file = assets_dir / asset_name
         with open(temp_file, "wb") as f:
             for chunk in response.iter_content(chunk_size=8192):
                 f.write(chunk)
 
-        print(f"  Extracting {asset_name} to {assets_dir}...")
-
-        # Extract based on file type
-        if asset_name.endswith(".zip"):
-            with zipfile.ZipFile(temp_file, "r") as zip_ref:
-                zip_ref.extractall(assets_dir)
-        elif asset_name.endswith((".tar.gz", ".tgz")):
-            with tarfile.open(temp_file, "r:gz") as tar_ref:
-                tar_ref.extractall(assets_dir)
-        elif asset_name.endswith(".tar"):
-            with tarfile.open(temp_file, "r") as tar_ref:
-                tar_ref.extractall(assets_dir)
-        else:
-            print(f"  Warning: Unknown file type for {asset_name}, skipping extraction")
-            return False
-
-        # Clean up temporary file
-        temp_file.unlink()
-        print(f"  Successfully extracted to {assets_dir}")
-        return True
+        return extract_asset(temp_file, assets_dir)
 
     except Exception as e:
         print(f"  Error downloading/extracting {asset_name}: {e}")
         return False
+    finally:
+        if temp_file.is_file():
+            temp_file.unlink()
 
 
-def get_oldest_release_and_assets(repo_name: str = "NVIDIA/Megatron-LM", assets_dir: str = "assets") -> None:
+def get_oldest_release_and_assets(repo_name: str = DEFAULT_REPO_NAME, assets_dir: str = "assets") -> None:
     """
     Fetch the oldest release of a GitHub repository and list its assets.
 
@@ -88,12 +120,15 @@ def get_oldest_release_and_assets(repo_name: str = "NVIDIA/Megatron-LM", assets_
         assets_dir: Directory to extract assets to
     """
     try:
-        # Initialize GitHub client
-        token = os.getenv("GH_TOKEN", None)
-        if token is None:
-            raise ValueError("GH_TOKEN environment variable is not set")
+        assets_path = Path(assets_dir)
+        assets_path.mkdir(parents=True, exist_ok=True)
 
-        g = Github(login_or_token=token)
+        if extract_staged_release_assets(repo_name, assets_path):
+            return
+
+        # Initialize an authenticated GitHub client when a token is available.
+        token = os.getenv("GH_TOKEN", None)
+        g = Github(login_or_token=token) if token else Github()
 
         # Get the repository
         repo = g.get_repo(repo_name)
@@ -161,9 +196,6 @@ def get_oldest_release_and_assets(repo_name: str = "NVIDIA/Megatron-LM", assets_
             print("-" * 80)
             print("Downloading and extracting assets...")
 
-            # Create assets directory
-            assets_path = Path(assets_dir)
-            assets_path.mkdir(parents=True, exist_ok=True)
             print(f"Created assets directory: {assets_path.absolute()}")
 
             successful_downloads = 0
@@ -182,7 +214,7 @@ def get_oldest_release_and_assets(repo_name: str = "NVIDIA/Megatron-LM", assets_
 
 
 @click.command()
-@click.option("--repo", default="NVIDIA/Megatron-LM", help="GitHub repository name (format: owner/repo)")
+@click.option("--repo", default=DEFAULT_REPO_NAME, help="GitHub repository name (format: owner/repo)")
 @click.option("--assets-dir", default="assets", help="Directory to extract assets to")
 def main(repo, assets_dir):
     """Fetch the oldest release of a GitHub repository and download its assets."""

--- a/tests/functional_tests/test_groups/data/download_unit_tests_dataset.py
+++ b/tests/functional_tests/test_groups/data/download_unit_tests_dataset.py
@@ -33,8 +33,8 @@ from tests.functional_tests.fixture_utils import get_test_data_root
 
 DEFAULT_REPO_NAME = "NVIDIA/Megatron-LM"
 STAGED_RELEASE_ASSETS = (
-    Path("megatron_bridge/release-assets/megatron-lm/v2.5/datasets.zip"),
-    Path("megatron_bridge/release-assets/megatron-lm/v2.5/tokenizers.zip"),
+    Path("megatron-lm/release-assets/v2.5/datasets.zip"),
+    Path("megatron-lm/release-assets/v2.5/tokenizers.zip"),
 )
 
 

--- a/tests/functional_tests/test_groups/models/qwen_audio/test_qwen2_audio_generation.py
+++ b/tests/functional_tests/test_groups/models/qwen_audio/test_qwen2_audio_generation.py
@@ -34,6 +34,8 @@ import pytest
 import torch
 from transformers import AutoTokenizer, Qwen2AudioConfig, Qwen2AudioForConditionalGeneration
 
+from tests.functional_tests.fixture_utils import resolve_test_data_file
+
 
 HF_QWEN2_AUDIO_TOY_MODEL_CONFIG = {
     "architectures": ["Qwen2AudioForConditionalGeneration"],
@@ -150,6 +152,11 @@ class TestQwen2AudioGeneration:
         Args:
             qwen2_audio_toy_model_path: Path to the toy Qwen2 Audio model (from fixture)
         """
+        audio_path = resolve_test_data_file(
+            "megatron_bridge/assets/glass-breaking-151256.mp3",
+            "https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen2-Audio/audio/glass-breaking-151256.mp3",
+        )
+        audio_option = "--audio_url" if audio_path.startswith(("http://", "https://")) else "--audio_path"
         cmd = [
             sys.executable,
             "-m",
@@ -157,7 +164,7 @@ class TestQwen2AudioGeneration:
             "--nproc_per_node=2",
             "examples/conversion/hf_to_megatron_generate_audio_lm.py",
             f"--hf_model_path={qwen2_audio_toy_model_path}",
-            "--audio_url=https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen2-Audio/audio/glass-breaking-151256.mp3",
+            f"{audio_option}={audio_path}",
             "--prompt=What's that sound?",
             "--tp=2",
             "--max_new_tokens=50",

--- a/tests/functional_tests/test_groups/models/qwen_vl/test_qwen3_vl_generation.py
+++ b/tests/functional_tests/test_groups/models/qwen_vl/test_qwen3_vl_generation.py
@@ -42,6 +42,8 @@ from transformers import (
 )
 from transformers.models.qwen3_vl import Qwen3VLConfig
 
+from tests.functional_tests.fixture_utils import resolve_test_data_file
+
 
 HF_QWEN3_VL_TOY_MODEL_CONFIG = {
     "architectures": ["Qwen3VLForConditionalGeneration"],
@@ -325,6 +327,10 @@ class TestQwen3VLGeneration:
         Args:
             qwen3_vl_toy_model_path: Path to the toy Qwen3 VL model (from fixture)
         """
+        image_path = resolve_test_data_file(
+            "megatron_bridge/assets/demo.jpeg",
+            "https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen-VL/assets/demo.jpeg",
+        )
         cmd = [
             "python",
             "-m",
@@ -332,7 +338,7 @@ class TestQwen3VLGeneration:
             "--nproc_per_node=2",
             "examples/conversion/hf_to_megatron_generate_vlm.py",
             f"--hf_model_path={qwen3_vl_toy_model_path}",
-            "--image_path=https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen-VL/assets/demo.jpeg",
+            f"--image_path={image_path}",
             "--prompt=Describe this image.",
         ]
 

--- a/tests/unit_tests/test_download_unit_tests_dataset.py
+++ b/tests/unit_tests/test_download_unit_tests_dataset.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+from zipfile import ZipFile
+
+from tests.functional_tests import fixture_utils
+from tests.functional_tests.test_groups.data import download_unit_tests_dataset
+
+
+def test_get_oldest_release_prefers_staged_assets(monkeypatch, tmp_path):
+    staged_root = tmp_path / "staged"
+    output_root = tmp_path / "output"
+    for relative_path in download_unit_tests_dataset.STAGED_RELEASE_ASSETS:
+        staged_asset = staged_root / relative_path
+        staged_asset.parent.mkdir(parents=True, exist_ok=True)
+        with ZipFile(staged_asset, "w") as archive:
+            archive.writestr(f"{staged_asset.stem}/fixture.txt", staged_asset.name)
+
+    monkeypatch.setenv(fixture_utils.TEST_DATA_ROOT_ENV, str(staged_root))
+    github = MagicMock(side_effect=AssertionError("GitHub fallback should not be used"))
+    monkeypatch.setattr(download_unit_tests_dataset, "Github", github)
+
+    download_unit_tests_dataset.get_oldest_release_and_assets(assets_dir=str(output_root))
+
+    assert (output_root / "datasets" / "fixture.txt").read_text() == "datasets.zip"
+    assert (output_root / "tokenizers" / "fixture.txt").read_text() == "tokenizers.zip"
+    github.assert_not_called()
+
+
+def test_get_oldest_release_falls_back_without_github_token(monkeypatch, tmp_path):
+    release = SimpleNamespace(
+        tag_name="v2.5",
+        title="Megatron-LM v2.5",
+        created_at=0,
+        published_at=0,
+        draft=False,
+        prerelease=False,
+        html_url="https://github.com/NVIDIA/Megatron-LM/releases/tag/v2.5",
+        body="",
+        get_assets=lambda: [],
+    )
+    repo = SimpleNamespace(
+        full_name="NVIDIA/Megatron-LM",
+        description="Megatron-LM",
+        html_url="https://github.com/NVIDIA/Megatron-LM",
+        get_releases=lambda: [release],
+    )
+    github = MagicMock()
+    github.return_value.get_repo.return_value = repo
+
+    monkeypatch.setenv(fixture_utils.TEST_DATA_ROOT_ENV, str(tmp_path / "missing"))
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.setattr(download_unit_tests_dataset, "Github", github)
+
+    download_unit_tests_dataset.get_oldest_release_and_assets(assets_dir=str(tmp_path / "output"))
+
+    github.assert_called_once_with()

--- a/tests/unit_tests/test_fixture_utils.py
+++ b/tests/unit_tests/test_fixture_utils.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from tests.functional_tests.fixture_utils import TEST_DATA_ROOT_ENV, resolve_test_data_file
+
+
+def test_resolve_test_data_file_prefers_staged_file(monkeypatch, tmp_path):
+    relative_path = "megatron_bridge/assets/demo.jpeg"
+    staged_path = tmp_path / relative_path
+    staged_path.parent.mkdir(parents=True)
+    staged_path.write_bytes(b"fixture")
+    monkeypatch.setenv(TEST_DATA_ROOT_ENV, str(tmp_path))
+
+    assert resolve_test_data_file(relative_path, "https://example.com/demo.jpeg") == str(staged_path)
+
+
+def test_resolve_test_data_file_uses_fallback_when_staged_file_is_missing(monkeypatch, tmp_path):
+    fallback = "https://example.com/demo.jpeg"
+    monkeypatch.setenv(TEST_DATA_ROOT_ENV, str(tmp_path))
+
+    assert resolve_test_data_file("megatron_bridge/assets/demo.jpeg", fallback) == fallback


### PR DESCRIPTION
## Background

Qwen functional tests fetch demo media from Aliyun during execution, and the shared functional-test data fixture fetches the oldest Megatron-LM release assets from GitHub. Restricted or unreliable egress causes timeouts even when TestData is mounted, while the release helper also hard-fails when `GH_TOKEN` is absent.

## What changed

- Add a shared TestData resolver that prefers staged files and retains existing remote values as fallbacks.
- Use staged image and audio fixtures in the Qwen VLM and Qwen2 Audio tests.
- Extract staged Megatron-LM v2.5 `datasets.zip` and `tokenizers.zip` archives before consulting GitHub.
- Use unauthenticated public GitHub access when `GH_TOKEN` is unset; use the token only when supplied.
- Add unit coverage for staged-file, staged-archive, and egress-fallback behavior.

## Details

`NEMO_TEST_DATA_ROOT` selects the mounted TestData root and defaults to `/home/TestData`, matching the CI container mount. No GitHub Actions environment override is required.

Qwen media resolves from `megatron_bridge/assets/`. The v2.5 archives resolve from `megatron-lm/release-assets/v2.5/`; both archives must exist before the local path is selected. They are extracted into the existing writable pytest temporary directory, so tests that modify their fixture data remain isolated.

If staged data is absent, Qwen retains the original Aliyun URLs and the release helper uses the public GitHub API and release URLs. `GH_TOKEN` remains supported for authenticated API rate limits but is optional.

The two v2.5 archives were staged under the same TestData-relative paths in the shared S3 bucket and both GCS buckets. `datasets.zip` is 2,387,175 bytes with SHA-256 `2dda736d6daa6ed32c5f866aec7e7915c380e353cd39b05ba2dcb13039225661`; `tokenizers.zip` is 10,615,506 bytes with SHA-256 `e58ed690b48958e31e3b1453a9bccb592cf4bb7a3b3ac3938da13dd52d694f9c`.

## Tested

- `uv run --no-sync ruff check <seven changed Python files>` — passed.
- `uv run --no-sync ruff format --check <seven changed Python files>` — passed; all files already formatted.
- `python -m pytest --noconftest tests/unit_tests/test_fixture_utils.py tests/unit_tests/test_download_unit_tests_dataset.py -q` — 4 passed.
- `git diff --name-only -z origin/main..HEAD -- "*.py" | xargs -0 python -m compileall -q` — passed.
- `pre-commit run --all-files` — all configured hooks passed.
- `env -u GH_TOKEN NEMO_TEST_DATA_ROOT=<missing> python -c <get_oldest_release_and_assets>` — fetched public v2.5 assets without authentication and extracted 12 dataset files plus 20 tokenizer files.
- Independently downloaded both objects from S3 and both GCS buckets; `sha256sum -c` passed for all six copies.
- GPU functional reruns on MCore main and dev are pending.

## Checklist

- [x] Followed the contributor guidelines and signed off all commits.
- [x] Added unit coverage for local and fallback resolution.
- [x] No documentation update is required for this test-only change.
- [x] No optional dependency or public API behavior is changed.