### PR TITLE
[training, data] fix: Enable packed PP shapes for heterogeneous configs

### DIFF
--- a/src/megatron/bridge/models/transformer_config.py
+++ b/src/megatron/bridge/models/transformer_config.py
@@ -311,6 +311,8 @@ class HeterogeneousTransformerConfig(TransformerConfig, MCoreHeterogeneousTransf
         _set_moe_expert_tensor_parallel_default(self)
         _enable_safe_hybridep_dispatch(self)
         MCoreHeterogeneousTransformerConfig.__post_init__(self)
+        if getattr(self, "_enable_in_batch_packing", False) and self.pipeline_model_parallel_size > 1:
+            self.variable_seq_lengths = True
 
     def get_config_for_layer(self, layer_number: int) -> MCoreTransformerConfig:
         """Return a layer-specific TransformerConfig without deep-copying process groups."""

--- a/tests/unit_tests/training/test_config.py
+++ b/tests/unit_tests/training/test_config.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import os
 from dataclasses import fields
 from typing import Any, Optional, Union
@@ -32,7 +33,7 @@ from megatron.bridge.models.gpt.model_config import BridgeGPTModelConfig
 from megatron.bridge.models.gpt_provider import GPTModelProvider
 from megatron.bridge.models.mla_provider import MLAModelProvider
 from megatron.bridge.models.t5_provider import T5ModelProvider
-from megatron.bridge.models.transformer_config import TransformerConfig
+from megatron.bridge.models.transformer_config import HeterogeneousTransformerConfig, TransformerConfig
 from megatron.bridge.training.comm_overlap import CommOverlapConfig
 from megatron.bridge.training.config import (
     CheckpointConfig,
@@ -1099,6 +1100,42 @@ class TestConfigContainerValidation:
                 ffn_hidden_size=256,
                 pipeline_model_parallel_size=2,
                 use_cpu_initialization=True,
+            ),
+            vocab_size=256,
+            seq_length=512,
+        )
+        train_cfg = create_test_training_config(micro_batch_size=2, global_batch_size=8)
+        dataset_cfg = create_test_direct_hf_sft_dataset_config(sequence_length=512)
+        dataset_cfg.enable_in_batch_packing = True
+
+        container, og_ws, cfg_mod = create_test_config_container(
+            world_size_override=2,
+            model_config=model_cfg,
+            train_config=train_cfg,
+            dataset_config_override=dataset_cfg,
+        )
+
+        try:
+            container.validate()
+            assert model_cfg.transformer.variable_seq_lengths is True
+        finally:
+            restore_get_world_size_safe(og_ws, cfg_mod)
+
+    def test_in_batch_packing_enables_variable_pp_shapes_for_heterogeneous_model(self):
+        """Test heterogeneous GPT configs use dynamic PP shapes for packed batches."""
+        block = {
+            "attention": {"no_op": False, "replace_with_linear": False, "num_query_groups": 4},
+            "mlp": {"no_op": False, "replace_with_linear": False, "ffn_hidden_size": 256},
+        }
+        model_cfg = BridgeGPTModelConfig(
+            transformer=HeterogeneousTransformerConfig(
+                num_layers=2,
+                hidden_size=128,
+                num_attention_heads=4,
+                ffn_hidden_size=256,
+                pipeline_model_parallel_size=2,
+                use_cpu_initialization=True,
+                heterogeneous_layers_config_encoded_json=json.dumps({"block_configs": [block, block]}),
             ),
             vocab_size=256,
             seq_length=512,


### PR DESCRIPTION
## Problem

In-batch-packed SFT with pipeline parallelism produces physical activations shaped as one aggregate token row. `ConfigContainer.validate()` marks the nested transformer config so its finalizer can enable variable pipeline shapes. Standard and MLA transformer configs honor that marker, but `HeterogeneousTransformerConfig` did not.

As a result, supported GPT configurations combining a heterogeneous transformer, in-batch packing, micro-batch size greater than one, and PP greater than one left MCore in static-shape mode. A downstream pipeline rank could receive the packed activation under the configured `[sequence, micro-batch, hidden]` shape instead of its actual `[packed tokens, 1, hidden]` shape.

## Fix

Honor the existing packing marker in the heterogeneous finalizer at the same ownership boundary as the standard and MLA sibling configs. Add a focused `ConfigContainer` regression test for the public nested-config path.

## Validation

Fail-before and pass-after used the same regression and exact base revision:

- `uv run --active --no-sync python -m pytest tests/unit_tests/training/test_config.py::TestConfigContainerValidation::test_in_batch_packing_enables_variable_pp_shapes_for_heterogeneous_model -q --tb=short`
  - Before: 1 failed because `variable_seq_lengths` remained `False`.
  - After: 1 passed.
- `uv run --active --no-sync python -m torch.distributed.run --standalone --nproc_per_node=2 reproduce_heterogeneous_pp_shape.py`
  - Before: receiver observed `(4, 2, 8)` for a sender activation shaped `(8, 1, 8)`.
  - After: passed; receiver retained `(8, 1, 8)`.
- Focused sibling/finalizer tests: 10 passed.
- `git diff --check`: passed.
- `uv run --active --no-sync pre-commit run --all-files`: passed.

## Scope

This only aligns heterogeneous transformer finalization with the existing packed-PP contract. It does not change packing behavior, public APIs, dependencies, or static-shape behavior for non-packed runs.
