### PR TITLE
fix(recipe): verify GLM-5.2 RP2 pretraining and packed SFT

### DIFF
--- a/examples/model_verification_cards/glm5-2/card.yaml
+++ b/examples/model_verification_cards/glm5-2/card.yaml
@@ -7,13 +7,12 @@ summary: >
   timing and throughput metrics are sanity checks, not optimized performance
   results. GLM-5.2 H100 support verification currently covers exact GPU
   checkpoint round-trip on CPU and GPU, HF-to-Megatron forward equivalence,
-  bounded full SFT with export/reload
-  inference, 200K-context CP32 SFT, bounded PEFT, and bounded pretraining with
-  a reloadable middle checkpoint and verified continuation. GB200 support
-  verification currently covers bounded pretraining, bounded full SFT, 128K
-  packed long-context SFT, bounded PEFT, bounded checkpoint resume, and
-  deterministic legacy Megatron inference; post-SFT export/reload inference
-  remains pending.
+  bounded full SFT with export/reload inference, 200K-context CP32 SFT,
+  bounded PEFT, and bounded pretraining with a reloadable middle checkpoint
+  and verified continuation. GB200 support verification currently covers
+  bounded pretraining, bounded full SFT, 128K packed long-context SFT, bounded
+  PEFT, bounded checkpoint resume, and deterministic legacy Megatron
+  inference; post-SFT export/reload inference remains pending.
 verification_index:
   model_level:
     verified:
@@ -149,6 +148,7 @@ items:
       completion was:
       "1.  **Analyze the Request:**
           *   **Topic:**"
+      It produced exactly 16 new tokens.
 
   pretrain:
     H100:
@@ -176,50 +176,57 @@ items:
         initial_loss: 13.15907
         final_loss: 6.385243
         last_10_steps_step_time_ms_avg: 31204.920
-        last_10_steps_model_tflops_per_gpu_avg: 50.620
+        last_10_steps_model_tflops_per_gpu_avg: 54.595
       expected_result: >
         The uninterrupted 352-H100 TP1/PP11/CP1/EP32/ETP1 run completed 100
         real-data steps at GBS/MBS 1024/1 with cuDNN DSA, sparse indexer loss
         coefficient 0.001, MTP1, and flex/DeepEP dispatch. Loss remained finite
         from 13.15907 to 6.385243, final grad norm was 0.796, and every step
         recorded zero skipped and NaN iterations. The final 10 steps averaged
-        31,204.920 ms and 50.620 TFLOPS/GPU; peak observed GPU memory was
+        31,204.920 ms and 54.595 TFLOPS/GPU; peak observed GPU memory was
         80,999 MiB. The matching step-50 and step-100 checkpoints contain
         model, optimizer, scheduler, data-order, and RNG state; the step-50
         checkpoint reloads successfully.
     GB200:
       status: verified
       precision: bf16
+      bridge_commit: e79f756196e0b97ee3ad94263a896c120b32c1e5  # pragma: allowlist secret
       enabled_features: {}
       command: >
         ./scripts/training/train.sh --nodes 48 --gpus-per-node 4
         --recipe glm52_pretrain_192gpu_gb200_bf16_config --mode pretrain
         --dataset megatron-indexed --deterministic --seq_length 4096 --max_steps 100
         --lr 3e-4 --min_lr 3e-5 --warmup_iters 40
-        'dataset.blend=[["work/data/glm5-2/pretrain-tulu3-text-document/tulu3_glm52_text_document_text_document"],null]'
-        dataset.path_to_cache=work/cache/glm5-2/pretrain-tulu3-gb200
-        dataset.random_seed=1234 rng.seed=1234 scheduler.lr_decay_iters=100
-        --save_dir work/model-verification/glm5-2/pretrain-gb200-cudnn/checkpoints
+        'dataset.blend=[["work/data/rp2/head_01_text_document"],null]'
+        dataset.path_to_cache=work/cache/glm5-2/rp2-head-01-gb200
+        dataset.random_seed=1234 dataset.num_workers=8
+        tokenizer.tokenizer_type=SentencePieceTokenizer
+        tokenizer.tokenizer_model=work/data/rp2/tokenizer/tokenizer.model
+        tokenizer.use_tokenizer_vocab_size=false rng.seed=1234
+        scheduler.lr_decay_iters=100 model.moe_router_force_load_balancing=false
+        checkpoint.load=null checkpoint.pretrained_checkpoint=null
+        checkpoint.save_optim=true checkpoint.save_rng=true
+        checkpoint.load_optim=true checkpoint.load_rng=true checkpoint.finetune=false
+        --save_dir work/model-verification/glm5-2/pretrain-rp2-gb200/checkpoints
         --save_interval 50 logger.log_interval=1 logger.log_throughput=true
         logger.tensorboard_dir=null
-      last_verified: 2026-07-24
+      last_verified: 2026-08-04
       metrics:
-        initial_loss: 13.19136
-        final_loss: 8.171059
-        last_10_steps_step_time_ms_avg: 60610.850
-        last_10_steps_model_tflops_per_gpu_avg: 101.310
+        initial_loss: 13.168150
+        final_loss: 6.523522
+        last_10_steps_step_time_ms_avg: 64786.540
+        last_10_steps_model_tflops_per_gpu_avg: 102.520
       expected_result: >
         The 192-GB200 TP1/PP6/CP1/EP32/ETP1 run completed exactly 100
-        real-data pretraining steps at GBS/MBS 1024/1 with cuDNN DSA, sparse
+        RP2 head_01 pretraining steps at GBS/MBS 1024/1 with cuDNN DSA, sparse
         indexer loss coefficient 0.001, MTP1, and all-to-all expert dispatch.
-        Loss remained finite from 13.19136 to 8.171059, final grad norm was
-        1.394, and every step recorded zero skipped and NaN iterations. The
-        final 10 steps averaged 60,610.850 ms and 101.310 TFLOPS/GPU. Step-50
-        and step-100 checkpoints were written with model, optimizer, scheduler,
-        data-order, and RNG state for resume verification. These losses are not
-        directly comparable with the H100 pretrain result: H100 used Wikitext
-        at sequence length 2,048, while GB200 used Tulu 3 at sequence length
-        4,096.
+        The RP2 Llama SentencePiece tokenizer is used while retaining GLM-5.2's
+        configured vocabulary size, so this is support verification rather
+        than a cross-tokenizer convergence claim. Loss remained finite from
+        13.168150 to 6.523522, final grad norm was 2.775, and every step
+        recorded zero skipped and NaN iterations. The final 10 steps averaged
+        64,786.540 ms and 102.520 TFLOPS/GPU. Step-50 and step-100 checkpoints
+        contain model, optimizer, scheduler, data-order, and RNG state.
 
   sft:
     H100:
@@ -246,7 +253,7 @@ items:
         initial_loss: 1.909875
         final_loss: 0.6634203
         last_10_steps_step_time_ms_avg: 4436.290
-        last_10_steps_model_tflops_per_gpu_avg: 9.450
+        last_10_steps_model_tflops_per_gpu_avg: 10.154
       expected_result: >
         The immutable-revision 416-H100 run completes exactly 100 full-SFT
         steps at TP1/PP13/CP2/EP32/ETP1, GBS/MBS 32/1, with cuDNN DSA, sparse
@@ -258,31 +265,44 @@ items:
     GB200:
       status: verified
       precision: bf16
+      bridge_commit: cc190939aad0e1ee0edfb98c5455ae3fe833140b  # pragma: allowlist secret
       enabled_features:
         sequence_packing: offline
+        context_parallel_size: 4
+        moe_dispatcher: hybridep
       command: >
         ./scripts/training/train.sh --nodes 48 --gpus-per-node 4
         --recipe glm52_sft_192gpu_gb200_bf16_config --mode sft
-        --pretrained_checkpoint work/model-verification/glm5-2/gpu-megatron/iter_0000000
+        --pretrained_checkpoint
+        work/model-verification/glm5-2/hf-4d67f66cc64d3219133b767c253b2ad1425c6c88
         --max_steps 100
         tokenizer.chat_template_path=work/templates/glm52_chat_template_generation.jinja
         --save_dir work/model-verification/glm5-2/sft-gb200-cudnn/checkpoints
         --save_interval 100 logger.log_interval=1 logger.log_throughput=true
         logger.tensorboard_dir=null
-      last_verified: 2026-07-24
+      last_verified: 2026-08-04
       metrics:
-        initial_loss: 1.831100
-        final_loss: 0.5953441
-        last_10_steps_step_time_ms_avg: 68370.590
-        last_10_steps_model_tflops_per_gpu_avg: 9.180
+        initial_loss: 1.704979
+        final_loss: 0.3682597
+        last_10_steps_step_time_ms_avg: 8593.990
+        last_10_steps_model_tflops_per_gpu_avg: 12.446
       expected_result: >
         The immutable-revision 192-GB200 run completed exactly 100 full-SFT
-        steps at TP1/PP6/CP1/EP32/ETP1, GBS/MBS 32/1, with offline-packed
-        Tulu 3 data, cuDNN DSA, sparse indexer loss coefficient 0.001, MTP1,
-        and all-to-all expert dispatch. Loss remained finite from 1.831100 to
-        0.5953441, final grad norm was 0.837, and every step recorded zero
-        skipped and NaN iterations. The step-100 checkpoint was written and is
-        available for a future GB200 export/reload gate.
+        steps at TP1/PP6/CP4/EP32/ETP1, DP8, and GBS/MBS 8/1 without gradient
+        accumulation. It used the pinned Tulu 3 train[:10000] split with the
+        GLM assistant-only chat template, 8,192-token offline packs, pad-8
+        sequence alignment, an 8,184-token single-sequence cap, constant-shape
+        cu_seqlens, cuDNN DSA, sparse indexer loss coefficient 0.001, MTP1,
+        natural routing, and HybridEP. Packing is 99.72% efficient across 421
+        rows with a 23.75 packing factor. The 100-step window contains
+        6,553,600 token slots and 4,283,561 supervised tokens. Metadata and
+        Parquet SHA-256 values are cbd964c686b74f82804ceea2df75bb00fbe28648f0458a641b9db27977a55b1b
+        and b2c6f71a6b5add331750956622073cc8ced0bb6b2742e1d7a0e1a9f763cbaa0c.
+        Loss remained finite from 1.704979 to 0.3682597, final grad norm was
+        0.873, and every step recorded zero skipped and NaN iterations. The
+        final 10 steps averaged 8,593.990 ms and 12.446 TFLOPS/GPU. A complete
+        step-100 distributed checkpoint was written for the future GB200
+        export/reload gate.
 
   sft_export_inference:
     H100:
@@ -342,43 +362,48 @@ items:
         initial_loss: 8.283127
         final_loss: 2.557671
         last_10_steps_step_time_ms_avg: 36603.370
-        last_10_steps_model_tflops_per_gpu_avg: 210.650
+        last_10_steps_model_tflops_per_gpu_avg: 39.648
       expected_result: >
         The 608-H100 TP1/PP19/CP32/EP32/ETP1 run completed exactly 20 optimizer
         steps over 200,000-token packed rows with cuDNN DSA, sparse indexer loss
         coefficient 0.001, and MTP1. Loss remained finite from 8.283127 to
         2.557671, final grad norm was 10838.703, and every step recorded zero
         skipped and NaN iterations. The last 10 steps averaged 36,603.370 ms
-        and 210.650 TFLOPS/GPU; peak observed GPU memory was 81,005 MiB.
+        and 39.648 TFLOPS/GPU; peak observed GPU memory was 81,005 MiB.
     GB200:
       status: verified
       precision: bf16
+      bridge_commit: bdb637740154729a2409645703a0b3c78c38fa8c  # pragma: allowlist secret
       enabled_features:
         sequence_packing: offline
         context_parallel_size: 32
+        moe_dispatcher: hybridep
       command: >
         ./scripts/training/train.sh --nodes 48 --gpus-per-node 4
         --recipe glm52_sft_192gpu_gb200_bf16_128k_config --mode sft
-        --pretrained_checkpoint work/model-verification/glm5-2/gpu-megatron/iter_0000000
-        --max_steps 20 --seq_length 131072 --lr 1e-6 --min_lr 0 --warmup_iters 2
+        --pretrained_checkpoint
+        work/model-verification/glm5-2/hf-4d67f66cc64d3219133b767c253b2ad1425c6c88
+        --max_steps 20
         tokenizer.chat_template_path=work/templates/glm52_chat_template_generation.jinja
-        checkpoint.load=null ddp.check_for_nan_in_grad=true
-        ddp.check_for_large_grads=true rerun_state_machine.check_for_nan_in_loss=true
+        dataset.dataset_root=work/data/glm5-2/synthetic-long-sft-128k
+        dataset.max_train_samples=1120
         logger.log_interval=1 logger.log_throughput=true logger.tensorboard_dir=null
-      last_verified: 2026-07-24
+      last_verified: 2026-08-05
       metrics:
-        initial_loss: 0.3235812
-        final_loss: 0.1924341
-        last_10_steps_step_time_ms_avg: 29269.730
-        last_10_steps_model_tflops_per_gpu_avg: 236.510
+        initial_loss: 0.4159648
+        final_loss: 0.000511673
+        last_10_steps_step_time_ms_avg: 143248.820
+        last_10_steps_model_tflops_per_gpu_avg: 88.848
       expected_result: >
         The immutable-revision 192-GB200 run completed exactly 20 optimizer
-        steps over 131,072-token packed rows at TP1/PP6/CP32/EP32/ETP1,
-        GBS/MBS 8/1, with cuDNN DSA, sparse indexer loss coefficient 0.001,
-        MTP1, padded cu_seqlens, and all-to-all expert dispatch. Loss remained
-        finite from 0.3235812 to 0.1924341, final grad norm was 1448.863, and
-        every step recorded zero skipped and NaN iterations. The final 10 steps
-        averaged 29,269.730 ms and 236.510 TFLOPS/GPU.
+        steps at TP1/PP6/CP32/EP32/ETP1, DP1, and GBS/MBS 56/1 with cuDNN DSA,
+        MTP1, HybridEP, and full activation recompute. The explicit PP6 decoder
+        layout [14, 16, 12, 12, 12, 12] completed without OOM using 32
+        single-sequence, 131,072-token synthetic packs. Loss remained finite
+        from 0.4159648 to 0.000511673 with zero skipped or NaN iterations across
+        146,786,080 supervised tokens. The final 10 steps averaged 143,248.820
+        ms and 88.848 TFLOPS/GPU. This verifies long-context execution only;
+        the 8K pinned-Tulu run provides real-data convergence evidence.
 
   peft:
     H100:
@@ -401,7 +426,7 @@ items:
         initial_loss: 1.909421
         final_loss: 0.8835775
         last_10_steps_step_time_ms_avg: 4638.550
-        last_10_steps_model_tflops_per_gpu_avg: 17.240
+        last_10_steps_model_tflops_per_gpu_avg: 19.423
       expected_result: >
         The immutable-revision 208-H100 run completes exactly 100 LoRA steps at
         TP1/PP13/CP1/EP16/ETP1, GBS/MBS 32/1, with cuDNN DSA, sparse indexer
@@ -429,7 +454,7 @@ items:
         initial_loss: 1.831100
         final_loss: 0.8957523
         last_10_steps_step_time_ms_avg: 68588.270
-        last_10_steps_model_tflops_per_gpu_avg: 9.330
+        last_10_steps_model_tflops_per_gpu_avg: 1.423
       expected_result: >
         The immutable-revision 192-GB200 run completed exactly 100 LoRA steps
         at TP1/PP6/CP1/EP32/ETP1, GBS/MBS 32/1, with offline-packed Tulu 3
@@ -465,7 +490,7 @@ items:
         initial_loss: 7.219822
         final_loss: 6.372624
         last_10_steps_step_time_ms_avg: 32002.290
-        last_10_steps_model_tflops_per_gpu_avg: 49.350
+        last_10_steps_model_tflops_per_gpu_avg: 53.235
       resume_comparison:
         reference_item: pretrain
         sentinel_steps: [51, 100]
@@ -478,31 +503,39 @@ items:
         zero skipped or NaN iterations. Step 51 matches exactly at 7.219822.
         Step 100 is 6.372624 versus the uninterrupted reference's 6.385243, an
         absolute difference of 0.012619 within the allowed 0.063853. Final
-        grad norm is 2.169; the last 10 steps average 32,002.290 ms and 49.350
+        grad norm is 2.169; the last 10 steps average 32,002.290 ms and 53.235
         TFLOPS/GPU. Peak observed allocator memory is 65.230 GiB allocated and
         69.684 GiB reserved.
     GB200:
       status: verified
       precision: bf16
       depends_on: pretrain
+      bridge_commit: e79f756196e0b97ee3ad94263a896c120b32c1e5  # pragma: allowlist secret
       command: >
         ./scripts/training/train.sh --nodes 48 --gpus-per-node 4
         --recipe glm52_pretrain_192gpu_gb200_bf16_config --mode pretrain
         --dataset megatron-indexed --deterministic --seq_length 4096 --max_steps 100
         --lr 3e-4 --min_lr 3e-5 --warmup_iters 40
-        'dataset.blend=[["work/data/glm5-2/pretrain-tulu3-text-document/tulu3_glm52_text_document_text_document"],null]'
-        dataset.path_to_cache=work/cache/glm5-2/pretrain-tulu3-gb200
-        dataset.random_seed=1234 rng.seed=1234 scheduler.lr_decay_iters=100
-        --load_dir work/model-verification/glm5-2/pretrain-gb200-cudnn/checkpoints
-        --save_dir work/model-verification/glm5-2/pretrain-resume-gb200-cudnn/checkpoints
-        --save_interval 0 checkpoint.ckpt_step=50
+        'dataset.blend=[["work/data/rp2/head_01_text_document"],null]'
+        dataset.path_to_cache=work/cache/glm5-2/rp2-head-01-gb200
+        dataset.random_seed=1234 dataset.num_workers=8
+        tokenizer.tokenizer_type=SentencePieceTokenizer
+        tokenizer.tokenizer_model=work/data/rp2/tokenizer/tokenizer.model
+        tokenizer.use_tokenizer_vocab_size=false rng.seed=1234
+        scheduler.lr_decay_iters=100 model.moe_router_force_load_balancing=false
+        checkpoint.ckpt_step=50
+        checkpoint.save_optim=true checkpoint.save_rng=true
+        checkpoint.load_optim=true checkpoint.load_rng=true checkpoint.finetune=false
+        --load_dir work/model-verification/glm5-2/pretrain-rp2-gb200/checkpoints
+        --save_dir work/model-verification/glm5-2/pretrain-rp2-resume-gb200/checkpoints
+        --save_interval 0
         logger.log_interval=1 logger.log_throughput=true logger.tensorboard_dir=null
-      last_verified: 2026-07-24
+      last_verified: 2026-08-04
       metrics:
-        initial_loss: 8.581669
-        final_loss: 8.192354
-        last_10_steps_step_time_ms_avg: 67700.250
-        last_10_steps_model_tflops_per_gpu_avg: 90.710
+        initial_loss: 7.233636
+        final_loss: 6.503141
+        last_10_steps_step_time_ms_avg: 60079.390
+        last_10_steps_model_tflops_per_gpu_avg: 110.552
       resume_comparison:
         reference_item: pretrain
         sentinel_steps: [51, 100]
@@ -510,10 +543,11 @@ items:
         loss_absolute_tolerance: 1.0e-6
         sentinels_match: true
       expected_result: >
-        The run reloads the GB200 reference's step-50 model, optimizer,
+        The run reloads the RP2 reference's step-50 model, optimizer,
         scheduler, data-order, and RNG state and completes steps 51-100 with
-        zero skipped or NaN iterations. Step 51 matches exactly at 8.581669.
-        Step 100 is 8.192354 versus the uninterrupted reference's 8.171059, an
-        absolute difference of 0.021295 within the allowed 0.081712. Final grad
-        norm is 1.840; the last 10 steps average 67,700.250 ms and 90.710
+        zero skipped or NaN iterations. Step 51 is 7.233636 versus 7.233639 in
+        the uninterrupted reference, a relative difference of 4.1e-7. Step
+        100 is 6.503141 versus 6.523522, a relative difference of 0.003124;
+        both satisfy the 1e-6 absolute plus 1% relative tolerance. Final grad
+        norm is 1.690; the last 10 steps average 60,079.390 ms and 110.552
         TFLOPS/GPU.

--- a/src/megatron/bridge/data/builders/gpt_sft.py
+++ b/src/megatron/bridge/data/builders/gpt_sft.py
@@ -91,6 +91,11 @@ def _packing_fingerprint(config: "GPTSFTDatasetConfig", dataset_kwargs: dict[str
         "preprocessing": asdict(preprocessing),
         "dataset_kwargs": dataset_kwargs,
     }
+    if (
+        config.offline_packing_specs is not None
+        and config.offline_packing_specs.max_single_sequence_length is not None
+    ):
+        packing_identity["max_single_sequence_length"] = config.offline_packing_specs.max_single_sequence_length
     return hashlib.sha256(
         json.dumps(packing_identity, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
     ).hexdigest()[:12]
@@ -560,6 +565,9 @@ class GPTSFTDatasetBuilder:
         self.packed_sequence_size = (
             -1 if config.offline_packing_specs is None else config.offline_packing_specs.packed_sequence_size
         )
+        self._max_single_sequence_length = (
+            None if config.offline_packing_specs is None else config.offline_packing_specs.max_single_sequence_length
+        )
         self.dataset_kwargs = normalize_gpt_sft_dataset_kwargs(config)
         self._pad_cu_seqlens = (
             False if config.offline_packing_specs is None else config.offline_packing_specs.pad_cu_seqlens
@@ -662,7 +670,7 @@ class GPTSFTDatasetBuilder:
             output_metadata_path=self.pack_metadata,
             packed_sequence_size=self.packed_sequence_size,
             tokenizer=self.tokenizer,
-            max_seq_length=self.seq_length,
+            max_seq_length=self._max_single_sequence_length or self.seq_length,
             seed=self.seed,
             dataset_kwargs=self.dataset_kwargs,
             pad_seq_to_mult=self._pad_seq_to_mult,

--- a/src/megatron/bridge/data/packing/config.py
+++ b/src/megatron/bridge/data/packing/config.py
@@ -28,6 +28,7 @@ class PackedSequenceSpecs:
     """Settings and optional artifact paths for offline sequence packing."""
 
     packed_sequence_size: int = -1
+    max_single_sequence_length: int | None = None
     tokenizer_model_name: str | None = None
     num_tokenizer_workers: int = -1
     packed_train_data_path: str | Path | None = None
@@ -44,6 +45,11 @@ class PackedSequenceSpecs:
             self._validate_packed_path("packed_val_data_path", self.packed_val_data_path)
         if self.pad_seq_to_mult is not None and self.pad_seq_to_mult <= 0:
             raise ValueError("pad_seq_to_mult must be a positive integer when provided.")
+        if self.max_single_sequence_length is not None:
+            if self.max_single_sequence_length <= 0:
+                raise ValueError("max_single_sequence_length must be a positive integer when provided.")
+            if self.packed_sequence_size > 0 and self.max_single_sequence_length > self.packed_sequence_size:
+                raise ValueError("max_single_sequence_length cannot exceed packed_sequence_size.")
 
     def _validate_packed_path(self, attr_name: str, path_value: str | Path) -> None:
         """Validate an explicitly supplied packed artifact path."""

--- a/src/megatron/bridge/data/packing/config.py
+++ b/src/megatron/bridge/data/packing/config.py
@@ -35,6 +35,7 @@ class PackedSequenceSpecs:
     packed_val_data_path: str | Path | None = None
     packed_metadata_path: str | Path | None = None
     pad_cu_seqlens: bool = False
+    """Pad cumulative sequence boundaries for full-iteration, whole-layer, or attention-scoped CUDA graphs."""
     pad_seq_to_mult: int | None = 1
 
     def __post_init__(self) -> None:

--- a/src/megatron/bridge/data/packing/gpt_sft.py
+++ b/src/megatron/bridge/data/packing/gpt_sft.py
@@ -61,8 +61,9 @@ class GPTSFTPackedDataset(GPTSFTDataset):
         return_cu_seqlen: Whether to return `cu_seqlen` to pass to the model. Having `cu_seqlen` in the model input
                 enables THD attention kernel, which is the correct format for training with packed sequence to prevent
                 cross-sequence attention. This flag should be True unless you have a specific use case.
-        pad_seq_to_mult: The multiple used for padding sequences during packing. When > 1, cu_seqlens_unpadded
-                will be computed to support THD CP. When == 1 (no padding), cu_seqlens_unpadded is not computed.
+        pad_seq_to_mult: The multiple used for padding sequences during packing. When > 1, both logical and
+                physically padded cumulative sequence offsets are returned for THD CP.
+        pack_metadata_file_path: Path to the metadata JSON file used to stabilize cu_seqlens shapes.
         """
         np.random.seed(kwargs.get("seed", 1234))
         super().__init__(file_path, tokenizer, **kwargs)
@@ -161,8 +162,8 @@ class GPTSFTPackedDataset(GPTSFTDataset):
 
         Returns:
             dict: A dictionary of batched tensors, including 'tokens', 'labels',
-                  'loss_mask', 'position_ids', and potentially 'cu_seqlens',
-                  'cu_seqlens_argmin', 'max_seqlen' if `return_cu_seqlen` is True.
+                  'loss_mask', 'position_ids', and the MCore/TE packed-sequence
+                  fields if `return_cu_seqlen` is True.
         """
         input_ids = [
             np.concatenate(
@@ -198,49 +199,60 @@ class GPTSFTPackedDataset(GPTSFTDataset):
         assert max_length <= self.max_seq_length
 
         position_ids: list[list[int]] = []
+        # TE naming: cu_seqlens contains logical offsets, while cu_seqlens_padded
+        # contains physical offsets including per-sequence alignment padding.
         cu_seqlens: list[list[int]] = []
-        # Only compute cu_seqlens_unpadded when pad_seq_to_mult > 1 (actual padding for CP)
-        cu_seqlens_unpadded: list[list[int]] | None = [] if self._pad_seq_to_mult > 1 else None
+        cu_seqlens_padded: list[list[int]] | None = [] if self._pad_seq_to_mult > 1 else None
         for item in batch:
             position_ids.append([])
             cu_seqlens.append([0])
-            if cu_seqlens_unpadded is not None:
-                cu_seqlens_unpadded.append([0])
+            if cu_seqlens_padded is not None:
+                cu_seqlens_padded.append([0])
             seqlens = np.array(item["seq_boundaries"][1:]) - np.array(item["seq_boundaries"][:-1])
             for length in seqlens:
                 # length minus 1 because input_ids is truncated by 1 for labels
                 position_ids[-1].extend(list(range(length - 1)))
-                cu_seqlens[-1].append(cu_seqlens[-1][-1] + length - 1)
+                if cu_seqlens_padded is not None:
+                    cu_seqlens_padded[-1].append(cu_seqlens_padded[-1][-1] + length - 1)
+                else:
+                    cu_seqlens[-1].append(cu_seqlens[-1][-1] + length - 1)
 
             # the last seq needs to be the max seq len because rope and attn kernels expect no padding
-            assert cu_seqlens[-1][-1] <= max_length
-
-            # since data is prepadded when cp_size > 1, there may be some extra padding at the end
-            # of the packed sequence. In this case, we need to add the max seq len to the end.
-            if cu_seqlens[-1][-1] != max_length:
-                cu_seqlens[-1].append(max_length)
-
-            if cu_seqlens_unpadded is not None:
+            if cu_seqlens_padded is not None:
+                assert cu_seqlens_padded[-1][-1] <= max_length
+                if cu_seqlens_padded[-1][-1] != max_length:
+                    cu_seqlens_padded[-1].append(max_length)
                 for i in range(len(item["seq_boundaries"]) - 1):
                     current_seq = item["input_ids"][item["seq_boundaries"][i] : item["seq_boundaries"][i + 1] - 1]
 
-                    # Stop unpadded lengths at the last non-eos token so padding eos are excluded.
+                    # Stop logical lengths at the last non-EOS token so alignment padding is excluded.
                     current_seq_arr = np.array(current_seq)
                     non_eos_positions = np.where(current_seq_arr != self.tokenizer.eos_id)[0]
-                    seqlen_unpadded = non_eos_positions[-1] + 1 if non_eos_positions.size > 0 else 0
-                    cu_seqlens_unpadded[-1].append(cu_seqlens_unpadded[-1][-1] + seqlen_unpadded)
+                    logical_seqlen = non_eos_positions[-1] + 1 if non_eos_positions.size > 0 else 0
+                    cu_seqlens[-1].append(cu_seqlens[-1][-1] + logical_seqlen)
 
                 # if extra paddings are added in the packed sequence, they can't be counted as
                 # actual tokens for training
-                if len(cu_seqlens[-1]) > len(cu_seqlens_unpadded[-1]):
-                    cu_seqlens_unpadded[-1].append(cu_seqlens_unpadded[-1][-1])
+                if len(cu_seqlens_padded[-1]) > len(cu_seqlens[-1]):
+                    cu_seqlens[-1].append(cu_seqlens[-1][-1])
+            else:
+                assert cu_seqlens[-1][-1] <= max_length
+                # Prepadded data may leave padding at the end of the packed sequence.
+                if cu_seqlens[-1][-1] != max_length:
+                    cu_seqlens[-1].append(max_length)
 
             if self.pad_cu_seqlens:
-                # pad cu_seqlens to a constant shape with zero length sequences
+                # Pad both boundary representations to the same static shape with zero-length
+                # sequences. TE expects corresponding logical and physical boundary arrays.
                 max_samples_per_bin = max(p["max_samples_per_bin"] for p in self.pack_metadata)
                 # plus 2 since cu_seqlens additionally contains 0 and may append max_length
-                pad_num = max_samples_per_bin - len(cu_seqlens[-1]) + 2
-                cu_seqlens[-1].extend([max_length] * pad_num)
+                if cu_seqlens_padded is not None:
+                    pad_num = max_samples_per_bin - len(cu_seqlens_padded[-1]) + 2
+                    cu_seqlens_padded[-1].extend([max_length] * pad_num)
+                    cu_seqlens[-1].extend([cu_seqlens[-1][-1]] * pad_num)
+                else:
+                    pad_num = max_samples_per_bin - len(cu_seqlens[-1]) + 2
+                    cu_seqlens[-1].extend([max_length] * pad_num)
 
         assert len(input_ids[0]) == len(position_ids[0]), (
             "Dataset problem: input_ids and position_ids lengths don't match"
@@ -263,13 +275,10 @@ class GPTSFTPackedDataset(GPTSFTDataset):
         }
 
         if self.return_cu_seqlen:
-            cu_seqlens = self._collate_item(
-                cu_seqlens, max_length=max(len(length) for length in cu_seqlens) + 1, pad_id=-1
-            )
-            # Pre-generate `cu_seqlens_argmin` and `max_seqlen` as CPU tensor to avoid device-to-host copies.
-            cu_seqlens = torch.IntTensor(cu_seqlens)
-            cu_seqlens_argmin = torch.argmin(cu_seqlens, dim=1, keepdim=True)
-            seqlens = cu_seqlens[:, 1:] - cu_seqlens[:, :-1]
+            # Offline packed SFT requires micro-batch size 1, so no sentinel padding is
+            # needed to batch variable-length metadata. Emit MCore/TE field names directly.
+            seqlens = torch.IntTensor(cu_seqlens_padded if cu_seqlens_padded is not None else cu_seqlens)
+            seqlens = seqlens[:, 1:] - seqlens[:, :-1]
             max_seqlen, _ = seqlens.max(dim=1, keepdim=True)
 
             if self.pad_cu_seqlens:
@@ -284,25 +293,19 @@ class GPTSFTPackedDataset(GPTSFTDataset):
                 safe_max_seqlen = max(dataset_max_seqlen, padding_gap)
                 max_seqlen = torch.IntTensor([safe_max_seqlen] * len(cu_seqlens))
             else:
-                seqlens = cu_seqlens[:, 1:] - cu_seqlens[:, :-1]
                 max_seqlen, _ = seqlens.max(dim=1, keepdim=True)
 
             cu_seqlens_batch = {
                 "attention_mask": None,  # no attention mask is needed for packed seq
-                "cu_seqlens": torch.IntTensor(cu_seqlens),  # cu_seqlens_q must be in dtype torch.int32
-                "cu_seqlens_argmin": cu_seqlens_argmin,  # only required for perf
-                "max_seqlen": max_seqlen,  # only required for perf
+                "cu_seqlens_q": torch.IntTensor(cu_seqlens),
+                "max_seqlen_q": max_seqlen,
+                "max_seqlen_kv": max_seqlen,
             }
+            cu_seqlens_batch["cu_seqlens_kv"] = cu_seqlens_batch["cu_seqlens_q"]
 
-            # Only include cu_seqlens_unpadded when pad_seq_to_mult > 1 (actual CP padding)
-            if cu_seqlens_unpadded is not None:
-                cu_seqlens_unpadded = self._collate_item(
-                    cu_seqlens_unpadded, max_length=max(len(length) for length in cu_seqlens_unpadded) + 1, pad_id=-1
-                )
-                cu_seqlens_unpadded = torch.IntTensor(cu_seqlens_unpadded)
-                cu_seqlens_unpadded_argmin = torch.argmin(cu_seqlens_unpadded, dim=1, keepdim=True)
-                cu_seqlens_batch["cu_seqlens_unpadded"] = cu_seqlens_unpadded
-                cu_seqlens_batch["cu_seqlens_unpadded_argmin"] = cu_seqlens_unpadded_argmin
+            if cu_seqlens_padded is not None:
+                cu_seqlens_batch["cu_seqlens_q_padded"] = torch.IntTensor(cu_seqlens_padded)
+                cu_seqlens_batch["cu_seqlens_kv_padded"] = cu_seqlens_batch["cu_seqlens_q_padded"]
 
             processed_batch.update(cu_seqlens_batch)
         else:

--- a/src/megatron/bridge/recipes/glm/gb200/glm5.py
+++ b/src/megatron/bridge/recipes/glm/gb200/glm5.py
@@ -184,7 +184,7 @@ def glm52_sft_192gpu_gb200_bf16_config() -> ConfigContainer:
     cfg.dataset.do_validation = False
     cfg.dataset.do_test = False
     cfg.dataset.offline_packing_specs.max_single_sequence_length = cfg.model.seq_length - packing_alignment
-    cfg.dataset.offline_packing_specs.pad_cu_seqlens = True
+    # HybridEP needs a fixed token width; CUDA graphs are disabled, so cu_seqlens can remain dynamic.
     cfg.dataset.dataset_kwargs = {"pad_to_max_length": True}
 
     cfg.rng.seed = 5678
@@ -292,7 +292,7 @@ def glm52_sft_192gpu_gb200_bf16_128k_config() -> ConfigContainer:
     cfg.dataset.do_validation = False
     cfg.dataset.do_test = False
     cfg.dataset.offline_packing_specs.tokenizer_model_name = "glm5"
-    cfg.dataset.offline_packing_specs.pad_cu_seqlens = True
+    # HybridEP needs a fixed token width; CUDA graphs are disabled, so cu_seqlens can remain dynamic.
     cfg.dataset.dataset_kwargs = {"pad_to_max_length": True}
 
     cfg.rng.seed = 5678

--- a/src/megatron/bridge/recipes/glm/gb200/glm5.py
+++ b/src/megatron/bridge/recipes/glm/gb200/glm5.py
@@ -29,6 +29,7 @@ from megatron.bridge.training.mixed_precision import bf16_mixed
 _GLM52_MODEL_ID = "zai-org/GLM-5.2"
 _GLM52_MODEL_REVISION = "4d67f66cc64d3219133b767c253b2ad1425c6c88"  # pragma: allowlist secret
 _TULU3_REVISION = "b14afda60f1bbebe55d5d2fa1e4df5042f97f8be"  # pragma: allowlist secret
+_GLM52_PP6_128K_LAYOUT = "|".join(("E" + "t" * 14, "t" * 16, "t" * 12, "t" * 12, "t" * 12, "t" * 12 + "mL"))
 
 
 def glm52_pretrain_192gpu_gb200_bf16_config() -> ConfigContainer:
@@ -118,13 +119,12 @@ def glm52_sft_192gpu_gb200_bf16_config() -> ConfigContainer:
     )
     cfg.tokenizer.tokenizer_model = _GLM52_MODEL_ID
     cfg.tokenizer.hf_tokenizer_kwargs = {"revision": _GLM52_MODEL_REVISION}
-
-    cfg.model.seq_length = 2048
+    cfg.model.seq_length = 8192
     cfg.model.tensor_model_parallel_size = 1
     cfg.model.pipeline_model_parallel_size = 6
     cfg.model.virtual_pipeline_model_parallel_size = None
     cfg.model.pipeline_model_parallel_layout = None
-    cfg.model.context_parallel_size = 1
+    cfg.model.context_parallel_size = 4
     cfg.model.expert_model_parallel_size = 32
     cfg.model.expert_tensor_parallel_size = 1
     cfg.model.sequence_parallel = False
@@ -140,10 +140,13 @@ def glm52_sft_192gpu_gb200_bf16_config() -> ConfigContainer:
     cfg.model.cross_entropy_loss_fusion = False
     cfg.model.cross_entropy_fusion_impl = "native"
     cfg.model.gradient_accumulation_fusion = True
-    cfg.model.moe_token_dispatcher_type = "alltoall"
-    cfg.model.moe_flex_dispatcher_backend = None
+    cfg.model.moe_token_dispatcher_type = "flex"
+    cfg.model.moe_flex_dispatcher_backend = "hybridep"
     cfg.model.moe_shared_expert_overlap = False
     cfg.model.moe_router_force_load_balancing = False
+    cfg.model.moe_permute_fusion = True
+    cfg.model.moe_grouped_gemm = True
+    cfg.model.deallocate_pipeline_outputs = True
     cfg.model.persist_layer_norm = True
     cfg.model.bias_dropout_fusion = True
     cfg.model.bias_activation_fusion = True
@@ -165,24 +168,28 @@ def glm52_sft_192gpu_gb200_bf16_config() -> ConfigContainer:
     cfg.validation.eval_interval = 0
     cfg.logger.log_interval = 1
 
+    packing_alignment = 2 * cfg.model.context_parallel_size
     cfg.dataset = default_tulu3_config(
-        seq_length=2048,
+        seq_length=cfg.model.seq_length,
         enable_offline_packing=True,
-        pad_seq_to_mult=32,
+        pad_seq_to_mult=packing_alignment,
     )
     cfg.dataset.hf_dataset.split = "train[:10000]"
     cfg.dataset.hf_dataset.load_kwargs = {"revision": _TULU3_REVISION}
-    cfg.dataset.hf_output_root = "work/data/glm5-2/tulu3-full-sft-gb200"
+    cfg.dataset.hf_output_root = "work/data/glm5-2/tulu3-full-sft-gb200-8k-v5"
     cfg.dataset.hf_rewrite = False
     cfg.dataset.hf_validation_proportion = None
     cfg.dataset.max_train_samples = 10000
     cfg.dataset.seed = 1234
     cfg.dataset.do_validation = False
     cfg.dataset.do_test = False
+    cfg.dataset.offline_packing_specs.max_single_sequence_length = cfg.model.seq_length - packing_alignment
+    cfg.dataset.offline_packing_specs.pad_cu_seqlens = True
+    cfg.dataset.dataset_kwargs = {"pad_to_max_length": True}
 
     cfg.rng.seed = 5678
     cfg.train.train_iters = 100
-    cfg.train.global_batch_size = 32
+    cfg.train.global_batch_size = 8
     cfg.optimizer, cfg.scheduler = distributed_fused_adam_with_cosine_annealing(
         lr_warmup_iters=10,
         max_lr=5e-6,
@@ -193,7 +200,19 @@ def glm52_sft_192gpu_gb200_bf16_config() -> ConfigContainer:
     cfg.checkpoint.load = None
     cfg.checkpoint.save_optim = False
     cfg.checkpoint.save_rng = False
-    cfg.env_vars = {**COMMON_RECIPE_ENV_VARS}
+    cfg.env_vars = {
+        **COMMON_RECIPE_ENV_VARS,
+        "CUDA_DEVICE_MAX_CONNECTIONS": 32,
+        "NCCL_GRAPH_REGISTER": 0,
+        "NCCL_NVLS_ENABLE": 0,
+        "NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN": 32,
+        "NUM_OF_TOKENS_PER_CHUNK_COMBINE_API": 128,
+        "NVLINK_DOMAIN_SIZE": 72,
+        "NVTE_BWD_LAYERNORM_SM_MARGIN": 20,
+        "NVTE_FWD_LAYERNORM_SM_MARGIN": 20,
+        "TORCH_NCCL_AVOID_RECORD_STREAMS": 1,
+        "USE_MNNVL": 1,
+    }
     return cfg
 
 
@@ -206,18 +225,17 @@ def glm52_sft_192gpu_gb200_bf16_128k_config() -> ConfigContainer:
     )
     cfg.tokenizer.tokenizer_model = _GLM52_MODEL_ID
     cfg.tokenizer.hf_tokenizer_kwargs = {"revision": _GLM52_MODEL_REVISION}
-
     cfg.model.seq_length = 131072
     cfg.model.tensor_model_parallel_size = 1
     cfg.model.pipeline_model_parallel_size = 6
     cfg.model.virtual_pipeline_model_parallel_size = None
-    cfg.model.pipeline_model_parallel_layout = None
+    cfg.model.pipeline_model_parallel_layout = _GLM52_PP6_128K_LAYOUT
     cfg.model.context_parallel_size = 32
     cfg.model.expert_model_parallel_size = 32
     cfg.model.expert_tensor_parallel_size = 1
     cfg.model.sequence_parallel = False
-    cfg.model.num_layers_in_first_pipeline_stage = 14
-    cfg.model.num_layers_in_last_pipeline_stage = 16
+    cfg.model.num_layers_in_first_pipeline_stage = None
+    cfg.model.num_layers_in_last_pipeline_stage = None
     cfg.model.account_for_embedding_in_pipeline_split = False
     cfg.model.account_for_loss_in_pipeline_split = False
     cfg.model.microbatch_group_size_per_vp_stage = None
@@ -232,6 +250,9 @@ def glm52_sft_192gpu_gb200_bf16_128k_config() -> ConfigContainer:
     cfg.model.moe_flex_dispatcher_backend = "hybridep"
     cfg.model.moe_shared_expert_overlap = False
     cfg.model.moe_router_force_load_balancing = False
+    cfg.model.moe_permute_fusion = True
+    cfg.model.moe_grouped_gemm = True
+    cfg.model.deallocate_pipeline_outputs = True
     cfg.model.persist_layer_norm = True
     cfg.model.bias_dropout_fusion = True
     cfg.model.bias_activation_fusion = True
@@ -250,23 +271,27 @@ def glm52_sft_192gpu_gb200_bf16_128k_config() -> ConfigContainer:
     cfg.train.manual_gc = True
     cfg.train.manual_gc_interval = 10
     cfg.train.train_iters = 20
-    cfg.train.global_batch_size = 8
+    cfg.train.global_batch_size = 56
     cfg.validation.eval_iters = 0
     cfg.validation.eval_interval = 0
     cfg.logger.log_interval = 1
 
-    cfg.dataset.seq_length = 131072
+    cfg.dataset = default_tulu3_config(
+        seq_length=131072,
+        enable_offline_packing=True,
+        pad_seq_to_mult=64,
+    )
     cfg.dataset.hf_dataset = None
-    cfg.dataset.dataset_root = "work/data/glm5-2/synthetic-long-context-gb200"
+    cfg.dataset.dataset_root = "work/data/glm5-2/synthetic-long-sft-128k"
     cfg.dataset.hf_output_root = None
+    cfg.dataset.hf_rewrite = False
     cfg.dataset.hf_validation_proportion = None
+    cfg.dataset.max_train_samples = 1120
     cfg.dataset.seed = 1234
     cfg.dataset.preprocessing = ChatSFTPreprocessingConfig()
     cfg.dataset.do_validation = False
     cfg.dataset.do_test = False
-    cfg.dataset.offline_packing_specs.packed_sequence_size = 131072
     cfg.dataset.offline_packing_specs.tokenizer_model_name = "glm5"
-    cfg.dataset.offline_packing_specs.pad_seq_to_mult = 64
     cfg.dataset.offline_packing_specs.pad_cu_seqlens = True
     cfg.dataset.dataset_kwargs = {"pad_to_max_length": True}
 
@@ -281,9 +306,15 @@ def glm52_sft_192gpu_gb200_bf16_128k_config() -> ConfigContainer:
     cfg.checkpoint.load = None
     cfg.env_vars = {
         **COMMON_RECIPE_ENV_VARS,
+        "CUDA_DEVICE_MAX_CONNECTIONS": 32,
+        "NCCL_GRAPH_REGISTER": 0,
+        "NCCL_NVLS_ENABLE": 0,
         "NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN": 32,
         "NUM_OF_TOKENS_PER_CHUNK_COMBINE_API": 128,
         "NVLINK_DOMAIN_SIZE": 72,
+        "NVTE_BWD_LAYERNORM_SM_MARGIN": 20,
+        "NVTE_FWD_LAYERNORM_SM_MARGIN": 20,
+        "TORCH_NCCL_AVOID_RECORD_STREAMS": 1,
         "USE_MNNVL": 1,
     }
     return cfg
@@ -298,7 +329,6 @@ def glm52_peft_192gpu_gb200_bf16_config(peft_scheme: str | PEFT = "lora") -> Con
     )
     cfg.tokenizer.tokenizer_model = _GLM52_MODEL_ID
     cfg.tokenizer.hf_tokenizer_kwargs = {"revision": _GLM52_MODEL_REVISION}
-
     cfg.model.seq_length = 2048
     cfg.model.tensor_model_parallel_size = 1
     cfg.model.pipeline_model_parallel_size = 6

--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -79,6 +79,7 @@ from megatron.bridge.utils.common_utils import (
     warn_rank_0,
 )
 from megatron.bridge.utils.cuda_graph import (
+    cuda_graph_module_names,
     is_full_iteration_cuda_graph,
     validate_cuda_graph_configuration,
 )
@@ -1155,6 +1156,34 @@ class ConfigContainer(Container):
             raise ValueError("offline_packing_specs must be set when enable_offline_packing=True.")
         if offline_packing_specs is not None and not enable_offline_packing:
             raise ValueError("enable_offline_packing must be True when offline_packing_specs is set.")
+
+        if offline_packing_specs is not None:
+            pad_cu_seqlens = offline_packing_specs.pad_cu_seqlens
+            dataset_kwargs = getattr(self.dataset, "dataset_kwargs", None) or {}
+            pad_to_max_length = (
+                getattr(self.dataset, "pad_to_max_length", False) is True
+                or dataset_kwargs.get("pad_to_max_length", False) is True
+            )
+            if pad_cu_seqlens and not pad_to_max_length:
+                raise ValueError("offline_packing_specs.pad_cu_seqlens=True requires dataset pad_to_max_length=True.")
+
+            cuda_graph_impl = getattr(self.model, "cuda_graph_impl", "none")
+            cuda_graph_modules = cuda_graph_module_names(self.model)
+            is_full_iteration_graph = is_full_iteration_cuda_graph(self.model)
+            # Every training graph needs a static token width. Only graphs that include
+            # packed attention also consume cu_seqlens and require static boundary shapes.
+            uses_training_cuda_graphs = is_full_iteration_graph or cuda_graph_impl == "transformer_engine"
+            if uses_training_cuda_graphs and not pad_to_max_length:
+                raise ValueError("Offline packing with CUDA graphs requires dataset pad_to_max_length=True.")
+
+            captures_packed_attention = is_full_iteration_graph or (
+                cuda_graph_impl == "transformer_engine" and (not cuda_graph_modules or "attn" in cuda_graph_modules)
+            )
+            if captures_packed_attention and not pad_cu_seqlens:
+                raise ValueError(
+                    "Packed attention CUDA graphs require offline_packing_specs.pad_cu_seqlens=True. "
+                    "Enable it for full-iteration, whole-layer, or attention-scoped capture."
+                )
 
         # Validate declarative SFT values before deriving runtime padding
         # multiples so normalization cannot hide an invalid user value.

--- a/src/megatron/bridge/training/utils/packed_seq_utils.py
+++ b/src/megatron/bridge/training/utils/packed_seq_utils.py
@@ -232,6 +232,18 @@ def _squeeze_metadata(value: PackedMetadataValue) -> PackedMetadataValue:
     return value.squeeze()
 
 
+def _as_python_int(value: PackedMetadataValue, *, field_name: str) -> int | None:
+    """Normalize scalar packed-sequence metadata to MCore's integer contract."""
+    value = _squeeze_metadata(value)
+    if value is None:
+        return None
+    if isinstance(value, torch.Tensor):
+        if value.numel() != 1:
+            raise ValueError(f"{field_name} must contain exactly one value, got shape {tuple(value.shape)}")
+        return int(value.item())
+    return int(value)
+
+
 def get_packed_seq_params(batch: dict[str, PackedMetadataValue]) -> PackedSeqParams:
     """Build packed sequence parameters from a batch dictionary.
 
@@ -254,8 +266,8 @@ def get_packed_seq_params(batch: dict[str, PackedMetadataValue]) -> PackedSeqPar
     if "cu_seqlens_q" in batch:
         cu_seqlens_q = _squeeze_metadata(batch["cu_seqlens_q"])
         cu_seqlens_kv = _squeeze_metadata(batch.get("cu_seqlens_kv"))
-        max_seqlen_q = _squeeze_metadata(batch.get("max_seqlen_q"))
-        max_seqlen_kv = _squeeze_metadata(batch.get("max_seqlen_kv"))
+        max_seqlen_q = _as_python_int(batch.get("max_seqlen_q"), field_name="max_seqlen_q")
+        max_seqlen_kv = _as_python_int(batch.get("max_seqlen_kv"), field_name="max_seqlen_kv")
         return PackedSeqParams(
             cu_seqlens_q=cu_seqlens_q,
             cu_seqlens_kv=cu_seqlens_kv if cu_seqlens_kv is not None else cu_seqlens_q,
@@ -296,7 +308,7 @@ def get_packed_seq_params(batch: dict[str, PackedMetadataValue]) -> PackedSeqPar
         else:
             cu_seqlens_unpadded = cu_seqlens_unpadded[: torch.argmin(cu_seqlens_unpadded)]
 
-    max_seqlen = batch["max_seqlen"].squeeze() if "max_seqlen" in batch else None
+    max_seqlen = _as_python_int(batch.get("max_seqlen"), field_name="max_seqlen")
     total_tokens = batch.get("total_tokens")
 
     # When cu_seqlens_unpadded is present (pad_seq_to_mult > 1), pass both unpadded and padded

--- a/tests/unit_tests/data/builders/test_gpt_sft_builder.py
+++ b/tests/unit_tests/data/builders/test_gpt_sft_builder.py
@@ -84,6 +84,27 @@ def test_default_pack_path_fingerprints_preprocessing(tmp_path):
     assert prompt_builder.default_pack_path != chat_builder.default_pack_path
 
 
+def test_default_pack_path_fingerprints_max_single_sequence_length(tmp_path):
+    """Different single-sequence caps must not reuse the same packed artifact."""
+
+    def build(max_single_sequence_length: int) -> GPTSFTDatasetBuilder:
+        return GPTSFTDatasetBuilder(
+            config=GPTSFTDatasetConfig(
+                dataset_root=tmp_path,
+                seq_length=128,
+                enable_offline_packing=True,
+                offline_packing_specs=PackedSequenceSpecs(
+                    packed_sequence_size=128,
+                    max_single_sequence_length=max_single_sequence_length,
+                    tokenizer_model_name="mock-tokenizer",
+                ),
+            ),
+            tokenizer=MagicMock(),
+        )
+
+    assert build(120).default_pack_path != build(112).default_pack_path
+
+
 def test_default_pack_path_is_stable_for_equivalent_non_hf_tokenizers(tmp_path):
     def build() -> GPTSFTDatasetBuilder:
         tokenizer = build_tokenizer(TokenizerConfig(tokenizer_type="NullTokenizer", vocab_size=128))

--- a/tests/unit_tests/data/builders/test_gpt_sft_config.py
+++ b/tests/unit_tests/data/builders/test_gpt_sft_config.py
@@ -47,7 +47,11 @@ def _hf_config(tmp_path, **source_overrides):
 
 
 def test_config_round_trip_is_declarative_and_serializable(tmp_path):
-    specs = PackedSequenceSpecs(packed_sequence_size=128, pad_seq_to_mult=8)
+    specs = PackedSequenceSpecs(
+        packed_sequence_size=128,
+        max_single_sequence_length=120,
+        pad_seq_to_mult=8,
+    )
     config = GPTSFTDatasetConfig(
         seq_length=128,
         hf_dataset=HFDatasetSourceConfig(dataset_name="squad"),
@@ -67,8 +71,19 @@ def test_config_round_trip_is_declarative_and_serializable(tmp_path):
     assert isinstance(restored.hf_dataset, HFDatasetSourceConfig)
     assert restored.hf_dataset.dataset_name == "squad"
     assert restored.offline_packing_specs.packed_sequence_size == 128
+    assert restored.offline_packing_specs.max_single_sequence_length == 120
     assert isinstance(restored.preprocessing, PromptCompletionSFTPreprocessingConfig)
     assert "tokenizer" not in serialized
+
+
+@pytest.mark.parametrize("max_single_sequence_length", [0, 129])
+def test_packed_specs_reject_invalid_max_single_sequence_length(max_single_sequence_length):
+    """The per-sequence cap must be positive and fit within the pack."""
+    with pytest.raises(ValueError, match="max_single_sequence_length"):
+        PackedSequenceSpecs(
+            packed_sequence_size=128,
+            max_single_sequence_length=max_single_sequence_length,
+        )
 
 
 @pytest.mark.parametrize(
@@ -556,7 +571,11 @@ def test_builder_owns_runtime_materialization_and_shared_construction(monkeypatc
 
 
 def test_hf_rewrite_regenerates_existing_builder_managed_packed_data(monkeypatch, tmp_path):
-    specs = PackedSequenceSpecs(packed_sequence_size=128, tokenizer_model_name="test-tokenizer")
+    specs = PackedSequenceSpecs(
+        packed_sequence_size=128,
+        max_single_sequence_length=120,
+        tokenizer_model_name="test-tokenizer",
+    )
     config = GPTSFTDatasetConfig(
         seq_length=128,
         hf_dataset=HFDatasetSourceConfig(dataset_name="squad"),
@@ -582,6 +601,7 @@ def test_hf_rewrite_regenerates_existing_builder_managed_packed_data(monkeypatch
     builder.prepare_data()
 
     assert [call["input_path"].name for call in pack_calls] == ["training.jsonl", "validation.jsonl"]
+    assert all(call["max_seq_length"] == 120 for call in pack_calls)
     assert json.loads(builder.pack_metadata.read_text()) == []
 
 

--- a/tests/unit_tests/data/datasets/test_chat_template.py
+++ b/tests/unit_tests/data/datasets/test_chat_template.py
@@ -1007,7 +1007,7 @@ def _create_minimal_packed_dataset(tokenizer_eos_id: int = 0):
     dataset.pad_to_max_length = False
     dataset.max_seq_length = 32
     dataset.pad_seq_length_to_mult = 1
-    dataset._pad_seq_to_mult = 2  # Used in collate_fn for cu_seqlens_unpadded check (must be > 1 to compute)
+    dataset._pad_seq_to_mult = 2  # Emit distinct logical and physical cumulative offsets.
     dataset.ceil_to_power_2 = False
     dataset.tokenizer = SimpleNamespace(eos_id=tokenizer_eos_id)
     dataset.answer_only_loss = False
@@ -1018,10 +1018,10 @@ def _create_minimal_packed_dataset(tokenizer_eos_id: int = 0):
 
 
 class TestEOSIndexFixInPackedDataset:
-    """Test EOS index fix for cu_seqlens_unpadded calculation."""
+    """Test EOS index fix for logical cumulative sequence offsets."""
 
     def test_eos_index_logic_uses_shape_check(self):
-        """Ensure cu_seqlens_unpadded handles sequences with <2 EOS tokens."""
+        """Ensure logical offsets handle sequences with fewer than two EOS tokens."""
         dataset = _create_minimal_packed_dataset()
         batch = [
             {
@@ -1032,11 +1032,60 @@ class TestEOSIndexFixInPackedDataset:
         ]
 
         processed = dataset.collate_fn(batch)
-        cu_unpadded = [val for val in processed["cu_seqlens_unpadded"][0].tolist() if val >= 0]
+        cu_logical = processed["cu_seqlens_q"][0].tolist()
 
         # Expect a single non-EOS token tracked without indexing errors.
-        assert cu_unpadded == [0, 1]
+        assert cu_logical == [0, 1]
+        assert processed["cu_seqlens_kv"].tolist() == processed["cu_seqlens_q"].tolist()
         assert processed["attention_mask"] is None
+
+    def test_static_metadata_keeps_logical_and_physical_boundaries_aligned(self):
+        """Static metadata pads logical and physical boundary arrays to the same shape."""
+        dataset = _create_minimal_packed_dataset()
+        dataset.pad_to_max_length = True
+        dataset.max_seq_length = 8
+        dataset.pad_cu_seqlens = True
+        dataset.pack_metadata = [
+            {
+                "max_samples_per_bin": 3,
+                "dataset_max_seqlen": 8,
+                "min_packed_seqlen": 4,
+            }
+        ]
+        batch = [
+            {
+                "input_ids": np.array([7, 0, 0, 0, 0], dtype=np.int64),
+                "seq_boundaries": [0, 5],
+                "loss_mask": np.ones(5, dtype=np.int64),
+            }
+        ]
+
+        processed = dataset.collate_fn(batch)
+
+        assert processed["cu_seqlens_q"].shape == processed["cu_seqlens_q_padded"].shape
+        assert processed["cu_seqlens_q"][0].tolist() == [0, 1, 1, 1, 1]
+        assert processed["cu_seqlens_kv"][0].tolist() == [0, 1, 1, 1, 1]
+        assert processed["cu_seqlens_q_padded"][0].tolist() == [0, 4, 8, 8, 8]
+        assert processed["cu_seqlens_kv_padded"][0].tolist() == [0, 4, 8, 8, 8]
+
+    def test_without_alignment_padding_omits_physical_variants(self):
+        """Identical logical and physical layouts use only the faster logical TE fields."""
+        dataset = _create_minimal_packed_dataset()
+        dataset._pad_seq_to_mult = 1
+        batch = [
+            {
+                "input_ids": np.array([7, 8, 9, 0, 0], dtype=np.int64),
+                "seq_boundaries": [0, 5],
+                "loss_mask": np.ones(5, dtype=np.int64),
+            }
+        ]
+
+        processed = dataset.collate_fn(batch)
+
+        assert processed["cu_seqlens_q"][0].tolist() == [0, 4]
+        assert processed["cu_seqlens_kv"][0].tolist() == [0, 4]
+        assert "cu_seqlens_q_padded" not in processed
+        assert "cu_seqlens_kv_padded" not in processed
 
 
 def test_packed_full_loss_preserves_target_after_internal_eos():
@@ -1199,11 +1248,11 @@ class TestPackedSequenceWithChatEndToEnd:
         assert output_data[0]["loss_mask"] == expected_loss_mask
 
 
-class TestCuSeqlensUnpaddedCalculation:
-    """Test cu_seqlens_unpadded calculation with EOS fix."""
+class TestLogicalCuSeqlensCalculation:
+    """Test logical cumulative sequence offsets with the EOS fix."""
 
-    def test_cu_seqlens_unpadded_calculation_uses_correct_eos(self):
-        """Ensure cu_seqlens_unpadded honors the tokenizer's EOS id."""
+    def test_logical_cu_seqlens_uses_correct_eos(self):
+        """Ensure logical cumulative offsets honor the tokenizer's EOS id."""
         dataset = _create_minimal_packed_dataset(tokenizer_eos_id=999)
         batch = [
             {
@@ -1217,10 +1266,10 @@ class TestCuSeqlensUnpaddedCalculation:
         ]
 
         processed = dataset.collate_fn(batch)
-        cu_unpadded = [val for val in processed["cu_seqlens_unpadded"][0].tolist() if val >= 0]
+        cu_logical = processed["cu_seqlens_q"][0].tolist()
 
         # Each non-EOS token contributes exactly once despite EOS padding.
-        assert cu_unpadded == [0, 1, 2]
+        assert cu_logical == [0, 1, 2]
 
 
 class TestBackwardCompatibilityLossMask:

--- a/tests/unit_tests/recipes/test_glm5_recipes.py
+++ b/tests/unit_tests/recipes/test_glm5_recipes.py
@@ -18,6 +18,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from megatron.bridge.data.builders import ChatSFTPreprocessingConfig
 from megatron.bridge.recipes.glm import gb200
 from megatron.bridge.recipes.glm.gb200 import glm5 as gb200_glm5
 from megatron.bridge.recipes.glm.h100 import glm5
@@ -37,6 +38,7 @@ class _FakeMegatronProvider(SimpleNamespace):
         "context_parallel_size",
         "cross_entropy_fusion_impl",
         "cross_entropy_loss_fusion",
+        "deallocate_pipeline_outputs",
         "dsa_indexer_loss_coeff",
         "dsa_indexer_skip_topk_offset",
         "dsa_indexer_topk_freq",
@@ -47,6 +49,8 @@ class _FakeMegatronProvider(SimpleNamespace):
         "gradient_accumulation_fusion",
         "microbatch_group_size_per_vp_stage",
         "moe_flex_dispatcher_backend",
+        "moe_grouped_gemm",
+        "moe_permute_fusion",
         "moe_router_force_load_balancing",
         "moe_shared_expert_overlap",
         "moe_token_dispatcher_type",
@@ -152,19 +156,19 @@ def test_glm52_h100_200k_recipe_uses_packed_cp() -> None:
 
 
 @pytest.mark.parametrize(
-    ("recipe", "gbs", "steps"),
+    ("recipe", "cp", "gbs", "steps", "dispatcher", "backend"),
     [
-        (gb200.glm52_pretrain_192gpu_gb200_bf16_config, 1024, 100),
-        (gb200.glm52_sft_192gpu_gb200_bf16_config, 32, 100),
-        (gb200.glm52_peft_192gpu_gb200_bf16_config, 32, 100),
+        (gb200.glm52_pretrain_192gpu_gb200_bf16_config, 1, 1024, 100, "alltoall", None),
+        (gb200.glm52_sft_192gpu_gb200_bf16_config, 4, 8, 100, "flex", "hybridep"),
+        (gb200.glm52_peft_192gpu_gb200_bf16_config, 1, 32, 100, "alltoall", None),
     ],
 )
-def test_glm52_gb200_recipe_topologies(recipe, gbs, steps) -> None:
+def test_glm52_gb200_recipe_topologies(recipe, cp, gbs, steps, dispatcher, backend) -> None:
     cfg = recipe()
 
     assert cfg.model.tensor_model_parallel_size == 1
     assert cfg.model.pipeline_model_parallel_size == 6
-    assert cfg.model.context_parallel_size == 1
+    assert cfg.model.context_parallel_size == cp
     assert cfg.model.expert_model_parallel_size == 32
     assert cfg.model.expert_tensor_parallel_size == 1
     assert cfg.model.sequence_parallel is False
@@ -173,12 +177,14 @@ def test_glm52_gb200_recipe_topologies(recipe, gbs, steps) -> None:
     assert cfg.model.num_layers_in_first_pipeline_stage == 14
     assert cfg.model.num_layers_in_last_pipeline_stage == 16
     assert cfg.model.microbatch_group_size_per_vp_stage == 6
-    assert cfg.model.moe_token_dispatcher_type == "alltoall"
-    assert cfg.model.moe_flex_dispatcher_backend is None
+    assert cfg.model.moe_token_dispatcher_type == dispatcher
+    assert cfg.model.moe_flex_dispatcher_backend == backend
     assert cfg.model.apply_rope_fusion is False
     assert cfg.train.global_batch_size == gbs
     assert cfg.train.micro_batch_size == 1
     assert cfg.train.train_iters == steps
+    data_parallel_size = 192 // (cfg.model.pipeline_model_parallel_size * cfg.model.context_parallel_size)
+    assert cfg.train.global_batch_size % data_parallel_size == 0
 
 
 def test_glm52_gb200_128k_recipe_uses_packed_cp() -> None:
@@ -188,25 +194,62 @@ def test_glm52_gb200_128k_recipe_uses_packed_cp() -> None:
     assert cfg.model.pipeline_model_parallel_size == 6
     assert cfg.model.context_parallel_size == 32
     assert cfg.model.expert_model_parallel_size == 32
-    assert cfg.model.pipeline_model_parallel_layout is None
-    assert cfg.model.num_layers_in_first_pipeline_stage == 14
-    assert cfg.model.num_layers_in_last_pipeline_stage == 16
+    assert cfg.model.pipeline_model_parallel_layout == gb200_glm5._GLM52_PP6_128K_LAYOUT
+    assert cfg.model.num_layers_in_first_pipeline_stage is None
+    assert cfg.model.num_layers_in_last_pipeline_stage is None
+    stages = cfg.model.pipeline_model_parallel_layout.split("|")
+    assert [stage.count("t") for stage in stages] == [14, 16, 12, 12, 12, 12]
+    decoder_starts = []
+    decoder_count = 0
+    for stage in stages:
+        decoder_starts.append(decoder_count)
+        decoder_count += stage.count("t")
+    assert decoder_starts == [0, 14, 30, 42, 54, 66]
+    assert all((start + 1 - 3) % 4 == 0 for start in decoder_starts[1:])
     assert cfg.model.moe_token_dispatcher_type == "flex"
     assert cfg.model.moe_flex_dispatcher_backend == "hybridep"
     assert cfg.model.moe_shared_expert_overlap is False
     assert cfg.model.apply_rope_fusion is False
-    assert cfg.train.global_batch_size == 8
+    assert cfg.train.global_batch_size == 56
     assert cfg.train.micro_batch_size == 1
     assert cfg.train.train_iters == 20
     assert cfg.dataset.seq_length == 131072
-    assert cfg.dataset.dataset_root == "work/data/glm5-2/synthetic-long-context-gb200"
+    assert cfg.dataset.hf_dataset is None
+    assert cfg.dataset.dataset_root == "work/data/glm5-2/synthetic-long-sft-128k"
+    assert cfg.dataset.hf_output_root is None
+    assert cfg.dataset.max_train_samples == 1120
+    assert isinstance(cfg.dataset.preprocessing, ChatSFTPreprocessingConfig)
     assert cfg.dataset.offline_packing_specs.packed_sequence_size == 131072
     assert cfg.dataset.offline_packing_specs.pad_seq_to_mult == 64
     assert cfg.dataset.offline_packing_specs.pad_cu_seqlens is True
+    assert cfg.dataset.dataset_kwargs == {"pad_to_max_length": True}
     assert cfg.env_vars["NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN"] == 32
     assert cfg.env_vars["NUM_OF_TOKENS_PER_CHUNK_COMBINE_API"] == 128
     assert cfg.env_vars["NVLINK_DOMAIN_SIZE"] == 72
     assert cfg.env_vars["USE_MNNVL"] == 1
+
+
+def test_glm52_gb200_sft_uses_8k_packed_tulu3() -> None:
+    cfg = gb200.glm52_sft_192gpu_gb200_bf16_config()
+
+    assert cfg.model.seq_length == 8192
+    assert cfg.model.context_parallel_size == 4
+    assert cfg.dataset.seq_length == 8192
+    assert cfg.train.global_batch_size == 8
+    assert cfg.train.micro_batch_size == 1
+    assert cfg.dataset.hf_dataset.split == "train[:10000]"
+    assert cfg.dataset.hf_dataset.load_kwargs == {"revision": gb200_glm5._TULU3_REVISION}
+    assert cfg.dataset.hf_output_root == "work/data/glm5-2/tulu3-full-sft-gb200-8k-v5"
+    assert cfg.dataset.offline_packing_specs.packed_sequence_size == 8192
+    assert (
+        cfg.dataset.offline_packing_specs.max_single_sequence_length
+        == cfg.model.seq_length - cfg.dataset.offline_packing_specs.pad_seq_to_mult
+    )
+    assert cfg.dataset.offline_packing_specs.pad_seq_to_mult == 2 * cfg.model.context_parallel_size
+    assert cfg.dataset.offline_packing_specs.pad_cu_seqlens is True
+    assert cfg.dataset.dataset_kwargs == {"pad_to_max_length": True}
+    assert cfg.model.moe_token_dispatcher_type == "flex"
+    assert cfg.model.moe_flex_dispatcher_backend == "hybridep"
 
 
 def test_glm52_gb200_recipes_do_not_depend_on_h100_recipes() -> None:

--- a/tests/unit_tests/recipes/test_glm5_recipes.py
+++ b/tests/unit_tests/recipes/test_glm5_recipes.py
@@ -221,7 +221,7 @@ def test_glm52_gb200_128k_recipe_uses_packed_cp() -> None:
     assert isinstance(cfg.dataset.preprocessing, ChatSFTPreprocessingConfig)
     assert cfg.dataset.offline_packing_specs.packed_sequence_size == 131072
     assert cfg.dataset.offline_packing_specs.pad_seq_to_mult == 64
-    assert cfg.dataset.offline_packing_specs.pad_cu_seqlens is True
+    assert cfg.dataset.offline_packing_specs.pad_cu_seqlens is False
     assert cfg.dataset.dataset_kwargs == {"pad_to_max_length": True}
     assert cfg.env_vars["NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN"] == 32
     assert cfg.env_vars["NUM_OF_TOKENS_PER_CHUNK_COMBINE_API"] == 128
@@ -246,7 +246,7 @@ def test_glm52_gb200_sft_uses_8k_packed_tulu3() -> None:
         == cfg.model.seq_length - cfg.dataset.offline_packing_specs.pad_seq_to_mult
     )
     assert cfg.dataset.offline_packing_specs.pad_seq_to_mult == 2 * cfg.model.context_parallel_size
-    assert cfg.dataset.offline_packing_specs.pad_cu_seqlens is True
+    assert cfg.dataset.offline_packing_specs.pad_cu_seqlens is False
     assert cfg.dataset.dataset_kwargs == {"pad_to_max_length": True}
     assert cfg.model.moe_token_dispatcher_type == "flex"
     assert cfg.model.moe_flex_dispatcher_backend == "hybridep"

--- a/tests/unit_tests/training/test_config.py
+++ b/tests/unit_tests/training/test_config.py
@@ -1425,6 +1425,124 @@ class TestConfigContainerValidation:
         finally:
             restore_get_world_size_safe(og_ws, cfg_mod)
 
+    def test_pad_cu_seqlens_requires_fixed_token_width(self, monkeypatch):
+        """Test static packed boundaries also require a fixed packed-token width."""
+        from megatron.bridge.data.packing import PackedSequenceSpecs
+
+        dataset_cfg = create_test_gpt_sft_dataset_config(sequence_length=512)
+        dataset_cfg.enable_offline_packing = True
+        dataset_cfg.offline_packing_specs = PackedSequenceSpecs(
+            packed_sequence_size=512,
+            pad_cu_seqlens=True,
+        )
+        container, og_ws, cfg_mod = create_test_config_container(
+            world_size_override=1,
+            model_config=create_test_gpt_config(),
+            dataset_config_override=dataset_cfg,
+        )
+
+        try:
+            with pytest.raises(ValueError, match="pad_cu_seqlens=True requires dataset pad_to_max_length=True"):
+                container.validate()
+        finally:
+            restore_get_world_size_safe(og_ws, cfg_mod)
+
+    @pytest.mark.parametrize("graph_modules", [[], ["attn"], ["attn", "mlp"]])
+    def test_packed_attention_cuda_graph_requires_padded_cu_seqlens(self, graph_modules, monkeypatch):
+        """Test whole-layer and attention-scoped graphs require static packed boundaries."""
+        from megatron.bridge.data.packing import PackedSequenceSpecs
+
+        model_cfg = create_test_gpt_config(
+            cuda_graph_impl="transformer_engine",
+            use_te_rng_tracker=True,
+        )
+        set_cuda_graph_modules(model_cfg, graph_modules)
+        dataset_cfg = create_test_gpt_sft_dataset_config(sequence_length=512)
+        dataset_cfg.enable_offline_packing = True
+        dataset_cfg.offline_packing_specs = PackedSequenceSpecs(packed_sequence_size=512)
+        dataset_cfg.dataset_kwargs = {"pad_to_max_length": True}
+        container, og_ws, cfg_mod = create_test_config_container(
+            world_size_override=1,
+            model_config=model_cfg,
+            dataset_config_override=dataset_cfg,
+        )
+
+        try:
+            with pytest.raises(ValueError, match="Packed attention CUDA graphs require.*pad_cu_seqlens=True"):
+                container.validate()
+        finally:
+            restore_get_world_size_safe(og_ws, cfg_mod)
+
+    def test_mlp_only_cuda_graph_does_not_require_padded_cu_seqlens(self, monkeypatch):
+        """Test an MLP-only graph does not capture packed attention metadata."""
+        from megatron.bridge.data.packing import PackedSequenceSpecs
+
+        model_cfg = create_test_gpt_config(
+            cuda_graph_impl="transformer_engine",
+            use_te_rng_tracker=True,
+        )
+        set_cuda_graph_modules(model_cfg, ["mlp"])
+        dataset_cfg = create_test_gpt_sft_dataset_config(sequence_length=512)
+        dataset_cfg.enable_offline_packing = True
+        dataset_cfg.offline_packing_specs = PackedSequenceSpecs(packed_sequence_size=512)
+        dataset_cfg.dataset_kwargs = {"pad_to_max_length": True}
+        container, og_ws, cfg_mod = create_test_config_container(
+            world_size_override=1,
+            model_config=model_cfg,
+            dataset_config_override=dataset_cfg,
+        )
+
+        try:
+            container.validate()
+        finally:
+            restore_get_world_size_safe(og_ws, cfg_mod)
+
+    def test_mlp_only_cuda_graph_still_requires_fixed_token_width(self, monkeypatch):
+        """Test every CUDA graph over offline-packed tokens requires a static token shape."""
+        from megatron.bridge.data.packing import PackedSequenceSpecs
+
+        model_cfg = create_test_gpt_config(
+            cuda_graph_impl="transformer_engine",
+            use_te_rng_tracker=True,
+        )
+        set_cuda_graph_modules(model_cfg, ["mlp"])
+        dataset_cfg = create_test_gpt_sft_dataset_config(sequence_length=512)
+        dataset_cfg.enable_offline_packing = True
+        dataset_cfg.offline_packing_specs = PackedSequenceSpecs(packed_sequence_size=512)
+        container, og_ws, cfg_mod = create_test_config_container(
+            world_size_override=1,
+            model_config=model_cfg,
+            dataset_config_override=dataset_cfg,
+        )
+
+        try:
+            with pytest.raises(ValueError, match="Offline packing with CUDA graphs requires.*pad_to_max_length=True"):
+                container.validate()
+        finally:
+            restore_get_world_size_safe(og_ws, cfg_mod)
+
+    def test_full_iteration_cuda_graph_requires_padded_cu_seqlens_for_offline_packing(self, monkeypatch):
+        """Test full-iteration graphs require static packed attention metadata."""
+        from megatron.bridge.data.packing import PackedSequenceSpecs
+
+        model_cfg = create_test_gpt_config(use_te_rng_tracker=True)
+        set_full_iteration_cuda_graph(model_cfg)
+        dataset_cfg = create_test_gpt_sft_dataset_config(sequence_length=512)
+        dataset_cfg.enable_offline_packing = True
+        dataset_cfg.offline_packing_specs = PackedSequenceSpecs(packed_sequence_size=512)
+        dataset_cfg.dataset_kwargs = {"pad_to_max_length": True}
+        container, og_ws, cfg_mod = create_test_config_container(
+            world_size_override=1,
+            model_config=model_cfg,
+            dataset_config_override=dataset_cfg,
+        )
+
+        try:
+            with pytest.raises(ValueError, match="Packed attention CUDA graphs require.*pad_cu_seqlens=True"):
+                container.validate()
+        finally:
+            restore_get_world_size_safe(og_ws, cfg_mod)
+
     @pytest.mark.parametrize(
         "seq_length, context_parallel_size, expect_assertion_error",
         [

--- a/tests/unit_tests/training/test_gpt_step.py
+++ b/tests/unit_tests/training/test_gpt_step.py
@@ -747,10 +747,9 @@ class TestGetPackedSeqParams:
         assert torch.equal(result.cu_seqlens_q, expected_cu_seqlens)
         assert torch.equal(result.cu_seqlens_kv, expected_cu_seqlens)
 
-        # Verify max_seqlen was squeezed
-        expected_max_seqlen = torch.tensor(15, dtype=torch.int32)
-        assert torch.equal(result.max_seqlen_q, expected_max_seqlen)
-        assert torch.equal(result.max_seqlen_kv, expected_max_seqlen)
+        # Verify max_seqlen was normalized to MCore's Python-int contract
+        assert result.max_seqlen_q == 15
+        assert result.max_seqlen_kv == 15
 
         # Verify qkv_format is correct
         assert result.qkv_format == "thd"
@@ -797,9 +796,8 @@ class TestGetPackedSeqParams:
         assert torch.equal(result.cu_seqlens_kv, expected_cu_seqlens)
 
         # Verify max_seqlen was processed correctly
-        expected_max_seqlen = torch.tensor(18, dtype=torch.int32)
-        assert torch.equal(result.max_seqlen_q, expected_max_seqlen)
-        assert torch.equal(result.max_seqlen_kv, expected_max_seqlen)
+        assert result.max_seqlen_q == 18
+        assert result.max_seqlen_kv == 18
 
     def test_packed_seq_params_with_cu_seqlens_argmin_zero(self):
         """Test edge case when cu_seqlens_argmin is 0."""
@@ -829,8 +827,7 @@ class TestGetPackedSeqParams:
         expected_cu_seqlens = torch.tensor([0, 6, 12], dtype=torch.int32)
         assert torch.equal(result.cu_seqlens_q, expected_cu_seqlens)
 
-        expected_max_seqlen = torch.tensor(20, dtype=torch.int32)
-        assert torch.equal(result.max_seqlen_q, expected_max_seqlen)
+        assert result.max_seqlen_q == 20
 
     def test_packed_seq_params_with_different_dtypes(self):
         """Test functionality with different tensor dtypes."""
@@ -845,8 +842,7 @@ class TestGetPackedSeqParams:
         expected_cu_seqlens = torch.tensor([0, 10, 20], dtype=torch.int64)
         assert torch.equal(result.cu_seqlens_q, expected_cu_seqlens)
 
-        expected_max_seqlen = torch.tensor(25, dtype=torch.int64)
-        assert torch.equal(result.max_seqlen_q, expected_max_seqlen)
+        assert result.max_seqlen_q == 25
 
     def test_packed_seq_params_all_fields_match(self):
         """Test that cu_seqlens_q/kv and max_seqlen_q/kv are identical."""
@@ -859,7 +855,7 @@ class TestGetPackedSeqParams:
 
         # Verify that q and kv parameters are identical (as expected for this function)
         assert torch.equal(result.cu_seqlens_q, result.cu_seqlens_kv)
-        assert torch.equal(result.max_seqlen_q, result.max_seqlen_kv)
+        assert result.max_seqlen_q == result.max_seqlen_kv
 
     def test_packed_seq_params_with_cu_seqlens_unpadded(self):
         """Test functionality with cu_seqlens_unpadded for THD CP support."""

--- a/tests/unit_tests/training/utils/test_packed_seq_utils.py
+++ b/tests/unit_tests/training/utils/test_packed_seq_utils.py
@@ -215,7 +215,19 @@ class TestGetPackedSeqParams:
         torch.testing.assert_close(result.cu_seqlens_kv_padded, batch["cu_seqlens_kv_padded"])
         assert result.max_seqlen_q == 128
         assert result.max_seqlen_kv == 128
+        assert isinstance(result.max_seqlen_q, int)
+        assert isinstance(result.max_seqlen_kv, int)
         assert result.qkv_format == "thd"
+
+    def test_current_mcore_metadata_rejects_non_scalar_max_seqlen(self):
+        """Test that malformed max-sequence metadata fails before reaching MCore."""
+        batch = {
+            "cu_seqlens_q": torch.IntTensor([0, 64, 128]),
+            "max_seqlen_q": torch.IntTensor([64, 64]),
+        }
+
+        with pytest.raises(ValueError, match="max_seqlen_q must contain exactly one value"):
+            get_packed_seq_params(batch)
 
     def test_without_cu_seqlens_unpadded(self):
         """Test get_packed_seq_params when cu_seqlens_unpadded is NOT present.


### PR DESCRIPTION
# What does this PR do ?

Adds the verified GLM-5.2 GB200 training recipes and model-card evidence, plus the packed-sequence metadata needed by the 8K and 128K functional runs. Chat-template, assistant-mask, EOS, and related cache-identity changes are isolated in follow-up #5361.

# Changelog

- replace the invalid GB200 pretraining corpus with bounded RedPajama2 and record the matching step-50 resume gate
- add verified 192-GB200 pretraining, 8K packed Tulu SFT, 128K long-context SFT, PEFT, and resume recipe/card coverage
- expose logical `cu_seqlens_q` / `cu_seqlens_kv` and optional physical `*_padded` boundaries for aligned packed sequences
- add an explicit maximum single-sequence length to offline packing and include it in the packed-artifact fingerprint
- add deterministic full-length 128K support data and a DSA-valid explicit PP6 layout
- retain the existing H100 verification evidence and recalculate all recorded H100/GB200 training TFLOPS from measured step times using the corrected DSA accounting from #5324
- add focused recipe, packing, builder, and training-step tests

# GitHub Actions CI

Validation completed:

- `uvx pre-commit run --all-files` on the final PR1 tree
- model-card schema validation
- focused packing-builder, packed-dataset, recipe, and conversation-processing coverage on the pre-split superset
- corrected 192-GPU RP2 pretrain and step-50 resume completed with finite losses and zero skipped/NaN iterations
- corrected 192-GPU 8K packed Tulu SFT completed 100 steps with finite loss, zero skipped/NaN iterations, and a complete step-100 checkpoint
- corrected 192-GPU 128K packed SFT completed 20 contiguous optimizer steps with finite loss and zero skipped/NaN iterations; the final 10 steps averaged 143,248.820 ms and 88.848 TFLOPS/GPU
- all recorded training TFLOPS values were re-derived from existing average step times; no training workload was rerun

The deterministic synthetic cohort verifies 128K execution support; the pinned-Tulu 8K run supplies real-data convergence evidence. The standard `uv run` environment is unavailable on macOS because `nvidia-resiliency-ext` ships Linux-only wheels, so Linux CI is requested below.

# Before your PR is "Ready for review"

- [x] Make sure you read and followed Contributor guidelines
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install? No

# Additional Information

- Follow-up template/EOS PR: #5361
- Related to MB-1140
