### PR TITLE
[data] fix: preserve packed full-loss masks

### DIFF
--- a/src/megatron/bridge/data/packing/gpt_sft.py
+++ b/src/megatron/bridge/data/packing/gpt_sft.py
@@ -253,8 +253,6 @@ class GPTSFTPackedDataset(GPTSFTDataset):
 
         tokens = torch.LongTensor(input_ids)
         loss_mask = torch.LongTensor(loss_mask)
-        # drop any padding/eos tokens from contributing to the loss
-        loss_mask[tokens == self.tokenizer.eos_id] = 0
 
         processed_batch = {
             "tokens": tokens,

--- a/tests/unit_tests/data/datasets/test_chat_template.py
+++ b/tests/unit_tests/data/datasets/test_chat_template.py
@@ -1039,6 +1039,38 @@ class TestEOSIndexFixInPackedDataset:
         assert processed["attention_mask"] is None
 
 
+def test_packed_full_loss_preserves_target_after_internal_eos():
+    """Full-loss packing must supervise the label after an EOS turn delimiter."""
+    from megatron.bridge.data.packing.algorithms import fill_packing_strategy
+
+    eos_id = 2
+    sequences = {length: [] for length in range(4)}
+    sequences[3].append(
+        {
+            "input_ids": [10, eos_id, 20, eos_id],
+            "loss_mask": [True, True, True, True],
+        }
+    )
+    packed_row = fill_packing_strategy([[3]], sequences, pack_size=3, pad_id=eos_id)[0]
+    dataset = _create_minimal_packed_dataset(tokenizer_eos_id=eos_id)
+    dataset.answer_only_loss = True
+    dataset.return_cu_seqlen = False
+
+    batch = dataset.collate_fn(
+        [
+            {
+                "input_ids": packed_row["input_ids"],
+                "seq_boundaries": [*packed_row["seq_start_id"], len(packed_row["input_ids"])],
+                "loss_mask": packed_row["loss_mask"],
+            }
+        ]
+    )
+
+    assert batch["tokens"].tolist() == [[10, eos_id, 20]]
+    assert batch["labels"].tolist() == [[eos_id, 20, eos_id]]
+    assert batch["loss_mask"].tolist() == [[1, 1, 1]]
+
+
 class TestPackedChatDatasetIntegration:
     """Integration tests for packed chat datasets."""
 


### PR DESCRIPTION
## What changed

Offline-packed GPT SFT now preserves the mask produced during packing instead of clearing positions based on the packed input token value.

## Supported trigger and impact

`GPTSFTDatasetConfig` supports `ChatSFTPreprocessingConfig(loss_mode="full")` together with offline packing and declarative chat templates. When a multi-turn template renders the tokenizer EOS token between turns, the packed artifact correctly marks the next target as trainable. The runtime collator previously cleared that position because its input token was EOS, silently dropping loss for the first ordinary token after the delimiter. Packed and unpacked runs therefore optimized different objectives for the same preprocessing policy.

## Root cause and fix

`fill_packing_strategy()` already shifts the token-aligned mask once to match next-token labels, and packed padding positions already carry zero mask values. `GPTSFTPackedDataset.collate_fn()` applied a second value-based filter using `tokens == eos_id`; that examines the input token rather than the aligned label and cannot distinguish a real turn delimiter from padding.

The fix removes that redundant filter and leaves semantic masking at the artifact/mask ownership boundary. The current Parquet runtime inherits the same collator.

## Regression evidence

Fail before, pass after:

```text
uv run --active --no-sync python -m pytest tests/unit_tests/data/datasets/test_chat_template.py::test_packed_full_loss_preserves_target_after_internal_eos -q --tb=short
```

- Before: 1 failed; expected `[1, 1, 1]`, received `[1, 0, 1]`.
- After: 1 passed.

Adjacent validation:

```text
uv run --active --no-sync python -m pytest tests/unit_tests/data/datasets/test_chat_template.py tests/unit_tests/data/datasets/test_gpt_sft.py tests/unit_tests/data/packing/test_offline.py tests/unit_tests/data/packing/test_parquet.py tests/unit_tests/data/test_sft_processing.py -q
```

- 133 passed.
- `git diff --check` passed.
- `uv run pre-commit run --all-files` passed.

## Scope

This changes only CPU-side packed GPT-SFT mask collation and adds one focused regression. It does not change public APIs, dependencies, workflows, tokenizer policy, attention boundaries, or unpacked/direct-HF collation. No GPU or distributed kernel behavior is involved.
