### PR TITLE
[training] fix: replace setup hooks across restarts

### DIFF
--- a/src/megatron/bridge/training/setup.py
+++ b/src/megatron/bridge/training/setup.py
@@ -292,7 +292,7 @@ def setup(
     # Register PEFT pre-wrap hook if PEFT is configured
     if cfg.peft is not None:
         peft_hook = _create_peft_pre_wrap_hook(cfg, state)
-        _register_pre_wrap_hook(cfg.model, peft_hook)
+        _register_setup_pre_wrap_hook(cfg.model, peft_hook, setup_hook_name="peft")
         print_rank_0("Registered PEFT pre-wrap hook")
 
     if getattr(cfg.model, "restore_modelopt_state", False):
@@ -323,7 +323,7 @@ def setup(
             load_modelopt_state(model, checkpoint_path, ckpt_step=ckpt_step)
             return model
 
-        _register_pre_wrap_hook(cfg.model, modelopt_pre_wrap_hook)
+        _register_setup_pre_wrap_hook(cfg.model, modelopt_pre_wrap_hook, setup_hook_name="modelopt")
 
     # Enable CUDA allocator history tracing before any model tensors are allocated,
     # so snapshots dumped later in training contain a full timeline + stack context.
@@ -467,12 +467,39 @@ def setup(
     )
 
 
-def _register_pre_wrap_hook(model_cfg: ModelConfig | ModelProviderMixin, hook):
+def _register_pre_wrap_hook(
+    model_cfg: ModelConfig | ModelProviderMixin,
+    hook: Callable[[list[MegatronModule]], list[MegatronModule]],
+) -> None:
     """Register a pre-wrap hook on either ModelConfig or ModelProviderMixin."""
     if isinstance(model_cfg, ModelConfig):
         model_cfg.pre_wrap_hooks.append(hook)
     else:
         model_cfg.register_pre_wrap_hook(hook)
+
+
+def _register_setup_pre_wrap_hook(
+    model_cfg: ModelConfig | ModelProviderMixin,
+    hook: Callable[[list[MegatronModule]], list[MegatronModule]],
+    *,
+    setup_hook_name: str,
+) -> None:
+    """Replace one setup-owned hook while preserving user registrations."""
+    setup_hooks = getattr(model_cfg, "_megatron_bridge_setup_pre_wrap_hooks", {})
+    previous_hook = setup_hooks.get(setup_hook_name)
+    if previous_hook is not None:
+        if isinstance(model_cfg, ModelConfig):
+            model_cfg.pre_wrap_hooks[:] = [
+                registered_hook for registered_hook in model_cfg.pre_wrap_hooks if registered_hook is not previous_hook
+            ]
+        else:
+            model_cfg._pre_wrap_hooks[:] = [
+                registered_hook for registered_hook in model_cfg._pre_wrap_hooks if registered_hook is not previous_hook
+            ]
+
+    setup_hooks[setup_hook_name] = hook
+    model_cfg._megatron_bridge_setup_pre_wrap_hooks = setup_hooks
+    _register_pre_wrap_hook(model_cfg, hook)
 
 
 def _build_distributed_model(cfg: ConfigContainer, pg_collection: ProcessGroupCollection) -> list[MegatronModule]:

--- a/tests/unit_tests/training/test_setup.py
+++ b/tests/unit_tests/training/test_setup.py
@@ -27,6 +27,7 @@ from megatron.bridge.training.setup import (
     _bind_dataset_provider_context,
     _build_distributed_model,
     _register_pre_wrap_hook,
+    _register_setup_pre_wrap_hook,
     _should_load_checkpoint,
     _update_model_config_funcs,
     _validate_and_set_vocab_size,
@@ -291,6 +292,19 @@ class TestRegisterPreWrapHook:
         hook = lambda models: models  # noqa: E731
         _register_pre_wrap_hook(mock_provider, hook)
         mock_provider.register_pre_wrap_hook.assert_called_once_with(hook)
+
+    def test_setup_hook_replacement_preserves_model_config_user_hooks(self):
+        """Replacing setup-owned hooks must not remove caller registrations."""
+        cfg = _make_gpt_model_config()
+        user_hook = Mock(side_effect=lambda models: models)
+        stale_setup_hook = Mock(side_effect=lambda models: models)
+        current_setup_hook = Mock(side_effect=lambda models: models)
+        _register_pre_wrap_hook(cfg, user_hook)
+
+        _register_setup_pre_wrap_hook(cfg, stale_setup_hook, setup_hook_name="peft")
+        _register_setup_pre_wrap_hook(cfg, current_setup_hook, setup_hook_name="peft")
+
+        assert cfg.pre_wrap_hooks == [user_hook, current_setup_hook]
 
 
 class TestBuildDistributedModel:

--- a/tests/unit_tests/training/test_setup_restart_hooks.py
+++ b/tests/unit_tests/training/test_setup_restart_hooks.py
@@ -1,0 +1,118 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+import torch
+from torch import nn
+
+import megatron.bridge.training.setup as training_setup
+from megatron.bridge.models.gpt_provider import GPTModelProvider
+from megatron.bridge.peft.base import PEFT
+
+
+class _OneTimeAdapterPEFT(PEFT):
+    """Minimal PEFT transform that exposes a duplicate-application freeze."""
+
+    def transform(self, module: nn.Module, name: str | None = None, prefix: str | None = None) -> nn.Module:
+        if not isinstance(module, nn.Linear) or getattr(module, "_adapter_applied", False):
+            return module
+
+        module._adapter_applied = True
+        for parameter in module.parameters(recurse=False):
+            parameter.requires_grad = True
+        return module
+
+
+def test_peft_setup_hook_does_not_accumulate_across_restart_attempts():
+    """A rebuilt model must receive one PEFT transform while user hooks survive."""
+
+    class StopAfterHooksRegistered(Exception):
+        pass
+
+    model_provider = GPTModelProvider(
+        num_layers=1,
+        hidden_size=16,
+        num_attention_heads=1,
+        vocab_size=64,
+    )
+    user_hook = Mock(side_effect=lambda model: model)
+    model_provider.register_pre_wrap_hook(user_hook)
+    peft = _OneTimeAdapterPEFT()
+    cfg = SimpleNamespace(
+        checkpoint=SimpleNamespace(
+            load=None,
+            pretrained_checkpoint="/pretrained",
+            save=None,
+        ),
+        dataset=SimpleNamespace(),
+        dist=SimpleNamespace(enable_megatron_core_experimental=False, disable_jit_fuser=False),
+        ft=None,
+        logger=SimpleNamespace(
+            filter_warnings=False,
+            log_progress=False,
+            logging_level="INFO",
+            modules_to_filter=[],
+            set_level_for_all_loggers=False,
+        ),
+        model=model_provider,
+        peft=peft,
+        profiling=SimpleNamespace(),
+        tensor_inspect=SimpleNamespace(),
+        tokenizer=SimpleNamespace(),
+        train=SimpleNamespace(micro_batch_size=1, num_epochs=None),
+    )
+    timer = MagicMock()
+    state = SimpleNamespace(
+        cfg=cfg,
+        initialize_async_checkpoint_worker=Mock(),
+        start_time=0.0,
+        timers=Mock(return_value=timer),
+    )
+    start_time_tensor = Mock()
+    start_time_tensor.item.return_value = 0.0
+
+    with (
+        patch.multiple(
+            training_setup,
+            barrier_and_log=Mock(),
+            build_tokenizer=Mock(return_value=SimpleNamespace(vocab_size=32)),
+            checkpoint_exists=Mock(side_effect=lambda path: path == "/pretrained"),
+            create_checkpoint_manager=Mock(),
+            initialize_megatron=Mock(return_value=object()),
+            initialize_tensor_inspect_pre_model_initialization=Mock(),
+            maybe_log_and_save_config=Mock(),
+            print_rank_0=Mock(),
+            set_experimental_flag=Mock(),
+            set_jit_fusion_options=Mock(),
+            setup_logging=Mock(),
+            start_memory_history_recording=Mock(),
+            _build_distributed_model=Mock(side_effect=StopAfterHooksRegistered),
+            _load_checkpoint_from_path=Mock(),
+        ),
+        patch.object(torch, "tensor", return_value=start_time_tensor),
+        patch.object(torch.distributed, "all_reduce"),
+    ):
+        for _attempt in range(2):
+            with pytest.raises(StopAfterHooksRegistered):
+                training_setup.setup(state, Mock())
+
+        model = [nn.Sequential(nn.Linear(4, 4))]
+        transformed_model = model_provider.pre_wrap_hook(model)
+
+        user_hook.assert_called_once_with(model)
+        assert any(parameter.requires_grad for parameter in transformed_model[0].parameters())
+        assert peft.params_to_save


### PR DESCRIPTION
## What changed

Replace Bridge-owned PEFT and ModelOpt pre-wrap hooks when `setup()` is re-entered with a retained model configuration. Caller-registered hooks remain intact on both `ModelConfig` and `ModelProviderMixin` paths.

## User impact and root cause

In-process restart retains `ConfigContainer` across workload attempts. Each attempt previously appended fresh setup-owned pre-wrap closures to that retained configuration. On a PEFT retry, both closures ran on the rebuilt model: the second PEFT application froze every parameter before the LoRA transform skipped already-adapted modules, leaving adapter parameters non-trainable and absent from `params_to_save`.

The fix records only Bridge setup-owned registrations by hook kind and removes the prior hook by identity before adding the current attempt's closure. It does not clear or replace user hooks.

## Validation

Fail before / pass after with the unchanged regression:

```text
uv run --no-sync python -m pytest tests/unit_tests/training/test_setup_restart_hooks.py -q --tb=short
before: 1 failed (rebuilt-model parameters were all frozen)
after:  1 passed
```

Focused adjacent coverage:

```text
uv run --no-sync python -m pytest tests/unit_tests/training/test_setup_restart_hooks.py tests/unit_tests/training/test_setup.py tests/unit_tests/training/test_state.py tests/unit_tests/training/test_modelopt_setup.py tests/unit_tests/models/test_model_provider_mixin.py -q --tb=short
99 passed

uv run --no-sync pre-commit run --all-files
passed

git diff --check
passed
```

## Scope

This changes only setup-time hook ownership across retained configurations. It does not alter PEFT transforms, ModelOpt restore behavior, checkpoint formats, public APIs, or distributed execution.
