### PR TITLE
fix(data): preserve partial evaluation batches

### DIFF
--- a/src/megatron/bridge/data/loaders.py
+++ b/src/megatron/bridge/data/loaders.py
@@ -360,6 +360,7 @@ def build_train_valid_test_data_loaders(
             data_parallel_rank=eval_dp_rank,
             data_parallel_size=eval_dp_size,
             global_batch_size=eval_gbs,
+            drop_last=not (isinstance(cfg.dataset, GPTSFTDatasetConfig) and cfg.dataset.dataloader_type == "batch"),
             seed=sampler_seed,
         )
     elif cfg.validation.eval_iters > 0:
@@ -378,6 +379,7 @@ def build_train_valid_test_data_loaders(
             data_parallel_rank=eval_dp_rank,
             data_parallel_size=eval_dp_size,
             global_batch_size=eval_gbs,
+            drop_last=not (isinstance(cfg.dataset, GPTSFTDatasetConfig) and val_dataloader_type == "batch"),
             seed=sampler_seed,
         )
 
@@ -396,6 +398,7 @@ def build_train_valid_test_data_loaders(
             data_parallel_rank=eval_dp_rank,
             data_parallel_size=eval_dp_size,
             global_batch_size=eval_gbs,
+            drop_last=not (isinstance(cfg.dataset, GPTSFTDatasetConfig) and cfg.dataset.dataloader_type == "batch"),
             seed=sampler_seed,
         )
 

--- a/tests/functional_tests/test_groups/data/test_loaders.py
+++ b/tests/functional_tests/test_groups/data/test_loaders.py
@@ -359,6 +359,53 @@ class TestDataLoaders:
     @mock.patch("torch.distributed.broadcast")
     @mock.patch("torch.distributed.get_world_size", return_value=1)
     @mock.patch("torch.distributed.get_rank", return_value=0)
+    def test_gpt_sft_batch_eval_preserves_split_smaller_than_global_batch(
+        self, _mock_rank, _mock_world_size, _mock_broadcast
+    ):
+        class PaddingAwareDataset:
+            def __init__(self, size):
+                self.size = size
+
+            def __len__(self):
+                return self.size
+
+            def __getitem__(self, index):
+                return index
+
+        cfg = create_simple_test_config()
+        cfg.train.global_batch_size = 4
+        cfg.validation.eval_global_batch_size = 4
+        cfg.validation.eval_micro_batch_size = 1
+        cfg.dataset = GPTSFTDatasetConfig(
+            dataset_root="/tmp/dataset",
+            seq_length=512,
+            num_workers=0,
+            persistent_workers=False,
+        )
+        datasets = (PaddingAwareDataset(4), PaddingAwareDataset(3), PaddingAwareDataset(3))
+        real_torch_tensor = torch.tensor
+
+        with mock.patch(
+            "megatron.bridge.data.loaders.torch.tensor",
+            side_effect=lambda data, *, dtype, device: real_torch_tensor(data, dtype=dtype),
+        ):
+            _, valid_dataloader, test_dataloader = build_train_valid_test_data_loaders(
+                cfg=cfg,
+                train_state=TrainState(),
+                build_train_valid_test_datasets_provider=mock.Mock(return_value=datasets),
+                dp_group=object(),
+            )
+
+        valid_batch = next(iter(valid_dataloader))
+        test_batch = next(iter(test_dataloader))
+        assert valid_batch.shape == (cfg.validation.eval_global_batch_size,)
+        assert test_batch.shape == (cfg.validation.eval_global_batch_size,)
+        assert -1 in valid_batch
+        assert -1 in test_batch
+
+    @mock.patch("torch.distributed.broadcast")
+    @mock.patch("torch.distributed.get_world_size", return_value=1)
+    @mock.patch("torch.distributed.get_rank", return_value=0)
     def test_iteration_based_loader_respects_drop_last_false(self, _mock_rank, _mock_world_size, _mock_broadcast):
         class PaddingAwareDataset:
             def __len__(self):


### PR DESCRIPTION
## What

Finite GPT-SFT validation or test splits smaller than the configured evaluation global batch size crash before producing a batch. Larger non-divisible splits silently omit examples from evaluation.

For example, a canonical batch-mode SFT configuration with three validation rows and an evaluation global batch size of four reaches `MegatronPretrainingBatchSampler._active_total_samples()` with `drop_last=True` and raises:

```text
AssertionError: drop_last=True requires at least one full global batch; got total_samples=3, global_batch_size=4
```

## Root cause

The standard validation and test loader calls relied on the sampler factory's `drop_last=True` default. Unlike training, finite evaluation splits have no minimum-size guard and retain their actual source lengths.

## Fix

Use `drop_last=False` only for batch-mode `GPTSFTDatasetConfig` validation and test loaders. This activates the existing `-1` padding contract; GPT-SFT datasets convert those sentinel samples into zero-loss padding examples. Other dataset providers and sampler modes are unchanged.

## Validation

- Regression on unmodified base: failed with the assertion above.
- Same unchanged regression after the fix:
  `uv run python -m pytest tests/functional_tests/test_groups/data/test_loaders.py::TestDataLoaders::test_gpt_sft_batch_eval_preserves_split_smaller_than_global_batch -q --tb=short`
  — passed.
- Regression plus adjacent epoch-loader and batch-sampler coverage:
  `uv run python -m pytest tests/functional_tests/test_groups/data/test_loaders.py::TestDataLoaders::test_gpt_sft_batch_eval_preserves_split_smaller_than_global_batch tests/functional_tests/test_groups/data/test_loaders.py::TestEpochBasedDataLoaders tests/functional_tests/test_groups/data/test_samplers.py::TestMegatronPretrainingBatchSampler -k 'not test_epoch_based_loader_allows_dataset_smaller_than_global_batch' -q --tb=short`
  — 26 passed, 1 deselected because that existing test requires CUDA initialization in the CPU validation environment.
- `git diff --check` — passed.
- `uv run pre-commit run --all-files` — passed.

## Scope

This changes only incomplete batch-mode GPT-SFT validation/test handling. It does not change training batches, other dataset providers, sequential/cyclic samplers, public APIs, dependencies, or CI configuration. No full-suite, GPU-training, convergence, model-quality, or performance validation was run.

This supersedes the author-closed prior attempt #4914 with fresh fail-before/pass-after evidence on current `main`.
