### PR TITLE
fix(perf): mount common performance scripts

### DIFF
--- a/scripts/performance/setup_experiment.py
+++ b/scripts/performance/setup_experiment.py
@@ -63,6 +63,7 @@ except (ImportError, ModuleNotFoundError):
 SCRIPT_DIR = Path(__file__).parent.resolve()
 REPO_ROOT = SCRIPT_DIR.parents[1]
 BRIDGE_SOURCE_DIR = REPO_ROOT / "src" / "megatron" / "bridge"
+COMMON_SCRIPTS_DIR = REPO_ROOT / "scripts" / "common"
 ENTRYPOINT_BOOTSTRAP = "bootstrap.py"
 
 logging.basicConfig(level=logging.DEBUG)
@@ -641,6 +642,7 @@ def main(
         [
             f"{run_script_path}:{run_script_path}",
             f"{SCRIPT_DIR}:{SCRIPT_DIR}",
+            f"{COMMON_SCRIPTS_DIR}:{COMMON_SCRIPTS_DIR}",
             _bridge_source_mount(in_container_script_dir),
         ]
     )


### PR DESCRIPTION
## Summary

Mount `scripts/common` alongside `scripts/performance` when launching performance workloads with custom mounts.

## Problem

`scripts/performance/utils/utils.py` imports `benchmark_parallelism` from `scripts/common`. However, `setup_experiment.py` only mounted `scripts/performance`, causing:

`ModuleNotFoundError: No module named 'benchmark_parallelism'`

This affected custom-mounted Slurm/Pyxis launches even when the staged Megatron-Bridge checkout and container used the same commit.

## Fix

Add `scripts/common` to the custom mounts generated by `setup_experiment.py`.

