### PR TITLE
[model] fix: Preserve consecutive Gemma4 global layers

### DIFF
--- a/src/megatron/bridge/models/gemma/gemma3_provider.py
+++ b/src/megatron/bridge/models/gemma/gemma3_provider.py
@@ -351,4 +351,5 @@ def _is_local_attn_layer(
     layer_pattern: Tuple[int, int],
 ) -> bool:
     pattern_size = sum(layer_pattern)
-    return layer_number % pattern_size != 0
+    local_layer_count = layer_pattern[0]
+    return (layer_number - 1) % pattern_size < local_layer_count

--- a/tests/unit_tests/models/gemma/test_gemma3_provider.py
+++ b/tests/unit_tests/models/gemma/test_gemma3_provider.py
@@ -220,11 +220,9 @@ class TestGemma3UtilityFunctions:
         for i in range(1, 4):
             assert _is_local_attn_layer(i, pattern) is True
 
-        # Layer 4: 4 % 5 = 4, should be local (True)
-        assert _is_local_attn_layer(4, pattern) is True
-
-        # Layer 5: 5 % 5 = 0, should be global (False)
-        assert _is_local_attn_layer(5, pattern) is False
+        # Layers 4-5: the two global layers in the pattern
+        for i in range(4, 6):
+            assert _is_local_attn_layer(i, pattern) is False
 
 
 class TestGemma3CustomComponents:

--- a/tests/unit_tests/models/gemma/test_gemma4_bridge.py
+++ b/tests/unit_tests/models/gemma/test_gemma4_bridge.py
@@ -23,6 +23,7 @@ from transformers import Gemma4TextConfig
 
 from megatron.bridge.models.conversion.mapping_registry import MegatronMappingRegistry
 from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge
+from megatron.bridge.models.gemma.gemma3_provider import _is_local_attn_layer
 from megatron.bridge.models.gemma.gemma4_bridge import (
     Gemma4Bridge,
     _infer_attn_pattern,
@@ -188,6 +189,21 @@ class TestGemma4BridgeProviderBridgeMoE:
 
     def test_interleaved_attn_pattern(self, bridge, mock_pretrained_moe):
         assert bridge.provider_bridge(mock_pretrained_moe).interleaved_attn_pattern == (5, 1)
+
+    def test_runtime_preserves_consecutive_full_attention_layers(self, bridge, mock_pretrained_moe):
+        layer_types = ["sliding_attention"] * 3 + ["full_attention"] * 2
+        mock_pretrained_moe.config.num_hidden_layers = len(layer_types)
+        mock_pretrained_moe.config.layer_types = layer_types
+
+        provider = bridge.provider_bridge(mock_pretrained_moe)
+        runtime_layer_types = [
+            "sliding_attention"
+            if _is_local_attn_layer(layer_number, provider.interleaved_attn_pattern)
+            else "full_attention"
+            for layer_number in range(1, provider.num_layers + 1)
+        ]
+
+        assert runtime_layer_types == layer_types
 
     def test_logit_softcapping(self, bridge, mock_pretrained_moe):
         assert bridge.provider_bridge(mock_pretrained_moe).final_logit_softcapping == 30.0


### PR DESCRIPTION
## What changed

Gemma 4 MoE accepts per-layer attention schedules with consecutive full-attention layers. For example, three sliding layers followed by two full layers are represented by `interleaved_attn_pattern=(3, 2)`.

The shared runtime classifier previously used only the sum of that tuple, so it marked layer 4 as sliding and layer 5 as full. Gemma 4 uses this classification for attention head dimensions, masks, RoPE, windowing, K/V handling, and checkpoint partitioning. With different local/global head dimensions, conversion can fail on the incorrectly constructed layer; otherwise training silently uses the wrong attention semantics.

The classifier now uses both tuple components: the first `local_count` positions in each cycle are local and the remaining positions are global. The common `(5, 1)` schedule is unchanged.

## Regression evidence

Focused regression, before the production fix:

```text
uv run python -m pytest tests/unit_tests/models/gemma/test_gemma4_bridge.py::TestGemma4BridgeProviderBridgeMoE::test_runtime_preserves_consecutive_full_attention_layers -q
FAILED: at index 3, 'sliding_attention' != 'full_attention'
```

The unchanged regression after the fix:

```text
uv run python -m pytest tests/unit_tests/models/gemma/test_gemma4_bridge.py::TestGemma4BridgeProviderBridgeMoE::test_runtime_preserves_consecutive_full_attention_layers -q
1 passed
```

Adjacent validation:

```text
uv run python -m pytest tests/unit_tests/models/gemma/test_gemma4_bridge.py tests/unit_tests/models/gemma/test_gemma3_provider.py tests/unit_tests/models/gemma_vl/test_gemma4_vl_bridge.py -q
177 passed

git diff --check
passed

uv run pre-commit run --all-files
passed
```

## Scope

This changes one private shared attention-classification expression and its focused unit expectations. It does not change public APIs, dependencies, CI configuration, model-quality behavior outside layer-type selection, or the MCore submodule. Validation was CPU-only; no full-suite, convergence, performance, or GPU claim is made.
