### PR TITLE
refactor(quant)!: simplify quantization examples and fix calibration dataset load

### DIFF
--- a/examples/quantization/README.md
+++ b/examples/quantization/README.md
@@ -2,7 +2,7 @@
 
 This directory contains example scripts for quantizing Megatron Bridge models using NVIDIA ModelOpt.
 
-> **Note**: These are minimal, hard-coded reference examples. For more comprehensive, production-quality post-training quantization (PTQ), export, and Quantization Aware Distillation (QAD) scripts, see the NVIDIA Model Optimizer repository: [examples/megatron_bridge/](https://github.com/NVIDIA/Model-Optimizer/tree/main/examples/megatron_bridge).
+> **Note**: These are minimal, reference examples. For more comprehensive, production-quality post-training quantization (PTQ), export, and Quantization Aware Distillation (QAD) scripts, see the NVIDIA Model Optimizer repository: [examples/megatron_bridge/](https://github.com/NVIDIA/Model-Optimizer/tree/main/examples/megatron_bridge).
 
 ## Overview
 

--- a/examples/quantization/export.py
+++ b/examples/quantization/export.py
@@ -18,7 +18,8 @@ to HuggingFace format using the AutoBridge on multiple GPUs.
 
 Prerequisites:
 First, you must run the quantization process to create a quantized checkpoint:
-    torchrun --nproc_per_node 2 examples/quantization/quantize.py --megatron-save-path ./quantized_megatron_checkpoint --tp 2
+    torchrun --nproc_per_node 2 examples/quantization/quantize.py \
+        --hf-model-id meta-llama/Llama-3.2-1B --megatron-save-path ./quantized_megatron_checkpoint --tp 2
 
 The process is as follows:
 1. An AutoBridge is initialized from a pretrained Hugging Face model
@@ -27,33 +28,37 @@ The process is as follows:
 3. The model is exported to HuggingFace format using ModelOpt export utilities.
 
 Usage:
-torchrun --nproc_per_node 2 examples/quantization/export.py --megatron-load-path ./quantized_megatron_checkpoint --export-dir ./hf_export --tp 2
+torchrun --nproc_per_node 2 examples/quantization/export.py --hf-model-id meta-llama/Llama-3.2-1B \
+    --megatron-load-path ./quantized_megatron_checkpoint --export-dir ./hf_export --tp 2
 """
 
 import argparse
-import os
-import sys
 import warnings
 
 import modelopt.torch.export as mtex
+import modelopt.torch.utils.distributed as dist
 import torch
 from megatron.core.utils import unwrap_model
-from rich.console import Console
+from quantize_utils import (
+    add_common_model_args,
+    build_bridge_and_provider,
+    console,
+    load_quantized_megatron_model,
+    print_parallelism_summary,
+    require_checkpoint,
+    require_torchrun,
+)
 
-from megatron.bridge import AutoBridge
 from megatron.bridge.models.decorators import torchrun_main
 from megatron.bridge.models.hf_pretrained.utils import is_safe_repo
 
 
 warnings.filterwarnings("ignore")
 
-HF_MODEL_ID = "meta-llama/Llama-3.2-1B"
-console = Console()
-
 
 @torchrun_main
 def main(
-    hf_model_id: str = HF_MODEL_ID,
+    hf_model_id: str,
     tp: int = 1,
     pp: int = 1,
     ep: int = 1,
@@ -65,35 +70,14 @@ def main(
     trust_remote_code: bool | None = None,
 ) -> None:
     """Export a quantized Megatron-LM checkpoint to HuggingFace format on multiple GPUs."""
-    if os.environ.get("WORLD_SIZE") is None:
-        console.print("This script must be launched with torchrun. Please run:")
-        console.print(f"torchrun --nproc_per_node <gpus> {sys.argv[0]}")
-        sys.exit(1)
-
-    # Check if the checkpoint path exists
-    if not os.path.exists(megatron_load_path):
-        console.print(f"[red]Error: Quantized checkpoint path {megatron_load_path} does not exist![/red]")
-        console.print("[yellow]Please run the quantization process first:[/yellow]")
-        console.print(
-            f"[yellow]torchrun --nproc_per_node {tp} examples/quantization/quantize.py --megatron-save-path {megatron_load_path} --tp {tp}[/yellow]"
-        )
-        sys.exit(1)
-
-    # Initialize bridge from HF model to get tokenizer and model structure
-    bridge = AutoBridge.from_hf_pretrained(
-        hf_model_id,
-        trust_remote_code=is_safe_repo(
-            trust_remote_code=trust_remote_code,
-            hf_path=hf_model_id,
+    require_torchrun()
+    require_checkpoint(
+        megatron_load_path,
+        quantize_command=(
+            f"torchrun --nproc_per_node {tp} examples/quantization/quantize.py "
+            f"--hf-model-id {hf_model_id} --megatron-save-path {megatron_load_path} --tp {tp}"
         ),
     )
-
-    # Get model provider and configure for multi-GPU execution
-    model_provider = bridge.to_megatron_provider(load_weights=False)
-    model_provider.tensor_model_parallel_size = tp
-    model_provider.pipeline_model_parallel_size = pp
-    model_provider.expert_model_parallel_size = ep
-    model_provider.expert_tensor_parallel_size = etp
 
     # Convert dtype string to torch dtype
     dtype_map = {
@@ -102,51 +86,34 @@ def main(
         "float32": torch.float32,
     }
     torch_dtype = dtype_map.get(dtype, torch.bfloat16)
-    model_provider.pipeline_dtype = torch_dtype
 
-    # Once all overrides are set, finalize the model provider to ensure the post initialization logic is run
-    model_provider.finalize()
-    model_provider.initialize_model_parallel(seed=0)
-
-    # Load the quantized model
-    megatron_model = bridge.load_megatron_model(
-        megatron_load_path,
-        mp_overrides={
-            "tensor_model_parallel_size": tp,
-            "pipeline_model_parallel_size": pp,
-            "expert_model_parallel_size": ep,
-            "expert_tensor_parallel_size": etp,
-        },
-        wrap_with_ddp=False,
+    # Initialize bridge from HF model to get tokenizer and model structure
+    bridge, model_provider = build_bridge_and_provider(
+        hf_model_id,
+        tp=tp,
+        pp=pp,
+        ep=ep,
+        etp=etp,
+        load_weights=False,
+        pipeline_dtype=torch_dtype,
+        trust_remote_code=trust_remote_code,
     )
+    megatron_model = load_quantized_megatron_model(bridge, megatron_load_path, tp=tp, pp=pp, ep=ep, etp=etp)
 
     # Now we can check for rank
-    is_rank_0 = torch.distributed.get_rank() == 0
+    is_rank_0 = dist.is_master()
 
+    print_parallelism_summary(model_provider)
     if is_rank_0:
-        console.print(f"[green]Tensor parallel size: {model_provider.tensor_model_parallel_size}[/green]")
-        console.print(f"[green]Pipeline parallel size: {model_provider.pipeline_model_parallel_size}[/green]")
-        console.print(f"[green]Expert parallel size: {model_provider.expert_model_parallel_size}[/green]")
-        console.print(f"[green]Expert tensor parallel size: {model_provider.expert_tensor_parallel_size}[/green]")
         console.print(f"[green]Loaded quantized model from: {megatron_load_path}[/green]")
 
     # Get the unwrapped model for export
     unwrapped_model = unwrap_model(megatron_model)[0]
 
-    # Decide whether we are exporting only the extra_modules (e.g. EAGLE, Medusa).
-    # Only the last pp stage may have extra_modules, hence broadcast from the last rank.
+    # Only the last pp stage may have extra_modules (e.g. EAGLE, Medusa), hence broadcast from the last rank.
     has_extra_modules = hasattr(unwrapped_model, "eagle_module") or hasattr(unwrapped_model, "medusa_heads")
-
-    # Broadcast from the last rank in case this is pipeline parallel
-    if torch.distributed.is_initialized():
-        extra_modules_list = [has_extra_modules]
-        torch.distributed.broadcast_object_list(
-            extra_modules_list,
-            src=torch.distributed.get_world_size() - 1,
-        )
-        export_extra_modules_flag = extra_modules_list[0] if export_extra_modules else False
-    else:
-        export_extra_modules_flag = has_extra_modules if export_extra_modules else False
+    has_extra_modules = dist.broadcast(has_extra_modules, src=dist.size() - 1)
+    export_extra_modules_flag = has_extra_modules if export_extra_modules else False
 
     if is_rank_0:
         console.print("[green]Exporting to HuggingFace format...[/green]")
@@ -173,14 +140,8 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Export a quantized Megatron-LM checkpoint to HuggingFace format on multiple GPUs"
     )
-    parser.add_argument(
-        "--hf-model-id", type=str, default=HF_MODEL_ID, help="HuggingFace model ID for tokenizer and model structure"
-    )
+    add_common_model_args(parser)
 
-    parser.add_argument("--tp", type=int, default=1, help="Tensor parallelism size")
-    parser.add_argument("--pp", type=int, default=1, help="Pipeline parallelism size")
-    parser.add_argument("--ep", type=int, default=1, help="Expert parallelism size")
-    parser.add_argument("--etp", type=int, default=1, help="Expert tensor parallelism size")
     parser.add_argument(
         "--megatron-load-path",
         type=str,
@@ -205,11 +166,6 @@ if __name__ == "__main__":
         choices=["bfloat16", "float16", "float32"],
         help="Data type for export",
     )
-    parser.add_argument(
-        "--trust-remote-code",
-        action="store_true",
-        help="if trust_remote_code",
-    )
 
     args = parser.parse_args()
     main(
@@ -225,5 +181,4 @@ if __name__ == "__main__":
         args.trust_remote_code,
     )
 
-    if torch.distributed.is_initialized():
-        torch.distributed.destroy_process_group()
+    dist.cleanup()

--- a/examples/quantization/pretrain_quantized_llama3_8b.py
+++ b/examples/quantization/pretrain_quantized_llama3_8b.py
@@ -68,7 +68,7 @@ import sys
 from pathlib import Path
 from typing import Tuple
 
-import torch
+import modelopt.torch.utils.distributed as dist
 from omegaconf import OmegaConf
 
 from megatron.bridge.recipes.llama import llama3_8b_pretrain_config as pretrain_config
@@ -210,9 +210,7 @@ def main() -> None:
     pretrain(config=cfg, forward_step_func=forward_step)
 
     # Cleanup process group
-    if torch.distributed.is_initialized():
-        torch.distributed.barrier()
-        torch.distributed.destroy_process_group()
+    dist.cleanup()
 
 
 if __name__ == "__main__":

--- a/examples/quantization/ptq_generate.py
+++ b/examples/quantization/ptq_generate.py
@@ -18,7 +18,8 @@ and perform text generation using the AutoBridge on multiple GPUs.
 
 Prerequisites:
 First, you must run the quantization process to create a quantized checkpoint:
-    torchrun --nproc_per_node 2 examples/quantization/quantize.py --megatron-save-path ./quantized_megatron_checkpoint --tp 2
+    torchrun --nproc_per_node 2 examples/quantization/quantize.py \
+        --hf-model-id meta-llama/Llama-3.2-1B --megatron-save-path ./quantized_megatron_checkpoint --tp 2
 
 The process is as follows:
 1. An AutoBridge is initialized from a pretrained Hugging Face model
@@ -27,28 +28,31 @@ The process is as follows:
 3. Text generation is performed using the loaded quantized model.
 
 Usage:
-torchrun --nproc_per_node 2 examples/quantization/ptq_generate.py --megatron-load-path ./quantized_megatron_checkpoint --tp 2
+torchrun --nproc_per_node 2 examples/quantization/ptq_generate.py --hf-model-id meta-llama/Llama-3.2-1B \
+    --megatron-load-path ./quantized_megatron_checkpoint --tp 2
 """
 
 import argparse
-import os
-import sys
 import warnings
 
+import modelopt.torch.utils.distributed as dist
 import torch
 from megatron.core.utils import unwrap_model
 from quantize import _custom_prompt_forward_loop_func
-from rich.console import Console
+from quantize_utils import (
+    add_common_model_args,
+    build_bridge_and_provider,
+    console,
+    load_quantized_megatron_model,
+    print_parallelism_summary,
+    require_checkpoint,
+    require_torchrun,
+)
 
-from megatron.bridge import AutoBridge
 from megatron.bridge.models.decorators import torchrun_main
-from megatron.bridge.models.hf_pretrained.utils import is_safe_repo
 
 
 warnings.filterwarnings("ignore")
-
-HF_MODEL_ID = "meta-llama/Llama-3.2-1B"
-console = Console()
 
 
 def _validate_quantized_model(model: torch.nn.Module, is_rank_0: bool) -> None:
@@ -121,7 +125,7 @@ def _validate_quantized_model(model: torch.nn.Module, is_rank_0: bool) -> None:
 
 @torchrun_main
 def main(
-    hf_model_id: str = HF_MODEL_ID,
+    hf_model_id: str,
     tp: int = 1,
     pp: int = 1,
     ep: int = 1,
@@ -132,65 +136,38 @@ def main(
     trust_remote_code: bool | None = None,
 ) -> None:
     """Load a quantized Megatron-LM checkpoint and perform text generation on multiple GPUs."""
-    if os.environ.get("WORLD_SIZE") is None:
-        console.print("This script must be launched with torchrun. Please run:")
-        console.print(f"torchrun --nproc_per_node <gpus> {sys.argv[0]}")
-        sys.exit(1)
-
-    # Check if the checkpoint path exists
-    if not os.path.exists(megatron_load_path):
-        console.print(f"[red]Error: Quantized checkpoint path {megatron_load_path} does not exist![/red]")
-        console.print("[yellow]Please run the quantization process first:[/yellow]")
-        console.print(
-            f"[yellow]torchrun --nproc_per_node {tp} examples/models/quantize.py --megatron-save-path {megatron_load_path} --tp {tp}[/yellow]"
-        )
-        sys.exit(1)
-
-    # Initialize bridge from HF model to get tokenizer and model structure
-    bridge = AutoBridge.from_hf_pretrained(
-        hf_model_id,
-        trust_remote_code=is_safe_repo(
-            trust_remote_code=trust_remote_code,
-            hf_path=hf_model_id,
+    require_torchrun()
+    require_checkpoint(
+        megatron_load_path,
+        quantize_command=(
+            f"torchrun --nproc_per_node {tp} examples/quantization/quantize.py "
+            f"--hf-model-id {hf_model_id} --megatron-save-path {megatron_load_path} --tp {tp}"
         ),
     )
 
-    # Get model provider and configure for multi-GPU execution
-    model_provider = bridge.to_megatron_provider(load_weights=False)
-    model_provider.tensor_model_parallel_size = tp
-    model_provider.pipeline_model_parallel_size = pp
-    model_provider.expert_model_parallel_size = ep
-    model_provider.expert_tensor_parallel_size = etp
-    model_provider.pipeline_dtype = torch.bfloat16
-
-    # Once all overrides are set, finalize the model provider to ensure the post initialization logic is run
-    model_provider.finalize()
-    model_provider.initialize_model_parallel(seed=0)
-    megatron_model = bridge.load_megatron_model(
-        megatron_load_path,
-        mp_overrides={
-            "tensor_model_parallel_size": tp,
-            "pipeline_model_parallel_size": pp,
-            "expert_model_parallel_size": ep,
-            "expert_tensor_parallel_size": etp,
-        },
-        wrap_with_ddp=False,
+    # Initialize bridge from HF model to get tokenizer and model structure
+    bridge, model_provider = build_bridge_and_provider(
+        hf_model_id,
+        tp=tp,
+        pp=pp,
+        ep=ep,
+        etp=etp,
+        load_weights=False,
+        pipeline_dtype=torch.bfloat16,
+        trust_remote_code=trust_remote_code,
     )
+    megatron_model = load_quantized_megatron_model(bridge, megatron_load_path, tp=tp, pp=pp, ep=ep, etp=etp)
     megatron_model = [m.cuda() for m in megatron_model]
 
     # Now we can check for rank
-    is_rank_0 = torch.distributed.get_rank() == 0
+    is_rank_0 = dist.is_master()
 
+    print_parallelism_summary(model_provider)
     if is_rank_0:
-        console.print(f"[green]Tensor parallel size: {model_provider.tensor_model_parallel_size}[/green]")
-        console.print(f"[green]Pipeline parallel size: {model_provider.pipeline_model_parallel_size}[/green]")
-        console.print(f"[green]Expert parallel size: {model_provider.expert_model_parallel_size}[/green]")
-        console.print(f"[green]Expert tensor parallel size: {model_provider.expert_tensor_parallel_size}[/green]")
         console.print(f"[green]Loaded quantized model from: {megatron_load_path}[/green]")
 
     # Get the unwrapped model for generation
     unwrapped_model = unwrap_model(megatron_model)[0]
-    unwrapped_model.eval()
 
     # Validate that the model has quantized layers
     _validate_quantized_model(unwrapped_model, is_rank_0)
@@ -210,14 +187,8 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Load a quantized Megatron-LM checkpoint and perform text generation on multiple GPUs"
     )
-    parser.add_argument(
-        "--hf-model-id", type=str, default=HF_MODEL_ID, help="HuggingFace model ID for tokenizer and model structure"
-    )
+    add_common_model_args(parser)
 
-    parser.add_argument("--tp", type=int, default=1, help="Tensor parallelism size")
-    parser.add_argument("--pp", type=int, default=1, help="Pipeline parallelism size")
-    parser.add_argument("--ep", type=int, default=1, help="Expert parallelism size")
-    parser.add_argument("--etp", type=int, default=1, help="Expert tensor parallelism size")
     parser.add_argument(
         "--megatron-load-path",
         type=str,
@@ -236,7 +207,6 @@ if __name__ == "__main__":
         default=32,
         help="Output sequence length for generation.",
     )
-    parser.add_argument("--trust-remote-code", action="store_true", help="if trust_remote_code")
 
     args = parser.parse_args()
     main(
@@ -251,5 +221,4 @@ if __name__ == "__main__":
         args.trust_remote_code,
     )
 
-    if torch.distributed.is_initialized():
-        torch.distributed.destroy_process_group()
+    dist.cleanup()

--- a/examples/quantization/ptq_generate_vlm.py
+++ b/examples/quantization/ptq_generate_vlm.py
@@ -44,20 +44,26 @@ import os
 import sys
 import warnings
 
+import modelopt.torch.utils.distributed as dist
 import torch
 from megatron.core.utils import unwrap_model
-from quantize_utils import console
+from quantize_utils import (
+    add_common_model_args,
+    build_bridge_and_provider,
+    console,
+    load_quantized_megatron_model,
+    print_parallelism_summary,
+    require_checkpoint,
+    require_torchrun,
+)
 from quantize_vlm import _custom_prompt_forward_loop_func
 from transformers import AutoProcessor
 
-from megatron.bridge import AutoBridge
 from megatron.bridge.models.decorators import torchrun_main
-from megatron.bridge.models.hf_pretrained.utils import is_safe_repo
 
 
 warnings.filterwarnings("ignore")
 
-HF_MODEL_ID = "Qwen/Qwen3-VL-8B-Instruct"
 DEFAULT_IMAGE_PATH = "/models/demo.jpeg"
 
 
@@ -113,7 +119,7 @@ def _validate_quantized_model(model: torch.nn.Module, is_rank_0: bool) -> None:
 
 @torchrun_main
 def main(
-    hf_model_id: str = HF_MODEL_ID,
+    hf_model_id: str,
     tp: int = 1,
     pp: int = 1,
     ep: int = 1,
@@ -125,20 +131,14 @@ def main(
     trust_remote_code: bool = True,
 ) -> None:
     """Load a quantized Megatron-LM VLM checkpoint and perform image+text generation on multiple GPUs."""
-    if os.environ.get("WORLD_SIZE") is None:
-        console.print("This script must be launched with torchrun. Please run:")
-        console.print(f"torchrun --nproc_per_node <gpus> {sys.argv[0]}")
-        sys.exit(1)
-
-    # Check if the checkpoint path exists
-    if not os.path.exists(megatron_load_path):
-        console.print(f"[red]Error: Quantized checkpoint path {megatron_load_path} does not exist![/red]")
-        console.print("[yellow]Please run the quantization process first:[/yellow]")
-        console.print(
-            f"[yellow]torchrun --nproc_per_node {tp} examples/quantization/quantize_vlm.py "
-            f"--hf-model-id {hf_model_id} --megatron-save-path {megatron_load_path} --tp {tp}[/yellow]"
-        )
-        sys.exit(1)
+    require_torchrun()
+    require_checkpoint(
+        megatron_load_path,
+        quantize_command=(
+            f"torchrun --nproc_per_node {tp} examples/quantization/quantize_vlm.py "
+            f"--hf-model-id {hf_model_id} --megatron-save-path {megatron_load_path} --tp {tp}"
+        ),
+    )
 
     # Check if the image path exists (skip check for URLs)
     is_url = image_path.startswith("http://") or image_path.startswith("https://")
@@ -147,53 +147,32 @@ def main(
         sys.exit(1)
 
     # Initialize bridge from HF model to get processor and model structure
-    bridge = AutoBridge.from_hf_pretrained(
+    bridge, model_provider = build_bridge_and_provider(
         hf_model_id,
-        trust_remote_code=is_safe_repo(
-            trust_remote_code=trust_remote_code,
-            hf_path=hf_model_id,
-        ),
+        tp=tp,
+        pp=pp,
+        ep=ep,
+        etp=etp,
+        load_weights=False,
+        pipeline_dtype=torch.bfloat16,
+        trust_remote_code=trust_remote_code,
     )
 
     # Load processor for VLM
     processor = AutoProcessor.from_pretrained(hf_model_id, trust_remote_code=trust_remote_code)
 
-    # Get model provider and configure for multi-GPU execution
-    model_provider = bridge.to_megatron_provider(load_weights=False)
-    model_provider.tensor_model_parallel_size = tp
-    model_provider.pipeline_model_parallel_size = pp
-    model_provider.expert_model_parallel_size = ep
-    model_provider.expert_tensor_parallel_size = etp
-    model_provider.pipeline_dtype = torch.bfloat16
-
-    # Once all overrides are set, finalize the model provider to ensure the post initialization logic is run
-    model_provider.finalize()
-    model_provider.initialize_model_parallel(seed=0)
-    megatron_model = bridge.load_megatron_model(
-        megatron_load_path,
-        mp_overrides={
-            "tensor_model_parallel_size": tp,
-            "pipeline_model_parallel_size": pp,
-            "expert_model_parallel_size": ep,
-            "expert_tensor_parallel_size": etp,
-        },
-        wrap_with_ddp=False,
-    )
+    megatron_model = load_quantized_megatron_model(bridge, megatron_load_path, tp=tp, pp=pp, ep=ep, etp=etp)
     megatron_model = [m.cuda() for m in megatron_model]
 
     # Now we can check for rank
-    is_rank_0 = torch.distributed.get_rank() == 0
+    is_rank_0 = dist.is_master()
 
+    print_parallelism_summary(model_provider)
     if is_rank_0:
-        console.print(f"[green]Tensor parallel size: {model_provider.tensor_model_parallel_size}[/green]")
-        console.print(f"[green]Pipeline parallel size: {model_provider.pipeline_model_parallel_size}[/green]")
-        console.print(f"[green]Expert parallel size: {model_provider.expert_model_parallel_size}[/green]")
-        console.print(f"[green]Expert tensor parallel size: {model_provider.expert_tensor_parallel_size}[/green]")
         console.print(f"[green]Loaded quantized model from: {megatron_load_path}[/green]")
 
     # Get the unwrapped model for generation
     unwrapped_model = unwrap_model(megatron_model)[0]
-    unwrapped_model.eval()
 
     # Validate that the model has quantized layers
     _validate_quantized_model(unwrapped_model, is_rank_0)
@@ -213,17 +192,8 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Load a quantized Megatron-LM VLM checkpoint and perform image+text generation on multiple GPUs"
     )
-    parser.add_argument(
-        "--hf-model-id",
-        type=str,
-        default=HF_MODEL_ID,
-        help="HuggingFace model ID for processor and model structure (e.g., Qwen/Qwen3-VL-8B-Instruct)",
-    )
+    add_common_model_args(parser)
 
-    parser.add_argument("--tp", type=int, default=1, help="Tensor parallelism size")
-    parser.add_argument("--pp", type=int, default=1, help="Pipeline parallelism size")
-    parser.add_argument("--ep", type=int, default=1, help="Expert parallelism size")
-    parser.add_argument("--etp", type=int, default=1, help="Expert tensor parallelism size")
     parser.add_argument(
         "--megatron-load-path",
         type=str,
@@ -248,7 +218,6 @@ if __name__ == "__main__":
         default=DEFAULT_IMAGE_PATH,
         help="Path to the image file for VLM generation.",
     )
-    parser.add_argument("--trust-remote-code", action="store_true", help="if trust_remote_code")
 
     args = parser.parse_args()
     try:
@@ -265,5 +234,4 @@ if __name__ == "__main__":
             args.trust_remote_code,
         )
     finally:
-        if torch.distributed.is_initialized():
-            torch.distributed.destroy_process_group()
+        dist.cleanup()

--- a/examples/quantization/quantize.py
+++ b/examples/quantization/quantize.py
@@ -17,78 +17,53 @@ This example demonstrates how to use the AutoBridge to perform quantization
 from a Hugging Face model to a quantized Megatron-LM model on multiple GPUs.
 
 The process is as follows:
-1. An AutoBridge is initialized from a pretrained Hugging Face model
-    (e.g., "meta-llama/Llama-3.2-1B"). This downloads the model from the Hub and loads it.
+1. An AutoBridge is initialized from the pretrained Hugging Face model given by `--hf-model-id`.
+    This downloads the model from the Hub (or loads it from a local path) and loads it.
 2. ModelOpt quantization is applied to the Megatron-LM model using the specified configuration.
 3. The quantized Megatron-LM model is saved in Megatron's native checkpoint format
     using the `--megatron-save-path` argument.
 
 Usage:
-torchrun --nproc_per_node 2 examples/models/quantize.py --export-quant-cfg fp8
-torchrun --nproc_per_node 2 examples/models/quantize.py --export-quant-cfg fp8 --megatron-save-path ./megatron_checkpoint
+torchrun --nproc_per_node 2 examples/quantization/quantize.py \
+    --hf-model-id meta-llama/Llama-3.2-1B --export-quant-cfg fp8
+torchrun --nproc_per_node 2 examples/quantization/quantize.py \
+    --hf-model-id meta-llama/Llama-3.2-1B --export-quant-cfg fp8 --megatron-save-path ./megatron_checkpoint
 """
 
 import argparse
-import os
-import sys
 import warnings
 
 import modelopt.torch.quantization as mtq
+import modelopt.torch.utils.distributed as dist
 import torch
-from datasets import load_dataset
 from megatron.core.utils import unwrap_model
+from modelopt.torch.utils.plugins.megatron_calibration import get_megatron_calibration_forward_loop
 from modelopt.torch.utils.plugins.megatron_generate import megatron_generate
 from quantize_utils import (
     QUANT_CFG_CHOICES,
     add_common_quantization_args,
+    build_bridge_and_provider,
     console,
     create_quantization_stats_table,
     get_modelopt_torch_quantization_config,
+    print_parallelism_summary,
+    require_torchrun,
 )
-from tqdm import tqdm
 
-from megatron.bridge import AutoBridge
 from megatron.bridge.models.decorators import torchrun_main
-from megatron.bridge.models.hf_pretrained.utils import is_safe_repo
 
 
 warnings.filterwarnings("ignore")
 
-HF_MODEL_ID = "meta-llama/Llama-3.2-1B"
-
-
-def get_calib_dataloader(calib_size=512, max_sequence_length=512):
-    """Return a dataloader for calibration."""
-    # Only rank 0 downloads/prepares the dataset to avoid race conditions when multiple
-    # ranks simultaneously write to the same HuggingFace cache directory.
-    rank = torch.distributed.get_rank()
-    if rank == 0:
-        dataset = load_dataset("cnn_dailymail", name="3.0.0", split="train")
-    torch.distributed.barrier()
-    if rank != 0:
-        dataset = load_dataset("cnn_dailymail", name="3.0.0", split="train")
-
-    text_column = "article"
-
-    calib_size = min(len(dataset), calib_size)
-    for i in range(calib_size):
-        yield dataset[i][text_column][:max_sequence_length]
-
-
-def _hf_dataset_forward_loop_func(model, tokenizer, calib_size):
-    """Forward loop function for calibration using HuggingFace dataset."""
-    dataloader = get_calib_dataloader(calib_size)
-
-    for prompt in tqdm(dataloader, total=calib_size, disable=torch.distributed.get_rank()):
-        tokens = tokenizer(prompt, return_tensors="pt")
-        megatron_generate(model, tokens.input_ids.cuda(), osl=1)
+# Resolved by ModelOpt's dataset registry, which pins the concrete namespaced Hub id.
+DEFAULT_CALIB_DATASET = "cnn_dailymail"
 
 
 def _custom_prompt_forward_loop_func(model, prompts, tokenizer, is_rank_0, osl=32):
     """Forward loop function for testing quantized model with custom prompts."""
     all_prompts = prompts.split("|")
 
-    for idx, prompt in tqdm(enumerate(all_prompts), disable=torch.distributed.get_rank()):
+    for idx, prompt in enumerate(all_prompts):
         tokens = tokenizer(prompt, return_tensors="pt")
         generated_ids = megatron_generate(model, tokens.input_ids.cuda(), osl=osl, enable_kv_cache=False)
         generated_texts = tokenizer.batch_decode(generated_ids)
@@ -99,7 +74,7 @@ def _custom_prompt_forward_loop_func(model, prompts, tokenizer, is_rank_0, osl=3
 
 @torchrun_main
 def main(
-    hf_model_id: str = HF_MODEL_ID,
+    hf_model_id: str,
     tp: int = 1,
     pp: int = 1,
     ep: int = 1,
@@ -107,6 +82,9 @@ def main(
     megatron_save_path: str | None = None,
     export_quant_cfg: str = "fp8",
     calib_size: int = 512,
+    calib_seq_length: int = 512,
+    calib_batch_size: int = 1,
+    calib_dataset: str = DEFAULT_CALIB_DATASET,
     compress: bool = False,
     weight_only: bool = False,
     export_kv_cache_quant: bool = False,
@@ -114,40 +92,24 @@ def main(
     trust_remote_code: bool | None = None,
 ) -> None:
     """Perform quantization from HuggingFace model to quantized Megatron-LM model on multiple GPUs."""
-    if os.environ.get("WORLD_SIZE") is None:
-        console.print("This script must be launched with torchrun. Please run:")
-        console.print(f"torchrun --nproc_per_node <gpus> {sys.argv[0]}")
-        sys.exit(1)
+    require_torchrun()
 
-    bridge = AutoBridge.from_hf_pretrained(
+    bridge, model_provider = build_bridge_and_provider(
         hf_model_id,
-        trust_remote_code=is_safe_repo(
-            trust_remote_code=trust_remote_code,
-            hf_path=hf_model_id,
-        ),
+        tp=tp,
+        pp=pp,
+        ep=ep,
+        etp=etp,
+        load_weights=True,
+        pipeline_dtype=torch.bfloat16,
+        trust_remote_code=trust_remote_code,
     )
-
-    model_provider = bridge.to_megatron_provider(load_weights=True)
-    model_provider.tensor_model_parallel_size = tp
-    model_provider.pipeline_model_parallel_size = pp
-    model_provider.expert_model_parallel_size = ep
-    model_provider.expert_tensor_parallel_size = etp
-    model_provider.pipeline_dtype = torch.bfloat16
-
-    # All models use TE spec (default) for quantization
-    # Once all overrides are set, finalize the model provider to ensure the post initialization logic is run
-    model_provider.finalize()
-    model_provider.initialize_model_parallel(seed=0)
     megatron_model = model_provider.provide_distributed_model(wrap_with_ddp=False)
 
     # Now we can check for rank
-    is_rank_0 = torch.distributed.get_rank() == 0
+    is_rank_0 = dist.is_master()
 
-    if is_rank_0:
-        console.print(f"[green]Tensor parallel size: {model_provider.tensor_model_parallel_size}[/green]")
-        console.print(f"[green]Pipeline parallel size: {model_provider.pipeline_model_parallel_size}[/green]")
-        console.print(f"[green]Expert parallel size: {model_provider.expert_model_parallel_size}[/green]")
-        console.print(f"[green]Expert tensor parallel size: {model_provider.expert_tensor_parallel_size}[/green]")
+    print_parallelism_summary(model_provider)
 
     # Formatting
     if is_rank_0:
@@ -164,15 +126,23 @@ def main(
         # Get quantization configuration
         mtq_config = get_modelopt_torch_quantization_config(export_quant_cfg, export_kv_cache_quant, weight_only)
 
-        # Define forward loop function for calibration
-        ptq_forward_loop_func = lambda model: _hf_dataset_forward_loop_func(
-            model, bridge.hf_pretrained.tokenizer, calib_size
-        )
+        # These configs derive scales from weights alone, so skip the dataset download and forward pass.
+        if weight_only or not mtq.need_calibration(mtq_config):
+            if is_rank_0:
+                console.print("[yellow]Weight-only or dynamic quantization: skipping calibration.[/yellow]")
+            ptq_forward_loop_func = None
+        else:
+            ptq_forward_loop_func = get_megatron_calibration_forward_loop(
+                bridge.hf_pretrained.tokenizer,
+                dataset_name=calib_dataset,
+                num_samples=calib_size,
+                seq_length=calib_seq_length,
+                batch_size=calib_batch_size,
+                pack=True,
+            )
 
         # Apply quantization
-        if weight_only:
-            mtq.quantize(unwrapped_model, mtq_config)
-        elif hasattr(unwrapped_model, "calibration_mode"):
+        if hasattr(unwrapped_model, "calibration_mode"):
             unwrapped_model.calibration_mode = True
             mtq.quantize(unwrapped_model, mtq_config, ptq_forward_loop_func)
             unwrapped_model.calibration_mode = False
@@ -198,7 +168,7 @@ def main(
 
             console.print(table)
 
-    torch.distributed.barrier()
+    dist.barrier()
 
     # Save quantized model in Megatron format
     if megatron_save_path:
@@ -213,7 +183,7 @@ def main(
         console.print(f"Saving quantized Megatron checkpoint in {save_path}...")
     bridge.save_megatron_model(megatron_model, save_path)
 
-    torch.distributed.barrier()
+    dist.barrier()
 
     # Test quantized model with custom prompts
     if export_quant_cfg in QUANT_CFG_CHOICES:
@@ -227,9 +197,6 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Quantize HuggingFace model to Megatron-LM format using ModelOpt on multiple GPUs"
     )
-    parser.add_argument("--hf-model-id", type=str, default=HF_MODEL_ID, help="HuggingFace model ID to quantize")
-
-    # Add common quantization arguments
     add_common_quantization_args(parser)
 
     # LLM-specific arguments
@@ -238,6 +205,25 @@ if __name__ == "__main__":
         type=str,
         default="Hello!|Born in California, Soyer trained as a",
         help="Input texts for testing quantized model. Please use | to separate different batches.",
+    )
+    parser.add_argument(
+        "--calib-seq-length",
+        type=int,
+        default=512,
+        help="Calibration sequence length in tokens.",
+    )
+    parser.add_argument(
+        "--calib-batch-size",
+        type=int,
+        default=1,
+        help="Calibration batch size. Raise it to speed up calibration when memory allows.",
+    )
+    parser.add_argument(
+        "--calib-dataset",
+        type=str,
+        default=DEFAULT_CALIB_DATASET,
+        help="Calibration dataset: a ModelOpt registered dataset name, a HuggingFace dataset path, "
+        "a local directory, or a .jsonl file. Use a local path when running without Hub access.",
     )
     parser.add_argument(
         "--disable-hf-datasets-file-lock",
@@ -254,20 +240,22 @@ if __name__ == "__main__":
         datasets.builder.FileLock = MagicMock()
 
     main(
-        args.hf_model_id,
-        args.tp,
-        args.pp,
-        args.ep,
-        args.etp,
-        args.megatron_save_path,
-        args.export_quant_cfg,
-        args.calib_size,
-        args.compress,
-        args.weight_only,
-        args.export_kv_cache_quant,
-        args.prompts,
-        args.trust_remote_code,
+        hf_model_id=args.hf_model_id,
+        tp=args.tp,
+        pp=args.pp,
+        ep=args.ep,
+        etp=args.etp,
+        megatron_save_path=args.megatron_save_path,
+        export_quant_cfg=args.export_quant_cfg,
+        calib_size=args.calib_size,
+        calib_seq_length=args.calib_seq_length,
+        calib_batch_size=args.calib_batch_size,
+        calib_dataset=args.calib_dataset,
+        compress=args.compress,
+        weight_only=args.weight_only,
+        export_kv_cache_quant=args.export_kv_cache_quant,
+        prompts=args.prompts,
+        trust_remote_code=args.trust_remote_code,
     )
 
-    if torch.distributed.is_initialized():
-        torch.distributed.destroy_process_group()
+    dist.cleanup()

--- a/examples/quantization/quantize_utils.py
+++ b/examples/quantization/quantize_utils.py
@@ -21,10 +21,18 @@ scripts (LLM and VLM) to avoid code duplication.
 
 import argparse
 import copy
+import os
+import sys
 
 import modelopt.torch.quantization as mtq
+import modelopt.torch.utils.distributed as dist
+import torch
 from rich.console import Console
 from rich.table import Table
+
+from megatron.bridge import AutoBridge
+from megatron.bridge.models.gpt_provider import GPTModelProvider
+from megatron.bridge.models.hf_pretrained.utils import is_safe_repo
 
 
 # Shared console instance for rich output
@@ -91,6 +99,131 @@ def get_modelopt_torch_quantization_config(
     return mtq_config
 
 
+def require_torchrun() -> None:
+    """Exit with guidance unless the script was launched under torchrun.
+
+    These examples all build a distributed model, so they cannot run as a plain
+    `python script.py` invocation.
+    """
+    if os.environ.get("WORLD_SIZE") is None:
+        console.print("This script must be launched with torchrun. Please run:")
+        console.print(f"torchrun --nproc_per_node <gpus> {sys.argv[0]}")
+        sys.exit(1)
+
+
+def require_checkpoint(megatron_load_path: str, *, quantize_command: str) -> None:
+    """Exit with guidance unless the quantized Megatron checkpoint exists.
+
+    Args:
+        megatron_load_path: Path the script expects to load the quantized checkpoint from.
+        quantize_command: The command that produces that checkpoint, echoed to the user.
+    """
+    if not os.path.exists(megatron_load_path):
+        console.print(f"[red]Error: Quantized checkpoint path {megatron_load_path} does not exist![/red]")
+        console.print("[yellow]Please run the quantization process first:[/yellow]")
+        console.print(f"[yellow]{quantize_command}[/yellow]")
+        sys.exit(1)
+
+
+def build_bridge_and_provider(
+    hf_model_id: str,
+    *,
+    tp: int,
+    pp: int,
+    ep: int,
+    etp: int,
+    load_weights: bool,
+    pipeline_dtype: torch.dtype,
+    trust_remote_code: bool | None = None,
+) -> tuple[AutoBridge, GPTModelProvider]:
+    """Build an AutoBridge for a HuggingFace model and a provider configured for multi-GPU execution.
+
+    The provider is finalized and model parallel is initialized, so the caller can immediately
+    call `provide_distributed_model` (to build from HF weights) or `bridge.load_megatron_model`
+    (to load an existing Megatron checkpoint).
+
+    Args:
+        hf_model_id: HuggingFace model ID or local path.
+        tp: Tensor parallel size.
+        pp: Pipeline parallel size.
+        ep: Expert parallel size.
+        etp: Expert tensor parallel size.
+        load_weights: Whether the bridge should load HF weights. Pass False when the weights
+            will come from a Megatron checkpoint instead.
+        pipeline_dtype: Pipeline dtype for the provider.
+        trust_remote_code: Forwarded to `is_safe_repo` to decide whether remote code is allowed.
+
+    Returns:
+        The bridge and its finalized model provider.
+    """
+    bridge = AutoBridge.from_hf_pretrained(
+        hf_model_id,
+        trust_remote_code=is_safe_repo(trust_remote_code=trust_remote_code, hf_path=hf_model_id),
+    )
+
+    model_provider = bridge.to_megatron_provider(load_weights=load_weights)
+    model_provider.tensor_model_parallel_size = tp
+    model_provider.pipeline_model_parallel_size = pp
+    model_provider.expert_model_parallel_size = ep
+    model_provider.expert_tensor_parallel_size = etp
+    model_provider.pipeline_dtype = pipeline_dtype
+
+    # All models use TE spec (default) for quantization.
+    # Once all overrides are set, finalize the provider so its post-initialization logic runs.
+    model_provider.finalize()
+    model_provider.initialize_model_parallel(seed=0)
+
+    return bridge, model_provider
+
+
+def load_quantized_megatron_model(
+    bridge: AutoBridge,
+    megatron_load_path: str,
+    *,
+    tp: int,
+    pp: int,
+    ep: int,
+    etp: int,
+) -> list[torch.nn.Module]:
+    """Load a quantized Megatron checkpoint, re-sharded to the requested parallelism.
+
+    Args:
+        bridge: Bridge built by `build_bridge_and_provider`.
+        megatron_load_path: Path to the quantized Megatron checkpoint.
+        tp: Tensor parallel size.
+        pp: Pipeline parallel size.
+        ep: Expert parallel size.
+        etp: Expert tensor parallel size.
+
+    Returns:
+        The loaded model chunks (not DDP-wrapped).
+    """
+    return bridge.load_megatron_model(
+        megatron_load_path,
+        mp_overrides={
+            "tensor_model_parallel_size": tp,
+            "pipeline_model_parallel_size": pp,
+            "expert_model_parallel_size": ep,
+            "expert_tensor_parallel_size": etp,
+        },
+        wrap_with_ddp=False,
+    )
+
+
+def print_parallelism_summary(model_provider: GPTModelProvider) -> None:
+    """Print the resolved parallelism sizes on the master rank.
+
+    Args:
+        model_provider: The finalized provider whose sizes are reported.
+    """
+    if not dist.is_master():
+        return
+    console.print(f"[green]Tensor parallel size: {model_provider.tensor_model_parallel_size}[/green]")
+    console.print(f"[green]Pipeline parallel size: {model_provider.pipeline_model_parallel_size}[/green]")
+    console.print(f"[green]Expert parallel size: {model_provider.expert_model_parallel_size}[/green]")
+    console.print(f"[green]Expert tensor parallel size: {model_provider.expert_tensor_parallel_size}[/green]")
+
+
 def create_quantization_stats_table() -> Table:
     """Create a rich Table for displaying quantization statistics.
 
@@ -104,16 +237,37 @@ def create_quantization_stats_table() -> Table:
     return table
 
 
-def add_common_quantization_args(parser: argparse.ArgumentParser) -> None:
-    """Add common quantization arguments to an argument parser.
+def add_common_model_args(parser: argparse.ArgumentParser) -> None:
+    """Add the model and parallelism arguments shared by every quantization example.
+
+    These are the arguments needed to build a bridge and provider, so they apply equally to the
+    scripts that quantize a model and to the ones that load an already-quantized checkpoint.
 
     Args:
         parser: The argparse.ArgumentParser to add arguments to.
     """
+    parser.add_argument(
+        "--hf-model-id",
+        type=str,
+        required=True,
+        help="HuggingFace model ID or local path (e.g. meta-llama/Llama-3.2-1B).",
+    )
+
     parser.add_argument("--tp", type=int, default=1, help="Tensor parallelism size")
     parser.add_argument("--pp", type=int, default=1, help="Pipeline parallelism size")
     parser.add_argument("--ep", type=int, default=1, help="Expert parallelism size")
     parser.add_argument("--etp", type=int, default=1, help="Expert tensor parallelism size")
+
+    parser.add_argument(
+        "--trust-remote-code",
+        action="store_true",
+        help="Trust remote code when loading HuggingFace models.",
+    )
+
+
+def add_common_quantization_args(parser: argparse.ArgumentParser) -> None:
+    """Add the arguments shared by the scripts that perform quantization."""
+    add_common_model_args(parser)
 
     parser.add_argument(
         "--megatron-save-path",
@@ -149,9 +303,4 @@ def add_common_quantization_args(parser: argparse.ArgumentParser) -> None:
         "--export-kv-cache-quant",
         action="store_true",
         help="Enable KV cache quantization.",
-    )
-    parser.add_argument(
-        "--trust-remote-code",
-        action="store_true",
-        help="Trust remote code when loading HuggingFace models.",
     )

--- a/examples/quantization/quantize_vlm.py
+++ b/examples/quantization/quantize_vlm.py
@@ -34,12 +34,11 @@ Usage:
 """
 
 import argparse
-import os
-import sys
 import warnings
 from typing import Generator, Optional
 
 import modelopt.torch.quantization as mtq
+import modelopt.torch.utils.distributed as dist
 import torch
 from datasets import load_dataset
 from megatron.core.utils import unwrap_model
@@ -47,17 +46,18 @@ from modelopt.torch.utils.plugins.megatron_generate import megatron_generate
 from quantize_utils import (
     QUANT_CFG_CHOICES,
     add_common_quantization_args,
+    build_bridge_and_provider,
     console,
     create_quantization_stats_table,
     get_modelopt_torch_quantization_config,
+    print_parallelism_summary,
+    require_torchrun,
 )
 from qwen_vl_utils import process_vision_info
 from tqdm import tqdm
 from transformers import AutoProcessor
 
-from megatron.bridge import AutoBridge
 from megatron.bridge.models.decorators import torchrun_main
-from megatron.bridge.models.hf_pretrained.utils import is_safe_repo
 
 
 warnings.filterwarnings("ignore")
@@ -173,7 +173,7 @@ def _hf_dataset_forward_loop_func(
     else:
         dataloader = get_coco_dataloader(calib_dataset, calib_size)
 
-    for messages in tqdm(dataloader, total=calib_size, disable=torch.distributed.get_rank(), desc="Calibration"):
+    for messages in tqdm(dataloader, total=calib_size, disable=not dist.is_master(), desc="Calibration"):
         image_inputs, video_inputs = process_vision_info(messages)
         text = processor.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
         inputs = processor(text=[text], images=image_inputs, videos=video_inputs, padding=True, return_tensors="pt")
@@ -278,40 +278,27 @@ def main(
     use_random_calib: bool = False,
 ) -> None:
     """Perform quantization from HuggingFace VLM model to quantized Megatron-LM model on multiple GPUs."""
-    if os.environ.get("WORLD_SIZE") is None:
-        console.print("This script must be launched with torchrun. Please run:")
-        console.print(f"torchrun --nproc_per_node <gpus> {sys.argv[0]}")
-        sys.exit(1)
+    require_torchrun()
 
-    bridge = AutoBridge.from_hf_pretrained(
+    bridge, model_provider = build_bridge_and_provider(
         hf_model_id,
-        trust_remote_code=is_safe_repo(
-            trust_remote_code=trust_remote_code,
-            hf_path=hf_model_id,
-        ),
+        tp=tp,
+        pp=pp,
+        ep=ep,
+        etp=etp,
+        load_weights=True,
+        pipeline_dtype=torch.bfloat16,
+        trust_remote_code=trust_remote_code,
     )
 
     processor = AutoProcessor.from_pretrained(hf_model_id, trust_remote_code=trust_remote_code)
 
-    model_provider = bridge.to_megatron_provider(load_weights=True)
-    model_provider.tensor_model_parallel_size = tp
-    model_provider.pipeline_model_parallel_size = pp
-    model_provider.expert_model_parallel_size = ep
-    model_provider.expert_tensor_parallel_size = etp
-    model_provider.pipeline_dtype = torch.bfloat16
-
-    model_provider.finalize()
-    model_provider.initialize_model_parallel(seed=0)
     megatron_model = model_provider.provide_distributed_model(wrap_with_ddp=False)
 
     # Now we can check for rank
-    is_rank_0 = torch.distributed.get_rank() == 0
+    is_rank_0 = dist.is_master()
 
-    if is_rank_0:
-        console.print(f"[green]Tensor parallel size: {model_provider.tensor_model_parallel_size}[/green]")
-        console.print(f"[green]Pipeline parallel size: {model_provider.pipeline_model_parallel_size}[/green]")
-        console.print(f"[green]Expert parallel size: {model_provider.expert_model_parallel_size}[/green]")
-        console.print(f"[green]Expert tensor parallel size: {model_provider.expert_tensor_parallel_size}[/green]")
+    print_parallelism_summary(model_provider)
 
     # Formatting
     if is_rank_0:
@@ -401,14 +388,6 @@ def main(
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Post-Training Quantization for Vision-Language Models (VLMs)")
-    parser.add_argument(
-        "--hf-model-id",
-        type=str,
-        default="Qwen/Qwen3-VL-8B-Instruct",
-        help="HuggingFace model ID for the VLM model (e.g., Qwen/Qwen3-VL-8B-Instruct)",
-    )
-
-    # Add common quantization arguments
     add_common_quantization_args(parser)
 
     # VLM-specific arguments
@@ -458,5 +437,4 @@ if __name__ == "__main__":
             args.use_random_calib,
         )
     finally:
-        if torch.distributed.is_initialized():
-            torch.distributed.destroy_process_group()
+        dist.cleanup()


### PR DESCRIPTION
## What

### 1. Replace the hand-rolled calibration loop (`quantize.py`)

The old `get_calib_dataloader` / `_hf_dataset_forward_loop_func` pair had three defects:

- **`load_dataset("cnn_dailymail", ...)`** — the bare legacy id. Fails hard on the pinned `huggingface-hub` 1.26.0 with `HfUriError: Repository id must be 'namespace/name'`. Reproduced standalone with no modelopt imported, so it is not version-specific to the bump. ModelOpt's dataset registry maps this to `abisee/cnn_dailymail` internally.
- **`text[:max_sequence_length]` sliced characters, not tokens.** The parameter said sequence length and defaulted to 512, but the sample is a `str`, so calibration saw roughly a quarter of the intended context.
- **`megatron_generate(..., osl=1)` per sample at batch size 1** — full generate machinery to produce one token, when calibration only needs prefill.

All three go away by delegating to `get_megatron_calibration_forward_loop`, which handles tokenization, token-accurate truncation, batching, DP sharding, and a logits-free prefill. Adds `--calib-seq-length`, `--calib-batch-size`, and `--calib-dataset`.

`--calib-dataset` accepts a ModelOpt registered dataset name, a HuggingFace path, a local directory, or a `.jsonl` file, so calibration data can be supplied without Hub access. `apply_chat_template` is left at ModelOpt's default (`True`) rather than forced off, so chat-format calibration datasets are formatted correctly; it is a no-op for plain-text datasets like the `cnn_dailymail` default.

**CI note:** ModelOpt's registry resolves `cnn_dailymail` to the namespaced `abisee/cnn_dailymail`. CI functional tests run with `HF_HUB_OFFLINE=1` against a pre-seeded `HF_HOME` that currently holds only the legacy `cnn_dailymail` cache key, so `L2_Launch_quantization_aware_training` fails with `ConnectionError: Couldn't reach 'abisee/cnn_dailymail' on the Hub (OfflineModeIsEnabled)` until the test-data cache is seeded with the namespaced id. That seeding has been requested from the Megatron-Bridge admins.

### 2. Correctness fixes

- **No explicit `.eval()` is added.** ModelOpt already handles it: `mtq.calibrate` wraps calibration in `model.eval()` and restores the prior mode (`model_quant.py:106-124`), and `megatron_prefill` / `megatron_generate` each call `model.eval()` themselves.
- **Skip calibration when it cannot help** — `weight_only or not mtq.need_calibration(cfg)` avoids the dataset download and forward pass for weight-only and dynamic configs.
- **`ptq_generate.py` pointed users at `examples/models/quantize.py`**, a path that does not exist, and omitted `--hf-model-id`.

### 3. Share common logic

`quantize_utils.py` already existed, but only 2 of 5 scripts imported it; the rest re-declared their own `--tp/--pp/--ep/--etp` and their own `console = Console()`. New helpers:

| Helper | Replaces | Copies removed |
|---|---|---|
| `require_torchrun()` | WORLD_SIZE guard | 5 |
| `require_checkpoint(path, *, quantize_command)` | "checkpoint missing → run this" block | 3 |
| `build_bridge_and_provider(...)` | `AutoBridge.from_hf_pretrained` + `is_safe_repo` + 5 provider assignments + `finalize()` + `initialize_model_parallel()` | 5 |
| `load_quantized_megatron_model(...)` | `load_megatron_model` + `mp_overrides` dict | 3 |
| `print_parallelism_summary(provider)` | 4 `console.print` lines | 5 |

`add_common_quantization_args` was split: `add_common_model_args` (model + parallelism + `--trust-remote-code`) is used by all five scripts, and the quantization-only flags stay in the original function so `ptq_generate.py` / `export.py` do not inherit `--export-quant-cfg` or `--megatron-save-path`.

`build_bridge_and_provider` keeps `AutoBridge` and the provider knobs visible and named — these are Megatron-Bridge examples, so the bridge → provider → model flow is the thing being taught. It is just no longer taught five times. ModelOpt's `load_mbridge_model_from_hf` would collapse it further but was deliberately not used, for the same reason.

### 4. Reuse `modelopt.torch.utils.distributed`

| Was | Now | Sites |
|---|---|---|
| `torch.distributed.get_rank() == 0` | `dist.is_master()` | 5 |
| `if is_initialized(): destroy_process_group()` | `dist.cleanup()` | 6 |
| `torch.distributed.barrier()` | `dist.barrier()` | 3 |
| `disable=torch.distributed.get_rank()` (tqdm) | `disable=not dist.is_master()` | 1 |
| `broadcast_object_list` + `is_initialized()`/`else` fork | `dist.broadcast(obj, src=dist.size() - 1)` | 1 |

Not purely cosmetic: `dist.broadcast` short-circuits at `size() == 1`, so the 9-line fork in `export.py` collapses to 2 lines; `dist.rank()` is safe before init (returns 0) where `torch.distributed.get_rank()` raises; and `dist.cleanup()` adds a suppressed barrier before destroy.

## Testing

All runs in `nvcr.io/nvidian/nemo:26.08.rc4` with `nvidia-modelopt==0.46.0rc1`, 2× RTX 6000 Ada.

**Functional tests — 10 passed, 0 failed:**

| Test | Result | Time | Scripts exercised |
|---|---|---|---|
| `test_quantization_workflow` | 3 passed | 21:34 | `quantize.py`, `ptq_generate.py` (real Llama-3.2-1B + real calibration) |
| `test_export_workflow` | 2 passed | 13:47 | `quantize.py`, `export.py` |
| `test_qwen3_moe_quantization_workflow` | 2 passed | 12:15 | `quantize.py`, `ptq_generate.py` (MoE TP=2/ETP=2, PP re-shard) |
| `test_qwen3_vl_quantization_workflow` | 2 passed | 11:18 | `quantize_vlm.py`, `ptq_generate_vlm.py` |
| `test_qat_workflow` | 1 passed | 08:34 | `quantize.py`, `pretrain_quantized_llama3_8b.py` |

`test_quantization_workflow` is the direct regression check: it is the test that failed with `HfUriError` before this change, and it passes here against the real `cnn_dailymail` calibration path.

**Scope note:** the table above was run just before the final `modelopt.torch.utils.distributed` swap and comment cleanup. Those were re-verified afterwards: `test_quantization_workflow` re-run on the final code gives the same **3 passed** (20:34), and all six scripts pass CLI smoke tests (import, `--help`, and exit 2 with `required: --hf-model-id`). Re-runs of the export and VLM suites were still in flight at the time of writing; CI is the authority.

**Lint:** `ruff check`, `ruff format --check`, and `ruff check --select I` clean at the pinned v0.9.9.



