### PR TITLE
fix(data): preserve tokenizer fork safety

### DIFF
--- a/src/megatron/bridge/data/datasets/gpt_sft.py
+++ b/src/megatron/bridge/data/datasets/gpt_sft.py
@@ -50,9 +50,6 @@ NEMO_DATASETS_CACHE = Path(os.getenv("NEMO_DATASETS_CACHE", DEFAULT_NEMO_DATASET
 DEFAULT_NEMO_MODELS_CACHE = NEMO_CACHE_HOME / "models"
 NEMO_MODELS_CACHE = Path(os.getenv("NEMO_MODELS_CACHE", DEFAULT_NEMO_MODELS_CACHE))
 
-if os.getenv("TOKENIZERS_PARALLELISM") is None:
-    os.putenv("TOKENIZERS_PARALLELISM", "True")
-
 logger = logging.getLogger(__name__)
 
 # hack to avoid the "not enough disk space" error in some slurm cluster

--- a/tests/unit_tests/data/datasets/test_gpt_sft.py
+++ b/tests/unit_tests/data/datasets/test_gpt_sft.py
@@ -33,6 +33,7 @@ from megatron.bridge.data.packing.gpt_sft import GPTSFTPackedDataset
 from megatron.bridge.data.samplers import build_pretraining_data_loader
 
 
+@pytest.mark.unit
 def test_import_preserves_tokenizers_fork_safety():
     """Importing the SFT dataset must not enable tokenizer parallelism across a fork."""
     code = textwrap.dedent(
@@ -56,7 +57,7 @@ def test_import_preserves_tokenizers_fork_safety():
 
         with multiprocessing.get_context("fork").Pool(1) as pool:
             result = pool.apply_async(encode_batch)
-            assert result.get(timeout=5) == len(batch)
+            assert result.get(timeout=10) == len(batch)
         """
     )
     environment = os.environ.copy()
@@ -67,7 +68,7 @@ def test_import_preserves_tokenizers_fork_safety():
         capture_output=True,
         env=environment,
         text=True,
-        timeout=15,
+        timeout=30,
         check=False,
     )
     assert result.returncode == 0, result.stderr

--- a/tests/unit_tests/data/datasets/test_gpt_sft.py
+++ b/tests/unit_tests/data/datasets/test_gpt_sft.py
@@ -13,6 +13,10 @@
 # limitations under the License.
 
 import json
+import os
+import subprocess
+import sys
+import textwrap
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -27,6 +31,46 @@ from megatron.bridge.data.datasets.gpt_sft import (
 )
 from megatron.bridge.data.packing.gpt_sft import GPTSFTPackedDataset
 from megatron.bridge.data.samplers import build_pretraining_data_loader
+
+
+def test_import_preserves_tokenizers_fork_safety():
+    """Importing the SFT dataset must not enable tokenizer parallelism across a fork."""
+    code = textwrap.dedent(
+        """
+        import multiprocessing
+
+        import megatron.bridge.data.datasets.gpt_sft
+        from tokenizers import Tokenizer
+        from tokenizers.models import WordPiece
+        from tokenizers.pre_tokenizers import Whitespace
+
+        tokenizer = Tokenizer(
+            WordPiece(vocab={"[UNK]": 0, "hello": 1, "world": 2}, unk_token="[UNK]")
+        )
+        tokenizer.pre_tokenizer = Whitespace()
+        batch = ["hello world"] * 4096
+        tokenizer.encode_batch(batch)
+
+        def encode_batch():
+            return len(tokenizer.encode_batch(batch))
+
+        with multiprocessing.get_context("fork").Pool(1) as pool:
+            result = pool.apply_async(encode_batch)
+            assert result.get(timeout=5) == len(batch)
+        """
+    )
+    environment = os.environ.copy()
+    environment.pop("TOKENIZERS_PARALLELISM", None)
+    environment["RAYON_NUM_THREADS"] = "2"
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        env=environment,
+        text=True,
+        timeout=15,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
 
 
 def create_mock_tokenizer():


### PR DESCRIPTION
# What does this PR do ?

Stop the GPT SFT dataset module from force-enabling Hugging Face tokenizer parallelism at import time, preserving the tokenizer library's fork-deadlock protection.

# Changelog

- Remove the process-wide TOKENIZERS_PARALLELISM=True import side effect from gpt_sft.
- Add a regression test that warms a fast tokenizer, forks a worker pool, and verifies batch encoding completes with bounded timeouts.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

Local validation:

- `uv run --no-sync pre-commit run --all-files` — passed.
- Minimal fork-pool harness — fixed code exits 0; the removed behavior reproducibly times out and exits 124.
- Targeted pytest collection is blocked on macOS arm64 because the pinned Megatron-Core imports Triton, which has no macOS wheel; the new test is intended to run in Linux CI.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation? (Not applicable; behavior-only fix.)
- [x] Does the PR affect components that are optional to install? (No.)
  - [x] Reviewer: Does the PR have correct import guards for all optional libraries? (Not applicable.)

# Additional Information

Fixes #5328
