### PR TITLE
[training, data] fix: Enable packed PP shapes for builder configs

### DIFF
--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -1231,7 +1231,8 @@ class ConfigContainer(Container):
         # Propagate in-batch packing flag to model config so TransformerConfig.finalize()
         # can enable variable_seq_lengths for pipeline parallelism.
         if enable_in_batch_packing:
-            self.model._enable_in_batch_packing = True
+            transformer_config = getattr(self.model, "transformer", self.model)
+            transformer_config._enable_in_batch_packing = True
             if hasattr(self.dataset, "in_batch_packing_pad_to_multiple_of"):
                 self.dataset.in_batch_packing_pad_to_multiple_of = collate_padding_multiple
         elif isinstance(

--- a/tests/unit_tests/training/test_config.py
+++ b/tests/unit_tests/training/test_config.py
@@ -28,9 +28,11 @@ from megatron.bridge.data.builders import (
     HFEnergonTaskEncoderConfig,
     MockVLMSFTDatasetConfig,
 )
+from megatron.bridge.models.gpt.model_config import BridgeGPTModelConfig
 from megatron.bridge.models.gpt_provider import GPTModelProvider
 from megatron.bridge.models.mla_provider import MLAModelProvider
 from megatron.bridge.models.t5_provider import T5ModelProvider
+from megatron.bridge.models.transformer_config import TransformerConfig
 from megatron.bridge.training.comm_overlap import CommOverlapConfig
 from megatron.bridge.training.config import (
     CheckpointConfig,
@@ -1084,6 +1086,37 @@ class TestConfigContainerValidation:
 
         try:
             container.validate()  # Should pass without error
+        finally:
+            restore_get_world_size_safe(og_ws, cfg_mod)
+
+    def test_in_batch_packing_enables_variable_pp_shapes_for_builder_model(self, monkeypatch):
+        """Test builder-backed GPT configs use dynamic PP shapes for packed batches."""
+        model_cfg = BridgeGPTModelConfig(
+            transformer=TransformerConfig(
+                num_layers=2,
+                hidden_size=128,
+                num_attention_heads=4,
+                ffn_hidden_size=256,
+                pipeline_model_parallel_size=2,
+                use_cpu_initialization=True,
+            ),
+            vocab_size=256,
+            seq_length=512,
+        )
+        train_cfg = create_test_training_config(micro_batch_size=2, global_batch_size=8)
+        dataset_cfg = create_test_direct_hf_sft_dataset_config(sequence_length=512)
+        dataset_cfg.enable_in_batch_packing = True
+
+        container, og_ws, cfg_mod = create_test_config_container(
+            world_size_override=2,
+            model_config=model_cfg,
+            train_config=train_cfg,
+            dataset_config_override=dataset_cfg,
+        )
+
+        try:
+            container.validate()
+            assert model_cfg.transformer.variable_seq_lengths is True
         finally:
             restore_get_world_size_safe(og_ws, cfg_mod)
 


### PR DESCRIPTION
## Summary

Builder-backed GPT configs can leave pipeline communication in static-shape
mode when Direct-HF in-batch packing is enabled. Propagate the packing marker
to the nested transformer config that owns `variable_seq_lengths`, while
preserving the legacy direct-config path.

## Supported trigger and impact

The trigger is a builder-backed GPT/Llama model config with:

- Direct-HF `enable_in_batch_packing=True`
- micro batch size greater than one
- pipeline model parallel size greater than one

Packed collation emits one physical row whose token width varies with the
logical examples. Before this change, validation stored the packing marker on
the outer `BridgeGPTModelConfig`, but nested `TransformerConfig.finalize()` was
its only consumer. The nested config therefore retained
`variable_seq_lengths=False`, and pipeline stages used configured static tensor
shapes instead of exchanging the packed activation's actual shape. Depending
on token counts, that can fail, stall, or reinterpret the packed sequence and
batch dimensions incorrectly.

## Fix

Resolve the transformer's actual config owner before setting the packing
marker. Configs without a nested transformer retain the existing behavior.
A focused regression test covers normal container validation for the
builder-backed ownership boundary.

## Validation

Fail before, pass after:

- `uv run --active --no-sync python -m pytest tests/unit_tests/training/test_config.py::TestConfigContainerValidation::test_in_batch_packing_enables_variable_pp_shapes_for_builder_model -q --tb=short`
  - before: failed because the nested transformer's `variable_seq_lengths` was false
  - after: 1 passed
- `uv run --active --no-sync python -m torch.distributed.run --standalone --nproc_per_node=2 reproduce_pp_shape.py`
  - before: failed after normal `ConfigContainer.validate()` left packed PP communication in static-shape mode
  - after: passed real two-rank NCCL communication and received the sender's dynamic packed shape

Adjacent checks:

- `uv run --active --no-sync python -m pytest tests/unit_tests/training/test_config.py -q --tb=short`: 249 passed
- `git diff --check`: passed
- `uv run --active --no-sync pre-commit run --all-files`: all hooks passed

## Scope

No dependency, workflow, public API, lockfile, or Megatron-Core changes. This
does not claim full-suite, convergence, model-quality, or performance
validation.
