### PR TITLE
fix(model): map GLM-5 routed expert count

### DIFF
--- a/src/megatron/bridge/models/glm_moe_dsa/glm5_bridge.py
+++ b/src/megatron/bridge/models/glm_moe_dsa/glm5_bridge.py
@@ -53,6 +53,10 @@ class GLM5Bridge(MegatronModelBridge):
         >>> provider = bridge.to_megatron_provider()
     """
 
+    CONFIG_MAPPING = [mapping for mapping in MegatronModelBridge.CONFIG_MAPPING if mapping[1] != "num_moe_experts"] + [
+        ("n_routed_experts", "num_moe_experts")
+    ]
+
     def provider_bridge(self, hf_pretrained: PreTrainedCausalLM) -> MLAModelProvider:
         provider = super().provider_bridge(hf_pretrained)
         hf_config = hf_pretrained.config

--- a/src/megatron/bridge/models/glm_moe_dsa/glm5_bridge.py
+++ b/src/megatron/bridge/models/glm_moe_dsa/glm5_bridge.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+from typing import Any
 
 from megatron.core.models.gpt.gpt_model import GPTModel
 from transformers import GlmMoeDsaForCausalLM
@@ -53,9 +54,17 @@ class GLM5Bridge(MegatronModelBridge):
         >>> provider = bridge.to_megatron_provider()
     """
 
-    CONFIG_MAPPING = [mapping for mapping in MegatronModelBridge.CONFIG_MAPPING if mapping[1] != "num_moe_experts"] + [
-        ("n_routed_experts", "num_moe_experts")
-    ]
+    def _should_map_hf_config_field(self, hf_config: Any, hf_name: str, megatron_name: str, value: Any) -> bool:
+        """Return whether an HF config field should be mapped to the Megatron provider."""
+        # Transformers 5.11-5.12 has an upstream GLM config bug: ``GlmMoeDsaConfig`` declares an independent
+        # ``num_experts=256`` default alongside the model's authoritative ``n_routed_experts`` field. The generic
+        # config mapping is first-wins, so that injected default can shadow the checkpoint's routed-expert count.
+        # Transformers 5.13 removed the duplicate field and redirects legacy ``num_experts`` input to
+        # ``n_routed_experts``. Detect the affected config shape instead of version-gating so this compatibility
+        # workaround applies only while both fields exist and does not become the default GLM mapping behavior.
+        if hf_name == "num_experts" and hasattr(hf_config, "num_experts") and hasattr(hf_config, "n_routed_experts"):
+            return False
+        return super()._should_map_hf_config_field(hf_config, hf_name, megatron_name, value)
 
     def provider_bridge(self, hf_pretrained: PreTrainedCausalLM) -> MLAModelProvider:
         provider = super().provider_bridge(hf_pretrained)

--- a/tests/unit_tests/models/glm_moe_dsa/test_glm5_bridge.py
+++ b/tests/unit_tests/models/glm_moe_dsa/test_glm5_bridge.py
@@ -21,7 +21,6 @@ from transformers import GlmMoeDsaConfig
 
 from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge
 from megatron.bridge.models.conversion.param_mapping import AutoMapping, GatedMLPMapping, QKVMapping
-from megatron.bridge.models.conversion.utils import conform_config_to_reference
 from megatron.bridge.models.glm_moe_dsa.glm5_bridge import GLM5Bridge
 
 
@@ -62,30 +61,40 @@ def _provider_from_hf_config(monkeypatch: pytest.MonkeyPatch, **config_overrides
     return GLM5Bridge().provider_bridge(SimpleNamespace(config=SimpleNamespace(**config)))
 
 
-def test_hf_config_maps_routed_expert_count() -> None:
-    """GLM-5 uses its routed-expert count even when num_experts differs."""
-    hf_config = GlmMoeDsaConfig(n_routed_experts=8, num_experts=256)
+def test_hf_config_ignores_upstream_num_experts_default() -> None:
+    """GLM-5 ignores the num_experts default injected by affected Transformers versions."""
+    hf_config = GlmMoeDsaConfig(n_routed_experts=8)
 
     provider_kwargs = GLM5Bridge().hf_config_to_provider_kwargs(hf_config)
 
     assert hf_config.num_experts == 256
-    assert [mapping for mapping in GLM5Bridge.CONFIG_MAPPING if mapping[1] == "num_moe_experts"] == [
-        ("n_routed_experts", "num_moe_experts")
-    ]
     assert provider_kwargs["num_moe_experts"] == hf_config.n_routed_experts == 8
 
 
-def test_megatron_config_export_preserves_reference_num_experts() -> None:
-    """GLM-5 export updates routed experts without changing the unrelated reference field."""
-    reference_config = GlmMoeDsaConfig(n_routed_experts=256, num_experts=256).to_dict()
+@pytest.mark.parametrize(
+    ("hf_config", "should_map"),
+    [
+        (SimpleNamespace(num_experts=256, n_routed_experts=8), False),
+        (SimpleNamespace(num_experts=8), True),
+        (SimpleNamespace(n_routed_experts=8), True),
+    ],
+)
+def test_num_experts_workaround_is_config_shape_specific(hf_config: SimpleNamespace, should_map: bool) -> None:
+    """The workaround applies only to the conflicting upstream config shape."""
+    bridge = GLM5Bridge()
+
+    result = bridge._should_map_hf_config_field(hf_config, "num_experts", "num_moe_experts", 256)
+
+    assert result is should_map
+
+
+def test_megatron_config_export_keeps_generic_moe_aliases() -> None:
+    """GLM-5 keeps the generic reverse mappings rather than establishing a special default."""
     mapped_config = GLM5Bridge.megatron_to_hf_config(SimpleNamespace(num_moe_experts=8))
 
-    exported_config = conform_config_to_reference(mapped_config, reference_config)
-
+    assert mapped_config["num_experts"] == 8
+    assert mapped_config["num_local_experts"] == 8
     assert mapped_config["n_routed_experts"] == 8
-    assert "num_experts" not in mapped_config
-    assert exported_config["n_routed_experts"] == 8
-    assert exported_config["num_experts"] == 256
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/models/glm_moe_dsa/test_glm5_bridge.py
+++ b/tests/unit_tests/models/glm_moe_dsa/test_glm5_bridge.py
@@ -17,9 +17,11 @@
 from types import SimpleNamespace
 
 import pytest
+from transformers import GlmMoeDsaConfig
 
 from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge
 from megatron.bridge.models.conversion.param_mapping import AutoMapping, GatedMLPMapping, QKVMapping
+from megatron.bridge.models.conversion.utils import conform_config_to_reference
 from megatron.bridge.models.glm_moe_dsa.glm5_bridge import GLM5Bridge
 
 
@@ -58,6 +60,32 @@ def _provider_from_hf_config(monkeypatch: pytest.MonkeyPatch, **config_overrides
         lambda _self, _hf_pretrained: SimpleNamespace(),
     )
     return GLM5Bridge().provider_bridge(SimpleNamespace(config=SimpleNamespace(**config)))
+
+
+def test_hf_config_maps_routed_expert_count() -> None:
+    """GLM-5 uses its routed-expert count even when num_experts differs."""
+    hf_config = GlmMoeDsaConfig(n_routed_experts=8, num_experts=256)
+
+    provider_kwargs = GLM5Bridge().hf_config_to_provider_kwargs(hf_config)
+
+    assert hf_config.num_experts == 256
+    assert [mapping for mapping in GLM5Bridge.CONFIG_MAPPING if mapping[1] == "num_moe_experts"] == [
+        ("n_routed_experts", "num_moe_experts")
+    ]
+    assert provider_kwargs["num_moe_experts"] == hf_config.n_routed_experts == 8
+
+
+def test_megatron_config_export_preserves_reference_num_experts() -> None:
+    """GLM-5 export updates routed experts without changing the unrelated reference field."""
+    reference_config = GlmMoeDsaConfig(n_routed_experts=256, num_experts=256).to_dict()
+    mapped_config = GLM5Bridge.megatron_to_hf_config(SimpleNamespace(num_moe_experts=8))
+
+    exported_config = conform_config_to_reference(mapped_config, reference_config)
+
+    assert mapped_config["n_routed_experts"] == 8
+    assert "num_experts" not in mapped_config
+    assert exported_config["n_routed_experts"] == 8
+    assert exported_config["num_experts"] == 256
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# What does this PR do ?

Fix the GLM-5 expert-count conversion when affected Hugging Face configurations expose both the authoritative `n_routed_experts` value and an unrelated default `num_experts=256`.

# Changelog

- Skip the generic `num_experts` alias only when the same GLM configuration also exposes `n_routed_experts`, allowing the routed-expert value to populate Megatron's `num_moe_experts`.
- Keep the shared generic mappings unchanged for fixed and legacy configuration shapes and for reverse export.
- Document that this is a compatibility workaround for an upstream Transformers 5.11-5.12 GLM configuration bug; Transformers 5.13 removes the duplicate field and redirects legacy input.
- Add regression coverage using the real affected configuration behavior without manually supplying the conflicting default, plus tests for affected and unaffected config shapes.

# GitHub Actions CI

- `uv run python -m pytest tests/unit_tests/models/glm_moe_dsa/test_glm5_bridge.py` — 14 passed.
- `uv run pre-commit run --all-files` — passed.
- Reproduced on the selected 26.08 release candidate before the fix: routed experts 8 produced provider experts 256.
- Verified with the identical causal reproducer after the fix: routed experts 8 produces provider experts 8.
- Verified with Transformers 5.13.0 that `num_experts` is absent and the unchanged generic mapping produces provider kwargs with 8 experts.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] Added focused regression tests.
- [x] Evaluated documentation impact; no documentation change is needed for this compatibility correction.
- [x] Evaluated optional-component impact; this change adds no dependency or optional import.

# Additional Information

- NVBug 6540522
