### PR TITLE
[ckpt] fix: Honor explicit checkpoint step over recovery

### DIFF
--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -3570,16 +3570,17 @@ def _load_base_checkpoint(
     # Try to load non-persistent checkpoint first
     non_persistent_global_dir = ""
     non_persistent_iteration = -1
-    if ckpt_cfg.non_persistent_ckpt_type == "global":
-        for candidate_dir in _get_global_non_persistent_checkpoint_dirs(load_dir, ckpt_cfg):
-            candidate_iteration = _get_non_persistent_iteration(candidate_dir, "global", checkpointing_context)
-            if candidate_iteration > non_persistent_iteration:
-                non_persistent_global_dir = candidate_dir
-                non_persistent_iteration = candidate_iteration
-    else:
-        non_persistent_iteration = _get_non_persistent_iteration(
-            non_persistent_global_dir, ckpt_cfg.non_persistent_ckpt_type, checkpointing_context
-        )
+    if ignore_ckpt_step or ckpt_cfg.ckpt_step is None:
+        if ckpt_cfg.non_persistent_ckpt_type == "global":
+            for candidate_dir in _get_global_non_persistent_checkpoint_dirs(load_dir, ckpt_cfg):
+                candidate_iteration = _get_non_persistent_iteration(candidate_dir, "global", checkpointing_context)
+                if candidate_iteration > non_persistent_iteration:
+                    non_persistent_global_dir = candidate_dir
+                    non_persistent_iteration = candidate_iteration
+        else:
+            non_persistent_iteration = _get_non_persistent_iteration(
+                non_persistent_global_dir, ckpt_cfg.non_persistent_ckpt_type, checkpointing_context
+            )
 
     tracker_filename = "because load directory is not defined"
     if load_dir is not None:

--- a/tests/unit_tests/training/test_checkpointing.py
+++ b/tests/unit_tests/training/test_checkpointing.py
@@ -2091,6 +2091,56 @@ class TestLoadBaseCheckpoint:
         assert checkpointing_context["dataloader_state_dir"] == str(save_dir / DATALOADER_STATE_SUBDIR)
         mock_load_persistent.assert_not_called()
 
+    @patch("megatron.bridge.training.checkpointing._load_global_dist_base_checkpoint")
+    @patch("megatron.bridge.training.checkpointing._get_checkpoint_format", return_value="torch_dist")
+    @patch("megatron.bridge.training.checkpointing._load_non_persistent_base_checkpoint")
+    @patch("megatron.bridge.training.checkpointing._resolve_checkpoint_iteration", return_value=(100, False))
+    def test_ckpt_step_overrides_newer_non_persistent_checkpoint(
+        self,
+        mock_resolve,
+        mock_load_non_persistent,
+        _mock_get_format,
+        mock_load_persistent,
+        tmp_path,
+        base_config,
+        mock_pg_collection,
+    ):
+        """An explicit checkpoint step selects that persistent iteration exactly."""
+        load_dir = tmp_path / "input"
+        non_persistent_dir = tmp_path / "recovery"
+        non_persistent_dir.mkdir(parents=True)
+        torch.save(
+            TrainState(step=200).state_dict(),
+            get_checkpoint_train_state_filename(str(non_persistent_dir), prefix="latest"),
+        )
+
+        base_config.ckpt_step = 100
+        base_config.save = str(tmp_path / "output")
+        base_config.ckpt_format = "torch_dist"
+        base_config.non_persistent_ckpt_type = "global"
+        base_config.non_persistent_global_ckpt_dir = str(non_persistent_dir)
+        mock_load_non_persistent.return_value = (
+            {"model": "recovery"},
+            str(non_persistent_dir / "iter_0000200"),
+            False,
+            CheckpointType.GLOBAL,
+        )
+        expected = ({"model": "requested"}, str(load_dir / "iter_0000100"), False, CheckpointType.GLOBAL)
+        mock_load_persistent.return_value = expected
+
+        checkpointing_context = {}
+        result = _load_base_checkpoint(
+            str(load_dir),
+            base_config,
+            checkpointing_context=checkpointing_context,
+            pg_collection=mock_pg_collection,
+        )
+
+        assert result == expected
+        mock_resolve.assert_called_once_with(load_dir=str(load_dir), ckpt_step_override=100)
+        mock_load_non_persistent.assert_not_called()
+        assert checkpointing_context["dataloader_state_dir"] == str(load_dir / DATALOADER_STATE_SUBDIR)
+
     @patch("megatron.bridge.training.checkpointing._load_non_persistent_base_checkpoint")
     @patch("megatron.bridge.training.checkpointing._resolve_checkpoint_iteration", return_value=(50, False))
     def test_newer_global_non_persistent_checkpoint_under_load_remains_available(


### PR DESCRIPTION
## What does this PR do?

Honor an explicitly configured `checkpoint.ckpt_step` when a newer non-persistent recovery checkpoint is also available.

## User impact and root cause

`ckpt_step` is the supported way to load a specific persistent checkpoint iteration, for example for rollback, evaluation, or reproducibility. `_resolve_checkpoint_iteration()` correctly resolved the requested persistent iteration, but `_load_base_checkpoint()` subsequently compared it with non-persistent recovery checkpoints and silently loaded a newer recovery checkpoint instead. Because both checkpoint loading passes made the same substitution, the model and training state could consistently come from the unintended iteration without an error.

The fix skips non-persistent checkpoint arbitration while an explicit `ckpt_step` is active. Normal latest-checkpoint recovery remains unchanged when `ckpt_step` is unset, and call sites that intentionally pass `ignore_ckpt_step=True` retain their existing behavior.

## Verification

The focused regression uses distinct persistent and recovery sentinels with requested step 100 and recovery step 200.

Before the fix:

```text
uv run --no-sync python -m pytest tests/unit_tests/training/test_checkpointing.py::TestLoadBaseCheckpoint::test_ckpt_step_overrides_newer_non_persistent_checkpoint -q --tb=short
1 failed (returned the recovery sentinel instead of the requested persistent sentinel)
```

After the fix:

```text
uv run --no-sync python -m pytest tests/unit_tests/training/test_checkpointing.py::TestLoadBaseCheckpoint::test_ckpt_step_overrides_newer_non_persistent_checkpoint -q --tb=short
1 passed
```

Adjacent checkpoint coverage, including the unaffected case where a newer recovery checkpoint wins when no explicit step is configured:

```text
uv run --no-sync python -m pytest tests/unit_tests/training/test_checkpointing.py::TestLoadBaseCheckpoint tests/unit_tests/training/test_checkpointing.py::TestCheckpointIterationResolution tests/unit_tests/training/test_checkpointing.py::TestLoadCheckpointFromPathDirectIterDir tests/unit_tests/training/test_checkpointing.py::TestMaybeLoadDataloaderState -q --tb=short
37 passed
```

Quality checks:

```text
git diff --check
uv run --no-sync pre-commit run --all-files
```

Both passed.

## Scope

This changes only checkpoint source selection and adds a focused unit regression. It does not change public APIs, dependencies, CI workflows, or Megatron-Core. No full-suite, distributed/GPU, model-quality, convergence, or performance validation is claimed.
