### PR TITLE
fix(inference): align VLM checkpoint precision

### DIFF
--- a/examples/conversion/hf_to_megatron_generate_vlm.py
+++ b/examples/conversion/hf_to_megatron_generate_vlm.py
@@ -205,6 +205,9 @@ def main(args) -> None:
             "expert_tensor_parallel_size": etp,
             "pipeline_dtype": torch.bfloat16,
         }
+        mp_overrides["params_dtype"] = mp_overrides["pipeline_dtype"]
+        mp_overrides["bf16"] = mp_overrides["pipeline_dtype"] == torch.bfloat16
+        mp_overrides["fp16"] = mp_overrides["pipeline_dtype"] == torch.float16
         if args.pp_layout:
             mp_overrides["pipeline_model_parallel_layout"] = args.pp_layout
         model = bridge.load_megatron_model(

--- a/tests/unit_tests/examples/test_hf_to_megatron_generate_vlm.py
+++ b/tests/unit_tests/examples/test_hf_to_megatron_generate_vlm.py
@@ -44,6 +44,7 @@ _import_stubs["megatron.core.pipeline_parallel.schedules"].get_forward_backward_
 _import_stubs["megatron.bridge"].AutoBridge = MagicMock()
 _import_stubs["megatron.bridge.models.hf_pretrained.utils"].is_safe_repo = MagicMock()
 _import_stubs["megatron.bridge.utils.common_utils"].get_last_rank = MagicMock()
+_import_stubs["megatron.bridge.utils.common_utils"].maybe_initialize_distributed = MagicMock()
 _import_stubs["megatron.bridge.utils.common_utils"].print_rank_0 = MagicMock()
 _import_stubs["megatron.bridge.utils.common_utils"].print_rank_last = MagicMock()
 for name in ("AutoConfig", "AutoProcessor", "AutoTokenizer", "GenerationConfig"):
@@ -61,6 +62,47 @@ for name in (
 with patch.dict(sys.modules, _import_stubs):
     _SCRIPT_GLOBALS = runpy.run_path(_SCRIPT)
 _main = _SCRIPT_GLOBALS["main"]
+
+
+@pytest.mark.unit
+def test_checkpoint_inference_aligns_parameter_dtype_with_pipeline_dtype() -> None:
+    """Checkpoint inference must not mix bf16 pipeline inputs with fp32 parameters."""
+    args = SimpleNamespace(
+        ep=1,
+        etp=1,
+        hf_model_path="org/gemma4-vl",
+        hf_revision="revision",
+        megatron_model_path="/checkpoint",
+        pp=2,
+        pp_layout=None,
+        tp=1,
+        trust_remote_code=False,
+    )
+
+    class StopAfterCheckpointLoad(Exception):
+        pass
+
+    provider = MagicMock()
+    bridge = MagicMock()
+    bridge.to_megatron_provider.return_value = provider
+    bridge.load_megatron_model.side_effect = StopAfterCheckpointLoad
+
+    script_globals = {
+        "AutoBridge": SimpleNamespace(from_hf_pretrained=MagicMock(return_value=bridge)),
+        "AutoConfig": SimpleNamespace(from_pretrained=MagicMock(return_value=SimpleNamespace(model_type="gemma4"))),
+        "is_safe_repo": MagicMock(return_value=False),
+        "maybe_initialize_distributed": MagicMock(),
+        "print_rank_0": MagicMock(),
+    }
+
+    with patch.dict(_main.__globals__, script_globals), pytest.raises(StopAfterCheckpointLoad):
+        _main(args)
+
+    mp_overrides = bridge.load_megatron_model.call_args.kwargs["mp_overrides"]
+    assert mp_overrides["pipeline_dtype"] == torch.bfloat16
+    assert mp_overrides["params_dtype"] == mp_overrides["pipeline_dtype"]
+    assert mp_overrides["bf16"] is True
+    assert mp_overrides["fp16"] is False
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

Checkpoint-backed VLM inference selects bfloat16 pipeline communication. Older converted Gemma4-VL checkpoints can record float32 parameter precision with bf16 disabled. With pipeline parallelism, a later stage then receives bfloat16 activations while Transformer Engine parameters such as layer_norm_weight remain float32, causing the reported dtype TypeError.

Use the existing pipeline_dtype selected by this inference workflow as the source for params_dtype, bf16, and fp16 in the same checkpoint-load override mapping.

## Scope

- Keep the precision alignment local to checkpoint-backed VLM inference.
- Keep ModelParallelKwargs unchanged.
- Do not change the generic checkpoint loader, where parameter and pipeline communication dtypes may intentionally differ.
- Remove the prior Gemma4 block-spec rename, provider target change, private-target allowlist entry, and spec-name tests. Those concern a separate checkpoint-serialization issue.
- No public API, dependency, CI, MCore, or unrelated behavior changes.

Current main already gives newly converted Gemma4 models bfloat16 provider defaults. This change protects checkpoint-backed inference when an existing run configuration still records float32 precision.

## Validation

- Red on current main: test_checkpoint_inference_aligns_parameter_dtype_with_pipeline_dtype failed because the checkpoint overrides had pipeline_dtype=bfloat16 but no aligned params_dtype.
- Green after the fix: tests/unit_tests/examples/test_hf_to_megatron_generate_vlm.py: 2 passed.
- uv run pre-commit run --all-files: passed.
- Fresh independent Codex review: no remaining high-confidence findings after two findings were addressed.

## Reference

NVBug 6491102.