### PR TITLE
fix(peft): preserve shared expert LoRA values across EP reshards

### DIFF
--- a/examples/conversion/adapter/export_adapter.py
+++ b/examples/conversion/adapter/export_adapter.py
@@ -54,6 +54,7 @@ from megatron.bridge import AutoBridge
 from megatron.bridge.peft.lora import LoRA, VLMLoRA
 from megatron.bridge.peft.utils import enable_legacy_shared_expert_adapter_loading
 from megatron.bridge.training.checkpointing import (
+    _checkpoint_expert_parallel_size,
     _generate_model_state_dict,
     _model_sharded_state_dict_load_metadata,
     apply_peft_adapter_filter_to_state_dict,
@@ -210,7 +211,12 @@ def _export_adapter_distributed(args: argparse.Namespace) -> None:
                 f"got {len(model)}. Use pipeline parallel size 1 without virtual pipeline parallelism."
             )
 
-        model_sd_kwargs = {"metadata": _model_sharded_state_dict_load_metadata(None)}
+        model_sd_kwargs = {
+            "metadata": _model_sharded_state_dict_load_metadata(
+                None,
+                source_expert_parallel_size=_checkpoint_expert_parallel_size(ckpt_path),
+            )
+        }
         sharded_state_dict = _generate_model_state_dict(model, model_sd_kwargs)
         sharded_state_dict = apply_peft_adapter_filter_to_state_dict(sharded_state_dict, lora)
         legacy_shared_expert_adapter = enable_legacy_shared_expert_adapter_loading(

--- a/examples/conversion/adapter/export_adapter.py
+++ b/examples/conversion/adapter/export_adapter.py
@@ -52,7 +52,10 @@ from transformers import AutoConfig
 
 from megatron.bridge import AutoBridge
 from megatron.bridge.peft.lora import LoRA, VLMLoRA
-from megatron.bridge.peft.utils import enable_legacy_shared_expert_adapter_loading
+from megatron.bridge.peft.utils import (
+    enable_legacy_shared_expert_adapter_loading,
+    validate_shared_expert_adapter_source_ep,
+)
 from megatron.bridge.training.checkpointing import (
     _checkpoint_expert_parallel_size,
     _generate_model_state_dict,
@@ -211,10 +214,11 @@ def _export_adapter_distributed(args: argparse.Namespace) -> None:
                 f"got {len(model)}. Use pipeline parallel size 1 without virtual pipeline parallelism."
             )
 
+        source_expert_parallel_size = _checkpoint_expert_parallel_size(ckpt_path)
         model_sd_kwargs = {
             "metadata": _model_sharded_state_dict_load_metadata(
                 None,
-                source_expert_parallel_size=_checkpoint_expert_parallel_size(ckpt_path),
+                source_expert_parallel_size=source_expert_parallel_size,
             )
         }
         sharded_state_dict = _generate_model_state_dict(model, model_sd_kwargs)
@@ -225,6 +229,8 @@ def _export_adapter_distributed(args: argparse.Namespace) -> None:
         if legacy_shared_expert_adapter:
             sharded_state_dict = _generate_model_state_dict(model, model_sd_kwargs)
             sharded_state_dict = apply_peft_adapter_filter_to_state_dict(sharded_state_dict, lora)
+        else:
+            validate_shared_expert_adapter_source_ep(model, source_expert_parallel_size)
         loaded_sd = dist_checkpointing.load(
             sharded_state_dict,
             str(ckpt_path),

--- a/examples/conversion/adapter/export_adapter.py
+++ b/examples/conversion/adapter/export_adapter.py
@@ -55,6 +55,7 @@ from megatron.bridge.peft.lora import LoRA, VLMLoRA
 from megatron.bridge.peft.utils import enable_legacy_shared_expert_adapter_loading
 from megatron.bridge.training.checkpointing import (
     _generate_model_state_dict,
+    _model_sharded_state_dict_load_metadata,
     apply_peft_adapter_filter_to_state_dict,
 )
 from megatron.bridge.training.utils.checkpoint_utils import read_run_config
@@ -209,13 +210,14 @@ def _export_adapter_distributed(args: argparse.Namespace) -> None:
                 f"got {len(model)}. Use pipeline parallel size 1 without virtual pipeline parallelism."
             )
 
-        sharded_state_dict = _generate_model_state_dict(model, {})
+        model_sd_kwargs = {"metadata": _model_sharded_state_dict_load_metadata(None)}
+        sharded_state_dict = _generate_model_state_dict(model, model_sd_kwargs)
         sharded_state_dict = apply_peft_adapter_filter_to_state_dict(sharded_state_dict, lora)
         legacy_shared_expert_adapter = enable_legacy_shared_expert_adapter_loading(
             model, sharded_state_dict, ckpt_path
         )
         if legacy_shared_expert_adapter:
-            sharded_state_dict = _generate_model_state_dict(model, {})
+            sharded_state_dict = _generate_model_state_dict(model, model_sd_kwargs)
             sharded_state_dict = apply_peft_adapter_filter_to_state_dict(sharded_state_dict, lora)
         loaded_sd = dist_checkpointing.load(
             sharded_state_dict,

--- a/examples/conversion/adapter/verify_adapter.py
+++ b/examples/conversion/adapter/verify_adapter.py
@@ -157,6 +157,7 @@ def _build_megatron_lora_model(
     from megatron.bridge.peft.lora import LoRA, VLMLoRA
     from megatron.bridge.training.checkpointing import (
         _generate_model_state_dict,
+        _model_sharded_state_dict_load_metadata,
         apply_peft_adapter_filter_to_state_dict,
     )
     from megatron.bridge.training.model_load_save import temporary_distributed_context
@@ -222,7 +223,8 @@ def _build_megatron_lora_model(
         init_model_with_meta_device=False,
     )
 
-    sharded_sd = _generate_model_state_dict(model, {})
+    model_sd_kwargs = {"metadata": _model_sharded_state_dict_load_metadata(None)}
+    sharded_sd = _generate_model_state_dict(model, model_sd_kwargs)
     sharded_sd = apply_peft_adapter_filter_to_state_dict(sharded_sd, lora)
     loaded_sd = dist_checkpointing.load(sharded_sd, str(ckpt_path))
     model_key = "model" if "model" in loaded_sd else next(k for k in loaded_sd if k.startswith("model"))

--- a/examples/conversion/adapter/verify_adapter.py
+++ b/examples/conversion/adapter/verify_adapter.py
@@ -156,6 +156,7 @@ def _build_megatron_lora_model(
     from megatron.bridge.models.conversion.auto_bridge import AutoBridge
     from megatron.bridge.peft.lora import LoRA, VLMLoRA
     from megatron.bridge.training.checkpointing import (
+        _checkpoint_expert_parallel_size,
         _generate_model_state_dict,
         _model_sharded_state_dict_load_metadata,
         apply_peft_adapter_filter_to_state_dict,
@@ -223,7 +224,12 @@ def _build_megatron_lora_model(
         init_model_with_meta_device=False,
     )
 
-    model_sd_kwargs = {"metadata": _model_sharded_state_dict_load_metadata(None)}
+    model_sd_kwargs = {
+        "metadata": _model_sharded_state_dict_load_metadata(
+            None,
+            source_expert_parallel_size=_checkpoint_expert_parallel_size(ckpt_path),
+        )
+    }
     sharded_sd = _generate_model_state_dict(model, model_sd_kwargs)
     sharded_sd = apply_peft_adapter_filter_to_state_dict(sharded_sd, lora)
     loaded_sd = dist_checkpointing.load(sharded_sd, str(ckpt_path))

--- a/examples/conversion/adapter/verify_adapter.py
+++ b/examples/conversion/adapter/verify_adapter.py
@@ -155,6 +155,10 @@ def _build_megatron_lora_model(
 
     from megatron.bridge.models.conversion.auto_bridge import AutoBridge
     from megatron.bridge.peft.lora import LoRA, VLMLoRA
+    from megatron.bridge.peft.utils import (
+        enable_legacy_shared_expert_adapter_loading,
+        validate_shared_expert_adapter_source_ep,
+    )
     from megatron.bridge.training.checkpointing import (
         _checkpoint_expert_parallel_size,
         _generate_model_state_dict,
@@ -224,15 +228,26 @@ def _build_megatron_lora_model(
         init_model_with_meta_device=False,
     )
 
+    source_expert_parallel_size = _checkpoint_expert_parallel_size(ckpt_path)
     model_sd_kwargs = {
         "metadata": _model_sharded_state_dict_load_metadata(
             None,
-            source_expert_parallel_size=_checkpoint_expert_parallel_size(ckpt_path),
+            source_expert_parallel_size=source_expert_parallel_size,
         )
     }
     sharded_sd = _generate_model_state_dict(model, model_sd_kwargs)
     sharded_sd = apply_peft_adapter_filter_to_state_dict(sharded_sd, lora)
-    loaded_sd = dist_checkpointing.load(sharded_sd, str(ckpt_path))
+    legacy_shared_expert_adapter = enable_legacy_shared_expert_adapter_loading(model, sharded_sd, ckpt_path)
+    if legacy_shared_expert_adapter:
+        sharded_sd = _generate_model_state_dict(model, model_sd_kwargs)
+        sharded_sd = apply_peft_adapter_filter_to_state_dict(sharded_sd, lora)
+    else:
+        validate_shared_expert_adapter_source_ep(model, source_expert_parallel_size)
+    loaded_sd = dist_checkpointing.load(
+        sharded_sd,
+        str(ckpt_path),
+        validate_access_integrity=not legacy_shared_expert_adapter,
+    )
     model_key = "model" if "model" in loaded_sd else next(k for k in loaded_sd if k.startswith("model"))
     model[0].load_state_dict(loaded_sd[model_key], strict=False)
 

--- a/examples/peft/merge_lora.py
+++ b/examples/peft/merge_lora.py
@@ -60,6 +60,7 @@ from megatron.bridge.peft.lora import LoRA, VLMLoRA
 from megatron.bridge.peft.utils import enable_legacy_shared_expert_adapter_loading
 from megatron.bridge.training.checkpointing import (
     _generate_model_state_dict,
+    _model_sharded_state_dict_load_metadata,
     apply_peft_adapter_filter_to_state_dict,
 )
 from megatron.bridge.training.utils.checkpoint_utils import read_run_config
@@ -221,12 +222,13 @@ def merge_lora(
     # 3) Load weights from the fine-tuned checkpoint
     print_rank_0(f"Loading LoRA adapter weights from {lora_dir}")
     # Generate full sharded_state_dict describing all model tensors
-    sharded_state_dict = _generate_model_state_dict(model, {})
+    model_sd_kwargs = {"metadata": _model_sharded_state_dict_load_metadata(None)}
+    sharded_state_dict = _generate_model_state_dict(model, model_sd_kwargs)
     # Keep only LoRA adapter tensors (and any other trainable parameters) so we don't read unnecessary dense weights.
     sharded_state_dict = apply_peft_adapter_filter_to_state_dict(sharded_state_dict, lora_peft)
     legacy_shared_expert_adapter = enable_legacy_shared_expert_adapter_loading(model, sharded_state_dict, lora_dir)
     if legacy_shared_expert_adapter:
-        sharded_state_dict = _generate_model_state_dict(model, {})
+        sharded_state_dict = _generate_model_state_dict(model, model_sd_kwargs)
         sharded_state_dict = apply_peft_adapter_filter_to_state_dict(sharded_state_dict, lora_peft)
 
     # Load those tensors from the checkpoint directory

--- a/examples/peft/merge_lora.py
+++ b/examples/peft/merge_lora.py
@@ -57,7 +57,10 @@ from megatron.core import dist_checkpointing
 
 from megatron.bridge.models.conversion.auto_bridge import AutoBridge
 from megatron.bridge.peft.lora import LoRA, VLMLoRA
-from megatron.bridge.peft.utils import enable_legacy_shared_expert_adapter_loading
+from megatron.bridge.peft.utils import (
+    enable_legacy_shared_expert_adapter_loading,
+    validate_shared_expert_adapter_source_ep,
+)
 from megatron.bridge.training.checkpointing import (
     _checkpoint_expert_parallel_size,
     _generate_model_state_dict,
@@ -223,10 +226,11 @@ def merge_lora(
     # 3) Load weights from the fine-tuned checkpoint
     print_rank_0(f"Loading LoRA adapter weights from {lora_dir}")
     # Generate full sharded_state_dict describing all model tensors
+    source_expert_parallel_size = _checkpoint_expert_parallel_size(lora_dir)
     model_sd_kwargs = {
         "metadata": _model_sharded_state_dict_load_metadata(
             None,
-            source_expert_parallel_size=_checkpoint_expert_parallel_size(lora_dir),
+            source_expert_parallel_size=source_expert_parallel_size,
         )
     }
     sharded_state_dict = _generate_model_state_dict(model, model_sd_kwargs)
@@ -236,6 +240,8 @@ def merge_lora(
     if legacy_shared_expert_adapter:
         sharded_state_dict = _generate_model_state_dict(model, model_sd_kwargs)
         sharded_state_dict = apply_peft_adapter_filter_to_state_dict(sharded_state_dict, lora_peft)
+    else:
+        validate_shared_expert_adapter_source_ep(model, source_expert_parallel_size)
 
     # Load those tensors from the checkpoint directory
     loaded_sd = dist_checkpointing.load(

--- a/examples/peft/merge_lora.py
+++ b/examples/peft/merge_lora.py
@@ -59,6 +59,7 @@ from megatron.bridge.models.conversion.auto_bridge import AutoBridge
 from megatron.bridge.peft.lora import LoRA, VLMLoRA
 from megatron.bridge.peft.utils import enable_legacy_shared_expert_adapter_loading
 from megatron.bridge.training.checkpointing import (
+    _checkpoint_expert_parallel_size,
     _generate_model_state_dict,
     _model_sharded_state_dict_load_metadata,
     apply_peft_adapter_filter_to_state_dict,
@@ -222,7 +223,12 @@ def merge_lora(
     # 3) Load weights from the fine-tuned checkpoint
     print_rank_0(f"Loading LoRA adapter weights from {lora_dir}")
     # Generate full sharded_state_dict describing all model tensors
-    model_sd_kwargs = {"metadata": _model_sharded_state_dict_load_metadata(None)}
+    model_sd_kwargs = {
+        "metadata": _model_sharded_state_dict_load_metadata(
+            None,
+            source_expert_parallel_size=_checkpoint_expert_parallel_size(lora_dir),
+        )
+    }
     sharded_state_dict = _generate_model_state_dict(model, model_sd_kwargs)
     # Keep only LoRA adapter tensors (and any other trainable parameters) so we don't read unnecessary dense weights.
     sharded_state_dict = apply_peft_adapter_filter_to_state_dict(sharded_state_dict, lora_peft)

--- a/src/megatron/bridge/models/conversion/auto_bridge.py
+++ b/src/megatron/bridge/models/conversion/auto_bridge.py
@@ -1589,6 +1589,7 @@ class AutoBridge(Generic[MegatronModelT]):
         from megatron.bridge.peft.lora import LoRA, VLMLoRA
         from megatron.bridge.peft.utils import enable_legacy_shared_expert_adapter_loading
         from megatron.bridge.training.checkpointing import (
+            _checkpoint_expert_parallel_size,
             _generate_model_state_dict,
             _model_sharded_state_dict_load_metadata,
             apply_peft_adapter_filter_to_state_dict,
@@ -1649,7 +1650,12 @@ class AutoBridge(Generic[MegatronModelT]):
             """Load adapter weights into a materialized model and export them as PEFT."""
 
             # Load adapter weights from the PEFT checkpoint
-            model_sd_kwargs = {"metadata": _model_sharded_state_dict_load_metadata(None)}
+            model_sd_kwargs = {
+                "metadata": _model_sharded_state_dict_load_metadata(
+                    None,
+                    source_expert_parallel_size=_checkpoint_expert_parallel_size(ckpt_path),
+                )
+            }
             sharded_state_dict = _generate_model_state_dict(model, model_sd_kwargs)
             sharded_state_dict = apply_peft_adapter_filter_to_state_dict(sharded_state_dict, lora)
             legacy_shared_expert_adapter = enable_legacy_shared_expert_adapter_loading(

--- a/src/megatron/bridge/models/conversion/auto_bridge.py
+++ b/src/megatron/bridge/models/conversion/auto_bridge.py
@@ -1587,7 +1587,10 @@ class AutoBridge(Generic[MegatronModelT]):
         from megatron.core import dist_checkpointing
 
         from megatron.bridge.peft.lora import LoRA, VLMLoRA
-        from megatron.bridge.peft.utils import enable_legacy_shared_expert_adapter_loading
+        from megatron.bridge.peft.utils import (
+            enable_legacy_shared_expert_adapter_loading,
+            validate_shared_expert_adapter_source_ep,
+        )
         from megatron.bridge.training.checkpointing import (
             _checkpoint_expert_parallel_size,
             _generate_model_state_dict,
@@ -1650,10 +1653,11 @@ class AutoBridge(Generic[MegatronModelT]):
             """Load adapter weights into a materialized model and export them as PEFT."""
 
             # Load adapter weights from the PEFT checkpoint
+            source_expert_parallel_size = _checkpoint_expert_parallel_size(ckpt_path)
             model_sd_kwargs = {
                 "metadata": _model_sharded_state_dict_load_metadata(
                     None,
-                    source_expert_parallel_size=_checkpoint_expert_parallel_size(ckpt_path),
+                    source_expert_parallel_size=source_expert_parallel_size,
                 )
             }
             sharded_state_dict = _generate_model_state_dict(model, model_sd_kwargs)
@@ -1664,6 +1668,8 @@ class AutoBridge(Generic[MegatronModelT]):
             if legacy_shared_expert_adapter:
                 sharded_state_dict = _generate_model_state_dict(model, model_sd_kwargs)
                 sharded_state_dict = apply_peft_adapter_filter_to_state_dict(sharded_state_dict, lora)
+            else:
+                validate_shared_expert_adapter_source_ep(model, source_expert_parallel_size)
             loaded_sd = dist_checkpointing.load(
                 sharded_state_dict,
                 str(ckpt_path),

--- a/src/megatron/bridge/models/conversion/auto_bridge.py
+++ b/src/megatron/bridge/models/conversion/auto_bridge.py
@@ -1590,6 +1590,7 @@ class AutoBridge(Generic[MegatronModelT]):
         from megatron.bridge.peft.utils import enable_legacy_shared_expert_adapter_loading
         from megatron.bridge.training.checkpointing import (
             _generate_model_state_dict,
+            _model_sharded_state_dict_load_metadata,
             apply_peft_adapter_filter_to_state_dict,
         )
         from megatron.bridge.training.model_load_save import temporary_distributed_context
@@ -1648,13 +1649,14 @@ class AutoBridge(Generic[MegatronModelT]):
             """Load adapter weights into a materialized model and export them as PEFT."""
 
             # Load adapter weights from the PEFT checkpoint
-            sharded_state_dict = _generate_model_state_dict(model, {})
+            model_sd_kwargs = {"metadata": _model_sharded_state_dict_load_metadata(None)}
+            sharded_state_dict = _generate_model_state_dict(model, model_sd_kwargs)
             sharded_state_dict = apply_peft_adapter_filter_to_state_dict(sharded_state_dict, lora)
             legacy_shared_expert_adapter = enable_legacy_shared_expert_adapter_loading(
                 model, sharded_state_dict, ckpt_path
             )
             if legacy_shared_expert_adapter:
-                sharded_state_dict = _generate_model_state_dict(model, {})
+                sharded_state_dict = _generate_model_state_dict(model, model_sd_kwargs)
                 sharded_state_dict = apply_peft_adapter_filter_to_state_dict(sharded_state_dict, lora)
             loaded_sd = dist_checkpointing.load(
                 sharded_state_dict,

--- a/src/megatron/bridge/peft/utils.py
+++ b/src/megatron/bridge/peft/utils.py
@@ -1392,11 +1392,12 @@ class ParallelLinearAdapter(nn.Module):
             sharded_tensors = []
             for expert_index in range(local_experts):
                 expert_offset = (expert_axis, first_expert_slot + expert_index, num_global_experts)
+                expert_tensor = tensor.clone()
                 if not split_swiglu:
                     sharded_tensors.append(
                         ShardedTensor.from_rank_offsets(
                             key,
-                            tensor,
+                            expert_tensor,
                             *sharded_offsets,
                             *preserved_rank_offsets,
                             expert_offset,
@@ -1406,7 +1407,7 @@ class ParallelLinearAdapter(nn.Module):
                     )
                     continue
 
-                tensor_w, tensor_v = torch.chunk(tensor, 2, dim=swiglu_shard_axis)
+                tensor_w, tensor_v = torch.chunk(expert_tensor, 2, dim=swiglu_shard_axis)
                 offset_w = (output_swiglu_global_axis, swiglu_rank_offset, swiglu_axis_frag * 2)
                 offset_v = (
                     output_swiglu_global_axis,

--- a/src/megatron/bridge/peft/utils.py
+++ b/src/megatron/bridge/peft/utils.py
@@ -1442,19 +1442,23 @@ class ParallelLinearAdapter(nn.Module):
             if not isinstance(sub_state_dict, list):
                 sub_state_dict = [sub_state_dict]
 
-            def mean_in_place(tensors):
-                result = tensors[0]
-                for tensor in tensors[1:]:
+            def mean_with_stable_accumulator(tensors):
+                if len(tensors) == 1:
+                    return tensors[0]
+                output_dtype = tensors[0].dtype
+                accumulator_dtype = torch.promote_types(output_dtype, torch.float32)
+                result = torch.zeros_like(tensors[0], dtype=accumulator_dtype)
+                for tensor in tensors:
                     result.add_(tensor)
-                return result.div_(len(tensors))
+                return result.div_(len(tensors)).to(output_dtype)
 
             if split_swiglu:
                 if len(sub_state_dict) % 2 != 0:
                     raise ValueError(f"Expected even number of SwiGLU shards for {sharded_tensor.key}")
-                gate_mean = mean_in_place(sub_state_dict[::2])
-                up_mean = mean_in_place(sub_state_dict[1::2])
+                gate_mean = mean_with_stable_accumulator(sub_state_dict[::2])
+                up_mean = mean_with_stable_accumulator(sub_state_dict[1::2])
                 return torch.cat((gate_mean, up_mean), dim=swiglu_shard_axis)
-            return mean_in_place(sub_state_dict)
+            return mean_with_stable_accumulator(sub_state_dict)
 
         return ShardedTensorFactory(
             sharded_tensor.key,

--- a/src/megatron/bridge/peft/utils.py
+++ b/src/megatron/bridge/peft/utils.py
@@ -240,6 +240,14 @@ def enable_legacy_shared_expert_adapter_loading(
         True if at least one shared expert adapter was marked for legacy loading.
     """
 
+    legacy_candidates = []
+    for factory in _iter_sharded_tensor_factories(sharded_state_dict):
+        adapter_key = _legacy_shared_expert_adapter_key(factory)
+        if adapter_key is not None:
+            legacy_candidates.append((factory, adapter_key))
+    if not legacy_candidates:
+        return False
+
     checkpoint_metadata = dist_checkpointing.load_tensors_metadata(str(checkpoint_path))
     models = megatron_model if isinstance(megatron_model, list) else [megatron_model]
     adapters_by_name: dict[str, ParallelLinearAdapter] = {}
@@ -249,10 +257,7 @@ def enable_legacy_shared_expert_adapter_loading(
                 adapters_by_name[name.removeprefix("module.")] = module
 
     enabled = False
-    for factory in _iter_sharded_tensor_factories(sharded_state_dict):
-        adapter_key = _legacy_shared_expert_adapter_key(factory)
-        if adapter_key is None:
-            continue
+    for factory, adapter_key in legacy_candidates:
         built = factory.build()
         shards = built if isinstance(built, list) else [built]
         expected_shape = tuple(shards[0].global_shape)
@@ -263,6 +268,33 @@ def enable_legacy_shared_expert_adapter_loading(
                 enabled = True
 
     return enabled
+
+
+def validate_shared_expert_adapter_source_ep(
+    megatron_model: list[nn.Module] | nn.Module,
+    source_expert_parallel_size: int | None,
+) -> None:
+    """Reject ambiguous EP>1 shared-adapter loads after legacy detection."""
+
+    if source_expert_parallel_size is not None:
+        return
+    models = megatron_model if isinstance(megatron_model, list) else [megatron_model]
+    for model in models:
+        if not isinstance(model, nn.Module):
+            continue
+        for module in model.modules():
+            if not isinstance(module, ParallelLinearAdapter) or not module._uses_grouped_expert_sharding():
+                continue
+            destination_ep_size = _process_group_size(
+                module.ep_group,
+                module.config.expert_model_parallel_size or 1,
+            )
+            if destination_ep_size > 1:
+                raise ValueError(
+                    "Shared grouped-expert adapter loading at EP>1 requires the source "
+                    "expert_model_parallel_size in run_config.yaml, legacy checkpoint args, "
+                    "or model sharded-state metadata."
+                )
 
 
 def _get_process_group(pg_collection: ProcessGroupCollection | None, *names: str) -> object | None:
@@ -412,9 +444,10 @@ def load_peft_adapter_checkpoint(
 
     model_chunks = _ensure_model_list(model)
     model_sd_kwargs = dict(model_sd_kwargs or {})
+    source_expert_parallel_size = _checkpoint_expert_parallel_size(adapter_checkpoint_path)
     model_sd_kwargs["metadata"] = _model_sharded_state_dict_load_metadata(
         model_sd_kwargs.get("metadata"),
-        source_expert_parallel_size=_checkpoint_expert_parallel_size(adapter_checkpoint_path),
+        source_expert_parallel_size=source_expert_parallel_size,
     )
     sharded_state_dict = _model_state_dict(
         model_chunks,
@@ -423,6 +456,21 @@ def load_peft_adapter_checkpoint(
         pg_collection=pg_collection,
     )
     sharded_state_dict = apply_peft_adapter_filter_to_state_dict(sharded_state_dict, peft)
+    legacy_shared_expert_adapter = enable_legacy_shared_expert_adapter_loading(
+        model_chunks,
+        sharded_state_dict,
+        adapter_checkpoint_path,
+    )
+    if legacy_shared_expert_adapter:
+        sharded_state_dict = _model_state_dict(
+            model_chunks,
+            model_sd_kwargs,
+            ckpt_format,
+            pg_collection=pg_collection,
+        )
+        sharded_state_dict = apply_peft_adapter_filter_to_state_dict(sharded_state_dict, peft)
+    else:
+        validate_shared_expert_adapter_source_ep(model_chunks, source_expert_parallel_size)
 
     checkpoint_path = str(adapter_checkpoint_path)
     if load_strategy is None:
@@ -1514,12 +1562,6 @@ class ParallelLinearAdapter(nn.Module):
                 metadata.get("expert_model_parallel_size"),
             )
         destination_ep_size = _process_group_size(self.ep_group, self.config.expert_model_parallel_size or 1)
-        if is_loading and source_ep_size is None and destination_ep_size > 1:
-            raise ValueError(
-                "Shared grouped-expert adapter loading at EP>1 requires the source "
-                "expert_model_parallel_size in run_config.yaml, legacy checkpoint args, "
-                "or model sharded-state metadata."
-            )
         reshard_expert_parallel = source_ep_size is not None and source_ep_size != destination_ep_size
         split_swiglu = "linear_fc1" in self.base_linear_name and getattr(self.config, "gated_linear_unit", False)
         linear_in_sd = self.linear_in.sharded_state_dict(f"{prefix}linear_in.", sharded_offsets, metadata)

--- a/src/megatron/bridge/peft/utils.py
+++ b/src/megatron/bridge/peft/utils.py
@@ -1361,6 +1361,7 @@ class ParallelLinearAdapter(nn.Module):
 
         expert_axis, first_expert_slot, num_global_experts = self._expert_axis_info(sharded_offsets)
         local_experts = self.local_experts_per_rank()
+        destination_ep_size = _process_group_size(self.ep_group, self.config.expert_model_parallel_size or 1)
         base_prepend_axis_num = len(sharded_offsets)
         output_prepend_axis_num = base_prepend_axis_num + 1
         swiglu_shard_axis = 0
@@ -1457,9 +1458,9 @@ class ParallelLinearAdapter(nn.Module):
                 for tensor in tensors:
                     result.add_(tensor.to(accumulator_device))
                 result.div_(len(tensors))
-                if reshard_expert_parallel and self.ep_size > 1:
+                if reshard_expert_parallel and destination_ep_size > 1:
                     torch.distributed.all_reduce(result, group=self.ep_group)
-                    result.div_(self.ep_size)
+                    result.div_(destination_ep_size)
                 return result.to(output_dtype)
 
             if split_swiglu:
@@ -1512,7 +1513,8 @@ class ParallelLinearAdapter(nn.Module):
                 "source_expert_model_parallel_size",
                 metadata.get("expert_model_parallel_size"),
             )
-        reshard_expert_parallel = source_ep_size is not None and source_ep_size != self.ep_size
+        destination_ep_size = _process_group_size(self.ep_group, self.config.expert_model_parallel_size or 1)
+        reshard_expert_parallel = source_ep_size is not None and source_ep_size != destination_ep_size
         split_swiglu = "linear_fc1" in self.base_linear_name and getattr(self.config, "gated_linear_unit", False)
         linear_in_sd = self.linear_in.sharded_state_dict(f"{prefix}linear_in.", sharded_offsets, metadata)
         linear_out_sd = self.linear_out.sharded_state_dict(f"{prefix}linear_out.", sharded_offsets, metadata)

--- a/src/megatron/bridge/peft/utils.py
+++ b/src/megatron/bridge/peft/utils.py
@@ -404,9 +404,14 @@ def load_peft_adapter_checkpoint(
     from megatron.core.dist_checkpointing.strategies.fully_parallel import FullyParallelLoadStrategyWrapper
     from megatron.core.dist_checkpointing.strategies.torch import TorchDistLoadShardedStrategy
 
-    from megatron.bridge.training.checkpointing import apply_peft_adapter_filter_to_state_dict
+    from megatron.bridge.training.checkpointing import (
+        _model_sharded_state_dict_load_metadata,
+        apply_peft_adapter_filter_to_state_dict,
+    )
 
     model_chunks = _ensure_model_list(model)
+    model_sd_kwargs = dict(model_sd_kwargs or {})
+    model_sd_kwargs["metadata"] = _model_sharded_state_dict_load_metadata(model_sd_kwargs.get("metadata"))
     sharded_state_dict = _model_state_dict(
         model_chunks,
         model_sd_kwargs,
@@ -1394,8 +1399,8 @@ class ParallelLinearAdapter(nn.Module):
             for expert_index in range(local_experts):
                 expert_offset = (expert_axis, first_expert_slot + expert_index, num_global_experts)
                 # Save shards all contain the same shared adapter value and can alias.
-                # Load shards need independent destinations until merge_fn averages them.
-                expert_tensor = tensor if not is_loading or expert_index == 0 else tensor.clone()
+                # Load shards need independent CPU destinations until merge_fn averages them.
+                expert_tensor = torch.empty_like(tensor, device="cpu") if is_loading else tensor
                 if not split_swiglu:
                     sharded_tensors.append(
                         ShardedTensor.from_rank_offsets(
@@ -1432,19 +1437,24 @@ class ParallelLinearAdapter(nn.Module):
                     )
             return sharded_tensors
 
+        @torch.no_grad()
         def sh_ten_merge_fn(sub_state_dict):
             if not isinstance(sub_state_dict, list):
                 sub_state_dict = [sub_state_dict]
+
+            def mean_in_place(tensors):
+                result = tensors[0]
+                for tensor in tensors[1:]:
+                    result.add_(tensor)
+                return result.div_(len(tensors))
+
             if split_swiglu:
                 if len(sub_state_dict) % 2 != 0:
                     raise ValueError(f"Expected even number of SwiGLU shards for {sharded_tensor.key}")
-                sub_state_dict = [
-                    torch.cat(sub_state_dict[index : index + 2], dim=swiglu_shard_axis)
-                    for index in range(0, len(sub_state_dict), 2)
-                ]
-            if len(sub_state_dict) == 1:
-                return sub_state_dict[0]
-            return torch.stack(sub_state_dict, dim=0).mean(dim=0)
+                gate_mean = mean_in_place(sub_state_dict[::2])
+                up_mean = mean_in_place(sub_state_dict[1::2])
+                return torch.cat((gate_mean, up_mean), dim=swiglu_shard_axis)
+            return mean_in_place(sub_state_dict)
 
         return ShardedTensorFactory(
             sharded_tensor.key,

--- a/src/megatron/bridge/peft/utils.py
+++ b/src/megatron/bridge/peft/utils.py
@@ -1345,6 +1345,7 @@ class ParallelLinearAdapter(nn.Module):
         sharded_offsets: Tuple,
         *,
         split_swiglu: bool = False,
+        is_loading: bool = False,
     ) -> ShardedTensorFactory:
         """Map one shared 2D adapter tensor to this rank's global expert slots."""
 
@@ -1392,7 +1393,9 @@ class ParallelLinearAdapter(nn.Module):
             sharded_tensors = []
             for expert_index in range(local_experts):
                 expert_offset = (expert_axis, first_expert_slot + expert_index, num_global_experts)
-                expert_tensor = tensor.clone()
+                # Save shards all contain the same shared adapter value and can alias.
+                # Load shards need independent destinations until merge_fn averages them.
+                expert_tensor = tensor if not is_loading or expert_index == 0 else tensor.clone()
                 if not split_swiglu:
                     sharded_tensors.append(
                         ShardedTensor.from_rank_offsets(
@@ -1478,6 +1481,7 @@ class ParallelLinearAdapter(nn.Module):
         # Non-grouped expert adapters already sit under .local_experts.* and keep
         # their existing expert-DP replica metadata instead.
         use_expert_axis = self._uses_grouped_expert_sharding() and not self.use_legacy_shared_expert_adapter_checkpoint
+        is_loading = bool(metadata and metadata.get("is_loading", False))
         split_swiglu = "linear_fc1" in self.base_linear_name and getattr(self.config, "gated_linear_unit", False)
         linear_in_sd = self.linear_in.sharded_state_dict(f"{prefix}linear_in.", sharded_offsets, metadata)
         linear_out_sd = self.linear_out.sharded_state_dict(f"{prefix}linear_out.", sharded_offsets, metadata)
@@ -1490,13 +1494,18 @@ class ParallelLinearAdapter(nn.Module):
                         del sd[key]
             for key, value in list(linear_in_sd.items()):
                 if isinstance(value, ShardedTensor):
-                    linear_in_sd[key] = self._apply_expert_axis_factory(value, sharded_offsets)
+                    linear_in_sd[key] = self._apply_expert_axis_factory(
+                        value,
+                        sharded_offsets,
+                        is_loading=is_loading,
+                    )
             for key, value in list(linear_out_sd.items()):
                 if isinstance(value, ShardedTensor):
                     linear_out_sd[key] = self._apply_expert_axis_factory(
                         value,
                         sharded_offsets,
                         split_swiglu=split_swiglu,
+                        is_loading=is_loading,
                     )
         elif self.is_expert:
             if _process_group_rank(self.tp_group) > 0:

--- a/src/megatron/bridge/peft/utils.py
+++ b/src/megatron/bridge/peft/utils.py
@@ -405,13 +405,17 @@ def load_peft_adapter_checkpoint(
     from megatron.core.dist_checkpointing.strategies.torch import TorchDistLoadShardedStrategy
 
     from megatron.bridge.training.checkpointing import (
+        _checkpoint_expert_parallel_size,
         _model_sharded_state_dict_load_metadata,
         apply_peft_adapter_filter_to_state_dict,
     )
 
     model_chunks = _ensure_model_list(model)
     model_sd_kwargs = dict(model_sd_kwargs or {})
-    model_sd_kwargs["metadata"] = _model_sharded_state_dict_load_metadata(model_sd_kwargs.get("metadata"))
+    model_sd_kwargs["metadata"] = _model_sharded_state_dict_load_metadata(
+        model_sd_kwargs.get("metadata"),
+        source_expert_parallel_size=_checkpoint_expert_parallel_size(adapter_checkpoint_path),
+    )
     sharded_state_dict = _model_state_dict(
         model_chunks,
         model_sd_kwargs,
@@ -1351,6 +1355,7 @@ class ParallelLinearAdapter(nn.Module):
         *,
         split_swiglu: bool = False,
         is_loading: bool = False,
+        reshard_expert_parallel: bool = False,
     ) -> ShardedTensorFactory:
         """Map one shared 2D adapter tensor to this rank's global expert slots."""
 
@@ -1443,14 +1448,19 @@ class ParallelLinearAdapter(nn.Module):
                 sub_state_dict = [sub_state_dict]
 
             def mean_with_stable_accumulator(tensors):
-                if len(tensors) == 1:
+                if len(tensors) == 1 and not reshard_expert_parallel:
                     return tensors[0]
                 output_dtype = tensors[0].dtype
                 accumulator_dtype = torch.promote_types(output_dtype, torch.float32)
-                result = torch.zeros_like(tensors[0], dtype=accumulator_dtype)
+                accumulator_device = sharded_tensor.data.device if reshard_expert_parallel else tensors[0].device
+                result = torch.zeros_like(tensors[0], dtype=accumulator_dtype, device=accumulator_device)
                 for tensor in tensors:
-                    result.add_(tensor)
-                return result.div_(len(tensors)).to(output_dtype)
+                    result.add_(tensor.to(accumulator_device))
+                result.div_(len(tensors))
+                if reshard_expert_parallel and self.ep_size > 1:
+                    torch.distributed.all_reduce(result, group=self.ep_group)
+                    result.div_(self.ep_size)
+                return result.to(output_dtype)
 
             if split_swiglu:
                 if len(sub_state_dict) % 2 != 0:
@@ -1496,6 +1506,13 @@ class ParallelLinearAdapter(nn.Module):
         # their existing expert-DP replica metadata instead.
         use_expert_axis = self._uses_grouped_expert_sharding() and not self.use_legacy_shared_expert_adapter_checkpoint
         is_loading = bool(metadata and metadata.get("is_loading", False))
+        source_ep_size = None
+        if metadata:
+            source_ep_size = metadata.get(
+                "source_expert_model_parallel_size",
+                metadata.get("expert_model_parallel_size"),
+            )
+        reshard_expert_parallel = source_ep_size is not None and source_ep_size != self.ep_size
         split_swiglu = "linear_fc1" in self.base_linear_name and getattr(self.config, "gated_linear_unit", False)
         linear_in_sd = self.linear_in.sharded_state_dict(f"{prefix}linear_in.", sharded_offsets, metadata)
         linear_out_sd = self.linear_out.sharded_state_dict(f"{prefix}linear_out.", sharded_offsets, metadata)
@@ -1512,6 +1529,7 @@ class ParallelLinearAdapter(nn.Module):
                         value,
                         sharded_offsets,
                         is_loading=is_loading,
+                        reshard_expert_parallel=reshard_expert_parallel,
                     )
             for key, value in list(linear_out_sd.items()):
                 if isinstance(value, ShardedTensor):
@@ -1520,6 +1538,7 @@ class ParallelLinearAdapter(nn.Module):
                         sharded_offsets,
                         split_swiglu=split_swiglu,
                         is_loading=is_loading,
+                        reshard_expert_parallel=reshard_expert_parallel,
                     )
         elif self.is_expert:
             if _process_group_rank(self.tp_group) > 0:

--- a/src/megatron/bridge/peft/utils.py
+++ b/src/megatron/bridge/peft/utils.py
@@ -444,10 +444,15 @@ def load_peft_adapter_checkpoint(
 
     model_chunks = _ensure_model_list(model)
     model_sd_kwargs = dict(model_sd_kwargs or {})
-    source_expert_parallel_size = _checkpoint_expert_parallel_size(adapter_checkpoint_path)
-    model_sd_kwargs["metadata"] = _model_sharded_state_dict_load_metadata(
+    discovered_source_ep_size = _checkpoint_expert_parallel_size(adapter_checkpoint_path)
+    load_metadata = _model_sharded_state_dict_load_metadata(
         model_sd_kwargs.get("metadata"),
-        source_expert_parallel_size=source_expert_parallel_size,
+        source_expert_parallel_size=discovered_source_ep_size,
+    )
+    model_sd_kwargs["metadata"] = load_metadata
+    source_expert_parallel_size = load_metadata.get(
+        "source_expert_model_parallel_size",
+        load_metadata.get("expert_model_parallel_size"),
     )
     sharded_state_dict = _model_state_dict(
         model_chunks,
@@ -1404,6 +1409,7 @@ class ParallelLinearAdapter(nn.Module):
         split_swiglu: bool = False,
         is_loading: bool = False,
         reshard_expert_parallel: bool = False,
+        same_expert_parallel_topology: bool = False,
     ) -> ShardedTensorFactory:
         """Map one shared 2D adapter tensor to this rank's global expert slots."""
 
@@ -1497,7 +1503,7 @@ class ParallelLinearAdapter(nn.Module):
                 sub_state_dict = [sub_state_dict]
 
             def mean_with_stable_accumulator(tensors):
-                if len(tensors) == 1 and not reshard_expert_parallel:
+                if same_expert_parallel_topology:
                     return tensors[0]
                 output_dtype = tensors[0].dtype
                 accumulator_dtype = torch.promote_types(output_dtype, torch.float32)
@@ -1563,6 +1569,8 @@ class ParallelLinearAdapter(nn.Module):
             )
         destination_ep_size = _process_group_size(self.ep_group, self.config.expert_model_parallel_size or 1)
         reshard_expert_parallel = source_ep_size is not None and source_ep_size != destination_ep_size
+        same_expert_parallel_topology = is_loading and source_ep_size == destination_ep_size
+        independent_load_buffers = is_loading and (source_ep_size is None or reshard_expert_parallel)
         split_swiglu = "linear_fc1" in self.base_linear_name and getattr(self.config, "gated_linear_unit", False)
         linear_in_sd = self.linear_in.sharded_state_dict(f"{prefix}linear_in.", sharded_offsets, metadata)
         linear_out_sd = self.linear_out.sharded_state_dict(f"{prefix}linear_out.", sharded_offsets, metadata)
@@ -1578,8 +1586,9 @@ class ParallelLinearAdapter(nn.Module):
                     linear_in_sd[key] = self._apply_expert_axis_factory(
                         value,
                         sharded_offsets,
-                        is_loading=is_loading,
+                        is_loading=independent_load_buffers,
                         reshard_expert_parallel=reshard_expert_parallel,
+                        same_expert_parallel_topology=same_expert_parallel_topology,
                     )
             for key, value in list(linear_out_sd.items()):
                 if isinstance(value, ShardedTensor):
@@ -1587,8 +1596,9 @@ class ParallelLinearAdapter(nn.Module):
                         value,
                         sharded_offsets,
                         split_swiglu=split_swiglu,
-                        is_loading=is_loading,
+                        is_loading=independent_load_buffers,
                         reshard_expert_parallel=reshard_expert_parallel,
+                        same_expert_parallel_topology=same_expert_parallel_topology,
                     )
         elif self.is_expert:
             if _process_group_rank(self.tp_group) > 0:

--- a/src/megatron/bridge/peft/utils.py
+++ b/src/megatron/bridge/peft/utils.py
@@ -1514,6 +1514,12 @@ class ParallelLinearAdapter(nn.Module):
                 metadata.get("expert_model_parallel_size"),
             )
         destination_ep_size = _process_group_size(self.ep_group, self.config.expert_model_parallel_size or 1)
+        if is_loading and source_ep_size is None and destination_ep_size > 1:
+            raise ValueError(
+                "Shared grouped-expert adapter loading at EP>1 requires the source "
+                "expert_model_parallel_size in run_config.yaml, legacy checkpoint args, "
+                "or model sharded-state metadata."
+            )
         reshard_expert_parallel = source_ep_size is not None and source_ep_size != destination_ep_size
         split_swiglu = "linear_fc1" in self.base_linear_name and getattr(self.config, "gated_linear_unit", False)
         linear_in_sd = self.linear_in.sharded_state_dict(f"{prefix}linear_in.", sharded_offsets, metadata)

--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -2216,10 +2216,11 @@ def _load_model_weights_from_checkpoint(
 
     sharded_sd_metadata = dist_checkpointing.load_content_metadata(preloaded_state_dict=state_dict)
     print_rank_0(f"sharded_state_dict metadata loaded from the checkpoint: {sharded_sd_metadata}")
+    source_ep_size = _checkpoint_expert_parallel_size(checkpoint_path)
     model_sd_kwargs = dict(
         metadata=_model_sharded_state_dict_load_metadata(
             sharded_sd_metadata,
-            source_expert_parallel_size=_checkpoint_expert_parallel_size(checkpoint_path),
+            source_expert_parallel_size=source_ep_size,
         )
     )
 
@@ -2227,6 +2228,10 @@ def _load_model_weights_from_checkpoint(
     restore_modelopt_state(model, state_dict)
 
     model = unwrap_model(model)
+    if source_ep_size is None:
+        from megatron.bridge.peft.utils import validate_shared_expert_adapter_source_ep
+
+        validate_shared_expert_adapter_source_ep(model, source_ep_size)
     pg_collection = get_pg_collection(model)
     sharded_state_dict = _generate_model_state_dict(model, model_sd_kwargs, pg_collection=pg_collection)
 
@@ -2734,6 +2739,7 @@ def _load_checkpoint_from_path(
                 "model": {
                     "tensor_model_parallel_size": cfg.model.tensor_model_parallel_size,
                     "pipeline_model_parallel_size": cfg.model.pipeline_model_parallel_size,
+                    "expert_model_parallel_size": cfg.model.expert_model_parallel_size,
                     "encoder_tensor_model_parallel_size": getattr(cfg.model, "encoder_tensor_model_parallel_size", 0),
                     "encoder_pipeline_model_parallel_size": getattr(
                         cfg.model, "encoder_pipeline_model_parallel_size", 0
@@ -2857,6 +2863,10 @@ def _load_checkpoint_from_path(
         source_ep_size = (
             source_model_config.get("expert_model_parallel_size") if isinstance(source_model_config, Mapping) else None
         )
+        if source_ep_size is None:
+            from megatron.bridge.peft.utils import validate_shared_expert_adapter_source_ep
+
+            validate_shared_expert_adapter_source_ep(model, source_ep_size)
         model_sd_kwargs = dict(
             metadata=_model_sharded_state_dict_load_metadata(
                 sharded_sd_metadata,

--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -2215,7 +2215,7 @@ def _load_model_weights_from_checkpoint(
 
     sharded_sd_metadata = dist_checkpointing.load_content_metadata(preloaded_state_dict=state_dict)
     print_rank_0(f"sharded_state_dict metadata loaded from the checkpoint: {sharded_sd_metadata}")
-    model_sd_kwargs = dict(metadata=sharded_sd_metadata)
+    model_sd_kwargs = dict(metadata=_model_sharded_state_dict_load_metadata(sharded_sd_metadata))
 
     # [ModelOpt]: Restore state
     restore_modelopt_state(model, state_dict)
@@ -2847,7 +2847,7 @@ def _load_checkpoint_from_path(
             sharded_sd_metadata = {}
         sharded_sd_metadata["dp_cp_group"] = pg_collection.dp_cp
         optim_sd_kwargs = dict(metadata=sharded_sd_metadata, is_loading=True)
-        model_sd_kwargs = dict(metadata=sharded_sd_metadata)
+        model_sd_kwargs = dict(metadata=_model_sharded_state_dict_load_metadata(sharded_sd_metadata))
 
         # Build sharded state dict for loading
         with contextlib.ExitStack() as stack:
@@ -3807,6 +3807,14 @@ def _build_sharded_state_dict_metadata(use_distributed_optimizer: bool, cfg: Che
     metadata["singleton_local_shards"] = False
     metadata["chained_optim_avoid_prefix"] = True
     return metadata
+
+
+def _model_sharded_state_dict_load_metadata(metadata: Optional[dict]) -> dict:
+    """Return model sharding metadata that identifies checkpoint load scaffolding."""
+
+    load_metadata = dict(metadata or {})
+    load_metadata["is_loading"] = True
+    return load_metadata
 
 
 def _get_train_state_from_state_dict(state_dict: dict[str, Any]) -> TrainState:

--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -27,7 +27,7 @@ from enum import Enum, auto
 from logging import getLogger
 from pathlib import Path
 from time import time
-from typing import Any, Callable, Literal, Optional, Protocol, Union, runtime_checkable
+from typing import Any, Callable, Literal, Mapping, Optional, Protocol, Union, runtime_checkable
 
 import numpy as np
 import torch
@@ -3809,9 +3809,11 @@ def _build_sharded_state_dict_metadata(use_distributed_optimizer: bool, cfg: Che
     return metadata
 
 
-def _model_sharded_state_dict_load_metadata(metadata: Optional[dict]) -> dict:
+def _model_sharded_state_dict_load_metadata(metadata: object | None) -> dict:
     """Return model sharding metadata that identifies checkpoint load scaffolding."""
 
+    if metadata is not None and not isinstance(metadata, Mapping):
+        raise TypeError(f"Expected model sharding metadata to be a mapping, got {type(metadata).__name__}")
     load_metadata = dict(metadata or {})
     load_metadata["is_loading"] = True
     return load_metadata

--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -32,7 +32,7 @@ from typing import Any, Callable, Literal, Mapping, Optional, Protocol, Union, r
 import numpy as np
 import torch
 import torch.nn.functional as F
-from megatron.core import dist_checkpointing, tensor_parallel
+from megatron.core import dist_checkpointing, parallel_state, tensor_parallel
 from megatron.core.dist_checkpointing.mapping import ShardedObject, ShardedStateDict, ShardedTensor
 from megatron.core.dist_checkpointing.serialization import StateDict
 from megatron.core.dist_checkpointing.strategies.async_utils import AsyncRequest
@@ -2215,7 +2215,12 @@ def _load_model_weights_from_checkpoint(
 
     sharded_sd_metadata = dist_checkpointing.load_content_metadata(preloaded_state_dict=state_dict)
     print_rank_0(f"sharded_state_dict metadata loaded from the checkpoint: {sharded_sd_metadata}")
-    model_sd_kwargs = dict(metadata=_model_sharded_state_dict_load_metadata(sharded_sd_metadata))
+    model_sd_kwargs = dict(
+        metadata=_model_sharded_state_dict_load_metadata(
+            sharded_sd_metadata,
+            source_expert_parallel_size=_checkpoint_expert_parallel_size(checkpoint_path),
+        )
+    )
 
     # [ModelOpt]: Restore state
     restore_modelopt_state(model, state_dict)
@@ -2847,7 +2852,16 @@ def _load_checkpoint_from_path(
             sharded_sd_metadata = {}
         sharded_sd_metadata["dp_cp_group"] = pg_collection.dp_cp
         optim_sd_kwargs = dict(metadata=sharded_sd_metadata, is_loading=True)
-        model_sd_kwargs = dict(metadata=_model_sharded_state_dict_load_metadata(sharded_sd_metadata))
+        source_model_config = run_config.get("model", {})
+        source_ep_size = (
+            source_model_config.get("expert_model_parallel_size") if isinstance(source_model_config, Mapping) else None
+        )
+        model_sd_kwargs = dict(
+            metadata=_model_sharded_state_dict_load_metadata(
+                sharded_sd_metadata,
+                source_expert_parallel_size=source_ep_size,
+            )
+        )
 
         # Build sharded state dict for loading
         with contextlib.ExitStack() as stack:
@@ -3806,16 +3820,42 @@ def _build_sharded_state_dict_metadata(use_distributed_optimizer: bool, cfg: Che
 
     metadata["singleton_local_shards"] = False
     metadata["chained_optim_avoid_prefix"] = True
+    expert_parallel_size = parallel_state.get_expert_model_parallel_world_size()
+    if expert_parallel_size > 0:
+        metadata["expert_model_parallel_size"] = expert_parallel_size
     return metadata
 
 
-def _model_sharded_state_dict_load_metadata(metadata: object | None) -> dict:
+def _checkpoint_expert_parallel_size(checkpoint_path: str | Path) -> int | None:
+    """Read the source expert-parallel size from a checkpoint run config, if present."""
+
+    checkpoint_path = Path(checkpoint_path)
+    for config_root in (checkpoint_path, checkpoint_path.parent):
+        config_path = get_checkpoint_run_config_filename(str(config_root))
+        if not file_exists(config_path):
+            continue
+        run_config = read_run_config(config_path)
+        model_config = run_config.get("model", {})
+        if isinstance(model_config, Mapping):
+            expert_parallel_size = model_config.get("expert_model_parallel_size")
+            if expert_parallel_size is not None:
+                return int(expert_parallel_size)
+    return None
+
+
+def _model_sharded_state_dict_load_metadata(
+    metadata: object | None,
+    *,
+    source_expert_parallel_size: int | None = None,
+) -> dict:
     """Return model sharding metadata that identifies checkpoint load scaffolding."""
 
     if metadata is not None and not isinstance(metadata, Mapping):
         raise TypeError(f"Expected model sharding metadata to be a mapping, got {type(metadata).__name__}")
     load_metadata = dict(metadata or {})
     load_metadata["is_loading"] = True
+    if source_expert_parallel_size is not None:
+        load_metadata["source_expert_model_parallel_size"] = source_expert_parallel_size
     return load_metadata
 
 

--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -3843,7 +3843,11 @@ def _checkpoint_expert_parallel_size(checkpoint_path: str | Path) -> int | None:
         config_path = get_checkpoint_run_config_filename(str(config_root))
         if not file_exists(config_path):
             continue
-        run_config = read_run_config(config_path)
+        try:
+            run_config = read_run_config(config_path)
+        except Exception:
+            logger.debug("Unable to read checkpoint run config at %s", config_path, exc_info=True)
+            continue
         model_config = run_config.get("model", {})
         if isinstance(model_config, Mapping):
             expert_parallel_size = model_config.get("expert_model_parallel_size")

--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -368,6 +368,7 @@ def _extract_megatron_lm_args_from_state_dict(state_dict: dict[str, Any]) -> dic
         "model": {
             "tensor_model_parallel_size": getattr(args, "tensor_model_parallel_size", 1),
             "pipeline_model_parallel_size": getattr(args, "pipeline_model_parallel_size", 1),
+            "expert_model_parallel_size": getattr(args, "expert_model_parallel_size", 1),
             "encoder_tensor_model_parallel_size": getattr(args, "encoder_tensor_model_parallel_size", 0),
             "encoder_pipeline_model_parallel_size": getattr(args, "encoder_pipeline_model_parallel_size", 0),
         },
@@ -3824,7 +3825,7 @@ def _build_sharded_state_dict_metadata(use_distributed_optimizer: bool, cfg: Che
 
 
 def _checkpoint_expert_parallel_size(checkpoint_path: str | Path) -> int | None:
-    """Read the source expert-parallel size from a checkpoint run config, if present."""
+    """Read the source expert-parallel size from checkpoint configuration, if present."""
 
     path_type = MultiStorageClientFeature.import_package().Path if MultiStorageClientFeature.is_enabled() else Path
     checkpoint_path = path_type(str(checkpoint_path))
@@ -3838,6 +3839,19 @@ def _checkpoint_expert_parallel_size(checkpoint_path: str | Path) -> int | None:
             expert_parallel_size = model_config.get("expert_model_parallel_size")
             if expert_parallel_size is not None:
                 return int(expert_parallel_size)
+
+    try:
+        common_state_dict = dist_checkpointing.load_common_state_dict(str(checkpoint_path))
+    except Exception:
+        logger.debug("Unable to inspect common checkpoint state at %s", checkpoint_path, exc_info=True)
+        return None
+    args = common_state_dict.get("args") if isinstance(common_state_dict, Mapping) else None
+    if isinstance(args, Mapping):
+        expert_parallel_size = args.get("expert_model_parallel_size")
+    else:
+        expert_parallel_size = getattr(args, "expert_model_parallel_size", None)
+    if expert_parallel_size is not None:
+        return int(expert_parallel_size)
     return None
 
 

--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -32,7 +32,7 @@ from typing import Any, Callable, Literal, Mapping, Optional, Protocol, Union, r
 import numpy as np
 import torch
 import torch.nn.functional as F
-from megatron.core import dist_checkpointing, parallel_state, tensor_parallel
+from megatron.core import dist_checkpointing, tensor_parallel
 from megatron.core.dist_checkpointing.mapping import ShardedObject, ShardedStateDict, ShardedTensor
 from megatron.core.dist_checkpointing.serialization import StateDict
 from megatron.core.dist_checkpointing.strategies.async_utils import AsyncRequest
@@ -3820,16 +3820,14 @@ def _build_sharded_state_dict_metadata(use_distributed_optimizer: bool, cfg: Che
 
     metadata["singleton_local_shards"] = False
     metadata["chained_optim_avoid_prefix"] = True
-    expert_parallel_size = parallel_state.get_expert_model_parallel_world_size()
-    if expert_parallel_size > 0:
-        metadata["expert_model_parallel_size"] = expert_parallel_size
     return metadata
 
 
 def _checkpoint_expert_parallel_size(checkpoint_path: str | Path) -> int | None:
     """Read the source expert-parallel size from a checkpoint run config, if present."""
 
-    checkpoint_path = Path(checkpoint_path)
+    path_type = MultiStorageClientFeature.import_package().Path if MultiStorageClientFeature.is_enabled() else Path
+    checkpoint_path = path_type(str(checkpoint_path))
     for config_root in (checkpoint_path, checkpoint_path.parent):
         config_path = get_checkpoint_run_config_filename(str(config_root))
         if not file_exists(config_path):

--- a/tests/unit_tests/models/test_adapter_export.py
+++ b/tests/unit_tests/models/test_adapter_export.py
@@ -820,7 +820,7 @@ class TestExportAdapterCkpt:
             patch(
                 "megatron.bridge.training.checkpointing._generate_model_state_dict",
                 return_value={"model": {}},
-            ),
+            ) as mock_generate_state_dict,
             patch(
                 "megatron.bridge.training.checkpointing.apply_peft_adapter_filter_to_state_dict",
                 side_effect=lambda sd, _lora: sd,
@@ -831,6 +831,7 @@ class TestExportAdapterCkpt:
             ),
         ):
             self.mock_dist_load = mock_dist_load
+            self.mock_generate_state_dict = mock_generate_state_dict
             yield
 
     def test_basic_export_calls_save_hf_adapter(self, bridge, ckpt_dir, tmp_path):
@@ -1002,6 +1003,7 @@ class TestExportAdapterCkpt:
         self.mock_dist_load.assert_called_once()
         load_path = self.mock_dist_load.call_args.args[1]
         assert load_path == str(ckpt_dir.resolve())
+        assert self.mock_generate_state_dict.call_args.args[1] == {"metadata": {"is_loading": True}}
 
     def test_base_model_name_from_name_or_path_fallback(self, bridge, ckpt_dir, tmp_path):
         """Falls back to hf_pretrained.name_or_path when model_name_or_path is empty."""

--- a/tests/unit_tests/models/test_adapter_export.py
+++ b/tests/unit_tests/models/test_adapter_export.py
@@ -1422,6 +1422,8 @@ class TestExportAdapterScript:
             export_adapter._export_adapter_distributed(args)
 
         assert mock_state_dict.call_count == 2
+        for call in mock_state_dict.call_args_list:
+            assert call.args[1] == {"metadata": {"is_loading": True}}
         assert mock_filter.call_count == 2
         mock_enable_legacy.assert_called_once_with([model_chunk], state_dicts[0], tmp_path)
         mock_load.assert_called_once_with(state_dicts[1], str(tmp_path), validate_access_integrity=False)

--- a/tests/unit_tests/peft/test_utils.py
+++ b/tests/unit_tests/peft/test_utils.py
@@ -967,6 +967,103 @@ class TestParallelLinearAdapter:
         merged = factory.merge_fn([torch.ones(2, 2), torch.full((2, 2), 3.0)])
         torch.testing.assert_close(merged, torch.full((2, 2), 2.0))
 
+    @pytest.mark.parametrize(
+        ("base_linear_name", "linear_out_shape", "key", "rank_values", "expected_mean"),
+        [
+            pytest.param(
+                "decoder.layers.0.mlp.experts.linear_fc1",
+                (4, 2),
+                "adapter.linear_in.weight",
+                (1.0, 3.0),
+                2.0,
+                id="fc1-linear-in",
+            ),
+            pytest.param(
+                "decoder.layers.0.mlp.experts.linear_fc1",
+                (4, 2),
+                "adapter.linear_out.weight",
+                (11.0, 7.0),
+                9.0,
+                id="fc1-linear-out",
+            ),
+            pytest.param(
+                "decoder.layers.0.mlp.experts.linear_fc2",
+                (2, 2),
+                "adapter.linear_in.weight",
+                (1.0, 3.0),
+                2.0,
+                id="fc2-linear-in",
+            ),
+            pytest.param(
+                "decoder.layers.0.mlp.experts.linear_fc2",
+                (2, 2),
+                "adapter.linear_out.weight",
+                (11.0, 7.0),
+                9.0,
+                id="fc2-linear-out",
+            ),
+        ],
+    )
+    @patch("megatron.bridge.peft.utils.ColumnParallelLinear")
+    @patch("megatron.bridge.peft.utils.RowParallelLinear")
+    def test_parallel_linear_adapter_grouped_expert_factory_averages_loaded_ep_values(
+        self,
+        mock_row_linear,
+        mock_col_linear,
+        mock_config,
+        base_linear_name,
+        linear_out_shape,
+        key,
+        rank_values,
+        expected_mean,
+    ):
+        """Every shared-expert adapter tensor should average EP=2 values when loaded at EP=1."""
+        mock_linear_in = Mock()
+        mock_linear_out = Mock()
+        mock_linear_in.sharded_state_dict.return_value = {
+            "adapter.linear_in.weight": ShardedTensor.from_rank_offsets(
+                "adapter.linear_in.weight", torch.zeros(2, 2), replica_id=(0, 0, 0)
+            ),
+        }
+        mock_linear_out.sharded_state_dict.return_value = {
+            "adapter.linear_out.weight": ShardedTensor.from_rank_offsets(
+                "adapter.linear_out.weight", torch.zeros(linear_out_shape), replica_id=(0, 0, 0)
+            ),
+        }
+        mock_col_linear.side_effect = [mock_linear_in, mock_linear_out]
+        mock_config.num_moe_experts = 4
+        mock_config.gated_linear_unit = True
+        mock_config._pg_collection = make_mock_pg_collection(ep_size=1, ep_rank=0)
+
+        adapter = ParallelLinearAdapter(
+            in_features=2,
+            out_features=linear_out_shape[0],
+            dim=2,
+            base_linear_name=base_linear_name,
+            is_expert=True,
+            model_parallel_config=mock_config,
+        )
+        state_dict = adapter.sharded_state_dict(prefix="adapter.")
+
+        factory = state_dict[key]
+        assert isinstance(factory, ShardedTensorFactory)
+        built = factory.build()
+        shards_per_expert = len(built) // mock_config.num_moe_experts
+        saved_expert_values = (rank_values[0], rank_values[0], rank_values[1], rank_values[1])
+        for shard_index, shard in enumerate(built):
+            shard.data.fill_(saved_expert_values[shard_index // shards_per_expert])
+
+        merged = factory.merge_fn([shard.data for shard in built])
+        expert_storage_count = len({shard.data.untyped_storage().data_ptr() for shard in built})
+
+        assert torch.equal(merged, torch.full_like(merged, expected_mean)) and (
+            expert_storage_count == mock_config.num_moe_experts
+        ), (
+            f"{key}: expected EP mean {expected_mean} from rank values {rank_values}, "
+            f"got {torch.unique(merged).tolist()} with {expert_storage_count}/"
+            f"{mock_config.num_moe_experts} independent expert buffers"
+        )
+
     @patch("megatron.bridge.peft.utils.ColumnParallelLinear")
     @patch("megatron.bridge.peft.utils.RowParallelLinear")
     def test_parallel_linear_adapter_grouped_expert_shared_adapter_syncs_grad_across_ep(

--- a/tests/unit_tests/peft/test_utils.py
+++ b/tests/unit_tests/peft/test_utils.py
@@ -1164,6 +1164,35 @@ class TestParallelLinearAdapter:
 
     @patch("megatron.bridge.peft.utils.ColumnParallelLinear")
     @patch("megatron.bridge.peft.utils.RowParallelLinear")
+    def test_shared_grouped_expert_load_rejects_unknown_source_ep(self, mock_row_linear, mock_col_linear, mock_config):
+        """An EP>1 load must not silently assume that an unknown source topology is unchanged."""
+        del mock_row_linear
+        mock_linear_in = Mock()
+        mock_linear_in.sharded_state_dict.return_value = {
+            "adapter.linear_in.weight": ShardedTensor.from_rank_offsets(
+                "adapter.linear_in.weight", torch.zeros(2, 2), replica_id=(0, 0, 0)
+            ),
+        }
+        mock_linear_out = Mock()
+        mock_linear_out.sharded_state_dict.return_value = {}
+        mock_col_linear.side_effect = [mock_linear_in, mock_linear_out]
+        mock_config.num_moe_experts = 4
+        mock_config._pg_collection = make_mock_pg_collection(ep_size=2, ep_rank=0)
+
+        adapter = ParallelLinearAdapter(
+            in_features=2,
+            out_features=2,
+            dim=2,
+            base_linear_name="decoder.layers.0.mlp.experts.linear_fc2",
+            is_expert=True,
+            model_parallel_config=mock_config,
+        )
+
+        with pytest.raises(ValueError, match="requires the source expert_model_parallel_size"):
+            adapter.sharded_state_dict(prefix="adapter.", metadata={"is_loading": True})
+
+    @patch("megatron.bridge.peft.utils.ColumnParallelLinear")
+    @patch("megatron.bridge.peft.utils.RowParallelLinear")
     def test_parallel_linear_adapter_grouped_expert_shared_adapter_syncs_grad_across_ep(
         self, mock_row_linear, mock_col_linear, mock_config
     ):

--- a/tests/unit_tests/peft/test_utils.py
+++ b/tests/unit_tests/peft/test_utils.py
@@ -1068,6 +1068,45 @@ class TestParallelLinearAdapter:
 
     @patch("megatron.bridge.peft.utils.ColumnParallelLinear")
     @patch("megatron.bridge.peft.utils.RowParallelLinear")
+    def test_shared_grouped_expert_merge_accumulates_low_precision_values_stably(
+        self, mock_row_linear, mock_col_linear, mock_config
+    ):
+        """Identical low-precision expert shards must remain identical after merging."""
+        del mock_row_linear
+        weight = torch.full((2, 2), 0.1, dtype=torch.bfloat16)
+        mock_linear_in = Mock()
+        mock_linear_in.sharded_state_dict.return_value = {
+            "adapter.linear_in.weight": ShardedTensor.from_rank_offsets(
+                "adapter.linear_in.weight", weight, replica_id=(0, 0, 0)
+            ),
+        }
+        mock_linear_out = Mock()
+        mock_linear_out.sharded_state_dict.return_value = {}
+        mock_col_linear.side_effect = [mock_linear_in, mock_linear_out]
+        mock_config.num_moe_experts = 16
+        mock_config._pg_collection = make_mock_pg_collection(ep_size=1, ep_rank=0)
+
+        adapter = ParallelLinearAdapter(
+            in_features=2,
+            out_features=2,
+            dim=2,
+            base_linear_name="decoder.layers.0.mlp.experts.linear_fc2",
+            is_expert=True,
+            model_parallel_config=mock_config,
+        )
+        factory = adapter.sharded_state_dict(prefix="adapter.", metadata={"is_loading": True})[
+            "adapter.linear_in.weight"
+        ]
+        built = factory.build()
+        for shard in built:
+            shard.data.copy_(weight)
+
+        merged = factory.merge_fn([shard.data for shard in built])
+
+        assert torch.equal(merged, weight)
+
+    @patch("megatron.bridge.peft.utils.ColumnParallelLinear")
+    @patch("megatron.bridge.peft.utils.RowParallelLinear")
     def test_parallel_linear_adapter_grouped_expert_shared_adapter_syncs_grad_across_ep(
         self, mock_row_linear, mock_col_linear, mock_config
     ):

--- a/tests/unit_tests/peft/test_utils.py
+++ b/tests/unit_tests/peft/test_utils.py
@@ -43,6 +43,7 @@ from megatron.bridge.peft.utils import (
     is_grouped_expert_linear,
     pad_seq_to_mult,
     unpad_seq_to_mult,
+    validate_shared_expert_adapter_source_ep,
     wildcard_match,
 )
 
@@ -1188,8 +1189,10 @@ class TestParallelLinearAdapter:
             model_parallel_config=mock_config,
         )
 
+        model = nn.Module()
+        model.add_module("adapter", adapter)
         with pytest.raises(ValueError, match="requires the source expert_model_parallel_size"):
-            adapter.sharded_state_dict(prefix="adapter.", metadata={"is_loading": True})
+            validate_shared_expert_adapter_source_ep(model, None)
 
     @patch("megatron.bridge.peft.utils.ColumnParallelLinear")
     @patch("megatron.bridge.peft.utils.RowParallelLinear")
@@ -1418,7 +1421,10 @@ class TestParallelLinearAdapter:
             model_parallel_config=mock_config,
         )
         sharded_state_dict = {
-            "model": adapter.sharded_state_dict(prefix="decoder.layers.0.mlp.experts.linear_fc2.adapter.")
+            "model": adapter.sharded_state_dict(
+                prefix="decoder.layers.0.mlp.experts.linear_fc2.adapter.",
+                metadata={"is_loading": True},
+            )
         }
         metadata = {
             "decoder.layers.0.mlp.experts.linear_fc2.adapter.linear_in.weight": ShardedTensor.from_rank_offsets(

--- a/tests/unit_tests/peft/test_utils.py
+++ b/tests/unit_tests/peft/test_utils.py
@@ -1165,6 +1165,43 @@ class TestParallelLinearAdapter:
 
     @patch("megatron.bridge.peft.utils.ColumnParallelLinear")
     @patch("megatron.bridge.peft.utils.RowParallelLinear")
+    def test_shared_grouped_expert_same_ep_load_reuses_staging_buffer(
+        self, mock_row_linear, mock_col_linear, mock_config
+    ):
+        """Known unchanged EP topology should not allocate one full buffer per local expert."""
+        del mock_row_linear
+        weight = torch.zeros(2, 2)
+        mock_linear_in = Mock()
+        mock_linear_in.sharded_state_dict.return_value = {
+            "adapter.linear_in.weight": ShardedTensor.from_rank_offsets(
+                "adapter.linear_in.weight", weight, replica_id=(0, 0, 0)
+            ),
+        }
+        mock_linear_out = Mock()
+        mock_linear_out.sharded_state_dict.return_value = {}
+        mock_col_linear.side_effect = [mock_linear_in, mock_linear_out]
+        mock_config.num_moe_experts = 4
+        mock_config._pg_collection = make_mock_pg_collection(ep_size=2, ep_rank=0)
+
+        adapter = ParallelLinearAdapter(
+            in_features=2,
+            out_features=2,
+            dim=2,
+            base_linear_name="decoder.layers.0.mlp.experts.linear_fc2",
+            is_expert=True,
+            model_parallel_config=mock_config,
+        )
+        factory = adapter.sharded_state_dict(
+            prefix="adapter.",
+            metadata={"is_loading": True, "source_expert_model_parallel_size": 2},
+        )["adapter.linear_in.weight"]
+
+        built = factory.build()
+
+        assert len({shard.data.untyped_storage().data_ptr() for shard in built}) == 1
+
+    @patch("megatron.bridge.peft.utils.ColumnParallelLinear")
+    @patch("megatron.bridge.peft.utils.RowParallelLinear")
     def test_shared_grouped_expert_load_rejects_unknown_source_ep(self, mock_row_linear, mock_col_linear, mock_config):
         """An EP>1 load must not silently assume that an unknown source topology is unchanged."""
         del mock_row_linear
@@ -2705,6 +2742,7 @@ def test_load_peft_adapter_checkpoint_filters_and_loads(monkeypatch) -> None:
         "/adapter",
         peft=peft,
         strict=False,
+        model_sd_kwargs={"metadata": {"source_expert_model_parallel_size": 2}},
         fully_parallel_load=False,
         load_strategy="strategy",
     )
@@ -2712,7 +2750,7 @@ def test_load_peft_adapter_checkpoint_filters_and_loads(monkeypatch) -> None:
     assert sorted(calls["sharded_state_dict"]["model"]) == ["adapter.weight"]
     assert calls["checkpoint_path"] == "/adapter"
     assert calls["load_strategy"] == "strategy"
-    assert calls["model_sd_kwargs"] == {"metadata": {"is_loading": True}}
+    assert calls["model_sd_kwargs"] == {"metadata": {"is_loading": True, "source_expert_model_parallel_size": 2}}
     assert torch.equal(model[0].loaded_state_dict["adapter.weight"], torch.tensor([4.0]))
     assert model[0].loaded_strict is False
 

--- a/tests/unit_tests/peft/test_utils.py
+++ b/tests/unit_tests/peft/test_utils.py
@@ -1107,6 +1107,59 @@ class TestParallelLinearAdapter:
 
     @patch("megatron.bridge.peft.utils.ColumnParallelLinear")
     @patch("megatron.bridge.peft.utils.RowParallelLinear")
+    def test_shared_grouped_expert_merge_reduces_across_ep_only_when_resharding(
+        self, mock_row_linear, mock_col_linear, mock_config
+    ):
+        """EP topology changes must produce one global mean without altering same-EP loads."""
+        del mock_row_linear
+        mock_linear_in = Mock()
+        mock_linear_in.sharded_state_dict.return_value = {
+            "adapter.linear_in.weight": ShardedTensor.from_rank_offsets(
+                "adapter.linear_in.weight", torch.zeros(2, 2), replica_id=(0, 0, 0)
+            ),
+        }
+        mock_linear_out = Mock()
+        mock_linear_out.sharded_state_dict.return_value = {}
+        mock_col_linear.side_effect = [mock_linear_in, mock_linear_out]
+        mock_config.num_moe_experts = 4
+        mock_config._pg_collection = make_mock_pg_collection(ep_size=2, ep_rank=0)
+
+        adapter = ParallelLinearAdapter(
+            in_features=2,
+            out_features=2,
+            dim=2,
+            base_linear_name="decoder.layers.0.mlp.experts.linear_fc2",
+            is_expert=True,
+            model_parallel_config=mock_config,
+        )
+        same_ep_factory = adapter.sharded_state_dict(
+            prefix="adapter.",
+            metadata={"is_loading": True, "source_expert_model_parallel_size": 2},
+        )["adapter.linear_in.weight"]
+        reshard_factory = adapter.sharded_state_dict(
+            prefix="adapter.",
+            metadata={"is_loading": True, "source_expert_model_parallel_size": 4},
+        )["adapter.linear_in.weight"]
+        local_shards = [torch.ones(2, 2), torch.full((2, 2), 3.0)]
+
+        with patch("torch.distributed.all_reduce") as mock_all_reduce:
+            same_ep_merged = same_ep_factory.merge_fn(local_shards)
+
+        mock_all_reduce.assert_not_called()
+        torch.testing.assert_close(same_ep_merged, torch.full((2, 2), 2.0))
+
+        def add_other_destination_mean(tensor, group):
+            assert group is mock_config._pg_collection.ep
+            tensor.add_(6.0)
+
+        with patch("torch.distributed.all_reduce", side_effect=add_other_destination_mean) as mock_all_reduce:
+            resharded = reshard_factory.merge_fn(local_shards)
+
+        mock_all_reduce.assert_called_once()
+        torch.testing.assert_close(resharded, torch.full((2, 2), 4.0))
+
+    @patch("megatron.bridge.peft.utils.ColumnParallelLinear")
+    @patch("megatron.bridge.peft.utils.RowParallelLinear")
     def test_parallel_linear_adapter_grouped_expert_shared_adapter_syncs_grad_across_ep(
         self, mock_row_linear, mock_col_linear, mock_config
     ):

--- a/tests/unit_tests/peft/test_utils.py
+++ b/tests/unit_tests/peft/test_utils.py
@@ -1132,14 +1132,18 @@ class TestParallelLinearAdapter:
             is_expert=True,
             model_parallel_config=mock_config,
         )
-        same_ep_factory = adapter.sharded_state_dict(
-            prefix="adapter.",
-            metadata={"is_loading": True, "source_expert_model_parallel_size": 2},
-        )["adapter.linear_in.weight"]
-        reshard_factory = adapter.sharded_state_dict(
-            prefix="adapter.",
-            metadata={"is_loading": True, "source_expert_model_parallel_size": 4},
-        )["adapter.linear_in.weight"]
+        sharded_tensor = mock_linear_in.sharded_state_dict.return_value["adapter.linear_in.weight"]
+        same_ep_factory = adapter._apply_expert_axis_factory(
+            sharded_tensor,
+            (),
+            is_loading=True,
+        )
+        reshard_factory = adapter._apply_expert_axis_factory(
+            sharded_tensor,
+            (),
+            is_loading=True,
+            reshard_expert_parallel=True,
+        )
         local_shards = [torch.ones(2, 2), torch.full((2, 2), 3.0)]
 
         with patch("torch.distributed.all_reduce") as mock_all_reduce:

--- a/tests/unit_tests/peft/test_utils.py
+++ b/tests/unit_tests/peft/test_utils.py
@@ -960,6 +960,7 @@ class TestParallelLinearAdapter:
 
         built = factory.build()
         assert len(built) == 2
+        assert len({shard.data.untyped_storage().data_ptr() for shard in built}) == 1
         assert built[0].global_shape == (4, 2, 2)
         assert built[0].global_offset == (2, 0, 0)
         assert built[1].global_offset == (3, 0, 0)
@@ -1043,7 +1044,7 @@ class TestParallelLinearAdapter:
             is_expert=True,
             model_parallel_config=mock_config,
         )
-        state_dict = adapter.sharded_state_dict(prefix="adapter.")
+        state_dict = adapter.sharded_state_dict(prefix="adapter.", metadata={"is_loading": True})
 
         factory = state_dict[key]
         assert isinstance(factory, ShardedTensorFactory)

--- a/tests/unit_tests/peft/test_utils.py
+++ b/tests/unit_tests/peft/test_utils.py
@@ -1064,6 +1064,7 @@ class TestParallelLinearAdapter:
             f"got {torch.unique(merged).tolist()} with {expert_storage_count}/"
             f"{mock_config.num_moe_experts} independent expert buffers"
         )
+        assert all(shard.data.device.type == "cpu" for shard in built)
 
     @patch("megatron.bridge.peft.utils.ColumnParallelLinear")
     @patch("megatron.bridge.peft.utils.RowParallelLinear")
@@ -2550,9 +2551,13 @@ def test_load_peft_adapter_checkpoint_filters_and_loads(monkeypatch) -> None:
             }
         }
 
+    def fake_model_state_dict(model, model_sd_kwargs, ckpt_format, pg_collection=None):
+        calls["model_sd_kwargs"] = model_sd_kwargs
+        return {"model": model[0].sharded_state_dict()}
+
     _patch_checkpointing(
         monkeypatch,
-        lambda model, model_sd_kwargs, ckpt_format, pg_collection=None: {"model": model[0].sharded_state_dict()},
+        fake_model_state_dict,
         fake_filter,
     )
 
@@ -2576,6 +2581,7 @@ def test_load_peft_adapter_checkpoint_filters_and_loads(monkeypatch) -> None:
     assert sorted(calls["sharded_state_dict"]["model"]) == ["adapter.weight"]
     assert calls["checkpoint_path"] == "/adapter"
     assert calls["load_strategy"] == "strategy"
+    assert calls["model_sd_kwargs"] == {"metadata": {"is_loading": True}}
     assert torch.equal(model[0].loaded_state_dict["adapter.weight"], torch.tensor([4.0]))
     assert model[0].loaded_strict is False
 

--- a/tests/unit_tests/training/test_checkpointing.py
+++ b/tests/unit_tests/training/test_checkpointing.py
@@ -2566,7 +2566,8 @@ class TestLoadModelWeightsFromCheckpoint:
         mock_unwrap_model.assert_called_once_with(mock_model)
         mock_generate_state_dict.assert_called_once()
         call_args = mock_generate_state_dict.call_args
-        assert call_args[0][1] == {"metadata": mock_metadata}
+        assert call_args[0][1] == {"metadata": {**mock_metadata, "is_loading": True}}
+        assert "is_loading" not in mock_metadata
         mock_strategy_cls.assert_called_once_with()
         mock_load_state_dict.assert_called_once_with(mock_model[0], mock_full_state_dict["model"], True)
         mock_gc_collect.assert_called_once_with()

--- a/tests/unit_tests/training/test_checkpointing.py
+++ b/tests/unit_tests/training/test_checkpointing.py
@@ -3760,6 +3760,43 @@ class TestFSDPDTensorFunctionality:
 
         assert result["distrib_optim_sharding_type"] == "dp_reshardable"
 
+    def test_checkpoint_expert_parallel_size_preserves_msc_uri(self):
+        """Run-config discovery must not collapse the double slash in MSC URIs."""
+        from megatron.bridge.training.checkpointing import _checkpoint_expert_parallel_size
+
+        class FakeMSCPath:
+            def __init__(self, value):
+                self.value = value
+
+            def __str__(self):
+                return self.value
+
+            def __truediv__(self, child):
+                return FakeMSCPath(f"{self.value.rstrip('/')}/{child}")
+
+            @property
+            def parent(self):
+                return FakeMSCPath(self.value.rsplit("/", 1)[0])
+
+        fake_msc = Mock(Path=FakeMSCPath)
+        parent_config = "msc://bucket/checkpoints/run_config.yaml"
+        with (
+            patch.object(MultiStorageClientFeature, "is_enabled", return_value=True),
+            patch.object(MultiStorageClientFeature, "import_package", return_value=fake_msc),
+            patch(
+                "megatron.bridge.training.checkpointing.file_exists",
+                side_effect=lambda path: path == parent_config,
+            ),
+            patch(
+                "megatron.bridge.training.checkpointing.read_run_config",
+                return_value={"model": {"expert_model_parallel_size": 4}},
+            ) as mock_read_run_config,
+        ):
+            result = _checkpoint_expert_parallel_size("msc://bucket/checkpoints/iter_0000001")
+
+        assert result == 4
+        mock_read_run_config.assert_called_once_with(parent_config)
+
     @patch("megatron.bridge.training.checkpointing.HAVE_MEGATRON_FSDP", True)
     @patch("torch.distributed.checkpoint.FileSystemReader")
     @patch("torch.distributed.checkpoint.load_state_dict")

--- a/tests/unit_tests/training/test_checkpointing.py
+++ b/tests/unit_tests/training/test_checkpointing.py
@@ -3817,6 +3817,22 @@ class TestFSDPDTensorFunctionality:
         assert result == 4
         mock_load_common_state_dict.assert_called_once_with("/checkpoints/iter_0000001")
 
+    def test_checkpoint_expert_parallel_size_falls_back_after_invalid_run_config(self):
+        """A malformed run config must not prevent legacy common-args discovery."""
+        from megatron.bridge.training.checkpointing import _checkpoint_expert_parallel_size
+
+        with (
+            patch("megatron.bridge.training.checkpointing.file_exists", return_value=True),
+            patch("megatron.bridge.training.checkpointing.read_run_config", side_effect=ValueError("invalid yaml")),
+            patch(
+                "megatron.bridge.training.checkpointing.dist_checkpointing.load_common_state_dict",
+                return_value={"args": Mock(expert_model_parallel_size=2)},
+            ),
+        ):
+            result = _checkpoint_expert_parallel_size("/checkpoints/iter_0000001")
+
+        assert result == 2
+
     @patch("megatron.bridge.training.checkpointing.HAVE_MEGATRON_FSDP", True)
     @patch("torch.distributed.checkpoint.FileSystemReader")
     @patch("torch.distributed.checkpoint.load_state_dict")

--- a/tests/unit_tests/training/test_checkpointing.py
+++ b/tests/unit_tests/training/test_checkpointing.py
@@ -2895,6 +2895,7 @@ class TestMegatronLMCompatibility:
         mock_args = Mock()
         mock_args.tensor_model_parallel_size = 2
         mock_args.pipeline_model_parallel_size = 4
+        mock_args.expert_model_parallel_size = 8
         mock_args.encoder_tensor_model_parallel_size = 1
         mock_args.encoder_pipeline_model_parallel_size = 2
         mock_args.no_save_optim = False  # Will become save_optim = True
@@ -2909,6 +2910,7 @@ class TestMegatronLMCompatibility:
             "model": {
                 "tensor_model_parallel_size": 2,
                 "pipeline_model_parallel_size": 4,
+                "expert_model_parallel_size": 8,
                 "encoder_tensor_model_parallel_size": 1,
                 "encoder_pipeline_model_parallel_size": 2,
             },
@@ -2941,6 +2943,7 @@ class TestMegatronLMCompatibility:
             "model": {
                 "tensor_model_parallel_size": 1,
                 "pipeline_model_parallel_size": 1,  # default
+                "expert_model_parallel_size": 1,  # default
                 "encoder_tensor_model_parallel_size": 0,  # default
                 "encoder_pipeline_model_parallel_size": 0,  # default
             },
@@ -3796,6 +3799,23 @@ class TestFSDPDTensorFunctionality:
 
         assert result == 4
         mock_read_run_config.assert_called_once_with(parent_config)
+
+    def test_checkpoint_expert_parallel_size_falls_back_to_legacy_args(self):
+        """Legacy distributed checkpoints can provide EP topology through their common args."""
+        from megatron.bridge.training.checkpointing import _checkpoint_expert_parallel_size
+
+        common_state_dict = {"args": Mock(expert_model_parallel_size=4)}
+        with (
+            patch("megatron.bridge.training.checkpointing.file_exists", return_value=False),
+            patch(
+                "megatron.bridge.training.checkpointing.dist_checkpointing.load_common_state_dict",
+                return_value=common_state_dict,
+            ) as mock_load_common_state_dict,
+        ):
+            result = _checkpoint_expert_parallel_size("/checkpoints/iter_0000001")
+
+        assert result == 4
+        mock_load_common_state_dict.assert_called_once_with("/checkpoints/iter_0000001")
 
     @patch("megatron.bridge.training.checkpointing.HAVE_MEGATRON_FSDP", True)
     @patch("torch.distributed.checkpoint.FileSystemReader")

--- a/tests/unit_tests/training/test_checkpointing.py
+++ b/tests/unit_tests/training/test_checkpointing.py
@@ -2548,6 +2548,10 @@ class TestLoadModelWeightsFromCheckpoint:
         from megatron.bridge.training.checkpointing import _load_model_weights_from_checkpoint
 
         with (
+            patch(
+                "megatron.bridge.training.checkpointing._checkpoint_expert_parallel_size",
+                return_value=None,
+            ),
             patch("megatron.bridge.training.checkpointing.gc.collect") as mock_gc_collect,
             patch("megatron.bridge.training.checkpointing.torch.cuda.is_available", return_value=True),
             patch("megatron.bridge.training.checkpointing.torch.cuda.empty_cache") as mock_empty_cache,


### PR DESCRIPTION
# What does this PR do ?

Preserve every shared grouped-expert LoRA checkpoint shard during load so EP resharding computes the intended expert-parallel mean instead of selecting one rank value.

# Changelog

- Mark Bridge training, direct adapter load/export, and standalone adapter load workflows with load-time sharding metadata.
- Give every expert slot an independent CPU checkpoint destination during reshard loads, avoiding aliasing and extra GPU staging pressure.
- Reuse the original buffer for save and known unchanged-topology loads, keeping ordinary resumes bounded in host memory.
- Average normal and SwiGLU expert shards with a bounded-memory FP32-or-higher accumulator and cast once, preventing low-precision drift.
- Read source EP topology from caller metadata, the run configuration, or legacy checkpoint args; reduce local means across destination EP ranks only when topology changes.
- Preserve local-checkpoint resumes and detect legacy 2D shared adapters before validating source EP topology.
- Reject non-legacy EP>1 adapter loads when source topology is genuinely unavailable instead of silently producing rank-dependent weights.
- Preserve MSC-backed checkpoint paths and tolerate malformed run configs while locating fallback metadata.
- Add focused regression coverage for FC1 and FC2 shared-expert adapters across both `linear_in.weight` and `linear_out.weight`, same-topology loads, cross-EP reduction, BF16 stability, legacy detection, and adapter load/export entry points.
- Confirm the direct merge remains an arithmetic mean; the original defect was buffer aliasing, not merge ordering or reduction semantics.

# GitHub Actions CI

Validated after independent review:

- Focused `uv run python -m pytest` selection — 45 passed.
- Tiny-model distributed checkpoint check — EP=2 save → EP=2 load retained each rank value; EP=2 save → EP=1 load produced exact means `2`, `9`, `24`, and `38` for all four shared-expert adapter tensors.
- `uv run pre-commit run --all-files` — passed.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed the Contributor guidelines.
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation? No documentation change is needed because this restores existing checkpoint semantics without changing user-facing APIs or configuration.
- [x] Does the PR affect components that are optional to install? No.
  - [x] Reviewer: Does the PR have correct import guards for all optional libraries? Not applicable.

# Additional Information

- NVBug 6565838
- Fail-before used distinct EP-rank values across every affected tensor: FC1 `linear_in` expected `2`, observed `3`; FC1 `linear_out` expected `9`, observed `7`; FC2 `linear_in` expected `24`, observed `27`; FC2 `linear_out` expected `38`, observed `35`. This confirms last-writer buffer aliasing.
