### PR TITLE
fix(perf): port r0.5.0 VR200 performance configs

### DIFF
--- a/scripts/performance/utils/executors.py
+++ b/scripts/performance/utils/executors.py
@@ -179,7 +179,7 @@ def slurm_executor(
     log_repo_status_cmd = "bash /opt/Megatron-Bridge/docker/common/print_sha.sh /nemo_run/configs/repo_status.json"
     custom_bash_cmds.append(log_repo_status_cmd)
 
-    numa_divisor = 2 if gpu.lower() in ["gb200", "gb300"] else 4
+    numa_divisor = 2 if gpu.lower() in ["gb200", "gb300", "vr200"] else 4
     numa_cmd = f"numactl --cpunodebind=$((SLURM_LOCALID/{numa_divisor})) --membind=$((SLURM_LOCALID/{numa_divisor}))"
     if gpu.lower() in ["b300"] and enable_pct_binding:
         numa_cmd += " -C $((SLURM_LOCALID * 16)),$((SLURM_LOCALID * 16 + 1))"

--- a/scripts/performance/utils/overrides.py
+++ b/scripts/performance/utils/overrides.py
@@ -250,7 +250,7 @@ def _apply_flat_cli_environment_compatibility(
     if connection_override:
         moe_a2a_overlap = args.moe_a2a_overlap if args.moe_a2a_overlap is not None else base_moe_a2a_overlap
         max_connections = 32 if base_dispatcher_backend in {"deepep", "hybridep"} else 8
-        if gpu in {"b200", "b300", "gb200", "gb300"}:
+        if gpu in {"b200", "b300", "gb200", "gb300", "vr200"}:
             max_connections = 32
         elif (tp_size > 1 or cp_size > 1) and not moe_a2a_overlap:
             max_connections = 1

--- a/src/megatron/bridge/perf_recipes/deepseek/vr200/deepseek_v3.py
+++ b/src/megatron/bridge/perf_recipes/deepseek/vr200/deepseek_v3.py
@@ -181,6 +181,9 @@ def deepseek_v3_pretrain_128gpu_vr200_fp8mx_config() -> ConfigContainer:
         "NVTE_BWD_LAYERNORM_SM_MARGIN": 20,
         "NVTE_CUTEDSL_FUSED_GROUPED_MLP": 1,
         "NVTE_FWD_LAYERNORM_SM_MARGIN": 20,
+        # Use cuDNN LayerNorm for this measured baseline.
+        "NVTE_NORM_BWD_USE_CUDNN": 1,
+        "NVTE_NORM_FWD_USE_CUDNN": 1,
         # Keep DeepSeek kernel selection aligned with the measured baseline.
         "NVTE_ALLOW_NONDETERMINISTIC_ALGO": 0,
     }
@@ -320,6 +323,9 @@ def deepseek_v3_pretrain_256gpu_vr200_fp8mx_config() -> ConfigContainer:
         "NVTE_BWD_LAYERNORM_SM_MARGIN": 20,
         "NVTE_CUTEDSL_FUSED_GROUPED_MLP": 1,
         "NVTE_FWD_LAYERNORM_SM_MARGIN": 20,
+        # Use cuDNN LayerNorm for this measured baseline.
+        "NVTE_NORM_BWD_USE_CUDNN": 1,
+        "NVTE_NORM_FWD_USE_CUDNN": 1,
         # Keep DeepSeek kernel selection aligned with the measured baseline.
         "NVTE_ALLOW_NONDETERMINISTIC_ALGO": 0,
     }

--- a/src/megatron/bridge/perf_recipes/gpt_oss/vr200/gpt_oss.py
+++ b/src/megatron/bridge/perf_recipes/gpt_oss/vr200/gpt_oss.py
@@ -37,7 +37,7 @@ def gpt_oss_20b_pretrain_8gpu_vr200_nvfp4_config() -> ConfigContainer:
     cfg.env_vars = {
         **COMMON_PERF_ENV_VARS,
         # CUDA stream scheduling for this model and parallel layout.
-        "CUDA_DEVICE_MAX_CONNECTIONS": 1,
+        "CUDA_DEVICE_MAX_CONNECTIONS": 32,
         # CUDA graph and allocator behavior for this recipe.
         "TORCH_NCCL_AVOID_RECORD_STREAMS": 1,
         # NCCL user-buffer and launch settings.
@@ -51,6 +51,9 @@ def gpt_oss_20b_pretrain_8gpu_vr200_nvfp4_config() -> ConfigContainer:
         # Transformer Engine overlap settings for this model.
         "NVTE_BWD_LAYERNORM_SM_MARGIN": 20,
         "NVTE_FWD_LAYERNORM_SM_MARGIN": 20,
+        # Use cuDNN LayerNorm for this measured baseline.
+        "NVTE_NORM_BWD_USE_CUDNN": 1,
+        "NVTE_NORM_FWD_USE_CUDNN": 1,
         # NVFP4 fast-math path.
         "NVTE_USE_FAST_MATH": 1,
     }
@@ -98,6 +101,9 @@ def gpt_oss_20b_pretrain_8gpu_vr200_fp8mx_config() -> ConfigContainer:
         # Transformer Engine overlap settings for this model.
         "NVTE_BWD_LAYERNORM_SM_MARGIN": 20,
         "NVTE_FWD_LAYERNORM_SM_MARGIN": 20,
+        # Use cuDNN LayerNorm for this measured baseline.
+        "NVTE_NORM_BWD_USE_CUDNN": 1,
+        "NVTE_NORM_FWD_USE_CUDNN": 1,
     }
     return cfg
 
@@ -129,7 +135,7 @@ def gpt_oss_20b_pretrain_64gpu_vr200_nvfp4_config() -> ConfigContainer:
     cfg.env_vars = {
         **COMMON_PERF_ENV_VARS,
         # CUDA stream scheduling for this model and parallel layout.
-        "CUDA_DEVICE_MAX_CONNECTIONS": 1,
+        "CUDA_DEVICE_MAX_CONNECTIONS": 32,
         # CUDA graph and allocator behavior for this recipe.
         "TORCH_NCCL_AVOID_RECORD_STREAMS": 1,
         # NCCL user-buffer and launch settings.
@@ -143,6 +149,9 @@ def gpt_oss_20b_pretrain_64gpu_vr200_nvfp4_config() -> ConfigContainer:
         # Transformer Engine overlap settings for this model.
         "NVTE_BWD_LAYERNORM_SM_MARGIN": 20,
         "NVTE_FWD_LAYERNORM_SM_MARGIN": 20,
+        # Use cuDNN LayerNorm for this measured baseline.
+        "NVTE_NORM_BWD_USE_CUDNN": 1,
+        "NVTE_NORM_FWD_USE_CUDNN": 1,
         # NVFP4 fast-math path.
         "NVTE_USE_FAST_MATH": 1,
     }

--- a/src/megatron/bridge/perf_recipes/kimi/vr200/kimi_k2.py
+++ b/src/megatron/bridge/perf_recipes/kimi/vr200/kimi_k2.py
@@ -71,5 +71,8 @@ def kimi_k2_pretrain_256gpu_vr200_fp8mx_config() -> ConfigContainer:
         # Transformer Engine overlap settings for this model.
         "NVTE_BWD_LAYERNORM_SM_MARGIN": 20,
         "NVTE_FWD_LAYERNORM_SM_MARGIN": 20,
+        # Use cuDNN LayerNorm for this measured baseline.
+        "NVTE_NORM_BWD_USE_CUDNN": 1,
+        "NVTE_NORM_FWD_USE_CUDNN": 1,
     }
     return cfg

--- a/src/megatron/bridge/perf_recipes/llama/vr200/llama3.py
+++ b/src/megatron/bridge/perf_recipes/llama/vr200/llama3.py
@@ -130,6 +130,9 @@ def llama3_70b_pretrain_64gpu_vr200_bf16_config() -> ConfigContainer:
         # Transformer Engine overlap settings for this model.
         "NVTE_BWD_LAYERNORM_SM_MARGIN": 20,
         "NVTE_FWD_LAYERNORM_SM_MARGIN": 20,
+        # Use cuDNN LayerNorm for this measured baseline.
+        "NVTE_NORM_BWD_USE_CUDNN": 1,
+        "NVTE_NORM_FWD_USE_CUDNN": 1,
     }
     return cfg
 

--- a/src/megatron/bridge/perf_recipes/llama/vr200/llama31.py
+++ b/src/megatron/bridge/perf_recipes/llama/vr200/llama31.py
@@ -31,7 +31,7 @@ def llama31_405b_pretrain_256gpu_vr200_bf16_config() -> ConfigContainer:
     cfg.env_vars = {
         **COMMON_PERF_ENV_VARS,
         # CUDA stream scheduling for this model and parallel layout.
-        "CUDA_DEVICE_MAX_CONNECTIONS": 1,
+        "CUDA_DEVICE_MAX_CONNECTIONS": 32,
         # CUDA graph and allocator behavior for this recipe.
         "TORCH_NCCL_AVOID_RECORD_STREAMS": 1,
         # NCCL user-buffer and launch settings.
@@ -50,7 +50,7 @@ def llama31_405b_pretrain_256gpu_vr200_fp8mx_config() -> ConfigContainer:
     cfg.env_vars = {
         **COMMON_PERF_ENV_VARS,
         # CUDA stream scheduling for this model and parallel layout.
-        "CUDA_DEVICE_MAX_CONNECTIONS": 1,
+        "CUDA_DEVICE_MAX_CONNECTIONS": 32,
         # CUDA graph and allocator behavior for this recipe.
         "NCCL_GRAPH_REGISTER": 0,
         "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True",
@@ -73,7 +73,7 @@ def llama31_405b_pretrain_256gpu_vr200_nvfp4_config() -> ConfigContainer:
     cfg.env_vars = {
         **COMMON_PERF_ENV_VARS,
         # CUDA stream scheduling for this model and parallel layout.
-        "CUDA_DEVICE_MAX_CONNECTIONS": 1,
+        "CUDA_DEVICE_MAX_CONNECTIONS": 32,
         # CUDA graph and allocator behavior for this recipe.
         "NCCL_GRAPH_REGISTER": 0,
         "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True",

--- a/tests/unit_tests/recipes/test_perf_recipe_environment.py
+++ b/tests/unit_tests/recipes/test_perf_recipe_environment.py
@@ -50,6 +50,18 @@ _DEEPSEEK_WITHOUT_HYBRID_EP_RECIPES = {
     ("b200", "deepseek_v3_pretrain_256gpu_b200_fp8mx_config"),
     ("b200", "deepseek_v3_pretrain_256gpu_b200_nvfp4_config"),
 }
+_VR200_CUDNN_LAYERNORM_RECIPES = {
+    "deepseek_v3_pretrain_128gpu_vr200_fp8mx_config",
+    "deepseek_v3_pretrain_256gpu_vr200_fp8mx_config",
+    "gpt_oss_20b_pretrain_8gpu_vr200_fp8mx_config",
+    "gpt_oss_20b_pretrain_8gpu_vr200_nvfp4_config",
+    "gpt_oss_20b_pretrain_64gpu_vr200_nvfp4_config",
+    "kimi_k2_pretrain_256gpu_vr200_fp8mx_config",
+    "llama3_70b_pretrain_64gpu_vr200_bf16_config",
+    "nemotron_3_nano_pretrain_8gpu_vr200_bf16_config",
+    "nemotron_3_nano_pretrain_8gpu_vr200_fp8mx_config",
+    "nemotron_3_nano_pretrain_8gpu_vr200_nvfp4_config",
+}
 
 
 def _function(path: Path, function_name: str) -> ast.FunctionDef:
@@ -155,6 +167,12 @@ def test_explicit_environment_invariants_across_all_flat_recipes():
 
         cudnn_names = {"NVTE_NORM_BWD_USE_CUDNN", "NVTE_NORM_FWD_USE_CUDNN"}
         assert environment.keys().isdisjoint(cudnn_names) or environment.keys() >= cudnn_names
+        if path.parent.name == "vr200":
+            assert environment["CUDA_DEVICE_MAX_CONNECTIONS"] == 32
+            uses_cudnn_layernorm = function_name in _VR200_CUDNN_LAYERNORM_RECIPES
+            assert (environment.keys() >= cudnn_names) == uses_cudnn_layernorm
+            if uses_cudnn_layernorm:
+                assert all(environment[name] == 1 for name in cudnn_names)
 
         hybrid_ep_names = environment.keys() & _HYBRID_EP_ENV_NAMES
         assert not hybrid_ep_names or hybrid_ep_names == _HYBRID_EP_ENV_NAMES

--- a/tests/unit_tests/recipes/test_r050_perf_recipe_ports.py
+++ b/tests/unit_tests/recipes/test_r050_perf_recipe_ports.py
@@ -18,17 +18,34 @@ import pytest
 import torch
 
 from megatron.bridge.perf_recipes.deepseek import (
+    deepseek_v3_pretrain_128gpu_vr200_fp8mx_config,
     deepseek_v3_pretrain_256gpu_b300_fp8mx_config,
     deepseek_v3_pretrain_256gpu_gb200_fp8mx_large_scale_config,
     deepseek_v3_pretrain_256gpu_gb300_fp8mx_large_scale_config,
+    deepseek_v3_pretrain_256gpu_vr200_fp8mx_config,
     deepseek_v4_pro_pretrain_256gpu_gb300_fp8mx_config,
+)
+from megatron.bridge.perf_recipes.gpt_oss import (
+    gpt_oss_20b_pretrain_8gpu_vr200_fp8mx_config,
+    gpt_oss_20b_pretrain_8gpu_vr200_nvfp4_config,
+    gpt_oss_20b_pretrain_64gpu_vr200_nvfp4_config,
+    gpt_oss_120b_pretrain_64gpu_vr200_fp8mx_config,
+)
+from megatron.bridge.perf_recipes.kimi import kimi_k2_pretrain_256gpu_vr200_fp8mx_config
+from megatron.bridge.perf_recipes.llama import (
+    llama3_70b_pretrain_64gpu_vr200_bf16_config,
+    llama31_405b_pretrain_256gpu_vr200_bf16_config,
+    llama31_405b_pretrain_256gpu_vr200_fp8mx_config,
+    llama31_405b_pretrain_256gpu_vr200_nvfp4_config,
 )
 from megatron.bridge.perf_recipes.qwen import (
     qwen3_30b_a3b_pretrain_8gpu_b200_fp8mx_config,
+    qwen3_30b_a3b_pretrain_8gpu_vr200_fp8mx_config,
     qwen3_235b_a22b_pretrain_256gpu_b200_fp8mx_config,
     qwen3_235b_a22b_pretrain_256gpu_b200_fp8mx_large_scale_config,
     qwen3_235b_a22b_pretrain_256gpu_b300_fp8mx_config,
     qwen3_235b_a22b_pretrain_256gpu_b300_fp8mx_large_scale_config,
+    qwen3_235b_a22b_pretrain_256gpu_vr200_fp8mx_config,
 )
 from tests.unit_tests.recipes.recipe_test_utils import patch_recipe_construction_dependencies
 
@@ -70,8 +87,10 @@ def _assert_full_iteration_hybridep_mxfp8(cfg, *, fp8_dot_product_attention: boo
     ("recipe", "expected_vpp"),
     [
         (qwen3_30b_a3b_pretrain_8gpu_b200_fp8mx_config, None),
+        (qwen3_30b_a3b_pretrain_8gpu_vr200_fp8mx_config, None),
         (qwen3_235b_a22b_pretrain_256gpu_b200_fp8mx_config, 3),
         (qwen3_235b_a22b_pretrain_256gpu_b300_fp8mx_config, 3),
+        (qwen3_235b_a22b_pretrain_256gpu_vr200_fp8mx_config, 12),
     ],
 )
 def test_qwen_mxfp8_recipes_match_r050_full_iteration_settings(recipe, expected_vpp) -> None:
@@ -84,6 +103,49 @@ def test_qwen_mxfp8_recipes_match_r050_full_iteration_settings(recipe, expected_
     assert cfg.env_vars["NVTE_CUTEDSL_FUSED_GROUPED_MLP"] == 1
     assert cfg.env_vars["TORCH_NCCL_AVOID_RECORD_STREAMS"] == 0
     assert "graph_capture_record_stream_reuse:True" in cfg.env_vars["PYTORCH_CUDA_ALLOC_CONF"]
+
+
+def test_gpt_oss_120b_vr200_mxfp8_matches_r050_full_iteration_settings() -> None:
+    cfg = gpt_oss_120b_pretrain_64gpu_vr200_fp8mx_config()
+
+    _assert_full_iteration_hybridep_mxfp8(cfg)
+    assert cfg.model.fp8_output_proj is True
+    assert cfg.model.cuda_graph_warmup_steps == 2
+
+
+@pytest.mark.parametrize(
+    "recipe",
+    [
+        gpt_oss_20b_pretrain_8gpu_vr200_fp8mx_config,
+        gpt_oss_20b_pretrain_8gpu_vr200_nvfp4_config,
+        gpt_oss_20b_pretrain_64gpu_vr200_nvfp4_config,
+        deepseek_v3_pretrain_128gpu_vr200_fp8mx_config,
+        deepseek_v3_pretrain_256gpu_vr200_fp8mx_config,
+        kimi_k2_pretrain_256gpu_vr200_fp8mx_config,
+        llama3_70b_pretrain_64gpu_vr200_bf16_config,
+    ],
+)
+def test_vr200_recipes_keep_r050_cudnn_layernorm_settings(recipe) -> None:
+    cfg = recipe()
+
+    assert cfg.env_vars["NVTE_NORM_BWD_USE_CUDNN"] == 1
+    assert cfg.env_vars["NVTE_NORM_FWD_USE_CUDNN"] == 1
+
+
+@pytest.mark.parametrize(
+    "recipe",
+    [
+        gpt_oss_20b_pretrain_8gpu_vr200_nvfp4_config,
+        gpt_oss_20b_pretrain_64gpu_vr200_nvfp4_config,
+        llama31_405b_pretrain_256gpu_vr200_bf16_config,
+        llama31_405b_pretrain_256gpu_vr200_fp8mx_config,
+        llama31_405b_pretrain_256gpu_vr200_nvfp4_config,
+    ],
+)
+def test_vr200_recipes_use_sm100_cuda_connection_count(recipe) -> None:
+    cfg = recipe()
+
+    assert cfg.env_vars["CUDA_DEVICE_MAX_CONNECTIONS"] == 32
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/recipes/test_r050_perf_recipe_ports.py
+++ b/tests/unit_tests/recipes/test_r050_perf_recipe_ports.py
@@ -18,34 +18,17 @@ import pytest
 import torch
 
 from megatron.bridge.perf_recipes.deepseek import (
-    deepseek_v3_pretrain_128gpu_vr200_fp8mx_config,
     deepseek_v3_pretrain_256gpu_b300_fp8mx_config,
     deepseek_v3_pretrain_256gpu_gb200_fp8mx_large_scale_config,
     deepseek_v3_pretrain_256gpu_gb300_fp8mx_large_scale_config,
-    deepseek_v3_pretrain_256gpu_vr200_fp8mx_config,
     deepseek_v4_pro_pretrain_256gpu_gb300_fp8mx_config,
-)
-from megatron.bridge.perf_recipes.gpt_oss import (
-    gpt_oss_20b_pretrain_8gpu_vr200_fp8mx_config,
-    gpt_oss_20b_pretrain_8gpu_vr200_nvfp4_config,
-    gpt_oss_20b_pretrain_64gpu_vr200_nvfp4_config,
-    gpt_oss_120b_pretrain_64gpu_vr200_fp8mx_config,
-)
-from megatron.bridge.perf_recipes.kimi import kimi_k2_pretrain_256gpu_vr200_fp8mx_config
-from megatron.bridge.perf_recipes.llama import (
-    llama3_70b_pretrain_64gpu_vr200_bf16_config,
-    llama31_405b_pretrain_256gpu_vr200_bf16_config,
-    llama31_405b_pretrain_256gpu_vr200_fp8mx_config,
-    llama31_405b_pretrain_256gpu_vr200_nvfp4_config,
 )
 from megatron.bridge.perf_recipes.qwen import (
     qwen3_30b_a3b_pretrain_8gpu_b200_fp8mx_config,
-    qwen3_30b_a3b_pretrain_8gpu_vr200_fp8mx_config,
     qwen3_235b_a22b_pretrain_256gpu_b200_fp8mx_config,
     qwen3_235b_a22b_pretrain_256gpu_b200_fp8mx_large_scale_config,
     qwen3_235b_a22b_pretrain_256gpu_b300_fp8mx_config,
     qwen3_235b_a22b_pretrain_256gpu_b300_fp8mx_large_scale_config,
-    qwen3_235b_a22b_pretrain_256gpu_vr200_fp8mx_config,
 )
 from tests.unit_tests.recipes.recipe_test_utils import patch_recipe_construction_dependencies
 
@@ -87,10 +70,8 @@ def _assert_full_iteration_hybridep_mxfp8(cfg, *, fp8_dot_product_attention: boo
     ("recipe", "expected_vpp"),
     [
         (qwen3_30b_a3b_pretrain_8gpu_b200_fp8mx_config, None),
-        (qwen3_30b_a3b_pretrain_8gpu_vr200_fp8mx_config, None),
         (qwen3_235b_a22b_pretrain_256gpu_b200_fp8mx_config, 3),
         (qwen3_235b_a22b_pretrain_256gpu_b300_fp8mx_config, 3),
-        (qwen3_235b_a22b_pretrain_256gpu_vr200_fp8mx_config, 12),
     ],
 )
 def test_qwen_mxfp8_recipes_match_r050_full_iteration_settings(recipe, expected_vpp) -> None:
@@ -103,49 +84,6 @@ def test_qwen_mxfp8_recipes_match_r050_full_iteration_settings(recipe, expected_
     assert cfg.env_vars["NVTE_CUTEDSL_FUSED_GROUPED_MLP"] == 1
     assert cfg.env_vars["TORCH_NCCL_AVOID_RECORD_STREAMS"] == 0
     assert "graph_capture_record_stream_reuse:True" in cfg.env_vars["PYTORCH_CUDA_ALLOC_CONF"]
-
-
-def test_gpt_oss_120b_vr200_mxfp8_matches_r050_full_iteration_settings() -> None:
-    cfg = gpt_oss_120b_pretrain_64gpu_vr200_fp8mx_config()
-
-    _assert_full_iteration_hybridep_mxfp8(cfg)
-    assert cfg.model.fp8_output_proj is True
-    assert cfg.model.cuda_graph_warmup_steps == 2
-
-
-@pytest.mark.parametrize(
-    "recipe",
-    [
-        gpt_oss_20b_pretrain_8gpu_vr200_fp8mx_config,
-        gpt_oss_20b_pretrain_8gpu_vr200_nvfp4_config,
-        gpt_oss_20b_pretrain_64gpu_vr200_nvfp4_config,
-        deepseek_v3_pretrain_128gpu_vr200_fp8mx_config,
-        deepseek_v3_pretrain_256gpu_vr200_fp8mx_config,
-        kimi_k2_pretrain_256gpu_vr200_fp8mx_config,
-        llama3_70b_pretrain_64gpu_vr200_bf16_config,
-    ],
-)
-def test_vr200_recipes_keep_r050_cudnn_layernorm_settings(recipe) -> None:
-    cfg = recipe()
-
-    assert cfg.env_vars["NVTE_NORM_BWD_USE_CUDNN"] == 1
-    assert cfg.env_vars["NVTE_NORM_FWD_USE_CUDNN"] == 1
-
-
-@pytest.mark.parametrize(
-    "recipe",
-    [
-        gpt_oss_20b_pretrain_8gpu_vr200_nvfp4_config,
-        gpt_oss_20b_pretrain_64gpu_vr200_nvfp4_config,
-        llama31_405b_pretrain_256gpu_vr200_bf16_config,
-        llama31_405b_pretrain_256gpu_vr200_fp8mx_config,
-        llama31_405b_pretrain_256gpu_vr200_nvfp4_config,
-    ],
-)
-def test_vr200_recipes_use_sm100_cuda_connection_count(recipe) -> None:
-    cfg = recipe()
-
-    assert cfg.env_vars["CUDA_DEVICE_MAX_CONNECTIONS"] == 32
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/scripts/performance/test_executors.py
+++ b/tests/unit_tests/scripts/performance/test_executors.py
@@ -191,6 +191,20 @@ def test_recipe_env_vars_are_exported_and_forced_into_container(tmp_path):
 
 
 @pytest.mark.skipif(not HAS_NEMO_RUN, reason="nemo_run not installed")
+def test_vr200_slurm_executor_uses_two_gpus_per_numa_node(tmp_path):
+    executor = slurm_executor(
+        gpu="vr200",
+        account="test",
+        partition="test",
+        log_dir=str(tmp_path),
+        nodes=1,
+        num_gpus_per_node=4,
+    )
+
+    assert "SLURM_LOCALID/2" in executor.launcher.template_vars["pre_cmds"]
+
+
+@pytest.mark.skipif(not HAS_NEMO_RUN, reason="nemo_run not installed")
 def test_recipe_env_vars_are_added_to_kubeflow_trainer_environment(monkeypatch):
     """Kubeflow workers should inherit launcher-resolved recipe variables."""
     monkeypatch.setattr(

--- a/tests/unit_tests/scripts/performance/test_recipe_environment.py
+++ b/tests/unit_tests/scripts/performance/test_recipe_environment.py
@@ -494,6 +494,41 @@ def test_flat_default_args_leave_inline_recipe_environment_unchanged():
     assert recipe.env_vars == original_env
 
 
+def test_vr200_argparse_overrides_keep_sm100_cuda_connection_count():
+    from utils.overrides import _apply_flat_cli_environment_compatibility
+
+    recipe = SimpleNamespace(
+        env_vars={"CUDA_DEVICE_MAX_CONNECTIONS": 1},
+        model=SimpleNamespace(
+            tensor_model_parallel_size=2,
+            pipeline_model_parallel_size=1,
+            context_parallel_size=1,
+            expert_model_parallel_size=1,
+        ),
+    )
+    args = SimpleNamespace(
+        gpu="vr200",
+        moe_a2a_overlap=None,
+        tensor_model_parallel_size=2,
+        pipeline_model_parallel_size=None,
+        context_parallel_size=None,
+        expert_model_parallel_size=None,
+        nccl_ub=None,
+        model_family_name="llama",
+        model_recipe_name="llama31_405b",
+        task="pretrain",
+    )
+
+    _apply_flat_cli_environment_compatibility(
+        recipe,
+        args,
+        base_dispatcher_backend=None,
+        base_moe_a2a_overlap=False,
+    )
+
+    assert recipe.env_vars["CUDA_DEVICE_MAX_CONNECTIONS"] == 32
+
+
 def test_flat_explicit_argparse_compatibility_changes_only_legacy_coupled_values():
     from utils.overrides import _apply_flat_cli_environment_compatibility
 


### PR DESCRIPTION
# What does this PR do ?

Ports the remaining effective VR200 performance behavior from r0.5.0 to the flattened performance recipes and launcher on `main`.

This is a manual flat-layout port of #4724, following the earlier r0.5.0 recipe migration in #5061. The Qwen3 and GPT-OSS 120B full-iteration CUDA-graph behavior from #4724 was already present on `main`; this PR carries over the remaining platform/environment behavior.

# Changelog

- Treat VR200 as an SM100+ target for CUDA stream connection tuning, including explicit argparse overrides.
- Restore cuDNN LayerNorm selection for the affected VR200 GPT-OSS 20B, DeepSeek V3 MXFP8, Kimi K2 MXFP8, and Llama 3 70B BF16 recipes.
- Use the VR200 NVL72 NUMA layout with two local GPU ranks per NUMA node.
- Add focused regression coverage for all VR200 inline recipe environments, argparse compatibility, and launcher NUMA binding.

# GitHub Actions CI

- `uvx --from pre-commit pre-commit run --all-files` (passed)
- `uv run --no-sync python -m pytest -o "pythonpath=src 3rdparty/Megatron-LM" tests/unit_tests/recipes/test_perf_recipe_environment.py tests/unit_tests/scripts/performance/test_recipe_environment.py tests/unit_tests/scripts/performance/test_executors.py` (56 passed in a Linux container on `d774d987e`)
- `uv run --no-sync python -m pytest -o "pythonpath=src 3rdparty/Megatron-LM" tests/unit_tests/scripts/training/test_recipe_runner.py tests/unit_tests/scripts/training/test_run_recipe.py tests/unit_tests/scripts/training/test_setup_experiment.py` (195 passed in a Linux container)

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation? N/A; no user-facing interface changed.
- [x] Does the PR affect components that are optional to install? No.
  - [x] Reviewer: Does the PR have correct import guards for all optional libraries? N/A.

# Additional Information

- Source PR: #4724
- Related main recipe port: #5061
