### PR TITLE
[recipe] fix: use image-shaped WAN mock data

### DIFF
--- a/src/megatron/bridge/diffusion/recipes/wan/wan.py
+++ b/src/megatron/bridge/diffusion/recipes/wan/wan.py
@@ -300,6 +300,7 @@ def wan_1_3b_text2image_pretrain_config() -> ConfigContainer:
     cfg = wan_1_3b_pretrain_config()
     cfg.model.seq_length = 4096
     cfg.dataset.seq_length = 4096
+    cfg.dataset.F_latents = 1
     cfg.model.context_parallel_size = 1
     cfg.optimizer.lr = 1e-4
     cfg.optimizer.min_lr = 1e-4

--- a/src/megatron/bridge/recipes/wan/h100/wan.py
+++ b/src/megatron/bridge/recipes/wan/h100/wan.py
@@ -313,6 +313,7 @@ def wan_1_3b_text2image_pretrain_1gpu_h100_bf16_config() -> ConfigContainer:
     cfg = wan_1_3b_pretrain_8gpu_h100_bf16_config()
     cfg.model.seq_length = 4096
     cfg.dataset.seq_length = 4096
+    cfg.dataset.F_latents = 1
     cfg.model.context_parallel_size = 1
     cfg.optimizer.lr = 1e-4
     cfg.optimizer.min_lr = 1e-4

--- a/tests/unit_tests/diffusion/recipes/wan/test_wan_recipe.py
+++ b/tests/unit_tests/diffusion/recipes/wan/test_wan_recipe.py
@@ -15,6 +15,7 @@
 import pytest
 
 from megatron.bridge.diffusion.data.wan.wan_energon_datamodule import WanDatasetConfig
+from megatron.bridge.diffusion.data.wan.wan_mock_datamodule import mock_batch
 from megatron.bridge.diffusion.models.wan.wan_provider import WanModelProvider
 from megatron.bridge.diffusion.recipes.wan.wan import (
     wan_1_3b_pretrain_config,
@@ -23,6 +24,12 @@ from megatron.bridge.diffusion.recipes.wan.wan import (
     wan_1_3b_text2video_pretrain_config,
     wan_14b_pretrain_config,
     wan_14b_sft_config,
+)
+from megatron.bridge.recipes.wan import (
+    wan_1_3b_text2image_pretrain_config as canonical_wan_1_3b_text2image_pretrain_config,
+)
+from megatron.bridge.recipes.wan import (
+    wan_1_3b_text2video_pretrain_config as canonical_wan_1_3b_text2video_pretrain_config,
 )
 from megatron.bridge.training.config import ConfigContainer
 
@@ -180,3 +187,26 @@ class TestWan1_3BText2ImageText2VideoConfigs:
         assert config.optimizer.lr == 1e-4
         assert config.optimizer.min_lr == 1e-4
         assert config.optimizer.weight_decay == 0.001
+
+    @pytest.mark.parametrize(
+        "recipe_factory",
+        [
+            wan_1_3b_text2image_pretrain_config,
+            canonical_wan_1_3b_text2image_pretrain_config,
+        ],
+    )
+    def test_text2image_mock_uses_single_temporal_latent(self, recipe_factory):
+        config = recipe_factory()
+        batch = mock_batch(
+            F_latents=config.dataset.F_latents,
+            H_latents=4,
+            W_latents=4,
+            patch_temporal=config.dataset.patch_temporal,
+            patch_spatial=config.dataset.patch_spatial,
+            number_packed_samples=1,
+            context_seq_len=2,
+            context_embeddings_dim=4,
+        )
+
+        assert batch["grid_sizes"][0, 0].item() == 1
+        assert canonical_wan_1_3b_text2video_pretrain_config().dataset.F_latents > 1


### PR DESCRIPTION
## What changed

WAN 1.3B text-to-image recipes now configure mock data with one temporal latent frame in both the legacy and canonical H100 recipe namespaces.

## Problem

Calling either supported text-to-image pretraining factory with its default mock-data path inherited `F_latents=24` from the video base recipe. The mock dataloader therefore emitted a 24-frame temporal grid (37,440 patches at the recipe defaults) even though these factories document and configure spatial-only image training. Real image preprocessing represents images as one-frame videos, so the mock path exercised different training semantics.

The fix sets `dataset.F_latents = 1` at each text-to-image specialization boundary. The shared base and text-to-video recipes remain unchanged.

## Validation

Regression test before the production fix:

```text
uv run --active --no-sync python -m pytest tests/unit_tests/diffusion/recipes/wan/test_wan_recipe.py::TestWan1_3BText2ImageText2VideoConfigs::test_text2image_mock_uses_single_temporal_latent -q --tb=short
2 failed: both factories produced temporal grid size 24 instead of 1
```

After the fix:

```text
uv run --active --no-sync python -m pytest tests/unit_tests/diffusion/recipes/wan/test_wan_recipe.py::TestWan1_3BText2ImageText2VideoConfigs::test_text2image_mock_uses_single_temporal_latent -q --tb=short
2 passed

uv run --active --no-sync python -m pytest tests/unit_tests/diffusion/recipes/wan/test_wan_recipe.py tests/unit_tests/diffusion/data/wan/test_wan_mock_datamodule.py -q --tb=short
20 passed

uv run --active --no-sync pre-commit run --all-files
Passed

git diff --check
Passed
```

Scope is limited to mock-data shape semantics for WAN 1.3B text-to-image recipes; no real-data preprocessing, video recipe, public API, dependency, or distributed behavior changes.
