### PR TITLE
Make LoRA merge happens before base quantize

### DIFF
--- a/src/megatron/bridge/models/conversion/model_bridge.py
+++ b/src/megatron/bridge/models/conversion/model_bridge.py
@@ -1481,24 +1481,32 @@ class MegatronModelBridge(
                 continue
 
             # --- Standard export path ---
+            # Merge LoRA delta into the base weight *before* quantization
+            # (``maybe_modify_converted_hf_weight``). Adding a bf16 LoRA delta to an
+            # already-quantized base (e.g. MXFP4, where the packed weight shape
+            # changes and values leave the 4-bit range) both breaks the LoRA delta
+            # shape match and produces an invalid quantized tensor, so vLLM reads
+            # back wrong weights. Merging first keeps the whole weight in the bf16
+            # domain until quantization acts on the merged result. The non-quantization
+            # work ``maybe_modify`` does (e.g. key renames) does not depend on the
+            # merge state, so the swap is safe for bridges that don't quantize.
+            if merge_adapter_weights and adapter_tasks:
+                adapter_weights = materialized_adapter_weights_cache.get(task_global_base_prefix)
+                if adapter_weights is None:
+                    adapter_weights = self.materialize_adapter_weights(adapter_tasks)
+                    materialized_adapter_weights_cache[task_global_base_prefix] = adapter_weights
+                converted_weights_dict = self._merge_lora_adapter_weights(
+                    megatron_model,
+                    converted_weights_dict,
+                    adapter_weights,
+                )
+
             converted_weights_dict = self.maybe_modify_converted_hf_weight(
                 task,
                 converted_weights_dict,
                 hf_state_dict,
             )  # dict will be none except for one expert;
             # All ranks get the full tensor
-
-            if merge_adapter_weights and adapter_tasks:
-                adapter_weights = materialized_adapter_weights_cache.get(task_global_base_prefix)
-                if adapter_weights is None:
-                    adapter_weights = self.materialize_adapter_weights(adapter_tasks)
-                    materialized_adapter_weights_cache[task_global_base_prefix] = adapter_weights
-                # Merge LoRA adapter weights back into the base tensor for HF export
-                converted_weights_dict = self._merge_lora_adapter_weights(
-                    megatron_model,
-                    converted_weights_dict,
-                    adapter_weights,
-                )
 
             converted_weights_dict = self._cast_export_weight_dtype(converted_weights_dict, task.weight_dtype)
 

--- a/tests/unit_tests/models/test_model_bridge_lora.py
+++ b/tests/unit_tests/models/test_model_bridge_lora.py
@@ -2478,6 +2478,111 @@ def test_stream_weights_megatron_to_hf_merges_router_adapters(monkeypatch):
     torch.testing.assert_close(weights[0].weight, expected)
 
 
+def test_stream_weights_megatron_to_hf_merges_lora_before_quantization(monkeypatch):
+    """LoRA delta must be merged into the bf16 base *before* ``maybe_modify`` quantizes.
+
+    If quantization runs first, the packed weight's shape no longer matches the LoRA
+    delta and the merge is silently skipped, so vLLM receives un-merged weights.
+    This test installs a ``maybe_modify`` that "quantizes" by recording the shape it
+    received and padding a sentinel column, then asserts the recorded shape is the
+    merged (base + delta) shape, not the raw base shape.
+    """
+    bridge = DummyBridge()
+
+    base_weight = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+
+    class QuantizingMapping:
+        def megatron_to_hf(self, weight, module):
+            return {"model.layers.0.mlp.fc1.weight": base_weight.clone()}
+
+    task = WeightConversionTask(
+        param_name="language_model.decoder.layers.0.mlp.fc1.to_wrap.weight",
+        global_param_name="language_model.decoder.layers.0.mlp.fc1.to_wrap.weight",
+        mapping=QuantizingMapping(),
+        pp_rank=0,
+        vp_stage=0,
+        megatron_module=None,
+        param_weight=torch.ones(1),
+    )
+
+    adapter_task = AdapterWeightConversionTask(
+        global_base_prefix="language_model.decoder.layers.0.mlp.fc1",
+        adapter_key=None,
+        alpha=2,
+        dim=2,
+        linear_in_task=WeightConversionTask(
+            param_name="local_in",
+            global_param_name="language_model.decoder.layers.0.mlp.fc1.adapter.linear_in.weight",
+            mapping=Mock(),
+        ),
+        linear_out_task=WeightConversionTask(
+            param_name="local_out",
+            global_param_name="language_model.decoder.layers.0.mlp.fc1.adapter.linear_out.weight",
+            mapping=Mock(),
+        ),
+    )
+    # delta = (alpha/dim=1) * linear_out @ linear_in = eye(2) @ in = in
+    # merged = base + in = [[2,4,6],[8,10,12]]
+    adapter_weight = AdapterWeight(
+        global_base_prefix="language_model.decoder.layers.0.mlp.fc1",
+        adapter_key=None,
+        alpha=2,
+        dim=2,
+        linear_in_weight=MegatronWeightTuple("in", torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]), vp_stage=0),
+        linear_out_weight=MegatronWeightTuple("out", torch.eye(2), vp_stage=0),
+    )
+
+    # Record what maybe_modify receives: if merge ran first, the weight is the
+    # merged tensor (base + delta); if quantize ran first, it's the raw base.
+    seen_by_maybe_modify: dict[str, torch.Tensor] = {}
+
+    def fake_maybe_modify(self, task, converted_weights_dict, hf_state_dict):
+        for name, tensor in converted_weights_dict.items():
+            seen_by_maybe_modify[name] = tensor.clone()
+        # Simulate "quantization" by tagging the tensor so we can tell it passed through.
+        return {name: t.clone() for name, t in converted_weights_dict.items()}
+
+    monkeypatch.setattr(DummyBridge, "maybe_modify_converted_hf_weight", fake_maybe_modify)
+    monkeypatch.setattr(
+        DummyBridge,
+        "_with_progress_tracking",
+        lambda self, tasks, *_args, **_kwargs: tasks,
+    )
+    monkeypatch.setattr(
+        DummyBridge,
+        "_share_embeddings_and_output_weights",
+        lambda self, *_args, **_kwargs: False,
+    )
+    monkeypatch.setattr(
+        DummyBridge,
+        "build_adapter_conversion_tasks",
+        lambda *_args, **_kwargs: {"language_model.decoder.layers.0.mlp.fc1": [adapter_task]},
+    )
+    monkeypatch.setattr(DummyBridge, "materialize_adapter_weights", lambda *_args, **_kwargs: [adapter_weight])
+    monkeypatch.setattr(
+        "megatron.bridge.models.conversion.model_bridge.unwrap_model",
+        lambda *_args, **_kwargs: [SimpleNamespace(config=SimpleNamespace(num_moe_experts=1))],
+    )
+
+    weights = list(
+        bridge.stream_weights_megatron_to_hf(
+            [Mock()],
+            SimpleNamespace(),
+            cpu=False,
+            show_progress=False,
+            conversion_tasks=[task],
+            merge_adapter_weights=True,
+        )
+    )
+
+    # maybe_modify must have received the MERGED weight (base + delta), not the raw base.
+    merged_expected = base_weight + torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    received = seen_by_maybe_modify["model.layers.0.mlp.fc1.weight"]
+    torch.testing.assert_close(received, merged_expected)
+    # And the final exported weight carries the merged values through the fake quantize.
+    torch.testing.assert_close(weights[0].weight, merged_expected)
+
+
 def test_column_parallel_mapping_skips_ep_gather_for_adapters(monkeypatch):
     mapping = ColumnParallelMapping(
         "decoder.layers.0.mlp.experts.linear_fc1.adapter.linear_in.weight",


### PR DESCRIPTION
# What does this PR do ?

Now several models such as DSV4/kimi V3 does quantization in ``maybe_modify_converted_hf_weight``. We need to Merge LoRA delta into the base weight *before* quantization. Adding a bf16 LoRA delta to an already-quantized base (e.g. MXFP4, where the packed weight shape changes and values leave the 4-bit range) both breaks the LoRA delta shape match and produces an invalid quantized tensor, so vLLM reads back wrong weights. Merging first keeps the whole weight in the bf16 domain until quantization acts on the merged result. The non-quantization work ``maybe_modify`` does (e.g. key renames) does not depend on the merge state, so the swap is safe for bridges that don't quantize.

# Changelog

- Move LoRA merge before `maybe_modify_converted_hf_weight`

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [X] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [X] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
