### PR TITLE
[recipes] fix: use Nemotron 3.5 Lightning checkpoint

### DIFF
--- a/examples/model_verification_cards/nemotron-3.5-nano/card.yaml
+++ b/examples/model_verification_cards/nemotron-3.5-nano/card.yaml
@@ -1,4 +1,4 @@
-# Agent-readable model verification card for Nemotron 3.5 Nano.
+# Agent-readable model verification card for Nemotron 3.5 Lightning.
 # status: unverified | verified | unsupported | not_applicable
 
 title: nemotron_3_5_nano
@@ -11,10 +11,11 @@ summary: >
   while adopting the corresponding hardware performance recipe's execution
   stack. The H100 performance leaf uses BF16 Adam moments in a benchmark-only
   workload and is not convergence-comparable with FP32 optimizer-state runs.
-  Nemotron 3.5 Nano support verification covers conversion, inference, and
-  training on H100 and GB200. The
-  model.hf_id/--hf-model and model.hf_revision/--hf-revision values are
-  non-functional placeholders pending publication.
+  Nemotron 3.5 Lightning support verification covers conversion, inference,
+  and training on H100 and GB200. The legacy Nano recipe and verification-card
+  names remain stable compatibility identifiers. The evidence used the 26.08
+  release-candidate software stack; the environment records its corresponding
+  public 26.08 base container.
 verification_index:
   model_level:
     verified:
@@ -35,12 +36,12 @@ verification_index:
   fsdp:
     GB200: verified
 model:
-  hf_id: nvidia/NVIDIA-Nemotron-3.5-Nano-30B-A3B-BF16
-  hf_revision: PUBLIC_HF_REVISION_PENDING
+  hf_id: nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16
+  hf_revision: b3caaabed0263651a17dc1f2d4ce97e794f76c44
   architecture: NemotronHForCausalLM
   min_transformers_version: "5.8.1"
 verification_environment:
-  base_container: nvcr.io/nvidian/nemo:26.08.rc2
+  base_container: nvcr.io/nvidia/nemo:26.08
   bridge_commit: 619a2df1da9517b4408ea475b428bf2aba618c8f  # pragma: allowlist secret
 
 items:
@@ -50,8 +51,8 @@ items:
     bridge_commit: 7edd7c7f68bcdd2b30cbaff426ece2ee0da9deb5  # pragma: allowlist secret
     command: >
       ./scripts/conversion/convert.sh import --executor slurm --device cpu --nodes 1
-      --hf-model nvidia/NVIDIA-Nemotron-3.5-Nano-30B-A3B-BF16
-      --hf-revision PUBLIC_HF_REVISION_PENDING
+      --hf-model nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16
+      --hf-revision b3caaabed0263651a17dc1f2d4ce97e794f76c44
       --megatron-path work/model-verification/nemotron-3.5-nano/cpu-megatron
       --torch-dtype bfloat16
     last_verified: 2026-07-23
@@ -67,8 +68,8 @@ items:
     command: >
       ./scripts/conversion/convert.sh import --executor slurm --device gpu
       --nodes 1 --gpus-per-node 8 --tp 1 --pp 1 --ep 8 --etp 1
-      --hf-model nvidia/NVIDIA-Nemotron-3.5-Nano-30B-A3B-BF16
-      --hf-revision PUBLIC_HF_REVISION_PENDING
+      --hf-model nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16
+      --hf-revision b3caaabed0263651a17dc1f2d4ce97e794f76c44
       --megatron-path work/model-verification/nemotron-3.5-nano/imported-megatron
       --torch-dtype bfloat16
     last_verified: 2026-07-23
@@ -84,8 +85,8 @@ items:
     bridge_commit: 7edd7c7f68bcdd2b30cbaff426ece2ee0da9deb5  # pragma: allowlist secret
     command: >
       ./scripts/conversion/convert.sh export --executor slurm --device cpu --nodes 1
-      --hf-model nvidia/NVIDIA-Nemotron-3.5-Nano-30B-A3B-BF16
-      --hf-revision PUBLIC_HF_REVISION_PENDING
+      --hf-model nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16
+      --hf-revision b3caaabed0263651a17dc1f2d4ce97e794f76c44
       --megatron-path work/model-verification/nemotron-3.5-nano/cpu-megatron/iter_0000000
       --hf-path work/model-verification/nemotron-3.5-nano/cpu-hf-export
       --torch-dtype bfloat16
@@ -101,8 +102,8 @@ items:
     command: >
       ./scripts/conversion/convert.sh export --executor slurm --device gpu
       --nodes 1 --gpus-per-node 8 --tp 1 --pp 1 --ep 8 --etp 1
-      --hf-model nvidia/NVIDIA-Nemotron-3.5-Nano-30B-A3B-BF16
-      --hf-revision PUBLIC_HF_REVISION_PENDING
+      --hf-model nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16
+      --hf-revision b3caaabed0263651a17dc1f2d4ce97e794f76c44
       --megatron-path work/model-verification/nemotron-3.5-nano/imported-megatron/iter_0000000
       --hf-path work/model-verification/nemotron-3.5-nano/hf-export
       --torch-dtype bfloat16 --distributed-save
@@ -118,8 +119,8 @@ items:
     command: >
       uv run python -m torch.distributed.run --standalone --nproc_per_node=8
       examples/conversion/compare_hf_and_megatron/compare.py
-      --hf_model_path nvidia/NVIDIA-Nemotron-3.5-Nano-30B-A3B-BF16
-      --hf-revision PUBLIC_HF_REVISION_PENDING
+      --hf_model_path nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16
+      --hf-revision b3caaabed0263651a17dc1f2d4ce97e794f76c44
       --megatron_model_path work/model-verification/nemotron-3.5-nano/imported-megatron/iter_0000000
       --tp 1 --pp 1 --ep 8 --etp 1
       --prompt "The capital of France is the city of"
@@ -136,8 +137,8 @@ items:
     command: >
       uv run python -m torch.distributed.run --standalone --nproc_per_node=8
       examples/conversion/hf_to_megatron_generate_text.py
-      --hf_model_path nvidia/NVIDIA-Nemotron-3.5-Nano-30B-A3B-BF16
-      --hf-revision PUBLIC_HF_REVISION_PENDING
+      --hf_model_path nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16
+      --hf-revision b3caaabed0263651a17dc1f2d4ce97e794f76c44
       --megatron_model_path work/model-verification/nemotron-3.5-nano/imported-megatron/iter_0000000
       --tp 1 --pp 1 --ep 8 --etp 1
       --prompt "The capital of France is" --max_new_tokens 2
@@ -327,17 +328,17 @@ items:
         --mode sft --max_steps 100
         --pretrained_checkpoint work/model-verification/nemotron-3.5-nano-h100/imported-megatron/iter_0000000
         --save_dir work/model-verification/nemotron-3.5-nano-h100/sft-checkpoints
-      last_verified: 2026-07-30
+      last_verified: 2026-08-03
       metrics:
-        initial_loss: 0.4407026
-        final_loss: 0.2756689
-        last_10_steps_step_time_ms_avg: 9856.900
-        last_10_steps_model_tflops_per_gpu_avg: 79.470
+        initial_loss: 0.4406566
+        final_loss: 0.2757806
+        last_10_steps_step_time_ms_avg: 9887.800
+        last_10_steps_model_tflops_per_gpu_avg: 79.240
       expected_result: >
         Packed OpenMathInstruct-2 full SFT completes 100 finite-loss steps with
-        active MTP gradients, LM loss 0.4407026 -> 0.2756689, finite MTP-1
-        loss 0.7634735 -> 0.4076096, and no skipped or NaN iterations. Steps
-        91-100 average 9,856.900 ms / 79.470 TFLOP/s/GPU, and the complete
+        active MTP gradients, LM loss 0.4406566 -> 0.2757806, finite MTP-1
+        loss 0.7371141 -> 0.4133309, and no skipped or NaN iterations. Steps
+        91-100 average 9,887.800 ms / 79.240 TFLOP/s/GPU, and the complete
         reloadable full-model checkpoint is written at step 100.
 
     GB200:
@@ -354,21 +355,21 @@ items:
         --mode sft --max_steps 100
         --pretrained_checkpoint work/model-verification/nemotron-3.5-nano-gb200/imported-megatron/iter_0000000
         --save_dir work/model-verification/nemotron-3.5-nano-gb200/sft-checkpoints
-      last_verified: 2026-07-30
+      last_verified: 2026-08-04
       metrics:
         initial_loss: 0.4407797
-        final_loss: 0.2760494
-        last_10_steps_step_time_ms_avg: 6697.760
-        last_10_steps_model_tflops_per_gpu_avg: 260.770
-        peak_allocated_memory_gib: 101.640
-        peak_reserved_memory_gib: 104.100
+        final_loss: 0.2762039
+        last_10_steps_step_time_ms_avg: 6795.830
+        last_10_steps_model_tflops_per_gpu_avg: 256.990
+        peak_allocated_memory_gib: 101.510
+        peak_reserved_memory_gib: 103.960
       expected_result: >
         On two complete four-GPU GB200 nodes in one segment-2 NVLink domain,
         packed OpenMathInstruct-2 full SFT completes exactly 100 finite-loss
         optimizer steps with active MTP gradients. LM loss is 0.4407797 ->
-        0.2760494, MTP-1 loss is 0.7641921 -> 0.4087451, and MTP-2 loss is
-        0.8651200 -> 0.4649736. Steps 91-100 average 6,697.760 ms / 260.770
-        TFLOP/s/GPU with 101.640 GiB peak allocated and 104.100 GiB peak
+        0.2762039, MTP-1 loss is 0.7373838 -> 0.4146959, and MTP-2 loss is
+        0.8092746 -> 0.4744196. Steps 91-100 average 6,795.830 ms / 256.990
+        TFLOP/s/GPU with 101.510 GiB peak allocated and 103.960 GiB peak
         reserved memory. No iteration is skipped or NaN, and the complete
         12-file reloadable full-model checkpoint is written at step 100.
 
@@ -381,8 +382,8 @@ items:
         - >
           ./scripts/conversion/convert.sh export --executor slurm --device gpu
           --nodes 2 --gpus-per-node 8 --tp 2 --pp 1 --ep 8 --etp 1
-          --hf-model nvidia/NVIDIA-Nemotron-3.5-Nano-30B-A3B-BF16
-          --hf-revision PUBLIC_HF_REVISION_PENDING
+          --hf-model nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16
+          --hf-revision b3caaabed0263651a17dc1f2d4ce97e794f76c44
           --megatron-path work/model-verification/nemotron-3.5-nano-h100/sft-checkpoints/iter_0000100
           --hf-path work/model-verification/nemotron-3.5-nano-h100/sft-hf-export
           --torch-dtype bfloat16 --export-weight-dtype bfloat16
@@ -392,7 +393,7 @@ items:
           --hf-model work/model-verification/nemotron-3.5-nano-h100/sft-hf-export
           --prompt "Solve briefly: If 3x + 5 = 20, what is x?"
           --max-new-tokens 45 --chat-template --disable-thinking
-      last_verified: 2026-07-30
+      last_verified: 2026-08-03
       expected_result: "The step-100 SFT checkpoint exports 6,513 tensors, including all 270 MTP tensors, to native Hugging Face format and reloads as NemotronHForCausalLM. The deterministic verifier performs one greedy generation and produces exactly 45 new tokens. The literal completion is: \"To solve for \u0024x\u0024, follow these steps:\n\n1. Subtract 5 from both sides of the equation:\n\\[ 3x + 5 - 5 = 20 - 5 \\Rightarrow 3x\"."
 
     GB200:
@@ -404,8 +405,8 @@ items:
         - >
           ./scripts/conversion/convert.sh export --executor slurm --device gpu
           --nodes 2 --gpus-per-node 4 --tp 1 --pp 1 --ep 8 --etp 1
-          --hf-model nvidia/NVIDIA-Nemotron-3.5-Nano-30B-A3B-BF16
-          --hf-revision PUBLIC_HF_REVISION_PENDING
+          --hf-model nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16
+          --hf-revision b3caaabed0263651a17dc1f2d4ce97e794f76c44
           --megatron-path work/model-verification/nemotron-3.5-nano-gb200/sft-checkpoints/iter_0000100
           --hf-path work/model-verification/nemotron-3.5-nano-gb200/sft-hf-export
           --torch-dtype bfloat16 --export-weight-dtype bfloat16
@@ -415,7 +416,7 @@ items:
           --hf-model work/model-verification/nemotron-3.5-nano-gb200/sft-hf-export
           --prompt "Solve briefly: If 3x + 5 = 20, what is x?"
           --max-new-tokens 45 --chat-template --disable-thinking
-      last_verified: 2026-07-30
+      last_verified: 2026-08-04
       expected_result: "The step-100 SFT checkpoint exports 6,513 tensors, including all 270 MTP tensors, to native Hugging Face format and reloads as NemotronHForCausalLM. The deterministic verifier performs one greedy generation and produces exactly 45 new tokens. The literal completion is: \"To solve for \u0024x\u0024, follow these steps:\n\n1. Subtract 5 from both sides of the equation:\n\\[ 3x + 5 - 5 = 20 - 5 \\Rightarrow 3x\"."
 
   sft_long_context:
@@ -449,17 +450,17 @@ items:
         --save_dir work/model-verification/nemotron-3.5-nano-h100/long-sft-checkpoints
         --save_interval 50 logger.log_interval=1 logger.log_throughput=true
         logger.tensorboard_dir=null
-      last_verified: 2026-07-30
+      last_verified: 2026-08-03
       metrics:
         initial_loss: 0.4268321
-        final_loss: 0.2649768
-        last_10_steps_step_time_ms_avg: 40995.130
-        last_10_steps_model_tflops_per_gpu_avg: 188.280
+        final_loss: 0.2650192
+        last_10_steps_step_time_ms_avg: 40863.010
+        last_10_steps_model_tflops_per_gpu_avg: 188.950
       expected_result: >
         Packed OpenMathInstruct-2 CP2 SFT completes exactly 100 finite-loss 32K
-        steps with LM loss 0.4268321 -> 0.2649768 and MTP-1 loss 0.7375677 ->
-        0.4385137. All 100 steps have finite LM/MTP losses and no skipped or
-        NaN iterations. Steps 91-100 average 40,995.130 ms / 188.280
+        steps with LM loss 0.4268321 -> 0.2650192 and MTP-1 loss 0.7322379 ->
+        0.4439273. All 100 steps have finite LM/MTP losses and no skipped or
+        NaN iterations. Steps 91-100 average 40,863.010 ms / 188.950
         TFLOP/s/GPU. Complete step-50 and step-100 checkpoints each contain 20
         files, distributed metadata, saved run configuration and training
         state, with latest marker 100.
@@ -495,19 +496,20 @@ items:
         --save_dir work/model-verification/nemotron-3.5-nano-gb200/long-sft-checkpoints
         --save_interval 100 logger.log_interval=1 logger.log_throughput=true
         logger.tensorboard_dir=null
-      last_verified: 2026-07-30
+      last_verified: 2026-08-04
       metrics:
         initial_loss: 0.4268995
-        final_loss: 0.2649511
-        last_10_steps_step_time_ms_avg: 100358.390
-        last_10_steps_model_tflops_per_gpu_avg: 153.810
+        final_loss: 0.2649925
+        last_10_steps_step_time_ms_avg: 129692.530
+        last_10_steps_model_tflops_per_gpu_avg: 119.030
       expected_result: >
         Packed OpenMathInstruct-2 CP2 SFT completes exactly 100 finite-loss 32K
-        steps with LM loss 0.4268995 -> 0.2649511 and MTP-1 loss 0.7376469 ->
-        0.4384451. All 100 steps have finite LM/MTP losses and no skipped or
-        NaN iterations. The complete step-100 checkpoint has distributed
-        metadata, 12 files, a latest marker of 100, and all four metrics
-        recorded.
+        steps with LM loss 0.4268995 -> 0.2649925 and MTP-1 loss 0.7322624 ->
+        0.4439029. All 100 steps have finite LM/MTP losses and no skipped or
+        NaN iterations. Steps 91-100 average 129,692.530 ms / 119.030
+        TFLOP/s/GPU. The complete step-100 checkpoint has distributed metadata,
+        saved run configuration and training state, 12 files, and a latest
+        marker of 100.
 
   peft:
     H100:
@@ -534,16 +536,16 @@ items:
         --save_dir work/model-verification/nemotron-3.5-nano-h100/peft-checkpoints
         --save_interval 100 logger.log_interval=1 logger.log_throughput=true
         logger.tensorboard_dir=null
-      last_verified: 2026-07-30
+      last_verified: 2026-08-03
       metrics:
-        initial_loss: 0.4406879
-        final_loss: 0.2856177
-        last_10_steps_step_time_ms_avg: 16927.070
-        last_10_steps_model_tflops_per_gpu_avg: 92.650
+        initial_loss: 0.4406696
+        final_loss: 0.2854756
+        last_10_steps_step_time_ms_avg: 16900.360
+        last_10_steps_model_tflops_per_gpu_avg: 92.890
       expected_result: >
         Packed rank-32, alpha-32, zero-dropout LoRA completes 100 finite-loss
-        steps with adapters on the MTP layers, LM loss 0.4406879 -> 0.2856177,
-        finite MTP-1 loss 0.7634883 -> 0.4294895, and no skipped or NaN
+        steps with adapters on the MTP layers, LM loss 0.4406696 -> 0.2854756,
+        finite MTP-1 loss 0.7370828 -> 0.4362708, and no skipped or NaN
         iterations. The complete adapter checkpoint is written at step 100 and
         reloads over the pinned base checkpoint at step 100.
 
@@ -572,19 +574,19 @@ items:
         --save_dir work/model-verification/nemotron-3.5-nano-gb200/peft-checkpoints
         --save_interval 100 logger.log_interval=1 logger.log_throughput=true
         logger.tensorboard_dir=null
-      last_verified: 2026-07-30
+      last_verified: 2026-08-04
       metrics:
-        initial_loss: 0.4405894
-        final_loss: 0.2855471
-        last_10_steps_step_time_ms_avg: 19163.540
-        last_10_steps_model_tflops_per_gpu_avg: 82.080
+        initial_loss: 0.4406088
+        final_loss: 0.2855029
+        last_10_steps_step_time_ms_avg: 19230.400
+        last_10_steps_model_tflops_per_gpu_avg: 81.780
       expected_result: >
         Packed rank-32, alpha-32, zero-dropout LoRA completes 100 finite-loss
         steps with 48 rank-local adapter attachment records covering MTP
-        attention, expert, and shared-expert layers, finite MTP losses, no
-        skipped or NaN iterations, and all four metrics recorded. The complete
-        adapter checkpoint is written at step 100 and reloads over the pinned
-        base checkpoint at step 100.
+        attention, expert, and shared-expert layers, LM loss 0.4406088 ->
+        0.2855029, finite MTP-1 loss 0.7371238 -> 0.4362065, and no skipped or
+        NaN iterations. The complete adapter checkpoint is written at step 100
+        and reloads over the pinned base checkpoint at step 100.
 
   checkpoint_resume:
     H100:

--- a/examples/model_verification_cards/nemotron-3.5-nano/card.yaml
+++ b/examples/model_verification_cards/nemotron-3.5-nano/card.yaml
@@ -37,7 +37,7 @@ verification_index:
     GB200: verified
 model:
   hf_id: nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16
-  hf_revision: b3caaabed0263651a17dc1f2d4ce97e794f76c44
+  hf_revision: b3caaabed0263651a17dc1f2d4ce97e794f76c44  # pragma: allowlist secret
   architecture: NemotronHForCausalLM
   min_transformers_version: "5.8.1"
 verification_environment:

--- a/src/megatron/bridge/perf_recipes/nemotronh/gb200/nemotronh.py
+++ b/src/megatron/bridge/perf_recipes/nemotronh/gb200/nemotronh.py
@@ -30,8 +30,9 @@ from megatron.bridge.perf_recipes.nemotronh.common import (
 from megatron.bridge.utils.cuda_graph import set_cuda_graph_modules
 
 
-# Placeholder until the public Nemotron 3.5 Nano repository is released.
-_NEMOTRON_3_5_NANO_MODEL_ID = "nvidia/NVIDIA-Nemotron-3.5-Nano-30B-A3B-BF16"
+# Public Nemotron 3.5 Lightning checkpoint used by the legacy Nano recipe API.
+_NEMOTRON_3_5_NANO_MODEL_ID = "nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16"
+_NEMOTRON_3_5_NANO_MODEL_REVISION = "b3caaabed0263651a17dc1f2d4ce97e794f76c44"  # pragma: allowlist secret
 
 
 def nemotronh_56b_pretrain_64gpu_gb200_fp8cs_config() -> ConfigContainer:
@@ -376,7 +377,9 @@ def nemotron_3_5_nano_pretrain_8gpu_gb200_bf16_config() -> ConfigContainer:
     cfg.model.keep_mtp_spec_in_bf16 = True
     cfg.model.mtp_loss_scaling_factor = 0.3
     cfg.model.hf_model_id = _NEMOTRON_3_5_NANO_MODEL_ID
+    cfg.model.hf_model_revision = _NEMOTRON_3_5_NANO_MODEL_REVISION
     cfg.tokenizer.tokenizer_model = _NEMOTRON_3_5_NANO_MODEL_ID
+    cfg.tokenizer.hf_tokenizer_kwargs = {"revision": _NEMOTRON_3_5_NANO_MODEL_REVISION}
     cfg.env_vars = {
         **COMMON_PERF_ENV_VARS,
         "CUDA_DEVICE_MAX_CONNECTIONS": 32,
@@ -405,7 +408,9 @@ def nemotron_3_5_nano_pretrain_8gpu_gb200_fp8mx_config() -> ConfigContainer:
     cfg.model.keep_mtp_spec_in_bf16 = True
     cfg.model.mtp_loss_scaling_factor = 0.3
     cfg.model.hf_model_id = _NEMOTRON_3_5_NANO_MODEL_ID
+    cfg.model.hf_model_revision = _NEMOTRON_3_5_NANO_MODEL_REVISION
     cfg.tokenizer.tokenizer_model = _NEMOTRON_3_5_NANO_MODEL_ID
+    cfg.tokenizer.hf_tokenizer_kwargs = {"revision": _NEMOTRON_3_5_NANO_MODEL_REVISION}
     cfg.env_vars = {
         **COMMON_PERF_ENV_VARS,
         "CUDA_DEVICE_MAX_CONNECTIONS": 32,
@@ -479,7 +484,9 @@ def nemotron_3_5_nano_pretrain_8gpu_gb200_nvfp4_config() -> ConfigContainer:
     cfg.model.keep_mtp_spec_in_bf16 = True
     cfg.model.mtp_loss_scaling_factor = 0.3
     cfg.model.hf_model_id = _NEMOTRON_3_5_NANO_MODEL_ID
+    cfg.model.hf_model_revision = _NEMOTRON_3_5_NANO_MODEL_REVISION
     cfg.tokenizer.tokenizer_model = _NEMOTRON_3_5_NANO_MODEL_ID
+    cfg.tokenizer.hf_tokenizer_kwargs = {"revision": _NEMOTRON_3_5_NANO_MODEL_REVISION}
     cfg.env_vars = {
         **COMMON_PERF_ENV_VARS,
         "CUDA_DEVICE_MAX_CONNECTIONS": 32,

--- a/src/megatron/bridge/perf_recipes/nemotronh/h100/nemotronh.py
+++ b/src/megatron/bridge/perf_recipes/nemotronh/h100/nemotronh.py
@@ -27,8 +27,9 @@ from megatron.bridge.perf_recipes.nemotronh.common import (
 from megatron.bridge.utils.cuda_graph import set_cuda_graph_modules
 
 
-# Placeholder until the public Nemotron 3.5 Nano repository is released.
-_NEMOTRON_3_5_NANO_MODEL_ID = "nvidia/NVIDIA-Nemotron-3.5-Nano-30B-A3B-BF16"
+# Public Nemotron 3.5 Lightning checkpoint used by the legacy Nano recipe API.
+_NEMOTRON_3_5_NANO_MODEL_ID = "nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16"
+_NEMOTRON_3_5_NANO_MODEL_REVISION = "b3caaabed0263651a17dc1f2d4ce97e794f76c44"  # pragma: allowlist secret
 
 
 def nemotronh_56b_pretrain_64gpu_h100_fp8cs_config() -> ConfigContainer:
@@ -187,7 +188,9 @@ def nemotron_3_5_nano_pretrain_16gpu_h100_bf16_config() -> ConfigContainer:
     cfg.model.keep_mtp_spec_in_bf16 = True
     cfg.model.mtp_loss_scaling_factor = 0.3
     cfg.model.hf_model_id = _NEMOTRON_3_5_NANO_MODEL_ID
+    cfg.model.hf_model_revision = _NEMOTRON_3_5_NANO_MODEL_REVISION
     cfg.tokenizer.tokenizer_model = _NEMOTRON_3_5_NANO_MODEL_ID
+    cfg.tokenizer.hf_tokenizer_kwargs = {"revision": _NEMOTRON_3_5_NANO_MODEL_REVISION}
 
     # This mock-data, force-balanced benchmark uses lower-precision Adam moments
     # to make the measured selective-recompute and activation-offload stack fit.
@@ -235,7 +238,9 @@ def nemotron_3_5_nano_pretrain_16gpu_h100_fp8cs_config() -> ConfigContainer:
     cfg.model.keep_mtp_spec_in_bf16 = True
     cfg.model.mtp_loss_scaling_factor = 0.3
     cfg.model.hf_model_id = _NEMOTRON_3_5_NANO_MODEL_ID
+    cfg.model.hf_model_revision = _NEMOTRON_3_5_NANO_MODEL_REVISION
     cfg.tokenizer.tokenizer_model = _NEMOTRON_3_5_NANO_MODEL_ID
+    cfg.tokenizer.hf_tokenizer_kwargs = {"revision": _NEMOTRON_3_5_NANO_MODEL_REVISION}
     cfg.env_vars = {
         **COMMON_PERF_ENV_VARS,
         "CUDA_DEVICE_MAX_CONNECTIONS": 32,

--- a/src/megatron/bridge/recipes/nemotronh/h100/nemotron_3_nano.py
+++ b/src/megatron/bridge/recipes/nemotronh/h100/nemotron_3_nano.py
@@ -32,8 +32,9 @@ from megatron.bridge.utils.cuda_graph import set_cuda_graph_modules
 
 
 _NEMOTRON_3_NANO_MODEL_ID = "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16"
-# Placeholder until the public Nemotron 3.5 Nano repository is released.
-_NEMOTRON_3_5_NANO_MODEL_ID = "nvidia/NVIDIA-Nemotron-3.5-Nano-30B-A3B-BF16"
+# Public Nemotron 3.5 Lightning checkpoint used by the legacy Nano recipe API.
+_NEMOTRON_3_5_NANO_MODEL_ID = "nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16"
+_NEMOTRON_3_5_NANO_MODEL_REVISION = "b3caaabed0263651a17dc1f2d4ce97e794f76c44"  # pragma: allowlist secret
 _OPENMATHINSTRUCT2_REVISION = "469216e3f46f4dacf476b382e192485ea51a143e"  # pragma: allowlist secret
 
 
@@ -269,7 +270,9 @@ def nemotron_3_5_nano_pretrain_config() -> ConfigContainer:
     cfg.model.keep_mtp_spec_in_bf16 = True
     cfg.model.mtp_loss_scaling_factor = 0.3
     cfg.model.hf_model_id = _NEMOTRON_3_5_NANO_MODEL_ID
+    cfg.model.hf_model_revision = _NEMOTRON_3_5_NANO_MODEL_REVISION
     cfg.tokenizer.tokenizer_model = _NEMOTRON_3_5_NANO_MODEL_ID
+    cfg.tokenizer.hf_tokenizer_kwargs = {"revision": _NEMOTRON_3_5_NANO_MODEL_REVISION}
     return cfg
 
 
@@ -414,7 +417,9 @@ def nemotron_3_5_nano_sft_config() -> ConfigContainer:
     cfg.model.keep_mtp_spec_in_bf16 = True
     cfg.model.mtp_loss_scaling_factor = 0.3
     cfg.model.hf_model_id = _NEMOTRON_3_5_NANO_MODEL_ID
+    cfg.model.hf_model_revision = _NEMOTRON_3_5_NANO_MODEL_REVISION
     cfg.tokenizer.tokenizer_model = _NEMOTRON_3_5_NANO_MODEL_ID
+    cfg.tokenizer.hf_tokenizer_kwargs = {"revision": _NEMOTRON_3_5_NANO_MODEL_REVISION}
     return cfg
 
 
@@ -648,7 +653,9 @@ def nemotron_3_5_nano_peft_config(peft_scheme: str | PEFT = "lora") -> ConfigCon
     cfg.model.keep_mtp_spec_in_bf16 = True
     cfg.model.mtp_loss_scaling_factor = 0.3
     cfg.model.hf_model_id = _NEMOTRON_3_5_NANO_MODEL_ID
+    cfg.model.hf_model_revision = _NEMOTRON_3_5_NANO_MODEL_REVISION
     cfg.tokenizer.tokenizer_model = _NEMOTRON_3_5_NANO_MODEL_ID
+    cfg.tokenizer.hf_tokenizer_kwargs = {"revision": _NEMOTRON_3_5_NANO_MODEL_REVISION}
     return cfg
 
 

--- a/tests/unit_tests/recipes/nemotronh/test_nemotron_3_nano.py
+++ b/tests/unit_tests/recipes/nemotronh/test_nemotron_3_nano.py
@@ -106,9 +106,11 @@ class TestNemotron3NanoPretrain:
         assert config.model.mtp_loss_scaling_factor == 0.3
         assert config.model.calculate_per_token_loss == base_config.model.calculate_per_token_loss
         assert config.model.use_te_rng_tracker == base_config.model.use_te_rng_tracker
-        assert recipe_module._NEMOTRON_3_5_NANO_MODEL_ID == ("nvidia/NVIDIA-Nemotron-3.5-Nano-30B-A3B-BF16")
+        assert recipe_module._NEMOTRON_3_5_NANO_MODEL_ID == ("nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16")
         assert config.model.hf_model_id == recipe_module._NEMOTRON_3_5_NANO_MODEL_ID
+        assert config.model.hf_model_revision == recipe_module._NEMOTRON_3_5_NANO_MODEL_REVISION
         assert config.tokenizer.tokenizer_model == recipe_module._NEMOTRON_3_5_NANO_MODEL_ID
+        assert config.tokenizer.hf_tokenizer_kwargs == {"revision": recipe_module._NEMOTRON_3_5_NANO_MODEL_REVISION}
         assert config.train.global_batch_size == 512
         assert config.model.context_parallel_size == 2
         assert config.model.cp_comm_type == "p2p"
@@ -292,6 +294,11 @@ class TestNemotron3NanoSft:
         assert config.model.mtp_loss_scaling_factor == (0.3 if mtp_num_layers else 0.1)
         assert config.model.hf_model_id == tokenizer_model
         assert config.tokenizer.tokenizer_model == tokenizer_model
+        if mtp_num_layers:
+            assert config.model.hf_model_revision == recipe_module._NEMOTRON_3_5_NANO_MODEL_REVISION
+            assert config.tokenizer.hf_tokenizer_kwargs == {
+                "revision": recipe_module._NEMOTRON_3_5_NANO_MODEL_REVISION
+            }
 
     @pytest.mark.parametrize(
         ("recipe_factory", "base_factory_name", "recipe_kwargs", "base_args"),
@@ -333,7 +340,9 @@ class TestNemotron3NanoSft:
         assert config.model.keep_mtp_spec_in_bf16 is True
         assert config.model.mtp_loss_scaling_factor == 0.3
         assert config.model.hf_model_id == recipe_module._NEMOTRON_3_5_NANO_MODEL_ID
+        assert config.model.hf_model_revision == recipe_module._NEMOTRON_3_5_NANO_MODEL_REVISION
         assert config.tokenizer.tokenizer_model == recipe_module._NEMOTRON_3_5_NANO_MODEL_ID
+        assert config.tokenizer.hf_tokenizer_kwargs == {"revision": recipe_module._NEMOTRON_3_5_NANO_MODEL_REVISION}
 
     def test_finetuning_recipes_do_not_expose_model_id(self):
         """Model selection is fixed by separate Nemotron 3 and 3.5 factories."""
@@ -359,6 +368,8 @@ class TestNemotron3NanoSft:
         assert config.model.keep_mtp_spec_in_bf16 is True
         assert config.model.mtp_loss_scaling_factor == 0.3
         assert config.model.hf_model_id == recipe_module._NEMOTRON_3_5_NANO_MODEL_ID
+        assert config.model.hf_model_revision == recipe_module._NEMOTRON_3_5_NANO_MODEL_REVISION
+        assert config.tokenizer.hf_tokenizer_kwargs == {"revision": recipe_module._NEMOTRON_3_5_NANO_MODEL_REVISION}
         assert config.model.tensor_model_parallel_size == 2
         assert config.model.sequence_parallel is True
         assert config.model.expert_tensor_parallel_size == 1

--- a/tests/unit_tests/recipes/test_nemotron_3_5_nano_perf_recipes.py
+++ b/tests/unit_tests/recipes/test_nemotron_3_5_nano_perf_recipes.py
@@ -39,7 +39,8 @@ from megatron.bridge.training.config import ConfigContainer
 
 pytestmark = pytest.mark.unit
 
-_NEMOTRON_3_5_NANO_MODEL_ID = "nvidia/NVIDIA-Nemotron-3.5-Nano-30B-A3B-BF16"
+_NEMOTRON_3_5_NANO_MODEL_ID = "nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16"
+_NEMOTRON_3_5_NANO_MODEL_REVISION = "b3caaabed0263651a17dc1f2d4ce97e794f76c44"  # pragma: allowlist secret
 
 _H100_RECIPES = (
     nemotron_3_5_nano_pretrain_16gpu_h100_bf16_config,
@@ -162,7 +163,9 @@ def test_perf_recipes_enable_mtp(recipe_factory: Callable[[], ConfigContainer]) 
     assert cfg.model.moe_router_force_load_balancing is True
     assert cfg.model.moe_flex_dispatcher_backend == "hybridep"
     assert cfg.model.hf_model_id == _NEMOTRON_3_5_NANO_MODEL_ID
+    assert cfg.model.hf_model_revision == _NEMOTRON_3_5_NANO_MODEL_REVISION
     assert cfg.tokenizer.tokenizer_model == _NEMOTRON_3_5_NANO_MODEL_ID
+    assert cfg.tokenizer.hf_tokenizer_kwargs == {"revision": _NEMOTRON_3_5_NANO_MODEL_REVISION}
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/recipes/test_nemotronh_recipes.py
+++ b/tests/unit_tests/recipes/test_nemotronh_recipes.py
@@ -31,6 +31,7 @@ from tests.unit_tests.recipes.recipe_test_utils import patch_recipe_module_globa
 
 
 _nemotronh_module = importlib.import_module("megatron.bridge.recipes.nemotronh")
+_NEMOTRON_3_5_NANO_MODEL_REVISION = "b3caaabed0263651a17dc1f2d4ce97e794f76c44"  # pragma: allowlist secret
 _NEMOTRONH_RECIPE_FUNCS = [
     getattr(_nemotronh_module, name)
     for name in getattr(_nemotronh_module, "__all__", [])
@@ -200,8 +201,10 @@ def test_nemotron_3_5_nano_h100_convergence_recipe_uses_perf_execution_policy():
     assert cfg.checkpoint.async_save is False
 
     assert cfg.tokenizer.tokenizer_type == "HuggingFaceTokenizer"
-    assert cfg.model.hf_model_id == "nvidia/NVIDIA-Nemotron-3.5-Nano-30B-A3B-BF16"
-    assert cfg.tokenizer.tokenizer_model == "nvidia/NVIDIA-Nemotron-3.5-Nano-30B-A3B-BF16"
+    assert cfg.model.hf_model_id == "nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16"
+    assert cfg.model.hf_model_revision == _NEMOTRON_3_5_NANO_MODEL_REVISION
+    assert cfg.tokenizer.tokenizer_model == "nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16"
+    assert cfg.tokenizer.hf_tokenizer_kwargs == {"revision": _NEMOTRON_3_5_NANO_MODEL_REVISION}
     assert cfg.env_vars["NVLINK_DOMAIN_SIZE"] == 8
     assert cfg.env_vars["USE_MNNVL"] == 0
 
@@ -242,8 +245,10 @@ def test_nemotron_3_5_nano_8k_convergence_recipe_uses_perf_execution_policy():
     assert cfg.checkpoint.async_save is False
 
     assert cfg.tokenizer.tokenizer_type == "HuggingFaceTokenizer"
-    assert cfg.model.hf_model_id == "nvidia/NVIDIA-Nemotron-3.5-Nano-30B-A3B-BF16"
-    assert cfg.tokenizer.tokenizer_model == "nvidia/NVIDIA-Nemotron-3.5-Nano-30B-A3B-BF16"
+    assert cfg.model.hf_model_id == "nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16"
+    assert cfg.model.hf_model_revision == _NEMOTRON_3_5_NANO_MODEL_REVISION
+    assert cfg.tokenizer.tokenizer_model == "nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16"
+    assert cfg.tokenizer.hf_tokenizer_kwargs == {"revision": _NEMOTRON_3_5_NANO_MODEL_REVISION}
     assert cfg.env_vars["NVLINK_DOMAIN_SIZE"] == 72
     assert cfg.env_vars["USE_MNNVL"] == 1
 
@@ -329,7 +334,9 @@ def test_nemotron_3_5_nano_openmath_sft_tp1_recipe_uses_tuned_defaults():
     assert cfg.model.moe_hybridep_num_sms == 32
     assert cfg.model.recompute_granularity is None
     assert cfg.model.recompute_modules is None
-    assert cfg.model.hf_model_id == "nvidia/NVIDIA-Nemotron-3.5-Nano-30B-A3B-BF16"
+    assert cfg.model.hf_model_id == "nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16"
+    assert cfg.model.hf_model_revision == _NEMOTRON_3_5_NANO_MODEL_REVISION
+    assert cfg.tokenizer.hf_tokenizer_kwargs == {"revision": _NEMOTRON_3_5_NANO_MODEL_REVISION}
 
     assert cfg.dataset.seq_length == 4096
     assert cfg.dataset.hf_dataset.dataset_name == "openmathinstruct2"
@@ -338,7 +345,9 @@ def test_nemotron_3_5_nano_openmath_sft_tp1_recipe_uses_tuned_defaults():
     assert cfg.dataset.enable_offline_packing is True
     assert cfg.dataset.offline_packing_specs.packed_sequence_size == 4096
     assert cfg.dataset.offline_packing_specs.pad_seq_to_mult == 2
-    assert cfg.dataset.offline_packing_specs.tokenizer_model_name == "nvidia/NVIDIA-Nemotron-3.5-Nano-30B-A3B-BF16"
+    assert cfg.dataset.offline_packing_specs.tokenizer_model_name == (
+        "nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16"
+    )
 
     assert cfg.train.train_iters == 100
     assert cfg.train.global_batch_size == 128


### PR DESCRIPTION
## What changed

- replace the unreleased Nemotron 3.5 Nano placeholder with the public
  `nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16` checkpoint;
- pin model and tokenizer loading to immutable revision
  `b3caaabed0263651a17dc1f2d4ce97e794f76c44`;
- preserve the existing `nemotron_3_5_nano_*` recipe APIs and verification-card
  path as compatibility identifiers;
- refresh all checkpoint-dependent H100 and GB200 SFT, PEFT, and 32K/CP2 loss
  evidence, plus import, export, and inference verification.

## Checkpoint compatibility

The public checkpoint retains `NemotronHForCausalLM`, the same model dimensions,
6,513 tensor names/shapes/dtypes, 32,913,266,240 parameters, 14 BF16 shards,
and byte-identical tokenizer/generation artifacts. Shards 1-13 are
byte-identical to the checkpoint used for the July evidence. All and only the
270 MTP tensors in shard 14 changed, so no conversion change is required.
Transformers 5.8.1 reconstructs the same base and MTP layer patterns consumed
by the existing bridge.

## Controlled loss refresh

All runs preserve the July data, packing, seeds, optimizer, precision,
parallelism, topology, step count, and 26.08 software environment; only the
starting checkpoint and fresh output roots changed.

| Hardware | Workload | Head | July step 1 -> 100 | Lightning step 1 -> 100 |
| --- | --- | --- | --- | --- |
| H100 | full SFT | LM | `0.4407026 -> 0.2756689` | `0.4406566 -> 0.2757806` |
| H100 | full SFT | MTP-1 | `0.7634735 -> 0.4076096` | `0.7371141 -> 0.4133309` |
| H100 | PEFT | LM | `0.4406879 -> 0.2856177` | `0.4406696 -> 0.2854756` |
| H100 | PEFT | MTP-1 | `0.7634883 -> 0.4294895` | `0.7370828 -> 0.4362708` |
| H100 | 32K/CP2 | LM | `0.4268321 -> 0.2649768` | `0.4268321 -> 0.2650192` |
| H100 | 32K/CP2 | MTP-1 | `0.7375677 -> 0.4385137` | `0.7322379 -> 0.4439273` |
| GB200 | full SFT | LM | `0.4407797 -> 0.2760494` | `0.4407797 -> 0.2762039` |
| GB200 | full SFT | MTP-1 | `0.7641921 -> 0.4087451` | `0.7373838 -> 0.4146959` |
| GB200 | full SFT | MTP-2 | `0.8651200 -> 0.4649736` | `0.8092746 -> 0.4744196` |
| GB200 | PEFT | LM | `0.4405894 -> 0.2855471` | `0.4406088 -> 0.2855029` |
| GB200 | PEFT | MTP-1 | `0.7634916 -> 0.4292603` | `0.7371238 -> 0.4362065` |
| GB200 | 32K/CP2 | LM | `0.4268995 -> 0.2649511` | `0.4268995 -> 0.2649925` |
| GB200 | 32K/CP2 | MTP-1 | `0.7376469 -> 0.4384451` | `0.7322624 -> 0.4439029` |

LM endpoints remain within 0.056% of July. MTP endpoints shift by roughly
0.7-6.5% initially and 1.2-2.0% finally, consistent with the MTP-only weight
change rather than a base-LM regression. Every training run completed exactly
100 finite-loss steps with zero skipped or NaN iterations and wrote the
expected checkpoint.

## Accepted jobs and immutable logs

| Hardware | Evidence | Job | Log SHA-256 |
| --- | --- | ---: | --- |
| H100 | import + two inference replays | `15043899` | scheduler/artifact audit |
| H100 | full SFT | `15044570` | `f9489546cfedf38e3ea17fb8adba59848024a99f5e6c4bf4ca79d02b0a6e9bb5` |
| H100 | PEFT | `15044571` | `1a8e0bd4c7cef8dc80fcaf0f863a25d83b65d1e204785f4d491b448b728c494d` |
| H100 | 32K/CP2 | `15044572` | `10f65ff64220147f70d7dd9185a6fd7b0ff7521f1809e63f1bc4e4188fd92ca8` |
| H100 | SFT export + inference | `15044573` | `2b4f3b015dc5c9959534a5e42a30c7c47f413a283775c3d4764c637a4446610e` |
| GB200 | import + two inference replays | `5848998` | `349b4c1e544a65f3b48f41134b8fa53e9deb95606acb68ec61e620c6f97396ee` |
| GB200 | full SFT | `5849674` | `79583c5957d4685cb485f4cf02a2c762494996cebe3291e4b942c6593bb380e4` |
| GB200 | PEFT | `5849675` | `f295f6f5d78e38f6cbaa27122162c67fef34b346bd3893b604110691354afaed` |
| GB200 | 32K/CP2 | `5849159` | `5a677a4569d1132c0717bf3131ed8dc04bb9e840d3d1db129033fecdc18c6c01` |
| GB200 | SFT export + inference | `5850662` | `2d52db8b3de18d37cb5c0d66dbbd9883eff449ff1d9ddfa0ea0caef99dd1b366` |

Both exports contain all 6,513 tensors, all 270 MTP tensors, and 14 BF16
shards. Repeated greedy inference produced the same exact 45-token completion
as the July evidence.

## Validation

- 134 focused recipe tests passed;
- model verification card validator passed;
- full repository pre-commit passed;
- `git diff --check` and complete public-information/privacy audit passed;
- independent exact-SHA diff and evidence review completed before publication.
