### PR TITLE
fix(modelopt): handle sparse export task lists

### DIFF
--- a/src/megatron/bridge/models/conversion/modelopt_utils.py
+++ b/src/megatron/bridge/models/conversion/modelopt_utils.py
@@ -477,7 +477,7 @@ def _build_hf_modelopt_pre_ep_quant_metadata(
 
 
 def collect_modelopt_quant_metadata(
-    conversion_tasks: list[WeightConversionTask],
+    conversion_tasks: list[WeightConversionTask | None],
 ) -> dict[str, QuantMeta]:
     """Collect ModelOpt quantization metadata from conversion task modules."""
     from modelopt.torch.export import quant_utils
@@ -492,7 +492,7 @@ def collect_modelopt_quant_metadata(
     metadata: dict[str, QuantMeta] = {}
     quantizer_metadata: dict[tuple[int, int, str, int], QuantMeta | None] = {}
     for task in conversion_tasks:
-        if task.megatron_module is None or task.param_weight is None:
+        if task is None or task.megatron_module is None or task.param_weight is None:
             continue
 
         weight_quantizer, quant_module = find_modelopt_weight_quantizer_and_module(
@@ -1018,7 +1018,7 @@ def _compose_export_hooks(exporter: HFExportHook, finalizer: HFExportHook | None
 
 
 def build_modelopt_export_plan(
-    conversion_tasks: list[WeightConversionTask],
+    conversion_tasks: list[WeightConversionTask | None],
     *,
     model: list[torch.nn.Module],
     bridge: "MegatronModelBridge",
@@ -1029,6 +1029,9 @@ def build_modelopt_export_plan(
     expected_qformat, export_weight = get_modelopt_quant_exporter(quant_mode)
     pg_collection = model_bridge_utils._get_pg_collection_from_model(model)
     local_metadata = collect_modelopt_quant_metadata(conversion_tasks)
+    # ``None`` slots represent global names without conversion tasks. They are
+    # not termination sentinels, so retain every concrete task after a hole.
+    concrete_tasks: list[WeightConversionTask] = [task for task in conversion_tasks if task is not None]
     if torch.distributed.is_initialized():
         pp_group = model_bridge_utils._get_pp_group(model)
         ep_group = model_bridge_utils._get_ep_group(model)
@@ -1049,7 +1052,7 @@ def build_modelopt_export_plan(
     candidate_mappings: dict[int, Any] = {}
     candidate_groups: dict[str, list[int]] = {}
     eligible_groups: dict[str, bool] = {}
-    for task_idx, task in enumerate(conversion_tasks):
+    for task_idx, task in enumerate(concrete_tasks):
         candidate = _modelopt_pre_ep_mapping(task.mapping, pg_collection) if can_export_before_ep else None
         if candidate is None:
             continue
@@ -1078,7 +1081,7 @@ def build_modelopt_export_plan(
             if valid_expert_layout:
                 try:
                     for task_idx in task_indices:
-                        candidate_task = conversion_tasks[task_idx]
+                        candidate_task = concrete_tasks[task_idx]
                         local_ids.append(
                             extract_expert_number_from_param(candidate_task.param_name) % experts_per_rank
                         )
@@ -1097,19 +1100,19 @@ def build_modelopt_export_plan(
             for group_key in all_group_keys
         }
 
-    mapped_tasks = list(conversion_tasks)
+    mapped_tasks = list(concrete_tasks)
     for group_key, task_indices in candidate_groups.items():
         if not eligible_groups[group_key]:
             continue
         for task_idx in task_indices:
             mapped_tasks[task_idx] = replace(
-                conversion_tasks[task_idx],
+                concrete_tasks[task_idx],
                 mapping=candidate_mappings[task_idx],
             )
 
     regular_metadata_tasks: list[WeightConversionTask] = []
     pre_ep_tasks: list[WeightConversionTask] = []
-    for original_task, mapped_task in zip(conversion_tasks, mapped_tasks, strict=True):
+    for original_task, mapped_task in zip(concrete_tasks, mapped_tasks, strict=True):
         if getattr(mapped_task.mapping, "is_modelopt_pre_ep_export", False):
             pre_ep_tasks.append(mapped_task)
         else:

--- a/tests/unit_tests/models/test_model_bridge.py
+++ b/tests/unit_tests/models/test_model_bridge.py
@@ -18,7 +18,10 @@ from unittest.mock import Mock
 
 import pytest
 import torch
+from transformers import PretrainedConfig
 
+from megatron.bridge.models.conversion import model_bridge as model_bridge_module
+from megatron.bridge.models.conversion import modelopt_utils
 from megatron.bridge.models.conversion.mapping_registry import MegatronMappingRegistry
 from megatron.bridge.models.conversion.model_bridge import HFWeightTuple, MegatronModelBridge, WeightConversionTask
 from megatron.bridge.models.conversion.param_mapping import AutoMapping
@@ -30,6 +33,59 @@ class DummyBridge(MegatronModelBridge):
 
     def mapping_registry(self):  # pragma: no cover - not used in tests
         return MegatronMappingRegistry()
+
+
+def test_modelopt_plan_skips_unmapped_task_slot_and_keeps_later_task(monkeypatch):
+    first_name = "first.weight"
+    unmapped_name = "unmapped.amax"
+    last_name = "last.weight"
+
+    class MappedBridge(DummyBridge):
+        def mapping_registry(self):
+            return MegatronMappingRegistry(
+                AutoMapping(first_name, "hf.first.weight"),
+                AutoMapping(last_name, "hf.last.weight"),
+            )
+
+    model = torch.nn.Module()
+    model.config = SimpleNamespace(share_embeddings_and_output_weights=False)
+    model.first = torch.nn.Linear(1, 1, bias=False)
+    model.unmapped = torch.nn.Module()
+    model.unmapped.register_buffer("amax", torch.ones(1))
+    model.last = torch.nn.Linear(1, 1, bias=False)
+    bridge = MappedBridge()
+    global_names = [first_name, unmapped_name, last_name]
+
+    monkeypatch.setattr(bridge, "_megatron_global_param_names_all_pp_ranks", lambda _model: global_names)
+    monkeypatch.setattr(bridge, "_share_embeddings_and_output_weights", lambda _config: False)
+    monkeypatch.setattr(model_bridge_module, "unwrap_model", lambda _model: [model])
+    monkeypatch.setattr(model_bridge_module, "_get_pg_collection_from_model", lambda _model: None)
+    monkeypatch.setattr(model_bridge_module, "_get_pp_rank", lambda _model: 0)
+    monkeypatch.setattr(
+        model_bridge_module,
+        "_megatron_local_name_to_global",
+        lambda _models, _config, local_name, _vp_stage: local_name,
+    )
+
+    tasks = bridge.build_conversion_tasks(PretrainedConfig(), [model])
+
+    assert tasks[0].global_param_name == first_name
+    assert tasks[1] is None
+    assert tasks[2].global_param_name == last_name
+
+    monkeypatch.setattr(modelopt_utils, "get_modelopt_quant_exporter", lambda _mode: ("unused", lambda *_args: ()))
+    monkeypatch.setattr(modelopt_utils, "get_pg_size", lambda _group: 1)
+    monkeypatch.setattr(modelopt_utils.model_bridge_utils, "_get_pg_collection_from_model", lambda _model: None)
+
+    export_tasks = modelopt_utils.build_modelopt_export_plan(
+        tasks,
+        model=[model],
+        bridge=bridge,
+        quant_mode="nvfp4",
+        ignore_patterns=[],
+    )
+
+    assert [task.global_param_name for task in export_tasks] == [first_name, last_name]
 
 
 def test_hf_weight_tuple_iter_finalized_preserves_two_field_abi():


### PR DESCRIPTION
## Summary

- preserve the existing sparse `build_conversion_tasks` contract and leave non-ModelOpt conversion paths unchanged
- restore the ModelOpt metadata guard for `None` task slots
- materialize concrete tasks once at the ModelOpt export-plan boundary, retaining every real task after a sparse hole
- add a real producer-to-consumer regression covering `mapped -> unmapped -> mapped`

This fixes NVBug 6565708.

## Root cause

`build_conversion_tasks` preserves the shared pipeline-parallel name order and may leave `None` for a global name without a conversion mapping. Existing callers such as the MIMO orchestrator explicitly recognize that sentinel.

#4566 narrowed the ModelOpt helper types and removed the existing `task is None` guard without changing the producer. The new export-plan prepass therefore dereferenced a sparse slot before normal export processing.

The fix restores the sentinel handling removed by #4566 and converts the sparse list to concrete ModelOpt tasks once before indexing, mapping, and hook construction. It does not catch `AttributeError`, alter the producer, or change other conversion paths.

## Tests

- `uv run python -m pytest tests/unit_tests/models/test_model_bridge.py tests/unit_tests/models/test_modelopt_utils.py` (85 passed)
- focused red check reproduces `AttributeError` at `task.megatron_module` without the sentinel fix
- `uv run pre-commit run --all-files`