### PR TITLE
fix(training): restore weak scaling for benchmark recipes

### DIFF
--- a/scripts/common/benchmark_parallelism.py
+++ b/scripts/common/benchmark_parallelism.py
@@ -1,0 +1,143 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Lightweight parallel-topology helpers shared by benchmark launchers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ParallelTopology:
+    """Model and expert parallel degrees that constrain a benchmark world."""
+
+    tensor_parallel: int = 1
+    pipeline_parallel: int = 1
+    context_parallel: int = 1
+    expert_parallel: int = 1
+    expert_tensor_parallel: int | None = None
+    gtp_remat: int = 1
+    expert_gtp_remat: int = 1
+
+
+def _first_attribute(config: Any, names: tuple[str, ...], default: Any) -> Any:
+    """Return the first exposed configuration attribute from ``names``."""
+    for name in names:
+        if hasattr(config, name):
+            return getattr(config, name)
+    return default
+
+
+def topology_from_config(config: Any) -> ParallelTopology:
+    """Read parallel degrees from a model config or lightweight workload config."""
+    return ParallelTopology(
+        tensor_parallel=getattr(config, "tensor_model_parallel_size", 1),
+        pipeline_parallel=getattr(config, "pipeline_model_parallel_size", 1),
+        context_parallel=getattr(config, "context_parallel_size", 1),
+        expert_parallel=getattr(config, "expert_model_parallel_size", 1),
+        expert_tensor_parallel=getattr(config, "expert_tensor_parallel_size", None),
+        gtp_remat=_first_attribute(config, ("gtp_weight_remat_size", "gtp_remat_size"), 1),
+        expert_gtp_remat=_first_attribute(
+            config,
+            ("expert_gtp_weight_remat_size", "expert_gtp_remat_size"),
+            1,
+        ),
+    )
+
+
+def _validate_positive_sizes(sizes: dict[str, int]) -> None:
+    """Require positive integer parallel degrees."""
+    invalid_sizes = {name: size for name, size in sizes.items() if not isinstance(size, int) or size <= 0}
+    if invalid_sizes:
+        raise ValueError(f"Parallel sizes must be positive integers, got {invalid_sizes}.")
+
+
+def data_parallel_size(*, num_gpus: int, topology: ParallelTopology) -> int:
+    """Validate dense and expert grids, then return the dense DP degree."""
+    if not isinstance(num_gpus, int) or num_gpus <= 0:
+        raise ValueError(f"Number of GPUs must be a positive integer, got {num_gpus!r}.")
+
+    expert_tensor_parallel = (
+        topology.tensor_parallel if topology.expert_tensor_parallel is None else topology.expert_tensor_parallel
+    )
+    sizes = {
+        "TP": topology.tensor_parallel,
+        "PP": topology.pipeline_parallel,
+        "CP": topology.context_parallel,
+        "EP": topology.expert_parallel,
+        "ETP": expert_tensor_parallel,
+        "GTP remat": topology.gtp_remat,
+        "expert GTP remat": topology.expert_gtp_remat,
+    }
+    _validate_positive_sizes(sizes)
+
+    dense_factor = (
+        topology.tensor_parallel * topology.pipeline_parallel * topology.context_parallel * topology.gtp_remat
+    )
+    if num_gpus % dense_factor != 0:
+        if topology.gtp_remat == 1:
+            factor_name = "TP * PP * CP"
+            factor_values = f"{topology.tensor_parallel} * {topology.pipeline_parallel} * {topology.context_parallel}"
+        else:
+            factor_name = "TP * PP * CP * GTP remat"
+            factor_values = (
+                f"{topology.tensor_parallel} * {topology.pipeline_parallel} * {topology.context_parallel} "
+                f"* {topology.gtp_remat}"
+            )
+        raise ValueError(
+            f"Requested {num_gpus} GPUs is not divisible by {factor_name} "
+            f"({factor_values} = {dense_factor}). Override the parallel sizes for this GPU count."
+        )
+
+    expert_factor = (
+        expert_tensor_parallel * topology.expert_parallel * topology.pipeline_parallel * topology.expert_gtp_remat
+    )
+    if num_gpus % expert_factor != 0:
+        if topology.expert_gtp_remat == 1:
+            factor_name = "ETP * EP * PP"
+            factor_values = f"{expert_tensor_parallel} * {topology.expert_parallel} * {topology.pipeline_parallel}"
+        else:
+            factor_name = "ETP * EP * PP * expert GTP remat"
+            factor_values = (
+                f"{expert_tensor_parallel} * {topology.expert_parallel} * {topology.pipeline_parallel} "
+                f"* {topology.expert_gtp_remat}"
+            )
+        raise ValueError(
+            f"The expert-parallel grid is incompatible with requested {num_gpus} GPUs: the world size must be "
+            f"divisible by {factor_name} ({factor_values} = {expert_factor}). "
+            "Override the expert or pipeline parallel sizes for this GPU count."
+        )
+
+    return num_gpus // dense_factor
+
+
+def weak_scaled_global_batch_size(*, base_gbs: int, base_data_parallel: int, data_parallel: int) -> int:
+    """Preserve samples per DP rank while requiring an integral GBS."""
+    sizes = {
+        "canonical DP": base_data_parallel,
+        "requested DP": data_parallel,
+        "canonical GBS": base_gbs,
+    }
+    invalid_sizes = {name: size for name, size in sizes.items() if not isinstance(size, int) or size <= 0}
+    if invalid_sizes:
+        raise ValueError(f"Weak-scaling inputs must be positive integers, got {invalid_sizes}.")
+
+    scaled_gbs_numerator = base_gbs * data_parallel
+    if scaled_gbs_numerator % base_data_parallel != 0:
+        raise ValueError(
+            f"Weak scaling GBS {base_gbs} from DP {base_data_parallel} to DP {data_parallel} does not produce "
+            "an integer global batch size. Pass --global_batch_size explicitly."
+        )
+    return scaled_gbs_numerator // base_data_parallel

--- a/scripts/performance/run_script.py
+++ b/scripts/performance/run_script.py
@@ -20,7 +20,7 @@ import re
 import sys
 
 from argument_parser import parse_cli_args
-from utils.utils import get_perf_recipe_by_name
+from utils.utils import PerfRecipeNotFoundError, get_perf_optimized_recipe, get_perf_recipe_by_name
 
 
 logger = logging.getLogger(__name__)
@@ -96,14 +96,38 @@ def _apply_perf_recipe_overrides(recipe, cli_overrides: list[str], args):
 
 def _prepare_perf_recipe(args, cli_overrides: list[str]):
     """Build a flat performance recipe with all user overrides applied."""
-    recipe = get_perf_recipe_by_name(
-        model_recipe_name=args.model_recipe_name,
-        task=args.task,
-        num_gpus=args.num_gpus,
-        gpu=args.gpu,
-        precision=args.compute_dtype,
-        config_variant=getattr(args, "config_variant", None),
-    )
+    try:
+        recipe = get_perf_recipe_by_name(
+            model_recipe_name=args.model_recipe_name,
+            task=args.task,
+            num_gpus=args.num_gpus,
+            gpu=args.gpu,
+            precision=args.compute_dtype,
+            config_variant=getattr(args, "config_variant", None),
+        )
+    except PerfRecipeNotFoundError:
+        recipe = get_perf_optimized_recipe(
+            model_family_name=args.model_family_name,
+            model_recipe_name=args.model_recipe_name,
+            train_task=args.task,
+            gpu=args.gpu,
+            compute_dtype=args.compute_dtype,
+            config_variant=getattr(args, "config_variant", None),
+        )
+        recipe = _apply_perf_recipe_overrides(recipe, cli_overrides, args)
+        from utils.overrides import set_post_overrides
+
+        return set_post_overrides(
+            recipe,
+            model_family_name=args.model_family_name,
+            model_recipe_name=args.model_recipe_name,
+            gpu=args.gpu,
+            num_gpus=args.num_gpus,
+            compute_dtype=args.compute_dtype,
+            task=args.task,
+            user_gbs=args.global_batch_size,
+            config_variant=getattr(args, "config_variant", None),
+        )
     return _apply_perf_recipe_overrides(recipe, cli_overrides, args)
 
 

--- a/scripts/performance/utils/overrides.py
+++ b/scripts/performance/utils/overrides.py
@@ -44,7 +44,12 @@ from utils.datasets import (
     create_rp2_dataset_config,
     create_squad_dataset_config,
 )
-from utils.utils import WorkloadBaseConfig, get_workload_base_config
+from utils.utils import (
+    WorkloadBaseConfig,
+    _data_parallel_size,
+    _weak_scaled_global_batch_size,
+    get_workload_base_config,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -665,7 +670,12 @@ def set_post_overrides(
     cp = recipe.model.context_parallel_size
     vp = recipe.model.virtual_pipeline_model_parallel_size or 1
 
-    dp = int(num_gpus / (tp * pp * cp))
+    dp = _data_parallel_size(
+        num_gpus=num_gpus,
+        tensor_parallel=tp,
+        pipeline_parallel=pp,
+        context_parallel=cp,
+    )
     logger.info(f"DP: {dp}; TP: {tp}; PP: {pp}; CP: {cp}; VP: {vp}")
     # NOTE: overlap_param_gather_with_optimizer_step causes NaN grad norm for fp8_mx. Disabling it until the issue is resolved.
     if dp > 1 and pp > 1 and vp > 1 and compute_dtype not in ("fp8_mx", "nvfp4"):
@@ -681,7 +691,11 @@ def set_post_overrides(
         # workload default — i.e., no one (Hydra or earlier step) has already
         # expressed an intent. Otherwise Hydra-set GBS gets silently stomped.
         if recipe.train.global_batch_size == workload_base_config.global_batch_size and num_gpus != default_num_gpus:
-            new_gbs = int(workload_base_config.gbs_scaling_factor * num_gpus)
+            new_gbs = _weak_scaled_global_batch_size(
+                base_gbs=workload_base_config.global_batch_size,
+                base_num_gpus=default_num_gpus,
+                num_gpus=num_gpus,
+            )
             recipe.train.global_batch_size = new_gbs
             logger.info(
                 f"Scaled global batch size from {workload_base_config.global_batch_size} to {new_gbs} based on {num_gpus} GPUs."

--- a/scripts/performance/utils/overrides.py
+++ b/scripts/performance/utils/overrides.py
@@ -46,9 +46,10 @@ from utils.datasets import (
 )
 from utils.utils import (
     WorkloadBaseConfig,
-    _data_parallel_size,
+    _validated_data_parallel_size,
     _weak_scaled_global_batch_size,
     get_workload_base_config,
+    topology_from_config,
 )
 
 
@@ -670,11 +671,13 @@ def set_post_overrides(
     cp = recipe.model.context_parallel_size
     vp = recipe.model.virtual_pipeline_model_parallel_size or 1
 
-    dp = _data_parallel_size(
+    base_dp = _validated_data_parallel_size(
+        num_gpus=workload_base_config.num_gpus,
+        topology=topology_from_config(workload_base_config),
+    )
+    dp = _validated_data_parallel_size(
         num_gpus=num_gpus,
-        tensor_parallel=tp,
-        pipeline_parallel=pp,
-        context_parallel=cp,
+        topology=topology_from_config(recipe.model),
     )
     logger.info(f"DP: {dp}; TP: {tp}; PP: {pp}; CP: {cp}; VP: {vp}")
     # NOTE: overlap_param_gather_with_optimizer_step causes NaN grad norm for fp8_mx. Disabling it until the issue is resolved.
@@ -685,20 +688,20 @@ def set_post_overrides(
             if hasattr(recipe, "comm_overlap") and isinstance(recipe.comm_overlap, CommOverlapConfig):
                 recipe.comm_overlap.overlap_param_gather_with_optimizer_step = True
 
-    default_num_gpus = workload_base_config.num_gpus
     if user_gbs is None:
         # Only auto-rescale if the recipe's current GBS still equals the
         # workload default — i.e., no one (Hydra or earlier step) has already
         # expressed an intent. Otherwise Hydra-set GBS gets silently stomped.
-        if recipe.train.global_batch_size == workload_base_config.global_batch_size and num_gpus != default_num_gpus:
+        if recipe.train.global_batch_size == workload_base_config.global_batch_size and dp != base_dp:
             new_gbs = _weak_scaled_global_batch_size(
                 base_gbs=workload_base_config.global_batch_size,
-                base_num_gpus=default_num_gpus,
-                num_gpus=num_gpus,
+                base_data_parallel=base_dp,
+                data_parallel=dp,
             )
             recipe.train.global_batch_size = new_gbs
             logger.info(
-                f"Scaled global batch size from {workload_base_config.global_batch_size} to {new_gbs} based on {num_gpus} GPUs."
+                f"Scaled global batch size from {workload_base_config.global_batch_size} to {new_gbs} "
+                f"based on DP {base_dp} -> {dp}."
             )
 
     return recipe

--- a/scripts/performance/utils/utils.py
+++ b/scripts/performance/utils/utils.py
@@ -72,6 +72,47 @@ _DEFAULT_GPU_COUNT_OVERRIDES = {
 }
 
 
+class PerfRecipeNotFoundError(ValueError):
+    """Raised when an exact flat performance recipe name is unavailable."""
+
+
+def _data_parallel_size(*, num_gpus: int, tensor_parallel: int, pipeline_parallel: int, context_parallel: int) -> int:
+    """Return DP after validating the requested world and model parallel sizes."""
+    parallel_sizes = {"TP": tensor_parallel, "PP": pipeline_parallel, "CP": context_parallel}
+    invalid_sizes = {name: size for name, size in parallel_sizes.items() if not isinstance(size, int) or size <= 0}
+    if invalid_sizes:
+        raise ValueError(f"Parallel sizes must be positive integers, got {invalid_sizes}.")
+    if not isinstance(num_gpus, int) or num_gpus <= 0:
+        raise ValueError(f"Number of GPUs must be a positive integer, got {num_gpus!r}.")
+
+    model_parallel_size = tensor_parallel * pipeline_parallel * context_parallel
+    if num_gpus % model_parallel_size != 0:
+        raise ValueError(
+            f"Requested {num_gpus} GPUs is not divisible by TP * PP * CP "
+            f"({tensor_parallel} * {pipeline_parallel} * {context_parallel} = {model_parallel_size}). "
+            "Override the parallel sizes for this GPU count."
+        )
+    return num_gpus // model_parallel_size
+
+
+def _weak_scaled_global_batch_size(*, base_gbs: int, base_num_gpus: int, num_gpus: int) -> int:
+    """Scale GBS proportionally, requiring the result to remain integral."""
+    if not isinstance(base_num_gpus, int) or base_num_gpus <= 0:
+        raise ValueError(f"Canonical recipe GPU count must be a positive integer, got {base_num_gpus!r}.")
+    if not isinstance(base_gbs, int) or base_gbs <= 0:
+        raise ValueError(f"Canonical recipe global batch size must be a positive integer, got {base_gbs!r}.")
+    if not isinstance(num_gpus, int) or num_gpus <= 0:
+        raise ValueError(f"Number of GPUs must be a positive integer, got {num_gpus!r}.")
+
+    scaled_gbs_numerator = base_gbs * num_gpus
+    if scaled_gbs_numerator % base_num_gpus != 0:
+        raise ValueError(
+            f"Weak scaling GBS {base_gbs} from {base_num_gpus} to {num_gpus} GPUs does not produce "
+            "an integer global batch size. Pass --global_batch_size explicitly."
+        )
+    return scaled_gbs_numerator // base_num_gpus
+
+
 def configure_slurm_gpu_tuning(
     executor: Any,
     *,
@@ -499,7 +540,7 @@ def get_perf_recipe_by_name(
     recipe_fn = find_perf_recipe(name)
     if recipe_fn is None:
         searched_modules = ", ".join(perf_recipe_family_modules()) or "none"
-        raise ValueError(f"No perf recipe {name!r} found in perf recipe packages: {searched_modules}.")
+        raise PerfRecipeNotFoundError(f"No perf recipe {name!r} found in perf recipe packages: {searched_modules}.")
     return recipe_fn()
 
 

--- a/scripts/performance/utils/utils.py
+++ b/scripts/performance/utils/utils.py
@@ -31,6 +31,21 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+_COMMON_SCRIPTS_ROOT = Path(__file__).resolve().parents[2] / "common"
+if str(_COMMON_SCRIPTS_ROOT) not in sys.path:
+    sys.path.insert(0, str(_COMMON_SCRIPTS_ROOT))
+
+from benchmark_parallelism import (  # noqa: E402
+    data_parallel_size as _validated_data_parallel_size,
+)
+from benchmark_parallelism import (
+    topology_from_config,
+)
+from benchmark_parallelism import (
+    weak_scaled_global_batch_size as _weak_scaled_global_batch_size,
+)
+
+
 # Default timeout for interactive config variant selection (in seconds)
 CONFIG_VARIANT_SELECTION_TIMEOUT = 15
 _REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -76,41 +91,24 @@ class PerfRecipeNotFoundError(ValueError):
     """Raised when an exact flat performance recipe name is unavailable."""
 
 
-def _data_parallel_size(*, num_gpus: int, tensor_parallel: int, pipeline_parallel: int, context_parallel: int) -> int:
-    """Return DP after validating the requested world and model parallel sizes."""
-    parallel_sizes = {"TP": tensor_parallel, "PP": pipeline_parallel, "CP": context_parallel}
-    invalid_sizes = {name: size for name, size in parallel_sizes.items() if not isinstance(size, int) or size <= 0}
-    if invalid_sizes:
-        raise ValueError(f"Parallel sizes must be positive integers, got {invalid_sizes}.")
-    if not isinstance(num_gpus, int) or num_gpus <= 0:
-        raise ValueError(f"Number of GPUs must be a positive integer, got {num_gpus!r}.")
-
-    model_parallel_size = tensor_parallel * pipeline_parallel * context_parallel
-    if num_gpus % model_parallel_size != 0:
-        raise ValueError(
-            f"Requested {num_gpus} GPUs is not divisible by TP * PP * CP "
-            f"({tensor_parallel} * {pipeline_parallel} * {context_parallel} = {model_parallel_size}). "
-            "Override the parallel sizes for this GPU count."
-        )
-    return num_gpus // model_parallel_size
-
-
-def _weak_scaled_global_batch_size(*, base_gbs: int, base_num_gpus: int, num_gpus: int) -> int:
-    """Scale GBS proportionally, requiring the result to remain integral."""
-    if not isinstance(base_num_gpus, int) or base_num_gpus <= 0:
-        raise ValueError(f"Canonical recipe GPU count must be a positive integer, got {base_num_gpus!r}.")
-    if not isinstance(base_gbs, int) or base_gbs <= 0:
-        raise ValueError(f"Canonical recipe global batch size must be a positive integer, got {base_gbs!r}.")
-    if not isinstance(num_gpus, int) or num_gpus <= 0:
-        raise ValueError(f"Number of GPUs must be a positive integer, got {num_gpus!r}.")
-
-    scaled_gbs_numerator = base_gbs * num_gpus
-    if scaled_gbs_numerator % base_num_gpus != 0:
-        raise ValueError(
-            f"Weak scaling GBS {base_gbs} from {base_num_gpus} to {num_gpus} GPUs does not produce "
-            "an integer global batch size. Pass --global_batch_size explicitly."
-        )
-    return scaled_gbs_numerator // base_num_gpus
+def _data_parallel_size(
+    *,
+    num_gpus: int,
+    tensor_parallel: int,
+    pipeline_parallel: int,
+    context_parallel: int,
+    expert_parallel: int = 1,
+    expert_tensor_parallel: int | None = None,
+) -> int:
+    """Return DP after validating the requested dense and expert grids."""
+    topology = WorkloadBaseConfig(
+        tensor_model_parallel_size=tensor_parallel,
+        pipeline_model_parallel_size=pipeline_parallel,
+        context_parallel_size=context_parallel,
+        expert_model_parallel_size=expert_parallel,
+        expert_tensor_parallel_size=expert_tensor_parallel,
+    )
+    return _validated_data_parallel_size(num_gpus=num_gpus, topology=topology_from_config(topology))
 
 
 def configure_slurm_gpu_tuning(
@@ -211,6 +209,8 @@ class WorkloadBaseConfig:
     virtual_pipeline_model_parallel_size: int | None = None
     expert_model_parallel_size: int = 1
     expert_tensor_parallel_size: int | None = None
+    gtp_weight_remat_size: int = 1
+    expert_gtp_weight_remat_size: int = 1
 
     global_batch_size: int = 1
     micro_batch_size: int = 1
@@ -644,6 +644,12 @@ def _workload_base_config_from_recipe(config, *, num_gpus: int) -> WorkloadBaseC
         virtual_pipeline_model_parallel_size=model.virtual_pipeline_model_parallel_size,
         expert_model_parallel_size=getattr(model, "expert_model_parallel_size", 1),
         expert_tensor_parallel_size=getattr(model, "expert_tensor_parallel_size", None),
+        gtp_weight_remat_size=getattr(model, "gtp_weight_remat_size", getattr(model, "gtp_remat_size", 1)),
+        expert_gtp_weight_remat_size=getattr(
+            model,
+            "expert_gtp_weight_remat_size",
+            getattr(model, "expert_gtp_remat_size", 1),
+        ),
         global_batch_size=train.global_batch_size,
         micro_batch_size=train.micro_batch_size,
         env_vars=dict(getattr(config, "env_vars", {})),
@@ -742,10 +748,32 @@ def get_exp_name_config(
     )
     mbs_size = args.micro_batch_size if args.micro_batch_size is not None else base_config.micro_batch_size
 
+    requested_topology = WorkloadBaseConfig(
+        tensor_model_parallel_size=tp_size,
+        pipeline_model_parallel_size=pp_size,
+        context_parallel_size=cp_size,
+        expert_model_parallel_size=ep_size,
+        expert_tensor_parallel_size=etp_size,
+        gtp_weight_remat_size=base_config.gtp_weight_remat_size,
+        expert_gtp_weight_remat_size=base_config.expert_gtp_weight_remat_size,
+    )
+    base_dp = _validated_data_parallel_size(
+        num_gpus=base_config.num_gpus,
+        topology=topology_from_config(base_config),
+    )
+    requested_dp = _validated_data_parallel_size(
+        num_gpus=num_gpus,
+        topology=topology_from_config(requested_topology),
+    )
+
     if args.global_batch_size is not None:
         gbs_size = args.global_batch_size
-    elif num_gpus != base_config.num_gpus:
-        gbs_size = int(base_config.gbs_scaling_factor * num_gpus)
+    elif requested_dp != base_dp:
+        gbs_size = _weak_scaled_global_batch_size(
+            base_gbs=base_config.global_batch_size,
+            base_data_parallel=base_dp,
+            data_parallel=requested_dp,
+        )
     else:
         gbs_size = base_config.global_batch_size
 

--- a/scripts/training/README.md
+++ b/scripts/training/README.md
@@ -52,9 +52,9 @@ requested adapter scheme.
 ### Benchmark recipe
 
 The training launcher can run exact exported recipes from `src/megatron/bridge/perf_recipes`, including text
-pretraining, text SFT/PEFT, Qwen-VL pretraining, and Wan pretraining. The total allocation must match the GPU count
-encoded by the recipe name; the user selects the node shape, and the Slurm partition must provide the requested
-hardware:
+pretraining, text SFT/PEFT, Qwen-VL pretraining, and Wan pretraining. The GPU count encoded by the recipe name is its
+canonical tuned allocation. The user selects the node shape and may weak-scale to a different compatible world size;
+the Slurm partition must provide the requested hardware:
 
 `benchmark` is the unified runner's user-facing term. The existing `perf_recipes` package and `scripts/performance/`
 compatibility paths retain their legacy names.
@@ -74,6 +74,11 @@ precision, dispatcher, CUDA-graph settings, and process environment. Trailing `K
 configuration. Benchmark recipes retain their selected dataset type, so `--dataset` is not supported on this path.
 Recipe environment defaults are installed before the launcher enters the training stack; values explicitly set by the
 shell or Slurm environment retain precedence.
+
+When the requested world size differs from the canonical count, the runner preserves the recipe's samples per GPU by
+scaling `train.global_batch_size` proportionally. The scaled batch size must be an integer, and the requested world size
+must be divisible by the resolved TP × PP × CP topology. Pass `--global_batch_size` or a trailing
+`train.global_batch_size=...` override to choose an explicit batch size instead of automatic weak scaling.
 
 The launcher does not infer offline mode, cluster-specific CPU/NUMA binding, Slurm segment sizing, or NCCL fabric
 settings from the recipe name. Supply those deployment settings explicitly through the target cluster's launcher
@@ -279,9 +284,10 @@ uv run python scripts/training/run_recipe.py \
     --dry-run logger.save_config_filepath=/tmp/config.yaml
 ```
 
-For a benchmark dry run, use the complete flat recipe name and omit `--dataset`. The rank-local dry run discovers the
-recipe and validates the final config against the total GPU count encoded in that name without
-requiring a live allocation; the submission dry run additionally validates `--nodes` and `--gpus-per-node`.
+For a benchmark dry run, use the complete flat recipe name and omit `--dataset`. Without a distributed world-size
+environment, the rank-local dry run validates the canonical allocation encoded in the recipe name. If `WORLD_SIZE` or
+`SLURM_NTASKS` is set, it validates and weak-scales against that requested size instead. The submission dry run validates
+the launcher arguments while leaving topology validation to the rank-local resolved config.
 
 ## Rank-local entry point
 

--- a/scripts/training/run_recipe.py
+++ b/scripts/training/run_recipe.py
@@ -83,7 +83,16 @@ logger = logging.getLogger(__name__)
 SCRIPT_DIR = Path(__file__).resolve().parent
 if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
+COMMON_SCRIPT_DIR = SCRIPT_DIR.parent / "common"
+if str(COMMON_SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(COMMON_SCRIPT_DIR))
 
+from benchmark_parallelism import (  # noqa: E402
+    ParallelTopology,
+    data_parallel_size,
+    topology_from_config,
+    weak_scaled_global_batch_size,
+)
 from recipe_metadata import (  # noqa: E402
     BenchmarkRecipeMetadata,
     infer_recipe_mode,
@@ -335,48 +344,31 @@ def _apply_benchmark_weak_scaling(
     metadata: BenchmarkRecipeMetadata,
     cli_overrides: list[str],
     *,
+    canonical_topology: ParallelTopology,
+    canonical_global_batch_size: int,
     world_size: int,
 ) -> ConfigContainer:
-    """Validate topology and proportionally scale benchmark GBS."""
+    """Validate topology and preserve samples per DP rank."""
     model = getattr(recipe, "model", None)
-    parallel_sizes = {
-        "TP": getattr(model, "tensor_model_parallel_size", 1),
-        "PP": getattr(model, "pipeline_model_parallel_size", 1),
-        "CP": getattr(model, "context_parallel_size", 1),
-    }
-    invalid_sizes = {name: size for name, size in parallel_sizes.items() if not isinstance(size, int) or size <= 0}
-    if invalid_sizes:
-        raise ValueError(f"Parallel sizes must be positive integers, got {invalid_sizes}.")
+    canonical_dp = data_parallel_size(num_gpus=metadata.num_gpus, topology=canonical_topology)
+    requested_dp = data_parallel_size(num_gpus=world_size, topology=topology_from_config(model))
 
-    model_parallel_size = parallel_sizes["TP"] * parallel_sizes["PP"] * parallel_sizes["CP"]
-    if world_size % model_parallel_size != 0:
-        raise ValueError(
-            f"Requested {world_size} GPUs is not divisible by TP * PP * CP "
-            f"({parallel_sizes['TP']} * {parallel_sizes['PP']} * {parallel_sizes['CP']} = {model_parallel_size}). "
-            "Override the parallel sizes for this GPU count."
-        )
-
-    if world_size == metadata.num_gpus or _config_override_is_explicit(cli_overrides, "train.global_batch_size"):
+    if _config_override_is_explicit(cli_overrides, "train.global_batch_size") or requested_dp == canonical_dp:
         return recipe
 
     train = getattr(recipe, "train", None)
-    base_gbs = getattr(train, "global_batch_size", None)
-    if not isinstance(base_gbs, int) or base_gbs <= 0:
-        raise ValueError(f"Canonical recipe global batch size must be a positive integer, got {base_gbs!r}.")
-
-    scaled_gbs_numerator = base_gbs * world_size
-    if scaled_gbs_numerator % metadata.num_gpus != 0:
-        raise ValueError(
-            f"Weak scaling GBS {base_gbs} from {metadata.num_gpus} to {world_size} GPUs does not produce "
-            "an integer global batch size. Pass --global_batch_size explicitly."
-        )
-    scaled_gbs = scaled_gbs_numerator // metadata.num_gpus
+    scaled_gbs = weak_scaled_global_batch_size(
+        base_gbs=canonical_global_batch_size,
+        base_data_parallel=canonical_dp,
+        data_parallel=requested_dp,
+    )
     train.global_batch_size = scaled_gbs
     logger.info(
-        "Weak scaled benchmark global batch size from %d to %d for %d GPUs.",
-        base_gbs,
+        "Weak scaled benchmark global batch size from %d to %d for DP %d -> %d.",
+        canonical_global_batch_size,
         scaled_gbs,
-        world_size,
+        canonical_dp,
+        requested_dp,
     )
     return recipe
 
@@ -478,6 +470,11 @@ def main(argv: list[str] | None = None) -> None:
         recipe = _apply_benchmark_dataset_defaults(recipe, benchmark_metadata)
     recipe = _apply_dataset(recipe, args)
     recipe = apply_determinism(recipe, deterministic=args.deterministic)
+    benchmark_canonical_topology = None
+    benchmark_canonical_global_batch_size = None
+    if benchmark_metadata is not None:
+        benchmark_canonical_topology = topology_from_config(getattr(recipe, "model", None))
+        benchmark_canonical_global_batch_size = getattr(getattr(recipe, "train", None), "global_batch_size", 1)
     recipe = apply_cli_overrides(recipe, cli_overrides)
     recipe = sync_model_pipeline_layout(recipe, cli_overrides=cli_overrides)
     benchmark_world_size = None
@@ -488,6 +485,8 @@ def main(argv: list[str] | None = None) -> None:
             recipe,
             benchmark_metadata,
             cli_overrides,
+            canonical_topology=benchmark_canonical_topology,
+            canonical_global_batch_size=benchmark_canonical_global_batch_size,
             world_size=benchmark_world_size,
         )
     configuration_mode = _train_mode(args.mode)

--- a/scripts/training/run_recipe.py
+++ b/scripts/training/run_recipe.py
@@ -77,6 +77,9 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
 
+logger = logging.getLogger(__name__)
+
+
 SCRIPT_DIR = Path(__file__).resolve().parent
 if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
@@ -304,21 +307,78 @@ def _current_world_size() -> int | None:
     return None
 
 
-def _validate_benchmark_world_size(metadata: BenchmarkRecipeMetadata, *, dryrun: bool) -> None:
-    """Require the recipe's total GPU count for an executable run."""
-    if dryrun:
-        return
+def _benchmark_world_size(metadata: BenchmarkRecipeMetadata, *, dryrun: bool) -> int:
+    """Resolve the requested benchmark world size from the active launcher."""
     world_size = _current_world_size()
     if world_size is None:
+        if dryrun:
+            return metadata.num_gpus
         raise ValueError(
             "Benchmark recipes require an existing distributed environment with the world size set by torchrun "
             "or Slurm."
         )
-    if world_size != metadata.num_gpus:
+    return world_size
+
+
+def _config_override_is_explicit(cli_overrides: list[str], field_name: str) -> bool:
+    """Return whether CLI overrides explicitly own a config field or its parent."""
+    parent_name = field_name.split(".", maxsplit=1)[0]
+    for override in cli_overrides:
+        override_name = override.lstrip("+~").split("=", maxsplit=1)[0]
+        if override_name in {field_name, parent_name}:
+            return True
+    return False
+
+
+def _apply_benchmark_weak_scaling(
+    recipe: ConfigContainer,
+    metadata: BenchmarkRecipeMetadata,
+    cli_overrides: list[str],
+    *,
+    world_size: int,
+) -> ConfigContainer:
+    """Validate topology and proportionally scale benchmark GBS."""
+    model = getattr(recipe, "model", None)
+    parallel_sizes = {
+        "TP": getattr(model, "tensor_model_parallel_size", 1),
+        "PP": getattr(model, "pipeline_model_parallel_size", 1),
+        "CP": getattr(model, "context_parallel_size", 1),
+    }
+    invalid_sizes = {name: size for name, size in parallel_sizes.items() if not isinstance(size, int) or size <= 0}
+    if invalid_sizes:
+        raise ValueError(f"Parallel sizes must be positive integers, got {invalid_sizes}.")
+
+    model_parallel_size = parallel_sizes["TP"] * parallel_sizes["PP"] * parallel_sizes["CP"]
+    if world_size % model_parallel_size != 0:
         raise ValueError(
-            f"Benchmark recipe requires exactly {metadata.num_gpus} GPUs, but the distributed world size is "
-            f"{world_size}. Select a recipe matching the allocation."
+            f"Requested {world_size} GPUs is not divisible by TP * PP * CP "
+            f"({parallel_sizes['TP']} * {parallel_sizes['PP']} * {parallel_sizes['CP']} = {model_parallel_size}). "
+            "Override the parallel sizes for this GPU count."
         )
+
+    if world_size == metadata.num_gpus or _config_override_is_explicit(cli_overrides, "train.global_batch_size"):
+        return recipe
+
+    train = getattr(recipe, "train", None)
+    base_gbs = getattr(train, "global_batch_size", None)
+    if not isinstance(base_gbs, int) or base_gbs <= 0:
+        raise ValueError(f"Canonical recipe global batch size must be a positive integer, got {base_gbs!r}.")
+
+    scaled_gbs_numerator = base_gbs * world_size
+    if scaled_gbs_numerator % metadata.num_gpus != 0:
+        raise ValueError(
+            f"Weak scaling GBS {base_gbs} from {metadata.num_gpus} to {world_size} GPUs does not produce "
+            "an integer global batch size. Pass --global_batch_size explicitly."
+        )
+    scaled_gbs = scaled_gbs_numerator // metadata.num_gpus
+    train.global_batch_size = scaled_gbs
+    logger.info(
+        "Weak scaled benchmark global batch size from %d to %d for %d GPUs.",
+        base_gbs,
+        scaled_gbs,
+        world_size,
+    )
+    return recipe
 
 
 def _apply_benchmark_runtime_defaults(
@@ -420,12 +480,19 @@ def main(argv: list[str] | None = None) -> None:
     recipe = apply_determinism(recipe, deterministic=args.deterministic)
     recipe = apply_cli_overrides(recipe, cli_overrides)
     recipe = sync_model_pipeline_layout(recipe, cli_overrides=cli_overrides)
+    benchmark_world_size = None
     if benchmark_metadata is not None:
         recipe = _apply_benchmark_runtime_defaults(recipe, benchmark_metadata, cli_overrides)
+        benchmark_world_size = _benchmark_world_size(benchmark_metadata, dryrun=args.dryrun)
+        recipe = _apply_benchmark_weak_scaling(
+            recipe,
+            benchmark_metadata,
+            cli_overrides,
+            world_size=benchmark_world_size,
+        )
     configuration_mode = _train_mode(args.mode)
 
     if benchmark_metadata is not None:
-        _validate_benchmark_world_size(benchmark_metadata, dryrun=args.dryrun)
         recipe = bootstrap_recipe_environment(
             recipe,
             script_path=str(Path(__file__).resolve()),
@@ -449,7 +516,7 @@ def main(argv: list[str] | None = None) -> None:
         mode=execution_mode,
         step_func=forward_step,
         dryrun=args.dryrun,
-        dryrun_world_size=benchmark_metadata.num_gpus if benchmark_metadata is not None else None,
+        dryrun_world_size=benchmark_world_size,
         dump_environment=args.dump_env,
     )
 

--- a/scripts/training/setup_experiment.py
+++ b/scripts/training/setup_experiment.py
@@ -199,9 +199,11 @@ def _validate_args(
     if benchmark_metadata is not None:
         requested_gpus = args.nodes * args.gpus_per_node
         if requested_gpus != benchmark_metadata.num_gpus:
-            raise ValueError(
-                f"Benchmark recipe requires exactly {benchmark_metadata.num_gpus} GPUs, but --nodes and "
-                f"--gpus-per-node request {requested_gpus}."
+            logger.info(
+                "Weak scaling benchmark recipe '%s' from %d to %d GPUs.",
+                benchmark_metadata.recipe_name,
+                benchmark_metadata.num_gpus,
+                requested_gpus,
             )
 
 

--- a/tests/unit_tests/recipes/test_override_precedence.py
+++ b/tests/unit_tests/recipes/test_override_precedence.py
@@ -235,6 +235,39 @@ class TestRecomputePrecedence:
 
 
 class TestGbsPrecedence:
+    @staticmethod
+    def _nemotronh_64gpu_base_recipe():
+        return SimpleNamespace(
+            optimizer=SimpleNamespace(optimizer="adam"),
+            model=SimpleNamespace(
+                tensor_model_parallel_size=2,
+                pipeline_model_parallel_size=1,
+                context_parallel_size=1,
+                virtual_pipeline_model_parallel_size=None,
+            ),
+            train=SimpleNamespace(global_batch_size=192),
+            comm_overlap=None,
+        )
+
+    def test_nemotronh_b300_64gpu_recipe_weak_scales_to_8_gpus(self, monkeypatch):
+        """Nemotron-H preserves samples per GPU when its canonical recipe is reused."""
+        from utils import overrides as override_utils
+
+        base_config = SimpleNamespace(num_gpus=64, global_batch_size=192, gbs_scaling_factor=3)
+        monkeypatch.setattr(override_utils, "get_workload_base_config", lambda *_args, **_kwargs: base_config)
+
+        recipe = override_utils.set_post_overrides(
+            self._nemotronh_64gpu_base_recipe(),
+            model_family_name="nemotronh",
+            model_recipe_name="nemotronh_56b",
+            gpu="b300",
+            num_gpus=8,
+            compute_dtype="fp8_cs",
+            task="pretrain",
+        )
+
+        assert recipe.train.global_batch_size == 24
+
     def test_F_autoscale_fires_when_no_one_sets(self):
         """When neither Hydra nor argparse sets GBS and num_gpus differs from
         the workload default, set_post_overrides should rescale. This is the

--- a/tests/unit_tests/recipes/test_override_precedence.py
+++ b/tests/unit_tests/recipes/test_override_precedence.py
@@ -253,7 +253,18 @@ class TestGbsPrecedence:
         """Nemotron-H preserves samples per GPU when its canonical recipe is reused."""
         from utils import overrides as override_utils
 
-        base_config = SimpleNamespace(num_gpus=64, global_batch_size=192, gbs_scaling_factor=3)
+        base_config = SimpleNamespace(
+            num_gpus=64,
+            tensor_model_parallel_size=2,
+            pipeline_model_parallel_size=1,
+            context_parallel_size=1,
+            expert_model_parallel_size=1,
+            expert_tensor_parallel_size=None,
+            gtp_weight_remat_size=1,
+            expert_gtp_weight_remat_size=1,
+            global_batch_size=192,
+            gbs_scaling_factor=3,
+        )
         monkeypatch.setattr(override_utils, "get_workload_base_config", lambda *_args, **_kwargs: base_config)
 
         recipe = override_utils.set_post_overrides(
@@ -268,6 +279,77 @@ class TestGbsPrecedence:
 
         assert recipe.train.global_batch_size == 24
 
+    def test_weak_scaling_uses_effective_data_parallel_ratio(self, monkeypatch):
+        """Parallelism overrides preserve samples per data-parallel rank."""
+        from utils import overrides as override_utils
+
+        base_config = SimpleNamespace(
+            num_gpus=64,
+            tensor_model_parallel_size=2,
+            pipeline_model_parallel_size=1,
+            context_parallel_size=1,
+            expert_model_parallel_size=1,
+            expert_tensor_parallel_size=None,
+            global_batch_size=192,
+        )
+        monkeypatch.setattr(override_utils, "get_workload_base_config", lambda *_args, **_kwargs: base_config)
+        recipe = self._nemotronh_64gpu_base_recipe()
+        recipe.model.tensor_model_parallel_size = 1
+
+        recipe = override_utils.set_post_overrides(
+            recipe,
+            model_family_name="nemotronh",
+            model_recipe_name="nemotronh_56b",
+            gpu="b300",
+            num_gpus=8,
+            compute_dtype="fp8_cs",
+            task="pretrain",
+        )
+
+        # Canonical DP is 32 and requested DP is 8, so 192 * 8 / 32 = 48.
+        assert recipe.train.global_batch_size == 48
+
+    def test_perf_fallback_rejects_world_size_incompatible_with_expert_grid(self, monkeypatch):
+        """The flat fallback rejects GPT-OSS layouts before MCore initialization."""
+        from utils import overrides as override_utils
+
+        base_config = SimpleNamespace(
+            num_gpus=64,
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=4,
+            context_parallel_size=1,
+            expert_model_parallel_size=8,
+            expert_tensor_parallel_size=1,
+            gtp_weight_remat_size=1,
+            expert_gtp_weight_remat_size=1,
+            global_batch_size=1280,
+        )
+        monkeypatch.setattr(override_utils, "get_workload_base_config", lambda *_args, **_kwargs: base_config)
+        recipe = SimpleNamespace(
+            optimizer=SimpleNamespace(optimizer="adam"),
+            model=SimpleNamespace(
+                tensor_model_parallel_size=1,
+                pipeline_model_parallel_size=4,
+                context_parallel_size=1,
+                virtual_pipeline_model_parallel_size=None,
+                expert_model_parallel_size=8,
+                expert_tensor_parallel_size=1,
+            ),
+            train=SimpleNamespace(global_batch_size=1280),
+            comm_overlap=None,
+        )
+
+        with pytest.raises(ValueError, match=r"expert.*8 GPUs.*ETP \* EP \* PP.*1 \* 8 \* 4 = 32"):
+            override_utils.set_post_overrides(
+                recipe,
+                model_family_name="gpt_oss",
+                model_recipe_name="gpt_oss_120b",
+                gpu="h100",
+                num_gpus=8,
+                compute_dtype="bf16",
+                task="pretrain",
+            )
+
     def test_F_autoscale_fires_when_no_one_sets(self):
         """When neither Hydra nor argparse sets GBS and num_gpus differs from
         the workload default, set_post_overrides should rescale. This is the
@@ -275,7 +357,7 @@ class TestGbsPrecedence:
         recipe = _fresh_recipe()
         # Canonical flat workload default for GB200 is GBS=4096 at 256 GPUs. At 64 GPUs,
         # gbs_scaling_factor * 64 should be applied.
-        recipe = _apply(recipe, num_gpus=64)
+        recipe = _apply(recipe, args_overrides={"expert_model_parallel_size": 16}, num_gpus=64)
         assert recipe.train.global_batch_size != 4096, "GBS auto-scale did not fire for num_gpus=64 (default=256)"
 
     def test_G_hydra_overrides_autoscale(self):
@@ -285,6 +367,7 @@ class TestGbsPrecedence:
         recipe = _apply(
             recipe,
             cli_overrides=["train.global_batch_size=128"],
+            args_overrides={"expert_model_parallel_size": 16},
             num_gpus=64,
         )
         assert recipe.train.global_batch_size == 128
@@ -294,7 +377,7 @@ class TestGbsPrecedence:
         recipe = _fresh_recipe()
         recipe = _apply(
             recipe,
-            args_overrides={"global_batch_size": 256},
+            args_overrides={"global_batch_size": 256, "expert_model_parallel_size": 16},
             num_gpus=64,
         )
         assert recipe.train.global_batch_size == 256

--- a/tests/unit_tests/scripts/performance/test_recipe_environment.py
+++ b/tests/unit_tests/scripts/performance/test_recipe_environment.py
@@ -267,6 +267,151 @@ def test_flat_environment_preparation_defaults_missing_recipe_environment(model_
     assert "Performance might be degraded" in caplog.text
 
 
+def test_missing_exact_gpu_recipe_uses_canonical_family_recipe(monkeypatch):
+    """Weak scaling falls back to the canonical recipe for the same workload."""
+    canonical_name = "nemotronh_56b_pretrain_64gpu_b300_fp8cs_config"
+    args = SimpleNamespace(
+        model_family_name="nemotronh",
+        model_recipe_name="nemotronh_56b",
+        task="pretrain",
+        num_gpus=8,
+        gpu="b300",
+        compute_dtype="fp8_cs",
+        config_variant=None,
+        global_batch_size=None,
+    )
+    canonical_recipe = SimpleNamespace(train=SimpleNamespace(global_batch_size=192))
+
+    def missing_exact(**_kwargs):
+        raise utils.PerfRecipeNotFoundError("missing exact 8-GPU recipe")
+
+    monkeypatch.setattr(run_script, "get_perf_recipe_by_name", missing_exact)
+    monkeypatch.setattr(utils, "flat_perf_recipe_names", lambda: (canonical_name,))
+    monkeypatch.setattr(
+        utils,
+        "find_perf_recipe",
+        lambda name: (lambda: canonical_recipe) if name == canonical_name else None,
+    )
+    monkeypatch.setattr(run_script, "_apply_perf_recipe_overrides", lambda recipe, _overrides, _args: recipe)
+
+    def apply_weak_scaling(recipe, **kwargs):
+        assert kwargs["num_gpus"] == 8
+        recipe.train.global_batch_size = 24
+        return recipe
+
+    override_utils = types.ModuleType("utils.overrides")
+    override_utils.set_post_overrides = apply_weak_scaling
+    monkeypatch.setitem(sys.modules, "utils.overrides", override_utils)
+
+    result = run_script._prepare_perf_recipe(args, [])
+
+    assert result is canonical_recipe
+    assert result.train.global_batch_size == 24
+
+
+def test_exact_gpu_recipe_takes_precedence_over_canonical_fallback(monkeypatch):
+    """A tuned exact-count recipe must not be replaced by weak scaling."""
+    exact_recipe = object()
+    args = SimpleNamespace(
+        model_family_name="test",
+        model_recipe_name="test_model",
+        task="pretrain",
+        num_gpus=8,
+        gpu="b300",
+        compute_dtype="bf16",
+        config_variant=None,
+        global_batch_size=None,
+    )
+    monkeypatch.setattr(run_script, "get_perf_recipe_by_name", lambda **_kwargs: exact_recipe)
+    monkeypatch.setattr(
+        run_script,
+        "get_perf_optimized_recipe",
+        lambda **_kwargs: pytest.fail("canonical fallback must not run for an exact recipe"),
+    )
+    monkeypatch.setattr(run_script, "_apply_perf_recipe_overrides", lambda recipe, _overrides, _args: recipe)
+
+    result = run_script._prepare_perf_recipe(args, [])
+
+    assert result is exact_recipe
+
+
+def test_exact_recipe_construction_error_is_not_treated_as_missing(monkeypatch):
+    args = SimpleNamespace(
+        model_family_name="test",
+        model_recipe_name="test_model",
+        task="pretrain",
+        num_gpus=8,
+        gpu="b300",
+        compute_dtype="bf16",
+        config_variant=None,
+        global_batch_size=None,
+    )
+
+    def construction_error(**_kwargs):
+        raise RuntimeError("recipe builder failed")
+
+    monkeypatch.setattr(run_script, "get_perf_recipe_by_name", construction_error)
+    monkeypatch.setattr(
+        run_script,
+        "get_perf_optimized_recipe",
+        lambda **_kwargs: pytest.fail("construction failures must not invoke canonical fallback"),
+    )
+
+    with pytest.raises(RuntimeError, match="recipe builder failed"):
+        run_script._prepare_perf_recipe(args, [])
+
+
+def test_missing_perf_recipe_family_reports_requested_workload(monkeypatch):
+    args = SimpleNamespace(
+        model_family_name="nemotronh",
+        model_recipe_name="nemotronh_56b",
+        task="pretrain",
+        num_gpus=8,
+        gpu="b300",
+        compute_dtype="fp8_cs",
+        config_variant=None,
+        global_batch_size=None,
+    )
+
+    def missing_exact(**_kwargs):
+        raise utils.PerfRecipeNotFoundError("missing exact 8-GPU recipe")
+
+    def missing_family(**_kwargs):
+        raise ValueError("No flat perf recipe found for nemotronh_56b/pretrain/b300/fp8_cs/default")
+
+    monkeypatch.setattr(run_script, "get_perf_recipe_by_name", missing_exact)
+    monkeypatch.setattr(run_script, "get_perf_optimized_recipe", missing_family)
+
+    with pytest.raises(
+        ValueError,
+        match=r"nemotronh_56b/pretrain/b300/fp8_cs/default",
+    ):
+        run_script._prepare_perf_recipe(args, [])
+
+
+def test_weak_scaling_validates_world_size_and_integer_gbs():
+    assert (
+        utils._data_parallel_size(
+            num_gpus=8,
+            tensor_parallel=2,
+            pipeline_parallel=1,
+            context_parallel=1,
+        )
+        == 4
+    )
+    assert utils._weak_scaled_global_batch_size(base_gbs=192, base_num_gpus=64, num_gpus=8) == 24
+
+    with pytest.raises(ValueError, match=r"7 GPUs.*TP \* PP \* CP.*2 \* 1 \* 1"):
+        utils._data_parallel_size(
+            num_gpus=7,
+            tensor_parallel=2,
+            pipeline_parallel=1,
+            context_parallel=1,
+        )
+    with pytest.raises(ValueError, match=r"does not produce an integer global batch size"):
+        utils._weak_scaled_global_batch_size(base_gbs=190, base_num_gpus=64, num_gpus=8)
+
+
 def test_flat_environment_preparation_applies_cli_overrides(monkeypatch):
     """Hydra env overrides must be reflected in the bootstrap recipe."""
     args = SimpleNamespace(

--- a/tests/unit_tests/scripts/performance/test_recipe_environment.py
+++ b/tests/unit_tests/scripts/performance/test_recipe_environment.py
@@ -399,7 +399,7 @@ def test_weak_scaling_validates_world_size_and_integer_gbs():
         )
         == 4
     )
-    assert utils._weak_scaled_global_batch_size(base_gbs=192, base_num_gpus=64, num_gpus=8) == 24
+    assert utils._weak_scaled_global_batch_size(base_gbs=192, base_data_parallel=32, data_parallel=4) == 24
 
     with pytest.raises(ValueError, match=r"7 GPUs.*TP \* PP \* CP.*2 \* 1 \* 1"):
         utils._data_parallel_size(
@@ -409,7 +409,41 @@ def test_weak_scaling_validates_world_size_and_integer_gbs():
             context_parallel=1,
         )
     with pytest.raises(ValueError, match=r"does not produce an integer global batch size"):
-        utils._weak_scaled_global_batch_size(base_gbs=190, base_num_gpus=64, num_gpus=8)
+        utils._weak_scaled_global_batch_size(base_gbs=190, base_data_parallel=32, data_parallel=4)
+
+
+def test_exp_name_rejects_fractional_data_parallel_weak_scaling(monkeypatch):
+    base_config = utils.WorkloadBaseConfig(
+        num_gpus=64,
+        tensor_model_parallel_size=2,
+        pipeline_model_parallel_size=1,
+        context_parallel_size=1,
+        expert_model_parallel_size=1,
+        expert_tensor_parallel_size=None,
+        global_batch_size=190,
+    )
+    monkeypatch.setattr(utils, "get_workload_base_config", lambda *_args, **_kwargs: base_config)
+    args = SimpleNamespace(
+        num_gpus=8,
+        tensor_model_parallel_size=1,
+        pipeline_model_parallel_size=None,
+        context_parallel_size=None,
+        virtual_pipeline_model_parallel_size=-1,
+        expert_model_parallel_size=None,
+        expert_tensor_parallel_size=None,
+        micro_batch_size=None,
+        global_batch_size=None,
+    )
+
+    with pytest.raises(ValueError, match="does not produce an integer global batch size"):
+        utils.get_exp_name_config(
+            args,
+            model_family_name="nemotronh",
+            model_recipe_name="nemotronh_56b",
+            gpu="b300",
+            compute_dtype="fp8_cs",
+            task="pretrain",
+        )
 
 
 def test_flat_environment_preparation_applies_cli_overrides(monkeypatch):

--- a/tests/unit_tests/scripts/training/test_run_recipe.py
+++ b/tests/unit_tests/scripts/training/test_run_recipe.py
@@ -529,6 +529,70 @@ def test_benchmark_recipe_weak_scales_noncanonical_world_size(monkeypatch):
     handles.recipe_runner.bootstrap_recipe_environment.assert_called_once()
 
 
+def test_benchmark_recipe_weak_scales_by_data_parallel_ratio_after_topology_override(monkeypatch):
+    module, handles = _load_module()
+    monkeypatch.setenv("WORLD_SIZE", "8")
+    config = SimpleNamespace(
+        optimizer=SimpleNamespace(optimizer="adam", use_precision_aware_optimizer=False),
+        model=SimpleNamespace(
+            tensor_model_parallel_size=2,
+            pipeline_model_parallel_size=1,
+            context_parallel_size=1,
+            expert_model_parallel_size=1,
+            expert_tensor_parallel_size=None,
+        ),
+        train=SimpleNamespace(global_batch_size=192),
+    )
+    handles.recipe_runner.load_recipe.return_value = config
+
+    def apply_overrides(recipe, overrides):
+        assert "model.tensor_model_parallel_size=1" in overrides
+        recipe.model.tensor_model_parallel_size = 1
+        return recipe
+
+    handles.recipe_runner.apply_cli_overrides.side_effect = apply_overrides
+
+    module.main(
+        [
+            "--recipe",
+            "nemotronh_56b_pretrain_64gpu_b300_fp8cs_config",
+            "--mode",
+            "pretrain",
+            "--tensor_model_parallel_size",
+            "1",
+        ]
+    )
+
+    # Canonical DP is 64 / TP2 = 32; requested DP is 8 / TP1 = 8.
+    assert config.train.global_batch_size == 48
+
+
+def test_benchmark_recipe_rejects_world_size_incompatible_with_expert_grid(monkeypatch):
+    module, handles = _load_module()
+    monkeypatch.setenv("WORLD_SIZE", "8")
+    handles.recipe_runner.load_recipe.return_value = SimpleNamespace(
+        optimizer=SimpleNamespace(optimizer="adam", use_precision_aware_optimizer=False),
+        model=SimpleNamespace(
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=4,
+            context_parallel_size=1,
+            expert_model_parallel_size=8,
+            expert_tensor_parallel_size=1,
+        ),
+        train=SimpleNamespace(global_batch_size=1280),
+    )
+
+    with pytest.raises(ValueError, match=r"expert.*8 GPUs.*ETP \* EP \* PP.*1 \* 8 \* 4 = 32"):
+        module.main(
+            [
+                "--recipe",
+                "gpt_oss_120b_pretrain_64gpu_h100_bf16_config",
+                "--mode",
+                "pretrain",
+            ]
+        )
+
+
 def test_benchmark_recipe_explicit_global_batch_size_disables_weak_scaling(monkeypatch):
     module, handles = _load_module()
     monkeypatch.setenv("WORLD_SIZE", "8")

--- a/tests/unit_tests/scripts/training/test_run_recipe.py
+++ b/tests/unit_tests/scripts/training/test_run_recipe.py
@@ -501,25 +501,115 @@ def test_benchmark_dry_run_accepts_config_overrides(monkeypatch):
     )
 
 
-def test_benchmark_recipe_rejects_noncanonical_world_size(monkeypatch):
+def test_benchmark_recipe_weak_scales_noncanonical_world_size(monkeypatch):
     module, handles = _load_module()
     monkeypatch.setenv("WORLD_SIZE", "8")
     monkeypatch.setenv("LOCAL_WORLD_SIZE", "8")
-    handles.recipe_runner.load_recipe.return_value = SimpleNamespace(
-        optimizer=SimpleNamespace(optimizer="adam", use_precision_aware_optimizer=False)
+    config = SimpleNamespace(
+        optimizer=SimpleNamespace(optimizer="adam", use_precision_aware_optimizer=False),
+        model=SimpleNamespace(
+            tensor_model_parallel_size=2,
+            pipeline_model_parallel_size=1,
+            context_parallel_size=1,
+        ),
+        train=SimpleNamespace(global_batch_size=192),
+    )
+    handles.recipe_runner.load_recipe.return_value = config
+
+    module.main(
+        [
+            "--recipe",
+            "nemotronh_56b_pretrain_64gpu_b300_fp8cs_config",
+            "--mode",
+            "pretrain",
+        ]
     )
 
-    with pytest.raises(ValueError, match="requires exactly 16 GPUs"):
+    assert config.train.global_batch_size == 24
+    handles.recipe_runner.bootstrap_recipe_environment.assert_called_once()
+
+
+def test_benchmark_recipe_explicit_global_batch_size_disables_weak_scaling(monkeypatch):
+    module, handles = _load_module()
+    monkeypatch.setenv("WORLD_SIZE", "8")
+    config = SimpleNamespace(
+        optimizer=SimpleNamespace(optimizer="adam", use_precision_aware_optimizer=False),
+        model=SimpleNamespace(
+            tensor_model_parallel_size=2,
+            pipeline_model_parallel_size=1,
+            context_parallel_size=1,
+        ),
+        train=SimpleNamespace(global_batch_size=192),
+    )
+    handles.recipe_runner.load_recipe.return_value = config
+
+    def apply_overrides(recipe, overrides):
+        assert "train.global_batch_size=7" in overrides
+        recipe.train.global_batch_size = 7
+        return recipe
+
+    handles.recipe_runner.apply_cli_overrides.side_effect = apply_overrides
+
+    module.main(
+        [
+            "--recipe",
+            "nemotronh_56b_pretrain_64gpu_b300_fp8cs_config",
+            "--mode",
+            "pretrain",
+            "--global_batch_size",
+            "7",
+        ]
+    )
+
+    assert config.train.global_batch_size == 7
+
+
+def test_benchmark_recipe_rejects_world_size_incompatible_with_model_parallelism(monkeypatch):
+    module, handles = _load_module()
+    monkeypatch.setenv("WORLD_SIZE", "7")
+    handles.recipe_runner.load_recipe.return_value = SimpleNamespace(
+        optimizer=SimpleNamespace(optimizer="adam", use_precision_aware_optimizer=False),
+        model=SimpleNamespace(
+            tensor_model_parallel_size=2,
+            pipeline_model_parallel_size=1,
+            context_parallel_size=1,
+        ),
+        train=SimpleNamespace(global_batch_size=192),
+    )
+
+    with pytest.raises(ValueError, match=r"7 GPUs.*TP \* PP \* CP.*2 \* 1 \* 1"):
         module.main(
             [
                 "--recipe",
-                "qwen3_30b_a3b_pretrain_16gpu_h100_bf16_config",
+                "nemotronh_56b_pretrain_64gpu_b300_fp8cs_config",
                 "--mode",
                 "pretrain",
             ]
         )
 
-    handles.recipe_runner.bootstrap_recipe_environment.assert_not_called()
+
+def test_benchmark_recipe_rejects_fractional_weak_scaled_global_batch_size(monkeypatch):
+    module, handles = _load_module()
+    monkeypatch.setenv("WORLD_SIZE", "8")
+    handles.recipe_runner.load_recipe.return_value = SimpleNamespace(
+        optimizer=SimpleNamespace(optimizer="adam", use_precision_aware_optimizer=False),
+        model=SimpleNamespace(
+            tensor_model_parallel_size=2,
+            pipeline_model_parallel_size=1,
+            context_parallel_size=1,
+        ),
+        train=SimpleNamespace(global_batch_size=190),
+    )
+
+    with pytest.raises(ValueError, match="does not produce an integer global batch size"):
+        module.main(
+            [
+                "--recipe",
+                "nemotronh_56b_pretrain_64gpu_b300_fp8cs_config",
+                "--mode",
+                "pretrain",
+            ]
+        )
 
 
 def test_benchmark_recipe_accepts_user_selected_per_node_topology(monkeypatch):

--- a/tests/unit_tests/scripts/training/test_setup_experiment.py
+++ b/tests/unit_tests/scripts/training/test_setup_experiment.py
@@ -116,7 +116,7 @@ def test_library_resolved_recipe_does_not_enable_benchmark_executor():
     assert module.selected_benchmark_recipe(training_args) is None
 
 
-def test_benchmark_recipe_validates_total_submission_size():
+def test_benchmark_recipe_accepts_weak_scaling_submission_size():
     module = _load_setup_experiment_module()
     args, training_args = module.parse_args(
         [
@@ -135,8 +135,7 @@ def test_benchmark_recipe_validates_total_submission_size():
         ]
     )
 
-    with pytest.raises(ValueError, match="requires exactly 16 GPUs"):
-        module._validate_args(args, module.selected_benchmark_recipe(training_args))
+    module._validate_args(args, module.selected_benchmark_recipe(training_args))
 
 
 def test_benchmark_recipe_accepts_user_selected_node_shape():


### PR DESCRIPTION
## Summary

- preserve exact GPU-count flat recipe selection when a tuned recipe exists
- fall back to the canonical flat recipe when the requested GPU count is not registered
- support the same weak scaling through the unified scripts/training launcher
- preserve samples per data-parallel rank by scaling GBS from canonical DP to effective requested DP
- validate both dense TP/PP/CP/GTP and MoE ETP/EP/PP/expert-GTP grids before MCore initialization
- preserve explicit global batch-size overrides and reject fractional automatic scaling
- use the same exact weak-scaling helper for performance experiment names, without integer truncation
- document canonical allocation and dry-run behavior for benchmark recipes

## Red to green

Before this change, requesting the Nemotron-H 8-GPU B300 FP8-CS workload failed because only the canonical 64-GPU recipe exists. The initial fallback also scaled by total world size, which was incorrect when TP/PP/CP overrides changed the effective DP ratio, and incompatible MoE expert grids failed only during MCore initialization.

After this change, both launch paths reuse the canonical recipe while retaining its identity. GBS follows the canonical-to-requested DP ratio, explicit GBS remains final, fractional results fail with an actionable error, and incompatible expert grids such as GPT-OSS 120B with TP=1, PP=4, EP=8 on WORLD_SIZE=8 are rejected early.

The reported Nemotron-H case still resolves the 64-GPU recipe and scales GBS from 192 to 24 at 8 GPUs with its unchanged topology.

## Tests

- red-to-green coverage for DP-ratio scaling, GPT-OSS expert-grid validation, and fractional experiment-name scaling
- targeted launcher, performance utility, and override-precedence tests: 182 passed
- focused review regressions after formatting: 6 passed
- pre-commit: passed

Fixes #4759