### PR TITLE
fix(models): use HybridEP for Kimi-K2.5 expert parallelism

### DIFF
--- a/examples/conversion/hf_to_megatron_generate_vlm.py
+++ b/examples/conversion/hf_to_megatron_generate_vlm.py
@@ -147,6 +147,19 @@ def _hf_revision_kwargs(revision: str | None) -> dict[str, str]:
     return {"revision": revision} if revision is not None else {}
 
 
+def _gather_last_token_logits(output: torch.Tensor, real_seq_len: int) -> torch.Tensor:
+    """Gather only the last real token's tensor-parallel vocabulary shards."""
+    local_logits = output[:, real_seq_len - 1]
+    world_size = parallel_state.get_tensor_model_parallel_world_size()
+    gathered_logits = [torch.zeros_like(local_logits) for _ in range(world_size)]
+    dist.all_gather(
+        gathered_logits,
+        local_logits,
+        group=parallel_state.get_tensor_model_parallel_group(),
+    )
+    return torch.cat(gathered_logits, dim=-1)
+
+
 def main(args) -> None:
     """Run VLM inference with HuggingFace or Megatron checkpoints."""
     maybe_initialize_distributed()
@@ -366,26 +379,22 @@ def main(args) -> None:
                 output = output[0]
 
             if parallel_state.is_pipeline_last_stage():
-                world_size = parallel_state.get_tensor_model_parallel_world_size()
-                gathered_tensors = [torch.zeros_like(output) for _ in range(world_size)]
-                dist.all_gather(gathered_tensors, output, group=parallel_state.get_tensor_model_parallel_group())
-                output = torch.cat(gathered_tensors, dim=2)
-
-                last_pos = real_seq_len - 1
-                next_token_ids = torch.argmax(output[:, last_pos], dim=-1, keepdim=True)
+                last_token_logits = _gather_last_token_logits(output, real_seq_len)
+                del output
+                next_token_ids = torch.argmax(last_token_logits, dim=-1, keepdim=True)
 
                 if step < 5:
                     print_rank_last(
-                        f"Step {step}: output shape={output.shape}, "
-                        f"real_seq_len={real_seq_len}, var={output.var():.4f}"
+                        f"Step {step}: last-token logits shape={last_token_logits.shape}, "
+                        f"real_seq_len={real_seq_len}, last-token var={last_token_logits.var():.4f}"
                     )
-                    logits = output[0, last_pos, :]
-                    top5_vals, top5_ids = torch.topk(logits, 5)
+                    top5_vals, top5_ids = torch.topk(last_token_logits[0], 5)
                     top5_tokens = [tokenizer.decode([idx]) for idx in top5_ids]
                     print_rank_last(f"Top 5: {list(zip(top5_tokens, top5_vals.tolist()))}")
                     print_rank_last(
                         f"Selected: '{tokenizer.decode([next_token_ids.item()])}' (id={next_token_ids.item()})"
                     )
+                del last_token_logits
             else:
                 next_token_ids = torch.ones((1, 1), device=generated_ids.device, dtype=generated_ids.dtype)
 

--- a/examples/models/kimi/kimi_k25_vl/README.md
+++ b/examples/models/kimi/kimi_k25_vl/README.md
@@ -78,6 +78,12 @@ See [slurm_inference.sh](slurm_inference.sh) for configuration details.
 
 Note:
 - `--trust_remote_code` is required for Kimi-K2.5 models.
+- Bridge-created Kimi-K2.5 providers use the HybridEP dispatcher with 16
+  communication SMs and unfused HybridEP permutation. On 8-GPU H100 nodes, set
+  `NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN=8`. A native Megatron checkpoint
+  can retain the dispatcher configuration with which it was saved, so loading
+  an older checkpoint may require applying the same overrides to the loaded
+  model configuration.
 - Use `--pp_layout` to specify custom pipeline layouts (e.g.
   `--pp_layout "Et*15|t*15|t*16|t*15L"` for PP=4).
 - You can optionally pass `--megatron_model_path` to use a pre-converted

--- a/examples/models/kimi/kimi_k25_vl/README.md
+++ b/examples/models/kimi/kimi_k25_vl/README.md
@@ -80,10 +80,10 @@ Note:
 - `--trust_remote_code` is required for Kimi-K2.5 models.
 - Bridge-created Kimi-K2.5 providers use the HybridEP dispatcher with 16
   communication SMs and unfused HybridEP permutation. On 8-GPU H100 nodes, set
-  `NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN=8`. A native Megatron checkpoint
-  can retain the dispatcher configuration with which it was saved, so loading
-  an older checkpoint may require applying the same overrides to the loaded
-  model configuration.
+  `NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN=8`, `NVLINK_DOMAIN_SIZE=8`, and
+  `USE_MNNVL=0`. A native Megatron checkpoint can retain the dispatcher
+  configuration with which it was saved, so loading an older checkpoint may
+  require applying the same overrides to the loaded model configuration.
 - Use `--pp_layout` to specify custom pipeline layouts (e.g.
   `--pp_layout "Et*15|t*15|t*16|t*15L"` for PP=4).
 - You can optionally pass `--megatron_model_path` to use a pre-converted

--- a/examples/models/kimi/kimi_k25_vl/slurm_inference.sh
+++ b/examples/models/kimi/kimi_k25_vl/slurm_inference.sh
@@ -57,6 +57,7 @@ MAX_NEW_TOKENS=200
 export TORCH_NCCL_AVOID_RECORD_STREAMS=1
 export NCCL_NVLS_ENABLE=0
 export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+export NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN=8
 
 echo "======================================"
 echo "Kimi-K2.5-VL Inference"

--- a/examples/models/kimi/kimi_k25_vl/slurm_inference.sh
+++ b/examples/models/kimi/kimi_k25_vl/slurm_inference.sh
@@ -58,6 +58,8 @@ export TORCH_NCCL_AVOID_RECORD_STREAMS=1
 export NCCL_NVLS_ENABLE=0
 export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
 export NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN=8
+export NVLINK_DOMAIN_SIZE=8
+export USE_MNNVL=0
 
 echo "======================================"
 echo "Kimi-K2.5-VL Inference"

--- a/src/megatron/bridge/models/kimi_vl/kimi_k25_vl_bridge.py
+++ b/src/megatron/bridge/models/kimi_vl/kimi_k25_vl_bridge.py
@@ -86,7 +86,10 @@ class KimiK25VLBridge(MegatronModelBridge):
         # MoE settings
         provider.moe_grouped_gemm = True
         provider.moe_router_pre_softmax = True
-        provider.moe_token_dispatcher_type = "alltoall"
+        provider.moe_token_dispatcher_type = "flex"
+        provider.moe_flex_dispatcher_backend = "hybridep"
+        provider.moe_flex_dispatcher_num_sms = 16
+        provider.moe_permute_fusion_into_hybridep = False
         provider.moe_router_load_balancing_type = "seq_aux_loss"
         provider.moe_shared_expert_overlap = True
         provider.moe_router_score_function = "sigmoid"

--- a/src/megatron/bridge/recipes/kimi_vl/h100/kimi_k25_vl.py
+++ b/src/megatron/bridge/recipes/kimi_vl/h100/kimi_k25_vl.py
@@ -99,9 +99,10 @@ def kimi_k25_vl_sft_512gpu_h100_bf16_config() -> ConfigContainer:
     cfg.dataset.hf_processor_path = "moonshotai/Kimi-K2.5"
 
     # MoE Token Dispatcher settings
-    cfg.model.moe_token_dispatcher_type = "alltoall"
-    cfg.model.moe_flex_dispatcher_backend = "deepep"
-    cfg.model.moe_hybridep_num_sms = 16
+    cfg.model.moe_token_dispatcher_type = "flex"
+    cfg.model.moe_flex_dispatcher_backend = "hybridep"
+    cfg.model.moe_flex_dispatcher_num_sms = 16
+    cfg.model.moe_permute_fusion_into_hybridep = False
 
     # Training config
     cfg.train.train_iters = 1_000_000
@@ -188,6 +189,7 @@ def kimi_k25_vl_sft_512gpu_h100_bf16_config() -> ConfigContainer:
     # Keep the complete process environment visible on the recipe.
     cfg.env_vars = {
         **COMMON_RECIPE_ENV_VARS,
+        "NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN": 8,
     }
     return cfg
 

--- a/src/megatron/bridge/recipes/kimi_vl/h100/kimi_k25_vl.py
+++ b/src/megatron/bridge/recipes/kimi_vl/h100/kimi_k25_vl.py
@@ -190,6 +190,8 @@ def kimi_k25_vl_sft_512gpu_h100_bf16_config() -> ConfigContainer:
     cfg.env_vars = {
         **COMMON_RECIPE_ENV_VARS,
         "NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN": 8,
+        "NVLINK_DOMAIN_SIZE": 8,
+        "USE_MNNVL": 0,
     }
     return cfg
 

--- a/tests/unit_tests/examples/test_hf_to_megatron_generate_vlm.py
+++ b/tests/unit_tests/examples/test_hf_to_megatron_generate_vlm.py
@@ -15,6 +15,7 @@
 import runpy
 import sys
 import types
+import weakref
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -61,6 +62,7 @@ for name in (
 
 with patch.dict(sys.modules, _import_stubs):
     _SCRIPT_GLOBALS = runpy.run_path(_SCRIPT)
+_gather_last_token_logits = _SCRIPT_GLOBALS["_gather_last_token_logits"]
 _main = _SCRIPT_GLOBALS["main"]
 
 
@@ -106,8 +108,8 @@ def test_checkpoint_inference_aligns_parameter_dtype_with_pipeline_dtype() -> No
 
 
 @pytest.mark.unit
-def test_generation_stops_on_any_configured_eos_token() -> None:
-    """An alternate EOS from generation_config must end the greedy loop."""
+def test_generation_releases_logits_and_stops_on_any_configured_eos_token() -> None:
+    """Generation must release prior logits and stop on an alternate EOS."""
     args = SimpleNamespace(
         ep=1,
         etp=1,
@@ -115,7 +117,7 @@ def test_generation_stops_on_any_configured_eos_token() -> None:
         hf_revision="revision",
         image_path=None,
         image_paths=None,
-        max_new_tokens=2,
+        max_new_tokens=3,
         megatron_model_path=None,
         pp=1,
         pp_layout=None,
@@ -144,18 +146,23 @@ def test_generation_stops_on_any_configured_eos_token() -> None:
     generation_config_cls.from_pretrained.return_value = generation_config
 
     forward = MagicMock()
+    gathered_refs: list[weakref.ReferenceType[torch.Tensor]] = []
 
     def run_forward(**kwargs):
+        if gathered_refs:
+            assert gathered_refs[-1]() is None
         seq_length = kwargs["seq_length"]
         logits = torch.zeros(1, seq_length, 8)
-        next_token = 2 if forward.call_count == 1 else 1
+        next_token = 3 if forward.call_count == 1 else 2
         logits[0, seq_length - 1, next_token] = 1
         return [logits]
 
     forward.side_effect = run_forward
 
-    def all_gather(outputs, tensor, group):
-        outputs[0].copy_(tensor)
+    def gather_last_token_logits(output, real_seq_len):
+        last_token_logits = output[:, real_seq_len - 1].clone()
+        gathered_refs.append(weakref.ref(last_token_logits))
+        return last_token_logits
 
     script_globals = {
         "AutoBridge": SimpleNamespace(from_hf_pretrained=MagicMock(return_value=bridge)),
@@ -165,6 +172,7 @@ def test_generation_stops_on_any_configured_eos_token() -> None:
         "AutoProcessor": SimpleNamespace(from_pretrained=MagicMock(return_value=MagicMock())),
         "AutoTokenizer": SimpleNamespace(from_pretrained=MagicMock(return_value=tokenizer)),
         "GenerationConfig": generation_config_cls,
+        "_gather_last_token_logits": gather_last_token_logits,
         "get_forward_backward_func": MagicMock(return_value=forward),
         "get_last_rank": MagicMock(return_value=0),
         "is_safe_repo": MagicMock(return_value=False),
@@ -178,12 +186,48 @@ def test_generation_stops_on_any_configured_eos_token() -> None:
     with (
         patch.dict(_main.__globals__, script_globals),
         patch.object(torch.Tensor, "cuda", lambda self: self),
-        patch.object(torch.distributed, "all_gather", side_effect=all_gather),
         patch.object(torch.distributed, "broadcast"),
-        patch.object(_main.__globals__["parallel_state"], "get_tensor_model_parallel_group", return_value=None),
-        patch.object(_main.__globals__["parallel_state"], "get_tensor_model_parallel_world_size", return_value=1),
         patch.object(_main.__globals__["parallel_state"], "is_pipeline_last_stage", return_value=True),
     ):
         _main(args)
 
-    assert forward.call_count == 1
+    assert forward.call_count == 2
+    assert all(ref() is None for ref in gathered_refs)
+
+
+@pytest.mark.unit
+def test_generation_gathers_only_last_token_logits() -> None:
+    """TP gathering must not retain or replicate full-prefix logits between steps."""
+    output = torch.arange(1 * 3 * 4, dtype=torch.float32).view(1, 3, 4)
+    output_ref = weakref.ref(output)
+    gathered_refs: list[weakref.ReferenceType[torch.Tensor]] = []
+    gathered_shapes: list[torch.Size] = []
+
+    def fake_all_gather(gathered, local_logits, group):
+        gathered_shapes.append(local_logits.shape)
+        gathered_refs.extend(weakref.ref(tensor) for tensor in gathered)
+        gathered[0].copy_(local_logits)
+        gathered[1].copy_(local_logits + 100)
+
+    with (
+        patch.object(torch.distributed, "all_gather", new=fake_all_gather),
+        patch.object(
+            _gather_last_token_logits.__globals__["parallel_state"],
+            "get_tensor_model_parallel_group",
+            return_value=None,
+        ),
+        patch.object(
+            _gather_last_token_logits.__globals__["parallel_state"],
+            "get_tensor_model_parallel_world_size",
+            return_value=2,
+        ),
+    ):
+        last_token_logits = _gather_last_token_logits(output, real_seq_len=3)
+
+    assert gathered_shapes == [torch.Size([1, 4])]
+    assert torch.equal(last_token_logits, torch.tensor([[8, 9, 10, 11, 108, 109, 110, 111]]))
+    assert all(ref() is None for ref in gathered_refs)
+
+    del output
+    assert output_ref() is None
+    assert torch.equal(last_token_logits[:, :4], torch.tensor([[8, 9, 10, 11]]))

--- a/tests/unit_tests/models/kimi_vl/test_kimi_k25_vl_bridge.py
+++ b/tests/unit_tests/models/kimi_vl/test_kimi_k25_vl_bridge.py
@@ -175,6 +175,10 @@ class TestKimiK25VLBridgeProviderBridge:
         assert provider.moe_router_topk == 8
         assert provider.moe_router_score_function == "sigmoid"
         assert provider.moe_router_enable_expert_bias is True
+        assert provider.moe_token_dispatcher_type == "flex"
+        assert provider.moe_flex_dispatcher_backend == "hybridep"
+        assert provider.moe_flex_dispatcher_num_sms == 16
+        assert provider.moe_permute_fusion_into_hybridep is False
 
     def test_provider_bridge_moe_layer_freq(self, kimi_bridge, mock_hf_pretrained):
         """Test MoE layer frequency computation."""

--- a/tests/unit_tests/recipes/kimi_vl/test_kimi_k25_vl.py
+++ b/tests/unit_tests/recipes/kimi_vl/test_kimi_k25_vl.py
@@ -245,18 +245,20 @@ class TestKimiK25VLSftConfig:
         assert cfg.optimizer.optimizer == "dist_muon"
 
     def test_sft_config_moe_settings(self):
-        """MoE wiring: alltoall dispatcher, deepep flex backend, grouped GEMM on."""
+        """MoE wiring: HybridEP dispatcher with grouped GEMM enabled."""
         cfg = kimi_k25_vl_sft_config()
 
-        assert cfg.model.moe_token_dispatcher_type == "alltoall"
-        assert cfg.model.moe_flex_dispatcher_backend == "deepep"
-        assert cfg.model.moe_hybridep_num_sms == 16
+        assert cfg.model.moe_token_dispatcher_type == "flex"
+        assert cfg.model.moe_flex_dispatcher_backend == "hybridep"
+        assert cfg.model.moe_flex_dispatcher_num_sms == 16
+        assert cfg.model.moe_permute_fusion_into_hybridep is False
         assert cfg.model.moe_router_fusion is False
         assert cfg.model.moe_permute_fusion is True
         assert cfg.model.moe_grouped_gemm is True
         assert cfg.model.moe_router_padding_for_fp8 is False
         assert cfg.model.moe_shared_expert_overlap is True
         assert cfg.model.moe_router_force_load_balancing is False
+        assert cfg.env_vars["NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN"] == 8
 
     def test_sft_config_transformer_engine_and_cuda_graph(self):
         """TE backend with CUDA graphs disabled by default (warmup steps still set)."""

--- a/tests/unit_tests/recipes/kimi_vl/test_kimi_k25_vl.py
+++ b/tests/unit_tests/recipes/kimi_vl/test_kimi_k25_vl.py
@@ -259,6 +259,8 @@ class TestKimiK25VLSftConfig:
         assert cfg.model.moe_shared_expert_overlap is True
         assert cfg.model.moe_router_force_load_balancing is False
         assert cfg.env_vars["NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN"] == 8
+        assert cfg.env_vars["NVLINK_DOMAIN_SIZE"] == 8
+        assert cfg.env_vars["USE_MNNVL"] == 0
 
     def test_sft_config_transformer_engine_and_cuda_graph(self):
         """TE backend with CUDA graphs disabled by default (warmup steps still set)."""


### PR DESCRIPTION
# What does this PR do?

Uses HybridEP for Bridge-created Kimi-K2.5 providers and the public H100 SFT recipe, and reduces temporary tensor-parallel vocabulary-gather memory in the legacy full-prefix VLM generation example.

Related to NVBug 6566459.

# Changes

- Configure the Kimi-K2.5 Bridge mapping to use `flex` / `hybridep`, 16 dispatcher SMs, with HybridEP permutation fusion disabled.
- Apply the same model settings to the 512-H100 SFT recipe and configure an 8-rank HybridEP NVLink domain for H100 nodes.
- Document the inference configuration and update the public Slurm launcher environment.
- Gather tensor-parallel vocabulary shards only for the final real token and release full-prefix logits when they are no longer needed.
- Add focused Bridge, recipe, shape, vocabulary-order, and tensor-lifetime regressions.

The dispatcher choice is owned by `KimiK25VLBridge.provider_bridge`; the generic MLA provider remains unchanged. Native Megatron checkpoints can retain their saved dispatcher setting, so an older checkpoint may require the same overrides when it is loaded.

# Diagnosis and validation status

The unchanged TP2/PP1/EP48 workflow passes on the prior release and fails on the current runtime. A model-independent EP48 round-trip reproducer isolated corruption in the current runtime's reverse variable-split all-to-all path; the resulting non-finite activations cause subsequent routing and expert-buffer growth. The final failed allocation is a symptom of that earlier corruption.

The Bridge-owned logits change avoids gathering unused full-prefix vocabulary logits. For a local output shaped `[batch, prefix, vocab / TP]`, the collective now receives `[batch, vocab / TP]`.

Focused validation on the current commit:

- Kimi-K2.5 Bridge and SFT recipe tests: 55 passed.
- Kimi inference launcher shell syntax: passed.
- Full repository pre-commit hooks: passed.

The Kimi HybridEP mapping has not yet completed a real-model GPU A/B at the original topology. This PR remains Draft and must not be marked ready based on the unit tests alone.

# Before this PR is ready for review

- [x] Root cause isolated below Bridge.
- [x] Bridge and SFT configuration contracts covered by focused tests.
- [x] No MCore source, dependency, CI, or public conversion API changed.
- [ ] Complete bounded one-node HybridEP validation.
- [ ] Complete the original-topology HybridEP inference validation if the one-node result is insufficient.
- [ ] Run bounded finite-loss SFT validation before claiming training support.
