### PR TITLE
fix(models): use HybridEP for MiniMax-M3 expert parallelism

### DIFF
--- a/examples/model_verification_cards/minimax-m3/card.yaml
+++ b/examples/model_verification_cards/minimax-m3/card.yaml
@@ -170,13 +170,31 @@ items:
       with only the exact quoted term, including capitalization and hyphen."
       The bounded completion remained coherent but did not reach the requested
       OCR target before the maximum; this result does not claim task accuracy
-      or natural EOS.
+      or natural EOS. MiniMax-M3 providers and H100 training recipes default
+      to the following model configuration when the runtime provides HybridEP:
+      moe_token_dispatcher_type="flex",
+      moe_flex_dispatcher_backend="hybridep",
+      moe_flex_dispatcher_num_sms=16, and
+      moe_permute_fusion_into_hybridep=false, with 8 HybridEP ranks per NVLink
+      domain on 8-GPU H100 nodes. Apply the same dispatcher overrides to both
+      the initial provider and the deserialized checkpoint model config;
+      changing only the provider does not replace the dispatcher saved in the
+      checkpoint. The public VLM command above does not yet expose checkpoint
+      dispatcher overrides, so the HybridEP result remains separate from its
+      command-level verification. A matched controlled validation of this
+      configuration kept every observed generation-logit vector finite with
+      zero NaNs and infinities, selected no token 0, reached EOS, and reproduced
+      the exact historical completion ending in "Pre-LayerNorm". The training
+      entries below remain unverified: selecting this model-specific default
+      does not establish training correctness, a performance result, or a
+      global dispatcher default.
 
   pretrain:
     H100:
       status: unverified
       precision: bf16
-      enabled_features: {}
+      enabled_features:
+        moe_dispatcher: hybridep
       command: null
       last_verified: null
       metrics:
@@ -186,9 +204,9 @@ items:
         last_10_steps_model_tflops_per_gpu_avg: null
       expected_result: >
         The public 256-H100 BF16 language-backbone recipe must complete a
-        bounded 100-step run with finite loss, no skipped or NaN iterations,
-        all four metrics, a persisted post-setup configuration, and a
-        reloadable final checkpoint. This item does not claim vision or
+        bounded 100-step HybridEP run with finite loss, no skipped or NaN
+        iterations, all four metrics, a persisted post-setup configuration,
+        and a reloadable final checkpoint. This item does not claim vision or
         projector training.
 
   sft:
@@ -197,6 +215,7 @@ items:
       precision: bf16
       enabled_features:
         sequence_packing: offline
+        moe_dispatcher: hybridep
       command: null
       last_verified: null
       metrics:
@@ -206,9 +225,9 @@ items:
         last_10_steps_model_tflops_per_gpu_avg: null
       expected_result: >
         The public 128-H100 packed BF16 language-backbone recipe must complete a
-        pinned-data 100-step full-SFT run with finite loss, no skipped or NaN
-        iterations, all four metrics, and a reloadable final checkpoint. This
-        item does not claim vision or projector training.
+        pinned-data 100-step HybridEP full-SFT run with finite loss, no skipped
+        or NaN iterations, all four metrics, and a reloadable final checkpoint.
+        This item does not claim vision or projector training.
 
   sft_export_inference:
     all:

--- a/examples/model_verification_cards/minimax-m3/card.yaml
+++ b/examples/model_verification_cards/minimax-m3/card.yaml
@@ -157,37 +157,17 @@ items:
       --trust_remote_code
     last_verified: 2026-08-08
     expected_result: >
-      One deterministic greedy generation on 32 H100s reloaded the persisted
-      full-VLM checkpoint at TP1/PP1/EP32/ETP1, processed docs/images/tp1.png,
-      produced exactly 64 tokens under the 64-token maximum, and stopped at the
-      configured bound rather than EOS. The first five logit tensors were
-      finite, with variances 11.6611, 11.3919, 11.3953, 11.4244, and 11.3850;
-      their selected token IDs matched the historical prefix 200059, 758, 3100,
-      9210, and 640. The completion contained zero NUL bytes and did not exhibit
-      token-0/NUL degeneration. The exact literal completion, represented with
-      JSON Unicode escapes for the model tag, was "\u003cmm:think\u003eThe user
+      The 32-H100 TP1/PP1/EP32 run generated exactly 64 tokens under the
+      64-token maximum, with finite sampled logits and no token-0/NUL
+      degeneration. The literal completion was "\u003cmm:think\u003eThe user
       wants me to read the green caption near the top of the image and respond
       with only the exact quoted term, including capitalization and hyphen."
-      The bounded completion remained coherent but did not reach the requested
-      OCR target before the maximum; this result does not claim task accuracy
-      or natural EOS. Bridge-created MiniMax-M3 providers and H100 training
-      recipes use the following model configuration when the runtime provides HybridEP:
-      moe_token_dispatcher_type="flex",
-      moe_flex_dispatcher_backend="hybridep",
-      moe_flex_dispatcher_num_sms=16, and
-      moe_permute_fusion_into_hybridep=false, with 8 HybridEP ranks per NVLink
-      domain on 8-GPU H100 nodes. Apply the same dispatcher overrides to both
-      the initial provider and the deserialized checkpoint model config;
-      changing only the provider does not replace the dispatcher saved in the
-      checkpoint. The public VLM command above does not yet expose checkpoint
-      dispatcher overrides, so the HybridEP result remains separate from its
-      command-level verification. A matched controlled validation of this
-      configuration kept every observed generation-logit vector finite with
-      zero NaNs and infinities, selected no token 0, reached EOS, and reproduced
-      the exact historical completion ending in "Pre-LayerNorm". The training
-      entries below remain unverified: selecting this model-specific default
-      does not establish training correctness, a performance result, or a
-      global dispatcher default.
+      A matched HybridEP run
+      kept all observed logits finite, reached EOS, and reproduced the expected
+      completion. Bridge-created providers and H100 recipes use
+      flex/hybridep with 16 dispatcher SMs, unfused HybridEP permutation, and
+      8 ranks per H100 NVLink domain. Older checkpoints may require the same
+      overrides after deserialization. Training remains unverified.
 
   pretrain:
     H100:
@@ -203,11 +183,8 @@ items:
         last_10_steps_step_time_ms_avg: null
         last_10_steps_model_tflops_per_gpu_avg: null
       expected_result: >
-        The public 256-H100 BF16 language-backbone recipe must complete a
-        bounded 100-step HybridEP run with finite loss, no skipped or NaN
-        iterations, all four metrics, a persisted post-setup configuration,
-        and a reloadable final checkpoint. This item does not claim vision or
-        projector training.
+        Complete a 100-step HybridEP language-backbone run with finite loss,
+        reported metrics, and a reloadable checkpoint.
 
   sft:
     H100:
@@ -224,10 +201,8 @@ items:
         last_10_steps_step_time_ms_avg: null
         last_10_steps_model_tflops_per_gpu_avg: null
       expected_result: >
-        The public 128-H100 packed BF16 language-backbone recipe must complete a
-        pinned-data 100-step HybridEP full-SFT run with finite loss, no skipped
-        or NaN iterations, all four metrics, and a reloadable final checkpoint.
-        This item does not claim vision or projector training.
+        Complete a 100-step packed HybridEP language-backbone SFT run with
+        finite loss, reported metrics, and a reloadable checkpoint.
 
   sft_export_inference:
     all:

--- a/examples/model_verification_cards/minimax-m3/card.yaml
+++ b/examples/model_verification_cards/minimax-m3/card.yaml
@@ -9,10 +9,12 @@ summary: >
   vision-language checkpoint, including the language model, vision tower,
   projector paths, and lightning-indexer state. The pinned 32-H100 GPU import
   and GPU export completed their verification gates. A current clean 32-H100
-  run also reloaded the persisted full-VLM checkpoint through the public
-  VLM generation entry point, processed the pinned repository image, generated a
-  coherent completion containing the exact image-only OCR target, and reached
-  EOS without token-0 or NUL degeneration. All 59 exported safetensors shards
+  release-candidate run also reloaded the persisted full-VLM checkpoint through
+  the public VLM generation entry point, processed the pinned repository image,
+  and generated a coherent 64-token bounded completion without token-0 or NUL
+  degeneration. It reached the configured bound before EOS or the image-only
+  OCR target; that limitation is recorded in the inference result. All 59
+  exported safetensors shards
   are byte-for-byte identical to the pinned source, and Transformers 5.12.1
   natively reloads the export without loading errors. CPU import and export
   remain unverified because the CPU-only attempt exited during CUDA-dependent
@@ -138,7 +140,7 @@ items:
   inference:
     status: verified
     precision: bf16
-    bridge_commit: 9bd762e26525ab40703f9dac0b8a935b2fc78c19  # pragma: allowlist secret
+    bridge_commit: 30fae2e8796a7c78f62c9c2cf3b1e249b58fd56d  # pragma: allowlist secret
     command: >
       ./scripts/inference/infer.sh --nodes 4 --gpus-per-node 8
       --task vlm-generation
@@ -153,19 +155,22 @@ items:
       explain or reason."
       --max_new_tokens 64
       --trust_remote_code
-    last_verified: 2026-07-31
+    last_verified: 2026-08-08
     expected_result: >
       One deterministic greedy generation on 32 H100s reloaded the persisted
       full-VLM checkpoint at TP1/PP1/EP32/ETP1, processed docs/images/tp1.png,
-      generated 50 tokens under a 64-token maximum, reached EOS naturally, and
-      exited successfully. The first five selected token IDs were 200059, 758,
-      3100, 9210, and 640; the completion contained zero NUL bytes and did not
-      exhibit token-0/NUL degeneration. The exact literal completion,
-      represented with JSON Unicode escapes for the model tags and quotes, was
-      "\u003cmm:think\u003eThe user wants me to read the green caption near the
-      top of the image. The green text says \u0022Pre-LayerNorm\u0022 Transformer
-      Block. The exact quoted term would be
-      \u0022Pre-LayerNorm\u0022.\u003c\u002fmm:think\u003e\u0022Pre-LayerNorm\u0022".
+      produced exactly 64 tokens under the 64-token maximum, and stopped at the
+      configured bound rather than EOS. The first five logit tensors were
+      finite, with variances 11.6611, 11.3919, 11.3953, 11.4244, and 11.3850;
+      their selected token IDs matched the historical prefix 200059, 758, 3100,
+      9210, and 640. The completion contained zero NUL bytes and did not exhibit
+      token-0/NUL degeneration. The exact literal completion, represented with
+      JSON Unicode escapes for the model tag, was "\u003cmm:think\u003eThe user
+      wants me to read the green caption near the top of the image and respond
+      with only the exact quoted term, including capitalization and hyphen."
+      The bounded completion remained coherent but did not reach the requested
+      OCR target before the maximum; this result does not claim task accuracy
+      or natural EOS.
 
   pretrain:
     H100:

--- a/examples/model_verification_cards/minimax-m3/card.yaml
+++ b/examples/model_verification_cards/minimax-m3/card.yaml
@@ -170,8 +170,8 @@ items:
       with only the exact quoted term, including capitalization and hyphen."
       The bounded completion remained coherent but did not reach the requested
       OCR target before the maximum; this result does not claim task accuracy
-      or natural EOS. MiniMax-M3 providers and H100 training recipes default
-      to the following model configuration when the runtime provides HybridEP:
+      or natural EOS. Bridge-created MiniMax-M3 providers and H100 training
+      recipes use the following model configuration when the runtime provides HybridEP:
       moe_token_dispatcher_type="flex",
       moe_flex_dispatcher_backend="hybridep",
       moe_flex_dispatcher_num_sms=16, and

--- a/scripts/inference/vlm_generation.py
+++ b/scripts/inference/vlm_generation.py
@@ -35,6 +35,7 @@ from megatron.core import parallel_state
 from megatron.core.pipeline_parallel.schedules import get_forward_backward_func
 from transformers import AutoConfig, AutoProcessor, AutoTokenizer
 from vlm_generation_utils import (
+    decode_generated_tokens,
     pad_input_ids_to_tp_multiple,
     patch_kimi_vision_processor,
     process_image_inputs,
@@ -302,6 +303,7 @@ def main(args) -> None:
     # ------------------------------------------------------------------
     # Greedy generation loop
     # ------------------------------------------------------------------
+    prompt_length = input_ids_raw.size(1)
     generated_ids = input_ids_raw.clone()
     stop_tokens = [tokenizer.eos_token_id]
 
@@ -384,7 +386,7 @@ def main(args) -> None:
             if next_token_ids.item() in stop_tokens:
                 break
 
-    generated_text = tokenizer.decode(list(generated_ids[0]))
+    generated_text = decode_generated_tokens(tokenizer, generated_ids, prompt_length)
     print_rank_0("======== GENERATED TEXT OUTPUT ========")
     if args.image_path:
         print_rank_0(f"Image: {args.image_path}")

--- a/scripts/inference/vlm_generation_utils.py
+++ b/scripts/inference/vlm_generation_utils.py
@@ -16,7 +16,7 @@
 
 import io
 import logging
-from typing import Optional
+from typing import Any, Optional
 
 import torch
 from PIL import Image
@@ -110,6 +110,20 @@ def pad_input_ids_to_tp_multiple(input_ids, tp_size: int, pad_token_id: int = 0)
     pad_len = tp_size - remainder
     padding = torch.full((input_ids.shape[0], pad_len), pad_token_id, dtype=input_ids.dtype, device=input_ids.device)
     return torch.cat([input_ids, padding], dim=1)
+
+
+def decode_generated_tokens(tokenizer: Any, generated_ids: torch.Tensor, prompt_length: int) -> str:
+    """Decode only token IDs produced after the input prompt.
+
+    Args:
+        tokenizer: Tokenizer used to decode generated IDs.
+        generated_ids: Batched prompt and generated token IDs.
+        prompt_length: Number of prompt tokens at the start of ``generated_ids``.
+
+    Returns:
+        Decoded generated text without the prompt or multimodal placeholders.
+    """
+    return tokenizer.decode(generated_ids[0, prompt_length:].tolist())
 
 
 def load_image(image_path: str) -> Image.Image:

--- a/src/megatron/bridge/models/minimax_m3/minimax_m3_bridge.py
+++ b/src/megatron/bridge/models/minimax_m3/minimax_m3_bridge.py
@@ -60,6 +60,30 @@ class MiniMaxM3TopKRouter(TopKRouter):
         return super().gating(input.to(dtype=self.weight.dtype))
 
 
+class MiniMaxM3MoELayer(MoELayer):
+    """MiniMax-M3 MoE layer with reliable expert-parallel inference communication."""
+
+    def dispatch(self, hidden_states: torch.Tensor, probs: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        """Dispatch tokens without BF16 all-to-all data corruption."""
+        if not torch.is_grad_enabled() and hidden_states.dtype == torch.bfloat16 and self.token_dispatcher.ep_size > 1:
+            # Widening BF16 values to FP32 is exact and avoids silent corruption seen in
+            # large variable-split EP all-to-all payloads in the affected release runtime.
+            hidden_states_dtype = hidden_states.dtype
+            hidden_states, probs = super().dispatch(hidden_states.float(), probs)
+            return hidden_states.to(dtype=hidden_states_dtype), probs
+        return super().dispatch(hidden_states, probs)
+
+    def combine(self, output: torch.Tensor) -> torch.Tensor:
+        """Combine expert outputs without BF16 all-to-all data corruption."""
+        if not torch.is_grad_enabled() and output.dtype == torch.bfloat16 and self.token_dispatcher.ep_size > 1:
+            # Widening BF16 values to FP32 is exact and avoids silent corruption seen in
+            # large variable-split EP all-to-all payloads in the affected release runtime.
+            output_dtype = output.dtype
+            output = self.token_dispatcher.token_combine(output.float()).to(dtype=output_dtype)
+            return output
+        return super().combine(output)
+
+
 def minimax_m3_block_spec(
     config: TransformerConfig,
     use_transformer_engine: bool = True,
@@ -88,7 +112,7 @@ def minimax_m3_block_spec(
             if mlp_submodules.router is not TopKRouter:
                 continue
             mlp_kwargs["submodules"] = replace(mlp_submodules, router=MiniMaxM3TopKRouter)
-            layer_spec.submodules.mlp = partial(mlp_spec.func, *mlp_spec.args, **mlp_kwargs)
+            layer_spec.submodules.mlp = partial(MiniMaxM3MoELayer, *mlp_spec.args, **mlp_kwargs)
 
     return block_spec
 

--- a/src/megatron/bridge/models/minimax_m3/minimax_m3_bridge.py
+++ b/src/megatron/bridge/models/minimax_m3/minimax_m3_bridge.py
@@ -79,7 +79,7 @@ class MiniMaxM3MoELayer(MoELayer):
             # Widening BF16 values to FP32 is exact and avoids silent corruption seen in
             # large variable-split EP all-to-all payloads in the affected release runtime.
             output_dtype = output.dtype
-            output = self.token_dispatcher.token_combine(output.float()).to(dtype=output_dtype)
+            output = super().combine(output.float()).to(dtype=output_dtype)
             return output
         return super().combine(output)
 

--- a/src/megatron/bridge/models/minimax_m3/minimax_m3_bridge.py
+++ b/src/megatron/bridge/models/minimax_m3/minimax_m3_bridge.py
@@ -115,12 +115,7 @@ def _promote_router_weights_to_float32(model: list[torch.nn.Module]) -> list[tor
 
 @dataclass
 class MiniMaxM3ModelProvider(GPTModelProvider):
-    """GPT provider with MiniMax-M3's FP32 router and HybridEP defaults."""
-
-    moe_token_dispatcher_type: str = "flex"
-    moe_flex_dispatcher_backend: str = "hybridep"
-    moe_flex_dispatcher_num_sms: int | None = 16
-    moe_permute_fusion_into_hybridep: bool = False
+    """GPT provider that preserves MiniMax-M3's FP32 router parameters."""
 
     def __post_init__(self) -> None:
         """Install MiniMax-M3 router behavior on fresh and deserialized providers."""
@@ -351,6 +346,10 @@ class MiniMaxM3Bridge(MegatronModelBridge):
         # MoE settings — sigmoid routing with expert bias correction and
         # normalized top-k weights scaled by routed_scaling_factor (DeepSeek-V3 style)
         provider.moe_grouped_gemm = True
+        provider.moe_token_dispatcher_type = "flex"
+        provider.moe_flex_dispatcher_backend = "hybridep"
+        provider.moe_flex_dispatcher_num_sms = 16
+        provider.moe_permute_fusion_into_hybridep = False
         provider.moe_permute_fusion = True
         provider.moe_router_pre_softmax = False
         provider.moe_router_score_function = "sigmoid"

--- a/src/megatron/bridge/models/minimax_m3/minimax_m3_bridge.py
+++ b/src/megatron/bridge/models/minimax_m3/minimax_m3_bridge.py
@@ -60,30 +60,6 @@ class MiniMaxM3TopKRouter(TopKRouter):
         return super().gating(input.to(dtype=self.weight.dtype))
 
 
-class MiniMaxM3MoELayer(MoELayer):
-    """MiniMax-M3 MoE layer with reliable expert-parallel inference communication."""
-
-    def dispatch(self, hidden_states: torch.Tensor, probs: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
-        """Dispatch tokens without BF16 all-to-all data corruption."""
-        if not torch.is_grad_enabled() and hidden_states.dtype == torch.bfloat16 and self.token_dispatcher.ep_size > 1:
-            # Widening BF16 values to FP32 is exact and avoids silent corruption seen in
-            # large variable-split EP all-to-all payloads in the affected release runtime.
-            hidden_states_dtype = hidden_states.dtype
-            hidden_states, probs = super().dispatch(hidden_states.float(), probs)
-            return hidden_states.to(dtype=hidden_states_dtype), probs
-        return super().dispatch(hidden_states, probs)
-
-    def combine(self, output: torch.Tensor) -> torch.Tensor:
-        """Combine expert outputs without BF16 all-to-all data corruption."""
-        if not torch.is_grad_enabled() and output.dtype == torch.bfloat16 and self.token_dispatcher.ep_size > 1:
-            # Widening BF16 values to FP32 is exact and avoids silent corruption seen in
-            # large variable-split EP all-to-all payloads in the affected release runtime.
-            output_dtype = output.dtype
-            output = super().combine(output.float()).to(dtype=output_dtype)
-            return output
-        return super().combine(output)
-
-
 def minimax_m3_block_spec(
     config: TransformerConfig,
     use_transformer_engine: bool = True,
@@ -112,7 +88,7 @@ def minimax_m3_block_spec(
             if mlp_submodules.router is not TopKRouter:
                 continue
             mlp_kwargs["submodules"] = replace(mlp_submodules, router=MiniMaxM3TopKRouter)
-            layer_spec.submodules.mlp = partial(MiniMaxM3MoELayer, *mlp_spec.args, **mlp_kwargs)
+            layer_spec.submodules.mlp = partial(mlp_spec.func, *mlp_spec.args, **mlp_kwargs)
 
     return block_spec
 
@@ -139,7 +115,12 @@ def _promote_router_weights_to_float32(model: list[torch.nn.Module]) -> list[tor
 
 @dataclass
 class MiniMaxM3ModelProvider(GPTModelProvider):
-    """GPT provider that preserves MiniMax-M3's FP32 router parameters."""
+    """GPT provider with MiniMax-M3's FP32 router and HybridEP defaults."""
+
+    moe_token_dispatcher_type: str = "flex"
+    moe_flex_dispatcher_backend: str = "hybridep"
+    moe_flex_dispatcher_num_sms: int | None = 16
+    moe_permute_fusion_into_hybridep: bool = False
 
     def __post_init__(self) -> None:
         """Install MiniMax-M3 router behavior on fresh and deserialized providers."""
@@ -370,7 +351,6 @@ class MiniMaxM3Bridge(MegatronModelBridge):
         # MoE settings — sigmoid routing with expert bias correction and
         # normalized top-k weights scaled by routed_scaling_factor (DeepSeek-V3 style)
         provider.moe_grouped_gemm = True
-        provider.moe_token_dispatcher_type = "alltoall"
         provider.moe_permute_fusion = True
         provider.moe_router_pre_softmax = False
         provider.moe_router_score_function = "sigmoid"

--- a/src/megatron/bridge/recipes/minimax/h100/minimax_m3.py
+++ b/src/megatron/bridge/recipes/minimax/h100/minimax_m3.py
@@ -134,6 +134,8 @@ def minimax_m3_pretrain_256gpu_h100_bf16_config() -> ConfigContainer:
     cfg.env_vars = {
         **COMMON_RECIPE_ENV_VARS,
         "NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN": 8,
+        "NVLINK_DOMAIN_SIZE": 8,
+        "USE_MNNVL": 0,
     }
     return cfg
 
@@ -206,6 +208,8 @@ def minimax_m3_sft_128gpu_h100_bf16_config() -> ConfigContainer:
     cfg.env_vars = {
         **COMMON_RECIPE_ENV_VARS,
         "NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN": 8,
+        "NVLINK_DOMAIN_SIZE": 8,
+        "USE_MNNVL": 0,
     }
     return cfg
 

--- a/src/megatron/bridge/recipes/minimax/h100/minimax_m3.py
+++ b/src/megatron/bridge/recipes/minimax/h100/minimax_m3.py
@@ -63,7 +63,10 @@ def minimax_m3_pretrain_256gpu_h100_bf16_config() -> ConfigContainer:
     cfg.model.transformer_impl = "transformer_engine"
     cfg.model.attention_backend = None
 
-    cfg.model.moe_token_dispatcher_type = "alltoall"
+    cfg.model.moe_token_dispatcher_type = "flex"
+    cfg.model.moe_flex_dispatcher_backend = "hybridep"
+    cfg.model.moe_flex_dispatcher_num_sms = 16
+    cfg.model.moe_permute_fusion_into_hybridep = False
     cfg.model.moe_grouped_gemm = True
     cfg.model.moe_permute_fusion = True
     cfg.model.moe_router_force_load_balancing = False
@@ -130,6 +133,7 @@ def minimax_m3_pretrain_256gpu_h100_bf16_config() -> ConfigContainer:
     # Keep the complete process environment visible on the recipe.
     cfg.env_vars = {
         **COMMON_RECIPE_ENV_VARS,
+        "NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN": 8,
     }
     return cfg
 
@@ -167,7 +171,10 @@ def minimax_m3_sft_128gpu_h100_bf16_config() -> ConfigContainer:
     cfg.model.transformer_impl = "transformer_engine"
     cfg.model.attention_backend = None
 
-    cfg.model.moe_token_dispatcher_type = "alltoall"
+    cfg.model.moe_token_dispatcher_type = "flex"
+    cfg.model.moe_flex_dispatcher_backend = "hybridep"
+    cfg.model.moe_flex_dispatcher_num_sms = 16
+    cfg.model.moe_permute_fusion_into_hybridep = False
     cfg.model.moe_grouped_gemm = True
     cfg.model.moe_permute_fusion = True
     cfg.model.moe_router_force_load_balancing = False
@@ -198,6 +205,7 @@ def minimax_m3_sft_128gpu_h100_bf16_config() -> ConfigContainer:
     # Keep the complete process environment visible on the recipe.
     cfg.env_vars = {
         **COMMON_RECIPE_ENV_VARS,
+        "NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN": 8,
     }
     return cfg
 

--- a/tests/unit_tests/models/minimax_m3/test_minimax_m3_bridge.py
+++ b/tests/unit_tests/models/minimax_m3/test_minimax_m3_bridge.py
@@ -31,6 +31,7 @@ from megatron.bridge.models.hf_pretrained.causal_lm import PreTrainedCausalLM
 from megatron.bridge.models.minimax_m3.minimax_m3_bridge import (
     MiniMaxM3Bridge,
     MiniMaxM3ModelProvider,
+    MiniMaxM3MoELayer,
     MiniMaxM3TopKRouter,
     MiniMaxM3VLModelProvider,
     TopKRouter,
@@ -480,9 +481,56 @@ class TestMiniMaxM3Bridge:
             )
         ]
         assert dense_layer_spec.submodules.mlp is dense_mlp_spec
-        assert moe_layer_spec.submodules.mlp.func is MoELayer
+        assert moe_layer_spec.submodules.mlp.func is MiniMaxM3MoELayer
         assert moe_layer_spec.submodules.mlp.keywords["submodules"].router is MiniMaxM3TopKRouter
         assert moe_submodules.router is TopKRouter
+
+    def test_moe_layer_uses_fp32_ep_transport_during_distributed_inference(self):
+        layer = object.__new__(MiniMaxM3MoELayer)
+        torch.nn.Module.__init__(layer)
+        layer.config = SimpleNamespace(overlap_dispatch_backward_with_experts_wgrad=False)
+        layer.token_dispatcher = Mock()
+        layer.token_dispatcher.ep_size = 32
+        layer.token_dispatcher.token_dispatch.side_effect = lambda hidden_states, probs: (hidden_states, probs)
+        layer.token_dispatcher.token_combine.side_effect = lambda tensor: tensor
+        expert_output = torch.randn(8, 16, dtype=torch.bfloat16)
+        router_probs = torch.rand(8, dtype=torch.float32)
+
+        with torch.no_grad():
+            dispatched_output, dispatched_probs = layer.dispatch(expert_output, router_probs)
+            combined_output = layer.combine(expert_output)
+
+        dispatched_transport = layer.token_dispatcher.token_dispatch.call_args.args[0]
+        combined_transport = layer.token_dispatcher.token_combine.call_args.args[0]
+        assert dispatched_transport.dtype == torch.float32
+        assert combined_transport.dtype == torch.float32
+        assert dispatched_output.dtype == torch.bfloat16
+        assert combined_output.dtype == torch.bfloat16
+        assert dispatched_probs is router_probs
+        torch.testing.assert_close(dispatched_output, expert_output)
+        torch.testing.assert_close(combined_output, expert_output)
+
+    def test_moe_layer_preserves_bf16_ep_transport_during_training(self):
+        layer = object.__new__(MiniMaxM3MoELayer)
+        torch.nn.Module.__init__(layer)
+        layer.config = SimpleNamespace(overlap_dispatch_backward_with_experts_wgrad=False)
+        layer.token_dispatcher = Mock()
+        layer.token_dispatcher.ep_size = 32
+        layer.token_dispatcher.token_dispatch.side_effect = lambda hidden_states, probs: (hidden_states, probs)
+        layer.token_dispatcher.token_combine.side_effect = lambda tensor: tensor
+        expert_output = torch.randn(8, 16, dtype=torch.bfloat16)
+        router_probs = torch.rand(8, dtype=torch.float32)
+
+        dispatched_output, dispatched_probs = layer.dispatch(expert_output, router_probs)
+        combined_output = layer.combine(expert_output)
+
+        dispatched_transport = layer.token_dispatcher.token_dispatch.call_args.args[0]
+        combined_transport = layer.token_dispatcher.token_combine.call_args.args[0]
+        assert dispatched_transport.dtype == torch.bfloat16
+        assert combined_transport.dtype == torch.bfloat16
+        assert dispatched_output is expert_output
+        assert dispatched_probs is router_probs
+        assert combined_output is expert_output
 
     def test_minimax_router_is_registered_as_replicated(self):
         assert "MiniMaxM3TopKRouter" in AutoMapping._MODULE_TYPE_REGISTRY["replicated"]

--- a/tests/unit_tests/models/minimax_m3/test_minimax_m3_bridge.py
+++ b/tests/unit_tests/models/minimax_m3/test_minimax_m3_bridge.py
@@ -31,7 +31,6 @@ from megatron.bridge.models.hf_pretrained.causal_lm import PreTrainedCausalLM
 from megatron.bridge.models.minimax_m3.minimax_m3_bridge import (
     MiniMaxM3Bridge,
     MiniMaxM3ModelProvider,
-    MiniMaxM3MoELayer,
     MiniMaxM3TopKRouter,
     MiniMaxM3VLModelProvider,
     TopKRouter,
@@ -231,6 +230,10 @@ class TestMiniMaxM3Bridge:
         assert text_provider.hidden_size == vlm_provider.hidden_size
         assert text_provider.num_layers == vlm_provider.num_layers
         assert text_provider.transformer_layer_spec == vlm_provider.transformer_layer_spec
+        assert text_provider.moe_token_dispatcher_type == "flex"
+        assert text_provider.moe_flex_dispatcher_backend == "hybridep"
+        assert text_provider.moe_flex_dispatcher_num_sms == 16
+        assert text_provider.moe_permute_fusion_into_hybridep is False
         assert not hasattr(text_provider, "vision_config")
 
     def test_provider_bridge_uses_top_level_embedding_tie_contract(self):
@@ -258,7 +261,10 @@ class TestMiniMaxM3Bridge:
         assert provider.moe_router_pre_softmax is False
         assert provider.moe_router_score_function == "sigmoid"
         assert provider.moe_router_enable_expert_bias is True
-        assert provider.moe_token_dispatcher_type == "alltoall"
+        assert provider.moe_token_dispatcher_type == "flex"
+        assert provider.moe_flex_dispatcher_backend == "hybridep"
+        assert provider.moe_flex_dispatcher_num_sms == 16
+        assert provider.moe_permute_fusion_into_hybridep is False
         assert provider.moe_router_load_balancing_type == "aux_loss"
         assert provider.moe_router_topk_scaling_factor == 2.0
         assert provider.moe_shared_expert_intermediate_size == 32
@@ -481,56 +487,9 @@ class TestMiniMaxM3Bridge:
             )
         ]
         assert dense_layer_spec.submodules.mlp is dense_mlp_spec
-        assert moe_layer_spec.submodules.mlp.func is MiniMaxM3MoELayer
+        assert moe_layer_spec.submodules.mlp.func is MoELayer
         assert moe_layer_spec.submodules.mlp.keywords["submodules"].router is MiniMaxM3TopKRouter
         assert moe_submodules.router is TopKRouter
-
-    def test_moe_layer_uses_fp32_ep_transport_during_distributed_inference(self):
-        layer = object.__new__(MiniMaxM3MoELayer)
-        torch.nn.Module.__init__(layer)
-        layer.config = SimpleNamespace(overlap_dispatch_backward_with_experts_wgrad=False)
-        layer.token_dispatcher = Mock()
-        layer.token_dispatcher.ep_size = 32
-        layer.token_dispatcher.token_dispatch.side_effect = lambda hidden_states, probs: (hidden_states, probs)
-        layer.token_dispatcher.token_combine.side_effect = lambda tensor: tensor
-        expert_output = torch.randn(8, 16, dtype=torch.bfloat16)
-        router_probs = torch.rand(8, dtype=torch.float32)
-
-        with torch.no_grad():
-            dispatched_output, dispatched_probs = layer.dispatch(expert_output, router_probs)
-            combined_output = layer.combine(expert_output)
-
-        dispatched_transport = layer.token_dispatcher.token_dispatch.call_args.args[0]
-        combined_transport = layer.token_dispatcher.token_combine.call_args.args[0]
-        assert dispatched_transport.dtype == torch.float32
-        assert combined_transport.dtype == torch.float32
-        assert dispatched_output.dtype == torch.bfloat16
-        assert combined_output.dtype == torch.bfloat16
-        assert dispatched_probs is router_probs
-        torch.testing.assert_close(dispatched_output, expert_output)
-        torch.testing.assert_close(combined_output, expert_output)
-
-    def test_moe_layer_preserves_bf16_ep_transport_during_training(self):
-        layer = object.__new__(MiniMaxM3MoELayer)
-        torch.nn.Module.__init__(layer)
-        layer.config = SimpleNamespace(overlap_dispatch_backward_with_experts_wgrad=False)
-        layer.token_dispatcher = Mock()
-        layer.token_dispatcher.ep_size = 32
-        layer.token_dispatcher.token_dispatch.side_effect = lambda hidden_states, probs: (hidden_states, probs)
-        layer.token_dispatcher.token_combine.side_effect = lambda tensor: tensor
-        expert_output = torch.randn(8, 16, dtype=torch.bfloat16)
-        router_probs = torch.rand(8, dtype=torch.float32)
-
-        dispatched_output, dispatched_probs = layer.dispatch(expert_output, router_probs)
-        combined_output = layer.combine(expert_output)
-
-        dispatched_transport = layer.token_dispatcher.token_dispatch.call_args.args[0]
-        combined_transport = layer.token_dispatcher.token_combine.call_args.args[0]
-        assert dispatched_transport.dtype == torch.bfloat16
-        assert combined_transport.dtype == torch.bfloat16
-        assert dispatched_output is expert_output
-        assert dispatched_probs is router_probs
-        assert combined_output is expert_output
 
     def test_minimax_router_is_registered_as_replicated(self):
         assert "MiniMaxM3TopKRouter" in AutoMapping._MODULE_TYPE_REGISTRY["replicated"]

--- a/tests/unit_tests/recipes/minimax/test_minimax_m3_recipes.py
+++ b/tests/unit_tests/recipes/minimax/test_minimax_m3_recipes.py
@@ -57,3 +57,5 @@ def test_text_recipe_uses_text_only_provider(monkeypatch, recipe):
     assert cfg.model.moe_flex_dispatcher_num_sms == 16
     assert cfg.model.moe_permute_fusion_into_hybridep is False
     assert cfg.env_vars["NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN"] == 8
+    assert cfg.env_vars["NVLINK_DOMAIN_SIZE"] == 8
+    assert cfg.env_vars["USE_MNNVL"] == 0

--- a/tests/unit_tests/recipes/minimax/test_minimax_m3_recipes.py
+++ b/tests/unit_tests/recipes/minimax/test_minimax_m3_recipes.py
@@ -52,3 +52,8 @@ def test_text_recipe_uses_text_only_provider(monkeypatch, recipe):
     cfg = recipe()
 
     assert isinstance(cfg.model, _FakeTextProvider)
+    assert cfg.model.moe_token_dispatcher_type == "flex"
+    assert cfg.model.moe_flex_dispatcher_backend == "hybridep"
+    assert cfg.model.moe_flex_dispatcher_num_sms == 16
+    assert cfg.model.moe_permute_fusion_into_hybridep is False
+    assert cfg.env_vars["NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN"] == 8

--- a/tests/unit_tests/utils/test_vlm_generate_utils.py
+++ b/tests/unit_tests/utils/test_vlm_generate_utils.py
@@ -42,6 +42,18 @@ with mock.patch.dict(sys.modules, {"megatron.bridge.utils.safe_url": _safe_url_m
 
 
 @pytest.mark.unit
+def test_decode_generated_tokens_excludes_prompt_and_uses_integer_ids():
+    tokenizer = mock.MagicMock()
+    tokenizer.decode.return_value = "completion"
+    generated_ids = torch.tensor([[10, 11, 12, 20, 21]])
+
+    output = vlm_generate_utils.decode_generated_tokens(tokenizer, generated_ids, prompt_length=3)
+
+    assert output == "completion"
+    tokenizer.decode.assert_called_once_with([20, 21])
+
+
+@pytest.mark.unit
 class TestProcessMultiImageInputs:
     """Tests for ``process_multi_image_inputs``."""
 


### PR DESCRIPTION
# What does this PR do?

Uses HybridEP as the MiniMax-M3 model-specific expert-parallel dispatcher default for inference and the public H100 pretrain/SFT recipes. This avoids the affected BF16 grouped all-to-all transport path and replaces the earlier inference-only FP32 transport workaround.

# Root cause

On the affected release runtime, finite MiniMax-M3 BF16 tensors become corrupted at variable-split EP all-to-all dispatch/combine and produce step-0 NaN logits. Isolation below MCore found stale or uninitialized `ncclIbRequest.send.onlyWriteImm` state in the SPCX grouped all-to-all path; requests can be misclassified, losing or corrupting payload data. The same model, checkpoint, prompt, and EP32 topology remain finite with NCCL internal IB or HybridEP.

This is not a prompt-formatting, checkpoint-conversion, router-math, or weight-roundtrip issue. It is also separate from the older cuBLAS router crash.

# Changes

- Configure the MiniMax-M3 Bridge mapping to use `flex` / `hybridep`, 16 dispatcher SMs, with HybridEP permute fusion disabled.
- Apply the same settings to the 256-H100 pretrain and 128-H100 packed-SFT recipes, including an 8-rank NVLink domain for H100 nodes.
- Remove the MiniMax-specific inference-only BF16-to-FP32 all-to-all dispatch/combine workaround and return to the standard MCore MoE layer.
- Keep MiniMax-M3's FP32 router projection and parameter behavior unchanged.
- Keep the generated-suffix-only VLM decoding fix from the earlier revision of this PR.
- Add provider/recipe assertions and update the MiniMax-M3 verification card. Training entries remain explicitly unverified.

Bridge-created MiniMax-M3 providers use the new configuration. Existing native checkpoints may still contain a serialized `alltoall` setting, so inference callers loading those checkpoints must also override the deserialized model config.

# Reproduction and controlled validation

The public reproduction shape is:

```bash
./scripts/inference/infer.sh --nodes 4 --gpus-per-node 8 \
  --task vlm-generation \
  --hf_model_path MiniMaxAI/MiniMax-M3 \
  --hf-revision 50942730318c7943fe83db7ec8e9f9177ecb1cf8 \
  --megatron_model_path <verified-imported-checkpoint> \
  --tp 1 --pp 1 --ep 32 --etp 1 \
  --image_path docs/images/tp1.png \
  --prompt "Read the green caption near the top of the image. Answer immediately with only the exact quoted term, including capitalization and hyphen; do not explain or reason." \
  --max_new_tokens 64 \
  --trust_remote_code
```

With the affected all-to-all path, step 0 produces NaN logits and empty/token-0 degeneration. With the four HybridEP model settings above and an 8-rank H100 NVLink domain, a matched 32-H100 TP1/PP1/EP32/ETP1 run observed 50/50 finite full-vocabulary logit vectors, no NaNs or infinities, no token 0, natural EOS, and the exact historical token sequence ending in `Pre-LayerNorm`.

This was a controlled configuration-level validation on clean Bridge/MCore source, not a training run and not a performance comparison.

# Validation and known dependency

- Model verification card schema: passed; its focused validator suite passed (18 tests).
- Focused MiniMax-M3 provider/recipe tests passed (37 tests).
- Focused VLM generation utility tests passed (13 tests).
- Full repository pre-commit hooks passed.
- The local GPU driver is older than the repository container runtime, so these local tests ran on CPU and do not substitute for GPU training validation.
- The earlier revision's generated-suffix decoding tests and full CI passed, but that prior CI result does not validate this new commit.

No backward pass, optimizer step, convergence run, or training performance run is claimed. The public recipes require 128 or 256 H100s, beyond the 32-GPU investigation ceiling.

Packed-SFT verification also requires the padding-safe dropless HybridEP routing changes merged to MCore dev in [NVIDIA/Megatron-LM#5542](https://github.com/NVIDIA/Megatron-LM/pull/5542). The current Bridge MCore main pin does not yet contain that complete change, so this PR should not merge until the applicable MCore main/backport pin is available and the bounded training checks pass.

# Before this PR is ready for review

- [x] Root cause isolated below MCore.
- [x] Deterministic real-model HybridEP inference validated on the target topology.
- [x] Bridge mapping, H100 training recipes, focused assertions, and verification card updated.
- [x] No MCore source, dependency, CI, or public API changed.
- [ ] Pin an MCore main revision with padding-safe HybridEP routing for packed SFT.
- [ ] Pass updated Bridge CI.
- [ ] Run bounded finite-loss pretrain/SFT validation before marking training verified.
