### PR TITLE
cp: `fix(data): collate ragged packed sequence metadata (5400)` into `r0.6.0`

### DIFF
--- a/src/megatron/bridge/data/packing/gpt_sft.py
+++ b/src/megatron/bridge/data/packing/gpt_sft.py
@@ -277,8 +277,18 @@ class GPTSFTPackedDataset(GPTSFTDataset):
         }
 
         if self.return_cu_seqlen:
-            # Offline packed SFT requires micro-batch size 1, so no sentinel padding is
-            # needed to batch variable-length metadata. Emit MCore/TE field names directly.
+            # The DataLoader collates every row assigned to this data-parallel rank before
+            # the training loop splits that global batch into MBS1 microbatches. Extend the
+            # boundary arrays with zero-length sequences so ragged rows form tensors while
+            # retaining the direct MCore/TE cumulative-offset contract.
+            boundary_batches = [cu_seqlens]
+            if cu_seqlens_padded is not None:
+                boundary_batches.append(cu_seqlens_padded)
+            max_num_boundaries = max(len(boundaries) for rows in boundary_batches for boundaries in rows)
+            for rows in boundary_batches:
+                for boundaries in rows:
+                    boundaries.extend([boundaries[-1]] * (max_num_boundaries - len(boundaries)))
+
             seqlens = torch.IntTensor(cu_seqlens_padded if cu_seqlens_padded is not None else cu_seqlens)
             seqlens = seqlens[:, 1:] - seqlens[:, :-1]
             max_seqlen, _ = seqlens.max(dim=1, keepdim=True)

--- a/tests/unit_tests/data/datasets/test_gpt_sft.py
+++ b/tests/unit_tests/data/datasets/test_gpt_sft.py
@@ -305,6 +305,31 @@ class TestDataGPTSFTPackedDataset:
         ]
         dataset.collate_fn(batch)
 
+    def test_collate_fn_supports_different_sequence_counts(self, tmp_path):
+        """Packed rows with different logical sequence counts collate into one global batch."""
+        dataset, _ = get_gpt_sft(tmp_path, dataset_type="packed")
+        dataset.max_seq_length = 8
+        dataset.pad_seq_length_to_mult = 1
+        batch = [
+            {
+                "input_ids": np.array([10, 11, 12, 13, 20, 21, 22, 23]),
+                "seq_boundaries": [0, 4, 8],
+                "loss_mask": np.ones(8, dtype=np.int64),
+            },
+            {
+                "input_ids": np.array([30, 31, 32, 33, 34, 35, 36, 37]),
+                "seq_boundaries": [0, 8],
+                "loss_mask": np.ones(8, dtype=np.int64),
+            },
+        ]
+
+        processed = dataset.collate_fn(batch)
+
+        assert processed["cu_seqlens_q"].tolist() == [[0, 3, 6, 7], [0, 7, 7, 7]]
+        assert processed["cu_seqlens_kv"].tolist() == processed["cu_seqlens_q"].tolist()
+        assert processed["max_seqlen_q"].tolist() == [[3], [7]]
+        assert processed["max_seqlen_kv"].tolist() == [[3], [7]]
+
     def test_utils_func_packed(self, tmp_path):
         dataset, _ = get_gpt_sft(tmp_path, dataset_type="packed")
 


### PR DESCRIPTION
## Source and stack

- Source PR: #5400
- Source commit: `4e085c1e497158011040e58f4e4d1b62dc7b33c3`
- Cherry-picked with `-x`.
- Stacked base: #5425 (`yuya/cherry-pick-5344-r0.6.0`) at `e8789f1975200558c245c63fd0d1f8aa28c5d849`.
- #5425 is itself stacked on prerequisite #5301, which introduces the GLM-5.2 card and recipes.

This PR must remain above #5425: it fixes the ragged packed-sequence collation regression introduced by source #5344 and must not be applied independently.

## Conflict resolution

The exact source commit applied cleanly atop #5425. There were no content conflicts.

## Semantic diff audit

- Both source files are retained with the exact source behavior.
- The visible two-file diff pads ragged logical and physical cumulative-boundary arrays only for collation, preserving zero-length sequence semantics and the direct MCore/Transformer Engine contract.
- The source regression test is retained unchanged.
- No file, behavior, or test was adapted or omitted, and no prerequisite change is absorbed into this PR's visible diff.

## Validation

- `git diff --check origin/yuya/cherry-pick-5344-r0.6.0...HEAD` — passed
- Direct GLM-5.2 model-card validation — passed
- `uv run --active --no-sync python -m pytest tests/unit_tests/data/datasets/test_gpt_sft.py tests/unit_tests/data/datasets/test_chat_template.py -q` — 69 passed in a supported Linux container
- `uv run --active --no-sync pre-commit run --all-files` — passed in a supported Linux container

## Residual risk

No GPU training run was repeated for this backport. The focused tests exercise different logical sequence counts in one collated global batch and the surrounding packed chat/SFT behavior.
