### PR TITLE
[data, ckpt] fix: Preserve Energon checkpoint state

### DIFF
--- a/src/megatron/bridge/data/builders/energon.py
+++ b/src/megatron/bridge/data/builders/energon.py
@@ -310,7 +310,7 @@ class EnergonDatasetBuilder:
             pg_collection=context.pg_collection,
             **self.config.dataset_kwargs,
         )
-        train = iter(datamodule.train_dataloader()) if build_train else None
+        train = datamodule.train_dataloader() if build_train else None
         validation = iter(datamodule.val_dataloader()) if build_validation else None
         return train, validation, None
 

--- a/tests/unit_tests/data/builders/test_energon_builder.py
+++ b/tests/unit_tests/data/builders/test_energon_builder.py
@@ -243,6 +243,38 @@ def test_builder_honors_requested_splits_and_reuses_runtime_encoder(monkeypatch:
     assert datamodule_cls.call_args.kwargs["packing_buffer_size"] == 32
 
 
+def test_builder_preserves_checkpointable_train_loader(monkeypatch: pytest.MonkeyPatch):
+    class CheckpointableLoader:
+        def __init__(self):
+            self._iterator = iter(["train"])
+
+        def __iter__(self):
+            return self._iterator
+
+        def save_state(self):
+            return {"sample": 0}
+
+        def restore_state(self, state):
+            self._iterator = iter(["train"])
+
+    config = _qwen_config()
+    train_loader = CheckpointableLoader()
+    datamodule = MagicMock()
+    datamodule.train_dataloader.return_value = train_loader
+    monkeypatch.setattr("megatron.bridge.data.builders.energon.build_energon_task_encoder", lambda _: object())
+    monkeypatch.setattr(
+        base_energon_datamodule,
+        "EnergonMultiModalDataModule",
+        MagicMock(return_value=datamodule),
+    )
+
+    train, _, _ = EnergonDatasetBuilder(config).build(
+        DatasetBuildContext(train_samples=1, valid_samples=0, test_samples=0)
+    )
+
+    assert train is train_loader
+
+
 def test_builder_skips_unrequested_validation(monkeypatch: pytest.MonkeyPatch):
     config = _qwen_config(do_validation=False)
     datamodule = MagicMock()


### PR DESCRIPTION
## Summary

- Preserve the checkpointable Energon train-loader wrapper returned by the
  declarative dataset builder.
- Add a regression test that verifies the builder keeps that wrapper intact.

## User impact and root cause

Maintained declarative Energon recipes use MCore's external dataloader path.
`EnergonDatasetBuilder.build()` eagerly called `iter()` on the train loader,
which replaced `EnergonDataloader` with its internal iterator before it reached
checkpoint setup. The resulting external iterator no longer exposed
`save_state()` or `restore_state()`.

Consequently, the default checkpoint path silently omitted Energon dataloader
state, an explicitly requested save path failed, and resume could restart the
sample stream instead of restoring it. This contradicts the exact-resume
contract introduced by #4521 (and reported in #3993).

The fix returns the train loader itself. It remains iterable for training while
retaining the checkpoint methods. Validation is unchanged because dataloader
checkpoint state is train-only.

## Verification

Regression on unmodified `e13b553b1f7906742762d6bf651caac03afb0c6d`:

```text
uv run --active --no-sync --with megatron-energon==7.4.0 python -m pytest --confcutdir=tests/unit_tests/data/builders tests/unit_tests/data/builders/test_energon_builder.py::test_builder_preserves_checkpointable_train_loader -q --tb=short
```

- Before: failed, `assert <list_iterator ...> is <CheckpointableLoader ...>`
- After: `1 passed`

Adjacent checks:

```text
uv run --active --no-sync --with megatron-energon==7.4.0 python -m pytest --confcutdir=tests/unit_tests/data/builders tests/unit_tests/data/builders/test_energon_builder.py -q --tb=short
# 12 passed

uv run --active --no-sync --with megatron-energon==7.4.0 python -m pytest --confcutdir=tests/functional_tests/test_groups/data/energon tests/functional_tests/test_groups/data/energon/test_base_energon_datamodule.py::TestEnergonDataModuleCPHandling::test_energon_dataloader_save_state tests/functional_tests/test_groups/data/energon/test_base_energon_datamodule.py::TestEnergonDataModuleCPHandling::test_energon_dataloader_restore_state -q --tb=short
# 2 passed
```

- `git diff --check`: passed
- `uv run --active --no-sync pre-commit run --all-files`: all hooks passed

## Scope

This changes only the declarative Energon train-loader ownership boundary. It
does not alter validation iteration, public APIs, dependencies, CI, MCore, or
checkpoint formats. No full-suite, GPU, convergence, performance, or
model-quality validation was run.
