### PR TITLE
[docs] fix: align Gemma 2 programmatic recipe examples

### DIFF
--- a/docs/fern/versions/nightly/pages/models/gemma/gemma2.mdx
+++ b/docs/fern/versions/nightly/pages/models/gemma/gemma2.mdx
@@ -133,37 +133,31 @@ Before training, ensure the following environment variables are set:
 ```python
 from megatron.bridge.recipes.gemma import gemma2_2b_pretrain_config
 
-# Create a pretraining configuration
-config = gemma2_2b_pretrain_config(
-    name="my_gemma2_2b_pretrain",
-    data_paths=["path/to/data"],
-    train_iters=100000,
-    global_batch_size=32,
-)
+# Create and customize a pretraining configuration.
+config = gemma2_2b_pretrain_config()
+config.dataset.blend = [["path/to/data"], None]
+config.train.train_iters = 100000
+config.train.global_batch_size = 32
 ```
 
 #### Gemma 2 9B
 ```python
 from megatron.bridge.recipes.gemma import gemma2_9b_pretrain_config
 
-config = gemma2_9b_pretrain_config(
-    name="my_gemma2_9b_pretrain",
-    data_paths=["path/to/data"],
-    train_iters=100000,
-    global_batch_size=32,
-)
+config = gemma2_9b_pretrain_config()
+config.dataset.blend = [["path/to/data"], None]
+config.train.train_iters = 100000
+config.train.global_batch_size = 32
 ```
 
 #### Gemma 2 27B
 ```python
 from megatron.bridge.recipes.gemma import gemma2_27b_pretrain_config
 
-config = gemma2_27b_pretrain_config(
-    name="my_gemma2_27b_pretrain",
-    data_paths=["path/to/data"],
-    train_iters=100000,
-    global_batch_size=32,
-)
+config = gemma2_27b_pretrain_config()
+config.dataset.blend = [["path/to/data"], None]
+config.train.train_iters = 100000
+config.train.global_batch_size = 32
 ```
 
 ### Full Finetuning
@@ -183,12 +177,10 @@ Or programmatically:
 ```python
 from megatron.bridge.recipes.gemma import gemma2_2b_sft_config
 
-config = gemma2_2b_sft_config(
-    name="gemma2_2b_full_finetune",
-    pretrained_checkpoint="/models/gemma-2-2b",
-    train_iters=1000,
-    global_batch_size=64,
-)
+config = gemma2_2b_sft_config()
+config.checkpoint.pretrained_checkpoint = "/models/gemma-2-2b"
+config.train.train_iters = 1000
+config.train.global_batch_size = 64
 ```
 
 #### Gemma 2 9B
@@ -233,39 +225,30 @@ Or programmatically:
 from megatron.bridge.recipes.gemma import gemma2_2b_peft_config
 
 # LoRA finetuning
-config = gemma2_2b_peft_config(
-    name="gemma2_2b_lora_finetune",
-    pretrained_checkpoint="/models/gemma-2-2b",
-    peft_scheme="lora",  # or "dora"
-    train_iters=1000,
-    global_batch_size=128,
-)
+config = gemma2_2b_peft_config(peft_scheme="lora")  # or "dora"
+config.checkpoint.pretrained_checkpoint = "/models/gemma-2-2b"
+config.train.train_iters = 1000
+config.train.global_batch_size = 128
 ```
 
 #### Gemma 2 9B LoRA
 ```python
 from megatron.bridge.recipes.gemma import gemma2_9b_peft_config
 
-config = gemma2_9b_peft_config(
-    name="gemma2_9b_lora_finetune",
-    pretrained_checkpoint="/models/gemma-2-9b",
-    peft_scheme="lora",
-    train_iters=1000,
-    global_batch_size=128,
-)
+config = gemma2_9b_peft_config(peft_scheme="lora")
+config.checkpoint.pretrained_checkpoint = "/models/gemma-2-9b"
+config.train.train_iters = 1000
+config.train.global_batch_size = 128
 ```
 
 #### Gemma 2 27B LoRA
 ```python
 from megatron.bridge.recipes.gemma import gemma2_27b_peft_config
 
-config = gemma2_27b_peft_config(
-    name="gemma2_27b_lora_finetune",
-    pretrained_checkpoint="/models/gemma-2-27b",
-    peft_scheme="lora",
-    train_iters=1000,
-    global_batch_size=128,
-)
+config = gemma2_27b_peft_config(peft_scheme="lora")
+config.checkpoint.pretrained_checkpoint = "/models/gemma-2-27b"
+config.train.train_iters = 1000
+config.train.global_batch_size = 128
 ```
 
 ### Recommended Configurations

--- a/docs/models/gemma/gemma2.md
+++ b/docs/models/gemma/gemma2.md
@@ -133,37 +133,31 @@ Before training, ensure the following environment variables are set:
 ```python
 from megatron.bridge.recipes.gemma import gemma2_2b_pretrain_config
 
-# Create a pretraining configuration
-config = gemma2_2b_pretrain_config(
-    name="my_gemma2_2b_pretrain",
-    data_paths=["path/to/data"],
-    train_iters=100000,
-    global_batch_size=32,
-)
+# Create and customize a pretraining configuration.
+config = gemma2_2b_pretrain_config()
+config.dataset.blend = [["path/to/data"], None]
+config.train.train_iters = 100000
+config.train.global_batch_size = 32
 ```
 
 #### Gemma 2 9B
 ```python
 from megatron.bridge.recipes.gemma import gemma2_9b_pretrain_config
 
-config = gemma2_9b_pretrain_config(
-    name="my_gemma2_9b_pretrain",
-    data_paths=["path/to/data"],
-    train_iters=100000,
-    global_batch_size=32,
-)
+config = gemma2_9b_pretrain_config()
+config.dataset.blend = [["path/to/data"], None]
+config.train.train_iters = 100000
+config.train.global_batch_size = 32
 ```
 
 #### Gemma 2 27B
 ```python
 from megatron.bridge.recipes.gemma import gemma2_27b_pretrain_config
 
-config = gemma2_27b_pretrain_config(
-    name="my_gemma2_27b_pretrain",
-    data_paths=["path/to/data"],
-    train_iters=100000,
-    global_batch_size=32,
-)
+config = gemma2_27b_pretrain_config()
+config.dataset.blend = [["path/to/data"], None]
+config.train.train_iters = 100000
+config.train.global_batch_size = 32
 ```
 
 ### Full Finetuning
@@ -183,12 +177,10 @@ Or programmatically:
 ```python
 from megatron.bridge.recipes.gemma import gemma2_2b_sft_config
 
-config = gemma2_2b_sft_config(
-    name="gemma2_2b_full_finetune",
-    pretrained_checkpoint="/models/gemma-2-2b",
-    train_iters=1000,
-    global_batch_size=64,
-)
+config = gemma2_2b_sft_config()
+config.checkpoint.pretrained_checkpoint = "/models/gemma-2-2b"
+config.train.train_iters = 1000
+config.train.global_batch_size = 64
 ```
 
 #### Gemma 2 9B
@@ -233,39 +225,30 @@ Or programmatically:
 from megatron.bridge.recipes.gemma import gemma2_2b_peft_config
 
 # LoRA finetuning
-config = gemma2_2b_peft_config(
-    name="gemma2_2b_lora_finetune",
-    pretrained_checkpoint="/models/gemma-2-2b",
-    peft_scheme="lora",  # or "dora"
-    train_iters=1000,
-    global_batch_size=128,
-)
+config = gemma2_2b_peft_config(peft_scheme="lora")  # or "dora"
+config.checkpoint.pretrained_checkpoint = "/models/gemma-2-2b"
+config.train.train_iters = 1000
+config.train.global_batch_size = 128
 ```
 
 #### Gemma 2 9B LoRA
 ```python
 from megatron.bridge.recipes.gemma import gemma2_9b_peft_config
 
-config = gemma2_9b_peft_config(
-    name="gemma2_9b_lora_finetune",
-    pretrained_checkpoint="/models/gemma-2-9b",
-    peft_scheme="lora",
-    train_iters=1000,
-    global_batch_size=128,
-)
+config = gemma2_9b_peft_config(peft_scheme="lora")
+config.checkpoint.pretrained_checkpoint = "/models/gemma-2-9b"
+config.train.train_iters = 1000
+config.train.global_batch_size = 128
 ```
 
 #### Gemma 2 27B LoRA
 ```python
 from megatron.bridge.recipes.gemma import gemma2_27b_peft_config
 
-config = gemma2_27b_peft_config(
-    name="gemma2_27b_lora_finetune",
-    pretrained_checkpoint="/models/gemma-2-27b",
-    peft_scheme="lora",
-    train_iters=1000,
-    global_batch_size=128,
-)
+config = gemma2_27b_peft_config(peft_scheme="lora")
+config.checkpoint.pretrained_checkpoint = "/models/gemma-2-27b"
+config.train.train_iters = 1000
+config.train.global_batch_size = 128
 ```
 
 ### Recommended Configurations


### PR DESCRIPTION
## Summary

Gemma 2's maintained programmatic recipe examples still used the pre-parameterless API. Copying any example passed removed flat keyword arguments to direct recipe aliases and raised `TypeError` before configuration or training began.

This updates the canonical and nightly pages to construct each recipe first, then customize its nested `ConfigContainer` fields. PEFT continues to pass its supported `peft_scheme` argument.

## Root cause and impact

The public legacy names directly alias the H100 builders. Pretrain and SFT builders accept no arguments, while PEFT builders accept only `peft_scheme`. The docs nevertheless passed `name`, `data_paths`, `pretrained_checkpoint`, `train_iters`, and `global_batch_size` as flat kwargs.

All seven maintained programmatic examples failed during Python argument binding, before Hugging Face access, GPU initialization, or training. Gemma 2 is deprecated for future removal, but these recipes and examples remain publicly available today.

## Fix

- Instantiate parameterless pretrain/SFT recipes before assigning dataset, checkpoint, and training fields.
- Pass only `peft_scheme` to PEFT builders, then assign the same nested fields.
- Keep the canonical and nightly pages identical.

## Validation

- `UV_CACHE_DIR=<cache> uv run --no-sync python "$REPRODUCER" .`
  - Before: exit 1; reported unsupported keyword sets for all 14 mirrored calls.
  - After: exit 0; `validated 14 documented Gemma 2 recipe calls`.
- `cmp -s docs/models/gemma/gemma2.md docs/fern/versions/nightly/pages/models/gemma/gemma2.mdx` — passed.
- `git diff --check` — passed.
- `UV_CACHE_DIR=<cache> uv run --no-sync pre-commit run --all-files` — all hooks passed.

`$REPRODUCER` is a dependency-free AST contract check that parses the maintained Python snippets, follows the public aliases, and compares call keywords with the actual builder signatures. Focused runner tests were attempted but did not collect in the local CPU environment because an optional FlashInfer import initialized CUDA from `conftest`; that environment failure is not claimed as validation. No runtime code changed.

## Scope

This PR changes only the two maintained Gemma 2 documentation mirrors. It does not change recipe signatures, deprecated-model policy, archived versioned docs, runtime behavior, dependencies, workflows, or the MCore submodule.
