### PR TITLE
[misc] fix: Honor VLM generation stop tokens

### DIFF
--- a/examples/conversion/hf_to_megatron_generate_vlm.py
+++ b/examples/conversion/hf_to_megatron_generate_vlm.py
@@ -33,7 +33,7 @@ import torch
 import torch.distributed as dist
 from megatron.core import parallel_state
 from megatron.core.pipeline_parallel.schedules import get_forward_backward_func
-from transformers import AutoConfig, AutoProcessor, AutoTokenizer
+from transformers import AutoConfig, AutoProcessor, AutoTokenizer, GenerationConfig
 from vlm_generate_utils import (
     pad_input_ids_to_tp_multiple,
     patch_kimi_vision_processor,
@@ -297,7 +297,19 @@ def main(args) -> None:
     # Greedy generation loop
     # ------------------------------------------------------------------
     generated_ids = input_ids_raw.clone()
-    stop_tokens = [tokenizer.eos_token_id]
+    try:
+        generation_config = GenerationConfig.from_pretrained(
+            args.hf_model_path,
+            **_hf_revision_kwargs(args.hf_revision),
+        )
+    except OSError:
+        generation_config = GenerationConfig.from_model_config(config)
+    stop_token_ids = generation_config.eos_token_id
+    if stop_token_ids is None:
+        stop_token_ids = [tokenizer.eos_token_id]
+    elif isinstance(stop_token_ids, int):
+        stop_token_ids = [stop_token_ids]
+    stop_tokens = set(stop_token_ids)
 
     for step in range(args.max_new_tokens):
         with torch.no_grad():

--- a/tests/unit_tests/examples/test_hf_to_megatron_generate_vlm.py
+++ b/tests/unit_tests/examples/test_hf_to_megatron_generate_vlm.py
@@ -1,0 +1,147 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import runpy
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+
+_SCRIPT = Path(__file__).parents[3] / "examples" / "conversion" / "hf_to_megatron_generate_vlm.py"
+_parallel_state = MagicMock()
+_import_stubs = {
+    "megatron": types.ModuleType("megatron"),
+    "megatron.core": types.ModuleType("megatron.core"),
+    "megatron.core.pipeline_parallel": types.ModuleType("megatron.core.pipeline_parallel"),
+    "megatron.core.pipeline_parallel.schedules": types.ModuleType("megatron.core.pipeline_parallel.schedules"),
+    "megatron.bridge": types.ModuleType("megatron.bridge"),
+    "megatron.bridge.models": types.ModuleType("megatron.bridge.models"),
+    "megatron.bridge.models.hf_pretrained": types.ModuleType("megatron.bridge.models.hf_pretrained"),
+    "megatron.bridge.models.hf_pretrained.utils": types.ModuleType("megatron.bridge.models.hf_pretrained.utils"),
+    "megatron.bridge.utils": types.ModuleType("megatron.bridge.utils"),
+    "megatron.bridge.utils.common_utils": types.ModuleType("megatron.bridge.utils.common_utils"),
+    "transformers": types.ModuleType("transformers"),
+    "vlm_generate_utils": types.ModuleType("vlm_generate_utils"),
+}
+_import_stubs["megatron.core"].parallel_state = _parallel_state
+_import_stubs["megatron.core.pipeline_parallel.schedules"].get_forward_backward_func = MagicMock()
+_import_stubs["megatron.bridge"].AutoBridge = MagicMock()
+_import_stubs["megatron.bridge.models.hf_pretrained.utils"].is_safe_repo = MagicMock()
+_import_stubs["megatron.bridge.utils.common_utils"].get_last_rank = MagicMock()
+_import_stubs["megatron.bridge.utils.common_utils"].print_rank_0 = MagicMock()
+_import_stubs["megatron.bridge.utils.common_utils"].print_rank_last = MagicMock()
+for name in ("AutoConfig", "AutoProcessor", "AutoTokenizer", "GenerationConfig"):
+    setattr(_import_stubs["transformers"], name, MagicMock())
+for name in (
+    "pad_input_ids_to_tp_multiple",
+    "patch_kimi_vision_processor",
+    "process_image_inputs",
+    "process_multi_image_inputs",
+    "process_video_inputs",
+    "to_cuda",
+):
+    setattr(_import_stubs["vlm_generate_utils"], name, MagicMock())
+
+with patch.dict(sys.modules, _import_stubs):
+    _SCRIPT_GLOBALS = runpy.run_path(_SCRIPT)
+_main = _SCRIPT_GLOBALS["main"]
+
+
+@pytest.mark.unit
+def test_generation_stops_on_any_configured_eos_token() -> None:
+    """An alternate EOS from generation_config must end the greedy loop."""
+    args = SimpleNamespace(
+        ep=1,
+        etp=1,
+        hf_model_path="org/model",
+        hf_revision="revision",
+        image_path=None,
+        image_paths=None,
+        max_new_tokens=2,
+        megatron_model_path=None,
+        pp=1,
+        pp_layout=None,
+        prompt="prompt",
+        tp=1,
+        trust_remote_code=False,
+        video_fps=2.0,
+        video_path=None,
+    )
+
+    model = MagicMock()
+    model.cuda.return_value = model
+    provider = MagicMock()
+    provider.provide_distributed_model.return_value = [model]
+    bridge = MagicMock()
+    bridge.to_megatron_provider.return_value = provider
+
+    tokenizer = MagicMock()
+    tokenizer.eos_token_id = 1
+    tokenizer.pad_token = "<pad>"
+    tokenizer.pad_token_id = 0
+    tokenizer.decode.return_value = "decoded"
+
+    generation_config = SimpleNamespace(eos_token_id=[1, 2])
+    generation_config_cls = MagicMock()
+    generation_config_cls.from_pretrained.return_value = generation_config
+
+    forward = MagicMock()
+
+    def run_forward(**kwargs):
+        seq_length = kwargs["seq_length"]
+        logits = torch.zeros(1, seq_length, 8)
+        next_token = 2 if forward.call_count == 1 else 1
+        logits[0, seq_length - 1, next_token] = 1
+        return [logits]
+
+    forward.side_effect = run_forward
+
+    def all_gather(outputs, tensor, group):
+        outputs[0].copy_(tensor)
+
+    script_globals = {
+        "AutoBridge": SimpleNamespace(from_hf_pretrained=MagicMock(return_value=bridge)),
+        "AutoConfig": SimpleNamespace(
+            from_pretrained=MagicMock(return_value=SimpleNamespace(model_type="qwen2_5_vl"))
+        ),
+        "AutoProcessor": SimpleNamespace(from_pretrained=MagicMock(return_value=MagicMock())),
+        "AutoTokenizer": SimpleNamespace(from_pretrained=MagicMock(return_value=tokenizer)),
+        "GenerationConfig": generation_config_cls,
+        "get_forward_backward_func": MagicMock(return_value=forward),
+        "get_last_rank": MagicMock(return_value=0),
+        "is_safe_repo": MagicMock(return_value=False),
+        "pad_input_ids_to_tp_multiple": lambda input_ids, tp_size, pad_token_id=0: input_ids,
+        "print_rank_0": MagicMock(),
+        "print_rank_last": MagicMock(),
+        "process_image_inputs": MagicMock(return_value=(torch.tensor([[3, 4]]), None, None, None, None, None)),
+        "to_cuda": lambda value: value,
+    }
+
+    with (
+        patch.dict(_main.__globals__, script_globals),
+        patch.object(torch.Tensor, "cuda", lambda self: self),
+        patch.object(torch.distributed, "all_gather", side_effect=all_gather),
+        patch.object(torch.distributed, "broadcast"),
+        patch.object(_main.__globals__["parallel_state"], "get_tensor_model_parallel_group", return_value=None),
+        patch.object(_main.__globals__["parallel_state"], "get_tensor_model_parallel_world_size", return_value=1),
+        patch.object(_main.__globals__["parallel_state"], "is_pipeline_last_stage", return_value=True),
+    ):
+        _main(args)
+
+    assert forward.call_count == 1


### PR DESCRIPTION
## Summary

The documented VLM conversion-generation entry point used only `tokenizer.eos_token_id` to stop its manual greedy loop. Supported instruction checkpoints can declare multiple terminal IDs in `generation_config.json` (for example, Gemma 4 and Qwen2.5-VL), so selecting a non-primary terminal token caused an extra forward pass and could continue into protocol tokens.

This change loads the selected checkpoint revision's `GenerationConfig`, normalizes scalar and list EOS values into the loop's stop set, and falls back to the model config and then tokenizer EOS when no generation-config file or EOS value exists.

## Root cause and fix

`examples/conversion/hf_to_megatron_generate_vlm.py` owns a manual autoregressive loop rather than calling Transformers `generate()`. The loop reconstructed termination semantics from the tokenizer's scalar EOS instead of the checkpoint's generation contract.

The fix reads `GenerationConfig` at that ownership boundary and leaves conversion, preprocessing, sampling, and parallel execution unchanged.

## Regression evidence

A deterministic one-rank reproducer drives the actual entry-point loop with first-step logits selecting an alternate configured EOS.

- Before: failed because the loop made 2 forward passes instead of stopping after 1.
- After: passed with 1 forward pass.

Focused regression:

```text
uv run python -m pytest tests/unit_tests/examples/test_hf_to_megatron_generate_vlm.py -q --tb=short
1 passed
```

Adjacent VLM preprocessing coverage:

```text
uv run python -m pytest tests/unit_tests/utils/test_vlm_generate_utils.py -q --tb=short
12 passed
```

Static checks:

```text
git diff --check
passed

uv run pre-commit run --all-files
all hooks passed
```

## Scope

- No public API or CLI changes.
- No dependency, lockfile, workflow, checkpoint-conversion, or MCore changes.
- No claim of full-suite, model-quality, convergence, performance, or full-checkpoint GPU validation.
