### PR TITLE
[model] fix: handle null Gemma 4 global KV heads

### DIFF
--- a/src/megatron/bridge/models/gemma/gemma4_bridge.py
+++ b/src/megatron/bridge/models/gemma/gemma4_bridge.py
@@ -409,12 +409,14 @@ class Gemma4Bridge(MegatronModelBridge):
                 if layer_match and layer_types:
                     layer_idx = int(layer_match.group(1))
                     if layer_idx < len(layer_types) and layer_types[layer_idx] == "full_attention":
-                        num_kv_heads = getattr(
+                        num_global_kv_heads = getattr(
                             text_config,
                             "num_global_key_value_heads",
-                            getattr(self, "_dense_num_global_query_groups", num_kv_heads),
+                            getattr(self, "_dense_num_global_query_groups", None),
                         )
-                elif hasattr(self, "_dense_num_global_query_groups"):
+                        if num_global_kv_heads is not None:
+                            num_kv_heads = num_global_kv_heads
+                elif getattr(self, "_dense_num_global_query_groups", None) is not None:
                     num_kv_heads = self._dense_num_global_query_groups
                 kv_shape = (num_kv_heads * kv_head_dim, q_weight.shape[1])
                 k_zero = torch.zeros(kv_shape, dtype=q_weight.dtype, device=q_weight.device)

--- a/tests/unit_tests/models/gemma/test_gemma4_bridge.py
+++ b/tests/unit_tests/models/gemma/test_gemma4_bridge.py
@@ -435,6 +435,34 @@ class TestMaybeModifyLoadedHFWeight:
         assert result["k"].shape == (12, 8)
         assert result["v"].shape == (12, 8)
 
+    def test_kv_synthesis_uses_local_head_count_when_global_count_is_none(self, bridge):
+        bridge.hf_config = Gemma4TextConfig(
+            hidden_size=8,
+            intermediate_size=16,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_key_value_heads=1,
+            head_dim=2,
+            global_head_dim=4,
+            num_global_key_value_heads=None,
+            num_kv_shared_layers=1,
+            layer_types=["sliding_attention", "full_attention"],
+        )
+        q_weight = torch.randn(16, 8)
+        q_name = "model.layers.1.self_attn.q_proj.weight"
+        hf_param = {
+            "q": q_name,
+            "k": "model.layers.1.self_attn.k_proj.weight",
+            "v": "model.layers.1.self_attn.v_proj.weight",
+        }
+
+        result = bridge.maybe_modify_loaded_hf_weight(hf_param, {q_name: q_weight})
+
+        assert result["k"].shape == (4, 8)
+        assert result["v"].shape == (4, 8)
+        assert torch.count_nonzero(result["k"]) == 0
+        assert torch.count_nonzero(result["v"]) == 0
+
     def test_kv_passthrough_when_v_present(self, bridge):
         sd = self._make_sd()
         sd["model.layers.0.self_attn.v_proj.weight"] = torch.randn(4, 8)


### PR DESCRIPTION
## What does this PR do?

Fixes Gemma 4 HF-to-Megatron import for valid shared-KV checkpoints whose config leaves `num_global_key_value_heads` as `null`.

Transformers defines that null value as falling back to `num_key_value_heads`. Its standard `save_pretrained()` output also omits K/V modules on shared-KV layers. When such a local E2B/E4B directory reached Bridge's missing-K/V synthesis hook on a full-attention shared layer, Bridge replaced the valid local KV count with `None` and crashed while constructing the placeholder tensor shape.

The fix keeps the already-selected local KV count when the optional global override is null, while preserving explicit numeric global counts. The focused regression uses a real `Gemma4TextConfig`, a Q-only full-attention shared layer, and verifies correctly shaped zero K/V placeholders.

## Validation

Fail-before on the unmodified base:

```text
uv run --no-sync python -m pytest tests/unit_tests/models/gemma/test_gemma4_bridge.py::TestMaybeModifyLoadedHFWeight::test_kv_synthesis_uses_local_head_count_when_global_count_is_none -q
1 failed: TypeError: unsupported operand type(s) for *: 'NoneType' and 'int'
```

Pass-after:

```text
uv run --no-sync python -m pytest tests/unit_tests/models/gemma/test_gemma4_bridge.py::TestMaybeModifyLoadedHFWeight::test_kv_synthesis_uses_local_head_count_when_global_count_is_none -q
1 passed

uv run --no-sync python -m pytest tests/unit_tests/models/gemma/test_gemma4_bridge.py::TestMaybeModifyLoadedHFWeight -q
9 passed

uv run --no-sync python -m pytest tests/unit_tests/models/gemma/test_gemma4_bridge.py -q
66 passed

uv run --no-sync python -m pytest tests/unit_tests/models/gemma/test_gemma4_provider.py tests/unit_tests/models/gemma_vl/test_gemma4_vl_bridge.py -q
171 passed

git diff --check
passed

uv run --no-sync pre-commit run --all-files
all hooks passed
```

## Scope

- No public API, dependency, workflow, lockfile, or Megatron-Core changes.
- This validates the conversion hook and adjacent provider/VL contracts on CPU; it does not claim full-model GPU parity, convergence, or performance validation.
- Original published shards that retain extra K/V tensors do not enter the affected missing-weight branch; the fix targets standard re-saves and other valid Q-only shared-layer directories.
