### PR TITLE
fix(recipe): backport #5386 batch-size alignment to r0.6.0

### DIFF
--- a/examples/models/nemotron/nemotron_3_omni/slurm_peft_valor32k_avqa.sh
+++ b/examples/models/nemotron/nemotron_3_omni/slurm_peft_valor32k_avqa.sh
@@ -133,6 +133,7 @@ CLI_OVERRIDES="\
     logger.tensorboard_dir=$OUTPUT_DIR/tb_logs \
     dataset.path=$ENERGON_PATH \
     dataset.seq_length=$SEQ_LENGTH \
+    dataset.micro_batch_size=$MICRO_BATCH_SIZE \
     dataset.enable_in_batch_packing=$PACKED_SEQ \
     model.seq_length=$SEQ_LENGTH \
     model.tensor_model_parallel_size=$TP \

--- a/examples/models/nemotron/nemotron_3_omni/slurm_sft_valor32k_avqa.sh
+++ b/examples/models/nemotron/nemotron_3_omni/slurm_sft_valor32k_avqa.sh
@@ -129,6 +129,7 @@ CLI_OVERRIDES="\
     logger.tensorboard_dir=$OUTPUT_DIR/tb_logs \
     dataset.path=$ENERGON_PATH \
     dataset.seq_length=$SEQ_LENGTH \
+    dataset.micro_batch_size=$MICRO_BATCH_SIZE \
     dataset.enable_in_batch_packing=$PACKED_SEQ \
     model.seq_length=$SEQ_LENGTH \
     model.tensor_model_parallel_size=$TP \


### PR DESCRIPTION
## What changed

This is the release cherry-pick of #5386 to `r0.6.0`.

It passes the launcher micro-batch size through to the Valor32K Energon dataset in both Nemotron Omni SFT and PEFT launchers. The launchers already set `train.micro_batch_size=2`, while the dataset otherwise materializes with its default of 1 and fails runtime validation.

Fixes NVBug 6566349.

## Release applicability

- Cherry-picked exact source commit `4fd17ac212ce64834bd110993bd4ca6db910eb8b`, not the merge commit.
- The stable patch ID matches the source commit.
- The release diff is exactly two insertions: `dataset.micro_batch_size=$MICRO_BATCH_SIZE` in the SFT and PEFT launchers, with no unrelated files or edits.
- Independent review of exact release commit `462bd44dd4e26b7f63df76d7d3b4e920c5b593a9` found no issues.

## Validation

- `bash -n` passes for both changed launchers.
- Harmless launcher rendering selects the expected SFT/PEFT recipes and proves `dataset.micro_batch_size=2` matches `train.micro_batch_size=2` in both commands.
- Focused Nemotron Omni recipe tests in the cached 26.08 RC5 container: 9 passed.
- Pre-commit completed on both changed files; configured hooks do not target shell files.
- `git diff --check` passes.
- Stable patch-ID equality and exact file/addition audit pass.
- DCO trailer and cryptographic commit signature verify.
- Original PR #5386 also records successful 26.08 RC5 two-node/16-H100 SFT iteration, checkpoint save, and validation.

## Environment note

Host-native dependency sync was unavailable because the release-locked resiliency wheel targets a newer glibc, and a CPU-only container import required `libcuda`. These were environment limitations; the focused test passed in the cached release-family container with the GPU runtime available.