### PR TITLE
[ckpt] fix: Deinterleave low-memory GLU checkpoints

### DIFF
--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -1250,25 +1250,20 @@ def save_checkpoint(
             "converting to contiguous format for checkpoint"
         )
     if routed_interleave_size is not None or shared_interleave_size is not None:
-        if len(model) == 1:
-            state_dict["model"] = _process_state_dict_for_model_glu_interleaving(
-                state_dict["model"],
+        use_megatron_fsdp = cfg.ddp is not None and cfg.ddp.use_megatron_fsdp
+        model_keys = (
+            ["model"]
+            if "model" in state_dict
+            else sorted(key for key in state_dict if key.startswith("model") and key.removeprefix("model").isdigit())
+        )
+        for model_key in model_keys:
+            state_dict[model_key] = _process_state_dict_for_model_glu_interleaving(
+                state_dict[model_key],
                 routed_interleave_size,
                 shared_interleave_size,
                 interleave=False,
-                use_megatron_fsdp=cfg.ddp.use_megatron_fsdp,
+                use_megatron_fsdp=use_megatron_fsdp,
             )
-        else:
-            for i in range(len(model)):
-                model_key = "model%d" % i
-                if model_key in state_dict:
-                    state_dict[model_key] = _process_state_dict_for_model_glu_interleaving(
-                        state_dict[model_key],
-                        routed_interleave_size,
-                        shared_interleave_size,
-                        interleave=False,
-                        use_megatron_fsdp=cfg.ddp.use_megatron_fsdp,
-                    )
 
     # Apply PEFT filtering to preserve the existing adapter-only Megatron
     # checkpoint behavior.  ``also_save_hf_checkpoint=True`` only adds the
@@ -2482,6 +2477,20 @@ def _process_state_dict_for_glu_interleaving(
             new_data = _apply_glu_interleave_to_tensor_data(value.data, interleave_size, interleave)
             # Interleaving permutes elements; local shape unchanged. Preserve global sharding metadata.
             processed_state_dict[key] = replace(value, data=new_data, local_shape=new_data.shape)
+            num_keys_processed += 1
+            continue
+
+        if isinstance(value, list) and value and all(isinstance(shard, ShardedTensor) for shard in value):
+            if any(shard.data is None for shard in value):
+                processed_state_dict[key] = value
+                continue
+            shard_sizes = [shard.data.shape[0] for shard in value]
+            data = torch.cat([shard.data for shard in value], dim=0)
+            new_data = _apply_glu_interleave_to_tensor_data(data, interleave_size, interleave)
+            processed_state_dict[key] = [
+                replace(shard, data=shard_data, local_shape=shard_data.shape)
+                for shard, shard_data in zip(value, new_data.split(shard_sizes, dim=0))
+            ]
             num_keys_processed += 1
             continue
 

--- a/tests/unit_tests/training/test_model_load_save.py
+++ b/tests/unit_tests/training/test_model_load_save.py
@@ -1062,6 +1062,87 @@ class TestSaveMegatronModel:
             callback_manager=None,
         )
 
+    def test_low_memory_save_deinterleaves_expanded_glu_factory(self, tmp_path):
+        """Low-memory save must persist canonical contiguous SwiGLU weights."""
+        from megatron.core.dist_checkpointing.mapping import ShardedTensor, ShardedTensorFactory
+
+        from megatron.bridge.training.checkpointing import _interleave_glu_tensor
+
+        interleave_size = 2
+        key = "decoder.layers.0.mlp.experts.local_experts.0.linear_fc1.weight"
+        contiguous_weight = torch.arange(32, dtype=torch.float32).reshape(8, 4)
+        runtime_weight = _interleave_glu_tensor(contiguous_weight, interleave_size)
+
+        module = torch.nn.Module()
+        module.register_parameter("linear_fc1_weight", torch.nn.Parameter(runtime_weight.clone()))
+        models = [module]
+
+        provider = GPTModelProvider(num_layers=1, hidden_size=8, num_attention_heads=1)
+        provider.moe_mlp_glu_interleave_size = interleave_size
+
+        def build_factory(
+            factory_key: str,
+            data: torch.Tensor,
+            replica_id: int,
+            flattened_range: slice | None,
+        ) -> list[ShardedTensor]:
+            assert flattened_range is None
+            return [
+                ShardedTensor.from_rank_offsets(factory_key, chunk, replica_id=replica_id)
+                for chunk in torch.chunk(data, 2, dim=0)
+            ]
+
+        factory = ShardedTensorFactory(
+            key=key,
+            data=module.linear_fc1_weight.data,
+            build_fn=build_factory,
+            merge_fn=lambda shards: torch.cat([shard.data for shard in shards], dim=0),
+        )
+        generated_state = {"model": {key: factory}}
+
+        pg_collection = Mock()
+        pg_collection.dp_cp = Mock()
+        pg_collection.tp.rank.return_value = 0
+        pg_collection.tp.size.return_value = 1
+        pg_collection.pp.rank.return_value = 0
+        pg_collection.pp.size.return_value = 1
+
+        rerun_state_machine = Mock()
+        rerun_state_machine.state_dict.return_value = {}
+        captured_state = {}
+
+        def capture_distributed_save(state_dict, *args, **kwargs):
+            captured_state.update(state_dict)
+            return None
+
+        with (
+            patch("megatron.bridge.training.model_load_save.get_model_config", return_value=provider),
+            patch("megatron.bridge.training.checkpointing.generate_state_dict", return_value=generated_state),
+            patch("megatron.bridge.training.checkpointing.get_rng_state", return_value=None),
+            patch("megatron.bridge.training.checkpointing.get_rerun_state_machine", return_value=rerun_state_machine),
+            patch("megatron.bridge.training.utils.pg_utils.get_pg_collection", return_value=pg_collection),
+            patch(
+                "megatron.bridge.training.checkpointing.dist_checkpointing.save", side_effect=capture_distributed_save
+            ),
+            patch("megatron.bridge.training.checkpointing.TorchDistSaveShardedStrategy", return_value=Mock()),
+            patch("megatron.bridge.training.checkpointing.FullyParallelSaveStrategyWrapper", return_value=Mock()),
+            patch("megatron.bridge.training.checkpointing.maybe_save_dataloader_state"),
+            patch("megatron.bridge.training.checkpointing.ensure_directory_exists"),
+            patch("megatron.bridge.training.checkpointing.fault_tolerance"),
+            patch("megatron.bridge.training.checkpointing.is_empty_async_queue", return_value=True),
+            patch("megatron.bridge.training.checkpointing.get_rank_safe", return_value=1),
+            patch("megatron.bridge.training.checkpointing.is_last_rank", return_value=False),
+            patch("megatron.bridge.training.checkpointing.print_rank_0"),
+            patch("torch.distributed.is_initialized", return_value=True),
+            patch("torch.distributed.get_rank", return_value=1),
+            patch("torch.distributed.barrier"),
+        ):
+            save_megatron_model(models, tmp_path, low_memory_save=True)
+
+        serialized_shards = captured_state["model"][key]
+        serialized_weight = torch.cat([shard.data for shard in serialized_shards], dim=0)
+        assert torch.equal(serialized_weight, contiguous_weight)
+
 
 class TestDtypeFromStr:
     """Test dtype_from_str function."""


### PR DESCRIPTION
## What changed

Low-memory `torch_dist` checkpoint saves now de-interleave configured GLU FC1 weights before serialization, including the `list[ShardedTensor]` representation produced when `ShardedTensorFactory` values are expanded.

## User impact

`save_megatron_model(..., low_memory_save=True)` clears the model list after building the sharded state dictionary. For providers with `moe_mlp_glu_interleave_size` or `moe_shared_expert_glu_interleave_size`, checkpoint normalization previously selected model state entries from that now-empty list and processed none. The saved checkpoint therefore retained runtime-interleaved FC1 rows. Loading it applied the expected checkpoint-to-runtime interleave again, silently permuting expert weights.

The same public path is used by `AutoBridge.save_megatron_model()`, `AutoBridge.import_ckpt()`, and GPU import with low-memory save when the provider enables GLU interleaving.

## Root cause and fix

The save path now discovers `model` or numeric `modelN` entries from the state dictionary itself instead of relying on the live model-list length. Expanded GLU factory shards are concatenated in factory order, transformed once, and split back at their original row boundaries while preserving the existing sharding metadata. Standalone saves with `ddp=None` are treated as non-FSDP.

## Validation

Fail before / pass after with the unchanged regression test:

```text
uv run --active --no-sync python -m pytest tests/unit_tests/training/test_model_load_save.py::TestSaveMegatronModel::test_low_memory_save_deinterleaves_expanded_glu_factory -q --tb=short

Before: 1 failed — serialized rows remained runtime-interleaved
After:  1 passed
```

Adjacent checkpoint coverage:

```text
uv run --active --no-sync python -m pytest tests/unit_tests/training/test_model_load_save.py tests/unit_tests/training/test_glu_fc1_checkpoint_round_trip.py -q
70 passed
```

Quality gates:

```text
git diff --check
Passed

uv run pre-commit run --all-files
Passed
```

## Scope

This change is limited to checkpoint GLU layout normalization. It does not change public APIs, checkpoint formats, non-GLU weights, or FSDP DTensor behavior. MegatronMIMO continues to reject low-memory save as before.
