### PR TITLE
fix(data): collate ragged packed sequence metadata

### DIFF
--- a/src/megatron/bridge/data/packing/gpt_sft.py
+++ b/src/megatron/bridge/data/packing/gpt_sft.py
@@ -275,8 +275,18 @@ class GPTSFTPackedDataset(GPTSFTDataset):
         }
 
         if self.return_cu_seqlen:
-            # Offline packed SFT requires micro-batch size 1, so no sentinel padding is
-            # needed to batch variable-length metadata. Emit MCore/TE field names directly.
+            # The DataLoader collates every row assigned to this data-parallel rank before
+            # the training loop splits that global batch into MBS1 microbatches. Extend the
+            # boundary arrays with zero-length sequences so ragged rows form tensors while
+            # retaining the direct MCore/TE cumulative-offset contract.
+            boundary_batches = [cu_seqlens]
+            if cu_seqlens_padded is not None:
+                boundary_batches.append(cu_seqlens_padded)
+            max_num_boundaries = max(len(boundaries) for rows in boundary_batches for boundaries in rows)
+            for rows in boundary_batches:
+                for boundaries in rows:
+                    boundaries.extend([boundaries[-1]] * (max_num_boundaries - len(boundaries)))
+
             seqlens = torch.IntTensor(cu_seqlens_padded if cu_seqlens_padded is not None else cu_seqlens)
             seqlens = seqlens[:, 1:] - seqlens[:, :-1]
             max_seqlen, _ = seqlens.max(dim=1, keepdim=True)

--- a/tests/unit_tests/data/datasets/test_gpt_sft.py
+++ b/tests/unit_tests/data/datasets/test_gpt_sft.py
@@ -357,6 +357,31 @@ class TestDataGPTSFTPackedDataset:
         ]
         dataset.collate_fn(batch)
 
+    def test_collate_fn_supports_different_sequence_counts(self, tmp_path):
+        """Packed rows with different logical sequence counts collate into one global batch."""
+        dataset, _ = get_gpt_sft(tmp_path, dataset_type="packed")
+        dataset.max_seq_length = 8
+        dataset.pad_seq_length_to_mult = 1
+        batch = [
+            {
+                "input_ids": np.array([10, 11, 12, 13, 20, 21, 22, 23]),
+                "seq_boundaries": [0, 4, 8],
+                "loss_mask": np.ones(8, dtype=np.int64),
+            },
+            {
+                "input_ids": np.array([30, 31, 32, 33, 34, 35, 36, 37]),
+                "seq_boundaries": [0, 8],
+                "loss_mask": np.ones(8, dtype=np.int64),
+            },
+        ]
+
+        processed = dataset.collate_fn(batch)
+
+        assert processed["cu_seqlens_q"].tolist() == [[0, 3, 6, 7], [0, 7, 7, 7]]
+        assert processed["cu_seqlens_kv"].tolist() == processed["cu_seqlens_q"].tolist()
+        assert processed["max_seqlen_q"].tolist() == [[3], [7]]
+        assert processed["max_seqlen_kv"].tolist() == [[3], [7]]
+
     def test_utils_func_packed(self, tmp_path):
         dataset, _ = get_gpt_sft(tmp_path, dataset_type="packed")
 


### PR DESCRIPTION
## What does this PR do?

Fixes NVBug 6570726, a regression introduced by #5344 where offline-packed SFT fails in `GPTSFTPackedDataset.collate_fn` before training step 1 when packed rows contain different numbers of logical sequences.

The finetuning batch sampler intentionally sends the full global batch assigned to each data-parallel rank through `collate_fn`, then splits the collated tensors into MBS1 microbatches. Therefore MBS1 does not imply that cumulative-sequence metadata is rectangular at collate time.

This change extends each logical and physical cumulative-offset row to the batch-local maximum boundary count by repeating its terminal offset. The repeated offsets represent zero-length sequences, matching the existing static `pad_cu_seqlens` convention while preserving the direct MCore/TE `cu_seqlens_q` / `cu_seqlens_kv`, optional `*_padded`, and per-row `max_seqlen_q` / `max_seqlen_kv` contract.

## Testing

- Added a focused regression through the real packed SFT `collate_fn` with two rows containing different logical sequence counts.
- Confirmed the test fails on unmodified main with `ValueError: expected sequence of length 4 at dim 1 (got 2)`.
- `uv run python -m pytest` focused packed-dataset, logical/physical boundary, batch-splitting, and packed-sequence utility coverage: 34 passed.
- `uv run pre-commit run --all-files`: passed.

An optional small 2-GPU packed-SFT smoke was attempted but the allocation was canceled before Python execution, so it is not counted as validation evidence.

## Tracking

- NVBug 6570726
- Regression from #5344 / e4cb868