### PR TITLE
[recipe,doc] fix: Update Qwen3 MoE recipe examples

### DIFF
--- a/docs/fern/versions/nightly/pages/models/qwen/qwen.mdx
+++ b/docs/fern/versions/nightly/pages/models/qwen/qwen.mdx
@@ -232,15 +232,16 @@ uv run python examples/conversion/hf_to_megatron_generate_text.py \
 ```python
 from megatron.bridge.recipes.qwen import qwen3_30b_a3b_pretrain_config
 
-config = qwen3_30b_a3b_pretrain_config(
-    name="qwen3_30b_a3b_pretrain",
-    data_paths=["/path/to/dataset.nvjsonl"],
-    dir="/results/qwen3_30b_a3b",
-    train_iters=500_000,
-    global_batch_size=2048,
-    seq_length=4096,
-    # Uses TP=1, PP=1, EP=16 (16 GPUs) automatically
-)
+config = qwen3_30b_a3b_pretrain_config()
+config.dataset.data_path = "/path/to/dataset_text_document"
+config.checkpoint.save = "/results/qwen3_30b_a3b/checkpoints"
+config.logger.tensorboard_dir = "/results/qwen3_30b_a3b/tb_logs"
+config.train.train_iters = 500_000
+config.train.global_batch_size = 2048
+config.scheduler.lr_decay_iters = 500_000
+config.model.seq_length = 4096
+config.dataset.seq_length = 4096
+# Uses TP=1, PP=1, EP=16 (16 GPUs) automatically
 ```
 
 **Qwen3-235B-A22B**
@@ -248,15 +249,16 @@ config = qwen3_30b_a3b_pretrain_config(
 ```python
 from megatron.bridge.recipes.qwen import qwen3_235b_a22b_pretrain_config
 
-config = qwen3_235b_a22b_pretrain_config(
-    name="qwen3_235b_a22b_pretrain",
-    data_paths=["/path/to/dataset.nvjsonl"],
-    dir="/results/qwen3_235b_a22b",
-    train_iters=500_000,
-    global_batch_size=4096,
-    seq_length=4096,
-    # Uses TP=2, PP=8, EP=32 (512 GPUs) automatically
-)
+config = qwen3_235b_a22b_pretrain_config()
+config.dataset.data_path = "/path/to/dataset_text_document"
+config.checkpoint.save = "/results/qwen3_235b_a22b/checkpoints"
+config.logger.tensorboard_dir = "/results/qwen3_235b_a22b/tb_logs"
+config.train.train_iters = 500_000
+config.train.global_batch_size = 4096
+config.scheduler.lr_decay_iters = 500_000
+config.model.seq_length = 4096
+config.dataset.seq_length = 4096
+# Uses TP=2, PP=8, EP=32 (512 GPUs) automatically
 ```
 
 #### Finetuning Examples
@@ -266,14 +268,13 @@ config = qwen3_235b_a22b_pretrain_config(
 ```python
 from megatron.bridge.recipes.qwen import qwen3_30b_a3b_sft_config
 
-config = qwen3_30b_a3b_sft_config(
-    name="qwen3_30b_a3b_full_sft",
-    pretrained_checkpoint="/results/qwen3_30b_a3b/checkpoints/iter_0500000",
-    train_iters=1000,
-    global_batch_size=64,
-    finetune_lr=5e-6,
-    # Uses TP=1, PP=1, EP=16 (16 GPUs) automatically
-)
+config = qwen3_30b_a3b_sft_config()
+config.checkpoint.pretrained_checkpoint = "/results/qwen3_30b_a3b/checkpoints/iter_0500000"
+config.train.train_iters = 1000
+config.train.global_batch_size = 64
+config.scheduler.lr_decay_iters = 1000
+config.optimizer.lr = 5e-6
+# Uses TP=1, PP=1, EP=16 (16 GPUs) automatically
 ```
 
 **LoRA Finetuning (30B):**
@@ -281,15 +282,13 @@ config = qwen3_30b_a3b_sft_config(
 ```python
 from megatron.bridge.recipes.qwen import qwen3_30b_a3b_peft_config
 
-config = qwen3_30b_a3b_peft_config(
-    name="qwen3_30b_a3b_lora",
-    pretrained_checkpoint="/results/qwen3_30b_a3b/checkpoints/iter_0500000",
-    peft_scheme="lora",  # or "dora"
-    train_iters=1000,
-    global_batch_size=128,
-    finetune_lr=1e-4,
-    # Uses TP=4, PP=1, EP=4 (4 GPUs) automatically
-)
+config = qwen3_30b_a3b_peft_config(peft_scheme="lora")  # or "dora"
+config.checkpoint.pretrained_checkpoint = "/results/qwen3_30b_a3b/checkpoints/iter_0500000"
+config.train.train_iters = 1000
+config.train.global_batch_size = 128
+config.scheduler.lr_decay_iters = 1000
+config.optimizer.lr = 1e-4
+# Uses TP=4, PP=1, EP=4 (4 GPUs) automatically
 ```
 
 ### Hugging Face Model Cards

--- a/docs/models/qwen/qwen.md
+++ b/docs/models/qwen/qwen.md
@@ -232,15 +232,16 @@ uv run python examples/conversion/hf_to_megatron_generate_text.py \
 ```python
 from megatron.bridge.recipes.qwen import qwen3_30b_a3b_pretrain_config
 
-config = qwen3_30b_a3b_pretrain_config(
-    name="qwen3_30b_a3b_pretrain",
-    data_paths=["/path/to/dataset.nvjsonl"],
-    dir="/results/qwen3_30b_a3b",
-    train_iters=500_000,
-    global_batch_size=2048,
-    seq_length=4096,
-    # Uses TP=1, PP=1, EP=16 (16 GPUs) automatically
-)
+config = qwen3_30b_a3b_pretrain_config()
+config.dataset.data_path = "/path/to/dataset_text_document"
+config.checkpoint.save = "/results/qwen3_30b_a3b/checkpoints"
+config.logger.tensorboard_dir = "/results/qwen3_30b_a3b/tb_logs"
+config.train.train_iters = 500_000
+config.train.global_batch_size = 2048
+config.scheduler.lr_decay_iters = 500_000
+config.model.seq_length = 4096
+config.dataset.seq_length = 4096
+# Uses TP=1, PP=1, EP=16 (16 GPUs) automatically
 ```
 
 **Qwen3-235B-A22B**
@@ -248,15 +249,16 @@ config = qwen3_30b_a3b_pretrain_config(
 ```python
 from megatron.bridge.recipes.qwen import qwen3_235b_a22b_pretrain_config
 
-config = qwen3_235b_a22b_pretrain_config(
-    name="qwen3_235b_a22b_pretrain",
-    data_paths=["/path/to/dataset.nvjsonl"],
-    dir="/results/qwen3_235b_a22b",
-    train_iters=500_000,
-    global_batch_size=4096,
-    seq_length=4096,
-    # Uses TP=2, PP=8, EP=32 (512 GPUs) automatically
-)
+config = qwen3_235b_a22b_pretrain_config()
+config.dataset.data_path = "/path/to/dataset_text_document"
+config.checkpoint.save = "/results/qwen3_235b_a22b/checkpoints"
+config.logger.tensorboard_dir = "/results/qwen3_235b_a22b/tb_logs"
+config.train.train_iters = 500_000
+config.train.global_batch_size = 4096
+config.scheduler.lr_decay_iters = 500_000
+config.model.seq_length = 4096
+config.dataset.seq_length = 4096
+# Uses TP=2, PP=8, EP=32 (512 GPUs) automatically
 ```
 
 #### Finetuning Examples
@@ -266,14 +268,13 @@ config = qwen3_235b_a22b_pretrain_config(
 ```python
 from megatron.bridge.recipes.qwen import qwen3_30b_a3b_sft_config
 
-config = qwen3_30b_a3b_sft_config(
-    name="qwen3_30b_a3b_full_sft",
-    pretrained_checkpoint="/results/qwen3_30b_a3b/checkpoints/iter_0500000",
-    train_iters=1000,
-    global_batch_size=64,
-    finetune_lr=5e-6,
-    # Uses TP=1, PP=1, EP=16 (16 GPUs) automatically
-)
+config = qwen3_30b_a3b_sft_config()
+config.checkpoint.pretrained_checkpoint = "/results/qwen3_30b_a3b/checkpoints/iter_0500000"
+config.train.train_iters = 1000
+config.train.global_batch_size = 64
+config.scheduler.lr_decay_iters = 1000
+config.optimizer.lr = 5e-6
+# Uses TP=1, PP=1, EP=16 (16 GPUs) automatically
 ```
 
 **LoRA Finetuning (30B):**
@@ -281,15 +282,13 @@ config = qwen3_30b_a3b_sft_config(
 ```python
 from megatron.bridge.recipes.qwen import qwen3_30b_a3b_peft_config
 
-config = qwen3_30b_a3b_peft_config(
-    name="qwen3_30b_a3b_lora",
-    pretrained_checkpoint="/results/qwen3_30b_a3b/checkpoints/iter_0500000",
-    peft_scheme="lora",  # or "dora"
-    train_iters=1000,
-    global_batch_size=128,
-    finetune_lr=1e-4,
-    # Uses TP=4, PP=1, EP=4 (4 GPUs) automatically
-)
+config = qwen3_30b_a3b_peft_config(peft_scheme="lora")  # or "dora"
+config.checkpoint.pretrained_checkpoint = "/results/qwen3_30b_a3b/checkpoints/iter_0500000"
+config.train.train_iters = 1000
+config.train.global_batch_size = 128
+config.scheduler.lr_decay_iters = 1000
+config.optimizer.lr = 1e-4
+# Uses TP=4, PP=1, EP=4 (4 GPUs) automatically
 ```
 
 ### Hugging Face Model Cards

--- a/tests/unit_tests/doc_consistency/test_readme_consistency.py
+++ b/tests/unit_tests/doc_consistency/test_readme_consistency.py
@@ -59,6 +59,8 @@ QWEN3_DOCS = (
 )
 QWEN3_ALIASES = RECIPES_DIR / "qwen" / "qwen3.py"
 QWEN3_H100_RECIPES = RECIPES_DIR / "qwen" / "h100" / "qwen3.py"
+QWEN3_MOE_ALIASES = RECIPES_DIR / "qwen" / "qwen3_moe.py"
+QWEN3_MOE_H100_RECIPES = RECIPES_DIR / "qwen" / "h100" / "qwen3_moe.py"
 VALOR_TUTORIAL = REPO_ROOT / "tutorials" / "data" / "valor32k-avqa" / "data-preparation.md"
 SPHINX_TUTORIAL_LINK_DOCS = (
     REPO_ROOT / "docs" / "training" / "data-preparation.md",
@@ -344,6 +346,53 @@ def test_qwen3_recipe_examples_use_current_factory_api():
         assert examples.count("config.optimizer.lr =") == 2
         assert examples.count("config.scheduler.lr_decay_iters = 1000") == 2
         assert "config.scheduler.max_lr" not in examples
+
+
+def test_qwen3_moe_recipe_examples_match_source_signatures():
+    """Qwen3-MoE examples must pass only keywords accepted by public recipes."""
+    recipe_names = {
+        "qwen3_30b_a3b_peft_config",
+        "qwen3_30b_a3b_pretrain_config",
+        "qwen3_30b_a3b_sft_config",
+        "qwen3_235b_a22b_pretrain_config",
+    }
+    alias_targets: dict[str, str] = {}
+    for node in ast.parse(_read(QWEN3_MOE_ALIASES), filename=str(QWEN3_MOE_ALIASES)).body:
+        if not isinstance(node, ast.ImportFrom):
+            continue
+        for imported_name in node.names:
+            if imported_name.asname in recipe_names:
+                alias_targets[imported_name.asname] = imported_name.name
+    assert set(alias_targets) == recipe_names
+
+    accepted_keywords: dict[str, set[str]] = {}
+    for node in ast.parse(_read(QWEN3_MOE_H100_RECIPES), filename=str(QWEN3_MOE_H100_RECIPES)).body:
+        if not isinstance(node, ast.FunctionDef) or node.name not in alias_targets.values():
+            continue
+        assert node.args.kwarg is None
+        accepted_keywords[node.name] = {
+            argument.arg for argument in (*node.args.posonlyargs, *node.args.args, *node.args.kwonlyargs)
+        }
+    assert set(accepted_keywords) == set(alias_targets.values())
+
+    for path in QWEN3_DOCS:
+        qwen3_moe_docs = _read(path).split("\n## Qwen3 MoE\n", 1)[1].split("\n## Qwen3\n", 1)[0]
+        examples = qwen3_moe_docs.split("#### Pre-training Examples", 1)[1].split("### Hugging Face Model Cards", 1)[0]
+        calls: dict[str, list[set[str | None]]] = {name: [] for name in recipe_names}
+        for code in re.findall(r"```python\n(.*?)```", examples, re.DOTALL):
+            tree = ast.parse(code, filename=str(path))
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id in calls:
+                    calls[node.func.id].append({keyword.arg for keyword in node.keywords})
+
+        for recipe_name in recipe_names:
+            assert len(calls[recipe_name]) == 1, (
+                f"{path.relative_to(REPO_ROOT)} should call {recipe_name} exactly once: {calls[recipe_name]}"
+            )
+            unsupported = calls[recipe_name][0] - accepted_keywords[alias_targets[recipe_name]]
+            assert not unsupported, (
+                f"{path.relative_to(REPO_ROOT)} calls {recipe_name} with unsupported keywords: {sorted(unsupported)}"
+            )
 
 
 def test_qwen3_recipe_examples_match_source_signatures_and_nested_owners():


### PR DESCRIPTION
# What does this PR do?

Fix the published Qwen3-MoE pretraining, SFT, and PEFT examples so they use the current public recipe factory and nested `ConfigContainer` APIs.

# Bug and root cause

The maintained Qwen3-MoE examples still passed removed flat factory keywords such as `name`, `data_paths`, `pretrained_checkpoint`, and `finetune_lr`.

The public recipe names are direct aliases to parameterless pretraining/SFT factories and PEFT factories that accept only `peft_scheme`. Copying any of the four training examples therefore raised `TypeError` during Python argument binding, before a config could be constructed.

# Fix

- Call pretraining and SFT factories without arguments and pass only `peft_scheme` to PEFT.
- Apply dataset, checkpoint, logging, training, scheduler, optimizer, and sequence-length overrides to their owning nested configs.
- Keep the two maintained documentation mirrors identical.
- Add a stdlib-only contract that resolves public aliases to canonical signatures and checks all four documented calls.

# Validation

Fail before:

```text
uv run --no-project --python 3.12 python tests/unit_tests/doc_consistency/test_readme_consistency.py
16/17 passed
AssertionError: docs/models/qwen/qwen.md calls qwen3_30b_a3b_peft_config with unsupported keywords
```

Pass after:

```text
uv run --no-project --python 3.12 python tests/unit_tests/doc_consistency/test_readme_consistency.py
17/17 passed

git diff --check
passed

uv run pre-commit run --all-files
all hooks passed
```

# Scope

This is limited to Qwen3-MoE recipe documentation and its stdlib contract test. It does not change recipe implementations, public APIs, dependencies, CI workflows, or the Megatron-LM submodule. No GPU, distributed, convergence, model-quality, or performance validation was required or performed.
