### PR TITLE
[model] fix: preserve Gemma 4 layer schedules

### DIFF
--- a/src/megatron/bridge/models/gemma/gemma3_provider.py
+++ b/src/megatron/bridge/models/gemma/gemma3_provider.py
@@ -348,8 +348,10 @@ class Gemma3RotaryEmbedding(RotaryEmbedding):
 
 def _is_local_attn_layer(
     layer_number: int,
-    layer_pattern: Tuple[int, int],
+    layer_pattern: tuple[int, int] | list[str],
 ) -> bool:
-    pattern_size = sum(layer_pattern)
-    local_layer_count = layer_pattern[0]
+    if layer_pattern and isinstance(layer_pattern[0], str):
+        return layer_pattern[layer_number - 1] == "sliding_attention"
+    local_layer_count = int(layer_pattern[0])
+    pattern_size = local_layer_count + int(layer_pattern[1])
     return (layer_number - 1) % pattern_size < local_layer_count

--- a/src/megatron/bridge/models/gemma/gemma4_bridge.py
+++ b/src/megatron/bridge/models/gemma/gemma4_bridge.py
@@ -80,8 +80,8 @@ class _Gemma4DenseQKVMapping(QKVMapping):
         self.allow_hf_name_mismatch = True
 
 
-def _infer_attn_pattern(layer_types: list[str]) -> tuple[int, int]:
-    """Infer (sliding, global) interleaved attention pattern from layer_types list."""
+def _infer_attn_pattern(layer_types: list[str]) -> tuple[int, int] | list[str]:
+    """Use a compact cycle when possible, otherwise preserve the per-layer pattern."""
     for i, lt in enumerate(layer_types):
         if lt == "full_attention":
             sliding_count = i
@@ -91,7 +91,10 @@ def _infer_attn_pattern(layer_types: list[str]) -> tuple[int, int]:
                     full_count += 1
                 else:
                     break
-            return (sliding_count, full_count)
+            pattern = (sliding_count, full_count)
+            cycle = ["sliding_attention"] * sliding_count + ["full_attention"] * full_count
+            reconstructed = [cycle[index % len(cycle)] for index in range(len(layer_types))]
+            return pattern if reconstructed == layer_types else list(layer_types)
     return (len(layer_types), 0)
 
 

--- a/src/megatron/bridge/models/gemma/gemma4_provider.py
+++ b/src/megatron/bridge/models/gemma/gemma4_provider.py
@@ -285,7 +285,7 @@ class Gemma4ModelProvider(GPTModelProvider):
     kv_channels: int = 256
     num_query_groups: int = 8
     window_size: int = 1024
-    interleaved_attn_pattern: tuple = (5, 1)
+    interleaved_attn_pattern: tuple[int, int] | list[str] = (5, 1)
     attention_dropout: float = 0.0
     hidden_dropout: float = 0.0
     attention_backend: AttnBackend = AttnBackend.auto

--- a/tests/unit_tests/models/gemma/test_gemma4_bridge.py
+++ b/tests/unit_tests/models/gemma/test_gemma4_bridge.py
@@ -205,6 +205,29 @@ class TestGemma4BridgeProviderBridgeMoE:
 
         assert runtime_layer_types == layer_types
 
+    def test_runtime_preserves_nonperiodic_attention_schedule(self, bridge):
+        layer_types = ["full_attention", "sliding_attention", "full_attention"]
+        hf_config = Gemma4TextConfig(
+            num_hidden_layers=len(layer_types),
+            enable_moe_block=True,
+            num_experts=2,
+            top_k_experts=1,
+            moe_intermediate_size=4,
+            layer_types=layer_types,
+        )
+        pretrained = Mock(spec=PreTrainedCausalLM)
+        pretrained.config = hf_config
+
+        provider = bridge.provider_bridge(pretrained)
+        runtime_layer_types = [
+            "sliding_attention"
+            if _is_local_attn_layer(layer_number, provider.interleaved_attn_pattern)
+            else "full_attention"
+            for layer_number in range(1, provider.num_layers + 1)
+        ]
+
+        assert runtime_layer_types == layer_types
+
     def test_logit_softcapping(self, bridge, mock_pretrained_moe):
         assert bridge.provider_bridge(mock_pretrained_moe).final_logit_softcapping == 30.0
 
@@ -383,7 +406,8 @@ class TestInferAttnPattern:
         assert _infer_attn_pattern(lt) == (3, 2)
 
     def test_global_at_start(self):
-        assert _infer_attn_pattern(["full_attention"] + ["sliding_attention"] * 5) == (0, 1)
+        layer_types = ["full_attention"] + ["sliding_attention"] * 5
+        assert _infer_attn_pattern(layer_types) == layer_types
 
 
 # ===========================================================================

--- a/tests/unit_tests/models/gemma_vl/test_gemma4_vl_bridge.py
+++ b/tests/unit_tests/models/gemma_vl/test_gemma4_vl_bridge.py
@@ -397,7 +397,8 @@ class TestInferAttnPattern:
         assert _infer_attn_pattern(lt) == (3, 2)
 
     def test_global_at_start(self):
-        assert _infer_attn_pattern(["full_attention"] + ["sliding_attention"] * 5) == (0, 1)
+        layer_types = ["full_attention"] + ["sliding_attention"] * 5
+        assert _infer_attn_pattern(layer_types) == layer_types
 
 
 class TestMaybeModifyLoadedHFWeightCausal:


### PR DESCRIPTION
## What does this PR do?

Preserves valid non-periodic Gemma 4 MoE attention schedules during Hugging Face provider conversion.

Transformers accepts `layer_types` as a per-layer list. Bridge previously reduced every list to the sliding/full run around its first full-attention layer and repeated that cycle. For a valid `[full_attention, sliding_attention, full_attention]` config, Bridge constructed all three layers as full attention. With different local/global head dimensions this breaks weight loading; with matching dimensions it silently selects the wrong window, mask, RoPE, tied-KV behavior, and checkpoint namespace.

The fix retains the compact `(sliding_count, full_count)` representation when it reconstructs the complete list exactly, and otherwise keeps the explicit per-layer schedule. The shared layer classifier now handles both representations, covering the text and VL MoE provider paths while leaving periodic and dense behavior unchanged.

## Validation

Fail-before on the unmodified base:

```text
uv run python -m pytest tests/unit_tests/models/gemma/test_gemma4_bridge.py::TestGemma4BridgeProviderBridgeMoE::test_runtime_preserves_nonperiodic_attention_schedule -q
1 failed: layer 2 was full attention instead of sliding attention
```

Pass-after with the unchanged regression:

```text
uv run python -m pytest tests/unit_tests/models/gemma/test_gemma4_bridge.py::TestGemma4BridgeProviderBridgeMoE::test_runtime_preserves_nonperiodic_attention_schedule -q
1 passed
```

Adjacent tests:

```text
uv run python -m pytest \
  tests/unit_tests/models/gemma/test_gemma4_bridge.py \
  tests/unit_tests/models/gemma/test_gemma3_provider.py \
  tests/unit_tests/models/gemma_vl/test_gemma4_vl_bridge.py -q
178 passed
```

`git diff --check` and `uv run pre-commit run --all-files` also passed.

## Scope

- No public API, dependency, workflow, lockfile, or Megatron-Core changes.
- Validation is limited to focused CPU contract and adjacent unit tests; this does not claim full-model GPU parity, convergence, performance, or full-suite validation.
