### PR TITLE
[data] fix: support MCore tokenizers in prompt-completion SFT

### DIFF
--- a/src/megatron/bridge/data/builders/direct_hf_sft.py
+++ b/src/megatron/bridge/data/builders/direct_hf_sft.py
@@ -30,6 +30,7 @@ from megatron.bridge.data.conversation_processing import get_processor_tokenizer
 from megatron.bridge.data.datasets.direct_sft import DirectSFTDataset
 from megatron.bridge.data.sft_processing import (
     ChatSFTPreprocessingConfig,
+    PromptCompletionSFTPreprocessingConfig,
     SFTPreprocessingConfig,
     is_text_only_prompt_completion_example,
     normalize_sft_examples,
@@ -270,6 +271,13 @@ class DirectHFSFTDatasetBuilder:
         prepare_hf_dataset_sources(requested_sources)
 
         processor = load_direct_hf_sft_processor(self.config, context.tokenizer)
+        if (
+            self.config.hf_processor_path is None
+            and self._collate_impl is None
+            and isinstance(self.config.preprocessing, PromptCompletionSFTPreprocessingConfig)
+            and getattr(context.tokenizer, "library", None) in {"sentencepiece", "tiktoken"}
+        ):
+            processor = normalize_direct_hf_sft_processor(context.tokenizer)
         train_dataset = build_direct_hf_sft_split(
             self.config,
             self.config.source,

--- a/src/megatron/bridge/data/sft_processing.py
+++ b/src/megatron/bridge/data/sft_processing.py
@@ -293,18 +293,22 @@ def sft_example_metadata(
 
 
 def _tokenize_text(tokenizer_or_processor: Any, text: str) -> list[int]:
-    tokenizer = get_processor_tokenizer(tokenizer_or_processor)
     try:
-        if hasattr(tokenizer, "encode"):
-            token_ids = tokenizer.encode(text, add_special_tokens=False)
-        elif callable(tokenizer):
-            token_ids = tokenizer(text, add_special_tokens=False)["input_ids"]
-        elif hasattr(tokenizer, "text_to_ids"):
-            token_ids = tokenizer.text_to_ids(text)
-        elif hasattr(tokenizer, "tokenize"):
-            token_ids = tokenizer.tokenize(text)
+        tokenizer_library = getattr(tokenizer_or_processor, "library", None)
+        if tokenizer_library in {"sentencepiece", "tiktoken"}:
+            token_ids = tokenizer_or_processor.tokenize(text)
         else:
-            raise TypeError(f"Unsupported tokenizer type: {type(tokenizer_or_processor).__name__}")
+            tokenizer = get_processor_tokenizer(tokenizer_or_processor)
+            if hasattr(tokenizer, "encode"):
+                token_ids = tokenizer.encode(text, add_special_tokens=False)
+            elif callable(tokenizer):
+                token_ids = tokenizer(text, add_special_tokens=False)["input_ids"]
+            elif hasattr(tokenizer, "text_to_ids"):
+                token_ids = tokenizer.text_to_ids(text)
+            elif hasattr(tokenizer, "tokenize"):
+                token_ids = tokenizer.tokenize(text)
+            else:
+                raise TypeError(f"Unsupported tokenizer type: {type(tokenizer_or_processor).__name__}")
     except (AttributeError, KeyError, TypeError, ValueError) as error:
         raise ValueError("Unable to tokenize prompt-completion text.") from error
     if isinstance(token_ids, torch.Tensor):
@@ -319,13 +323,17 @@ def _tokenize_text(tokenizer_or_processor: Any, text: str) -> list[int]:
 def _is_space_sensitive(tokenizer_or_processor: Any) -> bool:
     """Return whether a leading word-boundary space changes tokenization."""
     tokenizer = get_processor_tokenizer(tokenizer_or_processor)
-    try:
-        declared = getattr(tokenizer, "space_sensitive", None)
-    except (AttributeError, NotImplementedError):
-        declared = None
-    if declared is not None:
-        return bool(declared)
-    return _tokenize_text(tokenizer, "x y") != [*_tokenize_text(tokenizer, "x"), *_tokenize_text(tokenizer, "y")]
+    for owner in (tokenizer_or_processor, tokenizer):
+        try:
+            declared = getattr(owner, "space_sensitive", None)
+        except (AttributeError, NotImplementedError):
+            declared = None
+        if declared is not None:
+            return bool(declared)
+    return _tokenize_text(tokenizer_or_processor, "x y") != [
+        *_tokenize_text(tokenizer_or_processor, "x"),
+        *_tokenize_text(tokenizer_or_processor, "y"),
+    ]
 
 
 def _token_id(tokenizer_or_processor: Any, *names: str) -> int | None:

--- a/tests/unit_tests/data/test_sft_processing.py
+++ b/tests/unit_tests/data/test_sft_processing.py
@@ -1,8 +1,22 @@
 # Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
 
-import pytest
+import base64
+import json
+from types import SimpleNamespace
 
+import pytest
+import sentencepiece
+from megatron.core.tokenizers.megatron_tokenizer import MegatronTokenizer
+
+from megatron.bridge.data.base import DatasetBuildContext
+from megatron.bridge.data.builders import direct_hf_sft as direct_hf_builder_module
+from megatron.bridge.data.builders.direct_hf_sft import (
+    DirectHFSFTDatasetBuilder,
+    DirectHFSFTDatasetConfig,
+    load_direct_hf_sft_processor,
+)
 from megatron.bridge.data.collators.sft import text_prompt_completion_collate_fn
+from megatron.bridge.data.conversation_processing import get_processor_tokenizer
 from megatron.bridge.data.datasets.gpt_sft import GPTSFTDataset
 from megatron.bridge.data.datasets.utils import IGNORE_INDEX
 from megatron.bridge.data.sft_processing import (
@@ -11,6 +25,7 @@ from megatron.bridge.data.sft_processing import (
     normalize_sft_example,
     tokenize_prompt_completion_example,
 )
+from megatron.bridge.data.sources.hf import HFDatasetSourceConfig
 from megatron.bridge.data.sources.hf_adapters import adapt_hf_dataset
 
 
@@ -35,6 +50,130 @@ class _Tokenizer:
 
     def apply_chat_template(self, *args, **kwargs):
         pytest.fail("prompt-completion preprocessing must not call apply_chat_template")
+
+
+class _MCoreHuggingFaceTokenizer:
+    library = "huggingface"
+
+    def __init__(self):
+        self._tokenizer = _Tokenizer()
+
+    def tokenize(self, text):
+        pytest.fail("prompt-completion preprocessing must preserve raw Hugging Face encoding")
+
+
+def _build_mcore_text_tokenizer(tmp_path, library):
+    if library == "sentencepiece":
+        corpus_path = tmp_path / "corpus.txt"
+        corpus_path.write_text("question answer\nQ A\nprompt completion\n", encoding="utf-8")
+        model_prefix = tmp_path / "tokenizer"
+        sentencepiece.SentencePieceTrainer.train(
+            input=str(corpus_path),
+            model_prefix=str(model_prefix),
+            vocab_size=32,
+            hard_vocab_limit=False,
+            pad_id=0,
+            bos_id=1,
+            eos_id=2,
+            unk_id=3,
+        )
+        return MegatronTokenizer.from_pretrained(
+            str(model_prefix.with_suffix(".model")),
+            {"library": "sentencepiece"},
+        )
+
+    vocab_path = tmp_path / "tokenizer.json"
+    vocab_path.write_text(
+        json.dumps(
+            [
+                {
+                    "rank": rank,
+                    "token_bytes": base64.b64encode(bytes([rank])).decode(),
+                    "token_str": bytes([rank]).decode("utf-8", errors="replace"),
+                }
+                for rank in range(256)
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return MegatronTokenizer.from_pretrained(
+        str(vocab_path),
+        {"library": "tiktoken"},
+        num_special_tokens=7,
+        vocab_size=263,
+        pattern="v1",
+    )
+
+
+def _build_direct_hf_prompt_dataset(monkeypatch, tokenizer, *, collate_impl=None):
+    monkeypatch.setattr(
+        direct_hf_builder_module,
+        "load_and_adapt_hf_dataset",
+        lambda _source: [{"prompt": "Q", "completion": "A"}],
+    )
+    config = DirectHFSFTDatasetConfig(
+        seq_length=16,
+        source=HFDatasetSourceConfig(path_or_dataset="org/paired"),
+        preprocessing=PromptCompletionSFTPreprocessingConfig(separator=" "),
+        pad_to_multiple_of=1,
+        do_validation=False,
+        do_test=False,
+    )
+    train, _, _ = DirectHFSFTDatasetBuilder(config, collate_impl=collate_impl).build(
+        DatasetBuildContext(1, 0, 0, tokenizer=tokenizer)
+    )
+    assert train is not None
+    return train
+
+
+@pytest.mark.parametrize("library", ["sentencepiece", "tiktoken"])
+@pytest.mark.parametrize("runtime_path", ["gpt_sft", "direct_hf"])
+def test_prompt_completion_supports_mcore_text_tokenizers(tmp_path, monkeypatch, library, runtime_path):
+    tokenizer = _build_mcore_text_tokenizer(tmp_path, library)
+    if runtime_path == "direct_hf":
+        train = _build_direct_hf_prompt_dataset(monkeypatch, tokenizer)
+        batch = train.collate_fn([train[0]])
+    else:
+        batch = text_prompt_completion_collate_fn(
+            [{"prompt": "Q", "completion": "A"}],
+            tokenizer,
+            preprocessing=PromptCompletionSFTPreprocessingConfig(separator=" "),
+        )
+
+    expected_tokens = tokenizer.tokenize("Q") + tokenizer.tokenize(" A") + [tokenizer.eos_id]
+    assert batch["tokens"][0, : len(expected_tokens)].tolist() == expected_tokens
+
+
+@pytest.mark.parametrize("library", ["sentencepiece", "tiktoken"])
+def test_direct_hf_custom_collate_preserves_mcore_tokenizer_backend(tmp_path, monkeypatch, library):
+    tokenizer = _build_mcore_text_tokenizer(tmp_path, library)
+    observed = {}
+
+    def _collate(_examples, processor):
+        observed["processor"] = processor
+        return {}
+
+    train = _build_direct_hf_prompt_dataset(monkeypatch, tokenizer, collate_impl=_collate)
+
+    assert train.collate_fn([train[0]]) == {}
+    assert observed["processor"] is get_processor_tokenizer(tokenizer)
+
+
+def test_prompt_completion_preserves_mcore_huggingface_encoding():
+    tokenizer = _MCoreHuggingFaceTokenizer()
+    processor = load_direct_hf_sft_processor(
+        SimpleNamespace(hf_processor_path=None),
+        tokenizer,
+    )
+
+    tokenize_prompt_completion_example(
+        {"prompt": "Q", "completion": "A"},
+        tokenizer,
+        PromptCompletionSFTPreprocessingConfig(),
+    )
+
+    assert processor is tokenizer._tokenizer
+    assert tokenizer._tokenizer.encoded == ["Q", "A"]
 
 
 def test_chat_preprocessing_promotes_canonical_pair():


### PR DESCRIPTION
## Summary

Explicit prompt-completion preprocessing fails with supported Megatron-Core
SentencePiece and TikToken tokenizers. Both GPT-SFT and Direct-HF SFT can reach
the shared tokenizer path, but Bridge recursively unwraps the Megatron tokenizer
to a raw backend and passes the Hugging Face-only
`add_special_tokens=False` keyword.

This change:

- uses native wrapper tokenization only for MCore SentencePiece and TikToken;
- retains that wrapper only for Direct-HF's built-in prompt-completion collator;
- preserves the existing raw Hugging Face encoding contract and custom-collator
  processor ownership.

## Supported trigger and impact

- GPT-SFT: explicit `PromptCompletionSFTPreprocessingConfig` reaches
  `GPTSFTDataset._process_example()` and the shared prompt-completion tokenizer.
- Direct-HF SFT: prompt-completion preprocessing with no `hf_processor_path`
  reuses the build-context Megatron tokenizer and reaches the same helper
  through the builder-selected text collator.

With SentencePiece or TikToken, the unmodified code raises
`ValueError: Unable to tokenize prompt-completion text.` before producing a
sample or batch. Training, validation, inference, and offline-packing
materialization using this supported combination cannot proceed.

## Root cause and minimal fix

`get_processor_tokenizer()` recursively unwraps MCore's outer tokenizer and
library wrapper. The resulting raw `SentencePieceProcessor.encode()` and
`tiktoken.Encoding.encode()` methods do not accept `add_special_tokens`.

The fix dispatches through the outer tokenizer's native `tokenize()` method only
when its declared library is `sentencepiece` or `tiktoken`. Other tokenizer
types keep the prior unwrapped path. Direct-HF retains the outer wrapper only
when its own built-in prompt-completion collator needs that dispatch; configured
processors and custom collators keep their previous processor contract.

## Verification

Fail-before on unmodified production at the audited base:

```text
uv run --active --no-sync python -m pytest tests/unit_tests/data/test_sft_processing.py -k prompt_completion_supports_mcore_text_tokenizers -q
# 4 failed for the claimed raw-backend TypeError, 15 deselected
```

Pass-after:

```text
uv run --active --no-sync python -m pytest tests/unit_tests/data/test_sft_processing.py -q
# 19 passed

uv run --active --no-sync python -m pytest tests/unit_tests/data/test_sft_processing.py tests/unit_tests/data/builders/test_direct_hf_sft.py tests/unit_tests/data/collators/test_sft.py tests/unit_tests/data/test_conversation_processing.py tests/unit_tests/data/datasets/test_gpt_sft.py -q
# 182 passed

uv run --active --no-sync pre-commit run --all-files
# all configured hooks passed

git diff --check
# passed
```

## Scope

This is limited to explicit paired-text preprocessing and tokenizer ownership.
It does not change chat preprocessing, configured Hugging Face processor
loading, public API signatures, dependencies, CI workflows, or MCore source.
No full test suite, convergence, model-quality, or performance validation is
claimed.
