### PR TITLE
fix(recipe): resync DeepSeek V3 pipeline layout after overrides

### DIFF
--- a/src/megatron/bridge/recipes/deepseek/h100/deepseek_v3.py
+++ b/src/megatron/bridge/recipes/deepseek/h100/deepseek_v3.py
@@ -47,6 +47,27 @@ def _build_standalone_mtp_layout(num_decoder_layers: int, total_stages: int, mtp
     return layout
 
 
+def _get_deepseek_v3_pipeline_layout(pp_size: int, vp_size: int | None, mtp_layers: int = 1) -> list[list[str]] | None:
+    """Get a DeepSeek-V3 pipeline layout for the requested topology."""
+    last_layer = ["mtp"] * mtp_layers + ["loss"]
+    layout_map = {
+        (1, 1): None,
+        (4, 1): [["embedding"] + ["decoder"] * 16, ["decoder"] * 16, ["decoder"] * 16, ["decoder"] * 13 + last_layer],
+        (8, 1): [["embedding"] + ["decoder"] * 8] + [["decoder"] * 8] * 6 + [["decoder"] * 5 + last_layer],
+        (4, 2): [["embedding"] + ["decoder"] * 8] + [["decoder"] * 8] * 6 + [["decoder"] * 5 + last_layer],
+        (16, 1): [["embedding"] + ["decoder"] * 4] + [["decoder"] * 4] * 14 + [["decoder"] + last_layer],
+        (8, 2): [["embedding"] + ["decoder"] * 4] + [["decoder"] * 4] * 14 + [["decoder"] + last_layer],
+        (4, 4): [["embedding"] + ["decoder"] * 4] + [["decoder"] * 4] * 14 + [["decoder"] + last_layer],
+    }
+    effective_vp_size = 1 if vp_size is None else vp_size
+    if (pp_size, effective_vp_size) not in layout_map:
+        raise ValueError(
+            f"Invalid PP and VP size: {pp_size} and {effective_vp_size} to infer PP layout "
+            f"for DeepSeek-V3. Known PP and VP combinations: {layout_map.keys()}"
+        )
+    return layout_map[(pp_size, effective_vp_size)]
+
+
 def set_deepseek_v3_pipeline_model_parallel_layout(
     model_cfg: GPTModelProvider, layout: str | list[list[str]] | None = None, *, mtp_standalone: bool = False
 ) -> None:
@@ -63,18 +84,8 @@ def set_deepseek_v3_pipeline_model_parallel_layout(
         return
 
     mtp_layers = getattr(model_cfg, "mtp_num_layers", 1) or 0
-    last_layer = ["mtp"] * mtp_layers + ["loss"]
     pp_size = model_cfg.pipeline_model_parallel_size or 1
     vp_size = model_cfg.virtual_pipeline_model_parallel_size or 1
-    layout_map = {
-        (1, 1): None,
-        (4, 1): [["embedding"] + ["decoder"] * 16, ["decoder"] * 16, ["decoder"] * 16, ["decoder"] * 13 + last_layer],
-        (8, 1): [["embedding"] + ["decoder"] * 8] + [["decoder"] * 8] * 6 + [["decoder"] * 5 + last_layer],
-        (4, 2): [["embedding"] + ["decoder"] * 8] + [["decoder"] * 8] * 6 + [["decoder"] * 5 + last_layer],
-        (16, 1): [["embedding"] + ["decoder"] * 4] + [["decoder"] * 4] * 14 + [["decoder"] + last_layer],
-        (8, 2): [["embedding"] + ["decoder"] * 4] + [["decoder"] * 4] * 14 + [["decoder"] + last_layer],
-        (4, 4): [["embedding"] + ["decoder"] * 4] + [["decoder"] * 4] * 14 + [["decoder"] + last_layer],
-    }
     if mtp_standalone:
         num_decoder_layers = getattr(model_cfg, "num_layers", None)
         if not isinstance(num_decoder_layers, int) or isinstance(num_decoder_layers, bool) or num_decoder_layers <= 0:
@@ -84,8 +95,11 @@ def set_deepseek_v3_pipeline_model_parallel_layout(
             total_stages=pp_size * vp_size,
             mtp_layers=mtp_layers,
         )
-    elif (pp_size, vp_size) in layout_map:
-        model_cfg.pipeline_model_parallel_layout = layout_map[(pp_size, vp_size)]
+    else:
+        try:
+            model_cfg.pipeline_model_parallel_layout = _get_deepseek_v3_pipeline_layout(pp_size, vp_size, mtp_layers)
+        except ValueError:
+            pass
 
 
 def deepseek_v3_pretrain_1024gpu_h100_bf16_config() -> ConfigContainer:
@@ -137,6 +151,7 @@ def deepseek_v3_pretrain_1024gpu_h100_bf16_config() -> ConfigContainer:
     cfg.model.num_layers_in_last_pipeline_stage = None
 
     # Set pipeline layout
+    cfg.model._pipeline_model_parallel_layout_builder = _get_deepseek_v3_pipeline_layout
     set_deepseek_v3_pipeline_model_parallel_layout(cfg.model)
 
     # MoE Token Dispatcher settings
@@ -304,6 +319,7 @@ def deepseek_v3_pretrain_256gpu_h100_bf16_32nodes_config() -> ConfigContainer:
     cfg.model.num_layers_in_last_pipeline_stage = None
 
     # Set pipeline layout
+    cfg.model._pipeline_model_parallel_layout_builder = _get_deepseek_v3_pipeline_layout
     set_deepseek_v3_pipeline_model_parallel_layout(cfg.model)
 
     # MoE Token Dispatcher settings

--- a/tests/unit_tests/recipes/test_deepseek_recipes.py
+++ b/tests/unit_tests/recipes/test_deepseek_recipes.py
@@ -35,6 +35,7 @@ from megatron.bridge.recipes.deepseek import (
 )
 from megatron.bridge.recipes.deepseek.deepseek_v3 import _build_standalone_mtp_layout
 from tests.unit_tests.recipes.recipe_test_utils import patch_recipe_module_global
+from tests.unit_tests.training.test_run_recipe_qwen3_omni import _load_recipe_runner_module
 
 
 _deepseek_module = importlib.import_module("megatron.bridge.recipes.deepseek")
@@ -344,6 +345,28 @@ def test_deepseek_v3_pipeline_layout_keeps_default_mtp_with_loss():
     set_deepseek_v3_pipeline_model_parallel_layout(model_cfg)
 
     assert model_cfg.pipeline_model_parallel_layout[-1][-2:] == ["mtp", "loss"]
+
+
+def test_deepseek_v3_pipeline_layout_tracks_supported_cli_topology(monkeypatch: pytest.MonkeyPatch):
+    recipe_module = importlib.import_module("megatron.bridge.recipes.deepseek.h100.deepseek_v3")
+    patch_recipe_module_global(monkeypatch, recipe_module, "AutoBridge", _FakeBridge)
+    cfg = recipe_module.deepseek_v3_pretrain_1024gpu_h100_bf16_config()
+    recipe_runner, _ = _load_recipe_runner_module()
+
+    cfg.model.num_layers = 61
+    cfg.model.pipeline_model_parallel_size = 8
+    cfg.model.virtual_pipeline_model_parallel_size = 1
+    recipe_runner.sync_model_pipeline_layout(
+        cfg,
+        cli_overrides=[
+            "model.pipeline_model_parallel_size=8",
+            "model.virtual_pipeline_model_parallel_size=1",
+        ],
+    )
+
+    layout = PipelineParallelLayerLayout(cfg.model.pipeline_model_parallel_layout, pipeline_model_parallel_size=8)
+    assert layout.virtual_pipeline_model_parallel_size == 1
+    assert layout.validate_layer_layout(cfg.model.num_layers, cfg.model.mtp_num_layers) is False
 
 
 def _build_deepseek_v4_recipe(name: str, monkeypatch: pytest.MonkeyPatch):

--- a/tests/unit_tests/recipes/test_deepseek_recipes.py
+++ b/tests/unit_tests/recipes/test_deepseek_recipes.py
@@ -33,7 +33,10 @@ from megatron.bridge.recipes.deepseek import (
     set_deepseek_v3_pipeline_model_parallel_layout,
     set_deepseek_v4_pipeline_model_parallel_layout,
 )
-from megatron.bridge.recipes.deepseek.deepseek_v3 import _build_standalone_mtp_layout
+from megatron.bridge.recipes.deepseek.h100.deepseek_v3 import (
+    _build_standalone_mtp_layout,
+    _get_deepseek_v3_pipeline_layout,
+)
 from tests.unit_tests.recipes.recipe_test_utils import patch_recipe_module_global
 from tests.unit_tests.training.test_run_recipe_qwen3_omni import _load_recipe_runner_module
 
@@ -366,7 +369,13 @@ def test_deepseek_v3_pipeline_layout_tracks_supported_cli_topology(monkeypatch: 
 
     layout = PipelineParallelLayerLayout(cfg.model.pipeline_model_parallel_layout, pipeline_model_parallel_size=8)
     assert layout.virtual_pipeline_model_parallel_size == 1
+    # Validation returns whether MTP has a standalone stage; this canned layout colocates MTP with loss.
     assert layout.validate_layer_layout(cfg.model.num_layers, cfg.model.mtp_num_layers) is False
+
+
+def test_deepseek_v3_pipeline_layout_builder_rejects_unsupported_cli_topology():
+    with pytest.raises(ValueError, match="Invalid PP and VP size: 2 and 1"):
+        _get_deepseek_v3_pipeline_layout(pp_size=2, vp_size=None)
 
 
 def _build_deepseek_v4_recipe(name: str, monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
## Problem

The supported public launcher path using `--recipe deepseek_v3_pretrain_config -pp 8 -vp 1` updates the pipeline and virtual-pipeline sizes after the DeepSeek V3 recipe has already materialized its default 16-stage layout. Pinned Megatron-Core then derives VP=2 from the stale layout and rejects the explicit VP=1 request during model finalization.

PP=8/VP=1 is an existing DeepSeek V3 topology in the recipe's layout map. Both public H100 recipe constructors were affected. This is related to the earlier scaling report in #1502, but the current failure is in the shared recipe-runner override path.

## Root cause and fix

The DeepSeek V3 recipe owned the supported layout map but did not register a layout builder for the shared post-override synchronization hook. The hook therefore left the original layout unchanged after PP or VP CLI overrides.

This change extracts the existing topology map into a builder, registers it on both DeepSeek V3 H100 recipes, and adds a focused regression test through the shared synchronization path. Explicit user-provided layouts remain authoritative.

## Validation

Fail-before on the unmodified base with the test-only regression patch:

    uv run python -m pytest tests/unit_tests/recipes/test_deepseek_recipes.py::test_deepseek_v3_pipeline_layout_tracks_supported_cli_topology -q --tb=short

Result: 1 failed because the 16-stage layout at PP=8 produced detected VP=2 instead of requested VP=1.

Pass-after, with the regression test unchanged:

    uv run python -m pytest tests/unit_tests/recipes/test_deepseek_recipes.py::test_deepseek_v3_pipeline_layout_tracks_supported_cli_topology -q --tb=short

Result: 1 passed.

Adjacent validation:

    uv run python -m pytest tests/unit_tests/recipes/test_deepseek_recipes.py tests/unit_tests/scripts/training/test_recipe_runner.py -q --tb=short

Result: 67 passed.

    git diff --check

Result: passed.

    uv run pre-commit run --all-files

Result: all applicable hooks passed.

## Scope

This patch changes only DeepSeek V3 recipe-owned pipeline-layout synchronization and its focused regression test. It does not alter explicit custom layouts, dependencies, CI workflows, conversion APIs, or Megatron-Core. No full-suite, convergence, performance, or multi-GPU training validation was run.
