### PR TITLE
[ckpt] fix: support vocab padding with Megatron-FSDP TP

### DIFF
--- a/src/megatron/bridge/models/conversion/param_mapping.py
+++ b/src/megatron/bridge/models/conversion/param_mapping.py
@@ -993,7 +993,11 @@ class ColumnParallelMapping(MegatronParamMapping[torch.Tensor]):
                 hf_weights = hf_weights.to(target_param.dtype)
 
             actual_dim0_size = hf_weights.shape[0]
-            expect_dim0_size = target_param.shape[0] * self.tp_size
+            # DTensor.shape is already the global shape across TP ranks, while
+            # a regular Megatron parameter stores only its local TP shard.
+            expect_dim0_size = target_param.shape[0]
+            if not isinstance(target_param, DTensor):
+                expect_dim0_size *= self.tp_size
             if actual_dim0_size != expect_dim0_size:
                 assert self.megatron_param in {"embedding.word_embeddings.weight", "output_layer.weight"}, (
                     f"{hf_weights.shape=} {target_param.shape=} {self.tp_size=} {self.megatron_param=} {self.hf_param=}"

--- a/tests/functional_tests/test_groups/converter/test_hf_fsdp_conversion.py
+++ b/tests/functional_tests/test_groups/converter/test_hf_fsdp_conversion.py
@@ -101,9 +101,8 @@ class TestHFFSDPConversion:
     @pytest.mark.parametrize(
         "tp,ep,nproc,test_name",
         [
-            # CI only covers TP=1 cases. TP>1 cases depend on Megatron-LM commit
-            # 8cbc45b6e (PR#3191, merged 2026-04-07).
             (1, 1, 1, "FSDP_base"),
+            (2, 1, 2, "FSDP_TP2"),
         ],
     )
     def test_hf_fsdp_roundtrip(self, qwen3_moe_toy_model_path, tmp_path, tp, ep, nproc, test_name):


### PR DESCRIPTION
## Summary

- compute the padded global vocabulary size correctly when the Megatron target is an MFSDP `DTensor`
- add TP=2 coverage to the existing MFSDP Hugging Face round-trip functional test

## Root cause

`DTensor.shape` already describes the global tensor across TP ranks. The vocabulary-padding path multiplied that dimension by `tp_size` again, so a TP=2 import padded a 151,936-token embedding to 303,872 rows and scattered 151,936 rows to a local 75,968-row buffer.

This fixes the regression introduced by #1473 and tracked internally as NVBug 6565261.

## Validation

- Before the fix, the Qwen3-0.6B MFSDP TP=2 round trip reproduced `expected (75968, 1024), got (151936, 1024)`.
- After the fix, the same real-checkpoint round trip completed successfully and wrote all 226 tensors.
- `uv run --no-sync python -m pytest tests/functional_tests/test_groups/converter/test_hf_fsdp_conversion.py -k FSDP_TP2 -v -s` — 1 passed
- `uv run pre-commit run --all-files` — passed

