### PR TITLE
cp: `fix(training): include MTP stages in embedding groups (5380)` into `r0.6.0`

### DIFF
--- a/src/megatron/bridge/training/setup.py
+++ b/src/megatron/bridge/training/setup.py
@@ -28,11 +28,14 @@ from megatron.core.optimizer_param_scheduler import OptimizerParamScheduler
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.rerun_state_machine import RerunDataIterator
 from megatron.core.transformer import MegatronModule
+from megatron.core.transformer.multi_token_prediction import get_mtp_ranks
 from megatron.training.models.base import ModelConfig
 
 from megatron.bridge.data.loaders import build_train_valid_test_datasets_for_num_epochs, setup_data_iterators
 from megatron.bridge.models.gpt.gpt_builder import GPTModelConfig
+from megatron.bridge.models.gpt_provider import GPTModelProvider
 from megatron.bridge.models.hybrid.hybrid_builder import HybridModelConfig
+from megatron.bridge.models.hybrid.hybrid_provider import HybridModelProvider
 from megatron.bridge.models.model_provider import ModelProviderMixin
 from megatron.bridge.models.transformer_config import TransformerConfig
 from megatron.bridge.training import fault_tolerance
@@ -62,6 +65,43 @@ from megatron.bridge.training.utils.checkpoint_utils import checkpoint_exists, i
 from megatron.bridge.training.utils.log_utils import append_to_progress_log, barrier_and_log, setup_logging
 from megatron.bridge.training.utils.train_utils import start_memory_history_recording
 from megatron.bridge.utils.common_utils import get_rank_safe, print_rank_0
+
+
+def _get_embedding_ranks(
+    pp_ranks: list[int],
+    pipeline_model_parallel_size: int | None = None,
+    *,
+    model_config: GPTModelConfig | GPTModelProvider | HybridModelConfig | HybridModelProvider,
+) -> list[int]:
+    """Get the embedding ranks for a Bridge language-model config."""
+    # HyperCommGrid passes PP size as a second argument; MCore's MPU path does not.
+    del pipeline_model_parallel_size
+
+    # Keep this rank construction aligned with pretrain_gpt.get_embedding_ranks in MCore.
+    embedding_ranks = [pp_ranks[0]]
+    if len(pp_ranks) > 1:
+        if model_config.share_embeddings_and_output_weights:
+            embedding_ranks.append(pp_ranks[-1])
+        transformer_config = model_config.transformer if hasattr(model_config, "transformer") else model_config
+        mtp_ranks = get_mtp_ranks(pp_ranks, transformer_config)
+        embedding_ranks.extend(mtp_ranks)
+    embedding_ranks = list(set(embedding_ranks))
+    embedding_ranks = sorted(embedding_ranks)
+    return embedding_ranks
+
+
+def _resolve_embedding_ranks_fn(
+    model_config: object,
+    get_embedding_ranks: Callable[[list[int], Optional[int]], list[int]] | None,
+) -> Callable[[list[int], Optional[int]], list[int]] | None:
+    """Use model-aware language-model embedding ranks unless the caller supplied an override."""
+    if get_embedding_ranks is not None:
+        return get_embedding_ranks
+
+    language_model_configs = (GPTModelConfig, GPTModelProvider, HybridModelConfig, HybridModelProvider)
+    if isinstance(model_config, language_model_configs):
+        return partial(_get_embedding_ranks, model_config=model_config)
+    return None
 
 
 class SetupOutput(NamedTuple):
@@ -199,6 +239,8 @@ def setup(
         modules_to_filter=cfg.logger.modules_to_filter,
         set_level_for_all_loggers=cfg.logger.set_level_for_all_loggers,
     )
+
+    get_embedding_ranks = _resolve_embedding_ranks_fn(cfg.model, get_embedding_ranks)
 
     # pg_collection is returned from initialize_megatron:
     # - When use_decentralized_pg=True: uses HyperCommGrid to create local process groups

--- a/tests/unit_tests/training/test_setup.py
+++ b/tests/unit_tests/training/test_setup.py
@@ -18,15 +18,19 @@ from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
+import megatron.bridge.training.setup as training_setup
 from megatron.bridge.data.builders import GPTSFTDatasetConfig
 from megatron.bridge.models.gpt.gpt_builder import GPTModelConfig
 from megatron.bridge.models.gpt_provider import GPTModelProvider
+from megatron.bridge.models.hybrid.hybrid_builder import HybridModelConfig
+from megatron.bridge.models.hybrid.hybrid_provider import HybridModelProvider
 from megatron.bridge.models.transformer_config import TransformerConfig
 from megatron.bridge.training.checkpointing import load_checkpoint
 from megatron.bridge.training.setup import (
     _bind_dataset_provider_context,
     _build_distributed_model,
     _register_pre_wrap_hook,
+    _resolve_embedding_ranks_fn,
     _should_load_checkpoint,
     _update_model_config_funcs,
     _validate_and_set_vocab_size,
@@ -46,6 +50,30 @@ def _make_gpt_model_config(**kwargs):
     defaults = dict(transformer=_make_transformer(**tc_kwargs), vocab_size=32000)
     defaults.update(kwargs)
     return GPTModelConfig(**defaults)
+
+
+def _make_mtp_model_config(model_config_cls, *, share_embeddings_and_output_weights=False):
+    transformer_kwargs = {
+        "hidden_size": 128,
+        "mtp_num_layers": 1,
+        "num_attention_heads": 1,
+        "num_layers": 1,
+        "pipeline_model_parallel_layout": "Et|m|L",
+        "pipeline_model_parallel_size": 3,
+    }
+    if model_config_cls in (GPTModelProvider, HybridModelProvider):
+        model_config = model_config_cls(
+            share_embeddings_and_output_weights=share_embeddings_and_output_weights,
+            **transformer_kwargs,
+        )
+    else:
+        model_config = model_config_cls(
+            share_embeddings_and_output_weights=share_embeddings_and_output_weights,
+            transformer=_make_transformer(**transformer_kwargs),
+            vocab_size=128,
+        )
+    model_config.finalize()
+    return model_config
 
 
 def _make_checkpoint_source_config(
@@ -68,6 +96,64 @@ def _make_checkpoint_source_config(
         peft=peft,
         _checkpoint_load_required=required,
     )
+
+
+@pytest.mark.parametrize(
+    ("share_embeddings_and_output_weights", "expected_ranks"),
+    [(False, [0, 1]), (True, [0, 1, 2])],
+)
+@pytest.mark.parametrize(
+    "model_config_cls",
+    [GPTModelConfig, GPTModelProvider, HybridModelConfig, HybridModelProvider],
+)
+def test_mtp_embedding_group_includes_standalone_mtp_stage(
+    model_config_cls,
+    share_embeddings_and_output_weights,
+    expected_ranks,
+):
+    model_config = _make_mtp_model_config(
+        model_config_cls,
+        share_embeddings_and_output_weights=share_embeddings_and_output_weights,
+    )
+
+    get_embedding_ranks = _resolve_embedding_ranks_fn(model_config, None)
+    explicit_callback = Mock()
+
+    assert get_embedding_ranks is not None
+    assert get_embedding_ranks([0, 1, 2]) == expected_ranks
+    assert _resolve_embedding_ranks_fn(model_config, explicit_callback) is explicit_callback
+
+
+def test_setup_forwards_model_aware_embedding_ranks_to_parallel_initialization():
+    model_config = _make_mtp_model_config(GPTModelProvider)
+    cfg = SimpleNamespace(
+        dist=SimpleNamespace(disable_jit_fuser=False, enable_megatron_core_experimental=False),
+        logger=SimpleNamespace(
+            filter_warnings=False,
+            logging_level="INFO",
+            modules_to_filter=[],
+            set_level_for_all_loggers=False,
+        ),
+        model=model_config,
+    )
+    state = SimpleNamespace(cfg=cfg, initialize_async_checkpoint_worker=Mock())
+    initialize_megatron = Mock(side_effect=RuntimeError("stop after process-group initialization"))
+
+    with (
+        patch.multiple(
+            training_setup,
+            initialize_megatron=initialize_megatron,
+            maybe_log_and_save_config=Mock(),
+            set_experimental_flag=Mock(),
+            setup_logging=Mock(),
+        ),
+        pytest.raises(RuntimeError, match="stop after process-group initialization"),
+    ):
+        training_setup.setup(state, Mock())
+
+    get_embedding_ranks = initialize_megatron.call_args.kwargs["get_embedding_ranks"]
+    assert get_embedding_ranks([0, 1, 2]) == [0, 1]
+    assert get_embedding_ranks([0, 1, 2], 3) == [0, 1]
 
 
 def test_gpt_sft_config_receives_tokenizer_through_builder_binding_without_mutation():


### PR DESCRIPTION
## Summary

Backports #5380 to `r0.6.0` so standalone MTP pipeline stages join the embedding process group used for checkpoint-consistent synchronization.

- Source PR: #5380
- Source commit: `d4dd7a314707128b7e1f5053cc25db0e78c5a8cb`
- Backport method: semantic conflict resolution from an exact `git cherry-pick -x`

## Conflict resolution

Both source files had diverged on the release branch.

- Kept the release-native `FullyShardedDataParallel` import instead of restoring the obsolete source-baseline compatibility fallback.
- Kept the release test module without the obsolete `_register_setup_pre_wrap_hook` and callback imports.
- Restored the module import needed by the source forwarding test because that import existed on the source baseline but not on `r0.6.0`.
- Applied the model-aware GPT/hybrid embedding-rank callback, MTP-rank construction, setup forwarding, and tied/untied coverage unchanged in behavior.

## Semantic diff audit

The source PR touches two files and this backport touches the same two files. No source file or behavior was omitted. The backport has one extra test import required by the release test layout; all other patch differences are release-baseline context described above.

## Tests

- `git diff --check origin/r0.6.0...HEAD`
- `uv run --active --no-sync python -m pytest tests/unit_tests/training/test_setup.py -q` (30 passed in the supported Linux container)
- `uv run --active --no-sync pre-commit run --all-files` (passed in the supported Linux container)

## Residual risk

Focused unit coverage verifies all supported GPT/hybrid config forms, tied and untied standalone-MTP layouts, explicit callback preservation, and setup forwarding. The source three-stage deterministic training reproducer is not added to functional CI because functional tests are limited to two GPUs.