### PR TITLE
[model] fix: support MCore FSDP factory wrappers

### DIFF
--- a/src/megatron/bridge/models/conversion/utils.py
+++ b/src/megatron/bridge/models/conversion/utils.py
@@ -46,13 +46,20 @@ def unwrap_model(model, module_instances=None):
     if module_instances is None:
         from megatron.core.distributed import DistributedDataParallel as DDP
         from megatron.core.distributed import TorchFullyShardedDataParallel as torch_FSDP
-        from megatron.core.distributed.fsdp.mcore_fsdp_adapter import (
-            FullyShardedDataParallel as megatron_FSDP,
-        )
+        from megatron.core.distributed.fsdp import mcore_fsdp_adapter
         from megatron.core.distributed.fsdp.src.megatron_fsdp.megatron_fsdp import MegatronFSDP
         from megatron.core.transformer.module import Float16Module
 
-        module_instances = (DDP, torch_FSDP, megatron_FSDP, Float16Module, MegatronFSDP)
+        megatron_fsdp = mcore_fsdp_adapter.FullyShardedDataParallel
+        if isinstance(megatron_fsdp, type):
+            megatron_fsdp_classes = (megatron_fsdp,)
+        else:
+            megatron_fsdp_classes = (
+                mcore_fsdp_adapter.FullyShardedDataParallelV1,
+                mcore_fsdp_adapter.FullyShardedDataParallelV2,
+            )
+
+        module_instances = (DDP, torch_FSDP, *megatron_fsdp_classes, Float16Module, MegatronFSDP)
 
     return_list = True
     if not isinstance(model, list):

--- a/tests/unit_tests/models/test_conversion_utils.py
+++ b/tests/unit_tests/models/test_conversion_utils.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 import pytest
+import torch
 
+from megatron.bridge.models.conversion import utils as conversion_utils
 from megatron.bridge.models.conversion.utils import mcore_to_hf_window_size
 
 
@@ -33,3 +35,56 @@ def test_mcore_to_hf_window_size(window_size, expected):
 def test_mcore_to_hf_window_size_rejects_malformed_pair():
     with pytest.raises(ValueError, match="two-element MCore window"):
         mcore_to_hf_window_size([2047])
+
+
+def test_unwrap_model_supports_mcore_fsdp_factory(monkeypatch):
+    from megatron.core.distributed.fsdp import mcore_fsdp_adapter
+
+    class FakeFullyShardedDataParallelV1(torch.nn.Module):
+        def __init__(self, module):
+            super().__init__()
+            self.module = module
+
+    class FakeFullyShardedDataParallelV2(torch.nn.Module):
+        def __init__(self, module):
+            super().__init__()
+            self.module = module
+
+    def fsdp_factory(*args, **kwargs):
+        return FakeFullyShardedDataParallelV2(*args, **kwargs)
+
+    monkeypatch.setattr(mcore_fsdp_adapter, "FullyShardedDataParallel", fsdp_factory)
+    monkeypatch.setattr(
+        mcore_fsdp_adapter,
+        "FullyShardedDataParallelV1",
+        FakeFullyShardedDataParallelV1,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        mcore_fsdp_adapter,
+        "FullyShardedDataParallelV2",
+        FakeFullyShardedDataParallelV2,
+        raising=False,
+    )
+
+    model = torch.nn.Linear(2, 2)
+
+    assert conversion_utils.unwrap_model(FakeFullyShardedDataParallelV1(model)) is model
+    assert conversion_utils.unwrap_model(FakeFullyShardedDataParallelV2(model)) is model
+
+
+def test_unwrap_model_supports_legacy_mcore_fsdp_class(monkeypatch):
+    from megatron.core.distributed.fsdp import mcore_fsdp_adapter
+
+    class FakeFullyShardedDataParallel(torch.nn.Module):
+        def __init__(self, module):
+            super().__init__()
+            self.module = module
+
+    monkeypatch.setattr(mcore_fsdp_adapter, "FullyShardedDataParallel", FakeFullyShardedDataParallel)
+    monkeypatch.delattr(mcore_fsdp_adapter, "FullyShardedDataParallelV1", raising=False)
+    monkeypatch.delattr(mcore_fsdp_adapter, "FullyShardedDataParallelV2", raising=False)
+
+    model = torch.nn.Linear(2, 2)
+
+    assert conversion_utils.unwrap_model(FakeFullyShardedDataParallel(model)) is model


### PR DESCRIPTION
## Summary

- keep conversion `unwrap_model()` compatible with both the Bridge-pinned legacy MCore FSDP class API and the newer MCore factory API
- unwrap both concrete `FullyShardedDataParallelV1` and `FullyShardedDataParallelV2` wrappers without passing the factory function to `isinstance()`
- add regression coverage for both API generations, including the legacy case where the V1/V2 symbols do not exist

## Root cause

Newer MCore versions expose `mcore_fsdp_adapter.FullyShardedDataParallel` as a factory function and provide V1/V2 as the concrete wrapper classes. Bridge conversion code included the factory in an `isinstance()` tuple, which raises before MFSDP conversion reaches weight loading.

This is separate from the TP=2 vocabulary-scatter defect fixed by #5353. That fix is present on current main; this PR removes the newer MCore compatibility blocker that prevented QA from re-verifying the three MFSDP conversion examples.

## Compatibility

- legacy API: use `FullyShardedDataParallel` when it is a class; V1/V2 symbols may be absent
- factory API: use the explicit, independent V1 and V2 wrapper classes
- no training-path, dependency, CI, public API, or MCore submodule changes

## Validation

- Red on clean `origin/main` `c62be0886a`:
  - `uv run python -m pytest tests/unit_tests/models/test_conversion_utils.py -k unwrap_model -vv`
  - factory case failed with `TypeError: isinstance() arg 2 must be a type, a tuple of types, or a union`; legacy case passed
- Green on `ea19acb7f`:
  - `uv run python -m pytest tests/unit_tests/models/test_conversion_utils.py -vv` — 7 passed
  - `uv run pre-commit run --all-files` — passed

