### PR TITLE
[training] fix: support MegatronMIMO interval evaluation

### DIFF
--- a/src/megatron/bridge/training/eval.py
+++ b/src/megatron/bridge/training/eval.py
@@ -149,15 +149,17 @@ def evaluate(
             "Multimodule (MegatronMIMO) evaluation requires an explicit MultiModulePipelineCommunicator as p2p_communicator."
         )
 
-    if not state.cfg.dist.use_decentralized_pg:
+    default_seq_length = state.cfg.dataset.seq_length if is_multimodule else state.cfg.model.seq_length
+
+    if is_multimodule or state.cfg.dist.use_decentralized_pg:
+        adjust_tensor_shapes_fn = None
+    else:
         adjust_tensor_shapes_fn = get_tensor_shapes_adjust_fn_for_distillation(
             model,
-            seq_length=state.cfg.model.seq_length,
+            seq_length=default_seq_length,
             micro_batch_size=eval_micro_batch_size,
-            decoder_seq_length=state.cfg.model.seq_length,
+            decoder_seq_length=default_seq_length,
         )
-    else:
-        adjust_tensor_shapes_fn = None
 
     with torch.no_grad():
         if verbose:
@@ -187,7 +189,7 @@ def evaluate(
             )
         # Wrap model with PagedStashRunner when moe_expert_rank_capacity_factor padding is enabled.
         # PagedStashRunner is responsible for detecting overflow and re-running iteration in eager-mode without padding.
-        if HAS_PAGED_STASHING and state.cfg.model.moe_expert_rank_capacity_factor is not None:
+        if not is_multimodule and HAS_PAGED_STASHING and state.cfg.model.moe_expert_rank_capacity_factor is not None:
             copy_main_params = (
                 state.cfg.optimizer.reuse_grad_buf_for_mxfp8_param_ag and state.cfg.ddp.overlap_param_gather
             )
@@ -202,7 +204,7 @@ def evaluate(
                 print_rank_0(f"Evaluating iter {iteration}/{state.cfg.validation.eval_iters}")
 
             # Handle finetuning vs pretraining data consumption
-            seq_length = state.cfg.model.seq_length  # Default for pretraining
+            seq_length = default_seq_length  # Default for pretraining
             eval_data_iterator = data_iterator  # Default for pretraining
 
             if state.cfg.dataset.dataloader_type == "batch":
@@ -210,7 +212,7 @@ def evaluate(
                 eval_data_iterator, seq_length = prepare_finetuning_batch(
                     data_iterator=data_iterator,
                     num_microbatches=eval_num_microbatches,
-                    default_seq_length=state.cfg.model.seq_length,
+                    default_seq_length=default_seq_length,
                     seq_key="tokens",
                 )
 
@@ -256,7 +258,7 @@ def evaluate(
             fault_tolerance.on_eval_step_end(state)
 
             # Workaround: for FullIteration CG only. TODO: Filed #2569 to fix this.
-            if is_full_iteration_cuda_graph(state.cfg.model):
+            if not is_multimodule and is_full_iteration_cuda_graph(state.cfg.model):
                 torch.cuda.synchronize()
 
             if should_fire(callback_manager, step_end_event):
@@ -326,14 +328,14 @@ def evaluate(
         elif process_non_loss_data_func is not None and is_last_rank():
             # Handle finetuning vs pretraining for non-loss data collection
             non_loss_data_iterator = data_iterator
-            non_loss_seq_length = state.cfg.model.seq_length
+            non_loss_seq_length = default_seq_length
 
             if state.cfg.dataset.dataloader_type == "batch":
                 # Finetuning path: prepare batch and wrap for VPP
                 non_loss_microbatch_iterator, non_loss_seq_length = prepare_finetuning_batch(
                     data_iterator=data_iterator,
                     num_microbatches=eval_num_microbatches,
-                    default_seq_length=state.cfg.model.seq_length,
+                    default_seq_length=default_seq_length,
                     seq_key="tokens",
                 )
                 non_loss_data_iterator = make_data_iterator_list(

--- a/tests/functional_tests/test_groups/megatron_mimo/test_pretrain_megatron_mimo.py
+++ b/tests/functional_tests/test_groups/megatron_mimo/test_pretrain_megatron_mimo.py
@@ -240,7 +240,7 @@ def _wrap_iter(loader_iter, vision_dtype: torch.dtype = torch.bfloat16):
         yield batch
 
 
-def _build_data_iterators(cfg, megatron_mimo_infra, *, train_state=None):
+def _build_data_iterators(cfg, megatron_mimo_infra, *, train_state=None, valid_samples=0):
     """Build data iterators compatible with pretrain_megatron_mimo's build_data_iterators_fn.
 
     Accepts an optional ``train_state`` so consumed-sample offsets from a restored
@@ -254,12 +254,12 @@ def _build_data_iterators(cfg, megatron_mimo_infra, *, train_state=None):
         train_state = TrainState()
     train_samples = cfg.train.train_iters * cfg.train.global_batch_size
 
-    train_loader, _, _ = build_megatron_mimo_data_loaders(
+    train_loader, valid_loader, _ = build_megatron_mimo_data_loaders(
         cfg=cfg,
         train_state=train_state,
         megatron_mimo_provider=cfg.dataset,
         train_samples=max(train_samples, 100),
-        valid_samples=0,
+        valid_samples=valid_samples,
         test_samples=0,
     )
 
@@ -269,7 +269,17 @@ def _build_data_iterators(cfg, megatron_mimo_infra, *, train_state=None):
     )
     vision_dtype = torch.bfloat16 if vision_cfg.bf16 else torch.float32
     train_iter = _wrap_iter(train_loader, vision_dtype=vision_dtype) if train_loader is not None else None
-    return train_iter, None
+    valid_iter = _wrap_iter(valid_loader, vision_dtype=vision_dtype) if valid_loader is not None else None
+    return train_iter, valid_iter
+
+
+def _build_data_iterators_with_validation(cfg, megatron_mimo_infra, *, train_state=None):
+    return _build_data_iterators(
+        cfg,
+        megatron_mimo_infra,
+        train_state=train_state,
+        valid_samples=1,
+    )
 
 
 # ── Config builder ───────────────────────────────────────────────────────────
@@ -498,6 +508,54 @@ class TestMegatronMIMOTraining:
         torchrun --nproc_per_node=2 -m pytest -v -s -x \\
             tests/functional_tests/test_groups/megatron_mimo/test_pretrain_megatron_mimo.py
     """
+
+    @pytest.mark.run_only_on("GPU")
+    def test_megatron_mimo_interval_validation(self):
+        """MegatronMIMO should run interval validation with its canonical provider config."""
+        from megatron.bridge.training.state import GlobalState
+
+        initialize_distributed()
+
+        world_size = dist.get_world_size()
+        if world_size != 2:
+            pytest.skip(f"MegatronMIMO test requires exactly 2 GPUs, got {world_size}")
+
+        import megatron.bridge.training.utils.train_utils as _tu
+
+        _tu.report_theoretical_memory = lambda *a, **kw: None
+
+        par_cfg = MegatronMIMOParallelismConfig(
+            module_parallelisms={
+                "language": ModuleParallelismConfig(
+                    tensor_model_parallel_size=1,
+                    pipeline_model_parallel_size=1,
+                    data_parallel_size=1,
+                    rank_offset=0,
+                ),
+                "vision": ModuleParallelismConfig(
+                    tensor_model_parallel_size=1,
+                    pipeline_model_parallel_size=1,
+                    data_parallel_size=1,
+                    rank_offset=1,
+                ),
+            },
+        )
+
+        cfg = _build_config(par_cfg, train_iters=1)
+        cfg.validation.eval_interval = 1
+        cfg.validation.eval_iters = 1
+        cfg.validation.eval_global_batch_size = 1
+        cfg.validation.eval_micro_batch_size = 1
+
+        state = GlobalState()
+        pretrain_megatron_mimo(
+            cfg=cfg,
+            forward_step_func=megatron_mimo_forward_step,
+            build_data_iterators_fn=_build_data_iterators_with_validation,
+            global_state=state,
+        )
+
+        assert state.train_state.consumed_valid_samples == 1
 
     @pytest.mark.run_only_on("GPU")
     @pytest.mark.parametrize("deterministic", [False, True], ids=["default", "deterministic"])

--- a/tests/unit_tests/training/test_eval.py
+++ b/tests/unit_tests/training/test_eval.py
@@ -69,7 +69,7 @@ def _make_evaluate_state(*, eval_iters, exit_duration_in_mins=None):
             dist=SimpleNamespace(use_decentralized_pg=True),
             optimizer=SimpleNamespace(reuse_grad_buf_for_mxfp8_param_ag=False),
             ddp=SimpleNamespace(overlap_param_gather=False),
-            dataset=SimpleNamespace(dataloader_type="single"),
+            dataset=SimpleNamespace(dataloader_type="single", seq_length=1),
             train=SimpleNamespace(
                 empty_unused_memory_level=0,
                 exit_duration_in_mins=exit_duration_in_mins,


### PR DESCRIPTION
## What does this PR do?

Fixes interval validation for supported MegatronMIMO training configurations.

When a MIMO data provider returns a validation iterator and
`validation.eval_interval` is enabled, the MIMO training loop calls the shared
evaluator with its multimodule communicator and process-group collection. The
evaluator recognized the multimodule path but still read standard model-provider
fields before running the MIMO schedule. The canonical `MegatronMIMOProvider`
does not define `seq_length` or `moe_expert_rank_capacity_factor`, so validation
aborted with `AttributeError` before consuming a batch.

This path became directly configurable through #5341.

## Root cause and fix

MIMO owns sequence length on the dataset provider and does not support the
standard ModelOpt distillation shape adjustment, paged stashing, or full-iteration
CUDA-graph handling used by the ordinary evaluator path.

The fix:

- selects the dataset-owned sequence length for multimodule evaluation;
- skips standard-only shape adjustment, paged-stash wrapping, and CUDA-graph
  synchronization for MIMO;
- uses the selected sequence length consistently for ordinary and non-loss data
  evaluation; and
- adds a two-process regression that runs one real interval-validation step and
  verifies that one validation sample is consumed.

## Testing

Fail-before and pass-after used the same focused command:

```bash
uv run --active --no-sync python -m torch.distributed.run --standalone \
  --nproc_per_node=2 -m pytest \
  --confcutdir=tests/functional_tests/test_groups/megatron_mimo \
  -o addopts= \
  tests/functional_tests/test_groups/megatron_mimo/test_pretrain_megatron_mimo.py::TestMegatronMIMOTraining::test_megatron_mimo_interval_validation \
  -q -s --tb=short
```

- Before: failed on both ranks with
  `AttributeError: 'MegatronMIMOProvider' object has no attribute 'seq_length'`.
- After: `1 passed`.

Adjacent coverage:

```bash
uv run --active --no-sync python -m pytest \
  tests/unit_tests/training/test_eval.py \
  tests/unit_tests/training/megatron_mimo/test_megatron_mimo_checkpointing.py \
  -q --tb=short
```

Result: `45 passed`.

Additional checks:

```bash
git diff --check
uv run --active --no-sync pre-commit run --all-files
```

Both passed.

## Scope

This change covers single-set MegatronMIMO interval validation. It does not add
multiple-validation-set support, CUDA graphs, ModelOpt distillation shape
adjustment, or paged stashing for MIMO. No full test suite, convergence,
model-quality, or performance validation was run.
