### PR TITLE
fix(recipe): Qwen3-30B B200 fp8mx OOMs with full-iteration — use partial CG

### DIFF
--- a/src/megatron/bridge/perf_recipes/qwen/b200/qwen3_moe.py
+++ b/src/megatron/bridge/perf_recipes/qwen/b200/qwen3_moe.py
@@ -307,10 +307,26 @@ def qwen3_30b_a3b_pretrain_8gpu_b200_fp8mx_config() -> ConfigContainer:
     cfg.model.moe_flex_dispatcher_backend = "hybridep"
     cfg.model.moe_token_dispatcher_type = "flex"
 
-    cfg.comm_overlap = CommOverlapConfig(tp_comm_overlap=True)
+    # Partial (TE-scoped) CUDA graph, not full-iteration: B200's 180 GB cannot hold the
+    # full-iteration graph for this model — it OOMs at every workable config (TP1/EP8 and
+    # TP2/EP8, mbs4 and mbs2, even with defragmentation). Full-iteration is a B300/GB200
+    # feature (279/186 GB); B200 ships the partial-CG design.
+    cfg.model.cuda_graph_impl = "transformer_engine"
+    cfg.model.cuda_graph_scope = ["attn", "moe_router", "moe_preprocess"]
+
+    # Overlap the exposed HybridEP expert-parallel all-to-all with expert wgrad. Under
+    # partial CG the MoE a2a (~29% of kernel time here) is otherwise fully exposed; the
+    # B300 recipe gets this for free from the full-iteration helper. num_sms sizes the
+    # overlap stream (swept: 64 is the optimum; the curve turns up past 64).
+    cfg.comm_overlap = CommOverlapConfig(
+        tp_comm_overlap=True,
+        overlap_moe_expert_parallel_comm=True,
+        delay_wgrad_compute=True,
+    )
+    cfg.model.moe_hybridep_num_sms_preprocessing = 32
+    cfg.model.moe_hybridep_num_sms = 64
 
     _benchmark_common(cfg)
-    _enable_hybridep_full_iteration_mxfp8(cfg)
     # Keep process settings next to the recipe so users can see the exact benchmark environment.
     cfg.env_vars = {
         **COMMON_PERF_ENV_VARS,
@@ -318,8 +334,8 @@ def qwen3_30b_a3b_pretrain_8gpu_b200_fp8mx_config() -> ConfigContainer:
         "CUDA_DEVICE_MAX_CONNECTIONS": 32,
         # CUDA graph and allocator behavior for this recipe.
         "NCCL_GRAPH_REGISTER": 0,
-        "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True,graph_capture_record_stream_reuse:True",
-        "TORCH_NCCL_AVOID_RECORD_STREAMS": 0,
+        "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True",
+        "TORCH_NCCL_AVOID_RECORD_STREAMS": 1,
         # NCCL user-buffer and launch settings.
         "NCCL_NVLS_ENABLE": 0,
         # HybridEP topology for the target system.
@@ -327,10 +343,10 @@ def qwen3_30b_a3b_pretrain_8gpu_b200_fp8mx_config() -> ConfigContainer:
         "NUM_OF_TOKENS_PER_CHUNK_COMBINE_API": 128,
         "NVLINK_DOMAIN_SIZE": 8,
         "USE_MNNVL": 0,
-        # Transformer Engine overlap settings for this model.
-        "CUDNNFE_CLUSTER_OVERLAP_MARGIN": 8,
+        # cuDNN LayerNorm — marginal on B200 (TE TMA LN is already fast) but part of the tuned config.
+        "NVTE_NORM_FWD_USE_CUDNN": 1,
+        "NVTE_NORM_BWD_USE_CUDNN": 1,
         "NVTE_BWD_LAYERNORM_SM_MARGIN": 20,
-        "NVTE_CUTEDSL_FUSED_GROUPED_MLP": 1,
         "NVTE_FWD_LAYERNORM_SM_MARGIN": 20,
     }
     return cfg

--- a/src/megatron/bridge/perf_recipes/qwen/b200/qwen3_moe.py
+++ b/src/megatron/bridge/perf_recipes/qwen/b200/qwen3_moe.py
@@ -323,10 +323,11 @@ def qwen3_30b_a3b_pretrain_8gpu_b200_fp8mx_config() -> ConfigContainer:
         overlap_moe_expert_parallel_comm=True,
         delay_wgrad_compute=True,
     )
-    cfg.model.moe_hybridep_num_sms_preprocessing = 32
-    cfg.model.moe_hybridep_num_sms = 64
 
     _benchmark_common(cfg)
+    # After _benchmark_common: it forces moe_hybridep_num_sms=32 for every hybridep recipe.
+    cfg.model.moe_hybridep_num_sms_preprocessing = 32
+    cfg.model.moe_hybridep_num_sms = 64
     # Keep process settings next to the recipe so users can see the exact benchmark environment.
     cfg.env_vars = {
         **COMMON_PERF_ENV_VARS,

--- a/tests/unit_tests/recipes/test_r050_perf_recipe_ports.py
+++ b/tests/unit_tests/recipes/test_r050_perf_recipe_ports.py
@@ -69,7 +69,6 @@ def _assert_full_iteration_hybridep_mxfp8(cfg, *, fp8_dot_product_attention: boo
 @pytest.mark.parametrize(
     ("recipe", "expected_vpp"),
     [
-        (qwen3_30b_a3b_pretrain_8gpu_b200_fp8mx_config, None),
         (qwen3_235b_a22b_pretrain_256gpu_b200_fp8mx_config, 3),
         (qwen3_235b_a22b_pretrain_256gpu_b300_fp8mx_config, 3),
     ],
@@ -84,6 +83,31 @@ def test_qwen_mxfp8_recipes_match_r050_full_iteration_settings(recipe, expected_
     assert cfg.env_vars["NVTE_CUTEDSL_FUSED_GROUPED_MLP"] == 1
     assert cfg.env_vars["TORCH_NCCL_AVOID_RECORD_STREAMS"] == 0
     assert "graph_capture_record_stream_reuse:True" in cfg.env_vars["PYTORCH_CUDA_ALLOC_CONF"]
+
+
+def test_qwen_30b_a3b_b200_fp8mx_uses_partial_cuda_graph() -> None:
+    """B200's 180 GB cannot hold the full-iteration graph, so the 8-GPU MXFP8 recipe uses
+    partial (TE-scoped) CUDA graph plus explicit HybridEP a2a/wgrad overlap instead."""
+    cfg = qwen3_30b_a3b_pretrain_8gpu_b200_fp8mx_config()
+
+    # Partial (TE-scoped) CUDA graph, not full-iteration.
+    assert cfg.model.cuda_graph_impl == "transformer_engine"
+    assert cfg.model.cuda_graph_scope == ["attn", "moe_router", "moe_preprocess"]
+
+    # Explicit HybridEP expert-parallel overlap + swept SM tuning.
+    assert cfg.comm_overlap.overlap_moe_expert_parallel_comm is True
+    assert cfg.comm_overlap.delay_wgrad_compute is True
+    assert cfg.model.moe_hybridep_num_sms == 64
+    assert cfg.model.moe_hybridep_num_sms_preprocessing == 32
+    assert cfg.model.moe_flex_dispatcher_backend == "hybridep"
+    assert cfg.model.moe_token_dispatcher_type == "flex"
+
+    # Partial-CG allocator / env: the full-iteration extras are removed.
+    assert cfg.env_vars["PYTORCH_CUDA_ALLOC_CONF"] == "expandable_segments:True"
+    assert cfg.env_vars["TORCH_NCCL_AVOID_RECORD_STREAMS"] == 1
+    assert "NVTE_CUTEDSL_FUSED_GROUPED_MLP" not in cfg.env_vars
+    assert cfg.env_vars["NVTE_NORM_FWD_USE_CUDNN"] == 1
+    assert cfg.env_vars["NVTE_NORM_BWD_USE_CUDNN"] == 1
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

`qwen3_30b_a3b_pretrain_8gpu_b200_fp8mx_config` was switched to **full-iteration CUDA graph** by #5061 (`_enable_hybridep_full_iteration_mxfp8`), but **B200's 180 GB cannot hold the full-iteration graph for this model** — it OOMs at every workable config (TP1/EP8 and TP2/EP8, mbs4 and mbs2, even with `expandable_segments` defragmentation). Full-iteration is a B300/GB200 feature (279/186 GB); the B200 recipe should stay on the partial (TE-scoped) CUDA graph that actually fits.

This restores partial CG for the B200 fp8mx config and folds in the tuned levers that recover the overlap the full-iteration path would otherwise provide — validated on 8×B200.

## Changes (B200 30B-A3B fp8mx only)

- **CUDA graph:** `cuda_graph_impl="transformer_engine"`, scope `["attn","moe_router","moe_preprocess"]` (was `full_iteration` via the helper).
- **Expert-parallel a2a overlap:** `overlap_moe_expert_parallel_comm=True` + `delay_wgrad_compute=True`. Under partial CG the HybridEP all-to-all is otherwise fully exposed; the B300 recipe gets this for free from the full-iteration helper.
- **`moe_hybridep_num_sms=64`** (+ `moe_hybridep_num_sms_preprocessing=32`) — swept optimum for the overlap stream; the curve turns up past 64.
- **cuDNN LayerNorm** (`NVTE_NORM_{FWD,BWD}_USE_CUDNN=1`) — marginal on B200 (TE TMA LN is already fast) but part of the tuned config.

The `_enable_hybridep_full_iteration_mxfp8` import is retained (the 235B B200 config still uses it).

## Notes

- Split out of #4632 (which is approved) so it can be reviewed independently — this one reverts part of #5061 for the B200 fp8mx config specifically, so it likely wants eyes from that PR's authors.
- Full-iteration OOM evidence and the num_sms sweep were collected on 8×B200 (prenyx), rc8 container.

## Test plan

- [x] Qwen3 30B A3B B200 `fp8mx` runs (partial CG) — full-iteration OOMs (reproduced at TP1/EP8 and TP2/EP8, mbs4/mbs2).
- [x] `pytest tests/unit_tests/recipes/test_qwen_perf_recipes.py` (no assertions on B200 fp8mx; recipe builds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
