### PR TITLE
fix(switch_mcore): auto-fetch pinned commit when missing locally

### DIFF
--- a/scripts/switch_mcore.sh
+++ b/scripts/switch_mcore.sh
@@ -72,6 +72,19 @@ get_current_commit() {
     git -C "$SUBMODULE_PATH" rev-parse HEAD 2>/dev/null || echo "unknown"
 }
 
+# Ensure the target commit object is present locally. Pinned dev/main commits
+# often live on branches the initial shallow submodule clone never fetched, so
+# a plain checkout fails with "reference is not a tree". Fetch it on demand.
+ensure_commit() {
+    local commit="$1"
+    if git -C "$SUBMODULE_PATH" cat-file -e "${commit}^{commit}" 2>/dev/null; then
+        return 0
+    fi
+    log "Commit ${commit:0:12} not present locally. Fetching from origin..."
+    git -C "$SUBMODULE_PATH" fetch origin "$commit" \
+        || err "Failed to fetch $commit from origin"
+}
+
 do_status() {
     check_submodule
     local current
@@ -106,6 +119,7 @@ do_switch() {
     log "Before: ${current:0:12}"
     log "Switching to $target_name commit: ${target_commit:0:12}"
 
+    ensure_commit "$target_commit"
     git -C "$SUBMODULE_PATH" checkout "$target_commit" || err "Failed to checkout $target_commit"
 
     log "After:  $(get_current_commit | cut -c1-12)"


### PR DESCRIPTION
# What does this PR do ?

The initial submodule clone only fetches the default branch, so pinned dev/main commits living on other branches are absent locally and 'git checkout' fails with "reference is not a tree". Add ensure_commit() to fetch the target commit from origin on demand before checkout.

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
