### PR TITLE
fix(model): correct Gemma4 PLE sequence parallel sharding

### DIFF
--- a/src/megatron/bridge/models/gemma/modeling_gemma4.py
+++ b/src/megatron/bridge/models/gemma/modeling_gemma4.py
@@ -894,12 +894,14 @@ def _attach_ple_modules(
     ple_vocab = provider.per_layer_embed_vocab_size
     if ple_dim <= 0 or ple_vocab <= 0:
         return
+    tp_group = model.pg_collection.tp
 
     model.per_layer_embedding = tp.VocabParallelEmbedding(
         ple_vocab,
         n_layers * ple_dim,
         config=config,
         init_method=config.init_method,
+        tp_group=tp_group,
     )
     model.per_layer_model_proj = tp.ColumnParallelLinear(
         provider.hidden_size,
@@ -908,6 +910,7 @@ def _attach_ple_modules(
         init_method=config.init_method,
         bias=False,
         gather_output=True,
+        tp_group=tp_group,
     )
     model.per_layer_proj_norm = Gemma4RMSNorm(config, ple_dim, eps=provider.layernorm_epsilon)
 
@@ -929,15 +932,23 @@ def _compute_per_layer_inputs(
 
     tok_emb = model.per_layer_embedding(input_ids) * (ple_dim**0.5)
 
-    if getattr(model.config, "sequence_parallel", False):
-        from megatron.core.tensor_parallel import scatter_to_sequence_parallel_region as _scatter
-
-        tok_emb = _scatter(tok_emb.transpose(0, 1)).transpose(0, 1)
+    sequence_parallel = getattr(model.config, "sequence_parallel", False)
+    if sequence_parallel:
+        tok_emb = tensor_parallel.scatter_to_sequence_parallel_region(
+            tok_emb.transpose(0, 1), group=model.pg_collection.tp
+        ).transpose(0, 1)
 
     s_local: int = tok_emb.shape[1]
     tok_emb = tok_emb.view(b, s_local, n_layers, ple_dim)
 
-    mdl_proj, _ = model.per_layer_model_proj(decoder_input.transpose(0, 1))
+    if sequence_parallel:
+        # ColumnParallelLinear's sequence-parallel contract gathers and reduce-scatters
+        # dimension 0, so keep the input sequence-major through the projection.
+        mdl_proj, _ = model.per_layer_model_proj(decoder_input)
+        mdl_proj = tensor_parallel.scatter_to_sequence_parallel_region(mdl_proj, group=model.pg_collection.tp)
+        mdl_proj = mdl_proj.transpose(0, 1).contiguous()
+    else:
+        mdl_proj, _ = model.per_layer_model_proj(decoder_input.transpose(0, 1))
     mdl_proj = mdl_proj * (model.config.hidden_size**-0.5)
     mdl_proj = mdl_proj.view(b, s_local, n_layers, ple_dim)
     mdl_proj = model.per_layer_proj_norm(mdl_proj)

--- a/tests/functional_tests/launch_scripts/h100/active/L1_Launch_recipes_gemma.sh
+++ b/tests/functional_tests/launch_scripts/h100/active/L1_Launch_recipes_gemma.sh
@@ -23,4 +23,5 @@ export CUDA_VISIBLE_DEVICES="0,1"
 # This script tests recipe configurations with their default settings to ensure
 # they can run basic training without crashes
 uv run python -m torch.distributed.run --nproc_per_node=2 --nnodes=1 -m coverage run --data-file="${REPO_ROOT}/.coverage" --source="${REPO_ROOT}" --parallel-mode -m pytest -o log_cli=true -o log_cli_level=INFO -v -s -x -m "not pleasefixme" --tb=short -rA tests/functional_tests/test_groups/recipes/test_gemma3_recipes_pretrain.py
+uv run python -m torch.distributed.run --nproc_per_node=2 --nnodes=1 -m coverage run --data-file="${REPO_ROOT}/.coverage" --source="${REPO_ROOT}" --parallel-mode -m pytest -o log_cli=true -o log_cli_level=INFO -v -s -x -m "not pleasefixme" --tb=short -rA tests/unit_tests/models/gemma/test_gemma4_ple_sequence_parallel_distributed.py
 coverage combine -q

--- a/tests/unit_tests/models/gemma/test_gemma4_modeling.py
+++ b/tests/unit_tests/models/gemma/test_gemma4_modeling.py
@@ -1223,12 +1223,14 @@ class TestGemma4PLEHelpers:
         calls = []
 
         class FakeVocabParallelEmbedding:
-            def __init__(self, vocab_size, hidden_size, config, init_method):
-                calls.append(("embedding", vocab_size, hidden_size, config, init_method))
+            def __init__(self, vocab_size, hidden_size, config, init_method, tp_group):
+                calls.append(("embedding", vocab_size, hidden_size, config, init_method, tp_group))
 
         class FakeColumnParallelLinear:
-            def __init__(self, input_size, output_size, config, init_method, bias, gather_output):
-                calls.append(("projection", input_size, output_size, config, init_method, bias, gather_output))
+            def __init__(self, input_size, output_size, config, init_method, bias, gather_output, tp_group):
+                calls.append(
+                    ("projection", input_size, output_size, config, init_method, bias, gather_output, tp_group)
+                )
 
         monkeypatch.setattr(
             "megatron.core.tensor_parallel.VocabParallelEmbedding",
@@ -1238,7 +1240,8 @@ class TestGemma4PLEHelpers:
             "megatron.core.tensor_parallel.ColumnParallelLinear",
             FakeColumnParallelLinear,
         )
-        model = SimpleNamespace()
+        tp_group = object()
+        model = SimpleNamespace(pg_collection=SimpleNamespace(tp=tp_group))
         config = _config(init_method="init", layernorm_epsilon=1e-6)
         provider = SimpleNamespace(
             num_layers=3,
@@ -1254,8 +1257,8 @@ class TestGemma4PLEHelpers:
         assert isinstance(model.per_layer_model_proj, FakeColumnParallelLinear)
         assert isinstance(model.per_layer_proj_norm, Gemma4RMSNorm)
         assert calls == [
-            ("embedding", 128, 6, config, "init"),
-            ("projection", 4, 6, config, "init", False, True),
+            ("embedding", 128, 6, config, "init", tp_group),
+            ("projection", 4, 6, config, "init", False, True, tp_group),
         ]
 
     def test_compute_per_layer_inputs_combines_token_and_model_projections(self):
@@ -1285,6 +1288,56 @@ class TestGemma4PLEHelpers:
 
         out = _compute_per_layer_inputs(model, input_ids, decoder_input)
 
+        assert out.shape == (2, 3, 2, 3)
+        expected_value = (4.0 * (4**-0.5) + (3**0.5)) * (2.0**-0.5)
+        torch.testing.assert_close(out, torch.full_like(out, expected_value))
+
+    def test_compute_per_layer_inputs_preserves_sequence_major_sp_projection(self, monkeypatch):
+        tp_group = object()
+        scatter_shapes = []
+
+        def fake_scatter(tensor, *, group):
+            assert group is tp_group
+            assert tensor.shape[0] % 2 == 0
+            scatter_shapes.append(tensor.shape)
+            return tensor.chunk(2, dim=0)[0].contiguous()
+
+        class FakeEmbedding(torch.nn.Module):
+            def forward(self, input_ids):
+                batch, seq = input_ids.shape
+                return torch.ones(batch, seq, 6)
+
+        class FakeProjection(torch.nn.Module):
+            def forward(self, hidden_states):
+                # SP input is already sharded and must remain [sequence, batch, hidden].
+                assert hidden_states.shape == (3, 2, 4)
+                # Emulate ColumnParallelLinear's internal sequence all-gather.
+                return torch.full((6, 2, 6), 4.0), None
+
+        monkeypatch.setattr(
+            "megatron.core.tensor_parallel.scatter_to_sequence_parallel_region",
+            fake_scatter,
+        )
+        model = SimpleNamespace(
+            config=SimpleNamespace(
+                per_layer_embed_dim=3,
+                num_layers=2,
+                hidden_size=4,
+                sequence_parallel=True,
+            ),
+            pg_collection=SimpleNamespace(tp=tp_group),
+            per_layer_embedding=FakeEmbedding(),
+            per_layer_model_proj=FakeProjection(),
+            per_layer_proj_norm=torch.nn.Identity(),
+        )
+
+        out = _compute_per_layer_inputs(
+            model,
+            input_ids=torch.ones(2, 6, dtype=torch.long),
+            decoder_input=torch.zeros(3, 2, 4),
+        )
+
+        assert scatter_shapes == [torch.Size((6, 2, 6)), torch.Size((6, 2, 6))]
         assert out.shape == (2, 3, 2, 3)
         expected_value = (4.0 * (4**-0.5) + (3**0.5)) * (2.0**-0.5)
         torch.testing.assert_close(out, torch.full_like(out, expected_value))

--- a/tests/unit_tests/models/gemma/test_gemma4_ple_sequence_parallel_distributed.py
+++ b/tests/unit_tests/models/gemma/test_gemma4_ple_sequence_parallel_distributed.py
@@ -1,0 +1,273 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Two-rank Gemma4 PLE sequence-parallel parity and backward regression test.
+
+Run with:
+uv run python -m torch.distributed.run --nproc_per_node=2 -m pytest \
+    tests/unit_tests/models/gemma/test_gemma4_ple_sequence_parallel_distributed.py
+"""
+
+import os
+from types import SimpleNamespace
+
+import megatron.core.parallel_state as parallel_state
+import pytest
+import torch
+import torch.distributed as dist
+from megatron.core.process_groups_config import ProcessGroupCollection
+from megatron.core.tensor_parallel import (
+    gather_from_sequence_parallel_region,
+    scatter_to_sequence_parallel_region,
+)
+
+from megatron.bridge.models.gemma.gemma4_provider import Gemma4DenseProvider
+from megatron.bridge.models.gemma.modeling_gemma4 import (
+    _attach_ple_modules,
+    _compute_per_layer_inputs,
+)
+
+
+_TP_SIZE = 2
+_RTOL = 1e-5
+_ATOL = 1e-6
+
+
+def _full_weights(
+    *, vocab_size: int, packed_ple_size: int, hidden_size: int, ple_dim: int
+) -> tuple[torch.Tensor, ...]:
+    embedding = torch.arange(vocab_size * packed_ple_size, device="cuda", dtype=torch.float32).reshape(
+        vocab_size, packed_ple_size
+    )
+    projection = torch.arange(packed_ple_size * hidden_size, device="cuda", dtype=torch.float32).reshape(
+        packed_ple_size, hidden_size
+    )
+    norm = torch.arange(ple_dim, device="cuda", dtype=torch.float32) / 16 + 0.75
+    output = torch.arange(5 * packed_ple_size, device="cuda", dtype=torch.float32).reshape(5, packed_ple_size)
+    return (
+        (embedding.remainder(17) - 8) / 64,
+        (projection.remainder(13) - 6) / 32,
+        norm,
+        (output.remainder(11) - 5) / 32,
+    )
+
+
+def _build_ple_model(
+    *,
+    tp_size: int,
+    sequence_parallel: bool,
+    tp_group: dist.ProcessGroup,
+    num_layers: int,
+    ple_dim: int,
+    hidden_size: int,
+    vocab_size: int,
+) -> SimpleNamespace:
+    config = Gemma4DenseProvider(
+        num_layers=num_layers,
+        hidden_size=hidden_size,
+        ffn_hidden_size=16,
+        num_attention_heads=2,
+        num_query_groups=2,
+        kv_channels=4,
+        global_kv_channels=4,
+        per_layer_embed_vocab_size=vocab_size,
+        per_layer_embed_dim=ple_dim,
+        vocab_size=vocab_size,
+        tensor_model_parallel_size=tp_size,
+        sequence_parallel=sequence_parallel,
+        perform_initialization=False,
+        gradient_accumulation_fusion=False,
+        params_dtype=torch.float32,
+        bf16=False,
+    )
+    model = SimpleNamespace(config=config, pg_collection=ProcessGroupCollection(tp=tp_group))
+    _attach_ple_modules(model, config, config)
+    model.per_layer_proj_norm.cuda()
+    return model
+
+
+def _gather_sequence(local_tensor: torch.Tensor, tp_group: dist.ProcessGroup) -> torch.Tensor:
+    gathered = gather_from_sequence_parallel_region(
+        local_tensor.transpose(0, 1).contiguous(),
+        tensor_parallel_output_grad=False,
+        group=tp_group,
+    )
+    return gathered.transpose(0, 1).contiguous()
+
+
+def _assert_close(actual: torch.Tensor, expected: torch.Tensor) -> None:
+    torch.testing.assert_close(actual, expected, rtol=_RTOL, atol=_ATOL)
+
+
+@pytest.mark.gpu
+def test_gemma4_ple_tp2_sp_matches_tp1_forward_backward() -> None:
+    """TP2/SP PLE values and gradients must match TP1 on identical tensors."""
+    if int(os.environ.get("WORLD_SIZE", "1")) != _TP_SIZE:
+        pytest.skip("requires a two-rank torch.distributed launch")
+    if not torch.cuda.is_available():
+        pytest.skip("requires CUDA")
+
+    owns_process_group = not dist.is_initialized()
+    owns_model_parallel = not parallel_state.model_parallel_is_initialized()
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    torch.cuda.set_device(local_rank)
+    previous_matmul_precision = torch.get_float32_matmul_precision()
+    # Avoid TF32 so the tolerance measures only FP32 collective/reduction ordering.
+    torch.set_float32_matmul_precision("highest")
+
+    if owns_process_group:
+        dist.init_process_group(backend="nccl")
+
+    try:
+        if owns_model_parallel:
+            parallel_state.initialize_model_parallel(
+                tensor_model_parallel_size=_TP_SIZE,
+                pipeline_model_parallel_size=1,
+                context_parallel_size=1,
+            )
+        tp_group = ProcessGroupCollection.use_mpu_process_groups().tp
+        singleton_groups = [dist.new_group(ranks=[rank]) for rank in range(_TP_SIZE)]
+        reference_tp_group = singleton_groups[dist.get_rank()]
+
+        num_layers = 3
+        ple_dim = 4
+        packed_ple_size = num_layers * ple_dim
+        hidden_size = 8
+        vocab_size = 16
+        model = _build_ple_model(
+            tp_size=_TP_SIZE,
+            sequence_parallel=True,
+            tp_group=tp_group,
+            num_layers=num_layers,
+            ple_dim=ple_dim,
+            hidden_size=hidden_size,
+            vocab_size=vocab_size,
+        )
+        reference_model = _build_ple_model(
+            tp_size=1,
+            sequence_parallel=False,
+            tp_group=reference_tp_group,
+            num_layers=num_layers,
+            ple_dim=ple_dim,
+            hidden_size=hidden_size,
+            vocab_size=vocab_size,
+        )
+
+        full_embedding, full_projection, norm_weight, output_weight = _full_weights(
+            vocab_size=vocab_size,
+            packed_ple_size=packed_ple_size,
+            hidden_size=hidden_size,
+            ple_dim=ple_dim,
+        )
+        with torch.no_grad():
+            vocab_start = model.per_layer_embedding.vocab_start_index
+            vocab_end = model.per_layer_embedding.vocab_end_index
+            model.per_layer_embedding.weight.copy_(full_embedding[vocab_start:vocab_end])
+            output_partition = model.per_layer_model_proj.output_size_per_partition
+            output_start = dist.get_rank(group=tp_group) * output_partition
+            output_end = output_start + output_partition
+            model.per_layer_model_proj.weight.copy_(full_projection[output_start:output_end])
+            model.per_layer_proj_norm.weight.copy_(norm_weight)
+            reference_model.per_layer_embedding.weight.copy_(full_embedding)
+            reference_model.per_layer_model_proj.weight.copy_(full_projection)
+            reference_model.per_layer_proj_norm.weight.copy_(norm_weight)
+
+        for batch_size, seq_length in ((1, 4), (2, 6)):
+            input_ids = torch.arange(batch_size * seq_length, device="cuda").reshape(batch_size, seq_length)
+            input_ids = input_ids.remainder(vocab_size)
+            decoder_values = torch.arange(
+                seq_length * batch_size * hidden_size,
+                device="cuda",
+                dtype=torch.float32,
+            ).reshape(seq_length, batch_size, hidden_size)
+            decoder_values = (decoder_values.remainder(19) - 9) / 32
+            coefficients = torch.arange(
+                batch_size * seq_length * output_weight.shape[0], device="cuda", dtype=torch.float32
+            ).reshape(batch_size, seq_length, output_weight.shape[0])
+            coefficients = (coefficients.remainder(7) - 3) / 16
+
+            for parameter in (
+                reference_model.per_layer_embedding.weight,
+                reference_model.per_layer_model_proj.weight,
+                reference_model.per_layer_proj_norm.weight,
+            ):
+                parameter.grad = None
+            output_ref = output_weight.detach().clone().requires_grad_(True)
+            decoder_ref = decoder_values.detach().clone().requires_grad_(True)
+            ple_ref = _compute_per_layer_inputs(reference_model, input_ids, decoder_ref)
+            logits_ref = torch.nn.functional.linear(ple_ref.flatten(-2), output_ref)
+            loss_ref = (logits_ref * coefficients).sum()
+            loss_ref.backward()
+
+            for parameter in (
+                model.per_layer_embedding.weight,
+                model.per_layer_model_proj.weight,
+                model.per_layer_proj_norm.weight,
+            ):
+                parameter.grad = None
+            decoder_dist = decoder_values.detach().clone().requires_grad_(True)
+            local_decoder = scatter_to_sequence_parallel_region(decoder_dist, group=tp_group)
+            output_dist = output_weight.detach().clone().requires_grad_(True)
+            ple_local = _compute_per_layer_inputs(model, input_ids, local_decoder)
+            logits_local = torch.nn.functional.linear(ple_local.flatten(-2), output_dist)
+            coefficients_local = scatter_to_sequence_parallel_region(
+                coefficients.transpose(0, 1).contiguous(), group=tp_group
+            ).transpose(0, 1)
+            loss_local = (logits_local * coefficients_local).sum()
+
+            _assert_close(_gather_sequence(ple_local.detach(), tp_group), ple_ref.detach())
+            _assert_close(_gather_sequence(logits_local.detach(), tp_group), logits_ref.detach())
+            loss_dist = loss_local.detach().clone()
+            dist.all_reduce(loss_dist, group=tp_group)
+            _assert_close(loss_dist, loss_ref.detach())
+
+            loss_local.backward()
+            _assert_close(decoder_dist.grad, decoder_ref.grad)
+            _assert_close(
+                model.per_layer_embedding.weight.grad,
+                reference_model.per_layer_embedding.weight.grad[vocab_start:vocab_end],
+            )
+            _assert_close(
+                model.per_layer_model_proj.weight.grad,
+                reference_model.per_layer_model_proj.weight.grad[output_start:output_end],
+            )
+
+            norm_grad = model.per_layer_proj_norm.weight.grad.detach().clone()
+            dist.all_reduce(norm_grad, group=tp_group)
+            _assert_close(norm_grad, reference_model.per_layer_proj_norm.weight.grad)
+            output_grad = output_dist.grad.detach().clone()
+            dist.all_reduce(output_grad, group=tp_group)
+            _assert_close(output_grad, output_ref.grad)
+
+        with pytest.raises(
+            AssertionError,
+            match="First dimension of the tensor should be divisible by tensor parallel size",
+        ):
+            scatter_to_sequence_parallel_region(torch.zeros(5, 1, hidden_size, device="cuda"), group=tp_group)
+        with pytest.raises(AssertionError, match="9 is not divisible by 2"):
+            _build_ple_model(
+                tp_size=_TP_SIZE,
+                sequence_parallel=True,
+                tp_group=tp_group,
+                num_layers=3,
+                ple_dim=3,
+                hidden_size=hidden_size,
+                vocab_size=vocab_size,
+            )
+    finally:
+        torch.set_float32_matmul_precision(previous_matmul_precision)
+        if owns_model_parallel and parallel_state.model_parallel_is_initialized():
+            parallel_state.destroy_model_parallel()
+        if owns_process_group and dist.is_initialized():
+            dist.destroy_process_group()


### PR DESCRIPTION
## What does this PR do?

Fixes Gemma4 per-layer embedding (PLE) with tensor and sequence parallelism.

Fixes NVBug 6566810.

## Root cause

The PLE projection transposed sequence-parallel decoder activations from `[S/TP, B, H]` to `[B, S/TP, H]` before calling MCore's sequence-parallel `ColumnParallelLinear`. That layer all-gathers dimension 0, so it gathered batch slots rather than sequence shards and produced TP times the intended number of elements. Its backward reduce-scatter would have used the same incorrect ownership axis.

## Changes

- Keep the decoder activation sequence-major through the SP-aware column-parallel projection.
- Re-shard the gathered projection along sequence before converting to the PLE `[B, S/TP, L, D]` layout.
- Use the model's explicit TP process group for PLE modules and sequence collectives.
- Add a two-rank CUDA regression and route it through the existing Gemma L1 launcher.

## Validation

- Pre-fix focused replay: exact TP2 factor-of-two reshape failure.
- Post-fix deterministic TP2/SP comparison against the actual TP1/SP-disabled path on identical FP32 inputs and weights, with TF32 disabled and `rtol=1e-5`, `atol=1e-6`:
  - gathered PLE activations
  - downstream logits and global loss
  - decoder-input gradients
  - PLE embedding/projection, RMSNorm, and downstream-output gradients
  - odd local sequence length, batch size greater than one, and non-divisible sequence/output-width rejection
- One-node, eight-GPU TP2/SP training completed a forward/backward/update iteration in the selected 26.08 RC after the stock runtime reproduced the first-forward failure.
- Adjacent Gemma unit tests: 82 passed.
- `uv run pre-commit run --all-files` passed.
- Independent exact-commit review: no actionable findings.

## Checklist

- [x] Contributor guidelines followed
- [x] Focused regression coverage added
- [x] Documentation impact evaluated; no user-facing configuration or API changed
- [x] No optional-install component changed

AI assistance disclosure: This change was developed with Codex assistance and reviewed and tested by the author.
