### PR TITLE
fix(peft): sync grouped expert LoRA over expert DP

### DIFF
--- a/src/megatron/bridge/peft/utils.py
+++ b/src/megatron/bridge/peft/utils.py
@@ -1792,8 +1792,9 @@ class GroupedExpertLinearAdapter(nn.Module):
         self.pg_collection = _get_pg_collection(
             pg_collection,
             model_parallel_config,
-            required_pgs=["ep", "expt_tp", "expt_dp"],
+            required_pgs=["tp", "ep", "expt_tp", "expt_dp"],
         )
+        tensor_parallel_group = _get_tensor_parallel_group(self.pg_collection)
         self.expert_tp_group = _get_tensor_parallel_group(self.pg_collection, is_expert=True)
         self.ep_group = _get_process_group(self.pg_collection, "ep")
         self.expert_dp_group = _get_process_group(self.pg_collection, "expt_dp")
@@ -1803,6 +1804,10 @@ class GroupedExpertLinearAdapter(nn.Module):
         expert_tp_size = _process_group_size(
             self.expert_tp_group,
             model_parallel_config.expert_tensor_parallel_size or 1,
+        )
+        tensor_parallel_size = _process_group_size(
+            tensor_parallel_group,
+            getattr(model_parallel_config, "tensor_model_parallel_size", 1) or 1,
         )
         linear_in_tp_axis = 2 if input_is_parallel else 1
         linear_out_tp_axis = 1
@@ -1841,12 +1846,13 @@ class GroupedExpertLinearAdapter(nn.Module):
         ParallelLinearAdapter._get_init_fn(self, column_init_method)(linear_in_weight)
         ParallelLinearAdapter._get_init_fn(self, row_init_method)(linear_out_weight)
 
-        expert_parallel = (
+        use_expert_process_groups = (
             _process_group_size(
                 self.ep_group,
                 model_parallel_config.expert_model_parallel_size or 1,
             )
             > 1
+            or expert_tp_size != tensor_parallel_size
         )
         self._linear_in_tp_axis = linear_in_tp_axis
         self._linear_out_tp_axis = linear_out_tp_axis
@@ -1856,7 +1862,7 @@ class GroupedExpertLinearAdapter(nn.Module):
             (self.linear_in.weight, linear_in_tp_axis),
             (self.linear_out.weight, linear_out_tp_axis),
         ):
-            setattr(weight, "allreduce", not expert_parallel)
+            setattr(weight, "allreduce", not use_expert_process_groups)
             if tp_axis is not None:
                 set_tensor_model_parallel_attributes(weight, True, tp_axis, 1)
 

--- a/tests/unit_tests/peft/test_utils.py
+++ b/tests/unit_tests/peft/test_utils.py
@@ -2226,11 +2226,32 @@ class TestGroupedExpertLinearAdapter:
         )
         torch.testing.assert_close(merged, expected)
 
-    @pytest.mark.parametrize(("ep_size", "expected_allreduce"), [(1, True), (2, False)])
-    def test_grouped_expert_linear_adapter_allreduce_flag_tracks_expert_parallelism(self, ep_size, expected_allreduce):
-        """Per-expert grouped adapters should use expert-DP grad sync only when EP is enabled."""
+    @pytest.mark.parametrize(
+        ("ep_size", "tp_size", "etp_size", "expected_allreduce"),
+        [
+            pytest.param(1, 1, 1, True, id="ordinary-dp"),
+            pytest.param(2, 1, 1, False, id="expert-dp-with-ep"),
+            pytest.param(1, 2, 1, False, id="expert-dp-with-tp-greater-than-etp"),
+            pytest.param(1, 1, 2, False, id="expert-dp-with-etp-greater-than-tp"),
+        ],
+    )
+    def test_grouped_expert_linear_adapter_allreduce_flag_tracks_expert_topology(
+        self,
+        ep_size,
+        tp_size,
+        etp_size,
+        expected_allreduce,
+    ):
+        """Per-expert grouped adapters should select DP from the full expert topology."""
         config = MockModelParallelConfig()
-        config._pg_collection = make_mock_pg_collection(ep_size=ep_size, etp_size=1)
+        config.tensor_model_parallel_size = tp_size
+        config.expert_model_parallel_size = ep_size
+        config.expert_tensor_parallel_size = etp_size
+        config._pg_collection = make_mock_pg_collection(
+            tp_size=tp_size,
+            ep_size=ep_size,
+            etp_size=etp_size,
+        )
         adapter = GroupedExpertLinearAdapter(
             in_features=2,
             out_features=2,
@@ -2249,17 +2270,20 @@ class TestGroupedExpertLinearAdapter:
         assert adapter.linear_in.weight.partition_dim == 1
         assert adapter.linear_out.weight.partition_dim == 1
 
-    def test_grouped_expert_linear_adapter_groups_as_expert_ddp_buffer_when_ep_enabled(self):
-        """Per-expert adapter params must sync on expert-DP, not dense DP.
+    def test_grouped_expert_linear_adapter_groups_as_expert_ddp_buffer_when_etp_differs(self):
+        """Per-expert adapter params must sync on expert-DP when ETP differs from TP.
 
-        EP plus DP replicates each local expert across expert-DP ranks. Marking
-        these params as expert-parallel keeps replicas for the same expert in
-        sync without mixing different EP-owned experts.
+        Even with EP=1, differing TP and ETP topologies require the expert-DP
+        buffer so replicas synchronize over the process group that owns them.
         """
         from megatron.core.distributed.param_and_grad_buffer import group_params_for_buffers
+        from megatron.core.optimizer.param_layout import BufferKey
 
         config = MockModelParallelConfig()
-        config._pg_collection = make_mock_pg_collection(ep_size=8, etp_size=1)
+        config.tensor_model_parallel_size = 2
+        config.expert_model_parallel_size = 1
+        config.expert_tensor_parallel_size = 1
+        config._pg_collection = make_mock_pg_collection(tp_size=2, ep_size=1, etp_size=1)
         adapter = GroupedExpertLinearAdapter(
             in_features=2,
             out_features=2,
@@ -2271,18 +2295,12 @@ class TestGroupedExpertLinearAdapter:
             model_parallel_config=config,
         )
 
-        buffer_groups = group_params_for_buffers(
-            [adapter.linear_in.weight, adapter.linear_out.weight],
-            grad_reduce_in_fp32=False,
-        )
+        buffer_groups = group_params_for_buffers([adapter.linear_in.weight], grad_reduce_in_fp32=False)
 
         assert len(buffer_groups) == 1
         buffer_key, (params, _param_indices) = next(iter(buffer_groups.items()))
-        assert buffer_key.is_expert_parallel
-        assert [id(param) for param in params] == [
-            id(adapter.linear_in.weight),
-            id(adapter.linear_out.weight),
-        ]
+        assert buffer_key == BufferKey(torch.float32, torch.float32, True)
+        assert params == [adapter.linear_in.weight]
 
     def test_grouped_expert_linear_sharded_state_dict_uses_expert_parallel_offsets(self):
         """Grouped-expert weights should shard only across expert EP/ETP and use expert-DP replica ids."""


### PR DESCRIPTION
## What does this PR do?

Marks grouped-expert LoRA parameters for expert-DP synchronization whenever expert parallelism is enabled or expert TP differs from regular TP. This aligns Bridge-created adapter parameters with the MCore expert-parameter process-group contract and ensures `group_params_for_buffers()` produces expert `BufferKey` entries.

## Test design and evidence

Tests cover the complete topology matrix:

- EP=1 and TP=ETP: ordinary DP
- EP>1: expert DP
- EP=1 and TP>ETP: expert DP
- EP=1 and ETP>TP: expert DP
- Pinned MCore buffer grouping for an affected adapter parameter

Before the fix, the two TP/ETP mismatch cases and the expert `BufferKey` assertion failed: the adapter had `allreduce=True` and was grouped into ordinary DP. After the fix, all five focused cases pass.

A two-GPU distributed repro using real NCCL process groups confirmed the same red-to-green transition for EP=1, TP=2, ETP=1: before the fix `(allreduce, is_expert_parallel) == (True, False)`; after the fix the workload completed with the expected `(False, True)`.

## Validation

- `uv run python -m pytest tests/unit_tests/peft/test_utils.py tests/unit_tests/peft/test_lora.py tests/unit_tests/peft/test_canonical_lora.py tests/unit_tests/peft/test_multi_lora_layers.py -k "not MegatronIntegration" -q` — 212 passed, 8 skipped, 5 deselected
- `uv run python -m torch.distributed.run --standalone --nproc_per_node=2 ...` — passed
- `uv run pre-commit run --all-files` — passed
- `git diff --check` — passed

Fixes #5229