### PR TITLE
docs(models): link MiMo and StepFun examples

### DIFF
--- a/docs/models/mimo/mimo.md
+++ b/docs/models/mimo/mimo.md
@@ -18,6 +18,7 @@ Megatron Bridge supports Hugging Face checkpoints using the `MiMoForCausalLM` ar
 Checkpoint conversion and text-generation examples for MiMo causal language
 models live under
 [`examples/models/mimo`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/6a706b1c3afab4d21a6f5dd88aa6a75296d33fe2/examples/models/mimo/README.md).
+For MiMo-V2-Flash conversion and inference examples, see the [MiMo-V2-Flash examples README](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/examples/models/mimo_v2_flash/README.md).
 Heterogeneous multimodal training examples live separately under
 [`examples/megatron_mimo`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/examples/megatron_mimo).
 

--- a/docs/models/stepfun/step35.md
+++ b/docs/models/stepfun/step35.md
@@ -17,6 +17,7 @@
 ## Examples
 
 For conversion, inference, pretraining, Slurm launch scripts, and MCore branch notes, see the [Step-3.5-Flash examples README](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/examples/models/stepfun/step35/README.md).
+For Step 3.7 Flash conversion and training examples, see the [Step 3.7 Flash examples README](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/examples/models/stepfun/step37/README.md).
 
 ## Related Implementation
 


### PR DESCRIPTION
## Summary

- complete the two residual documentation coverage gaps identified when QA reverified PR #5351 for NVBug 6565236
- link the MiMo-V2-Flash examples README from the MiMo model guide
- link the Step 3.7 Flash examples README from the StepFun family guide

This is a documentation-only follow-up to PR #5351. It does not add or restore broad documentation inventory tests or model and recipe count assertions.

## Validation

- confirmed both linked README files exist on main and both GitHub URLs return HTTP 200
- focused repository link check on the two changed pages: 12 links checked, 0 errors
- uv run --active --no-sync pre-commit run --all-files

## Tracking

- NVBug 6565236
- Follow-up to PR #5351