### PR TITLE
[data] fix: Honor global SFT sample cap

### DIFF
--- a/src/megatron/bridge/data/datasets/gpt_sft.py
+++ b/src/megatron/bridge/data/datasets/gpt_sft.py
@@ -285,6 +285,8 @@ class GPTSFTDataset(Dataset):
                 index_mapping_dir=self.index_mapping_dir,
                 samples_mapping=osm,
             )
+            if self.global_sample_mapping:
+                self.samples_mapping = self.samples_mapping[: self.max_num_samples]
         else:
             self.samples_mapping = None
 

--- a/tests/unit_tests/data/datasets/test_gpt_sft.py
+++ b/tests/unit_tests/data/datasets/test_gpt_sft.py
@@ -46,7 +46,7 @@ def create_mock_tokenizer():
     return mock_tokenizer
 
 
-def get_gpt_sft(tmp_path, dataset_type="sft", max_num_samples="default"):
+def get_gpt_sft(tmp_path, dataset_type="sft", max_num_samples="default", global_sample_mapping=False):
     """Create a GPT SFT dataset for testing with mocked tokenizer.
 
     When ``max_num_samples`` is None the dataset builds no ``samples_mapping``,
@@ -78,6 +78,7 @@ def get_gpt_sft(tmp_path, dataset_type="sft", max_num_samples="default"):
             prompt_template="{input}\n\n### Response:\n{output}",
             truncation_field="output",
             memmap_workers=1,
+            global_sample_mapping=global_sample_mapping,
         )
     elif dataset_type == "packed":
         # Create a mock packed dataset file
@@ -136,6 +137,12 @@ class TestDataGPTSFTDataset:
     def test_build_samples_mapping(self, tmp_path):
         dataset, _ = get_gpt_sft(tmp_path)
         dataset._build_samples_mapping()
+
+    def test_global_sample_mapping_respects_max_num_samples(self, tmp_path):
+        dataset, dataset_length = get_gpt_sft(tmp_path, max_num_samples=2, global_sample_mapping=True)
+
+        assert dataset_length > 2
+        assert len(dataset) == 2
 
     def test_gpt_sft_dataset(self, tmp_path):
         dataset, dataset_length = get_gpt_sft(tmp_path)


### PR DESCRIPTION
## Summary

Honor `GPTSFTDatasetConfig.max_train_samples` when non-packed text SFT uses the compatibility option `dataset_kwargs={"global_sample_mapping": True}`.

## Trigger and impact

For a physical dataset with `D` rows and a positive cap `N` that is not divisible by `D`, the global mapping helper emits complete physical epochs. Bridge returned that unsliced mapping, so the dataset length became `D * ceil(N / D)` instead of `N`.

This silently trains on samples beyond the configured cap. Epoch-mode iteration calculation, sampler shuffle, and resume accounting all consume the inflated dataset length. A large dataset capped to a small subset could therefore run almost a complete physical epoch.

## Root cause and fix

`GPTSFTDataset._build_samples_mapping()` delegated the cap to the global MCore mapping helper, whose contract permits the final epoch to overshoot. Bridge now truncates only the returned global mapping to `max_num_samples` at the dataset ownership boundary.

The default online mapping, uncapped datasets, packed datasets, mapping shuffle order, and sampler padding behavior are unchanged.

## Regression evidence

Focused regression, before the fix:

```text
uv run --active --no-sync python -m pytest tests/unit_tests/data/datasets/test_gpt_sft.py::TestDataGPTSFTDataset::test_global_sample_mapping_respects_max_num_samples -q --tb=short --confcutdir=tests/unit_tests/data/datasets
```

Failed as expected: a 24-row dataset configured with `max_num_samples=2` exposed length 24.

The same command passes after the fix: `1 passed`.

Adjacent validation:

```text
uv run --active --no-sync python -m pytest tests/unit_tests/data/datasets/test_gpt_sft.py::TestDataGPTSFTDataset -q --tb=short --confcutdir=tests/unit_tests/data/datasets
uv run --active --no-sync python -m pytest tests/functional_tests/test_groups/data/datasets/test_utils.py::TestDataUtils::test_online_sample_mapping -q --tb=short --confcutdir=tests/functional_tests/test_groups/data/datasets
git diff --check
uv run --active --no-sync pre-commit run --all-files
```

Results: `11 passed`; `1 passed`; diff check passed; all applicable pre-commit hooks passed.

No GPU, distributed, full-suite, convergence, quality, or performance validation was required or claimed.
