### PR TITLE
[model] fix: Partition packed Kimi sequences per row

### DIFF
--- a/src/megatron/bridge/models/kimi_vl/modeling_kimi_k25_vl.py
+++ b/src/megatron/bridge/models/kimi_vl/modeling_kimi_k25_vl.py
@@ -25,13 +25,20 @@ from transformers.dynamic_module_utils import get_class_from_dynamic_module
 from transformers.utils import is_flash_attn_2_available
 
 from megatron.bridge.models.gpt_provider import GPTModelProvider
+from megatron.bridge.training.utils.packed_seq_utils import get_packed_seq_cp_partition_indices
 from megatron.bridge.utils.common_utils import hook_hf_module_setattr_for_tp_grad_sync
 
 
 logger = logging.getLogger(__name__)
 
 
-def _split_on_cp_rank(val: Optional[Tensor], cp_size: int, cp_rank: int, seq_dim: int) -> Optional[Tensor]:
+def _split_on_cp_rank(
+    val: Optional[Tensor],
+    cp_size: int,
+    cp_rank: int,
+    seq_dim: int,
+    packed_indices: Optional[Tensor] = None,
+) -> Optional[Tensor]:
     """Slice a tensor along ``seq_dim`` into this context-parallel rank's zigzag chunks.
 
     The image merge runs on the full sequence because every ``<|media_pad|>`` placeholder must
@@ -40,6 +47,8 @@ def _split_on_cp_rank(val: Optional[Tensor], cp_size: int, cp_rank: int, seq_dim
     """
     if val is None or cp_size <= 1:
         return val
+    if packed_indices is not None:
+        return val.index_select(seq_dim, packed_indices.to(device=val.device))
     seq_len = val.shape[seq_dim]
     if seq_len % (2 * cp_size) != 0:
         raise ValueError(
@@ -61,15 +70,16 @@ def _split_attention_mask_on_cp_rank(
     attention_mask: Optional[Tensor],
     cp_size: int,
     cp_rank: int,
+    packed_indices: Optional[Tensor] = None,
 ) -> Optional[Tensor]:
     """Slice a 2D or 4D attention mask into this context-parallel rank's zigzag chunks."""
     if attention_mask is None or cp_size <= 1:
         return attention_mask
     if attention_mask.dim() == 2:
-        return _split_on_cp_rank(attention_mask, cp_size, cp_rank, seq_dim=1)
+        return _split_on_cp_rank(attention_mask, cp_size, cp_rank, seq_dim=1, packed_indices=packed_indices)
     if attention_mask.dim() == 4:
-        attention_mask = _split_on_cp_rank(attention_mask, cp_size, cp_rank, seq_dim=2)
-        return _split_on_cp_rank(attention_mask, cp_size, cp_rank, seq_dim=3)
+        attention_mask = _split_on_cp_rank(attention_mask, cp_size, cp_rank, seq_dim=2, packed_indices=packed_indices)
+        return _split_on_cp_rank(attention_mask, cp_size, cp_rank, seq_dim=3, packed_indices=packed_indices)
     raise ValueError(f"attention_mask must be 2D or 4D for CP slicing, got shape {tuple(attention_mask.shape)}.")
 
 
@@ -429,6 +439,7 @@ class KimiK25VLModel(MegatronModule):
         """
         cp_size = parallel_state.get_context_parallel_world_size()
         cp_rank = parallel_state.get_context_parallel_rank() if cp_size > 1 else 0
+        packed_cp_indices = None
         if self.pre_process:
             if inputs_embeds is None:
                 inputs_embeds = self.language_model.embedding(
@@ -465,21 +476,51 @@ class KimiK25VLModel(MegatronModule):
                 # Don't need attention mask for causal attention.
                 attention_mask = None
 
+            if cp_size > 1 and packed_seq_params is not None:
+                packed_cp_indices = get_packed_seq_cp_partition_indices(
+                    packed_seq_params,
+                    total_tokens=inputs_embeds.shape[1],
+                    cp_size=cp_size,
+                    cp_rank=cp_rank,
+                    device=inputs_embeds.device,
+                    cp_group=parallel_state.get_context_parallel_group(),
+                )
+
             # Transpose back to (T, B, D) for Megatron language model
             inputs_embeds = inputs_embeds.transpose(1, 0).contiguous()  # (B, T, D) -> (T, B, D)
 
             if cp_size > 1:
-                inputs_embeds = _split_on_cp_rank(inputs_embeds, cp_size, cp_rank, seq_dim=0)
+                inputs_embeds = _split_on_cp_rank(
+                    inputs_embeds, cp_size, cp_rank, seq_dim=0, packed_indices=packed_cp_indices
+                )
 
             if self.config.sequence_parallel:
                 tp_group = self.config._pg_collection.tp if self.config._pg_collection is not None else None
                 inputs_embeds = scatter_to_sequence_parallel_region(inputs_embeds, group=tp_group)
 
         if cp_size > 1:
-            labels = _split_on_cp_rank(labels, cp_size, cp_rank, seq_dim=1)
-            loss_mask = _split_on_cp_rank(loss_mask, cp_size, cp_rank, seq_dim=1)
-            position_ids = _split_on_cp_rank(position_ids, cp_size, cp_rank, seq_dim=1)
-            attention_mask = _split_attention_mask_on_cp_rank(attention_mask, cp_size, cp_rank)
+            if packed_seq_params is not None and packed_cp_indices is None:
+                partition_source = next(
+                    (value for value in (labels, loss_mask, position_ids) if value is not None),
+                    None,
+                )
+                if partition_source is not None:
+                    packed_cp_indices = get_packed_seq_cp_partition_indices(
+                        packed_seq_params,
+                        total_tokens=partition_source.shape[1],
+                        cp_size=cp_size,
+                        cp_rank=cp_rank,
+                        device=partition_source.device,
+                        cp_group=parallel_state.get_context_parallel_group(),
+                    )
+            labels = _split_on_cp_rank(labels, cp_size, cp_rank, seq_dim=1, packed_indices=packed_cp_indices)
+            loss_mask = _split_on_cp_rank(loss_mask, cp_size, cp_rank, seq_dim=1, packed_indices=packed_cp_indices)
+            position_ids = _split_on_cp_rank(
+                position_ids, cp_size, cp_rank, seq_dim=1, packed_indices=packed_cp_indices
+            )
+            attention_mask = _split_attention_mask_on_cp_rank(
+                attention_mask, cp_size, cp_rank, packed_indices=packed_cp_indices
+            )
 
         outputs = self.language_model.forward(
             input_ids=None,

--- a/tests/unit_tests/models/kimi_vl/test_modeling_kimi_k25_vl.py
+++ b/tests/unit_tests/models/kimi_vl/test_modeling_kimi_k25_vl.py
@@ -202,6 +202,84 @@ def test_cp_split_attention_mask_slices_query_and_key_positions():
     assert torch.equal(rank0_mask, expected)
 
 
+def test_packed_cp_forward_partitions_each_logical_row(monkeypatch):
+    """Packed THD tensors must use MCore's per-row CP token ordering."""
+    from types import SimpleNamespace
+
+    from megatron.core.packed_seq_params import PackedSeqParams
+
+    from megatron.bridge.models.kimi_vl import modeling_kimi_k25_vl as kimi_model
+    from megatron.bridge.training.utils import packed_seq_utils
+
+    class _ProcessGroup:
+        def rank(self):
+            return 0
+
+        def size(self):
+            return 2
+
+    class _LanguageModel:
+        def __init__(self):
+            self.forward_kwargs = None
+
+        def embedding(self, input_ids, position_ids):  # noqa: ARG002
+            return input_ids.transpose(0, 1).unsqueeze(-1).float()
+
+        def forward(self, **kwargs):
+            self.forward_kwargs = kwargs
+            return torch.zeros_like(kwargs["labels"], dtype=torch.float32)
+
+    def _partition_each_row(batch, *, is_hybrid_cp, cp_group):
+        assert is_hybrid_cp is False
+        assert cp_group.size() == 2
+        boundaries = batch["cu_seqlens"].squeeze(0).tolist()
+        indices = []
+        for start, end in zip(boundaries[:-1], boundaries[1:]):
+            chunk = (end - start) // (2 * cp_group.size())
+            indices.extend(range(start, start + chunk))
+            indices.extend(range(end - chunk, end))
+        result = dict(batch)
+        result["tokens"] = batch["tokens"].index_select(1, torch.tensor(indices))
+        return result
+
+    cp_group = _ProcessGroup()
+    monkeypatch.setattr(kimi_model.parallel_state, "get_context_parallel_world_size", lambda: cp_group.size())
+    monkeypatch.setattr(kimi_model.parallel_state, "get_context_parallel_rank", cp_group.rank)
+    monkeypatch.setattr(kimi_model.parallel_state, "get_context_parallel_group", lambda: cp_group)
+    monkeypatch.setattr(packed_seq_utils, "get_batch_on_this_cp_rank", _partition_each_row)
+
+    language_model = _LanguageModel()
+    model = SimpleNamespace(
+        pre_process=True,
+        language_model=language_model,
+        config=SimpleNamespace(sequence_parallel=False),
+    )
+    positions = torch.arange(12).unsqueeze(0)
+    packed_seq_params = PackedSeqParams(
+        qkv_format="thd",
+        cu_seqlens_q=torch.tensor([0, 4, 12], dtype=torch.int32),
+        cu_seqlens_kv=torch.tensor([0, 4, 12], dtype=torch.int32),
+        max_seqlen_q=8,
+        max_seqlen_kv=8,
+    )
+
+    kimi_model.KimiK25VLModel.forward(
+        model,
+        input_ids=positions,
+        position_ids=positions,
+        labels=positions,
+        loss_mask=positions.float() + 100,
+        packed_seq_params=packed_seq_params,
+    )
+
+    expected_indices = torch.tensor([0, 3, 4, 5, 10, 11])
+    assert language_model.forward_kwargs is not None
+    assert torch.equal(language_model.forward_kwargs["decoder_input"].squeeze(), expected_indices.float())
+    assert torch.equal(language_model.forward_kwargs["labels"].squeeze(), expected_indices)
+    assert torch.equal(language_model.forward_kwargs["position_ids"].squeeze(), expected_indices)
+    assert torch.equal(language_model.forward_kwargs["loss_mask"].squeeze(), expected_indices.float() + 100)
+
+
 # ===========================================================================
 # Pre-expanded mode: num_placeholders == total_image_features
 # ===========================================================================


### PR DESCRIPTION
## Summary

Kimi K2.5-VL supports direct in-batch THD packing together with context
parallelism. With multiple physical packed rows and CP greater than one, its
model wrapper sliced the aggregate token stream into dense zigzag chunks.
MCore partitions THD tensors independently within every physical row, so the
old path could silently hand attention a different token-to-rank layout than
the global packed metadata described.

For example, with physical row boundaries `[0, 4, 12]` and CP=2, rank zero
received `[0, 1, 2, 9, 10, 11]` instead of
`[0, 3, 4, 5, 10, 11]`.

## Root cause and fix

The supported path is:

1. The Kimi collator builds one multi-row THD stream and physical cumulative
   lengths.
2. `vlm_step` forwards the full tensors and packed metadata.
3. Kimi merges embeddings and then applies model-side CP slicing.

That last step ignored packed row boundaries. The fix reuses the existing
MCore-backed packed-CP partition-index helper and applies its single physical
stream index consistently to embeddings, labels, loss masks, position IDs,
and attention-mask sequence dimensions. Dense non-packed CP behavior is
unchanged.

## Validation

Fail before, pass after with the unchanged regression:

```text
uv run --no-sync python -m pytest tests/unit_tests/models/kimi_vl/test_modeling_kimi_k25_vl.py::test_packed_cp_forward_partitions_each_logical_row -q --tb=short
```

- Before: `1 failed`; actual `[0, 1, 2, 9, 10, 11]`, expected
  `[0, 3, 4, 5, 10, 11]`.
- After: `1 passed`.

Focused adjacent coverage:

```text
uv run --no-sync python -m pytest tests/unit_tests/models/kimi_vl/test_modeling_kimi_k25_vl.py tests/unit_tests/training/utils/test_packed_seq_utils.py -q --tb=short
```

- `50 passed`.

A two-rank NCCL smoke also exercised Kimi forward with the pinned MCore THD
partition helper; both ranks matched their expected per-row ordering.

Quality gates:

```text
git diff --check
uv run --active --no-sync pre-commit run --all-files
```

- Both passed.

## Scope

- Kimi K2.5-VL packed context-parallel slicing only.
- No conversion API, recipe, dependency, workflow, or MCore submodule change.
- No full-suite, convergence, model-quality, or performance claim.
