### PR TITLE
chore(docker): update Dockerfile and install script to remove unnecessary packages

### DIFF
--- a/docker/Dockerfile.fw_final
+++ b/docker/Dockerfile.fw_final
@@ -92,8 +92,9 @@ RUN pip install "fastapi==0.139.1" \
     "mistune>=3.3.0" \
     "GitPython>=3.1.55" && \
     # Address CVE from transitive dependency
-    pip uninstall -y opencv-python-headless nvidia-dali-cuda130
-
+    # Remove the package pulled in by Humming kernels.
+    # Humming-backed vLLM quantization is unavailable without pyelftools.
+    pip uninstall -y opencv-python-headless nvidia-dali-cuda130 pyelftools
 # Remove PyTorch's bundled third-party onnx source tree (build artifact, not used at runtime).
 # The actual onnx Python package is managed above via pip/uv; this stale copy triggers CVE scanners.
 RUN rm -rf /opt/pytorch/pytorch/third_party/onnx

--- a/docker/common/install_aws_ofi_nccl.sh
+++ b/docker/common/install_aws_ofi_nccl.sh
@@ -42,8 +42,6 @@ SRC_DIR="$(mktemp -d)"
 apt-get update
 apt-get install -y --no-install-recommends \
     git ca-certificates build-essential autoconf automake libtool libhwloc-dev
-apt-get clean
-rm -rf /var/lib/apt/lists/*
 
 git clone --depth 1 --branch "${AWS_OFI_NCCL_VER}" \
     https://github.com/aws/aws-ofi-nccl.git "${SRC_DIR}"
@@ -62,6 +60,12 @@ pushd "${SRC_DIR}"
 make -j"$(nproc)"
 make install
 popd
+
+# The installed plugin links to libhwloc15 at runtime but does not need the
+# development headers or libltdl development files after compilation.
+apt-get purge -y libhwloc-dev libltdl-dev
+apt-get clean
+rm -rf /var/lib/apt/lists/*
 
 # Revive the ldconfig entry the base image left behind so a bare `libnccl-net.so`
 # lookup can also resolve here; EKSEnvPlugin still pins the absolute path.


### PR DESCRIPTION
# What does this PR do ?

chore(docker): update Dockerfile and install script to remove unnecessary packages

- Uninstalled `pyelftools` along with `opencv-python-headless` and `nvidia-dali-cuda130` in Dockerfile to address dependency/license issues.
- Uninstall packages that were needed for OFI build.


# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
