### PR TITLE
[model] fix: honor Gemma 4 image attention mode

### DIFF
--- a/src/megatron/bridge/models/gemma_vl/modeling_gemma4_vl.py
+++ b/src/megatron/bridge/models/gemma_vl/modeling_gemma4_vl.py
@@ -371,6 +371,8 @@ class Gemma4VLModel(MegatronModule):
         causal_mask = torch.tril(
             torch.ones((batch_size, 1, seq_len, seq_len), dtype=torch.bool, device=input_ids.device)
         )
+        if getattr(self.config.text_config, "use_bidirectional_attention", None) != "vision":
+            return ~causal_mask
 
         def _bidirectional_block_mask(token_mask: torch.Tensor) -> torch.Tensor:
             padded = F.pad(token_mask, (1, 0), value=0)

--- a/tests/unit_tests/models/gemma_vl/test_gemma4_vl_modeling.py
+++ b/tests/unit_tests/models/gemma_vl/test_gemma4_vl_modeling.py
@@ -36,12 +36,13 @@ IMAGE_TOKEN_ID = 258_880
 # ---------------------------------------------------------------------------
 
 
-def _make_model(image_token_id=IMAGE_TOKEN_ID):
+def _make_model(image_token_id=IMAGE_TOKEN_ID, use_bidirectional_attention="vision"):
     """Build a Gemma4VLModel with all heavy dependencies mocked out."""
     config = Mock()
     config.image_token_id = image_token_id
     config.vision_config = Mock()
     config.text_config = Mock()
+    config.text_config.use_bidirectional_attention = use_bidirectional_attention
     config.share_embeddings_and_output_weights = True
     config.sequence_parallel = False
     config._pg_collection = None
@@ -108,6 +109,15 @@ class TestComputeAttentionMask:
         for i in range(2, 5):
             for j in range(2, 5):
                 assert not mask[0, 0, i, j].item(), f"Image pos ({i},{j}) should be unblocked (bidirectional)"
+
+    def test_image_block_stays_causal_when_bidirectional_attention_is_disabled(self):
+        """Smaller Gemma 4 variants keep conventional causal attention for image tokens."""
+        model = _make_model(use_bidirectional_attention=None)
+        input_ids = self._make_ids([self.IMAGE_TOKEN, self.IMAGE_TOKEN])
+
+        mask = model._compute_attention_mask(input_ids)
+
+        assert mask[0, 0, 0, 1].item() is True
 
     def test_text_after_image_cannot_attend_back_to_image_beyond_causal(self):
         """Text token after image block uses causal attention (cannot look into future)."""


### PR DESCRIPTION
## Problem

Gemma 4 E2B/E4B full-VL checkpoints set `text_config.use_bidirectional_attention` to `null`. Their supported forward path still unconditionally made contiguous image-token blocks bidirectional, unlike the causal attention contract used by the Hugging Face implementation for these variants. This changes image-conditioned hidden states and logits after import.

## Root cause and fix

`Gemma4VLModel._compute_attention_mask()` built the image-block override without consulting the retained Hugging Face text config. Apply that override only for the explicit `"vision"` mode used by the 26B/31B variants; otherwise return the conventional causal mask.

The regression test checks that a future image token stays masked when bidirectional image attention is disabled. Existing image-block tests continue to cover the opt-in `"vision"` behavior.

## Validation

Fail before the production fix:

`uv run --no-sync python -m pytest tests/unit_tests/models/gemma_vl/test_gemma4_vl_modeling.py::TestComputeAttentionMask::test_image_block_stays_causal_when_bidirectional_attention_is_disabled -q`

Result: 1 failed because the future image token was unmasked.

Pass after the fix:

- Same focused command: 1 passed
- `uv run --no-sync python -m pytest tests/unit_tests/models/gemma_vl/test_gemma4_vl_modeling.py::TestComputeAttentionMask -q`: 8 passed
- `uv run --no-sync python -m pytest tests/unit_tests/models/gemma_vl/test_gemma4_vl_modeling.py tests/unit_tests/models/gemma_vl/test_gemma4_vl_bridge.py tests/unit_tests/models/gemma_vl/test_gemma4_vl_provider.py -q`: 132 passed
- `git diff --check`: passed
- `uv run pre-commit run --all-files`: passed

## Scope

This is a focused attention-mask semantics fix. No full-suite, model-quality, convergence, performance, or GPU validation is claimed.