### PR TITLE
cp: `fix: repair release QA regressions (5351)` into `r0.6.0`

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -36,10 +36,13 @@ bridge-tech-details.md
 models/README.md
 models/bailing/index.md
 models/deepseek/index.md
+models/ernie/ernie45.md
+models/exaone/exaone.md
 models/falcon/index.md
 models/gemma/index.md
 models/glm/index.md
 models/gpt_oss/index.md
+models/hy_v3/hy-v3.md
 models/kimi/index.md
 models/llama/index.md
 models/minimax/index.md

--- a/docs/models/README.md
+++ b/docs/models/README.md
@@ -17,10 +17,13 @@ Megatron Bridge conversion, training recipe links, and model-specific notes.
 |----------------|---------------------|
 | **Bailing** | [Ling 2.0](bailing/ling-2.md) |
 | **DeepSeek** | [DeepSeek V2 (deprecated)](deepseek/deepseek-v2.md), [DeepSeek V3](deepseek/deepseek-v3.md), [DeepSeek V4](deepseek/deepseek-v4.md) |
+| **ERNIE** | [ERNIE 4.5 and ERNIE 4.5 VL](ernie/ernie45.md) |
+| **EXAONE** | [EXAONE 4, EXAONE 4.5 VL, and K-EXAONE](exaone/exaone.md) |
 | **Falcon** | [Falcon H1](falcon/falcon-h1.md) |
 | **Gemma** | [Gemma (deprecated)](gemma/gemma.md), [Gemma 2 (deprecated)](gemma/gemma2.md), [Gemma 3](gemma/gemma3.md), [Gemma 3 VL](gemma/gemma3-vl.md), [Gemma 4 VL](gemma/gemma4-vl.md) |
 | **GLM** | [GLM 4.5](glm/glm45.md), [GLM-4.5V](glm/glm-45v.md), [GLM-4.7 / 4.7-Flash](glm/glm47.md), [GLM-5 / 5.1](glm/glm5.md) |
 | **GPT-OSS** | [GPT OSS](gpt_oss/gpt-oss.md) |
+| **HY V3** | [HY V3](hy_v3/hy-v3.md) |
 | **Kimi** | [Kimi K2](kimi/kimi-k2.md), [Kimi-K2.5-VL](kimi/kimi-k25-vl.md) |
 | **Llama** | [Llama 2 (deprecated)](llama/llama2.md), [Llama 3](llama/llama3.md) |
 | **MiniMax** | [MiniMax-M2 / M2.5 / M2.7](minimax/minimax-m2.md), [MiniMax-M3](minimax/minimax-m3.md) |
@@ -65,12 +68,13 @@ Each model documentation page typically includes:
 
 ### Decoder-Only and Hybrid Backbones
 
-- Bailing, DeepSeek, Falcon, Gemma, GLM, GPT-OSS, Kimi, Llama, MiniMax, Mistral, Moonlight, Nemotron, OLMoE, Qwen, Sarvam, StepFun, and Xiaomi-MiMo
+- Bailing, DeepSeek, ERNIE, EXAONE, Falcon, Gemma, GLM, GPT-OSS, HY V3, Kimi, Llama, MiniMax, Mistral, Moonlight, Nemotron, OLMoE, Qwen, Sarvam, StepFun, and Xiaomi-MiMo
 - MoE and hybrid variants including Bailing, DeepSeek, GLM, GPT-OSS, MiniMax, Nemotron-3, OLMoE, Qwen3-MoE, Qwen3-Next, and Sarvam
 
 ### Multimodal Variants
 
 - Gemma 3 VL and Gemma 4 VL
+- ERNIE 4.5 VL and EXAONE 4.5 VL
 - GLM-4.5V
 - Kimi-K2.5-VL
 - Ministral 3

--- a/docs/models/ernie/ernie45.md
+++ b/docs/models/ernie/ernie45.md
@@ -1,0 +1,20 @@
+# ERNIE 4.5
+
+Megatron Bridge registers Hugging Face conversion support for the text-only
+`baidu/ERNIE-4.5-0.3B-PT` MoE model and the
+`baidu/ERNIE-4.5-VL-28B-A3B-Instruct` and `baidu/ERNIE-4.5-VL-28B-A3B-Thinking`
+vision-language MoE models.
+
+Import a text checkpoint with the shared conversion CLI:
+
+```bash
+./scripts/conversion/convert.sh import \
+  --hf-model baidu/ERNIE-4.5-0.3B-PT \
+  --megatron-path /workspace/models/ernie-4.5-0.3b \
+  --trust-remote-code
+```
+
+For ERNIE 4.5 VL import, export, and inference commands, see the
+[checked-in examples](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/examples/models/vlm/ernie_vl).
+The VL bridge supports its modality-specific dual-pool MoE layout; use the
+parallelism settings documented with those examples.

--- a/docs/models/exaone/exaone.md
+++ b/docs/models/exaone/exaone.md
@@ -1,0 +1,18 @@
+# EXAONE
+
+Megatron Bridge supports Hugging Face conversion for EXAONE 4.0 dense language
+models, EXAONE 4.5 vision-language models, and K-EXAONE MoE language models.
+Checked-in H100 recipes cover EXAONE 4.0 1.2B, EXAONE 4.5 VL 33B,
+K-EXAONE-236B-A23B, and K-EXAONE 2.0 750B-A37B.
+
+Use the model-specific examples for commands and supported parallelism:
+
+- [EXAONE 4.0](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/examples/models/exaone/exaone4)
+- [EXAONE 4.5 VL](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/examples/models/exaone/exaone45)
+- [K-EXAONE MoE](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/examples/models/exaone/exaone_moe)
+
+The EXAONE 4.0 and EXAONE 4.5 examples use the shared
+`scripts/conversion/convert.sh import` entry point. The K-EXAONE examples use
+their model-specific distributed round-trip workflows. K-EXAONE 2.0 also has a checked-in
+[model verification card](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/examples/model_verification_cards/k-exaone-2/card.yaml)
+that records the current verification status of individual workflows.

--- a/docs/models/hy_v3/hy-v3.md
+++ b/docs/models/hy_v3/hy-v3.md
@@ -1,0 +1,27 @@
+# HY V3
+
+Megatron Bridge registers Hugging Face checkpoint conversion for the
+`tencent/Hy3-preview-Base` MoE causal language model. The bridge maps HY V3's
+GQA with QK layer normalization, dense-first layer schedule, sigmoid router,
+shared experts, and grouped-GEMM routed experts to Megatron Core.
+
+Import the checkpoint with the shared conversion CLI:
+
+```bash
+./scripts/conversion/convert.sh import \
+  --hf-model tencent/Hy3-preview-Base \
+  --megatron-path /workspace/models/hy3-preview-base \
+  --trust-remote-code
+```
+
+Export a converted checkpoint back to Hugging Face format:
+
+```bash
+./scripts/conversion/convert.sh export \
+  --hf-model tencent/Hy3-preview-Base \
+  --megatron-path /workspace/models/hy3-preview-base/iter_0000000 \
+  --hf-path /workspace/models/hy3-preview-base-hf \
+  --trust-remote-code
+```
+
+No library training recipe is currently exported for HY V3.

--- a/examples/conversion/mfsdp/convert_checkpoints_fsdp.py
+++ b/examples/conversion/mfsdp/convert_checkpoints_fsdp.py
@@ -269,9 +269,9 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--trust-remote-code", action="store_true", help="Allow custom model code execution")
     parser.add_argument(
         "--ckpt-format",
-        choices=["torch_dist", "fsdp_dtensor"],
+        choices=["fsdp_dtensor"],
         default="fsdp_dtensor",
-        help="Megatron checkpoint format to load/save (default: fsdp_dtensor for Megatron-FSDP)",
+        help="Megatron-FSDP checkpoint format (only fsdp_dtensor is supported)",
     )
 
 

--- a/examples/models/exaone/exaone45/README.md
+++ b/examples/models/exaone/exaone45/README.md
@@ -8,7 +8,7 @@ Scripts for [EXAONE-4.5-33B](https://huggingface.co/LGAI-EXAONE/EXAONE-4.5-33B),
 | Architecture | Vision-language model (`Exaone4_5_ForConditionalGeneration`) |
 | Default dtype | BF16 |
 | Default inference parallelism | `TP=4, PP=1, EP=1` |
-| Sequence length in recipes | 8192 |
+| Sequence length in recipes | 4096 |
 
 **Requirements:** use `--trust_remote_code` when loading the Hugging Face checkpoint.
 
@@ -64,26 +64,28 @@ ${WORKSPACE}/models/EXAONE-4.5-33B
 Equivalent direct command:
 
 ```bash
-uv run python examples/conversion/convert_checkpoints.py import \
+./scripts/conversion/convert.sh import \
   --hf-model LGAI-EXAONE/EXAONE-4.5-33B \
-  --megatron-path "${WORKSPACE}/models/EXAONE-4.5-33B"
+  --megatron-path "${WORKSPACE}/models/EXAONE-4.5-33B" \
+  --trust-remote-code
 ```
 
 ## Finetune Recipes
 
 Available recipes:
 
-- `exaone45_vl_sft_config`: Full supervised fine-tuning for EXAONE 4.5 VL.
-- `exaone45_vl_peft_config`: Parameter-efficient fine-tuning with LoRA or DoRA.
+- `exaone45_vl_33b_sft_16gpu_h100_bf16_config`: Full supervised fine-tuning for EXAONE 4.5 VL.
+- `exaone45_vl_33b_peft_4gpu_h100_bf16_config`: Parameter-efficient fine-tuning with LoRA or DoRA.
 
 Recipe defaults:
 
 | Recipe | TP | PP | Notes |
 |---|---:|---:|---|
-| `exaone45_vl_sft_config` | 4 | 1 | Full SFT, sequence parallel enabled |
-| `exaone45_vl_peft_config` | 1 | 1 | PEFT, sequence parallel disabled |
+| `exaone45_vl_33b_sft_16gpu_h100_bf16_config` | 4 | 4 | Full SFT, sequence parallel disabled |
+| `exaone45_vl_33b_peft_4gpu_h100_bf16_config` | 4 | 1 | PEFT, sequence parallel disabled |
 
-The recipes freeze the vision encoder by default (`freeze_vision_model=True`) and keep the language model and vision projection trainable.
+Both recipes train the vision encoder, language model, and vision projection. Their micro batch size is 1, so in-batch
+packing is disabled.
 
 Before training, set the usual runtime environment variables as needed:
 

--- a/examples/models/exaone/exaone45/conversion.sh
+++ b/examples/models/exaone/exaone45/conversion.sh
@@ -17,6 +17,7 @@ set -euo pipefail
 
 WORKSPACE=${WORKSPACE:-/workspace}
 
-uv run python examples/conversion/convert_checkpoints.py import \
+./scripts/conversion/convert.sh import \
     --hf-model LGAI-EXAONE/EXAONE-4.5-33B \
-    --megatron-path "${WORKSPACE}/models/EXAONE-4.5-33B"
+    --megatron-path "${WORKSPACE}/models/EXAONE-4.5-33B" \
+    --trust-remote-code

--- a/examples/models/gemma/gemma4_vl/README.md
+++ b/examples/models/gemma/gemma4_vl/README.md
@@ -157,24 +157,10 @@ We provide a [Weights & Biases report](https://api.wandb.ai/links/nvidia-nemo-fw
 
 ## Evaluation
 
-After training, use [eval_sft_cord_v2.py](eval_sft_cord_v2.py) to verify the fine-tuned checkpoint on CORD-v2. It feeds the full conversation (image + prompt + ground-truth response) through the model in a single forward pass and reports per-example cross-entropy loss, token accuracy, and GT vs. predicted text.
-
-Example invocation (single node, 8 GPUs). Replace `<JOB_ID>` with your training job ID:
-
-```bash
-uv run python -m torch.distributed.run --nproc_per_node=8 \
-  examples/models/gemma/gemma4_vl/eval_sft_cord_v2.py \
-    --hf_model_path google/gemma-4-26B-A4B-it \
-    --megatron_model_path ${WORKSPACE}/results/gemma4_vl_sft_tp2_pp1_ep8_<JOB_ID> \
-    --tp 2 --pp 1 --ep 4 \
-    --num_examples 20
-```
-
-For batch evaluation on Slurm, see [slurm_eval_sft.sh](slurm_eval_sft.sh).
-
-After 100 SFT iterations on CORD-v2, expected teacher-forced token accuracy is ~98%.
-
-> **These scripts run one sample at a time and are intended only as sanity checks of the trained checkpoint.** For production inference, re-export the checkpoint to HF format using the export step in [conversion.sh](conversion.sh) and run with vLLM.
+Use the [Gemma 4 26B-A4B-it model verification
+card](../../../model_verification_cards/gemma-4-26b-a4b-it/card.yaml) as the canonical source for checked-in training,
+export, and deterministic inference evidence. Run only items marked `verified`; an item without a checked-in command is
+not a supported evaluation workflow.
 
 ## LoRA Merge
 

--- a/src/megatron/bridge/recipes/exaone/h100/exaone45.py
+++ b/src/megatron/bridge/recipes/exaone/h100/exaone45.py
@@ -62,6 +62,7 @@ def _apply_exaone45_common(cfg: ConfigContainer) -> None:
 
     cfg.dataset.seq_length = 4096
     cfg.dataset.hf_processor_path = _HF_PATH
+    cfg.dataset.enable_in_batch_packing = False
 
     cfg.ddp.overlap_grad_reduce = False
     cfg.ddp.overlap_param_gather = False

--- a/src/megatron/bridge/recipes/glm_vl/h100/glm_45v.py
+++ b/src/megatron/bridge/recipes/glm_vl/h100/glm_45v.py
@@ -94,6 +94,7 @@ def glm_45v_sft_128gpu_h100_bf16_config() -> ConfigContainer:
     - Sequence length: 8192
     """
     cfg = _sft_common_vlm()
+    cfg.dataset.enable_in_batch_packing = False
 
     # Model configuration
     hf_path = "zai-org/GLM-4.5V"
@@ -244,6 +245,7 @@ def glm_45v_peft_32gpu_h100_bf16_config(peft_scheme: str | PEFT = "lora") -> Con
         peft_scheme: PEFT scheme - "lora", "dora", or a custom PEFT instance.
     """
     cfg = _peft_common_vlm()
+    cfg.dataset.enable_in_batch_packing = False
 
     # PEFT scheme
     if isinstance(peft_scheme, str) and peft_scheme.lower() in ["lora", "dora"]:


### PR DESCRIPTION
## Source

- Source PR: #5351
- Source commit: `fda844ee084448f638317d1221ec90a2f72a33d7`
- Target: `r0.6.0`

## Conflict resolution

The exact landed commit was cherry-picked with `-x`. `docs/models/README.md` conflicted because main already lists model-card content that is not shipped on `r0.6.0`. The backport keeps the release branch's existing GLM names and links and does not add the main-only GLM-5.2 or Kimi-K3 references. It retains #5351's ERNIE, EXAONE, and HY V3 documentation entries.

The Gemma 4 VL evaluation fix applies cleanly and leaves the separate inference-section work in #5319 untouched.

## Semantic diff audit

- Retained all 11 files changed by the source commit.
- No source file was omitted.
- The only content adaptation is the release-specific `docs/models/README.md` resolution described above.
- Preserved the release branch's dependency pins, APIs, file layout, and Megatron-Core submodule.

## Validation

- `git diff --check origin/r0.6.0...HEAD`
- `uv run --active --no-sync python -m pytest tests/unit_tests/recipes/test_glm_45v_recipes.py tests/unit_tests/recipes/test_all_recipe_factories.py -k "glm_45v or exaone45" -q` — 20 passed
- `uv run --active --no-sync python -m py_compile examples/conversion/mfsdp/convert_checkpoints_fsdp.py src/megatron/bridge/recipes/exaone/h100/exaone45.py src/megatron/bridge/recipes/glm_vl/h100/glm_45v.py`
- `bash -n examples/models/exaone/exaone45/conversion.sh`
- Verified the conversion CLI rejects `--ckpt-format torch_dist` and accepts only `fsdp_dtensor`.
- `uv run --active --no-sync pre-commit run --all-files`

The Python and pre-commit checks ran in a supported Linux container.

## Residual risk

No GPU training or checkpoint conversion job was run. The executable changes are limited to offline recipe defaults and argparse validation, both covered by the focused container checks above.
