### PR TITLE
[model] fix: isolate Step3.5 layer configs

### DIFF
--- a/src/megatron/bridge/models/stepfun/step35_provider.py
+++ b/src/megatron/bridge/models/stepfun/step35_provider.py
@@ -99,6 +99,11 @@ class Step35DecoderLayer(TransformerLayer):
         else:
             layer_idx = layer_number - 1
 
+        # Each layer carries forward-time settings selected by its global index.
+        # Keep those mutations local instead of rewriting other layers that were
+        # constructed from the provider's shared TransformerConfig instance.
+        config = copy.deepcopy(config)
+
         rotary_percents = getattr(config, "rotary_percents", None) or []
         if 0 <= layer_idx < len(rotary_percents):
             config.rotary_percent = rotary_percents[layer_idx]
@@ -113,7 +118,6 @@ class Step35DecoderLayer(TransformerLayer):
         )
         if is_sliding:
             if getattr(config, "sliding_attention_setting", None):
-                config = copy.deepcopy(config)
                 config.window_size = config.sliding_attention_setting["window_size"]
                 config.num_attention_heads = config.sliding_attention_setting["num_attention_heads"]
                 config.num_query_groups = config.sliding_attention_setting["num_query_groups"]

--- a/tests/unit_tests/models/stepfun/test_step35_provider.py
+++ b/tests/unit_tests/models/stepfun/test_step35_provider.py
@@ -232,16 +232,14 @@ class TestStep35DecoderLayerIsSliding:
 
         return config, recorder
 
-    def test_full_attention_keeps_original_config(self):
+    def test_full_attention_uses_independent_config(self):
         original, captured = self._build(layer_number=1)  # layer_idx=0 -> full_attention
-        # No deep-copy happens; downstream sub-modules see the original instance.
-        assert captured is original
+        assert captured is not original
         assert captured.num_attention_heads == 64
         assert captured.num_query_groups == 8
 
     def test_sliding_attention_overrides_shape(self):
         original, captured = self._build(layer_number=2)  # layer_idx=1 -> sliding
-        # Must be a deep-copy so other layers' configs are not mutated.
         assert captured is not original
         assert captured.rotary_percent == 1.0
         assert captured.num_attention_heads == 96
@@ -260,7 +258,7 @@ class TestStep35DecoderLayerIsSliding:
             offset_return=100,  # would have triggered out-of-range sliding lookup
             pp_rank=2,
         )
-        assert captured is original  # full attention
+        assert captured is not original  # full attention
 
     def test_mtp_layer_forwards_name_to_transformer_layer(self):
         """MCore's MTP builder passes ``name`` into the nested transformer layer."""
@@ -271,7 +269,7 @@ class TestStep35DecoderLayerIsSliding:
             name=name,
         )
 
-        assert recorder.captured_config is original
+        assert recorder.captured_config is not original
         assert recorder.captured_kwargs["name"] == name
 
     def test_pp_offset_applied_for_main_decoder(self):
@@ -290,7 +288,7 @@ class TestStep35DecoderLayerIsSliding:
             layer_number=2,
             sliding_setting=None,
         )
-        assert captured is original
+        assert captured is not original
         assert captured.num_attention_heads == 64
 
     def test_layer_idx_outside_layer_types_falls_through(self):
@@ -298,7 +296,7 @@ class TestStep35DecoderLayerIsSliding:
             layer_number=10,  # idx=9, outside len(layer_types)=2
             layer_types=["full_attention", "sliding_attention"],
         )
-        assert captured is original
+        assert captured is not original
 
     def test_sliding_override_does_not_leak_via_alias(self):
         """Mutating the deep-copied config must not change the original's
@@ -306,6 +304,48 @@ class TestStep35DecoderLayerIsSliding:
         original, captured = self._build(layer_number=2)
         captured.sliding_attention_setting["num_attention_heads"] = 999
         assert original.sliding_attention_setting["num_attention_heads"] == 96
+
+    def test_full_attention_layers_retain_independent_per_layer_config(self):
+        config = _make_config(
+            ["full_attention", "full_attention"],
+            sliding_setting=None,
+        )
+        config.rotary_percents = [0.5, 1.0]
+        config.swiglu_limits = [0.0, 7.0]
+        config.swiglu_limits_shared = [0.0, 16.0]
+        config.activation_func_clamp_value = None
+        config.activation_func_clamp_value_shared_expert = None
+
+        def record_config(instance, config, **kwargs):
+            instance.config = config
+
+        with (
+            patch.object(TransformerLayer, "__init__", record_config),
+            patch("megatron.bridge.models.stepfun.step35_provider.get_pg_rank", return_value=0),
+            patch(
+                "megatron.bridge.models.stepfun.step35_provider.get_transformer_layer_offset",
+                return_value=0,
+            ),
+        ):
+            layer_0 = Step35DecoderLayer(
+                config=config,
+                submodules=None,
+                layer_number=1,
+                pg_collection=SimpleNamespace(pp="dummy"),
+            )
+            layer_1 = Step35DecoderLayer(
+                config=config,
+                submodules=None,
+                layer_number=2,
+                pg_collection=SimpleNamespace(pp="dummy"),
+            )
+
+        assert layer_0.config.rotary_percent == 0.5
+        assert layer_0.config.activation_func_clamp_value is None
+        assert layer_0.config.activation_func_clamp_value_shared_expert is None
+        assert layer_1.config.rotary_percent == 1.0
+        assert layer_1.config.activation_func_clamp_value == 7.0
+        assert layer_1.config.activation_func_clamp_value_shared_expert == 16.0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Step3.5 full-attention decoder layers now receive independent configuration objects before applying per-layer rotary and activation-clamp settings.

## User impact

The supported Step-3.5 configuration reuses one TransformerConfig while constructing all decoder layers. The decoder-layer constructor mutates rotary and clamp fields for each layer. Previously, only sliding-window layers copied the config, so every full-attention layer shared one mutable object. Constructing the final full-attention layer could therefore overwrite the settings observed by earlier full-attention layers, including enabling expert and shared-expert activation clamps where those earlier layers should remain unclamped. This silently changes training and inference semantics.

## Root cause and fix

`Step35DecoderLayer` copied the configuration only inside the sliding-window branch, after checking the layer pattern. Full-attention layers retained the caller-owned shared configuration even though the constructor subsequently applies layer-specific values.

The fix deep-copies the configuration before any per-layer mutation for both attention modes. The existing sliding-window behavior is preserved, and a regression test constructs multiple full-attention layers from one input config and verifies that their rotary and clamp values remain independent.

## Reproduction and validation

Fail-before deterministic constructor reproducer, executing the production provider module:

`STEP35_PROVIDER_PATH=$REPO/src/megatron/bridge/models/stepfun/step35_provider.py UV_PROJECT_ENVIRONMENT=$PROJECT_VENV uv run --no-sync python $ARTIFACTS/reproduce_config_alias.py`

Result on `0c565c9a063bc8578ec094b4eb488594ed8b033a`: exit 1 with `AssertionError: layer 0 rotary_percent was overwritten by later layer construction: 1.0`.

The unchanged reproducer passes after the fix.

Focused and adjacent tests:

`uv run python -m pytest tests/unit_tests/models/stepfun/test_step35_provider.py tests/unit_tests/models/stepfun/test_step35_bridge.py -q`

Result: 71 passed.

Additional checks:

- `git diff --check` — passed
- `uv run pre-commit run --all-files` — passed

## Scope

This change only corrects Step3.5 decoder-layer configuration ownership and adds focused unit coverage. It does not modify public APIs, dependencies, CI configuration, checkpoint formats, or upstream Megatron-Core. No model-quality, convergence, performance, or end-to-end GPU claim is made.