### PR TITLE
fix(model): map the fused input norm for MLA with q_lora_rank=None

### DIFF
--- a/src/megatron/bridge/models/conversion/model_bridge.py
+++ b/src/megatron/bridge/models/conversion/model_bridge.py
@@ -1194,6 +1194,11 @@ class MegatronModelBridge(
 
         _hf_import_cache: Dict[str, torch.Tensor] = {}
         for task in self._with_progress_tracking(hf_to_megatron_tasks, description):
+            # build_conversion_tasks returns List[None | WeightConversionTask]; a slot stays None
+            # when no mapping matched that global parameter. It already warned, and crashing here
+            # with AttributeError buries which parameter was unmapped.
+            if task is None:
+                continue
             # None means megatron module not on current rank, skip if this task is not going to happen
             if task.megatron_module is None:
                 continue
@@ -1322,6 +1327,11 @@ class MegatronModelBridge(
             conversion_tasks = self.build_conversion_tasks(hf_pretrained, megatron_model)
 
         for task in conversion_tasks:
+            # build_conversion_tasks returns List[None | WeightConversionTask]; a slot stays None
+            # when no mapping matched that global parameter. It already warned, and crashing here
+            # with AttributeError buries which parameter was unmapped.
+            if task is None:
+                continue
             # None means megatron module not on current rank, skip if this task is not going to happen
             if task.megatron_module is None:
                 continue

--- a/src/megatron/bridge/models/deepseek/common.py
+++ b/src/megatron/bridge/models/deepseek/common.py
@@ -57,8 +57,12 @@ def get_common_mapping_list(hf_config=None) -> list:
         "decoder.layers.*.self_attention.linear_q_up_proj.layer_norm_weight": "model.layers.*.self_attn.q_a_layernorm.weight",
         # Mcore local spec
         "decoder.layers.*.self_attention.q_layernorm.weight": "model.layers.*.self_attn.q_a_layernorm.weight",
-        # For models without MLA
+        # Single-matrix q projection: used both without MLA and by MLA with q_lora_rank=None,
+        # which has no q_a_proj/q_a_layernorm to map.
         "decoder.layers.*.self_attention.linear_q_proj.weight": "model.layers.*.self_attn.q_proj.weight",
+        # TE fuses the input norm into that projection, so no standalone input_layernorm module
+        # exists. Both spellings target the same HF tensor; only one exists per model.
+        "decoder.layers.*.self_attention.linear_q_proj.layer_norm_weight": "model.layers.*.input_layernorm.weight",
     }
 
     mapping_list = []

--- a/tests/unit_tests/models/deepseek/test_deepseek_bridges.py
+++ b/tests/unit_tests/models/deepseek/test_deepseek_bridges.py
@@ -332,6 +332,40 @@ class TestDeepSeekV3MaybeModifyLoadedHFWeight:
         assert result["up"] is w2
 
 
+class TestCommonMappingSingleMatrixQProjection:
+    """Input-norm coverage when q_lora_rank is None, so MLA uses a single q projection."""
+
+    def test_fused_input_norm_is_mapped(self):
+        """TE fuses the input norm into linear_q_proj, and that spelling must map."""
+        registry = MegatronMappingRegistry(*get_common_mapping_list())
+
+        mapping = registry.megatron_to_hf_lookup("decoder.layers.0.self_attention.linear_q_proj.layer_norm_weight")
+
+        assert mapping is not None
+        assert mapping.hf_param == "model.layers.0.input_layernorm.weight"
+
+    def test_standalone_input_norm_still_maps(self):
+        """The q_lora_rank set case keeps its own input_layernorm module."""
+        registry = MegatronMappingRegistry(*get_common_mapping_list())
+
+        mapping = registry.megatron_to_hf_lookup("decoder.layers.0.input_layernorm.weight")
+
+        assert mapping is not None
+        assert mapping.hf_param == "model.layers.0.input_layernorm.weight"
+
+    def test_mtp_layers_pick_up_the_fused_input_norm(self):
+        """MTP mappings are rewritten from the same dict, so they inherit the new entry."""
+        hf_config = SimpleNamespace(num_nextn_predict_layers=1, num_hidden_layers=61)
+        registry = MegatronMappingRegistry(*get_common_mapping_list(hf_config=hf_config))
+
+        mapping = registry.megatron_to_hf_lookup(
+            "mtp.layers.0.mtp_model_layer.self_attention.linear_q_proj.layer_norm_weight"
+        )
+
+        assert mapping is not None
+        assert mapping.hf_param == "model.layers.61.input_layernorm.weight"
+
+
 class TestCommonMappingExpertBias:
     """Router expert_bias coverage in the shared DeepSeek-family mapping list (issue #4199)."""
 


### PR DESCRIPTION
# What does this PR do?

Maps the fused input norm that MLA uses when `q_lora_rank` is None, so those checkpoints stop loading with every layer's input layernorm left at its random initialization.

Fixes #5294.

## Why

With `q_lora_rank=None` there is no query LoRA to build, so Megatron-Core creates a single `linear_q_proj` and Transformer Engine fuses the input norm into it. The parameter is then

```
decoder.layers.*.self_attention.linear_q_proj.layer_norm_weight
```

and no standalone `input_layernorm` module exists to satisfy the registry's existing `decoder.layers.*.input_layernorm.weight` entry. `models/deepseek/common.py` already maps the weight of that single-matrix projection but not the norm that comes with it.

Nothing raises. The parameter has no mapping, so the conversion never visits it and the model trains from a partly random initialization. DeepSeek-V2 236B and V3 both set `q_lora_rank`, which is why the headline models never exercise this; `deepseek-ai/DeepSeek-V2-Lite` (27 layers) and `kakaocorp/kanana-2-30b-a3b-thinking` (48 layers) do not set it, and both go through this shared mapping list.

## What changes

One registry entry in `models/deepseek/common.py`. Both spellings target the same HF tensor and only one exists for a given model, so the pre-existing `input_layernorm` entry is unaffected. MTP mappings are rewritten from the same dict, so MTP-enabled models pick the entry up without further changes.

The PR also guards the two loops in `models/conversion/model_bridge.py` that consume conversion tasks. `build_conversion_tasks` is declared `List[None | WeightConversionTask]` and does leave `None` slots for unmapped global parameters, but both loops read `task.megatron_module` directly, so an unmapped parameter surfaces as

```
AttributeError: 'NoneType' object has no attribute 'megatron_module'
```

naming no parameter, despite the builder having already warned about each one. That is what made this bug hard to place. Worth noting the more dangerous variant the same gap allows: had the mapping been wrong rather than absent, there would be no `None` slot and no error at all.

## Tests

Three cases in `TestCommonMappingSingleMatrixQProjection`, no weights needed:

- the fused `linear_q_proj.layer_norm_weight` resolves to `input_layernorm.weight`
- the standalone `input_layernorm.weight` entry still resolves (regression guard for the `q_lora_rank` set case)
- MTP layers inherit the new entry

Removing just the new mapping line fails the first and third and leaves the second passing, so the tests track the fix rather than the file.

`tests/unit_tests/models/deepseek/test_deepseek_bridges.py` passes 25/25. `ruff check` and `ruff format` clean.

Verified end to end on 8x B300, TP1/PP1/EP8, with a DeepSeek-V3-shaped 48-layer / 128-expert / MTP=3 checkpoint that sets `q_lora_rank=None`: 51 unmapped parameters before, 0 after, weight load completing where it previously raised.
