### PR TITLE
add nemotron puzzle support

### DIFF
--- a/src/megatron/bridge/models/__init__.py
+++ b/src/megatron/bridge/models/__init__.py
@@ -146,6 +146,9 @@ from megatron.bridge.models.nemotron_vl import (
 from megatron.bridge.models.nemotronh import (
     NemotronHBridge,
 )
+from megatron.bridge.models.nemotronh_puzzle import (
+    NemotronHPuzzleBridge,
+)
 from megatron.bridge.models.olmoe import (
     OlMoEBridge,
     OlMoEModelProvider,
@@ -260,6 +263,7 @@ __all__ = [
     "OlMoEBridge",
     "OlMoEModelProvider",
     "NemotronHBridge",
+    "NemotronHPuzzleBridge",
     "MambaModelProvider",
     "MimoBridge",
     # MiMo-V2-Flash

--- a/src/megatron/bridge/models/conversion/utils.py
+++ b/src/megatron/bridge/models/conversion/utils.py
@@ -46,13 +46,26 @@ def unwrap_model(model, module_instances=None):
     if module_instances is None:
         from megatron.core.distributed import DistributedDataParallel as DDP
         from megatron.core.distributed import TorchFullyShardedDataParallel as torch_FSDP
-        from megatron.core.distributed.fsdp.mcore_fsdp_adapter import (
-            FullyShardedDataParallel as megatron_FSDP,
-        )
         from megatron.core.distributed.fsdp.src.megatron_fsdp.megatron_fsdp import MegatronFSDP
         from megatron.core.transformer.module import Float16Module
 
-        module_instances = (DDP, torch_FSDP, megatron_FSDP, Float16Module, MegatronFSDP)
+        # `mcore_fsdp_adapter.FullyShardedDataParallel` is a V1/V2 factory function on
+        # newer mcore (PR #5865) and a class on older mcore — accept both shapes by
+        # preferring the concrete V1/V2 classes and falling back to the symbol itself
+        # if the split hasn't landed yet.
+        try:
+            from megatron.core.distributed.fsdp.mcore_fsdp_adapter import (
+                FullyShardedDataParallelV1,
+                FullyShardedDataParallelV2,
+            )
+            megatron_FSDP: tuple = (FullyShardedDataParallelV1, FullyShardedDataParallelV2)
+        except ImportError:
+            from megatron.core.distributed.fsdp.mcore_fsdp_adapter import (
+                FullyShardedDataParallel as _mfsdp_symbol,
+            )
+            megatron_FSDP = (_mfsdp_symbol,)
+
+        module_instances = (DDP, torch_FSDP, *megatron_FSDP, Float16Module, MegatronFSDP)
 
     return_list = True
     if not isinstance(model, list):

--- a/src/megatron/bridge/models/nemotronh/nemotron_h_bridge.py
+++ b/src/megatron/bridge/models/nemotronh/nemotron_h_bridge.py
@@ -267,8 +267,32 @@ class NemotronHBridge(MegatronModelBridge):
         ("moe_shared_expert_intermediate_size", "moe_shared_expert_intermediate_size"),
     ]
 
+    # HF top-level prefix used for the transformer backbone. Vanilla NemotronH
+    # weights live under `backbone.*`; the NemotronHPuzzle checkpoints instead
+    # use `model.*`. Subclasses override this to reuse the shared mapping list.
+    HF_PREFIX = "backbone"
+
     # Additional files to copy during HF export (reasoning parser utilities)
     ADDITIONAL_FILE_PATTERNS = ["*reasoning_parser.py"]
+
+    def _apply_hf_prefix(self, mapping_list: list) -> list:
+        """Rewrite `backbone.` in each mapping's HF pattern to `self.HF_PREFIX + "."`.
+
+        No-op when HF_PREFIX == "backbone". Handles both string `hf_param` (most
+        mappings) and dict `hf_param` (QKVMapping). MTP mappings that store
+        `hf_param` as a dict of q/k/v keys are also covered.
+        """
+        if self.HF_PREFIX == "backbone":
+            return mapping_list
+        old = "backbone."
+        new = f"{self.HF_PREFIX}."
+        for m in mapping_list:
+            hf = getattr(m, "hf_param", None)
+            if isinstance(hf, str):
+                m.hf_param = hf.replace(old, new)
+            elif isinstance(hf, dict):
+                m.hf_param = {k: v.replace(old, new) if isinstance(v, str) else v for k, v in hf.items()}
+        return mapping_list
 
     @staticmethod
     def _hf_mtp_config(hf_config) -> tuple[int, Optional[str]]:
@@ -573,4 +597,4 @@ class NemotronHBridge(MegatronModelBridge):
                 ]
             )
 
-        return MegatronMappingRegistry(*mapping_list)
+        return MegatronMappingRegistry(*self._apply_hf_prefix(mapping_list))

--- a/src/megatron/bridge/models/nemotronh_puzzle/__init__.py
+++ b/src/megatron/bridge/models/nemotronh_puzzle/__init__.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from megatron.bridge.models.nemotronh_puzzle.nemotron_h_puzzle_bridge import (
+    NemotronHPuzzleBridge,
+)
+
+
+__all__ = [
+    "NemotronHPuzzleBridge",
+]

--- a/src/megatron/bridge/models/nemotronh_puzzle/nemotron_h_puzzle_bridge.py
+++ b/src/megatron/bridge/models/nemotronh_puzzle/nemotron_h_puzzle_bridge.py
@@ -17,15 +17,23 @@
 The Puzzle architecture (e.g. `NVIDIA-Nemotron-Labs-3-Puzzle-75B-A9B-BF16`) is a
 NemotronH hybrid backbone (mamba / attention / MoE blocks) where the MoE layers
 have a *different* `moe_intermediate_size` and `num_experts_per_tok` on almost
-every layer, expressed in HF config as a `block_configs: list[dict]` sequence.
-This bridge is thin: it inherits mapping infra + config translation from
-`NemotronHBridge`, only swaps the HF top-level prefix (`model.*` instead of
-`backbone.*`) and populates `moe_ffn_hidden_size_per_layer` /
-`moe_router_topk_per_layer` on the Megatron provider so
-`heterogeneous_block_specs` routing kicks in inside `hybrid_block.py`.
+every layer, expressed in HF config as `block_configs: list[dict]` (main block)
+and `mtp_block_configs: list[dict]` (positions inside one MTP depth).
+
+Both sides map 1:1 to Megatron-Core's sparse per-layer override interface:
+
+- `block_configs`      -> `per_layer_config_overrides`      (length = num_layers)
+- `mtp_block_configs`  -> `mtp_per_layer_config_overrides`  (length = mtp_pattern_length)
+
+Non-MoE positions get a `None` entry (no override — the global provider values
+apply). MoE positions carry the varying keys only (`moe_ffn_hidden_size`,
+`moe_router_topk`); the globally-constant `num_moe_experts` and
+`moe_shared_expert_intermediate_size` stay on the provider itself.
 """
 
 from __future__ import annotations
+
+from typing import Any
 
 from megatron.core.models.hybrid.hybrid_model import HybridModel
 
@@ -57,6 +65,25 @@ def _block_attr(b, name: str):
     if hasattr(b, name):
         return getattr(b, name)
     return b.get(name) if isinstance(b, dict) else None
+
+
+def _block_to_override(b) -> dict[str, Any] | None:
+    """Return the sparse override dict for one HF block config entry, or None.
+
+    Only MoE entries carry per-position overrides in Puzzle configs. Non-MoE
+    positions inherit the global provider config, which the resolver returns
+    verbatim when the override is `None`.
+    """
+    if _block_type(b) != "moe":
+        return None
+    moe_int = _block_attr(b, "moe_intermediate_size")
+    topk = _block_attr(b, "num_experts_per_tok")
+    if moe_int is None or topk is None:
+        raise ValueError(f"MoE block config missing required keys: {b!r}")
+    return {
+        "moe_ffn_hidden_size": int(moe_int),
+        "moe_router_topk": int(topk),
+    }
 
 
 @MegatronModelBridge.register_bridge(
@@ -109,40 +136,30 @@ class NemotronHPuzzleBridge(NemotronHBridge):
         num_layers = len(block_configs)
         main_pattern = _blocks_to_pattern(block_configs)
 
-        # MTP: mtp_block_configs is the per-sub-layer breakdown of a single MTP
-        # depth. For Puzzle this is [attention, moe]. We forward the sub-pattern
-        # via mtp_hybrid_override_pattern so HybridModelProvider.finalize()
-        # concatenates it into the unified hybrid_layer_pattern.
         mtp_block_configs = list(getattr(hf_config, "mtp_block_configs", []) or [])
         mtp_pattern = _blocks_to_pattern(mtp_block_configs) if mtp_block_configs else None
 
-        # Puzzle keeps expert count and shared expert size globally constant,
-        # but we still populate the per-layer lists with -1 sentinels for the
-        # non-MoE positions so the hetero validation path is exercised.
         total_experts = int(hf_config.n_routed_experts)
         shared_size = int(getattr(hf_config, "moe_shared_expert_intermediate_size", 0) or 0)
 
-        moe_ffn_hidden_size_per_layer: list[int] = []
-        moe_router_topk_per_layer: list[int] = []
-        num_moe_experts_per_layer: list[int] = []
-        moe_shared_expert_intermediate_size_per_layer: list[int] = []
-        for b in block_configs:
-            if _block_type(b) == "moe":
-                moe_int = _block_attr(b, "moe_intermediate_size")
-                topk = _block_attr(b, "num_experts_per_tok")
-                if moe_int is None or topk is None:
-                    raise ValueError(
-                        f"MoE block config missing required keys: {b!r}"
-                    )
-                moe_ffn_hidden_size_per_layer.append(int(moe_int))
-                moe_router_topk_per_layer.append(int(topk))
-                num_moe_experts_per_layer.append(total_experts)
-                moe_shared_expert_intermediate_size_per_layer.append(shared_size or -1)
-            else:
-                moe_ffn_hidden_size_per_layer.append(-1)
-                moe_router_topk_per_layer.append(-1)
-                num_moe_experts_per_layer.append(-1)
-                moe_shared_expert_intermediate_size_per_layer.append(-1)
+        # Sparse main-block overrides: one entry per layer, either a dict of
+        # override keys or None. Length must equal num_layers — the mcore
+        # validator enforces this in TransformerConfig.__post_init__.
+        per_layer_config_overrides: list[dict[str, Any] | None] = [
+            _block_to_override(b) for b in block_configs
+        ]
+
+        # Sparse MTP per-position overrides: one entry per position inside one
+        # MTP depth. All MTP depths share these — see `mtp_pattern_length` on
+        # TransformerConfig for the axis definition. Length must equal
+        # mtp_pattern_length.
+        mtp_per_layer_config_overrides: list[dict[str, Any] | None] | None = None
+        mtp_pattern_length: int | None = None
+        if mtp_block_configs:
+            mtp_pattern_length = len(mtp_block_configs)
+            mtp_per_layer_config_overrides = [
+                _block_to_override(b) for b in mtp_block_configs
+            ]
 
         # Overwrite scalar hybrid pattern derived by the parent from
         # hybrid_override_pattern (which Puzzle configs don't set) with the one
@@ -156,82 +173,51 @@ class NemotronHPuzzleBridge(NemotronHBridge):
         if shared_size:
             provider.moe_shared_expert_intermediate_size = shared_size
 
-        provider.moe_ffn_hidden_size_per_layer = moe_ffn_hidden_size_per_layer
-        provider.moe_router_topk_per_layer = moe_router_topk_per_layer
-        provider.num_moe_experts_per_layer = num_moe_experts_per_layer
-        provider.moe_shared_expert_intermediate_size_per_layer = (
-            moe_shared_expert_intermediate_size_per_layer
-        )
+        provider.per_layer_config_overrides = per_layer_config_overrides
+        provider.mtp_per_layer_config_overrides = mtp_per_layer_config_overrides
+        provider.mtp_pattern_length = mtp_pattern_length
 
-        # MTP HybridStack cannot use the main-block per-layer lists (its layer
-        # numbers restart at 1 with pp_layer_offset=0). Instead, populate the
-        # global scalar moe_ffn_hidden_size / moe_router_topk with the MTP MoE
-        # values so MTP falls through to those scalars via the guard in
-        # hybrid_block.py.
-        if mtp_block_configs:
-            mtp_moe = next(
-                (b for b in mtp_block_configs if _block_type(b) == "moe"), None
-            )
-            if mtp_moe is not None:
-                mtp_moe_int = _block_attr(mtp_moe, "moe_intermediate_size")
-                mtp_topk = _block_attr(mtp_moe, "num_experts_per_tok")
-                if mtp_moe_int is not None:
-                    provider.moe_ffn_hidden_size = int(mtp_moe_int)
-                if mtp_topk is not None:
-                    provider.moe_router_topk = int(mtp_topk)
-
+        # Validator flips this on when either override list is set, but
+        # __post_init__ has already run on the parent's provider — set it here
+        # explicitly so downstream builders route through get_config_for_layer /
+        # get_config_for_mtp_layer.
         provider.heterogeneous_block_specs = True
         return provider
 
     @classmethod
     def megatron_to_hf_config(cls, provider) -> dict:
-        """Emit HF-side `block_configs` and `mtp_block_configs` from per-layer lists."""
+        """Emit HF-side `block_configs` and `mtp_block_configs` from sparse per-layer overrides."""
         hf_cfg = super().megatron_to_hf_config(provider)
 
-        # Rebuild block_configs from per-layer lists + hybrid pattern.
+        # Rebuild block_configs from the main hybrid pattern + sparse overrides.
         pattern = hf_cfg.pop("hybrid_override_pattern", None)
         if pattern is None:
             # NemotronHBridge.megatron_to_hf_config normally returns a cleaned
             # pattern; if it's missing we can't rebuild block_configs.
             return hf_cfg
 
-        # `pattern` is already the main decoder pattern (no MTP suffix). Convert
-        # symbols back to block types.
         symbol_to_type = {v: k for k, v in _BLOCK_TYPE_TO_SYMBOL.items()}
         main_types = [symbol_to_type[s] for s in pattern if s in symbol_to_type]
 
-        moe_ffn_per_layer = provider.moe_ffn_hidden_size_per_layer or []
-        moe_topk_per_layer = provider.moe_router_topk_per_layer or []
-
-        block_configs: list[dict] = []
-        for i, t in enumerate(main_types):
-            entry: dict = {"block_type": t}
-            if t == "moe":
-                moe_int = moe_ffn_per_layer[i] if i < len(moe_ffn_per_layer) else -1
-                topk = moe_topk_per_layer[i] if i < len(moe_topk_per_layer) else -1
-                if moe_int != -1:
-                    entry["moe_intermediate_size"] = int(moe_int)
-                if topk != -1:
-                    entry["num_experts_per_tok"] = int(topk)
-            block_configs.append(entry)
-
+        per_layer_overrides = provider.per_layer_config_overrides or []
+        block_configs = [
+            _entry_from_override(t, per_layer_overrides[i] if i < len(per_layer_overrides) else None)
+            for i, t in enumerate(main_types)
+        ]
         hf_cfg["block_configs"] = block_configs
 
-        # MTP block: reconstruct from scalar moe_ffn_hidden_size / moe_router_topk.
+        # MTP block: reconstruct from sparse mtp_per_layer_config_overrides.
         mtp_pattern = hf_cfg.pop("mtp_hybrid_override_pattern", None)
         if mtp_pattern:
-            mtp_block_configs: list[dict] = []
-            for s in mtp_pattern:
-                if s not in symbol_to_type:
-                    continue
-                t = symbol_to_type[s]
-                entry = {"block_type": t}
-                if t == "moe":
-                    if provider.moe_ffn_hidden_size is not None:
-                        entry["moe_intermediate_size"] = int(provider.moe_ffn_hidden_size)
-                    if provider.moe_router_topk is not None:
-                        entry["num_experts_per_tok"] = int(provider.moe_router_topk)
-                mtp_block_configs.append(entry)
+            mtp_overrides = provider.mtp_per_layer_config_overrides or []
+            mtp_block_configs = [
+                _entry_from_override(
+                    symbol_to_type[s],
+                    mtp_overrides[i] if i < len(mtp_overrides) else None,
+                )
+                for i, s in enumerate(mtp_pattern)
+                if s in symbol_to_type
+            ]
             hf_cfg["mtp_block_configs"] = mtp_block_configs
 
         # Puzzle-specific auto_map overrides the vanilla NemotronH values set
@@ -253,3 +239,17 @@ class NemotronHPuzzleBridge(NemotronHBridge):
         if mtp_pattern:
             hf_cfg["mtp_layers_block_type"] = [entry["block_type"] for entry in hf_cfg["mtp_block_configs"]]
         return hf_cfg
+
+
+def _entry_from_override(block_type: str, override: dict[str, Any] | None) -> dict:
+    """Rebuild one HF block_configs entry from a Megatron per-layer override dict."""
+    entry: dict = {"block_type": block_type}
+    if block_type != "moe" or not override:
+        return entry
+    moe_int = override.get("moe_ffn_hidden_size")
+    topk = override.get("moe_router_topk")
+    if moe_int is not None:
+        entry["moe_intermediate_size"] = int(moe_int)
+    if topk is not None:
+        entry["num_experts_per_tok"] = int(topk)
+    return entry

--- a/src/megatron/bridge/models/nemotronh_puzzle/nemotron_h_puzzle_bridge.py
+++ b/src/megatron/bridge/models/nemotronh_puzzle/nemotron_h_puzzle_bridge.py
@@ -1,0 +1,255 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Bridge for NVIDIA Nemotron-H Puzzle heterogeneous MoE models.
+
+The Puzzle architecture (e.g. `NVIDIA-Nemotron-Labs-3-Puzzle-75B-A9B-BF16`) is a
+NemotronH hybrid backbone (mamba / attention / MoE blocks) where the MoE layers
+have a *different* `moe_intermediate_size` and `num_experts_per_tok` on almost
+every layer, expressed in HF config as a `block_configs: list[dict]` sequence.
+This bridge is thin: it inherits mapping infra + config translation from
+`NemotronHBridge`, only swaps the HF top-level prefix (`model.*` instead of
+`backbone.*`) and populates `moe_ffn_hidden_size_per_layer` /
+`moe_router_topk_per_layer` on the Megatron provider so
+`heterogeneous_block_specs` routing kicks in inside `hybrid_block.py`.
+"""
+
+from __future__ import annotations
+
+from megatron.core.models.hybrid.hybrid_model import HybridModel
+
+from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge
+from megatron.bridge.models.hf_pretrained.causal_lm import PreTrainedCausalLM
+from megatron.bridge.models.hybrid.hybrid_provider import HybridModelProvider
+from megatron.bridge.models.nemotronh.nemotron_h_bridge import NemotronHBridge
+
+
+# HF block_type -> hybrid layer pattern symbol used by Megatron HybridStack.
+_BLOCK_TYPE_TO_SYMBOL = {
+    "mamba": "M",
+    "attention": "*",
+    "moe": "E",
+    "mlp": "-",
+}
+
+
+def _blocks_to_pattern(blocks) -> str:
+    return "".join(_BLOCK_TYPE_TO_SYMBOL[_block_type(b)] for b in blocks)
+
+
+def _block_type(b) -> str:
+    """block_configs entries may arrive as dataclass instances or plain dicts."""
+    return getattr(b, "block_type", None) or b["block_type"]
+
+
+def _block_attr(b, name: str):
+    if hasattr(b, name):
+        return getattr(b, name)
+    return b.get(name) if isinstance(b, dict) else None
+
+
+@MegatronModelBridge.register_bridge(
+    source="NemotronHPuzzleForCausalLM",
+    target=HybridModel,
+    provider=HybridModelProvider,
+    model_type="nemotron_h_puzzle",
+)
+class NemotronHPuzzleBridge(NemotronHBridge):
+    """Bridge for NemotronH-Puzzle heterogeneous MoE hybrid models."""
+
+    # Puzzle checkpoints use `model.*` as the HF top-level prefix (vs `backbone.*`
+    # for vanilla NemotronH). See NemotronHBridge._apply_hf_prefix for how this
+    # rewrites the shared mapping registry.
+    HF_PREFIX = "model"
+
+    @staticmethod
+    def _hf_mtp_config(hf_config) -> tuple[int, "str | None"]:
+        """Puzzle's HF config expresses MTP via `mtp_block_configs`, not `mtp_hybrid_override_pattern`."""
+        mtp_num_layers = int(getattr(hf_config, "num_nextn_predict_layers", 0) or 0)
+        if mtp_num_layers < 0:
+            raise ValueError("num_nextn_predict_layers must be non-negative.")
+        if mtp_num_layers == 0:
+            return 0, None
+
+        blocks = list(getattr(hf_config, "mtp_block_configs", []) or [])
+        if not blocks:
+            # Fall back to the parent contract in case the config used the older
+            # `mtp_hybrid_override_pattern` key.
+            mtp_pattern = getattr(hf_config, "mtp_hybrid_override_pattern", None)
+            if not mtp_pattern:
+                raise ValueError(
+                    "NemotronHPuzzle HF config with num_nextn_predict_layers > 0 must set either "
+                    "`mtp_block_configs` (preferred) or `mtp_hybrid_override_pattern`."
+                )
+            return mtp_num_layers, mtp_pattern
+        return mtp_num_layers, _blocks_to_pattern(blocks)
+
+    def provider_bridge(self, hf_pretrained: PreTrainedCausalLM) -> HybridModelProvider:
+        provider = super().provider_bridge(hf_pretrained)
+        hf_config = hf_pretrained.config
+
+        block_configs = list(getattr(hf_config, "block_configs", []) or [])
+        if not block_configs:
+            raise ValueError(
+                "NemotronHPuzzle HF config is missing `block_configs`; cannot derive "
+                "per-layer heterogeneous MoE settings."
+            )
+
+        num_layers = len(block_configs)
+        main_pattern = _blocks_to_pattern(block_configs)
+
+        # MTP: mtp_block_configs is the per-sub-layer breakdown of a single MTP
+        # depth. For Puzzle this is [attention, moe]. We forward the sub-pattern
+        # via mtp_hybrid_override_pattern so HybridModelProvider.finalize()
+        # concatenates it into the unified hybrid_layer_pattern.
+        mtp_block_configs = list(getattr(hf_config, "mtp_block_configs", []) or [])
+        mtp_pattern = _blocks_to_pattern(mtp_block_configs) if mtp_block_configs else None
+
+        # Puzzle keeps expert count and shared expert size globally constant,
+        # but we still populate the per-layer lists with -1 sentinels for the
+        # non-MoE positions so the hetero validation path is exercised.
+        total_experts = int(hf_config.n_routed_experts)
+        shared_size = int(getattr(hf_config, "moe_shared_expert_intermediate_size", 0) or 0)
+
+        moe_ffn_hidden_size_per_layer: list[int] = []
+        moe_router_topk_per_layer: list[int] = []
+        num_moe_experts_per_layer: list[int] = []
+        moe_shared_expert_intermediate_size_per_layer: list[int] = []
+        for b in block_configs:
+            if _block_type(b) == "moe":
+                moe_int = _block_attr(b, "moe_intermediate_size")
+                topk = _block_attr(b, "num_experts_per_tok")
+                if moe_int is None or topk is None:
+                    raise ValueError(
+                        f"MoE block config missing required keys: {b!r}"
+                    )
+                moe_ffn_hidden_size_per_layer.append(int(moe_int))
+                moe_router_topk_per_layer.append(int(topk))
+                num_moe_experts_per_layer.append(total_experts)
+                moe_shared_expert_intermediate_size_per_layer.append(shared_size or -1)
+            else:
+                moe_ffn_hidden_size_per_layer.append(-1)
+                moe_router_topk_per_layer.append(-1)
+                num_moe_experts_per_layer.append(-1)
+                moe_shared_expert_intermediate_size_per_layer.append(-1)
+
+        # Overwrite scalar hybrid pattern derived by the parent from
+        # hybrid_override_pattern (which Puzzle configs don't set) with the one
+        # we just constructed from block_configs.
+        provider.hybrid_layer_pattern = main_pattern
+        provider.hybrid_override_pattern = None
+        provider.num_layers = num_layers
+        provider.mtp_hybrid_override_pattern = mtp_pattern
+
+        provider.num_moe_experts = total_experts
+        if shared_size:
+            provider.moe_shared_expert_intermediate_size = shared_size
+
+        provider.moe_ffn_hidden_size_per_layer = moe_ffn_hidden_size_per_layer
+        provider.moe_router_topk_per_layer = moe_router_topk_per_layer
+        provider.num_moe_experts_per_layer = num_moe_experts_per_layer
+        provider.moe_shared_expert_intermediate_size_per_layer = (
+            moe_shared_expert_intermediate_size_per_layer
+        )
+
+        # MTP HybridStack cannot use the main-block per-layer lists (its layer
+        # numbers restart at 1 with pp_layer_offset=0). Instead, populate the
+        # global scalar moe_ffn_hidden_size / moe_router_topk with the MTP MoE
+        # values so MTP falls through to those scalars via the guard in
+        # hybrid_block.py.
+        if mtp_block_configs:
+            mtp_moe = next(
+                (b for b in mtp_block_configs if _block_type(b) == "moe"), None
+            )
+            if mtp_moe is not None:
+                mtp_moe_int = _block_attr(mtp_moe, "moe_intermediate_size")
+                mtp_topk = _block_attr(mtp_moe, "num_experts_per_tok")
+                if mtp_moe_int is not None:
+                    provider.moe_ffn_hidden_size = int(mtp_moe_int)
+                if mtp_topk is not None:
+                    provider.moe_router_topk = int(mtp_topk)
+
+        provider.heterogeneous_block_specs = True
+        return provider
+
+    @classmethod
+    def megatron_to_hf_config(cls, provider) -> dict:
+        """Emit HF-side `block_configs` and `mtp_block_configs` from per-layer lists."""
+        hf_cfg = super().megatron_to_hf_config(provider)
+
+        # Rebuild block_configs from per-layer lists + hybrid pattern.
+        pattern = hf_cfg.pop("hybrid_override_pattern", None)
+        if pattern is None:
+            # NemotronHBridge.megatron_to_hf_config normally returns a cleaned
+            # pattern; if it's missing we can't rebuild block_configs.
+            return hf_cfg
+
+        # `pattern` is already the main decoder pattern (no MTP suffix). Convert
+        # symbols back to block types.
+        symbol_to_type = {v: k for k, v in _BLOCK_TYPE_TO_SYMBOL.items()}
+        main_types = [symbol_to_type[s] for s in pattern if s in symbol_to_type]
+
+        moe_ffn_per_layer = provider.moe_ffn_hidden_size_per_layer or []
+        moe_topk_per_layer = provider.moe_router_topk_per_layer or []
+
+        block_configs: list[dict] = []
+        for i, t in enumerate(main_types):
+            entry: dict = {"block_type": t}
+            if t == "moe":
+                moe_int = moe_ffn_per_layer[i] if i < len(moe_ffn_per_layer) else -1
+                topk = moe_topk_per_layer[i] if i < len(moe_topk_per_layer) else -1
+                if moe_int != -1:
+                    entry["moe_intermediate_size"] = int(moe_int)
+                if topk != -1:
+                    entry["num_experts_per_tok"] = int(topk)
+            block_configs.append(entry)
+
+        hf_cfg["block_configs"] = block_configs
+
+        # MTP block: reconstruct from scalar moe_ffn_hidden_size / moe_router_topk.
+        mtp_pattern = hf_cfg.pop("mtp_hybrid_override_pattern", None)
+        if mtp_pattern:
+            mtp_block_configs: list[dict] = []
+            for s in mtp_pattern:
+                if s not in symbol_to_type:
+                    continue
+                t = symbol_to_type[s]
+                entry = {"block_type": t}
+                if t == "moe":
+                    if provider.moe_ffn_hidden_size is not None:
+                        entry["moe_intermediate_size"] = int(provider.moe_ffn_hidden_size)
+                    if provider.moe_router_topk is not None:
+                        entry["num_experts_per_tok"] = int(provider.moe_router_topk)
+                mtp_block_configs.append(entry)
+            hf_cfg["mtp_block_configs"] = mtp_block_configs
+
+        # Puzzle-specific auto_map overrides the vanilla NemotronH values set
+        # by the parent.
+        hf_cfg["auto_map"] = {
+            "AutoConfig": "configuration_nemotron_h_puzzle.NemotronHPuzzleConfig",
+            "AutoModelForCausalLM": "modeling_nemotron_h_puzzle.NemotronHPuzzleForCausalLM",
+        }
+        hf_cfg["model_type"] = "nemotron_h_puzzle"
+        # In Puzzle, `moe_intermediate_size` and `num_experts_per_tok` are strictly
+        # blockwise members; NemotronHPuzzleConfig._delete_blockwise_members_from_global_config
+        # strips them from the top level. Drop them here so the emitted config
+        # round-trips through HF loading without stale globals.
+        for key in ("moe_intermediate_size", "num_experts_per_tok"):
+            hf_cfg.pop(key, None)
+        # layers_block_type is derived from block_configs by NemotronHPuzzleConfig,
+        # but emit it explicitly for readability / offline tooling.
+        hf_cfg["layers_block_type"] = [entry["block_type"] for entry in block_configs]
+        if mtp_pattern:
+            hf_cfg["mtp_layers_block_type"] = [entry["block_type"] for entry in hf_cfg["mtp_block_configs"]]
+        return hf_cfg

--- a/tests/unit_tests/models/nemotronh_puzzle/test_nemotron_h_puzzle_bridge.py
+++ b/tests/unit_tests/models/nemotronh_puzzle/test_nemotron_h_puzzle_bridge.py
@@ -1,0 +1,388 @@
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+import torch
+
+from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge
+from megatron.bridge.models.hf_pretrained.causal_lm import PreTrainedCausalLM
+from megatron.bridge.models.hybrid.hybrid_provider import HybridModelProvider
+from megatron.bridge.models.nemotronh.nemotron_h_bridge import NemotronHBridge
+from megatron.bridge.models.nemotronh_puzzle.nemotron_h_puzzle_bridge import (
+    NemotronHPuzzleBridge,
+    _block_to_override,
+    _blocks_to_pattern,
+)
+
+
+def _puzzle_hf_config_dict() -> dict:
+    # 4-layer toy puzzle backbone (mamba/moe/mamba/moe) with a 1-depth, 2-position
+    # MTP block (attention/moe). MoE varies per position — exactly what the sparse
+    # per_layer_config_overrides / mtp_per_layer_config_overrides are supposed to
+    # carry through provider_bridge and back through megatron_to_hf_config.
+    return {
+        "architectures": ["NemotronHPuzzleForCausalLM"],
+        "attention_bias": False,
+        "attention_dropout": 0.0,
+        "auto_map": {
+            "AutoConfig": "configuration_nemotron_h_puzzle.NemotronHPuzzleConfig",
+            "AutoModelForCausalLM": "modeling_nemotron_h_puzzle.NemotronHPuzzleForCausalLM",
+        },
+        "block_configs": [
+            {"block_type": "mamba"},
+            {"block_type": "moe", "moe_intermediate_size": 512, "num_experts_per_tok": 4},
+            {"block_type": "mamba"},
+            {"block_type": "moe", "moe_intermediate_size": 768, "num_experts_per_tok": 8},
+        ],
+        "bos_token_id": 1,
+        "chunk_size": 128,
+        "conv_kernel": 4,
+        "eos_token_id": 2,
+        "expand": 2,
+        "head_dim": 64,
+        "hidden_act": "relu2",
+        "hidden_dropout": 0.0,
+        "hidden_size": 256,
+        "initializer_range": 0.02,
+        "intermediate_size": 512,
+        "layer_norm_epsilon": 1e-5,
+        "mamba_head_dim": 32,
+        "mamba_hidden_act": "silu",
+        "mamba_num_heads": 8,
+        "mamba_proj_bias": False,
+        "max_position_embeddings": 8192,
+        "mlp_bias": False,
+        "mlp_hidden_act": "relu2",
+        "model_type": "nemotron_h_puzzle",
+        "moe_latent_size": 128,
+        "moe_shared_expert_intermediate_size": 1024,
+        "moe_shared_expert_overlap": True,
+        "mtp_block_configs": [
+            {"block_type": "attention"},
+            {"block_type": "moe", "moe_intermediate_size": 2688, "num_experts_per_tok": 22},
+        ],
+        "n_group": 1,
+        "n_groups": 4,
+        "n_routed_experts": 16,
+        "n_shared_experts": 1,
+        "norm_eps": 1e-5,
+        "num_attention_heads": 4,
+        "num_hidden_layers": 4,
+        "num_key_value_heads": 2,
+        "num_logits_to_keep": 1,
+        "num_nextn_predict_layers": 1,
+        "pad_token_id": 0,
+        "rescale_prenorm_residual": True,
+        "residual_in_fp32": False,
+        "rms_norm_eps": 1e-5,
+        "ssm_state_size": 64,
+        "tie_word_embeddings": False,
+        "torch_dtype": "bfloat16",
+        "use_bias": False,
+        "use_cache": True,
+        "use_conv_bias": True,
+        "use_mamba_kernels": True,
+        "vocab_size": 1024,
+    }
+
+
+class TestNemotronHPuzzleBridgeRegistration:
+    def test_bridge_is_subclass_of_nemotronh(self):
+        assert issubclass(NemotronHPuzzleBridge, NemotronHBridge)
+        assert issubclass(NemotronHPuzzleBridge, MegatronModelBridge)
+
+    def test_hf_prefix_is_model(self):
+        # Puzzle HF checkpoints put the backbone under `model.*`, not `backbone.*`.
+        assert NemotronHPuzzleBridge.HF_PREFIX == "model"
+
+
+class TestHfMtpConfig:
+    def test_from_block_configs(self):
+        cfg = Mock(spec=[])
+        cfg.num_nextn_predict_layers = 1
+        cfg.mtp_block_configs = [{"block_type": "attention"}, {"block_type": "moe"}]
+        num, pattern = NemotronHPuzzleBridge._hf_mtp_config(cfg)
+        assert num == 1
+        assert pattern == "*E"
+
+    def test_zero_layers_returns_none_pattern(self):
+        cfg = Mock(spec=[])
+        cfg.num_nextn_predict_layers = 0
+        cfg.mtp_block_configs = []
+        num, pattern = NemotronHPuzzleBridge._hf_mtp_config(cfg)
+        assert num == 0
+        assert pattern is None
+
+    def test_falls_back_to_hybrid_override_pattern(self):
+        cfg = Mock(spec=[])
+        cfg.num_nextn_predict_layers = 1
+        cfg.mtp_block_configs = []
+        cfg.mtp_hybrid_override_pattern = "*-"
+        num, pattern = NemotronHPuzzleBridge._hf_mtp_config(cfg)
+        assert num == 1
+        assert pattern == "*-"
+
+    def test_raises_when_positive_and_no_source(self):
+        cfg = Mock(spec=[])
+        cfg.num_nextn_predict_layers = 1
+        cfg.mtp_block_configs = []
+        cfg.mtp_hybrid_override_pattern = None
+        with pytest.raises(ValueError, match="mtp_block_configs"):
+            NemotronHPuzzleBridge._hf_mtp_config(cfg)
+
+    def test_raises_when_negative(self):
+        cfg = Mock(spec=[])
+        cfg.num_nextn_predict_layers = -1
+        with pytest.raises(ValueError, match="non-negative"):
+            NemotronHPuzzleBridge._hf_mtp_config(cfg)
+
+
+class TestProviderBridge:
+    @pytest.fixture
+    def hf_config_dict(self):
+        return _puzzle_hf_config_dict()
+
+    @pytest.fixture
+    def mock_hf_config(self, hf_config_dict):
+        # Mock(spec=[]) so undefined attrs raise AttributeError — getattr(..., default)
+        # then correctly returns the default. Without spec=[], Mock returns Mock objects
+        # for arbitrary attrs, which would incorrectly slip into provider fields.
+        cfg = Mock(spec=[])
+        for k, v in hf_config_dict.items():
+            setattr(cfg, k, v)
+        return cfg
+
+    @pytest.fixture
+    def mock_pretrained(self, mock_hf_config):
+        m = Mock(spec=PreTrainedCausalLM)
+        m.config = mock_hf_config
+        return m
+
+    def test_returns_hybrid_provider(self, mock_pretrained):
+        provider = NemotronHPuzzleBridge().provider_bridge(mock_pretrained)
+        assert isinstance(provider, HybridModelProvider)
+
+    def test_sets_hybrid_layer_pattern_from_block_configs(self, mock_pretrained):
+        provider = NemotronHPuzzleBridge().provider_bridge(mock_pretrained)
+        assert provider.hybrid_layer_pattern == "MEME"
+        assert provider.hybrid_override_pattern is None
+        assert provider.num_layers == 4
+
+    def test_sets_mtp_pattern_from_mtp_block_configs(self, mock_pretrained):
+        provider = NemotronHPuzzleBridge().provider_bridge(mock_pretrained)
+        assert provider.mtp_hybrid_override_pattern == "*E"
+        assert provider.mtp_num_layers == 1
+        assert provider.mtp_pattern_length == 2
+
+    def test_sparse_per_layer_config_overrides(self, mock_pretrained):
+        # Non-MoE positions -> None; MoE positions -> only the varying keys.
+        provider = NemotronHPuzzleBridge().provider_bridge(mock_pretrained)
+        assert provider.per_layer_config_overrides == [
+            None,
+            {"moe_ffn_hidden_size": 512, "moe_router_topk": 4},
+            None,
+            {"moe_ffn_hidden_size": 768, "moe_router_topk": 8},
+        ]
+
+    def test_sparse_mtp_per_layer_config_overrides(self, mock_pretrained):
+        provider = NemotronHPuzzleBridge().provider_bridge(mock_pretrained)
+        assert provider.mtp_per_layer_config_overrides == [
+            None,
+            {"moe_ffn_hidden_size": 2688, "moe_router_topk": 22},
+        ]
+
+    def test_sets_heterogeneous_block_specs_flag(self, mock_pretrained):
+        # __post_init__ ran on the provider before per_layer_config_overrides was
+        # set, so the validator didn't flip the flag — the bridge must do it.
+        provider = NemotronHPuzzleBridge().provider_bridge(mock_pretrained)
+        assert provider.heterogeneous_block_specs is True
+
+    def test_sets_global_moe_fields(self, mock_pretrained):
+        # Puzzle keeps num_moe_experts and moe_shared_expert_intermediate_size
+        # constant across MoE layers — they stay on the provider, not the
+        # per-layer overrides.
+        provider = NemotronHPuzzleBridge().provider_bridge(mock_pretrained)
+        assert provider.num_moe_experts == 16
+        assert provider.moe_shared_expert_intermediate_size == 1024
+
+    def test_raises_on_missing_block_configs(self, mock_pretrained):
+        mock_pretrained.config.block_configs = []
+        with pytest.raises(ValueError, match="block_configs"):
+            NemotronHPuzzleBridge().provider_bridge(mock_pretrained)
+
+    def test_raises_on_incomplete_moe_block(self, mock_pretrained):
+        mock_pretrained.config.block_configs = [
+            {"block_type": "mamba"},
+            {"block_type": "moe"},  # missing moe_intermediate_size + num_experts_per_tok
+        ]
+        with pytest.raises(ValueError, match="missing required keys"):
+            NemotronHPuzzleBridge().provider_bridge(mock_pretrained)
+
+    def test_no_mtp_when_num_nextn_predict_layers_zero(self, mock_pretrained):
+        mock_pretrained.config.num_nextn_predict_layers = 0
+        mock_pretrained.config.mtp_block_configs = []
+        provider = NemotronHPuzzleBridge().provider_bridge(mock_pretrained)
+        assert provider.mtp_hybrid_override_pattern is None
+        assert provider.mtp_per_layer_config_overrides is None
+        assert provider.mtp_pattern_length is None
+        assert provider.mtp_num_layers == 0
+
+    def test_dtype_bfloat16(self, mock_pretrained):
+        # Sanity: parent MegatronModelBridge honors torch_dtype from the HF config.
+        provider = NemotronHPuzzleBridge().provider_bridge(mock_pretrained)
+        assert provider.params_dtype == torch.bfloat16
+        assert provider.bf16 is True
+        assert provider.fp16 is False
+
+
+class TestMegatronToHfConfig:
+    """Reverse conversion: sparse overrides -> HF block_configs / mtp_block_configs."""
+
+    @staticmethod
+    def _stub_parent_hf_cfg(**overrides) -> dict:
+        # Emulate what NemotronHBridge.megatron_to_hf_config returns before the
+        # Puzzle child rewrites block_configs and swaps the auto_map. Keys the
+        # child pops or rewrites are all here so behavior is exercised.
+        base = {
+            "hybrid_override_pattern": "MEME",
+            "mtp_hybrid_override_pattern": "*E",
+            "moe_intermediate_size": 999,
+            "num_experts_per_tok": 99,
+            "auto_map": {"AutoConfig": "configuration_nemotron_h.NemotronHConfig"},
+            "model_type": "nemotron_h",
+        }
+        base.update(overrides)
+        return base
+
+    def test_rebuilds_block_configs_from_sparse_overrides(self):
+        provider = SimpleNamespace(
+            per_layer_config_overrides=[
+                None,
+                {"moe_ffn_hidden_size": 512, "moe_router_topk": 4},
+                None,
+                {"moe_ffn_hidden_size": 768, "moe_router_topk": 8},
+            ],
+            mtp_per_layer_config_overrides=None,
+        )
+        with patch.object(
+            NemotronHBridge, "megatron_to_hf_config", return_value=self._stub_parent_hf_cfg()
+        ):
+            hf_cfg = NemotronHPuzzleBridge.megatron_to_hf_config(provider)
+
+        assert hf_cfg["block_configs"] == [
+            {"block_type": "mamba"},
+            {"block_type": "moe", "moe_intermediate_size": 512, "num_experts_per_tok": 4},
+            {"block_type": "mamba"},
+            {"block_type": "moe", "moe_intermediate_size": 768, "num_experts_per_tok": 8},
+        ]
+
+    def test_rebuilds_mtp_block_configs_from_sparse_overrides(self):
+        provider = SimpleNamespace(
+            per_layer_config_overrides=[None, {"moe_ffn_hidden_size": 512, "moe_router_topk": 4}],
+            mtp_per_layer_config_overrides=[
+                None,
+                {"moe_ffn_hidden_size": 2688, "moe_router_topk": 22},
+            ],
+        )
+        parent = self._stub_parent_hf_cfg(hybrid_override_pattern="ME")
+        with patch.object(NemotronHBridge, "megatron_to_hf_config", return_value=parent):
+            hf_cfg = NemotronHPuzzleBridge.megatron_to_hf_config(provider)
+
+        assert hf_cfg["mtp_block_configs"] == [
+            {"block_type": "attention"},
+            {"block_type": "moe", "moe_intermediate_size": 2688, "num_experts_per_tok": 22},
+        ]
+
+    def test_sets_puzzle_auto_map_and_model_type(self):
+        provider = SimpleNamespace(
+            per_layer_config_overrides=[None],
+            mtp_per_layer_config_overrides=None,
+        )
+        parent = self._stub_parent_hf_cfg(hybrid_override_pattern="M")
+        with patch.object(NemotronHBridge, "megatron_to_hf_config", return_value=parent):
+            hf_cfg = NemotronHPuzzleBridge.megatron_to_hf_config(provider)
+
+        assert hf_cfg["model_type"] == "nemotron_h_puzzle"
+        assert hf_cfg["auto_map"] == {
+            "AutoConfig": "configuration_nemotron_h_puzzle.NemotronHPuzzleConfig",
+            "AutoModelForCausalLM": "modeling_nemotron_h_puzzle.NemotronHPuzzleForCausalLM",
+        }
+
+    def test_strips_blockwise_global_scalars(self):
+        # NemotronHPuzzleConfig strips moe_intermediate_size / num_experts_per_tok
+        # from the top level (they're strictly per-block members). Emit them at
+        # top level from the parent and the child must pop them so the exported
+        # config round-trips through HF loading.
+        provider = SimpleNamespace(
+            per_layer_config_overrides=[None],
+            mtp_per_layer_config_overrides=None,
+        )
+        parent = self._stub_parent_hf_cfg(hybrid_override_pattern="M")
+        with patch.object(NemotronHBridge, "megatron_to_hf_config", return_value=parent):
+            hf_cfg = NemotronHPuzzleBridge.megatron_to_hf_config(provider)
+
+        assert "moe_intermediate_size" not in hf_cfg
+        assert "num_experts_per_tok" not in hf_cfg
+
+    def test_emits_layers_block_type_from_block_configs(self):
+        provider = SimpleNamespace(
+            per_layer_config_overrides=[
+                None,
+                {"moe_ffn_hidden_size": 512, "moe_router_topk": 4},
+            ],
+            mtp_per_layer_config_overrides=None,
+        )
+        parent = self._stub_parent_hf_cfg(hybrid_override_pattern="ME", mtp_hybrid_override_pattern=None)
+        with patch.object(NemotronHBridge, "megatron_to_hf_config", return_value=parent):
+            hf_cfg = NemotronHPuzzleBridge.megatron_to_hf_config(provider)
+
+        assert hf_cfg["layers_block_type"] == ["mamba", "moe"]
+        assert "mtp_layers_block_type" not in hf_cfg
+
+    def test_emits_mtp_layers_block_type_when_mtp_present(self):
+        provider = SimpleNamespace(
+            per_layer_config_overrides=[None],
+            mtp_per_layer_config_overrides=[
+                None,
+                {"moe_ffn_hidden_size": 2688, "moe_router_topk": 22},
+            ],
+        )
+        parent = self._stub_parent_hf_cfg(hybrid_override_pattern="M")
+        with patch.object(NemotronHBridge, "megatron_to_hf_config", return_value=parent):
+            hf_cfg = NemotronHPuzzleBridge.megatron_to_hf_config(provider)
+
+        assert hf_cfg["mtp_layers_block_type"] == ["attention", "moe"]
+
+
+class TestHelpers:
+    def test_blocks_to_pattern_covers_all_types(self):
+        blocks = [
+            {"block_type": "mamba"},
+            {"block_type": "attention"},
+            {"block_type": "moe"},
+            {"block_type": "mlp"},
+        ]
+        assert _blocks_to_pattern(blocks) == "M*E-"
+
+    def test_blocks_to_pattern_accepts_dataclass_style_entries(self):
+        # `_block_type` and `_block_attr` support attr access as well as dict
+        # get — HF configs sometimes load block entries as dataclass instances.
+        blocks = [SimpleNamespace(block_type="mamba"), SimpleNamespace(block_type="moe")]
+        assert _blocks_to_pattern(blocks) == "ME"
+
+    def test_block_to_override_returns_none_for_non_moe(self):
+        assert _block_to_override({"block_type": "mamba"}) is None
+        assert _block_to_override({"block_type": "attention"}) is None
+        assert _block_to_override({"block_type": "mlp"}) is None
+
+    def test_block_to_override_extracts_moe_keys(self):
+        got = _block_to_override(
+            {"block_type": "moe", "moe_intermediate_size": 512, "num_experts_per_tok": 4}
+        )
+        assert got == {"moe_ffn_hidden_size": 512, "moe_router_topk": 4}
+
+    def test_block_to_override_raises_on_missing_moe_keys(self):
+        with pytest.raises(ValueError, match="missing required keys"):
+            _block_to_override({"block_type": "moe", "moe_intermediate_size": 512})
+        with pytest.raises(ValueError, match="missing required keys"):
+            _block_to_override({"block_type": "moe", "num_experts_per_tok": 4})


### PR DESCRIPTION
# What does this PR do ?

Adds Nemotron Puzzle (heterogenous mamba support) to bridge.

Requires mcore support for heterogenous mamba models https://github.com/NVIDIA/Megatron-LM/pull/6217 

# Changelog

- Add new bridge
- Consolidate mapping parameters 

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
