### PR TITLE
fix(recipe): resync DeepSeek V4 pipeline layout after overrides

### DIFF
--- a/src/megatron/bridge/models/deepseek/deepseek_v4_bridge.py
+++ b/src/megatron/bridge/models/deepseek/deepseek_v4_bridge.py
@@ -61,6 +61,7 @@ Megatron-Core prerequisites:
   - Separate MTP e_proj / h_proj modules with hyper-connections
 """
 
+from functools import partial
 from typing import Dict, Mapping
 
 import torch
@@ -122,29 +123,20 @@ def deepseek_v4_supports_fused_dsa_kernels() -> bool:
     return True
 
 
-def set_deepseek_v4_pipeline_model_parallel_layout(model_cfg: MLAModelProvider) -> None:
-    """Set an even DSv4 pipeline layout with MTP and loss on the last stage.
+def _get_deepseek_v4_pipeline_layout(
+    pp_size: int,
+    vp_size: int | None,
+    *,
+    num_layers: int,
+    mtp_layers: int,
+) -> list[list[str]] | None:
+    """Build a DeepSeek-V4 pipeline layout for the requested topology."""
+    effective_vp_size = 1 if vp_size is None else vp_size
+    if effective_vp_size != 1:
+        raise ValueError(f"DeepSeek-V4 pipeline layouts do not support VP={effective_vp_size}.")
+    if pp_size <= 1 or num_layers <= 0:
+        return None
 
-    DeepSeek-V4 uses hash-routed MoE layers that must co-locate with the
-    embedding on the first pipeline stage, so an explicit
-    ``pipeline_model_parallel_layout`` is required whenever
-    ``pipeline_model_parallel_size > 1``. This builds an even decoder split with
-    the embedding on the first stage and the MTP/loss layers on the last stage.
-
-    Args:
-        model_cfg: The DeepSeek-V4 model provider to configure in place.
-    """
-    pp_size = model_cfg.pipeline_model_parallel_size or 1
-    if pp_size <= 1:
-        model_cfg.pipeline_model_parallel_layout = None
-        return
-
-    num_layers = int(getattr(model_cfg, "num_layers", 0) or 0)
-    if num_layers <= 0:
-        model_cfg.pipeline_model_parallel_layout = None
-        return
-
-    mtp_layers = int(getattr(model_cfg, "mtp_num_layers", 0) or 0)
     base_layers, extra_layers = divmod(num_layers, pp_size)
     layout: list[list[str]] = []
     for pp_rank in range(pp_size):
@@ -159,8 +151,33 @@ def set_deepseek_v4_pipeline_model_parallel_layout(model_cfg: MLAModelProvider) 
             stage.extend(["mtp"] * mtp_layers)
             stage.append("loss")
         layout.append(stage)
+    return layout
 
-    model_cfg.pipeline_model_parallel_layout = layout
+
+def set_deepseek_v4_pipeline_model_parallel_layout(model_cfg: MLAModelProvider) -> None:
+    """Set an even DSv4 pipeline layout with MTP and loss on the last stage.
+
+    DeepSeek-V4 uses hash-routed MoE layers that must co-locate with the
+    embedding on the first pipeline stage, so an explicit
+    ``pipeline_model_parallel_layout`` is required whenever
+    ``pipeline_model_parallel_size > 1``. This builds an even decoder split with
+    the embedding on the first stage and the MTP/loss layers on the last stage.
+
+    Args:
+        model_cfg: The DeepSeek-V4 model provider to configure in place.
+    """
+    num_layers = int(getattr(model_cfg, "num_layers", 0) or 0)
+    mtp_layers = int(getattr(model_cfg, "mtp_num_layers", 0) or 0)
+    layout_builder = partial(
+        _get_deepseek_v4_pipeline_layout,
+        num_layers=num_layers,
+        mtp_layers=mtp_layers,
+    )
+    model_cfg._pipeline_model_parallel_layout_builder = layout_builder
+    model_cfg.pipeline_model_parallel_layout = layout_builder(
+        model_cfg.pipeline_model_parallel_size or 1,
+        getattr(model_cfg, "virtual_pipeline_model_parallel_size", None),
+    )
 
 
 def _dsv4_num_hash_layers(hf_config) -> int:

--- a/tests/unit_tests/recipes/test_deepseek_recipes.py
+++ b/tests/unit_tests/recipes/test_deepseek_recipes.py
@@ -35,6 +35,7 @@ from megatron.bridge.recipes.deepseek import (
 )
 from megatron.bridge.recipes.deepseek.deepseek_v3 import _build_standalone_mtp_layout
 from tests.unit_tests.recipes.recipe_test_utils import patch_recipe_module_global
+from tests.unit_tests.training.test_run_recipe_qwen3_omni import _load_recipe_runner_module
 
 
 _deepseek_module = importlib.import_module("megatron.bridge.recipes.deepseek")
@@ -71,15 +72,19 @@ class _FakeModelCfg:
 
 
 class _FakeBridge:
-    def __init__(self):
-        pass
+    def __init__(self, hf_path: str | None = None):
+        self.hf_path = hf_path
 
     def to_megatron_provider(self, load_weights: bool = False):
-        return _FakeModelCfg()
+        model_cfg = _FakeModelCfg()
+        if self.hf_path is not None and "DeepSeek-V4" in self.hf_path:
+            model_cfg.num_layers = 61 if "V4-Pro" in self.hf_path else 43
+            model_cfg.mtp_num_layers = 1
+        return model_cfg
 
     @staticmethod
     def from_hf_pretrained(hf_path: str, **kwargs):
-        return _FakeBridge()
+        return _FakeBridge(hf_path)
 
 
 class _DSv4ProviderStub(ModelProviderMixin):
@@ -470,3 +475,18 @@ def test_deepseek_v4_flash_no_mtp_sft_recipe_disables_mtp(monkeypatch: pytest.Mo
     assert cfg.model.use_fused_mhc is True
     assert cfg.model.mtp_num_layers is None
     assert cfg.model.mtp_loss_scaling_factor == 0.0
+
+
+def test_deepseek_v4_pipeline_layout_tracks_supported_cli_topology(monkeypatch: pytest.MonkeyPatch):
+    cfg = _build_deepseek_v4_recipe("deepseek_v4_flash_sft_config", monkeypatch)
+    recipe_runner, _ = _load_recipe_runner_module()
+
+    cfg.model.pipeline_model_parallel_size = 8
+    recipe_runner.sync_model_pipeline_layout(
+        cfg,
+        cli_overrides=["model.pipeline_model_parallel_size=8"],
+    )
+
+    layout = PipelineParallelLayerLayout(cfg.model.pipeline_model_parallel_layout, pipeline_model_parallel_size=8)
+    assert layout.virtual_pipeline_model_parallel_size == 1
+    assert layout.validate_layer_layout(cfg.model.num_layers, cfg.model.mtp_num_layers) is False


### PR DESCRIPTION
## What changed

DeepSeek V4 recipes now retain a topology-aware pipeline-layout builder so the shared recipe runner can rebuild the model layout after a supported pipeline-parallel CLI override.

## User impact and root cause

The documented H100 scale-up path uses pipeline parallel size 8, but `deepseek_v4_flash_sft_config` materialized its default four-stage layout during recipe construction and did not register a builder. When a user selected the recipe and overrode pipeline parallelism to 8, `sync_model_pipeline_layout` therefore left the four-stage layout unchanged. Megatron-Core rejected that configuration because the layout length was not divisible by the requested pipeline size.

The fix parameterizes the existing DeepSeek V4 layout construction with the provider's actual decoder and MTP layer counts, stores it under the existing recipe-runner builder contract, and uses it for both initial construction and override synchronization. The DeepSeek V4 layout remains non-interleaved; an unsupported VP value is rejected explicitly.

## Validation

Fail before / pass after:

```text
uv run python -m pytest tests/unit_tests/recipes/test_deepseek_recipes.py::test_deepseek_v4_pipeline_layout_tracks_supported_cli_topology -q --tb=short
before: 1 failed (four layout stages with pipeline_model_parallel_size=8)
after:  1 passed
```

Adjacent tests:

```text
uv run python -m pytest tests/unit_tests/recipes/test_deepseek_recipes.py tests/unit_tests/scripts/training/test_recipe_runner.py -q --tb=short
67 passed
```

Additional checks:

```text
uv run mypy --strict src/megatron/bridge/models/deepseek/deepseek_v4_bridge.py
uv run pre-commit run --all-files
git diff --check
```

All passed.

## Scope

This changes only DeepSeek V4 recipe-owned pipeline layout synchronization and its regression coverage. It does not change public APIs, dependencies, CI workflows, Megatron-Core, model numerics, or performance defaults. No GPU run, full test suite, convergence test, or performance benchmark was performed.
