### PR TITLE
[recipe,doc] fix: Update Qwen3-Next recipe examples

### DIFF
--- a/docs/fern/versions/nightly/pages/models/qwen/qwen.mdx
+++ b/docs/fern/versions/nightly/pages/models/qwen/qwen.mdx
@@ -106,23 +106,24 @@ uv run python examples/conversion/hf_to_megatron_generate_text.py \
 
 | Model | Mode | TP | PP | EP | Total GPUs | Use Case |
 |-------|------|----|----|----|-----------:|----------|
-| **Qwen3-Next-80B** | Pretrain | 2 | 8 | 16 | 256 | Pre-training (32 nodes) |
-| **Qwen3-Next-80B** | Full SFT | 2 | 8 | 16 | 256 | Full supervised finetuning (32 nodes) |
+| **Qwen3-Next-80B** | Pretrain | 1 | 4 | 8 | 32 | Pre-training (4 nodes) |
+| **Qwen3-Next-80B** | Full SFT | 1 | 2 | 8 | 16 | Full supervised finetuning (2 nodes) |
 
 #### Pre-training Example
 
 ```python
 from megatron.bridge.recipes.qwen import qwen3_next_80b_a3b_pretrain_config
 
-config = qwen3_next_80b_a3b_pretrain_config(
-    name="qwen3_next_80b_pretrain",
-    data_paths=["/path/to/dataset.nvjsonl"],
-    dir="/results/qwen3_next_80b",
-    train_iters=500_000,
-    global_batch_size=2048,
-    seq_length=4096,
-    # Uses TP=2, PP=8, EP=16 (256 GPUs) automatically
-)
+config = qwen3_next_80b_a3b_pretrain_config()
+config.dataset.data_path = "/path/to/dataset_text_document"
+config.checkpoint.save = "/results/qwen3_next_80b/checkpoints"
+config.logger.tensorboard_dir = "/results/qwen3_next_80b/tb_logs"
+config.train.train_iters = 500_000
+config.train.global_batch_size = 2048
+config.scheduler.lr_decay_iters = 500_000
+config.model.seq_length = 4096
+config.dataset.seq_length = 4096
+# Uses TP=1, PP=4, EP=8 (32 GPUs) automatically
 ```
 
 #### Finetuning Example
@@ -130,14 +131,13 @@ config = qwen3_next_80b_a3b_pretrain_config(
 ```python
 from megatron.bridge.recipes.qwen import qwen3_next_80b_a3b_sft_config
 
-config = qwen3_next_80b_a3b_sft_config(
-    name="qwen3_next_80b_full_sft",
-    pretrained_checkpoint="/results/qwen3_next_80b/checkpoints/iter_0500000",
-    train_iters=1000,
-    global_batch_size=64,
-    finetune_lr=5e-6,
-    # Uses TP=2, PP=8, EP=16 (256 GPUs) automatically
-)
+config = qwen3_next_80b_a3b_sft_config()
+config.checkpoint.pretrained_checkpoint = "/results/qwen3_next_80b/checkpoints/iter_0500000"
+config.train.train_iters = 1000
+config.train.global_batch_size = 64
+config.scheduler.lr_decay_iters = 1000
+config.optimizer.lr = 5e-6
+# Uses TP=1, PP=2, EP=8 (16 GPUs) automatically
 ```
 
 **Note**: PEFT (LoRA/DoRA) finetuning is not currently available for Qwen3-Next models.

--- a/docs/models/qwen/qwen.md
+++ b/docs/models/qwen/qwen.md
@@ -106,23 +106,24 @@ uv run python examples/conversion/hf_to_megatron_generate_text.py \
 
 | Model | Mode | TP | PP | EP | Total GPUs | Use Case |
 |-------|------|----|----|----|-----------:|----------|
-| **Qwen3-Next-80B** | Pretrain | 2 | 8 | 16 | 256 | Pre-training (32 nodes) |
-| **Qwen3-Next-80B** | Full SFT | 2 | 8 | 16 | 256 | Full supervised finetuning (32 nodes) |
+| **Qwen3-Next-80B** | Pretrain | 1 | 4 | 8 | 32 | Pre-training (4 nodes) |
+| **Qwen3-Next-80B** | Full SFT | 1 | 2 | 8 | 16 | Full supervised finetuning (2 nodes) |
 
 #### Pre-training Example
 
 ```python
 from megatron.bridge.recipes.qwen import qwen3_next_80b_a3b_pretrain_config
 
-config = qwen3_next_80b_a3b_pretrain_config(
-    name="qwen3_next_80b_pretrain",
-    data_paths=["/path/to/dataset.nvjsonl"],
-    dir="/results/qwen3_next_80b",
-    train_iters=500_000,
-    global_batch_size=2048,
-    seq_length=4096,
-    # Uses TP=2, PP=8, EP=16 (256 GPUs) automatically
-)
+config = qwen3_next_80b_a3b_pretrain_config()
+config.dataset.data_path = "/path/to/dataset_text_document"
+config.checkpoint.save = "/results/qwen3_next_80b/checkpoints"
+config.logger.tensorboard_dir = "/results/qwen3_next_80b/tb_logs"
+config.train.train_iters = 500_000
+config.train.global_batch_size = 2048
+config.scheduler.lr_decay_iters = 500_000
+config.model.seq_length = 4096
+config.dataset.seq_length = 4096
+# Uses TP=1, PP=4, EP=8 (32 GPUs) automatically
 ```
 
 #### Finetuning Example
@@ -130,14 +131,13 @@ config = qwen3_next_80b_a3b_pretrain_config(
 ```python
 from megatron.bridge.recipes.qwen import qwen3_next_80b_a3b_sft_config
 
-config = qwen3_next_80b_a3b_sft_config(
-    name="qwen3_next_80b_full_sft",
-    pretrained_checkpoint="/results/qwen3_next_80b/checkpoints/iter_0500000",
-    train_iters=1000,
-    global_batch_size=64,
-    finetune_lr=5e-6,
-    # Uses TP=2, PP=8, EP=16 (256 GPUs) automatically
-)
+config = qwen3_next_80b_a3b_sft_config()
+config.checkpoint.pretrained_checkpoint = "/results/qwen3_next_80b/checkpoints/iter_0500000"
+config.train.train_iters = 1000
+config.train.global_batch_size = 64
+config.scheduler.lr_decay_iters = 1000
+config.optimizer.lr = 5e-6
+# Uses TP=1, PP=2, EP=8 (16 GPUs) automatically
 ```
 
 **Note**: PEFT (LoRA/DoRA) finetuning is not currently available for Qwen3-Next models.

--- a/tests/unit_tests/doc_consistency/test_readme_consistency.py
+++ b/tests/unit_tests/doc_consistency/test_readme_consistency.py
@@ -61,6 +61,8 @@ QWEN3_ALIASES = RECIPES_DIR / "qwen" / "qwen3.py"
 QWEN3_H100_RECIPES = RECIPES_DIR / "qwen" / "h100" / "qwen3.py"
 QWEN3_MOE_ALIASES = RECIPES_DIR / "qwen" / "qwen3_moe.py"
 QWEN3_MOE_H100_RECIPES = RECIPES_DIR / "qwen" / "h100" / "qwen3_moe.py"
+QWEN3_NEXT_ALIASES = RECIPES_DIR / "qwen" / "qwen3_next.py"
+QWEN3_NEXT_H100_RECIPES = RECIPES_DIR / "qwen" / "h100" / "qwen3_next.py"
 VALOR_TUTORIAL = REPO_ROOT / "tutorials" / "data" / "valor32k-avqa" / "data-preparation.md"
 SPHINX_TUTORIAL_LINK_DOCS = (
     REPO_ROOT / "docs" / "training" / "data-preparation.md",
@@ -393,6 +395,103 @@ def test_qwen3_moe_recipe_examples_match_source_signatures():
             assert not unsupported, (
                 f"{path.relative_to(REPO_ROOT)} calls {recipe_name} with unsupported keywords: {sorted(unsupported)}"
             )
+
+
+def test_qwen3_next_recipe_examples_match_source_contracts():
+    """Qwen3-Next examples must match factory signatures, config ownership, and topology."""
+    assert _read(QWEN3_DOCS[0]) == _read(QWEN3_DOCS[1])
+    recipe_names = {
+        "qwen3_next_80b_a3b_pretrain_config",
+        "qwen3_next_80b_a3b_sft_config",
+    }
+    alias_targets: dict[str, str] = {}
+    for node in ast.parse(_read(QWEN3_NEXT_ALIASES), filename=str(QWEN3_NEXT_ALIASES)).body:
+        if not isinstance(node, ast.ImportFrom):
+            continue
+        for imported_name in node.names:
+            if imported_name.asname in recipe_names:
+                alias_targets[imported_name.asname] = imported_name.name
+    assert set(alias_targets) == recipe_names
+
+    accepted_keywords: dict[str, set[str]] = {}
+    for node in ast.parse(_read(QWEN3_NEXT_H100_RECIPES), filename=str(QWEN3_NEXT_H100_RECIPES)).body:
+        if not isinstance(node, ast.FunctionDef) or node.name not in alias_targets.values():
+            continue
+        assert node.args.kwarg is None
+        accepted_keywords[node.name] = {
+            argument.arg for argument in (*node.args.posonlyargs, *node.args.args, *node.args.kwonlyargs)
+        }
+    assert set(accepted_keywords) == set(alias_targets.values())
+
+    assignments_by_recipe: dict[str, dict[str, object]] = {}
+    for path in QWEN3_DOCS:
+        section = _read(path).split("\n## Qwen3-Next\n", 1)[1].split("\n## Qwen3 MoE\n", 1)[0]
+        examples = section.split("#### Pre-training Example", 1)[1].split("### Hugging Face Model Cards", 1)[0]
+        calls: dict[str, list[ast.Call]] = {name: [] for name in recipe_names}
+        for code in re.findall(r"```python\n(.*?)```", examples, re.DOTALL):
+            tree = ast.parse(code, filename=str(path))
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id in calls:
+                    calls[node.func.id].append(node)
+
+            recipe_name = next(
+                (
+                    node.value.func.id
+                    for node in tree.body
+                    if isinstance(node, ast.Assign)
+                    and isinstance(node.value, ast.Call)
+                    and isinstance(node.value.func, ast.Name)
+                    and node.value.func.id in recipe_names
+                ),
+                None,
+            )
+            if path == QWEN3_DOCS[0] and recipe_name is not None:
+                assignments_by_recipe[recipe_name] = {
+                    ast.unparse(node.targets[0]): ast.literal_eval(node.value)
+                    for node in tree.body
+                    if isinstance(node, ast.Assign)
+                    and len(node.targets) == 1
+                    and ast.unparse(node.targets[0]).startswith("config.")
+                }
+
+        for recipe_name in recipe_names:
+            assert len(calls[recipe_name]) == 1
+            documented_keywords = {keyword.arg for keyword in calls[recipe_name][0].keywords}
+            unsupported = documented_keywords - accepted_keywords[alias_targets[recipe_name]]
+            assert not unsupported, (
+                f"{path.relative_to(REPO_ROOT)} calls {recipe_name} with unsupported keywords: {sorted(unsupported)}"
+            )
+
+    expected_owners = {
+        "qwen3_next_80b_a3b_pretrain_config": {
+            "config.dataset.data_path",
+            "config.checkpoint.save",
+            "config.logger.tensorboard_dir",
+            "config.train.train_iters",
+            "config.train.global_batch_size",
+            "config.scheduler.lr_decay_iters",
+            "config.model.seq_length",
+            "config.dataset.seq_length",
+        },
+        "qwen3_next_80b_a3b_sft_config": {
+            "config.checkpoint.pretrained_checkpoint",
+            "config.train.train_iters",
+            "config.train.global_batch_size",
+            "config.scheduler.lr_decay_iters",
+            "config.optimizer.lr",
+        },
+    }
+    assert set(assignments_by_recipe) == recipe_names
+    for recipe_name, expected_fields in expected_owners.items():
+        assignments = assignments_by_recipe[recipe_name]
+        assert set(assignments) == expected_fields
+        assert assignments["config.scheduler.lr_decay_iters"] == assignments["config.train.train_iters"]
+
+    docs_lines = set(_read(QWEN3_DOCS[0]).splitlines())
+    assert {
+        "| **Qwen3-Next-80B** | Pretrain | 1 | 4 | 8 | 32 | Pre-training (4 nodes) |",
+        "| **Qwen3-Next-80B** | Full SFT | 1 | 2 | 8 | 16 | Full supervised finetuning (2 nodes) |",
+    } <= docs_lines
 
 
 def test_qwen3_recipe_examples_match_source_signatures_and_nested_owners():


### PR DESCRIPTION
# What does this PR do?

Fixes the published Qwen3-Next pretraining and full-SFT examples so they use the current public recipe factory and nested `ConfigContainer` APIs, and aligns their documented parallelism with the canonical H100 recipes.

# Bug and user impact

The maintained Qwen family page passed removed flat factory keywords such as `name`, `data_paths`, `pretrained_checkpoint`, and `finetune_lr` into the public Qwen3-Next aliases.

Those aliases directly expose parameterless pretraining and SFT factories. Copying either executable example therefore raised `TypeError` during Python argument binding, before a config could be constructed. The same section claimed the factories automatically selected TP=2/PP=8/EP=16 on 256 GPUs, while the current defaults are TP=1/PP=4/EP=8 on 32 GPUs for pretraining and TP=1/PP=2/EP=8 on 16 GPUs for SFT.

# Fix

- Call both factories without arguments.
- Apply dataset, checkpoint, logging, training, scheduler, optimizer, and sequence-length overrides to their owning nested configs.
- Align the topology table and inline comments with the canonical recipe defaults.
- Keep the two maintained documentation mirrors identical.
- Add a stdlib-only contract that resolves aliases to canonical signatures and checks keyword binding, nested ownership, and topology.

# Validation

Fail before on unmodified documentation with the new regression:

```text
uv run --no-project --python 3.12 python tests/unit_tests/doc_consistency/test_readme_consistency.py
17/18 passed
AssertionError: docs/models/qwen/qwen.md calls qwen3_next_80b_a3b_sft_config with unsupported keywords
```

Pass after and adjacent checks:

```text
uv run --no-project --python 3.12 python tests/unit_tests/doc_consistency/test_readme_consistency.py
18/18 passed

git diff --check
passed

uv run pre-commit run --all-files
all applicable hooks passed
```

# Scope

This is limited to Qwen3-Next recipe documentation and its static contract test. It does not change recipe implementations, public APIs, dependencies, CI workflows, or the Megatron-LM submodule. No GPU, distributed, convergence, model-quality, or performance validation was required or performed.

Related training-guidance request: #1146.
