### PR TITLE
[misc] fix: Print requested text generation log probabilities

### DIFF
--- a/scripts/inference/text_generation.py
+++ b/scripts/inference/text_generation.py
@@ -111,6 +111,15 @@ def _print_results(prompts: list[str], outputs: list[object]) -> None:
         generated_text = getattr(output, "generated_text", "")
         print_rank_0(f"[{idx}] Prompt: {prompt}")
         print_rank_0(f"[{idx}] Generated: {generated_text}")
+        for label, attribute in (
+            ("Prompt log probs", "prompt_log_probs"),
+            ("Generated log probs", "generated_log_probs"),
+            ("Prompt top-n logprobs", "prompt_top_n_logprobs"),
+            ("Generated top-n logprobs", "generated_top_n_logprobs"),
+        ):
+            value = getattr(output, attribute, None)
+            if value is not None:
+                print_rank_0(f"[{idx}] {label}: {value}")
     print_rank_0("=======================================")
 
 

--- a/tests/unit_tests/scripts/test_text_generation_entrypoint.py
+++ b/tests/unit_tests/scripts/test_text_generation_entrypoint.py
@@ -155,3 +155,27 @@ def test_dynamic_generation_accepts_stopping_controls(text_generation_entrypoint
             stop_words=["<END>"],
         )
     )
+
+
+@pytest.mark.unit
+def test_print_results_includes_returned_log_probabilities(
+    text_generation_entrypoint: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    messages: list[str] = []
+    monkeypatch.setattr(text_generation_entrypoint, "print_rank_0", messages.append)
+    output = types.SimpleNamespace(
+        generated_text="generated",
+        prompt_log_probs=[-0.1, -0.2],
+        generated_log_probs=[-0.3],
+        prompt_top_n_logprobs=[{"prompt-token": -0.1}],
+        generated_top_n_logprobs=[{"generated-token": -0.3}],
+    )
+
+    text_generation_entrypoint._print_results(["prompt"], [output])
+
+    rendered = "\n".join(messages)
+    assert "Prompt log probs: [-0.1, -0.2]" in rendered
+    assert "Generated log probs: [-0.3]" in rendered
+    assert "Prompt top-n logprobs: [{'prompt-token': -0.1}]" in rendered
+    assert "Generated top-n logprobs: [{'generated-token': -0.3}]" in rendered


### PR DESCRIPTION
## Summary

The maintained offline text-generation CLI accepts `--return-log-probs` and `--top-n-logprobs`, passes them through to MCore, and pays the cost to compute the requested data. Both dynamic and legacy generation return prompt/generated log probabilities and optional top-N values, but the CLI's only result sink printed generated text alone, so users could not observe any requested probability output.

This change prints each populated log-probability field alongside the existing prompt and generated text. Defensive attribute access preserves compatibility with result objects that do not carry those optional fields.

## Root cause

`build_sampling_params()` correctly enabled MCore log-probability materialization, and both engine paths returned populated request objects. `_print_results()` only read `generated_text` and then discarded the objects; the standalone CLI has no file, callback, server, or programmatic return channel.

## Validation

Fail-before on unmodified `origin/main`:

```text
uv run --no-sync python -m pytest --confcutdir=tests/unit_tests/scripts -p no:cacheprovider tests/unit_tests/scripts/test_text_generation_entrypoint.py::test_print_results_includes_returned_log_probabilities -q
1 failed: captured rank-zero output contained generated text but none of the four populated log-probability fields
```

Pass-after, with the unchanged regression and adjacent entry-point tests:

```text
uv run --no-sync python -m pytest --confcutdir=tests/unit_tests/scripts -p no:cacheprovider tests/unit_tests/scripts/test_text_generation_entrypoint.py -q
4 passed
```

Additional checks:

```text
uv run --no-sync ruff check scripts/inference/text_generation.py tests/unit_tests/scripts/test_text_generation_entrypoint.py
uv run --no-sync ruff format --check scripts/inference/text_generation.py tests/unit_tests/scripts/test_text_generation_entrypoint.py
git diff --check
uv run --no-sync pre-commit run --all-files
```

All passed.

## Scope

This changes only the standalone synchronous text-generation CLI's rank-zero rendering. It does not change MCore sampling semantics, output tensors, server/async behavior, model loading, distributed execution, dependencies, or public signatures. No GPU, distributed, convergence, performance, or full-suite validation is claimed.
