### PR TITLE
fix(model): stabilize GLM-5 export and expert parallel inference

### DIFF
--- a/examples/model_verification_cards/glm5/card.yaml
+++ b/examples/model_verification_cards/glm5/card.yaml
@@ -5,19 +5,18 @@ title: glm5
 summary: >
   Performance disclaimer: this model has not been performance-tuned; reported
   timing and throughput metrics are sanity checks, not optimized performance
-  results. This card intentionally limits its current verification scope to
-  deterministic inference from the pinned GLM-5 Hugging Face checkpoint.
-  Conversion, Hugging Face/Megatron forward parity, training, checkpoint
-  resume, and post-SFT export/reload verification are deferred; this card
-  makes no claims for those unverified workflows.
+  results. Model-level verification covers deterministic inference and exact
+  distributed GPU import/export of the pinned GLM-5 Hugging Face checkpoint's
+  78-layer inference graph. The checkpoint's appended MTP auxiliary layer is
+  intentionally disabled and excluded from those claims. CPU conversion,
+  Hugging Face/Megatron forward parity, training, checkpoint resume, and
+  post-SFT export/reload verification are deferred.
 verification_index:
   model_level:
-    verified: [inference]
+    verified: [hf_to_megatron_gpu, megatron_to_hf_gpu, inference]
     unverified:
       - hf_to_megatron_cpu
-      - hf_to_megatron_gpu
       - megatron_to_hf_cpu
-      - megatron_to_hf_gpu
       - manual_forward_pass
   training:
     H100:
@@ -43,14 +42,24 @@ items:
       deferred by this card.
 
   hf_to_megatron_gpu:
-    status: unverified
+    status: verified
     precision: bf16
-    command: null
-    last_verified: null
+    command: >
+      ./scripts/conversion/convert.sh import --executor slurm --device gpu
+      --nodes 4 --gpus-per-node 8 --hf-model zai-org/GLM-5
+      --hf-revision 4e6698ba8e85059d749020e3c4d2123719f23926
+      --megatron-path work/model-verification/glm5/gpu-megatron
+      --torch-dtype bfloat16 --tp 1 --pp 2 --ep 8 --etp 2
+      --distributed-timeout-minutes 60 --low-memory-save
+    last_verified: 2026-08-10
     expected_result: >
-      A distributed GPU import of the pinned Hugging Face revision must
-      complete every mapping and create a reloadable Megatron checkpoint.
-      This workflow is deferred by this card.
+      The pinned 32-H100 import exits successfully at TP1/PP2/EP8/ETP2,
+      completes all 6,201 distributed mapping tasks, and persists a reloadable
+      iter_0000000 checkpoint. Reload plus exact export projection covers all
+      59,079 tensors and 1,487,822,475,264 tensor-payload bytes in the 78-layer
+      inference graph with matching keys, shapes, dtypes, and values. The 791
+      source tensors under model.layers.78 belong only to the intentionally
+      disabled appended MTP auxiliary layer and are outside this item.
 
   megatron_to_hf_cpu:
     status: unverified
@@ -63,14 +72,29 @@ items:
       deferred by this card.
 
   megatron_to_hf_gpu:
-    status: unverified
+    status: verified
     precision: bf16
-    command: null
-    last_verified: null
+    bridge_commit: 7e2181dcc5d09a1a859dfb0c655c9a1cd486e0ac  # pragma: allowlist secret
+    command: >
+      ./scripts/conversion/convert.sh export --executor slurm --device gpu
+      --nodes 4 --gpus-per-node 8 --hf-model zai-org/GLM-5
+      --hf-revision 4e6698ba8e85059d749020e3c4d2123719f23926
+      --megatron-path work/model-verification/glm5/gpu-megatron/iter_0000000
+      --hf-path work/model-verification/glm5/gpu-hf-export
+      --torch-dtype bfloat16 --tp 1 --pp 2 --ep 8 --etp 2
+      --distributed-timeout-minutes 60 --distributed-save
+      --save-every-n-ranks 1
+    last_verified: 2026-08-10
     expected_result: >
-      A distributed GPU export from a verified Megatron checkpoint must
-      preserve every mapped tensor and strictly reload in Transformers. This
-      workflow is deferred by this card.
+      The 32-H100 distributed export exits successfully after all 6,201
+      mapping tasks and writes 280 safetensors shards. Of those, 278 are
+      byte-for-byte identical to the pinned source shards; the two shards that
+      also contain excluded MTP keys match all 63 common tensors exactly. The
+      composite audit covers all 59,079 inference-graph tensors and
+      1,487,822,475,264 tensor-payload bytes with zero key, shape, dtype, or
+      value mismatch. Transformers 5.12.1 strictly reloads the output as
+      GlmMoeDsaForCausalLM with 1,629 state tensors, 743,911,199,232
+      parameters, and no loading discrepancies.
 
   manual_forward_pass:
     status: unverified
@@ -97,11 +121,13 @@ items:
       "Etttttt|tttttttttttttttttttttttt|tttttttttttttttttttttttt|ttttttttttttttttttttttttL"
     last_verified: 2026-08-07
     expected_result: |-
-      One deterministic BF16 run imports all 6,201 tensors from the pinned
-      complete Hugging Face model directly into Megatron across 32 ranks at
-      TP1/PP4/EP8/ETP1. It exits successfully after exactly 16 new greedy
-      tokens. The first generated token is ID 16 (`1`), and first-step logits
-      are finite with variance 10.3619. The literal completion was:
+      One deterministic BF16 run completes all 6,201 distributed mapping tasks
+      from the pinned Hugging Face model directly into Megatron across 32 ranks
+      at TP1/PP4/EP8/ETP1. The inference graph intentionally excludes the
+      checkpoint's appended MTP auxiliary layer. It exits successfully after
+      exactly 16 new greedy tokens. The first generated token is ID 16 (`1`),
+      and first-step logits are finite with variance 10.3619. The literal
+      completion was:
       "1.  **Analyze the Request:**
           *   **Topic:**"
       It produced exactly 16 new tokens.

--- a/examples/model_verification_cards/glm5/card.yaml
+++ b/examples/model_verification_cards/glm5/card.yaml
@@ -1,0 +1,211 @@
+# Agent-readable model verification card.
+# status: unverified | verified | unsupported | not_applicable
+
+title: glm5
+summary: >
+  Performance disclaimer: this model has not been performance-tuned; reported
+  timing and throughput metrics are sanity checks, not optimized performance
+  results. This card intentionally limits its current verification scope to
+  deterministic inference from the pinned GLM-5 Hugging Face checkpoint.
+  Conversion, Hugging Face/Megatron forward parity, training, checkpoint
+  resume, and post-SFT export/reload verification are deferred; this card
+  makes no claims for those unverified workflows.
+verification_index:
+  model_level:
+    verified: [inference]
+    unverified:
+      - hf_to_megatron_cpu
+      - hf_to_megatron_gpu
+      - megatron_to_hf_cpu
+      - megatron_to_hf_gpu
+      - manual_forward_pass
+  training:
+    H100:
+      unverified: [pretrain, sft, sft_export_inference, sft_long_context, peft, checkpoint_resume]
+model:
+  hf_id: zai-org/GLM-5
+  hf_revision: 4e6698ba8e85059d749020e3c4d2123719f23926  # pragma: allowlist secret
+  architecture: GlmMoeDsaForCausalLM
+  min_transformers_version: "5.12.1"
+verification_environment:
+  base_container: nvcr.io/nvidia/nemo:26.08.rc3
+  bridge_commit: 5db9c262411cf4561d44cdf76a134b423fdaacc2  # pragma: allowlist secret
+
+items:
+  hf_to_megatron_cpu:
+    status: unverified
+    precision: bf16
+    command: null
+    last_verified: null
+    expected_result: >
+      A CPU import of the pinned Hugging Face revision must complete every
+      mapping and create a reloadable Megatron checkpoint. This workflow is
+      deferred by this card.
+
+  hf_to_megatron_gpu:
+    status: unverified
+    precision: bf16
+    command: null
+    last_verified: null
+    expected_result: >
+      A distributed GPU import of the pinned Hugging Face revision must
+      complete every mapping and create a reloadable Megatron checkpoint.
+      This workflow is deferred by this card.
+
+  megatron_to_hf_cpu:
+    status: unverified
+    precision: bf16
+    command: null
+    last_verified: null
+    expected_result: >
+      A CPU export from a verified Megatron checkpoint must preserve every
+      mapped tensor and strictly reload in Transformers. This workflow is
+      deferred by this card.
+
+  megatron_to_hf_gpu:
+    status: unverified
+    precision: bf16
+    command: null
+    last_verified: null
+    expected_result: >
+      A distributed GPU export from a verified Megatron checkpoint must
+      preserve every mapped tensor and strictly reload in Transformers. This
+      workflow is deferred by this card.
+
+  manual_forward_pass:
+    status: unverified
+    precision: bf16
+    command: null
+    last_verified: null
+    expected_result: >
+      A pinned first-token Hugging Face versus Megatron comparison must match
+      the argmax token and meet the card's logit-correlation threshold. The
+      full Hugging Face reference pass is deferred by this card.
+
+  inference:
+    status: verified
+    precision: bf16
+    command: >
+      ./scripts/inference/infer.sh --nodes 4 --gpus-per-node 8
+      --task legacy-full-prefix-generation
+      --hf_model_path zai-org/GLM-5
+      --hf-revision 4e6698ba8e85059d749020e3c4d2123719f23926
+      --prompt "Write one concise sentence explaining why deterministic tests matter:"
+      --apply-chat-template --thinking-mode disabled --max_new_tokens 16
+      --legacy-full-prefix --tp 1 --pp 4 --ep 8 --etp 1
+      --pipeline-model-parallel-layout
+      "Etttttt|tttttttttttttttttttttttt|tttttttttttttttttttttttt|ttttttttttttttttttttttttL"
+    last_verified: 2026-08-07
+    expected_result: |-
+      One deterministic BF16 run imports all 6,201 tensors from the pinned
+      complete Hugging Face model directly into Megatron across 32 ranks at
+      TP1/PP4/EP8/ETP1. It exits successfully after exactly 16 new greedy
+      tokens. The first generated token is ID 16 (`1`), and first-step logits
+      are finite with variance 10.3619. The literal completion was:
+      "1.  **Analyze the Request:**
+          *   **Topic:**"
+      It produced exactly 16 new tokens.
+
+  pretrain:
+    H100:
+      status: unverified
+      precision: bf16
+      enabled_features: {}
+      command: null
+      last_verified: null
+      metrics:
+        initial_loss: null
+        final_loss: null
+        last_10_steps_step_time_ms_avg: null
+        last_10_steps_model_tflops_per_gpu_avg: null
+      expected_result: >
+        A public GLM-5 H100 recipe must complete a bounded 100-step run with
+        finite loss, no skipped or NaN iterations, all four metrics, and a
+        reloadable final checkpoint. Training is deferred by this card.
+
+  sft:
+    H100:
+      status: unverified
+      precision: bf16
+      enabled_features: {}
+      command: null
+      last_verified: null
+      metrics:
+        initial_loss: null
+        final_loss: null
+        last_10_steps_step_time_ms_avg: null
+        last_10_steps_model_tflops_per_gpu_avg: null
+      expected_result: >
+        A pinned-data 100-step full-SFT run must finish with finite loss, no
+        skipped or NaN iterations, all four metrics, and a reloadable final
+        checkpoint. Training is deferred by this card.
+
+  sft_export_inference:
+    H100:
+      status: unverified
+      precision: bf16
+      depends_on: sft
+      commands: null
+      last_verified: null
+      expected_result: >
+        A verified SFT checkpoint must export to Hugging Face, strictly reload,
+        and produce deterministic checkpoint-backed inference. Training and
+        post-SFT export verification are deferred by this card.
+
+  sft_long_context:
+    H100:
+      status: unverified
+      precision: bf16
+      enabled_features: {}
+      command: null
+      last_verified: null
+      metrics:
+        initial_loss: null
+        final_loss: null
+        last_10_steps_step_time_ms_avg: null
+        last_10_steps_model_tflops_per_gpu_avg: null
+      expected_result: >
+        A dedicated packed long-context SFT run must complete a bounded run
+        with finite loss, no skipped or NaN iterations, all four metrics, and
+        a reloadable checkpoint. Training is deferred by this card.
+
+  peft:
+    H100:
+      status: unverified
+      precision: bf16
+      enabled_features: {}
+      command: null
+      last_verified: null
+      metrics:
+        initial_loss: null
+        final_loss: null
+        last_10_steps_step_time_ms_avg: null
+        last_10_steps_model_tflops_per_gpu_avg: null
+      expected_result: >
+        A GLM-5 PEFT recipe with an audited adapter target set must complete a
+        bounded run with finite loss, all four metrics, and a reloadable
+        adapter checkpoint. Training is deferred by this card.
+
+  checkpoint_resume:
+    H100:
+      status: unverified
+      precision: bf16
+      depends_on: pretrain
+      command: null
+      last_verified: null
+      metrics:
+        initial_loss: null
+        final_loss: null
+        last_10_steps_step_time_ms_avg: null
+        last_10_steps_model_tflops_per_gpu_avg: null
+      resume_comparison:
+        reference_item: pretrain
+        sentinel_steps: [51, 100]
+        loss_relative_tolerance: 1.0e-2
+        loss_absolute_tolerance: 1.0e-6
+        sentinels_match: null
+      expected_result: >
+        A direct continuation must restore model, optimizer, scheduler,
+        data-order, and RNG state, match declared sentinel losses, and save a
+        reloadable checkpoint to a distinct output root. Training is deferred
+        by this card.

--- a/src/megatron/bridge/models/glm_moe_dsa/glm5_bridge.py
+++ b/src/megatron/bridge/models/glm_moe_dsa/glm5_bridge.py
@@ -93,7 +93,10 @@ class GLM5Bridge(MegatronModelBridge):
 
         provider.moe_grouped_gemm = True
         provider.moe_router_pre_softmax = True
-        provider.moe_token_dispatcher_type = "alltoall"
+        provider.moe_token_dispatcher_type = "flex"
+        provider.moe_flex_dispatcher_backend = "hybridep"
+        provider.moe_flex_dispatcher_num_sms = 16
+        provider.moe_permute_fusion_into_hybridep = False
         provider.moe_router_load_balancing_type = "seq_aux_loss"
         provider.moe_shared_expert_overlap = True
         provider.moe_router_score_function = "sigmoid"

--- a/src/megatron/bridge/models/glm_moe_dsa/glm5_bridge.py
+++ b/src/megatron/bridge/models/glm_moe_dsa/glm5_bridge.py
@@ -233,7 +233,7 @@ class GLM5Bridge(MegatronModelBridge):
         )
 
         hf_config = self.hf_config
-        num_mtp_layers = getattr(hf_config, "num_nextn_predict_layers", 0)
+        num_mtp_layers = getattr(hf_config, "num_nextn_predict_layers", 0) or 0
         num_transformer_layers = hf_config.num_hidden_layers
         for mtp_layer in range(num_mtp_layers):
             # MTP specific mappings

--- a/tests/unit_tests/models/glm_moe_dsa/test_glm5_bridge.py
+++ b/tests/unit_tests/models/glm_moe_dsa/test_glm5_bridge.py
@@ -260,9 +260,15 @@ def test_mapping_registry_includes_mtp_standalone_weights(glm5_bridge: GLM5Bridg
         assert mapping.hf_param == hf_param
 
 
-def test_mapping_registry_omits_mtp_mappings_without_nextn_layers() -> None:
+@pytest.mark.parametrize("num_nextn_predict_layers", [0, None])
+def test_mapping_registry_omits_mtp_mappings_without_nextn_layers(
+    num_nextn_predict_layers: int | None,
+) -> None:
     """No MTP mappings are registered when the HF config has no MTP layers."""
     bridge = GLM5Bridge()
-    bridge.hf_config = SimpleNamespace(num_hidden_layers=4, num_nextn_predict_layers=0)
+    bridge.hf_config = SimpleNamespace(
+        num_hidden_layers=4,
+        num_nextn_predict_layers=num_nextn_predict_layers,
+    )
 
     assert all(not mapping.megatron_param.startswith("mtp.") for mapping in bridge.mapping_registry())

--- a/tests/unit_tests/models/glm_moe_dsa/test_glm5_bridge.py
+++ b/tests/unit_tests/models/glm_moe_dsa/test_glm5_bridge.py
@@ -141,6 +141,16 @@ def test_provider_bridge_maps_dsa_architecture_from_hf_config(
     assert provider.dsa_indexer_use_sparse_loss is True
 
 
+def test_provider_bridge_uses_hybridep_dispatcher(monkeypatch: pytest.MonkeyPatch) -> None:
+    """GLM-5 avoids the affected grouped all-to-all transport path."""
+    provider = _provider_from_hf_config(monkeypatch)
+
+    assert provider.moe_token_dispatcher_type == "flex"
+    assert provider.moe_flex_dispatcher_backend == "hybridep"
+    assert provider.moe_flex_dispatcher_num_sms == 16
+    assert provider.moe_permute_fusion_into_hybridep is False
+
+
 def test_mapping_registry_includes_grouped_and_local_expert_fc2_paths(glm5_bridge: GLM5Bridge) -> None:
     """GLM-5 MoE export supports both packed and local-expert down-projection names."""
     mappings = _mapping_by_megatron_param(glm5_bridge)


### PR DESCRIPTION
# What does this PR do?

Fix two GLM-5 model-path defects:

1. Megatron-to-Hugging-Face export failed when MTP was intentionally disabled because checkpoint restoration can set `num_nextn_predict_layers=None`, which was passed to `range()`.
2. The default `alltoall` MoE dispatcher is incompatible with the GLM-5 absorbed MLA expert-parallel inference path. Use the same validated flex/HybridEP settings as MiniMax-M3.

The GLM-5 H100 and GB200 training recipes already select their own dispatchers explicitly, so this provider-default change targets direct model construction and inference without silently changing those recipe configurations.

The model verification card records deterministic inference plus exact distributed GPU import/export evidence for the pinned checkpoint 78-layer inference graph. The source checkpoint appended MTP auxiliary layer is explicitly outside that graph and outside the conversion claim.

# Changelog

- Treat both `0` and `None` as disabled MTP during GLM-5 mapping-registry construction.
- Select flex/HybridEP by default with 16 communication SMs and the supported permutation path.
- Add focused regression coverage for the MTP and dispatcher settings.
- Add the GLM-5 model verification card and exact distributed GPU conversion evidence.

# Validation

- Focused GLM-5 unit suite: 19 passed.
- Model verification card validator: passed.
- `uv run --active --no-sync pre-commit run --all-files`: passed.
- Deterministic BF16 GLM-5 inference completed 20/20 generation steps on 64 H100 GPUs at TP1/PP2/EP32/ETP1 with HybridEP, exited successfully, and produced a non-degenerate completion.
- Persistent 32-H100 import completed all 6,201 mapping tasks and produced a reloadable checkpoint.
- Matched 32-H100 export completed all 6,201 mapping tasks and wrote 280 safetensors shards.
- Exact audit covered 59,079/59,079 common tensors and 1,487,822,475,264 tensor-payload bytes with zero key, shape, dtype, or value mismatch; exactly 791 `model.layers.78.*` MTP tensors were the declared excluded set.
- Transformers 5.12.1 strictly reloaded the export as `GlmMoeDsaForCausalLM` with 1,629 state tensors, 743,911,199,232 parameters, and no loading discrepancies.

# Scope

This PR does not modify MCore, CI definitions, dependencies, or public APIs.