### PR TITLE
fix(training): resolve MegatronMIMO evaluation batch defaults

### DIFF
--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -1925,6 +1925,18 @@ def megatron_mimo_runtime_config_update(cfg: ConfigContainer) -> None:
     cfg.train.finalize()
     cfg.scheduler.finalize()
     cfg.checkpoint.finalize()
+
+    if cfg.validation.eval_global_batch_size is None:
+        assert cfg.train.global_batch_size is not None, (
+            "train.global_batch_size must be set when eval_global_batch_size is not explicitly configured"
+        )
+        cfg.validation.eval_global_batch_size = cfg.train.global_batch_size
+    if cfg.validation.eval_micro_batch_size is None:
+        assert cfg.train.micro_batch_size is not None, (
+            "train.micro_batch_size must be set when eval_micro_batch_size is not explicitly configured"
+        )
+        cfg.validation.eval_micro_batch_size = cfg.train.micro_batch_size
+
     if cfg.profiling is not None:
         cfg.profiling.finalize()
         if cfg.profiling.nvtx_ranges:

--- a/tests/unit_tests/training/megatron_mimo/test_megatron_mimo_checkpointing.py
+++ b/tests/unit_tests/training/megatron_mimo/test_megatron_mimo_checkpointing.py
@@ -43,6 +43,26 @@ def _make_megatron_mimo_infra(*, num_active_pgs: int = 1) -> Mock:
     return infra
 
 
+def test_megatron_mimo_runtime_config_update_resolves_eval_batch_size_defaults():
+    from megatron.bridge.training.config import megatron_mimo_runtime_config_update
+
+    cfg = MagicMock()
+    cfg.env_vars = {}
+    cfg.train.num_epochs = None
+    cfg.train.global_batch_size = 8
+    cfg.train.micro_batch_size = 2
+    cfg.validation.eval_global_batch_size = None
+    cfg.validation.eval_micro_batch_size = None
+    cfg.profiling = None
+
+    megatron_mimo_runtime_config_update(cfg)
+
+    eval_num_microbatches = cfg.validation.eval_global_batch_size // (
+        cfg.validation.eval_micro_batch_size * cfg.data_parallel_size
+    )
+    assert eval_num_microbatches == 4
+
+
 def _make_global_state(
     *,
     save_interval: int | None = 10,


### PR DESCRIPTION
## Summary

- resolve documented evaluation batch-size defaults in the MegatronMIMO runtime config path
- add a focused regression covering the evaluator batch arithmetic

## Supported trigger and impact

Calling the supported `pretrain_megatron_mimo()` path with interval validation enabled and leaving `validation.eval_global_batch_size` and `validation.eval_micro_batch_size` at their documented `None` defaults reaches evaluation after a training step. Those defaults are intended to inherit the training batch sizes, but the MIMO-specific runtime updater left them unresolved. The evaluator then attempted arithmetic on `None` and aborted training with `TypeError`.

## Root cause and fix

The standard runtime update path resolves the validation defaults during container validation. MegatronMIMO intentionally uses the reduced `megatron_mimo_runtime_config_update()` path, which finalized the training-related subconfigs but omitted the equivalent inheritance.

The fix resolves both validation batch sizes from the finalized training config in the MIMO updater, preserving explicitly configured values. No public API or evaluator behavior changes.

## Verification

Fail-before on the unmodified base:

`uv run python -m pytest tests/unit_tests/training/megatron_mimo/test_megatron_mimo_checkpointing.py::test_megatron_mimo_runtime_config_update_resolves_eval_batch_size_defaults -q --tb=short`

Result: `1 failed` with `TypeError: unsupported operand type(s) for *: 'NoneType' and 'int'`.

Pass-after with the unchanged regression:

`uv run python -m pytest tests/unit_tests/training/megatron_mimo/test_megatron_mimo_checkpointing.py::test_megatron_mimo_runtime_config_update_resolves_eval_batch_size_defaults -q --tb=short`

Result: `1 passed`.

Focused adjacent validation:

`uv run python -m pytest tests/unit_tests/training/megatron_mimo/test_megatron_mimo_checkpointing.py::test_megatron_mimo_runtime_config_update_resolves_eval_batch_size_defaults tests/unit_tests/training/megatron_mimo/test_megatron_mimo_checkpointing.py::test_interval_evaluation_uses_evaluator_timer_ownership tests/unit_tests/training/megatron_mimo/test_megatron_mimo_checkpointing.py::TestNonColocatedGuard tests/unit_tests/training/megatron_mimo/test_megatron_mimo_checkpointing.py::TestTrainMegatronMIMOCheckpointIntegration tests/unit_tests/training/test_eval.py -q --tb=short`

Result: `16 passed`.

Also passed:

- `git diff --check`
- `uv run pre-commit run --all-files`

## Scope

This change is limited to MIMO runtime default resolution and a unit regression. It does not change public signatures, dependencies, CI configuration, model execution, or explicit validation batch-size settings. No full-suite, convergence, performance, or GPU validation is claimed.