### PR TITLE
fix(diffusion): calculate WAN FLOPs from runtime geometry

### DIFF
--- a/src/megatron/bridge/diffusion/models/wan/wan_provider.py
+++ b/src/megatron/bridge/diffusion/models/wan/wan_provider.py
@@ -72,6 +72,59 @@ class WanModelProvider(TransformerConfig, ModelProviderMixin[VisionModule]):  # 
     text_len: int = 512
     text_dim: int = 4096
 
+    def _get_num_floating_point_operations_with_runtime_stats(
+        self,
+        *,
+        batch_size: int,
+        seqlen_sum: int | None,
+        seqlen_squared_sum: int | None,
+        cross_seqlen_sum: int | None,
+        cross_seqlen_product_sum: int | None,
+    ) -> int:
+        """Estimate WAN training FLOPs from the executed latent and context lengths."""
+        if batch_size <= 0:
+            return 0
+        if any(
+            value is None for value in (seqlen_sum, seqlen_squared_sum, cross_seqlen_sum, cross_seqlen_product_sum)
+        ):
+            raise ValueError("WAN FLOP accounting requires runtime self- and cross-attention sequence metadata")
+
+        query_tokens = int(seqlen_sum)
+        query_tokens_squared = int(seqlen_squared_sum)
+        context_tokens = int(cross_seqlen_sum)
+        query_context_tokens = int(cross_seqlen_product_sum)
+
+        hidden_size = self.hidden_size
+        kv_channels = self.kv_channels or hidden_size // self.num_attention_heads
+        num_query_groups = self.num_attention_heads if self.num_query_groups is None else self.num_query_groups
+        query_projection_size = kv_channels * self.num_attention_heads
+        kv_projection_size = kv_channels * num_query_groups
+
+        self_attention_flops = (
+            2 * query_tokens * hidden_size * (query_projection_size + 2 * kv_projection_size)
+            + 4 * query_tokens_squared * query_projection_size
+            + 2 * query_tokens * query_projection_size * hidden_size
+        )
+        cross_attention_flops = (
+            2 * query_tokens * hidden_size * query_projection_size
+            + 4 * context_tokens * self.crossattn_emb_size * kv_projection_size
+            + 4 * query_context_tokens * query_projection_size
+            + 2 * query_tokens * query_projection_size * hidden_size
+        )
+        mlp_projection_factor = 6 if self.gated_linear_unit else 4
+        mlp_flops = mlp_projection_factor * query_tokens * hidden_size * self.ffn_hidden_size
+        transformer_flops = self.num_layers * (self_attention_flops + cross_attention_flops + mlp_flops)
+
+        patch_volume = self.patch_temporal * self.patch_spatial**2
+        patch_embedding_flops = 2 * query_tokens * self.in_channels * patch_volume * hidden_size
+        text_embedding_flops = (
+            2 * context_tokens * (self.text_dim * self.crossattn_emb_size + self.crossattn_emb_size**2)
+        )
+        output_head_flops = 2 * query_tokens * hidden_size * self.out_channels * patch_volume
+
+        # Backward costs approximately twice the forward matrix-multiplication work.
+        return 3 * (transformer_flops + patch_embedding_flops + text_embedding_flops + output_head_flops)
+
     def provide(self, pre_process=None, post_process=None, vp_stage=None) -> WanModel:
         vp_size = self.virtual_pipeline_model_parallel_size
         if vp_size:

--- a/src/megatron/bridge/diffusion/models/wan/wan_step.py
+++ b/src/megatron/bridge/diffusion/models/wan/wan_step.py
@@ -28,6 +28,7 @@ from megatron.bridge.diffusion.models.wan.flow_matching.flow_matching_pipeline_w
 )
 from megatron.bridge.training.losses import masked_next_token_loss
 from megatron.bridge.training.state import GlobalState
+from megatron.bridge.training.utils.flop_utils import accumulate_flops_metadata, get_model_chunk_vp_stage
 
 
 logger = logging.getLogger(__name__)
@@ -148,6 +149,20 @@ class WanForwardStep:  # noqa: D101
         with straggler_timer(bdata=True):
             batch = wan_data_step(qkv_format, data_iterator)
         timers("batch-generator").stop()
+
+        packed_seq_params = batch.get("packed_seq_params")
+        if packed_seq_params is not None:
+            self_attention = packed_seq_params["self_attention"]
+            cross_attention = packed_seq_params["cross_attention"]
+            accumulate_flops_metadata(
+                state,
+                batch["video_latents"],
+                vp_stage=get_model_chunk_vp_stage(model),
+                cu_seqlens=self_attention.cu_seqlens_q_padded,
+                cu_seqlens_unpadded=self_attention.cu_seqlens_q,
+                cross_cu_seqlens=cross_attention.cu_seqlens_kv_padded,
+                cross_cu_seqlens_unpadded=cross_attention.cu_seqlens_kv,
+            )
 
         check_for_nan_in_loss = state.cfg.rerun_state_machine.check_for_nan_in_loss
         check_for_spiky_loss = state.cfg.rerun_state_machine.check_for_spiky_loss

--- a/src/megatron/bridge/training/train.py
+++ b/src/megatron/bridge/training/train.py
@@ -467,6 +467,8 @@ def train(
         global_state._flops_seqlen_sum = 0
         global_state._flops_seqlen_sq_sum = 0
         global_state._flops_vision_patches = 0
+        global_state._flops_cross_seqlen_sum = 0
+        global_state._flops_cross_seqlen_product_sum = 0
         global_state._flops_requires_global_reduce = False
 
         (
@@ -579,11 +581,20 @@ def train(
         # fixed-length stats from the local DP rank; THD batches request one exact SUM
         # all-reduce over the pure DP group because packed sub-sequence lengths can
         # differ by rank.
-        seqlen_sum, seqlen_squared_sum, num_vision_patches = flop_utils.resolve_global_flops_seqlen_stats(
+        (
+            seqlen_sum,
+            seqlen_squared_sum,
+            num_vision_patches,
+            cross_seqlen_sum,
+            cross_seqlen_product_sum,
+        ) = flop_utils.resolve_global_flops_runtime_stats(
             global_state,
             data_parallel_size=dp_size,
             vp_size=config.model.virtual_pipeline_model_parallel_size,
             dp_group=pg_collection.dp,
+            include_cross_attention_stats=hasattr(
+                config.model, "_get_num_floating_point_operations_with_runtime_stats"
+            ),
         )
         num_floating_point_operations_in_batch = flop_utils.num_floating_point_operations(
             config,
@@ -591,6 +602,8 @@ def train(
             seqlen_sum=seqlen_sum,
             seqlen_squared_sum=seqlen_squared_sum,
             num_vision_patches=num_vision_patches,
+            cross_seqlen_sum=cross_seqlen_sum,
+            cross_seqlen_product_sum=cross_seqlen_product_sum,
         )
         global_state.train_state.floating_point_operations_so_far += num_floating_point_operations_in_batch
         num_floating_point_operations_so_far = global_state.train_state.floating_point_operations_so_far

--- a/src/megatron/bridge/training/utils/flop_utils.py
+++ b/src/megatron/bridge/training/utils/flop_utils.py
@@ -85,19 +85,21 @@ def _accumulator_to_int(value) -> int:
     return 0
 
 
-def resolve_global_flops_seqlen_stats(
+def resolve_global_flops_runtime_stats(
     state,
     *,
     data_parallel_size: int,
     vp_size: int | None = None,
     dp_group=None,
-) -> tuple[int | None, int | None, int]:
+    include_cross_attention_stats: bool = False,
+) -> tuple[int | None, int | None, int, int | None, int | None]:
     """Resolve data-parallel-global FLOPS sequence stats from per-rank accumulators.
 
-    Reads the three accumulators populated by the forward step
+    Reads the accumulators populated by the forward step
     (``_flops_seqlen_sum`` = Σ padded tokens, ``_flops_seqlen_sq_sum`` = Σᵢ sᵢ²
-    over real sub-sequences, ``_flops_vision_patches``) and reduces them to
-    global totals across the data-parallel group.
+    over real sub-sequences, ``_flops_vision_patches``, and optional cross-attention
+    key/value and query-key products) and reduces them to global totals across the
+    data-parallel group.
 
     Under variable-length (THD packed) training the per-rank ``Σᵢ sᵢ²`` can
     differ across DP ranks, so a single SUM all-reduce over ``dp_group`` is used
@@ -116,16 +118,22 @@ def resolve_global_flops_seqlen_stats(
         dp_group: Data-parallel process group to SUM-reduce over. Must be the
             pure DP group (excluding CP) matching ``data_parallel_size`` — CP
             ranks share the same ``cu_seqlens`` and would double-count.
+        include_cross_attention_stats: Whether the collective includes the two
+            optional cross-attention values. This must be uniform across every
+            rank in ``dp_group``; callers should derive it from model capability,
+            not local batch contents.
 
     Returns:
-        ``(seqlen_sum, seqlen_squared_sum, num_vision_patches)``. The first two
-        are ``None`` when no accumulation happened, signalling the caller to fall
-        back to a fixed-length estimate. ``num_vision_patches`` is ``0`` when no
-        vision tokens were seen.
+        ``(seqlen_sum, seqlen_squared_sum, num_vision_patches,
+        cross_seqlen_sum, cross_seqlen_product_sum)``. Sequence values are ``None``
+        when no corresponding accumulation happened. ``num_vision_patches`` is
+        ``0`` when no vision tokens were seen.
     """
     local_seqlen_sum = _accumulator_to_int(getattr(state, "_flops_seqlen_sum", 0))
     local_seqlen_sq_sum = _accumulator_to_int(getattr(state, "_flops_seqlen_sq_sum", 0))
     local_vision_patches = _accumulator_to_int(getattr(state, "_flops_vision_patches", 0))
+    local_cross_seqlen_sum = _accumulator_to_int(getattr(state, "_flops_cross_seqlen_sum", 0))
+    local_cross_seqlen_product_sum = _accumulator_to_int(getattr(state, "_flops_cross_seqlen_product_sum", 0))
     _ = vp_size
 
     use_all_reduce = (
@@ -137,22 +145,58 @@ def resolve_global_flops_seqlen_stats(
     )
     if use_all_reduce:
         device = torch.cuda.current_device() if torch.cuda.is_available() else None
-        stats = torch.tensor(
-            [local_seqlen_sum, local_seqlen_sq_sum, local_vision_patches],
-            dtype=torch.long,
-            device=device,
-        )
+        stats_values = [local_seqlen_sum, local_seqlen_sq_sum, local_vision_patches]
+        # Preserve the original three-int collective for every non-cross-attention
+        # caller. Only WAN currently records the two optional cross-attention terms.
+        if include_cross_attention_stats:
+            stats_values.extend([local_cross_seqlen_sum, local_cross_seqlen_product_sum])
+        stats = torch.tensor(stats_values, dtype=torch.long, device=device)
         torch.distributed.all_reduce(stats, op=torch.distributed.ReduceOp.SUM, group=dp_group)
-        seqlen_sum, seqlen_squared_sum, num_vision_patches = (int(x) for x in stats.tolist())
+        reduced_stats = [int(x) for x in stats.tolist()]
+        seqlen_sum, seqlen_squared_sum, num_vision_patches = reduced_stats[:3]
+        if include_cross_attention_stats:
+            cross_seqlen_sum, cross_seqlen_product_sum = reduced_stats[3:]
+        else:
+            cross_seqlen_sum = 0
+            cross_seqlen_product_sum = 0
     else:
         # No process group: extrapolate from the local rank (approximation).
         seqlen_sum = local_seqlen_sum * data_parallel_size
         seqlen_squared_sum = local_seqlen_sq_sum * data_parallel_size
         num_vision_patches = local_vision_patches * data_parallel_size
+        cross_seqlen_sum = local_cross_seqlen_sum * data_parallel_size
+        cross_seqlen_product_sum = local_cross_seqlen_product_sum * data_parallel_size
 
     if seqlen_sum <= 0:
-        return None, None, max(num_vision_patches, 0)
-    return seqlen_sum, seqlen_squared_sum, max(num_vision_patches, 0)
+        seqlen_sum = None
+        seqlen_squared_sum = None
+    if cross_seqlen_sum <= 0:
+        cross_seqlen_sum = None
+        cross_seqlen_product_sum = None
+    return (
+        seqlen_sum,
+        seqlen_squared_sum,
+        max(num_vision_patches, 0),
+        cross_seqlen_sum,
+        cross_seqlen_product_sum,
+    )
+
+
+def resolve_global_flops_seqlen_stats(
+    state,
+    *,
+    data_parallel_size: int,
+    vp_size: int | None = None,
+    dp_group=None,
+) -> tuple[int | None, int | None, int]:
+    """Resolve the original self-attention and vision FLOP statistics."""
+    return resolve_global_flops_runtime_stats(
+        state,
+        data_parallel_size=data_parallel_size,
+        vp_size=vp_size,
+        dp_group=dp_group,
+        include_cross_attention_stats=False,
+    )[:3]
 
 
 def _add_flops_accumulator(state, name: str, delta) -> None:
@@ -221,6 +265,8 @@ def accumulate_flops_metadata(
     cu_seqlens_argmin: torch.Tensor | None = None,
     cu_seqlens_unpadded: torch.Tensor | None = None,
     cu_seqlens_unpadded_argmin: torch.Tensor | None = None,
+    cross_cu_seqlens: torch.Tensor | None = None,
+    cross_cu_seqlens_unpadded: torch.Tensor | None = None,
     num_vision_patches: int | torch.Tensor | None = None,
 ) -> None:
     """Accumulate per-microbatch FLOPS metadata onto ``state``.
@@ -230,7 +276,7 @@ def accumulate_flops_metadata(
     0 contributes metadata so model chunking does not multiply the full-model
     FLOPS estimate. ``None`` and ``0`` both represent the primary/only chunk.
 
-    Writes three accumulators consumed by ``train.py`` at end of step:
+    Writes accumulators consumed by ``train.py`` at end of step:
 
     - ``_flops_seqlen_sum``: ``mbs * tokens.shape[1]`` (padded total tokens
       this microbatch contributes), or ``mbs * config_seq_len`` for dense
@@ -247,6 +293,9 @@ def accumulate_flops_metadata(
       pre-fix value). ``dense_seq_len`` is ``config_seq_len`` when provided,
       otherwise ``tokens.shape[1]``.
     - ``_flops_vision_patches``: running total of ``num_vision_patches``.
+    - ``_flops_cross_seqlen_sum`` and ``_flops_cross_seqlen_product_sum``:
+      optional cross-attention Σᵢ kᵢ and Σᵢ qᵢkᵢ terms for model-specific
+      estimators such as WAN.
 
     ``num_vision_patches`` is the precomputed number of vision patches in this
     microbatch (drives the ViT term). It is kept model-agnostic on purpose: the
@@ -282,6 +331,28 @@ def accumulate_flops_metadata(
         # sub-sequences → BSHD fallback (single pack-length sequence).
         _add_flops_accumulator(state, "_flops_seqlen_sum", mbs * dense_seq_len)
         _add_flops_accumulator(state, "_flops_seqlen_sq_sum", mbs * dense_seq_len**2)
+
+    cross_sub_seq_lens = _real_subseq_lengths(
+        cross_cu_seqlens,
+        cu_seqlens_unpadded=cross_cu_seqlens_unpadded,
+    )
+    if cross_sub_seq_lens is not None and cross_sub_seq_lens.numel() > 0:
+        if sub_seq_lens is None or sub_seq_lens.numel() != cross_sub_seq_lens.numel():
+            raise ValueError("Cross-attention FLOP metadata requires matching query and key/value sequences")
+        setattr(state, "_flops_requires_global_reduce", True)
+        cross_padded_sub_seq_lens = _real_subseq_lengths(cross_cu_seqlens)
+        if cross_padded_sub_seq_lens is None or cross_padded_sub_seq_lens.numel() == 0:
+            cross_padded_sub_seq_lens = cross_sub_seq_lens
+        _add_flops_accumulator(
+            state,
+            "_flops_cross_seqlen_sum",
+            _scalar_sum_for_accumulator(cross_padded_sub_seq_lens),
+        )
+        _add_flops_accumulator(
+            state,
+            "_flops_cross_seqlen_product_sum",
+            _scalar_sum_for_accumulator(sub_seq_lens * cross_sub_seq_lens),
+        )
 
     if num_vision_patches is not None:
         _add_flops_accumulator(state, "_flops_vision_patches", num_vision_patches)
@@ -357,6 +428,8 @@ def num_floating_point_operations(
     seqlen_sum: int | None = None,
     seqlen_squared_sum: int | None = None,
     num_vision_patches: int = 0,
+    cross_seqlen_sum: int | None = None,
+    cross_seqlen_product_sum: int | None = None,
 ):
     """Return the number of floating point operations.
 
@@ -374,7 +447,21 @@ def num_floating_point_operations(
             result matches the legacy constant-length estimate.
         num_vision_patches: Total number of vision patches in the batch
             (before spatial merge). Used to compute ViT encoder FLOPS.
+        cross_seqlen_sum: Sum of cross-attention key/value sequence lengths.
+        cross_seqlen_product_sum: Sum of per-sample query and key/value length products.
     """
+    peft = getattr(cfg, "peft", None)
+    is_lora = isinstance(peft, LoRA)
+    runtime_flops_estimator = getattr(cfg.model, "_get_num_floating_point_operations_with_runtime_stats", None)
+    if runtime_flops_estimator is not None and not is_lora:
+        return runtime_flops_estimator(
+            batch_size=batch_size,
+            seqlen_sum=seqlen_sum,
+            seqlen_squared_sum=seqlen_squared_sum,
+            cross_seqlen_sum=cross_seqlen_sum,
+            cross_seqlen_product_sum=cross_seqlen_product_sum,
+        )
+
     # Compute effective sequence length from actual values or fall back to config.
     if seqlen_sum is not None and batch_size > 0:
         effective_seq_length = seqlen_sum / batch_size
@@ -395,8 +482,6 @@ def num_floating_point_operations(
     else:
         core_attn_seq_factor = effective_seq_length
 
-    peft = getattr(cfg, "peft", None)
-    is_lora = isinstance(peft, LoRA)
     # If the model provider has a custom TFLOPS calculation method, use it (non-LoRA only).
     if not is_lora and hasattr(cfg.model, "_get_num_floating_point_operations"):
         return cfg.model._get_num_floating_point_operations(batch_size)

--- a/tests/unit_tests/diffusion/model/wan/test_wan_provider.py
+++ b/tests/unit_tests/diffusion/model/wan/test_wan_provider.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 import torch.nn as nn
@@ -20,6 +22,38 @@ from megatron.core import parallel_state
 import megatron.bridge.diffusion.models.wan.wan_model as wan_model_module
 from megatron.bridge.diffusion.models.wan.wan_model import WanModel
 from megatron.bridge.diffusion.models.wan.wan_provider import WanModelProvider
+from megatron.bridge.training.utils.flop_utils import num_floating_point_operations
+
+
+def test_wan_provider_uses_runtime_geometry_for_flops():
+    provider = WanModelProvider(
+        num_layers=2,
+        hidden_size=8,
+        ffn_hidden_size=16,
+        num_attention_heads=2,
+        crossattn_emb_size=6,
+        in_channels=4,
+        out_channels=4,
+        patch_spatial=2,
+        patch_temporal=1,
+        text_dim=12,
+    )
+    config = SimpleNamespace(model=provider)
+
+    runtime_stats = {
+        "batch_size": 2,
+        "seqlen_sum": 10,
+        "seqlen_squared_sum": 58,
+        "cross_seqlen_sum": 6,
+        "cross_seqlen_product_sum": 34,
+    }
+    provider.seq_length = 1024
+    old_value = num_floating_point_operations(config, **runtime_stats)
+    provider.seq_length = 8192
+    new_value = num_floating_point_operations(config, **runtime_stats)
+
+    assert old_value == 120_624
+    assert new_value == old_value
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/training/utils/test_flop_utils.py
+++ b/tests/unit_tests/training/utils/test_flop_utils.py
@@ -27,6 +27,7 @@ from megatron.bridge.training.utils.flop_utils import (
     _packed_data_exists,
     accumulate_flops_metadata,
     num_floating_point_operations,
+    resolve_global_flops_runtime_stats,
     resolve_global_flops_seqlen_stats,
     vit_flops,
 )
@@ -2433,6 +2434,37 @@ class TestProviderOverride:
         # Override must have been invoked twice with the right batch_size args.
         assert captured == [1, 4], f"Override call log mismatch: {captured}"
 
+    def test_runtime_stats_override_short_circuits(self):
+        model = MockModelConfig()
+        sentinel = 7_654_321
+        captured = {}
+
+        def custom(**kwargs):
+            captured.update(kwargs)
+            return sentinel
+
+        model._get_num_floating_point_operations_with_runtime_stats = custom
+        cfg = MockConfigContainer(model=model)
+
+        assert (
+            num_floating_point_operations(
+                cfg,
+                batch_size=4,
+                seqlen_sum=100,
+                seqlen_squared_sum=2_500,
+                cross_seqlen_sum=20,
+                cross_seqlen_product_sum=500,
+            )
+            == sentinel
+        )
+        assert captured == {
+            "batch_size": 4,
+            "seqlen_sum": 100,
+            "seqlen_squared_sum": 2_500,
+            "cross_seqlen_sum": 20,
+            "cross_seqlen_product_sum": 500,
+        }
+
 
 class _State:
     """Minimal stand-in for GlobalState — just an attribute bag."""
@@ -2533,6 +2565,41 @@ class TestAccumulateFlopsMetadata:
         accumulate_flops_metadata(state, tokens, cu_seqlens=cu_b)
         assert state._flops_seqlen_sum == 2 * 128
         assert state._flops_seqlen_sq_sum == (32**2 + 96**2) + (64**2 + 64**2)
+
+    def test_cross_attention_metadata_uses_matching_query_and_key_lengths(self):
+        state = _State()
+        tokens = torch.zeros(1, 12)
+        query_cu_seqlens = torch.tensor([0, 4, 12])
+        query_cu_seqlens_unpadded = torch.tensor([0, 3, 8])
+        key_value_cu_seqlens = torch.tensor([0, 4, 12])
+        key_value_cu_seqlens_unpadded = torch.tensor([0, 2, 9])
+
+        accumulate_flops_metadata(
+            state,
+            tokens,
+            cu_seqlens=query_cu_seqlens,
+            cu_seqlens_unpadded=query_cu_seqlens_unpadded,
+            cross_cu_seqlens=key_value_cu_seqlens,
+            cross_cu_seqlens_unpadded=key_value_cu_seqlens_unpadded,
+        )
+
+        assert state._flops_seqlen_sum == 12
+        assert state._flops_seqlen_sq_sum == 3**2 + 5**2
+        assert state._flops_cross_seqlen_sum == 4 + 8
+        assert state._flops_cross_seqlen_product_sum == 3 * 2 + 5 * 7
+        assert state._flops_requires_global_reduce
+
+    def test_cross_attention_metadata_requires_matching_sequence_counts(self):
+        state = _State()
+        tokens = torch.zeros(1, 8)
+
+        with pytest.raises(ValueError, match="matching query and key/value sequences"):
+            accumulate_flops_metadata(
+                state,
+                tokens,
+                cu_seqlens=torch.tensor([0, 3, 8]),
+                cross_cu_seqlens=torch.tensor([0, 9]),
+            )
 
     @pytest.mark.parametrize("vp_size", [1, 2, 10])
     def test_vpp_accumulates_each_logical_microbatch_once(self, vp_size):
@@ -2657,12 +2724,16 @@ class TestResolveGlobalFlopsSeqlenStats:
         state._flops_seqlen_sum = 1000
         state._flops_seqlen_sq_sum = 250_000
         state._flops_vision_patches = 64
-        seqlen_sum, seqlen_sq_sum, vision = resolve_global_flops_seqlen_stats(
+        state._flops_cross_seqlen_sum = 32
+        state._flops_cross_seqlen_product_sum = 8_000
+        seqlen_sum, seqlen_sq_sum, vision, cross_sum, cross_product_sum = resolve_global_flops_runtime_stats(
             state, data_parallel_size=4, dp_group=None
         )
         assert seqlen_sum == 1000 * 4
         assert seqlen_sq_sum == 250_000 * 4
         assert vision == 64 * 4
+        assert cross_sum == 32 * 4
+        assert cross_product_sum == 8_000 * 4
 
     def test_dp_size_one_returns_local(self):
         state = _State()
@@ -2761,7 +2832,36 @@ class TestResolveGlobalFlopsSeqlenStats:
         )
 
         all_reduce.assert_called_once()
+        assert all_reduce.call_args.args[0].numel() == 3
         assert (seqlen_sum, seqlen_sq_sum, vision) == (40, 400, 0)
+
+    def test_cross_capability_extends_all_reduce_when_local_stats_are_zero(self, monkeypatch):
+        state = _State()
+        state._flops_seqlen_sum = 10
+        state._flops_seqlen_sq_sum = 100
+        state._flops_cross_seqlen_sum = 0
+        state._flops_cross_seqlen_product_sum = 0
+        state._flops_requires_global_reduce = True
+
+        def fake_all_reduce(stats, op=None, group=None):
+            stats.mul_(4)
+
+        all_reduce = MagicMock(side_effect=fake_all_reduce)
+        monkeypatch.setattr(torch.distributed, "is_available", lambda: True)
+        monkeypatch.setattr(torch.distributed, "is_initialized", lambda: True)
+        monkeypatch.setattr(torch.distributed, "all_reduce", all_reduce)
+        monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+
+        stats = resolve_global_flops_runtime_stats(
+            state,
+            data_parallel_size=4,
+            dp_group=object(),
+            include_cross_attention_stats=True,
+        )
+
+        all_reduce.assert_called_once()
+        assert all_reduce.call_args.args[0].numel() == 5
+        assert stats == (40, 400, 0, None, None)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
# What does this PR do?

Calculate WAN training FLOPs from the latent and text-context geometry actually executed by each batch. The theoretical MODEL_TFLOP/s/GPU numerator no longer depends on the compatibility-only `model.seq_length` field.

# Changelog

- Collect padded and unpadded WAN query and cross-attention key/value lengths from the existing `PackedSeqParams` batch metadata.
- Aggregate DP-global query-token, query-square, context-token, and query-context-product sums without duplicating CP or virtual-pipeline replicas.
- Add a WAN-specific matrix-multiplication estimate for self-attention, cross-attention, MLP, patch/text embedding, and output-head work.
- Preserve the existing three-value `resolve_global_flops_seqlen_stats` API and the original three-int packed-data collective for non-WAN models. The five-int collective is selected from a rank-uniform provider capability only for runtime cross-attention accounting.
- Add focused tests for runtime-estimator dispatch, packed/padded cross-attention statistics, distributed extrapolation and collective shape, exact WAN arithmetic, and invariance to `model.seq_length`.

There are no changes to the performance evaluator, evaluation tests, flat performance overrides, FLUX, or generic throughput logging.

# Root cause and impact

PR #4779 synchronized the CLI sequence length into `model.seq_length`. That is meaningful for language models because the field controls token workload. For WAN it is a compatibility placeholder: work is determined by packed latent video geometry and text-context length.

The target WAN 14B mock workload executes 37,440 query tokens and 512 context tokens per sample. Its previous generic estimates used sequence lengths 1024 and 8192, so both 7 and 63 MODEL_TFLOP/s/GPU were invalid undercounts; their 9x ratio was an estimator artifact.

| Measurement | Run/control | Old MODEL_TFLOP/s/GPU | New MODEL_TFLOP/s/GPU | Old step time | New step time | Step-time change |
|---|---|---:|---:|---:|---:|---:|
| NeMo CI result | Stored baseline vs. MR current | 6.9933 | 63.1000 | 39.1637 s | 39.1675 s | +0.010% |
| Controlled measurement with legacy estimator | Old/new/new/old on 16 GB200 GPUs, 30 pooled samples per variant | 7.0000 | 63.4833 | 38.904237 s | 38.929890 s | +0.0659% |
| Same controlled measurement with this corrected WAN estimator | Identical timings, both variants re-scored with 395.781682 PFLOP/step | 635.83 | 635.41 | 38.904237 s | 38.929890 s | +0.0659% |

The first two rows show the bug directly: reported TFLOP/s jumps by about 9x while physical step time is effectively unchanged. With one valid numerator applied to both variants, the rates move only with the measured time. The new point estimate is 0.06594% slower, within run-to-run variance, so there is no demonstrated performance improvement.

This issue is exposed on WAN because its generic sequence field does not describe runtime geometry. Text-model estimators remain valid. Other diffusion architectures may also need architecture-specific estimators, but their patch/context formulas must be derived separately rather than applying WAN logic or a broad domain opt-out.

# Common-path impact audit

- Only WAN defines `_get_num_floating_point_operations_with_runtime_stats` and only `WanForwardStep` passes cross-attention boundaries.
- Ten representative non-WAN formula paths were compared directly against `origin/main`—dense GPT, dynamic lengths, transformer MoE, hybrid Mamba/MoE, GDN, MLA, Kimi KDA, DeepSeek-V4, VLM/ViT, and LoRA—and were bit-identical. The legacy provider override was also identical.
- Dense models still perform no FLOP-metadata collective. Packed non-WAN models retain the same one three-int all-reduce; only WAN uses five ints.
- A rank-local width selector found during independent review was replaced before final publication with a rank-uniform model-capability selector. A zero-local-cross regression verifies that every WAN DP rank still enters the five-int collective.

The common training-loop plumbing is required because the exact latent and text lengths are batch-dependent and the loop owns per-step DP-global FLOP accumulation. A provider-only static value would remain wrong for different video resolutions, frame counts, or context lengths; a WAN-only reduction inside `forward_step` would duplicate the existing synchronization and step/VPP accounting path.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger CI.

Validation in `nvcr.io/nvidian/nemo:26.08.rc3`, with the mounted checkout first on `PYTHONPATH`:

- 211 focused WAN, FLUX, FLOP utility, and common training-loop tests passed locally.
- HSG-OCI Slurm job `5839477` passed the same 211 tests on one full GB200 node (`nvl72110-T18`, 4 GPUs, explicit segment 1) at validated commit `fbc548b58816c6197bd46fce1a89f43238c91fbe`.
- Ruff formatting and checks passed on all changed Python files.
- `git diff --check` passed.
- Independent read-only final review approved with no findings after verifying formula, common-path isolation, and distributed collective safety.

# Before your PR is Ready for review

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] Added focused unit tests for the changed contracts and arithmetic.
- [x] Evaluated documentation needs; no user-facing configuration workflow changed.
- [x] No dependency or optional-install component is affected.

# Additional Information

- Follow-up to #4779.
- Opened and retained as a draft per repository policy.
- WAN with PEFT is not enabled by current recipes; hypothetical WAN+LoRA accounting remains a separate follow-up rather than broadening this BF16 performance fix.
