### PR TITLE
perf(recipe): llama3 70B GB200 NVFP4 — capture the whole Transformer layer

### DIFF
--- a/src/megatron/bridge/perf_recipes/llama/gb200/llama3.py
+++ b/src/megatron/bridge/perf_recipes/llama/gb200/llama3.py
@@ -29,6 +29,7 @@ from megatron.bridge.perf_recipes.llama.common import (
     userbuffers_bf16_b200_h8192_tp2_mbs1_seqlen8192,
     userbuffers_fp8_b200_h8192_tp2_mbs1_seqlen8192,
 )
+from megatron.bridge.utils.cuda_graph import clear_cuda_graph_modules
 
 
 def llama3_8b_pretrain_8gpu_gb200_bf16_config() -> ConfigContainer:
@@ -356,7 +357,8 @@ def llama3_70b_pretrain_64gpu_gb200_nvfp4_config() -> ConfigContainer:
     cfg.train.micro_batch_size = 1
 
     cfg.model.cuda_graph_impl = "transformer_engine"
-    cfg.model.cuda_graph_scope = ["mlp", "attn"]
+    # An empty module list captures the whole Transformer layer instead of MLP and attention separately.
+    clear_cuda_graph_modules(cfg.model)
 
     cfg.comm_overlap.tp_comm_overlap = False
     cfg.comm_overlap.tp_comm_overlap_cfg = userbuffers_fp8_b200_h8192_tp2_mbs1_seqlen8192

--- a/tests/unit_tests/recipes/test_llama_perf_recipes.py
+++ b/tests/unit_tests/recipes/test_llama_perf_recipes.py
@@ -108,3 +108,33 @@ def test_llama3_70b_h100_fp8cs_sets_explicit_pipeline_layout(monkeypatch: pytest
     assert cfg.model.context_parallel_size == 1
     assert cfg.train.global_batch_size == 256
     assert cfg.train.micro_batch_size == 1
+
+
+@pytest.mark.unit
+def test_llama3_70b_gb200_nvfp4_captures_whole_transformer_layer() -> None:
+    """The 64-GPU GB200 NVFP4 recipe captures the whole Transformer layer per graph.
+
+    Megatron-Core expresses whole-layer coverage as an empty ``cuda_graph_modules``; the field's
+    ``"full"`` default normalizes to the same empty list, and ``"full"`` itself is deprecated.
+    ``clear_cuda_graph_modules()`` also clears the deprecated ``cuda_graph_scope`` so the config
+    stays off the conversion path in ``TransformerConfig.__post_init__``.
+    """
+    from megatron.bridge.perf_recipes.llama.gb200.llama3 import (
+        llama3_70b_pretrain_64gpu_gb200_nvfp4_config,
+    )
+
+    cfg = llama3_70b_pretrain_64gpu_gb200_nvfp4_config()
+
+    assert cfg.model.cuda_graph_impl == "transformer_engine"
+    assert cfg.model.cuda_graph_modules == []
+    assert cfg.model.cuda_graph_scope is None
+
+    # TE RNG trackers are derived from graphs being active, not assigned by the recipe.
+    assert cfg.model.use_te_rng_tracker is True
+    assert cfg.rng.te_rng_tracker is True
+
+    # Parallelism and batch are unchanged by the capture-scope setting.
+    assert cfg.model.tensor_model_parallel_size == 2
+    assert cfg.model.pipeline_model_parallel_size == 4
+    assert cfg.model.virtual_pipeline_model_parallel_size == 5
+    assert cfg.train.global_batch_size == 256

--- a/tests/unit_tests/recipes/test_llama_perf_recipes.py
+++ b/tests/unit_tests/recipes/test_llama_perf_recipes.py
@@ -19,6 +19,9 @@ from collections.abc import Callable
 
 import pytest
 
+from megatron.bridge.perf_recipes.llama.gb200.llama3 import (
+    llama3_70b_pretrain_64gpu_gb200_nvfp4_config,
+)
 from megatron.bridge.perf_recipes.llama.h100.llama3 import (
     llama3_70b_pretrain_64gpu_h100_fp8cs_config,
 )
@@ -111,7 +114,7 @@ def test_llama3_70b_h100_fp8cs_sets_explicit_pipeline_layout(monkeypatch: pytest
 
 
 @pytest.mark.unit
-def test_llama3_70b_gb200_nvfp4_captures_whole_transformer_layer() -> None:
+def test_llama3_70b_gb200_nvfp4_captures_whole_transformer_layer(monkeypatch: pytest.MonkeyPatch) -> None:
     """The 64-GPU GB200 NVFP4 recipe captures the whole Transformer layer per graph.
 
     Megatron-Core expresses whole-layer coverage as an empty ``cuda_graph_modules``; the field's
@@ -119,9 +122,7 @@ def test_llama3_70b_gb200_nvfp4_captures_whole_transformer_layer() -> None:
     ``clear_cuda_graph_modules()`` also clears the deprecated ``cuda_graph_scope`` so the config
     stays off the conversion path in ``TransformerConfig.__post_init__``.
     """
-    from megatron.bridge.perf_recipes.llama.gb200.llama3 import (
-        llama3_70b_pretrain_64gpu_gb200_nvfp4_config,
-    )
+    patch_recipe_construction_dependencies(monkeypatch)
 
     cfg = llama3_70b_pretrain_64gpu_gb200_nvfp4_config()
 


### PR DESCRIPTION
## What

Widens per-layer TransformerEngine CUDA graph capture in
`llama3_70b_pretrain_64gpu_gb200_nvfp4_config` from `["mlp", "attn"]` to the whole Transformer
layer.

```python
 cfg.model.cuda_graph_impl = "transformer_engine"
-cfg.model.cuda_graph_scope = ["mlp", "attn"]
+# Empty modules captures the whole Transformer layer rather than [mlp, attn] separately.
+clear_cuda_graph_modules(cfg.model)
```

## Why this shape

`cuda_graph_modules` selects capture coverage within per-layer graphs. Per its docstring in
`TransformerConfig`, `"attn"` captures `TransformerLayer._forward_attention()`, `"mlp"` captures
`TransformerLayer._forward_mlp()`, and an empty list captures the whole Transformer layer. The
previous setting produced two graphs per layer, leaving the ops between and around them outside
the capture; this produces one graph per layer covering the full `TransformerLayer.forward`.

Whole-layer is also Megatron-Core's default coverage — `cuda_graph_modules` defaults to `"full"`,
and `TransformerConfig.__post_init__` warns *"full scope is deprecated. Use empty
cuda_graph_modules to capture the whole layer."* This recipe was narrowing from that default;
the change restores it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)