### PR TITLE
fix(model): map YARN fields to GPT model config

### DIFF
--- a/src/megatron/bridge/models/gpt_oss/gpt_oss_bridge.py
+++ b/src/megatron/bridge/models/gpt_oss/gpt_oss_bridge.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, Mapping, Optional, Tuple, Union
+from typing import Any, Dict, Mapping, Optional, Tuple, Union
 
 import torch
 import torch.nn as nn
@@ -28,8 +28,6 @@ from megatron.bridge.models.conversion.param_mapping import (
 )
 from megatron.bridge.models.conversion.quantization_utils import dequantize_mxfp4 as _dequantize_mxfp4
 from megatron.bridge.models.conversion.utils import get_module_and_param_from_name
-from megatron.bridge.models.gpt_provider import GPTModelProvider
-from megatron.bridge.models.hf_pretrained.causal_lm import PreTrainedCausalLM
 from megatron.bridge.utils.common_utils import extract_expert_number_from_param
 
 
@@ -53,53 +51,40 @@ class GPTOSSBridge(MegatronModelBridge):
         >>> provider = bridge.to_megatron_provider()
     """
 
-    def provider_bridge(self, hf_pretrained: PreTrainedCausalLM) -> GPTModelProvider:
-        """Convert HuggingFace config to GPTModelProvider."""
-        provider = super().provider_bridge(hf_pretrained)
+    def hf_config_to_model_config_kwargs(self, hf_config: Any) -> dict[str, Any]:
+        """Convert a Hugging Face GPT-OSS config to builder config kwargs."""
+        config_kwargs = super().hf_config_to_model_config_kwargs(hf_config)
+        config_kwargs.update(
+            normalization="RMSNorm",
+            gated_linear_unit=True,
+            add_bias_linear=True,
+            add_qkv_bias=False,
+            share_embeddings_and_output_weights=False,
+            position_embedding_type="yarn",
+            moe_router_pre_softmax=False,
+            moe_grouped_gemm=True,
+            moe_token_dispatcher_type="alltoall",
+            moe_permute_fusion=True,
+            moe_router_load_balancing_type="none",
+            bias_activation_fusion=True,
+            bias_dropout_fusion=False,
+            hidden_dropout=0.0,
+            fp16=False,
+            bf16=True,
+            params_dtype=torch.bfloat16,
+            activation_func=quick_gelu,
+            activation_func_clamp_value=7.0,
+            glu_linear_offset=1.0,
+            softmax_type="learnable",
+            window_size=(hf_config.sliding_window - 1, 0),
+            window_attn_skip_freq=2,
+            moe_ffn_hidden_size=hf_config.intermediate_size,
+        )
+        return config_kwargs
 
-        provider.normalization = "RMSNorm"
-        provider.gated_linear_unit = True
-        provider.add_bias_linear = True
-        provider.add_qkv_bias = False
-        provider.share_embeddings_and_output_weights = False
-        provider.position_embedding_type = "yarn"
-
-        provider.moe_router_pre_softmax = False
-        provider.moe_grouped_gemm = True
-        provider.moe_token_dispatcher_type = "alltoall"
-        provider.moe_permute_fusion = True
-        provider.moe_router_load_balancing_type = "none"
-
-        provider.bias_activation_fusion = True
-        provider.bias_dropout_fusion = False
-
-        provider.hidden_dropout = 0.0
-        provider.fp16 = False
-        provider.bf16 = True
-        provider.params_dtype = torch.bfloat16
-
-        # GPT-OSS specific activation
-        provider.activation_func = quick_gelu
-        provider.activation_func_clamp_value = 7.0
-        provider.glu_linear_offset = 1.0
-
-        provider.softmax_type = "learnable"
-        provider.window_size = (hf_pretrained.config.sliding_window - 1, 0)
-        provider.window_attn_skip_freq = 2
-
-        # GPT-OSS uses intermediate_size for MoE FFN hidden size
-        provider.moe_ffn_hidden_size = hf_pretrained.config.intermediate_size
-
-        # YARN position embedding settings (now dataclass fields on GPTModelProvider)
-        provider.yarn_rotary_scaling_factor = 32.0
-        provider.yarn_original_max_position_embeddings = 4096
-        provider.yarn_beta_fast = 32.0
-        provider.yarn_beta_slow = 1.0
-        provider.yarn_correction_range_round_to_int = False
-        provider.yarn_mscale = None
-        provider.yarn_mscale_all_dim = None
-
-        return provider
+    def hf_config_to_provider_kwargs(self, hf_config: Any) -> dict[str, Any]:
+        """Adapt the canonical builder mapping to the deprecated provider path."""
+        return self.hf_config_to_model_config_kwargs(hf_config)
 
     def maybe_modify_loaded_hf_weight(
         self, hf_param: str | dict[str, str], hf_state_dict: Mapping[str, torch.Tensor]

--- a/src/megatron/bridge/models/transformer_config.py
+++ b/src/megatron/bridge/models/transformer_config.py
@@ -152,6 +152,15 @@ class TransformerConfig(MCoreTransformerConfig):
         config.finalize()
     """
 
+    # YARN position embedding parameters consumed from the nested config by MCore GPTModel.
+    yarn_rotary_scaling_factor: float | None = None
+    yarn_original_max_position_embeddings: int | None = None
+    yarn_beta_fast: float | None = None
+    yarn_beta_slow: float | None = None
+    yarn_mscale: float | None = None
+    yarn_mscale_all_dim: float | None = None
+    yarn_correction_range_round_to_int: bool | None = None
+
     _NO_COPY_KEYS = {"_pg_collection"}
 
     def __post_init__(self) -> None:

--- a/tests/unit_tests/models/gpt_oss/test_gpt_oss_bridges.py
+++ b/tests/unit_tests/models/gpt_oss/test_gpt_oss_bridges.py
@@ -17,7 +17,9 @@ from unittest.mock import Mock
 
 import pytest
 import torch
+from transformers import GptOssConfig
 
+from megatron.bridge.models.conversion.auto_bridge import AutoBridge
 from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge
 from megatron.bridge.models.gpt_oss.gpt_oss_bridge import GPTOSSBridge
 from megatron.bridge.models.gpt_provider import GPTModelProvider
@@ -67,3 +69,54 @@ class TestGptOssBridge:
         # dtype mapping
         assert provider.bf16 is True
         assert provider.params_dtype == torch.bfloat16
+
+    def test_autobridge_model_config_preserves_yarn_fields(self):
+        config = GptOssConfig(architectures=["GptOssForCausalLM"])
+        bridge = AutoBridge.from_hf_config(config)
+
+        with pytest.warns(FutureWarning, match="get_model_config"):
+            provider = bridge.to_megatron_provider(load_weights=False)
+        model_config = bridge.get_model_config()
+
+        aligned_fields = (
+            "normalization",
+            "gated_linear_unit",
+            "add_bias_linear",
+            "add_qkv_bias",
+            "share_embeddings_and_output_weights",
+            "position_embedding_type",
+            "moe_router_pre_softmax",
+            "moe_grouped_gemm",
+            "moe_token_dispatcher_type",
+            "moe_permute_fusion",
+            "moe_router_load_balancing_type",
+            "bias_activation_fusion",
+            "bias_dropout_fusion",
+            "hidden_dropout",
+            "fp16",
+            "bf16",
+            "params_dtype",
+            "activation_func",
+            "activation_func_clamp_value",
+            "glu_linear_offset",
+            "softmax_type",
+            "window_size",
+            "window_attn_skip_freq",
+            "moe_ffn_hidden_size",
+        )
+        assert {name: getattr(model_config, name) for name in aligned_fields} == {
+            name: getattr(provider, name) for name in aligned_fields
+        }
+
+        expected_yarn_fields = {
+            "yarn_rotary_scaling_factor": 32.0,
+            "yarn_original_max_position_embeddings": 4096,
+            "yarn_beta_fast": 32.0,
+            "yarn_beta_slow": 1.0,
+            "yarn_mscale": None,
+            "yarn_mscale_all_dim": None,
+            "yarn_correction_range_round_to_int": False,
+        }
+        assert {name: getattr(provider, name) for name in expected_yarn_fields} == expected_yarn_fields
+        assert {name: getattr(model_config.transformer, name) for name in expected_yarn_fields} == expected_yarn_fields
+        assert all(name not in model_config.__dict__ for name in expected_yarn_fields)


### PR DESCRIPTION
# What does this PR do?

Fixes the builder-backed `AutoBridge.get_model_config()` path for GPT-OSS and other non-MLA GPT models that use YARN rope scaling.

Related to NVBug 6565578.

# Changelog

- Declare the complete YARN runtime field set on Bridge's nested transformer config, where MCore GPT model construction consumes it.
- Make GPT-OSS builder mapping canonical and adapt the deprecated provider path from the same kwargs, preserving model-family settings across both APIs.
- Add one config-only GPT-OSS regression test that verifies YARN field ownership and semantic alignment between the deprecated and builder-backed paths.

# Root cause and scope

The generic non-MLA YARN mapping already emits `yarn_rotary_scaling_factor`, `yarn_original_max_position_embeddings`, `yarn_beta_fast`, `yarn_beta_slow`, and `yarn_correction_range_round_to_int`. `GPTModelProvider` declares the full YARN runtime field set, so the deprecated path accepts those values, but the builder-backed config and its nested transformer config did not. The builder partitioner therefore rejected the five mapped values as unknown.

The fix declares the same seven runtime fields, including optional `yarn_mscale` and `yarn_mscale_all_dim`, on the nested Bridge transformer config that MCore passes into `GPTModel`. GPT-OSS now supplies its existing model-family settings through `hf_config_to_model_config_kwargs()`, and the deprecated provider path delegates to that canonical mapping. This avoids a model-specific YARN workaround while keeping both APIs aligned.

The change is limited to config mapping and one focused regression test. It adds no dependencies and does not touch Megatron-Core or CI workflows.

# Red-green evidence

- Before the fix, on unmodified `main`, the focused config-only test failed with one failure and the exact five-field `ValueError` from `_partition_model_config_kwargs`.
- After the fix, the focused regression passed: `1 passed`.
- Targeted GPT-OSS and shared GPT model-config tests passed after review changes: `10 passed`.
- `uv run pre-commit run --all-files` passed all hooks before commit and after review.

Focused command:

```bash
uv run python -m pytest tests/unit_tests/models/gpt_oss/test_gpt_oss_bridges.py::TestGptOssBridge::test_autobridge_model_config_preserves_yarn_fields -vv
```

Targeted command:

```bash
uv run python -m pytest tests/unit_tests/models/gpt_oss/test_gpt_oss_bridges.py tests/unit_tests/models/test_gpt_model_config.py -v
```

# GitHub Actions CI

This is a config-only unit-test change; standard PR CI is sufficient.

# Before your PR is "Ready for review"

- [x] Read and followed the contributor guidelines.
- [x] Added the focused regression test needed for this bug.
- [x] Documentation is not needed for this internal config-contract correction.
- [x] No optional-install component is affected.

# Additional Information

- NVBug 6565578