### PR TITLE
fix(misc): load modelopt plugins on a clean import

### DIFF
--- a/src/megatron/bridge/__init__.py
+++ b/src/megatron/bridge/__init__.py
@@ -13,6 +13,11 @@
 # limitations under the License.
 """Megatron Bridge - A component of the Megatron ecosystem."""
 
+try:
+    import modelopt.torch  # noqa: F401
+except ImportError:
+    pass
+
 import megatron.bridge.diffusion.models  # noqa: F401 — registers diffusion bridges
 import megatron.bridge.models  # noqa: F401 — triggers all bridge and HF Auto class registrations
 from megatron.bridge.models.conversion.auto_bridge import AutoBridge


### PR DESCRIPTION
# What does this PR do ?

There's a circular import with `modelopt` and `megatron.training`. Bridge imports `megatron.training`, which imports `modelopt.torch`, which performs `import_plugin("megatron.bridge")`, wihch causes the error "cannot import name 'MegatronMappingRegistry' from partially initialized module".

Confirmed to happen on top of `a372fdb6ab176c025a0a5c26d72176603885011f`.

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
