### PR TITLE
[data] fix: Support legacy pickle protocols for video shards

### DIFF
--- a/src/megatron/bridge/utils/safe_pickle.py
+++ b/src/megatron/bridge/utils/safe_pickle.py
@@ -62,6 +62,13 @@ _ENERGON_SAFE_STATE_GLOBALS = MappingProxyType(
 _TRAVERSAL_IN_PROGRESS = object()
 
 
+def _restore_legacy_bytes(value: object, encoding: object) -> bytes:
+    """Reconstruct bytes from the fixed representation emitted by pickle protocols 0-2."""
+    if type(value) is not str or encoding != "latin1":
+        raise pickle.UnpicklingError("Restricted unpickler refused an invalid legacy bytes payload.")
+    return str.encode(value, "latin1")
+
+
 class _SafeEnumToken:
     """Hold a validated Enum member until the pickle VM has finished."""
 
@@ -223,6 +230,8 @@ class _RestrictedUnpickler(pickle.Unpickler):
     )
 
     def find_class(self, module: str, name: str) -> object:
+        if module == "_codecs" and name == "encode":
+            return _restore_legacy_bytes
         if module in self._SAFE_MODULES and name in self._SAFE_MODULES[module]:
             return super().find_class(module, name)
         raise pickle.UnpicklingError(

--- a/tests/unit_tests/utils/test_safe_pickle.py
+++ b/tests/unit_tests/utils/test_safe_pickle.py
@@ -15,6 +15,7 @@
 
 """Tests for safe_pickle module."""
 
+import codecs
 import io
 import os
 import pickle
@@ -189,6 +190,15 @@ class TestSafePickleRoundTrip:
         data = pickle.dumps(obj)
         assert safe_pickle_loads(data) == obj
 
+    @pytest.mark.parametrize("protocol", [0, 1, 2])
+    def test_pickled_video_frames_from_legacy_protocols(self, protocol):
+        """Encoded video frames remain loadable when shards use older pickle protocols."""
+        frames = [[b"encoded JPEG frame"]]
+
+        result = safe_pickle_loads(pickle.dumps(frames, protocol=protocol))
+
+        assert result == frames
+
     def test_safe_pickle_load_from_file(self):
         obj = {"key": [1, 2, 3]}
         buf = io.BytesIO()
@@ -224,6 +234,34 @@ class TestSafePickleRejectsUnsafe:
         data = pickle.dumps(type(None))
         with pytest.raises(pickle.UnpicklingError, match="Restricted unpickler refused"):
             safe_pickle_loads(data)
+
+    def test_rejects_application_codec_for_legacy_bytes(self):
+        """Legacy bytes reconstruction cannot select an application codec hook."""
+        hook_called = False
+
+        def search(encoding):
+            nonlocal hook_called
+            if encoding == "applicationcodec":
+                hook_called = True
+                return codecs.CodecInfo(
+                    name=encoding,
+                    encode=lambda value, errors="strict": (b"encoded", len(value)),
+                    decode=None,
+                )
+            return None
+
+        class Payload:
+            def __reduce__(self):
+                return codecs.encode, ("attacker selected", "applicationcodec")
+
+        codecs.register(search)
+        try:
+            with pytest.raises(pickle.UnpicklingError, match="invalid legacy bytes payload"):
+                safe_pickle_loads(pickle.dumps(Payload()))
+        finally:
+            codecs.unregister(search)
+
+        assert not hook_called
 
 
 class TestAllowlistImmutability:


### PR DESCRIPTION
## Summary

Bridge documents VLM WebDataset video fields as pickled nested lists of encoded JPEG frame bytes. Shards serialized with pickle protocols 0, 1, or 2 are valid inputs, but those protocols reconstruct Python 3 `bytes` through `_codecs.encode`. The generic restricted unpickler rejected that global before `videohandler` could decode any frame, so affected training jobs crashed while loading data.

## Root cause and fix

`videohandler` passes the documented pickled frame payload directly to `safe_pickle_loads`. `_RestrictedUnpickler` admitted safe built-in values but did not recognize the legacy bytes representation. This change resolves that one global to a private adapter which accepts only the exact `(str, "latin1")` representation emitted by protocols 0–2 and calls `str.encode` with hard-coded `latin1`. Other globals and attacker-selected codecs remain rejected.

## Regression evidence

Fail-before on unmodified `origin/main`:

```text
uv run --active --no-sync python -m pytest tests/unit_tests/utils/test_safe_pickle.py::TestSafePickleRoundTrip::test_pickled_video_frames_from_legacy_protocols -q
3 failed: Restricted unpickler refused to load '_codecs.encode'
```

Pass-after with the unchanged compatibility test and the registered-codec negative control:

```text
uv run --active --no-sync python -m pytest \
  tests/unit_tests/utils/test_safe_pickle.py::TestSafePickleRoundTrip::test_pickled_video_frames_from_legacy_protocols \
  tests/unit_tests/utils/test_safe_pickle.py::TestSafePickleRejectsUnsafe::test_rejects_application_codec_for_legacy_bytes -q
4 passed
```

Focused and adjacent validation:

```text
uv run --active --no-sync python -m pytest tests/unit_tests/utils/test_safe_pickle.py -q
52 passed

git diff --check
passed

uv run --active --no-sync pre-commit run --all-files
passed
```

The focused tests used an import-isolated harness around the actual production utility because package-wide collection on the CPU workstation eagerly imported an unrelated CUDA-only component; restricted-unpickler behavior was not mocked.

## Scope

This only restores protocol 0–2 compatibility for the documented safe bytes payload. It does not broaden arbitrary class loading or permit selectable codecs. No GPU, distributed, full-suite, convergence, model-quality, performance, dependency, workflow, or public-API validation/change is claimed.
