### PR TITLE
[inference] fix: Align Qwen VLM context-window logits

### DIFF
--- a/src/megatron/bridge/inference/vlm/qwenvl_inference_wrapper.py
+++ b/src/megatron/bridge/inference/vlm/qwenvl_inference_wrapper.py
@@ -156,6 +156,7 @@ class QwenVLInferenceWrapper(AbstractModelInferenceWrapper):
             "pixel_values": inference_input.get("pixel_values"),
             "image_grid_thw": inference_input.get("image_grid_thw"),
             "mm_token_type_ids": inference_input.get("mm_token_type_ids"),
+            "_context_window_length": context_end_position - context_start_position,
         }
         if out["mm_token_type_ids"] is not None:
             out["mm_token_type_ids"] = out["mm_token_type_ids"][:, :context_end_position]
@@ -174,10 +175,15 @@ class QwenVLInferenceWrapper(AbstractModelInferenceWrapper):
         Returns:
             torch.Tensor: The output logits of shape [batch_size, seq_len, padded_vocab_size]
         """
+        model_input = dict(inference_input)
+        context_window_length = model_input.pop("_context_window_length", None)
         logits = self.model(
-            **inference_input,
+            **model_input,
             inference_context=self.inference_context,
             runtime_gather_output=True,
         )
+
+        if context_window_length is not None:
+            logits = logits[:, -context_window_length:, :]
 
         return logits

--- a/tests/unit_tests/inference/vlm/test_qwenvl_inference_wrapper.py
+++ b/tests/unit_tests/inference/vlm/test_qwenvl_inference_wrapper.py
@@ -139,6 +139,28 @@ class TestQwenVLInferenceWrapper:
         assert result["position_ids"].equal(torch.arange(2, dtype=torch.long).unsqueeze(0).expand(1, 2))
         assert result["attention_mask"].equal(torch.ones(1, 2, dtype=torch.bool))
 
+    def test_nonzero_context_window_returns_only_current_logits(self, wrapper):
+        input_ids = torch.tensor([[1, 2, 3, 4]])
+        inference_input = {
+            "input_ids": input_ids,
+            "position_ids": torch.arange(4, dtype=torch.long).unsqueeze(0).expand_as(input_ids),
+            "attention_mask": torch.ones_like(input_ids, dtype=torch.bool),
+            "pixel_values": None,
+            "image_grid_thw": None,
+            "mm_token_type_ids": None,
+        }
+
+        def position_logits(**model_input):
+            sequence_length = model_input["input_ids"].size(1)
+            return torch.arange(sequence_length, dtype=torch.float32).view(1, sequence_length, 1)
+
+        wrapper.model.side_effect = position_logits
+
+        context_window = wrapper.get_batch_for_context_window(inference_input, 2, 3)
+        logits = wrapper.forward_pass_without_pipeline_parallel(context_window)
+
+        assert logits.equal(torch.tensor([[[2.0]]]))
+
     def test_forward_pass_without_pipeline_parallel(self, wrapper):
         input_ids = torch.tensor([[1, 2, 3]])
         inference_input = {


### PR DESCRIPTION
## What changed

Qwen2.5-VL and Qwen3-VL legacy static generation recompute the full token prefix on every decode step. The pinned MCore controller requests a one-token context window and samples correctly from the final logit row, but `return_log_probs=True` gathers the generated token probability as though the wrapper returned only that requested window. On the second and later generated tokens, this silently reads sequence row 0 instead of the current decode row.

The wrapper now carries the requested context-window length as private metadata, removes it before calling the model, and returns only the matching trailing logit rows. Full-prefix tokens, MRoPE computation, and visual processing remain unchanged.

Supported trigger:

- Qwen2.5-VL or Qwen3-VL legacy generation
- `pipeline_model_parallel_size=1`
- `SamplingParams(return_log_probs=True, num_tokens_to_generate>=2)`

Generated text was already sampled from the correct final row. This fixes the silently incorrect generated log probabilities used by scoring, confidence filtering, evaluation, and likelihood accounting.

## Validation

Fail before, on unmodified production code with only the regression test present:

```text
uv run --no-sync python -m pytest -p mcore_import_stub --confcutdir=tests/unit_tests/inference/vlm tests/unit_tests/inference/vlm/test_qwenvl_inference_wrapper.py::TestQwenVLInferenceWrapper::test_nonzero_context_window_returns_only_current_logits -q --tb=short
1 failed: returned rows [0, 1, 2], expected current-window row [2]
```

Pass after:

```text
same focused command
1 passed

same harness, tests/unit_tests/inference/vlm/test_qwenvl_inference_wrapper.py
9 passed

uv run --no-sync pre-commit run --all-files
passed

git diff --check
passed
```

The local CPU harness stubs only MCore import-time class surfaces because the workstation's optional GPU packages cannot be imported there; it exercises the actual Bridge wrapper and deterministic PyTorch logits. The downstream gather semantics were separately verified against the repository-pinned MCore source.

## Scope

This is limited to the legacy Qwen VLM wrapper/controller logit-window contract. It does not add KV-cache support, pipeline parallelism, or change generated tokens. No full suite or end-to-end GPU model-quality/performance validation was run.
