### PR TITLE
[training] fix: clean up CUDA graphs after final evaluation

### DIFF
--- a/src/megatron/bridge/training/train.py
+++ b/src/megatron/bridge/training/train.py
@@ -1527,6 +1527,7 @@ def _finish_train(global_state: GlobalState, checkpoint_manager: CheckpointManag
     if global_state._comet_logger:
         global_state._comet_logger.end()
 
+    _delete_cuda_graphs(None)
     destroy_global_state()
 
 
@@ -1636,7 +1637,7 @@ def _handle_mxfp8_param_buffer_copy(
                     optim_instance._copy_main_params_to_param_buffer()
 
 
-def _delete_cuda_graphs(cuda_graph_helper: TECudaGraphHelper):
+def _delete_cuda_graphs(cuda_graph_helper: TECudaGraphHelper | None):
     """
     Delete the CUDA graph object as they hold a reference to the some of the nccl buffers, thus blocking the
     process-destory (torch.dist.destroy_process_group()) at the end of the training loop.

--- a/tests/unit_tests/training/test_train.py
+++ b/tests/unit_tests/training/test_train.py
@@ -25,6 +25,7 @@ from megatron.core.optimizer.distrib_optimizer import DistributedOptimizer
 from megatron.bridge.training.train import (
     _delete_cuda_graphs,
     _dummy_train_step,
+    _finish_train,
     _handle_mxfp8_param_buffer_copy,
     _maybe_register_fsdp_buffers,
     _should_skip_and_handle_iteration,
@@ -45,6 +46,32 @@ pytestmark = pytest.mark.unit
 
 class TestCudaGraphCleanup:
     """Unit tests for CUDA graph state cleanup."""
+
+    def test_finish_train_deletes_recaptured_validation_graph_before_global_teardown(self):
+        """Final cleanup must delete CUDA graphs captured by post-training validation."""
+        from megatron.core.full_cuda_graph import FullCudaGraphWrapper
+
+        validation_graph = Mock()
+        state = Mock()
+        state.wandb_logger = None
+        state._comet_logger = None
+        checkpoint_manager = Mock()
+
+        def assert_graph_deleted():
+            assert FullCudaGraphWrapper.cuda_graph["validation"] is None
+            assert FullCudaGraphWrapper.result["validation"] is None
+            assert FullCudaGraphWrapper.curr_iteration["validation"] == 0
+
+        with (
+            patch.object(FullCudaGraphWrapper, "cuda_graph", {"training": None, "validation": validation_graph}),
+            patch.object(FullCudaGraphWrapper, "result", {"training": None, "validation": object()}),
+            patch.object(FullCudaGraphWrapper, "curr_iteration", {"training": 0, "validation": 1}),
+            patch("megatron.bridge.training.train.safe_shutdown_nvrx_straggler_manager"),
+            patch("megatron.bridge.training.train.fault_tolerance"),
+            patch("megatron.bridge.training.train.destroy_global_state", side_effect=assert_graph_deleted),
+            patch("megatron.bridge.training.train.gc.collect"),
+        ):
+            _finish_train(state, checkpoint_manager)
 
     @patch("megatron.bridge.training.train.gc.collect")
     def test_delete_cuda_graphs_restores_full_graph_state(self, mock_collect):


### PR DESCRIPTION
## What changed

Clean up process-global local CUDA graph state after terminal validation and test evaluation, immediately before the framework tears down global distributed state.

## Supported trigger and impact

When a training run uses local full-iteration CUDA graphs and performs terminal validation or test evaluation, the normal end-of-training cleanup runs before that evaluation. Evaluation can then recapture the process-global validation graph. The graph can retain NCCL-backed references when the process group is destroyed, causing an otherwise successful distributed training job to hang during shutdown.

The runtime path is:

`train()` cleanup -> terminal validation/test graph capture -> `_finish_train()` -> distributed process-group teardown

## Root cause and fix

The existing cleanup boundary covered graphs captured during `train()`, but not graphs recaptured by the subsequent terminal evaluation path. `_finish_train()` now calls `_delete_cuda_graphs(None)` before `destroy_global_state()`. The helper already supports deleting process-global graph state without a training helper; its annotation now reflects that contract.

This is intentionally scoped to cleanup of the existing local full-iteration CUDA graph state. It does not change Transformer Engine scoped graph behavior or graph capture semantics.

## Validation

Failing before the production fix:

```text
uv run --active --no-sync python -m pytest tests/unit_tests/training/test_train.py::TestCudaGraphCleanup::test_finish_train_deletes_recaptured_validation_graph_before_global_teardown -q
# 1 failed: validation CUDA graph remained live at global teardown
```

Passing after the fix:

```text
uv run --active --no-sync python -m pytest tests/unit_tests/training/test_train.py::TestCudaGraphCleanup::test_finish_train_deletes_recaptured_validation_graph_before_global_teardown -q
# 1 passed

uv run --active --no-sync python -m pytest tests/unit_tests/training/test_train.py::TestCudaGraphCleanup -q
# 2 passed
```

A two-rank TP=2 mock-data training reproducer with local full-iteration graphs, terminal validation, and terminal test timed out during process-group teardown before the fix. The unchanged workflow completed with exit status 0 after the fix.

```text
git diff --check
# passed

uv run --active --no-sync pre-commit run --all-files
# all hooks passed
```

## Scope limitations

Validation used a minimal mock GPT configuration and two distributed ranks. It establishes graph lifetime and shutdown behavior; it does not claim model-quality, convergence, performance, or full-suite validation.
