### PR TITLE
build: support Transformers 5.14.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ classifiers = [
     "Topic :: Utilities",
 ]
 dependencies = [
-    "transformers>=5.8,<=5.12.1",
+    "transformers>=5.8,<=5.14.1",
     "mistral-common>=1.10.0",
     "peft>=0.18.1",
     "datasets>=2.20.0",

--- a/src/megatron/bridge/models/qwen_omni/modeling_qwen3_omni/thinker_model.py
+++ b/src/megatron/bridge/models/qwen_omni/modeling_qwen3_omni/thinker_model.py
@@ -28,7 +28,10 @@ from transformers.models.qwen3_omni_moe.modeling_qwen3_omni_moe import (
     Qwen3OmniMoeVisionEncoder as Qwen3OmniMoeVisionEncoderHF,
 )
 
-from megatron.bridge.models.qwen_omni.modeling_qwen3_omni.rope import get_rope_index
+from megatron.bridge.models.qwen_omni.modeling_qwen3_omni.rope import (
+    _get_feat_extract_output_lengths,
+    get_rope_index,
+)
 from megatron.bridge.models.qwen_omni.modeling_qwen3_omni.transformer_config import (
     Qwen3OmniTransformerConfig,
 )
@@ -337,7 +340,7 @@ class Qwen3OmniThinkerModel(MegatronModule):
         if expected_audio_token_counts is None:
             return audio_embeds
 
-        _, produced_output_lengths = self.audio_model._get_feat_extract_output_lengths(audio_feature_lengths)
+        produced_output_lengths = _get_feat_extract_output_lengths(audio_feature_lengths)
         expected_audio_token_counts = expected_audio_token_counts.to(produced_output_lengths.device)
 
         trimmed_embeds = []

--- a/tests/unit_tests/models/glm_moe_dsa/test_glm5_bridge.py
+++ b/tests/unit_tests/models/glm_moe_dsa/test_glm5_bridge.py
@@ -74,13 +74,12 @@ def _provider_from_hf_config(monkeypatch: pytest.MonkeyPatch, **config_overrides
     return GLM5Bridge().provider_bridge(SimpleNamespace(config=SimpleNamespace(**config)))
 
 
-def test_hf_config_ignores_upstream_num_experts_default() -> None:
-    """GLM-5 ignores the num_experts default injected by affected Transformers versions."""
+def test_hf_config_maps_authoritative_routed_expert_count() -> None:
+    """GLM-5 maps the routed-expert count across supported Transformers config shapes."""
     hf_config = GlmMoeDsaConfig(n_routed_experts=8)
 
     provider_kwargs = GLM5Bridge().hf_config_to_provider_kwargs(hf_config)
 
-    assert hf_config.num_experts == 256
     assert provider_kwargs["num_moe_experts"] == hf_config.n_routed_experts == 8
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = "==3.12.*"
 
 [options]
@@ -2100,7 +2100,7 @@ requires-dist = [
     { name = "timm" },
     { name = "torch", specifier = ">=2.6.0" },
     { name = "tqdm", specifier = ">=4.67.1" },
-    { name = "transformers", specifier = ">=5.8,<=5.12.1" },
+    { name = "transformers", specifier = ">=5.8,<=5.14.1" },
     { name = "typing-extensions" },
     { name = "wandb", specifier = ">=0.25.0" },
 ]
@@ -4624,7 +4624,7 @@ dependencies = [
 
 [[package]]
 name = "transformers"
-version = "5.12.1"
+version = "5.14.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
@@ -4637,9 +4637,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/aa/7c/8240f612819718100a9346dc28dea6a11370c3ca9c8c6eabadd3dea4ef29/transformers-5.12.1.tar.gz", hash = "sha256:679ee731c8225347889ad4fb3b2c926a62e9da3b7d284e9d12c791da7272466b", size = 8924054, upload-time = "2026-06-15T17:27:50.604Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/fb/2a2ba88f325e68a921d8b69ff63b477830b2e73ade9a3c8c8cab2f06d741/transformers-5.14.1.tar.gz", hash = "sha256:60d196c27781eacf8637e2b533f517582907ad6f9ae142046d6b69431a5b2173", size = 9295927, upload-time = "2026-07-16T09:41:57.773Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/56/bbd60dd8668055803bf8ba55a81f9b8a8b31497f620109a9671d26a2076d/transformers-5.12.1-py3-none-any.whl", hash = "sha256:2a5e109d2021265df7098ffbb738295acaf5ad256f12cbc586db2ea4dcbb1a8a", size = 11150587, upload-time = "2026-06-15T17:27:46.679Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/67/8d85ca2323233ae3c0365a659c4e52ee1f587b440e4bc577e7d8e4416d0f/transformers-5.14.1-py3-none-any.whl", hash = "sha256:9db974c4079ede2d1a3ea7ca5a240df33f2cc26fc2b36ba64c5f2a4f43b6e725", size = 11625234, upload-time = "2026-07-16T09:41:54.143Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# What does this PR do?

Extends Megatron Bridge support from Transformers 5.12.1 through 5.14.1.

# Changelog

- Raise Transformers upper bound from `<=5.12.1` to `<=5.14.1`.
- Regenerate `uv.lock` at Transformers 5.14.1.
- Update GLM-5 config coverage for Transformers 5.14.
- Keep Qwen3-Omni audio forward compatible with the Transformers 5.14 API change by using Bridge's existing audio-length helper.

# Why

[NovaSky-AI/SkyRL#1974](https://github.com/NovaSky-AI/SkyRL/pull/1974) adds GLM-5.2 config support but limits Transformers to 5.11 because of the Megatron Bridge compatibility range. SkyRL's GLM-5.2 stack works with Transformers 5.14.1, so raising Bridge's upper bound removes that constraint.

Transformers 5.14 also removed `Qwen3OmniMoeAudioEncoder._get_feat_extract_output_lengths`. Bridge still called that method, which broke Qwen3-Omni audio forward and its training smoke test. Bridge already has the matching length helper for Qwen3-Omni RoPE, so this PR uses it in the audio path too.

# GitHub Actions CI

Labels `needs-more-tests` and `full-test-suite` request H100 L0, L1, and L2 coverage against the locked maximum endpoint.

Local validation used the NVIDIA PyTorch 26.06 container on an RTX 5070 Ti with CUDA 13.3 and Transformers 5.14.1:

- `uv lock --check`
- 166 unit tests passed across Qwen3-Omni, Qwen2.5-Omni, Qwen3-ASR, Qwen2 Audio, Ministral3, and GLM-5
- Both Qwen3-Omni tests that failed in the first CI run passed on CUDA
- `uv run pre-commit run --all-files`

Full GLM-5.2 training and GB200 hardware were not tested locally. GB200 jobs are skipped for external-contributor PR runs, so this PR does not claim GB200 validation.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed contributor guidelines.
- [x] Existing tests cover the Transformers 5.14 regressions found by CI.
- [x] No documentation changes needed. Supported range is declared in package metadata.
- [x] No optional components added.

# Additional Information

- Follows [#4928](https://github.com/NVIDIA-NeMo/Megatron-Bridge/pull/4928), which expanded support through Transformers 5.12.1.
- Qwen3-ASR native registration protection from [#4876](https://github.com/NVIDIA-NeMo/Megatron-Bridge/pull/4876) is already on `main`.
- TorchAudio remains a downstream binary-pairing concern and is not added as a Bridge dependency.
- Minimum supported Transformers version remains 5.8.
