### PR TITLE
perf(glm): [DO NOT MERGE] add GLM-5.2 GB200 performance demo

### DIFF
--- a/examples/model_verification_cards/glm5-2/card.yaml
+++ b/examples/model_verification_cards/glm5-2/card.yaml
@@ -3,16 +3,18 @@
 
 title: glm5_2
 summary: >
-  Performance disclaimer: this model has not been performance-tuned; reported
-  timing and throughput metrics are sanity checks, not optimized performance
-  results. GLM-5.2 H100 support verification currently covers exact GPU
-  checkpoint round-trip on CPU and GPU, HF-to-Megatron forward equivalence,
-  bounded full SFT with export/reload inference, 200K-context CP32 SFT,
-  bounded PEFT, and bounded pretraining with a reloadable middle checkpoint
-  and verified continuation. GB200 support verification currently covers
-  bounded pretraining, bounded full SFT, 128K packed long-context SFT, bounded
-  PEFT, bounded checkpoint resume, and deterministic legacy Megatron
-  inference; post-SFT export/reload inference remains pending.
+  Performance scope: pretrain_performance.GB200 is a full-model, fixed-shape
+  mock-data perf demo using forced expert balance and zero DSA indexer loss;
+  timing and throughput metrics from functional training items remain sanity
+  checks rather than optimized performance results. GLM-5.2 H100 support
+  verification currently covers exact GPU checkpoint round-trip on CPU and
+  GPU, HF-to-Megatron forward equivalence, bounded full SFT with export/reload
+  inference, 200K-context CP32 SFT, bounded PEFT, and bounded pretraining with
+  a reloadable middle checkpoint and verified continuation. GB200 support
+  verification currently covers bounded pretraining, bounded full SFT, 128K
+  packed long-context SFT, bounded PEFT, bounded checkpoint resume, and
+  deterministic legacy Megatron inference; post-SFT export/reload inference
+  remains pending.
 verification_index:
   model_level:
     verified:
@@ -28,6 +30,8 @@ verification_index:
       unverified: [sft_export_inference]
     H100:
       verified: [pretrain, sft, sft_export_inference, sft_long_context, peft, checkpoint_resume]
+  performance:
+    GB200: unverified
 model:
   hf_id: zai-org/GLM-5.2
   hf_revision: 4d67f66cc64d3219133b767c253b2ad1425c6c88  # pragma: allowlist secret
@@ -227,6 +231,35 @@ items:
         recorded zero skipped and NaN iterations. The final 10 steps averaged
         64,786.540 ms and 102.520 TFLOPS/GPU. Step-50 and step-100 checkpoints
         contain model, optimizer, scheduler, data-order, and RNG state.
+
+  pretrain_performance:
+    GB200:
+      status: unverified
+      precision: fp8_mx
+      command: >
+        ./scripts/training/train.sh --nodes 48 --gpus-per-node 4
+        --recipe glm52_pretrain_192gpu_gb200_fp8mx_config --mode pretrain
+        --max_steps 50
+        logger.save_config_filepath=work/model-verification/glm5-2/gb200-performance/resolved-config.yaml
+      last_verified: null
+      metrics:
+        initial_loss: null
+        final_loss: null
+        last_10_steps_step_time_ms_avg: null
+        last_10_steps_model_tflops_per_gpu_avg: null
+      expected_result: >
+        On 192x GB200, the exact full-model, fixed-shape mock-data perf demo is
+        expected to complete 50 steps at TP1/PP6/CP1/EP32/ETP1 and GBS/MBS
+        3072/1 with MXFP8, HybridEP using 32 dispatch and 32 combine SMs, forced
+        expert balance, zero DSA indexer auxiliary loss, and no activation
+        recompute. A prior four-step bring-up with three steady steps observed
+        39,429.2 ms/step and 499.60 model TFLOP/s/GPU; that window is shorter
+        than the required final-10 window, so the canonical item remains
+        unverified. Do not compare it directly with pretrain.GB200, which uses
+        RP2 data, BF16, GBS 1024, natural routing, nonzero indexer loss, and
+        all-to-all dispatch. A canonical rerun must complete all 50 steps with
+        finite losses, no skipped or NaN iterations, and all four final-10
+        metrics recorded before this item can be marked verified.
 
   sft:
     H100:

--- a/src/megatron/bridge/perf_recipes/glm_moe_dsa/__init__.py
+++ b/src/megatron/bridge/perf_recipes/glm_moe_dsa/__init__.py
@@ -16,6 +16,7 @@
 
 from megatron.bridge.perf_recipes.glm_moe_dsa.gb200.glm5 import (
     glm51_sft_192gpu_gb200_bf16_config,
+    glm52_pretrain_192gpu_gb200_fp8mx_config,
     glm52_sft_192gpu_gb200_bf16_config,
 )
 from megatron.bridge.perf_recipes.glm_moe_dsa.h100.glm5 import (

--- a/src/megatron/bridge/perf_recipes/glm_moe_dsa/gb200/glm5.py
+++ b/src/megatron/bridge/perf_recipes/glm_moe_dsa/gb200/glm5.py
@@ -11,14 +11,154 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""GB200 performance recipes for GLM-5.1 and GLM-5.2 SFT."""
+"""GB200 performance recipes for GLM-5.1 and GLM-5.2 pretraining and SFT."""
+
+import torch
 
 from megatron.bridge import AutoBridge
 from megatron.bridge.perf_recipes._common import _benchmark_common, _perf_precision
 from megatron.bridge.perf_recipes.environment import COMMON_PERF_ENV_VARS
-from megatron.bridge.recipes.common import _sft_common
+from megatron.bridge.recipes.common import _pretrain_common, _sft_common
 from megatron.bridge.recipes.utils.tokenizer_utils import DEFAULT_NULL_TOKENIZER_VOCAB_SIZE
+from megatron.bridge.training.comm_overlap import CommOverlapConfig
 from megatron.bridge.training.config import ConfigContainer
+
+
+_GLM52_MODEL_ID = "zai-org/GLM-5.2"
+_GLM52_MODEL_REVISION = "4d67f66cc64d3219133b767c253b2ad1425c6c88"  # pragma: allowlist secret
+_GLM52_PP6_PERF_LAYOUT = "Et*10|t*12|t*12|t*12|t*16|t*16mL"
+
+
+def glm52_pretrain_192gpu_gb200_fp8mx_config() -> ConfigContainer:
+    """GLM-5.2 perf demo: 192× GB200, MXFP8, 4K mock data, PP6/EP32."""
+    cfg = _pretrain_common()
+
+    cfg.model = AutoBridge.from_hf_pretrained(
+        _GLM52_MODEL_ID,
+        revision=_GLM52_MODEL_REVISION,
+    ).to_megatron_provider(load_weights=False)
+    cfg.mixed_precision = _perf_precision("fp8_mx")
+
+    cfg.tokenizer.tokenizer_type = "NullTokenizer"
+    cfg.tokenizer.tokenizer_model = None
+    cfg.tokenizer.vocab_size = DEFAULT_NULL_TOKENIZER_VOCAB_SIZE
+
+    cfg.dataset.seq_length = 4096
+    cfg.dataset.num_dataset_builder_threads = 1
+
+    # Preserve the complete GLM-5.2 model while matching the measured 192-GPU
+    # topology. The uneven stages keep DSA index-sharing groups local and move
+    # more decoder layers away from the embedding-heavy first stage.
+    cfg.model.seq_length = 4096
+    cfg.model.qk_pos_emb_head_dim = 64
+    cfg.model.tensor_model_parallel_size = 1
+    cfg.model.pipeline_model_parallel_size = 6
+    cfg.model.virtual_pipeline_model_parallel_size = None
+    cfg.model.pipeline_model_parallel_layout = _GLM52_PP6_PERF_LAYOUT
+    cfg.model.context_parallel_size = 1
+    cfg.model.expert_model_parallel_size = 32
+    cfg.model.expert_tensor_parallel_size = 1
+    cfg.model.sequence_parallel = False
+    cfg.model.num_layers_in_first_pipeline_stage = None
+    cfg.model.num_layers_in_last_pipeline_stage = None
+    cfg.model.account_for_embedding_in_pipeline_split = False
+    cfg.model.account_for_loss_in_pipeline_split = False
+
+    cfg.train.global_batch_size = 3072
+    cfg.train.micro_batch_size = 1
+
+    cfg.model.transformer_impl = "transformer_engine"
+    cfg.model.attention_backend = "auto"
+    cfg.model.gradient_accumulation_fusion = True
+    cfg.model.moe_permute_fusion = True
+    cfg.model.moe_permute_fusion_into_hybridep = False
+    cfg.model.moe_grouped_gemm = True
+    cfg.model.moe_router_fusion = True
+    cfg.model.moe_router_force_load_balancing = True
+    cfg.model.moe_token_dispatcher_type = "flex"
+    cfg.model.moe_flex_dispatcher_backend = "hybridep"
+    cfg.model.moe_router_dtype = "fp32"
+    cfg.model.moe_shared_expert_overlap = False
+    cfg.model.persist_layer_norm = True
+    cfg.model.bias_dropout_fusion = True
+    cfg.model.bias_activation_fusion = True
+    cfg.model.calculate_per_token_loss = True
+    cfg.model.dsa_kernel_backend = "cudnn"
+    cfg.model.dsa_indexer_topk = 2048
+    # This is an upper-bound performance demo, not a convergence recipe. Force
+    # balancing and a disabled auxiliary indexer loss isolate system throughput.
+    cfg.model.dsa_indexer_loss_coeff = 0.0
+    cfg.model.dsa_indexer_use_sparse_loss = False
+    cfg.model.mtp_num_layers = 1
+
+    cfg.model.recompute_granularity = None
+    cfg.model.recompute_method = None
+    cfg.model.recompute_num_layers = None
+    cfg.model.recompute_modules = None
+
+    cfg.model.cuda_graph_impl = "none"
+    cfg.model.cuda_graph_scope = []
+    cfg.model.cuda_graph_warmup_steps = 0
+    cfg.model.high_priority_a2a_comm_stream = False
+    cfg.rng.te_rng_tracker = cfg.model.use_te_rng_tracker = False
+
+    cfg.ddp.use_distributed_optimizer = True
+    cfg.ddp.overlap_grad_reduce = False
+    cfg.ddp.overlap_param_gather = True
+    cfg.ddp.average_in_collective = False
+    cfg.ddp.grad_reduce_in_fp32 = False
+    cfg.ddp.reuse_grad_buf_for_mxfp8_param_ag = True
+    cfg.optimizer.use_distributed_optimizer = True
+    cfg.optimizer.use_precision_aware_optimizer = True
+    cfg.optimizer.main_grads_dtype = torch.bfloat16
+    cfg.optimizer.main_params_dtype = torch.float32
+    cfg.optimizer.exp_avg_dtype = torch.bfloat16
+    cfg.optimizer.exp_avg_sq_dtype = torch.bfloat16
+    cfg.optimizer.overlap_param_gather_with_optimizer_step = False
+    cfg.comm_overlap = CommOverlapConfig(
+        tp_comm_overlap=False,
+        overlap_p2p_comm=False,
+        batch_p2p_comm=True,
+        overlap_grad_reduce=False,
+        overlap_param_gather=True,
+        overlap_param_gather_with_optimizer_step=False,
+        overlap_moe_expert_parallel_comm=False,
+        delay_wgrad_compute=False,
+    )
+    cfg.dist.distributed_timeout_minutes = 45
+    cfg.dist.enable_megatron_core_experimental = True
+
+    _benchmark_common(cfg, cross_entropy_impl="native")
+    cfg.optimizer.lr = 3e-5
+    cfg.optimizer.min_lr = 3e-5
+    cfg.scheduler.lr_warmup_iters = 0
+    cfg.model.apply_rope_fusion = False
+    cfg.model.fp8_output_proj = True
+    cfg.model.moe_hybridep_num_sms = 32
+    cfg.model.moe_hybridep_num_sms_preprocessing = 32
+    cfg.model.moe_mlp_glu_interleave_size = 32
+    cfg.model.moe_router_padding_for_quantization = True
+    cfg.model.use_transformer_engine_op_fuser = True
+    cfg.env_vars = {
+        **COMMON_PERF_ENV_VARS,
+        "CUDA_DEVICE_MAX_CONNECTIONS": 32,
+        "CUDNNFE_CLUSTER_OVERLAP_MARGIN": 8,
+        "NCCL_GRAPH_REGISTER": 0,
+        "NCCL_NVLS_ENABLE": 0,
+        "NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN": 32,
+        "NUM_OF_TOKENS_PER_CHUNK_COMBINE_API": 128,
+        "NVLINK_DOMAIN_SIZE": 72,
+        "NVTE_ALLOW_NONDETERMINISTIC_ALGO": 0,
+        "NVTE_BWD_LAYERNORM_SM_MARGIN": 20,
+        "NVTE_CUTEDSL_FUSED_GROUPED_MLP": 1,
+        "NVTE_FWD_LAYERNORM_SM_MARGIN": 20,
+        "NVTE_NORM_BWD_USE_CUDNN": 1,
+        "NVTE_NORM_FWD_USE_CUDNN": 1,
+        "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True",
+        "TORCH_NCCL_AVOID_RECORD_STREAMS": 1,
+        "USE_MNNVL": 1,
+    }
+    return cfg
 
 
 def glm51_sft_192gpu_gb200_bf16_config() -> ConfigContainer:

--- a/tests/unit_tests/recipes/test_glm5_perf_recipes.py
+++ b/tests/unit_tests/recipes/test_glm5_perf_recipes.py
@@ -20,12 +20,14 @@ from collections.abc import Callable
 from types import SimpleNamespace
 
 import pytest
+import torch
 from megatron.core.transformer.enums import LayerType
 from megatron.core.transformer.pipeline_parallel_layer_layout import PipelineParallelLayerLayout
 
 from megatron.bridge.perf_recipes.glm_moe_dsa import (
     glm51_sft_192gpu_gb200_bf16_config,
     glm51_sft_416gpu_h100_bf16_config,
+    glm52_pretrain_192gpu_gb200_fp8mx_config,
     glm52_sft_192gpu_gb200_bf16_config,
     glm52_sft_416gpu_h100_bf16_config,
 )
@@ -36,6 +38,7 @@ pytestmark = pytest.mark.unit
 
 _RECIPES = [
     glm51_sft_192gpu_gb200_bf16_config,
+    glm52_pretrain_192gpu_gb200_fp8mx_config,
     glm52_sft_192gpu_gb200_bf16_config,
     glm51_sft_416gpu_h100_bf16_config,
     glm52_sft_416gpu_h100_bf16_config,
@@ -63,7 +66,9 @@ class _FakeAutoBridge:
         self.model_id = model_id
 
     @classmethod
-    def from_hf_pretrained(cls, model_id: str) -> "_FakeAutoBridge":
+    def from_hf_pretrained(cls, model_id: str, revision: str | None = None) -> "_FakeAutoBridge":
+        if revision is not None:
+            assert len(revision) == 40
         return cls(model_id)
 
     def to_megatron_provider(self, load_weights: bool = False) -> SimpleNamespace:
@@ -121,8 +126,74 @@ def test_glm5_perf_recipes_are_flat_and_preserve_bridge_dsa_fields(
     else:
         assert cfg.model.dsa_indexer_topk_freq == 1
         assert cfg.model.dsa_indexer_skip_topk_offset == 0
+    perf_demo_dsa_overrides = {
+        "dsa_indexer_topk": 2048,
+        "dsa_indexer_loss_coeff": 0.0,
+        "dsa_indexer_use_sparse_loss": False,
+    }
     for field, expected in _BRIDGE_DSA_VALUES.items():
+        if recipe_func is glm52_pretrain_192gpu_gb200_fp8mx_config:
+            expected = perf_demo_dsa_overrides.get(field, expected)
         assert getattr(cfg.model, field) == expected
+
+
+def test_glm52_gb200_pretrain_perf_demo_matches_measured_topology(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The full-model perf demo preserves the measured 192-GPU configuration."""
+    cfg = _build_recipe(glm52_pretrain_192gpu_gb200_fp8mx_config, monkeypatch)
+
+    assert cfg.model.num_layers == 78
+    assert cfg.dataset.seq_length == 4096
+    assert cfg.model.seq_length == 4096
+    assert cfg.model.qk_pos_emb_head_dim == 64
+    assert cfg.model.tensor_model_parallel_size == 1
+    assert cfg.model.pipeline_model_parallel_size == 6
+    assert cfg.model.virtual_pipeline_model_parallel_size is None
+    assert cfg.model.context_parallel_size == 1
+    assert cfg.model.expert_model_parallel_size == 32
+    assert cfg.model.expert_tensor_parallel_size == 1
+    assert cfg.model.sequence_parallel is False
+    assert cfg.train.global_batch_size == 3072
+    assert cfg.train.micro_batch_size == 1
+
+    layout = PipelineParallelLayerLayout(
+        cfg.model.pipeline_model_parallel_layout,
+        cfg.model.pipeline_model_parallel_size,
+    )
+    layout.validate_layer_layout(cfg.model.num_layers, cfg.model.mtp_num_layers)
+    decoder_counts = [
+        sum(chunk.count(LayerType.decoder) for chunk in physical_stage) for physical_stage in layout.layout
+    ]
+    assert decoder_counts == [10, 12, 12, 12, 16, 16]
+
+    assert cfg.mixed_precision.fp8 == "e4m3"
+    assert cfg.mixed_precision.fp8_recipe == "mxfp8"
+    assert cfg.model.moe_router_force_load_balancing is True
+    assert cfg.model.moe_token_dispatcher_type == "flex"
+    assert cfg.model.moe_flex_dispatcher_backend == "hybridep"
+    assert cfg.model.moe_hybridep_num_sms == 32
+    assert cfg.model.moe_hybridep_num_sms_preprocessing == 32
+    assert cfg.model.moe_permute_fusion_into_hybridep is False
+    assert cfg.model.dsa_indexer_topk == 2048
+    assert cfg.model.dsa_indexer_loss_coeff == 0.0
+    assert cfg.model.dsa_indexer_use_sparse_loss is False
+
+    assert cfg.model.recompute_granularity is None
+    assert cfg.model.recompute_method is None
+    assert cfg.model.recompute_num_layers is None
+    assert cfg.model.recompute_modules is None
+    assert cfg.model.cuda_graph_impl == "none"
+    assert cfg.model.cuda_graph_scope == []
+    assert cfg.model.high_priority_a2a_comm_stream is False
+    assert cfg.ddp.overlap_grad_reduce is False
+    assert cfg.ddp.overlap_param_gather is True
+    assert cfg.comm_overlap.overlap_p2p_comm is False
+    assert cfg.comm_overlap.batch_p2p_comm is True
+    assert cfg.optimizer.use_precision_aware_optimizer is True
+    assert cfg.optimizer.main_grads_dtype == torch.bfloat16
+    assert cfg.optimizer.main_params_dtype == torch.float32
+    assert cfg.optimizer.exp_avg_dtype == torch.bfloat16
+    assert cfg.optimizer.exp_avg_sq_dtype == torch.bfloat16
+    assert cfg.env_vars["NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN"] == 32
 
 
 @pytest.mark.parametrize("recipe_func", _H100_RECIPES, ids=lambda recipe: recipe.__name__)


### PR DESCRIPTION
## Summary

- add a canonical full-model GLM-5.2 GB200 MXFP8 performance recipe on 192 GPUs
- enable HybridEP with 32 dispatch / 32 combine SMs, forced expert balance, PP layout, and no activation recompute
- add an unverified `pretrain_performance.GB200` model-card item labeled as a fixed-shape mock-data perf demo

## Historical observation

A prior four-step bring-up (one warmup plus three steady steps) averaged 39.4292 s/step and 499.60 model TFLOP/s/GPU using the updated DSA FLOPs formula. The card item remains unverified because this is shorter than the required final-10 window. It is not directly comparable with the RP2 functional item because the demo uses mock data, GBS 3072, MXFP8, forced routing, zero indexer loss, and HybridEP.

## Validation

- GLM performance recipe tests on the GB200/Lyris environment: 10 passed
- all performance factory test filtered to the new recipe: 1 passed, 428 deselected
- model verification card validator: passed
- card validator unit tests: 15 passed
- `pre-commit run --all-files`: passed

## Follow-up

Run the canonical recipe for 50 steps and record the final-10 metrics before marking the model-card item verified.