### PR TITLE
fix(peft): preserve grouped expert SwiGLU LoRA order

### DIFF
--- a/src/megatron/bridge/peft/utils.py
+++ b/src/megatron/bridge/peft/utils.py
@@ -1621,18 +1621,6 @@ def _apply_grouped_expert_swiglu_sharded_factory(
         ]
 
     def sh_ten_merge_fn(sub_state_dict):
-        if not singleton_local_shards and len(sub_state_dict) > 1:
-            # Dist checkpoint load reconstructs one local fused shard per expert-TP
-            # rank, so the incoming tensors look like [gate_0|up_0, gate_1|up_1, ...].
-            # Restore the fused [gate_0, gate_1, ..., up_0, up_1, ...] layout before
-            # concatenating back along the SwiGLU axis.
-            gate_parts = []
-            up_parts = []
-            for tensor in sub_state_dict:
-                gate_part, up_part = torch.chunk(tensor, 2, dim=swiglu_shard_axis)
-                gate_parts.append(gate_part)
-                up_parts.append(up_part)
-            sub_state_dict = [*gate_parts, *up_parts]
         try:
             return torch.cat(sub_state_dict, dim=swiglu_shard_axis)
         except (RuntimeError, torch.cuda.OutOfMemoryError) as exc:

--- a/tests/unit_tests/peft/test_utils.py
+++ b/tests/unit_tests/peft/test_utils.py
@@ -2199,32 +2199,49 @@ class TestGroupedExpertLinearAdapter:
         assert built[0].global_offset == (2, 0, 0)
         assert built[1].global_offset == (2, 2, 0)
 
-    def test_grouped_expert_linear_fc1_factory_merge_restores_gate_up_order(self):
-        """Grouped expert fc1 checkpoint reload should de-interleave gate/up expert-TP shards."""
+    @pytest.mark.parametrize("etp_size", [1, 2])
+    def test_grouped_expert_linear_fc1_factory_merge_preserves_gate_up_and_expert_order(self, etp_size):
+        """Grouped expert fc1 checkpoint reload should preserve exact adapter weight ordering."""
         config = MockModelParallelConfig()
         config.gated_linear_unit = True
-        config._pg_collection = make_mock_pg_collection(ep_size=1, ep_rank=0, edp_rank=0, etp_size=2, etp_rank=0)
+        config._pg_collection = make_mock_pg_collection(
+            ep_size=1,
+            ep_rank=0,
+            edp_rank=0,
+            etp_size=etp_size,
+            etp_rank=0,
+        )
         adapter = GroupedExpertLinearAdapter(
             in_features=2,
             out_features=8,
             dim=2,
-            num_local_experts=1,
+            num_local_experts=2,
             base_linear_name="decoder.layers.0.mlp.experts.linear_fc1",
             activation="identity",
             input_is_parallel=False,
             model_parallel_config=config,
         )
 
+        expert = torch.arange(2).reshape(2, 1, 1) * 1000
+        local_rows = adapter.linear_out.weight.shape[1]
+        gate_rows = local_rows // 2
+        projection = torch.tensor([0] * gate_rows + [1] * gate_rows).reshape(1, local_rows, 1) * 100
+        row = torch.arange(gate_rows).repeat(2).reshape(1, local_rows, 1) * 10
+        column = torch.arange(2).reshape(1, 1, 2)
+        expected = (expert + projection + row + column).to(adapter.linear_out.weight)
+        with torch.no_grad():
+            adapter.linear_out.weight.copy_(expected)
+
         factory = adapter.sharded_state_dict("adapter.")["adapter.linear_out.weight"]
+        built = factory.build()
 
-        fused_tp0 = torch.tensor([[[1.0, 1.0], [1.0, 1.0], [2.0, 2.0], [2.0, 2.0]]])
-        fused_tp1 = torch.tensor([[[3.0, 3.0], [3.0, 3.0], [4.0, 4.0], [4.0, 4.0]]])
+        assert len(built) == 2
+        torch.testing.assert_close(built[0].data, expected[:, :gate_rows], rtol=0, atol=0)
+        torch.testing.assert_close(built[1].data, expected[:, gate_rows:], rtol=0, atol=0)
 
-        merged = factory.merge_fn([fused_tp0, fused_tp1])
-        expected = torch.tensor(
-            [[[1.0, 1.0], [1.0, 1.0], [3.0, 3.0], [3.0, 3.0], [2.0, 2.0], [2.0, 2.0], [4.0, 4.0], [4.0, 4.0]]]
-        )
-        torch.testing.assert_close(merged, expected)
+        merged = factory.merge_fn([shard.data for shard in built])
+
+        torch.testing.assert_close(merged, expected, rtol=0, atol=0)
 
     @pytest.mark.parametrize(
         ("ep_size", "tp_size", "etp_size", "expected_allreduce"),


### PR DESCRIPTION
# What does this PR do?

Preserves exact per-expert LoRA tensor ordering when gated grouped-expert `linear_fc1` adapters are loaded from distributed checkpoints. Related to NVBug 6565837.

# Changelog

- Remove a second gate/up de-interleave from the PEFT grouped-expert SwiGLU merge callback. Its build callback already emits pure gate and pure up shards in merge order.
- Replace the synthetic fused-shard merge test with an exact build-to-merge identity regression for two experts at ETP=1 and ETP=2.
- Keep the change scoped to `megatron.bridge.peft`; generic checkpoint code and checkpoint formats are unchanged.

# Root cause and PR #5366

The factory build callback splits each local fused `[gate|up]` tensor into pure gate and up `ShardedTensor` values. The merge callback incorrectly split those pure tensors again, moving the middle two quarters of each expert's fused axis.

Merged PR #5366 does not affect this path. It changes low-memory GLU normalization in `training/checkpointing.py`; this defect is in the separate PEFT factory in `peft/utils.py`.

# Validation

The unchanged regression failed on current `main` before the fix with 16 of 32 elements moved (50%) and passed after the fix. The deterministic tensor labels encode expert, gate/up projection, row, and column independently.

```text
uv run python -m pytest tests/unit_tests/peft/test_utils.py -k grouped_expert_linear_fc1 -q --tb=short
3 passed, 99 deselected

Two-rank EP=2 distributed checkpoint save/load with exact tensor equality
Passed

uv run pre-commit run --all-files
Passed
```

# GitHub Actions CI

Draft PR; CI can be triggered after review.

# Before your PR is "Ready for review"

- [x] Read and followed the contributor guidelines.
- [x] Added focused red-to-green regression coverage.
- [x] Documentation changes are not needed for this internal checkpoint mapping correction.
- [x] No optional dependency behavior is changed.

# Additional Information

- NVBug 6565837
