### PR TITLE
fix(recipe): align Nemotron Omni Valor batch sizes

### DIFF
--- a/examples/models/nemotron/nemotron_3_omni/slurm_peft_valor32k_avqa.sh
+++ b/examples/models/nemotron/nemotron_3_omni/slurm_peft_valor32k_avqa.sh
@@ -133,6 +133,7 @@ CLI_OVERRIDES="\
     logger.tensorboard_dir=$OUTPUT_DIR/tb_logs \
     dataset.path=$ENERGON_PATH \
     dataset.seq_length=$SEQ_LENGTH \
+    dataset.micro_batch_size=$MICRO_BATCH_SIZE \
     dataset.enable_in_batch_packing=$PACKED_SEQ \
     model.seq_length=$SEQ_LENGTH \
     model.tensor_model_parallel_size=$TP \

--- a/examples/models/nemotron/nemotron_3_omni/slurm_sft_valor32k_avqa.sh
+++ b/examples/models/nemotron/nemotron_3_omni/slurm_sft_valor32k_avqa.sh
@@ -129,6 +129,7 @@ CLI_OVERRIDES="\
     logger.tensorboard_dir=$OUTPUT_DIR/tb_logs \
     dataset.path=$ENERGON_PATH \
     dataset.seq_length=$SEQ_LENGTH \
+    dataset.micro_batch_size=$MICRO_BATCH_SIZE \
     dataset.enable_in_batch_packing=$PACKED_SEQ \
     model.seq_length=$SEQ_LENGTH \
     model.tensor_model_parallel_size=$TP \


### PR DESCRIPTION
## What changed

- pass the launcher micro-batch size through to the Valor32K Energon dataset in the Nemotron Omni SFT and PEFT examples

## Why

The launchers set `train.micro_batch_size=2`, while the recipe materialized the dataset with its default micro-batch size of 1. Runtime validation therefore rejected the shipped command before training.

Fixes NVBug 6566349.

## Validation

- `bash -n` on both launchers
- `git diff --check`
- `uv run --no-sync pre-commit run --all-files`
- exact `nvcr.io/nvidian/nemo:26.08.rc5` 2-node/16-H100 SFT verification: iteration 1 completed, checkpoint saved, and 10 validation iterations completed; the original mismatch oracle was absent
- independent review of the final change: no findings
