### PR TITLE
fix(data): normalize GLM VLM assistant content

### DIFF
--- a/src/megatron/bridge/models/glm_vl/data/collate_fn.py
+++ b/src/megatron/bridge/models/glm_vl/data/collate_fn.py
@@ -56,17 +56,14 @@ def _normalize_glm4v_assistant_content(example: dict[str, Any]) -> dict[str, Any
             normalized_conversation.append(turn)
             continue
 
-        content = turn.get("content")
-        parts = [content] if isinstance(content, Mapping) else content
-        if not isinstance(parts, list):
+        parts = turn.get("content")
+        if not isinstance(parts, list) or not parts:
             normalized_conversation.append(turn)
             continue
 
         text_parts = []
         for part in parts:
-            if isinstance(part, str):
-                text_parts.append(part)
-            elif isinstance(part, Mapping) and part.get("type") == "text" and isinstance(part.get("text"), str):
+            if isinstance(part, Mapping) and part.get("type") == "text" and isinstance(part.get("text"), str):
                 text_parts.append(part["text"])
             else:
                 break

--- a/src/megatron/bridge/models/glm_vl/data/collate_fn.py
+++ b/src/megatron/bridge/models/glm_vl/data/collate_fn.py
@@ -14,6 +14,7 @@
 
 """GLM VL collator implementations."""
 
+from collections.abc import Mapping
 from typing import Any
 
 import torch
@@ -40,6 +41,49 @@ GLM4V_ASSISTANT_START = "<|assistant|>\n"
 GLM4V_ASSISTANT_END = "<|endoftext|>"
 GLM4V_EMPTY_THINK = "<think></think>\n"
 GLM4V_NEXT_ROLE_MARKERS = ("<|system|>\n", "<|user|>\n", "<|observation|>\n")
+
+
+def _normalize_glm4v_assistant_content(example: dict[str, Any]) -> dict[str, Any]:
+    """Flatten text-only structured assistant content for GLM chat templates."""
+    conversation = example.get("conversation")
+    if not isinstance(conversation, list):
+        return example
+
+    normalized_conversation = []
+    changed = False
+    for turn in conversation:
+        if not isinstance(turn, Mapping) or turn.get("role") != "assistant":
+            normalized_conversation.append(turn)
+            continue
+
+        content = turn.get("content")
+        parts = [content] if isinstance(content, Mapping) else content
+        if not isinstance(parts, list):
+            normalized_conversation.append(turn)
+            continue
+
+        text_parts = []
+        for part in parts:
+            if isinstance(part, str):
+                text_parts.append(part)
+            elif isinstance(part, Mapping) and part.get("type") == "text" and isinstance(part.get("text"), str):
+                text_parts.append(part["text"])
+            else:
+                break
+        else:
+            normalized_turn = dict(turn)
+            normalized_turn["content"] = "".join(text_parts)
+            normalized_conversation.append(normalized_turn)
+            changed = True
+            continue
+
+        normalized_conversation.append(turn)
+
+    if not changed:
+        return example
+    normalized_example = dict(example)
+    normalized_example["conversation"] = normalized_conversation
+    return normalized_example
 
 
 def _glm4v_assistant_mask_boundary_config(processor: Any) -> AssistantMaskBoundaryConfig:
@@ -107,6 +151,7 @@ def glm4v_collate_fn(
     """
     del visual_keys, min_pixels, max_pixels
 
+    examples = [_normalize_glm4v_assistant_content(example) for example in examples]
     skipped_tokens = extract_skipped_token_ids(processor)
     boundary_config = _glm4v_assistant_mask_boundary_config(processor)
 

--- a/tests/unit_tests/data/collators/test_model_collators.py
+++ b/tests/unit_tests/data/collators/test_model_collators.py
@@ -920,6 +920,54 @@ def test_glm4v_collate_packs_mm_token_type_ids_and_restores_padding(monkeypatch)
 
 
 @pytest.mark.parametrize(
+    "assistant_content",
+    [
+        {"type": "text", "text": "A picture."},
+        [{"type": "text", "text": "A "}, {"type": "text", "text": "picture."}],
+    ],
+)
+def test_glm4v_collate_flattens_structured_assistant_content(monkeypatch, assistant_content):
+    class _GlmProcessor:
+        class _Tokenizer:
+            padding_side = "left"
+            pad_token_id = 0
+
+        def __init__(self):
+            self.tokenizer = self._Tokenizer()
+            self.conversations = None
+
+        def apply_chat_template(self, conversations, **kwargs):
+            self.conversations = conversations
+            return {
+                "input_ids": torch.tensor([[1, 2, 3]]),
+                "attention_mask": torch.ones((1, 3), dtype=torch.long),
+                "mm_token_type_ids": torch.zeros((1, 3), dtype=torch.long),
+            }
+
+    monkeypatch.setattr(
+        glm_vl_collate, "extract_skipped_token_ids", lambda processor: torch.empty(0, dtype=torch.long)
+    )
+    monkeypatch.setattr(glm_vl_collate, "_glm4v_assistant_mask_boundary_config", lambda processor: None)
+    monkeypatch.setattr(
+        glm_vl_collate,
+        "_build_glm4v_assistant_loss_mask",
+        lambda example, input_ids, *args, **kwargs: torch.ones_like(input_ids, dtype=torch.float32),
+    )
+    example = {
+        "conversation": [
+            {"role": "user", "content": "Describe."},
+            {"role": "assistant", "content": assistant_content},
+        ]
+    }
+    processor = _GlmProcessor()
+
+    glm_vl_collate.glm4v_collate_fn([example], processor)
+
+    assert processor.conversations[0][-1]["content"] == "A picture."
+    assert example["conversation"][-1]["content"] == assistant_content
+
+
+@pytest.mark.parametrize(
     ("input_ids", "expected_mask"),
     [
         (

--- a/tests/unit_tests/data/collators/test_model_collators.py
+++ b/tests/unit_tests/data/collators/test_model_collators.py
@@ -919,14 +919,7 @@ def test_glm4v_collate_packs_mm_token_type_ids_and_restores_padding(monkeypatch)
     assert processor.tokenizer.padding_side == "left"
 
 
-@pytest.mark.parametrize(
-    "assistant_content",
-    [
-        {"type": "text", "text": "A picture."},
-        [{"type": "text", "text": "A "}, {"type": "text", "text": "picture."}],
-    ],
-)
-def test_glm4v_collate_flattens_structured_assistant_content(monkeypatch, assistant_content):
+def test_glm4v_collate_flattens_structured_assistant_content(monkeypatch):
     class _GlmProcessor:
         class _Tokenizer:
             padding_side = "left"
@@ -953,6 +946,7 @@ def test_glm4v_collate_flattens_structured_assistant_content(monkeypatch, assist
         "_build_glm4v_assistant_loss_mask",
         lambda example, input_ids, *args, **kwargs: torch.ones_like(input_ids, dtype=torch.float32),
     )
+    assistant_content = [{"type": "text", "text": "A picture."}]
     example = {
         "conversation": [
             {"role": "user", "content": "Describe."},


### PR DESCRIPTION
## Summary

- flatten the Bridge VLM dataset contract for GLM assistant content: a non-empty list of text-part mappings
- leave plain strings and unsupported bare/mixed/non-text/empty shapes unchanged
- keep caller-owned examples unchanged
- add one representative CPU regression for the canonical list form

Fixes NVBug 6540096.

## Root cause

The GLM-4.x template interpolates assistant `content` directly. Canonical Bridge VLM datasets emit assistant content shaped as a list containing text-part mappings; GLM therefore renders and supervises Python container syntax instead of the response text. This shape is produced by the in-tree mock VLM builder and multiple Hugging Face dataset adapters.

## Validation

Fail-before reproduction on `origin/main` (`880523c14`): the assistant response rendered with Python list/dictionary syntax rather than as `A picture.`

Pass-after:

```text
uv run python -m pytest tests/unit_tests/data/collators/test_model_collators.py -k glm4v -q
# 5 passed, 68 deselected

git diff --check
# passed

uv run pre-commit run --all-files
# all hooks passed
```

CPU-only collation semantics; no GPU, distributed, convergence, or performance behavior is changed.