### PR TITLE
docs(ckpt): document Megatron-LM checkpoint export

### DIFF
--- a/docs/bridge-guide.md
+++ b/docs/bridge-guide.md
@@ -290,6 +290,11 @@ Or with a helper script:
 ./scripts/conversion/convert.sh export --hf-model meta-llama/Llama-3.2-1B --megatron-path ./megatron_checkpoints/llama32_1b --hf-path ./hf_exports/llama32_1b
 ```
 
+Megatron-LM training checkpoints do not normally contain the Bridge
+`run_config.yaml` required by this export command. See
+[Export Megatron-LM checkpoints without a Bridge run config](megatron-lm-to-megatron-bridge.md#export-megatron-lm-checkpoints-without-a-bridge-run-config)
+for the configuration generation and validation workflow.
+
 ### Create Megatron models and run locally
 
 ```bash

--- a/docs/fern/versions/nightly/pages/bridge-guide.mdx
+++ b/docs/fern/versions/nightly/pages/bridge-guide.mdx
@@ -258,6 +258,11 @@ Or with a helper script:
 ./scripts/conversion/convert.sh export --hf-model meta-llama/Llama-3.2-1B --megatron-path ./megatron_checkpoints/llama32_1b --hf-path ./hf_exports/llama32_1b
 ```
 
+Megatron-LM training checkpoints do not normally contain the Bridge
+`run_config.yaml` required by this export command. See
+[Export Megatron-LM checkpoints without a Bridge run config](megatron-lm-to-megatron-bridge.md#export-megatron-lm-checkpoints-without-a-bridge-run-config)
+for the configuration generation and validation workflow.
+
 ### Create Megatron models and run locally
 
 ```bash

--- a/docs/fern/versions/nightly/pages/megatron-lm-to-megatron-bridge.mdx
+++ b/docs/fern/versions/nightly/pages/megatron-lm-to-megatron-bridge.mdx
@@ -115,6 +115,187 @@ Notes:
 - Config groups are nested: `rng`, `train`, `model`, `optimizer`, `ddp`, `scheduler`, `dataset`, `logger`, `tokenizer`, `checkpoint`, `dist`, `profiling`, `peft`, `comm_overlap`, `mixed_precision`, `inprocess_restart`.
 - After overrides are applied, runtime validation computes any dependent fields (e.g., data-parallel size, scheduler steps) and checks consistency.
 
+## Export Megatron-LM checkpoints without a Bridge run config
+
+Megatron-LM checkpoints save their training arguments in `common.pt`; they do
+not normally contain the `run_config.yaml` written by Megatron Bridge. The
+Bridge checkpoint export launcher currently needs that file to reconstruct a
+model provider before loading the distributed weights.
+
+Use this procedure only when all of the following are true:
+
+- the iteration directory contains `common.pt` and the distributed checkpoint
+  metadata and shards;
+- the checkpoint architecture has an existing Megatron Bridge implementation;
+- `--hf-model` identifies the exact Hugging Face architecture used to create
+  the checkpoint; fine-tuned weights may differ, but model dimensions, layer
+  patterns, vocabulary configuration, and MTP structure must match; and
+- Megatron Bridge, Megatron Core, and Transformer Engine are compatible with
+  the versions that wrote the checkpoint.
+
+This procedure generates only `run_config.yaml`. It does not migrate legacy
+checkpoint keys or metadata, and it does not translate a custom Megatron-LM
+model spec into a Bridge provider.
+
+### Generate `run_config.yaml`
+
+Set `MB_CKPT` to the checkpoint iteration directory, not its parent. The
+Hugging Face reference is used only for configuration and provider selection;
+this generation step does not download its weights.
+
+```bash
+MB_CKPT=/workspace/checkpoints/model/iter_0001000
+MB_HF_REF=organization/model-reference
+
+uv run python - "$MB_CKPT" "$MB_HF_REF" --trust-remote-code <<'PY'
+from dataclasses import fields
+import logging
+from pathlib import Path
+import sys
+
+from megatron.core.ssm.mamba_hybrid_layer_allocation import Symbols
+
+from megatron.bridge import AutoBridge
+from megatron.bridge.training.config import ConfigContainer
+from megatron.bridge.training.model_load_save import load_model_config
+from megatron.bridge.utils.yaml_utils import dump_dataclass_to_yaml
+from transformers import AutoConfig
+
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger(__name__)
+
+checkpoint = Path(sys.argv[1])
+hf_reference = sys.argv[2]
+trust_remote_code = "--trust-remote-code" in sys.argv[3:]
+output = checkpoint / "run_config.yaml"
+
+if not (checkpoint / "common.pt").is_file():
+    raise FileNotFoundError(f"common.pt not found in {checkpoint}")
+if output.exists():
+    raise FileExistsError(f"Refusing to overwrite {output}")
+
+# Without run_config.yaml, this reads the Megatron-LM args from common.pt.
+checkpoint_config, megatron_args = load_model_config(str(checkpoint))
+if megatron_args is None:
+    raise RuntimeError("Expected a Megatron-LM checkpoint with args in common.pt")
+
+hf_config = AutoConfig.from_pretrained(
+    hf_reference,
+    trust_remote_code=trust_remote_code,
+)
+bridge = AutoBridge.from_hf_config(hf_config)
+provider = bridge.to_megatron_provider(load_weights=False)
+
+# Overlay the checkpoint's TransformerConfig, including FP8/MXFP8 fields, on
+# the architecture-specific provider derived from the HF reference.
+for field in fields(checkpoint_config):
+    if hasattr(provider, field.name):
+        setattr(provider, field.name, getattr(checkpoint_config, field.name))
+
+# Hybrid layer patterns are stored in the Megatron-LM Namespace rather than
+# its TransformerConfig. Preserve separate and already-unified MTP layouts.
+pattern = (
+    getattr(megatron_args, "hybrid_layer_pattern", None)
+    or getattr(megatron_args, "hybrid_override_pattern", None)
+)
+if pattern and hasattr(provider, "hybrid_layer_pattern"):
+    provider.hybrid_override_pattern = None
+    provider.hybrid_layer_pattern = pattern
+
+for name in (
+    "mtp_num_layers",
+    "mtp_hybrid_override_pattern",
+    "mtp_use_repeated_layer",
+    "keep_mtp_spec_in_bf16",
+    "seq_length",
+):
+    value = getattr(megatron_args, name, None)
+    if value is not None and hasattr(provider, name):
+        setattr(provider, name, value)
+
+if pattern and Symbols.MTP_SEPARATOR in pattern:
+    provider.mtp_hybrid_override_pattern = None
+
+if hasattr(provider, "hf_model_id"):
+    provider.hf_model_id = hf_reference
+provider.finalize()
+
+# Serializing the provider directly omits its dataclass fields. Convert it
+# through ConfigContainer so load_model_config() can instantiate it correctly.
+model_dict = ConfigContainer._convert_value_to_dict(provider)
+dump_dataclass_to_yaml({"model": model_dict}, str(output))
+logger.info("Wrote %s", output)
+PY
+```
+
+Omit `--trust-remote-code` unless the reference model requires custom code and
+you trust its repository.
+
+### Validate the generated provider
+
+Validate the YAML before allocating GPUs for conversion:
+
+```bash
+uv run python - "$MB_CKPT" <<'PY'
+import logging
+import sys
+
+from megatron.bridge.training.model_load_save import load_model_config
+
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger(__name__)
+
+config, megatron_args = load_model_config(sys.argv[1])
+if megatron_args is not None:
+    raise RuntimeError("run_config.yaml was not loaded")
+
+for name in (
+    "num_layers",
+    "hidden_size",
+    "ffn_hidden_size",
+    "num_moe_experts",
+    "hybrid_layer_pattern",
+    "mtp_num_layers",
+    "fp8",
+    "fp8_recipe",
+    "fp8_param",
+    "first_last_layers_bf16",
+    "num_layers_at_start_in_bf16",
+    "num_layers_at_end_in_bf16",
+):
+    logger.info("%s=%r", name, getattr(config, name, None))
+PY
+```
+
+Compare the reported architecture, hybrid/MTP layout, and precision fields
+with the original training configuration. Do not continue if they differ.
+
+Run the normal export after validation. Adapt the parallel topology to the
+checkpoint and available GPUs:
+
+```bash
+./scripts/conversion/convert.sh export \
+  --executor local \
+  --device gpu \
+  --gpus-per-node 8 \
+  --hf-model "$MB_HF_REF" \
+  --megatron-path "$MB_CKPT" \
+  --hf-path /workspace/exports/model-hf \
+  --tp 1 --pp 1 --ep 8 --etp 1 \
+  --torch-dtype bfloat16 \
+  --trust-remote-code
+```
+
+Keep strict conversion enabled for the first export. Do not use
+`--not-strict` to bypass missing MTP, expert, or quantized parameters.
+
+For MXFP8 parameter checkpoints, use hardware supported by the saved recipe
+(normally Blackwell). The default BF16 export dequantizes Transformer Engine
+quantized parameters. Do not request `--export-weight-dtype fp8` for MXFP8;
+native FP8 Hugging Face export currently supports blockwise FP8 parameters.
+
 ## Mapping Megatron-LM arguments to Megatron Bridge config
 
 Below is a concise mapping from common `megatron-lm/megatron/training/arguments.py` flags to the new dataclass fields. If a field is not listed here (e.g., highly model-specific knobs), it typically lives under `model.*`, `optimizer.*`, `dataset.*`, or `tokenizer.*` with similar names.

--- a/docs/megatron-lm-to-megatron-bridge.md
+++ b/docs/megatron-lm-to-megatron-bridge.md
@@ -115,6 +115,187 @@ Notes:
 - Config groups are nested: `rng`, `train`, `model`, `optimizer`, `ddp`, `scheduler`, `dataset`, `logger`, `tokenizer`, `checkpoint`, `dist`, `profiling`, `peft`, `comm_overlap`, `mixed_precision`, `inprocess_restart`.
 - After overrides are applied, runtime validation computes any dependent fields (e.g., data-parallel size, scheduler steps) and checks consistency.
 
+## Export Megatron-LM checkpoints without a Bridge run config
+
+Megatron-LM checkpoints save their training arguments in `common.pt`; they do
+not normally contain the `run_config.yaml` written by Megatron Bridge. The
+Bridge checkpoint export launcher currently needs that file to reconstruct a
+model provider before loading the distributed weights.
+
+Use this procedure only when all of the following are true:
+
+- the iteration directory contains `common.pt` and the distributed checkpoint
+  metadata and shards;
+- the checkpoint architecture has an existing Megatron Bridge implementation;
+- `--hf-model` identifies the exact Hugging Face architecture used to create
+  the checkpoint; fine-tuned weights may differ, but model dimensions, layer
+  patterns, vocabulary configuration, and MTP structure must match; and
+- Megatron Bridge, Megatron Core, and Transformer Engine are compatible with
+  the versions that wrote the checkpoint.
+
+This procedure generates only `run_config.yaml`. It does not migrate legacy
+checkpoint keys or metadata, and it does not translate a custom Megatron-LM
+model spec into a Bridge provider.
+
+### Generate `run_config.yaml`
+
+Set `MB_CKPT` to the checkpoint iteration directory, not its parent. The
+Hugging Face reference is used only for configuration and provider selection;
+this generation step does not download its weights.
+
+```bash
+MB_CKPT=/workspace/checkpoints/model/iter_0001000
+MB_HF_REF=organization/model-reference
+
+uv run python - "$MB_CKPT" "$MB_HF_REF" --trust-remote-code <<'PY'
+from dataclasses import fields
+import logging
+from pathlib import Path
+import sys
+
+from megatron.core.ssm.mamba_hybrid_layer_allocation import Symbols
+
+from megatron.bridge import AutoBridge
+from megatron.bridge.training.config import ConfigContainer
+from megatron.bridge.training.model_load_save import load_model_config
+from megatron.bridge.utils.yaml_utils import dump_dataclass_to_yaml
+from transformers import AutoConfig
+
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger(__name__)
+
+checkpoint = Path(sys.argv[1])
+hf_reference = sys.argv[2]
+trust_remote_code = "--trust-remote-code" in sys.argv[3:]
+output = checkpoint / "run_config.yaml"
+
+if not (checkpoint / "common.pt").is_file():
+    raise FileNotFoundError(f"common.pt not found in {checkpoint}")
+if output.exists():
+    raise FileExistsError(f"Refusing to overwrite {output}")
+
+# Without run_config.yaml, this reads the Megatron-LM args from common.pt.
+checkpoint_config, megatron_args = load_model_config(str(checkpoint))
+if megatron_args is None:
+    raise RuntimeError("Expected a Megatron-LM checkpoint with args in common.pt")
+
+hf_config = AutoConfig.from_pretrained(
+    hf_reference,
+    trust_remote_code=trust_remote_code,
+)
+bridge = AutoBridge.from_hf_config(hf_config)
+provider = bridge.to_megatron_provider(load_weights=False)
+
+# Overlay the checkpoint's TransformerConfig, including FP8/MXFP8 fields, on
+# the architecture-specific provider derived from the HF reference.
+for field in fields(checkpoint_config):
+    if hasattr(provider, field.name):
+        setattr(provider, field.name, getattr(checkpoint_config, field.name))
+
+# Hybrid layer patterns are stored in the Megatron-LM Namespace rather than
+# its TransformerConfig. Preserve separate and already-unified MTP layouts.
+pattern = (
+    getattr(megatron_args, "hybrid_layer_pattern", None)
+    or getattr(megatron_args, "hybrid_override_pattern", None)
+)
+if pattern and hasattr(provider, "hybrid_layer_pattern"):
+    provider.hybrid_override_pattern = None
+    provider.hybrid_layer_pattern = pattern
+
+for name in (
+    "mtp_num_layers",
+    "mtp_hybrid_override_pattern",
+    "mtp_use_repeated_layer",
+    "keep_mtp_spec_in_bf16",
+    "seq_length",
+):
+    value = getattr(megatron_args, name, None)
+    if value is not None and hasattr(provider, name):
+        setattr(provider, name, value)
+
+if pattern and Symbols.MTP_SEPARATOR in pattern:
+    provider.mtp_hybrid_override_pattern = None
+
+if hasattr(provider, "hf_model_id"):
+    provider.hf_model_id = hf_reference
+provider.finalize()
+
+# Serializing the provider directly omits its dataclass fields. Convert it
+# through ConfigContainer so load_model_config() can instantiate it correctly.
+model_dict = ConfigContainer._convert_value_to_dict(provider)
+dump_dataclass_to_yaml({"model": model_dict}, str(output))
+logger.info("Wrote %s", output)
+PY
+```
+
+Omit `--trust-remote-code` unless the reference model requires custom code and
+you trust its repository.
+
+### Validate the generated provider
+
+Validate the YAML before allocating GPUs for conversion:
+
+```bash
+uv run python - "$MB_CKPT" <<'PY'
+import logging
+import sys
+
+from megatron.bridge.training.model_load_save import load_model_config
+
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger(__name__)
+
+config, megatron_args = load_model_config(sys.argv[1])
+if megatron_args is not None:
+    raise RuntimeError("run_config.yaml was not loaded")
+
+for name in (
+    "num_layers",
+    "hidden_size",
+    "ffn_hidden_size",
+    "num_moe_experts",
+    "hybrid_layer_pattern",
+    "mtp_num_layers",
+    "fp8",
+    "fp8_recipe",
+    "fp8_param",
+    "first_last_layers_bf16",
+    "num_layers_at_start_in_bf16",
+    "num_layers_at_end_in_bf16",
+):
+    logger.info("%s=%r", name, getattr(config, name, None))
+PY
+```
+
+Compare the reported architecture, hybrid/MTP layout, and precision fields
+with the original training configuration. Do not continue if they differ.
+
+Run the normal export after validation. Adapt the parallel topology to the
+checkpoint and available GPUs:
+
+```bash
+./scripts/conversion/convert.sh export \
+  --executor local \
+  --device gpu \
+  --gpus-per-node 8 \
+  --hf-model "$MB_HF_REF" \
+  --megatron-path "$MB_CKPT" \
+  --hf-path /workspace/exports/model-hf \
+  --tp 1 --pp 1 --ep 8 --etp 1 \
+  --torch-dtype bfloat16 \
+  --trust-remote-code
+```
+
+Keep strict conversion enabled for the first export. Do not use
+`--not-strict` to bypass missing MTP, expert, or quantized parameters.
+
+For MXFP8 parameter checkpoints, use hardware supported by the saved recipe
+(normally Blackwell). The default BF16 export dequantizes Transformer Engine
+quantized parameters. Do not request `--export-weight-dtype fp8` for MXFP8;
+native FP8 Hugging Face export currently supports blockwise FP8 parameters.
+
 ## Mapping Megatron-LM arguments to Megatron Bridge config
 
 Below is a concise mapping from common `megatron-lm/megatron/training/arguments.py` flags to the new dataclass fields. If a field is not listed here (e.g., highly model-specific knobs), it typically lives under `model.*`, `optimizer.*`, `dataset.*`, or `tokenizer.*` with similar names.

--- a/scripts/conversion/README.md
+++ b/scripts/conversion/README.md
@@ -13,6 +13,14 @@ Run `./scripts/conversion/convert.sh import --help`,
 `./scripts/conversion/convert.sh export --help`, or
 `./scripts/conversion/convert.sh roundtrip --help` for the complete CLI.
 
+Megatron-LM training checkpoints normally store their arguments in `common.pt`
+instead of the Megatron Bridge `run_config.yaml` required by the export path.
+Before exporting such a checkpoint, follow
+[Export Megatron-LM checkpoints without a Bridge run config](../../docs/megatron-lm-to-megatron-bridge.md#export-megatron-lm-checkpoints-without-a-bridge-run-config)
+to generate and validate the provider configuration. Do not create an empty or
+hand-written YAML file; missing hybrid, MTP, MoE, or FP8 fields can construct a
+different model while appearing to load successfully.
+
 ## Local CPU conversion
 
 Local execution uses the current Megatron Bridge environment and waits for the


### PR DESCRIPTION
# What does this PR do ?

Document a safe, model-agnostic workflow for exporting Megatron-LM checkpoints that contain `common.pt` but do not contain the Megatron Bridge `run_config.yaml` required by `convert.sh export`.

The workflow derives an architecture-specific provider from an exact Hugging Face reference, overlays the TransformerConfig recovered from `common.pt`, preserves hybrid/MTP fields, serializes an instantiable model config, and requires validation before GPU conversion. It also calls out the behavior and limitations of MXFP8 parameter export.

# Changelog

- Add prerequisites and scope boundaries for converting Megatron-LM distributed checkpoints.
- Add a config-only `run_config.yaml` generation procedure that does not download the reference weights.
- Add a preflight validation step for architecture, hybrid/MTP, MoE, and FP8/MXFP8 fields.
- Recommend strict BF16 export for MXFP8 parameters and clarify that native FP8 export currently supports blockwise FP8 only.
- Link the workflow from the Bridge guide and conversion-script README, including the nightly Fern mirrors.

# GitHub Actions CI

Documentation-only change.

Validation performed:

- `uvx pre-commit run --all-files`
- `git diff --check`
- compiled both embedded Python snippets with Python 3.12
- verified the canonical Markdown section and nightly Fern mirror are identical

`uv run pre-commit run --all-files` was also attempted, but project environment creation is unavailable on this macOS ARM host because `nvidia-resiliency-ext==0.6.0` publishes Linux wheels only. Running pre-commit through the isolated uv tool environment passed all configured hooks.

Not run: checkpoint round-trip or GPU export; those require a compatible Linux/NVIDIA environment and a representative Megatron-LM checkpoint.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests? (Documentation-only; targeted snippet and hook validation is listed above.)
- [x] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install? (No.)
  - [x] Reviewer: Does the PR have correct import guards for all optional libraries? (Not applicable.)

# Additional Information

- Related to #1514.
- Generalizes the `run_config.yaml` serialization lesson from #5170 without including that PR's Nemotron Omni-specific legacy checkpoint migrations.
- This documentation does not remove the exporter's current `run_config.yaml` requirement.
