### PR TITLE
[docs] fix: pass process groups in RL integration guide

### DIFF
--- a/docs/bridge-rl-integration.md
+++ b/docs/bridge-rl-integration.md
@@ -155,7 +155,7 @@ from megatron.bridge.training.state import GlobalState
 # Minimal bootstrap
 state = GlobalState()
 state.cfg = megatron_cfg
-initialize_megatron(cfg=megatron_cfg)
+pg_collection = initialize_megatron(cfg=megatron_cfg)
 set_jit_fusion_options(megatron_cfg.model, megatron_cfg.train.micro_batch_size)
 
 ckpt_ctx = init_checkpointing_context(megatron_cfg.checkpoint)
@@ -165,6 +165,7 @@ model_list = get_model(
     use_torch_fsdp2=megatron_cfg.dist.use_torch_fsdp2,
     overlap_param_gather_with_optimizer_step=megatron_cfg.optimizer.overlap_param_gather_with_optimizer_step,
     data_parallel_random_init=megatron_cfg.rng.data_parallel_random_init,
+    pg_collection=pg_collection,
 )
 optimizer, scheduler = setup_optimizer(
     optimizer_config=megatron_cfg.optimizer,
@@ -440,11 +441,12 @@ class MegatronBridgeAdapter:
         from megatron.bridge.training.initialize import initialize_megatron, set_jit_fusion_options
         from megatron.bridge.models.model_provider import get_model
         from megatron.bridge.training.optim import setup_optimizer
-        initialize_megatron(cfg=self.megatron_cfg)
+        pg_collection = initialize_megatron(cfg=self.megatron_cfg)
         set_jit_fusion_options(self.megatron_cfg.model, self.megatron_cfg.train.micro_batch_size)
         self.model_list = get_model(self.megatron_cfg.model, self.megatron_cfg.ddp,
                                     use_torch_fsdp2=self.megatron_cfg.dist.use_torch_fsdp2,
-                                    overlap_param_gather_with_optimizer_step=self.megatron_cfg.optimizer.overlap_param_gather_with_optimizer_step)
+                                    overlap_param_gather_with_optimizer_step=self.megatron_cfg.optimizer.overlap_param_gather_with_optimizer_step,
+                                    pg_collection=pg_collection)
         self.model = self.model_list[0]
         self.optimizer, self.scheduler = setup_optimizer(self.megatron_cfg.optimizer, self.megatron_cfg.scheduler, self.model_list,
                                                          use_gloo_process_groups=self.megatron_cfg.dist.use_gloo_process_groups)

--- a/docs/fern/versions/0.4.2/pages/bridge-rl-integration.mdx
+++ b/docs/fern/versions/0.4.2/pages/bridge-rl-integration.mdx
@@ -151,7 +151,7 @@ from megatron.bridge.training.state import GlobalState
 # Minimal bootstrap
 state = GlobalState()
 state.cfg = megatron_cfg
-initialize_megatron(cfg=megatron_cfg)
+pg_collection = initialize_megatron(cfg=megatron_cfg)
 set_jit_fusion_options(megatron_cfg.model, megatron_cfg.train.micro_batch_size)
 
 ckpt_ctx = init_checkpointing_context(megatron_cfg.checkpoint)
@@ -161,6 +161,7 @@ model_list = get_model(
     use_torch_fsdp2=megatron_cfg.dist.use_torch_fsdp2,
     overlap_param_gather_with_optimizer_step=megatron_cfg.optimizer.overlap_param_gather_with_optimizer_step,
     data_parallel_random_init=megatron_cfg.rng.data_parallel_random_init,
+    pg_collection=pg_collection,
 )
 optimizer, scheduler = setup_optimizer(
     optimizer_config=megatron_cfg.optimizer,
@@ -431,11 +432,12 @@ class MegatronBridgeAdapter:
         from megatron.bridge.training.initialize import initialize_megatron, set_jit_fusion_options
         from megatron.bridge.models.model_provider import get_model
         from megatron.bridge.training.optim import setup_optimizer
-        initialize_megatron(cfg=self.megatron_cfg)
+        pg_collection = initialize_megatron(cfg=self.megatron_cfg)
         set_jit_fusion_options(self.megatron_cfg.model, self.megatron_cfg.train.micro_batch_size)
         self.model_list = get_model(self.megatron_cfg.model, self.megatron_cfg.ddp,
                                     use_torch_fsdp2=self.megatron_cfg.dist.use_torch_fsdp2,
-                                    overlap_param_gather_with_optimizer_step=self.megatron_cfg.optimizer.overlap_param_gather_with_optimizer_step)
+                                    overlap_param_gather_with_optimizer_step=self.megatron_cfg.optimizer.overlap_param_gather_with_optimizer_step,
+                                    pg_collection=pg_collection)
         self.model = self.model_list[0]
         self.optimizer, self.scheduler = setup_optimizer(self.megatron_cfg.optimizer, self.megatron_cfg.scheduler, self.model_list,
                                                          use_gloo_process_groups=self.megatron_cfg.dist.use_gloo_process_groups)

--- a/docs/fern/versions/nightly/pages/bridge-rl-integration.mdx
+++ b/docs/fern/versions/nightly/pages/bridge-rl-integration.mdx
@@ -151,7 +151,7 @@ from megatron.bridge.training.state import GlobalState
 # Minimal bootstrap
 state = GlobalState()
 state.cfg = megatron_cfg
-initialize_megatron(cfg=megatron_cfg)
+pg_collection = initialize_megatron(cfg=megatron_cfg)
 set_jit_fusion_options(megatron_cfg.model, megatron_cfg.train.micro_batch_size)
 
 ckpt_ctx = init_checkpointing_context(megatron_cfg.checkpoint)
@@ -161,6 +161,7 @@ model_list = get_model(
     use_torch_fsdp2=megatron_cfg.dist.use_torch_fsdp2,
     overlap_param_gather_with_optimizer_step=megatron_cfg.optimizer.overlap_param_gather_with_optimizer_step,
     data_parallel_random_init=megatron_cfg.rng.data_parallel_random_init,
+    pg_collection=pg_collection,
 )
 optimizer, scheduler = setup_optimizer(
     optimizer_config=megatron_cfg.optimizer,
@@ -431,11 +432,12 @@ class MegatronBridgeAdapter:
         from megatron.bridge.training.initialize import initialize_megatron, set_jit_fusion_options
         from megatron.bridge.models.model_provider import get_model
         from megatron.bridge.training.optim import setup_optimizer
-        initialize_megatron(cfg=self.megatron_cfg)
+        pg_collection = initialize_megatron(cfg=self.megatron_cfg)
         set_jit_fusion_options(self.megatron_cfg.model, self.megatron_cfg.train.micro_batch_size)
         self.model_list = get_model(self.megatron_cfg.model, self.megatron_cfg.ddp,
                                     use_torch_fsdp2=self.megatron_cfg.dist.use_torch_fsdp2,
-                                    overlap_param_gather_with_optimizer_step=self.megatron_cfg.optimizer.overlap_param_gather_with_optimizer_step)
+                                    overlap_param_gather_with_optimizer_step=self.megatron_cfg.optimizer.overlap_param_gather_with_optimizer_step,
+                                    pg_collection=pg_collection)
         self.model = self.model_list[0]
         self.optimizer, self.scheduler = setup_optimizer(self.megatron_cfg.optimizer, self.megatron_cfg.scheduler, self.model_list,
                                                          use_gloo_process_groups=self.megatron_cfg.dist.use_gloo_process_groups)

--- a/tests/unit_tests/doc_consistency/test_readme_consistency.py
+++ b/tests/unit_tests/doc_consistency/test_readme_consistency.py
@@ -34,6 +34,12 @@ TRAINING_README = REPO_ROOT / "scripts" / "training" / "README.md"
 DATASET_UTILS = REPO_ROOT / "src" / "megatron" / "bridge" / "recipes" / "utils" / "dataset_utils.py"
 LLAMA_README = REPO_ROOT / "tutorials" / "recipes" / "llama" / "README.md"
 DCLM_README = REPO_ROOT / "tutorials" / "data" / "dclm" / "README.md"
+RL_INTEGRATION_DOCS = (
+    REPO_ROOT / "docs" / "bridge-rl-integration.md",
+    REPO_ROOT / "docs" / "fern" / "versions" / "nightly" / "pages" / "bridge-rl-integration.mdx",
+    REPO_ROOT / "docs" / "fern" / "versions" / "0.4.2" / "pages" / "bridge-rl-integration.mdx",
+)
+MODEL_PROVIDER = REPO_ROOT / "src" / "megatron" / "bridge" / "models" / "model_provider.py"
 GEMMA3_VL_README = REPO_ROOT / "examples" / "models" / "gemma" / "gemma3_vl" / "README.md"
 GEMMA3_VL_RECIPES = RECIPES_DIR / "gemma3_vl" / "gemma3_vl.py"
 RUN_RECIPE = REPO_ROOT / "scripts" / "training" / "run_recipe.py"
@@ -203,6 +209,51 @@ def test_hf_path_flag_documented_if_implemented():
     if '"--hf_path"' not in _read(RUN_RECIPE):
         return  # flag not implemented — nothing to document
     assert "--hf_path" in _read(TRAINING_README), "--hf_path is implemented but not documented in README"
+
+
+def test_rl_integration_get_model_calls_supply_required_keyword_only_arguments():
+    """RL integration snippets must satisfy get_model's required keyword-only contract."""
+    provider_tree = ast.parse(_read(MODEL_PROVIDER), filename=str(MODEL_PROVIDER))
+    get_model_def = next(
+        node for node in provider_tree.body if isinstance(node, ast.FunctionDef) and node.name == "get_model"
+    )
+    required_keywords = {
+        arg.arg
+        for arg, default in zip(get_model_def.args.kwonlyargs, get_model_def.args.kw_defaults)
+        if default is None
+    }
+    assert required_keywords, "get_model has no required keyword-only arguments — update this contract test"
+
+    missing: dict[str, dict[int, list[str]]] = {}
+    for path in RL_INTEGRATION_DOCS:
+        text = _read(path)
+        documented_calls: list[tuple[int, set[str]]] = []
+        for match in re.finditer(r"```python\n(?P<code>.*?)```", text, re.DOTALL):
+            code = match.group("code")
+            if "get_model(" not in code:
+                continue
+            tree = ast.parse(code, filename=str(path))
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                function_name = getattr(node.func, "id", None) or getattr(node.func, "attr", None)
+                if function_name != "get_model":
+                    continue
+                source_line = text.count("\n", 0, match.start("code")) + node.lineno
+                documented_calls.append(
+                    (source_line, {keyword.arg for keyword in node.keywords if keyword.arg is not None})
+                )
+
+        assert len(documented_calls) == 2, f"expected two RL integration get_model calls in {path}"
+        omitted = {
+            source_line: sorted(required_keywords - supplied_keywords)
+            for source_line, supplied_keywords in documented_calls
+            if required_keywords - supplied_keywords
+        }
+        if omitted:
+            missing[str(path.relative_to(REPO_ROOT))] = omitted
+
+    assert not missing, f"RL integration get_model calls omit required keyword-only arguments: {missing}"
 
 
 def test_model_examples_use_current_run_recipe_arguments():


### PR DESCRIPTION
## What does this PR do?

Fixes the public RL integration bootstrap and adapter snippets so they satisfy the current distributed model-construction contract.

## Supported trigger and impact

An integrator following either documented snippet initializes Megatron and then calls the module-level `get_model()`. That function requires keyword-only `pg_collection`, but both calls omitted it. Python therefore raised `TypeError: get_model() missing 1 required keyword-only argument: pg_collection` before model construction, optimizer setup, or checkpoint loading.

The same broken calls were published in the canonical guide, the nightly Fern copy, and the 0.4.2 Fern copy currently selected by `latest.yml`.

## Root cause and fix

`initialize_megatron()` returns the process-group collection created for the eager initialization path. The snippets discarded that value after `get_model()` made it required.

Each snippet now retains that exact return value and passes it to `get_model()`. A stdlib AST regression derives required keyword-only arguments from the current function definition and checks both calls in all three published copies.

Related prior context: #5093 was closed unmerged without an unsupported-path determination; this PR also covers the Fern mirrors noted in its review.

## Validation

Fail before on unmodified `012529a47a294ce0d1e4be55bba55b6bc38fa6eb`:

```text
uv run --no-project --with pytest python -m pytest -p no:cacheprovider --confcutdir=tests/unit_tests/doc_consistency tests/unit_tests/doc_consistency/test_readme_consistency.py::test_rl_integration_get_model_calls_supply_required_keyword_only_arguments -q
```

Result: 1 failed. The assertion reported missing `pg_collection` in both calls across all three copies.

Pass after:

```text
uv run --no-project --with pytest python -m pytest -p no:cacheprovider --confcutdir=tests/unit_tests/doc_consistency tests/unit_tests/doc_consistency/test_readme_consistency.py::test_rl_integration_get_model_calls_supply_required_keyword_only_arguments -q
```

Result: 1 passed.

Adjacent controls:

```text
uv run --no-project --with pytest python -m pytest -p no:cacheprovider --confcutdir=tests/unit_tests/doc_consistency tests/unit_tests/doc_consistency/test_readme_consistency.py -q
```

Result: 19 passed.

```text
git diff --check
uv run --no-project --with pre-commit==3.6.2 pre-commit run --all-files
```

Result: passed; every applicable pre-commit hook passed.

## Scope

This changes only the RL integration guide copies and a documentation-contract test. It does not change runtime APIs, dependencies, workflows, or the Megatron-Core submodule. No GPU, distributed execution, model-quality, convergence, or performance validation is claimed because the reproduced failure is deterministic Python argument binding.