### PR TITLE
fix(training): account for DSA in model FLOPs

### DIFF
--- a/src/megatron/bridge/training/utils/flop_utils.py
+++ b/src/megatron/bridge/training/utils/flop_utils.py
@@ -881,6 +881,138 @@ def num_floating_point_operations(
 
                 sparse_attn_term = sparse_attn_r0 + sparse_attn_r4 + sparse_attn_r128
                 self_attn_term += 3 * 2 * (sparse_attn_term + main_compressor_term + indexer_term)
+            elif experimental_attention_variant == "dsa":
+                # DSA replaces dense MLA core attention with top-k attention while retaining a
+                # dense lightning indexer. The attention/indexer geometry follows equations 1-2
+                # of the official report: https://arxiv.org/abs/2512.02556. MCore implements the
+                # MLA path with matrix absorption: QK operates over kv_lora_rank + RoPE channels
+                # and AV over kv_lora_rank channels (experimental_attention_variant/absorbed_mla.py).
+                qk_head_dim = getattr(cfg.model, "qk_head_dim", 64)
+                qk_pos_emb_head_dim = getattr(cfg.model, "qk_pos_emb_head_dim", 0)
+                v_head_dim = getattr(cfg.model, "v_head_dim", 64)
+                kv_lora_rank = getattr(cfg.model, "kv_lora_rank", 0)
+                if kv_lora_rank <= 0:
+                    raise ValueError("kv_lora_rank must be positive for dsa FLOPs calculation")
+
+                idx_n_heads = getattr(cfg.model, "dsa_indexer_n_heads", None)
+                idx_head_dim = getattr(cfg.model, "dsa_indexer_head_dim", None)
+                idx_topk = getattr(cfg.model, "dsa_indexer_topk", None)
+                if idx_n_heads is None or idx_n_heads <= 0:
+                    raise ValueError("dsa_indexer_n_heads must be positive for dsa FLOPs calculation")
+                if idx_head_dim is None or idx_head_dim <= 0:
+                    raise ValueError("dsa_indexer_head_dim must be positive for dsa FLOPs calculation")
+                if idx_topk is None or idx_topk <= 0:
+                    raise ValueError("dsa_indexer_topk must be positive for dsa FLOPs calculation")
+
+                idx_topk_freq = getattr(cfg.model, "dsa_indexer_topk_freq", 1)
+                idx_skip_topk_offset = getattr(cfg.model, "dsa_indexer_skip_topk_offset", 0)
+                if not isinstance(idx_topk_freq, int) or idx_topk_freq <= 0:
+                    raise ValueError("dsa_indexer_topk_freq must be a positive integer")
+                if not isinstance(idx_skip_topk_offset, int) or idx_skip_topk_offset < 0:
+                    raise ValueError("dsa_indexer_skip_topk_offset must be a non-negative integer")
+
+                def count_indexer_layers(layer_count: int) -> int:
+                    """Count layers that compute rather than reuse DSA top-k indices."""
+                    sharing_offset = max(idx_skip_topk_offset, 1)
+                    return sum(
+                        max(layer_number - sharing_offset, 0) % idx_topk_freq == 0
+                        for layer_number in range(1, layer_count + 1)
+                    )
+
+                # MCore gives MTP layers their own 1-based numbering, so their sharing cadence
+                # restarts independently of the decoder. GLM-5.2 has MTP1, which computes one
+                # fresh index. See transformer/multi_token_prediction.py in Megatron-Core.
+                num_indexer_layers = count_indexer_layers(cfg.model.num_layers) + count_indexer_layers(mtp_num_layers)
+
+                # Average valid causal pairs per token. The top-k expression is exact for a
+                # fixed-length batch. Packed metadata supplies only sum(s) and sum(s^2), so for
+                # mixed sequences crossing top-k we use the token-weighted effective length
+                # (core_attn_seq_factor); it remains exact when every subsequence is <= top-k.
+                dense_causal_context = (core_attn_seq_factor + 1) / 2
+                if core_attn_seq_factor <= idx_topk:
+                    sparse_causal_context = dense_causal_context
+                else:
+                    sparse_causal_context = idx_topk - idx_topk * (idx_topk - 1) / (2 * core_attn_seq_factor)
+
+                if cfg.model.q_lora_rank is None:
+                    q_term = (
+                        cfg.model.hidden_size * cfg.model.num_attention_heads * (qk_head_dim + qk_pos_emb_head_dim)
+                    )
+                    indexer_q_input_size = cfg.model.hidden_size
+                else:
+                    q_term = cfg.model.q_lora_rank * (
+                        cfg.model.hidden_size
+                        + cfg.model.num_attention_heads * (qk_head_dim + qk_pos_emb_head_dim)
+                        + 1  # q norm
+                    )
+                    indexer_q_input_size = cfg.model.q_lora_rank
+
+                kv_term = (
+                    kv_lora_rank
+                    * (
+                        cfg.model.hidden_size
+                        + cfg.model.num_attention_heads * (qk_head_dim + v_head_dim)
+                        + 1  # kv norm
+                    )
+                    + cfg.model.hidden_size * qk_pos_emb_head_dim
+                )
+                output_term = cfg.model.num_attention_heads * v_head_dim * cfg.model.hidden_size
+                mla_projection_term = 3 * 2 * num_layers * (q_term + kv_term + output_term)
+
+                absorbed_qk_dim = kv_lora_rank + qk_pos_emb_head_dim
+                absorbed_v_dim = kv_lora_rank
+                sparse_mla_core_term = (
+                    3
+                    * 2
+                    * num_layers
+                    * sparse_causal_context
+                    * cfg.model.num_attention_heads
+                    * (absorbed_qk_dim + absorbed_v_dim)
+                )
+
+                indexer_projection_size = (
+                    indexer_q_input_size * idx_n_heads * idx_head_dim
+                    + cfg.model.hidden_size * idx_head_dim
+                    + cfg.model.hidden_size * idx_n_heads
+                )
+                indexer_loss_coeff = getattr(cfg.model, "dsa_indexer_loss_coeff", 0.0) or 0.0
+                trains_indexer = indexer_loss_coeff > 0
+
+                # MCore detaches x and q_resid before the indexer. With the auxiliary loss
+                # enabled, each projection therefore executes forward+wgrad (2x forward), not
+                # forward+dgrad+wgrad (3x). Without the loss, top-k is computed under no_grad.
+                indexer_projection_multiplier = 4 if trains_indexer else 2
+                indexer_projection_term = indexer_projection_multiplier * num_indexer_layers * indexer_projection_size
+
+                # Equation 1 computes H_i dense q_i.k_i dot products and a weighted head
+                # reduction. When trained, both score operands need gradients (3x forward).
+                # ReLU, normalization, and top-k comparisons are not floating-point matmuls and
+                # are intentionally outside this model-FLOPs numerator.
+                index_score_size = dense_causal_context * idx_n_heads * (idx_head_dim + 1)
+                index_score_multiplier = 6 if trains_indexer else 2
+                index_score_term = index_score_multiplier * num_indexer_layers * index_score_size
+
+                # GLM recipes enable MCore's sparse indexer KL loss. Its attention target uses
+                # detached main-model Q/K, hence forward-only QK work. Dense-loss configurations
+                # use the full causal context instead of the selected context.
+                indexer_teacher_term = 0
+                if trains_indexer:
+                    teacher_context = (
+                        sparse_causal_context
+                        if getattr(cfg.model, "dsa_indexer_use_sparse_loss", False)
+                        else dense_causal_context
+                    )
+                    indexer_teacher_term = (
+                        2 * num_indexer_layers * teacher_context * cfg.model.num_attention_heads * absorbed_qk_dim
+                    )
+
+                self_attn_term = (
+                    mla_projection_term
+                    + sparse_mla_core_term
+                    + indexer_projection_term
+                    + index_score_term
+                    + indexer_teacher_term
+                )
             else:
                 ## MLA
                 if not hasattr(cfg.model, "q_lora_rank") or cfg.model.q_lora_rank is None:

--- a/src/megatron/bridge/training/utils/flop_utils.py
+++ b/src/megatron/bridge/training/utils/flop_utils.py
@@ -985,23 +985,26 @@ def num_floating_point_operations(
                 indexer_projection_term = indexer_projection_multiplier * num_indexer_layers * indexer_projection_size
 
                 # Equation 1 computes H_i dense q_i.k_i dot products and a weighted head
-                # reduction. When trained, both score operands need gradients (3x forward).
+                # reduction. Top-k selection needs every causal score, so the forward is
+                # always dense. The backward only covers score entries the KL loss touches:
+                # every causal pair for the dense loss, but only the selected top-k pairs for
+                # the sparse loss (no gradient flows through the discrete top-k selection;
+                # MCore's indexer_backward_wrapper consumes the selected payload only).
                 # ReLU, normalization, and top-k comparisons are not floating-point matmuls and
                 # are intentionally outside this model-FLOPs numerator.
-                index_score_size = dense_causal_context * idx_n_heads * (idx_head_dim + 1)
-                index_score_multiplier = 6 if trains_indexer else 2
-                index_score_term = index_score_multiplier * num_indexer_layers * index_score_size
+                use_sparse_indexer_loss = getattr(cfg.model, "dsa_indexer_use_sparse_loss", False)
+                index_score_unit = idx_n_heads * (idx_head_dim + 1)
+                index_score_term = 2 * num_indexer_layers * dense_causal_context * index_score_unit
+                if trains_indexer:
+                    score_grad_context = sparse_causal_context if use_sparse_indexer_loss else dense_causal_context
+                    index_score_term += 4 * num_indexer_layers * score_grad_context * index_score_unit
 
                 # GLM recipes enable MCore's sparse indexer KL loss. Its attention target uses
                 # detached main-model Q/K, hence forward-only QK work. Dense-loss configurations
                 # use the full causal context instead of the selected context.
                 indexer_teacher_term = 0
                 if trains_indexer:
-                    teacher_context = (
-                        sparse_causal_context
-                        if getattr(cfg.model, "dsa_indexer_use_sparse_loss", False)
-                        else dense_causal_context
-                    )
+                    teacher_context = sparse_causal_context if use_sparse_indexer_loss else dense_causal_context
                     indexer_teacher_term = (
                         2 * num_indexer_layers * teacher_context * cfg.model.num_attention_heads * absorbed_qk_dim
                     )

--- a/tests/unit_tests/training/utils/test_flop_utils.py
+++ b/tests/unit_tests/training/utils/test_flop_utils.py
@@ -2168,10 +2168,10 @@ class TestDynamicSparseAttentionFlops:
         # per-token terms are:
         #   MLA projections: 906; sparse QK+AV: 147
         #   indexer projections (forward+wgrad): 192
-        #   dense index scores (forward+dgrad+wgrad): 90
+        #   index scores (dense forward 30 + sparse-loss backward 42): 72
         #   sparse detached teacher QK (forward only): 28
         #   vocabulary projection: 6144
-        expected = 4 * (906 + 147 + 192 + 90 + 28 + 6144)
+        expected = 4 * (906 + 147 + 192 + 72 + 28 + 6144)
 
         assert num_floating_point_operations(self._dsa_config(), batch_size=1) == expected
 
@@ -2182,11 +2182,12 @@ class TestDynamicSparseAttentionFlops:
         wider_topk = num_floating_point_operations(self._dsa_config(dsa_indexer_topk=4), batch_size=1)
 
         # S=8, k=2: average sparse context is 15/8 and dense causal context is 9/2.
-        assert long == 60_732
+        assert long == 60_228
         assert long > 2 * short
-        # S=4, k=4 raises average sparse context from 7/4 to 5/2. Only sparse
-        # QK/AV and the sparse teacher target change; top-k comparisons are not FLOPs.
-        assert wider_topk - short == 300
+        # S=4, k=4 raises average sparse context from 7/4 to 5/2. Sparse QK/AV,
+        # the sparse-loss score backward, and the sparse teacher target change;
+        # top-k comparisons are not FLOPs.
+        assert wider_topk - short == 372
 
     def test_dsa_index_sharing_cadence_and_offset(self):
         """Only full IndexShare layers pay indexer projection, score, and teacher work."""
@@ -2211,9 +2212,9 @@ class TestDynamicSparseAttentionFlops:
         )
 
         # Full layers are [1..6], [1,2,3], and [1,5], respectively. Each full
-        # layer contributes (192 + 90 + 28) FLOPs per token of indexer work.
-        assert no_sharing - offset_three == 3 * 4 * 310
-        assert offset_three - offset_one == 4 * 310
+        # layer contributes (192 + 72 + 28) FLOPs per token of indexer work.
+        assert no_sharing - offset_three == 3 * 4 * 292
+        assert offset_three - offset_one == 4 * 292
 
     def test_dsa_detached_indexer_projection_backward_multiplier(self):
         """Indexer loss adds wgrad, not dgrad, for projections fed by detached inputs."""
@@ -2221,16 +2222,17 @@ class TestDynamicSparseAttentionFlops:
         without_loss = num_floating_point_operations(self._dsa_config(dsa_indexer_loss_coeff=0.0), batch_size=1)
 
         # Enabling sparse indexer loss adds one projection wgrad (96/token),
-        # two score-operand gradients (60/token), and teacher QK (28/token).
-        assert with_loss - without_loss == 4 * (96 + 60 + 28)
+        # score gradients over the selected top-k context only (42/token),
+        # and teacher QK (28/token).
+        assert with_loss - without_loss == 4 * (96 + 42 + 28)
 
     def test_dsa_mtp_layer_has_independent_sparse_attention_and_indexer(self):
         """MTP1 adds one full DSA layer because MCore restarts MTP layer numbering at one."""
         decoder_only = num_floating_point_operations(self._dsa_config(), batch_size=1)
         with_mtp = num_floating_point_operations(self._dsa_config(mtp_num_layers=1), batch_size=1)
 
-        # Added per-token work: DSA layer 1363 + MTP norms/eh-proj 912 + logits 6144.
-        assert with_mtp - decoder_only == 4 * (1363 + 912 + 6144)
+        # Added per-token work: DSA layer 1345 + MTP norms/eh-proj 912 + logits 6144.
+        assert with_mtp - decoder_only == 4 * (1345 + 912 + 6144)
 
 
 @pytest.mark.unit

--- a/tests/unit_tests/training/utils/test_flop_utils.py
+++ b/tests/unit_tests/training/utils/test_flop_utils.py
@@ -100,6 +100,10 @@ class MockModelConfig:
     dsa_indexer_n_heads: int | None = None
     dsa_indexer_head_dim: int | None = None
     dsa_indexer_topk: int | None = None
+    dsa_indexer_topk_freq: int = 1
+    dsa_indexer_skip_topk_offset: int = 0
+    dsa_indexer_loss_coeff: float = 0.0
+    dsa_indexer_use_sparse_loss: bool = False
     # GDN (Gated DeltaNet) settings
     experimental_attention_variant: str | None = None
     linear_attention_freq: int | list | None = None
@@ -2120,6 +2124,113 @@ class TestMLAFlops:
         assert f_long > 2 * f_short, (
             f"Expected superlinear seq scaling but got f(s=256)={f_long:.6e} vs 2*f(s=128)={2 * f_short:.6e}"
         )
+
+
+@pytest.mark.unit
+class TestDynamicSparseAttentionFlops:
+    """Closed-form training FLOPs for absorbed MLA with Dynamic Sparse Attention."""
+
+    @staticmethod
+    def _dsa_config(**overrides) -> MockConfigContainer:
+        values = {
+            "num_layers": 1,
+            "hidden_size": 8,
+            "seq_length": 4,
+            "ffn_hidden_size": 0,
+            "num_attention_heads": 2,
+            "num_query_groups": 2,
+            "kv_channels": 4,
+            "vocab_size": 128,
+            "make_vocab_size_divisible_by": 1,
+            "gated_linear_unit": False,
+            "multi_latent_attention": True,
+            "experimental_attention_variant": "dsa",
+            "q_lora_rank": 4,
+            "kv_lora_rank": 3,
+            "qk_head_dim": 2,
+            "qk_pos_emb_head_dim": 1,
+            "v_head_dim": 2,
+            "dsa_indexer_n_heads": 2,
+            "dsa_indexer_head_dim": 2,
+            "dsa_indexer_topk": 2,
+            "dsa_indexer_topk_freq": 1,
+            "dsa_indexer_skip_topk_offset": 0,
+            "dsa_indexer_loss_coeff": 0.001,
+            "dsa_indexer_use_sparse_loss": True,
+        }
+        values.update(overrides)
+        return MockConfigContainer(model=MockModelConfig(**values))
+
+    def test_dsa_exact_toy_formula(self):
+        """A one-layer toy covers absorbed sparse MLA and every lightning-indexer matmul."""
+        # At S=4 and top-k=2, the causal selected counts are [1, 2, 2, 2],
+        # while the dense indexer sees [1, 2, 3, 4]. The independently reduced
+        # per-token terms are:
+        #   MLA projections: 906; sparse QK+AV: 147
+        #   indexer projections (forward+wgrad): 192
+        #   dense index scores (forward+dgrad+wgrad): 90
+        #   sparse detached teacher QK (forward only): 28
+        #   vocabulary projection: 6144
+        expected = 4 * (906 + 147 + 192 + 90 + 28 + 6144)
+
+        assert num_floating_point_operations(self._dsa_config(), batch_size=1) == expected
+
+    def test_dsa_sequence_length_and_topk_scaling(self):
+        """Sparse MLA saturates at top-k while the lightning indexer remains quadratic."""
+        short = num_floating_point_operations(self._dsa_config(), batch_size=1)
+        long = num_floating_point_operations(self._dsa_config(seq_length=8), batch_size=1)
+        wider_topk = num_floating_point_operations(self._dsa_config(dsa_indexer_topk=4), batch_size=1)
+
+        # S=8, k=2: average sparse context is 15/8 and dense causal context is 9/2.
+        assert long == 60_732
+        assert long > 2 * short
+        # S=4, k=4 raises average sparse context from 7/4 to 5/2. Only sparse
+        # QK/AV and the sparse teacher target change; top-k comparisons are not FLOPs.
+        assert wider_topk - short == 300
+
+    def test_dsa_index_sharing_cadence_and_offset(self):
+        """Only full IndexShare layers pay indexer projection, score, and teacher work."""
+        no_sharing = num_floating_point_operations(
+            self._dsa_config(num_layers=6, dsa_indexer_topk_freq=1), batch_size=1
+        )
+        offset_three = num_floating_point_operations(
+            self._dsa_config(
+                num_layers=6,
+                dsa_indexer_topk_freq=4,
+                dsa_indexer_skip_topk_offset=3,
+            ),
+            batch_size=1,
+        )
+        offset_one = num_floating_point_operations(
+            self._dsa_config(
+                num_layers=6,
+                dsa_indexer_topk_freq=4,
+                dsa_indexer_skip_topk_offset=1,
+            ),
+            batch_size=1,
+        )
+
+        # Full layers are [1..6], [1,2,3], and [1,5], respectively. Each full
+        # layer contributes (192 + 90 + 28) FLOPs per token of indexer work.
+        assert no_sharing - offset_three == 3 * 4 * 310
+        assert offset_three - offset_one == 4 * 310
+
+    def test_dsa_detached_indexer_projection_backward_multiplier(self):
+        """Indexer loss adds wgrad, not dgrad, for projections fed by detached inputs."""
+        with_loss = num_floating_point_operations(self._dsa_config(), batch_size=1)
+        without_loss = num_floating_point_operations(self._dsa_config(dsa_indexer_loss_coeff=0.0), batch_size=1)
+
+        # Enabling sparse indexer loss adds one projection wgrad (96/token),
+        # two score-operand gradients (60/token), and teacher QK (28/token).
+        assert with_loss - without_loss == 4 * (96 + 60 + 28)
+
+    def test_dsa_mtp_layer_has_independent_sparse_attention_and_indexer(self):
+        """MTP1 adds one full DSA layer because MCore restarts MTP layer numbering at one."""
+        decoder_only = num_floating_point_operations(self._dsa_config(), batch_size=1)
+        with_mtp = num_floating_point_operations(self._dsa_config(mtp_num_layers=1), batch_size=1)
+
+        # Added per-token work: DSA layer 1363 + MTP norms/eh-proj 912 + logits 6144.
+        assert with_mtp - decoder_only == 4 * (1363 + 912 + 6144)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Bug

`GLM5Bridge` selects `experimental_attention_variant="dsa"`, but the model-FLOPs calculator previously had no plain-DSA branch. It therefore fell through to dense MLA: the core used average context `S/2`, ignored DSA top-k and GLM-5.2 IndexShare cadence, and omitted the lightning indexer.

The fix is limited to the Bridge-side training FLOPs numerator. It does not change the B200 denominator, report projected MFU as measured performance, modify model-card metrics, or touch Megatron-Core.

## Sources and accounting

Primary architecture sources:

- [DeepSeek-V3.2 report](https://arxiv.org/abs/2512.02556), especially the lightning-indexer score and selected-attention equations, and [DeepSeek's official DSA reference release](https://github.com/deepseek-ai/DeepSeek-V3.2-Exp)
- [GLM-5 report](https://arxiv.org/abs/2602.15763)
- [GLM-5.2 architecture note](https://huggingface.co/blog/zai-org/glm-52-blog), which specifies one indexer per four backbone layers and first-step index computation for MTP
- The immutable [GLM-5.2 config at revision `4d67f66`](https://huggingface.co/zai-org/GLM-5.2/blob/4d67f66cc64d3219133b767c253b2ad1425c6c88/config.json)

Maintained training implementations compared:

- Current Megatron-Core [DSA](https://github.com/NVIDIA/Megatron-LM/blob/main/megatron/core/transformer/experimental_attention_variant/dsa.py), [absorbed MLA](https://github.com/NVIDIA/Megatron-LM/blob/main/megatron/core/transformer/experimental_attention_variant/absorbed_mla.py), and [indexer op](https://github.com/NVIDIA/Megatron-LM/blob/main/megatron/core/transformer/experimental_attention_variant/ops/indexer.py)
- NVIDIA NeMo AutoModel's maintained [GLM DSA training layers](https://github.com/NVIDIA-NeMo/Automodel/blob/main/nemo_automodel/components/models/glm_moe_dsa/layers.py)

For fixed sequence length `S` and top-k `K`, the exact average causal contexts are:

```text
C_dense = (S + 1) / 2
C_sparse = (S + 1) / 2                              if S <= K
           K - K(K - 1) / (2S)                      otherwise
```

For `L` DSA layers and `L_i` full indexer layers, the added branch accounts for:

- absorbed sparse MLA QK/AV: `6 L C_sparse N_h ((R_kv + D_rope) + R_kv)`
- indexer projections: `4 L_i (Q_in H_i D_i + H D_i + H H_i)`
- dense index scores and weighted head reduction: `6 L_i C_dense H_i (D_i + 1)`
- sparse teacher QK for the indexer loss: `2 L_i C_sparse N_h (R_kv + D_rope)`

These are per-token terms. The factors include 2 FLOPs/FMA. Main attention uses forward+dgrad+wgrad. Megatron-Core detaches the indexer's `x` and query residual, so trained indexer projections use forward+wgrad (factor 4), while their dense score operands use forward+dgrad+wgrad (factor 6). The teacher Q/K are detached, so teacher QK is forward-only (factor 2). When the auxiliary loss is disabled, the indexer runs under `no_grad`, and its projection/score factors become 2.

GLM-5.2 has 78 decoder layers plus MTP1. Its `(freq=4, offset=3)` schedule yields 21 full backbone indexers; MTP numbering restarts and MTP1 computes one more, for `L_i=22`. Every DSA layer still pays sparse MLA work. The pre-existing DSV4 compressed-attention expression is not reused.

The calculator excludes ReLU, normalization, and top-k comparisons from the matmul-oriented numerator. Fixed-length results are exact under this convention. Packed metadata provides only `sum(s)` and `sum(s^2)`; when mixed packed subsequences cross top-k, the branch uses the existing token-weighted effective length, an explicit approximation. MTP retains the calculator's existing full-sequence convention.

## Red to green

Before the implementation, the new focused class demonstrated the fallthrough:

```text
uv run python -m pytest tests/unit_tests/training/utils/test_flop_utils.py::TestDynamicSparseAttentionFlops -q
5 failed
```

The failures showed the old dense-MLA value (`28680` instead of the DSA toy result `30028`), zero response to top-k/cadence/loss configuration, and the old MTP delta (`32328` instead of `33676`). After the implementation, the same five tests pass.

The tests independently derive exact toy totals and cover sequence/top-k scaling, IndexShare frequency and offset, detached-input backward multipliers, and MTP1. Existing exact MLA and DSV4 tests are retained as non-DSA regressions.

## GLM-5.2 before/after

Training TFLOP per sequence, batch size 1, MTP1. "Old" reproduces the former generic dense-MLA fallthrough; the component columns independently sum to the new DSA attention subtotal.

| Sequence | Old model total | New model total | Old dense MLA attention | MLA projections | Sparse QK | Sparse AV | Index projections | Dense index scores | Detached teacher | New DSA attention |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 2,048 | 542.710 | 585.624 | 192.769 | 160.196 | 36.663 | 32.589 | 1.689 | 1.143 | 3.403 | 235.683 |
| 131,072 | 166,067.902 | 46,660.202 | 143,671.660 | 10,252.521 | 4,653.890 | 4,136.791 | 108.096 | 4,680.657 | 432.007 | 24,263.961 |
| 200,000 | 360,458.698 | 74,991.848 | 326,284.745 | 15,644.105 | 7,120.534 | 6,329.363 | 164.941 | 10,897.974 | 660.978 | 40,817.895 |

Historical verification-card TFLOPS remain unchanged because the original run logs were not recomputed; those values were emitted by the former formula.

## Validation

```text
uv run python -m pytest tests/unit_tests/training/utils/test_flop_utils.py -q
125 passed

uv run pre-commit run --all-files
all hooks passed

git diff --check
passed
```
