### PR TITLE
fix(model): enable RADIO recompute for Nemotron Omni SFT

### DIFF
--- a/examples/models/nemotron/nemotron_3_omni/README.md
+++ b/examples/models/nemotron/nemotron_3_omni/README.md
@@ -189,8 +189,9 @@ bash examples/models/nemotron/nemotron_3_omni/inference.sh
 ## Training
 
 All training scripts use the Nemotron-3-Nano-Omni-30B-A3B-Reasoning
-pretrained checkpoint and enable in-batch sequence packing via
-`dataset.enable_in_batch_packing=True`. Default GPU layout per script:
+pretrained checkpoint. Sequence packing is workload-specific: CORD Full SFT
+is non-packed, while LoRA enables in-batch packing. Default GPU layout per
+script:
 
 - **Full SFT** — 2 nodes / 16 GPUs (full optimizer state for ~33 B params)
 - **LoRA PEFT** — 1 node / 8 GPUs
@@ -253,8 +254,15 @@ RADIO input contract. Recipe base: `nemotron_omni_cord_v2_*_config` in
 | Full SFT | [slurm_sft_cord_v2.sh](slurm_sft_cord_v2.sh) | `nemotron_omni_cord_v2_sft_config` |
 | LoRA | [slurm_peft_cord_v2.sh](slurm_peft_cord_v2.sh) | `nemotron_omni_cord_v2_peft_config` |
 
-Parallelism (both): TP=2, EP=8, CP=1, MBS=2, GBS=16, packed sequences,
-selective recompute. LoRA targets `linear_qkv`, `linear_proj`, `in_proj`,
+Parallelism (both): TP=2, EP=8, CP=1, GBS=16, selective language recompute.
+Full SFT uses non-packed MBS=1 so each CORD row remains within the 4096-token
+limit after the legacy LLaVA path expands its image placeholder; the unchanged
+global batch is accumulated over two microbatches. Full SFT also
+enables per-layer full recompute for the unfrozen RADIO tower and sets
+`model.radio_force_eval_mode=False` so its training-mode recompute guard
+executes. It offloads half of the optimizer state to CPU with transfer overlap
+to retain GPU memory headroom; CPE remains forced to eval mode. LoRA uses packed
+MBS=2 and targets `linear_qkv`, `linear_proj`, `in_proj`,
 `out_proj` (LM attention + Mamba projections); vision / sound encoders +
 projections frozen.
 

--- a/examples/models/nemotron/nemotron_3_omni/slurm_sft_cord_v2.sh
+++ b/examples/models/nemotron/nemotron_3_omni/slurm_sft_cord_v2.sh
@@ -17,12 +17,11 @@
 # Nemotron-3 Nano Omni - Full SFT on CORD-V2 (image+text)
 #
 # Recipe: nemotron_omni_cord_v2_sft_config (HF dataset backend, no shards needed)
-# Default parallelism: TP=2, EP=8, CP=1, MBS=2, GBS=16, packed sequences,
-#                      selective recompute
+# Default parallelism: TP=2, EP=8, CP=1, MBS=1, GBS=16, selective recompute
 # Default layout:      2 nodes / 16 GPUs
 #
-# Override TP/EP/CP/PACKED_SEQ via environment, e.g.:
-#   TP=4 EP=4 CP=1 PACKED_SEQ=false sbatch slurm_sft_cord_v2.sh
+# Override TP/EP/CP via environment, e.g.:
+#   TP=4 EP=4 CP=1 sbatch slurm_sft_cord_v2.sh
 #
 # Usage:
 #   sbatch slurm_sft_cord_v2.sh
@@ -53,16 +52,17 @@ PRETRAINED_CHECKPOINT=${WORKSPACE}/models/${MODEL_NAME}
 RECIPE=nemotron_omni_cord_v2_sft_config
 DATASET_NAME=cord_v2
 
-# Parallelism / batching (override via env: TP=4 EP=4 CP=1 PACKED_SEQ=false sbatch ...)
+# Parallelism / batching (override via env: TP=4 EP=4 CP=1 sbatch ...)
 TP=${TP:-2}
 EP=${EP:-8}
 CP=${CP:-1}
-PACKED_SEQ=${PACKED_SEQ:-true}
 
 SEQ_LENGTH=4096
 TRAIN_ITERS=4000
 GLOBAL_BATCH_SIZE=16
-MICRO_BATCH_SIZE=2
+# The legacy LLaVA path expands image placeholders during model merge, so one
+# non-packed CORD row per microbatch stays within SEQ_LENGTH.
+MICRO_BATCH_SIZE=1
 EVAL_INTERVAL=50
 EVAL_ITERS=10
 SAVE_INTERVAL=500
@@ -105,7 +105,7 @@ echo "Nodes: ${SLURM_JOB_NUM_NODES:-N/A}"
 echo "GPUs per node: ${SLURM_GPUS_PER_NODE:-N/A}"
 echo "Recipe: $RECIPE"
 echo "Checkpoint: $PRETRAINED_CHECKPOINT"
-echo "Parallelism: TP=$TP EP=$EP CP=$CP (packed=$PACKED_SEQ)"
+echo "Parallelism: TP=$TP EP=$EP CP=$CP (packed=false)"
 echo "======================================"
 
 OUTPUT_DIR=${WORKSPACE}/results/${RECIPE}_sft
@@ -125,16 +125,24 @@ CLI_OVERRIDES="\
     model.sequence_parallel=True \
     model.recompute_granularity=selective \
     model.recompute_modules=[core_attn,mlp,layernorm,moe_act,moe] \
+    model.recompute_vision=True \
+    model.vision_recompute_granularity=full \
+    model.vision_recompute_method=uniform \
+    model.vision_recompute_num_layers=1 \
+    model.radio_force_eval_mode=False \
     model.freeze_language_model=False \
     model.freeze_vision_model=False \
     model.freeze_vision_projection=False \
     model.freeze_sound_encoder=False \
     model.freeze_sound_projection=False \
+    optimizer.optimizer_cpu_offload=True \
+    optimizer.optimizer_offload_fraction=0.5 \
+    optimizer.overlap_cpu_optimizer_d2h_h2d=True \
     train.train_iters=$TRAIN_ITERS \
     train.global_batch_size=$GLOBAL_BATCH_SIZE \
     train.micro_batch_size=$MICRO_BATCH_SIZE \
     dataset.trust_remote_code=True \
-    dataset.enable_in_batch_packing=$PACKED_SEQ \
+    dataset.enable_in_batch_packing=False \
     validation.eval_interval=$EVAL_INTERVAL \
     validation.eval_iters=$EVAL_ITERS \
     logger.log_interval=$LOG_INTERVAL \

--- a/src/megatron/bridge/models/nemotron_omni/nemotron_omni_provider.py
+++ b/src/megatron/bridge/models/nemotron_omni/nemotron_omni_provider.py
@@ -83,6 +83,10 @@ class NemotronVLModelProvider(HybridModelProvider, ABC):
     radio_interpolate_only_cpe: bool = True
     radio_cpe_aspect_ratio_select: bool = False
     radio_disable_cpe: bool = False
+    recompute_vision: bool = False
+    vision_recompute_granularity: Literal["full", "selective"] | None = None
+    vision_recompute_method: Literal["uniform", "block"] | None = None
+    vision_recompute_num_layers: int | None = None
     vision_proj_ffn_hidden_size: int = 20480
     vision_class_token_len: Optional[int] = None
 
@@ -93,13 +97,12 @@ class NemotronVLModelProvider(HybridModelProvider, ABC):
 
     def _build_vision_config(self, language_cfg):
         """Build RADIO ViT-H vision encoder config from a language config copy."""
+        if self.recompute_vision and self.radio_force_eval_mode:
+            raise ValueError("Vision recompute requires radio_force_eval_mode=False.")
         vision_cfg = copy.deepcopy(language_cfg)
         vision_cfg.sequence_parallel = False
         vision_cfg.context_parallel_size = 1
         vision_cfg.tp_comm_overlap = False
-        vision_cfg.recompute_granularity = None
-        vision_cfg.recompute_method = None
-        vision_cfg.recompute_num_layers = None
         vision_cfg.mtp_num_layers = None
         vision_cfg.num_layers = 32
         vision_cfg.num_attention_heads = 16
@@ -117,6 +120,54 @@ class NemotronVLModelProvider(HybridModelProvider, ABC):
         vision_cfg.normalization = "LayerNorm"
         vision_cfg.qk_layernorm = False
         vision_cfg.layernorm_epsilon = 1e-6
+        if self.recompute_vision:
+            granularity = (
+                self.vision_recompute_granularity
+                if self.vision_recompute_granularity is not None
+                else vision_cfg.recompute_granularity
+            )
+            if granularity is None:
+                raise ValueError("Vision recompute requires an effective recompute granularity.")
+            if granularity not in {"full", "selective"}:
+                raise ValueError("Vision recompute granularity must be 'full' or 'selective'.")
+            vision_cfg.recompute_granularity = granularity
+
+            if granularity == "selective":
+                if self.vision_recompute_method is not None or self.vision_recompute_num_layers is not None:
+                    raise ValueError("Selective vision recompute does not use a method or layer count.")
+                vision_cfg.recompute_method = None
+                vision_cfg.recompute_num_layers = None
+            else:
+                method = (
+                    self.vision_recompute_method
+                    if self.vision_recompute_method is not None
+                    else vision_cfg.recompute_method
+                )
+                num_layers = (
+                    self.vision_recompute_num_layers
+                    if self.vision_recompute_num_layers is not None
+                    else vision_cfg.recompute_num_layers
+                )
+                if method is None:
+                    raise ValueError("Full vision recompute requires a recompute method.")
+                if method not in {"uniform", "block"}:
+                    raise ValueError("Full vision recompute method must be 'uniform' or 'block'.")
+                if num_layers is None:
+                    raise ValueError("Full vision recompute requires a layer count.")
+                if (
+                    not isinstance(num_layers, int)
+                    or isinstance(num_layers, bool)
+                    or not 1 <= num_layers <= vision_cfg.num_layers
+                ):
+                    raise ValueError(
+                        f"Full vision recompute layer count must be an integer between 1 and {vision_cfg.num_layers}."
+                    )
+                vision_cfg.recompute_method = method
+                vision_cfg.recompute_num_layers = num_layers
+        else:
+            vision_cfg.recompute_granularity = None
+            vision_cfg.recompute_method = None
+            vision_cfg.recompute_num_layers = None
         if self.vision_class_token_len is not None:
             vision_cfg.class_token_len = self.vision_class_token_len
         return vision_cfg

--- a/tests/unit_tests/models/nemotron_omni/test_nemotron_omni_provider.py
+++ b/tests/unit_tests/models/nemotron_omni/test_nemotron_omni_provider.py
@@ -1,0 +1,177 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from megatron.bridge.models.nemotron_omni.nemotron_omni_provider import NemotronOmniModelProvider
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_vision_recompute_is_disabled_by_default():
+    provider = NemotronOmniModelProvider(
+        recompute_granularity="selective",
+        recompute_modules=["core_attn", "mlp"],
+    )
+
+    vision_config = provider._build_vision_config(provider)
+
+    assert vision_config.recompute_granularity is None
+    assert vision_config.recompute_method is None
+    assert vision_config.recompute_num_layers is None
+
+
+def test_vision_recompute_inherits_selective_model_config_when_enabled():
+    provider = NemotronOmniModelProvider(
+        recompute_vision=True,
+        radio_force_eval_mode=False,
+        recompute_granularity="selective",
+        recompute_modules=["core_attn", "mlp"],
+    )
+
+    vision_config = provider._build_vision_config(provider)
+
+    assert vision_config.recompute_granularity == "selective"
+    assert vision_config.recompute_modules == ["core_attn", "mlp"]
+    assert vision_config.recompute_num_layers is None
+
+
+def test_vision_recompute_inherits_full_model_config_when_enabled():
+    provider = NemotronOmniModelProvider(
+        recompute_vision=True,
+        radio_force_eval_mode=False,
+        recompute_granularity="full",
+        recompute_method="uniform",
+        recompute_num_layers=4,
+    )
+
+    vision_config = provider._build_vision_config(provider)
+
+    assert vision_config.recompute_granularity == "full"
+    assert vision_config.recompute_method == "uniform"
+    assert vision_config.recompute_num_layers == 4
+
+
+def test_vision_recompute_can_override_full_model_config_with_selective():
+    provider = NemotronOmniModelProvider(
+        recompute_vision=True,
+        radio_force_eval_mode=False,
+        recompute_granularity="full",
+        recompute_method="uniform",
+        recompute_num_layers=4,
+        vision_recompute_granularity="selective",
+    )
+
+    vision_config = provider._build_vision_config(provider)
+
+    assert provider.recompute_granularity == "full"
+    assert vision_config.recompute_granularity == "selective"
+    assert vision_config.recompute_method is None
+    assert vision_config.recompute_num_layers is None
+
+
+def test_vision_recompute_can_use_per_layer_full_recompute_independently():
+    provider = NemotronOmniModelProvider(
+        recompute_vision=True,
+        radio_force_eval_mode=False,
+        recompute_granularity="selective",
+        recompute_modules=["core_attn", "mlp"],
+        vision_recompute_granularity="full",
+        vision_recompute_method="uniform",
+        vision_recompute_num_layers=1,
+    )
+
+    vision_config = provider._build_vision_config(provider)
+
+    assert provider.recompute_granularity == "selective"
+    assert vision_config.recompute_granularity == "full"
+    assert vision_config.recompute_method == "uniform"
+    assert vision_config.recompute_num_layers == 1
+
+
+def test_vision_recompute_requires_effective_granularity():
+    provider = NemotronOmniModelProvider(
+        recompute_vision=True,
+        radio_force_eval_mode=False,
+    )
+
+    with pytest.raises(ValueError, match="effective recompute granularity"):
+        provider._build_vision_config(provider)
+
+
+@pytest.mark.parametrize(
+    ("method", "num_layers", "message"),
+    [
+        (None, 1, "requires a recompute method"),
+        ("uniform", None, "requires a layer count"),
+    ],
+)
+def test_full_vision_recompute_requires_complete_policy(method, num_layers, message):
+    provider = NemotronOmniModelProvider(
+        recompute_vision=True,
+        radio_force_eval_mode=False,
+        recompute_granularity="selective",
+        vision_recompute_granularity="full",
+        vision_recompute_method=method,
+        vision_recompute_num_layers=num_layers,
+    )
+
+    with pytest.raises(ValueError, match=message):
+        provider._build_vision_config(provider)
+
+
+def test_vision_recompute_rejects_invalid_granularity():
+    provider = NemotronOmniModelProvider(
+        recompute_vision=True,
+        radio_force_eval_mode=False,
+        vision_recompute_granularity="typo",
+    )
+
+    with pytest.raises(ValueError, match="must be 'full' or 'selective'"):
+        provider._build_vision_config(provider)
+
+
+def test_full_vision_recompute_rejects_invalid_method():
+    provider = NemotronOmniModelProvider(
+        recompute_vision=True,
+        radio_force_eval_mode=False,
+        vision_recompute_granularity="full",
+        vision_recompute_method="typo",
+        vision_recompute_num_layers=1,
+    )
+
+    with pytest.raises(ValueError, match="must be 'uniform' or 'block'"):
+        provider._build_vision_config(provider)
+
+
+@pytest.mark.parametrize("num_layers", [0, 33, 1.5, True])
+def test_full_vision_recompute_rejects_invalid_layer_count(num_layers):
+    provider = NemotronOmniModelProvider(
+        recompute_vision=True,
+        radio_force_eval_mode=False,
+        vision_recompute_granularity="full",
+        vision_recompute_method="uniform",
+        vision_recompute_num_layers=num_layers,
+    )
+
+    with pytest.raises(ValueError, match="integer between 1 and 32"):
+        provider._build_vision_config(provider)
+
+
+def test_vision_recompute_rejects_forced_radio_eval_mode():
+    provider = NemotronOmniModelProvider(recompute_vision=True)
+
+    with pytest.raises(ValueError, match="radio_force_eval_mode=False"):
+        provider._build_vision_config(provider)


### PR DESCRIPTION
# What does this PR do ?

Fixes the documented Nemotron 3 Omni CORD-V2 Full SFT recipe on the `r0.6.0` release branch by giving the legacy LLaVA-based RADIO tower an explicit recompute policy and correcting the release-only batch/packing configuration.

This PR intentionally targets `r0.6.0`, not `main`. Main now defaults to the rewritten canonical expanded-sequence Nemotron Omni model and has a different model/data contract.

# Changelog

- Add opt-in RADIO activation recompute with independent granularity, method, and layer-count controls while preserving the disabled default.
- Reject forced RADIO eval mode and invalid/incomplete recompute policies before model construction.
- Configure the release CORD-V2 2-node/16-GPU Full SFT launcher for non-packed MBS=1, selective language recompute, per-layer full RADIO recompute, and 50% overlapped optimizer-state CPU offload.
- Retain GBS=16 through two gradient-accumulation microbatches at DP=8.
- Document the release-specific memory and packing settings and add focused provider tests.

# Root cause and impact

The `r0.6.0` Omni provider unconditionally cleared recompute on the 32-layer RADIO encoder. RADIO was also forced into eval mode, while Megatron-Core full-layer recompute is gated on training mode. The documented Full SFT workload therefore retained unrecomputed vision activations above the lazy Adam state.

The old release launcher also used packed MBS=2. On the legacy LLaVA path, image-placeholder expansion can make a merged CORD row exceed the 4096-token limit; different data-parallel ranks then fail or wait at different points. The corrected Full SFT path is non-packed MBS=1. LoRA remains packed MBS=2.

This is a release source/configuration defect, not evidence that one valid unchanged configuration regressed between the 26.06 and 26.08 containers. Earlier current-main container A/B runs OOMed with matching peaks, but main's model class is no longer the release implementation.

# Validation

- `uv run --no-sync pre-commit run --all-files`
- NeMo `26.08.rc4`: Ruff check, Ruff format check, and all 15 focused provider-policy tests passed.
- Exact release scenario on 2 nodes / 16 H100s: TP=2, EP=8, CP=1, DP=8, non-packed MBS=1, GBS=16 (two microbatches).
- All 10 training iterations, final distributed checkpoint save, 10 validation batches, and 10 test batches completed successfully.
- Zero OOMs, allocator retries, skipped iterations, NaN iterations, or tracebacks across all 16 ranks.
- Worst observed peak: 55.8151 GiB allocated / 56.3203 GiB reserved (rank 13).
- Minimum observed device-free memory: 13.8017 GiB (rank 15).
- Independent final diff review: no actionable findings.

The exact RC4 run used two task-only diagnostics outside this diff: a pinned NVIDIA CUDA 13.3 `ptxas` because the RC4 image lacks `/usr/local/cuda/bin/ptxas`, and the previously isolated pad==EOS mask compatibility shim. Neither changes the model, batch, recompute, offload, or memory policy in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] Added focused tests.
- [x] Updated the affected recipe documentation.
- [x] No optional-install component is affected.

# Additional Information

No public GitHub issue.
