### PR TITLE
fix(docker): update dependencies in Dockerfile and fw_pyproject.toml for compatibility and security

### DIFF
--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -65,8 +65,7 @@ ENV PATH="/opt/venv/bin:/opt/venv/bin:/root/.local/bin:$PATH" \
 RUN --mount=type=bind,source=docker/patches/deepep.patch,target=/opt/deepep.patch \
     curl -LsSf https://astral.sh/uv/${UV_VERSION}/install.sh | sh && \
     uv venv ${UV_PROJECT_ENVIRONMENT} --system-site-packages && \
-    # Address CVE-2025-68973
-    apt-get update && apt install -y --only-upgrade gnupg && \
+    apt-get update && apt install -y --only-upgrade gnupg openssl libssl3t64 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     if [ "$INSTALL_DEEPEP" = "True" ]; then \

--- a/docker/Dockerfile.fw_final
+++ b/docker/Dockerfile.fw_final
@@ -71,24 +71,26 @@ RUN \
 ##
 ##############################################################################
 
-RUN pip install "starlette==0.49.1" \
+RUN pip install "fastapi==0.139.1" \
+    "starlette==1.3.1" \
+    "prometheus-fastapi-instrumentator>=8.0.0" \
     "urllib3>=2.7.0" \
     "aiohttp>=3.13.3" \
     "jaraco-context>=6.1.0" \
     "wheel>=0.46.2" \
     "python-multipart>=0.0.22" \
     "setuptools>=80.10.2" \
-    "pillow>=12.1.1" \
+    "pillow>=12.3.0" \
     "protobuf==6.33.5" \
     "xgrammar>=0.1.32" \
-    "tornado==6.5.5" \
+    "tornado==6.5.6" \
     "black==26.3.1" \
     "onnx==1.21.0" \
     "notebook>=7.5.6" \
-    "jupyterlab>=4.5.7" \
+    "jupyterlab>=4.5.10" \
     "jupyter-server>=2.20.0" \
-    "mistune>=3.2.1" \
-    "GitPython>=3.1.50" && \
+    "mistune>=3.3.0" \
+    "GitPython>=3.1.55" && \
     # Address CVE from transitive dependency
     pip uninstall -y opencv-python-headless nvidia-dali-cuda130
 
@@ -96,10 +98,10 @@ RUN pip install "starlette==0.49.1" \
 # The actual onnx Python package is managed above via pip/uv; this stale copy triggers CVE scanners.
 RUN rm -rf /opt/pytorch/pytorch/third_party/onnx
 
-# Patch wandb-core: bump google.golang.org/grpc from 1.79.2 to 1.79.3 (CVE fix)
+# Patch wandb-core with fixed gRPC-Go and Go standard-library versions.
 ARG TARGETARCH
-RUN GRPC_VERSION=1.79.3 && \
-    GO_VERSION=1.26.1 && \
+RUN GRPC_VERSION=1.82.1 && \
+    GO_VERSION=1.26.5 && \
     WANDB_VERSION=$(python3 -c "import wandb; print(wandb.__version__)") && \
     WANDB_CORE_BIN=/opt/venv/lib/python3.12/site-packages/wandb/bin/wandb-core && \
     curl -fsSL "https://dl.google.com/go/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz" | tar -C /tmp -xz && \
@@ -114,12 +116,13 @@ RUN GRPC_VERSION=1.79.3 && \
         -o "${WANDB_CORE_BIN}" ./cmd/wandb-core/ && \
     rm -rf /tmp/wandb-src /tmp/go /tmp/gopath
 
-# Patch wandb-core (dist-packages copy): bump github.com/go-git/go-git/v5 to 5.19.0 (CVE fix).
+# Patch wandb-core (dist-packages copy) with fixed go-git, gRPC-Go, and Go versions.
 # This stock upstream binary ships with go-git v5.17.2 and is a separate wandb install from the
 # /opt/venv copy rebuilt above, so it must be rebuilt against its own wandb version (resolved via
 # the system interpreter that owns dist-packages) to avoid a python/wandb-core version mismatch.
 RUN GO_GIT_VERSION=5.19.0 && \
-    GO_VERSION=1.26.1 && \
+    GRPC_VERSION=1.82.1 && \
+    GO_VERSION=1.26.5 && \
     WANDB_VERSION=$(/usr/bin/python3 -c "import wandb; print(wandb.__version__)") && \
     WANDB_CORE_BIN=/usr/local/lib/python3.12/dist-packages/wandb/bin/wandb-core && \
     curl -fsSL "https://dl.google.com/go/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz" | tar -C /tmp -xz && \
@@ -128,6 +131,7 @@ RUN GO_GIT_VERSION=5.19.0 && \
     git clone --depth 1 --branch "v${WANDB_VERSION}" https://github.com/wandb/wandb.git /tmp/wandb-src && \
     cd /tmp/wandb-src/core && \
     go get github.com/go-git/go-git/v5@v${GO_GIT_VERSION} && \
+    go get google.golang.org/grpc@v${GRPC_VERSION} && \
     go mod tidy && \
     go mod vendor && \
     CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -trimpath -ldflags="-s -w" \

--- a/docker/Dockerfile.fw_final
+++ b/docker/Dockerfile.fw_final
@@ -86,7 +86,7 @@ RUN pip install "starlette==0.49.1" \
     "onnx==1.21.0" \
     "notebook>=7.5.6" \
     "jupyterlab>=4.5.7" \
-    "jupyter-server>=2.18.0" \
+    "jupyter-server>=2.20.0" \
     "mistune>=3.2.1" \
     "GitPython>=3.1.50" && \
     # Address CVE from transitive dependency

--- a/docker/common/fw_pyproject.toml
+++ b/docker/common/fw_pyproject.toml
@@ -67,9 +67,9 @@ override-dependencies = [
     "packaging>=25.0",
     "nvidia-pytriton>=0.7.0",
     "urllib3>=2.0.7",
-    "sh==2.2.2",
+    "sh==2.2.4",
     "jupyter-core==5.8.1",
-    "pillow==12.2.0",
+    "pillow==12.3.0",
     "protobuf==6.33.5",
     "cuda-python>=13.0.0",
     "multi-storage-client!=0.36.0",
@@ -122,5 +122,8 @@ override-dependencies = [
     "decord; sys_platform == 'never'",                   # Optional dependency. Resolves CVE
     "av; sys_platform == 'never'",                       # Optional dependency. Resolves CVE
     "opencv-python-headless; sys_platform == 'never'",   # Optional dependency. Resolves CVE
-    "fastapi<0.139.2"                                    # 0.139.2 fails with ray 2.55.1 at least
+    "ray>=2.56.0",
+    "starlette==1.3.1",
+    "prometheus-fastapi-instrumentator>=8.0.0",          # 7.x requires starlette<1.0.0
+    "fastapi<0.139.2"                                    # 0.139.2 fails with ray serve
 ]

--- a/docker/common/fw_pyproject.toml
+++ b/docker/common/fw_pyproject.toml
@@ -115,7 +115,7 @@ override-dependencies = [
     "setuptools>=82.0.0",                                # Required by vllm
     "open-clip-torch>=3.2.0",                            # Required by megatron-bridge, override nemo-toolkit's 2.24.0 constraint
     "lilcom!=1.8.2",
-    "cryptography>=43.0.0,<47",                          # Required by megatron-bridge, override nemo-run's constraint
+    "cryptography>=48.0.1,<49",                          # Required by megatron-bridge, override nemo-run's constraint
     "opencv-python; sys_platform == 'never'",            # Use the dependency from the base pytorch container
     "langchain~=1.0.0",
     "langchain-core~=1.3.3",                             # GHSA-pjwx-r37v-7724


### PR DESCRIPTION
# What does this PR do ?
fix(docker): update dependencies in Dockerfile and fw_pyproject.toml for compatibility and security
- Replaced `starlette` with version 1.3.1 and updated `fastapi` to 0.139.1 in Dockerfile.fw_final.
- Upgraded `pillow` to 12.3.0 and `tornado` to 6.5.6 in Dockerfile.fw_final.
- Updated `jupyterlab` to 4.5.10 and `GitPython` to 3.1.55 in Dockerfile.fw_final.
- Adjusted `sh` version to 2.2.4 and added `ray` dependency in fw_pyproject.toml.
- Addressed CVEs by updating gRPC and Go versions in wandb-core patches.

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
