### PR TITLE
fix(training): include MTP stages in embedding groups

### DIFF
--- a/src/megatron/bridge/training/setup.py
+++ b/src/megatron/bridge/training/setup.py
@@ -95,7 +95,7 @@ def _get_embedding_ranks(
     return embedding_ranks
 
 
-def _resolve_embedding_ranks_callback(
+def _resolve_embedding_ranks_fn(
     model_config: object,
     get_embedding_ranks: Callable[[list[int], Optional[int]], list[int]] | None,
 ) -> Callable[[list[int], Optional[int]], list[int]] | None:
@@ -278,7 +278,7 @@ def setup(
         set_level_for_all_loggers=cfg.logger.set_level_for_all_loggers,
     )
 
-    get_embedding_ranks = _resolve_embedding_ranks_callback(cfg.model, get_embedding_ranks)
+    get_embedding_ranks = _resolve_embedding_ranks_fn(cfg.model, get_embedding_ranks)
 
     # pg_collection is returned from initialize_megatron:
     # - When use_decentralized_pg=True: uses HyperCommGrid to create local process groups

--- a/src/megatron/bridge/training/setup.py
+++ b/src/megatron/bridge/training/setup.py
@@ -72,22 +72,27 @@ from megatron.bridge.training.utils.train_utils import start_memory_history_reco
 from megatron.bridge.utils.common_utils import get_rank_safe, print_rank_0
 
 
-def _get_language_model_embedding_ranks(
+def _get_embedding_ranks(
     pp_ranks: list[int],
     pipeline_model_parallel_size: int | None = None,
     *,
     model_config: GPTModelConfig | GPTModelProvider | HybridModelConfig | HybridModelProvider,
 ) -> list[int]:
-    """Return pipeline ranks that hold synchronized language-model embeddings."""
+    """Get the embedding ranks for a Bridge language-model config."""
+    # HyperCommGrid passes PP size as a second argument; MCore's MPU path does not.
     del pipeline_model_parallel_size
 
-    embedding_ranks = {pp_ranks[0]}
+    # Keep this rank construction aligned with pretrain_gpt.get_embedding_ranks in MCore.
+    embedding_ranks = [pp_ranks[0]]
     if len(pp_ranks) > 1:
         if model_config.share_embeddings_and_output_weights:
-            embedding_ranks.add(pp_ranks[-1])
+            embedding_ranks.append(pp_ranks[-1])
         transformer_config = model_config.transformer if hasattr(model_config, "transformer") else model_config
-        embedding_ranks.update(get_mtp_ranks(pp_ranks, transformer_config))
-    return sorted(embedding_ranks)
+        mtp_ranks = get_mtp_ranks(pp_ranks, transformer_config)
+        embedding_ranks.extend(mtp_ranks)
+    embedding_ranks = list(set(embedding_ranks))
+    embedding_ranks = sorted(embedding_ranks)
+    return embedding_ranks
 
 
 def _resolve_embedding_ranks_callback(
@@ -100,7 +105,7 @@ def _resolve_embedding_ranks_callback(
 
     language_model_configs = (GPTModelConfig, GPTModelProvider, HybridModelConfig, HybridModelProvider)
     if isinstance(model_config, language_model_configs):
-        return partial(_get_language_model_embedding_ranks, model_config=model_config)
+        return partial(_get_embedding_ranks, model_config=model_config)
     return None
 
 

--- a/src/megatron/bridge/training/setup.py
+++ b/src/megatron/bridge/training/setup.py
@@ -33,11 +33,14 @@ from megatron.core.optimizer_param_scheduler import OptimizerParamScheduler
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.rerun_state_machine import RerunDataIterator
 from megatron.core.transformer import MegatronModule
+from megatron.core.transformer.multi_token_prediction import get_mtp_ranks
 from megatron.training.models.base import ModelConfig
 
 from megatron.bridge.data.loaders import build_train_valid_test_datasets_for_num_epochs, setup_data_iterators
 from megatron.bridge.models.gpt.gpt_builder import GPTModelConfig
+from megatron.bridge.models.gpt_provider import GPTModelProvider
 from megatron.bridge.models.hybrid.hybrid_builder import HybridModelConfig
+from megatron.bridge.models.hybrid.hybrid_provider import HybridModelProvider
 from megatron.bridge.models.model_provider import ModelProviderMixin
 from megatron.bridge.models.transformer_config import TransformerConfig
 from megatron.bridge.training import fault_tolerance
@@ -67,6 +70,38 @@ from megatron.bridge.training.utils.checkpoint_utils import checkpoint_exists, i
 from megatron.bridge.training.utils.log_utils import append_to_progress_log, barrier_and_log, setup_logging
 from megatron.bridge.training.utils.train_utils import start_memory_history_recording
 from megatron.bridge.utils.common_utils import get_rank_safe, print_rank_0
+
+
+def _get_language_model_embedding_ranks(
+    pp_ranks: list[int],
+    pipeline_model_parallel_size: int | None = None,
+    *,
+    model_config: GPTModelConfig | GPTModelProvider | HybridModelConfig | HybridModelProvider,
+) -> list[int]:
+    """Return pipeline ranks that hold synchronized language-model embeddings."""
+    del pipeline_model_parallel_size
+
+    embedding_ranks = {pp_ranks[0]}
+    if len(pp_ranks) > 1:
+        if model_config.share_embeddings_and_output_weights:
+            embedding_ranks.add(pp_ranks[-1])
+        transformer_config = model_config.transformer if hasattr(model_config, "transformer") else model_config
+        embedding_ranks.update(get_mtp_ranks(pp_ranks, transformer_config))
+    return sorted(embedding_ranks)
+
+
+def _resolve_embedding_ranks_callback(
+    model_config: object,
+    get_embedding_ranks: Callable[[list[int], Optional[int]], list[int]] | None,
+) -> Callable[[list[int], Optional[int]], list[int]] | None:
+    """Use model-aware language-model embedding ranks unless the caller supplied an override."""
+    if get_embedding_ranks is not None:
+        return get_embedding_ranks
+
+    language_model_configs = (GPTModelConfig, GPTModelProvider, HybridModelConfig, HybridModelProvider)
+    if isinstance(model_config, language_model_configs):
+        return partial(_get_language_model_embedding_ranks, model_config=model_config)
+    return None
 
 
 try:
@@ -237,6 +272,8 @@ def setup(
         modules_to_filter=cfg.logger.modules_to_filter,
         set_level_for_all_loggers=cfg.logger.set_level_for_all_loggers,
     )
+
+    get_embedding_ranks = _resolve_embedding_ranks_callback(cfg.model, get_embedding_ranks)
 
     # pg_collection is returned from initialize_megatron:
     # - When use_decentralized_pg=True: uses HyperCommGrid to create local process groups

--- a/tests/unit_tests/training/test_setup.py
+++ b/tests/unit_tests/training/test_setup.py
@@ -31,6 +31,7 @@ from megatron.bridge.training.setup import (
     _build_distributed_model,
     _register_pre_wrap_hook,
     _register_setup_pre_wrap_hook,
+    _resolve_embedding_ranks_callback,
     _should_load_checkpoint,
     _update_model_config_funcs,
     _validate_and_set_vocab_size,
@@ -72,6 +73,31 @@ def _make_checkpoint_source_config(
         peft=peft,
         _checkpoint_load_required=required,
     )
+
+
+@pytest.mark.parametrize(
+    ("share_embeddings_and_output_weights", "expected_ranks"),
+    [(False, [0, 1]), (True, [0, 1, 2])],
+)
+def test_mtp_embedding_group_includes_standalone_mtp_stage(
+    share_embeddings_and_output_weights,
+    expected_ranks,
+):
+    model_config = GPTModelProvider(
+        share_embeddings_and_output_weights=share_embeddings_and_output_weights,
+        hidden_size=128,
+        mtp_num_layers=1,
+        num_attention_heads=1,
+        num_layers=1,
+        pipeline_model_parallel_layout="Et|m|L",
+        pipeline_model_parallel_size=3,
+    )
+    model_config.finalize()
+
+    get_embedding_ranks = _resolve_embedding_ranks_callback(model_config, None)
+
+    assert get_embedding_ranks is not None
+    assert get_embedding_ranks([0, 1, 2]) == expected_ranks
 
 
 def test_gpt_sft_config_receives_tokenizer_through_builder_binding_without_mutation():

--- a/tests/unit_tests/training/test_setup.py
+++ b/tests/unit_tests/training/test_setup.py
@@ -23,6 +23,8 @@ import megatron.bridge.training.setup as training_setup
 from megatron.bridge.data.builders import GPTSFTDatasetConfig
 from megatron.bridge.models.gpt.gpt_builder import GPTModelConfig
 from megatron.bridge.models.gpt_provider import GPTModelProvider
+from megatron.bridge.models.hybrid.hybrid_builder import HybridModelConfig
+from megatron.bridge.models.hybrid.hybrid_provider import HybridModelProvider
 from megatron.bridge.models.transformer_config import TransformerConfig
 from megatron.bridge.training.callbacks import CallbackManager
 from megatron.bridge.training.checkpointing import load_checkpoint
@@ -53,6 +55,30 @@ def _make_gpt_model_config(**kwargs):
     return GPTModelConfig(**defaults)
 
 
+def _make_mtp_model_config(model_config_cls, *, share_embeddings_and_output_weights=False):
+    transformer_kwargs = {
+        "hidden_size": 128,
+        "mtp_num_layers": 1,
+        "num_attention_heads": 1,
+        "num_layers": 1,
+        "pipeline_model_parallel_layout": "Et|m|L",
+        "pipeline_model_parallel_size": 3,
+    }
+    if model_config_cls in (GPTModelProvider, HybridModelProvider):
+        model_config = model_config_cls(
+            share_embeddings_and_output_weights=share_embeddings_and_output_weights,
+            **transformer_kwargs,
+        )
+    else:
+        model_config = model_config_cls(
+            share_embeddings_and_output_weights=share_embeddings_and_output_weights,
+            transformer=_make_transformer(**transformer_kwargs),
+            vocab_size=128,
+        )
+    model_config.finalize()
+    return model_config
+
+
 def _make_checkpoint_source_config(
     *,
     load,
@@ -79,25 +105,58 @@ def _make_checkpoint_source_config(
     ("share_embeddings_and_output_weights", "expected_ranks"),
     [(False, [0, 1]), (True, [0, 1, 2])],
 )
+@pytest.mark.parametrize(
+    "model_config_cls",
+    [GPTModelConfig, GPTModelProvider, HybridModelConfig, HybridModelProvider],
+)
 def test_mtp_embedding_group_includes_standalone_mtp_stage(
+    model_config_cls,
     share_embeddings_and_output_weights,
     expected_ranks,
 ):
-    model_config = GPTModelProvider(
+    model_config = _make_mtp_model_config(
+        model_config_cls,
         share_embeddings_and_output_weights=share_embeddings_and_output_weights,
-        hidden_size=128,
-        mtp_num_layers=1,
-        num_attention_heads=1,
-        num_layers=1,
-        pipeline_model_parallel_layout="Et|m|L",
-        pipeline_model_parallel_size=3,
     )
-    model_config.finalize()
 
     get_embedding_ranks = _resolve_embedding_ranks_callback(model_config, None)
+    explicit_callback = Mock()
 
     assert get_embedding_ranks is not None
     assert get_embedding_ranks([0, 1, 2]) == expected_ranks
+    assert _resolve_embedding_ranks_callback(model_config, explicit_callback) is explicit_callback
+
+
+def test_setup_forwards_model_aware_embedding_ranks_to_parallel_initialization():
+    model_config = _make_mtp_model_config(GPTModelProvider)
+    cfg = SimpleNamespace(
+        dist=SimpleNamespace(disable_jit_fuser=False, enable_megatron_core_experimental=False),
+        logger=SimpleNamespace(
+            filter_warnings=False,
+            logging_level="INFO",
+            modules_to_filter=[],
+            set_level_for_all_loggers=False,
+        ),
+        model=model_config,
+    )
+    state = SimpleNamespace(cfg=cfg, initialize_async_checkpoint_worker=Mock())
+    initialize_megatron = Mock(side_effect=RuntimeError("stop after process-group initialization"))
+
+    with (
+        patch.multiple(
+            training_setup,
+            initialize_megatron=initialize_megatron,
+            maybe_log_and_save_config=Mock(),
+            set_experimental_flag=Mock(),
+            setup_logging=Mock(),
+        ),
+        pytest.raises(RuntimeError, match="stop after process-group initialization"),
+    ):
+        training_setup.setup(state, Mock())
+
+    get_embedding_ranks = initialize_megatron.call_args.kwargs["get_embedding_ranks"]
+    assert get_embedding_ranks([0, 1, 2]) == [0, 1]
+    assert get_embedding_ranks([0, 1, 2], 3) == [0, 1]
 
 
 def test_gpt_sft_config_receives_tokenizer_through_builder_binding_without_mutation():

--- a/tests/unit_tests/training/test_setup.py
+++ b/tests/unit_tests/training/test_setup.py
@@ -33,7 +33,7 @@ from megatron.bridge.training.setup import (
     _build_distributed_model,
     _register_pre_wrap_hook,
     _register_setup_pre_wrap_hook,
-    _resolve_embedding_ranks_callback,
+    _resolve_embedding_ranks_fn,
     _should_load_checkpoint,
     _update_model_config_funcs,
     _validate_and_set_vocab_size,
@@ -119,12 +119,12 @@ def test_mtp_embedding_group_includes_standalone_mtp_stage(
         share_embeddings_and_output_weights=share_embeddings_and_output_weights,
     )
 
-    get_embedding_ranks = _resolve_embedding_ranks_callback(model_config, None)
+    get_embedding_ranks = _resolve_embedding_ranks_fn(model_config, None)
     explicit_callback = Mock()
 
     assert get_embedding_ranks is not None
     assert get_embedding_ranks([0, 1, 2]) == expected_ranks
-    assert _resolve_embedding_ranks_callback(model_config, explicit_callback) is explicit_callback
+    assert _resolve_embedding_ranks_fn(model_config, explicit_callback) is explicit_callback
 
 
 def test_setup_forwards_model_aware_embedding_ranks_to_parallel_initialization():


### PR DESCRIPTION
# What does this PR do ?

Fix MTP checkpoint-resume loss discontinuity when a custom pipeline layout places MTP on a standalone stage and embeddings/output are untied.

Bridge previously used the generic first+last embedding process group. MCore GPT training instead synchronizes the first stage with every MTP stage, and adds the last stage only when embeddings and output weights are tied. The incorrect Bridge group let the live standalone MTP embedding diverge, while checkpoint load correctly restored it as a replica of the first-stage embedding, causing the first resumed MTP loss to jump.

# Changelog

- Derive default GPT and hybrid embedding ranks from the model configuration.
- Mirror MCore `pretrain_gpt.py` rank construction: first stage, tied last stage, all MTP stages, then deduplicate and sort.
- Include all MTP stages in the embedding group.
- Exclude an untied output-only stage while preserving tied output behavior.
- Preserve explicitly supplied embedding-rank callbacks.
- Add focused unit coverage for tied and untied standalone-MTP layouts, supported model-config forms, callback signatures, and setup forwarding.

# Validation

- uv run --no-sync python -m pytest tests/unit_tests/training/test_setup.py tests/unit_tests/training/test_initialize.py -q: 62 passed.
- uv run --no-sync pre-commit run --all-files: passed.
- Deterministic toy training with pipeline layout Et|m|L, distributed optimizer, checkpointed scheduler/RNG state, and mock-data resume position:
  - Before: iteration 3 LM matched at 4.788573, but MTP differed (continuous 4.796426, resumed 4.809828).
  - After: iteration 3 matched exactly at 9 consumed samples, LR 6.954058e-05, LM 4.766467, MTP 4.816601, and grad norm 3.097.

# GitHub Actions CI

See the CI section in CONTRIBUTING.md for trigger instructions.

# Before your PR is Ready for review

- [x] Read and followed the contributor guidelines.
- [x] Added focused unit tests.
- [x] Evaluated documentation impact; no user-facing API or configuration changed.
- [x] No optional-install component is affected.

# Additional Information

The three-stage manual reproducer is intentionally not added to functional CI because repository functional tests are limited to at most two GPUs.
