### PR TITLE
[training] fix: preserve resume RNG across data init callbacks

### DIFF
--- a/src/megatron/bridge/training/setup.py
+++ b/src/megatron/bridge/training/setup.py
@@ -14,11 +14,16 @@
 
 import inspect
 import logging
+import random
 import time
+from collections.abc import Iterator
+from contextlib import contextmanager
 from functools import partial
 from typing import Any, Callable, NamedTuple, Optional
 
+import numpy as np
 import torch
+from megatron.core import tensor_parallel
 from megatron.core.config import set_experimental_flag
 from megatron.core.distributed import DistributedDataParallel, DistributedDataParallelConfig, finalize_model_grads
 from megatron.core.jit import disable_jit_fuser
@@ -148,6 +153,33 @@ def _should_load_checkpoint(cfg: ConfigContainer, checkpoint_manager: Checkpoint
         )
 
     return should_load_checkpoint
+
+
+@contextmanager
+def _preserve_rng_state() -> Iterator[None]:
+    """Restore every training RNG stream after a disposable warmup."""
+    python_rng_state = random.getstate()
+    numpy_rng_state = np.random.get_state()
+    cuda_rng_tracker = tensor_parallel.get_cuda_rng_tracker()
+    graph_safe_rng = tensor_parallel.is_graph_safe_cuda_rng_tracker(cuda_rng_tracker)
+    rng_tracker_states = {
+        name: tensor_parallel.convert_cuda_rng_state(state).clone()
+        for name, state in cuda_rng_tracker.get_states().items()
+    }
+    cuda_devices = [torch.cuda.current_device()] if torch.cuda.is_available() else []
+
+    with torch.random.fork_rng(devices=cuda_devices):
+        try:
+            yield
+        finally:
+            random.setstate(python_rng_state)
+            np.random.set_state(numpy_rng_state)
+            cuda_rng_tracker.set_states(
+                {
+                    name: tensor_parallel.convert_cuda_rng_state(state, to_graphable=graph_safe_rng)
+                    for name, state in rng_tracker_states.items()
+                }
+            )
 
 
 def setup(
@@ -412,7 +444,11 @@ def setup(
             scheduler=scheduler,
             user_state=callback_manager.user_state,
         )
-        callback_manager.fire("on_data_init_start", context)
+        if should_load_checkpoint and cfg.checkpoint.load_rng and not cfg.checkpoint.finetune:
+            with _preserve_rng_state():
+                callback_manager.fire("on_data_init_start", context)
+        else:
+            callback_manager.fire("on_data_init_start", context)
 
     # Data stuff.
     timers("train/valid/test-data-iterators-setup", log_level=0).start(barrier=True)

--- a/tests/unit_tests/training/test_setup.py
+++ b/tests/unit_tests/training/test_setup.py
@@ -17,11 +17,14 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
+import torch
 
+import megatron.bridge.training.setup as training_setup
 from megatron.bridge.data.builders import GPTSFTDatasetConfig
 from megatron.bridge.models.gpt.gpt_builder import GPTModelConfig
 from megatron.bridge.models.gpt_provider import GPTModelProvider
 from megatron.bridge.models.transformer_config import TransformerConfig
+from megatron.bridge.training.callbacks import CallbackManager
 from megatron.bridge.training.checkpointing import load_checkpoint
 from megatron.bridge.training.setup import (
     _bind_dataset_provider_context,
@@ -88,6 +91,113 @@ def test_gpt_sft_config_receives_tokenizer_through_builder_binding_without_mutat
 
     assert received == [([1, 0, 0], config, tokenizer)]
     assert not hasattr(config, "tokenizer")
+
+
+def test_data_init_warmup_preserves_checkpoint_restored_rng_state():
+    """A disposable warmup must not change the first real resumed step's RNG state."""
+    cfg = SimpleNamespace(
+        _checkpoint_load_required=False,
+        checkpoint=SimpleNamespace(
+            finetune=False,
+            load="/checkpoint",
+            load_optim=True,
+            load_rng=True,
+            pretrained_checkpoint=None,
+            save=None,
+        ),
+        dataset=SimpleNamespace(),
+        ddp=SimpleNamespace(),
+        dist=SimpleNamespace(
+            align_grad_reduce=True,
+            disable_jit_fuser=False,
+            enable_megatron_core_experimental=False,
+            use_decentralized_pg=False,
+            use_gloo_process_groups=False,
+            use_torch_fsdp2=False,
+        ),
+        ft=None,
+        logger=SimpleNamespace(
+            filter_warnings=False,
+            log_progress=False,
+            logging_level="INFO",
+            modules_to_filter=[],
+            set_level_for_all_loggers=False,
+        ),
+        model=SimpleNamespace(
+            fine_grained_activation_offloading=False,
+            restore_modelopt_state=False,
+            should_pad_vocab=False,
+            vocab_size=32,
+        ),
+        optimizer=SimpleNamespace(overlap_param_gather_with_optimizer_step=False),
+        optimizer_config_override_provider=None,
+        peft=None,
+        profiling=SimpleNamespace(),
+        rng=SimpleNamespace(data_parallel_random_init=False),
+        scheduler=SimpleNamespace(),
+        tensor_inspect=SimpleNamespace(),
+        tokenizer=SimpleNamespace(use_tokenizer_vocab_size=False),
+        train=SimpleNamespace(micro_batch_size=1, num_epochs=None),
+    )
+    timer = MagicMock()
+    state = SimpleNamespace(
+        _eval_pgs=None,
+        cfg=cfg,
+        comet_logger=None,
+        initialize_async_checkpoint_worker=Mock(),
+        start_time=0.0,
+        tensorboard_logger=None,
+        timers=Mock(return_value=timer),
+        train_state=SimpleNamespace(step=1),
+        wandb_logger=None,
+    )
+    pg_collection = SimpleNamespace(dp=object())
+    checkpoint_manager = MagicMock(checkpointing_context={})
+    model = [MagicMock()]
+    optimizer = MagicMock()
+    scheduler = MagicMock()
+
+    torch.manual_seed(1234)
+    restored_rng_state = torch.get_rng_state().clone()
+    torch.manual_seed(4321)
+    checkpoint_manager.load.side_effect = lambda _ctx: torch.set_rng_state(restored_rng_state)
+
+    callback_manager = CallbackManager()
+    callback_manager.register("on_data_init_start", lambda _ctx: torch.rand(4))
+
+    start_time_tensor = Mock()
+    start_time_tensor.item.return_value = 0.0
+    with (
+        patch.multiple(
+            training_setup,
+            _build_distributed_model=Mock(return_value=model),
+            _should_load_checkpoint=Mock(return_value=True),
+            _update_model_config_funcs=Mock(),
+            _validate_and_set_vocab_size=Mock(return_value=(32, False)),
+            barrier_and_log=Mock(),
+            build_tokenizer=Mock(return_value=SimpleNamespace(vocab_size=32)),
+            create_checkpoint_manager=Mock(return_value=checkpoint_manager),
+            finalize_tensor_inspect_post_model_initialization=Mock(),
+            initialize_megatron=Mock(return_value=pg_collection),
+            initialize_tensor_inspect_pre_model_initialization=Mock(),
+            maybe_load_dataloader_state=Mock(),
+            maybe_log_and_save_config=Mock(),
+            memory_efficient_fp32_optimizer_state_loading=Mock(return_value=MagicMock()),
+            print_rank_0=Mock(),
+            set_experimental_flag=Mock(),
+            set_jit_fusion_options=Mock(),
+            setup_data_iterators=Mock(return_value=(None, None, None)),
+            setup_logging=Mock(),
+            setup_optimizer=Mock(return_value=(optimizer, scheduler)),
+            start_memory_history_recording=Mock(),
+            sync_hybrid_device_optimizer_fp32_master_copies=Mock(),
+        ),
+        patch.object(torch, "tensor", return_value=start_time_tensor),
+        patch.object(torch.distributed, "all_reduce"),
+    ):
+        training_setup.setup(state, Mock(), callback_manager=callback_manager)
+
+    assert torch.equal(torch.get_rng_state(), restored_rng_state)
 
 
 class TestShouldLoadCheckpoint:


### PR DESCRIPTION
## What changed

Resume now preserves checkpoint-restored random-number-generator state while
`on_data_init_start` callbacks perform the documented mock-data JIT warmup.

## User impact

When a run resumed with `load_rng=True`, a stochastic warmup callback could
consume the restored Python, NumPy, Torch, CUDA, or Megatron RNG streams before
the first real training step. Dropout masks and subsequent updates then diverged
from the checkpoint continuation point.

Checkpoint loading restores RNG state before firing `on_data_init_start`, but
the callback previously ran without a temporary snapshot. This change preserves
those streams only around the callback for non-finetune checkpoint loads with
RNG restoration enabled. Fresh runs and `load_rng=False` keep their existing
semantics.

## Validation

- Fail before:
  `uv run --no-sync python -m pytest tests/unit_tests/training/test_setup.py::test_data_init_warmup_preserves_checkpoint_restored_rng_state -q`
  — 1 failed at the checkpoint-restored Torch RNG invariant.
- Pass after: the same command — 1 passed.
- Adjacent:
  `uv run --no-sync python -m pytest tests/unit_tests/training/test_setup.py tests/unit_tests/training/test_callbacks.py -q`
  — 65 passed.
- `git diff --check` — passed.
- `uv run --no-project --with 'pre-commit==3.5.0' pre-commit run --all-files`
  — all hooks passed.

Scope is limited to callback RNG isolation during resume. No full-suite,
distributed-training, convergence, or performance validation was run.
