### PR TITLE
cp: `fix(models): use HybridEP for Kimi-K2.5 inference (5421)` into `r0.6.0`

### DIFF
--- a/examples/models/kimi/kimi_k25_vl/README.md
+++ b/examples/models/kimi/kimi_k25_vl/README.md
@@ -78,6 +78,12 @@ See [slurm_inference.sh](slurm_inference.sh) for configuration details.
 
 Note:
 - `--trust_remote_code` is required for Kimi-K2.5 models.
+- Bridge-created Kimi-K2.5 providers use the HybridEP dispatcher with 16
+  communication SMs and unfused HybridEP permutation. On 8-GPU H100 nodes, set
+  `NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN=8`, `NVLINK_DOMAIN_SIZE=8`, and
+  `USE_MNNVL=0`. A native Megatron checkpoint can retain the dispatcher
+  configuration with which it was saved, so loading an older checkpoint may
+  require applying the same overrides to the loaded model configuration.
 - Use `--pp_layout` to specify custom pipeline layouts (e.g.
   `--pp_layout "Et*15|t*15|t*16|t*15L"` for PP=4).
 - You can optionally pass `--megatron_model_path` to use a pre-converted

--- a/examples/models/kimi/kimi_k25_vl/slurm_inference.sh
+++ b/examples/models/kimi/kimi_k25_vl/slurm_inference.sh
@@ -57,6 +57,9 @@ MAX_NEW_TOKENS=200
 export TORCH_NCCL_AVOID_RECORD_STREAMS=1
 export NCCL_NVLS_ENABLE=0
 export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+export NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN=8
+export NVLINK_DOMAIN_SIZE=8
+export USE_MNNVL=0
 
 echo "======================================"
 echo "Kimi-K2.5-VL Inference"

--- a/src/megatron/bridge/models/kimi_vl/kimi_k25_vl_bridge.py
+++ b/src/megatron/bridge/models/kimi_vl/kimi_k25_vl_bridge.py
@@ -86,7 +86,10 @@ class KimiK25VLBridge(MegatronModelBridge):
         # MoE settings
         provider.moe_grouped_gemm = True
         provider.moe_router_pre_softmax = True
-        provider.moe_token_dispatcher_type = "alltoall"
+        provider.moe_token_dispatcher_type = "flex"
+        provider.moe_flex_dispatcher_backend = "hybridep"
+        provider.moe_flex_dispatcher_num_sms = 16
+        provider.moe_permute_fusion_into_hybridep = False
         provider.moe_router_load_balancing_type = "seq_aux_loss"
         provider.moe_shared_expert_overlap = True
         provider.moe_router_score_function = "sigmoid"

--- a/tests/unit_tests/models/kimi_vl/test_kimi_k25_vl_bridge.py
+++ b/tests/unit_tests/models/kimi_vl/test_kimi_k25_vl_bridge.py
@@ -175,6 +175,10 @@ class TestKimiK25VLBridgeProviderBridge:
         assert provider.moe_router_topk == 8
         assert provider.moe_router_score_function == "sigmoid"
         assert provider.moe_router_enable_expert_bias is True
+        assert provider.moe_token_dispatcher_type == "flex"
+        assert provider.moe_flex_dispatcher_backend == "hybridep"
+        assert provider.moe_flex_dispatcher_num_sms == 16
+        assert provider.moe_permute_fusion_into_hybridep is False
 
     def test_provider_bridge_moe_layer_freq(self, kimi_bridge, mock_hf_pretrained):
         """Test MoE layer frequency computation."""


### PR DESCRIPTION
## Source and scope

- Source PR: #5421
- Selected source commits: `718b6a3faebbd0c658d4912d7459812551d0cc67` and `1f319cb82f88f79aa2d7dc8072dcd8054f6dd3cd`
- Target: `r0.6.0`
- Fixes NVBug 6566459

This selectively backports the Kimi-K2.5 inference provider, focused unit assertions, public inference launcher environment, and adjacent documentation. It intentionally excludes the source PR's generic VLM last-token logits optimization and SFT recipe changes because neither is required for the reported first-forward inference failure.

## Root cause and fix

At the reported 48-GPU expert-parallel shape, the standard all-to-all dispatcher path produced extreme late-layer expert-owner fan-in and exhausted memory during the first model forward. The backport switches Kimi-K2.5 to the flex/HybridEP dispatcher, configures 16 communication SMs, disables fused HybridEP permutation for this model, and supplies the required 8-GPU NVLink-domain environment.

## Validation

- Full-model six-node/48-H100 inference with TP=2, PP=1, EP=48, the original media/prompt, on-the-fly HF import, and the full 200-token budget: passed.
- Loaded all 2,089 tensors, completed generation steps 0 through 199, emitted coherent image-description output, and exited zero with no OOM, traceback, timeout, or illegal-memory signature.
- Focused Kimi Bridge unit tests: 24 passed.
- Launcher shell syntax and `git diff --check`: passed.
- `pre-commit run --all-files`: passed without modifying the patch.

## Residual risk

The backport changes only Kimi-K2.5's default expert dispatcher. The r0.6.0-pinned Megatron Core implements every selected flex/HybridEP option, and the exact release-branch source completed the full reported workload. SFT defaults are deliberately unchanged in this selective backport.

The validated path imports from Hugging Face. An older native Megatron checkpoint can retain its saved `alltoall` dispatcher because the current checkpoint loader does not override dispatcher fields; such a checkpoint must be reconverted or have equivalent model-config overrides applied before use. Adding automatic checkpoint-load overrides is outside this narrowly validated backport.

## AI assistance

This selective backport, investigation, and validation summary were prepared with AI assistance and reviewed by the committer and an independent review agent.
