### PR TITLE
fix(data): pad Qwen VLM token type IDs

### DIFF
--- a/src/megatron/bridge/models/qwen_vl/data/collate_fn.py
+++ b/src/megatron/bridge/models/qwen_vl/data/collate_fn.py
@@ -364,5 +364,6 @@ def qwen2_5_collate_fn(
         enable_in_batch_packing=enable_in_batch_packing,
         in_batch_packing_pad_to_multiple_of=in_batch_packing_pad_to_multiple_of,
         ignore_index=IGNORE_INDEX,
+        sequence_tensor_pad_values={"mm_token_type_ids": 0},
     )
     return batch

--- a/tests/unit_tests/data/collators/test_model_collators.py
+++ b/tests/unit_tests/data/collators/test_model_collators.py
@@ -234,6 +234,31 @@ def test_qwen2_5_collate_fn_uses_shared_pixel_defaults(monkeypatch):
     assert proc.processor_kwargs[-1]["max_pixels"] == qwen_vl_collate.QWEN_VL_MAX_PIXELS
 
 
+def test_qwen2_5_collate_fn_pads_mm_token_type_ids_with_sequence(monkeypatch):
+    monkeypatch.setattr(qwen_vl_collate, "HAVE_QWEN_VL_UTILS", True)
+    monkeypatch.setattr(qwen_vl_collate, "process_vision_info", lambda conv: (None, None))
+
+    class _TokenTypeProcessor(_DummyProcessor):
+        def __call__(self, *args, **kwargs):
+            batch = super().__call__(*args, **kwargs)
+            batch["mm_token_type_ids"] = torch.tensor([[0, 1, 0]])
+            return batch
+
+    examples = [
+        {"conversation": [{"role": "user", "content": [{"type": "text", "text": "hi"}]}]},
+    ]
+
+    batch = collate.qwen2_5_collate_fn(
+        examples,
+        _TokenTypeProcessor(),
+        sequence_length=8,
+        pad_to_multiple_of=4,
+    )
+
+    assert batch["input_ids"].shape == batch["mm_token_type_ids"].shape == (1, 4)
+    assert batch["mm_token_type_ids"].tolist() == [[0, 1, 0, 0]]
+
+
 def test_qwen2_audio_collate_fn_uses_audio_inputs_key(monkeypatch):
     """qwen2_audio_collate_fn should store Qwen2AudioInputs under 'audio_inputs', not 'visual_inputs'."""
 


### PR DESCRIPTION
## Summary

- pad Qwen processor `mm_token_type_ids` with the other sequence-aligned tensors
- use token type `0` for padded text positions
- add a CPU regression test covering padded batch width and values

Fixes NVBug 6540097.

## Root cause

Qwen processor output retained `mm_token_type_ids` in the batch, but the collator did not register it with the shared sequence-padding helper. `input_ids`, labels, masks, and positions were padded while the per-token type IDs kept their raw width.

## Validation

Fail-before reproduction on `origin/main` (`880523c14`):

```text
input_ids width: 4
mm_token_type_ids width: 3
```

Pass-after:

```text
uv run python -m pytest tests/unit_tests/data/collators/test_model_collators.py::test_qwen2_5_collate_fn_pads_mm_token_type_ids_with_sequence -q
# 1 passed

uv run python -m pytest tests/unit_tests/data/collators/test_model_collators.py -k 'qwen2_5' -q
# 10 passed, 63 deselected

git diff --check
# passed

uv run pre-commit run --all-files
# all hooks passed
```

CPU-only collation semantics; no GPU, distributed, convergence, or performance behavior is changed.
