### PR TITLE
fix(recipe): tune Gemma 4 VL SFT and PEFT memory

### DIFF
--- a/examples/model_verification_cards/gemma-4-26b-a4b-it/card.yaml
+++ b/examples/model_verification_cards/gemma-4-26b-a4b-it/card.yaml
@@ -13,8 +13,9 @@ summary: >
   Decoder-focused SFT is verified on one 8-GPU H100 node with TP4/PP1/EP8/ETP1,
   a frozen vision encoder, and selective core-attention and MoE-activation
   recompute. The real CORD-v2 run completed 10 optimizer steps with stable
-  memory and saved iter_0000010. Long-context SFT and PEFT are pending. The
-  published Bridge recipes do not currently provide VLM pretraining.
+  memory and saved iter_0000010. LoRA PEFT is also verified on four H100 GPUs
+  with TP2/PP1/EP4/ETP1 and a complete adapter checkpoint. Long-context SFT is
+  pending. The published Bridge recipes do not currently provide VLM pretraining.
 verification_index:
   model_level:
     verified:
@@ -27,8 +28,8 @@ verification_index:
       - inference
   training:
     H100:
-      verified: [sft]
-      unverified: [sft_export_inference, sft_long_context, peft]
+      verified: [sft, peft]
+      unverified: [sft_export_inference, sft_long_context]
       unsupported: [pretrain, checkpoint_resume]
 model:
   hf_id: google/gemma-4-26B-A4B-it
@@ -249,9 +250,10 @@ items:
 
   peft:
     H100:
-      status: unverified
+      status: verified
       precision: bf16
       enabled_features: {}
+      bridge_commit: df1b978e751753707100417cb4e89645a23537f8  # pragma: allowlist secret
       command: >
         ./scripts/training/train.sh --nodes 1 --gpus-per-node 4
         --recipe gemma4_vl_26b_peft_config --mode lora --dataset cord-v2
@@ -261,16 +263,30 @@ items:
         validation.eval_iters=0 validation.eval_interval=0 checkpoint.load=null
         --save_dir work/model-verification/gemma-4-26b-a4b-it/peft-checkpoints
         --save_interval 10 logger.log_interval=1 logger.log_throughput=true
-      last_verified: null
+        logger.save_config_filepath=work/model-verification/gemma-4-26b-a4b-it/peft-post-setup.yaml
+      last_verified: 2026-08-04
       metrics:
-        initial_loss: null
-        final_loss: null
-        last_10_steps_step_time_ms_avg: null
-        last_10_steps_model_tflops_per_gpu_avg: null
+        initial_loss: 1.288328
+        final_loss: 0.1072377
+        last_10_steps_step_time_ms_avg: 14163.25
+        last_10_steps_model_tflops_per_gpu_avg: 65.01
+        peak_allocated_memory_gib: 44.252
+        peak_reserved_memory_gib: 45.637
       expected_result: >
-        The 4-GPU TP2/PP1/EP4 LoRA run must complete exactly 10 optimizer steps
-        with finite loss, no skipped or NaN iterations, all four required
-        metrics, and a reloadable final adapter checkpoint.
+        On 2026-08-04 the 4-GPU TP2/PP1/EP4/ETP1 LoRA run loaded the immutable
+        BF16 checkpoint and real CORD-v2 revision, then completed exactly 10
+        optimizer steps at MBS1 and GBS32. The persisted post-setup config
+        recorded rank-32 adapters with alpha 32 and zero dropout on linear_qkv,
+        linear_proj, linear_fc1, and linear_fc2. Runtime transformation froze
+        the base model and reported 22,272,000 trainable adapter parameters,
+        0.30% of the local model shard. Loss moved from 1.288328 to 0.1072377,
+        final grad norm was 22.994, and every step reported zero skipped and
+        zero NaN iterations. Across all four ranks, allocated memory returned
+        to 14.582 GiB after each step, while cumulative peak allocated and
+        reserved memory remained at or below 44.252 and 45.637 GiB. The run
+        saved a complete iter_0000010 adapter checkpoint with four rank shards,
+        finalized metadata, training state, and a latest-checkpoint tracker
+        containing iteration 10.
 
   checkpoint_resume:
     all:

--- a/examples/model_verification_cards/gemma-4-26b-a4b-it/card.yaml
+++ b/examples/model_verification_cards/gemma-4-26b-a4b-it/card.yaml
@@ -9,14 +9,12 @@ summary: >
   export are verified. Deterministic multimodal inference remains unverified
   because the recorded run stopped after 29 of the requested 32 tokens. Manual
   forward comparison remains unverified because the recorded run compared a
-  tensor-parallel padding position rather than the prompt's next token. Full
-  SFT remains unverified: the current two-node EP8 recipe does not complete its
-  first optimizer step, while the supported single-node TP4/PP2/EP1 fallback
-  completes one finite step before running out of memory during the second.
-  The formerly reported stall was failure cleanup waiting on outstanding
-  collectives, not a pipeline-boundary shape mismatch. Long-context SFT and
-  PEFT are pending. The published Bridge recipes do not currently provide VLM
-  pretraining.
+  tensor-parallel padding position rather than the prompt's next token.
+  Decoder-focused SFT is verified on one 8-GPU H100 node with TP4/PP1/EP8/ETP1,
+  a frozen vision encoder, and selective core-attention and MoE-activation
+  recompute. The real CORD-v2 run completed 10 optimizer steps with stable
+  memory and saved iter_0000010. Long-context SFT and PEFT are pending. The
+  published Bridge recipes do not currently provide VLM pretraining.
 verification_index:
   model_level:
     verified:
@@ -29,7 +27,8 @@ verification_index:
       - inference
   training:
     H100:
-      unverified: [sft, sft_export_inference, sft_long_context, peft]
+      verified: [sft]
+      unverified: [sft_export_inference, sft_long_context, peft]
       unsupported: [pretrain, checkpoint_resume]
 model:
   hf_id: google/gemma-4-26B-A4B-it
@@ -178,11 +177,12 @@ items:
 
   sft:
     H100:
-      status: unverified
+      status: verified
       precision: bf16
       enabled_features: {}
+      bridge_commit: 81e559ca4d579cf2d9ed5b8f3f48bef82e06451f  # pragma: allowlist secret
       command: >
-        ./scripts/training/train.sh --nodes 2 --gpus-per-node 8
+        ./scripts/training/train.sh --nodes 1 --gpus-per-node 8
         --recipe gemma4_vl_26b_sft_config --mode sft --dataset cord-v2
         --pretrained_checkpoint work/model-verification/gemma-4-26b-a4b-it/imported-megatron/iter_0000000
         --max_steps 10 --seq_length 4096
@@ -191,30 +191,28 @@ items:
         --save_dir work/model-verification/gemma-4-26b-a4b-it/sft-checkpoints
         --save_interval 10 logger.log_interval=1 logger.log_throughput=true
         logger.save_config_filepath=work/model-verification/gemma-4-26b-a4b-it/sft-post-setup.yaml
-      last_verified: null
+      last_verified: 2026-08-04
       metrics:
-        initial_loss: null
-        final_loss: null
-        last_10_steps_step_time_ms_avg: null
-        last_10_steps_model_tflops_per_gpu_avg: null
+        initial_loss: 1.268018
+        final_loss: 0.06543536
+        last_10_steps_step_time_ms_avg: 18699.99
+        last_10_steps_model_tflops_per_gpu_avg: 26.47
+        peak_allocated_memory_gib: 70.624
+        peak_reserved_memory_gib: 71.021
       expected_result: >
-        On 2026-08-03 this exact real-CORD TP2/PP1/EP8 run loaded the immutable
-        BF16 checkpoint, persisted its post-setup configuration, and entered
-        iteration zero, but completed no optimizer step during 39 observed
-        minutes. A subset of ranks remained active while the others waited,
-        with no log growth, OOM, or traceback. A separate README-supported
-        single-node TP4/PP2/EP1 run with selective recompute and a frozen vision
-        encoder completed one optimizer step in 54,344.4 ms with lm loss
-        1.293086, grad norm 46.201, 1.8 TFLOP/s/GPU, zero skipped iterations,
-        and zero NaN iterations. A controlled full-dimension reproduction
-        showed that the apparent second-step stall is a 352 MiB CUDA OOM on all
-        first-stage ranks in the MoE combine reduce-scatter. Those ranks then
-        waited in process-group cleanup while second-stage ranks waited in
-        pipeline communication. Tiny multimodal PP1 and PP2 controls completed
-        three steps with compatible BF16 boundary tensors and matching
-        recompute shapes, so the evidence does not indicate a PP boundary
-        contract mismatch. No valid 10-step metrics or iter_0000010 checkpoint
-        were produced, so SFT remains unverified.
+        On 2026-08-04 the single-node TP4/PP1/EP8/ETP1 run loaded the immutable
+        BF16 checkpoint and real CORD-v2 revision, then completed exactly 10
+        optimizer steps at MBS1 and GBS32. The persisted post-setup config
+        confirmed a frozen vision encoder, trainable projection and language
+        model, expandable CUDA allocator segments, and selective core_attn plus
+        moe_act recompute with CUDA graphs and CPU offload disabled. Loss moved
+        from 1.268018 to 0.06543536, final grad norm was 1.561, and every step
+        reported zero skipped and zero NaN iterations. Across all eight ranks,
+        allocated memory returned to 56.493 GiB after each step, while
+        cumulative peak allocated and reserved memory remained at or below
+        70.624 and 71.021 GiB. The run saved a complete iter_0000010 torch_dist
+        checkpoint with eight rank shards, finalized metadata, training state,
+        and a latest-checkpoint tracker containing iteration 10.
 
   sft_export_inference:
     H100:
@@ -224,12 +222,11 @@ items:
       commands: null
       last_verified: null
       expected_result: >
-        This item is blocked because SFT produced no verified iter_0000010
-        checkpoint, so no export or post-SFT inference command is recorded.
-        Once that dependency passes, the checkpoint must export, strictly
-        reload as Gemma4ForConditionalGeneration, and complete one
-        deterministic greedy VLM generation with a recorded literal
-        completion.
+        SFT produced a verified iter_0000010 checkpoint, but export, strict
+        Hugging Face reload, and post-SFT inference have not been run. This
+        item requires the checkpoint to export, strictly reload as
+        Gemma4ForConditionalGeneration, and complete one deterministic greedy
+        VLM generation with a recorded literal completion.
 
   sft_long_context:
     H100:

--- a/src/megatron/bridge/recipes/gemma4_vl/h100/gemma4_vl.py
+++ b/src/megatron/bridge/recipes/gemma4_vl/h100/gemma4_vl.py
@@ -110,8 +110,9 @@ def gemma4_vl_26b_sft_8gpu_h100_bf16_config() -> ConfigContainer:
     """Return a full SFT config for Gemma 4 VL 26B-A4B (MoE VLM).
 
     Default configuration: 8 GPUs
-    - TP=2, PP=1, EP=8 (max EP with 16 GPUs at TP=2,PP=1; DP=8, EP divides DP)
-    - No activation recompute — EP=8 shards 87.5% of expert params per GPU
+    - TP=4, PP=1, EP=8, ETP=1 (dense DP=2, expert DP=1)
+    - Selective core-attention and MoE-activation recompute
+    - Frozen vision encoder with trainable projection and language model
     - LR=5e-5 (full SFT)
     - Sequence length: 4096
     """
@@ -119,14 +120,26 @@ def gemma4_vl_26b_sft_8gpu_h100_bf16_config() -> ConfigContainer:
 
     _apply_gemma4_vl_common(cfg, _HF_PATH)
 
-    # Parallel settings — TP=2, PP=1, EP=8 on 2×8 GPUs
-    # DP = 16/(TP*PP) = 8; EP=8 shards experts across all DP ranks (1 expert replica)
-    cfg.model.tensor_model_parallel_size = 2
+    # The dense TP and expert EP meshes overlap: PP * max(TP, EP * ETP) = 8 GPUs.
+    # Dense DP = 8 / (TP * PP) = 2; expert DP = 8 / (PP * EP * ETP) = 1.
+    cfg.model.tensor_model_parallel_size = 4
     cfg.model.pipeline_model_parallel_size = 1
     cfg.model.pipeline_dtype = None
     cfg.model.virtual_pipeline_model_parallel_size = None
     cfg.model.context_parallel_size = 1
-    cfg.model.expert_model_parallel_size = 8  # override common EP=1
+    cfg.model.expert_model_parallel_size = 8
+    cfg.model.expert_tensor_parallel_size = 1
+
+    # Real CORD-v2 measurements require both modules to preserve H100 memory
+    # headroom after optimizer-state initialization. Full-layer recompute is not needed.
+    cfg.model.recompute_granularity = "selective"
+    cfg.model.recompute_modules = ["core_attn", "moe_act"]
+    cfg.model.recompute_method = None
+    cfg.model.recompute_num_layers = None
+
+    # Decoder-focused SFT keeps the vision encoder fixed while training the
+    # multimodal projection and language model.
+    cfg.model.freeze_vision_model = True
 
     # Reduce overhead to fit within 30-min wall time.
     # 40 iters × ~15s + 5 min init + 4 evals × 35s = ~20 min → 10 min for checkpoint save.

--- a/src/megatron/bridge/recipes/gemma4_vl/h100/gemma4_vl.py
+++ b/src/megatron/bridge/recipes/gemma4_vl/h100/gemma4_vl.py
@@ -183,7 +183,8 @@ def gemma4_vl_26b_peft_4gpu_h100_bf16_config(
     """Return a PEFT (LoRA/DoRA) config for Gemma 4 VL 26B-A4B (MoE VLM).
 
     Default configuration: 4 GPUs
-    - TP=4, PP=1, EP=4 (PEFT needs less memory, drop PP)
+    - TP=2, PP=1, EP=4, ETP=1 (dense DP=2, expert DP=1)
+    - MBS=1, GBS=32
     - LR=2e-4 (PEFT)
     - Sequence length: 4096
 
@@ -207,7 +208,12 @@ def gemma4_vl_26b_peft_4gpu_h100_bf16_config(
     cfg.model.pipeline_dtype = None
     cfg.model.virtual_pipeline_model_parallel_size = None
     cfg.model.context_parallel_size = 1
-    cfg.model.expert_model_parallel_size = 4  # override common EP=1
+    cfg.model.expert_model_parallel_size = 4
+    cfg.model.expert_tensor_parallel_size = 1
+
+    # Real CORD-v2 measurements fit with substantial activation-memory headroom
+    # at MBS=1, so recompute and LoRA sequence-parallel input re-gather are not needed.
+    cfg.train.micro_batch_size = 1
 
     # Optimizer — higher LR for PEFT
     opt_cfg, scheduler_cfg = distributed_fused_adam_with_cosine_annealing(

--- a/tests/unit_tests/recipes/test_gemma4_vl_recipes.py
+++ b/tests/unit_tests/recipes/test_gemma4_vl_recipes.py
@@ -49,3 +49,28 @@ def test_gemma4_vl_sft_uses_long_distributed_timeout(monkeypatch: pytest.MonkeyP
     cfg = _gemma4_vl_module.gemma4_vl_26b_sft_config()
 
     assert cfg.dist.distributed_timeout_minutes == 90
+
+
+def test_gemma4_vl_sft_uses_memory_stable_8gpu_contract(monkeypatch: pytest.MonkeyPatch):
+    """Full Gemma 4 VL SFT should use the measured single-node memory contract."""
+    patch_recipe_module_global(monkeypatch, _gemma4_vl_module, "AutoBridge", _FakeAutoBridge)
+
+    cfg = _gemma4_vl_module.gemma4_vl_26b_sft_config()
+
+    assert cfg.model.tensor_model_parallel_size == 4
+    assert cfg.model.pipeline_model_parallel_size == 1
+    assert cfg.model.context_parallel_size == 1
+    assert cfg.model.expert_model_parallel_size == 8
+    assert cfg.model.expert_tensor_parallel_size == 1
+    assert cfg.model.sequence_parallel is True
+    assert cfg.model.recompute_granularity == "selective"
+    assert cfg.model.recompute_modules == ["core_attn", "moe_act"]
+    assert cfg.model.recompute_method is None
+    assert cfg.model.recompute_num_layers is None
+    assert cfg.model.cuda_graph_impl == "none"
+    assert cfg.model.freeze_vision_model is True
+    assert cfg.model.freeze_vision_projection is False
+    assert cfg.model.freeze_language_model is False
+    assert cfg.train.micro_batch_size == 1
+    assert cfg.train.global_batch_size == 32
+    assert cfg.env_vars["PYTORCH_CUDA_ALLOC_CONF"] == "expandable_segments:True"

--- a/tests/unit_tests/recipes/test_gemma4_vl_recipes.py
+++ b/tests/unit_tests/recipes/test_gemma4_vl_recipes.py
@@ -74,3 +74,29 @@ def test_gemma4_vl_sft_uses_memory_stable_8gpu_contract(monkeypatch: pytest.Monk
     assert cfg.train.micro_batch_size == 1
     assert cfg.train.global_batch_size == 32
     assert cfg.env_vars["PYTORCH_CUDA_ALLOC_CONF"] == "expandable_segments:True"
+
+
+def test_gemma4_vl_peft_uses_memory_stable_4gpu_contract(monkeypatch: pytest.MonkeyPatch):
+    """Gemma 4 VL PEFT should use the measured single-node LoRA contract."""
+    patch_recipe_module_global(monkeypatch, _gemma4_vl_module, "AutoBridge", _FakeAutoBridge)
+
+    cfg = _gemma4_vl_module.gemma4_vl_26b_peft_config()
+
+    assert cfg.model.tensor_model_parallel_size == 2
+    assert cfg.model.pipeline_model_parallel_size == 1
+    assert cfg.model.context_parallel_size == 1
+    assert cfg.model.expert_model_parallel_size == 4
+    assert cfg.model.expert_tensor_parallel_size == 1
+    assert cfg.model.sequence_parallel is True
+    assert cfg.model.recompute_granularity is None
+    assert cfg.model.recompute_modules is None
+    assert cfg.model.cuda_graph_impl == "none"
+    assert cfg.train.micro_batch_size == 1
+    assert cfg.train.global_batch_size == 32
+    assert cfg.peft.target_modules == ["linear_qkv", "linear_proj", "linear_fc1", "linear_fc2"]
+    assert cfg.peft.dim == 32
+    assert cfg.peft.alpha == 32
+    assert cfg.peft.dropout == 0.0
+    assert cfg.peft.sequence_parallel_input_regather is False
+    assert cfg.peft.share_expert_adapters is True
+    assert cfg.env_vars["PYTORCH_CUDA_ALLOC_CONF"] == "expandable_segments:True"


### PR DESCRIPTION
## Summary

- tune Gemma 4 VL 26B-A4B decoder-focused SFT to fit one 8-GPU H100 node
- use the measured SFT TP4/PP1/EP8/ETP1 topology with selective `core_attn` and `moe_act` recompute
- align LoRA PEFT with a measured 4-GPU TP2/PP1/EP4/ETP1, MBS1/GBS32 contract that needs neither recompute nor input re-gather
- freeze the vision encoder for SFT; PEFT freezes the base model and trains language-model adapters
- add focused recipe-contract coverage and record real CORD-v2 SFT and PEFT verification

## SFT evidence

The ordered real-data matrix showed:

- TP2/PP1/EP8 without recompute OOMed during step 2
- adding only `core_attn` still OOMed during step 2
- adding `moe_act` reduced activation pressure, but TP2 still reached allocator capacity
- TP4/PP1/EP8 with only `core_attn` OOMed during step 2 with about a 990 MiB deficit on the tightest rank
- TP4/PP1/EP8 with `core_attn` plus `moe_act` completed both the smoke GBS and documented GBS32 runs

The final one-node SFT run used the immutable BF16 checkpoint and pinned real CORD-v2 revision. It completed 10/10 optimizer steps at MBS1/GBS32 with:

- loss `1.268018 -> 0.06543536`
- final grad norm `1.561`
- zero skipped and zero NaN iterations
- 18,699.99 ms average step time and 26.47 TFLOP/s/GPU across all 10 steps
- 70.624 GiB peak allocated and 71.021 GiB peak reserved memory across ranks
- a complete `iter_0000010` distributed checkpoint with eight shards and finalized metadata/training state

Full-layer recompute, MLP recompute, CPU offload, pipeline parallelism, and a second node were not needed.

## PEFT evidence

The 4-GPU TP2/PP1/EP4/ETP1 LoRA configuration first completed a 3-step MBS1/GBS4 smoke, then a 3-step MBS1/GBS32 run. The final clean verification used the immutable BF16 checkpoint and the same pinned real CORD-v2 revision and completed 10/10 optimizer steps at MBS1/GBS32 with:

- rank-32, alpha-32, zero-dropout adapters on `linear_qkv`, `linear_proj`, `linear_fc1`, and `linear_fc2`
- 22,272,000 trainable adapter parameters, 0.30% of the local model shard
- loss `1.288328 -> 0.1072377`
- final grad norm `22.994`
- zero skipped and zero NaN iterations
- 14,163.25 ms average step time and 65.01 TFLOP/s/GPU across all 10 steps
- 44.252 GiB peak allocated and 45.637 GiB peak reserved memory across ranks
- a complete iteration-10 adapter checkpoint with four rank shards, finalized metadata/training state, and latest-checkpoint tracking

The measured headroom supports keeping recompute and sequence-parallel input re-gather disabled for this PEFT recipe.

## Verification

- `uv run --active --no-sync python -m pytest tests/unit_tests/recipes/test_gemma4_vl_recipes.py -q` — 3 passed
- model verification card validator — passed
- `uv run --active --no-sync pre-commit run --all-files` — passed
- final 8-GPU SFT and 4-GPU PEFT Slurm steps — completed successfully

## Stack

This PR targets the head branch of #5283 so the review contains only the OOM-tuning recipe, test, and verification-card changes. It does not push directly to the existing PR branch.
