### PR TITLE
perf(recipe): add DeepSeek V4 Flash GB200 and GB300 FP8MX recipes

### DIFF
--- a/src/megatron/bridge/models/transformer_config.py
+++ b/src/megatron/bridge/models/transformer_config.py
@@ -110,12 +110,25 @@ def _enable_safe_hybridep_dispatch(config: MCoreTransformerConfig) -> None:
         or _uses_legacy_full_iteration(getattr(config, "cuda_graph_scope", None))
     )
     if (
-        config.moe_token_dispatcher_type == "flex"
-        and config.moe_flex_dispatcher_backend == "hybridep"
-        and not config.moe_hybridep_pad_uneven_dispatch_inputs
-        and not cuda_graphs_enabled
+        config.moe_token_dispatcher_type != "flex"
+        or config.moe_flex_dispatcher_backend != "hybridep"
+        or cuda_graphs_enabled
     ):
-        config.moe_hybridep_pad_uneven_dispatch_inputs = True
+        return
+
+    padding_fields = tuple(
+        field_name
+        for field_name in (
+            "moe_hybridep_pad_uneven_dispatch_inputs",
+            "moe_hybridep_pad_variable_tokens",
+        )
+        if hasattr(config, field_name)
+    )
+    if not padding_fields:
+        raise AttributeError("Megatron Core TransformerConfig does not expose a HybridEP uneven-input padding field")
+    for padding_field in padding_fields:
+        if not getattr(config, padding_field):
+            setattr(config, padding_field, True)
 
 
 @dataclass

--- a/src/megatron/bridge/perf_recipes/deepseek/__init__.py
+++ b/src/megatron/bridge/perf_recipes/deepseek/__init__.py
@@ -20,6 +20,9 @@ from megatron.bridge.perf_recipes.deepseek.gb200.deepseek_v3 import (
     deepseek_v3_pretrain_256gpu_gb200_fp8mx_partial_cg_dev_config,
     deepseek_v3_pretrain_256gpu_gb200_nvfp4_config,
 )
+from megatron.bridge.perf_recipes.deepseek.gb200.deepseek_v4 import (
+    deepseek_v4_flash_pretrain_128gpu_gb200_fp8mx_config,
+)
 from megatron.bridge.perf_recipes.deepseek.gb300.deepseek_v3 import (
     deepseek_v3_pretrain_64gpu_gb300_bf16_fsdp_config,
     deepseek_v3_pretrain_64gpu_gb300_fp8mx_fsdp_config,
@@ -32,6 +35,7 @@ from megatron.bridge.perf_recipes.deepseek.gb300.deepseek_v3 import (
     deepseek_v3_pretrain_256gpu_gb300_nvfp4_config,
 )
 from megatron.bridge.perf_recipes.deepseek.gb300.deepseek_v4 import (
+    deepseek_v4_flash_pretrain_128gpu_gb300_fp8mx_config,
     deepseek_v4_pro_pretrain_256gpu_gb300_fp8mx_config,
 )
 from megatron.bridge.perf_recipes.deepseek.h100.deepseek_v3 import (

--- a/src/megatron/bridge/perf_recipes/deepseek/gb200/deepseek_v4.py
+++ b/src/megatron/bridge/perf_recipes/deepseek/gb200/deepseek_v4.py
@@ -11,84 +11,102 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""GB300 performance recipes for DeepSeek V4."""
+"""GB200 performance recipes for DeepSeek V4."""
 
 import torch
 
 from megatron.bridge.perf_recipes._common import _benchmark_common
-from megatron.bridge.perf_recipes.deepseek.gb200.deepseek_v4 import (
-    deepseek_v4_flash_pretrain_128gpu_gb200_fp8mx_config,
-)
 from megatron.bridge.perf_recipes.environment import COMMON_PERF_ENV_VARS
-from megatron.bridge.recipes.deepseek.gb300.deepseek_v4 import (
-    deepseek_v4_pro_pretrain_32gpu_gb300_fp8mx_config,
+from megatron.bridge.recipes.deepseek.gb200.deepseek_v4 import (
+    deepseek_v4_flash_pretrain_64gpu_gb200_fp8mx_config,
 )
 from megatron.bridge.training.config import ConfigContainer
+from megatron.bridge.utils.cuda_graph import set_full_iteration_cuda_graph
 
 
-def deepseek_v4_flash_pretrain_128gpu_gb300_fp8mx_config() -> ConfigContainer:
-    """DeepSeek V4 Flash pretrain: 128× GB300, MXFP8."""
-    return deepseek_v4_flash_pretrain_128gpu_gb200_fp8mx_config()
-
-
-def deepseek_v4_pro_pretrain_256gpu_gb300_fp8mx_config() -> ConfigContainer:
-    """DeepSeek V4 Pro pretrain: 256× GB300, MXFP8, dev Megatron-Core required."""
-    cfg = deepseek_v4_pro_pretrain_32gpu_gb300_fp8mx_config()
+def deepseek_v4_flash_pretrain_128gpu_gb200_fp8mx_config() -> ConfigContainer:
+    """DeepSeek V4 Flash pretrain: 128× GB200, MXFP8, full-iteration CUDA graph."""
+    cfg = deepseek_v4_flash_pretrain_64gpu_gb200_fp8mx_config()
 
     cfg.model.tensor_model_parallel_size = 1
-    cfg.model.pipeline_model_parallel_size = 4
-    cfg.model.virtual_pipeline_model_parallel_size = 4
+    cfg.model.pipeline_model_parallel_size = 1
+    # The Sheet lists VPP=4, but the measured PP=1 W&B run resolves VPP to None.
+    cfg.model.virtual_pipeline_model_parallel_size = None
     cfg.model.context_parallel_size = 1
     cfg.model.expert_model_parallel_size = 64
     cfg.model.expert_tensor_parallel_size = 1
     cfg.model.sequence_parallel = False
-    cfg.train.global_batch_size = 4096
+    cfg.model.pipeline_model_parallel_layout = None
+    cfg.train.global_batch_size = 2048
     cfg.train.micro_batch_size = 1
 
+    cfg.model.attention_backend = "auto"
     cfg.model.moe_flex_dispatcher_backend = "hybridep"
     cfg.model.moe_token_dispatcher_type = "flex"
     cfg.model.moe_shared_expert_overlap = False
-    cfg.model.pipeline_model_parallel_layout = "Et*4|(tttt|)*14tmL"
+    cfg.model.moe_hybridep_num_sms = 32
+    cfg.model.moe_hybridep_num_sms_preprocessing = 108
+    cfg.model.moe_router_fusion = True
+    cfg.model.moe_router_force_load_balancing = True
+    cfg.model.moe_router_load_balancing_type = "seq_aux_loss"
+    cfg.model.moe_aux_loss_coeff = 1.0e-4
+
     cfg.model.recompute_granularity = "selective"
-    cfg.model.recompute_modules = ["mla_up_proj", "mhc"]
+    cfg.model.recompute_modules = ["mla_up_proj"]
+    cfg.model.recompute_method = None
+    cfg.model.recompute_num_layers = None
+    cfg.model.fine_grained_activation_offloading = False
+    cfg.model.offload_modules = []
+    cfg.model.fine_grained_offloading_max_inflight_offloads = None
 
     _benchmark_common(cfg, cross_entropy_impl="native")
 
-    cfg.model.cuda_graph_impl = "full_iteration"
-    cfg.model.cuda_graph_scope = []
+    set_full_iteration_cuda_graph(cfg.model)
     cfg.model.cuda_graph_warmup_steps = 3
     cfg.model.use_te_rng_tracker = True
     cfg.rng.te_rng_tracker = True
+    cfg.train.manual_gc_interval = 10
 
+    cfg.model.moe_expert_rank_capacity_factor = 1.5
     cfg.model.moe_pad_experts_for_cuda_graph_inference = True
     cfg.model.moe_paged_stash = True
-    cfg.model.moe_expert_rank_capacity_factor = 1.5
-    cfg.model.moe_paged_stash_buffer_size_factor_cuda = 1.2
+    cfg.model.moe_paged_stash_page_size = 64
     cfg.model.moe_paged_stash_buffer_size_factor_cpu = 0.0
-
-    cfg.model.moe_router_force_load_balancing = True
-    cfg.model.apply_dsa_kernel_fusion = True
-    cfg.model.use_transformer_engine_op_fuser = True
-    cfg.model.cross_entropy_loss_fusion = True
-    cfg.model.cross_entropy_fusion_impl = "native"
+    cfg.model.moe_paged_stash_buffer_size_factor_cuda = 1.2
     cfg.model.moe_mlp_glu_interleave_size = 32
+    cfg.model.use_transformer_engine_op_fuser = True
 
+    cfg.model.csa_compress_rotary_base = 40_000
+    cfg.model.rotary_scaling_factor = 4
+    cfg.model.apply_dsa_kernel_fusion = True
+    cfg.model.dsa_indexer_loss_coeff = 0.01
+    cfg.model.dsa_indexer_use_sparse_loss = True
     cfg.model.quant_recipe = None
+    cfg.model.moe_router_padding_for_fp8 = False
+    cfg.model.moe_router_padding_for_quantization = True
+
     cfg.mixed_precision.fp8_param_gather = True
     cfg.mixed_precision.reuse_grad_buf_for_mxfp8_param_ag = True
     cfg.mixed_precision.grad_reduce_in_fp32 = False
 
-    cfg.model.dsa_indexer_loss_coeff = 0.01
-    cfg.model.dsa_indexer_use_sparse_loss = True
+    cfg.optimizer.main_grads_dtype = torch.float32
+    cfg.optimizer.main_params_dtype = torch.float32
+    cfg.optimizer.exp_avg_dtype = torch.bfloat16
+    cfg.optimizer.exp_avg_sq_dtype = torch.bfloat16
+    cfg.optimizer.optimizer_offload_fraction = 1.0
+    cfg.optimizer.offload_optimizer_states = False
 
-    cfg.optimizer.main_grads_dtype = torch.bfloat16
-    cfg.dist.enable_megatron_core_experimental = True
+    cfg.ddp.overlap_param_gather = True
+    cfg.ddp.overlap_grad_reduce = True
     cfg.ddp.grad_reduce_in_fp32 = False
-
-    cfg.model.fine_grained_activation_offloading = True
-    cfg.model.offload_modules = ["core_attn", "attn_proj"]
-    cfg.model.fine_grained_offloading_max_inflight_offloads = 2
+    cfg.ddp.average_in_collective = False
     cfg.comm_overlap.overlap_grad_reduce = True
+    cfg.comm_overlap.overlap_moe_expert_parallel_comm = False
+    cfg.comm_overlap.delay_wgrad_compute = False
+
+    cfg.checkpoint.load_optim = False
+    cfg.checkpoint.load_rng = False
+    cfg.checkpoint.save_optim = False
 
     cfg.env_vars = {
         **COMMON_PERF_ENV_VARS,
@@ -102,7 +120,6 @@ def deepseek_v4_pro_pretrain_256gpu_gb300_fp8mx_config() -> ConfigContainer:
         "NVLINK_DOMAIN_SIZE": 72,
         "USE_MNNVL": 1,
         "NVTE_BWD_LAYERNORM_SM_MARGIN": 20,
-        "NVTE_CPU_OFFLOAD_V1": 1,
         "NVTE_CUTEDSL_FUSED_GROUPED_MLP": 1,
         "NVTE_FWD_LAYERNORM_SM_MARGIN": 20,
         "NVTE_NORM_BWD_USE_CUDNN": 1,

--- a/src/megatron/bridge/perf_recipes/deepseek/gb300/deepseek_v4.py
+++ b/src/megatron/bridge/perf_recipes/deepseek/gb300/deepseek_v4.py
@@ -28,7 +28,26 @@ from megatron.bridge.training.config import ConfigContainer
 
 def deepseek_v4_flash_pretrain_128gpu_gb300_fp8mx_config() -> ConfigContainer:
     """DeepSeek V4 Flash pretrain: 128× GB300, MXFP8."""
-    return deepseek_v4_flash_pretrain_128gpu_gb200_fp8mx_config()
+    cfg = deepseek_v4_flash_pretrain_128gpu_gb200_fp8mx_config()
+    cfg.env_vars = {
+        **COMMON_PERF_ENV_VARS,
+        "CUDA_DEVICE_MAX_CONNECTIONS": 32,
+        "NCCL_GRAPH_REGISTER": 0,
+        "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True,graph_capture_record_stream_reuse:True",
+        "TORCH_NCCL_AVOID_RECORD_STREAMS": 0,
+        "NCCL_NVLS_ENABLE": 0,
+        "NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN": 64,
+        "NUM_OF_TOKENS_PER_CHUNK_COMBINE_API": 128,
+        "NVLINK_DOMAIN_SIZE": 72,
+        "USE_MNNVL": 1,
+        "NVTE_BWD_LAYERNORM_SM_MARGIN": 20,
+        "NVTE_CUTEDSL_FUSED_GROUPED_MLP": 1,
+        "NVTE_FWD_LAYERNORM_SM_MARGIN": 20,
+        "NVTE_NORM_BWD_USE_CUDNN": 1,
+        "NVTE_NORM_FWD_USE_CUDNN": 1,
+        "NVTE_ALLOW_NONDETERMINISTIC_ALGO": 0,
+    }
+    return cfg
 
 
 def deepseek_v4_pro_pretrain_256gpu_gb300_fp8mx_config() -> ConfigContainer:

--- a/tests/unit_tests/models/test_transformer_config.py
+++ b/tests/unit_tests/models/test_transformer_config.py
@@ -15,6 +15,7 @@
 """Unit tests for megatron.bridge.models.transformer_config."""
 
 import json
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -24,6 +25,7 @@ from megatron.bridge.models.transformer_config import (
     HeterogeneousTransformerConfig,
     MLATransformerConfig,
     TransformerConfig,
+    _enable_safe_hybridep_dispatch,
     _resolve_string_fields,
 )
 
@@ -42,6 +44,31 @@ def _make_config(**kwargs) -> TransformerConfig:
     defaults = dict(num_layers=2, hidden_size=64, num_attention_heads=4)
     defaults.update(kwargs)
     return TransformerConfig(**defaults)
+
+
+class TestEnableSafeHybridepDispatch:
+    """Tests for cross-branch Megatron Core HybridEP padding compatibility."""
+
+    def test_enables_dev_padding_field(self):
+        cfg = SimpleNamespace(
+            moe_token_dispatcher_type="flex",
+            moe_flex_dispatcher_backend="hybridep",
+            moe_hybridep_pad_variable_tokens=False,
+            cuda_graph_impl="none",
+        )
+
+        _enable_safe_hybridep_dispatch(cfg)
+
+        assert cfg.moe_hybridep_pad_variable_tokens is True
+
+    def test_cuda_graph_config_does_not_require_padding_field(self):
+        cfg = SimpleNamespace(
+            moe_token_dispatcher_type="flex",
+            moe_flex_dispatcher_backend="hybridep",
+            cuda_graph_impl="full_iteration",
+        )
+
+        _enable_safe_hybridep_dispatch(cfg)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/recipes/test_deepseek_v4_flash_perf_recipes.py
+++ b/tests/unit_tests/recipes/test_deepseek_v4_flash_perf_recipes.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for the DeepSeek V4 Flash performance recipes."""
+
+import pytest
+import torch
+
+from megatron.bridge.perf_recipes.deepseek import (
+    deepseek_v4_flash_pretrain_128gpu_gb200_fp8mx_config,
+    deepseek_v4_flash_pretrain_128gpu_gb300_fp8mx_config,
+)
+from megatron.bridge.utils.cuda_graph import cuda_graph_module_names, is_full_iteration_cuda_graph
+from tests.unit_tests.recipes.recipe_test_utils import patch_recipe_construction_dependencies
+
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def _keep_recipe_construction_offline(monkeypatch: pytest.MonkeyPatch) -> None:
+    patch_recipe_construction_dependencies(monkeypatch)
+
+
+def test_deepseek_v4_flash_128gpu_gb200_fp8mx_config() -> None:
+    cfg = deepseek_v4_flash_pretrain_128gpu_gb200_fp8mx_config()
+
+    assert cfg.model.tensor_model_parallel_size == 1
+    assert cfg.model.pipeline_model_parallel_size == 1
+    assert cfg.model.virtual_pipeline_model_parallel_size is None
+    assert cfg.model.context_parallel_size == 1
+    assert cfg.model.expert_model_parallel_size == 64
+    assert cfg.model.expert_tensor_parallel_size == 1
+    assert cfg.model.sequence_parallel is False
+    assert cfg.model.pipeline_model_parallel_layout is None
+    assert cfg.train.global_batch_size == 2048
+    assert cfg.train.micro_batch_size == 1
+
+    assert cfg.model.moe_token_dispatcher_type == "flex"
+    assert cfg.model.moe_flex_dispatcher_backend == "hybridep"
+    assert cfg.model.moe_router_force_load_balancing is True
+    assert cfg.model.moe_hybridep_num_sms == 32
+    assert cfg.model.moe_hybridep_num_sms_preprocessing == 108
+    assert cfg.model.recompute_granularity == "selective"
+    assert cfg.model.recompute_modules == ["mla_up_proj"]
+
+    assert is_full_iteration_cuda_graph(cfg.model)
+    assert cuda_graph_module_names(cfg.model) == []
+    assert cfg.model.cuda_graph_warmup_steps == 3
+    assert cfg.model.use_te_rng_tracker is True
+    assert cfg.rng.te_rng_tracker is True
+    assert cfg.rerun_state_machine.check_for_nan_in_loss is False
+    assert cfg.ddp.check_for_nan_in_grad is False
+
+    assert cfg.model.moe_expert_rank_capacity_factor == 1.5
+    assert cfg.model.moe_pad_experts_for_cuda_graph_inference is True
+    assert cfg.model.moe_paged_stash is True
+    assert cfg.model.moe_paged_stash_page_size == 64
+    assert cfg.model.moe_paged_stash_buffer_size_factor_cpu == 0.0
+    assert cfg.model.moe_paged_stash_buffer_size_factor_cuda == 1.2
+    assert cfg.model.moe_mlp_glu_interleave_size == 32
+    assert cfg.model.use_transformer_engine_op_fuser is True
+
+    assert cfg.model.csa_compress_rotary_base == 40_000
+    assert cfg.model.rotary_scaling_factor == 4
+    assert cfg.model.apply_dsa_kernel_fusion is True
+    assert cfg.model.dsa_indexer_loss_coeff == 0.01
+    assert cfg.model.dsa_indexer_use_sparse_loss is True
+    assert cfg.model.cross_entropy_fusion_impl == "native"
+    assert cfg.model.quant_recipe is None
+    assert cfg.model.moe_router_padding_for_fp8 is False
+    assert cfg.model.moe_router_padding_for_quantization is True
+
+    assert cfg.mixed_precision.fp8_param_gather is True
+    assert cfg.mixed_precision.reuse_grad_buf_for_mxfp8_param_ag is True
+    assert cfg.optimizer.main_grads_dtype == torch.float32
+    assert cfg.optimizer.main_params_dtype == torch.float32
+    assert cfg.optimizer.exp_avg_dtype == torch.bfloat16
+    assert cfg.optimizer.exp_avg_sq_dtype == torch.bfloat16
+    assert cfg.optimizer.optimizer_offload_fraction == 1.0
+    assert cfg.optimizer.offload_optimizer_states is False
+    assert cfg.ddp.grad_reduce_in_fp32 is False
+    assert cfg.ddp.average_in_collective is False
+    assert cfg.comm_overlap.overlap_moe_expert_parallel_comm is False
+    assert cfg.comm_overlap.delay_wgrad_compute is False
+
+    assert cfg.checkpoint.load_optim is False
+    assert cfg.checkpoint.load_rng is False
+    assert cfg.checkpoint.save_optim is False
+    assert cfg.env_vars["PYTORCH_CUDA_ALLOC_CONF"] == (
+        "expandable_segments:True,graph_capture_record_stream_reuse:True"
+    )
+    assert cfg.env_vars["NCCL_GRAPH_REGISTER"] == 0
+    assert cfg.env_vars["TORCH_NCCL_AVOID_RECORD_STREAMS"] == 0
+    assert cfg.env_vars["CUDA_DEVICE_MAX_CONNECTIONS"] == 32
+    assert cfg.env_vars["NVTE_FWD_LAYERNORM_SM_MARGIN"] == 20
+    assert cfg.env_vars["NVTE_BWD_LAYERNORM_SM_MARGIN"] == 20
+    assert cfg.env_vars["NVTE_CUTEDSL_FUSED_GROUPED_MLP"] == 1
+    assert cfg.env_vars["NVLINK_DOMAIN_SIZE"] == 72
+    assert cfg.env_vars["USE_MNNVL"] == 1
+
+
+def test_deepseek_v4_flash_128gpu_gb300_fp8mx_config() -> None:
+    cfg = deepseek_v4_flash_pretrain_128gpu_gb300_fp8mx_config()
+
+    assert cfg.model.tensor_model_parallel_size == 1
+    assert cfg.model.pipeline_model_parallel_size == 1
+    assert cfg.model.virtual_pipeline_model_parallel_size is None
+    assert cfg.model.expert_model_parallel_size == 64
+    assert cfg.train.global_batch_size == 2048
+    assert cfg.train.micro_batch_size == 1
+    assert cfg.model.recompute_modules == ["mla_up_proj"]
+    assert is_full_iteration_cuda_graph(cfg.model)


### PR DESCRIPTION
## What does this PR do?

Ports the finalized DeepSeek V4 Flash 128-GPU MXFP8 benchmark recipes to `main`. This is the main-branch counterpart of [PR #5258](https://github.com/NVIDIA-NeMo/Megatron-Bridge/pull/5258), which targets `r0.6.0`.

The PR adds:

- `deepseek_v4_flash_pretrain_128gpu_gb200_fp8mx_config`
    - perf: ~724 TFLOPs/sec/GPU 
- `deepseek_v4_flash_pretrain_128gpu_gb300_fp8mx_config`
    - perf: ~758 TFLOPs/sec/GPU 

The GB200 recipe captures the benchmark configuration from row 9 of the performance sheet and its corresponding W&B run. The GB300 entry intentionally reuses that validated GB200 configuration while exposing the canonical GB300 recipe name expected by the performance launcher.

These are throughput benchmark recipes under `perf_recipes`; they are not production or convergence-training presets.

## Changelog

- Add the DeepSeek V4 Flash 128-GPU GB200 MXFP8 recipe.
- Add the canonical 128-GPU GB300 MXFP8 recipe backed by the same validated configuration.
- Export both recipes from the DeepSeek performance recipe package.
- Add focused unit coverage for recipe construction, topology, batching, CUDA graphs, MXFP8 settings, recompute, offload, and environment variables.

## Validation

- Ported files are byte-for-byte identical to the finalized `r0.6.0` PR branch.
- `python3 -m pre_commit run --all-files` — passed.
- Commit-time pre-commit hooks — passed.
- Python compilation for the changed recipe and unit-test files — passed.
- Exact recipe-name/export checks — passed.
- Focused pytest could not start in the clean linked worktree because its Megatron-LM submodule initialization timed out; no test result is claimed.

## References

- [DeepSeek V4 benchmark sheet](https://docs.google.com/spreadsheets/d/11Wv1uOO5ETri7CE74NSe_joh_f_GsjmKBPeFdQHHZL4/edit?gid=694334680#gid=694334680)
- [GB200 W&B run](https://wandb.ai/megatron-core-moe-dev/hongxiaob-deepseek-v4-flash-GB200-benchmark/runs/c7434c989f0b4b61bf64f8056a107be5)
- [Release-branch PR #5258](https://github.com/NVIDIA-NeMo/Megatron-Bridge/pull/5258)
- [Main-targeted nemo-ci MR !2762](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/merge_requests/2762)

## Before this PR is ready for review

- [x] Based on the latest `main` at creation time (`8dbc2977d`).
- [x] Read and followed the contributor guidelines.
- [x] Added focused unit coverage.
- [x] Added no dependencies or public API signature changes outside the new benchmark recipe exports.
