### PR TITLE
fix(build): preserve launcher executable bits

### DIFF
--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -145,4 +145,5 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 
 COPY --chmod=644 . /opt/Megatron-Bridge
 COPY --chmod=755 scripts/conversion/convert.sh /opt/Megatron-Bridge/scripts/conversion/convert.sh
+COPY --chmod=755 scripts/inference/infer.sh /opt/Megatron-Bridge/scripts/inference/infer.sh
 COPY --chmod=755 scripts/training/train.sh /opt/Megatron-Bridge/scripts/training/train.sh

--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -144,3 +144,5 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     uv cache prune ${UV_CACHE_PRUNE_ARGS}
 
 COPY --chmod=644 . /opt/Megatron-Bridge
+COPY --chmod=755 scripts/conversion/convert.sh /opt/Megatron-Bridge/scripts/conversion/convert.sh
+COPY --chmod=755 scripts/training/train.sh /opt/Megatron-Bridge/scripts/training/train.sh

--- a/tests/unit_tests/docker/test_dockerfile_ci.py
+++ b/tests/unit_tests/docker/test_dockerfile_ci.py
@@ -25,6 +25,11 @@ def test_dockerfile_ci_keeps_public_launchers_executable():
     contents = dockerfile.read_text()
     repository_copy = contents.index("COPY --chmod=644 . /opt/Megatron-Bridge")
 
-    for launcher in ("scripts/conversion/convert.sh", "scripts/training/train.sh"):
+    launchers = (
+        "scripts/conversion/convert.sh",
+        "scripts/inference/infer.sh",
+        "scripts/training/train.sh",
+    )
+    for launcher in launchers:
         executable_copy = f"COPY --chmod=755 {launcher} /opt/Megatron-Bridge/{launcher}"
         assert contents.index(executable_copy) > repository_copy

--- a/tests/unit_tests/docker/test_dockerfile_ci.py
+++ b/tests/unit_tests/docker/test_dockerfile_ci.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from pathlib import Path
 
 import pytest

--- a/tests/unit_tests/docker/test_dockerfile_ci.py
+++ b/tests/unit_tests/docker/test_dockerfile_ci.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+import pytest
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_dockerfile_ci_keeps_public_launchers_executable():
+    dockerfile = Path(__file__).resolve().parents[3] / "docker" / "Dockerfile.ci"
+    contents = dockerfile.read_text()
+    repository_copy = contents.index("COPY --chmod=644 . /opt/Megatron-Bridge")
+
+    for launcher in ("scripts/conversion/convert.sh", "scripts/training/train.sh"):
+        executable_copy = f"COPY --chmod=755 {launcher} /opt/Megatron-Bridge/{launcher}"
+        assert contents.index(executable_copy) > repository_copy


### PR DESCRIPTION
## Summary

- retain the repository-wide mode `644` copy policy in `Dockerfile.ci`
- recopy the documented conversion, inference, and training launchers with mode `755`
- add a unit contract that ensures executable copies occur after the broad repository copy

Fixes NVBug 6539685.

## Root cause

The launchers are mode `100755` in git, but the final `COPY --chmod=644 . /opt/Megatron-Bridge` overrides every source mode. The shipped image therefore contains non-executable scripts even though documented invocations use `./scripts/...`.

## Validation

Fail-before BuildKit reproduction on `origin/main` (`880523c14`):

```text
644 /convert.sh
644 /train.sh
```

Pass-after:

```text
uv run python -m pytest tests/unit_tests/docker/test_dockerfile_ci.py -q
# 1 passed; covers convert.sh, infer.sh, and train.sh

BuildKit mode smoke using the same copy ordering as Dockerfile.ci:
755 scripts/conversion/convert.sh
755 scripts/training/train.sh
# test -x passed for both original NVBug launchers

git diff --check
# passed

uv run pre-commit run --all-files
# all hooks passed
```

No dependency, workflow, or runtime code changes.