### PR TITLE
fix(misc): accept greedy token-count wording

### DIFF
--- a/skills/create-model-verification-card/scripts/validate_card.py
+++ b/skills/create-model-verification-card/scripts/validate_card.py
@@ -1172,7 +1172,7 @@ def _validate_inference(
     if token_count_text not in expected:
         errors.append(f"{_pointer(*path, 'expected_result')}: state the {token_count_text}-token maximum")
     actual_count_patterns = (
-        r"\bexact(?:ly)?\s+(\d+)(?:-token|\s+(?:new\s+|generated\s+)?tokens?|\s+generation\s+steps?)\b",
+        r"\bexact(?:ly)?\s+(\d+)(?:-token|\s+(?:new\s+|generated\s+)?(?:greedy\s+)?tokens?|\s+generation\s+steps?)\b",
         r"\b(\d+)-token\s+(?:greedy\s+)?(?:result|output|completion|completions)\b",
         r"\b(?:generated|produced|returned?)\s+(?:exactly\s+)?(\d+)\s+(?:new\s+|generated\s+)?tokens?\b",
         r"\bafter\s+(\d+)\s+(?:new\s+|generated\s+)?tokens?\b",

--- a/tests/unit_tests/skills/create_model_verification_card/test_validate_card.py
+++ b/tests/unit_tests/skills/create_model_verification_card/test_validate_card.py
@@ -3,6 +3,8 @@
 """Focused tests for model-verification-card validation."""
 
 import importlib.util
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -19,6 +21,22 @@ def _load_validator():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
+
+
+def test_shipped_greedy_inference_cards_validate():
+    cards = [
+        REPO_ROOT / "examples" / "model_verification_cards" / model / "card.yaml" for model in ("glm5-2", "kimi-k3")
+    ]
+
+    result = subprocess.run(
+        [sys.executable, str(VALIDATOR_PATH), *(str(card) for card in cards)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
 
 
 def test_manual_forward_accepts_inference_launcher():


### PR DESCRIPTION
# What does this PR do ?

Accept deterministic inference results that state the actual generated-token count as new greedy tokens.

# Changelog

- Allow an optional greedy descriptor in the exact generated-token count wording.
- Add focused CLI regression coverage that invokes the validator on the shipped GLM-5.2 and Kimi-K3 cards.
- Preserve the existing maximum, single-count, EOS, and literal-completion validation.

# GitHub Actions CI

- uv run --no-project python -m pytest --confcutdir=tests/unit_tests/skills/create_model_verification_card tests/unit_tests/skills/create_model_verification_card/test_validate_card.py -q (18 passed)
- uv run --no-project python -m pytest --confcutdir=tests/unit_tests/scripts tests/unit_tests/scripts/test_validate_model_verification_card.py -q (15 passed)
- uv run --no-project pre-commit run --all-files

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation? No documentation change is needed for this validator compatibility fix.
- [x] Does the PR affect components that are optional to install? No.

# Additional Information

- Related to NVBug 6565518.