### PR TITLE
fix: use explicit Megatron-FSDP V1/V2 classes in isinstance checks

### DIFF
--- a/src/megatron/bridge/models/conversion/utils.py
+++ b/src/megatron/bridge/models/conversion/utils.py
@@ -46,13 +46,26 @@ def unwrap_model(model, module_instances=None):
     if module_instances is None:
         from megatron.core.distributed import DistributedDataParallel as DDP
         from megatron.core.distributed import TorchFullyShardedDataParallel as torch_FSDP
-        from megatron.core.distributed.fsdp.mcore_fsdp_adapter import (
-            FullyShardedDataParallel as megatron_FSDP,
-        )
         from megatron.core.distributed.fsdp.src.megatron_fsdp.megatron_fsdp import MegatronFSDP
         from megatron.core.transformer.module import Float16Module
 
-        module_instances = (DDP, torch_FSDP, megatron_FSDP, Float16Module, MegatronFSDP)
+        try:
+            # `FullyShardedDataParallel` is a factory function rather than a class on
+            # newer megatron-core, so it cannot be passed to isinstance().
+            from megatron.core.distributed.fsdp.mcore_fsdp_adapter import (
+                FullyShardedDataParallelV1,
+                FullyShardedDataParallelV2,
+            )
+
+            megatron_FSDP = (FullyShardedDataParallelV1, FullyShardedDataParallelV2)
+        except ImportError:
+            from megatron.core.distributed.fsdp.mcore_fsdp_adapter import (
+                FullyShardedDataParallel as FullyShardedDataParallelV1,
+            )
+
+            megatron_FSDP = (FullyShardedDataParallelV1,)
+
+        module_instances = (DDP, torch_FSDP, *megatron_FSDP, Float16Module, MegatronFSDP)
 
     return_list = True
     if not isinstance(model, list):

--- a/src/megatron/bridge/training/train.py
+++ b/src/megatron/bridge/training/train.py
@@ -24,7 +24,6 @@ from typing import Any, Callable, Optional, Union
 import torch
 import torch.profiler
 from megatron.core.distributed import DistributedDataParallel as DDP
-from megatron.core.distributed.fsdp.mcore_fsdp_adapter import FullyShardedDataParallel as megatron_FSDP
 from megatron.core.full_cuda_graph import FullCudaGraphWrapper
 from megatron.core.num_microbatches_calculator import (
     get_current_global_batch_size,
@@ -102,6 +101,23 @@ from megatron.bridge.training.utils.train_utils import (
 )
 from megatron.bridge.utils.common_utils import get_world_size_safe, print_rank_0
 from megatron.bridge.utils.cuda_graph import is_full_iteration_cuda_graph
+
+
+try:
+    # `FullyShardedDataParallel` is a factory function rather than a class on newer
+    # megatron-core, so it cannot be passed to isinstance().
+    from megatron.core.distributed.fsdp.mcore_fsdp_adapter import (
+        FullyShardedDataParallelV1,
+        FullyShardedDataParallelV2,
+    )
+
+    megatron_FSDP = (FullyShardedDataParallelV1, FullyShardedDataParallelV2)
+except ImportError:
+    from megatron.core.distributed.fsdp.mcore_fsdp_adapter import (
+        FullyShardedDataParallel as FullyShardedDataParallelV1,
+    )
+
+    megatron_FSDP = (FullyShardedDataParallelV1,)
 
 
 # For Paged Stashing support


### PR DESCRIPTION
Found by the nemo-rl-testing-agent while validating
[NVIDIA/Megatron-LM#5382](https://github.com/NVIDIA/Megatron-LM/pull/5382)
against the NeMo-RL Megatron functional suites. The break is not that PR's
fault — it reproduces on megatron-core `main`, so every NeMo-RL Megatron L1
test is currently failing at import time.

## Failure

All 7 tests in `L1_Functional_Tests_Megatron_4` failed with an identical
signature, reached via `build_conversion_tasks` ->
`_get_pg_collection_from_model` -> `unwrap_model`:

```
TypeError: isinstance() arg 2 must be a type, a tuple of types, or a union
```

## Root cause

[Megatron-LM #5865](https://github.com/NVIDIA/Megatron-LM/pull/5865) split the
FSDP adapter into explicit `FullyShardedDataParallelV1` / `FullyShardedDataParallelV2`
classes and turned `FullyShardedDataParallel` into a factory function that
dispatches between them. The old name is therefore no longer a type, and any
`isinstance()` against it raises. The factory's own docstring says so:

> This is a factory function, not a wrapper type. Use the explicit V1 or V2
> implementation classes for type checks.

Bridge has three `isinstance` sites against that name, in three different states:

| Site | State against megatron-core `main` |
|---|---|
| `models/conversion/utils.py` (`unwrap_model`) | No shim — this is the crash above |
| `training/train.py` (FSDP manual buffer registration) | No shim — same crash, on a path this suite does not reach |
| `training/setup.py` | Already shimmed, but imports V1 only |

## Fix

Type-check against the explicit classes at the two crash sites, using the same
`try/except ImportError` idiom `training/setup.py` already uses so older
megatron-core (where `FullyShardedDataParallel` is still a class) keeps working.
V1 and V2 were both introduced by #5865, so the two-name import succeeds or
fails together.

One thing left for a maintainer rather than folded in here: `training/setup.py`
imports `FullyShardedDataParallelV1` only, so its `isinstance` check silently
misses a V2-wrapped model instead of crashing. That looked like a behavioural
question the functional suite does not exercise, so I did not touch it.

## Validation

`L1_Functional_Tests_Megatron_4` on oci-hsg (GB200, 4 GPUs), NeMo-RL
`86774472`, megatron-core at Megatron-LM#5382 head `eb01b689`:

- Before: 7/7 fail, all with the `TypeError` above.
- After: 6/7 pass. The 7th, `grpo_megatron_generation_topp_topk`, no longer
  crashes — it runs to completion and misses a metric threshold
  (`max(train/token_mult_prob_error)` 1.078 vs `< 1.06`). That is a separate
  question being baselined against megatron-core `main` independently, and is
  unrelated to this change.

Draft: raised by an agent, needs a human review before merge.