### PR TITLE
fix(data): reject truncation without supervision

### DIFF
--- a/src/megatron/bridge/data/collators/sequence_padding.py
+++ b/src/megatron/bridge/data/collators/sequence_padding.py
@@ -153,9 +153,21 @@ def pad_or_truncate_sequence_batch(
         if pad_to_max_length
         else min(sequence_length, _ceil_to_multiple(tokens.size(1), pad_to_multiple_of))
     )
+    loss_mask = batch.get("loss_mask")
+    prepared_loss_mask = _pad_or_truncate_2d(loss_mask, target_length, 0)
+    if tokens.size(1) > target_length and loss_mask is not None and prepared_loss_mask is not None:
+        had_supervision = torch.any(loss_mask != 0, dim=1)
+        has_supervision = torch.any(prepared_loss_mask != 0, dim=1)
+        emptied_rows = torch.nonzero(had_supervision & ~has_supervision, as_tuple=False).flatten().tolist()
+        if emptied_rows:
+            raise ValueError(
+                f"Truncating sequence batch from {tokens.size(1)} to {target_length} tokens removed every "
+                f"supervised token from rows {emptied_rows}. Increase sequence_length or filter overlength samples."
+            )
+
     _set_tokens(batch, token_key, _pad_or_truncate_2d(tokens, target_length, pad_token_id))
     batch["labels"] = _pad_or_truncate_2d(batch.get("labels"), target_length, ignore_index)
-    batch["loss_mask"] = _pad_or_truncate_2d(batch.get("loss_mask"), target_length, 0)
+    batch["loss_mask"] = prepared_loss_mask
     batch["position_ids"] = _pad_or_truncate_position_ids(batch.get("position_ids"), target_length)
     batch["attention_mask"] = _pad_or_truncate_attention_mask(batch.get("attention_mask"), target_length)
     for key, tensor_pad_value in (sequence_tensor_pad_values or {}).items():

--- a/tests/unit_tests/data/collators/test_sequence.py
+++ b/tests/unit_tests/data/collators/test_sequence.py
@@ -62,6 +62,36 @@ def test_prepare_sequence_batch_pads_to_model_length_when_required():
     assert batch["attention_mask"].tolist() == [[1, 1, 1, 0, 0, 0]]
 
 
+def test_prepare_sequence_batch_rejects_truncation_that_removes_all_supervision():
+    batch = {
+        "input_ids": torch.arange(8).unsqueeze(0),
+        "labels": torch.arange(8).unsqueeze(0),
+        "loss_mask": torch.tensor([[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0]]),
+        "position_ids": torch.arange(8).unsqueeze(0),
+        "attention_mask": torch.ones((1, 8), dtype=torch.long),
+    }
+
+    with pytest.raises(ValueError, match=r"removed every supervised token from rows \[0\]"):
+        prepare_sequence_batch(batch, sequence_length=6, pad_to_multiple_of=1)
+
+    assert batch["input_ids"].shape == (1, 8)
+
+
+def test_prepare_sequence_batch_allows_truncation_that_preserves_supervision():
+    batch = {
+        "input_ids": torch.arange(8).unsqueeze(0),
+        "labels": torch.arange(8).unsqueeze(0),
+        "loss_mask": torch.tensor([[0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0]]),
+        "position_ids": torch.arange(8).unsqueeze(0),
+        "attention_mask": torch.ones((1, 8), dtype=torch.long),
+    }
+
+    prepare_sequence_batch(batch, sequence_length=6, pad_to_multiple_of=1)
+
+    assert batch["input_ids"].shape == (1, 6)
+    assert batch["loss_mask"].sum().item() == 1.0
+
+
 def test_prepare_sequence_batch_handles_rectangular_4d_attention_mask():
     batch = {
         "input_ids": torch.tensor([[1, 2, 3]]),

--- a/tests/unit_tests/models/qwen_omni/test_qwen3_omni_collate.py
+++ b/tests/unit_tests/models/qwen_omni/test_qwen3_omni_collate.py
@@ -134,7 +134,7 @@ def test_direct_sft_dataset_collates_qwen3_omni_media_and_loss_mask():
 
 def test_qwen3_omni_collator_right_pads_before_truncating_mixed_lengths():
     short_row = [103, 20, 105, 100, 30, 31, 105]
-    long_row = [103, *([20] * 70), 105, 100, 30, 31, 105]
+    long_row = [103, 20, 105, 100, *([30] * 70), 31, 105]
     processor = Qwen3OmniMoeProcessor([short_row, long_row])
     examples = _examples()
     dataset = DirectSFTDataset(


### PR DESCRIPTION
## Summary

- detect sequence rows that had supervised tokens before right truncation and have none afterward
- raise a focused error with the affected row indices and remediation
- leave the batch unmodified when the guard fires
- retain valid truncation when at least one supervised token survives

Fixes NVBug 6540095.

## Root cause

The padded collate path truncated sequence-aligned tensors before `HFTaskEncoder` could observe the original length. Because VLM assistant responses occur at the suffix, right truncation could remove every nonzero `loss_mask` entry and silently admit a zero-gradient row. The downstream width guard remains useful for custom collators, but it cannot diagnose standard collators after truncation.

## Validation

Fail-before reproduction on `origin/main` (`880523c14`):

```text
truncated width: 6
supervised tokens: 0.0
```

Pass-after:

```text
uv run python -m pytest tests/unit_tests/data/collators/test_sequence.py -k 'truncation' -q
# 2 passed, 9 deselected

uv run python -m pytest tests/unit_tests/data/collators/test_sequence.py -q
# 11 passed

uv run python -m pytest tests/unit_tests/data/collators/test_model_collators.py -q
# 72 passed

uv run python -m pytest tests/unit_tests/models/qwen_omni/test_qwen3_omni_collate.py tests/unit_tests/data/collators/test_sequence.py -q
# 15 passed

git diff --check
# passed

uv run pre-commit run --all-files
# all hooks passed
```

CPU-only collation validation; no GPU, distributed, convergence, or performance behavior is changed.
