### PR TITLE
fix(perf): lock memory clock per GPU

### DIFF
--- a/scripts/performance/utils/utils.py
+++ b/scripts/performance/utils/utils.py
@@ -163,6 +163,11 @@ def configure_slurm_gpu_tuning(
         )
 
     if peak_mem_clk is not None:
+        peak_mem_clock_cmd = (
+            f"for idx in {{0..{executor.ntasks_per_node - 1}}}; do "
+            f'sudo nvidia-smi -lmc {peak_mem_clk},{peak_mem_clk} -i "$idx"; '
+            "done"
+        )
         commands.append(
             "\n".join(
                 [
@@ -178,7 +183,7 @@ def configure_slurm_gpu_tuning(
                             "--error",
                             os.path.join(job_dir, "peak_mem_clock.err"),
                             "bash -c",
-                            shlex.quote(f"sudo nvidia-smi -lmc {peak_mem_clk},{peak_mem_clk}"),
+                            shlex.quote(peak_mem_clock_cmd),
                         ]
                     ),
                     "",

--- a/tests/unit_tests/scripts/performance/test_run_script_entrypoint.py
+++ b/tests/unit_tests/scripts/performance/test_run_script_entrypoint.py
@@ -165,6 +165,7 @@ def test_compatibility_overrides_preserve_legacy_manual_gc_defaults():
 def test_gpu_tuning_options_are_applied_directly_to_slurm_executor():
     executor = SimpleNamespace(
         nodes=2,
+        ntasks_per_node=4,
         tunnel=SimpleNamespace(job_dir="/job/dir"),
         setup_lines="existing setup\n",
     )
@@ -182,7 +183,7 @@ def test_gpu_tuning_options_are_applied_directly_to_slurm_executor():
     assert "sudo nvidia-smi -lgc 1200" in executor.setup_lines
     assert "srun --ntasks=2 --ntasks-per-node=1 --output /job/dir/peak_mem_clock.out" in executor.setup_lines
     assert "--error /job/dir/peak_mem_clock.err" in executor.setup_lines
-    assert "sudo nvidia-smi -lmc 2600,2600" in executor.setup_lines
+    assert 'for idx in {0..3}; do sudo nvidia-smi -lmc 2600,2600 -i "$idx"; done' in executor.setup_lines
 
 
 def test_run_script_main_runs_training_once(monkeypatch):


### PR DESCRIPTION
## Summary

- apply the configured memory-clock lock sequentially to each local GPU
- derive the GPU index range from the Slurm executor's tasks per node
- preserve the existing one-task-per-node launch and log files

## Why

Some GPUs can report that they are not ready when `nvidia-smi -lmc` targets every GPU in one invocation. Iterating device indices applies the workaround independently on each node.

## Validation

- `uv run --no-project --with pytest --with nemo-run python -m pytest --confcutdir=tests/unit_tests/scripts/performance tests/unit_tests/scripts/performance/test_run_script_entrypoint.py -k 'gpu_tuning' -v` (2 passed)
- `bash -n -c 'for idx in {0..3}; do sudo nvidia-smi -lmc 4752,4752 -i "$idx"; done'`
- `uv run --no-project --with pre-commit pre-commit run --all-files`