### PR TITLE
fix(training): surface distributed failures without cleanup hangs

### DIFF
--- a/examples/model_verification_cards/gemma-4-26b-a4b-it/card.yaml
+++ b/examples/model_verification_cards/gemma-4-26b-a4b-it/card.yaml
@@ -5,13 +5,16 @@ title: gemma_4_26b_a4b_it
 summary: >
   Performance disclaimer: this model has not been performance-tuned; reported
   timing and throughput metrics are sanity checks, not optimized performance
-  results. Gemma 4 26B-A4B-it BF16 CPU and GPU import, exact CPU and GPU
-  export, and deterministic multimodal inference are verified. Manual forward
-  comparison remains unverified because the recorded run compared a
+  results. Gemma 4 26B-A4B-it BF16 CPU and GPU import and exact CPU and GPU
+  export are verified. Deterministic multimodal inference remains unverified
+  because the recorded run stopped after 29 of the requested 32 tokens. Manual
+  forward comparison remains unverified because the recorded run compared a
   tensor-parallel padding position rather than the prompt's next token. Full
   SFT remains unverified: the current two-node EP8 recipe does not complete its
   first optimizer step, while the supported single-node TP4/PP2/EP1 fallback
-  completes one finite step but stalls during the second. Long-context SFT and
+  completes one finite step before running out of memory during the second.
+  The formerly reported stall was failure cleanup waiting on outstanding
+  collectives, not a pipeline-boundary shape mismatch. Long-context SFT and
   PEFT are pending. The published Bridge recipes do not currently provide VLM
   pretraining.
 verification_index:
@@ -21,9 +24,9 @@ verification_index:
       - hf_to_megatron_gpu
       - megatron_to_hf_cpu
       - megatron_to_hf_gpu
-      - inference
     unverified:
       - manual_forward_pass
+      - inference
   training:
     H100:
       unverified: [sft, sft_export_inference, sft_long_context, peft]
@@ -129,9 +132,8 @@ items:
       agreement and cosine similarity of at least 0.99.
 
   inference:
-    status: verified
+    status: unverified
     precision: bf16
-    bridge_commit: c4250ac1382eccc8e2b58c2424b3db85415fbf6f  # pragma: allowlist secret
     command: >
       uv run python -m torch.distributed.run --standalone --nproc_per_node=8
       examples/conversion/hf_to_megatron_generate_vlm.py
@@ -142,17 +144,18 @@ items:
       --prompt "What animal is on the candy?"
       --max_new_tokens 32
       --tp 2 --pp 1 --ep 4 --etp 1
-    last_verified: 2026-07-23
+    last_verified: null
     expected_result: >
-      One BF16 deterministic greedy run terminated on EOS after 29 generated
-      tokens. The JSON-escaped
-      literal completion was "\u003c|channel\u003ethought\n\u003cchannel|\u003eThe
+      The 2026-07-23 BF16 deterministic greedy run stopped on EOS after 29 of
+      the requested 32 tokens, so it does not satisfy the exact-length gate.
+      Its JSON-escaped diagnostic completion was
+      "\u003c|channel\u003ethought\n\u003cchannel|\u003eThe
       animal on the candy is a
       turtle.\u003cturn|\u003e\u003cturn|\u003e\u003cturn|\u003e\u002f\u002fthought\n\u003cchannel|\u003eThe
       animal on the candy is a
       turtle.\u003cturn|\u003e\u003cturn|\u003e\u003cturn|\u003e\u003ceos\u003e".
-      The input was
-      p-blog/candy.JPG from huggingface/documentation-images at revision
+      Verification requires a fresh run that emits exactly 32 tokens. The
+      input was p-blog/candy.JPG from huggingface/documentation-images at revision
       44c3249461c5a5336585d1e31e0a4ce7fce06a5a, with SHA-256
       fc417c899e94f8df465b7541c5a70f0eebb85c414d06345f0b290c061eccc84c.
 
@@ -203,11 +206,15 @@ items:
         single-node TP4/PP2/EP1 run with selective recompute and a frozen vision
         encoder completed one optimizer step in 54,344.4 ms with lm loss
         1.293086, grad norm 46.201, 1.8 TFLOP/s/GPU, zero skipped iterations,
-        and zero NaN iterations. Its second step then made no observable
-        progress for more than nine minutes while all four ranks on the second
-        pipeline stage remained active and the first stage waited. No valid
-        10-step metrics or iter_0000010 checkpoint were produced, so SFT
-        remains unverified.
+        and zero NaN iterations. A controlled full-dimension reproduction
+        showed that the apparent second-step stall is a 352 MiB CUDA OOM on all
+        first-stage ranks in the MoE combine reduce-scatter. Those ranks then
+        waited in process-group cleanup while second-stage ranks waited in
+        pipeline communication. Tiny multimodal PP1 and PP2 controls completed
+        three steps with compatible BF16 boundary tensors and matching
+        recompute shapes, so the evidence does not indicate a PP boundary
+        contract mismatch. No valid 10-step metrics or iter_0000010 checkpoint
+        were produced, so SFT remains unverified.
 
   sft_export_inference:
     H100:

--- a/examples/model_verification_cards/gemma-4-26b-a4b-it/card.yaml
+++ b/examples/model_verification_cards/gemma-4-26b-a4b-it/card.yaml
@@ -9,14 +9,13 @@ summary: >
   export are verified. Deterministic multimodal inference remains unverified
   because the recorded run stopped after 29 of the requested 32 tokens. Manual
   forward comparison remains unverified because the recorded run compared a
-  tensor-parallel padding position rather than the prompt's next token. Full
-  SFT remains unverified: the current two-node EP8 recipe does not complete its
-  first optimizer step, while the supported single-node TP4/PP2/EP1 fallback
-  completes one finite step before running out of memory during the second.
-  The formerly reported stall was failure cleanup waiting on outstanding
-  collectives, not a pipeline-boundary shape mismatch. Long-context SFT and
-  PEFT are pending. The published Bridge recipes do not currently provide VLM
-  pretraining.
+  tensor-parallel padding position rather than the prompt's next token.
+  Decoder-focused SFT is verified on one 8-GPU H100 node with TP4/PP1/EP8/ETP1,
+  a frozen vision encoder, and selective core-attention and MoE-activation
+  recompute. The real CORD-v2 run completed 10 optimizer steps with stable
+  memory and saved iter_0000010. LoRA PEFT is also verified on four H100 GPUs
+  with TP2/PP1/EP4/ETP1 and a complete adapter checkpoint. Long-context SFT is
+  pending. The published Bridge recipes do not currently provide VLM pretraining.
 verification_index:
   model_level:
     verified:
@@ -29,7 +28,8 @@ verification_index:
       - inference
   training:
     H100:
-      unverified: [sft, sft_export_inference, sft_long_context, peft]
+      verified: [sft, peft]
+      unverified: [sft_export_inference, sft_long_context]
       unsupported: [pretrain, checkpoint_resume]
 model:
   hf_id: google/gemma-4-26B-A4B-it
@@ -178,11 +178,12 @@ items:
 
   sft:
     H100:
-      status: unverified
+      status: verified
       precision: bf16
       enabled_features: {}
+      bridge_commit: 81e559ca4d579cf2d9ed5b8f3f48bef82e06451f  # pragma: allowlist secret
       command: >
-        ./scripts/training/train.sh --nodes 2 --gpus-per-node 8
+        ./scripts/training/train.sh --nodes 1 --gpus-per-node 8
         --recipe gemma4_vl_26b_sft_config --mode sft --dataset cord-v2
         --pretrained_checkpoint work/model-verification/gemma-4-26b-a4b-it/imported-megatron/iter_0000000
         --max_steps 10 --seq_length 4096
@@ -191,30 +192,28 @@ items:
         --save_dir work/model-verification/gemma-4-26b-a4b-it/sft-checkpoints
         --save_interval 10 logger.log_interval=1 logger.log_throughput=true
         logger.save_config_filepath=work/model-verification/gemma-4-26b-a4b-it/sft-post-setup.yaml
-      last_verified: null
+      last_verified: 2026-08-04
       metrics:
-        initial_loss: null
-        final_loss: null
-        last_10_steps_step_time_ms_avg: null
-        last_10_steps_model_tflops_per_gpu_avg: null
+        initial_loss: 1.268018
+        final_loss: 0.06543536
+        last_10_steps_step_time_ms_avg: 18699.99
+        last_10_steps_model_tflops_per_gpu_avg: 26.47
+        peak_allocated_memory_gib: 70.624
+        peak_reserved_memory_gib: 71.021
       expected_result: >
-        On 2026-08-03 this exact real-CORD TP2/PP1/EP8 run loaded the immutable
-        BF16 checkpoint, persisted its post-setup configuration, and entered
-        iteration zero, but completed no optimizer step during 39 observed
-        minutes. A subset of ranks remained active while the others waited,
-        with no log growth, OOM, or traceback. A separate README-supported
-        single-node TP4/PP2/EP1 run with selective recompute and a frozen vision
-        encoder completed one optimizer step in 54,344.4 ms with lm loss
-        1.293086, grad norm 46.201, 1.8 TFLOP/s/GPU, zero skipped iterations,
-        and zero NaN iterations. A controlled full-dimension reproduction
-        showed that the apparent second-step stall is a 352 MiB CUDA OOM on all
-        first-stage ranks in the MoE combine reduce-scatter. Those ranks then
-        waited in process-group cleanup while second-stage ranks waited in
-        pipeline communication. Tiny multimodal PP1 and PP2 controls completed
-        three steps with compatible BF16 boundary tensors and matching
-        recompute shapes, so the evidence does not indicate a PP boundary
-        contract mismatch. No valid 10-step metrics or iter_0000010 checkpoint
-        were produced, so SFT remains unverified.
+        On 2026-08-04 the single-node TP4/PP1/EP8/ETP1 run loaded the immutable
+        BF16 checkpoint and real CORD-v2 revision, then completed exactly 10
+        optimizer steps at MBS1 and GBS32. The persisted post-setup config
+        confirmed a frozen vision encoder, trainable projection and language
+        model, expandable CUDA allocator segments, and selective core_attn plus
+        moe_act recompute with CUDA graphs and CPU offload disabled. Loss moved
+        from 1.268018 to 0.06543536, final grad norm was 1.561, and every step
+        reported zero skipped and zero NaN iterations. Across all eight ranks,
+        allocated memory returned to 56.493 GiB after each step, while
+        cumulative peak allocated and reserved memory remained at or below
+        70.624 and 71.021 GiB. The run saved a complete iter_0000010 torch_dist
+        checkpoint with eight rank shards, finalized metadata, training state,
+        and a latest-checkpoint tracker containing iteration 10.
 
   sft_export_inference:
     H100:
@@ -224,12 +223,11 @@ items:
       commands: null
       last_verified: null
       expected_result: >
-        This item is blocked because SFT produced no verified iter_0000010
-        checkpoint, so no export or post-SFT inference command is recorded.
-        Once that dependency passes, the checkpoint must export, strictly
-        reload as Gemma4ForConditionalGeneration, and complete one
-        deterministic greedy VLM generation with a recorded literal
-        completion.
+        SFT produced a verified iter_0000010 checkpoint, but export, strict
+        Hugging Face reload, and post-SFT inference have not been run. This
+        item requires the checkpoint to export, strictly reload as
+        Gemma4ForConditionalGeneration, and complete one deterministic greedy
+        VLM generation with a recorded literal completion.
 
   sft_long_context:
     H100:
@@ -252,9 +250,10 @@ items:
 
   peft:
     H100:
-      status: unverified
+      status: verified
       precision: bf16
       enabled_features: {}
+      bridge_commit: df1b978e751753707100417cb4e89645a23537f8  # pragma: allowlist secret
       command: >
         ./scripts/training/train.sh --nodes 1 --gpus-per-node 4
         --recipe gemma4_vl_26b_peft_config --mode lora --dataset cord-v2
@@ -264,16 +263,30 @@ items:
         validation.eval_iters=0 validation.eval_interval=0 checkpoint.load=null
         --save_dir work/model-verification/gemma-4-26b-a4b-it/peft-checkpoints
         --save_interval 10 logger.log_interval=1 logger.log_throughput=true
-      last_verified: null
+        logger.save_config_filepath=work/model-verification/gemma-4-26b-a4b-it/peft-post-setup.yaml
+      last_verified: 2026-08-04
       metrics:
-        initial_loss: null
-        final_loss: null
-        last_10_steps_step_time_ms_avg: null
-        last_10_steps_model_tflops_per_gpu_avg: null
+        initial_loss: 1.288328
+        final_loss: 0.1072377
+        last_10_steps_step_time_ms_avg: 14163.25
+        last_10_steps_model_tflops_per_gpu_avg: 65.01
+        peak_allocated_memory_gib: 44.252
+        peak_reserved_memory_gib: 45.637
       expected_result: >
-        The 4-GPU TP2/PP1/EP4 LoRA run must complete exactly 10 optimizer steps
-        with finite loss, no skipped or NaN iterations, all four required
-        metrics, and a reloadable final adapter checkpoint.
+        On 2026-08-04 the 4-GPU TP2/PP1/EP4/ETP1 LoRA run loaded the immutable
+        BF16 checkpoint and real CORD-v2 revision, then completed exactly 10
+        optimizer steps at MBS1 and GBS32. The persisted post-setup config
+        recorded rank-32 adapters with alpha 32 and zero dropout on linear_qkv,
+        linear_proj, linear_fc1, and linear_fc2. Runtime transformation froze
+        the base model and reported 22,272,000 trainable adapter parameters,
+        0.30% of the local model shard. Loss moved from 1.288328 to 0.1072377,
+        final grad norm was 22.994, and every step reported zero skipped and
+        zero NaN iterations. Across all four ranks, allocated memory returned
+        to 14.582 GiB after each step, while cumulative peak allocated and
+        reserved memory remained at or below 44.252 and 45.637 GiB. The run
+        saved a complete iter_0000010 adapter checkpoint with four rank shards,
+        finalized metadata, training state, and a latest-checkpoint tracker
+        containing iteration 10.
 
   checkpoint_resume:
     all:

--- a/examples/model_verification_cards/gemma-4-26b-a4b-it/card.yaml
+++ b/examples/model_verification_cards/gemma-4-26b-a4b-it/card.yaml
@@ -9,10 +9,11 @@ summary: >
   export, and deterministic multimodal inference are verified. Manual forward
   comparison remains unverified because the recorded run compared a
   tensor-parallel padding position rather than the prompt's next token. Full
-  SFT remains unverified because the default and selective-MLP configurations
-  exceed H100 memory, while full-layer recompute is too slow for the 10-step
-  verification window. Long-context SFT and PEFT are pending. The published
-  Bridge recipes do not currently provide VLM pretraining.
+  SFT remains unverified: the current two-node EP8 recipe does not complete its
+  first optimizer step, while the supported single-node TP4/PP2/EP1 fallback
+  completes one finite step but stalls during the second. Long-context SFT and
+  PEFT are pending. The published Bridge recipes do not currently provide VLM
+  pretraining.
 verification_index:
   model_level:
     verified:
@@ -143,8 +144,8 @@ items:
       --tp 2 --pp 1 --ep 4 --etp 1
     last_verified: 2026-07-23
     expected_result: >
-      One BF16 deterministic greedy run used an exact 32-token generation
-      limit and terminated on EOS after 29 generated tokens. The JSON-escaped
+      One BF16 deterministic greedy run terminated on EOS after 29 generated
+      tokens. The JSON-escaped
       literal completion was "\u003c|channel\u003ethought\n\u003cchannel|\u003eThe
       animal on the candy is a
       turtle.\u003cturn|\u003e\u003cturn|\u003e\u003cturn|\u003e\u002f\u002fthought\n\u003cchannel|\u003eThe
@@ -178,7 +179,7 @@ items:
       precision: bf16
       enabled_features: {}
       command: >
-        ./scripts/training/train.sh --nodes 1 --gpus-per-node 8
+        ./scripts/training/train.sh --nodes 2 --gpus-per-node 8
         --recipe gemma4_vl_26b_sft_config --mode sft --dataset cord-v2
         --pretrained_checkpoint work/model-verification/gemma-4-26b-a4b-it/imported-megatron/iter_0000000
         --max_steps 10 --seq_length 4096
@@ -186,6 +187,7 @@ items:
         validation.eval_iters=0 validation.eval_interval=0 checkpoint.load=null
         --save_dir work/model-verification/gemma-4-26b-a4b-it/sft-checkpoints
         --save_interval 10 logger.log_interval=1 logger.log_throughput=true
+        logger.save_config_filepath=work/model-verification/gemma-4-26b-a4b-it/sft-post-setup.yaml
       last_verified: null
       metrics:
         initial_loss: null
@@ -193,13 +195,19 @@ items:
         last_10_steps_step_time_ms_avg: null
         last_10_steps_model_tflops_per_gpu_avg: null
       expected_result: >
-        On 2026-07-23 the default 8-GPU TP2/PP1/EP8/ETP1 run and a GBS4
-        selective-MLP recompute run both failed before the first completed
-        optimizer step. Each rank had about 77.84 to 78.70 GiB in use and
-        needed an additional 1 to 2 GiB. Full 30-layer recompute crossed that
-        memory peak, but one GBS4 optimizer step did not finish during more
-        than nine observed minutes. No valid 10-step metrics or iter_0000010
-        checkpoint were produced, so SFT remains unverified.
+        On 2026-08-03 this exact real-CORD TP2/PP1/EP8 run loaded the immutable
+        BF16 checkpoint, persisted its post-setup configuration, and entered
+        iteration zero, but completed no optimizer step during 39 observed
+        minutes. A subset of ranks remained active while the others waited,
+        with no log growth, OOM, or traceback. A separate README-supported
+        single-node TP4/PP2/EP1 run with selective recompute and a frozen vision
+        encoder completed one optimizer step in 54,344.4 ms with lm loss
+        1.293086, grad norm 46.201, 1.8 TFLOP/s/GPU, zero skipped iterations,
+        and zero NaN iterations. Its second step then made no observable
+        progress for more than nine minutes while all four ranks on the second
+        pipeline stage remained active and the first stage waited. No valid
+        10-step metrics or iter_0000010 checkpoint were produced, so SFT
+        remains unverified.
 
   sft_export_inference:
     H100:

--- a/src/megatron/bridge/recipes/gemma4_vl/h100/gemma4_vl.py
+++ b/src/megatron/bridge/recipes/gemma4_vl/h100/gemma4_vl.py
@@ -110,8 +110,9 @@ def gemma4_vl_26b_sft_8gpu_h100_bf16_config() -> ConfigContainer:
     """Return a full SFT config for Gemma 4 VL 26B-A4B (MoE VLM).
 
     Default configuration: 8 GPUs
-    - TP=2, PP=1, EP=8 (max EP with 16 GPUs at TP=2,PP=1; DP=8, EP divides DP)
-    - No activation recompute — EP=8 shards 87.5% of expert params per GPU
+    - TP=4, PP=1, EP=8, ETP=1 (dense DP=2, expert DP=1)
+    - Selective core-attention and MoE-activation recompute
+    - Frozen vision encoder with trainable projection and language model
     - LR=5e-5 (full SFT)
     - Sequence length: 4096
     """
@@ -119,14 +120,26 @@ def gemma4_vl_26b_sft_8gpu_h100_bf16_config() -> ConfigContainer:
 
     _apply_gemma4_vl_common(cfg, _HF_PATH)
 
-    # Parallel settings — TP=2, PP=1, EP=8 on 2×8 GPUs
-    # DP = 16/(TP*PP) = 8; EP=8 shards experts across all DP ranks (1 expert replica)
-    cfg.model.tensor_model_parallel_size = 2
+    # The dense TP and expert EP meshes overlap: PP * max(TP, EP * ETP) = 8 GPUs.
+    # Dense DP = 8 / (TP * PP) = 2; expert DP = 8 / (PP * EP * ETP) = 1.
+    cfg.model.tensor_model_parallel_size = 4
     cfg.model.pipeline_model_parallel_size = 1
     cfg.model.pipeline_dtype = None
     cfg.model.virtual_pipeline_model_parallel_size = None
     cfg.model.context_parallel_size = 1
-    cfg.model.expert_model_parallel_size = 8  # override common EP=1
+    cfg.model.expert_model_parallel_size = 8
+    cfg.model.expert_tensor_parallel_size = 1
+
+    # Real CORD-v2 measurements require both modules to preserve H100 memory
+    # headroom after optimizer-state initialization. Full-layer recompute is not needed.
+    cfg.model.recompute_granularity = "selective"
+    cfg.model.recompute_modules = ["core_attn", "moe_act"]
+    cfg.model.recompute_method = None
+    cfg.model.recompute_num_layers = None
+
+    # Decoder-focused SFT keeps the vision encoder fixed while training the
+    # multimodal projection and language model.
+    cfg.model.freeze_vision_model = True
 
     # Reduce overhead to fit within 30-min wall time.
     # 40 iters × ~15s + 5 min init + 4 evals × 35s = ~20 min → 10 min for checkpoint save.
@@ -170,7 +183,8 @@ def gemma4_vl_26b_peft_4gpu_h100_bf16_config(
     """Return a PEFT (LoRA/DoRA) config for Gemma 4 VL 26B-A4B (MoE VLM).
 
     Default configuration: 4 GPUs
-    - TP=4, PP=1, EP=4 (PEFT needs less memory, drop PP)
+    - TP=2, PP=1, EP=4, ETP=1 (dense DP=2, expert DP=1)
+    - MBS=1, GBS=32
     - LR=2e-4 (PEFT)
     - Sequence length: 4096
 
@@ -194,7 +208,12 @@ def gemma4_vl_26b_peft_4gpu_h100_bf16_config(
     cfg.model.pipeline_dtype = None
     cfg.model.virtual_pipeline_model_parallel_size = None
     cfg.model.context_parallel_size = 1
-    cfg.model.expert_model_parallel_size = 4  # override common EP=1
+    cfg.model.expert_model_parallel_size = 4
+    cfg.model.expert_tensor_parallel_size = 1
+
+    # Real CORD-v2 measurements fit with substantial activation-memory headroom
+    # at MBS=1, so recompute and LoRA sequence-parallel input re-gather are not needed.
+    cfg.train.micro_batch_size = 1
 
     # Optimizer — higher LR for PEFT
     opt_cfg, scheduler_cfg = distributed_fused_adam_with_cosine_annealing(

--- a/src/megatron/bridge/training/pretrain.py
+++ b/src/megatron/bridge/training/pretrain.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+import os
 
 import torch.distributed as dist
 from nvidia_resiliency_ext.inprocess import CallWrapper
@@ -196,9 +197,19 @@ def _pretrain(
             )
 
         _finish_train(state, checkpoint_manager)
-    except BaseException:
+    except BaseException as error:
         if inprocess_call_wrapper is None:
-            _cleanup_after_pretrain_failure(state, should_destroy_process_group)
+            logger.exception(
+                "Pretrain failed on rank=%s with %s: %s. Bridge is aborting framework-owned distributed resources "
+                "because peer ranks may be blocked in collectives.",
+                _safe_distributed_rank(),
+                type(error).__name__,
+                error,
+            )
+            try:
+                _cleanup_after_pretrain_failure(state, should_destroy_process_group)
+            except BaseException:
+                logger.exception("Unexpected failure while cleaning up after pretrain failure")
         raise
 
     _maybe_destroy_process_group(should_destroy_process_group)
@@ -220,6 +231,16 @@ def _abort_async_checkpoint_worker(state: GlobalState) -> None:
                 filesystem_async._results_queue._manager.shutdown()
             finally:
                 filesystem_async._results_queue = None
+
+
+def _safe_distributed_rank() -> str:
+    """Return a rank identifier without obscuring an active training failure."""
+    try:
+        if dist.is_initialized():
+            return str(dist.get_rank())
+    except Exception:
+        pass
+    return os.environ.get("RANK", "unknown")
 
 
 def _cleanup_after_pretrain_failure(state: GlobalState, should_destroy_process_group: bool) -> None:

--- a/src/megatron/bridge/training/pretrain.py
+++ b/src/megatron/bridge/training/pretrain.py
@@ -235,19 +235,31 @@ def _cleanup_after_pretrain_failure(state: GlobalState, should_destroy_process_g
         logger.exception("Failed to destroy Megatron global state after pretrain failure")
 
     try:
-        _maybe_destroy_process_group(should_destroy_process_group, synchronize=False)
+        _maybe_destroy_process_group(should_destroy_process_group, synchronize=False, abort=True)
     except Exception:
-        logger.exception("Failed to destroy the process group after pretrain failure")
+        logger.exception("Failed to abort process groups after pretrain failure")
 
 
-def _maybe_destroy_process_group(should_destroy: bool, *, synchronize: bool = True) -> None:
-    """Destroy the process group if it was created by this training session.
+def _maybe_destroy_process_group(
+    should_destroy: bool,
+    *,
+    synchronize: bool = True,
+    abort: bool = False,
+) -> None:
+    """Destroy or abort process groups created by this training session.
 
     Args:
         should_destroy: Whether the process group should be destroyed
         synchronize: Whether to synchronize ranks before destruction
+        abort: Whether to abort all process groups instead of waiting for their
+            outstanding work to finish
     """
     if should_destroy and dist.is_initialized():
+        if abort:
+            # Orderly shutdown waits for outstanding collectives, but failure
+            # cleanup may run while peer ranks are still blocked in those calls.
+            dist.distributed_c10d._abort_process_group()
+            return
         if synchronize:
             dist.barrier()
         dist.destroy_process_group()

--- a/tests/unit_tests/recipes/test_gemma4_vl_recipes.py
+++ b/tests/unit_tests/recipes/test_gemma4_vl_recipes.py
@@ -49,3 +49,54 @@ def test_gemma4_vl_sft_uses_long_distributed_timeout(monkeypatch: pytest.MonkeyP
     cfg = _gemma4_vl_module.gemma4_vl_26b_sft_config()
 
     assert cfg.dist.distributed_timeout_minutes == 90
+
+
+def test_gemma4_vl_sft_uses_memory_stable_8gpu_contract(monkeypatch: pytest.MonkeyPatch):
+    """Full Gemma 4 VL SFT should use the measured single-node memory contract."""
+    patch_recipe_module_global(monkeypatch, _gemma4_vl_module, "AutoBridge", _FakeAutoBridge)
+
+    cfg = _gemma4_vl_module.gemma4_vl_26b_sft_config()
+
+    assert cfg.model.tensor_model_parallel_size == 4
+    assert cfg.model.pipeline_model_parallel_size == 1
+    assert cfg.model.context_parallel_size == 1
+    assert cfg.model.expert_model_parallel_size == 8
+    assert cfg.model.expert_tensor_parallel_size == 1
+    assert cfg.model.sequence_parallel is True
+    assert cfg.model.recompute_granularity == "selective"
+    assert cfg.model.recompute_modules == ["core_attn", "moe_act"]
+    assert cfg.model.recompute_method is None
+    assert cfg.model.recompute_num_layers is None
+    assert cfg.model.cuda_graph_impl == "none"
+    assert cfg.model.freeze_vision_model is True
+    assert cfg.model.freeze_vision_projection is False
+    assert cfg.model.freeze_language_model is False
+    assert cfg.train.micro_batch_size == 1
+    assert cfg.train.global_batch_size == 32
+    assert cfg.env_vars["PYTORCH_CUDA_ALLOC_CONF"] == "expandable_segments:True"
+
+
+def test_gemma4_vl_peft_uses_memory_stable_4gpu_contract(monkeypatch: pytest.MonkeyPatch):
+    """Gemma 4 VL PEFT should use the measured single-node LoRA contract."""
+    patch_recipe_module_global(monkeypatch, _gemma4_vl_module, "AutoBridge", _FakeAutoBridge)
+
+    cfg = _gemma4_vl_module.gemma4_vl_26b_peft_config()
+
+    assert cfg.model.tensor_model_parallel_size == 2
+    assert cfg.model.pipeline_model_parallel_size == 1
+    assert cfg.model.context_parallel_size == 1
+    assert cfg.model.expert_model_parallel_size == 4
+    assert cfg.model.expert_tensor_parallel_size == 1
+    assert cfg.model.sequence_parallel is True
+    assert cfg.model.recompute_granularity is None
+    assert cfg.model.recompute_modules is None
+    assert cfg.model.cuda_graph_impl == "none"
+    assert cfg.train.micro_batch_size == 1
+    assert cfg.train.global_batch_size == 32
+    assert cfg.peft.target_modules == ["linear_qkv", "linear_proj", "linear_fc1", "linear_fc2"]
+    assert cfg.peft.dim == 32
+    assert cfg.peft.alpha == 32
+    assert cfg.peft.dropout == 0.0
+    assert cfg.peft.sequence_parallel_input_regather is False
+    assert cfg.peft.share_expert_adapters is True
+    assert cfg.env_vars["PYTORCH_CUDA_ALLOC_CONF"] == "expandable_segments:True"

--- a/tests/unit_tests/training/test_pretrain.py
+++ b/tests/unit_tests/training/test_pretrain.py
@@ -64,12 +64,23 @@ class TestDestroyProcessGroupIfNeeded:
         mock_dist.barrier.assert_not_called()
         mock_dist.destroy_process_group.assert_not_called()
 
+    @patch("megatron.bridge.training.pretrain.dist")
+    def test_abort_does_not_wait_for_outstanding_collectives(self, mock_dist):
+        """Test failure cleanup aborts process groups without synchronization."""
+        mock_dist.is_initialized.return_value = True
+
+        _maybe_destroy_process_group(should_destroy=True, synchronize=False, abort=True)
+
+        mock_dist.distributed_c10d._abort_process_group.assert_called_once_with()
+        mock_dist.barrier.assert_not_called()
+        mock_dist.destroy_process_group.assert_not_called()
+
 
 class TestPretrainProcessGroupOwnership:
     """Test process group ownership across exceptional pretrain exits."""
 
-    def test_framework_owned_process_group_is_destroyed_when_setup_raises(self):
-        """Test Bridge destroys a process group initialized during failed setup."""
+    def test_framework_owned_process_group_is_aborted_when_setup_raises(self):
+        """Test Bridge aborts process groups initialized during failed setup."""
         state = MagicMock()
 
         with (
@@ -88,9 +99,10 @@ class TestPretrainProcessGroupOwnership:
 
         mock_destroy_global_state.assert_called_once_with()
         mock_dist.barrier.assert_not_called()
-        mock_dist.destroy_process_group.assert_called_once_with()
+        mock_dist.distributed_c10d._abort_process_group.assert_called_once_with()
+        mock_dist.destroy_process_group.assert_not_called()
 
-    def test_framework_owned_async_worker_is_aborted_before_process_group_destroyed(self):
+    def test_framework_owned_async_worker_is_aborted_before_process_groups(self):
         """Test failed setup aborts its async checkpoint worker before distributed cleanup."""
         state = MagicMock()
         async_queue = MagicMock()
@@ -109,12 +121,14 @@ class TestPretrainProcessGroupOwnership:
             patch("megatron.bridge.training.pretrain.setup", side_effect=setup_then_fail),
         ):
             mock_dist.is_initialized.side_effect = [False, True]
-            mock_dist.destroy_process_group.side_effect = lambda: cleanup_order.append(("process_group", None))
+            mock_dist.distributed_c10d._abort_process_group.side_effect = lambda: cleanup_order.append(
+                ("process_group", "abort")
+            )
 
             with pytest.raises(RuntimeError, match="setup failed after async worker initialization"):
                 _pretrain(state, MagicMock())
 
-        assert cleanup_order == [("async_queue", True), ("process_group", None)]
+        assert cleanup_order == [("async_queue", True), ("process_group", "abort")]
         assert state._async_calls_queue is None
 
     def test_caller_owned_process_group_is_preserved_when_setup_raises(self):

--- a/tests/unit_tests/training/test_pretrain.py
+++ b/tests/unit_tests/training/test_pretrain.py
@@ -14,6 +14,7 @@
 
 """Unit tests for pretrain module process group cleanup."""
 
+import logging
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -79,28 +80,80 @@ class TestDestroyProcessGroupIfNeeded:
 class TestPretrainProcessGroupOwnership:
     """Test process group ownership across exceptional pretrain exits."""
 
-    def test_framework_owned_process_group_is_aborted_when_setup_raises(self):
-        """Test Bridge aborts process groups initialized during failed setup."""
+    def test_framework_owned_failure_is_logged_before_cleanup_and_abort(self, caplog):
+        """Test Bridge logs the original failure before cleaning up framework-owned state."""
         state = MagicMock()
+        async_queue = MagicMock()
+        state._async_calls_queue = async_queue
+        original_error = RuntimeError("setup failed after distributed initialization")
+
+        def assert_failure_was_logged():
+            failure_records = [
+                record for record in caplog.records if record.getMessage().startswith("Pretrain failed")
+            ]
+            assert len(failure_records) == 1
 
         with (
             patch("megatron.bridge.training.pretrain.dist") as mock_dist,
             patch("megatron.bridge.training.pretrain.destroy_global_state") as mock_destroy_global_state,
             patch("megatron.bridge.training.pretrain.get_dataset_provider"),
-            patch(
-                "megatron.bridge.training.pretrain.setup",
-                side_effect=RuntimeError("setup failed after distributed initialization"),
-            ),
+            patch("megatron.bridge.training.pretrain.setup", side_effect=original_error),
         ):
-            mock_dist.is_initialized.side_effect = [False, True]
+            mock_dist.is_initialized.side_effect = [False, True, True]
+            mock_dist.get_rank.return_value = 7
+            async_queue.close.side_effect = lambda *, abort: assert_failure_was_logged()
+            mock_destroy_global_state.side_effect = assert_failure_was_logged
+            mock_dist.distributed_c10d._abort_process_group.side_effect = assert_failure_was_logged
 
-            with pytest.raises(RuntimeError, match="setup failed after distributed initialization"):
+            with (
+                caplog.at_level(logging.ERROR, logger="megatron.bridge.training.pretrain"),
+                pytest.raises(RuntimeError) as exc_info,
+            ):
                 _pretrain(state, MagicMock())
 
+        assert exc_info.value is original_error
         mock_destroy_global_state.assert_called_once_with()
         mock_dist.barrier.assert_not_called()
         mock_dist.distributed_c10d._abort_process_group.assert_called_once_with()
         mock_dist.destroy_process_group.assert_not_called()
+        failure_record = next(record for record in caplog.records if record.getMessage().startswith("Pretrain failed"))
+        failure_message = failure_record.getMessage()
+        assert "rank=7" in failure_message
+        assert "RuntimeError: setup failed after distributed initialization" in failure_message
+        assert "aborting framework-owned distributed resources" in failure_message
+        assert "peer ranks may be blocked in collectives" in failure_message
+        assert failure_record.exc_info is not None
+        assert failure_record.exc_info[1] is original_error
+        assert "Traceback (most recent call last)" in caplog.text
+        assert "RuntimeError: setup failed after distributed initialization" in caplog.text
+
+    def test_cleanup_failure_does_not_replace_original_failure(self, caplog):
+        """Test cleanup errors are logged while the original pretrain failure propagates."""
+        state = MagicMock()
+        original_error = RuntimeError("original setup failure")
+
+        with (
+            patch("megatron.bridge.training.pretrain.dist") as mock_dist,
+            patch(
+                "megatron.bridge.training.pretrain.destroy_global_state",
+                side_effect=RuntimeError("cleanup failure"),
+            ),
+            patch("megatron.bridge.training.pretrain.get_dataset_provider"),
+            patch("megatron.bridge.training.pretrain.setup", side_effect=original_error),
+        ):
+            mock_dist.is_initialized.side_effect = [False, True, True]
+            mock_dist.get_rank.return_value = 2
+
+            with (
+                caplog.at_level(logging.ERROR, logger="megatron.bridge.training.pretrain"),
+                pytest.raises(RuntimeError) as exc_info,
+            ):
+                _pretrain(state, MagicMock())
+
+        assert exc_info.value is original_error
+        messages = [record.getMessage() for record in caplog.records]
+        assert messages[0].startswith("Pretrain failed on rank=2 with RuntimeError: original setup failure")
+        assert "Failed to destroy Megatron global state after pretrain failure" in messages
 
     def test_framework_owned_async_worker_is_aborted_before_process_groups(self):
         """Test failed setup aborts its async checkpoint worker before distributed cleanup."""
@@ -120,7 +173,7 @@ class TestPretrainProcessGroupOwnership:
             patch("megatron.bridge.training.pretrain.get_dataset_provider"),
             patch("megatron.bridge.training.pretrain.setup", side_effect=setup_then_fail),
         ):
-            mock_dist.is_initialized.side_effect = [False, True]
+            mock_dist.is_initialized.side_effect = [False, True, True]
             mock_dist.distributed_c10d._abort_process_group.side_effect = lambda: cleanup_order.append(
                 ("process_group", "abort")
             )
@@ -159,6 +212,7 @@ class TestPretrainProcessGroupOwnership:
             patch("megatron.bridge.training.pretrain.destroy_global_state") as mock_destroy_global_state,
             patch("megatron.bridge.training.pretrain.get_dataset_provider"),
             patch("megatron.bridge.training.pretrain.setup", side_effect=RuntimeError("setup failed")),
+            patch("megatron.bridge.training.pretrain.logger.exception") as mock_logger_exception,
         ):
             mock_dist.is_initialized.return_value = False
 
@@ -172,5 +226,6 @@ class TestPretrainProcessGroupOwnership:
 
         mock_dist.PrefixStore.assert_called_once_with("1", store)
         mock_destroy_global_state.assert_not_called()
+        mock_logger_exception.assert_not_called()
         mock_dist.barrier.assert_not_called()
         mock_dist.destroy_process_group.assert_not_called()


### PR DESCRIPTION
## Summary

- prove that the Gemma4-VL SFT stall is not caused by a pipeline boundary shape or dtype mismatch
- log the original rank-local exception and traceback before exceptional cleanup begins
- abort framework-owned process groups during exceptional cleanup so a rank-local failure is surfaced instead of hidden behind outstanding collectives
- keep Gemma4-VL SFT unverified because the full-dimension workload still exceeds H100 memory
- correct the inference card leaf to unverified because the recorded run stopped after 29 of 32 requested tokens

## Root cause

A tiny structural Gemma4-VL proxy completed three optimizer steps for PP1, PP1/EP2, PP2 multimodal, and PP2 image-free controls. The PP2 path sent and received matching BF16 boundary tensors, all ranks consumed compatible metadata, and selective-recompute replay used the same shapes as forward.

A full-dimension random-initialized TP4/PP2/EP1 diagnostic preserved sequence length 4096, image expansion, frozen vision, selective recompute, 128 MoE experts, and GBS32. It completed step 1, then all first-stage ranks failed during step-2 microbatch 34 with the same 352 MiB CUDA OOM in the MoE combine reduce-scatter as NVBug 6491103. Second-stage ranks were waiting in pipeline send/receive. The apparent hang came from failed ranks entering orderly process-group destruction while peers still had outstanding collective work.

The fix changes only ordinary exceptional cleanup. Bridge now logs the active exception with rank context and its full traceback before cleanup, then uses the PyTorch process-group abort path for framework-owned distributed resources. Cleanup errors remain diagnostic-only and cannot replace the original exception. The in-process restart wrapper retains cleanup ownership and does not use this fatal path.

The same full-dimension diagnostic now reports the original OOM and terminates all ranks promptly. It does not claim to solve the underlying H100 memory limit.

The exact-checkpoint real-data rerun remains pending because that immutable artifact was not accessible from the available validation environment. No SFT verification status or checkpoint is claimed.

## Verification

- focused pretrain unit tests: 10 passed, including log-before-cleanup/abort ordering, rank/type/message/traceback context, original-exception identity, cleanup-error logging, and in-process restart ownership
- model-card validator: passed
- `uv run --active --no-sync pre-commit run --all-files`: passed
- tiny PP1/PP2 structural matrix: four configurations completed 3/3 optimizer steps
- full-dimension before fix: step 1 completed, step 2 OOM was masked by distributed cleanup
- full-dimension after abort fix: the same OOM was printed and all ranks exited promptly
- small PP2 blocked-peer failure diagnostic after the logging follow-up: the injected `torch.OutOfMemoryError` was logged with rank 0 and its full traceback before abort; both ranks exited about four seconds after injection, inside the 150-second fail-fast timeout

Strict mypy was also attempted on the changed production file; the repository checkout reported existing package-stub and untyped-decorator errors, with no new diagnostic on the abort call.
