### PR TITLE
docs: add Nsight Systems analysis skill

### DIFF
--- a/docs/skills-index.md
+++ b/docs/skills-index.md
@@ -56,6 +56,13 @@ skills/nemo-mbridge-perf-activation-recompute/SKILL
 ```
 
 ```{toctree}
+:hidden:
+
+skills/nemo-mbridge-perf-nsys-analysis/references/pitfalls
+skills/nemo-mbridge-perf-nsys-analysis/references/sql-recipes
+```
+
+```{toctree}
 :caption: Cluster & Debugging
 :maxdepth: 1
 

--- a/docs/skills-index.md
+++ b/docs/skills-index.md
@@ -39,6 +39,7 @@ skills/nemo-rl-e2e-testing/SKILL
 skills/nemo-mbridge-perf-cpu-offloading/SKILL
 skills/nemo-mbridge-perf-moe-long-context/SKILL
 skills/nemo-mbridge-perf-moe-optimization-workflow/SKILL
+skills/nemo-mbridge-perf-nsys-analysis/SKILL
 skills/nemo-mbridge-perf-moe-vlm-training/SKILL
 skills/nemo-mbridge-perf-memory-tuning/SKILL
 skills/nemo-mbridge-perf-moe-dispatcher-selection/SKILL

--- a/skills/nemo-mbridge-perf-nsys-analysis/SKILL.md
+++ b/skills/nemo-mbridge-perf-nsys-analysis/SKILL.md
@@ -13,6 +13,8 @@ Use these principles throughout:
 
 - Use the performance model as the ceiling and the profiler as the agenda.
 - Compute wall time with interval unions, never summed stream or kernel time.
+- Inventory the active communication backend; distributed work is not
+  necessarily NCCL-only.
 - Treat visible communication and copies as coincident work until a dependency
   proves that they blocked compute.
 - Separate a measured phenomenon from its source-level root cause.
@@ -28,8 +30,11 @@ Record before calculating:
 2. Model, precision, sequence length, micro/global batch sizes, task, and the
    measured step definition.
 3. TP, PP, VPP, CP, EP, ETP, and DP sizes plus the rank-to-stage mapping.
-4. The steady-state iteration range and the number of analyzed iterations.
-5. Whether source for the exact profiled revision is available.
+4. The steady-state iteration range, number of analyzed iterations, and
+   same-run unprofiled reference steps when available.
+5. Capture diagnostics, hardware- versus software-instrumented mode, and any
+   warning that events may be incomplete.
+6. Whether source for the exact profiled revision is available.
 
 Never infer a rank id or pipeline stage from a filename. Never compare ranks
 that hold different model parts as if they performed identical work.
@@ -73,10 +78,22 @@ select a recurring anchor whose count is stable per iteration:
 3. optimizer kernels;
 4. a stable recurring kernel sequence.
 
-Drop capture warmup, graph capture, and cooldown iterations. Report median,
+Drop capture warmup, graph capture, and cooldown. Do not use the outer trace
+span as a step. When CUDA profiler APIs define the capture boundary, clip the
+device ROI after profiler-start and before profiler-stop or buffer flush, and
+state that exclusion. Do not use a trainer step containing profiler stop/flush
+as a steady reference; it can be extended by trace flushing. Report median,
 minimum, maximum, and `n`. Cross-check with a second anchor when possible. Stop
 and state the ambiguity when candidate anchors imply materially different step
 times.
+
+Measure capture perturbation from trainer logs, not from the
+`PROFILER_OVERHEAD` table. Compare the profiled step or median against same-run
+unprofiled steady steps with identical workload and topology. Report both
+values, the reference range and `n`, and the percentage slowdown. The overhead
+table accounts for profiler activity recorded in the trace; it is not total
+end-to-end profiler slowdown. If slowdown is material relative to the natural
+step spread, label absolute trace budgets and gain ceilings perturbed.
 
 For a comparison, require matching iteration semantics, model inputs, batch
 shape, precision, topology, and capture mode. Describe mismatches before
@@ -98,9 +115,14 @@ same rank is repeatedly slow or the straggler rotates.
 
 Relate timestamps from different exports only after rebasing with
 `TARGET_INFO_SESSION_START_TIME`. Same-host clocks can be compared after this
-rebase. Across hosts, refine only with matched collective end timestamps and
-state the remaining alignment error. Duration-based spread remains usable when
-cross-host arrival time cannot be established.
+rebase. Across hosts, refine a constant offset with many matched collective end
+timestamps and report a robust center plus residual error or percentiles.
+Duration-based spread remains usable when cross-host arrival time cannot be
+established, but it does not prove late completion. After alignment, compare
+both iteration starts and ends: a longer window that starts earlier and ends
+with its peer is start skew, not a straggler. If only a subset of ranks was
+captured, limit the verdict to those ranks and do not rule out an unsampled
+straggler.
 
 ### 3. Build the per-iteration device budget
 
@@ -111,12 +133,13 @@ all streams:
 |---|---|
 | Device busy | Union of kernels, memcpy, and memset |
 | Device idle | Iteration minus device busy |
-| Non-transfer busy | Union after removing NCCL and HtoD/DtoH copies |
+| Non-communication/dispatcher busy | Union after removing copies and the complete declared communication/dispatcher taxonomy |
+| Communication/dispatcher busy | Union of NCCL plus backend-specific transport, synchronization, dispatch, and combine kernels; overlaps other semantic categories unless explicitly partitioned |
 | Compute busy | Union of compute kernels only |
 | Compute-absent | Iteration minus compute busy |
 | Occupied-not-computing | Device busy minus compute busy |
 
-Require `compute busy <= non-transfer busy <= device busy <= iteration`.
+Require `compute busy <= non-communication/dispatcher busy <= device busy <= iteration`.
 Reconcile `device busy + device idle` to iteration time. Show kernel-duration
 sums only as work volume and label them explicitly; never present them as wall
 time.
@@ -151,16 +174,30 @@ the largest bucket.
 
 ### 5. Analyze communication and overlap
 
-Report three different quantities:
+Inventory the active dispatcher and transport before calculating. Do not assume
+that communication is NCCL-only. Flex/HybridEP, DeepEP, NVSHMEM, and similar
+backends may expose dispatch, combine, RDMA, or device-synchronization kernels.
+Inspect exact material names and source when available. Keep packing, routing,
+and control work labeled as dispatcher work unless evidence proves it is pure
+transport. Report NCCL and backend-specific components separately plus their
+interval union. Never rename the complete dispatcher union as network time.
 
-1. **Communication volume:** collective count and total device work.
-2. **Exposed communication:** NCCL interval union not overlapped by any
-   non-NCCL device operation. Treat it as an upper bound.
+Report three different quantities over the complete communication/dispatcher
+taxonomy:
+
+1. **Communication/dispatcher volume:** operation count and total device work,
+   split into NCCL, transport/synchronization, and packing/routing/control when
+   distinguishable.
+2. **Exposed communication/dispatcher:** its interval union not overlapped by
+   any device operation outside that taxonomy. Treat it as an upper bound.
 3. **Blocking communication:** compute-absent time whose resolved dependency
-   producer is a collective. Use this as the recoverable critical-path bound.
+   producer is a collective or verified dispatcher transport/sync operation.
+   Use this as the recoverable critical-path bound.
 
-Never call a collective a bottleneck from NCCL duration or exposed time alone.
-Report exposed and blocking values together.
+Never call a collective or dispatcher a bottleneck from duration or exposed
+time alone. Report exposed and blocking values together. Include NCCL-only
+figures for comparability when useful, but never present them as total
+distributed cost when material backend kernels exist.
 
 When all collective participants are available, match instances and split a
 rank's collective residence into:
@@ -175,8 +212,8 @@ bandwidth. If only one participant is present, do not make a bandwidth claim.
 Calculate overlap as an observed timeline property, not as proof of causality:
 
 ```text
-overlapped_comm = total_comm_union - exposed_comm
-overlap_pct = overlapped_comm / total_comm_union
+overlapped_comm_dispatcher = total_comm_dispatcher_union - exposed_comm_dispatcher
+overlap_pct = overlapped_comm_dispatcher / total_comm_dispatcher_union
 ```
 
 Use blocking communication, available independent compute, and matched A/B
@@ -223,6 +260,10 @@ Prefer source evidence from the exact revision. Nsight Runtime API correlation
 can connect a kernel to a CUDA API launch but often not to a Python or framework
 call site.
 
+Report kernel-to-CUDA-runtime correlation coverage separately from source
+call-stack link coverage. A correlation-id join can be 100% while source
+call-stack coverage is zero; never describe the former as call-stack coverage.
+
 If a separate CUDA call-stack capture is available, correlate launches by
 `(rank, thread, launch ordinal)` against the same workload, configuration, ROI,
 and declared ranks. Do not capture call stacks under Nsight Systems. Report the
@@ -261,7 +302,10 @@ Use the MFU formula only when the algorithmic numerator and precision are
 unchanged. Call these ceilings, not forecasts. Give a likely gain only when a
 comparable measured implementation supports it, and cite that measurement.
 Do not add opportunity bounds unless their intervals are disjoint and their
-fixes are independent.
+fixes are independent. When profiling materially perturbs step time, calculate
+trace-derived ceilings against the profiled `T` and label them perturbed. Do
+not transplant a trace-derived `R` onto the unprofiled reference step or use
+the `PROFILER_OVERHEAD` table to correct it.
 
 ## Map findings to MBridge actions
 
@@ -284,11 +328,15 @@ Return sections in this order:
 
 1. **Verdict:** one paragraph naming the dominant cost and trace limitations.
 2. **Capture quality:** inputs, ranks/stages, iteration anchor, `n`, CUDA graph
-   state, source availability, metric availability, and call-stack link rate.
+   state, source availability, diagnostics/event completeness, instrumentation
+   mode, same-run profiler slowdown, metric availability, runtime-correlation
+   rate, and source call-stack link rate.
 3. **Per-step budget:** iteration, device busy/idle, compute busy/absent, and
    launch-starved/blocking/dependency-stalled reconciliation.
-4. **Rank and communication findings:** transfer proxy, jitter wait, exposed
-   comm, blocking comm, overlap, and straggler verdict where supported.
+4. **Rank and communication findings:** backend taxonomy, transfer proxy,
+   jitter wait, exposed communication/dispatcher, blocking communication,
+   overlap, sampled-rank coverage, alignment residual, and straggler verdict
+   where supported.
 5. **Ranked opportunities:** evidence, recoverable bound, throughput/MFU
    ceiling, confidence, action, and verification step.
 6. **Claim status:** distinguish source-verified facts from trace inference.

--- a/skills/nemo-mbridge-perf-nsys-analysis/SKILL.md
+++ b/skills/nemo-mbridge-perf-nsys-analysis/SKILL.md
@@ -1,0 +1,303 @@
+---
+name: nemo-mbridge-perf-nsys-analysis
+description: Analyze NVIDIA Nsight Systems `.nsys-rep` and exported `.sqlite` traces for Megatron Bridge training. Use for single-trace diagnosis, before/after comparisons, multi-rank surveys, slow-rank and pipeline-stage analysis, MFU or step-time investigations, GPU busy/compute-absent accounting, communication overlap and rank-jitter analysis, CUDA launch starvation, CPU offload or memcpy investigations, source-level attribution, and evidence-backed gain estimates. Do not use as a substitute for Nsight Compute kernel roofline analysis.
+---
+
+# Nsight Systems Analysis for Megatron Bridge
+
+Turn an Nsight Systems trace into a critical-path diagnosis and a ranked,
+evidence-backed optimization plan. Treat the profile as timing evidence, not as
+a list of long kernels to optimize.
+
+Use these principles throughout:
+
+- Use the performance model as the ceiling and the profiler as the agenda.
+- Compute wall time with interval unions, never summed stream or kernel time.
+- Treat visible communication and copies as coincident work until a dependency
+  proves that they blocked compute.
+- Separate a measured phenomenon from its source-level root cause.
+- Report a gain ceiling from recoverable critical-path time; do not invent a
+  likely gain without comparable measured evidence.
+
+## Establish the analysis contract
+
+Record before calculating:
+
+1. Trace path, rank id, hostname, GPU, Nsight Systems version, Bridge and MCore
+   revisions, container, and whether CUDA graphs were enabled.
+2. Model, precision, sequence length, micro/global batch sizes, task, and the
+   measured step definition.
+3. TP, PP, VPP, CP, EP, ETP, and DP sizes plus the rank-to-stage mapping.
+4. The steady-state iteration range and the number of analyzed iterations.
+5. Whether source for the exact profiled revision is available.
+
+Never infer a rank id or pipeline stage from a filename. Never compare ranks
+that hold different model parts as if they performed identical work.
+
+Preserve the input report. Export a separate SQLite file when necessary:
+
+```bash
+nsys export --type sqlite -o profile.sqlite profile.nsys-rep
+```
+
+Check the available tables before using a query because schemas vary by Nsight
+version. Read [references/sql-recipes.md](references/sql-recipes.md) for
+portable inspection queries and [references/pitfalls.md](references/pitfalls.md)
+before making a bottleneck claim.
+
+## Choose the workflow
+
+- **One implementation, one rank:** produce an absolute time budget and ranked
+  optimization opportunities.
+- **One implementation, several ranks:** survey every supplied rank before
+  selecting representatives; diagnose stage imbalance, jitter, and the
+  slowest-rank step.
+- **Two implementations:** verify identical workload and topology, then
+  reconcile their median per-iteration delta.
+
+For distributed runs, declare representatives rather than selecting them
+silently. Cover at least the slowest trainer-step rank and one representative
+for every distinct PP stage or rank fingerprint relevant to the question. Rank
+0 is not automatically representative. If the mapping is unavailable, report
+the rank survey first and label any provisional selection.
+
+## Run the analysis
+
+### 1. Establish iteration windows
+
+Prefer an NVTX range that exactly matches the user's step definition. Otherwise
+select a recurring anchor whose count is stable per iteration:
+
+1. a repeated optimizer or train-step range;
+2. a repeated NCCL collective sequence;
+3. optimizer kernels;
+4. a stable recurring kernel sequence.
+
+Drop capture warmup, graph capture, and cooldown iterations. Report median,
+minimum, maximum, and `n`. Cross-check with a second anchor when possible. Stop
+and state the ambiguity when candidate anchors imply materially different step
+times.
+
+For a comparison, require matching iteration semantics, model inputs, batch
+shape, precision, topology, and capture mode. Describe mismatches before
+showing a delta.
+
+### 2. Survey ranks before drilling down
+
+For every supplied rank, report:
+
+- median/min/max iteration time and `n`;
+- non-communication busy time;
+- compute, collective, memcpy, and idle fingerprints;
+- collective types and counts;
+- pipeline stage or model part when known.
+
+Group ranks only when their fingerprints and model parts match. Within each
+declared part, report the fastest and slowest rank, the spread, and whether the
+same rank is repeatedly slow or the straggler rotates.
+
+Relate timestamps from different exports only after rebasing with
+`TARGET_INFO_SESSION_START_TIME`. Same-host clocks can be compared after this
+rebase. Across hosts, refine only with matched collective end timestamps and
+state the remaining alignment error. Duration-based spread remains usable when
+cross-host arrival time cannot be established.
+
+### 3. Build the per-iteration device budget
+
+Clip all intervals to each iteration window and compute interval unions across
+all streams:
+
+| Metric | Definition |
+|---|---|
+| Device busy | Union of kernels, memcpy, and memset |
+| Device idle | Iteration minus device busy |
+| Non-transfer busy | Union after removing NCCL and HtoD/DtoH copies |
+| Compute busy | Union of compute kernels only |
+| Compute-absent | Iteration minus compute busy |
+| Occupied-not-computing | Device busy minus compute busy |
+
+Require `compute busy <= non-transfer busy <= device busy <= iteration`.
+Reconcile `device busy + device idle` to iteration time. Show kernel-duration
+sums only as work volume and label them explicitly; never present them as wall
+time.
+
+### 4. Attribute compute-absent time
+
+Split each interval with no compute on any stream into:
+
+- **Launch-starved:** the next compute kernel had not been issued by the host.
+- **Blocking:** the kernel was issued and a resolved producer finished after
+  the gap began; require a device dependency and negative slack.
+- **Dependency-stalled:** the kernel was issued, but no resolved producer
+  explains the remaining delay.
+
+Follow relayed event dependencies to the operation that produced the awaited
+event. Classify that operation, not its stream. Join CUDA event records using
+`eventSyncId`, not the reused `eventId` handle. Report unresolved wait share and
+whether the blocking measurement is an upper or lower bound.
+
+CUDA graph replay may give many kernels one launch and omit per-kernel launch
+rows. In that case, describe the missing dependency resolution and avoid a
+false host-launch or call-site conclusion.
+
+Verify:
+
+```text
+launch-starved + blocking + dependency-stalled ~= compute-absent
+```
+
+Investigate a residual above 0.5 ms per iteration instead of absorbing it into
+the largest bucket.
+
+### 5. Analyze communication and overlap
+
+Report three different quantities:
+
+1. **Communication volume:** collective count and total device work.
+2. **Exposed communication:** NCCL interval union not overlapped by any
+   non-NCCL device operation. Treat it as an upper bound.
+3. **Blocking communication:** compute-absent time whose resolved dependency
+   producer is a collective. Use this as the recoverable critical-path bound.
+
+Never call a collective a bottleneck from NCCL duration or exposed time alone.
+Report exposed and blocking values together.
+
+When all collective participants are available, match instances and split a
+rank's collective residence into:
+
+- **Transfer proxy:** the shortest participant duration for the instance.
+- **Jitter wait:** this rank's duration minus that proxy.
+
+Report both together with matched/unmatched instance counts. If jitter wait
+dominates, pursue the late participant or load imbalance rather than network
+bandwidth. If only one participant is present, do not make a bandwidth claim.
+
+Calculate overlap as an observed timeline property, not as proof of causality:
+
+```text
+overlapped_comm = total_comm_union - exposed_comm
+overlap_pct = overlapped_comm / total_comm_union
+```
+
+Use blocking communication, available independent compute, and matched A/B
+measurements to judge whether an overlap knob can help.
+
+### 6. Classify compute and transfers
+
+Break compute work into at least GEMM, attention, normalization, elementwise or
+fused, optimizer, and other. Keep NCCL, memcpy, and memset separate. Inspect
+every regex-matched kernel above 1% of iteration time and list material
+unclassified kernels. Treat observed exact names as stronger evidence than
+regexes.
+
+For copies, report direction, bytes, stream, occupancy, achieved bandwidth,
+and pinned versus pageable memory when present. Require a saturated engine or a
+blocking dependency before claiming a copy-bandwidth bottleneck.
+
+Use Nsight Compute for kernel-level SOL, instruction, occupancy, or memory
+roofline conclusions. Nsight Systems shows placement and duration, not why an
+individual kernel underuses the GPU.
+
+### 7. Use metrics without overclaiming
+
+Prefer a separate, short metric-sampling capture over representative ranks at
+100 kHz. Keep timing and metrics passes separate because sampling greatly
+increases trace size. Join them by operator name, not individual launch.
+
+For every utilization number, report sample count and exclusivity—the share of
+samples in which only that operator was resident. Mark low-exclusivity rows as
+contaminated instead of correcting them.
+
+- Use `SM Issue` and `Tensor Active` as compute-throughput evidence.
+- Use DRAM read/write throughput for memory pressure.
+- Use NVLink **response** user-data throughput for interconnect saturation.
+- Use `SMs Active` only as residency context, not compute throughput.
+- Treat an unsampled operator as unknown, never zero.
+
+If GPU metrics are absent or permission is denied, continue with timing
+analysis and state the limitation.
+
+### 8. Link kernels to code carefully
+
+Prefer source evidence from the exact revision. Nsight Runtime API correlation
+can connect a kernel to a CUDA API launch but often not to a Python or framework
+call site.
+
+If a separate CUDA call-stack capture is available, correlate launches by
+`(rank, thread, launch ordinal)` against the same workload, configuration, ROI,
+and declared ranks. Do not capture call stacks under Nsight Systems. Report the
+link rate beside every call-site-derived figure. A missing capture means
+regex-only taxonomy and no source-scope claim; zero links does not mean zero
+launches, especially with CUDA graphs.
+
+For each root cause, provide:
+
+1. the measured trace phenomenon;
+2. the source/config mechanism that creates it;
+3. the exact MBridge knob or code anchor to change;
+4. status: `trace-verified`, `source-verified`, `inferred`, or `unverified`.
+
+Without source, stop at trace phenomena and proposed verification steps.
+
+### 9. Estimate gain without double counting
+
+Rank opportunities by recoverable critical-path milliseconds per iteration.
+Use one of these evidence bases:
+
+- matched before/after median delta on the same workload;
+- launch-starved time affected by a verified launch-reduction mechanism;
+- blocking time attributed through a dependency edge;
+- a non-overlapping, source-verified critical-path interval.
+
+For current step time `T` and recoverable bound `R`:
+
+```text
+new_step_ceiling = T - R
+throughput_gain_ceiling_pct = (T / (T - R) - 1) * 100
+new_mfu_ceiling = old_mfu * T / (T - R)
+```
+
+Use the MFU formula only when the algorithmic numerator and precision are
+unchanged. Call these ceilings, not forecasts. Give a likely gain only when a
+comparable measured implementation supports it, and cite that measurement.
+Do not add opportunity bounds unless their intervals are disjoint and their
+fixes are independent.
+
+## Map findings to MBridge actions
+
+| Proven dominant cost | Next skill or action |
+|---|---|
+| Launch-starved | `@skills/nemo-mbridge-perf-cuda-graphs/SKILL.md`; inspect CPU affinity, Python work, GC, and microbatch size |
+| Blocking TP/DP/PP communication | `@skills/nemo-mbridge-perf-tp-dp-comm-overlap/SKILL.md` |
+| Blocking MoE dispatch/combine | `@skills/nemo-mbridge-perf-moe-comm-overlap/SKILL.md` and dispatcher selection |
+| Long-context communication/layout | `@skills/nemo-mbridge-perf-hierarchical-context-parallel/SKILL.md` and parallelism strategies |
+| Blocking HtoD/DtoH | `@skills/nemo-mbridge-perf-cpu-offloading/SKILL.md`; inspect prefetch distance and pinned memory |
+| Memory-constrained layout | `@skills/nemo-mbridge-perf-memory-tuning/SKILL.md` |
+| Low kernel SOL | Capture Nsight Compute and inspect precision, fusion, shape, and kernel choice |
+| Rank jitter | Inspect slow rank, topology, data imbalance, CPU affinity, and straggler telemetry |
+
+Enable knobs only after the corresponding critical-path cost is established.
+
+## Output contract
+
+Return sections in this order:
+
+1. **Verdict:** one paragraph naming the dominant cost and trace limitations.
+2. **Capture quality:** inputs, ranks/stages, iteration anchor, `n`, CUDA graph
+   state, source availability, metric availability, and call-stack link rate.
+3. **Per-step budget:** iteration, device busy/idle, compute busy/absent, and
+   launch-starved/blocking/dependency-stalled reconciliation.
+4. **Rank and communication findings:** transfer proxy, jitter wait, exposed
+   comm, blocking comm, overlap, and straggler verdict where supported.
+5. **Ranked opportunities:** evidence, recoverable bound, throughput/MFU
+   ceiling, confidence, action, and verification step.
+6. **Claim status:** distinguish source-verified facts from trace inference.
+
+State all times per iteration and include `n`. Include an uncertainty range or
+the observed min/max when estimating a gain.
+
+## Design note
+
+Keep this workflow standalone. It does not require an external orchestrator or
+proprietary trace-processing service; use standard Nsight Systems exports and
+the evidence available for the profiled Megatron Bridge revision.

--- a/skills/nemo-mbridge-perf-nsys-analysis/evals/evals.json
+++ b/skills/nemo-mbridge-perf-nsys-analysis/evals/evals.json
@@ -35,5 +35,33 @@
     "expected_behavior": [
       "Do not use the nsys analysis skill as a substitute for Nsight Compute analysis."
     ]
+  },
+  {
+    "id": "nsys-analysis-hybridep-cross-host",
+    "question": "Use the nemo-mbridge-perf-nsys-analysis skill on a two-node EP=16 run where only ranks 0 and 8 were captured. Rank 8's profile window is 102 ms longer. The traces contain 3.3-3.6 s of NCCL and 7.5-7.7 s of hybrid_ep dispatch/combine/sync kernels. After matching 5,261 collective ends across hosts, both ranks end together within 0.1 ms and rank 8 started earlier. Is rank 8 a straggler, is NCCL the full communication cost, and what overlap gain should I expect?",
+    "expected_skill": "nemo-mbridge-perf-nsys-analysis",
+    "expected_script": null,
+    "ground_truth": "The response must not call rank 8 a straggler: the duration delta is earlier start skew after collective-based cross-host clock alignment. It must limit the verdict to the two sampled ranks. It must include material HybridEP transport/synchronization/dispatcher kernels in a backend-aware communication/dispatcher taxonomy, report NCCL and dispatcher components separately plus their interval union, and avoid calling the full dispatcher union network time because it can include packing and control work. Exposed communication is an upper bound, not dependency-proven blocking or an expected overlap gain. No likely gain is justified without blocking attribution or a matched A/B.",
+    "expected_behavior": [
+      "Use backend-aware rather than NCCL-only communication taxonomy.",
+      "Distinguish dispatcher occupancy from pure network transfer.",
+      "Align cross-host clocks with matched collectives before a straggler claim.",
+      "Limit the verdict to captured ranks.",
+      "Do not turn exposed time into an overlap-gain forecast."
+    ]
+  },
+  {
+    "id": "nsys-analysis-capture-quality-overhead",
+    "question": "Use the nemo-mbridge-perf-nsys-analysis skill. A profiled trainer step is 34.60 s while same-run unprofiled steady steps have a 29.39 s median. PROFILER_OVERHEAD sums to 0.23 s. Every kernel correlates to a CUDA Runtime API row, but no source call-stack capture or GPU metric tables exist, and DIAGNOSTIC_EVENT warns that some CUDA and NVTX events may be missing. What can be claimed?",
+    "expected_skill": "nemo-mbridge-perf-nsys-analysis",
+    "expected_script": null,
+    "ground_truth": "The response must report 17.7% end-to-end profiler slowdown from trainer steps and must not use the 0.23 s PROFILER_OVERHEAD sum as total slowdown or as a correction. It must label absolute trace budgets and ceilings perturbed and avoid transplanting trace-derived recoverable time onto the unprofiled step. It must distinguish complete kernel-to-runtime correlation from zero source call-stack coverage, report missing metrics and event-completeness warnings, and avoid source-level, bandwidth-saturation, or likely-gain claims.",
+    "expected_behavior": [
+      "Measure profiler perturbation from same-run trainer steps.",
+      "Do not interpret PROFILER_OVERHEAD as end-to-end slowdown.",
+      "Separate runtime correlation from source call-stack coverage.",
+      "Surface diagnostic warnings and missing metrics in capture quality.",
+      "Avoid correcting or forecasting from a materially perturbed trace."
+    ]
   }
 ]

--- a/skills/nemo-mbridge-perf-nsys-analysis/evals/evals.json
+++ b/skills/nemo-mbridge-perf-nsys-analysis/evals/evals.json
@@ -1,0 +1,39 @@
+[
+  {
+    "id": "nsys-analysis-single-trace-critical-path",
+    "question": "Use the nemo-mbridge-perf-nsys-analysis skill to explain how you would analyze one Megatron Bridge .nsys-rep where NCCL occupies 38% of summed kernel time and memcpy occupies 20%. Rank likely fixes and estimate the possible gain without inventing numbers.",
+    "expected_skill": "nemo-mbridge-perf-nsys-analysis",
+    "expected_script": null,
+    "ground_truth": "The response must not call NCCL or memcpy bottlenecks from summed duration. It must establish a steady-state iteration window, use interval unions, split compute-absent time into launch-starved/blocking/dependency-stalled, report exposed and dependency-proven blocking communication together, verify copy direction/bandwidth/dependency, and estimate gain only from recoverable critical-path time. It should map proven launch starvation to CUDA graphs, blocking communication to overlap, and blocking copies to offload scheduling, while stating that no numeric gain is justified from the supplied percentages.",
+    "expected_behavior": [
+      "Read the nsys analysis skill before answering.",
+      "Use interval-union and critical-path accounting.",
+      "Distinguish exposed from blocking communication and copies.",
+      "Avoid a fabricated gain estimate.",
+      "Map verified findings to MBridge tuning skills."
+    ]
+  },
+  {
+    "id": "nsys-analysis-multi-rank-pipeline",
+    "question": "Use the nemo-mbridge-perf-nsys-analysis skill. I have rank 0, 17, and 71 traces from a PP=8 distributed training run. Which rank should be analyzed and how should NCCL time be interpreted?",
+    "expected_skill": "nemo-mbridge-perf-nsys-analysis",
+    "expected_script": null,
+    "ground_truth": "The response must not silently select rank 0. It should request or derive a rank-to-stage map, survey all supplied ranks, identify the slowest trainer-step rank, cover distinct pipeline stages or fingerprints, and compare only like model parts. For matched collective participants it should separate shortest-participant transfer proxy from rank jitter wait, distinguish total/exposed/blocking communication, and state alignment limitations across hosts.",
+    "expected_behavior": [
+      "Read the nsys analysis skill before answering.",
+      "Survey ranks before choosing representatives.",
+      "Respect pipeline-stage differences.",
+      "Separate transfer proxy, jitter wait, exposed communication, and blocking communication."
+    ]
+  },
+  {
+    "id": "nsys-analysis-negative-ncu",
+    "question": "Use Nsight Compute counters to determine why one GEMM reaches only 42% tensor-core SOL and rewrite the kernel.",
+    "expected_skill": null,
+    "expected_script": null,
+    "ground_truth": "The nsys analysis skill should not trigger because this is a kernel-level Nsight Compute and implementation task rather than an Nsight Systems trace analysis.",
+    "expected_behavior": [
+      "Do not use the nsys analysis skill as a substitute for Nsight Compute analysis."
+    ]
+  }
+]

--- a/skills/nemo-mbridge-perf-nsys-analysis/references/pitfalls.md
+++ b/skills/nemo-mbridge-perf-nsys-analysis/references/pitfalls.md
@@ -10,47 +10,64 @@ Read this checklist before finalizing a diagnosis.
    and stragglers can have different work.
 4. **Different rank fingerprints are not comparable implementations.** Compare
    like model parts or explain the structural difference.
-5. **NCCL duration is not pure network transfer.** It can include arrival
-   jitter and device-side waiting.
-6. **Exposed is not blocking.** A collective or copy may occupy an otherwise
+5. **Distributed communication is not necessarily NCCL-only.** HybridEP,
+   DeepEP, NVSHMEM, and other backends may use their own dispatch, combine,
+   RDMA, and synchronization kernels.
+6. **Dispatcher time is not pure network transfer.** It can contain packing,
+   routing, synchronization, control work, arrival jitter, and device-side
+   waiting. Report its components and union without relabeling the union as
+   network time.
+7. **Exposed is not blocking.** A collective or copy may occupy an otherwise
    empty interval without delaying the next compute kernel.
-7. **An occupant is not necessarily the producer.** Attribute a gap only after
+8. **An occupant is not necessarily the producer.** Attribute a gap only after
    resolving the dependency followed by the waiting compute kernel.
-8. **CUDA event handles are reused.** Join on `eventSyncId`, not `eventId`.
-9. **CUDA event timestamps may be zero.** Reconstruct completion from the last
+9. **CUDA event handles are reused.** Join on `eventSyncId`, not `eventId`.
+10. **CUDA event timestamps may be zero.** Reconstruct completion from the last
    device operation before the event record on its stream.
-10. **Host synchronization duration is not GPU stall.** Intersect host sync
+11. **Host synchronization duration is not GPU stall.** Intersect host sync
     intervals with device-idle time.
-11. **A copy needs engine evidence.** Check achieved bandwidth, occupancy,
+12. **A copy needs engine evidence.** Check achieved bandwidth, occupancy,
     direction, pinned memory, stream, and blocking dependency.
-12. **Default-stream async copies may synchronize.** Verify the actual stream
+13. **Default-stream async copies may synchronize.** Verify the actual stream
     and pinned/pageable kinds.
-13. **Metric samples are device-wide.** Report exclusivity and sample count;
+14. **Metric samples are device-wide.** Report exclusivity and sample count;
     do not attach a separate-pass sample to an individual timing-pass launch.
-14. **SMs Active is occupancy context.** Use SM Issue and Tensor Active for
+15. **SMs Active is occupancy context.** Use SM Issue and Tensor Active for
     compute-throughput evidence.
-15. **NVLink request metrics understate payload traffic.** Use response
+16. **NVLink request metrics understate payload traffic.** Use response
     user-data throughput and make no peer claim from device-aggregate metrics.
-16. **Metric ids are unstable.** Resolve by metric name in each report.
-17. **Unsampled is not zero.** Short operators may receive no samples.
-18. **Profiler permission failure is not workload failure.** Continue timing
+17. **Metric ids are unstable.** Resolve by metric name in each report.
+18. **Unsampled is not zero.** Short operators may receive no samples.
+19. **Profiler permission failure is not workload failure.** Continue timing
     analysis when GPU metrics are unavailable.
-19. **Regex taxonomy is fallible.** Inspect material matched and unclassified
+20. **Regex taxonomy is fallible.** Inspect material matched and unclassified
     names; preserve fused operators rather than forcing them into one primitive.
-20. **CUDA graphs break launch assumptions.** Graph kernels may have no
+21. **CUDA graphs break launch assumptions.** Graph kernels may have no
     individual CUDA API row or call-stack link.
-21. **Cross-host clocks are not automatically aligned.** Rebase capture starts,
-    refine against collective ends, and report residual uncertainty.
-22. **Capture overhead can change the workload.** Keep the ROI short, compare
-    profiled and unprofiled step time, and separate metrics from timing.
-23. **Dataloading scope changes the conclusion.** Match the user's step
+22. **Runtime correlation is not source attribution.** A kernel can correlate
+    perfectly with its CUDA Runtime API launch while having no Python or
+    framework call-stack link. Report the two rates separately.
+23. **Cross-host clocks are not automatically aligned.** Rebase capture starts,
+    refine against many matched collective ends, and report residual
+    uncertainty. A longer duration can be earlier start skew rather than late
+    completion.
+24. **A sampled-rank verdict is not a global verdict.** Two representative
+    ranks can agree while an uncaptured participant is the true straggler.
+25. **Capture overhead can change the workload.** Keep the ROI short, compare
+    same-run profiled and unprofiled step time, and separate metrics from
+    timing. The `PROFILER_OVERHEAD` table is not end-to-end slowdown.
+26. **Profiler boundary steps are not steady state.** Start/stop and buffer
+    flush can inflate a logged step outside the selected device ROI.
+27. **Capture warnings constrain the claim.** Missing CUDA, NVTX, OS-runtime,
+    scheduling, metric, or hardware-trace data must appear in capture quality.
+28. **Dataloading scope changes the conclusion.** Match the user's step
     definition before attributing GPU idle to training code.
-24. **MFU numerator errors survive perfect timing analysis.** Recheck the model-
+29. **MFU numerator errors survive perfect timing analysis.** Recheck the model-
     specific FLOP formula and precision denominator separately.
-25. **One failed implementation does not disprove a technique.** Classify the
+30. **One failed implementation does not disprove a technique.** Classify the
     failure as mechanism, implementation, environment, or verification-gate
     failure and retain the technique's measured ceiling.
-26. **Opportunity ceilings do not automatically add.** Add them only for
+31. **Opportunity ceilings do not automatically add.** Add them only for
     disjoint intervals and independent fixes.
-27. **Trace phenomena are not source root causes.** Require a source/config
+32. **Trace phenomena are not source root causes.** Require a source/config
     mechanism and actionable code anchor, or mark the claim inferred.

--- a/skills/nemo-mbridge-perf-nsys-analysis/references/pitfalls.md
+++ b/skills/nemo-mbridge-perf-nsys-analysis/references/pitfalls.md
@@ -1,0 +1,56 @@
+# Nsight Systems analysis pitfalls
+
+Read this checklist before finalizing a diagnosis.
+
+1. **Summed kernels are not wall time.** Use interval unions across streams and
+   clip them to the iteration window.
+2. **The longest stream is not step time.** The trainer's slowest-rank step and
+   the iteration anchor define the wall clock.
+3. **Rank 0 is not automatically representative.** PP stages, expert groups,
+   and stragglers can have different work.
+4. **Different rank fingerprints are not comparable implementations.** Compare
+   like model parts or explain the structural difference.
+5. **NCCL duration is not pure network transfer.** It can include arrival
+   jitter and device-side waiting.
+6. **Exposed is not blocking.** A collective or copy may occupy an otherwise
+   empty interval without delaying the next compute kernel.
+7. **An occupant is not necessarily the producer.** Attribute a gap only after
+   resolving the dependency followed by the waiting compute kernel.
+8. **CUDA event handles are reused.** Join on `eventSyncId`, not `eventId`.
+9. **CUDA event timestamps may be zero.** Reconstruct completion from the last
+   device operation before the event record on its stream.
+10. **Host synchronization duration is not GPU stall.** Intersect host sync
+    intervals with device-idle time.
+11. **A copy needs engine evidence.** Check achieved bandwidth, occupancy,
+    direction, pinned memory, stream, and blocking dependency.
+12. **Default-stream async copies may synchronize.** Verify the actual stream
+    and pinned/pageable kinds.
+13. **Metric samples are device-wide.** Report exclusivity and sample count;
+    do not attach a separate-pass sample to an individual timing-pass launch.
+14. **SMs Active is occupancy context.** Use SM Issue and Tensor Active for
+    compute-throughput evidence.
+15. **NVLink request metrics understate payload traffic.** Use response
+    user-data throughput and make no peer claim from device-aggregate metrics.
+16. **Metric ids are unstable.** Resolve by metric name in each report.
+17. **Unsampled is not zero.** Short operators may receive no samples.
+18. **Profiler permission failure is not workload failure.** Continue timing
+    analysis when GPU metrics are unavailable.
+19. **Regex taxonomy is fallible.** Inspect material matched and unclassified
+    names; preserve fused operators rather than forcing them into one primitive.
+20. **CUDA graphs break launch assumptions.** Graph kernels may have no
+    individual CUDA API row or call-stack link.
+21. **Cross-host clocks are not automatically aligned.** Rebase capture starts,
+    refine against collective ends, and report residual uncertainty.
+22. **Capture overhead can change the workload.** Keep the ROI short, compare
+    profiled and unprofiled step time, and separate metrics from timing.
+23. **Dataloading scope changes the conclusion.** Match the user's step
+    definition before attributing GPU idle to training code.
+24. **MFU numerator errors survive perfect timing analysis.** Recheck the model-
+    specific FLOP formula and precision denominator separately.
+25. **One failed implementation does not disprove a technique.** Classify the
+    failure as mechanism, implementation, environment, or verification-gate
+    failure and retain the technique's measured ceiling.
+26. **Opportunity ceilings do not automatically add.** Add them only for
+    disjoint intervals and independent fixes.
+27. **Trace phenomena are not source root causes.** Require a source/config
+    mechanism and actionable code anchor, or mark the claim inferred.

--- a/skills/nemo-mbridge-perf-nsys-analysis/references/sql-recipes.md
+++ b/skills/nemo-mbridge-perf-nsys-analysis/references/sql-recipes.md
@@ -1,0 +1,214 @@
+# Nsight Systems SQLite recipes
+
+Use these as inspection starting points. Inspect `.schema <table>` first and
+adapt column names to the installed Nsight Systems version. Durations are
+nanoseconds unless the schema says otherwise.
+
+## Export a report
+
+```bash
+nsys export --type sqlite -o profile.sqlite profile.nsys-rep
+```
+
+## Discover tables and metadata
+
+```sql
+.tables
+SELECT sqlite_version();
+SELECT value FROM TARGET_INFO_SYSTEM_ENV WHERE name = 'Hostname';
+SELECT utcEpochNs FROM TARGET_INFO_SESSION_START_TIME;
+```
+
+## Top kernels by work volume
+
+This is summed device work, not wall time.
+
+```sql
+SELECT
+  COALESCE(s.value, '<unknown>') AS kernel,
+  COUNT(*) AS launches,
+  SUM(k.end - k.start) / 1e6 AS work_ms
+FROM CUPTI_ACTIVITY_KIND_KERNEL AS k
+LEFT JOIN StringIds AS s ON s.id = k.demangledName
+GROUP BY kernel
+ORDER BY work_ms DESC
+LIMIT 40;
+```
+
+## Per-stream work volume and span
+
+Do not call `work_ms` or `span_ms` wall time. Compute interval unions outside
+SQL before comparing them with an iteration.
+
+```sql
+SELECT
+  streamId,
+  COUNT(*) AS launches,
+  SUM(end - start) / 1e6 AS work_ms,
+  (MAX(end) - MIN(start)) / 1e6 AS span_ms
+FROM CUPTI_ACTIVITY_KIND_KERNEL
+GROUP BY streamId
+ORDER BY work_ms DESC;
+```
+
+## Runtime API summary
+
+```sql
+SELECT
+  COALESCE(s.value, '<unknown>') AS api,
+  COUNT(*) AS calls,
+  SUM(r.end - r.start) / 1e6 AS host_api_ms,
+  AVG(r.end - r.start) / 1e3 AS avg_us
+FROM CUPTI_ACTIVITY_KIND_RUNTIME AS r
+LEFT JOIN StringIds AS s ON s.id = r.nameId
+GROUP BY api
+ORDER BY host_api_ms DESC;
+```
+
+Intersect API intervals with device-idle unions before calling host API time a
+stall. A synchronization call may correctly wait while the GPU is busy.
+
+## Launch-to-start queueing
+
+```sql
+SELECT
+  k.streamId,
+  (k.start - r.end) / 1e3 AS launch_to_start_us
+FROM CUPTI_ACTIVITY_KIND_KERNEL AS k
+JOIN CUPTI_ACTIVITY_KIND_RUNTIME AS r
+  ON r.correlationId = k.correlationId
+ORDER BY launch_to_start_us;
+```
+
+Validate that the join is one-to-one. CUDA graph nodes commonly share a launch
+and cannot be interpreted as independent host dispatches.
+
+## Synchronization and device dependency edges
+
+Join event records by `eventSyncId`, not `eventId`.
+
+```sql
+SELECT
+  y.start AS wait_timestamp,
+  y.streamId AS waiting_stream,
+  e.streamId AS recording_stream,
+  waiting_name.value AS waiting_api,
+  recording_name.value AS recording_api
+FROM CUPTI_ACTIVITY_KIND_SYNCHRONIZATION AS y
+JOIN CUPTI_ACTIVITY_KIND_CUDA_EVENT AS e
+  ON e.eventSyncId = y.eventSyncId
+LEFT JOIN CUPTI_ACTIVITY_KIND_RUNTIME AS waiting_runtime
+  ON waiting_runtime.correlationId = y.correlationId
+LEFT JOIN StringIds AS waiting_name
+  ON waiting_name.id = waiting_runtime.nameId
+LEFT JOIN CUPTI_ACTIVITY_KIND_RUNTIME AS recording_runtime
+  ON recording_runtime.correlationId = e.correlationId
+LEFT JOIN StringIds AS recording_name
+  ON recording_name.id = recording_runtime.nameId
+WHERE y.syncType = 2
+ORDER BY y.start;
+```
+
+Reconstruct the producer completion from device stream order. Do not use
+`CUPTI_ACTIVITY_KIND_CUDA_EVENT.timestamp`; it may be zero.
+
+## Memcpy volume and bandwidth
+
+```sql
+SELECT
+  copyKind,
+  streamId,
+  COUNT(*) AS copies,
+  SUM(bytes) AS bytes,
+  SUM(end - start) / 1e6 AS work_ms,
+  SUM(bytes) / 1e9 / (SUM(end - start) / 1e9) AS achieved_GBps
+FROM CUPTI_ACTIVITY_KIND_MEMCPY
+GROUP BY copyKind, streamId
+ORDER BY work_ms DESC;
+```
+
+Check pinned versus pageable memory:
+
+```sql
+SELECT
+  src.label AS src_kind,
+  dst.label AS dst_kind,
+  COUNT(*) AS copies,
+  SUM(m.end - m.start) / 1e6 AS work_ms
+FROM CUPTI_ACTIVITY_KIND_MEMCPY AS m
+LEFT JOIN ENUM_CUDA_MEM_KIND AS src ON src.id = m.srcKind
+LEFT JOIN ENUM_CUDA_MEM_KIND AS dst ON dst.id = m.dstKind
+GROUP BY src_kind, dst_kind
+ORDER BY work_ms DESC;
+```
+
+## Recurring collective anchors
+
+```sql
+SELECT
+  k.start,
+  k.end,
+  COALESCE(s.value, '<unknown>') AS kernel
+FROM CUPTI_ACTIVITY_KIND_KERNEL AS k
+LEFT JOIN StringIds AS s ON s.id = k.demangledName
+WHERE s.value LIKE '%AllGather%'
+   OR s.value LIKE '%ReduceScatter%'
+   OR s.value LIKE '%AllReduce%'
+   OR s.value LIKE '%AllToAll%'
+ORDER BY k.start;
+```
+
+Use only a recurring sequence with stable count and position per iteration.
+
+## Rebase two rank exports
+
+Add each report's `TARGET_INFO_SESSION_START_TIME.utcEpochNs` to raw activity
+timestamps before comparing ranks. Match collective counts and order first.
+
+```sql
+ATTACH 'rank1.sqlite' AS rank1;
+
+WITH base0 AS (
+  SELECT utcEpochNs AS epoch FROM main.TARGET_INFO_SESSION_START_TIME
+), base1 AS (
+  SELECT utcEpochNs AS epoch FROM rank1.TARGET_INFO_SESSION_START_TIME
+), rank0_ops AS (
+  SELECT ROW_NUMBER() OVER (ORDER BY k.start) AS seq,
+         k.start + (SELECT epoch FROM base0) AS start_ns,
+         k.end + (SELECT epoch FROM base0) AS end_ns
+  FROM main.CUPTI_ACTIVITY_KIND_KERNEL AS k
+  JOIN main.StringIds AS s ON s.id = k.demangledName
+  WHERE s.value LIKE '%AllReduce%'
+), rank1_ops AS (
+  SELECT ROW_NUMBER() OVER (ORDER BY k.start) AS seq,
+         k.start + (SELECT epoch FROM base1) AS start_ns,
+         k.end + (SELECT epoch FROM base1) AS end_ns
+  FROM rank1.CUPTI_ACTIVITY_KIND_KERNEL AS k
+  JOIN rank1.StringIds AS s ON s.id = k.demangledName
+  WHERE s.value LIKE '%AllReduce%'
+)
+SELECT
+  rank0_ops.seq,
+  (rank0_ops.start_ns - rank1_ops.start_ns) / 1e3 AS start_delta_us,
+  (rank0_ops.end_ns - rank1_ops.end_ns) / 1e3 AS end_delta_us
+FROM rank0_ops
+JOIN rank1_ops USING (seq)
+ORDER BY rank0_ops.seq;
+```
+
+Across hosts, use matched collective ends to estimate residual clock offset and
+report its error. Do not claim exact arrival lateness when alignment is weak.
+
+## Metric inventory
+
+Resolve metrics by name because ids change between reports.
+
+```sql
+SELECT metricId, typeId, metricName
+FROM TARGET_INFO_GPU_METRICS
+ORDER BY metricId, typeId;
+```
+
+Consume only established throughput metrics. Join metric samples to operation
+windows by timestamp and device. Report sample count and exclusivity because
+samples are device-wide and carry no stream or correlation id.

--- a/skills/nemo-mbridge-perf-nsys-analysis/references/sql-recipes.md
+++ b/skills/nemo-mbridge-perf-nsys-analysis/references/sql-recipes.md
@@ -4,6 +4,21 @@ Use these as inspection starting points. Inspect `.schema <table>` first and
 adapt column names to the installed Nsight Systems version. Durations are
 nanoseconds unless the schema says otherwise.
 
+## Contents
+
+- [Export a report](#export-a-report)
+- [Discover tables and metadata](#discover-tables-and-metadata)
+- [Capture diagnostics and recorded profiler activity](#capture-diagnostics-and-recorded-profiler-activity)
+- [Top kernels by work volume](#top-kernels-by-work-volume)
+- [Distributed backend kernel inventory](#distributed-backend-kernel-inventory)
+- [Per-stream work volume and span](#per-stream-work-volume-and-span)
+- [Runtime API and launch correlation](#runtime-api-summary)
+- [Synchronization and dependencies](#synchronization-and-device-dependency-edges)
+- [Memcpy volume and bandwidth](#memcpy-volume-and-bandwidth)
+- [Recurring collective anchors](#recurring-collective-anchors)
+- [Cross-rank timestamp alignment](#rebase-two-rank-exports)
+- [Metric inventory](#metric-inventory)
+
 ## Export a report
 
 ```bash
@@ -18,6 +33,43 @@ SELECT sqlite_version();
 SELECT value FROM TARGET_INFO_SYSTEM_ENV WHERE name = 'Hostname';
 SELECT utcEpochNs FROM TARGET_INFO_SESSION_START_TIME;
 ```
+
+## Capture diagnostics and recorded profiler activity
+
+Inspect warnings before trusting absence, scheduling, or source attribution.
+These tables are version-dependent; query `sqlite_master` before using them.
+
+```sql
+SELECT
+  severity.label AS severity,
+  source.label AS source,
+  d.text
+FROM DIAGNOSTIC_EVENT AS d
+LEFT JOIN ENUM_DIAGNOSTIC_SEVERITY_LEVEL AS severity
+  ON severity.id = d.severity
+LEFT JOIN ENUM_DIAGNOSTIC_SOURCE_TYPE AS source
+  ON source.id = d.source
+WHERE d.severity > 1
+ORDER BY d.timestamp;
+```
+
+Summarize activity that Nsight recorded as profiler overhead:
+
+```sql
+SELECT
+  COALESCE(s.value, '<unknown>') AS activity,
+  e.label AS overhead_type,
+  COUNT(*) AS events,
+  SUM(p.end - p.start) / 1e6 AS work_ms
+FROM PROFILER_OVERHEAD AS p
+LEFT JOIN StringIds AS s ON s.id = p.nameId
+LEFT JOIN ENUM_CUPTI_OVERHEAD_TYPE AS e ON e.id = p.overheadType
+GROUP BY activity, overhead_type
+ORDER BY work_ms DESC;
+```
+
+This is recorded profiler activity, not total training slowdown. Calculate
+end-to-end perturbation from same-run profiled and unprofiled trainer steps.
 
 ## Top kernels by work volume
 
@@ -34,6 +86,36 @@ GROUP BY kernel
 ORDER BY work_ms DESC
 LIMIT 40;
 ```
+
+## Distributed backend kernel inventory
+
+Do not stop at NCCL. Inventory exact material names from the configured
+dispatcher or transport before defining a communication union.
+
+```sql
+SELECT
+  COALESCE(s.value, '<unknown>') AS kernel,
+  COUNT(*) AS launches,
+  SUM(k.end - k.start) / 1e6 AS work_ms
+FROM CUPTI_ACTIVITY_KIND_KERNEL AS k
+LEFT JOIN StringIds AS s ON s.id = k.demangledName
+WHERE LOWER(s.value) LIKE '%nccl%'
+   OR LOWER(s.value) LIKE '%hybrid_ep%'
+   OR LOWER(s.value) LIKE '%hybridep%'
+   OR LOWER(s.value) LIKE '%deepep%'
+   OR LOWER(s.value) LIKE '%nvshmem%'
+   OR LOWER(s.value) LIKE '%dispatch%'
+   OR LOWER(s.value) LIKE '%combine%'
+   OR LOWER(s.value) LIKE '%rdma%'
+   OR LOWER(s.value) LIKE '%device_sync%'
+GROUP BY kernel
+ORDER BY work_ms DESC;
+```
+
+Inspect every material match and material unclassified kernel. Split NCCL,
+backend transport/synchronization, and packing/routing/control where evidence
+allows. A dispatch/combine union is dispatcher occupancy, not automatically
+network transfer.
 
 ## Per-stream work volume and span
 
@@ -82,6 +164,23 @@ ORDER BY launch_to_start_us;
 
 Validate that the join is one-to-one. CUDA graph nodes commonly share a launch
 and cannot be interpreted as independent host dispatches.
+
+Measure kernel-to-CUDA-runtime correlation separately:
+
+```sql
+WITH runtime_correlations AS (
+  SELECT DISTINCT correlationId
+  FROM CUPTI_ACTIVITY_KIND_RUNTIME
+)
+SELECT
+  COUNT(*) AS kernel_launches,
+  COUNT(r.correlationId) AS runtime_correlated_launches
+FROM CUPTI_ACTIVITY_KIND_KERNEL AS k
+LEFT JOIN runtime_correlations AS r USING (correlationId);
+```
+
+This join does not measure source call-stack coverage. Report source links only
+from an independently captured and validated call-stack dataset.
 
 ## Synchronization and device dependency edges
 
@@ -196,8 +295,13 @@ JOIN rank1_ops USING (seq)
 ORDER BY rank0_ops.seq;
 ```
 
-Across hosts, use matched collective ends to estimate residual clock offset and
-report its error. Do not claim exact arrival lateness when alignment is weak.
+Across hosts, match collective name, order, and participant group—not just a
+single global ordinal. Use many matched collective end deltas to estimate a
+constant clock offset with a robust center such as the median, then report
+residual p05/p95 or another error interval after correction. Compare aligned
+starts and ends separately. Do not call a longer window a straggler when it
+started earlier and ended with its peer, and do not claim exact arrival lateness
+when alignment is weak.
 
 ## Metric inventory
 


### PR DESCRIPTION
# What does this PR do ?

Adds a reusable Nsight Systems analysis skill for Megatron Bridge performance investigations.

# Changelog

- Add a critical-path workflow for single-trace, comparative, and multi-rank analysis.
- Distinguish interval-union wall time, exposed work, dependency-proven blocking time, launch starvation, and rank jitter.
- Add backend-aware communication/dispatcher accounting for NCCL, HybridEP, DeepEP, NVSHMEM, and similar transports without relabeling dispatcher occupancy as network time.
- Require matched-collective cross-host clock alignment, aligned start/end comparison, and sampled-rank-scoped straggler verdicts.
- Measure profiler perturbation from same-run trainer steps; distinguish recorded `PROFILER_OVERHEAD` from end-to-end slowdown.
- Separate kernel-to-CUDA-runtime correlation from source call-stack coverage and surface capture diagnostics/event completeness.
- Add evidence-based throughput and MFU gain ceilings plus mappings to existing MBridge tuning skills.
- Add portable SQLite inspection recipes, a misdiagnosis checklist, and positive/negative skill evaluations.
- Add the skill and its reference pages to the Agent Skills Reference index.

# GitHub Actions CI

Documentation-only change. Local validation completed:

- Skill quick validation
- Evaluation JSON parsing
- Git diff whitespace validation
- New SQLite recipes exercised against an exported Nsight Systems trace
- Full Sphinx HTML build with warnings treated as errors
- `uv tool run pre-commit run --all-files`

The exact `uv run pre-commit run --all-files` command was also attempted, but dependency setup cannot start on macOS because the pinned `nvidia-resiliency-ext` package only provides Linux wheels.

# Before your PR is "Ready for review"

- [x] Read and followed the contributor guidelines.
- [x] Added targeted evaluation cases.
- [x] Added the skill and references to the documentation index.
- [x] No optional dependency or runtime import changes.

# Additional Information

The hardening follow-up incorporates findings from a real two-node HybridEP profile: NCCL-only taxonomy, unaligned rank durations, profiler slowdown, and runtime-versus-source link coverage can otherwise produce incorrect conclusions.
