### PR TITLE
fix(fsdp): support MCore FullyShardedDataParallel factory in isinstance checks

### DIFF
--- a/src/megatron/bridge/models/conversion/utils.py
+++ b/src/megatron/bridge/models/conversion/utils.py
@@ -46,13 +46,24 @@ def unwrap_model(model, module_instances=None):
     if module_instances is None:
         from megatron.core.distributed import DistributedDataParallel as DDP
         from megatron.core.distributed import TorchFullyShardedDataParallel as torch_FSDP
-        from megatron.core.distributed.fsdp.mcore_fsdp_adapter import (
-            FullyShardedDataParallel as megatron_FSDP,
-        )
+        from megatron.core.distributed.fsdp import mcore_fsdp_adapter
         from megatron.core.distributed.fsdp.src.megatron_fsdp.megatron_fsdp import MegatronFSDP
         from megatron.core.transformer.module import Float16Module
 
-        module_instances = (DDP, torch_FSDP, megatron_FSDP, Float16Module, MegatronFSDP)
+        # ``FullyShardedDataParallel`` is a class in older Megatron-Core but a factory function
+        # dispatching to V1/V2 in newer versions, so gather only the concrete wrapper *classes*
+        # to keep the ``isinstance`` operands below valid.
+        megatron_fsdp_wrappers = tuple(
+            cls
+            for cls in (
+                getattr(mcore_fsdp_adapter, "FullyShardedDataParallelV1", None),
+                getattr(mcore_fsdp_adapter, "FullyShardedDataParallelV2", None),
+                getattr(mcore_fsdp_adapter, "FullyShardedDataParallel", None),
+            )
+            if isinstance(cls, type)
+        )
+
+        module_instances = (DDP, torch_FSDP, *megatron_fsdp_wrappers, Float16Module, MegatronFSDP)
 
     return_list = True
     if not isinstance(model, list):

--- a/src/megatron/bridge/training/train.py
+++ b/src/megatron/bridge/training/train.py
@@ -24,7 +24,6 @@ from typing import Any, Callable, Optional, Union
 import torch
 import torch.profiler
 from megatron.core.distributed import DistributedDataParallel as DDP
-from megatron.core.distributed.fsdp.mcore_fsdp_adapter import FullyShardedDataParallel as megatron_FSDP
 from megatron.core.full_cuda_graph import FullCudaGraphWrapper
 from megatron.core.num_microbatches_calculator import (
     get_current_global_batch_size,
@@ -120,6 +119,14 @@ try:
     HAS_OPTIMIZER_CUDA_GRAPH = True
 except ImportError:
     HAS_OPTIMIZER_CUDA_GRAPH = False
+
+
+# ``FullyShardedDataParallel`` became a factory function (dispatching to V1/V2) in newer
+# Megatron-Core; prefer the concrete V1 wrapper class so ``isinstance`` checks stay valid.
+try:
+    from megatron.core.distributed.fsdp.mcore_fsdp_adapter import FullyShardedDataParallelV1 as megatron_FSDP
+except ImportError:
+    from megatron.core.distributed.fsdp.mcore_fsdp_adapter import FullyShardedDataParallel as megatron_FSDP
 
 
 def train(


### PR DESCRIPTION
# What does this PR do ?

Restore Megatron-Bridge compatibility with newer Megatron-Core, where `mcore_fsdp_adapter.FullyShardedDataParallel` became a **factory function** (dispatching to V1/V2) instead of a class. Passing that symbol into `isinstance()` now raises `TypeError: isinstance() arg 2 must be a type, a tuple of types, or a union`, which fails **every** mbridge-in-mcore CI run (both unit and functional suites) through `unwrap_model`.

Root cause landed in Megatron-Core via NVIDIA/Megatron-LM#5865 ("Add MFSDP v2 MCore integration with FullyShardedOptimizer"). The factory's own docstring states: *"Use the explicit V1 or V2 implementation classes for type checks."*

# Changelog

- `models/conversion/utils.py` (`unwrap_model`): build the `isinstance` tuple from the concrete FSDP wrapper **classes** — `FullyShardedDataParallelV1`/`V2` when present, or the legacy `FullyShardedDataParallel` class on older Core — via `getattr` + `isinstance(cls, type)` filtering. The factory function is excluded automatically (it is not a type). This unblocks all failing CI jobs, which route through here (e.g. `model_bridge.py:load_weights_hf_to_megatron → unwrap_model`).
- `training/train.py`: fix the latent sibling call site (`isinstance(model_chunk, megatron_FSDP)`, manual FSDP buffer registration) by moving its import to the same `try FullyShardedDataParallelV1 except FullyShardedDataParallel` guard already established in `training/setup.py`.

# GitHub Actions CI

See the CI section in the Contributing doc.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed Contributor guidelines
- [ ] Did you write any new necessary tests? — existing unit + functional coverage (`test_train.py::TestFSDPRegistration`, conversion tests) already exercises `unwrap_model`; this restores them to green.
- [ ] Did you add or update any necessary documentation? — n/a
- [x] Does the PR affect components that are optional to install? — the newer-vs-older Core symbols are handled with import guards / `getattr` fallbacks.

# Additional Information

- Verified against the four failing mcore CI runs (PRs #6166, #6201, #6177, and the scheduled `main` run) — all share this single root cause.
- Follow-up (out of scope): `train.py` and `setup.py` type-check only against V1 (`megatron_FSDP`). If Core's factory ever dispatches `FullyShardedDataParallelV2` instances at runtime, those two sites would miss them. Consider a shared helper mirroring the `unwrap_model` tuple so all three sites stay aligned.
