### PR TITLE
[data] fix: resolve character-class Parquet globs

### DIFF
--- a/src/megatron/bridge/data/packing/paths.py
+++ b/src/megatron/bridge/data/packing/paths.py
@@ -63,7 +63,7 @@ def is_packed_parquet_spec(spec: str | Path) -> bool:
         return True
 
     # Check for glob patterns containing parquet extension
-    if "*" in spec_str or "?" in spec_str:
+    if glob.has_magic(spec_str):
         # Extract the pattern part after the last glob character
         return ".parquet" in spec_str or ".pq" in spec_str
 
@@ -97,6 +97,17 @@ def _is_parquet_file(path: str) -> bool:
     return name.endswith(".parquet") or name.endswith(".pq")
 
 
+def _is_existing_file(path: str) -> bool:
+    """Check whether a path is an existing file using the active filesystem backend."""
+    if MultiStorageClientFeature.is_enabled():
+        msc = MultiStorageClientFeature.import_package()
+        path_obj = msc.Path(path)
+        if hasattr(path_obj, "is_file"):
+            return path_obj.is_file()
+        return path_obj.exists() and not (path_obj.is_dir() if hasattr(path_obj, "is_dir") else False)
+    return Path(path).is_file()
+
+
 def _resolve_parquet_paths(file_path: str) -> list[str]:
     """Resolve a file path specification to a list of actual file paths.
 
@@ -116,8 +127,14 @@ def _resolve_parquet_paths(file_path: str) -> list[str]:
     """
     path_str = str(file_path)
 
+    # Preserve direct-file behavior for literal bracketed filenames. Patterns
+    # can still select such files with the escaping provided by glob.escape().
+    bracket_only_magic = "[" in path_str and "*" not in path_str and "?" not in path_str
+    if bracket_only_magic and _is_parquet_file(path_str) and _is_existing_file(path_str):
+        return [path_str]
+
     # Check if it's a glob pattern
-    if "*" in path_str or "?" in path_str:
+    if glob.has_magic(path_str):
         if MultiStorageClientFeature.is_enabled():
             msc = MultiStorageClientFeature.import_package()
             # MSC glob support - normalize to strings immediately

--- a/tests/unit_tests/data/packing/test_paths.py
+++ b/tests/unit_tests/data/packing/test_paths.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from megatron.bridge.data.packing.paths import resolve_packed_parquet_paths
+
+
+@pytest.mark.unit
+def test_resolve_character_class_glob_pattern(tmp_path):
+    expected = [tmp_path / f"shard_{index}.idx.parquet" for index in range(2)]
+    for shard in expected:
+        shard.touch()
+
+    resolved = resolve_packed_parquet_paths(tmp_path / "shard_[01].idx.parquet")
+
+    assert resolved == [str(shard) for shard in expected]
+
+
+@pytest.mark.unit
+def test_resolve_existing_literal_bracket_path(tmp_path):
+    path = tmp_path / "shard_[01].idx.parquet"
+    path.touch()
+
+    assert resolve_packed_parquet_paths(path) == [str(path)]


### PR DESCRIPTION
## Problem

Packed Parquet paths support file, directory, and glob specifications, but the resolver recognized only `*` and `?` as glob syntax. A standard Python character-class pattern such as `shard_[01].idx.parquet` was accepted as a Parquet spec and then treated as a literal filename.

For an explicit packed train or validation path, this raises during configuration even when both shards exist. The same root cause makes the SFT builder exhaust its retry budget before returning no dataset, and affects direct packed-dataset loading and packed-data statistics.

## Fix

Use Python's standard `glob.has_magic` predicate in both packed-Parquet classification and resolution. Character classes now enter the existing glob, Parquet-filter, and sorting path. Existing direct files whose names contain brackets retain exact-file precedence. There are no dependency, public API, or format changes.

## Regression evidence

The same public-resolver regression test was run against the unmodified base and the patch:

```bash
uv run --no-sync python -m pytest --confcutdir=tests/unit_tests/data/packing \
  tests/unit_tests/data/packing/test_paths.py -q
```

- Before: `1 failed` with `ValueError: Packed Parquet file not found: .../shard_[01].idx.parquet`.
- After: `2 passed`, including a negative control for an existing literal bracketed filename.

Adjacent resolver and classifier coverage:

```bash
uv run --no-sync python -m pytest --confcutdir=tests/unit_tests/data/packing \
  tests/unit_tests/data/packing/test_parquet.py -q \
  -k 'TestResolveParquetPaths or TestIsPackedParquetFile'
```

Result: `10 passed, 24 deselected`.

Static validation:

```bash
git diff --check
uv run --no-sync pre-commit run --all-files
```

Both passed.

## Scope

This changes recognition of standard Python character-class globs while preserving direct bracketed filenames. It does not add brace expansion, recursive-glob semantics, or change packed Parquet schema/runtime behavior.
