### PR TITLE
docs(model): add Nemotron 3.5 Lightning release entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 </div>
 
 ## 📣 News
+- [08/11/2026] **NVIDIA Nemotron 3.5 Lightning is released!** See the [Nemotron 3.5 Lightning README](https://github.com/NVIDIA-NeMo/RL/blob/main/docs/guides/nemotron-3.5-lightning.md) for details.
+
 - [07/31/2026] **[K-EXAONE-2](https://huggingface.co/LGAI-EXAONE/K-EXAONE-2.0-750B-A37B) is now supported**! Day-0 support for LG AI Research's K-EXAONE-2 (750B-A37B MoE) is now available on the [k-exaone-2 branch](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/k-exaone-2). Users can convert checkpoints, run inference, fine-tune with SFT or PEFT (LoRA), and use the NVFP4 inference-optimized checkpoint released alongside the model. See the branch documentation for setup instructions and examples.
 
 - [07/17/2026] [**LongStraw (MinT-2M)**](https://github.com/MindLab-Research/longstraw) is a long-context RL research system from MindLab Research that uses Megatron Bridge's modeling and LoRA capabilities. LongStraw explores resident-prefix, response-only GRPO by capturing a shared prompt once and replaying only the trainable response branches, and reports a 2.1M-token GLM-5.2 execution path across 32 NVIDIA H20 GPUs. The broader MinT system behind this work was also used to post-train [**Macaron-V1-Preview**](https://macaron.im/mindlab/research/macaron-v1-preview), MindLab's 749B Mixture-of-LoRA agent model derived from GLM-5.1. Learn more in the [paper](https://arxiv.org/abs/2607.14952).

--- a/examples/models/nemotron/nemotron_3/README.md
+++ b/examples/models/nemotron/nemotron_3/README.md
@@ -1,5 +1,16 @@
 # Nemotron 3 Examples
 
+## Nemotron 3.5 Lightning
+
+Day-0 support for Nemotron 3.5 Lightning is available through the
+`nvcr.io/nvidia/nemo:26.06.01` container plus the
+[custom Megatron Bridge 0.5.1 branch and release README](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/nemotron-3.5-lightning-mb-0.5.1/examples/models/nemotron/nemotron_3_5_lightning/README.md).
+The model will also be supported in the `nvcr.io/nvidia/nemo:26.08` container.
+
+See the
+[Nemotron 3.5 Lightning model verification card](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/examples/model_verification_cards/nemotron-3.5-lightning/card.yaml)
+for verification scripts and results.
+
 This directory contains example scripts for Nemotron 3 language models:
 
 | Model | Parameters | Active Parameters | Subdirectory |

--- a/examples/models/nemotron/nemotron_3/README.md
+++ b/examples/models/nemotron/nemotron_3/README.md
@@ -1,21 +1,11 @@
 # Nemotron 3 Examples
 
-## Nemotron 3.5 Lightning
-
-Day-0 support for Nemotron 3.5 Lightning is available through the
-`nvcr.io/nvidia/nemo:26.06.01` container plus the
-[custom Megatron Bridge 0.5.1 branch and release README](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/nemotron-3.5-lightning-mb-0.5.1/examples/models/nemotron/nemotron_3_5_lightning/README.md).
-The model will also be supported in the `nvcr.io/nvidia/nemo:26.08` container.
-
-See the
-[Nemotron 3.5 Lightning model verification card](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/examples/model_verification_cards/nemotron-3.5-lightning/card.yaml)
-for verification scripts and results.
-
 This directory contains example scripts for Nemotron 3 language models:
 
 | Model | Parameters | Active Parameters | Subdirectory |
 |-------|-----------|-------------------|--------------|
 | Nemotron 3 Nano | 30B | A3B | [nano/](nano/) |
+| Nemotron 3.5 Lightning | 30B | A3B | [lightning/](lightning/) |
 | Nemotron 3 Super | 120B | A12B | [super/](super/) |
 | Nemotron 3 Ultra | 550B | A55B | [ultra/](ultra/) |
 

--- a/examples/models/nemotron/nemotron_3/lightning/README.md
+++ b/examples/models/nemotron/nemotron_3/lightning/README.md
@@ -1,0 +1,16 @@
+# Nemotron 3.5 Lightning
+
+Nemotron 3.5 Lightning uses the same architecture as Nemotron 3 Nano, but its
+checkpoint was trained natively with multi-token prediction (MTP).
+
+Day-0 support for Nemotron 3.5 Lightning is available through the
+`nvcr.io/nvidia/nemo:26.06.01` container plus the
+[custom Megatron Bridge 0.5.1 branch and release README](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/nemotron-3.5-lightning-mb-0.5.1/examples/models/nemotron/nemotron_3_5_lightning/README.md).
+The model is also available on the
+[`main`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main) and
+[`r0.6.0`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/r0.6.0)
+branches through the `nvcr.io/nvidia/nemo:26.08` container.
+
+See the
+[Nemotron 3.5 Lightning model verification card](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/examples/model_verification_cards/nemotron-3.5-lightning/card.yaml)
+for verification scripts and results.


### PR DESCRIPTION
## Summary

- add a concise Nemotron 3.5 Lightning release entry point under `examples/models/nemotron/nemotron_3/lightning/`
- add only a Lightning table row to the parent Nemotron 3 examples README
- document the shared Nemotron 3 Nano architecture, native MTP training, and support paths for the 26.06.01 and 26.08 containers
- link the 0.5.1 custom-branch release guide and main verification card
- announce the August 11 release in the root README and link the NeMo RL guide

## Validation

- `uv run --active --no-sync pre-commit run --all-files` in `nvcr.io/nvidia/nemo:26.06.01`
- verified that the custom-branch README, `main`, `r0.6.0`, verification card, and NeMo RL guide links resolve
