### PR TITLE
fix(ckpt): restrict dataloader state deserialization

### DIFF
--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -91,6 +91,7 @@ from megatron.bridge.utils.common_utils import (
 )
 from megatron.bridge.utils.import_utils import safe_import
 from megatron.bridge.utils.instantiate_utils import _validate_target_prefix
+from megatron.bridge.utils.safe_pickle import energon_torch_load
 
 
 _, HAVE_RESIL = safe_import("nvidia_resiliency_ext.checkpointing")
@@ -1753,53 +1754,6 @@ def maybe_save_dataloader_state(
     torch.save(dataloader_save_dict, data_state_save_path)
 
 
-def _get_dataloader_state_safe_globals() -> list[Any]:
-    """Return the trusted globals required to restore an Energon dataloader state.
-
-    Energon persists a small set of dataclass wrappers around tensors, NumPy RNG state, and plain
-    containers. Keeping this allowlist local to the dataloader restore prevents a checkpoint from
-    importing arbitrary globals while retaining compatibility with existing Energon ``.pt`` files.
-    """
-    from megatron.energon.flavors.webdataset.sample_loader import SliceState
-    from megatron.energon.rng import SystemRngState
-    from megatron.energon.savable_loader import (
-        SavableDataLoaderState,
-        SavableDatasetCheckpoint,
-        SavableDatasetState,
-    )
-    from megatron.energon.state import FlexState
-
-    # NumPy arrays are not in torch.load's default weights-only allowlist. Energon's RNG state uses
-    # uint32 arrays, and dataset state may contain other NumPy dtypes, so permit array reconstruction
-    # and dtype classes without permitting arbitrary NumPy callables.
-    numpy_reconstruct = np.empty(0).__reduce__()[0]
-    numpy_scalar = np.uint32(0).__reduce__()[0]
-    numpy_dtype_types = {type(np.dtype(scalar_type)) for scalar_type in np.sctypeDict.values()}
-
-    safe_globals: list[Any] = [
-        FlexState,
-        SystemRngState,
-        SavableDataLoaderState,
-        SavableDatasetCheckpoint,
-        SavableDatasetState,
-        SliceState,
-        np.ndarray,
-        np.dtype,
-        numpy_reconstruct,
-        numpy_scalar,
-        *numpy_dtype_types,
-    ]
-
-    # NumPy 2 moved these globals from numpy.core to numpy._core. Accept the legacy pickle names so
-    # checkpoints written with NumPy 1 remain loadable after upgrading NumPy.
-    if numpy_reconstruct.__module__ != "numpy.core.multiarray":
-        safe_globals.append((numpy_reconstruct, "numpy.core.multiarray._reconstruct"))
-    if numpy_scalar.__module__ != "numpy.core.multiarray":
-        safe_globals.append((numpy_scalar, "numpy.core.multiarray.scalar"))
-
-    return safe_globals
-
-
 def maybe_load_dataloader_state(
     train_iterator: Any,
     iteration: int,
@@ -1864,8 +1818,7 @@ def maybe_load_dataloader_state(
         )
 
     print_rank_0(f"restoring dataloader state at iteration {iteration} from {data_state_load_path}")
-    with torch.serialization.safe_globals(_get_dataloader_state_safe_globals()):
-        loaded = torch.load(data_state_load_path, map_location="cpu", weights_only=True)
+    loaded = energon_torch_load(data_state_load_path)
     iterable.restore_state(loaded["dataloader_state_dict"])
 
 

--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -1753,6 +1753,53 @@ def maybe_save_dataloader_state(
     torch.save(dataloader_save_dict, data_state_save_path)
 
 
+def _get_dataloader_state_safe_globals() -> list[Any]:
+    """Return the trusted globals required to restore an Energon dataloader state.
+
+    Energon persists a small set of dataclass wrappers around tensors, NumPy RNG state, and plain
+    containers. Keeping this allowlist local to the dataloader restore prevents a checkpoint from
+    importing arbitrary globals while retaining compatibility with existing Energon ``.pt`` files.
+    """
+    from megatron.energon.flavors.webdataset.sample_loader import SliceState
+    from megatron.energon.rng import SystemRngState
+    from megatron.energon.savable_loader import (
+        SavableDataLoaderState,
+        SavableDatasetCheckpoint,
+        SavableDatasetState,
+    )
+    from megatron.energon.state import FlexState
+
+    # NumPy arrays are not in torch.load's default weights-only allowlist. Energon's RNG state uses
+    # uint32 arrays, and dataset state may contain other NumPy dtypes, so permit array reconstruction
+    # and dtype classes without permitting arbitrary NumPy callables.
+    numpy_reconstruct = np.empty(0).__reduce__()[0]
+    numpy_scalar = np.uint32(0).__reduce__()[0]
+    numpy_dtype_types = {type(np.dtype(scalar_type)) for scalar_type in np.sctypeDict.values()}
+
+    safe_globals: list[Any] = [
+        FlexState,
+        SystemRngState,
+        SavableDataLoaderState,
+        SavableDatasetCheckpoint,
+        SavableDatasetState,
+        SliceState,
+        np.ndarray,
+        np.dtype,
+        numpy_reconstruct,
+        numpy_scalar,
+        *numpy_dtype_types,
+    ]
+
+    # NumPy 2 moved these globals from numpy.core to numpy._core. Accept the legacy pickle names so
+    # checkpoints written with NumPy 1 remain loadable after upgrading NumPy.
+    if numpy_reconstruct.__module__ != "numpy.core.multiarray":
+        safe_globals.append((numpy_reconstruct, "numpy.core.multiarray._reconstruct"))
+    if numpy_scalar.__module__ != "numpy.core.multiarray":
+        safe_globals.append((numpy_scalar, "numpy.core.multiarray.scalar"))
+
+    return safe_globals
+
+
 def maybe_load_dataloader_state(
     train_iterator: Any,
     iteration: int,
@@ -1817,7 +1864,8 @@ def maybe_load_dataloader_state(
         )
 
     print_rank_0(f"restoring dataloader state at iteration {iteration} from {data_state_load_path}")
-    loaded = torch.load(data_state_load_path, map_location="cpu", weights_only=False)
+    with torch.serialization.safe_globals(_get_dataloader_state_safe_globals()):
+        loaded = torch.load(data_state_load_path, map_location="cpu", weights_only=True)
     iterable.restore_state(loaded["dataloader_state_dict"])
 
 

--- a/src/megatron/bridge/utils/safe_pickle.py
+++ b/src/megatron/bridge/utils/safe_pickle.py
@@ -14,6 +14,7 @@
 
 import io
 import pickle
+import types
 from types import MappingProxyType
 
 
@@ -78,6 +79,8 @@ class _NumpyRestrictedUnpickler(pickle.Unpickler):
             "numpy.core.multiarray": frozenset({"_reconstruct", "scalar"}),
             # numpy ≥ 2.0 moved internals under ``numpy._core``
             "numpy._core.multiarray": frozenset({"_reconstruct", "scalar"}),
+            # _codecs.encode is used by NumPy to encode raw array bytes into the pickle stream
+            "_codecs": frozenset({"encode"}),
         }
     )
 
@@ -88,6 +91,66 @@ class _NumpyRestrictedUnpickler(pickle.Unpickler):
             f"Restricted unpickler refused to load '{module}.{name}'. "
             "Only safe built-in and numpy array types are allowed."
         )
+
+
+class _EnergonUnpickler(_NumpyRestrictedUnpickler):
+    """Unpickler for Energon dataloader state files (``.pt``).
+
+    Extends the NumPy-safe unpickler with the exact Energon dataclass types that Energon serialises
+    into dataloader checkpoint files.  All other globals — including ``os``, ``subprocess``, and any
+    ``__reduce__`` payload callable outside this allowlist — are blocked, preventing arbitrary code
+    execution from attacker-controlled checkpoint files.
+
+    Use via :func:`energon_pickle_load` rather than instantiating directly.
+    """
+
+    _SAFE_MODULES: MappingProxyType = MappingProxyType(
+        {
+            **_NumpyRestrictedUnpickler._SAFE_MODULES,
+            # PyTorch tensor reconstruction — required for any .pt file containing tensors.
+            # These functions only rebuild tensor objects from pre-loaded storage; they do
+            # not execute arbitrary code.
+            "torch._utils": frozenset({"_rebuild_tensor_v2", "_rebuild_tensor"}),
+            # Energon dataloader state types — the explicit allowlist for this load site.
+            "megatron.energon.state": frozenset({"FlexState"}),
+            "megatron.energon.rng": frozenset({"SystemRngState"}),
+            "megatron.energon.savable_loader": frozenset(
+                {
+                    "SavableDataLoaderState",
+                    "SavableDatasetCheckpoint",
+                    "SavableDatasetState",
+                }
+            ),
+            "megatron.energon.flavors.webdataset.sample_loader": frozenset({"SliceState"}),
+        }
+    )
+
+
+def energon_torch_load(path: str, *, map_location: str = "cpu") -> object:
+    """Load an Energon dataloader state ``.pt`` file through a restricted unpickler.
+
+    Replaces ``torch.load(..., weights_only=True)`` + ``safe_globals`` for Energon checkpoint
+    files.  Security is provided by :class:`_EnergonUnpickler`: any GLOBAL opcode not in its
+    allowlist raises ``pickle.UnpicklingError``, blocking ``__reduce__``-based code execution.
+    Using a custom ``pickle_module`` rather than ``weights_only=True`` avoids PyTorch's internal
+    SETITEM restriction, which rejects dict subclasses such as ``FlexState`` in PyTorch ≥ 2.13.
+
+    Args:
+        path: Path to the ``.pt`` file written by
+            :func:`~megatron.bridge.training.checkpointing.maybe_save_dataloader_state`.
+        map_location: Passed to ``torch.load``; defaults to ``"cpu"`` to avoid GPU allocation
+            during restore.
+
+    Returns:
+        The deserialized object (a ``dict`` containing ``"dataloader_state_dict"``).
+    """
+    import torch  # local import — keeps safe_pickle importable without torch on the test path
+
+    _energon_pickle = types.ModuleType("_energon_pickle")
+    for _k in dir(pickle):
+        setattr(_energon_pickle, _k, getattr(pickle, _k))
+    _energon_pickle.Unpickler = _EnergonUnpickler  # type: ignore[attr-defined]
+    return torch.load(path, map_location=map_location, pickle_module=_energon_pickle, weights_only=False)
 
 
 def safe_pickle_load(fp) -> object:

--- a/src/megatron/bridge/utils/safe_pickle.py
+++ b/src/megatron/bridge/utils/safe_pickle.py
@@ -101,7 +101,7 @@ class _EnergonUnpickler(_NumpyRestrictedUnpickler):
     ``__reduce__`` payload callable outside this allowlist — are blocked, preventing arbitrary code
     execution from attacker-controlled checkpoint files.
 
-    Use via :func:`energon_pickle_load` rather than instantiating directly.
+    Use via :func:`energon_torch_load` rather than instantiating directly.
     """
 
     _SAFE_MODULES: MappingProxyType = MappingProxyType(
@@ -126,20 +126,59 @@ class _EnergonUnpickler(_NumpyRestrictedUnpickler):
     )
 
 
-def _load_energon_zip(path: str, *, map_location: str) -> object:
-    """Parse a torch zip-format ``.pt`` file and deserialize it through :class:`_EnergonUnpickler`.
+def energon_torch_load(path: str, *, map_location: str = "cpu") -> object:
+    """Load an Energon dataloader state ``.pt`` file through a restricted unpickler.
 
-    ``torch.save`` writes a zip archive whose directory prefix is the file stem (e.g.
-    ``train_dataloader_dprank000/data.pkl``).  By opening the zip ourselves and running the
-    pickle stream through :class:`_EnergonUnpickler` directly, we get the same ``find_class``
-    security as ``weights_only=True`` without calling ``torch.load`` at all — so there is no
-    ``weights_only=`` argument to audit.
+    Parses the torch zip format directly without calling ``torch.load``.  Security is enforced
+    by :class:`_EnergonUnpickler`: any GLOBAL opcode whose ``(module, name)`` is not in the
+    explicit allowlist raises ``pickle.UnpicklingError``, blocking ``__reduce__``-based code
+    execution from attacker-controlled checkpoint files.
 
-    The ``persistent_load`` hook reconstructs each tensor storage from its raw blob; the dtype
-    and layout are recovered by ``_rebuild_tensor_v2`` (already in the allowlist), which reads
-    those fields from the pickle stream itself.
+    ``torch.load(weights_only=True)`` is not used because PyTorch ≥ 2.13 restricts
+    SETITEM/SETITEMS to exact ``dict``, ``OrderedDict``, and ``Counter`` types, rejecting dict
+    subclasses such as Energon's ``FlexState`` — which is always present in real Energon
+    checkpoints (``SavableDatasetState.dataset_state`` is typed ``FlexState``, not Optional).
+
+    ``torch.save`` writes a zip archive whose directory prefix is the file stem.  This function
+    opens the zip, runs :class:`_EnergonUnpickler` on the pickle stream, and reconstructs
+    tensor storages from the raw blobs via ``persistent_load``.  Storages are cached by key so
+    that tensors sharing a storage (views, slices) remain aliased after restore.
+
+    Args:
+        path: Path to the ``.pt`` file written by
+            :func:`~megatron.bridge.training.checkpointing.maybe_save_dataloader_state`.
+        map_location: Device to map tensor storages to; defaults to ``"cpu"`` to avoid GPU
+            allocation during restore.
+
+    Returns:
+        The deserialized object (a ``dict`` containing ``"dataloader_state_dict"``).
     """
     import torch
+
+    # PyTorch storage classes that torch.save may embed as GLOBAL opcodes in the persistent_id
+    # tuple.  Enumerated explicitly rather than matched by suffix to avoid admitting future
+    # classes or monkey-patched attributes that happen to end with "Storage".
+    _TORCH_STORAGE_NAMES: frozenset[str] = frozenset(
+        {
+            "UntypedStorage",
+            "TypedStorage",
+            "FloatStorage",
+            "LongStorage",
+            "ByteStorage",
+            "HalfStorage",
+            "DoubleStorage",
+            "IntStorage",
+            "ShortStorage",
+            "CharStorage",
+            "BFloat16Storage",
+            "ComplexFloatStorage",
+            "ComplexDoubleStorage",
+            "QInt8Storage",
+            "QInt32Storage",
+            "QUInt8Storage",
+            "BoolStorage",
+        }
+    )
 
     with zipfile.ZipFile(path) as zf:
         names = zf.namelist()
@@ -154,12 +193,17 @@ def _load_energon_zip(path: str, *, map_location: str) -> object:
         pkl_bytes = zf.read(pkl_entry)
 
     class _ZipLoader(_EnergonUnpickler):
+        def __init__(self, data: io.BytesIO) -> None:
+            super().__init__(data)
+            # Cache by storage key so tensors that share a storage remain aliased after restore,
+            # matching the behaviour of torch.load's own loaded_storages dict.
+            self._storage_cache: dict[str, object] = {}
+
         def find_class(self, module: str, name: str) -> type:
-            # torch.save embeds the storage class (e.g. torch.LongStorage,
-            # torch.storage.UntypedStorage) in the persistent_id tuple as a GLOBAL
-            # opcode.  Storage classes hold raw bytes and are not executable; allow
-            # them here without adding them to the shared _SAFE_MODULES allowlist.
-            if module in ("torch", "torch.storage") and name.endswith("Storage"):
+            # torch.save embeds the storage class in the persistent_id tuple as a GLOBAL opcode.
+            # Storage classes hold raw bytes and are not executable; allow the known set here
+            # without adding them to the shared _SAFE_MODULES allowlist.
+            if module in ("torch", "torch.storage") and name in _TORCH_STORAGE_NAMES:
                 return pickle.Unpickler.find_class(self, module, name)
             return super().find_class(module, name)
 
@@ -168,43 +212,20 @@ def _load_energon_zip(path: str, *, map_location: str) -> object:
             #   ('storage', storage_cls, key, location, nbytes)
             _typename, storage_cls, key, _location, _nbytes = pid
             key = key.decode() if isinstance(key, bytes) else key
+            if key in self._storage_cache:
+                return self._storage_cache[key]
             raw = blob_map[key]
             untyped = torch.frombuffer(bytearray(raw), dtype=torch.uint8).untyped_storage()
-            if map_location and map_location != _location:
+            if map_location != _location:
                 untyped = untyped.to(torch.device(map_location))
             # _rebuild_tensor_v2 reads storage.dtype to determine the tensor dtype.
             # UntypedStorage has no dtype attribute; wrap it with the typed storage class
             # (e.g. torch.LongStorage) that torch.save recorded in the persistent_id.
-            if storage_cls is torch.storage.UntypedStorage:
-                return untyped
-            return storage_cls(wrap_storage=untyped)
+            result = untyped if storage_cls is torch.storage.UntypedStorage else storage_cls(wrap_storage=untyped)
+            self._storage_cache[key] = result
+            return result
 
     return _ZipLoader(io.BytesIO(pkl_bytes)).load()
-
-
-def energon_torch_load(path: str, *, map_location: str = "cpu") -> object:
-    """Load an Energon dataloader state ``.pt`` file through a restricted unpickler.
-
-    Parses the torch zip format directly via :func:`_load_energon_zip` rather than delegating
-    to ``torch.load``.  Security is enforced by :class:`_EnergonUnpickler`: any GLOBAL opcode
-    whose ``(module, name)`` is not in the explicit allowlist raises ``pickle.UnpicklingError``,
-    blocking ``__reduce__``-based code execution from attacker-controlled checkpoint files.
-
-    ``torch.load(weights_only=True)`` is not used because PyTorch ≥ 2.13 restricts
-    SETITEM/SETITEMS to exact ``dict``, ``OrderedDict``, and ``Counter`` types, rejecting dict
-    subclasses such as Energon's ``FlexState`` — which is always present in real Energon
-    checkpoints (``SavableDatasetState.dataset_state`` is typed ``FlexState``, not Optional).
-
-    Args:
-        path: Path to the ``.pt`` file written by
-            :func:`~megatron.bridge.training.checkpointing.maybe_save_dataloader_state`.
-        map_location: Device to map tensor storages to; defaults to ``"cpu"`` to avoid GPU
-            allocation during restore.
-
-    Returns:
-        The deserialized object (a ``dict`` containing ``"dataloader_state_dict"``).
-    """
-    return _load_energon_zip(path, map_location=map_location)
 
 
 def safe_pickle_load(fp) -> object:

--- a/src/megatron/bridge/utils/safe_pickle.py
+++ b/src/megatron/bridge/utils/safe_pickle.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib
 import io
 import pickle
 import types
@@ -126,14 +127,48 @@ class _EnergonUnpickler(_NumpyRestrictedUnpickler):
     )
 
 
-def energon_torch_load(path: str, *, map_location: str = "cpu") -> object:
-    """Load an Energon dataloader state ``.pt`` file through a restricted unpickler.
+def _build_energon_safe_globals() -> list:
+    """Resolve :attr:`_EnergonUnpickler._SAFE_MODULES` into the list of objects required by
+    ``torch.serialization.safe_globals``.
 
-    Replaces ``torch.load(..., weights_only=True)`` + ``safe_globals`` for Energon checkpoint
-    files.  Security is provided by :class:`_EnergonUnpickler`: any GLOBAL opcode not in its
-    allowlist raises ``pickle.UnpicklingError``, blocking ``__reduce__``-based code execution.
-    Using a custom ``pickle_module`` rather than ``weights_only=True`` avoids PyTorch's internal
-    SETITEM restriction, which rejects dict subclasses such as ``FlexState`` in PyTorch ≥ 2.13.
+    Builtins, ``collections``, and ``torch._utils`` are already permitted by
+    ``weights_only=True`` and are excluded from the returned list to keep it minimal.
+    Modules that are not importable in the current environment (e.g. Energon absent) are
+    silently skipped — the ``weights_only=True`` call will then raise on the missing type,
+    and the caller decides how to proceed.
+    """
+    _ALREADY_ALLOWED = frozenset({"builtins", "collections", "torch._utils"})
+    safe: list = []
+    for module_name, names in _EnergonUnpickler._SAFE_MODULES.items():
+        if module_name in _ALREADY_ALLOWED:
+            continue
+        try:
+            mod = importlib.import_module(module_name)
+        except ImportError:
+            continue
+        for name in names:
+            obj = getattr(mod, name, None)
+            if obj is not None:
+                safe.append(obj)
+    return safe
+
+
+def energon_torch_load(path: str, *, map_location: str = "cpu") -> object:
+    """Load an Energon dataloader state ``.pt`` file with the tightest available restrictions.
+
+    Primary path — ``weights_only=True`` with an explicit allowlist derived from
+    :class:`_EnergonUnpickler`: PyTorch's restricted unpickler blocks every GLOBAL opcode not
+    in the allowlist, preventing ``__reduce__``-based code execution from attacker-controlled
+    checkpoint files.
+
+    Fallback path — PyTorch ≥ 2.13 restricts SETITEM/SETITEMS to the exact types ``dict``,
+    ``collections.OrderedDict``, and ``collections.Counter``, rejecting dict subclasses such as
+    Energon's ``FlexState``.  When that specific error is detected, the loader retries with
+    :class:`_EnergonUnpickler` as a custom ``pickle_module``.  ``_EnergonUnpickler.find_class``
+    enforces the same allowlist as the primary path, so the security guarantee is identical; the
+    only difference is that standard ``pickle.Unpickler`` does not impose the dict-subclass
+    SETITEM restriction.  The fallback is removed automatically once an upstream PyTorch version
+    extends the SETITEM allowlist to include safe dict subclasses.
 
     Args:
         path: Path to the ``.pt`` file written by
@@ -146,6 +181,17 @@ def energon_torch_load(path: str, *, map_location: str = "cpu") -> object:
     """
     import torch  # local import — keeps safe_pickle importable without torch on the test path
 
+    # Primary: weights_only=True with explicit allowlist — PyTorch's own restricted unpickler.
+    try:
+        with torch.serialization.safe_globals(_build_energon_safe_globals()):
+            return torch.load(path, map_location=map_location, weights_only=True)
+    except pickle.UnpicklingError as exc:
+        # Re-raise anything that is not the known PyTorch ≥ 2.13 dict-subclass SETITEM error.
+        if "Can only SETITEM" not in str(exc):
+            raise
+
+    # Fallback: _EnergonUnpickler enforces the same find_class allowlist; standard pickle
+    # SETITEM has no dict-subclass restriction so FlexState deserializes correctly.
     _energon_pickle = types.ModuleType("_energon_pickle")
     for _k in dir(pickle):
         setattr(_energon_pickle, _k, getattr(pickle, _k))

--- a/src/megatron/bridge/utils/safe_pickle.py
+++ b/src/megatron/bridge/utils/safe_pickle.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import importlib
 import io
 import pickle
 import zipfile
@@ -127,32 +126,6 @@ class _EnergonUnpickler(_NumpyRestrictedUnpickler):
     )
 
 
-def _build_energon_safe_globals() -> list:
-    """Resolve :attr:`_EnergonUnpickler._SAFE_MODULES` into the list of objects required by
-    ``torch.serialization.safe_globals``.
-
-    Builtins, ``collections``, and ``torch._utils`` are already permitted by
-    ``weights_only=True`` and are excluded from the returned list to keep it minimal.
-    Modules that are not importable in the current environment (e.g. Energon absent) are
-    silently skipped — the ``weights_only=True`` call will then raise on the missing type,
-    and the caller decides how to proceed.
-    """
-    _ALREADY_ALLOWED = frozenset({"builtins", "collections", "torch._utils"})
-    safe: list = []
-    for module_name, names in _EnergonUnpickler._SAFE_MODULES.items():
-        if module_name in _ALREADY_ALLOWED:
-            continue
-        try:
-            mod = importlib.import_module(module_name)
-        except ImportError:
-            continue
-        for name in names:
-            obj = getattr(mod, name, None)
-            if obj is not None:
-                safe.append(obj)
-    return safe
-
-
 def _load_energon_zip(path: str, *, map_location: str) -> object:
     """Parse a torch zip-format ``.pt`` file and deserialize it through :class:`_EnergonUnpickler`.
 
@@ -210,45 +183,27 @@ def _load_energon_zip(path: str, *, map_location: str) -> object:
 
 
 def energon_torch_load(path: str, *, map_location: str = "cpu") -> object:
-    """Load an Energon dataloader state ``.pt`` file with the tightest available restrictions.
+    """Load an Energon dataloader state ``.pt`` file through a restricted unpickler.
 
-    Primary path — ``weights_only=True`` with an explicit allowlist derived from
-    :class:`_EnergonUnpickler`: PyTorch's restricted unpickler blocks every GLOBAL opcode not
-    in the allowlist, preventing ``__reduce__``-based code execution from attacker-controlled
-    checkpoint files.
+    Parses the torch zip format directly via :func:`_load_energon_zip` rather than delegating
+    to ``torch.load``.  Security is enforced by :class:`_EnergonUnpickler`: any GLOBAL opcode
+    whose ``(module, name)`` is not in the explicit allowlist raises ``pickle.UnpicklingError``,
+    blocking ``__reduce__``-based code execution from attacker-controlled checkpoint files.
 
-    Fallback path — PyTorch ≥ 2.13 restricts SETITEM/SETITEMS to the exact types ``dict``,
-    ``collections.OrderedDict``, and ``collections.Counter``, rejecting dict subclasses such as
-    Energon's ``FlexState``.  When that specific error is detected for a known Energon dict
-    subclass, the loader retries via :func:`_load_energon_zip`, which parses the torch zip
-    format directly and runs :class:`_EnergonUnpickler` on the pickle stream without invoking
-    ``torch.load`` at all.  The ``find_class`` allowlist is identical to the primary path.
+    ``torch.load(weights_only=True)`` is not used because PyTorch ≥ 2.13 restricts
+    SETITEM/SETITEMS to exact ``dict``, ``OrderedDict``, and ``Counter`` types, rejecting dict
+    subclasses such as Energon's ``FlexState`` — which is always present in real Energon
+    checkpoints (``SavableDatasetState.dataset_state`` is typed ``FlexState``, not Optional).
 
     Args:
         path: Path to the ``.pt`` file written by
             :func:`~megatron.bridge.training.checkpointing.maybe_save_dataloader_state`.
-        map_location: Passed to ``torch.load`` / ``_load_energon_zip``; defaults to ``"cpu"``
-            to avoid GPU allocation during restore.
+        map_location: Device to map tensor storages to; defaults to ``"cpu"`` to avoid GPU
+            allocation during restore.
 
     Returns:
         The deserialized object (a ``dict`` containing ``"dataloader_state_dict"``).
     """
-    import torch  # local import — keeps safe_pickle importable without torch on the test path
-
-    # Primary: weights_only=True with an explicit allowlist.
-    try:
-        with torch.serialization.safe_globals(_build_energon_safe_globals()):
-            return torch.load(path, map_location=map_location, weights_only=True)
-    except pickle.UnpicklingError as exc:
-        # Re-raise unless this is specifically the PyTorch ≥ 2.13 SETITEM restriction on a
-        # known Energon dict subclass (currently FlexState).  Checking the class name ensures
-        # an unexpected dict subclass surfaces a clear error rather than silently falling back.
-        _exc_str = str(exc)
-        _known_dict_subclasses = _EnergonUnpickler._SAFE_MODULES.get("megatron.energon.state", frozenset())
-        if "Can only SETITEM" not in _exc_str or not any(name in _exc_str for name in _known_dict_subclasses):
-            raise
-
-    # Fallback: parse the torch zip directly — no torch.load, no weights_only= argument.
     return _load_energon_zip(path, map_location=map_location)
 
 

--- a/src/megatron/bridge/utils/safe_pickle.py
+++ b/src/megatron/bridge/utils/safe_pickle.py
@@ -112,10 +112,14 @@ class _EnergonUnpickler(_NumpyRestrictedUnpickler):
             # not execute arbitrary code.
             "torch._utils": frozenset({"_rebuild_tensor_v2", "_rebuild_tensor"}),
             # Energon dataloader state types — the explicit allowlist for this load site.
+            # If a real Energon checkpoint references a type not listed here the load will
+            # raise an UnpicklingError that names the missing ``module.name``; file a bug
+            # against Megatron Bridge so the allowlist can be extended.
             "megatron.energon.state": frozenset({"FlexState"}),
             "megatron.energon.rng": frozenset({"SystemRngState"}),
             "megatron.energon.savable_loader": frozenset(
                 {
+                    "SavableCheckpoint",
                     "SavableDataLoaderState",
                     "SavableDatasetCheckpoint",
                     "SavableDatasetState",
@@ -124,6 +128,15 @@ class _EnergonUnpickler(_NumpyRestrictedUnpickler):
             "megatron.energon.flavors.webdataset.sample_loader": frozenset({"SliceState"}),
         }
     )
+
+    def find_class(self, module: str, name: str) -> type:
+        if module in self._SAFE_MODULES and name in self._SAFE_MODULES[module]:
+            return pickle.Unpickler.find_class(self, module, name)
+        raise pickle.UnpicklingError(
+            f"Restricted unpickler refused to load '{module}.{name}'. "
+            "This Energon checkpoint contains a type not in the dataloader-state allowlist. "
+            "Please file a bug against Megatron Bridge so it can be added."
+        )
 
 
 def energon_torch_load(path: str, *, map_location: str = "cpu") -> object:

--- a/src/megatron/bridge/utils/safe_pickle.py
+++ b/src/megatron/bridge/utils/safe_pickle.py
@@ -15,7 +15,7 @@
 import importlib
 import io
 import pickle
-import types
+import zipfile
 from types import MappingProxyType
 
 
@@ -153,6 +153,62 @@ def _build_energon_safe_globals() -> list:
     return safe
 
 
+def _load_energon_zip(path: str, *, map_location: str) -> object:
+    """Parse a torch zip-format ``.pt`` file and deserialize it through :class:`_EnergonUnpickler`.
+
+    ``torch.save`` writes a zip archive whose directory prefix is the file stem (e.g.
+    ``train_dataloader_dprank000/data.pkl``).  By opening the zip ourselves and running the
+    pickle stream through :class:`_EnergonUnpickler` directly, we get the same ``find_class``
+    security as ``weights_only=True`` without calling ``torch.load`` at all — so there is no
+    ``weights_only=`` argument to audit.
+
+    The ``persistent_load`` hook reconstructs each tensor storage from its raw blob; the dtype
+    and layout are recovered by ``_rebuild_tensor_v2`` (already in the allowlist), which reads
+    those fields from the pickle stream itself.
+    """
+    import torch
+
+    with zipfile.ZipFile(path) as zf:
+        names = zf.namelist()
+
+        # torch.save uses the file stem as the archive prefix: "<stem>/data.pkl".
+        pkl_entry = next(n for n in names if n.endswith("/data.pkl"))
+        prefix = pkl_entry[: -len("/data.pkl")]
+        blob_prefix = f"{prefix}/data/"
+
+        # Map storage key → raw bytes for every tensor storage blob.
+        blob_map = {n[len(blob_prefix) :]: zf.read(n) for n in names if n.startswith(blob_prefix)}
+        pkl_bytes = zf.read(pkl_entry)
+
+    class _ZipLoader(_EnergonUnpickler):
+        def find_class(self, module: str, name: str) -> type:
+            # torch.save embeds the storage class (e.g. torch.LongStorage,
+            # torch.storage.UntypedStorage) in the persistent_id tuple as a GLOBAL
+            # opcode.  Storage classes hold raw bytes and are not executable; allow
+            # them here without adding them to the shared _SAFE_MODULES allowlist.
+            if module in ("torch", "torch.storage") and name.endswith("Storage"):
+                return pickle.Unpickler.find_class(self, module, name)
+            return super().find_class(module, name)
+
+        def persistent_load(self, pid: tuple):
+            # torch.save persistent_id format (zip path):
+            #   ('storage', storage_cls, key, location, nbytes)
+            _typename, storage_cls, key, _location, _nbytes = pid
+            key = key.decode() if isinstance(key, bytes) else key
+            raw = blob_map[key]
+            untyped = torch.frombuffer(bytearray(raw), dtype=torch.uint8).untyped_storage()
+            if map_location and map_location != _location:
+                untyped = untyped.to(torch.device(map_location))
+            # _rebuild_tensor_v2 reads storage.dtype to determine the tensor dtype.
+            # UntypedStorage has no dtype attribute; wrap it with the typed storage class
+            # (e.g. torch.LongStorage) that torch.save recorded in the persistent_id.
+            if storage_cls is torch.storage.UntypedStorage:
+                return untyped
+            return storage_cls(wrap_storage=untyped)
+
+    return _ZipLoader(io.BytesIO(pkl_bytes)).load()
+
+
 def energon_torch_load(path: str, *, map_location: str = "cpu") -> object:
     """Load an Energon dataloader state ``.pt`` file with the tightest available restrictions.
 
@@ -163,40 +219,37 @@ def energon_torch_load(path: str, *, map_location: str = "cpu") -> object:
 
     Fallback path — PyTorch ≥ 2.13 restricts SETITEM/SETITEMS to the exact types ``dict``,
     ``collections.OrderedDict``, and ``collections.Counter``, rejecting dict subclasses such as
-    Energon's ``FlexState``.  When that specific error is detected, the loader retries with
-    :class:`_EnergonUnpickler` as a custom ``pickle_module``.  ``_EnergonUnpickler.find_class``
-    enforces the same allowlist as the primary path, so the security guarantee is identical; the
-    only difference is that standard ``pickle.Unpickler`` does not impose the dict-subclass
-    SETITEM restriction.  The fallback is removed automatically once an upstream PyTorch version
-    extends the SETITEM allowlist to include safe dict subclasses.
+    Energon's ``FlexState``.  When that specific error is detected for a known Energon dict
+    subclass, the loader retries via :func:`_load_energon_zip`, which parses the torch zip
+    format directly and runs :class:`_EnergonUnpickler` on the pickle stream without invoking
+    ``torch.load`` at all.  The ``find_class`` allowlist is identical to the primary path.
 
     Args:
         path: Path to the ``.pt`` file written by
             :func:`~megatron.bridge.training.checkpointing.maybe_save_dataloader_state`.
-        map_location: Passed to ``torch.load``; defaults to ``"cpu"`` to avoid GPU allocation
-            during restore.
+        map_location: Passed to ``torch.load`` / ``_load_energon_zip``; defaults to ``"cpu"``
+            to avoid GPU allocation during restore.
 
     Returns:
         The deserialized object (a ``dict`` containing ``"dataloader_state_dict"``).
     """
     import torch  # local import — keeps safe_pickle importable without torch on the test path
 
-    # Primary: weights_only=True with explicit allowlist — PyTorch's own restricted unpickler.
+    # Primary: weights_only=True with an explicit allowlist.
     try:
         with torch.serialization.safe_globals(_build_energon_safe_globals()):
             return torch.load(path, map_location=map_location, weights_only=True)
     except pickle.UnpicklingError as exc:
-        # Re-raise anything that is not the known PyTorch ≥ 2.13 dict-subclass SETITEM error.
-        if "Can only SETITEM" not in str(exc):
+        # Re-raise unless this is specifically the PyTorch ≥ 2.13 SETITEM restriction on a
+        # known Energon dict subclass (currently FlexState).  Checking the class name ensures
+        # an unexpected dict subclass surfaces a clear error rather than silently falling back.
+        _exc_str = str(exc)
+        _known_dict_subclasses = _EnergonUnpickler._SAFE_MODULES.get("megatron.energon.state", frozenset())
+        if "Can only SETITEM" not in _exc_str or not any(name in _exc_str for name in _known_dict_subclasses):
             raise
 
-    # Fallback: _EnergonUnpickler enforces the same find_class allowlist; standard pickle
-    # SETITEM has no dict-subclass restriction so FlexState deserializes correctly.
-    _energon_pickle = types.ModuleType("_energon_pickle")
-    for _k in dir(pickle):
-        setattr(_energon_pickle, _k, getattr(pickle, _k))
-    _energon_pickle.Unpickler = _EnergonUnpickler  # type: ignore[attr-defined]
-    return torch.load(path, map_location=map_location, pickle_module=_energon_pickle, weights_only=False)
+    # Fallback: parse the torch zip directly — no torch.load, no weights_only= argument.
+    return _load_energon_zip(path, map_location=map_location)
 
 
 def safe_pickle_load(fp) -> object:

--- a/tests/unit_tests/training/test_checkpointing.py
+++ b/tests/unit_tests/training/test_checkpointing.py
@@ -5104,6 +5104,97 @@ class TestMaybeLoadDataloaderState:
         assert not marker_path.exists()
         train_iterator.iterable.restore_state.assert_not_called()
 
+    def test_restores_multi_worker_state_with_savable_checkpoint(self, tmp_path):
+        """Multi-worker state and SavableCheckpoint nested inside FlexState round-trip correctly.
+
+        SavableCheckpoint (checkpoint_time + sample_index) is distinct from
+        SavableDatasetCheckpoint and can appear as a FlexState value when a
+        SavableDatasetWrapper is used inside a blending dataset.  Two worker
+        states are used to confirm the loader handles the list correctly.
+        """
+        from megatron.energon.flavors.webdataset.sample_loader import SliceState
+        from megatron.energon.rng import SystemRngState
+        from megatron.energon.savable_loader import (
+            SavableCheckpoint,
+            SavableDataLoaderState,
+            SavableDatasetCheckpoint,
+            SavableDatasetState,
+        )
+        from megatron.energon.state import FlexState
+
+        def _rng(seed: int) -> SystemRngState:
+            return SystemRngState(
+                torch=torch.arange(seed, seed + 3),
+                numpy=np.arange(seed, seed + 3, dtype=np.uint32),
+                random=(seed, tuple(range(seed, seed + 3)), None),
+            )
+
+        # Worker 0: simple blending state with two active slices.
+        worker0 = SavableDatasetCheckpoint(
+            state=SavableDatasetState(
+                rng=_rng(0),
+                dataset_state=FlexState(
+                    active_slices=[SliceState(index=0, current=11), SliceState(index=1, current=22)]
+                ),
+                sample_index=100,
+            ),
+            offset=0,
+        )
+        # Worker 1: FlexState contains a nested SavableCheckpoint, simulating a
+        # SavableDatasetWrapper used as an inner dataset.
+        nested_ckpt = SavableCheckpoint(
+            state=SavableDatasetState(
+                rng=_rng(10),
+                dataset_state=FlexState(active_slices=[SliceState(index=5, current=99)]),
+                sample_index=50,
+            ),
+            checkpoint_time=1.0,
+            sample_index=50,
+        )
+        worker1 = SavableDatasetCheckpoint(
+            state=SavableDatasetState(
+                rng=_rng(20),
+                dataset_state=FlexState(inner=nested_ckpt),
+                sample_index=200,
+            ),
+            offset=2,
+        )
+
+        loader_state = SavableDataLoaderState(
+            worker_states=[worker0, worker1],
+            next_worker_id=1,
+            micro_batch_size=8,
+        )
+
+        train_iterator = Mock()
+        iter_dir = Path(get_checkpoint_name(str(tmp_path), 10))
+        iter_dir.mkdir(parents=True)
+        state_path = iter_dir / "train_dataloader_dprank000.pt"
+        torch.save({"dataloader_state_dict": loader_state}, state_path)
+
+        maybe_load_dataloader_state(train_iterator, 10, str(tmp_path), pg_collection=self._pg())
+
+        restored = train_iterator.iterable.restore_state.call_args.args[0]
+        assert isinstance(restored, SavableDataLoaderState)
+        assert restored.next_worker_id == 1
+        assert restored.micro_batch_size == 8
+        assert len(restored.worker_states) == 2
+
+        r0 = restored.worker_states[0].state
+        assert r0.sample_index == 100
+        assert r0.dataset_state["active_slices"] == [
+            SliceState(index=0, current=11),
+            SliceState(index=1, current=22),
+        ]
+        np.testing.assert_array_equal(r0.rng.numpy, _rng(0).numpy)
+
+        r1 = restored.worker_states[1].state
+        assert r1.sample_index == 200
+        assert isinstance(r1.dataset_state["inner"], SavableCheckpoint)
+        assert r1.dataset_state["inner"].sample_index == 50
+        assert r1.dataset_state["inner"].checkpoint_time == 1.0
+        np.testing.assert_array_equal(r1.rng.numpy, _rng(20).numpy)
+
 
 class TestMaybeSaveDataloaderState:
     """Tests for gating which rank writes the Energon dataloader stream-position state."""

--- a/tests/unit_tests/training/test_checkpointing.py
+++ b/tests/unit_tests/training/test_checkpointing.py
@@ -5098,7 +5098,7 @@ class TestMaybeLoadDataloaderState:
         torch.save({"dataloader_state_dict": _MaliciousDataloaderState(marker_path)}, state_path)
 
         assert not marker_path.exists()
-        with pytest.raises(pickle.UnpicklingError, match="Weights only load failed"):
+        with pytest.raises(pickle.UnpicklingError, match="Restricted unpickler refused to load"):
             maybe_load_dataloader_state(train_iterator, 10, str(tmp_path), pg_collection=self._pg())
 
         assert not marker_path.exists()

--- a/tests/unit_tests/training/test_checkpointing.py
+++ b/tests/unit_tests/training/test_checkpointing.py
@@ -5098,7 +5098,7 @@ class TestMaybeLoadDataloaderState:
         torch.save({"dataloader_state_dict": _MaliciousDataloaderState(marker_path)}, state_path)
 
         assert not marker_path.exists()
-        with pytest.raises(pickle.UnpicklingError, match="Restricted unpickler refused to load"):
+        with pytest.raises(pickle.UnpicklingError, match="Weights only load failed"):
             maybe_load_dataloader_state(train_iterator, 10, str(tmp_path), pg_collection=self._pg())
 
         assert not marker_path.exists()

--- a/tests/unit_tests/training/test_checkpointing.py
+++ b/tests/unit_tests/training/test_checkpointing.py
@@ -5006,7 +5006,7 @@ class TestMaybeLoadDataloaderState:
         with pytest.raises(RuntimeError, match="data-parallel size"):
             maybe_load_dataloader_state(train_iterator, 10, str(tmp_path), pg_collection=self._pg())
 
-    @patch("megatron.bridge.training.checkpointing.torch.load")
+    @patch("megatron.bridge.training.checkpointing.energon_torch_load")
     def test_restores_on_every_cp_tp_pp_rank(self, mock_load, tmp_path):
         """Unlike save, restore must run on every cp/tp/pp because
         each rank pulls from its own data iterator. Keyed by the pure DP rank."""
@@ -5026,7 +5026,7 @@ class TestMaybeLoadDataloaderState:
 
         train_iterator.iterable.restore_state.assert_called_once_with({"dummy_energon_state": "xyz"})
 
-    @patch("megatron.bridge.training.checkpointing.torch.load")
+    @patch("megatron.bridge.training.checkpointing.energon_torch_load")
     def test_restores_from_file(self, mock_load, tmp_path):
         """Happy path: the per-DP-rank file is loaded and restore_state is called with the saved dict."""
         train_iterator = Mock()
@@ -5098,7 +5098,7 @@ class TestMaybeLoadDataloaderState:
         torch.save({"dataloader_state_dict": _MaliciousDataloaderState(marker_path)}, state_path)
 
         assert not marker_path.exists()
-        with pytest.raises(pickle.UnpicklingError, match="Weights only load failed"):
+        with pytest.raises(pickle.UnpicklingError, match="Restricted unpickler refused to load"):
             maybe_load_dataloader_state(train_iterator, 10, str(tmp_path), pg_collection=self._pg())
 
         assert not marker_path.exists()

--- a/tests/unit_tests/training/test_checkpointing.py
+++ b/tests/unit_tests/training/test_checkpointing.py
@@ -5040,8 +5040,8 @@ class TestMaybeLoadDataloaderState:
 
         train_iterator.iterable.restore_state.assert_called_once_with({"dummy_energon_state": "xyz"})
 
-    def test_restores_energon_state_with_weights_only(self, tmp_path):
-        """Existing Energon dataclass and NumPy state remains loadable through the restricted loader."""
+    def test_restores_energon_state_via_restricted_unpickler(self, tmp_path):
+        """Energon dataclass and NumPy state round-trips correctly through the restricted zip loader."""
         from megatron.energon.flavors.webdataset.sample_loader import SliceState
         from megatron.energon.rng import SystemRngState
         from megatron.energon.savable_loader import (

--- a/tests/unit_tests/training/test_checkpointing.py
+++ b/tests/unit_tests/training/test_checkpointing.py
@@ -14,10 +14,12 @@
 """Unit tests for megatron.bridge.training.checkpointing module."""
 
 import os
+import pickle
 import tempfile
 from pathlib import Path
 from unittest.mock import Mock, mock_open, patch
 
+import numpy as np
 import pytest
 import torch
 from megatron.core.msc_utils import MultiStorageClientFeature
@@ -72,6 +74,21 @@ class _DummyClass:
 
 
 _dummy_obj = _DummyClass()
+
+
+def _write_dataloader_state_marker(path: str) -> None:
+    """Write a marker if an unsafe deserializer executes a test payload."""
+    Path(path).write_text("dataloader state payload executed")
+
+
+class _MaliciousDataloaderState:
+    """Pickle payload used to verify that dataloader restore blocks arbitrary globals."""
+
+    def __init__(self, marker_path: Path):
+        self.marker_path = marker_path
+
+    def __reduce__(self):
+        return _write_dataloader_state_marker, (str(self.marker_path),)
 
 
 class TestCheckpointUtilities:
@@ -5022,6 +5039,70 @@ class TestMaybeLoadDataloaderState:
         maybe_load_dataloader_state(train_iterator, 10, str(tmp_path), pg_collection=self._pg())
 
         train_iterator.iterable.restore_state.assert_called_once_with({"dummy_energon_state": "xyz"})
+
+    def test_restores_energon_state_with_weights_only(self, tmp_path):
+        """Existing Energon dataclass and NumPy state remains loadable through the restricted loader."""
+        from megatron.energon.flavors.webdataset.sample_loader import SliceState
+        from megatron.energon.rng import SystemRngState
+        from megatron.energon.savable_loader import (
+            SavableDataLoaderState,
+            SavableDatasetCheckpoint,
+            SavableDatasetState,
+        )
+        from megatron.energon.state import FlexState
+
+        train_iterator = Mock()
+        iter_dir = Path(get_checkpoint_name(str(tmp_path), 10))
+        iter_dir.mkdir(parents=True)
+        state_path = iter_dir / "train_dataloader_dprank000.pt"
+        rng_state = SystemRngState(
+            torch=torch.arange(3),
+            numpy=np.arange(3, dtype=np.uint32),
+            random=(3, (1, 2, 3), None),
+        )
+        loader_state = SavableDataLoaderState(
+            worker_states=[
+                SavableDatasetCheckpoint(
+                    state=SavableDatasetState(
+                        rng=rng_state,
+                        dataset_state=FlexState(active_slices=[SliceState(index=2, current=17)]),
+                        sample_index=5,
+                    ),
+                    offset=1,
+                )
+            ],
+            next_worker_id=0,
+            micro_batch_size=2,
+        )
+        torch.save({"dataloader_state_dict": loader_state}, state_path)
+
+        maybe_load_dataloader_state(train_iterator, 10, str(tmp_path), pg_collection=self._pg())
+
+        restored = train_iterator.iterable.restore_state.call_args.args[0]
+        assert isinstance(restored, SavableDataLoaderState)
+        assert restored.next_worker_id == loader_state.next_worker_id
+        assert restored.micro_batch_size == loader_state.micro_batch_size
+        restored_dataset_state = restored.worker_states[0].state
+        assert restored_dataset_state is not None
+        assert restored_dataset_state.sample_index == 5
+        np.testing.assert_array_equal(restored_dataset_state.rng.numpy, rng_state.numpy)
+        assert restored_dataset_state.dataset_state["active_slices"] == [SliceState(index=2, current=17)]
+
+    def test_rejects_reduce_payload_without_executing_it(self, tmp_path):
+        """A checkpoint cannot execute an arbitrary callable through pickle ``__reduce__``."""
+        train_iterator = Mock()
+        iter_dir = Path(get_checkpoint_name(str(tmp_path), 10))
+        iter_dir.mkdir(parents=True)
+        marker_path = tmp_path / "dataloader-state-payload-executed"
+        state_path = iter_dir / "train_dataloader_dprank000.pt"
+        torch.save({"dataloader_state_dict": _MaliciousDataloaderState(marker_path)}, state_path)
+
+        assert not marker_path.exists()
+        with pytest.raises(pickle.UnpicklingError, match="Weights only load failed"):
+            maybe_load_dataloader_state(train_iterator, 10, str(tmp_path), pg_collection=self._pg())
+
+        assert not marker_path.exists()
+        train_iterator.iterable.restore_state.assert_not_called()
 
 
 class TestMaybeSaveDataloaderState:


### PR DESCRIPTION
# What does this PR do ?

Hardens Megatron Energon dataloader-state restoration against arbitrary code execution from attacker-controlled checkpoint files.

The resume path now loads Torch ZIP-format dataloader checkpoints through a dedicated restricted unpickler instead of the unrestricted `torch.load(..., weights_only=False)` call. The loader permits the bounded set of Energon state, NumPy reconstruction, Torch tensor-rebuild, and storage types required by these checkpoints; other pickle globals, including `__reduce__` payload callables, are rejected.

# Changelog

- Add `energon_torch_load()` and `_EnergonUnpickler` in `utils/safe_pickle.py`.
- Parse the `torch.save` ZIP archive directly, load `data.pkl` through the restricted unpickler, and reconstruct tensor storages from the archive blobs on CPU.
- Extend the NumPy-safe globals with `_codecs.encode`, which is required by NumPy array payloads in Torch archives.
- Replace the unrestricted dataloader-state `torch.load` call with `energon_torch_load`.
- Update mocked restore tests to patch the new loader.
- Add a representative Energon state round-trip test covering Energon dataclasses, `FlexState`, Torch tensors, NumPy RNG state, and slice state.
- Add a malicious `__reduce__` regression test that verifies the payload is rejected before `restore_state()` and never writes its marker.

# Why not `torch.load(weights_only=True)`?

PyTorch 2.13's restricted unpickler limits `SETITEM`/`SETITEMS` to a small set of exact mapping types. Energon's required `FlexState` is a `dict` subclass, so real Energon checkpoints fail to restore through that path.

The dedicated ZIP loader preserves support for `FlexState` while enforcing the repository's explicit restricted-unpickler boundary for pickle globals.

# GitHub Actions CI

Focused validation reported for the latest implementation:

- `TestMaybeLoadDataloaderState`: **10 passed**
- Environment: `nvcr.io/nvidian/nemo:26.08.rc3`
- PyTorch: `2.13.0a0`
- NumPy: `1.26.4`

At the current PR head, GitHub lint, copyright, secrets detection, link checking, pre-flight, and DCO checks have passed. Remaining CI jobs are still queued or waiting.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [x] Reviewer: Does the PR have correct import guards for all optional libraries?

# Additional Information

- The unsafe load was introduced with Energon dataloader checkpoint restore in #4521.
- The affected code is also present on `r0.6.0` and will require a backport.
