### PR TITLE
fix(training): pad uneven HybridEP dispatch inputs

### DIFF
--- a/docs/parallelisms.md
+++ b/docs/parallelisms.md
@@ -223,27 +223,23 @@ model_config = GPTModelProvider(
 
 # Apply HybridEP optimization
 apply_flex_dispatcher_backend(model_config, moe_flex_dispatcher_backend="hybridep")
-
-# Opt in when local dispatch token counts can differ across HybridEP ranks.
-model_config.moe_hybridep_pad_uneven_dispatch_inputs = True
 ```
 
-`moe_hybridep_pad_uneven_dispatch_inputs` is an explicit opt-in. Enable it
-when ranks in the HybridEP communication group can enter dispatch with different
-token counts, such as dynamically packed THD batches. HybridEP then takes the
-group-wide maximum token count, aligns it for the kernel, pads each rank before
-dispatch, and removes the padding after combine.
+Megatron Bridge automatically enables `moe_hybridep_pad_uneven_dispatch_inputs`
+when an eager model config uses the HybridEP flex backend. HybridEP requires
+equal per-rank dispatch shapes, but dynamically packed THD batches can produce
+different local token counts. The safety path takes the group-wide maximum token
+count, aligns it for the kernel, pads each rank before dispatch, and removes the
+padding after combine.
 
-Leave the option disabled when every rank already supplies the same number of
-tokens. Sequence packing alone does not imply that dispatcher inputs are uneven,
-and enabling this path unnecessarily adds a MAX all-reduce and padding overhead.
-The option does not enable HybridEP or sequence packing; configure those
-separately. With `scripts/training/run_recipe.py`, the equivalent trailing CLI
-override is:
+This adds a MAX all-reduce and temporary padding overhead, including when every
+rank already supplies the same number of tokens. The safety path does not enable
+HybridEP or sequence packing; configure those separately.
 
-```bash
-model.moe_hybridep_pad_uneven_dispatch_inputs=true
-```
+CUDA-graph configs preserve their explicit padding setting because the uneven-input
+path performs a host scalar synchronization that is not capture-safe. They must
+provide equal per-rank dispatch shapes. Disable CUDA graphs when runtime token
+counts can differ so Bridge can enable safe padding.
 
 **GPU Architecture Requirements:**
 

--- a/docs/training/packed-sequences.md
+++ b/docs/training/packed-sequences.md
@@ -113,19 +113,18 @@ The durable constraints for packed sequences in Bridge are:
   evaluation CP constraints and `CP * TP` when sequence parallelism is enabled
 - for fine-tuning with CP enabled, per-token loss behavior and reduction
   settings matter
-- HybridEP users whose local dispatch token counts differ across ranks must
-  explicitly set `model.moe_hybridep_pad_uneven_dispatch_inputs=True`; this
-  pads only to the group-wide aligned maximum before dispatch and trims the
-  padding after combine
+- Megatron Bridge automatically enables safe uneven-input padding for eager
+  HybridEP configs; this pads only to the group-wide aligned maximum before
+  dispatch and trims the padding after combine
 - CUDA-graph-friendly packed metadata requires additional padding constraints
 
 Model-family support is not universal. Some families and recipe paths explicitly
 opt out of packed sequences or related packing modes.
 
-The HybridEP option is not enabled automatically by in-batch packing. Some
-packed datasets already produce equal dispatcher sizes, while variable-sized
-inputs can also occur without sequence packing. Keeping the option explicit
-avoids an unnecessary synchronization and padding cost for equal-sized inputs.
+HybridEP CUDA-graph configs preserve their explicit uneven-input setting because
+the safety path performs a host scalar synchronization that is not capture-safe.
+They must provide equal per-rank dispatch shapes. Disable CUDA graphs when packed
+runtime token counts can differ so Bridge can enable safe padding.
 
 ## Relationship to Long-Sequence Training
 

--- a/src/megatron/bridge/models/transformer_config.py
+++ b/src/megatron/bridge/models/transformer_config.py
@@ -82,6 +82,42 @@ def _set_moe_expert_tensor_parallel_default(config: MCoreTransformerConfig) -> N
         config.expert_tensor_parallel_size = 1
 
 
+def _enable_safe_hybridep_dispatch(config: MCoreTransformerConfig) -> None:
+    """Ensure eager HybridEP can dispatch different token counts across ranks.
+
+    Bridge model configs are finalized before runtime batches expose whether their
+    THD token counts differ by rank. HybridEP requires equal dispatch shapes, so use
+    Megatron Core's padding path for eager Bridge-configured HybridEP dispatchers.
+    CUDA-graph configs retain their explicit setting because the padding path's host
+    scalar synchronization is not capture-safe; those configs require equal inputs.
+    """
+
+    def _uses_legacy_full_iteration(value: object) -> bool:
+        values = value if isinstance(value, list) else [value]
+        return any(
+            "full_iteration" in item.split(",")
+            if isinstance(item, str)
+            else getattr(item, "name", None) == "full_iteration"
+            for item in values
+        )
+
+    cuda_graph_impl = getattr(config, "cuda_graph_impl", "none")
+    cuda_graphs_enabled = (
+        cuda_graph_impl not in (None, "none")
+        or getattr(config, "enable_cuda_graph", False)
+        or getattr(config, "external_cuda_graph", False)
+        or _uses_legacy_full_iteration(getattr(config, "cuda_graph_modules", None))
+        or _uses_legacy_full_iteration(getattr(config, "cuda_graph_scope", None))
+    )
+    if (
+        config.moe_token_dispatcher_type == "flex"
+        and config.moe_flex_dispatcher_backend == "hybridep"
+        and not config.moe_hybridep_pad_uneven_dispatch_inputs
+        and not cuda_graphs_enabled
+    ):
+        config.moe_hybridep_pad_uneven_dispatch_inputs = True
+
+
 @dataclass
 class TransformerConfig(MCoreTransformerConfig):
     """Megatron Core TransformerConfig with deferred post-init.
@@ -127,6 +163,7 @@ class TransformerConfig(MCoreTransformerConfig):
         if self.sequence_parallel and self.tensor_model_parallel_size <= 1:
             self.sequence_parallel = False
         _set_moe_expert_tensor_parallel_default(self)
+        _enable_safe_hybridep_dispatch(self)
         MCoreTransformerConfig.__post_init__(self)
 
         # In-batch packing produces variable-length packed sequences across microbatches,
@@ -203,6 +240,7 @@ class MLATransformerConfig(TransformerConfig, MCoreMLATransformerConfig):
         if self.sequence_parallel and self.tensor_model_parallel_size <= 1:
             self.sequence_parallel = False
         _set_moe_expert_tensor_parallel_default(self)
+        _enable_safe_hybridep_dispatch(self)
         MCoreMLATransformerConfig.__post_init__(self)
 
         if getattr(self, "_enable_in_batch_packing", False) and self.pipeline_model_parallel_size > 1:
@@ -259,6 +297,7 @@ class HeterogeneousTransformerConfig(TransformerConfig, MCoreHeterogeneousTransf
         if self.sequence_parallel and self.tensor_model_parallel_size <= 1:
             self.sequence_parallel = False
         _set_moe_expert_tensor_parallel_default(self)
+        _enable_safe_hybridep_dispatch(self)
         MCoreHeterogeneousTransformerConfig.__post_init__(self)
 
     def get_config_for_layer(self, layer_number: int) -> MCoreTransformerConfig:

--- a/tests/unit_tests/models/test_transformer_config.py
+++ b/tests/unit_tests/models/test_transformer_config.py
@@ -225,6 +225,61 @@ class TestTransformerConfigFinalize:
             cfg.finalize()
         assert cfg.expert_tensor_parallel_size is None
 
+    def test_hybridep_finalization_enables_uneven_dispatch_padding(self):
+        """HybridEP must safely handle different token counts on each EP rank."""
+        cfg = _make_config(
+            num_moe_experts=8,
+            moe_token_dispatcher_type="flex",
+            moe_flex_dispatcher_backend="hybridep",
+            moe_hybridep_pad_uneven_dispatch_inputs=False,
+        )
+
+        with patch(_FINALIZE_PATCH):
+            cfg.finalize()
+
+        assert cfg.moe_hybridep_pad_uneven_dispatch_inputs is True
+
+    def test_non_hybridep_finalization_preserves_uneven_dispatch_padding(self):
+        """Other flex backends must retain their configured padding behavior."""
+        cfg = _make_config(
+            num_moe_experts=8,
+            moe_token_dispatcher_type="flex",
+            moe_flex_dispatcher_backend="deepep",
+            moe_hybridep_pad_uneven_dispatch_inputs=False,
+        )
+
+        with patch(_FINALIZE_PATCH):
+            cfg.finalize()
+
+        assert cfg.moe_hybridep_pad_uneven_dispatch_inputs is False
+
+    @pytest.mark.parametrize(
+        "cuda_graph_settings",
+        [
+            {"cuda_graph_impl": "full_iteration"},
+            {"cuda_graph_impl": "transformer_engine"},
+            {"cuda_graph_impl": "local"},
+            {"enable_cuda_graph": True},
+            {"external_cuda_graph": True},
+            {"cuda_graph_modules": "full_iteration"},
+            {"cuda_graph_scope": "full_iteration"},
+        ],
+    )
+    def test_hybridep_cuda_graph_finalization_preserves_padding_setting(self, cuda_graph_settings):
+        """CUDA-graph HybridEP configs must not gain a host scalar synchronization."""
+        cfg = _make_config(
+            num_moe_experts=8,
+            moe_token_dispatcher_type="flex",
+            moe_flex_dispatcher_backend="hybridep",
+            moe_hybridep_pad_uneven_dispatch_inputs=False,
+            **cuda_graph_settings,
+        )
+
+        with patch(_FINALIZE_PATCH):
+            cfg.finalize()
+
+        assert cfg.moe_hybridep_pad_uneven_dispatch_inputs is False
+
 
 class TestMLATransformerConfigFinalize:
     """Tests for MLATransformerConfig.finalize()."""
@@ -241,6 +296,22 @@ class TestMLATransformerConfigFinalize:
         with patch(_MLA_FINALIZE_PATCH):
             cfg.finalize()
         assert cfg.expert_tensor_parallel_size == 1
+
+    def test_hybridep_finalization_enables_uneven_dispatch_padding(self):
+        cfg = MLATransformerConfig(
+            num_layers=2,
+            hidden_size=64,
+            num_attention_heads=4,
+            num_moe_experts=8,
+            moe_token_dispatcher_type="flex",
+            moe_flex_dispatcher_backend="hybridep",
+            moe_hybridep_pad_uneven_dispatch_inputs=False,
+        )
+
+        with patch(_MLA_FINALIZE_PATCH):
+            cfg.finalize()
+
+        assert cfg.moe_hybridep_pad_uneven_dispatch_inputs is True
 
 
 # ---------------------------------------------------------------------------
@@ -298,6 +369,19 @@ class TestHeterogeneousTransformerConfigFinalize:
         with patch(_HETERO_FINALIZE_PATCH):
             cfg.finalize()
         assert cfg.sequence_parallel is True
+
+    def test_hybridep_finalization_enables_uneven_dispatch_padding(self):
+        cfg = self._make_hetero(
+            num_moe_experts=8,
+            moe_token_dispatcher_type="flex",
+            moe_flex_dispatcher_backend="hybridep",
+            moe_hybridep_pad_uneven_dispatch_inputs=False,
+        )
+
+        with patch(_HETERO_FINALIZE_PATCH):
+            cfg.finalize()
+
+        assert cfg.moe_hybridep_pad_uneven_dispatch_inputs is True
 
     def test_pipeline_dtype_propagated_from_params_dtype_when_pp_gt1(self):
         cfg = self._make_valid_hetero(


### PR DESCRIPTION
# What does this PR do ?

Make eager HybridEP dispatch safe when local token counts differ across expert-parallel ranks.

Fixes NVBug 6540116.

# Changelog

- Enable Megatron Core's aligned group-maximum padding path whenever an eager Bridge model config finalizes the HybridEP flex dispatcher.
- Cover Transformer, MLA, and heterogeneous configs while preserving non-HybridEP behavior.
- Preserve explicit padding behavior for CUDA-graph configs, whose static dispatch shapes must remain capture-safe.
- Update HybridEP and packed-sequence documentation to remove the obsolete explicit opt-in requirement.

# Root cause

HybridEP requires equal per-rank dispatch shapes, but Bridge finalized eager HybridEP configs with Megatron Core's uneven-input padding disabled by default. Dynamically packed THD batches could therefore complete every optimizer step while some ranks made almost no training progress. CUDA-graph configs retain their explicit setting because the safe-padding path includes a host scalar synchronization; those configs require equal per-rank dispatch shapes.

# Verification

- The unchanged four-GPU EP=4 release-container A/B reproduced the uneven-rank stall before the fix.
- After the fix, the arm that still requested the default-false setting measured aligned dispatch shapes and material finite loss progress on all four ranks; the padded and equal-token controls also passed.
- HybridEP CUDA-graph finalization coverage for local, Transformer Engine, full-iteration, legacy boolean, and legacy scope/module settings.
- `uv run python -m pytest tests/unit_tests/models/test_transformer_config.py tests/unit_tests/training/test_deepep.py -q` (58 passed)
- `uv run pre-commit run --all-files`
- `git diff --check`

# GitHub Actions CI

CI is pending for this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install? No.

# Additional Information

AI assistance: OpenAI Codex assisted with implementation and validation. The complete change and evidence received an independent review before publication.
