### PR TITLE
build: bump nvidia-modelopt to 0.46.0rc1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,7 @@ override-dependencies = [
     "mlflow>=3.15.0",                                       # To address CVE-2025-15031
     "cachetools>=5.0.0",
     "cryptography>=43.0.0,<47",
-    "nvidia-modelopt==0.44.0rc5",
+    "nvidia-modelopt==0.46.0rc1",
     "urllib3>=2.6.3",                                       # To address CVE-2026-21441
     "langchain>=0.3.28",                                    # To address CVE-2025-65106
     "langchain-core>=0.3.80",                               # To address CVE-2025-65106

--- a/uv.lock
+++ b/uv.lock
@@ -19,7 +19,7 @@ overrides = [
     { name = "mlflow", specifier = ">=3.15.0" },
     { name = "nvidia-cudnn-frontend", specifier = "==1.26.0" },
     { name = "nvidia-cutlass-dsl", extras = ["cu13"], marker = "sys_platform == 'never'" },
-    { name = "nvidia-modelopt", specifier = "==0.44.0rc5", index = "https://pypi.nvidia.com/" },
+    { name = "nvidia-modelopt", specifier = "==0.46.0rc1", index = "https://pypi.nvidia.com/" },
     { name = "onnx", marker = "python_full_version < '3.13'", specifier = ">=1.21.0" },
     { name = "tokenizers", specifier = ">=0.22.0,<0.23" },
     { name = "torch", marker = "sys_platform == 'never'" },
@@ -2801,7 +2801,7 @@ wheels = [
 
 [[package]]
 name = "nvidia-modelopt"
-version = "0.44.0rc5"
+version = "0.46.0rc1"
 source = { registry = "https://pypi.nvidia.com/" }
 dependencies = [
     { name = "ninja" },
@@ -2821,7 +2821,7 @@ dependencies = [
     { name = "tqdm" },
 ]
 wheels = [
-    { url = "https://pypi.nvidia.com/nvidia-modelopt/nvidia_modelopt-0.44.0rc5-py3-none-any.whl", hash = "sha256:4934c50f1fb94f7b60a6b53f2bdbd470e68b00d1161206118b0be196cc7d9b22" },
+    { url = "https://pypi.nvidia.com/nvidia-modelopt/nvidia_modelopt-0.46.0rc1-py3-none-any.whl", hash = "sha256:9eb5393812462674283d1919626d8ef23e17f15530b6626a6aaa32c5b810c5ad" },
 ]
 
 [[package]]


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## What
- Bump `nvidia-modelopt` to `0.46.0rc1` (from `0.44.0rc5`) in `override-dependencies`.
- Regenerate `uv.lock`.

## Lockfile delta
```
Resolved 327 packages
Updated nvidia-modelopt v0.44.0rc5 -> v0.46.0rc1
```

No transitive movement — `nvidia-modelopt`'s own dependency list is unchanged
between the two versions, so the only lockfile edits are the override
specifier, the package version, and the wheel URL + sha256.

Relocked with `uv 0.7.2` to match the `UV_VERSION` pin in
`docker/Dockerfile.ci`; the lockfile `revision` header is untouched.

## Test plan
- [ ] L0 CI green
- [ ] L1 CI green (label `needs-more-tests` applied)
- [ ] L2 CI green (label `full-test-suite` applied — modelopt drives the
      quantization paths that only L2 exercises)

## Quarantined tests (this bump)
_None yet — will be appended as flakes are identified during CI iteration._

</details>
