### PR TITLE
[training] fix: persist final MegatronMIMO checkpoint

### DIFF
--- a/src/megatron/bridge/training/train_megatron_mimo.py
+++ b/src/megatron/bridge/training/train_megatron_mimo.py
@@ -42,7 +42,7 @@ from megatron.bridge.training.profiling import (
     should_profile_rank,
 )
 from megatron.bridge.training.state import GlobalState
-from megatron.bridge.training.train import checkpoint_and_decide_exit, maybe_run_manual_gc
+from megatron.bridge.training.train import checkpoint_and_decide_exit, maybe_run_manual_gc, save_checkpoint_and_time
 from megatron.bridge.training.utils.train_utils import (
     prepare_forward_step_func,
     training_log,
@@ -287,6 +287,7 @@ def train_megatron_mimo(
     prof = None
     nsys_nvtx_context = None
     profiling_stopped = False
+    should_exit = False
     prof_config = cfg.profiling
     if prof_config and should_profile_rank(prof_config, dist.get_rank()):
         if prof_config.use_pytorch_profiler:
@@ -446,6 +447,29 @@ def train_megatron_mimo(
             profiling_stopped = prof_config is not None and train_state.step == prof_config.profile_step_end
         if should_exit:
             break
+
+    # Save final checkpoint when training completes normally and the last
+    # step wasn't already persisted by the interval-based save inside
+    # checkpoint_and_decide_exit.
+    if not should_exit:
+        ckpt_config = cfg.checkpoint
+        if (
+            ckpt_config.save
+            and train_state.step != 0
+            and ckpt_config.save_interval != 0
+            and (ckpt_config.save_interval is None or train_state.step % ckpt_config.save_interval != 0)
+        ):
+            save_checkpoint_and_time(
+                state=global_state,
+                model=[model],
+                optimizer=optimizer,
+                opt_param_scheduler=first_scheduler,
+                num_floating_point_operations_so_far=0,
+                checkpoint_manager=checkpoint_manager,
+                train_data_iterator=train_data_iterator,
+                pg_collection=local_pg_collection,
+                module_name=active_module_name,
+            )
 
     if not profiling_stopped:
         handle_profiling_stop(

--- a/tests/unit_tests/training/megatron_mimo/test_megatron_mimo_checkpointing.py
+++ b/tests/unit_tests/training/megatron_mimo/test_megatron_mimo_checkpointing.py
@@ -428,7 +428,7 @@ def test_interval_evaluation_uses_evaluator_timer_ownership(use_canonical_valida
 
     from megatron.bridge.training.train_megatron_mimo import train_megatron_mimo
 
-    state = _make_global_state(train_iters=1)
+    state = _make_global_state(save_dir=None, train_iters=1)
     if use_canonical_validation_config:
         state.cfg.validation.eval_interval = 1
     else:
@@ -520,7 +520,7 @@ class TestTrainMegatronMIMOCheckpointIntegration:
 
         mock_build_pg.return_value = Mock(spec=[])  # not a list
 
-        state = _make_global_state(train_iters=1, step=0)
+        state = _make_global_state(save_dir=None, train_iters=1, step=0)
         ckpt_mgr = MagicMock()
         train_iter = Mock()
 
@@ -621,7 +621,7 @@ class TestTrainMegatronMIMOCheckpointIntegration:
         infra.topology = Mock()
         mock_build_pg.return_value = Mock(spec=[])
 
-        state = _make_global_state(train_iters=2, step=0)
+        state = _make_global_state(save_dir=None, train_iters=2, step=0)
         ckpt_mgr = MagicMock()
 
         train_megatron_mimo(
@@ -649,54 +649,61 @@ class TestTrainMegatronMIMOCheckpointIntegration:
         # The blocking shutdown call (blocking=True, terminate=True) is now in
         # _finish_train (pretrain_megatron_mimo.py), tested separately.
 
-    @patch("megatron.bridge.training.train_megatron_mimo.checkpoint_and_decide_exit", return_value=False)
-    @patch("megatron.bridge.training.train_megatron_mimo.train_step_megatron_mimo")
-    @patch("megatron.bridge.training.train_megatron_mimo.build_pg_collection_for_schedule")
-    @patch("megatron.bridge.training.train_megatron_mimo.get_module_to_grid_tuple")
-    @patch("megatron.bridge.training.train_megatron_mimo.prepare_forward_step_func")
-    @patch("megatron.bridge.training.train_megatron_mimo.get_num_microbatches", return_value=1)
-    @patch("torch.distributed.get_rank", return_value=0)
-    @patch("torch.distributed.get_world_size", return_value=1)
-    def test_no_inline_save_checkpoint_call(
-        self,
-        mock_world_size,
-        mock_rank,
-        mock_num_mb,
-        mock_prep_fwd,
-        mock_get_grid,
-        mock_build_pg,
-        mock_train_step,
-        mock_ckpt_exit,
+    @pytest.mark.parametrize(
+        ("save_interval", "expected_saved_steps"),
+        [(2, [2, 3]), (3, [3])],
+        ids=["off_interval", "interval_aligned"],
+    )
+    def test_persists_terminal_checkpoint_without_duplicate_interval_save(
+        self, save_interval: int, expected_saved_steps: list[int]
     ):
-        """Verify there is no inline save_checkpoint call — all saves go through
-        checkpoint_and_decide_exit."""
+        """Normal completion should persist the terminal step exactly once."""
         from megatron.bridge.training.train_megatron_mimo import train_megatron_mimo
 
-        mock_train_step.return_value = ({}, 0, 0.0, 0)
-
+        pg = Mock()
         infra = Mock()
-        infra.pg_collections = {"language": Mock()}
+        infra.pg_collections = {"language": pg}
         infra.module_to_grid_map = {"language": Mock()}
         infra.topology = Mock()
-        mock_build_pg.return_value = Mock(spec=[])
-
-        state = _make_global_state(save_interval=1, train_iters=3, step=0)
-
-        train_megatron_mimo(
-            forward_step_func=Mock(),
-            model=Mock(),
-            optimizer=Mock(),
-            schedulers={"language": _make_scheduler_mock()},
-            train_data_iterator=Mock(),
-            valid_data_iterator=None,
-            global_state=state,
-            megatron_mimo_infra=infra,
-            multimodule_communicator=Mock(),
-            checkpoint_manager=MagicMock(),
+        state = _make_global_state(save_interval=save_interval, train_iters=3, step=0)
+        checkpoint_manager = MagicMock()
+        saved_steps = []
+        checkpoint_manager.save.side_effect = lambda context, _callback_manager: saved_steps.append(
+            context.state.train_state.step
         )
 
-        # checkpoint_and_decide_exit should have been called
-        assert mock_ckpt_exit.call_count == 3
+        with (
+            patch("torch.distributed.get_rank", return_value=0),
+            patch("torch.distributed.get_world_size", return_value=1),
+            patch("megatron.bridge.training.train_megatron_mimo.get_num_microbatches", return_value=1),
+            patch("megatron.bridge.training.train_megatron_mimo.prepare_forward_step_func", return_value=Mock()),
+            patch("megatron.bridge.training.train_megatron_mimo.get_module_to_grid_tuple", return_value=[]),
+            patch(
+                "megatron.bridge.training.train_megatron_mimo.build_pg_collection_for_schedule",
+                return_value=Mock(spec=[]),
+            ),
+            patch(
+                "megatron.bridge.training.train_megatron_mimo.train_step_megatron_mimo",
+                return_value=({}, 0, 0.0, 0),
+            ),
+            patch("megatron.bridge.training.train.check_nvrx_straggler_detection", return_value=False),
+            patch("megatron.bridge.training.train.should_disable_forward_pre_hook", return_value=False),
+            patch("megatron.bridge.training.train.force_param_sync"),
+        ):
+            train_megatron_mimo(
+                forward_step_func=Mock(),
+                model=Mock(),
+                optimizer=Mock(),
+                schedulers={"language": _make_scheduler_mock()},
+                train_data_iterator=Mock(),
+                valid_data_iterator=None,
+                global_state=state,
+                megatron_mimo_infra=infra,
+                multimodule_communicator=Mock(),
+                checkpoint_manager=checkpoint_manager,
+            )
+
+        assert saved_steps == expected_saved_steps
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Supported trigger and impact

A maintained non-colocated MegatronMIMO run with persistent checkpointing enabled can complete normally at a step that is not divisible by `checkpoint.save_interval`. For example, `train_iters=3` with `save_interval=2` returns successfully while step 2 remains the latest durable checkpoint; with `save_interval=None`, no normal training checkpoint is scheduled at all.

This loses the final trained model, optimizer, scheduler, and iterator state. The checkpoint directory can therefore contain stale state—or no checkpoint—even though training reports successful completion.

## Root cause

`train_megatron_mimo()` delegated interval and early-exit saves to `checkpoint_and_decide_exit()`, then returned directly after normal loop exhaustion. That helper does not own normal off-interval completion, and `_finish_train()` only finalizes saves that were already scheduled.

The standard Bridge training loop explicitly owns this boundary and saves the nonzero terminal step unless the persistent interval already saved it. The MIMO loop omitted the equivalent terminal owner.

## Fix

Mirror the standard normal-completion guard in the MIMO loop and call the shared `save_checkpoint_and_time()` helper with the MIMO rank-local process-group collection and module name. The change preserves existing signal/duration/exit behavior, `save_interval=0` disabling semantics, final-only behavior for `save_interval=None`, async finalization, and duplicate suppression when the interval already lands on the terminal step.

## Regression evidence

Fail-before on the unmodified base:

`uv run --active --no-sync python -m pytest tests/unit_tests/training/megatron_mimo/test_megatron_mimo_checkpointing.py::TestTrainMegatronMIMOCheckpointIntegration::test_persists_terminal_checkpoint_without_duplicate_interval_save -q --tb=short`

Result: `1 failed, 1 passed`. The off-interval case recorded saved steps `[2]` instead of `[2, 3]`; the aligned-interval control passed.

Pass-after with the unchanged regression:

Same command; result: `2 passed`.

Adjacent validation:

`uv run --active --no-sync python -m pytest tests/unit_tests/training/megatron_mimo/test_megatron_mimo_checkpointing.py tests/unit_tests/training/megatron_mimo/test_pretrain_megatron_mimo.py tests/unit_tests/training/test_train.py::TestSaveCheckpointAndTime tests/unit_tests/training/test_train.py::TestCheckpointAndDecideExit -q --tb=short`

Result: `67 passed`.

Also passed:

- `git diff --check`
- `uv run --no-sync pre-commit run --all-files`

## Scope

This PR changes only the MIMO terminal checkpoint owner and focused unit coverage. It does not change public APIs, dependencies, CI workflows, checkpoint formats, conversion behavior, or Megatron-Core. No full-suite, convergence, performance, or distributed-training validation is claimed.