### PR TITLE
[ckpt] fix: Preserve Energon checkpoints during retention

### DIFF
--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -1661,7 +1661,7 @@ def cleanup_old_non_persistent_checkpoint(
     save_dir = Path(save_dir)
 
     iter_prefix = "iter_"
-    iter_ckpts = save_dir.rglob(f"{iter_prefix}*")
+    iter_ckpts = save_dir.glob(f"{iter_prefix}*")
     if max_iteration is not None:
         iter_ckpts = (
             ckpt_path for ckpt_path in iter_ckpts if int(ckpt_path.name[len(iter_prefix) :]) <= max_iteration

--- a/tests/unit_tests/training/test_checkpointing.py
+++ b/tests/unit_tests/training/test_checkpointing.py
@@ -1934,6 +1934,28 @@ class TestCleanupNonPersistentCheckpoints:
         assert retained_checkpoint.is_dir()
         assert future_incomplete_checkpoint.is_dir()
 
+    @patch("torch.distributed.is_initialized", return_value=True)
+    @patch("torch.distributed.get_rank", return_value=0)
+    def test_cleanup_keeps_complete_checkpoint_generation_with_energon_state(
+        self, mock_get_rank, mock_dist_init, tmp_path
+    ):
+        """Retention counts a model checkpoint and its Energon state as one generation."""
+        dataloader_checkpoint = tmp_path / "energon" / "iter_0000010"
+        dataloader_checkpoint.mkdir(parents=True)
+        (dataloader_checkpoint / "train_dataloader_dprank000.pt").touch()
+        model_checkpoint = tmp_path / "iter_0000010"
+        model_checkpoint.mkdir()
+
+        cleanup_old_non_persistent_checkpoint(
+            str(tmp_path),
+            leave_ckpt_num=1,
+            do_async=False,
+            max_iteration=10,
+        )
+
+        assert model_checkpoint.is_dir()
+        assert dataloader_checkpoint.is_dir()
+
     @patch("torch.distributed.is_initialized")
     @patch("torch.distributed.get_rank")
     def test_cleanup_old_non_persistent_checkpoint_retain_interval(self, mock_get_rank, mock_dist_init):


### PR DESCRIPTION
## What does this PR do?

Keep checkpoint retention scoped to iteration directories directly under the configured checkpoint root, so documented sibling state such as `energon/iter_N` is not counted as another checkpoint generation.

## User impact and root cause

Persistent training with an Energon `SavableDataLoader`, the default dataloader-state path, and `checkpoint.most_recent_k=1` could make the just-saved checkpoint unloadable.

Bridge stores the model checkpoint at `checkpoint.save/iter_N` and the matching deterministic dataloader state at `checkpoint.save/energon/iter_N`. Retention recursively discovered every `iter_*` directory and sorted them as independent checkpoints. The same generation therefore consumed two retention slots; with `most_recent_k=1`, the model directory was removed while its Energon sidecar was kept, leaving the published tracker pointing to a missing checkpoint.

The fix changes retention discovery from recursive traversal to direct children of the configured checkpoint root. Persistent and global non-persistent model checkpoints are created at that level, while documented sidecar trees remain associated state rather than retention candidates.

## Verification

Focused regression before the fix:

```text
uv run --no-sync python -m pytest tests/unit_tests/training/test_checkpointing.py::TestCleanupNonPersistentCheckpoints::test_cleanup_keeps_complete_checkpoint_generation_with_energon_state -q --tb=short
1 failed (retention removed iter_0000010 and kept energon/iter_0000010)
```

The unchanged regression after the fix:

```text
uv run --no-sync python -m pytest tests/unit_tests/training/test_checkpointing.py::TestCleanupNonPersistentCheckpoints::test_cleanup_keeps_complete_checkpoint_generation_with_energon_state -q --tb=short
1 passed
```

Adjacent cleanup, async/synchronous retention, and Energon state coverage:

```text
uv run --no-sync python -m pytest \
  tests/unit_tests/training/test_checkpointing.py::TestCleanupNonPersistentCheckpoints \
  tests/unit_tests/training/test_checkpointing.py::TestSaveCheckpoint::test_async_retention_keeps_tracker_checkpoint_until_finalize \
  tests/unit_tests/training/test_checkpointing.py::TestSaveCheckpoint::test_async_global_non_persistent_overlap_preserves_tracker_checkpoint \
  tests/unit_tests/training/test_checkpointing.py::TestSaveCheckpoint::test_sync_global_non_persistent_honors_configured_retention \
  tests/unit_tests/training/test_checkpointing.py::TestMaybeLoadDataloaderState \
  tests/unit_tests/training/test_checkpointing.py::TestMaybeSaveDataloaderState \
  -q --tb=short
24 passed
```

Quality checks:

```text
git diff --check
uv run --no-sync pre-commit run --all-files
```

Both passed.

## Scope

This changes only checkpoint retention target discovery and adds a focused CPU unit regression. It does not change public APIs, dependencies, CI workflows, Megatron-Core, checkpoint payload formats, or configured custom dataloader paths. No full-suite, GPU/distributed, model-quality, convergence, or performance validation is claimed.
