### PR TITLE
[peft] feat: default MoE expert LoRA to per-expert adapters

### DIFF
--- a/docs/training/peft.md
+++ b/docs/training/peft.md
@@ -76,7 +76,7 @@ The following table lists key hyperparameters for configuring LoRA, which contro
 | `alpha` | `float` | `32` | Scaling parameter for LoRA |
 | `dropout` | `float` | `0.0` | Dropout rate for LoRA layers |
 | `normalize_moe_lora` | `bool` | `False` | Reduce expert-layer rank to `dim // moe_router_topk` while keeping dense layers at the full rank |
-| `share_expert_adapters` | `bool` | `True` | Share one adapter across all local experts on an EP rank instead of creating one adapter per local expert |
+| `share_expert_adapters` | `bool` | `False` | Create one adapter per local expert (EP-invariant); set `True` to instead share one adapter across all local experts on an EP rank |
 
 #### Target Modules
 The following table lists specific submodules within transformer architectures that are commonly targeted for LoRA, enabling efficient fine-tuning of attention and feedforward components:
@@ -107,11 +107,11 @@ MLP layers such as `linear_fc1`, `linear_fc2`, `linear_fc1_up`, and
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `share_expert_adapters` | `bool` | `True` | Preserve the original behavior and share one adapter across all local experts on each EP rank |
+| `share_expert_adapters` | `bool` | `False` | Create one adapter per local expert (EP-invariant); set `True` to instead share one adapter across the experts co-located on each EP rank |
 | `normalize_moe_lora` | `bool` | `False` | Use `dim // moe_router_topk` for expert layers only so MoE adapter capacity stays comparable to a dense model |
 
-- `share_expert_adapters=True` keeps the original shared-adapter behavior for grouped expert linears.
-- `share_expert_adapters=False` opts into per-local-expert adapters.
+- `share_expert_adapters=False` (default) uses per-local-expert adapters, which are EP-invariant.
+- `share_expert_adapters=True` shares one adapter across the experts co-located on each EP rank. Note this makes the adapter's effective sharing granularity — and therefore the trained numerics — depend on the expert-parallel degree; use it mainly to save parameters.
 - `normalize_moe_lora=True` only changes expert layers; non-expert layers still use the full `dim`.
 - `dim` must be divisible by `moe_router_topk` when `normalize_moe_lora=True`.
 - When expert tensor parallelism shards a non-input-parallel expert layer, Megatron Bridge may round the effective expert rank up to the expert-TP granularity so the adapter can be partitioned cleanly.
@@ -224,7 +224,7 @@ canonical_lora_config = CanonicalLoRA(
 | `lora_A_init_method` | `str` | `"xavier"` | Initialization method for LoRA A matrix |
 | `lora_B_init_method` | `str` | `"zero"` | Initialization method for LoRA B matrix |
 | `normalize_moe_lora` | `bool` | `False` | Reduce expert-layer rank to `dim // moe_router_topk` while keeping dense layers at the full rank |
-| `share_expert_adapters` | `bool` | `True` | Share one adapter across all local experts on an EP rank instead of creating one adapter per local expert |
+| `share_expert_adapters` | `bool` | `False` | Create one adapter per local expert (EP-invariant); set `True` to instead share one adapter across all local experts on an EP rank |
 
 #### Target Modules for Canonical LoRA
 

--- a/src/megatron/bridge/peft/canonical_lora.py
+++ b/src/megatron/bridge/peft/canonical_lora.py
@@ -211,7 +211,11 @@ class CanonicalLoRA(PEFT, ModuleMatcher):
             while non-expert layers keep the full dim. This normalizes the total adapter capacity for MoE models
             so it is comparable to a dense model. Defaults to False.
         share_expert_adapters (bool): When True, grouped MoE expert linears share one adapter across all local
-            experts on the EP rank. Set to False to create one adapter per local expert instead. Defaults to True.
+            experts on the EP rank. When False, one adapter is created per local expert instead. Defaults to
+            False, so that adapter semantics are independent of the expert-parallel (EP) degree: a shared
+            adapter is shared only across the experts co-located on an EP rank, so its effective sharing
+            granularity (and the resulting numerics) silently changes with EP. Per-expert adapters are
+            EP-invariant. Set to True to recover the previous shared-adapter behavior (e.g. to save parameters).
     """
 
     target_modules: List[str] = field(
@@ -232,7 +236,7 @@ class CanonicalLoRA(PEFT, ModuleMatcher):
     lora_A_init_method: str = "xavier"
     lora_B_init_method: str = "zero"
     normalize_moe_lora: bool = False
-    share_expert_adapters: bool = True
+    share_expert_adapters: bool = False
 
     def __post_init__(self) -> None:
         """Eagerly build ``canonical_mapping`` from the initial ``target_modules``.

--- a/src/megatron/bridge/peft/lora.py
+++ b/src/megatron/bridge/peft/lora.py
@@ -88,7 +88,11 @@ class LoRA(PEFT, ModuleMatcher):
             while non-expert layers keep the full dim. This normalizes the total adapter capacity for MoE models
             so it is comparable to a dense model. Defaults to False.
         share_expert_adapters (bool): When True, grouped MoE expert linears share one adapter across all local
-            experts on the EP rank. Set to False to create one adapter per local expert instead. Defaults to True.
+            experts on the EP rank. When False, one adapter is created per local expert instead. Defaults to
+            False, so that adapter semantics are independent of the expert-parallel (EP) degree: a shared
+            adapter is shared only across the experts co-located on an EP rank, so its effective sharing
+            granularity (and the resulting numerics) silently changes with EP. Per-expert adapters are
+            EP-invariant. Set to True to recover the previous shared-adapter behavior (e.g. to save parameters).
         experts_shared_outer_loras (bool): When True, grouped-expert LoRA
             (``TE*ParallelGroupedLinear`` base modules) uses
             :class:`SharedOuterGroupedExpertAdapter` — ``gate_up`` lora_A and
@@ -111,7 +115,7 @@ class LoRA(PEFT, ModuleMatcher):
     a2a_experimental: bool = False
     lora_dtype: torch.dtype = None
     normalize_moe_lora: bool = False
-    share_expert_adapters: bool = True
+    share_expert_adapters: bool = False
     experts_shared_outer_loras: bool = False
 
     def transform(self, module: nn.Module, name: Optional[str] = None, prefix: Optional[str] = None) -> nn.Module:

--- a/tests/unit_tests/peft/test_canonical_lora.py
+++ b/tests/unit_tests/peft/test_canonical_lora.py
@@ -194,7 +194,7 @@ class TestCanonicalLoRA:
         assert lora.lora_A_init_method == "xavier"
         assert lora.lora_B_init_method == "zero"
         assert hasattr(lora, "canonical_mapping")
-        assert lora.share_expert_adapters is True
+        assert lora.share_expert_adapters is False
 
         # Test custom initialization
         custom_lora = CanonicalLoRA(
@@ -387,7 +387,7 @@ class TestCanonicalLoRA:
     def test_canonical_lora_treats_moe_expert_linear_fc1_as_unfused(self):
         """Grouped expert linear_fc1 should keep a single unfused LoRA adapter."""
         model = MoEMegatronStyleModel()
-        lora = CanonicalLoRA(target_modules=["linear_fc1_up", "linear_fc1_gate"])
+        lora = CanonicalLoRA(target_modules=["linear_fc1_up", "linear_fc1_gate"], share_expert_adapters=True)
 
         def mock_get_attrs(module, is_expert=False):
             return AdapterAttributes(
@@ -420,6 +420,7 @@ class TestCanonicalLoRA:
             target_modules=["linear_fc1_up", "linear_fc1_gate"],
             dim=32,
             normalize_moe_lora=True,
+            share_expert_adapters=True,
         )
 
         def mock_get_attrs(module, is_expert=False):
@@ -470,6 +471,7 @@ class TestCanonicalLoRA:
             target_modules=["linear_fc1_up", "linear_fc1_gate"],
             dim=8,
             normalize_moe_lora=True,
+            share_expert_adapters=True,
         )
 
         def mock_get_attrs(module, is_expert=False):
@@ -510,6 +512,7 @@ class TestCanonicalLoRA:
             target_modules=["linear_fc1_up", "linear_fc1_gate"],
             dim=32,
             normalize_moe_lora=True,
+            share_expert_adapters=True,
         )
 
         def mock_get_attrs(module, is_expert=False):

--- a/tests/unit_tests/peft/test_lora.py
+++ b/tests/unit_tests/peft/test_lora.py
@@ -216,7 +216,7 @@ class TestLoRA:
         assert lora.sequence_parallel_input_regather is False
         assert lora.lora_A_init_method == "xavier"
         assert lora.lora_B_init_method == "zero"
-        assert lora.share_expert_adapters is True
+        assert lora.share_expert_adapters is False
 
         # Test custom initialization
         custom_lora = LoRA(
@@ -599,7 +599,12 @@ class TestLoRANormalizeMoE:
     def test_normalize_moe_lora_reduces_expert_dim(self):
         """Expert layers should get dim // moe_router_topk when normalize_moe_lora is enabled."""
         model = MoEModel(moe_router_topk=2)
-        lora = LoRA(target_modules=["linear_fc1", "linear_fc2", "linear_proj"], dim=32, normalize_moe_lora=True)
+        lora = LoRA(
+            target_modules=["linear_fc1", "linear_fc2", "linear_proj"],
+            dim=32,
+            normalize_moe_lora=True,
+            share_expert_adapters=True,
+        )
 
         def mock_get_attrs(module, is_expert=False, sequence_parallel_input_regather=False):
             assert sequence_parallel_input_regather is False
@@ -639,7 +644,12 @@ class TestLoRANormalizeMoE:
     def test_normalize_moe_lora_disabled_uses_full_dim(self):
         """All layers should get full dim when normalize_moe_lora is False (default)."""
         model = MoEModel(moe_router_topk=2)
-        lora = LoRA(target_modules=["linear_fc1", "linear_fc2"], dim=32, normalize_moe_lora=False)
+        lora = LoRA(
+            target_modules=["linear_fc1", "linear_fc2"],
+            dim=32,
+            normalize_moe_lora=False,
+            share_expert_adapters=True,
+        )
 
         def mock_get_attrs(module, is_expert=False, sequence_parallel_input_regather=False):
             assert sequence_parallel_input_regather is False
@@ -664,7 +674,7 @@ class TestLoRANormalizeMoE:
     def test_normalize_moe_lora_indivisible_dim_raises(self):
         """Should raise ValueError when dim is not divisible by moe_router_topk."""
         model = MoEModel(moe_router_topk=3)
-        lora = LoRA(target_modules=["linear_fc1"], dim=32, normalize_moe_lora=True)
+        lora = LoRA(target_modules=["linear_fc1"], dim=32, normalize_moe_lora=True, share_expert_adapters=True)
 
         def mock_get_attrs(module, is_expert=False, sequence_parallel_input_regather=False):
             assert sequence_parallel_input_regather is False
@@ -686,7 +696,7 @@ class TestLoRANormalizeMoE:
     def test_normalize_moe_lora_shared_experts_get_full_dim(self):
         """Shared expert layers should get full dim (they are excluded by is_expert_linear)."""
         model = MoEModel(moe_router_topk=2)
-        lora = LoRA(target_modules=["linear_fc1"], dim=32, normalize_moe_lora=True)
+        lora = LoRA(target_modules=["linear_fc1"], dim=32, normalize_moe_lora=True, share_expert_adapters=True)
 
         def mock_get_attrs(module, is_expert=False, sequence_parallel_input_regather=False):
             assert sequence_parallel_input_regather is False
@@ -716,7 +726,7 @@ class TestLoRANormalizeMoE:
         for module in model.modules():
             if hasattr(module, "config"):
                 module.config.expert_tensor_parallel_size = 2
-        lora = LoRA(target_modules=["linear_fc1"], dim=8, normalize_moe_lora=True)
+        lora = LoRA(target_modules=["linear_fc1"], dim=8, normalize_moe_lora=True, share_expert_adapters=True)
 
         def mock_get_attrs(module, is_expert=False, sequence_parallel_input_regather=False):
             assert sequence_parallel_input_regather is False


### PR DESCRIPTION
# What does this PR do ?

Flip the default of `share_expert_adapters` from `True` to `False` for both `LoRA` and `CanonicalLoRA`, so grouped MoE expert linears get **one adapter per local expert** by default instead of one adapter shared across the experts co-located on an EP rank.

## Motivation: the shared default has EP-dependent semantics

A shared expert adapter is shared only across the experts on a **single EP rank** (the plain shared `ParallelLinearAdapter` has no cross-EP replication — only the newer shared-outer path added one). So the effective sharing granularity, and therefore the **trained numerics**, silently changes with the expert-parallel degree:

- EP=1 → 1 adapter shared across all experts
- EP=8 → 8 independent adapters, each over 1/8 of the experts

The same recipe produces different capacity/numerics at different EP. Per-expert adapters are **EP-invariant**, which is the more defensible default.

## Ecosystem alignment

| Framework | MoE-expert LoRA default | Shared offered? |
|-----------|------------------------|-----------------|
| NeMo Automodel | per-expert | no — per-expert only |
| SkyRL (`skyrl-tx`) | per-expert | no — per-expert only |
| Miles (Bridge LoRA consumer) | per-expert | shared-outer opt-in only |
| Megatron-Bridge (before) | **shared** | yes |

Two first-party implementations offer per-expert only, and Miles — a downstream Megatron-Bridge LoRA consumer — already defaults to per-expert.

## Changelog

- `peft/lora.py`, `peft/canonical_lora.py`: default `share_expert_adapters=False`; docstrings explain the EP-invariance rationale.
- `docs/training/peft.md`: default tables + prose updated.
- Unit tests: two default-value asserts flipped; nine tests that specifically exercise the shared path pin `share_expert_adapters=True` explicitly (so shared mode stays covered).

## Breaking change

Marked with the `breaking-change` label (kept out of the title per request):
- Recipes on the default now produce larger (per-expert) adapters with different numerics.
- Previously-trained shared adapters require `share_expert_adapters=True` to load.
- Pin `share_expert_adapters=True` to recover the prior behavior (e.g. to save parameters).

The shared layout is unchanged and fully supported via the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
