### PR TITLE
Rsalagame llama31 pretrain and finetune fixes

### DIFF
--- a/scripts/performance/configs/llama/__init__.py
+++ b/scripts/performance/configs/llama/__init__.py
@@ -49,8 +49,6 @@ if HAVE_MEGATRON_BRIDGE:
         llama3_70b_pretrain_config_vr200,
     )
     from .llama31_llm_pretrain import (
-        llama31_8b_pretrain_config_gb300,
-        llama31_8b_pretrain_config_gb200,
         llama31_405b_pretrain_config_b200,
         llama31_405b_pretrain_config_b300,
         llama31_405b_pretrain_config_gb200,
@@ -166,12 +164,6 @@ from .llama3_workload_base_configs import (
     LLAMA3_70B_SFT_CONFIG_H100_FP8_CS_V1,
 )
 from .llama31_workload_base_configs import (
-    LLAMA31_8B_PRETRAIN_CONFIG_GB300_NVFP4_V1,
-    LLAMA31_8B_PRETRAIN_CONFIG_GB300_NVFP4_V2,
-    LLAMA31_8B_PRETRAIN_CONFIG_GB300_FP8_CS_V1,
-    LLAMA31_8B_PRETRAIN_CONFIG_GB200_NVFP4_V1,
-    LLAMA31_8B_PRETRAIN_CONFIG_GB200_NVFP4_V2,
-    LLAMA31_8B_PRETRAIN_CONFIG_GB200_FP8_CS_V1,
     LLAMA31_405B_PRETRAIN_CONFIG_B200_BF16_V1,
     LLAMA31_405B_PRETRAIN_CONFIG_B200_BF16_V2,
     LLAMA31_405B_PRETRAIN_CONFIG_B200_FP8_CS_V1,
@@ -215,13 +207,6 @@ from .llama31_workload_base_configs import (
 
 
 __all__ = [
-    # MLPerf Llama3.1 8B configs
-    "LLAMA31_8B_PRETRAIN_CONFIG_GB300_NVFP4_V1",
-    "LLAMA31_8B_PRETRAIN_CONFIG_GB300_NVFP4_V2",
-    "LLAMA31_8B_PRETRAIN_CONFIG_GB300_FP8_CS_V1",
-    "LLAMA31_8B_PRETRAIN_CONFIG_GB200_NVFP4_V1",
-    "LLAMA31_8B_PRETRAIN_CONFIG_GB200_NVFP4_V2",
-    "LLAMA31_8B_PRETRAIN_CONFIG_GB200_FP8_CS_V1",
     # V1 (GB300/GB200: num_gpus=128, GBS=64; H100: GBS=512)
     "LLAMA31_405B_PRETRAIN_CONFIG_GB200_BF16_V1",
     "LLAMA31_405B_PRETRAIN_CONFIG_GB200_FP8_CS_V1",
@@ -399,8 +384,6 @@ if HAVE_MEGATRON_BRIDGE:
             "llama3_70b_lora_config_gb300",
             "llama3_70b_lora_config_h100",
             "llama3_70b_sft_config_gb300",
-            "llama31_8b_pretrain_config_gb300",
-            "llama31_8b_pretrain_config_gb200",
             "llama31_405b_pretrain_config_gb300",
             "llama31_405b_pretrain_config_gb200",
             "llama31_405b_pretrain_config_b300",
@@ -417,3 +400,4 @@ if HAVE_LLAMA2_FINETUNE:
             "llama2_70b_lora_config_gb300",
         ]
     )
+

--- a/scripts/performance/configs/llama/__init__.py
+++ b/scripts/performance/configs/llama/__init__.py
@@ -5,11 +5,22 @@ try:
 except ModuleNotFoundError:
     HAVE_MEGATRON_BRIDGE = False
 
+HAVE_LLAMA2_FINETUNE = False
+
 if HAVE_MEGATRON_BRIDGE:
-    from .llama2_llm_finetune import (
-        llama2_70b_lora_config_gb200,
-        llama2_70b_lora_config_gb300,
-    )
+    # llama2_llm_finetune needs llama2_70b_peft_config, which only exists in
+    # megatron.bridge >= the commit that added the MLPerf LoRA script. Older
+    # container images ship a bridge without it, and a hard import here would
+    # take down every llama pretrain config in this package too.
+    try:
+        from .llama2_llm_finetune import (
+            llama2_70b_lora_config_gb200,
+            llama2_70b_lora_config_gb300,
+        )
+
+        HAVE_LLAMA2_FINETUNE = True
+    except ImportError:
+        pass
     from .llama3_llm_finetune import (
         llama3_8b_sft_config_gb200,
         llama3_8b_sft_config_h100,
@@ -365,8 +376,6 @@ __all__ = [
 if HAVE_MEGATRON_BRIDGE:
     __all__.extend(
         [
-            "llama2_70b_lora_config_gb200",
-            "llama2_70b_lora_config_gb300",
             "llama3_8b_pretrain_config_gb300",
             "llama3_8b_pretrain_config_gb200",
             "llama3_8b_pretrain_config_b300",
@@ -398,5 +407,13 @@ if HAVE_MEGATRON_BRIDGE:
             "llama31_405b_pretrain_config_b200",
             "llama31_405b_pretrain_config_h100",
             "llama31_405b_pretrain_config_vr200",
+        ]
+    )
+
+if HAVE_LLAMA2_FINETUNE:
+    __all__.extend(
+        [
+            "llama2_70b_lora_config_gb200",
+            "llama2_70b_lora_config_gb300",
         ]
     )

--- a/scripts/performance/configs/llama/__init__.py
+++ b/scripts/performance/configs/llama/__init__.py
@@ -49,6 +49,8 @@ if HAVE_MEGATRON_BRIDGE:
         llama3_70b_pretrain_config_vr200,
     )
     from .llama31_llm_pretrain import (
+        llama31_8b_pretrain_config_gb300,
+        llama31_8b_pretrain_config_gb200,
         llama31_405b_pretrain_config_b200,
         llama31_405b_pretrain_config_b300,
         llama31_405b_pretrain_config_gb200,
@@ -164,6 +166,12 @@ from .llama3_workload_base_configs import (
     LLAMA3_70B_SFT_CONFIG_H100_FP8_CS_V1,
 )
 from .llama31_workload_base_configs import (
+    LLAMA31_8B_PRETRAIN_CONFIG_GB300_NVFP4_V1,
+    LLAMA31_8B_PRETRAIN_CONFIG_GB300_NVFP4_V2,
+    LLAMA31_8B_PRETRAIN_CONFIG_GB300_FP8_CS_V1,
+    LLAMA31_8B_PRETRAIN_CONFIG_GB200_NVFP4_V1,
+    LLAMA31_8B_PRETRAIN_CONFIG_GB200_NVFP4_V2,
+    LLAMA31_8B_PRETRAIN_CONFIG_GB200_FP8_CS_V1,
     LLAMA31_405B_PRETRAIN_CONFIG_B200_BF16_V1,
     LLAMA31_405B_PRETRAIN_CONFIG_B200_BF16_V2,
     LLAMA31_405B_PRETRAIN_CONFIG_B200_FP8_CS_V1,
@@ -207,6 +215,13 @@ from .llama31_workload_base_configs import (
 
 
 __all__ = [
+    # MLPerf Llama3.1 8B configs
+    "LLAMA31_8B_PRETRAIN_CONFIG_GB300_NVFP4_V1",
+    "LLAMA31_8B_PRETRAIN_CONFIG_GB300_NVFP4_V2",
+    "LLAMA31_8B_PRETRAIN_CONFIG_GB300_FP8_CS_V1",
+    "LLAMA31_8B_PRETRAIN_CONFIG_GB200_NVFP4_V1",
+    "LLAMA31_8B_PRETRAIN_CONFIG_GB200_NVFP4_V2",
+    "LLAMA31_8B_PRETRAIN_CONFIG_GB200_FP8_CS_V1",
     # V1 (GB300/GB200: num_gpus=128, GBS=64; H100: GBS=512)
     "LLAMA31_405B_PRETRAIN_CONFIG_GB200_BF16_V1",
     "LLAMA31_405B_PRETRAIN_CONFIG_GB200_FP8_CS_V1",
@@ -384,6 +399,8 @@ if HAVE_MEGATRON_BRIDGE:
             "llama3_70b_lora_config_gb300",
             "llama3_70b_lora_config_h100",
             "llama3_70b_sft_config_gb300",
+            "llama31_8b_pretrain_config_gb300",
+            "llama31_8b_pretrain_config_gb200",
             "llama31_405b_pretrain_config_gb300",
             "llama31_405b_pretrain_config_gb200",
             "llama31_405b_pretrain_config_b300",
@@ -400,4 +417,3 @@ if HAVE_LLAMA2_FINETUNE:
             "llama2_70b_lora_config_gb300",
         ]
     )
-

--- a/scripts/performance/configs/nemotronh/nemotron_3_workload_base_configs.py
+++ b/scripts/performance/configs/nemotronh/nemotron_3_workload_base_configs.py
@@ -140,9 +140,6 @@ NEMOTRON_3_SUPER_PRETRAIN_CONFIG_B300_NVFP4_V1 = NEMOTRON_3_SUPER_PRETRAIN_CONFI
 
 BASE_NEMOTRON_3_SUPER_CONFIG_B200 = replace(
     BASE_NEMOTRON_3_SUPER_CONFIG,
-    # B200 is an NVL8 topology; EP must stay within one NVLink domain or
-    # HybridEP falls back to its inter-domain RDMA path and crashes.
-    expert_model_parallel_size=8,
     cuda_graph_impl="none",
     recompute_modules=["moe_act", "layernorm"],
 )
@@ -154,15 +151,7 @@ NEMOTRON_3_SUPER_PRETRAIN_CONFIG_B200_BF16_V1 = replace(
     cuda_graph_scope=["mamba", "attn", "moe_router", "moe_preprocess"],
     recompute_modules=["moe_act", "layernorm", "core_attn"],
 )
-NEMOTRON_3_SUPER_PRETRAIN_CONFIG_B200_FP8_MX_V1 = replace(
-    BASE_NEMOTRON_3_SUPER_CONFIG_B200,
-    # At EP=8 each rank holds 64 of the 512 experts, so it needs the same
-    # memory posture as the BF16 variant, which peaks at 156 of 178 GB.
-    tensor_model_parallel_size=2,
-    cuda_graph_impl="transformer_engine",
-    cuda_graph_scope=["mamba", "attn", "moe_router", "moe_preprocess"],
-    recompute_modules=["moe_act", "layernorm", "core_attn"],
-)
+NEMOTRON_3_SUPER_PRETRAIN_CONFIG_B200_FP8_MX_V1 = BASE_NEMOTRON_3_SUPER_CONFIG_B200
 NEMOTRON_3_SUPER_PRETRAIN_CONFIG_B200_NVFP4_V1 = replace(
     BASE_NEMOTRON_3_SUPER_CONFIG_B200,
     tensor_model_parallel_size=2,

--- a/scripts/performance/configs/nemotronh/nemotron_3_workload_base_configs.py
+++ b/scripts/performance/configs/nemotronh/nemotron_3_workload_base_configs.py
@@ -140,6 +140,9 @@ NEMOTRON_3_SUPER_PRETRAIN_CONFIG_B300_NVFP4_V1 = NEMOTRON_3_SUPER_PRETRAIN_CONFI
 
 BASE_NEMOTRON_3_SUPER_CONFIG_B200 = replace(
     BASE_NEMOTRON_3_SUPER_CONFIG,
+    # B200 is an NVL8 topology; EP must stay within one NVLink domain or
+    # HybridEP falls back to its inter-domain RDMA path and crashes.
+    expert_model_parallel_size=8,
     cuda_graph_impl="none",
     recompute_modules=["moe_act", "layernorm"],
 )
@@ -151,7 +154,15 @@ NEMOTRON_3_SUPER_PRETRAIN_CONFIG_B200_BF16_V1 = replace(
     cuda_graph_scope=["mamba", "attn", "moe_router", "moe_preprocess"],
     recompute_modules=["moe_act", "layernorm", "core_attn"],
 )
-NEMOTRON_3_SUPER_PRETRAIN_CONFIG_B200_FP8_MX_V1 = BASE_NEMOTRON_3_SUPER_CONFIG_B200
+NEMOTRON_3_SUPER_PRETRAIN_CONFIG_B200_FP8_MX_V1 = replace(
+    BASE_NEMOTRON_3_SUPER_CONFIG_B200,
+    # At EP=8 each rank holds 64 of the 512 experts, so it needs the same
+    # memory posture as the BF16 variant, which peaks at 156 of 178 GB.
+    tensor_model_parallel_size=2,
+    cuda_graph_impl="transformer_engine",
+    cuda_graph_scope=["mamba", "attn", "moe_router", "moe_preprocess"],
+    recompute_modules=["moe_act", "layernorm", "core_attn"],
+)
 NEMOTRON_3_SUPER_PRETRAIN_CONFIG_B200_NVFP4_V1 = replace(
     BASE_NEMOTRON_3_SUPER_CONFIG_B200,
     tensor_model_parallel_size=2,


### PR DESCRIPTION
**What the issue was:** **configs/llama/__init__.py** unconditionally imported the Llama-2 70B LoRA configs, and that module imports llama2_70b_peft_config from megatron.bridge.recipes.llama. That symbol exists in newer Megatron-Bridge but not in the 26.06.01 container image — possible because scripts/performance is host-mounted while megatron.bridge comes from inside the container. Because the import sat in the package __init__, the resulting ImportError took down the entire configs.llama package, so every Llama job aborted at startup, pretrain and finetune alike, on all GPU types. The launcher only catches **ModuleNotFoundError**, so a missing symbol wasn't converted into a clean error either. 

**Fix:** wrap the Llama-2 import in try/except ImportError and export those two config names only when it succeeds. Verified on GB300 with llama3.1 8B pretrain and llama3 70B LoRA finetune.

**Steps to reproduce:**

1) clone the repo: git clone ssh://git@gitlab-master.nvidia.com:12051/unified-cloud-benchmarking/llm-benchmarking-collection-internal.git; cd llm-benchmarking-collection-internal

2) check out to my branch: 

```
git fetch origin
git checkout -b 'rsalagame_all_workloads_llmb_release_26.08.00_draft' 'origin/rsalagame_all_workloads_llmb_release_26.08.00_draft'
```

3) llmb-install (select llama pretrain and finetune workloads)

4) Run with cmd ex: `llmb-run submit -w pretrain_llama3.1 -s 8b -d fp8 --scale 8` under $LLMB_INSTALL
[log-general_infra-rd_gsw-gsw.pretrain_llama3_8b_fp8_cs_gpus16_tp1_pp1_cp1_vpNone_ep1_etpNone_mbs4_gbs256_329677_0.txt](https://github.com/user-attachments/files/30681598/log-general_infra-rd_gsw-gsw.pretrain_llama3_8b_fp8_cs_gpus16_tp1_pp1_cp1_vpNone_ep1_etpNone_mbs4_gbs256_329677_0.txt)



Log file with the issue (ex on OCI-AGA GB300 cluster where I noticed this but not chip specific): 