### PR TITLE
feat(data): add indexed storage for packed SFT

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -78,6 +78,7 @@ training/cpu-offloading.md
 training/moe-optimization.md
 training/peft.md
 training/packed-sequences.md
+training/packed-sft-indexed-dataset.md
 training/multi-token-prediction.md
 training/callbacks.md
 ```

--- a/docs/training/README.md
+++ b/docs/training/README.md
@@ -33,6 +33,7 @@ This directory contains comprehensive documentation for training and customizing
 | **[Configuration Container Overview](config-container-overview.md)** | Central configuration object for all training settings | First time setting up training |
 | **[Entry Points](entry-points.md)** | Training entry points and execution flow | Understanding how training starts |
 | **[Data Preparation](data-preparation.md)** | Dataset formats for pretraining, SFT, PEFT, and VLM fine-tuning | Preparing data or choosing dataset config fields |
+| **[Packed SFT Indexed Dataset](packed-sft-indexed-dataset.md)** | Prepare and consume `.sft.bin/.sft.idx` data | Moving packed SFT from Parquet to MCore indexed storage |
 | **[Training Loop Settings](training-loop-settings.md)** | Training loop parameters and configuration | Configuring batch sizes, iterations, validation |
 
 ### Optimization and Performance

--- a/docs/training/data-preparation.md
+++ b/docs/training/data-preparation.md
@@ -8,8 +8,7 @@ Megatron Bridge uses different dataset config objects for pretraining, text fine
 |----------|--------|-------------|--------------------|
 | LLM pretraining | Recommended | Megatron binary `.bin`/`.idx` prefixes | `GPTDatasetConfig` |
 | Text SFT or PEFT, processed at runtime | Recommended | Hosted Hugging Face rows or local JSON/JSONL loaded through Hugging Face datasets | [Hugging Face text-only](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/tutorials/data/hf-text-only/README.md) through `DirectHFSFTDatasetConfig` + builder |
-| Text SFT or PEFT, prepared data | Planned; not available yet | Pretokenized `.bin`/`.idx` | Future Issue #4664 prepared-SFT builder |
-| Text SFT or PEFT, transitional prepared data | Supported until `.bin`/`.idx` replacement | Local/materialized JSONL and optional packed Parquet | `GPTSFTDatasetConfig` |
+| Text SFT or PEFT, prepared data | Recommended | Offline-packed `.sft.bin`/`.sft.idx`; packed Parquet for compatibility | [`GPTSFTDatasetConfig`](packed-sft-indexed-dataset.md) |
 | Multimodal SFT or PEFT | Recommended | Hosted Hugging Face rows or local conversation JSON/JSONL | [Hugging Face multimodal](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/tutorials/data/hf-multimodal/README.md) through `DirectHFSFTDatasetConfig` + builder |
 | Large sharded multimodal training | Recommended | WebDataset/Energon | [Multimodal Energon](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/tutorials/data/energon/README.md) through `EnergonDatasetConfig` + builder |
 
@@ -102,6 +101,8 @@ uv run python -m torch.distributed.run --nproc_per_node=1 scripts/training/run_r
 For PEFT, use the PEFT recipe or set `cfg.peft`; the data layout stays the same. `checkpoint.pretrained_checkpoint` is required for the frozen base model, and `checkpoint.load` is used only when resuming adapter checkpoints.
 
 For preparation schemas, offline packing, finite epochs, and a complete knob reference, see the [text-only SFT dataset tutorial](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/tutorials/data/text-only-sft/README.md).
+For the prepared `.bin/.idx` workflow and Parquet migration checks, see the
+[packed SFT indexed dataset tutorial](packed-sft-indexed-dataset.md).
 
 ## Hugging Face Datasets for SFT and PEFT
 

--- a/docs/training/packed-sequences.md
+++ b/docs/training/packed-sequences.md
@@ -31,11 +31,15 @@ primarily addresses activation memory and communication tradeoffs at larger
 sequence lengths.
 
 The shared implementation lives under `megatron.bridge.data.packing`: offline
-GPT SFT materialization, packed Parquet runtime datasets, bin-packing
-algorithms, and collate-time THD packing each have separate modules. Ordinary
+GPT SFT materialization, indexed and compatibility Parquet runtime datasets,
+bin-packing algorithms, and collate-time THD packing each have separate modules. Ordinary
 non-packed padding remains in `megatron.bridge.data.collators`. Use
 `scripts/training/prepare_gpt_sft_packed_data.py` when packed GPT SFT artifacts
 should be prepared before launching training.
+
+New offline-packed data uses MCore `.bin/.idx` pairs by default. See the
+[packed SFT indexed dataset tutorial](packed-sft-indexed-dataset.md) for
+preparation, configuration, migration, and Parquet parity checks.
 
 ## When to Use It
 
@@ -118,6 +122,7 @@ The durable constraints for packed sequences in Bridge are:
   pads only to the group-wide aligned maximum before dispatch and trims the
   padding after combine
 - CUDA-graph-friendly packed metadata requires additional padding constraints
+- offline packed SFT is not compatible with Multi-Token Prediction
 
 Model-family support is not universal. Some families and recipe paths explicitly
 opt out of packed sequences or related packing modes.
@@ -158,6 +163,7 @@ The most stable caveats to remember are:
 
 ## Related Docs
 
+- [Packed SFT Indexed Dataset Tutorial](packed-sft-indexed-dataset.md)
 - [docs/training/multi-token-prediction.md](multi-token-prediction.md)
 - [docs/performance-guide.md](../performance-guide.md)
 - [docs/training/hierarchical-context-parallel.md](hierarchical-context-parallel.md)

--- a/docs/training/packed-sft-indexed-dataset.md
+++ b/docs/training/packed-sft-indexed-dataset.md
@@ -103,6 +103,43 @@ A prefix, either pair filename, a glob, or a directory of canonical
 `*.sft.bin/*.sft.idx` pairs is accepted. Directory and glob inputs are read in
 sorted shard order. Every pair must be complete.
 
+For `msc://` prefixes, MCore streams `.bin` ranges and caches each `.idx`
+locally. Bridge enables MCore's Multi-Storage Client integration when it sees
+the prefix; this only toggles MCore's feature flag. Before launch, install and
+configure the storage provider and named profile according to the
+[Multi-Storage Client configuration guide](https://nvidia.github.io/multi-storage-client/). Bridge does not create
+profiles or credentials. It uses
+`$NEMO_DATASETS_CACHE/packed_sft_index_cache` (or the corresponding default
+NeMo cache) unless an explicit cache is configured. In multi-node jobs the
+cache path must be visible to every rank:
+
+```python
+offline_packing_specs=PackedSequenceSpecs(
+    packed_sequence_size=4096,
+    packed_train_data_path="msc://profile/sft/training_4096.sft",
+    packed_val_data_path="msc://profile/sft/validation_4096.sft",
+    object_storage_cache_path="/shared/cache/packed-sft-indices",
+    # MCore defaults to 256 MiB range-read chunks; tune only after measuring.
+    object_storage_bin_chunk_nbytes=256 * 1024 * 1024,
+)
+```
+
+The canonical builder downloads remote indices on rank zero before its
+distributed barrier and automatically disables mmap for remote `.bin` files.
+Remote artifacts are read-only: prepare the pair locally, then upload both
+files before constructing the recipe. For example:
+
+```python
+import multistorageclient as msc
+
+msc.upload_file("msc://profile/sft/training_4096.sft.bin", "/data/packed/training_4096.sft.bin")
+msc.upload_file("msc://profile/sft/training_4096.sft.idx", "/data/packed/training_4096.sft.idx")
+```
+
+Do not upload `.idx` until `.bin` has completed. Direct packing or rewriting to
+an object-storage prefix is rejected because a two-object replacement cannot
+provide the local pair's reader/writer atomicity.
+
 ## Launch Training
 
 The normal recipe launcher consumes the indexed pair through the configured
@@ -147,12 +184,20 @@ throughput on the target filesystem before making capacity decisions.
 Each IndexedDataset item is one complete packed row. Its int32 payload contains
 a versioned header, the sequence start offsets, and one word per token. The
 lower 31 bits store the token ID and the high bit stores the binary loss mask.
-The reader validates the magic value, version, mask, token range, and strictly
-increasing boundaries before constructing a training sample.
+The writer validates mask and token ranges. The reader validates the magic
+value, version, row dimensions, and strictly increasing boundaries before
+constructing a training sample.
+
+Writers validate every row under the versioned schema, build a temporary pair,
+take an exclusive filesystem lock, and publish `.idx` last as the completion
+point. Local readers take the shared side of that lock while opening both files.
+If either publication step raises, the writer restores the previous pair. The
+internal `.sft.lock` sidecar intentionally remains for later readers and
+writers.
 
 This is a packed-SFT schema, not an ordinary pretraining token stream. Both use
-the MCore `.bin/.idx` container and mmap reader, but their payloads are not
-interchangeable.
+the MCore `.bin/.idx` container; local data uses mmap and remote data uses range
+reads. Their payloads are not interchangeable.
 
 ## Compatibility Notes
 

--- a/docs/training/packed-sft-indexed-dataset.md
+++ b/docs/training/packed-sft-indexed-dataset.md
@@ -1,0 +1,163 @@
+# Packed SFT Indexed Dataset Tutorial
+
+Megatron Bridge stores offline-packed text SFT and PEFT data in Megatron
+Core's binary indexed format by default. One logical prefix produces a pair of
+files:
+
+```text
+/data/packed/training_4096.sft.bin
+/data/packed/training_4096.sft.idx
+```
+
+Pass `/data/packed/training_4096.sft` to Bridge, without the final `.bin` or
+`.idx`. This gives pretraining and prepared SFT the same file-container model,
+while the packed SFT payload keeps the additional loss-mask and sequence-boundary
+information required for supervised training.
+
+This format applies to text-only offline packing. Direct Hugging Face and VLM
+in-batch packing use a different runtime path.
+
+## Configure Offline Packing
+
+Use `GPTSFTDatasetConfig` with `PackedSequenceSpecs`. The builder materializes
+the indexed pair on rank zero the first time it is needed, then reuses it on
+later launches.
+
+```python
+from megatron.bridge.data.builders import (
+    GPTSFTDatasetConfig,
+    HFDatasetSourceConfig,
+    PromptCompletionSFTPreprocessingConfig,
+)
+from megatron.bridge.data.packing import PackedSequenceSpecs
+
+dataset = GPTSFTDatasetConfig(
+    seq_length=4096,
+    hf_dataset=HFDatasetSourceConfig(dataset_name="squad"),
+    hf_validation_proportion=0.1,
+    do_test=False,
+    preprocessing=PromptCompletionSFTPreprocessingConfig(
+        separator=" ",
+        loss_mode="completion",
+    ),
+    enable_offline_packing=True,
+    offline_packing_specs=PackedSequenceSpecs(
+        packed_sequence_size=4096,
+        pad_seq_to_mult=1,
+    ),
+)
+```
+
+Builder-managed outputs live under a fingerprinted directory below the
+materialized dataset root:
+
+```text
+<dataset-root>/packed/<tokenizer-and-fingerprint>/training_4096.sft.bin
+<dataset-root>/packed/<tokenizer-and-fingerprint>/training_4096.sft.idx
+<dataset-root>/packed/<tokenizer-and-fingerprint>/validation_4096.sft.bin
+<dataset-root>/packed/<tokenizer-and-fingerprint>/validation_4096.sft.idx
+```
+
+The fingerprint protects against accidentally reusing data prepared with
+different tokenization, preprocessing, sequence length, or dataset options.
+Set `hf_rewrite=True` only when the builder should regenerate its managed
+JSONL and packed artifacts.
+
+## Prepare Data Before a Training Job
+
+For a recipe that already enables offline packing, prepare the data on a CPU
+node before reserving training GPUs:
+
+```bash
+uv run python scripts/training/prepare_gpt_sft_packed_data.py \
+    --recipe llama32_1b_sft_1gpu_h100_bf16_config \
+    --num-tokenizer-workers 8
+```
+
+To choose the artifact locations explicitly, provide a prefix rather than a
+file suffix:
+
+```bash
+uv run python scripts/training/prepare_gpt_sft_packed_data.py \
+    --recipe llama32_1b_sft_1gpu_h100_bf16_config \
+    --train-input-path /data/sft/training.jsonl \
+    --val-input-path /data/sft/validation.jsonl \
+    --packed-train-data-path /data/packed/training_4096.sft \
+    --packed-val-data-path /data/packed/validation_4096.sft \
+    --packed-metadata-path /data/packed/4096_metadata.json \
+    --num-tokenizer-workers 8
+```
+
+Reference prebuilt pairs from a dataset config after both files exist:
+
+```python
+offline_packing_specs=PackedSequenceSpecs(
+    packed_sequence_size=4096,
+    packed_train_data_path="/data/packed/training_4096.sft",
+    packed_val_data_path="/data/packed/validation_4096.sft",
+    packed_metadata_path="/data/packed/4096_metadata.json",
+)
+```
+
+A prefix, either pair filename, a glob, or a directory of canonical
+`*.sft.bin/*.sft.idx` pairs is accepted. Directory and glob inputs are read in
+sorted shard order. Every pair must be complete.
+
+## Launch Training
+
+The normal recipe launcher consumes the indexed pair through the configured
+`GPTSFTDatasetBuilder`; no storage-specific training flag is required:
+
+```bash
+uv run python -m torch.distributed.run --nproc_per_node=1 \
+    scripts/training/run_recipe.py \
+    --recipe llama32_1b_sft_1gpu_h100_bf16_config \
+    --mode sft \
+    checkpoint.pretrained_checkpoint=/checkpoints/llama32_1b
+```
+
+Offline packed SFT requires `micro_batch_size=1`. Keep `model.seq_length`,
+`dataset.seq_length`, and `packed_sequence_size` equal. If context parallelism
+is enabled, set `pad_seq_to_mult` to satisfy the training topology; the usual
+minimum is `2 * context_parallel_size`, combined with sequence-parallel
+alignment when applicable. Rebuild the packed pair whenever preprocessing,
+tokenizer, sequence length, or topology-derived alignment changes.
+
+## Validate Against Parquet
+
+Parquet remains available as an explicit compatibility format. Prepare the
+same input and configuration twice with the same seed: use a `.sft` output
+prefix for indexed data and an output ending in `.parquet` for the comparison
+copy. Then validate every row and measure sequential decode throughput:
+
+```bash
+uv run python scripts/training/compare_packed_sft_formats.py \
+    --parquet /data/packed/training_4096.idx.parquet \
+    --indexed /data/packed/training_4096.sft
+```
+
+Use `--max-rows N` for a quick sample. The command fails on any difference in
+`input_ids`, the target-aligned `loss_mask`, or `seq_start_id`, and reports row
+rate, token rate, elapsed time, and bytes on disk for each format. Read-rate
+results are microbenchmarks; validate end-to-end dataloader and training
+throughput on the target filesystem before making capacity decisions.
+
+## On-Disk Schema
+
+Each IndexedDataset item is one complete packed row. Its int32 payload contains
+a versioned header, the sequence start offsets, and one word per token. The
+lower 31 bits store the token ID and the high bit stores the binary loss mask.
+The reader validates the magic value, version, mask, token range, and strictly
+increasing boundaries before constructing a training sample.
+
+This is a packed-SFT schema, not an ordinary pretraining token stream. Both use
+the MCore `.bin/.idx` container and mmap reader, but their payloads are not
+interchangeable.
+
+## Compatibility Notes
+
+- Existing packed `.parquet` and deprecated `.npy` paths remain readable when
+  explicitly configured.
+- The default for newly prepared data is `.sft.bin/.sft.idx`.
+- Multi-Token Prediction is not supported with offline packed SFT.
+- VLM packing is unchanged and does not use this indexed schema.

--- a/docs/training/packed-sft-indexed-dataset.md
+++ b/docs/training/packed-sft-indexed-dataset.md
@@ -1,8 +1,12 @@
-# Packed SFT Indexed Dataset Tutorial
+# Packed SFT with MCore Indexed Datasets
 
-Megatron Bridge stores offline-packed text SFT and PEFT data in Megatron
-Core's binary indexed format by default. One logical prefix produces a pair of
-files:
+This tutorial covers the complete text-only offline-packed SFT and PEFT
+workflow: why the indexed format exists, how to prepare raw data, how to attach
+the resulting artifacts to a recipe, how to start training, and how to migrate
+from packed Parquet.
+
+Newly prepared packed SFT data uses Megatron Core's binary indexed container by
+default. One logical prefix produces two files:
 
 ```text
 /data/packed/training_4096.sft.bin
@@ -10,42 +14,293 @@ files:
 ```
 
 Pass `/data/packed/training_4096.sft` to Bridge, without the final `.bin` or
-`.idx`. This gives pretraining and prepared SFT the same file-container model,
-while the packed SFT payload keeps the additional loss-mask and sequence-boundary
-information required for supervised training.
+`.idx`. Packed Parquet remains readable when it is selected explicitly.
 
-This format applies to text-only offline packing. Direct Hugging Face and VLM
-in-batch packing use a different runtime path.
+## Background
 
-## Configure Offline Packing
+Fine-tuning examples are often much shorter than the model context length.
+Padding every example to that length wastes computation. Offline packing
+tokenizes the examples ahead of training and combines several examples into one
+row up to the selected packing capacity while preserving:
 
-Use `GPTSFTDatasetConfig` with `PackedSequenceSpecs`. The builder materializes
-the indexed pair on rank zero the first time it is needed, then reuses it on
-later launches.
+- the token IDs
+- the target-aligned loss mask, so prompt and padding tokens can be excluded
+- the start offset of every source sequence, so attention does not cross
+  example boundaries
 
-```python
-from megatron.bridge.data.builders import (
-    GPTSFTDatasetConfig,
-    HFDatasetSourceConfig,
-    PromptCompletionSFTPreprocessingConfig,
+Rows are padded to a fixed width only when the dataset or runtime configuration
+requires it, for example for a separately supported static-shape kernel path.
+
+The resulting data flow is:
+
+```text
+local JSONL or Hugging Face source
+  -> schema normalization
+  -> tokenization and loss-mask construction
+  -> offline bin packing
+  -> .sft.bin + .sft.idx + packing metadata
+  -> GPTSFTDatasetBuilder
+  -> packed THD training batch
+```
+
+Previously, prepared SFT rows were normally stored in Parquet while pretraining
+used MCore `.bin/.idx`. The indexed SFT format removes that storage-path split:
+both workflows now use MCore's indexed container, mmap-backed local reads, and
+the same object-storage reader infrastructure.
+
+The payloads are intentionally different and are not interchangeable:
+
+| Property | Pretraining indexed data | Packed SFT indexed data |
+| --- | --- | --- |
+| Typical prefix | `corpus_text_document` | `training_4096.sft` |
+| One item contains | A tokenized document or sentence | One complete packed SFT row |
+| Supervision metadata | Derived by the pretraining sampler | Encoded loss mask and sequence boundaries |
+| Bridge config | `GPTDatasetConfig` | `GPTSFTDatasetConfig` plus `PackedSequenceSpecs` |
+
+This tutorial applies to text-only offline packing. Direct Hugging Face and VLM
+in-batch packing are separate runtime paths and do not use this schema.
+
+## Choose a Workflow
+
+| Starting point | Recommended path |
+| --- | --- |
+| Trying the feature | Run the local JSONL end-to-end example below |
+| A recipe's built-in Hugging Face dataset | Run the preparation script with only `--recipe`, then launch the same recipe |
+| Custom local JSONL | Set `dataset_root`, preprocessing, and offline packing in `GPTSFTDatasetConfig` |
+| Prebuilt local shards | Set explicit packed prefixes in `PackedSequenceSpecs` |
+| Prebuilt object-storage shards | Upload complete local pairs and use `msc://` prefixes |
+| Existing packed Parquet | Keep it explicit during migration, regenerate indexed data from the same normalized input, and run the parity tool |
+
+## Prerequisites
+
+Run commands from the Megatron Bridge repository root in an environment created
+with `uv sync` or in the project container. The example uses the gated
+`meta-llama/Llama-3.2-1B` tokenizer and model configuration, so authenticate
+with Hugging Face before preparation if they are not already cached.
+
+SFT and PEFT also require base weights. `checkpoint.pretrained_checkpoint` may
+point to a native Megatron checkpoint or a local Hugging Face full-model
+directory. A remote Hugging Face model ID is not a checkpoint path. For a
+repeatable production setup, import it first:
+
+```bash
+./scripts/conversion/convert.sh import \
+    --hf-model meta-llama/Llama-3.2-1B \
+    --megatron-path /data/checkpoints/llama32_1b
+```
+
+Use `checkpoint.pretrained_checkpoint` to initialize a new fine-tuning run. Use
+`checkpoint.load` instead when resuming optimizer, scheduler, RNG, and dataloader
+state from a complete native training checkpoint. The shipped SFT recipes have
+a default `checkpoint.load` directory, so explicitly set it to `null`/`None`
+when the run must start from `pretrained_checkpoint` rather than resume an old
+run found in the working directory.
+
+## End-to-End Local Quickstart
+
+The tiny dataset in this section is only a plumbing smoke test. It is too small
+for meaningful model quality evaluation.
+
+### 1. Create and inspect raw JSONL
+
+Generate prompt-completion train, validation, and test files:
+
+```bash
+uv run python tutorials/data/text-only-sft/prepare_example_data.py \
+    --output-dir /tmp/bridge-text-only-sft
+```
+
+The packing path expects conventional split names:
+
+```text
+/tmp/bridge-text-only-sft/
+  training.jsonl
+  validation.jsonl
+  test.jsonl
+```
+
+Each line is one JSON object. The example uses `input` and `output`:
+
+```json
+{"input": "What is SFT?", "output": "Supervised fine-tuning."}
+```
+
+Validate the files before tokenization:
+
+```bash
+uv run python - <<'PY'
+import json
+import logging
+from pathlib import Path
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger(__name__)
+for path in sorted(Path("/tmp/bridge-text-only-sft").glob("*.jsonl")):
+    rows = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+    logger.info("%s: %d rows", path.name, len(rows))
+PY
+```
+
+For a production prompt-completion dataset, set the actual column names with
+`PromptCompletionSFTPreprocessingConfig`. For conversation data, store a
+`messages` list and select `ChatSFTPreprocessingConfig`; do not flatten a
+multi-turn conversation implicitly.
+
+### 2. Prepare `.sft.bin/.sft.idx`
+
+Prepare on a CPU node before reserving training GPUs. The named recipe supplies
+the tokenizer, prompt-completion schema, sequence length, padding settings, and
+random seed:
+
+```bash
+mkdir -p /tmp/bridge-packed-sft
+
+uv run python scripts/training/prepare_gpt_sft_packed_data.py \
+    --recipe llama32_1b_sft_1gpu_h100_bf16_config \
+    --train-input-path /tmp/bridge-text-only-sft/training.jsonl \
+    --val-input-path /tmp/bridge-text-only-sft/validation.jsonl \
+    --packed-train-data-path /tmp/bridge-packed-sft/training_4096.sft \
+    --packed-val-data-path /tmp/bridge-packed-sft/validation_4096.sft \
+    --packed-metadata-path /tmp/bridge-packed-sft/4096_metadata.json \
+    --num-tokenizer-workers 1
+```
+
+Increase `--num-tokenizer-workers` after the single-worker path succeeds. The
+explicit inputs must match the preprocessing schema of the selected recipe. If
+the columns, chat template, or loss policy differ, use the custom config path
+in [Integrate with a Python Recipe](#integrate-with-a-python-recipe) so
+preparation and training share one config definition.
+
+The command creates:
+
+```text
+/tmp/bridge-packed-sft/training_4096.sft.bin
+/tmp/bridge-packed-sft/training_4096.sft.idx
+/tmp/bridge-packed-sft/validation_4096.sft.bin
+/tmp/bridge-packed-sft/validation_4096.sft.idx
+/tmp/bridge-packed-sft/4096_metadata.json
+```
+
+`.idx` is the metadata and offset table for MCore's indexed reader; it is not a
+standalone dataset. The additional JSON file records packing statistics and is
+required when `pad_cu_seqlens=True`.
+
+### 3. Inspect the prepared rows
+
+Check that both members of every pair exist and decode the first row:
+
+```bash
+ls -lh /tmp/bridge-packed-sft
+
+uv run python - <<'PY'
+import logging
+
+from megatron.bridge.data.packing.indexed import PackedSFTIndexedDataset
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger(__name__)
+dataset = PackedSFTIndexedDataset("/tmp/bridge-packed-sft/training_4096.sft")
+sample = dataset[0]
+logger.info(
+    "rows=%d first_row_tokens=%d first_row_sequences=%d",
+    len(dataset),
+    len(sample["input_ids"]),
+    len(sample["seq_start_id"]),
 )
-from megatron.bridge.data.packing import PackedSequenceSpecs
+PY
+```
 
-dataset = GPTSFTDatasetConfig(
-    seq_length=4096,
-    hf_dataset=HFDatasetSourceConfig(dataset_name="squad"),
-    hf_validation_proportion=0.1,
-    do_test=False,
-    preprocessing=PromptCompletionSFTPreprocessingConfig(
-        separator=" ",
-        loss_mode="completion",
-    ),
-    enable_offline_packing=True,
-    offline_packing_specs=PackedSequenceSpecs(
-        packed_sequence_size=4096,
-        pad_seq_to_mult=1,
-    ),
-)
+This reader validates the SFT magic value, schema version, row dimensions, and
+increasing sequence boundaries. Token range and binary loss-mask validation
+happen when the row is encoded by the writer.
+
+### 4. Attach the exact pair to the recipe
+
+The recipe already enables offline packing. The following overrides replace its
+built-in SQuAD source with the local JSONL source and point it at the pair just
+prepared:
+
+```text
+dataset.hf_dataset=null
+dataset.hf_validation_proportion=null
+dataset.dataset_root=/tmp/bridge-text-only-sft
+dataset.offline_packing_specs.packed_train_data_path=/tmp/bridge-packed-sft/training_4096.sft
+dataset.offline_packing_specs.packed_val_data_path=/tmp/bridge-packed-sft/validation_4096.sft
+dataset.offline_packing_specs.packed_metadata_path=/tmp/bridge-packed-sft/4096_metadata.json
+dataset.do_test=false
+```
+
+Keeping these overrides together is important: the source schema used to
+prepare data and the packed prefixes consumed at training time must describe
+the same dataset. The public `local-jsonl` preset starts with unpacked local
+data; selecting it replaces the recipe's packed dataset object. The quickstart
+therefore keeps the recipe dataset and changes its source and artifact paths.
+
+### 5. Start a one-step training smoke
+
+Launch with one GPU and a real local base checkpoint:
+
+```bash
+uv run python -m torch.distributed.run --nproc_per_node=1 \
+    scripts/training/run_recipe.py \
+    --recipe llama32_1b_sft_1gpu_h100_bf16_config \
+    --mode sft \
+    --pretrained_checkpoint /data/checkpoints/llama32_1b \
+    --save_dir /tmp/bridge-packed-sft-checkpoints \
+    --max_steps 1 \
+    --global_batch_size 1 \
+    --micro_batch_size 1 \
+    dataset.hf_dataset=null \
+    dataset.hf_validation_proportion=null \
+    dataset.dataset_root=/tmp/bridge-text-only-sft \
+    dataset.offline_packing_specs.packed_train_data_path=/tmp/bridge-packed-sft/training_4096.sft \
+    dataset.offline_packing_specs.packed_val_data_path=/tmp/bridge-packed-sft/validation_4096.sft \
+    dataset.offline_packing_specs.packed_metadata_path=/tmp/bridge-packed-sft/4096_metadata.json \
+    dataset.do_test=false \
+    checkpoint.load=null
+```
+
+At startup, inspect the printed final configuration and confirm:
+
+- `dataset.enable_offline_packing` is `true`
+- the resolved train and validation prefixes are the expected `.sft` prefixes
+- `model.seq_length`, `dataset.seq_length`, and `packed_sequence_size` are all
+  `4096`
+- `train.micro_batch_size` is `1`
+- `checkpoint.pretrained_checkpoint` points to the intended base weights
+- `checkpoint.load` is `null` for a new fine-tuning run
+
+Because the pair already exists, rank zero logs that packed preparation is
+being skipped. Training then reads the local `.bin` with mmap and saves to the
+configured checkpoint directory.
+
+For LoRA or DoRA, select the corresponding PEFT recipe and mode, then apply the
+same dataset overrides. An indexed pair can be shared between full SFT and PEFT
+only when tokenizer, preprocessing, sequence length, seed, padding, and packing
+settings are identical.
+
+## Use a Recipe-Managed Hugging Face Source
+
+For a recipe that already enables offline packing, the shortest path is to let
+the builder materialize and cache its configured source. For example, the
+Llama 3.2 1B SFT recipe uses SQuAD:
+
+```bash
+uv run python scripts/training/prepare_gpt_sft_packed_data.py \
+    --recipe llama32_1b_sft_1gpu_h100_bf16_config \
+    --num-tokenizer-workers 8
+```
+
+Then launch the same recipe without replacing its dataset:
+
+```bash
+uv run python -m torch.distributed.run --nproc_per_node=1 \
+    scripts/training/run_recipe.py \
+    --recipe llama32_1b_sft_1gpu_h100_bf16_config \
+    --mode sft \
+    --pretrained_checkpoint /data/checkpoints/llama32_1b \
+    --save_dir /data/checkpoints/llama32_1b_sft \
+    checkpoint.load=null
 ```
 
 Builder-managed outputs live under a fingerprinted directory below the
@@ -56,153 +311,397 @@ materialized dataset root:
 <dataset-root>/packed/<tokenizer-and-fingerprint>/training_4096.sft.idx
 <dataset-root>/packed/<tokenizer-and-fingerprint>/validation_4096.sft.bin
 <dataset-root>/packed/<tokenizer-and-fingerprint>/validation_4096.sft.idx
+<dataset-root>/packed/<tokenizer-and-fingerprint>/4096_metadata.jsonl
 ```
 
-The fingerprint protects against accidentally reusing data prepared with
-different tokenization, preprocessing, sequence length, or dataset options.
-Set `hf_rewrite=True` only when the builder should regenerate its managed
-JSONL and packed artifacts.
+The fingerprint separates different tokenizers, preprocessing settings,
+sequence lengths, and dataset options. It does not hash the bytes of local
+JSONL files. When local source content changes, use a versioned dataset root or
+new explicit output prefixes. For a builder-managed Hugging Face source, set
+`hf_rewrite=True` only when normalized JSONL and packed outputs should be
+regenerated. It cannot be combined safely with explicit packed paths.
 
-## Prepare Data Before a Training Job
+For reproducibility, record the source revision or content hash, tokenizer
+revision, preprocessing and loss policy, seed, sequence length,
+`pad_seq_to_mult`, and Bridge commit with each packed dataset.
 
-For a recipe that already enables offline packing, prepare the data on a CPU
-node before reserving training GPUs:
+## Integrate with a Python Recipe
+
+Replace the dataset object when integrating custom local data into an existing
+SFT or PEFT recipe. This example lets the builder choose fingerprinted output
+paths and prepare them on the first call:
+
+```python
+from megatron.bridge.data.builders import (
+    GPTSFTDatasetBuilder,
+    GPTSFTDatasetConfig,
+    PromptCompletionSFTPreprocessingConfig,
+)
+from megatron.bridge.data.packing import PackedSequenceSpecs
+from megatron.bridge.recipes.llama import llama32_1b_sft_config
+from megatron.bridge.training.tokenizers.tokenizer import build_tokenizer
+
+cfg = llama32_1b_sft_config()
+cfg.dataset = GPTSFTDatasetConfig(
+    seq_length=cfg.model.seq_length,
+    dataset_root="/data/sft-jsonl",
+    preprocessing=PromptCompletionSFTPreprocessingConfig(
+        prompt_column="input",
+        completion_column="output",
+        separator=" ",
+        loss_mode="completion",
+    ),
+    dataset_kwargs={"pad_to_max_length": True},
+    enable_offline_packing=True,
+    offline_packing_specs=PackedSequenceSpecs(
+        packed_sequence_size=cfg.model.seq_length,
+        pad_seq_to_mult=1,
+        num_tokenizer_workers=8,
+    ),
+    do_validation=True,
+    do_test=False,
+)
+cfg.train.micro_batch_size = 1
+
+tokenizer = build_tokenizer(cfg.tokenizer)
+GPTSFTDatasetBuilder(config=cfg.dataset, tokenizer=tokenizer).prepare_data()
+```
+
+Run the final two lines once in a single CPU process before submitting the GPU
+job. The normal training builder calls the same preparation method on rank zero
+and skips work when the complete pair is already present.
+
+For a Hugging Face source, replace `dataset_root` with a declarative source and
+choose where normalized JSONL should be cached:
+
+```python
+from megatron.bridge.data.builders import HFDatasetSourceConfig
+
+cfg.dataset.dataset_root = None
+cfg.dataset.hf_dataset = HFDatasetSourceConfig(dataset_name="squad")
+cfg.dataset.hf_validation_proportion = 0.1
+cfg.dataset.hf_output_root = "/data/materialized-squad"
+```
+
+For conversation data, replace the prompt-completion preprocessing object with
+`ChatSFTPreprocessingConfig(loss_mode="assistant")`. The selected tokenizer
+must provide the intended chat template. Preparation and training must use the
+same preprocessing object.
+
+To train from that config, set the checkpoint fields and call the standard SFT
+entry point from a script launched with `torch.distributed.run`:
+
+```python
+from megatron.bridge.training.finetune import finetune
+from megatron.bridge.training.gpt_step import forward_step
+
+cfg.checkpoint.pretrained_checkpoint = "/data/checkpoints/llama32_1b"
+cfg.checkpoint.load = None
+cfg.checkpoint.save = "/data/checkpoints/llama32_1b_sft"
+finetune(config=cfg, forward_step_func=forward_step)
+```
+
+If the complete example is saved as `train_packed_sft.py`, launch it with:
+
+```bash
+uv run python -m torch.distributed.run --nproc_per_node=1 train_packed_sft.py
+```
+
+Do not construct a different preprocessing config for the training job. Packing
+captures tokenization, loss policy, truncation, padding, sequence alignment, and
+pack membership; those settings are part of the artifact's identity.
+
+## Use Explicit Local Prefixes and Shards
+
+After both files exist, reference prebuilt pairs directly:
+
+```python
+cfg.dataset.offline_packing_specs = PackedSequenceSpecs(
+    packed_sequence_size=4096,
+    packed_train_data_path="/data/packed/training_4096.sft",
+    packed_val_data_path="/data/packed/validation_4096.sft",
+    packed_metadata_path="/data/packed/4096_metadata.json",
+    pad_seq_to_mult=1,
+)
+```
+
+The following path specifications are accepted:
+
+- a prefix such as `/data/packed/training_4096.sft`
+- either pair filename, such as `training_4096.sft.bin`
+- a glob over canonical pairs
+- a split-specific directory containing canonical `*.sft.bin/*.sft.idx` pairs
+
+Directory and glob inputs are consumed in sorted shard order. Every resolved
+prefix must have both files. Directory resolution loads every pair in that
+directory, so never mix training, validation, and test pairs in one directory
+when the directory itself is used as the path specification. Prefer
+split-specific globs such as `training_*.sft` and `validation_*.sft`. Generate
+shards into distinct prefixes; do not concatenate `.bin` or `.idx` files with
+shell tools.
+
+The preparation command writes one training pair and, optionally, one
+validation pair per invocation. It does not split a large input automatically,
+and the current packer materializes the tokenized input and packing output in
+host memory. For a dataset that does not fit comfortably on one preparation
+node:
+
+1. split normalized JSONL deterministically before tokenization
+2. run the preparation command once per raw shard with a stable, unique `.sft`
+   prefix such as `training_00000.sft`
+3. consume a split-specific sorted glob in the training config
+4. record raw-row and packed-row counts so missing or duplicated shards are
+   detected before training
+
+For example, one invocation can prepare the first shard:
 
 ```bash
 uv run python scripts/training/prepare_gpt_sft_packed_data.py \
     --recipe llama32_1b_sft_1gpu_h100_bf16_config \
+    --train-input-path /data/sft-shards/training_00000.jsonl \
+    --packed-train-data-path /data/packed/training_00000.sft \
+    --packed-metadata-path /data/packed/4096_metadata.json \
     --num-tokenizer-workers 8
 ```
 
-To choose the artifact locations explicitly, provide a prefix rather than a
-file suffix:
+Repeat sequentially for later shards. The preparation function appends packing
+statistics to the metadata JSON; do not run multiple writers concurrently
+against the same metadata path. When `pad_cu_seqlens=True`, the metadata passed
+to training must contain statistics for every consumed shard.
+
+Configure train and validation shards with separate globs:
+
+```python
+cfg.dataset.offline_packing_specs = PackedSequenceSpecs(
+    packed_sequence_size=4096,
+    packed_train_data_path="/data/packed/training_*.sft",
+    packed_val_data_path="/data/packed/validation_*.sft",
+    packed_metadata_path="/data/packed/4096_metadata.json",
+)
+```
+
+Local writers validate every row, build a temporary pair, take an exclusive
+filesystem lock, publish `.bin`, and publish `.idx` last as the completion
+point. Readers take the shared side of that lock while opening the pair. The
+`.sft.lock` sidecar intentionally remains for later readers and writers.
+
+## Read Prebuilt Data from Object Storage
+
+For `msc://` prefixes, MCore streams `.bin` ranges and caches each `.idx`
+locally. Bridge enables MCore's Multi-Storage Client integration when it sees
+the prefix, but it does not create storage profiles or credentials. Configure
+the provider and named profile according to the
+[Multi-Storage Client configuration guide](https://nvidia.github.io/multi-storage-client/).
+
+Use a local index-cache directory visible to every rank in a multi-node job:
+
+```python
+cfg.dataset.offline_packing_specs = PackedSequenceSpecs(
+    packed_sequence_size=4096,
+    packed_train_data_path="msc://profile/sft/training_4096.sft",
+    packed_val_data_path="msc://profile/sft/validation_4096.sft",
+    packed_metadata_path="msc://profile/sft/4096_metadata.json",
+    object_storage_cache_path="/shared/cache/packed-sft-indices",
+    # MCore defaults to 256 MiB range-read chunks. Tune only after measuring.
+    object_storage_bin_chunk_nbytes=256 * 1024 * 1024,
+)
+```
+
+When no cache is set, Bridge uses
+`$NEMO_DATASETS_CACHE/packed_sft_index_cache`, or the corresponding default
+NeMo cache. Rank zero downloads the remote indices before the distributed
+barrier, and remote `.bin` files automatically use range reads instead of mmap.
+
+Remote artifacts are read-only. Prepare a local pair, upload `.bin` completely,
+then upload `.idx` as the completion marker:
+
+```python
+import multistorageclient as msc
+
+msc.upload_file(
+    "msc://profile/sft/training_4096.sft.bin",
+    "/data/packed/training_4096.sft.bin",
+)
+msc.upload_file(
+    "msc://profile/sft/training_4096.sft.idx",
+    "/data/packed/training_4096.sft.idx",
+)
+```
+
+Upload the metadata JSON as well when the config references it. Direct packing
+or rewriting to object storage is rejected because replacing two remote objects
+cannot provide the local pair's reader/writer atomicity.
+
+## Training Constraints
+
+Start with the recipe defaults and change one topology feature at a time.
+
+| Setting | Requirement |
+| --- | --- |
+| Micro batch | Offline packed SFT requires `micro_batch_size=1` |
+| Global batch | `global_batch_size` must be divisible by `micro_batch_size * data_parallel_size`; with packed MBS1 it must be a multiple of and no smaller than DP |
+| Sequence length | Keep model, dataset, and packed sequence sizes equal in the standard path |
+| Context parallelism | Sequence length must be divisible by `2 * context_parallel_size` |
+| SFT with CP | Set `model.calculate_per_token_loss=True` and `ddp.average_in_collective=False` |
+| Packing alignment | Use `lcm(2 * CP if CP > 1 else 1, CP * TP if sequence parallelism and TP > 1 else 1)` |
+| CUDA graphs | TE-scoped graphs do not support packed SFT because `packed_seq_params` is a non-Tensor input; keep graphs disabled unless a separate local full-iteration path has been validated |
+| MTP | Multi-Token Prediction is not supported with offline packed SFT |
+
+The generic launcher synchronizes `model.seq_length` and
+`packed_sequence_size` from the resolved dataset length. It also raises the
+packing alignment to satisfy the resolved TP, CP, evaluation CP, and sequence
+parallel topology. If those values change, rebuild the pair because padding and
+pack membership can change.
+
+`pad_cu_seqlens=True`, fixed-width padding, and packing metadata provide static
+packed shapes, but they do not by themselves make CUDA graph capture supported.
+They are only prerequisites for a separately validated experimental graph path.
+See [CUDA Graphs](cuda-graphs.md) for the additional RNG, NaN-check, scope, and
+backend constraints.
+
+Offline LLM packing and VLM in-batch packing have opposite micro-batch rules.
+Do not apply `micro_batch_size=1` to a VLM path that uses
+`enable_in_batch_packing=True`; see [Packed Sequences](packed-sequences.md) for
+that path and for model-family opt-outs.
+
+## Migrate from Packed Parquet
+
+Migration is intentionally explicit, so existing jobs do not silently switch
+artifacts.
+
+1. Keep the old job on its existing `.parquet` path.
+2. Re-run packing from the same normalized JSONL using the same tokenizer,
+   preprocessing, seed, sequence length, alignment, and dataset options.
+3. Give the new output a `.sft` prefix, which selects indexed storage.
+4. Compare every decoded row before changing the production recipe.
+5. Run a short loss and throughput smoke on the target filesystem.
+
+The comparison path requires the optional Parquet dependency:
+
+```bash
+uv sync --extra parquet
+mkdir -p /data/packed-parquet /data/packed-indexed
+```
+
+First, prepare only the new indexed artifact from the normalized source and
+settings that produced the existing production Parquet:
 
 ```bash
 uv run python scripts/training/prepare_gpt_sft_packed_data.py \
     --recipe llama32_1b_sft_1gpu_h100_bf16_config \
     --train-input-path /data/sft/training.jsonl \
-    --val-input-path /data/sft/validation.jsonl \
-    --packed-train-data-path /data/packed/training_4096.sft \
-    --packed-val-data-path /data/packed/validation_4096.sft \
-    --packed-metadata-path /data/packed/4096_metadata.json \
+    --packed-train-data-path /data/packed-indexed/training_4096.sft \
+    --packed-metadata-path /data/packed-indexed/4096_metadata.json \
     --num-tokenizer-workers 8
 ```
 
-Reference prebuilt pairs from a dataset config after both files exist:
-
-```python
-offline_packing_specs=PackedSequenceSpecs(
-    packed_sequence_size=4096,
-    packed_train_data_path="/data/packed/training_4096.sft",
-    packed_val_data_path="/data/packed/validation_4096.sft",
-    packed_metadata_path="/data/packed/4096_metadata.json",
-)
-```
-
-A prefix, either pair filename, a glob, or a directory of canonical
-`*.sft.bin/*.sft.idx` pairs is accepted. Directory and glob inputs are read in
-sorted shard order. Every pair must be complete.
-
-For `msc://` prefixes, MCore streams `.bin` ranges and caches each `.idx`
-locally. Bridge enables MCore's Multi-Storage Client integration when it sees
-the prefix; this only toggles MCore's feature flag. Before launch, install and
-configure the storage provider and named profile according to the
-[Multi-Storage Client configuration guide](https://nvidia.github.io/multi-storage-client/). Bridge does not create
-profiles or credentials. It uses
-`$NEMO_DATASETS_CACHE/packed_sft_index_cache` (or the corresponding default
-NeMo cache) unless an explicit cache is configured. In multi-node jobs the
-cache path must be visible to every rank:
-
-```python
-offline_packing_specs=PackedSequenceSpecs(
-    packed_sequence_size=4096,
-    packed_train_data_path="msc://profile/sft/training_4096.sft",
-    packed_val_data_path="msc://profile/sft/validation_4096.sft",
-    object_storage_cache_path="/shared/cache/packed-sft-indices",
-    # MCore defaults to 256 MiB range-read chunks; tune only after measuring.
-    object_storage_bin_chunk_nbytes=256 * 1024 * 1024,
-)
-```
-
-The canonical builder downloads remote indices on rank zero before its
-distributed barrier and automatically disables mmap for remote `.bin` files.
-Remote artifacts are read-only: prepare the pair locally, then upload both
-files before constructing the recipe. For example:
-
-```python
-import multistorageclient as msc
-
-msc.upload_file("msc://profile/sft/training_4096.sft.bin", "/data/packed/training_4096.sft.bin")
-msc.upload_file("msc://profile/sft/training_4096.sft.idx", "/data/packed/training_4096.sft.idx")
-```
-
-Do not upload `.idx` until `.bin` has completed. Direct packing or rewriting to
-an object-storage prefix is rejected because a two-object replacement cannot
-provide the local pair's reader/writer atomicity.
-
-## Launch Training
-
-The normal recipe launcher consumes the indexed pair through the configured
-`GPTSFTDatasetBuilder`; no storage-specific training flag is required:
-
-```bash
-uv run python -m torch.distributed.run --nproc_per_node=1 \
-    scripts/training/run_recipe.py \
-    --recipe llama32_1b_sft_1gpu_h100_bf16_config \
-    --mode sft \
-    checkpoint.pretrained_checkpoint=/checkpoints/llama32_1b
-```
-
-Offline packed SFT requires `micro_batch_size=1`. Keep `model.seq_length`,
-`dataset.seq_length`, and `packed_sequence_size` equal. If context parallelism
-is enabled, set `pad_seq_to_mult` to satisfy the training topology; the usual
-minimum is `2 * context_parallel_size`, combined with sequence-parallel
-alignment when applicable. Rebuild the packed pair whenever preprocessing,
-tokenizer, sequence length, or topology-derived alignment changes.
-
-## Validate Against Parquet
-
-Parquet remains available as an explicit compatibility format. Prepare the
-same input and configuration twice with the same seed: use a `.sft` output
-prefix for indexed data and an output ending in `.parquet` for the comparison
-copy. Then validate every row and measure sequential decode throughput:
+Compare the existing production Parquet directly with the new indexed output:
 
 ```bash
 uv run python scripts/training/compare_packed_sft_formats.py \
-    --parquet /data/packed/training_4096.idx.parquet \
-    --indexed /data/packed/training_4096.sft
+    --parquet /data/existing-packed/training_4096.idx.parquet \
+    --indexed /data/packed-indexed/training_4096.sft
+```
+
+This direct comparison is the migration gate. Rebuilding both sides with the
+current code could allow a shared behavior change to pass parity while differing
+from the artifact used by the old production job.
+
+Optionally, validate the current Parquet writer as a separate A/B check. An
+output ending in `.parquet` selects the compatibility writer:
+
+```bash
+uv run python scripts/training/prepare_gpt_sft_packed_data.py \
+    --recipe llama32_1b_sft_1gpu_h100_bf16_config \
+    --train-input-path /data/sft/training.jsonl \
+    --packed-train-data-path /data/packed-parquet/training_4096.idx.parquet \
+    --packed-metadata-path /data/packed-parquet/4096_metadata.json \
+    --num-tokenizer-workers 8
+
+uv run python scripts/training/compare_packed_sft_formats.py \
+    --parquet /data/packed-parquet/training_4096.idx.parquet \
+    --indexed /data/packed-indexed/training_4096.sft
 ```
 
 Use `--max-rows N` for a quick sample. The command fails on any difference in
-`input_ids`, the target-aligned `loss_mask`, or `seq_start_id`, and reports row
-rate, token rate, elapsed time, and bytes on disk for each format. Read-rate
-results are microbenchmarks; validate end-to-end dataloader and training
-throughput on the target filesystem before making capacity decisions.
+`input_ids`, target-aligned `loss_mask`, or `seq_start_id`. It also reports row
+rate, token rate, elapsed time, and bytes on disk. These are sequential-read
+microbenchmarks; measure end-to-end dataloader and training throughput on the
+target filesystem before making capacity decisions.
+
+Success is reported as `Parity validation passed for N rows`. If any field
+differs, do not switch the recipe: verify that both outputs were freshly built
+or originally built with the same normalized input, tokenizer revision,
+preprocessing, seed, sequence length, alignment, and dataset options.
+
+Existing `.parquet` and deprecated `.npy` paths remain readable when configured
+explicitly. An output without a Parquet or NumPy suffix selects the indexed
+writer; use a canonical `.sft` prefix so the pair is named
+`.sft.bin/.sft.idx`.
 
 ## On-Disk Schema
 
-Each IndexedDataset item is one complete packed row. Its int32 payload contains
-a versioned header, the sequence start offsets, and one word per token. The
-lower 31 bits store the token ID and the high bit stores the binary loss mask.
-The writer validates mask and token ranges. The reader validates the magic
-value, version, row dimensions, and strictly increasing boundaries before
-constructing a training sample.
+Each MCore IndexedDataset item is one complete packed SFT row. Its int32 payload
+contains:
 
-Writers validate every row under the versioned schema, build a temporary pair,
-take an exclusive filesystem lock, and publish `.idx` last as the completion
-point. Local readers take the shared side of that lock while opening both files.
-If either publication step raises, the writer restores the previous pair. The
-internal `.sft.lock` sidecar intentionally remains for later readers and
-writers.
+1. a magic value and schema version
+2. the number of sequence boundaries
+3. the `seq_start_id` offsets
+4. one int32 word per token
 
-This is a packed-SFT schema, not an ordinary pretraining token stream. Both use
-the MCore `.bin/.idx` container; local data uses mmap and remote data uses range
-reads. Their payloads are not interchangeable.
+The lower 31 bits of a token word store the token ID. The high bit stores the
+binary, target-aligned loss mask. The writer rejects non-binary masks, token IDs
+outside the supported range, mismatched lengths, empty rows, and invalid
+boundaries. The reader validates the header and boundaries before returning a
+sample.
 
-## Compatibility Notes
+This schema preserves the logical fields used by the Parquet implementation
+without requiring PyArrow on the default indexed training path.
 
-- Existing packed `.parquet` and deprecated `.npy` paths remain readable when
-  explicitly configured.
-- The default for newly prepared data is `.sft.bin/.sft.idx`.
-- Multi-Token Prediction is not supported with offline packed SFT.
-- VLM packing is unchanged and does not use this indexed schema.
+## Troubleshooting
+
+- **`Exactly one text-only SFT source must be set`.** Set exactly one of
+  `dataset_root` or `hf_dataset`. When changing a built-in HF recipe to local
+  JSONL through overrides, clear both `hf_dataset` and its
+  `hf_validation_proportion` before setting `dataset_root`.
+
+- **`Packed SFT IndexedDataset is incomplete or missing`.** Pass the logical
+  `.sft` prefix and verify that both `<prefix>.bin` and `<prefix>.idx` are
+  visible on every node. For shards, verify every resolved pair.
+
+- **Training tries to prepare data again.** Inspect the printed final config.
+  The packed prefix, sequence length, and source overrides probably differ from
+  the preparation command, or only one member of the pair was uploaded.
+
+- **The training command reads SQuAD instead of custom data.** The named recipe
+  has a built-in HF source. Set `dataset.hf_dataset=null`, clear the HF split
+  settings, and set `dataset.dataset_root` as shown in the quickstart.
+
+- **`a metadata json file is required when pad_cu_seqlens is enabled`.** Point
+  `packed_metadata_path` at the metadata produced with the pair. Do not enable
+  padded cumulative sequence lengths without it.
+
+- **Packed micro-batch validation fails.** Set `train.micro_batch_size=1`.
+  Increase `global_batch_size` for gradient accumulation rather than increasing
+  the offline-packed micro batch.
+
+- **CP or sequence-parallel divisibility fails.** Recompute `pad_seq_to_mult`
+  from the final topology and rebuild the pair. Do not reuse data packed for a
+  different alignment.
+
+- **Remote reads fail before training starts.** Verify the MSC profile and
+  credentials on every node, confirm that `.bin` was uploaded before `.idx`,
+  and use a shared writable local index cache.
+
+- **Preparation is slow or exhausts file descriptors.** First validate with one
+  tokenizer worker. Then increase `num_tokenizer_workers` gradually and check
+  the node's memory and file descriptor limits.
+
+- **Finetuning reports that a checkpoint is required.** Set
+  `checkpoint.pretrained_checkpoint` for a new SFT/PEFT run, or
+  `checkpoint.load` for a complete native checkpoint resume.
+
+For raw schema details and all `GPTSFTDatasetConfig` knobs, see the
+[text-only SFT dataset tutorial](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/tutorials/data/text-only-sft/README.md).
+For packed attention behavior and performance guidance, see
+[Packed Sequences](packed-sequences.md).

--- a/scripts/training/compare_packed_sft_formats.py
+++ b/scripts/training/compare_packed_sft_formats.py
@@ -98,9 +98,14 @@ def validate_parity(parquet_path: str, indexed_path: str, *, max_rows: int) -> i
     """Validate row-level equality between Parquet and indexed datasets."""
     indexed = PackedSFTIndexedDataset(indexed_path)
     parquet_rows = _parquet_row_count(parquet_path)
-    if max_rows <= 0 and parquet_rows != len(indexed):
-        raise ValueError(f"Row count mismatch: parquet={parquet_rows}, indexed={len(indexed)}")
-    rows_to_compare = min(_limited_count(parquet_rows, max_rows), _limited_count(len(indexed), max_rows))
+    parquet_rows_to_compare = _limited_count(parquet_rows, max_rows)
+    indexed_rows_to_compare = _limited_count(len(indexed), max_rows)
+    if parquet_rows_to_compare != indexed_rows_to_compare:
+        raise ValueError(
+            "Row count mismatch within comparison range: "
+            f"parquet={parquet_rows}, indexed={len(indexed)}, max_rows={max_rows}"
+        )
+    rows_to_compare = parquet_rows_to_compare
     parquet_iterator = _iter_parquet_rows(parquet_path)
     for row_index in range(rows_to_compare):
         parquet_row = next(parquet_iterator)

--- a/scripts/training/compare_packed_sft_formats.py
+++ b/scripts/training/compare_packed_sft_formats.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Validate semantic parity and read performance of packed SFT formats."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import time
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+
+from megatron.bridge.data.packing.indexed import PackedSFTIndexedDataset, resolve_packed_indexed_prefixes
+from megatron.bridge.data.packing.paths import resolve_packed_parquet_paths
+
+
+logger = logging.getLogger(__name__)
+_FIELDS = ("input_ids", "loss_mask", "seq_start_id")
+
+
+@dataclass(frozen=True)
+class ReadStats:
+    """Sequential-read measurements for one packed dataset format."""
+
+    rows: int
+    tokens: int
+    seconds: float
+    bytes_on_disk: int
+
+    @property
+    def rows_per_second(self) -> float:
+        """Return sequential rows decoded per second."""
+        return self.rows / self.seconds
+
+    @property
+    def tokens_per_second(self) -> float:
+        """Return sequential tokens decoded per second."""
+        return self.tokens / self.seconds
+
+
+def _import_parquet():
+    """Import PyArrow lazily so indexed-only training does not require it."""
+    try:
+        import pyarrow.parquet as pq
+    except ImportError as error:
+        raise ImportError("Parquet comparison requires the optional 'parquet' dependencies") from error
+    return pq
+
+
+def _iter_parquet_rows(path_spec: str) -> Iterator[dict[str, list[int]]]:
+    """Yield packed rows from all resolved Parquet shards."""
+    pq = _import_parquet()
+    for path in resolve_packed_parquet_paths(path_spec):
+        parquet_file = pq.ParquetFile(path)
+        for row_group_index in range(parquet_file.num_row_groups):
+            table = parquet_file.read_row_group(row_group_index, columns=list(_FIELDS))
+            for row_index in range(table.num_rows):
+                yield {field: table.column(field)[row_index].as_py() for field in _FIELDS}
+
+
+def _parquet_row_count(path_spec: str) -> int:
+    """Return the row count across all Parquet shards."""
+    pq = _import_parquet()
+    return sum(pq.read_metadata(path).num_rows for path in resolve_packed_parquet_paths(path_spec))
+
+
+def _limited_count(total_rows: int, max_rows: int) -> int:
+    return total_rows if max_rows <= 0 else min(total_rows, max_rows)
+
+
+def _local_file_size(paths: list[str]) -> int:
+    total = 0
+    for path in paths:
+        try:
+            total += Path(path).stat().st_size
+        except OSError:
+            return 0
+    return total
+
+
+def validate_parity(parquet_path: str, indexed_path: str, *, max_rows: int) -> int:
+    """Validate row-level equality between Parquet and indexed datasets."""
+    indexed = PackedSFTIndexedDataset(indexed_path)
+    parquet_rows = _parquet_row_count(parquet_path)
+    if max_rows <= 0 and parquet_rows != len(indexed):
+        raise ValueError(f"Row count mismatch: parquet={parquet_rows}, indexed={len(indexed)}")
+    rows_to_compare = min(_limited_count(parquet_rows, max_rows), _limited_count(len(indexed), max_rows))
+    parquet_iterator = _iter_parquet_rows(parquet_path)
+    for row_index in range(rows_to_compare):
+        parquet_row = next(parquet_iterator)
+        indexed_row = indexed[row_index]
+        for field in _FIELDS:
+            if not np.array_equal(np.asarray(parquet_row[field]), np.asarray(indexed_row[field])):
+                raise ValueError(f"Parity mismatch at row {row_index}, field '{field}'")
+    return rows_to_compare
+
+
+def benchmark_indexed(path_spec: str, *, max_rows: int) -> ReadStats:
+    """Measure sequential indexed decoding throughput."""
+    dataset = PackedSFTIndexedDataset(path_spec)
+    rows = _limited_count(len(dataset), max_rows)
+    start = time.perf_counter()
+    token_count = sum(len(dataset[row_index]["input_ids"]) for row_index in range(rows))
+    seconds = max(time.perf_counter() - start, 1e-12)
+    prefixes = resolve_packed_indexed_prefixes(path_spec)
+    paths = [path for prefix in prefixes for path in (f"{prefix}.bin", f"{prefix}.idx")]
+    return ReadStats(rows, token_count, seconds, _local_file_size(paths))
+
+
+def benchmark_parquet(path_spec: str, *, max_rows: int) -> ReadStats:
+    """Measure sequential Parquet decoding throughput."""
+    rows = _limited_count(_parquet_row_count(path_spec), max_rows)
+    start = time.perf_counter()
+    token_count = 0
+    for row_index, row in enumerate(_iter_parquet_rows(path_spec)):
+        if row_index >= rows:
+            break
+        token_count += len(row["input_ids"])
+    seconds = max(time.perf_counter() - start, 1e-12)
+    paths = resolve_packed_parquet_paths(path_spec)
+    return ReadStats(rows, token_count, seconds, _local_file_size(paths))
+
+
+def _log_stats(name: str, stats: ReadStats) -> None:
+    logger.info(
+        "%s: rows=%d tokens=%d time=%.4fs rows/s=%.1f tokens/s=%.1f size=%.2f MiB",
+        name,
+        stats.rows,
+        stats.tokens,
+        stats.seconds,
+        stats.rows_per_second,
+        stats.tokens_per_second,
+        stats.bytes_on_disk / (1024 * 1024),
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--parquet", required=True, help="Packed Parquet file, directory, or glob.")
+    parser.add_argument("--indexed", required=True, help="Packed SFT .bin/.idx prefix, directory, or glob.")
+    parser.add_argument("--max-rows", type=int, default=0, help="Rows to compare and benchmark; 0 means all rows.")
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Run parity validation followed by sequential-read measurements."""
+    args = parse_args()
+    compared_rows = validate_parity(args.parquet, args.indexed, max_rows=args.max_rows)
+    logger.info("Parity validation passed for %d rows", compared_rows)
+    _log_stats("Parquet", benchmark_parquet(args.parquet, max_rows=args.max_rows))
+    _log_stats("bin/idx", benchmark_indexed(args.indexed, max_rows=args.max_rows))
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s", force=True)
+    main()

--- a/scripts/training/prepare_gpt_sft_packed_data.py
+++ b/scripts/training/prepare_gpt_sft_packed_data.py
@@ -16,8 +16,8 @@
 """Pre-pack SFT training data for a recipe that uses packed sequences.
 
 Run this before submitting a training job so packing is not performed on
-GPU compute nodes. Packed .parquet files are written to the dataset cache
-directory defined by the recipe.
+GPU compute nodes. Packed ``.sft.bin/.sft.idx`` files are written to the
+dataset cache directory defined by the recipe.
 
 Usage (inside container with PYTHONPATH=/opt/megatron-lm:/opt/Megatron-Bridge/src):
 
@@ -55,10 +55,14 @@ def main() -> None:
         "--val-input-path", default=None, help="Optional processed JSONL path for the validation split."
     )
     parser.add_argument(
-        "--packed-train-data-path", default=None, help="Optional output path for packed training data."
+        "--packed-train-data-path",
+        default=None,
+        help="Optional packed output prefix (.bin/.idx by default; .parquet remains supported).",
     )
     parser.add_argument(
-        "--packed-val-data-path", default=None, help="Optional output path for packed validation data."
+        "--packed-val-data-path",
+        default=None,
+        help="Optional packed output prefix (.bin/.idx by default; .parquet remains supported).",
     )
     parser.add_argument("--packed-metadata-path", default=None, help="Optional output path for packing metadata.")
     parser.add_argument(

--- a/src/megatron/bridge/data/builders/gpt_sft.py
+++ b/src/megatron/bridge/data/builders/gpt_sft.py
@@ -31,6 +31,10 @@ from megatron.core.tokenizers.text.libraries import HuggingFaceTokenizer
 from megatron.bridge.data.base import DataloaderConfig, validate_declarative_mapping
 from megatron.bridge.data.datasets.gpt_sft import GPTSFTChatDataset, GPTSFTDataset, get_dataset_root
 from megatron.bridge.data.packing import PackedSequenceSpecs
+from megatron.bridge.data.packing.indexed import (
+    is_packed_indexed_dataset,
+    normalize_packed_indexed_prefix,
+)
 from megatron.bridge.data.packing.paths import (
     is_packed_parquet_spec,
     resolve_packed_parquet_paths,
@@ -435,7 +439,9 @@ def build_gpt_sft_split(
 ) -> Any | None:
     """Build one GPT SFT split from a local JSONL or packed-data path."""
     path_str = str(path)
-    if is_packed_parquet_spec(path_str):
+    if is_packed_indexed_dataset(path_str):
+        path_exists = True
+    elif is_packed_parquet_spec(path_str):
         try:
             # Retry with directory-metadata refresh: on NFS filesystems a non-producer
             # node can transiently see zero files right after rank 0 wrote them (#4207).
@@ -454,11 +460,12 @@ def build_gpt_sft_split(
 
     is_not_packing = packed_sequence_size <= 0
     effective_metadata_path = None
-    if not is_not_packing:
-        if pad_cu_seqlens:
-            effective_metadata_path = pack_metadata_path
-        elif not is_packed_parquet_spec(path_str):
-            effective_metadata_path = pack_metadata_path
+    if not is_not_packing and pad_cu_seqlens:
+        effective_metadata_path = pack_metadata_path
+    elif not is_not_packing and path_str.lower().endswith(".npy"):
+        # The legacy NumPy reader needs metadata even when cumulative sequence
+        # lengths are not padded. Indexed and Parquet rows are self-describing.
+        effective_metadata_path = pack_metadata_path
 
     options = dict(dataset_kwargs or {})
     chat = options.pop("chat", False)
@@ -492,6 +499,17 @@ def build_gpt_sft_split(
         from megatron.bridge.data.packing.gpt_sft import GPTSFTPackedDataset
 
         return GPTSFTPackedDataset(
+            pack_metadata_file_path=effective_metadata_path,
+            pad_cu_seqlens=pad_cu_seqlens,
+            pad_seq_to_mult=pad_seq_to_mult,
+            **dataset_init_kwargs,
+            **options,
+        )
+
+    if is_packed_indexed_dataset(path_str):
+        from megatron.bridge.data.packing.indexed import GPTSFTPackedIndexedDataset
+
+        return GPTSFTPackedIndexedDataset(
             pack_metadata_file_path=effective_metadata_path,
             pad_cu_seqlens=pad_cu_seqlens,
             pad_seq_to_mult=pad_seq_to_mult,
@@ -597,7 +615,7 @@ class GPTSFTDatasetBuilder:
 
         Skips preparation if:
         - packed_sequence_size <= 0 (packing disabled)
-        - packed data files already exist (parquet or legacy .npy), unless
+        - packed data files already exist (IndexedDataset, Parquet, or legacy .npy), unless
           ``hf_rewrite`` requested regeneration
         """
         if self.packed_sequence_size <= 0:
@@ -649,7 +667,7 @@ class GPTSFTDatasetBuilder:
         if packed_path_str.lower().endswith(".npy"):
             warnings.warn(
                 "Automatic .npy packed sequence preparation is deprecated and will be removed in the next release. "
-                "Please use packed parquet format instead.",
+                "Please use packed SFT .bin/.idx format instead.",
                 DeprecationWarning,
                 stacklevel=3,
             )
@@ -673,6 +691,7 @@ class GPTSFTDatasetBuilder:
     def _packed_path_exists(self, path: Union[str, Path]) -> bool:
         """Check if a packed data path exists.
 
+        For packed IndexedDataset: check both .bin and .idx exist
         For .npy files: check file exists
         For packed parquet specs: check if resolution returns non-empty
 
@@ -683,6 +702,9 @@ class GPTSFTDatasetBuilder:
             True if the packed data exists
         """
         path_str = str(path)
+
+        if is_packed_indexed_dataset(path_str):
+            return True
 
         # For packed parquet specs, check if resolution returns files
         if is_packed_parquet_spec(path_str):
@@ -702,6 +724,20 @@ class GPTSFTDatasetBuilder:
     def _remove_packed_path(self, path: Union[str, Path]) -> None:
         """Remove one builder-managed packed artifact if it exists."""
         path_str = str(path)
+        if is_packed_indexed_dataset(path_str):
+            prefix = normalize_packed_indexed_prefix(path_str)
+            indexed_paths = (f"{prefix}.bin", f"{prefix}.idx")
+            if MultiStorageClientFeature.is_enabled():
+                msc = MultiStorageClientFeature.import_package()
+                for indexed_path in indexed_paths:
+                    path_obj = msc.Path(indexed_path)
+                    if path_obj.exists():
+                        path_obj.unlink()
+            else:
+                for indexed_path in indexed_paths:
+                    Path(indexed_path).unlink(missing_ok=True)
+            return
+
         if MultiStorageClientFeature.is_enabled():
             msc = MultiStorageClientFeature.import_package()
             path_obj = msc.Path(path_str)
@@ -852,7 +888,7 @@ class GPTSFTDatasetBuilder:
         if self.packed_sequence_size > 0:
             if self.offline_packing_specs.packed_train_data_path is not None:
                 return self.offline_packing_specs.packed_train_data_path
-            return self.default_pack_path / f"training_{self.packed_sequence_size}.idx.parquet"
+            return self.default_pack_path / f"training_{self.packed_sequence_size}.sft"
         else:
             raise ValueError("`train_path_packed` invalid since packed sequence size is not specified.")
 
@@ -872,7 +908,7 @@ class GPTSFTDatasetBuilder:
         if self.packed_sequence_size > 0:
             if self.offline_packing_specs.packed_val_data_path is not None:
                 return self.offline_packing_specs.packed_val_data_path
-            return self.default_pack_path / f"validation_{self.packed_sequence_size}.idx.parquet"
+            return self.default_pack_path / f"validation_{self.packed_sequence_size}.sft"
         else:
             raise ValueError("`validation_path_packed` invalid since packed sequence size is not specified.")
 

--- a/src/megatron/bridge/data/builders/gpt_sft.py
+++ b/src/megatron/bridge/data/builders/gpt_sft.py
@@ -17,7 +17,9 @@
 import hashlib
 import json
 import logging
+import os
 import re
+import time
 import warnings
 from dataclasses import asdict, dataclass
 from pathlib import Path
@@ -32,8 +34,12 @@ from megatron.bridge.data.base import DataloaderConfig, validate_declarative_map
 from megatron.bridge.data.datasets.gpt_sft import GPTSFTChatDataset, GPTSFTDataset, get_dataset_root
 from megatron.bridge.data.packing import PackedSequenceSpecs
 from megatron.bridge.data.packing.indexed import (
+    cache_packed_indexed_dataset_indices,
     is_packed_indexed_dataset,
+    is_packed_indexed_spec,
     normalize_packed_indexed_prefix,
+    resolve_packed_indexed_prefixes,
+    resolve_packed_indexed_prefixes_with_retry,
 )
 from megatron.bridge.data.packing.paths import (
     is_packed_parquet_spec,
@@ -73,6 +79,44 @@ _SEMANTIC_DATASET_KWARGS = {
     "truncation_method",
     "use_hf_tokenizer_chat_template",
 }
+
+
+def _path_is_directory(path: str) -> bool:
+    """Return whether a local or enabled-MSC path is a directory."""
+    if MultiStorageClientFeature.is_enabled():
+        msc = MultiStorageClientFeature.import_package()
+        path_obj = msc.Path(path)
+        return path_obj.is_dir() if hasattr(path_obj, "is_dir") else False
+    return Path(path).is_dir()
+
+
+def _resolve_packed_directory_format_with_retry(
+    path: str,
+    *,
+    max_attempts: int = 10,
+    backoff_s: float = 1.0,
+) -> Literal["indexed", "parquet"] | None:
+    """Resolve an ambiguous packed directory without favoring one retry loop."""
+    for attempt in range(max_attempts):
+        try:
+            if resolve_packed_indexed_prefixes(path):
+                return "indexed"
+        except ValueError:
+            pass
+        try:
+            if resolve_packed_parquet_paths(path):
+                return "parquet"
+        except ValueError:
+            pass
+        if attempt == max_attempts - 1:
+            break
+        if not path.startswith(("msc://", "s3://")):
+            try:
+                os.listdir(path)
+            except OSError:
+                pass
+        time.sleep(backoff_s * (attempt + 1))
+    return None
 
 
 def _default_gpt_sft_preprocessing() -> PromptCompletionSFTPreprocessingConfig:
@@ -434,14 +478,34 @@ def build_gpt_sft_split(
     pack_metadata_path: str | Path | None = None,
     pad_cu_seqlens: bool = False,
     pad_seq_to_mult: int | None = None,
+    object_storage_cache_path: str | Path | None = None,
+    object_storage_bin_chunk_nbytes: int = 256 * 1024 * 1024,
     is_test: bool = False,
     dataset_kwargs: dict[str, Any] | None = None,
 ) -> Any | None:
     """Build one GPT SFT split from a local JSONL or packed-data path."""
     path_str = str(path)
-    if is_packed_indexed_dataset(path_str):
+    if path_str.startswith("msc://") and not MultiStorageClientFeature.is_enabled():
+        MultiStorageClientFeature.enable()
+    path_is_indexed = is_packed_indexed_spec(path_str)
+    path_is_parquet = False
+    if path_is_indexed:
+        try:
+            # Match the Parquet path's stale-NFS protection: another node can
+            # retain a negative dentry after rank zero publishes the pair.
+            path_exists = bool(resolve_packed_indexed_prefixes_with_retry(path_str))
+        except ValueError:
+            path_exists = False
+    elif _path_is_directory(path_str):
+        packed_format = _resolve_packed_directory_format_with_retry(path_str)
+        path_is_indexed = packed_format == "indexed"
+        path_is_parquet = packed_format == "parquet"
+        path_exists = packed_format is not None
+    elif is_packed_indexed_dataset(path_str):
+        path_is_indexed = True
         path_exists = True
     elif is_packed_parquet_spec(path_str):
+        path_is_parquet = True
         try:
             # Retry with directory-metadata refresh: on NFS filesystems a non-producer
             # node can transiently see zero files right after rank 0 wrote them (#4207).
@@ -506,18 +570,20 @@ def build_gpt_sft_split(
             **options,
         )
 
-    if is_packed_indexed_dataset(path_str):
+    if path_is_indexed:
         from megatron.bridge.data.packing.indexed import GPTSFTPackedIndexedDataset
 
         return GPTSFTPackedIndexedDataset(
             pack_metadata_file_path=effective_metadata_path,
             pad_cu_seqlens=pad_cu_seqlens,
             pad_seq_to_mult=pad_seq_to_mult,
+            object_storage_cache_path=object_storage_cache_path,
+            object_storage_bin_chunk_nbytes=object_storage_bin_chunk_nbytes,
             **dataset_init_kwargs,
             **options,
         )
 
-    if is_packed_parquet_spec(path_str):
+    if path_is_parquet:
         from megatron.bridge.data.packing.parquet import GPTSFTPackedParquetDataset
 
         return GPTSFTPackedParquetDataset(
@@ -560,6 +626,8 @@ class GPTSFTDatasetBuilder:
             raise ValueError("GPTSFTDatasetBuilder requires an initialized tokenizer.")
         config.validate()
         dataset_root = resolve_gpt_sft_dataset_root(config)
+        if str(dataset_root).startswith("msc://") and not MultiStorageClientFeature.is_enabled():
+            MultiStorageClientFeature.enable()
         self._source_root = Path(dataset_root) if config.hf_dataset is not None else None
 
         if MultiStorageClientFeature.is_enabled():
@@ -588,6 +656,14 @@ class GPTSFTDatasetBuilder:
         self._num_tokenizer_workers = (
             -1 if config.offline_packing_specs is None else config.offline_packing_specs.num_tokenizer_workers
         )
+        self._object_storage_cache_path = (
+            None if config.offline_packing_specs is None else config.offline_packing_specs.object_storage_cache_path
+        )
+        self._object_storage_bin_chunk_nbytes = (
+            256 * 1024 * 1024
+            if config.offline_packing_specs is None
+            else config.offline_packing_specs.object_storage_bin_chunk_nbytes
+        )
         self._rewrite_packed_data = config.hf_dataset is not None and config.hf_rewrite
         self._packing_fingerprint = _packing_fingerprint(config, config.dataset_kwargs)
 
@@ -609,6 +685,22 @@ class GPTSFTDatasetBuilder:
             assert self._source_root is not None
             materialize_hf_dataset(self.config, self._source_root)
         self.prepare_packed_data()
+        self._cache_remote_packed_indices()
+
+    def _cache_remote_packed_indices(self) -> None:
+        """Stage remote MCore index files before the distributed build barrier."""
+        if self.packed_sequence_size <= 0:
+            return
+        packed_paths = [self.train_path_packed]
+        if self.do_validation:
+            packed_paths.append(self.validation_path_packed)
+        for packed_path in packed_paths:
+            if is_packed_indexed_dataset(packed_path):
+                cache_packed_indexed_dataset_indices(
+                    packed_path,
+                    cache_path=self._object_storage_cache_path,
+                    bin_chunk_nbytes=self._object_storage_bin_chunk_nbytes,
+                )
 
     def prepare_packed_data(self) -> None:
         """Prepare packed sequence data files if configured.
@@ -724,7 +816,7 @@ class GPTSFTDatasetBuilder:
     def _remove_packed_path(self, path: Union[str, Path]) -> None:
         """Remove one builder-managed packed artifact if it exists."""
         path_str = str(path)
-        if is_packed_indexed_dataset(path_str):
+        if is_packed_indexed_spec(path_str) or is_packed_indexed_dataset(path_str):
             prefix = normalize_packed_indexed_prefix(path_str)
             indexed_paths = (f"{prefix}.bin", f"{prefix}.idx")
             if MultiStorageClientFeature.is_enabled():
@@ -785,6 +877,8 @@ class GPTSFTDatasetBuilder:
             pack_metadata_path=None if self.packed_sequence_size <= 0 else self.pack_metadata,
             pad_cu_seqlens=self._pad_cu_seqlens,
             pad_seq_to_mult=self._pad_seq_to_mult,
+            object_storage_cache_path=self._object_storage_cache_path,
+            object_storage_bin_chunk_nbytes=self._object_storage_bin_chunk_nbytes,
             dataset_kwargs={"max_num_samples": self.max_train_samples, **self.dataset_kwargs},
         )
 
@@ -799,6 +893,8 @@ class GPTSFTDatasetBuilder:
                 pack_metadata_path=None if self.packed_sequence_size <= 0 else self.pack_metadata,
                 pad_cu_seqlens=self._pad_cu_seqlens,
                 pad_seq_to_mult=self._pad_seq_to_mult,
+                object_storage_cache_path=self._object_storage_cache_path,
+                object_storage_bin_chunk_nbytes=self._object_storage_bin_chunk_nbytes,
                 is_test=True,
                 dataset_kwargs=self.dataset_kwargs,
             )

--- a/src/megatron/bridge/data/packing/algorithms.py
+++ b/src/megatron/bridge/data/packing/algorithms.py
@@ -409,10 +409,9 @@ def calculate_avg_seqlen(
     """Calculate average sequence length statistics from a packed dataset.
 
     Args:
-        dataset_file: Path to the packed dataset. Either a legacy ``.npy`` file, or a
-            parquet spec (``.parquet`` / ``.pq``) which may be a single file, a glob
-            pattern, or a directory -- resolved via ``resolve_packed_parquet_paths``
-            so this matches the specs accepted by the FLOP-accounting existence gate.
+        dataset_file: Path to packed SFT ``.bin/.idx``, legacy ``.npy``, or
+            Parquet data. Indexed and Parquet inputs may be a single dataset,
+            glob pattern, or directory.
         gbs: Global batch size used to determine how many rows to process.
         max_seq_len: Maximum sequence length (reserved for future use).
         drop_remainder: If True, drop rows that don't fill a complete batch.
@@ -427,12 +426,12 @@ def calculate_avg_seqlen(
     Raises:
         ValueError: If no rows remain after applying drop_remainder, or if no sequences are found.
     """
-    # Same predicate the packed-parquet loader (and flop_utils._packed_data_exists)
-    # uses, so the format detected here matches the spec accepted by the existence
-    # gate -- covers single file, glob pattern, and directory specs.
+    from megatron.bridge.data.packing.indexed import PackedSFTIndexedDataset, is_packed_indexed_dataset
     from megatron.bridge.data.packing.paths import is_packed_parquet_spec, resolve_packed_parquet_paths
 
-    if is_packed_parquet_spec(dataset_file):
+    if is_packed_indexed_dataset(dataset_file):
+        data = PackedSFTIndexedDataset(dataset_file)
+    elif is_packed_parquet_spec(dataset_file):
         import pyarrow.parquet as pq
 
         # Resolve the spec (single file / glob / directory) to concrete shard paths

--- a/src/megatron/bridge/data/packing/algorithms.py
+++ b/src/megatron/bridge/data/packing/algorithms.py
@@ -16,6 +16,7 @@
 
 import collections
 import logging
+from pathlib import Path
 from typing import Dict, List, Sequence, Tuple, TypeVar
 
 import numpy as np
@@ -404,7 +405,13 @@ def get_seqlen_list(elem: Dict) -> Tuple[List[int], int]:
 
 
 def calculate_avg_seqlen(
-    dataset_file: str, gbs: int, max_seq_len: int, drop_remainder: bool
+    dataset_file: str,
+    gbs: int,
+    max_seq_len: int,
+    drop_remainder: bool,
+    *,
+    object_storage_cache_path: str | Path | None = None,
+    object_storage_bin_chunk_nbytes: int = 256 * 1024 * 1024,
 ) -> Tuple[float, float, float, float]:
     """Calculate average sequence length statistics from a packed dataset.
 
@@ -415,6 +422,8 @@ def calculate_avg_seqlen(
         gbs: Global batch size used to determine how many rows to process.
         max_seq_len: Maximum sequence length (reserved for future use).
         drop_remainder: If True, drop rows that don't fill a complete batch.
+        object_storage_cache_path: Shared local index-cache path for remote indexed data.
+        object_storage_bin_chunk_nbytes: Range-read chunk size for remote indexed data.
 
     Returns:
         A tuple of (avg_seqlen_count, avg_seqlen_total, avg_seqlen_sq_individual, avg_seqlen_sq_per_row):
@@ -430,7 +439,11 @@ def calculate_avg_seqlen(
     from megatron.bridge.data.packing.paths import is_packed_parquet_spec, resolve_packed_parquet_paths
 
     if is_packed_indexed_dataset(dataset_file):
-        data = PackedSFTIndexedDataset(dataset_file)
+        data = PackedSFTIndexedDataset(
+            dataset_file,
+            object_storage_cache_path=object_storage_cache_path,
+            object_storage_bin_chunk_nbytes=object_storage_bin_chunk_nbytes,
+        )
     elif is_packed_parquet_spec(dataset_file):
         import pyarrow.parquet as pq
 

--- a/src/megatron/bridge/data/packing/config.py
+++ b/src/megatron/bridge/data/packing/config.py
@@ -48,10 +48,16 @@ class PackedSequenceSpecs:
     def _validate_packed_path(self, attr_name: str, path_value: str | Path) -> None:
         """Validate an explicitly supplied packed artifact path."""
         path_str = str(path_value)
+        from megatron.bridge.data.packing.indexed import is_packed_indexed_dataset
+
+        if is_packed_indexed_dataset(path_str):
+            setattr(self, attr_name, path_str)
+            return
+
         if path_str.lower().endswith(".npy"):
             warnings.warn(
                 "The .npy packed sequence format is deprecated and will be removed in the next release. "
-                f"Please use packed parquet format instead. Path: {path_str}",
+                f"Please use packed SFT .bin/.idx format instead. Path: {path_str}",
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -75,6 +81,6 @@ class PackedSequenceSpecs:
             return
 
         raise ValueError(
-            f"{attr_name} must be a .npy file or a packed parquet spec "
+            f"{attr_name} must be a packed SFT .bin/.idx prefix, a .npy file, or a packed parquet spec "
             f"(file/directory/glob ending in .parquet or .pq): {path_str}"
         )

--- a/src/megatron/bridge/data/packing/config.py
+++ b/src/megatron/bridge/data/packing/config.py
@@ -35,6 +35,8 @@ class PackedSequenceSpecs:
     packed_metadata_path: str | Path | None = None
     pad_cu_seqlens: bool = False
     pad_seq_to_mult: int | None = 1
+    object_storage_cache_path: str | Path | None = None
+    object_storage_bin_chunk_nbytes: int = 256 * 1024 * 1024
 
     def __post_init__(self) -> None:
         """Validate alignment settings and any explicitly supplied artifacts."""
@@ -44,6 +46,12 @@ class PackedSequenceSpecs:
             self._validate_packed_path("packed_val_data_path", self.packed_val_data_path)
         if self.pad_seq_to_mult is not None and self.pad_seq_to_mult <= 0:
             raise ValueError("pad_seq_to_mult must be a positive integer when provided.")
+        if self.object_storage_cache_path is not None:
+            cache_path = str(self.object_storage_cache_path).strip()
+            if not cache_path or cache_path.startswith(("msc://", "s3://")):
+                raise ValueError("object_storage_cache_path must be a non-empty local path when provided.")
+        if self.object_storage_bin_chunk_nbytes <= 0:
+            raise ValueError("object_storage_bin_chunk_nbytes must be greater than 0.")
 
     def _validate_packed_path(self, attr_name: str, path_value: str | Path) -> None:
         """Validate an explicitly supplied packed artifact path."""

--- a/src/megatron/bridge/data/packing/gpt_sft.py
+++ b/src/megatron/bridge/data/packing/gpt_sft.py
@@ -121,7 +121,7 @@ class GPTSFTPackedDataset(GPTSFTDataset):
             max_num_epochs = np.ceil(self.max_num_samples / dataset_len)
             indices = np.arange(dataset_len)[None, :].repeat(max_num_epochs, axis=0)
             [np.random.shuffle(x) for x in indices]
-            self.samples_mapping = indices.reshape(1, -1).squeeze()[: self.max_num_samples]
+            self.samples_mapping = indices.reshape(-1)[: self.max_num_samples]
         else:
             self.samples_mapping = None
 

--- a/src/megatron/bridge/data/packing/indexed.py
+++ b/src/megatron/bridge/data/packing/indexed.py
@@ -23,8 +23,13 @@ existing packed Parquet semantics while using MCore's mmap-backed storage.
 from __future__ import annotations
 
 import bisect
+import contextlib
+import fcntl
 import glob
+import logging
 import os
+import time
+import uuid
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -37,7 +42,13 @@ from megatron.core.datasets.indexed_dataset import (
     get_bin_path,
     get_idx_path,
 )
-from megatron.core.datasets.object_storage_utils import ObjectStorageConfig
+from megatron.core.datasets.object_storage_utils import (
+    ObjectStorageConfig,
+    cache_index_file,
+    get_index_cache_path,
+    is_object_storage_path,
+    parse_s3_path,
+)
 from megatron.core.msc_utils import MultiStorageClientFeature
 
 from megatron.bridge.data.packing.gpt_sft import GPTSFTPackedDataset
@@ -48,11 +59,14 @@ if TYPE_CHECKING:
 
 
 PACKED_SFT_SUFFIX = ".sft"
+DEFAULT_OBJECT_STORAGE_BIN_CHUNK_NBYTES = 256 * 1024 * 1024
 _ROW_MAGIC = 0x53465442  # ASCII "SFTB".
 _FORMAT_VERSION = 1
 _HEADER_WORDS = 3
 _TOKEN_BITS_MASK = np.uint32(0x7FFFFFFF)
 _LOSS_MASK_SHIFT = np.uint32(31)
+
+logger = logging.getLogger(__name__)
 
 
 def normalize_packed_indexed_prefix(path: str | Path) -> str:
@@ -61,6 +75,12 @@ def normalize_packed_indexed_prefix(path: str | Path) -> str:
     if path_str.lower().endswith((".bin", ".idx")):
         return path_str[:-4]
     return path_str
+
+
+def is_packed_indexed_spec(spec: str | Path) -> bool:
+    """Return whether a path syntactically names canonical packed SFT indexed data."""
+    spec_str = str(spec).lower()
+    return spec_str.endswith((PACKED_SFT_SUFFIX, f"{PACKED_SFT_SUFFIX}.bin", f"{PACKED_SFT_SUFFIX}.idx"))
 
 
 def _glob_prefixes(pattern: str) -> list[str]:
@@ -75,7 +95,43 @@ def _glob_prefixes(pattern: str) -> list[str]:
     else:
         matches = glob.glob(pattern)
     prefixes = {normalize_packed_indexed_prefix(path) for path in matches}
-    return sorted(prefix for prefix in prefixes if IndexedDataset.exists(prefix))
+    return sorted(prefix for prefix in prefixes if _packed_indexed_pair_exists(prefix))
+
+
+def _s3_object_exists(path: str) -> bool:
+    """Check one S3 object without relying on MCore's pinned existence helper."""
+    try:
+        import boto3
+        from botocore.exceptions import ClientError
+    except ModuleNotFoundError as error:
+        raise RuntimeError("Reading packed SFT data from s3:// requires boto3 and botocore") from error
+
+    bucket, key = parse_s3_path(path)
+    client = boto3.client("s3")
+    try:
+        client.head_object(Bucket=bucket, Key=key)
+    except ClientError as error:
+        response = error.response
+        error_code = str(response.get("Error", {}).get("Code", ""))
+        status_code = response.get("ResponseMetadata", {}).get("HTTPStatusCode")
+        if error_code in {"404", "NoSuchKey", "NotFound"} or status_code == 404:
+            return False
+        raise
+    finally:
+        close = getattr(client, "close", None)
+        if close is not None:
+            close()
+    return True
+
+
+def _packed_indexed_pair_exists(prefix: str) -> bool:
+    """Return whether both files in one local, MSC, or S3 pair exist."""
+    if prefix.startswith("s3://"):
+        return _s3_object_exists(get_bin_path(prefix)) and _s3_object_exists(get_idx_path(prefix))
+    if prefix.startswith("msc://"):
+        msc = MultiStorageClientFeature.import_package()
+        return msc.Path(get_bin_path(prefix)).exists() and msc.Path(get_idx_path(prefix)).exists()
+    return IndexedDataset.exists(prefix)
 
 
 def resolve_packed_indexed_prefixes(spec: str | Path) -> list[str]:
@@ -92,6 +148,8 @@ def resolve_packed_indexed_prefixes(spec: str | Path) -> list[str]:
         ValueError: If no complete dataset pair can be resolved.
     """
     spec_str = str(spec)
+    if spec_str.startswith("msc://") and not MultiStorageClientFeature.is_enabled():
+        MultiStorageClientFeature.enable()
     if "*" in spec_str or "?" in spec_str:
         suffix = "" if spec_str.lower().endswith((".bin", ".idx")) else ".idx"
         prefixes = _glob_prefixes(f"{spec_str}{suffix}")
@@ -113,12 +171,53 @@ def resolve_packed_indexed_prefixes(spec: str | Path) -> list[str]:
         return prefixes
 
     prefix = normalize_packed_indexed_prefix(spec_str)
-    if not IndexedDataset.exists(prefix):
+    if not _packed_indexed_pair_exists(prefix):
         raise ValueError(
             f"Packed SFT IndexedDataset is incomplete or missing for prefix '{prefix}'; "
             f"expected both '{get_bin_path(prefix)}' and '{get_idx_path(prefix)}'"
         )
     return [prefix]
+
+
+def _refresh_directory_metadata(spec: str | Path) -> None:
+    """Refresh the nearest local ancestor after a stale shared-filesystem miss."""
+    spec_str = str(spec)
+    if is_object_storage_path(spec_str):
+        return
+    base = spec_str.split("*", 1)[0].split("?", 1)[0]
+    directory = Path(base if os.path.isdir(base) else os.path.dirname(base))
+    while True:
+        try:
+            os.listdir(directory)
+            return
+        except OSError:
+            parent = directory.parent
+            if parent == directory:
+                return
+            directory = parent
+
+
+def resolve_packed_indexed_prefixes_with_retry(
+    spec: str | Path,
+    *,
+    max_attempts: int = 10,
+    backoff_s: float = 1.0,
+) -> list[str]:
+    """Resolve packed indexed data with bounded NFS metadata refresh and retry."""
+    if max_attempts <= 0:
+        raise ValueError("max_attempts must be greater than 0")
+    last_error: ValueError | None = None
+    for attempt in range(max_attempts):
+        try:
+            return resolve_packed_indexed_prefixes(spec)
+        except ValueError as error:
+            last_error = error
+            if attempt == max_attempts - 1:
+                break
+            _refresh_directory_metadata(spec)
+            time.sleep(backoff_s * (attempt + 1))
+    assert last_error is not None
+    raise last_error
 
 
 def is_packed_indexed_dataset(spec: str | Path) -> bool:
@@ -127,6 +226,54 @@ def is_packed_indexed_dataset(spec: str | Path) -> bool:
         return bool(resolve_packed_indexed_prefixes(spec))
     except ValueError:
         return False
+
+
+def default_packed_index_cache_path() -> Path:
+    """Return the standard local index-cache directory for remote packed data."""
+    nemo_home = Path(os.getenv("NEMO_HOME", Path.home() / ".cache" / "nemo"))
+    datasets_cache = Path(os.getenv("NEMO_DATASETS_CACHE", nemo_home / "datasets"))
+    cache_path = datasets_cache / "packed_sft_index_cache"
+    cache_path.mkdir(parents=True, exist_ok=True)
+    return cache_path
+
+
+def make_object_storage_config(
+    cache_path: str | Path | None,
+    *,
+    bin_chunk_nbytes: int = DEFAULT_OBJECT_STORAGE_BIN_CHUNK_NBYTES,
+) -> ObjectStorageConfig:
+    """Build MCore's object-storage reader config from declarative values."""
+    if bin_chunk_nbytes <= 0:
+        raise ValueError("object_storage_bin_chunk_nbytes must be greater than 0")
+    if cache_path is not None and is_object_storage_path(str(cache_path)):
+        raise ValueError("object_storage_cache_path must be a local path visible to every rank")
+    resolved_cache_path = default_packed_index_cache_path() if cache_path is None else Path(cache_path)
+    resolved_cache_path.mkdir(parents=True, exist_ok=True)
+    return ObjectStorageConfig(
+        path_to_idx_cache=str(resolved_cache_path),
+        bin_chunk_nbytes=bin_chunk_nbytes,
+    )
+
+
+def cache_packed_indexed_dataset_indices(
+    path_spec: str | Path,
+    *,
+    cache_path: str | Path | None,
+    bin_chunk_nbytes: int = DEFAULT_OBJECT_STORAGE_BIN_CHUNK_NBYTES,
+) -> None:
+    """Cache remote index files before all distributed ranks construct readers."""
+    prefixes = resolve_packed_indexed_prefixes(path_spec)
+    remote_prefixes = [prefix for prefix in prefixes if is_object_storage_path(prefix)]
+    if not remote_prefixes:
+        return
+    object_storage_config = make_object_storage_config(
+        cache_path,
+        bin_chunk_nbytes=bin_chunk_nbytes,
+    )
+    for prefix in remote_prefixes:
+        idx_path = get_idx_path(prefix)
+        local_idx_path = get_index_cache_path(idx_path, object_storage_config)
+        cache_index_file(idx_path, local_idx_path)
 
 
 def _as_integral_vector(value: Sequence[int | float] | np.ndarray, *, field: str) -> np.ndarray:
@@ -215,18 +362,123 @@ def decode_packed_row(encoded: np.ndarray, *, row_index: int) -> dict[str, np.nd
     }
 
 
+def _unlink_path(path: str) -> None:
+    """Remove a local path when it exists."""
+    Path(path).unlink(missing_ok=True)
+
+
+def _cleanup_path(path: str) -> None:
+    """Remove a temporary path without masking the primary write error."""
+    try:
+        _unlink_path(path)
+    except OSError:
+        logger.warning("Could not clean up temporary packed SFT path %s", path, exc_info=True)
+
+
+def _replace_path(source: str, destination: str) -> None:
+    """Atomically replace one local path."""
+    os.replace(source, destination)
+
+
+@contextlib.contextmanager
+def _publication_lock(prefix: str, *, exclusive: bool):
+    """Coordinate local readers and writers while a pair is opened or published."""
+    lock_path = f"{prefix}.lock"
+    with open(lock_path, "a+b") as lock_file:
+        lock_mode = fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH
+        fcntl.flock(lock_file.fileno(), lock_mode)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+
+def _publish_temporary_pair(temporary_prefix: str, final_prefix: str) -> None:
+    """Publish the data file first and roll back both files on failure."""
+    temporary_bin = get_bin_path(temporary_prefix)
+    temporary_idx = get_idx_path(temporary_prefix)
+    final_bin = get_bin_path(final_prefix)
+    final_idx = get_idx_path(final_prefix)
+    backup_prefix = f"{final_prefix}.backup-{uuid.uuid4().hex}"
+    backup_bin = get_bin_path(backup_prefix)
+    backup_idx = get_idx_path(backup_prefix)
+
+    with _publication_lock(final_prefix, exclusive=True):
+        old_bin_backed_up = False
+        old_idx_backed_up = False
+        new_bin_published = False
+        new_idx_published = False
+        publication_succeeded = False
+        rollback_succeeded = False
+        try:
+            # Remove the old commit point before moving its data. Readers take
+            # the shared side of this lock while opening both files.
+            if Path(final_idx).exists():
+                _replace_path(final_idx, backup_idx)
+                old_idx_backed_up = True
+            if Path(final_bin).exists():
+                _replace_path(final_bin, backup_bin)
+                old_bin_backed_up = True
+            _replace_path(temporary_bin, final_bin)
+            new_bin_published = True
+            _replace_path(temporary_idx, final_idx)
+            new_idx_published = True
+        except Exception as publication_error:
+            try:
+                if old_bin_backed_up:
+                    _replace_path(backup_bin, final_bin)
+                elif new_bin_published:
+                    _cleanup_path(final_bin)
+                if old_idx_backed_up:
+                    _replace_path(backup_idx, final_idx)
+                elif new_idx_published:
+                    _cleanup_path(final_idx)
+            except Exception as rollback_error:
+                publication_error.add_note(f"Rollback also failed: {rollback_error}")
+                raise publication_error from rollback_error
+            rollback_succeeded = True
+            raise
+        else:
+            publication_succeeded = True
+        finally:
+            # Preserve backups for manual recovery if rollback itself raises.
+            if publication_succeeded or rollback_succeeded:
+                _cleanup_path(backup_bin)
+                _cleanup_path(backup_idx)
+
+
 def write_packed_indexed_dataset(
     rows: Sequence[Mapping[str, Sequence[int | float] | np.ndarray]], output_path: str | Path
 ) -> str:
-    """Write packed SFT rows to one MCore ``.bin/.idx`` pair."""
+    """Write packed SFT rows to a transactionally published MCore pair."""
     if not rows:
         raise ValueError("Cannot write an empty packed SFT IndexedDataset")
+
     prefix = normalize_packed_indexed_prefix(output_path)
-    builder = IndexedDatasetBuilder(get_bin_path(prefix), dtype=np.int32)
+    if is_object_storage_path(prefix):
+        raise ValueError(
+            "Direct writes to object storage are not supported for packed SFT IndexedDataset; "
+            "write a local pair and upload both files before training"
+        )
+
+    # Validate before creating any output, so a malformed later row cannot
+    # truncate an existing valid pair.
     for row in rows:
-        builder.add_item(torch.from_numpy(encode_packed_row(row)))
-        builder.end_document()
-    builder.finalize(get_idx_path(prefix))
+        encode_packed_row(row)
+
+    temporary_prefix = f"{prefix}.tmp-{uuid.uuid4().hex}"
+    temporary_bin = get_bin_path(temporary_prefix)
+    temporary_idx = get_idx_path(temporary_prefix)
+    try:
+        builder = IndexedDatasetBuilder(temporary_bin, dtype=np.int32)
+        for row in rows:
+            builder.add_item(torch.from_numpy(encode_packed_row(row)))
+            builder.end_document()
+        builder.finalize(temporary_idx)
+        _publish_temporary_pair(temporary_prefix, prefix)
+    finally:
+        _cleanup_path(temporary_bin)
+        _cleanup_path(temporary_idx)
     return prefix
 
 
@@ -239,18 +491,39 @@ class PackedSFTIndexedDataset(Sequence[dict[str, np.ndarray | list[int]]]):
         *,
         mmap: bool = True,
         object_storage_config: ObjectStorageConfig | None = None,
+        object_storage_cache_path: str | Path | None = None,
+        object_storage_bin_chunk_nbytes: int = DEFAULT_OBJECT_STORAGE_BIN_CHUNK_NBYTES,
     ) -> None:
         """Initialize the packed indexed reader."""
-        self.prefixes = resolve_packed_indexed_prefixes(path_spec)
-        self.datasets = [
-            IndexedDataset(prefix, mmap=mmap, object_storage_config=object_storage_config) for prefix in self.prefixes
-        ]
+        self.prefixes = resolve_packed_indexed_prefixes_with_retry(path_spec)
+        has_remote_prefix = any(is_object_storage_path(prefix) for prefix in self.prefixes)
+        if has_remote_prefix and object_storage_config is None:
+            object_storage_config = make_object_storage_config(
+                object_storage_cache_path,
+                bin_chunk_nbytes=object_storage_bin_chunk_nbytes,
+            )
+
+        self.datasets = []
+        for prefix in self.prefixes:
+            is_remote = is_object_storage_path(prefix)
+            lock_context = contextlib.nullcontext() if is_remote else _publication_lock(prefix, exclusive=False)
+            with lock_context:
+                dataset = IndexedDataset(
+                    prefix,
+                    mmap=mmap and not is_remote,
+                    object_storage_config=object_storage_config if is_remote else None,
+                )
+                if len(dataset) == 0:
+                    raise ValueError(f"Packed SFT IndexedDataset shard is empty: {prefix}")
+                try:
+                    decode_packed_row(dataset[0], row_index=0)
+                except ValueError as error:
+                    raise ValueError(f"Invalid packed SFT IndexedDataset shard '{prefix}': {error}") from error
+            self.datasets.append(dataset)
+
         self.offsets = [0]
         for dataset in self.datasets:
             self.offsets.append(self.offsets[-1] + len(dataset))
-        if self.offsets[-1] == 0:
-            raise ValueError(f"Packed SFT IndexedDataset is empty: {path_spec}")
-        decode_packed_row(self.datasets[0][0], row_index=0)
 
     def __len__(self) -> int:
         """Return the row count across all shards."""
@@ -283,12 +556,16 @@ class GPTSFTPackedIndexedDataset(GPTSFTPackedDataset):
         pack_metadata_file_path: str | None = None,
         mmap: bool = True,
         object_storage_config: ObjectStorageConfig | None = None,
+        object_storage_cache_path: str | Path | None = None,
+        object_storage_bin_chunk_nbytes: int = DEFAULT_OBJECT_STORAGE_BIN_CHUNK_NBYTES,
         **kwargs: object,
     ) -> None:
         """Initialize an indexed packed GPT SFT dataset."""
         self._path_spec = file_path
         self._mmap = mmap
         self._object_storage_config = object_storage_config
+        self._object_storage_cache_path = object_storage_cache_path
+        self._object_storage_bin_chunk_nbytes = object_storage_bin_chunk_nbytes
         super().__init__(
             file_path=file_path,
             tokenizer=tokenizer,
@@ -301,14 +578,23 @@ class GPTSFTPackedIndexedDataset(GPTSFTPackedDataset):
     def _load_dataset(self) -> None:
         """Load the versioned packed SFT IndexedDataset rows."""
         self.indexed_dataset = PackedSFTIndexedDataset(
-            self._path_spec, mmap=self._mmap, object_storage_config=self._object_storage_config
+            self._path_spec,
+            mmap=self._mmap,
+            object_storage_config=self._object_storage_config,
+            object_storage_cache_path=self._object_storage_cache_path,
+            object_storage_bin_chunk_nbytes=self._object_storage_bin_chunk_nbytes,
         )
 
     def __getitem__(self, index: int) -> dict[str, np.ndarray | list[int]]:
         """Load and decode one packed training sample."""
         is_padding_sample = index < 0
         if self.samples_mapping is not None:
-            index = int(self.samples_mapping[index])
+            mapped_index = self.samples_mapping[index]
+            if isinstance(mapped_index, np.ndarray):
+                mapped_index = mapped_index.reshape(-1)[0]
+            elif isinstance(mapped_index, (tuple, list)):
+                mapped_index = mapped_index[0]
+            index = int(mapped_index)
         row = self.indexed_dataset[index]
         input_ids = row["input_ids"]
         loss_mask = row["loss_mask"]

--- a/src/megatron/bridge/data/packing/indexed.py
+++ b/src/megatron/bridge/data/packing/indexed.py
@@ -1,0 +1,325 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""MCore ``.bin/.idx`` storage for offline-packed GPT SFT samples.
+
+Each IndexedDataset item contains one complete pack. Token IDs use the lower
+31 bits of an int32 word and the target-aligned binary loss mask uses the high
+bit. A versioned header stores the sequence start offsets. This preserves the
+existing packed Parquet semantics while using MCore's mmap-backed storage.
+"""
+
+from __future__ import annotations
+
+import bisect
+import glob
+import os
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import numpy as np
+import torch
+from megatron.core.datasets.indexed_dataset import (
+    IndexedDataset,
+    IndexedDatasetBuilder,
+    get_bin_path,
+    get_idx_path,
+)
+from megatron.core.datasets.object_storage_utils import ObjectStorageConfig
+from megatron.core.msc_utils import MultiStorageClientFeature
+
+from megatron.bridge.data.packing.gpt_sft import GPTSFTPackedDataset
+
+
+if TYPE_CHECKING:
+    from megatron.bridge.training.tokenizers.tokenizer import MegatronTokenizer
+
+
+PACKED_SFT_SUFFIX = ".sft"
+_ROW_MAGIC = 0x53465442  # ASCII "SFTB".
+_FORMAT_VERSION = 1
+_HEADER_WORDS = 3
+_TOKEN_BITS_MASK = np.uint32(0x7FFFFFFF)
+_LOSS_MASK_SHIFT = np.uint32(31)
+
+
+def normalize_packed_indexed_prefix(path: str | Path) -> str:
+    """Normalize a packed IndexedDataset path to its extension-free prefix."""
+    path_str = str(path)
+    if path_str.lower().endswith((".bin", ".idx")):
+        return path_str[:-4]
+    return path_str
+
+
+def _glob_prefixes(pattern: str) -> list[str]:
+    """Resolve a local or MSC glob to complete IndexedDataset prefixes."""
+    if MultiStorageClientFeature.is_enabled():
+        msc = MultiStorageClientFeature.import_package()
+        if hasattr(msc, "glob"):
+            matches = [str(path) for path in msc.glob(pattern)]
+        else:
+            pattern_path = msc.Path(pattern)
+            matches = [str(path) for path in pattern_path.parent.glob(pattern_path.name)]
+    else:
+        matches = glob.glob(pattern)
+    prefixes = {normalize_packed_indexed_prefix(path) for path in matches}
+    return sorted(prefix for prefix in prefixes if IndexedDataset.exists(prefix))
+
+
+def resolve_packed_indexed_prefixes(spec: str | Path) -> list[str]:
+    """Resolve a packed SFT IndexedDataset prefix, pair file, glob, or directory.
+
+    Args:
+        spec: A single prefix, either pair file, glob, or directory containing
+            ``*.sft.bin``/``*.sft.idx`` pairs.
+
+    Returns:
+        Sorted, normalized IndexedDataset prefixes.
+
+    Raises:
+        ValueError: If no complete dataset pair can be resolved.
+    """
+    spec_str = str(spec)
+    if "*" in spec_str or "?" in spec_str:
+        suffix = "" if spec_str.lower().endswith((".bin", ".idx")) else ".idx"
+        prefixes = _glob_prefixes(f"{spec_str}{suffix}")
+        if not prefixes:
+            raise ValueError(f"No packed SFT .bin/.idx datasets found matching: {spec_str}")
+        return prefixes
+
+    if MultiStorageClientFeature.is_enabled():
+        msc = MultiStorageClientFeature.import_package()
+        path = msc.Path(spec_str)
+        is_dir = path.is_dir() if hasattr(path, "is_dir") else False
+    else:
+        path = Path(spec_str)
+        is_dir = path.is_dir()
+    if is_dir:
+        prefixes = _glob_prefixes(os.path.join(spec_str, f"*{PACKED_SFT_SUFFIX}.idx"))
+        if not prefixes:
+            raise ValueError(f"No packed SFT .bin/.idx datasets found in directory: {spec_str}")
+        return prefixes
+
+    prefix = normalize_packed_indexed_prefix(spec_str)
+    if not IndexedDataset.exists(prefix):
+        raise ValueError(
+            f"Packed SFT IndexedDataset is incomplete or missing for prefix '{prefix}'; "
+            f"expected both '{get_bin_path(prefix)}' and '{get_idx_path(prefix)}'"
+        )
+    return [prefix]
+
+
+def is_packed_indexed_dataset(spec: str | Path) -> bool:
+    """Return whether a path resolves to packed SFT ``.bin/.idx`` data."""
+    try:
+        return bool(resolve_packed_indexed_prefixes(spec))
+    except ValueError:
+        return False
+
+
+def _as_integral_vector(value: Sequence[int | float] | np.ndarray, *, field: str) -> np.ndarray:
+    """Validate and normalize one packed-row field as an integer vector."""
+    array = np.asarray(value)
+    if array.ndim != 1:
+        raise ValueError(f"{field} must be one-dimensional, got shape {array.shape}")
+    if array.size == 0:
+        return array.astype(np.int64)
+    if not np.issubdtype(array.dtype, np.integer):
+        raise ValueError(f"{field} must contain integers, got dtype {array.dtype}")
+    return array.astype(np.int64, copy=False)
+
+
+def encode_packed_row(row: Mapping[str, Sequence[int | float] | np.ndarray]) -> np.ndarray:
+    """Encode a Parquet-compatible packed row as versioned int32 words.
+
+    Args:
+        row: Mapping containing ``input_ids``, ``loss_mask``, and
+            ``seq_start_id``.
+
+    Returns:
+        Encoded one-dimensional int32 array.
+
+    Raises:
+        ValueError: If the packed row invariants are violated.
+    """
+    missing = {"input_ids", "loss_mask", "seq_start_id"} - row.keys()
+    if missing:
+        raise ValueError(f"Packed SFT row is missing required fields: {sorted(missing)}")
+
+    input_ids = _as_integral_vector(row["input_ids"], field="input_ids")
+    seq_start_id = _as_integral_vector(row["seq_start_id"], field="seq_start_id")
+    loss_mask = np.asarray(row["loss_mask"])
+    if loss_mask.ndim != 1:
+        raise ValueError(f"loss_mask must be one-dimensional, got shape {loss_mask.shape}")
+    if input_ids.size == 0:
+        raise ValueError("input_ids must not be empty")
+    if loss_mask.size != input_ids.size:
+        raise ValueError(f"loss_mask length ({loss_mask.size}) != input_ids length ({input_ids.size})")
+    if not np.all((loss_mask == 0) | (loss_mask == 1)):
+        raise ValueError("loss_mask must contain only binary 0/1 values")
+    if np.any(input_ids < 0) or np.any(input_ids > int(_TOKEN_BITS_MASK)):
+        raise ValueError(f"input_ids must be in the range [0, {int(_TOKEN_BITS_MASK)}]")
+    if seq_start_id.size == 0 or seq_start_id[0] != 0:
+        raise ValueError("seq_start_id must start with 0")
+    if np.any(seq_start_id < 0) or np.any(seq_start_id >= input_ids.size):
+        raise ValueError("seq_start_id values must be within input_ids")
+    if np.any(seq_start_id[1:] <= seq_start_id[:-1]):
+        raise ValueError("seq_start_id values must be strictly increasing")
+
+    token_words = input_ids.astype(np.uint32) | (loss_mask.astype(np.uint32) << _LOSS_MASK_SHIFT)
+    header = np.asarray([_ROW_MAGIC, _FORMAT_VERSION, seq_start_id.size], dtype=np.int32)
+    return np.concatenate((header, seq_start_id.astype(np.int32), token_words.view(np.int32)))
+
+
+def decode_packed_row(encoded: np.ndarray, *, row_index: int) -> dict[str, np.ndarray | list[int]]:
+    """Decode and validate one packed SFT IndexedDataset item."""
+    if encoded.dtype != np.int32:
+        raise ValueError(f"Packed SFT row {row_index} uses dtype {encoded.dtype}; expected int32")
+    if encoded.ndim != 1 or encoded.size < _HEADER_WORDS + 2:
+        raise ValueError(f"Packed SFT row {row_index} is too short to contain a valid sample")
+    if int(encoded[0]) != _ROW_MAGIC:
+        raise ValueError(f"Packed SFT row {row_index} has invalid magic {int(encoded[0]):#x}")
+    if int(encoded[1]) != _FORMAT_VERSION:
+        raise ValueError(
+            f"Packed SFT row {row_index} uses unsupported format version {int(encoded[1])}; expected {_FORMAT_VERSION}"
+        )
+
+    boundary_count = int(encoded[2])
+    token_offset = _HEADER_WORDS + boundary_count
+    if boundary_count <= 0 or token_offset >= encoded.size:
+        raise ValueError(f"Packed SFT row {row_index} has invalid boundary count {boundary_count}")
+    seq_start_id = encoded[_HEADER_WORDS:token_offset].astype(np.int64)
+    token_words = encoded[token_offset:].view(np.uint32)
+    if seq_start_id[0] != 0:
+        raise ValueError(f"Packed SFT row {row_index} sequence boundaries must start with 0")
+    if np.any(seq_start_id < 0) or np.any(seq_start_id >= token_words.size):
+        raise ValueError(f"Packed SFT row {row_index} has sequence boundaries outside the token range")
+    if np.any(seq_start_id[1:] <= seq_start_id[:-1]):
+        raise ValueError(f"Packed SFT row {row_index} sequence boundaries must be strictly increasing")
+    return {
+        "input_ids": (token_words & _TOKEN_BITS_MASK).astype(np.int64),
+        "loss_mask": (token_words >> _LOSS_MASK_SHIFT).astype(np.int64),
+        "seq_start_id": seq_start_id.tolist(),
+    }
+
+
+def write_packed_indexed_dataset(
+    rows: Sequence[Mapping[str, Sequence[int | float] | np.ndarray]], output_path: str | Path
+) -> str:
+    """Write packed SFT rows to one MCore ``.bin/.idx`` pair."""
+    if not rows:
+        raise ValueError("Cannot write an empty packed SFT IndexedDataset")
+    prefix = normalize_packed_indexed_prefix(output_path)
+    builder = IndexedDatasetBuilder(get_bin_path(prefix), dtype=np.int32)
+    for row in rows:
+        builder.add_item(torch.from_numpy(encode_packed_row(row)))
+        builder.end_document()
+    builder.finalize(get_idx_path(prefix))
+    return prefix
+
+
+class PackedSFTIndexedDataset(Sequence[dict[str, np.ndarray | list[int]]]):
+    """Read one or more packed SFT IndexedDataset shards as one sequence."""
+
+    def __init__(
+        self,
+        path_spec: str | Path,
+        *,
+        mmap: bool = True,
+        object_storage_config: ObjectStorageConfig | None = None,
+    ) -> None:
+        """Initialize the packed indexed reader."""
+        self.prefixes = resolve_packed_indexed_prefixes(path_spec)
+        self.datasets = [
+            IndexedDataset(prefix, mmap=mmap, object_storage_config=object_storage_config) for prefix in self.prefixes
+        ]
+        self.offsets = [0]
+        for dataset in self.datasets:
+            self.offsets.append(self.offsets[-1] + len(dataset))
+        if self.offsets[-1] == 0:
+            raise ValueError(f"Packed SFT IndexedDataset is empty: {path_spec}")
+        decode_packed_row(self.datasets[0][0], row_index=0)
+
+    def __len__(self) -> int:
+        """Return the row count across all shards."""
+        return self.offsets[-1]
+
+    def __getitem__(
+        self, index: int | slice
+    ) -> dict[str, np.ndarray | list[int]] | list[dict[str, np.ndarray | list[int]]]:
+        """Decode one row or a Python slice."""
+        if isinstance(index, slice):
+            start, stop, step = index.indices(len(self))
+            return [self[item_index] for item_index in range(start, stop, step)]
+        normalized_index = index + len(self) if index < 0 else index
+        if normalized_index < 0 or normalized_index >= len(self):
+            raise IndexError(f"Packed SFT row index out of range: {index}")
+        dataset_index = bisect.bisect_right(self.offsets, normalized_index) - 1
+        local_index = normalized_index - self.offsets[dataset_index]
+        return decode_packed_row(self.datasets[dataset_index][local_index], row_index=normalized_index)
+
+
+class GPTSFTPackedIndexedDataset(GPTSFTPackedDataset):
+    """Packed GPT SFT training dataset backed by MCore IndexedDataset."""
+
+    def __init__(
+        self,
+        file_path: str,
+        tokenizer: MegatronTokenizer,
+        return_cu_seqlen: bool = True,
+        pad_cu_seqlens: bool = False,
+        pack_metadata_file_path: str | None = None,
+        mmap: bool = True,
+        object_storage_config: ObjectStorageConfig | None = None,
+        **kwargs: object,
+    ) -> None:
+        """Initialize an indexed packed GPT SFT dataset."""
+        self._path_spec = file_path
+        self._mmap = mmap
+        self._object_storage_config = object_storage_config
+        super().__init__(
+            file_path=file_path,
+            tokenizer=tokenizer,
+            return_cu_seqlen=return_cu_seqlen,
+            pad_cu_seqlens=pad_cu_seqlens,
+            pack_metadata_file_path=pack_metadata_file_path,
+            **kwargs,
+        )
+
+    def _load_dataset(self) -> None:
+        """Load the versioned packed SFT IndexedDataset rows."""
+        self.indexed_dataset = PackedSFTIndexedDataset(
+            self._path_spec, mmap=self._mmap, object_storage_config=self._object_storage_config
+        )
+
+    def __getitem__(self, index: int) -> dict[str, np.ndarray | list[int]]:
+        """Load and decode one packed training sample."""
+        is_padding_sample = index < 0
+        if self.samples_mapping is not None:
+            index = int(self.samples_mapping[index])
+        row = self.indexed_dataset[index]
+        input_ids = row["input_ids"]
+        loss_mask = row["loss_mask"]
+        seq_start_id = row["seq_start_id"]
+        assert isinstance(input_ids, np.ndarray)
+        assert isinstance(loss_mask, np.ndarray)
+        assert isinstance(seq_start_id, list)
+        if is_padding_sample or index < 0:
+            loss_mask = np.zeros_like(loss_mask)
+        return {
+            "input_ids": input_ids,
+            "seq_boundaries": [*seq_start_id, len(input_ids)],
+            "loss_mask": loss_mask,
+        }

--- a/src/megatron/bridge/data/packing/offline.py
+++ b/src/megatron/bridge/data/packing/offline.py
@@ -275,19 +275,24 @@ def prepare_gpt_sft_packed_data(
     finally:
         np.random.set_state(random_state)
 
-    # save output data
+    # IndexedDataset is the default storage. Parquet remains available for
+    # migration and explicit A/B validation.
     output_path_str = str(output_path)
     if output_path_str.lower().endswith((".parquet", ".pq")):
         from megatron.bridge.data.packing.parquet import write_packed_parquet
 
         write_packed_parquet(output_data, output_path)
-    else:
+    elif output_path_str.lower().endswith(".npy"):
         # Legacy .npy format
         if MultiStorageClientFeature.is_enabled():
             msc = MultiStorageClientFeature.import_package()
             msc.numpy.save(output_path, output_data)
         else:
             np.save(output_path, output_data)
+    else:
+        from megatron.bridge.data.packing.indexed import write_packed_indexed_dataset
+
+        write_packed_indexed_dataset(output_data, output_path)
 
     # save packing metadata, packing_metadata is appended to the packing file if it exists
     if output_metadata_path is not None:

--- a/src/megatron/bridge/training/utils/flop_utils.py
+++ b/src/megatron/bridge/training/utils/flop_utils.py
@@ -32,22 +32,24 @@ _lora_seq_stats_cache: dict = {}
 
 
 def _packed_data_exists(path: str | None) -> bool:
-    """Return True if a packed dataset file exists, for both parquet and npy formats.
+    """Return True when an indexed, Parquet, or legacy NumPy pack exists.
 
-    Parquet specs may be a single file, a glob, or a directory, so they are detected
-    with ``is_packed_parquet_spec`` and validated via the packed-parquet resolver
-    rather than a bare ``Path.exists()`` check (which would fail for globs/directories
-    and silently disable LoRA-aware FLOP accounting). This mirrors the format detection
-    in ``calculate_avg_seqlen`` so a spec that passes this gate also reads correctly.
+    Indexed and Parquet specs may be a single dataset, glob, or directory, so
+    each format uses its own resolver instead of a bare ``Path.exists()``
+    check. This mirrors ``calculate_avg_seqlen`` so an accepted path is also
+    readable by LoRA-aware FLOP accounting.
     """
     if not path:
         return False
     try:
+        from megatron.bridge.data.packing.indexed import is_packed_indexed_dataset
         from megatron.bridge.data.packing.paths import (
             is_packed_parquet_spec,
             resolve_packed_parquet_paths,
         )
 
+        if is_packed_indexed_dataset(path):
+            return True
         if is_packed_parquet_spec(path):
             return len(resolve_packed_parquet_paths(path)) > 0
     except Exception:
@@ -695,11 +697,16 @@ def num_floating_point_operations(
             dataset_root = getattr(dataset_cfg, "dataset_root", None) or getattr(dataset_cfg, "hf_output_root", None)
             seq_size = getattr(packed_specs, "packed_sequence_size", None)
             if dataset_root is not None and seq_size is not None:
-                # Prefer the current parquet format; fall back to the deprecated .npy.
-                matches = sorted(Path(dataset_root).glob(f"packed/*/training_{seq_size}.idx.parquet"))
+                # Prefer the default indexed format, then the explicit Parquet
+                # compatibility path, and finally deprecated NumPy data.
+                matches = sorted(Path(dataset_root).glob(f"packed/*/training_{seq_size}.sft.idx"))
+                if matches:
+                    packed_data_path = str(matches[0])[: -len(".idx")]
+                else:
+                    matches = sorted(Path(dataset_root).glob(f"packed/*/training_{seq_size}.idx.parquet"))
                 if not matches:
                     matches = sorted(Path(dataset_root).glob(f"packed/*/training_{seq_size}.npy"))
-                if matches:
+                if matches and packed_data_path is None:
                     packed_data_path = str(matches[0])
         if is_lora and is_squad and is_llama3_70b and _packed_data_exists(packed_data_path):
             gbs = cfg.train.global_batch_size

--- a/src/megatron/bridge/training/utils/flop_utils.py
+++ b/src/megatron/bridge/training/utils/flop_utils.py
@@ -691,6 +691,8 @@ def num_floating_point_operations(
             else None
         )
         packed_data_path = getattr(packed_specs, "packed_train_data_path", None)
+        object_storage_cache_path = getattr(packed_specs, "object_storage_cache_path", None)
+        object_storage_bin_chunk_nbytes = getattr(packed_specs, "object_storage_bin_chunk_nbytes", 256 * 1024 * 1024)
         # If not explicitly set, try to find the file via dataset_root (the GPTSFTDatasetBuilder
         # computes this path dynamically, but dataset_root is available from the config).
         if packed_data_path is None and packed_specs is not None:
@@ -714,7 +716,12 @@ def num_floating_point_operations(
             cache_key = (packed_data_path, gbs, seq_len)
             if cache_key not in _lora_seq_stats_cache:
                 _lora_seq_stats_cache[cache_key] = calculate_avg_seqlen(
-                    packed_data_path, gbs, seq_len, drop_remainder=True
+                    packed_data_path,
+                    gbs,
+                    seq_len,
+                    drop_remainder=True,
+                    object_storage_cache_path=object_storage_cache_path,
+                    object_storage_bin_chunk_nbytes=object_storage_bin_chunk_nbytes,
                 )
             _, avg_tokens, _, avg_seqlen2 = _lora_seq_stats_cache[cache_key]
 

--- a/tests/functional_tests/test_groups/data/builders/test_gpt_sft_builder.py
+++ b/tests/functional_tests/test_groups/data/builders/test_gpt_sft_builder.py
@@ -113,7 +113,7 @@ class TestGPTSFTDatasetBuilder:
         dataset, _ = get_dataset(ensure_test_data)
         train_path_packed = dataset.train_path_packed
 
-        assert PosixPath(train_path_packed) == PosixPath(dataset.default_pack_path / "training_1.idx.parquet")
+        assert PosixPath(train_path_packed) == PosixPath(dataset.default_pack_path / "training_1.sft")
 
         dataset, _ = get_dataset(ensure_test_data, packed_sequence_size=-1)
 
@@ -131,7 +131,7 @@ class TestGPTSFTDatasetBuilder:
         dataset, _ = get_dataset(ensure_test_data)
         validation_path_packed = dataset.validation_path_packed
 
-        assert PosixPath(validation_path_packed) == PosixPath(dataset.default_pack_path / "validation_1.idx.parquet")
+        assert PosixPath(validation_path_packed) == PosixPath(dataset.default_pack_path / "validation_1.sft")
 
         dataset, _ = get_dataset(ensure_test_data, packed_sequence_size=-1)
         try:
@@ -161,7 +161,7 @@ class TestGPTSFTDatasetBuilder:
         dataset, _ = get_dataset(ensure_test_data)
         train_path_packed = dataset.train_path_packed
 
-        assert train_path_packed == msc.Path(str(dataset.default_pack_path / "training_1.idx.parquet"))
+        assert train_path_packed == msc.Path(str(dataset.default_pack_path / "training_1.sft"))
 
         # Validation
         dataset, _ = get_dataset(ensure_test_data, packed_val_data_path=npy_path)
@@ -172,7 +172,7 @@ class TestGPTSFTDatasetBuilder:
         dataset, _ = get_dataset(ensure_test_data)
         validation_path_packed = dataset.validation_path_packed
 
-        assert validation_path_packed == msc.Path(str(dataset.default_pack_path / "validation_1.idx.parquet"))
+        assert validation_path_packed == msc.Path(str(dataset.default_pack_path / "validation_1.sft"))
 
         dataset, _ = get_dataset(ensure_test_data, packed_sequence_size=-1)
 

--- a/tests/functional_tests/test_groups/data/builders/test_gpt_sft_builder.py
+++ b/tests/functional_tests/test_groups/data/builders/test_gpt_sft_builder.py
@@ -22,8 +22,9 @@ from megatron.bridge.data.builders import (
     ChatSFTPreprocessingConfig,
     GPTSFTDatasetConfig,
 )
-from megatron.bridge.data.builders.gpt_sft import GPTSFTDatasetBuilder
+from megatron.bridge.data.builders.gpt_sft import GPTSFTDatasetBuilder, build_gpt_sft_split
 from megatron.bridge.data.packing import PackedSequenceSpecs
+from megatron.bridge.data.packing.indexed import GPTSFTPackedIndexedDataset, write_packed_indexed_dataset
 from megatron.bridge.training.tokenizers.config import TokenizerConfig
 from megatron.bridge.training.tokenizers.tokenizer import build_tokenizer
 
@@ -214,6 +215,34 @@ class TestGPTSFTDatasetBuilder:
         assert datasets[0] is not None
         assert datasets[1] is not None
         assert datasets[2] is not None
+
+    def test_build_indexed_dataset_from_msc_url(self, ensure_test_data):
+        MultiStorageClientFeature.disable()
+        local_prefix = f"{ensure_test_data}/datasets/finetune_msc/remote.sft"
+        PosixPath(local_prefix).parent.mkdir(parents=True, exist_ok=True)
+        write_packed_indexed_dataset(
+            [{"input_ids": [10, 11, 12], "loss_mask": [0, 1, 0], "seq_start_id": [0]}],
+            local_prefix,
+        )
+        prefix = f"msc://default{local_prefix}"
+        tokenizer = build_tokenizer(TokenizerConfig(tokenizer_type="NullTokenizer", vocab_size=128))
+
+        dataset = build_gpt_sft_split(
+            prefix,
+            tokenizer=tokenizer,
+            seq_length=8,
+            memmap_workers=1,
+            seed=1234,
+            packed_sequence_size=8,
+            object_storage_cache_path=f"{ensure_test_data}/packed-sft-index-cache",
+            object_storage_bin_chunk_nbytes=1024,
+            dataset_kwargs={"pad_seq_length_to_mult": 1},
+        )
+
+        assert isinstance(dataset, GPTSFTPackedIndexedDataset)
+        assert MultiStorageClientFeature.is_enabled()
+        assert dataset[0]["input_ids"].tolist() == [10, 11, 12]
+        MultiStorageClientFeature.disable()
 
 
 class TestGPTSFTDatasetBuilderWithChatTemplates:

--- a/tests/unit_tests/data/builders/test_gpt_sft_builder.py
+++ b/tests/unit_tests/data/builders/test_gpt_sft_builder.py
@@ -138,6 +138,7 @@ def test_builder_prepares_and_loads_indexed_packed_data(tmp_path):
         config=GPTSFTDatasetConfig(
             dataset_root=tmp_path,
             seq_length=32,
+            max_train_samples=2,
             enable_offline_packing=True,
             offline_packing_specs=PackedSequenceSpecs(
                 packed_sequence_size=32,
@@ -155,6 +156,7 @@ def test_builder_prepares_and_loads_indexed_packed_data(tmp_path):
     assert builder.validation_path_packed.with_suffix(".sft.bin").is_file()
     assert builder.validation_path_packed.with_suffix(".sft.idx").is_file()
     assert isinstance(train_dataset, GPTSFTPackedIndexedDataset)
+    assert len(train_dataset) == 2
     assert isinstance(validation_dataset, GPTSFTPackedIndexedDataset)
     assert test_dataset is not None
     batch = train_dataset.collate_fn([train_dataset[0]])

--- a/tests/unit_tests/data/builders/test_gpt_sft_builder.py
+++ b/tests/unit_tests/data/builders/test_gpt_sft_builder.py
@@ -20,6 +20,7 @@ import pytest
 from megatron.bridge.data.builders import ChatSFTPreprocessingConfig, GPTSFTDatasetConfig
 from megatron.bridge.data.builders.gpt_sft import GPTSFTDatasetBuilder
 from megatron.bridge.data.packing import PackedSequenceSpecs
+from megatron.bridge.data.packing.indexed import GPTSFTPackedIndexedDataset
 from megatron.bridge.training.tokenizers.config import TokenizerConfig
 from megatron.bridge.training.tokenizers.tokenizer import build_tokenizer
 
@@ -100,3 +101,61 @@ def test_default_pack_path_is_stable_for_equivalent_non_hf_tokenizers(tmp_path):
     first = build()
     second = build()
     assert first.default_pack_path == second.default_pack_path
+
+
+def test_default_packed_paths_use_indexed_dataset_prefixes(tmp_path):
+    builder = GPTSFTDatasetBuilder(
+        config=GPTSFTDatasetConfig(
+            dataset_root=tmp_path,
+            seq_length=128,
+            enable_offline_packing=True,
+            offline_packing_specs=PackedSequenceSpecs(
+                packed_sequence_size=128,
+                tokenizer_model_name="mock-tokenizer",
+            ),
+        ),
+        tokenizer=MagicMock(),
+    )
+
+    assert builder.train_path_packed.name == "training_128.sft"
+    assert builder.validation_path_packed.name == "validation_128.sft"
+
+
+def test_builder_prepares_and_loads_indexed_packed_data(tmp_path):
+    row = '{"input": "one two", "output": "three four"}\n'
+    for split_name in ("training", "validation", "test"):
+        (tmp_path / f"{split_name}.jsonl").write_text(row * 4)
+
+    tokenizer = MagicMock()
+    tokenizer.eos_id = 2
+    tokenizer.eod = 2
+    tokenizer.bos_id = 1
+    tokenizer.pad_id = 0
+    tokenizer.vocab_size = 128
+    tokenizer.space_sensitive = True
+    tokenizer.text_to_ids = lambda text: list(range(3, len(text.split()) + 4))
+    builder = GPTSFTDatasetBuilder(
+        config=GPTSFTDatasetConfig(
+            dataset_root=tmp_path,
+            seq_length=32,
+            enable_offline_packing=True,
+            offline_packing_specs=PackedSequenceSpecs(
+                packed_sequence_size=32,
+                tokenizer_model_name="null",
+                num_tokenizer_workers=1,
+            ),
+        ),
+        tokenizer=tokenizer,
+    )
+
+    train_dataset, validation_dataset, test_dataset = builder.build()
+
+    assert builder.train_path_packed.with_suffix(".sft.bin").is_file()
+    assert builder.train_path_packed.with_suffix(".sft.idx").is_file()
+    assert builder.validation_path_packed.with_suffix(".sft.bin").is_file()
+    assert builder.validation_path_packed.with_suffix(".sft.idx").is_file()
+    assert isinstance(train_dataset, GPTSFTPackedIndexedDataset)
+    assert isinstance(validation_dataset, GPTSFTPackedIndexedDataset)
+    assert test_dataset is not None
+    batch = train_dataset.collate_fn([train_dataset[0]])
+    assert batch["tokens"].shape == batch["labels"].shape == batch["loss_mask"].shape

--- a/tests/unit_tests/data/builders/test_gpt_sft_config.py
+++ b/tests/unit_tests/data/builders/test_gpt_sft_config.py
@@ -137,15 +137,22 @@ def test_hf_rewrite_rejects_explicit_packed_paths(tmp_path):
     [
         ("training.idx.parquet", False, False),
         ("training.idx.parquet", True, True),
+        ("training.sft", False, False),
+        ("training.sft", True, True),
         ("training.npy", False, True),
     ],
 )
 def test_packed_metadata_forwarding_depends_on_format_and_padding(
     monkeypatch, tmp_path, filename, pad_cu_seqlens, expects_metadata
 ):
-    """Test Parquet and legacy packed formats receive metadata when required."""
+    """Test packed formats receive metadata only when their reader requires it."""
     packed_path = tmp_path / filename
-    packed_path.touch()
+    if filename.endswith(".sft"):
+        from megatron.bridge.data.packing.indexed import write_packed_indexed_dataset
+
+        write_packed_indexed_dataset([{"input_ids": [1, 2], "loss_mask": [0, 1], "seq_start_id": [0]}], packed_path)
+    else:
+        packed_path.touch()
     metadata_path = tmp_path / "metadata.jsonl"
     captured = {}
 
@@ -155,10 +162,17 @@ def test_packed_metadata_forwarding_depends_on_format_and_padding(
 
     if filename.endswith(".npy"):
         from megatron.bridge.data.packing import gpt_sft as packed_module
+    elif filename.endswith(".sft"):
+        from megatron.bridge.data.packing import indexed as packed_module
     else:
         from megatron.bridge.data.packing import parquet as packed_module
 
-    dataset_class_name = "GPTSFTPackedDataset" if filename.endswith(".npy") else "GPTSFTPackedParquetDataset"
+    if filename.endswith(".npy"):
+        dataset_class_name = "GPTSFTPackedDataset"
+    elif filename.endswith(".sft"):
+        dataset_class_name = "GPTSFTPackedIndexedDataset"
+    else:
+        dataset_class_name = "GPTSFTPackedParquetDataset"
     monkeypatch.setattr(packed_module, dataset_class_name, _build)
 
     build_gpt_sft_split(

--- a/tests/unit_tests/data/builders/test_gpt_sft_config.py
+++ b/tests/unit_tests/data/builders/test_gpt_sft_config.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
 
 import json
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -47,7 +48,12 @@ def _hf_config(tmp_path, **source_overrides):
 
 
 def test_config_round_trip_is_declarative_and_serializable(tmp_path):
-    specs = PackedSequenceSpecs(packed_sequence_size=128, pad_seq_to_mult=8)
+    specs = PackedSequenceSpecs(
+        packed_sequence_size=128,
+        pad_seq_to_mult=8,
+        object_storage_cache_path=tmp_path / "index-cache",
+        object_storage_bin_chunk_nbytes=1024,
+    )
     config = GPTSFTDatasetConfig(
         seq_length=128,
         hf_dataset=HFDatasetSourceConfig(dataset_name="squad"),
@@ -67,8 +73,23 @@ def test_config_round_trip_is_declarative_and_serializable(tmp_path):
     assert isinstance(restored.hf_dataset, HFDatasetSourceConfig)
     assert restored.hf_dataset.dataset_name == "squad"
     assert restored.offline_packing_specs.packed_sequence_size == 128
+    assert restored.offline_packing_specs.object_storage_cache_path == tmp_path / "index-cache"
+    assert restored.offline_packing_specs.object_storage_bin_chunk_nbytes == 1024
     assert isinstance(restored.preprocessing, PromptCompletionSFTPreprocessingConfig)
     assert "tokenizer" not in serialized
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "error"),
+    [
+        ({"object_storage_cache_path": ""}, "non-empty local path"),
+        ({"object_storage_cache_path": "msc://profile/cache"}, "non-empty local path"),
+        ({"object_storage_bin_chunk_nbytes": 0}, "greater than 0"),
+    ],
+)
+def test_packed_specs_validate_object_storage_settings(kwargs, error):
+    with pytest.raises(ValueError, match=error):
+        PackedSequenceSpecs(packed_sequence_size=128, **kwargs)
 
 
 @pytest.mark.parametrize(
@@ -185,12 +206,17 @@ def test_packed_metadata_forwarding_depends_on_format_and_padding(
         pack_metadata_path=metadata_path,
         pad_cu_seqlens=pad_cu_seqlens,
         pad_seq_to_mult=4,
+        object_storage_cache_path=tmp_path / "index-cache",
+        object_storage_bin_chunk_nbytes=1024,
         dataset_kwargs={"chat": True, "use_hf_tokenizer_chat_template": True},
     )
 
     expected = metadata_path if expects_metadata else None
     assert captured["pack_metadata_file_path"] == expected
     assert captured["pad_seq_to_mult"] == 4
+    if filename.endswith(".sft"):
+        assert captured["object_storage_cache_path"] == tmp_path / "index-cache"
+        assert captured["object_storage_bin_chunk_nbytes"] == 1024
 
 
 def test_build_gpt_sft_split_routes_chat_options(monkeypatch, tmp_path):
@@ -221,6 +247,40 @@ def test_build_gpt_sft_split_routes_chat_options(monkeypatch, tmp_path):
     assert result == str(dataset_path)
     assert captured["use_hf_tokenizer_chat_template"] is True
     assert captured["tool_schemas"] == {"type": "function"}
+
+
+def test_build_gpt_sft_split_retries_ambiguous_indexed_directory(monkeypatch, tmp_path):
+    packed_directory = tmp_path / "packed"
+    packed_directory.mkdir()
+    indexed_attempts = []
+
+    def resolve_indexed(_path):
+        indexed_attempts.append(None)
+        if len(indexed_attempts) == 1:
+            raise ValueError("stale directory entry")
+        return [str(packed_directory / "training.sft")]
+
+    def resolve_parquet(_path):
+        raise ValueError("no parquet files")
+
+    monkeypatch.setattr(builder_mod, "resolve_packed_indexed_prefixes", resolve_indexed)
+    monkeypatch.setattr(builder_mod, "resolve_packed_parquet_paths", resolve_parquet)
+    monkeypatch.setattr(builder_mod.time, "sleep", lambda _seconds: None)
+    from megatron.bridge.data.packing import indexed as packed_module
+
+    monkeypatch.setattr(packed_module, "GPTSFTPackedIndexedDataset", lambda **kwargs: kwargs["file_path"])
+
+    result = build_gpt_sft_split(
+        packed_directory,
+        tokenizer=object(),
+        seq_length=128,
+        memmap_workers=1,
+        seed=1234,
+        packed_sequence_size=128,
+    )
+
+    assert result == str(packed_directory)
+    assert len(indexed_attempts) == 2
 
 
 def test_local_source_rejects_hf_only_settings(tmp_path):
@@ -582,8 +642,11 @@ def test_hf_rewrite_regenerates_existing_builder_managed_packed_data(monkeypatch
         do_test=False,
     )
     builder = GPTSFTDatasetBuilder(config=config, tokenizer=SimpleNamespace(_tokenizer=object()))
-    builder.train_path_packed.touch()
-    builder.validation_path_packed.touch()
+    from megatron.bridge.data.packing.indexed import write_packed_indexed_dataset
+
+    row = {"input_ids": [1, 2], "loss_mask": [0, 1], "seq_start_id": [0]}
+    write_packed_indexed_dataset([row], builder.train_path_packed)
+    write_packed_indexed_dataset([row], builder.validation_path_packed)
     builder.pack_metadata.write_text('[{"stale": true}]')
     pack_calls = []
 
@@ -612,8 +675,11 @@ def test_hf_rewrite_removes_disabled_validation_pack(monkeypatch, tmp_path):
         do_test=False,
     )
     builder = GPTSFTDatasetBuilder(config=config, tokenizer=SimpleNamespace(_tokenizer=object()))
-    builder.train_path_packed.touch()
-    builder.validation_path_packed.touch()
+    from megatron.bridge.data.packing.indexed import write_packed_indexed_dataset
+
+    row = {"input_ids": [1, 2], "loss_mask": [0, 1], "seq_start_id": [0]}
+    write_packed_indexed_dataset([row], builder.train_path_packed)
+    write_packed_indexed_dataset([row], builder.validation_path_packed)
     builder.pack_metadata.write_text('[{"stale": true}]')
     pack_calls = []
 
@@ -626,7 +692,8 @@ def test_hf_rewrite_removes_disabled_validation_pack(monkeypatch, tmp_path):
     builder.prepare_data()
 
     assert len(pack_calls) == 1
-    assert not builder.validation_path_packed.exists()
+    assert not Path(f"{builder.validation_path_packed}.bin").exists()
+    assert not Path(f"{builder.validation_path_packed}.idx").exists()
     assert json.loads(builder.pack_metadata.read_text()) == []
 
 

--- a/tests/unit_tests/data/packing/test_algorithms.py
+++ b/tests/unit_tests/data/packing/test_algorithms.py
@@ -140,8 +140,8 @@ class TestSegmentTreeMatchesLinearScan:
 #   seqlen_sq_accum   = (9+9) + 16         = 34
 # -> (count, total, sq_individual, sq_per_row) = (3/2, 10/2, 34/3, 34/2)
 _AVG_SEQLEN_ROWS = [
-    {"input_ids": list(range(8)), "seq_start_id": [0, 4]},
-    {"input_ids": list(range(5)), "seq_start_id": [0]},
+    {"input_ids": list(range(8)), "loss_mask": [1] * 8, "seq_start_id": [0, 4]},
+    {"input_ids": list(range(5)), "loss_mask": [1] * 5, "seq_start_id": [0]},
 ]
 _AVG_SEQLEN_EXPECTED = (3 / 2, 10 / 2, 34 / 3, 34 / 2)
 
@@ -160,7 +160,7 @@ def _write_avg_seqlen_parquet(path, rows) -> None:
 
 
 class TestCalculateAvgSeqlen:
-    """calculate_avg_seqlen must load npy and parquet (single/glob/dir) identically."""
+    """All supported packed formats must produce identical sequence statistics."""
 
     def _assert_expected(self, stats):
         assert stats == pytest.approx(_AVG_SEQLEN_EXPECTED)
@@ -169,6 +169,22 @@ class TestCalculateAvgSeqlen:
         path = tmp_path / "training_4096.npy"
         np.save(path, np.array(_AVG_SEQLEN_ROWS, dtype=object))
         stats = calculate_avg_seqlen(str(path), gbs=1, max_seq_len=8, drop_remainder=True)
+        self._assert_expected(stats)
+
+    def test_indexed_single_prefix(self, tmp_path):
+        from megatron.bridge.data.packing.indexed import write_packed_indexed_dataset
+
+        prefix = tmp_path / "training_4096.sft"
+        write_packed_indexed_dataset(_AVG_SEQLEN_ROWS, prefix)
+        stats = calculate_avg_seqlen(str(prefix), gbs=1, max_seq_len=8, drop_remainder=True)
+        self._assert_expected(stats)
+
+    def test_indexed_directory_spec(self, tmp_path):
+        from megatron.bridge.data.packing.indexed import write_packed_indexed_dataset
+
+        write_packed_indexed_dataset(_AVG_SEQLEN_ROWS[:1], tmp_path / "shard_000.sft")
+        write_packed_indexed_dataset(_AVG_SEQLEN_ROWS[1:], tmp_path / "shard_001.sft")
+        stats = calculate_avg_seqlen(str(tmp_path), gbs=1, max_seq_len=8, drop_remainder=True)
         self._assert_expected(stats)
 
     def test_parquet_single_file(self, tmp_path):

--- a/tests/unit_tests/data/packing/test_indexed.py
+++ b/tests/unit_tests/data/packing/test_indexed.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import numpy as np
@@ -21,6 +22,7 @@ import pytest
 import torch
 
 from megatron.bridge.data.builders.gpt_sft import build_gpt_sft_split
+from megatron.bridge.data.packing import indexed as indexed_module
 from megatron.bridge.data.packing.indexed import (
     GPTSFTPackedIndexedDataset,
     PackedSFTIndexedDataset,
@@ -28,6 +30,7 @@ from megatron.bridge.data.packing.indexed import (
     encode_packed_row,
     is_packed_indexed_dataset,
     resolve_packed_indexed_prefixes,
+    resolve_packed_indexed_prefixes_with_retry,
     write_packed_indexed_dataset,
 )
 
@@ -51,12 +54,12 @@ def _make_tokenizer() -> MagicMock:
     return tokenizer
 
 
-def _make_training_dataset(path: str) -> GPTSFTPackedIndexedDataset:
+def _make_training_dataset(path: str, *, max_num_samples: int | None = None) -> GPTSFTPackedIndexedDataset:
     return GPTSFTPackedIndexedDataset(
         file_path=path,
         tokenizer=_make_tokenizer(),
         max_seq_length=16,
-        max_num_samples=None,
+        max_num_samples=max_num_samples,
         pad_to_max_length=False,
         pad_seq_length_to_mult=1,
         add_bos=False,
@@ -121,6 +124,176 @@ def test_writer_reader_and_path_resolution(tmp_path) -> None:
         assert actual["seq_start_id"] == expected["seq_start_id"]
 
 
+def test_invalid_overwrite_preserves_existing_pair(tmp_path) -> None:
+    prefix = tmp_path / "train.sft"
+    original_rows = [_make_row(), _make_row(offset=100)]
+    write_packed_indexed_dataset(original_rows, prefix)
+    original_bin = (tmp_path / "train.sft.bin").read_bytes()
+    original_idx = (tmp_path / "train.sft.idx").read_bytes()
+    invalid_row = _make_row(offset=200)
+    invalid_row["loss_mask"][0] = 2
+
+    with pytest.raises(ValueError, match="binary"):
+        write_packed_indexed_dataset([_make_row(offset=300), invalid_row], prefix)
+
+    assert (tmp_path / "train.sft.bin").read_bytes() == original_bin
+    assert (tmp_path / "train.sft.idx").read_bytes() == original_idx
+    assert not list(tmp_path.glob("train.sft.tmp-*"))
+
+
+def test_finalize_failure_preserves_existing_pair_and_cleans_temporary_files(tmp_path, monkeypatch) -> None:
+    prefix = tmp_path / "train.sft"
+    write_packed_indexed_dataset([_make_row()], prefix)
+    original_bin = (tmp_path / "train.sft.bin").read_bytes()
+    original_idx = (tmp_path / "train.sft.idx").read_bytes()
+
+    def fail_finalize(self, idx_path):
+        self.data_file.close()
+        raise OSError("injected finalize failure")
+
+    monkeypatch.setattr(indexed_module.IndexedDatasetBuilder, "finalize", fail_finalize)
+
+    with pytest.raises(OSError, match="injected"):
+        write_packed_indexed_dataset([_make_row(offset=100)], prefix)
+
+    assert (tmp_path / "train.sft.bin").read_bytes() == original_bin
+    assert (tmp_path / "train.sft.idx").read_bytes() == original_idx
+    assert not list(tmp_path.glob("train.sft.tmp-*"))
+
+
+def test_temporary_cleanup_failure_does_not_mask_primary_error(tmp_path, monkeypatch) -> None:
+    def fail_finalize(self, idx_path):
+        self.data_file.close()
+        raise OSError("injected finalize failure")
+
+    original_unlink = indexed_module._unlink_path
+
+    def fail_temporary_cleanup(path):
+        if ".tmp-" in path:
+            raise OSError("injected cleanup failure")
+        original_unlink(path)
+
+    monkeypatch.setattr(indexed_module.IndexedDatasetBuilder, "finalize", fail_finalize)
+    monkeypatch.setattr(indexed_module, "_unlink_path", fail_temporary_cleanup)
+
+    with pytest.raises(OSError, match="injected finalize failure"):
+        write_packed_indexed_dataset([_make_row()], tmp_path / "train.sft")
+
+
+@pytest.mark.parametrize("failing_suffix", [".bin", ".idx"])
+def test_publication_failure_restores_existing_pair(tmp_path, monkeypatch, failing_suffix) -> None:
+    prefix = tmp_path / "train.sft"
+    write_packed_indexed_dataset([_make_row()], prefix)
+    original_bin = (tmp_path / "train.sft.bin").read_bytes()
+    original_idx = (tmp_path / "train.sft.idx").read_bytes()
+    original_replace = indexed_module._replace_path
+    failure_injected = False
+
+    def fail_temporary_publish(source, destination):
+        nonlocal failure_injected
+        if not failure_injected and ".tmp-" in source and source.endswith(failing_suffix):
+            failure_injected = True
+            raise OSError(f"injected {failing_suffix} publication failure")
+        original_replace(source, destination)
+
+    monkeypatch.setattr(indexed_module, "_replace_path", fail_temporary_publish)
+
+    with pytest.raises(OSError, match="publication failure"):
+        write_packed_indexed_dataset([_make_row(offset=100)], prefix)
+
+    assert (tmp_path / "train.sft.bin").read_bytes() == original_bin
+    assert (tmp_path / "train.sft.idx").read_bytes() == original_idx
+    assert not list(tmp_path.glob("train.sft.tmp-*"))
+    assert not list(tmp_path.glob("train.sft.backup-*"))
+
+
+@pytest.mark.parametrize("failing_suffix", [".bin", ".idx"])
+def test_backup_failure_leaves_existing_pair_untouched(tmp_path, monkeypatch, failing_suffix) -> None:
+    prefix = tmp_path / "train.sft"
+    write_packed_indexed_dataset([_make_row()], prefix)
+    original_bin = (tmp_path / "train.sft.bin").read_bytes()
+    original_idx = (tmp_path / "train.sft.idx").read_bytes()
+    original_replace = indexed_module._replace_path
+
+    def fail_backup(source, destination):
+        if source == f"{prefix}{failing_suffix}" and ".backup-" in destination:
+            raise OSError(f"injected {failing_suffix} backup failure")
+        original_replace(source, destination)
+
+    monkeypatch.setattr(indexed_module, "_replace_path", fail_backup)
+
+    with pytest.raises(OSError, match="backup failure"):
+        write_packed_indexed_dataset([_make_row(offset=100)], prefix)
+
+    assert (tmp_path / "train.sft.bin").read_bytes() == original_bin
+    assert (tmp_path / "train.sft.idx").read_bytes() == original_idx
+    assert not list(tmp_path.glob("train.sft.tmp-*"))
+    assert not list(tmp_path.glob("train.sft.backup-*"))
+
+
+def test_writer_rejects_direct_object_storage_output() -> None:
+    with pytest.raises(ValueError, match="write a local pair"):
+        write_packed_indexed_dataset([_make_row()], "msc://profile/train.sft")
+
+
+def test_multi_shard_reader_validates_every_shard(tmp_path) -> None:
+    write_packed_indexed_dataset([_make_row()], tmp_path / "shard_000.sft")
+    invalid_prefix = tmp_path / "shard_001.sft"
+    builder = indexed_module.IndexedDatasetBuilder(f"{invalid_prefix}.bin", dtype=np.int32)
+    builder.add_item(torch.tensor([1, 2, 3, 4, 5], dtype=torch.int32))
+    builder.end_document()
+    builder.finalize(f"{invalid_prefix}.idx")
+
+    with pytest.raises(ValueError, match="shard_001.*invalid magic"):
+        PackedSFTIndexedDataset(tmp_path)
+
+
+def test_indexed_resolution_retries_after_stale_visibility(monkeypatch) -> None:
+    calls = []
+
+    def resolve(_spec):
+        calls.append(None)
+        if len(calls) < 3:
+            raise ValueError("stale")
+        return ["train.sft"]
+
+    monkeypatch.setattr(indexed_module, "resolve_packed_indexed_prefixes", resolve)
+    monkeypatch.setattr(indexed_module, "_refresh_directory_metadata", lambda _spec: None)
+
+    assert resolve_packed_indexed_prefixes_with_retry("train.sft", max_attempts=3, backoff_s=0) == ["train.sft"]
+    assert len(calls) == 3
+
+
+def test_remote_reader_disables_mmap_and_builds_object_storage_config(monkeypatch) -> None:
+    encoded = encode_packed_row(_make_row())
+    observed = []
+
+    class FakeIndexedDataset:
+        def __init__(self, prefix, *, mmap, object_storage_config):
+            observed.append((prefix, mmap, object_storage_config))
+
+        def __len__(self):
+            return 1
+
+        def __getitem__(self, index):
+            assert index == 0
+            return encoded
+
+    config = SimpleNamespace(path_to_idx_cache="/cache", bin_chunk_nbytes=123)
+    monkeypatch.setattr(indexed_module, "resolve_packed_indexed_prefixes", lambda _spec: ["msc://p/train.sft"])
+    monkeypatch.setattr(indexed_module, "make_object_storage_config", lambda *args, **kwargs: config)
+    monkeypatch.setattr(indexed_module, "IndexedDataset", FakeIndexedDataset)
+
+    dataset = PackedSFTIndexedDataset(
+        "msc://p/train.sft",
+        object_storage_cache_path="/cache",
+        object_storage_bin_chunk_nbytes=123,
+    )
+
+    assert len(dataset) == 1
+    assert observed == [("msc://p/train.sft", False, config)]
+
+
 def test_packed_sequence_specs_accepts_complete_indexed_pair(tmp_path) -> None:
     from megatron.bridge.data.packing import PackedSequenceSpecs
 
@@ -168,6 +341,24 @@ def test_negative_index_zeroes_loss_mask(tmp_path) -> None:
     write_packed_indexed_dataset([_make_row()], prefix)
     dataset = _make_training_dataset(str(prefix))
     assert dataset[-1]["loss_mask"].tolist() == [0] * 6
+
+
+def test_samples_mapping_uses_mapped_row_index(tmp_path) -> None:
+    prefix = tmp_path / "train.sft"
+    write_packed_indexed_dataset([_make_row(), _make_row(offset=100)], prefix)
+    dataset = _make_training_dataset(str(prefix))
+    dataset.samples_mapping = np.asarray([[1, 0, 1]], dtype=np.int64)
+
+    assert dataset[0]["input_ids"].tolist() == _make_row(offset=100)["input_ids"]
+
+
+def test_single_row_single_sample_mapping_remains_one_dimensional(tmp_path) -> None:
+    prefix = tmp_path / "train.sft"
+    write_packed_indexed_dataset([_make_row()], prefix)
+    dataset = _make_training_dataset(str(prefix), max_num_samples=1)
+
+    assert dataset.samples_mapping.shape == (1,)
+    assert dataset[0]["input_ids"].tolist() == _make_row()["input_ids"]
 
 
 def test_parquet_and_indexed_produce_identical_samples_and_batches(tmp_path) -> None:

--- a/tests/unit_tests/data/packing/test_indexed.py
+++ b/tests/unit_tests/data/packing/test_indexed.py
@@ -1,0 +1,214 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+import torch
+
+from megatron.bridge.data.builders.gpt_sft import build_gpt_sft_split
+from megatron.bridge.data.packing.indexed import (
+    GPTSFTPackedIndexedDataset,
+    PackedSFTIndexedDataset,
+    decode_packed_row,
+    encode_packed_row,
+    is_packed_indexed_dataset,
+    resolve_packed_indexed_prefixes,
+    write_packed_indexed_dataset,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+def _make_row(offset: int = 0) -> dict[str, list[int]]:
+    return {
+        "input_ids": [10 + offset, 11 + offset, 12 + offset, 20 + offset, 21 + offset, 22 + offset],
+        "loss_mask": [0, 1, 0, 1, 1, 0],
+        "seq_start_id": [0, 3],
+    }
+
+
+def _make_tokenizer() -> MagicMock:
+    tokenizer = MagicMock()
+    tokenizer.eos_id = 999
+    tokenizer.eod = 999
+    tokenizer.pad_id = 999
+    return tokenizer
+
+
+def _make_training_dataset(path: str) -> GPTSFTPackedIndexedDataset:
+    return GPTSFTPackedIndexedDataset(
+        file_path=path,
+        tokenizer=_make_tokenizer(),
+        max_seq_length=16,
+        max_num_samples=None,
+        pad_to_max_length=False,
+        pad_seq_length_to_mult=1,
+        add_bos=False,
+        add_eos=False,
+        add_sep=False,
+        seed=42,
+        label_key="output",
+        answer_only_loss=True,
+        truncation_field="input",
+        prompt_template="{input} {output}",
+        return_cu_seqlen=True,
+    )
+
+
+def test_encode_decode_round_trip_preserves_packed_row() -> None:
+    row = _make_row()
+    encoded = encode_packed_row(row)
+    decoded = decode_packed_row(encoded, row_index=0)
+
+    assert encoded.dtype == np.int32
+    assert np.any(encoded < 0), "enabled loss-mask bits should set the int32 sign bit"
+    np.testing.assert_array_equal(decoded["input_ids"], row["input_ids"])
+    np.testing.assert_array_equal(decoded["loss_mask"], row["loss_mask"])
+    assert decoded["seq_start_id"] == row["seq_start_id"]
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "error"),
+    [
+        ("input_ids", [], "must not be empty"),
+        ("input_ids", [-1, 11, 12, 20, 21, 22], "range"),
+        ("loss_mask", [0, 2, 0, 1, 1, 0], "binary"),
+        ("loss_mask", [0, 1], "length"),
+        ("seq_start_id", [1, 3], "start with 0"),
+        ("seq_start_id", [0, 0], "strictly increasing"),
+    ],
+)
+def test_encode_rejects_invalid_rows(field: str, value: list[int], error: str) -> None:
+    row = _make_row()
+    row[field] = value
+    with pytest.raises(ValueError, match=error):
+        encode_packed_row(row)
+
+
+def test_writer_reader_and_path_resolution(tmp_path) -> None:
+    prefix = tmp_path / "train.sft"
+    rows = [_make_row(), _make_row(offset=100)]
+    assert write_packed_indexed_dataset(rows, prefix) == str(prefix)
+    assert (tmp_path / "train.sft.bin").is_file()
+    assert (tmp_path / "train.sft.idx").is_file()
+    assert is_packed_indexed_dataset(prefix)
+    assert is_packed_indexed_dataset(tmp_path / "train.sft.bin")
+    assert resolve_packed_indexed_prefixes(tmp_path) == [str(prefix)]
+    assert resolve_packed_indexed_prefixes(tmp_path / "*.sft") == [str(prefix)]
+
+    dataset = PackedSFTIndexedDataset(prefix)
+    assert len(dataset) == len(rows)
+    for index, expected in enumerate(rows):
+        actual = dataset[index]
+        np.testing.assert_array_equal(actual["input_ids"], expected["input_ids"])
+        np.testing.assert_array_equal(actual["loss_mask"], expected["loss_mask"])
+        assert actual["seq_start_id"] == expected["seq_start_id"]
+
+
+def test_packed_sequence_specs_accepts_complete_indexed_pair(tmp_path) -> None:
+    from megatron.bridge.data.packing import PackedSequenceSpecs
+
+    prefix = tmp_path / "train.sft"
+    write_packed_indexed_dataset([_make_row()], prefix)
+
+    specs = PackedSequenceSpecs(packed_sequence_size=16, packed_train_data_path=prefix)
+
+    assert specs.packed_train_data_path == str(prefix)
+
+
+def test_training_dataset_preserves_per_sequence_shift_and_mask(tmp_path) -> None:
+    prefix = tmp_path / "train.sft"
+    write_packed_indexed_dataset([_make_row()], prefix)
+    dataset = _make_training_dataset(str(prefix))
+    sample = dataset[0]
+    batch = dataset.collate_fn([sample])
+
+    assert sample["seq_boundaries"] == [0, 3, 6]
+    assert batch["tokens"].tolist() == [[10, 11, 20, 21]]
+    assert batch["labels"].tolist() == [[11, 12, 21, 22]]
+    assert batch["loss_mask"].tolist() == [[0, 1, 1, 1]]
+    assert batch["position_ids"].tolist() == [[0, 1, 0, 1]]
+    assert batch["cu_seqlens"].tolist() == [[0, 2, 4, -1]]
+
+
+def test_builder_routes_indexed_dataset(tmp_path) -> None:
+    prefix = tmp_path / "train.sft"
+    write_packed_indexed_dataset([_make_row()], prefix)
+    dataset = build_gpt_sft_split(
+        prefix,
+        tokenizer=_make_tokenizer(),
+        seq_length=16,
+        memmap_workers=1,
+        seed=42,
+        packed_sequence_size=16,
+        pad_seq_to_mult=1,
+        dataset_kwargs={"pad_seq_length_to_mult": 1},
+    )
+    assert isinstance(dataset, GPTSFTPackedIndexedDataset)
+
+
+def test_negative_index_zeroes_loss_mask(tmp_path) -> None:
+    prefix = tmp_path / "train.sft"
+    write_packed_indexed_dataset([_make_row()], prefix)
+    dataset = _make_training_dataset(str(prefix))
+    assert dataset[-1]["loss_mask"].tolist() == [0] * 6
+
+
+def test_parquet_and_indexed_produce_identical_samples_and_batches(tmp_path) -> None:
+    pytest.importorskip("pyarrow")
+    from megatron.bridge.data.packing.parquet import GPTSFTPackedParquetDataset, write_packed_parquet
+
+    rows = [_make_row(), _make_row(offset=100)]
+    indexed_prefix = tmp_path / "train.sft"
+    parquet_path = tmp_path / "train.idx.parquet"
+    write_packed_indexed_dataset(rows, indexed_prefix)
+    write_packed_parquet(rows, parquet_path)
+    indexed = _make_training_dataset(str(indexed_prefix))
+    parquet = GPTSFTPackedParquetDataset(
+        file_path=str(parquet_path),
+        tokenizer=_make_tokenizer(),
+        max_seq_length=16,
+        max_num_samples=None,
+        pad_to_max_length=False,
+        pad_seq_length_to_mult=1,
+        add_bos=False,
+        add_eos=False,
+        add_sep=False,
+        seed=42,
+        label_key="output",
+        answer_only_loss=True,
+        truncation_field="input",
+        prompt_template="{input} {output}",
+        return_cu_seqlen=True,
+    )
+
+    for row_index in range(len(rows)):
+        indexed_sample = indexed[row_index]
+        parquet_sample = parquet[row_index]
+        np.testing.assert_array_equal(indexed_sample["input_ids"], parquet_sample["input_ids"])
+        np.testing.assert_array_equal(indexed_sample["loss_mask"], parquet_sample["loss_mask"])
+        assert indexed_sample["seq_boundaries"] == parquet_sample["seq_boundaries"]
+        indexed_batch = indexed.collate_fn([indexed_sample])
+        parquet_batch = parquet.collate_fn([parquet_sample])
+        assert indexed_batch.keys() == parquet_batch.keys()
+        for key in indexed_batch:
+            if isinstance(indexed_batch[key], torch.Tensor):
+                torch.testing.assert_close(indexed_batch[key], parquet_batch[key])
+            else:
+                assert indexed_batch[key] == parquet_batch[key]

--- a/tests/unit_tests/data/packing/test_offline.py
+++ b/tests/unit_tests/data/packing/test_offline.py
@@ -14,6 +14,7 @@
 
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import Mock
 
 import numpy as np
 import pytest
@@ -29,6 +30,31 @@ from megatron.bridge.data.packing.offline import (
 
 
 PAD_ID = 0
+
+
+def test_default_output_uses_indexed_dataset_writer(monkeypatch, tmp_path):
+    from megatron.bridge.data.packing import indexed, offline
+
+    rows = [{"input_ids": [1, 2], "loss_mask": [0, 1], "seq_start_id": [0]}]
+    writer = Mock()
+    monkeypatch.setattr(offline, "tokenize_dataset", lambda *args, **kwargs: np.array([], dtype=object))
+    monkeypatch.setattr(offline, "create_hist", lambda *args, **kwargs: ({}, []))
+    monkeypatch.setattr(offline, "create_packing_strategy", lambda *args, **kwargs: ([], {}))
+    monkeypatch.setattr(offline, "fill_packing_strategy", lambda *args, **kwargs: rows)
+    monkeypatch.setattr(indexed, "write_packed_indexed_dataset", writer)
+    prefix = tmp_path / "training_128.sft"
+
+    prepare_gpt_sft_packed_data(
+        input_path=tmp_path / "training.jsonl",
+        output_path=prefix,
+        output_metadata_path=None,
+        packed_sequence_size=128,
+        tokenizer=SimpleNamespace(eos_id=PAD_ID),
+        max_seq_length=128,
+        dataset_builder=Mock(),
+    )
+
+    writer.assert_called_once_with(rows, prefix)
 
 
 def test_configured_seed_controls_offline_packing(monkeypatch):

--- a/tests/unit_tests/scripts/test_compare_packed_sft_formats.py
+++ b/tests/unit_tests/scripts/test_compare_packed_sft_formats.py
@@ -81,3 +81,14 @@ def test_compare_detects_field_mismatch(tmp_path) -> None:
 
     with pytest.raises(ValueError, match="row 2, field 'loss_mask'"):
         module.validate_parity(str(parquet_path), str(indexed_prefix), max_rows=0)
+
+
+def test_compare_detects_row_count_mismatch_with_positive_limit(tmp_path) -> None:
+    module = _load_module()
+    parquet_path = tmp_path / "train.idx.parquet"
+    indexed_prefix = tmp_path / "train.sft"
+    write_packed_parquet(_rows()[:1], parquet_path)
+    write_packed_indexed_dataset(_rows()[:2], indexed_prefix)
+
+    with pytest.raises(ValueError, match="Row count mismatch within comparison range"):
+        module.validate_parity(str(parquet_path), str(indexed_prefix), max_rows=100)

--- a/tests/unit_tests/scripts/test_compare_packed_sft_formats.py
+++ b/tests/unit_tests/scripts/test_compare_packed_sft_formats.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+from megatron.bridge.data.packing.indexed import write_packed_indexed_dataset
+from megatron.bridge.data.packing.parquet import write_packed_parquet
+
+
+pytest.importorskip("pyarrow")
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPT_PATH = _REPO_ROOT / "scripts" / "training" / "compare_packed_sft_formats.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("compare_packed_sft_formats_under_test", _SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    try:
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.modules.pop(spec.name, None)
+
+
+def _rows() -> list[dict[str, list[int]]]:
+    return [
+        {
+            "input_ids": [10 + offset, 11 + offset, 12 + offset, 20 + offset],
+            "loss_mask": [0, 1, 0, 0],
+            "seq_start_id": [0, 3],
+        }
+        for offset in range(4)
+    ]
+
+
+def test_compare_reports_parity_and_read_stats(tmp_path) -> None:
+    module = _load_module()
+    rows = _rows()
+    parquet_path = tmp_path / "train.idx.parquet"
+    indexed_prefix = tmp_path / "train.sft"
+    write_packed_parquet(rows, parquet_path)
+    write_packed_indexed_dataset(rows, indexed_prefix)
+
+    assert module.validate_parity(str(parquet_path), str(indexed_prefix), max_rows=0) == len(rows)
+    parquet_stats = module.benchmark_parquet(str(parquet_path), max_rows=0)
+    indexed_stats = module.benchmark_indexed(str(indexed_prefix), max_rows=0)
+    assert parquet_stats.rows == indexed_stats.rows == len(rows)
+    assert parquet_stats.tokens == indexed_stats.tokens == 16
+    assert parquet_stats.bytes_on_disk > 0
+    assert indexed_stats.bytes_on_disk > 0
+
+
+def test_compare_detects_field_mismatch(tmp_path) -> None:
+    module = _load_module()
+    parquet_rows = _rows()
+    indexed_rows = _rows()
+    indexed_rows[2]["loss_mask"][1] = 0
+    parquet_path = tmp_path / "train.idx.parquet"
+    indexed_prefix = tmp_path / "train.sft"
+    write_packed_parquet(parquet_rows, parquet_path)
+    write_packed_indexed_dataset(indexed_rows, indexed_prefix)
+
+    with pytest.raises(ValueError, match="row 2, field 'loss_mask'"):
+        module.validate_parity(str(parquet_path), str(indexed_prefix), max_rows=0)

--- a/tests/unit_tests/training/utils/test_flop_utils.py
+++ b/tests/unit_tests/training/utils/test_flop_utils.py
@@ -2850,6 +2850,8 @@ class TestLoraSquadPackedFlopBranch:
             offline_packing_specs=SimpleNamespace(
                 packed_train_data_path=packed_train_data_path,
                 packed_sequence_size=seq_len,
+                object_storage_cache_path=None,
+                object_storage_bin_chunk_nbytes=256 * 1024 * 1024,
             ),
             dataset_root=str(dataset_root),
         )
@@ -2899,6 +2901,27 @@ class TestLoraSquadPackedFlopBranch:
         mock_calc.assert_called_once()
         assert mock_calc.call_args.args[0].endswith("training_512.sft")
         assert flops > 0
+
+    def test_forwards_object_storage_reader_settings(self, tmp_path):
+        from megatron.bridge.data.packing.indexed import write_packed_indexed_dataset
+
+        prefix = tmp_path / "training_512.sft"
+        write_packed_indexed_dataset(
+            [{"input_ids": [1, 2], "loss_mask": [0, 1], "seq_start_id": [0]}],
+            prefix,
+        )
+        cfg = self._cfg(tmp_path, seq_len=512, packed_train_data_path=str(prefix))
+        cfg.dataset.offline_packing_specs.object_storage_cache_path = "/shared/index-cache"
+        cfg.dataset.offline_packing_specs.object_storage_bin_chunk_nbytes = 1024
+
+        with patch(
+            "megatron.bridge.training.utils.flop_utils.calculate_avg_seqlen",
+            return_value=(2.0, 10.0, 5.0, 34.0),
+        ) as mock_calc:
+            num_floating_point_operations(cfg, batch_size=1)
+
+        assert mock_calc.call_args.kwargs["object_storage_cache_path"] == "/shared/index-cache"
+        assert mock_calc.call_args.kwargs["object_storage_bin_chunk_nbytes"] == 1024
 
     def test_falls_back_to_npy_when_no_parquet(self, tmp_path):
         # No parquet present -> discovery must fall back to the deprecated .npy.

--- a/tests/unit_tests/training/utils/test_flop_utils.py
+++ b/tests/unit_tests/training/utils/test_flop_utils.py
@@ -2766,7 +2766,7 @@ class TestResolveGlobalFlopsSeqlenStats:
 
 @pytest.mark.unit
 class TestPackedDataExists:
-    """Unit tests for ``_packed_data_exists`` (parquet spec + npy fallback gate).
+    """Unit tests for ``_packed_data_exists`` across packed storage formats.
 
     The helper decides whether the LoRA-aware FLOP branch fires. It must accept
     the same specs the packed-parquet loader does -- a single file, a glob, or a
@@ -2778,6 +2778,13 @@ class TestPackedDataExists:
     def test_none_or_empty_is_false(self):
         assert _packed_data_exists(None) is False
         assert _packed_data_exists("") is False
+
+    def test_indexed_prefix(self, tmp_path):
+        from megatron.bridge.data.packing.indexed import write_packed_indexed_dataset
+
+        prefix = tmp_path / "training_4096.sft"
+        write_packed_indexed_dataset([{"input_ids": [1, 2], "loss_mask": [0, 1], "seq_start_id": [0]}], prefix)
+        assert _packed_data_exists(str(prefix)) is True
 
     def test_parquet_single_file(self, tmp_path):
         f = tmp_path / "training_4096.idx.parquet"
@@ -2811,8 +2818,8 @@ class TestPackedDataExists:
 class TestLoraSquadPackedFlopBranch:
     """The LoRA + SQuAD + Llama-3-70B packed-dataset FLOP branch.
 
-    Exercises the packed-data-path discovery (prefer ``*.idx.parquet``, fall back
-    to the deprecated ``*.npy``) and confirms that when a packed dataset is found
+    Exercises packed-data discovery (prefer indexed data, then Parquet, then
+    deprecated ``*.npy``) and confirms that when a packed dataset is found
     the LoRA-aware (~4ND) branch fires -- i.e. ``calculate_avg_seqlen`` is consulted
     -- instead of falling through to the full-model (6ND) accounting.
     ``calculate_avg_seqlen`` itself is patched (its parquet/npy loading is covered
@@ -2871,6 +2878,26 @@ class TestLoraSquadPackedFlopBranch:
         mock_calc.assert_called_once()
         # The resolved path must be the parquet shard, not the npy.
         assert mock_calc.call_args.args[0].endswith("training_512.idx.parquet")
+        assert flops > 0
+
+    def test_prefers_indexed_and_takes_lora_branch(self, tmp_path):
+        from megatron.bridge.data.packing.indexed import write_packed_indexed_dataset
+
+        packed_dir = tmp_path / "packed" / "run0"
+        packed_dir.mkdir(parents=True)
+        prefix = packed_dir / "training_512.sft"
+        write_packed_indexed_dataset([{"input_ids": [1, 2], "loss_mask": [0, 1], "seq_start_id": [0]}], prefix)
+        (packed_dir / "training_512.idx.parquet").touch()
+        cfg = self._cfg(tmp_path, seq_len=512)
+
+        with patch(
+            "megatron.bridge.training.utils.flop_utils.calculate_avg_seqlen",
+            return_value=(2.0, 10.0, 5.0, 34.0),
+        ) as mock_calc:
+            flops = num_floating_point_operations(cfg, batch_size=1)
+
+        mock_calc.assert_called_once()
+        assert mock_calc.call_args.args[0].endswith("training_512.sft")
         assert flops > 0
 
     def test_falls_back_to_npy_when_no_parquet(self, tmp_path):

--- a/tests/unit_tests/tutorials/test_text_dataset_tutorials.py
+++ b/tests/unit_tests/tutorials/test_text_dataset_tutorials.py
@@ -63,6 +63,12 @@ def test_text_only_sft_tutorial_uses_standard_distributed_launcher():
     assert "uv run python -m torch.distributed.run" in readme
 
 
+def test_text_only_sft_tutorial_documents_indexed_packing_default():
+    readme = (TEXT_ONLY_SFT_TUTORIAL / "README.md").read_text(encoding="utf-8")
+    assert ".sft.bin/.sft.idx" in readme
+    assert "default `.idx.parquet`" not in readme
+
+
 def test_hf_text_only_tutorial_documents_hosted_native_messages_source():
     readme = (HF_TEXT_ONLY_TUTORIAL / "README.md").read_text(encoding="utf-8")
     assert "HuggingFaceH4/ultrachat_200k" in readme

--- a/tests/unit_tests/tutorials/test_text_dataset_tutorials.py
+++ b/tests/unit_tests/tutorials/test_text_dataset_tutorials.py
@@ -12,6 +12,7 @@ pytestmark = pytest.mark.unit
 REPO_ROOT = Path(__file__).parents[3]
 TEXT_ONLY_SFT_TUTORIAL = REPO_ROOT / "tutorials/data/text-only-sft"
 HF_TEXT_ONLY_TUTORIAL = REPO_ROOT / "tutorials/data/hf-text-only"
+PACKED_SFT_INDEXED_TUTORIAL = REPO_ROOT / "docs/training/packed-sft-indexed-dataset.md"
 
 
 def _load_rows(path: Path) -> list[dict]:
@@ -67,6 +68,28 @@ def test_text_only_sft_tutorial_documents_indexed_packing_default():
     readme = (TEXT_ONLY_SFT_TUTORIAL / "README.md").read_text(encoding="utf-8")
     assert ".sft.bin/.sft.idx" in readme
     assert "default `.idx.parquet`" not in readme
+
+
+def test_packed_sft_indexed_tutorial_covers_the_end_to_end_workflow():
+    tutorial = PACKED_SFT_INDEXED_TUTORIAL.read_text(encoding="utf-8")
+
+    for section in (
+        "## Background",
+        "## Prerequisites",
+        "## End-to-End Local Quickstart",
+        "## Integrate with a Python Recipe",
+        "## Read Prebuilt Data from Object Storage",
+        "## Migrate from Packed Parquet",
+        "## Troubleshooting",
+    ):
+        assert section in tutorial
+    assert "prepare_example_data.py" in tutorial
+    assert "prepare_gpt_sft_packed_data.py" in tutorial
+    assert "scripts/training/run_recipe.py" in tutorial
+    assert "checkpoint.pretrained_checkpoint" in tutorial
+    assert "checkpoint.load=null" in tutorial
+    assert "global_batch_size" in tutorial
+    assert "uv sync --extra parquet" in tutorial
 
 
 def test_hf_text_only_tutorial_documents_hosted_native_messages_source():

--- a/tutorials/data/text-only-sft/README.md
+++ b/tutorials/data/text-only-sft/README.md
@@ -1,6 +1,6 @@
 # Text-only SFT Dataset Tutorial
 
-Choose this transitional path when you have local text JSONL, or when you want to normalize a Hugging Face text source into reusable JSONL before SFT or PEFT. It also supports offline packed-Parquet processing and finite `num_epochs` training. The planned prepared `.bin`/`.idx` SFT workflow tracked by Issue #4664 will replace packed Parquet as the recommended scalable prepared-data path. See the [data tutorial overview](../README.md#which-sft-path-should-i-use) if you are deciding between this path and direct SFT.
+Choose this path when you have local text JSONL, or when you want to normalize a Hugging Face text source into reusable JSONL before SFT or PEFT. It supports offline packing into MCore `.sft.bin/.sft.idx` pairs and finite `num_epochs` training. Packed Parquet remains available only as an explicitly configured compatibility format. See the [data tutorial overview](../README.md#which-sft-path-should-i-use) if you are deciding between this path and direct SFT.
 
 You configure the data with `GPTSFTDatasetConfig`; the training framework uses `GPTSFTDatasetBuilder` to bind the tokenizer, materialize sources when needed, prepare offline packing, and construct `GPTSFTDataset` splits.
 
@@ -105,7 +105,7 @@ The builder loads the source, applies the optional registered row adapter, norma
 
 ## Enable offline packing
 
-Offline packing preprocesses examples into packed Parquet plus metadata and reuses it across runs:
+Offline packing preprocesses examples into MCore `.sft.bin/.sft.idx` pairs plus metadata and reuses them across runs:
 
 ```python
 from megatron.bridge.data.packing import PackedSequenceSpecs
@@ -155,7 +155,7 @@ GPTSFTDatasetBuilder(config=dataset, tokenizer=tokenizer).prepare_data()
 PY
 ```
 
-This writes default `.idx.parquet` packed splits and metadata under the dataset root. `scripts/training/prepare_gpt_sft_packed_data.py` is also available when the selected named recipe's dataset schema matches the input files.
+This writes default `.sft.bin/.sft.idx` packed splits and metadata under the dataset root. `scripts/training/prepare_gpt_sft_packed_data.py` is also available when the selected named recipe's dataset schema matches the input files. Existing Parquet packs remain supported when configured explicitly.
 
 Packed SFT requires micro batch size 1. With context parallelism, sequence lengths must be divisible by twice the CP size, `calculate_per_token_loss=True`, and `ddp.average_in_collective=False`. CUDA graphs require padded packed metadata.
 

--- a/tutorials/data/text-only-sft/README.md
+++ b/tutorials/data/text-only-sft/README.md
@@ -161,6 +161,11 @@ Packed SFT requires micro batch size 1. With context parallelism, sequence lengt
 
 For the complete constraints and runtime behavior, see [Packed Sequences](../../../docs/training/packed-sequences.md). Contributors can also use the [sequence-packing validation guide](../../../skills/nemo-mbridge-perf-sequence-packing/SKILL.md) when changing or validating this path.
 
+For a complete indexed-data walkthrough—from background and JSONL preparation
+through `.sft.bin/.sft.idx` inspection, recipe integration, training launch,
+remote storage, and Parquet migration—see
+[Packed SFT with MCore Indexed Datasets](../../../docs/training/packed-sft-indexed-dataset.md).
+
 `train.num_epochs` is supported for this finite dataset only with `dataloader_type="batch"`; Bridge derives the iteration count from the true training split size and keeps the final incomplete global batch.
 
 ## Available knobs


### PR DESCRIPTION
# What does this PR do?

Use Megatron Core `.bin/.idx` IndexedDataset pairs as the default storage for offline-packed text SFT and PEFT data, while retaining explicit Parquet and deprecated NumPy compatibility paths.

# Changelog

- Add a versioned packed-SFT IndexedDataset schema with one pack per item, token IDs in the lower 31 bits, a target-aligned loss-mask bit, and stored sequence boundaries.
- Route offline preparation, runtime loading, path validation, multi-shard resolution, builder-managed caching, and LoRA FLOP statistics through indexed data.
- Change builder-managed outputs from `training_<length>.idx.parquet` to the logical prefix `training_<length>.sft`, producing `.sft.bin` and `.sft.idx`.
- Keep explicit `.parquet` output and loading for migration and A/B checks; keep deprecated `.npy` loading behavior.
- Add bounded stale-NFS retries, per-shard schema checks, sample-cap mapping fixes, and parity checks that detect row-count mismatches.
- Publish local pairs under a reader/writer filesystem lock, restore the previous pair if either publication step fails, and preserve recovery backups if rollback itself fails.
- Support prebuilt `msc://` pairs with automatic MCore feature enablement, shared index-cache configuration, and remote range reads. Direct object-storage writes are rejected: prepare locally and upload `.bin` before `.idx`.
- Add `compare_packed_sft_formats.py` for row-level semantic parity and sequential-read microbenchmarks.
- Add a complete packed SFT indexed-dataset tutorial and update the text-SFT, data-preparation, and packed-sequence guides.

The `.bin/.idx` container is now shared with pretraining, but the packed-SFT payload remains a distinct versioned schema because SFT also needs loss masks and sequence boundaries.

# Validation

- 184 targeted unit/integration executions passed on CW against the original implementation, including end-to-end JSONL -> offline packing -> `.bin/.idx` -> builder load -> packed collate.
- After multiple independent review/fix rounds, focused compatibility-isolated local runs passed: 26 indexed storage tests, 40 packing algorithm/statistics tests, 3 Parquet/indexed comparison tests, 1 end-to-end builder/sample-cap test, and 10 tutorial tests.
- A locked `multi-storage-client==0.51.0` smoke test passed for local pair generation followed by `msc://default` auto-enable, remote index caching/range reading, and row decode.
- Full repository pre-commit passed after the final fixes; `git diff --check`, compile checks, and secret/path scans passed.
- CW/Lustre synthetic warm-read comparison: 512 rows x 4096 tokens (2,097,152 tokens), all `input_ids`, `loss_mask`, and `seq_start_id` values matched in three runs. Median sequential decode was about 2.32M tokens/s for Parquet and 174.9M tokens/s for bin/idx. Storage was 5.16 MiB and 8.03 MiB respectively. This is a decoder microbenchmark, not an end-to-end training-throughput claim.

The full functional builder module previously stalled while downloading legacy Megatron-LM release assets before executing a test. Fresh post-review CW attempts did not enter the Python payload because Pyxis/container initialization stalled on multiple nodes; no test failure occurred. The final changes are therefore covered by focused local tests and still require normal NVIDIA CI validation.

# GitHub Actions CI

This remains a draft PR. NVIDIA unit/L0 workflows have not run because copy-pr-bot requires additional validation before NVIDIA runners can start.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install? No new dependency is added. Parquet remains lazily imported on Parquet-only paths; MSC must already be installed and configured for `msc://` inputs.

# Additional Information

- Follow-up to the prepared SFT `.bin/.idx` direction discussed in #4664.
- Tutorial: `docs/training/packed-sft-indexed-dataset.md`