### PR TITLE
[ckpt] fix: Align FSDP checkpoint source selection

### DIFF
--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -2687,8 +2687,8 @@ def _load_checkpoint_from_path(
             skip_load_to_model_and_opt=skip_load_to_model_and_opt,
         )
 
-    # Step 1: Load base checkpoint with rank0=True (torch_dist only)
-    if ckpt_format == "torch_dist":
+    # Step 1: Resolve the checkpoint source and load common metadata when available.
+    if ckpt_format in ("torch_dist", "fsdp_dtensor"):
         state_dict, checkpoint_name, release, ckpt_type = _load_base_checkpoint(
             load_dir,
             cfg.checkpoint,
@@ -2859,44 +2859,31 @@ def _load_checkpoint_from_path(
 
     elif ckpt_format == "fsdp_dtensor":
         # Handle fsdp_dtensor format
-
-        # Resolve checkpoint path
-        if is_checkpoint_iteration_directory(load_dir):
-            checkpoint_name = load_dir
-        else:
-            tracker_filename = get_checkpoint_train_state_filename(load_dir, prefix=TRACKER_PREFIX)
-            if file_exists(tracker_filename):
-                train_state = read_train_state(tracker_filename)
-                iteration = train_state.step
-                release = False
-            else:
-                legacy_tracker_filename = get_checkpoint_tracker_filename(load_dir)
-                if file_exists(legacy_tracker_filename):
-                    iteration, release = read_metadata(legacy_tracker_filename)
-                else:
-                    print_rank_0(f"WARNING: could not find metadata file in {load_dir}")
-                    return 0, 0
-            checkpoint_name = get_checkpoint_name(load_dir, iteration, release)
+        if state_dict is None:
+            return 0, 0
 
         tp_pp_match = True
-        run_config_filename = get_checkpoint_run_config_filename(checkpoint_name)
-        if file_exists(run_config_filename):
-            run_config = read_run_config(run_config_filename)
-            ckpt_tp_pp = (
-                run_config["model"]["tensor_model_parallel_size"],
-                run_config["model"]["pipeline_model_parallel_size"],
-            )
-            run_tp_pp = (
-                cfg.model.tensor_model_parallel_size,
-                cfg.model.pipeline_model_parallel_size,
-            )
-            tp_pp_match = ckpt_tp_pp == run_tp_pp
-
-        reader = _get_filesystem_reader(checkpoint_name)
-        try:
-            state_dict_metadata = reader.read_metadata().state_dict_metadata
-        except FileNotFoundError:
+        if ckpt_type == CheckpointType.LOCAL:
             state_dict_metadata = {}
+        else:
+            run_config_filename = get_checkpoint_run_config_filename(checkpoint_name)
+            if file_exists(run_config_filename):
+                run_config = read_run_config(run_config_filename)
+                ckpt_tp_pp = (
+                    run_config["model"]["tensor_model_parallel_size"],
+                    run_config["model"]["pipeline_model_parallel_size"],
+                )
+                run_tp_pp = (
+                    cfg.model.tensor_model_parallel_size,
+                    cfg.model.pipeline_model_parallel_size,
+                )
+                tp_pp_match = ckpt_tp_pp == run_tp_pp
+
+            reader = _get_filesystem_reader(checkpoint_name)
+            try:
+                state_dict_metadata = reader.read_metadata().state_dict_metadata
+            except FileNotFoundError:
+                state_dict_metadata = {}
 
         # Decide what sections to load based on metadata and config
         gen_sd_rerun_state = {}
@@ -3404,6 +3391,7 @@ def _load_non_persistent_base_checkpoint(
     sharded_state_dict: Optional[dict[str, Any]],
     non_persistent_iteration: int,
     checkpointing_context: Optional[dict[str, Any]] = None,
+    cfg: Optional[ConfigContainer] = None,
     *,
     pg_collection: ProcessGroupCollection,
 ) -> tuple[dict[str, Any], str, bool, CheckpointType]:
@@ -3412,6 +3400,16 @@ def _load_non_persistent_base_checkpoint(
     if ckpt_cfg.non_persistent_ckpt_type == "global":
         if not rank0:
             print_rank_0(f"Loading from a non-persistent checkpoint (non-persistent iter {non_persistent_iteration})")
+        if ckpt_cfg.ckpt_format == "fsdp_dtensor":
+            return load_fsdp_dtensor_checkpoint(
+                non_persistent_global_dir,
+                ckpt_cfg,
+                rank0,
+                sharded_state_dict,
+                non_persistent_iteration,
+                checkpointing_context=checkpointing_context,
+                cfg=cfg,
+            )
         return _load_global_dist_base_checkpoint(
             non_persistent_global_dir,
             ckpt_cfg,
@@ -3607,6 +3605,7 @@ def _load_base_checkpoint(
                 sharded_state_dict,
                 non_persistent_iteration,
                 checkpointing_context,
+                cfg=cfg,
                 pg_collection=pg_collection,
             )
         else:

--- a/tests/unit_tests/training/test_checkpointing.py
+++ b/tests/unit_tests/training/test_checkpointing.py
@@ -40,6 +40,7 @@ from megatron.bridge.training.checkpointing import (
     _load_checkpoint_from_path,
     _load_hf_pretrained_checkpoint,
     _load_model_state_dict,
+    _load_non_persistent_base_checkpoint,
     _record_dataloader_state_dir,
     _save_hf_adapter_weights,
     _save_hf_weights,
@@ -1519,7 +1520,10 @@ class TestLoadCheckpoint:
             ) as mock_generate,
             patch(
                 "megatron.bridge.training.checkpointing._load_base_checkpoint",
-                return_value=(None, "", False, None),
+                side_effect=[
+                    ({}, "/checkpoints/iter_0000003", False, CheckpointType.FSDP_DTENSOR),
+                    (None, "", False, None),
+                ],
             ),
         ):
             mock_read_run_config.return_value = {
@@ -1990,6 +1994,42 @@ class TestLoadBaseCheckpoint:
         mock_pg.tp.rank.return_value = 0
         mock_pg.tp.size.return_value = 1
         return mock_pg
+
+    @patch("megatron.bridge.training.checkpointing.load_fsdp_dtensor_checkpoint")
+    def test_global_non_persistent_fsdp_uses_fsdp_loader(
+        self,
+        mock_load_fsdp,
+        base_config,
+        mock_pg_collection,
+    ):
+        """Global non-persistent FSDP checkpoints must use the DTensor loader."""
+        base_config.ckpt_format = "fsdp_dtensor"
+        base_config.non_persistent_ckpt_type = "global"
+        full_config = Mock(spec=ConfigContainer)
+        expected = ({}, "/ckpt/iter_0000100", False, CheckpointType.FSDP_DTENSOR)
+        mock_load_fsdp.return_value = expected
+
+        result = _load_non_persistent_base_checkpoint(
+            "/ckpt",
+            base_config,
+            True,
+            None,
+            100,
+            checkpointing_context={},
+            cfg=full_config,
+            pg_collection=mock_pg_collection,
+        )
+
+        assert result == expected
+        mock_load_fsdp.assert_called_once_with(
+            "/ckpt",
+            base_config,
+            True,
+            None,
+            100,
+            checkpointing_context={},
+            cfg=full_config,
+        )
 
     def test_global_non_persistent_checkpoint_is_found_under_distinct_save_dir(self, tmp_path):
         """An unchanged restart discovers the non-persistent checkpoint written under save."""
@@ -3969,26 +4009,21 @@ class TestCheckpointPathOverride:
 class TestLoadCheckpointFromPathDirectIterDir:
     """Test _load_checkpoint_from_path with a direct iteration directory (fsdp_dtensor path).
 
-    The fsdp_dtensor branch in _load_checkpoint_from_path has its own
-    is_checkpoint_iteration_directory check to resolve the checkpoint path
-    before constructing the sharded state dict.  We verify that when the
-    load_dir is an iteration directory the FileSystemReader receives the
-    directory directly (no tracker-file indirection).
+    Checkpoint source selection happens before the FSDP-specific metadata
+    preparation. We verify that a selected iteration directory is passed
+    directly to the filesystem reader.
     """
 
-    @patch("megatron.bridge.training.checkpointing.is_checkpoint_iteration_directory")
     @patch("megatron.bridge.training.checkpointing.get_pg_collection")
     @patch("megatron.bridge.training.checkpointing.unwrap_model")
     @patch("megatron.core.dist_checkpointing.strategies.torch.FileSystemReader")
-    def test_fsdp_dtensor_skips_tracker_resolution(self, mock_reader, mock_unwrap, mock_get_pg, mock_is_iter_dir):
+    def test_fsdp_dtensor_skips_tracker_resolution(self, mock_reader, mock_unwrap, mock_get_pg):
         """When load_dir is an iteration directory, FileSystemReader should receive it directly."""
         from megatron.core.msc_utils import MultiStorageClientFeature
 
         from megatron.bridge.training.checkpointing import _load_checkpoint_from_path
 
         MultiStorageClientFeature.disable()
-
-        mock_is_iter_dir.return_value = True
 
         mock_metadata = Mock()
         mock_metadata.state_dict_metadata = {}
@@ -4044,23 +4079,95 @@ class TestLoadCheckpointFromPathDirectIterDir:
             # The fsdp_dtensor prep block should have called FileSystemReader
             # with the direct path (not a tracker-resolved path).
             mock_reader.assert_called_once_with("/ckpt/iter_0001000")
-            mock_is_iter_dir.assert_called_once_with("/ckpt/iter_0001000")
 
+    @patch("megatron.bridge.training.checkpointing.read_train_state")
+    @patch("megatron.bridge.training.checkpointing.file_exists")
     @patch("megatron.bridge.training.checkpointing.is_checkpoint_iteration_directory")
     @patch("megatron.bridge.training.checkpointing.get_pg_collection")
     @patch("megatron.bridge.training.checkpointing.unwrap_model")
-    @patch("multistorageclient.torch.MultiStorageFileSystemReader")
-    def test_fsdp_dtensor_skips_tracker_resolution_with_msc(
-        self, mock_reader, mock_unwrap, mock_get_pg, mock_is_iter_dir
+    @patch("megatron.core.dist_checkpointing.strategies.torch.FileSystemReader")
+    def test_fsdp_dtensor_ckpt_step_prepares_requested_iteration(
+        self,
+        mock_reader,
+        mock_unwrap,
+        mock_get_pg,
+        mock_is_iter_dir,
+        mock_file_exists,
+        mock_read_train_state,
     ):
+        """FSDP metadata and payload loading must use the explicitly requested iteration."""
+        from megatron.core.msc_utils import MultiStorageClientFeature
+
+        from megatron.bridge.training.checkpointing import _load_checkpoint_from_path
+
+        MultiStorageClientFeature.disable()
+        mock_is_iter_dir.return_value = False
+        mock_file_exists.side_effect = lambda path: path.endswith("latest_train_state.pt")
+        mock_read_train_state.return_value = TrainState(step=200)
+
+        mock_metadata = Mock()
+        mock_metadata.state_dict_metadata = {}
+        mock_reader_instance = Mock()
+        mock_reader_instance.read_metadata.return_value = mock_metadata
+        mock_reader.return_value = mock_reader_instance
+
+        mock_model = Mock()
+        mock_unwrap.return_value = [mock_model]
+        mock_pg = Mock()
+        mock_pg.dp_cp = Mock()
+        mock_get_pg.return_value = mock_pg
+
+        mock_cfg = Mock()
+        mock_cfg.checkpoint = Mock(spec=CheckpointConfig)
+        mock_cfg.checkpoint.ckpt_format = "fsdp_dtensor"
+        mock_cfg.checkpoint.finetune = True
+        mock_cfg.checkpoint.load_rng = False
+        mock_cfg.checkpoint.load_optim = False
+        mock_cfg.checkpoint.ckpt_step = 100
+        mock_cfg.checkpoint.load = "/ckpt"
+        mock_cfg.checkpoint.pretrained_checkpoint = None
+        mock_cfg.optimizer = Mock()
+        mock_cfg.optimizer.use_distributed_optimizer = False
+        mock_cfg.peft = None
+        mock_cfg.rng = Mock()
+
+        mock_state = Mock(spec=GlobalState)
+        mock_state.cfg = mock_cfg
+
+        with (
+            patch("megatron.bridge.training.checkpointing.generate_state_dict", return_value={"model": {}}),
+            patch("megatron.bridge.training.checkpointing._build_sharded_state_dict_metadata", return_value={}),
+            patch("megatron.bridge.training.checkpointing._load_base_checkpoint") as mock_load_base,
+            patch("megatron.bridge.training.checkpointing.set_checkpoint_version"),
+        ):
+            mock_load_base.return_value = (
+                {"model": {}, "checkpoint_version": 3.0},
+                "/ckpt/iter_0000100",
+                False,
+                CheckpointType.FSDP_DTENSOR,
+            )
+
+            _load_checkpoint_from_path(
+                load_dir="/ckpt",
+                state=mock_state,
+                model=[mock_model],
+                optimizer=None,
+                opt_param_scheduler=None,
+                skip_load_to_model_and_opt=True,
+            )
+
+        mock_reader.assert_called_once_with("/ckpt/iter_0000100")
+
+    @patch("megatron.bridge.training.checkpointing.get_pg_collection")
+    @patch("megatron.bridge.training.checkpointing.unwrap_model")
+    @patch("multistorageclient.torch.MultiStorageFileSystemReader")
+    def test_fsdp_dtensor_skips_tracker_resolution_with_msc(self, mock_reader, mock_unwrap, mock_get_pg):
         """When load_dir is an iteration directory, FileSystemReader should receive it directly."""
         from megatron.core.msc_utils import MultiStorageClientFeature
 
         from megatron.bridge.training.checkpointing import _load_checkpoint_from_path
 
         MultiStorageClientFeature.enable()
-
-        mock_is_iter_dir.return_value = True
 
         mock_metadata = Mock()
         mock_metadata.state_dict_metadata = {}
@@ -4116,7 +4223,6 @@ class TestLoadCheckpointFromPathDirectIterDir:
             # The fsdp_dtensor prep block should have called FileSystemReader
             # with the direct path (not a tracker-resolved path).
             mock_reader.assert_called_once_with("/ckpt/iter_0001000", thread_count=2)
-            mock_is_iter_dir.assert_called_once_with("/ckpt/iter_0001000")
 
 
 class TestCheckpointManager:


### PR DESCRIPTION
## Problem

When `ckpt_format="fsdp_dtensor"` is used with an explicit `ckpt_step`, the
FSDP preparation pass independently followed the latest tracker while the
payload pass honored `ckpt_step`. For example, with tracker step 200 and
`ckpt_step=100`, run configuration and DCP metadata came from iteration 200
while model and training state came from iteration 100.

The same split resolver caused FSDP-only non-persistent recovery points to be
skipped or prepared using metadata from a different persistent checkpoint.
This can silently skip a valid resume or apply incorrect RNG/rerun-state
loading decisions.

## Root cause and fix

`_load_checkpoint_from_path` used `_load_base_checkpoint` for the initial
metadata pass only for `torch_dist`; its FSDP branch reimplemented a
tracker-only checkpoint resolver.

This change:

- routes FSDP metadata preparation through the common checkpoint selector, so
  direct directories, `ckpt_step`, and persistent/non-persistent selection use
  one checkpoint identity;
- dispatches global non-persistent FSDP checkpoints through the FSDP DTensor
  loader and propagates the full config needed for preprocessing;
- avoids filesystem metadata reads for local non-persistent checkpoints; and
- updates existing direct-directory/layout tests to assert the common-source
  contract.

## Verification

Fail-before on unmodified `main`:

```text
uv run --no-sync python -m pytest tests/unit_tests/training/test_checkpointing.py::TestLoadCheckpointFromPathDirectIterDir::test_fsdp_dtensor_ckpt_step_prepares_requested_iteration -q
1 failed
Expected: FileSystemReader('/ckpt/iter_0000100')
Actual:   FileSystemReader('/ckpt/iter_0000200')
```

Pass-after with the unchanged regression:

```text
uv run --no-sync python -m pytest tests/unit_tests/training/test_checkpointing.py::TestLoadCheckpointFromPathDirectIterDir::test_fsdp_dtensor_ckpt_step_prepares_requested_iteration -q
1 passed
```

Focused FSDP source-selection coverage:

```text
uv run --no-sync python -m pytest tests/unit_tests/training/test_checkpointing.py -k 'fsdp_layout_change_ignores_rng_state or TestLoadCheckpointFromPathDirectIterDir or test_global_non_persistent_fsdp_uses_fsdp_loader or TestResolveCheckpointIteration' -q
5 passed, 163 deselected
```

Adjacent checkpointing coverage:

```text
uv run --no-sync python -m pytest tests/unit_tests/training/test_checkpointing.py -k 'not test_clear_auto_bridge_cache_resets_cached_bridge and not test_ensure_directory_exists_with_msc_url and not test_init_checkpointing_context_local' -q
164 passed, 4 deselected
```

Also passed:

- `git diff --check`
- `uv run --no-sync pre-commit run --all-files`

## Scope

This is limited to checkpoint source selection and FSDP DTensor loading
dispatch. It does not change checkpoint formats, public APIs, dependencies, CI
workflows, or Megatron-Core.
