### PR TITLE
fix(qwen3.5-vl): use top-level prefix for dense MTP mappings

### DIFF
--- a/src/megatron/bridge/models/qwen/qwen35_bridge.py
+++ b/src/megatron/bridge/models/qwen/qwen35_bridge.py
@@ -583,8 +583,10 @@ class Qwen35Bridge(MegatronModelBridge):
         """Get MTP (Multi-Token Prediction) parameter mappings for dense Qwen3.5.
 
         Args:
-            megatron_prefix: Prefix for Megatron param names. Use "" for LM and
-                "language_model." for VL models.
+            megatron_prefix: Prefix for Megatron param names. In both the plain LM
+                and the VL model, MTP is attached at the top level of the Megatron
+                model (a sibling of "language_model", not nested under it), so this
+                should always be "".
 
         Returns:
             List of mapping objects for the MTP portion.
@@ -594,8 +596,8 @@ class Qwen35Bridge(MegatronModelBridge):
         # =================================================================
         # MTP (Multi-Token Prediction) mappings
         # MTP uses standard attention (not GDN) and dense MLP.
-        # Megatron VL prefix: language_model.mtp.*
-        # Megatron ML prefix: mtp.*
+        # Megatron prefix: mtp.* (top-level, not nested under "language_model.",
+        # even for the VL model).
         # HF prefix: mtp.* (top-level, not under model.language_model.)
         # =================================================================
         mtp_param_mappings = {

--- a/src/megatron/bridge/models/qwen_vl/qwen35_vl_bridge.py
+++ b/src/megatron/bridge/models/qwen_vl/qwen35_vl_bridge.py
@@ -357,7 +357,12 @@ class Qwen35VLBridge(MegatronModelBridge):
         mapping_list.extend(
             Qwen35Bridge._get_dense_lm_mappings(hf_prefix="model.language_model.", megatron_prefix="language_model.")
         )
-        mapping_list.extend(Qwen35Bridge._get_dense_mtp_mappings(megatron_prefix="language_model."))
+        # MTP is attached at the top level of the Megatron VL model (a sibling of
+        # `language_model`, not nested under it), so its real parameter names are
+        # "mtp.layers.*" rather than "language_model.mtp.layers.*". Passing a
+        # "language_model." prefix here would produce mappings that never match the
+        # actual Megatron parameter names.
+        mapping_list.extend(Qwen35Bridge._get_dense_mtp_mappings(megatron_prefix=""))
         mapping_list.extend(_get_vision_mappings())
         return MegatronMappingRegistry(*mapping_list)
 

--- a/tests/unit_tests/models/qwen_vl/test_qwen35_vl_bridge.py
+++ b/tests/unit_tests/models/qwen_vl/test_qwen35_vl_bridge.py
@@ -282,6 +282,18 @@ class TestQwen35VLBridgeMappingRegistry:
         names = self._get_mapping_names(bridge.mapping_registry())
         assert any("patch_embed" in n for n in names)
 
+    def test_mapping_registry_mtp_params_use_top_level_prefix(self, bridge):
+        """MTP is a sibling of `language_model` in the real Megatron VL model, not
+        nested under it, so its Megatron param names must be "mtp.layers.*" rather
+        than "language_model.mtp.layers.*" (see regression this guards against:
+        MTP params silently failing to resolve during weight conversion)."""
+        registry = bridge.mapping_registry()
+        assert registry.megatron_to_hf_lookup("mtp.layers.0.enorm.weight") is not None
+        assert registry.megatron_to_hf_lookup("mtp.layers.0.hnorm.weight") is not None
+        assert registry.megatron_to_hf_lookup("mtp.layers.0.eh_proj.weight") is not None
+        assert registry.megatron_to_hf_lookup("mtp.layers.0.final_layernorm.weight") is not None
+        assert registry.megatron_to_hf_lookup("language_model.mtp.layers.0.enorm.weight") is None
+
 
 # =====================================================================
 # Tests for Qwen35TokenClassificationBridge


### PR DESCRIPTION
## Problem

`Qwen35VLBridge.mapping_registry()` (the dense Qwen3.5/3.6 VL bridge) builds its MTP mappings
with the wrong Megatron-side prefix:

```python
mapping_list.extend(Qwen35Bridge._get_dense_mtp_mappings(megatron_prefix="language_model."))
```

In the real instantiated Megatron VL model, the MTP submodule is attached at the top level (a
sibling of `language_model`, same as the vision tower), so its real parameter names are
`mtp.layers.0.*`, not `language_model.mtp.layers.0.*`. Every MTP parameter therefore fails to
resolve via `megatron_to_hf_lookup` / `hf_to_megatron_lookup`, and `load_weights_hf_to_megatron()`
then crashes with `AttributeError: 'NoneType' object has no attribute 'megatron_module'` when it
hits the resulting missing task entries in `build_conversion_tasks()`.

Confirmed against a dense Qwen3.5/3.6-27B VL checkpoint with `mtp_num_layers=1`, importing
pretrained HF weights into a freshly-constructed Megatron model — every MTP parameter (`enorm`,
`hnorm`, `eh_proj`, `final_layernorm`, and the MTP transformer layer's attention/MLP weights)
logs `No mapping found for megatron_param: mtp.layers.0.*`, followed by the `AttributeError`
above.

Fixes #5252

## Solution

One-line fix in `Qwen35VLBridge.mapping_registry()`:

```diff
-        mapping_list.extend(Qwen35Bridge._get_dense_mtp_mappings(megatron_prefix="language_model."))
+        mapping_list.extend(Qwen35Bridge._get_dense_mtp_mappings(megatron_prefix=""))
```

This mirrors the plain (non-VL) `Qwen35Bridge.mapping_registry()` in
`src/megatron/bridge/models/qwen/qwen35_bridge.py`, which already calls
`_get_dense_mtp_mappings(megatron_prefix="")` correctly. The mapping *content* was already right —
only the Megatron-side prefix was wrong.

Also corrected the docstring/comment on `_get_dense_mtp_mappings` in `qwen35_bridge.py`, which
documented the (incorrect) assumption that VL models should pass `"language_model."` here — that
comment was the source of the confusion that produced this bug.

## Tests

Added `test_mapping_registry_mtp_params_use_top_level_prefix` to
`TestQwen35VLBridgeMappingRegistry` in `test_qwen35_vl_bridge.py`, asserting:
- `mapping_registry().megatron_to_hf_lookup("mtp.layers.0.<param>")` resolves for the MTP norm/
  projection params, and
- the incorrect `"language_model.mtp.layers.0.enorm.weight"` does *not* resolve.

Ran the full `test_qwen35_vl_bridge.py` and `test_qwen35_bridge.py` suites locally (42 and 39
tests respectively, all passing) plus `ruff check`/`ruff format --check` on the touched files.
Verified the test fails on `main` before this change and passes after, reproducing the reported
symptom exactly (all MTP params `MISSING`, `language_model.mtp.*` present instead).

## Notes

- `Qwen35VLMoEBridge` (the MoE VL variant, e.g. Qwen3.5-397B-A17B) has the exact same pattern at
  its own `_get_moe_mtp_mappings(megatron_prefix="language_model.", ...)` call site — likely the
  same class of bug with the same fix (empty prefix). I have **not** verified this against real
  MoE+VL+MTP training logs, so I've left it out of this PR to keep the change minimal to the
  confirmed issue. Flagging it in case a maintainer wants to fold it in, or I'm happy to send a
  follow-up once/if it's confirmed.
