### PR TITLE
[training] fix: honor MIMO validation interval config

### DIFF
--- a/src/megatron/bridge/training/train_megatron_mimo.py
+++ b/src/megatron/bridge/training/train_megatron_mimo.py
@@ -238,6 +238,9 @@ def train_megatron_mimo(
 
     # Get training config
     train_config = cfg.train
+    eval_interval = cfg.validation.eval_interval
+    if eval_interval is None:
+        eval_interval = train_config.eval_interval
     num_microbatches = get_num_microbatches()
     seq_length = cfg.dataset.seq_length
     micro_batch_size = train_config.micro_batch_size
@@ -394,11 +397,7 @@ def train_megatron_mimo(
                     wandb_writer.log({"iteration-time": iteration_time}, train_state.step)
 
         # Evaluation at specified intervals
-        if (
-            train_config.eval_interval is not None
-            and train_state.step % train_config.eval_interval == 0
-            and valid_data_iterator is not None
-        ):
+        if eval_interval and train_state.step % eval_interval == 0 and valid_data_iterator is not None:
             if train_config.manual_gc and train_config.manual_gc_eval:
                 gc.collect()
             evaluate_and_print_results(

--- a/tests/unit_tests/training/megatron_mimo/test_megatron_mimo_checkpointing.py
+++ b/tests/unit_tests/training/megatron_mimo/test_megatron_mimo_checkpointing.py
@@ -73,6 +73,13 @@ def _make_global_state(
                 manual_gc=False,
                 manual_gc_interval=0,
             ),
+            validation=SimpleNamespace(
+                eval_interval=None,
+                eval_iters=1,
+                eval_global_batch_size=1,
+                eval_micro_batch_size=1,
+                start_eval_at_iter=None,
+            ),
             dataset=SimpleNamespace(seq_length=128),
             checkpoint=SimpleNamespace(
                 save=save_dir,
@@ -394,14 +401,18 @@ class TestNonColocatedGuard:
 # ---------------------------------------------------------------------------
 
 
-def test_interval_evaluation_uses_evaluator_timer_ownership():
-    """Interval evaluation should let the shared evaluator own its timer."""
+@pytest.mark.parametrize("use_canonical_validation_config", [False, True], ids=["deprecated", "canonical"])
+def test_interval_evaluation_uses_evaluator_timer_ownership(use_canonical_validation_config):
+    """Interval evaluation should honor both config paths and let the shared evaluator own its timer."""
     from megatron.core.timers import Timers
 
     from megatron.bridge.training.train_megatron_mimo import train_megatron_mimo
 
     state = _make_global_state(train_iters=1)
-    state.cfg.train.eval_interval = 1
+    if use_canonical_validation_config:
+        state.cfg.validation.eval_interval = 1
+    else:
+        state.cfg.train.eval_interval = 1
     state.timers = Timers(log_level=0, log_option="minmax")
 
     infra = _make_megatron_mimo_infra()


### PR DESCRIPTION
## What does this PR do?

MegatronMIMO now schedules periodic validation from the canonical
`ValidationConfig.eval_interval` setting. If that setting is unset, the loop
retains compatibility with the deprecated `TrainingConfig.eval_interval` field.

## Trigger and impact

A supported MegatronMIMO configuration with a validation iterator,
`validation.eval_interval=1`, and the deprecated `train.eval_interval` left
unset silently skipped every periodic evaluation. Validation data could be
built but never consumed, so expected validation metrics were absent.

The MIMO pretrain path passes the canonical config and validation iterator into
`train_megatron_mimo`, but the loop previously consulted only the deprecated
training field. The fix resolves the interval once, preferring the canonical
field and falling back only when it is `None`.

## Validation

Focused regression:

```bash
uv run python -m pytest tests/unit_tests/training/megatron_mimo/test_megatron_mimo_checkpointing.py::test_interval_evaluation_uses_evaluator_timer_ownership -q
```

- Before the production fix: deprecated control passed; canonical case failed
  because the evaluator was called zero times (`1 failed, 1 passed`).
- After the fix: both cases passed (`2 passed`).

Adjacent MIMO loop coverage:

```bash
uv run python -m pytest \
  tests/unit_tests/training/megatron_mimo/test_megatron_mimo_checkpointing.py::test_interval_evaluation_uses_evaluator_timer_ownership \
  tests/unit_tests/training/megatron_mimo/test_megatron_mimo_checkpointing.py::TestTrainMegatronMIMOCheckpointIntegration \
  tests/unit_tests/training/megatron_mimo/test_megatron_mimo_checkpointing.py::TestNonColocatedGuard -q
```

Result: `8 passed`.

```bash
git diff --check
uv run pre-commit run --all-files
```

Both passed.

## Scope

This change is limited to selecting the periodic-validation interval. It does
not change evaluator internals, validation batch-size resolution, delayed
evaluation semantics, data iteration, or distributed execution.
