### PR TITLE
docs(skills): make MoE tuning guidance evidence-gated

### DIFF
--- a/docs/training/cuda-graphs.md
+++ b/docs/training/cuda-graphs.md
@@ -7,7 +7,7 @@ every training step.
 This page is the stable guide for what CUDA graphs are, when they help, and
 what tradeoffs to expect. For exact enablement knobs, code anchors, and
 verification commands, see
-[skills/nemo-mbridge-perf-cuda-graphs/SKILL.md](../../skills/nemo-mbridge-perf-cuda-graphs/SKILL.md).
+[skills/nemo-mbridge-perf-cuda-graphs/SKILL.md](../skills/nemo-mbridge-perf-cuda-graphs/SKILL.md).
 
 ## What It Is
 
@@ -113,7 +113,7 @@ If you choose `local` with `full_iteration`, disable the loss and gradient NaN
 checks that conflict with full capture.
 
 For exact config snippets and runnable commands, see
-[skills/nemo-mbridge-perf-cuda-graphs/SKILL.md](../../skills/nemo-mbridge-perf-cuda-graphs/SKILL.md).
+[skills/nemo-mbridge-perf-cuda-graphs/SKILL.md](../skills/nemo-mbridge-perf-cuda-graphs/SKILL.md).
 
 ## Minimal Runnable Example
 
@@ -207,4 +207,4 @@ The `OptimizerCudaGraphWrapper` is an experimental utility that enables CUDA gra
 
 - [Performance Guide](../performance-guide.md)
 - [Communication Overlap](communication-overlap.md)
-- [skills/nemo-mbridge-perf-cuda-graphs/SKILL.md](../../skills/nemo-mbridge-perf-cuda-graphs/SKILL.md)
+- [skills/nemo-mbridge-perf-cuda-graphs/SKILL.md](../skills/nemo-mbridge-perf-cuda-graphs/SKILL.md)

--- a/docs/training/cuda-graphs.md
+++ b/docs/training/cuda-graphs.md
@@ -7,7 +7,7 @@ every training step.
 This page is the stable guide for what CUDA graphs are, when they help, and
 what tradeoffs to expect. For exact enablement knobs, code anchors, and
 verification commands, see
-[skills/nemo-mbridge-perf-cuda-graphs/SKILL.md](../skills/nemo-mbridge-perf-cuda-graphs/SKILL.md).
+[skills/nemo-mbridge-perf-cuda-graphs/SKILL.md](../../skills/nemo-mbridge-perf-cuda-graphs/SKILL.md).
 
 ## What It Is
 
@@ -24,7 +24,12 @@ Megatron Bridge supports two capture implementations:
 | `"none"` (default) | Disabled | — |
 
 `"local"` captures the whole forward-backward iteration. `"transformer_engine"`
-captures selected submodules and is usually the more flexible default path.
+captures selected submodules and is the more flexible candidate when a profile
+shows meaningful host/launch overhead.
+
+Scope names follow real module types. `mamba` applies to Mamba layers; it is not
+a generic label for linear attention. Qwen3.5 Gated DeltaNet (GDN) lives under
+`self_attention`, so its applicable TE scope is `attn`, not `mamba`.
 
 ## What Problem It Solves
 
@@ -60,7 +65,8 @@ Enable CUDA graphs when all of the following are mostly true:
 
 As a rule of thumb:
 
-- prefer `transformer_engine` scoped graphs for the safer first rollout
+- after profiling, prefer the narrowest useful `transformer_engine` scoped graph
+  for the first A/B
 - use `local` `full_iteration` graphs only when you specifically want the
   largest launch-overhead reduction and can accept the stricter constraints
 
@@ -107,7 +113,7 @@ If you choose `local` with `full_iteration`, disable the loss and gradient NaN
 checks that conflict with full capture.
 
 For exact config snippets and runnable commands, see
-[skills/nemo-mbridge-perf-cuda-graphs/SKILL.md](../skills/nemo-mbridge-perf-cuda-graphs/SKILL.md).
+[skills/nemo-mbridge-perf-cuda-graphs/SKILL.md](../../skills/nemo-mbridge-perf-cuda-graphs/SKILL.md).
 
 ## Minimal Runnable Example
 
@@ -150,7 +156,8 @@ pretrain run with the all-to-all dispatcher, TE-scoped
 warmup steps (`48` graphable layers, about `6.9 s` capture time on rank 0) but
 replay iterations 5-8 averaged `42.00 s` versus `41.36 s` for eager. Treat this
 as evidence to validate CUDA graphs on the target dispatcher, container, and
-batch shape rather than enabling them blindly.
+batch shape rather than enabling them blindly. Repeat the eager/graph A/B after
+changing dispatcher, overlap, precision, or recompute.
 
 ### Packed-sequence SFT and LoRA
 
@@ -200,4 +207,4 @@ The `OptimizerCudaGraphWrapper` is an experimental utility that enables CUDA gra
 
 - [Performance Guide](../performance-guide.md)
 - [Communication Overlap](communication-overlap.md)
-- [skills/nemo-mbridge-perf-cuda-graphs/SKILL.md](../skills/nemo-mbridge-perf-cuda-graphs/SKILL.md)
+- [skills/nemo-mbridge-perf-cuda-graphs/SKILL.md](../../skills/nemo-mbridge-perf-cuda-graphs/SKILL.md)

--- a/docs/training/moe-optimization.md
+++ b/docs/training/moe-optimization.md
@@ -6,12 +6,12 @@ training Mixture-of-Experts models with Megatron-Core. It is based on
 
 For tuning knobs, hardware-specific configs, and benchmark-oriented guidance, see:
 
-- [skills/nemo-mbridge-perf-moe-optimization-workflow/SKILL.md](../../skills/nemo-mbridge-perf-moe-optimization-workflow/SKILL.md)
-- [skills/nemo-mbridge-perf-moe-long-context/SKILL.md](../../skills/nemo-mbridge-perf-moe-long-context/SKILL.md)
-- [skills/nemo-mbridge-perf-moe-vlm-training/SKILL.md](../../skills/nemo-mbridge-perf-moe-vlm-training/SKILL.md)
-- [skills/nemo-mbridge-perf-moe-dispatcher-selection/SKILL.md](../../skills/nemo-mbridge-perf-moe-dispatcher-selection/SKILL.md)
-- [skills/nemo-mbridge-perf-moe-hardware-configs/SKILL.md](../../skills/nemo-mbridge-perf-moe-hardware-configs/SKILL.md)
-- [skills/nemo-mbridge-perf-moe-comm-overlap/SKILL.md](../../skills/nemo-mbridge-perf-moe-comm-overlap/SKILL.md)
+- [skills/nemo-mbridge-perf-moe-optimization-workflow/SKILL.md](../skills/nemo-mbridge-perf-moe-optimization-workflow/SKILL.md)
+- [skills/nemo-mbridge-perf-moe-long-context/SKILL.md](../skills/nemo-mbridge-perf-moe-long-context/SKILL.md)
+- [skills/nemo-mbridge-perf-moe-vlm-training/SKILL.md](../skills/nemo-mbridge-perf-moe-vlm-training/SKILL.md)
+- [skills/nemo-mbridge-perf-moe-dispatcher-selection/SKILL.md](../skills/nemo-mbridge-perf-moe-dispatcher-selection/SKILL.md)
+- [skills/nemo-mbridge-perf-moe-hardware-configs/SKILL.md](../skills/nemo-mbridge-perf-moe-hardware-configs/SKILL.md)
+- [skills/nemo-mbridge-perf-moe-comm-overlap/SKILL.md](../skills/nemo-mbridge-perf-moe-comm-overlap/SKILL.md)
 
 ## The Three Walls
 

--- a/docs/training/moe-optimization.md
+++ b/docs/training/moe-optimization.md
@@ -6,12 +6,12 @@ training Mixture-of-Experts models with Megatron-Core. It is based on
 
 For tuning knobs, hardware-specific configs, and benchmark-oriented guidance, see:
 
-- [skills/nemo-mbridge-perf-moe-optimization-workflow/SKILL.md](../skills/nemo-mbridge-perf-moe-optimization-workflow/SKILL.md)
-- [skills/nemo-mbridge-perf-moe-long-context/SKILL.md](../skills/nemo-mbridge-perf-moe-long-context/SKILL.md)
-- [skills/nemo-mbridge-perf-moe-vlm-training/SKILL.md](../skills/nemo-mbridge-perf-moe-vlm-training/SKILL.md)
-- [skills/nemo-mbridge-perf-moe-dispatcher-selection/SKILL.md](../skills/nemo-mbridge-perf-moe-dispatcher-selection/SKILL.md)
-- [skills/nemo-mbridge-perf-moe-hardware-configs/SKILL.md](../skills/nemo-mbridge-perf-moe-hardware-configs/SKILL.md)
-- [skills/nemo-mbridge-perf-moe-comm-overlap/SKILL.md](../skills/nemo-mbridge-perf-moe-comm-overlap/SKILL.md)
+- [skills/nemo-mbridge-perf-moe-optimization-workflow/SKILL.md](../../skills/nemo-mbridge-perf-moe-optimization-workflow/SKILL.md)
+- [skills/nemo-mbridge-perf-moe-long-context/SKILL.md](../../skills/nemo-mbridge-perf-moe-long-context/SKILL.md)
+- [skills/nemo-mbridge-perf-moe-vlm-training/SKILL.md](../../skills/nemo-mbridge-perf-moe-vlm-training/SKILL.md)
+- [skills/nemo-mbridge-perf-moe-dispatcher-selection/SKILL.md](../../skills/nemo-mbridge-perf-moe-dispatcher-selection/SKILL.md)
+- [skills/nemo-mbridge-perf-moe-hardware-configs/SKILL.md](../../skills/nemo-mbridge-perf-moe-hardware-configs/SKILL.md)
+- [skills/nemo-mbridge-perf-moe-comm-overlap/SKILL.md](../../skills/nemo-mbridge-perf-moe-comm-overlap/SKILL.md)
 
 ## The Three Walls
 
@@ -30,6 +30,20 @@ latency, but it may add scheduling and buffer constraints. Effective
 optimization treats all three as a unified system.
 
 ## The Optimization Workflow
+
+Use the full evidence-gated loop:
+
+```text
+freeze the measurement contract -> fit -> scale -> profile -> retune -> validate
+```
+
+### Phase 0: Freeze the Measurement Contract
+
+Before tuning, record and hold fixed the software/runtime versions, hardware
+and topology, model/task/data/routing semantics, precision, sequence and batch
+shape, parallelism, graph scopes, and steady-state timing window. Label forced
+routing, synthetic data, or disabled optimizer/checkpoint paths as
+**benchmark-only**; they cannot establish training-equivalent acceptance.
 
 ### Phase 1: Establish Memory-Feasible Parallelism
 
@@ -72,9 +86,10 @@ Five guidelines, in order of priority:
    depends on model size and hardware. Use hierarchical CP (`a2a+p2p`) on
    NVL72-class systems when appropriate.
 
-### Phase 3: Profile and Optimize Bottlenecks
+### Phase 3: Profile the Bottleneck
 
-Profile the training run and identify which wall dominates:
+Profile the training run and operationally split the paper's compute-efficiency
+wall into compute and host/launch bottlenecks:
 
 **Memory bottleneck** — forced into full recompute or excessive parallelism:
 
@@ -112,8 +127,24 @@ Profile the training run and identify which wall dominates:
 | Kernel fusions | `--moe-router-fusion --moe-permute-fusion` |
 | FP8 precision | `--fp8-format --fp8-recipe` |
 
-This process is **iterative**: fitting the model, choosing parallelism, and
-profiling the dominant wall usually matter more than any single micro-optimization.
+### Phase 4: Retune One Variable at a Time
+
+Use the profile to choose one candidate: dispatcher, one overlap mode, lower
+precision, CUDA graphs, recompute, or a parallelism adjustment. Keep the rest
+of the measurement contract fixed. Hardware support narrows the candidate set;
+it does not guarantee which backend or precision mode will improve end-to-end
+step time.
+
+### Phase 5: Validate the Complete Winner
+
+Use short post-warmup screens to reject weak candidates, then run the winner for
+at least 50 steps and report a declared steady window. Require runtime evidence
+that the requested dispatcher, lower-precision kernels, overlap path, and graph
+replay actually ran. Report finite loss, skipped/NaN iterations, peak memory,
+step time, model TFLOPS/GPU, and checkpoint/optimizer-state behavior when the
+production path requires them.
+
+This process is **iterative**: solving one bottleneck often exposes another.
 
 ## Parallel Folding
 
@@ -171,12 +202,12 @@ Ordered by overhead (lowest first):
 
 ## FP8 Recipe Selection
 
-| Recipe | Platform | Granularity | Recommended |
+| Recipe | Platform | Granularity | Role after BF16 is stable |
 |---|---|---|---|
 | Per-tensor FP8 | Hopper/Blackwell | 1 scale/tensor | Starting point |
-| Blockwise FP8 | Hopper | 128×128 blocks | **Production on Hopper** |
-| MXFP8 | Blackwell | 1×32 elements | **Default on Blackwell** |
-| NVFP4 | Blackwell | 16 elements, 2-level | Maximum throughput |
+| Blockwise FP8 | Hopper | 128×128 blocks | Candidate when the target stack supports the intended kernels |
+| MXFP8 | Blackwell | 1×32 elements | High-priority candidate |
+| NVFP4 | Blackwell | 16 elements, 2-level | Speed-first candidate after BF16/FP8 validation |
 
 Key rules:
 - Router stays in FP32 always
@@ -192,14 +223,14 @@ Two modes, different trade-offs:
 | Mode | What's Captured | When to Use |
 |---|---|---|
 | Full CUDA Graphs | Entire fwd+bwd | Drop-and-pad MoE only |
-| Partial (layer-wise) | attn + router + moe_preprocess | **Dropless MoE (default)** |
+| Partial (layer-wise) | router + moe_preprocess, optionally attn | Dropless-MoE candidate when host/launch overhead is visible |
 
 Partial CUDA graphs capture static components while leaving dynamic expert
-computation outside the graph, which is why they are the safer default for
-dropless MoE. Validate the replay window against an eager run on the same
-dispatcher and container: TE-scoped capture can be neutral or slightly slower
-on all-to-all fallback shapes that are not visibly launch-bound, even when
-capture succeeds.
+computation outside the graph. Start with the narrowest useful scope only after
+profiling host/launch overhead. Validate replay against eager on the same full
+stack: TE-scoped capture can be neutral or slightly slower when the workload is
+not launch-bound, and an earlier win can disappear after dispatcher, overlap,
+precision, or recompute changes.
 
 For full CUDA Graphs on dropless MoE, three techniques are needed:
 
@@ -258,16 +289,16 @@ dispatcher backend controls how this communication is implemented:
 | `flex` + DeepEP | DeepEP library | Low-latency SM-based dispatch with GPU-side routing |
 | `flex` + HybridEP | HybridEP library | Fused intra-node NVLink + inter-node IB dispatch |
 
-### Hardware affinity
+### Hardware-informed candidate order
 
-| Hardware | Recommended Dispatcher | Rationale |
+| Hardware | Bring-up | Tuned candidates |
 |---|---|---|
-| H100 / B200 (NVL8) | DeepEP, if installed | Optimized for node-based topologies |
-| GB200 / GB300 (NVL72) | HybridEP, if installed | Exploits NVLink domain for lower latency |
+| H100 / B200 (NVL8) | `alltoall` | A/B DeepEP and HybridEP when supported |
+| GB200 / GB300 (NVL72) | `alltoall` | HybridEP first, then compare other installed backends |
 
-HybridEP advantage usually grows with EP degree because it fuses intra-node
-NVLink transfers with inter-node IB work, avoiding much of the two-phase
-overhead of standard all-to-all at large EP sizes.
+Topology and EP degree affect the candidate order, but they do not determine the
+winner. The canonical 16×H100 Qwen3 30B recipe uses HybridEP, while the current
+256×H100 Qwen3 235B recipe uses standard `alltoall` plus overlap.
 
 Treat dispatcher package availability as part of the experiment setup, not as a
 given. `alltoall` is the correctness fallback and should be the first smoke test
@@ -278,6 +309,13 @@ Keep the container, CUDA graph scope, routing mode, and MoE kernel-fusion flags
 fixed when comparing dispatcher throughput.
 
 ### Short-run H100 sanity check
+
+The current canonical 16×H100 Qwen3 30B-A3B BF16 performance recipe uses
+HybridEP with 32 SMs, 64-token combine chunks, plain EP overlap, delayed
+weight-gradient compute disabled, and TE graphs over `moe_router` and
+`moe_preprocess`. Its verified 50-step run averaged 20.14729 seconds and
+299.352 model TFLOPS/GPU over steps 41–50. This is a workload-specific result,
+not a universal H100 dispatcher rule.
 
 On 2026-05-17, a 16-GPU H100 smoke run of Qwen3 30B A3B BF16 with EP=16 and
 the recipe's Transformer Engine CUDA graph scopes (`moe_router`,
@@ -350,7 +388,7 @@ Key principles:
 
 | Feature | Purpose |
 |---|---|
-| Force-balance routing | Even token distribution; best for benchmarking |
+| Force-balance routing | Even token distribution for disclosed benchmark-only comparisons; validate natural routing separately |
 | Aux-loss-free balancing | Learnable expert bias; adapts over time |
 | Shared expert overlap | Hides shared expert latency behind dispatch/combine |
 | LatentMoE | Reduces comms and per-expert params by compression ratio α |

--- a/skills/nemo-mbridge-perf-cuda-graphs/SKILL.md
+++ b/skills/nemo-mbridge-perf-cuda-graphs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nemo-mbridge-perf-cuda-graphs
-description: Validate and use CUDA graph capture in Megatron Bridge, including local full-iteration graphs and Transformer Engine scoped graphs for attention, MLP, and MoE modules.
+description: Profile, validate, and use CUDA graph capture in Megatron Bridge, including local full-iteration graphs and Transformer Engine scoped graphs. Covers replay evidence, matched eager A/Bs, model-specific scopes, regressions, and failures.
 license: Apache-2.0
 when_to_use: Reducing host-driver overhead via CUDA graphs, or tracing a crash or regression to a CUDA graph config change; 'cuda_graph_impl', 'full iteration graph', 'TE scoped graph', 'graphed callables', 'CUDA graph capture'.
 ---
@@ -24,11 +24,12 @@ host-driver overhead. Bridge supports two implementations:
 
 ## Quick Decision
 
-Start with TE-scoped graphs for most training workloads, then verify replay
-timing against eager on the same dispatcher, layout, and container:
+First confirm a profile shows material host/launch gaps. Then test the narrowest
+TE-scoped graph candidate and verify replay timing against eager on the same
+dispatcher, layout, routing, precision, and container:
 
 - dense models: `attn`, then optionally `mlp`
-- dropless MoE: `attn moe_router moe_preprocess`
+- dropless MoE: `moe_router moe_preprocess`, then optionally `attn`
 - VLMs: the same dropless-MoE scope, but only after the real-data path is stable
 
 Use `local` + `full_iteration` only when you specifically want full-iteration
@@ -73,7 +74,7 @@ cfg.rng.te_rng_tracker = True
 
 ```python
 cfg.model.cuda_graph_impl = "transformer_engine"
-cfg.model.cuda_graph_scope = ["attn", "moe_router", "moe_preprocess"]
+cfg.model.cuda_graph_scope = ["moe_router", "moe_preprocess"]
 cfg.model.cuda_graph_warmup_steps = 3
 cfg.model.use_te_rng_tracker = True
 cfg.rng.te_rng_tracker = True
@@ -90,7 +91,7 @@ uv run python scripts/performance/run_script.py \
   -c bf16 \
   -ng 16 \
   --cuda_graph_impl transformer_engine \
-  --cuda_graph_scope attn,moe_router,moe_preprocess \
+  --cuda_graph_scope moe_router,moe_preprocess \
   ...
 ```
 
@@ -101,6 +102,11 @@ Valid CLI values live in `scripts/performance/argument_parser.py`:
 The performance harness uses a comma-separated `--cuda_graph_scope` value and
 auto-enables `model.use_te_rng_tracker` plus `rng.te_rng_tracker` when
 `--cuda_graph_impl` is not `none`.
+
+Scope names follow the actual MCore module type. `mamba` applies to real Mamba
+layers; do not use it as a generic label for every linear-attention block.
+Qwen3.5 Gated DeltaNet (GDN) lives under `self_attention`, so its applicable TE
+scope is `attn`, not `mamba`.
 
 ### Required constraints
 
@@ -125,6 +131,8 @@ auto-enables `model.use_te_rng_tracker` plus `rng.te_rng_tracker` when
 5. Compare eager against graph replay iterations after warmup and capture; do
    not include the capture step in steady-state timing.
 6. Only then widen scope or combine with overlap features.
+7. Re-run the eager/graph A/B on the final dispatcher, overlap, precision, and
+   recompute stack. An earlier graph win can disappear after other tuning.
 
 ## Code Anchors
 
@@ -318,6 +326,10 @@ def _delete_cuda_graphs(cuda_graph_helper):
     graphable layers, about `6.9 s` capture time on rank 0), but replay
     iterations 5-8 averaged `42.00 s` versus `41.36 s` for eager. Treat
     scoped graphs as a bring-up candidate and validate on the target stack.
+
+14. **Scope names are structural, not architectural nicknames**: use `mamba`
+    only for real Mamba layers. Hybrid models such as Qwen3.5 place GDN in the
+    attention path, so graph it with `attn` when supported.
 
 ## Verification
 

--- a/skills/nemo-mbridge-perf-cuda-graphs/card.yaml
+++ b/skills/nemo-mbridge-perf-cuda-graphs/card.yaml
@@ -1,5 +1,5 @@
 title: cuda_graphs
-validated_on: "2026-05-18"
+validated_on: "2026-07-31"
 summary: >
   Megatron Bridge supports CUDA graph capture through two implementations:
   local full-iteration graphs (MCore FullCudaGraphWrapper) and Transformer
@@ -97,6 +97,7 @@ enable_when:
   - the run has memory headroom for pinned graph buffers
   - throughput improvement is desired without changing training math
   - pretrain or other static-shape workloads can avoid packed-sequence paths
+  - a matched eager profile shows meaningful host or launch overhead
 avoid_when:
   - sequence length or batch shapes vary across steps
   - CPU offloading is enabled
@@ -125,7 +126,9 @@ feature_meaning:
   cuda_graph_impl: >
     Which graph capture backend to use: local (MCore), transformer_engine (TE), or none.
   cuda_graph_scope: >
-    Which modules to capture: full_iteration, attn, mlp, moe, moe_router, moe_preprocess, mamba.
+    Which modules to capture: full_iteration, attn, mlp, moe, moe_router,
+    moe_preprocess, mamba. The scope follows the actual module type; mamba is
+    not a generic label for linear attention, and Qwen3.5 GDN uses attn.
   cuda_graph_warmup_steps: >
     Number of eager warmup steps before graph capture begins (default 3).
 config_keys:
@@ -137,10 +140,12 @@ config_keys:
   - rerun_state_machine.check_for_nan_in_loss
   - ddp.check_for_nan_in_grad
 recommended_path:
+  prerequisite: profile_eager_host_or_launch_overhead
   model.cuda_graph_impl: transformer_engine_for_scoped_or_local_for_full
-  model.cuda_graph_scope: attn_plus_moe_router_moe_preprocess_for_moe_models
+  model.cuda_graph_scope: moe_router_plus_moe_preprocess_first_for_dropless_moe_then_ab_attn
   rng.te_rng_tracker: true
   model.use_te_rng_tracker: true
+  acceptance: prove_replay_then_compare_post_capture_steady_iterations_against_eager_on_final_stack
 expected_metric_change:
   - metric: step_time
     direction: down
@@ -269,11 +274,13 @@ known_constraints:
   - With expandable_segments, NCCL_GRAPH_REGISTER=0 required (MCore cuda_graphs.py:1428, 1697).
   - MoE recompute unsupported with moe_router scope + TE impl (MCore transformer_config.py:1977).
   - full recompute (recompute_granularity=full) only works with local full_iteration, not TE scoped.
+  - mamba scope applies to real Mamba layers; Qwen3.5 GDN is in self_attention and uses attn scope.
 known_limitations:
   - Most public recipes default to cuda_graph_impl none.
   - Tensor shapes must be static; variable-length sequences break graph replay.
   - TE-scoped graphs and packed-sequence finetuning remain a fragile combination across model families.
   - Large-model MoE rollout is memory-headroom-sensitive even when smaller-model TE-scoped graphs work.
+  - A successful capture is not a speedup guarantee, and a prior win may disappear after dispatcher, overlap, precision, or recompute changes.
 evidence:
   - docs/training/cuda-graphs.md
   - docs/performance-guide.md

--- a/skills/nemo-mbridge-perf-cuda-graphs/evals/evals.json
+++ b/skills/nemo-mbridge-perf-cuda-graphs/evals/evals.json
@@ -4,13 +4,27 @@
     "question": "Use the nemo-mbridge-perf-cuda-graphs skill. I am training a Megatron Bridge Qwen3 MoE model and want to reduce CPU launch overhead with CUDA graphs. Which cuda_graph_impl and cuda_graph_scope should I start with, and what prerequisites should I set?",
     "expected_skill": "nemo-mbridge-perf-cuda-graphs",
     "expected_script": null,
-    "ground_truth": "For most Megatron Bridge training workloads, start with Transformer Engine scoped graphs rather than local full-iteration capture. For a dropless MoE model, use cuda_graph_impl=\"transformer_engine\" with cuda_graph_scope including attn, moe_router, and moe_preprocess. Set cuda_graph_warmup_steps, enable model.use_te_rng_tracker and rng.te_rng_tracker, keep sequence length and micro-batch size static, and compare steady-state replay iterations after warmup and capture. Do not combine moe and moe_router scopes.",
+    "ground_truth": "First profile the eager run and only test CUDA graphs when host/launch gaps are material. For a dropless MoE model, start with cuda_graph_impl=\"transformer_engine\" and the narrow moe_router plus moe_preprocess scope, then add attn only if a matched A/B improves the same final stack. Set cuda_graph_warmup_steps, enable model.use_te_rng_tracker and rng.te_rng_tracker, keep sequence length and micro-batch size static, prove replay is active, and compare post-capture steady iterations against eager. Do not combine moe and moe_router scopes. A successful capture is not a speedup guarantee, and the comparison must be repeated after dispatcher, overlap, precision, or recompute changes.",
     "expected_behavior": [
       "Read the nemo-mbridge-perf-cuda-graphs skill before answering.",
-      "Recommend transformer_engine scoped graphs for the MoE bring-up path.",
-      "Name the relevant MoE scopes: attn, moe_router, and moe_preprocess.",
+      "Require eager profiling before recommending graph capture.",
+      "Recommend the narrow transformer_engine moe_router plus moe_preprocess candidate first, with attn as a later A/B.",
       "Mention the TE RNG tracker requirement and static-shape constraint.",
-      "Tell the user to compare replay timing after warmup and capture rather than measuring the capture step."
+      "Tell the user to prove replay and compare timing after warmup and capture rather than measuring the capture step.",
+      "Require a new eager/graph A/B after other performance-stack changes."
+    ]
+  },
+  {
+    "id": "cuda-graphs-qwen35-gdn-scope",
+    "question": "Use the nemo-mbridge-perf-cuda-graphs skill. Qwen3.5 mixes standard attention with Gated DeltaNet layers. Should I use the mamba CUDA graph scope for GDN, and what evidence is required before keeping the graph configuration?",
+    "expected_skill": "nemo-mbridge-perf-cuda-graphs",
+    "expected_script": null,
+    "ground_truth": "Do not use mamba merely because GDN is a linear-attention variant. CUDA graph scopes follow the actual MCore module type: mamba is for real Mamba layers, while Qwen3.5 GDN is implemented under self_attention and therefore uses the attn scope when supported. Profile eager first, confirm host/launch overhead, prove graph replay is active, and keep the scopes only if a matched post-capture steady-state A/B beats eager on the final dispatcher, overlap, precision, and recompute stack.",
+    "expected_behavior": [
+      "Read the nemo-mbridge-perf-cuda-graphs skill before answering.",
+      "Reject mamba scope for Qwen3.5 GDN.",
+      "Explain that GDN follows the attn scope because it is under self_attention.",
+      "Require profile justification, replay evidence, and a matched final-stack eager A/B."
     ]
   }
 ]

--- a/skills/nemo-mbridge-perf-moe-dispatcher-selection/SKILL.md
+++ b/skills/nemo-mbridge-perf-moe-dispatcher-selection/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nemo-mbridge-perf-moe-dispatcher-selection
-description: Choose the right MoE token dispatcher (`alltoall`, DeepEP, or HybridEP) for the hardware, EP degree, and optimization stage. Summarizes patterns from DSV3, Qwen3, Qwen3-Next, and VLM bring-up work.
+description: Select and validate an MoE token dispatcher (`alltoall`, DeepEP, or HybridEP) for a fixed workload and runtime. Covers backend availability, topology, matched A/B evidence, routing semantics, and failure diagnosis.
 license: Apache-2.0
 when_to_use: Choosing a MoE token dispatcher, or tracing a MoE regression or crash to a dispatcher config change; 'which dispatcher', 'alltoall vs DeepEP', 'HybridEP', 'MoE dispatcher', 'flex backend', 'EP dispatcher selection'.
 ---
@@ -14,29 +14,33 @@ Card: @skills/nemo-mbridge-perf-moe-dispatcher-selection/card.yaml
 
 ### By hardware
 
-| Hardware | First choice | Why |
+| Hardware | Bring-up path | Tuned candidates |
 |---|---|---|
-| H100 | DeepEP, if the runtime package is installed | Strong default for cross-node EP on Hopper |
-| B200 | DeepEP, if the runtime package is installed | Good first choice unless a platform-specific HybridEP path is available |
-| GB200 / GB300 NVL72 | HybridEP, if the runtime package is installed | Best fit for NVLink-domain-aware dispatch and lower memory pressure |
-| Unknown or first bring-up | `alltoall` | Easiest path for correctness and debugging |
+| H100 | `alltoall` | A/B DeepEP and HybridEP when installed; the current 16×H100 Qwen3 30B winner is HybridEP |
+| B200 | `alltoall` | A/B DeepEP and HybridEP when supported by the target runtime |
+| GB200 / GB300 NVL72 | `alltoall` | HybridEP is the strongest topology-informed candidate; compare DeepEP when available |
+| Unknown | `alltoall` | Add one flex backend only after the correctness baseline is stable |
+
+Hardware narrows the candidate set; it does not select the winner. Hold the
+model, routing, batch shape, parallelism, overlap, graph scope, container, and
+timing window fixed during the comparison.
 
 ### By EP degree
 
 | EP size | Guidance |
 |---|---|
-| Small EP | Dispatcher choice is usually second-order; start with `alltoall` or DeepEP |
-| Medium EP | DeepEP often becomes worthwhile |
-| Large EP | HybridEP is usually the best target on NVL72 systems |
+| Small EP | Dispatcher choice may be second-order; start with `alltoall` |
+| Medium EP | Profile first, then A/B the installed flex backends |
+| Large EP | Prioritize topology-aware candidates, but still require a matched A/B |
 
 ## Model-Family Patterns
 
 | Workload | Common best path | Notes |
 |---|---|---|
-| DSV3 at large scale | HybridEP on GB200 or GB300, DeepEP on H100 | Dispatcher choice matters more as EP and PP both grow |
-| Qwen3 235B | DeepEP on H100, HybridEP on GB200 | HybridEP usually wins on GB200 and often uses less memory |
-| Qwen3 30B | DeepEP | Smaller models still benefit, but the absolute gap is smaller |
-| Qwen3-Next | Close race in BF16, HybridEP stronger in FP8 or memory-tight runs | Good reminder to test, not assume |
+| DSV3 at large scale | Measured snapshots use HybridEP on GB200/GB300 and DeepEP on H100 | Revalidate against the target container and topology |
+| Qwen3 235B | Current H100 recipe uses `alltoall` plus overlap; measured GB200 snapshots use HybridEP | Do not replace the current recipe from a hardware rule alone |
+| Qwen3 30B | Current canonical 16×H100 recipe uses HybridEP | Direct counterexample to H100 → DeepEP mapping |
+| Qwen3-Next | Workload-dependent | Precision, memory, PP layout, and kernels can change the ordering |
 | MoE VLMs | Start simple, then test HybridEP on GB200-class systems | Vision workloads are sensitive to both memory and host overhead |
 
 ## Rounded Evidence Summary
@@ -52,6 +56,17 @@ record the import failure as an environment limitation and treat `alltoall` as
 the only measured correctness fallback for that run.
 
 ### Qwen3 30B A3B on H100
+
+The current canonical 16×H100 BF16 performance recipe uses HybridEP, 32
+HybridEP SMs, 64-token combine chunks, plain expert-parallel communication
+overlap, delayed weight-gradient compute disabled, and TE graphs over
+`moe_router` and `moe_preprocess`. Its verified 50-step run averaged 20.14729 s
+and 299.352 model TFLOPS/GPU over steps 41–50. This proves HybridEP can win on
+NVL8 H100; it does not prove HybridEP is universal.
+
+An earlier matched overlap A/B on the same broad shape isolated a rise from
+244.039 to 287.305 TFLOPS/GPU. Keep that causal result separate from the later
+multi-knob canonical winner.
 
 A short 2026-05-17 H100 smoke run used Qwen3 30B A3B BF16, 16 GPUs, EP=16,
 the recipe's Transformer Engine CUDA graph scopes (`moe_router`,
@@ -139,15 +154,17 @@ available.
 --moe-router-force-load-balancing
 ```
 
-For performance benchmarking, force-balance routing is the safer default. It
-usually outperforms dropless routing in large-scale benchmarks and makes results
-more comparable across dispatcher backends.
+Forced load balancing is a **benchmark-only** control that can reduce routing
+variance across dispatcher backends. It changes routing semantics, so keep it
+fixed within the dispatcher A/B and do not use it to accept a
+training-equivalent or convergence-sensitive result. Validate the production
+winner again with natural routing.
 
 ## Key Interactions
 
 | Feature | Interaction |
 |---|---|
-| CUDA graphs | Best paired with `attn moe_router moe_preprocess` on dropless MoE |
+| CUDA graphs | Profile-driven candidate; start narrow and re-test after dispatcher changes |
 | EP overlap | Helps when dispatcher time is still visible after backend tuning |
 | FP8 | Often increases the relative importance of communication and host overhead |
 | CPU affinity | Can matter as much as dispatcher choice on GB200 or GB300 |
@@ -163,13 +180,14 @@ more comparable across dispatcher backends.
 
 ### DeepEP
 
-- Hopper or B200 deployments
+- any supported target runtime where DeepEP imports successfully
 - cross-node EP is clearly visible in profiles
-- you want a mature intermediate step before testing HybridEP
+- a matched steady-state A/B beats the alternatives
 
 ### HybridEP
 
-- GB200 or GB300 NVL72 systems
+- NVL72 systems, where the topology makes it a high-priority candidate
+- NVL8 systems when the package supports the topology and a matched A/B wins
 - large EP degrees
 - memory headroom matters in addition to throughput
 
@@ -178,8 +196,8 @@ more comparable across dispatcher backends.
 1. **Do not compare dispatchers on different stacks**: container, routing mode,
    PP layout, and CUDA-graph scope can move the result as much as the dispatcher.
 
-2. **HybridEP is topology-sensitive**: it is not a universal win outside the
-   hardware it was designed for.
+2. **HybridEP is topology-sensitive**: configure the actual NVLink domain and
+   do not infer support or performance from the GPU SKU alone.
 
 3. **Both dispatchers need SM tuning**: default `moe_deepep_num_sms` (20) and
    `moe_hybridep_num_sms` (16) are reasonable starting points but rarely optimal.
@@ -195,3 +213,9 @@ more comparable across dispatcher backends.
    is missing from the container, do not compare its failed job against a
    completed `alltoall` job. Fix the environment first, then rerun the same
    stack.
+
+7. **Forced routing is not training equivalence**: use it only as a disclosed
+   benchmark control, then validate natural routing separately.
+
+8. **Config selection is not backend proof**: require runtime evidence that the
+   requested flex backend initialized and completed steady iterations.

--- a/skills/nemo-mbridge-perf-moe-dispatcher-selection/card.yaml
+++ b/skills/nemo-mbridge-perf-moe-dispatcher-selection/card.yaml
@@ -1,10 +1,9 @@
 title: moe_dispatcher_selection
-validated_on: "2026-04-01"
+validated_on: "2026-07-31"
 summary: >
-  Empirical guide for selecting MoE token dispatchers (AlltoAll, DeepEP,
-  HybridEP) based on hardware platform, model scale, and EP degree.
-  Backed by measured benchmarks from DSV3, Qwen3, and Qwen3-Next experiments
-  across H100, B200, GB200, and GB300 systems.
+  Evidence-gated guide for selecting MoE token dispatchers (AlltoAll, DeepEP,
+  HybridEP). Hardware and EP degree form a candidate set; matched target-stack
+  A/Bs, routing semantics, and runtime activation evidence select the winner.
 
 validation_status:
   dsv3_h100_benchmarks:
@@ -24,18 +23,19 @@ validation_status:
 
 training_dimensions:
   speed:
-    effect: "HybridEP ~10-20% faster than DeepEP/AlltoAll on NVL72 systems"
-    confidence: high
+    effect: "workload-dependent"
+    confidence: medium
     rationale: >
-      Measured across DSV3 and Qwen3 on GB200/GB300. HybridEP exploits NVLink
-      domain for fused intra/inter-node dispatch.
+      HybridEP is strong in measured GB200/GB300 snapshots and in the canonical
+      16×H100 Qwen3 30B recipe, but dispatcher ordering changes by workload.
   memory:
-    effect: "HybridEP uses ~15% less GPU memory than AlltoAll"
-    confidence: high
+    effect: "workload-dependent"
+    confidence: medium
     rationale: >
-      Measured on Qwen3 GB200: HybridEP ~75% vs AlltoAll ~90% memory utilization.
+      Some measured Qwen3 GB200 runs show better HybridEP headroom; reproduce
+      the comparison with identical routing, layout, graphs, and runtime.
   scale:
-    effect: "HybridEP advantage grows with EP degree"
+    effect: "topology and EP degree can change the ordering"
     confidence: medium
     rationale: >
       Higher EP means more communication; HybridEP's NVLink optimization
@@ -43,17 +43,21 @@ training_dimensions:
 
 dispatcher_recommendations:
   h100:
-    recommended: DeepEP
-    rationale: "HybridEP not available; DeepEP outperforms AlltoAll"
+    bring_up: alltoall
+    tuned_candidates: [DeepEP, HybridEP]
+    rationale: "The current 16×H100 Qwen3 30B winner uses HybridEP; measure rather than infer from the GPU SKU"
   b200:
-    recommended: DeepEP
-    rationale: "Best measured perf for cross-node EP"
+    bring_up: alltoall
+    tuned_candidates: [DeepEP, HybridEP]
+    rationale: "Use only backends supported by the target runtime and select by matched A/B"
   gb200_nvl72:
-    recommended: HybridEP
-    rationale: "Exploits NVLink domain; ~8% MFU jump over optimized DeepEP"
+    bring_up: alltoall
+    first_tuned_candidate: HybridEP
+    rationale: "NVLink-domain-aware dispatch makes HybridEP high priority, but still validate the exact stack"
   gb300_nvl72:
-    recommended: HybridEP
-    rationale: "Same NVLink advantage as GB200"
+    bring_up: alltoall
+    first_tuned_candidate: HybridEP
+    rationale: "NVLink-domain-aware candidate; remeasure the exact software and topology"
 
 key_tuning_parameters:
   - name: moe-deepep-num-sms
@@ -68,13 +72,21 @@ key_tuning_parameters:
     default: varies
     recommended: "match NVLink domain size (e.g., 16 for GB200)"
   - name: moe-router-force-load-balancing
-    recommended: always
-    rationale: "Force balance consistently outperforms dropless by 5–10%"
+    recommended: benchmark_only
+    rationale: "Controls routing variance but changes semantics; validate natural routing separately"
   - name: CUDA_DEVICE_MAX_CONNECTIONS
     default: 1
     note: "Set to 32 when using EP overlap + CUDA graphs"
 
 best_measured_configs:
+  - model: "Qwen3 30B-A3B"
+    hardware: "16×H100"
+    dispatcher: HybridEP
+    precision: BF16
+    tflops: 299.352
+    step_time_ms: 20147.290
+    parallelism: "TP1 CP1 EP16 PP1"
+    note: "50 steps; steps 41-50; 32 HybridEP SMs; 64-token combine chunks"
   - model: "DSV3 685B w/ MTP"
     hardware: "1024×H100"
     dispatcher: DeepEP
@@ -110,21 +122,25 @@ best_measured_configs:
     mfu: "~28%"
     tflops: ~700
     parallelism: "TP1 EP32 PP4 VPP12"
-  - model: "Qwen3 235B-A22B"
+  - model: "Qwen3 235B-A22B current recipe seed"
     hardware: "256×H100"
-    dispatcher: DeepEP
+    dispatcher: alltoall
     precision: BF16
-    mfu: "~30%"
-    tflops: ~300
     parallelism: "TP2 EP32 PP8 VPP4"
+    measurement_status: "remeasure on the target stack"
+    note: "Current canonical recipe uses alltoall plus expert-parallel overlap; do not attach historical DeepEP metrics"
 
 evidence:
+  - "examples/model_verification_cards/qwen3-30b-a3b/card.yaml"
+  - "src/megatron/bridge/perf_recipes/qwen/h100/qwen3_moe.py"
   - "[MoE Perf] MCore Release Performance Tracker - DeepSeek-V3"
   - "[MoE Perf] MCore Release Performance Tracker - Qwen3"
   - "[MoE Perf] MCore Release Performance Tracker - Qwen3-Next"
 
 known_limitations:
-  - HybridEP only works on NVL72 systems (GB200, GB300)
+  - HybridEP is topology-sensitive but is supported and measured on the canonical 16×H100 Qwen3 30B workload
   - DeepEP SM count tuning is hardware-specific
   - Container version can cause performance regression
   - 1F1B overlap + DeepEP may regress on some configurations
+  - Forced load balancing is benchmark-only and cannot establish training-equivalent correctness
+  - Backend selection in a config is not proof that the requested runtime initialized or ran

--- a/skills/nemo-mbridge-perf-moe-dispatcher-selection/evals/evals.json
+++ b/skills/nemo-mbridge-perf-moe-dispatcher-selection/evals/evals.json
@@ -4,13 +4,15 @@
     "question": "Use the nemo-mbridge-perf-moe-dispatcher-selection skill. In Megatron Bridge, give the exact MoE dispatcher selection checklist for H100 versus GB200/NVL72, including the flex backend config names, default DeepEP/HybridEP SM knobs, and what to conclude if the backend package import fails.",
     "expected_skill": "nemo-mbridge-perf-moe-dispatcher-selection",
     "expected_script": null,
-    "ground_truth": "The answer should use MoE dispatcher selection guidance. It should recommend alltoall for first bring-up or missing packages, DeepEP as the first tuned choice for H100/B200 when the package is installed, and HybridEP for GB200/GB300 NVL72 or large EP/memory-tight runs. It should state that DeepEP and HybridEP use moe_token_dispatcher_type=\"flex\" with moe_flex_dispatcher_backend=\"deepep\" or \"hybridep\", mention starting knobs --moe-deepep-num-sms 20 and --moe-hybridep-num-sms 16, and say backend import failures are environment limitations, not throughput data.",
+    "ground_truth": "The answer should use MoE dispatcher selection guidance. It should recommend alltoall for correctness bring-up or missing packages, then require matched A/B measurements of the installed flex backends instead of mapping H100 directly to DeepEP. It should identify the canonical 16xH100 Qwen3 30B winner as HybridEP and the current 256xH100 Qwen3 235B recipe as alltoall plus overlap. It should state that DeepEP and HybridEP use moe_token_dispatcher_type=\"flex\" with moe_flex_dispatcher_backend=\"deepep\" or \"hybridep\", mention starting knobs --moe-deepep-num-sms 20 and --moe-hybridep-num-sms 16, and say backend import failures are environment limitations, not throughput data. It should keep routing and the rest of the stack fixed, disclose forced load balancing as benchmark-only, and require runtime proof that the requested backend completed steady iterations.",
     "expected_behavior": [
       "Read the nemo-mbridge-perf-moe-dispatcher-selection skill before answering.",
-      "Compare alltoall, DeepEP, and HybridEP by hardware and EP scale.",
+      "Use hardware and EP scale to form a candidate set, not to declare a winner.",
+      "Cite the H100 Qwen3 counterexamples to a universal dispatcher mapping.",
       "Name the flex dispatcher backend settings for DeepEP and HybridEP.",
       "Mention the DeepEP and HybridEP SM tuning knobs and defaults.",
-      "Warn that backend import failures mean the environment is missing a package, not that the dispatcher is slow."
+      "Warn that backend import failures mean the environment is missing a package, not that the dispatcher is slow.",
+      "Treat forced load balancing as benchmark-only and require runtime backend evidence."
     ]
   }
 ]

--- a/skills/nemo-mbridge-perf-moe-hardware-configs/SKILL.md
+++ b/skills/nemo-mbridge-perf-moe-hardware-configs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nemo-mbridge-perf-moe-hardware-configs
-description: Representative MoE training playbooks by hardware platform and model family. Summarizes rounded throughput bands, parallelism patterns, and common tuning stacks.
+description: Representative, point-in-time MoE training playbooks by hardware and model family. Use them as candidate seeds, then revalidate the exact runtime, semantics, topology, and steady-state throughput.
 license: Apache-2.0
 when_to_use: Hardware-specific MoE playbooks or throughput estimates; 'MoE on H100', 'GB200 config', 'expected throughput', 'MoE hardware playbook', 'parallelism for B200'.
 ---
@@ -12,12 +12,14 @@ Card: @skills/nemo-mbridge-perf-moe-hardware-configs/card.yaml
 
 ## Quick Platform Playbook
 
-| Platform | Typical MoE strategy | What usually matters most |
+These rows are search seeds, not hardware defaults or throughput promises.
+
+| Platform | Candidates to screen after `alltoall` bring-up | What usually matters most |
 |---|---|---|
-| H100 | DeepEP or HybridEP + explicit EP overlap | communication overlap, dispatcher/runtime compatibility, and PP efficiency |
-| B200 | DeepEP + MXFP8 + careful PP layout | container quality and tuned comm settings |
-| GB200 | HybridEP + partial CUDA graphs + CPU cleanup | host overhead, topology-aware dispatch, memory headroom |
-| GB300 | HybridEP + newer FP8 and kernel stack | same GB200 playbook, usually with a higher ceiling |
+| H100 | DeepEP or HybridEP, explicit overlap, supported FP8 modes | communication overlap, dispatcher/runtime compatibility, and PP efficiency |
+| B200 | DeepEP or HybridEP, supported FP8 modes, careful PP layout | container quality and tuned communication settings |
+| GB200 | HybridEP, then profile-driven graphs and CPU cleanup | host overhead, topology-aware dispatch, memory headroom |
+| GB300 | HybridEP and the target container's lower-precision/kernel stack | the same system interactions as GB200, with remeasurement required |
 
 ## First Answer Checklist
 
@@ -28,13 +30,14 @@ throughput caveats:
 |---|---|---|---|
 | DSV3 | H100 | DeepEP | TP=2, EP=64, PP=8, VPP=4 |
 | DSV3 | GB200/GB300 | HybridEP | TP=1, EP=64, PP=4, VPP=4 |
-| Qwen3 235B | H100 | DeepEP | TP=2, EP=32, PP=8, VPP=4 |
+| Qwen3 235B | H100 | `alltoall` + overlap in the current canonical recipe | TP=2, EP=32, PP=8, VPP=4 |
 | Qwen3 235B | GB200 | HybridEP | TP=1 or 2, EP=32-64, PP=4, VPP=unspecified |
 | Qwen3 30B | 16×H100 | HybridEP | TP=1, EP=16, PP=1, plain EP overlap |
 
 For Qwen3 235B on GB200, explicitly say `VPP=unspecified`; do not invent or
-extrapolate `VPP=12` unless a measured row provides it. Include TE-scoped CUDA
-graph scopes (`attn`, `moe_router`, `moe_preprocess`),
+extrapolate `VPP=12` unless a measured row provides it. Treat TE-scoped CUDA
+graph scopes (`attn`, `moe_router`, `moe_preprocess`) as profile-driven
+candidates,
 `CUDA_DEVICE_MAX_CONNECTIONS` selection,
 `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`, `NCCL_GRAPH_REGISTER=0`,
 GB200/GB300 CPU-side tuning, and the warning not to cargo-cult tracker rows.
@@ -50,9 +53,9 @@ moves. Treat them as planning ranges, not exact promises.
 | DSV3, large-scale | B200 | high-hundreds TFLOPS/GPU, mid-teens MFU | TP1, EP32, PP8, DeepEP |
 | DSV3, large-scale | GB200 | around 1K TFLOPS/GPU, low-20s MFU | TP1, EP64, PP4, HybridEP |
 | DSV3, large-scale | GB300 | above the GB200 band, often mid-20s MFU | TP1, EP64, PP4, HybridEP |
-| Qwen3 235B | H100 | low-300s TFLOPS/GPU, around 30% MFU | TP2, EP32, PP8, DeepEP |
+| Qwen3 235B | H100 | historical low-300s snapshots; remeasure the current recipe | TP2, EP32, PP8; current recipe uses `alltoall` + overlap |
 | Qwen3 235B | GB200 | high-hundreds TFLOPS/GPU in tuned runs | TP1 or TP2, EP32-64, PP4, HybridEP |
-| Qwen3 30B | H100 | high-200s TFLOPS/GPU on the validated 16-GPU shape | TP1, EP16, PP1, HybridEP + EP overlap |
+| Qwen3 30B | H100 | about 300 TFLOPS/GPU on the validated 16-GPU shape | TP1, EP16, PP1, HybridEP + EP overlap |
 | Qwen3-Next 80B | GB200 | low-300s TFLOPS/GPU in BF16-class runs | TP1, EP32, PP2, HybridEP |
 
 ## Representative Config Families
@@ -90,9 +93,9 @@ Priority: HybridEP, CPU optimization, and graph-friendly static shapes
 ### Qwen3 235B on H100
 
 ```text
-Dispatcher: DeepEP
+Dispatcher: alltoall in the current canonical recipe; re-screen flex backends on the target stack
 TP=2  EP=32  PP=8  VPP=4
-Recompute: norm and activation-side selective recompute
+Recompute: none in the current canonical recipe
 Priority: communication overlap and router-path cleanup
 ```
 
@@ -118,13 +121,15 @@ Routing: force balance
 EP overlap: enabled
 Delayed wgrad: disabled
 CUDA Graph: moe_router + moe_preprocess
-Measured: 20.992s/step, 287.305 model TFLOPS/GPU over iterations 41-50
+HybridEP: permute fusion, 32 SMs, 64-token combine chunks
+Measured: 20.14729s/step, 299.352 model TFLOPS/GPU over iterations 41-50
 Rank-0 peak allocated memory: 62.166 GiB
 ```
 
-This shape improved 17.729% over its reproduced 244.039 TFLOPS/GPU baseline
-when only plain EP overlap changed. A matched Nsight A/B increased
-communication hidden by GEMM/attention from 0.11% to 36.55%.
+The current number is the final multi-knob canonical recipe result. An earlier
+matched A/B isolated plain EP overlap: 244.039 to 287.305 TFLOPS/GPU, with
+communication hidden by GEMM/attention increasing from 0.11% to 36.55%. Do not
+attribute the later 299.352 result entirely to overlap.
 
 ### Qwen3-Next 80B on GB200
 
@@ -186,10 +191,15 @@ work, not as afterthoughts.
 4. **Compare absolute throughput, not only MFU**: MFU can mislead when switching
    between BF16, FP8, and other precision modes.
 
-5. **Force-balance routing is the safer benchmark default**: keep routing mode
-   fixed when comparing hardware or dispatcher stacks.
+5. **Force-balance routing is benchmark-only**: it can control routing variance,
+   but it changes semantics. Keep routing fixed within an A/B and validate
+   natural routing separately for training acceptance.
 
-6. **Do not treat the dispatcher table as a hard platform rule**: HybridEP was
-   the validated winner for the 16×H100 Qwen3 30B shape, while DeepEP failed
-   bring-up in that matched runtime. Benchmark backend compatibility and
-   throughput in the production container.
+6. **Do not treat the dispatcher table as a hard platform rule**: HybridEP is
+   the validated winner for the canonical 16×H100 Qwen3 30B shape, while the
+   current 256×H100 Qwen3 235B recipe uses `alltoall`. Benchmark backend
+   compatibility and throughput in the production container.
+
+7. **Separate screening, causality, and acceptance**: short runs reject weak
+   candidates, matched one-variable A/Bs explain a mechanism, and a 50-step
+   final run validates the complete winner.

--- a/skills/nemo-mbridge-perf-moe-hardware-configs/card.yaml
+++ b/skills/nemo-mbridge-perf-moe-hardware-configs/card.yaml
@@ -1,9 +1,9 @@
 title: moe_hardware_configs
-validated_on: "2026-07-25"
+validated_on: "2026-07-31"
 summary: >
-  Best-known MoE training configurations per model family and hardware platform,
-  with measured throughput, MFU, and parallelism settings. Covers DSV3, Qwen3,
-  and Qwen3-Next across H100, B200, GB200, and GB300 systems.
+  Representative point-in-time MoE configurations by model family and hardware.
+  Rows are candidate seeds, not platform defaults or throughput promises, and
+  must be revalidated with fixed semantics, topology, runtime, and timing windows.
 
 validation_status:
   dsv3_h100:
@@ -15,7 +15,8 @@ validation_status:
   dsv3_gb300:
     - measured
   qwen3_235b_h100:
-    - measured
+    - current_recipe_seed
+    - historical_measurements_not_attached_to_current_dispatcher
   qwen3_235b_b200:
     - measured
   qwen3_235b_gb200:
@@ -108,17 +109,20 @@ best_configs:
     overlap_1f1b: true
     cuda_graph: "attn, moe_router, moe_preprocess"
 
-  qwen3_235b_h100_256:
+  qwen3_235b_h100_256_current_recipe_seed:
     model: "Qwen3 235B-A22B"
     hardware: "256×H100"
     precision: BF16
-    dispatcher: DeepEP
-    tflops: ~320
-    mfu: "~32%"
+    dispatcher: alltoall
     parallelism: "TP2 EP32 PP8 VPP4"
-    batch: "MBS1 GBS2048"
+    batch: "MBS1 GBS8192"
     routing: force_balance
-    overlap_1f1b: true
+    moe_a2a_overlap: true
+    ep_overlap: true
+    delay_wgrad_compute: true
+    recompute: none
+    measurement_status: "recipe seed; remeasure on the target stack"
+    note: "Do not attach historical DeepEP throughput to this current alltoall configuration"
 
   qwen3_235b_b200_128:
     model: "Qwen3 235B-A22B"
@@ -161,8 +165,8 @@ best_configs:
     hardware: "16×H100"
     precision: BF16
     dispatcher: HybridEP
-    tflops: 287.305
-    step_time_ms: 20992.030
+    tflops: 299.352
+    step_time_ms: 20147.290
     parallelism: "TP1 EP16 PP1 CP1"
     sequence_length: 4096
     batch: "MBS1 GBS1024"
@@ -170,10 +174,15 @@ best_configs:
     ep_overlap: true
     delay_wgrad_compute: false
     cuda_graph: "moe_router, moe_preprocess"
+    hybridep_permute_fusion: true
+    hybridep_num_sms: 32
+    combine_chunk_tokens: 64
     rank0_peak_allocated_gib: 62.166
-    baseline_tflops: 244.039
-    throughput_gain_percent: 17.729
-    profile_comm_hidden_percent: "0.11 off, 36.55 on"
+    earlier_overlap_ab:
+      baseline_tflops: 244.039
+      overlap_tflops: 287.305
+      throughput_gain_percent: 17.729
+      profile_comm_hidden_percent: "0.11 off, 36.55 on"
 
   qwen3_next_80b_gb200_64:
     model: "Qwen3-Next 80B-A3B"
@@ -203,15 +212,15 @@ optimization_patterns:
   - name: ep_comm_overlap
     impact: "+17.729% throughput on measured Qwen3 30B 16×H100 HybridEP shape"
   - name: force_balance_routing
-    impact: "+5-10% MFU over dropless"
+    impact: "benchmark-only control; validate natural routing separately"
   - name: 1f1b_overlap
-    impact: "+15% on H100, varies on GB200"
+    impact: "candidate; measure on the exact PP/VPP and dispatcher stack"
   - name: cuda_graphs
-    impact: "+10-15% with attn+moe_router+moe_preprocess scope"
+    impact: "candidate only when host/launch overhead is visible; capture can be neutral or slower"
   - name: cpu_binding
-    impact: "+15% on GB200"
+    impact: "profile-driven host-overhead candidate"
   - name: mbs_tuning
-    impact: "up to +15% from MBS sweep"
+    impact: "shape-dependent; sweep without changing global token semantics"
 
 evidence:
   - "examples/model_verification_cards/qwen3-30b-a3b/card.yaml"
@@ -227,3 +236,5 @@ known_limitations:
   - VPP must divide transformer layers evenly across PP stages
   - FP8 MFU numbers use higher peak FLOPS denominator than BF16
   - Configs are point-in-time measurements; mcore/TE updates may change results
+  - Forced-routing benchmark rows are not training-equivalent acceptance evidence
+  - Earlier one-variable A/B gains must not be attributed to a later multi-knob winner

--- a/skills/nemo-mbridge-perf-moe-hardware-configs/evals/evals.json
+++ b/skills/nemo-mbridge-perf-moe-hardware-configs/evals/evals.json
@@ -4,14 +4,15 @@
     "question": "Use the nemo-mbridge-perf-moe-hardware-configs skill as an implementation checklist. I am choosing MoE training playbooks for DSV3 and Qwen3 235B on H100 versus GB200/GB300. Give the representative TP/EP/PP/VPP layouts where the skill provides VPP; explicitly say Qwen3 235B on GB200 has VPP=unspecified and do not invent VPP=12. Include dispatcher choices, CUDA graph scopes, environment knobs, GB200/GB300 CPU-side tuning note, and the main warning about copying tracker rows.",
     "expected_skill": "nemo-mbridge-perf-moe-hardware-configs",
     "expected_script": null,
-    "ground_truth": "The answer should use MoE hardware configuration guidance. It should state DSV3 on H100 uses DeepEP with TP=2, EP=64, PP=8, VPP=4, while DSV3 on GB200 or GB300 uses HybridEP with TP=1, EP=64, PP=4, VPP=4 and CUDA graph scopes attn + moe_router + moe_preprocess. It should state Qwen3 235B on H100 uses DeepEP with TP=2, EP=32, PP=8, VPP=4, while Qwen3 235B on GB200 uses HybridEP with TP=1 or 2, EP=32-64, PP=4, leaves VPP unspecified unless a measured row provides it, and does not invent VPP=12. It should mention CUDA_DEVICE_MAX_CONNECTIONS=1 or 32 depending on overlap/graphs, PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True, NCCL_GRAPH_REGISTER=0, CPU-side tuning on GB200/GB300, and warn not to cargo-cult throughput rows.",
+    "ground_truth": "The answer should use MoE hardware configuration guidance and label every row as a point-in-time candidate seed rather than a hardware default. It should state DSV3 measured snapshots use DeepEP with TP=2, EP=64, PP=8, VPP=4 on H100 and HybridEP with TP=1, EP=64, PP=4, VPP=4 on GB200/GB300. It should state the current Qwen3 235B H100 recipe uses alltoall plus overlap with TP=2, EP=32, PP=8, VPP=4, while a representative GB200 row uses HybridEP with TP=1 or 2, EP=32-64, PP=4 and leaves VPP unspecified unless measured. It must not invent VPP=12. It should identify the canonical 16xH100 Qwen3 30B result as HybridEP at 299.352 model TFLOPS/GPU over steps 41-50, distinguish that final winner from the earlier 244.039 to 287.305 overlap A/B, mention relevant environment knobs and GB200/GB300 CPU-side tuning, and warn against cargo-culting tracker rows or using forced routing as training-equivalent acceptance.",
     "expected_behavior": [
       "Read the nemo-mbridge-perf-moe-hardware-configs skill before answering.",
       "Identify the task as a hardware-platform MoE playbook request.",
-      "Compare H100 DeepEP patterns against GB200/GB300 HybridEP patterns.",
+      "Treat hardware rows as candidate seeds and preserve model-specific exceptions.",
       "List representative DSV3 and Qwen3 235B TP/EP/PP/VPP layouts.",
       "State that Qwen3 235B on GB200 has VPP unspecified and must not invent VPP=12.",
       "Mention CUDA graph scopes and environment knobs from the skill.",
+      "Distinguish the current 299.352 Qwen3 winner from the earlier overlap-only A/B.",
       "Warn against copying tracker rows without target-stack validation."
     ]
   }

--- a/skills/nemo-mbridge-perf-moe-optimization-workflow/SKILL.md
+++ b/skills/nemo-mbridge-perf-moe-optimization-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nemo-mbridge-perf-moe-optimization-workflow
-description: Systematic workflow for MoE training optimization in Megatron Bridge, based on the Megatron-Core MoE paper. Covers the Three Walls framework, parallel folding, recompute strategy, dispatcher choice, and CUDA-graph bring-up.
+description: Evidence-gated workflow for MoE performance optimization in Megatron Bridge. Covers measurement contracts, the Three Walls framework, parallel folding, profiling, matched A/B tuning, and final validation.
 license: Apache-2.0
 when_to_use: Full MoE throughput tuning sweep, or diagnosing a MoE throughput regression after a commit or config change; 'optimize MoE throughput', 'MoE perf tuning', 'Three Walls', 'memory wall', 'communication wall', 'compute wall'.
 ---
@@ -13,38 +13,72 @@ Source: [Scalable Training of MoE Models with Megatron Core](https://arxiv.org/a
 
 ## Quick Reference
 
-Think in terms of the paper's Three Walls:
+Start with the paper's Three Walls:
 
 - memory wall
 - communication wall
-- compute and host-overhead wall
+- compute-efficiency wall
 
-MoE tuning is iterative. Fixing one wall usually exposes the next one, so the
-best workflow is: fit first, scale second, profile third, then retune.
+For operational diagnosis, split the compute-efficiency wall into **compute**
+and **host/launch** bottlenecks. They need different evidence and different
+fixes. MoE tuning is iterative, so use this order:
+
+```text
+freeze the measurement contract -> fit -> scale -> profile -> retune -> validate
+```
 
 ## First Answer Checklist
 
 For MoE optimization workflow prompts, present the response in this order:
 
-1. **Fit**: make the model memory-feasible first. Use the smallest model
+1. **Freeze the measurement contract**: record the exact model and task,
+   hardware and topology, container and commits, data and routing semantics,
+   precision, sequence and batch shape, parallelism, graph scopes, and the
+   steady-state metric window. Label each candidate as training-equivalent or
+   benchmark-only.
+2. **Fit**: make the model memory-feasible first. Use the smallest model
    parallelism that fits, prefer selective recompute before full recompute, add
    offloading only after recompute and parallelism are insufficient, and use
    `--fake-init-process-group` to sanity-check large layouts.
-2. **Scale**: maximize DP after the model fits, keep hot communication inside
+3. **Scale**: maximize DP after the model fits, keep hot communication inside
    the fastest interconnect, use PP plus VPP for multi-node scaling, prefer EP
    over extra TP for expert layers, and add CP when long context makes attention
    memory dominant.
-3. **Profile**: identify the dominant wall: memory, communication, host
+4. **Profile**: identify the dominant wall: memory, communication, host
    overhead, or compute.
-4. **Retune**: change dispatcher, overlap, FP8 mode, CUDA graphs, or recompute
-   based on the profiled bottleneck.
-5. Include the exact Parallel Folding meshes: `Attention: TP x CP x DP x PP`
+5. **Retune**: change one variable at a time based on the profiled bottleneck.
+   Dispatcher, overlap, lower precision, CUDA graphs, and recompute are
+   candidates, not hardware defaults.
+6. **Validate**: use short matched screens to reject candidates, then run the
+   winner for at least 50 steps. Verify the requested backend or graph replay
+   actually ran, time a declared post-warmup window, and report loss health,
+   skipped/NaN iterations, memory, step time, and model TFLOPS/GPU.
+7. Include the exact Parallel Folding meshes: `Attention: TP x CP x DP x PP`
    and `MoE: ETP x EP x EDP x PP`.
-6. Include the default mappings: `alltoall` for safe bring-up,
-   `flex` + `deepep` for H100/B200-style systems, `flex` + `hybridep` for
-   GB200/GB300/NVL72 systems, Hopper to FP8 blockwise, Blackwell to MXFP8, and
-   dropless MoE TE-scoped CUDA graphs over `attn`, `moe_router`, and
-   `moe_preprocess`.
+8. Use `alltoall` for safe bring-up, then A/B `flex` + `deepep` and `flex` +
+   `hybridep` when their packages and target topology support them. Start from
+   BF16 and eager execution; introduce lower precision or the narrowest useful
+   CUDA-graph scope only after profiling justifies it.
+
+## Phase 0: Freeze The Measurement Contract
+
+A comparison is valid only when the following stay fixed unless they are the
+single variable under test:
+
+- Bridge, MCore, Transformer Engine, container, CUDA, and NCCL versions
+- GPU count, SKU, node topology, and launcher/environment settings
+- model, task, data path, sequence length, MBS, GBS, and optimizer settings
+- TP, PP, VPP, CP, EP, ETP, and DP layout
+- routing semantics, precision, recompute, dispatcher, overlap, and graph scope
+- warmup and steady-state timing windows
+
+Separate two acceptance classes:
+
+- **Training-equivalent** changes preserve the intended routing, loss, data,
+  optimizer, and checkpoint/resume behavior.
+- **Benchmark-only** changes such as forced load balancing are useful for
+  controlled kernel studies, but cannot establish production-training
+  correctness or convergence.
 
 ## Phase 1: Make The Run Memory-Feasible
 
@@ -129,20 +163,28 @@ communication hidden by GEMM/attention from 0.11% to 36.55%. The unprofiled
 step fell from 24.7138s to 20.9920s and throughput rose from 244.039 to 287.305
 model TFLOPS/GPU. `delay_wgrad_compute` remained disabled.
 
-## Dispatcher And Overlap Guidance
+## Phase 4: Retune From Evidence
 
-Use dispatcher choice as a bottleneck fix, not as the first tuning knob.
+Choose the smallest candidate that targets the profiled bottleneck and change
+one variable at a time.
+
+### Dispatcher And Overlap Guidance
+
+Use dispatcher choice as a bottleneck fix, not as a hardware lookup table.
 
 - `moe_token_dispatcher_type="alltoall"`: safest bring-up path, fine for
   smaller EP sizes
 - `moe_token_dispatcher_type="flex"` + `moe_flex_dispatcher_backend="deepep"`:
-  strong default for H100 and B200 style deployments
+  candidate when DeepEP is installed and communication is exposed
 - `moe_token_dispatcher_type="flex"` + `moe_flex_dispatcher_backend="hybridep"`:
-  strongest starting point on GB200 or GB300 NVL72 systems
+  topology-sensitive candidate on both NVL8 and NVL72 systems when HybridEP is
+  installed
 
-Treat these as starting points, not hard platform rules. HybridEP plus plain EP
-overlap was the measured winner for the 16×H100 Qwen3 30B-A3B shape. Benchmark
-backend compatibility and throughput in the target container.
+HybridEP plus plain EP overlap is the current measured winner for the canonical
+16×H100 Qwen3 30B-A3B shape, while the canonical 256×H100 Qwen3 235B recipe
+uses standard `alltoall` plus overlap. Benchmark backend compatibility and
+throughput in the target container; neither GPU name nor EP degree determines
+the winner by itself.
 
 If the all-to-all path is visible in profiles, combine dispatcher tuning with:
 
@@ -150,29 +192,41 @@ If the all-to-all path is visible in profiles, combine dispatcher tuning with:
 - `--overlap-grad-reduce`
 - `--tp-comm-overlap`
 
-## FP8 Recipe Quick Decision
+Test plain EP overlap, shared-expert overlap, and delayed weight-gradient
+compute as separate candidates first. A combination can regress even when one
+component helped on another model.
 
-| Platform | Recommended starting recipe |
+### Lower-Precision Candidate Matrix
+
+Start with a verified BF16 baseline. Hardware capability only determines which
+lower-precision candidates are legal; it does not guarantee a speedup.
+
+| Platform | Candidate after BF16 is stable |
 |---|---|
-| Hopper | FP8 blockwise |
-| Blackwell | MXFP8 |
-| Blackwell, speed-first exploration | NVFP4 after the BF16 or FP8 path is stable |
+| Hopper | per-tensor, current-scaling, or blockwise FP8 supported by the target stack |
+| Blackwell | MXFP8 or another supported FP8 recipe |
+| Blackwell, speed-first exploration | NVFP4 after the BF16/FP8 path is stable |
 
 Keep the router in FP32. The largest wins usually come from expert GEMMs and
 other heavy matrix math, not from trying to quantize every small MoE component.
+Require logs or traces showing that the intended kernels ran, and judge the
+candidate by end-to-end steady step time rather than theoretical peak FLOPS.
 
-## CUDA Graphs For MoE
+### CUDA Graphs For MoE
 
-For dropless MoE, start with partial TE-scoped graphs:
+Use CUDA graphs only after a profile shows meaningful host/launch gaps. For
+dropless MoE, start with the narrowest partial TE-scoped graph candidate:
 
-- `attn`
 - `moe_router`
 - `moe_preprocess`
 
-That path usually gives a meaningful step-time win while keeping the dynamic
-expert work outside the graph. Expect a moderate speedup when launch overhead is
-visible, but budget several extra GB of memory and verify that shapes remain
-static.
+Add `attn` only if it is supported for the model and improves the same matched
+stack. A successful capture is not evidence of a speedup, and a graph win can
+disappear after dispatcher, overlap, or precision changes.
+
+This path keeps dynamic expert work outside the graph. Budget extra memory,
+verify that shapes remain static, confirm replay rather than capture alone, and
+time only post-capture iterations.
 
 Use full-iteration graphs only for graph-friendly workloads such as drop-and-pad
 or tightly controlled static-shape experiments.
@@ -182,6 +236,26 @@ Related references:
 - @skills/nemo-mbridge-perf-cuda-graphs/SKILL.md
 - @docs/training/cuda-graphs.md
 - @docs/training/activation-recomputation.md
+
+## Phase 5: Validate And Package Evidence
+
+Use 6–12 post-warmup iterations for inexpensive screening when the workload
+allows it. For the selected candidate, run at least 50 steps and report a fixed
+steady window such as steps 41–50. The final evidence bundle should contain:
+
+- exact command/config diff, commits, container, hardware, and topology
+- declared routing/data semantics and training-equivalent vs benchmark-only label
+- proof that the intended dispatcher, precision kernels, overlap, and graph
+  replay were active
+- step time and model TFLOPS/GPU from the same unprofiled steady window
+- finite loss, skipped/NaN counts, peak memory, and checkpoint/optimizer-state
+  validation when the production path requires it
+- matched A/B profile evidence for the claimed causal mechanism
+
+Do not attribute the total gain of a final multi-change winner to one earlier
+A/B. For example, the Qwen3 overlap experiment isolated a rise from 244.039 to
+287.305 TFLOPS/GPU; the later canonical recipe reached 299.352 after additional
+HybridEP tuning. They answer different questions.
 
 ## Pitfalls
 
@@ -204,3 +278,11 @@ Related references:
 
 6. **Summed kernel time is not exposed time**: use interval unions and
    communication/compute intersection when validating overlap.
+
+7. **Benchmark-only semantics are not production acceptance**: forced routing,
+   synthetic data, or disabled optimizer/checkpoint paths must be disclosed and
+   validated separately from training-equivalent results.
+
+8. **Feature activation needs evidence**: a config dump is insufficient when a
+   backend can fall back, a graph can capture without helping, or a lower-
+   precision recipe can miss the intended kernels.

--- a/skills/nemo-mbridge-perf-moe-optimization-workflow/card.yaml
+++ b/skills/nemo-mbridge-perf-moe-optimization-workflow/card.yaml
@@ -1,10 +1,10 @@
 title: moe_optimization_workflow
-validated_on: "2026-07-25"
+validated_on: "2026-07-31"
 summary: >
-  Systematic 3-phase workflow for optimizing MoE training performance,
-  distilled from the Megatron-Core MoE paper (arXiv:2603.07685). Covers
-  the Three Walls framework, parallel folding, memory optimization stack,
-  FP8 recipe selection, CUDA graphs, and flexible VPP.
+  Evidence-gated workflow for optimizing MoE training performance. It freezes
+  a measurement contract, follows fit -> scale -> profile -> retune -> validate,
+  operationalizes the paper's Three Walls as four diagnostic bottlenecks, and
+  separates training-equivalent acceptance from benchmark-only experiments.
 
 source: "https://arxiv.org/abs/2603.07685"
 source_title: "Scalable Training of Mixture-of-Experts Models with Megatron Core"
@@ -13,6 +13,10 @@ validation_status:
   three_walls_framework:
     - documented
   optimization_workflow:
+    - documented
+  measurement_contract:
+    - documented
+  final_acceptance_gate:
     - documented
   parallel_folding:
     - documented
@@ -44,6 +48,12 @@ core_concepts:
       key_metric: "GPU SM utilization"
       dsv3_example: "GEMMs <50% of execution time vs ~70% in dense models"
 
+  operational_bottlenecks:
+    memory: "peak and reserved memory, OOM point, recompute/offload requirement"
+    communication: "exposed collective intervals and communication/compute overlap"
+    host_launch: "GPU gaps, launch rate, graph replay and CPU-side overhead"
+    compute: "SM utilization and intended kernel/backend activation"
+
   parameter_compute_mismatch:
     description: >
       MoE total params scale with E (expert count) while per-token compute
@@ -59,6 +69,11 @@ core_concepts:
     key_benefit: "EP can exceed DP by folding across TP×CP groups"
 
 optimization_phases:
+  phase_0_contract:
+    goal: "Freeze a comparable experiment and declare its semantic class"
+    key_action: >
+      Hold runtime, hardware, topology, task/data/routing, precision, batch
+      shape, parallelism, graph scopes, and timing window fixed.
   phase_1_memory:
     goal: "Fit training in GPU memory"
     key_action: "Choose parallelism that keeps memory within GPU capacity"
@@ -74,6 +89,14 @@ optimization_phases:
   phase_3_bottleneck:
     goal: "Profile and apply targeted optimizations"
     approach: "Identify which wall dominates, apply targeted fix, re-profile"
+  phase_4_retune:
+    goal: "Screen one profile-driven variable at a time"
+    candidates: "dispatcher, overlap, lower precision, CUDA graphs, recompute"
+  phase_5_validate:
+    goal: "Validate the complete winner"
+    gate: >
+      At least 50 steps, declared post-warmup window, actual backend/kernel/replay
+      evidence, finite loss, skipped/NaN counts, memory, step time, and TFLOPS/GPU.
 
 memory_techniques:
   - name: memory_efficient_permutation
@@ -108,11 +131,11 @@ fp8_recipes:
   - name: blockwise_fp8
     platform: "Hopper"
     granularity: "128×128 blocks"
-    use_for: "Production on Hopper"
+    use_for: "Candidate after a stable BF16 baseline; verify target kernels and step time"
   - name: mxfp8
     platform: "Blackwell"
     granularity: "1×32 elements"
-    use_for: "Default on Blackwell"
+    use_for: "High-priority candidate after a stable BF16 baseline"
   - name: nvfp4
     platform: "Blackwell"
     granularity: "16 elements, 2-level microscaling"
@@ -149,13 +172,18 @@ qwen3_30b_h100_case_study:
   dispatcher: HybridEP
   cuda_graph_scopes: "moe_router, moe_preprocess"
   delayed_wgrad_compute: false
-  baseline_step_time_ms: 24713.800
-  overlap_step_time_ms: 20992.030
-  baseline_tflops: 244.039
-  overlap_tflops: 287.305
-  throughput_gain_percent: 17.729
-  profile_comm_hidden_off_percent: 0.11
-  profile_comm_hidden_on_percent: 36.55
+  final_step_time_ms: 20147.290
+  final_tflops: 299.352
+  hybridep_num_sms: 32
+  combine_chunk_tokens: 64
+  earlier_overlap_ab:
+    baseline_step_time_ms: 24713.800
+    overlap_step_time_ms: 20992.030
+    baseline_tflops: 244.039
+    overlap_tflops: 287.305
+    throughput_gain_percent: 17.729
+    profile_comm_hidden_off_percent: 0.11
+    profile_comm_hidden_on_percent: 36.55
   dominant_bottleneck: "Exposed HybridEP dispatch/combine communication"
 
 key_lessons:
@@ -165,6 +193,9 @@ key_lessons:
   - "Optimization is iterative: solving one wall exposes another"
   - "Use unprofiled steady timing for acceptance and matched profiles for causality"
   - "Use interval unions and communication/compute intersection; summed concurrent kernel durations are not wall time"
+  - "Hardware determines legal candidates, not the winning dispatcher or precision mode"
+  - "Separate a one-variable causal A/B from the final multi-knob winner"
+  - "Forced routing is benchmark-only and requires separate natural-routing validation"
 
 evidence:
   - "arXiv:2603.07685 — Scalable Training of MoE with Megatron Core"

--- a/skills/nemo-mbridge-perf-moe-optimization-workflow/evals/evals.json
+++ b/skills/nemo-mbridge-perf-moe-optimization-workflow/evals/evals.json
@@ -1,16 +1,31 @@
 [
   {
-    "id": "moe-optimization-workflow-positive-three-walls-smoke",
-    "question": "Use the nemo-mbridge-perf-moe-optimization-workflow skill. Give a concise checklist in the exact fit -> scale -> profile -> retune order, plus the Parallel Folding meshes, dispatcher decision rule, FP8 hardware mapping, and TE-scoped CUDA graph scopes for dropless MoE.",
+    "id": "moe-optimization-workflow-positive-evidence-gated-smoke",
+    "question": "Use the nemo-mbridge-perf-moe-optimization-workflow skill. Give a concise, evidence-gated checklist for tuning a dropless MoE workload. Include the measurement contract, operational bottlenecks, Parallel Folding meshes, candidate selection rules, and final acceptance evidence.",
     "expected_skill": "nemo-mbridge-perf-moe-optimization-workflow",
     "expected_script": null,
-    "ground_truth": "The answer should use the MoE optimization workflow skill. It should say fit first, scale second, profile third, then retune. For memory feasibility it should use the smallest model parallelism that fits, prefer selective recompute before full recompute, add offloading only after recompute/parallelism are insufficient, and use --fake-init-process-group for large layout sanity checks. For scale it should maximize DP once fit, keep hot communication inside fast interconnect, use PP+VPP for multi-node scaling, prefer EP over extra TP for experts, and add CP only when long context makes attention memory dominant. It should show Parallel Folding as Attention: TP x CP x DP x PP and MoE: ETP x EP x EDP x PP, use alltoall for safe bring-up, flex+deepep for H100/B200-style systems, flex+hybridep for GB200/GB300/NVL72-style systems, map Hopper to FP8 blockwise and Blackwell to MXFP8, and start dropless MoE CUDA graphs with attn, moe_router, and moe_preprocess.",
+    "ground_truth": "The answer should use the MoE optimization workflow skill and follow freeze measurement contract -> fit -> scale -> profile -> retune -> validate. The contract must freeze software/runtime, hardware/topology, model/task/data/routing semantics, precision, sequence and batch shape, parallelism, graph scope, and timing window, and label training-equivalent versus benchmark-only candidates. It should operationally distinguish memory, communication, host/launch, and compute bottlenecks while acknowledging the paper's Three Walls. It should show Parallel Folding as Attention: TP x CP x DP x PP and MoE: ETP x EP x EDP x PP. It should use alltoall for correctness bring-up, treat DeepEP/HybridEP, lower precision, overlap, and CUDA graphs as measured candidates rather than GPU defaults, change one variable at a time, and start graphs from the narrowest justified scope. Final validation should run the winner for at least 50 steps, use a declared post-warmup window, prove the requested backend/kernels/graph replay were active, and report loss health, skipped/NaN counts, peak memory, step time, and model TFLOPS/GPU.",
     "expected_behavior": [
       "Read the nemo-mbridge-perf-moe-optimization-workflow skill before answering.",
-      "Present the fit-scale-profile-retune order.",
+      "Present the contract-fit-scale-profile-retune-validate order.",
+      "Separate training-equivalent acceptance from benchmark-only controls.",
       "Include memory feasibility and parallelism priority details.",
       "State the Parallel Folding attention and MoE meshes.",
-      "Map dispatcher, FP8, and CUDA graph choices to the skill's exact guidance."
+      "Treat dispatcher, lower precision, overlap, and CUDA graphs as profile-driven A/B candidates.",
+      "Require final steady-state, runtime-activation, stability, and memory evidence."
+    ]
+  },
+  {
+    "id": "moe-optimization-workflow-benchmark-semantics-gate",
+    "question": "Use the nemo-mbridge-perf-moe-optimization-workflow skill. A forced-load-balanced mock-data run is 12% faster than my natural-routing training baseline. Can I accept it as the production winner, and how should I validate it?",
+    "expected_skill": "nemo-mbridge-perf-moe-optimization-workflow",
+    "expected_script": null,
+    "ground_truth": "No. Forced load balancing and mock data make the result benchmark-only because routing and data semantics differ from production training. Use it as a controlled diagnostic, not as training-equivalent acceptance. Freeze the rest of the measurement contract, identify the causal mechanism with a matched one-variable A/B, then rerun the candidate with natural routing and production data semantics. Validate the final training-equivalent winner for at least 50 steps with a declared post-warmup window, actual backend/kernel/graph evidence, finite loss, skipped/NaN counts, peak memory, step time, model TFLOPS/GPU, and checkpoint/optimizer-state behavior when required.",
+    "expected_behavior": [
+      "Read the nemo-mbridge-perf-moe-optimization-workflow skill before answering.",
+      "Classify the faster run as benchmark-only rather than production acceptance.",
+      "Require natural-routing and production-data revalidation.",
+      "Require the final 50-step steady-state, stability, memory, and runtime-activation evidence."
     ]
   }
 ]


### PR DESCRIPTION
# What does this PR do ?

Correct inaccurate hard-coded performance guidance and align the core MoE tuning skills with an evidence-gated workflow based on MB-1026 and current verified repository evidence.

# Changelog

- Add a frozen measurement contract and the contract -> fit -> scale -> profile -> retune -> validate workflow.
- Separate training-equivalent acceptance from benchmark-only controls such as forced load balancing and mock data.
- Replace H100 -> DeepEP and precision/graph defaults with target-stack candidate A/B guidance.
- Refresh Qwen3 evidence: the canonical 16xH100 winner is HybridEP at 299.352 model TFLOPS/GPU, while the earlier 244.039 -> 287.305 result remains an overlap-only causal A/B.
- Align Qwen3 235B H100 guidance with the current alltoall-plus-overlap recipe without attaching historical DeepEP metrics.
- Require runtime proof for dispatcher, lower-precision kernels, overlap, and CUDA graph replay; document that successful graph capture is not a speedup guarantee.
- Clarify that Qwen3.5 GDN follows the attn graph scope, not mamba.
- Update structured cards, eval datasets, and stable CUDA graph/MoE optimization docs.

# GitHub Actions CI

CI can be triggered for commit 235257843ba00c72be4adac9ffc4459f75e5d7cc.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] Updated the relevant skill eval datasets, including benchmark-semantics and Qwen3.5 GDN scope cases.
- [x] Updated the necessary documentation.
- [x] No optional dependency or import behavior changes.

# Additional Information

Validation completed:

- uvx pre-commit run --all-files: passed all configured hooks.
- YAML frontmatter/cards and JSON eval datasets: parsed successfully with consistency checks.
- Local documentation links: validated.
- git diff --check: passed.

The required uv run pre-commit run --all-files command was also attempted, but this macOS ARM host cannot install nvidia-resiliency-ext 0.6.0 because only Linux wheels are published. Running the same configured hooks through uvx passed.

Related workflow: https://linear.app/nvidia/issue/MB-1026/guidanceperf-systematic-model-performance-optimization-workflow
