### PR TITLE
[model] fix: use local GPT spec for CPU-only initialization

### DIFF
--- a/src/megatron/bridge/models/gpt_provider.py
+++ b/src/megatron/bridge/models/gpt_provider.py
@@ -97,6 +97,11 @@ def local_layer_spec(config: "GPTModelProvider") -> ModuleSpec:
     )
 
 
+def _use_local_spec_for_cpu_only_initialization(config: "GPTModelProvider") -> bool:
+    """Return whether CPU initialization must avoid Transformer Engine modules."""
+    return bool(config.use_cpu_initialization) and not torch.cuda.is_available()
+
+
 def modelopt_transformer_layer_spec(config: "GPTModelProvider") -> ModuleSpec:
     """Layer specification for quantization with ModelOpt."""
     # arbitrary attention mask is used for speculative decoding training
@@ -119,6 +124,8 @@ def modelopt_transformer_layer_spec(config: "GPTModelProvider") -> ModuleSpec:
 
 def default_layer_spec(config: "GPTModelProvider") -> ModuleSpec:
     """Determine the most appropriate layer specification based on availability."""
+    if _use_local_spec_for_cpu_only_initialization(config):
+        return local_layer_spec(config)
     if config.use_transformer_engine_full_layer_spec:
         return transformer_engine_full_layer_spec(config)
     else:
@@ -352,6 +359,7 @@ def mtp_block_spec(config: "GPTModelProvider", vp_stage: Optional[int] = None) -
     if getattr(config, "mtp_num_layers", None):
         from megatron.core.models.gpt.gpt_layer_specs import get_gpt_mtp_block_spec
 
+        use_transformer_engine = not _use_local_spec_for_cpu_only_initialization(config)
         if isinstance(config.transformer_layer_spec, Callable):
             if "vp_stage" in inspect.signature(config.transformer_layer_spec).parameters:
                 spec = config.transformer_layer_spec(config, vp_stage=vp_stage)
@@ -368,12 +376,12 @@ def mtp_block_spec(config: "GPTModelProvider", vp_stage: Optional[int] = None) -
 
             decoder_layer_specs = get_gpt_decoder_layer_specs(
                 config,
-                use_transformer_engine=True,
+                use_transformer_engine=use_transformer_engine,
                 normalization=config.normalization,
                 qk_l2_norm=config.qk_l2_norm,
             )
             spec = decoder_layer_specs[-1]
-        return get_gpt_mtp_block_spec(config, spec, use_transformer_engine=True, vp_stage=vp_stage)
+        return get_gpt_mtp_block_spec(config, spec, use_transformer_engine=use_transformer_engine, vp_stage=vp_stage)
     else:
         return None
 

--- a/tests/unit_tests/models/test_gpt_provider.py
+++ b/tests/unit_tests/models/test_gpt_provider.py
@@ -374,6 +374,57 @@ class TestGPTModelProvider:
         mock_te_spec.assert_called_once_with(provider)
         assert result == "te_spec"
 
+    @patch("megatron.bridge.models.gpt_provider.local_layer_spec")
+    @patch("megatron.bridge.models.gpt_provider.transformer_engine_layer_spec")
+    @patch("megatron.bridge.models.gpt_provider.transformer_engine_full_layer_spec")
+    @patch("megatron.bridge.models.gpt_provider.torch.cuda.is_available", return_value=False)
+    def test_default_layer_spec_uses_local_spec_for_cpu_only_initialization(
+        self, mock_cuda_available, mock_te_full_spec, mock_te_spec, mock_local_spec
+    ):
+        """CPU-only model construction must not instantiate Transformer Engine modules."""
+        from megatron.bridge.models.gpt_provider import default_layer_spec
+
+        provider = GPTModelProvider(
+            num_layers=12,
+            hidden_size=768,
+            num_attention_heads=12,
+            use_cpu_initialization=True,
+            use_transformer_engine_full_layer_spec=True,
+        )
+        mock_local_spec.return_value = "local_spec"
+
+        result = default_layer_spec(provider)
+
+        mock_cuda_available.assert_called_once_with()
+        mock_local_spec.assert_called_once_with(provider)
+        mock_te_full_spec.assert_not_called()
+        mock_te_spec.assert_not_called()
+        assert result == "local_spec"
+
+    @patch("megatron.bridge.models.gpt_provider.local_layer_spec")
+    @patch("megatron.bridge.models.gpt_provider.transformer_engine_layer_spec")
+    @patch("megatron.bridge.models.gpt_provider.torch.cuda.is_available", return_value=True)
+    def test_default_layer_spec_keeps_te_spec_for_cpu_initialization_with_cuda(
+        self, mock_cuda_available, mock_te_spec, mock_local_spec
+    ):
+        """CPU initialization on a CUDA host preserves the configured TE model layout."""
+        from megatron.bridge.models.gpt_provider import default_layer_spec
+
+        provider = GPTModelProvider(
+            num_layers=12,
+            hidden_size=768,
+            num_attention_heads=12,
+            use_cpu_initialization=True,
+        )
+        mock_te_spec.return_value = "te_spec"
+
+        result = default_layer_spec(provider)
+
+        mock_cuda_available.assert_called_once_with()
+        mock_local_spec.assert_not_called()
+        mock_te_spec.assert_called_once_with(provider)
+        assert result == "te_spec"
+
     def test_mtp_block_spec_returns_none_when_mtp_disabled(self):
         """mtp_block_spec returns None when mtp_num_layers is unset."""
         from megatron.bridge.models.gpt_provider import mtp_block_spec
@@ -454,6 +505,42 @@ class TestGPTModelProvider:
             qk_l2_norm=provider.qk_l2_norm,
         )
         mock_get_mtp.assert_called_once_with(provider, moe_layer_spec, use_transformer_engine=True, vp_stage=2)
+        assert result == "mtp_spec"
+
+    @patch("megatron.bridge.models.gpt_provider.torch.cuda.is_available", return_value=False)
+    @patch("megatron.core.models.gpt.gpt_layer_specs.get_gpt_decoder_layer_specs")
+    @patch("megatron.core.models.gpt.gpt_layer_specs.get_gpt_mtp_block_spec")
+    def test_mtp_block_spec_uses_local_spec_for_cpu_only_initialization(
+        self, mock_get_mtp, mock_get_decoder_specs, mock_cuda_available
+    ):
+        """CPU-only MTP construction must propagate the non-TE layer selection."""
+        from megatron.bridge.models.gpt_provider import mtp_block_spec
+
+        provider = GPTModelProvider(
+            num_layers=2,
+            hidden_size=128,
+            num_attention_heads=4,
+            mtp_num_layers=1,
+            use_cpu_initialization=True,
+        )
+        empty_block_spec = Mock()
+        empty_block_spec.layer_specs = []
+        provider.transformer_layer_spec = lambda config: empty_block_spec
+
+        local_moe_spec = Mock(name="local_moe_spec")
+        mock_get_decoder_specs.return_value = [local_moe_spec]
+        mock_get_mtp.return_value = "mtp_spec"
+
+        result = mtp_block_spec(provider, vp_stage=2)
+
+        mock_cuda_available.assert_called_once_with()
+        mock_get_decoder_specs.assert_called_once_with(
+            provider,
+            use_transformer_engine=False,
+            normalization=provider.normalization,
+            qk_l2_norm=provider.qk_l2_norm,
+        )
+        mock_get_mtp.assert_called_once_with(provider, local_moe_spec, use_transformer_engine=False, vp_stage=2)
         assert result == "mtp_spec"
 
     @patch("megatron.core.models.gpt.gpt_layer_specs.get_gpt_mtp_block_spec")


### PR DESCRIPTION
<details><summary>Summary</summary>

## What

- Select the MCore-local GPT layer spec when `use_cpu_initialization=True`
  and CUDA is unavailable, avoiding CUDA-only Transformer Engine module
  construction on CPU-only hosts.
- Keep the existing TE spec when CUDA is available.
- Propagate the same local-versus-TE choice to MTP block construction.

This revisits the narrow spec-selection portion of #3853 in response to a real
full `openai/gpt-oss-20b` CPU-import failure. It does not revive that closed PR's
broader provider monkeypatches.

## Compatibility gate

The local-spec versus later GPU/TE checkpoint compatibility concern that closed
#3853 is treated as an acceptance gate, not assumed away. Current MCore provides
canonical sharded-state mappings and direct local-GPT-spec ↔ TE-GPT-spec
save/load coverage, including SequentialMLP ↔ TEGroupedMLP interchange.

Before this PR is called verified, a full GPT-OSS checkpoint produced by the
CPU-only local-spec path must load into the GPU/TE model from exact clean pushed
commits. If it does not, this approach is not acceptable.

## Validation

- [x] `tests/unit_tests/models/test_gpt_provider.py`: 29 passed in a
  driverless 26.06 container.
- [x] `uv run --no-sync pre-commit run --all-files`.
- [ ] Full `openai/gpt-oss-20b` CPU import from a clean public integration
  commit.
- [ ] Load the CPU-produced checkpoint into the GPU/TE GPT-OSS model.

No tests will be quarantined without Chen's explicit approval. No local source
patch or unpublished overlay may be counted as verification evidence.

</details>
