### PR TITLE
fix(data): preserve VLM pixel defaults

### DIFF
--- a/src/megatron/bridge/data/energon/hf_task_encoder.py
+++ b/src/megatron/bridge/data/energon/hf_task_encoder.py
@@ -156,18 +156,19 @@ class HFTaskEncoder(DefaultTaskEncoder[ChatMLSample, HFEnergonSample, HFEnergonB
             The exact batch dictionary returned by the selected HF collate
             function for this processor type.
         """
-        return self._collate_impl(
-            examples,
-            self.processor,
-            visual_keys=self.visual_keys,
-            min_pixels=self.min_pixels,
-            max_pixels=self.max_pixels,
-            sequence_length=self.seq_length,
-            pad_to_max_length=self.pad_to_max_length,
-            pad_to_multiple_of=self.pad_to_multiple_of,
-            enable_in_batch_packing=self.enable_in_batch_packing,
-            in_batch_packing_pad_to_multiple_of=self.in_batch_packing_pad_to_multiple_of,
-        )
+        collate_kwargs: dict[str, Any] = {
+            "visual_keys": self.visual_keys,
+            "sequence_length": self.seq_length,
+            "pad_to_max_length": self.pad_to_max_length,
+            "pad_to_multiple_of": self.pad_to_multiple_of,
+            "enable_in_batch_packing": self.enable_in_batch_packing,
+            "in_batch_packing_pad_to_multiple_of": self.in_batch_packing_pad_to_multiple_of,
+        }
+        if self.min_pixels is not None:
+            collate_kwargs["min_pixels"] = self.min_pixels
+        if self.max_pixels is not None:
+            collate_kwargs["max_pixels"] = self.max_pixels
+        return self._collate_impl(examples, self.processor, **collate_kwargs)
 
     # ------------------------------------------------------------------
     # batch

--- a/tests/unit_tests/data/energon/test_hf_task_encoder.py
+++ b/tests/unit_tests/data/energon/test_hf_task_encoder.py
@@ -321,6 +321,30 @@ class TestHFTaskEncoderBatch(unittest.TestCase):
         self.assertEqual(seen_kwargs["min_pixels"], 16)
         self.assertEqual(seen_kwargs["max_pixels"], 128)
 
+    def test_collate_fn_preserves_model_pixel_defaults_when_unset(self):
+        seen_kwargs = {}
+
+        def _collate(
+            examples,
+            processor,
+            *,
+            min_pixels=16,
+            max_pixels=128,
+            **kwargs,
+        ):
+            seen_kwargs.update(min_pixels=min_pixels, max_pixels=max_pixels)
+            return _make_collate_fn()(examples, processor, **kwargs)
+
+        encoder = HFTaskEncoder(
+            processor=self.processor,
+            seq_length=128,
+            collate_fn=_collate,
+        )
+
+        encoder.collate_fn([{"conversation": [{"role": "user", "content": "manual"}]}])
+
+        self.assertEqual(seen_kwargs, {"min_pixels": 16, "max_pixels": 128})
+
     def test_collate_fallback_rejects_oversized_batches(self):
         processor = _make_processor()
         encoder = HFTaskEncoder(


### PR DESCRIPTION
## Summary

- omit `min_pixels` and `max_pixels` when the generic HF task encoder was not configured with them
- preserve model-owned collator defaults, including Qwen VLM's visual-resolution policy
- continue forwarding explicitly configured bounds unchanged
- add CPU regression coverage for both behaviors

Fixes NVBug 6540094.

## Root cause

`HFTaskEncoder` defaulted both bounds to `None` but always forwarded them. Passing `None` explicitly overrides a model collator's Python defaults, so Qwen skipped its `200704`/`1003520` bounds and fell back to different processor resolution behavior.

## Validation

Fail-before reproduction on `origin/main` (`880523c14`):

```text
{'min_pixels': None, 'max_pixels': None}
```

Pass-after:

```text
uv run python -m pytest tests/unit_tests/data/energon/test_hf_task_encoder.py -k 'pixel_defaults or threads_supported_encoder_options' -q
# 2 passed, 14 deselected

uv run python -m pytest tests/unit_tests/data/energon/test_hf_task_encoder.py -q
# 16 passed

git diff --check
# passed

uv run pre-commit run --all-files
# all hooks passed
```

CPU-only argument-forwarding behavior; no GPU, distributed, convergence, or performance behavior is changed.
