### PR TITLE
fix(peft): synchronize shared expert LoRA across EP

### DIFF
--- a/src/megatron/bridge/peft/utils.py
+++ b/src/megatron/bridge/peft/utils.py
@@ -1293,7 +1293,7 @@ class ParallelLinearAdapter(nn.Module):
         weights = [
             weight
             for module in (self.linear_in, self.linear_out)
-            if isinstance(weight := getattr(module, "weight", None), torch.Tensor) and weight.is_cuda
+            if isinstance(weight := getattr(module, "weight", None), torch.Tensor)
         ]
         if not weights:
             return
@@ -1301,7 +1301,17 @@ class ParallelLinearAdapter(nn.Module):
         src_rank = torch.distributed.get_global_rank(self.ep_group, 0)
         with torch.no_grad():
             for weight in weights:
-                torch.distributed.broadcast(weight, src=src_rank, group=self.ep_group)
+                if weight.is_meta:
+                    raise RuntimeError(
+                        "Shared expert adapter parameters must be materialized before EP synchronization"
+                    )
+                if weight.is_cuda or torch.distributed.get_backend(self.ep_group) != "nccl":
+                    torch.distributed.broadcast(weight, src=src_rank, group=self.ep_group)
+                    continue
+
+                staged_weight = weight.to(torch.device("cuda", torch.cuda.current_device()))
+                torch.distributed.broadcast(staged_weight, src=src_rank, group=self.ep_group)
+                weight.copy_(staged_weight.cpu())
 
     def _register_shared_expert_grad_sync_hooks(self) -> None:
         """Keep shared grouped-expert adapters synchronized across EP ranks."""

--- a/src/megatron/bridge/peft/utils.py
+++ b/src/megatron/bridge/peft/utils.py
@@ -1067,6 +1067,7 @@ class ParallelLinearAdapter(nn.Module):
             self.half()
 
         if self._uses_grouped_expert_sharding():
+            self._synchronize_shared_expert_parameters()
             self._register_shared_expert_grad_sync_hooks()
 
         # revert config change in case it is read elsewhere
@@ -1280,6 +1281,27 @@ class ParallelLinearAdapter(nn.Module):
         # EP x expert-DP data-parallel world, not just expert-DP.
         torch.distributed.all_reduce(grad, group=self.ep_group)
         return grad
+
+    def _synchronize_shared_expert_parameters(self) -> None:
+        """Broadcast shared expert adapter parameters from EP group rank zero."""
+
+        if not torch.distributed.is_available() or not torch.distributed.is_initialized():
+            return
+        if self.ep_group is None or _process_group_size(self.ep_group) <= 1:
+            return
+
+        weights = [
+            weight
+            for module in (self.linear_in, self.linear_out)
+            if isinstance(weight := getattr(module, "weight", None), torch.Tensor) and weight.is_cuda
+        ]
+        if not weights:
+            return
+
+        src_rank = torch.distributed.get_global_rank(self.ep_group, 0)
+        with torch.no_grad():
+            for weight in weights:
+                torch.distributed.broadcast(weight, src=src_rank, group=self.ep_group)
 
     def _register_shared_expert_grad_sync_hooks(self) -> None:
         """Keep shared grouped-expert adapters synchronized across EP ranks."""

--- a/tests/unit_tests/peft/test_shared_expert_lora_distributed.py
+++ b/tests/unit_tests/peft/test_shared_expert_lora_distributed.py
@@ -1,0 +1,158 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Two-rank parity tests for shared expert LoRA parameters.
+
+Run with:
+uv run python -m torch.distributed.run --nproc_per_node=2 -m pytest \
+    tests/unit_tests/peft/test_shared_expert_lora_distributed.py
+"""
+
+import os
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+import megatron.core.parallel_state as parallel_state
+import pytest
+import torch
+import torch.distributed as dist
+from megatron.core.model_parallel_config import ModelParallelConfig
+from megatron.core.process_groups_config import ProcessGroupCollection
+from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+
+from megatron.bridge.peft.utils import ParallelLinearAdapter
+
+
+_EP_SIZE = 2
+_ADAPTER_CASES = (
+    ("decoder.layers.0.mlp.experts.linear_fc1", False),
+    ("decoder.layers.0.mlp.experts.linear_fc2", True),
+)
+
+
+@contextmanager
+def _distributed_ep() -> Iterator[ProcessGroupCollection]:
+    """Initialize the minimum two-rank EP topology used by these tests."""
+    owns_process_group = not dist.is_initialized()
+    owns_model_parallel = not parallel_state.model_parallel_is_initialized()
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    torch.cuda.set_device(local_rank)
+
+    if owns_process_group:
+        dist.init_process_group(backend="nccl")
+    if owns_model_parallel:
+        parallel_state.initialize_model_parallel(
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=1,
+            context_parallel_size=1,
+            expert_model_parallel_size=_EP_SIZE,
+            expert_tensor_parallel_size=1,
+        )
+    model_parallel_cuda_manual_seed(2026, force_reset_rng=True)
+
+    try:
+        yield ProcessGroupCollection.use_mpu_process_groups()
+    finally:
+        if owns_model_parallel and parallel_state.model_parallel_is_initialized():
+            parallel_state.destroy_model_parallel()
+        if owns_process_group and dist.is_initialized():
+            dist.destroy_process_group()
+
+
+def _make_adapter(
+    pg_collection: ProcessGroupCollection,
+    *,
+    base_linear_name: str,
+    input_is_parallel: bool,
+) -> ParallelLinearAdapter:
+    """Construct a real MCore-backed shared expert adapter."""
+    config = ModelParallelConfig(
+        tensor_model_parallel_size=1,
+        expert_model_parallel_size=_EP_SIZE,
+        expert_tensor_parallel_size=1,
+        params_dtype=torch.float32,
+        gradient_accumulation_fusion=False,
+    )
+    return ParallelLinearAdapter(
+        in_features=8,
+        out_features=8,
+        dim=4,
+        base_linear_name=base_linear_name,
+        activation="identity",
+        input_is_parallel=input_is_parallel,
+        is_expert=True,
+        model_parallel_config=config,
+        pg_collection=pg_collection,
+    )
+
+
+def _assert_identical_across_ep(tensor: torch.Tensor, ep_group: object) -> None:
+    """Require bitwise equality for one logical tensor on every EP rank."""
+    gathered = [torch.empty_like(tensor) for _ in range(_EP_SIZE)]
+    dist.all_gather(gathered, tensor, group=ep_group)
+    for replica in gathered[1:]:
+        torch.testing.assert_close(replica, gathered[0], rtol=0, atol=0)
+
+
+def _set_identical_nonzero_weights(adapter: ParallelLinearAdapter) -> None:
+    """Make gradients for both LoRA projections nonzero on the first backward."""
+    with torch.no_grad():
+        for index, parameter in enumerate(adapter.parameters(), start=1):
+            values = torch.arange(1, parameter.numel() + 1, device=parameter.device, dtype=parameter.dtype)
+            parameter.copy_(values.reshape_as(parameter) * (0.01 * index))
+
+
+@pytest.mark.gpu
+def test_shared_expert_lora_initialization_is_identical_across_ep() -> None:
+    """Every shared expert LoRA parameter must start bitwise identical across EP."""
+    if int(os.environ.get("WORLD_SIZE", "1")) != _EP_SIZE:
+        pytest.skip("requires a two-rank torch.distributed launch")
+    if not torch.cuda.is_available():
+        pytest.skip("requires CUDA")
+
+    with _distributed_ep() as pg_collection:
+        for base_linear_name, input_is_parallel in _ADAPTER_CASES:
+            adapter = _make_adapter(
+                pg_collection,
+                base_linear_name=base_linear_name,
+                input_is_parallel=input_is_parallel,
+            )
+            for parameter in adapter.parameters():
+                _assert_identical_across_ep(parameter.detach(), pg_collection.ep)
+
+
+@pytest.mark.gpu
+def test_shared_expert_lora_gradients_are_identical_across_ep() -> None:
+    """EP gradient synchronization must produce identical nonzero gradients."""
+    if int(os.environ.get("WORLD_SIZE", "1")) != _EP_SIZE:
+        pytest.skip("requires a two-rank torch.distributed launch")
+    if not torch.cuda.is_available():
+        pytest.skip("requires CUDA")
+
+    with _distributed_ep() as pg_collection:
+        ep_rank = dist.get_rank(group=pg_collection.ep)
+        for base_linear_name, input_is_parallel in _ADAPTER_CASES:
+            adapter = _make_adapter(
+                pg_collection,
+                base_linear_name=base_linear_name,
+                input_is_parallel=input_is_parallel,
+            )
+            _set_identical_nonzero_weights(adapter)
+            inputs = torch.arange(1, 25, device="cuda", dtype=torch.float32).reshape(3, 8) + ep_rank
+            adapter(inputs).square().sum().backward()
+
+            for parameter in adapter.parameters():
+                assert parameter.grad is not None
+                assert torch.count_nonzero(parameter.grad) > 0
+                _assert_identical_across_ep(parameter.grad, pg_collection.ep)

--- a/tests/unit_tests/peft/test_shared_expert_lora_distributed.py
+++ b/tests/unit_tests/peft/test_shared_expert_lora_distributed.py
@@ -75,6 +75,7 @@ def _make_adapter(
     *,
     base_linear_name: str,
     input_is_parallel: bool,
+    use_cpu_initialization: bool = False,
 ) -> ParallelLinearAdapter:
     """Construct a real MCore-backed shared expert adapter."""
     config = ModelParallelConfig(
@@ -83,6 +84,7 @@ def _make_adapter(
         expert_tensor_parallel_size=1,
         params_dtype=torch.float32,
         gradient_accumulation_fusion=False,
+        use_cpu_initialization=use_cpu_initialization,
     )
     return ParallelLinearAdapter(
         in_features=8,
@@ -99,8 +101,9 @@ def _make_adapter(
 
 def _assert_identical_across_ep(tensor: torch.Tensor, ep_group: object) -> None:
     """Require bitwise equality for one logical tensor on every EP rank."""
-    gathered = [torch.empty_like(tensor) for _ in range(_EP_SIZE)]
-    dist.all_gather(gathered, tensor, group=ep_group)
+    collective_tensor = tensor if tensor.is_cuda else tensor.cuda()
+    gathered = [torch.empty_like(collective_tensor) for _ in range(_EP_SIZE)]
+    dist.all_gather(gathered, collective_tensor, group=ep_group)
     for replica in gathered[1:]:
         torch.testing.assert_close(replica, gathered[0], rtol=0, atol=0)
 
@@ -113,46 +116,69 @@ def _set_identical_nonzero_weights(adapter: ParallelLinearAdapter) -> None:
             parameter.copy_(values.reshape_as(parameter) * (0.01 * index))
 
 
+@pytest.fixture(scope="module")
+def ep_pg_collection() -> Iterator[ProcessGroupCollection]:
+    """Provide one shared two-rank EP topology for this test module."""
+    if int(os.environ.get("WORLD_SIZE", "1")) != _EP_SIZE:
+        pytest.skip("requires a two-rank torch.distributed launch")
+    if not torch.cuda.is_available():
+        pytest.skip("requires CUDA")
+
+    with _distributed_ep() as pg_collection:
+        yield pg_collection
+
+
 @pytest.mark.gpu
-def test_shared_expert_lora_initialization_is_identical_across_ep() -> None:
+def test_shared_expert_lora_initialization_is_identical_across_ep(
+    ep_pg_collection: ProcessGroupCollection,
+) -> None:
     """Every shared expert LoRA parameter must start bitwise identical across EP."""
-    if int(os.environ.get("WORLD_SIZE", "1")) != _EP_SIZE:
-        pytest.skip("requires a two-rank torch.distributed launch")
-    if not torch.cuda.is_available():
-        pytest.skip("requires CUDA")
-
-    with _distributed_ep() as pg_collection:
-        for base_linear_name, input_is_parallel in _ADAPTER_CASES:
-            adapter = _make_adapter(
-                pg_collection,
-                base_linear_name=base_linear_name,
-                input_is_parallel=input_is_parallel,
-            )
-            for parameter in adapter.parameters():
-                _assert_identical_across_ep(parameter.detach(), pg_collection.ep)
+    for base_linear_name, input_is_parallel in _ADAPTER_CASES:
+        adapter = _make_adapter(
+            ep_pg_collection,
+            base_linear_name=base_linear_name,
+            input_is_parallel=input_is_parallel,
+        )
+        for parameter in adapter.parameters():
+            _assert_identical_across_ep(parameter.detach(), ep_pg_collection.ep)
 
 
 @pytest.mark.gpu
-def test_shared_expert_lora_gradients_are_identical_across_ep() -> None:
+def test_shared_expert_lora_gradients_are_identical_across_ep(
+    ep_pg_collection: ProcessGroupCollection,
+) -> None:
     """EP gradient synchronization must produce identical nonzero gradients."""
-    if int(os.environ.get("WORLD_SIZE", "1")) != _EP_SIZE:
-        pytest.skip("requires a two-rank torch.distributed launch")
-    if not torch.cuda.is_available():
-        pytest.skip("requires CUDA")
+    ep_rank = dist.get_rank(group=ep_pg_collection.ep)
+    for base_linear_name, input_is_parallel in _ADAPTER_CASES:
+        adapter = _make_adapter(
+            ep_pg_collection,
+            base_linear_name=base_linear_name,
+            input_is_parallel=input_is_parallel,
+        )
+        _set_identical_nonzero_weights(adapter)
+        inputs = torch.arange(1, 25, device="cuda", dtype=torch.float32).reshape(3, 8) + ep_rank
+        adapter(inputs).square().sum().backward()
 
-    with _distributed_ep() as pg_collection:
-        ep_rank = dist.get_rank(group=pg_collection.ep)
-        for base_linear_name, input_is_parallel in _ADAPTER_CASES:
-            adapter = _make_adapter(
-                pg_collection,
-                base_linear_name=base_linear_name,
-                input_is_parallel=input_is_parallel,
-            )
-            _set_identical_nonzero_weights(adapter)
-            inputs = torch.arange(1, 25, device="cuda", dtype=torch.float32).reshape(3, 8) + ep_rank
-            adapter(inputs).square().sum().backward()
+        for parameter in adapter.parameters():
+            assert parameter.grad is not None
+            assert torch.count_nonzero(parameter.grad) > 0
+            _assert_identical_across_ep(parameter.grad, ep_pg_collection.ep)
 
-            for parameter in adapter.parameters():
-                assert parameter.grad is not None
-                assert torch.count_nonzero(parameter.grad) > 0
-                _assert_identical_across_ep(parameter.grad, pg_collection.ep)
+
+@pytest.mark.gpu
+def test_shared_expert_lora_cpu_initialization_is_identical_across_ep(
+    ep_pg_collection: ProcessGroupCollection,
+) -> None:
+    """CPU initialization must be synchronized when EP ranks use different seeds."""
+    ep_rank = dist.get_rank(group=ep_pg_collection.ep)
+    for base_linear_name, input_is_parallel in _ADAPTER_CASES:
+        torch.manual_seed(2026 + ep_rank)
+        adapter = _make_adapter(
+            ep_pg_collection,
+            base_linear_name=base_linear_name,
+            input_is_parallel=input_is_parallel,
+            use_cpu_initialization=True,
+        )
+        for parameter in adapter.parameters():
+            assert parameter.device.type == "cpu"
+            _assert_identical_across_ep(parameter.detach(), ep_pg_collection.ep)

--- a/tests/unit_tests/peft/test_utils.py
+++ b/tests/unit_tests/peft/test_utils.py
@@ -21,7 +21,7 @@ and the ParallelLinearAdapter class for distributed PEFT scenarios.
 
 import math
 from types import SimpleNamespace
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, PropertyMock, patch
 
 import pytest
 import torch
@@ -1009,6 +1009,87 @@ class TestParallelLinearAdapter:
             grad = call.args[0]
             torch.testing.assert_close(grad, torch.ones_like(grad))
             assert call.kwargs["group"] is ep_group
+
+    @patch("megatron.bridge.peft.utils.ColumnParallelLinear")
+    @patch("megatron.bridge.peft.utils.RowParallelLinear")
+    def test_parallel_linear_adapter_grouped_expert_shared_adapter_syncs_init_across_ep(
+        self, mock_row_linear, mock_col_linear, mock_config
+    ):
+        """Shared grouped-expert adapters must broadcast every weight across EP."""
+        mock_linear_in = Mock()
+        mock_linear_out = Mock()
+        mock_linear_in.weight = nn.Parameter(torch.ones(2, 2))
+        mock_linear_out.weight = nn.Parameter(torch.ones(2, 2))
+        mock_col_linear.side_effect = [mock_linear_in, mock_linear_out]
+        mock_config._pg_collection = make_mock_pg_collection(ep_size=2)
+        ep_group = mock_config._pg_collection.ep
+
+        with (
+            patch("torch.distributed.is_available", return_value=True),
+            patch("torch.distributed.is_initialized", return_value=True),
+            patch("torch.distributed.get_global_rank", return_value=7) as mock_get_global_rank,
+            patch("torch.distributed.broadcast") as mock_broadcast,
+            patch.object(torch.Tensor, "is_cuda", new_callable=PropertyMock, return_value=True),
+        ):
+            ParallelLinearAdapter(
+                in_features=2,
+                out_features=2,
+                dim=2,
+                base_linear_name="decoder.layers.0.mlp.experts.linear_fc2",
+                is_expert=True,
+                model_parallel_config=mock_config,
+            )
+
+        mock_get_global_rank.assert_called_once_with(ep_group, 0)
+        assert mock_broadcast.call_count == 2
+        for call, expected_weight in zip(
+            mock_broadcast.call_args_list,
+            (mock_linear_in.weight, mock_linear_out.weight),
+            strict=True,
+        ):
+            assert call.args[0] is expected_weight
+            assert call.kwargs == {"src": 7, "group": ep_group}
+
+    @patch("megatron.bridge.peft.utils.ColumnParallelLinear")
+    @patch("megatron.bridge.peft.utils.RowParallelLinear")
+    def test_parallel_linear_adapter_grouped_expert_shared_adapter_syncs_cpu_init_across_ep(
+        self, mock_row_linear, mock_col_linear, mock_config
+    ):
+        """CPU-initialized shared adapters must stage both weights through NCCL."""
+        mock_linear_in = Mock()
+        mock_linear_out = Mock()
+        mock_linear_in.weight = nn.Parameter(torch.ones(2, 2))
+        mock_linear_out.weight = nn.Parameter(torch.ones(2, 2))
+        mock_col_linear.side_effect = [mock_linear_in, mock_linear_out]
+        mock_config._pg_collection = make_mock_pg_collection(ep_size=2)
+        ep_group = mock_config._pg_collection.ep
+        staged_weights = (torch.full((2, 2), 3.0), torch.full((2, 2), 5.0))
+
+        with (
+            patch("torch.distributed.is_available", return_value=True),
+            patch("torch.distributed.is_initialized", return_value=True),
+            patch("torch.distributed.get_global_rank", return_value=7),
+            patch("torch.distributed.get_backend", return_value="nccl"),
+            patch("torch.distributed.broadcast") as mock_broadcast,
+            patch("torch.cuda.current_device", return_value=0),
+            patch.object(torch.Tensor, "to", side_effect=staged_weights) as mock_to,
+        ):
+            ParallelLinearAdapter(
+                in_features=2,
+                out_features=2,
+                dim=2,
+                base_linear_name="decoder.layers.0.mlp.experts.linear_fc2",
+                is_expert=True,
+                model_parallel_config=mock_config,
+            )
+
+        assert mock_to.call_count == 2
+        assert mock_broadcast.call_count == 2
+        for call, staged_weight in zip(mock_broadcast.call_args_list, staged_weights, strict=True):
+            assert call.args[0] is staged_weight
+            assert call.kwargs == {"src": 7, "group": ep_group}
+        torch.testing.assert_close(mock_linear_in.weight, staged_weights[0])
+        torch.testing.assert_close(mock_linear_out.weight, staged_weights[1])
 
     @patch("megatron.bridge.peft.utils.ColumnParallelLinear")
     @patch("megatron.bridge.peft.utils.RowParallelLinear")


### PR DESCRIPTION
# What does this PR do ?

Keep shared expert LoRA parameters bitwise identical across expert-parallel ranks from initialization through backward.

# Changelog

- Broadcast CUDA-initialized shared grouped-expert LoRA weights from expert-parallel group rank zero.
- Stage CPU-initialized weights through the existing NCCL expert-parallel group, then copy the synchronized values back to CPU.
- Reject unmaterialized meta parameters instead of silently leaving rank-local values.
- Retain the existing SUM gradient synchronization across expert-parallel ranks.
- Add normal unit-CI coverage plus two-rank exact-parity coverage for FC1 and FC2 adapters, including every linear_in and linear_out parameter and nonzero gradient.

# Root cause

Expert LoRA layers use the expert RNG tracker, whose seed differs by expert-parallel rank. CPU initialization can also use rank-dependent seeds. The existing gradient all-reduce applies identical updates but cannot remove an initialization offset.

Before the fix, the regression test found all 32 LoRA-A elements mismatched across two expert-parallel ranks. After the fix, CUDA initialization, deliberately rank-divergent CPU initialization, and nonzero gradients match exactly for both shared expert adapter layouts.

# GitHub Actions CI

Targeted validation:

- `uv run --no-sync --with pytest python -m torch.distributed.run --standalone --nproc_per_node=2 -m pytest tests/unit_tests/peft/test_shared_expert_lora_distributed.py -vv` (3 passed)
- `uv run --no-sync --with pytest python -m pytest` on the focused normal-CI init/CPU-init/gradient tests (3 passed)
- Existing shared-expert sharded-state, SwiGLU, extra-state, and gradient-sync tests (4 passed)
- `uv run --no-sync --active pre-commit run --all-files` (passed)

# Before your PR is "Ready for review"

- [x] Read and followed the contributor guidelines.
- [x] Added focused regression tests.
- [x] No documentation update is needed for this correctness fix.
- [x] No optional-install component behavior is changed.

# Additional Information

Related to NVBug 6565838.