### PR TITLE
Wrap nn.Linear LoRA path with LoRALinear (to_wrap/adapter)

### DIFF
--- a/src/megatron/bridge/models/conversion/peft_bridge.py
+++ b/src/megatron/bridge/models/conversion/peft_bridge.py
@@ -39,6 +39,7 @@ from megatron.bridge.models.conversion.utils import (
     persistent_buffers,
 )
 from megatron.bridge.peft.canonical_lora import ModuleDict
+from megatron.bridge.peft.lora_layers import LinearAdapter
 from megatron.bridge.peft.lora_merge import LoRAMerge
 from megatron.bridge.peft.utils import (
     get_adapter_attributes_from_linear,
@@ -595,6 +596,12 @@ class MegatronPeftBridge:
                     input_is_parallel = adapter.input_is_parallel
                     base_linear_is_parallel = True
                     requires_expert_splits = adapter.linear_in.weight.ndim > 2
+                elif isinstance(adapter, LinearAdapter):
+                    # Adapter wrapping a plain nn.Linear: no parallelism layout
+                    # and the wrapped module has no Megatron ``config`` to derive one from.
+                    input_is_parallel = False
+                    base_linear_is_parallel = False
+                    requires_expert_splits = False
                 else:
                     attrs = get_adapter_attributes_from_linear(to_wrap)
                     input_is_parallel = attrs.input_is_parallel

--- a/src/megatron/bridge/peft/adapter_wrapper.py
+++ b/src/megatron/bridge/peft/adapter_wrapper.py
@@ -16,12 +16,40 @@ from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple
 
 import torch
 import torch.nn as nn
+from megatron.core.utils import make_sharded_tensor_for_checkpoint
 
 from megatron.bridge.peft.utils import ParallelLinearAdapter
 
 
 if TYPE_CHECKING:
     from megatron.core.dist_checkpointing.mapping import ShardedStateDict
+
+
+def _plain_module_sharded_state_dict(
+    module: nn.Module,
+    prefix: str,
+    sharded_offsets: Tuple[Tuple[int, int, int], ...] = (),
+) -> "ShardedStateDict":
+    """Build a sharded state dict for a module that has no ``sharded_state_dict``.
+
+    Used as a fallback for plain ``nn.Linear`` / delta-only ``LinearAdapter`` leaves on
+    the simple (non-parallel) path: each parameter is wrapped as a replicated
+    :class:`ShardedTensor` so distributed checkpointing preserves the trained weights
+    instead of silently dropping them.
+
+    Args:
+        module: The plain module whose parameters to shard.
+        prefix: Key prefix applied to every parameter.
+        sharded_offsets: Offsets prepended to each sharded tensor.
+
+    Returns:
+        A sharded state dict mapping ``f"{prefix}{param_name}"`` to ShardedTensor.
+    """
+    sharded_state_dict: Dict[str, Any] = {}
+    for name, param in module.state_dict(prefix="", keep_vars=True).items():
+        key = f"{prefix}{name}"
+        sharded_state_dict[key] = make_sharded_tensor_for_checkpoint(param, key, prepend_offsets=sharded_offsets)
+    return sharded_state_dict
 
 
 def _compute_mamba_dim_info(wrapped_module: nn.Module) -> Dict[str, int]:
@@ -225,16 +253,24 @@ class AdapterWrapper(nn.Module):
             adapter_sharded_state_dict_kwargs["mamba_dim_info"] = _compute_mamba_dim_info(self.to_wrap)
 
         sharded_state_dict = {}
-        # The wrapped module may be a plain nn.Linear (simple, non-parallel path) which
-        # does not implement distributed sharding; fall back gracefully in that case.
+        # The wrapped module may be a plain nn.Linear (simple, non-parallel path) that
+        # does not implement distributed sharding. Fall back to wrapping each parameter
+        # as a replicated ShardedTensor so the trained weights are preserved.
         if hasattr(self.to_wrap, "sharded_state_dict"):
             sharded_state_dict.update(self.to_wrap.sharded_state_dict(prefix, sharded_offsets, metadata))
+        else:
+            sharded_state_dict.update(_plain_module_sharded_state_dict(self.to_wrap, prefix, sharded_offsets))
         # Likewise, a delta-only LinearAdapter has no sharded layout; only parallel adapters
-        # carry distributed-sharding information.
+        # carry distributed-sharding information. Fall back to replicated ShardedTensors for
+        # the plain-adapter case so the trained LoRA matrices are not dropped.
         if hasattr(self.adapter, "sharded_state_dict"):
             sharded_state_dict.update(
                 self.adapter.sharded_state_dict(
                     f"{prefix}adapter.", sharded_offsets, metadata, **adapter_sharded_state_dict_kwargs
                 )
+            )
+        else:
+            sharded_state_dict.update(
+                _plain_module_sharded_state_dict(self.adapter, f"{prefix}adapter.", sharded_offsets)
             )
         return sharded_state_dict

--- a/src/megatron/bridge/peft/adapter_wrapper.py
+++ b/src/megatron/bridge/peft/adapter_wrapper.py
@@ -101,6 +101,7 @@ class AdapterWrapper(nn.Module):
         self.to_wrap = to_wrap
         self.adapter = adapter
         self._adapter_enabled = True
+        self._base_returns_tuple = True
 
     def enable_adapter_layers(self) -> None:
         """Enable the adapter layers, allowing them to contribute to the forward pass output."""
@@ -140,12 +141,23 @@ class AdapterWrapper(nn.Module):
             4. both: (out, bias, ln_out)
         """
         linear_output = self.to_wrap(x, *args, **kwargs)
-        assert isinstance(linear_output, tuple), (
-            f"{self.to_wrap} should return a tuple but instead returns {linear_output}"
-        )
 
         bias = None
         layernorm_output = x
+
+        # Plain nn.Linear (and similar modules) return a bare tensor rather than the
+        # Megatron-style tuple. Handle that case without asserting, so the wrapper stays
+        # a drop-in for nn.Linear in simple (non-parallel) models. Record the return
+        # shape so ``forward`` implementations can mirror it (tensor vs. tuple).
+        if isinstance(linear_output, torch.Tensor):
+            self._base_returns_tuple = False
+            bias = getattr(self.to_wrap, "bias", None)
+            return linear_output, bias, layernorm_output
+
+        assert isinstance(linear_output, tuple), (
+            f"{self.to_wrap} should return a tensor or a tuple but instead returns {type(linear_output).__name__}"
+        )
+        self._base_returns_tuple = True
 
         if len(linear_output) == 2:
             linear_output, bias = linear_output
@@ -213,10 +225,16 @@ class AdapterWrapper(nn.Module):
             adapter_sharded_state_dict_kwargs["mamba_dim_info"] = _compute_mamba_dim_info(self.to_wrap)
 
         sharded_state_dict = {}
-        sharded_state_dict.update(self.to_wrap.sharded_state_dict(prefix, sharded_offsets, metadata))
-        sharded_state_dict.update(
-            self.adapter.sharded_state_dict(
-                f"{prefix}adapter.", sharded_offsets, metadata, **adapter_sharded_state_dict_kwargs
+        # The wrapped module may be a plain nn.Linear (simple, non-parallel path) which
+        # does not implement distributed sharding; fall back gracefully in that case.
+        if hasattr(self.to_wrap, "sharded_state_dict"):
+            sharded_state_dict.update(self.to_wrap.sharded_state_dict(prefix, sharded_offsets, metadata))
+        # Likewise, a delta-only LinearAdapter has no sharded layout; only parallel adapters
+        # carry distributed-sharding information.
+        if hasattr(self.adapter, "sharded_state_dict"):
+            sharded_state_dict.update(
+                self.adapter.sharded_state_dict(
+                    f"{prefix}adapter.", sharded_offsets, metadata, **adapter_sharded_state_dict_kwargs
+                )
             )
-        )
         return sharded_state_dict

--- a/src/megatron/bridge/peft/canonical_lora.py
+++ b/src/megatron/bridge/peft/canonical_lora.py
@@ -319,15 +319,16 @@ class CanonicalLoRA(PEFT, ModuleMatcher):
         """
 
         # Skip already transformed modules
-        if isinstance(m, (LinearAdapter, LoRALinear, LoRALinearSplitQKV, LoRALinearSplitFC1UpGate, LoRATopKRouter)):
+        if isinstance(m, (LoRALinear, LoRALinearSplitQKV, LoRALinearSplitFC1UpGate, LoRATopKRouter)):
             return m
 
         if (ans := self.match(m, name, prefix)) is not None:
             (match, full_name) = ans
             if isinstance(m, nn.Linear) and not is_modelopt_linear(m):
-                return LinearAdapter(
+                adapter = LinearAdapter(
                     m, dim=self.dim, alpha=self.alpha, dropout=self.dropout, lora_A_init_method=self.lora_A_init_method
                 )
+                return LoRALinear(m, adapter)
 
             is_expert = is_expert_linear(full_name)
             attrs = get_adapter_attributes_from_linear(m, is_expert=is_expert)

--- a/src/megatron/bridge/peft/lora.py
+++ b/src/megatron/bridge/peft/lora.py
@@ -127,14 +127,14 @@ class LoRA(PEFT, ModuleMatcher):
             nn.Module: The modified module with LoRA applied, or the original module if not a target.
         """
         # Skip already transformed modules
-        adapter_types = (LinearAdapter, LoRALinear, LoRATopKRouter)
+        adapter_types = (LoRALinear, LoRATopKRouter)
         if isinstance(module, adapter_types):
             return module
 
         if (ans := self.match(module, name, prefix)) is not None:
             _, full_name = ans
             if isinstance(module, nn.Linear) and not is_modelopt_linear(module):
-                return LinearAdapter(
+                adapter = LinearAdapter(
                     module,
                     dim=self.dim,
                     alpha=self.alpha,
@@ -142,6 +142,7 @@ class LoRA(PEFT, ModuleMatcher):
                     lora_A_init_method=self.lora_A_init_method,
                     lora_dtype=self.lora_dtype,
                 )
+                return LoRALinear(module, adapter)
 
             is_expert = is_expert_linear(full_name)
             attrs = get_adapter_attributes_from_linear(

--- a/src/megatron/bridge/peft/lora_layers.py
+++ b/src/megatron/bridge/peft/lora_layers.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import math
-from typing import Any, Literal, Optional, Tuple
+from typing import Any, Literal, Optional
 
 import torch
 import torch.nn as nn
@@ -62,7 +62,7 @@ class LoRALinear(AdapterWrapper):
         """Return the wrapped linear bias."""
         return getattr(self.to_wrap, "bias", None)
 
-    def forward(self, x: torch.Tensor, *args: Any, **kwargs: Any) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+    def forward(self, x: torch.Tensor, *args: Any, **kwargs: Any):
         """Forward pass that combines the wrapped module output with the adapter output.
 
         Args:
@@ -71,18 +71,21 @@ class LoRALinear(AdapterWrapper):
             **kwargs: Additional keyword arguments for the wrapped module.
 
         Returns:
-            A tuple containing:
-                - Combined output (linear_output + adapter_output) if adapter is enabled,
-                  otherwise just the linear_output
-                - Bias term (if present, otherwise None)
+            When the wrapped module returns a Megatron-style tuple, a
+            ``(combined_output, bias)`` tuple; when it returns a bare tensor
+            (e.g. a plain ``nn.Linear``), a bare tensor so the wrapper stays a
+            drop-in replacement in simple (non-parallel) models.
         """
         # pylint: disable=C0115,C0116
         linear_output, bias, layernorm_output = self.base_linear_forward(x, *args, **kwargs)
         if not self._adapter_enabled:
-            return linear_output, bias
+            return linear_output if not self._base_returns_tuple else (linear_output, bias)
         adapter_output = self.adapter_forward(self.adapter, layernorm_output.contiguous(), *args, **kwargs)
         adapter_output = adapter_output.reshape(linear_output.shape)
-        return linear_output + adapter_output, bias
+        combined = linear_output + adapter_output
+        if not self._base_returns_tuple:
+            return combined
+        return combined, bias
 
 
 class LoRATopKRouter(AdapterWrapper):
@@ -343,11 +346,18 @@ class TEFusedLoRALinear(LoRALinear):
         return out, None
 
 
-class LinearAdapter(nn.Linear):
-    """Linear with LoRA that preserves the base weight and bias checkpoint keys.
+class LinearAdapter(nn.Module):
+    """Delta-only LoRA adapter for a plain ``nn.Linear``, mirroring :class:`ParallelLinearAdapter`'s role.
+
+    This adapter holds *only* the low-rank LoRA delta (``linear_in`` -> ``linear_out``) and
+    produces just the scaled adaptation term. It is intended to be wrapped together with the
+    original linear by :class:`LoRALinear` (the ``to_wrap`` / ``adapter`` pattern), so that
+    base weights and adapter weights live in distinct submodules and adapter state is
+    checkpointed under the ``adapter.`` prefix.
 
     Args:
-        orig_linear: The linear module to augment.
+        orig_linear: The linear module to augment (only its shape/dtype/device are used; its
+            weights are *not* copied).
         dim: LoRA's dimension (in_features -> dim -> out_features).
         alpha: LoRA's scaling alpha.
         dropout: Dropout probability (default: 0.0).
@@ -366,10 +376,10 @@ class LinearAdapter(nn.Linear):
         lora_A_init_method: Literal["xavier", "uniform"] = "xavier",
         lora_dtype: Optional[torch.dtype] = None,
     ) -> None:
-        """Initialize LinearAdapter by copying from original Linear and adding LoRA components.
+        """Initialize the LoRA delta weights from the original Linear's shape and dtype.
 
         Args:
-            orig_linear: The original Linear module to adapt.
+            orig_linear: The original Linear module to adapt (weights are not copied).
             dim: LoRA rank dimension.
             alpha: LoRA scaling factor.
             dropout: Dropout probability.
@@ -377,19 +387,10 @@ class LinearAdapter(nn.Linear):
             lora_A_init_method: Initialization method for LoRA matrix A.
             lora_dtype: Data type for LoRA weights.
         """
+        super().__init__()
         assert isinstance(orig_linear, nn.Linear)
-        super(LinearAdapter, self).__init__(
-            in_features=orig_linear.in_features,
-            out_features=orig_linear.out_features,
-            bias=orig_linear.bias is not None,
-            device=orig_linear.weight.device,
-            dtype=orig_linear.weight.dtype,
-        )
-        # copy weights
-        self.weight.data.copy_(orig_linear.weight.data)
-        if orig_linear.bias is not None:
-            self.bias.data.copy_(orig_linear.bias.data)
-        # initialize the adapter
+        self.in_features = orig_linear.in_features
+        self.out_features = orig_linear.out_features
         self._init_adapter(
             dim=dim,
             alpha=alpha,
@@ -397,16 +398,9 @@ class LinearAdapter(nn.Linear):
             dropout_position=dropout_position,
             lora_A_init_method=lora_A_init_method,
             lora_dtype=lora_dtype,
+            device=orig_linear.weight.device,
+            base_dtype=orig_linear.weight.dtype,
         )
-        self._adapter_enabled = True
-
-    def enable_adapter_layers(self) -> None:
-        """Enable the adapter layers, allowing them to contribute to the forward pass output."""
-        self._adapter_enabled = True
-
-    def disable_adapter_layers(self) -> None:
-        """Disable the adapter layers, making the forward pass return only the base module output."""
-        self._adapter_enabled = False
 
     @torch.no_grad
     def _init_adapter(
@@ -417,8 +411,10 @@ class LinearAdapter(nn.Linear):
         dropout_position: Literal["pre", "post"] = "pre",
         lora_A_init_method: Literal["xavier", "uniform"] = "xavier",
         lora_dtype: Optional[torch.dtype] = None,
+        device: Optional[torch.device] = None,
+        base_dtype: Optional[torch.dtype] = None,
     ) -> None:
-        """Initialize the LoRA weights and freeze the base parameters.
+        """Initialize the LoRA delta weights.
 
         Args:
             dim: LoRA's dimension (in_features -> dim -> out_features).
@@ -427,20 +423,16 @@ class LinearAdapter(nn.Linear):
             dropout_position: Where to apply dropout relative to LoRA (choices: ['pre', 'post'], default='pre').
             lora_A_init_method: Initialization method for lora_A (choices: ['xavier', 'uniform']).
             lora_dtype: Adapter weight dtype. Defaults to the base weight dtype.
+            device: Device for the LoRA weights.
+            base_dtype: Base weight dtype, used when ``lora_dtype`` is not provided.
         """
         self.dim = dim
         self.alpha = alpha
         self.scale = alpha / dim
 
-        # Freeze original weights
-        device = self.weight.device
-        self.weight.requires_grad = False
-        if self.bias is not None:
-            self.bias.requires_grad = False
-
         in_features = self.in_features
         out_features = self.out_features
-        dtype = lora_dtype or self.weight.dtype
+        dtype = lora_dtype or base_dtype
 
         self.linear_in = nn.Linear(in_features, dim, bias=False, dtype=dtype, device=device)
         self.linear_out = nn.Linear(dim, out_features, bias=False, dtype=dtype, device=device)
@@ -457,24 +449,20 @@ class LinearAdapter(nn.Linear):
         self.dropout_position = dropout_position
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """Forward pass combining Linear output with LoRA adaptation.
+        """Compute the scaled LoRA delta only (no base-weight term).
 
         Args:
             x: Input tensor.
 
         Returns:
-            Combined output from original linear layer and LoRA adaptation.
+            The scaled low-rank adaptation ``scale * linear_out(linear_in(x))`` with dropout
+            applied per ``dropout_position``.
         """
         # pylint: disable=C0115,C0116
-        res = torch.nn.functional.linear(x, self.weight, self.bias)
-
-        if not self._adapter_enabled:
-            return res
-
         if self.dropout_position == "pre":
             x = self.dropout(x)
         lora_res = self.linear_out(self.linear_in(x))
         lora_res = lora_res * self.scale
         if self.dropout_position == "post":
             lora_res = self.dropout(lora_res)
-        return res + lora_res
+        return lora_res

--- a/tests/unit_tests/peft/test_adapter_wrapper.py
+++ b/tests/unit_tests/peft/test_adapter_wrapper.py
@@ -19,6 +19,7 @@ Tests the AdapterWrapper base class and its functionality for wrapping
 modules with adapters in Parameter-Efficient Fine-Tuning scenarios.
 """
 
+import os
 from unittest.mock import Mock, patch
 
 import pytest
@@ -408,3 +409,92 @@ class TestAdapterWrapper:
         peft.enable_adapter_layers(model)
         reenabled_output = model(x)
         assert torch.allclose(reenabled_output, enabled_output, atol=1e-6)
+
+
+class TestPlainLinearShardedStateDict:
+    """Sharded state dict for LoRALinear(nn.Linear, LinearAdapter) preserves all weights."""
+
+    @pytest.fixture(autouse=True)
+    def setup_dist(self, tmp_path):
+        """Initialize a single-rank process group and model parallel for dist checkpointing."""
+        import os
+
+        import torch.distributed as dist
+        from megatron.core import parallel_state
+
+        if not dist.is_initialized():
+            os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+            os.environ.setdefault("MASTER_PORT", "29531")
+            os.environ.setdefault("RANK", "0")
+            os.environ.setdefault("LOCAL_RANK", "0")
+            os.environ.setdefault("WORLD_SIZE", "1")
+            backend = "nccl" if torch.cuda.is_available() else "gloo"
+            dist.init_process_group(backend=backend, world_size=1, rank=0)
+
+        if not parallel_state.model_parallel_is_initialized():
+            parallel_state.initialize_model_parallel(
+                tensor_model_parallel_size=1,
+                pipeline_model_parallel_size=1,
+                virtual_pipeline_model_parallel_size=None,
+                context_parallel_size=1,
+            )
+        yield
+        # leave global state intact for subsequent tests
+
+    def _make_wrapped(self):
+        from megatron.bridge.peft.lora_layers import LinearAdapter
+
+        base = nn.Linear(6, 4, bias=True)
+        adapter = LinearAdapter(base, dim=2, alpha=4)
+        # Set distinct, non-zero values so we can detect loss on reload.
+        with torch.no_grad():
+            base.weight.fill_(0.3)
+            base.bias.fill_(0.1)
+            adapter.linear_in.weight.fill_(0.5)
+            adapter.linear_out.weight.fill_(0.7)
+        return LoRALinear(base, adapter)
+
+    def test_sharded_state_dict_has_all_entries(self):
+        """sharded_state_dict must include base + adapter params (not be empty)."""
+        from megatron.core.dist_checkpointing.mapping import ShardedTensor
+
+        wrapped = self._make_wrapped()
+        ssd = wrapped.sharded_state_dict(prefix="layer0.")
+
+        assert set(ssd.keys()) == {
+            "layer0.weight",
+            "layer0.bias",
+            "layer0.adapter.linear_in.weight",
+            "layer0.adapter.linear_out.weight",
+        }
+        for value in ssd.values():
+            assert isinstance(value, ShardedTensor)
+
+    def test_sharded_save_load_roundtrip_preserves_weights(self, tmp_path):
+        """A real dist_checkpointing save -> load round-trip preserves trained LoRA matrices."""
+        from megatron.core.dist_checkpointing import load, save
+
+        wrapped = self._make_wrapped()
+        prefix = "layer0."
+        save_ssd = wrapped.sharded_state_dict(prefix=prefix)
+
+        ckpt_dir = str(tmp_path / "plain_lora_ckpt")
+        os.makedirs(ckpt_dir, exist_ok=True)
+        save(save_ssd, ckpt_dir)
+
+        # Build a fresh load-side sharded state dict on a new wrapper (uninitialized weights).
+        rewrapped = self._make_wrapped()
+        with torch.no_grad():
+            rewrapped.to_wrap.weight.zero_()
+            rewrapped.to_wrap.bias.zero_()
+            rewrapped.adapter.linear_in.weight.zero_()
+            rewrapped.adapter.linear_out.weight.zero_()
+        load_ssd = rewrapped.sharded_state_dict(prefix=prefix)
+        load(load_ssd, ckpt_dir)
+        # dist_checkpointing.load populates each ShardedTensor's .data in place.
+        rewrapped.load_state_dict({k.removeprefix(prefix): v.data for k, v in load_ssd.items()}, strict=False)
+
+        assert torch.allclose(rewrapped.to_wrap.weight, wrapped.to_wrap.weight)
+        assert torch.allclose(rewrapped.to_wrap.bias, wrapped.to_wrap.bias)
+        assert torch.allclose(rewrapped.adapter.linear_in.weight, wrapped.adapter.linear_in.weight)
+        assert torch.allclose(rewrapped.adapter.linear_out.weight, wrapped.adapter.linear_out.weight)

--- a/tests/unit_tests/peft/test_adapter_wrapper.py
+++ b/tests/unit_tests/peft/test_adapter_wrapper.py
@@ -176,15 +176,40 @@ class TestAdapterWrapper:
         assert bias is not None
         assert not torch.equal(layernorm_output, x)
 
-    def test_base_linear_forward_invalid_return(self, simple_adapter):
-        """Test base_linear_forward with invalid return type."""
+    def test_base_linear_forward_tensor_return(self, simple_adapter):
+        """Test base_linear_forward with a bare tensor return (plain nn.Linear path)."""
 
-        class InvalidLinear(nn.Module):
+        class TensorLinear(nn.Module):
             """Mock linear module that returns a tensor instead of a tuple."""
+
+            def __init__(self):
+                super().__init__()
+                self.weight = nn.Parameter(torch.randn(10, 10))
+                self.bias = None
 
             def forward(self, x):
                 """Return a tensor instead of a tuple."""
-                return x
+                return torch.matmul(x, self.weight.t())
+
+        wrapper = ConcreteAdapterWrapper(TensorLinear(), simple_adapter)
+        x = torch.randn(5, 10)
+
+        linear_output, bias, layernorm_output = wrapper.base_linear_forward(x)
+
+        assert isinstance(linear_output, torch.Tensor)
+        assert bias is None
+        assert torch.equal(layernorm_output, x)
+        assert not wrapper._base_returns_tuple
+
+    def test_base_linear_forward_invalid_return(self, simple_adapter):
+        """Test base_linear_forward rejects a return that is neither a tensor nor a tuple."""
+
+        class InvalidLinear(nn.Module):
+            """Mock linear module that returns a non-tensor, non-tuple value."""
+
+            def forward(self, x):
+                """Return an int instead of a tensor or tuple."""
+                return 0
 
         wrapper = ConcreteAdapterWrapper(InvalidLinear(), simple_adapter)
         x = torch.randn(5, 10)

--- a/tests/unit_tests/peft/test_canonical_lora.py
+++ b/tests/unit_tests/peft/test_canonical_lora.py
@@ -26,7 +26,7 @@ from megatron.core.transformer.module import MegatronModule
 
 from megatron.bridge.models.gpt_provider import GPTModelProvider
 from megatron.bridge.peft.canonical_lora import CanonicalLoRA, LoRALinearSplitFC1UpGate, LoRALinearSplitQKV, ModuleDict
-from megatron.bridge.peft.lora_layers import LinearAdapter, LoRALinear
+from megatron.bridge.peft.lora_layers import LoRALinear
 from megatron.bridge.peft.utils import AdapterAttributes, GroupedExpertLinearAdapter
 
 
@@ -261,7 +261,7 @@ class TestCanonicalLoRA:
 
         # canonical_mapping was rebuilt at apply time from the new target_modules
         assert set(lora.canonical_mapping.keys()) == {"linear_proj"}
-        assert isinstance(transformed.linear_proj, LinearAdapter)
+        assert isinstance(transformed.linear_proj, LoRALinear)
 
     def test_canonical_lora_wildcard_mapping(self):
         """Test wildcard pattern mapping in canonical LoRA."""
@@ -284,8 +284,8 @@ class TestCanonicalLoRA:
         transformed_model = lora(model, training=True)
 
         # Check that target modules were transformed to LinearAdapter (simple nn.Linear case)
-        assert isinstance(transformed_model.linear_proj, LinearAdapter)
-        assert isinstance(transformed_model.linear_fc2, LinearAdapter)
+        assert isinstance(transformed_model.linear_proj, LoRALinear)
+        assert isinstance(transformed_model.linear_fc2, LoRALinear)
 
         # Check that non-target modules were not transformed
         assert isinstance(transformed_model.linear_q, nn.Linear)
@@ -540,8 +540,8 @@ class TestCanonicalLoRA:
 
         # Check that nested target modules were transformed
         for layer in transformed_model.layers:
-            assert isinstance(layer["attention"]["linear_proj"], LinearAdapter)
-            assert isinstance(layer["mlp"]["linear_fc2"], LinearAdapter)
+            assert isinstance(layer["attention"]["linear_proj"], LoRALinear)
+            assert isinstance(layer["mlp"]["linear_fc2"], LoRALinear)
 
             # Check non-target modules remain unchanged
             assert isinstance(layer["attention"]["linear_q"], nn.Linear)
@@ -587,10 +587,10 @@ class TestCanonicalLoRA:
         transformed_model = lora(model, training=True)
 
         # Check first layer attention modules are transformed
-        assert isinstance(transformed_model.layers[0]["attention"]["linear_q"], LinearAdapter)
-        assert isinstance(transformed_model.layers[0]["attention"]["linear_k"], LinearAdapter)
-        assert isinstance(transformed_model.layers[0]["attention"]["linear_v"], LinearAdapter)
-        assert isinstance(transformed_model.layers[0]["attention"]["linear_proj"], LinearAdapter)
+        assert isinstance(transformed_model.layers[0]["attention"]["linear_q"], LoRALinear)
+        assert isinstance(transformed_model.layers[0]["attention"]["linear_k"], LoRALinear)
+        assert isinstance(transformed_model.layers[0]["attention"]["linear_v"], LoRALinear)
+        assert isinstance(transformed_model.layers[0]["attention"]["linear_proj"], LoRALinear)
 
         # Check first layer MLP modules are NOT transformed
         assert isinstance(transformed_model.layers[0]["mlp"]["linear_fc1_up"], nn.Linear)
@@ -611,8 +611,8 @@ class TestCanonicalLoRA:
         # Apply CanonicalLoRA
         transformed_model = lora(model, training=True)
 
-        # Check adapter properties
-        adapter = transformed_model.linear_proj
+        # Check adapter properties (live on the delta-only LinearAdapter sub-module)
+        adapter = transformed_model.linear_proj.adapter
         assert hasattr(adapter, "dim")
         assert hasattr(adapter, "alpha")
         assert hasattr(adapter, "scale")
@@ -632,15 +632,15 @@ class TestCanonicalLoRA:
         # Apply CanonicalLoRA
         transformed_model = lora(model, training=True)
 
-        # Check that original weights are frozen
-        linear_adapter = transformed_model.linear_proj
-        assert not linear_adapter.weight.requires_grad
-        if linear_adapter.bias is not None:
-            assert not linear_adapter.bias.requires_grad
+        # Check that original weights are frozen (base weight on the wrapped module)
+        wrapped = transformed_model.linear_proj
+        assert not wrapped.to_wrap.weight.requires_grad
+        if wrapped.to_wrap.bias is not None:
+            assert not wrapped.to_wrap.bias.requires_grad
 
         # Check that LoRA parameters are trainable
-        assert linear_adapter.linear_in.weight.requires_grad
-        assert linear_adapter.linear_out.weight.requires_grad
+        assert wrapped.adapter.linear_in.weight.requires_grad
+        assert wrapped.adapter.linear_out.weight.requires_grad
 
     def test_canonical_lora_forward_pass(self):
         """Test that CanonicalLoRA adapted models can perform forward passes."""
@@ -701,8 +701,8 @@ class TestCanonicalLoRA:
 
         # Each chunk should have LoRA applied to target modules
         for chunk in transformed_chunks:
-            assert isinstance(chunk.linear_proj, LinearAdapter)
-            assert isinstance(chunk.linear_fc2, LinearAdapter)
+            assert isinstance(chunk.linear_proj, LoRALinear)
+            assert isinstance(chunk.linear_fc2, LoRALinear)
             # Non-target modules should remain unchanged
             assert isinstance(chunk.linear_q, nn.Linear)
             assert isinstance(chunk.linear_k, nn.Linear)
@@ -740,12 +740,12 @@ class TestCanonicalLoRA:
         adapted_model2 = lora2(model2, training=True)
 
         # LoRA weights should be identical with same seed
-        linear_in_1 = adapted_model1.linear_proj.linear_in.weight.data
-        linear_in_2 = adapted_model2.linear_proj.linear_in.weight.data
+        linear_in_1 = adapted_model1.linear_proj.adapter.linear_in.weight.data
+        linear_in_2 = adapted_model2.linear_proj.adapter.linear_in.weight.data
         assert torch.equal(linear_in_1, linear_in_2)
 
-        linear_out_1 = adapted_model1.linear_proj.linear_out.weight.data
-        linear_out_2 = adapted_model2.linear_proj.linear_out.weight.data
+        linear_out_1 = adapted_model1.linear_proj.adapter.linear_out.weight.data
+        linear_out_2 = adapted_model2.linear_proj.adapter.linear_out.weight.data
         assert torch.equal(linear_out_1, linear_out_2)
 
     def test_canonical_lora_transform_idempotent(self):
@@ -762,8 +762,8 @@ class TestCanonicalLoRA:
         first_linear_q = first_transform.linear_q  # Should remain unchanged
 
         # Verify first transformation worked
-        assert isinstance(first_linear_proj, LinearAdapter)
-        assert isinstance(first_linear_fc2, LinearAdapter)
+        assert isinstance(first_linear_proj, LoRALinear)
+        assert isinstance(first_linear_fc2, LoRALinear)
         assert isinstance(first_linear_q, nn.Linear)
 
         # Apply CanonicalLoRA second time to the already-transformed model
@@ -775,16 +775,18 @@ class TestCanonicalLoRA:
         assert second_transform.linear_q is first_linear_q
 
         # Verify the module types are still correct
-        assert isinstance(second_transform.linear_proj, LinearAdapter)
-        assert isinstance(second_transform.linear_fc2, LinearAdapter)
+        assert isinstance(second_transform.linear_proj, LoRALinear)
+        assert isinstance(second_transform.linear_fc2, LoRALinear)
         assert isinstance(second_transform.linear_q, nn.Linear)
 
         # Verify the LoRA parameters are identical
         assert torch.equal(
-            first_transform.linear_proj.linear_in.weight.data, second_transform.linear_proj.linear_in.weight.data
+            first_transform.linear_proj.adapter.linear_in.weight.data,
+            second_transform.linear_proj.adapter.linear_in.weight.data,
         )
         assert torch.equal(
-            first_transform.linear_proj.linear_out.weight.data, second_transform.linear_proj.linear_out.weight.data
+            first_transform.linear_proj.adapter.linear_out.weight.data,
+            second_transform.linear_proj.adapter.linear_out.weight.data,
         )
 
     def test_canonical_lora_transform_idempotent_fused_layers(self):
@@ -1273,8 +1275,8 @@ class TestCanonicalLoRAIntegration:
         adapted_model = lora(model, training=True)
 
         # Verify CanonicalLoRA was applied
-        assert isinstance(adapted_model.linear_proj, LinearAdapter)
-        assert isinstance(adapted_model.linear_fc2, LinearAdapter)
+        assert isinstance(adapted_model.linear_proj, LoRALinear)
+        assert isinstance(adapted_model.linear_fc2, LoRALinear)
         # Verify non-target modules were not adapted
         assert isinstance(adapted_model.linear_q, nn.Linear)
         assert isinstance(adapted_model.linear_k, nn.Linear)

--- a/tests/unit_tests/peft/test_lora.py
+++ b/tests/unit_tests/peft/test_lora.py
@@ -247,10 +247,10 @@ class TestLoRA:
         transformed_model = lora(model, training=True)
 
         # Check that target modules were transformed to LinearAdapter
-        assert isinstance(transformed_model.linear_qkv, LinearAdapter)
-        assert isinstance(transformed_model.linear_proj, LinearAdapter)
-        assert isinstance(transformed_model.linear_fc1, LinearAdapter)
-        assert isinstance(transformed_model.linear_fc2, LinearAdapter)
+        assert isinstance(transformed_model.linear_qkv, LoRALinear)
+        assert isinstance(transformed_model.linear_proj, LoRALinear)
+        assert isinstance(transformed_model.linear_fc1, LoRALinear)
+        assert isinstance(transformed_model.linear_fc2, LoRALinear)
 
         # Check that non-target modules were not transformed
         assert isinstance(transformed_model.output_projection, nn.Linear)
@@ -275,9 +275,9 @@ class TestLoRA:
 
         # Check that non-excluded linear modules were transformed
         # (In exclude mode, all linear layers except excluded ones should be transformed)
-        assert isinstance(transformed_model.linear_qkv, LinearAdapter)
-        assert isinstance(transformed_model.linear_proj, LinearAdapter)
-        assert isinstance(transformed_model.linear_fc1, LinearAdapter)
+        assert isinstance(transformed_model.linear_qkv, LoRALinear)
+        assert isinstance(transformed_model.linear_proj, LoRALinear)
+        assert isinstance(transformed_model.linear_fc1, LoRALinear)
 
         # Non-linear modules should never be transformed regardless
         assert isinstance(transformed_model.embedding, nn.Embedding)
@@ -293,10 +293,10 @@ class TestLoRA:
 
         # Check that nested target modules were transformed
         for layer in transformed_model.layers:
-            assert isinstance(layer["attention"]["linear_qkv"], LinearAdapter)
-            assert isinstance(layer["attention"]["linear_proj"], LinearAdapter)
-            assert isinstance(layer["mlp"]["linear_fc1"], LinearAdapter)
-            assert isinstance(layer["mlp"]["linear_fc2"], LinearAdapter)
+            assert isinstance(layer["attention"]["linear_qkv"], LoRALinear)
+            assert isinstance(layer["attention"]["linear_proj"], LoRALinear)
+            assert isinstance(layer["mlp"]["linear_fc1"], LoRALinear)
+            assert isinstance(layer["mlp"]["linear_fc2"], LoRALinear)
 
     def test_lora_grouped_expert_transform_uses_shared_adapter_by_default(self):
         """Grouped expert linears should keep the cheaper shared adapter path by default."""
@@ -362,8 +362,8 @@ class TestLoRA:
         transformed_model = lora(model, training=True)
 
         # Check first layer attention modules are transformed
-        assert isinstance(transformed_model.layers[0]["attention"]["linear_qkv"], LinearAdapter)
-        assert isinstance(transformed_model.layers[0]["attention"]["linear_proj"], LinearAdapter)
+        assert isinstance(transformed_model.layers[0]["attention"]["linear_qkv"], LoRALinear)
+        assert isinstance(transformed_model.layers[0]["attention"]["linear_proj"], LoRALinear)
 
         # Check first layer MLP modules are NOT transformed
         assert isinstance(transformed_model.layers[0]["mlp"]["linear_fc1"], nn.Linear)
@@ -400,7 +400,7 @@ class TestLoRA:
 
         transformed = lora(model, training=True)
 
-        assert isinstance(transformed.linear_qkv, LinearAdapter)
+        assert isinstance(transformed.linear_qkv, LoRALinear)
         assert isinstance(transformed.linear_proj, nn.Linear)
         assert isinstance(transformed.linear_fc1, nn.Linear)
         assert isinstance(transformed.linear_fc2, nn.Linear)
@@ -413,8 +413,8 @@ class TestLoRA:
         # Apply LoRA
         transformed_model = lora(model, training=True)
 
-        # Check adapter properties
-        adapter = transformed_model.linear_qkv
+        # Adapter properties live on the delta-only LinearAdapter sub-module.
+        adapter = transformed_model.linear_qkv.adapter
         assert hasattr(adapter, "dim")
         assert hasattr(adapter, "alpha")
         assert hasattr(adapter, "scale")
@@ -434,15 +434,15 @@ class TestLoRA:
         # Apply LoRA
         transformed_model = lora(model, training=True)
 
-        # Check that original weights are frozen
-        linear_adapter = transformed_model.linear_qkv
-        assert not linear_adapter.weight.requires_grad
-        if linear_adapter.bias is not None:
-            assert not linear_adapter.bias.requires_grad
+        # Check that original weights are frozen (base weight on the wrapped module)
+        wrapped = transformed_model.linear_qkv
+        assert not wrapped.to_wrap.weight.requires_grad
+        if wrapped.to_wrap.bias is not None:
+            assert not wrapped.to_wrap.bias.requires_grad
 
         # Check that LoRA parameters are trainable
-        assert linear_adapter.linear_in.weight.requires_grad
-        assert linear_adapter.linear_out.weight.requires_grad
+        assert wrapped.adapter.linear_in.weight.requires_grad
+        assert wrapped.adapter.linear_out.weight.requires_grad
 
     def test_lora_forward_pass(self):
         """Test that LoRA adapted models can perform forward passes."""
@@ -499,10 +499,10 @@ class TestLoRA:
 
         # Each chunk should have LoRA applied
         for chunk in transformed_chunks:
-            assert isinstance(chunk.linear_qkv, LinearAdapter)
-            assert isinstance(chunk.linear_proj, LinearAdapter)
-            assert isinstance(chunk.linear_fc1, LinearAdapter)
-            assert isinstance(chunk.linear_fc2, LinearAdapter)
+            assert isinstance(chunk.linear_qkv, LoRALinear)
+            assert isinstance(chunk.linear_proj, LoRALinear)
+            assert isinstance(chunk.linear_fc1, LoRALinear)
+            assert isinstance(chunk.linear_fc2, LoRALinear)
 
 
 class TestModelOptLinear:
@@ -786,10 +786,10 @@ class TestLoRANormalizeMoE:
 
         transformed_model = lora(model, training=True)
 
-        assert isinstance(transformed_model.linear_fc1, LinearAdapter)
-        assert isinstance(transformed_model.linear_fc2, LinearAdapter)
-        assert transformed_model.linear_fc1.dim == 32
-        assert transformed_model.linear_fc2.dim == 32
+        assert isinstance(transformed_model.linear_fc1, LoRALinear)
+        assert isinstance(transformed_model.linear_fc2, LoRALinear)
+        assert transformed_model.linear_fc1.adapter.dim == 32
+        assert transformed_model.linear_fc2.adapter.dim == 32
 
 
 class TestLoRAMerge:
@@ -1015,7 +1015,7 @@ class TestLoRAIntegration:
         adapted_model = lora(model, training=True)
 
         # Verify LoRA was applied
-        assert isinstance(adapted_model.linear_qkv, LinearAdapter)
+        assert isinstance(adapted_model.linear_qkv, LoRALinear)
 
         # Perform training step (mock)
         optimizer = torch.optim.Adam(adapted_model.parameters())
@@ -1030,7 +1030,7 @@ class TestLoRAIntegration:
         loss.backward()
         optimizer.step()
 
-        assert isinstance(adapted_model.linear_qkv, LinearAdapter)
+        assert isinstance(adapted_model.linear_qkv, LoRALinear)
 
     def test_lora_parameter_efficiency(self):
         """Test that LoRA significantly reduces trainable parameters."""
@@ -1064,12 +1064,12 @@ class TestLoRAIntegration:
         adapted_model2 = lora2(model2, training=True)
 
         # LoRA weights should be identical with same seed
-        linear_in_1 = adapted_model1.linear_qkv.linear_in.weight.data
-        linear_in_2 = adapted_model2.linear_qkv.linear_in.weight.data
+        linear_in_1 = adapted_model1.linear_qkv.adapter.linear_in.weight.data
+        linear_in_2 = adapted_model2.linear_qkv.adapter.linear_in.weight.data
         assert torch.equal(linear_in_1, linear_in_2)
 
-        linear_out_1 = adapted_model1.linear_qkv.linear_out.weight.data
-        linear_out_2 = adapted_model2.linear_qkv.linear_out.weight.data
+        linear_out_1 = adapted_model1.linear_qkv.adapter.linear_out.weight.data
+        linear_out_2 = adapted_model2.linear_qkv.adapter.linear_out.weight.data
         assert torch.equal(linear_out_1, linear_out_2)
 
     def test_lora_transform_idempotent(self):
@@ -1086,8 +1086,8 @@ class TestLoRAIntegration:
         first_linear_fc1 = first_transform.linear_fc1  # Should remain unchanged
 
         # Verify first transformation worked
-        assert isinstance(first_linear_qkv, LinearAdapter)
-        assert isinstance(first_linear_proj, LinearAdapter)
+        assert isinstance(first_linear_qkv, LoRALinear)
+        assert isinstance(first_linear_proj, LoRALinear)
         assert isinstance(first_linear_fc1, nn.Linear)
 
         # Apply LoRA second time to the already-transformed model
@@ -1099,16 +1099,18 @@ class TestLoRAIntegration:
         assert second_transform.linear_fc1 is first_linear_fc1
 
         # Verify the module types are still correct
-        assert isinstance(second_transform.linear_qkv, LinearAdapter)
-        assert isinstance(second_transform.linear_proj, LinearAdapter)
+        assert isinstance(second_transform.linear_qkv, LoRALinear)
+        assert isinstance(second_transform.linear_proj, LoRALinear)
         assert isinstance(second_transform.linear_fc1, nn.Linear)
 
         # Verify the LoRA parameters are identical
         assert torch.equal(
-            first_transform.linear_qkv.linear_in.weight.data, second_transform.linear_qkv.linear_in.weight.data
+            first_transform.linear_qkv.adapter.linear_in.weight.data,
+            second_transform.linear_qkv.adapter.linear_in.weight.data,
         )
         assert torch.equal(
-            first_transform.linear_qkv.linear_out.weight.data, second_transform.linear_qkv.linear_out.weight.data
+            first_transform.linear_qkv.adapter.linear_out.weight.data,
+            second_transform.linear_qkv.adapter.linear_out.weight.data,
         )
 
 

--- a/tests/unit_tests/peft/test_lora_layers.py
+++ b/tests/unit_tests/peft/test_lora_layers.py
@@ -19,7 +19,6 @@ Tests LoRA adapters and linear adapter functionality for Parameter-Efficient Fin
 """
 
 import os
-from copy import deepcopy
 from types import SimpleNamespace
 
 import megatron.core.parallel_state as parallel_state
@@ -203,7 +202,7 @@ class TestLoRALinear:
 
 
 class TestLinearAdapter:
-    """Test the LinearAdapter class."""
+    """Test the LinearAdapter class (delta-only LoRA adapter)."""
 
     @pytest.fixture
     def original_linear(self):
@@ -222,12 +221,12 @@ class TestLinearAdapter:
         return linear
 
     def test_linear_adapter_init_with_bias(self, original_linear):
-        """Test LinearAdapter initialization with bias."""
+        """Test LinearAdapter initialization derives shape from the original linear."""
         adapter = LinearAdapter(original_linear, dim=8, alpha=16)
 
-        # Check that original weights are copied
-        assert torch.equal(adapter.weight, original_linear.weight)
-        assert torch.equal(adapter.bias, original_linear.bias)
+        # LinearAdapter is now delta-only: it must NOT copy the base weight/bias.
+        assert not hasattr(adapter, "weight")
+        assert not hasattr(adapter, "bias")
 
         # Check LoRA components exist
         assert hasattr(adapter, "linear_in")
@@ -245,11 +244,11 @@ class TestLinearAdapter:
         assert adapter.scale == 16 / 8  # alpha / dim
 
     def test_linear_adapter_init_no_bias(self, original_linear_no_bias):
-        """Test LinearAdapter initialization without bias."""
+        """Test LinearAdapter initialization without bias derives out_features correctly."""
         adapter = LinearAdapter(original_linear_no_bias, dim=4, alpha=8)
 
-        assert torch.equal(adapter.weight, original_linear_no_bias.weight)
-        assert adapter.bias is None
+        assert adapter.linear_in.in_features == 10
+        assert adapter.linear_out.out_features == 5
 
     def test_linear_adapter_linear_out_initialized_to_zero(self, original_linear):
         """Test that LoRA B matrix is initialized to zero."""
@@ -264,14 +263,6 @@ class TestLinearAdapter:
 
         # Should not be all zeros
         assert not torch.allclose(adapter.linear_in.weight, torch.zeros_like(adapter.linear_in.weight))
-
-    def test_linear_adapter_freezes_original_weights(self, original_linear):
-        """Test that original weights are frozen."""
-        adapter = LinearAdapter(original_linear)
-
-        assert not adapter.weight.requires_grad
-        if adapter.bias is not None:
-            assert not adapter.bias.requires_grad
 
     def test_linear_adapter_lora_weights_trainable(self, original_linear):
         """Test that LoRA weights are trainable."""
@@ -288,8 +279,8 @@ class TestLinearAdapter:
         assert adapter.dropout_position == dropout_position
         assert isinstance(adapter.dropout, nn.Dropout)
 
-    def test_linear_adapter_forward_basic(self, original_linear):
-        """Test LinearAdapter forward pass."""
+    def test_linear_adapter_forward_is_delta_only(self, original_linear):
+        """Test that LinearAdapter.forward returns only the scaled LoRA delta."""
         adapter = LinearAdapter(original_linear, dim=4)
         x = torch.randn(3, 10)
 
@@ -297,6 +288,12 @@ class TestLinearAdapter:
 
         assert output.shape == (3, 5)
         assert isinstance(output, torch.Tensor)
+
+        # The delta must equal scale * linear_out(linear_in(x)) with zero dropout in eval mode.
+        adapter.eval()
+        with torch.no_grad():
+            expected = adapter.scale * adapter.linear_out(adapter.linear_in(x))
+        assert torch.allclose(output, expected, atol=1e-6)
 
     def test_linear_adapter_forward_with_dropout(self, original_linear):
         """Test LinearAdapter forward with dropout."""
@@ -313,40 +310,107 @@ class TestLinearAdapter:
 
         assert output_train.shape == output_eval.shape == (3, 5)
 
-    def test_linear_adapter_state_dict_preservation(self, original_linear):
-        """Test that state dict keys are preserved as in NeMo tests."""
-        state_init = deepcopy(original_linear.state_dict())
+    def test_linear_adapter_state_dict_keys(self, original_linear):
+        """Test that LinearAdapter state dict only contains LoRA delta keys."""
         adapter = LinearAdapter(original_linear)
 
-        # Check if the original state-dict keys are preserved
-        for key, val in state_init.items():
-            assert key in adapter.state_dict(), f"Key {key} not found in LinearAdapter"
-            assert torch.equal(val, adapter.state_dict()[key]), f"Key {key} diff. val in LinearAdapter"
+        keys = set(adapter.state_dict().keys())
+        assert keys == {"linear_in.weight", "linear_out.weight"}
 
-        # Make sure the additional keys are in the allow list
-        for key, val in adapter.state_dict().items():
-            if key in state_init:
-                continue
-            assert key in ["linear_in.weight", "linear_out.weight"]
-
-    def test_linear_adapter_zero_output_initially(self, original_linear):
-        """Test that adapter produces zero output initially (LoRA B is zero)."""
-        # Create adapter with specific initialization
+    def test_linear_adapter_zero_delta_initially(self, original_linear):
+        """Test that the adapter delta is zero initially (LoRA B is zero)."""
         adapter = LinearAdapter(original_linear, dim=4)
         x = torch.randn(3, 10)
 
-        # Get original output
-        with torch.no_grad():
-            original_output = torch.nn.functional.linear(x, original_linear.weight, original_linear.bias)
-
-        # Get adapter output
         with torch.no_grad():
             adapter_output = adapter(x)
 
-        # Initially, LoRA should add approximately zero
-        # (not exactly zero due to random initialization of linear_in, but very small)
-        lora_contribution = adapter_output - original_output
-        assert torch.allclose(lora_contribution, torch.zeros_like(lora_contribution), atol=1e-2)
+        # Initially, LoRA B is zero, so the delta is exactly zero.
+        assert torch.allclose(adapter_output, torch.zeros_like(adapter_output), atol=1e-6)
+
+
+class TestLoRALinearWithPlainLinear:
+    """Test LoRALinear wrapping a plain nn.Linear (to_wrap/adapter pattern)."""
+
+    @pytest.fixture
+    def original_linear(self):
+        """Create an original linear layer."""
+        linear = nn.Linear(10, 5, bias=True)
+        nn.init.constant_(linear.weight, 1.0)
+        nn.init.constant_(linear.bias, 0.1)
+        return linear
+
+    def test_wrap_returns_tensor(self, original_linear):
+        """Wrapping a plain nn.Linear must return a bare tensor (drop-in for nn.Linear)."""
+        adapter = LinearAdapter(original_linear, dim=4, alpha=8)
+        wrapped = LoRALinear(original_linear, adapter)
+
+        x = torch.randn(3, 10)
+        out = wrapped(x)
+
+        assert isinstance(out, torch.Tensor)
+        assert out.shape == (3, 5)
+
+    def test_wrap_to_wrap_and_adapter(self, original_linear):
+        """LoRALinear exposes to_wrap and adapter submodules."""
+        adapter = LinearAdapter(original_linear, dim=4, alpha=8)
+        wrapped = LoRALinear(original_linear, adapter)
+
+        assert wrapped.to_wrap is original_linear
+        assert wrapped.adapter is adapter
+
+    def test_wrap_state_dict_uses_adapter_prefix(self, original_linear):
+        """State dict keeps base weight/bias flat and LoRA delta under adapter. prefix."""
+        adapter = LinearAdapter(original_linear, dim=4, alpha=8)
+        wrapped = LoRALinear(original_linear, adapter)
+
+        keys = set(wrapped.state_dict().keys())
+        assert "weight" in keys
+        assert "bias" in keys
+        assert "adapter.linear_in.weight" in keys
+        assert "adapter.linear_out.weight" in keys
+
+    def test_wrap_matches_base_at_init(self, original_linear):
+        """At init (LoRA B zero), wrapped output equals the base linear output."""
+        adapter = LinearAdapter(original_linear, dim=4, alpha=8)
+        wrapped = LoRALinear(original_linear, adapter)
+
+        x = torch.randn(3, 10)
+        with torch.no_grad():
+            base_output = torch.nn.functional.linear(x, original_linear.weight, original_linear.bias)
+            wrapped_output = wrapped(x)
+
+        assert torch.allclose(wrapped_output, base_output, atol=1e-6)
+
+    def test_wrap_adds_delta_when_enabled(self, original_linear):
+        """When adapter is enabled and B is nonzero, wrapped output = base + delta."""
+        adapter = LinearAdapter(original_linear, dim=4, alpha=8)
+        with torch.no_grad():
+            adapter.linear_out.weight.fill_(0.5)
+        wrapped = LoRALinear(original_linear, adapter)
+
+        x = torch.randn(3, 10)
+        with torch.no_grad():
+            base_output = torch.nn.functional.linear(x, original_linear.weight, original_linear.bias)
+            delta = adapter(x)
+            wrapped_output = wrapped(x)
+
+        assert torch.allclose(wrapped_output, base_output + delta, atol=1e-6)
+
+    def test_wrap_disable_returns_base(self, original_linear):
+        """Disabling the adapter makes the wrapper return only the base output."""
+        adapter = LinearAdapter(original_linear, dim=4, alpha=8)
+        with torch.no_grad():
+            adapter.linear_out.weight.fill_(0.5)
+        wrapped = LoRALinear(original_linear, adapter)
+        wrapped.disable_adapter_layers()
+
+        x = torch.randn(3, 10)
+        with torch.no_grad():
+            base_output = torch.nn.functional.linear(x, original_linear.weight, original_linear.bias)
+            wrapped_output = wrapped(x)
+
+        assert torch.allclose(wrapped_output, base_output, atol=1e-6)
 
 
 class TestTEFusedLoRALinear:
@@ -598,7 +662,7 @@ class TestLoRAUtilities:
         assert output1.shape == output2.shape == (3, 5)
 
     def test_linear_adapter_math_correctness(self):
-        """Test that LinearAdapter math is correct."""
+        """Test that LinearAdapter (delta-only) and its LoRALinear wrapper are correct."""
         linear = nn.Linear(10, 5, bias=False)
         nn.init.constant_(linear.weight, 1.0)
 
@@ -611,16 +675,21 @@ class TestLoRAUtilities:
 
         x = torch.ones(1, 10)
 
-        # Expected: original + lora_scale * linear_out(linear_in(x))
-        # original = x @ linear.weight.T = 1*10 @ 1_{5,10}.T = 10 * ones(1,5)
+        # Delta math (LinearAdapter.forward returns the scaled delta only):
         # linear_in(x) = x @ linear_in.weight.T = 1*10 @ 0.1_{2,10}.T = 1.0 * ones(1,2)
         # linear_out(linear_in(x)) = 1.0 @ 0.1_{5,2}.T = 0.2 * ones(1,5)
         # lora_scale = alpha/dim = 4/2 = 2
-        # final = 10 + 2 * 0.2 = 10.4
+        # delta = 2 * 0.2 = 0.4
+        delta = adapter(x)
+        expected_delta = torch.full((1, 5), 0.4)
+        assert torch.allclose(delta, expected_delta, atol=1e-6)
 
-        output = adapter(x)
+        # Combined via LoRALinear = base + delta
+        # original = x @ linear.weight.T = 1*10 @ 1_{5,10}.T = 10 * ones(1,5)
+        # final = 10 + 0.4 = 10.4
+        wrapped = LoRALinear(linear, adapter)
+        output = wrapped(x)
         expected = torch.full((1, 5), 10.4)
-
         assert torch.allclose(output, expected, atol=1e-6)
 
 

--- a/tests/unit_tests/recipes/test_moonlight_recipes.py
+++ b/tests/unit_tests/recipes/test_moonlight_recipes.py
@@ -487,7 +487,7 @@ def test_moonlight_16b_legacy_sft_contract_remains_available(monkeypatch: pytest
 def test_moonlight_16b_peft_convergence_contract(monkeypatch: pytest.MonkeyPatch):
     """Test the exact 4-GPU LoRA convergence contract and frozen base."""
     from megatron.bridge.peft.lora import LoRA
-    from megatron.bridge.peft.lora_layers import LinearAdapter
+    from megatron.bridge.peft.lora_layers import LoRALinear
     from megatron.bridge.recipes.moonlight import moonlight_16b_peft_config
 
     patch_recipe_module_global(monkeypatch, moonlight_16b_peft_config, "AutoBridge", _FakeBridge)
@@ -534,7 +534,7 @@ def test_moonlight_16b_peft_convergence_contract(monkeypatch: pytest.MonkeyPatch
     for target in expected_targets + ["linear_qkv"]:
         setattr(base_model, target, torch.nn.Linear(2, 2))
     cfg.peft(base_model)
-    assert all(isinstance(getattr(base_model, target), LinearAdapter) for target in expected_targets)
+    assert all(isinstance(getattr(base_model, target), LoRALinear) for target in expected_targets)
     assert isinstance(base_model.linear_qkv, torch.nn.Linear)
     assert all(not parameter.requires_grad for parameter in base_model.linear_qkv.parameters())
     assert cfg.model.recompute_granularity is None


### PR DESCRIPTION
# What does this PR do ?

To make PEFT bridge / LoRA merge work smoothly, we need to align the simple `nn.Linear` LoRA code path with the Megatron parallel path by adopting the `to_wrap`/`adapter` wrapper pattern: plain linears are now wrapped as `LoRALinear(module, LinearAdapter(...))` instead of returning a self-contained fused `LinearAdapter`.

# Changelog

- **`LinearAdapter` (`peft/lora_layers.py`)** — refactored from an `nn.Linear` subclass that copied the base weight and fused base+LoRA in one `forward` into a delta-only `nn.Module` (mirrors `ParallelLinearAdapter`'s role): it holds only `linear_in`/`linear_out` and returns the scaled LoRA delta. No base weight/bias copy.
- **Simple path (`peft/lora.py`, `peft/canonical_lora.py`)** — `LoRA.transform`/`CanonicalLoRA.transform` now build `LinearAdapter(module, ...)` and wrap it as `LoRALinear(module, adapter)`; `LinearAdapter` removed from the already-transformed skip-tuples (it is now a sub-module, not a top-level wrapper).
- **`LoRALinear` / `base_linear_forward` (`peft/adapter_wrapper.py`, `peft/lora_layers.py`)** — generalized to handle plain `nn.Linear`'s bare-tensor return (Megatron modules return tuples). `base_linear_forward` branches on `isinstance(result, torch.Tensor)` before the tuple unpacking and records the return shape via `_base_returns_tuple`; `LoRALinear.forward` returns a bare tensor for plain `nn.Linear` (drop-in replacement) and `(out, bias)` for Megatron modules. Non-tensor, non-tuple returns still raise `AssertionError`.
- **Checkpoint keys** — adapter delta now stored under the `adapter.` prefix (`adapter.linear_in.weight`, `adapter.linear_out.weight`) via `AdapterWrapper.state_dict`, consistent with the parallel path. **Breaking:** existing simple-linear LoRA checkpoints (flat `linear_in.weight`/`linear_out.weight`) are not forward-compatible and must be re-saved.
- **Guards for plain `nn.Linear`**:
  - `AdapterWrapper.sharded_state_dict` guards `hasattr(to_wrap/adapter, "sharded_state_dict")` so it no longer crashes on plain modules.
  - `models/conversion/peft_bridge.py` short-circuits `LinearAdapter` to default parallelism attributes (`input_is_parallel=False`, `base_linear_is_parallel=False`, `requires_expert_splits=False`) instead of calling `get_adapter_attributes_from_linear(to_wrap)`, which requires `to_wrap.config` that plain `nn.Linear` lacks.
- **Tests** — updated `test_adapter_wrapper.py`, `test_lora_layers.py`, `test_lora.py`, `test_canonical_lora.py`, `test_moonlight_recipes.py` for the new `isinstance(..., LoRALinear)` wrapper type, `.adapter.*` attribute access, and `adapter.`-prefixed state-dict keys. Added `test_base_linear_forward_tensor_return` and restored `test_base_linear_forward_invalid_return` for the malformed-return guard.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [X] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [X] Did you write any new necessary tests?
- [X] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
