### PR TITLE
[misc] fix: Reject unsupported VLM stopping controls

### DIFF
--- a/src/megatron/bridge/inference/vlm/base.py
+++ b/src/megatron/bridge/inference/vlm/base.py
@@ -199,6 +199,11 @@ def generate(
             either as a string or as an InferenceRequest object.
     """
 
+    if sampling_params is not None and (
+        sampling_params.termination_id is not None or sampling_params.stop_words is not None
+    ):
+        raise ValueError("MCore legacy static generation does not support termination_id or stop_words.")
+
     if isinstance(wrapped_model, QwenVLInferenceWrapper):
         if processor is None:
             processor = getattr(wrapped_model, "processor", None)

--- a/tests/unit_tests/inference/vlm/test_base.py
+++ b/tests/unit_tests/inference/vlm/test_base.py
@@ -478,3 +478,40 @@ class TestGenerate:
         mock_engine.return_value.generate.assert_called()
         call_args = mock_engine.return_value.generate.call_args
         assert call_args[1]["sampling_params"] == sampling_params
+
+    @pytest.mark.parametrize(
+        "stopping_control",
+        [
+            {"termination_id": 42},
+            {"stop_words": ["<STOP>"]},
+        ],
+        ids=["termination-id", "stop-words"],
+    )
+    @patch("megatron.bridge.inference.vlm.base.VLMEngine")
+    @patch("megatron.bridge.inference.vlm.base.QwenVLTextGenerationController")
+    def test_generate_rejects_unsupported_legacy_stopping_controls(
+        self,
+        mock_qwen_controller,
+        mock_engine,
+        mock_tokenizer,
+        mock_image_processor,
+        stopping_control,
+    ):
+        from megatron.core.inference.sampling_params import SamplingParams
+
+        mock_wrapper = MagicMock(spec=QwenVLInferenceWrapper)
+        sampling_params = SamplingParams(num_tokens_to_generate=8, **stopping_control)
+
+        with pytest.raises(ValueError, match="legacy static generation does not support"):
+            generate(
+                wrapped_model=mock_wrapper,
+                tokenizer=mock_tokenizer,
+                image_processor=mock_image_processor,
+                prompts=["test"],
+                images=["image"],
+                processor="processor",
+                sampling_params=sampling_params,
+            )
+
+        mock_qwen_controller.assert_not_called()
+        mock_engine.assert_not_called()


### PR DESCRIPTION
## Summary

The checkpoint-backed VLM helper accepts MCore `SamplingParams` but always runs the pinned legacy static engine. That engine does not consume `termination_id` or `stop_words`, so supported TP=1/PP=1 Qwen2.5-VL and dense Qwen3-VL callers could receive extra tokens and text after their requested stopping boundary.

This change rejects those unsupported controls before constructing the legacy controller or engine. Default VLM sampling and all supported sampling fields remain unchanged.

## Root cause and fix

`megatron.bridge.inference.vlm.base.generate` forwarded unrestricted request sampling parameters into `VLMEngine(..., legacy=True)`. The pinned legacy controller independently selects tokenizer EOD and never checks or trims the two custom stopping fields.

Because this VLM path has no dynamic-engine mode and MCore is pinned upstream code, the Bridge-facing ownership boundary now fails explicitly, matching the sibling legacy text-generation entrypoint.

## Regression evidence

Exact regression against unmodified production code:

```text
uv run --no-sync python -m pytest tests/unit_tests/inference/vlm/test_base.py::TestGenerate::test_generate_rejects_unsupported_legacy_stopping_controls -q --tb=short
2 failed: both cases reported Failed: DID NOT RAISE ValueError
```

The unchanged regression after the fix:

```text
uv run --no-sync python -m pytest tests/unit_tests/inference/vlm/test_base.py::TestGenerate::test_generate_rejects_unsupported_legacy_stopping_controls -q --tb=short
2 passed
```

Focused file:

```text
uv run --no-sync python -m pytest tests/unit_tests/inference/vlm/test_base.py -q --tb=short
16 passed
```

Adjacent VLM boundaries:

```text
uv run --no-sync python -m pytest tests/unit_tests/inference/vlm/test_base.py tests/unit_tests/inference/vlm/test_vlm_engine.py tests/unit_tests/inference/vlm/test_vlm_inference_controller.py tests/unit_tests/inference/vlm/test_qwenvl_inference_wrapper.py -k 'not test_generate_uses_requested_seed_for_sampling' -q --tb=short
42 passed, 1 deselected
```

The deselected test is a CUDA random-generator seed test unrelated to this validation-only boundary.

Static checks:

```text
git diff --check
passed

uv run --no-sync pre-commit run --all-files
all hooks passed
```

## Scope

- No dependency, lockfile, workflow, public signature, checkpoint, conversion, or MCore changes.
- No change to dynamic inference or default legacy EOD behavior.
- No full-suite, GPU model-quality, convergence, or performance claim.
