### PR TITLE
fix(model): use public Gemma4 block spec target

### DIFF
--- a/src/megatron/bridge/models/gemma/gemma4_provider.py
+++ b/src/megatron/bridge/models/gemma/gemma4_provider.py
@@ -36,9 +36,9 @@ from megatron.bridge.models.gemma.modeling_gemma4 import (
     Gemma4OutputLayer,
     Gemma4RotaryEmbedding,
     _attach_ple_modules,
-    _gemma4_block_spec,
     _install_ple_forward,
     _install_tied_kv,
+    gemma4_block_spec,
     get_gemma4_layer_spec,
     wire_gemma4_kv_sharing,
 )
@@ -320,7 +320,7 @@ class Gemma4ModelProvider(GPTModelProvider):
 
     flash_decode: bool = False
     transformer_layer_spec: Union[Callable, object] = field(
-        default_factory=lambda: partial(_gemma4_block_spec, use_transformer_engine=HAVE_TE)
+        default_factory=lambda: partial(gemma4_block_spec, use_transformer_engine=HAVE_TE)
     )
     scatter_embedding_sequence_parallel: bool = True
 

--- a/src/megatron/bridge/models/gemma/modeling_gemma4.py
+++ b/src/megatron/bridge/models/gemma/modeling_gemma4.py
@@ -1514,7 +1514,7 @@ def _install_tied_kv(model: "torch.nn.Module", provider: "Gemma4ModelProvider") 
         attn._tied_kv = True
 
 
-def _gemma4_block_spec(config, use_transformer_engine=True, **kwargs):
+def gemma4_block_spec(config, use_transformer_engine=True, **kwargs):
     """Build Gemma 4 MoE block spec with patched attention, layer, and MoE modules."""
     block_spec = get_gpt_decoder_block_spec(config, use_transformer_engine=use_transformer_engine, **kwargs)
 
@@ -1544,8 +1544,8 @@ def _gemma4_block_spec(config, use_transformer_engine=True, **kwargs):
     return block_spec
 
 
-# Preserve checkpoint configs serialized with this public target name.
-gemma4_block_spec = _gemma4_block_spec
+# Preserve references to the previous private name.
+_gemma4_block_spec = gemma4_block_spec
 
 
 class Gemma4SelfAttention(SelfAttention):

--- a/src/megatron/bridge/utils/instantiate_utils.py
+++ b/src/megatron/bridge/utils/instantiate_utils.py
@@ -58,6 +58,8 @@ _TARGET_ALLOWLIST_MUTATORS: tuple[str, ...] = (
 )
 
 _ALLOWED_PRIVATE_TARGETS: set[str] = {
+    # Legacy Gemma 4 checkpoints serialized the block spec under its previous private name.
+    "megatron.bridge.models.gemma.modeling_gemma4._gemma4_block_spec",
     # PyTorch exposes torch.nn.functional.gelu as this C-extension symbol, and
     # the YAML function representer serializes it with its underlying module.
     "torch._C._nn.gelu",

--- a/tests/unit_tests/models/gemma/test_gemma4_provider.py
+++ b/tests/unit_tests/models/gemma/test_gemma4_provider.py
@@ -14,11 +14,13 @@
 
 """Unit tests for Gemma 4 text-only providers."""
 
+from dataclasses import dataclass
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import pytest
 import torch
+import yaml
 from torch import nn
 
 from megatron.bridge.models.gemma.gemma4_provider import (
@@ -31,9 +33,17 @@ from megatron.bridge.models.gemma.modeling_gemma4 import (
     _gemma4_checkpointed_forward,
     _install_tied_kv,
     _patch_ple_block_threading,
+    gemma4_block_spec,
 )
 from megatron.bridge.models.gemma.modules import extend_instance
 from megatron.bridge.models.gpt_provider import GPTModelProvider
+from megatron.bridge.training.utils.config_utils import _ConfigContainerBase
+from megatron.bridge.utils.instantiate_utils import InstantiationMode
+
+
+@dataclass
+class Gemma4RunConfigForTest(_ConfigContainerBase):
+    model: Gemma4ModelProvider
 
 
 class _IdentityOutputLayer(nn.Module):
@@ -546,6 +556,42 @@ class TestGemma4ModelProviderDefaults:
         raw_logits = torch.tensor([[-120.0, 120.0]])
         logits, _ = built.output_layer(raw_logits)
         torch.testing.assert_close(logits, 30.0 * torch.tanh(raw_logits / 30.0))
+
+
+class TestGemma4TransformerLayerSpecCheckpoint:
+    """Gemma 4's default layer spec must survive run-config checkpoint reloads."""
+
+    @staticmethod
+    def _write_run_config(tmp_path, provider):
+        run_config_path = tmp_path / "run_config.yaml"
+        Gemma4RunConfigForTest(model=provider).to_yaml(str(run_config_path))
+        return run_config_path
+
+    def test_default_provider_serializes_a_public_reloadable_spec_target(self, tmp_path):
+        provider = Gemma4ModelProvider()
+        run_config_path = self._write_run_config(tmp_path, provider)
+        serialized = yaml.safe_load(run_config_path.read_text())
+
+        spec_func = provider.transformer_layer_spec.func
+        target = f"{spec_func.__module__}.{spec_func.__qualname__}"
+        assert serialized["model"]["transformer_layer_spec"]["_target_"] == target
+        assert target == "megatron.bridge.models.gemma.modeling_gemma4.gemma4_block_spec"
+
+        loaded = Gemma4RunConfigForTest.from_yaml(str(run_config_path), mode=InstantiationMode.STRICT)
+
+        assert loaded.model.transformer_layer_spec.func is gemma4_block_spec
+
+    def test_legacy_private_spec_target_reloads(self, tmp_path):
+        run_config_path = self._write_run_config(tmp_path, Gemma4ModelProvider())
+        serialized = yaml.safe_load(run_config_path.read_text())
+        serialized["model"]["transformer_layer_spec"]["_target_"] = (
+            "megatron.bridge.models.gemma.modeling_gemma4._gemma4_block_spec"
+        )
+        run_config_path.write_text(yaml.safe_dump(serialized))
+
+        loaded = Gemma4RunConfigForTest.from_yaml(str(run_config_path), mode=InstantiationMode.STRICT)
+
+        assert loaded.model.transformer_layer_spec.func is gemma4_block_spec
 
 
 class TestInstallTiedKV:


### PR DESCRIPTION
## Summary

- Define the Gemma 4 MoE block-spec function under the public `gemma4_block_spec` name so new `run_config.yaml` files serialize a reloadable target.
- Keep `_gemma4_block_spec` as a legacy alias and allowlist only that exact private target so existing checkpoints remain reloadable.
- Cover both the real provider serialization round trip and a legacy private-target reload.

## Problem

`Gemma4ModelProvider.transformer_layer_spec` used a partial of `_gemma4_block_spec`. YAML serialization derives callable targets from the function `__qualname__`, so the pre-existing public alias did not help: new checkpoints still recorded the private name, and strict checkpoint reload rejected it.

## Scope

This is limited to the Gemma 4 block-spec target and its exact legacy checkpoint compatibility entry. It does not change inference precision handling, model behavior, public conversion APIs, dependencies, CI, or Megatron-LM.

## Validation

- Red on current `main`: the provider default serialized `megatron.bridge.models.gemma.modeling_gemma4._gemma4_block_spec`, and strict reload raised `InstantiationException` at `model.transformer_layer_spec`.
- Focused unit tests after the fix: 82 passed.
- `uv run pre-commit run --all-files`: passed.
- Real checkpoint-backed `google/gemma-4-26B-A4B-it` inference on 8x H100 with BF16 weights, TP4/PP2/EP1:
  - reloaded the legacy `run_config.yaml` and checkpoint;
  - crossed the PP boundary without a private-target or Transformer Engine dtype exception;
  - produced finite full-vocabulary logits;
  - stopped naturally after 10 generated tokens with `The animal on the candy is a turtle.`;
  - all eight ranks exited cleanly.

No model verification card status was changed.

## Reference

NVBug 6491102.
