### PR TITLE
fix(training): train the DSpark TV term at 0.5 * L1 as documented

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -82,6 +82,7 @@ training/moe-optimization.md
 training/peft.md
 training/packed-sequences.md
 training/multi-token-prediction.md
+training/dspark-speculative-decoding.md
 training/callbacks.md
 ```
 

--- a/docs/training/dspark-speculative-decoding.md
+++ b/docs/training/dspark-speculative-decoding.md
@@ -1,0 +1,212 @@
+# DSpark Speculative Decoding (Draft Training) Design
+
+## Overview
+
+This page is a design proposal (RFC) for adding **DSpark** speculative-decoding
+draft training to Megatron-Bridge. It tracks
+[issue #5230](https://github.com/NVIDIA-NeMo/Megatron-Bridge/issues/5230).
+
+DSpark ([arXiv:2607.05147](https://arxiv.org/abs/2607.05147)) is a
+speculative-decoding method that trains a lightweight **draft** against a frozen
+target. The draft proposes a block of tokens; the target verifies them. DSpark's
+draft is *semi-autoregressive*: a parallel backbone predicts a whole block in one
+pass, and a small sequential head restores the intra-block token dependency that a
+purely parallel drafter loses (the "suffix decay" problem). A confidence head
+predicts per-position acceptance so the serving engine can schedule its verify
+budget.
+
+A working draft-training reference already exists in NeMo AutoModel at
+`nemo_automodel/components/speculative/dspark/`. This document specifies how the
+same training recipe maps onto Megatron-Bridge and Megatron-Core, and proposes a
+phased plan. It intentionally does **not** ship the draft module itself: that is a
+Megatron-Core (or ModelOpt) neural module whose parallel/loss integration must be
+validated on multi-GPU runs, so it belongs in later, separately reviewed PRs.
+
+## Background: the DSpark draft
+
+### Semi-autoregressive draft
+
+For a block of `block_size` positions (`gamma`, default 7 offline / 5 in
+production), the draft factorizes the block distribution as
+`P(x | x0) = prod_k p_k(x_k | x0, x_1..x_{k-1})`:
+
+- **Parallel backbone.** A small transformer predicts every position of the block
+  in one forward pass. Crucially, the backbone does not re-encode the prompt: it
+  attends to the frozen target's hidden states as the attention **context K/V**,
+  with the block's own "noise" slots as the queries. Each block query attends to
+  the context strictly before its anchor and bidirectionally within its own block.
+  This is the block-parallel (DFlash-style) half of the draft.
+- **Sequential head.** A lightweight module adds intra-block dependency on top of
+  the parallel logits. DSpark provides a **Markov head** (a low-rank,
+  token-conditioned additive logit bias, rank 256) and an **RNN head** (a
+  GRU-like recurrence carrying prefix state across the block). At training time
+  the head is teacher-forced with the previous block tokens; only at inference is
+  it run serially.
+- **Confidence head.** A small projection `c_k = sigmoid(w^T [h_k ; embed(x_{k-1})])`
+  predicts each position's acceptance probability.
+
+The draft **shares and freezes the target's token embedding and LM head**; there
+is no separate (compressed) draft vocabulary or `d2t`/`t2d` remapping. The
+target's selected decoder-layer hidden states are fused by a learned linear
+projection (`fc`) into the draft hidden size and used as the attention context.
+
+### Training objective
+
+The draft is trained with three position-weighted terms (weights `exp(-k/gamma)`,
+emphasizing earlier positions):
+
+- `L_ce` (weight 0.1): cross-entropy of the draft logits against the target's
+  teacher-forced next tokens.
+- `L_tv` (weight 0.9): total-variation distance `0.5 * ||p_draft - p_target||_1`
+  to the target's next-token distribution. This is the dominant term and a direct
+  acceptance proxy.
+- `L_conf` (weight 1.0): binary cross-entropy training the confidence head against
+  the analytical acceptance label `c_k* = 1 - TV(p_draft, p_target)`.
+
+The target's teacher distribution is produced by passing the target's last hidden
+state through the (shared, frozen) LM head and is always detached, so no gradient
+flows into the target.
+
+### Acceptance and confidence
+
+Training measures acceptance analytically rather than by running rejection
+sampling. Per position, `accept_rate = clamp(1 - TV, 0, 1)`. The expected accepted
+prefix length of a block is `tau = sum_k cumprod(accept_rate)_k + 1` (a token
+survives only if every earlier token in its block is accepted; the `+1` counts the
+verified anchor token). `tau` is the training-time speedup proxy. The confidence
+head regresses to `accept_rate`; the paper applies a post-hoc Sequential
+Temperature Scaling calibration for serving.
+
+### Reference implementation (NeMo AutoModel)
+
+The AutoModel implementation separates cleanly into an architecture-agnostic core
+and per-target glue:
+
+- Architecture-agnostic core: the Markov/RNN heads, the three-term loss and
+  acceptance metrics, anchor sampling and block "noise" embedding, the eval mask,
+  the confidence-head module, and the block-attention mask builder.
+- Per-target glue: the draft backbone (attention that reads target hidden states
+  as context K/V, plus the decoder MLP), a draft config builder, a one-line
+  registry entry, and the frozen-target hidden-state capture.
+
+This split is what makes a Megatron-Bridge port tractable: the core is nearly
+verbatim, and only the backbone must be re-expressed in Megatron-Core layer specs.
+
+## Where DSpark fits in Megatron-Bridge
+
+### Current state
+
+Megatron-Bridge has no standalone speculative or draft-training subsystem today.
+The only draft-adjacent training path is **Multi-Token Prediction (MTP)**, which
+is a native Megatron-Core module that Bridge integrates thinly (provider flags,
+batch plumbing in `training/gpt_step.py`, and per-model HF weight mappings such as
+`mtp.*` in `models/qwen/qwen3_bridge.py`). EAGLE and Medusa appear only in the
+ModelOpt **export** path, not in training.
+
+DSpark's draft (semi-autoregressive block plus Markov and confidence heads) is a
+new neural module. It therefore has to live in one of two places:
+
+1. **A Megatron-Core native module** (as MTP does in
+   `megatron/core/transformer/multi_token_prediction.py`), with tensor- and
+   pipeline-parallel-aware layers and loss folding. This is a Megatron-LM change,
+   not a Bridge change.
+2. **A ModelOpt-injected module** (as EAGLE/Medusa are, via
+   `modelopt.torch.speculative`), in which case Bridge only needs a provider hook,
+   a custom forward step, and export mappings.
+
+### Blueprint: the ModelOpt distillation subsystem
+
+Bridge already contains a self-contained, bolt-on training subsystem that DSpark
+should mirror: **ModelOpt knowledge distillation**. It slots a new training mode
+in without touching the core training loop, via four pieces:
+
+- `models/distillation_provider.py`: a provider that dynamically subclasses the
+  base provider and registers a pre-wrap hook to mutate the already-built,
+  weight-loaded model (there, it attaches the teacher).
+- `training/post_training/distillation.py`: the custom loss (`loss_func_kd`).
+- `training/gpt_step.py`: `forward_step_modelopt`, which selects that loss when the
+  model is a distillation model.
+- `training/distill.py`: a thin entry point, `distill(config) = pretrain(config,
+  forward_step_modelopt)`.
+
+Plus an `examples/distillation/` recipe and a `docs/training/` page. This
+provider-hook plus custom-forward-step plus custom-loss plus thin-entry pattern is
+the established, low-friction way to add a training subsystem here, and it is the
+recommended shape for DSpark.
+
+## Proposed design
+
+Following the distillation blueprint, the Bridge-side surface is:
+
+| Piece | Location (proposed) | Mirrors |
+|---|---|---|
+| Draft provider hook | `models/dspark_provider.py` | `distillation_provider.py` (dynamic subclass + pre-wrap hook that attaches the frozen target's feature capture and the draft heads) |
+| Custom forward + loss dispatch | `training/gpt_step.py` (`forward_step_dspark`) | `forward_step_modelopt` |
+| DSpark loss | `training/post_training/dspark.py` | `post_training/distillation.py` (the three-term CE/TV/confidence loss and the `tau` acceptance metric) |
+| Thin entry point | `training/dspark.py` | `training/distill.py` |
+| HF to/from Megatron weight mapping for `dspark.*` params | `models/<family>/<name>_bridge.py` mapping registry | the `mtp.*` mappings in `qwen3_bridge.py` |
+| Export flag | ModelOpt `export_extra_modules` path | the existing EAGLE/Medusa/MTP export |
+| Recipe + example | `recipes/<family>/…` + `examples/dspark/` | the distillation recipe/example |
+| Docs | this page | `multi-token-prediction.md` |
+
+### Frozen-target supervision
+
+The draft trains against features captured from the frozen target: the selected
+decoder-layer hidden states (fused by `fc` into the draft's context K/V) and the
+final hidden state (which drives the teacher distribution through the shared LM
+head). In Megatron-Core, this capture must respect tensor, pipeline, and context
+parallelism. Two options, to be decided in Phase 1:
+
+- Colocated capture during the same forward (analogous to how MTP consumes extra
+  token IDs), keeping the target and draft in one model.
+- Offline precomputation of target features, streamed to a draft-only training
+  job (as AutoModel's `precompute_dspark.py` does), which sidesteps holding the
+  target in memory but adds a cache format.
+
+### HF to/from Megatron conversion
+
+Because the draft reuses the target's embedding and LM head and adds `fc`,
+`markov_head`, `confidence_head`, and the draft decoder layers, the bridge mapping
+registry must gain `dspark.*` entries (QKV and gated-MLP splits for the draft
+backbone, plain linears for `fc` and the heads), so trained drafts round-trip
+through `AutoBridge` for serving. The `mtp.*` mappings are the closest existing
+template.
+
+## Phased implementation plan
+
+- **Phase 0 (this PR): design.** Specify the algorithm, the Bridge mapping, and
+  the plan.
+- **Phase 1: the DSpark draft module.** Implement the semi-autoregressive backbone
+  plus Markov and confidence heads as a parallel-aware module (Megatron-Core
+  native, or a ModelOpt speculative module), with the three-term loss. Validate
+  numerically with L0 unit tests and L1/L2 functional tests within the 2-GPU cap.
+  This is the load-bearing, separately reviewed piece.
+- **Phase 2: Bridge integration.** Add `dspark_provider.py`, `forward_step_dspark`,
+  `post_training/dspark.py`, the `training/dspark.py` entry, and the `dspark.*`
+  weight mappings, following the distillation files.
+- **Phase 3: recipe, example, and convergence.** Add a recipe/config and an
+  example, and validate acceptance-length (`tau`) convergence against the AutoModel
+  reference on a small target (for example Qwen3 dense) on multi-GPU.
+
+## Open questions and risks
+
+- **Module placement.** MCore-native (a Megatron-LM PR, full TP/PP/EP/CP support)
+  versus ModelOpt-injected (Bridge-only, but tied to ModelOpt). Phase 1 must
+  decide this first; it drives everything downstream.
+- **Parallelism.** The draft heads and the block-attention mask need correct
+  tensor/pipeline/expert/context-parallel behavior; this is the part that cannot
+  be validated single-GPU and must go through functional tests.
+- **Optional dependency.** If the draft leans on `modelopt.torch.speculative`, it
+  must be an optional extra and land as a separate dependency PR first, per
+  `CONTRIBUTING.md`.
+- **Target-feature capture cost.** Colocated capture holds the target in memory;
+  offline precompute adds a cache format. The choice affects the recipe surface.
+
+## References
+
+- DSpark paper: [arXiv:2607.05147](https://arxiv.org/abs/2607.05147),
+  *Confidence-Scheduled Speculative Decoding with Semi-Autoregressive Generation*.
+- Draft-training reference implementation: NeMo AutoModel,
+  [`nemo_automodel/components/speculative/dspark/`](https://github.com/NVIDIA-NeMo/Automodel/tree/main/nemo_automodel/components/speculative/dspark).
+- Tracking issue: [#5230](https://github.com/NVIDIA-NeMo/Megatron-Bridge/issues/5230).
+- Related in-repo training: [Multi-Token Prediction](multi-token-prediction.md).

--- a/docs/training/dspark-speculative-decoding.md
+++ b/docs/training/dspark-speculative-decoding.md
@@ -17,8 +17,8 @@ budget.
 
 A working draft-training reference already exists in NeMo AutoModel at
 `nemo_automodel/components/speculative/dspark/`. This document specifies how the
-same training recipe maps onto Megatron-Bridge and Megatron-Core, and proposes a
-phased plan. It intentionally does **not** ship the draft module itself: that is a
+same training recipe maps onto Megatron-Bridge and Megatron-Core. It
+intentionally does **not** ship the draft module itself: that is a
 Megatron-Core (or ModelOpt) neural module whose parallel/loss integration must be
 validated on multi-GPU runs, so it belongs in later, separately reviewed PRs.
 
@@ -140,7 +140,7 @@ The draft trains against features captured from the frozen target: the selected
 decoder-layer hidden states (fused by `fc` into the draft's context K/V) and the
 final hidden state (which drives the teacher distribution through the shared LM
 head). In Megatron-Core, this capture must respect tensor, pipeline, and context
-parallelism. Two options, to be decided in Phase 1:
+parallelism. Two options carry different trade-offs:
 
 - Colocated capture during the same forward (analogous to how MTP consumes extra
   token IDs), keeping the target and draft in one model.
@@ -156,36 +156,6 @@ registry must gain `dspark.*` entries (QKV and gated-MLP splits for the draft
 backbone, plain linears for `fc` and the heads), so trained drafts round-trip
 through `AutoBridge` for serving. The `mtp.*` mappings are the closest existing
 template.
-
-## Phased implementation plan
-
-- **Phase 0 (this PR): design.** Specify the algorithm, the Bridge mapping, and
-  the plan.
-- **Phase 1: the DSpark draft module.** Implement the semi-autoregressive backbone
-  plus Markov and confidence heads as a parallel-aware module (Megatron-Core
-  native, or a ModelOpt speculative module), with the three-term loss. Validate
-  numerically with L0 unit tests and L1/L2 functional tests within the 2-GPU cap.
-  This is the load-bearing, separately reviewed piece.
-- **Phase 2: Bridge integration.** Add `dspark_provider.py`, `forward_step_dspark`,
-  `post_training/dspark.py`, the `training/dspark.py` entry, and the `dspark.*`
-  weight mappings, following the distillation files.
-- **Phase 3: recipe, example, and convergence.** Add a recipe/config and an
-  example, and validate acceptance-length (`tau`) convergence against the AutoModel
-  reference on a small target (for example Qwen3 dense) on multi-GPU.
-
-## Open questions and risks
-
-- **Module placement.** MCore-native (a Megatron-LM PR, full TP/PP/EP/CP support)
-  versus ModelOpt-injected (Bridge-only, but tied to ModelOpt). Phase 1 must
-  decide this first; it drives everything downstream.
-- **Parallelism.** The draft heads and the block-attention mask need correct
-  tensor/pipeline/expert/context-parallel behavior; this is the part that cannot
-  be validated single-GPU and must go through functional tests.
-- **Optional dependency.** If the draft leans on `modelopt.torch.speculative`, it
-  must be an optional extra and land as a separate dependency PR first, per
-  `CONTRIBUTING.md`.
-- **Target-feature capture cost.** Colocated capture holds the target in memory;
-  offline precompute adds a cache format. The choice affects the recipe surface.
 
 ## References
 

--- a/docs/training/dspark-speculative-decoding.md
+++ b/docs/training/dspark-speculative-decoding.md
@@ -77,21 +77,6 @@ verified anchor token). `tau` is the training-time speedup proxy. The confidence
 head regresses to `accept_rate`; the paper applies a post-hoc Sequential
 Temperature Scaling calibration for serving.
 
-### Reference implementation (NeMo AutoModel)
-
-The AutoModel implementation separates cleanly into an architecture-agnostic core
-and per-target glue:
-
-- Architecture-agnostic core: the Markov/RNN heads, the three-term loss and
-  acceptance metrics, anchor sampling and block "noise" embedding, the eval mask,
-  the confidence-head module, and the block-attention mask builder.
-- Per-target glue: the draft backbone (attention that reads target hidden states
-  as context K/V, plus the decoder MLP), a draft config builder, a one-line
-  registry entry, and the frozen-target hidden-state capture.
-
-This split is what makes a Megatron-Bridge port tractable: the core is nearly
-verbatim, and only the backbone must be re-expressed in Megatron-Core layer specs.
-
 ## Where DSpark fits in Megatron-Bridge
 
 ### Current state

--- a/src/megatron/bridge/training/post_training/dspark/__init__.py
+++ b/src/megatron/bridge/training/post_training/dspark/__init__.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DSpark speculative-decoding draft training (architecture-agnostic core).
+
+This package holds the pure-``torch`` pieces of DSpark draft training: the
+sequential (Markov / RNN) and confidence heads (:mod:`heads`) and the three-term
+CE / TV / confidence objective with its acceptance metrics (:mod:`loss`). The
+parallel-aware draft backbone and the Megatron-Core forward-step / provider wiring
+are separate, GPU-validated concerns. See ``docs/training/dspark-speculative-decoding.md``.
+"""
+
+from megatron.bridge.training.post_training.dspark.heads import (
+    ConfidenceHead,
+    GatedMarkovHead,
+    RNNHead,
+    VanillaMarkov,
+    build_markov_head,
+)
+from megatron.bridge.training.post_training.dspark.loss import DSparkForwardOutput, dspark_loss
+
+
+__all__ = [
+    "ConfidenceHead",
+    "DSparkForwardOutput",
+    "GatedMarkovHead",
+    "RNNHead",
+    "VanillaMarkov",
+    "build_markov_head",
+    "dspark_loss",
+]

--- a/src/megatron/bridge/training/post_training/dspark/heads.py
+++ b/src/megatron/bridge/training/post_training/dspark/heads.py
@@ -1,0 +1,209 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DSpark draft heads: the sequential (Markov / RNN) head and the confidence head.
+
+DSpark (arXiv:2607.05147) draft training. The parallel backbone predicts every
+position of a block in one pass; these small heads add the pieces the paper needs
+on top of that:
+
+* the **sequential head** injects intra-block token dependency onto the parallel
+  logits, as a factorized ``P(x | x0) = prod_k p_k(x_k | x0, x_1..x_{k-1})`` bias.
+  ``VanillaMarkov`` is a memoryless low-rank token-to-token additive logit bias;
+  ``GatedMarkovHead`` gates the previous-token embedding by the backbone hidden
+  state; ``RNNHead`` carries a recurrent state so position k sees the full prefix.
+* the **confidence head** predicts a per-position acceptance logit.
+
+Only the training-time (teacher-forced, parallel) ``apply_block_logits`` path is
+provided here; the serial autoregressive sampling used at inference is a separate
+concern. These modules depend only on ``torch``.
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+
+class VanillaMarkov(nn.Module):
+    """Memoryless low-rank token-to-token additive logit bias.
+
+    The step bias is ``markov_w2(markov_w1[prev_token])``: a rank-``markov_rank``
+    factorization of a ``[vocab, vocab]`` transition-bias matrix.
+    """
+
+    def __init__(self, *, vocab_size: int, markov_rank: int):
+        super().__init__()
+        if markov_rank <= 0:
+            raise ValueError(f"VanillaMarkov requires markov_rank > 0, got {markov_rank}.")
+        self.vocab_size = int(vocab_size)
+        self.markov_rank = int(markov_rank)
+        self.markov_head_type = "vanilla"
+        self.markov_w1 = nn.Embedding(self.vocab_size, self.markov_rank)
+        self.markov_w2 = nn.Linear(self.markov_rank, self.vocab_size, bias=False)
+
+    def get_prev_embeddings(self, token_ids: torch.Tensor) -> torch.Tensor:
+        """Look up ``markov_w1`` for ``token_ids`` (any shape) -> ``[..., markov_rank]``."""
+        return self.markov_w1(token_ids.long())
+
+    def project_bias(self, latent_states: torch.Tensor) -> torch.Tensor:
+        """Project ``[..., markov_rank]`` latent states to a ``[..., vocab]`` logit bias."""
+        return self.markov_w2(latent_states)
+
+    def compute_step_bias(self, token_ids: torch.Tensor, hidden_states: torch.Tensor | None) -> torch.Tensor:
+        """Logit bias for the previous tokens ``token_ids`` -> ``[..., vocab]`` (hidden unused)."""
+        del hidden_states
+        return self.project_bias(self.get_prev_embeddings(token_ids))
+
+    def apply_block_logits(
+        self,
+        base_logits: torch.Tensor,
+        *,
+        token_ids: torch.Tensor,
+        hidden_states: torch.Tensor | None,
+    ) -> torch.Tensor:
+        """Add the (teacher-forced) sequential bias to the whole block's logits.
+
+        Args:
+            base_logits: Backbone logits ``[batch, num_blocks, block_size, vocab]``.
+            token_ids: Teacher-forced previous token per position
+                ``[batch, num_blocks, block_size]``.
+            hidden_states: Backbone hidden ``[batch, num_blocks, block_size, hidden]``
+                (used by the gated / RNN heads, ignored here).
+
+        Returns:
+            Corrected logits ``[batch, num_blocks, block_size, vocab]``.
+        """
+        if base_logits.size(-2) == 0:
+            return base_logits
+        return base_logits + self.compute_step_bias(token_ids, hidden_states)
+
+
+class GatedMarkovHead(VanillaMarkov):
+    """``VanillaMarkov`` whose previous-token embedding is gated by the backbone hidden."""
+
+    def __init__(self, *, vocab_size: int, markov_rank: int, hidden_size: int):
+        super().__init__(vocab_size=vocab_size, markov_rank=markov_rank)
+        self.markov_head_type = "gated"
+        self.gate_proj = nn.Linear(hidden_size + markov_rank, markov_rank)
+
+    def compute_step_bias(self, token_ids: torch.Tensor, hidden_states: torch.Tensor | None) -> torch.Tensor:
+        """Gate ``markov_w1[prev]`` by ``sigmoid(gate_proj([hidden; prev]))`` before ``markov_w2``.
+
+        Args:
+            token_ids: Previous token ids ``[..., ]``.
+            hidden_states: Backbone hidden ``[..., hidden]`` (required).
+
+        Returns:
+            Logit bias ``[..., vocab]``.
+        """
+        if hidden_states is None:
+            raise ValueError("GatedMarkovHead requires hidden_states.")
+        prev_embeddings = self.get_prev_embeddings(token_ids)
+        gate_inputs = torch.cat([hidden_states, prev_embeddings], dim=-1)
+        gate = torch.sigmoid(self.gate_proj(gate_inputs)).to(dtype=prev_embeddings.dtype)
+        return self.project_bias(gate * prev_embeddings)
+
+
+class RNNHead(VanillaMarkov):
+    """GRU-like head carrying recurrent state across a block so position k sees ``x_1..x_{k-1}``."""
+
+    def __init__(self, *, vocab_size: int, markov_rank: int, hidden_size: int):
+        super().__init__(vocab_size=vocab_size, markov_rank=markov_rank)
+        self.markov_head_type = "rnn"
+        self.hidden_size = int(hidden_size)
+        # Joint projection of [state; W1[prev]; hidden] -> [gate; candidate; output].
+        self.joint_proj = nn.Linear(2 * markov_rank + hidden_size, 3 * markov_rank)
+
+    def _rnn_step(
+        self, state: torch.Tensor, prev_embeddings: torch.Tensor, hidden_states: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """One recurrent step.
+
+        Args:
+            state: Previous recurrent state ``[..., markov_rank]``.
+            prev_embeddings: ``markov_w1[prev]`` ``[..., markov_rank]``.
+            hidden_states: Backbone hidden at this position ``[..., hidden]``.
+
+        Returns:
+            ``(new_state [..., markov_rank], logit_bias [..., vocab])``.
+        """
+        z = torch.cat([state, prev_embeddings, hidden_states], dim=-1)
+        gate_raw, candidate_raw, output_raw = self.joint_proj(z).chunk(3, dim=-1)
+        gate = torch.sigmoid(gate_raw)
+        candidate = torch.tanh(candidate_raw)
+        new_state = gate * state + (1.0 - gate) * candidate
+        return new_state, self.project_bias(torch.tanh(output_raw))
+
+    def apply_block_logits(
+        self,
+        base_logits: torch.Tensor,
+        *,
+        token_ids: torch.Tensor,
+        hidden_states: torch.Tensor | None,
+    ) -> torch.Tensor:
+        """Unroll the recurrence over the block (teacher-forced). Layout matches the base class."""
+        if hidden_states is None:
+            raise ValueError("RNNHead requires hidden_states.")
+        block_size = base_logits.size(-2)
+        if block_size == 0:
+            return base_logits
+        leading_shape = base_logits.shape[:-2]  # [batch, num_blocks]
+        state = torch.zeros(*leading_shape, self.markov_rank, device=base_logits.device, dtype=hidden_states.dtype)
+        output_logits = []
+        for k in range(block_size):
+            prev_emb = self.get_prev_embeddings(token_ids[..., k])
+            state, bias = self._rnn_step(state, prev_emb, hidden_states[..., k, :])
+            output_logits.append(base_logits[..., k, :] + bias)
+        return torch.stack(output_logits, dim=-2)
+
+
+def build_markov_head(
+    *, markov_rank: int, markov_head_type: str, vocab_size: int, hidden_size: int
+) -> nn.Module | None:
+    """Construct the sequential head, or ``None`` when ``markov_rank == 0`` (disabled).
+
+    Args:
+        markov_rank: Low-rank size; ``0`` disables the head.
+        markov_head_type: One of ``"vanilla"``, ``"gated"``, ``"rnn"``.
+        vocab_size: Draft vocabulary size.
+        hidden_size: Backbone hidden size (used by ``gated`` / ``rnn``).
+
+    Returns:
+        The head module, or ``None``.
+    """
+    if markov_rank < 0:
+        raise ValueError(f"markov_rank must be >= 0, got {markov_rank}.")
+    if markov_rank == 0:
+        return None
+    head_type = str(markov_head_type).lower()
+    if head_type == "vanilla":
+        return VanillaMarkov(vocab_size=vocab_size, markov_rank=markov_rank)
+    if head_type == "gated":
+        return GatedMarkovHead(vocab_size=vocab_size, markov_rank=markov_rank, hidden_size=hidden_size)
+    if head_type == "rnn":
+        return RNNHead(vocab_size=vocab_size, markov_rank=markov_rank, hidden_size=hidden_size)
+    raise ValueError(f"Unsupported markov_head_type: {markov_head_type!r}.")
+
+
+class ConfidenceHead(nn.Module):
+    """Per-position acceptance-logit predictor (a single linear projection to a scalar)."""
+
+    def __init__(self, input_dim: int):
+        super().__init__()
+        self.proj = nn.Linear(int(input_dim), 1)
+
+    def forward(self, features: torch.Tensor) -> torch.Tensor:
+        """Project ``[..., input_dim]`` features to a ``[...]`` acceptance logit."""
+        return self.proj(features).squeeze(-1)

--- a/src/megatron/bridge/training/post_training/dspark/loss.py
+++ b/src/megatron/bridge/training/post_training/dspark/loss.py
@@ -1,0 +1,216 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DSpark draft training objective and acceptance metrics.
+
+DSpark (arXiv:2607.05147) trains the draft with three position-weighted terms:
+
+* ``ce``: cross-entropy of the draft logits against the target's next tokens;
+* ``tv``: total-variation distance ``0.5 * ||p_draft - p_target||_1`` to the
+  target's next-token distribution (the dominant, acceptance-proxy term);
+* ``confidence``: binary cross-entropy training the confidence head against the
+  analytical acceptance label ``1 - TV``.
+
+Each block position ``k`` is weighted by ``exp(-k / loss_decay_gamma)``.
+Acceptance is measured analytically as ``accept_rate = 1 - TV`` and the expected
+accepted prefix length of a block as ``tau = sum_k cumprod(accept_rate)_k + 1``.
+
+The per-term losses are computed as ``(numerator, denominator)`` sums so that a
+data-parallel training step can all-reduce the denominators over its DP group
+before dividing once (avoiding per-micro-batch token-count bias). Pass
+``dp_group`` for that reduction; the default (``None``) computes the local loss,
+which is what single-process unit tests exercise. This module depends only on
+``torch`` and ``torch.distributed``; wiring it to a Megatron-Core forward step and
+the correct DP group is a separate integration concern.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+
+
+@dataclass
+class DSparkForwardOutput:
+    """Outputs of one DSpark training forward, consumed by :func:`dspark_loss`.
+
+    Shape symbols: ``batch``, ``num_blocks`` (sampled anchor blocks per sample),
+    ``block_size`` (draft positions per anchor), ``vocab``.
+
+    Attributes:
+        draft_logits: Draft logits ``[batch, num_blocks, block_size, vocab]``.
+        target_ids: Teacher-forced next token per position
+            ``[batch, num_blocks, block_size]``.
+        eval_mask: Bool/float supervision mask ``[batch, num_blocks, block_size]``
+            (a block is a contiguous, in-bounds, loss-enabled prefix).
+        block_keep_mask: Kept-anchor mask ``[batch, num_blocks]``.
+        confidence_pred: Optional per-position acceptance logit
+            ``[batch, num_blocks, block_size]``.
+        aligned_target_logits: Optional target next-token logits
+            ``[batch, num_blocks, block_size, vocab]`` (the TV / confidence teacher).
+    """
+
+    draft_logits: torch.Tensor
+    target_ids: torch.Tensor
+    eval_mask: torch.Tensor
+    block_keep_mask: torch.Tensor
+    confidence_pred: torch.Tensor | None = None
+    aligned_target_logits: torch.Tensor | None = None
+
+
+def _loss_weight_mask(eval_mask: torch.Tensor, block_size: int, loss_decay_gamma: float | None) -> torch.Tensor:
+    """``eval_mask`` (float) scaled by the per-position decay ``exp(-k / gamma)``."""
+    weight = eval_mask.to(torch.float32)
+    if loss_decay_gamma is not None and loss_decay_gamma > 0:
+        positions = torch.arange(block_size, device=eval_mask.device).view(1, 1, -1)
+        weight = weight * torch.exp(-positions.float() / float(loss_decay_gamma))
+    return weight
+
+
+def _l1_distance_per_token(draft_logits: torch.Tensor, target_logits: torch.Tensor) -> torch.Tensor:
+    """FP32 probability L1 distance ``||softmax(draft) - softmax(target)||_1`` per position.
+
+    Args:
+        draft_logits: ``[..., vocab]``.
+        target_logits: ``[..., vocab]``.
+
+    Returns:
+        Per-position L1 distance ``[...]`` (twice the total-variation distance).
+    """
+    draft_probs = torch.softmax(draft_logits.float(), dim=-1)
+    target_probs = torch.softmax(target_logits.float(), dim=-1)
+    return (draft_probs - target_probs).abs().sum(dim=-1)
+
+
+def _reduce_den(value: torch.Tensor, dp_group) -> torch.Tensor:
+    """Sum a denominator over the data-parallel group (no-op without a live group)."""
+    out = value.detach().clone()
+    if dp_group is not None or (dist.is_available() and dist.is_initialized()):
+        dist.all_reduce(out, op=dist.ReduceOp.SUM, group=dp_group)
+    return out
+
+
+def dspark_loss(
+    outputs: DSparkForwardOutput,
+    *,
+    ce_alpha: float = 0.1,
+    l1_alpha: float = 0.9,
+    confidence_alpha: float = 1.0,
+    loss_decay_gamma: float | None = 4.0,
+    dp_group=None,
+) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
+    """Compute the DSpark draft loss and acceptance metrics.
+
+    Args:
+        outputs: The draft forward outputs; see :class:`DSparkForwardOutput`. All
+            tensors are ``[batch, num_blocks, block_size(, vocab)]``.
+        ce_alpha: Cross-entropy weight.
+        l1_alpha: Total-variation (``0.5 * L1``) weight.
+        confidence_alpha: Confidence-BCE weight (used only when
+            ``outputs.confidence_pred`` is set).
+        loss_decay_gamma: Per-position decay; ``None`` disables it.
+        dp_group: Optional data-parallel process group over which the loss
+            denominators are summed before dividing. ``None`` computes the local
+            (single-process) loss.
+
+    Returns:
+        Tuple ``(loss, metrics)``. ``loss`` is the scalar training loss; ``metrics``
+        holds the detached per-term losses (``ce_loss`` / ``l1_loss`` /
+        ``confidence_loss``) and acceptance diagnostics (``accept_rate``, ``tau``).
+    """
+    draft_logits = outputs.draft_logits
+    _, _, block_size, vocab_size = draft_logits.shape
+    weight = _loss_weight_mask(outputs.eval_mask, block_size, loss_decay_gamma)  # [B, N, L]
+
+    # Cross-entropy against the teacher-forced next tokens.
+    ce_per_token = F.cross_entropy(
+        draft_logits.reshape(-1, vocab_size), outputs.target_ids.reshape(-1).long(), reduction="none"
+    ).reshape_as(weight)
+    ce_num = (ce_per_token * weight).sum()
+    ce_den = weight.sum()
+
+    has_confidence = outputs.confidence_pred is not None
+    target_logits = outputs.aligned_target_logits
+    if target_logits is not None:
+        target_logits = target_logits.detach()  # never backprop into the (shared) lm_head
+    if (l1_alpha > 0 or has_confidence) and target_logits is None:
+        raise ValueError("aligned_target_logits is required for the TV loss or the confidence head.")
+
+    zero = ce_num.new_zeros(())
+    l1_num = l1_den = zero
+    conf_num = conf_den = zero
+    accept_rate = None
+    if target_logits is not None and (l1_alpha > 0 or has_confidence):
+        l1_dist = _l1_distance_per_token(draft_logits, target_logits)  # [B, N, L] == 2 * TV
+        accept_rate = (1.0 - 0.5 * l1_dist).clamp_(0.0, 1.0)
+        if l1_alpha > 0:
+            l1_num = (l1_dist * weight).sum()
+            l1_den = weight.sum()
+        if has_confidence:
+            conf_num = (
+                F.binary_cross_entropy_with_logits(
+                    outputs.confidence_pred.float(), accept_rate.detach(), reduction="none"
+                )
+                * weight
+            ).sum()
+            conf_den = weight.sum()
+
+    # Divide by the (optionally DP-reduced) denominators; the backward gradient is
+    # scaled by world_size so the DP-averaged gradient matches the global loss.
+    world_size = dist.get_world_size(dp_group) if (dist.is_available() and dist.is_initialized()) else 1
+    ce_g, l1_g, conf_g = (_reduce_den(d, dp_group) for d in (ce_den, l1_den, conf_den))
+    ce_loss = ce_num / (ce_g + 1e-6)
+    l1_loss = l1_num / (l1_g + 1e-6) if l1_g.item() > 0 else zero
+    conf_loss = conf_num / (conf_g + 1e-6) if (has_confidence and conf_g.item() > 0) else zero
+    loss = (ce_alpha * ce_loss + l1_alpha * l1_loss + confidence_alpha * conf_loss) * world_size
+
+    metrics: dict[str, torch.Tensor] = {
+        "ce_loss": (ce_num / (ce_den + 1e-6)).detach(),
+        "l1_loss": (l1_num / (l1_den + 1e-6)).detach() if l1_den.item() > 0 else zero,
+        "confidence_loss": (conf_num / (conf_den + 1e-6)).detach() if conf_den.item() > 0 else zero,
+    }
+    with torch.no_grad():
+        metrics.update(_acceptance_metrics(outputs, accept_rate))
+    return loss, metrics
+
+
+def _acceptance_metrics(outputs: DSparkForwardOutput, accept_rate: torch.Tensor | None) -> dict[str, torch.Tensor]:
+    """Analytical acceptance diagnostics.
+
+    ``accept_rate`` (``= 1 - TV``) is the per-position acceptance probability. A
+    draft token survives only if every earlier token in its block is accepted,
+    hence ``tau`` is the running product over the block, ``+ 1`` for the verified
+    anchor token.
+
+    Args:
+        outputs: The forward outputs (for the masks).
+        accept_rate: Per-position acceptance ``[batch, num_blocks, block_size]`` or
+            ``None`` when no teacher signal is available.
+
+    Returns:
+        ``{"accept_rate": scalar, "tau": scalar}`` (zeros when ``accept_rate`` is None).
+    """
+    zero = outputs.draft_logits.new_zeros((), dtype=torch.float32)
+    if accept_rate is None:
+        return {"accept_rate": zero, "tau": zero}
+    eval_mask = outputs.eval_mask.to(torch.float32)
+    valid_accept = accept_rate * eval_mask
+    accept_rate_mean = valid_accept.sum() / eval_mask.sum().clamp_min(1.0)
+    valid_blocks = (outputs.block_keep_mask.bool() & outputs.eval_mask.bool().any(dim=-1)).to(torch.float32)
+    tau_per_block = valid_accept.cumprod(dim=-1).sum(dim=-1) + 1.0
+    tau_mean = (tau_per_block * valid_blocks).sum() / valid_blocks.sum().clamp_min(1.0)
+    return {"accept_rate": accept_rate_mean, "tau": tau_mean}

--- a/src/megatron/bridge/training/post_training/dspark/loss.py
+++ b/src/megatron/bridge/training/post_training/dspark/loss.py
@@ -97,9 +97,14 @@ def _l1_distance_per_token(draft_logits: torch.Tensor, target_logits: torch.Tens
 
 
 def _reduce_den(value: torch.Tensor, dp_group) -> torch.Tensor:
-    """Sum a denominator over the data-parallel group (no-op without a live group)."""
+    """Sum a denominator over ``dp_group``. No reduction when ``dp_group`` is ``None``.
+
+    The caller must pass the intended data-parallel group explicitly; ``None`` is
+    local-only. (Do not fall back to the default process group, whose members are
+    not the DP replicas under Megatron-Core parallelism.)
+    """
     out = value.detach().clone()
-    if dp_group is not None or (dist.is_available() and dist.is_initialized()):
+    if dp_group is not None:
         dist.all_reduce(out, op=dist.ReduceOp.SUM, group=dp_group)
     return out
 
@@ -171,7 +176,7 @@ def dspark_loss(
 
     # Divide by the (optionally DP-reduced) denominators; the backward gradient is
     # scaled by world_size so the DP-averaged gradient matches the global loss.
-    world_size = dist.get_world_size(dp_group) if (dist.is_available() and dist.is_initialized()) else 1
+    world_size = dist.get_world_size(dp_group) if dp_group is not None else 1
     ce_g, l1_g, conf_g = (_reduce_den(d, dp_group) for d in (ce_den, l1_den, conf_den))
     ce_loss = ce_num / (ce_g + 1e-6)
     l1_loss = l1_num / (l1_g + 1e-6) if l1_g.item() > 0 else zero

--- a/src/megatron/bridge/training/post_training/dspark/loss.py
+++ b/src/megatron/bridge/training/post_training/dspark/loss.py
@@ -81,19 +81,19 @@ def _loss_weight_mask(eval_mask: torch.Tensor, block_size: int, loss_decay_gamma
     return weight
 
 
-def _l1_distance_per_token(draft_logits: torch.Tensor, target_logits: torch.Tensor) -> torch.Tensor:
-    """FP32 probability L1 distance ``||softmax(draft) - softmax(target)||_1`` per position.
+def _tv_distance_per_token(draft_logits: torch.Tensor, target_logits: torch.Tensor) -> torch.Tensor:
+    """FP32 total-variation distance ``0.5 * ||softmax(draft) - softmax(target)||_1`` per position.
 
     Args:
         draft_logits: ``[..., vocab]``.
         target_logits: ``[..., vocab]``.
 
     Returns:
-        Per-position L1 distance ``[...]`` (twice the total-variation distance).
+        Per-position TV distance ``[...]``, in ``[0, 1]``.
     """
     draft_probs = torch.softmax(draft_logits.float(), dim=-1)
     target_probs = torch.softmax(target_logits.float(), dim=-1)
-    return (draft_probs - target_probs).abs().sum(dim=-1)
+    return 0.5 * (draft_probs - target_probs).abs().sum(dim=-1)
 
 
 def _reduce_den(value: torch.Tensor, dp_group) -> torch.Tensor:
@@ -160,10 +160,10 @@ def dspark_loss(
     conf_num = conf_den = zero
     accept_rate = None
     if target_logits is not None and (l1_alpha > 0 or has_confidence):
-        l1_dist = _l1_distance_per_token(draft_logits, target_logits)  # [B, N, L] == 2 * TV
-        accept_rate = (1.0 - 0.5 * l1_dist).clamp_(0.0, 1.0)
+        tv_dist = _tv_distance_per_token(draft_logits, target_logits)  # [B, N, L]
+        accept_rate = (1.0 - tv_dist).clamp_(0.0, 1.0)
         if l1_alpha > 0:
-            l1_num = (l1_dist * weight).sum()
+            l1_num = (tv_dist * weight).sum()
             l1_den = weight.sum()
         if has_confidence:
             conf_num = (

--- a/tests/functional_tests/test_groups/training/test_dspark_loss_dp.py
+++ b/tests/functional_tests/test_groups/training/test_dspark_loss_dp.py
@@ -1,0 +1,118 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Multi-GPU functional test for the DSpark loss data-parallel reduction.
+
+The DSpark loss (:func:`megatron.bridge.training.post_training.dspark.loss.dspark_loss`)
+divides each per-token numerator by an all-reduced global denominator and scales
+the backward by ``world_size``, so that the data-parallel-averaged gradient equals
+the single-process full-batch gradient. That invariant cannot be exercised on a
+single process; this test runs two NCCL ranks and asserts the DP-averaged gradient
+through a shared head matches the single-process reference over the concatenated
+batch. It needs 2 GPUs and is intended for a GPU node / cluster runner (not the
+CPU unit-test lane). Run it directly on a 2-GPU node: ``pytest <this file>``.
+"""
+
+import os
+import socket
+
+import pytest
+import torch
+import torch.multiprocessing as mp
+
+from megatron.bridge.training.post_training.dspark.heads import VanillaMarkov
+from megatron.bridge.training.post_training.dspark.loss import DSparkForwardOutput, dspark_loss
+
+
+def _free_port() -> int:
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    return port
+
+
+def _grad_over(head, sl, batch, dp_group):
+    """Loss backward over the block-slice ``sl``; return the shared head's grad.
+
+    Args:
+        head: Shared ``VanillaMarkov`` whose ``markov_w2.weight`` grad is returned.
+        sl: Slice into the block axis (dim 0) selecting this rank's blocks.
+        batch: ``(base_logits, prev_ids, target_ids, aligned_target_logits,
+            eval_mask, block_keep_mask)`` for the full batch; each is
+            ``[total_blocks, num_blocks, block_size(, vocab)]``.
+        dp_group: Data-parallel process group for the loss denominator reduction,
+            or ``None`` for the single-process reference.
+
+    Returns:
+        ``markov_w2.weight.grad`` after one backward.
+    """
+    base, prev, target_ids, aligned, eval_mask, keep = batch
+    head.zero_grad(set_to_none=True)
+    draft = head.apply_block_logits(base[sl], token_ids=prev[sl], hidden_states=None)
+    out = DSparkForwardOutput(
+        draft_logits=draft,
+        target_ids=target_ids[sl],
+        eval_mask=eval_mask[sl],
+        block_keep_mask=keep[sl],
+        aligned_target_logits=aligned[sl],
+    )
+    loss, _ = dspark_loss(out, ce_alpha=0.1, l1_alpha=0.9, confidence_alpha=0.0, dp_group=dp_group)
+    loss.backward()
+    return head.markov_w2.weight.grad.detach().clone()
+
+
+def _worker(rank: int, world_size: int, port: int) -> None:
+    os.environ.update(MASTER_ADDR="127.0.0.1", MASTER_PORT=str(port), RANK=str(rank), WORLD_SIZE=str(world_size))
+    torch.cuda.set_device(rank)
+    torch.distributed.init_process_group("nccl", rank=rank, world_size=world_size)
+    try:
+        dev = torch.device("cuda", rank)
+        blocks_per_rank, num_blocks, block_size, vocab, rank_dim = 3, 2, 4, 32, 5
+        total = blocks_per_rank * world_size
+
+        # Identical head and full batch on every rank (seeded on CPU, then moved), so
+        # each rank can form the same single-process reference locally.
+        torch.manual_seed(0)
+        head = VanillaMarkov(vocab_size=vocab, markov_rank=rank_dim).to(dev)
+        torch.manual_seed(1234)
+        shape4 = (total, num_blocks, block_size, vocab)
+        shape3 = (total, num_blocks, block_size)
+        batch = (
+            torch.randn(*shape4).to(dev),  # base logits
+            torch.randint(0, vocab, shape3).to(dev),  # prev token ids
+            torch.randint(0, vocab, shape3).to(dev),  # target ids
+            torch.randn(*shape4).to(dev),  # aligned target logits
+            torch.ones(*shape3, dtype=torch.bool).to(dev),  # eval mask
+            torch.ones(total, num_blocks, dtype=torch.bool).to(dev),  # block keep mask
+        )
+
+        grad_ref = _grad_over(head, slice(0, total), batch, dp_group=None)
+
+        sl = slice(rank * blocks_per_rank, (rank + 1) * blocks_per_rank)
+        grad_local = _grad_over(head, sl, batch, dp_group=torch.distributed.group.WORLD)
+        grad_dist = grad_local.clone()
+        torch.distributed.all_reduce(grad_dist, op=torch.distributed.ReduceOp.SUM)
+        grad_dist /= world_size
+
+        rel = (grad_dist - grad_ref).abs().max() / grad_ref.abs().max().clamp_min(1e-6)
+        assert rel < 1e-4, f"[rank {rank}] DP-averaged gradient mismatch rel={rel.item():.3e}"
+    finally:
+        if torch.distributed.is_initialized():
+            torch.distributed.destroy_process_group()
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="DSpark loss DP-gradient test needs 2 GPUs")
+def test_dspark_loss_dp_gradient_matches_single_process():
+    mp.spawn(_worker, args=(2, _free_port()), nprocs=2, join=True)

--- a/tests/unit_tests/training/post_training/test_dspark_heads.py
+++ b/tests/unit_tests/training/post_training/test_dspark_heads.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU unit tests for the DSpark draft heads."""
+
+import pytest
+import torch
+
+from megatron.bridge.training.post_training.dspark.heads import (
+    ConfidenceHead,
+    GatedMarkovHead,
+    RNNHead,
+    VanillaMarkov,
+    build_markov_head,
+)
+
+
+B, N, L, V, H, R = 2, 3, 4, 16, 8, 5
+
+
+def test_vanilla_markov_bias_is_lowrank_token_bias():
+    torch.manual_seed(0)
+    head = VanillaMarkov(vocab_size=V, markov_rank=R)
+    base = torch.randn(B, N, L, V)
+    prev = torch.randint(0, V, (B, N, L))
+    out = head.apply_block_logits(base, token_ids=prev, hidden_states=None)
+    expected = base + head.markov_w2(head.markov_w1(prev))
+    assert out.shape == (B, N, L, V)
+    assert torch.allclose(out, expected, atol=1e-5)
+
+
+def test_empty_block_is_identity():
+    head = VanillaMarkov(vocab_size=V, markov_rank=R)
+    base = torch.randn(B, N, 0, V)
+    prev = torch.randint(0, V, (B, N, 0))
+    out = head.apply_block_logits(base, token_ids=prev, hidden_states=None)
+    assert out.shape == (B, N, 0, V)
+
+
+@pytest.mark.parametrize("head_type,cls", [("vanilla", VanillaMarkov), ("gated", GatedMarkovHead), ("rnn", RNNHead)])
+def test_build_markov_head_dispatch_and_shape(head_type, cls):
+    head = build_markov_head(markov_rank=R, markov_head_type=head_type, vocab_size=V, hidden_size=H)
+    assert isinstance(head, cls)
+    base = torch.randn(B, N, L, V)
+    prev = torch.randint(0, V, (B, N, L))
+    hidden = torch.randn(B, N, L, H)
+    out = head.apply_block_logits(base, token_ids=prev, hidden_states=hidden)
+    assert out.shape == (B, N, L, V)
+    assert torch.isfinite(out).all()
+
+
+def test_build_markov_head_disabled_when_rank_zero():
+    assert build_markov_head(markov_rank=0, markov_head_type="vanilla", vocab_size=V, hidden_size=H) is None
+
+
+def test_build_markov_head_rejects_unknown_type():
+    with pytest.raises(ValueError, match="Unsupported markov_head_type"):
+        build_markov_head(markov_rank=R, markov_head_type="bogus", vocab_size=V, hidden_size=H)
+
+
+def test_gated_and_rnn_require_hidden_states():
+    for head in (
+        GatedMarkovHead(vocab_size=V, markov_rank=R, hidden_size=H),
+        RNNHead(vocab_size=V, markov_rank=R, hidden_size=H),
+    ):
+        base = torch.randn(B, N, L, V)
+        prev = torch.randint(0, V, (B, N, L))
+        with pytest.raises(ValueError, match="requires hidden_states"):
+            head.apply_block_logits(base, token_ids=prev, hidden_states=None)
+
+
+def test_rnn_head_state_makes_positions_prefix_dependent():
+    # Changing an earlier prefix token must change a later position's bias (state carries).
+    torch.manual_seed(0)
+    head = RNNHead(vocab_size=V, markov_rank=R, hidden_size=H)
+    base = torch.zeros(1, 1, L, V)
+    hidden = torch.randn(1, 1, L, H)
+    prev_a = torch.tensor([[[1, 2, 3, 4]]])
+    prev_b = torch.tensor([[[9, 2, 3, 4]]])  # differs only at position 0
+    out_a = head.apply_block_logits(base, token_ids=prev_a, hidden_states=hidden)
+    out_b = head.apply_block_logits(base, token_ids=prev_b, hidden_states=hidden)
+    # The last position differs because the recurrent state depends on position 0.
+    assert not torch.allclose(out_a[..., -1, :], out_b[..., -1, :])
+
+
+def test_confidence_head_projects_to_scalar_logit():
+    head = ConfidenceHead(input_dim=H)
+    out = head(torch.randn(B, N, L, H))
+    assert out.shape == (B, N, L)

--- a/tests/unit_tests/training/post_training/test_dspark_loss.py
+++ b/tests/unit_tests/training/post_training/test_dspark_loss.py
@@ -79,6 +79,27 @@ def test_three_terms_combine_with_alphas():
     loss.backward()
 
 
+def test_l1_loss_is_total_variation_not_full_l1():
+    # Disjoint saturated distributions: draft puts all mass on token 0, the target
+    # on token 1, so the raw L1 distance is 2.0 and the TV distance is 1.0. The
+    # trained/reported term must be the TV value, not the full L1.
+    draft = torch.full((1, 1, 1, V), -30.0)
+    draft[..., 0] = 30.0
+    draft.requires_grad_()
+    target = torch.full((1, 1, 1, V), -30.0)
+    target[..., 1] = 30.0
+    out = DSparkForwardOutput(
+        draft_logits=draft,
+        target_ids=torch.zeros(1, 1, 1, dtype=torch.long),
+        eval_mask=torch.ones(1, 1, 1, dtype=torch.bool),
+        block_keep_mask=torch.ones(1, 1, dtype=torch.bool),
+        aligned_target_logits=target,
+    )
+    loss, metrics = dspark_loss(out, ce_alpha=0.0, l1_alpha=1.0, confidence_alpha=0.0, loss_decay_gamma=None)
+    assert metrics["l1_loss"].item() == pytest.approx(1.0, abs=1e-5)
+    assert loss.item() == pytest.approx(1.0, abs=1e-5)
+
+
 def test_missing_target_logits_raises_when_tv_requested():
     out = _outputs(with_target=False, with_confidence=False)
     with pytest.raises(ValueError, match="aligned_target_logits is required"):

--- a/tests/unit_tests/training/post_training/test_dspark_loss.py
+++ b/tests/unit_tests/training/post_training/test_dspark_loss.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU unit tests for the DSpark draft loss and acceptance metrics."""
+
+import pytest
+import torch
+
+from megatron.bridge.training.post_training.dspark.loss import DSparkForwardOutput, dspark_loss
+
+
+B, N, L, V = 2, 3, 4, 32
+
+
+def _outputs(*, with_target: bool, with_confidence: bool, draft_equals_target: bool = False):
+    torch.manual_seed(0)
+    draft = torch.randn(B, N, L, V, requires_grad=True)
+    target_ids = torch.randint(0, V, (B, N, L))
+    eval_mask = torch.ones(B, N, L, dtype=torch.bool)
+    keep = torch.ones(B, N, dtype=torch.bool)
+    confidence = torch.randn(B, N, L) if with_confidence else None
+    aligned = None
+    if with_target:
+        aligned = draft.detach().clone() if draft_equals_target else torch.randn(B, N, L, V)
+    return DSparkForwardOutput(
+        draft_logits=draft,
+        target_ids=target_ids,
+        eval_mask=eval_mask,
+        block_keep_mask=keep,
+        confidence_pred=confidence,
+        aligned_target_logits=aligned,
+    )
+
+
+def test_acceptance_is_one_minus_tv_and_tau_when_distributions_match():
+    # draft == target -> TV 0 -> accept_rate 1 -> tau = block_size + 1.
+    out = _outputs(with_target=True, with_confidence=False, draft_equals_target=True)
+    _, metrics = dspark_loss(out, l1_alpha=0.9, confidence_alpha=0.0)
+    assert metrics["accept_rate"].item() == pytest.approx(1.0, abs=1e-5)
+    assert metrics["tau"].item() == pytest.approx(L + 1.0, abs=1e-4)
+    assert metrics["l1_loss"].item() == pytest.approx(0.0, abs=1e-5)
+
+
+def test_mismatched_distributions_give_lower_acceptance():
+    out = _outputs(with_target=True, with_confidence=False)
+    _, metrics = dspark_loss(out, l1_alpha=0.9, confidence_alpha=0.0)
+    assert 0.0 <= metrics["accept_rate"].item() < 1.0
+    assert 1.0 <= metrics["tau"].item() <= L + 1.0
+
+
+def test_ce_only_without_target_logits():
+    out = _outputs(with_target=False, with_confidence=False)
+    loss, metrics = dspark_loss(out, ce_alpha=0.1, l1_alpha=0.0, confidence_alpha=0.0)
+    assert metrics["l1_loss"].item() == pytest.approx(0.0)
+    assert metrics["confidence_loss"].item() == pytest.approx(0.0)
+    # Loss reduces to ce_alpha * ce_loss.
+    assert loss.item() == pytest.approx(0.1 * metrics["ce_loss"].item(), rel=1e-5)
+    loss.backward()  # differentiable path
+
+
+def test_three_terms_combine_with_alphas():
+    out = _outputs(with_target=True, with_confidence=True)
+    ce_a, l1_a, cf_a = 0.1, 0.9, 1.0
+    loss, m = dspark_loss(out, ce_alpha=ce_a, l1_alpha=l1_a, confidence_alpha=cf_a)
+    expected = ce_a * m["ce_loss"].item() + l1_a * m["l1_loss"].item() + cf_a * m["confidence_loss"].item()
+    assert loss.item() == pytest.approx(expected, rel=1e-5)
+    assert m["l1_loss"].item() > 0 and m["confidence_loss"].item() > 0
+    loss.backward()
+
+
+def test_missing_target_logits_raises_when_tv_requested():
+    out = _outputs(with_target=False, with_confidence=False)
+    with pytest.raises(ValueError, match="aligned_target_logits is required"):
+        dspark_loss(out, l1_alpha=0.9)
+
+
+def test_eval_mask_zero_positions_do_not_contribute():
+    out = _outputs(with_target=True, with_confidence=False)
+    out.eval_mask = torch.zeros(B, N, L, dtype=torch.bool)
+    loss, metrics = dspark_loss(out, ce_alpha=0.1, l1_alpha=0.9, confidence_alpha=0.0)
+    # All positions masked out: numerators are zero, so the loss is zero.
+    assert loss.item() == pytest.approx(0.0, abs=1e-6)
+    assert metrics["accept_rate"].item() == pytest.approx(0.0, abs=1e-6)


### PR DESCRIPTION
> Stacked on #5233 and #5234: this fixes the DSpark core introduced there, so until those merge this PR also lists their commits. Only the last commit is new here; I will rebase once the base PRs land.

## What

The trained TV term summed the raw probability L1 distance, which is twice the total-variation distance. With the default alphas the objective was effectively `0.1 * CE + 1.8 * TV` instead of the documented `0.1 * CE + 0.9 * TV`, and the `l1_loss` metric reported twice the documented TV value.

## Fix

Move the L1-vs-TV convention into the helper itself: `_l1_distance_per_token` becomes `_tv_distance_per_token` and returns `0.5 * ||p_draft - p_target||_1` directly. `accept_rate = 1 - tv` and `l1_num = (tv * weight).sum()` then fall out with no inline `0.5` constants, so no future call site can accidentally grab the un-halved distance.

Note: the `l1_loss` metric key is kept for continuity but now reports the TV value (half the raw L1), matching the module docstring and the design doc. Runs compared across this change will show the term drop by 2x; that is the fix, not a regression.

## Tests

New unit test `test_l1_loss_is_total_variation_not_full_l1` builds two disjoint saturated distributions (raw L1 = 2.0, TV = 1.0) and asserts both the metric and the loss equal 1.0. The test fails on the parent commit and passes here. All 17 dspark unit tests pass; ruff check and format are clean.

## Merge note

This branch and the masked-input-robustness fix PR (same stack) both touch the `l1_dist` block of `dspark_loss`, so merging both into the DSpark core branch (#5234) will conflict there. Resolve by scrubbing first, then using the TV helper: `tv_dist = _tv_distance_per_token(...)`, `tv_dist = torch.where(eval_bool, tv_dist, 0.0)`, then `accept_rate = (1.0 - tv_dist).clamp_(0.0, 1.0)`.
