### PR TITLE
[training] fix: Honor max-attention-logit monitoring without clipping

### DIFF
--- a/src/megatron/bridge/training/train.py
+++ b/src/megatron/bridge/training/train.py
@@ -928,8 +928,9 @@ def train_step(
     # get max attention logit for logging and run clip_qk()
     # Part of MuonClip Optimizer step
     log_max_attention_logit = None
-    if hasattr(cfg.model, "qk_clip") and cfg.model.qk_clip:
-        log_max_attention_logit = clip_qk(model)
+    qk_clip_enabled = getattr(cfg.model, "qk_clip", False)
+    if qk_clip_enabled or getattr(cfg.model, "log_max_attention_logit", False):
+        log_max_attention_logit = clip_qk(model, log_max_only=not qk_clip_enabled)
 
     timers("optimizer").stop()
     nvtx_range_pop(suffix="optimizer_step")

--- a/tests/unit_tests/training/test_train.py
+++ b/tests/unit_tests/training/test_train.py
@@ -37,11 +37,84 @@ from megatron.bridge.training.train import (
     maybe_synchronize_training_step,
     save_checkpoint_and_time,
     should_disable_forward_pre_hook,
+    train_step,
 )
 from megatron.bridge.training.utils.train_utils import maybe_inject_state
 
 
 pytestmark = pytest.mark.unit
+
+
+class TestTrainStepAttentionLogitMonitoring:
+    """Unit tests for max-attention-logit collection in a training step."""
+
+    @patch("megatron.bridge.training.train.get_num_microbatches", return_value=1)
+    @patch("megatron.bridge.training.train.get_model_config")
+    @patch("megatron.bridge.training.train.get_rerun_state_machine")
+    @patch("megatron.bridge.training.train.clip_qk", return_value=12.5)
+    def test_log_max_attention_logit_without_qk_clipping(
+        self,
+        mock_clip_qk,
+        mock_get_rerun_state_machine,
+        mock_get_model_config,
+        _mock_get_num_microbatches,
+    ):
+        """The independent monitoring flag collects logits without modifying weights."""
+        model_config = SimpleNamespace(seq_length=8)
+        mock_get_model_config.return_value = model_config
+
+        rerun_state_machine = Mock()
+        rerun_state_machine.should_run_forward_backward.side_effect = [True, False]
+        rerun_state_machine.should_checkpoint_and_exit.return_value = (False, False, 0)
+        mock_get_rerun_state_machine.return_value = rerun_state_machine
+
+        global_state = SimpleNamespace(
+            cfg=SimpleNamespace(
+                data_parallel_size=1,
+                model=SimpleNamespace(
+                    seq_length=8,
+                    qk_clip=False,
+                    log_max_attention_logit=True,
+                ),
+                dataset=SimpleNamespace(dataloader_type="single"),
+                dist=SimpleNamespace(use_decentralized_pg=True),
+                ddp=SimpleNamespace(overlap_param_gather=False),
+                optimizer=SimpleNamespace(
+                    barrier_with_L1_time=False,
+                    log_num_zeros_in_grad=False,
+                    reuse_grad_buf_for_mxfp8_param_ag=False,
+                ),
+                train=SimpleNamespace(
+                    check_optimizer_step_success=False,
+                    empty_unused_memory_level=0,
+                    micro_batch_size=1,
+                    skip_sync_grad_norm_across_mp=True,
+                ),
+            ),
+            timers=Mock(),
+        )
+        model = [Mock()]
+        optimizer = Mock()
+        optimizer.step.return_value = (True, 1.0, 0)
+        scheduler = Mock()
+        forward_backward_func = Mock(return_value=[])
+        p2p_communicator = SimpleNamespace(is_pp_last_stage=False)
+        pg_collection = SimpleNamespace(mp=Mock())
+
+        result = train_step(
+            forward_step_func=Mock(),
+            data_iterator=None,
+            model=model,
+            optimizer=optimizer,
+            scheduler=scheduler,
+            global_state=global_state,
+            pg_collection=pg_collection,
+            forward_backward_func=forward_backward_func,
+            p2p_communicator=p2p_communicator,
+        )
+
+        mock_clip_qk.assert_called_once_with(model, log_max_only=True)
+        assert result[-1] == 12.5
 
 
 class TestCudaGraphCleanup:


### PR DESCRIPTION
# What does this PR do?

Honor `log_max_attention_logit=True` when Q/K clipping itself is disabled.

Transformer Engine collects the per-step maximum attention logit when either
`qk_clip` or `log_max_attention_logit` is enabled. Bridge previously called
`clip_qk()` only when `qk_clip=True`, so the supported monitoring-only
configuration never retrieved or logged its metric and did not reset the
collected maximum between steps.

The fix mirrors the pinned Megatron-Core contract: run the collection path when
either option is enabled and pass `log_max_only=True` when clipping is disabled.
The clipping-enabled path retains its prior behavior.

## Validation

Focused regression, before the fix:

```text
uv run --no-sync python -m pytest tests/unit_tests/training/test_train.py::TestTrainStepAttentionLogitMonitoring::test_log_max_attention_logit_without_qk_clipping -q
1 failed: Expected 'clip_qk' to be called once. Called 0 times.
```

The unchanged test after the fix:

```text
uv run --no-sync python -m pytest tests/unit_tests/training/test_train.py::TestTrainStepAttentionLogitMonitoring::test_log_max_attention_logit_without_qk_clipping -q
1 passed
```

Adjacent training tests:

```text
uv run --no-sync python -m pytest tests/unit_tests/training/test_train.py tests/unit_tests/training/utils/test_train_utils.py::TestTrainingLog::test_optional_params_are_keyword_only -q
61 passed
```

Static checks:

```text
git diff --check
uv run pre-commit run --all-files
all applicable checks passed
```

## Scope

- No public API, dependency, lockfile, workflow, or Megatron-Core changes.
- Validation is focused CPU unit coverage; no full suite, distributed run,
  convergence, or performance claim is made.
