### PR TITLE
fix(training): preserve alltoall flex fallback

### DIFF
--- a/src/megatron/bridge/training/flex_dispatcher_backend.py
+++ b/src/megatron/bridge/training/flex_dispatcher_backend.py
@@ -24,6 +24,12 @@ from megatron.bridge.utils.common_utils import get_rank_safe
 logger: logging.Logger = logging.getLogger(__name__)
 
 
+def _fallback_to_alltoall(model_config: TransformerConfig) -> None:
+    """Clear flex dispatcher state when the requested backend cannot be used."""
+    model_config.moe_token_dispatcher_type = "alltoall"
+    model_config.moe_flex_dispatcher_backend = None
+
+
 def apply_flex_dispatcher_backend(
     model_config: TransformerConfig,
     moe_flex_dispatcher_backend: str | None = None,
@@ -51,16 +57,18 @@ def apply_flex_dispatcher_backend(
             if get_rank_safe() == 0:
                 logger.warning(
                     f"DeepEP is only applicable to Ampere, Hopper, and Blackwell (B200/B300) GPUs. "
-                    f"Current GPU: {device_properties.name}. Skipping DeepEP configuration."
+                    f"Current GPU: {device_properties.name}. Falling back to alltoall."
                 )
+            _fallback_to_alltoall(model_config)
             return
     elif moe_flex_dispatcher_backend == "hybridep":
         if not device_properties.major in [8, 9, 10]:
             if get_rank_safe() == 0:
                 logger.warning(
                     f"HybridEP is only applicable for GB200, GB300 with NVL72 and for Ampere, Hopper, B200 and B300 GPUs. "
-                    f"Current GPU: {device_properties.name}. Skipping HybridEP configuration."
+                    f"Current GPU: {device_properties.name}. Falling back to alltoall."
                 )
+            _fallback_to_alltoall(model_config)
             return
     else:
         if get_rank_safe() == 0:

--- a/tests/unit_tests/training/test_deepep.py
+++ b/tests/unit_tests/training/test_deepep.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 from megatron.core.transformer import TransformerConfig
+from scripts.performance.utils.utils import finalize_config_overrides
 
 from megatron.bridge.training.flex_dispatcher_backend import (
     apply_flex_dispatcher_backend,
@@ -183,6 +185,48 @@ class TestApplyDeepEP:
         # Verify configs were NOT set
         assert config.moe_token_dispatcher_type != "flex"
         assert config.moe_shared_expert_overlap != False
+
+
+class TestFlexDispatcherFallback:
+    """Test unsupported flex backends stay disabled after config finalization."""
+
+    @pytest.mark.parametrize(
+        ("backend", "major", "device_name"),
+        [
+            pytest.param("deepep", 10, "NVIDIA GB200", id="deepep-gb200"),
+            pytest.param("hybridep", 11, "NVIDIA X200", id="hybridep-unsupported"),
+        ],
+    )
+    @patch("torch.cuda.get_device_properties")
+    def test_unsupported_backend_falls_back_to_alltoall(
+        self,
+        mock_get_device_properties,
+        backend,
+        major,
+        device_name,
+    ):
+        mock_properties = MagicMock()
+        mock_properties.major = major
+        mock_properties.name = device_name
+        mock_get_device_properties.return_value = mock_properties
+        config = SimpleNamespace(
+            model=SimpleNamespace(
+                num_moe_experts=8,
+                moe_token_dispatcher_type="alltoall",
+                moe_flex_dispatcher_backend=backend,
+                moe_shared_expert_overlap=True,
+            ),
+            ddp=SimpleNamespace(nccl_ub=False, fsdp_manual_registration=False),
+        )
+
+        apply_flex_dispatcher_backend(config.model, moe_flex_dispatcher_backend=backend)
+        finalize_config_overrides(config)
+        validate_flex_dispatcher_backend(config.model)
+
+        assert config.model.moe_token_dispatcher_type == "alltoall"
+        assert config.model.moe_flex_dispatcher_backend is None
+        assert config.model.moe_shared_expert_overlap is True
+        mock_get_device_properties.assert_called_once_with(0)
 
 
 class TestValidateDeepEP:


### PR DESCRIPTION
## Summary

- clear stale flex backend metadata when DeepEP or HybridEP is unsupported on the current GPU
- preserve the standard `alltoall` correctness fallback through performance config finalization
- add regression coverage for DeepEP on NVIDIA GB200 and unsupported HybridEP across `apply → finalize → validate`

## Regression

Linear: MB-917

The generic Qwen3 235B recipe resolves to the H100 recipe, which starts with `alltoall` plus DeepEP backend metadata. On NVIDIA GB200, `apply_flex_dispatcher_backend()` correctly rejects DeepEP, but previously returned without clearing that metadata.

The config finalizer introduced by #4682 then saw `moe_flex_dispatcher_backend="deepep"` and changed the dispatcher back to `flex`. Validation raised before training:

`ValueError: DeepEP is supported for Ampere, Hopper, and Blackwell (B200/B300) GPUs. Current GPU: NVIDIA GB200`

Evidence:

- last known successful fallback: [nemo-ci job 349612719](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/349612719), completed 50 steps
- regression reproduction: [nemo-ci job 373587520](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/373587520), failed before step 0
- regression boundary: #4682 / `cce4953735489fdf76395893982a80e61bb7c1d6`

This change does not add NVIDIA GB200 to the DeepEP allow-list. GB200 should use HybridEP when an architecture-specific recipe selects it, or fall back to `alltoall` for correctness.

## Testing

Using `nvcr.io/nvidia/nemo:26.06.01` with the PR source and pinned MCore:

- `uv run --active --no-sync python -m pytest tests/unit_tests/training/test_deepep.py -q` — 17 passed
- `uv run --active --no-sync pre-commit run --all-files` — passed
- targeted Ruff check and format check — passed
- `mypy --strict --ignore-missing-imports src/megatron/bridge/training/flex_dispatcher_backend.py` — passed

A representative 128-GPU GB200 nemo-ci rerun should confirm training proceeds through the restored `alltoall` fallback.