### PR TITLE
cp: `[models, conversion] fix: verify Step-3.5 model workflows (5334)` into `r0.6.0`

### DIFF
--- a/examples/model_verification_cards/step35-flash/card.yaml
+++ b/examples/model_verification_cards/step35-flash/card.yaml
@@ -1,0 +1,259 @@
+# Agent-readable model verification card.
+# status: unverified | verified | unsupported | not_applicable
+
+title: step35_flash
+summary: >
+  Performance disclaimer: this model has not been performance-tuned; reported
+  timing and throughput metrics are sanity checks, not optimized performance
+  results. This card intentionally limits its current verification scope to
+  model-level conversion, parity, and checkpoint-backed inference for the
+  pinned Step-3.5-Flash checkpoint. Training verification is deferred and no
+  training-support result is claimed by this card. Four model-level conversion
+  items are verified; inference is unverified because the source evidence used
+  a launcher task not shipped on r0.6.0, and manual HF/Megatron logit
+  correlation remains below the required gate.
+verification_index:
+  model_level:
+    verified:
+      - hf_to_megatron_cpu
+      - hf_to_megatron_gpu
+      - megatron_to_hf_cpu
+      - megatron_to_hf_gpu
+    unverified:
+      - manual_forward_pass
+      - inference
+  training:
+    H100:
+      unverified: [pretrain, sft, sft_export_inference, sft_long_context, peft, checkpoint_resume]
+model:
+  hf_id: stepfun-ai/Step-3.5-Flash
+  hf_revision: ab446a3de5e171ea341227e24bb1f090e1b771f7  # pragma: allowlist secret
+  architecture: Step3p5ForCausalLM
+  min_transformers_version: "5.8.1"
+verification_environment:
+  base_container: nvcr.io/nvidia/pytorch:26.04-py3
+  bridge_commit: d5c416c50e60a6fa2ddb4a840d2ff036a08ce864  # pragma: allowlist secret
+
+items:
+  hf_to_megatron_cpu:
+    status: verified
+    precision: bf16
+    bridge_commit: dd0fe603c598d1e031ada0f1af4c5040b237cdef  # pragma: allowlist secret
+    command: >
+      ./scripts/conversion/convert.sh import --executor slurm --device cpu
+      --nodes 1 --hf-model stepfun-ai/Step-3.5-Flash
+      --hf-revision ab446a3de5e171ea341227e24bb1f090e1b771f7
+      --megatron-path work/model-verification/step35-flash/cpu-megatron
+      --torch-dtype bfloat16 --trust-remote-code
+    last_verified: 2026-08-05
+    expected_result: >
+      CPU import completed all mappings for the immutable 44-shard source,
+      constructed 199,997,706,240 parameters, and created iter_0000000. The
+      checkpoint reloaded successfully for CPU export; its subsequent strict
+      audit covered all 804 source tensors.
+
+  hf_to_megatron_gpu:
+    status: verified
+    precision: bf16
+    bridge_commit: dd0fe603c598d1e031ada0f1af4c5040b237cdef  # pragma: allowlist secret
+    command: >
+      ./scripts/conversion/convert.sh import --executor slurm --device gpu
+      --nodes 1 --gpus-per-node 8 --hf-model stepfun-ai/Step-3.5-Flash
+      --hf-revision ab446a3de5e171ea341227e24bb1f090e1b771f7
+      --megatron-path work/model-verification/step35-flash/imported-megatron
+      --torch-dtype bfloat16 --tp 1 --pp 1 --ep 8 --etp 1
+      --distributed-timeout-minutes 110 --trust-remote-code --low-memory-save
+    last_verified: 2026-08-05
+    expected_result: >
+      Distributed import completed at TP1/PP1/EP8/ETP1, constructed
+      33,525,780,480 parameters per rank, and created iter_0000000. The
+      persisted checkpoint then reloaded successfully for both distributed
+      export and checkpoint-backed generation.
+
+  megatron_to_hf_cpu:
+    status: verified
+    precision: bf16
+    command: >
+      ./scripts/conversion/convert.sh export --executor slurm --device cpu
+      --nodes 1 --hf-model stepfun-ai/Step-3.5-Flash
+      --hf-revision ab446a3de5e171ea341227e24bb1f090e1b771f7
+      --megatron-path
+      work/model-verification/step35-flash/cpu-megatron/iter_0000000
+      --hf-path work/model-verification/step35-flash/cpu-hf-export
+      --torch-dtype bfloat16 --trust-remote-code
+    last_verified: 2026-08-05
+    expected_result: >
+      CPU export reloaded the imported checkpoint and wrote 44 indexed BF16
+      shards with all 804 source keys, shapes, and dtypes. Of 398,768,626,944
+      serialized bytes, 395,600,878,848 bytes across 801 tensors matched the
+      immutable source bitwise. The three published MTP output entries occupy
+      3,167,748,096 bytes and were intentionally materialized from Megatron's
+      shared lm_head representation; each exported entry matched lm_head
+      bitwise and used independent safetensors storage. A Transformers reload
+      through the pinned checkpoint's metadata/RoPE compatibility view ignored
+      only the three published inference-unused MTP layers, predicted the same
+      next token as the source (' Paris'), and reached cosine similarity
+      0.997260 with maximum/mean absolute logit differences 1.320312/0.209649.
+
+  megatron_to_hf_gpu:
+    status: verified
+    precision: bf16
+    bridge_commit: 0b5cc0206e77b4d18139c2ff4fc0d353ea260c20  # pragma: allowlist secret
+    command: >
+      ./scripts/conversion/convert.sh export --executor slurm --device gpu
+      --nodes 1 --gpus-per-node 8 --hf-model stepfun-ai/Step-3.5-Flash
+      --hf-revision ab446a3de5e171ea341227e24bb1f090e1b771f7
+      --megatron-path
+      work/model-verification/step35-flash/imported-megatron/iter_0000000
+      --hf-path work/model-verification/step35-flash/hf-export
+      --torch-dtype bfloat16
+      --tp 1 --pp 1 --ep 8 --etp 1 --distributed-timeout-minutes 110
+      --distributed-save --save-every-n-ranks 1 --no-progress
+      --trust-remote-code
+    last_verified: 2026-08-05
+    expected_result: >
+      Distributed export reloaded the TP1/PP1/EP8/ETP1 checkpoint and wrote 44
+      indexed BF16 shards with all 804 source keys, shapes, and dtypes. The
+      exact audit found 801 tensors and 395,600,878,848 bytes bit-identical to
+      the source. Megatron-Core shares the output head with MTP, so the three
+      source MTP output tensors were explicitly normalized to lm_head.weight;
+      all three exported copies matched that tensor bitwise and had independent
+      storage. The generic grouped-expert export path recovered from CUDA stack
+      pressure by moving only the affected merge to CPU. A Transformers reload
+      through the pinned checkpoint's metadata/RoPE compatibility view ignored
+      only the three published inference-unused MTP layers, predicted the same
+      next token as the source (' Paris'), and reached cosine similarity
+      0.997260 with maximum/mean absolute logit differences 1.320312/0.209649.
+
+  manual_forward_pass:
+    status: unverified
+    precision: bf16
+    command: null
+    last_verified: null
+    expected_result: >
+      The 2026-08-05 full-checkpoint attempt used the public model-comparison
+      launcher and memory-bounded pinned-HF reference logits for input IDs
+      [0, 671, 6102, 294, 8760, 344]. Hugging Face and Megatron both predicted
+      token 11111 (' Paris'), but cosine similarity was 0.987008, below the
+      required 0.99 gate; maximum and mean absolute logit differences were
+      4.937500 and 1.064947. Exact weight audits passed, so this remains an
+      unverified runtime-architecture/configuration follow-up rather than a
+      conversion-key mismatch. A future rerun must preserve the next-token
+      match and reach cosine similarity of at least 0.99.
+
+  inference:
+    status: unverified
+    precision: bf16
+    command: null
+    last_verified: null
+    expected_result: >
+      Checkpoint-backed inference must be rerun through a public inference task
+      supported on r0.6.0. The source evidence used the main-only
+      legacy-full-prefix-generation task, so it is not transferred as verified
+      release evidence.
+
+  pretrain:
+    H100:
+      status: unverified
+      precision: bf16
+      enabled_features:
+        context_parallel_size: 8
+        moe_dispatcher: deepep
+      command: null
+      last_verified: null
+      metrics:
+        initial_loss: null
+        final_loss: null
+        last_10_steps_step_time_ms_avg: null
+        last_10_steps_model_tflops_per_gpu_avg: null
+      expected_result: >
+        The public Step-3.5-Flash H100 recipe must complete a bounded 100-step
+        run with finite loss, no skipped or NaN iterations, all four metrics,
+        and a reloadable final checkpoint. Training is deferred by this card.
+
+  sft:
+    H100:
+      status: unverified
+      precision: bf16
+      enabled_features: {}
+      command: null
+      last_verified: null
+      metrics:
+        initial_loss: null
+        final_loss: null
+        last_10_steps_step_time_ms_avg: null
+        last_10_steps_model_tflops_per_gpu_avg: null
+      expected_result: >
+        A pinned-data 100-step full-SFT run must finish with finite loss, no
+        skipped or NaN iterations, all four metrics, and a reloadable final
+        checkpoint. Training is deferred by this card.
+
+  sft_export_inference:
+    H100:
+      status: unverified
+      precision: bf16
+      depends_on: sft
+      commands: null
+      last_verified: null
+      expected_result: >
+        A verified SFT checkpoint must export to Hugging Face, strictly reload,
+        and produce deterministic checkpoint-backed inference. Training and
+        post-SFT export verification are deferred by this card.
+
+  sft_long_context:
+    H100:
+      status: unverified
+      precision: bf16
+      enabled_features: {}
+      command: null
+      last_verified: null
+      metrics:
+        initial_loss: null
+        final_loss: null
+        last_10_steps_step_time_ms_avg: null
+        last_10_steps_model_tflops_per_gpu_avg: null
+      expected_result: >
+        A dedicated packed long-context SFT run must complete 100 steps with
+        finite loss, no skipped or NaN iterations, all four metrics, and a
+        reloadable checkpoint. Training is deferred by this card.
+
+  peft:
+    H100:
+      status: unverified
+      precision: bf16
+      enabled_features: {}
+      command: null
+      last_verified: null
+      metrics:
+        initial_loss: null
+        final_loss: null
+        last_10_steps_step_time_ms_avg: null
+        last_10_steps_model_tflops_per_gpu_avg: null
+      expected_result: >
+        A Step-3.5-Flash PEFT recipe with an audited adapter target set must
+        complete 100 steps with finite loss, all four metrics, and a reloadable
+        adapter checkpoint. Training is deferred by this card.
+
+  checkpoint_resume:
+    H100:
+      status: unverified
+      precision: bf16
+      depends_on: pretrain
+      command: null
+      last_verified: null
+      metrics:
+        initial_loss: null
+        final_loss: null
+        last_10_steps_step_time_ms_avg: null
+        last_10_steps_model_tflops_per_gpu_avg: null
+      resume_comparison:
+        reference_item: pretrain
+        sentinel_steps: [51, 100]
+        loss_relative_tolerance: 1.0e-2
+        loss_absolute_tolerance: 1.0e-6
+        sentinels_match: null
+      expected_result: >
+        A direct continuation must restore model, optimizer, scheduler,
+        data-order, and RNG state, match declared sentinel losses, and save a
+        reloadable checkpoint to a distinct output root. Training is deferred
+        by this card.

--- a/src/megatron/bridge/models/conversion/model_bridge.py
+++ b/src/megatron/bridge/models/conversion/model_bridge.py
@@ -15,6 +15,7 @@
 import abc
 import contextlib
 import fnmatch
+import gc
 import itertools
 import logging
 import math
@@ -979,7 +980,23 @@ class MegatronModelBridge(
             if len(grouped_buffers[group_key]) != num_experts:
                 continue
 
-            merged = torch.stack([grouped_buffers[group_key][i] for i in range(num_experts)], dim=0)
+            grouped_tensors = [grouped_buffers[group_key][i] for i in range(num_experts)]
+            try:
+                merged = torch.stack(grouped_tensors, dim=0)
+            except torch.OutOfMemoryError:
+                if not any(getattr(tensor, "is_cuda", False) for tensor in grouped_tensors):
+                    raise
+                logger.warning(
+                    "Grouped expert export ran out of CUDA memory while stacking %d experts; retrying on CPU.",
+                    num_experts,
+                )
+                cpu_tensors = [tensor.cpu() for tensor in grouped_tensors]
+                del grouped_tensors
+                del grouped_buffers[group_key]
+                gc.collect()
+                if torch.cuda.is_available():
+                    torch.cuda.empty_cache()
+                merged = torch.stack(cpu_tensors, dim=0)
 
             if getattr(task.mapping, "transpose_on_export", False):
                 if group_key in hf_state_dict:
@@ -994,7 +1011,7 @@ class MegatronModelBridge(
                 else:
                     merged = merged.transpose(-1, -2).contiguous()
 
-            del grouped_buffers[group_key]
+            grouped_buffers.pop(group_key, None)
             merged_result[group_key] = merged
 
         return merged_result or None

--- a/src/megatron/bridge/models/hf_pretrained/state.py
+++ b/src/megatron/bridge/models/hf_pretrained/state.py
@@ -80,6 +80,11 @@ def _resolve_output_shard_path(output_path: Path, filename: str) -> Path:
     return output_file_path
 
 
+def _contiguous_safetensors(tensors: Mapping[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+    """Return tensors in the contiguous layout required by safetensors."""
+    return {name: tensor if tensor.is_contiguous() else tensor.contiguous() for name, tensor in tensors.items()}
+
+
 class StateDict(Mapping[str, torch.Tensor]):
     """
     A state dict accessor that provides a unified interface for querying model
@@ -752,7 +757,7 @@ class SafeTensorsStateSource(StateSource):
         if not key_to_filename_map:
             buffered_tensors = dict(generator)
             if buffered_tensors:
-                save_file(buffered_tensors, output_path / "model.safetensors")
+                save_file(_contiguous_safetensors(buffered_tensors), output_path / "model.safetensors")
             return
 
         filename_to_keys_map = defaultdict(set)
@@ -797,7 +802,7 @@ class SafeTensorsStateSource(StateSource):
 
                 output_file_path = _resolve_output_shard_path(output_path, filename)
                 output_file_path.parent.mkdir(parents=True, exist_ok=True)
-                save_file(tensors_to_save, output_file_path)
+                save_file(_contiguous_safetensors(tensors_to_save), output_file_path)
                 total_saved_tensor_bytes += sum(
                     tensor.numel() * tensor.element_size() for tensor in tensors_to_save.values()
                 )
@@ -833,7 +838,7 @@ class SafeTensorsStateSource(StateSource):
                     tensors_to_save = {key: buffered_tensors[key] for key in keys_for_file if key in buffered_tensors}
                     output_file_path = _resolve_output_shard_path(output_path, filename)
                     output_file_path.parent.mkdir(parents=True, exist_ok=True)
-                    save_file(tensors_to_save, output_file_path)
+                    save_file(_contiguous_safetensors(tensors_to_save), output_file_path)
                     total_saved_tensor_bytes += sum(
                         tensor.numel() * tensor.element_size() for tensor in tensors_to_save.values()
                     )
@@ -959,7 +964,7 @@ class SafeTensorsStateSource(StateSource):
             if is_saver_rank and saver_index == 0:
                 buffered_tensors = dict(generator)
                 if buffered_tensors:
-                    save_file(buffered_tensors, output_path / "model.safetensors")
+                    save_file(_contiguous_safetensors(buffered_tensors), output_path / "model.safetensors")
             else:
                 for _ in generator:
                     pass
@@ -1033,7 +1038,7 @@ class SafeTensorsStateSource(StateSource):
                     continue
                 output_file_path = _resolve_output_shard_path(output_path, fname)
                 output_file_path.parent.mkdir(parents=True, exist_ok=True)
-                save_file(tensors_to_save, output_file_path)
+                save_file(_contiguous_safetensors(tensors_to_save), output_file_path)
                 actually_saved_keys.update(tensors_to_save.keys())
                 local_saved_tensor_bytes += sum(
                     tensor.numel() * tensor.element_size() for tensor in tensors_to_save.values()

--- a/src/megatron/bridge/models/stepfun/step35_bridge.py
+++ b/src/megatron/bridge/models/stepfun/step35_bridge.py
@@ -14,7 +14,7 @@
 
 import logging
 from functools import partial
-from typing import Dict
+from typing import Dict, Mapping
 
 import torch
 from megatron.core.models.gpt.gpt_layer_specs import (
@@ -26,7 +26,7 @@ from megatron.core.transformer.transformer_config import TransformerConfig as MC
 from transformers import AutoConfig
 
 from megatron.bridge.models.conversion.mapping_registry import MegatronMappingRegistry
-from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge
+from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge, WeightConversionTask
 from megatron.bridge.models.conversion.param_mapping import (
     AutoMapping,
     GatedMLPMapping,
@@ -213,6 +213,48 @@ class Step35Bridge(MegatronModelBridge):
         ("attention_output_gate", "attention_output_gate"),
         ("layer_types", "layer_types"),
     ]
+
+    def maybe_modify_converted_hf_weight(
+        self,
+        task: WeightConversionTask,
+        converted_weights_dict: Dict[str, torch.Tensor],
+        hf_state_dict: Mapping[str, torch.Tensor],
+    ) -> Dict[str, torch.Tensor]:
+        """Materialize HF MTP output entries from Megatron's shared output layer.
+
+        The published checkpoint serializes a separate output tensor for each
+        MTP layer, although its HF inference implementation ignores those
+        layers. Megatron-Core instead defines MTP with a shared output layer.
+        Export the Megatron representation faithfully by materializing one
+        independent CPU tensor per HF entry from that shared output weight.
+        """
+        converted_weights_dict = super().maybe_modify_converted_hf_weight(
+            task,
+            converted_weights_dict,
+            hf_state_dict,
+        )
+        if self.hf_config is None or "lm_head.weight" not in converted_weights_dict:
+            return converted_weights_dict
+
+        first_mtp_layer = self.hf_config.num_hidden_layers
+        num_mtp_layers = getattr(self.hf_config, "num_nextn_predict_layers", 0)
+        mtp_output_names = [
+            f"model.layers.{first_mtp_layer + offset}.transformer.shared_head.output.weight"
+            for offset in range(num_mtp_layers)
+        ]
+        missing_output_names = [
+            name for name in mtp_output_names if name in hf_state_dict and name not in converted_weights_dict
+        ]
+        if not missing_output_names:
+            return converted_weights_dict
+
+        # Safetensors forbids shared storage. Keep distinct CPU storage for
+        # each entry without adding several gigabytes of peak CUDA memory.
+        output_weight = converted_weights_dict["lm_head.weight"].detach().cpu()
+        converted_weights_dict["lm_head.weight"] = output_weight
+        for name in missing_output_names:
+            converted_weights_dict[name] = output_weight.clone()
+        return converted_weights_dict
 
     def provider_bridge(self, hf_pretrained: PreTrainedCausalLM) -> GPTModelProvider:
         """Convert HuggingFace Step3.5 config to GPTModelProvider.

--- a/tests/unit_tests/models/stepfun/test_step35_bridge.py
+++ b/tests/unit_tests/models/stepfun/test_step35_bridge.py
@@ -675,6 +675,27 @@ class TestStep35BridgeMappingRegistry:
         assert "mtp.layers.0.final_layernorm.weight" in params
 
 
+def test_mtp_output_entries_are_materialized_from_megatron_shared_head():
+    bridge = Step35Bridge()
+    bridge.hf_config = SimpleNamespace(num_hidden_layers=45, num_nextn_predict_layers=3)
+    output_weight = torch.ones(8, 4)
+    expected_output_names = {f"model.layers.{layer}.transformer.shared_head.output.weight" for layer in range(45, 48)}
+    hf_state_dict = {name: torch.zeros_like(output_weight) for name in expected_output_names}
+
+    converted = bridge.maybe_modify_converted_hf_weight(
+        SimpleNamespace(),
+        {"lm_head.weight": output_weight},
+        hf_state_dict,
+    )
+
+    assert converted.keys() == {"lm_head.weight", *expected_output_names}
+    for name in expected_output_names:
+        torch.testing.assert_close(converted[name], output_weight)
+        assert not torch.equal(converted[name], hf_state_dict[name])
+    all_output_names = {"lm_head.weight", *expected_output_names}
+    assert len({converted[name].data_ptr() for name in all_output_names}) == len(all_output_names)
+
+
 # ---------------------------------------------------------------------------
 # StackedExpertAutoMapping / StackedExpertGatedMLPMapping
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/models/test_hf_pretrained_state.py
+++ b/tests/unit_tests/models/test_hf_pretrained_state.py
@@ -148,6 +148,33 @@ def test_save_generator_recomputes_index_total_size(tmp_path, monkeypatch, distr
     assert index_data["metadata"] == {"format": "pt", "total_size": expected_total_size}
 
 
+@pytest.mark.parametrize("distributed_save", [False, True])
+def test_save_generator_materializes_noncontiguous_tensors(tmp_path, monkeypatch, distributed_save: bool) -> None:
+    shard = "model-00001-of-00001.safetensors"
+    _write_safetensors_index(tmp_path, {"model.weight": shard})
+    source = SafeTensorsStateSource(tmp_path)
+    output_path = tmp_path / "output"
+    weight = torch.arange(12, dtype=torch.float32).reshape(3, 4).transpose(0, 1)
+    assert not weight.is_contiguous()
+
+    if distributed_save:
+        monkeypatch.setattr(torch.distributed, "is_available", lambda: True)
+        monkeypatch.setattr(torch.distributed, "is_initialized", lambda: True)
+        monkeypatch.setattr(torch.distributed, "get_world_size", lambda: 1)
+        monkeypatch.setattr(torch.distributed, "get_rank", lambda: 0)
+        monkeypatch.setattr(torch.distributed, "barrier", lambda: None)
+
+        def gather_rank_zero(output: list[object | None], value: object) -> None:
+            output[0] = value
+
+        monkeypatch.setattr(torch.distributed, "all_gather_object", gather_rank_zero)
+
+    source.save_generator(iter([("model.weight", weight)]), output_path, distributed_save=distributed_save)
+
+    with safe_open(output_path / shard, framework="pt", device="cpu") as saved:
+        torch.testing.assert_close(saved.get_tensor("model.weight"), weight)
+
+
 def test_save_generator_writes_shard_as_soon_as_its_remaining_keys_arrive(tmp_path, monkeypatch) -> None:
     class _SubsetForbiddenSet(set[str]):
         def issubset(self, _other: Iterable[object]) -> bool:

--- a/tests/unit_tests/models/test_model_bridge.py
+++ b/tests/unit_tests/models/test_model_bridge.py
@@ -285,6 +285,65 @@ def test_stream_weights_megatron_to_hf_transforms_grouped_tensor_once_after_accu
     ]
 
 
+def test_grouped_export_retries_stack_on_cpu_after_cuda_oom(monkeypatch, caplog):
+    class FakeCudaTensor:
+        is_cuda = True
+
+        def __init__(self, value):
+            self.value = value
+
+        def cpu(self):
+            return torch.tensor([self.value])
+
+    original_stack = torch.stack
+    stack_devices = []
+
+    def stack_with_cuda_oom(tensors, dim=0):
+        stack_devices.append([type(tensor).__name__ for tensor in tensors])
+        if isinstance(tensors[0], FakeCudaTensor):
+            raise torch.OutOfMemoryError("simulated grouped-export CUDA OOM")
+        return original_stack(tensors, dim=dim)
+
+    monkeypatch.setattr(torch, "stack", stack_with_cuda_oom)
+    monkeypatch.setattr(
+        "megatron.bridge.models.conversion.model_bridge.parallel_state.get_expert_model_parallel_world_size",
+        lambda: 1,
+    )
+    mapping = SimpleNamespace(is_grouped_export=True, ep_size=1)
+    model_config = SimpleNamespace(num_moe_experts=2)
+    buffers = {}
+
+    first = MegatronModelBridge._accumulate_grouped_export(
+        None,
+        SimpleNamespace(
+            mapping=mapping,
+            param_name="decoder.layers.0.mlp.experts.linear_fc2.weight0",
+        ),
+        {"hf.grouped": FakeCudaTensor(1.0)},
+        model_config,
+        buffers,
+        {},
+    )
+    with caplog.at_level("WARNING"):
+        second = MegatronModelBridge._accumulate_grouped_export(
+            None,
+            SimpleNamespace(
+                mapping=mapping,
+                param_name="decoder.layers.0.mlp.experts.linear_fc2.weight1",
+            ),
+            {"hf.grouped": FakeCudaTensor(2.0)},
+            model_config,
+            buffers,
+            {},
+        )
+
+    assert first is None
+    torch.testing.assert_close(second["hf.grouped"], torch.tensor([[1.0], [2.0]]))
+    assert stack_devices == [["FakeCudaTensor", "FakeCudaTensor"], ["Tensor", "Tensor"]]
+    assert "retrying on CPU" in caplog.text
+    assert buffers == {}
+
+
 def test_stream_weights_megatron_to_hf_finalizes_exported_tensors_before_cpu(monkeypatch):
     bridge = DummyBridge()
     events = []


### PR DESCRIPTION
## Source

- Source PR: #5334
- Source commit: `86a9ab8fd704f138b91627300a152a35bf3f0716`
- Cherry-picked with `-x` onto `r0.6.0`.

## Conflict resolution and release adaptations

- Preserved the release branch's safetensors writer architecture and wrapped each existing `save_file` boundary with the source change's contiguous-tensor normalization. The unrelated writer refactor present on `main` was not imported.
- Kept the release conversion-test layout and adapted the new tests to its existing single-rank distributed and expert-parallel APIs.
- Retained every source production fix and every source file. No source file was omitted.
- Marked the Step-3.5 inference item unverified on `r0.6.0` and removed its command/result claim. The source evidence uses the `legacy-full-prefix-generation` launcher task, which is not shipped by this release branch; importing that unrelated launcher feature or claiming unsupported release evidence would be incorrect. The four checkpoint-conversion items remain verified as recorded by the source PR.

## Semantic diff audit

The final seven-file release diff preserves the source fixes for contiguous safetensors export, grouped-export CUDA OOM fallback, Step-3.5 router-bias conversion, and their focused tests. Release-only differences are limited to the writer/test API adaptations above and the conservative inference-evidence downgrade.

## Validation

- `uv run --active --no-sync python skills/create-model-verification-card/scripts/validate_card.py examples/model_verification_cards/step35-flash/card.yaml` — passed
- YAML parse — passed
- `uv run --active --no-sync python -m pytest tests/unit_tests/models/test_hf_pretrained_state.py tests/unit_tests/models/test_model_bridge.py tests/unit_tests/models/stepfun/test_step35_bridge.py -q` — 79 passed in a supported Linux container
- `git diff --check origin/r0.6.0...HEAD` — passed
- `uv run --active --no-sync pre-commit run --all-files` — passed in a supported Linux container

## Residual risk

The pinned 200B checkpoint workflows were not rerun for this backport. The source PR's four conversion results remain recorded; release inference is explicitly unverified until it can be rerun through a launcher task supported on `r0.6.0`.
