### PR TITLE
feat(data): blend several sources on the direct-HF SFT path

### DIFF
--- a/docs/fern/versions/nightly/pages/training/data-preparation.mdx
+++ b/docs/fern/versions/nightly/pages/training/data-preparation.mdx
@@ -191,6 +191,28 @@ dataset.preprocessing = PromptCompletionSFTPreprocessingConfig(
 
 Structured multi-turn rows require chat preprocessing; Bridge does not silently flatten them into prompt-completion text.
 
+To train on several sources at once, pass a list to `source`. Each entry in `source_weights` is an epoch count for its source: `1.0` keeps every row once, `2.5` keeps every row twice plus half of them again, and `0.5` keeps half of them. Fractional passes draw without replacement and round up to a whole row. Omitting the weights gives every source one pass.
+
+```python
+from megatron.bridge.data.builders import DirectHFSFTDatasetConfig, HFDatasetSourceConfig
+
+dataset = DirectHFSFTDatasetConfig(
+    seq_length=4096,
+    source=[
+        HFDatasetSourceConfig(dataset_name="squad"),
+        HFDatasetSourceConfig(dataset_name="gsm8k"),
+    ],
+    source_weights=[1.0, 2.0],
+    blend_seed=1234,
+    validation_source=HFDatasetSourceConfig(dataset_name="squad", split="validation"),
+    do_test=False,
+)
+```
+
+Sources are adapted to canonical SFT rows before mixing, so their raw column layouts do not have to match. A single source still derives its own validation and test splits; a list has no single split to derive from, so set `validation_source` and `test_source` explicitly or disable those splits.
+
+Weights count rows, not tokens. SFT rows vary in length, so sources with equal row counts can still contribute very different token counts.
+
 Known semantic datasets should use their preset name, for example `squad`, `gsm8k`, `openmathinstruct2`, `cord_v2`, `raven`, `rdr`, `medpix`, `cv17`, or `llava_video_178k`. Do not combine `dataset_name` with `path_or_dataset`, `subset`, or `schema_adapter`; a preset owns those coupled fields. `split`, `load_kwargs`, and `adapter_kwargs` remain available for split selection and declarative runtime options such as a video root. Presets validate published split support: `raven`, `rdr`, and `llava_video_178k` are train-only; `medpix` and `squad` have no test split; `gsm8k` has no validation split; and OpenMathInstruct-2 exposes training variants only. Disable unsupported derived validation/test splits or supply explicit compatible sources.
 
 For text chat, `hf_processor_path=None` reuses the training tokenizer only when that tokenizer already defines the intended chat template. Otherwise select a vocabulary-compatible instruction processor explicitly, as above.

--- a/docs/training/data-preparation.md
+++ b/docs/training/data-preparation.md
@@ -189,6 +189,28 @@ dataset.preprocessing = PromptCompletionSFTPreprocessingConfig(
 
 Structured multi-turn rows require chat preprocessing; Bridge does not silently flatten them into prompt-completion text.
 
+To train on several sources at once, pass a list to `source`. Each entry in `source_weights` is an epoch count for its source: `1.0` keeps every row once, `2.5` keeps every row twice plus half of them again, and `0.5` keeps half of them. Fractional passes draw without replacement. Omitting the weights gives every source one pass.
+
+```python
+from megatron.bridge.data.builders import DirectHFSFTDatasetConfig, HFDatasetSourceConfig
+
+dataset = DirectHFSFTDatasetConfig(
+    seq_length=4096,
+    source=[
+        HFDatasetSourceConfig(dataset_name="squad"),
+        HFDatasetSourceConfig(dataset_name="gsm8k"),
+    ],
+    source_weights=[1.0, 2.0],
+    blend_seed=1234,
+    validation_source=HFDatasetSourceConfig(dataset_name="squad", split="validation"),
+    do_test=False,
+)
+```
+
+Sources are adapted to canonical SFT rows before mixing, so their raw column layouts do not have to match. A single source still derives its own validation and test splits; a list has no single split to derive from, so set `validation_source` and `test_source` explicitly or disable those splits.
+
+Weights count rows, not tokens. SFT rows vary in length, so sources with equal row counts can still contribute very different token counts.
+
 Known semantic datasets should use their preset name, for example `squad`, `gsm8k`, `openmathinstruct2`, `cord_v2`, `raven`, `rdr`, `medpix`, `cv17`, or `llava_video_178k`. Do not combine `dataset_name` with `path_or_dataset`, `subset`, or `schema_adapter`; a preset owns those coupled fields. `split`, `load_kwargs`, and `adapter_kwargs` remain available for split selection and declarative runtime options such as a video root. Presets validate published split support: `raven`, `rdr`, and `llava_video_178k` are train-only; `medpix` and `squad` have no test split; `gsm8k` has no validation split; and OpenMathInstruct-2 exposes training variants only. Disable unsupported derived validation/test splits or supply explicit compatible sources.
 
 For text chat, `hf_processor_path=None` reuses the training tokenizer only when that tokenizer already defines the intended chat template. Otherwise select a vocabulary-compatible instruction processor explicitly, as above.

--- a/docs/training/data-preparation.md
+++ b/docs/training/data-preparation.md
@@ -189,7 +189,7 @@ dataset.preprocessing = PromptCompletionSFTPreprocessingConfig(
 
 Structured multi-turn rows require chat preprocessing; Bridge does not silently flatten them into prompt-completion text.
 
-To train on several sources at once, pass a list to `source`. Each entry in `source_weights` is an epoch count for its source: `1.0` keeps every row once, `2.5` keeps every row twice plus half of them again, and `0.5` keeps half of them. Fractional passes draw without replacement. Omitting the weights gives every source one pass.
+To train on several sources at once, pass a list to `source`. Each entry in `source_weights` is an epoch count for its source: `1.0` keeps every row once, `2.5` keeps every row twice plus half of them again, and `0.5` keeps half of them. Fractional passes draw without replacement and round up to a whole row. Omitting the weights gives every source one pass.
 
 ```python
 from megatron.bridge.data.builders import DirectHFSFTDatasetConfig, HFDatasetSourceConfig

--- a/src/megatron/bridge/data/builders/direct_hf_sft.py
+++ b/src/megatron/bridge/data/builders/direct_hf_sft.py
@@ -15,7 +15,7 @@
 """Serializable config and runtime builder for direct Hugging Face SFT."""
 
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from functools import partial
 from typing import Any, Literal
@@ -40,7 +40,9 @@ from megatron.bridge.data.sources.hf import (
     HFDatasetSourceConfig,
     hf_dataset_supports_split,
     load_and_adapt_hf_dataset,
+    load_and_blend_hf_datasets,
     prepare_hf_dataset_sources,
+    resolve_blend_weights,
 )
 from megatron.bridge.models.hf_pretrained.utils import is_safe_repo
 from megatron.bridge.training.tokenizers.tokenizer import MegatronTokenizer
@@ -51,6 +53,13 @@ logger = logging.getLogger(__name__)
 CollateFunction = Callable[..., dict[str, torch.Tensor]]
 
 
+def _as_source(entry: "HFDatasetSourceConfig | Mapping[str, Any]") -> HFDatasetSourceConfig:
+    """Rebuild a source that an override round trip flattened into a mapping."""
+    if isinstance(entry, HFDatasetSourceConfig):
+        return entry
+    return HFDatasetSourceConfig(**dict(entry))
+
+
 @dataclass(kw_only=True)
 class DirectHFSFTDatasetConfig(DataloaderConfig):
     """Serializable configuration for direct Hugging Face SFT datasets.
@@ -58,10 +67,15 @@ class DirectHFSFTDatasetConfig(DataloaderConfig):
     Chat preprocessing is the compatibility default for multimodal and
     conversation sources. New text recipes should select chat or paired-text
     preprocessing explicitly.
+
+    ``source`` takes one source or a list of them. A list blends the training
+    rows across the sources, weighted by ``source_weights``.
     """
 
     seq_length: int
-    source: HFDatasetSourceConfig
+    source: HFDatasetSourceConfig | list[HFDatasetSourceConfig]
+    source_weights: list[float] | None = None
+    blend_seed: int = 1234
     validation_source: HFDatasetSourceConfig | None = None
     test_source: HFDatasetSourceConfig | None = None
     preprocessing: SFTPreprocessingConfig = field(default_factory=ChatSFTPreprocessingConfig)
@@ -82,7 +96,7 @@ class DirectHFSFTDatasetConfig(DataloaderConfig):
         if self.seq_length <= 0:
             raise ValueError("seq_length must be greater than 0.")
         validate_sft_preprocessing_config(self.preprocessing)
-        self.source.validate()
+        self._validate_sources()
         if self.do_validation and self.validation_source is not None:
             self._inherit_source_adapter_kwargs(self.validation_source)
             self.validation_source.validate()
@@ -101,12 +115,50 @@ class DirectHFSFTDatasetConfig(DataloaderConfig):
         if self.in_batch_packing_pad_to_multiple_of <= 0:
             raise ValueError("in_batch_packing_pad_to_multiple_of must be greater than 0.")
 
+    @property
+    def training_sources(self) -> list[HFDatasetSourceConfig]:
+        """The sources the training rows are drawn from, blended or not."""
+        return list(self.source) if isinstance(self.source, list) else [self.source]
+
+    @property
+    def split_source(self) -> HFDatasetSourceConfig | None:
+        """The source that derives validation and test splits, if one is unambiguous."""
+        sources = self.training_sources
+        return sources[0] if len(sources) == 1 else None
+
+    def _validate_sources(self) -> None:
+        """Validate the training sources and any blend weights."""
+        # Any override re-serializes this config through OmegaConf, which returns
+        # dataclasses as plain mappings even when the override targeted another field.
+        if isinstance(self.source, list):
+            self.source = [_as_source(entry) for entry in self.source]
+        else:
+            self.source = _as_source(self.source)
+
+        sources = self.training_sources
+        if isinstance(self.source, list) or self.source_weights is not None:
+            resolve_blend_weights(sources, self.source_weights)
+        for entry in sources:
+            entry.validate()
+
+        if len(sources) > 1:
+            for name, split_source in (
+                ("validation_source", self.validation_source),
+                ("test_source", self.test_source),
+            ):
+                enabled = self.do_validation if name == "validation_source" else self.do_test
+                if enabled and split_source is None:
+                    raise ValueError(
+                        f"A blended source has no single split to derive from; set {name} or disable that split."
+                    )
+
     def _inherit_source_adapter_kwargs(self, split_source: HFDatasetSourceConfig) -> None:
         """Fill unset adapter arguments on another split of the training source."""
-        if split_source.dataset_name != self.source.dataset_name or not self.source.adapter_kwargs:
+        source = self.split_source
+        if source is None or split_source.dataset_name != source.dataset_name or not source.adapter_kwargs:
             return
         split_adapter_kwargs = dict(split_source.adapter_kwargs or {})
-        for key, value in self.source.adapter_kwargs.items():
+        for key, value in source.adapter_kwargs.items():
             if split_adapter_kwargs.get(key) is None:
                 split_adapter_kwargs[key] = value
         split_source.adapter_kwargs = split_adapter_kwargs
@@ -197,6 +249,15 @@ def select_direct_hf_sft_collate(
     raise ValueError("Prompt-completion preprocessing supports text-only examples.")
 
 
+def load_direct_hf_sft_train_examples(config: DirectHFSFTDatasetConfig) -> list[dict[str, Any]]:
+    """Load the training rows, blending them when the config names several sources."""
+    sources = config.training_sources
+    if len(sources) == 1 and config.source_weights is None:
+        return load_direct_hf_sft_examples(sources[0], config.preprocessing)
+    rows = load_and_blend_hf_datasets(sources, config.source_weights, seed=config.blend_seed)
+    return normalize_sft_examples(rows, config.preprocessing)
+
+
 def build_direct_hf_sft_split(
     config: DirectHFSFTDatasetConfig,
     source: HFDatasetSourceConfig,
@@ -204,13 +265,15 @@ def build_direct_hf_sft_split(
     processor: Any,
     *,
     collate_impl: CollateFunction | None = None,
+    examples: list[dict[str, Any]] | None = None,
 ) -> DirectSFTDataset | None:
     """Build one requested direct-HF SFT split."""
     if target_length <= 0:
         return None
     from megatron.bridge.data.collators.registry import model_collate_required_for_all_examples
 
-    examples = load_direct_hf_sft_examples(source, config.preprocessing)
+    if examples is None:
+        examples = load_direct_hf_sft_examples(source, config.preprocessing)
     if collate_impl is None and model_collate_required_for_all_examples(type(processor).__name__):
         if not isinstance(config.preprocessing, ChatSFTPreprocessingConfig):
             raise ValueError(
@@ -256,7 +319,7 @@ class DirectHFSFTDatasetBuilder:
             self.config.do_validation
             and context.valid_samples > 0
             and self.config.validation_source is None
-            and not hf_dataset_supports_split(self.config.source, "validation")
+            and not hf_dataset_supports_split(self.config.split_source, "validation")
         ):
             raise ValueError(
                 "The selected Hugging Face source has no validation split; disable validation or set one."
@@ -265,14 +328,19 @@ class DirectHFSFTDatasetBuilder:
             self.config.do_test
             and context.test_samples > 0
             and self.config.test_source is None
-            and not hf_dataset_supports_split(self.config.source, "test")
+            and not hf_dataset_supports_split(self.config.split_source, "test")
         ):
             raise ValueError("The selected Hugging Face source has no test split; disable test or set one.")
-        validation_source = self.config.validation_source or self.config.source.with_split("validation")
-        test_source = self.config.test_source or self.config.source.with_split("test")
+        split_source = self.config.split_source
+        validation_source = self.config.validation_source or (
+            split_source.with_split("validation") if split_source is not None else None
+        )
+        test_source = self.config.test_source or (
+            split_source.with_split("test") if split_source is not None else None
+        )
         requested_sources = []
         if context.train_samples > 0:
-            requested_sources.append(self.config.source)
+            requested_sources.extend(self.config.training_sources)
         if self.config.do_validation and context.valid_samples > 0:
             requested_sources.append(validation_source)
         if self.config.do_test and context.test_samples > 0:
@@ -287,12 +355,14 @@ class DirectHFSFTDatasetBuilder:
             and getattr(context.tokenizer, "library", None) in {"sentencepiece", "tiktoken"}
         ):
             processor = normalize_direct_hf_sft_processor(context.tokenizer)
+        train_examples = load_direct_hf_sft_train_examples(self.config) if context.train_samples > 0 else None
         train_dataset = build_direct_hf_sft_split(
             self.config,
-            self.config.source,
+            self.config.training_sources[0],
             context.train_samples,
             processor,
             collate_impl=self._collate_impl,
+            examples=train_examples,
         )
         valid_dataset = (
             build_direct_hf_sft_split(

--- a/src/megatron/bridge/data/builders/direct_hf_sft.py
+++ b/src/megatron/bridge/data/builders/direct_hf_sft.py
@@ -97,6 +97,10 @@ class DirectHFSFTDatasetConfig(DataloaderConfig):
             raise ValueError("seq_length must be greater than 0.")
         validate_sft_preprocessing_config(self.preprocessing)
         self._validate_sources()
+        if self.validation_source is not None:
+            self.validation_source = _as_source(self.validation_source)
+        if self.test_source is not None:
+            self.test_source = _as_source(self.test_source)
         if self.do_validation and self.validation_source is not None:
             self._inherit_source_adapter_kwargs(self.validation_source)
             self.validation_source.validate()
@@ -138,6 +142,10 @@ class DirectHFSFTDatasetConfig(DataloaderConfig):
         sources = self.training_sources
         if isinstance(self.source, list) or self.source_weights is not None:
             resolve_blend_weights(sources, self.source_weights)
+            # random.Random(None) reseeds from system entropy, so an unset seed
+            # would give every rank and every rebuild a different blend order.
+            if not isinstance(self.blend_seed, int) or isinstance(self.blend_seed, bool):
+                raise ValueError(f"blend_seed must be an integer, got {self.blend_seed!r}.")
         for entry in sources:
             entry.validate()
 

--- a/src/megatron/bridge/data/sources/hf.py
+++ b/src/megatron/bridge/data/sources/hf.py
@@ -14,6 +14,7 @@
 
 """Declarative Hugging Face sources, named presets, and shared normalization."""
 
+import math
 import random
 from collections.abc import Sequence
 from dataclasses import dataclass, replace
@@ -342,7 +343,7 @@ def resolve_blend_weights(
 
     Raises:
         ValueError: If no source is given, if the counts disagree, or if a weight
-            is not positive.
+            is not a positive finite number.
     """
     if not sources:
         raise ValueError("A blend must name at least one source.")
@@ -350,10 +351,16 @@ def resolve_blend_weights(
         return [1.0] * len(sources)
     if len(weights) != len(sources):
         raise ValueError(f"Blend sources and weights must be equal in number, got {len(sources)} and {len(weights)}.")
+
+    resolved = []
     for weight in weights:
-        if weight <= 0:
-            raise ValueError(f"Blend weights must be positive, got {weight}.")
-    return [float(weight) for weight in weights]
+        # NaN and infinity pass every comparison below, so they are rejected by
+        # kind rather than by range.
+        value = float(weight)
+        if not math.isfinite(value) or value <= 0:
+            raise ValueError(f"Blend weights must be positive finite numbers, got {weight}.")
+        resolved.append(value)
+    return resolved
 
 
 def blend_sft_rows(
@@ -366,7 +373,8 @@ def blend_sft_rows(
 
     A weight is how many passes the blend takes over a source: ``1.0`` keeps
     every row once, ``2.5`` keeps every row twice plus half of them again, and
-    ``0.5`` keeps half of them. Fractional passes draw without replacement.
+    ``0.5`` keeps half of them. Fractional passes draw without replacement and
+    round up to a whole row, so a positive weight always keeps at least one.
 
     Weights count rows, not tokens. SFT rows vary in length, so equal row counts
     do not make equal token counts.
@@ -390,7 +398,9 @@ def blend_sft_rows(
         full_passes = int(weight)
         for _ in range(full_passes):
             blended.extend(rows)
-        remainder = round(len(rows) * (weight - full_passes))
+        # Rounding up rather than to nearest, so a positive weight always draws
+        # something. A share below half a row would otherwise drop the source.
+        remainder = math.ceil(len(rows) * (weight - full_passes))
         if remainder:
             blended.extend(rng.sample(list(rows), remainder))
 

--- a/src/megatron/bridge/data/sources/hf.py
+++ b/src/megatron/bridge/data/sources/hf.py
@@ -14,6 +14,7 @@
 
 """Declarative Hugging Face sources, named presets, and shared normalization."""
 
+import random
 from collections.abc import Sequence
 from dataclasses import dataclass, replace
 from pathlib import Path
@@ -324,3 +325,98 @@ def load_and_adapt_hf_dataset(source: HFDatasetSourceConfig) -> list[dict[str, A
         adapter_name=resolved.schema_adapter,
         adapter_kwargs=resolved.adapter_kwargs,
     )
+
+
+def resolve_blend_weights(
+    sources: Sequence[HFDatasetSourceConfig],
+    weights: Sequence[float] | None,
+) -> list[float]:
+    """Validate blend weights against their sources and fill in the uniform default.
+
+    Args:
+        sources: The sources taking part in the blend.
+        weights: One positive weight per source, or None for equal weights.
+
+    Returns:
+        One weight per source.
+
+    Raises:
+        ValueError: If no source is given, if the counts disagree, or if a weight
+            is not positive.
+    """
+    if not sources:
+        raise ValueError("A blend must name at least one source.")
+    if weights is None:
+        return [1.0] * len(sources)
+    if len(weights) != len(sources):
+        raise ValueError(f"Blend sources and weights must be equal in number, got {len(sources)} and {len(weights)}.")
+    for weight in weights:
+        if weight <= 0:
+            raise ValueError(f"Blend weights must be positive, got {weight}.")
+    return [float(weight) for weight in weights]
+
+
+def blend_sft_rows(
+    rows_per_source: Sequence[Sequence[dict[str, Any]]],
+    weights: Sequence[float],
+    *,
+    seed: int,
+) -> list[dict[str, Any]]:
+    """Draw rows from several sources under per-source epoch counts.
+
+    A weight is how many passes the blend takes over a source: ``1.0`` keeps
+    every row once, ``2.5`` keeps every row twice plus half of them again, and
+    ``0.5`` keeps half of them. Fractional passes draw without replacement.
+
+    Weights count rows, not tokens. SFT rows vary in length, so equal row counts
+    do not make equal token counts.
+
+    Args:
+        rows_per_source: Canonical SFT rows for each source of the blend.
+        weights: One positive weight per source.
+        seed: Seeds the fractional draws and the shuffle that interleaves sources.
+
+    Returns:
+        The blended rows, holding references to the rows that were passed in.
+
+    Raises:
+        ValueError: If a source contributed no rows.
+    """
+    rng = random.Random(seed)
+    blended: list[dict[str, Any]] = []
+    for index, (rows, weight) in enumerate(zip(rows_per_source, weights)):
+        if not rows:
+            raise ValueError(f"Blend source {index} produced no rows.")
+        full_passes = int(weight)
+        for _ in range(full_passes):
+            blended.extend(rows)
+        remainder = round(len(rows) * (weight - full_passes))
+        if remainder:
+            blended.extend(rng.sample(list(rows), remainder))
+
+    rng.shuffle(blended)
+    return blended
+
+
+def load_and_blend_hf_datasets(
+    sources: Sequence[HFDatasetSourceConfig],
+    weights: Sequence[float] | None,
+    *,
+    seed: int,
+) -> list[dict[str, Any]]:
+    """Load several Hugging Face splits and mix them under per-source epoch counts.
+
+    Each source is adapted to canonical SFT rows first, so sources with unrelated
+    column layouts can be blended as long as they share a schema adapter target.
+
+    Args:
+        sources: The sources taking part in the blend.
+        weights: One positive weight per source, or None for one pass each.
+        seed: Seeds the fractional draws and the shuffle that interleaves sources.
+
+    Returns:
+        The blended canonical SFT rows.
+    """
+    resolved_weights = resolve_blend_weights(sources, weights)
+    rows_per_source = [load_and_adapt_hf_dataset(source) for source in sources]
+    return blend_sft_rows(rows_per_source, resolved_weights, seed=seed)

--- a/tests/functional_tests/test_groups/training/test_sft.py
+++ b/tests/functional_tests/test_groups/training/test_sft.py
@@ -181,6 +181,67 @@ class TestSupervisedFinetuning:
             clear_directories(shared_base_dir)
 
     @pytest.mark.run_only_on("GPU")
+    def test_direct_hf_blended_sources_training_step(self, tmp_path):
+        """Run one GPT training step over a weighted blend of two direct-HF sources."""
+        initialize_distributed()
+        shared_base_dir = broadcast_path(tmp_path)
+        checkpoint_dir, tensorboard_dir, _, _ = self._setup_directories(shared_base_dir)
+        first_path = os.path.join(shared_base_dir, "blend-a.jsonl")
+        second_path = os.path.join(shared_base_dir, "blend-b.jsonl")
+
+        if torch.distributed.get_rank() == 0:
+            # NullTokenizer reads whitespace-separated integers, so the sources are
+            # told apart by disjoint number ranges rather than by a text label.
+            for path, offset, rows in ((first_path, 0, 8), (second_path, 100, 4)):
+                with open(path, "w", encoding="utf-8") as output_file:
+                    for index in range(rows):
+                        value = offset + index
+                        record = {"input": f"{value} {value}", "output": str(value + 1)}
+                        output_file.write(json.dumps(record) + "\n")
+        torch.distributed.barrier()
+
+        try:
+            config = self._create_config(1, checkpoint_dir, tensorboard_dir, seq_length=16)
+            config.model.vocab_size = 1024
+            config.train.global_batch_size = 4
+            config.train.micro_batch_size = 2
+            config.tokenizer = TokenizerConfig(tokenizer_type="NullTokenizer", vocab_size=1024)
+            config.dataset = DirectHFSFTDatasetConfig(
+                seq_length=16,
+                source=[
+                    HFDatasetSourceConfig(
+                        path_or_dataset="json",
+                        load_kwargs={"data_files": {"train": first_path}},
+                    ),
+                    HFDatasetSourceConfig(
+                        path_or_dataset="json",
+                        load_kwargs={"data_files": {"train": second_path}},
+                    ),
+                ],
+                source_weights=[1.0, 3.0],
+                preprocessing=PromptCompletionSFTPreprocessingConfig(
+                    prompt_column="input",
+                    completion_column="output",
+                ),
+                do_validation=False,
+                do_test=False,
+                enable_in_batch_packing=True,
+                pad_to_multiple_of=1,
+                num_workers=0,
+                persistent_workers=False,
+            )
+
+            pretrain(config, forward_step)
+            verify_checkpoint_files(
+                checkpoint_dir,
+                1,
+                ckpt_format=config.checkpoint.ckpt_format,
+                storage_writers_per_rank=config.checkpoint.storage_writers_per_rank,
+            )
+        finally:
+            clear_directories(shared_base_dir)
+
+    @pytest.mark.run_only_on("GPU")
     def test_direct_hf_non_packed_context_parallel_training_step(self, tmp_path):
         """Run direct-HF dynamic padding through a two-rank context-parallel step."""
         initialize_distributed()

--- a/tests/unit_tests/data/builders/test_direct_hf_sft_blend.py
+++ b/tests/unit_tests/data/builders/test_direct_hf_sft_blend.py
@@ -41,6 +41,8 @@ def _row(tag, index):
 
 
 def _config(source, weights=None, **kwargs):
+    kwargs.setdefault("do_validation", False)
+    kwargs.setdefault("do_test", False)
     return DirectHFSFTDatasetConfig(
         seq_length=16,
         source=source,
@@ -49,8 +51,6 @@ def _config(source, weights=None, **kwargs):
             prompt_column="prompt",
             completion_column="completion",
         ),
-        do_validation=False,
-        do_test=False,
         pad_to_multiple_of=1,
         **kwargs,
     )
@@ -142,3 +142,37 @@ def test_blend_survives_an_unrelated_cli_override():
     assert config.seq_length == 32
     assert all(isinstance(entry, HFDatasetSourceConfig) for entry in config.source)
     assert [entry.dataset_name for entry in config.source] == ["squad", "gsm8k"]
+
+
+@pytest.mark.parametrize("seed", [None, 1.5, "1234", True])
+def test_config_rejects_a_non_integer_blend_seed(seed):
+    # random.Random(None) reseeds from entropy, so ranks would disagree on order.
+    with pytest.raises(ValueError, match="blend_seed must be an integer"):
+        _config(_blend(), [1.0, 2.0], blend_seed=seed).validate()
+
+
+def test_config_rejects_a_non_finite_blend_weight():
+    with pytest.raises(ValueError, match="positive finite"):
+        _config(_blend(), [1.0, float("nan")]).validate()
+
+
+def test_blend_introduced_by_override_keeps_split_sources_usable():
+    # A scalar-source config gains a blend through Hydra, and the split sources
+    # the blend now requires arrive in the same override as plain mappings.
+    config = _config(HFDatasetSourceConfig(dataset_name="squad"), do_validation=True, do_test=True)
+
+    process_config_with_overrides(
+        config,
+        cli_overrides=[
+            "~source",
+            "+source=[{dataset_name: squad}, {dataset_name: gsm8k}]",
+            "+validation_source={dataset_name: squad, split: validation}",
+            "+test_source={dataset_name: gsm8k, split: test}",
+        ],
+    )
+    config.validate()
+
+    assert [entry.dataset_name for entry in config.source] == ["squad", "gsm8k"]
+    assert isinstance(config.validation_source, HFDatasetSourceConfig)
+    assert isinstance(config.test_source, HFDatasetSourceConfig)
+    assert config.validation_source.split == "validation"

--- a/tests/unit_tests/data/builders/test_direct_hf_sft_blend.py
+++ b/tests/unit_tests/data/builders/test_direct_hf_sft_blend.py
@@ -1,0 +1,144 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+
+from collections import Counter
+
+import pytest
+from megatron.training.config.instantiate_utils import instantiate
+
+from megatron.bridge.data.base import DatasetBuildContext
+from megatron.bridge.data.builders import (
+    DirectHFSFTDatasetBuilder,
+    DirectHFSFTDatasetConfig,
+    HFDatasetSourceConfig,
+    PromptCompletionSFTPreprocessingConfig,
+)
+from megatron.bridge.data.builders import direct_hf_sft as builder_module
+from megatron.bridge.data.sources import hf as hf_sources
+from megatron.bridge.training.config import ConfigContainer
+from megatron.bridge.training.utils.omegaconf_utils import process_config_with_overrides
+
+
+pytestmark = pytest.mark.unit
+
+
+class _Tokenizer:
+    added_tokens_decoder = {}
+    pad_token_id = 0
+    eos_token_id = 3
+
+
+def _rows_by_dataset(rows_by_name):
+    """Serve a distinct row list per dataset preset name."""
+
+    def _load(source):
+        return rows_by_name[source.dataset_name]
+
+    return _load
+
+
+def _row(tag, index):
+    return {"prompt": f"{tag} question {index}", "completion": f"answer {index}"}
+
+
+def _config(source, weights=None, **kwargs):
+    return DirectHFSFTDatasetConfig(
+        seq_length=16,
+        source=source,
+        source_weights=weights,
+        preprocessing=PromptCompletionSFTPreprocessingConfig(
+            prompt_column="prompt",
+            completion_column="completion",
+        ),
+        do_validation=False,
+        do_test=False,
+        pad_to_multiple_of=1,
+        **kwargs,
+    )
+
+
+def _blend():
+    return [HFDatasetSourceConfig(dataset_name="squad"), HFDatasetSourceConfig(dataset_name="gsm8k")]
+
+
+def test_builder_draws_training_rows_from_every_blend_source(monkeypatch):
+    monkeypatch.setattr(
+        hf_sources,
+        "load_and_adapt_hf_dataset",
+        _rows_by_dataset(
+            {"squad": [_row("squad", i) for i in range(4)], "gsm8k": [_row("gsm8k", i) for i in range(4)]}
+        ),
+    )
+    config = _config(_blend(), [1.0, 3.0])
+
+    train, validation, test = DirectHFSFTDatasetBuilder(config).build(
+        DatasetBuildContext(16, 0, 0, tokenizer=_Tokenizer())
+    )
+
+    # Weights are epoch counts: squad contributes its 4 rows once, gsm8k three times.
+    tags = Counter(train[index]["prompt"].split()[0] for index in range(16))
+    assert tags == {"gsm8k": 12, "squad": 4}
+    assert (validation, test) == (None, None)
+
+
+def test_builder_without_a_blend_reads_the_single_source(monkeypatch):
+    # The single-source path resolves the loader through the builder module.
+    monkeypatch.setattr(builder_module, "load_and_adapt_hf_dataset", _rows_by_dataset({"squad": [_row("squad", 0)]}))
+    config = _config(HFDatasetSourceConfig(dataset_name="squad"))
+
+    train, _, _ = DirectHFSFTDatasetBuilder(config).build(DatasetBuildContext(2, 0, 0, tokenizer=_Tokenizer()))
+
+    assert train[0]["prompt"].startswith("squad")
+
+
+def test_config_rejects_a_weight_count_that_does_not_match(monkeypatch):
+    with pytest.raises(ValueError, match="equal in number"):
+        _config(_blend(), [1.0]).validate()
+
+
+def test_config_rejects_a_non_positive_weight():
+    with pytest.raises(ValueError, match="must be positive"):
+        _config(_blend(), [1.0, 0.0]).validate()
+
+
+def test_config_rejects_an_empty_blend():
+    with pytest.raises(ValueError, match="at least one source"):
+        _config([]).validate()
+
+
+def test_config_validates_every_blend_source():
+    with pytest.raises(ValueError, match="Unknown Hugging Face dataset preset"):
+        _config([HFDatasetSourceConfig(dataset_name="not-a-preset")]).validate()
+
+
+def test_blend_config_round_trip_is_declarative():
+    config = _config(_blend(), [1.0, 2.0], blend_seed=7)
+
+    restored = instantiate(ConfigContainer._convert_value_to_dict(config))
+
+    assert isinstance(restored, DirectHFSFTDatasetConfig)
+    assert [entry.dataset_name for entry in restored.source] == ["squad", "gsm8k"]
+    assert restored.source_weights == [1.0, 2.0]
+    assert restored.blend_seed == 7
+    restored.validate()
+
+
+def test_blend_weights_can_be_supplied_by_cli_override():
+    config = _config(_blend(), [1.0, 1.0])
+
+    process_config_with_overrides(config, cli_overrides=["source_weights=[1.0,4.0]"])
+    config.validate()
+
+    assert config.source_weights == [1.0, 4.0]
+
+
+def test_blend_survives_an_unrelated_cli_override():
+    # Any override re-serializes the whole config, so the blend has to come back
+    # as source configs even when the override never mentions it.
+    config = _config(_blend(), [1.0, 2.0])
+
+    process_config_with_overrides(config, cli_overrides=["seq_length=32"])
+    config.validate()
+
+    assert config.seq_length == 32
+    assert all(isinstance(entry, HFDatasetSourceConfig) for entry in config.source)
+    assert [entry.dataset_name for entry in config.source] == ["squad", "gsm8k"]

--- a/tests/unit_tests/data/sources/test_hf_blend.py
+++ b/tests/unit_tests/data/sources/test_hf_blend.py
@@ -113,3 +113,38 @@ def test_blended_rows_are_not_copied():
     blended = blend_sft_rows([rows], [1.0], seed=1234)
 
     assert all(any(row is original for original in rows) for row in blended)
+
+
+@pytest.mark.parametrize("weight", [float("nan"), float("inf"), float("-inf")])
+def test_non_finite_weights_are_rejected(weight):
+    # NaN and infinity pass a plain `<= 0` check, so they need a kind check.
+    sources = [HFDatasetSourceConfig(dataset_name="squad")]
+
+    with pytest.raises(ValueError, match="positive finite"):
+        resolve_blend_weights(sources, [weight])
+
+
+def test_a_positive_weight_keeps_a_row_even_when_its_share_is_under_one():
+    # Half a row of a one-row source still has to keep that source present.
+    blended = blend_sft_rows([_rows("a", 1)], [0.5], seed=1234)
+
+    assert len(blended) == 1
+
+
+def test_a_small_share_of_a_large_source_keeps_one_row():
+    blended = blend_sft_rows([_rows("a", 100)], [0.004], seed=1234)
+
+    assert len(blended) == 1
+
+
+def test_a_source_with_a_sub_row_share_does_not_vanish_from_a_blend():
+    blended = blend_sft_rows([_rows("a", 40), _rows("b", 1)], [1.0, 0.5], seed=1234)
+
+    assert _tags(blended) == {"a": 40, "b": 1}
+
+
+def test_a_fractional_share_rounds_up_to_a_whole_row():
+    # 100 * 0.333 is 33.3, and a partial row cannot be drawn.
+    blended = blend_sft_rows([_rows("a", 100)], [0.333], seed=1234)
+
+    assert len(blended) == 34

--- a/tests/unit_tests/data/sources/test_hf_blend.py
+++ b/tests/unit_tests/data/sources/test_hf_blend.py
@@ -1,0 +1,115 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+
+from collections import Counter
+
+import pytest
+
+from megatron.bridge.data.sources.hf import (
+    HFDatasetSourceConfig,
+    blend_sft_rows,
+    resolve_blend_weights,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+def _rows(tag, count):
+    return [{"prompt": f"{tag}{index}", "completion": str(index)} for index in range(count)]
+
+
+def _tags(rows):
+    return Counter(row["prompt"][0] for row in rows)
+
+
+def test_weights_default_to_uniform():
+    sources = [HFDatasetSourceConfig(dataset_name="squad"), HFDatasetSourceConfig(dataset_name="gsm8k")]
+
+    assert resolve_blend_weights(sources, None) == [1.0, 1.0]
+
+
+def test_weights_must_match_the_source_count():
+    sources = [HFDatasetSourceConfig(dataset_name="squad")]
+
+    with pytest.raises(ValueError, match="equal in number"):
+        resolve_blend_weights(sources, [1.0, 2.0])
+
+
+def test_weights_must_be_positive():
+    sources = [HFDatasetSourceConfig(dataset_name="squad")]
+
+    with pytest.raises(ValueError, match="must be positive"):
+        resolve_blend_weights(sources, [0.0])
+
+
+def test_a_blend_needs_a_source():
+    with pytest.raises(ValueError, match="at least one source"):
+        resolve_blend_weights([], None)
+
+
+def test_a_weight_of_one_keeps_every_row_once():
+    blended = blend_sft_rows([_rows("a", 50), _rows("b", 20)], [1.0, 1.0], seed=1234)
+
+    assert _tags(blended) == {"a": 50, "b": 20}
+
+
+def test_a_whole_weight_repeats_the_source():
+    blended = blend_sft_rows([_rows("a", 10), _rows("b", 10)], [1.0, 3.0], seed=1234)
+
+    assert _tags(blended) == {"a": 10, "b": 30}
+    # Repeats are copies of the same rows, not new ones.
+    assert len({row["prompt"] for row in blended if row["prompt"].startswith("b")}) == 10
+
+
+def test_a_fractional_weight_draws_a_subset_without_replacement():
+    blended = blend_sft_rows([_rows("a", 100)], [0.25], seed=1234)
+
+    assert len(blended) == 25
+    assert len({row["prompt"] for row in blended}) == 25
+
+
+def test_a_mixed_weight_repeats_then_draws_the_remainder():
+    blended = blend_sft_rows([_rows("a", 40)], [2.5], seed=1234)
+
+    assert len(blended) == 100
+    counts = Counter(row["prompt"] for row in blended)
+    assert set(counts.values()) == {2, 3}
+
+
+def test_blend_size_follows_the_data_not_the_schedule():
+    # Epoch counts bound the pool by the sources, so a long run cycles the pool
+    # instead of materializing one row per training sample.
+    blended = blend_sft_rows([_rows("a", 30), _rows("b", 30)], [1.0, 2.0], seed=1234)
+
+    assert len(blended) == 30 + 60
+
+
+def test_blend_is_deterministic_for_a_seed():
+    args = ([_rows("a", 60), _rows("b", 40)], [1.0, 2.0])
+
+    first = blend_sft_rows(*args, seed=7)
+    same = blend_sft_rows(*args, seed=7)
+    other = blend_sft_rows(*args, seed=8)
+
+    assert [row["prompt"] for row in first] == [row["prompt"] for row in same]
+    assert [row["prompt"] for row in first] != [row["prompt"] for row in other]
+    assert _tags(first) == _tags(other)
+
+
+def test_sources_are_interleaved_rather_than_concatenated():
+    blended = blend_sft_rows([_rows("a", 100), _rows("b", 100)], [1.0, 1.0], seed=1234)
+
+    assert {row["prompt"][0] for row in blended[:20]} == {"a", "b"}
+
+
+def test_an_empty_source_is_rejected():
+    with pytest.raises(ValueError, match="produced no rows"):
+        blend_sft_rows([_rows("a", 4), []], [1.0, 1.0], seed=1234)
+
+
+def test_blended_rows_are_not_copied():
+    rows = _rows("a", 4)
+
+    blended = blend_sft_rows([rows], [1.0], seed=1234)
+
+    assert all(any(row is original for original in rows) for row in blended)


### PR DESCRIPTION
# What does this PR do ?

Let the direct Hugging Face SFT path draw its training rows from several sources at once, so a training mixture no longer has to be prepared outside Bridge.

# Changelog

- Let `DirectHFSFTDatasetConfig.source` take a list of sources as well as a single one, following the same shape as `GPTDatasetConfig.data_path`. A list blends the training rows.
- Add `source_weights` and `blend_seed`. Each weight is an epoch count for its source and defaults to one pass each.
- Add `resolve_blend_weights`, `blend_sft_rows`, and `load_and_blend_hf_datasets` to `data/sources/hf.py`, alongside the existing source loading helpers.
- Mix sources after they are adapted to canonical SFT rows, so sources whose raw column layouts differ can be blended when their schema adapters agree.
- Require explicit `validation_source` and `test_source` when several sources are given, since a blend has no single source to derive those splits from. A single source is unchanged.
- Add unit coverage for the blend arithmetic and the config surface, and a single-GPU functional training step over a blend.
- Document the field and its weight semantics in the data preparation guide.

## Weight semantics

Weights are epoch counts over each source: `1.0` keeps every row once, `2.5` keeps every row twice plus half of them again, and `0.5` keeps half of them, drawn without replacement.

They count rows, not tokens. A Megatron pretraining blend can read its weights as token shares because every sample it draws is `sequence_length` tokens, but SFT rows vary in length, so a row share is not a token share. A token-share blend needs fixed-size units and would have to follow per-source packing, which the direct Hugging Face path does not have yet.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

Local validation in the 26.04 container:

- `python -m pytest tests/unit_tests/data/builders tests/unit_tests/data/sources` gives 175 passed, covering the new cases plus the existing builder and source suites.
- `torchrun --nproc_per_node=1 -m pytest tests/functional_tests/test_groups/training/test_sft.py -k blended_sources` gives 1 passed, running one optimizer step over a two-source blend on a single GPU.
- `ruff check` and `ruff format --check` are clean.

The new cases cover the weight arithmetic, seed determinism, source interleaving, validation errors, and the config surface through serialization and CLI overrides.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

# Additional Information

- No new dependencies. The blend uses `random` from the standard library.
- Existing configs are unaffected: a single `source` keeps its current behavior, including validation and test derivation.
- Possible follow-up: once the direct Hugging Face path can pack per source, a token-share blend becomes expressible and would match the Megatron blend semantics more closely.
