### PR TITLE
cp: `[data] fix: Preserve assistant mask provenance (#5166)` into `r0.6.0`

### DIFF
--- a/src/megatron/bridge/data/conversation_processing.py
+++ b/src/megatron/bridge/data/conversation_processing.py
@@ -1141,8 +1141,14 @@ def _align_assistant_mask_to_padded_ids(
     if source_ids == target_ids:
         return source_mask
 
+    if len(source_ids) > len(target_ids):
+        window_start = _rendered_window_start(source_ids, target_ids, tokenizer)
+        if window_start is None:
+            return None
+        return source_mask[window_start : window_start + len(target_ids)]
+
     pad_token_id = getattr(tokenizer, "pad_token_id", None)
-    if pad_token_id is None or len(source_ids) > len(target_ids):
+    if pad_token_id is None:
         return None
 
     pad_len = len(target_ids) - len(source_ids)
@@ -1155,12 +1161,175 @@ def _align_assistant_mask_to_padded_ids(
     return None
 
 
+def _assistant_mask_from_conversation_turns(
+    example_or_conversation: Mapping[str, Any] | Sequence[Mapping[str, Any]],
+    ids: Sequence[int],
+    template_owner: Any,
+    tokenizer: Any,
+    boundary_config: AssistantMaskBoundaryConfig,
+    *,
+    include_content: bool = True,
+) -> torch.Tensor | None:
+    """Build a role-safe mask by locating turns through conversation-prefix renders."""
+    conversation = _conversation_from_example(example_or_conversation)
+    loss_roles = set(boundary_config.loss_roles)
+    loss_turns = [(turn_index, turn) for turn_index, turn in enumerate(conversation) if turn.get("role") in loss_roles]
+    if not loss_turns:
+        return None
+
+    tokenize_kwargs = {
+        "tokenize": True,
+        "add_generation_prompt": False,
+        "return_dict": True,
+        **chat_template_kwargs_from_example(example_or_conversation),
+    }
+    template = _get_chat_template(template_owner)
+    if template is not None and GENERATION_REGEX.search(template) is not None:
+        tokenize_kwargs["return_assistant_tokens_mask"] = True
+    try:
+        rendered = _apply_tokenized_chat_template(template_owner, conversation, tokenize_kwargs)
+        rendered_ids = _chat_template_input_ids(rendered)
+    except (AssertionError, AttributeError, KeyError, TypeError, ValueError):
+        return None
+    role_start_tokens = _token_map_from_boundary_config(boundary_config.role_start_tokens)
+    role_end_tokens = _token_map_from_boundary_config(boundary_config.role_end_tokens)
+    role_end_token_variants = {
+        role: [token_ids for raw_token_ids in raw_variants if (token_ids := _as_token_id_list(raw_token_ids))]
+        for role, raw_variants in boundary_config.role_end_token_variants.items()
+    }
+    include_start_roles = set(boundary_config.include_start_tokens_for_roles)
+    include_end_roles = set(boundary_config.include_end_tokens_for_roles)
+    rendered_mask = torch.zeros(len(rendered_ids), dtype=torch.float32)
+
+    for turn_index, turn in loss_turns:
+        role = turn["role"]
+        start_tokens = role_start_tokens.get(role)
+        end_patterns = [role_end_tokens.get(role, []), *role_end_token_variants.get(role, [])]
+        if not start_tokens or not any(end_patterns):
+            return None
+
+        try:
+            before_ids = (
+                _chat_template_input_ids(
+                    _apply_tokenized_chat_template(template_owner, conversation[:turn_index], tokenize_kwargs)
+                )
+                if turn_index > 0
+                else []
+            )
+            through_ids = (
+                rendered_ids
+                if turn_index + 1 == len(conversation)
+                else _chat_template_input_ids(
+                    _apply_tokenized_chat_template(template_owner, conversation[: turn_index + 1], tokenize_kwargs)
+                )
+            )
+        except (AssertionError, AttributeError, KeyError, TypeError, ValueError):
+            return None
+
+        turn_search_start = _common_token_prefix_length(before_ids, rendered_ids)
+        turn_limit = _common_token_prefix_length(through_ids, rendered_ids)
+        if turn_search_start >= turn_limit:
+            return None
+
+        role_start, content_start = find_token_span(rendered_ids, start_tokens, turn_search_start)
+        if role_start < 0 or content_start > turn_limit:
+            return None
+
+        candidate_ends: list[tuple[int, int, int, list[int]]] = []
+        for priority, pattern in enumerate(end_patterns):
+            if not pattern:
+                continue
+            search_start = content_start
+            while search_start < turn_limit:
+                end_start, after_end = find_token_span(rendered_ids, pattern, search_start)
+                if end_start < 0 or after_end > turn_limit:
+                    break
+                candidate_ends.append((end_start, -priority, after_end, pattern))
+                search_start = end_start + 1
+        if not candidate_ends:
+            return None
+        content_end, _, after_end, _ = max(candidate_ends)
+
+        loss_start = _trim_leading_token_sequences(
+            rendered_ids,
+            content_start,
+            content_end,
+            boundary_config.trim_leading_token_sequences,
+        )
+        loss_start = _trim_leading_token_ids(
+            rendered_ids,
+            loss_start,
+            content_end,
+            _as_token_id_list(boundary_config.trim_leading_token_ids),
+        )
+        if include_content:
+            rendered_mask[loss_start:content_end] = 1.0
+        if role in include_start_roles:
+            rendered_mask[role_start : role_start + len(start_tokens)] = 1.0
+        if role in include_end_roles:
+            rendered_mask[content_end:after_end] = 1.0
+
+    aligned_mask = _align_assistant_mask_to_padded_ids(rendered_ids, rendered_mask.tolist(), ids, tokenizer)
+    if aligned_mask is None:
+        return None
+    return torch.tensor(aligned_mask, dtype=torch.float32)
+
+
 def _token_map_from_boundary_config(token_map: Mapping[str, Sequence[int]] | None) -> dict[str, list[int]]:
     if token_map is None:
         return {}
     return {
         role: token_ids for role, raw_token_ids in token_map.items() if (token_ids := _as_token_id_list(raw_token_ids))
     }
+
+
+def _value_contains_token_sequence(
+    value: Any,
+    tokenizer: Any,
+    token_sequences: Sequence[Sequence[int]],
+) -> bool | None:
+    """Check recursively tokenizable payload values for configured boundary sequences."""
+    if isinstance(value, str):
+        try:
+            token_ids = tokenize_text_without_special_tokens(tokenizer, value)
+        except (AssertionError, AttributeError, KeyError, TypeError, ValueError):
+            return None
+        return any(find_token_span(token_ids, token_sequence)[0] >= 0 for token_sequence in token_sequences)
+    if isinstance(value, Mapping):
+        results = [_value_contains_token_sequence(item, tokenizer, token_sequences) for item in value.values()]
+    elif isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        results = [_value_contains_token_sequence(item, tokenizer, token_sequences) for item in value]
+    elif value is None or isinstance(value, (bool, int, float)):
+        return False
+    else:
+        return None
+    if any(result is True for result in results):
+        return True
+    return None if any(result is None for result in results) else False
+
+
+def _conversation_contains_boundary_tokens(
+    example_or_conversation: Mapping[str, Any] | Sequence[Mapping[str, Any]],
+    tokenizer: Any,
+    boundary_config: AssistantMaskBoundaryConfig,
+) -> bool | None:
+    """Return whether rendered conversation payloads contain structural token sequences."""
+    token_sequences = [
+        *(_token_map_from_boundary_config(boundary_config.role_start_tokens).values()),
+        *(_token_map_from_boundary_config(boundary_config.role_end_tokens).values()),
+        *(
+            token_ids
+            for raw_variants in boundary_config.role_end_token_variants.values()
+            for raw_token_ids in raw_variants
+            if (token_ids := _as_token_id_list(raw_token_ids))
+        ),
+    ]
+    payloads: list[Any] = [
+        {key: value for key, value in turn.items() if key != "role"}
+        for turn in _conversation_from_example(example_or_conversation)
+    ]
+    payloads.append(chat_template_kwargs_from_example(example_or_conversation))
+    return _value_contains_token_sequence(payloads, tokenizer, token_sequences)
 
 
 def _trim_leading_token_ids(
@@ -1216,6 +1385,7 @@ def _assistant_mask_from_boundary_config(
     boundary_config: AssistantMaskBoundaryConfig,
     *,
     include_content: bool = True,
+    conversation_roles: Sequence[str] | None = None,
 ) -> torch.Tensor | None:
     role_start_tokens = _token_map_from_boundary_config(boundary_config.role_start_tokens)
     role_end_tokens = _token_map_from_boundary_config(boundary_config.role_end_tokens)
@@ -1253,6 +1423,11 @@ def _assistant_mask_from_boundary_config(
         if deduped_markers and marker[0] == deduped_markers[-1][0]:
             continue
         deduped_markers.append(marker)
+    if conversation_roles is not None:
+        expected_loss_roles = [role for role in conversation_roles if role in loss_roles]
+        observed_loss_roles = [role for _, role, _ in deduped_markers if role in loss_roles]
+        if observed_loss_roles != expected_loss_roles:
+            return None
 
     include_start_tokens_for_roles = set(boundary_config.include_start_tokens_for_roles)
     include_end_tokens_for_roles = set(boundary_config.include_end_tokens_for_roles)
@@ -1269,11 +1444,17 @@ def _assistant_mask_from_boundary_config(
 
         candidate_end_spans = []
         for priority, role_end_pattern in enumerate([role_end_tokens[role], *role_end_token_variants.get(role, [])]):
-            end_start, after_end = find_token_span(ids, role_end_pattern, content_start)
-            if end_start >= 0 and end_start < next_marker_start:
+            search_start = content_start
+            while search_start < next_marker_start:
+                end_start, after_end = find_token_span(ids, role_end_pattern, search_start)
+                if end_start < 0 or after_end > next_marker_start:
+                    break
                 candidate_end_spans.append((end_start, priority, after_end))
+                search_start = end_start + 1
         if not candidate_end_spans:
             continue
+        if conversation_roles is not None and len({end_start for end_start, _, _ in candidate_end_spans}) != 1:
+            return None
         end_start, _, after_end = min(candidate_end_spans)
         role_end_span = (end_start, after_end)
 
@@ -1314,19 +1495,66 @@ def build_assistant_loss_mask(
     """
     tokenizer = get_processor_tokenizer(processor)
     ids = _as_token_id_list(input_ids)
+    conversation = _conversation_from_example(example_or_conversation)
+    conversation_roles = [turn.get("role") for turn in conversation] if conversation else None
 
     mask = _assistant_mask_from_hf_chat_template(example_or_conversation, ids, processor, tokenizer)
     if boundary_config is not None:
+        boundary_scan_is_safe = (
+            not conversation
+            or _conversation_contains_boundary_tokens(example_or_conversation, tokenizer, boundary_config) is False
+        )
         if mask is None or float(mask.sum().item()) == 0.0:
-            boundary_mask = _assistant_mask_from_boundary_config(ids, boundary_config)
+            boundary_mask = _assistant_mask_from_conversation_turns(
+                example_or_conversation,
+                ids,
+                tokenizer,
+                tokenizer,
+                boundary_config,
+            )
+            if boundary_mask is None and processor is not tokenizer:
+                boundary_mask = _assistant_mask_from_conversation_turns(
+                    example_or_conversation,
+                    ids,
+                    processor,
+                    tokenizer,
+                    boundary_config,
+                )
+            if boundary_mask is None and boundary_scan_is_safe:
+                boundary_mask = _assistant_mask_from_boundary_config(
+                    ids,
+                    boundary_config,
+                    conversation_roles=conversation_roles,
+                )
+            if boundary_mask is None and not boundary_scan_is_safe and mask is not None:
+                mask = None
             if mask is None or (boundary_mask is not None and float(boundary_mask.sum().item()) > 0.0):
                 mask = boundary_mask
         else:
-            boundary_token_mask = _assistant_mask_from_boundary_config(
+            boundary_token_mask = _assistant_mask_from_conversation_turns(
+                example_or_conversation,
                 ids,
+                tokenizer,
+                tokenizer,
                 boundary_config,
                 include_content=False,
             )
+            if boundary_token_mask is None and processor is not tokenizer:
+                boundary_token_mask = _assistant_mask_from_conversation_turns(
+                    example_or_conversation,
+                    ids,
+                    processor,
+                    tokenizer,
+                    boundary_config,
+                    include_content=False,
+                )
+            if boundary_token_mask is None and boundary_scan_is_safe:
+                boundary_token_mask = _assistant_mask_from_boundary_config(
+                    ids,
+                    boundary_config,
+                    include_content=False,
+                    conversation_roles=conversation_roles,
+                )
             if boundary_token_mask is not None:
                 mask = torch.maximum(mask, boundary_token_mask)
     if mask is None:

--- a/tests/unit_tests/data/collators/test_model_collators.py
+++ b/tests/unit_tests/data/collators/test_model_collators.py
@@ -76,7 +76,13 @@ class _DummyProcessor:
                 "<|im_end|>": [103],
                 "<|im_end|>\n": [103, 104],
             }
-            return {"input_ids": mapping.get(text, [1])}
+            if text in mapping:
+                return {"input_ids": mapping[text]}
+            # Non-assistant role markers must tokenize to distinct ids so that content
+            # (default) never collides with a role-boundary token in the safety check.
+            if isinstance(text, str) and text.startswith("<|im_start|>"):
+                return {"input_ids": [199]}
+            return {"input_ids": [1]}
 
     def __init__(self):
         self.tokenizer = self._Tok()
@@ -615,6 +621,8 @@ def test_qwen2_5_collate_fn_preserves_attention_mask_for_mixed_image_text_batch(
             chat_template = "{% generation %}{{ messages }}{% endgeneration %}"
 
             def __call__(self, text, add_special_tokens=False):
+                if isinstance(text, str) and text.startswith("<|im_start|>"):
+                    return {"input_ids": [199]}
                 return {"input_ids": [1]}
 
         def __init__(self):
@@ -694,7 +702,11 @@ def test_qwen2_5_collate_fn_uses_declared_chatml_boundary_config_without_generat
                     "<|im_end|>": [103],
                     "<|im_end|>\n": [103, 104],
                 }
-                return {"input_ids": mapping.get(text, [42])}
+                if text in mapping:
+                    return {"input_ids": mapping[text]}
+                if isinstance(text, str) and text.startswith("<|im_start|>"):
+                    return {"input_ids": [199]}
+                return {"input_ids": [42]}
 
         def __init__(self):
             self.tokenizer = self._Tok()
@@ -735,6 +747,8 @@ def test_qwen2_5_collate_fn_packs_vlm_batch(monkeypatch):
             chat_template = "{% generation %}{{ messages }}{% endgeneration %}"
 
             def __call__(self, text, add_special_tokens=False):
+                if isinstance(text, str) and text.startswith("<|im_start|>"):
+                    return {"input_ids": [199]}
                 return {"input_ids": [1]}
 
         def __init__(self):
@@ -1848,7 +1862,11 @@ class _NemotronOmniTokenizer:
                 "<|im_end|>": [102],
                 "<|im_end|>\n": [102, 103],
             }
-            return {"input_ids": marker_tokens.get(texts, [1])}
+            if texts in marker_tokens:
+                return {"input_ids": marker_tokens[texts]}
+            if texts.startswith("<|im_start|>"):
+                return {"input_ids": [199]}
+            return {"input_ids": [1]}
         self.tokenized_texts = list(texts)
         max_len = max(len(row) for row in self.tokenized_rows)
         out = torch.full((len(self.tokenized_rows), max_len), self.pad_token_id, dtype=torch.long)

--- a/tests/unit_tests/data/collators/test_sft.py
+++ b/tests/unit_tests/data/collators/test_sft.py
@@ -130,6 +130,10 @@ class _ChatMLBoundaryTokenizer:
             return {"input_ids": [102]}
         if text == "<|im_end|>\n":
             return {"input_ids": [102, 103]}
+        if text == "hi":
+            return {"input_ids": [10]}
+        if text == "answer":
+            return {"input_ids": [21, 22]}
 
         texts = text if isinstance(text, list) else [text]
         tokenized = [[100, 10, 102, 103, 101, 21, 22, 102, 103] for _ in texts]

--- a/tests/unit_tests/data/datasets/test_chat_template.py
+++ b/tests/unit_tests/data/datasets/test_chat_template.py
@@ -151,10 +151,13 @@ class TestChatPreprocess:
                 mapping = {
                     "<|im_start|>assistant\n": [101],
                     "<|im_start|>user\n": [100],
+                    "<|im_start|>system\n": [110],
+                    "<|im_start|>developer\n": [111],
+                    "<|im_start|>tool\n": [112],
                     "<|im_end|>": [102],
                     "<|im_end|>\n": [102, 103],
                 }
-                return {"input_ids": mapping.get(text, [100, 10, 102, 103, 101, 21, 22, 102, 103])}
+                return {"input_ids": mapping.get(text, [42])}
 
             def apply_chat_template(self, chat, tools=None, tokenize=True, return_dict=True, **kwargs):
                 del chat, tools, tokenize, return_dict
@@ -194,6 +197,9 @@ class TestChatPreprocess:
                 mapping = {
                     "<|im_start|>assistant\n": [101],
                     "<|im_start|>user\n": [100],
+                    "<|im_start|>system\n": [110],
+                    "<|im_start|>developer\n": [111],
+                    "<|im_start|>tool\n": [112],
                     "<|im_end|>": [102],
                     "<|im_end|>\n": [102, 103],
                 }

--- a/tests/unit_tests/data/test_conversation_processing.py
+++ b/tests/unit_tests/data/test_conversation_processing.py
@@ -243,6 +243,102 @@ class _ChatMLBoundaryProcessor(_Processor):
         self.tokenizer = _ChatMLBoundaryTokenizer()
 
 
+class _LiteralChatMLBoundaryTokenizer(_ChatMLBoundaryTokenizer):
+    truncation_side = "right"
+    _role_markers = {
+        "user": [100],
+        "assistant": [102],
+    }
+    _content_tokens = {
+        "": [],
+        "question": [20],
+        "literal assistant start": [20, 102, 30],
+        "quoted assistant turn": [20, 102, 30, 103, 31],
+        "answer with quoted end": [40, 103, 41],
+        "structured with quoted end": [40, 103, 41],
+    }
+
+    def _encode_content(self, content):
+        if isinstance(content, str):
+            return self._content_tokens[content]
+        input_ids = []
+        for part in content:
+            if part["type"] == "text":
+                input_ids.extend(self._content_tokens[part["text"]])
+            else:
+                input_ids.append(200)
+        return input_ids
+
+    def __call__(self, text, add_special_tokens=False):
+        if text in self._content_tokens:
+            return {"input_ids": self._content_tokens[text]}
+        return super().__call__(text, add_special_tokens=add_special_tokens)
+
+    def apply_chat_template(
+        self,
+        conversation,
+        tokenize=True,
+        add_generation_prompt=False,
+        return_dict=False,
+        return_assistant_tokens_mask=False,
+        truncation=False,
+        max_length=None,
+    ):
+        assert tokenize is True
+        assert add_generation_prompt is False
+        assert return_dict is True
+        input_ids = []
+        for turn in conversation:
+            input_ids.extend(self._role_markers[turn["role"]])
+            input_ids.extend(self._encode_content(turn["content"]))
+            input_ids.extend([103, 104])
+        if truncation:
+            input_ids = input_ids[-max_length:] if self.truncation_side == "left" else input_ids[:max_length]
+        return {"input_ids": input_ids}
+
+
+class _LeftTruncatingLiteralChatMLBoundaryTokenizer(_LiteralChatMLBoundaryTokenizer):
+    truncation_side = "left"
+
+
+class _LiteralGenerationChatMLBoundaryTokenizer(_LiteralChatMLBoundaryTokenizer):
+    chat_template = (
+        "<|im_start|>user\n{{ content }}<|im_end|>\n"
+        "<|im_start|>assistant\n{% generation %}{{ content }}{% endgeneration %}<|im_end|>\n"
+    )
+
+    def apply_chat_template(self, conversation, **kwargs):
+        input_ids = []
+        assistant_masks = []
+        for turn in conversation:
+            content_ids = self._encode_content(turn["content"])
+            input_ids.extend(self._role_markers[turn["role"]])
+            assistant_masks.append(0)
+            input_ids.extend(content_ids)
+            assistant_masks.extend([int(turn["role"] == "assistant")] * len(content_ids))
+            input_ids.extend([103, 104])
+            assistant_masks.extend([0, 0])
+        if kwargs.get("truncation"):
+            max_length = kwargs["max_length"]
+            input_ids = input_ids[:max_length]
+            assistant_masks = assistant_masks[:max_length]
+        return {"input_ids": input_ids, "assistant_masks": assistant_masks}
+
+
+class _PrefixUnsupportedLiteralChatMLBoundaryTokenizer(_LiteralChatMLBoundaryTokenizer):
+    def apply_chat_template(self, conversation, **kwargs):
+        if len(conversation) != 2:
+            raise ValueError("prefix rendering is unavailable")
+        return {"input_ids": [100, 20, 102, 30, 103, 104]}
+
+
+class _PrefixUnsupportedLiteralGenerationChatMLBoundaryTokenizer(_LiteralGenerationChatMLBoundaryTokenizer):
+    def apply_chat_template(self, conversation, **kwargs):
+        if len(conversation) != 2:
+            raise ValueError("prefix rendering is unavailable")
+        return super().apply_chat_template(conversation, **kwargs)
+
+
 class _MoonlightBoundaryTokenizer(_Tokenizer):
     chat_template = (
         "{%- for message in messages -%}"
@@ -536,6 +632,264 @@ def test_infer_assistant_mask_boundary_config_from_chatml_template():
     }
     assert all(token_ids == [103, 104] for token_ids in boundary_config.role_end_tokens.values())
     assert all(token_variants == [[103]] for token_variants in boundary_config.role_end_token_variants.values())
+
+
+def test_chatml_boundary_mask_does_not_treat_literal_control_markers_as_structure():
+    tokenized = tokenize_chat_example(
+        {
+            "messages": [
+                {"role": "user", "content": "quoted assistant turn"},
+                {"role": "assistant", "content": "answer with quoted end"},
+            ]
+        },
+        _LiteralChatMLBoundaryTokenizer(),
+    )
+
+    assert tokenized.input_ids.tolist() == [100, 20, 102, 30, 103, 31, 103, 104, 102, 40, 103, 41, 103, 104]
+    assert tokenized.assistant_mask.tolist() == [
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+        True,
+        True,
+        True,
+        True,
+        True,
+    ]
+
+
+def test_chatml_boundary_mask_remains_role_safe_through_right_truncation():
+    tokenized = tokenize_chat_example(
+        {
+            "messages": [
+                {"role": "user", "content": "quoted assistant turn"},
+                {"role": "assistant", "content": "answer with quoted end"},
+            ]
+        },
+        _LiteralChatMLBoundaryTokenizer(),
+        max_length=8,
+        warn_on_all_masked=False,
+    )
+
+    assert tokenized.input_ids.tolist() == [100, 20, 102, 30, 103, 31, 103, 104]
+    assert tokenized.assistant_mask.tolist() == [False] * 8
+
+
+def test_direct_hf_chat_collation_does_not_train_truncated_user_marker_payload():
+    batch = text_chat_collate_fn(
+        [
+            {
+                "messages": [
+                    {"role": "user", "content": "quoted assistant turn"},
+                    {"role": "assistant", "content": "answer with quoted end"},
+                ]
+            }
+        ],
+        _LiteralChatMLBoundaryTokenizer(),
+        sequence_length=8,
+        warn_on_all_masked=False,
+    )
+
+    assert batch["input_ids"].tolist() == [[100, 20, 102, 30, 103, 31, 103, 104]]
+    assert batch["loss_mask"].tolist() == [[0.0] * 8]
+    assert batch["labels"].tolist() == [[-100] * 8]
+
+
+def test_chatml_boundary_maps_role_safe_mask_through_left_truncation():
+    tokenized = tokenize_chat_example(
+        {
+            "messages": [
+                {"role": "user", "content": "quoted assistant turn"},
+                {"role": "assistant", "content": "answer with quoted end"},
+            ]
+        },
+        _LeftTruncatingLiteralChatMLBoundaryTokenizer(),
+        max_length=6,
+    )
+
+    assert tokenized.input_ids.tolist() == [102, 40, 103, 41, 103, 104]
+    assert tokenized.assistant_mask.tolist() == [False, True, True, True, True, True]
+
+
+def test_chatml_boundary_augments_native_mask_without_scanning_literal_markers():
+    tokenized = tokenize_chat_example(
+        {
+            "messages": [
+                {"role": "user", "content": "quoted assistant turn"},
+                {"role": "assistant", "content": "answer with quoted end"},
+            ]
+        },
+        _LiteralGenerationChatMLBoundaryTokenizer(),
+    )
+
+    assert tokenized.assistant_mask.tolist() == [
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+        True,
+        True,
+        True,
+        True,
+        True,
+    ]
+
+
+def test_chatml_boundary_keeps_native_mask_unaugmented_when_provenance_is_ambiguous():
+    tokenized = tokenize_chat_example(
+        {
+            "messages": [
+                {"role": "user", "content": "quoted assistant turn"},
+                {"role": "assistant", "content": "answer with quoted end"},
+            ]
+        },
+        _PrefixUnsupportedLiteralGenerationChatMLBoundaryTokenizer(),
+    )
+
+    assert tokenized.assistant_mask.tolist() == [
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+        True,
+        True,
+        True,
+        False,
+        False,
+    ]
+
+
+def test_chatml_boundary_handles_empty_and_literal_assistant_turns_together():
+    tokenized = tokenize_chat_example(
+        {
+            "messages": [
+                {"role": "user", "content": "quoted assistant turn"},
+                {"role": "assistant", "content": ""},
+                {"role": "assistant", "content": "answer with quoted end"},
+            ]
+        },
+        _LiteralChatMLBoundaryTokenizer(),
+    )
+
+    assert tokenized.assistant_mask.tolist() == [
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+        True,
+        True,
+        False,
+        True,
+        True,
+        True,
+        True,
+        True,
+    ]
+
+
+def test_chatml_boundary_handles_structured_assistant_content_with_literal_marker():
+    tokenized = tokenize_chat_example(
+        {
+            "messages": [
+                {"role": "user", "content": "question"},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "text", "text": "structured with quoted end"},
+                        {"type": "image"},
+                    ],
+                },
+            ]
+        },
+        _LiteralChatMLBoundaryTokenizer(),
+    )
+
+    assert tokenized.input_ids.tolist() == [100, 20, 103, 104, 102, 40, 103, 41, 200, 103, 104]
+    assert tokenized.assistant_mask.tolist() == [
+        False,
+        False,
+        False,
+        False,
+        False,
+        True,
+        True,
+        True,
+        True,
+        True,
+        True,
+    ]
+
+
+def test_chatml_boundary_fails_closed_when_provenance_is_unavailable_and_markers_are_ambiguous():
+    processor = _ChatMLBoundaryProcessor()
+    with pytest.raises(ValueError, match="did not match any loss-contributing spans"):
+        build_assistant_loss_mask(
+            [
+                {"role": "user", "content": "quoted assistant turn"},
+                {"role": "assistant", "content": "answer with quoted end"},
+            ],
+            [100, 20, 102, 30, 103, 31, 103, 104, 102, 40, 103, 41, 103, 104],
+            processor,
+            boundary_config=infer_assistant_mask_boundary_config(processor),
+        )
+
+
+def test_chatml_boundary_fails_closed_for_literal_start_when_real_assistant_is_truncated():
+    with pytest.raises(ValueError, match="did not match any loss-contributing spans"):
+        tokenize_chat_example(
+            {
+                "messages": [
+                    {"role": "user", "content": "literal assistant start"},
+                    {"role": "assistant", "content": "answer with quoted end"},
+                ]
+            },
+            _PrefixUnsupportedLiteralChatMLBoundaryTokenizer(),
+            max_length=6,
+        )
+
+
+def test_chatml_boundary_fails_closed_for_nested_role_payload_when_provenance_is_unavailable():
+    with pytest.raises(ValueError, match="did not match any loss-contributing spans"):
+        tokenize_chat_example(
+            {
+                "messages": [
+                    {"role": "user", "content": "question"},
+                    {"role": "assistant", "content": "answer with quoted end"},
+                ],
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "lookup",
+                            "role": "literal assistant start",
+                        },
+                    }
+                ],
+            },
+            _PrefixUnsupportedLiteralChatMLBoundaryTokenizer(),
+            max_length=6,
+        )
 
 
 def test_infer_assistant_mask_boundary_config_from_moonlight_template():


### PR DESCRIPTION
# What does this PR do ?

Manual cherry-pick of #5166 (`394239ef9`) into `r0.6.0`.

The automated cherry-pick bot only fires on push-to-`main` and reads the merged PR's release labels; #5166 merged (2026-07-29) without the `r0.6.0` label, so it was never picked. Adding the label now cannot retro-trigger the workflow, hence this manual cherry-pick.

# Why

#5166 introduces the turn-based assistant-mask builder `_assistant_mask_from_conversation_turns` (and its alignment helper `_rendered_window_start`), which produces a single contiguous loss span across a multi-channel assistant turn.

This is a **prerequisite for #5447** (the cherry-pick of #5389, "infer assistant loss mask for gpt-oss Harmony chat template"). On `r0.6.0` without this builder, `test_gpt_oss_harmony_assistant_mask_covers_analysis_and_final_channels` fails because the older per-marker scanner re-masks the `<|start|>assistant` header at the analysis→final channel boundary. #5389 itself only adds the Harmony boundary config + test and relies on this builder already being present.

**Merge order:** this PR should land before #5447 (or #5447 should be rebased after this merges).

# Changelog

- Cherry-pick `394239ef9` verbatim (clean apply, no conflicts): turn-based assistant-mask builder + provenance handling and accompanying unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)