### PR TITLE
fix(recipes): use max-pool FSDP for Qwen3.5-VL

### DIFF
--- a/src/megatron/bridge/recipes/qwen_vl/h100/qwen35_vl.py
+++ b/src/megatron/bridge/recipes/qwen_vl/h100/qwen35_vl.py
@@ -1069,6 +1069,7 @@ def qwen35_vl_35b_a3b_sft_2gpu_h100_bf16_fsdp_config() -> ConfigContainer:
     cfg.ddp.data_parallel_sharding_strategy = "optim_grads_params"
     cfg.ddp.use_megatron_fsdp = True
     cfg.ddp.fsdp_double_buffer = True
+    cfg.ddp.megatron_fsdp_max_pool_double_buffer = True
     cfg.ddp.nccl_ub = False
     cfg.ddp.fsdp_db_use_persist_buf_on_alloc_fail = True
     cfg.ddp.overlap_grad_reduce = True

--- a/tests/unit_tests/recipes/qwen_vl/test_qwen35_vl_recipes.py
+++ b/tests/unit_tests/recipes/qwen_vl/test_qwen35_vl_recipes.py
@@ -503,6 +503,7 @@ def test_qwen35_vl_35b_a3b_fsdp_sft_defaults(monkeypatch: pytest.MonkeyPatch):
     assert cfg.model.moe_router_fusion is True
     assert cfg.ddp.use_megatron_fsdp is True
     assert cfg.ddp.fsdp_double_buffer is True
+    assert cfg.ddp.megatron_fsdp_max_pool_double_buffer is True
     assert cfg.ddp.nccl_ub is False
     assert cfg.ddp.overlap_grad_reduce is True
     assert cfg.ddp.overlap_param_gather is True


### PR DESCRIPTION
## Summary

- enable the asymmetry-aware Megatron-FSDP max-pool double buffer for the Qwen3.5-VL 35B-A3B FSDP SFT recipe
- lock the safe allocator choice into the focused recipe-default regression test

Refs NVBug 6570995.

## Root cause

Bridge constructs the expected expert-DP groups for TP1/PP1/EP2 and passes the expert group through the process-group collection into Megatron FSDP. With 16 ranks, each expert-DP group has eight alternating global ranks. The reported 50,331,648-element input and 402,653,184-element output are also correct for the local Qwen expert FC1/FC2 buffer.

Small one-node and two-node controls completed the forward and first pre-backward expert gathers with those exact memberships and shapes. The full Qwen provider then showed the actual problem: the fixed-pool allocator selected the dominant symmetric unit class and persistently retained fallback buffers for 38 asymmetric VLM, GDN, attention, and MoE units. On 80 GB devices the unmodified recipe completed all backward collectives, saturated 79.1 GB, and failed while initializing optimizer state.

Max-pool reuses two buffers sized for every FSDP unit. In the matched 2-node, 16-GPU A/B, it completed iteration 1 with 54.4 GB allocated after the step and a 74.8 GB peak. This points to allocator-induced memory pressure rather than an application collective mismatch or an MCore process-group defect, so no MCore source change is needed.

## Testing

- fail-before/current main: focused recipe test fails because max-pool defaults to false
- after fix: uv run python -m pytest tests/unit_tests/recipes/qwen_vl/test_qwen35_vl_recipes.py::test_qwen35_vl_35b_a3b_fsdp_sft_defaults -q
- one-node tiny EP2 Megatron-FSDP training control
- one-node and two-node exact-shape expert-DP gather controls
- matched 2-node, 16-GPU full Qwen provider A/B through one optimizer step
- uv run pre-commit run --all-files