### PR TITLE
feat(training): enable MFSDP V2

### DIFF
--- a/src/megatron/bridge/models/conversion/utils.py
+++ b/src/megatron/bridge/models/conversion/utils.py
@@ -46,23 +46,18 @@ def unwrap_model(model, module_instances=None):
     if module_instances is None:
         from megatron.core.distributed import DistributedDataParallel as DDP
         from megatron.core.distributed import TorchFullyShardedDataParallel as torch_FSDP
-        from megatron.core.distributed.fsdp import mcore_fsdp_adapter
+        from megatron.core.distributed.fsdp.mcore_fsdp_adapter import (
+            FullyShardedDataParallelV1,
+            FullyShardedDataParallelV2,
+        )
         from megatron.core.distributed.fsdp.src.megatron_fsdp.megatron_fsdp import MegatronFSDP
         from megatron.core.transformer.module import Float16Module
 
-        fsdp_module_instances = tuple(
-            module_type
-            for module_type in (
-                getattr(mcore_fsdp_adapter, "FullyShardedDataParallel", None),
-                getattr(mcore_fsdp_adapter, "FullyShardedDataParallelV1", None),
-                getattr(mcore_fsdp_adapter, "FullyShardedDataParallelV2", None),
-            )
-            if isinstance(module_type, type)
-        )
         module_instances = (
             DDP,
             torch_FSDP,
-            *fsdp_module_instances,
+            FullyShardedDataParallelV1,
+            FullyShardedDataParallelV2,
             Float16Module,
             MegatronFSDP,
         )

--- a/src/megatron/bridge/models/conversion/utils.py
+++ b/src/megatron/bridge/models/conversion/utils.py
@@ -46,18 +46,15 @@ def unwrap_model(model, module_instances=None):
     if module_instances is None:
         from megatron.core.distributed import DistributedDataParallel as DDP
         from megatron.core.distributed import TorchFullyShardedDataParallel as torch_FSDP
-        from megatron.core.distributed.fsdp.mcore_fsdp_adapter import (
-            FullyShardedDataParallelV1,
-            FullyShardedDataParallelV2,
-        )
         from megatron.core.distributed.fsdp.src.megatron_fsdp.megatron_fsdp import MegatronFSDP
         from megatron.core.transformer.module import Float16Module
+
+        from megatron.bridge.training.fsdp_compat import MEGATRON_FSDP_TYPES
 
         module_instances = (
             DDP,
             torch_FSDP,
-            FullyShardedDataParallelV1,
-            FullyShardedDataParallelV2,
+            *MEGATRON_FSDP_TYPES,
             Float16Module,
             MegatronFSDP,
         )

--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -1069,8 +1069,10 @@ class ConfigContainer(Container):
 
         if self.ddp.megatron_fsdp_version == 1:
             self._validate_and_apply_megatron_fsdp_v1_configs()
-        else:
+        elif self.ddp.megatron_fsdp_version == 2:
             self._validate_and_apply_megatron_fsdp_v2_configs()
+        else:
+            raise ValueError(f"Unsupported megatron_fsdp_version: {self.ddp.megatron_fsdp_version}")
 
     def _validate_and_apply_megatron_fsdp_v1_configs(self) -> None:
         """Validate and apply the established MFSDP V1 training contract."""

--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -1166,6 +1166,8 @@ class ConfigContainer(Container):
             raise ValueError("MFSDP V2 checkpoint loading is not yet supported.")
         if self.optimizer.loss_scale is not None:
             raise ValueError("MFSDP V2 does not support loss scaling.")
+        if self.optimizer.clip_grad > 0.0:
+            raise ValueError("MFSDP V2 does not currently support gradient clipping.")
         if self.optimizer.use_precision_aware_optimizer:
             raise ValueError("MFSDP V2 does not support precision-aware optimizer.")
         if self.optimizer.optimizer_cpu_offload:

--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -1062,12 +1062,14 @@ class ConfigContainer(Container):
         torch.use_deterministic_algorithms(True)
 
     def _validate_and_apply_megatron_fsdp_configs(self) -> None:
-        """
-        Validate Megatron-FSDP configuration when Megatron-FSDP is used.
-        """
+        """Validate and apply configuration required by the selected Megatron-FSDP version."""
         # Set configs needed for Megatron-FSDP.
         self.dist.use_megatron_fsdp = True
         self.ddp.use_megatron_fsdp = True
+
+        if self.ddp.megatron_fsdp_version == 2:
+            self._validate_and_apply_megatron_fsdp_v2_configs()
+            return
 
         # Megatron-FSDP always uses a distributed optimizer.
         if not self.ddp.use_distributed_optimizer or not self.optimizer.use_distributed_optimizer:
@@ -1113,6 +1115,78 @@ class ConfigContainer(Container):
                 "supported with the Megatron-FSDP optim_grads_params sharding strategy"
             )
         assert not self.dist.use_tp_pp_dp_mapping, "use_tp_pp_dp_mapping is not supported with Megatron FSDP"
+
+    def _validate_and_apply_megatron_fsdp_v2_configs(self) -> None:
+        """Validate and apply the experimental MFSDP V2 training contract.
+
+        MFSDP V2 owns its sharded parameter and gradient storage, so it must use
+        its dedicated optimizer rather than Bridge's distributed-optimizer path.
+        Checkpointing and model-parallel topologies remain intentionally unsupported
+        upstream and are rejected here before model construction.
+        """
+        if not self.model.bf16 or self.model.fp16 or not self.optimizer.bf16 or self.optimizer.fp16:
+            raise ValueError("MFSDP V2 requires BF16 training (model.bf16=True and optimizer.bf16=True).")
+        if self.model.params_dtype != torch.bfloat16:
+            raise ValueError("MFSDP V2 requires model.params_dtype=torch.bfloat16.")
+
+        unsupported_parallelisms = (
+            "tensor_model_parallel_size",
+            "pipeline_model_parallel_size",
+            "context_parallel_size",
+            "expert_model_parallel_size",
+        )
+        configured_parallelisms = [
+            f"{name}={getattr(self.model, name)}"
+            for name in unsupported_parallelisms
+            if getattr(self.model, name) != 1
+        ]
+        if configured_parallelisms:
+            raise ValueError(
+                "MFSDP V2 currently supports DP-only training; unsupported settings: "
+                + ", ".join(configured_parallelisms)
+            )
+        if self.model.num_moe_experts is not None:
+            raise ValueError("MFSDP V2 does not currently support MoE models.")
+        if self.model.virtual_pipeline_model_parallel_size is not None:
+            raise ValueError("MFSDP V2 does not currently support multiple model chunks.")
+        if self.dist.use_tp_pp_dp_mapping:
+            raise ValueError("MFSDP V2 does not support use_tp_pp_dp_mapping.")
+        if self.rng.data_parallel_random_init:
+            raise ValueError("MFSDP V2 does not support data_parallel_random_init.")
+        if self.ddp.num_distributed_optimizer_instances != 1:
+            raise ValueError("MFSDP V2 does not currently support HSDP.")
+        if self.ddp.outer_dp_sharding_strategy != "no_shard":
+            raise ValueError("MFSDP V2 does not currently support outer DP sharding.")
+        if self.checkpoint.save is not None or self.checkpoint.load is not None:
+            raise ValueError("MFSDP V2 checkpoint save and load are not yet supported.")
+        if self.checkpoint.pretrained_checkpoint is not None:
+            raise ValueError("MFSDP V2 checkpoint loading is not yet supported.")
+        if self.optimizer.loss_scale is not None:
+            raise ValueError("MFSDP V2 does not support loss scaling.")
+        if self.optimizer.use_precision_aware_optimizer:
+            raise ValueError("MFSDP V2 does not support precision-aware optimizer.")
+        if self.optimizer.optimizer_cpu_offload:
+            raise ValueError("MFSDP V2 does not support optimizer CPU offload.")
+        if self.optimizer.use_layer_wise_distributed_optimizer:
+            raise ValueError("MFSDP V2 does not support layer-wise distributed optimizer.")
+        if self.optimizer.optimizer_cuda_graph:
+            raise ValueError("MFSDP V2 does not support optimizer CUDA graphs.")
+        if self.model.calculate_per_token_loss:
+            raise ValueError("MFSDP V2 does not support per-token loss normalization.")
+        if self.model.fp8 or self.model.fp4 or self.ddp.fp8_param_gather or self.ddp.fp4_param_gather:
+            raise ValueError("MFSDP V2 does not support FP8 or FP4.")
+        if self.model.cuda_graph_impl != "none" or self.ddp.megatron_fsdp_cuda_graph_mode:
+            raise ValueError("MFSDP V2 does not support CUDA graphs.")
+
+        self.ddp.data_parallel_sharding_strategy = "optim_grads_params"
+        self.ddp.use_distributed_optimizer = False
+        self.optimizer.use_distributed_optimizer = False
+        self.ddp.overlap_grad_reduce = False
+        self.ddp.overlap_param_gather = False
+        self.optimizer.overlap_param_gather = False
+        self.optimizer.overlap_param_gather_with_optimizer_step = False
+        self.model.gradient_accumulation_fusion = False
+        self.ddp.fsdp_all_gather_in_start_param_sync = False
 
     def _validate_hf_checkpoint_export_source(self) -> None:
         """Validate that HF sidecar export has a source for HF config/tokenizer assets."""

--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -1067,10 +1067,13 @@ class ConfigContainer(Container):
         self.dist.use_megatron_fsdp = True
         self.ddp.use_megatron_fsdp = True
 
-        if self.ddp.megatron_fsdp_version == 2:
+        if self.ddp.megatron_fsdp_version == 1:
+            self._validate_and_apply_megatron_fsdp_v1_configs()
+        else:
             self._validate_and_apply_megatron_fsdp_v2_configs()
-            return
 
+    def _validate_and_apply_megatron_fsdp_v1_configs(self) -> None:
+        """Validate and apply the established MFSDP V1 training contract."""
         # Megatron-FSDP always uses a distributed optimizer.
         if not self.ddp.use_distributed_optimizer or not self.optimizer.use_distributed_optimizer:
             print_rank_0("use_distributed_optimizer=True is required for Megatron-FSDP. Activating...")

--- a/src/megatron/bridge/training/fsdp_compat.py
+++ b/src/megatron/bridge/training/fsdp_compat.py
@@ -12,25 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import torch
+"""Megatron-FSDP wrapper compatibility helpers."""
 
-from megatron.bridge.models.conversion.utils import unwrap_model
-
-
-def test_unwrap_model_uses_fsdp_wrapper_types(monkeypatch):
-    class FSDPV1(torch.nn.Module):
-        def __init__(self, module):
-            super().__init__()
-            self.module = module
-
-    class FSDPV2(FSDPV1):
-        pass
-
-    monkeypatch.setattr(
-        "megatron.bridge.training.fsdp_compat.MEGATRON_FSDP_TYPES",
-        (FSDPV1, FSDPV2),
+try:
+    from megatron.core.distributed.fsdp.mcore_fsdp_adapter import (
+        FullyShardedDataParallelV1,
+        FullyShardedDataParallelV2,
     )
 
-    module = torch.nn.Linear(1, 1)
+    MEGATRON_FSDP_TYPES = (FullyShardedDataParallelV1, FullyShardedDataParallelV2)
+except ImportError:
+    from megatron.core.distributed.fsdp.mcore_fsdp_adapter import FullyShardedDataParallel
 
-    assert unwrap_model(FSDPV2(FSDPV1(module))) is module
+    MEGATRON_FSDP_TYPES = (FullyShardedDataParallel,)

--- a/src/megatron/bridge/training/setup.py
+++ b/src/megatron/bridge/training/setup.py
@@ -110,7 +110,12 @@ def _resolve_embedding_ranks_fn(
 
 
 try:
-    from megatron.core.distributed.fsdp.mcore_fsdp_adapter import FullyShardedDataParallelV1 as megatron_FSDP
+    from megatron.core.distributed.fsdp.mcore_fsdp_adapter import (
+        FullyShardedDataParallelV1,
+        FullyShardedDataParallelV2,
+    )
+
+    megatron_FSDP = (FullyShardedDataParallelV1, FullyShardedDataParallelV2)
 except ImportError:
     from megatron.core.distributed.fsdp.mcore_fsdp_adapter import FullyShardedDataParallel as megatron_FSDP
 

--- a/src/megatron/bridge/training/setup.py
+++ b/src/megatron/bridge/training/setup.py
@@ -54,6 +54,7 @@ from megatron.bridge.training.checkpointing import (
     maybe_load_dataloader_state,
 )
 from megatron.bridge.training.config import ConfigContainer
+from megatron.bridge.training.fsdp_compat import MEGATRON_FSDP_TYPES
 from megatron.bridge.training.initialize import initialize_megatron, set_jit_fusion_options
 from megatron.bridge.training.optim import (
     memory_efficient_fp32_optimizer_state_loading,
@@ -107,17 +108,6 @@ def _resolve_embedding_ranks_fn(
     if isinstance(model_config, language_model_configs):
         return partial(_get_embedding_ranks, model_config=model_config)
     return None
-
-
-try:
-    from megatron.core.distributed.fsdp.mcore_fsdp_adapter import (
-        FullyShardedDataParallelV1,
-        FullyShardedDataParallelV2,
-    )
-
-    megatron_FSDP = (FullyShardedDataParallelV1, FullyShardedDataParallelV2)
-except ImportError:
-    from megatron.core.distributed.fsdp.mcore_fsdp_adapter import FullyShardedDataParallel as megatron_FSDP
 
 
 class SetupOutput(NamedTuple):
@@ -626,7 +616,7 @@ def _update_model_config_funcs(
     pg_collection: Optional[ProcessGroupCollection] = None,
 ) -> None:
     """Update model config sync funcs based on initialized model."""
-    if isinstance(model[0], (DistributedDataParallel, megatron_FSDP)) and ddp_config.overlap_grad_reduce:
+    if isinstance(model[0], (DistributedDataParallel, *MEGATRON_FSDP_TYPES)) and ddp_config.overlap_grad_reduce:
         assert model_config.no_sync_func is None, (
             "When overlap_grad_reduce is True, config.no_sync_func must be None; "
             "a custom no_sync_func is not supported when overlapping grad-reduce"

--- a/src/megatron/bridge/training/train.py
+++ b/src/megatron/bridge/training/train.py
@@ -24,7 +24,10 @@ from typing import Any, Callable, Optional, Union
 import torch
 import torch.profiler
 from megatron.core.distributed import DistributedDataParallel as DDP
-from megatron.core.distributed.fsdp import mcore_fsdp_adapter
+from megatron.core.distributed.fsdp.mcore_fsdp_adapter import (
+    FullyShardedDataParallelV1,
+    FullyShardedDataParallelV2,
+)
 from megatron.core.full_cuda_graph import FullCudaGraphWrapper
 from megatron.core.num_microbatches_calculator import (
     get_current_global_batch_size,
@@ -1693,20 +1696,7 @@ def _delete_cuda_graphs(cuda_graph_helper: TECudaGraphHelper | None):
     gc.collect()
 
 
-def _get_megatron_fsdp_types(adapter: Any = mcore_fsdp_adapter) -> tuple[type, ...]:
-    """Return the concrete MCore FSDP wrapper types exposed by an adapter version."""
-    return tuple(
-        module_type
-        for module_type in (
-            getattr(adapter, "FullyShardedDataParallel", None),
-            getattr(adapter, "FullyShardedDataParallelV1", None),
-            getattr(adapter, "FullyShardedDataParallelV2", None),
-        )
-        if isinstance(module_type, type)
-    )
-
-
-_MEGATRON_FSDP_TYPES = _get_megatron_fsdp_types()
+_MEGATRON_FSDP_TYPES = (FullyShardedDataParallelV1, FullyShardedDataParallelV2)
 
 
 def _maybe_register_fsdp_buffers(

--- a/src/megatron/bridge/training/train.py
+++ b/src/megatron/bridge/training/train.py
@@ -24,10 +24,6 @@ from typing import Any, Callable, Optional, Union
 import torch
 import torch.profiler
 from megatron.core.distributed import DistributedDataParallel as DDP
-from megatron.core.distributed.fsdp.mcore_fsdp_adapter import (
-    FullyShardedDataParallelV1,
-    FullyShardedDataParallelV2,
-)
 from megatron.core.full_cuda_graph import FullCudaGraphWrapper
 from megatron.core.num_microbatches_calculator import (
     get_current_global_batch_size,
@@ -77,6 +73,7 @@ from megatron.bridge.training.checkpointing import (
 from megatron.bridge.training.config import ConfigContainer
 from megatron.bridge.training.eval import evaluate_and_print_results
 from megatron.bridge.training.forward_step_func_types import ForwardStepCallable
+from megatron.bridge.training.fsdp_compat import MEGATRON_FSDP_TYPES
 from megatron.bridge.training.initialize import destroy_global_state
 from megatron.bridge.training.nvrx_straggler import (
     check_nvrx_straggler_detection,
@@ -1696,9 +1693,6 @@ def _delete_cuda_graphs(cuda_graph_helper: TECudaGraphHelper | None):
     gc.collect()
 
 
-_MEGATRON_FSDP_TYPES = (FullyShardedDataParallelV1, FullyShardedDataParallelV2)
-
-
 def _maybe_register_fsdp_buffers(
     config: ConfigContainer,
     model: list[MegatronModule],
@@ -1712,7 +1706,7 @@ def _maybe_register_fsdp_buffers(
     ):
         print_rank_0("[Megatron-FSDP] Registering FSDP communication buffers manually")
         for model_chunk in model:
-            if isinstance(model_chunk, _MEGATRON_FSDP_TYPES) and getattr(
+            if isinstance(model_chunk, MEGATRON_FSDP_TYPES) and getattr(
                 model_chunk.ddp_config, "fsdp_manual_registration", False
             ):
                 fsdp_param_and_grad_buffer = getattr(model_chunk, "param_and_grad_buffer", None)

--- a/tests/functional_tests/test_groups/megatron_fsdp/test_megatron_fsdp.py
+++ b/tests/functional_tests/test_groups/megatron_fsdp/test_megatron_fsdp.py
@@ -82,8 +82,8 @@ class Llama3FSDPTestModelProvider(GPTModelProvider):
 
 
 @dataclass
-class DenseHybridFSDPV2TestModelProvider(HybridModelProvider):
-    """Small dense HybridModel configuration for the MFSDP V2 smoke test."""
+class DenseHybridSmokeModelProvider(HybridModelProvider):
+    """Small dense HybridModel configuration for the training smoke test."""
 
     normalization: str = "RMSNorm"
     activation_func: Callable = F.silu
@@ -133,8 +133,8 @@ def create_fsdp_model_config(seq_length: int, bf16: bool = True, **kwargs) -> Ll
     return Llama3FSDPTestModelProvider(**base_config)
 
 
-def create_dense_hybrid_fsdp_v2_model_config(**kwargs) -> DenseHybridFSDPV2TestModelProvider:
-    """Create the dense two-layer HybridModel configuration used by MFSDP V2."""
+def create_dense_hybrid_smoke_model_config(**kwargs) -> DenseHybridSmokeModelProvider:
+    """Create the dense two-layer HybridModel configuration used by the smoke test."""
     base_config = {
         "tensor_model_parallel_size": 1,
         "pipeline_model_parallel_size": 1,
@@ -147,7 +147,7 @@ def create_dense_hybrid_fsdp_v2_model_config(**kwargs) -> DenseHybridFSDPV2TestM
         "pipeline_dtype": torch.bfloat16,
     }
     base_config.update(kwargs)
-    return DenseHybridFSDPV2TestModelProvider(**base_config)
+    return DenseHybridSmokeModelProvider(**base_config)
 
 
 def create_base_training_config(
@@ -430,7 +430,7 @@ class TestMegatronFSDP:
                 train={"global_batch_size": 2},
                 logger={"log_params_norm": False},
             )
-            cfg.model = create_dense_hybrid_fsdp_v2_model_config()
+            cfg.model = create_dense_hybrid_smoke_model_config()
             cfg.ddp.megatron_fsdp_version = 2
             runtime_config_update(cfg)
 

--- a/tests/functional_tests/test_groups/megatron_fsdp/test_megatron_fsdp.py
+++ b/tests/functional_tests/test_groups/megatron_fsdp/test_megatron_fsdp.py
@@ -412,7 +412,7 @@ class TestMegatronFSDP:
             clear_directories(tmp_path)
 
     @pytest.mark.run_only_on("GPU")
-    def test_fsdp_v2_dense_hybrid_pretrain_smoke(self, tmp_path):
+    def test_mfsdp_v2_dense_hybrid_pretrain_smoke(self, tmp_path):
         """Train a dense two-layer HybridModel with the experimental MFSDP V2 path."""
         from megatron.core.distributed.fsdp.mcore_fsdp_adapter import FullyShardedDataParallelV2
         from megatron.core.optimizer import FullyShardedOptimizer

--- a/tests/functional_tests/test_groups/megatron_fsdp/test_megatron_fsdp.py
+++ b/tests/functional_tests/test_groups/megatron_fsdp/test_megatron_fsdp.py
@@ -21,6 +21,7 @@ import torch
 import torch.nn.functional as F
 
 from megatron.bridge.models.gpt_provider import GPTModelProvider
+from megatron.bridge.models.hybrid.hybrid_provider import HybridModelProvider
 from megatron.bridge.training.config import (
     CheckpointConfig,
     ConfigContainer,
@@ -80,6 +81,35 @@ class Llama3FSDPTestModelProvider(GPTModelProvider):
     gradient_accumulation_fusion: bool = False
 
 
+@dataclass
+class DenseHybridFSDPV2TestModelProvider(HybridModelProvider):
+    """Small dense HybridModel configuration for the MFSDP V2 smoke test."""
+
+    normalization: str = "RMSNorm"
+    activation_func: Callable = F.silu
+    gated_linear_unit: bool = True
+    position_embedding_type: str = "rope"
+    add_bias_linear: bool = False
+    attention_dropout: float = 0.0
+    hidden_dropout: float = 0.0
+    share_embeddings_and_output_weights: bool = False
+    bias_dropout_fusion: bool = True
+    apply_rope_fusion: bool = True
+    num_query_groups: int = 8
+    init_method_std: float = 0.01
+    layernorm_epsilon: float = 1e-5
+    rotary_percent: float = 1.0
+    rotary_base: int = 500_000
+    seq_length: int = 128
+    num_layers: int | None = 2
+    hidden_size: int = 128
+    ffn_hidden_size: int = 512
+    num_attention_heads: int = 8
+    hybrid_layer_pattern: str | None = "**"
+    vocab_size: int | None = None
+    gradient_accumulation_fusion: bool = False
+
+
 def create_fsdp_model_config(seq_length: int, bf16: bool = True, **kwargs) -> Llama3FSDPTestModelProvider:
     """Create a standardized FSDP model configuration."""
     base_config = {
@@ -101,6 +131,23 @@ def create_fsdp_model_config(seq_length: int, bf16: bool = True, **kwargs) -> Ll
         )
     base_config.update(kwargs)
     return Llama3FSDPTestModelProvider(**base_config)
+
+
+def create_dense_hybrid_fsdp_v2_model_config(**kwargs) -> DenseHybridFSDPV2TestModelProvider:
+    """Create the dense two-layer HybridModel configuration used by MFSDP V2."""
+    base_config = {
+        "tensor_model_parallel_size": 1,
+        "pipeline_model_parallel_size": 1,
+        "context_parallel_size": 1,
+        "sequence_parallel": False,
+        "attention_softmax_in_fp32": True,
+        "make_vocab_size_divisible_by": 128,
+        "vocab_size": None,
+        "bf16": True,
+        "pipeline_dtype": torch.bfloat16,
+    }
+    base_config.update(kwargs)
+    return DenseHybridFSDPV2TestModelProvider(**base_config)
 
 
 def create_base_training_config(
@@ -361,6 +408,62 @@ class TestMegatronFSDP:
 
             torch.distributed.barrier()
 
+        finally:
+            clear_directories(tmp_path)
+
+    @pytest.mark.run_only_on("GPU")
+    def test_fsdp_v2_dense_hybrid_pretrain_smoke(self, tmp_path):
+        """Train a dense two-layer HybridModel with the experimental MFSDP V2 path."""
+        from megatron.core.distributed.fsdp.mcore_fsdp_adapter import FullyShardedDataParallelV2
+        from megatron.core.optimizer import FullyShardedOptimizer
+
+        from megatron.bridge.data.utils import get_dataset_provider
+        from megatron.bridge.training.setup import setup
+
+        initialize_distributed()
+        torch.distributed.barrier()
+
+        try:
+            cfg = create_fsdp_config_container(
+                seq_length=128,
+                train_iters=2,
+                train={"global_batch_size": 2},
+                logger={"log_params_norm": False},
+            )
+            cfg.model = create_dense_hybrid_fsdp_v2_model_config()
+            cfg.ddp.megatron_fsdp_version = 2
+            runtime_config_update(cfg)
+
+            state = GlobalState()
+            state.cfg = cfg
+            setup_out = setup(state, get_dataset_provider(cfg.dataset))
+
+            assert isinstance(setup_out.model[0], FullyShardedDataParallelV2)
+            assert isinstance(setup_out.optimizer, FullyShardedOptimizer)
+
+            run_training(
+                forward_step,
+                setup_out.model,
+                setup_out.optimizer,
+                setup_out.scheduler,
+                setup_out.train_data_iterator,
+                setup_out.valid_data_iterator,
+                setup_out.state,
+                setup_out.checkpoint_manager,
+                setup_out.pg_collection,
+            )
+
+            losses = _compute_forward_only_loss(
+                forward_step,
+                setup_out.model,
+                setup_out.train_data_iterator,
+                setup_out.state,
+                setup_out.pg_collection,
+            )
+            assert losses, "MFSDP V2 smoke test did not produce a loss"
+            assert all(torch.isfinite(loss).all() for loss in losses.values())
+
+            _finish_train(setup_out.state, setup_out.checkpoint_manager)
         finally:
             clear_directories(tmp_path)
 

--- a/tests/functional_tests/test_groups/megatron_fsdp/test_megatron_fsdp.py
+++ b/tests/functional_tests/test_groups/megatron_fsdp/test_megatron_fsdp.py
@@ -386,7 +386,7 @@ class TestMegatronFSDP:
     """
 
     @pytest.mark.run_only_on("GPU")
-    def test_fsdp_pretrain_basic(self, tmp_path):
+    def test_fsdp_pretrain_basic(self):
         """
         Test basic FSDP training without checkpointing.
         """
@@ -394,43 +394,36 @@ class TestMegatronFSDP:
 
         torch.distributed.barrier()
 
-        try:
-            seq_length = 512
-            total_iters = 10
+        seq_length = 512
+        total_iters = 10
 
-            cfg = create_fsdp_config_container(
-                seq_length=seq_length,
-                train_iters=total_iters,
-            )
+        cfg = create_fsdp_config_container(
+            seq_length=seq_length,
+            train_iters=total_iters,
+        )
 
-            # Run training
-            pretrain(cfg, forward_step)
+        # Run training
+        pretrain(cfg, forward_step)
 
-            torch.distributed.barrier()
-
-        finally:
-            clear_directories(tmp_path)
+        torch.distributed.barrier()
 
     @pytest.mark.run_only_on("GPU")
-    def test_fsdp_v2_dense_hybrid_pretrain_smoke(self, tmp_path):
+    def test_fsdp_v2_dense_hybrid_pretrain_smoke(self):
         """Train a dense two-layer HybridModel with the experimental MFSDP V2 path."""
         initialize_distributed()
         torch.distributed.barrier()
 
-        try:
-            cfg = create_fsdp_config_container(
-                seq_length=128,
-                train_iters=10,
-                optimizer={"clip_grad": 0.0},
-            )
-            cfg.model = create_dense_hybrid_smoke_model_config()
-            cfg.ddp.megatron_fsdp_version = 2
+        cfg = create_fsdp_config_container(
+            seq_length=128,
+            train_iters=10,
+            optimizer={"clip_grad": 0.0},
+        )
+        cfg.model = create_dense_hybrid_smoke_model_config()
+        cfg.ddp.megatron_fsdp_version = 2
 
-            pretrain(cfg, forward_step)
+        pretrain(cfg, forward_step)
 
-            torch.distributed.barrier()
-        finally:
-            clear_directories(tmp_path)
+        torch.distributed.barrier()
 
     @pytest.mark.run_only_on("GPU")
     def test_fsdp_pretrain_save_resume(self, tmp_path):
@@ -547,7 +540,7 @@ class TestMegatronFSDP:
             clear_directories(shared_base_dir)
 
     @pytest.mark.run_only_on("GPU")
-    def test_fsdp_precision_aware_optimizer_decoupled_grad_consistency(self, tmp_path):
+    def test_fsdp_precision_aware_optimizer_decoupled_grad_consistency(self):
         """Verify that MFSDP + precision-aware optimizer keeps decoupled_grad
         consistent across ParamAndGradBuffer, FusedAdam, and clip_grad_norm.
 
@@ -567,58 +560,54 @@ class TestMegatronFSDP:
 
         torch.distributed.barrier()
 
-        try:
-            seq_length = 512
-            train_iters = 1
+        seq_length = 512
+        train_iters = 1
 
-            cfg = create_fsdp_config_container(
-                seq_length=seq_length,
-                train_iters=train_iters,
-                optimizer={"use_precision_aware_optimizer": True},
-            )
-            runtime_config_update(cfg)
+        cfg = create_fsdp_config_container(
+            seq_length=seq_length,
+            train_iters=train_iters,
+            optimizer={"use_precision_aware_optimizer": True},
+        )
+        runtime_config_update(cfg)
 
-            state = GlobalState()
-            state.cfg = cfg
-            setup_out = setup(state, get_dataset_provider(cfg.dataset))
+        state = GlobalState()
+        state.cfg = cfg
+        setup_out = setup(state, get_dataset_provider(cfg.dataset))
 
-            model_list = setup_out.model
-            optimizer = setup_out.optimizer
+        model_list = setup_out.model
+        optimizer = setup_out.optimizer
 
-            # --- Run one training iteration ---
-            run_training(
-                forward_step,
-                model_list,
-                optimizer,
-                setup_out.scheduler,
-                setup_out.train_data_iterator,
-                setup_out.valid_data_iterator,
-                setup_out.state,
-                setup_out.checkpoint_manager,
-                setup_out.pg_collection,
-            )
+        # --- Run one training iteration ---
+        run_training(
+            forward_step,
+            model_list,
+            optimizer,
+            setup_out.scheduler,
+            setup_out.train_data_iterator,
+            setup_out.valid_data_iterator,
+            setup_out.state,
+            setup_out.checkpoint_manager,
+            setup_out.pg_collection,
+        )
 
-            # --- (a) MFSDP ParamAndGradBuffer has use_decoupled_grad=True ---
-            mfsdp_model = model_list[0].module
-            assert isinstance(mfsdp_model, MegatronFSDP), f"Expected MegatronFSDP, got {type(mfsdp_model)}"
-            pgb = mfsdp_model.param_and_grad_buffer
-            assert pgb.use_decoupled_grad is True, (
-                "ParamAndGradBuffer.use_decoupled_grad should be True when use_precision_aware_optimizer is enabled"
-            )
+        # --- (a) MFSDP ParamAndGradBuffer has use_decoupled_grad=True ---
+        mfsdp_model = model_list[0].module
+        assert isinstance(mfsdp_model, MegatronFSDP), f"Expected MegatronFSDP, got {type(mfsdp_model)}"
+        pgb = mfsdp_model.param_and_grad_buffer
+        assert pgb.use_decoupled_grad is True, (
+            "ParamAndGradBuffer.use_decoupled_grad should be True when use_precision_aware_optimizer is enabled"
+        )
 
-            # --- (b) Underlying FusedAdam has use_decoupled_grad=True ---
-            inner_opt = _get_inner_optimizer(optimizer)
-            assert getattr(inner_opt, "use_decoupled_grad", False), (
-                f"FusedAdam.use_decoupled_grad should be True, "
-                f"got {getattr(inner_opt, 'use_decoupled_grad', 'MISSING')} "
-                f"on {type(inner_opt).__name__}"
-            )
+        # --- (b) Underlying FusedAdam has use_decoupled_grad=True ---
+        inner_opt = _get_inner_optimizer(optimizer)
+        assert getattr(inner_opt, "use_decoupled_grad", False), (
+            f"FusedAdam.use_decoupled_grad should be True, "
+            f"got {getattr(inner_opt, 'use_decoupled_grad', 'MISSING')} "
+            f"on {type(inner_opt).__name__}"
+        )
 
-            # --- (c) clip_grad_norm does not segfault / has non-zero grad norm ---
-            grad_norm = optimizer.clip_grad_norm(cfg.optimizer.clip_grad)
-            assert torch.isfinite(torch.tensor(grad_norm)), f"clip_grad_norm returned non-finite grad_norm={grad_norm}"
+        # --- (c) clip_grad_norm does not segfault / has non-zero grad norm ---
+        grad_norm = optimizer.clip_grad_norm(cfg.optimizer.clip_grad)
+        assert torch.isfinite(torch.tensor(grad_norm)), f"clip_grad_norm returned non-finite grad_norm={grad_norm}"
 
-            _finish_train(setup_out.state, setup_out.checkpoint_manager)
-
-        finally:
-            clear_directories(tmp_path)
+        _finish_train(setup_out.state, setup_out.checkpoint_manager)

--- a/tests/functional_tests/test_groups/megatron_fsdp/test_megatron_fsdp.py
+++ b/tests/functional_tests/test_groups/megatron_fsdp/test_megatron_fsdp.py
@@ -426,9 +426,7 @@ class TestMegatronFSDP:
         try:
             cfg = create_fsdp_config_container(
                 seq_length=128,
-                train_iters=2,
-                train={"global_batch_size": 2},
-                logger={"log_params_norm": False},
+                train_iters=10,
             )
             cfg.model = create_dense_hybrid_smoke_model_config()
             cfg.ddp.megatron_fsdp_version = 2

--- a/tests/functional_tests/test_groups/megatron_fsdp/test_megatron_fsdp.py
+++ b/tests/functional_tests/test_groups/megatron_fsdp/test_megatron_fsdp.py
@@ -412,7 +412,7 @@ class TestMegatronFSDP:
             clear_directories(tmp_path)
 
     @pytest.mark.run_only_on("GPU")
-    def test_mfsdp_v2_dense_hybrid_pretrain_smoke(self, tmp_path):
+    def test_fsdp_v2_dense_hybrid_pretrain_smoke(self, tmp_path):
         """Train a dense two-layer HybridModel with the experimental MFSDP V2 path."""
         from megatron.core.distributed.fsdp.mcore_fsdp_adapter import FullyShardedDataParallelV2
         from megatron.core.optimizer import FullyShardedOptimizer

--- a/tests/functional_tests/test_groups/megatron_fsdp/test_megatron_fsdp.py
+++ b/tests/functional_tests/test_groups/megatron_fsdp/test_megatron_fsdp.py
@@ -421,6 +421,7 @@ class TestMegatronFSDP:
             cfg = create_fsdp_config_container(
                 seq_length=128,
                 train_iters=10,
+                optimizer={"clip_grad": 0.0},
             )
             cfg.model = create_dense_hybrid_smoke_model_config()
             cfg.ddp.megatron_fsdp_version = 2

--- a/tests/functional_tests/test_groups/megatron_fsdp/test_megatron_fsdp.py
+++ b/tests/functional_tests/test_groups/megatron_fsdp/test_megatron_fsdp.py
@@ -414,12 +414,6 @@ class TestMegatronFSDP:
     @pytest.mark.run_only_on("GPU")
     def test_fsdp_v2_dense_hybrid_pretrain_smoke(self, tmp_path):
         """Train a dense two-layer HybridModel with the experimental MFSDP V2 path."""
-        from megatron.core.distributed.fsdp.mcore_fsdp_adapter import FullyShardedDataParallelV2
-        from megatron.core.optimizer import FullyShardedOptimizer
-
-        from megatron.bridge.data.utils import get_dataset_provider
-        from megatron.bridge.training.setup import setup
-
         initialize_distributed()
         torch.distributed.barrier()
 
@@ -430,38 +424,10 @@ class TestMegatronFSDP:
             )
             cfg.model = create_dense_hybrid_smoke_model_config()
             cfg.ddp.megatron_fsdp_version = 2
-            runtime_config_update(cfg)
 
-            state = GlobalState()
-            state.cfg = cfg
-            setup_out = setup(state, get_dataset_provider(cfg.dataset))
+            pretrain(cfg, forward_step)
 
-            assert isinstance(setup_out.model[0], FullyShardedDataParallelV2)
-            assert isinstance(setup_out.optimizer, FullyShardedOptimizer)
-
-            run_training(
-                forward_step,
-                setup_out.model,
-                setup_out.optimizer,
-                setup_out.scheduler,
-                setup_out.train_data_iterator,
-                setup_out.valid_data_iterator,
-                setup_out.state,
-                setup_out.checkpoint_manager,
-                setup_out.pg_collection,
-            )
-
-            losses = _compute_forward_only_loss(
-                forward_step,
-                setup_out.model,
-                setup_out.train_data_iterator,
-                setup_out.state,
-                setup_out.pg_collection,
-            )
-            assert losses, "MFSDP V2 smoke test did not produce a loss"
-            assert all(torch.isfinite(loss).all() for loss in losses.values())
-
-            _finish_train(setup_out.state, setup_out.checkpoint_manager)
+            torch.distributed.barrier()
         finally:
             clear_directories(tmp_path)
 

--- a/tests/unit_tests/models/test_conversion_unwrap_utils.py
+++ b/tests/unit_tests/models/test_conversion_unwrap_utils.py
@@ -26,13 +26,6 @@ def test_unwrap_model_uses_fsdp_wrapper_types(monkeypatch):
     class FSDPV2(FSDPV1):
         pass
 
-    def fsdp_factory(*_args, **_kwargs):
-        return None
-
-    monkeypatch.setattr(
-        "megatron.core.distributed.fsdp.mcore_fsdp_adapter.FullyShardedDataParallel",
-        fsdp_factory,
-    )
     monkeypatch.setattr(
         "megatron.core.distributed.fsdp.mcore_fsdp_adapter.FullyShardedDataParallelV1",
         FSDPV1,

--- a/tests/unit_tests/training/test_train.py
+++ b/tests/unit_tests/training/test_train.py
@@ -19,13 +19,13 @@ from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import pytest
+from megatron.core.distributed.fsdp.mcore_fsdp_adapter import FullyShardedDataParallelV1
 from megatron.core.optimizer.distrib_optimizer import DistributedOptimizer
 
 from megatron.bridge.training.train import (
     _delete_cuda_graphs,
     _dummy_train_step,
     _finish_train,
-    _get_megatron_fsdp_types,
     _handle_mxfp8_param_buffer_copy,
     _maybe_register_fsdp_buffers,
     _should_skip_and_handle_iteration,
@@ -180,21 +180,6 @@ class TestCudaGraphCleanup:
 class TestFSDPRegistration:
     """Unit tests for FSDP buffer manual registration."""
 
-    def test_get_megatron_fsdp_types_ignores_factory(self):
-        class FSDPV1:
-            pass
-
-        class FSDPV2:
-            pass
-
-        adapter = SimpleNamespace(
-            FullyShardedDataParallel=lambda: None,
-            FullyShardedDataParallelV1=FSDPV1,
-            FullyShardedDataParallelV2=FSDPV2,
-        )
-
-        assert _get_megatron_fsdp_types(adapter) == (FSDPV1, FSDPV2)
-
     def test_maybe_register_fsdp_buffers_execution(self):
         """Test that manual registration is called when conditions are met."""
         # Setup mocks
@@ -203,8 +188,7 @@ class TestFSDPRegistration:
         config.ddp.fsdp_manual_registration = True
 
         # Mock model chunk
-        fsdp_type = _get_megatron_fsdp_types()[0]
-        model_chunk = Mock(spec=fsdp_type)
+        model_chunk = Mock(spec=FullyShardedDataParallelV1)
         # Mock ddp_config on the chunk
         model_chunk.ddp_config = Mock()
         model_chunk.ddp_config.fsdp_manual_registration = True

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = "==3.12.*"
 
 [options]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = "==3.12.*"
 
 [options]


### PR DESCRIPTION
## What

- Bump Megatron-LM to `59b72fa57` and regenerate `uv.lock` for MFSDP V2 support.
- Keep MFSDP V1 as the default while making `ddp.megatron_fsdp_version=2` opt into the experimental V2 path.
- Enforce V2's supported DP-only BF16 configuration and reject checkpointing, gradient clipping, and other unsupported features early.
- Add a two-GPU, ten-step dense `HybridModelProvider` smoke test using `hybrid_layer_pattern="**"` and `clip_grad=0.0`.
- Remove unused temporary-directory fixtures from the non-checkpoint MFSDP tests; retain the checkpoint-resume test's real temporary directory.

## Why

MFSDP V2 has a distinct wrapper and optimizer contract from V1. Bridge must select its safe configuration explicitly and avoid V1-only assumptions.

## Validation

- `uv run --no-sync pre-commit run --all-files`
- Two-GPU functional smoke: existing MFSDP V1 basic training and the new MFSDP V2 dense-Hybrid test.

Related to NVIDIA/Megatron-LM#6325.
